### PR TITLE
AARCH64 fixes tested on Cavium ThunderX 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1314,6 +1314,14 @@ AS_IF([test "x$has_128bit_cas" = "x1"], [
   TS_ADDTO(CFLAGS, [-mcx16])
   TS_ADDTO(CXXFLAGS, [-mcx16])
 ])
+AC_MSG_CHECKING([TESTING KERNEL PAGE SIZE])
+kernel_page_size=`getconf PAGE_SIZE`
+AS_IF([test "x${kernel_page_size}" = "x65536"],
+[
+  TS_ADDTO(CXXFLAGS, [-DSTORE_BLOCK_SIZE=65536])
+]
+)
+AC_MSG_RESULT([$kernel_page_size])
 
 # Check for POSIX capabilities library.
 # If we don't find it, disable checking for header.

--- a/iocore/cache/I_Store.h
+++ b/iocore/cache/I_Store.h
@@ -33,7 +33,9 @@
 
 #include "ts/ink_platform.h"
 
+#ifndef STORE_BLOCK_SIZE
 #define STORE_BLOCK_SIZE 8192
+#endif
 #define STORE_BLOCK_SHIFT 13
 #define DEFAULT_HW_SECTOR_SIZE 512
 

--- a/iocore/net/Spinlock.h
+++ b/iocore/net/Spinlock.h
@@ -1,0 +1,56 @@
+/** @file
+
+Author: Shay Gal-On
+
+A class implementing a simple spinlock using GCC atomics, 
+using sched_yield while lock fails.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+*/
+
+#include <sched.h>
+
+class Spinlock
+{
+public:
+    int _data;
+
+public:
+    bool try_lock()
+    {
+        int r = __sync_lock_test_and_set( &_data, 1 );
+        return r == 0;
+    }
+
+    void lock()
+    {
+        for( unsigned k = 0; !try_lock(); ++k )
+        {
+		  sched_yield();
+        }
+    }
+
+    void unlock()
+    {
+        __sync_lock_release( &_data );
+    }
+};
+
+

--- a/lib/ts/ink_queue.h
+++ b/lib/ts/ink_queue.h
@@ -133,9 +133,14 @@ typedef union {
 #define SET_FREELIST_POINTER_VERSION(_x, _p, _v) \
   (_x).s.pointer = _p;                           \
   (_x).s.version = _v
-#elif defined(__x86_64__) || defined(__ia64__) || defined(__powerpc64__) || defined(__aarch64__)
+#elif defined(__x86_64__) || defined(__ia64__) || defined(__powerpc64__) 
 #define FREELIST_POINTER(_x) \
   ((void *)(((((intptr_t)(_x).data) << 16) >> 16) | (((~((((intptr_t)(_x).data) << 16 >> 63) - 1)) >> 48) << 48))) // sign extend
+#define FREELIST_VERSION(_x) (((intptr_t)(_x).data) >> 48)
+#define SET_FREELIST_POINTER_VERSION(_x, _p, _v) (_x).data = ((((intptr_t)(_p)) & 0x0000FFFFFFFFFFFFULL) | (((_v)&0xFFFFULL) << 48))
+#elif defined(__aarch64__)
+#define FREELIST_POINTER(_x) \
+  ((void *)(((((intptr_t)(_x).data) & 0x0000FFFFFFFFFFFFULL )))) // clear the version
 #define FREELIST_VERSION(_x) (((intptr_t)(_x).data) >> 48)
 #define SET_FREELIST_POINTER_VERSION(_x, _p, _v) (_x).data = ((((intptr_t)(_p)) & 0x0000FFFFFFFFFFFFULL) | (((_v)&0xFFFFULL) << 48))
 #else


### PR DESCRIPTION
Tested on linux aarch64 Cavium ThunderX platform, 4.2 kernel configured with 64K pages. 
Crashes during freelist operations when trying to access pointer after sign extension.

Freelist pointer versioning sign extends upper 16 bits. Does not work well for 48b va on aarch64.
Patch clears the upper 16 bits instead.
