### PR TITLE
Fix KA check for chunked responses by tracking a conn-id

### DIFF
--- a/ci/new_tsqa/tests/test_chunked.py
+++ b/ci/new_tsqa/tests/test_chunked.py
@@ -22,7 +22,6 @@ import requests
 import time
 import logging
 import json
-import threading
 import uuid
 import socket
 
@@ -56,7 +55,10 @@ class ChunkedHandler(SocketServer.BaseRequestHandler):
                 log.info('Client disconnected')
                 break
             inc_lines = data.splitlines()
-            uri = inc_lines[0].split()[1]
+            try:
+                uri = inc_lines[0].split()[1]
+            except IndexError:
+                break
             parts = 5  # how many things to send
             sleep_time = 0.2  # how long to sleep between parts
             close = True  # whether to close properly
@@ -68,10 +70,10 @@ class ChunkedHandler(SocketServer.BaseRequestHandler):
                     sleep_time = float(uri_parts[1])
                 if len(uri_parts) >= 3:
                     close = json.loads(uri_parts[2])
-
             resp = ('HTTP/1.1 200 OK\r\n'
                     'X-Conn-Id: ' + str(conn_id) + '\r\n'
                     'Transfer-Encoding: chunked\r\n'
+                    'Connection: keep-alive\r\n'
                     '\r\n')
             self.request.sendall(resp)
             for x in xrange(0, parts):
@@ -94,10 +96,10 @@ class TestChunked(helpers.EnvironmentCase):
 
         # create a socket server
         cls.port = tsqa.utils.bind_unused_port()[1]
