### PR TITLE
Add TSSslContextCreate method

### DIFF
--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -117,6 +117,9 @@ extern RecRawStatBlock *ssl_rsb;
 // Create a default SSL server context.
 SSL_CTX *SSLDefaultServerContext();
 
+// Create a new SSL server context fully configured.
+SSL_CTX *SSLCreateServerContext(const SSLConfigParams *params);
+
 // Initialize the SSL library.
 void SSLInitializeLibrary();
 

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1257,6 +1257,123 @@ SSLCheckServerCertNow(X509 *cert, const char *certname)
 } /* CheckServerCertNow() */
 
 
+static char *
+asn1_strdup(ASN1_STRING *s)
+{
+  // Make sure we have an 8-bit encoding.
+  ink_assert(ASN1_STRING_type(s) == V_ASN1_IA5STRING || ASN1_STRING_type(s) == V_ASN1_UTF8STRING ||
+             ASN1_STRING_type(s) == V_ASN1_PRINTABLESTRING || ASN1_STRING_type(s) == V_ASN1_T61STRING);
+
+  return ats_strndup((const char *)ASN1_STRING_data(s), ASN1_STRING_length(s));
+}
+
+// Given a certificate and it's corresponding SSL_CTX context, insert hash
+// table aliases for subject CN and subjectAltNames DNS without wildcard,
+// insert trie aliases for those with wildcard.
+static bool
+ssl_index_certificate(SSLCertLookup *lookup, SSLCertContext const &cc, X509 *cert, const char *certname)
+{
+  X509_NAME *subject = NULL;
+  bool inserted = false;
+
+  if (NULL == cert) {
+    Error("Failed to load certificate %s", certname);
+    lookup->is_valid = false;
+    return false;
+  }
+
+  // Insert a key for the subject CN.
+  subject = X509_get_subject_name(cert);
+  ats_scoped_str subj_name;
+  if (subject) {
+    int pos = -1;
+    for (;;) {
+      pos = X509_NAME_get_index_by_NID(subject, NID_commonName, pos);
+      if (pos == -1) {
+        break;
+      }
+
+      X509_NAME_ENTRY *e = X509_NAME_get_entry(subject, pos);
+      ASN1_STRING *cn = X509_NAME_ENTRY_get_data(e);
+      subj_name = asn1_strdup(cn);
+
+      Debug("ssl", "mapping '%s' to certificate %s", (const char *)subj_name, certname);
+      if (lookup->insert(subj_name, cc) >= 0)
+        inserted = true;
+    }
+  }
+
+#if HAVE_OPENSSL_TS_H
+  // Traverse the subjectAltNames (if any) and insert additional keys for the SSL context.
+  GENERAL_NAMES *names = (GENERAL_NAMES *)X509_get_ext_d2i(cert, NID_subject_alt_name, NULL, NULL);
+  if (names) {
+    unsigned count = sk_GENERAL_NAME_num(names);
+    for (unsigned i = 0; i < count; ++i) {
+      GENERAL_NAME *name;
+
+      name = sk_GENERAL_NAME_value(names, i);
+      if (name->type == GEN_DNS) {
+        ats_scoped_str dns(asn1_strdup(name->d.dNSName));
+        // only try to insert if the alternate name is not the main name
+        if (strcmp(dns, subj_name) != 0) {
+          Debug("ssl", "mapping '%s' to certificates %s", (const char *)dns, certname);
+          if (lookup->insert(dns, cc) >= 0)
+            inserted = true;
+        }
+      }
+    }
+
+    GENERAL_NAMES_free(names);
+  }
+#endif // HAVE_OPENSSL_TS_H
+  return inserted;
+}
+
+// This callback function is executed while OpenSSL processes the SSL
+// handshake and does SSL record layer stuff.  It's used to trap
+// client-initiated renegotiations and update cipher stats
+static void
+ssl_callback_info(const SSL *ssl, int where, int ret)
+{
+  Debug("ssl", "ssl_callback_info ssl: %p where: %d ret: %d", ssl, where, ret);
+  SSLNetVConnection *netvc = (SSLNetVConnection *)SSL_get_app_data(ssl);
+
+  if ((where & SSL_CB_ACCEPT_LOOP) && netvc->getSSLHandShakeComplete() == true &&
+      SSLConfigParams::ssl_allow_client_renegotiation == false) {
+    int state = SSL_get_state(ssl);
+
+    if (state == SSL3_ST_SR_CLNT_HELLO_A || state == SSL23_ST_SR_CLNT_HELLO_A) {
+      netvc->setSSLClientRenegotiationAbort(true);
+      Debug("ssl", "ssl_callback_info trying to renegotiate from the client");
+    }
+  }
+  if (where & SSL_CB_HANDSHAKE_DONE) {
+    // handshake is complete
+    const SSL_CIPHER *cipher = SSL_get_current_cipher(ssl);
+    if (cipher) {
+      const char *cipherName = SSL_CIPHER_get_name(cipher);
+      // lookup index of stat by name and incr count
+      InkHashTableValue data;
+      if (ink_hash_table_lookup(ssl_cipher_name_table, cipherName, &data)) {
+        SSL_INCREMENT_DYN_STAT((intptr_t)data);
+      }
+    }
+  }
+}
+
+static void
+ssl_set_handshake_callbacks(SSL_CTX *ctx)
+{
+#if TS_USE_TLS_SNI
+// Make sure the callbacks are set
+#if TS_USE_CERT_CB
+  SSL_CTX_set_cert_cb(ctx, ssl_cert_callback, NULL);
+#else
+  SSL_CTX_set_tlsext_servername_callback(ctx, ssl_servername_callback);
+#endif
+#endif
+}
+
 SSL_CTX *
 SSLInitServerContext(const SSLConfigParams *params, const ssl_user_config &sslMultCertSettings, Vec<X509 *> &certList)
 {
@@ -1520,140 +1637,7 @@ SSLInitServerContext(const SSLConfigParams *params, const ssl_user_config &sslMu
   if (!ssl_context_enable_dhe(params->dhparamsFile, ctx)) {
     goto fail;
   }
-  return ssl_context_enable_ecdh(ctx);
-
-fail:
-  SSL_CLEAR_PW_REFERENCES(ud, ctx)
-  SSL_CTX_free(ctx);
-  for (unsigned int i = 0; i < certList.length(); i++) {
-    X509_free(certList[i]);
-  }
-
-  return NULL;
-}
-
-static char *
-asn1_strdup(ASN1_STRING *s)
-{
-  // Make sure we have an 8-bit encoding.
-  ink_assert(ASN1_STRING_type(s) == V_ASN1_IA5STRING || ASN1_STRING_type(s) == V_ASN1_UTF8STRING ||
-             ASN1_STRING_type(s) == V_ASN1_PRINTABLESTRING || ASN1_STRING_type(s) == V_ASN1_T61STRING);
-
-  return ats_strndup((const char *)ASN1_STRING_data(s), ASN1_STRING_length(s));
-}
-
-// Given a certificate and it's corresponding SSL_CTX context, insert hash
-// table aliases for subject CN and subjectAltNames DNS without wildcard,
-// insert trie aliases for those with wildcard.
-static bool
-ssl_index_certificate(SSLCertLookup *lookup, SSLCertContext const &cc, X509 *cert, const char *certname)
-{
-  X509_NAME *subject = NULL;
-  bool inserted = false;
-
-  if (NULL == cert) {
-    Error("Failed to load certificate %s", certname);
-    lookup->is_valid = false;
-    return false;
-  }
-
-  // Insert a key for the subject CN.
-  subject = X509_get_subject_name(cert);
-  ats_scoped_str subj_name;
-  if (subject) {
-    int pos = -1;
-    for (;;) {
-      pos = X509_NAME_get_index_by_NID(subject, NID_commonName, pos);
-      if (pos == -1) {
-        break;
-      }
-
-      X509_NAME_ENTRY *e = X509_NAME_get_entry(subject, pos);
-      ASN1_STRING *cn = X509_NAME_ENTRY_get_data(e);
-      subj_name = asn1_strdup(cn);
-
-      Debug("ssl", "mapping '%s' to certificate %s", (const char *)subj_name, certname);
-      if (lookup->insert(subj_name, cc) >= 0)
-        inserted = true;
-    }
-  }
-
-#if HAVE_OPENSSL_TS_H
-  // Traverse the subjectAltNames (if any) and insert additional keys for the SSL context.
-  GENERAL_NAMES *names = (GENERAL_NAMES *)X509_get_ext_d2i(cert, NID_subject_alt_name, NULL, NULL);
-  if (names) {
-    unsigned count = sk_GENERAL_NAME_num(names);
-    for (unsigned i = 0; i < count; ++i) {
-      GENERAL_NAME *name;
-
-      name = sk_GENERAL_NAME_value(names, i);
-      if (name->type == GEN_DNS) {
-        ats_scoped_str dns(asn1_strdup(name->d.dNSName));
-        // only try to insert if the alternate name is not the main name
-        if (strcmp(dns, subj_name) != 0) {
-          Debug("ssl", "mapping '%s' to certificates %s", (const char *)dns, certname);
-          if (lookup->insert(dns, cc) >= 0)
-            inserted = true;
-        }
-      }
-    }
-
-    GENERAL_NAMES_free(names);
-  }
-#endif // HAVE_OPENSSL_TS_H
-  return inserted;
-}
-
-// This callback function is executed while OpenSSL processes the SSL
-// handshake and does SSL record layer stuff.  It's used to trap
-// client-initiated renegotiations and update cipher stats
-static void
-ssl_callback_info(const SSL *ssl, int where, int ret)
-{
-  Debug("ssl", "ssl_callback_info ssl: %p where: %d ret: %d", ssl, where, ret);
-  SSLNetVConnection *netvc = (SSLNetVConnection *)SSL_get_app_data(ssl);
-
-  if ((where & SSL_CB_ACCEPT_LOOP) && netvc->getSSLHandShakeComplete() == true &&
-      SSLConfigParams::ssl_allow_client_renegotiation == false) {
-    int state = SSL_get_state(ssl);
-
-    if (state == SSL3_ST_SR_CLNT_HELLO_A || state == SSL23_ST_SR_CLNT_HELLO_A) {
-      netvc->setSSLClientRenegotiationAbort(true);
-      Debug("ssl", "ssl_callback_info trying to renegotiate from the client");
-    }
-  }
-  if (where & SSL_CB_HANDSHAKE_DONE) {
-    // handshake is complete
-    const SSL_CIPHER *cipher = SSL_get_current_cipher(ssl);
-    if (cipher) {
-      const char *cipherName = SSL_CIPHER_get_name(cipher);
-      // lookup index of stat by name and incr count
-      InkHashTableValue data;
-      if (ink_hash_table_lookup(ssl_cipher_name_table, cipherName, &data)) {
-        SSL_INCREMENT_DYN_STAT((intptr_t)data);
-      }
-    }
-  }
-}
-
-static void
-ssl_set_handshake_callbacks(SSL_CTX *ctx)
-{
-#if TS_USE_TLS_SNI
-// Make sure the callbacks are set
-#if TS_USE_CERT_CB
-  SSL_CTX_set_cert_cb(ctx, ssl_cert_callback, NULL);
-#else
-  SSL_CTX_set_tlsext_servername_callback(ctx, ssl_servername_callback);
-#endif
-#endif
-}
-
-SSL_CTX *
-SSLCreateServerContext(const SSLConfigParams *params) {
-  Vec<X509 *> cert_list;
-  const ssl_user_config sslMultCertSettings;
-  SSL_CTX *ctx = SSLInitServerContext(params, sslMultCertSettings, cert_list);
+  ssl_context_enable_ecdh(ctx);
 
   // The certificate callbacks are set by the caller only
   // for the default certificate
@@ -1666,9 +1650,6 @@ SSLCreateServerContext(const SSLConfigParams *params) {
 #if TS_USE_TLS_ALPN
   SSL_CTX_set_alpn_select_cb(ctx, SSLNetVConnection::select_next_protocol, NULL);
 #endif /* TS_USE_TLS_ALPN */
-
-  // TODO: Allow control over tickets and ticket path when using SSLCreateServerContext
-  ssl_context_enable_tickets(ctx, NULL);
 
 #ifdef HAVE_OPENSSL_OCSP_STAPLING
   if (SSLConfigParams::ssl_ocsp_enabled) {
@@ -1683,11 +1664,27 @@ SSLCreateServerContext(const SSLConfigParams *params) {
   }
 #endif /* HAVE_OPENSSL_OCSP_STAPLING */
 
-
   if (SSLConfigParams::init_ssl_ctx_cb) {
     SSLConfigParams::init_ssl_ctx_cb(ctx, true);
   }
+
   return ctx;
+
+fail:
+  SSL_CLEAR_PW_REFERENCES(ud, ctx)
+  SSL_CTX_free(ctx);
+  for (unsigned int i = 0; i < certList.length(); i++) {
+    X509_free(certList[i]);
+  }
+
+  return NULL;
+}
+
+SSL_CTX *
+SSLCreateServerContext(const SSLConfigParams *params) {
+  const ssl_user_config sslMultCertSettings;
+  Vec<X509 *> cert_list;
+  return SSLInitServerContext(params, sslMultCertSettings, cert_list);
 }
 
 static SSL_CTX *
@@ -1702,19 +1699,6 @@ ssl_store_ssl_context(const SSLConfigParams *params, SSLCertLookup *lookup, cons
     lookup->is_valid = false;
     return ctx;
   }
-
-  // The certificate callbacks are set by the caller only
-  // for the default certificate
-
-  SSL_CTX_set_info_callback(ctx, ssl_callback_info);
-
-#if TS_USE_TLS_NPN
-  SSL_CTX_set_next_protos_advertised_cb(ctx, SSLNetVConnection::advertise_next_protocol, NULL);
-#endif /* TS_USE_TLS_NPN */
-
-#if TS_USE_TLS_ALPN
-  SSL_CTX_set_alpn_select_cb(ctx, SSLNetVConnection::select_next_protocol, NULL);
-#endif /* TS_USE_TLS_ALPN */
 
   const char *certname = sslMultCertSettings.cert.get();
   for (unsigned i = 0; i < cert_list.length(); ++i) {
@@ -1733,7 +1717,6 @@ ssl_store_ssl_context(const SSLConfigParams *params, SSLCertLookup *lookup, cons
   } else if (sslMultCertSettings.session_ticket_enabled != 0) {
     keyblock = ssl_context_enable_tickets(ctx, NULL);
   }
-
 
   // Index this certificate by the specified IP(v6) address. If the address is "*", make it the default context.
   if (sslMultCertSettings.addr) {
@@ -1765,7 +1748,6 @@ ssl_store_ssl_context(const SSLConfigParams *params, SSLCertLookup *lookup, cons
 #endif
   }
 
-
 #if defined(SSL_OP_NO_TICKET)
   // Session tickets are enabled by default. Disable if explicitly requested.
   if (sslMultCertSettings.session_ticket_enabled == 0) {
@@ -1773,24 +1755,6 @@ ssl_store_ssl_context(const SSLConfigParams *params, SSLCertLookup *lookup, cons
     Debug("ssl", "ssl session ticket is disabled");
   }
 #endif
-
-#ifdef HAVE_OPENSSL_OCSP_STAPLING
-  if (SSLConfigParams::ssl_ocsp_enabled) {
-    Debug("ssl", "ssl ocsp stapling is enabled");
-    SSL_CTX_set_tlsext_status_cb(ctx, ssl_callback_ocsp_stapling);
-    for (unsigned i = 0; i < cert_list.length(); ++i) {
-      if (!ssl_stapling_init_cert(ctx, cert_list[i], certname)) {
-        Warning("fail to configure SSL_CTX for OCSP Stapling info for certificate at %s", (const char *)certname);
-      }
-    }
-  } else {
-    Debug("ssl", "ssl ocsp stapling is disabled");
-  }
-#else
-  if (SSLConfigParams::ssl_ocsp_enabled) {
-    Warning("fail to enable ssl ocsp stapling, this openssl version does not support it");
-  }
-#endif /* HAVE_OPENSSL_OCSP_STAPLING */
 
   // Insert additional mappings. Note that this maps multiple keys to the same value, so when
   // this code is updated to reconfigure the SSL certificates, it will need some sort of
@@ -1802,11 +1766,6 @@ ssl_store_ssl_context(const SSLConfigParams *params, SSLCertLookup *lookup, cons
     }
   }
 
-  if (inserted) {
-    if (SSLConfigParams::init_ssl_ctx_cb) {
-      SSLConfigParams::init_ssl_ctx_cb(ctx, true);
-    }
-  }
   if (!inserted) {
     if (ctx != NULL) {
       SSL_CTX_free(ctx);

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1649,6 +1649,47 @@ ssl_set_handshake_callbacks(SSL_CTX *ctx)
 #endif
 }
 
+SSL_CTX *
+SSLCreateServerContext(const SSLConfigParams *params) {
+  Vec<X509 *> cert_list;
+  const ssl_user_config sslMultCertSettings;
+  SSL_CTX *ctx = SSLInitServerContext(params, sslMultCertSettings, cert_list);
+
+  // The certificate callbacks are set by the caller only
+  // for the default certificate
+  SSL_CTX_set_info_callback(ctx, ssl_callback_info);
+
+#if TS_USE_TLS_NPN
+  SSL_CTX_set_next_protos_advertised_cb(ctx, SSLNetVConnection::advertise_next_protocol, NULL);
+#endif /* TS_USE_TLS_NPN */
+
+#if TS_USE_TLS_ALPN
+  SSL_CTX_set_alpn_select_cb(ctx, SSLNetVConnection::select_next_protocol, NULL);
+#endif /* TS_USE_TLS_ALPN */
+
+  // TODO: Allow control over tickets and ticket path when using SSLCreateServerContext
+  ssl_context_enable_tickets(ctx, NULL);
+
+#ifdef HAVE_OPENSSL_OCSP_STAPLING
+  if (SSLConfigParams::ssl_ocsp_enabled) {
+    Debug("ssl", "ssl ocsp stapling is enabled");
+    SSL_CTX_set_tlsext_status_cb(ctx, ssl_callback_ocsp_stapling);
+  } else {
+    Debug("ssl", "ssl ocsp stapling is disabled");
+  }
+#else
+  if (SSLConfigParams::ssl_ocsp_enabled) {
+    Warning("fail to enable ssl ocsp stapling, this openssl version does not support it");
+  }
+#endif /* HAVE_OPENSSL_OCSP_STAPLING */
+
+
+  if (SSLConfigParams::init_ssl_ctx_cb) {
+    SSLConfigParams::init_ssl_ctx_cb(ctx, true);
+  }
+  return ctx;
+}
+
 static SSL_CTX *
 ssl_store_ssl_context(const SSLConfigParams *params, SSLCertLookup *lookup, const ssl_user_config &sslMultCertSettings)
 {

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -8868,6 +8868,19 @@ TSSslContextFindByAddr(struct sockaddr const *addr)
   return ret;
 }
 
+tsapi TSSslContext
+TSSslContextCreate()
+{
+  TSSslContext ret = NULL;
+  SSLConfigParams *config = SSLConfig::acquire();
+  if (config != NULL) {
+    ret = reinterpret_cast<TSSslContext>(SSLCreateServerContext(config));
+    SSLConfig::release(config);
+  }
+  return ret;
+}
+
+
 tsapi int
 TSVConnIsSsl(TSVConn sslp)
 {

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -8880,6 +8880,12 @@ TSSslContextCreate()
   return ret;
 }
 
+tsapi void
+TSSslContextDestroy(TSSslContext ctx)
+{
+  SSL_CTX *ssl_ctx = reinterpret_cast<SSL_CTX*>(ctx);
+  SSL_CTX_free(ssl_ctx);
+}
 
 tsapi int
 TSVConnIsSsl(TSVConn sslp)

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -1226,7 +1226,7 @@ tsapi TSSslConnection TSVConnSSLConnectionGet(TSVConn sslp);
 tsapi TSSslContext TSSslContextFindByName(const char *name);
 tsapi TSSslContext TSSslContextFindByAddr(struct sockaddr const *);
 // Create a new SSL context based on the settings in records.config
-tsapi TSSslContext TSSslContextCreate();
+tsapi TSSslContext TSSslContextCreate(void);
 
 // Returns 1 if the sslp argument refers to a SSL connection
 tsapi int TSVConnIsSsl(TSVConn sslp);

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -1225,8 +1225,12 @@ tsapi TSSslConnection TSVConnSSLConnectionGet(TSVConn sslp);
 // Fetch a SSL context from the global lookup table
 tsapi TSSslContext TSSslContextFindByName(const char *name);
 tsapi TSSslContext TSSslContextFindByAddr(struct sockaddr const *);
+// Create a new SSL context based on the settings in records.config
+tsapi TSSslContext TSSslContextCreate();
+
 // Returns 1 if the sslp argument refers to a SSL connection
 tsapi int TSVConnIsSsl(TSVConn sslp);
+
 
 /* --------------------------------------------------------------------------
    HTTP transactions */

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -1227,6 +1227,7 @@ tsapi TSSslContext TSSslContextFindByName(const char *name);
 tsapi TSSslContext TSSslContextFindByAddr(struct sockaddr const *);
 // Create a new SSL context based on the settings in records.config
 tsapi TSSslContext TSSslContextCreate(void);
+tsapi void TSSslContextDestroy(TSSslContext ctx);
 
 // Returns 1 if the sslp argument refers to a SSL connection
 tsapi int TSVConnIsSsl(TSVConn sslp);


### PR DESCRIPTION
TSSslContextCreate returns a new SSL Context that's configured according to
the settings in records.config

This is useful if an extension wants to use the TS_SSL_CERT_HOOK to
control loading of SNI certificates, and still want to respect the
cipher suite and related SSL settings.

The current experimental plugin for loading SSL certificates just use [SSL_CTX_new(SSLv23_client_method())](https://github.com/apache/trafficserver/blob/f54fbd5bf426c8ff42c16422e9b0708f79c3745e/plugins/experimental/ssl_cert_loader/ssl-cert-loader.cc#L156) to create a new context, and doesn't respect the cipher suite settings in records.config.

The meat of this implementation is in SSLCreateServerContext and could be cleaned up a lot, since there's a lot of repetition between this method and ssl_store_ssl_context. Ideally I would refactor that method to separate context initialization and configuration from inserting the context into the SSLCertLookup. Just wanted to check first to see if there is support for adding the new TSSslContextCreate API method...

