### PR TITLE
Add support for whitelist of headers to be proxied from origin servers by combo handler

### DIFF
--- a/plugins/experimental/esi/README.combo
+++ b/plugins/experimental/esi/README.combo
@@ -12,6 +12,9 @@ The arguments in the plugin.config line in order represent
 2) The name of the key used for signature verification (disabled
    by default) [verification not implemented yet]
 
+3) A colon separated list of headers which, if present on atleast one 
+   response, will be added to the combo response.
+
 A "-" can be supplied as a value for any of these arguments to request
 default value be applied.
 

--- a/plugins/experimental/esi/combo_handler.cc
+++ b/plugins/experimental/esi/combo_handler.cc
@@ -818,7 +818,7 @@ prepareResponse(InterceptData &int_data, ByteBlockList &body_blocks, string &res
             continue;
           }
 
-          string header = HEADER_WHITELIST[i];
+          const string& header = HEADER_WHITELIST[i];
 
           field_loc = TSMimeHdrFieldFind(resp_data.bufp, resp_data.hdr_loc, header.c_str(), header.size());
           if (field_loc != TS_NULL_MLOC) {

--- a/plugins/experimental/esi/combo_handler.cc
+++ b/plugins/experimental/esi/combo_handler.cc
@@ -23,6 +23,8 @@
 
 #include <list>
 #include <string>
+#include <sstream>
+#include <vector>
 #include <time.h>
 #include <pthread.h>
 #include <arpa/inet.h>
@@ -46,6 +48,7 @@ using namespace EsiLib;
 
 int arg_idx;
 static string SIG_KEY_NAME;
+static vector<string> HEADER_WHITELIST;
 
 #define DEFAULT_COMBO_HANDLER_PATH "admin/v1/combo"
 static string COMBO_HANDLER_PATH;
@@ -215,6 +218,18 @@ TSPluginInit(int argc, const char *argv[])
 
   SIG_KEY_NAME = ((argc > 2) && (strcmp(argv[2], "-") != 0)) ? argv[2] : "";
   LOG_DEBUG("Signature key is [%s]", SIG_KEY_NAME.c_str());
+
+  if ((argc > 3) && (strcmp(argv[3], "-") != 0)) {
+    stringstream strstream(argv[3]);
+    string header;
+    while (getline(strstream, header, ':')) {
+      HEADER_WHITELIST.push_back(header);
+    }
+  }
+
+  for (unsigned int i = 0; i < HEADER_WHITELIST.size(); i++) {
+    LOG_DEBUG("WhiteList: %s", HEADER_WHITELIST[i].c_str());
+  }
 
   TSReleaseAssert(pthread_key_create(&threadKey, NULL) == 0);
 
@@ -767,6 +782,13 @@ prepareResponse(InterceptData &int_data, ByteBlockList &body_blocks, string &res
     TSMLoc field_loc;
     time_t expires_time;
     bool got_expires_time = false;
+    int num_headers = HEADER_WHITELIST.size();
+    int flags_list[num_headers];
+
+    for (int i = 0; i < num_headers; i++) {
+      flags_list[i] = 0;
+    }
+
     for (StringList::iterator iter = int_data.creq.file_urls.begin(); iter != int_data.creq.file_urls.end();
          ++iter) {
       if (int_data.fetcher->getData(*iter, resp_data) && resp_data.status == TS_HTTP_STATUS_OK) {
@@ -790,6 +812,27 @@ prepareResponse(InterceptData &int_data, ByteBlockList &body_blocks, string &res
           }
           TSHandleMLocRelease(resp_data.bufp, resp_data.hdr_loc, field_loc);
         }
+
+        for (int i = 0; i < num_headers; i++) {
+          if (flags_list[i]) {
+            continue;
+          }
+
+          string header = HEADER_WHITELIST[i];
+
+          field_loc = TSMimeHdrFieldFind(resp_data.bufp, resp_data.hdr_loc, header.c_str(), header.size());
+          if (field_loc != TS_NULL_MLOC) {
+            int hdr_len = 0;
+            const char* hdr = TSMimeHdrFieldValueStringGet(resp_data.bufp, resp_data.hdr_loc, field_loc, 0, &hdr_len);
+            if (hdr) {
+              string hdr_value = string(hdr, hdr_len);
+              resp_header_fields.append(header + ": " + hdr_value + "\r\n");
+              flags_list[i] = 1;
+            }
+            TSHandleMLocRelease(resp_data.bufp, resp_data.hdr_loc, field_loc);
+          }
+        }
+
       } else {
         LOG_ERROR("Could not get content for requested URL [%s]", iter->c_str());
         int_data.creq.status = TS_HTTP_STATUS_BAD_REQUEST;


### PR DESCRIPTION
Combo handler strips out all headers from the individual responses except for Expires and Content-Type header. This pull request is to extend this functionality to a configurable set of headers (white list).