### PR TITLE
TS-3752: Accept Large Header

### DIFF
--- a/proxy/http2/HPACK.cc
+++ b/proxy/http2/HPACK.cc
@@ -43,8 +43,6 @@ const unsigned HPACK_LEN_STATUS = countof(":status") - 1;
 // Section 6.2), plus 32.
 const static unsigned ADDITIONAL_OCTETS = 32;
 
-const static uint32_t HEADER_FIELD_LIMIT_LENGTH = 4096;
-
 typedef enum {
   TS_HPACK_STATIC_TABLE_0 = 0,
   TS_HPACK_STATIC_TABLE_AUTHORITY,
@@ -538,7 +536,7 @@ decode_string(Arena &arena, char **str, uint32_t &str_length, const uint8_t *buf
     return HPACK_ERROR_COMPRESSION_ERROR;
   p += len;
 
-  if (encoded_string_len > HEADER_FIELD_LIMIT_LENGTH || (p + encoded_string_len) > buf_end) {
+  if ((p + encoded_string_len) > buf_end) {
     return HPACK_ERROR_COMPRESSION_ERROR;
   }
 

--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -247,6 +247,8 @@ struct Http2Priority {
 
 // 6.2 HEADERS Format
 struct Http2HeadersParameter {
+  Http2HeadersParameter() : pad_length(0) {}
+
   uint8_t pad_length;
   Http2Priority priority;
 };
@@ -314,7 +316,7 @@ bool http2_parse_goaway(IOVec, Http2Goaway &);
 
 bool http2_parse_window_update(IOVec, uint32_t &);
 
-int64_t http2_parse_header_fragment(HTTPHdr *, IOVec, Http2DynamicTable &, bool);
+int64_t http2_decode_header_blocks(HTTPHdr *, const uint8_t *, const uint8_t *, Http2DynamicTable &);
 
 MIMEParseResult convert_from_2_to_1_1_header(HTTPHdr *);
 

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -352,9 +352,11 @@ Http2ClientSession::state_start_frame_read(int event, void *edata)
     }
 
     // CONTINUATIONs MUST follow behind HEADERS which doesn't have END_HEADERS
-    if (this->connection_state.get_continued_id() != 0 && this->current_hdr.type != HTTP2_FRAME_TYPE_CONTINUATION) {
+    Http2StreamId continued_stream_id = this->connection_state.get_continued_stream_id();
+
+    if (continued_stream_id != 0 && this->current_hdr.type != HTTP2_FRAME_TYPE_CONTINUATION) {
       SCOPED_MUTEX_LOCK(lock, this->connection_state.mutex, this_ethread());
-      if (!this->connection_state.is_state_closed()) {
+      if (!this->connection_state.is_state_closed() || continued_stream_id != this->current_hdr.streamid) {
         this->connection_state.send_goaway_frame(this->current_hdr.streamid, HTTP2_ERROR_PROTOCOL_ERROR);
       }
       return 0;


### PR DESCRIPTION
Fix [TS-3752](https://issues.apache.org/jira/browse/TS-3752).
Approach: Collect all Header Block Fragments before decode with HPACK.