### PR TITLE
TS-1775: General hrtime cleanup.

### DIFF
--- a/iocore/aio/AIO.cc
+++ b/iocore/aio/AIO.cc
@@ -116,7 +116,7 @@ static AIOTestData *data;
 int
 AIOTestData::ink_aio_stats(int event, void *d)
 {
-  ink_hrtime now = ink_get_hrtime();
+  ink_hrtime now = Thread::get_hrtime();
   double time_msec = (double)(now - start) / (double)HRTIME_MSECOND;
   int i = (aio_reqs[0] == NULL) ? 1 : 0;
   for (; i < num_filedes; ++i)
@@ -509,7 +509,7 @@ aio_thread_main(void *arg)
         op->thread->schedule_imm_signal(op);
       ink_mutex_acquire(&my_aio_req->aio_mutex);
     } while (1);
-    timespec timedwait_msec = ink_hrtime_to_timespec(Thread::get_hrtime() + HRTIME_MSECONDS(net_config_poll_timeout));
+    timespec timedwait_msec = ink_hrtime_to_timespec(Thread::get_hrtime_updated() + HRTIME_MSECONDS(net_config_poll_timeout));
     ink_cond_timedwait(&my_aio_req->aio_cond, &my_aio_req->aio_mutex, &timedwait_msec);
   }
   return 0;

--- a/iocore/cache/CacheDir.cc
+++ b/iocore/cache/CacheDir.cc
@@ -1425,25 +1425,25 @@ EXCLUSIVE_REGRESSION_TEST(Cache_dir)(RegressionTest *t, int /* atype ATS_UNUSED 
   // test insert-delete
   rprintf(t, "insert-delete test\n");
   regress_rand_init(13);
-  ttime = ink_get_hrtime_internal();
+  ttime = Thread::get_hrtime_updated();
   for (i = 0; i < newfree; i++) {
     regress_rand_CacheKey(&key);
     dir_insert(&key, d, &dir);
   }
-  uint64_t us = (ink_get_hrtime_internal() - ttime) / HRTIME_USECOND;
+  uint64_t us = (Thread::get_hrtime_updated() - ttime) / HRTIME_USECOND;
   // On windows us is sometimes 0. I don't know why.
   // printout the insert rate only if its not 0
   if (us)
     rprintf(t, "insert rate = %d / second\n", (int)((newfree * (uint64_t)1000000) / us));
   regress_rand_init(13);
-  ttime = ink_get_hrtime_internal();
+  ttime = Thread::get_hrtime_updated();
   for (i = 0; i < newfree; i++) {
     Dir *last_collision = 0;
     regress_rand_CacheKey(&key);
     if (!dir_probe(&key, d, &dir, &last_collision))
       ret = REGRESSION_TEST_FAILED;
   }
-  us = (ink_get_hrtime_internal() - ttime) / HRTIME_USECOND;
+  us = (Thread::get_hrtime_updated() - ttime) / HRTIME_USECOND;
   // On windows us is sometimes 0. I don't know why.
   // printout the probe rate only if its not 0
   if (us)

--- a/iocore/eventsystem/I_Thread.h
+++ b/iocore/eventsystem/I_Thread.h
@@ -157,9 +157,37 @@ public:
   {
   }
 
+  /** Get the current ATS high resolution time.
+      This gets a cached copy of the time so it is very fast and reasonably accurate.
+      The cached time is updated every time the actual operating system time is fetched which is
+      at least every 10ms and generally more frequently.
+      @note The cached copy shared among threads which means the cached copy is udpated
+      for all threads if any thread updates it.
+  */
   static ink_hrtime get_hrtime();
+
+  /** Get the operating system high resolution time.
+
+      Get the current time at high resolution from the operating system.  This is more expensive
+      than @c get_hrtime and should be used only where very precise timing is required.
+
+      @note This also updates the cached time.
+  */
+  static ink_hrtime get_hrtime_updated();
 };
 
 extern Thread *this_thread();
+
+TS_INLINE ink_hrtime
+Thread::get_hrtime()
+{
+  return cur_time;
+}
+
+TS_INLINE ink_hrtime
+Thread::get_hrtime_updated()
+{
+  return cur_time = ink_get_hrtime_internal();
+}
 
 #endif /*_I_Thread_h*/

--- a/iocore/eventsystem/PQ-List.cc
+++ b/iocore/eventsystem/PQ-List.cc
@@ -25,7 +25,7 @@
 
 PriorityEventQueue::PriorityEventQueue()
 {
-  last_check_time = ink_get_based_hrtime_internal();
+  last_check_time = Thread::get_hrtime_updated();
   last_check_buckets = last_check_time / PQ_BUCKET_TIME(0);
 }
 

