### PR TITLE
Allow transparent pass through for SSL port

### DIFF
--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -52,6 +52,8 @@
 #define SSL_TLSEXT_ERR_NOACK 3
 #endif
 
+#define SSL_OP_HANDSHAKE 0x16
+
 // TS-2503: dynamic TLS record sizing
 // For smaller records, we should also reserve space for various TCP options
 // (timestamps, SACKs.. up to 40 bytes [1]), and account for TLS record overhead
@@ -136,6 +138,16 @@ public:
     sslClientRenegotiationAbort = state;
   };
 
+  bool getTransparentPassThrough() const
+  {
+    return transparentPassThrough;
+  };
+
+  void setTransparentPassThrough(bool val)
+  {
+    transparentPassThrough = val;
+  };
+
   // Copy up here so we overload but don't override
   using super::reenable;
 
@@ -181,6 +193,8 @@ private:
   MIOBuffer *handShakeBuffer;
   IOBufferReader *handShakeHolder;
   IOBufferReader *handShakeReader;
+
+  bool transparentPassThrough;
 
   /// The current hook.
   /// @note For @C SSL_HOOKS_INVOKE, this is the hook to invoke.

--- a/iocore/net/P_SSLNextProtocolAccept.h
+++ b/iocore/net/P_SSLNextProtocolAccept.h
@@ -34,7 +34,7 @@
 class SSLNextProtocolAccept: public SessionAccept
 {
 public:
-  SSLNextProtocolAccept(Continuation *);
+  SSLNextProtocolAccept(Continuation *, bool);
   ~SSLNextProtocolAccept();
 
   void accept(NetVConnection *, MIOBuffer *, IOBufferReader*);
@@ -58,6 +58,7 @@ private:
   MIOBuffer * buffer; // XXX do we really need this?
   Continuation * endpoint;
   SSLNextProtocolSet protoset;
+  bool transparent_passthrough;
 
 friend struct SSLNextProtocolTrampoline;
 };

--- a/iocore/net/SSLNextProtocolAccept.cc
+++ b/iocore/net/SSLNextProtocolAccept.cc
@@ -125,6 +125,9 @@ SSLNextProtocolAccept::mainEvent(int event, void * edata)
   switch (event) {
   case NET_EVENT_ACCEPT:
     ink_release_assert(netvc != NULL);
+
+    netvc->setTransparentPassThrough(transparent_passthrough);
+
     // Register our protocol set with the VC and kick off a zero-length read to
     // force the SSLNetVConnection to complete the SSL handshake. Don't tell
     // the endpoint that there is an accept to handle until the read completes
@@ -158,8 +161,9 @@ SSLNextProtocolAccept::unregisterEndpoint(
   return this->protoset.unregisterEndpoint(protocol, handler);
 }
 
-SSLNextProtocolAccept::SSLNextProtocolAccept(Continuation * ep)
-    : SessionAccept(NULL), buffer(new_empty_MIOBuffer()), endpoint(ep)
+SSLNextProtocolAccept::SSLNextProtocolAccept(Continuation * ep, bool transparent_passthrough)
+    : SessionAccept(NULL), buffer(new_empty_MIOBuffer()), endpoint(ep),
+      transparent_passthrough(transparent_passthrough)
 {
   SET_HANDLER(&SSLNextProtocolAccept::mainEvent);
 }

--- a/proxy/http/HttpProxyServerMain.cc
+++ b/proxy/http/HttpProxyServerMain.cc
@@ -190,7 +190,7 @@ MakeHttpProxyAcceptor(HttpProxyAcceptor& acceptor, HttpProxyPort& port, unsigned
   }
 
   if (port.isSSL()) {
-    SSLNextProtocolAccept *ssl = new SSLNextProtocolAccept(probe);
+    SSLNextProtocolAccept *ssl = new SSLNextProtocolAccept(probe, port.m_transparent_passthrough);
 
     // ALPN selects the first server-offered protocol,
     // so make sure that we offer the newest protocol first.

--- a/proxy/http/HttpProxyServerMain.cc
+++ b/proxy/http/HttpProxyServerMain.cc
@@ -190,7 +190,8 @@ MakeHttpProxyAcceptor(HttpProxyAcceptor& acceptor, HttpProxyPort& port, unsigned
   }
 
   if (port.isSSL()) {
-    SSLNextProtocolAccept *ssl = new SSLNextProtocolAccept(probe, port.m_transparent_passthrough);
+    SSLNextProtocolAccept *ssl = new SSLNextProtocolAccept(probe,
+      port.m_transparent_passthrough && port.m_inbound_transparent_p);
 
     // ALPN selects the first server-offered protocol,
     // so make sure that we offer the newest protocol first.


### PR DESCRIPTION
If the parsing of ClientHello fails and first byte does not indicate SSL
packet, start a blind tunnel if tr-pass is set.

This feature allows to blind-tunnel non-SSL traffic and use SNI hook for
SSL traffic.