### PR TITLE
Fix broken test of min_keep_alive_connection

### DIFF
--- a/ci/tsqa/tests/test_origin_min_keep_alive_connection.py
+++ b/ci/tsqa/tests/test_origin_min_keep_alive_connection.py
@@ -22,42 +22,44 @@ import time
 import logging
 import uuid
 import socket
+import requests
 import tsqa.test_cases
 import helpers
-import thread
+import SocketServer
 
 log = logging.getLogger(__name__)
 
 
-def simple_socket_server(host, port):
-    log.info("starting the socket server")
-    serv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    serv.bind((host, port))
-    serv.setblocking(1)
-    serv.listen(3)
-    conn_id = uuid.uuid4().hex
-    start = None
-    while True:
-        conn, addr = serv.accept()
-        if start is None:
-            start = time.time()
-        data = conn.recv(4096).strip()
-        if data:
-            log.info('Sending data back to the client: {uid}'.format(uid=conn_id))
-        else:
-            log.info('Client disconnected: {timeout}seconds'.format(timeout=time.time() - start))
-            break
-        body = conn_id
-        resp = ('HTTP/1.1 200 OK\r\n'
-                'Content-Length: {content_length}\r\n'
-                'Content-Type: text/html; charset=UTF-8\r\n'
-                'Connection: keep-alive\r\n'
-                '\r\n'
-                '{body}'.format(content_length=len(body), body=body))
-        conn.sendall(resp)
-    serv.shutdown(socket.SHUT_RDWR)
-    serv.close()
-    log.info("end the socket server")
+class KAHandler(SocketServer.BaseRequestHandler):
+    """
+    A subclass of RequestHandler which return chunked encoding optionally
+
+    /parts/sleep_time/close
+        parts: number of parts to send
+        sleep_time: time between parts
+        close: bool wether to close properly
+    """
+
+    def handle(self):
+        # Receive the data in small chunks and retransmit it
+        conn_id = uuid.uuid4().hex
+        start = time.time()
+        while True:
+            data = self.request.recv(4096).strip()
+            if data:
+                log.info('Sending data back to the client: {uid}'.format(uid=conn_id))
+            else:
+                log.info('Client disconnected: {timeout}seconds'.format(timeout=time.time() - start))
+                break
+            body = conn_id
+            time.sleep(1)
+            resp = ('HTTP/1.1 200 OK\r\n'
+                    'Content-Length: {content_length}\r\n'
+                    'Content-Type: text/html; charset=UTF-8\r\n'
+                    'Connection: keep-alive\r\n'
+                    '\r\n'
+                    '{body}'.format(content_length=len(body), body=body))
+            self.request.sendall(resp)
 
 
 class TestKeepAlive_Origin_Min_connections(helpers.EnvironmentCase):
@@ -67,37 +69,31 @@ class TestKeepAlive_Origin_Min_connections(helpers.EnvironmentCase):
         cls.traffic_server_port = int(cls.configs['records.config']['CONFIG']['proxy.config.http.server_ports'])
         cls.socket_server_port = int(tsqa.utils.bind_unused_port()[1])
         log.info("socket_server_port = %d" % (cls.socket_server_port))
-        thread.start_new_thread(simple_socket_server, (cls.traffic_server_host, cls.socket_server_port, ))
+        cls.server = tsqa.endpoint.SocketServerDaemon(KAHandler, port=cls.socket_server_port)
+        cls.server.start()
+        cls.server.ready.wait()
+
         cls.configs['remap.config'].add_line('map / http://127.0.0.1:{0}'.format(cls.socket_server_port))
-        cls.origin_keep_alive_timeout = 3
-        cls.configs['records.config']['CONFIG']['origin_min_keep_alive_connections'] = 1
-        cls.configs['records.config']['CONFIG']['keep_alive_enabled_out'] = 1
-        cls.configs['records.config']['CONFIG']['proxy.config.http.keep_alive_no_activity_timeout_out'] = cls.origin_keep_alive_timeout
+        cls.origin_keep_alive_timeout = 1
+
+        cls.configs['records.config']['CONFIG'].update({
+            'proxy.config.http.origin_min_keep_alive_connections':  1,
+            'proxy.config.http.keep_alive_enabled_out': 1,
+            'proxy.config.http.keep_alive_no_activity_timeout_out': cls.origin_keep_alive_timeout,
+            'proxy.config.exec_thread.limit': 1,
+            'proxy.config.exec_thread.autoconfig': 0,
+        })
 
     def test_origin_min_connection(self):
-        conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        conn.connect((self.traffic_server_host, self.traffic_server_port))
-        request_content = 'GET / HTTP/1.1\r\nConnection: keep-alive\r\nHost: 127.0.0.1\r\n\r\n'
-        conn.setblocking(1)
-        conn.send(request_content)
-        first_resp = None
-        second_resp = None
-        while 1:
-            try:
-                resp = conn.recv(4096)
-                resp = resp.split('\r\n\r\n')[1]
-                log.info(resp)
-                if first_resp is None:
-                    first_resp = resp
-                else:
-                    second_resp = resp
-                    break
-                if len(resp) == 0:
-                    break
-                time.sleep(2 + self.origin_keep_alive_timeout)
-                conn.send(request_content)
-            except:
-                break
-        conn.shutdown(socket.SHUT_RDWR)
-        conn.close()
-        self.assertEqual(first_resp, second_resp)
+        response_uuids = []
+        # make the request N times, ensure that they are on the same connection
+        for _ in xrange(0, 3):
+            ret = requests.get('http://{0}:{1}/'.format(self.traffic_server_host, self.traffic_server_port))
+            response_uuids.append(ret.text)
+
+        self.assertEqual(1, len(set(response_uuids)))
+
+        # sleep for a time greater than the keepalive timeout and ensure its the same connection
+        time.sleep(self.origin_keep_alive_timeout * 2)
+        ret = requests.get('http://{0}:{1}/'.format(self.traffic_server_host, self.traffic_server_port))
+        self.assertEqual(ret.text, response_uuids[0])


### PR DESCRIPTION
This test was previously not setting the UUID per transaction (but rather per request). This was working because the configuration options set for keepalive etc. were incorrect. This patch corrects the configuration options, and the UUIDs to make the test check what it is intending to check.