### PR TITLE
docs: Add Doxygen group commands to API sections

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,9 @@
                                                          -*- coding: utf-8 -*-
 Changes with Apache Traffic Server 5.0.0
 
+  *) [TS-2803] Use documentation strings extracted from source files
+   in project documentation
+
   *) [TS-2797] Build all manual pages in the doc/reference/api directory
 
   *) [TS-2733] Do not build the old SPDY plugin.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -42,7 +42,17 @@ sys.path.insert(0, os.path.abspath('ext'))
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.graphviz', 'sphinx.ext.intersphinx', 'sphinx.ext.autodoc', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.pngmath', 'sphinx.ext.mathjax', 'sphinx.ext.viewcode', 'traffic-server' ]
+extensions = (
+  'doxygen',
+  'sphinx.ext.autodoc',
+  'sphinx.ext.coverage',
+  'sphinx.ext.graphviz',
+  'sphinx.ext.intersphinx',
+  'sphinx.ext.mathjax',
+  'sphinx.ext.pngmath',
+  'sphinx.ext.todo',
+  'sphinx.ext.viewcode',
+  'traffic-server')
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/ext/doxygen.py
+++ b/doc/ext/doxygen.py
@@ -1,0 +1,391 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to you under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+
+import codecs, os, re, subprocess
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.statemachine import ViewList
+from docutils.transforms import Transform
+from lxml import etree
+from os import path
+from sphinx.domains import Domain
+from sphinx.domains.c import CObject
+
+def lookup_group(cache, name):
+  """
+  Doxygen doesn't index group or section titles, so iterate over all
+  Doxygen files in search of a matching group.  This is slow, so try
+  to be clever about it.
+  """
+
+  # Start with files that have already been parsed.  Checking these
+  # should be less expensive than parsing new files, and there's a
+  # good chance that sections at least will belong to the same file as
+  # other sections or functions in which we're interested.
+  for doxygen in cache.itervalues():
+    try:
+      compounddef, = doxygen.xpath('(descendant::compounddef[title[text() = $name]] | descendant::sectiondef[header[text() = $name]])[1]', name=name)
+
+    except ValueError:
+      continue
+
+    return compounddef
+
+  # Iterate over the remaining files
+  for filename in os.listdir('source/doxygen_xml_api'):
+    if filename != 'index.xml' and filename not in cache:
+
+      # Check first if it contains the string we're after.  This
+      # should be less expensive than parsing every file.
+      if name in codecs.open('source/doxygen_xml_api/' + filename, encoding='utf-8').read():
+
+        doxygen = cache[filename] = etree.parse('source/doxygen_xml_api/' + filename)
+        try:
+          compounddef, = doxygen.xpath('(descendant::compounddef[title[text() = $name]] | descendant::sectiondef[header[text() = $name]])[1]', name=name)
+
+        except ValueError:
+          continue
+
+        return compounddef
+
+def markup_text(text):
+  """Add markup to text with the help of regular expressions."""
+
+  # Admonitions
+  text = re.compile('(?<=\.)\s+(important|note):', re.I).sub('\n\n.. \\1::\n\n   ', text)
+  text = re.compile('^(important|note):', re.I).sub('.. \\1::\n\n   ', text)
+
+  # Constants, functions, and types.  Markup function calls (non-empty
+  # argument lists) with the literal role, which Sphinx prescribes for
+  # code.
+  text = re.compile('\\b[A-Z]+(?:_[A-Z]+)+\\b').sub(':c:data:`\g<0>`', text)
+  text = re.compile('\\b[A-Z](?:[A-Z]+[a-z]+|[a-z]+[A-Z]+)[A-Za-z]*\\b(\(.*?\))?').sub(lambda m: ':c:func:`' + m.group(0) + '`' if m.group(1) == '()' else '``' + m.group(0) + '``' if m.group(1) else ':c:type:`' + m.group(0) + '`', text)
+
+  return text
+
+def markup_tree(paragraphs, text, elem):
+  """
+  Walk a Doxygen tree gathering text content along the way, similarly
+  to Element.itertext().  elem is the input and paragraphs and text
+  are state.  Complete, marked up paragraphs are appended to the
+  paragraphs list while text is the current incomplete paragraph (or
+  empty string).  The paragraphs list is mutable while text is a
+  string and therefore immutable.  Alternative implementations might
+  use a class or a closure to keep track of state, instead of
+  arguments and the return value.
+  """
+
+  # Add text content inside the element to the current incomplete
+  # paragraph
+  if elem.text:
+    text += elem.text
+
+  # Process child elements
+  for elem in elem:
+
+    # Split up paragraphs
+    if elem.tag == 'para':
+
+      # Markup the paragraph before the element
+      if text:
+        paragraphs.append(markup_text(text))
+
+      # Gather text content inside the element
+      text = markup_tree(paragraphs, '', elem)
+
+      # Markup any incomplete paragraph inside the element
+      if text:
+        paragraphs.append(markup_text(text))
+
+      # Gather text content after the element
+      text = elem.tail or ''
+
+    # Exclude parameter and return value descriptions
+    elif elem.tag == 'parameterlist' or elem.tag == 'simplesect' and elem.get('kind') == 'return':
+
+      # Gather text content after the element
+      if elem.tail:
+        text += elem.tail
+
+    # Markup code blocks as literal blocks, as prescribed by Sphinx
+    elif elem.tag == 'programlisting':
+
+      # Markup the paragraph before the element
+      if text:
+        paragraphs.append(markup_text(text))
+
+      # Gather text content inside the element
+      sub_paragraphs = []
+      text = markup_tree(sub_paragraphs, '', elem)
+
+      # Do *not* add markup inside a code block
+      if text:
+        sub_paragraphs.append(text)
+
+      # Indent paragraphs inside the element and append a literal
+      # block to our paragraphs list
+      paragraphs.append('::\n\n' + re.compile('^.', re.M).sub('   \g<0>', '\n\n'.join(sub_paragraphs)))
+
+      # Gather text content after the element
+      text = elem.tail or ''
+
+    # Markup notes
+    elif elem.tag == 'simplesect' and elem.get('kind') == 'note':
+
+      # Markup the paragraph before the element
+      if text:
+        paragraphs.append(markup_text(text))
+
+      # Gather text content inside the element
+      sub_paragraphs = []
+      text = markup_tree(sub_paragraphs, '', elem)
+
+      # Markup any incomplete paragraph inside the element
+      if text:
+        sub_paragraphs.append(markup_text(text))
+
+      # Indent paragraphs inside the element and append a note
+      # directive to our paragraphs list
+      paragraphs.append('.. note::\n\n' + re.compile('^.', re.M).sub('   \g<0>', '\n\n'.join(sub_paragraphs)))
+
+      # Gather text content after the element
+      text = elem.tail or ''
+
+    # Markup e.g. @deprecated with a generic admonition directive.
+    # The Sphinx deprecated directive demands a version number, but
+    # there's a precedent for a "Deprecated" generic admonition in the
+    # [reStructuredText reference].
+    #
+    #    [reStructuredText reference]
+    #                  http://docutils.sourceforge.net/docs/ref/rst/directives.txt
+    elif elem.tag == 'xrefsect':
+
+      # Markup the paragraph before the element
+      if text:
+        paragraphs.append(markup_text(text))
+
+      # Gather text content inside the xrefdescription child element
+      sub_paragraphs = []
+
+      xrefdescription, = elem.xpath('xrefdescription')
+      text = markup_tree(sub_paragraphs, '', xrefdescription)
+
+      # Markup any incomplete paragraph inside the xrefdescription
+      if text:
+        sub_paragraphs.append(markup_text(text))
+
+      # Indent paragraphs inside the xrefdescription and append a
+      # generic admonition directive to our paragraphs list
+      paragraphs.append('.. admonition:: ' + elem.xpath('string(xreftitle)') + '\n\n' + re.compile('^.', re.M).sub('   \g<0>', '\n\n'.join(sub_paragraphs)))
+
+      # Gather text content after the element
+      text = elem.tail or ''
+
+    # Add all other text content to the current incomplete paragraph
+    else:
+      text = markup_tree(paragraphs, text, elem)
+
+      # Add text content between child elements
+      if elem.tail:
+        text += elem.tail
+
+  return text
+
+class DoxygenDescription(Directive):
+  """
+  Directive to use descriptions extracted from source files.  Grab
+  documentation strings that have been extracted from source files by
+  Doxygen, translate them into reStructuredText, and then use them
+  inside Sphinx documents.
+  """
+
+  has_content = True
+
+  def run(self):
+    if not path.isfile('source/doxygen_xml_api/index.xml'):
+      return []
+
+    env = self.state.document.settings.env
+
+    # The construct whose documentation strings to grab.  It can be
+    # specified directly to this directive, e.g.
+    #
+    #    .. doxygen:description:: TSPluginRegistrationInfo
+    #
+    # or it can be inherited from a parent directive, e.g.
+    #
+    # .. doxygen:function:: TSPluginRegister
+    #
+    #    .. doxygen:description::
+    if self.content:
+      name, = self.content
+
+    else:
+      name = env.doxygen_name
+
+    # Lookup the construct in the Doxygen index or, failing that,
+    # iterate over all Doxygen files in search of a matching group
+    try:
+      compound, = env.doxygenindex.xpath('descendant::compound[descendant::name[text() = $name]][1]', name=name)
+
+    except ValueError:
+
+      memberdef = lookup_group(env.doxygen, name)
+      if memberdef is None:
+        return []
+
+    else:
+
+      filename = compound.get('refid') + '.xml'
+      if filename not in env.doxygen:
+        env.doxygen[filename] = etree.parse('source/doxygen_xml_api/' + filename)
+
+      memberdef, = env.doxygen[filename].xpath('descendant::compounddef[compoundname[text() = $name]] | descendant::memberdef[name[text() = $name]]', name=name)
+
+    # Grab the documentation strings and translate them into
+    # reStructuredText
+    paragraphs = []
+
+    directive = self.name.split(':', 1)[-1]
+    if directive == 'description':
+
+      # Doxygen sections have only a single description.  Otherwise
+      # concatenate the brief and detailed descriptions.
+      try:
+        description, = memberdef.xpath('description')
+
+      except ValueError:
+
+        briefdescription, = memberdef.xpath('briefdescription')
+        detaileddescription, = memberdef.xpath('detaileddescription')
+
+        text = markup_tree(paragraphs, markup_tree(paragraphs, '', briefdescription), detaileddescription)
+
+      else:
+        text = markup_tree(paragraphs, '', description)
+
+    else:
+
+      # Brief or detailed description.  Doxygen sections have only a
+      # single description.
+      elem, = memberdef.xpath(directive + ' | description')
+      text = markup_tree(paragraphs, '', elem)
+
+    if text:
+      paragraphs.append(markup_text(text))
+
+    block = ViewList('\n\n'.join(paragraphs).split('\n'))
+
+    node = self.state.parent
+    self.state.nested_parse(block, 0, node)
+
+    return []
+
+class DoxygenObject(CObject):
+  """
+  Directive to use objects' signatures, or a group of objects'
+  signatures, that have been extracted from source files by Doxygen.
+  """
+
+  def get_signatures(self):
+    if not path.isfile('source/doxygen_xml_api/index.xml'):
+      return
+
+    if self.objtype == 'group':
+
+      # DoxygenDescription can inherit the construct whose
+      # documentation strings to grab from this directive
+      self.env.doxygen_name, = name, = CObject.get_signatures(self)
+
+      # Lookup the group in the Doxygen index or, failing that,
+      # iterate over all Doxygen files in search of a matching group
+      try:
+        compound, = self.env.doxygenindex.xpath('descendant::compound[attribute::kind = "group" and descendant::name[text() = $name]][1]', name=name)
+
+      except ValueError:
+
+        compounddef = lookup_group(self.env.doxygen, name)
+        if compounddef is None:
+          return
+
+      else:
+
+        filename = compound.get('refid') + '.xml'
+        if filename in self.env.doxygen:
+          compounddef = self.env.doxygen[filename]
+
+        else:
+          compounddef = self.env.doxygen[filename] = etree.parse('source/doxygen_xml_api/' + filename)
+
+      # Return the signatures of the objects in the group
+      for memberdef in compounddef.xpath('descendant::memberdef'):
+        yield memberdef.xpath('concat(definition, argsstring)')
+
+    else:
+      for name in CObject.get_signatures(self):
+
+        # DoxygenDescription can inherit the construct whose
+        # documentation strings to grab from this directive, e.g.
+        #
+        # .. doxygen:function:: TSPluginRegister
+        #
+        #    .. doxygen:description::
+        self.env.doxygen_name = name
+
+        # Lookup the object in the Doxygen index.  (Don't iterate over
+        # all Doxygen files since this is definitely not a group.)
+        compound, = self.env.doxygenindex.xpath('descendant::compound[descendant::name[text() = $name]][1]', name=name)
+
+        filename = compound.get('refid') + '.xml'
+        if filename not in self.env.doxygen:
+          self.env.doxygen[filename] = etree.parse('source/doxygen_xml_api/' + filename)
+
+        memberdef, = self.env.doxygen[filename].xpath('descendant::compounddef[compoundname[text() = $name]] | descendant::memberdef[name[text() = $name]]', name=name)
+
+        # Return the signatures of the objects
+        yield memberdef.xpath('concat(definition, argsstring)')
+
+class DoxygenDomain(Domain):
+
+  directives = {
+    'briefdescription': DoxygenDescription,
+    'detaileddescription': DoxygenDescription,
+    'description': DoxygenDescription,
+    'group': DoxygenObject,
+    'function': DoxygenObject,
+    'macro': DoxygenObject,
+    'type': DoxygenObject }
+
+  name = 'doxygen'
+
+  def __init__(self, env):
+    Domain.__init__(self, env)
+
+    # Run Doxygen on Read the Docs to generate XML files
+    if os.environ.get('READTHEDOCS'):
+      subprocess.call('doxygen')
+
+    if not path.isfile('source/doxygen_xml_api/index.xml'):
+      return
+
+    # Doxygen files that have already been parsed
+    env.doxygen = {}
+
+    # Doxygen index
+    env.doxygenindex = etree.parse('source/doxygen_xml_api/index.xml')
+
+def setup(app):
+  app.add_domain(DoxygenDomain)

--- a/doc/reference/api/TSActionCancel.en.rst
+++ b/doc/reference/api/TSActionCancel.en.rst
@@ -18,13 +18,18 @@
 TSActionCancel
 ==============
 
+.. doxygen:briefdescription:: TSActionCancel
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSActionCancel(TSAction actionp)
+.. doxygen:function:: TSActionCancel
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSActionCancel

--- a/doc/reference/api/TSActionDone.en.rst
+++ b/doc/reference/api/TSActionDone.en.rst
@@ -18,13 +18,18 @@
 TSActionDone
 ============
 
+.. doxygen:briefdescription:: TSActionDone
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: int TSActionDone(TSAction actionp)
+.. doxygen:function:: TSActionDone
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSActionDone

--- a/doc/reference/api/TSCacheRead.en.rst
+++ b/doc/reference/api/TSCacheRead.en.rst
@@ -18,8 +18,7 @@
 TSCacheRead
 ===========
 
-Asks the Traffic Server cache if the object corresponding to key
-exists in the cache and can be read.
+.. doxygen:briefdescription:: TSCacheRead
 
 
 Synopsis
@@ -27,20 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSAction TSCacheRead(TSCont contp, TSCacheKey key)
+.. doxygen:function:: TSCacheRead
 
 
 Description
 -----------
 
-If the object can be read, the Traffic Server cache calls the
-continuation contp back with the event
-:c:data:`TS_EVENT_CACHE_OPEN_READ`.  In this case, the cache also
-passes contp a cache vconnection and contp can then initiate a read
-operation on that vconnection using :c:type:`TSVConnRead`.
-
-If the object cannot be read, the cache calls contp back with the
-event :c:data:`TS_EVENT_CACHE_OPEN_READ_FAILED`.  The user (contp) has
-the option to cancel the action returned by :c:type:`TSCacheRead`.
-Note that reentrant calls are possible, i.e. the cache can call back
-the user (contp) in the same call.
+.. doxygen:detaileddescription:: TSCacheRead

--- a/doc/reference/api/TSCacheRemove.en.rst
+++ b/doc/reference/api/TSCacheRemove.en.rst
@@ -18,7 +18,7 @@
 TSCacheRemove
 =============
 
-Removes the object corresponding to key from the cache.
+.. doxygen:briefdescription:: TSCacheRemove
 
 
 Synopsis
@@ -26,18 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSAction TSCacheRemove(TSCont contp, TSCacheKey key)
+.. doxygen:function:: TSCacheRemove
 
 
 Description
 -----------
 
-If the object was removed successfully, the cache calls contp back
-with the event :c:data:`TS_EVENT_CACHE_REMOVE`.  If the object was not
-found in the cache, the cache calls contp back with the event
-:c:data:`TS_EVENT_CACHE_REMOVE_FAILED`.
-
-In both of these callbacks, the user (contp) does not have to do
-anything.  The user does not get any vconnection from the cache, since
-no data needs to be transferred.  When the cache calls contp back with
-:c:data:`TS_EVENT_CACHE_REMOVE`, the remove has already been commited.
+.. doxygen:detaileddescription:: TSCacheRemove

--- a/doc/reference/api/TSCacheWrite.en.rst
+++ b/doc/reference/api/TSCacheWrite.en.rst
@@ -18,8 +18,7 @@
 TSCacheWrite
 ============
 
-Asks the Traffic Server cache if contp can start writing the object
-(corresponding to key) to the cache.
+.. doxygen:briefdescription:: TSCacheWrite
 
 
 Synopsis
@@ -27,26 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSAction TSCacheWrite(TSCont contp, TSCacheKey key)
+.. doxygen:function:: TSCacheWrite
 
 
 Description
 -----------
 
