### PR TITLE
TS-4055: InactivityCop callback SM with INACTIVE_TIMEOUT before NET_EVENT_OPEN

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -5271,7 +5271,7 @@ HttpSM::handle_server_setup_error(int event, void *data)
     // In case of TIMEOUT, the iocore sends back
     // server_entry->read_vio instead of the write_vio
     // if (vio->op == VIO::WRITE && vio->ndone == 0) {
-    if (server_entry->write_vio->nbytes > 0 && server_entry->write_vio->ndone == 0) {
+    if (server_entry->write_vio && server_entry->write_vio->nbytes > 0 && server_entry->write_vio->ndone == 0) {
       t_state.current.state = HttpTransact::CONNECTION_ERROR;
     } else {
       t_state.current.state = HttpTransact::INACTIVE_TIMEOUT;


### PR DESCRIPTION
for explain:

on a heavy load system, HttpSM create a connection to OS.

First, a TCP-SYN packet send to OS.
then, InactivityCop::check_activity callbacked before TCP-SYN/ACK send back from OS.
then, UnixNetVConnection::mainEvent(INACTIVE_TIMEOUT) is callbacked
then, HttpSM::main_handler(INACTIVE_TIMEOUT) is callbacked
...
then, HttpSM::handle_server_setup_error(INACTIVE_TIMEOUT) is callbacked

currently, the write_vio still not set, thus segment fault.