### PR TITLE
[TS-4157] traffic_via tests use bad characters in the file name

### DIFF
--- a/cmd/traffic_via/tests/[u c s f p eS;tNc  i p s ]
+++ b/cmd/traffic_via/tests/[u c s f p eS;tNc  i p s ]
@@ -1,4 +1,4 @@
-Via header is [u c s f p eS:tNc  i p s ], Length is 26
+Via header is [u c s f p eS;tNc  i p s ], Length is 26
 Via Header Details:
 Request headers received from client                   :unknown
 Result of Traffic Server cache lookup for URL          :no cache lookup

--- a/cmd/traffic_via/tests/[uIcRs f p eN;t cCHi p s ]
+++ b/cmd/traffic_via/tests/[uIcRs f p eN;t cCHi p s ]
@@ -1,4 +1,4 @@
-Via header is [uIcRs f p eN:t cCHi p s ], Length is 26
+Via header is [uIcRs f p eN;t cCHi p s ], Length is 26
 Via Header Details:
 Request headers received from client                   :IMS
 Result of Traffic Server cache lookup for URL          :in cache, fresh Ram hit (a cache "HIT")

--- a/cmd/traffic_via/tests/[uIcRs f p eN;t cCNi p s ]
+++ b/cmd/traffic_via/tests/[uIcRs f p eN;t cCNi p s ]
@@ -1,6 +1,6 @@
-Via header is [uScRs f p eN:t cCHi p s ], Length is 26
+Via header is [uIcRs f p eN;t cCNi p s ], Length is 26
 Via Header Details:
-Request headers received from client                   :simple request (not conditional)
+Request headers received from client                   :IMS
 Result of Traffic Server cache lookup for URL          :in cache, fresh Ram hit (a cache "HIT")
 Response information received from origin server       :no server connection needed
 Result of document write-to-cache:                     :no cache write performed
@@ -8,7 +8,7 @@ Proxy operation result                                 :unknown
 Error codes (if any)                                   :no error
 Tunnel info                                            :no tunneling
 Cache Type                                             :cache
-Cache Lookup Result                                    :cache hit
+Cache Lookup Result                                    :conditional hit (client sent conditional, doc fresh in cache, returned 304)
 ICP status                                             :no icp
 Parent proxy connection status                         :no parent proxy or unknown
 Origin server connection status                        :no server connection needed

--- a/cmd/traffic_via/tests/[uScMsSf pSeN;t cCMi p sS]
+++ b/cmd/traffic_via/tests/[uScMsSf pSeN;t cCMi p sS]
@@ -1,4 +1,4 @@
-Via header is [uScMsSf pSeN:t cCMi p sS], Length is 26
+Via header is [uScMsSf pSeN;t cCMi p sS], Length is 26
 Via Header Details:
 Request headers received from client                   :simple request (not conditional)
 Result of Traffic Server cache lookup for URL          :miss (a cache "MISS")

--- a/cmd/traffic_via/tests/[uScRs f p eN;t cCHi p s ]
+++ b/cmd/traffic_via/tests/[uScRs f p eN;t cCHi p s ]
@@ -1,6 +1,6 @@
-Via header is [uIcRs f p eN:t cCNi p s ], Length is 26
+Via header is [uScRs f p eN;t cCHi p s ], Length is 26
 Via Header Details:
-Request headers received from client                   :IMS
+Request headers received from client                   :simple request (not conditional)
 Result of Traffic Server cache lookup for URL          :in cache, fresh Ram hit (a cache "HIT")
 Response information received from origin server       :no server connection needed
 Result of document write-to-cache:                     :no cache write performed
@@ -8,7 +8,7 @@ Proxy operation result                                 :unknown
 Error codes (if any)                                   :no error
 Tunnel info                                            :no tunneling
 Cache Type                                             :cache
-Cache Lookup Result                                    :conditional hit (client sent conditional, doc fresh in cache, returned 304)
+Cache Lookup Result                                    :cache hit
 ICP status                                             :no icp
 Parent proxy connection status                         :no parent proxy or unknown
 Origin server connection status                        :no server connection needed

--- a/cmd/traffic_via/traffic_via.cc
+++ b/cmd/traffic_via/traffic_via.cc
@@ -201,7 +201,7 @@ printViaHeader(const char *header)
 
   // Loop through input via header flags
   for (const char *c = header; *c; ++c) {
-    if (*c == ':') {
+    if (*c == ';') {
       isDetail = true;
       continue;
     }

--- a/cmd/traffic_via/traffic_via.cc
+++ b/cmd/traffic_via/traffic_via.cc
@@ -201,7 +201,7 @@ printViaHeader(const char *header)
 
   // Loop through input via header flags
   for (const char *c = header; *c; ++c) {
-    if (*c == ';') {
+    if ((*c == ':') || (*c == ';')) {
       isDetail = true;
       continue;
     }


### PR DESCRIPTION
Changed the usage of : to ; which seems to be more filename friendly.
Changed test files to have ; in them