-        server = SocketServer.TCPServer(('127.0.0.1', cls.port), ChunkedHandler)
-        t = threading.Thread(target=server.serve_forever)
-        t.daemon = True
-        t.start()
+        cls.server = tsqa.endpoint.SocketServerDaemon(ChunkedHandler, port=cls.port)
+        cls.server.start()
+        cls.server.ready.wait()
+
         cls.configs['remap.config'].add_line('map / http://127.0.0.1:{0}/'.format(cls.port))
 
         cls.configs['records.config']['CONFIG'].update({
@@ -114,23 +116,53 @@ class TestChunked(helpers.EnvironmentCase):
         '''
         Test that the origin does in fact support keepalive
         '''
-        with requests.Session() as s:
-            url = 'http://127.0.0.1:{0}/'.format(self.port)
-            ret = s.get(url)
-            conn_id = ret.headers['x-conn-id']
-            self.assertEqual(ret.text, '01234')
+        self._client_test_chunked_keepalive(self.port)
+        self._client_test_chunked_keepalive(self.port, num_bytes=2)
+        self._client_test_chunked_keepalive(self.port, num_bytes=2, sleep=1)
 
-            url = 'http://127.0.0.1:{0}/2'.format(self.port)
-            ret = s.get(url)
-            self.assertEqual(ret.text, '01')
-            self.assertEqual(ret.headers['x-conn-id'], conn_id)
+    def _client_test_chunked_keepalive(self,
+                                       port=None,
+                                       times=3,
+                                       num_bytes=None,
+                                       sleep=None,
+                                       ):
+        if port is None:
+            port = int(self.configs['records.config']['CONFIG']['proxy.config.http.server_ports'])
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.connect(('127.0.0.1', port))
 
-            url = 'http://127.0.0.1:{0}/2/1'.format(self.port)
-            start = time.time()
-            ret = s.get(url)
-            self.assertEqual(ret.text, '01')
-            self.assertEqual(ret.headers['x-conn-id'], conn_id)
-            self.assertTrue(time.time() - start > 2)
+        url = '/'
+        if num_bytes is not None:
+            url += str(num_bytes)
+        if sleep is not None:
+            if num_bytes is None:
+                raise Exception()
+            url += '/' + str(sleep)
+
+        request = ('GET ' + url + ' HTTP/1.1\r\n'
+                   'Host: 127.0.0.1\r\n'
+                   '\r\n')
+        uuid = None
+        # test basic
+        for x in xrange(1, times):
+            s.send(request)
+            resp = ''
+            while True:
+                response = s.recv(4096)
+                for line in response.splitlines():
+                    line = line.strip()
+                    if line.startswith('X-Conn-Id:'):
+                        r_uuid = line.replace('X-Conn-Id:', '')
+                        if uuid is None:
+                            uuid = r_uuid
+                        else:
+                            self.assertEqual(uuid, r_uuid)
+                resp += response
+                if resp.endswith('\r\n0\r\n\r\n'):
+                    break
+            for x in xrange(0, num_bytes or 4):
+                self.assertIn('1\r\n{0}\r\n'.format(x), resp)
+        s.close()
 
     def test_chunked_basic(self):
         url = 'http://127.0.0.1:{0}'.format(self.port)
@@ -154,27 +186,11 @@ class TestChunked(helpers.EnvironmentCase):
         self.assertEqual(conn_id, ret.headers['x-conn-id'])
 
     def test_chunked_keepalive_client(self):
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.connect(('127.0.0.1', int(self.configs['records.config']['CONFIG']['proxy.config.http.server_ports'])))
-
-        request = ('GET / HTTP/1.1\r\n'
-                   'Host: 127.0.0.1\r\n'
-                   '\r\n')
-        for x in xrange(1, 10):
-            s.send(request)
-            resp = ''
-            while True:
-                response = s.recv(4096)
-                if '0\r\n\r\n' in response:
-                    break
-                else:
-                    resp += response
-            for x in xrange(0, 4):
-                self.assertIn('1\r\n{0}\r\n'.format(x), resp)
+        self._client_test_chunked_keepalive()
+        self._client_test_chunked_keepalive(num_bytes=2)
+        self._client_test_chunked_keepalive(num_bytes=2, sleep=1)
 
     def test_chunked_bad_close(self):
         url = 'http://127.0.0.1:{0}/5/0.1/false'.format(self.port)
         with self.assertRaises(requests.exceptions.ConnectionError):
             ret = requests.get(url, proxies=self.proxies, timeout=2)
-
-

--- a/ci/new_tsqa/tests/test_keepalive.py
+++ b/ci/new_tsqa/tests/test_keepalive.py
@@ -68,13 +68,41 @@ class KeepAliveInMixin(object):
         s.connect(('127.0.0.1', int(self.configs['records.config']['CONFIG']['proxy.config.http.server_ports'])))
         return s
 
-    def _aux_working_path(self, protocol):
+    def _headers_to_str(self, headers):
+        if headers is None:
+            headers = {}
+        request = ''
+        for k, v in headers.iteritems():
+            request += '{0}: {1}\r\n'.format(k, v)
+        return request
+
+    def _aux_KA_working_path_connid(self, protocol, headers=None):
+        # connect tcp
+        s = self._get_socket()
+
+        request = ('GET / HTTP/1.1\r\n'
+                   'Host: foobar.com\r\n')
+        request += self._headers_to_str(headers)
+        request += '\r\n'
+
+        for x in xrange(1, 10):
+            s.send(request)
+            response = s.recv(4096)
+            # cheat, since we know what the body should have
+            if '\r\n\r\n' not in response:
+                response += s.recv(4096)
+            self.assertIn('HTTP/1.1 200 OK', response)
+            self.assertIn('hello', response)
+
+    def _aux_working_path(self, protocol, headers=None):
         # connect tcp
         s = self._get_socket()
 
         request = ('GET /exists/ HTTP/1.1\r\n'
-                   'Host: foobar.com\r\n'
-                   '\r\n')
+                   'Host: foobar.com\r\n')
+        request += self._headers_to_str(headers)
+        request += '\r\n'
+
         for x in xrange(1, 10):
             s.send(request)
             response = s.recv(4096)
@@ -84,19 +112,20 @@ class KeepAliveInMixin(object):
             self.assertIn('HTTP/1.1 200 OK', response)
             self.assertIn('hello', response)
 
-    def _aux_error_path(self, protocol):
+    def _aux_error_path(self, protocol, headers=None):
         # connect tcp
         s = self._get_socket()
 
         request = ('GET / HTTP/1.1\r\n'
-                   'Host: foobar.com\r\n'
-                   '\r\n')
+                   'Host: foobar.com\r\n')
+        request += self._headers_to_str(headers)
+        request += '\r\n'
         for x in xrange(1, 10):
             s.send(request)
             response = s.recv(4096)
             self.assertIn('HTTP/1.1 404 Not Found on Accelerator', response)
 
-    def _aux_error_path_post(self, protocol):
+    def _aux_error_path_post(self, protocol, headers=None):
         '''
         Ensure that sending a request with a body doesn't break the keepalive session
         '''
@@ -105,9 +134,11 @@ class KeepAliveInMixin(object):
 
         request = ('POST / HTTP/1.1\r\n'
                    'Host: foobar.com\r\n'
-                   'Content-Length: 10\r\n'
-                   '\r\n'
-                   '1234567890')
+                   'Content-Length: 10\r\n')
+        request += self._headers_to_str(headers)
+        request += '\r\n'
+        request += '1234567890'
+
         for x in xrange(1, 10):
             try:
                 s.send(request)
@@ -123,7 +154,7 @@ class KeepAliveInMixin(object):
 
 class BasicTestsOutMixin(object):
 
-    def _aux_KA_origin(self, protocol):
+    def _aux_KA_origin(self, protocol, headers=None):
         '''
         Test that the origin does in fact support keepalive
         '''
@@ -131,13 +162,13 @@ class BasicTestsOutMixin(object):
         with requests.Session() as s:
             url = '{0}://127.0.0.1:{1}/'.format(protocol, self.socket_server.port)
             for x in xrange(1, 10):
-                ret = s.get(url, verify=False)
+                ret = s.get(url, verify=False, headers=headers)
                 if not conn_id:
                     conn_id = ret.text.strip()
                 self.assertEqual(ret.status_code, 200)
                 self.assertEqual(ret.text.strip(), conn_id, "Client reports server closed connection")
 
