### PR TITLE
TS 4271: metrics fail to clear

### DIFF
--- a/cmd/traffic_manager/StatType.cc
+++ b/cmd/traffic_manager/StatType.cc
@@ -47,9 +47,9 @@ bool StatDebug = false; // global debug flag
 StatExprToken::StatExprToken()
   : m_arith_symbol('\0'), m_token_name(NULL), m_token_type(RECD_NULL), m_sum_var(false), m_node_var(true)
 {
-  RecDataClear(RECD_NULL, &m_token_value);
-  RecDataClear(RECD_NULL, &m_token_value_max);
-  RecDataClear(RECD_NULL, &m_token_value_min);
+  RecDataZero(RECD_NULL, &m_token_value);
+  RecDataZero(RECD_NULL, &m_token_value_max);
+  RecDataZero(RECD_NULL, &m_token_value_min);
   memset(&m_token_value_delta, 0, sizeof(m_token_value_delta));
 }
 
@@ -234,7 +234,7 @@ StatExprToken::statVarSet(RecDataT type, RecData value)
        "[StatPro] ERROR in a statistics aggregation operations\n");
      */
     RecData err_value;
-    RecDataClear(m_token_type, &err_value);
+    RecDataZero(m_token_type, &err_value);
     return varSetData(m_token_type, m_token_name, err_value);
   }
 
@@ -535,8 +535,8 @@ StatObject::assignExpr(char *str)
         statToken->m_token_value_delta->previous_time = (ink_hrtime)0;
         statToken->m_token_value_delta->current_time = (ink_hrtime)0;
         statToken->m_token_value_delta->data_type = RECD_NULL;
-        RecDataClear(RECD_NULL, &statToken->m_token_value_delta->previous_value);
-        RecDataClear(RECD_NULL, &statToken->m_token_value_delta->current_value);
+        RecDataZero(RECD_NULL, &statToken->m_token_value_delta->previous_value);
+        RecDataZero(RECD_NULL, &statToken->m_token_value_delta->current_value);
       }
 
       statToken->assignTokenName(token);
@@ -644,7 +644,7 @@ StatObject::NodeStatEval(RecDataT *result_type, bool cluster)
   StatExprToken *result = NULL;
   StatExprToken *curToken = NULL;
   RecData tempValue;
-  RecDataClear(RECD_NULL, &tempValue);
+  RecDataZero(RECD_NULL, &tempValue);
 
   *result_type = RECD_NULL;
 
