### PR TITLE
Misc hostdb cleanups

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3111,7 +3111,7 @@ Sockets
 
 .. ts:cv:: CONFIG  proxy.config.net.tcp_congestion_control_out STRING ""
 
-   This directive will override the congestion control algorithm for outgoing 
+   This directive will override the congestion control algorithm for outgoing
    connections (connect sockets). On linux the allowed values are typically
    specified in a space seperated list in /proc/sys/net/ipv4/tcp_allowed_congestion_control
 

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -2239,6 +2239,10 @@ This value is a global default that can be overridden by :ts:cv:`proxy.config.ht
    Note: hostdb is syncd to disk on a per-partition basis (of which there are 64).
    This means that the minumum time to sync all data to disk is :ts:cv:`proxy.config.cache.hostdb.sync_frequency` * 64
 
+.. ts:cv:: CONFIG proxy.config.hostdb.verify_after INT 720
+
+    Set the interval (in seconds) in which to re-query DNS regardless of TTL status.
+
 Logging Configuration
 =====================
 

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -2232,6 +2232,13 @@ This value is a global default that can be overridden by :ts:cv:`proxy.config.ht
    origin server is determined by the client, which forces the IP address family of the address used for the origin
    server. In effect, outbound transparent connections always use a resolution style of "``client``".
 
+.. ts:cv:: CONFIG proxy.config.cache.hostdb.sync_frequency INT 120
+
+   Set the frequency (in seconds) to sync hostdb to disk.
+
+   Note: hostdb is syncd to disk on a per-partition basis (of which there are 64).
+   This means that the minumum time to sync all data to disk is :ts:cv:`proxy.config.cache.hostdb.sync_frequency` * 64
+
 Logging Configuration
 =====================
 

--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -1465,13 +1465,13 @@ HostDBContinuation::dnsEvent(int event, HostEnt *e)
   } else {
     bool failed = !e;
 
-    bool rr = false;
+    bool is_rr = false;
     pending_action = NULL;
 
     if (is_srv()) {
-      rr = !failed && (e->srv_hosts.srv_host_count > 0);
+      is_rr = !failed && (e->srv_hosts.srv_host_count > 0);
     } else if (!failed) {
-      rr = 0 != e->ent.h_addr_list[1];
+      is_rr = 0 != e->ent.h_addr_list[1];
     } else {
     }
 
@@ -1495,7 +1495,7 @@ HostDBContinuation::dnsEvent(int event, HostEnt *e)
     int n = 0, nn = 0;
     void *first = 0;
     uint8_t af = e ? e->ent.h_addrtype : AF_UNSPEC; // address family
-    if (rr) {
+    if (is_rr) {
       if (is_srv() && !failed) {
         n = e->srv_hosts.srv_host_count;
       } else {
@@ -1514,7 +1514,7 @@ HostDBContinuation::dnsEvent(int event, HostEnt *e)
         }
         if (!first) {
           failed = true;
-          rr = false;
+          is_rr = false;
         }
       }
     } else if (!failed) {
@@ -1527,13 +1527,13 @@ HostDBContinuation::dnsEvent(int event, HostEnt *e)
     if (is_byname()) {
       if (first)
         ip_addr_set(tip, af, first);
-      r = lookup_done(tip, md5.host_name, rr, ttl_seconds, failed ? 0 : &e->srv_hosts);
+      r = lookup_done(tip, md5.host_name, is_rr, ttl_seconds, failed ? 0 : &e->srv_hosts);
     } else if (is_srv()) {
       if (!failed)
         tip._family = AF_INET;       // force the tip valid, or else the srv will fail
       r = lookup_done(tip,           /* junk: FIXME: is the code in lookup_done() wrong to NEED this? */
                       md5.host_name, /* hostname */
-                      rr,            /* is round robin, doesnt matter for SRV since we recheck getCount() inside lookup_done() */
+                      is_rr,            /* is round robin, doesnt matter for SRV since we recheck getCount() inside lookup_done() */
                       ttl_seconds,   /* ttl in seconds */
                       failed ? 0 : &e->srv_hosts);
     } else if (failed) {
@@ -1545,7 +1545,7 @@ HostDBContinuation::dnsEvent(int event, HostEnt *e)
     // @c lookup_done should always return a valid value so @a r should be null @c NULL.
     ink_assert(r && r->app.allotment.application1 == 0 && r->app.allotment.application2 == 0);
 
-    if (rr) {
+    if (is_rr) {
       const int rrsize = HostDBRoundRobin::size(n, e->srv_hosts.srv_hosts_length);
       HostDBRoundRobin *rr_data = (HostDBRoundRobin *)hostDB.alloc(&r->app.rr.offset, rrsize);
 
@@ -1652,7 +1652,7 @@ HostDBContinuation::dnsEvent(int event, HostEnt *e)
         r->round_robin_elt = 0;
       }
     }
-    if (!failed && !rr && !is_srv())
+    if (!failed && !is_rr && !is_srv())
       restore_info(r, old_r, old_info, old_rr_data);
     ink_assert(!r || !r->round_robin || !r->reverse_dns);
     ink_assert(failed || !r->round_robin || r->app.rr.offset);


### PR DESCRIPTION
While looking into hostdb serialization out to disk, I found a couple things: (1) rr is a very confusing name, and its overloaded-- so a patch for that. (2) hostdb.sync_frequency isn't documented at all-- and its a fairly important configuration option.