### PR TITLE
TS-3779: Add per-host error pages to body factory

### DIFF
--- a/ci/tsqa/tests/test_body_factory.py
+++ b/ci/tsqa/tests/test_body_factory.py
@@ -1,0 +1,79 @@
+'''
+Test body_factory
+'''
+
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import requests
+import time
+import logging
+import SocketServer
+import random
+import tsqa.test_cases
+import helpers
+import json
+
+log = logging.getLogger(__name__)
+
+class TestDomainSpecificBodyFactory(helpers.EnvironmentCase):
+    '''
+    Tests for how body factory works with requests of different domains
+    '''
+    @classmethod
+    def setUpEnv(cls, env):
+        cls.configs['records.config']['CONFIG'].update({
+            'proxy.config.body_factory.enable_customizations': 3,  # enable domain specific body factory
+        })
+        cls.configs['remap.config'].add_line(
+            'map / http://www.linkedin.com/ @action=deny'
+        )
+        cls.body_factory_dir = os.path.join(cls.environment.layout.prefix, cls.configs['records.config']['CONFIG']['proxy.config.body_factory.template_sets_dir'])
+        cls.domain_directory = ['www.linkedin.com', '127.0.0.1', 'www.foobar.net']
+        for directory_item in cls.domain_directory:
+            current_dir = os.path.join(cls.body_factory_dir, directory_item)
+            try:
+                os.mkdir(current_dir)
+            except:
+                pass
+            fname = os.path.join(current_dir, "access#denied")
+            with open(fname, "w") as f:
+              f.write(directory_item)
+            fname = os.path.join(current_dir, ".body_factory_info")
+            with open(fname, "w") as f:
+              pass
+
+    def test_domain_specific_body_factory(self):
+      times = 1000
+      no_dir_domain = 'www.nodir.com'
+      self.domain_directory.append(no_dir_domain)
+      self.assertEqual(4, len(self.domain_directory))
+      url = 'http://127.1.0.1:{0}'.format(self.configs['records.config']['CONFIG']['proxy.config.http.server_ports'])
+      for i in xrange(times):
+          domain = random.choice(self.domain_directory)
+          headers = {'Host' : domain}
+          r = requests.get(url, headers = headers)
+          domain_in_response = no_dir_domain
+          for domain_item in self.domain_directory:
+              if domain_item in r.text:
+                   domain_in_response = domain_item
+                   break
+          self.assertEqual(domain, domain_in_response)
+
+
+
+

--- a/doc/reference/configuration/records.config.en.rst
+++ b/doc/reference/configuration/records.config.en.rst
@@ -1690,6 +1690,7 @@ Customizable User Response Pages
 
    -  ``1`` = enable customizable user response pages in the default directory only
    -  ``2`` = enable language-targeted user response pages
+   -  ``3`` = enable host-targeted user response pages
 
 .. ts:cv:: CONFIG proxy.config.body_factory.enable_logging INT 0
 

--- a/proxy/http/HttpBodyFactory.cc
+++ b/proxy/http/HttpBodyFactory.cc
@@ -419,10 +419,13 @@ HttpBodyFactory::fabricate(StrList *acpt_language_list, StrList *acpt_charset_li
     Debug("body_factory", "  customization disabled, returning NULL template");
     return (NULL);
   }
+
   // what set should we use (language target if enable_customizations == 2)
   if (enable_customizations == 2)
     set = determine_set_by_language(acpt_language_list, acpt_charset_list);
-  else
+  else if (enable_customizations == 3) {
+    set = determine_set_by_host(context);
+  } else
     set = "default";
 
   if (set_return)
@@ -443,6 +446,23 @@ HttpBodyFactory::fabricate(StrList *acpt_language_list, StrList *acpt_charset_li
   return (buffer);
 }
 
+
+// LOCKING: must be called with lock taken
+const char *
+HttpBodyFactory::determine_set_by_host(HttpTransact::State *context) {
+  const char *set;
+  RawHashTable_Value v;
+  int host_len = context->hh_info.host_len;
+  char host_buffer[host_len + 1];
+  strncpy(host_buffer, context->hh_info.request_host, host_len);
+  host_buffer[host_len] = '\0';
+  if (table_of_sets->getValue((RawHashTable_Key)host_buffer, &v)) {
+    set = table_of_sets->getKeyFromBinding(table_of_sets->getCurrentBinding((RawHashTable_Key)host_buffer));
+  } else {
+    set = "default";
+  }
+  return set;
+}
 
 // LOCKING: must be called with lock taken
 const char *

--- a/proxy/http/HttpBodyFactory.h
+++ b/proxy/http/HttpBodyFactory.h
@@ -187,6 +187,7 @@ private:
                   const char **set_return = NULL);
 
   const char *determine_set_by_language(StrList *acpt_language_list, StrList *acpt_charset_list);
+  const char *determine_set_by_host(HttpTransact::State *context);
   HttpBodyTemplate *find_template(const char *set, const char *type, HttpBodySet **body_set_return);
   bool is_response_suppressed(HttpTransact::State *context);
   bool


### PR DESCRIPTION
Extending body factory to support per-host error pages.