### PR TITLE
TS-4145 Fix cross-site scripting exploits in error messages.

### DIFF
--- a/proxy/config/body_factory/default/Makefile.am
+++ b/proxy/config/body_factory/default/Makefile.am
@@ -21,7 +21,6 @@ bodyfactorydir = $(pkgsysconfdir)/body_factory/default
 dist_bodyfactory_DATA = \
   access\#denied \
   access\#proxy_auth_required \
-  access\#redirect_url \
   access\#ssl_forbidden \
   .body_factory_info \
   cache\#not_in_cache \

--- a/proxy/config/body_factory/default/redirect#moved_permanently
+++ b/proxy/config/body_factory/default/redirect#moved_permanently
@@ -8,7 +8,7 @@
 <HR>
 
 <FONT FACE="Helvetica,Arial"><B>
-Description: The document you requested has moved to a new location.  The new location is "%<{Location}psh>".
+Description: The document you requested has moved to a new location.  The new location is "%<{Location}epsh>".
 </B></FONT>
 <HR>
 </BODY>

--- a/proxy/config/body_factory/default/redirect#moved_temporarily
+++ b/proxy/config/body_factory/default/redirect#moved_temporarily
@@ -8,7 +8,7 @@
 <HR>
 
 <FONT FACE="Helvetica,Arial"><B>
-Description: The document you requested has moved to a new location.  The new location is "%<{Location}psh>".
+Description: The document you requested has moved to a new location.  The new location is "%<{Location}epsh>".
 </B></FONT>
 <HR>
 </BODY>


### PR DESCRIPTION
Address potential cross-site scripting exploits in the
following files:

1.) Replace the variable psh with epsh in files:
 proxy/config/body_factory/default/redirect#moved_temporarily
 proxy/config/body_factory/default/redirect#moved_permanently

2.) Variable cqh in proxy/config/body_factory/default/access#redirect_url
should be replaced with ecqh. However the files appears unutilized in
ATS 6.0.0, hence remove from Makefile alltogether.