### PR TITLE
Added Unique Identifier to HttpSM, to aid on debugging

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1448,19 +1448,31 @@ fi
 # by the project, no new dependency.)
 # Otherwise we'll search for ossp_uuid. If found, add to ldflags.
 # This fallback is needed for old distros.
+
+
 if test "x${enable_uuid}" = "xyes"; then
+	has_boost_uuid=no
+	has_ossp_uuid=no
+
 	AC_LANG_PUSH([C++])
 	AC_CHECK_HEADERS([boost/uuid/uuid.hpp],
-		[AC_DEFINE([HAVE_BOOST_UUID], [1], [Define that we can use boost for UUID generation.])],
+		[has_boost_uuid=yes],
 		[PKG_CHECK_MODULES([OSSP_UUID], [ossp-uuid],
-			[HAVE_OSSP_UUID=yes],
+			[has_ossp_uuid=yes],
 			[AC_MSG_ERROR([UUID generation is on but neither a compatible boost nor lib ossp_uuid found.])]
                        )]
 	)
 	AC_LANG_POP([C++])
 
-	if test "x${HAVE_OSSP_UUID}" = "xyes"; then
-		AC_DEFINE([HAVE_OSSP_UUID], [1], [Define that we can use OSSP_UUID lib for UUID generation.])
+	if test "x${has_boost_uuid}" = "xyes"; then
+		AC_DEFINE([HAS_BOOST_UUID], [1], [Define that we can use boost for UUID generation.])
+	fi
+
+
+	if test "x${has_ossp_uuid}" = "xyes"; then
+		AC_CHECK_HEADERS([uuid.h],
+			[AC_DEFINE([HAS_OSSP_UUID], [1], [Define that we can use OSSP_UUID lib for UUID generation.])],
+			[AC_MSG_ERROR([OSSP header file uuid.h not found.])])
 		EXTRA_CXX_LDFLAGS+=" -lossp-uuid"
 	fi
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -393,6 +393,20 @@ TS_ARG_ENABLE_VAR([has], [spdy])
 AC_SUBST(has_spdy)
 AM_CONDITIONAL([BUILD_SPDY], [test 0 -ne $has_spdy])
 
+
+#
+# Options for UUID
+#
+AC_MSG_CHECKING([whether to enable uuid generation.])
+AC_ARG_ENABLE([uuid],
+	[AS_HELP_STRING([--enable-uuid], [turn on uuid generation])],
+	[],
+	[enable_uuid="no"])
+AC_MSG_RESULT([$enable_uuid])
+TS_ARG_ENABLE_VAR([has], [uuid])
+AC_SUBST(has_uuid)
+AM_CONDITIONAL([BUILD_UUID], [test 0 -ne $has_uuid])
+
 #
 # Configure how many stats to allocate for plugins. Default is 512.
 #
@@ -1427,6 +1441,30 @@ AM_CONDITIONAL([BUILD_HTTP_LOAD], [test x"$ac_cv_func_epoll_ctl" = x"yes"])
 if test "x${enable_spdy}" = "xyes"; then
   PKG_CHECK_MODULES([SPDYLAY],[libspdylay])
 fi
+
+# UUID generation may either use boost or ossp-uuid.
+# We first try boost, if we have version 1.42 up will use it
+# (because it does not need an extra lib and it's already being used
+# by the project, no new dependency.)
+# Otherwise we'll search for ossp_uuid. If found, add to ldflags.
+# This fallback is needed for old distros.
+if test "x${enable_uuid}" = "xyes"; then
+	AC_LANG_PUSH([C++])
+	AC_CHECK_HEADERS([boost/uuid/uuid.hpp],
+		[AC_DEFINE([HAVE_BOOST_UUID], [1], [Define that we can use boost for UUID generation.])],
+		[PKG_CHECK_MODULES([OSSP_UUID], [ossp-uuid],
+			[HAVE_OSSP_UUID=yes],
+			[AC_MSG_ERROR([UUID generation is on but neither a compatible boost nor lib ossp_uuid found.])]
+                       )]
+	)
+	AC_LANG_POP([C++])
+
+	if test "x${HAVE_OSSP_UUID}" = "xyes"; then
+		AC_DEFINE([HAVE_OSSP_UUID], [1], [Define that we can use OSSP_UUID lib for UUID generation.])
+		EXTRA_CXX_LDFLAGS+=" -lossp-uuid"
+	fi
+fi
+
 
 # -----------------------------------------------------------------------------
 # 5. CHECK FOR HEADER FILES

