### PR TITLE
TS-3535: Experimental Support of Stream Priority Feature in HTTP/2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,8 @@ iocore/eventsystem/test_Event
 proxy/config/records.config.default
 proxy/config/storage.config.default
 proxy/http2/test_Huffmancode
+proxy/http2/test_Http2DependencyTree
+proxy/http2/test_Http2PriorityQueue
 
 plugins/header_rewrite/header_rewrite_test
 plugins/experimental/esi/*_test

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1975,6 +1975,8 @@ static const RecordElement RecordsConfig[] =
   //############
   {RECT_CONFIG, "proxy.config.http2.enabled", RECD_INT, "0", RECU_RESTART_TM, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.http2.stream_priority_enabled", RECD_INT, "0", RECU_RESTART_TM, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
+  ,
   {RECT_CONFIG, "proxy.config.http2.max_concurrent_streams_in", RECD_INT, "100", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.http2.initial_window_size_in", RECD_INT, "1048576", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}

--- a/proxy/FetchSM.h
+++ b/proxy/FetchSM.h
@@ -129,6 +129,11 @@ public:
     is_internal_request = val;
   }
 
+  VIO* get_read_vio()
+  {
+    return read_vio;
+  }
+
 private:
   int InvokePlugin(int event, void *data);
   void InvokePluginExt(int error_event = 0);

--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -60,6 +60,10 @@ const uint32_t HTTP2_MAX_FRAME_SIZE = 16384;
 const uint32_t HTTP2_HEADER_TABLE_SIZE = 4096;
 const uint32_t HTTP2_MAX_HEADER_LIST_SIZE = UINT_MAX;
 
+// [RFC 7540] 5.3.5 Default Priorities
+const uint32_t HTTP2_PRIORITY_DEFAULT_STREAM_DEPENDENCY = 0;
+const uint8_t HTTP2_PRIORITY_DEFAULT_WEIGHT = 15;
+
 // Statistics
 enum {
   HTTP2_STAT_CURRENT_CLIENT_SESSION_COUNT,  // Current # of active HTTP2
@@ -247,10 +251,14 @@ struct Http2SettingsParameter {
 
 // [RFC 7540] 6.3 PRIORITY Format
 struct Http2Priority {
-  Http2Priority() : stream_dependency(0), weight(15) {}
+  Http2Priority()
+    : exclusive_flag(false), weight(HTTP2_PRIORITY_DEFAULT_WEIGHT), stream_dependency(HTTP2_PRIORITY_DEFAULT_STREAM_DEPENDENCY)
+  {
+  }
 
-  uint32_t stream_dependency;
+  bool exclusive_flag;
   uint8_t weight;
+  uint32_t stream_dependency;
 };
 
 // [RFC 7540] 6.2 HEADERS Format
@@ -342,6 +350,7 @@ int64_t http2_write_header_fragment(HTTPHdr *, MIMEFieldIter &, uint8_t *, uint6
 class Http2
 {
 public:
+  static bool stream_priority_enabled;
   static uint32_t max_concurrent_streams;
   static uint32_t initial_window_size;
   static uint32_t max_frame_size;

--- a/proxy/http2/Http2DependencyTree.h
+++ b/proxy/http2/Http2DependencyTree.h
@@ -1,0 +1,279 @@
+/** @file
+
+  HTTP/2 Dependency Tree
+
+  The original idea of Stream Priority Algorithm using Weighted Fair Queue (WFQ)
+  Scheduling is invented by Kazuho Oku (H2O project).
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#ifndef __HTTP2_DEP_TREE_H__
+#define __HTTP2_DEP_TREE_H__
+
+#include "ts/List.h"
+#include "ts/Diags.h"
+#include "HTTP2.h"
+#include "Http2PriorityQueue.h"
+
+// TODO: K is a constant, 256 is temporal value.
+const static int K = 256;
+
+template <typename T> class Http2DependencyTree
+{
+public:
+  class Node
+  {
+  public:
+    Node()
+      : active(false), queued(false), id(HTTP2_PRIORITY_DEFAULT_STREAM_DEPENDENCY), weight(HTTP2_PRIORITY_DEFAULT_WEIGHT), point(0),
+        parent(NULL), t(NULL)
+    {
+      entry = new Http2PriorityQueueEntry<Node *>(this);
+    }
+    Node(uint32_t i, uint32_t w, uint32_t p, Node *n, T t)
+      : active(false), queued(false), id(i), weight(w), point(p), parent(n), t(t)
+    {
+      entry = new Http2PriorityQueueEntry<Node *>(this);
+    }
+
+    ~Node()
+    {
+      delete entry;
+
+      // delete all child nodes
+      if (!children.empty()) {
+        Node *node = children.head;
+        Node *next = NULL;
+        while (node) {
+          next = node->link.next;
+          children.remove(node);
+          delete node;
+          node = next;
+        }
+      }
+    }
+
+    LINK(Node, link);
+
+    bool operator<(const Node &n) const { return point < n.point; }
+    bool operator>(const Node &n) const { return point > n.point; }
+
+    bool active;
+    bool queued;
+    uint32_t id;
+    uint32_t weight;
+    uint32_t point;
+    Node *parent;
+    DLL<Node> children;
+    Http2PriorityQueueEntry<Node *> *entry;
+    Http2PriorityQueue<Node *> queue;
+    T t;
+  };
+
+  Http2DependencyTree() { _root = new Node(); }
+  ~Http2DependencyTree() { delete _root; }
+
+  Node *find(uint32_t id);
+  void add(uint32_t parent_id, uint32_t id, uint32_t weight, bool exclusive, T t);
+  void reprioritize(uint32_t new_parent_id, uint32_t id, bool exclusive);
+  Node *top();
+  void activate(Node *node);
+  void deactivate(Node *node, uint32_t sent);
+  void update(Node *node, uint32_t sent);
+
+private:
+  Node *_find(Node *node, uint32_t id);
+  Node *_top(Node *node);
+  void _change_parent(Node *new_parent, Node *node, bool exclusive);
+
+  Node *_root;
+};
+
+// TODO: Add a link to Node from Http2Stream after TS-3612 to avoid calling this function.
+template <typename T>
+typename Http2DependencyTree<T>::Node *
+Http2DependencyTree<T>::_find(Node *node, uint32_t id)
+{
+  if (node->id == id) {
+    return node;
+  }
+
+  if (node->children.empty()) {
+    return NULL;
+  }
+
+  Node *result = NULL;
+  for (Node *n = node->children.head; n; n = n->link.next) {
+    result = _find(n, id);
+    if (result != NULL) {
+      break;
+    }
+  }
+
+  return result;
+}
+
+template <typename T>
+typename Http2DependencyTree<T>::Node *
+Http2DependencyTree<T>::find(uint32_t id)
+{
+  return _find(_root, id);
+}
+
+template <typename T>
+void
+Http2DependencyTree<T>::add(uint32_t parent_id, uint32_t id, uint32_t weight, bool exclusive, T t)
+{
+  Node *parent = find(parent_id);
+  if (parent == NULL) {
+    parent = _root;
+  }
+
+  Node *node = new Node(id, weight, 0, parent, t);
+
+  if (exclusive) {
+    while (Node *child = parent->children.pop()) {
+      node->children.push(child);
+      child->parent = node;
+    }
+  }
+
+  parent->children.push(node);
+}
+
+template <typename T>
+void
+Http2DependencyTree<T>::reprioritize(uint32_t id, uint32_t new_parent_id, bool exclusive)
+{
+  Node *node = find(id);
+  if (node == NULL) {
+    return;
+  }
+
+  Node *old_parent = node->parent;
+  if (old_parent->id == new_parent_id) {
+    // Do nothing
+    return;
+  }
+
+  Node *new_parent = find(new_parent_id);
+  if (new_parent == NULL) {
+    return;
+  }
+  _change_parent(new_parent, old_parent, false);
+  _change_parent(node, new_parent, exclusive);
+}
+
+// Change node's parent to new_parent
+template <typename T>
+void
+Http2DependencyTree<T>::_change_parent(Node *node, Node *new_parent, bool exclusive)
+{
+  node->parent->children.remove(node);
+  node->parent = NULL;
+
+  if (exclusive) {
+    while (Node *child = new_parent->children.pop()) {
+      node->children.push(child);
+      child->parent = node;
+    }
+  }
+
+  new_parent->children.push(node);
+  node->parent = new_parent;
+}
+
+template <typename T>
+typename Http2DependencyTree<T>::Node *
+Http2DependencyTree<T>::_top(Node *node)
+{
+  Node *child = node;
+
+  while (child != NULL) {
+    if (child->active) {
+      return child;
+    } else if (!child->queue.empty()) {
+      child = child->queue.top()->node;
+    } else {
+      return NULL;
+    }
+  }
+
+  return child;
+}
+
+
+template <typename T>
+typename Http2DependencyTree<T>::Node *
+Http2DependencyTree<T>::top()
+{
+  return _top(_root);
+}
+
+template <typename T>
+void
+Http2DependencyTree<T>::activate(Node *node)
+{
+  node->active = true;
+
+  while (node->parent != NULL && !node->queued) {
+    node->parent->queue.push(node->entry);
+    node->queued = true;
+    node = node->parent;
+  }
+}
+
+template <typename T>
+void
+Http2DependencyTree<T>::deactivate(Node *node, uint32_t sent)
+{
+  node->active = false;
+
+  while (node->queue.empty() && node->parent != NULL) {
+    ink_assert(node->parent->queue.top() == node->entry);
+
+    node->parent->queue.pop();
+    node->queued = false;
+
+    node = node->parent;
+  }
+
+  update(node, sent);
+}
+
+template <typename T>
+void
+Http2DependencyTree<T>::update(Node *node, uint32_t sent)
+{
+  while (node->parent != NULL) {
+    node->point += sent * K / (node->weight + 1);
+
+    if (node->queued) {
+      node->parent->queue.update(node->entry);
+    } else {
+      node->parent->queue.push(node->entry);
+      node->queued = true;
+    }
+
+    node = node->parent;
+  }
+}
+
+#endif // __HTTP2_DEP_TREE_H__

--- a/proxy/http2/Http2PriorityQueue.h
+++ b/proxy/http2/Http2PriorityQueue.h
@@ -1,0 +1,194 @@
+/** @file
+
+  HTTP/2 Priority Queue
+
+  Priority Queue Implimentation using Min Heap.
+  Used by HTTP/2 Dependency Tree for WFQ Scheduling.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#ifndef __HTTP2_PRIORITY_QUEUE_H__
+#define __HTTP2_PRIORITY_QUEUE_H__
+
+#include "ts/Diags.h"
+#include "ts/Vec.h"
+
+template <typename T> struct Http2PriorityQueueEntry {
+  Http2PriorityQueueEntry(T n) : index(0), node(n) {}
+
+  uint32_t index;
+  T node;
+};
+
+template <typename T> class Http2PriorityQueue
+{
+public:
+  Http2PriorityQueue() {}
+  ~Http2PriorityQueue() {}
+
+  const bool empty();
+  Http2PriorityQueueEntry<T> *top();
+  void pop();
+  void push(Http2PriorityQueueEntry<T> *);
+  void update(Http2PriorityQueueEntry<T> *, bool);
+  const Vec<Http2PriorityQueueEntry<T> *> &dump() const;
+
+private:
+  Vec<Http2PriorityQueueEntry<T> *> _v;
+
+  void _swap(uint32_t, uint32_t);
+  void _bubble_up(uint32_t);
+  void _bubble_down(uint32_t);
+};
+
+template <typename T>
+const Vec<Http2PriorityQueueEntry<T> *> &
+Http2PriorityQueue<T>::dump() const
+{
+  return _v;
+}
+
+template <typename T>
+const bool
+Http2PriorityQueue<T>::empty()
+{
+  return _v.length() == 0;
+}
+
+template <typename T>
+void
+Http2PriorityQueue<T>::push(Http2PriorityQueueEntry<T> *entry)
+{
+  ink_release_assert(entry != NULL);
+
+  int len = _v.length();
+  _v.push_back(entry);
+  entry->index = len;
+
+  _bubble_up(len);
+}
+
+template <typename T>
+Http2PriorityQueueEntry<T> *
+Http2PriorityQueue<T>::top()
+{
+  if (empty()) {
+    return NULL;
+  } else {
+    return _v[0];
+  }
+}
+
+template <typename T>
+void
+Http2PriorityQueue<T>::pop()
+{
+  if (empty()) {
+    return;
+  }
+
+  _v[0] = _v[_v.length() - 1];
+  _v.pop();
+  _bubble_down(0);
+}
+
+template <typename T>
+void
+Http2PriorityQueue<T>::update(Http2PriorityQueueEntry<T> *entry, bool increased = true)
+{
+  ink_release_assert(entry != NULL);
+
+  if (empty()) {
+    return;
+  }
+
+  if (increased) {
+    _bubble_down(entry->index);
+  } else {
+    _bubble_up(entry->index);
+  }
+}
+
+template <typename T>
+void
+Http2PriorityQueue<T>::_swap(uint32_t i, uint32_t j)
+{
+  Http2PriorityQueueEntry<T> *tmp = _v[i];
+  _v[i] = _v[j];
+  _v[j] = tmp;
+
+  _v[i]->index = i;
+  _v[j]->index = j;
+}
+
+
+template <typename T>
+void
+Http2PriorityQueue<T>::_bubble_up(uint32_t index)
+{
+  if (empty()) {
+    ink_release_assert(false);
+  }
+
+  uint32_t parent;
+  while (index != 0) {
+    parent = (index - 1) / 2;
+    if (*(_v[index]->node) < *(_v[parent]->node)) {
+      _swap(parent, index);
+      index = parent;
+      continue;
+    }
+
+    break;
+  }
+}
+
+
+template <typename T>
+void
+Http2PriorityQueue<T>::_bubble_down(uint32_t index)
+{
+  if (empty()) {
+    // Do nothing
+    return;
+  }
+
+  uint32_t left, right, smaller;
+
+  while (true) {
+    if ((left = index * 2 + 1) >= _v.length()) {
+      break;
+    } else if ((right = index * 2 + 2) >= _v.length()) {
+      smaller = left;
+    } else {
+      smaller = (*(_v[left]->node) < *(_v[right]->node)) ? left : right;
+    }
+
+    if (*(_v[smaller]->node) < *(_v[index]->node)) {
+      _swap(smaller, index);
+      index = smaller;
+      continue;
+    }
+
+    break;
+  }
+}
+
+#endif // __HTTP2_PRIORITY_QUEUE_H__

--- a/proxy/http2/Makefile.am
+++ b/proxy/http2/Makefile.am
@@ -42,6 +42,8 @@ libhttp2_a_SOURCES = \
   Http2ConnectionState.h \
   Http2DebugNames.cc \
   Http2DebugNames.h \
+  Http2DependencyTree.h \
+  Http2PriorityQueue.h \
   Http2Stream.cc \
   Http2Stream.h \
   Http2SessionAccept.cc \
@@ -55,9 +57,14 @@ if BUILD_TESTS
 endif
 
 noinst_PROGRAMS = \
-  test_Huffmancode
+  test_Huffmancode \
+  test_Http2DependencyTree \
+  test_Http2PriorityQueue
 
-TESTS = test_Huffmancode
+TESTS = \
+  test_Huffmancode \
+  test_Http2DependencyTree \
+  test_Http2PriorityQueue
 
 test_Huffmancode_LDADD = \
   $(top_builddir)/lib/ts/libtsutil.la
@@ -66,3 +73,17 @@ test_Huffmancode_SOURCES = \
   test_Huffmancode.cc \
   HuffmanCodec.cc \
   HuffmanCodec.h
+
+test_Http2DependencyTree_LDADD = \
+  $(top_builddir)/lib/ts/libtsutil.la
+
+test_Http2DependencyTree_SOURCES = \
+  test_Http2DependencyTree.cc \
+  Http2DependencyTree.h
+
+test_Http2PriorityQueue_LDADD = \
+  $(top_builddir)/lib/ts/libtsutil.la
+
+test_Http2PriorityQueue_SOURCES = \
+  test_Http2PriorityQueue.cc \
+  Http2PriorityQueue.h

--- a/proxy/http2/test_Http2DependencyTree.cc
+++ b/proxy/http2/test_Http2DependencyTree.cc
@@ -1,0 +1,367 @@
+/** @file
+
+    Unit tests for Http2DependencyTree
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <stdlib.h>
+#include <iostream>
+#include <assert.h>
+#include <string.h>
+#include <sstream>
+
+#include "Http2DependencyTree.h"
+
+using namespace std;
+
+
+typedef Http2DependencyTree<string *> Tree;
+
+/**
+ * Exclusive Dependency Creation
+ *
+ *       A            A
+ *      / \    =>     |
+ *     B   C          D
+ *                   / \
+ *                  B   C
+ */
+bool
+exclusive_dependency_creaion()
+{
+  Tree *tree = new Tree();
+  string a("A"), b("B"), c("C"), d("D");
+
+  tree->add(0, 1, 0, false, &b);
+  tree->add(0, 3, 0, false, &c);
+
+  Tree::Node *node_a = tree->find(0);
+  Tree::Node *node_b = tree->find(1);
+  Tree::Node *node_c = tree->find(3);
+
+  ink_assert(node_b->parent == node_a);
+  ink_assert(node_c->parent == node_a);
+
+  // Add node with exclusive flag
+  tree->add(0, 5, 0, true, &d);
+
+  Tree::Node *node_d = tree->find(5);
+
+  ink_assert(node_d->parent == node_a);
+  ink_assert(node_b->parent == node_d);
+  ink_assert(node_c->parent == node_d);
+
+  return true;
+}
+
+
+/**
+ * Reprioritization (non-exclusive)
+ *
+ *    x                x
+ *    |                |
+ *    A                D
+ *   / \              / \
+ *  B   C     ==>    F   A
+ *     / \              / \
+ *    D   E            B   C
+ *    |                    |
+ *    F                    E
+ */
+bool
+reprioritization()
+{
+  Tree *tree = new Tree();
+  string a("A"), b("B"), c("C"), d("D"), e("E"), f("F");
+
+  tree->add(0, 1, 0, false, &a);
+  tree->add(1, 3, 0, false, &b);
+  tree->add(1, 5, 0, false, &c);
+  tree->add(5, 7, 0, false, &d);
+  tree->add(5, 9, 0, false, &e);
+  tree->add(7, 11, 0, false, &f);
+
+  tree->reprioritize(1, 7, false);
+
+  Tree::Node *node_x = tree->find(0);
+  Tree::Node *node_a = tree->find(1);
+  Tree::Node *node_d = tree->find(7);
+  Tree::Node *node_f = tree->find(11);
+
+  ink_assert(node_a->parent == node_d);
+  ink_assert(node_d->parent == node_x);
+  ink_assert(node_f->parent == node_d);
+
+  return true;
+}
+
+/**
+ * Reprioritization (exclusive)
+ *
+ *    x              x
+ *    |              |
+ *    A              D
+ *   / \             |
+ *  B   C     ==>    A
+ *     / \          /|\
+ *    D   E        B C F
+ *    |              |
+ *    F              E
+ */
+bool
+exclusive_reprioritization()
+{
+  Tree *tree = new Tree();
+  string a("A"), b("B"), c("C"), d("D"), e("E"), f("F");
+
+  tree->add(0, 1, 0, false, &a);
+  tree->add(1, 3, 0, false, &b);
+  tree->add(1, 5, 0, false, &c);
+  tree->add(5, 7, 0, false, &d);
+  tree->add(5, 9, 0, false, &e);
+  tree->add(7, 11, 0, false, &f);
+
+  tree->reprioritize(1, 7, true);
+
+  Tree::Node *node_x = tree->find(0);
+  Tree::Node *node_a = tree->find(1);
+  Tree::Node *node_d = tree->find(7);
+  Tree::Node *node_f = tree->find(11);
+
+  ink_assert(node_a->parent == node_d);
+  ink_assert(node_d->parent == node_x);
+  ink_assert(node_f->parent == node_a);
+
+  return true;
+}
+
+
+/**
+ * Tree
+ *      ROOT
+ *      /
+ *    A(1)
+ */
+bool
+one_node()
+{
+  Tree *tree = new Tree();
+  string a("A");
+  tree->add(0, 1, 0, false, &a);
+
+  Tree::Node *node_a = tree->find(1);
+
+  ink_assert(tree->top() == NULL);
+
+  tree->activate(node_a);
+  ink_assert(tree->top() == node_a);
+
+  tree->deactivate(node_a, 0);
+  ink_assert(tree->top() == NULL);
+
+  return true;
+}
+
+/**
+ * Tree
+ *      ROOT
+ *      /
+ *    A(3)
+ *   /
+ * B(5)
+ *
+ */
+bool
+active_intermediate_node()
+{
+  Tree *tree = new Tree();
+  string a("A"), b("B"), c("C");
+
+  tree->add(0, 3, 15, false, &a);
+  tree->add(3, 5, 15, false, &b);
+
+  Tree::Node *node_a = tree->find(3);
+  Tree::Node *node_b = tree->find(5);
+
+  ink_assert(tree->top() == NULL);
+
+  tree->activate(node_a);
+  tree->activate(node_b);
+  ink_assert(tree->top() == node_a);
+
+  tree->deactivate(node_a, 0);
+  ink_assert(tree->top() == node_b);
+
+  return true;
+}
+
+/**
+ * Basic Tree
+ *      ROOT
+ *      /  \
+ *    A(3)  D(9)
+ *   /  \
+ * B(5) C(7)
+ *
+ */
+bool
+basic_tree()
+{
+  Tree *tree = new Tree();
+
+  string a("A"), b("B"), c("C"), d("D");
+
+  // NOTE, weight is actual weight - 1
+  tree->add(0, 3, 0, false, &a);
+  tree->add(3, 5, 0, false, &b);
+  tree->add(3, 7, 1, false, &c);
+  tree->add(0, 9, 1, false, &d);
+
+  Tree::Node *node_b = tree->find(5);
+  Tree::Node *node_c = tree->find(7);
+  Tree::Node *node_d = tree->find(9);
+
+  // Activate B, C and D
+  tree->activate(node_b);
+  tree->activate(node_c);
+  tree->activate(node_d);
+
+  ostringstream oss;
+
+  for (int i = 0; i < 30; ++i) {
+    Tree::Node *node = tree->top();
+    oss << node->t->c_str();
+    tree->update(node, 100);
+  }
+
+  bool result = false;
+
+  // TODO: check strictly
+  if (oss.str() == "BDDDCDDCDDCDDBDDCDDCDDBDDCDDCD") {
+    result = true;
+  } else {
+    cerr << "ERR: " << oss.str() << endl;
+    result = false;
+  }
+
+  delete tree;
+
+  return result;
+}
+
+/**
+ * Chrome's Tree
+ *      ROOT
+ *      /  \
+ *   A(3)   C(7)
+ *   /        \
+ * B(5)       D(9)
+ *
+ */
+bool
+chrome_tree()
+{
+  Tree *tree = new Tree();
+
+  string a("A"), b("B"), c("C"), d("D");
+
+  tree->add(0, 3, 15, false, &a);
+  tree->add(3, 5, 15, true, &b);
+  tree->add(0, 7, 15, false, &c);
+  tree->add(7, 9, 15, true, &d);
+
+  Tree::Node *node_a = tree->find(3);
+  Tree::Node *node_b = tree->find(5);
+  Tree::Node *node_c = tree->find(7);
+  Tree::Node *node_d = tree->find(9);
+
+  // Activate A and B
+  tree->activate(node_a);
+  tree->activate(node_b);
+  tree->activate(node_c);
+  tree->activate(node_d);
+
+  ostringstream oss;
+
+  for (int i = 0; i < 30; ++i) {
+    Tree::Node *node = tree->top();
+    oss << node->t->c_str();
+
+    if (i == 14 || i == 15) {
+      tree->deactivate(node, 100);
+    } else {
+      tree->update(node, 100);
+    }
+  }
+
+  bool result = false;
+
+  if (oss.str() == "ACCAACCAACCAACCABDDBBDDBBDDBBD") {
+    result = true;
+  } else {
+    cerr << "ERR: " << oss.str() << endl;
+    result = false;
+  }
+
+  delete tree;
+
+  return result;
+}
+
+int
+main()
+{
+  cout << "Exclusive Dependency Creation: ";
+  if (exclusive_dependency_creaion()) {
+    cout << "OK" << endl;
+  }
+
+  cout << "Reprioritization: ";
+  if (reprioritization()) {
+    cout << "OK" << endl;
+  }
+
+  cout << "Exclusive Reprioritization: ";
+  if (exclusive_reprioritization()) {
+    cout << "OK" << endl;
+  }
+
+  cout << "One node: ";
+  if (one_node()) {
+    cout << "OK" << endl;
+  }
+
+  cout << "Active Intermidiate Node: ";
+  if (active_intermediate_node()) {
+    cout << "OK" << endl;
+  }
+
+  cout << "Basic Tree: ";
+  if (basic_tree()) {
+    cout << "OK" << endl;
+  }
+
+  cout << "Chrome Tree: ";
+  if (chrome_tree()) {
+    cout << "OK" << endl;
+  }
+
+  return 0;
+}

