### PR TITLE
TS-4056: Remove cached netVC from NetAccept

### DIFF
--- a/iocore/net/P_NetAccept.h
+++ b/iocore/net/P_NetAccept.h
@@ -80,7 +80,6 @@ struct NetAcceptAction : public Action, public RefCountObj {
 struct NetAccept : public Continuation {
   ink_hrtime period;
   Server server;
-  void *alloc_cache;
   AcceptFunctionPtr accept_fn;
   int ifd;
   bool callback_on_open;


### PR DESCRIPTION
This is an updated, rebased version of PR 366[1].

[1] https://github.com/apache/trafficserver/pull/366