### PR TITLE
TS-3984: CID 1328817: multiplexer patch to use std::auto_ptr

### DIFF
--- a/plugins/experimental/multiplexer/dispatch.cc
+++ b/plugins/experimental/multiplexer/dispatch.cc
@@ -37,16 +37,38 @@ extern size_t timeout;
 
 Request::Request(const std::string &h, const TSMBuffer b, const TSMLoc l)
   : host(h), length(TSHttpHdrLengthGet(b, l)),
-    // coverity[ctor_dtor_leak]
     io(new ats::io::IO())
 {
   assert(!host.empty());
   assert(b != NULL);
   assert(l != NULL);
-  assert(io != NULL);
   assert(length > 0);
+  assert(io.get() != NULL);
   TSHttpHdrPrint(b, l, io->buffer);
   assert(length == TSIOBufferReaderAvail(io->reader));
+}
+
+Request::Request(const Request &r)
+  : host(r.host), length(r.length),
+    io(const_cast< Request & >(r).io)
+{
+  assert(!host.empty());
+  assert(length > 0);
+  assert(io.get() != NULL);
+  assert(r.io.get() != NULL);
+}
+
+Request &
+Request::operator=(const Request &r)
+{
+  host = r.host;
+  length = r.length;
+  io = const_cast< Request & >(r).io;
+  assert(!host.empty());
+  assert(length > 0);
+  assert(io.get() != NULL);
+  assert(r.io.get() == NULL);
+  return *this;
 }
 
 uint64_t
@@ -218,7 +240,7 @@ addBody(Requests &r, const TSIOBufferReader re)
   }
   assert(length > 0);
   for (; iterator != end; ++iterator) {
-    assert(iterator->io != NULL);
+    assert(iterator->io.get() != NULL);
     const int64_t size = copy(re, iterator->io->buffer);
     assert(size == length);
     iterator->length += size;
@@ -231,7 +253,7 @@ dispatch(Requests &r, const int t)
   Requests::iterator iterator = r.begin();
   const Requests::iterator end = r.end();
   for (; iterator != end; ++iterator) {
-    assert(iterator->io != NULL);
+    assert(iterator->io.get() != NULL);
     if (TSIsDebugTagSet(PLUGIN_TAG) > 0) {
       TSDebug(PLUGIN_TAG, "Dispatching %i bytes to \"%s\"", iterator->length, iterator->host.c_str());
       std::string b;

--- a/plugins/experimental/multiplexer/dispatch.cc
+++ b/plugins/experimental/multiplexer/dispatch.cc
@@ -239,8 +239,7 @@ dispatch(Requests &r, const int t)
       assert(b.size() == static_cast<uint64_t>(iterator->length));
       TSDebug(PLUGIN_TAG, "%s", b.c_str());
     }
-    ats::get(iterator->io, iterator->length, Handler(iterator->host), t);
     // forwarding iterator->io pointer ownership
-    iterator->io = NULL;
+    ats::get(iterator->io.release(), iterator->length, Handler(iterator->host), t);
   }
 }

--- a/plugins/experimental/multiplexer/dispatch.h
+++ b/plugins/experimental/multiplexer/dispatch.h
@@ -24,6 +24,7 @@
 #define DISPATCH_H
 
 #include <assert.h>
+#include <memory>
 #include <string>
 #include <ts/ts.h>
 #include <vector>
@@ -50,7 +51,7 @@ typedef std::vector<std::string> Origins;
 struct Request {
   std::string host;
   int length;
-  ats::io::IO *io;
+  std::auto_ptr<ats::io::IO> io;
 
   Request(const std::string &, const TSMBuffer, const TSMLoc);
 };

--- a/plugins/experimental/multiplexer/dispatch.h
+++ b/plugins/experimental/multiplexer/dispatch.h
@@ -54,6 +54,8 @@ struct Request {
   std::auto_ptr<ats::io::IO> io;
 
   Request(const std::string &, const TSMBuffer, const TSMLoc);
+  Request(const Request &);
+  Request &operator=(const Request &);
 };
 
 typedef std::vector<Request> Requests;


### PR DESCRIPTION
@bcall @sc0ttbeardsley @zwoop a fix for multiplexer, I am not sure how coverity flags it... please let me know your thoughts...