### PR TITLE
TS-4038: Redundant `isdigit(b)` in `LogFormat::parse_escape_string

### DIFF
--- a/proxy/logging/LogFormat.cc
+++ b/proxy/logging/LogFormat.cc
@@ -570,7 +570,7 @@ LogFormat::parse_escape_string(const char *str, int len)
   b = (unsigned char)str[start + 2];
   c = (unsigned char)str[start + 3];
 
-  if (isdigit(a) && isdigit(b) && isdigit(b)) {
+  if (isdigit(a) && isdigit(b)) {
     sum = (a - '0') * 64 + (b - '0') * 8 + (c - '0');
 
     if (sum == 0 || sum >= 255) {


### PR DESCRIPTION
Simple fix that shouldn't have any side effects since isdigit is not changing the value of b.

@bgaff 