### PR TITLE
TS-3718 Remove unused member variables/functions

### DIFF
--- a/proxy/logging/LogFile.cc
+++ b/proxy/logging/LogFile.cc
@@ -69,7 +69,6 @@ LogFile::LogFile(const char *name, const char *header, LogFileFormat format, uin
   m_start_time = 0L;
   m_end_time = 0L;
   m_bytes_written = 0;
-  m_size_bytes = 0;
   m_ascii_buffer_size = (ascii_buffer_size < max_line_size ? max_line_size : ascii_buffer_size);
 
   Debug("log-file", "exiting LogFile constructor, m_name=%s, this=%p", m_name, this);

--- a/proxy/logging/LogFile.h
+++ b/proxy/logging/LogFile.h
@@ -195,7 +195,6 @@ public:
 
   void check_fd();
   static int writeln(char *data, int len, int fd, const char *path);
-  void read_metadata();
 
 public:
   LogFileFormat m_file_format;
@@ -215,7 +214,6 @@ public:
   long m_start_time;
   long m_end_time;
   volatile uint64_t m_bytes_written;
-  off_t m_size_bytes; // current size of file in bytes
 
 public:
   Link<LogFile> link;


### PR DESCRIPTION
read_metadata() and m_size_bytes are not used anywhere
in the code base.