### PR TITLE
TS-4190: Disabling LuaJIT in configure still builds portions with Lua.

### DIFF
--- a/build/common.m4
+++ b/build/common.m4
@@ -544,6 +544,7 @@ dnl
 dnl Note: As with AC_ARG_ENABLE, non-alphanumeric characters are
 dnl transformed to underscores.
 dnl
+dnl This macro also AC_SUBST's the constructed variable name.
 AC_DEFUN([TS_ARG_ENABLE_VAR],[
   tsl_prefix="AS_TR_SH($1)"
   tsl_stem="AS_TR_SH($2)"
@@ -552,6 +553,7 @@ AC_DEFUN([TS_ARG_ENABLE_VAR],[
      [eval "${tsl_prefix}_${tsl_stem}=1"],
      [eval "${tsl_prefix}_${tsl_stem}=0"]
   )
+  AC_SUBST(m4_join([_], $1, AS_TR_SH($2)))
 ])
 
 dnl

--- a/cmd/traffic_manager/Makefile.am
+++ b/cmd/traffic_manager/Makefile.am
@@ -41,23 +41,20 @@ AM_LDFLAGS = \
   @EXPAT_LDFLAGS@ \
   @OPENSSL_LDFLAGS@
 
-AM_LDFLAGS += \
-  $(LUAJIT_LDFLAGS)
-
 traffic_manager_SOURCES = \
   AddConfigFilesHere.cc \
-  traffic_manager.cc \
-  metrics.cc \
+  MgmtHandlers.cc \
+  MgmtHandlers.h \
   StatProcessor.cc \
   StatProcessor.h \
   StatType.cc \
   StatType.h \
   StatXML.cc \
   StatXML.h \
-  MgmtHandlers.cc \
-  MgmtHandlers.h \
   WebOverview.cc \
-  WebOverview.h
+  WebOverview.h \
+  metrics.h \
+  traffic_manager.cc
 
 traffic_manager_LDADD = \
   $(top_builddir)/mgmt/api/libmgmtapilocal.la \
@@ -70,6 +67,12 @@ traffic_manager_LDADD = \
   $(top_builddir)/proxy/shared/libdiagsconfig.a
 
 if BUILD_LUAJIT
+AM_LDFLAGS += \
+  $(LUAJIT_LDFLAGS)
+
+traffic_manager_SOURCES += \
+  metrics.cc
+
 traffic_manager_LDADD += \
   $(top_builddir)/lib/bindings/libbindings.la \
   $(top_builddir)/lib/luajit/src/libluajit.a

--- a/cmd/traffic_manager/metrics.h
+++ b/cmd/traffic_manager/metrics.h
@@ -24,8 +24,27 @@
 #ifndef METRICS_H_D289E71B_AAC5_4CF3_9954_D54EDED60D1B
 #define METRICS_H_D289E71B_AAC5_4CF3_9954_D54EDED60D1B
 
+#if TS_USE_LUAJIT
+
 bool metrics_binding_initialize(BindingInstance &binding);
 void metrics_binding_destroy(BindingInstance &binding);
 void metrics_binding_evaluate(BindingInstance &binding);
+
+#else /* TS_USE_LUAJIT */
+
+struct BindingInstance{};
+
+static inline bool
+metrics_binding_initialize(BindingInstance &binding) {
+  return false;
+}
+
+static inline void
+metrics_binding_destroy(BindingInstance &binding) { }
+
+static inline void
+metrics_binding_evaluate(BindingInstance &binding) { }
+
+#endif /* TS_USE_LUAJIT */
 
 #endif /* METRICS_H_D289E71B_AAC5_4CF3_9954_D54EDED60D1B */

--- a/cmd/traffic_manager/traffic_manager.cc
+++ b/cmd/traffic_manager/traffic_manager.cc
@@ -51,8 +51,11 @@
 #include "StatProcessor.h"
 #include "P_RecLocal.h"
 
+#if TS_USE_LUAJIT
 #include "bindings/bindings.h"
 #include "bindings/metrics.h"
+#endif
+
 #include "metrics.h"
 
 #if TS_USE_POSIX_CAP
@@ -737,6 +740,18 @@ main(int argc, const char **argv)
   RecRegisterStatInt(RECT_NODE, "proxy.node.config.restart_required.proxy", 0, RECP_NON_PERSISTENT);
   RecRegisterStatInt(RECT_NODE, "proxy.node.config.restart_required.manager", 0, RECP_NON_PERSISTENT);
   RecRegisterStatInt(RECT_NODE, "proxy.node.config.restart_required.cop", 0, RECP_NON_PERSISTENT);
+
+#if !TS_USE_LUAJIT
+  if (enable_lua) {
+    static bool warned = false;
+    enable_lua = false;
+
+    if (!warned) {
+      Warning("missing Lua support, disabling Lua derived metrics");
+      warned = true;
+    }
+  }
+#endif
 
   if (enable_lua) {
     binding = new BindingInstance;

--- a/configure.ac
+++ b/configure.ac
@@ -197,7 +197,6 @@ AC_ARG_ENABLE([fast-sdk],
 )
 AC_MSG_RESULT([$enable_fast_sdk])
 TS_ARG_ENABLE_VAR([use], [fast-sdk])
-AC_SUBST(use_fast_sdk)
 
 #
 # Diags
@@ -211,7 +210,6 @@ AC_ARG_ENABLE([diags],
 )
 AC_MSG_RESULT([$enable_diags])
 TS_ARG_ENABLE_VAR([use], [diags])
-AC_SUBST(use_diags)
 
 #
 # Build regression tests?
@@ -225,7 +223,6 @@ AC_ARG_ENABLE([tests],
 )
 AC_MSG_RESULT([$enable_tests])
 TS_ARG_ENABLE_VAR([has], [tests])
-AC_SUBST(has_tests)
 AM_CONDITIONAL([BUILD_TESTS], [test 0 -ne $has_tests])
 
 #
@@ -266,7 +263,6 @@ AC_ARG_ENABLE([wccp],
 )
 AC_MSG_RESULT([$enable_wccp])
 TS_ARG_ENABLE_VAR([has],[wccp])
-AC_SUBST(has_wccp)
 AM_CONDITIONAL([BUILD_WCCP], [test 0 -ne $has_wccp])
 
 # Google profiler
@@ -353,7 +349,6 @@ AC_ARG_ENABLE([spdy],
         [enable_spdy="no"])
 AC_MSG_RESULT([$enable_spdy])
 TS_ARG_ENABLE_VAR([has], [spdy])
-AC_SUBST(has_spdy)
 AM_CONDITIONAL([BUILD_SPDY], [test 0 -ne $has_spdy])
 
 #
@@ -467,7 +462,6 @@ AC_ARG_ENABLE([luajit],
 AC_MSG_RESULT([$enable_luajit])
 AM_CONDITIONAL([BUILD_LUAJIT], [ test "x${enable_luajit}" = "xyes" ])
 TS_ARG_ENABLE_VAR([use], [luajit])
-AC_SUBST(use_luajit)
 
 #
 # Check if we should allow builds on 32-bit platforms
@@ -1203,7 +1197,6 @@ AS_IF([test "$host_os_def" = "linux"], [
   ])
 ])
 TS_ARG_ENABLE_VAR([use], [remote_unwinding])
-AC_SUBST(use_remote_unwinding)
 
 use_epoll=0
 use_kqueue=0
@@ -1328,7 +1321,6 @@ AS_IF([test "x$enable_linux_native_aio" = "xyes"], [
 
 AC_MSG_RESULT([$enable_linux_native_aio])
 TS_ARG_ENABLE_VAR([use], [linux_native_aio])
-AC_SUBST(use_linux_native_aio)
 
 # Check for hwloc library.
 # If we don't find it, disable checking for header.

--- a/configure.ac
+++ b/configure.ac
@@ -466,7 +466,8 @@ AC_ARG_ENABLE([luajit],
 )
 AC_MSG_RESULT([$enable_luajit])
 AM_CONDITIONAL([BUILD_LUAJIT], [ test "x${enable_luajit}" = "xyes" ])
-
+TS_ARG_ENABLE_VAR([use], [luajit])
+AC_SUBST(use_luajit)
 
 #
 # Check if we should allow builds on 32-bit platforms

--- a/lib/ts/ink_config.h.in
+++ b/lib/ts/ink_config.h.in
@@ -78,9 +78,10 @@
 #define TS_USE_SET_RBIO                @use_set_rbio@
 #define TS_USE_TLS_ECKEY               @use_tls_eckey@
 #define TS_USE_LINUX_NATIVE_AIO        @use_linux_native_aio@
-#define TS_HAS_SO_PEERCRED             @has_so_peercred@
-
 #define TS_USE_REMOTE_UNWINDING	       @use_remote_unwinding@
+#define TS_USE_LUAJIT                  @use_luajit@
+
+#define TS_HAS_SO_PEERCRED             @has_so_peercred@
 
 /* OS API definitions */
 #define GETHOSTBYNAME_R_GLIBC2         @gethostbyname_r_glibc2@


### PR DESCRIPTION
Don't try to build Lua derived metrics support if we don't have any LuaJIT support.