### PR TITLE
TS-3995: Fix Akamai Live streaming

### DIFF
--- a/proxy/http/HttpTransactCache.cc
+++ b/proxy/http/HttpTransactCache.cc
@@ -1371,7 +1371,7 @@ HttpTransactCache::match_response_to_request_conditionals(HTTPHdr *request, HTTP
     ink_time_t lm_value = response->get_last_modified();
 
     // Condition fails if Last-modified not exists
-    if ((request->get_if_unmodified_since() < lm_value) || (lm_value == 0)) {
+    if ((lm_value == 0) || (request->get_if_unmodified_since() < lm_value)) {
       return HTTP_STATUS_PRECONDITION_FAILED;
     } else {
       // we cannot return yet, need to check If-match

--- a/proxy/http/HttpTransactCache.cc
+++ b/proxy/http/HttpTransactCache.cc
@@ -1299,7 +1299,7 @@ HttpTransactCache::match_response_to_request_conditionals(HTTPHdr *request, HTTP
       ink_time_t lm_value = response->get_last_modified();
 
       // we won't return NOT_MODIFIED if Last-modified is too recent
-      if ((lm_value == 0) || (request->get_if_modified_since() < lm_value)) {
+      if ((lm_value == 0) || (request->get_if_modified_since() <= lm_value)) {
         return response->status_get();
       }
 


### PR DESCRIPTION
Akamai live streaming uses If-Modified-Since/Last-Modified headers to
synchronise position between client and server, thus If-Modified-Since
request will always get same timestamp as Last-Modified in response.
ATS discards the 200 OK result and returns 304 Not Modified instead
which freezes the video at the second requested chunk.