### PR TITLE
patch for TS-2720 atscppapi: Request transformation streaming doesn't work

### DIFF
--- a/lib/atscppapi/examples/null_transformation_plugin/NullTransformationPlugin.cc
+++ b/lib/atscppapi/examples/null_transformation_plugin/NullTransformationPlugin.cc
@@ -32,9 +32,15 @@ namespace {
 
 class NullTransformationPlugin : public TransformationPlugin {
 public:
-  NullTransformationPlugin(Transaction &transaction)
-    : TransformationPlugin(transaction, RESPONSE_TRANSFORMATION) {
-    registerHook(HOOK_SEND_RESPONSE_HEADERS);
+  NullTransformationPlugin(Transaction &transaction, TransformationPlugin::Type xformType)
+    : TransformationPlugin(transaction, xformType) {
+    registerHook((xformType == TransformationPlugin::REQUEST_TRANSFORMATION) ? 
+                 HOOK_SEND_REQUEST_HEADERS : HOOK_SEND_RESPONSE_HEADERS);
+  }
+
+  void handleSendRequestHeaders(Transaction &transaction) {
+    transaction.getServerRequest().getHeaders()["X-Content-Transformed"] = "1";
+    transaction.resume();
   }
 
   void handleSendResponseHeaders(Transaction &transaction) {
@@ -60,14 +66,19 @@ private:
 class GlobalHookPlugin : public GlobalPlugin {
 public:
   GlobalHookPlugin() {
+    registerHook(HOOK_READ_REQUEST_HEADERS_POST_REMAP);
     registerHook(HOOK_READ_RESPONSE_HEADERS);
   }
 
-  virtual void handleReadResponseHeaders(Transaction &transaction) {
-    transaction.addPlugin(new NullTransformationPlugin(transaction));
+  virtual void handleReadRequestHeadersPostRemap(Transaction &transaction) {
+    transaction.addPlugin(new NullTransformationPlugin(transaction, TransformationPlugin::REQUEST_TRANSFORMATION));
     transaction.resume();
   }
 
+  virtual void handleReadResponseHeaders(Transaction &transaction) {
+    transaction.addPlugin(new NullTransformationPlugin(transaction, TransformationPlugin::RESPONSE_TRANSFORMATION));
+    transaction.resume();
+  }
 };
 
 void TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED) {

--- a/lib/atscppapi/src/TransformationPlugin.cc
+++ b/lib/atscppapi/src/TransformationPlugin.cc
@@ -56,6 +56,8 @@ struct atscppapi::TransformationPluginState: noncopyable {
   // sent the input end our write complte.
   bool input_complete_dispatched_;
 
+  std::string request_xform_output_; // in case of request xform, data produced is buffered here
+
   TransformationPluginState(atscppapi::Transaction &transaction, TransformationPlugin &transformation_plugin,
       TransformationPlugin::Type type, TSHttpTxn txn)
     : vconn_(NULL), transaction_(transaction), transformation_plugin_(transformation_plugin), type_(type),
@@ -232,7 +234,7 @@ TransformationPlugin::~TransformationPlugin() {
   delete state_;
 }
 
-size_t TransformationPlugin::produce(const std::string &data) {
+size_t TransformationPlugin::doProduce(const std::string &data) {
   LOG_DEBUG("TransformationPlugin=%p tshttptxn=%p producing output with length=%ld", this, state_->txn_, data.length());
   int64_t write_length = static_cast<int64_t>(data.length());
   if (!write_length) {
@@ -281,7 +283,21 @@ size_t TransformationPlugin::produce(const std::string &data) {
   return static_cast<size_t>(bytes_written);
 }
 
+size_t TransformationPlugin::produce(const std::string &data) {
+  if (state_->type_ == REQUEST_TRANSFORMATION) {
+    state_->request_xform_output_.append(data);
+    return data.size();
+  }
+  else {
+    return doProduce(data);
+  }
+}
+
 size_t TransformationPlugin::setOutputComplete() {
+  if (state_->type_ = REQUEST_TRANSFORMATION) {
+    doProduce(state_->request_xform_output_);
+  }
+
   int connection_closed = TSVConnClosedGet(state_->vconn_);
   LOG_DEBUG("OutputComplete TransformationPlugin=%p tshttptxn=%p vconn=%p connection_closed=%d, total bytes written=%" PRId64, this, state_->txn_, state_->vconn_, connection_closed,state_->bytes_written_);
 

--- a/lib/atscppapi/src/include/atscppapi/TransformationPlugin.h
+++ b/lib/atscppapi/src/include/atscppapi/TransformationPlugin.h
@@ -121,6 +121,7 @@ protected:
   TransformationPlugin(Transaction &transaction, Type type);
 private:
   TransformationPluginState *state_; /** Internal state for a TransformationPlugin */
+  size_t doProduce(const std::string &);
 };
 
 } /* atscppapi */


### PR DESCRIPTION
Patch buffers the output till setOutputComplete() is called.
