### PR TITLE
Ts 3656

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -1804,14 +1804,6 @@ HttpSM::state_read_server_response_header(int event, void *data)
     t_state.transact_return_point = HttpTransact::HandleResponse;
     t_state.api_next_action = HttpTransact::SM_ACTION_API_READ_RESPONSE_HDR;
 
-    // if exceeded limit deallocate postdata buffers and disable redirection
-    if (enable_redirection && (redirection_tries < HttpConfig::m_master.number_of_redirections)) {
-      ++redirection_tries;
-    } else {
-      tunnel.deallocate_redirect_postdata_buffers();
-      enable_redirection = false;
-    }
-
     do_api_callout();
     break;
   case PARSE_CONT:
@@ -3401,8 +3393,6 @@ HttpSM::tunnel_handler_for_partial_post(int event, void * /* data ATS_UNUSED */)
   STATE_ENTER(&HttpSM::tunnel_handler_for_partial_post, event);
   tunnel.deallocate_buffers();
   tunnel.reset();
-
-  tunnel.allocate_redirect_postdata_producer_buffer();
 
   t_state.redirect_info.redirect_in_process = false;
 
@@ -5303,17 +5293,20 @@ HttpSM::do_setup_post_tunnel(HttpVC_t to_vc_type)
   // if redirect_in_process and redirection is enabled add static producer
 
   if (t_state.redirect_info.redirect_in_process && enable_redirection &&
-      (tunnel.postbuf && tunnel.postbuf->postdata_copy_buffer_start != NULL && tunnel.postbuf->postdata_producer_buffer != NULL)) {
+      (tunnel.postbuf && tunnel.postbuf->postdata_copy_buffer_start != NULL)) {
     post_redirect = true;
     // copy the post data into a new producer buffer for static producer
-    tunnel.postbuf->postdata_producer_buffer->write(tunnel.postbuf->postdata_copy_buffer_start);
-    int64_t post_bytes = tunnel.postbuf->postdata_producer_reader->read_avail();
+    int64_t alloc_index = buffer_size_to_index(t_state.hdr_info.request_content_length);
+    MIOBuffer *postdata_producer_buffer = new_MIOBuffer(alloc_index);
+    IOBufferReader *postdata_producer_reader = postdata_producer_buffer->alloc_reader();
+    postdata_producer_buffer->write(tunnel.postbuf->postdata_copy_buffer_start);
+    int64_t post_bytes = postdata_producer_reader->read_avail();
     transfered_bytes = post_bytes;
-    p = tunnel.add_producer(HTTP_TUNNEL_STATIC_PRODUCER, post_bytes, tunnel.postbuf->postdata_producer_reader,
+    p = tunnel.add_producer(HTTP_TUNNEL_STATIC_PRODUCER, post_bytes, postdata_producer_reader,
                             (HttpProducerHandler)NULL, HT_STATIC, "redirect static agent post");
     // the tunnel has taken over the buffer and will free it
-    tunnel.postbuf->postdata_producer_buffer = NULL;
-    tunnel.postbuf->postdata_producer_reader = NULL;
+    postdata_producer_buffer = NULL;
+    postdata_producer_reader = NULL;
   } else {
     int64_t alloc_index;
     // content length is undefined, use default buffer size
@@ -5342,6 +5335,8 @@ HttpSM::do_setup_post_tunnel(HttpVC_t to_vc_type)
     ua_buffer_reader->consume(client_request_body_bytes);
     p = tunnel.add_producer(ua_entry->vc, post_bytes - transfered_bytes, buf_start, &HttpSM::tunnel_handler_post_ua, HT_HTTP_CLIENT,
                             "user agent post");
+    post_buffer = NULL;
+    buf_start = NULL;
   }
   ua_entry->in_tunnel = true;
 
@@ -7287,8 +7282,10 @@ void
 HttpSM::do_redirect()
 {
   DebugSM("http_redirect", "[HttpSM::do_redirect]");
-  if (!enable_redirection || redirection_tries >= HttpConfig::m_master.number_of_redirections) {
+  // if exceeded limit deallocate postdata buffers and disable redirection
+  if (!enable_redirection || (redirection_tries++ >= HttpConfig::m_master.number_of_redirections)) {
     tunnel.deallocate_redirect_postdata_buffers();
+    enable_redirection = false;
     return;
   }
 

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -3144,8 +3144,7 @@ HttpSM::tunnel_handler_ua(int event, HttpTunnelConsumer *c)
   if (close_connection) {
     // If the client could be pipelining, we need to set the ua_session into half close mode
 
-    if (t_state.client_info.pipeline_possible == true && c->producer->vc_type != HT_STATIC &&
-        event == VC_EVENT_WRITE_COMPLETE) {
+    if (t_state.client_info.pipeline_possible == true && c->producer->vc_type != HT_STATIC && event == VC_EVENT_WRITE_COMPLETE) {
       ua_session->set_half_close_flag();
     }
 
@@ -5302,8 +5301,8 @@ HttpSM::do_setup_post_tunnel(HttpVC_t to_vc_type)
     postdata_producer_buffer->write(tunnel.postbuf->postdata_copy_buffer_start);
     int64_t post_bytes = postdata_producer_reader->read_avail();
     transfered_bytes = post_bytes;
-    p = tunnel.add_producer(HTTP_TUNNEL_STATIC_PRODUCER, post_bytes, postdata_producer_reader,
-                            (HttpProducerHandler)NULL, HT_STATIC, "redirect static agent post");
+    p = tunnel.add_producer(HTTP_TUNNEL_STATIC_PRODUCER, post_bytes, postdata_producer_reader, (HttpProducerHandler)NULL, HT_STATIC,
+                            "redirect static agent post");
     // the tunnel has taken over the buffer and will free it
     postdata_producer_buffer = NULL;
     postdata_producer_reader = NULL;

--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -920,9 +920,9 @@ HttpTunnel::producer_run(HttpTunnelProducer *p)
   }
 
   // YTS Team, yamsat Plugin
-  // Allocate and copy partial POST data to buffers. Check for the various parameters
-  // including the maximum configured post data size
-  if (p->alive && sm->t_state.method == HTTP_WKSIDX_POST && sm->enable_redirection && (p->vc_type == HT_HTTP_CLIENT)) {
+  // Allocate and copy partial POST data to buffers for possible later use in redirect. 
+  // Check for the various parameters including the maximum configured post data size
+  if (p->alive && sm->t_state.method == HTTP_WKSIDX_POST && (p->vc_type == HT_HTTP_CLIENT)) {
     Debug("http_redirect", "[HttpTunnel::producer_run] client post: %" PRId64 " max size: %" PRId64 "",
           p->buffer_start->read_avail(), HttpConfig::m_master.post_copy_size);
 
@@ -1622,19 +1622,6 @@ HttpTunnel::copy_partial_post_data()
 }
 
 // YTS Team, yamsat Plugin
-// Allocate a new buffer for static producers
-void
-HttpTunnel::allocate_redirect_postdata_producer_buffer()
-{
-  int64_t alloc_index = buffer_size_to_index(sm->t_state.hdr_info.request_content_length);
-
-  ink_release_assert(postbuf->postdata_producer_buffer == NULL);
-
-  postbuf->postdata_producer_buffer = new_MIOBuffer(alloc_index);
-  postbuf->postdata_producer_reader = postbuf->postdata_producer_buffer->alloc_reader();
-}
-
-// YTS Team, yamsat Plugin
 // Allocating the post data buffers
 void
 HttpTunnel::allocate_redirect_postdata_buffers(IOBufferReader *ua_reader)
@@ -1650,13 +1637,10 @@ HttpTunnel::allocate_redirect_postdata_buffers(IOBufferReader *ua_reader)
     postbuf->ua_buffer_reader = ua_reader;
     postbuf->postdata_copy_buffer = new_MIOBuffer(alloc_index);
     postbuf->postdata_copy_buffer_start = postbuf->postdata_copy_buffer->alloc_reader();
-    allocate_redirect_postdata_producer_buffer();
   } else {
     // Reset the buffer readers
     postbuf->postdata_copy_buffer->dealloc_reader(postbuf->postdata_copy_buffer_start);
     postbuf->postdata_copy_buffer_start = postbuf->postdata_copy_buffer->alloc_reader();
-    postbuf->postdata_producer_buffer->dealloc_reader(postbuf->postdata_producer_reader);
-    postbuf->postdata_producer_reader = postbuf->postdata_producer_buffer->alloc_reader();
   }
 }
 
@@ -1669,11 +1653,6 @@ HttpTunnel::deallocate_redirect_postdata_buffers()
   Debug("http_redirect", "[HttpTunnel::deallocate_postdata_copy_buffers]");
 
   if (postbuf != NULL) {
-    if (postbuf->postdata_producer_buffer != NULL) {
-      free_MIOBuffer(postbuf->postdata_producer_buffer);
-      postbuf->postdata_producer_buffer = NULL;
-      postbuf->postdata_producer_reader = NULL; // deallocated by the buffer
-    }
     if (postbuf->postdata_copy_buffer != NULL) {
       free_MIOBuffer(postbuf->postdata_copy_buffer);
       postbuf->postdata_copy_buffer = NULL;

--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -920,7 +920,7 @@ HttpTunnel::producer_run(HttpTunnelProducer *p)
   }
 
   // YTS Team, yamsat Plugin
-  // Allocate and copy partial POST data to buffers for possible later use in redirect. 
+  // Allocate and copy partial POST data to buffers for possible later use in redirect.
   // Check for the various parameters including the maximum configured post data size
   if (p->alive && sm->t_state.method == HTTP_WKSIDX_POST && (p->vc_type == HT_HTTP_CLIENT)) {
     Debug("http_redirect", "[HttpTunnel::producer_run] client post: %" PRId64 " max size: %" PRId64 "",

--- a/proxy/http/HttpTunnel.h
+++ b/proxy/http/HttpTunnel.h
@@ -260,9 +260,7 @@ struct HttpTunnelProducer {
 class PostDataBuffers
 {
 public:
-  PostDataBuffers()
-    : postdata_copy_buffer(NULL), postdata_copy_buffer_start(NULL),
-      ua_buffer_reader(NULL)
+  PostDataBuffers() : postdata_copy_buffer(NULL), postdata_copy_buffer_start(NULL), ua_buffer_reader(NULL)
   {
     Debug("http_redirect", "[PostDataBuffers::PostDataBuffers]");
   }

--- a/proxy/http/HttpTunnel.h
+++ b/proxy/http/HttpTunnel.h
@@ -261,15 +261,13 @@ class PostDataBuffers
 {
 public:
   PostDataBuffers()
-    : postdata_producer_buffer(NULL), postdata_copy_buffer(NULL), postdata_producer_reader(NULL), postdata_copy_buffer_start(NULL),
+    : postdata_copy_buffer(NULL), postdata_copy_buffer_start(NULL),
       ua_buffer_reader(NULL)
   {
     Debug("http_redirect", "[PostDataBuffers::PostDataBuffers]");
   }
 
-  MIOBuffer *postdata_producer_buffer;
   MIOBuffer *postdata_copy_buffer;
-  IOBufferReader *postdata_producer_reader;
   IOBufferReader *postdata_copy_buffer_start;
   IOBufferReader *ua_buffer_reader;
 };
@@ -314,7 +312,6 @@ public:
 
   // YTS Team, yamsat Plugin
   void copy_partial_post_data();
-  void allocate_redirect_postdata_producer_buffer();
   void allocate_redirect_postdata_buffers(IOBufferReader *ua_reader);
   void deallocate_redirect_postdata_buffers();
 


### PR DESCRIPTION
Changes to allow activating follow redirection in send server response hook.  Originally this would not work for the post case, because the buffers storing the post data for redirect were being freed too early.  Delayed the cleanup until later.  Also changed one of the buffers stored with the post state to be set up as local variables instead.

Also since the redirection decision is made late, we needed to make a copy (reference counted copy) of the post buffer regardless what the enable_redirection flag value happens to be at the time the post data is received from the client.

Given that the redirect and post logic are both squirrelly, I'd appreciate another set of eyes looking this over before I commit.

I have validation from a production environment that this patch works to enable the functionality.