### PR TITLE
Memory leak in Rule::socksParse(char*) if a token is missing the '=' sign

### DIFF
--- a/mgmt/api/GenericParser.cc
+++ b/mgmt/api/GenericParser.cc
@@ -623,6 +623,7 @@ Rule::socksParse(char *rule)
         // Every token must have a '=' sign
         if (numSubRuleTok < 2) {
           setErrorHint("'=' is expected in space-delimited token");
+          delete m_tokenList;
           return NULL;
         }
 


### PR DESCRIPTION
Memory is allocated at line 585 with `TokenList *m_tokenList = new TokenList()` but reference to it is lost when the function returns early due to a token not having the `=` sign.

@bgaff 