### PR TITLE
TS-4050 - Trafficserver is crashing when buckets=0 is configured in cache_promote plugin

### DIFF
--- a/plugins/experimental/cache_promote/cache_promote.cc
+++ b/plugins/experimental/cache_promote/cache_promote.cc
@@ -256,7 +256,7 @@ public:
     map_it = _map.find(&hash);
     if (_map.end() != map_it) {
       // We have an entry in the LRU
-      TSReleaseAssert(_list.size() > 0);
+      TSReleaseAssert(_list.size() > 0); // mismatch in the LRUs hash and list
       if (++(map_it->second->second) >= _hits) {
         // Promoted! Cleanup the LRU, and signal success. Save the promoted entry on the freelist.
         TSDebug(PLUGIN_NAME, "saving the LRUEntry to the freelist");

--- a/plugins/experimental/cache_promote/cache_promote.cc
+++ b/plugins/experimental/cache_promote/cache_promote.cc
@@ -256,22 +256,17 @@ public:
     map_it = _map.find(&hash);
     if (_map.end() != map_it) {
       // We have an entry in the LRU
+      TSReleaseAssert(_list.size() > 0);
       if (++(map_it->second->second) >= _hits) {
         // Promoted! Cleanup the LRU, and signal success. Save the promoted entry on the freelist.
         TSDebug(PLUGIN_NAME, "saving the LRUEntry to the freelist");
-        // Check if list is not empty
-        if (!_list.empty()) {
-          _freelist.splice(_freelist.begin(), _list, map_it->second);
-        }
+        _freelist.splice(_freelist.begin(), _list, map_it->second);
         _map.erase(map_it->first);
         ret = true;
       } else {
         // It's still not promoted, make sure it's moved to the front of the list
         TSDebug(PLUGIN_NAME, "still not promoted, got %d hits so far", map_it->second->second);
-        // Check if list is not empty
-        if (!_list.empty()) {
-          _list.splice(_list.begin(), _list, map_it->second);
-        }
+        _list.splice(_list.begin(), _list, map_it->second);
       }
     } else {
       // New LRU entry for the URL, try to repurpose the list entry as much as possible


### PR DESCRIPTION
Fix trafficserver crash when buckets=0 is configured in cache_promote plugin and Set buckets default value to be 10