### PR TITLE
TS-4158 Adds appropriate releases of URL MLocs

### DIFF
--- a/plugins/experimental/background_fetch/background_fetch.cc
+++ b/plugins/experimental/background_fetch/background_fetch.cc
@@ -244,7 +244,9 @@ BgFetchData::initialize(TSMBuffer request, TSMLoc req_hdr, TSHttpTxn txnp)
       char *url = TSUrlStringGet(mbuf, url_loc, &len);
 
       _url.append(url, len); // Save away the URL for later use when acquiring lock
+
       TSfree(static_cast<void *>(url));
+      TSHandleMLocRelease(request, TS_NULL_MLOC, purl);
 
       if (TS_SUCCESS == TSHttpHdrUrlSet(mbuf, hdr_loc, url_loc)) {
         // Make sure we have the correct Host: header for this request.

--- a/plugins/experimental/channel_stats/channel_stats.cc
+++ b/plugins/experimental/channel_stats/channel_stats.cc
@@ -361,6 +361,7 @@ get_pristine_host(TSHttpTxn txnp, TSMBuffer bufp, std::string &host)
   }
 
   pristine_port = TSUrlPortGet(bufp, purl_loc);
+  TSHandleMLocRelease(bufp, TS_NULL_MLOC, purl_loc);
   host = std::string(pristine_host, pristine_host_len);
   if (pristine_port != 80) {
     char buf[12];

--- a/plugins/experimental/escalate/escalate.cc
+++ b/plugins/experimental/escalate/escalate.cc
@@ -129,13 +129,12 @@ EscalateResponse(TSCont cont, TSEvent event, void *edata)
     if (es->use_pristine) {
       if (TS_SUCCESS == TSHttpTxnPristineUrlGet(txn, &mbuf, &url)) {
         url_str = MakeEscalateUrl(mbuf, url, entry->second.target.c_str(), entry->second.target.size(), url_len);
-        printf("STRING is %.*s\n", url_len, url_str);
+        TSHandleMLocRelease(mbuf, TS_NULL_MLOC, url);
       }
     } else {
       if (TS_SUCCESS == TSHttpTxnClientReqGet(txn, &mbuf, &hdrp)) {
         if (TS_SUCCESS == TSHttpHdrUrlGet(mbuf, hdrp, &url)) {
           url_str = MakeEscalateUrl(mbuf, url, entry->second.target.c_str(), entry->second.target.size(), url_len);
-          printf("Old code STRING is %.*s\n", url_len, url_str);
         }
         // Release the request MLoc
         TSHandleMLocRelease(mbuf, TS_NULL_MLOC, hdrp);

--- a/plugins/header_rewrite/expander.cc
+++ b/plugins/header_rewrite/expander.cc
@@ -66,6 +66,7 @@ VariableExpander::expand(const Resources &res)
       if (TSHttpTxnPristineUrlGet(res.txnp, &bufp, &url_loc) == TS_SUCCESS) {
         int len;
         resolved_variable = TSUrlSchemeGet(bufp, url_loc, &len);
+        TSHandleMLocRelease(bufp, TS_NULL_MLOC, url_loc);
       }
     } else if (variable == "%<port>") {
       // Original port of the incoming request


### PR DESCRIPTION
The missing releases are benign, this is merely for correctness. There are two misplaces printf()'s as well that I removed.