### PR TITLE
TS-4089: Fixed coverity issues in parent selection.

### DIFF
--- a/proxy/ParentConsistentHash.cc
+++ b/proxy/ParentConsistentHash.cc
@@ -155,7 +155,7 @@ ParentConsistentHash::selectParent(const ParentSelectionPolicy *policy, bool fir
           parentRetry = true;
           // make sure that the proper state is recorded in the result structure
           // so that markParentUp() finds the proper record.
-          result->last_parent = prtmp->idx;
+          result->last_parent = pRec->idx;
           result->last_lookup = last_lookup;
           result->retry = parentRetry;
           result->r = PARENT_SPECIFIED;

--- a/proxy/ParentSelection.h
+++ b/proxy/ParentSelection.h
@@ -199,7 +199,7 @@ public:
   ParentRecord *DefaultParent;
   explicit ParentConfigParams(P_table *_parent_table);
   ParentSelectionPolicy *policy;
-  ~ParentConfigParams(){};
+  ~ParentConfigParams() { delete policy; }
 
   bool apiParentExists(HttpRequestData *rdata);
   void findParent(HttpRequestData *rdata, ParentResult *result);


### PR DESCRIPTION
Updated the ParentConfigParams destructor to free the memory pointed at by policy and corrected the null pointer issue in ParentConsistentHash.cc:158.