### PR TITLE
[TS-2157] Replace "addr" with appropriate "src_addr" and "dst_addr" in ConnectionAttributes

### DIFF
--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -5285,7 +5285,7 @@ TSHttpTxnServerAddrSet(TSHttpTxn txnp, struct sockaddr const* addr)
   HttpSM *sm = reinterpret_cast<HttpSM *>(txnp);
   if (ats_ip_copy(&sm->t_state.server_info.remote_addr.sa, addr)) {
     ats_ip_port_cast(&sm->t_state.server_info.remote_addr.sa) = ats_ip_port_cast(addr);
-    sm->t_state.server_info.local_addr.port() = htons(ats_ip_port_cast(addr));
+    sm->t_state.server_info.remote_addr.port() = htons(ats_ip_port_cast(addr));
     sm->t_state.api_server_addr_set = true;
     return TS_SUCCESS;
   } else {

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -5274,7 +5274,7 @@ TSHttpTxnServerAddrGet(TSHttpTxn txnp)
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
 
   HttpSM *sm = reinterpret_cast<HttpSM *>(txnp);
-  return &sm->t_state.server_info.addr.sa;
+  return &sm->t_state.server_info.remote_addr.sa;
 }
 
 TSReturnCode
@@ -5283,9 +5283,9 @@ TSHttpTxnServerAddrSet(TSHttpTxn txnp, struct sockaddr const* addr)
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
 
   HttpSM *sm = reinterpret_cast<HttpSM *>(txnp);
-  if (ats_ip_copy(&sm->t_state.server_info.addr.sa, addr)) {
-    ats_ip_port_cast(&sm->t_state.server_info.addr.sa) = ats_ip_port_cast(addr);
-    sm->t_state.server_info.port = htons(ats_ip_port_cast(addr));
+  if (ats_ip_copy(&sm->t_state.server_info.remote_addr.sa, addr)) {
+    ats_ip_port_cast(&sm->t_state.server_info.remote_addr.sa) = ats_ip_port_cast(addr);
+    sm->t_state.server_info.local_addr.port() = htons(ats_ip_port_cast(addr));
     sm->t_state.api_server_addr_set = true;
     return TS_SUCCESS;
   } else {
@@ -5299,7 +5299,7 @@ TSHttpTxnClientIncomingPortSet(TSHttpTxn txnp, int port)
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
 
   HttpSM *sm = (HttpSM *) txnp;
-  sm->t_state.client_info.port = port;
+  sm->t_state.client_info.local_addr.port() = port;
 }
 
 // [amc] This might use the port. The code path should do that but it
@@ -5336,7 +5336,7 @@ TSHttpTxnNextHopAddrGet(TSHttpTxn txnp)
   if (sm->t_state.current.server == NULL)
     return NULL;
 
-  return &sm->t_state.current.server->addr.sa;
+  return &sm->t_state.current.server->remote_addr.sa;
 }
 
 TSReturnCode

--- a/proxy/Prefetch.cc
+++ b/proxy/Prefetch.cc
@@ -593,7 +593,7 @@ PrefetchTransform::redirect(HTTPHdr *resp)
       }
 
       Debug("PrefetchTransform", "Found embedded URL: %s", redirect_url);
-      entry->req_ip = m_sm->t_state.client_info.addr;
+      entry->req_ip = m_sm->t_state.client_info.remote_addr;
 
       PrefetchBlaster *blaster = prefetchBlasterAllocator.alloc();
       blaster->init(entry, &m_sm->t_state.hdr_info.client_request, this);
@@ -617,7 +617,7 @@ PrefetchTransform::parse_data(IOBufferReader *reader)
       continue;
     }
     //Debug("PrefetchParserURLs", "Found embedded URL: %s", url_start);
-    ats_ip_copy(&entry->req_ip, &m_sm->t_state.client_info.addr);
+    ats_ip_copy(&entry->req_ip, &m_sm->t_state.client_info.remote_addr);
 
     PrefetchBlaster *blaster = prefetchBlasterAllocator.alloc();
     blaster->init(entry, &m_sm->t_state.hdr_info.client_request, this);
@@ -661,7 +661,7 @@ check_n_attach_prefetch_transform(HttpSM *sm, HTTPHdr *resp, bool from_cache)
   INKVConnInternal *prefetch_trans;
   ip_text_buffer client_ipb;
 
-  IpEndpoint client_ip = sm->t_state.client_info.addr;
+  IpEndpoint client_ip = sm->t_state.client_info.remote_addr;
 
   // we depend on this to setup @a client_ipb for all subsequent Debug().
   Debug("PrefetchParser", "Checking response for request from %s\n",

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -1655,7 +1655,7 @@ HttpSM::state_http_server_open(int event, void *data)
        server_vc->con.fd); */
     ats_ip_copy(&session->server_ip, &t_state.current.server->remote_addr);
     session->new_connection((NetVConnection *) data);
-    ats_ip_port_cast(&session->server_ip) = htons(t_state.current.server->local_addr.port());
+    ats_ip_port_cast(&session->server_ip) = htons(t_state.current.server->remote_addr.port());
     session->state = HSS_ACTIVE;
 
     attach_server_session(session);
@@ -2163,7 +2163,7 @@ HttpSM::state_hostdb_lookup(int event, void *data)
 
       char *host_name = t_state.dns_info.srv_lookup_success ? t_state.dns_info.srv_hostname : t_state.dns_info.lookup_name;
       HostDBProcessor::Options opt;
-      opt.port = t_state.dns_info.srv_lookup_success ? t_state.dns_info.srv_port : t_state.server_info.local_addr.port();
+      opt.port = t_state.dns_info.srv_lookup_success ? t_state.dns_info.srv_port : t_state.server_info.remote_addr.port();
       opt.flags = (t_state.cache_info.directives.does_client_permit_dns_storing)
             ? HostDBProcessor::HOSTDB_DO_NOT_FORCE_DNS
             : HostDBProcessor::HOSTDB_FORCE_DNS_RELOAD
