### PR TITLE
header_rewrite: remove RemapAPI-only restriction for PATH conditions

### DIFF
--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -244,10 +244,6 @@ ConditionPath::eval(const Resources& res)
 {
   std::string s;
 
-  if (NULL == res._rri) {
-    TSDebug(PLUGIN_NAME, "PATH requires remap initialization! Evaluating to false!");
-    return false;
-  }
   append_value(s, res);
   TSDebug(PLUGIN_NAME, "Evaluating PATH");
 


### PR DESCRIPTION
Segfault in PATH condition was already fixed in 236c52cf:
    "TS-2316: header_rewrite: fixed segfaults in ConditionPath::append_value()"

Submitted by: Alexey Ivanov aivanov@linkedin.com
Sponsored by: LinkedIn
