### PR TITLE
TS-4034: Minor atscppapi cleanup

### DIFF
--- a/lib/atscppapi/src/CaseInsensitiveStringComparator.cc
+++ b/lib/atscppapi/src/CaseInsensitiveStringComparator.cc
@@ -20,17 +20,16 @@
  * @file CaseInsensitiveStringComparator.cc
  */
 
+#include <cstring>
 #include "atscppapi/CaseInsensitiveStringComparator.h"
-
-namespace
-{
-static char NORMALIZED_CHARACTERS[256];
-static volatile bool normalizer_initialized(false);
-}
 
 using atscppapi::CaseInsensitiveStringComparator;
 using std::string;
 
+/**
+ * This class should eventually be removed, but because it's in a public API we cannot remove
+ * it until the next major release.
+ */
 bool CaseInsensitiveStringComparator::operator()(const string &lhs, const string &rhs) const
 {
   return (compare(lhs, rhs) < 0);
@@ -39,36 +38,5 @@ bool CaseInsensitiveStringComparator::operator()(const string &lhs, const string
 int
 CaseInsensitiveStringComparator::compare(const string &lhs, const string &rhs) const
 {
-  if (!normalizer_initialized) {
-    // this initialization is safe to execute in concurrent threads - hence no locking
-    for (int i = 0; i < 256; ++i) {
-      NORMALIZED_CHARACTERS[i] = static_cast<unsigned char>(i);
-    }
-    for (unsigned char i = 'A'; i < 'Z'; ++i) {
-      NORMALIZED_CHARACTERS[i] = 'a' + (i - 'A');
-    }
-    normalizer_initialized = true;
-  }
-  size_t lhs_size = lhs.size();
-  size_t rhs_size = rhs.size();
-  if ((lhs_size > 0) && (rhs_size > 0)) {
-    size_t num_chars_to_compare = (lhs_size < rhs_size) ? lhs_size : rhs_size;
-    for (size_t i = 0; i < num_chars_to_compare; ++i) {
-      unsigned char normalized_lhs_char = NORMALIZED_CHARACTERS[static_cast<const unsigned char>(lhs[i])];
-      unsigned char normalized_rhs_char = NORMALIZED_CHARACTERS[static_cast<const unsigned char>(rhs[i])];
-      if (normalized_lhs_char < normalized_rhs_char) {
-        return -1;
-      }
-      if (normalized_lhs_char > normalized_rhs_char) {
-        return 1;
-      }
-    }
-  }
-  if (lhs_size < rhs_size) {
-    return -1;
-  }
-  if (lhs_size > rhs_size) {
-    return 1;
-  }
-  return 0; // both strings are equal
+  return strcasecmp(lhs.c_str(), rhs.c_str());
 }

--- a/lib/atscppapi/src/GzipDeflateTransformation.cc
+++ b/lib/atscppapi/src/GzipDeflateTransformation.cc
@@ -23,7 +23,7 @@
 #include <cstring>
 #include <vector>
 #include <zlib.h>
-#include <inttypes.h>
+#include <cinttypes>
 #include "atscppapi/TransformationPlugin.h"
 #include "atscppapi/GzipDeflateTransformation.h"
 #include "logging_internal.h"

--- a/lib/atscppapi/src/GzipInflateTransformation.cc
+++ b/lib/atscppapi/src/GzipInflateTransformation.cc
@@ -24,7 +24,7 @@
 #include <cstring>
 #include <vector>
 #include <zlib.h>
-#include <inttypes.h>
+#include <cinttypes>
 #include "atscppapi/TransformationPlugin.h"
 #include "atscppapi/GzipInflateTransformation.h"
 #include "logging_internal.h"

--- a/lib/atscppapi/src/TransformationPlugin.cc
+++ b/lib/atscppapi/src/TransformationPlugin.cc
@@ -24,7 +24,7 @@
 
 #include <ts/ts.h>
 #include <cstddef>
-#include <inttypes.h>
+#include <cinttypes>
 #include "utils_internal.h"
 #include "logging_internal.h"
 #include "atscppapi/noncopyable.h"

--- a/lib/atscppapi/src/Url.cc
+++ b/lib/atscppapi/src/Url.cc
@@ -76,7 +76,7 @@ Url::getUrlString() const
     int length;
     char *memptr = TSUrlStringGet(state_->hdr_buf_, state_->url_loc_, &length);
     if (memptr && length) {
-      ret_str = std::string(memptr, length);
+      ret_str.assign(memptr, length);
       TSfree(memptr);
       LOG_DEBUG("Got URL [%s]", ret_str.c_str());
     } else {
@@ -95,7 +95,7 @@ Url::getPath() const
     int length;
     const char *memptr = TSUrlPathGet(state_->hdr_buf_, state_->url_loc_, &length);
     if (memptr && length) {
-      ret_str = std::string(memptr, length);
+      ret_str.assign(memptr, length);
     }
     LOG_DEBUG("Using path [%s]", ret_str.c_str());
   }
@@ -110,7 +110,7 @@ Url::getQuery() const
     int length;
     const char *memptr = TSUrlHttpQueryGet(state_->hdr_buf_, state_->url_loc_, &length);
     if (memptr && length) {
-      ret_str = std::string(memptr, length);
+      ret_str.assign(memptr, length);
     }
     LOG_DEBUG("Using query [%s]", ret_str.c_str());
   }
@@ -125,7 +125,7 @@ Url::getScheme() const
     int length;
     const char *memptr = TSUrlSchemeGet(state_->hdr_buf_, state_->url_loc_, &length);
     if (memptr && length) {
-      ret_str = std::string(memptr, length);
+      ret_str.assign(memptr, length);
     }
     LOG_DEBUG("Using scheme [%s]", ret_str.c_str());
   }
@@ -140,7 +140,7 @@ Url::getHost() const
     int length;
     const char *memptr = TSUrlHostGet(state_->hdr_buf_, state_->url_loc_, &length);
     if (memptr && length) {
-      ret_str = std::string(memptr, length);
+      ret_str.assign(memptr, length);
     }
     LOG_DEBUG("Using host [%s]", ret_str.c_str());
   }
@@ -193,7 +193,6 @@ Url::setScheme(const std::string &scheme)
 {
   if (!isInitialized()) {
     LOG_ERROR("Url %p not initialized", this);
-    ;
     return;
   }
 


### PR DESCRIPTION
A few things should be cleaned up in atscppapi.

 - CaseInsensitiveStringComparitor isn't used internally but it is exposed in a public API, so because we can't remove it we should change it to use strcasecmp() under the covers.
 - In several places we do:
    somestr = std::string(ptr, len);
  We should do:
    somestr.assign(ptr,len);
 - We use c style includes in a few places when we should use the c++ equivalents.