### PR TITLE
Fixes for TS-3720

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,0 +1,4137 @@
+                                                         -*- coding: utf-8 -*-
+Changes with Apache Traffic Server 5.3.0
+
+  *) [TS-3226]: Move access of read vio inside the mutex to prevent ntodo corruption
+
+  *) [TS-3224] fix ts_lua core dump issue.
+
+  *) [TS-3229] Filter unsupported epic metric names.
+
+  *) [TS-3230] Remove unused ink_error APIs.
+
+  *) [TS-3231] Add metrics to represent configuration freshness.
+
+  *) [TS-3232] Remove obsolete proxy.config.vary_on_user_agent configuration.
+
+  *) [TS-3233] Add drain option to restart API.
+
+Changes with Apache Traffic Server 5.2.0
+
+  *) [TS-1570] Remap doesn't reject request with extract characters after port in Host header
+     Author: Cynthia Gu <czhenggu@linkedin.com>
+
+  *) [TS-3221] ink_atoi64 fix for single digit case
+     Author: Cynthia Gu <czhenggu@linkedin.com>
+
+  *) [TS-3223] Fix the internal buffer sizing.
+
+  *) [TS-3130] Delay setting buffer to NULL to prevent crash in logging
+
+  *) [TS-3207] _xstrdup incorrectly calls ink_strlcpy with 0 length strings.
+
+  *) [TS-3205] ASAN complaints on config reload freeing malloc'ed memory with
+   delete[].
+
+  *) [TS-3074] Fix FreeBSD regression.
+
+  *) [TS-3191] Reduce confusion with HTTP_TUNNEL_STATIC_PRODUCER.
+
+  *) [TS-3065] Remove"Transfer-Encoding" header when the error body was set by
+   ATS (e.g. plugin). Author: portl4t <portl4t.cn@gmail.com>
+
+  *) [TS-3064] Expose TS_EVENT_VCONN_ACTIVE_TIMEOUT in headers.
+   Author: Daniel Vitor Morilha <dmorilha@gmail.com>
+
+  *) [TS-3190] Change producer_run() to run a specific producer in more cases.
+
+  *) [TS-3188] Do not set half_close_flag on keep_alive connections.
+
+  *) [TS-3189] Delay starting read on server to user agent tunnel.
+
+  *) [TS-2417] Add forward secrecy support with DHE.
+   Author: John Eaglesham <je@8192.net>
+
+  *) [TS-3202] Enforce token character constraints on method field in HTTP header.
+
+  *) [TS-2009] Fail HTTP header parsing for null characters.
+
+  *) [TS-3196] Prevent crash due to de-allocated read VIO continuation.
+
+  *) [TS-3199] Do not wait for body for HEAD method.
+
+  *) [TS-3192] Implement proxy.config.config_dir.
+
+  *) [TS-3195] Improved crash logging.
+
+  *) [TS-3194] Remove unused proxy.config.plugin.plugin_mgmt_dir configuration.
+
+  *) [TS-3185] Increase the default spdy initial_window_size_in setting to 1MB.
+
+  *) [TS-3178] ProxyAllocators Improvements.
+
+  *) [TS-2812] Initial version of header_normalize plugin.
+
+  *) [TS-2959] Fix compiler issue for MultiCache.
+
+  *) [TS-3155] Added value_get_index to MimeField.
+
+  *) [TS-3184] spdy window_update not triggered correctly.
+
+  *) [TS-3024] Build with OPENSSL_NO_SSL_INTERN
+   Author: Susan Hinrichs <shinrich@network-geographics.com>
+
+  *) [TS-1175] Replace LogBuffer's new/delete buffer alloc with
+   ioBufAllocator.
+
+  *) [TS-1432] Adding TSMutexDestroy API.
+
+  *) [TS-3171] Minor style updates to Tokenizer interface.
+
+  *) [TS-3156] Remove MutexLock bool operators.
+   Author: Powell Molleti <powellm@yahoo-inc.com>
+
+  *) [TS-2682] Add per remap support for background fetch plugin.
+
+  *) [TS-2683]: Enhance the bg fetch plugin to support configuration
+     control with inclusion/exclusion criteria based on client-ip
+     or any header.
+
+  *) [TS-3149] Move Via decode out of traffic_line and make a separate tool.
+   Author: Meera Mosale Nataraja <mechins@gmail.com>
+
+  *) [TS-3151] Added an extra check for background fills to avoid crash.
+
+  *) [TS-3119] Add SO_LINGER socket option support.
+   Author: Kang Li <kangli@yahoo-inc.com>
+
+  *) [TS-3157] Standardize --help and --version arguments across tools.
+
+  *) [TS-3143] Create new Regex class that uses PCRE JIT.
+
+  *) [TS-3115] Add server response time logging fields.
+   Author: Acácio Centeno <acaciocenteno@gmail.com>
+
+  *) [TS-3154] Add proxy port access log tag as 'php'.
+   Author: Acácio Centeno <acaciocenteno@gmail.com>
+
+  *) [TS-3152] stop offerring HTTP/2 over TLS by default.
+
+  *) [TS-3060] Fix memory leak in cleaning up tunnel resources.
+
+  *) [TS-3147] Improvements fo ESI plugin.
+
+  *) [TS-3145] Add traffic_line --backtrace option.
+
+  *) [TS-2503]: Dynamic TLS Record Sizing for better page load latencies.
+
+  *) [TS-3139] New script, traffic_primer, which will fetch a URL from origin
+   (or another proxy) and PUSH the same object to a given set of
+   caches. Useful for priming a pool of servers with the same object.
+
+  *) [TS-3135] Disable SSLv3 by default. This can be enabled again by adding a
+   line to records.config for proxy.config.ssl.SSLv3.
+
+  *) [TS-3129] Parent proxy configuration does not work for incoming HTTPS
+   requests.
+
+  *) [TS-3127] Add config for OpenSSL session cache auto clear.
+
+  *) [TS-3125] SSL ctx is set to a constant allowing for potential
+   inappropriate session reuse.
+
+  *) [TS-3060] Enhance POST timeout scenario to send HTTP status response.
+
+  *) [TS-3120] Overlapping remap rank when using .include directives.
+   Author: Feifei Cai <ffcai@yahoo-inc.com>
+
+  *) [TS-3080] Optimized SSL session caching.
+
+  *) [TS-3121] Prevent sending garbage HTTP/0.8 responses from SPDY.
+
+  *) [TS-3116] Add support for tracking the use of the ioBuffers.
+
+  *) [TS-3106] Keep Alive not correctly applied to errored pages.
+
+  *) [TS-3109] Fix traffic_layout libhwloc linking on Ubuntu.
+
+  *) [TS-2314] - remove possible invalid array index access from debug log.
+
+  *) [TS-3112] - Add null pointer check for contp.
+
+  *) [TS-3103] Improve privilege elevation.
+
+  *) [TS-3044] Use eventfd in AIO_MODE_NATIVE if available.
+
+  *) [TS-3108] Add port matching condition to header_rewrite.
+
+  *) [TS-3068] Remove usage of Boost.
+
+  *) [TS-2289] Removed old unused AIO modes.
+
+  *) [TS-3098] Fix the ability to configure keep-alive on post to the origin.
+
+  *) [TS-3085] Large POSTs over (relatively) slower connections failing.
+
+  *) [TS-3092] Set SSL CTX timeout regardless of Session Cache.
+
+  *) [TS-2095] Replace TS_FLAG_HEADERS wich AC_CHECK_HEADERS.
+
+  *) [TS-2314] New config to allow unsatifiable Range: request to go straight
+   to Origin.
+
+  *) [TS-3006] Add SSL extensions and examples.
+     Author: Susan Hinrichs <shinrich@network-geographics.com>
+
+  *) [TS-3054] Forward partial chunked data to client to be more transparent.
+     Author: Susan Hinrichs <shinrich@network-geographics.com>
+
+  *) [TS-3084] Fix FIN forwarding issue with POST.
+     Author: Susan Hinrichs <shinrich@network-geographics.com>
+
+  *) [TS-3073] Fix FIN forwarding issue with transparent pass-through.
+     Author: Susan Hinrichs <shinrich@network-geographics.com>
+
+  *) [TS-3059] Add the TSTextLogObjectRollingSizeMbSet API function.
+   Author: Brian Rectanus <brectanus@qualys.com>
+
+  *) [TS-3081] FetchSM needs to notify body done, when no more read bytes in
+   the buffer.
+
+  *) [TS-2945] Add target port number support to the balancer plugin.
+
+  *) [TS-3070] Make span configuration work consistently across platforms.
+
+  *) [TS-3076] Fix minor strtok_r errors.
+
+  *) [TS-2938] fix core dump in 307 redirect follow handling.
+
+  *) [TS-3035] fix duplicate logging on error transactions.
+
+  *) [TS-2955] support variable expansion in set-redirect operator for header_rewrite.
+
+  *) [TS-3023] Support space separated values in inline plugin parameters in
+   remap rules.
+
+  *) [TS-3051] Fix libaio error handling.
+
+  *) [TS-3071] Optionally emit JSON numbers in stats_over_http.
+   Thanks to Saltuk Alakus <saltukalakus@gmail.com>
+
+  *) [TS-3069] Add mysql_remap to autoconf.
+
+  *) [TS-3066] Fix various build issues for OmniOS, broken since 5.0.x.
+
+  *) [TS-407] Cleanup the syslog facility setup for traffic_server.
+
+  *) [TS-3049] - Enhance FetchSM to handle response with "Connection:Close"
+     header and limit the response header/body duplication to non-streaming
+     scenarios for backward compatibility with TSFetchUrl().
+
+  *) [TS-3039] Plug SSL memory leaks in OCSP stapling support.
+
+  *) [TS-2832] docs: Add links from an API description to the source code for
+   that object.
+
+  *) [TS-3020] Blind Tunnel fake request URL is IPv4 only.
+   Author: Patrick McGleenon <Patrick.McGleenon@openwave.com>
+
+  *) [TS-2561] Remove example/app-template, it's no longer supported.
+
+  *) [TS-3048]: Remove hard coded directory in TSPluginDirGet() regression.
+   Author: Steven Feltner <steven.feltner@gmail.com>
+
+  *) [TS-3047] The Makefile.am for traffic_top is inconsistent with the rest
+   of the build system.
+
+  *) [TS-3042] Fix the option to build a static traffic_server binary.
+
+  *) [TS-3041] Add a traffic_layout tool to show the installed
+   and configured file locations.
+
+  *) [TS-3034] Use an unanchored regex match in traffic_line -m.
+
+  *) [TS-3033] Reimplement the management protocol to use a generic
+   message initial marshalling format.
+
+  *) [TS-3027] Add hashed intermediate SSL certificate support.
+   Author: Steven Feltner <steven.feltner@gmail.com>
+
+  *) [TS-3031] Race condition in SSLNextProtocolSet::advertiseProtocols
+
+  *) [TS-2983] Fix protocol probe to not skip data.
+
+  *) [TS-3026] SPDY not forwarding Accept-Encoding for FF.
+
+  *) [TS-2970] Fix assertions with transparent pass through.
+   Author: Susan Hinrichs <shinrich@network-geographics.com>
+
+  *) [TS-3150] atscppapi should support streaming HTTP fetch.
+
+Changes with Apache Traffic Server 5.1.0
+
+  *) [TS-2993] Update ats_pagespeed towards PSOL 1.8.31.4-stable.
+
+  *) [TS-3005] Rename pagespeed plugin: ats_speed -> ats_pagespeed.
+
+  *) [TS-3003] Remove overwriting of robots.txt in ats_pagespeed.
+
+  *) [TS-2926] IP Clearance for ats_speed - PageSpeed optimization plugin.
+
+  *) [TS-2954] Protect against DNS cache poisoning when
+   proxy.config.http.use_client_target_addr is enabled.
+   Author: Susan Hinrichs <shinrich@network-geographics.com>
+
+  *) [TS-2995] Apply TOS/SO marks to client connection in all accept cases.
+
+  *) [TS-2912] Don't clear stale object on HEAD request.
+
+  *) [TS-2905] Change IP logging to print '0' instead of error text.
+
+  *) [TS-2982] Interim cache compile errors.
+
+  *) [TS-2584] Remove assert for negatively cached transformed objects.
+
+  *) [TS-3001] GlobalSign responds 403 when OCSP request posted without Host header
+
+  *) [TS-2913] Missing body factory template for permanent redirects.
+
+  *) [TS-2279] Update range for proxy.config.exec_thread.affinity.
+
+  *) [TS-3004] Update vendor_name and support_email in ats_speed plugin.
+
+  *) [TS-2947] Make the setting proxy.config.http.global_user_agent_header.
+
+  *) [TS-2902] Allow POST requests without a Content-Length header.
+
+  *) [TS-2423] Add option for server sessions that use auth headers that can
+   be placed into the shared pool.
+
+  *) [TS-2635] remove unused include <net/ppp_defs.h>.
+
+  *) [TS-3001] GlobalSign responds 403 when OCSP request posted without Host
+   header.
+
+  *) [TS-2722] authproxy: Eliminate the DNS lookup state, just use the client.
+
+  *) [TS-2933] Fix post remap and effective URL.
+
+  *) [TS-2972] authproxy: Change the hook used, to always do the auth.
+
+  *) [TS-698] Add IP filter to logging.
+
+  *) [TS-3002] Add DSCP support to header_rewrite.
+
+  *) [TS-2564] Cherry pick for full cache compatibility.
+
+  *) [TS-2362] Make cache backwards compatible to 3.2.0.
+
+  *) [TS-2357] Add option to cache POST requests.
+
+  *) [TS-2996] Add consistent hash method to parent selection.
+
+  *) [TS-2332] Add Consistent Hash class.
+
+  *) [TS-1800] Create one hashing infrastructure.
+
+  *) [TS-2860] Add AArch64 support.
+
+  *) [TS-2916] set response header properly for combo_handler plugin.
+
+  *) [TS-2883] Core dump in TSFetchCreate().
+
+  *) [TS-2991] SessionManager incorrectly releasing sessions back to pool.
+
+  *) [TS-2986] Adding stats to TLS errors.
+
+  *) [TS-2977] Move traffic_manager under the cmd subdirectory.
+
+  *) [TS-2971] Authproxy plugin has inconsistent debug symbol.
+
+  *) [TS-2976] Perform some librecords build cleanup.
+
+  *) [TS-2975] Add cache lookup status support to the xdebug plugin.
+
+  *) [TS-2974] Add a new metrics plugin to support the Epic monitoring system.
+
+  *) [TS-2973] Add milestones support to the xdebug plugin.
+
+  *) [TS-2957] Add new sslheaders plugin.
+
+  *) [TS-2802] Add SNI support for origin server connections.
+   Author: Wei Sun <sunwei@yahoo-inc.com>
+
+  *) [TS-2958] url_sig: remove printf's and make redirects use appropriate
+   status codes.
+
+  *) [TS-2939] Metalink: Fix crash when checking the digest of a file
+   that wasn't cacheable.
+
+  *) [TS-2922] Support the new ppc64le platform. Author: Breno Leitao
+
+  *) [TS-2944] Remove the proxy.config.http.record_tcp_mem_hit configuration variable.
+
+  *) [TS-2924] Configurable client's ssl protocols and cipher suite.
+
+  *) [TS-2915] SEGV occurs when POST request was posted without Expect:
+   100-continue header.
+
+  *) [TS-2940] Fix varargs corruption when logging fatal errors.
+
+  *) [TS-2935] Clean up semaphore platform code.
+
+  *) [TS-2930] missing hostname in ts.client_request.get_url() for lua plugin.
+
+  *) [TS-2934] Default remap rule will remap synthetic test.
+
+  *) [TS-2904] Add Via header decoder option to traffic_line.
+   Author: Meera Mosale Nataraja <mechins@gmail.com>
+
+  *) [TS-2932] Add an option to specify the build number at configure time.
+
+  *) [TS-2931] Plugin metrics fail after a crash.
+
+  *) [TS-2649] Use SSL certificate chain loading everywhere.
+
+  *) [TS-2780] Core dump in SpdyRequest::clear() in production testing of SPDY.
+
+  *) [TS-2929] SPDY should allow arbitrary methods.
+
+  *) [TS-2921] Fix build failure from TS-2893.
+   Author: Ryo Okubo <rokubo@yahoo-corp.jp>
+
+  *) [TS-2893: improved support for ECDSA certificates.
+   Author: Wei Sun <sunwei@yahoo-inc.com>
+
+  *) [TS-2919] Omit git contol files from tarball releases.
+
+  *) [TS-2906] SPDY incorrectly marks streams as internal requests.
+
+  *) [TS-2574] Sharing server sessions per thread doesn't work when doing
+   https to http.
+
+  *) [TS-2689] Remove extraneous TSfree that caused segfault.
+
+  *) [TS-2892] Keep alive post out enabled by default.
+
+  *) [TS-2889] Crash in FetchSM related to spdy FetchSM changes in 5.0.x.
+
+  *) [TS-2891] Fix casting bug in remap_stats.
+
+  *) [TS-2879] Remap errors and redirects should honor keep-alive.
+
+  *) [TS-2236] Remove trailing null in response body set by fabricate_with_old_api.
+   Author: Thach Tran <tranngocthachs@gmail.com>
+
+  *) [TS-2877] http_load waits until timeout when response body is zero.
+   Author: Masaori Koshiba <mkoshiba@yahoo-corp.jp>
+
+Changes with Apache Traffic Server 5.0.0
+
+  *) [TS-2885] Change LuaJIT to build statically, add --disable-luajit. This
+  is an option that will eventually be removed as we make LuaJIT mandatory.
+
+  *) [TS-2886] Fix regression where body factory is not used.
+
+  *) [TS-2881] Redirection handling broken
+
+  *) [TS-2875] Change hwloc library env variables from hwloc_ to HWLOC_.
+
+  *) [TS-2874] Make some of the SPDY metrics persistent, and also fix how we
+   measure transaction time / total streams.
+
+  *) [TS-2872] Can't set "Send Window" for SPDY/3.1 > 64k. Code mostly
+   provided by our SPDY brainiac, Geffon.
+
+  *) [TS-2873] Cleanup SPDY metrics and configs, also make it use the common
+   pattern for stats increments/decrements (even though it's ugly, sorry amc).
+
+  *) [TS-2870] Update SPDY defaults to better match our other defaults.
+
+  *) [TS-2868] Error setting HSTS max age with traffic_line.
+
+  *) [TS-2776] Core dump inside openssl library.
+
+  *) [TS-2845] Commit e6b9cb533 causes problems with stats_over_http.
+
+  *) [TS-1981] Url remap and IPAllow method filtering is broken with non-wks method
+   and add support for arbitrary methods.
+
+  *) [TS-2865] Fix warnings in collapsed connection plugin.
+
+  *) [TS-2580] SSL Connection reset by peer errors in 4.2.0-rc0.
+
+  *) [TS-2783] Update documentation defaults, and fix RecordsConfig.cc.
+
+  *) [TS-2792] Large request header causes unexpected remap.
+   Author: Masakazu Kitajo <m4sk17@gmail.com>
+
+  *) [TS-2834] header_rewrite: Add Internal transaction and client-IP
+   conditions.
+
+  *) [TS-2855] Add the TSHttpIsInternalSession API.
+
+  *) [TS-2859] Remove DBG macros to not generate warnings from GCC 4.9.
+
+  *) [TS-2858] Build failures on OmniOS. Also add some LuaJIT flags as per
+   Theo's and Daniel's recommendations.
+
+  *) [TS-2857] Cleanup SPDY and SSL stat names.
+
+  *) [TS-2856] Remove proxy.config.spdy.verbose_in and use diags instead
+
+  *) [TS-2391] Traffic Server tries to reverse resolve 127.0.0.1.
+
+  *) [TS-2837] Dangling pointer in URLImpl which may cause core dump.
+
+  *) [TS-2842] Can't set SPDY inactivity timeout with traffic_line.
+
+  *) [TS-2618] IOBufferBlock::realloc()'s bounds check is wrong.
+
+  *) [TS-2850] Fix logging of response header length.
+
+  *) [TS-2839] tsxs does not work on OSX (Darwin).
+   Author: Masakazu Kitajo <m4sk17@gmail.com>
+
+  *) [TS-2820] Add check to Transformations in C++ api to prevent closing
+   connections twice.
+
+  *) [TS-2804] Add regex_revalidate plugin to explerimental plugins directory.
+
+  *) [TS-2528] Use <stdbool.h> in the public mgmtapi.h interface. This follows
+   the C99 standard, and we should move other public APIs to it.
+
+  *) [TS-2428] Move P_Freer.h continuations to run on ET_TASK (if available).
+
+  *) [TS-2344] 404 error was logged while url redirect request was processed
+   correctly.
+
+  *) [TS-2753] Add more SPDY and HTTPS statistics.
+
+  *) [TS-2677] Don't apply path / scheme URL changes in remap when method is
+   CONNECT.
+
+  *) [TS-2308] includedir in config.layout is not used.
+
+  *) [TS-2527] mgmtapi.h should be C style. This is slightly ugly in the core
+   now, but that public struct/union has to be named to be C99 compliant.
+
+  *) [TS-2838] Add logging fields for plugins to TS connect API. Use for SPDY.
+
+  *) [TS-2833] Remove REC_BUILD_STAND_ALONE, REC_BUILD_MGMT and
+   REC_BUILD_STUB. Dead code.
+
+  *) [TS-2547] Remove Resource.c/h, and NEW as well.
+
+  *) [TS-1588] slow log should include client addr
+
+  *) [TS-2728] The lib/perl Makefile.am does not properly detect in-source
+   builds, generating errors.
+
+  *) [TS-2723] add new features to ts_lua plugin.
+   Author: Quehan <quehan@taobao.com>
+
+  *) [TS-2816] Bump the minor cache version for ATS 5.0 release
+
+  *) [TS-2764] Remove when_to_add_no_cache_to_msie_requests configuration.
+
+  *) [TS-2737] Rename rfc5861 plugin to stale_while_revalidate.
+
+  *) [TS-2400] Our default SSL cipher-suite advocates speed over security
+
+  *) [TS-2818] TSHttpTxnServerAddrSet() doesn't update the server port
+
+  *) [TS-2793] Remove UnixNetVConnection::selected_next_protocol.
+
+  *) [TS-2831] Add SPDY stream count statistic.
+
+  *) [TS-1665] Remove the old traffic_shell (R.I.P.).
+
+  *) [TS-2830] Make SPDY configurable.
+
+  *) [TS-2684] Add a text-log format to background_fetch plugin.
+
+  *) [TS-2577] Tracing on e.g. -T http_hdrs does not show Proxy Request
+   headers accurately. Author: Masakazu Kitajo <m4sk17@gmail.com>
+
+  *) [TS-1486] Drop support for Sun Studio compilers.
+
+  *) [TS-2765] Memory Leak in SSLConfig initialization
+
+  *) [TS-1125] POST's with Expect: 100-continue are slowed by delayed 100
+  response
+
+  *) [TS-2826] SPDY implementation does not support OPTIONS and TRACE methods
+
+  *) [TS-2274] Minimize the default records.config, and also fix a number of
+   inconsistencies and missing configs in RecordsConfig.cc. This is as per
+   discussions on IRC etc. I have verified that traffic_line -m reports the
+   same internal values for all configs before and after this change. In
+   addition, the following defaults are changing:
+
+      - proxy.config.url_remap.pristine_host_hdr -> 0
+      - proxy.config.http.normalize_ae_gzip -> 1
+      - proxy.config.http.cache.ignore_client_cc_max_age -> 1
+      - proxy.config.http.background_fill_active_timeout -> 0
+      - proxy.config.http.background_fill_completed_threshold -> 0.0
+      - proxy.config.cache.enable_read_while_writer -> 1
+      - proxy.config.net.sock_send_buffer_size_in -> 0
+      - proxy.config.cache.permit.pinning -> 1
+      - proxy.config.diags.show_location -> 1
+      - proxy.config.dns.round_robin_nameservers -> 1
+      - proxy.config.http.connect_ports -> 443
+      - proxy.config.log.custom_logs_enabled -> 1
+      - proxy.config.spdy.client.max_concurrent_streams -> 100
+      - proxy.config.env_prep -> NULL
+
+  *) [TS-2824] Revert TS-2592.
+
+  *) [TS-2632] Do not lock the object in cache (by default) on Range
+   requests. This adds proxy.config.http.cache.range.write.
+
+  *) [TS-2822] Crash in LogBufferIterator::next
+
+  *) [TS-2705] Make the background fill check more robust.
+
+  *) [TS-1411] Seg fault when using %<cquuc>
+
+  *) [TS-2739] ATS doesn't send back Transfer-Encoding when client keep-alive
+     is turned off
+
+  *) [TS-2253] PluginVC::process_close Segmentation fault
+
+  *) [TS-2823] Change the Mgmt API names TSEvent and TSError to avoid name
+     collisions with the plugin API.
+
+  *) [TS-2029] Eliminate CacheHttpHdr argument from Cache::generate_key().
+
+  *) [TS-2821] Added configuration for max concurrent streams for SPDY.
+
+  *) [TS-2558] Remove check for inbound transparency vs. SSL.
+
+  *) [TS-2810] Add the TSVConnFdCreate API.
+
+  *) [TS-2342] Problem with cache.cache_responses_to_cookies value 0.
+   Author: Paul Marquess <Paul.Marquess@owmobility.com>
+
+  *) [TS-2751] Remove the ProtocolNetAccept layer.
+
+  *) [TS-2815] SSL orgin server connection hangs if ssl handshake is slow
+
+  *) [TS-2788] Make proxy.config.alarm.bin reloadable.
+
+  *) [TS-2811] Error logged in regex_remap when lowercase_substitutions option
+   is used.
+
+  *) [TS-2791] SPDY POST transactions failing with ERR_CLIENT_ABORT.
+
+  *) [TS-2805] Client connections are connecting with SPDY 3 instead of 3.1.
+
+  *) [TS-2619] Changed TSRecordDump declaration from TSRecordType to int to
+   accommodate bit-masks. Also changed TSRecordType enums to hexidecimal, as
+   this is easier to read for bit arguments.
+
+  *) [TS-2797] docs: Build all manual pages in the doc/reference/api
+   directory.
+
+  *) [TS-2733] Do not build the old SPDY plugin.
+
+  *) [TS-2716] Fix indentation for ts_lua plugin.
+
+  *) [TS-2789] Typo in HttpSessionManger would cause ATS reuse wrong session
+   to origin server.
+
+  *) [TS-2636] Enhance ATS custom logging to support WIPE_FIELD_VALUE filter
+   action.
+
+  *) [TS-2786, TS-2784] Make Lua and header_rewrite plugins compile on FBSD.
+
+  *) [TS-1375] Setting default inactivity timeout, if one is not set, to 1
+   day.
+
+  *) [TS-2780] Core dump in SpdyRequest::clear() in production testing of
+   SPDY.
+
+  *) [TS-2744] Remove TSNetAcceptNamedProtocol assertion for unknown
+   protocols.
+
+  *) [TS-898] Stop the esi plugin referencing invalidated strings.
+
+  *) [TS-2778] Websockets remap doesn't properly handle the implicit port for
+   wss.
+
+  *) [TS-2774] TS::AdminClient.pm's get_stat API broken in 5.0.
+
+  *) [TS-2766] HdrHeap::coalesce_str_heaps doesn't properly calculate new heap
+   size.
+
+  *) [TS-2767] ATS Memory Leak related to SPDY.
+
+  *) [TS-2757] Fix logging crashes on reconfiguration.
+
+  *) [TS-2770] Allow proxy.config.log.rolling_interval_sec to be as low as 60sec.
+
+  *) [TS-2772] Clean up mgmt/preparse code.
+
+  *) [TS-2763] Remove the unused proxy.config.log.xuid_logging_enabled config
+   setting.
+
+  *) [TS-2762] Core dump when benchmarking SPDY.
+
+  *) [TS-2755] Document TSTextLogObjectRollingEnabledSet.
+
+  *) [TS-2746] Rename session accept layer with a standard convention.
+
+  *) [TS-2754] Emit a tcpinfo log on TS_EVENT_HTTP_TXN_CLOSE.
+
+  *) [TS-2760] Add TSFetchClientProtoStackSet/Get() API in experimental.h.
+
+  *) [TS-2743] Ignore invalid HTTP headers in SpdyNV carefully.
+
+  *) [TS-2742] TSFetchCreate should accept both IPv4 and IPv6.
+
+  *) [TS-2736] Add config option to set the max open files limit for the
+    traffic_server process to some percentage of the fs.file-max proc value on
+    Linux. The default is 90%.
+
+  *) [TS-2741] Add a server intercept example plugins and documentation.
+
+  *) [TS-2616] Sanitize duplicate Transfer-Encoding: chunked headers.
+   Author: Dimitry Andric <dimitry@andric.com>
+
+  *) [TS-645] Remove broken hard restart from traffic_shell.
+
+  *) [TS-2562] Improve init script support for Debian/Ubuntu.
+   Author: Tomasz Kuzemko <tomasz@kuzemko.net>
+
+  *) [TS-2735] Align all memory during freelist allocations.
+
+  *) [TS-2120] remove stale_while_revalidate plugin.
+
+  *) [TS-2732] Add url_sign (Signed URL's) plugin.
+   Author: Jan van Doorn <jvd@knutsel.com>
+
+  *) [TS-2650] Redirect handling enhancements in ATS.
+
+  *) [TS-2548] Add client IP to SSLError() calls in SSLNetVConnection
+
+  *) [TS-2710] ATS serves the wrong cert because it matches wildcard certs
+   incorrectly.
+
+  *) [TS-2704] Core dump in state_raw_http_server_open getting EVENT_INTERVAL
+   event.
+
+  *) [TS-2720] Fix bug with request transformations in C++ api
+
+  *) [TS-2714] Promote the tcp_info plugin to stable as 'tcpinfo'.
+
+  *) [TS-2708] Refactor and modernize the tcp_info plugin.
+
+  *) [TS-2555] Adding global plugin support to ts_lua plugin.
+
+  *) [TS-2717] header-rewrite set-redirect not working.
+   Author: Igor Brezac
+
+  *) [TS-2715] Fix some ESI compile warnings, change the constants to
+   be part of an include.
+
+  *) [TS-898] Remove pointless NULL check on address of array.
+
+  *) [TS-898] Avoid passing -1 to close (2) in traffic_cop.
+
+  *) [TS-898] Fix minor regex_remap parsing bug.
+
+  *) [TS-2711] Include Lua JIT as a Submodule.
+
+  *) [TS-898] Ensure the cache span probe always closes file descriptors.
+
+  *) [TS-2706] Replace the tcp_info plugin config file with options.
+
+  *) [TS-2691] Fix how we count redirect retries in the core and APIs.
+
+  *) [TS-2693] Deprecate the old TSRedirectUrlSet()/TSRedirectUrlGet().
+
+  *) [TS-2692] Add an API to Get the current redirection retry count,
+   TSHttpTxnRedirectRetries().
+
+  *) [TS-2707] Migrate TSRedirectUrlSet/Get to TSHttpTxnRedirectUrlSet/Get.
+
+  *) [TS-2690] Fixes and improvements for the escalate plugin.
+
+  *) [TS-2699] Add TSClientProtoStackCreate API.
+
+  *) [TS-2678] Some sites (e.g. craigslist) fails to load due to
+   incorrect truncated response detection.
+
+  *) [TS-2603] Do not update HostDB for server intercept requests.
+   Author: Quehan <quehan@taobao.com>
+
+  *) [TS-2622] Optimize the ink_cluster_time() function.
+   Author: Yu Qing <zhuangyuan@taobao.com>
+
+  *) [TS-2701] Silence traffic_cop logging on chown of missing lock files.
+
+  *) [TS-2656 Determine server connection scheme immediately before
+   connecting. Author: Ron Barber <rwbarber2@gmail.com>
+
+  *) [TS-2578] Close the client connection when you close TransformTerminus.
+   Author: Jack Bates <jack@nottheoilrig.com>
+
+  *) [TS-2657] Eliminate TSHttpTxnSetHttpRetBody() and improve upon
+   TSHttpTxnErrorBodySet(). This also reduces the size of the HttpSM by 25%.
+
+  *) [TS-2589] Don't hold up the response until the server starts sending
+   content. Author: Jack Bates <jack@nottheoilrig.com>
+
+  *) [TS-2687] Support for MIPS paltform.
+   Author: Dejan Latinovic <Dejan.Latinovic@rt-rk.com>
+
+  *) [TS-2688] atscppapi: new example plugin Boom.
+   Author: Omer Shapira <oshapira@linkedin.com>
+
+  *) [TS-2686] Change background_fetch to defer cacheability check until
+   SEND_RESPONSE_HDR hook. This allows for other READ_REQUEST_HDR hooks to
+   modify the response header before we evaluate.
+
+  *) [TS-2679] background_fetch plugin can use uninitialized cont pointer.
+
+  *) [TS-2675] Metalink: Fix crash and plug memory leaks.
+   Author: Jack Bates <jack@nottheoilrig.com>
+
+  *) [TS-2674] Remove debug printf() from traffic_top.
+
+  *) [TS-2652] atscppapi: Providing a cancel() in asyncproviders .
+
+  *) [TS-2667] atscppapi: Allow intercept plugins to access request headers
+   object.
+
+  *) [TS-2672] TSMimeHdrFieldDestroy should not assert on removed fields.
+
+  *) [TS-2554] New plugin: background_fetch, which under certain conditions
+   will kick off a background fetch when it detects Range request and
+   responses. This allows for the cache to start populating objects that would
+   otherwise not be cacheable. This is ideally used together with the
+   read-while-writer feature as well.
+
+  *) [TS-2671] Restore missing .useflt remap directive.
+
+  *) [TS-2654] Crash in Range requests with read-while-writer.
+
+  *) [TS-2665] Clean up ink_stack_trace_dump code
+   Thanks to Alexey Ivanov <aivanov@linkedin.com> for reporting this issue.
+
+  *) [TS-2663] Wrong condition on log code for server connection errors.
+   Author: David Binderman <dcb314@hotmail.com>
+
+  *) [TS-2664] atscppapi: Removing initializable values.
+
+  *) [TS-2660] Rename StateMachineAction_t values for legibility.
+
+  *) [TS-2662] Re-enable KEEP_ALIVE_POST_OUT by default.
+
+  *) [TS-2661] Remove unused HttpSM::decided_cached_url.
+
+  *) [TS-2658] Additional debug logging for SSL certificates.
+
+  *) [TS-2431] Migrate Taobao SPDY plugin to ATS core.
+
+  *) [TS-2651] atscppapi: race conditions in destruction of async providers
+
+  *) [TS-2646] regex_remap: Add a new option, @caseless.
+
+  *) [TS-2647] atscppapi: Bug fixes in headers and atscppapi.
+
+  *) [TS-2598] Expose HttpDebugNames to public plugin APIs.
+
+  *) [TS-2639] Release HttpClientSession objects back to the proxy allocator.
+
+  *) [TS-2637] Add traffic_line records match option.
+
+  *) [TS-2630] Add lib/ts/apidefs.h to place common types.
+
+  *) [TS-2610] Add "client_protocol_stack"(%<cps>) field into LogFormat.
+
+  *) [TS-2612] Indroduce TSHttpConnectWithProtoStack() API.
+
+  *) [TS-1062] Extends and optimizes FetchSM.
+
+  *) [TS-2631] Header_rewrite should support changing destination in non-remap
+   case.
+
+  *) [TS-2623] Remove the limit on the number of cachurl regular expressions.
+
+  *) [TS-2628] traffic_line should tell you when a reload is needed.
+
+  *) [TS-2627] Reduce management socket code duplication.
+
+  *) [TS-2625] trafficserver.in doesn't use TS_BASE.
+
+  *) [TS-2624] Make thread affinity more robust.
+
+  *) [TS-2620] Make the stats_over_http plugin publish node and plugin stats.
+
+  *) [TS-2614] Response to invalid Content-Length for POST should be a 400
+   error. Author: Ron Barber <rbarber@yahoo-inc.com>
+
+  *) [TS-2615] Better logging and error handling in SSL client session startup.
+
+  *) [TS-2613] Can't turn on attach server session to client from
+   records.config.
+
+  *) [TS-2611] Add a new S3 authentication plugin, s3_auth. This only supports
+   the v2 features of the S3 API.
+
+  *) [TS-2522] Better hook management for header_rewrite plugin, and some
+   cleanup.
+
+  *) [TS-2169] Add SSL statistics
+   Author: Ron Barber <rbarber@yahoo-inc.com>
+
+  *) [TS-2607] Fix TS_USE_HWLOC #define in build process
+
+  *) [TS-2595] DNS lookup failed with multiple search domains.
+   Author: Thach Tran <tranngocthachs@gmail.com>
+
+  *) [TS-2019] Fix the "vector inconsistency" errors.
+
+  *) [TS-2585] Add overridable configs support to regex_remap plugin.
+   Author: Ethan Lai <yzlai@yahoo.com>
+
+  *) [TS-2569] Set the default SSL options correctly.
+   Author: Ron Barber <rbarber@yahoo-inc.com>
+
+  *) [TS-2599] Remove dead code in RedCore related to Record Types
+
+  *) [TS-2593] HTTPS to origin fails on CentOS6.x. This is a regression of
+   sort from TS-2355.
+
+  *) [TS-2576] Add Oct/Hex escape representation into LogFormat
+
+  *) [TS-2494] fix the crash that return the stale cached document
+   when os is down, even if it`s status is not 200 (ok).
+
+  *) [TS-2590] Translate documentation into Japanese.
+   Authors: Masaori Koshiba <masaori335@gmail.com>
+            Masakazu Kitajo <m4sk17@gmail.com>
+            syucream <syucream1031@gmail.com>
+
+  *) [TS-2586] Improvements to the internal implementation of overridable
+   configuration lookups (_conf_to_memberp() ).
+   Author: Yu Qing <zhuangyuan@taobao.com>
+
+  *) [TS-2210] Add a plugin API to manipulate the session's SSL context.
+   Author: Kang Li <kangli@yahoo-inc.com>
+
+  *) [TS-2542] Turn on caching zero length responses by default.
+
+  *) [TS-2405] Change the default for proxy.config.net.sock_option_flag_out to
+   1, which enables TCP_NODELAY.
+
+  *) [TS-2531] The default remap rule doesn't match a forward proxy request
+
+  *) [TS-612] Add support for SSL keys with passphrases.
+   Author: Ron Barber <rbarber@yahoo-inc.com>
+
+  *) [TS-2319] Change default behavior for the various ignore-mismatch
+   configurations.
+
+  *) [TS-2563] Always set the SSL default verify paths.
+   Author: Wei Sun <sunwei@yahoo-inc.com>
+
+  *) [TS-2437] Add a lifecycle hook to expose loaded SSL certificates to
+   plugins. Author: Wei Sun <sunwei@yahoo-inc.com>
+
+  *) [TS-2582] Make traffic_cop debugging eadier by logging to stdout.
+
+  *) [TS-2579] Remove ipv4 limit for FetchSM and TSFetchUrl/TSFetchPages.
+
+  *) [TS-1893] Add more options to server session control.
+
+  *) [TS-2239] Initial ALPN TLS extension support.
+
+  *) [TS-2568] Better template messages.
+
+  *) [TS-2567] Add --install-test-tools configure option.
+
+  *) [TS-1622] Add a new API, TSHttpTxnIsCacheable(), which allows a plugin
+   to determine whether a request (and/or response) would be cacheable.
+
+  *) [TS-2560] regex_remap lowercase substitutions is not being initialized in
+   the construtor
+
+  *) [TS-2559] Disconnect clients on unrecoverable origin errors.
+
+  *) [TS-2556] Fix ink_hrtime_diff_msec.
+
+  *) [TS-2553] Metalink: Fix a segfault reported by Faysal Banna and
+   preserve the Content-Length header
+   Author: Jack Bates <jack@nottheoilrig.com>
+
+  *) [TS-2195] Remove the (deprecated) TSHttpTxnCacheLookupSkip API.
+
+  *) [TS-2229] Deprecate the header_filter plugin, use header_rewrite instead.
+
+  *) [TS-2290] Remove X-ID special log tag, and cleanup HdrToken confusion.
+
+  *) [TS-2088] Change TSRecordType enum values to powers of two
+
+Changes with Apache Traffic Server 4.2.0
+
+  *) [TS-2552] configure fails to detect missing the #define for
+   SSL_CTX_set_tlsext_ticket_key_cb().
+
+  *) [TS-2549] printf() compiler warnings  on OSX (clang) with the CPP APIs.
+
+  *) [TS-2532] Fix make distclean for C++ API examples.
+
+  *) [TS-2306] Client connection hang while downloading big file from origin
+   server over SSL connection
+
+  *) [TS-2353] Add ability to load ssl certs that are owned by root and only
+   read only by the user
+
+  *) [TS-2551] Eliminate the tr1 dependency from CPP APIs.
+
+  *) [TS-2541] Add WebSocket support
+
+  *) [TS-2550] Add inline configuration overrised to the conf_remap plugin.
+
+  *) [TS-2546] Move xptr and _xstrdup to ink_memory.{h,cc}.
+
+  *) [TS-2180] Small memory leak in RecCore.cc, from previous refactoring.
+
+  *) [TS-2534] Make sure RecRecord structs are always properly initialized.
+
+  *) [TS-2483] Add a new metric, proxy.node.restarts.proxy.cache_ready_time,
+   tracking absolute time when the cache started (finished
+   initialization). Until cache is available, or no cache configured, this
+   metric stays at a value of "0".
+
+  *) [TS-2517 First implementation of traffic_shell.pl, and reorg the modules
+   a bit for more consistency. Also fixes a timeout issue in AdminClient.pm.
+
+  *) [TS-1467] Disable client initiated renegotiation (SSL) DDoS by default
+
+  *) [TS-2538] Cleanup of ProcessMutex (unused) and InkMutex (dupe of
+   ink_mutex). We now use ink_mutex consistently.
+
+  *) [TS-2544] conf_remap plugin: allow for multiple configuration files.
+
+  *) [TS-2530] Check for loopback interfaces when computing the local address.
+   Author: Ron Barber rbarber@yahoo-inc.com
+
+  *) [TS-2031] Prevent duplicate SSL SNI name registration.
+   Author: Feifei Cai <ffcai@yahoo-inc.com>
+
+  *) [TS-2501] Refactor and improve performance for the case without
+   expansions. Review: Alexey Ivanov <aivanov@linkedin.com>.
+
+  *) [TS-2533 ] Add three commands previously provided by traffic_shell.
+
+  *) [TS-2304] Make the healthcheck plugin watch for file permission changes.
+
+  *) [TS-2519] Make build version metrics non-persistent.
+
+  *) [TS-1606] Log buffers are not flushed periodically when TS is launched
+   with NO_REMOTE_MANAGEMENT flag
+
+  *) [TS-2481] Incorrect origin server port used sometimes (with keep-alive).
+   Author: Dimitry Andric <dimitry@andric.com>
+
+  *) [TS-2526] Remove the g_stats_snap_fpath global variable.
+
+  *) [TS-2525] Remove restrictions on outbound transparency with SSL.
+
+  *) [TS-2425] Update to TS-2261 for loading plugins as root
+
+  *) [TS-2505] Add traffic_line --offline option.
+
+  *) [TS-2305] Fall back to ftruncate if posix_fallocate fails.
+
+  *) [TS-2504] Support OpenSSL installations that use the lib64 directory.
+
+  *) [TS-799] Have AdminClient.pm created from .in file.
+
+  *) [TS-2509] Add the const qualifier to pure HttpTunnel member functions.
+
+  *) [TS-2508] Add a *highly* experimental escalation plugin.
+
+  *) [TS-2507] Fix the state transition logging in HttpSM::handle_server_setup_error.
+
+  *) [TS-1648] Segmentation fault in dir_clear_range()
+
+  *) [TS-2500] Fix handling of cache stripe assignment when a disk is
+   taken offline.
+
+  *) [TS-2499] Fix the header_rewrite plugin expansions of the new %<>
+   strings. Author: Alexey Ivanov <aivanov@linkedin.com>.
+
+  *) [TS-2498] Add a build option to install the example plugins.
+
+  *) [TS-2484] Add API support for the two missing overridable APIs:
+         proxy.config.http.cache.max_open_read_retries
+         proxy.config.http.cache.open_read_retry_time
+
+  *) [TS-2497] Failed post results in tunnel buffers being returned to
+   freelist prematurely.
+   Reporter: Thomas Jackson <thjackso@linkedin.com>
+
+  *) [TS-1668] Added HSTS configuration options to ATS
+
+  *) [TS-2495] Reduce the size of HttpVCTableEntry.
+
+  *) [TS-2491] stop other esi plugin unit test programs after error.
+   Author: Yu Qing <zhuangyuan@taobao.com>
+
+  *) [TS-1821] make the AIO test pass when build with native aio.
+
+  *) [TS-2412] fix the bug of restarting ATS causes complete cache data
+  loss when use linux-native-aio.
+
+  *) [TS-2488] enhance esi plugin to allow any of the space characters to
+   follow esi starting tags.
+   Author: Yu Qing <zhuangyuan@taobao.com>
+
+  *) [TS-2489] Fix esi plugin problem with contents in comments output
+   twice when the node list is cached.
+   Author: Yu Qing <zhuangyuan@taobao.com>
+
+  *) [TS-2336] First attempt at moving the Prefetch APIs into some usable
+   state. There's still work to be done here, but separate bugs for that.
+
+  *) [TS-2487] Export PUSH HTTP method constants to the TS API.
+
+  *) [TS-2486] Eliminate SIMPLE_MEMCPY_INIT define.
+
+  *) [TS-2476] Fix size_t format string.
+   Author: Radim Kolar <hsn@sendmail.cz>
+
+  *) [TS-2471] Writing records.config can fail when the disk is full.
+   Author: Yu Qing <zhuangyuan@taobao.com>
+
+  *) [TS-2479] Don't output orphan log after failover sucessfully.
+
+  *) [TS-2370] SSL proxy.config.ssl.server.honor_cipher_order is backwards.
+  Changed the default setting and changed the meaning of it in the code.
+
+  *) [TS-2466] NOT increase the version of records.config when changing
+   the local parameter
+   Author: Yu Qing
+
+  *) [TS-2469] remove libreadline which is gpl licensed.
+   Author: Ben Aitchison <ben@meh.net.nz>
+
+  *) [TS-2235] url_print should NOT output "?" for empty query string,
+   fix two remains.
+   Author: Yu Qing
+
+  *) [TS-2475] Adding new transaction methods in C++ API
+
+  *) [TS-2474] Change proxy.config.net.poll_timeout to 10ms consistently.
+
+  *) [TS-2473] Fix C++ API includes for FreeBSD.
+   Author: Radim Kolar <hsn@sendmail.cz>
+
+  *) [TS-2467] traffic_shell doesn't work with tcl 8.6.
+   Author: Ben Aitchison <ben@meh.net.nz>
+
+  *) [TS-1365] Add a new configuration option, proxy.config.net.poll_timeout,
+   with the same behavior as the command line option --poll_timeout. Also
+   adjust AIO scheduling to correlate to this setting, to avoid additional
+   CPU load. Note that this configuration is generally not necessary to
+   configure, unless you are concerned with system idle CPU consumption.
+
+  *) [TS-2468] Bring back the load balancer plugin.
+
+  *) [TS-2465] libxml2 detection generates an invalid linker path.
+   Author: Radim Kolar <hsn@sendmail.cz>
+
+  *) [TS-2271] Threaded plugin support with 3rd party libraries.
+   Author: Heikki Hannikainen <hessu@hes.iki.fi>
+
+  *) [TS-2464] Remove useless and buggy connection header handling
+
+  *) [TS-2457] Protocol.c: change usage of atoi to strtol.
+   Author: Radim Kolar <hsn@sendmail.cz>
+
+  *) [TS-2459] Fix wrong name for a couple of librecord APIs.
+    Author: Yu Qing <happy_fish100@yahoo.com.cn>
+
+  *) [TS-2463] Crash regression around slow-log feature, when logging an
+   event. This fixes commit c290ce0df2a.
+
+  *) [TS-32] Fix ICP. Author: Gota Adachi <ada@iij.ad.jp>
+
+  *) [TS-2248] Segmentation fault in HttpTunnel with flow control.
+   Author: bettydramit <b13621367396@gmail.com>
+
+  *) [TS-2454] Fix undefined reference to `__sync_fetch_and_sub_8' on ARM
+   32bit system.
+
+  *) [TS-2450] Fix assertion failure for T61String type.
+
+  *) [TS-2117] make hipes plugin build.
+
+  *) [TS-2452] Can't access a deleted object.
+
+  *) [TS-2363] Fix assertion of "Unknown file format type!".
+
+  *) [TS-2448] Fix traffic_cop and traffic_manager to obey the
+   proxy.config.local_state_dir setting.
+
+  *) [TS-2445] Fix problem with 204 responses closing POST requests.
+
+  *) [TS-2434] Use the FATAL error level to handle plugin errors.
+
+  *) [TS-2203] Clarify syslog startup messages for standalone log programs.
+
+  *) [TS-2436] Add a simple integration test harness.
+
+  *) [TS-2355] ATS 4.0.x crashes when using OpenSSL 1.0.1e.
+
+  *) [TS-2432] Fix a race in aio_err_callblk.
+
+  *) [TS-2251] Simplify LogBuffer reference counting.
+
+  *) [TS-2190] Remove cache.log from the cachurl plugin.
+
+  *) [TS-2426] Add a new plugin, xdebug, for cache debugging using HTTP
+   headers.
+
+  *) [TS-2077] Remove pipeline configurations, they were no-op's anyways. We
+   still support pipelining (we always do), it's just not treated specially
+   (or optimized).
+
+  *) [TS-2386] clean up unused files and codes -- round 4.2.
+
+  *) [TS-548] remove Initialize.cc Initialize.h
+
+  *) [TS-2082] remove STANDALONE_IOCORE FIXME_NONMODULAR and NON_MODULAR
+   defines.
+
+  *) [TS-312] Add option to always share keep-alive connections to the origin
+   server.
+
+  *) [TS-2419] Don't close client connection when responding with a 204 and
+   there is no body.
+
+  *) [TS-1146] Add RFC 5077 TLS session ticket support.
+   Author: Wei Sun <sunwei@yahoo-inc.com>
+
+  *) [TS-2401] Use Layout instead of global install path directories.
+
+  *) [TS-2420] Remove STAT_SYNC, CONF_SYNC, and REM_SYNC threads and schedule
+   those continuations in ET_TASK.
+
+  *) [TS-2372] Enable TLS perfect forward security with ECDHE.
+
+  *) [TS-2416] Make TLS the session timeout threshold configurable.
+   Author: Wei Sun <sunwei@yahoo-inc.com>
+
+  *) [TS-2335] adding ts_lua plugin to experimental directory.
+
+  *) [TS-2347] buffer_upload uses unsafe function tempnam(). Replace it
+   with mkstemp().
+
+  *) [TS-1815] Add thread number and port to accept thread name and
+   add the file descriptor number to the ET_AIO thread names.
+
+  *) [TS-2415] Use standard continuations to release UrlRewrite objects.
+
+  *) [TS-2413] Release memory for idle SSL connections.
+   Author: Wei Sun <sunwei@yahoo-inc.com>
+
+  *) [TS-2365] Configure the maximum TLS record size.
+   Author: Wei Sun <sunwei@yahoo-inc.com>
+
+  *) [TS-2351] Bandaid fix for Range request crash related to
+   Read-While-Writer and content length calculations.
+
+  *) [TS-2408] Fix double free of proxy.config.admin.user_id.
+
+  *) [TS-2396] UrlRewrite.cc does not free the queue correctly.
+   Author: Yu Qing <zhuangyuan@taobao.com>
+
+  *) [TS-2382] Partial fix for make install creating man files as root.
+
+  *) [TS-2381] Reorganize TSUrlCreate docs into separate files.
+
+  *) [TS-2377] Install man pages as part of the build.
+
+  *) [TS-2379] Add a new field: '%<chp>', "client_host_port" to LogFormat.
+
+  *) [TS-2374] Abort the producer if the none of it`s consumers is alive.
+
+  *) [TS-2330] Update proxy.config.body_factory.enable_customizations comments
+   in records.config.
+
+  *) [TS-2327] TSRedirectUrlSet does not perform DNS lookup of redirected OS.
+
+  *) [TS-1468] Check vary and accept headers on non-200 responses in cache.
+
+  *) [TS-2352] refine THREAD_ALLOC feature.
+
+  *) [TS-2364] Introduce slice notation to field syntax in log format.
+
+  *) [TS-2360] Fix usage of TSMimeHdrFieldValueStringGet() IDX in some plugins.
+
+  *) [TS-2361] Load regex_remap configuration relative to the configuration
+   directory.
+
+  *) [TS-2359] Make install over existing installation can fail.
+
+  *) [TS-2350] Enhancements to traffic_top.
+
+  *) [TS-2348] Rename tstop to traffic_top.
+
+  *) [TS-2384] Fix regression in key-lookup code between 4.0.x and 4.1.x.
+
+  *) [TS-2340] Fix TextLogObject log rolling.
+   Author: bettydramit <b13621367396@gmail.com>
+
+  *) [TS-2343] Remove the --schema option from Traffic Manager, and the code
+   around it.
+
+  *) [TS-2316] header_rewrite: numerous improvements: cookie based conditions,
+   rule counters, improved documentation.
+   Author: Alexey Ivanov <aivanov@linkedin.com>
+
+  *) [TS-2338] Remove IPRange.cc and .h, and SocksParser.cc.
+
+  *) [TS-2333] Change the SAX callbacks to not clash with libxml2, which broke
+   synthetic metric completely.
+
+  *) [TS-2339] Cleanup Makefile.am, fixing missing / wrong _SOURCES entries.
+
+  *) [TS-2341] Cast TSHttpStatus to int to suppress compiler warning in clang.
+
+  *) [TS-2303] Incorrect docs for negative_caching_enabled.
+    Author: Thomas Jackson <jacksontj.89@gmail.com>
+
+  *) [TS-2712] Explicitly use subdir-objects in automake init.
+
+  *) [TS-2309] Allow mod_generator plugin for lighttpd to accept "SI" postfixes.
+
+Changes with Apache Traffic Server 4.1.0
+
+  *) [TS-2252] Fix bison version check on Ubuntu.
+
+  *) [TS-2108] Fix TSConfig to build with bison 3.0
+
+  *) [TS-2311] ESI: Support responses that are of other text content type as
+   well as non-200 status response. Author: Kit Chan
+
+  *) [TS-2321] C++ API: Clean up header code to not use STL containers and use
+   structures directly.
+
+  *) [TS-2323] Implement a .include directive for remap.config.
+
+  *) [TS-2322] Set PCRE malloc hooks globally.
+
+  *) [TS-1955] Range: requests during read-while-writer gets the wrong
+  Content-Length.
+
+  *) [TS-2245] This adds a '2' config state to the ignore mismatch configs.
+
+  *) [TS-2178] Force keep alive off if re-using client 4-tuple and server is
+  not keep alive.
+
+  *) [TS-2264] Fixed problem with EADDR_NOTAVAIL handling.
+
+  *) [TS-2317] Read/write mutex of PluginVC may be held without release.
+   Author: portl4t.cn@gmail.com
+
+  *) [TS-2315] ESI Plugin: fetcher does not handle error gracefully.
+   Author: Kit Chan
+
+  *) [TS-2115] buffer_upload hard-codes "nobody" user/group.
+   Author: Kit Chan
+
+  *) [TS-2008] Cache control with multiple suffixes.
+    Author: bettydramit <b13621367396@gmail.com>
+
+  *) [TS-2247] ua close time in milestone may not set.
+   Author: Gang Li
+
+  *) [TS-2302] Log collation causes error logging to stop.
+
+  *) [TS-2200] TS_HRTIME_xxx in experimental.h is invalid to use.
+   Author: Yu Qing
+
+  *) [TS-2235] url_print should NOT output "?" for empty query string.
+   Author: Yu Qing
+
+  *) [TS-2292] the version of records.config increases unexpectly.
+   Author: Yu Qing
+
+  *) [TS-2277] cluster alarm messages broadcast infinitely.
+   Author: Yu Qing
+
+  *) [TS-2276] manager memory leak in some case.
+   Author: Yu Qing
+
+  *) [TS-1638] less strict on kernel version checking in clustering.
+   Author: Yu Qing
+
+  *) [TS-2265] Remove unused log tags for prob, prcb and cgid.
+
+  *) [TS-2301] Replace the CACHE_READY macro with CacheProcessor::IsCacheReady.
+
+  *) [TS-2300] Remove the HIT_EVACUATE build option.
+
+  *) [TS-2227] Allow for multiple config files for a header_rewrite plugin
+   invocation (be it in remap.config or plugin.config).
+
+  *) [TS-2230] header_rewrite should support the same hook-management that
+  header_filter does for remap rules. This allows per-remap rules that
+  triggers in hooks other than the remap phase.
+
+  *) [TS-2228] Add a set-config operator for header_rewrite plugin.
+
+  *) [TS-2226] Add a set-header operator for header_rewrite plugin.
+
+  *) [TS-2296] improve ConfigProcessor reference counting.
+
+  *) [ TS-2295] update statvfs usage.
+
+  *) [TS-2139] Fix PURGE twice to remove object in cache if
+   enable-interim-cache.
+
+  *) [TS-2216] Fix cquuh log tag, which does not calculate the right
+   string length.
+
+  *) [TS-2275] fix interim cache lossing data if the server process crash.
+   Author: Gang Li
+
+  *) [TS-2291] Add remap_stats plugin to experimental.
+
+  *) [TS-2242] Update core plugins' support_email and vendor_name for
+   consistency.
+
+  *) [TS-1988] cquuc and cquup log tags can have no values.
+
+  *) [TS-2159] Force first log rotation at proxy.config.log.rolling_size_mb.
+
+  *) [TS-2138] Fix the bug that restarting ats cause cache data loss if
+  enable the native-aio.
+
+  *) [TS-2197] Use HttpSM::main_handler to handle the client request stuff.
+
+  *) [TS-2254] On ARM arch, ink_atomic_increment returns wrong value.
+   Author: Yu Qing
+
+  *) [TS-2269] regex_remap plugin does not deal with empty path's properly.
+   Author: Kit Chan
+
+  *) [TS-2270] ESI Plugin can have infinite loop while doing gunzip on
+   responses. Author: Kit Chan
+
+  *) [TS-2268] Add support for opening protocol traffic sockets through the
+   traffic_manager. Added TSPluginDescriptorAccept into expiremental API.
+
+  *) [TS-2266] Add a "make rat" Makefile target, to create a RAT report. This
+   is used for verifying licensing compliance on the entire source tree.
+
+  *) [TS-2212] Implement the <fsiz> log tag for HTTP requests. This also does
+   a small refactoring of the "atoi" functions in lib/ts, such that we now
+   consistently have both prototypes for all types (with and without a
+   string length parameter).
+
+  *) [TS-2261] Add config option to restore/elevate access to reading files by
+   root when loading plugins.
+
+  *) [TS-2257] Healthcheck plugin can stop watching some events.
+
+  *) [TS-2260] Avoid flooding log when log host is down.
+
+  *) [TS-2259] Introduce failover hosts for logging system.
+
+  *) [TS-2256] Mem stats info is bad when enable reclaimable-freelist.
+
+  *) [TS-2255] TS should not flood printing after log space reach the limit.
+
+  *) [TS-2245] cancel the trigger of CacheVC in openWriteCloseDataDone.
+
+  *) [TS-2232] log level should be change from Status to Debug.
+    Author: Yu Qing <zhuangyuan@taobao.com>
+
+  *) [TS-2201] split drainIncomingChannel two thread, one handle Broadcast
+   message and other handle Reliable(TCP) request for supporing large cluster.
+
+  *) [TS-2144] Avoid race on e.g. "traffic_server -Cclear" which would crash
+   the process intermittently.
+
+  *) [TS-2217] remove the option to turn off body factory - setting it to 0
+   will result in empty responses.
+
+  *) [TS-2209] add support for lowercasing all substitutions in regex_remap.
+
+  *) [TS-2187] failed assert `nr == sizeof(uint64_t)` in EventNotify::signal().
+
+  *) [TS-2206] The trafficserver RC script does not use absolute path to
+   traffic_line binary.
+
+  *) [TS-2207] CentOS5 out of tree perl module build fails.
+
+  *) [TS-1637] Fix nodes as idle/dead if we have not heard from them in
+   awhile.
+
+  *) [TS-2185] Support to control ClusterCom::sendSharedData frequency.
+
+  *) [TS-2195] Deprecate experimental TSHttpTxnCacheLookupSkip API.
+
+  *) [TS-2176] Do not reset value of api_skip_cache_lookup when reading it.
+    Author: Corey Cossentino <corey@omniti.com>
+
+  *) [TS-2191] Do not reschedule http_sm when the sm_list`s lock is not
+   acquired. This can lose items for the WebUI, which will be fixed in a
+   separate bug.
+
+  *) [TS-2188] Fixes to make healthcheck plugin not segfault, and parse the
+   log files properly. Author: Scott Harris <scott@harrisnet.id.au>
+
+  *) [TS-1086] Avoid edge case returning 304 to an unconditional request.
+   Diagnosis and patch by Mohamad Khateeb.
+
+  *) [TS-2168] Make RecordsConfig.cc more inline with default builds.
+
+  *) [TS-2174] traffic_shell/traffic_line miss some stats value
+
+  *) [TS-2173] RECD_COUNTER type is missing in setTokenValue().
+
+  *) [TS-2165] Introduce cluster-wide logging stats.
+
+  *) [TS-2167] Update apichecker.pl to give suggestions on additional
+   deprecated APIs.
+
+  *) [TS-2163] Remove WDA_BILLING, ACC_ALARMS etc. code and definitions.
+
+  *) [TS-2156] Fix stats trap in different type of threads.
+
+  *) [TS-2160] Remove ats_is_ip_nonroutable and replace it with the less
+   confusing ats_is_ip_linklocal and ats_is_ip_private.
+
+  *) [TS-2158] Properly mark an IP as non-routable for IPv4 and IPv6 link
+   local addresses as well as IPv6 private addresses and IPv4 Carrier Grade
+   NAT addresses from RFC 6598.
+
+  *) [TS-2155] Make a new RAT exclude file that uses the regular expressions
+   now supported. Also cleanup some of minor licensing discrepancies.
+
+  *) [TS-2148] handle_cache_operation_on_forward_server_response ignores value
+    of api_server_response_no_store.
+    Author: Corey Cossentino <corey@cossentino.com>
+
+  *) [TS-2147] Set server_share_sessions to 1 for 'internal' transactions in
+   rfc5861 plugin.
+
+  *) [TS-2114] buffer_upload plugin defines true and false
+    Author: Kit Chan <chanshukit@gmail.com>
+
+  *) [TS-2116] buffer_upload plugin is in the source tree but does not build
+    Author: Kit Chan <chanshukit@gmail.com>
+
+  *) [TS-2094] eliminate xcrun warnings at configure time
+
+  *) [TS-2141] Inconsistent euid cause bad mgmtapi/eventapi sockets.
+
+  *) [TS-2137] Use eventfd instread of pthread signal/wait in ATS.
+
+  *) [TS-287] Fix transaction_active_timeout_in does not trigger on the first
+   request of a Keep-Alive connection. Author: Li Gang <quehan@taobao.com>
+
+  *) [TS-2136] Fix the first proxy.config.http.accept_no_activity_timeout is
+   invalid.
+
+  *) [TS-2089] Introduce configurable collation preproc threads.
+
+  *) [TS-2126] Avoid unnecessary memory copy in LogHost::write()
+
+  *)[ TS-2096] Improve SSL certificate loading error messages.
+
+  *) [TS-2122] Enlarge the 64KB limitation of log buffer size.
+
+  *) [TS-2061] LogFile::write_ascii_logbuffer3() can silently drop log
+   entries.
+
+  *) [TS-2123] Remove useless max_entries_per_buffer option.
+
+Changes with Apache Traffic Server 4.0.1
+
+  *) [TS-2161] TSHttpTxnHookAdd memory Leak.
+    Author: bettydramit <b13621367396@gmail.com>
+
+  *) [TS-2154] Lua plugin asserts traffic_server on startup.
+
+  *) [TS-2127] Move hostdb.config to var/trafficserver, together with with the
+   host.db itself.
+
+  *) [TS-1823] remap.config line continuation support.
+    Author: Jim Riggs <jim@riggs.me>
+
+  *) [TS-1597] Document remap.config filters.
+    Author: Jim Riggs <jim@riggs.me>
+
+  *) [TS-2132, TS-2131] ${libexecdir} and $(localstatedir} chowned
+   needlessly chowned to to ATS' user.
+   Author: Tomasz Kuzemko <tomasz@kuzemko.net>
+
+  *) [TS-2130] pthread_setname_np() detection fails on various platforms.
+
+  *) [TS-2129] Check for existence of ExtUtils::MakeMaker.
+
+  *) [TS-2128] Don't link libGeoIP.so.1 into binaries.
+
+  *) [TS-2112] Make libloader compile by default.
+
+  *) [TS-2111] configure check in boost falsely requires 1.50. Reducing it to
+   v1.33, which is what RHEL5 ships with.
+
+Changes with Apache Traffic Server 3.3.5
+
+  *) [TS-2051] Fix SSL crash due to excess READ_COMPLETE events.
+
+  *) [TS-2099] Using wrong member when setting active timeout.
+
+  *) [TS-2102] SPDY plugin tries to setup protocol handler too early.
+
+  *) [TS-1953] remove version checks from plugins that don't use it and
+   add an example showing off the version API and partial compilation.
+
+  *) [TS-2100] Initialize the SSL/NPN registration mutex.
+
+  * [TS-1987, TS-2097]: Remove duplicate and unused string functions.
+
+  *) [TS-2091] Return an error from RecGetRecordOrderAndId if the stat isn't
+   registered.
+
+  *) [TS-2081] Make the WCCP addr configuration LOCAL.
+
+  *) [TS-2093] Check bounds on plugin stat creation.
+
+  *) [TS-2092] Use of uninitialized member in HdrHeap.
+
+  *) [TS-2052] ET_SSL thread spinning.
+   Author: Can Selcik <cselcik at linkedin.com>
+
+  *) [TS-2090 Make proxy.config.allocator.enable_reclaim default based on
+   build instructions.
+
+  *) [TS-2086] Remove a few more unused configs.
+
+  *) [TS-1685] Remove TS_MICRO and fellas.
+
+  *) [TS-1255] Add more overridable configurations, and fix bugs in how we
+   deal with some of these (all "float" configs were completely broken). I
+   also modified the regression tests to be less easy to fool.
+
+  *) [TS-1976] Prevent an invalid httpport argument being passed from
+   traffic_manager to traffic_server.
+   Author: Thach Tran <tranngocthachs@gmail.com>
+
+  *) [TS-2076] Removed proxy.config.http.accept_encoding_filter_enabled, which
+   is obsolete.
+
+  *) [TS-2075] Cleanup around suboptimal checks on redirects.
+
+  *) [TS-2074] Remove proxy.config.http.server_port and
+   proxy.config.http.server_other_ports remnants.
+
+  *) [TS-2073] Set the defaults for request_hdr_max_size and
+   response_hdr_max_size properly.
+
+  *) [TS-2071] Remove proxy.config.http.session_auth_cache_keep_alive_enabled
+   remnants.
+
+  *) [TS-2072] Remove proxy.config.http.avoid_content_spoofing, and also fix a
+    logical bug around the tests of when to mark the request header dirty.
+
+  *) [TS-1993] SSL certificate chains are loaded from the wrong directory.
+
+  *) [TS-2059] Remove dead code in EnvBlock.cc and processSpawn().
+
+  *) [TS-2057] Removed deprecated proxy port configuration values from
+   records.config.
+
+  *) [TS-1280] Add url match token about cache control rule.
+
+  *) [TS-2064] Fix the authproxy plugin to send an error body.
+
+  *) [TS-2061] Avoid writing outside buffer boundaries in LogFile overfill
+   buffers (for ASCII logging). Author: quehan
+
+  *) [TS-2041] Allow environment values to override records.config settings.
+
+  *) [TS-2044] Avoid logging client running into DENY status infinitely.
+    Author: Yunkai Zhang <qiushu.zyk@taobao.com>
+
+  *) [TS-2030] Build error with --enable-interim-cache on fedora19 x86_64.
+    Author: bettydramit <b13621367396 at gmail dot com>
+
+  *) [TS-1943] Rename mcport and rsport parameters to make them more readable.
+    Author: Yunkai Zhang <qiushu.zyk@taobao.com>
+
+  *) [TS-2046] Move perl contribs to lib/perl, and have make / make install
+   build and install the modules as appropriate.
+
+  *) [TS-954] Better calculation of blocks in volume. Bumped cache DB version.
+
+  *) [TS-2050] Cleanup ink_config.h.in, removing unused symbols.
+
+  *) [TS-1487] [TS-2035] Moved plugin init, added plugin lifecycle hooks,
+   added delay listen for cache. Removed TS_NO_API defined/build option.
+
+  *) [TS-2047] Schedule RamCacheCLFUSCompressor in RamCacheCLFUS::init instead
+   of immediately after instantiation.
+
+  *) [TS-2042] Remove remnants of unused vingid command line option.
+
+  *) [TS-1898] improve cluster read/write performance.
+
+  *) [TS-2036] Enable mgmt update (traffic_line -x) for plugins.
+
+  *) [TS-2037] Fix start-stop-daemon typo in debian init script.
+
+  *) [TS-2003] Fix RAM cache stats when using cluster. Author: Yunkai Zhang.
+
+  *) [TS-1820] Cleanup UNUSED / INK_UNUSED / RELEASE_UNUSED. This also removes
+   the entire mgmt/tools directory, and relevant support in traffic_shell for
+   managing network interfaces.
+
+  *) [TS-2033] Remove EncryptToFile() and mgmt API.
+
+  *) [TS-2027] Initialize the ConnectionCount`s mutex.
+
+  *) [TS-1997] Remove TSHttpTxnCachedUrlSet() API.
+
+  *) [TS-2028] Config parse problems in healthchecks plugin.
+
+  *) [TS-1966] Add new configuration option to control ProxyAllocator size.
+
+  *) [TS-1151] cop may crash due to uninitialized pointer val
+
+  *) [TS-2013] Install the tspush script.
+
+  *) [TS-2012] Use standard C++11 containers in logstats.
+
+  *) [TS-1999] Merge in the healthcheck plugin from GoDaddy.
+
+  *) [TS-1998] Make stats-over-http support configurable URL path.
+
+  *) [TS-1990] Fix core at CacheContinuation::handleDisposeEvent().
+
+  *) [TS-2010] Build fixes for OS X 10.9 and Xcode 5.
+
+  *) [TS-1957] fix If CacheContinuation timeout, timeout Event will be loop
+
+  *) [TS-2007] Add TSNetConnectTransparent API for transparent net connections
+
+  *) [TS-1991] clang complaint: logical not is only applied to the left hand
+   side of this comparison.
+
+  *) [TS-1958] Web UI can crash doing a regex lookup.
+
+  *) [TS-1994] Increase default RAM cache size by a magnitude.
+
+  *) [TS-1978] Segfault when trying to set an error from (remap) plugin. This
+   also fixes a bug where the "default" template was not loaded upon startup.
+
+  *) [TS-1977] Build issues on OSX / clang related to stacksize changes.
+
+  *) [TS-1972] TSNetAcceptNamedProtocol does not receive connections.
+
+  *) [TS-1970] Using ssl_ca_name= in ssl_multicert.config fails.
+
+  *) [TS-1946] Reduce the verbosity of SSL handshake errors.
+
+  *) [TS-1971] Switch jtest over to standard argument parsing.
+
+  *) [TS-1786] Only enable -Werror for development builds.
+
+  *) [TS-1960] Decouple stacksize config from core, this fixes regressions.
+
+  *) [TS-1959] traffic_manager not honoring some records.config settings
+   necessary for e.g. logging.
+
+  *) [TS-745] support interim caching in storage to enable, use
+   '--enable-interim-cache' configure option.
+
+  *) [TS-1968] Promote header_rewrite plugin from experimental
+
+  *) [TS-1961] Add tsxs support for querying installation variables.
+
+  *) [TS-1886] Allow users to attempt gcc builds on Mac OS X.
+
+  *) [TS-1934] Make geoip_acl experimental plugin compile.
+
+  *) [TS-1948] Remove obsolete TSPluginLicenseRequired and plugin.db.
+
+  *) [TS-1942] Remove username.cache configs, they are obsolete and long gone.
+
+  *) [TS-1496] Enable per transaction flow control.
+
+  *) [TS-1684] Added more ProxyAllocators for faster and local memory
+   allocation.  Have seen a doubling in performance depending on the benchmark.
+   Details in the ticket.
+
+  *) [TS-1962] Don't add POST server connections to the shared pool unless POST
+   keep-alive option is on
+
+Changes with Apache Traffic Server 3.3.4
+
+  *) [TS-1940] HostDB gets reinitialized on startup.
+
+  *) [TS-1941] Make Linux native-AIO build cleanly.
+
+  *) [TS-1938] Remove unnecessary thread_id() wrapper in reclaimable freelist.
+    Author: Yunkai Zhang <qiushu.zyk@taobao.com>
+
+Changes with Apache Traffic Server 3.3.3 (never released)
+
+  *) [TS-1936] Make traffic_logstats honor the log-directory as intended.
+
+  *) [TS-1937] Prevent assert on SSL forward proxy connect.
+
+  *) [TS-1907] Using the "ipv6" option for port configuration cancels the
+   "ssl" option.
+
+  *) [TS-1927] Make ats_base64_decode able to handle the URL variant
+
+  *) [TS-1207] Move cacheurl plugin out of experimental
+
+  *) [TS-1857] On CentOS the Lua plugin is built whether Lua is found or not.
+
+  *) [TS-1492]  Prevent net-throttling from locking out the health checks
+   from traffic_cop.
+
+  *) [TS-1827] Make combo_handler be enabled via remap.config, and
+   various other cleanup fixes. Author: Conan Wang and Leif.
+
+  *) [TS-1932] Use a more modern tar format so asf-dist can handle
+   file paths longer that 99 bytes
+
+  *) [TS-1891] Add double-free checking for reclaimable freelist
+    Author: Yunkai Zhang <qiushu.zyk@taobao.com>
+
+  *) [TS-1926] Require Lua v5.1, by checking for lua_getfenv(). This is
+   necessary since we are incompatible with Lua v5.2 (for now).
+
+  *) [TS-1921] Fix reclaimable freelist getting stuck in infinite loop.
+    Author: Yunkai Zhang <qiushu.zyk@taobao.com>
+
+  *) [TS-1824] TSHttpTxnPushedRespHdrBytesGet() takes an int argument in the
+   implementation, whereas the prototype does not have this.
+
+  *) [TS-1928] False warning when setting log rotation size to exactly 10.
+
+  *) [TS-1812] Remove obsolete syslog_thr_init calls.
+
+  *) [TS-1825] TSPortDescriptorAccept does not use it's argument.
+
+  *) [TS-1925] Remove obsolete MMH hash API.
+
+  *) [TS-1924] Metalink: Add plugin documentation.
+    Author: Jack Bates <jack@nottheoilrig.com>
+
+  *) [TS-1913] Fix memory issue caused by resolve_logfield_string()
+    Author: Yunkai Zhang <qiushu.zyk@taobao.com>
+
+  *) [TS-1915]  header_rewrite uses TSUrlHostSet() when using set-destination
+   PATH. Author: Nick Berry.
+
+  *) [TS-1941] Configured socket buffer sizes are not applied.
+
+  *) [TS-1912] SSL hangs after origin handshake.
+
+  *) [TS-1911] Enforce MIOBufferAccessor accessor API.
+
+  *) [TS-1909] Remove duplicate listen socket conditioning.
+
+  *) [TS-1896] Cleanup of unused defines, sometimes duplicated.
+
+  *) [TS-374] Reduce lock contention in HostDB.
+
+  *) [TS-1728] Assign storage entries to volumes
+     Author: Justin Laue <justin@fp-x.com>
+
+  *) [TS-1899] strtod() does not honor Hex strings on Solaris.
+
+  *) [TS-1894] madvise() not found on Solaris. And some cleanup.
+
+  *) [TS-1765] Make jtest build more like the rest of the code.
+
+  *) [TS-1892] Move msync APIs to ink_memory.h.
+
+  *) [TS-1890] Authproxy plugin caching and reliability fixes.
+
+  *) [TS-1868] TSREMAP_*_STOP does not stop remap plugin evaluation chain.
+
+  *) [TS-1889] Refactor remap plugin request URL handling.
+
+  *) [TS-1887] Make diagnostic location logging more succinct.
+
+  *) [TS-1884] Remove deprecated IPv4-only NetProcessor API.
+
+  *) [TS-1444] [TS-1881] URL lookup with regex through the web interface was broken.
+
+  *) [TS-1880] Use pthread_setname_np to set the thread name on multiple platforms.
+
+  *) [TS-1879] Make the Ptr<> conversion constructor explicit.
+
+  *) [TS-1768] Prefer AC_SEARCH_LIBS to AC_CHECK_LIB to avoid unnecessary linking.
+
+  *) [TS-1877] Fix multiple Lua remap plugin instance creation.
+
+  *) [TS-1770] Unable to create remap rule for SSL sites when accessed as a
+   forward proxy. Author: Mark Harrison.
+
+  *) [TS-1867] The combo_handler plugin crashes when receiving non-200 responses.
+    Author: Conan Wang <conanmind@gmail.com>
+
+  *) [TS-1838] Improve configure.ac to recognize compiler setup better.
+
+  *) [TS-1865] Support DESTDIR in tsxs.
+
+  *) [TS-1864] Illumos / OmniOS needs -m64 with gcc to compile properly on
+   64-bit platforms. We also only support ATS on 64-bit Illumos.
+
+  *) [TS-1811] Make the HostDB sizes variable on the SRV enabled config.
+   This restores compatibility with HostDB's prior to v3.3.1.
+
+  *) [TS-1843] Detect and link libhwloc on Ubuntu.
+
+  *) [TS-1858] Fix redefinition of timersub on Solaris.
+
+  *) [TS-1861] Build fails with reclaimable freelist enabled.
+
+  *) [TS-1860] cacheurl doesn't compile on platforms with pcre/pcre.h
+   (e.g. solaris).
+
+  *) [TS-1729] Fix channel_stats to compile on various Unixen. Note that this
+   is still IPV4 only.
+
+  *) [TS-1839] We fail "make test" on some platforms, due to install
+   directory missing.
+
+  *) [TS-1856] Replace SIZE() macro with COUNTOF() and countof().
+
+  *) [TS-1853] Fix formatting in logstats to be consistenly 2 decimals.
+
+  *) [TS-1852] Fix missing AC_PROG_SED on CentOS 5.9.
+
+  *) [TS-1717] Fix the static build as much as possible.
+
+  *) [TS-1851] Turn HostDBInfo back into a POD type.
+
+  *) [TS-1850] Improve SSL certificate error reporting.
+
+  *) [TS-1848] Fix MIMEHdr::field_value_set_int64() wrapper.
+   Author: Yunkai Zhang <qiushu.zyk@taobao.com>
+
+  *) [TS-986] experimental.h has a dependency on netinet/net.h (for
+  struct in_addr).
+
+  *) [TS-1794 Replace all usage of ts_debug_assert() with ts_assert().
+
+  *) [TS-1834] Force absolute paths to fix logstats unit tests.
+
+  *) [TS-1817] Use the libaio interface to the Linux AIO system calls.
+
+  *) [TS-1721] Integrate tstop into the autotools build.
+
+  *) [TS-1706] Fix documentation for Config::Records.pm.
+
+  *) [TS-1218] Make traffic_cop tracing configureable at build time.
+
+  *) [TS-1846] Remove TestHook.
+
+  *) [TS-1844] Efficient HostDB file allocation.
+
+  *) [TS-1586] Fix the SPDY plugin build under clang on Linux.
+
+  *) [TS-1053] Make combo_handler compiler. Author: Conan Wang.
+
+  *) [TS-1792] Cleanup extremely verbvose debug text on Vary headers.
+
+  *) [TS-1819] Guarantee hwloc initialization.
+
+  *) [TS-1830] Add getpagesize library function.
+
+  *) [TS-1801] Remove proxy.config.net.throttle_enabled, it's an artifact
+   of a debugging case, and should not have been included upstream.
+
+  *) [TS-1829] Values exceed capacity of 'long' data type on 32-bit
+
+  *) [TS-1755] Add basic logstats tests.
+
+  *) TS-1184 Additional whitespace in proxy.config.admin.user_id value results
+   in error.
+
+  *) [TS-1662] Remove remaining use of register storage class.
+
+  *) [TS-846] Eliminate proxy.config.remap.use_remap_processor.
+
+  *) [TS-1802] Remove proxy.config.net.accept_throttle.
+
+  *) [TS-1752] Change type of "len" in jtest to off_t, for better
+  compiler compliance.
+
+  *) [TS-1826] Remove DumpStats/http_dump dead code.
+
+Changes with Apache Traffic Server 3.3.2
+
+  *) [TS-621] Allow caching of empty docs (currently only if a header
+   Content-Length: 0 is in the response). New config option is named
+   proxy.config.http.cache.allow_empty_doc, and is disabled by default.
+
+  *) [TS-1778] Remove vestigal extensions.config support.
+
+  *) [TS-1806] bogus buffer sizing in CfgContextUtils.cc.
+
+  *) [TS-1805] Fix stats ExpressionEval in stats xml.
+   Author: Yunkai Zhang
+
+  *) [TS-1783] Eliminate the wpad.dat configuration option (it's unused).
+
+  *) [TS-1787] Eliminate old ink_time code (was probably only used by the
+   now obsolete Web UI). This fixes compiling with gcc 4.8 as well.
+
+  *) [TS-1067] Remove unused config (and code) for bandwidth management.
+
+  *) [TS-1736] Fatal() terminates process without a backtrace.
+    Author: Yunkai Zhang <yunkai.me@gmail.com>
+
+  *) [TS-1791] remove m_mutex acquire&release to avoid deadlock in
+   ~LogBufferList(). Author: Gang Li <quehan@taobao.com>.
+
+  *) [TS-1713] SRV support refine. Now the srv option is able to enable, with
+   no crash. Be care, the hostdb.storage_size or ostdb.size need check.
+
+  *) [TS-1632] In addition to the changes from TS-1674, also add
+   some safety measures assuring that the stats sums don't go.
+   negative. Author: Yakov Kopel.
+
+  *) [TS-1789] Script to compare RecordsConfig.cc default values with
+   records.config.default.in: Author: Mark Harrison.
+
+  *) [TS-1631] Mgmt API to clear stats does not actually clear it.
+   Author: Yakov Kopel.
+
+  *) [TS-1772] Remove multiple TS_INLINE defines.
+
+  *) [TS-1771] add http_load to the build.
+
+  *) [TS-1766] integrate AIO test into the autotools test suite.
+
+  *) [TS-1753] Add remap support to the cacheurl plugin.
+   Author: Mark Harrison <mark@mivok.net>
+
+  *) [TS-1790] authproxy should accept 2xx as authorization success.
+
+  *) [TS-1780] Fix Debuntu build with hardening flags.
+
+  *) [TS-1623, TS-1625] Fixes for logging where the host name was not handled
+    correctly because it was not in the URL.
+
+  *) [TS-1754] Remove unecessary wWarnings from stats evaluation.
+   Author: Yunkai Zhang.
+
+  *) [TS-1169] Eliminate bogus asserts. Credits to Conan Wang.
+
+  *) [TS-1764] Unify MAX/MIN definitions (in ink_defs.h). Also clean
+   up the checks of gcc prior to v3.x (which we no longer support).
+
+  *) [TS-1724] Add tool to compare records.config files to contrib.
+   Author: Mark Harrison <mark@mivok.net>
+
+  *) [TS-1566] dynamic update for string vars does not work.
+   Author: Aidan McGurn <aidan.mcgurn@openwave.com>
+
+  *) [TS-1708] Using tr-pass port option causes requests with large headers to
+   hang.
+
+  *) [TS-1734] Remove dead code that invokes missing vmap_config tool.
+   Author: John Kew <john.v.kew.ii@gmail.com>
+
+  *) [TS-1660] Host field should not has c style terminator.
+
+  *) [TS-1627] Support requests with payload.
+
+  *) [TS-1763] Add Arch Linux config.layout.
+   Author: Galen Sampson <galen.sampson@gmail.com>
+
+  *) [TS-1749] Stats cluster values among nodes are not consistent.
+   Author: Yunkai Zhang <qiushu.zyk@taobao.com>
+
+  *) [TS-1761] Improve scheduling and configuration around HostDB disk sync.
+
+  *) [TS-1758] Remove unused overviewPage aggregation functions.
+   Author: Yunkai Zhang.
+
+  *) [TS-1748] Add jtest to the build.
+
+  *) [TS-1730] Supporting First Byte Flush for ESI plugin.
+   Author: Shu Kit Chan <chanshukit@gmail.com>
+
+  *) [TS-1745] Fix typos.
+   Author: Benjamin Kerensa <bkerensa@ubuntu.com>
+
+  *) [TS-1671] Remove AlarmListable from overviewRecord.
+   Author: Yunkai Zhang <qiushu.zyk@taobao.com>
+
+  *) [TS-1740] Improve precision of stats values.
+   Author: Yunkai Zhang <qiushu.zyk@taobao.com>
+
+  *) [TS-1742] Freelists to use 64bit version w/ Double Word Compare and Swap.
+
+  *) [TS-1356] Ability to set thread affinity with multiple modes.
+
+Changes with Apache Traffic Server 3.3.1
+
+  *) [TS-1743] Implement our own hash mechanism for traffic_logstats, since
+   C++11 does not provide a sensical hash<const char*>.
+
+  *) [TS-1628] In validate_unmapped_url(), pristine_url can be invalid().
+
+  *) [TS-1714] Fix some build problems for gcc v4.8.
+
+  *) [TS-1626] Remove WUTS proxy code.
+   Author: Uri Shachar <ushachar@hotmail.com>
+
+  *) [TS-1741] Add plugins examples to the build.
+
+  *) [TS-1058] Add TSHttpTxnCloseAfterResponse experimental API.
+   Author: Yakov Kopel <ykopel@websense.com>
+
+  *) [TS-1733] Retool tsxs so that it can compile multiple source files
+   Author: Dale Ghent <daleg@omniti.com>
+
+  *) [TS-1738] proxy.cluster.cache_total_hits_mem is missing in RecordsConfig.
+   Author: Yunkai Zhang <qiushu.zyk@taobao.com>
+
+  *) [TS-1739] Fix TODO within varFloatFromName()
+   Author: Yunkai Zhang <qiushu.zyk@taobao.com>
+
+  *) [TS-1559] Server side termination not handled properly when a PluginVC
+   Protocol Plugin is used. Author: Yossi Gottlieb.
+
+  *) [TS-1300] Document the usage of TSUrlStringGet() and derivatives.
+   Author: Uri Shachar.
+
+  *) [TS-1645] increase the file stat resolution on config files
+   Author: Yakov Kopel <ykopel@websense.com>
+
+  *) [TS-1557] update ua_begin_write
+   Author: Aidan McGurn <aidan.mcgurn@openwave.com>
+
+  *) [TS-1320] Reading from SSL origin can starve sending data to client.
+
+  *) [TS-1155] POST requests that are chunked encoding hang when going
+  forward to origin over SSL
+
+  *) [TS-1634] reimplement Lua state management to support reload
+
+  *) [TS-1716] authproxy fails to reserve an argument index in global mode
+
+  *) [TS-1710] esi plugin enhancement such as support forward proxy
+   Author: Yu Qing <zhuangyuan@taobao.com>
+
+  *) [TS-1707] fix FreeBSD store blocks calculation
+   Thanks to Ben Aitchison <ben at meh dot net dot nz>
+
+  *) [TS-1704] null pointer dereference in dns_result
+   Author: Li-Wen Hsu <lwhsu@lwhsu.org>
+
+  *) [TS-1701] segv if header_rewrite is configured with the InkAPI and uses
+   PATH or QUERY conditions. Author: John Kew.
+
+  *) [TS-1700] disable static libraries by default.
+
+  *) [TS-1653] prevent the crash that retry dns lookup after timeout.
+
+  *) [TS-1006] memory management, cut down memory usage.
+   Author: Yunkai Zhang <qiushu.zyk@taobao.com>
+
+  *) [TS-1678] Simplify register_record
+   Author: Yunkai Zhang <qiushu.zyk@taobao.com>
+
+  *) [TS-1252] stats summary in cluster not working
+   Author: Yunkai Zhang <qiushu.zyk@taobao.com>
+
+  *) [TS-1679] channel_stats plugin: count 5xx response and clean up code.
+   Author: Conan Wang
+
+  *) [TS-1676] FetchSM (TSFetchUrl) cannot handle POST bodies > 32kb.
+
+  *) [TS-1675] Adding API method TSHttpTxnClientIncomingPortSet.
+
+  *) [TS-1674] TSStatIntDecrement is broken: the logic is flawed.
+
+  *) [TS-1673] Remap with recv port is using the wrong port.
+
+  *) [TS-1672] Emergency throttling can continue forever.
+
+  *) [TS-1650] Inactivity cop should use TRY_LOCK instead of LOCK to avoid
+   deadlock.
+
+  *) [TS-1649] Don't use ink_bind if we're not specifying a local port.
+
+  *) [TS-1667] remove unused enum TSIOBufferDataFlags.
+
+  *) [TS-1538] SSL accept performance regression.
+
+  *) [TS-977] RecCore usage cleanup.
+
+  *) [TS-1574] [TS-1577] when read_from_writer, we should not do range
+   acceleration. Range request can invalidate cached copy if the server
+   reponse is 304.
+
+  *) [TS-1609] Traffic Cop doesn't wait() for its children.
+
+  *) [TS-1601] HttpServerSession::release don't close ServerSession if
+   ServerSessionPool locking contention.
+
+  *) [TS-1643] Post requests with no Content-Length header sends default error
+   response.
+
+  *) [TS-1640] SSL certificate reconfiguration only works once.
+
+  *) [TS-1246] trafficserver script error message (in ubuntu).
+
+  *) [TS-1630] Add Lua API for TSHttpTxnCacheLookupStatusGet.
+
+  *) [TS-1423] Added option to do transparent passthrough on connections that
+   are not valid HTTP.
+
+  *) [TS-1599] set OpenSSL allocator with CRYPTO_set_mem_functions.
+
+  *) [TS-1624] Remove JEMALLOC_P use, it seems to have been deprecated.
+
+  *) [TS-1500] let ssl_multicert.config specify sslcert per port
+
+  *) [TS-1621] Adopt ConfigUpdateHandler pattern.
+   Author: Ethan Lai <yzlai@yahoo.com>
+
+  *) [TS-1619] simplify ConfigurationProcessor reconfiguration pattern.
+
+  *) [TS-1617] Build cacheurl when experimental plugins are enabled.
+   Author: Aron Xu.
+
+  *) [TS-1307] [TS-1422] Changed HostDB handling of IPv4 and IPv6. Address
+   resolution preferences can be configured globally and per HTTP proxy
+   port. Transparent connections can now fail over even if
+   use_client_target_addr is set.
+
+  *) [TS-1616] authorization proxy plugin.
+
+  *) [TS-1615] Some spelling errors in source code. Author: Aron Xu.
+
+  *) [TS-1608] IpAllow should use standard config update.
+
+  *) [TS-1580] Mutex leak plugged.
+
+  *) [TS-1596] Added channel_stats plugin to experimental. Author: Conan Wang.
+
+  *) [TS-1607] decouple SSL certificate lookup
+
+  *) [TS-1506] %<cquuh> log symbol will crash TS when requesting a SSL url.
+   Author: Conan Wang.
+
+  *) [TS-1594] ProxyMutexPtr and Ptr<ProxyMutex> are identical.
+
+  *) [TS-1591] gzip plugin should load relative config file.
+
+  *) [TS-1582] C++11 requires space between strings and format specifiers.
+   Author: Luca Rea
+
+  *) [TS-1491] Browser always prompts for authentication (NTLM).
+   Author: Yakov Kopel.
+
+  *) [TS-1553] Detect and build C++11 dependencies.
+
+  *) [TS-1576] reload splitdns.config at runtime.
+   Author: Ethan Lai <yzlai@yahoo.com>
+
+  *) [TS-1551] reload ssl_multicert.config at runtime
+   Author: Ethan Lai <yzlai@yahoo.com>
+
+  *) [TS-1572] Plugin response status change can trigger ATS assertion
+   Author: Uri Shachar
+
+  *) [TS-1433] to make read from writer work
+
+  *) [TS-1564] fix the rolling of Logs created via the API in plugins
+     Author: Craig Forbes <cforbes at qualys dot com>
+
+  *) [TS-1565] TSStringPercentEncode returns one character short in no-op case
+   (no encoding needed). Author: Thach Tran <tranngocthachs at gmail dot com>.
+
+  *) [TS-1561] Plugin esi - Enhancements on ESI plugin.
+     Author: Kit Chan <chanshukit at gmail dot com>
+             Yu Qing <zhuangyuan at taobao dot com>
+
+  *) [TS-1560] plugins need memory barriers for ARM.
+
+  *) [TS-1558] use_client_addr breaks control over upstream HTTP protocol
+   version.
+
+  *) [TS-207] Add raw disk support for FreeBSD.
+
+  *) [TS-1494] sslCa should be set NULL after parseConfigLine in
+   SSLCertLookup.cc.
+
+  *) [TS-1382] make jtest 64bit nice.
+
+  *) [TS-1550] remove unnecessary USE_CONFIG_PROCESSOR define.
+
+  *) [TS-1549] Drop MakeErrorVA, enabling body_factory by default.
+
+  *) [TS-1548] Update documentation for ip_allow.config.
+     Author: Nick Berry
+
+  *) [TS-1223] fix the crash in http_ui show network connections.
+
+  *) [TS-1543] Enable non-debug logging for rfc5861 plugin.
+
+  *) [TS-1512] get volume & hosting work with cluster.
+
+  *) [TS-1542] Fix so that rfc5861 plugin will compile against older versions
+   of TS.
+
+  *) [TS-1446] Make sure age header is enabled in rfc5861 plugin
+
+  *) [TS-1539] Update build package list in README
+
+  *) [TS-1535] FetchSM process_fetch_write should ignore event
+   TS_EVENT_VCONN_WRITE_READY.
+
+  *) [TS-1534] implement the interim cache for ESI parser result.
+
+  *) [TS-1501] vc`s inactivity_timeout event should be schedule in vc`s
+   thread.
+
+  *) [TS-1503] make Event::schedule simple and efficient
+     Author: KuoTai
+
+  *) [TS-1532] make esi plugin support cookie sub keys.
+
+  *) [TS-1526] SNI support breaks IP-based lookup.
+
+  *) [TS-1513] SPDY plugin crashes on connection close.
+
+  *) [TS-1516] use_client_addr breaks parent proxy configuration
+     Author: Uri Shachar.
+
+  *) [TS-1518] detect header_rewrite plugin boost dependency.
+
+  *) [TS-1003] make Prefetch config file reloadable
+
+  *) [TS-1462] SPDY proxy plugin
+
+  *) [TS-1488] Check the event`s cancel flag before put it into the
+   PriorityEventQueue. Author: Chen Bin (kuotai).
+
+  *) [TS-1484] Fix SNI crashes where there is no default certificate
+
+  *) [TS-1473] Fix header_filter plugin for ARM.
+
+  *) [TS-1457] Change chunking output to avoid massive memory use by
+   transforms.
+
+  *) [TS-1469] Manager uses hardcoded FD limit causing restarts forever on
+   traffic_server. Reported By: Thomas Jackson
+
+  *) [TS-1466] disable ssl compression by default.
+
+  *) [TS-1464] mark ink_assert with the noreturn attribute.
+
+  *) [TS-1458] fix LuaJIT include ordering.
+
+  *) [TS-1454] crash when ic_hostname is null in cluster mode.
+
+  *) [TS-1270] add force local cache control in clustering mode.
+
+  *) [TS-1386] thread hang in cluster type=1, which will trigger the
+     throttling.
+
+  *) [TS-1351] raw disk cache disabled when system start.
+
+  *) [TS-1452] gzip build failure with Apple/clang-421.0.57.
+
+  *) [TS-1339] Move fragment offset table from First Doc to Alt header so
+     that fragment offsets are stored per alternate.
+
+  *) [TS-1416] Do not do cache lookup if cop_test_page is true to stop
+     artificial increase of cache misses.
+
+  *) [TS-1364] Rewrite reverse-proxy URL headers in all cases, not just
+     a basic Redirect target.
+
+  *) [TS-1440] Lua transaction and session hook support.
+
+  *) [TS-1266] RAM cache stats are wrong with CLFUS.
+
+  *) [TS-1437] Make the Lua plugin compile on RedHat based distros.
+
+  *) [TS-1436] Added Yahoo directory layout for installation.
+
+  *) [TS-1418] Add automake file to Metalink plugin. Author: Jack Bates.
+   Also reorganize the plugins/experimental Makefile.am stuff slightly.
+
+  *) [TS-1414] gzip plugin enhancements.
+
+Changes with Apache Traffic Server 3.3.0
+
+  *) [TS-1427] PluginVCs now use a method similar to actual socket VCs
+   for firing inactivity timeout events.
+
+  *) [TS-1426] protection from NULL deref when using
+   TSHttpTxnOutgoingTransparencySet after a user agent has disconnected.
+
+  *) [TS-1425] clean up the lingering read before deallocating its buffers
+   when an origin server terminates the connection during a POST request.
+
+  *) [TS-1249] Disable ESI packed nodes by default.
+   Author: Shu Kit Chan <chanshukit@gmail.com>
+
+  *) [TS-1421] Modify the default log configs to avoid logging to stdout
+   or stderr. This helps with TS-306 (but is not a solution for lack of
+   log rotation on traffic.out).
+
+  *) [TS-1415] return 400 if the length of request hostname is zero.
+
+  *) [TS-1379] Better error message when mgmt socket is not available.
+
+  *) [TS-1389] Replace TSHttpTxnServerRespNoStore() with
+   TSHttpTxnServerRespNoStoreSet(), and move it to ts/ts.h. Author: Phil
+   Sorber.
+
+  *) Removed the (experiemental) TSHttpTxnClientDataGet() API. See
+   TS-998 for more details.
+
+  *) [TS-1408] Plugin to implement the stale-while-revalidate and
+    stale-if-error features of RFC5861
+    Author: Phil Sorber <phil@omniti.com>
+
+  *) [TS-1406] add ESI to experimental plugins build.
+
+  *) [TS-1387] Allow proxy.config.http.insert_age_in_response to be
+   overridden. Author: Phil Sorber
+
+  *) [TS-1392] Fix SNI certificate fallback path.
+
+  *) [TS-1385] generic atomic operations API.
+
+  *) [TS-1380] SSL wildcard lookup doesn't find the longest match.
+
+  *) [TS-1315] Fix URL parsing to handle non-HTTP schemes correctly.
+
+  *) [TS-1322] CONNECT to parent proxy has URL with a trailing slash
+    Author: Yakov Kopel
+
+  *) [TS-1370] Restore original stale-wile-revalidate code for posterity
+    Author: Phil Sorber
+
+  *) [TS-1340] Improve IPv6 port example in records.comfig
+    Author: Jan-Frode Myklebust
+
+  *) [TS-1363] Cert path not working using intermdiate certificate.
+
+  *) [TS-895] Added version checks for bison and flex.
+
+  *) [TS-1331] Wrong regex for ip in records config. Authors:
+   Yakov Kopel and Uri Shachar.
+
+  *) [TS-1348] Remove the active timeout when releasing or
+  binding server_session.
+
+  *) [TS-1350] Detect and prefer LuaJIT.
+
+  *) [TS-538] Remove deprecated INKStats API.
+
+  *) [TS-1345] fix signed/unsigned compilation issues in Vec.
+
+  *) [TS-1343] Stat system doesn't check buffer sizes.
+
+  *) [TS-1342] Lua plugin initial hook support.
+
+  *) [TS-1314] Remove TS_ARG_MAX usage so that platforms with
+  unlimited ARG_MAX can build correctly.
+
+  *) [TS-1341] Remove remnants of TSCacheHookAdd() API.
+
+  *) [TS-1328] TSMgmtIntCreate and TSMgmtStringCreate validation.
+   Author: Yakov Kopel.
+
+  *) [TS-1338] SSL not handling some events properly.
+
+  *) [TS-1258] Need the ability to allow a user to alter the background fill
+   config values on a per transaction basis. Author: Robert Logue.
+
+  *) [TS-961] Add TSPortDescriptor API to support accepting connections with
+   inbound transparency.
+
+  *) [TS-1332] Silence spurious error when adding SSL certificates with
+   alternate names.
+
+  *) [TS-1087] TSHttpTxnOutgoingAddrSet forward declaration does not match
+   implementation.
+
+  *) [TS-1319] Large cache (> 16TB) not working
+  Author: Van Doorn, Jan R <Jan_VanDoorn@cable.comcast.com>
+
+  *) Fix a bug that ram cache and evcuation can not work
+    well in disks larger than 2TB. Author: weijin
+
+  *) [TS-1321] improve RT on Cluster purge missing objects
+   Author: Bin Chen
+
+  *) [TS-1312] Allow to open cache disk without O_DIRECT, for e.g. tmpfs
+   "disk" cache.
+
+  *) [TS-1289] stats codes mess up when disk fail
+
+  *) [TS-959] remove ae_ua filter
+
+  *) [TS-1310] Fix a endless loop in CacheVC::removeEvent.
+   Author: weijin & Hua Cai
+
+  *) [TS-1299] Fix collation in custom logging.
+   Author: bettydramit
+
+  *) [TS-1306] Fix WCCP build problems on FreeBSD.
+
+  *) [TS-1303] Added '=6' as special case for HTTP port configuration for
+     backwards compatibility.
+
+  *) [TS-1301] Add a new API, TSHttpTxnMilestoneGet(), which can be used
+   to retrieve the various internal milestone timers from a plugin.
+
+  *) [TS-1295] Don't assume root privileges during make install.
+   Author: Jan-Frode Myklebust
+
+  *) [TS-1294] initscript mentions using /etc/sysconfig/trafficserver, but
+   doesn't use it. Author: Jan-Frode Myklebust
+
+  *) [TS-1293] initscript should provide chkconfig header.
+   Author: Jan-Frode Myklebust
+
+  *) [TS-1297] Do not link all binaries and plugins with libz and liblzma.
+
+  *) [TS-1296] Do not link all binaries and plugins with libreadline.
+
+Changes with Apache Traffic Server 3.2.0
+
+  *) [TS-1286] Cleanup some code around freelists and allocators.
+
+Changes with Apache Traffic Server 3.1.4
+
+  *) [TS-1281] make check fail on RHEL 5.x.
+
+  *) [TS-1282] Verbosity settings for Via headers is broken.
+
+  *) [TS-1279] Fix build system for gcc < 4.3.
+
+  *) [TS-1277] Fixed issue with IPv6 URLs and remap configuration.
+
+  *) [TS-1195] Support the use of raw IPv6 address in URLs and Host fields.
+
+  *) [TS-1275] Fix startup problem where /var is on a volatile disk.
+   Author: Eric Connell.
+
+  *) [TS-1274] Transformation plugins can send content-length with
+   non-identity transfer encoding. Author: Otto van der Schaff.
+
+  *) [TS-1272] workaround for - FATAL: HttpSM.cc:890: failed assert `0`
+
+  *) [TS-1240] Fix race in log buffer queuing code.
+
+  *) [TS-1271] deprecate INKStats API
+
+  *) [TS-1250] Cache inspector does not seem to work properly
+
+  *) [TS-1269] Building outside source tree fails on plugins.
+
+  *) [TS-1222] single tcp connection will limit the cluster throughput.
+
+  *) [TS-475] Accelerated single range requests.
+     Based on initial work by ericb, with help from bwyatt.
+
+  *) [TS-1236] HTTP Accept filters do not work on Illumos.
+
+  *) [TS-1075] Workarounds for linux auto-port issues in transparent
+   deployments.
+
+  *) [TS-672] cleanup Win32 references.
+
+  *) [TS-1181] Make the overridable configs work with "byte" configs.
+
+  *) [TS-1252] Fixed include issues when using mgmtapi.h.
+
+  *) [TS-1248] update HTTP status codes and strings.
+
+  *) [TS-1245] proxy.config.http.connect_ports may be '*'.
+
+  *) [TS-1239] TSHttpTxnServerAddrSet implementation.
+
+  *) [TS-1237] custom log field/filtering improvements.
+
+  *) [TS-1090] SO_MARK and IP_TOS support for Linux.
+
+  *) [TS-1238] RAM cache hit rate unexpectedly low with CLFUS.
+
+  *) [TS-1242] Make it build with some more recent automake versions.
+
+  *) [TS-1241] Memory leaks when using TSHttpSchedule().
+   Author: Aidan McGurn.
+
+  *) [TS-1163] Support for raw disks larger than 2TB on Linux.
+
+  *) [TS-1230] added a paramter to the configure script to allow overriding
+   the calculated ARG_MAX value.
+
+  *) [TS-1208] enable check_memory() in traffic_cop for Linux.
+
+  *) [TS-1217] cop cleanup, remove unused variables & defines.
+
+  *) [TS-1209] Allow for background fill even when a transform plugin is
+   the producer. Author: Robert Logue.
+
+  *) [TS-1229] clean up RecordsCofing.cc, remove unused entries.
+
+  *) [TS-1142] record ram hit in stats.
+
+  *) [TS-1213] update will crash at HttpTransact::process_quick_http_filter.
+
+  *) [TS-1186] Fixed Perl stats API to work with 64-bit stat values
+
+  *) [TS-1227] header_filter "set" operator doesn't work if the header
+   doesn't already exist.
+
+  *) [TS-1210] remove 3.0.x deprecated APIs
+
+  *) [TS-1225] Remove 32 bit doc_len instances.
+
+  *) [TS-1226] Make header_filter support e.g. '=' characters in header
+   values.
+
+  *) [TS-1150] Some performance improvements around the heap guard.
+
+  *) [TS-1216] Remove the initializer for some gcc`s limits.
+
+  *) [TS-1205] double free when RecDataSet in cluster mode.
+
+  *) [TS-1220] stats: cleanup and fix the wrong values.
+
+  *) [TS-1212] can not limit ram cache, also fix the stats.
+
+  *) [TS-1214] another race condition in cache init.
+
+  *) [TS-1130] Wrong CAS operation on ink_time_t on 64 bit system.
+
+  *) [TS-1127] Wrong returned value of incoming port address. This
+   API is deprecated, so I also fixed the regression tests accordingly.
+   Authors: Yakov Kopel and Leif.
+
+  *) [TS-1211] Read backlog config value to set the listen backlog.
+
+  *) [TS-1202] Install traffic_shell man/doc pages in a more appropriate
+   location. Author: Igor Brezac.
+
+  *) [TS-1198] ssl crash when certificates are missing.
+
+  *) [TS-1164] a race condition in cache init.
+
+  *) [TS-1079] Add an API function to turn debugging on for specific
+   transactions/sessions. This also adds a new Debug() functionality in
+   both core and APIs. Author: Uri Shachar.
+
+  *) [TS-1194 Change conversions to build with gcc-4.6 on OmniOS/Solaris.
+   Also cleanup a couple of plugins to use our "core" build environment.
+
+  *) [TS-1192] Remove gethostbyname usage in test code
+
+  *) [TS-1147] deprecate records.config SSL configuration
+
+  *) [TS-1121] Make --disable-diags at least disable Debug etc.
+
+  *) [TS-1191] Change defaults for proxy.config.dns.search_default_domains to
+   not use the search domains in resolv.conf.
+
+  *) [TS-1190] Change defaults for proxy.config.http.share_server_sessions to
+   have a session pool per net-thread. This is best performance for most
+   common use cases.
+
+  *) [TS-1189] Build problem with older versions of OpenSSL.
+
+  *) [TS-1178] cop will kill manager & server, even cop it self, in cluster.
+
+  *) [TS-1156] Fix timestamp log fields, and stop supporting network byte
+   order in various log buffers. See TS-1182 for future enhancements.
+
+  *) [TS-1017] Update logging to be IPv6 compliant, including collation.
+
+  *) [TS-1080] If we run out of Log Buffer slots, we assert.
+
+  *) [TS-1176] Eliminates the need for a delayed "delete" of log buffers.
+   This was a serious race condition, which was previously sold by delaying
+   deletes via a ring buffer.
+
+  *) [TS-1036] Improve some squid log compatiblity. Suggestions from mnot.
+
+  *) [TS-1092] Remove specific SSL termination mode, we either terminate, or
+   we do not.
+
+  *) [TS-1173] Improve the comments in remap.config.
+
+  *) [TS-981] Remove the support for libev (for now at least).
+
+  *) [TS-1172] Remove remap/StringHash.{cc,h}, they are not used.
+
+  *) [TS-1171] http_ui cache lookup, double free.
+
+  *) [TS-1168] Change UrlRewrite::BuildTable to be IPv6 compliant.
+
+  *) [TS-1167] Updates parent socks server setup to be IPv6 compliant.
+
+  *) [TS-1166] Remove proxy/Stuffer.[cc,h] because they were unused.
+
+  *) [TS-1162] UnixNetVConnection assertion when accepting a TLS connection
+
+  *) [TS-1135] support wildcard certificates for ServerNameIndication (SNI)
+
+  *) [TS-1140] Combine IP Allow and QuickFilter.
+
+  *) [TS-1159] Add compiler hints to debug logging
+
+  *) [TS-1143] Fixed edge case problems in IpMap.
+
+  *) [TS-1114] Fix to lock vol for CacheVC::write_vector.
+
+  *) [TS-857] Possibly related race in UnixNetVConnection::mainEvent
+   on inactivity timeout.
+
+  *) [TS-1149] Pretty up automake output.
+
+Changes with Apache Traffic Server 3.1.3
+
+  *) [TS-1145] Additional clang build fixes. Author: Darrin Jewell.
+
+  *) [TS-1144] Fix out of tree builds. Author: Darrin Jewell.
+
+  *) [TS-1138] Fixed off by one range error in IpMap.
+
+  *) [TS-462] Support TLS Server Name Indication (SNI)
+
+  *) [TS-1134] TSNetAcceptNamedProtocol should fail if NPN is not supported.
+
+  *) [TS-1133] Make the max host-header length configure.ac configurable.
+
+  *) [TS-1002] fix custom loggin with cquuc cquup, and introduce cquuh
+   to recode the client_req_unmapped_url_host.
+
+  *) [TS-701] Remove mgmt/cli/script_configs.sh
+
+  *) [TS-1124] Move regex_remap, header_filter and stats_over_http from
+   the plugin repo to the main repo.
+
+  *) [TS-1111] fix crash in RangeTransform::handle_event
+
+  *) [TS-1109] fix stack dump crashing
+
+  *) [TS-1123] editline/readline conflicts when building on OSX.
+
+  *) [TS-1116] Fixes for building the source with clang/lvm.
+
+  *) [TS-1115] Fixes for building the source with Intel CC (icc).
+
+  *) [TS-1102] Cleanup of Diagnostics code. Author: Uri Shachar and Leif.
+
+  *) [TS-1117] Remove TS_HAS_PURIFY MACRO
+
+  *) [TS-937] EThread::execute still processing cancelled event
+
+  *) [TS-995] Name change for IP support (ink_inet.h).
+
+  *) [TS-841] support TLS NextProtocol negotiation
+
+Changes with Apache Traffic Server 3.1.2
+
+  *) [TS-1110] logstats incorrectly bucketizes all status codes greater
+  than 599 as 5xx. Author: Manjesh Nilange
+
+  *) [TS-1094] Fixed MIME parser so certain sequences of requests on
+   keep alive conections no longer wedge it.
+
+  *) [TS-1084] Add compile-time format string checking.
+
+  *) [TS-1101] traffic_line -x no longer works, at least not in
+   reasonable time.
+
+  *) [TS-1098] Make RC script support Amazon EC2 Linux AMI.
+
+  *) [TS-1035] EventProcessor::spawn_thread doesn't check that there
+   is enough event threads and segfaults.
+
+  *) [TS-1096] readline support for traffic_shell.
+
+  *) [TS-1097] online help for traffic_shell.
+
+  *) [TS-1066] TSHttpTxnServerReqHdrBytesGet in InkAPI.cc has an extra
+   parameter (int *bytes) from the prototype in <ts/ts.h>.
+   Author: Alistair Stevenson
+
+  *) [TS-1089] Added TSHttpConnectTransparent.
+
+  *) [TS-1088] Added TSHttpTxnOutgoingTransparencySet to API to
+   control outbound transparency.
+
+  *) [TS-1083] Initial SSL next protocol negotiation support.
+
+  *) [TS-1082] Obey existing optimizer CXXFLAGS and CFLAGS at configure time.
+
+  *) [TS-1077] All proxy ports are now configured by
+   proxy.config.http.server_ports. All other port configuration values
+   are deprecated.
+
+  *) [TS-1091] CFLAGS=-w` causes configure script to wrongly guess style of
+   `gethostbyname_r` on BSD flavors. Author: Marc Abramowitz.
+
+  *) [TS-1073] no_dns_just_forward_to_parent configuration parameter is
+   ignored/not used. Author: Kevin Giles.
+
+  *) [TS-996] HTTPHdr::m_host goes stale if HdrHeap::evacuate_from_str_heaps
+   is called. Author: B. Wyatt.
+
+  *) [TS-1041] Populate sockaddr length. Author: James Peach.
+
+  *) [TS-1081] Eliminate an additional copy of the pristine URL string.
+
+  *) [TS-1038] TSHttpTxnErrorBodySet() can leak memory.
+   Author: Brian Geffon
+
+  *) [TS-1049] TS hangs (dead lock) on HTTPS POST requests.
+   Author: Wilson Ho
+
+  *) [TS-1056] Lost UA connections can show up as "400 ERR_INVALID_REQ"
+   in logs.
+
+  *) [TS-1048] Add TS API to enable plugins to use traffic server
+   configuration infrastructure. Author: Bianca Cooper.
+
+  *) [TS-1074] PluginVC should schedule to the local queue instead of the
+  external queue. Author: Brian Geffon
+
+  *) [TS-1032] Assertion when upstream connection is established (with event
+   handled by thread A) and immediately disconnected (handled by thread B).
+   Author: Uri Shachar.
+
+  *) [TS-1052] trafficserver restart does not work (needs to let the old
+   process die). Author: Billy Viera
+
+  *) [TS-1044] Fix TSVConn{Read,Write}VIOGet in UnixNetVConnection.
+    Author: James Peach.
+
+  *) [TS-1040] Teach TSHostLookup to use const. Author: James Peach.
+
+  *) [TS-1071] Debug statement in FetchSM broken. Author: Brian Geffon.
+
+  *) [TS-1057] Expose Base64-encoding through APIs.
+   Author: Yakov Kopel and leif
+
+  *) [TS-1014] slow log can not print logs well on 32-bit system,
+  changed the %d to RPI64. Author: weijin.
+
+  *) [TS-992] Various portability fixes. Author: Piotr Sikora
+
+  *) [TS-999] Deprecate TSUrlDestroy(), it's a no-op. Just make sure
+   to release the marshal buffers as normal.
+
+  *) [TS-245] Add TSStringPercentEncode(), TSUrlPercentEncode(), and
+   TSStringPercentDecode().
+
+  *) [TS-1065] traffic_cop segment fault when enable TRACE_LOG_COP.
+   Author: Conan Wang.
+
+  *) [TS-1029] DNS crash if we free the memory into system. Author: weijin
+
+  *) [TS-1055] Wrong implementation of TSHttpSsnArgGet().
+   Author: Yakov Kopel
+
+  *) [TS-992] Portability fixes. Author: Piotr Sikora.
+
+  *) [TS-949] Fix key->vol hash to be consistent when a disk is marked bad.
+
+  *) [TS-1047] fix lots of spelling mistakes Author: Arno Töll
+
+  *) [TS-1042] correct debug message in FetchSM. Author: James Peach
+
+  *) [TS-1039] use pcre-config to find libpcre. Author: James Peach
+
+  *) [TS-1037] Fix for computing local machine address (was ignoring
+   general addresses).
+
+  *) [TS-1030] Improve hashing mechanism on WKS.
+
+  *) [TS-1028] Avoid triggering assert when running debug build and enabling
+   per-thread connection pols
+
+  *) [TS-1021] Remove extra newline from binary logs.
+
+  *) [TS-1022] Use size specific types for serialized data in binary logs.
+
+Changes with Apache Traffic Server 3.1.1
+
+  *) [TS-1020] Make logging to a named pipe work on Solaris.
+
+  *) [TS-1016] Make the update frequency for stats configurable.
+
+  *) [TS-944] Align all configurations of paths to use the same function
+
+  *) [TS-1018] Remove obsolete OpenSSL acceleration code and configs
+
+  *) [TS-1013] Allow ssl_multicert.config to support CA chains per host
+
+  *) [TS-971] make cache evacuate work as expect.
+
+  *) [TS-982] Fixed PluginVC set active/passive address. Clarified that
+   it expects host order input.
+
+  *) [TS-1012] Eliminate proxy.config.http.append_xforwards_header, which
+   is never used.
+
+  *) [TS-1004] Transformation plugins cause connection close when content
+   length is not known ahead. Author: Otto van der Schaaf.
+
+  *) [TS-1011] Fixes for OpenSSL, specifically triggered for Solaris, but
+   generally broken assumptions in the old code.
+
+  *) [TS-989] Logging is now IPv6 compatible.
+
+  NOTE: IP addresses are now encoded as a specific type of binary
+  data, not a mix of unsigned ints and strings. This is a log binary
+  format change and therefore WILL BREAK ACCESS TO LOG DATA FROM
+  PREVIOUS VERSIONS.
+
+  *) [TS-1009] Disable starting ICP continuations if ICP is not enabled.
+
+  *) [TS-1005] Use traffic_line for reload option with RC script.
+   Author: Jan-Frode Myklebust.
+
+  *) [TS-984] Log roll crash fixed.
+
+  *) [TS-997] ATS crashes on remap plugin initialization failure.
+   Author: Manjesh Nilange.
+
+  *) [TS-988] Updated ICP for IPv6.
+
+  *) [TS-994] Removed the extra splace from X-Forwarded-For.
+
+  *) [TS-934] Added some wrapping around NetVConnection for server
+   handling so that connection objects can be safely locked across
+   threads.
+
+  *) [TS-991] Fixed race / stall condition for WCCP during restart.
+
+  *) [TS-985] ts/ts.h uses C++ comments, which are technically not C.
+
+  *) [TS-928] Compile problem in TsErrataUtil on FreeBSD 8.
+
+  *) [TS-973] Eliminate proxy.config.http.verbose_via_str.
+
+  *) [TS-747] Add a new option, proxy.config.ssl.compression, to turn
+   SSL compression on / off. This currently only works with OpenSSL
+   v1.0.0 and later.
+
+  *) [TS-963] Change the way ip_allow is parsed to be consistent with
+   earlier versions (first match). Added default IPv6 allow. Added
+   regression tests for the underlying IpMap class.
+
+  *) [TS-948] Don't reload or load a broken remap.config.
+
+  *) [TS-824] Range requests that result in cache refresh give 200 status
+   response with full contents. Review and suggestions for improvements
+   by Charlie Gero.
+
+  *) [TS-964] Add 64-bit integer plugin APIs for HTTP headers.
+
+  *) [TS-932] Fix m_pending_event == NULL crash in LogCollationClientSM.cc
+   Author: weijin
+
+  *) [TS-830] Better error when there are CLI permission problems, or
+   other problems preventing operation. Author: AdunGaos.
+
+  *) [TS-979] Found a few places where we can segfault with strlcpy.
+
+  *) [TS-938] Fix VIA to avoid loopback address. For Solaris only IPv4
+   is supported.
+
+  *) [TS-945] Convert transparent forward requests to server style when
+     forwarding to a parent proxy. Contributed by Yossi Gottlieb.
+
+  *) [TS-926] IPv6 conversion of iocore.
+
+  *) [TS-967] This is a simplified version of Arno Toell's patch which does
+   the same: Check if any -O options where given, and if so, use those, if
+   not, use our default -O3.
+
+  *) [TS-957] remove IE6 from the white list of ae_ua filter
+
+  *) [TS-955] Fix the logging regression testing.
+
+  *) [TS-962] typo of key name in logstats.cc. Author: Nick Berry.
+
+  *) [TS-958] Fix a few valgrind memory check errors.
+
+  *) [TS-567] A number of memory allocation clean up, and improvements. We
+   now also support building with tcmalloc, jemalloc, and you can also turn
+   off the freelist feature (for better debugging).
+
+  *) [TS-950] Make the HTTP header regressions work on 32-bit, inefficient,
+   but it works.
+
+  *) [TS-956] fix the building with zlib-1.2.5.1.
+
+  *) [TS-953] consolidate string copy/concat for examples.
+
+  *) [TS-924] More efficient sharing of origin connections.
+
+   This also overloads the config for shared connections as follows:
+
+       #  0 - Never
+       #  1 - Share, with a single global connection pool
+       #  2 - Share, with a connection pool per worker thread
+       CONFIG proxy.config.http.share_server_sessions INT 1
+
+   This option is now per-request (remap or plugin) overridable. This is
+   heavily based on William Bardwells and Weijin's work.
+
+  *) [TS-84] Unify all code to use PATH_NAME_MAX, and increase it to 4K.
+
+  *) [TS-943] Implement support for HTTP accept filters.
+
+  *) [TS-168] revert iObject and other changes, make collation client work
+   in the clean way.
+
+  *) [TS-941] invalid cast of off_t math to int. Author: B Wyatt.
+
+  *) [TS-940] Add new configuration option, and solaris support, to set
+  an initial congestion window size, proxy.config.http.server_tcp_init_cwnd.
+
+  *) [TS-931] cluster latency too high, about 24ms. this change will cut
+   the latency from 20+ms to about 10ms. Author: weijin
+
+  *) [TS-896] When logging config changes, we should check if it is remote
+   logging and clean up the collation client related data.
+
+  *) [TS-936] Fix problems with core file generation on Linux.
+
+  *) [TS-930] Fixed TSNetConnect to use network order for port.
+
+  *) [TS-1008] Add API to get TCP connection from SSN.
+
+Changes with Apache Traffic Server 3.1.0
+
+  *) Make sure --enable-purify works again
+
+  *) [TS-888] Fix SSL by enabling the right direction on successful setup.
+
+  *) [TS-925] Switch from integer thread IDs to hex thread IDs with the
+   diagnostics output. Author: Brian Geffon.
+
+  *) [TS-919] All of iocore is now IPv6 compatible. Much of this work
+   was contributed by Yossi Gottlieb.
+
+  *) [TS-867] moving to a different thread only if the pluginvc is invoked
+   from a non regular thread.
+
+  *) [TS-876] forward map based on request receive port. Author: Manjesh
+   Nilange.
+
+  *) [TS-880] Major performance problem with second request on same
+   keep-alive connection. This is a partial fix, another 2x improvement
+   can be made, but too risky right now. Authors: William Bardwell and
+   weijin.
+
+  *) [TS-900] TSHttpTxnNewCacheLookupDo (experimental) breaks requests
+   to origin server. Author: William Bardwell.
+
+  *) [TS-918] Allow interval-based rotation for round robin entries.
+   Author: M. Nunberg.
+
+  *) [TS-916] TSHttpIsInternalRequest() crashes if client connection is
+   terminated prematurely. Author: Manjesh Nilange.
+
+  *) [TS-466] Multiline headers handled improperly.
+
+  *) [TS-914] fix iocore_net_main_poll debug info in UnixNet.cc
+   Author: taorui
+
+  *) [TS-911] Remove unecessary lock in HTTP accept.
+
+  *) [TS-908] HostDB now stores IPv6 addresses.
+
+  *) [TS-813] fix http_ui /stat/ to response with content type
+
+  *) [TS-849] fix some variables for traffic_line -s setting
+
+  *) [TS-874] make asf-dist work with git repo
+
+  *) [TS-906] ATS doesn't use proxy.config.http.forward.proxy_auth_to_parent.
+
+  *) [TS-592] DNS internals are now IPv6 compatible. Externally this means
+     DNS servers with IPv6 addresses can be used although only IPv4 responses
+     are useful until other IPv6 upgrades are done.
+
+  *) [TS-907] The source address for DNS requests can be set.
+
+  *) [TS-903] Internal resolver library now IPv6 compatible.
+     IP address matching libraries removed, replaced with IpMap which is
+     faster and IPv6 compatible. SOCKS and IpAllow configurations files
+     will now parse IPv6 ranges, although they do not current have effect.
+
+  *) [TS-901] Valgrind found minor leaks and uninitialized variables.
+   Author: William Bardwell.
+
+  *) [TS-863] Make proxy.config.http.keep_alive_no_activity_timeout_out
+   configurable per transaction. Author: William Bardwell.
+
+  *) [TS-859] Make parent proxy not not work anymore.
+
+  *) [TS-889] Disable warnings on deprecated APIs for Darwin (OSX). This
+   fixes build problesm on OSX 10.7 (Lion) when using the system OpenSSL.
+
+  *) [TS-890] update remap.config comments on regexes to be
+   accurate. Author: Manjesh Nilange.
+
+  *) TS-885 service trafficserver condrestart does the opposite of what´s
+    intended. Author: Jan-Frode Myklebust
+
+  *) [TS-898] "fixed" problems reported by Coverity
+    1. Changed sprintf to snprintf
+    2. ignore error on sscanf that is safe
+
+  *) [TS-807] no config item "proxy.config.hostdb.disable_reverse_lookup" in
+   hostdb. Author: weijin.
+
+  *) [TS-883] Fix help / usage text to be, ehm, correct.
+
+  *) [TS-567] Cleanup, removing unecessary, and unsupported, debug features.
+
+  *) [TS-848] fix crash in net pages and remove useless option.
+
+  *) IpLookup was removed from the experimental API.
+
+  *) proxy.config.http.cache.cache_responses_to_cookies can now be overridden
+   on a per request basis in cache.config.
+
+  *) [TS-816] Other ports now obey specified options for both normal
+   and standalone usage.
+
+  *) [TS-882] traffic_logstats dies when printing log.
+
+  *) [TS-804] libcap required when running standalone.
+
+  *) [TS-730] Allow for the SSL Cipher Suite to be configured.
+
+  *) [TS-881] Better error message from TrafficCop when admin user lookup
+   fails.
+
+  *) [TS-875] TSFetchRestpGet(), TSFetchPageResptGet() and TSFetchUrl() have
+   incorrect asserts. Author: Manjesh Nilange.
+
+  *) [TS-853] Fix a few example plugins to use the new (appropriate) sockaddr
+   based APIs (and not the deprecated APIs).
+
+  *) [TS-870] Fix evacuate relevant codes in cache to work, Author: mohan_zl
+
+  *) [TS-869] The stat code for ram_cache miss is lost, Author: mohan_zl
+
+  *) [TS-873] Wrong code in iocore/net/UnixNet.cc, Author: mohan_zl
+
+  *) [TS-833] Continuation::handleEvent deadbeef fix, authors jplevyak and
+  taorui.
+
+  *) [TS-834] InactivityCopy::check_inactivity crash.
+
+  *) [TS-864] Need more information from CacheHttpInfo (req time, resp time,
+  size). Author: William Bardwell.
+
+  *) [TS-860] Built in error for host not found looks like Internet Explorer
+  error. Author: William Bardwell.
+
+  *) [TS-861] Need a way to disable Vary: Accept-Encoding checking so a plugin
+  can take care of that. Author: William Bardwell.
+
+  *) [TS-862] Need to be able to make keep alive connections not shared on a
+  per-transaction basis. Author: William Bardwell.
+
+  *) [TS-865] Need to get address for a VConn from a plugin similar to how you
+   can get it for the various things in a transaction. Author: William
+   Bardwell.
+
+  *) [TS-868] build fails with --as-needed. Author: Ilya Barygin.
+
+  *) [TS-851] run TS without a real interface
+
+  *) [TS-822] make cluster thread number configable
+
+  *) [TS-845] make proxy.config.cluster.ethernet_interface default to
+   loopback interface: lo on linux and lo0 on bsd derivatives
+
+  *) [TS-847] Bad timeout when using CONNECT method.
+
+  *) [TS-826] TSHttpTxnErrorBodySet() can leak memory. Author: William
+  Bardwell.
+
+  *) [TS-840] Regression checks fail (again) due to faulty assert use.
+   Author: Arno Toell.
+
+  *) [TS-842] remove uninstall target from build system
+
+  *) [TS-648] Use hwloc library when available. This can be disabled
+   with --disable-hwloc.
+
+  *) [TS-398] Autoscaling threads vs Hyper Threading. This requires
+   support for hwloc as well.
+
+  *) [TS-760] Cleanup mgmt types.
+
+  *) [TS-359] Remove DIR_SEP and use slash directly.
+
+  *) [TS-839] Build problems when specifying lmza location.
+
+  *) [TS-828] Various memory leaks and uninitialized values. Author:
+   William Bardwell.
+
+  *) [TS-815] make sure that a missing yacc/bison|flex/lex is *fatal* when
+   building with wccp. Author: Arno Toll.
+
+Changes with Apache Traffic Server 3.0.0
+
+  *) [TS-827] TSMimeHdrFieldValueStringInsert() can use freed memory to
+  edit headers. Author: William Bardwell.
+
+  *) [TS-825] negative caching caches responses that should never be
+   cached: Author: William Bardwell.
+
+  *) [TS-820] Restore log buffer size to previous defaults.
+
+  *) [TS-818] Assertion/abort when starting TS with SOCKS proxy enabled.
+   Author: Yakov Markovitch
+
+  *) [TS-810] Typo in switch statement + slight improvement.
+
+  *) [TS-809] ts.h broken when compiling C plugins.
+
+  *) [TS-798] We add broken remap rules when we encounter parse errors of
+   remap.config.
+
+Changes with Apache Traffic Server 2.1.9
+
+  *) [TS-805] HostDB wastes a lot of storage for round-robin entries,
+   and the calculations of size are off.
+
+  *) [TS-806] TS_ADDTO removes duplicates, so avoid this by using the
+   -R option to libtool
+
+  *) [TS-793] Improve print statements for ink_freelist debugging.
+
+  *) [TS-679] The external API was changed to make it IPv6 compliant
+     (although it doesn't actually work with IPv6). Old API functions
+     were deprecated but not removed.
+
+  *) [TS-797] Wrong delete used in stats processor.
+
+  *) [TS-769] Fixed infinite loop when getting a 505 response from the
+   origin and the connection is keep-alive.  Now downgrading keep-alive
+   all the time along with the protocol.
+
+  *) [TS-788] Cleaned up the request and response cacheable apis.
+
+  *) [TS-792] Add a config option (disabled by default) to support
+  mlock() and mlockall().
+
+  *) [TS-783] Port ATS to IA64. Author: Arno Toell.
+
+  *) [TS-778] Compile Fails on Solaris 10 (gcc). Author: Igor Brezac.
+
+  *) [TS-404] Add a new API, TSOSIpSet() which allows you to bypass the
+    origin server DNS lookup.
+
+  *) [TS-791] Remove ShmemClean.cc, it's no longer needed.
+
+  *) [TS-786] Add a perl module to edit a records.config configuration
+  file.
+
+  *) [TS-779] Set thread name for various event types.
+
+  *) [TS-784] Don not use class allocator for remap processing when no
+   remap threads are enabled.
+
+  *) [TS-782] Remap processor creates a remap thread even when asked not
+   to.
+
+  *) [TS-781] Cleanup of unusual configs, and better defaults making
+   records.config leaner, and a little more useful.
+
+  *) [TS-780] Retune the number of SSL threads.
+
+  *) [TS-775] Disable cluster autodiscovery via multicast when
+   clustering is disabled. This should hopefully fix run-time errors
+   with Ubuntu 11.x.
+
+  *) [TS-776] memchr in glibc has evolved, and is faster than our
+   version, replaced.
+
+  *) [TS-774] Add a new configure option, --enable-static-libts, which
+   avoids the dynamic linking hassles involved with the dynamic nature
+   of libts. This is for devs only.
+
+  *) [TS-773] Traffic server has a hard limit of 512 gigabytes per RAW
+   disk partition. This fix required changing the disk structure which
+   will result in a total disk cache clear (wipe) after upgrading.
+
+  *) [TS-772] Make proxy.config.http.doc_in_cache_skip_dns overridable.
+
+  *) [TS-770] proxy.config.http.doc_in_cache_skip_dns is not being read
+   from records.config. Author: Yakov Markovitch
+
+  *) [TS-738] 'make check` fails on x86.
+
+  *) [TS-771] Remove remaining v1 log buffer code.
+
+  *) [TS-562] Make --with-openssl path be honored with an -rpath to
+   libtool. This also fixes the same problem with other libraries,
+   e.g. pcre, zlib etc.
+
+  *) [TS-765] Make the backdoor port (8084 by default) only listen on
+   127.0.0.1 .
+
+  *) [TS-762] Range values like -10 are processed. Author: William
+   Bardwell.
+
+  *) [TS-761] Fixed bug where 3 (or more) remap plugins in a chain
+   couldn't be loaded.
+
+  *) [TS-763] When creating multiple SSL accept threads, we use the
+   wrong instantiator.
+
+  *) [TS-757] Change TSNetAccept() API to take an option for enabling
+    (and number of) accept threads.
+
+  *) [TS-759] Makefile in proxy/config handles $DESTDIR incorrectly.
+   Author: Arno Toell
+
+Changes with Apache Traffic Server 2.1.8
+
+  *) [TS-750] TS does not fail-over if one origin server for a 2 address
+   hostname. Author: William Bardwell.
+
+  *) [TS-752] If you cancel a scan really quickly you can get a NULL
+  dereference. Also other important performance and correctness fixes
+  for the cache scanning code. Author: William Bardwell and jplevyak.
+
+  *) [TS-749] Connection hangs if origin server goes down in the middle of
+  a response. Author: William Bardwell.
+
+  *) [TS-753] TS-753 Some more cleanup in InkAPI, move a few experimental
+   APIs to ts.h
+
+  *) [TS-751] Experimental TSHttpTxnCacheLookupStatusSet(HIT_STALE) calls
+   cause a crash. Author: William Bardwell
+
+  *) [TS-748] Client side transparency doesn't work on trunk.
+
+  *) [TS-702] FATAL: MIME.cc:1250: failed assert `j < block_count`.
+  Author: Yakov Markovitch
+
+  *) [TS-746] Allow to remove URL fields with "NULL" (or 0) values.
+
+  *) [TS-744] Configurations to control SSL session reuse and cache
+  size. Authors: qianshi and Leif
+
+  *) [TS-716] Bug where NetVC could be double free'd.
+   Fix for DNS crash: bad memory management of HostEnt structures. It is
+   not clear that this fixes the bug entirely.  Some of the stack traces
+   are consistent with this bug, but some are not.
+
+  *) [TS-743] Support separate configs for keep-alive enabled for _in
+   and _out connections.
+
+  *) [TS-741] traffic_manager handles sockets incorrectly.
+
+  *) [TS-742] assert triggered wrongly (in debug builds).
+
+  *) [TS-740] Traffic Server fails to build on kfreebsd.
+   Author: Arno Toell.
+
+  *) [TS-737] Small hackish fix for rc/trafficserver.in so rc/trafficserver
+   will work with FreeBSD. Author: G Todd.
+
+  *) [TS-735] Disable ccache by default, use with --enable-ccache.
+
+  *) [TS-734] Remove unused fields in net stats pages.
+
+  *) [TS-212] Startup service support for Solaris. Author: Igor Brezac.
+
+  *) [TS-629] fix some non-portable char == unsigned char assumptions.
+
+  *) [TS-621] Update records.config.default.in with changed / removed
+   configs.
+
+  *) [TS-641] Remove a bunch of Web UI related configs and code.
+
+  *) [TS-719] libtsutil.so is not self-contained.
+  Author: Igor Brezac.
+
+  *) [TS-729] Fix bugs with Via Headers handling. (Note: This is
+   unlikely to have caused the crash the bug report)
+   Author Leif Hedstrom
+
+  *) [TS-721] Incorrect http hit ratio in stats.
+   This also removes a number of obsoleted stats and also disables
+   stats aggregation in WebOverview.cc, one more nail to WebUI's
+   grave. Author: Leif Hedstrom
+
+  *) [TS-728] Remove the --enable-webui option, since it doesn't
+   produce a running webui anyway. Also remove html2
+
+  *) [TS-685] Rename partition.config because it doesn't have
+   anything todo with disks. Also rename all code related to it
+   so as not to confuse anybody.
+
+  *) [TS-714] Fix traffic_shell hanging on every command
+
+  *) [TS-562] Fix TCL linking to honor custom library dirs.
+   Author: Eric Connell.
+
+  *) [TS-624] make install should not overwrite etc/trafficserver/.
+   Author: Eric Connell.
+
+  *) [TS-465] Allow for existing Server: string to not be overwritten.
+   This adds a new semantic for the value "2" to this option.
+
+  *) [TS-633] Fix reverse mapping with different schemes.
+   Author: Andreas Hartke.
+
+  *) [TS-715] Fixes and cleanup for Perl client. Author: Billy Vierra.
+
+  *) TS-550 Remove an unused / unsupported debug tool. Also update the
+   remap code to use our standard linked list (Queue in this case).
+
+  *) [TS-704] Link traffic_server dynamically to make distros happy,
+  since --disable-static will work.
+
+  *) [TS-545] Clean out more cruft from MIXT legacy.
+
+  *) [TS-713] Honor the offset within do_io_pread.
+
+  *) [TS-712] Fix compile problems with clang / llvm
+
+  *) [TS-545] parent.config (and perhaps other configs) have an unused
+   concept of "tags" for MIXT media. Cleanup remaining MIXT junk.
+
+Changes with Apache Traffic Server 2.1.7
+
+  *) [TS-711] Don't schedule remap.config reloads on a network threads.
+   We now schedule this task on an ET_TASK thread, which avoids blocking
+   a net-thread for several seconds (when reloading very large remaps).
+
+  *) [TS-710] Do not dlopen / reload a remap plugin .so more than once.
+
+  *) [TS-588] Change Remap plugin APIs to use URL TSMLoc, and normal
+   ts/ts.h APIs for getting and setting components.
+
+  *) [TS-708] TsConfig doesn't handle backslashes correctly.
+
+  *) [TS-209] add support for raw disk on Solaris: credits: Igor Brezac
+    for both the code and testing!
+
+  *) [TS-705] Fixes for compiling with gcc v4.6.
+
+  *) [TS-706] hardware sector size's over 8K current report an Error
+   but are passed through resulting in lots of disk waste.
+
+  *) [TS-707] The random number generator from 1-23-2011 is using the
+   same seed for all threads = collisions in the cache
+
+  *) [TS-700] Need additional controls in cache.config.
+
+  *) [TS-696] make check fails on libtsutil due to missing libresolv
+   and librt. Author: Eric Connell.
+
+  *) [TS-691] LogFilter not working for "int" types.
+   Author: Eric Connell.
+
+  *) [TS-692] Add an experimental API to modify the outgoing IP address.
+
+  *) TS-676: logic in Store::clear and Store::read_config is wrong.
+  Author: mohan_zl.
+
+  *) [TS-680] Change many typedef void* types to anonymous structs.
+
+  *) [TS-690] Schedule some callbacks on the ET_TASK threads
+
+  *) TS-689 Restore TSMgmtUpdateRegister() to the SDK APIs.
+
+  *) [TS-550] Remove MgmtPlugin.{cc,h}.
+
+  *) [TS-657] Proper validation of RWW settings on startup.
+
+  *) [TS-688] Remove the "tag" modifier from parent.config.
+
+  *) [TS-682] Segfault when partition.config is used.
+
+  *) [TS-687] Build failures on FreeBSD8
+
+  *) [TS-684] config.layout for gentoo linux, may also be used on Fedora
+
+  *) [TS-675] Make redirect and reverse maps work again.
+
+Changes with Apache Traffic Server 2.1.6
+
+  *) [TS-678] Add a config option for try-lock retry delay.
+
+   This adds a configuration option
+
+         proxy.config.cache.mutex_retry_delay INT 2
+
+   2ms seems to be fairly optimal, with little detrimental effect on CPU
+   usage. We'll fine tune this further in the next release.
+
+  *) [TS-674] Fixes for cache.config and the "modifiers" to work.
+
+  *) [TS-641] Remove inktomi*.css and some files only referenced by it.
+   Removing mgmt/html2/charting. Remove the now empty mgmt/html2/tune.
+
+  *) [TS-590] Cleanup all SDK APIs to be more consistent. This changes a
+   large number of APIs, so please check updated docs and signatures in
+   ts/ts.h. A new tools, tools/apichecker.pl, can be used to help
+   identifying areas in existing plugins that might need changes.
+
+  *) [TS-673] Make the default configurations more conservative
+   for when content is cacheable.
+
+  *) [TS-672] Remove unused/unreferenced Win32 header files and
+   code paths
+
+  *) [TS-671] Detect install group based on install user.
+
+  *) [TS-644] Fix clustered cache pages crash.
+
+  *) [TS-651] Clear all stats when we ask to clear the local stats.
+
+  *) [TS-489] Remove the "connection collapsing" feature, it was poorly
+   implemented, and caused major problem if enabled. We should redo this
+   for v3.1 in a way that fits with the HttpSM [author: mohan_zl].
+
+  *) [TS-668] Add support for URL stats to traffic_logstats.
+
+  *) [TS-665] Remove HTTP_ASSERT from the code base, use standard asserts.
+
+  *) [TS-663, TS-664] Fixes to WCCP with mask assignments, and trunk build
+   problems.
+
+  *) [TS-662] Make per partition stats for bytes_used work.
+
+  *) [TS-661] Delay the copy of per transaction configs until a plugin
+   actually tries to modify a setting. We also add these settings to the
+   list of configurations that is overridable:
+
+       proxy.config.http.cache.max_open_read_retries
+       proxy.config.http.cache.open_read_retry_time
+
+  *) [TS-660] Cache scan can not be canceled.
+
+  *) [TS-505, TS-506] Changed the defaults to deal with read contention on
+   the cache, this dramatically improves the performance on cache misses.
+
+  *) [TS-655] Reorganize some code to reduce binary foot prints.
+
+  *) [TS-653] Bogus logcat conversion of squid timestamps.
+
+  *) [TS-643] Unable to purge objects on other servers in full cluster mode.
+
+  *) New 64-bit random generator.
+
+  *) [TS-639] Rename the management APIs from INK* to TS*.
+
+  *) [TS-650] Remove the dead v2 stats code.
+
+  *) [TS-649] Dynamic libraries for mgmt APIs.
+
+    This makes libts -> libtsutil, and we now support making .so's for
+    libtsutil.so and libtsmgmt.so. All binaries are changed to use this,
+    except traffic_server which continues to use the libtsutil.a library
+    (for performance on e.g. 32-bit platforms).
+
+    This also renames the public API include file to be
+
+         #include <ts/mgmtapi.h>
+
+  *) [TS-647] Move Layout out of iocore and into lib/ts.
+
+  *) [TS-638] Rename various directories:
+      proxy/mgmt -> mgmt/
+      proxy/mgmt/cop -> cop/
+
+   All "cli" APIs are now also migrated into mgmt/cli, unified into one
+   single cli.
+
+  *) [TS-641] Cleanup of Web2/HTML2.
+
+  *) [TS-636, TS-637] Remove various unused source files.
+
+  *) [TS-631] Rename proxy/http2 -> proxy/http and proxy/mgmt2 to proxy/mgmt.
+
+  *) [TS-582] Add an example to records.config for how to bind a specific IP.
+
+  *) [TS-491] Cluster port was activated even with clustering disabled. This fix also
+   adds monitoring support for the "cli" unix domain socket.
+
+  *) [TS-593] Cleanup of inktomi.com.
+
+  *) [TS-324] Cleaning up some old TCL files and dependencies.
+
+  *) Remove traces of FTP references [TS-324] by purging the now useless TCL
+  bindings to it.
+
+  *) [TS-513] Fix configure issues for sqlite3. This fix eliminates all of
+  SimpleDBM, sqlite3 and bdb dependencies. It also fixes the "make
+  distclean" problem, and clean things up a bit.
+
+  *) [TS-491] Add the CLI interface to Traffic Cop, and make it possible to
+   run traffic_manager without listening on the cluster port.
+
+  *) [TS-583] Build fails if --disable-webui is added.
+
+  *) [TS-618] Removing traces of CCAS/CCASFLAGS.
+
+  *) [TS-627] Fixes for "make check" to succeed (author: Arno Toell).
+
+  *) [TS-632] Fixes for bad cast and cleanup for Intel CC.
+
+Changes with Apache Traffic Server 2.1.5
+
+  *) More 64-bit issues has been identified in the SDK and HTTP core, and
+  fixed [TS-620].
+
+  *) Code cleanup of old transparency code and options [TS-613].
+
+  *) We now require a compiler (or libc) that provides atomic
+  operations. This includes gcc 4.1.2 or later, Intel CC, clang (recent
+  versions) as well as Sun's Solaris compilers and libc [TS-618].
+
+  *) Support normal default path for remap plugins [TS-616].
+
+  *) Change default settings for MSIE User-Agent sniffing [TS-615].
+
+  *) Remove remnants from InktoSwitch. This removes the following
+  configurations [TS-614]:
+
+      proxy.config.http.inktoswitch_enabled
+      proxy.config.http.router_ip
+      proxy.config.http.router_port
+
+  *) Modify TSContSchedule to take a thread type, and add
+  TSContScheduleEvery [TS-589].
+
+  *) Added support to allow some select (~50 or so) records.config
+  configurations to be overridable per transaction. This is done via new SDK
+  APIs, as well as a remap plugin provided with the core [TS-599]. The new
+  APIs available are
+
+      TSHttpTxnConfigIntSet()
+      TSHttpTxnConfigIntGet()
+      TSHttpTxnConfigFloatSet()
+      TSHttpTxnConfigFloatGet()
+      TSHttpTxnConfigStringSet()
+      TSHttpTxnConfigStringGet()
+      TSHttpTxnConfigFind()
+
+  *) Eliminate dedicated default DNS for SplitDNS [TS-597]. Author: Zhao
+   Yongming.
+
+  *) Eliminate proxy.config.net.max_poll_delay configs [TS-605].
+
+  *) Old traffic_net configurations are eliminated [TS-601].
+
+  *) Multiple preads: this patch is only active if you call do_io_pread on
+  the cache.  This includes a regression test for do_io_pread which is at
+  least a smoke test of the new code. [TS-61]
+
+  *) Migrate from home-grown regular expression classes to pcre [TS-604]
+
+  *) Reduce number of calls to regex matcher for standard requests with
+   well-known-strings (WKS). [TS-603]
+
+  *) Parse Range: requests a bit better. Prior, a request like like Range:
+   bytes=100-200 would return 0-200. Additionally, Range: bytes=100- would
+   not parse properly. [TS-596]
+
+  *) Remove old, unused configuration code (duplicated) [TS-576].
+
+  *) Bump the SDK version numbers properly [TS-595].
+
+  *) Migrate from our own int64 (et.al) to int64_t / stdint types. This also
+   changes the SDK, so ts/ts.h users should now use int64_t etc. [TS-594].
+
+  *)./configure will now tell us more about its defaults.
+
+  *) Add better tests for eventfd, making sure sys/eventfd.h exists
+   [TS-515].
+
+  *) Stub / base implementation for the Task thread pool [TS-589].
+
+  *) Cleanup of traffic_logstats, and also add support for JSON
+   output. Several new options and query args added to select output format
+   and data [TS-587].
+
+  *) Add back support for using the default DNSHandler from DNS.cc This
+   helps with SplitDNS [TS-580].
+
+  *) Fixes for DNS to properly schedule and initialize [TS-570].
+
+  *) Fix make check so it actually compiles [TS-586].
+
+  *) Remove RAF pieces [TS-584].
+
+  *) Replace the SDKAllocator with a ClassAllocator [TS-577].
+
+     This reduces the amount of memory allocation for plugins, but requires
+     that plugins now religiously release the handles that they are expected
+     to release (i.e. no automatic gc is done for lazy developers).
+
+  *) Fixes for getting the altinfo regression check to succeeds [TS-171].
+
+  *) Fixes for some transform, and other, mismatches of int vs int64 in the
+   new APIs and underlying cache [TS-456].
+
+  *) Eliminate misguided string copies in the SDK [TS-579].
+
+  *) Fix build of ts.h and tsxs when the .in files changes [TS-574].
+
+  *) Move libinktomi++ and librecords to lib/ts and lib/records [TS-571].
+
+  *) Add SDK API calls to directly get the elements of the running TS
+   version [TS-568].
+
+  *) Added WCCP support.
+
+  *) Bring IPv6 functionality back to trunk, for incoming (client)
+   connections [TS-18]. Original author: Tsunayoshi Egawa.
+
+  *) Segfault with HTTPS, fixed by correctly initializing SSLNetVConnection
+   being added to freelist [TS-559].
+
+  *) The old logs.config custom log format is no longer supported. Only the
+   XML custom logs are now supported. This eliminates the config
+
+       proxy.config.log.xml_logs_config
+
+   as well, since it's the only option for custom logs [TS-556].
+
+  *) All log configurations (and stats) are renamed from log2.* to
+   log.*. This is to avoid confusion, since Apache Traffic Server never had
+   the old (obsolete) log system. There's now only one log system, log
+   [TS-555].
+
+  *) Many fixes and improvements on the Stats pages subsystem. This now
+   properly supports (if configured) various internal URLs, like
+   http://{net}, http://{hostdb} etc. [TS-554].
+
+  *) The NewCacheVC is removed [TS-551].
+
+  *) Support for the Alpha processor is eliminated [TS-552].
+
+  *) A number of unecessary memory allocations are removed, improving
+   performance under heavy load. [TS-550, TS-549]
+
+  *) All streaming media (MIXT) configurations are now properly removed from
+   code and default configs [TS-544].
+
+  *) URL scheme was case sensitive in the cache key [TS-474].
+
+  *) Fixes for broken API signatures, additions / modifications to the
+   following API:
+
+     TSReturnCode TSHttpTxnArgSet(TSHttpTxn txnp, int arg_idx, void *arg);
+     TSReturnCode TSHttpTxnArgGet(TSHttpTxn txnp, int arg_idx, void **argp);
+     TSReturnCode TSHttpSsnArgSet(TSHttpSsn ssnp, int arg_idx, void *arg);
+     TSReturnCode TSHttpSsnArgGet(TSHttpSsn ssnp, int arg_idx, void **argp);
+
+     TSReturnCode TSHttpArgIndexReserve(const char* name, const char*
+     description, int* arg_idx); TSReturnCode TSHttpArgIndexNameLookup(const
+     char* name, int* arg_idx, const char** description); TSReturnCode
+     TSHttpArgIndexLookup(int arg_idx, const char** name, const char**
+     description);
+
+     TSReturnCode TSHttpSsnTransactionCount(TSHttpSsn ssnp, int* count);
+
+   This was all combine into [TS-504], but also see [TS-503].
+
+  *) Many fixes for broken regression tests!
+
+  *) RNI is now completely cleaned out [TS-536].
+
+  *) Fixes for SplitDNS (co-author: mohan_zl) [TS-435].
+
+  *) HTTPS to origin servers, with Chunked responses, would hang [TS-540].
+
+  *) Mismatched APIs using "unsigned char*" [TS-458].
+
+  *) Rename / modify TSSetCacheUrl() API, the new prototype is
+
+     TSReturnCode TSCacheUrlSet(TSHttpTxn txnp, const char *url, int
+     length);
+
+   If length == -1, then the API will calculate it using strlen() [TS-520].
+
+  *) All public APIs, structs and defines are now prefixed with "TS" instead
+   of the old "INK". There are two exceptions, for the deprecated INKStats*
+   and INKCoupledStats* APIs [TS-521].
+
+  *) The hooks around "remap" has been organized, and a new hook as been
+   added (for post-remap). New / renamed hooks are
+
+     TS_HTTP_PRE_REMAP_HOOK TS_HTTP_POST_REMAP_HOOK
+
+   In addition, a new API was added, to allow a plugin to skip the remap
+   phase completely:
+
+     TSReturnCode TSSkipRemappingSet(TSHttpTxn txnp, int flag);
+
+   These fixes went in with [TS-529] and [TS-530].
+
+  *) INKHttpTxnSetHttpRetStatus not honored when an API transaction is
+   reenabled with INK_EVENT_HTTP_ERROR [TS-535].
+
+  *) Various defines for version identification has been moved to the public
+   ts/ts.h include file, e.g.
+
+       #define TS_VERSION_STRING             "2.1.6-unstable"
+       #define TS_VERSION_NUMBER              2001006
+       #define TS_VERSION_MAJOR               2
+       #define TS_VERSION_MINOR               1
+       #define TS_VERSION_MICRO               6
+
+   The intended use is for plugins to be able to verify available APIs at
+   compile time (vs the existing runtime checks) [TS-534].
+
+  *) Traffic Server should now build on ARM processors. Commit message is
+   appropriately describing the situation with this CPU:
+
+   This is a sad day of defeat.  Not my defeat, but more a collective human
+   defeat.
+
+   Question: "Chips fabricated today don't have 64bit atomic primitives?"
+   Answer: "Be sad."
+
+   The ARM box we're working on (armv5tejl) doesn't support any 64bit
+   primitives.
+
+   This means we need a method of using a global (yes, giant lock of death)
+   to protect modifications of arbitrary 64bit integers in process space.
+   We could make this less contentious by allocating pagesize/8 mutexs and
+   then protecting an int64 based on its page offset.  Instead, I think we
+   should mobilize to burn these architectures to the ground and use public
+   embarrassment to fix future instruction sets. If another platform has
+   this issue, we'll want to change the define to:
+
+   TS_ARCHITECTURE_LACKS_64BIT_INSTRUCTIONS and turn on the global death
+   lock based on that.
+
+   This does not change performance on any other platform -- it's compile
+   time capital punishment. [TS-533] and [TS-135].
+
+  *) Very old APIs, that have been deprecated since long before the Apache
+   Open Source project, are removed. Also, only three public include files
+   are now available:
+
+     ts/ts.h ts/experimental.h ts/remap.h
+
+  Various other cleanup related to the APIs was also done [TS-522].
+
+Changes with Apache Traffic Server 2.1.4
+
+  *) Fixes to clustering, that caused an assert to trigger after the stats
+   changes [TS-519].
+
+  *) Make the checks when to honor the Content-Length: header less strict,
+   against origins without Keep-Alive [TS-500].
+
+  *) Eliminate old ssl_ports feature, it's completely replaced with the
+   connect_ports configuration [TS-517].
+
+  *) New script available to help build plugins, tsxs [TS-512].
+
+  *) Simple, brute force (and efficient) status code stats counters
+   [TS-509].
+
+  *) Generalize RecDumpRecordsHt to use RecDumpRecords which is a
+   callback/map pattern [TS-508].
+
+  *) Fix plugin APIs to be compatible with the 64-bit changes in the
+   core. This is an incompatible change with previous releases [TS-14].
+
+  *) Fixes for stats around origin connection counters, used when allowing
+   for origin connections to be reused between clients [TS-501].
+
+  *) Experimental supoprt for a dedicated DNS thread. This can be enabled
+   with the records.config option
+
+      CONFIG proxy.config.dns.dedicated_thread INT 1
+
+  This feature is possibly useful for very busy forward or transparent
+  proxies [TS-307].
+
+  *) Accept threads can leak some amount of memory. This patch also supports
+   multiple accept threads (very experimental!) [TS-496].
+
+  *) HttpSM has an assertion that checks the client URL against the cache
+   URL, which breaks INKSetCacheUrl [TS-495].
+
+  *) Return value from pcre_exec tested incorrectly [TS-493].
+
+  *) Improved loop detection using the Via header [TS-490].
+
+  *) Fixes for Solaris build (yay, it builds!).
+
+  *) Remove filter.config remnants [TS-486].
+
+  *) Cleanup in InkAPI [TS-485].
+
+  *) Move PKGSYSUSER to ink_config.h.in [TS-482].
+
+  *) Unresponsive server can stall ATS [TS-480].
+
+  *) UrlRewrite cleanup [TS-434].
+
+  *) Build TS with clang (author: Igor Galic) [TS-427].
+
+  *) Better support and handling of DNS round-robin options (author: Zhao
+   Yongming) [TS-313].
+
+  *) Make it possible to "write" Content-Length headers > 2GB [TS-471].
+
+  *) Better support for Age: headers, and avoiding overflows [TS-470].
+
+  *) Added a configure option to size the API stats "slots". The new option
+  is --with-max-api-stats=<n> [TS-454].
+
+  *) In Cache.cc, make snprintf() around Debug statements conditional for
+   performance [TS-459].
+
+  *) Cleanup / optimize Via: string generation [TS-460]. Also make the
+   default for Via: on responses to be disabled (it can leak info).
+
+Changes with Apache Traffic Server 2.1.3
+
+  *) Removed the remnants of NCA from the source [TS-455].
+
+  *) New plugin APIs for stats, and making the "v2" (incomplete) stats
+  experimental (no longer built by default) [TS-390]. See
+  https://cwiki.apache.org/confluence/display/TS/NewStatsAPI for more
+  details.
+
+  *) Cleanup in duplicated configs, and obsoleted configs [TS-447] and
+   [TS-451].
+
+  *) Remove some remnants of SNMP [TS-401].
+
+  *) Cleanup of MIX and LDAP/NTLM remnants [TS-443].
+
+  *) Make the target fragment size configurable for the disk cache. This
+   adds a new option, proxy.config.cache.target_fragment_size [TS-445].
+   This should dramatically improve large file disk performance.
+
+  *) Improve build include dependencies [TS-442].
+
+  *) Cleanup / fixes for remap plugin chaining [TS-224].
+
+  *) Support the rc/trafficserver script for FreeBSD [TS-211].
+
+  *) traffic_shell shows wrong RAM cache size > 2GB [TS-439].
+
+  *) Better warnings / errors when bad NIC is configured [TS-327].
+
+  *) Add support for hardware sector sizes 512 - 8192 bytes (e.g. 4096, the
+   new standard). Autodetected for raw devices on Linux (no support for
+   other OSes yet), and added a new configuration
+
+       CONFIG proxy.config.cache.force_sector_size INT 4096
+
+   This change invalidates the entire cache as well, since it's no longer
+   compatible [TS-43].
+
+  *) Added APIs to override the cacheablity of the response [TS-395].
+
+  *) Add OSX support to 'trafficserver' script (author: Dan Mercer)
+   [TS-210].
+
+  *) Fix for (very) large buffers fed to the cache [TS-413].
+
+  *) Forward transparency is available on Linux kernels with TPROXY
+   [TS-291].
+
+  *) Fix defaults / max for DNS retries [TS-424].
+
+  *) Improvements for Perl admin module (author: Adam Faris) [TS-418].
+
+  *) Problems with specifying separate config files for SSL certificates and
+   keys [TS-405].
+
+  *) Logging: Default settings for diagnostic logging [TS-55].
+
+  *) Fixes to Debian layout (author: Igor Galić) [TS-415].
+
+  *) Remove DNS proxy support [TS-422].
+
+  *) rc/trafficserver start/stop quits with bogus status on success (author:
+   Igor Galić) [TS-429].
+
+  *) Increase default max in-flight DNS queries [TS-423].
+
+  *) Update so the pristine URL will work for reverse and forward proxy.
+    Also, clearing the url on transaction close (author: Wendy Huang)
+    [TS-410].
+
+  *) TS fails to use user ID with user name > 8 characters (author: Yakov
+   Markovitch) [TS-420].
+
+  *) Duplication of RAM cache hits and miss statistics (reading 2x) (author:
+   John Plevyak) [TS-453].
+
+Changes with Apache Traffic Server 2.1.2
+
+  *) Improvements in resilience against DNS poisoning and forging of
+   response packets [TS-425] and [CVE-2010-2952].
+
+  *) Segmentation fault in INKError when error output is made both in error
+   log and as debug messages (author: Yakov Markovitch) [TS-419].
+
+  *) Debian layout for config.layout (author: Igor Galic) [TS-415].
+
+  *) Eliminate extraneous stats thread [TS-411].
+
+  *) CACHE_FRAG_TYPE is now not a power of 2 [TS-76].
+
+  *) Remove unnecessary stats update [TS-390].
+
+  *) Get basic features to compile with Intel CC [TS-400].
+
+  *) More 64 bit issues, this time in the PluginVC code [TS-380].
+
+  *) Add configure option to enable detailed logging [TS-392].
+
+  *) Make sure to honor user settings for "dirs" (author: Theo Schlossnagle)
+   [TS-399].
+
+  *) Errors on failing to bind / listen on a specified port [TS-247].
+
+  *) Exempt quick filter for 127.0.0.1 [TS-397].
+
+  *) Cleanup after "layout changes" (author: Zhao Yongming) [TS-389].
+
+  *) Fix remaining (non-API) INK64 etc. [TS-365].
+
+  *) Segfault when using show:network [TS-109].
+
+  *) Update all examples to use non-deprecated APIs [TS-266].
+
+  *) Do some cleanup on Connection::fast_connect and
+   Connection::bind_connect (author: Alan M. Carrol) [TS-320].
+
+  *) Remove LLONG config option [Ts-364].
+
+  *) Cleanup some proxy/mgmt2/tools [TS-16].
+
+  *) Cleanup a little more of webui [TS-91].
+
+  *) TCL missing [TS-326].
+
+  *) logstats does not work with layout changes (author: Zhao Yongming)
+   [TS-385].
+
+  *) Convert bogus IOCORE_MachineFatal and IOCORE_ProcessFatal to Warning
+    and MachineFatal respectively based on review of the code and related
+    uses [TS-144].
+
+  *) INKIOBufferReaderCopy, INKIOBufferWrite should take void * instead of
+   char * [TS-67].
+
+  *) Adds APIs for aio disk read and writes using the internal aio support
+    in iocore (author: Wendy Huang) [TS-387].
+
+  *) Solaris 10 (x86) 64-bit patch (author: Igor Brezac) [TS-388].
+
+  *) Fix for 64-bit conversion [TS-385].
+
+  *) Creating transaction specific 'to URL' in case of regex remap match
+   [TS-384].
+
+  *) Backing out m_capacity_host changes [TS-383]
+
+  *) Solaris 10 port work.
+
+Changes with Apache Traffic Server 2.1.1
+
+  *) Allow SI decimal multipliers for numeric configuration parameters
+    [TS-361].
+
+  *) Standardize configure options by allowing to specify the location for
+    any third-party library, and split library detection code into separate
+    .m4 files [TS-345].
+
+  *) Reorganization of the path layout system.  Add --enable-layout=LAYOUT
+    configure option that can select layout from config.layout file
+    [TS-280].
+
+  *) HTTP state machine is now 64-bit "clean", allowing for caching and
+   proxying documents larger than 2GB [TS-34].
+
+  *) Fix for truncated Content-Type on TS-generated responses [TS-290].
+
+  *) Performance improvements on cache for larger(ish) objects.
+
+Changes with Apache Traffic Server 2.1.0
+
+  *) Support for many more platforms, including FreeBSD, MacOSX and Solaris.
+
+  *) Code cleanup to get the ATS software into a distributable shape. This
+   means that certain things are missing, or not functional (intentionally).
+
+  *) Support for larger Cache Partitions up to .5 PB (Petabytes), reducing
+   seeks/write.
+
+  *) Reduced Cache miss latency (sub millesecond).
+
+  *) RAM Cache pluggability, new algorithm (CLFUS) and optional compression.
+
+  *) Support for TCL v8.6 and later [TS-246].
+
+  *) The cache is now 64-bit "clean".
+
+Changes with Apache Traffic Server 2.0.1
+
+  *) Port of CVE-2010-2952 for 2.0.x [TS-425].
+
+  *) Backport part of TS-322 that deals with indexing arrays with char
+   (author: Marcus Ruckert) [TS-334].
+
+  *) Backport TS-336 to 2.0.x. Problems with make install DESTDIR=...
+
+Changes with Apache Traffic Server 2.0.0
+
+  *) Change SDK versioning schemes to 2.0 [TS-249).
+
+  *) Minor additions to the SDK (see the docs for details).
+
+  *) Support regexe_map rules in remap.config [TS-80]
+
+Changes with Apache Traffic Server 2.0.0-alpha
+
+  *) Code cleanup to get the ATS software into a distributable shape. This
+   means that certain things are missing, or not functional (intentionally).
+
+  *) Ports available for most Linux distros, including 64-bit.

