### PR TITLE
TS-2978 Reorder member variables in HttpSM State

### DIFF
--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -829,23 +829,23 @@ public:
     bool cdn_remap_complete;
     bool first_dns_lookup;
 
+    bool backdoor_request; // internal
+    bool cop_test_page;    // internal
     ParentConfigParams *parent_params;
     ParentResult parent_result;
     HttpRequestData request_data;
     CacheControlResult cache_control;
     CacheLookupResult_t cache_lookup_result;
     // FilterResult             content_control;
-    bool backdoor_request; // internal
-    bool cop_test_page;    // internal
 
     StateMachineAction_t next_action;                      // out
     StateMachineAction_t api_next_action;                  // out
     void (*transact_return_point)(HttpTransact::State *s); // out
 
     // We keep this so we can jump back to the upgrade handler after remap is complete
-    bool is_upgrade_request;
     void (*post_remap_upgrade_return_point)(HttpTransact::State *s); // out
     const char *upgrade_token_wks;
+    bool is_upgrade_request;
 
     // Some WebSocket state
     bool is_websocket;
@@ -856,15 +856,15 @@ public:
     int64_t internal_msg_buffer_size; // out
     int64_t internal_msg_buffer_fast_allocator_size;
 
-    bool icp_lookup_success;          // in
     struct sockaddr_in icp_ip_result; // in
+    bool icp_lookup_success;          // in
 
     int scheme;          // out
     int next_hop_scheme; // out
     int orig_scheme;     // pre-mapped scheme
     int method;
-    HostDBInfo host_db_info;  // in
     int cause_of_death_errno; // in
+    HostDBInfo host_db_info;  // in
 
     ink_time_t client_request_time;    // internal
     ink_time_t request_sent_time;      // internal
@@ -892,10 +892,10 @@ public:
     bool acl_filtering_performed;
 
     // INK API/Remap API plugin interface
-    remap_plugin_info::_tsremap_os_response *fp_tsremap_os_response;
     void *remap_plugin_instance;
-    HTTPStatus http_return_code;
     void *user_args[HTTP_SSN_TXN_MAX_USER_ARG];
+    remap_plugin_info::_tsremap_os_response *fp_tsremap_os_response;
+    HTTPStatus http_return_code;
 
     int api_txn_active_timeout_value;
     int api_txn_connect_timeout_value;
@@ -917,11 +917,11 @@ public:
     bool api_req_cacheable;
     bool api_resp_cacheable;
     bool api_server_addr_set;
+    bool stale_icp_lookup;
     UpdateCachedObject_t api_update_cached_object;
     LockUrl_t api_lock_url;
     StateMachineAction_t saved_update_next_action;
     CacheAction_t saved_update_cache_action;
-    bool stale_icp_lookup;
 
     // Remap plugin processor support
     UrlMappingContainer url_map;
@@ -934,15 +934,15 @@ public:
     int congestion_congested_or_failed;
     int congestion_connection_opened;
 
+    unsigned int filter_mask;
+    char *remap_redirect;
     bool reverse_proxy;
     bool url_remap_success;
-    char *remap_redirect;
-    unsigned int filter_mask;
+
+    bool api_skip_all_remapping;
 
     bool already_downgraded;
     URL pristine_url; // pristine url is the url before remap
-
-    bool api_skip_all_remapping;
 
     // Http Range: related variables
     RangeSetup_t range_setup;
@@ -971,27 +971,27 @@ public:
         is_revalidation_necessary(false), request_will_not_selfloop(false), // YTS Team, yamsat
         source(SOURCE_NONE), pre_transform_source(SOURCE_NONE), req_flavor(REQ_FLAVOR_FWDPROXY), pending_work(NULL),
         cdn_saved_next_action(SM_ACTION_UNDEFINED), cdn_saved_transact_return_point(NULL), cdn_remap_complete(false),
