### PR TITLE
TS-3340: Coverity fixes: CID #1022050

### DIFF
--- a/lib/ts/Version.cc
+++ b/lib/ts/Version.cc
@@ -47,21 +47,24 @@ AppVersionInfo::setup(const char *pkg_name, const char *app_name, const char *ap
 {
   char month_name[8];
   int year, month, day, hour, minute, second;
+  bool invalid_datetime;
 
   static const char *months[] = {
     "Jan", "Feb", "Mar", "Apr", "May", "Jun",
     "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", "???"
   };
 
-  // coverity[secure_coding]
-  sscanf(build_time, "%d:%d:%d", &hour, &minute, &second);
-  // coverity[secure_coding]
-  sscanf(build_date, "%3s %d %d", month_name, &day, &year);
+  invalid_datetime =
+      sscanf(build_time, "%d:%d:%d", &hour, &minute, &second) < 3;
+  invalid_datetime |=
+      sscanf(build_date, "%3s %d %d", month_name, &day, &year) < 3;
 
+  // Jan=1, Feb=2 ... Dec=12, ???=13
   for (month = 0; month < 11; month++) {
     if (strcasecmp(months[month], month_name) == 0)
       break;
   }
+  month ++;
 
   ///////////////////////////////////////////
   // now construct the version information //
@@ -70,11 +73,14 @@ AppVersionInfo::setup(const char *pkg_name, const char *app_name, const char *ap
   ink_strlcpy(AppStr, app_name, sizeof(AppStr));
   snprintf(VersionStr, sizeof(VersionStr), "%s", app_version);
 
-  // If the builder set a build number, use that. Otherwise take the build timestamp.
-  if (strlen(BUILD_NUMBER) == 0) {
-    snprintf(BldNumStr, sizeof(BldNumStr), "%d%d%d", month, day, hour);
-  } else {
+  // If the builder set a build number, use that.
+  // Otherwise take the build timestamp ("??????" if invalid).
+  if (0 != strlen(BUILD_NUMBER)) {
     snprintf(BldNumStr, sizeof(BldNumStr), "%s", BUILD_NUMBER);
+  } else if (! invalid_datetime) {
+    snprintf(BldNumStr, sizeof(BldNumStr), "%02d%02d%02d", month, day, hour);
+  } else {
+    snprintf(BldNumStr, sizeof(BldNumStr), "??????");
   }
 
   snprintf(BldTimeStr, sizeof(BldTimeStr), "%s", build_time);
@@ -113,3 +119,52 @@ AppVersionInfo::setup(const char *pkg_name, const char *app_name, const char *ap
 
   defined = 1;
 }
+
+
+#if TS_HAS_TESTS
+#include <ts/TestBox.h>
+
+/**
+ * AppVersionInfo class test.
+ */
+REGRESSION_TEST(AppVersionInfo)(RegressionTest* t, int /* atype ATS_UNUSED */,
+    int*  pstatus)
+{
+  *pstatus = REGRESSION_TEST_PASSED;
+
+  AppVersionInfo info;
+
+  TestBox tb(t, pstatus);
+
+  const char * errMsgFormat = "wrong build number, expected '%s', got '%s'";
+  const char * bench[][3] =
+  {
+      // date, time, resulting build number
+      {"Oct  4 1957", "19:28:34", BUILD_NUMBER},
+      {"Oct  4 1957", "19:28:34", "100419"},
+      {"Apr  4 1957", "09:08:04", "040409"},
+      {" 4 Apr 1957", "09:08:04", "??????"},
+      {"Apr  4 1957", "09-08-04", "??????"}
+  };
+
+  int benchSize = sizeof(bench) / sizeof(bench[0]);
+
+  if (0 != strlen(BUILD_NUMBER)) {
+    // Since BUILD_NUMBER is defined by a #define directive, it is not
+    // possible to change the version value from inside the regression test.
+    // If not empty BUILD_NUMBER overrides any result, in this case run only
+    // this test (the rest will always fail).
+    info.setup("Apache Traffic Server", "traffic_server", "5.2.1",
+        bench[0][0], bench[0][1], "build_slave", "builder", "");
+    tb.check(0 == strcmp(info.BldNumStr, bench[0][2]), errMsgFormat,
+        bench[0][2], info.BldNumStr);
+  } else {
+    for (int i = 1; i < benchSize; i++) {
+      info.setup("Apache Traffic Server", "traffic_server", "5.2.1",
+          bench[i][0], bench[i][1], "build_slave", "builder", "");
+      tb.check(0 == strcmp(info.BldNumStr, bench[i][2]), errMsgFormat,
+          bench[i][2], info.BldNumStr);
+    }
+  }
+}
+#endif


### PR DESCRIPTION
Fixed unchecked-return-value issues in the build number generation.
Validated input date and time format and generated a fixed-size
build number if not set by the builder.