### PR TITLE
TS-2316: properly cherry-pick client header condition fix

### DIFF
--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -192,10 +192,10 @@ ConditionHeader::append_value(std::string& s, const Resources& res)
     field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, _qualifier.c_str(), _qualifier.size());
     TSDebug(PLUGIN_NAME, "Getting Header: %s, field_loc: %p", _qualifier.c_str(), field_loc);
     if (field_loc != NULL) {
-      value = TSMimeHdrFieldValueStringGet(bufp, res.hdr_loc, field_loc, 0, &len);
+      value = TSMimeHdrFieldValueStringGet(bufp, hdr_loc, field_loc, 0, &len);
       TSDebug(PLUGIN_NAME, "Appending HEADER(%s) to evaluation value -> %.*s", _qualifier.c_str(), len, value);
       s.append(value, len);
-      TSHandleMLocRelease(bufp, res.hdr_loc, field_loc);
+      TSHandleMLocRelease(bufp, hdr_loc, field_loc);
     }
   }
 }


### PR DESCRIPTION
This commit was cherry-picked with some errors:
    header_rewrite: fix for crash in client header condition

Pointy hat to: me (aivanov@)
