### PR TITLE
[TS-3648] Desire support for client TLS cipher in custom log format

### DIFF
--- a/doc/admin/event-logging-formats.en.rst
+++ b/doc/admin/event-logging-formats.en.rst
@@ -188,6 +188,16 @@ The following list describes Traffic Server custom logging fields.
     The SSL session/ticket reused status; indicates if this request hit
     the SSL session/ticket and avoided a full SSL handshake.
 
+.. _cqssv:
+
+``cqssv``
+    The SSL/TLS version used to communicate with the client.
+
+.. _cqssc:
+
+``cqssc``
+    The cipher used by ATS to communicate with the client over SSL.
+
 .. _cqtx:
 
 ``cqtx``

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -267,6 +267,20 @@ public:
 
   bool computeSSLTrace();
 
+  const char * getSSLProtocol(void) const
+  {
+    if ( ssl == NULL )
+      return NULL;
+    return SSL_get_version(ssl);
+  };
+
+  const char * getSSLCipherSuite(void) const
+  {
+    if ( ssl == NULL )
+      return NULL;
+    return SSL_get_cipher_name(ssl);    
+  }
+
 private:
   SSLNetVConnection(const SSLNetVConnection &);
   SSLNetVConnection &operator=(const SSLNetVConnection &);

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -277,9 +277,9 @@ HttpSM::HttpSM()
     client_request_hdr_bytes(0), client_request_body_bytes(0), server_request_hdr_bytes(0), server_request_body_bytes(0),
     server_response_hdr_bytes(0), server_response_body_bytes(0), client_response_hdr_bytes(0), client_response_body_bytes(0),
     cache_response_hdr_bytes(0), cache_response_body_bytes(0), pushed_response_hdr_bytes(0), pushed_response_body_bytes(0),
