### PR TITLE
[TS-3235] fix crash problem caused by sync problem in PluginVC.

### DIFF
--- a/proxy/PluginVC.cc
+++ b/proxy/PluginVC.cc
@@ -301,6 +301,9 @@ PluginVC::reenable(VIO * vio)
   ink_assert(magic == PLUGIN_VC_MAGIC_ALIVE);
   ink_assert(vio->mutex->thread_holding == this_ethread());
 
+  Ptr<ProxyMutex> sm_mutex = vio->mutex;
+  MUTEX_LOCK(lock, sm_mutex, this_ethread());
+
   Debug("pvc", "[%u] %s: reenable %s", core_obj->id, PVC_TYPE, (vio->op == VIO::WRITE) ? "Write" : "Read");
 
   if (vio->op == VIO::WRITE) {
@@ -365,6 +368,11 @@ PluginVC::do_io_close(int /* flag ATS_UNUSED */)
 
   Debug("pvc", "[%u] %s: do_io_close", core_obj->id, PVC_TYPE);
 
+  MUTEX_LOCK(lock, mutex, this_ethread());
+  if (closed == true) {
+    return;
+  }
+
   if (reentrancy_count > 0) {
     // Do nothing since dealloacting ourselves
     //  now will lead to us running on a dead
@@ -374,17 +382,9 @@ PluginVC::do_io_close(int /* flag ATS_UNUSED */)
     return;
   }
 
-  MUTEX_TRY_LOCK(lock, mutex, this_ethread());
+  setup_event_cb(PVC_LOCK_RETRY_TIME, &sm_lock_retry_event);
+  closed = true;
 
-  if (!lock.is_locked()) {
-    setup_event_cb(PVC_LOCK_RETRY_TIME, &sm_lock_retry_event);
-    closed = true;
-    return;
-  } else {
-    closed = true;
-  }
-
-  process_close();
 }
 
 void


### PR DESCRIPTION
This fix is for the multi-thread sync problem exists in PluginVC of TS-3235.
Below is the scenario of this problem:
1. customer uses interceptplugin which calls TSVIOReenable and TSVConnClose and that will call PluginVC's APIs in their work threads
2. That customer creates  their work threads by using TSThreadCreate which are not controlled by ATS.
3. Because the interceptplugin works in their work threads and the lock provided by interceptplugin can only sync their work threads and it cannot sync the threads between ATS and interceptplugin, the sync problem will occur when TSVIOReenable and TSVConnClose are called from intercetplugin in customer's work threads.

So, we need to consider this kind of scenario also, as it is common to customer to start their threads.