### PR TITLE
TS-3956: Header_rewrite applies strange logic with = operator

### DIFF
--- a/plugins/header_rewrite/Makefile.am
+++ b/plugins/header_rewrite/Makefile.am
@@ -31,5 +31,9 @@ header_rewrite_la_SOURCES = \
   resources.cc \
   ruleset.cc \
   statement.cc
-
+  
 header_rewrite_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+bin_PROGRAMS = header_rewrite_test
+header_rewrite_test_SOURCES = parser.cc header_rewrite_test.cc
+header_rewrite_test_CXXFLAGS = $(AM_CXXFLAGS)

--- a/plugins/header_rewrite/header_rewrite_test.cc
+++ b/plugins/header_rewrite/header_rewrite_test.cc
@@ -1,0 +1,225 @@
+/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/*
+ * These are misc unit tests for header rewrite
+ */
+
+#include <cstdio>
+#include <cstdarg>
+#include <parser.h>
+
+const char PLUGIN_NAME[] = "TEST_header_rewrite";
+const char PLUGIN_NAME_DBG[] = "TEST_dbg_header_rewrite";
+
+extern "C" void TSError(const char* fmt, ...) {
+  char buf[2048];
+  int bytes = 0;
+  va_list args;
+  va_start (args, fmt);
+  if((bytes = vsnprintf (buf, sizeof(buf), fmt, args)) > 0) {
+    fprintf(stderr, "TSError: %s: %.*s\n", PLUGIN_NAME, bytes, buf);
+  }
+}
+
+extern "C" void TSDebug(const char *tag, const char* fmt, ...) {
+  char buf[2048];
+  int bytes = 0;
+  va_list args;
+  va_start (args, fmt);
+  if((bytes = vsnprintf (buf, sizeof(buf), fmt, args)) > 0) {
+    fprintf(stdout, "TSDebug: %s: %.*s\n", PLUGIN_NAME, bytes, buf);
+  }
+}
+
+#define CHECK_EQ(x, y) \
+  do { \
+   if ( (x) != (y) ) { \
+    fprintf(stderr, "CHECK FAILED " #x " != " #y "\n"); \
+    return 1; \
+   } \
+  } while (false);
+
+class ParserTest : public Parser {
+public:
+  ParserTest(std::string line) : Parser(line) { }
+
+  std::vector<std::string> getTokens() {
+    return _tokens;
+  }
+};
+
+int test_parsing() {
+
+  {
+    ParserTest p("cond      %{READ_REQUEST_HDR_HOOK}");
+    CHECK_EQ(p.getTokens().size(), 2);
+    CHECK_EQ(p.getTokens()[0], "cond");
+    CHECK_EQ(p.getTokens()[1], "%{READ_REQUEST_HDR_HOOK}");
+  }
+
+  {
+    ParserTest p("cond %{CLIENT-HEADER:Host}    =a");
+    CHECK_EQ(p.getTokens().size(), 4);
+    CHECK_EQ(p.getTokens()[0], "cond");
+    CHECK_EQ(p.getTokens()[1], "%{CLIENT-HEADER:Host}");
+    CHECK_EQ(p.getTokens()[2], "=");
+    CHECK_EQ(p.getTokens()[3], "a");
+  }
+
+  {
+    ParserTest p(" # COMMENT!");
+    CHECK_EQ(p.getTokens().size(), 0);
+    CHECK_EQ(p.empty(), true);
+  }
+
+  {
+    ParserTest p("# COMMENT");
+    CHECK_EQ(p.getTokens().size(), 0);
+    CHECK_EQ(p.empty(), true);
+  }
+
+  {
+    ParserTest p("cond %{Client-HEADER:Foo} =b");
+    CHECK_EQ(p.getTokens().size(), 4);
+    CHECK_EQ(p.getTokens()[0], "cond");
+    CHECK_EQ(p.getTokens()[1], "%{Client-HEADER:Foo}");
+    CHECK_EQ(p.getTokens()[2], "=");
+    CHECK_EQ(p.getTokens()[3], "b");
+  }
+
+  {
+    ParserTest p("cond %{Client-HEADER:Blah}       =        x");
+    CHECK_EQ(p.getTokens().size(), 4);
+    CHECK_EQ(p.getTokens()[0], "cond");
+    CHECK_EQ(p.getTokens()[1], "%{Client-HEADER:Blah}");
+    CHECK_EQ(p.getTokens()[2], "=");
+    CHECK_EQ(p.getTokens()[3], "x");
+  }
+
+  {
+    ParserTest p("cond %{CLIENT-HEADER:non_existent_header} =  \"shouldnt_   exist    _anyway\"          [AND]");
+    CHECK_EQ(p.getTokens().size(), 5);
+    CHECK_EQ(p.getTokens()[0], "cond");
+    CHECK_EQ(p.getTokens()[1], "%{CLIENT-HEADER:non_existent_header}");
+    CHECK_EQ(p.getTokens()[2], "=");
+    CHECK_EQ(p.getTokens()[3], "shouldnt_   exist    _anyway");
+    CHECK_EQ(p.getTokens()[4], "[AND]");
+  }
+
+  {
+    ParserTest p("cond %{CLIENT-HEADER:non_existent_header} =  \"shouldnt_   =    _anyway\"          [AND]");
+    CHECK_EQ(p.getTokens().size(), 5);
+    CHECK_EQ(p.getTokens()[0], "cond");
+    CHECK_EQ(p.getTokens()[1], "%{CLIENT-HEADER:non_existent_header}");
+    CHECK_EQ(p.getTokens()[2], "=");
+    CHECK_EQ(p.getTokens()[3], "shouldnt_   =    _anyway");
+    CHECK_EQ(p.getTokens()[4], "[AND]");
+  }
+
+  {
+    ParserTest p("cond %{CLIENT-HEADER:non_existent_header} =\"=\"          [AND]");
+    CHECK_EQ(p.getTokens().size(), 5);
+    CHECK_EQ(p.getTokens()[0], "cond");
+    CHECK_EQ(p.getTokens()[1], "%{CLIENT-HEADER:non_existent_header}");
+    CHECK_EQ(p.getTokens()[2], "=");
+    CHECK_EQ(p.getTokens()[3], "=");
+    CHECK_EQ(p.getTokens()[4], "[AND]");
+  }
+
+  {
+    ParserTest p("cond %{CLIENT-HEADER:non_existent_header} =\"\"          [AND]");
+    CHECK_EQ(p.getTokens().size(), 5);
+    CHECK_EQ(p.getTokens()[0], "cond");
+    CHECK_EQ(p.getTokens()[1], "%{CLIENT-HEADER:non_existent_header}");
+    CHECK_EQ(p.getTokens()[2], "=");
+    CHECK_EQ(p.getTokens()[3], "");
+    CHECK_EQ(p.getTokens()[4], "[AND]");
+  }
+
+  {
+    ParserTest p("add-header X-HeaderRewriteApplied true");
+    CHECK_EQ(p.getTokens().size(), 3);
+    CHECK_EQ(p.getTokens()[0], "add-header");
+    CHECK_EQ(p.getTokens()[1], "X-HeaderRewriteApplied");
+    CHECK_EQ(p.getTokens()[2], "true");
+  }
+
+  /*
+   * test some failure scenarios
+   */
+
+  { /* unterminated quote */
+    ParserTest p("cond %{CLIENT-HEADER:non_existent_header} =\" [AND]");
+    CHECK_EQ(p.getTokens().size(), 0);
+  }
+
+  { /* quote in a token */
+    ParserTest p("cond %{CLIENT-HEADER:non_existent_header} =a\"b [AND]");
+    CHECK_EQ(p.getTokens().size(), 0);
+  }
+
+  return 0;
+}
+
+int test_processing() {
+
+  /*
+   * These tests are designed to verify that the processing of the parsed input is correct.
+   */
+  {
+    ParserTest p("cond %{CLIENT-HEADER:non_existent_header} =\"=\"          [AND]");
+    CHECK_EQ(p.getTokens().size(), 5);
+    CHECK_EQ(p.get_op(), "CLIENT-HEADER:non_existent_header");
+    CHECK_EQ(p.get_arg(), "==");
+    CHECK_EQ(p.is_cond(), true);
+  }
+
+  {
+    ParserTest p("cond %{CLIENT-HEADER:non_existent_header} =  \"shouldnt_   =    _anyway\"          [AND]");
+    CHECK_EQ(p.getTokens().size(), 5);
+    CHECK_EQ(p.get_op(), "CLIENT-HEADER:non_existent_header");
+    CHECK_EQ(p.get_arg(), "=shouldnt_   =    _anyway");
+    CHECK_EQ(p.is_cond(), true);
+  }
+
+  {
+    ParserTest p("add-header X-HeaderRewriteApplied true");
+    CHECK_EQ(p.getTokens().size(), 3);
+    CHECK_EQ(p.get_op(), "add-header");
+    CHECK_EQ(p.get_arg(), "X-HeaderRewriteApplied");
+    CHECK_EQ(p.get_value(), "true")
+    CHECK_EQ(p.is_cond(), false);
+  }
+
+  return 0;
+}
+
+int tests() {
+  if (test_parsing() ||
+      test_processing()) {
+    return 1;
+  }
+
+  return 0;
+}
+
+int main () {
+  return tests();
+}
+

--- a/plugins/header_rewrite/parser.h
+++ b/plugins/header_rewrite/parser.h
@@ -81,7 +81,7 @@ public:
   }
 
 private:
