### PR TITLE
TS-4054 Incorrect ink_assert behavior in Diags.cc

### DIFF
--- a/lib/ts/Diags.cc
+++ b/lib/ts/Diags.cc
@@ -154,7 +154,8 @@ Diags::Diags(const char *bdt, const char *bat, BaseLogFile *_diags_log)
   stdout_log->open_file(); // should never fail
   stderr_log->open_file(); // should never fail
 
-  setup_diagslog(_diags_log);
+  if (setup_diagslog(_diags_log))
+    diags_log = _diags_log;
 
   //////////////////////////////////////////////////////////////////
   // start off with empty tag tables, will build in reconfigure() //
@@ -586,25 +587,25 @@ Diags::error_va(DiagsLevel level, const char *file, const char *func, const int 
 
 /*
  * Sets up and error handles the given BaseLogFile object to work
- * with this instance of Diags
+ * with this instance of Diags.
+ *
+ * Returns true on success, false otherwise
  */
-void
+bool
 Diags::setup_diagslog(BaseLogFile *blf)
 {
-  // We don't want to ink_assert here because the correct behavior is to just
-  // do nothing, not crash TS
-  if (blf == NULL)
-    return;
+  bool retval = false;
 
-  if (blf->open_file() != BaseLogFile::LOG_FILE_NO_ERROR) {
-    delete blf;
-
-    log_log_error("Could not open diags log file: %s\n", strerror(errno));
-    return;
+  if (blf != NULL) {
+    if (blf->open_file() == BaseLogFile::LOG_FILE_NO_ERROR) {
+      log_log_trace("Exiting setup_diagslog, name=%s, this=%p\n", blf->get_name(), this);
+      retval = true;
+    } else {
+      log_log_error("Could not open diags log file: %s\n", strerror(errno));
+      delete blf;
+    }
   }
-
-  diags_log = blf;
-  log_log_trace("Exiting setup_diagslog, name=%s, this=%p\n", blf->get_name(), this);
+  return retval;
 }
 
 void
@@ -661,8 +662,11 @@ Diags::should_roll_diagslog()
         if (diags_log->roll()) {
           char *oldname = ats_strdup(diags_log->get_name());
           log_log_trace("in should_roll_logs() for diags.log, oldname=%s\n", oldname);
-          delete diags_log;
-          setup_diagslog(new BaseLogFile(oldname));
+          BaseLogFile *n = new BaseLogFile(oldname);
+          if (setup_diagslog(n)) {
+            delete diags_log;
+            diags_log = n;
+          }
           ats_free(oldname);
           ret_val = true;
         }
@@ -675,8 +679,11 @@ Diags::should_roll_diagslog()
           diagslog_time_last_roll = now;
           char *oldname = ats_strdup(diags_log->get_name());
           log_log_trace("in should_roll_logs() for diags.log, oldname=%s\n", oldname);
-          delete diags_log;
-          setup_diagslog(new BaseLogFile(oldname));
+          BaseLogFile *n = new BaseLogFile(oldname);
+          if (setup_diagslog(n)) {
+            delete diags_log;
+            diags_log = n;
+          }
           ats_free(oldname);
           ret_val = true;
         }

--- a/lib/ts/Diags.cc
+++ b/lib/ts/Diags.cc
@@ -593,9 +593,8 @@ Diags::setup_diagslog(BaseLogFile *blf)
 {
   // We don't want to ink_assert here because the correct behavior is to just
   // do nothing, not crash TS
-  if (blf == NULL) {
+  if (blf == NULL)
     return;
-  }
 
   if (blf->open_file() != BaseLogFile::LOG_FILE_NO_ERROR) {
     delete blf;

--- a/lib/ts/Diags.cc
+++ b/lib/ts/Diags.cc
@@ -591,9 +591,13 @@ Diags::error_va(DiagsLevel level, const char *file, const char *func, const int 
 void
 Diags::setup_diagslog(BaseLogFile *blf)
 {
-  ink_assert(diags_log == NULL);
+  // We don't want to ink_assert here because the correct behavior is to just
+  // do nothing, not crash TS
+  if (blf == NULL) {
+    return;
+  }
 
-  if (blf != NULL && blf->open_file() != BaseLogFile::LOG_FILE_NO_ERROR) {
+  if (blf->open_file() != BaseLogFile::LOG_FILE_NO_ERROR) {
     delete blf;
 
     log_log_error("Could not open diags log file: %s\n", strerror(errno));

--- a/lib/ts/Diags.h
+++ b/lib/ts/Diags.h
@@ -115,9 +115,7 @@ public:
   }
 
   SrcLoc(const SrcLoc &rhs) : file(rhs.file), func(rhs.func), line(rhs.line) {}
-
   SrcLoc(const char *_file, const char *_func, int _line) : file(_file), func(_func), line(_line) {}
-
   SrcLoc &operator=(const SrcLoc &rhs)
   {
     this->file = rhs.file;
@@ -272,7 +270,7 @@ private:
   time_t outputlog_time_last_roll;
   time_t diagslog_time_last_roll;
 
-  void setup_diagslog(BaseLogFile *blf);
+  bool setup_diagslog(BaseLogFile *blf);
   bool rebind_stdout(int new_fd);
   bool rebind_stderr(int new_fd);
   void


### PR DESCRIPTION
`ink_assert(diags_log == NULL)` is incorrect since there are times
when `blf` correctly has the value NULL. In that case, we would
like for the function to do nothing and return early versus crash
ATS via an assert. That is to say, semantically an early return is
more clear than an assert.