-If the object can be written, the cache calls contp back with the
-event :c:data:`TS_EVENT_CACHE_OPEN_WRITE`.  In this case, the cache
-also passes contp a cache vconnection and contp can then initiate a
-write operation on that vconnection using :c:type:`TSVConnWrite`.  The
-object is not committed to the cache until the vconnection is closed.
-When all data has been transferred, the user (contp) must do an
-:c:type:`TSVConnClose`.  In case of any errors, the user MUST do an
-``TSVConnAbort(contp, 0)``.
-
-If the object cannot be written, the cache calls contp back with the
-event :c:data:`TS_EVENT_CACHE_OPEN_WRITE_FAILED`.  This can happen,
-for example, if there is another object with the same key being
-written to the cache.  The user (contp) has the option to cancel the
-action returned by :c:type:`TSCacheWrite`.
-
-Note that reentrant calls are possible, i.e. the cache can call back
-the user (contp) in the same call.
+.. doxygen:detaileddescription:: TSCacheWrite

--- a/doc/reference/api/TSConfigDataGet.en.rst
+++ b/doc/reference/api/TSConfigDataGet.en.rst
@@ -18,13 +18,18 @@
 TSConfigDataGet
 ===============
 
+.. doxygen:briefdescription:: TSConfigDataGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: void* TSConfigDataGet(TSConfig configp)
+.. doxygen:function:: TSConfigDataGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSConfigDataGet

--- a/doc/reference/api/TSConfigGet.en.rst
+++ b/doc/reference/api/TSConfigGet.en.rst
@@ -18,13 +18,18 @@
 TSConfigGet
 ===========
 
+.. doxygen:briefdescription:: TSConfigGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSConfig TSConfigGet(unsigned int id)
+.. doxygen:function:: TSConfigGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSConfigGet

--- a/doc/reference/api/TSConfigRelease.en.rst
+++ b/doc/reference/api/TSConfigRelease.en.rst
@@ -18,13 +18,18 @@
 TSConfigRelease
 ===============
 
+.. doxygen:briefdescription:: TSConfigRelease
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSConfigRelease(unsigned int id, TSConfig configp)
+.. doxygen:function:: TSConfigRelease
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSConfigRelease

--- a/doc/reference/api/TSConfigSet.en.rst
+++ b/doc/reference/api/TSConfigSet.en.rst
@@ -18,13 +18,18 @@
 TSConfigSet
 ===========
 
+.. doxygen:briefdescription:: TSConfigSet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: unsigned int TSConfigSet(unsigned int id, void *data, TSConfigDestroyFunc funcp)
+.. doxygen:function:: TSConfigSet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSConfigSet

--- a/doc/reference/api/TSContCall.en.rst
+++ b/doc/reference/api/TSContCall.en.rst
@@ -18,13 +18,18 @@
 TSContCall
 ==========
 
+.. doxygen:briefdescription:: TSContCall
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: int TSContCall(TSCont contp, TSEvent event, void *edata)
+.. doxygen:function:: TSContCall
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSContCall

--- a/doc/reference/api/TSContCreate.en.rst
+++ b/doc/reference/api/TSContCreate.en.rst
@@ -18,13 +18,18 @@
 TSContCreate
 ============
 
+.. doxygen:briefdescription:: TSContCreate
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSCont TSContCreate(TSEventFunc funcp, TSMutex mutexp)
+.. doxygen:function:: TSContCreate
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSContCreate

--- a/doc/reference/api/TSContDataGet.en.rst
+++ b/doc/reference/api/TSContDataGet.en.rst
@@ -18,13 +18,18 @@
 TSContDataGet
 =============
 
+.. doxygen:briefdescription:: TSContDataGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: void* TSContDataGet(TSCont contp)
+.. doxygen:function:: TSContDataGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSContDataGet

--- a/doc/reference/api/TSContDataSet.en.rst
+++ b/doc/reference/api/TSContDataSet.en.rst
@@ -18,13 +18,18 @@
 TSContDataSet
 =============
 
+.. doxygen:briefdescription:: TSContDataSet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSContDataSet(TSCont contp, void *data)
+.. doxygen:function:: TSContDataSet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSContDataSet

--- a/doc/reference/api/TSContDestroy.en.rst
+++ b/doc/reference/api/TSContDestroy.en.rst
@@ -18,13 +18,18 @@
 TSContDestroy
 =============
 
+.. doxygen:briefdescription:: TSContDestroy
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSContDestroy(TSCont contp)
+.. doxygen:function:: TSContDestroy
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSContDestroy

--- a/doc/reference/api/TSContMutexGet.en.rst
+++ b/doc/reference/api/TSContMutexGet.en.rst
@@ -18,13 +18,18 @@
 TSContMutexGet
 ==============
 
+.. doxygen:briefdescription:: TSContMutexGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSMutex TSContMutexGet(TSCont contp)
+.. doxygen:function:: TSContMutexGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSContMutexGet

--- a/doc/reference/api/TSContSchedule.en.rst
+++ b/doc/reference/api/TSContSchedule.en.rst
@@ -18,13 +18,18 @@
 TSContSchedule
 ==============
 
+.. doxygen:briefdescription:: TSContSchedule
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSAction TSContSchedule(TSCont contp, ink_hrtime timeout, TSThreadPool tp)
+.. doxygen:function:: TSContSchedule
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSContSchedule

--- a/doc/reference/api/TSDebug.en.rst
+++ b/doc/reference/api/TSDebug.en.rst
@@ -26,19 +26,19 @@ Synopsis
 ========
 `#include <ts/ts.h>`
 
-.. function:: void TSDebug(const char * tag, const char * format, ...)
-.. function:: void TSError(const char * tag, const char * format, ...)
-.. function:: int TSIsDebugTagSet(const char * tag)
-.. function:: void TSDebugSpecific(int debug_flag, const char * tag, const char * format, ...)
-.. function:: void TSHttpTxnDebugSet(TSHttpTxn txnp, int on)
-.. function:: void TSHttpSsnDebugSet(TSHttpSsn ssn, int on)
-.. function:: int TSHttpTxnDebugGet(TSHttpTxn txnp)
-.. function:: int TSHttpSsnDebugGet(TSHttpSsn ssn)
-.. function:: const char* TSHttpServerStateNameLookup(TSServerState state)
-.. function:: const char* TSHttpHookNameLookup(TSHttpHookID hook)
-.. function:: const char* TSHttpEventNameLookup(TSEvent event)
-.. macro:: void TSAssert(expression)
-.. macro:: void TSReleaseAssert(expression)
+.. doxygen:function:: TSDebug
+.. doxygen:function:: TSError
+.. doxygen:function:: TSIsDebugTagSet
+.. doxygen:function:: TSDebugSpecific
+.. doxygen:function:: TSHttpTxnDebugSet
+.. doxygen:function:: TSHttpSsnDebugSet
+.. doxygen:function:: TSHttpTxnDebugGet
+.. doxygen:function:: TSHttpSsnDebugGet
+.. doxygen:function:: TSHttpServerStateNameLookup
+.. doxygen:function:: TSHttpHookNameLookup
+.. doxygen:function:: TSHttpEventNameLookup
+.. doxygen:macro:: TSAssert
+.. doxygen:macro:: TSReleaseAssert
 
 Description
 ===========

--- a/doc/reference/api/TSHostLookup.en.rst
+++ b/doc/reference/api/TSHostLookup.en.rst
@@ -18,13 +18,18 @@
 TSHostLookup
 ============
 
+.. doxygen:briefdescription:: TSHostLookup
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSAction TSHostLookup(TSCont contp, const char *hostname, size_t namelen)
+.. doxygen:function:: TSHostLookup
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHostLookup

--- a/doc/reference/api/TSHostLookupResultAddrGet.en.rst
+++ b/doc/reference/api/TSHostLookupResultAddrGet.en.rst
@@ -18,13 +18,18 @@
 TSHostLookupResultAddrGet
 =========================
 
+.. doxygen:briefdescription:: TSHostLookupResultAddrGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: sockaddr const* TSHostLookupResultAddrGet(TSHostLookupResult lookup_result)
+.. doxygen:function:: TSHostLookupResultAddrGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHostLookupResultAddrGet

--- a/doc/reference/api/TSHttpConnect.en.rst
+++ b/doc/reference/api/TSHttpConnect.en.rst
@@ -18,7 +18,7 @@
 TSHttpConnect
 =============
 
-Allows the plugin to initiate an http connection.
+.. doxygen:briefdescription:: TSHttpConnect
 
 
 Synopsis
@@ -26,17 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSVConn TSHttpConnect(sockaddr const *addr)
+.. doxygen:function:: TSHttpConnect
 
 
 Description
 -----------
 
-The :c:type:`TSVConn` the plugin receives as the result of successful
-operates identically to one created through :c:type:`TSNetConnect`.
-Aside from allowing the plugin to set the client ip and port for
-logging, the functionality of :c:func:`TSHttpConnect` is identical to
-connecting to localhost on the proxy port with :c:func:`TSNetConnect`.
-:c:func:`TSHttpConnect` is more efficient than :c:func:`TSNetConnect`
-to localhost since it avoids the overhead of passing the data through
-the operating system.
+.. doxygen:detaileddescription:: TSHttpConnect

--- a/doc/reference/api/TSHttpHdrClone.en.rst
+++ b/doc/reference/api/TSHttpHdrClone.en.rst
@@ -18,13 +18,18 @@
 TSHttpHdrClone
 ==============
 
+.. doxygen:briefdescription:: TSHttpHdrClone
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSHttpHdrClone(TSMBuffer dest_bufp, TSMBuffer src_bufp, TSMLoc src_hdr, TSMLoc *locp)
+.. doxygen:function:: TSHttpHdrClone
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpHdrClone

--- a/doc/reference/api/TSHttpHdrCopy.en.rst
+++ b/doc/reference/api/TSHttpHdrCopy.en.rst
@@ -18,8 +18,7 @@
 TSHttpHdrCopy
 =============
 
-Copies the contents of the HTTP header located at src_loc within
-src_bufp to the HTTP header located at dest_loc within dest_bufp.
+.. doxygen:briefdescription:: TSHttpHdrCopy
 
 
 Synopsis
@@ -27,19 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSHttpHdrCopy(TSMBuffer dest_bufp, TSMLoc dest_offset, TSMBuffer src_bufp, TSMLoc src_offset)
+.. doxygen:function:: TSHttpHdrCopy
 
 
 Description
 -----------
 
-:c:func:`TSHttpHdrCopy` works correctly even if src_bufp and dest_bufp
-point to different marshal buffers.  Make sure that you create the
-destination HTTP header before copying into it.
-
-.. note::
-
-   :c:func:`TSHttpHdrCopy` appends the port number to the domain of
-   the URL portion of the header.  For example, a copy of
-   http://www.example.com appears as http://www.example.com:80 in the
-   destination buffer.
+.. doxygen:detaileddescription:: TSHttpHdrCopy

--- a/doc/reference/api/TSHttpHdrCreate.en.rst
+++ b/doc/reference/api/TSHttpHdrCreate.en.rst
@@ -18,13 +18,18 @@
 TSHttpHdrCreate
 ===============
 
+.. doxygen:briefdescription:: TSHttpHdrCreate
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSMLoc TSHttpHdrCreate(TSMBuffer bufp)
+.. doxygen:function:: TSHttpHdrCreate
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpHdrCreate

--- a/doc/reference/api/TSHttpHdrDestroy.en.rst
+++ b/doc/reference/api/TSHttpHdrDestroy.en.rst
@@ -18,8 +18,7 @@
 TSHttpHdrDestroy
 ================
 
-Destroys the HTTP header located at hdr_loc within the marshal buffer
-bufp.
+.. doxygen:briefdescription:: TSHttpHdrDestroy
 
 
 Synopsis
@@ -27,11 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSHttpHdrDestroy(TSMBuffer bufp, TSMLoc offset)
+.. doxygen:function:: TSHttpHdrDestroy
 
 
 Description
 -----------
 
-Do not forget to release the handle hdr_loc with a call to
-:c:func:`TSHandleMLocRelease`.
+.. doxygen:detaileddescription:: TSHttpHdrDestroy

--- a/doc/reference/api/TSHttpHdrLengthGet.en.rst
+++ b/doc/reference/api/TSHttpHdrLengthGet.en.rst
@@ -18,13 +18,18 @@
 TSHttpHdrLengthGet
 ==================
 
+.. doxygen:briefdescription:: TSHttpHdrLengthGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: int TSHttpHdrLengthGet(TSMBuffer bufp, TSMLoc offset)
+.. doxygen:function:: TSHttpHdrLengthGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpHdrLengthGet

--- a/doc/reference/api/TSHttpHdrMethodGet.en.rst
+++ b/doc/reference/api/TSHttpHdrMethodGet.en.rst
@@ -18,13 +18,18 @@
 TSHttpHdrMethodGet
 ==================
 
+.. doxygen:briefdescription:: TSHttpHdrMethodGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: const char* TSHttpHdrMethodGet(TSMBuffer bufp, TSMLoc offset, int *length)
+.. doxygen:function:: TSHttpHdrMethodGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpHdrMethodGet

--- a/doc/reference/api/TSHttpHdrMethodSet.en.rst
+++ b/doc/reference/api/TSHttpHdrMethodSet.en.rst
@@ -18,13 +18,18 @@
 TSHttpHdrMethodSet
 ==================
 
+.. doxygen:briefdescription:: TSHttpHdrMethodSet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSHttpHdrMethodSet(TSMBuffer bufp, TSMLoc offset, const char *value, int length)
+.. doxygen:function:: TSHttpHdrMethodSet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpHdrMethodSet

--- a/doc/reference/api/TSHttpHdrPrint.en.rst
+++ b/doc/reference/api/TSHttpHdrPrint.en.rst
@@ -18,13 +18,18 @@
 TSHttpHdrPrint
 ==============
 
+.. doxygen:briefdescription:: TSHttpHdrPrint
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSHttpHdrPrint(TSMBuffer bufp, TSMLoc offset, TSIOBuffer iobufp)
+.. doxygen:function:: TSHttpHdrPrint
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpHdrPrint

--- a/doc/reference/api/TSHttpHdrReasonGet.en.rst
+++ b/doc/reference/api/TSHttpHdrReasonGet.en.rst
@@ -18,13 +18,18 @@
 TSHttpHdrReasonGet
 ==================
 
+.. doxygen:briefdescription:: TSHttpHdrReasonGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: const char* TSHttpHdrReasonGet(TSMBuffer bufp, TSMLoc offset, int *length)
+.. doxygen:function:: TSHttpHdrReasonGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpHdrReasonGet

--- a/doc/reference/api/TSHttpHdrReasonLookup.en.rst
+++ b/doc/reference/api/TSHttpHdrReasonLookup.en.rst
@@ -18,13 +18,18 @@
 TSHttpHdrReasonLookup
 =====================
 
+.. doxygen:briefdescription:: TSHttpHdrReasonLookup
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: const char* TSHttpHdrReasonLookup(TSHttpStatus status)
+.. doxygen:function:: TSHttpHdrReasonLookup
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpHdrReasonLookup

--- a/doc/reference/api/TSHttpHdrReasonSet.en.rst
+++ b/doc/reference/api/TSHttpHdrReasonSet.en.rst
@@ -18,13 +18,18 @@
 TSHttpHdrReasonSet
 ==================
 
+.. doxygen:briefdescription:: TSHttpHdrReasonSet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSHttpHdrReasonSet(TSMBuffer bufp, TSMLoc offset, const char *value, int length)
+.. doxygen:function:: TSHttpHdrReasonSet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpHdrReasonSet

--- a/doc/reference/api/TSHttpHdrStatusGet.en.rst
+++ b/doc/reference/api/TSHttpHdrStatusGet.en.rst
@@ -18,13 +18,18 @@
 TSHttpHdrStatusGet
 ==================
 
+.. doxygen:briefdescription:: TSHttpHdrStatusGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSHttpStatus TSHttpHdrStatusGet(TSMBuffer bufp, TSMLoc offset)
+.. doxygen:function:: TSHttpHdrStatusGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpHdrStatusGet

--- a/doc/reference/api/TSHttpHdrStatusSet.en.rst
+++ b/doc/reference/api/TSHttpHdrStatusSet.en.rst
@@ -18,13 +18,18 @@
 TSHttpHdrStatusSet
 ==================
 
+.. doxygen:briefdescription:: TSHttpHdrStatusSet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSHttpHdrStatusSet(TSMBuffer bufp, TSMLoc offset, TSHttpStatus status)
+.. doxygen:function:: TSHttpHdrStatusSet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpHdrStatusSet

--- a/doc/reference/api/TSHttpHdrTypeGet.en.rst
+++ b/doc/reference/api/TSHttpHdrTypeGet.en.rst
@@ -18,13 +18,18 @@
 TSHttpHdrTypeGet
 ================
 
+.. doxygen:briefdescription:: TSHttpHdrTypeGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSHttpType TSHttpHdrTypeGet(TSMBuffer bufp, TSMLoc offset)
+.. doxygen:function:: TSHttpHdrTypeGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpHdrTypeGet

--- a/doc/reference/api/TSHttpHdrTypeSet.en.rst
+++ b/doc/reference/api/TSHttpHdrTypeSet.en.rst
@@ -18,13 +18,18 @@
 TSHttpHdrTypeSet
 ================
 
+.. doxygen:briefdescription:: TSHttpHdrTypeSet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSHttpHdrTypeSet(TSMBuffer bufp, TSMLoc offset, TSHttpType type)
+.. doxygen:function:: TSHttpHdrTypeSet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpHdrTypeSet

--- a/doc/reference/api/TSHttpHdrUrlGet.en.rst
+++ b/doc/reference/api/TSHttpHdrUrlGet.en.rst
@@ -18,13 +18,18 @@
 TSHttpHdrUrlGet
 ===============
 
+.. doxygen:briefdescription:: TSHttpHdrUrlGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSHttpHdrUrlGet(TSMBuffer bufp, TSMLoc offset, TSMLoc *locp)
+.. doxygen:function:: TSHttpHdrUrlGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpHdrUrlGet

--- a/doc/reference/api/TSHttpHdrUrlSet.en.rst
+++ b/doc/reference/api/TSHttpHdrUrlSet.en.rst
@@ -18,13 +18,18 @@
 TSHttpHdrUrlSet
 ===============
 