--- a/lib/ts/ink_config.h.in
+++ b/lib/ts/ink_config.h.in
@@ -63,16 +63,6 @@
 #define TS_HAS_SO_MARK                 @has_so_mark@
 #define TS_HAS_SPDY                    @has_spdy@
 #define TS_HAS_UUID                    @has_uuid@
-
-#if TS_HAS_UUID == 1
-	#define TS_USE_UUID
-	#ifdef HAVE_BOOST_UUID
-		#define TS_USE_BOOST_UUID
-	#elif HAVE_OSSP_UUID
-		#define TS_USE_OSSP_UUID
-	#endif
-#endif
-
 #define TS_HAS_IP_TOS                  @has_ip_tos@
 #define TS_USE_HWLOC                   @use_hwloc@
 #define TS_USE_FREELIST                @use_freelist@

--- a/lib/ts/ink_config.h.in
+++ b/lib/ts/ink_config.h.in
@@ -62,6 +62,17 @@
 #define TS_USE_TPROXY                  @use_tproxy@
 #define TS_HAS_SO_MARK                 @has_so_mark@
 #define TS_HAS_SPDY                    @has_spdy@
+#define TS_HAS_UUID                    @has_uuid@
+
+#if TS_HAS_UUID == 1
+	#define TS_USE_UUID
+	#ifdef HAVE_BOOST_UUID
+		#define TS_USE_BOOST_UUID
+	#elif HAVE_OSSP_UUID
+		#define TS_USE_OSSP_UUID
+	#endif
+#endif
+
 #define TS_HAS_IP_TOS                  @has_ip_tos@
 #define TS_USE_HWLOC                   @use_hwloc@
 #define TS_USE_FREELIST                @use_freelist@

--- a/plugins/cacheurl/cacheurl.cc
+++ b/plugins/cacheurl/cacheurl.cc
@@ -403,7 +403,6 @@ TSRemapDeleteInstance(void *ih)
 
   TSDebug(PLUGIN_NAME, "Deleting remap instance");
 
-  TSfree(prl);
   delete prl;
 }
 

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -8591,3 +8591,14 @@ TSHttpEventNameLookup(TSEvent event)
 {
   return HttpDebugNames::get_event_name(static_cast<int>(event));
 }
+
+const char*
+TSHttpTxnGetUUID(TSHttpTxn txnp)
+{
+  HttpSM * sm = (HttpSM *) txnp;
+
+  if ( txnp == NULL || sm->magic != HTTP_SM_MAGIC_ALIVE )
+    return "ERROR";
+
+  return sm->get_uuid();
+}

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -1535,6 +1535,7 @@ main(int /* argc ATS_UNUSED */, char **argv)
     extern int spdy_config_load ();
     spdy_config_load(); // must be before HttpProxyPort init.
 # endif
+
     // Load HTTP port data. getNumSSLThreads depends on this.
     if (!HttpProxyPort::loadValue(http_accept_port_descriptor))
       HttpProxyPort::loadConfig();

--- a/proxy/Makefile.am
+++ b/proxy/Makefile.am
@@ -189,7 +189,9 @@ if BUILD_TESTS
     RegressionSM.cc
 endif
 
