### PR TITLE
Reverse proxy mode - no need to set browser proxy

### DIFF
--- a/doc/admin/configuring-cache.en.rst
+++ b/doc/admin/configuring-cache.en.rst
@@ -380,8 +380,7 @@ To access the Cache Inspector utility:
       map http://yourhost.com/myCI/ http://{cache} @action=allow @src_ip=172.28.56.1-172.28.56.254
 
 #. Reload the Traffic Server configuration by running :option:`traffic_ctl config reload`.
-#. Open your web browser and configure it to use your Traffic Server as
-   a proxy server. Type the following URL::
+#. Open your web browser and go to the the following URL::
 
       http://yourhost/myCI/
 


### PR DESCRIPTION
The instructions say "To access the cache inspector in reverse proxy mode". In reverse proxy mode, user shouldn't "and configure it to use your Traffic Server as a proxy server".