+.. doxygen:briefdescription:: TSHttpHdrUrlSet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSHttpHdrUrlSet(TSMBuffer bufp, TSMLoc offset, TSMLoc url)
+.. doxygen:function:: TSHttpHdrUrlSet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpHdrUrlSet

--- a/doc/reference/api/TSHttpHdrVersionGet.en.rst
+++ b/doc/reference/api/TSHttpHdrVersionGet.en.rst
@@ -18,13 +18,18 @@
 TSHttpHdrVersionGet
 ===================
 
+.. doxygen:briefdescription:: TSHttpHdrVersionGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: int TSHttpHdrVersionGet(TSMBuffer bufp, TSMLoc offset)
+.. doxygen:function:: TSHttpHdrVersionGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpHdrVersionGet

--- a/doc/reference/api/TSHttpHdrVersionSet.en.rst
+++ b/doc/reference/api/TSHttpHdrVersionSet.en.rst
@@ -18,13 +18,18 @@
 TSHttpHdrVersionSet
 ===================
 
+.. doxygen:briefdescription:: TSHttpHdrVersionSet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSHttpHdrVersionSet(TSMBuffer bufp, TSMLoc offset, int ver)
+.. doxygen:function:: TSHttpHdrVersionSet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpHdrVersionSet

--- a/doc/reference/api/TSHttpHookAdd.en.rst
+++ b/doc/reference/api/TSHttpHookAdd.en.rst
@@ -27,9 +27,9 @@ Synopsis
 ========
 `#include <ts/ts.h>`
 
-.. function:: void TSHttpHookAdd(TSHttpHookID id, TSCont contp)
-.. function:: void TSHttpSsnHookAdd(TSHttpSsn ssnp, TSHttpHookID id, TSCont contp)
-.. function:: void TSHttpTxnHookAdd(TSHttpTxn txnp, TSHttpHookID id, TSCont contp)
+.. doxygen:function:: TSHttpHookAdd
+.. doxygen:function:: TSHttpSsnHookAdd
+.. doxygen:function:: TSHttpTxnHookAdd
 
 Description
 ===========

--- a/doc/reference/api/TSHttpOverridableConfig.en.rst
+++ b/doc/reference/api/TSHttpOverridableConfig.en.rst
@@ -27,15 +27,15 @@ Synopsis
 ========
 `#include <ts/ts.h>`
 
-.. type:: TSOverridableConfigKey
+.. doxygen:type:: TSOverridableConfigKey
 
-.. function:: TSReturnCode TSHttpTxnConfigIntSet(TSHttpTxn txnp, TSOverridableConfigKey key, TSMgmtInt value)
-.. function:: TSReturnCode TSHttpTxnConfigIntGet(TSHttpTxn txnp, TSOverridableConfigKey key, TSMgmtInt* value)
-.. function:: TSReturnCode TSHttpTxnConfigFloatSet(TSHttpTxn txnp, TSOverridableConfigKey key, TSMgmtFloat value)
-.. function:: TSReturnCode TSHttpTxnConfigFloatGet(TSHttpTxn txnp, TSOverridableConfigKey key, TSMgmtFloat* value)
-.. function:: TSReturnCode TSHttpTxnConfigStringSet(TSHttpTxn txnp, TSOverridableConfigKey key, const char* value, int length)
-.. function:: TSReturnCode TSHttpTxnConfigStringGet(TSHttpTxn txnp, TSOverridableConfigKey key, const char** value, int* length)
-.. function:: TSReturnCode TSHttpTxnConfigFind(const char* name, int length, TSOverridableConfigKey* key, TSRecordDataType* type)
+.. doxygen:function:: TSHttpTxnConfigIntSet
+.. doxygen:function:: TSHttpTxnConfigIntGet
+.. doxygen:function:: TSHttpTxnConfigFloatSet
+.. doxygen:function:: TSHttpTxnConfigFloatGet
+.. doxygen:function:: TSHttpTxnConfigStringSet
+.. doxygen:function:: TSHttpTxnConfigStringGet
+.. doxygen:function:: TSHttpTxnConfigFind
 
 Description
 ===========

--- a/doc/reference/api/TSHttpParserCreate.en.rst
+++ b/doc/reference/api/TSHttpParserCreate.en.rst
@@ -28,11 +28,11 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. function:: TSHttpParser TSHttpParserCreate(void)
-.. function:: void TSHttpParserClear(TSHttpParser parser)
-.. function:: void TSHttpParserDestroy(TSHttpParser parser)
-.. function:: TSParseResult TSHttpHdrParseReq(TSHttpParser parser, TSMBuffer bufp, TSMLoc offset, const char ** start, const char * end)
-.. function:: TSParseResult TSHttpHdrParseResp(TSHttpParser parser, TSMBuffer bufp, TSMLoc offset, const char ** start, const char * end)
+.. doxygen:function:: TSHttpParserCreate
+.. doxygen:function:: TSHttpParserClear
+.. doxygen:function:: TSHttpParserDestroy
+.. doxygen:function:: TSHttpHdrParseReq
+.. doxygen:function:: TSHttpHdrParseResp
 
 Description
 ===========

--- a/doc/reference/api/TSHttpSsnReenable.en.rst
+++ b/doc/reference/api/TSHttpSsnReenable.en.rst
@@ -18,13 +18,18 @@
 TSHttpSsnReenable
 =================
 
+.. doxygen:briefdescription:: TSHttpSsnReenable
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSHttpSsnReenable(TSHttpSsn ssnp, TSEvent event)
+.. doxygen:function:: TSHttpSsnReenable
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpSsnReenable

--- a/doc/reference/api/TSHttpTxnCacheLookupStatusGet.en.rst
+++ b/doc/reference/api/TSHttpTxnCacheLookupStatusGet.en.rst
@@ -18,13 +18,18 @@
 TSHttpTxnCacheLookupStatusGet
 =============================
 
+.. doxygen:briefdescription:: TSHttpTxnCacheLookupStatusGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSHttpTxnCacheLookupStatusGet(TSHttpTxn txnp, int *lookup_status)
+.. doxygen:function:: TSHttpTxnCacheLookupStatusGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpTxnCacheLookupStatusGet

--- a/doc/reference/api/TSHttpTxnCacheLookupUrlGet.en.rst
+++ b/doc/reference/api/TSHttpTxnCacheLookupUrlGet.en.rst
@@ -18,13 +18,18 @@
 TSHttpTxnCacheLookupUrlGet
 ==========================
 
+.. doxygen:briefdescription:: TSHttpTxnCacheLookupUrlGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSHttpTxnCacheLookupUrlGet(TSHttpTxn txnp, TSMBuffer bufp, TSMLoc offset)
+.. doxygen:function:: TSHttpTxnCacheLookupUrlGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpTxnCacheLookupUrlGet

--- a/doc/reference/api/TSHttpTxnCachedReqGet.en.rst
+++ b/doc/reference/api/TSHttpTxnCachedReqGet.en.rst
@@ -18,13 +18,18 @@
 TSHttpTxnCachedReqGet
 =====================
 
+.. doxygen:briefdescription:: TSHttpTxnCachedReqGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSHttpTxnCachedReqGet(TSHttpTxn txnp, TSMBuffer *bufp, TSMLoc *offset)
+.. doxygen:function:: TSHttpTxnCachedReqGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpTxnCachedReqGet

--- a/doc/reference/api/TSHttpTxnCachedRespGet.en.rst
+++ b/doc/reference/api/TSHttpTxnCachedRespGet.en.rst
@@ -18,13 +18,18 @@
 TSHttpTxnCachedRespGet
 ======================
 
+.. doxygen:briefdescription:: TSHttpTxnCachedRespGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSHttpTxnCachedRespGet(TSHttpTxn txnp, TSMBuffer *bufp, TSMLoc *offset)
+.. doxygen:function:: TSHttpTxnCachedRespGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpTxnCachedRespGet

--- a/doc/reference/api/TSHttpTxnClientReqGet.en.rst
+++ b/doc/reference/api/TSHttpTxnClientReqGet.en.rst
@@ -18,13 +18,18 @@
 TSHttpTxnClientReqGet
 =====================
 
+.. doxygen:briefdescription:: TSHttpTxnClientReqGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSHttpTxnClientReqGet(TSHttpTxn txnp, TSMBuffer *bufp, TSMLoc *offset)
+.. doxygen:function:: TSHttpTxnClientReqGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpTxnClientReqGet

--- a/doc/reference/api/TSHttpTxnClientRespGet.en.rst
+++ b/doc/reference/api/TSHttpTxnClientRespGet.en.rst
@@ -18,13 +18,18 @@
 TSHttpTxnClientRespGet
 ======================
 
+.. doxygen:briefdescription:: TSHttpTxnClientRespGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSHttpTxnClientRespGet(TSHttpTxn txnp, TSMBuffer *bufp, TSMLoc *offset)
+.. doxygen:function:: TSHttpTxnClientRespGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpTxnClientRespGet

--- a/doc/reference/api/TSHttpTxnErrorBodySet.en.rst
+++ b/doc/reference/api/TSHttpTxnErrorBodySet.en.rst
@@ -18,7 +18,7 @@
 TSHttpTxnErrorBodySet
 =====================
 
-Sets an error type body to a transaction.
+.. doxygen:briefdescription:: TSHttpTxnErrorBodySet
 
 
 Synopsis
@@ -26,14 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSHttpTxnErrorBodySet(TSHttpTxn txnp, char *buf, size_t buflength, char *mimetype)
+.. doxygen:function:: TSHttpTxnErrorBodySet
 
 
 Description
 -----------
 
-Note that both string arguments must be allocated with
-:c:func:`TSmalloc` or :c:func:`TSstrdup`.  The mimetype argument is
-optional, if not provided it defaults to "text/html".  Sending an
-emptry string would prevent setting a content type header
-(but that is not adviced).
+.. doxygen:detaileddescription:: TSHttpTxnErrorBodySet

--- a/doc/reference/api/TSHttpTxnIntercept.en.rst
+++ b/doc/reference/api/TSHttpTxnIntercept.en.rst
@@ -18,8 +18,7 @@
 TSHttpTxnIntercept
 ==================
 
-Allows a plugin take over the servicing of the request as though it
-was the origin server.
+.. doxygen:briefdescription:: TSHttpTxnIntercept
 
 
 Synopsis
@@ -27,24 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSHttpTxnIntercept(TSCont contp, TSHttpTxn txnp)
+.. doxygen:function:: TSHttpTxnIntercept
 
 
 Description
 -----------
 
-contp will be sent :c:data:`TS_EVENT_NET_ACCEPT`.  The edata passed
-with :c:data:`TS_NET_EVENT_ACCEPT` is an :c:type:`TSVConn` just as it
-would be for a normal accept.  The plugin must act as if it is an http
-server and read the http request and body off the :c:type:`TSVConn`
-and send an http response header and body.
-
-:c:func:`TSHttpTxnIntercept` must be called be called from only
-:c:data:`TS_HTTP_READ_REQUEST_HOOK`.  Using
-:c:type:`TSHttpTxnIntercept` will bypass the Traffic Server cache.  If
-response sent by the plugin should be cached, use
-:c:func:`TSHttpTxnServerIntercept` instead.
-:c:func:`TSHttpTxnIntercept` primary use is allow plugins to serve
-data about their functioning directly.
-
-:c:func:`TSHttpTxnIntercept` must only be called once per transaction.
+.. doxygen:detaileddescription:: TSHttpTxnIntercept

--- a/doc/reference/api/TSHttpTxnMilestoneGet.en.rst
+++ b/doc/reference/api/TSHttpTxnMilestoneGet.en.rst
@@ -28,7 +28,7 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. function:: TSReturnCode TSHttpTxnMilestoneGet(TSHttpTxn txnp, TSMilestonesType milestone, TSHRTime* time)
+.. doxygen:function:: TSHttpTxnMilestoneGet
 
 Description
 ===========
@@ -37,7 +37,7 @@ Description
 calculated during the lifetime of a transaction and are measured in nanoseconds from the beginning of the transaction.
 :arg:`time` is used a pointer to storage to update if the call is successful.
 
-.. type:: TSMilestonesType
+.. doxygen:type:: TSMilestonesType
 
 =============================================== ==========
 Value                                           Milestone

--- a/doc/reference/api/TSHttpTxnNextHopAddrGet.en.rst
+++ b/doc/reference/api/TSHttpTxnNextHopAddrGet.en.rst
@@ -18,7 +18,7 @@
 TSHttpTxnNextHopAddrGet
 =======================
 
-Get the next hop address.
+.. doxygen:briefdescription:: TSHttpTxnNextHopAddrGet
 
 
 Synopsis
@@ -26,14 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: sockaddr const* TSHttpTxnNextHopAddrGet(TSHttpTxn txnp)
+.. doxygen:function:: TSHttpTxnNextHopAddrGet
 
 
 Description
 -----------
 
-.. note::
-
-   The pointer is valid only for the current callback.  Clients that
-   need to keep the value across callbacks must maintain their own
-   storage.
+.. doxygen:detaileddescription:: TSHttpTxnNextHopAddrGet

--- a/doc/reference/api/TSHttpTxnParentProxySet.en.rst
+++ b/doc/reference/api/TSHttpTxnParentProxySet.en.rst
@@ -18,7 +18,7 @@
 TSHttpTxnParentProxySet
 =======================
 
-Sets the parent proxy name and port.
+.. doxygen:briefdescription:: TSHttpTxnParentProxySet
 
 
 Synopsis
@@ -26,12 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSHttpTxnParentProxySet(TSHttpTxn txnp, char *hostname, int port)
+.. doxygen:function:: TSHttpTxnParentProxySet
 
 
 Description
 -----------
 
-The string hostname is copied into the :c:type:`TSHttpTxn`; you can
-modify or delete the string after calling
-:c:func:`TSHttpTxnParentProxySet`.
+.. doxygen:detaileddescription:: TSHttpTxnParentProxySet

--- a/doc/reference/api/TSHttpTxnReenable.en.rst
+++ b/doc/reference/api/TSHttpTxnReenable.en.rst
@@ -18,8 +18,7 @@
 TSHttpTxnReenable
 =================
 
-Notifies the HTTP transaction txnp that the plugin is finished
-processing the current hook.
+.. doxygen:briefdescription:: TSHttpTxnReenable
 
 
 Synopsis
@@ -27,16 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSHttpTxnReenable(TSHttpTxn txnp, TSEvent event)
+.. doxygen:function:: TSHttpTxnReenable
 
 
 Description
 -----------
 
-The plugin tells the transaction to either continue
-(:c:data:`TS_EVENT_HTTP_CONTINUE`) or stop
-(:c:data:`TS_EVENT_HTTP_ERROR`).
-
-You must always reenable the HTTP transaction after the processing of
-each transaction event.  However, never reenable twice.  Reenabling
-twice is a serious error.
+.. doxygen:detaileddescription:: TSHttpTxnReenable

--- a/doc/reference/api/TSHttpTxnServerAddrGet.en.rst
+++ b/doc/reference/api/TSHttpTxnServerAddrGet.en.rst
@@ -18,7 +18,7 @@
 TSHttpTxnServerAddrGet
 ======================
 
-Get the origin server address.
+.. doxygen:briefdescription:: TSHttpTxnServerAddrGet
 
 
 Synopsis
@@ -26,14 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: sockaddr const* TSHttpTxnServerAddrGet(TSHttpTxn txnp)
+.. doxygen:function:: TSHttpTxnServerAddrGet
 
 
 Description
 -----------
 
-.. note::
-
-   The pointer is valid only for the current callback.  Clients that
-   need to keep the value across callbacks must maintain their own
-   storage.
+.. doxygen:detaileddescription:: TSHttpTxnServerAddrGet

--- a/doc/reference/api/TSHttpTxnServerIntercept.en.rst
+++ b/doc/reference/api/TSHttpTxnServerIntercept.en.rst
@@ -28,7 +28,7 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. function:: void TSHttpTxnServerIntercept(TSCont contp, TSHttpTxn txnp)
+.. doxygen:function:: TSHttpTxnServerIntercept
 
 Description
 ===========

--- a/doc/reference/api/TSHttpTxnServerReqGet.en.rst
+++ b/doc/reference/api/TSHttpTxnServerReqGet.en.rst
@@ -18,13 +18,18 @@
 TSHttpTxnServerReqGet
 =====================
 
+.. doxygen:briefdescription:: TSHttpTxnServerReqGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSHttpTxnServerReqGet(TSHttpTxn txnp, TSMBuffer *bufp, TSMLoc *offset)
+.. doxygen:function:: TSHttpTxnServerReqGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpTxnServerReqGet

--- a/doc/reference/api/TSHttpTxnServerRespGet.en.rst
+++ b/doc/reference/api/TSHttpTxnServerRespGet.en.rst
@@ -18,13 +18,18 @@
 TSHttpTxnServerRespGet
 ======================
 
+.. doxygen:briefdescription:: TSHttpTxnServerRespGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSHttpTxnServerRespGet(TSHttpTxn txnp, TSMBuffer *bufp, TSMLoc *offset)
+.. doxygen:function:: TSHttpTxnServerRespGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpTxnServerRespGet

--- a/doc/reference/api/TSHttpTxnSsnGet.en.rst
+++ b/doc/reference/api/TSHttpTxnSsnGet.en.rst
@@ -18,13 +18,18 @@
 TSHttpTxnSsnGet
 ===============
 
+.. doxygen:briefdescription:: TSHttpTxnSsnGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSHttpSsn TSHttpTxnSsnGet(TSHttpTxn txnp)
+.. doxygen:function:: TSHttpTxnSsnGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpTxnSsnGet

--- a/doc/reference/api/TSHttpTxnTransformRespGet.en.rst
+++ b/doc/reference/api/TSHttpTxnTransformRespGet.en.rst
@@ -18,13 +18,18 @@
 TSHttpTxnTransformRespGet
 =========================
 
+.. doxygen:briefdescription:: TSHttpTxnTransformRespGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSHttpTxnTransformRespGet(TSHttpTxn txnp, TSMBuffer *bufp, TSMLoc *offset)
+.. doxygen:function:: TSHttpTxnTransformRespGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpTxnTransformRespGet

