### PR TITLE
TS-3435 Make Log.cc:PERIODIC_TASKS_INTERVAL configurable

### DIFF
--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1993,10 +1993,6 @@ static const RecordElement RecordsConfig[] =
   //#
   //###########
   {RECT_CONFIG, "proxy.config.cache.http.compatibility.4-2-0-fixup", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_NULL, NULL, RECA_NULL}
-  ,
-
-  //#Test
-
 };
 // clang-format on
 

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1170,6 +1170,9 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.log.max_line_size", RECD_INT, "9216", RECU_DYNAMIC, RR_NULL, RECC_NULL, NULL, RECA_NULL}
   ,
+  // How often periodic tasks get executed in the Log.cc infrastructure
+  {RECT_CONFIG, "proxy.config.log.periodic_tasks_interval", RECD_INT, "5", RECU_DYNAMIC, RR_NULL, RECC_NULL, NULL, RECA_NULL}
+  ,
 
   //##############################################################################
   //#
@@ -1990,6 +1993,9 @@ static const RecordElement RecordsConfig[] =
   //#
   //###########
   {RECT_CONFIG, "proxy.config.cache.http.compatibility.4-2-0-fixup", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_NULL, NULL, RECA_NULL}
+  ,
+
+  //#Test
 
 };
 // clang-format on

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1171,7 +1171,7 @@ static const RecordElement RecordsConfig[] =
   {RECT_CONFIG, "proxy.config.log.max_line_size", RECD_INT, "9216", RECU_DYNAMIC, RR_NULL, RECC_NULL, NULL, RECA_NULL}
   ,
   // How often periodic tasks get executed in the Log.cc infrastructure
-  {RECT_CONFIG, "proxy.config.log.periodic_tasks_interval", RECD_INT, "5", RECU_DYNAMIC, RR_NULL, RECC_NULL, NULL, RECA_NULL}
+  {RECT_CONFIG, "proxy.config.log.periodic_tasks_interval", RECD_INT, "5", RECU_DYNAMIC, RR_NULL, RECC_NULL, "^[0-9]+$", RECA_NULL}
   ,
 
   //##############################################################################

--- a/proxy/config/records.config.default.in
+++ b/proxy/config/records.config.default.in
@@ -146,6 +146,7 @@ CONFIG proxy.config.log.rolling_enabled INT 1
 CONFIG proxy.config.log.rolling_interval_sec INT 86400
 CONFIG proxy.config.log.rolling_size_mb INT 10
 CONFIG proxy.config.log.auto_delete_rolled_files INT 1
+CONFIG proxy.config.log.periodic_tasks_interval INT 5
 
 ##############################################################################
 # These settings control remapping, and if the proxy allows (open) forward proxy or not. Docs:

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -744,20 +744,19 @@ Log::handle_logging_mode_change(const char * /* name ATS_UNUSED */, RecDataT /* 
 }
 
 int
-Log::handle_periodic_tasks_int_change(const char * /* name ATS_UNUSED */, RecDataT /* data_type ATS_UNUSED */,
-                                       RecData data, void * /* cookie ATS_UNSED */)
+Log::handle_periodic_tasks_int_change(const char * /* name ATS_UNUSED */, RecDataT /* data_type ATS_UNUSED */, RecData data,
+                                      void * /* cookie ATS_UNSED */)
 {
   Debug("log-periodic", "periodic task interval changed");
   if (data.rec_int <= 0) {
     periodic_tasks_interval = PERIODIC_TASKS_INTERVAL_FALLBACK;
-    Error("new periodic tasks interval = %d is invalid, falling back to default = %d"
-           ,data.rec_int, PERIODIC_TASKS_INTERVAL_FALLBACK);
-  }
-  else {
+    Error("new periodic tasks interval = %d is invalid, falling back to default = %d", data.rec_int,
+          PERIODIC_TASKS_INTERVAL_FALLBACK);
+  } else {
     periodic_tasks_interval = data.rec_int;
     Debug("log-periodic", "periodic task interval changed to %d", periodic_tasks_interval);
   }
-  return REC_ERR_OKAY; 
+  return REC_ERR_OKAY;
 }
 
 
@@ -807,13 +806,12 @@ Log::init(int flags)
   // periodic task interval are set on a per instance basis
   periodic_tasks_interval = (int)REC_ConfigReadInteger("proxy.config.log.periodic_tasks_interval");
   if (periodic_tasks_interval <= 0) {
-    Error("proxy.config.log.periodic_tasks_interval = %d is invalid",periodic_tasks_interval);
-    Note("falling back to default periodic tasks interval = %d",PERIODIC_TASKS_INTERVAL_FALLBACK);
+    Error("proxy.config.log.periodic_tasks_interval = %d is invalid", periodic_tasks_interval);
+    Note("falling back to default periodic tasks interval = %d", PERIODIC_TASKS_INTERVAL_FALLBACK);
     periodic_tasks_interval = PERIODIC_TASKS_INTERVAL_FALLBACK;
   }
 
