### PR TITLE
tsxs accepts .lo files as argument for linking

### DIFF
--- a/tools/tsxs.in
+++ b/tools/tsxs.in
@@ -102,7 +102,7 @@ compile() {
 			MY_CFLAGS="$CPPFLAGS $CXXFLAGS"
 			MY_CC=$CXX
 			;;
-		lo)
+		lo|o|a)
 			OBJS="${OBJS} ${SRC}"
 			return
 			;;

--- a/tools/tsxs.in
+++ b/tools/tsxs.in
@@ -102,6 +102,10 @@ compile() {
 			MY_CFLAGS="$CPPFLAGS $CXXFLAGS"
 			MY_CC=$CXX
 			;;
+		lo)
+			OBJS="${OBJS} ${SRC}"
+			return
+			;;
 		*)
 			bail "unrecognized input file: $SRC"
 			;;


### PR DESCRIPTION
It would be quite useful for tsxs utility to accept .lo files while linking the plugin: it would enable writing makefile that first compile changed files and then link all object files into a plugin.
The suggested patch modifies tsxs.in file accordingly.