### PR TITLE
Background Fetch Plugin: Cleanup mutex

### DIFF
--- a/plugins/experimental/background_fetch/background_fetch.cc
+++ b/plugins/experimental/background_fetch/background_fetch.cc
@@ -270,7 +270,7 @@ public:
 
   ~BGFetchConfig()
   {
-    // ToDo: Destroy mutex ? TS-1432
+	TSMutexDestroy(_lock);	
   }
 
   void


### PR DESCRIPTION
The ticket TS-1432 describes why mutex destroy should be exposed on the API. I was added on 5.2, but the plugin was not updated. Without this call the plugin leaks memory. 