@@ -665,11 +665,11 @@ StatObject::NodeStatEval(RecDataT *result_type, bool cluster)
       tempValue = src->m_token_value_delta->diff_value(src->m_token_name);
     } else if (!cluster) {
       if (!varDataFromName(src->m_token_type, src->m_token_name, &tempValue)) {
-        RecDataClear(src->m_token_type, &tempValue);
+        RecDataZero(src->m_token_type, &tempValue);
       }
     } else {
       if (!overviewGenerator->varClusterDataFromName(src->m_token_type, src->m_token_name, &tempValue)) {
-        RecDataClear(src->m_token_type, &tempValue);
+        RecDataZero(src->m_token_type, &tempValue);
       }
     }
   } else {
@@ -736,7 +736,7 @@ StatObject::ClusterStatEval(RecDataT *result_type)
 
     if (!overviewGenerator->varClusterDataFromName(m_node_dest->m_token_type, m_node_dest->m_token_name, &tempValue)) {
       *result_type = RECD_NULL;
-      RecDataClear(*result_type, &tempValue);
+      RecDataZero(*result_type, &tempValue);
     }
 
     return (tempValue);
@@ -783,14 +783,14 @@ StatObject::setTokenValue(StatExprToken *token, bool cluster)
     case RECD_FLOAT:
       if (cluster) {
         if (!overviewGenerator->varClusterDataFromName(token->m_token_type, token->m_token_name, &(token->m_token_value))) {
-          RecDataClear(token->m_token_type, &token->m_token_value);
+          RecDataZero(token->m_token_type, &token->m_token_value);
         }
       } else {
         if (token->m_token_value_delta) {
           token->m_token_value = token->m_token_value_delta->diff_value(token->m_token_name);
         } else {
           if (!varDataFromName(token->m_token_type, token->m_token_name, &(token->m_token_value))) {
-            RecDataClear(token->m_token_type, &token->m_token_value);
+            RecDataZero(token->m_token_type, &token->m_token_value);
           }
         } // delta?
       }   // cluster?
@@ -862,8 +862,8 @@ StatObject::StatBinaryEval(StatExprToken *left, char op, StatExprToken *right, b
   /*
    * We should make the operands with the same type before calculating.
    */
-  RecDataClear(RECD_NULL, &l);
-  RecDataClear(RECD_NULL, &r);
+  RecDataZero(RECD_NULL, &l);
+  RecDataZero(RECD_NULL, &r);
 
   if (left->m_token_type == right->m_token_type) {
     l = left->m_token_value;
@@ -904,7 +904,7 @@ StatObject::StatBinaryEval(StatExprToken *left, char op, StatExprToken *right, b
 
   case '/':
     RecData recTmp;
-    RecDataClear(RECD_NULL, &recTmp);
+    RecDataZero(RECD_NULL, &recTmp);
 
     /*
      * Force the type of result to be RecFloat on div operation
@@ -1002,8 +1002,8 @@ StatObjectList::Eval()
   ink_hrtime delta = 0;
   short count = 0;
 
-  RecDataClear(RECD_NULL, &tempValue);
-  RecDataClear(RECD_NULL, &result);
+  RecDataZero(RECD_NULL, &tempValue);
+  RecDataZero(RECD_NULL, &result);
 
   for (StatObject *object = first(); object; object = next(object)) {
     StatError = false;
@@ -1088,7 +1088,7 @@ StatObjectList::Eval()
 
             if (token->m_token_value_delta) {
               if (!varDataFromName(token->m_token_type, token->m_token_name, &tempValue)) {
-                RecDataClear(RECD_NULL, &tempValue);
+                RecDataZero(RECD_NULL, &tempValue);
               }
 
               token->m_token_value_delta->previous_time = token->m_token_value_delta->current_time;

--- a/cmd/traffic_manager/StatType.h
+++ b/cmd/traffic_manager/StatType.h
@@ -58,7 +58,7 @@ struct StatDataSamples {
     if (data_type != RECD_NULL)
       return RecDataSub(data_type, current_value, previous_value);
     else {
-      RecDataClear(RECD_NULL, &tmp);
+      RecDataZero(RECD_NULL, &tmp);
       return tmp;
     }
   }

--- a/cmd/traffic_manager/WebOverview.cc
+++ b/cmd/traffic_manager/WebOverview.cc
@@ -238,7 +238,7 @@ overviewRecord::readData(RecDataT varType, const char *name, bool *found)
   int rec_status = REC_ERR_OKAY;
   int order = -1;
   RecData rec;
-  RecDataClear(RECD_NULL, &rec);
+  RecDataZero(RECD_NULL, &rec);
 
   if (localNode == false) {
     rec_status = RecGetRecordOrderAndId(name, &order, NULL);
@@ -531,7 +531,7 @@ overviewPage::clusterSumData(RecDataT varType, const char *nodeVar, RecData *sum
   RecData recTmp;
 
   ink_assert(sum != NULL);
-  RecDataClear(varType, sum);
+  RecDataZero(varType, sum);
 
   for (int i = 0; i < numHosts_local; i++) {
     current = (overviewRecord *)sortRecords[i];

--- a/cmd/traffic_manager/metrics.cc
+++ b/cmd/traffic_manager/metrics.cc
@@ -290,7 +290,7 @@ metrics_cluster_sum(lua_State *L)
 
   // Sum the cluster value.
   if (!overviewGenerator->varClusterDataFromName(data_type, rec_name, &rec_data)) {
-    RecDataClear(data_type, &rec_data);
+    RecDataZero(data_type, &rec_data);
 
     // If we can't get any cluster data, return nil. This will generally cause the
     // evaluator to fail, which is handled by logging and ignoring the failure.

--- a/lib/records/P_RecCore.cc
+++ b/lib/records/P_RecCore.cc
@@ -627,7 +627,7 @@ RecConsumeConfigEntry(RecT rec_type, RecDataT data_type, const char *name, const
   memset(&data, 0, sizeof(RecData));
   RecDataSetFromString(data_type, &data, value);
   RecSetRecord(rec_type, name, data_type, &data, NULL, source, false, inc_version);
-  RecDataClear(data_type, &data);
+  RecDataZero(data_type, &data);
 }
 
 //-------------------------------------------------------------------------

--- a/lib/records/P_RecUtils.h
+++ b/lib/records/P_RecUtils.h
@@ -51,7 +51,9 @@ RecRecord *RecAlloc(RecT rec_type, const char *name, RecDataT data_type);
 // RecData Utils
 //-------------------------------------------------------------------------
 
-void RecDataClear(RecDataT type, RecData *data);
+// Reset the value of this RecData to zero.
+void RecDataZero(RecDataT type, RecData *data);
+
 void RecDataSetMax(RecDataT type, RecData *data);
 void RecDataSetMin(RecDataT type, RecData *data);
 bool RecDataSet(RecDataT data_type, RecData *data_dst, RecData *data_src);

--- a/lib/records/RecCore.cc
+++ b/lib/records/RecCore.cc
@@ -60,8 +60,8 @@ register_record(RecT rec_type, const char *name, RecDataT data_type, RecData dat
 
     if (data_type != r->data_type) {
       // Clear with the old type before resetting with the new type.
-      RecDataClear(r->data_type, &(r->data));
-      RecDataClear(r->data_type, &(r->data_default));
+      RecDataZero(r->data_type, &(r->data));
+      RecDataZero(r->data_type, &(r->data_default));
 
       // If the data type changed, reset the current value to the default.
       RecDataSet(data_type, &(r->data), &(data_default));

--- a/lib/records/RecUtils.cc
+++ b/lib/records/RecUtils.cc
@@ -68,10 +68,10 @@ RecAlloc(RecT rec_type, const char *name, RecDataT data_type)
 
 
 //-------------------------------------------------------------------------
-// RecDataClear
+// RecDataZero
 //-------------------------------------------------------------------------
 void
-RecDataClear(RecDataT data_type, RecData *data)
+RecDataZero(RecDataT data_type, RecData *data)
 {
   if ((data_type == RECD_STRING) && (data->rec_string)) {
     ats_free(data->rec_string);

--- a/mgmt/RecordsConfigUtils.cc
+++ b/mgmt/RecordsConfigUtils.cc
@@ -43,7 +43,7 @@ override_record(const RecordElement *record, void *)
         // "interesting" results if you are trying to override configuration values
         // early in startup (before we have synced with the local manager).
         RecSetRecord(record->type, record->name, record->value_type, &data, NULL, REC_SOURCE_ENV, false);
-        RecDataClear(record->value_type, &data);
+        RecDataZero(record->value_type, &data);
       }
     }
   }
@@ -115,7 +115,7 @@ initialize_record(const RecordElement *record, void *)
       break;
     } // switch
 
-    RecDataClear(record->value_type, &data);
+    RecDataZero(record->value_type, &data);
   } else { // Everything else, except PROCESS, are stats. TODO: Should modularize this too like PROCESS was done.
     ink_assert(REC_TYPE_IS_STAT(type));
 

--- a/mgmt/api/TSControlMain.cc
+++ b/mgmt/api/TSControlMain.cc
@@ -977,7 +977,7 @@ handle_stats_reset(int fd, void *req, size_t reqlen)
   MgmtMarshallInt err;
 
   err = recv_mgmt_request(req, reqlen, STATS_RESET_NODE, &optype, &name);
-  if (err != TS_ERR_OKAY) {
+  if (err == TS_ERR_OKAY) {
     err = StatsReset(optype == STATS_RESET_CLUSTER, name);
   }
 


### PR DESCRIPTION
Fix failing ``traffic_ctl metric clear`` command. Rename ``RecDataClear`` to ``RecDataZero`` to make it more obvious.