### PR TITLE
TS-4057 Missing check for system call error

### DIFF
--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -1420,7 +1420,7 @@ static int
 elevating_open(char const *path, unsigned int flags, unsigned int fperms)
 {
   int fd = open(path, flags, fperms);
-  if (fd < 0 && EPERM == errno) {
+  if (fd < 0 && (EPERM == errno || EACCES == errno)) {
     ElevateAccess access;
     fd = open(path, flags, fperms);
   }


### PR DESCRIPTION
EPERM and EACCES are often consfused for each other.

EPERM means "operation not permitted", ie doing this would not be
in your best interest.
EACCES means "permission denied", meaning if you run this command
as sudo it will work.

Opening a log file will _probably_ never be bad, and even if the
system says so, it shouldn't be bad. So in this case it doesn't
hurt to leave both conditions in here.