--- a/doc/reference/api/TSHttpTxnTransformedRespCache.en.rst
+++ b/doc/reference/api/TSHttpTxnTransformedRespCache.en.rst
@@ -18,13 +18,18 @@
 TSHttpTxnTransformedRespCache
 =============================
 
+.. doxygen:briefdescription:: TSHttpTxnTransformedRespCache
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSHttpTxnTransformedRespCache(TSHttpTxn txnp, int on)
+.. doxygen:function:: TSHttpTxnTransformedRespCache
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpTxnTransformedRespCache

--- a/doc/reference/api/TSHttpTxnUntransformedRespCache.en.rst
+++ b/doc/reference/api/TSHttpTxnUntransformedRespCache.en.rst
@@ -18,13 +18,18 @@
 TSHttpTxnUntransformedRespCache
 ===============================
 
+.. doxygen:briefdescription:: TSHttpTxnUntransformedRespCache
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSHttpTxnUntransformedRespCache(TSHttpTxn txnp, int on)
+.. doxygen:function:: TSHttpTxnUntransformedRespCache
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSHttpTxnUntransformedRespCache

--- a/doc/reference/api/TSIOBufferBlockReadStart.en.rst
+++ b/doc/reference/api/TSIOBufferBlockReadStart.en.rst
@@ -18,13 +18,18 @@
 TSIOBufferBlockReadStart
 ========================
 
+.. doxygen:briefdescription:: TSIOBufferBlockReadStart
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: const char* TSIOBufferBlockReadStart(TSIOBufferBlock blockp, TSIOBufferReader readerp, int64_t *avail)
+.. doxygen:function:: TSIOBufferBlockReadStart
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSIOBufferBlockReadStart

--- a/doc/reference/api/TSIOBufferCopy.en.rst
+++ b/doc/reference/api/TSIOBufferCopy.en.rst
@@ -18,13 +18,18 @@
 TSIOBufferCopy
 ==============
 
+.. doxygen:briefdescription:: TSIOBufferCopy
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: int64_t TSIOBufferCopy(TSIOBuffer bufp, TSIOBufferReader readerp, int64_t length, int64_t offset)
+.. doxygen:function:: TSIOBufferCopy
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSIOBufferCopy

--- a/doc/reference/api/TSIOBufferCreate.en.rst
+++ b/doc/reference/api/TSIOBufferCreate.en.rst
@@ -27,13 +27,13 @@ Synopsis
 ========
 `#include <ts/ts.h>`
 
-.. function:: TSIOBuffer TSIOBufferCreate(void)
-.. function:: TSIOBuffer TSIOBufferSizedCreate(TSIOBufferSizeIndex index)
-.. function:: void TSIOBufferDestroy(TSIOBuffer bufp)
-.. function:: int64_t TSIOBufferWrite(TSIOBuffer bufp, const void * buf, int64_t length)
-.. function:: void TSIOBufferProduce(TSIOBuffer bufp, int64_t nbytes)
-.. function:: int64_t TSIOBufferWaterMarkGet(TSIOBuffer bufp)
-.. function:: void TSIOBufferWaterMarkSet(TSIOBuffer bufp, int64_t water_mark)
+.. doxygen:function:: TSIOBufferCreate
+.. doxygen:function:: TSIOBufferSizedCreate
+.. doxygen:function:: TSIOBufferDestroy
+.. doxygen:function:: TSIOBufferWrite
+.. doxygen:function:: TSIOBufferProduce
+.. doxygen:function:: TSIOBufferWaterMarkGet
+.. doxygen:function:: TSIOBufferWaterMarkSet
 
 Description
 ===========

--- a/doc/reference/api/TSInstallDirGet.en.rst
+++ b/doc/reference/api/TSInstallDirGet.en.rst
@@ -28,9 +28,7 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. doxygen:function:: TSInstallDirGet
-.. doxygen:function:: TSConfigDirGet
-.. doxygen:function:: TSPluginDirGet
+.. doxygen:group:: Install and Plugin Locations
 
 Description
 ===========

--- a/doc/reference/api/TSInstallDirGet.en.rst
+++ b/doc/reference/api/TSInstallDirGet.en.rst
@@ -28,9 +28,9 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. function:: const char * TSInstallDirGet(void)
-.. function:: const char * TSConfigDirGet(void)
-.. function:: const char * TSPluginDirGet(void)
+.. doxygen:function:: TSInstallDirGet
+.. doxygen:function:: TSConfigDirGet
+.. doxygen:function:: TSPluginDirGet
 
 Description
 ===========

--- a/doc/reference/api/TSLifecycleHookAdd.en.rst
+++ b/doc/reference/api/TSLifecycleHookAdd.en.rst
@@ -27,7 +27,7 @@ Synopsis
 ========
 `#include <ts/ts.h>`
 
-.. function:: void TSLifecycleHookAdd(TSLifecycleHookID id, TSCont contp)
+.. doxygen:function:: TSLifecycleHookAdd
 
 Description
 ===========

--- a/doc/reference/api/TSLifecycleHookAdd.en.rst
+++ b/doc/reference/api/TSLifecycleHookAdd.en.rst
@@ -27,7 +27,7 @@ Synopsis
 ========
 `#include <ts/ts.h>`
 
-.. doxygen:function:: TSLifecycleHookAdd
+.. doxygen:group:: Plugin Lifecycle Hooks
 
 Description
 ===========

--- a/doc/reference/api/TSMBufferCreate.en.rst
+++ b/doc/reference/api/TSMBufferCreate.en.rst
@@ -27,9 +27,9 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. function:: TSMBuffer TSMBufferCreate(void)
-.. function:: TSReturnCode TSMBufferDestroy(TSMBuffer bufp)
-.. function:: TSReturnCode TSHandleMLocRelease(TSMBuffer bufp, TSMLoc parent, TSMLoc mloc)
+.. doxygen:function:: TSMBufferCreate
+.. doxygen:function:: TSMBufferDestroy
+.. doxygen:function:: TSHandleMLocRelease
 
 Description
 ===========

--- a/doc/reference/api/TSMgmtCounterGet.en.rst
+++ b/doc/reference/api/TSMgmtCounterGet.en.rst
@@ -18,13 +18,18 @@
 TSMgmtCounterGet
 ================
 
+.. doxygen:briefdescription:: TSMgmtCounterGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMgmtCounterGet(const char *var_name, TSMgmtCounter *result)
+.. doxygen:function:: TSMgmtCounterGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMgmtCounterGet

--- a/doc/reference/api/TSMgmtFloatGet.en.rst
+++ b/doc/reference/api/TSMgmtFloatGet.en.rst
@@ -18,13 +18,18 @@
 TSMgmtFloatGet
 ==============
 
+.. doxygen:briefdescription:: TSMgmtFloatGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMgmtFloatGet(const char *var_name, TSMgmtFloat *result)
+.. doxygen:function:: TSMgmtFloatGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMgmtFloatGet

--- a/doc/reference/api/TSMgmtIntGet.en.rst
+++ b/doc/reference/api/TSMgmtIntGet.en.rst
@@ -18,13 +18,18 @@
 TSMgmtIntGet
 ============
 
+.. doxygen:briefdescription:: TSMgmtIntGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMgmtIntGet(const char *var_name, TSMgmtInt *result)
+.. doxygen:function:: TSMgmtIntGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMgmtIntGet

--- a/doc/reference/api/TSMgmtStringGet.en.rst
+++ b/doc/reference/api/TSMgmtStringGet.en.rst
@@ -18,13 +18,18 @@
 TSMgmtStringGet
 ===============
 
+.. doxygen:briefdescription:: TSMgmtStringGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMgmtStringGet(const char *var_name, TSMgmtString *result)
+.. doxygen:function:: TSMgmtStringGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMgmtStringGet

--- a/doc/reference/api/TSMgmtUpdateRegister.en.rst
+++ b/doc/reference/api/TSMgmtUpdateRegister.en.rst
@@ -18,13 +18,18 @@
 TSMgmtUpdateRegister
 ====================
 
+.. doxygen:briefdescription:: TSMgmtUpdateRegister
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSMgmtUpdateRegister(TSCont contp, const char *plugin_name)
+.. doxygen:function:: TSMgmtUpdateRegister
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMgmtUpdateRegister

--- a/doc/reference/api/TSMimeHdrClone.en.rst
+++ b/doc/reference/api/TSMimeHdrClone.en.rst
@@ -18,9 +18,7 @@
 TSMimeHdrClone
 ==============
 
-Copies a specified MIME header to a specified marshal buffer, and
-returns the location of the copied MIME header within the destination
-marshal buffer.
+.. doxygen:briefdescription:: TSMimeHdrClone
 
 
 Synopsis
@@ -28,12 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMimeHdrClone(TSMBuffer dest_bufp, TSMBuffer src_bufp, TSMLoc src_hdr, TSMLoc *locp)
+.. doxygen:function:: TSMimeHdrClone
 
 
 Description
 -----------
 
-Unlike :c:func:`TSMimeHdrCopy`, you do not have to create the
-destination MIME header before cloning.  Release the returned
-:c:type:`TSMLoc` handle with a call to :c:func:`TSHandleMLocRelease`.
+.. doxygen:detaileddescription:: TSMimeHdrClone

--- a/doc/reference/api/TSMimeHdrCopy.en.rst
+++ b/doc/reference/api/TSMimeHdrCopy.en.rst
@@ -18,8 +18,7 @@
 TSMimeHdrCopy
 =============
 
-Copies the contents of the MIME header located at src_loc within
-src_bufp to the MIME header located at dest_loc within dest_bufp.
+.. doxygen:briefdescription:: TSMimeHdrCopy
 
 
 Synopsis
@@ -27,16 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMimeHdrCopy(TSMBuffer dest_bufp, TSMLoc dest_offset, TSMBuffer src_bufp, TSMLoc src_offset)
+.. doxygen:function:: TSMimeHdrCopy
 
 
 Description
 -----------
 
-:c:func:`TSMimeHdrCopy` works correctly even if src_bufp and dest_bufp
-point to different marshal buffers.
-
-.. important::
-
-   you must create the destination MIME header before copying into
-   it--use :c:func:`TSMimeHdrCreate`.
+.. doxygen:detaileddescription:: TSMimeHdrCopy

--- a/doc/reference/api/TSMimeHdrCreate.en.rst
+++ b/doc/reference/api/TSMimeHdrCreate.en.rst
@@ -18,7 +18,7 @@
 TSMimeHdrCreate
 ===============
 
-Creates a new MIME header within bufp.
+.. doxygen:briefdescription:: TSMimeHdrCreate
 
 
 Synopsis
@@ -26,10 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMimeHdrCreate(TSMBuffer bufp, TSMLoc *locp)
+.. doxygen:function:: TSMimeHdrCreate
 
 
 Description
 -----------
 
-Release with a call to :c:func:`TSHandleMLocRelease`.
+.. doxygen:detaileddescription:: TSMimeHdrCreate

--- a/doc/reference/api/TSMimeHdrDestroy.en.rst
+++ b/doc/reference/api/TSMimeHdrDestroy.en.rst
@@ -18,7 +18,7 @@
 TSMimeHdrDestroy
 ================
 
-Destroys the MIME header located at hdr_loc within bufp.
+.. doxygen:briefdescription:: TSMimeHdrDestroy
 
 
 Synopsis
@@ -26,8 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMimeHdrDestroy(TSMBuffer bufp, TSMLoc offset)
+.. doxygen:function:: TSMimeHdrDestroy
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeHdrDestroy

--- a/doc/reference/api/TSMimeHdrFieldAppend.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldAppend.en.rst
@@ -18,8 +18,7 @@
 TSMimeHdrFieldAppend
 ====================
 
-Returns the :c:type:`TSMLoc` location of a specified MIME field from
-within the MIME header located at hdr.
+.. doxygen:briefdescription:: TSMimeHdrFieldAppend
 
 
 Synopsis
@@ -27,17 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMimeHdrFieldAppend(TSMBuffer bufp, TSMLoc hdr, TSMLoc field)
+.. doxygen:function:: TSMimeHdrFieldAppend
 
 
 Description
 -----------
 
-The retrieved_str parameter specifies which field to retrieve.  For
-each MIME field in the MIME header, a pointer comparison is done
-between the field name and retrieved_str.  This is a much quicker
-retrieval function than :c:func:`TSMimeHdrFieldFind` since it obviates
-the need for a string comparison.  However, retrieved_str must be one
-of the predefined field names of the form :c:data:`TS_MIME_FIELD_XXX`
-for the call to succeed.  Release the returned :c:type:`TSMLoc` handle
-with a call to :c:func:`TSHandleMLocRelease`.
+.. doxygen:detaileddescription:: TSMimeHdrFieldAppend

--- a/doc/reference/api/TSMimeHdrFieldClone.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldClone.en.rst
@@ -18,13 +18,18 @@
 TSMimeHdrFieldClone
 ===================
 
+.. doxygen:briefdescription:: TSMimeHdrFieldClone
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMimeHdrFieldClone(TSMBuffer dest_bufp, TSMLoc dest_hdr, TSMBuffer src_bufp, TSMLoc src_hdr, TSMLoc src_field, TSMLoc *locp)
+.. doxygen:function:: TSMimeHdrFieldClone
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeHdrFieldClone

--- a/doc/reference/api/TSMimeHdrFieldCopy.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldCopy.en.rst
@@ -18,13 +18,18 @@
 TSMimeHdrFieldCopy
 ==================
 
+.. doxygen:briefdescription:: TSMimeHdrFieldCopy
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMimeHdrFieldCopy(TSMBuffer dest_bufp, TSMLoc dest_hdr, TSMLoc dest_field, TSMBuffer src_bufp, TSMLoc src_hdr, TSMLoc src_field)
+.. doxygen:function:: TSMimeHdrFieldCopy
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeHdrFieldCopy

--- a/doc/reference/api/TSMimeHdrFieldCopyValues.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldCopyValues.en.rst
@@ -18,13 +18,18 @@
 TSMimeHdrFieldCopyValues
 ========================
 
+.. doxygen:briefdescription:: TSMimeHdrFieldCopyValues
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMimeHdrFieldCopyValues(TSMBuffer dest_bufp, TSMLoc dest_hdr, TSMLoc dest_field, TSMBuffer src_bufp, TSMLoc src_hdr, TSMLoc src_field)
+.. doxygen:function:: TSMimeHdrFieldCopyValues
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeHdrFieldCopyValues

--- a/doc/reference/api/TSMimeHdrFieldCreate.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldCreate.en.rst
@@ -18,13 +18,18 @@
 TSMimeHdrFieldCreate
 ====================
 
+.. doxygen:briefdescription:: TSMimeHdrFieldCreate
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMimeHdrFieldCreate(TSMBuffer bufp, TSMLoc hdr, TSMLoc *locp)
+.. doxygen:function:: TSMimeHdrFieldCreate
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeHdrFieldCreate

--- a/doc/reference/api/TSMimeHdrFieldDestroy.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldDestroy.en.rst
@@ -18,7 +18,7 @@
 TSMimeHdrFieldDestroy
 =====================
 
-Destroys the MIME field located at field within bufp.
+.. doxygen:briefdescription:: TSMimeHdrFieldDestroy
 
 
 Synopsis
@@ -26,11 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMimeHdrFieldDestroy(TSMBuffer bufp, TSMLoc hdr, TSMLoc field)
+.. doxygen:function:: TSMimeHdrFieldDestroy
 
 
 Description
 -----------
 
-You must release the :c:type:`TSMLoc` field with a call to
-:c:func:`TSHandleMLocRelease`.
+.. doxygen:detaileddescription:: TSMimeHdrFieldDestroy

--- a/doc/reference/api/TSMimeHdrFieldFind.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldFind.en.rst
@@ -18,8 +18,7 @@
 TSMimeHdrFieldFind
 ==================
 
-Retrieves the :c:type:`TSMLoc` location of a specified MIME field from
-within the MIME header located at hdr.
+.. doxygen:briefdescription:: TSMimeHdrFieldFind
 
 
 Synopsis
@@ -27,15 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSMLoc TSMimeHdrFieldFind(TSMBuffer bufp, TSMLoc hdr, const char *name, int length)
+.. doxygen:function:: TSMimeHdrFieldFind
 
 
 Description
 -----------
 
-The name and length parameters specify which field to retrieve.  For
-each MIME field in the MIME header, a case insensitive string
-comparison is done between the field name and name.  If
-:c:func:`TSMimeHdrFieldFind` cannot find the requested field, it
-returns :c:data:`TS_NULL_MLOC`.  Release the returned :c:type:`TSMLoc`
-handle with a call to :c:func:`TSHandleMLocRelease`.
+.. doxygen:detaileddescription:: TSMimeHdrFieldFind

--- a/doc/reference/api/TSMimeHdrFieldGet.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldGet.en.rst
@@ -18,8 +18,7 @@
 TSMimeHdrFieldGet
 =================
 
-Retrieves the location of a specified MIME field within the MIME
-header located at hdr_loc within bufp.
+.. doxygen:briefdescription:: TSMimeHdrFieldGet
 
 
 Synopsis
@@ -27,14 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSMLoc TSMimeHdrFieldGet(TSMBuffer bufp, TSMLoc hdr, int idx)
+.. doxygen:function:: TSMimeHdrFieldGet
 
 
 Description
 -----------
 
-The idx parameter specifies which field to retrieve.  The fields are
-numbered from 0 to ``TSMimeHdrFieldsCount(bufp, hdr_loc)`` - 1.  If
-idx does not lie within that range then :c:type:`TSMimeHdrFieldGet`
-returns 0.  Release the returned handle with a call to
-:c:type:`TSHandleMLocRelease`.
+.. doxygen:detaileddescription:: TSMimeHdrFieldGet

--- a/doc/reference/api/TSMimeHdrFieldLengthGet.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldLengthGet.en.rst
@@ -18,13 +18,18 @@
 TSMimeHdrFieldLengthGet
 =======================
 
+.. doxygen:briefdescription:: TSMimeHdrFieldLengthGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: int TSMimeHdrFieldLengthGet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field)
+.. doxygen:function:: TSMimeHdrFieldLengthGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeHdrFieldLengthGet

