### PR TITLE
Fix for TS-4276

### DIFF
--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -1275,6 +1275,7 @@ HostDBContinuation::removeEvent(int /* event ATS_UNUSED */, Event *e)
 // Lookup done, insert into the local table, return data to the
 // calling continuation or to the calling cluster node.
 //
+// Note: this method must *always* return a valid response
 HostDBInfo *
 HostDBContinuation::lookup_done(IpAddr const &ip, char const *aname, bool around_robin, unsigned int ttl_seconds, SRVHosts *srv)
 {
@@ -1360,7 +1361,6 @@ HostDBContinuation::lookup_done(IpAddr const &ip, char const *aname, bool around
         ink_assert(!"out of room in hostdb data area");
         Warning("out of room in hostdb for reverse DNS data");
         hostDB.delete_block(i);
-        return NULL;
       }
     }
   }
@@ -1374,7 +1374,6 @@ HostDBContinuation::lookup_done(IpAddr const &ip, char const *aname, bool around
     } else {
       Warning("Out of room in hostdb for hostname (data area full!)");
       hostDB.delete_block(i);
-      return NULL;
     }
   }
 


### PR DESCRIPTION
In the event that `lookup_done` returns a NULL, we'll reschedule the lookup in the future instead of dumping core.

2 fixes:
 (1) retry: https://github.com/jacksontj/trafficserver/commit/805c041ba8cb464c82a47d611d93b7e03ca2cd7c
 (2) return non-mmaped entry: https://github.com/jacksontj/trafficserver/commit/29043cf5dfaa143f5dc4e0a670d5a0ba760ee306