### PR TITLE
TS-3072: Debug logging for single connection.

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -2276,7 +2276,13 @@ Diagnostic Logging Configuration
 
 .. ts:cv:: CONFIG proxy.config.diags.debug.enabled INT 0
 
-   Enables logging for diagnostic messages whose log level is `diag` or `debug`.
+   When set to 1, enables logging for diagnostic messages whose log level is `diag` or `debug`.
+
+   When set to 2, interprets the :ts:cv:`proxy.config.diags.debug.client_ip` setting determine whether diagnostic messages are logged.
+
+.. ts:cv:: CONFIG proxy.config.diags.debug.client_ip STRING NULL
+
+   if :ts:cv:`proxy.config.diags.debug.enabled` is set to 2, this value is tested against the source IP of the incoming connection.  If there is a match, all the diagnostic messages for that connection and the related outgoing connection will be logged.
 
 .. ts:cv:: CONFIG proxy.config.diags.debug.tags STRING http.*|dns.*
 

--- a/iocore/eventsystem/I_Continuation.h
+++ b/iocore/eventsystem/I_Continuation.h
@@ -39,6 +39,7 @@
 #include "ts/ink_platform.h"
 #include "ts/List.h"
 #include "I_Lock.h"
+#include "ts/ContFlags.h"
 
 class Continuation;
 class ContinuationQueue;
@@ -128,6 +129,12 @@ public:
   LINK(Continuation, link);
 
   /**
+    Contains values for debug_override and future flags that
+    needs to be thread local while this continuation is running
+  */
+  ContFlags control_flags;
+
+  /**
     Receives the event code and data for an Event.
 
     This function receives the event code and data for an event and
@@ -191,6 +198,8 @@ inline Continuation::Continuation(ProxyMutex *amutex)
 #endif
     mutex(amutex)
 {
+  // Pick up the control flags from the creating thread
+  this->control_flags.set_flags(get_cont_flags().get_flags());
 }
 
 #endif /*_Continuation_h_*/

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -36,6 +36,7 @@
 #include "I_NetVConnection.h"
 #include "P_UnixNetState.h"
 #include "P_Connection.h"
+#include "ts/Diags.h"
 
 class UnixNetVConnection;
 class NetHandler;
@@ -323,6 +324,7 @@ TS_INLINE void
 UnixNetVConnection::set_remote_addr()
 {
   ats_ip_copy(&remote_addr, &con.addr);
+  this->control_flags.set_flag(ContFlags::DEBUG_OVERRIDE, diags->test_override_ip(remote_addr));
 }
 
 TS_INLINE void

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -36,7 +36,6 @@
 #include "I_NetVConnection.h"
 #include "P_UnixNetState.h"
 #include "P_Connection.h"
-#include "ts/Diags.h"
 
 class UnixNetVConnection;
 class NetHandler;

