### PR TITLE
TS-4243:  Added collapsed_forward to the parent makefile so it will g…

### DIFF
--- a/plugins/experimental/Makefile.am
+++ b/plugins/experimental/Makefile.am
@@ -23,6 +23,7 @@ SUBDIRS = \
  cache_range_requests \
  cache_promote \
  collapsed_connection \
+ collapsed_forwarding \
  custom_redirect \
  epic \
  escalate \

--- a/plugins/experimental/collapsed_forwarding/collapsed_forwarding.cc
+++ b/plugins/experimental/collapsed_forwarding/collapsed_forwarding.cc
@@ -195,7 +195,7 @@ on_send_response_header(RequestData *req, TSHttpTxn &txnp, TSCont &contp)
   TSHttpStatus status = TSHttpHdrStatusGet(bufp, hdr_loc);
   TSDebug(DEBUG_TAG, "Response code: %d", status);
 
-  if ((status == TS_HTTP_STATUS_BAD_GATEWAY) || (status == TS_HTTP_STATUS_SEE_OTHER)) {
+  if ((status == TS_HTTP_STATUS_BAD_GATEWAY) || (status == TS_HTTP_STATUS_SEE_OTHER) || status == TS_HTTP_STATUS_INTERNAL_SERVER_ERROR) {
     bool is_internal_message_hdr = check_internal_message_hdr(txnp);
     bool delay_request =
       is_internal_message_hdr || ((req->wl_retry > 0) && (req->wl_retry < OPEN_WRITE_FAIL_MAX_REQ_DELAY_RETRIES));

--- a/plugins/experimental/collapsed_forwarding/collapsed_forwarding.cc
+++ b/plugins/experimental/collapsed_forwarding/collapsed_forwarding.cc
@@ -216,7 +216,7 @@ on_send_response_header(RequestData *req, TSHttpTxn &txnp, TSCont &contp)
   }
 
   // done..cleanup
-  TSfree(req);
+  delete req;
   TSContDestroy(contp);
 
   TSHandleMLocRelease(bufp, TS_NULL_MLOC, hdr_loc);
@@ -242,8 +242,8 @@ collapsed_cont(TSCont contp, TSEvent event, void *edata)
   case TS_EVENT_HTTP_READ_RESPONSE_HDR: {
     return on_read_response_header(txnp);
   }
-  case TSEvent::TS_EVENT_IMMEDIATE:
-  case TSEvent::TS_EVENT_TIMEOUT: {
+  case TS_EVENT_IMMEDIATE:
+  case TS_EVENT_TIMEOUT: {
     return on_immediate(my_req, contp);
   }
   case TS_EVENT_HTTP_SEND_RESPONSE_HDR: {
@@ -286,16 +286,14 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
 {
   TSCont cont = TSContCreate(collapsed_cont, TSMutexCreate());
 
-  RequestData *req_data;
-  req_data = static_cast<RequestData *>(TSmalloc(sizeof(RequestData)));
-  memset(req_data, 0, sizeof(RequestData));
+  RequestData *req_data = new RequestData();
 
   req_data->txnp = rh;
   req_data->wl_retry = 0;
 
   int url_len = 0;
   char *url = TSHttpTxnEffectiveUrlStringGet(rh, &url_len);
-  req_data->req_url = std::string(url, url_len);
+  req_data->req_url.assign(url, url_len);
 
   TSfree(url);
   TSContDataSet(cont, req_data);


### PR DESCRIPTION
…et built.

Also changed the allocation of the RequestData so the std::string member is appropriately initialized. This was
causing a crash when running.  And fixed a compile error I saw in RHEL 6