### PR TITLE
TS-3960: traffic_line -x doesn't reload SSL certs content

### DIFF
--- a/iocore/net/P_SSLConfig.h
+++ b/iocore/net/P_SSLConfig.h
@@ -47,13 +47,18 @@ struct SSLCertLookup;
 
 
 typedef void (*init_ssl_ctx_func)(void *, bool);
-typedef void (*load_ssl_file_func)(const char *, bool);
+typedef void (*load_ssl_file_func)(const char *, unsigned int);
 
 struct SSLConfigParams : public ConfigInfo {
   enum SSL_SESSION_CACHE_MODE {
     SSL_SESSION_CACHE_MODE_OFF = 0,
     SSL_SESSION_CACHE_MODE_SERVER_OPENSSL_IMPL = 1,
     SSL_SESSION_CACHE_MODE_SERVER_ATS_IMPL = 2
+  };
+
+  enum SSL_CONFIG_VERISON_MODE {
+    SSL_CONFIG_UNVERISONED = 0,
+    SSL_CONFIG_VERISONED = 1
   };
 
   SSLConfigParams();

--- a/iocore/net/P_SSLConfig.h
+++ b/iocore/net/P_SSLConfig.h
@@ -47,6 +47,7 @@ struct SSLCertLookup;
 
 
 typedef void (*init_ssl_ctx_func)(void *, bool);
+typedef void (*load_ssl_file_func)(const char *);
 
 struct SSLConfigParams : public ConfigInfo {
   enum SSL_SESSION_CACHE_MODE {
@@ -107,6 +108,7 @@ struct SSLConfigParams : public ConfigInfo {
   static char *ssl_wire_trace_server_name;
 
   static init_ssl_ctx_func init_ssl_ctx_cb;
+  static load_ssl_file_func load_ssl_file_cb;
 
   void initialize();
   void cleanup();

--- a/iocore/net/P_SSLConfig.h
+++ b/iocore/net/P_SSLConfig.h
@@ -47,7 +47,7 @@ struct SSLCertLookup;
 
 
 typedef void (*init_ssl_ctx_func)(void *, bool);
-typedef void (*load_ssl_file_func)(const char *);
+typedef void (*load_ssl_file_func)(const char *, bool);
 
 struct SSLConfigParams : public ConfigInfo {
   enum SSL_SESSION_CACHE_MODE {

--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -154,7 +154,7 @@ const char *SSLErrorName(int ssl_error);
 void SSLDebugBufferPrint(const char *tag, const char *buffer, unsigned buflen, const char *message);
 
 // Load the SSL certificate configuration.
-bool SSLParseCertificateConfiguration(const SSLConfigParams *params, SSLCertLookup *lookup, Vec<char *> &cert_files_vec);
+bool SSLParseCertificateConfiguration(const SSLConfigParams *params, SSLCertLookup *lookup);
 
 namespace ssl
 {

--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -154,7 +154,7 @@ const char *SSLErrorName(int ssl_error);
 void SSLDebugBufferPrint(const char *tag, const char *buffer, unsigned buflen, const char *message);
 
 // Load the SSL certificate configuration.
-bool SSLParseCertificateConfiguration(const SSLConfigParams *params, SSLCertLookup *lookup);
+bool SSLParseCertificateConfiguration(const SSLConfigParams *params, SSLCertLookup *lookup, Vec<char *> &cert_files_vec);
 
 namespace ssl
 {

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -53,6 +53,7 @@ size_t SSLConfigParams::session_cache_number_buckets = 1024;
 bool SSLConfigParams::session_cache_skip_on_lock_contention = false;
 size_t SSLConfigParams::session_cache_max_bucket_size = 100;
 init_ssl_ctx_func SSLConfigParams::init_ssl_ctx_cb = NULL;
+load_ssl_file_func SSLConfigParams::load_ssl_file_cb = NULL;
 
 // TS-3534 Wiretracing for SSL Connections
 int SSLConfigParams::ssl_wire_trace_enabled = 0;
@@ -389,12 +390,7 @@ SSLCertificateConfig::reconfigure()
     ink_hrtime_sleep(HRTIME_SECONDS(secs));
   }
 
-  Vec<char *> cert_files_vec;
-  SSLParseCertificateConfiguration(params, lookup, cert_files_vec);
-  for (size_t i = 0; i < cert_files_vec.n; i++) {
-    pmgmt->signalConfigFileChild("ssl_multicert.config", cert_files_vec[i]);
-  }
-  cert_files_vec.free_and_clear();
+  SSLParseCertificateConfiguration(params, lookup);
 
   if (!lookup->is_valid) {
     retStatus = false;

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -389,7 +389,12 @@ SSLCertificateConfig::reconfigure()
     ink_hrtime_sleep(HRTIME_SECONDS(secs));
   }
 
-  SSLParseCertificateConfiguration(params, lookup);
+  Vec<char *> cert_files_vec;
+  SSLParseCertificateConfiguration(params, lookup, cert_files_vec);
+  for (size_t i = 0; i < cert_files_vec.n; i++) {
+    pmgmt->signalConfigFileChild("ssl_multicert.config", cert_files_vec[i]);
+  }
+  cert_files_vec.free_and_clear();
 
   if (!lookup->is_valid) {
     retStatus = false;

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1194,7 +1194,7 @@ SSLPrivateKeyHandler(SSL_CTX *ctx, const SSLConfigParams *params, const ats_scop
       SSLError("failed to load server private key from %s", (const char *)completeServerKeyPath);
       return false;
     }
-    SSLConfigParams::load_ssl_file_cb(completeServerKeyPath, false);
+    SSLConfigParams::load_ssl_file_cb(completeServerKeyPath, SSLConfigParams::SSL_CONFIG_UNVERISONED);
   } else {
     SSLError("empty SSL private key path in records.config");
     return false;
@@ -1377,7 +1377,7 @@ SSLInitServerContext(const SSLConfigParams *params, const ssl_user_config &sslMu
         goto fail;
       }
       certList.push_back(cert);
-      SSLConfigParams::load_ssl_file_cb(completeServerCertPath, false);
+      SSLConfigParams::load_ssl_file_cb(completeServerCertPath, SSLConfigParams::SSL_CONFIG_UNVERISONED);
       // Load up any additional chain certificates
       X509 *ca;
       while ((ca = PEM_read_bio_X509(bio.get(), NULL, 0, NULL))) {
@@ -1400,7 +1400,7 @@ SSLInitServerContext(const SSLConfigParams *params, const ssl_user_config &sslMu
         SSLError("failed to load global certificate chain from %s", (const char *)completeServerCertChainPath);
         goto fail;
       }
-      SSLConfigParams::load_ssl_file_cb(completeServerCertChainPath, false);
+      SSLConfigParams::load_ssl_file_cb(completeServerCertChainPath, SSLConfigParams::SSL_CONFIG_UNVERISONED);
     }
 
     // Now, load any additional certificate chains specified in this entry.
@@ -1410,7 +1410,7 @@ SSLInitServerContext(const SSLConfigParams *params, const ssl_user_config &sslMu
         SSLError("failed to load certificate chain from %s", (const char *)completeServerCertChainPath);
         goto fail;
       }
-      SSLConfigParams::load_ssl_file_cb(completeServerCertChainPath, false);
+      SSLConfigParams::load_ssl_file_cb(completeServerCertChainPath, SSLConfigParams::SSL_CONFIG_UNVERISONED);
     }
   }
 

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1194,7 +1194,7 @@ SSLPrivateKeyHandler(SSL_CTX *ctx, const SSLConfigParams *params, const ats_scop
       SSLError("failed to load server private key from %s", (const char *)completeServerKeyPath);
       return false;
     }
-    SSLConfigParams::load_ssl_file_cb(completeServerKeyPath);
+    SSLConfigParams::load_ssl_file_cb(completeServerKeyPath, false);
   } else {
     SSLError("empty SSL private key path in records.config");
     return false;
@@ -1377,7 +1377,7 @@ SSLInitServerContext(const SSLConfigParams *params, const ssl_user_config &sslMu
         goto fail;
       }
       certList.push_back(cert);
-      SSLConfigParams::load_ssl_file_cb(completeServerCertPath);
+      SSLConfigParams::load_ssl_file_cb(completeServerCertPath, false);
       // Load up any additional chain certificates
       X509 *ca;
       while ((ca = PEM_read_bio_X509(bio.get(), NULL, 0, NULL))) {
@@ -1400,7 +1400,7 @@ SSLInitServerContext(const SSLConfigParams *params, const ssl_user_config &sslMu
         SSLError("failed to load global certificate chain from %s", (const char *)completeServerCertChainPath);
         goto fail;
       }
-      SSLConfigParams::load_ssl_file_cb(completeServerCertChainPath);
+      SSLConfigParams::load_ssl_file_cb(completeServerCertChainPath, false);
     }
 
     // Now, load any additional certificate chains specified in this entry.
@@ -1410,7 +1410,7 @@ SSLInitServerContext(const SSLConfigParams *params, const ssl_user_config &sslMu
         SSLError("failed to load certificate chain from %s", (const char *)completeServerCertChainPath);
         goto fail;
       }
-      SSLConfigParams::load_ssl_file_cb(completeServerCertChainPath);
+      SSLConfigParams::load_ssl_file_cb(completeServerCertChainPath, false);
     }
   }
 

--- a/mgmt/BaseManager.h
+++ b/mgmt/BaseManager.h
@@ -40,7 +40,7 @@
 #include "ts/ink_hash_table.h"
 
 #include "MgmtDefs.h"
-
+#include "MgmtMarshall.h"
 
 /*******************************************
  * used by LocalManager and in Proxy Main. *
@@ -99,6 +99,8 @@
 #define MGMT_SIGNAL_LIBRECORDS 16
 #define MGMT_SIGNAL_HTTP_CONGESTED_SERVER 20  /* Congestion control -- congested server */
 #define MGMT_SIGNAL_HTTP_ALLEVIATED_SERVER 21 /* Congestion control -- alleviated server */
+
+#define MGMT_SIGNAL_CONFIG_FILE_CHILD 22
 
 #define MGMT_SIGNAL_SAC_SERVER_DOWN 400
 

--- a/mgmt/FileManager.h
+++ b/mgmt/FileManager.h
@@ -117,7 +117,7 @@ class FileManager : public MultiFile
 public:
   FileManager();
   ~FileManager();
-  void addFile(const char *fileName, bool root_access_needed, Rollback *parentRollback = NULL);
+  void addFile(const char *fileName, bool root_access_needed, Rollback *parentRollback = NULL, bool versioned = true);
   bool getRollbackObj(const char *fileName, Rollback **rbPtr);
   void registerCallback(FileCallbackFunc func);
   void fileChanged(const char *fileName, bool incVersion);
@@ -132,7 +132,7 @@ public:
   SnapResult removeSnap(const char *snapName, const char *snapDir);
   void displaySnapOption(textBuffer *output);
   SnapResult WalkSnaps(ExpandingArray *snapList);
-  void configFileChild(const char *parent, const char *child);
+  void configFileChild(const char *parent, const char *child, bool versioned);
 
 private:
   void doRollbackLocks(lockAction_t action);
@@ -150,7 +150,7 @@ private:
   void generateRestoreConfirm(char *snapName, textBuffer *output);
   bool checkValidName(const char *name);
   const char *getParentFileName(const char *fileName);
-  void addFileHelper(const char *fileName, bool root_access_needed, Rollback *parentRollback = NULL);
+  void addFileHelper(const char *fileName, bool root_access_needed, Rollback *parentRollback, bool versioned);
 };
 
 int snapEntryCmpFunc(const void *e1, const void *e2);

--- a/mgmt/FileManager.h
+++ b/mgmt/FileManager.h
@@ -117,7 +117,7 @@ class FileManager : public MultiFile
 public:
   FileManager();
   ~FileManager();
-  void addFile(const char *fileName, bool root_access_needed, Rollback *parentRollback = NULL, bool versioned = true);
+  void addFile(const char *fileName, bool root_access_needed, Rollback *parentRollback = NULL, RollBackVersionType version_type = ROLLBACK_VERSIONED);
   bool getRollbackObj(const char *fileName, Rollback **rbPtr);
   void registerCallback(FileCallbackFunc func);
   void fileChanged(const char *fileName, bool incVersion);
@@ -132,7 +132,7 @@ public:
   SnapResult removeSnap(const char *snapName, const char *snapDir);
   void displaySnapOption(textBuffer *output);
   SnapResult WalkSnaps(ExpandingArray *snapList);
-  void configFileChild(const char *parent, const char *child, bool versioned);
+  void configFileChild(const char *parent, const char *child, unsigned int options);
 
 private:
   void doRollbackLocks(lockAction_t action);
@@ -150,7 +150,7 @@ private:
   void generateRestoreConfirm(char *snapName, textBuffer *output);
   bool checkValidName(const char *name);
   const char *getParentFileName(const char *fileName);
-  void addFileHelper(const char *fileName, bool root_access_needed, Rollback *parentRollback, bool versioned);
+  void addFileHelper(const char *fileName, bool root_access_needed, Rollback *parentRollback, RollBackVersionType version_type);
 };
 
 int snapEntryCmpFunc(const void *e1, const void *e2);

--- a/mgmt/FileManager.h
+++ b/mgmt/FileManager.h
@@ -35,9 +35,8 @@
 
 #include "ts/ink_hash_table.h"
 #include "ts/List.h"
-#include "ts/ink_string++.h"
-#include "ts/Vec.h"
 #include "Rollback.h"
+#include "ts/Vec.h"
 #include "MultiFile.h"
 
 class Rollback;
@@ -137,8 +136,8 @@ public:
 
 private:
   void doRollbackLocks(lockAction_t action);
-  ink_mutex accessLock;    // Protects bindings hashtable
-  ink_mutex cbListLock;    // Protects the CallBack List
+  ink_mutex accessLock; // Protects bindings hashtable
+  ink_mutex cbListLock; // Protects the CallBack List
   DLL<callbackListable> cblist;
   InkHashTable *bindings;
   // InkHashTable* g_snapshot_directory_ht;
@@ -151,6 +150,7 @@ private:
   void generateRestoreConfirm(char *snapName, textBuffer *output);
   bool checkValidName(const char *name);
   const char *getParentFileName(const char *fileName);
+  void addFileHelper(const char *fileName, bool root_access_needed, Rollback *parentRollback = NULL);
 };
 
 int snapEntryCmpFunc(const void *e1, const void *e2);

--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -606,12 +606,14 @@ LocalManager::handleMgmtMsgFromProcesses(MgmtMessageHdr *mh)
   // Congestion Control - end
   case MGMT_SIGNAL_CONFIG_FILE_CHILD: {
     static const MgmtMarshallType fields[] = {
-      MGMT_MARSHALL_STRING, MGMT_MARSHALL_STRING,
+      MGMT_MARSHALL_STRING, MGMT_MARSHALL_STRING, MGMT_MARSHALL_INT
     };
     char *parent = NULL;
     char *child = NULL;
-    if (-1 != mgmt_message_parse(data_raw, mh->data_len, fields, countof(fields), &parent, &child)) {
-      configFiles->configFileChild(parent, child);
+    int option = 0;
+    if (-1 != mgmt_message_parse(data_raw, mh->data_len, fields, countof(fields), &parent, &child, &option)) {
+      bool versioned = (bool)option;
+      configFiles->configFileChild(parent, child, versioned);
       ats_free_null(parent);
       ats_free_null(child);
     } else {

--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -604,6 +604,21 @@ LocalManager::handleMgmtMsgFromProcesses(MgmtMessageHdr *mh)
     alarm_keeper->signalAlarm(MGMT_ALARM_PROXY_HTTP_ALLEVIATED_SERVER, data_raw);
     break;
   // Congestion Control - end
+  case MGMT_SIGNAL_CONFIG_FILE_CHILD: {
+    static const MgmtMarshallType fields[] = {
+      MGMT_MARSHALL_STRING, MGMT_MARSHALL_STRING,
+    };
+    char *parent = NULL;
+    char *child = NULL;
+    if (-1 != mgmt_message_parse(data_raw, mh->data_len, fields, countof(fields), &parent, &child)) {
+      configFiles->configFileChild(parent, child);
+      ats_free_null(parent);
+      ats_free_null(child);
+    } else {
+      mgmt_elog(stderr, 0, "[LocalManager::handleMgmtMsgFromProcesses] "
+                           "MGMT_SIGNAL_CONFIG_FILE_CHILD mgmt_message_parse error\n");
+    }
+  } break;
   case MGMT_SIGNAL_SAC_SERVER_DOWN:
     alarm_keeper->signalAlarm(MGMT_ALARM_SAC_SERVER_DOWN, data_raw);
     break;

--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -610,16 +610,16 @@ LocalManager::handleMgmtMsgFromProcesses(MgmtMessageHdr *mh)
     };
     char *parent = NULL;
     char *child = NULL;
-    int option = 0;
-    if (-1 != mgmt_message_parse(data_raw, mh->data_len, fields, countof(fields), &parent, &child, &option)) {
-      bool versioned = (bool)option;
-      configFiles->configFileChild(parent, child, versioned);
-      ats_free_null(parent);
-      ats_free_null(child);
+    MgmtMarshallInt options = 0;
+    if (-1 != mgmt_message_parse(data_raw, mh->data_len, fields, countof(fields), &parent, &child, &options)) {
+      configFiles->configFileChild(parent, child, (unsigned int)options);
     } else {
       mgmt_elog(stderr, 0, "[LocalManager::handleMgmtMsgFromProcesses] "
                            "MGMT_SIGNAL_CONFIG_FILE_CHILD mgmt_message_parse error\n");
     }
+    //Output pointers are guaranteed to be NULL or valid
+    ats_free_null(parent);
+    ats_free_null(child);
   } break;
   case MGMT_SIGNAL_SAC_SERVER_DOWN:
     alarm_keeper->signalAlarm(MGMT_ALARM_SAC_SERVER_DOWN, data_raw);

--- a/mgmt/ProcessManager.cc
+++ b/mgmt/ProcessManager.cc
@@ -88,6 +88,18 @@ ProcessManager::reconfigure()
   return;
 } /* End ProcessManager::reconfigure */
 
+void
+ProcessManager::signalConfigFileChild(const char *parent, const char *child)
+{
+  static const MgmtMarshallType fields[] = {
+    MGMT_MARSHALL_STRING, MGMT_MARSHALL_STRING,
+  };
+  size_t len = mgmt_message_length(fields, countof(fields), &parent, &child);
+  void *buffer = ats_malloc(len);
+  mgmt_message_marshall(buffer, len, fields, countof(fields), &parent, &child);
+  signalManager(MGMT_SIGNAL_CONFIG_FILE_CHILD, (char *)buffer, len);
+  ats_free(buffer);
+}
 
 void
 ProcessManager::signalManager(int msg_id, const char *data_str)

--- a/mgmt/ProcessManager.cc
+++ b/mgmt/ProcessManager.cc
@@ -89,15 +89,14 @@ ProcessManager::reconfigure()
 } /* End ProcessManager::reconfigure */
 
 void
-ProcessManager::signalConfigFileChild(const char *parent, const char *child, bool versioned)
+ProcessManager::signalConfigFileChild(const char *parent, const char *child, unsigned int options)
 {
   static const MgmtMarshallType fields[] = {
     MGMT_MARSHALL_STRING, MGMT_MARSHALL_STRING, MGMT_MARSHALL_INT
   };
-  int option = (int)versioned;
-  size_t len = mgmt_message_length(fields, countof(fields), &parent, &child, &option);
+  size_t len = mgmt_message_length(fields, countof(fields), &parent, &child, (MgmtMarshallInt *)&options);
   void *buffer = ats_malloc(len);
-  mgmt_message_marshall(buffer, len, fields, countof(fields), &parent, &child, &option);
+  mgmt_message_marshall(buffer, len, fields, countof(fields), &parent, &child, (MgmtMarshallInt *)&options);
   signalManager(MGMT_SIGNAL_CONFIG_FILE_CHILD, (char *)buffer, len);
   ats_free(buffer);
 }

--- a/mgmt/ProcessManager.cc
+++ b/mgmt/ProcessManager.cc
@@ -89,14 +89,15 @@ ProcessManager::reconfigure()
 } /* End ProcessManager::reconfigure */
 
 void