--- a/doc/reference/api/TSMimeHdrFieldNameGet.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldNameGet.en.rst
@@ -18,13 +18,18 @@
 TSMimeHdrFieldNameGet
 =====================
 
+.. doxygen:briefdescription:: TSMimeHdrFieldNameGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: const char* TSMimeHdrFieldNameGet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int *length)
+.. doxygen:function:: TSMimeHdrFieldNameGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeHdrFieldNameGet

--- a/doc/reference/api/TSMimeHdrFieldNameSet.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldNameSet.en.rst
@@ -18,13 +18,18 @@
 TSMimeHdrFieldNameSet
 =====================
 
+.. doxygen:briefdescription:: TSMimeHdrFieldNameSet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMimeHdrFieldNameSet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, const char *name, int length)
+.. doxygen:function:: TSMimeHdrFieldNameSet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeHdrFieldNameSet

--- a/doc/reference/api/TSMimeHdrFieldNext.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldNext.en.rst
@@ -18,13 +18,18 @@
 TSMimeHdrFieldNext
 ==================
 
+.. doxygen:briefdescription:: TSMimeHdrFieldNext
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSMLoc TSMimeHdrFieldNext(TSMBuffer bufp, TSMLoc hdr, TSMLoc field)
+.. doxygen:function:: TSMimeHdrFieldNext
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeHdrFieldNext

--- a/doc/reference/api/TSMimeHdrFieldNextDup.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldNextDup.en.rst
@@ -18,13 +18,18 @@
 TSMimeHdrFieldNextDup
 =====================
 
+.. doxygen:briefdescription:: TSMimeHdrFieldNextDup
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSMLoc TSMimeHdrFieldNextDup(TSMBuffer bufp, TSMLoc hdr, TSMLoc field)
+.. doxygen:function:: TSMimeHdrFieldNextDup
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeHdrFieldNextDup

--- a/doc/reference/api/TSMimeHdrFieldRemove.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldRemove.en.rst
@@ -18,8 +18,7 @@
 TSMimeHdrFieldRemove
 ====================
 
-Removes the MIME field located at field within bufp from the header
-located at hdr within bufp.
+.. doxygen:briefdescription:: TSMimeHdrFieldRemove
 
 
 Synopsis
@@ -27,20 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMimeHdrFieldRemove(TSMBuffer bufp, TSMLoc hdr, TSMLoc field)
+.. doxygen:function:: TSMimeHdrFieldRemove
 
 
 Description
 -----------
 
-If the specified field cannot be found in the list of fields
-associated with the header then nothing is done.
-
-.. note::
-
-   removing the field does not destroy the field, it only detaches the
-   field, hiding it from the printed output.  The field can be
-   reattached with a call to :c:func:`TSMimeHdrFieldAppend`.  If you
-   do not use the detached field you should destroy it with a call to
-   :c:func:`TSMimeHdrFieldDestroy` and release the handle field with a
-   call to :c:func:`TSHandleMLocRelease`.
+.. doxygen:detaileddescription:: TSMimeHdrFieldRemove

--- a/doc/reference/api/TSMimeHdrFieldValueAppend.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldValueAppend.en.rst
@@ -18,13 +18,18 @@
 TSMimeHdrFieldValueAppend
 =========================
 
+.. doxygen:briefdescription:: TSMimeHdrFieldValueAppend
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMimeHdrFieldValueAppend(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx, const char *value, int length)
+.. doxygen:function:: TSMimeHdrFieldValueAppend
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeHdrFieldValueAppend

--- a/doc/reference/api/TSMimeHdrFieldValueDateInsert.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldValueDateInsert.en.rst
@@ -18,13 +18,18 @@
 TSMimeHdrFieldValueDateInsert
 =============================
 
+.. doxygen:briefdescription:: TSMimeHdrFieldValueDateInsert
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMimeHdrFieldValueDateInsert(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, time_t value)
+.. doxygen:function:: TSMimeHdrFieldValueDateInsert
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeHdrFieldValueDateInsert

--- a/doc/reference/api/TSMimeHdrFieldValueDateSet.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldValueDateSet.en.rst
@@ -18,13 +18,18 @@
 TSMimeHdrFieldValueDateSet
 ==========================
 
+.. doxygen:briefdescription:: TSMimeHdrFieldValueDateSet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMimeHdrFieldValueDateSet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, time_t value)
+.. doxygen:function:: TSMimeHdrFieldValueDateSet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeHdrFieldValueDateSet

--- a/doc/reference/api/TSMimeHdrFieldValueIntSet.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldValueIntSet.en.rst
@@ -18,13 +18,18 @@
 TSMimeHdrFieldValueIntSet
 =========================
 
+.. doxygen:briefdescription:: TSMimeHdrFieldValueIntSet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMimeHdrFieldValueIntSet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx, int value)
+.. doxygen:function:: TSMimeHdrFieldValueIntSet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeHdrFieldValueIntSet

--- a/doc/reference/api/TSMimeHdrFieldValueStringGet.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldValueStringGet.en.rst
@@ -28,11 +28,11 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. function::  const char* TSMimeHdrFieldValueStringGet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx, int* value_len_ptr)
-.. function::  int TSMimeHdrFieldValueIntGet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx)
-.. function::  int64_t TSMimeHdrFieldValueInt64Get(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx)
-.. function::  unsigned int TSMimeHdrFieldValueUintGet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx)
-.. function::  time_t TSMimeHdrFieldValueDateGet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field)
+.. doxygen:function:: TSMimeHdrFieldValueStringGet
+.. doxygen:function:: TSMimeHdrFieldValueIntGet
+.. doxygen:function:: TSMimeHdrFieldValueInt64Get
+.. doxygen:function:: TSMimeHdrFieldValueUintGet
+.. doxygen:function:: TSMimeHdrFieldValueDateGet
 
 
 Description

--- a/doc/reference/api/TSMimeHdrFieldValueStringInsert.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldValueStringInsert.en.rst
@@ -18,13 +18,18 @@
 TSMimeHdrFieldValueStringInsert
 ===============================
 
+.. doxygen:briefdescription:: TSMimeHdrFieldValueStringInsert
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMimeHdrFieldValueStringInsert(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx, const char *value, int length)
+.. doxygen:function:: TSMimeHdrFieldValueStringInsert
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeHdrFieldValueStringInsert

--- a/doc/reference/api/TSMimeHdrFieldValueStringSet.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldValueStringSet.en.rst
@@ -18,13 +18,18 @@
 TSMimeHdrFieldValueStringSet
 ============================
 
+.. doxygen:briefdescription:: TSMimeHdrFieldValueStringSet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMimeHdrFieldValueStringSet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx, const char *value, int length)
+.. doxygen:function:: TSMimeHdrFieldValueStringSet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeHdrFieldValueStringSet

--- a/doc/reference/api/TSMimeHdrFieldValueUintInsert.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldValueUintInsert.en.rst
@@ -18,13 +18,18 @@
 TSMimeHdrFieldValueUintInsert
 =============================
 
+.. doxygen:briefdescription:: TSMimeHdrFieldValueUintInsert
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMimeHdrFieldValueUintInsert(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx, unsigned int value)
+.. doxygen:function:: TSMimeHdrFieldValueUintInsert
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeHdrFieldValueUintInsert

--- a/doc/reference/api/TSMimeHdrFieldValueUintSet.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldValueUintSet.en.rst
@@ -18,13 +18,18 @@
 TSMimeHdrFieldValueUintSet
 ==========================
 
+.. doxygen:briefdescription:: TSMimeHdrFieldValueUintSet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMimeHdrFieldValueUintSet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx, unsigned int value)
+.. doxygen:function:: TSMimeHdrFieldValueUintSet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeHdrFieldValueUintSet

--- a/doc/reference/api/TSMimeHdrFieldValuesClear.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldValuesClear.en.rst
@@ -18,13 +18,18 @@
 TSMimeHdrFieldValuesClear
 =========================
 
+.. doxygen:briefdescription:: TSMimeHdrFieldValuesClear
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMimeHdrFieldValuesClear(TSMBuffer bufp, TSMLoc hdr, TSMLoc field)
+.. doxygen:function:: TSMimeHdrFieldValuesClear
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeHdrFieldValuesClear

--- a/doc/reference/api/TSMimeHdrFieldValuesCount.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldValuesCount.en.rst
@@ -18,13 +18,18 @@
 TSMimeHdrFieldValuesCount
 =========================
 
+.. doxygen:briefdescription:: TSMimeHdrFieldValuesCount
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: int TSMimeHdrFieldValuesCount(TSMBuffer bufp, TSMLoc hdr, TSMLoc field)
+.. doxygen:function:: TSMimeHdrFieldValuesCount
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeHdrFieldValuesCount

--- a/doc/reference/api/TSMimeHdrFieldsClear.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldsClear.en.rst
@@ -18,8 +18,7 @@
 TSMimeHdrFieldsClear
 ====================
 
-Removes and destroys all the MIME fields within the MIME header
-located at hdr_loc within the marshal buffer bufp.
+.. doxygen:briefdescription:: TSMimeHdrFieldsClear
 
 
 Synopsis
@@ -27,8 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMimeHdrFieldsClear(TSMBuffer bufp, TSMLoc offset)
+.. doxygen:function:: TSMimeHdrFieldsClear
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeHdrFieldsClear

--- a/doc/reference/api/TSMimeHdrFieldsCount.en.rst
+++ b/doc/reference/api/TSMimeHdrFieldsCount.en.rst
@@ -18,8 +18,7 @@
 TSMimeHdrFieldsCount
 ====================
 
-Returns a count of the number of MIME fields within the MIME header
-located at hdr_loc within the marshal buffer bufp.
+.. doxygen:briefdescription:: TSMimeHdrFieldsCount
 
 
 Synopsis
@@ -27,8 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: int TSMimeHdrFieldsCount(TSMBuffer bufp, TSMLoc offset)
+.. doxygen:function:: TSMimeHdrFieldsCount
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeHdrFieldsCount

--- a/doc/reference/api/TSMimeHdrLengthGet.en.rst
+++ b/doc/reference/api/TSMimeHdrLengthGet.en.rst
@@ -18,8 +18,7 @@
 TSMimeHdrLengthGet
 ==================
 
-Calculates the length of the MIME header located at hdr_loc if it were
-returned as a string.
+.. doxygen:briefdescription:: TSMimeHdrLengthGet
 
 
 Synopsis
@@ -27,10 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: int TSMimeHdrLengthGet(TSMBuffer bufp, TSMLoc offset)
+.. doxygen:function:: TSMimeHdrLengthGet
 
 
 Description
 -----------
 
-This the length of the MIME header in its unparsed form.
+.. doxygen:detaileddescription:: TSMimeHdrLengthGet

--- a/doc/reference/api/TSMimeHdrParse.en.rst
+++ b/doc/reference/api/TSMimeHdrParse.en.rst
@@ -18,7 +18,7 @@
 TSMimeHdrParse
 ==============
 
-Parses a MIME header.
+.. doxygen:briefdescription:: TSMimeHdrParse
 
 
 Synopsis
@@ -26,14 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSParseResult TSMimeHdrParse(TSMimeParser parser, TSMBuffer bufp, TSMLoc offset, const char **start, const char *end)
+.. doxygen:function:: TSMimeHdrParse
 
 
 Description
 -----------
 
-The MIME header must have already been allocated and both bufp and
-hdr_loc must point within that header.  It is possible to parse a MIME
-header a single byte at a time using repeated calls to
-:c:func:`TSMimeHdrParse`.  As long as an error does not occur,
-:c:func:`TSMimeHdrParse` consumes each single byte and asks for more.
+.. doxygen:detaileddescription:: TSMimeHdrParse

--- a/doc/reference/api/TSMimeHdrPrint.en.rst
+++ b/doc/reference/api/TSMimeHdrPrint.en.rst
@@ -18,8 +18,7 @@
 TSMimeHdrPrint
 ==============
 
-Formats the MIME header located at hdr_loc within bufp into the
-:c:type:`TSIOBuffer` iobufp.
+.. doxygen:briefdescription:: TSMimeHdrPrint
 
 
 Synopsis
@@ -27,8 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSMimeHdrPrint(TSMBuffer bufp, TSMLoc offset, TSIOBuffer iobufp)
+.. doxygen:function:: TSMimeHdrPrint
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeHdrPrint

--- a/doc/reference/api/TSMimeParserClear.en.rst
+++ b/doc/reference/api/TSMimeParserClear.en.rst
@@ -18,7 +18,7 @@
 TSMimeParserClear
 =================
 
-Clears the specified MIME parser so that it can be used again.
+.. doxygen:briefdescription:: TSMimeParserClear
 
 
 Synopsis
@@ -26,8 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSMimeParserClear(TSMimeParser parser)
+.. doxygen:function:: TSMimeParserClear
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeParserClear

--- a/doc/reference/api/TSMimeParserCreate.en.rst
+++ b/doc/reference/api/TSMimeParserCreate.en.rst
@@ -18,7 +18,7 @@
 TSMimeParserCreate
 ==================
 
-Creates a MIME parser.
+.. doxygen:briefdescription:: TSMimeParserCreate
 
 
 Synopsis
@@ -26,13 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSMimeParser TSMimeParserCreate(void)
+.. doxygen:function:: TSMimeParserCreate
 
 
 Description
 -----------
 
-The parser's data structure contains information about the header
-being parsed.  A single MIME parser can be used multiple times, though
-not simultaneously.  Before being used again, the parser must be
-cleared by calling :c:func:`TSMimeParserClear`.
+.. doxygen:detaileddescription:: TSMimeParserCreate

--- a/doc/reference/api/TSMimeParserDestroy.en.rst
+++ b/doc/reference/api/TSMimeParserDestroy.en.rst
@@ -18,7 +18,7 @@
 TSMimeParserDestroy
 ===================
 
-Destroys the specified MIME parser and frees the associated memory.
+.. doxygen:briefdescription:: TSMimeParserDestroy
 
 
 Synopsis
@@ -26,8 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSMimeParserDestroy(TSMimeParser parser)
+.. doxygen:function:: TSMimeParserDestroy
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMimeParserDestroy

--- a/doc/reference/api/TSMutexCreate.en.rst
+++ b/doc/reference/api/TSMutexCreate.en.rst
@@ -18,13 +18,18 @@
 TSMutexCreate
 =============
 
+.. doxygen:briefdescription:: TSMutexCreate
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSMutex TSMutexCreate(void)
+.. doxygen:function:: TSMutexCreate
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMutexCreate

--- a/doc/reference/api/TSMutexLock.en.rst
+++ b/doc/reference/api/TSMutexLock.en.rst
@@ -18,13 +18,18 @@
 TSMutexLock
 ===========
 
+.. doxygen:briefdescription:: TSMutexLock
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSMutexLock(TSMutex mutexp)
+.. doxygen:function:: TSMutexLock
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMutexLock

--- a/doc/reference/api/TSMutexLockTry.en.rst
+++ b/doc/reference/api/TSMutexLockTry.en.rst
@@ -18,13 +18,18 @@
 TSMutexLockTry
 ==============
 
+.. doxygen:briefdescription:: TSMutexLockTry
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSMutexLockTry(TSMutex mutexp)
+.. doxygen:function:: TSMutexLockTry
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMutexLockTry

--- a/doc/reference/api/TSMutexUnlock.en.rst
+++ b/doc/reference/api/TSMutexUnlock.en.rst
@@ -18,13 +18,18 @@
 TSMutexUnlock
 =============
 
+.. doxygen:briefdescription:: TSMutexUnlock
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSMutexUnlock(TSMutex mutexp)
+.. doxygen:function:: TSMutexUnlock
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSMutexUnlock

--- a/doc/reference/api/TSNetAccept.en.rst
+++ b/doc/reference/api/TSNetAccept.en.rst
@@ -18,13 +18,18 @@
 TSNetAccept
 ===========
 
+.. doxygen:briefdescription:: TSNetAccept
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSAction TSNetAccept(TSCont contp, int port, int domain, int accept_threads)
+.. doxygen:function:: TSNetAccept
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSNetAccept

--- a/doc/reference/api/TSNetAcceptNamedProtocol.en.rst
+++ b/doc/reference/api/TSNetAcceptNamedProtocol.en.rst
@@ -18,8 +18,7 @@
 TSNetAcceptNamedProtocol
 ========================
 
-Listen on all SSL ports for connections for the specified protocol
-name.
+.. doxygen:briefdescription:: TSNetAcceptNamedProtocol
 
 
 Synopsis
@@ -27,28 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSNetAcceptNamedProtocol(TSCont contp, const char *protocol)
+.. doxygen:function:: TSNetAcceptNamedProtocol
 
 
 Description
 -----------
 
-:c:type:`TSNetAcceptNamedProtocol` registers the specified protocol
-for all statically configured TLS ports.  When a client using the TLS
-Next Protocol Negotiation extension negotiates the requested protocol,
-:c:type:`TrafficServer` will route the request to the given handler.
-Note that the protocol is not registered on ports opened by other
-plugins.
-
-The event and data provided to the handler are the same as for
-:c:func:`TSNetAccept`.  If a connection is successfully accepted, the
-event code will be :c:data:`TS_EVENT_NET_ACCEPT` and the event data
-will be a valid :c:type:`TSVConn` bound to the accepted connection.
-
-Neither contp nor protocol are copied.  They must remain valid for the
-lifetime of the plugin.
-
-:c:type:`TSNetAcceptNamedProtocol` fails if the requested protocol
-cannot be registered on all of the configured TLS ports.  If it fails,
-the protocol will not be registered on any ports
-(ie..  no partial failure).
+.. doxygen:detaileddescription:: TSNetAcceptNamedProtocol

--- a/doc/reference/api/TSNetConnect.en.rst
+++ b/doc/reference/api/TSNetConnect.en.rst
@@ -18,13 +18,18 @@
 TSNetConnect
 ============
 
+.. doxygen:briefdescription:: TSNetConnect
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSAction TSNetConnect(TSCont contp, sockaddr const *addr)
+.. doxygen:function:: TSNetConnect
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSNetConnect

