### PR TITLE
OCSP docs

### DIFF
--- a/doc/admin/security-options.en.rst
+++ b/doc/admin/security-options.en.rst
@@ -275,3 +275,51 @@ a ticket key file as a reverse queue in 48-byte chunks.
 #. Touch :file:`ssl_multicert.config` to indicate that the SSL configuration is stale.
 
 #. Run the command :option:`traffic_ctl config reload` to apply the new ticket key.
+
+OCSP Stapling
+============================================
+
+OCSP Stapling is an alternative approach to Online Certificate Status Protocol,
+a method for checking revocation status of an SSL certificate.
+
+Under the original OCSP implementation, clients requested a certificate's
+revocation status directly from the Certificate Authority (CA) of the
+certificate.  This could cause significant load on the CA servers since they
+were required to provide a response to every client of a given certificate in
+real time.
+
+Enabling OCSP Stapling instructs Traffic Server to retrieve and cache the
+revocation status of all configured SSL certificatesm, and present them to the
+client when the client requests the status.  Traffic Server will automatically
+query the OCSP responder specified in the SSL certificate to gather the latest
+revocation status.  Traffic Server will then cache the results for each
+configured certifcate.  The location of the OCSP responder is taken from the
+Authority Information Access field of the signed certificate. For example::
+
+    Authority Information Access:
+                OCSP - URI:http://ocsp.digicert.com
+                CA Issuers - URI:http://cacerts.digicert.com/DigiCertSHA2SecureServerCA.crt
+
+Support for OCSP Stapling can be tested using the -status option of the OpenSSL client::
+
+    $ openssl s_client -connect mozillalabs.com:443 -status
+    ...
+    ======================================
+    OCSP Response Data:
+        OCSP Response Status: successful (0x0)
+        Response Type: Basic OCSP Response
+        Version: 1 (0x0)
+    ...
+
+Details of the OCSP Stapling TLS extension can be found in `The Transport 
+Layer Security (TLS) Multiple Certificate Status Request Extension (June 2013) 
+<https://tools.ietf.org/rfc/rfc6961.txt>`_.
+
+To configure Traffic Server to use OCSP Stapling, edit the following variables
+in :file:`records.config` file:
+
+* :ts:cv:`proxy.config.ssl.ocsp.enabled`
+* :ts:cv:`proxy.config.ssl.ocsp.cache_timeout`
+* :ts:cv:`proxy.config.ssl.ocsp.request_timeout`
+* :ts:cv:`proxy.config.ssl.ocsp.update_period`
+

--- a/doc/reference/configuration/records.config.en.rst
+++ b/doc/reference/configuration/records.config.en.rst
@@ -2585,6 +2585,28 @@ Client-Related Configuration
    Specifies the location of the certificate authority file against
    which the origin server will be verified.
 
+OCSP Stapling Configuration
+===========================
+
+.. ts:cv:: CONFIG proxy.config.ssl.ocsp.enabled INT 0
+
+   Enable OCSP stapling.
+
+   -  ``0`` = disables OCSP Stapling
+   -  ``1`` = allows Traffic Server to request SSL certificate revocation status from an OCSP responder.
+
+.. ts:cv:: CONFIG proxy.config.ssl.ocsp.cache_timeout INT 3600
+
+   Number of seconds before an OCSP response expires in the stapling cache.
+
+.. ts:cv:: CONFIG proxy.config.ssl.ocsp.request_timeout INT 10
+
+   Timeout (in seconds) for queries to OCSP responders.
+
+.. ts:cv:: CONFIG proxy.config.ssl.ocsp.update_period INT 60
+
+   Update period (in seconds) for stapling caches.
+
 ICP Configuration
 =================
 
@@ -2948,11 +2970,11 @@ Value Effect
 
 2     Do not accept inbound connections until cache initialization has finished and been sufficiently
       successful that cache is enabled. This means at least one cache span is usable. If there are no
-      spans in :configfile:`storage.config` or none of the spans can be successfully parsed and
+      spans in :file:`storage.config` or none of the spans can be successfully parsed and
       initialized then Traffic Server will shut down.
 
 3     Do not accept inbound connections until cache initialization has finished and been completely
-      successful. This requires at least one cache span in :configfile:`storage.config` and that every
+      successful. This requires at least one cache span in :file:`storage.config` and that every
       span specified is valid and successfully initialized. Any error will cause Traffic Server to shut
       down.
 ===== ====================


### PR DESCRIPTION
Added proxy.config.ssl.ocsp.* configuration directives to records.config doc.  Also added a brief OCSP Stapling section to Administrator's Guide.