### PR TITLE
TS-4056: remove alloc_cache from NetAccept

### DIFF
--- a/iocore/net/P_NetAccept.h
+++ b/iocore/net/P_NetAccept.h
@@ -80,7 +80,6 @@ struct NetAcceptAction : public Action, public RefCountObj {
 struct NetAccept : public Continuation {
   ink_hrtime period;
   Server server;
-  void *alloc_cache;
   AcceptFunctionPtr accept_fn;
   int ifd;
   bool callback_on_open;

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -117,6 +117,9 @@ net_accept(NetAccept *na, void *ep, bool blockable)
     NET_SUM_GLOBAL_DYN_STAT(net_connections_currently_open_stat, 1);
     vc->id = net_next_connection_number();
     vc->con = con;
+    // the con.fd has copy to vc->con.fd
+    // set con.fd to NO_FD to avoid con.fd closed by ~Connection()
+    con.fd = NO_FD;
     vc->submit_time = Thread::get_hrtime();
     ats_ip_copy(&vc->server_addr, &vc->con.addr);
     vc->mutex = new_ProxyMutex();

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -92,7 +92,7 @@ net_accept(NetAccept *na, void *ep, bool blockable)
   // do-while for accepting all the connections
   // added by YTS Team, yamsat
   do {
-    if ((res = na->server.accept(&vc->con)) < 0) {
+    if ((res = na->server.accept(&con)) < 0) {
       if (res == -EAGAIN || res == -ECONNABORTED || res == -EPIPE)
         goto Ldone;
       if (na->server.fd != NO_FD && !na->action_->cancelled) {


### PR DESCRIPTION
remove alloc_cache from NetAccept & net_accept() to avoid mem leak on ~NetAccept().
add a condition check for vc==NULL follow allocate_vc().