### PR TITLE
Maintain and use a mapping of hostname -> IP to implement host file support

### DIFF
--- a/iocore/hostdb/I_HostDBProcessor.h
+++ b/iocore/hostdb/I_HostDBProcessor.h
@@ -452,6 +452,8 @@ struct HostDBProcessor : public Processor {
 
   inkcoreapi Action *getbyname_re(Continuation *cont, const char *hostname, int len, Options const &opt = DEFAULT_OPTIONS);
 
+  Action *getbynameport_re(Continuation *cont, const char *hostname, int len, Options const &opt = DEFAULT_OPTIONS);
+
   Action *getSRVbyname_imm(Continuation *cont, process_srv_info_pfn process_srv_info, const char *hostname, int len,
                            Options const &opt = DEFAULT_OPTIONS);
 

--- a/iocore/hostdb/P_HostDBProcessor.h
+++ b/iocore/hostdb/P_HostDBProcessor.h
@@ -191,7 +191,7 @@ extern RecRawStatBlock *hostdb_rsb;
 
 
 struct CmpConstBuffferCaseInsensitive {
-  bool operator()(ts::ConstBuffer a, ts::ConstBuffer b) { return ptr_len_casecmp(a._ptr, a._size, b._ptr, b._size) < 0;}
+  bool operator()(ts::ConstBuffer a, ts::ConstBuffer b) { return ptr_len_casecmp(a._ptr, a._size, b._ptr, b._size) < 0; }
 };
 
 // Our own typedef for the host file mapping

--- a/iocore/hostdb/P_HostDBProcessor.h
+++ b/iocore/hostdb/P_HostDBProcessor.h
@@ -190,6 +190,18 @@ extern RecRawStatBlock *hostdb_rsb;
 #define HOSTDB_DECREMENT_THREAD_DYN_STAT(_s, _t) RecIncrRawStatSum(hostdb_rsb, _t, (int)_s, -1);
 
 
+struct CmpConstBuffferCaseInsensitive {
+  bool operator()(ts::ConstBuffer a, ts::ConstBuffer b) { return ptr_len_casecmp(a._ptr, a._size, b._ptr, b._size) < 0;}
+};
+
+// Our own typedef for the host file mapping
+typedef std::map<ts::ConstBuffer, IpAddr, CmpConstBuffferCaseInsensitive> HostsFileMap;
+// A to hold a ref-counted map
+struct RefCountedHostsFileMap : public RefCountObj {
+  HostsFileMap hosts_file_map;
+  ats_scoped_str HostFileText;
+};
+
 //
 // HostDBCache (Private)
 //
@@ -209,6 +221,9 @@ struct HostDBCache : public MultiCache<HostDBInfo> {
   {
     return sizeof(HostDBInfo) * 2 + 512 * hostdb_srv_enabled;
   }
+
+  // Map to contain all of the host file overrides, initialize it to empty
+  Ptr<RefCountedHostsFileMap> hosts_file_ptr;
 
   Queue<HostDBContinuation, Continuation::Link_link> pending_dns[MULTI_CACHE_PARTITIONS];
   Queue<HostDBContinuation, Continuation::Link_link> &pending_dns_for_hash(INK_MD5 &md5);


### PR DESCRIPTION
This allows the background thread to populate a map of overrides, which we simply inject in the lookup method-- in place of calling to DNS.

I'm sure this implementation is riddled with holes, but it works in the most basic of cases. Pointers to get it cleaned up are much appreciated :)