-        first_dns_lookup(true), parent_params(NULL), cache_lookup_result(CACHE_LOOKUP_NONE), backdoor_request(false),
-        cop_test_page(false), next_action(SM_ACTION_UNDEFINED), api_next_action(SM_ACTION_UNDEFINED), transact_return_point(NULL),
-        is_upgrade_request(false), post_remap_upgrade_return_point(NULL), upgrade_token_wks(NULL), is_websocket(false),
-        did_upgrade_succeed(false), internal_msg_buffer(NULL), internal_msg_buffer_type(NULL), internal_msg_buffer_size(0),
-        internal_msg_buffer_fast_allocator_size(-1), icp_lookup_success(false), scheme(-1), next_hop_scheme(scheme),
-        orig_scheme(scheme), method(0), cause_of_death_errno(-UNKNOWN_INTERNAL_ERROR), client_request_time(UNDEFINED_TIME),
-        request_sent_time(UNDEFINED_TIME), response_received_time(UNDEFINED_TIME), plugin_set_expire_time(UNDEFINED_TIME),
-        state_machine_id(0), first_stats(), current_stats(NULL), negative_caching(false), srv_lookup(false),
-        www_auth_content(CACHE_AUTH_NONE), client_connection_enabled(true), acl_filtering_performed(false),
-        fp_tsremap_os_response(NULL), remap_plugin_instance(0), http_return_code(HTTP_STATUS_NONE),
+        first_dns_lookup(true), backdoor_request(false), cop_test_page(false), parent_params(NULL),
+        cache_lookup_result(CACHE_LOOKUP_NONE), next_action(SM_ACTION_UNDEFINED), api_next_action(SM_ACTION_UNDEFINED), 
+        transact_return_point(NULL), post_remap_upgrade_return_point(NULL), upgrade_token_wks(NULL), is_upgrade_request(false),
+        is_websocket(false), did_upgrade_succeed(false), internal_msg_buffer(NULL), internal_msg_buffer_type(NULL), 
+        internal_msg_buffer_size(0), internal_msg_buffer_fast_allocator_size(-1), icp_lookup_success(false), scheme(-1), 
+        next_hop_scheme(scheme), orig_scheme(scheme), method(0), cause_of_death_errno(-UNKNOWN_INTERNAL_ERROR),
+        client_request_time(UNDEFINED_TIME), request_sent_time(UNDEFINED_TIME), response_received_time(UNDEFINED_TIME), 
+        plugin_set_expire_time(UNDEFINED_TIME), state_machine_id(0), first_stats(), current_stats(NULL), negative_caching(false),
+        srv_lookup(false), www_auth_content(CACHE_AUTH_NONE), client_connection_enabled(true), acl_filtering_performed(false),
+        remap_plugin_instance(0), fp_tsremap_os_response(NULL), http_return_code(HTTP_STATUS_NONE),
         api_txn_active_timeout_value(-1), api_txn_connect_timeout_value(-1), api_txn_dns_timeout_value(-1),
         api_txn_no_activity_timeout_value(-1), cache_req_hdr_heap_handle(NULL), cache_resp_hdr_heap_handle(NULL),
         api_cleanup_cache_read(false), api_server_response_no_store(false), api_server_response_ignore(false),
         api_http_sm_shutdown(false), api_modifiable_cached_resp(false), api_server_request_body_set(false),
         api_req_cacheable(false), api_resp_cacheable(false), api_server_addr_set(false),
-        api_update_cached_object(UPDATE_CACHED_OBJECT_NONE), api_lock_url(LOCK_URL_FIRST),
-        saved_update_next_action(SM_ACTION_UNDEFINED), saved_update_cache_action(CACHE_DO_UNDEFINED), stale_icp_lookup(false),
+        stale_icp_lookup(false), api_update_cached_object(UPDATE_CACHED_OBJECT_NONE), api_lock_url(LOCK_URL_FIRST),
+        saved_update_next_action(SM_ACTION_UNDEFINED), saved_update_cache_action(CACHE_DO_UNDEFINED),
         url_map(), pCongestionEntry(NULL), congest_saved_next_action(SM_ACTION_UNDEFINED), congestion_control_crat(0),
