### PR TITLE
TS-4043 Prevent bogus FQDN characters in host header

### DIFF
--- a/proxy/hdrs/HTTP.cc
+++ b/proxy/hdrs/HTTP.cc
@@ -161,6 +161,14 @@ is_digit(char c)
   return ((c <= '9') && (c >= '0'));
 }
 
+// test to see if a character is a valid character for a host in a URI according to
+// RFC 2396
+inline static int
+is_host_char(char c)
+{
+	return (ParseRules::is_alpha(c) || ParseRules::is_digit(c) || (c == '-') || (c == '.'));
+}
+
 /***********************************************************************
  *                                                                     *
  *                         M A I N    C O D E                          *
@@ -1124,8 +1132,13 @@ validate_hdr_host(HTTPHdrImpl *hh)
           if (port.size() > 5)
             return PARSE_ERROR;
           int port_i = ink_atoi(port.data(), port.size());
-          if (port.size() > 5 || port_i >= 65536 || port_i <= 0)
+          if (port_i >= 65536 || port_i <= 0)
             return PARSE_ERROR;
+        }
+        while (addr && PARSE_DONE == ret) {
+          if (!(is_host_char(*addr)))
+            return PARSE_ERROR;
+          ++addr;
         }
         while (rest && PARSE_DONE == ret) {
           if (!ParseRules::is_ws(*rest))

--- a/proxy/hdrs/HTTP.cc
+++ b/proxy/hdrs/HTTP.cc
@@ -162,11 +162,13 @@ is_digit(char c)
 }
 
 // test to see if a character is a valid character for a host in a URI according to
-// RFC 2396
+// RFC 3986 and RFC 1034
 inline static int
 is_host_char(char c)
 {
-	return (ParseRules::is_alpha(c) || ParseRules::is_digit(c) || (c == '-') || (c == '.'));
+	return (ParseRules::is_alnum(c) || (c == '-') || (c == '.')
+			|| (c == '[') || (c == ']') || (c == '_') || (c == ':') 
+			|| (c == '~') || (c == '%'));
 }
 
 /***********************************************************************

--- a/proxy/hdrs/HTTP.h
+++ b/proxy/hdrs/HTTP.h
@@ -29,6 +29,7 @@
 #include "ts/INK_MD5.h"
 #include "MIME.h"
 #include "URL.h"
+#include "ts/TsBuffer.h"
 
 #include "ts/ink_apidefs.h"
 
@@ -454,6 +455,7 @@ void http_parser_clear(HTTPParser *parser);
 MIMEParseResult http_parser_parse_req(HTTPParser *parser, HdrHeap *heap, HTTPHdrImpl *hh, const char **start, const char *end,
                                       bool must_copy_strings, bool eof);
 MIMEParseResult validate_hdr_host(HTTPHdrImpl *hh);
+bool validate_hdr_field(ts::ConstBuffer &addr);
 MIMEParseResult http_parser_parse_resp(HTTPParser *parser, HdrHeap *heap, HTTPHdrImpl *hh, const char **start, const char *end,
                                        bool must_copy_strings, bool eof);
 


### PR DESCRIPTION
Validate the host header string to prevent malformed hostnames from being let in.