### PR TITLE
TS-4284 Modernize the geoip_acl plugin

### DIFF
--- a/build/common.m4
+++ b/build/common.m4
@@ -556,30 +556,6 @@ AC_DEFUN([TS_ARG_ENABLE_VAR],[
   AC_SUBST(m4_join([_], $1, AS_TR_SH($2)))
 ])
 
-dnl
-dnl TS_SEARCH_LIBRARY(function, search-libs, [action-if-found], [action-if-not-found])
-dnl This macro works like AC_SEARCH_LIBS, except that $LIBS is not modified. If the library
-dnl is found, it is cached in the ts_cv_lib_${function} variable.
-dnl
-AC_DEFUN([TS_SEARCH_LIBRARY], [
-  __saved_LIBS="$LIBS"
-
-  AC_SEARCH_LIBS($1, $2, [
-    dnl action-if-found
-    case $ac_cv_search_$1 in
-    "none required"|"no") ts_cv_search_$1="" ;;
-    *) ts_cv_search_$1=$ac_cv_search_$1 ;;
-    esac
-    m4_default([$3], [true])
-  ], [
-    dnl action-if-not-found
-    m4_default([$4], [true])
-  ])
-
-  LIBS="$__saved_LIBS"
-  unset __saved_LIBS
-])
-
 dnl TS_CHECK_SOCKOPT(socket-option, [action-if-found], [action-if-not-found]
 AC_DEFUN([TS_CHECK_SOCKOPT], [
   AC_MSG_CHECKING([for $1 socket option])

--- a/configure.ac
+++ b/configure.ac
@@ -1406,14 +1406,14 @@ AC_SUBST(use_hwloc)
 # GeoIP as a "helper" plugin, which other plugins can then use. Such a plugin could
 # then manage which libraries to use via explicit dlopen()'s.
 #
-enable_maxmind_geoip=no
-TS_SEARCH_LIBRARY([GeoIP_id_by_code], [GeoIP], [
-  GEOIP_LIBS=$ts_cv_search_GeoIP_id_by_code
-  AC_CHECK_HEADERS([GeoIP.h], [ enable_maxmind_geoip=yes ])
+AC_CHECK_HEADERS([GeoIP.h], [
+  AC_CHECK_LIB([GeoIP], [GeoIP_new], [
+    AC_SUBST([GEO_LIBS], ["-lGeoIP"])
+  ], [
+    AC_SUBST([GEO_LIBS], [""])
+  ])
 ])
 
-AC_SUBST(GEOIP_LIBS)
-AM_CONDITIONAL([BUILD_GEOIP_PLUGIN], [ test "x${enable_maxmind_geoip}" = x"yes" ])
 
 # Right now, the healthcheck plugins requires inotify_init (and friends)
 AM_CONDITIONAL([BUILD_HEALTHCHECK_PLUGIN], [ test "$ac_cv_func_inotify_init" = "yes" ])

--- a/plugins/experimental/geoip_acl/Makefile.am
+++ b/plugins/experimental/geoip_acl/Makefile.am
@@ -16,11 +16,7 @@
 
 include $(top_srcdir)/build/plugins.mk
 
-if BUILD_GEOIP_PLUGIN
-
 pkglib_LTLIBRARIES = geoip_acl.la
 geoip_acl_la_SOURCES = acl.cc geoip_acl.cc
 geoip_acl_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
-geoip_acl_la_LIBADD = $(GEOIP_LIBS)
-
-endif
+geoip_acl_la_LIBADD = $(GEO_LIBS)

--- a/plugins/experimental/geoip_acl/acl.h
+++ b/plugins/experimental/geoip_acl/acl.h
@@ -85,6 +85,7 @@ protected:
   bool _allow;
   int _added_tokens;
   static GeoDBHandle _geoip;
+  static GeoDBHandle _geoip6;
 };
 
 


### PR DESCRIPTION
There are two commits here:

1) Modernizes / refactors the plugin

and 

2) Adds IPv6 support

I kept them as two separate commits, since they are two distinct changes. If anyone feels strongly, I can squash them.