### PR TITLE
Potential Fix for TS-4207

### DIFF
--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -2862,6 +2862,7 @@ ParseHostLine(RefCountedHostsFileMap *map, char *l)
       // If we don't have an entry already (host files only support single IPs for a given name)
       if (map->hosts_file_map.find(name) == map->hosts_file_map.end()) {
         HostsFileMap::mapped_type &item = map->hosts_file_map[name];
+        memset(&item, 0, sizeof(item));
         item.round_robin = false;
         item.round_robin_elt = false;
         item.reverse_dns = false;


### PR DESCRIPTION
std::map is creating an entry, and we are setting a subset of values. Since we were not clearing the memory that we got, we end up with some non-initialized structure fields-- meaning the HostDBInfo object we return is corrupt.