### PR TITLE
DOC: fix some syntax errors in documents

### DIFF
--- a/doc/admin/faqs.en.rst
+++ b/doc/admin/faqs.en.rst
@@ -29,7 +29,7 @@ FAQs
 How do you create a raw disk for the cache if all your disks have mounted file systems?
 ---------------------------------------------------------------------------------------
 
-Create a large file on filesystem (with :manpage`dd(1)`) and mount it as loopback device.
+Create a large file on filesystem (with :manpage:`dd(1)`) and mount it as loopback device.
 This is accomplished with :manpage:`losetup(8)` on Linux, :manpage:`lofiadm(1m)` on Solaris
 and Illumos, and :manpage:`mdconfig(8)` on FreeBSD.
 

--- a/doc/reference/commands/traffic_top.en.rst
+++ b/doc/reference/commands/traffic_top.en.rst
@@ -15,9 +15,9 @@
   specific language governing permissions and limitations
   under the License.
 
-==========
+===========
 traffic_top
-==========
+===========
 
 .. program:: traffic_top
 

--- a/doc/reference/configuration/cache.config.en.rst
+++ b/doc/reference/configuration/cache.config.en.rst
@@ -128,6 +128,7 @@ The following list shows possible actions and their allowed values.
       this content to be stored locally on every cluster node.
 
 .. _cache-responses-to-cookies:
+
 ``cache-responses-to-cookies``
    Change the style of caching with regard to cookies. This effectively
    overrides the configuration parameter

--- a/doc/reference/configuration/plugin.config.en.rst
+++ b/doc/reference/configuration/plugin.config.en.rst
@@ -54,7 +54,7 @@ Server configuration can be changed. If a plugin requires the current
 value, it must obtain that using the management API.
 
 Examples
-=======
+========
 
 ::
 

--- a/doc/reference/plugins/combo_handler.en.rst
+++ b/doc/reference/plugins/combo_handler.en.rst
@@ -69,6 +69,7 @@ file paths can be extracted and specified separately using a 'p' query
 parameter. Successive file path parameters are appended to this prefix
 to create complete file paths. The prefix will remain active until
 changed or cleared (set to an empty string). For example, the query ::
+
     "/file1&p=/path1/&file2&file3&p=&/file4&p=/dir:path2/&file5&file6"
 
 results in these file paths being "reconstructed"::

--- a/doc/reference/plugins/ts_lua.en.rst
+++ b/doc/reference/plugins/ts_lua.en.rst
@@ -218,6 +218,7 @@ Synopsis
 **test_server_intercept.lua**
 
 ::
+
     require 'os'
 
     function send_data()
@@ -561,7 +562,7 @@ ts.client_request.header.HEADER
 
 **description**: Set, add to, clear or get the current request's HEADER.
 
-Here is an example:
+Here is an example:::
 
     function do_remap()
         local req_host = ts.client_request.header.Host

--- a/doc/sdk/mutex-guide.en.rst
+++ b/doc/sdk/mutex-guide.en.rst
@@ -116,7 +116,7 @@ accessed by other continuations or processes. Here's how:
        mutexp = TSMutexCreate ();
 
 2. | When you create the continuation, specify this mutex as the
-   continuation's mutex.
+     continuation's mutex.
    | For example:
 
    ::


### PR DESCRIPTION
This fixes some of reST syntax errors in the documents.