-    client_tcp_reused(false), client_ssl_reused(false), client_connection_is_ssl(false), plugin_tag(0), plugin_id(0),
-    hooks_set(false), cur_hook_id(TS_HTTP_LAST_HOOK), cur_hook(NULL), cur_hooks(0), callout_state(HTTP_API_NO_CALLOUT),
-    terminate_sm(false), kill_this_async_done(false), parse_range_done(false)
+    client_tcp_reused(false), client_ssl_reused(false), client_connection_is_ssl(false), client_sec_protocol("-"), 
+    client_cipher_suite("-"), plugin_tag(0), plugin_id(0), hooks_set(false), cur_hook_id(TS_HTTP_LAST_HOOK), cur_hook(NULL),
+    cur_hooks(0), callout_state(HTTP_API_NO_CALLOUT), terminate_sm(false), kill_this_async_done(false), parse_range_done(false)
 {
   memset(&history, 0, sizeof(history));
   memset(&vc_table, 0, sizeof(vc_table));
@@ -481,6 +481,8 @@ HttpSM::attach_client_session(HttpClientSession *client_vc, IOBufferReader *buff
   if (ssl_vc != NULL) {
     client_connection_is_ssl = true;
     client_ssl_reused = ssl_vc->getSSLSessionCacheHit();
+    client_sec_protocol = ssl_vc->getSSLProtocol();
+    client_cipher_suite = ssl_vc->getSSLCipherSuite();
   }
 
   ink_release_assert(ua_session->get_half_close_flag() == false);

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -494,8 +494,12 @@ public:
   int pushed_response_hdr_bytes;
   int64_t pushed_response_body_bytes;
   bool client_tcp_reused;
+  // Info about client's SSL connection.
   bool client_ssl_reused;
   bool client_connection_is_ssl;
+  const char * client_sec_protocol;
+  const char * client_cipher_suite;
+
   TransactionMilestones milestones;
   ink_hrtime api_timer;
   // The next two enable plugins to tag the state machine for

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -476,6 +476,20 @@ Log::init_fields()
   global_field_list.add(field, false);
   ink_hash_table_insert(field_symbol_hash, "cqssr", field);
 
+  field = new LogField("client_sec_protocol", "cqssv",
+                       LogField::STRING,
+                       &LogAccess::marshal_client_security_protocol,
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
+  global_field_list.add(field, false);
+  ink_hash_table_insert(field_symbol_hash, "cqssv", field);
+
+  field = new LogField("client_cipher_suite", "cqssc",
+                       LogField::STRING,
+                       &LogAccess::marshal_client_security_cipher_suite,
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
+  global_field_list.add(field, false);
+  ink_hash_table_insert(field_symbol_hash, "cqssc", field);
+
   Ptr<LogFieldAliasTable> finish_status_map = make_ptr(new LogFieldAliasTable);
   finish_status_map->init(N_LOG_FINISH_CODE_TYPES, LOG_FINISH_FIN, "FIN", LOG_FINISH_INTR, "INTR", LOG_FINISH_TIMEOUT, "TIMEOUT");
 

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -278,6 +278,20 @@ LogAccess::marshal_client_finish_status_code(char *buf)
 }
 
 /*-------------------------------------------------------------------------
+-------------------------------------------------------------------------*/
+int
+LogAccess::marshal_client_security_protocol(char *buf)
+{
+  DEFAULT_STR_FIELD;
+}
+
+int
+LogAccess::marshal_client_security_cipher_suite(char *buf)
+{
+  DEFAULT_STR_FIELD;
+}
+
+/*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
 int

--- a/proxy/logging/LogAccess.h
+++ b/proxy/logging/LogAccess.h
@@ -190,6 +190,8 @@ public:
   inkcoreapi virtual int marshal_client_req_is_ssl(char *);             // INT
   inkcoreapi virtual int marshal_client_req_ssl_reused(char *);         // INT
   inkcoreapi virtual int marshal_client_finish_status_code(char *);     // INT
+  inkcoreapi virtual int marshal_client_security_protocol(char *); // STR
+  inkcoreapi virtual int marshal_client_security_cipher_suite(char *); // STR
 
   //
   // proxy -> client fields

--- a/proxy/logging/LogAccessHttp.cc
+++ b/proxy/logging/LogAccessHttp.cc
@@ -701,6 +701,32 @@ LogAccessHttp::marshal_client_finish_status_code(char *buf)
 }
 
 /*-------------------------------------------------------------------------
+-------------------------------------------------------------------------*/
+int
+LogAccessHttp::marshal_client_security_protocol(char *buf)
+{
+  int round_len = INK_MIN_ALIGN;
+  if (buf) {
+    const char * proto = m_http_sm->client_sec_protocol;
+    round_len = LogAccess::strlen(proto);
+    marshal_str(buf, proto, round_len);
+  }
+  return round_len;
+}
+
+int
+LogAccessHttp::marshal_client_security_cipher_suite(char *buf)
+{
+  int round_len = INK_MIN_ALIGN;
+  if (buf) {
+    const char * cipher = m_http_sm->client_cipher_suite;
+    round_len = LogAccess::strlen(cipher);
+    marshal_str(buf, cipher, round_len);
+  }
+  return round_len;
+}
+
+/*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
 int

--- a/proxy/logging/LogAccessHttp.h
+++ b/proxy/logging/LogAccessHttp.h
@@ -75,6 +75,8 @@ public:
   virtual int marshal_client_req_is_ssl(char *);             // INT
   virtual int marshal_client_req_ssl_reused(char *);         // INT
   virtual int marshal_client_finish_status_code(char *);     // INT
+  virtual int marshal_client_security_protocol(char *);       // STR
+  virtual int marshal_client_security_cipher_suite(char *);   // STR
 
   //
   // proxy -> client fields


### PR DESCRIPTION
Took @acaciocenteno's original PR here and updated it a bit: https://github.com/apache/trafficserver/pull/122

1) added docs and changed log tags to be more in line with ats conventions
2) removed some accessor methods and reordered where log tags are set to happen at the same time @fpesce was already grabbing some SSL info
3) made other changes suggested in the original PR