### PR TITLE
TS-3059 Add missing TSTextLogObjectRollingSizeMbSet API function.

### DIFF
--- a/doc/reference/api/TSTextLogObjectCreate.en.rst
+++ b/doc/reference/api/TSTextLogObjectCreate.en.rst
@@ -36,6 +36,7 @@ Synopsis
 .. function:: TSReturnCode TSTextLogObjectRollingEnabledSet(TSTextLogObject the_object, int rolling_enabled)
 .. function:: void TSTextLogObjectRollingIntervalSecSet(TSTextLogObject the_object, int rolling_interval_sec)
 .. function:: void TSTextLogObjectRollingOffsetHrSet(TSTextLogObject the_object, int rolling_offset_hr)
+.. function:: void TSTextLogObjectRollingSizeMbSet(TSTextLogObject the_object, int rolling_size_mb)
 
 Description
 ===========

--- a/doc/sdk/plugin-management/guide-to-the-logging-api.en.rst
+++ b/doc/sdk/plugin-management/guide-to-the-logging-api.en.rst
@@ -41,6 +41,9 @@ The logging API enables you to:
 -  Set the rolling offset for your custom text log: see
    :c:func:`TSTextLogObjectRollingOffsetHrSet`
 
+-  Set the rolling size for your custom text log: see
+   :c:func:`TSTextLogObjectRollingSizeMbSet`
+
 -  Write text entries to the custom text log: see
    :c:func:`TSTextLogObjectWrite`
 

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -6901,6 +6901,14 @@ TSTextLogObjectRollingOffsetHrSet(TSTextLogObject the_object, int rolling_offset
   ((TextLogObject *) the_object)->set_rolling_offset_hr(rolling_offset_hr);
 }
 
+void
+TSTextLogObjectRollingSizeMbSet(TSTextLogObject the_object, int rolling_size_mb)
+{
+  sdk_assert(sdk_sanity_check_iocore_structure(the_object) == TS_SUCCESS);
+
+  ((TextLogObject *) the_object)->set_rolling_size_mb(rolling_size_mb);
+}
+
 TSReturnCode
 TSHttpSsnClientFdGet(TSHttpSsn ssnp, int *fdp)
 {

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -2126,6 +2126,13 @@ extern "C"
   tsapi void TSTextLogObjectRollingOffsetHrSet(TSTextLogObject the_object, int rolling_offset_hr);
 
   /**
+      Set the rolling size. rolling_size_mb specifies the size in MB when log rolling
+      should take place.
+
+   */
+  tsapi void TSTextLogObjectRollingSizeMbSet(TSTextLogObject the_object, int rolling_size_mb);
+
+  /**
       Async disk IO read
 
       @return TS_SUCCESS or TS_ERROR.


### PR DESCRIPTION
Trivial patch for TS-3059 to add the missing TSTextLogObjectRollingSizeMbSet API function.
