### PR TITLE
TS-3948 Lock g_records during in RecDumpRecords to avoid a race

### DIFF
--- a/lib/records/RecCore.cc
+++ b/lib/records/RecCore.cc
@@ -964,6 +964,8 @@ RecDumpRecords(RecT rec_type, RecDumpEntryCb callback, void *edata)
 {
   int i, num_records;
 
+  ink_rwlock_rdlock(&g_records_rwlock);
+
   num_records = g_num_records;
   for (i = 0; i < num_records; i++) {
     RecRecord *r = &(g_records[i]);
@@ -973,6 +975,8 @@ RecDumpRecords(RecT rec_type, RecDumpEntryCb callback, void *edata)
       rec_mutex_release(&(r->lock));
     }
   }
+
+  ink_rwlock_unlock(&g_records_rwlock);
 }
 
 void


### PR DESCRIPTION
Under certain conditions, data passing to RecDumpEntryCb and data inside the callback can be different. The problem is that g_records is not locked.