### PR TITLE
TS-3780: Custom log add incoming interface ip

### DIFF
--- a/ci/tsqa/tests/test_custom_log.py
+++ b/ci/tsqa/tests/test_custom_log.py
@@ -1,0 +1,71 @@
+'''
+Test custom log field
+'''
+
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import requests
+import time
+import logging
+import SocketServer
+import random
+import tsqa.test_cases
+import helpers
+import json
+
+log = logging.getLogger(__name__)
+
+class TestCustomLogField(helpers.EnvironmentCase):
+    '''
+    Tests for a customed log field called hii
+    '''
+    @classmethod
+    def setUpEnv(cls, env):
+        
+        cls.configs['remap.config'].add_line(
+            'map / http://www.linkedin.com/ @action=deny'
+        )
+        cls.log_file_name = 'test_log_field'
+        cls.configs['records.config']['CONFIG'].update({
+          'proxy.config.log.custom_logs_enabled': 1,
+        })
+
+        cls.log_file_path = os.path.join(cls.environment.layout.prefix, 'var/log/test_log_field.log')
+        cls.log_etc_file = os.path.join(cls.environment.layout.prefix, 'etc/trafficserver/logs_xml.config')
+        cls.configs['logs_xml.config'].add_line('<LogFormat><Name = "testlogfield"/><Format = "%<hii> %<hiih>"/></LogFormat>')
+        cls.configs['logs_xml.config'].add_line('<LogObject><Format = "testlogfield"/><Filename = "test_log_field"/><Mode = "ascii"/></LogObject>')
+
+    def ip_to_hex(self, ipstr):
+      num_list = ipstr.split('.')
+      int_value = (int(num_list[0]) << 24) + (int(num_list[1]) << 16) + (int(num_list[2]) << 8) + (int(num_list[3]))
+      return hex(int_value).upper()[2:]
+
+    def test_log_field(self):
+      random.seed()
+      times = 10
+      for i in xrange(times):
+        request_ip = "127.%d.%d.%d" % (random.randint(1, 255), random.randint(1, 255), random.randint(1, 255))
+        url = 'http://%s:%s' % (request_ip, self.configs['records.config']['CONFIG']['proxy.config.http.server_ports'])
+        r = requests.get(url)
+        #get the last line of the log file
+        time.sleep(10)
+        with open(self.log_file_path) as f:
+          for line in f:
+            pass
+        expected_line = "%s %s\n" % (request_ip, self.ip_to_hex(request_ip))
+        self.assertEqual(line, expected_line)

--- a/doc/admin/event-logging-formats.en.rst
+++ b/doc/admin/event-logging-formats.en.rst
@@ -109,6 +109,16 @@ The following list describes Traffic Server custom logging fields.
 ``chih``
     The IP address of the client's host machine in hexadecimal.
 
+.. _hii:
+
+``hii``
+    This is the incoming (interface) ip for traffic server, in otherwords this is the ip address the client connected to.
+
+.. _hiih:
+
+``hiih``
+    The the incoming (interface) ip in hexadecimal.
+
 .. _chp:
 
 ``chp``

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -344,7 +344,18 @@ Log::init_fields()
     new LogField("client_host_ip_hex", "chih", LogField::IP, &LogAccess::marshal_client_host_ip, &LogAccess::unmarshal_ip_to_hex);
   global_field_list.add(field, false);
   ink_hash_table_insert(field_symbol_hash, "chih", field);
+  
+  // interface ip 
 
+  field = new LogField("host_interface_ip", "hii", LogField::IP, &LogAccess::marshal_host_interface_ip, &LogAccess::unmarshal_ip_to_str);
+  global_field_list.add(field, false);
+  ink_hash_table_insert(field_symbol_hash, "hii", field);
+
+  field =
+    new LogField("host_interface_ip_hex", "hiih", LogField::IP, &LogAccess::marshal_host_interface_ip, &LogAccess::unmarshal_ip_to_hex);
+  global_field_list.add(field, false);
+  ink_hash_table_insert(field_symbol_hash, "hiih", field);
+  // interface ip end
   field = new LogField("client_auth_user_name", "caun", LogField::STRING, &LogAccess::marshal_client_auth_user_name,
                        (LogField::UnmarshalFunc) & LogAccess::unmarshal_str);
   global_field_list.add(field, false);

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -92,6 +92,11 @@ LogAccess::marshal_client_host_ip(char *buf)
   DEFAULT_IP_FIELD;
 }
 
+int
+LogAccess::marshal_host_interface_ip(char *buf)
+{
+  DEFAULT_IP_FIELD;
+}
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 int

--- a/proxy/logging/LogAccess.h
+++ b/proxy/logging/LogAccess.h
@@ -170,10 +170,11 @@ public:
   //
   // client -> proxy fields
   //
-  inkcoreapi virtual int marshal_client_host_ip(char *);        // STR
-  inkcoreapi virtual int marshal_client_host_port(char *);      // INT
-  inkcoreapi virtual int marshal_client_auth_user_name(char *); // STR
-  int marshal_client_req_timestamp_sec(char *);                 // INT
+  inkcoreapi virtual int marshal_client_host_ip(char *);                // STR
+  inkcoreapi virtual int marshal_host_interface_ip(char *);      // STR
+  inkcoreapi virtual int marshal_client_host_port(char *);              // INT
+  inkcoreapi virtual int marshal_client_auth_user_name(char *);         // STR
+  int marshal_client_req_timestamp_sec(char *);                         // INT
 
   inkcoreapi virtual int marshal_client_req_text(char *);               // STR
   inkcoreapi virtual int marshal_client_req_http_method(char *);        // STR

--- a/proxy/logging/LogAccessHttp.cc
+++ b/proxy/logging/LogAccessHttp.cc
@@ -237,6 +237,12 @@ LogAccessHttp::marshal_client_host_ip(char *buf)
   return marshal_ip(buf, &m_http_sm->t_state.client_info.src_addr.sa);
 }
 
+int
+LogAccessHttp::marshal_host_interface_ip(char *buf)
+{
+  return marshal_ip(buf, &m_http_sm->t_state.client_info.dst_addr.sa);
+}
+
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 int

--- a/proxy/logging/LogAccessHttp.h
+++ b/proxy/logging/LogAccessHttp.h
@@ -56,6 +56,7 @@ public:
   // client -> proxy fields
   //
   virtual int marshal_client_host_ip(char *);                // STR
+  virtual int marshal_host_interface_ip(char *);             // STR
   virtual int marshal_client_host_port(char *);              // INT
   virtual int marshal_client_auth_user_name(char *);         // STR
   virtual int marshal_client_req_text(char *);               // STR


### PR DESCRIPTION
Extending the custom log fields to support incoming server (interface) ip.