### PR TITLE
Add escaped container options to the docs

### DIFF
--- a/doc/reference/configuration/ip_allow.config.en.rst
+++ b/doc/reference/configuration/ip_allow.config.en.rst
@@ -5,9 +5,9 @@
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
- 
+
    http://www.apache.org/licenses/LICENSE-2.0
- 
+
   Unless required by applicable law or agreed to in writing,
   software distributed under the License is distributed on an
   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -43,9 +43,12 @@ access the Traffic Server proxy cache, and ``ip_deny`` denies the
 specified client(s) to access the Traffic Server proxy cache. Multiple
 method keywords can be specified (method=GET method=HEAD), or multiple
 methods can be separated by an '\|' (method=GET\|HEAD). The method
-keyword is optional and it is defaulted to ALL. Available methods: ALL,
-GET, CONNECT, DELETE, HEAD, ICP_QUERY, OPTIONS, POST, PURGE, PUT,
-TRACE, PUSH
+keyword is optional and it is defaulted to ALL. This supports ANY string
+as the HTTP method, meaning no validation is done to check wether it
+is a valid HTTP method. This allows you to create filters for any method
+that your origin may require, this is especially useful if you use newer
+methods that aren't know to trafficserver (such as PROPFIND) or if your
+origin uses an http-ish protocol.
 
 By default, the :file:`ip_allow.config` file contains the following lines,
 which allows all methods to localhost to access the Traffic Server proxy

--- a/doc/reference/configuration/remap.config.en.rst
+++ b/doc/reference/configuration/remap.config.en.rst
@@ -375,6 +375,27 @@ This will pass "1" and "2" to plugin1.so and "3" to plugin2.so
 
 .. _remap-config-named-filters:
 
+Acl Filters
+===========
+
+Acl filters can be created to control access of specific remap lines. The markup
+is very similar to that of :file:`ip_allow.config`, with slight changes to
+accomodate remap markup
+
+Examples
+--------
+
+::
+    map http://foo.example.com/neverpost  http://foo.example.com/neverpost @action=deny @method=post
+    map http://foo.example.com/onlypost  http://foo.example.com/onlypost @action=allow @method=post
+
+    map http://foo.example.com/  http://foo.example.com/ @action=deny @src_ip=1.2.3.4
+    map http://foo.example.com/  http://foo.example.com/ @action=allow @src_ip=127.0.0.1
+
+    map http://foo.example.com/  http://foo.example.com/ @action=allow @src_ip=127.0.0.1 @method=post @method=get @method=head
+
+Note that these Acl filters will return a 403 response if the resource is restricted.
+
 Named Filters
 =============
 


### PR DESCRIPTION
Thanks to Alan for finding this feature down in the logging guts. I tested locally and it all seems to work (my box is 4.2.1), so I figure we might as well document it.