-        congestion_congested_or_failed(0), congestion_connection_opened(0), reverse_proxy(false), url_remap_success(false),
-        remap_redirect(NULL), filter_mask(0), already_downgraded(false), pristine_url(), api_skip_all_remapping(false),
-        range_setup(RANGE_NONE), num_range_fields(0), range_output_cl(0), ranges(NULL), txn_conf(NULL),
+        congestion_congested_or_failed(0), congestion_connection_opened(0), filter_mask(0), remap_redirect(NULL),
+        reverse_proxy(false), url_remap_success(false),  api_skip_all_remapping(false), already_downgraded(false),
+        pristine_url(), range_setup(RANGE_NONE), num_range_fields(0), range_output_cl(0), ranges(NULL), txn_conf(NULL),
         transparent_passthrough(false), range_in_cache(false)
     {
       int i;

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -798,8 +798,8 @@ public:
 
     HttpConfigParams *http_config_param;
     CacheLookupInfo cache_info;
-    bool force_dns;
     DNSLookupInfo dns_info;
+    bool force_dns;
     RedirectInfo redirect_info;
     unsigned int updated_server_version;
     unsigned int cache_open_write_fail_action;
@@ -831,9 +831,9 @@ public:
 
     bool backdoor_request; // internal
     bool cop_test_page;    // internal
+    HttpRequestData request_data;
     ParentConfigParams *parent_params;
     ParentResult parent_result;
-    HttpRequestData request_data;
     CacheControlResult cache_control;
     CacheLookupResult_t cache_lookup_result;
     // FilterResult             content_control;
@@ -879,6 +879,10 @@ public:
 
     StatBlock first_stats;
     StatBlock *current_stats;
+    
+    // new ACL filtering result (calculated immediately after remap)
+    bool client_connection_enabled;
+    bool acl_filtering_performed;
 
     // for negative caching
     bool negative_caching;
@@ -886,10 +890,6 @@ public:
     bool srv_lookup;
     // for authenticated content caching
     CacheAuth_t www_auth_content;
-
-    // new ACL filtering result (calculated immediately after remap)
-    bool client_connection_enabled;
-    bool acl_filtering_performed;
 
     // INK API/Remap API plugin interface
     void *remap_plugin_instance;
@@ -978,8 +978,9 @@ public:
         internal_msg_buffer_size(0), internal_msg_buffer_fast_allocator_size(-1), icp_lookup_success(false), scheme(-1), 
         next_hop_scheme(scheme), orig_scheme(scheme), method(0), cause_of_death_errno(-UNKNOWN_INTERNAL_ERROR),
         client_request_time(UNDEFINED_TIME), request_sent_time(UNDEFINED_TIME), response_received_time(UNDEFINED_TIME), 
-        plugin_set_expire_time(UNDEFINED_TIME), state_machine_id(0), first_stats(), current_stats(NULL), negative_caching(false),
-        srv_lookup(false), www_auth_content(CACHE_AUTH_NONE), client_connection_enabled(true), acl_filtering_performed(false),
+        plugin_set_expire_time(UNDEFINED_TIME), state_machine_id(0), first_stats(), current_stats(NULL), 
+        client_connection_enabled(true), acl_filtering_performed(false), negative_caching(false),
+        srv_lookup(false), www_auth_content(CACHE_AUTH_NONE), 
         remap_plugin_instance(0), fp_tsremap_os_response(NULL), http_return_code(HTTP_STATUS_NONE),
         api_txn_active_timeout_value(-1), api_txn_connect_timeout_value(-1), api_txn_dns_timeout_value(-1),
         api_txn_no_activity_timeout_value(-1), cache_req_hdr_heap_handle(NULL), cache_resp_hdr_heap_handle(NULL),


### PR DESCRIPTION
Reduce padding by grouping non four byte aligned variables together.
Packing was done by hand, and pretty much only touched bools and chars. There was no attempt to pack any structs/objects. 
Testing with sizeof()s showed a reduction in the size of HttpTransact::State from 4088B to 4064B. 
