### PR TITLE
TS-4066: Memory leaks in gmake check tests

### DIFF
--- a/lib/ts/test_List.cc
+++ b/lib/ts/test_List.cc
@@ -51,11 +51,15 @@ main()
   s.push(f);
   d.push(s.pop());
   q.enqueue(d.pop());
-  for (int i = 0; i < 100; i++)
+  for (int i = 0; i < 100; i++) {
     q.enqueue(new Foo(i));
+  }
   int tot = 0;
-  for (int i = 0; i < 101; i++)
-    tot += q.dequeue()->x;
+  for (int i = 0; i < 101; i++) {
+    Foo *foo = q.dequeue();
+    tot += foo->x;
+    delete foo;
+  }
   if (tot != 4957) {
     printf("test_List FAILED\n");
     exit(1);


### PR DESCRIPTION
This fixes leaks in test_List