### PR TITLE
[TS-4135] fix redirect coredump

### DIFF
--- a/lib/atscppapi/src/Request.cc
+++ b/lib/atscppapi/src/Request.cc
@@ -84,11 +84,6 @@ Request::Request(const string &url_str, HttpMethod method, HttpVersion version)
 void
 Request::init(void *hdr_buf, void *hdr_loc)
 {
-  if (state_->hdr_buf_ || state_->hdr_loc_) {
-    LOG_ERROR("Reinitialization; (hdr_buf, hdr_loc) current(%p, %p), attempted(%p, %p)", state_->hdr_buf_, state_->hdr_loc_,
-              hdr_buf, hdr_loc);
-    return;
-  }
   state_->hdr_buf_ = static_cast<TSMBuffer>(hdr_buf);
   state_->hdr_loc_ = static_cast<TSMLoc>(hdr_loc);
   state_->headers_.reset(state_->hdr_buf_, state_->hdr_loc_);

--- a/lib/atscppapi/src/Request.cc
+++ b/lib/atscppapi/src/Request.cc
@@ -97,6 +97,16 @@ Request::init(void *hdr_buf, void *hdr_loc)
   }
 }
 
+void
+Request::reset()
+{
+  state_->hdr_buf_ = NULL;
+  state_->hdr_loc_ = NULL;
+  state_->headers_.reset(NULL, NULL);
+  state_->url_loc_ = NULL;
+  LOG_DEBUG("Reset request %p", this);
+}
+
 HttpMethod
 Request::getMethod() const
 {

--- a/lib/atscppapi/src/Request.cc
+++ b/lib/atscppapi/src/Request.cc
@@ -84,6 +84,10 @@ Request::Request(const string &url_str, HttpMethod method, HttpVersion version)
 void
 Request::init(void *hdr_buf, void *hdr_loc)
 {
+  reset();
+  if (!hdr_buf || !hdr_loc) {
+    return;
+  }
   state_->hdr_buf_ = static_cast<TSMBuffer>(hdr_buf);
   state_->hdr_loc_ = static_cast<TSMLoc>(hdr_loc);
   state_->headers_.reset(state_->hdr_buf_, state_->hdr_loc_);

--- a/lib/atscppapi/src/Response.cc
+++ b/lib/atscppapi/src/Response.cc
@@ -54,6 +54,15 @@ Response::init(void *hdr_buf, void *hdr_loc)
   LOG_DEBUG("Initializing response %p with hdr_buf=%p and hdr_loc=%p", this, state_->hdr_buf_, state_->hdr_loc_);
 }
 
+void
+Response::reset()
+{
+  state_->hdr_buf_ = NULL;
+  state_->hdr_loc_ = NULL;
+  state_->headers_.reset(NULL, NULL);
+  LOG_DEBUG("Reset response %p", this);
+}
+
 HttpVersion
 Response::getVersion() const
 {

--- a/lib/atscppapi/src/Response.cc
+++ b/lib/atscppapi/src/Response.cc
@@ -48,6 +48,10 @@ Response::Response()
 void
 Response::init(void *hdr_buf, void *hdr_loc)
 {
+  reset();
+  if (!hdr_buf || !hdr_loc) {
+    return;
+  }
   state_->hdr_buf_ = static_cast<TSMBuffer>(hdr_buf);
   state_->hdr_loc_ = static_cast<TSMLoc>(hdr_loc);
   state_->headers_.reset(state_->hdr_buf_, state_->hdr_loc_);

--- a/lib/atscppapi/src/Transaction.cc
+++ b/lib/atscppapi/src/Transaction.cc
@@ -431,68 +431,46 @@ void
 Transaction::initServerRequest()
 {
   static initializeHandles initializeServerRequestHandles(TSHttpTxnServerReqGet);
-  if (initializeServerRequestHandles(state_->txn_, state_->server_request_hdr_buf_, state_->server_request_hdr_loc_,
-                                     "server request")) {
-    LOG_DEBUG("Initializing server request");
-    state_->server_request_.init(state_->server_request_hdr_buf_, state_->server_request_hdr_loc_);
-  } else {
-    LOG_DEBUG("Reset server request");
-    state_->server_request_.reset();
-  }
+  initializeServerRequestHandles(state_->txn_, state_->server_request_hdr_buf_, state_->server_request_hdr_loc_, "server request");
+  LOG_DEBUG("Initializing server request");
+  state_->server_request_.init(state_->server_request_hdr_buf_, state_->server_request_hdr_loc_);
 }
 
 void
 Transaction::initServerResponse()
 {
   static initializeHandles initializeServerResponseHandles(TSHttpTxnServerRespGet);
-  if (initializeServerResponseHandles(state_->txn_, state_->server_response_hdr_buf_, state_->server_response_hdr_loc_,
-                                      "server response")) {
-    LOG_DEBUG("Initializing server response");
-    state_->server_response_.init(state_->server_response_hdr_buf_, state_->server_response_hdr_loc_);
-  } else {
-    LOG_DEBUG("Reset server response");
-    state_->server_response_.reset();
-  }
+  initializeServerResponseHandles(state_->txn_, state_->server_response_hdr_buf_, state_->server_response_hdr_loc_,
+                                  "server response");
+  LOG_DEBUG("Initializing server response");
+  state_->server_response_.init(state_->server_response_hdr_buf_, state_->server_response_hdr_loc_);
 }
 
 void
 Transaction::initClientResponse()
 {
   static initializeHandles initializeClientResponseHandles(TSHttpTxnClientRespGet);
-  if (initializeClientResponseHandles(state_->txn_, state_->client_response_hdr_buf_, state_->client_response_hdr_loc_,
-                                      "client response")) {
-    LOG_DEBUG("Initializing client response");
-    state_->client_response_.init(state_->client_response_hdr_buf_, state_->client_response_hdr_loc_);
-  } else {
-    LOG_DEBUG("Reset client response");
-    state_->client_response_.reset();
-  }
+  initializeClientResponseHandles(state_->txn_, state_->client_response_hdr_buf_, state_->client_response_hdr_loc_,
+                                  "client response");
+  LOG_DEBUG("Initializing client response");
+  state_->client_response_.init(state_->client_response_hdr_buf_, state_->client_response_hdr_loc_);
 }
 
 void
 Transaction::initCachedRequest()
 {
   static initializeHandles initializeCachedRequestHandles(TSHttpTxnCachedReqGet);
-  if (initializeCachedRequestHandles(state_->txn_, state_->cached_request_hdr_buf_, state_->cached_request_hdr_loc_,
-                                     "cached request")) {
-    LOG_DEBUG("Initializing cached request");
-    state_->cached_request_.init(state_->cached_request_hdr_buf_, state_->cached_request_hdr_loc_);
-  } else {
-    LOG_DEBUG("Reset cached request");
-    state_->cached_request_.reset();
-  }
+  initializeCachedRequestHandles(state_->txn_, state_->cached_request_hdr_buf_, state_->cached_request_hdr_loc_, "cached request");
+  LOG_DEBUG("Initializing cached request");
+  state_->cached_request_.init(state_->cached_request_hdr_buf_, state_->cached_request_hdr_loc_);
 }
 
 void
 Transaction::initCachedResponse()
 {
   static initializeHandles initializeCachedResponseHandles(TSHttpTxnCachedRespGet);
-  if (initializeCachedResponseHandles(state_->txn_, state_->cached_response_hdr_buf_, state_->cached_response_hdr_loc_,
-                                      "cached response")) {
-    LOG_DEBUG("Initializing cached response");
-    state_->cached_response_.init(state_->cached_response_hdr_buf_, state_->cached_response_hdr_loc_);
-  } else {
-    LOG_DEBUG("Reset cached response");
-    state_->cached_response_.reset();
-  }
+  initializeCachedResponseHandles(state_->txn_, state_->cached_response_hdr_buf_, state_->cached_response_hdr_loc_,
+                                  "cached response");
+  LOG_DEBUG("Initializing cached response");
+  state_->cached_response_.init(state_->cached_response_hdr_buf_, state_->cached_response_hdr_loc_);
 }

--- a/lib/atscppapi/src/Transaction.cc
+++ b/lib/atscppapi/src/Transaction.cc
@@ -435,6 +435,9 @@ Transaction::initServerRequest()
                                      "server request")) {
     LOG_DEBUG("Initializing server request");
     state_->server_request_.init(state_->server_request_hdr_buf_, state_->server_request_hdr_loc_);
+  } else {
+    LOG_DEBUG("Reset server request");
+    state_->server_request_.reset();
   }
 }
 
