### PR TITLE
TS-3639 Implement GeoIP information into header_rewrite

### DIFF
--- a/plugins/header_rewrite/Examples/Geo
+++ b/plugins/header_rewrite/Examples/Geo
@@ -1,0 +1,6 @@
+cond %{SEND_RESPONSE_HDR_HOOK} [AND]
+cond %${GEO:COUNTRY} =US
+    set-header ATS-Geo-Country %{GEO:COUNTRY}
+    set-header ATS-Geo-Country-ISO %{GEO:COUNTRY-ISO}
+    set-header ATS-Geo-ASN %{GEO:ASN}
+    set-header ATS-Geo-ASN-NAME %{GEO:ASN-NAME}

--- a/plugins/header_rewrite/Makefile.am
+++ b/plugins/header_rewrite/Makefile.am
@@ -31,8 +31,9 @@ header_rewrite_la_SOURCES = \
   resources.cc \
   ruleset.cc \
   statement.cc
-  
+
 header_rewrite_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+header_rewrite_la_LIBADD = $(GEOIP_LIBS)
 
 bin_PROGRAMS = header_rewrite_test
 header_rewrite_test_SOURCES = parser.cc header_rewrite_test.cc

--- a/plugins/header_rewrite/conditions.h
+++ b/plugins/header_rewrite/conditions.h
@@ -220,6 +220,7 @@ private:
   };
 };
 
+
 // header
 class ConditionHeader : public Condition
 {
@@ -240,6 +241,7 @@ private:
 
   bool _client;
 };
+
 
 // path
 class ConditionPath : public Condition
@@ -374,6 +376,7 @@ private:
   DISALLOW_COPY_AND_ASSIGN(ConditionIncomingPort);
 };
 
+
 // Transact Count
 class ConditionTransactCount : public Condition
 {
@@ -392,6 +395,7 @@ private:
   DISALLOW_COPY_AND_ASSIGN(ConditionTransactCount);
 };
 
+
 // now: Keeping track of current time / day / hour etc.
 class ConditionNow : public Condition
 {
@@ -408,6 +412,45 @@ protected:
 private:
   DISALLOW_COPY_AND_ASSIGN(ConditionNow);
   NowQualifiers _now_qual;
+};
+
+
+// GeoIP class for the "integer" based Geo information pieces
+class ConditionGeo : public Condition
+{
+public:
+  explicit ConditionGeo() : _geo_qual(GEO_QUAL_COUNTRY), _int_type(false)
+  {
+    TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for ConditionGeo");
+  };
+
+  void initialize(Parser &p);
+  void set_qualifier(const std::string &q);
+  void append_value(std::string &s, const Resources &res);
+
+  // These are special for this sub-class
+  bool
+  is_int_type() const
+  {
+    return _int_type;
+  }
+  void
+  is_int_type(bool flag)
+  {
+    _int_type = flag;
+  }
+
+  int64_t get_geo_int(const sockaddr *addr);
+  const char *get_geo_string(const sockaddr *addr);
+
+protected:
+  bool eval(const Resources &res);
+
+private:
+  DISALLOW_COPY_AND_ASSIGN(ConditionGeo);
+
+  GeoQualifiers _geo_qual;
+  bool _int_type;
 };
 
 

--- a/plugins/header_rewrite/factory.cc
+++ b/plugins/header_rewrite/factory.cc
@@ -129,6 +129,8 @@ condition_factory(const std::string &cond)
     c = new ConditionTransactCount();
   } else if (c_name == "NOW") {
     c = new ConditionNow();
+  } else if (c_name == "GEO") {
+    c = new ConditionGeo();
   } else {
     TSError("[%s] Unknown condition: %s", PLUGIN_NAME, c_name.c_str());
     return NULL;

--- a/plugins/header_rewrite/resources.cc
+++ b/plugins/header_rewrite/resources.cc
@@ -24,6 +24,7 @@
 #include "resources.h"
 #include "lulu.h"
 
+
 // Collect all resources
 void
 Resources::gather(const ResourceIDs ids, TSHttpHookID hook)

--- a/plugins/header_rewrite/resources.h
+++ b/plugins/header_rewrite/resources.h
@@ -29,6 +29,10 @@
 
 #include "lulu.h"
 
+#if HAVE_GEOIP_H
+#include <GeoIP.h>
+extern GeoIP *gGeoIP[NUM_DB_TYPES];
+#endif
 
 #define TS_REMAP_PSEUDO_HOOK TS_HTTP_LAST_HOOK // Ugly, but use the "last hook" for remap instances.
 

--- a/plugins/header_rewrite/statement.h
+++ b/plugins/header_rewrite/statement.h
@@ -58,6 +58,13 @@ enum NowQualifiers {
   NOW_QUAL_YEARDAY
 };
 
+enum GeoQualifiers {
+  GEO_QUAL_COUNTRY,
+  GEO_QUAL_COUNTRY_ISO,
+  GEO_QUAL_ASN,
+  GEO_QUAL_ASN_NAME,
+};
+
 
 class Statement
 {
@@ -128,6 +135,7 @@ protected:
   virtual void initialize_hooks();
 
   UrlQualifiers parse_url_qualifier(const std::string &q) const;
+
   NowQualifiers parse_now_qualifier(const std::string &q) const;
   int64_t get_now_qualified(NowQualifiers qual) const;
 


### PR DESCRIPTION
This adds a set of new GeoIP based conditions to the header_rewrite plugin, see the Examples/Geo file for an example. They can also be used as conditions, of course, as well as for setting header values.