### PR TITLE
TS-3036: Added the 'chm' logging field

### DIFF
--- a/doc/admin/event-logging-formats.en.rst
+++ b/doc/admin/event-logging-formats.en.rst
@@ -72,6 +72,11 @@ The following list describes Traffic Server custom logging fields.
 ``chih``
     The IP address of the client's host machine in hexadecimal.
 
+``chm``
+    The cache medium the HIT was served from. If it was a RAM cache HIT
+    the value is 'ram'. For a HIT (see ``crc``) with a ``chm`` value of
+    ``-`` the medium was disk cache.
+
 ``chp``
     The port number of the client's host machine.
 

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -877,6 +877,13 @@ Log::init_fields()
   global_field_list.add(field, false);
   ink_hash_table_insert(field_symbol_hash, "etype", field);
 
+  field = new LogField("cache_hit_medium", "chm",
+                       LogField::STRING,
+                       &LogAccess::marshal_cache_hit_medium,
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
+  global_field_list.add(field, false);
+  ink_hash_table_insert(field_symbol_hash, "chm", field);
+
   init_status |= FIELDS_INITIALIZED;
 }
 

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -838,8 +838,7 @@ LogAccess::marshal_ip(char* dest, sockaddr const* ip) {
 }
 
 int
-LogAccess::marshal_cache_hit_medium(LogField::Container /* container ATS_UNUSED */,
-                                     char * /* field ATS_UNUSED */, char *buf)
+LogAccess::marshal_cache_hit_medium(char *buf)
 {
   DEFAULT_STR_FIELD;
 }

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -837,6 +837,13 @@ LogAccess::marshal_ip(char* dest, sockaddr const* ip) {
   return INK_ALIGN_DEFAULT(len);
 }
 
+int
+LogAccess::marshal_cache_hit_medium(LogField::Container /* container ATS_UNUSED */,
+                                     char * /* field ATS_UNUSED */, char *buf)
+{
+  DEFAULT_STR_FIELD;
+}
+
 inline int
 LogAccess::unmarshal_with_map(int64_t code, char *dest, int len, Ptr<LogFieldAliasMap> map, const char *msg)
 {

--- a/proxy/logging/LogAccess.h
+++ b/proxy/logging/LogAccess.h
@@ -252,6 +252,7 @@ public:
   inkcoreapi virtual int marshal_file_size(char *);     // INT
   inkcoreapi virtual int marshal_plugin_identity_id(char *); // INT
   inkcoreapi virtual int marshal_plugin_identity_tag(char *); // STR
+  inkcoreapi virtual int marshal_cache_hit_medium(char *);    // STR
   int marshal_entry_type(char *);       // INT
 
 

--- a/proxy/logging/LogAccessHttp.cc
+++ b/proxy/logging/LogAccessHttp.cc
@@ -1293,10 +1293,10 @@ LogAccessHttp::marshal_http_header_field_escapify(LogField::Container container,
 int
 LogAccessHttp::marshal_cache_hit_medium(char *buf)
 {
-  char *str = NULL;
+  const char *str = NULL;
   int len = INK_MIN_ALIGN;
    if (m_http_sm->t_state.cache_info.is_ram_cache_hit) {
-    str = “ram";
+    str = "ram";
     len = LogAccess::strlen(str);
   }
 

--- a/proxy/logging/LogAccessHttp.cc
+++ b/proxy/logging/LogAccessHttp.cc
@@ -1289,3 +1289,19 @@ LogAccessHttp::marshal_http_header_field_escapify(LogField::Container container,
 
   return (padded_len);
 }
+
+int
+LogAccessHttp::marshal_cache_hit_medium(char *buf)
+{
+  char *str = NULL;
+  int len = INK_MIN_ALIGN;
+   if (m_http_sm->t_state.cache_info.is_ram_cache_hit) {
+    str = “ram";
+    len = LogAccess::strlen(str);
+  }
+
+  if (buf) {
+    marshal_str(buf, str, len);
+  }
+  return len;
+}

--- a/proxy/logging/LogAccessHttp.h
+++ b/proxy/logging/LogAccessHttp.h
@@ -129,6 +129,7 @@ public:
   virtual int marshal_file_size(char *); // INT
   virtual int marshal_plugin_identity_id(char *);    // INT
   virtual int marshal_plugin_identity_tag(char *);    // STR
+  virtual int marshal_cache_hit_medium(char *); // STR
 
   //
   // named fields from within a http header

--- a/proxy/logging/LogAccessTest.h
+++ b/proxy/logging/LogAccessTest.h
@@ -90,6 +90,7 @@ public:
   // other fields
   //
   virtual int marshal_transfer_time_ms(char *); // INT
+  virtual int marshal_cache_hit_medium(char *); // STR
 
   //
   // named fields from within a http header


### PR DESCRIPTION
The 'chm' logging field notes, in the case of a cache hit, if the medium the hit was served from was RAM.