### PR TITLE
TS-3998: Disable h2c upgrades

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -983,28 +983,7 @@ HttpTransact::handle_upgrade_request(State *s)
       }
     }
 
-    /*
-       draft-ietf-httpbis-http2-15
-
-       3.2.  Starting HTTP/2 for "http" URIs
-
-       The client makes an HTTP/1.1 request
-       that includes an Upgrade header field identifying HTTP/2 with the
-       "h2c" token.  The HTTP/1.1 request MUST include exactly one
-       HTTP2-Settings header field.
-     */
-    if (s->upgrade_token_wks == MIME_VALUE_H2C) {
-      MIMEField *http2_settings = s->hdr_info.client_request.field_find(MIME_FIELD_HTTP2_SETTINGS, MIME_LEN_HTTP2_SETTINGS);
-
-      // TODO Check whether h2c is enabled or not.
-      if (http2_settings) {
-        s->state_machine->ua_session->set_h2c_upgrade_flag();
-        build_upgrade_response(s);
-        TRANSACT_RETURN_VAL(SM_ACTION_INTERNAL_CACHE_NOOP, NULL, true);
-      } else {
-        DebugTxn("http_trans_upgrade", "Unable to upgrade connection to h2c, invalid headers");
-      }
-    }
+    // TODO accept h2c token to start HTTP/2 session after TS-3498 is fixed
   } else {
     DebugTxn("http_trans_upgrade", "Transaction requested upgrade for unknown protocol: %s", upgrade_hdr_val);
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TS-3998

Reject h2c token for now. after applying this patch, h2c upgrading is handled as Invalid Upgrade Request.
```
$ nghttp -v -u http://127.0.0.1/
...
[  0.001] HTTP Upgrade response
HTTP/1.1 400 Invalid Upgrade Request
Date: Sun, 15 Nov 2015 20:06:14 GMT
Connection: keep-alive
Server: ATS/6.1.0
Cache-Control: no-store
Content-Type: text/html
Content-Language: en
Content-Length: 220
...
```