### PR TITLE
docs: Fix visible hyperlink target on Read the Docs (should only show th...

### DIFF
--- a/doc/sdk/actions-guide.en.rst
+++ b/doc/sdk/actions-guide.en.rst
@@ -175,6 +175,6 @@ cancel the action. The following sample code implements this:
 
 The action functions are:
 
--  ```TSActionCancel`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a5d49a6addcc9dbdc7f339ee6b73ac0b6>`__
--  ```TSActionDone`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#abe189274ad59911f2a57d345d11bfecb>`__
+-  :c:func:`TSActionCancel`
+-  :c:func:`TSActionDone`
 

--- a/doc/sdk/actions-guide/hosts-lookup-api.en.rst
+++ b/doc/sdk/actions-guide/hosts-lookup-api.en.rst
@@ -23,6 +23,6 @@ lookup of a host name, much like a DNS lookup.
 
 The hosts lookup functions are as follows:
 
--  ```TSHostLookup`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#ab5bf6eea0ed883e5dc69253965935d12>`__
--  ```TSHostLookupResultAddrGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#aecac0767192746af1867f528e01d167b>`__
+-  :c:func:`TSHostLookup`
+-  :c:func:`TSHostLookupResultAddrGet`
 

--- a/doc/sdk/http-headers/http-headers.en.rst
+++ b/doc/sdk/http-headers/http-headers.en.rst
@@ -159,28 +159,28 @@ known schemes, since this removes the possibility of a spelling error.
 
 The **HTTP Header Functions** are listed below:
 
--  ```TSHttpHdrClone`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#abd410a18e8bc73298302c4ff3ee9b0c6>`__
--  ```TSHttpHdrCopy`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a5ff26f3836a74e885113423dfd4d9ed6>`__
--  ```TSHttpHdrCreate`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a8bbd8c2aaf70fb579af4520053fd5e10>`__
--  ```TSHttpHdrDestroy`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a500ac4aae8f369221cf3ac2e3ce0d2a0>`__
--  ```TSHttpHdrLengthGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a3afc557e4e99565ab81bf6437b65181b>`__
--  ```TSHttpHdrMethodGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a358627e05506baa5c8270891652ac4d2>`__
--  ```TSHttpHdrMethodSet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a32bbcacacbef997e89c04cc3898b0ca4>`__
--  ```TSHttpHdrPrint`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a7c88f30d6325a461fb038e6a117b3731>`__
--  ```TSHttpHdrReasonGet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a8b1609e9c8a8a52ebe7762b6109d3bef>`__
--  ```TSHttpHdrReasonLookup`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#ab49fded8874b8e3e17cf4395c9832378>`__
--  ```TSHttpHdrReasonSet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#ab86e5f5e7c0af2092c77327d2e0d3b23>`__
--  ```TSHttpHdrStatusGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#ac29d5acc357a0c82c83874f42b1e487b>`__
--  ```TSHttpHdrStatusSet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#af34459170ed7f3b002ddd597ae38af12>`__
--  ```TSHttpHdrTypeGet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#afc1c6f0a3258c4bc6567805df1db1ca3>`__
--  ```TSHttpHdrTypeSet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a86058d8590a665dbf43a529714202d3f>`__
--  ```TSHttpHdrUrlGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#af149d7b5c1b8902363afc0ad658c494e>`__
--  ```TSHttpHdrUrlSet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#ad935635a3918575fa6cca6843c474cfe>`__
--  ```TSHttpHdrVersionGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a90cc8783f5d0bc159f226079aa0104e4>`__
--  ```TSHttpHdrVersionSet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#aa2a2c03399cdc8dc39b8756f13e7f189>`__
--  ```TSHttpParserClear`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a7cb1b53b4464dc71287351616d6e7509>`__
--  ```TSHttpParserCreate`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a6075fb4e8fc41eb75d640f258722115b>`__
+-  :c:func:`TSHttpHdrClone`
+-  :c:func:`TSHttpHdrCopy`
+-  :c:func:`TSHttpHdrCreate`
+-  :c:func:`TSHttpHdrDestroy`
+-  :c:func:`TSHttpHdrLengthGet`
+-  :c:func:`TSHttpHdrMethodGet`
+-  :c:func:`TSHttpHdrMethodSet`
+-  :c:func:`TSHttpHdrPrint`
+-  :c:func:`TSHttpHdrReasonGet`
+-  :c:func:`TSHttpHdrReasonLookup`
+-  :c:func:`TSHttpHdrReasonSet`
+-  :c:func:`TSHttpHdrStatusGet`
+-  :c:func:`TSHttpHdrStatusSet`
+-  :c:func:`TSHttpHdrTypeGet`
+-  :c:func:`TSHttpHdrTypeSet`
+-  :c:func:`TSHttpHdrUrlGet`
+-  :c:func:`TSHttpHdrUrlSet`
+-  :c:func:`TSHttpHdrVersionGet`
+-  :c:func:`TSHttpHdrVersionSet`
+-  :c:func:`TSHttpParserClear`
+-  :c:func:`TSHttpParserCreate`
 -  `TSHttpParserDestroy <link/to/doxyge>`__
--  ```TSHttpHdrParseReq`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a64193b3c9ddff8bc434c1cc9332004cc>`__
--  ```TSHttpHdrParseResp`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a03c8a14b6ab2b7896ef0e4005222ecff>`__
+-  :c:func:`TSHttpHdrParseReq`
+-  :c:func:`TSHttpHdrParseResp`
 

--- a/doc/sdk/http-headers/mime-headers.en.rst
+++ b/doc/sdk/http-headers/mime-headers.en.rst
@@ -74,7 +74,7 @@ a MIME header location. If an HTTP header location is passed to these
 functions, then the system locates the MIME header associated with that
 HTTP header and executes the corresponding MIME header operations
 specified by the functions (see the example in the description of
-```TSMimeHdrCopy`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a6e0a392b2e072db8e7f1d795151203b4>`__).
+:c:func:`TSMimeHdrCopy`).
 
 **Note:** MIME headers may contain more than one MIME field with the
 same name. Previous versions of Traffic Server joined multiple fields
@@ -393,45 +393,45 @@ object in one of the MIME headers associated with the object.
 
 The MIME header functions are listed below:
 
--  ```TSMimeHdrFieldAppend`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#ae36c9bab9147a30b259d8e0223d697f2>`__
--  ```TSMimeHdrFieldClone`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#ade66cd69ddff40d14b015a9e2cd7b46f>`__
--  ```TSMimeHdrFieldCopy`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a612ebefde403abc216af99f9150dd66f>`__
--  ```TSMimeHdrFieldCopyValues`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a5e4b2f68392a26643620641e50e5045b>`__
--  ```TSMimeHdrFieldCreate`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a7f79c0bea2ce14ced3b017eac08f8916>`__
--  ```TSMimeHdrFieldDestroy`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a6bf2d8e95e6f3ef351f63dbe8bc54020>`__
--  ```TSMimeHdrFieldLengthGet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a8a906f22ccf7a4a04fac817dc57a785f>`__
--  ```TSMimeHdrFieldNameGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#ad68f51073e4630ad6a0433efbfeef2ea>`__
--  ```TSMimeHdrFieldNameSet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a6856f6069fa4ee67d1a788bd642d59f0>`__
--  ```TSMimeHdrFieldNext`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#aaf3a205e8a4e7128f3fa3de70991df80>`__
--  ```TSMimeHdrFieldNextDup`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#af2d776615afe959ed7c3639830a7061f>`__
--  ```TSMimeHdrFieldValueAppend`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#ad1d4d1dda95311e3389245fd9fa961b5>`__
--  ```TSMimeHdrFieldValueAppend`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#ad1d4d1dda95311e3389245fd9fa961b5>`__
--  ```TSMimeHdrFieldValueDateGet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#ad74a60f0da93397ee015d82f30021d15>`__
--  ```TSMimeHdrFieldValueDateInsert`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a0520a29de96736b04f14e9d790ec8e9c>`__
--  ```TSMimeHdrFieldValueDateSet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#abf85e014cb316977dedca38c341d4369>`__
--  ```TSMimeHdrFieldValueIntGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#ace1fac92d2be75ff7cbd8eb7725d3fac>`__
--  ```TSMimeHdrFieldValueIntSet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#aec96c5629a750cdaec709228c4bd8a76>`__
--  ```TSMimeHdrFieldValueStringGet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a4aa55cd4eeb9e6d0a5151c02f0c18c28>`__
--  ```TSMimeHdrFieldValueStringInsert`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a979d1591becf1c59de830af117d54923>`__
--  ```TSMimeHdrFieldValueStringSet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#ac21e44e84b25c23e52ba7bea7bd09ed6>`__
--  ```TSMimeHdrFieldValueUintGet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a116b4c9144ad6eda66213adb0167706a>`__
--  ```TSMimeHdrFieldValueUintInsert`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a88db3a90d3ac7766e55c734c89dfe86f>`__
--  ```TSMimeHdrFieldValueUintSet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a63b0a686b4a6ec6b8a4f1b796009c3cd>`__
--  ```TSMimeHdrFieldValuesClear`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a8fd3afaf88f6c76793fdb635bbd22113>`__
--  ```TSMimeHdrFieldValuesCount`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a326283521986acf9b8a9ec00f3d6d164>`__
--  ```TSMimeHdrClone`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#aa8ab95bda93c3e16e6d134fe35acd1b6>`__
--  ```TSMimeHdrCopy`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a6e0a392b2e072db8e7f1d795151203b4>`__
--  ```TSMimeHdrCreate`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a3427dfbd6b79c531fcba4e8c8b4e217d>`__
--  ```TSMimeHdrDestroy`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a60ad7f4f4f9e2559dcc2ff28ebe8d96c>`__
--  ```TSMimeHdrFieldFind`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a30e4ce224761b273a119dcd57f5a352b>`__
--  ```TSMimeHdrFieldGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a31c0c307010a5d19d027ffb3a2656745>`__
--  ```TSMimeHdrFieldRemove`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a96d9a50d0687456e6e67eb2e9a9c2d72>`__
--  ```TSMimeHdrFieldsClear`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a65d7539e48c9f5c26075344dee6c6ae2>`__
--  ```TSMimeHdrFieldsCount`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#ab02f7d0cba75cf0146c6a9b507c79fcf>`__
--  ```TSMimeHdrLengthGet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a001cd786282f5c9d04189ddf7c96e269>`__
--  ```TSMimeHdrParse`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a4a6042bcd5b5b0a21267c03cf102e90d>`__
--  ```TSMimeParserClear`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#ac173b595659d1909aae5410ecd1ce028>`__
--  ```TSMimeParserCreate`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a518072dc5a90b753df7726878119506b>`__
--  ```TSMimeParserDestroy`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a5f287f5016d931842c0a5012c3d227b7>`__
--  ```TSMimeHdrPrint`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#adfca8722edc6469df4410b8050406bb0>`__
+-  :c:func:`TSMimeHdrFieldAppend`
+-  :c:func:`TSMimeHdrFieldClone`
+-  :c:func:`TSMimeHdrFieldCopy`
+-  :c:func:`TSMimeHdrFieldCopyValues`
+-  :c:func:`TSMimeHdrFieldCreate`
+-  :c:func:`TSMimeHdrFieldDestroy`
+-  :c:func:`TSMimeHdrFieldLengthGet`
+-  :c:func:`TSMimeHdrFieldNameGet`
+-  :c:func:`TSMimeHdrFieldNameSet`
+-  :c:func:`TSMimeHdrFieldNext`
+-  :c:func:`TSMimeHdrFieldNextDup`
+-  :c:func:`TSMimeHdrFieldValueAppend`
+-  :c:func:`TSMimeHdrFieldValueAppend`
+-  :c:func:`TSMimeHdrFieldValueDateGet`
+-  :c:func:`TSMimeHdrFieldValueDateInsert`
+-  :c:func:`TSMimeHdrFieldValueDateSet`
+-  :c:func:`TSMimeHdrFieldValueIntGet`
+-  :c:func:`TSMimeHdrFieldValueIntSet`
+-  :c:func:`TSMimeHdrFieldValueStringGet`
+-  :c:func:`TSMimeHdrFieldValueStringInsert`
+-  :c:func:`TSMimeHdrFieldValueStringSet`
+-  :c:func:`TSMimeHdrFieldValueUintGet`
+-  :c:func:`TSMimeHdrFieldValueUintInsert`
+-  :c:func:`TSMimeHdrFieldValueUintSet`
+-  :c:func:`TSMimeHdrFieldValuesClear`
+-  :c:func:`TSMimeHdrFieldValuesCount`
+-  :c:func:`TSMimeHdrClone`
+-  :c:func:`TSMimeHdrCopy`
+-  :c:func:`TSMimeHdrCreate`
+-  :c:func:`TSMimeHdrDestroy`
+-  :c:func:`TSMimeHdrFieldFind`
+-  :c:func:`TSMimeHdrFieldGet`
+-  :c:func:`TSMimeHdrFieldRemove`
+-  :c:func:`TSMimeHdrFieldsClear`
+-  :c:func:`TSMimeHdrFieldsCount`
+-  :c:func:`TSMimeHdrLengthGet`
+-  :c:func:`TSMimeHdrParse`
+-  :c:func:`TSMimeParserClear`
+-  :c:func:`TSMimeParserCreate`
+-  :c:func:`TSMimeParserDestroy`
+-  :c:func:`TSMimeHdrPrint`
 

--- a/doc/sdk/http-headers/urls.en.rst
+++ b/doc/sdk/http-headers/urls.en.rst
@@ -104,31 +104,31 @@ schemes, since doing so can prevent the possibility of spelling errors.
 
 Traffic Server **URL functions** are listed below:
 
-```TSUrlClone`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#acb775f48f1da5f6c5bf32c833a236574>`__
-```TSUrlCopy`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#aa2b8d5f9289a23ab985210914a6301a7>`__
-```TSUrlCreate`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#ad3518ea3bca6a6f2d899b859c6fbbede>`__
-```TSUrlDestroy`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a87559aac42f4f9439399ba2bd32693fa>`__
-```TSUrlPrint`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#adec26f5a4afe62b4308dd86f97ae08fd>`__
-```TSUrlFtpTypeGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a5cd15d2c288a48b832f0fc096ed6fb80>`__
-```TSUrlFtpTypeSet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a66df700e23085cabf945e92eb1e22890>`__
-```TSUrlHostGet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a48e626d9497d4d81c0b9d2781f86066b>`__
-```TSUrlHostSet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a7e550dac573f5780f7ba39509aa881f3>`__
-```TSUrlHttpFragmentGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a316696ad964cb6c6afb7e3028da3ef84>`__
-```TSUrlHttpFragmentSet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a45f7b216882c4517b92929145adf5424>`__
-```TSUrlHttpParamsGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a9395d5d794078c8ec0f17f27dc8d8498>`__
-```TSUrlHttpParamsSet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a566f2996d36663e3eb8ed4a8fda738c3>`__
-```TSUrlHttpQueryGet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a74a6c51ea9f472cf29514facbf897785>`__
-```TSUrlHttpQuerySet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a9846aaf11accd8c817fff48bfaa784e0>`__
-```TSUrlLengthGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a96ded2567985b187c0a8274d76d12c17>`__
-```TSUrlParse`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a17f785697773b62b1f5094c06896cac5>`__
-```TSUrlPasswordGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a14614f77e0c15b206bab8fd6fdfa7bd1>`__
-```TSUrlPasswordSet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#abb4d983b9d47ba5a254c2b9dd9ad835e>`__
-```TSUrlPathGet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#aa064a2d5256d839819d1ec8f252c01a9>`__
-```TSUrlPathSet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#ad73274cb5b7e98a64d53f992681110b7>`__
-```TSUrlPortGet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#ad99bfb408a46f47c4aa9478fc1b95e0c>`__
-```TSUrlPortSet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#aab07c0482fc3c3aae1b545fb0104e3aa>`__
-```TSUrlSchemeGet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a24c660b5b46f17b24d7a1cc9aa9a4930>`__
-```TSUrlSchemeSet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a03b1a806ea8d79806dfff39bfe138934>`__
-```TSUrlStringGet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a1cda3103d8dd59372609aed6c9c47417>`__
-```TSUrlUserGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a3c4d7ffcbbda447c3b665dc857a3226b>`__
-```TSUrlUserSet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a3175e9c89c2bbea5ed50e2a7f52d7f9f>`__
+:c:func:`TSUrlClone`
+:c:func:`TSUrlCopy`
+:c:func:`TSUrlCreate`
+:c:func:`TSUrlDestroy`
+:c:func:`TSUrlPrint`
+:c:func:`TSUrlFtpTypeGet`
+:c:func:`TSUrlFtpTypeSet`
+:c:func:`TSUrlHostGet`
+:c:func:`TSUrlHostSet`
+:c:func:`TSUrlHttpFragmentGet`
+:c:func:`TSUrlHttpFragmentSet`
+:c:func:`TSUrlHttpParamsGet`
+:c:func:`TSUrlHttpParamsSet`
+:c:func:`TSUrlHttpQueryGet`
+:c:func:`TSUrlHttpQuerySet`
+:c:func:`TSUrlLengthGet`
+:c:func:`TSUrlParse`
+:c:func:`TSUrlPasswordGet`
+:c:func:`TSUrlPasswordSet`
+:c:func:`TSUrlPathGet`
+:c:func:`TSUrlPathSet`
+:c:func:`TSUrlPortGet`
+:c:func:`TSUrlPortSet`
+:c:func:`TSUrlSchemeGet`
+:c:func:`TSUrlSchemeSet`
+:c:func:`TSUrlStringGet`
+:c:func:`TSUrlUserGet`
+:c:func:`TSUrlUserSet`

--- a/doc/sdk/http-hooks-and-transactions/adding-hooks.en.rst
+++ b/doc/sdk/http-hooks-and-transactions/adding-hooks.en.rst
@@ -34,7 +34,7 @@ There are several ways to add hooks to your plugin.
 
 -  **Transformation hooks** Transformation hooks are a special case of
    transaction hooks. See
-   ```TSVConnCacheObjectSizeGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#af5ca2c5b00e4859d2fa5dec466dfd058>`__
+   :c:func:`TSVConnCacheObjectSizeGet`
    for more information about transformation hooks. You add a
    transformation hook using ``TSHttpTxnHookAdd``, as described in `HTTP
    Transactions <HTTP_Transactions.html>`__.
@@ -55,9 +55,9 @@ There are several ways to add hooks to your plugin.
    information on the alternate selection mechanism.
 
 All of the hook addition functions
-(```TSHttpHookAdd`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a19a663edd3ec439f66256fbbb26cc1db>`__,
-```TSHttpSsnHookAdd`` <HTTPSessionFunctions.html#TSHttpSsnHookAdd>`__,
-```TSHttpSsnReenable`` <HTTPSessionFunctions.html#TSHttpSsnReenable>`__)
+(:c:func:`TSHttpHookAdd`,
+:c:func:`TSHttpSsnHookAdd`,
+:c:func:`TSHttpSsnReenable`)
 take ``TSHttpHookID`` (identifies the hook to add on to) and ``TSCont``
 (the basic callback mechanism in Traffic Server). A single ``TSCont``
 can be added to any number of hooks at a time.
@@ -150,4 +150,4 @@ values for ``TSHttpHookID`` are:
     was left open for keep alive has new data available.
 
 The function you use to add a global HTTP hook is
-```TSHttpHookAdd`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a19a663edd3ec439f66256fbbb26cc1db>`__.
+:c:func:`TSHttpHookAdd`.

--- a/doc/sdk/http-hooks-and-transactions/http-sessions.en.rst
+++ b/doc/sdk/http-hooks-and-transactions/http-sessions.en.rst
@@ -47,6 +47,6 @@ processing a session hook.
 
 The session hook functions are listed below:
 
--  ```TSHttpSsnHookAdd`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a268d493d94fa5461c8200883a9b8d20b>`__
--  ```TSHttpSsnReenable`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a3bbe42bf4757625bdb8bb65e7ac6f52d>`__
+-  :c:func:`TSHttpSsnHookAdd`
+-  :c:func:`TSHttpSsnReenable`
 

--- a/doc/sdk/http-hooks-and-transactions/http-transactions.en.rst
+++ b/doc/sdk/http-hooks-and-transactions/http-transactions.en.rst
@@ -158,12 +158,12 @@ for an illustration of the steps involved in a typical HTTP transaction.
 
 The HTTP transaction functions are:
 
--  ```TSHttpTxnCacheLookupStatusGet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#ad26c77fa4ba251fb8ccbbd1505a74687>`__
+-  :c:func:`TSHttpTxnCacheLookupStatusGet`
 
--  ```TSHttpTxnCachedReqGet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a889b626142157077f4f3cfe479e8b8e2>`__
+-  :c:func:`TSHttpTxnCachedReqGet`
    - Note that it is an error to modify cached headers.
 
--  ```TSHttpTxnCachedRespGet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#ae8f24b8dabb5008ad11620a11682ffd6>`__
+-  :c:func:`TSHttpTxnCachedRespGet`
    - Note that it is an error to modify cached headers.
 
 -  `TSHttpTxnClientIncomingPortGet <link/to/doxygen>`__
@@ -172,34 +172,34 @@ The HTTP transaction functions are:
 
 -  `TSHttpTxnClientRemotePortGet <link/to/doxygen>`__
 
--  ```TSHttpTxnClientReqGet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#acca66f22d0f87bf8f08478ed926006a5>`__
+-  :c:func:`TSHttpTxnClientReqGet`
    - Plugins that must read client request headers use this call to
    retrieve the HTTP header.
 
--  ```TSHttpTxnClientRespGet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a92349c8363f72b1f6dfed3ae80901fff>`__
+-  :c:func:`TSHttpTxnClientRespGet`
 
--  ```TSHttpTxnErrorBodySet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#ad7efc431279dc97de4b50a58d4ed33c1>`__
+-  :c:func:`TSHttpTxnErrorBodySet`
 
--  ```TSHttpTxnHookAdd`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a10382b88145bbfba0fa9d8ed6402f4b1>`__
+-  :c:func:`TSHttpTxnHookAdd`
 
--  ```TSHttpTxnNextHopAddrGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#aa0118beabfefe35d2642f007ac7afa97>`__
+-  :c:func:`TSHttpTxnNextHopAddrGet`
 
--  ```TSHttpTxnParentProxySet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a2a1260b900b665d38a262544446b886c>`__
+-  :c:func:`TSHttpTxnParentProxySet`
 
--  ```TSHttpTxnReenable`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#ac367347e02709ac809994dfb21d3288a>`__
+-  :c:func:`TSHttpTxnReenable`
 
--  ```TSHttpTxnServerAddrGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a63917ec11275c4f1ed559362865cd65f>`__
+-  :c:func:`TSHttpTxnServerAddrGet`
 
--  ```TSHttpTxnServerReqGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#aac2343a8b47bf9150f3ff7cd4e692d57>`__
+-  :c:func:`TSHttpTxnServerReqGet`
 
--  ```TSHttpTxnServerRespGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a39e8bfb199eadabb54c067ff25a9a400>`__
+-  :c:func:`TSHttpTxnServerRespGet`
 
--  ```TSHttpTxnSsnGet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a8c5190bd2e940ef2d1969a5be65f0edd>`__
+-  :c:func:`TSHttpTxnSsnGet`
 
--  ```TSHttpTxnTransformedRespCache`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a213b584cd04001e8f8ad509d187a4103>`__
+-  :c:func:`TSHttpTxnTransformedRespCache`
 
--  ```TSHttpTxnTransformRespGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a4fc46502733adcff09587a436e300114>`__
+-  :c:func:`TSHttpTxnTransformRespGet`
 
--  ```TSHttpTxnUntransformedRespCache`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a8b9c0e61cbcb251417df0d06ae6c4408>`__
+-  :c:func:`TSHttpTxnUntransformedRespCache`
 
 

--- a/doc/sdk/http-hooks-and-transactions/initiate-http-connection.en.rst
+++ b/doc/sdk/http-hooks-and-transactions/initiate-http-connection.en.rst
@@ -21,5 +21,5 @@ Initiate HTTP Connection
 This function enables plugins to initiate HTTP transactions. The
 initiate HTTP connection function is:
 
--  ```TSHttpConnect`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a2b45aa63ac1353b4c52123110197b61e>`__
+-  :c:func:`TSHttpConnect`
 

--- a/doc/sdk/http-hooks-and-transactions/intercepting-http-transactions.en.rst
+++ b/doc/sdk/http-hooks-and-transactions/intercepting-http-transactions.en.rst
@@ -26,5 +26,5 @@ for reading ``POST`` bodies in plugins as well as using alternative
 transports to the origin server.The intercepting HTTP transaction
 functions are:
 
--  ```TSHttpTxnIntercept`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a3408017633f95161e2ab4fa175c44fa3>`__
+-  :c:func:`TSHttpTxnIntercept`
 

--- a/doc/sdk/io-guide.en.rst
+++ b/doc/sdk/io-guide.en.rst
@@ -182,13 +182,13 @@ Plugins <../http-transformation-plugin#WritingContentTransformPlugins>`__.
 
 The vconnection functions are listed below:
 
--  ```TSVConnAbort`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a08444a9b2fee637672e177ede78b6218>`__
--  ```TSVConnClose`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a69344c2c6e57ece0990a5cee73b75215>`__
--  ```TSVConnClosedGet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a441d74cd77bf5d5564048682ca83b6ec>`__
--  ```TSVConnRead`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a29674799a8deffdde3d6ae3231aba1dc>`__
--  ```TSVConnReadVIOGet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#aa6f8788f062737f211c788ad5fcd2813>`__
--  ```TSVConnShutdown`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a5935b6c762b65fe87057adf94b1b00b4>`__
--  ```TSVConnWrite`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#acea65496d1fcaf01924b0210f3129e6b>`__
--  ```TSVConnWriteVIOGet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#ae9a38dbd4866c59131a1f3b806a18aab>`__
+-  :c:func:`TSVConnAbort`
+-  :c:func:`TSVConnClose`
+-  :c:func:`TSVConnClosedGet`
+-  :c:func:`TSVConnRead`
+-  :c:func:`TSVConnReadVIOGet`
+-  :c:func:`TSVConnShutdown`
+-  :c:func:`TSVConnWrite`
+-  :c:func:`TSVConnWriteVIOGet`
 
 

--- a/doc/sdk/io-guide/io-buffers.en.rst
+++ b/doc/sdk/io-guide/io-buffers.en.rst
@@ -35,7 +35,7 @@ structure. Since only a single writer is allowed, there is no
 corresponding ``TSIOBufferWriter`` data structure. The writer simply
 modifies the IO buffer directly. To see an example that illustrates how
 to use IOBuffers, refer to the sample code in the description of
-```TSIOBufferBlockReadStart`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a367203e6e2cf4349e019952782deb96c>`__.
+:c:func:`TSIOBufferBlockReadStart`.
 
 Additional information about IO buffer functions:
 

--- a/doc/sdk/io-guide/transformations.en.rst
+++ b/doc/sdk/io-guide/transformations.en.rst
@@ -177,6 +177,6 @@ Here's how to make sure that all incoming data is consumed:
    because it knows it already holds the mutex.
 
 The transformation functions are: \*
-```TSTransformCreate`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a54c4902bb537d3d40763bd947ed753b9>`__
+:c:func:`TSTransformCreate`
 \*
-```TSTransformOutputVConnGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#ac6832718a2d9f2658409ad231811e1e3>`__
+:c:func:`TSTransformOutputVConnGet`

--- a/doc/sdk/io-guide/vios.en.rst
+++ b/doc/sdk/io-guide/vios.en.rst
@@ -45,15 +45,15 @@ as follows:
 The VIO functions below access and modify various parts of the data
 structure.
 
--  ```TSVIOBufferGet`` <http://people.apache.org/~amc/ats/doc/html/InkIOCoreAPI_8cc.html#a55df75b6ba6e9152292a01e0b4e21963>`__
--  ```TSVIOVConnGet`` <http://people.apache.org/~amc/ats/doc/html/InkIOCoreAPI_8cc.html#a32b9eaaadf2145f98ceb4d64b7c06c2f>`__
--  ```TSVIOContGet`` <http://people.apache.org/~amc/ats/doc/html/InkIOCoreAPI_8cc.html#a071f12b307885c02aceebc41601bbdcf>`__
--  ```TSVIOMutexGet`` <http://people.apache.org/~amc/ats/doc/html/InkIOCoreAPI_8cc.html#ab4e8c755cf230918a14a4411af8b3e63>`__
--  ```TSVIONBytesGet`` <http://people.apache.org/~amc/ats/doc/html/InkIOCoreAPI_8cc.html#af6fc57adc7308864b343b6b7fd30c5ff>`__
--  ```TSVIONBytesSet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a27594723f14891ac43da3e1368328d0e>`__
--  ```TSVIONDoneGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#ad71156f68a119c00502ff1fd598824ab>`__
--  ```TSVIONDoneSet`` <http://people.apache.org/~amc/ats/doc/html/InkIOCoreAPI_8cc.html#af4590966899039571d874e0c090042ad>`__
--  ```TSVIONTodoGet`` <http://people.apache.org/~amc/ats/doc/html/InkIOCoreAPI_8cc.html#a1dd145ddd60822a5f892becf7b8e8f84>`__
--  ```TSVIOReaderGet`` <http://people.apache.org/~amc/ats/doc/html/InkIOCoreAPI_8cc.html#a471ee1fde01fbeabce6c39944dfe9da6>`__
--  ```TSVIOReenable`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a792ef9d6962193badad2877a81d8bcff>`__
+-  :c:func:`TSVIOBufferGet`
+-  :c:func:`TSVIOVConnGet`
+-  :c:func:`TSVIOContGet`
+-  :c:func:`TSVIOMutexGet`
+-  :c:func:`TSVIONBytesGet`
+-  :c:func:`TSVIONBytesSet`
+-  :c:func:`TSVIONDoneGet`
+-  :c:func:`TSVIONDoneSet`
+-  :c:func:`TSVIONTodoGet`
+-  :c:func:`TSVIOReaderGet`
+-  :c:func:`TSVIOReenable`
 

--- a/doc/sdk/misc-interface-guide.en.rst
+++ b/doc/sdk/misc-interface-guide.en.rst
@@ -39,22 +39,22 @@ all Traffic Server-support platforms).
 Debugging Functions
 -------------------
 
--  ```TSDebug`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#afccd91047cc46eb35478a751ec65c78d>`__
+-  :c:func:`TSDebug`
    prints out a formatted statement if you are running Traffic Server in
    debug mode.
 
--  ```TSIsDebugTagSet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a2d3ceac855c1cde83eff5484bc952288>`__
+-  :c:func:`TSIsDebugTagSet`
    checks to see if a debug tag is set. If the debug tag is set, then
    Traffic Server prints out all debug statements associated with the
    tag.
 
--  ```TSError`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a19ff77fecfc3e331b03da6e358907787>`__
+-  :c:func:`TSError`
    prints error messages to Traffic Server's error log
 
--  ```TSAssert`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#ad94eb4fb1f08082ea1634f169cc49c68>`__
+-  :c:func:`TSAssert`
    enables the use of assertion in a plugin.
 
--  ```TSReleaseAssert`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a5e751769785de91c52bd503bcbc28b0a>`__
+-  :c:func:`TSReleaseAssert`
    enables the use of assertion in a plugin.
 
 

--- a/doc/sdk/misc-interface-guide/memory-allocation.en.rst
+++ b/doc/sdk/misc-interface-guide/memory-allocation.en.rst
@@ -33,14 +33,14 @@ leaks.
 
 The memory allocation functions are:
 
--  ```TSfree`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#afe7f18beddf31a80436a03a5ab7e759f>`__
+-  :c:func:`TSfree`
 
--  ```TSmalloc`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#af030092823148cbbc5525c4fcde9bb37>`__
+-  :c:func:`TSmalloc`
 
--  ```TSrealloc`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a3abaf3d50d82377dccd1c16bc7b631ab>`__
+-  :c:func:`TSrealloc`
 
--  ```TSstrdup`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a92c01584655c52e46a58986435e17c86>`__
+-  :c:func:`TSstrdup`
 
--  ```TSstrndup`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a11072c11fa6d8470ace2963615229146>`__
+-  :c:func:`TSstrndup`
 
 

--- a/doc/sdk/misc-interface-guide/thread-functions.en.rst
+++ b/doc/sdk/misc-interface-guide/thread-functions.en.rst
@@ -27,8 +27,8 @@ shared resources and data using the ``TSMutex`` type, as described in
 
 The thread functions are listed below:
 
--  ```TSThreadCreate`` <http://people.apache.org/~amc/ats/doc/html/InkIOCoreAPI_8cc.html#ad087d67be30b68b6d608a5094fceed2a>`__
--  ```TSThreadDestroy`` <http://people.apache.org/~amc/ats/doc/html/InkIOCoreAPI_8cc.html#a600e8ad830081bdcf6caabc07b54c9e4>`__
--  ```TSThreadInit`` <http://people.apache.org/~amc/ats/doc/html/InkIOCoreAPI_8cc.html#a11088d9aaba362827841687864e55242>`__
--  ```TSThreadSelf`` <http://people.apache.org/~amc/ats/doc/html/InkIOCoreAPI_8cc.html#a5cc33c5182755e3d62b4aa55277425d9>`__
+-  :c:func:`TSThreadCreate`
+-  :c:func:`TSThreadDestroy`
+-  :c:func:`TSThreadInit`
+-  :c:func:`TSThreadSelf`
 

--- a/doc/sdk/misc-interface-guide/tsfopen-family.en.rst
+++ b/doc/sdk/misc-interface-guide/tsfopen-family.en.rst
@@ -39,16 +39,16 @@ corresponding usage of the ``fopen`` family of functions is
 inappropriate due to file descriptor and portability limitations. The
 ``TSfopen`` family of functions consists of the following:
 
--  ```TSfclose`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a2efebe7583752668e6136de0b47bee4f>`__
+-  :c:func:`TSfclose`
 
--  ```TSfflush`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a3cb0cb348ed189a98577f84e0629ca9a>`__
+-  :c:func:`TSfflush`
 
--  ```TSfgets`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a6dcc724a432a287836352b31984e0de8>`__
+-  :c:func:`TSfgets`
 
--  ```TSfopen`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a53b0430d5b0c042bdb3d06689cf244f3>`__
+-  :c:func:`TSfopen`
 
--  ```TSfread`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a29f83c50b52e4fcabfe2b829de5742e2>`__
+-  :c:func:`TSfread`
 
--  ```TSfwrite`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a596a5562db5180ea8818f7bb87336a15>`__
+-  :c:func:`TSfwrite`
 
 

--- a/doc/sdk/mutex-guide.en.rst
+++ b/doc/sdk/mutex-guide.en.rst
@@ -81,24 +81,24 @@ created in ``TSPluginInit``. The ``blacklist-1.c`` code uses
 information, see the
 ```blacklist-1.c`` <../sample-source-code#Sample_blacklist-1.c>`__ code;
 start by looking at the
-```TSPluginInit`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a9a0b0ac9cbce9d6644f66bbe93098313>`__
+:c:func:`TSPluginInit`
 function.
 
 General guidelines for locking shared data are as follows:
 
 1. Create a mutex for the shared data with
-   ```TSMutexCreate`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#aa4300d8888c6962a44c9e827d633e433>`__.
+   :c:func:`TSMutexCreate`.
 
 2. Whenever you need to read or modify this data, first lock it by
    calling
-   ```TSMutexLockTry`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#ac9c08451aa529851b9474e3c035f44bb>`__;
+   :c:func:`TSMutexLockTry`;
    then read or modify the data.
 
 3. When you are done with the data, unlock it with
-   ```TSMutexUnlock`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#afbb474c217fd5b927f1f8487c45646dd>`__.
+   :c:func:`TSMutexUnlock`.
    If you are unlocking data accessed during the processing of an HTTP
    transaction, then you must unlock it before calling
-   ```TSHttpTxnReenable`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#ac367347e02709ac809994dfb21d3288a>`__.
+   :c:func:`TSHttpTxnReenable`.
 
 Protecting a Continuation's Data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -405,7 +405,7 @@ continuation created in ``txn_handler``:
 
 The mutex functions are listed below:
 
--  ```TSMutexCreate`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#aa4300d8888c6962a44c9e827d633e433>`__
--  ```TSMutexLock`` <http://people.apache.org/~amc/ats/doc/html/InkIOCoreAPI_8cc.html#a306f9923bc9d3c0f417c185919531934>`__
--  ```TSMutexLockTry`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#ac9c08451aa529851b9474e3c035f44bb>`__
+-  :c:func:`TSMutexCreate`
+-  :c:func:`TSMutexLock`
+-  :c:func:`TSMutexLockTry`
 

--- a/doc/sdk/plugin-configurations.en.rst
+++ b/doc/sdk/plugin-configurations.en.rst
@@ -105,12 +105,12 @@ Here's how the interface works:
 
 The configuration functions are:
 
--  ```TSConfigDataGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#aed2a6f9d350935ac890f75fdd80605db>`__
+-  :c:func:`TSConfigDataGet`
 
--  ```TSConfigGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a478189d6ad87c6b873d8676cb51508c5>`__
+-  :c:func:`TSConfigGet`
 
--  ```TSConfigRelease`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a06711d4a0e70f1ff27f9b5ca34bb649c>`__
+-  :c:func:`TSConfigRelease`
 
--  ```TSConfigSet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a8bba9468fdca478e68035a9776f6e9ca>`__
+-  :c:func:`TSConfigSet`
 
 

--- a/doc/sdk/plugin-management/guide-to-the-logging-api.en.rst
+++ b/doc/sdk/plugin-management/guide-to-the-logging-api.en.rst
@@ -27,28 +27,28 @@ you can set log properties.
 The logging API enables you to:
 
 -  Establish a custom text log for your plugin: see
-   ```TSTextLogObjectCreate`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#ae75e85e476efeaa16ded185da7a3081b>`__
+   :c:func:`TSTextLogObjectCreate`
 
 -  Set the log header for your custom text log: see
-   ```TSTextLogObjectHeaderSet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a7c10f89fe8bcb6b733f4a83b5a73b71c>`__
+   :c:func:`TSTextLogObjectHeaderSet`
 
 -  Enable or disable rolling your custom text log: see
-   ```TSTextLogObjectRollingEnabledSet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#aec1e883f0735ee40c8b56d90cf27acd1>`__
+   :c:func:`TSTextLogObjectRollingEnabledSet`
 
 -  Set the rolling interval (in seconds) for your custom text log: see
-   ```TSTextLogObjectRollingIntervalSecSet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#aac0be2e81694db0363c5321e8a2019ce>`__
+   :c:func:`TSTextLogObjectRollingIntervalSecSet`
 
 -  Set the rolling offset for your custom text log: see
-   ```TSTextLogObjectRollingOffsetHrSet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a9d90885b975947c241f74c33550180b4>`__
+   :c:func:`TSTextLogObjectRollingOffsetHrSet`
 
 -  Write text entries to the custom text log: see
-   ```TSTextLogObjectWrite`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a34de01e5603ea639d7ce6c7bf9613254>`__
+   :c:func:`TSTextLogObjectWrite`
 
 -  Flush the contents of the custom text log's write buffer to disk: see
-   ```TSTextLogObjectFlush`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#ad746b22f992c2adb5f0271e5136a6ca1>`__
+   :c:func:`TSTextLogObjectFlush`
 
 -  Destroy custom text logs when you are done with them: see
-   ```TSTextLogObjectDestroy`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#af6521931ada7bbc38194e79e60081d54>`__
+   :c:func:`TSTextLogObjectDestroy`
 
 The steps below show how the logging API is used in the
 ``blacklist-1.c`` sample plugin. For the complete source code, see the

--- a/doc/sdk/plugin-management/reading-trafficserver-settings-and-statistics.en.rst
+++ b/doc/sdk/plugin-management/reading-trafficserver-settings-and-statistics.en.rst
@@ -40,16 +40,16 @@ the `Traffic Server Administrator's Guide <../../admin/>`__.
 Depending on the result type, you'll use ``TSMgmtIntGet``,
 ``TSMgmtCounterGet``, ``TSMgmtFloatGet``, or ``TSMgmtStringGet`` to
 obtain the variable value (see the example for
-```TSMgmtIntGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a097aaecda41d04b522796ae25eea9a3d>`__.
+:c:func:`TSMgmtIntGet`.
 
 The ``TSMgmt*Get`` functions are:
 
--  ```TSMgmtCounterGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a583e21e614b70256f68658fc6c455ea6>`__
+-  :c:func:`TSMgmtCounterGet`
 
--  ```TSMgmtFloatGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a2ace94b52c71656304b53824d3fa7080>`__
+-  :c:func:`TSMgmtFloatGet`
 
--  ```TSMgmtIntGet`` <http://people.apache.org/~amc/ats/doc/html/ts_8h.html#a097aaecda41d04b522796ae25eea9a3d>`__
+-  :c:func:`TSMgmtIntGet`
 
--  ```TSMgmtStringGet`` <http://people.apache.org/~amc/ats/doc/html/InkAPI_8cc.html#a14167888ed89d5b30df5bdcdcfdf1c30>`__
+-  :c:func:`TSMgmtStringGet`
 
 


### PR DESCRIPTION
...e link text)
e.g. http://trafficserver.readthedocs.org/en/latest/sdk/plugin-management/guide-to-the-logging-api.en.html
