### PR TITLE
TS-4109: fix ts.debug/ts.error problem with long string

### DIFF
--- a/plugins/experimental/ts_lua/ts_lua_misc.c
+++ b/plugins/experimental/ts_lua/ts_lua_misc.c
@@ -62,9 +62,10 @@ static int
 ts_lua_debug(lua_State *L)
 {
   const char *msg;
+  size_t len = 0;
 
-  msg = luaL_checkstring(L, 1);
-  TSDebug(TS_LUA_DEBUG_TAG, msg, NULL);
+  msg = luaL_checklstring(L, 1, &len);
+  TSDebug(TS_LUA_DEBUG_TAG, "[%.*s]", (int)len, msg);
   return 0;
 }
 
@@ -72,9 +73,10 @@ static int
 ts_lua_error(lua_State *L)
 {
   const char *msg;
+  size_t len = 0;
 
-  msg = luaL_checkstring(L, 1);
-  TSError(msg, NULL);
+  msg = luaL_checklstring(L, 1, &len);
+  TSError("[%.*s]", (int) len, msg);
   return 0;
 }
 

--- a/plugins/experimental/ts_lua/ts_lua_misc.c
+++ b/plugins/experimental/ts_lua/ts_lua_misc.c
@@ -65,7 +65,7 @@ ts_lua_debug(lua_State *L)
   size_t len = 0;
 
   msg = luaL_checklstring(L, 1, &len);
-  TSDebug(TS_LUA_DEBUG_TAG, "[%.*s]", (int)len, msg);
+  TSDebug(TS_LUA_DEBUG_TAG, "%.*s", (int)len, msg);
   return 0;
 }
 
@@ -76,7 +76,7 @@ ts_lua_error(lua_State *L)
   size_t len = 0;
 
   msg = luaL_checklstring(L, 1, &len);
-  TSError("[%.*s]", (int) len, msg);
+  TSError("%.*s", (int) len, msg);
   return 0;
 }
 


### PR DESCRIPTION
fix ts.debug/ts.error problem with long string in ts_lua plugin