### PR TITLE
TS-4299 Allows for the content length to be processed even with C: close

### DIFF
--- a/proxy/FetchSM.cc
+++ b/proxy/FetchSM.cc
@@ -128,12 +128,14 @@ FetchSM::has_body()
   if (check_chunked())
     return true;
 
-  if (check_connection_close())
-    return true;
-
   resp_content_length = hdr->value_get_int64(MIME_FIELD_CONTENT_LENGTH, MIME_LEN_CONTENT_LENGTH);
-  if (!resp_content_length)
-    return false;
+  if (!resp_content_length) {
+    if (check_connection_close()) {
+      return true;
+    } else {
+      return false;
+    }
+  }
 
   return true;
 }


### PR DESCRIPTION
This might look clunky, but a) I tried to minimize the possible damage done to the FetchSM and b) the additions done earlier re: Connection: close are difficult to test / verify. I'd be OK personally to just remove the check, but I believe it was added for a reason back then. I'm also open to other suggestions for a fix, but I do know that this fix fixes my problem with H2 :).

See e83b131b and TS-3049 for the origin of this problem.