-  REC_RegisterConfigUpdateFunc("proxy.config.log.periodic_tasks_interval", 
-      &Log::handle_periodic_tasks_int_change, NULL);
+  REC_RegisterConfigUpdateFunc("proxy.config.log.periodic_tasks_interval", &Log::handle_periodic_tasks_int_change, NULL);
 
   // if remote management is enabled, do all necessary initialization to
   // be able to handle a logging mode change

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -82,7 +82,7 @@ int Log::collation_port;
 int Log::init_status = 0;
 int Log::config_flags = 0;
 bool Log::logging_mode_changed = false;
-int Log::periodic_tasks_interval = PERIODIC_TASKS_INTERVAL_FALLBACK;
+uint32_t Log::periodic_tasks_interval = PERIODIC_TASKS_INTERVAL_FALLBACK;
 
 // Hash table for LogField symbols
 InkHashTable *Log::field_symbol_hash = 0;
@@ -750,11 +750,11 @@ Log::handle_periodic_tasks_int_change(const char * /* name ATS_UNUSED */, RecDat
   Debug("log-periodic", "periodic task interval changed");
   if (data.rec_int <= 0) {
     periodic_tasks_interval = PERIODIC_TASKS_INTERVAL_FALLBACK;
-    Error("new periodic tasks interval = %d is invalid, falling back to default = %d", data.rec_int,
+    Error("new periodic tasks interval = %d is invalid, falling back to default = %d", (int)data.rec_int,
           PERIODIC_TASKS_INTERVAL_FALLBACK);
   } else {
-    periodic_tasks_interval = data.rec_int;
-    Debug("log-periodic", "periodic task interval changed to %d", periodic_tasks_interval);
+    periodic_tasks_interval = (uint32_t)data.rec_int;
+    Debug("log-periodic", "periodic task interval changed to %u", periodic_tasks_interval);
   }
   return REC_ERR_OKAY;
 }
@@ -804,12 +804,13 @@ Log::init(int flags)
   }
 
   // periodic task interval are set on a per instance basis
-  periodic_tasks_interval = (int)REC_ConfigReadInteger("proxy.config.log.periodic_tasks_interval");
-  if (periodic_tasks_interval <= 0) {
-    Error("proxy.config.log.periodic_tasks_interval = %d is invalid", periodic_tasks_interval);
+  int pti = (int)REC_ConfigReadInteger("proxy.config.log.periodic_tasks_interval");
+  if (pti <= 0) {
+    Error("proxy.config.log.periodic_tasks_interval = %d is invalid", pti);
     Note("falling back to default periodic tasks interval = %d", PERIODIC_TASKS_INTERVAL_FALLBACK);
     periodic_tasks_interval = PERIODIC_TASKS_INTERVAL_FALLBACK;
-  }
+  } else
+    periodic_tasks_interval = (uint32_t)pti;
 
   REC_RegisterConfigUpdateFunc("proxy.config.log.periodic_tasks_interval", &Log::handle_periodic_tasks_int_change, NULL);
 

--- a/proxy/logging/Log.h
+++ b/proxy/logging/Log.h
@@ -448,6 +448,7 @@ public:
   // reconfiguration stuff
   static void change_configuration();
   static int handle_logging_mode_change(const char *name, RecDataT data_type, RecData data, void *cookie);
+  static int handle_periodic_tasks_int_change(const char *name, RecDataT data_type, RecData data, void *cookie);
 
   Log(); // shut up stupid DEC C++ compiler
 
@@ -461,6 +462,7 @@ private:
   static int init_status;
   static int config_flags;
   static bool logging_mode_changed;
+  static int periodic_tasks_interval;
 
   // -- member functions that are not allowed --
   Log(const Log &rhs);

--- a/proxy/logging/Log.h
+++ b/proxy/logging/Log.h
@@ -462,7 +462,7 @@ private:
   static int init_status;
   static int config_flags;
   static bool logging_mode_changed;
-  static int periodic_tasks_interval;
+  static uint32_t periodic_tasks_interval;
 
   // -- member functions that are not allowed --
   Log(const Log &rhs);


### PR DESCRIPTION
Allow interval between periodic tasks in Log.cc to be configured
via records.config. This allows for finer granularity when managing
log based periodic tasks.