### PR TITLE
This is the fix for TS-3848.

### DIFF
--- a/doc/reference/configuration/records.config.en.rst
+++ b/doc/reference/configuration/records.config.en.rst
@@ -2883,5 +2883,20 @@ Sockets
    exception being if you run Traffic Server with a protocol plugin, and would
    like for it to not support HTTP requests at all.
 
+.. ts:cv:: CONFIG proxy.config.http.wait_for_cache INT 0
+
+   If the cache cannot be initialized or read for some reason, this variable
+   decides whether we should continue serving the requests. This setting only 
+   takes effect if proxy.config.http.cache.http is 1 and 
+   proxy.config.http.wait_for_cache is 1.
+===== ====================
+Value Effect
+===== ====================
+0     Start listening for requests without waiting for the cache to initialize 
+1     Wait for the cache to initialize. 
+2     Wait for the cache to initialize. If none of the cache disks could be initialized, abort.
+3     Wait for the cache to initialize. If even one of the disks or volumes failed to initialize, abort.
+===== ====================
+
 .. _Traffic Shaping:
                  https://cwiki.apache.org/confluence/display/TS/Traffic+Shaping

--- a/iocore/cache/I_Cache.h
+++ b/iocore/cache/I_Cache.h
@@ -65,7 +65,8 @@ typedef HTTPInfo CacheHTTPInfo;
 struct CacheProcessor : public Processor {
   CacheProcessor()
     : min_stripe_version(CACHE_DB_MAJOR_VERSION, CACHE_DB_MINOR_VERSION),
-      max_stripe_version(CACHE_DB_MAJOR_VERSION, CACHE_DB_MINOR_VERSION), cb_after_init(0)
+      max_stripe_version(CACHE_DB_MAJOR_VERSION, CACHE_DB_MINOR_VERSION), cb_after_init(0),
+      wait_for_cache(0)
   {
   }
 
@@ -147,6 +148,8 @@ struct CacheProcessor : public Processor {
 
   void cacheInitialized();
 
+  int waitForCache() const;
+
   static volatile uint32_t cache_ready;
   static volatile int initialized;
   static volatile int start_done;
@@ -160,6 +163,7 @@ struct CacheProcessor : public Processor {
   VersionNumber max_stripe_version;
 
   CALLBACK_FUNC cb_after_init;
+  int wait_for_cache;
 };
 
 inline void

--- a/iocore/cache/I_Store.h
+++ b/iocore/cache/I_Store.h
@@ -240,6 +240,9 @@ struct Store {
   Store();
   ~Store();
 
+  // The number of disks/paths defined in storage.config
+  unsigned n_disks_from_config;
+  // The number of disks/paths we could actually read
   unsigned n_disks;
   Span **disk;
   //

--- a/iocore/cache/Store.cc
+++ b/iocore/cache/Store.cc
@@ -71,7 +71,8 @@ span_file_typename(mode_t st_mode)
 }
 
 Ptr<ProxyMutex> tmp_p;
-Store::Store() : n_disks(0), disk(NULL)
+  Store::Store()
+  : n_disks_from_config(0), n_disks(0), disk(NULL)
 {
 }
 
@@ -381,6 +382,8 @@ Store::read_config()
     }
 
     char *pp = Layout::get()->relative(path);
+
+    ++n_disks_from_config;
     ns = new Span;
     Debug("cache_init", "Store::read_config - ns = new Span; ns->init(\"%s\",%" PRId64 "), forced volume=%d%s%s", pp, size,
           volume_num, seed ? " id=" : "", seed ? seed : "");

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -377,7 +377,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.http.server_ports", RECD_STRING, "8080", RECU_RESTART_TM, RR_NULL, RECC_NULL, NULL, RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.http.wait_for_cache", RECD_INT, "0", RECU_RESTART_TM, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.http.wait_for_cache", RECD_INT, "0", RECU_RESTART_TM, RR_NULL, RECC_INT, "[0-3]", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.http.insert_request_via_str", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_NULL, NULL, RECA_NULL}
   ,
@@ -1999,7 +1999,8 @@ static const RecordElement RecordsConfig[] =
   //# Temporary and esoteric values.
   //#
   //###########
-  {RECT_CONFIG, "proxy.config.cache.http.compatibility.4-2-0-fixup", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_NULL, NULL, RECA_NULL}
+  {RECT_CONFIG, "proxy.config.cache.http.compatibility.4-2-0-fixup", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_NULL, NULL, RECA_NULL},
+
 };
 // clang-format on
 


### PR DESCRIPTION
The values for wait_for_cache are extended to the range 0-3.
If none of the disks or volumes could be initialized and the wait_for_cache
value is 2, traffic_server will abort.
If even one or more of the disks or volumes could not be initialized
and the wait_for_cache value is 3, traffic_server will abort.