### PR TITLE
Add initial python-based functional test framework with example test

### DIFF
--- a/tests/example/config.json
+++ b/tests/example/config.json
@@ -6,7 +6,7 @@
             "interfaces": {
                 "http": {
                     "type": "http",
-                    "hostname": "localhost",
+                    "hostname": "127.0.0.1",
                     "port": 8080
                 }
             },
@@ -19,7 +19,7 @@
                 ],
                 "remap.config": [
                     {
-                        "append": "map / http://localhost:8082"
+                        "append": "map / http://127.0.0.1:8082"
                     }
                 ]
             }
@@ -29,7 +29,7 @@
             "interfaces": {
                 "http": {
                     "type": "http",
-                    "hostname": "localhost",
+                    "hostname": "127.0.0.1",
                     "port": 8082
                 }
             },

--- a/tests/example/config.json
+++ b/tests/example/config.json
@@ -1,0 +1,118 @@
+{
+    "processes": {
+        "ats1": {
+            "type": "ats",
+            "root": "ats1",
+            "interfaces": {
+                "http": {
+                    "type": "http",
+                    "hostname": "localhost",
+                    "port": 8080
+                }
+            },
+            "config": {
+                "records.config": [
+                    {
+                        "match": "^CONFIG proxy.config.diags.debug.enabled",
+                        "substitute": "CONFIG proxy.config.diags.debug.enabled INT 0"
+                    }
+                ],
+                "remap.config": [
+                    {
+                        "append": "map /foo/bar http://localhost:8082/foo/bar"
+                    }
+                ]
+            }
+        },
+        "origin1": {
+            "type": "origin",
+            "interfaces": {
+                "http": {
+                    "type": "http",
+                    "hostname": "localhost",
+                    "port": 8082
+                }
+            },
+            "actions": {
+                "GET": {
+                    "/foo/bar": {
+                        "type": "chunkedresponse",
+                        "status_code": 200,
+                        "headers": {
+                            "content-type": "text/plain"
+                        },
+                        "delay_first_chunk_sec": 1,
+                        "chunk_size_bytes": 1024,
+                        "num_chunks": 10,
+                        "delay_between_chunk_sec": 0,
+                        "chunk_byte_value": 99
+                    }
+                }
+            }
+        },
+        "python1": {
+            "type": "python",
+            "spawn": false,
+            "script": "../framework/origin.py",
+            "args": [
+                "python1",
+                "config.json"
+            ],
+            "interfaces": {
+                "http": {
+                    "type": "http",
+                    "hostname": "localhost",
+                    "port": 8082
+                }
+            },
+            "actions": {
+                "GET": {
+                    "/foo/bar": {
+                        "type": "chunkedresponse",
+                        "status_code": 200,
+                        "headers": {
+                            "content-type": "text/plain"
+                        },
+                        "delay_first_chunk_sec": 1,
+                        "chunk_size_bytes": 1024,
+                        "num_chunks": 10,
+                        "delay_between_chunk_sec": 0,
+                        "chunk_byte_value": 99
+                    }
+                }
+            }
+        },
+        "other1": {
+            "type": "other",
+            "spawn": false,
+            "executable": "../framework/origin.py",
+            "args": [
+                "python1",
+                "config.json"
+            ],
+            "interfaces": {
+                "http": {
+                    "type": "http",
+                    "hostname": "localhost",
+                    "port": 8082
+                }
+            },
+            "actions": {
+                "GET": {
+                    "/foo/bar": {
+                        "type": "chunkedresponse",
+                        "status_code": 200,
+                        "headers": {
+                            "content-type": "text/plain"
+                        },
+                        "delay_first_chunk_sec": 1,
+                        "chunk_size_bytes": 1024,
+                        "num_chunks": 10,
+                        "delay_between_chunk_sec": 0,
+                        "chunk_byte_value": 99
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/example/config.json
+++ b/tests/example/config.json
@@ -19,7 +19,7 @@
                 ],
                 "remap.config": [
                     {
-                        "append": "map /foo/bar http://localhost:8082/foo/bar"
+                        "append": "map / http://localhost:8082"
                     }
                 ]
             }
@@ -35,7 +35,7 @@
             },
             "actions": {
                 "GET": {
-                    "/foo/bar": {
+                    "/chunked/down": {
                         "type": "chunkedresponse",
                         "status_code": 200,
                         "headers": {
@@ -47,67 +47,17 @@
                         "delay_between_chunk_sec": 0,
                         "chunk_byte_value": 99
                     }
-                }
-            }
-        },
-        "python1": {
-            "type": "python",
-            "spawn": false,
-            "script": "../framework/origin.py",
-            "args": [
-                "python1",
-                "config.json"
-            ],
-            "interfaces": {
-                "http": {
-                    "type": "http",
-                    "hostname": "localhost",
-                    "port": 8082
-                }
-            },
-            "actions": {
-                "GET": {
-                    "/foo/bar": {
+                },
+                "POST": {
+                    "/nonchunked/up": {
                         "type": "chunkedresponse",
                         "status_code": 200,
                         "headers": {
                             "content-type": "text/plain"
                         },
-                        "delay_first_chunk_sec": 1,
+                        "delay_first_chunk_sec": 0,
                         "chunk_size_bytes": 1024,
-                        "num_chunks": 10,
-                        "delay_between_chunk_sec": 0,
-                        "chunk_byte_value": 99
-                    }
-                }
-            }
-        },
-        "other1": {
-            "type": "other",
-            "spawn": false,
-            "executable": "../framework/origin.py",
-            "args": [
-                "python1",
-                "config.json"
-            ],
-            "interfaces": {
-                "http": {
-                    "type": "http",
-                    "hostname": "localhost",
-                    "port": 8082
-                }
-            },
-            "actions": {
-                "GET": {
-                    "/foo/bar": {
-                        "type": "chunkedresponse",
-                        "status_code": 200,
-                        "headers": {
-                            "content-type": "text/plain"
-                        },
-                        "delay_first_chunk_sec": 1,
-                        "chunk_size_bytes": 1024,
-                        "num_chunks": 10,
+                        "num_chunks": 1,
                         "delay_between_chunk_sec": 0,
                         "chunk_byte_value": 99
                     }

--- a/tests/example/httplib_test.py
+++ b/tests/example/httplib_test.py
@@ -1,0 +1,46 @@
+import httplib
+import unittest
+import sys
+
+sys.path = ['../framework'] + sys.path
+import atstf
+
+class ExampleHttpClientTest(unittest.TestCase):
+    def test_get(self):
+        #
+        # Read test case configuration from the same config file used to start ATS and origin processes.
+        #
+
+        conf = atstf.parse_config()
+
+        ats1_conf = conf['processes']['ats1']
+
+        hostname = ats1_conf['interfaces']['http']['hostname']
+        port = ats1_conf['interfaces']['http']['port']
+
+        origin_conf = conf['processes']['origin1']
+
+        expected_status_code = origin_conf['actions']['GET']['/chunked/down']['status_code']
+        chunk_size_bytes = origin_conf['actions']['GET']['/chunked/down']['chunk_size_bytes']
+        num_chunks = origin_conf['actions']['GET']['/chunked/down']['num_chunks']
+        expected_bytes_received = chunk_size_bytes * num_chunks
+
+        #
+        # Send request to ATS and assert that the correct response is received
+        #
+
+        conn = httplib.HTTPConnection("%s:%d" % (hostname.encode("utf-8"), port))
+
+        try:
+            conn.request('GET', '/chunked/down')
+            response = conn.getresponse()
+
+            self.assertEqual(expected_status_code, response.status)
+
+            response_body = response.read()
+
+            self.assertEqual(expected_bytes_received, len(response_body))
+        finally:
+            conn.close()
+
+

--- a/tests/example/suite.py
+++ b/tests/example/suite.py
@@ -1,0 +1,28 @@
+#!/bin/env python
+
+import sys
+import logging
+
+sys.path = ['../framework'] + sys.path
+import atstf
+
+from twisted_test import ExampleTwistedTest
+
+test_cases = [ExampleTwistedTest]
+
+if __name__ == '__main__':
+    # Spawn ATS and origin processes
+
+    tm = atstf.ProcessManager(root_path="../..", config_path="config.json", log_level=logging.INFO, max_start_sec=5)
+
+    try:
+        tm.start()
+
+        # Run the test suite and generate a JUnit XML report
+
+        if atstf.run_tests(test_cases=test_cases, name='example', report='report.xml'):
+            sys.exit(0)
+        else:
+            sys.exit(1)
+    finally:
+        tm.stop()

--- a/tests/example/suite.py
+++ b/tests/example/suite.py
@@ -7,8 +7,9 @@ sys.path = ['../framework'] + sys.path
 import atstf
 
 from twisted_test import ExampleTwistedTest
+from httplib_test import ExampleHttpClientTest
 
-test_cases = [ExampleTwistedTest]
+test_cases = [ExampleTwistedTest, ExampleHttpClientTest]
 
 if __name__ == '__main__':
     # Spawn ATS and origin processes

--- a/tests/example/twisted_test.py
+++ b/tests/example/twisted_test.py
@@ -1,0 +1,121 @@
+import sys
+import unittest
+
+from twisted.internet import reactor
+from twisted.internet.defer import Deferred
+from twisted.internet.protocol import Protocol
+from twisted.web.client import Agent
+from twisted.web.http_headers import Headers
+
+sys.path = ['../framework'] + sys.path
+import atstf
+
+class ExampleTwistedTest(unittest.TestCase):
+    def test_ats1(self):
+        #
+        # Read test case configuration from the same config file used to start ATS and origin processes.
+        #
+
+        conf = atstf.parse_config()
+
+        ats1_conf = conf['processes']['ats1']
+
+        hostname = ats1_conf['interfaces']['http']['hostname']
+        port = ats1_conf['interfaces']['http']['port']
+
+        origin_conf = conf['processes']['origin1']
+
+        expected_status_code = origin_conf['actions']['GET']['/foo/bar']['status_code']
+        chunk_size_bytes = origin_conf['actions']['GET']['/foo/bar']['chunk_size_bytes']
+        num_chunks = origin_conf['actions']['GET']['/foo/bar']['num_chunks']
+        expected_bytes_received = chunk_size_bytes * num_chunks
+
+        #
+        # Create a twisted HTTP client that will interact with ATS and save all details of the interaction.   We'll
+        # later assert that the saved details are correct.   Ideally we'd just throw assertions into the client itself,
+        # but sadly assertions are implemented with exceptions and twisted eats any exception raised by our callbacks.
+        #
+        # See https://twistedmatrix.com/documents/current/web/howto/client.html for details on writing HTTP clients
+        #
+
+        agent = Agent(reactor)
+
+        request = agent.request('GET',  "http://%s:%d/foo/bar" % (hostname.encode("utf-8"), port),
+                                Headers({'User-Agent': ['ExampleTwistedTest']}), None)
+
+        response_handler = ResponseHandler(reactor)
+
+        request.addCallback(response_handler.handle_response)
+        request.addCallback(response_handler.handle_completion)
+        request.addErrback(response_handler.handle_error)
+
+        reactor.run()
+
+        #
+        # Now assert
+        #
+
+        self.assertEqual(expected_status_code, response_handler.get_status_code())
+        self.assertEqual(expected_bytes_received, response_handler.get_body_handler().get_bytes_received())
+        self.assertEqual("Response body fully received", \
+                         response_handler.get_body_handler().get_reason().getErrorMessage())
+
+class ResponseBodyHandler(Protocol):
+    def __init__(self, deferred):
+        self.__deferred = deferred
+        self.__bytes_received = 0
+        self.__reason = None
+
+    def dataReceived(self, data):
+        self.__bytes_received += len(data)
+
+    def connectionLost(self, reason):
+        #
+        # This function name is highly misleading.  According to the web client docs:
+        #
+        # When the body has been completely delivered, the protocol's connectionLost method is called. It is important
+        # to inspect the Failure passed to connectionLost . If the response body has been completely received, the
+        # failure will wrap a twisted.web.client.ResponseDone exception. This indicates that it is known that all data
+        # has been received. It is also possible for the failure to wrap a twisted.web.http.PotentialDataLoss exception:
+        # this indicates that the server framed the response such that there is no way to know when the entire response
+        # body has been received. Only HTTP/1.0 servers should behave this way. Finally, it is possible for the
+        # exception to be of another type, indicating guaranteed data loss for some reason (a lost connection, a memory
+        # error, etc).
+        #
+        self.__reason = reason
+        self.__deferred.callback(None)
+
+    def get_bytes_received(self):
+        return self.__bytes_received
+
+    def get_reason(self):
+        return self.__reason
+
+class ResponseHandler:
+    def __init__(self, reactor):
+        self.__reactor = reactor
+        self.__deferred = Deferred()
+        self.__body_handler = ResponseBodyHandler(self.__deferred)
+        self.__error = None
+        self.__status_code = None
+
+    def handle_response(self, response):
+        self.__status_code = response.code
+        response.deliverBody(self.__body_handler)
+        return self.__deferred
+
+    def handle_completion(self):
+        self.__reactor.stop()
+
+    def handle_error(self, error):
+        self.__error = error
+        self.__reactor.stop()
+
+    def get_body_handler(self):
+        return self.__body_handler
+
+    def get_error(self):
+        return self.__error
+
+    def get_status_code(self):
+        return self.__status_code

--- a/tests/framework/atstf.py
+++ b/tests/framework/atstf.py
@@ -1,0 +1,684 @@
+import os
+import atexit
+import signal
+import json
+import subprocess
+import threading
+import select
+import fcntl
+import logging
+import shutil
+import socket
+import time
+import unittest
+import re
+import fileinput
+
+class ProcessManager:
+    def __init__(self, **kwargs):
+        """Initialize..
+
+        :param kwargs:
+        root_path -- path to the ats project dir.  ats_path, origin_path and default_config_path are inferred from this
+        ats_path -- path to the traffic_sever binary
+        config_path --path to the ProcessManager's JSON config file.  Defaults to 'config.json' in cwd
+        origin_path -- only if origin proc type is used: path to the configurable origin script (origin.py)
+        default_config_path -- path to the *.config.default default config files and default body_factory files
+        max_start_sec -- max time in seconds to wait for all interfaces in the config file to come up before erroring
+        log_level - log level threshold from the python logging module (e.g,. logging.INFO)
+        """
+
+        self.__processes = {}  # process_name => same object as returned by process.Popen
+        self.__lock = threading.Lock()  # protects self.__processes
+        self.__is_running = False
+        self.__ats_path = None # path to proxy/traffic_server
+        self.__origin_path = None # path to tests/framework/origin.py
+        self.__default_config_path = None # path to proxy/config
+        self.__max_start_sec = 5
+
+        if kwargs.has_key('root_path'):
+            root_path = kwargs['root_path']
+            self.__ats_path = os.path.abspath(root_path + '/proxy/traffic_server')
+            self.__origin_path = os.path.abspath(root_path + '/tests/framework/origin.py')
+            self.__default_config_path = os.path.abspath(root_path + '/proxy/config/')
+
+        if kwargs.has_key('ats_path'):
+            self.__ats_path = os.path.abspath(kwargs['ats_path'])
+
+        if kwargs.has_key('origin_path'):
+            self.__origin_path = os.path.abspath(kwargs['origin_path'])
+
+        if kwargs.has_key('default_config_path'):
+            self.__default_config_path = os.path.abspath(kwargs['default_config_path'])
+
+        if not self.__ats_path:
+            raise Exception("Test Manager must be initialized with 'root_path' or 'ats_path' keyword argument")
+
+        if kwargs.has_key('max_start_sec'):
+            self.__max_start_sec = kwargs['max_start_sec']
+
+        if kwargs.has_key('config_path'):
+            self.__config_path = os.path.abspath(os.getcwd() + '/' + kwargs['config_path'])
+        elif os.path.isfile('config.json'):
+            self.__config_path = os.path.abspath(os.getcwd() + '/config.json')
+        else:
+            raise Exception("Test Manager must be initialized with 'config_path' keyword argument")
+
+        self.__conf = self.__validate_conf(json.load(open(self.__config_path, 'r'), encoding='utf-8'))
+
+        self.__logger = logging.getLogger()
+
+        if kwargs.has_key('log_level'):
+            # If the caller has already configured a handler, use it.   Else add a console handler.
+            self.__logger.setLevel(kwargs['log_level'])
+            handlers = self.__logger.handlers
+            if not handlers:
+                handler = logging.StreamHandler()
+                handler.setFormatter(logging.Formatter("%(levelname)s %(asctime)-15s - %(message)s"))
+                self.__logger.addHandler(handler)
+
+        # Any keyword arg that ends in a '.config' is a config file overlay
+
+        # proxy/config/ssl_multicert.config.default
+
+        atexit.register(self.__shutdown)
+
+
+    def start(self):
+        """ Start all processes defined in the configuration file and wait for them to start """
+
+        signal.signal(signal.SIGTERM, self.__signal_handler)
+        signal.signal(signal.SIGINT, self.__signal_handler)
+
+        if not self.__conf['processes']:
+            return
+
+        #
+        # This consists of two threads.  This thread will walk the config file and determine all interfaces
+        # that will be opened by child processes.   This thread will return once it can connect to all of them.
+        #
+        # This thread also creates a background thread.   The background thread is responsible for actually
+        # starting the child processes, relaying their stdout/stderr to the logging callback (the main reason why we
+        # need a background thread), and alerting if any child process dies prematurely.
+        #
+
+        # Spawn the background thread
+
+        self.__background_thread = threading.Thread(target=self.__background_thread)
+        self.__background_thread.setDaemon(True)
+        self.__is_running = True
+        self.__background_thread.start()
+
+        # Consider a service 'started' once we can connect to all of its hostnames and ports
+
+        self.__wait_for_interfaces()
+
+    def stop(self):
+        """ Stop all processes spawned by the start function, do not wait for them to exit """
+        self.__shutdown()
+
+    def __signal_handler(self, signum, frame):
+        #sys.exit(0)
+        os._exit(0)
+
+    def __shutdown(self):
+        if self.__logger and self.__logger.isEnabledFor(logging.DEBUG):
+            self.__logger.debug("Shutting down")
+
+        self.__is_running = False
+
+        try:
+            self.__background_thread.join()
+        except:
+            # Can happen if the background thread is already dead
+            pass
+
+        with self.__lock:
+            for process_name, process in self.__processes.iteritems():
+                if self.__logger and self.__logger.isEnabledFor(logging.DEBUG):
+                    self.__logger.debug("Killing process '%s', pid=%d", process_name, process.pid)
+                process.kill()
+            self.__processes = {}
+
+    def __validate_conf(self, conf):
+        """ Fixup conf file or throw exception if something in the conf file cannot be fixed up.
+        :param conf: The input conf file
+        :return: The fixed up conf file
+        """
+
+        if not conf.has_key('processes'):
+            conf['processes'] = {}
+            return conf
+
+        for process_name, process_conf in conf['processes'].iteritems():
+            if not process_conf.has_key('type'):
+                raise Exception("Process '%s' is missing 'type'" % process_name)
+
+            type = process_conf['type']
+
+            if not process_conf.has_key('interfaces'):
+                process_conf['interfaces'] = {}
+
+            interfaces = process_conf['interfaces']
+
+            # Don't validate config for items that have been disabled
+
+            if process_conf.has_key('spawn') and not process_conf['spawn']:
+                continue
+
+            # Validate interfaces
+
+            for interface_name, interface_conf in interfaces.iteritems():
+                if not interface_conf.has_key('hostname'):
+                    raise Exception("Interface '%s:%s' is missing 'hostname'" % (process_name, interface_name))
+
+                if not interface_conf.has_key('port'):
+                    raise Exception("Interface '%s:%s' is missing 'port'" % (process_name, interface_name))
+
+            # Do type-specific validation
+
+            if 'ats' == type:
+                self.__validate_ats_conf(process_name, process_conf)
+            elif 'python' == type:
+                self.__validate_python_conf(process_name, process_conf)
+            elif 'origin' == type:
+                self.__validate_origin_conf(process_name, process_conf)
+            elif 'other' == type:
+                self.__validate_other_conf(process_name, process_conf)
+            else:
+                raise Exception("Process '%s' has unknown type '%s" % (process_name, type))
+
+        return conf
+
+    def __background_thread(self):
+        try:
+            for process_name, process_conf in self.__conf['processes'].iteritems():
+                type = process_conf['type']
+
+                if process_conf.has_key('spawn') and not process_conf['spawn']:
+                    continue
+
+                # Do type-specific validation
+
+                if 'ats' == type:
+                    process = self.__start_ats(process_name, process_conf)
+                elif 'python' == type:
+                    process = self.__start_python(process_name, process_conf)
+                elif 'origin' == type:
+                    process = self.__start_origin(process_name, process_conf)
+                elif 'other' == type:
+                    process = self.__start_other(process_name, process_conf)
+                else:
+                    # defensive, should be caught by validation code
+                    raise Exception("Process '%s' has unknown type '%s" % (process_name, type))
+
+                if process:
+                    with self.__lock:
+                        self.__processes[process_name] = process
+
+            # monitor children and relay their output
+
+            poll = select.poll()
+            process_fds = {}  # map of fd to process_name
+
+            with self.__lock:
+                for process_name, process in self.__processes.iteritems():
+                    stdout_fd = process.stdout.fileno()
+                    stderr_fd = process.stderr.fileno()
+
+                    # non-blocking io
+                    flags = fcntl.fcntl(stdout_fd, fcntl.F_GETFL, 0)
+                    fcntl.fcntl(stdout_fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+                    flags = fcntl.fcntl(stderr_fd, fcntl.F_GETFL, 0)
+                    fcntl.fcntl(stderr_fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+                    # remember mapping of fd back to process name so we can later find the process object
+                    process_fds[stdout_fd] = process_name
+                    process_fds[stderr_fd] = process_name
+
+                    # always interested in read, error, and close events
+                    poll.register(stdout_fd, select.POLLIN | select.POLLERR | select.POLLHUP | select.POLLPRI)
+                    poll.register(stderr_fd, select.POLLIN | select.POLLERR | select.POLLHUP | select.POLLPRI)
+
+            while self.__is_running:
+                events = poll.poll(100) # 100 milliseconds
+
+                if not self.__is_running:
+                    break
+
+                if not events:
+                    continue
+
+                for fd, flag in events:
+                    if not process_fds.has_key(fd):
+                        # already removed, late poll event
+                        continue
+
+                    process_name = process_fds[fd]
+
+                    with self.__lock:
+                        if not self.__processes.has_key(process_name):
+                            # already removed by shutdown event
+                            return
+                        process = self.__processes[process_name]
+
+                    if flag & (select.POLLIN | select.POLLPRI):
+                        buffer = os.read(fd, 32 * 1024)
+
+                        if not buffer:
+                            if self.__logger and self.__logger.isEnabledFor(logging.ERROR):
+                                self.__logger.error("%s: process closed pipe prematurely, killing", process_name)
+                            self.__cleanup_process(process_name, process, poll, process_fds)
+
+                        buffer = buffer.rstrip()
+
+                        if buffer:
+                            if fd == process.stderr.fileno():
+                                if self.__logger and self.__logger.isEnabledFor(logging.WARNING):
+                                    self.__logger.warn("%s: %s" % (process_name, buffer))
+                            elif fd == process.stdout.fileno():
+                                if self.__logger and self.__logger.isEnabledFor(logging.INFO):
+                                    self.__logger.info("%s: %s" % (process_name, buffer))
+
+                    elif flag & select.POLLERR:
+                        if self.__logger and self.__logger.isEnabledFor(logging.ERROR):
+                            self.__logger.error("%s: error reading from process pipe, killing", process_name)
+                        self.__cleanup_process(process_name, process, poll, process_fds)
+
+                    elif flag & select.POLLHUP:
+                        if self.__logger and self.__logger.isEnabledFor(logging.ERROR):
+                            self.__logger.error("%s: process closed pipe prematurely, killing", process_name)
+                        self.__cleanup_process(process_name, process, poll, process_fds)
+        except:
+            self.__shutdown()
+            raise
+
+
+    def __cleanup_process(self, process_name, process, poll, process_fds):
+        process.kill()
+
+        with self.__lock:
+            self.__processes.pop(process_name, None)
+
+        poll.unregister(process.stderr.fileno())
+        poll.unregister(process.stdout.fileno())
+        process_fds.pop(process.stderr.fileno(), None)
+        process_fds.pop(process.stdout.fileno(), None)
+
+    def __validate_ats_conf(self, process_name, process_conf):
+        if not process_conf.has_key('interfaces'):
+            raise Exception("Process '%s' must specify 1+ 'interfaces'", process_name)
+
+        if not process_conf.has_key('root'):
+            raise Exception("Process '%s' must specify a 'root'", process_name)
+
+    def __start_ats(self, process_name, process_conf):
+        if self.__logger and self.__logger.isEnabledFor(logging.DEBUG):
+            self.__logger.debug("Starting ATS process '%s'", process_name)
+
+        args = [self.__ats_path]
+
+        if process_conf.has_key('args'):
+            for arg in process_conf['args']:
+                args.append(str(arg))
+
+        interfaces = process_conf['interfaces']
+        root = process_conf['root']
+
+        # Build ats args
+
+        args.append('--httpport')
+        fd = 7
+
+        for interface_name, interface_conf in interfaces.iteritems():
+            port = interface_conf['port']
+
+            if interface_conf.has_key('type'):
+                type = interface_conf['type']
+            else:
+                raise Exception("Interface '%s:%s' is missing 'type'" % (process_name, interface_name))
+
+            if 'http' == type:
+                args.append("%d:fd=%d" % (port, fd));
+                fd += 1
+            else:
+                raise Exception("Interface '%s:%s' has unknown type '%s" % (process_name, interface_name, type))
+
+        # clean and recreate var dirs
+
+        cwd = os.getcwd()
+        ts_root = os.path.normpath(cwd + '/' + root)
+
+        self.__generate_ts_root(process_name, process_conf, ts_root)
+
+        # Spawn ATS.
+
+        env = os.environ.copy()
+        env['TS_ROOT'] = ts_root
+
+        if self.__logger and self.__logger.isEnabledFor(logging.DEBUG):
+            self.__logger.debug("Spawning ATS '%s' with TS_ROOT=%s", ' '.join(args), ts_root)
+
+        return subprocess.Popen(args, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=ts_root, \
+                                env=env, bufsize=0)
+
+    def __generate_ts_root(self, process_name, process_conf, ts_root):
+        # Clean and recreate ts_root
+
+        if os.path.isdir(ts_root):
+            shutil.rmtree(ts_root)
+
+        for dir in ['var/trafficserver', 'var/log/trafficserver', 'etc/trafficserver/body_factory']:
+            os.makedirs(ts_root + '/' + dir)
+
+        # Copy default config files
+
+        if process_conf.has_key('default_config_path'):
+            src_config_path = process_conf['default_config_path']
+        else:
+            src_config_path = self.__default_config_path
+
+        dst_config_path = ts_root + '/etc/trafficserver/'
+
+        for file in os.listdir(src_config_path):
+            if not file.endswith('.config.default'):
+                continue
+
+            shutil.copy(src_config_path + '/' + file, dst_config_path + os.path.splitext(file)[0])
+
+        # Copy default body factory
+
+        default_body_factory_path = src_config_path + '/body_factory/default/'
+
+        for file in os.listdir(default_body_factory_path):
+            if file.startswith('Makefile'):
+                continue
+
+            shutil.copy(default_body_factory_path + '/' + file, dst_config_path + '/body_factory/' + file)
+
+        # Apply transformations to the config files we just copied
+
+        if not process_conf.has_key('config'):
+            return
+
+        config = process_conf['config']
+
+        for file_name, transforms in config.iteritems():
+            src_file = dst_config_path + file_name
+
+            if not os.path.isfile(src_file):
+                raise Exception("Cannot transform non-existent config file '%s'" % src_file)
+
+            # Optimize data structure
+
+            substitutions = {}
+            appends = []
+
+            for transform in transforms:
+                if transform.has_key('match') and transform.has_key('substitute'):
+                    substitutions[re.compile(transform['match'])] = transform['substitute']
+
+                # if append, pull out and add to append list
+                if transform.has_key('append'):
+                    appends.append(transform['append'])
+
+            # Generate new config file, then move it over
+
+            dst_file =  src_file + '.tmp'
+            fp = open(dst_file, 'w')
+
+            try:
+                os.chmod(dst_file, 0555)
+
+                for line in fileinput.input(src_file):
+                    replaced = False
+                    for regex, substitution in substitutions.iteritems():
+                        if regex.match(line):
+                            replaced = True
+                            fp.write(substitution)
+                            fp.write('\n')
+                            break
+
+                    if not replaced:
+                        fp.write(line)
+
+                for append in appends:
+                    fp.write(append)
+                    fp.write('\n')
+            finally:
+                fp.close()
+
+            shutil.move(dst_file, src_file)
+
+    def __validate_python_conf(self, process_name, process_conf):
+        if not process_conf.has_key('script'):
+            raise Exception("Process '%s' must specify a 'script'", process_name)
+
+    def __start_python(self, process_name, process_conf):
+        args = ['python', process_conf['script']]
+
+        if process_conf.has_key('args'):
+            for arg in process_conf['args']:
+                args.append(str(arg))
+
+        if process_conf.has_key('cwd'):
+            cwd = process_conf['cwd']
+        else:
+            cwd = os.getcwd()
+
+        if self.__logger and self.__logger.isEnabledFor(logging.DEBUG):
+            self.__logger.debug("Spawning Python script '%s'", " ".join(args))
+
+        return subprocess.Popen(args, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd,
+                                env=os.environ, bufsize=0)
+
+    def __validate_origin_conf(self, process_name, process_conf):
+        if not self.__origin_path:
+            raise Exception("Test Manager must be initialized with 'root_path' or 'origin_path' keyword argument")
+
+        if not process_conf.has_key('interfaces'):
+            raise Exception("Process '%s' must specify 1+ 'interfaces'", process_name)
+
+        if not process_conf.has_key('actions'):
+            raise Exception("Process '%s' must specify 1+ 'actions'", process_name)
+
+    def __start_origin(self, process_name, process_conf):
+        if self.__logger and self.__logger.isEnabledFor(logging.DEBUG):
+            self.__logger.debug("Starting origin process '%s'", process_name)
+
+        args = ['python', self.__origin_path, process_name, self.__config_path]
+
+        if process_conf.has_key('cwd'):
+            cwd = process_conf['cwd']
+        else:
+            cwd = os.getcwd()
+
+        if self.__logger and self.__logger.isEnabledFor(logging.DEBUG):
+            self.__logger.debug("Spawning origin script: %s", ' '.join(args))
+
+        return subprocess.Popen(args, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd,
+                                env=os.environ, bufsize=0)
+
+
+    def __validate_other_conf(self, process_name, process_conf):
+        if not process_conf.has_key('executable'):
+            raise Exception("Process '%s' must specify an 'executable'", process_name)
+
+    def __start_other(self, process_name, process_conf):
+        args = [process_conf['executable']]
+
+        if process_conf.has_key('args'):
+            for arg in process_conf['args']:
+                args.append(str(arg))
+
+        if process_conf.has_key('cwd'):
+            cwd = process_conf['cwd']
+        else:
+            cwd = os.getcwd()
+
+        if self.__logger and self.__logger.isEnabledFor(logging.DEBUG):
+            self.__logger.debug("Starting other process '%s'", ' '.join(args))
+
+        return subprocess.Popen(args, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd,
+                                env=os.environ, bufsize=0)
+
+    def __wait_for_interfaces(self):
+        """ Block until we can connect to all interfaces specified in the conf file """
+
+        # Walk the config file and start all processes, remembering the hostnames and
+        # ports of all their interfaces in the process
+
+        hostports = []
+
+        for process_name, process_conf in self.__conf['processes'].iteritems():
+            type = process_conf['type']
+            interfaces = process_conf['interfaces']
+
+            if process_conf.has_key('spawn') and not process_conf['spawn']:
+                # Arguable, don't check interface if we are not responsible for starting the process
+                continue
+
+            for interface_name, interface_conf in interfaces.iteritems():
+                hostports.append({'process_name': process_name, 'hostname': interface_conf['hostname'],
+                                  'port': interface_conf['port']})
+
+
+        # poll.
+
+        connect_timeout_sec = 1
+        poll_sleep_sec = 1
+
+        timeout_abs_sec = time.time() + self.__max_start_sec
+
+        # Have to check and bail if self.__is_running is false in case the background thread failed to start procs
+
+        while timeout_abs_sec > time.time() and self.__is_running:
+            for hostport in hostports:
+                process_name = hostport['process_name']
+                hostname = hostport['hostname']
+                port = hostport['port']
+
+                if self.__logger and self.__logger.isEnabledFor(logging.DEBUG):
+                    self.__logger.debug("Checking '%s' interface '%s:%d'", process_name, hostname, port)
+
+                # This supports IPv6
+
+                try:
+                    s = socket.create_connection((hostname, port), timeout=connect_timeout_sec)
+                    s.close()
+                    hostports.remove(hostport)
+
+                    if self.__logger and self.__logger.isEnabledFor(logging.DEBUG):
+                        self.__logger.debug("'%s' interface '%s:%d' is up", process_name, hostname, port)
+                except:
+                    pass
+
+            if not hostports:
+                break
+
+            time.sleep(poll_sleep_sec)
+
+        if not self.__is_running:
+            raise Exception("Aborted before all procs could start")
+
+        if hostports:
+            process_names = []
+            for hostport in hostports:
+                process_names.append(hostport['process_name'])
+            raise Exception("Timeout waiting for the following processes to start: %s" % ', '.join(process_names))
+
+        if self.__logger and self.__logger.isEnabledFor(logging.DEBUG):
+            self.__logger.debug("All interfaces are up")
+
+def ___load_suite(test_cases):
+    suite = unittest.TestSuite()
+    loader = unittest.TestLoader()
+    ids = set()
+
+    for test_case in test_cases:
+        suite.addTest(loader.loadTestsFromTestCase(test_case))
+
+        for name in loader.getTestCaseNames(test_case):
+            ids.add("%s.%s.%s" % (test_case.__module__, test_case.__name__, name))
+
+    return (suite, ids)
+
+def __report_list(file, list, type, message, ids):
+    for result in list:
+        test = result[0]
+        description = result[1]
+        id = test.id().split('.')
+        classname = '.'.join(id[:len(id) - 1])
+        name = id[len(id) - 1]
+
+        file.write('\t<testcase classname="%s" name="%s" time="%d">\n' % (classname, name, 0))
+        file.write('\t\t<%s message="%s">\n<![CDATA[%s]]>\n\t\t</%s>\n' % (type, message, description, type))
+        file.write('\t</testcase>\n')
+
+        ids.remove(test.id()) # The only thing left will be non-errors and non-failures
+
+
+def ___report(path, name, results, ids):
+    file = open(path, 'w')
+
+    file.write('<testsuite name="%s" tests="%d" errors="%d" failures="%d" skip="0">\n' % \
+               (name, results.testsRun, len(results.errors), len(results.failures)))
+
+    __report_list(file, results.failures, 'failure', 'failed assertion', ids)
+    __report_list(file, results.errors, 'error', 'exception', ids)
+
+    for id in ids:
+        idp = id.split('.')
+        classname = '.'.join(idp[:len(idp) - 1])
+        name = idp[len(idp) - 1]
+        file.write('\t<testcase classname="%s" name="%s" time="%d"/>\n' % (classname, name, 0))
+
+    file.write('</testsuite>')
+    file.close()
+
+def run_tests(**kwargs):
+    if not kwargs.has_key('test_cases'):
+        raise Exception("'test_cases' kwarg must be supplied")
+
+    test_cases = kwargs['test_cases']
+
+    if kwargs.has_key('name'):
+        name = kwargs['name']
+    else:
+        name = 'ats_test_suite'
+
+    if kwargs.has_key('report'):
+        report = kwargs['report']
+    else:
+        report = 'report.xml'
+
+    runner = unittest.TextTestRunner()
+    suite, ids = ___load_suite(test_cases)
+    results = runner.run(suite)
+
+    ___report(report, name, results, ids)
+
+    return results.wasSuccessful()
+
+def parse_config(config_path='config.json', process_name=None):
+    """ Get the test manager's parsed configuration file
+    :param process_name: Optional: if supplied return only subdoc for the process.  Else return the entire config
+    """
+
+    if not os.path.isfile(config_path):
+        raise Exception("Config file '%s' does not exist" % config_path)
+
+    conf = json.load(open(config_path, 'r'), encoding='utf-8')
+
+    if not process_name:
+        return conf
+
+    if not conf.has_key('processes'):
+        raise Exception("Configuration has no 'processes' section")
+
+    if not conf['processes'].has_key(process_name):
+        raise Exception("Configuration has no '%s' process" % process_name)
+
+    return conf['processes'][process_name]
+
+

--- a/tests/framework/origin.py
+++ b/tests/framework/origin.py
@@ -1,0 +1,158 @@
+#!/bin/env python
+
+from twisted.web.resource import Resource, NoResource, UnsupportedMethod
+from twisted.web.server import Site
+from twisted.internet import reactor
+from twisted.python import log
+from twisted.web import server
+
+import sys
+sys.path = ['../framework'] + sys.path
+import atstf
+
+
+# See http://twistedmatrix.com/documents/current/web/howto/web-in-60/index.html
+
+class ChunkedResponseResource(Resource):
+    def __init__(self, conf, method):
+        self.__conf = conf
+        self.__method = method
+        self.isLeaf = 1
+
+        if conf.has_key('status_code'):
+            self.__status_code = conf['status_code']
+        else:
+            self.__status_code = 200
+
+        if conf.has_key('headers'):
+            self.__headers = conf['headers']
+        else:
+            self.__headers = {}
+
+        if conf.has_key('num_chunks'):
+            self.__chunks_to_send = conf['num_chunks']
+        else:
+            self.__chunks_to_send = 0
+
+        if conf.has_key('delay_first_chunk_sec'):
+            self.__delay_first_chunk_sec = conf['delay_first_chunk_sec']
+        else:
+            self.__delay_first_chunk_sec = 0
+
+        if conf.has_key('delay_between_chunk_sec'):
+            self.__delay_between_chunk_sec = conf['delay_between_chunk_sec']
+        else:
+            self.__delay_between_chunk_sec = 0
+
+        if conf.has_key('chunk_byte_value'):
+            chunk_byte_value = conf['chunk_byte_value']
+        else:
+            chunk_byte_value = 42
+
+        if conf.has_key('chunk_size_bytes'):
+            chunk_size_bytes = conf['chunk_size_bytes']
+        else:
+            chunk_size_bytes = 1024
+
+        self.__chunk = chr(chunk_byte_value) * chunk_size_bytes
+
+    def __send_chunk(self, request, chunks_left):
+        request.write(self.__chunk)
+
+        if 1 == chunks_left:
+            request.finish()
+            return
+
+        reactor.callLater(self.__delay_between_chunk_sec, self.__send_chunk, request, chunks_left - 1)
+        return server.NOT_DONE_YET
+
+
+    def render(self, request):
+        if self.__method != request.method:
+            request.setResponseCode(405)
+            return ""
+
+        chunks_left = self.__chunks_to_send
+
+        for field_name, field_value in self.__headers.iteritems():
+            request.setHeader(bytes(field_name), bytes(field_value))
+
+        request.setResponseCode(self.__status_code)
+
+        if 0 == chunks_left:
+            return ""
+
+        reactor.callLater(self.__delay_first_chunk_sec, self.__send_chunk, request, chunks_left)
+        return server.NOT_DONE_YET
+
+def main():
+    if 3 > len(sys.argv):
+        sys.stderr.write("usage: %s <process name> <json config file>\n" % sys.argv[0])
+        sys.exit(1)
+
+    process_name = sys.argv[1]
+    config_path = sys.argv[2]
+
+    conf = atstf.parse_config(config_path, process_name)
+
+    if not conf.has_key('interfaces') or not conf['interfaces'].has_key('http') or \
+        not conf['interfaces']['http'].has_key('port'):
+        raise Exception("'interfaces:http:port' does not exist for process '%s'" % process_name)
+
+    if not conf.has_key('actions'):
+        raise Exception("'actions' does not exist for process '%s" % process_name)
+
+    port = conf['interfaces']['http']['port']
+
+    log.startLogging(sys.stdout)
+
+    reactor.listenTCP(port, Site(build_resource_tree(conf['actions'])))
+    reactor.run()
+
+def build_resource_tree(actions):
+    """ build a static resource map that corresponds to the test case's config.json.  Limitation:  currently
+    only one abs_path per method can be supported due to blattj's limited understanding of the twisted api.
+
+    :param actions: The origin process's 'actions' section from the test case's config.json
+    :return: a root resource with all sub-resources described in the config.json registered.
+    """
+    root = Resource()
+
+    for method, paths in actions.iteritems():
+        for abs_path, conf in paths.iteritems():
+            if not conf.has_key('type'):
+                raise Exception("conf for '%s:%s' is missing type" % (method, abs_path))
+
+            # Add interior resources
+
+            parent = root
+            abs_path = abs_path.split('/')
+            length = len(abs_path)
+
+            for i in range(1, length - 1):
+                child = parent.getChild(abs_path[i], None)
+
+                if not child or isinstance(child, NoResource):
+                    child = Resource()
+                    parent.putChild(abs_path[i], child)
+                elif child.isLeaf:
+                    raise Exception("Leaf resource cannot contain other resources")
+
+                parent = child
+
+            # Add leaf resource.   In the future other leaf resources can be added here
+
+            type = conf['type']
+
+            if type == 'chunkedresponse':
+                child = ChunkedResponseResource(conf, method)
+            else:
+                raise Exception("conf for %s:%s has unknown type '%s'" % (method, abs_path, type))
+
+            parent.putChild(abs_path[length - 1], child)
+
+    return root
+
+if __name__ == '__main__':
+    main()
+

--- a/tests/framework/origin.py
+++ b/tests/framework/origin.py
@@ -68,9 +68,9 @@ class ChunkedResponseResource(Resource):
 
 
     def render(self, request):
-        if self.__method != request.method:
+        """if self.__method != request.method:
             request.setResponseCode(405)
-            return ""
+            return "" """
 
         chunks_left = self.__chunks_to_send
 
@@ -130,7 +130,7 @@ def build_resource_tree(actions):
             length = len(abs_path)
 
             for i in range(1, length - 1):
-                child = parent.getChild(abs_path[i], None)
+                child = parent.getStaticEntity(abs_path[i])
 
                 if not child or isinstance(child, NoResource):
                     child = Resource()


### PR DESCRIPTION
# Apache Traffic Server Functional Test Framework

The goal of the functional test framework is to allow traffic server contributors to develop and exercise a reasonable functional test framework from the comfort of their development environments.   This encourages traffic server developers to write their own functional test cases (it's not the province of a detached QA team).   This also gives traffic server developers critical test feedback as early in the development process as possible.

The framework consists of a 'process manager' responsible for configuring and spawning 1+ traffic server processes, a configuration-driven reusable origin process so you don't have to write your own for every test case (though sometimes you will), and a small number of utilities for the test cases themselves.   In this context the test cases are traffic server HTTP/SPDY clients.  That is:

   * test cases/clients -->  traffic server  -->  (configurable/reusable origin | ad hoc origin)

## Framework Prerequisites

   * Python 2.6+ (the default python on RHEL, CentOS, etc. 6.5+)
   * [Twisted](https://twistedmatrix.com/trac/) 14.0.2+
      1. [Install pip](https://pip.pypa.io/en/latest/installing.html)
      2. Install twisted and its dependencies using pip:
```      
$ sudo pip install --upgrade pyOpenSSL zope.interface twisted
```

Individual test cases may add additional dependencies.  

## The ProcessManager class:

The ProcessManager class can be found in tests/framework/atstf.py.  It is responsible for configuring, starting, and stopping the processes used by a test suite.

### ProcessManager Configuration

The ProcessManager is driven by a JSON config file that describes all managed processes.   Individual test cases can  also read this config file to discover server ports, hostnames, etc.   As long as test cases do not hardcode these values they can later be turned against an external functional test environment.

#### config.json path

By default the ProcessManager looks for a 'config.json' file in the test suite's current working directory.  An alternate location can be passed to its constructor:

```python
tm = atstf.ProcessManager(config_path="/tmp/config.json")
```

#### trafficserver and other paths

Test suites inside the trafficserver source repo only have to tell the ProcessManager the path to the source repo root and it will infer the rest:
```python
tm = atstf.ProcessManager(root_path="../..")
```

Test suites outside the trafficserver source repo have to explicitly set each of the following paths:
```python
tm = atstf.ProcessManager(ats_path="/usr/local/bin/trafficserver", 
                          default_config_path="~/trafficserver/proxy/config",
                          origin_path="~/trafficserver/tests/framework/origin.py")
```

The last two paths (default_config_path and origin_path) are paths into a local trafficserver source repo, but we can potentially incorporate those into a 'devel' package in the future.

#### logging:

You can tell the ProcessManager to log stuff including the stdout and stderr of the processes it manages.  The ProcessManager uses python's [logging module](https://docs.python.org/2/library/logging.html).   If you configure python's logging module outside of ProcessManager, the ProcessManager will just use that config.   If you don't want to configure the logging module you can tell the ProcessManager to do it for you by passing it a log_level (e.g., logging.INFO):

```python
import logging

tm = atstf.ProcessManager(log_level=logging.DEBUG)
```

#### max start time

By default the ProcessManager will wait for up to 5 seconds for the processes it manages to start.   If any managed process does not start in time, the ProcessManager will throw an exception which should fail the test.

The ProcessManager considers a managed process to have started when it can successfully connect to all ports listed in the process's 'interfaces' section.  More on this later.

To change the max start time:
```python
tm = atstf.ProcessManager(max_start_sec=3)
```

#### The config.json

The JSON configuration file used by the ProcessManager has the following common format:

```
{
    "processes": {
        <process name>: {
            "type": <"ats"|"origin"|"python"|"other">,
            "spawn": <true|false>
            "interfaces": {
                <interface name>: {
                    "hostname": <hostname|ipv4 addr|ipv6 addr>,
                    "port": <port>
                }
            },
            <other stuff specific to the process type>
        }
    },
    <optional: other stuff specific to the test suite.  Ignored by ProcessManager>
}
```

Because this must be valid JSON, process names must be unique.   They will be incorporated into log messages and into exceptions thrown by the ProcessManager.

The process types supported by the ProcessManager are described below.   Different process types may support additional configuration options.

The 'spawn' attribute defaults to true.   If set to false the ProcessManager will not manage the process.  This is intended to support turning a functional test case against an externally managed set of processes.   The test case code can still discover hostnames and ports from the config.json without a code change.

The optional 'interfaces' attribute details which ports will be opened by a managed process.  If specified the ProcessManager will block caller until either all ports are up or the 'max start time' is exceeded.

#### The config.json Process Types

The ProcessManager currently supports the following process types:

##### Process Type 'ats'

'ats' processes support additional config.json options.

Example:
```json
{
    "servers": {
        "ats1": {
            "type": "ats",
            "root": "ats1",
            "interfaces": {
                "http": {
                    "type": "http",
                    "hostname": "localhost",
                    "port": 8080
                }
            },
            "config": {
                "records.config": [
                    {
                        "match": "^CONFIG proxy.config.diags.debug.enabled",
                        "substitute": "CONFIG proxy.config.diags.debug.enabled INT 1"
                    }
                ],
                "remap.config": [
                    {
                        "append": "map /foo/bar http://localhost:8082/foo/bar"
                    }
                ]
            }
        }
    }
}
```

LIMITATION: Only the 'http' interface type is presently supported.   Need to add HTTPS and SPDY ASAP.

The ProcessManager will run the trafficserver in the 'root' dir.   This is the same as the trafficserver 'TS_ROOT' environment variable.   If you configure multiple 'ats' processes, be sure to assign each of them a distinct root dir.   The root dir should be relative to the test case dir and MUST NOT CONTAIN ANYTHING IMPORTANT!   If ats crashes and the system is configured to capture cores, they should appear in the root dir.

Before trafficserver is started:

   * The ProcessManager will rm -rf the 'root' dir if it already exists, then recreate it with a minimal directory structure (a few var dirs and an etc dir)
   * The ProcessManager will copy over all the default config files and body factory files from proxy/config
   * If the config.json has a 'config' section, the ProcessManager will transform the copied default config files accordingly.   On a per config file basis:
      * match/substitue directives will replace any line that matches a regex (match) with a substitution line
      * append directives will simply add lines to the end of the config file.
      
After trafficserver is started:

   * trafficserver will create transient files in the root/var dirs, including log files

##### Process Type 'origin'

A configurable origin server.   Multiple types of 'origins' can be specified on a per-path basis, but currently only a 'chunkedresponse' type has been developed.   The 'chunkedresponse' origin type supports the following configuration:

   1. response status code
   1. response headers
   1. number of chunks to send in the response
   1. size of each chunk
   1. byte value of each byte in chunk
   1. seconds to wait before sending the first chunk
   1. seconds to wait before sending all subsequent chunks

Example:
```json
{
    "servers": {
        "origin1": {
            "type": "origin",
            "interfaces": {
                "http": {
                    "type": "http",
                    "hostname": "localhost",
                    "port": 8082
                }
            },
            "actions": {
                "GET": {
                    "/foo/bar": {
                        "type": "chunkedresponse",
                        "status_code": 200,
                        "headers": {
                            "content-type": "text/plain"
                        },
                        "delay_first_chunk_sec": 1,
                        "chunk_size_bytes": 1024,
                        "num_chunks": 10,
                        "delay_between_chunk_sec": 0,
                        "chunk_byte_value": 99
                    }
                }
            }
        }
    }
}
```

##### Process Type 'python'

The ProcessManager can manage ad hoc origins written in python providing they exit cleanly when sent a SIGTERM.   If they specify an 'interfaces' section then the ProcessManager will also wait for them to start.

Example:
```json
{
    "servers": {
        "python1": {
            "type": "python",
            "script": "ad_hoc_origin.py",
            "args": [
                "python1",
                "config.json"
            ],
            "interfaces": {
                "http": {
                    "type": "http",
                    "hostname": "localhost",
                    "port": 8082
                }
            }
        }
    }
}
```

##### Process Type 'other'

Finally the ProcessManager can manage any executable, again providing it exits cleanly when sent a SIGTERM.  If it specifies an 'interface' secion then the ProcessManager will also wait for it to start.

Example:
```json
{
    "servers": {
        "other1": {
            "type": "other",
            "spawn": false,
            "executable": "/usr/local/apache2/bin/httpd",
            "args": [
                "-f",
                "/usr/local/apache2/conf/httpd.conf",
                "-k",
                "start",
                "-x"
            ],
            "interfaces": {
                "http": {
                    "type": "http",
                    "hostname": "localhost",
                    "port": 8082
                }
            }
        }
    }
}
```

## Writing Test Cases

### Using the 'unittest' and 'twisted' modules

Test cases should use [the Python Standard Library's unittest module](https://docs.python.org/2/library/unittest.html). Test cases also need to send traffic to trafficserver.   This particular example uses the [Python twisted framework](https://twistedmatrix.com/trac/), but other approaches are possible.  

The main advantage of twisted is that it can be used for lightweight load testing.   The main disadvantage is that Python's unittest module implements assertions on top of exceptions.   Failed assertions in twisted callbacks will be eaten by the twisted framework and will not be incorporated into the test results.

This example works around this issue by saving the state of its interaction with trafficserver, then performing all assertions in the main thread against the saved state at the end of the test case:

```python
import sys
import unittest

from twisted.internet import reactor
from twisted.internet.defer import Deferred
from twisted.internet.protocol import Protocol
from twisted.web.client import Agent
from twisted.web.http_headers import Headers

sys.path = ['../framework'] + sys.path
import atstf

class ExampleTwistedTest(unittest.TestCase):
    def test_ats1(self):
        #
        # Read test case configuration from the same config file used to start ATS and origin processes.
        #

        conf = atstf.parse_config()

        ats1_conf = conf['processes']['ats1']

        hostname = ats1_conf['interfaces']['http']['hostname']
        port = ats1_conf['interfaces']['http']['port']

        origin_conf = conf['processes']['origin1']

        expected_status_code = origin_conf['actions']['GET']['/foo/bar']['status_code']
        chunk_size_bytes = origin_conf['actions']['GET']['/foo/bar']['chunk_size_bytes']
        num_chunks = origin_conf['actions']['GET']['/foo/bar']['num_chunks']
        expected_bytes_received = chunk_size_bytes * num_chunks

        #
        # Create a twisted HTTP client that will interact with ATS and save all details of the interaction.   We'll
        # later assert that the saved details are correct.   Ideally we'd just throw assertions into the client itself,
        # but sadly assertions are implemented with exceptions and twisted eats any exception raised by our callbacks.
        #
        # See https://twistedmatrix.com/documents/current/web/howto/client.html for details on writing HTTP clients
        #

        agent = Agent(reactor)

        request = agent.request('GET',  "http://%s:%d/foo/bar" % (hostname.encode("utf-8"), port),
                                Headers({'User-Agent': ['ExampleTwistedTest']}), None)

        response_handler = ResponseHandler(reactor)

        request.addCallback(response_handler.handle_response)
        request.addCallback(response_handler.handle_completion)
        request.addErrback(response_handler.handle_error)

        reactor.run()

        #
        # Now assert
        #

        self.assertEqual(expected_status_code, response_handler.get_status_code())
        self.assertEqual(expected_bytes_received, response_handler.get_body_handler().get_bytes_received())
        self.assertEqual("Response body fully received", \
                         response_handler.get_body_handler().get_reason().getErrorMessage())

class ResponseBodyHandler(Protocol):
    def __init__(self, deferred):
        self.__deferred = deferred
        self.__bytes_received = 0
        self.__reason = None

    def dataReceived(self, data):
        self.__bytes_received += len(data)

    def connectionLost(self, reason):
        #
        # This function name is highly misleading.  According to the web client docs:
        #
        # When the body has been completely delivered, the protocol's connectionLost method is called. It is important
        # to inspect the Failure passed to connectionLost . If the response body has been completely received, the
        # failure will wrap a twisted.web.client.ResponseDone exception. This indicates that it is known that all data
        # has been received. It is also possible for the failure to wrap a twisted.web.http.PotentialDataLoss exception:
        # this indicates that the server framed the response such that there is no way to know when the entire response
        # body has been received. Only HTTP/1.0 servers should behave this way. Finally, it is possible for the
        # exception to be of another type, indicating guaranteed data loss for some reason (a lost connection, a memory
        # error, etc).
        #
        self.__reason = reason
        self.__deferred.callback(None)

    def get_bytes_received(self):
        return self.__bytes_received

    def get_reason(self):
        return self.__reason

class ResponseHandler:
    def __init__(self, reactor):
        self.__reactor = reactor
        self.__deferred = Deferred()
        self.__body_handler = ResponseBodyHandler(self.__deferred)
        self.__error = None
        self.__status_code = None

    def handle_response(self, response):
        self.__status_code = response.code
        response.deliverBody(self.__body_handler)
        return self.__deferred

    def handle_completion(self):
        self.__reactor.stop()

    def handle_error(self, error):
        self.__error = error
        self.__reactor.stop()

    def get_body_handler(self):
        return self.__body_handler

    def get_error(self):
        return self.__error

    def get_status_code(self):
        return self.__status_code
```


### Pulling it all together with a Test Suite

Multiple test cases should be run together in a test suite and the results of the entire suite should be summarized in a JUnit report suitable for Jenkins.  This is also a good place to instantiate and start the ProcessManager (start it before any test case is invoked, stop it after all test cases finish).   

Example:
```python
#!/bin/env python

import sys
import logging

sys.path = ['../framework'] + sys.path
import atstf

from twisted_test import ExampleTwistedTest

test_cases = [ExampleTwistedTest]

if __name__ == '__main__':
    # Spawn ATS and origin processes

    tm = atstf.ProcessManager(root_path="../..", config_path="config.json", log_level=logging.DEBUG, max_start_sec=5)

    try:
        tm.start()

        # Run the test suite and generate a JUnit XML report

        if atstf.run_tests(test_cases=test_cases, name='example', report='report.xml'):
            sys.exit(0)
        else:
            sys.exit(1)
    finally:
        tm.stop()
```

Here the important bits are:

   1. Initializing the ProcessManager and starting it before the running the test suite
   1. Passing all the test case classes to run_tests().   This will auto discover all test cases in the test classes, run them, and spit the results out in a report.xml file in the cwd.
   1. Exiting zero if the run_tests() method returns True, non-zero otherwise
   
Not so important is explicitly stopping the ProcessManager.   It's good practice, but the ProcessManager will stop automatically on process exit.