-ProcessManager::signalConfigFileChild(const char *parent, const char *child)
+ProcessManager::signalConfigFileChild(const char *parent, const char *child, bool versioned)
 {
   static const MgmtMarshallType fields[] = {
-    MGMT_MARSHALL_STRING, MGMT_MARSHALL_STRING,
+    MGMT_MARSHALL_STRING, MGMT_MARSHALL_STRING, MGMT_MARSHALL_INT
   };
-  size_t len = mgmt_message_length(fields, countof(fields), &parent, &child);
+  int option = (int)versioned;
+  size_t len = mgmt_message_length(fields, countof(fields), &parent, &child, &option);
   void *buffer = ats_malloc(len);
-  mgmt_message_marshall(buffer, len, fields, countof(fields), &parent, &child);
+  mgmt_message_marshall(buffer, len, fields, countof(fields), &parent, &child, &option);
   signalManager(MGMT_SIGNAL_CONFIG_FILE_CHILD, (char *)buffer, len);
   ats_free(buffer);
 }

--- a/mgmt/ProcessManager.h
+++ b/mgmt/ProcessManager.h
@@ -72,7 +72,7 @@ public:
     close_socket(local_manager_sockfd);
   }
 
-  inkcoreapi void signalConfigFileChild(const char *parent, const char *child, bool versioned);
+  inkcoreapi void signalConfigFileChild(const char *parent, const char *child, unsigned int options);
   inkcoreapi void signalManager(int msg_id, const char *data_str);
   inkcoreapi void signalManager(int msg_id, const char *data_raw, int data_len);
 

