### PR TITLE
proxy.config.stack_dump_enabled

### DIFF
--- a/doc/sdk/troubleshooting-tips/using-a-debugger.en.rst
+++ b/doc/sdk/troubleshooting-tips/using-a-debugger.en.rst
@@ -29,6 +29,16 @@ the core files in the :file:`records.config` file to -1 as follows:
 
 This is the equivalent of setting ``ulimit -c unlimited``
 
+Also, if you want to generate a core dump, you must set the variable:
+
+::
+
+    CONFIG proxy.config.stack_dump_enabled INT 0
+
+If this variable is set to 1, ATS will handle the SIGSEGV signal and
+print the backtrace to traffic.out, preventing the core file from being
+generated.
+
 Debugging Tips:
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
While debugging the issues we've had with ATS, we needed to generate core files, but by default ATS handles the SIGSEGV signal and prints the backtrace to traffic.out. We've find out, though, that there's a config setting that disables this behavior, allowing core files to be generated, and decided we should add this information to the doc as others, specially newcomers to ATS, may find it useful. 
