### PR TITLE
TS-3443: Fix configure detection of openssl tls1.h

### DIFF
--- a/build/crypto.m4
+++ b/build/crypto.m4
@@ -92,6 +92,7 @@ AC_DEFUN([TS_CHECK_CRYPTO_SNI], [
   AC_CHECK_HEADERS(openssl/ssl.h openssl/ts.h)
   AC_CHECK_HEADERS(openssl/tls1.h, [], [], 
 [ #if HAVE_OPENSSL_SSL_H
+#include <openssl/ssl.h>
 #include <openssl/tls1.h>
 #endif ])
 


### PR DESCRIPTION
In openssl 1.0.2 tls1.h depends on STACK_OF to be defined, which is declared in openssl/safestack.h, so the configure check fails.

Because we already depend on ssl.h let's include that file, because it in turn includes safestack.h for us.

This problem also affects 5.2.0 which also tries to checks for tls1.h in isolation.