### PR TITLE
Fix the automake rule to satisfy header requirements of atscppapi

### DIFF
--- a/lib/atscppapi/src/Makefile.am
+++ b/lib/atscppapi/src/Makefile.am
@@ -82,4 +82,5 @@ library_include_HEADERS = $(base_include_folder)/GlobalPlugin.h \
 			  $(base_include_folder)/GzipDeflateTransformation.h \
 			  $(base_include_folder)/GzipInflateTransformation.h \
 			  $(base_include_folder)/AsyncTimer.h \
-			  $(base_include_folder)/InterceptPlugin.h
+			  $(base_include_folder)/InterceptPlugin.h \
+			  $(top_srcdir)/lib/ts/ink_autoconf.h


### PR DESCRIPTION
When I built my plugin outside of trafficserver source tree, I found build failure related to header requirements of atscppapi as below logs.

```
# I set /usr/local/trafficserver/ as prefix.
In file included from /usr/local/trafficserver/include/atscppapi/Transaction.h:30:
/usr/local/trafficserver/include/atscppapi/shared_ptr.h:28:10: fatal error: 'ink_autoconf.h' file not found
#include "ink_autoconf.h"
         ^
1 error generated.
```

The shared_ptr.h requires a variable defined on ink_autoconf.h but it doesn't exist in destination directory. so I'll fix by installing it.
