### PR TITLE
Runtimedir on Gentoo changed from /var/run to /run

### DIFF
--- a/config.layout
+++ b/config.layout
@@ -214,7 +214,7 @@
     installbuilddir: ${datadir}/build
     includedir:    ${prefix}/include+
     localstatedir: /var+
-    runtimedir:    /var/run+
+    runtimedir:    /run+
     logdir:        /var/log+
     cachedir:      /var/cache+
 </Layout>


### PR DESCRIPTION
the runtimedir on Gentoo systems has changed.