--- a/iocore/hostdb/I_HostDBProcessor.h
+++ b/iocore/hostdb/I_HostDBProcessor.h
@@ -280,8 +280,8 @@ struct HostDBInfo {
         HostDBRoundRobin current_rr;
         memcpy(&current_info, &info[i], sizeof(HostDBInfo));
         memcpy(&current_rr, this, sizeof(HostDBRoundRobin));
-#endif
         ink_assert(!"extreme clock skew");
+#endif
         app.http_data.last_failure = 0;
         return false;
       }

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -3935,14 +3935,18 @@ HttpSM::do_hostdb_lookup()
   } else { /* we aren't using SRV stuff... */
     DebugSM("http_seq", "[HttpSM::do_hostdb_lookup] Doing DNS Lookup");
 
+    // If there is not a current server, we must be looking up the origin
+    //  server at the beginning of the transaction
+    int server_port = t_state.current.server ? t_state.current.server->port : t_state.server_info.port;
+
     if (t_state.api_txn_dns_timeout_value != -1) {
       DebugSM("http_timeout", "beginning DNS lookup. allowing %d mseconds for DNS lookup", t_state.api_txn_dns_timeout_value);
     }
 
     HostDBProcessor::Options opt;
-
-    opt.flags = (t_state.cache_info.directives.does_client_permit_dns_storing) ? HostDBProcessor::HOSTDB_DO_NOT_FORCE_DNS :
-                                                                                 HostDBProcessor::HOSTDB_FORCE_DNS_RELOAD;
+    opt.port = server_port;
+opt.flags = (t_state.cache_info.directives.does_client_permit_dns_storing) ? HostDBProcessor::HOSTDB_DO_NOT_FORCE_DNS :
+                                                                             HostDBProcessor::HOSTDB_FORCE_DNS_RELOAD;
     opt.timeout = (t_state.api_txn_dns_timeout_value != -1) ? t_state.api_txn_dns_timeout_value : 0;
     opt.host_res_style = ua_session->host_res_style;
 


### PR DESCRIPTION
The first commit here is to revert @SolidWallOfCode 's commit that has broken it right now. We actually had a long conversation about this on IRC and we'd prefer a better solution, but at least for now this has broken last_failure checking completely. I'm going to take a crack at maintaining a map of the port health separately, but I'm not sure how hard it'll be.

The second commit makes all 3 LB methods check the status of the real, instead of just default (which isn't even RR BTW).