--- a/doc/reference/api/TSPluginInit.en.rst
+++ b/doc/reference/api/TSPluginInit.en.rst
@@ -27,8 +27,8 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. function:: void TSPluginInit(int argc, const char* argv[])
-.. function:: TSReturnCode TSPluginRegister(TSSDKVersion sdk_version, TSPluginRegistrationInfo* plugin_info)
+.. doxygen:function:: TSPluginInit
+.. doxygen:function:: TSPluginRegister
 
 Description
 ===========

--- a/doc/reference/api/TSRemap.en.rst
+++ b/doc/reference/api/TSRemap.en.rst
@@ -28,12 +28,12 @@ Synopsis
 | `#include <ts/ts.h>`
 | `#include <ts/remap.h>`
 
-.. function:: TSReturnCode TSRemapInit(TSRemapInterface * api_info, char* errbuf, int errbuf_size)
-.. function:: void TSRemapDone(void)
-.. function:: TSRemapStatus TSRemapDoRemap(void * ih, TSHttpTxn rh, TSRemapRequestInfo * rri)
-.. function:: TSReturnCode TSRemapNewInstance(int argc, char * argv[], void ** ih, char * errbuf, int errbuf_size)
-.. function:: void TSRemapDeleteInstance(void * )
-.. function:: void TSRemapOSResponse(void * ih, TSHttpTxn rh, int os_response_type)
+.. doxygen:function:: TSRemapInit
+.. doxygen:function:: TSRemapDone
+.. doxygen:function:: TSRemapDoRemap
+.. doxygen:function:: TSRemapNewInstance
+.. doxygen:function:: TSRemapDeleteInstance
+.. doxygen:function:: TSRemapOSResponse
 
 Description
 ===========

--- a/doc/reference/api/TSTextLogObjectCreate.en.rst
+++ b/doc/reference/api/TSTextLogObjectCreate.en.rst
@@ -28,14 +28,14 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. function:: TSReturnCode TSTextLogObjectCreate(const char* filename, int mode, TSTextLogObject * new_log_obj)
-.. function:: TSReturnCode TSTextLogObjectWrite(TSTextLogObject the_object, const char * format, ...)
-.. function:: void TSTextLogObjectFlush(TSTextLogObject the_object)
-.. function:: TSReturnCode TSTextLogObjectDestroy(TSTextLogObject the_object)
-.. function:: void TSTextLogObjectHeaderSet(TSTextLogObject the_object, const char * header)
-.. function:: TSReturnCode TSTextLogObjectRollingEnabledSet(TSTextLogObject the_object, int rolling_enabled)
-.. function:: void TSTextLogObjectRollingIntervalSecSet(TSTextLogObject the_object, int rolling_interval_sec)
-.. function:: void TSTextLogObjectRollingOffsetHrSet(TSTextLogObject the_object, int rolling_offset_hr)
+.. doxygen:function:: TSTextLogObjectCreate
+.. doxygen:function:: TSTextLogObjectWrite
+.. doxygen:function:: TSTextLogObjectFlush
+.. doxygen:function:: TSTextLogObjectDestroy
+.. doxygen:function:: TSTextLogObjectHeaderSet
+.. doxygen:function:: TSTextLogObjectRollingEnabledSet
+.. doxygen:function:: TSTextLogObjectRollingIntervalSecSet
+.. doxygen:function:: TSTextLogObjectRollingOffsetHrSet
 
 Description
 ===========

--- a/doc/reference/api/TSThreadCreate.en.rst
+++ b/doc/reference/api/TSThreadCreate.en.rst
@@ -18,13 +18,18 @@
 TSThreadCreate
 ==============
 
+.. doxygen:briefdescription:: TSThreadCreate
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSThread TSThreadCreate(TSThreadFunc func, void *data)
+.. doxygen:function:: TSThreadCreate
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSThreadCreate

--- a/doc/reference/api/TSThreadDestroy.en.rst
+++ b/doc/reference/api/TSThreadDestroy.en.rst
@@ -18,13 +18,18 @@
 TSThreadDestroy
 ===============
 
+.. doxygen:briefdescription:: TSThreadDestroy
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSThreadDestroy(TSThread thread)
+.. doxygen:function:: TSThreadDestroy
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSThreadDestroy

--- a/doc/reference/api/TSThreadInit.en.rst
+++ b/doc/reference/api/TSThreadInit.en.rst
@@ -18,13 +18,18 @@
 TSThreadInit
 ============
 
+.. doxygen:briefdescription:: TSThreadInit
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSThread TSThreadInit(void)
+.. doxygen:function:: TSThreadInit
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSThreadInit

--- a/doc/reference/api/TSThreadSelf.en.rst
+++ b/doc/reference/api/TSThreadSelf.en.rst
@@ -18,13 +18,18 @@
 TSThreadSelf
 ============
 
+.. doxygen:briefdescription:: TSThreadSelf
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSThread TSThreadSelf(void)
+.. doxygen:function:: TSThreadSelf
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSThreadSelf

--- a/doc/reference/api/TSTrafficServerVersionGet.en.rst
+++ b/doc/reference/api/TSTrafficServerVersionGet.en.rst
@@ -27,10 +27,7 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. doxygen:function:: TSTrafficServerVersionGet
-.. doxygen:function:: TSTrafficServerVersionGetMajor
-.. doxygen:function:: TSTrafficServerVersionGetMinor
-.. doxygen:function:: TSTrafficServerVersionGetPatch
+.. doxygen:group:: Traffic Server Version
 
 Description
 ===========

--- a/doc/reference/api/TSTrafficServerVersionGet.en.rst
+++ b/doc/reference/api/TSTrafficServerVersionGet.en.rst
@@ -27,10 +27,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. function:: const char * TSTrafficServerVersionGet(void)
-.. function:: int TSTrafficServerVersionGetMajor(void)
-.. function:: int TSTrafficServerVersionGetMinor(void)
-.. function:: int TSTrafficServerVersionGetPatch(void)
+.. doxygen:function:: TSTrafficServerVersionGet
+.. doxygen:function:: TSTrafficServerVersionGetMajor
+.. doxygen:function:: TSTrafficServerVersionGetMinor
+.. doxygen:function:: TSTrafficServerVersionGetPatch
 
 Description
 ===========

--- a/doc/reference/api/TSTransformCreate.en.rst
+++ b/doc/reference/api/TSTransformCreate.en.rst
@@ -18,13 +18,18 @@
 TSTransformCreate
 =================
 
+.. doxygen:briefdescription:: TSTransformCreate
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSVConn TSTransformCreate(TSEventFunc event_funcp, TSHttpTxn txnp)
+.. doxygen:function:: TSTransformCreate
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSTransformCreate

--- a/doc/reference/api/TSTransformOutputVConnGet.en.rst
+++ b/doc/reference/api/TSTransformOutputVConnGet.en.rst
@@ -18,13 +18,18 @@
 TSTransformOutputVConnGet
 =========================
 
+.. doxygen:briefdescription:: TSTransformOutputVConnGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSVConn TSTransformOutputVConnGet(TSVConn connp)
+.. doxygen:function:: TSTransformOutputVConnGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSTransformOutputVConnGet

--- a/doc/reference/api/TSTypes.en.rst
+++ b/doc/reference/api/TSTypes.en.rst
@@ -31,109 +31,127 @@ Description
 The Apache Traffic Server API provides large number of types. Many of them are specific to a particular API function or
 function group, but others are used more widely. Those are described on this page.
 
-.. type:: TSCont
+.. doxygen:type:: TSCont
 
    An opaque type that represents a Traffic Server :term:`continuation`.
 
-.. type:: TSEvent
+.. doxygen:type:: TSEvent
 
-   :type:`TSEvents` are sent to continuations when they are called
-   back.
+   .. doxygen:description::
 
-   The :type:`TSEvent` provides the continuation's handler function
-   with information about the callback.  Based on the event it
-   receives, the handler function can decide what to do.
+.. doxygen:type:: TSEventFunc
 
-.. type:: TSEventFunc
+   .. doxygen:description::
 
-.. type:: TSHostLookupResult
+.. doxygen:type:: TSHostLookupResult
 
-.. type:: TSHRTime
+   .. doxygen:description::
+
+.. doxygen:type:: TSHRTime
 
    "High Resolution Time"
 
    A 64 bit time value, measured in nanoseconds.
 
-.. type:: TSHttpHookID
+.. doxygen:type:: TSHttpHookID
 
    An enumeration that identifies a specific type of hook for HTTP transactions.
 
-.. type:: TSHttpParser
+.. doxygen:type:: TSHttpParser
 
-.. type:: TSHttpSsn
+   .. doxygen:description::
+
+.. doxygen:type:: TSHttpSsn
 
    An opaque type that represents a Traffic Server :term:`session`.
 
-.. type:: TSHttpTxn
+.. doxygen:type:: TSHttpTxn
 
    An opaque type that represents a Traffic Server HTTP :term:`transaction`.
 
-.. type:: TSIOBuffer
+.. doxygen:type:: TSIOBuffer
 
-.. type:: TSIOBufferReader
+   .. doxygen:description::
 
-.. type:: TSIOBufferSizeIndex
+.. doxygen:type:: TSIOBufferReader
 
-.. type:: TSLifecycleHookID
+   .. doxygen:description::
+
+.. doxygen:type:: TSIOBufferSizeIndex
+
+   .. doxygen:description::
+
+.. doxygen:type:: TSLifecycleHookID
 
    An enumeration that identifies a :ref:`life cycle hook <ts-lifecycle-hook-add>`.
 
-.. type:: TSMBuffer
+.. doxygen:type:: TSMBuffer
 
-.. type:: TSMgmtFloat
+   .. doxygen:description::
+
+.. doxygen:type:: TSMgmtFloat
 
    The type used internally for a floating point value. This corresponds to the value :const:`TS_RECORDDATATYPE_FLOAT` for
    :type:`TSRecordDataType`.
 
-.. type:: TSMgmtInt
+.. doxygen:type:: TSMgmtInt
 
    The type used internally for an integer. This corresponds to the value :const:`TS_RECORDDATATYPE_INT` for
    :type:`TSRecordDataType`.
 
-.. type:: TSMLoc
+.. doxygen:type:: TSMLoc
 
-.. type:: TSMutex
+   .. doxygen:description::
 
-.. type:: TSParseResult
+.. doxygen:type:: TSMutex
 
-   This set of enums are possible values returned by
-   :func:`TSHttpHdrParseReq` and :func:`TSHttpHdrParseResp`.
+   .. doxygen:description::
 
-.. type:: TSPluginRegistrationInfo
+.. doxygen:type:: TSParseResult
 
-   The following struct is used by :func:`TSPluginRegister`.
+   .. doxygen:description::
 
-   It stores registration information about the plugin.
+.. doxygen:type:: TSPluginRegistrationInfo
 
-.. type:: TSRecordDataType
+   .. doxygen:description::
+
+.. doxygen:type:: TSRecordDataType
 
    An enumeration that specifies the type of a value in an internal data structure that is accessible via the API.
 
-.. type:: TSRemapInterface
+.. doxygen:type:: TSRemapInterface
 
-.. type:: TSRemapRequestInfo
+   .. doxygen:description::
 
-.. type:: TSRemapStatus
+.. doxygen:type:: TSRemapRequestInfo
 
-.. type:: TSReturnCode
+   .. doxygen:description::
+
+.. doxygen:type:: TSRemapStatus
+
+   .. doxygen:description::
+
+.. doxygen:type:: TSReturnCode
 
    An indicator of the results of an API call. A value of :const:`TS_SUCCESS` means the call was successful. Any other value
    indicates a failure and is specific to the API call.
 
-.. type:: TSSDKVersion
+.. doxygen:type:: TSSDKVersion
 
-   Starting 2.0, SDK now follows same versioning as Traffic Server.
+   .. doxygen:description::
 
-.. type:: TSServerState
+.. doxygen:type:: TSServerState
 
-.. type:: TSTextLogObject
+   .. doxygen:description::
 
-   This type represents a custom log file that you create with
-   :func:`TSTextLogObjectCreate`.
+.. doxygen:type:: TSTextLogObject
 
-   Your plugin writes entries into this log file using
-   :func:`TSTextLogObjectWrite`.
+   .. doxygen:description::
 
-.. type:: TSVConn
+.. doxygen:type:: TSVConn
 
-.. type:: TSVIO
+   .. doxygen:description::
+
+.. doxygen:type:: TSVIO
+
+   .. doxygen:description::

--- a/doc/reference/api/TSUrlCreate.en.rst
+++ b/doc/reference/api/TSUrlCreate.en.rst
@@ -28,10 +28,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. function:: TSReturnCode TSUrlCreate(TSMBuffer bufp, TSMLoc* locp)
-.. function:: TSReturnCode TSUrlClone(TSMBuffer dest_bufp, TSMBuffer src_bufp, TSMLoc src_url, TSMLoc* locp)
-.. function:: TSReturnCode TSUrlCopy(TSMBuffer dest_bufp, TSMLoc dest_url, TSMBuffer src_bufp, TSMLoc src_url)
-.. function:: TSParseResult TSUrlParse(TSMBuffer bufp, TSMLoc offset, const char ** start, const char* end)
+.. doxygen:function:: TSUrlCreate
+.. doxygen:function:: TSUrlClone
+.. doxygen:function:: TSUrlCopy
+.. doxygen:function:: TSUrlParse
 
 Description
 ===========

--- a/doc/reference/api/TSUrlDestroy.en.rst
+++ b/doc/reference/api/TSUrlDestroy.en.rst
@@ -18,7 +18,7 @@
 TSUrlDestroy
 ============
 
-Destroys the URL located at url_loc within the marshal buffer bufp.
+.. doxygen:briefdescription:: TSUrlDestroy
 
 
 Synopsis
@@ -26,18 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSUrlDestroy(TSMBuffer bufp, TSMLoc offset)
+.. doxygen:function:: TSUrlDestroy
 
 
 Description
 -----------
 
-Do not forget to release the :c:type:`TSMLoc` url_loc with a call to
-:c:func:`TSHandleMLocRelease`.
-
-.. admonition:: Deprecated
-
-   There is no reason to destroy the URL, just release the marshal
-   buffers.
-
-Should be removed for v5.0.0
+.. doxygen:detaileddescription:: TSUrlDestroy

--- a/doc/reference/api/TSUrlFtpTypeGet.en.rst
+++ b/doc/reference/api/TSUrlFtpTypeGet.en.rst
@@ -18,7 +18,7 @@
 TSUrlFtpTypeGet
 ===============
 
-Retrieves the FTP type of the URL located at url_loc within bufp.
+.. doxygen:briefdescription:: TSUrlFtpTypeGet
 
 
 Synopsis
@@ -26,8 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: int TSUrlFtpTypeGet(TSMBuffer bufp, TSMLoc offset)
+.. doxygen:function:: TSUrlFtpTypeGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSUrlFtpTypeGet

--- a/doc/reference/api/TSUrlFtpTypeSet.en.rst
+++ b/doc/reference/api/TSUrlFtpTypeSet.en.rst
@@ -18,8 +18,7 @@
 TSUrlFtpTypeSet
 ===============
 
-Sets the FTP type portion of the URL located at url_loc within bufp to
-the value type.
+.. doxygen:briefdescription:: TSUrlFtpTypeSet
 
 
 Synopsis
@@ -27,8 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSReturnCode TSUrlFtpTypeSet(TSMBuffer bufp, TSMLoc offset, int type)
+.. doxygen:function:: TSUrlFtpTypeSet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSUrlFtpTypeSet

--- a/doc/reference/api/TSUrlHostGet.en.rst
+++ b/doc/reference/api/TSUrlHostGet.en.rst
@@ -28,15 +28,15 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. function:: const char* TSUrlHostGet(TSMBuffer bufp, TSMLoc offset, int* length)
-.. function:: const char* TSUrlSchemeGet(TSMBuffer bufp, TSMLoc offset, int* length)
-.. function:: const char* TSUrlUserGet(TSMBuffer bufp, TSMLoc offset, int* length)
-.. function:: const char* TSUrlPasswordGet(TSMBuffer bufp, TSMLoc offset, int* length)
-.. function:: int TSUrlPortGet(TSMBuffer bufp, TSMLoc offset)
-.. function:: const char* TSUrlPathGet(TSMBuffer bufp, TSMLoc offset, int* length)
-.. function:: const char* TSUrlHttpQueryGet(TSMBuffer bufp, TSMLoc offset, int* length)
-.. function:: const char* TSUrlHttpParamsGet(TSMBuffer bufp, TSMLoc offset, int* length)
-.. function:: const char* TSUrlHttpFragmentGet(TSMBuffer bufp, TSMLoc offset, int* length)
+.. doxygen:function:: TSUrlHostGet
+.. doxygen:function:: TSUrlSchemeGet
+.. doxygen:function:: TSUrlUserGet
+.. doxygen:function:: TSUrlPasswordGet
+.. doxygen:function:: TSUrlPortGet
+.. doxygen:function:: TSUrlPathGet
+.. doxygen:function:: TSUrlHttpQueryGet
+.. doxygen:function:: TSUrlHttpParamsGet
+.. doxygen:function:: TSUrlHttpFragmentGet
 
 Description
 ===========

