### PR TITLE
TS-4144: Add TSHttpTxnSetHttpRetStatus wrapper in CPP API

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1957,6 +1957,7 @@ AS_IF([test "x$enable_cppapi" = "xyes"], [
   lib/atscppapi/examples/null_transformation_plugin/Makefile
   lib/atscppapi/examples/post_buffer/Makefile
   lib/atscppapi/examples/remap_plugin/Makefile
+  lib/atscppapi/examples/custom_error_remap_plugin/Makefile
   lib/atscppapi/examples/serverresponse/Makefile
   lib/atscppapi/examples/stat_example/Makefile
   lib/atscppapi/examples/timeout_example/Makefile

--- a/lib/atscppapi/examples/custom_error_remap_plugin/CustomErrorRemapPlugin.cc
+++ b/lib/atscppapi/examples/custom_error_remap_plugin/CustomErrorRemapPlugin.cc
@@ -1,0 +1,57 @@
+/**
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include <atscppapi/RemapPlugin.h>
+#include <atscppapi/PluginInit.h>
+#include <string>
+
+using namespace std;
+using namespace atscppapi;
+
+class MyRemapPlugin : public RemapPlugin
+{
+public:
+  MyRemapPlugin(void **instance_handle) : RemapPlugin(instance_handle) {}
+
+  Result
+  doRemap(const Url &map_from_url, const Url &map_to_url, Transaction &transaction, bool &redirect)
+  {
+    if (transaction.getClientRequest().getUrl().getQuery().find("custom=1") != string::npos) {
+      transaction.setStatusCode(HTTP_STATUS_FORBIDDEN);
+      if (transaction.getClientRequest().getUrl().getQuery().find("output=xml") != string::npos) {
+        transaction.setErrorBody(
+          "<Error>Hello! This is a custom response without making an origin request and no server intercept.</Error>",
+          "application/xml");
+      } else {
+        transaction.setErrorBody("Hello! This is a custom response without making an origin request and no server intercept.");
+      }
+
+      return RESULT_DID_REMAP;
+    }
+
+    return RESULT_NO_REMAP;
+  }
+};
+
+TSReturnCode
+TSRemapNewInstance(int argc ATSCPPAPI_UNUSED, char *argv[] ATSCPPAPI_UNUSED, void **instance_handle, char *errbuf ATSCPPAPI_UNUSED,
+                   int errbuf_size ATSCPPAPI_UNUSED)
+{
+  new MyRemapPlugin(instance_handle);
+  return TS_SUCCESS;
+}

--- a/lib/atscppapi/examples/custom_error_remap_plugin/Makefile.am
+++ b/lib/atscppapi/examples/custom_error_remap_plugin/Makefile.am
@@ -15,26 +15,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-SUBDIRS = \
-	helloworld \
-	globalhook \
-	transactionhook \
-	multiple_transaction_hooks \
-	clientrequest \
-	serverresponse \
-	clientredirect \
-	customresponse \
-	null_transformation_plugin \
-	post_buffer \
-	logger_example \
-	boom \
-	stat_example \
-	remap_plugin \
-	custom_error_remap_plugin \
-	async_http_fetch \
-	gzip_transformation \
-	timeout_example \
-	internal_transaction_handling \
-	async_timer \
-	intercept \
-	async_http_fetch_streaming
+include $(top_srcdir)/build/plugins.mk
+
+AM_CPPFLAGS += -I$(top_srcdir)/lib/atscppapi/src/include -Wno-unused-variable
+
+target=CustomErrorRemapPlugin.so
+pkglib_LTLIBRARIES = CustomErrorRemapPlugin.la
+CustomErrorRemapPlugin_la_SOURCES = CustomErrorRemapPlugin.cc
+CustomErrorRemapPlugin_la_LDFLAGS = -module -avoid-version -shared -L$(top_builddir)/lib/atscppapi/src/ -latscppapi $(TS_PLUGIN_LDFLAGS)

--- a/lib/atscppapi/src/Transaction.cc
+++ b/lib/atscppapi/src/Transaction.cc
@@ -182,15 +182,19 @@ Transaction::error(const std::string &page)
 void
 Transaction::setErrorBody(const std::string &page)
 {
-  LOG_DEBUG("Transaction tshttptxn=%p setting error body page: %s", state_->txn_, page.c_str());
-  TSHttpTxnErrorBodySet(state_->txn_, TSstrdup(page.c_str()), page.length(), NULL); // Default to text/html
+  LOG_DEBUG("Transaction tshttptxn=%p setting error body page length: %d", state_->txn_, page.length());
+  char *body = (char *)TSmalloc(page.length());
+  memcpy(body, page.data(), page.length());
+  TSHttpTxnErrorBodySet(state_->txn_, body, page.length(), NULL); // Default to text/html
 }
 
 void
 Transaction::setErrorBody(const std::string &page, const std::string &mimetype)
 {
-  LOG_DEBUG("Transaction tshttptxn=%p setting error body page: %s", state_->txn_, page.c_str());
-  TSHttpTxnErrorBodySet(state_->txn_, TSstrdup(page.c_str()), page.length(), TSstrdup(mimetype.c_str()));
+  LOG_DEBUG("Transaction tshttptxn=%p setting error body page length: %d", state_->txn_, page.length());
+  char *body = (char *)TSmalloc(page.length());
+  memcpy(body, page.data(), page.length());
+  TSHttpTxnErrorBodySet(state_->txn_, body, page.length(), TSstrdup(mimetype.c_str()));
 }
 
 void

--- a/lib/atscppapi/src/Transaction.cc
+++ b/lib/atscppapi/src/Transaction.cc
@@ -186,6 +186,20 @@ Transaction::setErrorBody(const std::string &page)
   TSHttpTxnErrorBodySet(state_->txn_, TSstrdup(page.c_str()), page.length(), NULL); // Default to text/html
 }
 
+void
+Transaction::setErrorBody(const std::string &page, const std::string &mimetype)
+{
+  LOG_DEBUG("Transaction tshttptxn=%p setting error body page: %s", state_->txn_, page.c_str());
+  TSHttpTxnErrorBodySet(state_->txn_, TSstrdup(page.c_str()), page.length(), TSstrdup(mimetype.c_str()));
+}
+
+void
+Transaction::setStatusCode(HttpStatus code)
+{
+  LOG_DEBUG("Transaction tshttptxn=%p setting status code: %d", state_->txn_, code);
+  TSHttpTxnSetHttpRetStatus(state_->txn_, static_cast<TSHttpStatus>(code));
+}
+
 bool
 Transaction::isInternalRequest() const
 {

--- a/lib/atscppapi/src/include/atscppapi/Transaction.h
+++ b/lib/atscppapi/src/include/atscppapi/Transaction.h
@@ -30,6 +30,7 @@
 #include "atscppapi/shared_ptr.h"
 #include "atscppapi/ClientRequest.h"
 #include "atscppapi/Response.h"
+#include "atscppapi/HttpStatus.h"
 #include <ts/apidefs.h>
 namespace atscppapi
 {
@@ -133,6 +134,25 @@ public:
    * @param content the error page content.
    */
   void setErrorBody(const std::string &content);
+
+  /**
+   * Sets the error body page with mimetype.
+   * This method does not advance the state machine to the error state.
+   * To do that you must explicitally call error().
+   *
+   * @param content the error page content.
+   * @param mimetype the error page's content-type.
+   */
+  void setErrorBody(const std::string &content, const std::string &mimetype);
+
+  /**
+   * Sets the status code.
+   * This is usable before transaction has the response of client like a remap state.
+   * A remap logic may advance the state machine to the error state depending on status code.
+   *
+   * @param code the status code.
+   */
+  void setStatusCode(HttpStatus code);
 
   /**
    * Get the clients address


### PR DESCRIPTION
Add supports in Transaction class.
1. add new method to set http status code.
2. add setErrorBody to set mimetype.