### PR TITLE
TS-4052: Remove use of deprecated std::auto_ptr.

### DIFF
--- a/lib/atscppapi/src/include/atscppapi/shared_ptr.h
+++ b/lib/atscppapi/src/include/atscppapi/shared_ptr.h
@@ -42,8 +42,10 @@ namespace atscppapi
  */
 #if HAVE_STD_SHARED_PTR
 using std::shared_ptr;
+using std::unique_ptr;
 #else
 using std::tr1::shared_ptr;
+using std::tr1::unique_ptr;
 #endif
 
 } /* atscppapi */

--- a/plugins/experimental/multiplexer/Makefile.am
+++ b/plugins/experimental/multiplexer/Makefile.am
@@ -16,7 +16,7 @@
 
 include $(top_srcdir)/build/plugins.mk
 
-AM_CPPFLAGS += -DPLUGIN_TAG=\"multiplexer\"
+AM_CPPFLAGS += -DPLUGIN_TAG=\"multiplexer\" -I $(top_srcdir)/lib/atscppapi/src/include
 
 pkglib_LTLIBRARIES = multiplexer.la
 

--- a/plugins/experimental/multiplexer/dispatch.cc
+++ b/plugins/experimental/multiplexer/dispatch.cc
@@ -47,7 +47,7 @@ Request::Request(const std::string &h, const TSMBuffer b, const TSMLoc l)
   assert(length == TSIOBufferReaderAvail(io->reader));
 }
 
-Request::Request(const Request &r) : host(r.host), length(r.length), io(const_cast<Request &>(r).io)
+Request::Request(const Request &r) : host(r.host), length(r.length), io(const_cast<Request &>(r).io.release())
 {
   assert(!host.empty());
   assert(length > 0);
@@ -59,7 +59,7 @@ Request &Request::operator=(const Request &r)
 {
   host = r.host;
   length = r.length;
-  io = const_cast<Request &>(r).io;
+  io.reset(const_cast<Request &>(r).io.release());
   assert(!host.empty());
   assert(length > 0);
   assert(io.get() != NULL);

--- a/plugins/experimental/multiplexer/dispatch.h
+++ b/plugins/experimental/multiplexer/dispatch.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <ts/ts.h>
 #include <vector>
+#include <atscppapi/shared_ptr.h>
 
 #include "ts.h"
 
@@ -51,7 +52,7 @@ typedef std::vector<std::string> Origins;
 struct Request {
   std::string host;
   int length;
-  std::auto_ptr<ats::io::IO> io;
+  atscppapi::unique_ptr<ats::io::IO> io;
 
   Request(const std::string &, const TSMBuffer, const TSMLoc);
   Request(const Request &);


### PR DESCRIPTION
Rather than figuring out how to integrate `std::unique_ptr` I just tweaked the CPP API and used that.