### PR TITLE
TS-3806 Resolve undefined reference to symbol MD5_Final

### DIFF
--- a/cmd/traffic_manager/Makefile.am
+++ b/cmd/traffic_manager/Makefile.am
@@ -67,5 +67,6 @@ traffic_manager_LDADD = \
 if BUILD_WCCP
 traffic_manager_LDADD += \
   $(top_builddir)/lib/wccp/libwccp.a \
-  $(top_builddir)/lib/tsconfig/libtsconfig.la
+  $(top_builddir)/lib/tsconfig/libtsconfig.la \
+  @OPENSSL_LIBS@
 endif


### PR DESCRIPTION
This is similar to TS-3632. It should also be cherry-picked to the 5.3.x branch.