### PR TITLE
TS-3846: Initialize priority with default values

### DIFF
--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -245,6 +245,8 @@ struct Http2SettingsParameter {
 
 // 6.3 PRIORITY
 struct Http2Priority {
+  Http2Priority() : stream_dependency(0), weight(15) {}
+
   uint32_t stream_dependency;
   uint8_t weight;
 };


### PR DESCRIPTION
The range of weight is between 1 and 256, and the the default weight is 16.
Therefore, a value in the code (or transferred) is one less than its weight.

https://issues.apache.org/jira/browse/TS-3846