### PR TITLE
TS-3536: Fix memory leak in post processing.

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -5052,6 +5052,7 @@ HttpSM::handle_post_failure()
   t_state.current.server->keep_alive = HTTP_NO_KEEPALIVE;
 
   if (server_buffer_reader->read_avail() > 0) {
+    tunnel.deallocate_buffers();
     tunnel.reset();
     // There's data from the server so try to read the header
     setup_server_read_response_header();


### PR DESCRIPTION
With this change, we effectively undo the last of the fix for ts-2497.  I would like people to take a look.  Feifei and I have looked it over, and we have been running this in production for a month or so without problems.  But since the deallocate_buffers was original removed to avoid a crash, I'd appreciate other people's analyses.