### PR TITLE
TS-3160 fix problem of mis-closing fd before forking traffic_manager

### DIFF
--- a/cmd/traffic_cop/traffic_cop.cc
+++ b/cmd/traffic_cop/traffic_cop.cc
@@ -1823,9 +1823,9 @@ main(int /* argc */, char *argv[])
       fcntl(fd, F_DUPFD, STDOUT_FILENO);
       fcntl(fd, F_DUPFD, STDERR_FILENO);
 
-	  if (fd != STDIN_FILENO && fd != STDOUT_FILENO && fd != STDERR_FILENO){
-		close(fd);
-	  }
+      if (fd != STDIN_FILENO && fd != STDOUT_FILENO && fd != STDERR_FILENO) {
+        close(fd);
+      }
     } else {
       ink_fputln(stderr, "Unable to open /dev/null");
       return 0;

--- a/cmd/traffic_cop/traffic_cop.cc
+++ b/cmd/traffic_cop/traffic_cop.cc
@@ -1822,7 +1822,10 @@ main(int /* argc */, char *argv[])
       fcntl(fd, F_DUPFD, STDIN_FILENO);
       fcntl(fd, F_DUPFD, STDOUT_FILENO);
       fcntl(fd, F_DUPFD, STDERR_FILENO);
-      close(fd);
+
+	  if (fd != STDIN_FILENO && fd != STDOUT_FILENO && fd != STDERR_FILENO){
+		close(fd);
+	  }
     } else {
       ink_fputln(stderr, "Unable to open /dev/null");
       return 0;


### PR DESCRIPTION
In traffic_cop 'main' function, before it forks traffic_manager, it will first close stdin, stdout, and stderr and then redirect them to /dev/null.
But when it closes the fd opened by /dev/null, it doesn't check whether the fd is 0, 1 or 2. So, in current code logic, the fd may be 1, and after close it, later opened file will uses the fd 1, and printf will corrupt that file.
1826 if (!stdout_flag) {
1827 close(STDIN_FILENO);
1828 close(STDOUT_FILENO);
1829 close(STDERR_FILENO);
1830 if ((fd = open("/dev/null", O_WRONLY, 0)) >= 0)
{ 1831 fcntl(fd, F_DUPFD, STDIN_FILENO); 1832 fcntl(fd, F_DUPFD, STDOUT_FILENO); 1833 fcntl(fd, F_DUPFD, STDERR_FILENO); 1834 close(fd); //zouyu this doesn't check the fd value 0, 1 or 2. 1835 }
else
{ 1836 ink_fputln(stderr, "Unable to open /dev/null"); 1837 return 0; 1838 }
1839 }