### PR TITLE
BUG: Use of the PATH or QUERY conditionals in header_rewrite requires the remap api.

### DIFF
--- a/plugins/experimental/header_rewrite/conditions.cc
+++ b/plugins/experimental/header_rewrite/conditions.cc
@@ -238,6 +238,10 @@ ConditionPath::eval(const Resources& res)
 {
   std::string s;
 
+  if (NULL == res._rri) {
+    TSDebug(PLUGIN_NAME, "PATH requires remap initialization! Evaluating to false!");
+    return false;
+  }
   append_value(s, res);
   TSDebug(PLUGIN_NAME, "Evaluating PATH");
 
@@ -270,6 +274,10 @@ ConditionQuery::eval(const Resources& res)
 {
   std::string s;
 
+  if (NULL == res._rri) {
+    TSDebug(PLUGIN_NAME, "QUERY requires remap initialization! Evaluating to false!");
+    return false;
+  }
   append_value(s, res);
   TSDebug(PLUGIN_NAME, "Evaluating QUERY - %s", s.c_str());
   return static_cast<const Matchers<std::string>*>(_matcher)->test(s);


### PR DESCRIPTION
BUG: Use of the PATH or QUERY conditionals in header_rewrite requires the remap api.
     requires the remap api. If these are configured using the
     InkAPI an null pointer will be dereferenced. There may be
     a better way to check this as the Conditions are initialized
     in the factory with some refactoring. Currently if Resources
     is missing this field the conditional will be false and we
     log a debug message.
