### PR TITLE
Fix an further keepalive issue when responding with 204

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -6753,7 +6753,7 @@ HttpTransact::handle_response_keep_alive_headers(State* s, HTTPVersion ver, HTTP
     ka_action = KA_DISABLED;
   }
   else if (heads->status_get() == HTTP_STATUS_NO_CONTENT &&
-      (s->current.server->transfer_encoding != NO_TRANSFER_ENCODING || s->hdr_info.request_content_length != 0)) {
+      (s->current.server->transfer_encoding != NO_TRANSFER_ENCODING || heads->get_content_length() != 0)) {
     // some systems hang until the connection closes when receiving a 204 regardless of the K-A headers
     // close if there is any body response from the origin
     ka_action = KA_CLOSE;


### PR DESCRIPTION
Just found there is a further keepalive issue when responding with 204 return code, when I emit a curl call, I always get the `Connection: close` and `* Closing connection 0`, the result:

```
$ curl -v -X POST --data-binary @test.json 'http://localhost/v0/test'
* About to connect() to localhost port 80 (#0)
*   Trying ::1...
* Adding handle: conn: 0x12d8c40
* Adding handle: send: 0
* Adding handle: recv: 0
* Curl_addHandleToPipeline: length: 1
* - Conn 0 (0x12d8c40) send_pipe: 1, recv_pipe: 0
* Connection refused
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 80 (#0)
> POST /v0/test HTTP/1.1
> User-Agent: curl/7.33.0
> Host: localhost
> Accept: */*
> Content-Length: 1560
> Content-Type: application/x-www-form-urlencoded
> Expect: 100-continue
>
* Done waiting for 100-continue
< HTTP/1.1 204 No Content
< Date: Thu, 19 Dec 2013 12:18:07 GMT
< Content-Length: 0
< Cache-Control: private
< Content-Type: application/json
< Age: 1
< Connection: close
* Server ATS/4.0.2 is not blacklisted
< Server: ATS/4.0.2
<
* Closing connection 0
```

The problem is that the trafficserver check the request content length, not the response.
To solve it, we need to check the content length from origin server's response.
After apply the patch, the response returned with `Connection: keep-alive` while curl show the `* Connection #0 to host localhost left intact`, the detail as following:

```
$ curl -v -X POST --data-binary @test.json 'http://localhost/v0/test'
* About to connect() to localhost port 80 (#0)
*   Trying ::1...
* Adding handle: conn: 0x1323c40
* Adding handle: send: 0
* Adding handle: recv: 0
* Curl_addHandleToPipeline: length: 1
* - Conn 0 (0x1323c40) send_pipe: 1, recv_pipe: 0
* Connection refused
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 80 (#0)
> POST /v0/test HTTP/1.1
> User-Agent: curl/7.33.0
> Host: localhost
> Accept: */*
> Content-Length: 1560
> Content-Type: application/x-www-form-urlencoded
> Expect: 100-continue
>
* Done waiting for 100-continue
< HTTP/1.1 204 No Content
< Date: Thu, 19 Dec 2013 12:49:13 GMT
< Content-Length: 0
< Cache-Control: private
< Content-Type: application/json
< Age: 1
< Connection: keep-alive
* Server ATS/4.0.2 is not blacklisted
< Server: ATS/4.0.2
<
* Connection #0 to host localhost left intact
```

Thanks,
Yuzhang
