### PR TITLE
TS3848

### DIFF
--- a/doc/reference/configuration/records.config.en.rst
+++ b/doc/reference/configuration/records.config.en.rst
@@ -2883,5 +2883,20 @@ Sockets
    exception being if you run Traffic Server with a protocol plugin, and would
    like for it to not support HTTP requests at all.
 
+.. ts:cv:: CONFIG proxy.config.http.cache.required INT 0
+   :reloadable:
+
+   If the cache cannot be initialized or read for some reason, this variable
+   decides whether we should continue serving the requests. This setting only 
+   takes effect if proxy.config.http.cache.http is 1 and 
+   proxy.config.http.wait_for_cache is 1.
+===== ====================
+Value Effect
+===== ====================
+0     Continue serving requests even if we failed to initialize the cache
+1     Stop serving requests if none of the cache disks or volumes could be initialized
+2     Stop serving requests even if one or some of the cache disks or volumes could not be initialized
+===== ====================
+
 .. _Traffic Shaping:
                  https://cwiki.apache.org/confluence/display/TS/Traffic+Shaping

--- a/doc/reference/configuration/records.config.en.rst
+++ b/doc/reference/configuration/records.config.en.rst
@@ -2883,8 +2883,7 @@ Sockets
    exception being if you run Traffic Server with a protocol plugin, and would
    like for it to not support HTTP requests at all.
 
-.. ts:cv:: CONFIG proxy.config.http.cache.required INT 0
-   :reloadable:
+.. ts:cv:: CONFIG proxy.config.http.wait_for_cache INT 0
 
    If the cache cannot be initialized or read for some reason, this variable
    decides whether we should continue serving the requests. This setting only 
@@ -2893,9 +2892,10 @@ Sockets
 ===== ====================
 Value Effect
 ===== ====================
-0     Continue serving requests even if we failed to initialize the cache
-1     Stop serving requests if none of the cache disks or volumes could be initialized
-2     Stop serving requests even if one or some of the cache disks or volumes could not be initialized
+0     Start listening for requests without waiting for the cache to initialize 
+1     Wait for the cache to initialize. 
+2     Wait for the cache to initialize. If none of the cache disks could be initialized, abort.
+3     Wait for the cache to initialize. If even one of the disks or volumes failed to initialize, abort.
 ===== ====================
 
 .. _Traffic Shaping:

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -733,12 +733,19 @@ CacheProcessor::start_internal(int flags)
     }
   }
 
