### PR TITLE
Solve 'undefined reference to symbol MD5_Final@@OPENSSL_1.0.0'.…

### DIFF
--- a/cmd/traffic_wccp/Makefile.am
+++ b/cmd/traffic_wccp/Makefile.am
@@ -22,7 +22,8 @@ AM_CPPFLAGS = $(iocore_include_dirs) \
   -I$(top_srcdir)/lib \
   -I$(top_srcdir)/lib/records \
   -I$(top_srcdir)/lib/ts \
-  -I$(top_srcdir)/lib/wccp
+  -I$(top_srcdir)/lib/wccp \
+  @OPENSSL_INCLUDES@
 
 AM_LDFLAGS = \
   @EXTRA_CXX_LDFLAGS@ \
@@ -37,5 +38,5 @@ traffic_wccp_SOURCES = \
 traffic_wccp_LDADD = \
   $(top_builddir)/lib/tsconfig/libtsconfig.la \
   $(top_builddir)/lib/wccp/libwccp.a \
-  $(top_builddir)/lib/ts/libtsutil.la
-
+  $(top_builddir)/lib/ts/libtsutil.la \
+  @OPENSSL_LIBS@


### PR DESCRIPTION
Fix for TS-3632

While building ATS 5.3 for Debian, I had the exact same error as reported in TS-3632.
I solved it adding OPENSSL_INCLUDE & OPENSSL_LIBS in Makefile.am.

Now build & tests are OK.