--- a/mgmt/ProcessManager.h
+++ b/mgmt/ProcessManager.h
@@ -39,7 +39,7 @@
 #include "MgmtUtils.h"
 #include "BaseManager.h"
 #include "ts/ink_sock.h"
-
+#include "ts/Vec.h"
 #include "ts/ink_apidefs.h"
 
 class ConfigUpdateCbTable;
@@ -72,6 +72,7 @@ public:
     close_socket(local_manager_sockfd);
   }
 
+  inkcoreapi void signalConfigFileChild(const char *parent, const char *child);
   inkcoreapi void signalManager(int msg_id, const char *data_str);
   inkcoreapi void signalManager(int msg_id, const char *data_raw, int data_len);
 

--- a/mgmt/ProcessManager.h
+++ b/mgmt/ProcessManager.h
@@ -39,7 +39,7 @@
 #include "MgmtUtils.h"
 #include "BaseManager.h"
 #include "ts/ink_sock.h"
-#include "ts/Vec.h"
+
 #include "ts/ink_apidefs.h"
 
 class ConfigUpdateCbTable;

--- a/mgmt/ProcessManager.h
+++ b/mgmt/ProcessManager.h
@@ -72,7 +72,7 @@ public:
     close_socket(local_manager_sockfd);
   }
 