--- a/iocore/eventsystem/P_UnixEventProcessor.h
+++ b/iocore/eventsystem/P_UnixEventProcessor.h
@@ -90,7 +90,7 @@ EventProcessor::schedule_imm_signal(Continuation *cont, EventType et, int callba
 
   ink_assert(et < MAX_EVENT_TYPES);
 #ifdef ENABLE_TIME_TRACE
-  e->start_time = ink_get_hrtime();
+  e->start_time = Thread::get_hrtime();
 #endif
   e->callback_event = callback_event;
   e->cookie = cookie;
@@ -104,7 +104,7 @@ EventProcessor::schedule_imm(Continuation *cont, EventType et, int callback_even
 
   ink_assert(et < MAX_EVENT_TYPES);
 #ifdef ENABLE_TIME_TRACE
-  e->start_time = ink_get_hrtime();
+  e->start_time = Thread::get_hrtime();
 #endif
   e->callback_event = callback_event;
   e->cookie = cookie;

--- a/iocore/eventsystem/Thread.cc
+++ b/iocore/eventsystem/Thread.cc
@@ -102,9 +102,3 @@ Thread::start(const char *name, size_t stacksize, ThreadFunction f, void *a)
 
   return tid;
 }
-
-ink_hrtime
-Thread::get_hrtime()
-{
-  return Thread::cur_time;
-}

--- a/iocore/eventsystem/UnixEThread.cc
+++ b/iocore/eventsystem/UnixEThread.cc
@@ -42,14 +42,14 @@ struct AIOCallback;
 bool shutdown_event_system = false;
 
 EThread::EThread()
-  : generator((uint64_t)ink_get_hrtime_internal() ^ (uint64_t)(uintptr_t) this), ethreads_to_be_signalled(NULL),
+  : generator((uint64_t)Thread::get_hrtime_updated() ^ (uint64_t)(uintptr_t) this), ethreads_to_be_signalled(NULL),
     n_ethreads_to_be_signalled(0), main_accept_index(-1), id(NO_ETHREAD_ID), event_types(0), signal_hook(0), tt(REGULAR)
 {
   memset(thread_private, 0, PER_THREAD_DATA);
 }
 
 EThread::EThread(ThreadType att, int anid)
-  : generator((uint64_t)ink_get_hrtime_internal() ^ (uint64_t)(uintptr_t) this), ethreads_to_be_signalled(NULL),
+  : generator((uint64_t)Thread::get_hrtime_updated() ^ (uint64_t)(uintptr_t) this), ethreads_to_be_signalled(NULL),
     n_ethreads_to_be_signalled(0), main_accept_index(-1), id(anid), event_types(0), signal_hook(0), tt(att),
     server_session_pool(NULL)
 {
@@ -136,7 +136,7 @@ EThread::process_event(Event *e, int calling_code)
         if (e->period < 0)
           e->timeout_at = e->period;
         else {
-          cur_time = get_hrtime();
+          this->get_hrtime_updated();
           e->timeout_at = cur_time + e->period;
           if (e->timeout_at < cur_time)
             e->timeout_at = cur_time;
@@ -175,7 +175,7 @@ EThread::execute()
       }
       // execute all the available external events that have
       // already been dequeued
-      cur_time = ink_get_based_hrtime_internal();
+      cur_time = Thread::get_hrtime_updated();
       while ((e = EventQueueExternal.dequeue_local())) {
         if (e->cancelled)
           free_event(e);

--- a/iocore/eventsystem/UnixEventProcessor.cc
+++ b/iocore/eventsystem/UnixEventProcessor.cc
@@ -85,7 +85,7 @@ EventProcessor::start(int n_event_threads, size_t stacksize)
     if (i == 0) {
       ink_thread_setspecific(Thread::thread_data_key, t);
       global_mutex = t->mutex;
-      t->cur_time = ink_get_based_hrtime_internal();
+      Thread::get_hrtime_updated();
     }
     all_ethreads[i] = t;
 

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -698,7 +698,7 @@ SSLNetVConnection::load_buffer_and_write(int64_t towrite, int64_t &wattempted, i
   // Dynamic TLS record sizing
   ink_hrtime now = 0;
   if (SSLConfigParams::ssl_maxrecord == -1) {
-    now = ink_get_hrtime_internal();
+    now = Thread::get_hrtime_updated();
     int msec_since_last_write = ink_hrtime_diff_msec(now, sslLastWriteTime);
 
     if (msec_since_last_write > SSL_DEF_TLS_RECORD_MSEC_THRESHOLD) {

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1163,7 +1163,7 @@ UnixNetVConnection::mainEvent(int event, Event *e)
   if (event == EVENT_IMMEDIATE) {
     /* BZ 49408 */
     // ink_assert(inactivity_timeout_in);
-    // ink_assert(next_inactivity_timeout_at < ink_get_hrtime());
+    // ink_assert(next_inactivity_timeout_at < Thread::get_hrtime());
     if (!inactivity_timeout_in || next_inactivity_timeout_at > Thread::get_hrtime())
       return EVENT_CONT;
     signal_event = VC_EVENT_INACTIVITY_TIMEOUT;

--- a/iocore/net/UnixUDPNet.cc
+++ b/iocore/net/UnixUDPNet.cc
@@ -630,7 +630,7 @@ void
 UDPQueue::service(UDPNetHandler *nh)
 {
   (void)nh;
-  ink_hrtime now = ink_get_hrtime_internal();
+  ink_hrtime now = Thread::get_hrtime_updated();
   uint64_t timeSpent = 0;
   uint64_t pktSendStartTime;
   UDPPacketInternal *p;
@@ -684,8 +684,8 @@ void
 UDPQueue::SendPackets()
 {
   UDPPacketInternal *p;
-  static ink_hrtime lastCleanupTime = ink_get_hrtime_internal();
-  ink_hrtime now = ink_get_hrtime_internal();
+  static ink_hrtime lastCleanupTime = Thread::get_hrtime_updated();
+  ink_hrtime now = Thread::get_hrtime_updated();
   ink_hrtime send_threshold_time = now + SLOT_TIME;
   int32_t bytesThisSlot = INT_MAX, bytesUsed = 0;
   int32_t bytesThisPipe, sentOne;
@@ -721,7 +721,7 @@ sendPackets:
 
   if ((bytesThisSlot > 0) && sentOne) {
     // redistribute the slack...
-    now = ink_get_hrtime_internal();
+    now = Thread::get_hrtime_updated();
     if (pipeInfo.firstPacket(now) == NULL) {
       pipeInfo.advanceNow(now);
     }
@@ -797,7 +797,7 @@ UDPNetHandler::UDPNetHandler()
   mutex = new_ProxyMutex();
   ink_atomiclist_init(&udpOutQueue.atomicQueue, "Outgoing UDP Packet queue", offsetof(UDPPacketInternal, alink.next));
   ink_atomiclist_init(&udpNewConnections, "UDP Connection queue", offsetof(UnixUDPConnection, newconn_alink.next));
-  nextCheck = ink_get_hrtime_internal() + HRTIME_MSECONDS(1000);
+  nextCheck = Thread::get_hrtime_updated() + HRTIME_MSECONDS(1000);
   lastCheck = 0;
   SET_HANDLER((UDPNetContHandler)&UDPNetHandler::startNetEvent);
 }
@@ -847,7 +847,7 @@ UDPNetHandler::mainNetEvent(int event, Event *e)
   }   // end for
 
   // remove dead UDP connections
-  ink_hrtime now = ink_get_hrtime_internal();
+  ink_hrtime now = Thread::get_hrtime_updated();
   if (now >= nextCheck) {
     for (uc = udp_polling.head; uc; uc = next) {
       ink_assert(uc->mutex && uc->continuation);
@@ -859,7 +859,7 @@ UDPNetHandler::mainNetEvent(int event, Event *e)
         uc->Release();
       }
     }
-    nextCheck = ink_get_hrtime_internal() + HRTIME_MSECONDS(1000);
+    nextCheck = Thread::get_hrtime_updated() + HRTIME_MSECONDS(1000);
   }
   // service UDPConnections with data ready for callback.
   Que(UnixUDPConnection, callback_link) q = udp_callbacks;

--- a/proxy/TestDNS.cc
+++ b/proxy/TestDNS.cc
@@ -181,7 +181,7 @@ complete()
   ink_hrtime now;
   state_machines_finished++;
   if (!(state_machines_finished % measurement_interval)) {
-    now = ink_get_hrtime();
+    now = Thread::get_hrtime();
     cumul_throughput = state_machines_finished * 1.0 * HRTIME_SECOND / (now - start_time);
     throughput = measurement_interval * 1.0 * HRTIME_SECOND / (now - last_measurement_time);
     last_measurement_time = now;
@@ -199,7 +199,7 @@ complete()
     fout_rate.flush();
   }
   if (state_machines_finished == state_machines_created) {
-    now = ink_get_hrtime();
+    now = Thread::get_hrtime();
     fout_rate_misc << (now - start_time) * 1.0 / HRTIME_SECOND << "\n";
     fout_rate_misc.flush();
     fout.close();
@@ -240,14 +240,14 @@ test()
   state_machines_created = N_STATE_MACHINES;
   state_machines_finished = 0;
   measurement_interval = MEASUREMENT_INTERVAL;
-  start_time = ink_get_hrtime();
-  last_measurement_time = ink_get_hrtime();
+  start_time = Thread::get_hrtime();
+  last_measurement_time = Thread::get_hrtime();
   while ((fscanf(fin, "%s", host) != EOF) && (i < state_machines_created)) {
     test_dns_state_machine = new TestDnsStateMachine(host, sizeof(host));
     test_dns_state_machine->handleEvent();
     i++;
   }
-  now = ink_get_hrtime();
+  now = Thread::get_hrtime();
   cout << "Finished creating all Continuations at " << (now - start_time) / HRTIME_SECOND << " sec and "
        << (now - start_time) % HRTIME_SECOND << "nanosec\n";
   fout_rate_misc << (now - start_time) * 1.0 / HRTIME_SECOND << "\n";


### PR DESCRIPTION
This removes as much as possible references to TS lib hr time functions and replaces them with calls to `Thread`. There are some other minor clean ups based on the discussion of TS-1775.