### PR TITLE
Correct default for log.extended_log_is_ascii

### DIFF
--- a/doc/reference/configuration/records.config.en.rst
+++ b/doc/reference/configuration/records.config.en.rst
@@ -1760,7 +1760,7 @@ Logging Configuration
    Enables (``1``) or disables (``0``) the `Netscape extended log file format
    <../working-log-files/log-formats#NetscapeFormats>`_. 
 
-.. ts:cv:: CONFIG proxy.config.log.extended_log_is_ascii INT 1
+.. ts:cv:: CONFIG proxy.config.log.extended_log_is_ascii INT 0
 
    The `Netscape extended log <../working-log-files/log-formats#NetscapeFormats>`_ file type:
 


### PR DESCRIPTION
0 Is used in `RecordsConfig.cc`:

E: proxy.config.log.extended_log_is_ascii
  RecordsConfig.cc          : CONFIG  INT      0
  records.config.en.rst     : CONFIG  INT      1
  records.config.default.in : missing
