### PR TITLE
[TS-3211] Add support for modifying the SCHEME via header_rewrite

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,8 @@ Changes with Apache Traffic Server 5.3.0
 
 Changes with Apache Traffic Server 5.2.0
 
+  *) [TS-3211] Add support for modifying the SCHEME via header_rewrite
+
   *) [TS-3130]: Delay setting buffer to NULL to prevent crash in logging 
 
   *) [TS-3207] _xstrdup incorrectly calls ink_strlcpy with 0 length strings.

--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -181,6 +181,17 @@ OperatorSetDestination::exec(const Resources& res) const
     // Never set an empty destination value (I don't think that ever makes sense?)
     switch (_url_qual) {
 
+    case URL_QUAL_SCHEME:
+        _value.append_value(value, res);
+        if (value.empty()) {
+          TSDebug(PLUGIN_NAME, "Would set destination SCHEME to an empty value, skipping");
+        } else {
+          const_cast<Resources&>(res).changed_url = true;
+          TSUrlSchemeSet(bufp, url_m_loc, value.c_str(), value.size());
+          TSDebug(PLUGIN_NAME, "OperatorSetDestination::exec() invoked with SCHEME: %s", value.c_str());
+        }
+        break;
+
     case URL_QUAL_HOST:
       _value.append_value(value, res);
       if (value.empty()) {


### PR DESCRIPTION
I need a way to rewrite the destination scheme based on a request header. It looks like it was partially added before (I see URL_QUAL_SCHEME in statement.h already) but the actual implementation was missing.

Here is an example:

cond %{READ_REQUEST_HDR_HOOK} [AND]
cond %{CLIENT-HEADER:X-Force-Origin-To-Use-HTTPS} /1/
set-destination PORT 443
set-destination SCHEME https