### PR TITLE
TS-3792: Crash with non-existant or missing resolve_conf

### DIFF
--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -883,6 +883,13 @@ write_dns(DNSHandler *h)
   int max_nscount = h->m_res->nscount;
   if (max_nscount > MAX_NAMED)
     max_nscount = MAX_NAMED;
+  if (max_nscount <= 0) {
+    Warning("There is no name server found in the resolv.conf");
+    if (h->entries.head) {
+      dns_result(h, h->entries.head, NULL, false);
+    }
+    return;
+  }
 
   if (h->in_write_dns)
     return;

--- a/lib/ts/ink_res_init.cc
+++ b/lib/ts/ink_res_init.cc
@@ -432,7 +432,7 @@ ink_res_init(ink_res_state statp,         ///< State object to update.
 
 #define MATCH(line, name) \
   (!strncmp(line, name, sizeof(name) - 1) && (line[sizeof(name) - 1] == ' ' || line[sizeof(name) - 1] == '\t'))
-retry_load_resolve_conf:
+
   if ((fp = fopen(pResolvConf, "r")) != NULL) {
     /* read the config file */
     while (fgets(buf, sizeof(buf), fp) != NULL) {
@@ -521,17 +521,8 @@ retry_load_resolve_conf:
     (void)fclose(fp);
   }
 
-  if (nserv == 0 && strcmp(pResolvConf, "/etc/resolv.conf") != 0) {
-    syslog(LOG_WARNING, "WARNING: trying default because user specified did not have any resolvers");
-    pResolvConf = "/etc/resolv.conf";
-    goto retry_load_resolve_conf;
-  }
-  if (nserv == 0) {
-    syslog(LOG_ERR, "ERR: aborting the traffic server because it did not have any resolvers");
-    abort();
-  }
-
-  statp->nscount = nserv;
+  if (nserv > 0)
+    statp->nscount = nserv;
 
   if (statp->defdname[0] == 0 && gethostname(buf, sizeof(statp->defdname) - 1) == 0 && (cp = strchr(buf, '.')) != NULL)
     ink_strlcpy(statp->defdname, cp + 1, sizeof(statp->defdname));


### PR DESCRIPTION
Fix the bug issue TS-3792: Pointing proxy.config.dns.resolv_conf at an empty (or nonexistant) file causes segmentation faults on first DNS query. If the user specified resolve conf doesn't work, use the default resolve conf instead. If the default resolve conf doesn't work neither, abort the traffic server.