-traffic_server_LDFLAGS = @EXTRA_CXX_LDFLAGS@ @LIBTOOL_LINK_FLAGS@
+
+
+traffic_server_LDFLAGS = @EXTRA_CXX_LDFLAGS@ @LIBTOOL_LINK_FLAGS@ @OSSP_UUID_LIBS@
 traffic_server_LDADD = \
   http/libhttp.a \
   spdy/libspdy.a \

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -2337,6 +2337,17 @@ extern "C"
   */
   tsapi const char* TSHttpEventNameLookup(TSEvent event);
 
+  /**
+     Returns a unique identifier for a request (if proxy.config.http.use_uuid is set).
+
+     @param txnp The Transaction Handler.
+
+     @return The transactions'unique identifier if proxy.config.http.use_uuid
+     is set, an empty string otherwise. If the transaction handler is
+     invalid, "ERROR" is returned.
+   */
+  tsapi const char* TSHttpTxnGetUUID(TSHttpTxn txnp);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -18,7 +18,7 @@
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License.
+  limitations under the License
  */
 
 /****************************************************************************
@@ -44,15 +44,15 @@
 #include "HdrUtils.h"
 //#include "AuthHttpAdapter.h"
 
-#ifdef TS_USE_UUID
-  #ifdef TS_USE_BOOST_UUID
+#ifdef TS_HAS_UUID
+  #ifdef HAS_BOOST_UUID
     #include <boost/uuid/uuid.hpp>
     #include <boost/uuid/uuid_generators.hpp>
     #include <boost/uuid/uuid_io.hpp>
 
     using namespace boost;
-    using namespace boost::uuid;
-  #else // TS_USE_OSSP_UUID
+    using namespace boost::uuids;
+  #else // HAS_OSSP_UUID
     #include <uuid.h>
   #endif
 #endif
@@ -547,16 +547,26 @@ public:
 public:
   bool set_server_session_private(bool private_session);
 
-#ifdef TS_USE_UUID
+#ifdef TS_HAS_UUID
   const char *get_uuid(void) const;
+  bool should_add_uuid_to_request(void) const;
+  bool should_add_uuid_to_response(void) const;
+  void add_uuid_header(HTTPHdr *hdr) const;
 
 protected:
-  static RecInt use_uuid;
   std::string   id;
 
-  #ifdef TS_USE_BOOST_UUID
+  static RecInt      use_uuid;
+  static std::string header_name;
+  static RecInt      add_to_request;
+  static RecInt      add_to_response;
+
+  void init_uuid_config();
+  void generate_uuid();
+
+  #ifdef HAS_BOOST_UUID
     boost::uuids::basic_random_generator<boost::mt19937> gen;
-  #else //TS_USE_OSSP_UUID
+  #else //HAS_OSSP_UUID
     uuid_t *_uuid;
   #endif
 #endif

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -44,6 +44,20 @@
 #include "HdrUtils.h"
 //#include "AuthHttpAdapter.h"
 
+#ifdef TS_USE_UUID
+  #ifdef TS_USE_BOOST_UUID
+    #include <boost/uuid/uuid.hpp>
+    #include <boost/uuid/uuid_generators.hpp>
+    #include <boost/uuid/uuid_io.hpp>
+
+    using namespace boost;
+    using namespace boost::uuid;
+  #else // TS_USE_OSSP_UUID
+    #include <uuid.h>
+  #endif
+#endif
+
+
 /* Enable LAZY_BUF_ALLOC to delay allocation of buffers until they
  * are actually required.
  * Enabling LAZY_BUF_ALLOC, stop Http code from allocation space
@@ -218,11 +232,11 @@ public:
   // setup Range transfomration if so.
   // return true when the Range is unsatisfiable
   void do_range_setup_if_necessary();
-  
+
   void do_range_parse(MIMEField *range_field);
   void calculate_output_cl(int64_t, int64_t);
   void parse_range_and_compare(MIMEField*, int64_t);
-  
+
   // Called by transact to prevent reset problems
   //  failed PUSH requests
   void set_ua_half_close_flag();
@@ -532,6 +546,20 @@ public:
 
 public:
   bool set_server_session_private(bool private_session);
+
+#ifdef TS_USE_UUID
+  const char *get_uuid(void) const;
+
+protected:
+  RecInt      use_uuid;
+  std::string id;
+
+  #ifdef TS_USE_BOOST_UUID
+    boost::uuids::basic_random_generator<boost::mt19937> gen;
+  #else //TS_USE_OSSP_UUID
+    uuid_t *_uuid;
+  #endif
+#endif
 };
 
 //Function to get the cache_sm object - YTS Team, yamsat

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -551,8 +551,8 @@ public:
   const char *get_uuid(void) const;
 
 protected:
-  RecInt      use_uuid;
-  std::string id;
+  static RecInt use_uuid;
+  std::string   id;
 
   #ifdef TS_USE_BOOST_UUID
     boost::uuids::basic_random_generator<boost::mt19937> gen;

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -531,7 +531,7 @@ how_to_open_connection(HttpTransact::State* s)
         int port = url->port_get();
         if (port != url_canonicalize_port(URL_TYPE_HTTP, 0)) {
           char *buf = (char *)alloca(host_len + 15);
-          memcpy(buf, host, host_len); 
+          memcpy(buf, host, host_len);
           host_len += snprintf(buf + host_len, 15, ":%d", port);
           s->hdr_info.server_request.value_set(MIME_FIELD_HOST, MIME_LEN_HOST, buf, host_len);
         } else {
@@ -640,7 +640,7 @@ HttpTransact::HandleBlindTunnel(State* s)
     url_remap_success = true;
   } else if (url_remap_mode == URL_REMAP_DEFAULT || url_remap_mode == URL_REMAP_ALL) {
     // TODO: take a look at this
-    // This probably doesn't work properly, since request_url_remap() is broken.  
+    // This probably doesn't work properly, since request_url_remap() is broken.
     url_remap_success = request_url_remap(s, &s->hdr_info.client_request, &remap_redirect);
   }
   // We must have mapping or we will self loop since the this
@@ -756,7 +756,7 @@ HttpTransact::perform_accept_encoding_filtering(State* s)
 void
 HttpTransact::StartRemapRequest(State* s)
 {
-  
+
   if (s->api_skip_all_remapping) {
     Debug ("http_trans", "API request to skip remapping");
 
@@ -766,7 +766,7 @@ HttpTransact::StartRemapRequest(State* s)
 
     TRANSACT_RETURN(SM_ACTION_POST_REMAP_SKIP, HttpTransact::HandleRequest);
   }
-  
+
   DebugTxn("http_trans", "START HttpTransact::StartRemapRequest");
 
   /**
@@ -842,7 +842,7 @@ HttpTransact::EndRemapRequest(State* s)
   int host_len;
   const char *host = incoming_request->host_get(&host_len);
   DebugTxn("http_trans","EndRemapRequest host is %.*s", host_len,host);
-  
+
   ////////////////////////////////////////////////////////////////
   // if we got back a URL to redirect to, vector the user there //
   ////////////////////////////////////////////////////////////////
@@ -956,9 +956,9 @@ done:
   /*
     if s->reverse_proxy == false, we can assume remapping failed in some way
       -however-
-    If an API setup a tunnel to fake the origin or proxy's response we will 
+    If an API setup a tunnel to fake the origin or proxy's response we will
     continue to handle the request (as this was likely the plugin author's intent)
-    
+
     otherwise, 502/404 the request right now. /eric
   */
   if (!s->reverse_proxy && s->state_machine->plugin_tunnel_type == HTTP_NO_PLUGIN_TUNNEL) {
@@ -1355,7 +1355,7 @@ HttpTransact::HandleRequest(State* s)
     // origin server. Ignore the no_dns_just_forward_to_parent setting.
     // we need to see if the hostname is an
     //   ip address since the parent selection code result
-    //   could change as a result of this ip address    
+    //   could change as a result of this ip address
     IpEndpoint addr;
     ats_ip_pton(s->server_info.name, &addr);
     if (ats_is_ip(&addr)) {
@@ -1469,9 +1469,9 @@ HttpTransact::HandleApiErrorJump(State* s)
     s->hdr_info.client_response.fields_clear();
     s->source = SOURCE_INTERNAL;
   }
-  
-  /** 
-    The API indicated an error. Lets use a >=400 error from the state (if one's set) or fallback to a 
+
+  /**
+    The API indicated an error. Lets use a >=400 error from the state (if one's set) or fallback to a
     generic HTTP/1.X 500 INKApi Error
   **/
   if ( s->http_return_code && s->http_return_code >= HTTP_STATUS_BAD_REQUEST ) {
@@ -1482,7 +1482,7 @@ HttpTransact::HandleApiErrorJump(State* s)
   else {
     build_response(s, &s->hdr_info.client_response, s->client_info.http_version,
                    HTTP_STATUS_INTERNAL_SERVER_ERROR, "INKApi Error");
-  }  
+  }
 
   TRANSACT_RETURN(SM_ACTION_INTERNAL_CACHE_NOOP, NULL);
   return;
@@ -3118,9 +3118,9 @@ HttpTransact::HandleICPLookup(State* s)
     // TODO in this case we should go to the miss case
     // just a little shy about using goto's, that's all.
     ink_release_assert(
-        (s->icp_info.port != s->client_info.port) || 
+        (s->icp_info.port != s->client_info.port) ||
         (ats_ip_addr_cmp(&s->icp_info.addr.sa, &Machine::instance()->ip.sa) != 0)
-    );        
+    );
 
     // Since the ICPDNSLookup is not called, these two
     //   values are not initialized.