-  inkcoreapi void signalConfigFileChild(const char *parent, const char *child);
+  inkcoreapi void signalConfigFileChild(const char *parent, const char *child, bool versioned);
   inkcoreapi void signalManager(int msg_id, const char *data_str);
   inkcoreapi void signalManager(int msg_id, const char *data_raw, int data_len);
 

--- a/mgmt/Rollback.cc
+++ b/mgmt/Rollback.cc
@@ -43,8 +43,8 @@
 const char *RollbackStrings[] = {"Rollback Ok", "File was not found", "Version was out of date", "System Call Error",
                                  "Invalid Version - Version Numbers Must Increase"};
 
-Rollback::Rollback(const char *fileName_, bool root_access_needed_, Rollback *parentRollback_, bool versioned_)
-  : configFiles(NULL), root_access_needed(root_access_needed_), parentRollback(parentRollback_), versioned(versioned_)
+Rollback::Rollback(const char *fileName_, bool root_access_needed_, Rollback *parentRollback_, RollBackVersionType versionType_)
+  : configFiles(NULL), root_access_needed(root_access_needed_), parentRollback(parentRollback_), versionType(versionType_)
 {
   version_t highestSeen;             // the highest backup version
   ExpandingArray existVer(25, true); // Exsisting versions
@@ -106,7 +106,7 @@ Rollback::Rollback(const char *fileName_, bool root_access_needed_, Rollback *pa
 
   ink_mutex_init(&fileAccessLock, "RollBack Mutex");
 
-  if (!versioned) {
+  if (versionType == ROLLBACK_UNVERSIONED) {
     currentVersion = 0;
     setLastModifiedTime();
     numberBackups = 0;

--- a/mgmt/Rollback.cc
+++ b/mgmt/Rollback.cc
@@ -43,7 +43,8 @@
 const char *RollbackStrings[] = {"Rollback Ok", "File was not found", "Version was out of date", "System Call Error",
                                  "Invalid Version - Version Numbers Must Increase"};
 
-Rollback::Rollback(const char *baseFileName, bool root_access_needed_) : configFiles(NULL), root_access_needed(root_access_needed_)
+Rollback::Rollback(const char *fileName_, bool root_access_needed_, Rollback *parentRollback_)
+  : configFiles(NULL), root_access_needed(root_access_needed_), parentRollback(parentRollback_)
 {
   version_t highestSeen;             // the highest backup version
   ExpandingArray existVer(25, true); // Exsisting versions
@@ -60,20 +61,43 @@ Rollback::Rollback(const char *baseFileName, bool root_access_needed_) : configF
   char *activeVerStr;
   bool needZeroLength;
 
-  ink_assert(baseFileName != NULL);
-
+  ink_assert(fileName_ != NULL);
   // Copy the file name
-  fileNameLen = strlen(baseFileName);
+  fileNameLen = strlen(fileName_);
   fileName = (char *)ats_malloc(fileNameLen + 1);
-  ink_strlcpy(fileName, baseFileName, fileNameLen + 1);
+  ink_strlcpy(fileName, fileName_, fileNameLen + 1);
+
+  // extract the file base name
+  fileBaseName = strrchr(fileName, '/');
+  if (fileBaseName) {
+    fileBaseName++;
+  } else {
+    fileBaseName = fileName;
+  }
+  fileBaseNameLen = strlen(fileBaseName);
+  // For the parent files, the fileName is baseName,
+  // otherwise it's a child file with rooted name.
+  ink_assert(isFileNameRooted() || fileBaseName == fileName);
+
+  // extract the file dir name
+  if (isFileNameRooted()) {
+    fileDirLen = fileBaseName - fileName;
+    fileDir = (char *)ats_malloc(fileDirLen + 1);
+    ink_strlcpy(fileDir, fileName_, fileDirLen + 1);
+  }
 
   // TODO: Use the runtime directory for storing mutable data
   // XXX: Sysconfdir should be imutable!!!
-
-  ats_scoped_str sysconfdir(RecConfigReadConfigDir());
-  if (access(sysconfdir, F_OK) < 0) {
-    mgmt_fatal(0, "[Rollback::Rollback] unable to access() directory '%s': %d, %s\n", (const char *)sysconfdir, errno,
-               strerror(errno));
+  if (!isFileNameRooted()) {
+    ats_scoped_str sysconfdir(RecConfigReadConfigDir());
+    if (access(sysconfdir, F_OK) < 0) {
+      mgmt_fatal(0, "[Rollback::Rollback] unable to access() directory '%s': %d, %s\n", (const char *)sysconfdir, errno,
+                 strerror(errno));
+    }
+  } else {
+    if (access(fileName, F_OK) < 0) {
+      mgmt_fatal(0, "[Rollback::Rollback] unable to access() file '%s': %d, %s\n", (const char *)fileName, errno, strerror(errno));
+    }
   }
 
   if (varIntFromName("proxy.config.admin.number_config_bak", &numBak) == true) {
@@ -206,6 +230,7 @@ Rollback::Rollback(const char *baseFileName, bool root_access_needed_) : configF
 Rollback::~Rollback()
 {
   ats_free(fileName);
+  ats_free(fileDir);
 }
 
 
@@ -216,12 +241,12 @@ Rollback::~Rollback()
 char *
 Rollback::createPathStr(version_t version)
 {
-  ats_scoped_str sysconfdir(RecConfigReadConfigDir());
-  int bufSize = strlen(sysconfdir) + fileNameLen + MAX_VERSION_DIGITS + 1;
-  char *buffer = (char *)ats_malloc(bufSize);
-
-  Layout::get()->relative_to(buffer, bufSize, sysconfdir, fileName);
-
+  int bufSize = 0;
+  char *buffer = NULL;
+  ats_scoped_str sysconfdir(isFileNameRooted() ? ats_strdup(fileDir) : RecConfigReadConfigDir());
+  bufSize = strlen(sysconfdir) + fileBaseNameLen + MAX_VERSION_DIGITS + 1;
+  buffer = (char *)ats_malloc(bufSize);
+  Layout::get()->relative_to(buffer, bufSize, sysconfdir, fileBaseName);
   if (version != ACTIVE_VERSION) {
     size_t pos = strlen(buffer);
     snprintf(buffer + pos, bufSize - pos, "_%d", version);
@@ -389,7 +414,6 @@ Rollback::internalUpdate(textBuffer *buf, version_t newVersion, bool notifyChang
   currentVersion_local = createPathStr(this->currentVersion);
   activeVersion = createPathStr(ACTIVE_VERSION);
   nextVersion = createPathStr(newVersion);
-
   // Create the new configuration file
   // TODO: Make sure they are not created in Sysconfigdir!
   diskFD = openFile(newVersion, O_WRONLY | O_CREAT | O_TRUNC);
@@ -466,7 +490,8 @@ Rollback::internalUpdate(textBuffer *buf, version_t newVersion, bool notifyChang
   returnCode = OK_ROLLBACK;
 
   // Post the change to the config file manager
-  if (notifyChange && configFiles) {
+  // rooted file (child file) should not post a change
+  if (notifyChange && configFiles && !isFileNameRooted()) {
     configFiles->fileChanged(fileName, incVersion);
   }
 

--- a/mgmt/Rollback.cc
+++ b/mgmt/Rollback.cc
@@ -43,8 +43,8 @@
 const char *RollbackStrings[] = {"Rollback Ok", "File was not found", "Version was out of date", "System Call Error",
                                  "Invalid Version - Version Numbers Must Increase"};
 
-Rollback::Rollback(const char *fileName_, bool root_access_needed_, Rollback *parentRollback_)
-  : configFiles(NULL), root_access_needed(root_access_needed_), parentRollback(parentRollback_)
+Rollback::Rollback(const char *fileName_, bool root_access_needed_, Rollback *parentRollback_, bool versioned_)
+  : configFiles(NULL), root_access_needed(root_access_needed_), parentRollback(parentRollback_), versioned(versioned_)
 {
   version_t highestSeen;             // the highest backup version
   ExpandingArray existVer(25, true); // Exsisting versions
@@ -106,7 +106,7 @@ Rollback::Rollback(const char *fileName_, bool root_access_needed_, Rollback *pa
 
   ink_mutex_init(&fileAccessLock, "RollBack Mutex");
 
-  if (isChildRollback()) {
+  if (!versioned) {
     currentVersion = 0;
     setLastModifiedTime();
     numberBackups = 0;

--- a/mgmt/Rollback.h
+++ b/mgmt/Rollback.h
@@ -157,7 +157,7 @@ class Rollback
 {
 public:
   // fileName_ should be rooted or a base file name.
-  Rollback(const char *fileName_, bool root_access_needed, Rollback *parentRollback = NULL);
+  Rollback(const char *fileName_, bool root_access_needed, Rollback *parentRollback = NULL, bool versioned = true);
   ~Rollback();
 
   // Manual take out of lock required
@@ -229,6 +229,11 @@ public:
   {
     return parentRollback;
   }
+  const bool
+  getVersioned()
+  {
+    return versioned;
+  }
   FileManager *configFiles; // Manager to notify on an update.
 
 private:
@@ -247,6 +252,7 @@ private:
   size_t fileDirLen;
   bool root_access_needed;
   Rollback *parentRollback;
+  bool versioned;
   version_t currentVersion;
   time_t fileLastModified;
   int numVersions;

--- a/mgmt/Rollback.h
+++ b/mgmt/Rollback.h
@@ -220,9 +220,9 @@ public:
     return fileName;
   }
   bool
-  isFileNameRooted() const
+  isChildRollback() const
   {
-    return *fileName == '/';
+    return parentRollback != NULL;
   }
   Rollback *
   getParentRollback()

--- a/mgmt/Rollback.h
+++ b/mgmt/Rollback.h
@@ -156,7 +156,8 @@ struct versionInfo {
 class Rollback
 {
 public:
-  Rollback(const char *baseFileName, bool root_access_needed);
+  // fileName_ should be rooted or a base file name.
+  Rollback(const char *fileName_, bool root_access_needed, Rollback *parentRollback = NULL);
   ~Rollback();
 
   // Manual take out of lock required
@@ -211,9 +212,23 @@ public:
   const char *
   getBaseName()
   {
-    return fileName;
+    return fileBaseName;
   };
-
+  const char *
+  getFileName()
+  {
+    return fileName;
+  }
+  bool
+  isFileNameRooted() const
+  {
+    return *fileName == '/';
+  }
+  Rollback *
+  getParentRollback()
+  {
+    return parentRollback;
+  }
   FileManager *configFiles; // Manager to notify on an update.
 
 private:
@@ -224,9 +239,14 @@ private:
   char *createPathStr(version_t version);
   RollBackCodes internalUpdate(textBuffer *buf, version_t newVersion, bool notifyChange = true, bool incVersion = true);
   ink_mutex fileAccessLock;
+  char *fileBaseName;
+  char *fileDir;
   char *fileName;
+  size_t fileBaseNameLen;
   size_t fileNameLen;
+  size_t fileDirLen;
   bool root_access_needed;
+  Rollback *parentRollback;
   version_t currentVersion;
   time_t fileLastModified;
   int numVersions;

--- a/mgmt/Rollback.h
+++ b/mgmt/Rollback.h
@@ -66,6 +66,11 @@ enum RollBackCheckType {
   ROLLBACK_CHECK_ONLY,
 };
 
+enum RollBackVersionType {
+  ROLLBACK_UNVERSIONED,
+  ROLLBACK_VERSIONED,
+};
+
 class ExpandingArray;
 
 // Stores info about a backup version
@@ -157,7 +162,7 @@ class Rollback
 {
 public:
   // fileName_ should be rooted or a base file name.
-  Rollback(const char *fileName_, bool root_access_needed, Rollback *parentRollback = NULL, bool versioned = true);
+  Rollback(const char *fileName_, bool root_access_needed, Rollback *parentRollback = NULL, RollBackVersionType versionType = ROLLBACK_VERSIONED);
   ~Rollback();
 
   // Manual take out of lock required
@@ -229,10 +234,10 @@ public:
   {
     return parentRollback;
   }
-  const bool
-  getVersioned()
+  const RollBackVersionType
+  getVersionType()
   {
-    return versioned;
+    return versionType;
   }
   FileManager *configFiles; // Manager to notify on an update.
 
@@ -252,7 +257,7 @@ private:
   size_t fileDirLen;
   bool root_access_needed;
   Rollback *parentRollback;
-  bool versioned;
+  RollBackVersionType versionType;
   version_t currentVersion;
   time_t fileLastModified;
   int numVersions;

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -124,8 +124,7 @@ static const long MAX_LOGIN = ink_login_name_max();
 static void *mgmt_restart_shutdown_callback(void *, char *, int data_len);
 static void *mgmt_storage_device_cmd_callback(void *x, char *data, int len);
 static void init_ssl_ctx_callback(void *ctx, bool server);
-// if @versioned is enabled, the file will be made backup copies
-static void load_ssl_file_callback(const char *ssl_file, bool versioned);
+static void load_ssl_file_callback(const char *ssl_file, unsigned int options);
 
 static int num_of_net_threads = ink_number_of_processors();
 static int num_of_udp_threads = 0;
@@ -1981,7 +1980,7 @@ init_ssl_ctx_callback(void *ctx, bool server)
 }
 
 static void
-load_ssl_file_callback(const char *ssl_file, bool versioned)
+load_ssl_file_callback(const char *ssl_file, unsigned int options)
 {
-  pmgmt->signalConfigFileChild("ssl_multicert.config", ssl_file, versioned);
+  pmgmt->signalConfigFileChild("ssl_multicert.config", ssl_file, options);
 }

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -124,6 +124,7 @@ static const long MAX_LOGIN = ink_login_name_max();
 static void *mgmt_restart_shutdown_callback(void *, char *, int data_len);
 static void *mgmt_storage_device_cmd_callback(void *x, char *data, int len);
 static void init_ssl_ctx_callback(void *ctx, bool server);
+static void load_ssl_file_callback(const char *ssl_file);
 
 static int num_of_net_threads = ink_number_of_processors();
 static int num_of_udp_threads = 0;
@@ -1801,6 +1802,7 @@ main(int /* argc ATS_UNUSED */, const char **argv)
     (void)plugin_init(); // plugin.config
 
     SSLConfigParams::init_ssl_ctx_cb = init_ssl_ctx_callback;
+    SSLConfigParams::load_ssl_file_cb = load_ssl_file_callback;
     sslNetProcessor.start(getNumSSLThreads(), stacksize);
 
     pmgmt->registerPluginCallbacks(global_config_cbs);
@@ -1975,4 +1977,10 @@ init_ssl_ctx_callback(void *ctx, bool server)
     hook->invoke(event, ctx);
     hook = hook->next();
   }
+}
+
+static void
+load_ssl_file_callback(const char *ssl_file)
+{
+  pmgmt->signalConfigFileChild("ssl_multicert.config", ssl_file);
 }

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -124,7 +124,8 @@ static const long MAX_LOGIN = ink_login_name_max();
 static void *mgmt_restart_shutdown_callback(void *, char *, int data_len);
 static void *mgmt_storage_device_cmd_callback(void *x, char *data, int len);
 static void init_ssl_ctx_callback(void *ctx, bool server);
-static void load_ssl_file_callback(const char *ssl_file);
+// if @versioned is enabled, the file will be made backup copies
+static void load_ssl_file_callback(const char *ssl_file, bool versioned);
 
 static int num_of_net_threads = ink_number_of_processors();
 static int num_of_udp_threads = 0;
@@ -1980,7 +1981,7 @@ init_ssl_ctx_callback(void *ctx, bool server)
 }
 
 static void
-load_ssl_file_callback(const char *ssl_file)
+load_ssl_file_callback(const char *ssl_file, bool versioned)
 {
-  pmgmt->signalConfigFileChild("ssl_multicert.config", ssl_file);
+  pmgmt->signalConfigFileChild("ssl_multicert.config", ssl_file, versioned);
 }


### PR DESCRIPTION
traffic_line -x doesn't reload  when SSL certs change file contents without changing the file names.