-  void preprocess(std::vector<std::string> &tokens);
+  void preprocess(std::vector<std::string> tokens);
   DISALLOW_COPY_AND_ASSIGN(Parser);
 
   bool _cond;
@@ -90,6 +90,9 @@ private:
   std::string _op;
   std::string _arg;
   std::string _val;
+
+protected:
+  std::vector<std::string> _tokens;
 };
 
 


### PR DESCRIPTION
Please see ticket TS-3956 for more information, I'm using github here so that @zwoop / @jacksontj can provide a code review.

It appears that whitespace causes weird behavior with header_rewrite, for example:
If you remove the white space before the = and the quotes it appears to behave correctly. This whitespace issue is likely to cause strange bugs and needs to be fixed.

```
cond %{READ_REQUEST_HDR_HOOK}
cond %{CLIENT-HEADER:Host} /^localhost$/ [AND]
cond %{CLIENT-HEADER:non_existent_header} = "shouldnt_exist_anyway" [AND]
add-header X-HeaderRewriteApplied true
```
With the following request:

```
curl -v localhost/
```

Header_rewrite will incorrectly apply the rule:

```
[Oct  4 20:56:49.245] Server {0x7ffff61b5700} DIAG: (header_rewrite) Building resources, hook=TS_HTTP_READ_REQUEST_HDR_HOOK
[Oct  4 20:56:49.245] Server {0x7ffff61b5700} DIAG: (header_rewrite) 	Adding TXN client request header buffers
[Oct  4 20:56:49.245] Server {0x7ffff61b5700} DIAG: (header_rewrite) Getting Header: Host, field_loc: 0x7fffd02070d0
[Oct  4 20:56:49.245] Server {0x7ffff61b5700} DIAG: (header_rewrite) Appending HEADER(Host) to evaluation value -> localhost
[Oct  4 20:56:49.245] Server {0x7ffff61b5700} DIAG: (header_rewrite) Test regular expression ^localhost$ : localhost
[Oct  4 20:56:49.245] Server {0x7ffff61b5700} DIAG: (header_rewrite) Successfully found regular expression match
[Oct  4 20:56:49.245] Server {0x7ffff61b5700} DIAG: (header_rewrite) Evaluating HEADER(): localhost - rval: 1
[Oct  4 20:56:49.245] Server {0x7ffff61b5700} DIAG: (header_rewrite) Getting Header: non_existent_header, field_loc: (nil)
[Oct  4 20:56:49.245] Server {0x7ffff61b5700} DIAG: (header_rewrite) Evaluating HEADER():  - rval: 1
[Oct  4 20:56:49.245] Server {0x7ffff61b5700} DIAG: (header_rewrite) OperatorAddHeader::exec() invoked on header X-HeaderRewriteApplied: true
[Oct  4 20:56:49.245] Server {0x7ffff61b5700} DIAG: (header_rewrite)    Adding header X-HeaderRewriteApplied
```
I have a proposed patch incoming it maintains backwards compatability while being a little more flexible with whitespace, for example the following config will parse as:

```
cond %{READ_REQUEST_HDR_HOOK}
cond %{CLIENT-HEADER:Host} /^localhost$/            [AND]
   cond %{CLIENT-HEADER:Host}    =a
     # COMMENT!
# COMMENT
   cond %{Client-HEADER:Foo} =b
   cond %{Client-HEADER:Blah}       =        x
cond %{CLIENT-HEADER:non_existent_header} =  "shouldnt_   exist    _anyway"          [AND]
cond %{CLIENT-HEADER:non_existent_header} =  "shouldnt_   =    _anyway"          [AND]
cond %{CLIENT-HEADER:non_existent_header} ="="          [AND]
cond %{CLIENT-HEADER:non_existent_header} =""          [AND]
add-header X-HeaderRewriteApplied true
```

```
$1 = std::vector of length 2, capacity 2 = {"cond", "%{READ_REQUEST_HDR_HOOK}"}
$2 = std::vector of length 4, capacity 4 = {"cond", "%{CLIENT-HEADER:Host}", "/^localhost$/", "[AND]"}
$3 = std::vector of length 4, capacity 4 = {"cond", "%{CLIENT-HEADER:Host}", "=", "a"}
$4 = std::vector of length 4, capacity 4 = {"cond", "%{Client-HEADER:Foo}", "=", "b"}
$5 = std::vector of length 4, capacity 4 = {"cond", "%{Client-HEADER:Blah}", "=", "x"}
$6 = std::vector of length 5, capacity 8 = {"cond", "%{CLIENT-HEADER:non_existent_header}", "=", "shouldnt_   exist    _anyway", "[AND]"}
$7 = std::vector of length 5, capacity 8 = {"cond", "%{CLIENT-HEADER:non_existent_header}", "=", "shouldnt_   =    _anyway", "[AND]"}
$8 = std::vector of length 5, capacity 8 = {"cond", "%{CLIENT-HEADER:non_existent_header}", "=", "=", "[AND]"}
$9 = std::vector of length 5, capacity 8 = {"cond", "%{CLIENT-HEADER:non_existent_header}", "=", "", "[AND]"}
$10 = std::vector of length 3, capacity 4 = {"add-header", "X-HeaderRewriteApplied", "true"}
```