### PR TITLE
TS-3797: Crashes due to cross-thread race conditions.

### DIFF
--- a/iocore/net/Connection.cc
+++ b/iocore/net/Connection.cc
@@ -62,7 +62,7 @@ NetVCOptions::toString(addr_bind_style s)
   return ANY_ADDR == s ? "any" : INTF_ADDR == s ? "interface" : "foreign";
 }
 
-Connection::Connection() : fd(NO_FD), is_bound(false), is_connected(false), sock_type(0)
+Connection::Connection() : fd(NO_FD), is_bound(false), is_connected(false), is_zombie(false), sock_type(0)
 {
   memset(&addr, 0, sizeof(addr));
 }
@@ -114,14 +114,32 @@ Connection::close()
   is_connected = false;
   is_bound = false;
   // don't close any of the standards
-  if (fd >= 2) {
+  if (fd >= 2 && !is_zombie) {
     int fd_save = fd;
     fd = NO_FD;
     return socketManager.close(fd_save);
   } else {
     fd = NO_FD;
+    is_zombie = false;
     return -EBADF;
   }
+}
+
+/**
+ * Move control of the socket from the argument object orig to the current object.
+ * Orig is marked as zombie, so when it is freed, the socket will not be closed
+ */
+void
+Connection::move(Connection &orig)
+{
+  this->is_connected = orig.is_connected;
+  this->is_bound = orig.is_bound;
+  this->fd = orig.fd;
+  this->addr = orig.addr;
+  this->sock_type = orig.sock_type;
+  // The original is now the zombie
+  // The target has taken ownership of the file descriptor
+  orig.is_zombie = true;
 }
 
 static int

--- a/iocore/net/P_Connection.h
+++ b/iocore/net/P_Connection.h
@@ -83,6 +83,7 @@ struct Connection {
   IpEndpoint addr;   ///< Associated address.
   bool is_bound;     ///< Flag for already bound to a local address.
   bool is_connected; ///< Flag for already connected.
+  bool is_zombie;    ///< Flag true if the fd should not be closed
   int sock_type;
 
   /** Create and initialize the socket for this connection.
@@ -138,6 +139,17 @@ struct Connection {
 
   /// Default options.
   static NetVCOptions const DEFAULT_OPTIONS;
+
+  /**
+   * Move control of the socket from the argument object orig to the current object.
+   * Orig is marked as zombie, so when it is freed, the socket will not be closed
+   */
+  void move(Connection &);
+
+private:
+  // Don't want copy constructors to avoid having the deconstructor on
+  // temporarly copies close the file descriptor too soon. Use move instead
+  Connection(Connection const &);
 
 protected:
   void _cleanup();

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -283,6 +283,13 @@ public:
     return SSL_get_cipher_name(ssl);
   }
 
+  /**
+   * Populate the current object based on the socket information in in the
+   * con parameter and the ssl object in the arg parameter
+   * This is logic is invoked when the NetVC object is created in a new thread context
+   */
+  virtual int populate(Connection &con, Continuation *c, void *arg);
+
 private:
   SSLNetVConnection(const SSLNetVConnection &);
   SSLNetVConnection &operator=(const SSLNetVConnection &);

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -216,6 +216,12 @@ public:
   void readReschedule(NetHandler *nh);
   void writeReschedule(NetHandler *nh);
   void netActivity(EThread *lthread);
+  /**
+   * If the current object's thread does not match the t argument, create a new
+   * NetVC in the thread t context based on the socket and ssl information in the
+   * current NetVC and mark the current NetVC to be closed.
+   */
+  UnixNetVConnection *migrateToCurrentThread(Continuation *c, EThread *t);
 
   Action action_;
   volatile int closed;
@@ -271,6 +277,12 @@ public:
   int acceptEvent(int event, Event *e);
   int mainEvent(int event, Event *e);
   virtual int connectUp(EThread *t, int fd);
+  /**
+   * Populate the current object based on the socket information in in the
+   * con parameter.
+   * This is logic is invoked when the NetVC object is created in a new thread context
+   */
+  virtual int populate(Connection &con, Continuation *c, void *arg);
   virtual void free(EThread *t);
 
   virtual ink_hrtime get_inactivity_timeout();

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -451,6 +451,7 @@ NetAccept::acceptFastEvent(int event, void *ep)
       return EVENT_DONE;
     }
 
+    ink_assert(vc->nh->mutex->thread_holding == this_ethread());
     vc->nh->open_list.enqueue(vc);
 
 #ifdef USE_EDGE_TRIGGER
