### PR TITLE
TS-4168: Only close inactive and active connections that have a non-z…

### DIFF
--- a/iocore/net/UnixNet.cc
+++ b/iocore/net/UnixNet.cc
@@ -592,7 +592,7 @@ NetHandler::manage_active_queue(bool ignore_queue_size = false)
   int total_idle_count = 0;
   for (; vc != NULL; vc = vc_next) {
     vc_next = vc->active_queue_link.next;
-    if ((vc->next_inactivity_timeout_at <= now) || (vc->next_activity_timeout_at <= now)) {
+    if ((vc->inactivity_timeout_in && vc->next_inactivity_timeout_at <= now) || (vc->active_timeout_in && vc->next_activity_timeout_at <= now)) {
       _close_vc(vc, now, handle_event, closed, total_idle_time, total_idle_count);
     }
     if (ignore_queue_size == false && max_connections_active_per_thread_in > active_queue_size) {


### PR DESCRIPTION
…ero timeout