### PR TITLE
patch for TS-2834

### DIFF
--- a/plugins/header_rewrite/conditions.h
+++ b/plugins/header_rewrite/conditions.h
@@ -330,4 +330,23 @@ private:
   TSMutex _mutex;
 };
 
+class ConditionInternalTransaction : public Condition
+{
+public:
+  void append_value(std::string &/* s ATS_UNUSED */, const Resources &/* res ATS_UNUSED */) { }
+
+protected:
+  bool eval(const Resources &res);
+};
+
+class ConditionClientIp : public Condition
+{
+public:
+  void initialize(Parser& p);
+  void append_value(std::string &s, const Resources &res);
+
+protected:
+  bool eval(const Resources &res);
+};
+
 #endif // __CONDITIONS_H

--- a/plugins/header_rewrite/factory.cc
+++ b/plugins/header_rewrite/factory.cc
@@ -107,6 +107,10 @@ condition_factory(const std::string& cond)
     c = new ConditionUrl(true);
   } else if (c_name == "DBM") {
     c = new ConditionDBM();
+  } else if (c_name == "INTERNAL-TRANSACTION") {
+    c = new ConditionInternalTransaction();
+  } else if (c_name == "%<chi>") {
+    c = new ConditionClientIp();
   } else {
     TSError("%s: unknown condition: %s", PLUGIN_NAME, c_name.c_str());
     return NULL;


### PR DESCRIPTION
This patch adds a condition "INTERNAL-TRANSACTION' and makes the client IP '%<chi>' available for COND arguments. Usage examples

cond %{READ_REQUEST_HDR_HOOK} [AND]
cond %{INTERNAL-TRANSACTION} [NOT]
rm-header client_ip
add-header client_ip %<chi>

cond %{READ_REQUEST_HDR_HOOK} [AND]
cond %{%<chi>}  =127.0.0.1 [NOT]
rm-header client_ip
add-header client_ip %<chi>
