### PR TITLE
TS-3196: Core dump when handle event check_inactivity

### DIFF
--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -134,7 +134,9 @@ static inline int
 read_signal_and_update(int event, UnixNetVConnection *vc)
 {
   vc->recursion++;
-  vc->read.vio._cont->handleEvent(event, &vc->read.vio);
+  if(vc->read.vio._cont) {
+    vc->read.vio._cont->handleEvent(event, &vc->read.vio);
+  }
   if (!--vc->recursion && vc->closed) {
     /* BZ  31932 */
     ink_assert(vc->thread == this_ethread());
@@ -552,8 +554,9 @@ VIO *
 UnixNetVConnection::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
 {
   ink_assert(!closed);
+  ink_assert(c || 0 == nbytes);
   read.vio.op = VIO::READ;
-  read.vio.mutex = c->mutex;
+  read.vio.mutex = c ? c->mutex : this->mutex;
   read.vio._cont = c;
   read.vio.nbytes = nbytes;
   read.vio.ndone = 0;

--- a/proxy/ProtocolProbeSessionAccept.cc
+++ b/proxy/ProtocolProbeSessionAccept.cc
@@ -111,7 +111,7 @@ struct ProtocolProbeTrampoline : public Continuation, public ProtocolProbeSessio
       key = PROTO_HTTP;
     }
 
-    netvc->do_io_read(this, 0, NULL); // Disable the read IO that we started.
+    netvc->do_io_read(NULL, 0, NULL); // Disable the read IO that we started.
 
     if (probeParent->endpoint[key] == NULL) {
       Warning("Unregistered protocol type %d", key);


### PR DESCRIPTION
From the core dump, if we use ssl and spdy, so in the function
'ProtocolProbeTrampoline::ioCompletionEvent', it will first disable the read io
adn handover the continuation of read.vio._cont from 'ProtocolProbeTrampoline'
to 'SpdyClientSession' by below two steps:
1. first disable current io by using 'netvc->do_io_read(this, 0, NULL)'.
2. change the read.vio._cont by using
'probeParent->endpoint[key]>accept(netvc, this>iobuf, reader);' which will be
'SpdySessionAccept::accept' in our case. and in the end, it will call
'SpdyClientSession::state_session_start' which will call 'this->vc->do_io_read'
to set read.vio._cont to SpdyClientSession.
the main point is that the function 'SpdySessionAccept::accept' function will
put an SpdyClientSession event into eventProcessor for net
'eventProcessor.schedule_imm(sm, ET_NET);'
and because each 'net' thread will put a check_inactivity event into the queue
So, in the end, between 'netvc->do_io_read(this, 0, NULL)' and
spdy handler is set, the
check_inactivity may be executed, and if so, the crash will occur.