--- a/doc/reference/api/TSUrlHostSet.en.rst
+++ b/doc/reference/api/TSUrlHostSet.en.rst
@@ -28,15 +28,15 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. function:: TSReturnCode TSUrlHostSet(TSMBuffer bufp, TSMLoc offset, const char* value, int length)
-.. function:: TSReturnCode TSUrlSchemeSet(TSMBuffer bufp, TSMLoc offset, const char* value, int length)
-.. function:: TSReturnCode TSUrlUserSet(TSMBuffer bufp, TSMLoc offset, const char* value, int length)
-.. function:: TSReturnCode TSUrlPasswordSet(TSMBuffer bufp, TSMLoc offset, const char* value, int length)
-.. function:: TSReturnCode TSUrlPortSet(TSMBuffer bufp, TSMLoc offset, int port)
-.. function:: TSReturnCode TSUrlPathSet(TSMBuffer bufp, TSMLoc offset, const char* value, int length)
-.. function:: TSReturnCode TSUrlHttpQuerySet(TSMBuffer bufp, TSMLoc offset, const char* value, int length)
-.. function:: TSReturnCode TSUrlHttpParamsSet(TSMBuffer bufp, TSMLoc offset, const char* value, int length)
-.. function:: TSReturnCode TSUrlHttpFragmentSet(TSMBuffer bufp, TSMLoc offset, const char* value, int length)
+.. doxygen:function:: TSUrlHostSet
+.. doxygen:function:: TSUrlSchemeSet
+.. doxygen:function:: TSUrlUserSet
+.. doxygen:function:: TSUrlPasswordSet
+.. doxygen:function:: TSUrlPortSet
+.. doxygen:function:: TSUrlPathSet
+.. doxygen:function:: TSUrlHttpQuerySet
+.. doxygen:function:: TSUrlHttpParamsSet
+.. doxygen:function:: TSUrlHttpFragmentSet
 
 Description
 ===========

--- a/doc/reference/api/TSUrlPercentEncode.en.rst
+++ b/doc/reference/api/TSUrlPercentEncode.en.rst
@@ -28,9 +28,9 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. function:: TSReturnCode TSUrlPercentEncode(TSMBuffer bufp, TSMLoc offset, char* dst, size_t dst_size, size_t* length, const unsigned char* map)
-.. function:: TSReturnCode TSStringPercentEncode(const char* str, int str_len, char* dst, size_t dst_size, size_t* length, const unsigned char* map)
-.. function:: TSReturnCode TSStringPercentDecode(const char* str, size_t str_len, char* dst, size_t dst_size, size_t* length)
+.. doxygen:function:: TSUrlPercentEncode
+.. doxygen:function:: TSStringPercentEncode
+.. doxygen:function:: TSStringPercentDecode
 
 Description
 ===========

--- a/doc/reference/api/TSUrlStringGet.en.rst
+++ b/doc/reference/api/TSUrlStringGet.en.rst
@@ -28,9 +28,9 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. function:: char* TSUrlStringGet(TSMBuffer bufp, TSMLoc offset, int* length)
-.. function:: int TSUrlLengthGet(TSMBuffer bufp, TSMLoc offset)
-.. function:: void TSUrlPrint(TSMBuffer bufp, TSMLoc offset, TSIOBuffer iobufp)
+.. doxygen:function:: TSUrlStringGet
+.. doxygen:function:: TSUrlLengthGet
+.. doxygen:function:: TSUrlPrint
 
 
 Description

--- a/doc/reference/api/TSVConnAbort.en.rst
+++ b/doc/reference/api/TSVConnAbort.en.rst
@@ -18,13 +18,18 @@
 TSVConnAbort
 ============
 
+.. doxygen:briefdescription:: TSVConnAbort
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSVConnAbort(TSVConn connp, int error)
+.. doxygen:function:: TSVConnAbort
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSVConnAbort

--- a/doc/reference/api/TSVConnCacheObjectSizeGet.en.rst
+++ b/doc/reference/api/TSVConnCacheObjectSizeGet.en.rst
@@ -18,13 +18,18 @@
 TSVConnCacheObjectSizeGet
 =========================
 
+.. doxygen:briefdescription:: TSVConnCacheObjectSizeGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: int64_t TSVConnCacheObjectSizeGet(TSVConn connp)
+.. doxygen:function:: TSVConnCacheObjectSizeGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSVConnCacheObjectSizeGet

--- a/doc/reference/api/TSVConnClose.en.rst
+++ b/doc/reference/api/TSVConnClose.en.rst
@@ -18,13 +18,18 @@
 TSVConnClose
 ============
 
+.. doxygen:briefdescription:: TSVConnClose
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSVConnClose(TSVConn connp)
+.. doxygen:function:: TSVConnClose
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSVConnClose

--- a/doc/reference/api/TSVConnClosedGet.en.rst
+++ b/doc/reference/api/TSVConnClosedGet.en.rst
@@ -18,13 +18,18 @@
 TSVConnClosedGet
 ================
 
+.. doxygen:briefdescription:: TSVConnClosedGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: int TSVConnClosedGet(TSVConn connp)
+.. doxygen:function:: TSVConnClosedGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSVConnClosedGet

--- a/doc/reference/api/TSVConnRead.en.rst
+++ b/doc/reference/api/TSVConnRead.en.rst
@@ -18,13 +18,18 @@
 TSVConnRead
 ===========
 
+.. doxygen:briefdescription:: TSVConnRead
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSVIO TSVConnRead(TSVConn connp, TSCont contp, TSIOBuffer bufp, int64_t nbytes)
+.. doxygen:function:: TSVConnRead
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSVConnRead

--- a/doc/reference/api/TSVConnReadVIOGet.en.rst
+++ b/doc/reference/api/TSVConnReadVIOGet.en.rst
@@ -18,13 +18,18 @@
 TSVConnReadVIOGet
 =================
 
+.. doxygen:briefdescription:: TSVConnReadVIOGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSVIO TSVConnReadVIOGet(TSVConn connp)
+.. doxygen:function:: TSVConnReadVIOGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSVConnReadVIOGet

--- a/doc/reference/api/TSVConnShutdown.en.rst
+++ b/doc/reference/api/TSVConnShutdown.en.rst
@@ -18,13 +18,18 @@
 TSVConnShutdown
 ===============
 
+.. doxygen:briefdescription:: TSVConnShutdown
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSVConnShutdown(TSVConn connp, int read, int write)
+.. doxygen:function:: TSVConnShutdown
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSVConnShutdown

--- a/doc/reference/api/TSVConnWrite.en.rst
+++ b/doc/reference/api/TSVConnWrite.en.rst
@@ -18,13 +18,18 @@
 TSVConnWrite
 ============
 
+.. doxygen:briefdescription:: TSVConnWrite
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSVIO TSVConnWrite(TSVConn connp, TSCont contp, TSIOBufferReader readerp, int64_t nbytes)
+.. doxygen:function:: TSVConnWrite
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSVConnWrite

--- a/doc/reference/api/TSVConnWriteVIOGet.en.rst
+++ b/doc/reference/api/TSVConnWriteVIOGet.en.rst
@@ -18,13 +18,18 @@
 TSVConnWriteVIOGet
 ==================
 
+.. doxygen:briefdescription:: TSVConnWriteVIOGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSVIO TSVConnWriteVIOGet(TSVConn connp)
+.. doxygen:function:: TSVConnWriteVIOGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSVConnWriteVIOGet

--- a/doc/reference/api/TSVIOBufferGet.en.rst
+++ b/doc/reference/api/TSVIOBufferGet.en.rst
@@ -18,13 +18,18 @@
 TSVIOBufferGet
 ==============
 
+.. doxygen:briefdescription:: TSVIOBufferGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSIOBuffer TSVIOBufferGet(TSVIO viop)
+.. doxygen:function:: TSVIOBufferGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSVIOBufferGet

--- a/doc/reference/api/TSVIOContGet.en.rst
+++ b/doc/reference/api/TSVIOContGet.en.rst
@@ -18,13 +18,18 @@
 TSVIOContGet
 ============
 
+.. doxygen:briefdescription:: TSVIOContGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSCont TSVIOContGet(TSVIO viop)
+.. doxygen:function:: TSVIOContGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSVIOContGet

--- a/doc/reference/api/TSVIOMutexGet.en.rst
+++ b/doc/reference/api/TSVIOMutexGet.en.rst
@@ -18,13 +18,18 @@
 TSVIOMutexGet
 =============
 
+.. doxygen:briefdescription:: TSVIOMutexGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSMutex TSVIOMutexGet(TSVIO viop)
+.. doxygen:function:: TSVIOMutexGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSVIOMutexGet

--- a/doc/reference/api/TSVIONBytesGet.en.rst
+++ b/doc/reference/api/TSVIONBytesGet.en.rst
@@ -18,13 +18,18 @@
 TSVIONBytesGet
 ==============
 
+.. doxygen:briefdescription:: TSVIONBytesGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: int64_t TSVIONBytesGet(TSVIO viop)
+.. doxygen:function:: TSVIONBytesGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSVIONBytesGet

--- a/doc/reference/api/TSVIONBytesSet.en.rst
+++ b/doc/reference/api/TSVIONBytesSet.en.rst
@@ -18,13 +18,18 @@
 TSVIONBytesSet
 ==============
 
+.. doxygen:briefdescription:: TSVIONBytesSet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSVIONBytesSet(TSVIO viop, int64_t nbytes)
+.. doxygen:function:: TSVIONBytesSet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSVIONBytesSet

--- a/doc/reference/api/TSVIONDoneGet.en.rst
+++ b/doc/reference/api/TSVIONDoneGet.en.rst
@@ -18,13 +18,18 @@
 TSVIONDoneGet
 =============
 
+.. doxygen:briefdescription:: TSVIONDoneGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: int64_t TSVIONDoneGet(TSVIO viop)
+.. doxygen:function:: TSVIONDoneGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSVIONDoneGet

--- a/doc/reference/api/TSVIONDoneSet.en.rst
+++ b/doc/reference/api/TSVIONDoneSet.en.rst
@@ -18,13 +18,18 @@
 TSVIONDoneSet
 =============
 
+.. doxygen:briefdescription:: TSVIONDoneSet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSVIONDoneSet(TSVIO viop, int64_t ndone)
+.. doxygen:function:: TSVIONDoneSet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSVIONDoneSet

--- a/doc/reference/api/TSVIONTodoGet.en.rst
+++ b/doc/reference/api/TSVIONTodoGet.en.rst
@@ -18,13 +18,18 @@
 TSVIONTodoGet
 =============
 
+.. doxygen:briefdescription:: TSVIONTodoGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: int64_t TSVIONTodoGet(TSVIO viop)
+.. doxygen:function:: TSVIONTodoGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSVIONTodoGet

--- a/doc/reference/api/TSVIOReaderGet.en.rst
+++ b/doc/reference/api/TSVIOReaderGet.en.rst
@@ -18,13 +18,18 @@
 TSVIOReaderGet
 ==============
 
+.. doxygen:briefdescription:: TSVIOReaderGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSIOBufferReader TSVIOReaderGet(TSVIO viop)
+.. doxygen:function:: TSVIOReaderGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSVIOReaderGet

--- a/doc/reference/api/TSVIOReenable.en.rst
+++ b/doc/reference/api/TSVIOReenable.en.rst
@@ -18,13 +18,18 @@
 TSVIOReenable
 =============
 
+.. doxygen:briefdescription:: TSVIOReenable
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSVIOReenable(TSVIO viop)
+.. doxygen:function:: TSVIOReenable
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSVIOReenable

--- a/doc/reference/api/TSVIOVConnGet.en.rst
+++ b/doc/reference/api/TSVIOVConnGet.en.rst
@@ -18,13 +18,18 @@
 TSVIOVConnGet
 =============
 
+.. doxygen:briefdescription:: TSVIOVConnGet
+
+
 Synopsis
 --------
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSVConn TSVIOVConnGet(TSVIO viop)
+.. doxygen:function:: TSVIOVConnGet
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSVIOVConnGet

--- a/doc/reference/api/TSfclose.en.rst
+++ b/doc/reference/api/TSfclose.en.rst
@@ -18,8 +18,7 @@
 TSfclose
 ========
 
-Closes the file to which filep points and frees the data structures
-and buffers associated with it.
+.. doxygen:briefdescription:: TSfclose
 
 
 Synopsis
@@ -27,10 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSfclose(TSFile filep)
+.. doxygen:function:: TSfclose
 
 
 Description
 -----------
 
-If the file was opened for writing, any pending data is flushed.
+.. doxygen:detaileddescription:: TSfclose

--- a/doc/reference/api/TSfflush.en.rst
+++ b/doc/reference/api/TSfflush.en.rst
@@ -18,8 +18,7 @@
 TSfflush
 ========
 
-Flushes pending data that has been buffered up in memory from previous
-calls to :c:func:`TSfwrite`.
+.. doxygen:briefdescription:: TSfflush
 
 
 Synopsis
@@ -27,8 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: void TSfflush(TSFile filep)
+.. doxygen:function:: TSfflush
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSfflush

--- a/doc/reference/api/TSfgets.en.rst
+++ b/doc/reference/api/TSfgets.en.rst
@@ -18,7 +18,7 @@
 TSfgets
 =======
 
-Reads a line from the file pointed to by filep into the buffer buf.
+.. doxygen:briefdescription:: TSfgets
 
 
 Synopsis
@@ -26,13 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: char* TSfgets(TSFile filep, char *buf, size_t length)
+.. doxygen:function:: TSfgets
 
 
 Description
 -----------
 
-Lines are terminated by a line feed character, ' '.  The line placed
-in the buffer includes the line feed character and is terminated with
-a NULL.  If the line is longer than length bytes then only the first
-length-minus-1 bytes are placed in buf.
+.. doxygen:detaileddescription:: TSfgets

--- a/doc/reference/api/TSfopen.en.rst
+++ b/doc/reference/api/TSfopen.en.rst
@@ -18,8 +18,7 @@
 TSfopen
 =======
 
-Opens a file for reading or writing and returns a descriptor for
-accessing the file.
+.. doxygen:briefdescription:: TSfopen
 
 
 Synopsis
@@ -27,11 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: TSFile TSfopen(const char *filename, const char *mode)
+.. doxygen:function:: TSfopen
 
 
 Description
 -----------
 
-The current implementation cannot open a file for both reading or
-writing.  See the SDK Programmer's Guide for sample code.
+.. doxygen:detaileddescription:: TSfopen

--- a/doc/reference/api/TSfread.en.rst
+++ b/doc/reference/api/TSfread.en.rst
@@ -18,8 +18,7 @@
 TSfread
 =======
 
-Attempts to read length bytes of data from the file pointed to by
-filep into the buffer buf.
+.. doxygen:briefdescription:: TSfread
 
 
 Synopsis
@@ -27,8 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: size_t TSfread(TSFile filep, void *buf, size_t length)
+.. doxygen:function:: TSfread
 
 
 Description
 -----------
+
+.. doxygen:detaileddescription:: TSfread

--- a/doc/reference/api/TSfwrite.en.rst
+++ b/doc/reference/api/TSfwrite.en.rst
@@ -18,8 +18,7 @@
 TSfwrite
 ========
 
-Attempts to write length bytes of data from the buffer buf to the file
-filep.
+.. doxygen:briefdescription:: TSfwrite
 
 
 Synopsis
@@ -27,13 +26,10 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. c:function:: size_t TSfwrite(TSFile filep, const void *buf, size_t length)
+.. doxygen:function:: TSfwrite
 
 
 Description
 -----------
 
-Make sure that filep is open for writing.  You might want to check the
-number of bytes written (:c:func:`TSfwrite` returns this value)
-against the value of length.  If it is less, there might be
-insufficient space on disk, for example.
+.. doxygen:detaileddescription:: TSfwrite