--- a/proxy/http2/test_Http2PriorityQueue.cc
+++ b/proxy/http2/test_Http2PriorityQueue.cc
@@ -1,0 +1,248 @@
+/** @file
+
+    Unit tests for Http2PriorityQueue
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <stdlib.h>
+#include <iostream>
+#include <assert.h>
+#include <string.h>
+#include <sstream>
+
+#include "Http2PriorityQueue.h"
+
+using namespace std;
+
+class N
+{
+public:
+  N(uint32_t w, string c) : weight(w), content(c) {}
+
+  bool operator<(const N &n) const { return weight < n.weight; }
+  bool operator>(const N &n) const { return weight > n.weight; }
+
+  uint32_t weight;
+  string content;
+};
+
+typedef Http2PriorityQueueEntry<N *> Entry;
+typedef Http2PriorityQueue<N *> PQ;
+
+// For debug
+void
+dump(PQ *pq)
+{
+  Vec<Entry *> v = pq->dump();
+
+  for (uint32_t i = 0; i < v.length(); i++) {
+    std::cout << v[i]->index << "," << v[i]->node->weight << "," << v[i]->node->content << std::endl;
+  }
+  std::cout << "--------" << std::endl;
+}
+
+// Push, top, and pop a entry
+void
+test_pq_scenario_1()
+{
+  PQ *pq = new PQ();
+  N *a = new N(6, "A");
+  Entry *entry_a = new Entry(a);
+
+  pq->push(entry_a);
+  ink_assert(pq->top() == entry_a);
+
+  pq->pop();
+  ink_assert(pq->top() == NULL);
+}
+
+// Update weight
+void
+test_pq_scenario_2()
+{
+  PQ *pq = new PQ();
+
+  N *a = new N(10, "A");
+  N *b = new N(20, "B");
+
+  Entry *entry_a = new Entry(a);
+  Entry *entry_b = new Entry(b);
+
+  pq->push(entry_a);
+  pq->push(entry_b);
+
+  ink_assert(pq->top() == entry_a);
+
+  a->weight = 30;
+  pq->update(entry_a);
+
+  ink_assert(pq->top() == entry_b);
+}
+
+// Push, top, and pop 9 entries
+void
+test_pq_scenario_3()
+{
+  PQ *pq = new PQ();
+
+  ink_assert(pq->empty());
+  ink_assert(pq->top() == NULL);
+
+  N *a = new N(6, "A");
+  N *b = new N(1, "B");
+  N *c = new N(9, "C");
+  N *d = new N(8, "D");
+  N *e = new N(4, "E");
+  N *f = new N(3, "F");
+  N *g = new N(2, "G");
+  N *h = new N(7, "H");
+  N *i = new N(5, "I");
+
+  Entry *entry_a = new Entry(a);
+  Entry *entry_b = new Entry(b);
+  Entry *entry_c = new Entry(c);
+  Entry *entry_d = new Entry(d);
+  Entry *entry_e = new Entry(e);
+  Entry *entry_f = new Entry(f);
+  Entry *entry_g = new Entry(g);
+  Entry *entry_h = new Entry(h);
+  Entry *entry_i = new Entry(i);
+
+  pq->push(entry_a);
+  pq->push(entry_b);
+  pq->push(entry_c);
+  pq->push(entry_d);
+  pq->push(entry_e);
+  pq->push(entry_f);
+  pq->push(entry_g);
+  pq->push(entry_h);
+  pq->push(entry_i);
+
+  ink_assert(pq->top() == entry_b); // 1
+  pq->pop();
+  ink_assert(pq->top() == entry_g); // 2
+  pq->pop();
+  ink_assert(pq->top() == entry_f); // 3
+  pq->pop();
+  ink_assert(pq->top() == entry_e); // 4
+  pq->pop();
+  ink_assert(pq->top() == entry_i); // 5
+  pq->pop();
+  ink_assert(pq->top() == entry_a); // 6
+  pq->pop();
+  ink_assert(pq->top() == entry_h); // 7
+  pq->pop();
+  ink_assert(pq->top() == entry_d); // 8
+  pq->pop();
+  ink_assert(pq->top() == entry_c); // 9
+  pq->pop();
+
+  ink_assert(pq->top() == NULL);
+}
+
+// Push, top, pop, and update 9 entries
+void
+test_pq_scenario_4()
+{
+  PQ *pq = new PQ();
+
+  ink_assert(pq->empty());
+  ink_assert(pq->top() == NULL);
+
+  N *a = new N(6, "A");
+  N *b = new N(1, "B");
+  N *c = new N(9, "C");
+  N *d = new N(8, "D");
+  N *e = new N(4, "E");
+  N *f = new N(3, "F");
+  N *g = new N(2, "G");
+  N *h = new N(7, "H");
+  N *i = new N(5, "I");
+
+  Entry *entry_a = new Entry(a);
+  Entry *entry_b = new Entry(b);
+  Entry *entry_c = new Entry(c);
+  Entry *entry_d = new Entry(d);
+  Entry *entry_e = new Entry(e);
+  Entry *entry_f = new Entry(f);
+  Entry *entry_g = new Entry(g);
+  Entry *entry_h = new Entry(h);
+  Entry *entry_i = new Entry(i);
+
+  pq->push(entry_a);
+  pq->push(entry_b);
+  pq->push(entry_c);
+  pq->push(entry_d);
+  pq->push(entry_e);
+  pq->push(entry_f);
+  pq->push(entry_g);
+  pq->push(entry_h);
+  pq->push(entry_i);
+  dump(pq);
+
+  // Pop head and push it back again
+  ink_assert(pq->top() == entry_b); // 1
+  pq->pop();
+  b->weight += 100;
+  pq->push(entry_b);
+  // Update weight
+  a->weight += 100;
+  pq->update(entry_a);
+  c->weight += 100;
+  pq->update(entry_d);
+  e->weight += 100;
+  pq->update(entry_e);
+  g->weight += 100;
+  pq->update(entry_g);
+  dump(pq);
+
+  // Check
+  ink_assert(pq->top() == entry_f); // 3
+  pq->pop();
+  ink_assert(pq->top() == entry_i); // 5
+  pq->pop();
+  ink_assert(pq->top() == entry_h); // 7
+  pq->pop();
+  ink_assert(pq->top() == entry_d); // 8
+  pq->pop();
+  ink_assert(pq->top() == entry_b); // 101
+  pq->pop();
+  ink_assert(pq->top() == entry_g); // 102
+  pq->pop();
+  ink_assert(pq->top() == entry_e); // 104
+  pq->pop();
+  ink_assert(pq->top() == entry_a); // 106
+  pq->pop();
+  ink_assert(pq->top() == entry_c); // 109
+  pq->pop();
+
+  ink_assert(pq->top() == NULL);
+}
+
+int
+main()
+{
+  test_pq_scenario_1();
+  test_pq_scenario_2();
+  test_pq_scenario_3();
+  test_pq_scenario_4();
+
+  return 0;
+}


### PR DESCRIPTION
This is an experimental support of Stream Priority Feature. ( [TS-3535](https://issues.apache.org/jira/browse/TS-3535) )

## Approach
- Basically I followed WFQ Scheduling Algorithm invented by Kazuho and introduced by Kazu and Tatsuhiro at [ATS Meetup in Tokyo](https://cwiki.apache.org/confluence/display/TS/Meetup+Tokyo+2015#MeetupTokyo2015-PresentationSession)
- Using MinHeap for PriorityQueue

## Issues
- Currently overheads of Priority Feature is high, we need optimization.
- Works fine with Chrome, FireFox, Safari (on MacOSX), but has troubles with h2spec and h2load.