### PR TITLE
TS-4220  DNSHandler::mainEvent

### DIFF
--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -809,7 +809,7 @@ DNSHandler::mainEvent(int event, Event *e)
     for (int i = 0; i < n_con; i++) {
       if (!ns_down[i] && failover_soon(i)) {
         Debug("dns", "mainEvent: nameserver = %d failover soon", name_server);
-        if (failover_now(i))
+        if (!failover_now(i))
           rr_failure(i);
         else {
           Debug("dns", "mainEvent: nameserver = %d no failover now - retrying", i);


### PR DESCRIPTION
Dear all
failover_now return false when the name server's mark is not expiring, and we need to call rr_failure to mark the name server as down.
Thx!!