### PR TITLE
TS-2531: add a nohost_rule check for proxy request

### DIFF
--- a/proxy/http/remap/RemapProcessor.cc
+++ b/proxy/http/remap/RemapProcessor.cc
@@ -106,6 +106,14 @@ RemapProcessor::setup_for_remap(HttpTransact::State *s)
     mapping_found = rewrite_table->forwardMappingLookup(request_url, request_port, request_host, request_host_len, s->url_map);
   }
 
+  // If no rules match and we have a host, check empty host rules since
+  // they function as default rules for server requests.
+  // If there's no host, we've already done this.
+  if (!mapping_found && rewrite_table->nohost_rules && request_host_len) {
+    Debug("url_rewrite", "[lookup] nothing matched");
+    mapping_found = rewrite_table->forwardMappingLookup(request_url, 0, "", 0, s->url_map);
+  }
+
   if (!proxy_request) { // do extra checks on a server request
 
     // Save this information for later
@@ -113,14 +121,6 @@ RemapProcessor::setup_for_remap(HttpTransact::State *s)
     s->hh_info.host_len = request_host_len;
     s->hh_info.request_host = request_host;
     s->hh_info.request_port = request_port;
-
-    // If no rules match and we have a host, check empty host rules since
-    // they function as default rules for server requests.
-    // If there's no host, we've already done this.
-    if (!mapping_found && rewrite_table->nohost_rules && request_host_len) {
-      Debug("url_rewrite", "[lookup] nothing matched");
-      mapping_found = rewrite_table->forwardMappingLookup(request_url, 0, "", 0, s->url_map);
-    }
 
     if (mapping_found) {
       // Downstream mapping logic (e.g., self::finish_remap())


### PR DESCRIPTION
This change is used to solve the problem TS-2531. 

Below is my test method:

config remap.config as below:  (127.0.0.1:8885 is my backend server.)

```
map / http://127.0.0.1:8885/
```

Before I added this change, when I send a `GET http://localhost/test` to ATS, it returns 404 not found.

```
GET http://localhost/test HTTP/1.1

HTTP/1.1 404 Not Found
```

The root reason is that ATS doesn't check no host rules for this requests which contain host, and these 
requests can not be matched the rule `map / http://127.0.0.1:8885/` .

So I moved these check logic to outside, now ATS can return 200 response.

```
GET http://localhost/test HTTP/1.1

HTTP/1.1 200 OK
```

Now , a 200 OK response returns.
