### PR TITLE
TS-3378: SpdyRequest used after free.

### DIFF
--- a/proxy/spdy/SpdyCallbacks.cc
+++ b/proxy/spdy/SpdyCallbacks.cc
@@ -188,7 +188,7 @@ spdy_fetcher_launch(SpdyRequest *req)
   fetch_flags |= TS_FETCH_FLAGS_NOT_INTERNAL_REQUEST;
 
   req->fetch_sm = TSFetchCreate((TSCont)sm, req->method.c_str(), url.c_str(), req->version.c_str(), client_addr, fetch_flags);
-  TSFetchUserDataSet(req->fetch_sm, (void *)req->stream_id);
+  TSFetchUserDataSet(req->fetch_sm, (void *)req);
 
   //
   // Set header list

--- a/proxy/spdy/SpdyCallbacks.cc
+++ b/proxy/spdy/SpdyCallbacks.cc
@@ -188,7 +188,7 @@ spdy_fetcher_launch(SpdyRequest *req)
   fetch_flags |= TS_FETCH_FLAGS_NOT_INTERNAL_REQUEST;
 
   req->fetch_sm = TSFetchCreate((TSCont)sm, req->method.c_str(), url.c_str(), req->version.c_str(), client_addr, fetch_flags);
-  TSFetchUserDataSet(req->fetch_sm, req);
+  TSFetchUserDataSet(req->fetch_sm, (void *)req->stream_id);
 
   //
   // Set header list


### PR DESCRIPTION
Changed logic to look up request by stream ID from the spdy_fetch callback rather than setting the request pointer directly in the data set with the FetchSM argument which may have been freed.
Would appreciate a review by SPDY experts before committing.