### PR TITLE
TS-4257: Using original scheme and check for not set in log field cqus

### DIFF
--- a/proxy/logging/LogAccessHttp.cc
+++ b/proxy/logging/LogAccessHttp.cc
@@ -544,11 +544,19 @@ LogAccessHttp::marshal_client_req_url_path(char *buf)
 int
 LogAccessHttp::marshal_client_req_url_scheme(char *buf)
 {
-  char *str = NULL;
-  int alen = 0;
+  int scheme = m_http_sm->t_state.orig_scheme;
+  const char *str = NULL;
+  int alen;
   int plen = INK_MIN_ALIGN;
 
-  str = (char *)m_client_request->scheme_get(&alen);
+  // If the transaction aborts very early, the scheme may not be set, or so ASAN reports.
+  if (scheme >= 0) {
+    str = hdrtoken_index_to_wks(scheme);
+    alen = hdrtoken_index_to_length(scheme);
+  } else {
+    str = "UNKNOWN";
+    alen = strlen(str);
+  }
 
   // calculate the the padded length only if the actual length
   // is not zero. We don't want the padded length to be zero


### PR DESCRIPTION
This is two fixes used inside Yahoo!, both to the same method. {{orig_scheme}} is used to prevent the log field from always reporting "http" and that value also needs to be checked because in certain cases in can be -1 which causes ASAN to get upset.