--- a/iocore/net/UnixNet.cc
+++ b/iocore/net/UnixNet.cc
@@ -510,6 +510,8 @@ NetHandler::mainNetEvent(int event, Event *e)
 #if defined(USE_EDGE_TRIGGER)
   // UnixNetVConnection *
   while ((vc = read_ready_list.dequeue())) {
+    // Initialize the thread-local continuation flags
+    set_cont_flags(vc->control_flags);
     if (vc->closed)
       close_UnixNetVConnection(vc, trigger_event->ethread);
     else if (vc->read.enabled && vc->read.triggered)
@@ -526,6 +528,7 @@ NetHandler::mainNetEvent(int event, Event *e)
     }
   }
   while ((vc = write_ready_list.dequeue())) {
+    set_cont_flags(vc->control_flags);
     if (vc->closed)
       close_UnixNetVConnection(vc, trigger_event->ethread);
     else if (vc->write.enabled && vc->write.triggered)
@@ -543,6 +546,7 @@ NetHandler::mainNetEvent(int event, Event *e)
   }
 #else  /* !USE_EDGE_TRIGGER */
   while ((vc = read_ready_list.dequeue())) {
+    diags->set_override(vc->control.debug_override);
     if (vc->closed)
       close_UnixNetVConnection(vc, trigger_event->ethread);
     else if (vc->read.enabled && vc->read.triggered)
@@ -551,6 +555,7 @@ NetHandler::mainNetEvent(int event, Event *e)
       vc->ep.modify(-EVENTIO_READ);
   }
   while ((vc = write_ready_list.dequeue())) {
+    diags->set_override(vc->control.debug_override);
     if (vc->closed)
       close_UnixNetVConnection(vc, trigger_event->ethread);
     else if (vc->write.enabled && vc->write.triggered)

--- a/lib/ts/ContFlags.cc
+++ b/lib/ts/ContFlags.cc
@@ -1,0 +1,71 @@
+/** @file
+
+  A brief file description
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "ContFlags.h"
+
+static ink_thread_key init_thread_key();
+static inkcoreapi ink_thread_key flags_data_key = init_thread_key();
+
+static ink_thread_key
+init_thread_key()
+{
+  ink_thread_key_create(&flags_data_key, NULL);
+  return flags_data_key;
+}
+
+
+/* Set up a cont_flags entry for this threa */
+void
+init_cont_flags()
+{
+  ContFlags new_flags;
+  ink_thread_setspecific(flags_data_key, (void *)new_flags.get_flags());
+}
+
+void
+set_cont_flags(const ContFlags &flags)
+{
+  ink_thread_setspecific(flags_data_key, (void *)flags.get_flags());
+}
+
+void
+set_cont_flag(ContFlags::flags flag_bit, bool value)
+{
+  u_int64_t flags = (u_int64_t)ink_thread_getspecific(flags_data_key);
+  ContFlags new_flags(flags);
+  new_flags.set_flag(flag_bit, value);
+  ink_thread_setspecific(flags_data_key, (void *)new_flags.get_flags());
+}
+
+ContFlags
+get_cont_flags()
+{
+  return ContFlags((u_int64_t)ink_thread_getspecific(flags_data_key));
+}
+
+bool
+get_cont_flag(ContFlags::flags flag_bit)
+{
+  ContFlags flags((u_int64_t)ink_thread_getspecific(flags_data_key));
+  return flags.get_flag(flag_bit);
+}

--- a/lib/ts/ContFlags.h
+++ b/lib/ts/ContFlags.h
@@ -1,0 +1,93 @@
+/** @file
+
+  A brief file description
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+/****************************************************************************
+
+ ContFlags.h
+
+ Thread local storage for a set of flags that are updated based the continuation
+ currently running in the thread.  These flags are handy if the data is needed
+ as a "global" in parts of the code where the original net VC is not available.
+ Storing the flags in the void * of the thread key directly. I assume we are on
+ at least a 32 bit architecture, so the rawflags size is 32 bits.
+ ****************************************************************************/
+
+#ifndef _CONT_FLAGS_H
+#define _CONT_FLAGS_H
+
+#include "ink_thread.h"
+
+class ContFlags
+{
+public:
+  enum flags { DEBUG_OVERRIDE = 0, DISABLE_PLUGINS = 1, LAST_FLAG };
+
+  ContFlags() : raw_flags(0) {}
+  ContFlags(u_int32_t in_flags) : raw_flags(in_flags) {}
+  void
+  set_flags(u_int32_t new_flags)
+  {
+    raw_flags = new_flags;
+  }
+  ContFlags &operator=(ContFlags const &other)
+  {
+    this->set_flags(other.get_flags());
+    return *this;
+  }
+ 
+  u_int32_t
+  get_flags() const
+  {
+    return raw_flags;
+  }
+  void
+  set_flag(enum flags flag_bit, bool value)
+  {
+    if (flag_bit >= 0 && flag_bit < LAST_FLAG) {
+      if (value)
+        raw_flags |= (1 << flag_bit);
+      else
+        raw_flags &= ~(1 << flag_bit);
+    }
+  }
+  bool
+  get_flag(enum flags flag_bit) const
+  {
+    if (flag_bit >= 0 && flag_bit < LAST_FLAG) {
+      return (raw_flags & (1 << flag_bit)) != 0;
+    } else {
+      return false;
+    }
+  }
+
+private:
+  u_int32_t raw_flags;
+};
+
+void init_cont_flags();
+void set_cont_flags(const ContFlags &flags);
+void set_cont_flag(ContFlags::flags flag_bit, bool value);
+ContFlags get_cont_flags();
+bool get_cont_flag(ContFlags::flags flag_bit);
+
+#endif // _CONT_FLAGS_H

--- a/lib/ts/Diags.cc
+++ b/lib/ts/Diags.cc
@@ -45,7 +45,7 @@
 #include "ts/Diags.h"
 
 int diags_on_for_plugins = 0;
-bool DiagsConfigState::enabled[2] = {false, false};
+int DiagsConfigState::enabled[2] = {0, 0};
 
 // Global, used for all diagnostics
 inkcoreapi Diags *diags = NULL;

--- a/lib/ts/Makefile.am
+++ b/lib/ts/Makefile.am
@@ -49,6 +49,8 @@ libtsutil_la_SOURCES = \
   Bitops.h \
   ConsistentHash.cc \
   ConsistentHash.h \
+  ContFlags.cc \
+  ContFlags.h \
   Cryptohash.h \
   Diags.cc \
   Diags.h \

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -200,6 +200,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.diags.debug.tags", RECD_STRING, "http.*|dns.*", RECU_NULL, RR_NULL, RECC_NULL, NULL, RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.diags.debug.client_ip", RECD_STRING, NULL, RECU_NULL, RR_NULL, RECC_NULL, NULL, RECA_NULL} 
+  ,
   {RECT_CONFIG, "proxy.config.diags.action.enabled", RECD_INT, "0", RECU_NULL, RR_NULL, RECC_NULL, NULL, RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.diags.action.tags", RECD_STRING, NULL, RECU_NULL, RR_NULL, RECC_NULL, NULL, RECA_NULL}

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -332,6 +332,23 @@ public:
   }
 };
 
