### PR TITLE
setting BUILD variable for .lo, .o and .a files

### DIFF
--- a/tools/tsxs.in
+++ b/tools/tsxs.in
@@ -104,6 +104,7 @@ compile() {
 			;;
 		lo|o|a)
 			OBJS="${OBJS} ${SRC}"
+			BUILD=1
 			return
 			;;
 		*)


### PR DESCRIPTION
The BUILD variable has to be set in order to link to proceed.
