### PR TITLE
TS-4133: Update the url_sig plugin so that application query paramete…

### DIFF
--- a/plugins/experimental/url_sig/README
+++ b/plugins/experimental/url_sig/README
@@ -41,6 +41,15 @@ Edge cache debugging
 	to traffic.out.  Failed transactions (signature check fails
 	that is) will be logged in to error.log.
 
+Application Query Parameters.
+  If a request to be signed has application query parameters, the signing
+  parameters must be concatenated to the end of the requests application
+  query parameters.  The application query parameters will be included in
+  the signing calculation as determined by the 'Parts' signing explained
+  below.  At the edge after verification of the signing by this plugin,
+  the signing parameters are removed and the application query parameters
+  are preserved in the request.
+
 Signing a URL
 	At the signing portal take the full URL, without any query string, and
 	add on a query string with the following parameters:

--- a/plugins/experimental/url_sig/sign.pl
+++ b/plugins/experimental/url_sig/sign.pl
@@ -65,12 +65,24 @@ foreach my $part ( split( /\//, $url ) ) {
 	}
 	$j++;
 }
+my $urlHasParams = index($string,"?");
+
 chop($string);
 if ( defined($client) ) {
-	$string .= "?C=" . $client . "&E=" . ( time() + $duration ) . "&A=" . $algorithm . "&K=" . $keyindex . "&P=" . $useparts . "&S=";
+  if ($urlHasParams > 0) {
+	  $string .= "&C=" . $client . "&E=" . ( time() + $duration ) . "&A=" . $algorithm . "&K=" . $keyindex . "&P=" . $useparts . "&S=";
+  }
+  else {
+	  $string .= "?C=" . $client . "&E=" . ( time() + $duration ) . "&A=" . $algorithm . "&K=" . $keyindex . "&P=" . $useparts . "&S=";
+  }
 }
 else {
-	$string .= "?E=" . ( time() + $duration ) . "&A=" . $algorithm . "&K=" . $keyindex . "&P=" . $useparts . "&S=";
+  if ($urlHasParams > 0) {
+	  $string .= "&E=" . ( time() + $duration ) . "&A=" . $algorithm . "&K=" . $keyindex . "&P=" . $useparts . "&S=";
+  }
+  else {
+	  $string .= "?E=" . ( time() + $duration ) . "&A=" . $algorithm . "&K=" . $keyindex . "&P=" . $useparts . "&S=";
+  }
 }
 
 $verbose && print "signed string = " . $string . "\n";
@@ -82,9 +94,17 @@ if ( $algorithm == 1 ) {
 else {
 	$digest = hmac_md5_hex( $string, $key );
 }
-my $qstring = ( split( /\?/, $string ) )[1];
+if ($urlHasParams == -1) {
+  my $qstring = ( split( /\?/, $string ) )[1];
 
-print "curl -s -o /dev/null -v --max-redirs 0 'http://" . $url . "?" . $qstring . $digest . "'\n";
+  print "curl -s -o /dev/null -v --max-redirs 0 'http://" . $url . "?" . $qstring . $digest . "'\n";
+}
+else {
+  my $url_noparams = ( split( /\?/, $url ) )[0];
+  my $qstring = ( split( /\?/, $string ) )[1];
+
+  print "curl -s -o /dev/null -v --max-redirs 0 'http://" . $url_noparams . "?" . $qstring . $digest . "'\n";
+}
 
 sub help {
 	print "sign.pl - Example signing utility in perl for signed URLs\n";

--- a/plugins/experimental/url_sig/url_sig.h
+++ b/plugins/experimental/url_sig/url_sig.h
@@ -45,6 +45,7 @@
 #define MAX_REQ_LEN 8192
 #define MAX_KEY_LEN 256
 #define MAX_KEY_NUM 16
+#define MAX_QUERY_LEN 4096
 
 #define USIG_HMAC_SHA1 1
 #define USIG_HMAC_MD5 2


### PR DESCRIPTION
See TS-4133.  This update to url_sig will allow application query parameters destined for an origin server to remain intact rather than stripping all query parameters after request signing validation.