-  if (gndisks == 0) {
-    // TS-3848
-    if (cacheRequired()) {
-        Fatal("no disks could be read");
+  // TS-3848
+  if (cacheRequired()) {
+    if (gndisks == 0) {
+      Fatal("no disks could be read");
     }
+    else if ((static_cast<unsigned int>(gndisks) < theCacheStore.n_disks_from_config)
+            && cache_required == 2) {
+      Fatal("Only %d out of %d disks could be read", 
+            gndisks, theCacheStore.n_disks_from_config);
+    }
+  }
 
+  if (gndisks == 0) {
     Warning("unable to open cache disk(s): Cache Disabled\n");
     return -1;
   }

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -755,13 +755,13 @@ CacheProcessor::diskInitialized()
         bad_disks++;
     }
 
-    if (HttpConfig::m_master.oride.cache_http) {
+    if (HttpConfig::m_master.oride.cache_http && wait_for_cache) {
       if (cache_required && gndisks == bad_disks) {
-        Fatal("cache_required = %d, no disks could be read", cacheProcessor.cache_required);
+        Fatal("cache_required = %d, no disks could be read", cache_required);
       }
       else if (cache_required == 2 && bad_disks) {
         Fatal("cache_required = %d, disks configured = %d, disks read = %d", 
-              cacheProcessor.cache_required,
+              cache_required,
               theCacheStore.n_disks_from_config,
               gndisks - bad_disks);
       }
@@ -805,7 +805,7 @@ CacheProcessor::diskInitialized()
 
     if (res == -1) {
 
-      if (HttpConfig::m_master.oride.cache_http && cache_required) {
+      if (HttpConfig::m_master.oride.cache_http && wait_for_cache && cache_required) {
         Fatal("cache_required = %d, no volumes could be configured", cacheProcessor.cache_required);
       }
 
@@ -2096,7 +2096,7 @@ Cache::open_done()
   statPagesManager.register_http("cache", register_ShowCache);
   statPagesManager.register_http("cache-internal", register_ShowCacheInternal);
 
-  if (HttpConfig::m_master.oride.cache_http) {
+  if (HttpConfig::m_master.oride.cache_http && cacheProcessor.wait_for_cache) {
     if (cacheProcessor.cache_required == 1 && total_good_nvol == 0) {
       Fatal("cache_required = %d, no volumes could be initialized", 
             cacheProcessor.cache_required);
@@ -3276,7 +3276,9 @@ ink_cache_init(ModuleVersion v)
   }
 
   REC_ReadConfigInteger(cacheProcessor.cache_required, "proxy.config.http.cache.required");
-  if (HttpConfig::m_master.oride.cache_http) {
+  REC_ReadConfigInteger(cacheProcessor.wait_for_cache, "proxy.config.http.wait_for_cache");
+
+  if (HttpConfig::m_master.oride.cache_http && cacheProcessor.wait_for_cache) {
     if (theCacheStore.n_disks == 0 && cacheProcessor.cache_required) {
       Fatal("cache_required = %d, no disks could be read", cacheProcessor.cache_required);
     }

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -1059,9 +1059,12 @@ CacheProcessor::cacheInitialized()
   if (cache_init_ok) {
 
     // TS-3848
+    bool bTheCacheFailed = theCache && theCache->ready == CACHE_INIT_FAILED;
+    bool bTheStreamCacheFailed = theStreamCache && 
+      theStreamCache->ready == CACHE_INIT_FAILED;
+
     if (cacheRequired() && cache_required == 2 &&
-        (theCache->ready == CACHE_INIT_FAILED || 
-         theStreamCache->ready == CACHE_INIT_FAILED)) {
+        (bTheCacheFailed || bTheStreamCacheFailed)) { 
       Fatal("cache init partially failed");
     }
 

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -734,6 +734,11 @@ CacheProcessor::start_internal(int flags)
   }
 
   if (gndisks == 0) {
+    // TS-3848
+    if (cacheRequired()) {
+        Fatal("no disks could be read");
+    }
+
     Warning("unable to open cache disk(s): Cache Disabled\n");
     return -1;
   }

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -755,6 +755,7 @@ CacheProcessor::diskInitialized()
         bad_disks++;
     }
 
+    // TS-3848
     if (cacheRequired()) {
       if (gndisks == bad_disks) {
         Fatal("no disks could be read");
@@ -804,6 +805,7 @@ CacheProcessor::diskInitialized()
 
     if (res == -1) {
 
+      // TS-3848
       if (cacheRequired()) {
         Fatal("no volumes could be configured");
       }
@@ -1056,6 +1058,7 @@ CacheProcessor::cacheInitialized()
   }
   if (cache_init_ok) {
 
+    // TS-3848
     if (cacheRequired() && cache_required == 2 &&
         (theCache->ready == CACHE_INIT_FAILED || 
          theStreamCache->ready == CACHE_INIT_FAILED)) {
@@ -1076,6 +1079,7 @@ CacheProcessor::cacheInitialized()
     CacheProcessor::initialized = CACHE_INIT_FAILED;
     Note("cache disabled");
 
+    // TS-3848
     if (cacheProcessor.cacheRequired()) {
       Fatal("cache init failed");
     }
@@ -2106,12 +2110,11 @@ Cache::open_done()
   statPagesManager.register_http("cache", register_ShowCache);
   statPagesManager.register_http("cache-internal", register_ShowCacheInternal);
 
+  // TS-3848
   if (cacheProcessor.cacheRequired()) {
-    if (total_good_nvol == 0) {
-      Fatal("no volumes could be initialized");
-    }
-
-    if (cacheProcessor.cache_required == 2 && total_good_nvol < total_nvol) {
+    if (cacheProcessor.cache_required == 2 && 
+        total_nvol && 
+        total_good_nvol < total_nvol) {
       Fatal("not all volumes could be initialized");
     }
   }
@@ -3286,6 +3289,7 @@ ink_cache_init(ModuleVersion v)
   REC_ReadConfigInteger(cacheProcessor.cache_required, "proxy.config.http.cache.required");
   REC_ReadConfigInteger(cacheProcessor.wait_for_cache, "proxy.config.http.wait_for_cache");
 
+  // TS-3848
   if (cacheProcessor.cacheRequired()) {
     if (theCacheStore.n_disks == 0) {
       Fatal("no disks could be read");

--- a/iocore/cache/I_Cache.h
+++ b/iocore/cache/I_Cache.h
@@ -66,7 +66,6 @@ struct CacheProcessor : public Processor {
   CacheProcessor()
     : min_stripe_version(CACHE_DB_MAJOR_VERSION, CACHE_DB_MINOR_VERSION),
       max_stripe_version(CACHE_DB_MAJOR_VERSION, CACHE_DB_MINOR_VERSION), cb_after_init(0),
-      cache_required(0),
       wait_for_cache(0)
   {
   }
@@ -149,7 +148,7 @@ struct CacheProcessor : public Processor {
 
   void cacheInitialized();
 
-  bool cacheRequired() const;
+  int waitForCache() const;
 
   static volatile uint32_t cache_ready;
   static volatile int initialized;
@@ -164,7 +163,6 @@ struct CacheProcessor : public Processor {
   VersionNumber max_stripe_version;
 
   CALLBACK_FUNC cb_after_init;
-  int cache_required;
   int wait_for_cache;
 };
 

--- a/iocore/cache/I_Cache.h
+++ b/iocore/cache/I_Cache.h
@@ -65,7 +65,8 @@ typedef HTTPInfo CacheHTTPInfo;
 struct CacheProcessor : public Processor {
   CacheProcessor()
     : min_stripe_version(CACHE_DB_MAJOR_VERSION, CACHE_DB_MINOR_VERSION),
-      max_stripe_version(CACHE_DB_MAJOR_VERSION, CACHE_DB_MINOR_VERSION), cb_after_init(0)
+      max_stripe_version(CACHE_DB_MAJOR_VERSION, CACHE_DB_MINOR_VERSION), cb_after_init(0),
+      cache_required(0)
   {
   }
 
@@ -160,6 +161,7 @@ struct CacheProcessor : public Processor {
   VersionNumber max_stripe_version;
 
   CALLBACK_FUNC cb_after_init;
+  int cache_required;
 };
 
 inline void

--- a/iocore/cache/I_Cache.h
+++ b/iocore/cache/I_Cache.h
@@ -149,6 +149,8 @@ struct CacheProcessor : public Processor {
 
   void cacheInitialized();
 
+  bool cacheRequired() const;
+
   static volatile uint32_t cache_ready;
   static volatile int initialized;
   static volatile int start_done;

--- a/iocore/cache/I_Cache.h
+++ b/iocore/cache/I_Cache.h
@@ -66,7 +66,8 @@ struct CacheProcessor : public Processor {
   CacheProcessor()
     : min_stripe_version(CACHE_DB_MAJOR_VERSION, CACHE_DB_MINOR_VERSION),
       max_stripe_version(CACHE_DB_MAJOR_VERSION, CACHE_DB_MINOR_VERSION), cb_after_init(0),
-      cache_required(0)
+      cache_required(0),
+      wait_for_cache(0)
   {
   }
 
@@ -162,6 +163,7 @@ struct CacheProcessor : public Processor {
 
   CALLBACK_FUNC cb_after_init;
   int cache_required;
+  int wait_for_cache;
 };
 
 inline void

--- a/iocore/cache/I_Store.h
+++ b/iocore/cache/I_Store.h
@@ -240,6 +240,9 @@ struct Store {
   Store();
   ~Store();
 
+  // The number of disks/paths defined in storage.config
+  unsigned n_disks_from_config;
+  // The number of disks/paths we could actually read
   unsigned n_disks;
   Span **disk;
   //

--- a/iocore/cache/Store.cc
+++ b/iocore/cache/Store.cc
@@ -71,7 +71,8 @@ span_file_typename(mode_t st_mode)
 }
 
 Ptr<ProxyMutex> tmp_p;
-Store::Store() : n_disks(0), disk(NULL)
+  Store::Store()
+  : n_disks_from_config(0), n_disks(0), disk(NULL)
 {
 }
 
@@ -381,6 +382,8 @@ Store::read_config()
     }
 
     char *pp = Layout::get()->relative(path);
+
+    ++n_disks_from_config;
     ns = new Span;
     Debug("cache_init", "Store::read_config - ns = new Span; ns->init(\"%s\",%" PRId64 "), forced volume=%d%s%s", pp, size,
           volume_num, seed ? " id=" : "", seed ? seed : "");

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -2003,6 +2003,7 @@ static const RecordElement RecordsConfig[] =
 
   //###########
   //#
+  //# TS-3848
   //# Variable to control whether we should continue running the traffic_server
   //# if we HTTP caching is enabled and we fail to initialize the cache
   //#

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -377,7 +377,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.http.server_ports", RECD_STRING, "8080", RECU_RESTART_TM, RR_NULL, RECC_NULL, NULL, RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.http.wait_for_cache", RECD_INT, "0", RECU_RESTART_TM, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.http.wait_for_cache", RECD_INT, "0", RECU_RESTART_TM, RR_NULL, RECC_INT, "[0-3]", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.http.insert_request_via_str", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_NULL, NULL, RECA_NULL}
   ,
@@ -2001,15 +2001,6 @@ static const RecordElement RecordsConfig[] =
   //###########
   {RECT_CONFIG, "proxy.config.cache.http.compatibility.4-2-0-fixup", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_NULL, NULL, RECA_NULL},
 
-  //###########
-  //#
-  //# TS-3848
-  //# Variable to control whether we should continue running the traffic_server
-  //# if we HTTP caching is enabled and we fail to initialize the cache
-  //#
-  //###########
-  {RECT_CONFIG, "proxy.config.http.cache.required", RECD_INT, "0", RECU_RESTART_TM, RR_NULL, RECC_INT, "[0-2]", RECA_NULL},
- 
 };
 // clang-format on
 

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1999,7 +1999,16 @@ static const RecordElement RecordsConfig[] =
   //# Temporary and esoteric values.
   //#
   //###########
-  {RECT_CONFIG, "proxy.config.cache.http.compatibility.4-2-0-fixup", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_NULL, NULL, RECA_NULL}
+  {RECT_CONFIG, "proxy.config.cache.http.compatibility.4-2-0-fixup", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_NULL, NULL, RECA_NULL},
+
+  //###########
+  //#
+  //# Variable to control whether we should continue running the traffic_server
+  //# if we HTTP caching is enabled and we fail to initialize the cache
+  //#
+  //###########
+  {RECT_CONFIG, "proxy.config.http.cache.required", RECD_INT, "0", RECU_RESTART_TM, RR_NULL, RECC_INT, "[0-2]", RECA_NULL},
+ 
 };
 // clang-format on
 


### PR DESCRIPTION
Fixes TS-3848.
A new variable proxy.config.http.cache.required (range: 0-2) controls whether we will exit on cache or volume initialization failure. 
0     Continue serving requests even if we failed to initialize the cache
1     Stop serving requests if none of the cache disks or volumes could be initialized
2     Stop serving requests even if one or some of the cache disks or volumes could not be initialized