+void
+set_debug_ip(const char *ip_string)
+{
+  if (ip_string)
+    diags->debug_client_ip.load(ip_string);
+  else
+    diags->debug_client_ip.invalidate();
+}
+
+static int
+update_debug_client_ip(const char * /*name ATS_UNUSED */, RecDataT /* data_type ATS_UNUSED */, RecData data,
+                       void * /* data_type ATS_UNUSED */)
+{
+  set_debug_ip(data.rec_string);
+  return 0;
+}
+
 static int
 init_memory_tracker(const char *config_var, RecDataT /* type ATS_UNUSED */, RecData data, void * /* cookie ATS_UNUSED */)
 {
@@ -1746,6 +1763,13 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   eventProcessor.schedule_every(new DiagsLogContinuation, HRTIME_SECOND, ET_TASK);
   REC_RegisterConfigUpdateFunc("proxy.config.dump_mem_info_frequency", init_memory_tracker, NULL);
   init_memory_tracker(NULL, RECD_NULL, RecData(), NULL);
+
+  char *p = REC_ConfigReadString("proxy.config.diags.debug.client_ip");
+  if (p) {
+    // Translate string to IpAddr
+    set_debug_ip(p);
+  }
+  REC_RegisterConfigUpdateFunc("proxy.config.diags.debug.client_ip", update_debug_client_ip, NULL);
 
   // log initialization moved down
 

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -5619,6 +5619,9 @@ HttpSM::attach_server_session(HttpServerSession *s)
   hsm_release_assert(s->state == HSS_ACTIVE);
   server_session = s;
   server_transact_count = server_session->transact_count++;
+  // Propagate the per client IP debugging
+  if (ua_session)
+    s->get_netvc()->control_flags = get_cont_flags();
 
   // Set the mutex so that we have something to update
   //   stats with

--- a/proxy/shared/DiagsConfig.cc
+++ b/proxy/shared/DiagsConfig.cc
@@ -78,7 +78,7 @@ DiagsConfig::reconfigure_diags()
 
   e = (int)REC_readInteger("proxy.config.diags.debug.enabled", &found);
   if (e && found)
-    c.enabled[DiagsTagType_Debug] = 1; // implement OR logic
+    c.enabled[DiagsTagType_Debug] = e; // implement OR logic
   all_found = all_found && found;
 
   e = (int)REC_readInteger("proxy.config.diags.action.enabled", &found);


### PR DESCRIPTION
Proposed changes to enable per-client-ip specification for debug messages.  A version of this code has been running in our production for the past month.  We are able to capture debug messages from the start of the TCP connection.