-    def _aux_KA_proxy(self, protocol):
+    def _aux_KA_proxy(self, protocol, headers=None):
         '''
         Test that keepalive works through ATS to that origin
         '''
@@ -145,7 +176,7 @@ class BasicTestsOutMixin(object):
             self.configs['records.config']['CONFIG']['proxy.config.http.server_ports'])
         conn_id = None
         for x in xrange(1, 10):
-            ret = requests.get(url, verify=False)
+            ret = requests.get(url, verify=False, headers=headers)
             if not conn_id:
               conn_id = ret.text.strip()
             self.assertEqual(ret.status_code, 200)
@@ -189,6 +220,7 @@ class OriginMinMaxMixin(object):
         time.sleep(3)
         ret = requests.get(url, verify=False)
         self.assertEqual(ret.text.strip(), conn_id, "Client reports server closed connection")
+
 
 class TestKeepAliveInHTTP(tsqa.test_cases.DynamicHTTPEndpointCase, helpers.EnvironmentCase, KeepAliveInMixin):
     @classmethod
@@ -377,3 +409,68 @@ class TestKeepAliveOutHTTPS(helpers.EnvironmentCase, BasicTestsOutMixin, Timeout
     def test_KA_timeout_proxy(self):
         '''Tests that keepalive timeout is honored through ATS to origin via https.'''
         self._aux_KA_timeout_proxy("http")
+
+
+
+# TODO: refactor these tests, these are *very* similar, we should paramatarize them
+## Some basic tests for auth_sever_session_private
+class TestKeepAlive_Authorization_private(helpers.EnvironmentCase, BasicTestsOutMixin, KeepAliveInMixin):
+    @classmethod
+    def setUpEnv(cls, env):
+
+        cls.socket_server = tsqa.endpoint.SocketServerDaemon(KeepaliveTCPHandler)
+        cls.socket_server.start()
+        cls.socket_server.ready.wait()
+        cls.configs['remap.config'].add_line('map / http://127.0.0.1:{0}/exists/'.format(cls.socket_server.port))
+
+        # only add server headers when there weren't any
+        cls.configs['records.config']['CONFIG']['proxy.config.http.response_server_enabled'] = 2
+        cls.configs['records.config']['CONFIG']['proxy.config.http.keep_alive_enabled_in'] = 1
+        cls.configs['records.config']['CONFIG']['share_server_session'] = 2
+
+        # set only one ET_NET thread (so we don't have to worry about the per-thread pools causing issues)
+        cls.configs['records.config']['CONFIG']['proxy.config.exec_thread.limit'] = 1
+        cls.configs['records.config']['CONFIG']['proxy.config.exec_thread.autoconfig'] = 0
+
+        # make auth sessions private
+        cls.configs['records.config']['CONFIG']['proxy.config.auth_server_session_private'] = 1
+
+    def test_KA_server(self):
+        '''Tests that keepalive works through ATS to origin via https.'''
+        with self.assertRaises(AssertionError):
+            self._aux_KA_proxy("http", headers={'Authorization': 'Foo'})
+
+    def test_KA_client(self):
+        '''Tests that keepalive works through ATS to origin via https.'''
+        with self.assertRaises(AssertionError):
+            self._aux_KA_working_path_connid("http", headers={'Authorization': 'Foo'})
+
+
+class TestKeepAlive_Authorization_no_private(helpers.EnvironmentCase, BasicTestsOutMixin, KeepAliveInMixin):
+    @classmethod
+    def setUpEnv(cls, env):
+
+        cls.socket_server = tsqa.endpoint.SocketServerDaemon(KeepaliveTCPHandler)
+        cls.socket_server.start()
+        cls.socket_server.ready.wait()
+        cls.configs['remap.config'].add_line('map / http://127.0.0.1:{0}/exists/'.format(cls.socket_server.port))
+
+        # only add server headers when there weren't any
+        cls.configs['records.config']['CONFIG']['proxy.config.http.response_server_enabled'] = 2
+        cls.configs['records.config']['CONFIG']['proxy.config.http.keep_alive_enabled_in'] = 1
+        cls.configs['records.config']['CONFIG']['share_server_session'] = 2
+
+        # set only one ET_NET thread (so we don't have to worry about the per-thread pools causing issues)
+        cls.configs['records.config']['CONFIG']['proxy.config.exec_thread.limit'] = 1
+        cls.configs['records.config']['CONFIG']['proxy.config.exec_thread.autoconfig'] = 0
+
+        # make auth sessions private
+        cls.configs['records.config']['CONFIG']['proxy.config.http.auth_server_session_private'] = 0
+
+    def test_KA_server(self):
+        '''Tests that keepalive works through ATS to origin via https.'''
+        self._aux_KA_proxy("http", headers={'Authorization': 'Foo'})
+
+    def test_KA_client(self):
+        '''Tests that keepalive works through ATS to origin via https.'''
+        self._aux_KA_working_path_connid("http", headers={'Authorization': 'Foo'})


### PR DESCRIPTION
A test case for https://issues.apache.org/jira/browse/TS-3557