### PR TITLE
TS-4070 RemapProcessor Forward Mapping w/ Recv Port failing w/ TS-2157

### DIFF
--- a/proxy/http/remap/RemapProcessor.cc
+++ b/proxy/http/remap/RemapProcessor.cc
@@ -87,8 +87,8 @@ RemapProcessor::setup_for_remap(HttpTransact::State *s)
   Debug("url_rewrite", "[lookup] attempting %s lookup", proxy_request ? "proxy" : "normal");
 
   if (rewrite_table->num_rules_forward_with_recv_port) {
-    Debug("url_rewrite", "[lookup] forward mappings with recv port found; Using recv port %d", s->client_info.src_addr.port());
-    if (rewrite_table->forwardMappingWithRecvPortLookup(request_url, s->client_info.src_addr.host_order_port(), request_host,
+    Debug("url_rewrite", "[lookup] forward mappings with recv port found; Using recv port %d", s->client_info.dst_addr.port());
+    if (rewrite_table->forwardMappingWithRecvPortLookup(request_url, s->client_info.dst_addr.port(), request_host,
                                                         request_host_len, s->url_map)) {
       Debug("url_rewrite", "Found forward mapping with recv port");
       mapping_found = true;


### PR DESCRIPTION
…-2157 changes

During the rework of RemapProcessor.cc, RemapProcessor::setup_for_remap()
as part of the TS-2157 changeset, the port access API appears to have been
incorrectly modified to use the client_info.src_addr.host_order_port() API
[source port, host order] instead of the client_info.dst_addr.port()
[destination/receive port, network order] API. This caused port based
remapping based on the receive port to fail with ATS 6.0.0.