### PR TITLE
TS-3828: HEAD requests hang when origin returns Transfer-Encoding: Chunked

### DIFF
--- a/ci/tsqa/tests/test_headrequest.py
+++ b/ci/tsqa/tests/test_headrequest.py
@@ -1,0 +1,118 @@
+'''
+Test Head Request
+'''
+
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import requests
+import time
+import logging
+import SocketServer
+import random
+import tsqa.test_cases
+import helpers
+import json
+import select
+import socket
+
+log = logging.getLogger(__name__)
+
+
+class HeadRequestServerHandler(SocketServer.BaseRequestHandler):
+    """ 
+    A subclass of RequestHandler which will response to head requests
+    """
+
+    def handle(self):
+        # Receive the data in small chunks and retransmit it
+        while True:
+            data = self.request.recv(4096).strip()
+            if data:
+                log.debug('Sending data back to the client')
+            else:
+                log.debug('Client disconnected')
+                break
+            if 'TE' in data:
+                resp = ('HTTP/1.1 200 OK\r\n'
+                    'Server: Apache-Coyote/1.1\r\n'
+                    'Transfer-Encoding: chunked\r\n'
+                    'Vary: Accept-Encoding\r\n'
+                    '\r\n'
+                    )  
+                self.request.sendall(resp)
+            elif 'CL' in data:
+                resp = ('HTTP/1.1 200 OK\r\n'
+                    'Server: Apache-Coyote/1.1\r\n'
+                    'Content-Length: 123\r\n'
+                    'Vary: Accept-Encoding\r\n'
+                    '\r\n'
+                    )  
+                self.request.sendall(resp)
+            else:
+                resp = ('HTTP/1.1 200 OK\r\n'
+                    'Server: Apache-Coyote/1.1\r\n'
+                    'Vary: Accept-Encoding\r\n'
+                    '\r\n'
+                    )  
+                self.request.sendall(resp)
+
+
+
+class TestHeadRequestWithoutTimeout(helpers.EnvironmentCase):
+    '''
+    Tests for ATS handling head requests correctly without waiting for the http body
+    '''
+    @classmethod
+    def setUpEnv(cls, env):
+        cls.timeout = 5
+        cls.configs['records.config']['CONFIG'].update({
+            'proxy.config.http.transaction_no_activity_timeout_out': cls.timeout,
+        })
+        cls.socket_server = tsqa.endpoint.SocketServerDaemon(HeadRequestServerHandler)
+        cls.socket_server.start()
+        cls.socket_server.ready.wait()
+        cls.configs['remap.config'].add_line('map / http://127.0.0.1:{0}/'.format(cls.socket_server.port))
+        log.info('map / http://127.0.0.1:{0}/'.format(cls.socket_server.port))
+
+        cls.proxy_host = '127.0.0.1'
+        cls.proxy_port = int(cls.configs['records.config']['CONFIG']['proxy.config.http.server_ports'])
+
+    def test_head_request_without_timout(cls):
+        request_cases = ['TE', 'CL', '']
+        for request_case in request_cases:
+            begin_time = time.time()
+            conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            conn.connect((cls.proxy_host, cls.proxy_port))
+            request_content = 'HEAD / HTTP/1.1\r\nConnection: close\r\nHost: 127.0.0.1\r\nContent-Length: %d\r\n\r\n%s' % (
+                    len(request_case), request_case)
+            conn.setblocking(1)
+            conn.send(request_content)
+            while 1:
+                try:
+                    resp = conn.recv(4096)
+                    if len(resp) == 0: 
+                        break
+                    log.info(resp)
+                except:
+                    break
+            conn.shutdown(socket.SHUT_RDWR)
+            conn.close()
+            end_time = time.time()
+            log.info("head request with case(%s) costs %f seconds while the timout is %f seconds." % (
+                    request_case, end_time - begin_time, cls.timeout))
+            cls.assertGreater(cls.timeout, end_time - begin_time)

--- a/ci/tsqa/tests/test_headrequest.py
+++ b/ci/tsqa/tests/test_headrequest.py
@@ -107,6 +107,7 @@ class TestHeadRequestWithoutTimeout(helpers.EnvironmentCase):
                     resp = conn.recv(4096)
                     if len(resp) == 0: 
                         break
+                    response_content = resp
                     log.info(resp)
                 except:
                     break
@@ -116,3 +117,5 @@ class TestHeadRequestWithoutTimeout(helpers.EnvironmentCase):
             log.info("head request with case(%s) costs %f seconds while the timout is %f seconds." % (
                     request_case, end_time - begin_time, cls.timeout))
             cls.assertGreater(cls.timeout, end_time - begin_time)
+            if request_case == 'CL':
+                cls.assertIn('Content-Length', response_content)

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -7928,8 +7928,12 @@ HttpTransact::build_response(State *s, HTTPHdr *base_response, HTTPHdr *outgoing
 
   // If the response is prohibited from containing a body,
   //  we know the content length is trustable for keep-alive
-  if (is_response_body_precluded(status_code, s->method))
+  if (is_response_body_precluded(status_code, s->method)) {
     s->hdr_info.trust_response_cl = true;
+    s->hdr_info.response_content_length = 0;
+    s->client_info.transfer_encoding = HttpTransact::NO_TRANSFER_ENCODING;
+    s->server_info.transfer_encoding = HttpTransact::NO_TRANSFER_ENCODING;
+  }
 
   handle_response_keep_alive_headers(s, outgoing_version, outgoing_response);
 


### PR DESCRIPTION
When a client makes a HEAD request and the origin returns a header containing Transfer-Encoding: chunked or Content-Length, ATS now waits for the http body which will never come. Then the ATS goes though several timeouts whose length is configured by the record called proxy.config.http.transaction_no_activity_timeout_out.