### PR TITLE
[TS-3834] Close connection after sending GOAWAY Frame

### DIFF
--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -131,6 +131,16 @@ public:
     }
   }
 
+  int64_t
+  size()
+  {
+    if (ioblock) {
+      return ioblock->size();
+    } else {
+      return sizeof(this->hdr.raw);
+    }
+  }
+
 private:
   Http2Frame(Http2Frame &);                  // noncopyable
   Http2Frame &operator=(const Http2Frame &); // noncopyable
@@ -213,6 +223,7 @@ private:
   int state_complete_frame_read(int, void *);
 
   int64_t con_id;
+  int64_t total_write_len;
   SessionHandler session_handler;
   NetVConnection *client_vc;
   MIOBuffer *read_buffer;


### PR DESCRIPTION
Fix [TS-3834](https://issues.apache.org/jira/browse/TS-3834)
```
$ ./h2spec -h `hostname` -p 4443 -t -k -s 5.4.1
  5.4. Error Handling
    5.4.1. Connection Error Handling
      _ Receives a GOAWAY frame

68 tests, 1 passed, 67 skipped, 0 failed
All tests passed
```