### PR TITLE
TS-4107: proxy.process.ssl.total_success_handshake_count_in has wrong record type

### DIFF
--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -902,7 +902,7 @@ SSLInitializeStatistics()
   // SSL handshake time
   RecRegisterRawStat(ssl_rsb, RECT_PROCESS, "proxy.process.ssl.total_handshake_time", RECD_INT, RECP_PERSISTENT,
                      (int)ssl_total_handshake_time_stat, RecRawStatSyncSum);
-  RecRegisterRawStat(ssl_rsb, RECT_PROCESS, "proxy.process.ssl.total_success_handshake_count", RECD_INT, RECP_PERSISTENT,
+  RecRegisterRawStat(ssl_rsb, RECT_PROCESS, "proxy.process.ssl.total_success_handshake_count_in", RECD_INT, RECP_PERSISTENT,
                      (int)ssl_total_success_handshake_count_in_stat, RecRawStatSyncCount);
   RecRegisterRawStat(ssl_rsb, RECT_PROCESS, "proxy.process.ssl.total_success_handshake_count_out", RECD_INT, RECP_PERSISTENT,
                      (int)ssl_total_success_handshake_count_out_stat, RecRawStatSyncCount);

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1767,7 +1767,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_NODE, "proxy.node.log.bytes_lost_before_written_to_disk", RECD_INT, "0", RECU_NULL, RR_NULL, RECC_NULL, NULL, RECA_NULL}
   ,
-  {RECT_NODE, "proxy.process.ssl.total_success_handshake_count_in", RECD_INT, "0", RECU_NULL, RR_NULL, RECC_NULL, NULL, RECA_NULL}
+  {RECT_PROCESS, "proxy.process.ssl.total_success_handshake_count", RECD_INT, "0", RECU_NULL, RR_NULL, RECC_NULL, NULL, RECA_NULL}
   ,
 
   //#

--- a/proxy/config/stats.config.xml.default
+++ b/proxy/config/stats.config.xml.default
@@ -1946,11 +1946,12 @@
         </expression>
     </statistics>
 
+    <!-- TS-3409. Mirror proxy.process.ssl.total_success_handshake_count_in for backwards compatibility. -->
     <statistics
 	minimum="0">
-        <destination>proxy.process.ssl.total_success_handshake_count_in</destination>
+        <destination>proxy.process.ssl.total_success_handshake_count</destination>
         <expression>
-            proxy.process.ssl.total_success_handshake_count
+            proxy.process.ssl.total_success_handshake_count_in
         </expression>
     </statistics>
 


### PR DESCRIPTION
``proxy.process.ssl.total_success_handshake_count_in`` should be the
metrics generated in the core SSL code, and the old compatible name
``proxy.process.ssl.total_success_handshake_count`` should be generated
as a custom metric. The custom metric needs to be registered in
``RecordsConfig.cc`` but it should be of type ``RECT_PROCESS`` not ``RECT_NODE``.