@@ -3696,7 +3696,7 @@ void
 HttpTransact::delete_server_rr_entry(State* s, int max_retries)
 {
   char addrbuf[INET6_ADDRSTRLEN];
-  
+
   DebugTxn("http_trans", "[%d] failed to connect to %s", s->current.attempts,
         ats_ip_ntop(&s->current.server->addr.sa, addrbuf, sizeof(addrbuf)));
   DebugTxn("http_trans", "[delete_server_rr_entry] marking rr entry " "down and finding next one");
@@ -7641,6 +7641,13 @@ HttpTransact::build_request(State* s, HTTPHdr* base_request, HTTPHdr* outgoing_r
   handle_request_keep_alive_headers(s, outgoing_version, outgoing_request);
   HttpTransactHeaders::handle_conditional_headers(&s->cache_info, outgoing_request);
 
+#ifdef TS_HAS_UUID
+  if ( s->state_machine->should_add_uuid_to_request() ) {
+    Debug("http_trans", "Adding UUID header to proxy's request.");
+    s->state_machine->add_uuid_header(outgoing_request);
+  }
+#endif
+
   if (s->next_hop_scheme < 0)
     s->next_hop_scheme = URL_WKSIDX_HTTP;
   if (s->orig_scheme < 0)
@@ -7777,7 +7784,7 @@ HttpTransact::build_response(State* s, HTTPHdr* base_response, HTTPHdr* outgoing
       //  before processing the keep_alive headers
       //
       handle_content_length_header(s, outgoing_response, base_response);
-    } else
+    } else {
       switch (status_code) {
       case HTTP_STATUS_NOT_MODIFIED:
         HttpTransactHeaders::build_base_response(outgoing_response, status_code, reason_phrase, strlen(reason_phrase),
@@ -7833,7 +7840,15 @@ HttpTransact::build_response(State* s, HTTPHdr* base_response, HTTPHdr* outgoing
         // ink_assert(!"unexpected status code in build_response()");
         break;
       }
+    }
   }
+
+#ifdef TS_HAS_UUID
+  if ( s->state_machine->should_add_uuid_to_response() ) {
+	Debug("http_hdrs", "Adding UUID header to response.");
+	s->state_machine->add_uuid_header(outgoing_response);
+  }
+#endif
 
   // the following is done whether base_response == NULL or not
 
@@ -8096,9 +8111,9 @@ HttpTransact::build_error_response(State *s, HTTPStatus status_code, const char 
   if (s->http_config_param->errors_log_error_pages && status_code >= HTTP_STATUS_BAD_REQUEST) {
     char ip_string[INET6_ADDRSTRLEN];
 
-    Log::error("RESPONSE: sent %s status %d (%s) for '%s'", 
-        ats_ip_ntop(&s->client_info.addr.sa, ip_string, sizeof(ip_string)), 
-        status_code, 
+    Log::error("RESPONSE: sent %s status %d (%s) for '%s'",
+        ats_ip_ntop(&s->client_info.addr.sa, ip_string, sizeof(ip_string)),
+        status_code,
         reason_phrase,
         (url_string ? url_string : "<none>"));
   }
@@ -8163,7 +8178,7 @@ HttpTransact::build_redirect_response(State* s)
   s->internal_msg_buffer = body_factory->fabricate_with_old_api_build_va("redirect#moved_temporarily", s, 8192,
                                                                          &s->internal_msg_buffer_size,
                                                                          body_language, sizeof(body_language),
-                                                                         body_type, sizeof(body_type), 
+                                                                         body_type, sizeof(body_type),
                                                                          "%s <a href=\"%s\">%s</a>.  %s.",
                                                                          "The document you requested is now",
                                                                          new_url, new_url,
@@ -8462,7 +8477,7 @@ HttpTransact::client_result_stat(State* s, ink_hrtime total_time, ink_hrtime req
     default: break;
     }
   }
-  
+
   // Increment the completed connection count
   HTTP_INCREMENT_TRANS_STAT(http_completed_requests_stat);
 

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -576,6 +576,15 @@ Log::init_fields()
   global_field_list.add(field, false);
   ink_hash_table_insert(field_symbol_hash, "pfsc", field);
 
+#ifdef TS_HAS_UUID
+  field = new LogField("proxy_uuid", "uuid",
+                       LogField::STRING,
+                       &LogAccess::marshal_proxy_uuid,
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
+  global_field_list.add(field, false);
+  ink_hash_table_insert(field_symbol_hash, "uuid", field);
+#endif
+
   Ptr<LogFieldAliasTable> cache_code_map = make_ptr(new LogFieldAliasTable);
   cache_code_map->init(49,
                        SQUID_LOG_EMPTY, "UNDEFINED",

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -301,6 +301,15 @@ LogAccess::marshal_cache_result_code(char *buf)
   -------------------------------------------------------------------------*/
 
 int
+LogAccess::marshal_proxy_uuid(char *buf)
+{
+  DEFAULT_STR_FIELD;
+}
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+int
 LogAccess::marshal_proxy_req_header_len(char *buf)
 {
   DEFAULT_INT_FIELD;

--- a/proxy/logging/LogAccess.h
+++ b/proxy/logging/LogAccess.h
@@ -196,6 +196,7 @@ public:
   inkcoreapi virtual int marshal_proxy_resp_header_len(char *); // INT
   inkcoreapi virtual int marshal_proxy_finish_status_code(char *);      // INT
   inkcoreapi virtual int marshal_cache_result_code(char *);     // INT
+  inkcoreapi virtual int marshal_proxy_uuid(char *);                    // STR
 
   //
   // proxy -> server fields

--- a/proxy/logging/LogAccessHttp.cc
+++ b/proxy/logging/LogAccessHttp.cc
@@ -122,6 +122,7 @@ LogAccessHttp::init()
       }
     }
   }
+
   if (hdr->server_request.valid()) {
     m_proxy_request = &(hdr->server_request);
   }
@@ -707,6 +708,22 @@ LogAccessHttp::marshal_cache_result_code(char *buf)
   }
   return INK_MIN_ALIGN;
 }
+
+#ifdef TS_HAS_UUID
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+int
+LogAccessHttp::marshal_proxy_uuid(char *buf)
+{
+  int len = 36 + 1;
+  if (buf) {
+    m_proxy_uuid_str = m_http_sm->get_uuid();
+    marshal_mem(buf, m_proxy_uuid_str, 36, len);
+  }
+  return len;
+}
+#endif
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/

--- a/proxy/logging/LogAccessHttp.h
+++ b/proxy/logging/LogAccessHttp.h
@@ -82,6 +82,7 @@ public:
   virtual int marshal_proxy_resp_header_len(char *);    // INT
   virtual int marshal_proxy_finish_status_code(char *); // INT
   virtual int marshal_cache_result_code(char *);        // INT
+  virtual int marshal_proxy_uuid(char *);               // STR
 
   //
   // proxy -> server fields
@@ -169,6 +170,7 @@ private:
   int m_client_req_url_path_len;
   char *m_proxy_resp_content_type_str;
   int m_proxy_resp_content_type_len;
+  const char *m_proxy_uuid_str;
 
   void validate_unmapped_url(void);
   void validate_unmapped_url_path(void);

--- a/proxy/logging/LogAccessICP.cc
+++ b/proxy/logging/LogAccessICP.cc
@@ -186,6 +186,23 @@ LogAccessICP::marshal_proxy_resp_content_type(char *buf)
   return len;
 }
 
+#ifdef TS_HAS_UUID
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+int
+LogAccessICP::marshal_proxy_uuid(char *buf)
+{
+  // On ICP messages we don't have an UUID, so leave the field blank.
+  if (buf) {
+    marshal_mem(buf, "-", 1, 2);
+  }
+  return 2;
+}
+#endif
+
+
+
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 


### PR DESCRIPTION
While debugging the plugins we've written, we sometimes had trouble
correlating the log messages to one specific request. That is, suppose
thread 1 was executing plugin A, while thread 2 was also executing
plugin A, but for another request. Then the messages on traffic.out
would be intermingled and separating them was sometimes hard. The same
issue would happen if we wanted to correlate messages from the Core
with messages from the plugin, or when trying to correlate plugin A
messages with plugin B messages for the same request.

The solution we came up with was to patch the HttpSM to generate a
Unique Identifier, and expose it to the plugins. Then we created a
script to grep the traffic.out log for this UUID, resulting in
something like this:

1. Issue request:
$ curl -i --proxy 127.0.0.1:8080 'http://a.com/'
HTTP/1.1 200 OK
...
X-Azion-UUID: a7555903-0939-41ab-bc29-2c02ee80e19a
...

2. Get logs using a script to grep traffic.out:
$ getlog.sh a7555903-0939-41ab-bc29-2c02ee80e19a
======== [Sep 1 21:05:07.394] ========
Client IP: [127.0.0.1].
Current Tier: [Slaves]
Chosen origin server: [127.0.0.1:1025].
Orignal scheme [http]
Orignal host [a.com]
Host set to [www.example.com]. Scheme set to [http]
Sending Request.
Got Response [404]. Falling back.
Current Tier: [Master]
Chosen origin server: [127.0.0.1:1026].
Host set to [a.com]. Scheme set to [http]
Sending Request.
Got Response [200]. Delivering to client.
======== [Sep 1 21:05:07.398] ========


This ID has proved very useful while debugging several issues, not to
mention that it helped us to understand how the Core was handling the
requests, so we thought it could be useful for others, and decided to
create this pull request.

As we understand that not everyone would like to use it, we've added a
configure flag, namely, --enable-uuid, to turn the feature on/off at
compile time. Also, as we understand that this feature is useful for
debugging only, we've added options to records.config that allow it to
be turned off:

CONFIG proxy.config.http.use_uuid INT 1
CONFIG proxy.config.http.add_uuid_to_response INT 1
CONFIG proxy.config.http.add_uuid_to_request INT 1
CONFIG proxy.config.http.uuid_header_name STRING X-Azion-UUID

The first one allows to turn the feature on or off. The second adds
the UUID to the client's response, using the header specified on
uuid_header_name. The third one add this header to the proxy's
request. This last feature is useful when the origin server
understands the ID and logs it on its own logs, so one can correlate
ATS logs for one request with origin's logs for the same request.