--- a/doc/reference/api/TSmalloc.en.rst
+++ b/doc/reference/api/TSmalloc.en.rst
@@ -28,13 +28,13 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. function:: void * TSmalloc(size_t size , const char * path)
-.. function:: void * TSrealloc(void * ptr , size_t size , const char * path)
-.. function:: char * TSstrdup(const char * str)
-.. function:: char * TSstrndup(const char * str, size_t size)
-.. function:: size_t TSstrlcpy(char * dst , const char * src , size_t size)
-.. function:: size_t TSstrlcat(char * dst , const char * src , size_t size)
-.. function:: void TSfree(void * ptr)
+.. doxygen:function:: TSmalloc
+.. doxygen:function:: TSrealloc
+.. doxygen:function:: TSstrdup
+.. doxygen:function:: TSstrndup
+.. doxygen:function:: TSstrlcpy
+.. doxygen:function:: TSstrlcat
+.. doxygen:function:: TSfree
 
 Description
 ===========

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -37,8 +37,12 @@ extern "C"
 {
 #endif /* __cplusplus */
 
-  /* --------------------------------------------------------------------------
-     Memory */
+
+  /** @name Memory
+
+   */
+  /** @{ */
+
 #define TSmalloc(s)      _TSmalloc ((s), TS_RES_MEM_PATH)
 #define TSrealloc(p,s)   _TSrealloc ((p), (s), TS_RES_MEM_PATH)
 #define TSstrdup(p)      _TSstrdup ((p), -1, TS_RES_MEM_PATH)
@@ -54,8 +58,14 @@ extern "C"
   tsapi size_t _TSstrlcat(char *dst, const char *str, size_t siz);
   tsapi void _TSfree(void* ptr);
 
-  /* --------------------------------------------------------------------------
-     Component object handles */
+  /** @} */
+
+
+  /** @name Component Object Handles
+
+   */
+  /** @{ */
+
   /**
       Releases the TSMLoc mloc created from the TSMLoc parent.
       If there is no parent TSMLoc, use TS_NULL_MLOC.
@@ -69,8 +79,14 @@ extern "C"
    */
   tsapi TSReturnCode TSHandleMLocRelease(TSMBuffer bufp, TSMLoc parent, TSMLoc mloc);
 
-  /* --------------------------------------------------------------------------
-     Install and plugin locations */
+  /** @} */
+
+
+  /** @name Install and Plugin Locations
+
+   */
+  /** @{ */
+
   /**
       Gets the path of the directory in which Traffic Server is installed.
       Use this function to specify the location of files that the
@@ -104,8 +120,14 @@ extern "C"
    */
   tsapi const char* TSPluginDirGet(void);
 
-  /* --------------------------------------------------------------------------
-     Traffic Server Version */
+  /** @} */
+
+
+  /** @name Traffic Server Version
+
+   */
+  /** @{ */
+
   /**
       Gets the version of Traffic Server currently running. Use this
       function to make sure that the plugin version and Traffic Server
@@ -140,8 +162,13 @@ extern "C"
    */
   int TSTrafficServerVersionGetPatch(void);
 
-  /* --------------------------------------------------------------------------
-     Plugin registration */
+  /** @} */
+
+
+  /** @name Plugin Registration
+
+   */
+  /** @{ */
 
   /**
       This function registers your plugin with a particular version
@@ -158,8 +185,14 @@ extern "C"
    */
   tsapi TSReturnCode TSPluginRegister(TSSDKVersion sdk_version, TSPluginRegistrationInfo* plugin_info);
 
-  /* --------------------------------------------------------------------------
-     Files */
+  /** @} */
+
+
+  /** @name Files
+
+   */
+  /** @{ */
+
   /**
       Opens a file for reading or writing and returns a descriptor for
       accessing the file. The current implementation cannot open a file
@@ -242,8 +275,14 @@ extern "C"
    */
   tsapi char* TSfgets(TSFile filep, char* buf, size_t length);
 
-  /* --------------------------------------------------------------------------
-     Error logging */
+  /** @} */
+
+
+  /** @name Error Logging
+
+   */
+  /** @{ */
+
   /**
       Writes printf-style error messages to the Traffic Server error
       log. One advantage of TSError over printf is that each call is
@@ -257,8 +296,14 @@ extern "C"
   */
   tsapi void TSError(const char* fmt, ...) TS_PRINTFLIKE(1, 2);
 
-  /* --------------------------------------------------------------------------
-     Assertions */
+  /** @} */
+
+
+  /** @name Assertions
+
+   */
+  /** @{ */
+
   tsapi void _TSReleaseAssert(const char* txt, const char* f, int l) TS_NORETURN;
   tsapi int _TSAssert(const char* txt, const char* f, int l);
 
@@ -268,8 +313,14 @@ extern "C"
 #define TSAssert(EX) \
             (void)((EX) || (_TSAssert(#EX, __FILE__, __LINE__)))
 
-  /* --------------------------------------------------------------------------
-     Marshal buffers */
+  /** @} */
+
+
+  /** @name Marshal Buffers
+
+   */
+  /** @{ */
+
   /**
       Creates a new marshal buffer and initializes the reference count
       to 1.
@@ -287,8 +338,14 @@ extern "C"
    */
   tsapi TSReturnCode TSMBufferDestroy(TSMBuffer bufp);
 
-  /* --------------------------------------------------------------------------
-     URLs */
+  /** @} */
+
+
+  /** @name URLs
+
+   */
+  /** @{ */
+
   /**
       Creates a new URL within the marshal buffer bufp. Returns a
       location for the URL within the marshal buffer.
@@ -435,8 +492,14 @@ extern "C"
    */
   tsapi TSReturnCode TSUrlSchemeSet(TSMBuffer bufp, TSMLoc offset, const char* value, int length);
 
-  /* --------------------------------------------------------------------------
-     Internet specific URLs */
+  /** @} */
+
+
+  /** @name Internet Specific URLs
+
+   */
+  /** @{ */
+
   /**
       Retrieves the user portion of the URL located at url_loc
       within bufp. Note: the returned string is not guaranteed to
@@ -544,8 +607,14 @@ extern "C"
    */
   tsapi TSReturnCode TSUrlPortSet(TSMBuffer bufp, TSMLoc offset, int port);
 
-  /* --------------------------------------------------------------------------
-     HTTP specific URLs */
+  /** @} */
+
+
+  /** @name HTTP Specific URLs
+
+   */
+  /** @{ */
+
   /**
       Retrieves the path portion of the URL located at url_loc within
       bufp. TSUrlPathGet() places the length of the returned string in
@@ -575,8 +644,14 @@ extern "C"
    */
   tsapi TSReturnCode TSUrlPathSet(TSMBuffer bufp, TSMLoc offset, const char* value, int length);
 
-  /* --------------------------------------------------------------------------
-     FTP specific URLs */
+  /** @} */
+
+
+  /** @name FTP Specific URLs
+
+   */
+  /** @{ */
+
   /**
       Retrieves the FTP type of the URL located at url_loc within bufp.
 
@@ -598,8 +673,14 @@ extern "C"
    */
   tsapi TSReturnCode TSUrlFtpTypeSet(TSMBuffer bufp, TSMLoc offset, int type);
 
-  /* --------------------------------------------------------------------------
-     HTTP specific URLs */
+  /** @} */
+
+
+  /** @name HTTP Specific URLs
+
+   */
+  /** @{ */
+
   /**
       Retrieves the HTTP params portion of the URL located at url_loc
       within bufp. The length of the returned string is in the length
@@ -732,10 +813,13 @@ extern "C"
   */
   tsapi TSReturnCode TSStringPercentDecode(const char *str, size_t str_len, char *dst, size_t dst_size, size_t *length);
 
+  /** @} */
 
 
-  /* --------------------------------------------------------------------------
-     MIME headers */
+  /** @name MIME Headers
+
+   */
+  /** @{ */
 
   /**
       Creates a MIME parser. The parser's data structure contains
@@ -1024,8 +1108,14 @@ extern "C"
 
   tsapi TSReturnCode TSMimeHdrFieldValueDelete(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx);
 
-  /* --------------------------------------------------------------------------
-     HTTP headers */
+  /** @} */
+
+
+  /** @name HTTP Headers
+
+   */
+  /** @{ */
+
   tsapi TSHttpParser TSHttpParserCreate(void);
   tsapi void TSHttpParserClear(TSHttpParser parser);
   tsapi void TSHttpParserDestroy(TSHttpParser parser);
@@ -1117,23 +1207,41 @@ extern "C"
   tsapi TSReturnCode TSHttpHdrReasonSet(TSMBuffer bufp, TSMLoc offset, const char* value, int length);
   tsapi const char* TSHttpHdrReasonLookup(TSHttpStatus status);
 
-  /* --------------------------------------------------------------------------
-     Threads */
+  /** @} */
+
+
+  /** @name Threads
+
+   */
+  /** @{ */
+
   tsapi TSThread TSThreadCreate(TSThreadFunc func, void* data);
   tsapi TSThread TSThreadInit(void);
   tsapi void TSThreadDestroy(TSThread thread);
   tsapi TSThread TSThreadSelf(void);
 
-  /* --------------------------------------------------------------------------
-     Mutexes */
+  /** @} */
+
+
+  /** @name Mutexes
+
+   */
+  /** @{ */
+
   tsapi TSMutex TSMutexCreate(void);
   tsapi void TSMutexLock(TSMutex mutexp);
   tsapi TSReturnCode TSMutexLockTry(TSMutex mutexp);
 
   tsapi void TSMutexUnlock(TSMutex mutexp);
 
-  /* --------------------------------------------------------------------------
-     cachekey */
+  /** @} */
+
+
+  /** @name Cache Key
+
+   */
+  /** @{ */
+
   /**
       Creates (allocates memory for) a new cache key.
    */
@@ -1177,27 +1285,51 @@ extern "C"
    */
   tsapi TSReturnCode TSCacheKeyDestroy(TSCacheKey key);
 
-  /* --------------------------------------------------------------------------
-     cache url */
+  /** @} */
+
+
+  /** @name Cache URL
+
+   */
+  /** @{ */
+
   tsapi TSReturnCode TSCacheUrlSet(TSHttpTxn txnp, const char* url, int length);
 
-  /* --------------------------------------------------------------------------
-     Configuration */
+  /** @} */
+
+
+  /** @name Configuration
+
+   */
+  /** @{ */
+
   tsapi unsigned int TSConfigSet(unsigned int id, void* data, TSConfigDestroyFunc funcp);
   tsapi TSConfig TSConfigGet(unsigned int id);
   tsapi void TSConfigRelease(unsigned int id, TSConfig configp);
   tsapi void* TSConfigDataGet(TSConfig configp);
 
-  /* --------------------------------------------------------------------------
-     Management */
+  /** @} */
+
+
+  /** @name Management
+
+   */
+  /** @{ */
+
   tsapi void TSMgmtUpdateRegister(TSCont contp, const char *plugin_name);
   tsapi TSReturnCode TSMgmtIntGet(const char* var_name, TSMgmtInt* result);
   tsapi TSReturnCode TSMgmtCounterGet(const char* var_name, TSMgmtCounter* result);
   tsapi TSReturnCode TSMgmtFloatGet(const char* var_name, TSMgmtFloat* result);
   tsapi TSReturnCode TSMgmtStringGet(const char* var_name, TSMgmtString* result);
 
-  /* --------------------------------------------------------------------------
-     Continuations */
+  /** @} */
+
+
+  /** @name Continuations
+
+   */
+  /** @{ */
+
   tsapi TSCont TSContCreate(TSEventFunc funcp, TSMutex mutexp);
   tsapi void TSContDestroy(TSCont contp);
   tsapi void TSContDataSet(TSCont contp, void* data);
@@ -1208,21 +1340,46 @@ extern "C"
   tsapi int TSContCall(TSCont contp, TSEvent event, void* edata);
   tsapi TSMutex TSContMutexGet(TSCont contp);
 
-  /* --------------------------------------------------------------------------
-     Plugin lifecycle  hooks */
+  /** @} */
+
+
+  /** @name Plugin Lifecycle Hooks
+
+   */
+  /** @{ */
+
   tsapi void TSLifecycleHookAdd(TSLifecycleHookID id, TSCont contp);
-  /* --------------------------------------------------------------------------
-     HTTP hooks */
+
+  /** @} */
+
+
+  /** @name HTTP Hooks
+
+   */
+  /** @{ */
+
   tsapi void TSHttpHookAdd(TSHttpHookID id, TSCont contp);
 
-  /* --------------------------------------------------------------------------
-     HTTP sessions */
+  /** @} */
+
+
+  /** @name HTTP Sessions
+
+   */
+  /** @{ */
+
   tsapi void TSHttpSsnHookAdd(TSHttpSsn ssnp, TSHttpHookID id, TSCont contp);
   tsapi void TSHttpSsnReenable(TSHttpSsn ssnp, TSEvent event);
   tsapi int TSHttpSsnTransactionCount(TSHttpSsn ssnp);
 
-  /* --------------------------------------------------------------------------
-     HTTP transactions */
+  /** @} */
+
+
+  /** @name HTTP Transactions
+
+   */
+  /** @{ */
+
   tsapi void TSHttpTxnHookAdd(TSHttpTxn txnp, TSHttpHookID id, TSCont contp);
   tsapi TSHttpSsn TSHttpTxnSsnGet(TSHttpTxn txnp);
 
@@ -1480,8 +1637,13 @@ extern "C"
 
   tsapi TSServerState TSHttpTxnServerStateGet(TSHttpTxn txnp);
 
-  /* --------------------------------------------------------------------------
-     Transaction specific debugging control  */
+  /** @} */
+
+
+  /** @name Transaction Specific Debugging Control
+
+   */
+  /** @{ */
 
   /**
          Set the transaction specific debugging flag for this transaction.
@@ -1516,8 +1678,13 @@ extern "C"
   */
   tsapi int TSHttpSsnDebugGet(TSHttpSsn ssnp, int *on);
 
-  /* --------------------------------------------------------------------------
-     Intercepting Http Transactions */
+  /** @} */
+
+
+  /** @name Intercepting HTTP Transactions
+
+   */
+  /** @{ */
 
   /**
       Allows a plugin take over the servicing of the request as though
@@ -1575,8 +1742,13 @@ extern "C"
    */
   tsapi void TSHttpTxnServerIntercept(TSCont contp, TSHttpTxn txnp);
 
-  /* --------------------------------------------------------------------------
-     Initiate Http Connection */
+  /** @} */
+
+
+  /** @name Initiate HTTP Connection
+
+   */
+  /** @{ */
 
   tsapi TSClientProtoStack TSClientProtoStackCreate(TSProtoType, ...);
 
@@ -1602,8 +1774,14 @@ extern "C"
   tsapi TSVConn TSHttpConnectWithProtoStack(struct sockaddr const* addr,
                                             TSClientProtoStack proto_stack);
 
-    /* --------------------------------------------------------------------------
-     Initiate Transparent Http Connection */
+  /** @} */
+
+
+  /** @name Initiate Transparent HTTP Connection
+
+   */
+  /** @{ */
+
   /**
       Allows the plugin to initiate a transparent http connection. This operates
       identically to TSHttpConnect except that it is treated as an intercepted
@@ -1624,20 +1802,38 @@ extern "C"
   /* Check if HTTP State machine is internal or not */
   tsapi TSReturnCode TSHttpIsInternalRequest(TSHttpTxn txnp);
 
-  /* --------------------------------------------------------------------------
-     HTTP alternate selection */
+  /** @} */
+
+
+  /** @name HTTP Alternate Selection
+
+   */
+  /** @{ */
+
   tsapi TSReturnCode TSHttpAltInfoClientReqGet(TSHttpAltInfo infop, TSMBuffer* bufp, TSMLoc* offset);
   tsapi TSReturnCode TSHttpAltInfoCachedReqGet(TSHttpAltInfo infop, TSMBuffer* bufp, TSMLoc* offset);
   tsapi TSReturnCode TSHttpAltInfoCachedRespGet(TSHttpAltInfo infop, TSMBuffer* bufp, TSMLoc* offset);
   tsapi void TSHttpAltInfoQualitySet(TSHttpAltInfo infop, float quality);
 
-  /* --------------------------------------------------------------------------
-     Actions */
+  /** @} */
+
+
+  /** @name Actions
+
+   */
+  /** @{ */
+
   tsapi void TSActionCancel(TSAction actionp);
   tsapi int TSActionDone(TSAction actionp);
 
-  /* --------------------------------------------------------------------------
-     VConnections */
+  /** @} */
+
+
+  /** @name VConnections
+
+   */
+  /** @{ */
+
   tsapi TSVIO TSVConnReadVIOGet(TSVConn connp);
   tsapi TSVIO TSVConnWriteVIOGet(TSVConn connp);
   tsapi int TSVConnClosedGet(TSVConn connp);
@@ -1648,17 +1844,34 @@ extern "C"
   tsapi void TSVConnAbort(TSVConn connp, int error);
   tsapi void TSVConnShutdown(TSVConn connp, int read, int write);
 
-  /* --------------------------------------------------------------------------
-     Cache VConnections */
+  /** @} */
+
+
+  /** @name Cache VConnections
+
+   */
+  /** @{ */
+
   tsapi int64_t TSVConnCacheObjectSizeGet(TSVConn connp);
 
-  /* --------------------------------------------------------------------------
-     Transformations */
+  /** @} */
+
+
+  /** @name Transformations
+
+   */
+  /** @{ */
+
   tsapi TSVConn TSTransformCreate(TSEventFunc event_funcp, TSHttpTxn txnp);
   tsapi TSVConn TSTransformOutputVConnGet(TSVConn connp);
 
-  /* --------------------------------------------------------------------------
-     Net VConnections */
+  /** @} */
+
+
+  /** @name Net VConnections
+
+   */
+  /** @{ */
 
   tsapi struct sockaddr const* TSNetVConnRemoteAddrGet(TSVConn vc);
 
@@ -1726,8 +1939,14 @@ extern "C"
    */
   tsapi TSReturnCode TSPortDescriptorAccept(TSPortDescriptor, TSCont);
 
-  /* --------------------------------------------------------------------------
-     DNS Lookups */
+  /** @} */
+
+
+  /** @name DNS Lookups
+
+   */
+  /** @{ */
+
   tsapi TSAction TSHostLookup(TSCont contp, const char* hostname, size_t namelen);
   tsapi struct sockaddr const* TSHostLookupResultAddrGet(TSHostLookupResult lookup_result);
   /* TODO: Eventually, we might want something like this as well, but it requires
@@ -1735,8 +1954,14 @@ extern "C"
      tsapi void TSHostLookupResultSet(TSHttpTxn txnp, TSHostLookupResult result);
   */
 
-  /* --------------------------------------------------------------------------
-     Cache VConnections */
+  /** @} */
+
+
+  /** @name Cache VConnections
+
+   */
+  /** @{ */
+
   /**
       Asks the Traffic Server cache if the object corresponding to key
       exists in the cache and can be read. If the object can be read,
@@ -1814,8 +2039,14 @@ extern "C"
   tsapi TSReturnCode TSCacheReady(int* is_ready);
   tsapi TSAction TSCacheScan(TSCont contp, TSCacheKey key, int KB_per_second);
 
-  /* --------------------------------------------------------------------------
-     VIOs */
+  /** @} */
+
+
+  /** @name VIOs
+
+   */
+  /** @{ */
+
   tsapi void TSVIOReenable(TSVIO viop);
   tsapi TSIOBuffer TSVIOBufferGet(TSVIO viop);
   tsapi TSIOBufferReader TSVIOReaderGet(TSVIO viop);
@@ -1828,8 +2059,14 @@ extern "C"
   tsapi TSCont TSVIOContGet(TSVIO viop);
   tsapi TSVConn TSVIOVConnGet(TSVIO viop);
 
-  /* --------------------------------------------------------------------------
-     Buffers */
+  /** @} */
+
+
+  /** @name Buffers
+
+   */
+  /** @{ */
+
   tsapi TSIOBuffer TSIOBufferCreate(void);
 
   /**
@@ -1951,8 +2188,13 @@ extern "C"
 
   tsapi TSReturnCode TSStatFindName(const char* name, int* idp);
 
-  /* --------------------------------------------------------------------------
-     tracing api */
+  /** @} */
+
+
+  /** @name Tracing API
+
+   */
+  /** @{ */
 
   tsapi int TSIsDebugTagSet(const char* t);
   tsapi void TSDebug(const char* tag, const char* format_str, ...) TS_PRINTFLIKE(2, 3);
@@ -1974,8 +2216,13 @@ extern "C"
   extern int diags_on_for_plugins;
 #define TSDEBUG if (diags_on_for_plugins) TSDebug
 
-  /* --------------------------------------------------------------------------
-     logging api */
+  /** @} */
+
+
+  /** @name Logging API
+
+   */
+  /** @{ */
 
   /**
       The following enum values are flags, so they should be powers
@@ -2123,6 +2370,9 @@ extern "C"
 
    */
   tsapi void TSTextLogObjectRollingOffsetHrSet(TSTextLogObject the_object, int rolling_offset_hr);
+
+  /** @} */
+
 
   /**
       Async disk IO read


### PR DESCRIPTION
Where API reference pages match API sections, use the Doxygen group to include the members' signatures.