### PR TITLE
TS-4165 Logging breaks if changing log format

### DIFF
--- a/proxy/logging/LogObject.h
+++ b/proxy/logging/LogObject.h
@@ -379,6 +379,7 @@ private:
   static bool _has_internal_filename_conflict(const char *filename, LogObjectList &objects);
   int _solve_filename_conflicts(LogObject *log_obj, int maxConflicts);
   int _solve_internal_filename_conflicts(LogObject *log_obj, int maxConflicts, int fileNum = 0);
+  void _filename_resolution_abort(const char *fname);
 
 public:
   LogObjectManager();


### PR DESCRIPTION
TS wasn't calling `open_file()` on the LogFile it was trying
to rotate away. This was occurring when an existing log file's
formatting was changed in logs_xml.config and TS was restarted.
The result was TS not updating/creating the updated log file.