@@ -446,6 +449,9 @@ Transaction::initServerResponse()
                                       "server response")) {
     LOG_DEBUG("Initializing server response");
     state_->server_response_.init(state_->server_response_hdr_buf_, state_->server_response_hdr_loc_);
+  } else {
+    LOG_DEBUG("Reset server response");
+    state_->server_response_.reset();
   }
 }
 
@@ -457,6 +463,9 @@ Transaction::initClientResponse()
                                       "client response")) {
     LOG_DEBUG("Initializing client response");
     state_->client_response_.init(state_->client_response_hdr_buf_, state_->client_response_hdr_loc_);
+  } else {
+    LOG_DEBUG("Reset client response");
+    state_->client_response_.reset();
   }
 }
 
@@ -468,6 +477,9 @@ Transaction::initCachedRequest()
                                      "cached request")) {
     LOG_DEBUG("Initializing cached request");
     state_->cached_request_.init(state_->cached_request_hdr_buf_, state_->cached_request_hdr_loc_);
+  } else {
+    LOG_DEBUG("Reset cached request");
+    state_->cached_request_.reset();
   }
 }
 
@@ -479,5 +491,8 @@ Transaction::initCachedResponse()
                                       "cached response")) {
     LOG_DEBUG("Initializing cached response");
     state_->cached_response_.init(state_->cached_response_hdr_buf_, state_->cached_response_hdr_loc_);
+  } else {
+    LOG_DEBUG("Reset cached response");
+    state_->cached_response_.reset();
   }
 }

--- a/lib/atscppapi/src/include/atscppapi/Request.h
+++ b/lib/atscppapi/src/include/atscppapi/Request.h
@@ -65,6 +65,7 @@ private:
   Request(void *hdr_buf, void *hdr_loc);
   RequestState *state_;
   void init(void *hdr_buf, void *hdr_loc);
+  void reset();
   friend class Transaction;
   friend class ClientRequest;
 };

--- a/lib/atscppapi/src/include/atscppapi/Response.h
+++ b/lib/atscppapi/src/include/atscppapi/Response.h
@@ -67,6 +67,7 @@ public:
 private:
   ResponseState *state_;
   void init(void *hdr_buf, void *hdr_loc);
+  void reset();
   friend class Transaction;
   friend class utils::internal;
 };


### PR DESCRIPTION
@bgaff @shukitchan @sudheerv can you review. 
Removing TSMlocRelease is harmless as it s a no-op. Until we come up with a better way of cleanup lets not release the mloc for request and response headers.