### PR TITLE
Correct error handling for TSPluginRegister

### DIFF
--- a/plugins/header_filter/header_filter.cc
+++ b/plugins/header_filter/header_filter.cc
@@ -104,7 +104,7 @@ TSPluginInit(int argc, const char *argv[])
   info.vendor_name = const_cast<char*>("Apache");
   info.support_email = const_cast<char*>("users@trafficserver.apache.org");
 
-  if (!TSPluginRegister(TS_SDK_VERSION_3_0 , &info)) {
+  if (TSPluginRegister(TS_SDK_VERSION_3_0 , &info) != TS_SUCCESS) {
     TSError("header_filter: plugin registration failed.\n"); 
   }
 


### PR DESCRIPTION
  typedef enum
  {
    TS_ERROR = -1,
    TS_SUCCESS = 0
  } TSReturnCode;

The original logic would log an error on TS_SUCCESS, and not log an error on TS_ERROR.
