### PR TITLE
Fix mysql remap's build files

### DIFF
--- a/plugins/experimental/mysql_remap/Makefile.am
+++ b/plugins/experimental/mysql_remap/Makefile.am
@@ -17,5 +17,21 @@
 include $(top_srcdir)/build/plugins.mk
 
 pkglib_LTLIBRARIES = mysql_remap.la
+noinst_LTLIBRARIES = libmysql_remap.la
+
+AM_CPPFLAGS += \
+  -I$(srcdir)/lib
+
+if BUILD_HAVE_LIBCXX
+AM_CXXFLAGS += -stdlib=libc++
+endif
+
+
 mysql_remap_la_SOURCES = mysql_remap.cc
-mysql_remap_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS) $(LIB_MYSQLCLIENT)
+
+libmysql_remap_la_SOURCES = \
+  lib/dictionary.cc \
+  lib/iniparser.cc
+
+mysql_remap_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS) $(LIB_MYSQLCLIENT) -no-undefined
+mysql_remap_la_LIBADD = libmysql_remap.la


### PR DESCRIPTION
The current build files produce a binary that has undefined symbols
(relating to the modules in lib/). To include these symbols, need to use
the `-no-undefined` flag.

Other structural changes make mysql remap look like other modules that
use a lib directory.
