### PR TITLE
Jira TS-3932 IP TOS field not set.

### DIFF
--- a/iocore/net/UnixConnection.cc
+++ b/iocore/net/UnixConnection.cc
@@ -322,6 +322,8 @@ Connection::connect(sockaddr const *target, NetVCOptions const &opt)
   int res;
 
   this->setRemote(target);
+  // apply dynamic options with this.addr initialized
+  apply_options(opt);
 
   cleaner<Connection> cleanup(this, &Connection::_cleanup); // mark for close until we succeed.
 


### PR DESCRIPTION
For Jira TS-3932, added second call to Connection::apply_options() within Connection::connect() so that the IP TOS field will be set properly. The first call to apply_options() within Connect::open()
does not set the IP TOS field properly since addr is not initialized at that time. If addr is not initialized then the IPv4 check within apply_options() will fail.