@@ -464,8 +465,9 @@ NetAccept::acceptFastEvent(int event, void *ep)
       // We must be holding the lock already to do later do_io_read's
       SCOPED_MUTEX_LOCK(lock, vc->mutex, e->ethread);
       action_->continuation->handleEvent(NET_EVENT_ACCEPT, vc);
-    } else
+    } else {
       close_UnixNetVConnection(vc, e->ethread);
+    }
   } while (loop);
 
 Ldone:

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -101,6 +101,9 @@ close_UnixNetVConnection(UnixNetVConnection *vc, EThread *t)
   vc->cancel_OOB();
   vc->ep.stop();
   vc->con.close();
+
+  ink_release_assert(vc->thread == t);
+
 #ifdef INACTIVITY_TIMEOUT
   if (vc->inactivity_timeout) {
     vc->inactivity_timeout->cancel_action(vc);
@@ -117,20 +120,22 @@ close_UnixNetVConnection(UnixNetVConnection *vc, EThread *t)
   vc->inactivity_timeout_in = 0;
 
   vc->active_timeout_in = 0;
-  nh->open_list.remove(vc);
-  nh->cop_list.remove(vc);
-  nh->read_ready_list.remove(vc);
-  nh->write_ready_list.remove(vc);
-  if (vc->read.in_enabled_list) {
-    nh->read_enable_list.remove(vc);
-    vc->read.in_enabled_list = 0;
+  if (nh) {
+    nh->open_list.remove(vc);
+    nh->cop_list.remove(vc);
+    nh->read_ready_list.remove(vc);
+    nh->write_ready_list.remove(vc);
+    if (vc->read.in_enabled_list) {
+      nh->read_enable_list.remove(vc);
+      vc->read.in_enabled_list = 0;
+    }
+    if (vc->write.in_enabled_list) {
+      nh->write_enable_list.remove(vc);
+      vc->write.in_enabled_list = 0;
+    }
+    vc->remove_from_keep_alive_queue();
+    vc->remove_from_active_queue();
   }
-  if (vc->write.in_enabled_list) {
-    nh->write_enable_list.remove(vc);
-    vc->write.in_enabled_list = 0;
-  }
-  vc->remove_from_keep_alive_queue();
-  vc->remove_from_active_queue();
   vc->free(t);
 }
 
@@ -252,6 +257,14 @@ read_from_net(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
 
   if (!lock.is_locked()) {
     read_reschedule(nh, vc);
+    return;
+  }
+
+  // It is possible that the closed flag got set from HttpSessionManager in the
+  // global session pool case.  If so, the closed flag should be stable once we get the
+  // s->vio.mutex (the global session pool mutex).
+  if (vc->closed) {
+    close_UnixNetVConnection(vc, thread);
     return;
   }
   // if it is not enabled.
@@ -672,7 +685,7 @@ UnixNetVConnection::do_io_close(int alerrno /* = -1 */)
   write.vio._cont = NULL;
 
   EThread *t = this_ethread();
-  bool close_inline = !recursion && nh->mutex->thread_holding == t;
+  bool close_inline = !recursion && (!nh || nh->mutex->thread_holding == t);
 
   INK_WRITE_MEMORY_BARRIER;
   if (alerrno && alerrno != -1)
@@ -1183,6 +1196,34 @@ UnixNetVConnection::mainEvent(int event, Event *e)
   return EVENT_DONE;
 }
 
+int
+UnixNetVConnection::populate(Connection &con_in, Continuation *c, void *arg)
+{
+  this->con.move(con_in);
+  this->mutex = c->mutex;
+  this->thread = this_ethread();
+
+  EThread *t = this_ethread();
+  if (ep.start(get_PollDescriptor(t), this, EVENTIO_READ | EVENTIO_WRITE) < 0) {
+    Debug("iocore_net", "populate : Failed to add to epoll list\n");
+    return EVENT_ERROR;
+  }
+
+  SET_HANDLER(&UnixNetVConnection::mainEvent);
+
+  this->nh = get_NetHandler(t);
+  ink_assert(this->nh != NULL);
+  MUTEX_TRY_LOCK(lock, this->nh->mutex, t);
+  if (!lock.is_locked()) {
+    // Clean up and go home
+    return EVENT_ERROR;
+  }
+  ink_assert(nh->mutex->thread_holding == this_ethread());
+  ink_assert(!nh->open_list.in(this));
+  this->nh->open_list.enqueue(this);
+  ink_assert(this->con.fd != NO_FD);
+  return EVENT_DONE;
+}
 
 int
 UnixNetVConnection::connectUp(EThread *t, int fd)
@@ -1273,6 +1314,7 @@ fail:
 void
 UnixNetVConnection::free(EThread *t)
 {
+  ink_release_assert(t == this_ethread());
   NET_SUM_GLOBAL_DYN_STAT(net_connections_currently_open_stat, -1);
   // clear variables for reuse
   this->mutex.clear();
@@ -1317,4 +1359,52 @@ void
 UnixNetVConnection::apply_options()
 {
   con.apply_options(options);
+}
+
+/*
+ * Close down the current netVC.  Save aside the socket and SSL information
+ * and create new netVC in the current thread/netVC
+ */
+UnixNetVConnection *
+UnixNetVConnection::migrateToCurrentThread(Continuation *cont, EThread *t)
+{
+  NetHandler *client_nh = get_NetHandler(t);
+  ink_assert(client_nh);
+  if (this->nh == client_nh) {
+    // We're already there!
+    return this;
+  }
+  Connection hold_con;
+  hold_con.move(this->con);
+  SSLNetVConnection *sslvc = dynamic_cast<SSLNetVConnection *>(this);
+  SSL *save_ssl = (sslvc) ? sslvc->ssl : NULL;
+  if (save_ssl) {
+    SSL_set_ex_data(sslvc->ssl, get_ssl_client_data_index(), NULL);
+    sslvc->ssl = NULL;
+  }
+
+  // Do_io_close will signal the VC to be freed on the original thread
+  // Since we moved the con context, the fd will not be closed
+  this->do_io_close();
+
+  // Create new VC:
+  NetVConnection *new_vc = NULL;
+  if (save_ssl) {
+    new_vc = sslNetProcessor.allocate_vc(t);
+    SSLNetVConnection *sslvc = dynamic_cast<SSLNetVConnection *>(new_vc);
+    if (sslvc->populate(hold_con, cont, save_ssl) != EVENT_DONE) {
+      sslvc->do_io_close();
+      sslvc = NULL;
+    }
+    return sslvc;
+    // Update the SSL fields
+  } else {
+    new_vc = netProcessor.allocate_vc(t);
+    UnixNetVConnection *netvc = dynamic_cast<UnixNetVConnection *>(new_vc);
+    if (netvc->populate(hold_con, cont, save_ssl) != EVENT_DONE) {
+      netvc->do_io_close();
+      netvc = NULL;
+    }
+    return netvc;
+  }
 }

--- a/proxy/http/HttpServerSession.cc
+++ b/proxy/http/HttpServerSession.cc
@@ -120,7 +120,9 @@ HttpServerSession::do_io_close(int alerrno)
 
   Debug("http_ss", "[%" PRId64 "] session closing, netvc %p", con_id, server_vc);
 
-  server_vc->do_io_close(alerrno);
+  if (server_vc) {
+    server_vc->do_io_close(alerrno);
+  }
   server_vc = NULL;
 
   HTTP_SUM_GLOBAL_DYN_STAT(http_current_server_connections_stat, -1); // Make sure to work on the global stat

--- a/proxy/http/HttpServerSession.h
+++ b/proxy/http/HttpServerSession.h
@@ -112,6 +112,11 @@ public:
   {
     return server_vc;
   };
+  void
+  set_netvc(NetVConnection *new_vc)
+  {
+    server_vc = new_vc;
+  }
 
   // Keys for matching hostnames
   IpEndpoint server_ip;

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -3826,7 +3826,6 @@ HttpTransact::handle_server_connection_not_open(State *s)
   DebugTxn("http_trans", "[handle_server_connection_not_open] (hscno)");
   DebugTxn("http_seq", "[HttpTransact::handle_server_connection_not_open] ");
   ink_assert(s->current.state != CONNECTION_ALIVE);
-  ink_assert(s->current.server->had_connect_fail());
 
   SET_VIA_STRING(VIA_SERVER_RESULT, VIA_SERVER_ERROR);
   HTTP_INCREMENT_TRANS_STAT(http_broken_server_connections_stat);


### PR DESCRIPTION
We have been testing a version of this in production on a few machines for the past two weeks.  We are expanding the testing to more machines.  

This patch is slightly different than what we are running in production.  I've done a bit a clean up (removing asserts and unifying changed methods that didn't really need to be there).  The biggest difference from what we are running in production is moving the locking logic in HttpSessionManager::acquire_session to release the global pool lock sooner.  I'm running this version on a single test box in production at this point.   Will roll these changes back into broader production after the initial version passes muster (plus changes that get identified in this review).

Article describing the design of VC Migration https://cwiki.apache.org/confluence/display/TS/Threading+Issues+And+NetVC+Migration

Also a heads up that while I'm calling this VC migration, the only thing that is migrating is the socket and the SSL object.  The actual VC data structures are re-created on the new thread.