### PR TITLE
Magical Mystery Tour through VMap, vaddrs.conf.

### DIFF
--- a/mgmt/Main.cc
+++ b/mgmt/Main.cc
@@ -757,24 +757,6 @@ main(int argc, char **argv)
   Debug("lm", "Created Web Agent thread (%"  PRId64 ")", (int64_t)webThrId);
   lmgmt->listenForProxy();
 
-  /* Check the permissions on vip_config */
-  if (lmgmt->virt_map->enabled) {
-    char absolute_vipconf_binary[1024];
-    struct stat buf;
-
-    snprintf(absolute_vipconf_binary, sizeof(absolute_vipconf_binary), "%s/vip_config", lmgmt->bin_path);
-    if (stat(absolute_vipconf_binary, &buf) < 0) {
-      mgmt_elog(stderr, "[main] Unable to stat vip_config for proper permissions\n");
-    } else if (!((buf.st_mode & S_ISUID) &&
-                 (buf.st_mode & S_IRWXU) &&
-                 (buf.st_mode & S_IRGRP) &&
-                 (buf.st_mode & S_IXGRP) && (buf.st_mode & S_IROTH) && (buf.st_mode & S_IXOTH))) {
-      lmgmt->alarm_keeper->signalAlarm(MGMT_ALARM_PROXY_SYSTEM_ERROR,
-                                       "Virtual IP Addressing enabled, but improper permissions on '/inktomi/bin/vip_config'"
-                                       "[requires: setuid root and at least a+rx]\n");
-    }
-  }
-
   ticker = time(NULL);
   mgmt_log("[TrafficManager] Setup complete\n");
 

--- a/mgmt/cluster/ClusterCom.cc
+++ b/mgmt/cluster/ClusterCom.cc
@@ -63,16 +63,16 @@ drainIncomingChannel(void *arg)
   struct sockaddr_in cli_addr;
 
   // Fix for INKqa07688: There was a problem at Genuity where if you
-  // pulled out the cable on the cluser interface (or just ifconfig'd
-  // down/up the cluster interface), the fd assocated with that
-  // inteface would somehow get into a bad state... and the multicast
+  // pulled out the cable on the cluster interface (or just ifconfig'd
+  // down/up the cluster interface), the fd associated with that
+  // interface would somehow get into a bad state... and the multicast
   // packets from other nodes wouldn't be received anymore.
   //
   // The fix for the problem was to close() and re-open the multicast
-  // socket if we detected that no activity has occured for 30
+  // socket if we detected that no activity has occurred for 30
   // seconds.  30 seconds was based on the default peer_timeout
   // (proxy.config.cluster.peer_timeout) value.  davey showed that
-  // this value worked out well experiementally (though more testing
+  // this value worked out well experimentally (though more testing
   // and experimentation would be beneficial).
   //
   // traffic_manager running w/ no cop: In this case, our select()
@@ -1236,7 +1236,7 @@ ClusterCom::handleMultiCastAlarmPacket(char *last, char *ip)
 
 /*
  * handleMultiCastVMapPacket(...)
- *   Handles incoming reports from peers about which virtua interfaces
+ *   Handles incoming reports from peers about which virtual interfaces
  * they are servicing. This then updates the VMap class to indicate who
  * is holding what.
  */

--- a/mgmt/cluster/VMap.h
+++ b/mgmt/cluster/VMap.h
@@ -65,19 +65,13 @@ public:
   VMap(char *interface, unsigned long ip, ink_mutex * m);
    ~VMap();
 
-  void init();                  /* VIP is ON, initialize it */
-
-  bool upAddr(char *virt_ip);
-  bool downAddr(char *virt_ip);
   void downAddrs();
   void downOurAddrs();
   void rl_downAddrs();
-
+  void removeAddressMapping(int i);
   void lt_runGambit();
   void lt_readAListFile(char *data);
   void lt_constructVMapMessage(char *ip, char *message, int max);
-
-  void rl_rebalance();
 
   bool rl_remote_map(char *virt_ip, char *real_ip);
   bool rl_remote_unmap(char *virt_ip, char *real_ip);
@@ -88,7 +82,6 @@ public:
 
   char *rl_checkConflict(char *virt_ip);
   bool rl_checkGlobConflict(char *virt_ip);
-  void rl_resolveConflict(char *virt_ip, char *conf_ip);
 
   int rl_boundAddr(char *virt_ip);
   unsigned long rl_boundTo(char *virt_ip);
@@ -99,7 +92,6 @@ public:
   char absolute_vipconf_binary[PATH_NAME_MAX];
 
   int enabled;
-  bool enabled_init;            /* have we initialized VIP? Call when VIP is turned on */
   bool turning_off;             /* are we turning off VIP but haven't down'd the addr? */
   /* map_init has never been used, remove it to avoid coverity complain */
   int map_change_thresh;
@@ -116,7 +108,10 @@ public:
   unsigned long our_ip;
 
   ink_mutex *mutex;
+  // Map of virtual ip addresses assigned to the local node
   InkHashTable *our_map;
+  // Map of virtual ip addresses assigned to other nodes; as indicated through multicast messages; used
+  // to detect conflicts
   InkHashTable *ext_map;
   InkHashTable *id_map;
   InkHashTable *interface_realip_map;

--- a/proxy/config/vaddrs.config.default
+++ b/proxy/config/vaddrs.config.default
@@ -1,7 +1,16 @@
 # Virtual IP Address Configuration
 #
 # The purpose of this file is to specify virtual IP addresses
-# for Traffic Server.
+# for Traffic Server. This DOES NOT actually bind to these
+# addresses; ATS either listens to all or the address specified
+# through proxy.local.incoming_ip_to_bind.
+#
+# The vips specified here will be verified and broadcast across
+# the cluster. Any conflicts will be logged as errors.
+#
+# In order to enable these checks you must also set:
+#     CONFIG proxy.config.vmap.enabled INT 1
+# In records.conf
 #
 # UNIX
 #   Format:


### PR DESCRIPTION
CLEANUP: Virtual IPs were once managed such that within a cluster they
       would automatically rebalance themselves between nodes by bringing
       subinterfaces up and down. After ATS was open sourced the original
       setuid tool, vip_config (or traffic_vip_config) was inadvertently
       removed; but the code which depended on this tool was not cleaned
       up.

```
   Since modern deployments either do not use this tool at all
   (because it was broken for a few years) and modern deployments also
   have some central system for managing cluster state reliably, we
   do not need VMap to implement some scheme for automatically
   rebalancing the ips.

   This CL keeps much of the code for detecting ip address conflicts
   and for receiving the multicast messages from the cluster; but we
   remove all instances where we either bring up/down an interface.

   Deployments should manage this through external state systems.

   Note: VIPs do not actually bind to the specific addresses in
   vaddrs; this is just an operations convience to ensure that a
   cluster has no ip conflicts or unmanaged vips.

   Note: The *right* thing to do here may be to recall that old tool and let
   VMap do it's thing.

   Note: Another *right* thing to do may be to remove VMap entirely, along
   with the associated cluster messages. At least with this exiting changeset
   we can detect ip address conflicts.
```

Reviewed-by: TBD
