### PR TITLE
TS-3781: Add the log field "pqsp" (server port)

### DIFF
--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -587,6 +587,11 @@ Log::init_fields()
   global_field_list.add(field, false);
   ink_hash_table_insert(field_symbol_hash, "pqsi", field);
 
+  field = new LogField("proxy_req_server_port", "pqsp", LogField::sINT, &LogAccess::marshal_proxy_req_server_port,
+                       &LogAccess::unmarshal_int_to_str);
+  global_field_list.add(field, false);
+  ink_hash_table_insert(field_symbol_hash, "pqsp", field);
+
   Ptr<LogFieldAliasTable> hierarchy_map = make_ptr(new LogFieldAliasTable);
   hierarchy_map->init(
     36, SQUID_HIER_EMPTY, "EMPTY", SQUID_HIER_NONE, "NONE", SQUID_HIER_DIRECT, "DIRECT", SQUID_HIER_SIBLING_HIT, "SIBLING_HIT",

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -389,6 +389,15 @@ LogAccess::marshal_proxy_req_server_ip(char *buf)
   -------------------------------------------------------------------------*/
 
 int
+LogAccess::marshal_proxy_req_server_port(char *buf)
+{
+  DEFAULT_INT_FIELD;
+}
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+int
 LogAccess::marshal_proxy_hierarchy_route(char *buf)
 {
   DEFAULT_INT_FIELD;

--- a/proxy/logging/LogAccess.h
+++ b/proxy/logging/LogAccess.h
@@ -213,6 +213,7 @@ public:
   inkcoreapi virtual int marshal_proxy_req_body_len(char *);    // INT
   inkcoreapi virtual int marshal_proxy_req_server_name(char *); // STR
   inkcoreapi virtual int marshal_proxy_req_server_ip(char *);   // INT
+  inkcoreapi virtual int marshal_proxy_req_server_port(char *); // INT
   inkcoreapi virtual int marshal_proxy_hierarchy_route(char *); // INT
   inkcoreapi virtual int marshal_proxy_host_name(char *);       // STR
   inkcoreapi virtual int marshal_proxy_host_ip(char *);         // STR

--- a/proxy/logging/LogAccessHttp.cc
+++ b/proxy/logging/LogAccessHttp.cc
@@ -906,6 +906,16 @@ LogAccessHttp::marshal_proxy_req_server_ip(char *buf)
   return marshal_ip(buf, m_http_sm->t_state.current.server != NULL ? &m_http_sm->t_state.current.server->dst_addr.sa : 0);
 }
 
+int
+LogAccessHttp::marshal_proxy_req_server_port(char *buf)
+{
+  if (buf) {
+      uint16_t port = ntohs(m_http_sm->t_state.current.server != NULL ? m_http_sm->t_state.current.server->dst_addr.port() : 0);
+      marshal_int(buf, port);
+  }
+  return INK_MIN_ALIGN;
+}
+
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 

--- a/proxy/logging/LogAccessHttp.h
+++ b/proxy/logging/LogAccessHttp.h
@@ -95,6 +95,7 @@ public:
   virtual int marshal_proxy_req_body_len(char *);    // INT
   virtual int marshal_proxy_req_server_name(char *); // STR
   virtual int marshal_proxy_req_server_ip(char *);   // INT
+  virtual int marshal_proxy_req_server_port(char *); // INT
   virtual int marshal_proxy_hierarchy_route(char *); // INT
   virtual int marshal_proxy_host_port(char *);       // INT
 


### PR DESCRIPTION
We already have the server IP available as a field for logging.
This patch adds the server port as well.