### PR TITLE
TS-4280 Refactors the gzip plugin to improve hooks and memory usage

### DIFF
--- a/plugins/gzip/configuration.cc
+++ b/plugins/gzip/configuration.cc
@@ -97,8 +97,9 @@ enum ParserState {
 };
 
 void
-Configuration::AddHostConfiguration(HostConfiguration *hc)
+Configuration::add_host_configuration(HostConfiguration *hc)
 {
+  hc->hold(); // We hold a lease on the HostConfig while it's in this container
   host_configurations_.push_back(hc);
 }
 
@@ -115,30 +116,42 @@ HostConfiguration::add_compressible_content_type(const std::string &content_type
 }
 
 HostConfiguration *
-Configuration::Find(const char *host, int host_length)
+Configuration::find(const char *host, int host_length)
 {
   HostConfiguration *host_configuration = host_configurations_[0];
 
-  std::string shost(host, host_length);
+  if (host && host_length > 0 && host_configurations_.size() > 1) {
+    std::string shost(host, host_length);
 
-  for (size_t i = 1; i < host_configurations_.size(); i++) {
-    if (host_configurations_[i]->host() == shost) {
-      host_configuration = host_configurations_[i];
-      break;
+    // ToDo: Maybe use std::find() here somehow?
+    for (HostContainer::iterator it = host_configurations_.begin() + 1; it != host_configurations_.end(); ++it) {
+      if ((*it)->host() == shost) {
+        host_configuration = *it;
+        break;
+      }
     }
   }
 
+  host_configuration->hold(); // Hold a lease
   return host_configuration;
 }
 
+void
+Configuration::release_all()
+{
+  for (HostContainer::iterator it = host_configurations_.begin(); it != host_configurations_.end(); ++it) {
+    (*it)->release();
+  }
+}
+
 bool
-HostConfiguration::IsUrlAllowed(const char *url, int url_len)
+HostConfiguration::is_url_allowed(const char *url, int url_len)
 {
   string surl(url, url_len);
 
-  for (size_t i = 0; i < disallows_.size(); i++) {
-    if (fnmatch(disallows_[i].c_str(), surl.c_str(), 0) == 0) {
-      info("url [%s] disabled for compression, matched on pattern [%s]", surl.c_str(), disallows_[i].c_str());
+  for (StringContainer::iterator it = disallows_.begin(); it != disallows_.end(); ++it) {
+    if (fnmatch(it->c_str(), surl.c_str(), 0) == 0) {
+      info("url [%s] disabled for compression, matched on pattern [%s]", surl.c_str(), it->c_str());
       return false;
     }
   }
@@ -147,20 +160,20 @@ HostConfiguration::IsUrlAllowed(const char *url, int url_len)
 }
 
 bool
-HostConfiguration::ContentTypeIsCompressible(const char *content_type, int content_type_length)
+HostConfiguration::is_content_type_compressible(const char *content_type, int content_type_length)
 {
   string scontent_type(content_type, content_type_length);
   bool is_match = false;
 
-  for (size_t i = 0; i < compressible_content_types_.size(); i++) {
-    const char *match_string = compressible_content_types_[i].c_str();
+  for (StringContainer::iterator it = compressible_content_types_.begin(); it != compressible_content_types_.end(); ++it) {
+    const char *match_string = it->c_str();
     bool exclude = match_string[0] == '!';
+
     if (exclude) {
-      match_string++; // skip '!'
+      ++match_string; // skip '!'
     }
     if (fnmatch(match_string, scontent_type.c_str(), 0) == 0) {
-      info("compressible content type [%s], matched on pattern [%s]", scontent_type.c_str(),
-           compressible_content_types_[i].c_str());
+      info("compressible content type [%s], matched on pattern [%s]", scontent_type.c_str(), it->c_str());
       is_match = !exclude;
     }
   }
@@ -185,7 +198,7 @@ Configuration::Parse(const char *path)
 
   Configuration *c = new Configuration();
   HostConfiguration *current_host_configuration = new HostConfiguration("");
-  c->AddHostConfiguration(current_host_configuration);
+  c->add_host_configuration(current_host_configuration);
 
   if (pathstring.empty()) {
     return c;
@@ -235,7 +248,7 @@ Configuration::Parse(const char *path)
         if ((token[0] == '[') && (token[token.size() - 1] == ']')) {
           std::string current_host = token.substr(1, token.size() - 2);
           current_host_configuration = new HostConfiguration(current_host);
-          c->AddHostConfiguration(current_host_configuration);
+          c->add_host_configuration(current_host_configuration);
         } else if (token == "compressible-content-type") {
           state = kParseCompressibleContentType;
         } else if (token == "remove-accept-encoding") {

--- a/plugins/gzip/configuration.h
+++ b/plugins/gzip/configuration.h
@@ -28,66 +28,90 @@
 #include <string>
 #include <vector>
 #include "debug_macros.h"
+#include "ts/ink_atomic.h"
 
 namespace Gzip
 {
+typedef std::vector<std::string> StringContainer;
+
 class HostConfiguration
 {
-public: // todo -> only configuration should be able to construct hostconfig
+public:
   explicit HostConfiguration(const std::string &host)
-    : host_(host), enabled_(true), cache_(true), remove_accept_encoding_(false), flush_(false)
+    : host_(host), enabled_(true), cache_(true), remove_accept_encoding_(false), flush_(false), ref_count_(0)
   {
   }
 
-  inline bool
+  bool
   enabled()
   {
     return enabled_;
   }
-  inline void
+  void
   set_enabled(bool x)
   {
     enabled_ = x;
   }
-  inline bool
+  bool
   cache()
   {
     return cache_;
   }
-  inline void
+  void
   set_cache(bool x)
   {
     cache_ = x;
   }
-  inline bool
+  bool
   flush()
   {
     return flush_;
   }
-  inline void
+  void
   set_flush(bool x)
   {
     flush_ = x;
   }
-  inline bool
+  bool
   remove_accept_encoding()
   {
     return remove_accept_encoding_;
   }
-  inline void
+  void
   set_remove_accept_encoding(bool x)
   {
     remove_accept_encoding_ = x;
   }
-  inline std::string
+  std::string
   host()
   {
     return host_;
   }
+  bool
+  has_disallows() const
+  {
+    return !disallows_.empty();
+  }
+
   void add_disallow(const std::string &disallow);
   void add_compressible_content_type(const std::string &content_type);
-  bool IsUrlAllowed(const char *url, int url_len);
-  bool ContentTypeIsCompressible(const char *content_type, int content_type_length);
+  bool is_url_allowed(const char *url, int url_len);
+  bool is_content_type_compressible(const char *content_type, int content_type_length);
+
+  // Ref-counting these host configuration objects
+  void
+  hold()
+  {
+    ink_atomic_increment(&ref_count_, 1);
+  }
+  void
+  release()
+  {
+    if (1 >= ink_atomic_decrement(&ref_count_, 1)) {
+      debug("released and deleting HostConfiguration for %s settings", host_.size() > 0 ? host_.c_str() : "global");
+      delete this;
+    }
+  }
 
 private:
   std::string host_;
@@ -95,10 +119,15 @@ private:
   bool cache_;
   bool remove_accept_encoding_;
   bool flush_;
-  std::vector<std::string> compressible_content_types_;
-  std::vector<std::string> disallows_;
+  volatile int ref_count_;
+
+  StringContainer compressible_content_types_;
+  StringContainer disallows_;
+
   DISALLOW_COPY_AND_ASSIGN(HostConfiguration);
-}; // class HostConfiguration
+};
+
+typedef std::vector<HostConfiguration *> HostContainer;
 
 class Configuration
 {
@@ -106,19 +135,16 @@ class Configuration
 
 public:
   static Configuration *Parse(const char *path);
-  HostConfiguration *Find(const char *host, int host_length);
-  inline HostConfiguration *
-  GlobalConfiguration()
-  {
-    return host_configurations_[0];
-  }
+  HostConfiguration *find(const char *host, int host_length);
+  void release_all();
 
 private:
   explicit Configuration() {}
-  void AddHostConfiguration(HostConfiguration *hc);
 
-  std::vector<HostConfiguration *> host_configurations_;
-  // todo: destructor. delete owned host configurations
+  void add_host_configuration(HostConfiguration *hc);
+
+  HostContainer host_configurations_;
+
   DISALLOW_COPY_AND_ASSIGN(Configuration);
 }; // class Configuration
 

--- a/plugins/gzip/misc.h
+++ b/plugins/gzip/misc.h
@@ -26,8 +26,12 @@
 
 #include <zlib.h>
 #include <ts/ts.h>
-#include <stdlib.h> //exit()
+#include <stdlib.h>
 #include <stdio.h>
+
+#include "configuration.h"
+
+using namespace Gzip;
 
 // zlib stuff, see [deflateInit2] at http://www.zlib.net/manual.html
 static const int ZLIB_MEMLEVEL = 9; // min=1 (optimize for memory),max=9 (optimized for speed)
@@ -37,10 +41,6 @@ static const int WINDOW_BITS_GZIP = 31;
 // misc
 static const int COMPRESSION_TYPE_DEFLATE = 1;
 static const int COMPRESSION_TYPE_GZIP = 2;
-// this one is just for txnargset/get to point to
-static const int GZIP_ONE = 1;
-static const int DICT_PATH_MAX = 512;
-static const int DICT_ENTRY_MAX = 2048;
 
 // this one is used to rename the accept encoding header
 // it will be restored later on
@@ -55,6 +55,7 @@ enum transform_state {
 
 typedef struct {
   TSHttpTxn txn;
+  HostConfiguration *hc;
   TSVIO downstream_vio;
   TSIOBuffer downstream_buffer;
   TSIOBufferReader downstream_reader;


### PR DESCRIPTION
This accomplishes three things:

1) Fix memory leak on config reload (ref-counting)

2) Reduces the number of global hooks, which then

3) Allows to eliminate the usage of all TXN data slots