### PR TITLE
Dereferencing a NULL pointer in SpdyClientSession::clear()

### DIFF
--- a/proxy/spdy/SpdyClientSession.cc
+++ b/proxy/spdy/SpdyClientSession.cc
@@ -120,6 +120,9 @@ SpdyClientSession::init(NetVConnection *netvc)
 void
 SpdyClientSession::clear()
 {
+  if (!mutex)
+    return; // this object wasn't initialized.
+
   int last_event = event;
 
   SPDY_DECREMENT_THREAD_DYN_STAT(SPDY_STAT_CURRENT_CLIENT_SESSION_COUNT, this->mutex->thread_holding);


### PR DESCRIPTION
  - At `SpdyClientSession.cc:28`, `static ClassAllocator<SpdyClientSession> spdyClientSessionAllocator` creates an instance of `SpdyClientSession` using the default constructor.
  - From that point on, `spdyClientSessionAllocator.alloc()` essentially calls memcpy on this prototype as an optimization to return new instances.
  - The regular usage of `SpdyClientSession` ensures that `SpdyClientSession::init()` would be called before its destructor is invoked. This init function sets the value of the `mutex` pointer inside `SpdyClientSession` from its initial value of `NULL`.
  - When `ClassAllocator` is being freed, the destructor on its `SpdyClientSession` prototype is called. However, the `mutex` inside the prototype is `NULL` and dereferencing it to get to `this->mutex->thread_holding` causes a SEGFAULT.

@bgaff 