### PR TITLE
TS-306: Fix file privilege elevation to work with log rotation.

### DIFF
--- a/lib/ts/BaseLogFile.cc
+++ b/lib/ts/BaseLogFile.cc
@@ -326,7 +326,9 @@ BaseLogFile::open_file(int perm)
   m_fp = fopen(m_name.get(), "a+");
 
   // error check
-  if (!m_fp) {
+  if (m_fp) {
+    setlinebuf(m_fp);
+  } else {
     log_log_error("Error opening log file %s: %s\n", m_name.get(), strerror(errno));
     log_log_error("Actual error: %s\n", (errno == EINVAL ? "einval" : "something else"));
     return LOG_FILE_COULD_NOT_OPEN_FILE;

--- a/lib/ts/ink_cap.h
+++ b/lib/ts/ink_cap.h
@@ -64,10 +64,10 @@ public:
     TRACE_PRIVILEGE = 0x2u // Trace other processes with privilege
   } privilege_level;
 
-  ElevateAccess(const bool state, unsigned level = FILE_PRIVILEGE);
+  ElevateAccess(unsigned level = FILE_PRIVILEGE);
   ~ElevateAccess();
 
-  void elevate();
+  void elevate(unsigned level);
   void demote();
 
 private:
@@ -75,8 +75,12 @@ private:
   uid_t saved_uid;
   unsigned level;
 
+  void acquireFileAccessCap(unsigned level);
+  void releaseFileAccessCap();
 #if !TS_USE_POSIX_CAP
   static ink_mutex lock; // only one thread at a time can elevate
+#else
+  void *cap_state; ///< Original capabilities state to restore.
 #endif
 };
 

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -1419,25 +1419,26 @@ change_uid_gid(const char *user)
  * has elevated file access.
  */
 void
-bind_outputs(const char *_bind_stdout, const char *_bind_stderr)
+bind_outputs(const char *bind_stdout, const char *bind_stderr)
 {
   int log_fd;
-  if (*_bind_stdout != 0) {
-    Debug("log", "binding stdout to %s", _bind_stdout);
-    log_fd = open(_bind_stdout, O_WRONLY | O_APPEND | O_CREAT, 0644);
+  ElevateAccess access;
+  if (*bind_stdout != 0) {
+    Debug("log", "binding stdout to %s", bind_stdout);
+    log_fd = open(bind_stdout, O_WRONLY | O_APPEND | O_CREAT | O_SYNC, 0644);
     if (log_fd < 0) {
-      fprintf(stdout, "[Warning]: TS unable to open log file \"%s\" [%d '%s']\n", _bind_stdout, errno, strerror(errno));
+      fprintf(stdout, "[Warning]: TS unable to open log file \"%s\" [%d '%s']\n", bind_stdout, errno, strerror(errno));
     } else {
       Debug("log", "duping stdout");
       dup2(log_fd, STDOUT_FILENO);
       close(log_fd);
     }
   }
-  if (*_bind_stderr != 0) {
-    Debug("log", "binding stderr to %s", _bind_stderr);
-    log_fd = open(_bind_stderr, O_WRONLY | O_APPEND | O_CREAT, 0644);
+  if (*bind_stderr != 0) {
+    Debug("log", "binding stderr to %s", bind_stderr);
+    log_fd = open(bind_stderr, O_WRONLY | O_APPEND | O_CREAT | O_SYNC, 0644);
     if (log_fd < 0) {
-      fprintf(stdout, "[Warning]: TS unable to open log file \"%s\" [%d '%s']\n", _bind_stderr, errno, strerror(errno));
+      fprintf(stdout, "[Warning]: TS unable to open log file \"%s\" [%d '%s']\n", bind_stderr, errno, strerror(errno));
     } else {
       Debug("log", "duping stderr");
       dup2(log_fd, STDERR_FILENO);


### PR DESCRIPTION
This fixes several issues.

The biggest is DAC bypass privilege elevation. Because `traffic_server` is invoked in multiple ways (full deployment, standalone, via `gdb`, etc.) sometimes the process is privileged when the logfiles are bound and sometimes it is not. The existing elevation mechanism does not work if the process is already privileged because it incorrectly removes the privileges when it lowers privileges. I have changed this to save the current capability set and restore it on lowering so that it works in both cases.

I tweaked the buffering on the logfiles to avoid log messages apparently stopping in the middle.

I changed an argument naming to reserve leading underscores for class member variables.