### PR TITLE
TS-1007: SSLN Close called before TXN Close

### DIFF
--- a/iocore/net/UnixNet.cc
+++ b/iocore/net/UnixNet.cc
@@ -672,7 +672,8 @@ NetHandler::_close_vc(UnixNetVConnection *vc, ink_hrtime now, int &handle_event,
     ++closed;
   } else {
     vc->next_inactivity_timeout_at = now;
-    keep_alive_queue.head->handleEvent(EVENT_IMMEDIATE, NULL);
+    if (keep_alive_queue.head)
+      keep_alive_queue.head->handleEvent(EVENT_IMMEDIATE, NULL);
     ++handle_event;
   }
 }

--- a/proxy/http/HttpClientSession.cc
+++ b/proxy/http/HttpClientSession.cc
@@ -92,6 +92,9 @@ HttpClientSession::destroy()
     HTTP_DECREMENT_DYN_STAT(http_current_client_connections_stat);
     conn_decrease = false;
   }
+  if (current_reader) {
+    current_reader->ua_session = NULL;
+  }
 
   super::destroy();
   THREAD_FREE(this, httpClientSessionAllocator, this_thread());
@@ -327,6 +330,9 @@ HttpClientSession::do_io_close(int alerrno)
     HTTP_SUM_DYN_STAT(http_transactions_per_client_con, transact_count);
     HTTP_DECREMENT_DYN_STAT(http_current_client_connections_stat);
     conn_decrease = false;
+
+    // Should only be triggering the hooks for session close
+    // if this is a SSLNetVConnection or a UnixNetVConnection
     do_api_callout(TS_HTTP_SSN_CLOSE_HOOK);
   }
 }

--- a/proxy/spdy/SpdyClientSession.cc
+++ b/proxy/spdy/SpdyClientSession.cc
@@ -114,7 +114,6 @@ SpdyClientSession::init(NetVConnection *netvc)
 
   this->vc->set_inactivity_timeout(HRTIME_SECONDS(spdy_accept_no_activity_timeout));
   vc->add_to_keep_alive_queue();
-  SET_HANDLER(&SpdyClientSession::state_session_start);
 }
 
 void
@@ -193,11 +192,11 @@ SpdyClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBu
   sm->resp_buffer = TSIOBufferCreate();
   sm->resp_reader = TSIOBufferReaderAlloc(sm->resp_buffer);
 
-  eventProcessor.schedule_imm(sm, ET_NET);
+  do_api_callout(TS_HTTP_SSN_START_HOOK);
 }
 
-int
-SpdyClientSession::state_session_start(int /* event */, void * /* edata */)
+void
+SpdyClientSession::start()
 {
   const spdylay_settings_entry entries[] = {
     {SPDYLAY_SETTINGS_MAX_CONCURRENT_STREAMS, SPDYLAY_ID_FLAG_SETTINGS_NONE, spdy_max_concurrent_streams},
@@ -224,7 +223,6 @@ SpdyClientSession::state_session_start(int /* event */, void * /* edata */)
   }
 
   TSVIOReenable(this->write_vio);
-  return EVENT_CONT;
 }
 
 int

--- a/proxy/spdy/SpdyClientSession.h
+++ b/proxy/spdy/SpdyClientSession.h
@@ -117,11 +117,8 @@ public:
     ink_release_assert(false);
     return NULL;
   }
-  void
-  start()
-  {
-    ink_release_assert(false);
-  }
+  void start();
+  
   void do_io_close(int lerrno = -1);
   void
   do_io_shutdown(ShutdownHowTo_t howto)


### PR DESCRIPTION
I'd appreciate a review on this.  I feel pretty comfortable with the change in HttpSM.cc to delay the session close until after the transaction has a chance to close.

I also rearranged things in SpdyClientSession to better follow the ProxyClientSession framework so the session start hook gets called and not just the session close hook.  I feel less sure about those changes, so I would appreciate comments from the SPDY experts out there.