@@ -3985,7 +3985,7 @@ HttpSM::do_hostdb_lookup()
       historical_action = pending_action;
     } else {
       char *host_name = t_state.dns_info.srv_lookup_success ? t_state.dns_info.srv_hostname : t_state.dns_info.lookup_name;
-      opt.port = t_state.dns_info.srv_lookup_success ? t_state.dns_info.srv_port : t_state.server_info.local_addr.port();
+      opt.port = t_state.dns_info.srv_lookup_success ? t_state.dns_info.srv_port : t_state.server_info.remote_addr.port();
       opt.flags = (t_state.cache_info.directives.does_client_permit_dns_storing)
             ? HostDBProcessor::HOSTDB_DO_NOT_FORCE_DNS
             : HostDBProcessor::HOSTDB_FORCE_DNS_RELOAD
@@ -4012,7 +4012,7 @@ HttpSM::do_hostdb_lookup()
 
     // If there is not a current server, we must be looking up the origin
     //  server at the beginning of the transaction
-    int server_port = t_state.current.server ? t_state.current.server->local_addr.port() : t_state.server_info.local_addr.port();
+    int server_port = t_state.current.server ? t_state.current.server->remote_addr.port() : t_state.server_info.remote_addr.port();
 
     if (t_state.api_txn_dns_timeout_value != -1) {
       DebugSM("http_timeout", "beginning DNS lookup. allowing %d mseconds for DNS lookup",
@@ -4101,7 +4101,7 @@ HttpSM::do_hostdb_update_if_necessary()
   } else {
     if (t_state.host_db_info.app.http_data.last_failure != 0) {
       t_state.host_db_info.app.http_data.last_failure = 0;
-      ats_ip_port_cast(&t_state.current.server->remote_addr) = htons(t_state.current.server->local_addr.port());
+      ats_ip_port_cast(&t_state.current.server->remote_addr) = htons(t_state.current.server->remote_addr.port());
       issue_update |= 1;
       char addrbuf[INET6_ADDRPORTSTRLEN];
       DebugSM("http", "[%" PRId64 "] hostdb update marking IP: %s as up",
@@ -4580,8 +4580,8 @@ HttpSM::do_http_server_open(bool raw)
   ink_assert(pending_action == NULL);
 
   if (false == t_state.api_server_addr_set) {
-    ink_assert(t_state.current.server->local_addr.port() > 0);
-    t_state.current.server->remote_addr.port() = htons(t_state.current.server->local_addr.port());
+    ink_assert(t_state.current.server->remote_addr.port() > 0);
+    t_state.current.server->remote_addr.port() = htons(t_state.current.server->remote_addr.port());
   } else {
     ink_assert(ats_ip_port_cast(&t_state.current.server->remote_addr) != 0);
   }

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -548,8 +548,8 @@ HttpSM::attach_client_session(HttpClientSession * client_vc, IOBufferReader * bu
 
   NetVConnection* netvc = client_vc->get_netvc();
 
-  ats_ip_copy(&t_state.client_info.addr, netvc->get_remote_addr());
-  t_state.client_info.port = netvc->get_local_port();
+  ats_ip_copy(&t_state.client_info.remote_addr, netvc->get_remote_addr());
+  ats_ip_copy(&t_state.client_info.local_addr, netvc->get_local_addr());
   t_state.client_info.is_transparent = netvc->get_is_transparent();
   t_state.backdoor_request = !client_vc->hooks_enabled();
   t_state.client_info.port_attribute = static_cast<HttpProxyPort::TransportType>(netvc->attributes);
@@ -1653,9 +1653,9 @@ HttpSM::state_http_server_open(int event, void *data)
        UnixNetVConnection *server_vc = (UnixNetVConnection*)data;
        printf("client fd is :%d , server fd is %d\n",vc->con.fd,
        server_vc->con.fd); */
-    ats_ip_copy(&session->server_ip, &t_state.current.server->addr);
+    ats_ip_copy(&session->server_ip, &t_state.current.server->remote_addr);
     session->new_connection((NetVConnection *) data);
-    ats_ip_port_cast(&session->server_ip) = htons(t_state.current.server->port);
+    ats_ip_port_cast(&session->server_ip) = htons(t_state.current.server->local_addr.port());
     session->state = HSS_ACTIVE;
 
     attach_server_session(session);
@@ -1689,8 +1689,8 @@ HttpSM::state_http_server_open(int event, void *data)
       if (is_debug_tag_set("http_tproxy")) {
         ip_port_text_buffer ip_c, ip_s;
         Debug("http_tproxy", "Force close of client connect (%s->%s) due to EADDRNOTAVAIL [%" PRId64 "]"
-              , ats_ip_nptop(&t_state.client_info.addr.sa, ip_c, sizeof ip_c)
-              , ats_ip_nptop(&t_state.server_info.addr.sa, ip_s, sizeof ip_s)
+              , ats_ip_nptop(&t_state.client_info.remote_addr.sa, ip_c, sizeof ip_c)
+              , ats_ip_nptop(&t_state.server_info.remote_addr.sa, ip_s, sizeof ip_s)
               , sm_id
           );
       }
@@ -2068,7 +2068,7 @@ HttpSM::process_hostdb_info(HostDBInfo * r)
         // may be very large, we cannot use client_request_time to approximate
         // current time when calling select_best_http().
         HostDBRoundRobin *rr = r->rr();
-        ret = rr->select_best_http(&t_state.client_info.addr.sa, now, (int) t_state.txn_conf->down_server_timeout);
+        ret = rr->select_best_http(&t_state.client_info.remote_addr.sa, now, (int) t_state.txn_conf->down_server_timeout);
 
         // set the srv target`s last_failure
         if (t_state.dns_info.srv_lookup_success) {
@@ -2163,7 +2163,7 @@ HttpSM::state_hostdb_lookup(int event, void *data)
 
       char *host_name = t_state.dns_info.srv_lookup_success ? t_state.dns_info.srv_hostname : t_state.dns_info.lookup_name;
       HostDBProcessor::Options opt;
-      opt.port = t_state.dns_info.srv_lookup_success ? t_state.dns_info.srv_port : t_state.server_info.port;
+      opt.port = t_state.dns_info.srv_lookup_success ? t_state.dns_info.srv_port : t_state.server_info.local_addr.port();
       opt.flags = (t_state.cache_info.directives.does_client_permit_dns_storing)
             ? HostDBProcessor::HOSTDB_DO_NOT_FORCE_DNS
             : HostDBProcessor::HOSTDB_FORCE_DNS_RELOAD
@@ -2240,7 +2240,7 @@ HttpSM::state_mark_os_down(int event, void *data)
       ink_assert(t_state.current.server != NULL);
       ink_assert(t_state.current.request_to == HttpTransact::ORIGIN_SERVER);
       if (t_state.current.server) {
-        mark_down = r->rr()->find_ip(&t_state.current.server->addr.sa);
+        mark_down = r->rr()->find_ip(&t_state.current.server->remote_addr.sa);
       }
     } else {
       // No longer a round robin, check to see if our address is the same
@@ -3985,7 +3985,7 @@ HttpSM::do_hostdb_lookup()
       historical_action = pending_action;
     } else {
       char *host_name = t_state.dns_info.srv_lookup_success ? t_state.dns_info.srv_hostname : t_state.dns_info.lookup_name;
-      opt.port = t_state.dns_info.srv_lookup_success ? t_state.dns_info.srv_port : t_state.server_info.port;
+      opt.port = t_state.dns_info.srv_lookup_success ? t_state.dns_info.srv_port : t_state.server_info.local_addr.port();
       opt.flags = (t_state.cache_info.directives.does_client_permit_dns_storing)
             ? HostDBProcessor::HOSTDB_DO_NOT_FORCE_DNS
             : HostDBProcessor::HOSTDB_FORCE_DNS_RELOAD
@@ -4012,7 +4012,7 @@ HttpSM::do_hostdb_lookup()
 
     // If there is not a current server, we must be looking up the origin
     //  server at the beginning of the transaction
-    int server_port = t_state.current.server ? t_state.current.server->port : t_state.server_info.port;
+    int server_port = t_state.current.server ? t_state.current.server->local_addr.port() : t_state.server_info.local_addr.port();
 
     if (t_state.api_txn_dns_timeout_value != -1) {
       DebugSM("http_timeout", "beginning DNS lookup. allowing %d mseconds for DNS lookup",
@@ -4074,7 +4074,7 @@ HttpSM::do_hostdb_update_if_necessary()
   }
   // If we failed back over to the origin server, we don't have our
   //   hostdb information anymore which means we shouldn't update the hostdb
-  if (!ats_ip_addr_eq(&t_state.current.server->addr.sa, t_state.host_db_info.ip())) {
+  if (!ats_ip_addr_eq(&t_state.current.server->remote_addr.sa, t_state.host_db_info.ip())) {
     DebugSM("http", "[%" PRId64 "] skipping hostdb update due to server failover", sm_id);
     return;
   }
@@ -4101,12 +4101,12 @@ HttpSM::do_hostdb_update_if_necessary()
   } else {
     if (t_state.host_db_info.app.http_data.last_failure != 0) {
       t_state.host_db_info.app.http_data.last_failure = 0;
-      ats_ip_port_cast(&t_state.current.server->addr) = htons(t_state.current.server->port);
+      ats_ip_port_cast(&t_state.current.server->remote_addr) = htons(t_state.current.server->local_addr.port());
       issue_update |= 1;
       char addrbuf[INET6_ADDRPORTSTRLEN];
       DebugSM("http", "[%" PRId64 "] hostdb update marking IP: %s as up",
             sm_id,
-            ats_ip_nptop(&t_state.current.server->addr.sa, addrbuf, sizeof(addrbuf)));
+            ats_ip_nptop(&t_state.current.server->remote_addr.sa, addrbuf, sizeof(addrbuf)));
     }
 
     if (t_state.dns_info.srv_lookup_success && t_state.dns_info.srv_app.http_data.last_failure != 0) {
@@ -4121,13 +4121,13 @@ HttpSM::do_hostdb_update_if_necessary()
   if (issue_update) {
     hostDBProcessor.setby(t_state.current.server->name,
       strlen(t_state.current.server->name),
-      &t_state.current.server->addr.sa,
+      &t_state.current.server->remote_addr.sa,
       &t_state.host_db_info.app
     );
   }
 
   char addrbuf[INET6_ADDRPORTSTRLEN];
-  DebugSM("http", "server info = %s", ats_ip_nptop(&t_state.current.server->addr.sa, addrbuf, sizeof(addrbuf)));
+  DebugSM("http", "server info = %s", ats_ip_nptop(&t_state.current.server->remote_addr.sa, addrbuf, sizeof(addrbuf)));
   return;
 }
 
@@ -4565,7 +4565,7 @@ HttpSM::do_cache_prepare_action(HttpCacheSM * c_sm, CacheHTTPInfo * object_read_
 void
 HttpSM::do_http_server_open(bool raw)
 {
-  int ip_family = t_state.current.server->addr.sa.sa_family;
+  int ip_family = t_state.current.server->remote_addr.sa.sa_family;
   DebugSM("http_track", "entered inside do_http_server_open ][%s]", ats_ip_family_name(ip_family));
 
   ink_assert(server_entry == NULL);
@@ -4580,16 +4580,16 @@ HttpSM::do_http_server_open(bool raw)
   ink_assert(pending_action == NULL);
 
   if (false == t_state.api_server_addr_set) {
-    ink_assert(t_state.current.server->port > 0);
-    t_state.current.server->addr.port() = htons(t_state.current.server->port);
+    ink_assert(t_state.current.server->local_addr.port() > 0);
+    t_state.current.server->remote_addr.port() = htons(t_state.current.server->local_addr.port());
   } else {
-    ink_assert(ats_ip_port_cast(&t_state.current.server->addr) != 0);
+    ink_assert(ats_ip_port_cast(&t_state.current.server->remote_addr) != 0);
   }
 
   char addrbuf[INET6_ADDRPORTSTRLEN];
   DebugSM("http", "[%" PRId64 "] open connection to %s: %s",
         sm_id, t_state.current.server->name,
-        ats_ip_nptop(&t_state.current.server->addr.sa, addrbuf, sizeof(addrbuf)));
+        ats_ip_nptop(&t_state.current.server->remote_addr.sa, addrbuf, sizeof(addrbuf)));
 
   if (plugin_tunnel) {
     PluginVCCore *t = plugin_tunnel;
@@ -4639,7 +4639,7 @@ HttpSM::do_http_server_open(bool raw)
        !is_private() && ua_session != NULL) {
     HSMresult_t shared_result;
     shared_result = httpSessionManager.acquire_session(this,    // state machine
-                                                       &t_state.current.server->addr.sa,    // ip + port
+                                                       &t_state.current.server->remote_addr.sa,    // ip + port
                                                        t_state.current.server->name,    // hostname
                                                        ua_session,      // has ptr to bound ua sessions
                                                        this     // sm
@@ -4673,7 +4673,7 @@ HttpSM::do_http_server_open(bool raw)
       // so there's no point in further checking on the match or pool values. But why check anything? The
       // client has already exchanged a request with this specific origin server and has sent another one
       // shouldn't we just automatically keep the association?
-      if (ats_ip_addr_port_eq(&existing_ss->server_ip.sa, &t_state.current.server->addr.sa)) {
+      if (ats_ip_addr_port_eq(&existing_ss->server_ip.sa, &t_state.current.server->remote_addr.sa)) {
         ua_session->attach_server_session(NULL);
         existing_ss->state = HSS_ACTIVE;
         this->attach_server_session(existing_ss);
@@ -4723,9 +4723,9 @@ HttpSM::do_http_server_open(bool raw)
     ConnectionCount *connections = ConnectionCount::getInstance();
 
     char addrbuf[INET6_ADDRSTRLEN];
-    if (connections->getCount((t_state.current.server->addr)) >= t_state.txn_conf->origin_max_connections) {
+    if (connections->getCount((t_state.current.server->remote_addr)) >= t_state.txn_conf->origin_max_connections) {
       DebugSM("http", "[%" PRId64 "] over the number of connection for this host: %s", sm_id,
-        ats_ip_ntop(&t_state.current.server->addr.sa, addrbuf, sizeof(addrbuf)));
+        ats_ip_ntop(&t_state.current.server->remote_addr.sa, addrbuf, sizeof(addrbuf)));
       ink_assert(pending_action == NULL);
       pending_action = eventProcessor.schedule_in(this, HRTIME_MSECONDS(100));
       return;
@@ -4755,7 +4755,7 @@ HttpSM::do_http_server_open(bool raw)
       opt.local_ip = outbound_ip;
     } else if (ua_session->f_outbound_transparent) {
       opt.addr_binding = NetVCOptions::FOREIGN_ADDR;
-      opt.local_ip = t_state.client_info.addr;
+      opt.local_ip = t_state.client_info.remote_addr;
       /* If the connection is server side transparent, we can bind to the
          port that the client chose instead of randomly assigning one at
          the proxy.  This is controlled by the 'use_client_source_port'
@@ -4788,13 +4788,13 @@ HttpSM::do_http_server_open(bool raw)
     const char * host = t_state.hdr_info.server_request.host_get(&len);
     opt.set_sni_servername(host, len);
     connect_action_handle = sslNetProcessor.connect_re(this,    // state machine
-                                                       &t_state.current.server->addr.sa,    // addr + port
+                                                       &t_state.current.server->remote_addr.sa,    // addr + port
                                                        &opt);
   } else {
     if (t_state.method != HTTP_WKSIDX_CONNECT) {
       DebugSM("http", "calling netProcessor.connect_re");
       connect_action_handle = netProcessor.connect_re(this,     // state machine
-                                                      &t_state.current.server->addr.sa,    // addr + port
+                                                      &t_state.current.server->remote_addr.sa,    // addr + port
                                                       &opt);
     } else {
       // Setup the timeouts
@@ -4814,7 +4814,7 @@ HttpSM::do_http_server_open(bool raw)
       }
       DebugSM("http", "calling netProcessor.connect_s");
       connect_action_handle = netProcessor.connect_s(this,      // state machine
-                                                     &t_state.current.server->addr.sa,    // addr + port
+                                                     &t_state.current.server->remote_addr.sa,    // addr + port
                                                      connect_timeout, &opt);
     }
   }
@@ -4961,7 +4961,7 @@ HttpSM::mark_host_failure(HostDBInfo * info, time_t time_down)
     char *url_str = t_state.hdr_info.client_request.url_string_get(&t_state.arena, 0);
     Log::error("CONNECT: could not connect to %s "
                "for '%s' (setting last failure time)",
-               ats_ip_ntop(&t_state.current.server->addr.sa, addrbuf, sizeof(addrbuf)),
+               ats_ip_ntop(&t_state.current.server->remote_addr.sa, addrbuf, sizeof(addrbuf)),
                url_str ? url_str : "<none>"
     );
     if (url_str)
@@ -4977,7 +4977,7 @@ HttpSM::mark_host_failure(HostDBInfo * info, time_t time_down)
 
   DebugSM("http", "[%" PRId64 "] hostdb update marking IP: %s as down",
         sm_id,
-        ats_ip_nptop(&t_state.current.server->addr.sa, addrbuf, sizeof(addrbuf)));
+        ats_ip_nptop(&t_state.current.server->remote_addr.sa, addrbuf, sizeof(addrbuf)));
 }
 
 void
@@ -6806,7 +6806,7 @@ HttpSM::update_stats()
       status = t_state.hdr_info.client_response.status_get();
     }
     char client_ip[INET6_ADDRSTRLEN];
-    ats_ip_ntop(&t_state.client_info.addr, client_ip, sizeof(client_ip));
+    ats_ip_ntop(&t_state.client_info.remote_addr, client_ip, sizeof(client_ip));
     Error("[%" PRId64 "] Slow Request: "
           "client_ip: %s:%u "
           "url: %s "
@@ -6830,7 +6830,7 @@ HttpSM::update_stats()
           "sm_finish: %.3f",
           sm_id,
           client_ip,
-          ats_ip_port_host_order(&t_state.client_info.addr),
+          ats_ip_port_host_order(&t_state.client_info.remote_addr),
           url_string,
           status,
           unique_id_string,
@@ -7021,9 +7021,9 @@ HttpSM::set_next_state()
          * then we can skip the lookup
          */
         ip_text_buffer ipb;
-        DebugSM("dns", "[HttpTransact::HandleRequest] Skipping DNS lookup for API supplied target %s.\n", ats_ip_ntop(&t_state.server_info.addr, ipb, sizeof(ipb)));
+        DebugSM("dns", "[HttpTransact::HandleRequest] Skipping DNS lookup for API supplied target %s.\n", ats_ip_ntop(&t_state.server_info.remote_addr, ipb, sizeof(ipb)));
         // this seems wasteful as we will just copy it right back
-        ats_ip_copy(t_state.host_db_info.ip(), &t_state.server_info.addr);
+        ats_ip_copy(t_state.host_db_info.ip(), &t_state.server_info.remote_addr);
         t_state.dns_info.lookup_success = true;
         call_transact_and_set_next_state(NULL);
         break;

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -283,7 +283,7 @@ find_server_and_update_current_info(HttpTransact::State* s)
       //  to go the origin server, we can only obey this if we
       //  dns'ed the origin server
       if (s->parent_result.r == PARENT_DIRECT && s->http_config_param->no_dns_forward_to_parent != 0) {
-        ink_assert(!ats_is_ip(&s->server_info.addr));
+        ink_assert(!ats_is_ip(&s->server_info.remote_addr));
         s->parent_result.r = PARENT_FAIL;
       }
       break;
@@ -312,7 +312,7 @@ find_server_and_update_current_info(HttpTransact::State* s)
   switch (s->parent_result.r) {
   case PARENT_SPECIFIED:
     s->parent_info.name = s->arena.str_store(s->parent_result.hostname, strlen(s->parent_result.hostname));
-    s->parent_info.port = s->parent_result.port;
+    s->parent_info.local_addr.port() = s->parent_result.port;
     update_current_info(&s->current, &s->parent_info, HttpTransact::PARENT_PROXY, (s->current.attempts)++);
     update_dns_info(&s->dns_info, &s->current, 0, &s->arena);
     ink_assert(s->dns_info.looking_up == HttpTransact::PARENT_PROXY);
@@ -755,7 +755,7 @@ HttpTransact::StartRemapRequest(State* s)
     port == s->http_config_param->autoconf_port &&
     s->method == HTTP_WKSIDX_GET &&
     s->orig_scheme == URL_WKSIDX_HTTP &&
-    (!s->http_config_param->autoconf_localhost_only || ats_ip4_addr_cast(&s->client_info.addr.sa) == htonl(INADDR_LOOPBACK));
+    (!s->http_config_param->autoconf_localhost_only || ats_ip4_addr_cast(&s->client_info.remote_addr.sa) == htonl(INADDR_LOOPBACK));
 
   //////////////////////////////////////////////////////////////////
   // FIX: this logic seems awfully convoluted and hard to follow; //
@@ -1339,7 +1339,7 @@ HttpTransact::HandleRequest(State* s)
       //  DNS service available, we just want to forward the request
       //  the parent proxy.  In this case, we never find out the
       //  origin server's ip.  So just skip past OSDNS
-      ats_ip_invalidate(&s->server_info.addr);
+      ats_ip_invalidate(&s->server_info.remote_addr);
       StartAccessControl(s);
       return;
     } else if (s->http_config_param->no_origin_server_dns) {
@@ -1491,7 +1491,7 @@ HttpTransact::PPDNSLookup(State* s)
   if (!s->dns_info.lookup_success) {
     // DNS lookup of parent failed, find next parent or o.s.
     find_server_and_update_current_info(s);
-    if (!ats_is_ip(&s->current.server->addr)) {
+    if (!ats_is_ip(&s->current.server->remote_addr)) {
       if (s->current.request_to == PARENT_PROXY) {
         TRANSACT_RETURN(SM_ACTION_DNS_LOOKUP, PPDNSLookup);
       } else {
@@ -1504,13 +1504,13 @@ HttpTransact::PPDNSLookup(State* s)
     }
   } else {
     // lookup succeeded, open connection to p.p.
-    ats_ip_copy(&s->parent_info.addr, s->host_db_info.ip());
+    ats_ip_copy(&s->parent_info.remote_addr, s->host_db_info.ip());
     get_ka_info_from_host_db(s, &s->parent_info, &s->client_info, &s->host_db_info);
     s->parent_info.dns_round_robin = s->host_db_info.round_robin;
 
     char addrbuf[INET6_ADDRSTRLEN];
     DebugTxn("http_trans", "[PPDNSLookup] DNS lookup for sm_id[%" PRId64"] successful IP: %s",
-          s->state_machine->sm_id, ats_ip_ntop(&s->parent_info.addr.sa, addrbuf, sizeof(addrbuf)));
+          s->state_machine->sm_id, ats_ip_ntop(&s->parent_info.remote_addr.sa, addrbuf, sizeof(addrbuf)));
   }
 
   // Since this function can be called several times while retrying
@@ -1559,14 +1559,14 @@ HttpTransact::ReDNSRoundRobin(State* s)
 
     // Our ReDNS of the server succeeded so update the necessary
     //  information and try again
-    ats_ip_copy(&s->server_info.addr, s->host_db_info.ip());
-    ats_ip_copy(&s->request_data.dest_ip, &s->server_info.addr);
+    ats_ip_copy(&s->server_info.remote_addr, s->host_db_info.ip());
+    ats_ip_copy(&s->request_data.dest_ip, &s->server_info.remote_addr);
     get_ka_info_from_host_db(s, &s->server_info, &s->client_info, &s->host_db_info);
     s->server_info.dns_round_robin = s->host_db_info.round_robin;
 
     char addrbuf[INET6_ADDRSTRLEN];
     DebugTxn("http_trans", "[ReDNSRoundRobin] DNS lookup for O.S. successful IP: %s",
-          ats_ip_ntop(&s->server_info.addr.sa, addrbuf, sizeof(addrbuf)));
+          ats_ip_ntop(&s->server_info.remote_addr.sa, addrbuf, sizeof(addrbuf)));
 
     s->next_action = how_to_open_connection(s);
   } else {
@@ -1684,7 +1684,7 @@ HttpTransact::OSDNSLookup(State* s)
     // HostDB addresses. We use those if they're different from the CTA.
     // In all cases we now commit to client or HostDB for our source.
     if (s->host_db_info.round_robin) {
-      HostDBInfo* cta = s->host_db_info.rr()->select_next(&s->current.server->addr.sa);
+      HostDBInfo* cta = s->host_db_info.rr()->select_next(&s->current.server->remote_addr.sa);
       if (cta) {
         // found another addr, lock in host DB.
         s->host_db_info = *cta;
@@ -1693,7 +1693,7 @@ HttpTransact::OSDNSLookup(State* s)
         // nothing else there, continue with CTA.
         s->dns_info.os_addr_style = DNSLookupInfo::OS_ADDR_USE_CLIENT;
       }
-    } else if (ats_ip_addr_eq(s->host_db_info.ip(), &s->server_info.addr.sa)) {
+    } else if (ats_ip_addr_eq(s->host_db_info.ip(), &s->server_info.remote_addr.sa)) {
       s->dns_info.os_addr_style = DNSLookupInfo::OS_ADDR_USE_CLIENT;
     } else {
       s->dns_info.os_addr_style = DNSLookupInfo::OS_ADDR_USE_HOSTDB;
@@ -1703,14 +1703,14 @@ HttpTransact::OSDNSLookup(State* s)
   // Check to see if can fullfill expect requests based on the cached
   // update some state variables with hostdb information that has
   // been provided.
-  ats_ip_copy(&s->server_info.addr, s->host_db_info.ip());
-  ats_ip_copy(&s->request_data.dest_ip, &s->server_info.addr);
+  ats_ip_copy(&s->server_info.remote_addr, s->host_db_info.ip());
+  ats_ip_copy(&s->request_data.dest_ip, &s->server_info.remote_addr);
   get_ka_info_from_host_db(s, &s->server_info, &s->client_info, &s->host_db_info);
   s->server_info.dns_round_robin = s->host_db_info.round_robin;
 
   char addrbuf[INET6_ADDRSTRLEN];
   DebugTxn("http_trans", "[OSDNSLookup] DNS lookup for O.S. successful "
-        "IP: %s", ats_ip_ntop(&s->server_info.addr.sa, addrbuf, sizeof(addrbuf)));
+        "IP: %s", ats_ip_ntop(&s->server_info.remote_addr.sa, addrbuf, sizeof(addrbuf)));
 
   // so the dns lookup was a success, but the lookup succeeded on
   // a hostname which was expanded by the traffic server. we should
@@ -2648,7 +2648,7 @@ HttpTransact::HandleCacheOpenReadHit(State* s)
     }
 
     if (server_up || s->stale_icp_lookup) {
-      if (!s->stale_icp_lookup && !ats_is_ip(&s->current.server->addr)) {
+      if (!s->stale_icp_lookup && !ats_is_ip(&s->current.server->remote_addr)) {
 //        ink_release_assert(s->current.request_to == PARENT_PROXY ||
 //                    s->http_config_param->no_dns_forward_to_parent != 0);
 
@@ -3046,7 +3046,7 @@ HttpTransact::HandleCacheOpenReadMiss(State* s)
 
   if (!h->is_cache_control_set(HTTP_VALUE_ONLY_IF_CACHED)) {
     find_server_and_update_current_info(s);
-    if (!ats_is_ip(&s->current.server->addr)) {
+    if (!ats_is_ip(&s->current.server->remote_addr)) {
       ink_release_assert(s->current.request_to == PARENT_PROXY ||
                   s->http_config_param->no_dns_forward_to_parent != 0);
       if (s->current.request_to == PARENT_PROXY) {
@@ -3089,14 +3089,14 @@ HttpTransact::HandleICPLookup(State* s)
   if (s->icp_lookup_success == true) {
     HTTP_INCREMENT_TRANS_STAT(http_icp_suggested_lookups_stat);
     DebugTxn("http_trans", "[HandleICPLookup] Success, sending request to icp suggested host.");
-    ats_ip4_set(&s->icp_info.addr, s->icp_ip_result.sin_addr.s_addr);
-    s->icp_info.port = ntohs(s->icp_ip_result.sin_port);
+    ats_ip4_set(&s->icp_info.remote_addr, s->icp_ip_result.sin_addr.s_addr);
+    s->icp_info.local_addr.port() = ntohs(s->icp_ip_result.sin_port);
 
     // TODO in this case we should go to the miss case
     // just a little shy about using goto's, that's all.
     ink_release_assert(
-        (s->icp_info.port != s->client_info.port) ||
-        (ats_ip_addr_cmp(&s->icp_info.addr.sa, &Machine::instance()->ip.sa) != 0)
+        (s->icp_info.local_addr.port() != s->client_info.local_addr.port()) ||
+        (ats_ip_addr_cmp(&s->icp_info.remote_addr.sa, &Machine::instance()->ip.sa) != 0)
     );
 
     // Since the ICPDNSLookup is not called, these two
@@ -3119,10 +3119,10 @@ HttpTransact::HandleICPLookup(State* s)
     SET_VIA_STRING(VIA_DETAIL_CACHE_LOOKUP, VIA_DETAIL_MISS_NOT_CACHED);
     DebugTxn("http_trans", "[HandleICPLookup] Failure, sending request to forward server.");
     s->parent_info.name = NULL;
-    ink_zero(s->parent_info.addr);
+    ink_zero(s->parent_info.remote_addr);
 
     find_server_and_update_current_info(s);
-    if (!ats_is_ip(&s->current.server->addr)) {
+    if (!ats_is_ip(&s->current.server->remote_addr)) {
       if (s->current.request_to == PARENT_PROXY) {
         TRANSACT_RETURN(SM_ACTION_DNS_LOOKUP, PPDNSLookup);
       } else {
@@ -3402,7 +3402,7 @@ HttpTransact::handle_response_from_icp_suggested_host(State* s)
     // send request to parent proxy now if there is
     // one or else directly to the origin server.
     find_server_and_update_current_info(s);
-    if (!ats_is_ip(&s->current.server->addr)) {
+    if (!ats_is_ip(&s->current.server->remote_addr)) {
       if (s->current.request_to == PARENT_PROXY) {
         TRANSACT_RETURN(SM_ACTION_DNS_LOOKUP, PPDNSLookup);
       } else {
@@ -3467,7 +3467,7 @@ HttpTransact::handle_response_from_parent(State* s)
 
       char addrbuf[INET6_ADDRSTRLEN];
       DebugTxn("http_trans", "[%d] failed to connect to parent %s", s->current.attempts,
-            ats_ip_ntop(&s->current.server->addr.sa, addrbuf, sizeof(addrbuf)));
+            ats_ip_ntop(&s->current.server->remote_addr.sa, addrbuf, sizeof(addrbuf)));
 
       // If the request is not retryable, just give up!
       if (!is_request_retryable(s)) {
@@ -3622,7 +3622,7 @@ HttpTransact::handle_response_from_server(State* s)
         // Force host resolution to have the same family as the client.
         // Because this is a transparent connection, we can't switch address
         // families - that is locked in by the client source address.
-        s->state_machine->ua_session->host_res_style = ats_host_res_match(&s->current.server->addr.sa);
+        s->state_machine->ua_session->host_res_style = ats_host_res_match(&s->current.server->remote_addr.sa);
         TRANSACT_RETURN(SM_ACTION_DNS_LOOKUP, OSDNSLookup);
       } else if ((s->dns_info.srv_lookup_success || s->server_info.dns_round_robin) &&
                  (s->txn_conf->connect_attempts_rr_retries > 0) &&
@@ -3675,7 +3675,7 @@ HttpTransact::delete_server_rr_entry(State* s, int max_retries)
   char addrbuf[INET6_ADDRSTRLEN];
 
   DebugTxn("http_trans", "[%d] failed to connect to %s", s->current.attempts,
-        ats_ip_ntop(&s->current.server->addr.sa, addrbuf, sizeof(addrbuf)));
+        ats_ip_ntop(&s->current.server->remote_addr.sa, addrbuf, sizeof(addrbuf)));
   DebugTxn("http_trans", "[delete_server_rr_entry] marking rr entry " "down and finding next one");
   ink_assert(s->current.server->had_connect_fail());
   ink_assert(s->current.request_to == ORIGIN_SERVER);
@@ -3710,7 +3710,7 @@ HttpTransact::retry_server_connection_not_open(State* s, ServerState_t conn_stat
   char *url_string = s->hdr_info.client_request.url_string_get(&s->arena);
 
   DebugTxn("http_trans", "[%d] failed to connect [%d] to %s", s->current.attempts, conn_state,
-        ats_ip_ntop(&s->current.server->addr.sa, addrbuf, sizeof(addrbuf)));
+        ats_ip_ntop(&s->current.server->remote_addr.sa, addrbuf, sizeof(addrbuf)));
 
   //////////////////////////////////////////
   // on the first connect attempt failure //
@@ -3720,7 +3720,7 @@ HttpTransact::retry_server_connection_not_open(State* s, ServerState_t conn_stat
     Log::error("CONNECT:[%d] could not connect [%s] to %s for '%s'",
      s->current.attempts,
      HttpDebugNames::get_server_state_name(conn_state),
-     ats_ip_ntop(&s->current.server->addr.sa, addrbuf, sizeof(addrbuf)), url_string ? url_string : "<none>"
+     ats_ip_ntop(&s->current.server->remote_addr.sa, addrbuf, sizeof(addrbuf)), url_string ? url_string : "<none>"
     );
 
   if (url_string) {
@@ -5044,11 +5044,11 @@ HttpTransact::add_client_ip_to_outgoing_request(State* s, HTTPHdr* request)
   char ip_string[INET6_ADDRSTRLEN + 1] = {'\0'};
   size_t ip_string_size = 0;
 
-  if (!ats_is_ip(&s->client_info.addr.sa))
+  if (!ats_is_ip(&s->client_info.remote_addr.sa))
     return;
 
   // Always prepare the IP string.
-  if (ats_ip_ntop(&s->client_info.addr.sa, ip_string, sizeof(ip_string)) != NULL) {
+  if (ats_ip_ntop(&s->client_info.remote_addr.sa, ip_string, sizeof(ip_string)) != NULL) {
     ip_string_size += strlen(ip_string);
   } else {
     // Failure, omg
@@ -5412,13 +5412,13 @@ void
 HttpTransact::initialize_state_variables_for_origin_server(State* s, HTTPHdr* incoming_request, bool second_time)
 {
   if (s->server_info.name && !second_time) {
-    ink_assert(s->server_info.port != 0);
+    ink_assert(s->server_info.local_addr.port() != 0);
   }
 
   int host_len;
   const char *host = incoming_request->host_get(&host_len);
   s->server_info.name = s->arena.str_store(host, host_len);
-  s->server_info.port = incoming_request->port_get();
+  s->server_info.local_addr.port() = incoming_request->port_get();
 
   if (second_time) {
     s->dns_info.attempts = 0;
@@ -5488,7 +5488,7 @@ HttpTransact::initialize_state_variables_from_request(State* s, HTTPHdr* obsolet
 
   if (!s->server_info.name || s->redirect_info.redirect_in_process) {
     s->server_info.name = s->arena.str_store(host_name, host_len);
-    s->server_info.port = incoming_request->port_get();
+    s->server_info.local_addr.port() = incoming_request->port_get();
   }
 
   s->next_hop_scheme = s->scheme = incoming_request->url_get()->scheme_get_wksidx();
@@ -5555,7 +5555,7 @@ HttpTransact::initialize_state_variables_from_request(State* s, HTTPHdr* obsolet
   s->request_data.hdr = &s->hdr_info.client_request;
 
   s->request_data.hostname_str = s->arena.str_store(host_name, host_len);
-  ats_ip_copy(&s->request_data.src_ip, &s->client_info.addr);
+  ats_ip_copy(&s->request_data.src_ip, &s->client_info.remote_addr);
   memset(&s->request_data.dest_ip, 0, sizeof(s->request_data.dest_ip));
   if (s->state_machine->ua_session) {
     s->request_data.incoming_port = s->state_machine->ua_session->get_netvc()->get_local_port();
@@ -6436,7 +6436,7 @@ HttpTransact::process_quick_http_filter(State* s, int method)
     if (deny_request) {
       if (is_debug_tag_set("ip-allow")) {
         ip_text_buffer ipb;
-        Debug("ip-allow", "Quick filter denial on %s:%s with mask %x", ats_ip_ntop(&s->client_info.addr.sa, ipb, sizeof(ipb)), hdrtoken_index_to_wks(method), acl_record ? acl_record->_method_mask : 0x0);
+        Debug("ip-allow", "Quick filter denial on %s:%s with mask %x", ats_ip_ntop(&s->client_info.remote_addr.sa, ipb, sizeof(ipb)), hdrtoken_index_to_wks(method), acl_record ? acl_record->_method_mask : 0x0);
       }
       s->client_connection_enabled = false;
     }
@@ -6510,7 +6510,7 @@ HttpTransact::will_this_request_self_loop(State* s)
   if (s->dns_info.lookup_success) {
     if (ats_ip_addr_eq(s->host_db_info.ip(), &Machine::instance()->ip.sa)) {
       uint16_t host_port = s->hdr_info.client_request.url_get()->port_get();
-      uint16_t local_port = ats_ip_port_host_order(&s->client_info.addr);
+      uint16_t local_port = ats_ip_port_host_order(&s->client_info.remote_addr);
       if (host_port == local_port) {
         switch (s->dns_info.looking_up) {
         case ORIGIN_SERVER:
@@ -8094,7 +8094,7 @@ HttpTransact::build_error_response(State *s, HTTPStatus status_code, const char 
     char ip_string[INET6_ADDRSTRLEN];
 
     Log::error("RESPONSE: sent %s status %d (%s) for '%s'",
-        ats_ip_ntop(&s->client_info.addr.sa, ip_string, sizeof(ip_string)),
+        ats_ip_ntop(&s->client_info.remote_addr.sa, ip_string, sizeof(ip_string)),
         status_code,
         reason_phrase,
         (url_string ? url_string : "<none>"));

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -698,16 +698,10 @@ public:
     bool dns_round_robin;
     TransferEncoding_t transfer_encoding;
 
-    IpEndpoint addr;    // replaces 'ip' field
+    //TS-2157 Replace addr with src_addr dst_addr
+    IpEndpoint src_addr;    // replaces 'ip' field
+    IpEndpoint dst_addr;
 
-    // port to connect to, except for client
-    // connection where it is port on proxy
-    // that client connected to.
-    // This field is managed separately from the port
-    // part of 'addr' above as in various cases the two
-    // are set/manipulated independently and things are
-    // clearer this way.
-    uint16_t port; // host order.
     ServerState_t state;
     AbortState_t abort;
     HttpProxyPort::TransportType port_attribute;
@@ -729,13 +723,13 @@ public:
         name(NULL),
         dns_round_robin(false),
         transfer_encoding(NO_TRANSFER_ENCODING),
-        port(0),
         state(STATE_UNDEFINED),
         abort(ABORT_UNDEFINED),
         port_attribute(HttpProxyPort::TRANSPORT_DEFAULT),
         is_transparent(false)
     {
-      memset(&addr, 0, sizeof(addr));
+      memset(&src_addr, 0, sizeof(src_addr));
+      memset(&dst_addr, 0, sizeof(dst_addr));
     }
 
   };

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -699,8 +699,8 @@ public:
     TransferEncoding_t transfer_encoding;
 
     //TS-2157 Replace addr with src_addr dst_addr
-    IpEndpoint src_addr;    // replaces 'ip' field
-    IpEndpoint dst_addr;
+    IpEndpoint remote_addr;    // replaces 'ip' field
+    IpEndpoint local_addr;
 
     ServerState_t state;
     AbortState_t abort;
@@ -728,8 +728,8 @@ public:
         port_attribute(HttpProxyPort::TRANSPORT_DEFAULT),
         is_transparent(false)
     {
-      memset(&src_addr, 0, sizeof(src_addr));
-      memset(&dst_addr, 0, sizeof(dst_addr));
+      memset(&remote_addr, 0, sizeof(remote_addr));
+      memset(&local_addr, 0, sizeof(local_addr));
     }
 
   };

--- a/proxy/http/HttpUpdateSM.cc
+++ b/proxy/http/HttpUpdateSM.cc
@@ -75,7 +75,7 @@ HttpUpdateSM::start_scheduled_update(Continuation * cont, HTTPHdr * request)
 
   // Fix ME: What should these be set to since there is not a
   //   real client
-  ats_ip4_set(&t_state.client_info.addr, htonl(INADDR_LOOPBACK), 0);
+  ats_ip4_set(&t_state.client_info.remote_addr, htonl(INADDR_LOOPBACK), 0);
   t_state.backdoor_request = 0;
   t_state.client_info.port_attribute = HttpProxyPort::TRANSPORT_DEFAULT;
 

--- a/proxy/http/remap/RemapProcessor.cc
+++ b/proxy/http/remap/RemapProcessor.cc
@@ -90,8 +90,8 @@ RemapProcessor::setup_for_remap(HttpTransact::State *s)
 
   if (rewrite_table->num_rules_forward_with_recv_port) {
     Debug("url_rewrite", "[lookup] forward mappings with recv port found; Using recv port %d",
-          s->client_info.port);
-    if (rewrite_table->forwardMappingWithRecvPortLookup(request_url, s->client_info.port,
+          s->client_info.local_addr.port());
+    if (rewrite_table->forwardMappingWithRecvPortLookup(request_url, s->client_info.local_addr.port(),
                                                          request_host, request_host_len, s->url_map)) {
       Debug("url_rewrite", "Found forward mapping with recv port");
       mapping_found = true;

--- a/proxy/http/remap/UrlRewrite.cc
+++ b/proxy/http/remap/UrlRewrite.cc
@@ -426,7 +426,7 @@ UrlRewrite::PerformACLFiltering(HttpTransact::State *s, url_mapping *map)
     int method = s->hdr_info.client_request.method_get_wksidx();
     int method_wksidx = (method != -1) ? (method - HTTP_WKSIDX_CONNECT) : -1;
     bool client_enabled_flag = true;
-    ink_release_assert(ats_is_ip(&s->client_info.addr));
+    ink_release_assert(ats_is_ip(&s->client_info.remote_addr));
     for (acl_filter_rule * rp = map->filter; rp; rp = rp->next) {
       bool match = true;
       if (rp->method_restriction_enabled) {
@@ -442,7 +442,7 @@ UrlRewrite::PerformACLFiltering(HttpTransact::State *s, url_mapping *map)
       if (match && rp->src_ip_valid) {
         match = false;
         for (int j = 0; j < rp->src_ip_cnt && !match; j++) {
-          res = rp->src_ip_array[j].contains(s->client_info.addr) ? 1 : 0;
+          res = rp->src_ip_array[j].contains(s->client_info.remote_addr) ? 1 : 0;
           if (rp->src_ip_array[j].invert) {
             if (res != 1)
               match = true;

--- a/proxy/logging/LogAccessHttp.cc
+++ b/proxy/logging/LogAccessHttp.cc
@@ -230,7 +230,7 @@ LogAccessHttp::marshal_plugin_identity_tag(char *buf)
 int
 LogAccessHttp::marshal_client_host_ip(char *buf)
 {
-  return marshal_ip(buf, &m_http_sm->t_state.client_info.addr.sa);
+  return marshal_ip(buf, &m_http_sm->t_state.client_info.remote_addr.sa);
 }
 
 /*-------------------------------------------------------------------------
@@ -240,7 +240,7 @@ int
 LogAccessHttp::marshal_client_host_port(char *buf)
 {
   if (buf) {
-    uint16_t port = ntohs(m_http_sm->t_state.client_info.addr.port());
+    uint16_t port = ntohs(m_http_sm->t_state.client_info.remote_addr.port());
     marshal_int(buf, port);
   }
   return INK_MIN_ALIGN;
@@ -773,7 +773,7 @@ LogAccessHttp::marshal_proxy_req_server_name(char *buf)
 int
 LogAccessHttp::marshal_proxy_req_server_ip(char *buf)
 {
-  return marshal_ip(buf, m_http_sm->t_state.current.server != NULL ? &m_http_sm->t_state.current.server->addr.sa : 0);
+  return marshal_ip(buf, m_http_sm->t_state.current.server != NULL ? &m_http_sm->t_state.current.server->remote_addr.sa : 0);
 }
 
 /*-------------------------------------------------------------------------
@@ -797,10 +797,10 @@ int
 LogAccessHttp::marshal_server_host_ip(char *buf)
 {
   sockaddr const* ip = 0;
-  ip = &m_http_sm->t_state.server_info.addr.sa;
+  ip = &m_http_sm->t_state.server_info.remote_addr.sa;
   if (! ats_is_ip(ip)) {
     if (m_http_sm->t_state.current.server) {
-      ip = &m_http_sm->t_state.current.server->addr.sa;
+      ip = &m_http_sm->t_state.current.server->remote_addr.sa;
       if (! ats_is_ip(ip)) ip = 0;
     } else {
       ip = 0;


### PR DESCRIPTION
Have made initial changes.  No added functionality as of yet.  Have tested and performs the same as previous addr/port version in my tests.  Wondering if someone could give this a look/if we should extend api to allow for more control over local_addr and remote_addr.  There will also be some occasions where local_addr remains unused do we want to set it in all cases?  If so, where? Feel free to let me know in code review.