### PR TITLE
TS-4425: Make Ptr<T> pointer value private.

### DIFF
--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -2415,7 +2415,7 @@ CacheVC::handleReadDone(int event, Event *e)
                         (doc_len && (int64_t)doc_len < cache_config_ram_cache_cutoff) || !cache_config_ram_cache_cutoff);
         if (cutoff_check && !f.doc_from_ram_cache) {
           uint64_t o = dir_offset(&dir);
-          vol->ram_cache->put(read_key, buf, doc->len, http_copy_hdr, (uint32_t)(o >> 32), (uint32_t)o);
+          vol->ram_cache->put(read_key, buf.get(), doc->len, http_copy_hdr, (uint32_t)(o >> 32), (uint32_t)o);
         }
         if (!doc_len) {
           // keep a pointer to it. In case the state machine decides to
@@ -2510,7 +2510,7 @@ Cache::lookup(Continuation *cont, const CacheKey *key, CacheFragType type, char 
   }
 
   Vol *vol = key_to_vol(key, hostname, host_len);
-  ProxyMutex *mutex = cont->mutex;
+  ProxyMutex *mutex = cont->mutex.get();
   CacheVC *c = new_CacheVC(cont);
   SET_CONTINUATION_HANDLER(c, &CacheVC::openReadStartHead);
   c->vio.op = VIO::READ;

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -2203,7 +2203,7 @@ unmarshal_helper(Doc *doc, Ptr<IOBufferData> &buf, int &okay)
   char *tmp = doc->hdr();
   int len = doc->hlen;
   while (len > 0) {
-    int r = HTTPInfo::unmarshal(tmp, len, buf._ptr());
+    int r = HTTPInfo::unmarshal(tmp, len, buf.get());
     if (r < 0) {
       ink_assert(!"CacheVC::handleReadDone unmarshal failed");
       okay = 0;

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -888,7 +888,7 @@ CacheProcessor::cacheInitialized()
   uint64_t vol_used_direntries = 0;
   Vol *vol;
 
-  ProxyMutex *mutex = this_ethread()->mutex;
+  ProxyMutex *mutex = this_ethread()->mutex.get();
 
   if (theCache) {
     total_size += theCache->cache_size;

--- a/iocore/cache/CacheDir.cc
+++ b/iocore/cache/CacheDir.cc
@@ -33,19 +33,19 @@
 
 #define CACHE_INC_DIR_USED(_m)                            \
   do {                                                    \
-    ProxyMutex *mutex = _m;                               \
+    ProxyMutex *mutex = _m.get();                         \
     CACHE_INCREMENT_DYN_STAT(cache_direntries_used_stat); \
   } while (0)
 
 #define CACHE_DEC_DIR_USED(_m)                            \
   do {                                                    \
-    ProxyMutex *mutex = _m;                               \
+    ProxyMutex *mutex = _m.get();                         \
     CACHE_DECREMENT_DYN_STAT(cache_direntries_used_stat); \
   } while (0)
 
 #define CACHE_INC_DIR_COLLISIONS(_m)                                \
   do {                                                              \
-    ProxyMutex *mutex = _m;                                         \
+    ProxyMutex *mutex = _m.get();                                   \
     CACHE_INCREMENT_DYN_STAT(cache_directory_collision_count_stat); \
   } while (0);
 

--- a/iocore/cache/CacheRead.cc
+++ b/iocore/cache/CacheRead.cc
@@ -410,7 +410,7 @@ CacheVC::openReadFromWriter(int event, Event *e)
       // Update case (b) : grab doc_len from the writer's alternate
       doc_len = alternate.object_size_get();
       if (write_vc->update_key == cod->single_doc_key && (cod->move_resident_alt || write_vc->f.rewrite_resident_alt) &&
-          write_vc->first_buf._ptr()) {
+          write_vc->first_buf.get()) {
         // the resident alternate is being updated and its a
         // header only update. The first_buf of the writer has the
         // document body.

--- a/iocore/cache/CacheTest.cc
+++ b/iocore/cache/CacheTest.cc
@@ -555,7 +555,7 @@ test_RamCache(RegressionTest *t, RamCache *cache, const char *name, int64_t cach
       data.push_back(make_ptr(d));
       md5.u64[0] = ((uint64_t)i << 32) + i;
       md5.u64[1] = ((uint64_t)i << 32) + i;
-      cache->put(&md5, data[i], 1 << 15);
+      cache->put(&md5, data[i].get(), 1 << 15);
       // More hits for the first 10.
       for (int j = 0; j <= i && j < 10; j++) {
         Ptr<IOBufferData> data;
@@ -597,7 +597,7 @@ test_RamCache(RegressionTest *t, RamCache *cache, const char *name, int64_t cach
       IOBufferData *d = THREAD_ALLOC(ioDataAllocator, this_thread());
       d->alloc(BUFFER_SIZE_INDEX_16K);
       data.push_back(make_ptr(d));
-      cache->put(&md5, data.back(), 1 << 15);
+      cache->put(&md5, data.back().get(), 1 << 15);
       if (i >= sample_size / 2)
         misses++; // Sample last half of the gets.
     }
@@ -616,7 +616,7 @@ test_RamCache(RegressionTest *t, RamCache *cache, const char *name, int64_t cach
       IOBufferData *d = THREAD_ALLOC(ioDataAllocator, this_thread());
       d->alloc(BUFFER_SIZE_INDEX_8K + (r[i] % 3));
       data.push_back(make_ptr(d));
-      cache->put(&md5, data.back(), d->block_size());
+      cache->put(&md5, data.back().get(), d->block_size());
       if (i >= sample_size / 2)
         misses++; // Sample last half of the gets.
     }

--- a/iocore/cache/CacheVol.cc
+++ b/iocore/cache/CacheVol.cc
@@ -239,7 +239,7 @@ CacheVC::scanObject(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
       char *tmp = doc->hdr();
       int len = doc->hlen;
       while (len > 0) {
-        int r = HTTPInfo::unmarshal(tmp, len, buf._ptr());
+        int r = HTTPInfo::unmarshal(tmp, len, buf.get());
         if (r < 0) {
           ink_assert(!"CacheVC::scanObject unmarshal failed");
           goto Lskip;

--- a/iocore/cache/CacheWrite.cc
+++ b/iocore/cache/CacheWrite.cc
@@ -106,7 +106,7 @@ CacheVC::updateVector(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
       alternate_index = write_vector->insert(&alternate, alternate_index);
     }
 
-    if (od->move_resident_alt && first_buf._ptr() && !od->has_multiple_writers()) {
+    if (od->move_resident_alt && first_buf.get() && !od->has_multiple_writers()) {
       Doc *doc = (Doc *)first_buf->data();
       int small_doc = (int64_t)doc->data_len() < (int64_t)cache_config_alt_rewrite_max_size;
       int have_res_alt = doc->key == od->single_doc_key;

--- a/iocore/cache/CacheWrite.cc
+++ b/iocore/cache/CacheWrite.cc
@@ -364,7 +364,7 @@ CacheVC *
 new_DocEvacuator(int nbytes, Vol *vol)
 {
   CacheVC *c = new_CacheVC(vol);
-  ProxyMutex *mutex = vol->mutex;
+  ProxyMutex *mutex = vol->mutex.get();
   c->base_stat = cache_evacuate_active_stat;
   CACHE_INCREMENT_DYN_STAT(c->base_stat + CACHE_STAT_ACTIVE);
   c->buf = new_IOBufferData(iobuffer_size_to_index(nbytes, MAX_BUFFER_SIZE_INDEX), MEMALIGNED);
@@ -802,7 +802,7 @@ agg_copy(char *p, CacheVC *vc)
     // move data
     if (vc->write_len) {
       {
-        ProxyMutex *mutex ATS_UNUSED = vc->vol->mutex;
+        ProxyMutex *mutex ATS_UNUSED = vc->vol->mutex.get();
         ink_assert(mutex->thread_holding == this_ethread());
         CACHE_DEBUG_SUM_DYN_STAT(cache_write_bytes_stat, vc->write_len);
       }
@@ -841,7 +841,7 @@ agg_copy(char *p, CacheVC *vc)
     Doc *doc = (Doc *)vc->buf->data();
     int l = vc->vol->round_to_approx_size(doc->len);
     {
-      ProxyMutex *mutex ATS_UNUSED = vc->vol->mutex;
+      ProxyMutex *mutex ATS_UNUSED = vc->vol->mutex.get();
       ink_assert(mutex->thread_holding == this_ethread());
       CACHE_DEBUG_INCREMENT_DYN_STAT(cache_gc_frags_evacuated_stat);
       CACHE_DEBUG_SUM_DYN_STAT(cache_gc_bytes_evacuated_stat, l);
@@ -1583,7 +1583,7 @@ Cache::open_write(Continuation *cont, const CacheKey *key, CacheFragType frag_ty
 
   intptr_t res = 0;
   CacheVC *c = new_CacheVC(cont);
-  ProxyMutex *mutex = cont->mutex;
+  ProxyMutex *mutex = cont->mutex.get();
   SCOPED_MUTEX_LOCK(lock, c->mutex, this_ethread());
   c->vio.op = VIO::WRITE;
   c->base_stat = cache_write_active_stat;
@@ -1651,7 +1651,7 @@ Cache::open_write(Continuation *cont, const CacheKey *key, CacheHTTPInfo *info, 
   intptr_t err = 0;
   int if_writers = (uintptr_t)info == CACHE_ALLOW_MULTIPLE_WRITES;
   CacheVC *c = new_CacheVC(cont);
-  ProxyMutex *mutex = cont->mutex;
+  ProxyMutex *mutex = cont->mutex.get();
   c->vio.op = VIO::WRITE;
   c->first_key = *key;
   /*

--- a/iocore/cache/P_CacheInternal.h
+++ b/iocore/cache/P_CacheInternal.h
@@ -234,17 +234,20 @@ struct CacheVC : public CacheVConnection {
     ink_assert(vio.op == VIO::READ);
     return !f.not_from_ram_cache;
   }
+
   int
   get_header(void **ptr, int *len)
   {
-    if (first_buf.m_ptr) {
+    if (first_buf) {
       Doc *doc = (Doc *)first_buf->data();
       *ptr = doc->hdr();
       *len = doc->hlen;
       return 0;
-    } else
-      return -1;
+    }
+
+    return -1;
   }
+
   int
   set_header(void *ptr, int len)
   {
@@ -252,10 +255,11 @@ struct CacheVC : public CacheVConnection {
     header_to_write_len = len;
     return 0;
   }
+
   int
   get_single_data(void **ptr, int *len)
   {
-    if (first_buf.m_ptr) {
+    if (first_buf) {
       Doc *doc = (Doc *)first_buf->data();
       if (doc->data_len() == doc->total_len) {
         *ptr = doc->data();
@@ -263,16 +267,20 @@ struct CacheVC : public CacheVConnection {
         return 0;
       }
     }
+
     return -1;
   }
+
   int
   get_volume_number() const
   {
     if (vol && vol->cache_vol) {
       return vol->cache_vol->vol_number;
     }
+
     return -1;
   }
+
   bool
   is_compressed_in_ram() const
   {
@@ -560,7 +568,7 @@ TS_INLINE int
 free_CacheVC(CacheVC *cont)
 {
   Debug("cache_free", "free %p", cont);
-  ProxyMutex *mutex = cont->mutex;
+  ProxyMutex *mutex = cont->mutex.get();
   Vol *vol = cont->vol;
   if (vol) {
     CACHE_DECREMENT_DYN_STAT(cont->base_stat + CACHE_STAT_ACTIVE);

--- a/iocore/cache/P_CacheInternal.h
+++ b/iocore/cache/P_CacheInternal.h
@@ -879,7 +879,7 @@ dir_overwrite_lock(CacheKey *key, Vol *d, Dir *to_part, ProxyMutex *m, Dir *over
 }
 
 void TS_INLINE
-rand_CacheKey(CacheKey *next_key, ProxyMutex *mutex)
+rand_CacheKey(CacheKey *next_key, Ptr<ProxyMutex> &mutex)
 {
   next_key->b[0] = mutex->thread_holding->generator.random();
   next_key->b[1] = mutex->thread_holding->generator.random();

--- a/iocore/cache/RamCacheCLFUS.cc
+++ b/iocore/cache/RamCacheCLFUS.cc
@@ -302,10 +302,10 @@ RamCacheCLFUS::get(INK_MD5 *key, Ptr<IOBufferData> *ret_data, uint32_t auxkey1, 
           }
           (*ret_data) = data;
         } else {
-          IOBufferData *data = e->data;
+          IOBufferData *data = e->data.get();
           if (e->flag_bits.copy) {
             data = new_IOBufferData(iobuffer_size_to_index(e->len, MAX_BUFFER_SIZE_INDEX), MEMALIGNED);
-            memcpy(data->data(), e->data->data(), e->len);
+            ::memcpy(data->data(), e->data->data(), e->len);
           }
           (*ret_data) = data;
         }

--- a/iocore/cluster/ClusterCache.cc
+++ b/iocore/cluster/ClusterCache.cc
@@ -243,7 +243,7 @@ ClusterVConnectionCache::insert(INK_MD5 *key, ClusterVConnection *vc)
   int index = MD5ToIndex(key);
   Entry *e;
   EThread *thread = this_ethread();
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = thread->mutex.get();
 
   MUTEX_TRY_LOCK(lock, hash_lock[index], thread);
   if (!lock.is_locked()) {
@@ -269,7 +269,7 @@ ClusterVConnectionCache::lookup(INK_MD5 *key)
   Entry *e;
   ClusterVConnection *vc = 0;
   EThread *thread = this_ethread();
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = thread->mutex.get();
 
   MUTEX_TRY_LOCK(lock, hash_lock[index], thread);
   if (!lock.is_locked()) {
@@ -1023,7 +1023,7 @@ void
 cache_op_ClusterFunction(ClusterHandler *ch, void *data, int len)
 {
   EThread *thread = this_ethread();
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = thread->mutex.get();
   ////////////////////////////////////////////////////////
   // Note: we are running on the ET_CLUSTER thread
   ////////////////////////////////////////////////////////
@@ -1939,7 +1939,7 @@ cache_op_result_ClusterFunction(ClusterHandler *ch, void *d, int l)
 
   unsigned int hash = FOLDHASH(ch->machine->ip, msg->seq_number);
   EThread *thread = this_ethread();
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = thread->mutex.get();
   if (MUTEX_TAKE_TRY_LOCK(remoteCacheContQueueMutex[hash], thread)) {
     // Find it in pending list
 
@@ -2504,7 +2504,7 @@ cache_lookup_ClusterFunction(ClusterHandler *ch, void *data, int len)
 {
   (void)len;
   EThread *thread = this_ethread();
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = thread->mutex.get();
   ////////////////////////////////////////////////////////
   // Note: we are running on the ET_CLUSTER thread
   ////////////////////////////////////////////////////////

--- a/iocore/cluster/ClusterCache.cc
+++ b/iocore/cluster/ClusterCache.cc
@@ -1616,7 +1616,7 @@ CacheContinuation::replyOpEvent(int event, VConnection *cvc)
       msg->token = token; // Tell sender conn established
 
       OneWayTunnel *pOWT = OneWayTunnel::OneWayTunnel_alloc();
-      pOWT->init(read_cluster_vc, cache_vc, NULL, nbytes ? nbytes : DEFAULT_MAX_BUFFER_SIZE, this->mutex);
+      pOWT->init(read_cluster_vc, cache_vc, NULL, nbytes ? nbytes : DEFAULT_MAX_BUFFER_SIZE, this->mutex.get());
       read_cluster_vc->allow_remote_close();
       results_expected--;
     }
@@ -1688,7 +1688,7 @@ CacheContinuation::replyOpEvent(int event, VConnection *cvc)
       // Transmit reply message and object data in same cluster message
       Debug("cache_proto", "Sending reply/data seqno=%d buflen=%" PRId64, seq_number,
             readahead_data ? bytes_IOBufferBlockList(readahead_data, 1) : 0);
-      clusterProcessor.invoke_remote_data(ch, CACHE_OP_RESULT_CLUSTER_FUNCTION, (void *)msg, (flen + len), readahead_data,
+      clusterProcessor.invoke_remote_data(ch, CACHE_OP_RESULT_CLUSTER_FUNCTION, (void *)msg, (flen + len), readahead_data.get(),
                                           cluster_vc_channel, &token, &CacheContinuation::disposeOfDataBuffer, (void *)this,
                                           CLUSTER_OPT_STEAL);
     } else {
@@ -1975,7 +1975,7 @@ cache_op_result_ClusterFunction(ClusterHandler *ch, void *d, int l)
     c->freeMsgBuffer();
     if (ci.valid()) {
       // Unmarshaled CacheHTTPInfo contained in reply message, copy it.
-      c->setMsgBufferLen(len, iob);
+      c->setMsgBufferLen(len, iob.get());
       c->ic_new_info = ci;
     }
     msg->seq_number = len; // HACK ALERT: reusing variable
@@ -1996,7 +1996,7 @@ cache_op_result_ClusterFunction(ClusterHandler *ch, void *d, int l)
       c->token = msg->token;
     if (ci.valid()) {
       // Unmarshaled CacheHTTPInfo contained in reply message, copy it.
-      c->setMsgBufferLen(len, iob);
+      c->setMsgBufferLen(len, iob.get());
       c->ic_new_info = ci;
     }
     c->result_error = op_result_error;

--- a/iocore/cluster/ClusterConfig.cc
+++ b/iocore/cluster/ClusterConfig.cc
@@ -285,7 +285,7 @@ configuration_add_machine(ClusterConfiguration *c, ClusterMachine *m)
   // Machines are stored in ip sorted order.
   //
   EThread *thread = this_ethread();
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = thread->mutex.get();
   int i = 0;
   ClusterConfiguration *cc = new ClusterConfiguration(*c);
 
@@ -321,8 +321,7 @@ configuration_add_machine(ClusterConfiguration *c, ClusterMachine *m)
 ClusterConfiguration *
 configuration_remove_machine(ClusterConfiguration *c, ClusterMachine *m)
 {
-  EThread *thread = this_ethread();
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = this_thread()->mutex.get();
 
   //
   // Build a new cluster configuration without a machine

--- a/iocore/cluster/ClusterHandlerBase.cc
+++ b/iocore/cluster/ClusterHandlerBase.cc
@@ -67,7 +67,7 @@ ClusterControl::ClusterControl()
 void
 ClusterControl::real_alloc_data(int read_access, bool align_int32_on_non_int64_boundary)
 {
-  ProxyMutex *mutex = this_ethread()->mutex;
+  ProxyMutex *mutex = this_ethread()->mutex.get();
 
   ink_assert(!data);
   if ((len + DATA_HDR + sizeof(int32_t)) <= DEFAULT_MAX_BUFFER_SIZE) {

--- a/iocore/cluster/ClusterLib.cc
+++ b/iocore/cluster/ClusterLib.cc
@@ -104,13 +104,13 @@ clone_IOBufferBlockList(IOBufferBlock *b, int start_off, int n, IOBufferBlock **
   while (bsrc && nbytes) {
     // Skip zero length blocks
     if (!bsrc->read_avail()) {
-      bsrc = bsrc->next;
+      bsrc = bsrc->next.get();
       continue;
     }
 
     if (bclone_head) {
       bclone->next = bsrc->clone();
-      bclone = bclone->next;
+      bclone = bclone->next.get();
     } else {
       // Skip bytes already processed
       if (bytes_to_skip) {
@@ -125,7 +125,7 @@ clone_IOBufferBlockList(IOBufferBlock *b, int start_off, int n, IOBufferBlock **
 
         } else {
           // Skip entire block
-          bsrc = bsrc->next;
+          bsrc = bsrc->next.get();
           continue;
         }
       } else {
@@ -140,7 +140,7 @@ clone_IOBufferBlockList(IOBufferBlock *b, int start_off, int n, IOBufferBlock **
       bclone->fill(nbytes);
       nbytes = 0;
     }
-    bsrc = bsrc->next;
+    bsrc = bsrc->next.get();
   }
   ink_release_assert(!nbytes);
   *b_tail = bclone;
@@ -167,14 +167,15 @@ consume_IOBufferBlockList(IOBufferBlock *b, int64_t n)
 
       } else {
         // Consumed entire block
-        b_remainder = b->next;
+        b_remainder = b->next.get();
       }
       break;
 
     } else {
-      b = b->next;
+      b = b->next.get();
     }
   }
+
   ink_release_assert(nbytes == 0);
   return b_remainder; // return remaining blocks
 }
@@ -191,8 +192,9 @@ bytes_IOBufferBlockList(IOBufferBlock *b, int64_t read_avail_bytes)
     } else {
       n += b->write_avail();
     }
-    b = b->next;
+    b = b->next.get();
   }
+
   return n;
 }
 

--- a/iocore/cluster/ClusterLoadMonitor.cc
+++ b/iocore/cluster/ClusterLoadMonitor.cc
@@ -218,7 +218,7 @@ void
 ClusterLoadMonitor::note_ping_response_time(ink_hrtime response_time, int sequence_number)
 {
 #ifdef CLUSTER_TOMCAT
-  ProxyMutex *mutex = this->ch->mutex; // hack for stats
+  ProxyMutex *mutex = this->ch->mutex.get(); // hack for stats
 #endif
 
   CLUSTER_SUM_DYN_STAT(CLUSTER_PING_TIME_STAT, response_time);

--- a/iocore/cluster/ClusterMachine.cc
+++ b/iocore/cluster/ClusterMachine.cc
@@ -78,8 +78,7 @@ ClusterMachine::ClusterMachine(char *ahostname, unsigned int aip, int aport)
     msg_proto_minor(0),
     clusterHandlers(0)
 {
-  EThread *thread = this_ethread();
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = this_ethread()->mutex.get();
   CLUSTER_INCREMENT_DYN_STAT(CLUSTER_MACHINES_ALLOCATED_STAT);
   if (!aip) {
     char localhost[1024];
@@ -191,8 +190,7 @@ struct MachineTimeoutContinuation : public Continuation {
 void
 free_ClusterMachine(ClusterMachine *m)
 {
-  EThread *thread = this_ethread();
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = this_ethread()->mutex.get();
   // delay before the final free
   CLUSTER_INCREMENT_DYN_STAT(CLUSTER_MACHINES_FREED_STAT);
   m->dead = true;

--- a/iocore/cluster/ClusterProcessor.cc
+++ b/iocore/cluster/ClusterProcessor.cc
@@ -53,7 +53,7 @@ ClusterProcessor::~ClusterProcessor()
 int
 ClusterProcessor::internal_invoke_remote(ClusterHandler *ch, int cluster_fn, void *data, int len, int options, void *cmsg)
 {
-  ProxyMutex *mutex = this_ethread()->mutex;
+  ProxyMutex *mutex = this_ethread()->mutex.get();
   //
   // RPC facility for intercluster communication available to other
   //  subsystems.
@@ -238,7 +238,7 @@ ClusterProcessor::open_local(Continuation *cont, ClusterMachine * /* m ATS_UNUSE
     return NULL;
 
   EThread *thread = this_ethread();
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = thread->mutex.get();
   ClusterVConnection *vc = clusterVCAllocator.alloc();
   vc->new_connect_read = (options & CLUSTER_OPT_CONN_READ ? 1 : 0);
   vc->start_time = Thread::get_hrtime();
@@ -308,7 +308,7 @@ ClusterProcessor::connect_local(Continuation *cont, ClusterVCToken *token, int c
     return NULL;
 
   EThread *thread = this_ethread();
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = thread->mutex.get();
   ClusterVConnection *vc = clusterVCAllocator.alloc();
   vc->new_connect_read = (options & CLUSTER_OPT_CONN_READ ? 1 : 0);
   vc->start_time = Thread::get_hrtime();

--- a/iocore/cluster/ClusterProcessor.cc
+++ b/iocore/cluster/ClusterProcessor.cc
@@ -53,8 +53,7 @@ ClusterProcessor::~ClusterProcessor()
 int
 ClusterProcessor::internal_invoke_remote(ClusterHandler *ch, int cluster_fn, void *data, int len, int options, void *cmsg)
 {
-  EThread *thread = this_ethread();
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = this_ethread()->mutex;
   //
   // RPC facility for intercluster communication available to other
   //  subsystems.

--- a/iocore/cluster/ClusterRPC.cc
+++ b/iocore/cluster/ClusterRPC.cc
@@ -132,7 +132,7 @@ CacheVC *
 ChannelToCacheWriteVC(ClusterHandler *ch, int channel, uint32_t channel_seqno, ClusterVConnection **cluster_vc)
 {
   EThread *thread = this_ethread();
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = thread->mutex.get();
 
   ClusterVConnection *cvc = ch->channels[channel];
   if (!VALID_CHANNEL(cvc) || (channel_seqno != cvc->token.sequence_number) || (cvc->read.vio.op != VIO::READ)) {
@@ -160,7 +160,7 @@ void
 set_channel_data_ClusterFunction(ClusterHandler *ch, void *tdata, int tlen)
 {
   EThread *thread = this_ethread();
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = thread->mutex.get();
   // We are called on the ET_CLUSTER thread.
 
   char *data;
@@ -229,7 +229,7 @@ void
 post_setchan_send_ClusterFunction(ClusterHandler *ch, void *data, int /* len ATS_UNUSED */)
 {
   EThread *thread = this_ethread();
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = thread->mutex.get();
   // We are called on the ET_CLUSTER thread.
   // set_data() control message has been queued into cluster transfer message.
   // This allows us to assume that it has been sent.
@@ -289,7 +289,7 @@ void
 post_setchan_pin_ClusterFunction(ClusterHandler *ch, void *data, int /* len ATS_UNUSED */)
 {
   EThread *thread = this_ethread();
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = thread->mutex.get();
   // We are called on the ET_CLUSTER thread.
   // Control message has been queued into cluster transfer message.
   // This allows us to assume that it has been sent.
@@ -349,7 +349,7 @@ void
 post_setchan_priority_ClusterFunction(ClusterHandler *ch, void *data, int /* len ATS_UNUSED */)
 {
   EThread *thread = this_ethread();
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = thread->mutex.get();
 
   // We are called on the ET_CLUSTER thread.
   // Control message has been queued into cluster transfer message.

--- a/iocore/cluster/ClusterVConnection.cc
+++ b/iocore/cluster/ClusterVConnection.cc
@@ -31,7 +31,7 @@ ClassAllocator<ClusterVConnection> clusterVCAllocator("clusterVCAllocator");
 ClassAllocator<ByteBankDescriptor> byteBankAllocator("byteBankAllocator");
 
 ByteBankDescriptor *
-ByteBankDescriptor::ByteBankDescriptor_alloc(IOBufferBlock *iob)
+ByteBankDescriptor::ByteBankDescriptor_alloc(Ptr<IOBufferBlock> &iob)
 {
   ByteBankDescriptor *b = byteBankAllocator.alloc();
   b->block = iob;

--- a/iocore/cluster/P_ClusterCache.h
+++ b/iocore/cluster/P_ClusterCache.h
@@ -454,12 +454,12 @@ class ByteBankDescriptor
 public:
   ByteBankDescriptor() {}
   IOBufferBlock *
-  get_block()
+  get_block() const
   {
-    return block;
+    return block.get();
   }
 
-  static ByteBankDescriptor *ByteBankDescriptor_alloc(IOBufferBlock *);
+  static ByteBankDescriptor *ByteBankDescriptor_alloc(Ptr<IOBufferBlock> &);
   static void ByteBankDescriptor_free(ByteBankDescriptor *);
 
 public:

--- a/iocore/cluster/P_ClusterCacheInternal.h
+++ b/iocore/cluster/P_ClusterCacheInternal.h
@@ -195,7 +195,7 @@ struct CacheContinuation : public Continuation {
   inline void
   setMsgBufferLen(int l, IOBufferData *b = 0)
   {
-    ink_assert(rw_buf_msg == 0);
+    ink_assert(!rw_buf_msg);
     ink_assert(rw_buf_msg_len == 0);
 
     rw_buf_msg = b;
@@ -211,7 +211,7 @@ struct CacheContinuation : public Continuation {
   inline void
   allocMsgBuffer()
   {
-    ink_assert(rw_buf_msg == 0);
+    ink_assert(!rw_buf_msg);
     ink_assert(rw_buf_msg_len);
     if (rw_buf_msg_len <= DEFAULT_MAX_BUFFER_SIZE) {
       rw_buf_msg = new_IOBufferData(buffer_size_to_index(rw_buf_msg_len, MAX_BUFFER_SIZE_INDEX));
@@ -228,9 +228,9 @@ struct CacheContinuation : public Continuation {
   }
 
   inline IOBufferData *
-  getMsgBufferIOBData()
+  getMsgBufferIOBData() const
   {
-    return rw_buf_msg;
+    return rw_buf_msg.get();
   }
 
   inline void

--- a/iocore/cluster/P_ClusterHandler.h
+++ b/iocore/cluster/P_ClusterHandler.h
@@ -52,17 +52,19 @@ struct ClusterControl : public Continuation {
   Ptr<IOBufferBlock> iob_block;
 
   IOBufferBlock *
-  get_block()
+  get_block() const
   {
-    return iob_block;
+    return iob_block.get();
   }
+
   bool
-  fast_data()
+  fast_data() const
   {
     return (len <= MAX_FAST_CONTROL_MESSAGE);
   }
+
   bool
-  valid_alloc_data()
+  valid_alloc_data() const
   {
     return iob_block && real_data && data;
   }
@@ -240,9 +242,9 @@ struct ClusterMsg {
   }
 
   IOBufferBlock *
-  get_block()
+  get_block() const
   {
-    return iob_descriptor_block;
+    return iob_descriptor_block.get();
   }
 
   IOBufferBlock *
@@ -255,7 +257,7 @@ struct ClusterMsg {
     iob_descriptor_block->next = 0;
     iob_descriptor_block->fill(start_offset);
     iob_descriptor_block->consume(start_offset);
-    return iob_descriptor_block;
+    return iob_descriptor_block.get();
   }
 
   IOBufferBlock *
@@ -268,7 +270,7 @@ struct ClusterMsg {
     iob_descriptor_block->next = 0;
     iob_descriptor_block->fill(start_offset);
     iob_descriptor_block->consume(start_offset);
-    return iob_descriptor_block;
+    return iob_descriptor_block.get();
   }
 
   void

--- a/iocore/cluster/P_ClusterInternal.h
+++ b/iocore/cluster/P_ClusterInternal.h
@@ -493,8 +493,28 @@ extern void cluster_update_priority(ClusterHandler *, ClusterVConnection *, Clus
 extern void cluster_bump(ClusterHandler *, ClusterVConnectionBase *, ClusterVConnState *, int);
 
 extern IOBufferBlock *clone_IOBufferBlockList(IOBufferBlock *, int, int, IOBufferBlock **);
+
+static inline IOBufferBlock *
+clone_IOBufferBlockList(Ptr<IOBufferBlock> &src, int start_off, int b, IOBufferBlock **b_tail)
+{
+  return clone_IOBufferBlockList(src.get(), start_off, b, b_tail);
+}
+
 extern IOBufferBlock *consume_IOBufferBlockList(IOBufferBlock *, int64_t);
+
+static inline IOBufferBlock *
+consume_IOBufferBlockList(Ptr<IOBufferBlock> &b, int64_t n)
+{
+  return consume_IOBufferBlockList(b.get(), n);
+}
+
 extern int64_t bytes_IOBufferBlockList(IOBufferBlock *, int64_t);
+
+static inline int64_t
+bytes_IOBufferBlockList(Ptr<IOBufferBlock> &b, int64_t read_avail_bytes)
+{
+  return bytes_IOBufferBlockList(b.get(), read_avail_bytes);
+}
 
 // ClusterVConnection declarations
 extern void clusterVCAllocator_free(ClusterVConnection *vc);

--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -874,7 +874,7 @@ get_entry(DNSHandler *h, char *qname, int qtype)
 static void
 write_dns(DNSHandler *h)
 {
-  ProxyMutex *mutex = h->mutex;
+  ProxyMutex *mutex = h->mutex.get();
   DNS_INCREMENT_DYN_STAT(dns_total_lookups_stat);
   int max_nscount = h->m_res->nscount;
   if (max_nscount > MAX_NAMED)
@@ -955,7 +955,7 @@ DNSHandler::get_query_id()
 static bool
 write_dns_event(DNSHandler *h, DNSEntry *e)
 {
-  ProxyMutex *mutex = h->mutex;
+  ProxyMutex *mutex = h->mutex.get();
   union {
     HEADER _h;
     char _b[MAX_DNS_PACKET_LEN];
@@ -1110,7 +1110,7 @@ DNSProcessor::getby(const char *x, int len, int type, Continuation *cont, Option
 static void
 dns_result(DNSHandler *h, DNSEntry *e, HostEnt *ent, bool retry)
 {
-  ProxyMutex *mutex = h->mutex;
+  ProxyMutex *mutex = h->mutex.get();
   bool cancelled = (e->action.cancelled ? true : false);
 
   if (!ent && !cancelled) {
@@ -1279,7 +1279,7 @@ DNSEntry::postEvent(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
 static bool
 dns_process(DNSHandler *handler, HostEnt *buf, int len)
 {
-  ProxyMutex *mutex = handler->mutex;
+  ProxyMutex *mutex = handler->mutex.get();
   HEADER *h = (HEADER *)(buf->buf);
   DNSEntry *e = get_dns(handler, (uint16_t)ntohs(h->id));
   bool retry = false;

--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -1070,7 +1070,7 @@ DNSEntry::mainEvent(int event, Event *e)
     Debug("dns", "timeout for query %s", qname);
     if (dnsH->txn_lookup_timeout) {
       timeout = NULL;
-      dns_result(dnsH, this, result_ent, false); // do not retry -- we are over TXN timeout on DNS alone!
+      dns_result(dnsH, this, result_ent.get(), false); // do not retry -- we are over TXN timeout on DNS alone!
       return EVENT_DONE;
     }
     if (written_flag) {
@@ -1080,7 +1080,7 @@ DNSEntry::mainEvent(int event, Event *e)
       DNS_DECREMENT_DYN_STAT(dns_in_flight_stat);
     }
     timeout = NULL;
-    dns_result(dnsH, this, result_ent, true);
+    dns_result(dnsH, this, result_ent.get(), true);
     return EVENT_DONE;
   }
 }
@@ -1266,7 +1266,7 @@ DNSEntry::postEvent(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
 {
   if (!action.cancelled) {
     Debug("dns", "called back continuation for %s", qname);
-    action.continuation->handleEvent(DNS_EVENT_LOOKUP, result_ent);
+    action.continuation->handleEvent(DNS_EVENT_LOOKUP, result_ent.get());
   }
   result_ent = NULL;
   action.mutex = NULL;

--- a/iocore/eventsystem/I_Continuation.h
+++ b/iocore/eventsystem/I_Continuation.h
@@ -161,6 +161,7 @@ public:
 
   */
   Continuation(ProxyMutex *amutex = NULL);
+  Continuation(Ptr<ProxyMutex> &amutex);
 };
 
 /**
@@ -190,6 +191,17 @@ public:
 #else
 #define SET_CONTINUATION_HANDLER(_c, _h) (_c->handler = ((ContinuationHandler)_h))
 #endif
+
+inline Continuation::Continuation(Ptr<ProxyMutex> &amutex)
+  : handler(NULL),
+#ifdef DEBUG
+    handler_name(NULL),
+#endif
+    mutex(amutex)
+{
+  // Pick up the control flags from the creating thread
+  this->control_flags.set_flags(get_cont_flags().get_flags());
+}
 
 inline Continuation::Continuation(ProxyMutex *amutex)
   : handler(NULL),

--- a/iocore/eventsystem/I_IOBuffer.h
+++ b/iocore/eventsystem/I_IOBuffer.h
@@ -1318,11 +1318,6 @@ public:
     return new_IOBufferBlock_internal(loc);
   }
   IOBufferBlock *
-  operator()(IOBufferData *d, int64_t len = 0, int64_t offset = 0)
-  {
-    return new_IOBufferBlock_internal(loc, d, len, offset);
-  }
-  IOBufferBlock *
   operator()(Ptr<IOBufferData> &d, int64_t len = 0, int64_t offset = 0)
   {
     return new_IOBufferBlock_internal(loc, d.get(), len, offset);

--- a/iocore/eventsystem/I_IOBuffer.h
+++ b/iocore/eventsystem/I_IOBuffer.h
@@ -917,18 +917,19 @@ public:
     Returns a pointer to the first writable block on the block chain.
     Returns NULL if there are not currently any writable blocks on the
     block list.
-
   */
   IOBufferBlock *
   first_write_block()
   {
     if (_writer) {
-      if (_writer->next && !_writer->write_avail())
-        return _writer->next;
+      if (_writer->next && !_writer->write_avail()) {
+        return _writer->next.get();
+      }
       ink_assert(!_writer->next || !_writer->next->read_avail());
-      return _writer;
-    } else
-      return NULL;
+      return _writer.get();
+    }
+
+    return NULL;
   }
 
   char *
@@ -937,16 +938,19 @@ public:
     IOBufferBlock *b = first_write_block();
     return b ? b->buf() : 0;
   }
+
   char *
   buf_end()
   {
     return first_write_block()->buf_end();
   }
+
   char *
   start()
   {
     return first_write_block()->start();
   }
+
   char *
   end()
   {
@@ -1317,6 +1321,11 @@ public:
   operator()(IOBufferData *d, int64_t len = 0, int64_t offset = 0)
   {
     return new_IOBufferBlock_internal(loc, d, len, offset);
+  }
+  IOBufferBlock *
+  operator()(Ptr<IOBufferData> &d, int64_t len = 0, int64_t offset = 0)
+  {
+    return new_IOBufferBlock_internal(loc, d.get(), len, offset);
   }
 };
 #endif

--- a/iocore/eventsystem/I_Thread.h
+++ b/iocore/eventsystem/I_Thread.h
@@ -61,20 +61,15 @@
 
 #if !defined(_I_EventSystem_h) && !defined(_P_EventSystem_h)
 #error "include I_EventSystem.h or P_EventSystem.h"
--- - include I_Event.h or
-  P_Event.h
 #endif
+
 #include "ts/ink_platform.h"
 #include "ts/ink_thread.h"
 #include "I_ProxyAllocator.h"
-  class Thread;
+
+class Thread;
 class ProxyMutex;
-
-#define THREADAPI
-#define THREADAPI_RETURN_TYPE void *
-typedef THREADAPI_RETURN_TYPE(THREADAPI *ThreadFunction)(void *arg);
-
-extern ProxyMutex *global_mutex;
+typedef void *(*ThreadFunction)(void *arg);
 
 static const int MAX_THREAD_NAME_LENGTH = 16;
 static const int DEFAULT_STACKSIZE = 1048576; // 1MB
@@ -124,7 +119,6 @@ public:
 
   static ink_hrtime cur_time;
   inkcoreapi static ink_thread_key thread_data_key;
-  Ptr<ProxyMutex> mutex_ptr;
 
   // For THREAD_ALLOC
   ProxyAllocator eventAllocator;

--- a/iocore/eventsystem/I_Thread.h
+++ b/iocore/eventsystem/I_Thread.h
@@ -110,7 +110,7 @@ public:
     regions. Do not modify this member directly.
 
   */
-  ProxyMutex *mutex;
+  Ptr<ProxyMutex> mutex;
 
   // PRIVATE
   void set_specific();

--- a/iocore/eventsystem/I_VConnection.h
+++ b/iocore/eventsystem/I_VConnection.h
@@ -311,6 +311,7 @@ public:
   virtual void do_io_shutdown(ShutdownHowTo_t howto) = 0;
 
   VConnection(ProxyMutex *aMutex);
+  VConnection(Ptr<ProxyMutex> &aMutex);
 
   /** @deprecated */
   VIO *do_io(int op, Continuation *c = NULL, int64_t nbytes = INT64_MAX, MIOBuffer *buf = 0, int data = 0);

--- a/iocore/eventsystem/P_UnixEThread.h
+++ b/iocore/eventsystem/P_UnixEThread.h
@@ -97,7 +97,7 @@ EThread::schedule(Event *e, bool fast_signal)
     e->mutex = e->continuation->mutex;
   else
     e->mutex = e->continuation->mutex = e->ethread->mutex;
-  ink_assert(e->mutex.m_ptr);
+  ink_assert(e->mutex.get());
   EventQueueExternal.enqueue(e, fast_signal);
   return e;
 }
@@ -145,7 +145,7 @@ EThread::schedule_local(Event *e)
     ink_assert(tt == DEDICATED);
     return eventProcessor.schedule(e, ET_CALL);
   }
-  if (!e->mutex.m_ptr) {
+  if (!e->mutex) {
     e->ethread = this;
     e->mutex = e->continuation->mutex;
   } else {

--- a/iocore/eventsystem/P_VConnection.h
+++ b/iocore/eventsystem/P_VConnection.h
@@ -61,6 +61,12 @@ VConnection::VConnection(ProxyMutex *aMutex) : Continuation(aMutex), lerrno(0)
 }
 
 TS_INLINE
+VConnection::VConnection(Ptr<ProxyMutex> &aMutex) : Continuation(aMutex), lerrno(0)
+{
+  SET_HANDLER(0);
+}
+
+TS_INLINE
 VConnection::~VConnection()
 {
 }

--- a/iocore/eventsystem/Thread.cc
+++ b/iocore/eventsystem/Thread.cc
@@ -37,14 +37,12 @@
 
 static ink_thread_key init_thread_key();
 
-ProxyMutex *global_mutex = NULL;
 ink_hrtime Thread::cur_time = 0;
 inkcoreapi ink_thread_key Thread::thread_data_key = init_thread_key();
 
 Thread::Thread()
 {
   mutex = new_ProxyMutex();
-  mutex_ptr = mutex;
   MUTEX_TAKE_LOCK(mutex, (EThread *)this);
   mutex->nthread_holding = THREAD_MUTEX_THREAD_HOLDING;
 }

--- a/iocore/eventsystem/UnixEThread.cc
+++ b/iocore/eventsystem/UnixEThread.cc
@@ -135,7 +135,7 @@ void
 EThread::process_event(Event *e, int calling_code)
 {
   ink_assert((!e->in_the_prot_queue && !e->in_the_priority_queue));
-  MUTEX_TRY_LOCK_FOR(lock, e->mutex.m_ptr, this, e->continuation);
+  MUTEX_TRY_LOCK_FOR(lock, e->mutex, this, e->continuation);
   if (!lock.is_locked()) {
     e->timeout_at = cur_time + DELAY_FOR_RETRY;
     EventQueueExternal.enqueue_local(e);

--- a/iocore/eventsystem/UnixEventProcessor.cc
+++ b/iocore/eventsystem/UnixEventProcessor.cc
@@ -85,7 +85,6 @@ EventProcessor::start(int n_event_threads, size_t stacksize)
     EThread *t = new EThread(REGULAR, i);
     if (i == 0) {
       ink_thread_setspecific(Thread::thread_data_key, t);
-      global_mutex = t->mutex;
       Thread::get_hrtime_updated();
     }
     all_ethreads[i] = t;

--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -754,7 +754,7 @@ HostDBProcessor::getby(Continuation *cont, const char *hostname, int len, sockad
 {
   HostDBMD5 md5;
   EThread *thread = this_ethread();
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = thread->mutex.get();
   ip_text_buffer ipb;
 
   HOSTDB_INCREMENT_DYN_STAT(hostdb_total_lookups_stat);
@@ -840,7 +840,7 @@ HostDBProcessor::getbyname_re(Continuation *cont, const char *ahostname, int len
 {
   bool force_dns = false;
   EThread *thread = this_ethread();
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = thread->mutex.get();
 
   if (opt.flags & HOSTDB_FORCE_DNS_ALWAYS)
     force_dns = true;
@@ -857,7 +857,7 @@ HostDBProcessor::getbynameport_re(Continuation *cont, const char *ahostname, int
 {
   bool force_dns = false;
   EThread *thread = this_ethread();
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = thread->mutex.get();
 
   if (opt.flags & HOSTDB_FORCE_DNS_ALWAYS)
     force_dns = true;
@@ -879,7 +879,7 @@ HostDBProcessor::getSRVbyname_imm(Continuation *cont, process_srv_info_pfn proce
   ink_assert(cont->mutex->thread_holding == this_ethread());
   bool force_dns = false;
   EThread *thread = cont->mutex->thread_holding;
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = thread->mutex.get();
 
   if (opt.flags & HOSTDB_FORCE_DNS_ALWAYS)
     force_dns = true;
@@ -952,7 +952,7 @@ HostDBProcessor::getbyname_imm(Continuation *cont, process_hostdb_info_pfn proce
   ink_assert(cont->mutex->thread_holding == this_ethread());
   bool force_dns = false;
   EThread *thread = cont->mutex->thread_holding;
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = thread->mutex.get();
   HostDBMD5 md5;
 
   if (opt.flags & HOSTDB_FORCE_DNS_ALWAYS)
@@ -1022,7 +1022,7 @@ HostDBProcessor::iterate(Continuation *cont)
 {
   ink_assert(cont->mutex->thread_holding == this_ethread());
   EThread *thread = cont->mutex->thread_holding;
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = thread->mutex.get();
 
   HOSTDB_INCREMENT_DYN_STAT(hostdb_total_lookups_stat);
 

--- a/iocore/hostdb/MultiCache.cc
+++ b/iocore/hostdb/MultiCache.cc
@@ -1046,7 +1046,7 @@ struct MultiCacheSync : public Continuation {
   }
 
   MultiCacheSync(Continuation *acont, MultiCacheBase *amc)
-    : Continuation(amc->locks[0]), partition(0), mc(amc), cont(acont), before_used(0)
+    : Continuation(amc->locks[0].get()), partition(0), mc(amc), cont(acont), before_used(0)
   {
     mutex = mc->locks[partition];
     SET_HANDLER((MCacheSyncHandler)&MultiCacheSync::heapEvent);
@@ -1159,7 +1159,7 @@ struct MultiCacheHeapGC : public Continuation {
   }
 
   MultiCacheHeapGC(Continuation *acont, MultiCacheBase *amc)
-    : Continuation(amc->locks[0]), cont(acont), mc(amc), partition(0), n_offsets(0)
+    : Continuation(amc->locks[0].get()), cont(acont), mc(amc), partition(0), n_offsets(0)
   {
     SET_HANDLER((MCacheHeapGCHandler)&MultiCacheHeapGC::startEvent);
     offset_table = (OffsetTable *)ats_malloc(sizeof(OffsetTable) *

--- a/iocore/hostdb/P_MultiCache.h
+++ b/iocore/hostdb/P_MultiCache.h
@@ -321,8 +321,9 @@ struct MultiCacheBase : public MultiCacheHeader {
   ProxyMutex *
   lock_for_bucket(int bucket)
   {
-    return locks[partition_of_bucket(bucket)];
+    return locks[partition_of_bucket(bucket)].get();
   }
+
   uint64_t
   make_tag(uint64_t folded_md5)
   {

--- a/iocore/net/I_UDPPacket.h
+++ b/iocore/net/I_UDPPacket.h
@@ -49,7 +49,7 @@ public:
   void setConnection(UDPConnection *c);
   UDPConnection *getConnection();
   IOBufferBlock *getIOBlockChain();
-  int64_t getPktLength();
+  int64_t getPktLength() const;
 
   /**
      Add IOBufferBlock (chain) to end of packet.

--- a/iocore/net/P_CompletionUtil.h
+++ b/iocore/net/P_CompletionUtil.h
@@ -33,7 +33,7 @@ public:
   static void setContinuation(Event *e, Continuation *c);
   static void *getHandle(Event *e);
   static void setHandle(Event *e, void *handle);
-  static void setInfo(Event *e, int fd, IOBufferBlock *buf, int actual, int errno_);
+  static void setInfo(Event *e, int fd, const Ptr<IOBufferBlock> &buf, int actual, int errno_);
   static void setInfo(Event *e, int fd, struct msghdr *msg, int actual, int errno_);
   static int getBytesTransferred(Event *e);
   static IOBufferBlock *getIOBufferBlock(Event *e);

--- a/iocore/net/P_Socks.h
+++ b/iocore/net/P_Socks.h
@@ -140,7 +140,7 @@ struct SocksEntry : public Continuation {
   int startEvent(int event, void *data);
   int mainEvent(int event, void *data);
   void findServer();
-  void init(ProxyMutex *m, SocksNetVC *netvc, unsigned char socks_support, unsigned char ver);
+  void init(Ptr<ProxyMutex> &m, SocksNetVC *netvc, unsigned char socks_support, unsigned char ver);
   void free();
 
   SocksEntry()

--- a/iocore/net/P_UDPConnection.h
+++ b/iocore/net/P_UDPConnection.h
@@ -156,7 +156,7 @@ TS_INLINE void
 UDPConnection::setContinuation(Continuation *c)
 {
   // it is not safe to switch among continuations that don't share locks
-  ink_assert(mutex == NULL || c->mutex == mutex);
+  ink_assert(mutex.get() == NULL || c->mutex == mutex);
   mutex = c->mutex;
   ((UDPConnectionInternal *)this)->continuation = c;
 }

--- a/iocore/net/P_UDPIOEvent.h
+++ b/iocore/net/P_UDPIOEvent.h
@@ -31,14 +31,16 @@ class UDPIOEvent : public Event
 public:
   UDPIOEvent() : fd(-1), err(0), m(0), handle(0), b(0), bytesTransferred(0){};
   ~UDPIOEvent(){};
+
   void
-  setInfo(int fd_, IOBufferBlock *b_, int bytesTransferred_, int errno_)
+  setInfo(int fd_, const Ptr<IOBufferBlock> &b_, int bytesTransferred_, int errno_)
   {
     fd = fd_;
     b = b_;
     bytesTransferred = bytesTransferred_;
     err = errno_;
   };
+
   void
   setInfo(int fd_, struct msghdr *m_, int bytesTransferred_, int errno_)
   {
@@ -47,37 +49,44 @@ public:
     bytesTransferred = bytesTransferred_;
     err = errno_;
   };
+
   void
   setHandle(void *v)
   {
     handle = v;
   }
+
   void *
   getHandle()
   {
     return handle;
   }
-  void free();
+
   int
-  getBytesTransferred()
+  getBytesTransferred() const
   {
     return bytesTransferred;
   }
+
   IOBufferBlock *
-  getIOBufferBlock()
+  getIOBufferBlock() const
   {
-    return b;
+    return b.get();
   }
+
   int
-  getError()
+  getError() const
   {
     return err;
   }
+
   Continuation *
-  getContinuation()
+  getContinuation() const
   {
     return continuation;
   }
+
+  void free();
   static void free(UDPIOEvent *e);
 
 private:

--- a/iocore/net/P_UnixCompletionUtil.h
+++ b/iocore/net/P_UnixCompletionUtil.h
@@ -66,7 +66,7 @@ completionUtil::setHandle(Event *e, void *handle)
   u->setHandle(handle);
 }
 TS_INLINE void
-completionUtil::setInfo(Event *e, int fd, IOBufferBlock *buf, int actual, int errno_)
+completionUtil::setInfo(Event *e, int fd, const Ptr<IOBufferBlock> &buf, int actual, int errno_)
 {
   UDPIOEvent *u = (UDPIOEvent *)e;
   u->setInfo(fd, buf, actual, errno_);

--- a/iocore/net/P_UnixNet.h
+++ b/iocore/net/P_UnixNet.h
@@ -160,8 +160,8 @@ struct PollCont : public Continuation {
   PollDescriptor *nextPollDescriptor;
   int poll_timeout;
 
-  PollCont(ProxyMutex *m, int pt = net_config_poll_timeout);
-  PollCont(ProxyMutex *m, NetHandler *nh, int pt = net_config_poll_timeout);
+  PollCont(Ptr<ProxyMutex> &m, int pt = net_config_poll_timeout);
+  PollCont(Ptr<ProxyMutex> &m, NetHandler *nh, int pt = net_config_poll_timeout);
   ~PollCont();
   int pollEvent(int event, Event *e);
 };

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -88,7 +88,7 @@ struct OOB_callback : public Continuation {
   Continuation *server_cont;
   int retry_OOB_send(int, Event *);
 
-  OOB_callback(ProxyMutex *m, NetVConnection *vc, Continuation *cont, char *buf, int len)
+  OOB_callback(Ptr<ProxyMutex> &m, NetVConnection *vc, Continuation *cont, char *buf, int len)
     : Continuation(m), data(buf), length(len), trigger(0)
   {
     server_vc = (UnixNetVConnection *)vc;

--- a/iocore/net/SSLNextProtocolAccept.cc
+++ b/iocore/net/SSLNextProtocolAccept.cc
@@ -27,10 +27,8 @@ static void
 send_plugin_event(Continuation *plugin, int event, void *edata)
 {
   if (plugin->mutex) {
-    EThread *thread(this_ethread());
-    MUTEX_TAKE_LOCK(plugin->mutex, thread);
+    SCOPED_MUTEX_LOCK(lock, plugin->mutex, this_ethread());
     plugin->handleEvent(event, edata);
-    MUTEX_UNTAKE_LOCK(plugin->mutex, thread);
   } else {
     plugin->handleEvent(event, edata);
   }
@@ -64,7 +62,7 @@ ssl_netvc_cast(int event, void *edata)
 // lock across the handshake, so we make a trampoline to bounce the event from the SSL acceptor to the ultimate session
 // acceptor.
 struct SSLNextProtocolTrampoline : public Continuation {
-  explicit SSLNextProtocolTrampoline(const SSLNextProtocolAccept *npn, ProxyMutex *mutex) : Continuation(mutex), npnParent(npn)
+  SSLNextProtocolTrampoline(const SSLNextProtocolAccept *npn, Ptr<ProxyMutex> &mutex) : Continuation(mutex), npnParent(npn)
   {
     SET_HANDLER(&SSLNextProtocolTrampoline::ioCompletionEvent);
   }

--- a/iocore/net/Socks.cc
+++ b/iocore/net/Socks.cc
@@ -41,7 +41,7 @@ socks_conf_struct *g_socks_conf_stuff = 0;
 ClassAllocator<SocksEntry> socksAllocator("socksAllocator");
 
 void
-SocksEntry::init(ProxyMutex *m, SocksNetVC *vc, unsigned char socks_support, unsigned char ver)
+SocksEntry::init(Ptr<ProxyMutex> &m, SocksNetVC *vc, unsigned char socks_support, unsigned char ver)
 {
   mutex = m;
   buf = new_MIOBuffer();

--- a/iocore/net/UnixNet.cc
+++ b/iocore/net/UnixNet.cc
@@ -42,7 +42,7 @@ int update_cop_config(const char *name, RecDataT data_type, RecData data, void *
 class InactivityCop : public Continuation
 {
 public:
-  InactivityCop(ProxyMutex *m) : Continuation(m), default_inactivity_timeout(0)
+  explicit InactivityCop(Ptr<ProxyMutex> &m) : Continuation(m.get()), default_inactivity_timeout(0)
   {
     SET_HANDLER(&InactivityCop::check_inactivity);
     REC_ReadConfigInteger(default_inactivity_timeout, "proxy.config.net.default_inactivity_timeout");
@@ -138,14 +138,15 @@ update_cop_config(const char *name, RecDataT data_type ATS_UNUSED, RecData data,
 
 #endif
 
-PollCont::PollCont(ProxyMutex *m, int pt) : Continuation(m), net_handler(NULL), nextPollDescriptor(NULL), poll_timeout(pt)
+PollCont::PollCont(Ptr<ProxyMutex> &m, int pt)
+  : Continuation(m.get()), net_handler(NULL), nextPollDescriptor(NULL), poll_timeout(pt)
 {
   pollDescriptor = new PollDescriptor();
   SET_HANDLER(&PollCont::pollEvent);
 }
 
-PollCont::PollCont(ProxyMutex *m, NetHandler *nh, int pt)
-  : Continuation(m), net_handler(nh), nextPollDescriptor(NULL), poll_timeout(pt)
+PollCont::PollCont(Ptr<ProxyMutex> &m, NetHandler *nh, int pt)
+  : Continuation(m.get()), net_handler(nh), nextPollDescriptor(NULL), poll_timeout(pt)
 {
   pollDescriptor = new PollDescriptor();
   SET_HANDLER(&PollCont::pollEvent);

--- a/iocore/net/UnixNetProcessor.cc
+++ b/iocore/net/UnixNetProcessor.cc
@@ -85,7 +85,7 @@ Action *
 UnixNetProcessor::accept_internal(Continuation *cont, int fd, AcceptOptions const &opt)
 {
   EventType upgraded_etype = opt.etype; // setEtype requires non-const ref.
-  ProxyMutex *mutex = this_ethread()->mutex;
+  ProxyMutex *mutex = this_ethread()->mutex.get();
   int accept_threads = opt.accept_threads; // might be changed.
   IpEndpoint accept_ip;                    // local binding address.
   char thr_name[MAX_THREAD_NAME_LENGTH];

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -253,7 +253,7 @@ static void
 read_from_net(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
 {
   NetState *s = &vc->read;
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = thread->mutex.get();
   int64_t r = 0;
 
   MUTEX_TRY_LOCK_FOR(lock, s->vio.mutex, thread, s->vio._cont);
@@ -416,7 +416,7 @@ read_from_net(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
 void
 write_to_net(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
 {
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = thread->mutex.get();
 
   NET_INCREMENT_DYN_STAT(net_calls_to_writetonet_stat);
   NET_INCREMENT_DYN_STAT(net_calls_to_writetonet_afterpoll_stat);
@@ -428,7 +428,7 @@ void
 write_to_net_io(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
 {
   NetState *s = &vc->write;
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = thread->mutex.get();
 
   MUTEX_TRY_LOCK_FOR(lock, s->vio.mutex, thread, s->vio._cont);
 
@@ -1012,7 +1012,7 @@ UnixNetVConnection::load_buffer_and_write(int64_t towrite, int64_t &wattempted, 
       }
     }
 
-    ProxyMutex *mutex = thread->mutex;
+    ProxyMutex *mutex = thread->mutex.get();
     NET_INCREMENT_DYN_STAT(net_calls_to_write_stat);
   } while (r == wattempted && total_written < towrite);
 

--- a/iocore/utils/OneWayMultiTunnel.cc
+++ b/iocore/utils/OneWayMultiTunnel.cc
@@ -63,7 +63,7 @@ OneWayMultiTunnel::init(VConnection *vcSource, VConnection **vcTargets, int n_vc
                         bool aclose_targets,                 /* = false */
                         Transform_fn aManipulate_fn, int water_mark)
 {
-  mutex = aCont ? (ProxyMutex *)aCont->mutex : new_ProxyMutex();
+  mutex = aCont ? aCont->mutex : make_ptr(new_ProxyMutex());
   cont = aCont;
   manipulate_fn = aManipulate_fn;
   close_source = aclose_source;
@@ -108,7 +108,7 @@ void
 OneWayMultiTunnel::init(Continuation *aCont, VIO *SourceVio, VIO **TargetVios, int n_TargetVios, bool aclose_source,
                         bool aclose_targets)
 {
-  mutex = aCont ? (ProxyMutex *)aCont->mutex : new_ProxyMutex();
+  mutex = aCont ? aCont->mutex : make_ptr(new_ProxyMutex());
   cont = aCont;
   single_buffer = true;
   manipulate_fn = 0;

--- a/iocore/utils/OneWayTunnel.cc
+++ b/iocore/utils/OneWayTunnel.cc
@@ -107,7 +107,7 @@ OneWayTunnel::~OneWayTunnel()
 }
 
 OneWayTunnel::OneWayTunnel(Continuation *aCont, Transform_fn aManipulate_fn, bool aclose_source, bool aclose_target)
-  : Continuation(aCont ? (ProxyMutex *)aCont->mutex : new_ProxyMutex()),
+  : Continuation(aCont ? aCont->mutex.get() : new_ProxyMutex()),
     cont(aCont),
     manipulate_fn(aManipulate_fn),
     n_connections(2),
@@ -126,7 +126,7 @@ OneWayTunnel::init(VConnection *vcSource, VConnection *vcTarget, Continuation *a
                    int64_t nbytes, bool asingle_buffer, bool aclose_source, bool aclose_target, Transform_fn aManipulate_fn,
                    int water_mark)
 {
-  mutex = aCont ? (ProxyMutex *)aCont->mutex : (aMutex ? aMutex : new_ProxyMutex());
+  mutex = aCont ? aCont->mutex.get() : (aMutex ? aMutex : new_ProxyMutex());
   cont = aMutex ? NULL : aCont;
   single_buffer = asingle_buffer;
   manipulate_fn = aManipulate_fn;
@@ -170,7 +170,7 @@ OneWayTunnel::init(VConnection *vcSource, VConnection *vcTarget, Continuation *a
                    bool aclose_source, bool aclose_target)
 {
   (void)vcSource;
-  mutex = aCont ? (ProxyMutex *)aCont->mutex : new_ProxyMutex();
+  mutex = aCont ? aCont->mutex : make_ptr(new_ProxyMutex());
   cont = aCont;
   single_buffer = true;
   manipulate_fn = 0;
@@ -196,7 +196,7 @@ OneWayTunnel::init(VConnection *vcSource, VConnection *vcTarget, Continuation *a
 void
 OneWayTunnel::init(Continuation *aCont, VIO *SourceVio, VIO *TargetVio, bool aclose_source, bool aclose_target)
 {
-  mutex = aCont ? (ProxyMutex *)aCont->mutex : new_ProxyMutex();
+  mutex = aCont ? aCont->mutex : make_ptr(new_ProxyMutex());
   cont = aCont;
   single_buffer = true;
   manipulate_fn = 0;

--- a/lib/ts/Makefile.am
+++ b/lib/ts/Makefile.am
@@ -21,7 +21,8 @@ library_includedir=$(includedir)/ts
 library_include_HEADERS = apidefs.h
 
 noinst_PROGRAMS = mkdfa CompileParseRules
-check_PROGRAMS = test_arena test_atomic test_freelist test_geometry test_List test_Map test_Regex test_PriorityQueue test_Vec test_X509HostnameValidator
+check_PROGRAMS = test_arena test_atomic test_freelist test_geometry test_List test_Map test_Regex test_PriorityQueue test_Vec test_X509HostnameValidator test_Ptr
+
 TESTS = $(check_PROGRAMS)
 
 AM_CPPFLAGS = -I$(top_srcdir)/lib
@@ -234,6 +235,10 @@ test_geometry_LDFLAGS = @EXTRA_CXX_LDFLAGS@ @LIBTOOL_LINK_FLAGS@
 test_X509HostnameValidator_SOURCES = test_X509HostnameValidator.cc
 test_X509HostnameValidator_LDADD = libtsutil.la @LIBTCL@ @LIBPCRE@ @OPENSSL_LIBS@
 test_X509HostnameValidator_LDFLAGS = @EXTRA_CXX_LDFLAGS@ @LIBTOOL_LINK_FLAGS@
+
+test_Ptr_SOURCES = test_Ptr.cc
+test_Ptr_LDADD = libtsutil.la @LIBTCL@ @LIBPCRE@
+test_Ptr_LDFLAGS = @EXTRA_CXX_LDFLAGS@ @LIBTOOL_LINK_FLAGS@
 
 CompileParseRules_SOURCES = CompileParseRules.cc
 

--- a/lib/ts/Ptr.h
+++ b/lib/ts/Ptr.h
@@ -69,6 +69,7 @@ public:
     delete this;
   }
 
+private:
   volatile int m_refcount;
 };
 

--- a/lib/ts/Ptr.h
+++ b/lib/ts/Ptr.h
@@ -161,6 +161,15 @@ public:
     return tmp;
   }
 
+  // XXX Clearly this is not safe. This is used in HdrHeap::unmarshal() to swizzle
+  // the refcount of the managed heap pointers. That code needs to be cleaned up
+  // so that this can be removed. Do not use this in new code.
+  void
+  swizzle(RefCountObj *ptr)
+  {
+    m_ptr = ptr;
+  }
+
   T *m_ptr;
 };
 

--- a/lib/ts/Ptr.h
+++ b/lib/ts/Ptr.h
@@ -100,6 +100,13 @@ private:
 ////////////////////////////////////////////////////////////////////////
 template <class T> class Ptr
 {
+  // https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Safe_bool.
+  typedef void (Ptr::*bool_type)() const;
+  void
+  this_type_does_not_support_comparisons() const
+  {
+  }
+
 public:
   explicit Ptr(T *p = 0);
   Ptr(const Ptr<T> &);
@@ -109,9 +116,9 @@ public:
   Ptr<T> &operator=(const Ptr<T> &);
   Ptr<T> &operator=(T *);
 
-  operator T *() const { return (m_ptr); }
   T *operator->() const { return (m_ptr); }
   T &operator*() const { return (*m_ptr); }
+  operator bool_type() const { return m_ptr ? &Ptr::this_type_does_not_support_comparisons : 0; }
   int
   operator==(const T *p)
   {
@@ -170,7 +177,10 @@ public:
     m_ptr = ptr;
   }
 
+private:
   T *m_ptr;
+
+  friend class CoreUtils;
 };
 
 template <typename T>

--- a/lib/ts/Ptr.h
+++ b/lib/ts/Ptr.h
@@ -151,6 +151,16 @@ public:
     return static_cast<RefCountObj *>(m_ptr);
   }
 
+  // Return the stored pointer, storing NULL instead. Do not increment
+  // the refcount; the caller is now responsible for owning the RefCountObj.
+  T *
+  detach()
+  {
+    T *tmp = m_ptr;
+    m_ptr = NULL;
+    return tmp;
+  }
+
   T *m_ptr;
 };
 

--- a/lib/ts/Ptr.h
+++ b/lib/ts/Ptr.h
@@ -109,17 +109,6 @@ public:
   Ptr<T> &operator=(const Ptr<T> &);
   Ptr<T> &operator=(T *);
 
-  T *
-  to_ptr()
-  {
-    if (m_ptr && m_ptr->m_refcount == 1) {
-      T *ptr = m_ptr;
-      m_ptr = 0;
-      ptr->m_refcount = 0;
-      return ptr;
-    }
-    return 0;
-  }
   operator T *() const { return (m_ptr); }
   T *operator->() const { return (m_ptr); }
   T &operator*() const { return (*m_ptr); }
@@ -128,16 +117,19 @@ public:
   {
     return (m_ptr == p);
   }
+
   int
   operator==(const Ptr<T> &p)
   {
     return (m_ptr == p.m_ptr);
   }
+
   int
   operator!=(const T *p)
   {
     return (m_ptr != p);
   }
+
   int
   operator!=(const Ptr<T> &p)
   {
@@ -208,6 +200,7 @@ Ptr<T>::operator=(T *p)
 
   return (*this);
 }
+
 template <class T>
 inline void
 Ptr<T>::clear()
@@ -218,6 +211,7 @@ Ptr<T>::clear()
     m_ptr = NULL;
   }
 }
+
 template <class T>
 inline Ptr<T> &
 Ptr<T>::operator=(const Ptr<T> &src)

--- a/lib/ts/Ptr.h
+++ b/lib/ts/Ptr.h
@@ -136,10 +136,19 @@ public:
     return (m_ptr != p.m_ptr);
   }
 
-  RefCountObj *
-  _ptr()
+  // Return the raw pointer.
+  T *
+  get() const
   {
-    return (RefCountObj *)m_ptr;
+    return m_ptr;
+  }
+
+  // Return the raw pointer as a RefCount object. Typically
+  // this is for keeping a collection of heterogenous objects.
+  RefCountObj *
+  object() const
+  {
+    return static_cast<RefCountObj *>(m_ptr);
   }
 
   T *m_ptr;
@@ -159,24 +168,23 @@ make_ptr(T *p)
 ////////////////////////////////////////////////////////////////////////
 template <class T> inline Ptr<T>::Ptr(T *ptr /* = 0 */) : m_ptr(ptr)
 {
-  if (m_ptr)
-    _ptr()->refcount_inc();
-  return;
+  if (m_ptr) {
+    m_ptr->refcount_inc();
+  }
 }
 
 template <class T> inline Ptr<T>::Ptr(const Ptr<T> &src) : m_ptr(src.m_ptr)
 {
-  if (m_ptr)
-    _ptr()->refcount_inc();
-  return;
+  if (m_ptr) {
+    m_ptr->refcount_inc();
+  }
 }
 
 template <class T> inline Ptr<T>::~Ptr()
 {
-  if ((m_ptr) && _ptr()->refcount_dec() == 0) {
-    _ptr()->free();
+  if (m_ptr && m_ptr->refcount_dec() == 0) {
+    m_ptr->free();
   }
-  return;
 }
 
 template <class T>
@@ -185,17 +193,18 @@ Ptr<T>::operator=(T *p)
 {
   T *temp_ptr = m_ptr;
 
-  if (m_ptr == p)
+  if (m_ptr == p) {
     return (*this);
+  }
 
   m_ptr = p;
 
-  if (m_ptr != 0) {
-    _ptr()->refcount_inc();
+  if (m_ptr) {
+    m_ptr->refcount_inc();
   }
 
-  if ((temp_ptr) && ((RefCountObj *)temp_ptr)->refcount_dec() == 0) {
-    ((RefCountObj *)temp_ptr)->free();
+  if (temp_ptr && temp_ptr->refcount_dec() == 0) {
+    temp_ptr->free();
   }
 
   return (*this);

--- a/lib/ts/Ptr.h
+++ b/lib/ts/Ptr.h
@@ -51,6 +51,7 @@ public:
     (void)s;
     return;
   }
+
   virtual ~RefCountObj() {}
   RefCountObj &
   operator=(const RefCountObj &s)
@@ -59,9 +60,25 @@ public:
     return (*this);
   }
 
-  int refcount_inc();
-  int refcount_dec();
-  int refcount() const;
+  // Increment the reference count, returning the new count.
+  int
+  refcount_inc()
+  {
+    return ink_atomic_increment((int *)&m_refcount, 1) + 1;
+  }
+
+  // Decrement the reference count, returning the new count.
+  int
+  refcount_dec()
+  {
+    return ink_atomic_increment((int *)&m_refcount, -1) - 1;
+  }
+
+  int
+  refcount() const
+  {
+    return m_refcount;
+  }
 
   virtual void
   free()
@@ -73,29 +90,8 @@ private:
   volatile int m_refcount;
 };
 
-// Increment the reference count, returning the new count.
-inline int
-RefCountObj::refcount_inc()
-{
-  return ink_atomic_increment((int *)&m_refcount, 1) + 1;
-}
-
 #define REF_COUNT_OBJ_REFCOUNT_INC(_x) (_x)->refcount_inc()
-
-// Decrement the reference count, returning the new count.
-inline int
-RefCountObj::refcount_dec()
-{
-  return ink_atomic_increment((int *)&m_refcount, -1) - 1;
-}
-
 #define REF_COUNT_OBJ_REFCOUNT_DEC(_x) (_x)->refcount_dec()
-
-inline int
-RefCountObj::refcount() const
-{
-  return m_refcount;
-}
 
 ////////////////////////////////////////////////////////////////////////
 //

--- a/lib/ts/test_Ptr.cc
+++ b/lib/ts/test_Ptr.cc
@@ -85,6 +85,19 @@ REGRESSION_TEST(Ptr_refcount)(RegressionTest *t, int /* atype ATS_UNUSED */, int
   box.check(alive == 0, "refcounts dropped");
 }
 
+REGRESSION_TEST(Ptr_bool)(RegressionTest *t, int /* atype ATS_UNUSED */, int *pstatus)
+{
+  TestBox box(t, pstatus);
+  box = REGRESSION_TEST_PASSED;
+  unsigned alive = 0;
+
+  Ptr<PtrObject> none;
+  Ptr<PtrObject> some = make_ptr(new PtrObject(&alive));
+
+  box.check(!none, "Empty Ptr<T> is false");
+  box.check(some, "Non-empty Ptr<T> is true");
+}
+
 int
 main(int /* argc ATS_UNUSED */, char ** /* argv ATS_UNUSED */)
 {

--- a/lib/ts/test_Ptr.cc
+++ b/lib/ts/test_Ptr.cc
@@ -1,0 +1,93 @@
+/*
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include "ts/Ptr.h"
+#include "ts/TestBox.h"
+
+struct PtrObject : RefCountObj {
+  PtrObject(unsigned *_c) : count(_c) { ++(*count); }
+  ~PtrObject() { --(*count); }
+  unsigned *count;
+};
+
+REGRESSION_TEST(Ptr_detach)(RegressionTest *t, int /* atype ATS_UNUSED */, int *pstatus)
+{
+  TestBox box(t, pstatus);
+  box = REGRESSION_TEST_PASSED;
+  unsigned alive = 0;
+
+  Ptr<PtrObject> p1 = make_ptr(new PtrObject(&alive));
+  PtrObject *p2 = p1.detach();
+
+  box.check(p1.get() == NULL, "Ptr<T>::detach NULLs the stored pointer");
+  box.check(p2->refcount() == 1, "Ptr<T>::detach preserves the refcount");
+
+  // Note that there's no symmetric reattach.
+  p1 = p2;
+  box.check(p2->refcount() == 2, "reattaching increments the refcount again");
+  p1->refcount_dec();
+}
+
+REGRESSION_TEST(Ptr_clear)(RegressionTest *t, int /* atype ATS_UNUSED */, int *pstatus)
+{
+  TestBox box(t, pstatus);
+  box = REGRESSION_TEST_PASSED;
+  unsigned alive = 0;
+
+  Ptr<PtrObject> p1 = make_ptr(new PtrObject(&alive));
+  box.check(alive == 1, "we have a live object");
+  p1.clear();
+  box.check(p1.get() == NULL, "Ptr<T>::clear NULLs the pointer");
+  box.check(alive == 0, "Ptr<T>::clear drops the refcount");
+
+  p1 = make_ptr(new PtrObject(&alive));
+  box.check(alive == 1, "we have a live object");
+  p1 = 0;
+  box.check(alive == 0, "assigning NULL drops the refcount");
+}
+
+REGRESSION_TEST(Ptr_refcount)(RegressionTest *t, int /* atype ATS_UNUSED */, int *pstatus)
+{
+  TestBox box(t, pstatus);
+  box = REGRESSION_TEST_PASSED;
+  unsigned alive = 0;
+
+  {
+    Ptr<PtrObject> p1 = make_ptr(new PtrObject(&alive));
+
+    box.check(p1->refcount() == 1, "initial refcount is 1");
+
+    Ptr<PtrObject> p2(p1);
+    box.check(p1->refcount() == 2, "initial refcount is 1");
+
+    Ptr<PtrObject> p3 = p1;
+  }
+
+  // Everything goes out of scope, so the refcounts should drop to zero.
+  box.check(alive == 0, "refcounts dropped");
+}
+
+int
+main(int /* argc ATS_UNUSED */, char ** /* argv ATS_UNUSED */)
+{
+  RegressionTest::run();
+  return RegressionTest::final_status == REGRESSION_TEST_PASSED ? 0 : 1;
+}

--- a/mgmt/ProxyConfig.h
+++ b/mgmt/ProxyConfig.h
@@ -104,12 +104,12 @@ template <typename UpdateClass> struct ConfigUpdateContinuation : public Continu
     return EVENT_DONE;
   }
 
-  ConfigUpdateContinuation(ProxyMutex *m) : Continuation(m) { SET_HANDLER(&ConfigUpdateContinuation::update); }
+  ConfigUpdateContinuation(Ptr<ProxyMutex> &m) : Continuation(m.get()) { SET_HANDLER(&ConfigUpdateContinuation::update); }
 };
 
 template <typename UpdateClass>
 int
-ConfigScheduleUpdate(ProxyMutex *mutex)
+ConfigScheduleUpdate(Ptr<ProxyMutex> &mutex)
 {
   eventProcessor.schedule_imm(new ConfigUpdateContinuation<UpdateClass>(mutex), ET_CALL);
   return 0;

--- a/proxy/CacheControl.cc
+++ b/proxy/CacheControl.cc
@@ -99,7 +99,7 @@ struct CC_UpdateContinuation : public Continuation {
     delete this;
     return EVENT_DONE;
   }
-  CC_UpdateContinuation(ProxyMutex *m) : Continuation(m) { SET_HANDLER(&CC_UpdateContinuation::file_update_handler); }
+  CC_UpdateContinuation(Ptr<ProxyMutex> &m) : Continuation(m) { SET_HANDLER(&CC_UpdateContinuation::file_update_handler); }
 };
 
 int

--- a/proxy/CoreUtils.cc
+++ b/proxy/CoreUtils.cc
@@ -743,8 +743,8 @@ CoreUtils::process_EThread(EThread *eth_test)
   ats_free(buf);
 }
 
-static void
-print_netstate(NetState *n)
+void
+CoreUtils::print_netstate(NetState *n)
 {
   printf("      enabled: %d\n", n->enabled);
   printf("      op: %d  _cont: 0x%p\n", n->vio.op, n->vio._cont);

--- a/proxy/CoreUtils.h
+++ b/proxy/CoreUtils.h
@@ -92,6 +92,7 @@ class HdrHeap;
 
 class EThread;
 class UnixNetVConnection;
+struct NetState;
 
 class CoreUtils
 {
@@ -185,6 +186,7 @@ public:
   * outputs: none
   **********************************************************************/
   static void print_http_hdr(HTTPHdr *h, const char *name);
+  static void print_netstate(NetState *n);
 
   /**********************************************************************
   * purpose: loads a null terminated string from the core file

--- a/proxy/FetchSM.cc
+++ b/proxy/FetchSM.cc
@@ -343,12 +343,10 @@ out:
 }
 
 void
-FetchSM::get_info_from_buffer(IOBufferReader *the_reader)
+FetchSM::get_info_from_buffer(IOBufferReader *reader)
 {
   char *buf, *info;
   int64_t read_avail, read_done;
-  IOBufferBlock *blk;
-  IOBufferReader *reader = the_reader;
 
   if (!reader) {
     client_bytes = 0;
@@ -369,9 +367,11 @@ FetchSM::get_info_from_buffer(IOBufferReader *the_reader)
   if (!(fetch_flags & TS_FETCH_FLAGS_STREAM) || !check_chunked()) {
     /* Read the data out of the reader */
     while (read_avail > 0) {
-      if (reader->block != NULL)
+      if (reader->block) {
         reader->skip_empty_blocks();
-      blk = reader->block;
+      }
+
+      IOBufferBlock *blk = reader->block.get();
 
       // This is the equivalent of TSIOBufferBlockReadStart()
       buf = blk->start() + reader->start_offset;
@@ -401,9 +401,11 @@ FetchSM::get_info_from_buffer(IOBufferReader *the_reader)
     /* Read the data out of the reader */
     read_avail = reader->read_avail();
     while (read_avail > 0) {
-      if (reader->block != NULL)
+      if (reader->block) {
         reader->skip_empty_blocks();
-      blk = reader->block;
+      }
+
+      IOBufferBlock *blk = reader->block.get();
 
       // This is the equivalent of TSIOBufferBlockReadStart()
       buf = blk->start() + reader->start_offset;

--- a/proxy/ICP.cc
+++ b/proxy/ICP.cc
@@ -1821,7 +1821,7 @@ ICPProcessor::ICPQuery(Continuation *c, URL *url)
 
   // Build continuation to process ICP request
   EThread *thread = this_ethread();
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = thread->mutex.get();
   ICPRequestCont *rc = new (ICPRequestCont_allocator.alloc()) ICPRequestCont(this, c, url);
 
   ICP_INCREMENT_DYN_STAT(icp_query_requests_stat);

--- a/proxy/ICP.h
+++ b/proxy/ICP.h
@@ -818,12 +818,12 @@ public:
   inline Peer *
   GetLocalPeer()
   {
-    return _LocalPeer;
+    return _LocalPeer.get();
   }
   inline Peer *
   IdToPeer(int id)
   {
-    return _PeerList[id];
+    return _PeerList[id].get();
   }
   inline ICPConfiguration *
   GetConfig()
@@ -918,7 +918,7 @@ private:
   inline Peer *
   GetNthSendPeer(int n, int bias)
   {
-    return _SendPeerList[(bias + n) % (_nSendPeerList + 1)];
+    return _SendPeerList[(bias + n) % (_nSendPeerList + 1)].get();
   }
 
   inline int
@@ -929,7 +929,7 @@ private:
   inline Peer *
   GetNthRecvPeer(int n, int bias)
   {
-    return _RecvPeerList[(bias + n) % (_nRecvPeerList + 1)];
+    return _RecvPeerList[(bias + n) % (_nRecvPeerList + 1)].get();
   }
 
   inline int
@@ -951,7 +951,7 @@ private:
   inline Peer *
   GetNthParentPeer(int n, int bias)
   {
-    return _ParentPeerList[(bias + n) % (_nParentPeerList + 1)];
+    return _ParentPeerList[(bias + n) % (_nParentPeerList + 1)].get();
   }
   inline int
   GetStartingParentPeerBias()

--- a/proxy/ICPConfig.cc
+++ b/proxy/ICPConfig.cc
@@ -1028,7 +1028,7 @@ Action *
 MultiCastPeer::RecvFrom_re(Continuation *cont, void *token, IOBufferBlock * /* bufblock ATS_UNUSED */, int len,
                            struct sockaddr *from, socklen_t *fromlen)
 {
-  Action *a = udpNet.recvfrom_re(cont, token, _recv_chan.fd, from, fromlen, buf, len, true, 0);
+  Action *a = udpNet.recvfrom_re(cont, token, _recv_chan.fd, from, fromlen, buf.get(), len, true, 0);
   return a;
 }
 
@@ -1431,7 +1431,7 @@ ICPProcessor::DumpICPConfig()
         GetConfig()->globalConfig()->ICPReplyToUnknownPeer(), GetConfig()->globalConfig()->ICPDefaultReplyPort());
 
   for (int i = 0; i < (_nPeerList + 1); i++) {
-    P = _PeerList[i];
+    P = IdToPeer(i);
     id = P->GetPeerID();
     type = P->GetType();
     const char *str_type;

--- a/proxy/ICPConfig.cc
+++ b/proxy/ICPConfig.cc
@@ -518,7 +518,7 @@ void *
 ICPConfiguration::icp_config_change_callback(void *data, void *value, int startup)
 {
   EThread *thread = this_ethread();
-  ProxyMutex *mutex = thread->mutex;
+  ProxyMutex *mutex = thread->mutex.get();
 
   //
   // Cast passed parameters to correct types

--- a/proxy/InkAPIInternal.h
+++ b/proxy/InkAPIInternal.h
@@ -299,7 +299,7 @@ class LifecycleAPIHooks : public FeatureAPIHooks<TSLifecycleHookID, TS_LIFECYCLE
 class ConfigUpdateCallback : public Continuation
 {
 public:
-  ConfigUpdateCallback(INKContInternal *contp) : Continuation(contp->mutex), m_cont(contp)
+  ConfigUpdateCallback(INKContInternal *contp) : Continuation(contp->mutex.get()), m_cont(contp)
   {
     SET_HANDLER(&ConfigUpdateCallback::event_handler);
   }

--- a/proxy/InkAPIInternal.h
+++ b/proxy/InkAPIInternal.h
@@ -307,7 +307,7 @@ public:
   int
   event_handler(int, void *)
   {
-    if (m_cont->mutex != NULL) {
+    if (m_cont->mutex) {
       MUTEX_TRY_LOCK(trylock, m_cont->mutex, this_ethread());
       if (!trylock.is_locked()) {
         eventProcessor.schedule_in(this, HRTIME_MSECONDS(10), ET_TASK);

--- a/proxy/InkIOCoreAPI.cc
+++ b/proxy/InkIOCoreAPI.cc
@@ -54,7 +54,7 @@ sdk_sanity_check_mutex(TSMutex mutex)
 
   ProxyMutex *mutexp = (ProxyMutex *)mutex;
 
-  if (mutexp->m_refcount < 0)
+  if (mutexp->refcount() < 0)
     return TS_ERROR;
   if (mutexp->nthread_holding < 0)
     return TS_ERROR;
@@ -210,7 +210,7 @@ TSMutexCheck(TSMutex mutex)
 {
   ProxyMutex *mutexp = (ProxyMutex *)mutex;
 
-  if (mutexp->m_refcount < 0)
+  if (mutexp->refcount() < 0)
     return -1;
   if (mutexp->nthread_holding < 0)
     return -1;

--- a/proxy/InkIOCoreAPI.cc
+++ b/proxy/InkIOCoreAPI.cc
@@ -338,7 +338,7 @@ TSVIOMutexGet(TSVIO viop)
   sdk_assert(sdk_sanity_check_iocore_structure(viop) == TS_SUCCESS);
 
   VIO *vio = (VIO *)viop;
-  return (TSMutex)((ProxyMutex *)vio->mutex);
+  return (TSMutex)(vio->mutex.get());
 }
 
 /* High Resolution Time */

--- a/proxy/InkIOCoreAPI.cc
+++ b/proxy/InkIOCoreAPI.cc
@@ -588,7 +588,7 @@ TSIOBufferBlockNext(TSIOBufferBlock blockp)
   sdk_assert(sdk_sanity_check_iocore_structure(blockp) == TS_SUCCESS);
 
   IOBufferBlock *blk = (IOBufferBlock *)blockp;
-  return (TSIOBufferBlock)((IOBufferBlock *)blk->next);
+  return (TSIOBufferBlock)(blk->next.get());
 }
 
 // dev API, not exposed
@@ -615,7 +615,7 @@ TSIOBufferBlockReadStart(TSIOBufferBlock blockp, TSIOBufferReader readerp, int64
   if (avail)
     *avail = blk->read_avail();
 
-  if (blk == reader->block) {
+  if (reader->block.get() == blk) {
     p += reader->start_offset;
     if (avail) {
       *avail -= reader->start_offset;
@@ -640,7 +640,7 @@ TSIOBufferBlockReadAvail(TSIOBufferBlock blockp, TSIOBufferReader readerp)
 
   avail = blk->read_avail();
 
-  if (blk == reader->block) {
+  if (reader->block.get() == blk) {
     avail -= reader->start_offset;
     if (avail < 0) {
       avail = 0;
@@ -728,8 +728,10 @@ TSIOBufferReaderStart(TSIOBufferReader readerp)
 
   IOBufferReader *r = (IOBufferReader *)readerp;
 
-  if (r->block != NULL)
+  if (r->block) {
     r->skip_empty_blocks();
+  }
+
   return reinterpret_cast<TSIOBufferBlock>(r->get_current_block());
 }
 

--- a/proxy/PluginVC.cc
+++ b/proxy/PluginVC.cc
@@ -145,7 +145,7 @@ PluginVC::main_handler(int event, void *data)
       return 0;
     }
 
-    if (read_side_mutex.m_ptr != read_state.vio.mutex.m_ptr) {
+    if (read_side_mutex != read_state.vio.mutex) {
       // It's possible some swapped the mutex on us before
       //  we were able to grab it
       Mutex_unlock(read_side_mutex, my_ethread);
@@ -167,7 +167,7 @@ PluginVC::main_handler(int event, void *data)
       return 0;
     }
 
-    if (write_side_mutex.m_ptr != write_state.vio.mutex.m_ptr) {
+    if (write_side_mutex != write_state.vio.mutex) {
       // It's possible some swapped the mutex on us before
       //  we were able to grab it
       Mutex_unlock(write_side_mutex, my_ethread);

--- a/proxy/ProtocolProbeSessionAccept.cc
+++ b/proxy/ProtocolProbeSessionAccept.cc
@@ -59,7 +59,7 @@ struct ProtocolProbeTrampoline : public Continuation, public ProtocolProbeSessio
   static const unsigned buffer_size_index = CLIENT_CONNECTION_FIRST_READ_BUFFER_SIZE_INDEX;
   IOBufferReader *reader;
 
-  explicit ProtocolProbeTrampoline(const ProtocolProbeSessionAccept *probe, ProxyMutex *mutex, MIOBuffer *buffer,
+  explicit ProtocolProbeTrampoline(const ProtocolProbeSessionAccept *probe, Ptr<ProxyMutex> &mutex, MIOBuffer *buffer,
                                    IOBufferReader *reader)
     : Continuation(mutex), probeParent(probe)
   {

--- a/proxy/ReverseProxy.cc
+++ b/proxy/ReverseProxy.cc
@@ -132,7 +132,7 @@ struct UR_UpdateContinuation : public Continuation {
     delete this;
     return EVENT_DONE;
   }
-  UR_UpdateContinuation(ProxyMutex *m) : Continuation(m)
+  UR_UpdateContinuation(Ptr<ProxyMutex> &m) : Continuation(m)
   {
     SET_HANDLER((UR_UpdContHandler)&UR_UpdateContinuation::file_update_handler);
   }

--- a/proxy/SocksProxy.cc
+++ b/proxy/SocksProxy.cc
@@ -347,7 +347,7 @@ SocksProxy::mainEvent(int event, void *data)
     OneWayTunnel *s_to_c = OneWayTunnel::OneWayTunnel_alloc();
 
     c_to_s->init(clientVC, serverVC, NULL, clientVIO, reader);
-    s_to_c->init(serverVC, clientVC, /*aCont = */ NULL, 0 /*best guess */, c_to_s->mutex);
+    s_to_c->init(serverVC, clientVC, /*aCont = */ NULL, 0 /*best guess */, c_to_s->mutex.get());
 
     OneWayTunnel::SetupTwoWayTunnel(c_to_s, s_to_c);
 

--- a/proxy/Transform.cc
+++ b/proxy/Transform.cc
@@ -385,7 +385,7 @@ TransformTerminus::reenable(VIO *vio)
   -------------------------------------------------------------------------*/
 
 TransformVConnection::TransformVConnection(Continuation *cont, APIHook *hooks)
-  : TransformVCChain(cont->mutex), m_cont(cont), m_terminus(this), m_closed(0)
+  : TransformVCChain(cont->mutex.get()), m_cont(cont), m_terminus(this), m_closed(0)
 {
   INKVConnInternal *xform;
 

--- a/proxy/congest/MT_hashtable.h
+++ b/proxy/congest/MT_hashtable.h
@@ -347,10 +347,11 @@ public:
       delete hashTables[i];
     }
   }
+
   ProxyMutex *
   lock_for_key(key_t key)
   {
-    return locks[part_num(key)];
+    return locks[part_num(key)].get();
   }
 
   int

--- a/proxy/hdrs/HdrHeap.cc
+++ b/proxy/hdrs/HdrHeap.cc
@@ -43,7 +43,6 @@ Allocator hdrHeapAllocator("hdrHeap", HDR_HEAP_DEFAULT_SIZE);
 static HdrHeap proto_heap;
 
 Allocator strHeapAllocator("hdrStrHeap", HDR_STR_HEAP_DEFAULT_SIZE);
-static HdrStrHeap str_proto_heap;
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
@@ -99,11 +98,11 @@ HdrHeap::init()
   // We need to clear m_ptr directly since it's garbage and
   //  using the operator functions will to free() what ever
   //  garbage it is pointing to
-  m_read_write_heap.m_ptr = NULL;
+  m_read_write_heap.detach();
 
   for (int i = 0; i < HDR_BUF_RONLY_HEAPS; i++) {
     m_ronly_heap[i].m_heap_start = NULL;
-    m_ronly_heap[i].m_ref_count_ptr.m_ptr = NULL;
+    m_ronly_heap[i].m_ref_count_ptr.detach();
     m_ronly_heap[i].m_locked = false;
     m_ronly_heap[i].m_heap_len = 0;
   }
@@ -332,8 +331,8 @@ HdrHeap::demote_rw_str_heap()
   for (int i = 0; i < HDR_BUF_RONLY_HEAPS; i++) {
     if (m_ronly_heap[i].m_heap_start == NULL) {
       // We've found a slot
-      m_ronly_heap[i].m_ref_count_ptr = m_read_write_heap;
-      m_ronly_heap[i].m_heap_start = (char *)m_read_write_heap.m_ptr;
+      m_ronly_heap[i].m_ref_count_ptr = m_read_write_heap.object();
+      m_ronly_heap[i].m_heap_start = (char *)m_read_write_heap.get();
       m_ronly_heap[i].m_heap_len = m_read_write_heap->m_heap_size - m_read_write_heap->m_free_size;
 
       //          Debug("hdrs", "Demoted rw heap of %d size", m_read_write_heap->m_heap_size);
@@ -479,7 +478,7 @@ HdrHeap::sanity_check_strs()
 
   // Build up a string check table
   if (m_read_write_heap) {
-    heaps[num_heaps].start = ((char *)m_read_write_heap.m_ptr) + sizeof(HdrStrHeap);
+    heaps[num_heaps].start = ((char *)m_read_write_heap.get()) + sizeof(HdrStrHeap);
 
     int heap_size = m_read_write_heap->m_heap_size - (sizeof(HdrStrHeap) + m_read_write_heap->m_free_size);
 
@@ -669,12 +668,12 @@ HdrHeap::marshal(char *buf, int len)
   marshal_hdr->m_size = ptr_heap_size + HDR_HEAP_HDR_SIZE;
   marshal_hdr->m_next = NULL;
   marshal_hdr->m_free_size = 0;
-  marshal_hdr->m_read_write_heap.m_ptr = NULL;
+  marshal_hdr->m_read_write_heap.detach();
   marshal_hdr->m_lost_string_space = this->m_lost_string_space;
 
   // We'have one read-only string heap after marshalling
   marshal_hdr->m_ronly_heap[0].m_heap_start = (char *)(intptr_t)marshal_hdr->m_size; // offset
-  marshal_hdr->m_ronly_heap[0].m_ref_count_ptr.m_ptr = NULL;
+  marshal_hdr->m_ronly_heap[0].m_ref_count_ptr.detach();
 
   for (int i = 1; i < HDR_BUF_RONLY_HEAPS; i++)
     marshal_hdr->m_ronly_heap[i].m_heap_start = NULL;
@@ -691,7 +690,7 @@ HdrHeap::marshal(char *buf, int len)
   MarshalXlate str_xlation[HDR_BUF_RONLY_HEAPS + 1];
 
   if (m_read_write_heap) {
-    char *copy_start = ((char *)m_read_write_heap.m_ptr) + sizeof(HdrStrHeap);
+    char *copy_start = ((char *)m_read_write_heap.get()) + sizeof(HdrStrHeap);
     int nto_copy = m_read_write_heap->m_heap_size - (sizeof(HdrStrHeap) + m_read_write_heap->m_free_size);
 
     if (nto_copy > len) {
@@ -904,7 +903,7 @@ HdrHeap::unmarshal(int buf_length, int obj_type, HdrHeapObjImpl **found_obj, Ref
   m_free_start = ((char *)this) + m_size;
   m_ronly_heap[0].m_heap_start = ((char *)this) + (intptr_t)m_ronly_heap[0].m_heap_start;
 
-  // Crazy Invarient - If we are sitting in a ref counted block,
+  // Crazy Invariant - If we are sitting in a ref counted block,
   //   the HdrHeap lifetime is externally determined.  Whoever
   //   unmarshalls us should keep the block around as long as
   //   they want to use the header.  However, the strings can
@@ -915,8 +914,9 @@ HdrHeap::unmarshal(int buf_length, int obj_type, HdrHeapObjImpl **found_obj, Ref
   //   the lifetime is explicit but copies will increase
   //   the refcount
   if (block_ref) {
-    m_ronly_heap[0].m_ref_count_ptr.m_ptr = block_ref;
+    m_ronly_heap[0].m_ref_count_ptr.swizzle(block_ref);
   }
+
   // Loop over objects and swizzle there pointer to
   //  live offsets
   char *obj_data = m_data_start;
@@ -962,11 +962,11 @@ HdrHeap::unmarshal(int buf_length, int obj_type, HdrHeapObjImpl **found_obj, Ref
   return unmarshal_size;
 }
 
-inline int
+inline bool
 HdrHeap::attach_str_heap(char *h_start, int h_len, RefCountObj *h_ref_obj, int *index)
 {
   if (*index >= HDR_BUF_RONLY_HEAPS) {
-    return 0;
+    return false;
   }
 
   // Loop over existing entries to see if this one is already present
@@ -980,7 +980,7 @@ HdrHeap::attach_str_heap(char *h_start, int h_len, RefCountObj *h_ref_obj, int *
       //   to was attached
       if (h_len > m_ronly_heap[z].m_heap_len)
         m_ronly_heap[z].m_heap_len = h_len;
-      return 1;
+      return true;
     }
   }
 
@@ -990,7 +990,7 @@ HdrHeap::attach_str_heap(char *h_start, int h_len, RefCountObj *h_ref_obj, int *
   m_ronly_heap[*index].m_locked = false;
   *index = *index + 1;
 
-  return 1;
+  return true;
 }
 
 // void HdrHeap::inhertit_string_heaps(const HdrHeap* inherit_from)
@@ -1005,7 +1005,7 @@ HdrHeap::inherit_string_heaps(const HdrHeap *inherit_from)
   if (inherit_from == (const HdrHeap *)this)
     return;
 
-  int index, result;
+  int index;
   int first_free = HDR_BUF_RONLY_HEAPS; // default is out of array bounds
   int free_slots = 0;
   int inherit_str_size = 0;
@@ -1055,16 +1055,14 @@ HdrHeap::inherit_string_heaps(const HdrHeap *inherit_from)
     if (inherit_from->m_read_write_heap) {
       int str_size =
         inherit_from->m_read_write_heap->m_heap_size - STR_HEAP_HDR_SIZE - inherit_from->m_read_write_heap->m_free_size;
-      result = attach_str_heap(((char *)inherit_from->m_read_write_heap.m_ptr) + STR_HEAP_HDR_SIZE, str_size,
-                               inherit_from->m_read_write_heap, &first_free);
-      ink_release_assert(result != 0);
+      ink_release_assert(attach_str_heap(((char *)inherit_from->m_read_write_heap.get()) + STR_HEAP_HDR_SIZE, str_size,
+                                         inherit_from->m_read_write_heap.get(), &first_free));
     }
     // Copy over read only string heaps
     for (int i = 0; i < HDR_BUF_RONLY_HEAPS; i++) {
       if (inherit_from->m_ronly_heap[i].m_heap_start) {
-        result = attach_str_heap(inherit_from->m_ronly_heap[i].m_heap_start, inherit_from->m_ronly_heap[i].m_heap_len,
-                                 inherit_from->m_ronly_heap[i].m_ref_count_ptr.m_ptr, &first_free);
-        ink_release_assert(result != 0);
+        ink_release_assert(attach_str_heap(inherit_from->m_ronly_heap[i].m_heap_start, inherit_from->m_ronly_heap[i].m_heap_len,
+                                           inherit_from->m_ronly_heap[i].m_ref_count_ptr.get(), &first_free));
       }
     }
 
@@ -1201,7 +1199,7 @@ REGRESSION_TEST(HdrHeap_Coalesce)(RegressionTest *t, int /* atype ATS_UNUSED */,
   HdrHeap *heap = new_HdrHeap();
   URLImpl *url = url_create(heap);
 
-  tb.check(heap->m_read_write_heap.m_ptr == NULL, "Checking that we have no rw heap.");
+  tb.check(heap->m_read_write_heap.get() == NULL, "Checking that we have no rw heap.");
   url_path_set(heap, url, buf, next_required_overflow_size, true);
   tb.check(heap->m_read_write_heap->m_free_size == 0, "Checking that we've completely consumed the rw heap");
   for (int i = 0; i < HDR_BUF_RONLY_HEAPS; ++i) {

--- a/proxy/hdrs/HdrHeap.cc
+++ b/proxy/hdrs/HdrHeap.cc
@@ -155,13 +155,14 @@ new_HdrStrHeap(int requested_size)
 
   //    Debug("hdrs", "Allocated string heap in size %d", alloc_size);
 
-  // Patch virtual function table ptr
-  *((void **)sh) = *((void **)&str_proto_heap);
+  // Placement new the HdrStrHeap.
+  sh = new (sh) HdrStrHeap();
 
   sh->m_heap_size = alloc_size;
   sh->m_free_size = alloc_size - STR_HEAP_HDR_SIZE;
   sh->m_free_start = ((char *)sh) + STR_HEAP_HDR_SIZE;
-  sh->m_refcount = 0;
+
+  ink_assert(sh->refcount() == 0);
 
   ink_assert(sh->m_free_size > 0);
 

--- a/proxy/hdrs/HdrHeap.cc
+++ b/proxy/hdrs/HdrHeap.cc
@@ -972,7 +972,7 @@ HdrHeap::attach_str_heap(char *h_start, int h_len, RefCountObj *h_ref_obj, int *
   // Loop over existing entries to see if this one is already present
   for (int z = 0; z < *index; z++) {
     if (m_ronly_heap[z].m_heap_start == h_start) {
-      ink_assert(m_ronly_heap[z].m_ref_count_ptr._ptr() == h_ref_obj);
+      ink_assert(m_ronly_heap[z].m_ref_count_ptr.object() == h_ref_obj);
 
       // The lengths could be different because our copy could be
       //   read-only and the copy we are attaching from could be

--- a/proxy/hdrs/HdrTSOnly.cc
+++ b/proxy/hdrs/HdrTSOnly.cc
@@ -171,7 +171,7 @@ RETRY:
       // Add block to heap in this slot
       m_ronly_heap[i].m_heap_start = (char *)use_start;
       m_ronly_heap[i].m_heap_len = (int)(b->end() - b->start());
-      m_ronly_heap[i].m_ref_count_ptr = b->data;
+      m_ronly_heap[i].m_ref_count_ptr = b->data.object();
       //          printf("Attaching block at %X for %d in slot %d\n",
       //                 m_ronly_heap[i].m_heap_start,
       //                 m_ronly_heap[i].m_heap_len,

--- a/proxy/hdrs/HdrTest.cc
+++ b/proxy/hdrs/HdrTest.cc
@@ -1257,7 +1257,10 @@ HdrTest::test_http_hdr_print_and_copy_aux(int testnum, const char *request, cons
   /*** (2) copy the request header ***/
   HTTPHdr new_hdr, marshal_hdr;
   RefCountObj ref;
-  ref.m_refcount = 100;
+
+  // Pretend to pin this object with a refcount.
+  ref.refcount_inc();
+
   int marshal_len = hdr.m_heap->marshal(marshal_buf, marshal_bufsize);
   marshal_hdr.create(HTTP_TYPE_REQUEST);
   marshal_hdr.unmarshal(marshal_buf, marshal_len, &ref);

--- a/proxy/http/HttpCacheSM.h
+++ b/proxy/http/HttpCacheSM.h
@@ -60,7 +60,7 @@ public:
   HttpCacheSM();
 
   void
-  init(HttpSM *sm_arg, ProxyMutex *amutex)
+  init(HttpSM *sm_arg, Ptr<ProxyMutex> &amutex)
   {
     master_sm = sm_arg;
     mutex = amutex;

--- a/proxy/http/HttpProxyServerMain.cc
+++ b/proxy/http/HttpProxyServerMain.cc
@@ -266,9 +266,8 @@ init_HttpProxyServer(int n_accept_threads)
     plugin_http_transparent_accept = new HttpSessionAccept(ha_opt);
     plugin_http_transparent_accept->mutex = new_ProxyMutex();
   }
-  if (ssl_plugin_mutex == NULL) {
-    ssl_plugin_mutex = mutexAllocator.alloc();
-    ssl_plugin_mutex->init("SSL Acceptor List");
+  if (!ssl_plugin_mutex) {
+    ssl_plugin_mutex = new_ProxyMutex();
   }
 
   // Do the configuration defined ports.

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -2078,7 +2078,7 @@ HttpSM::process_srv_info(HostDBInfo *r)
     HostDBRoundRobin *rr = r->rr();
     HostDBInfo *srv = NULL;
     if (rr) {
-      srv = rr->select_best_srv(t_state.dns_info.srv_hostname, &mutex.m_ptr->thread_holding->generator, ink_cluster_time(),
+      srv = rr->select_best_srv(t_state.dns_info.srv_hostname, &mutex->thread_holding->generator, ink_cluster_time(),
                                 (int)t_state.txn_conf->down_server_timeout);
     }
     if (!srv) {
@@ -4464,7 +4464,7 @@ HttpSM::do_range_setup_if_necessary()
         content_type = t_state.cache_info.object_read->response_get()->value_get(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE,
                                                                                  &field_content_type_len);
         // create a Range: transform processor for requests of type Range: bytes=1-2,4-5,10-100 (eg. multiple ranges)
-        range_trans = transformProcessor.range_transform(mutex, t_state.ranges, t_state.num_range_fields,
+        range_trans = transformProcessor.range_transform(mutex.get(), t_state.ranges, t_state.num_range_fields,
                                                          &t_state.hdr_info.transform_response, content_type, field_content_type_len,
                                                          t_state.cache_info.object_read->object_size_get());
         api_hooks.append(TS_HTTP_RESPONSE_TRANSFORM_HOOK, range_trans);
@@ -5055,7 +5055,7 @@ HttpSM::do_post_transform_open()
   ink_assert(post_transform_info.vc == NULL);
 
   if (is_action_tag_set("http_post_nullt")) {
-    txn_hook_prepend(TS_HTTP_REQUEST_TRANSFORM_HOOK, transformProcessor.null_transform(mutex));
+    txn_hook_prepend(TS_HTTP_REQUEST_TRANSFORM_HOOK, transformProcessor.null_transform(mutex.get()));
   }
 
   post_transform_info.vc = transformProcessor.open(this, api_hooks.get(TS_HTTP_REQUEST_TRANSFORM_HOOK));
@@ -5076,7 +5076,7 @@ HttpSM::do_transform_open()
   APIHook *hooks;
 
   if (is_action_tag_set("http_nullt")) {
-    txn_hook_prepend(TS_HTTP_RESPONSE_TRANSFORM_HOOK, transformProcessor.null_transform(mutex));
+    txn_hook_prepend(TS_HTTP_RESPONSE_TRANSFORM_HOOK, transformProcessor.null_transform(mutex.get()));
   }
 
   hooks = api_hooks.get(TS_HTTP_RESPONSE_TRANSFORM_HOOK);

--- a/proxy/http/HttpSessionManager.cc
+++ b/proxy/http/HttpSessionManager.cc
@@ -279,8 +279,8 @@ HttpSessionManager::acquire_session(Continuation * /* cont ATS_UNUSED */, sockad
     // Now check to see if we have a connection in our shared connection pool
     EThread *ethread = this_ethread();
     ProxyMutex *pool_mutex = (TS_SERVER_SESSION_SHARING_POOL_THREAD == sm->t_state.http_config_param->server_session_sharing_pool) ?
-                               ethread->server_session_pool->mutex :
-                               m_g_pool->mutex;
+                               ethread->server_session_pool->mutex.get() :
+                               m_g_pool->mutex.get();
     MUTEX_TRY_LOCK(lock, pool_mutex, ethread);
     if (lock.is_locked()) {
       if (TS_SERVER_SESSION_SHARING_POOL_THREAD == sm->t_state.http_config_param->server_session_sharing_pool) {

--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -534,7 +534,7 @@ HttpTunnel::HttpTunnel()
 }
 
 void
-HttpTunnel::init(HttpSM *sm_arg, ProxyMutex *amutex)
+HttpTunnel::init(HttpSM *sm_arg, Ptr<ProxyMutex> &amutex)
 {
   HttpConfigParams *params = sm_arg->t_state.http_config_param;
   sm = sm_arg;

--- a/proxy/http/HttpTunnel.h
+++ b/proxy/http/HttpTunnel.h
@@ -300,7 +300,7 @@ class HttpTunnel : public Continuation
 public:
   HttpTunnel();
 
-  void init(HttpSM *sm_arg, ProxyMutex *amutex);
+  void init(HttpSM *sm_arg, Ptr<ProxyMutex> &amutex);
   void reset();
   void kill_tunnel();
   bool

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -124,7 +124,7 @@ public:
   xmit(MIOBuffer *iobuffer)
   {
     if (ioblock) {
-      iobuffer->append_block(this->ioblock);
+      iobuffer->append_block(this->ioblock.get());
     } else {
       iobuffer->write(this->hdr.raw, sizeof(this->hdr.raw));
     }

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -1164,7 +1164,7 @@ Log::preproc_thread_main(void *args)
       // TODO: the bytes_to_disk should be set to Log
 
       Debug("log-preproc", "%zu buffers preprocessed from LogConfig %p (refcount=%d) this round", buffers_preproced, current,
-            current->m_refcount);
+            current->refcount());
 
       configProcessor.release(log_configid, current);
     }

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -1005,7 +1005,7 @@ Log::access(LogAccess *lad)
   int ret;
   static long sample = 1;
   long this_sample;
-  ProxyMutex *mutex = this_ethread()->mutex;
+  ProxyMutex *mutex = this_ethread()->mutex.get();
 
   // See if we're sampling and it is not time for another sample
   //
@@ -1061,7 +1061,7 @@ int
 Log::va_error(const char *format, va_list ap)
 {
   int ret_val = Log::SKIP;
-  ProxyMutex *mutex = this_ethread()->mutex;
+  ProxyMutex *mutex = this_ethread()->mutex.get();
 
   if (error_log) {
     ink_assert(format != NULL);
@@ -1196,7 +1196,7 @@ Log::flush_thread_main(void * /* args ATS_UNUSED */)
   ink_hrtime now, last_time = 0;
   int len, total_bytes;
   SLL<LogFlushData, LogFlushData::Link_link> link, invert_link;
-  ProxyMutex *mutex = this_thread()->mutex;
+  ProxyMutex *mutex = this_thread()->mutex.get();
 
   Log::flush_notify->lock();
 

--- a/proxy/logging/LogField.cc
+++ b/proxy/logging/LogField.cc
@@ -223,7 +223,7 @@ LogField::LogField(const char *name, const char *symbol, Type type, MarshalFunc 
   ink_assert(m_symbol != NULL);
   ink_assert(m_type >= 0 && m_type < N_TYPES);
   ink_assert(m_marshal_func != (MarshalFunc)NULL);
-  ink_assert(m_alias_map != NULL);
+  ink_assert(m_alias_map);
 
   m_time_field = (strcmp(m_symbol, "cqts") == 0 || strcmp(m_symbol, "cqth") == 0 || strcmp(m_symbol, "cqtq") == 0 ||
                   strcmp(m_symbol, "cqtn") == 0 || strcmp(m_symbol, "cqtd") == 0 || strcmp(m_symbol, "cqtt") == 0);
@@ -521,7 +521,7 @@ LogField::marshal_agg(char *buf)
 unsigned
 LogField::unmarshal(char **buf, char *dest, int len)
 {
-  if (m_alias_map == NULL) {
+  if (!m_alias_map) {
     if (m_unmarshal_func == (UnmarshalFunc)LogAccess::unmarshal_str ||
         m_unmarshal_func == (UnmarshalFunc)LogAccess::unmarshal_http_text) {
       UnmarshalFuncWithSlice func = (UnmarshalFuncWithSlice)m_unmarshal_func;

--- a/proxy/logging/LogFile.cc
+++ b/proxy/logging/LogFile.cc
@@ -314,7 +314,7 @@ LogFile::preproc_and_try_delete(LogBuffer *lb)
     //
     LogFlushData *flush_data = new LogFlushData(this, lb);
 
-    ProxyMutex *mutex = this_thread()->mutex;
+    ProxyMutex *mutex = this_thread()->mutex.get();
 
     RecIncrRawStat(log_rsb, mutex->thread_holding, log_stat_num_flush_to_disk_stat, lb->header()->entry_count);
 
@@ -422,7 +422,7 @@ LogFile::write_ascii_logbuffer3(LogBufferHeader *buffer_header, const char *alt_
         m_name, this);
   ink_assert(buffer_header != NULL);
 
-  ProxyMutex *mutex = this_thread()->mutex;
+  ProxyMutex *mutex = this_thread()->mutex.get();
   LogBufferIterator iter(buffer_header);
   LogEntryHeader *entry_header;
   int fmt_entry_count = 0;

--- a/proxy/logging/LogFilter.cc
+++ b/proxy/logging/LogFilter.cc
@@ -435,7 +435,7 @@ LogFilterInt::LogFilterInt(const char *name, LogField *field, LogFilter::Action 
     char *t;
     while (t = tok.getNext(), t != NULL) {
       int64_t ival;
-      if (!_convertStringToInt(t, &ival, field->map())) {
+      if (!_convertStringToInt(t, &ival, field->map().get())) {
         // conversion was successful, add entry to array
         //
         val_array[i++] = ival;

--- a/proxy/logging/LogHost.cc
+++ b/proxy/logging/LogHost.cc
@@ -228,7 +228,10 @@ LogHost::disconnect()
 void
 LogHost::create_orphan_LogFile_object()
 {
-  delete m_orphan_file;
+  // We expect that no-one else is holding any refcounts on the
+  // orphan file so that is will be releases when we replace it
+  // below.
+  ink_assert(m_orphan_file->refcount() == 1);
 
   const char *orphan_ext = "orphan";
   unsigned name_len = (unsigned)(strlen(m_object_filename) + strlen(name()) + strlen(orphan_ext) + 16);
@@ -241,7 +244,6 @@ LogHost::create_orphan_LogFile_object()
   // should check for conflicts with orphan filename
   //
   m_orphan_file = new LogFile(name_buf, NULL, LOG_FILE_ASCII, m_object_signature);
-  ink_assert(m_orphan_file != NULL);
   ats_free(name_buf);
 }
 

--- a/proxy/logging/LogHost.h
+++ b/proxy/logging/LogHost.h
@@ -87,8 +87,9 @@ public:
   LogFile *
   get_orphan_logfile() const
   {
-    return m_orphan_file;
+    return m_orphan_file.get();
   }
+
   // check if we will be able to write orphan file
   int
   do_filesystem_checks()

--- a/proxy/logging/LogObject.cc
+++ b/proxy/logging/LogObject.cc
@@ -1301,7 +1301,7 @@ int
 LogObjectManager::log(LogAccess *lad)
 {
   int ret = Log::SKIP;
-  ProxyMutex *mutex = this_thread()->mutex;
+  ProxyMutex *mutex = this_thread()->mutex.get();
 
   for (unsigned i = 0; i < this->_objects.length(); i++) {
     //

--- a/proxy/logging/LogObject.h
+++ b/proxy/logging/LogObject.h
@@ -143,7 +143,7 @@ public:
       idx = m_buffer_manager_idx++ % m_flush_threads;
 
     if (m_logFile) {
-      nfb = m_buffer_manager[idx].preproc_buffers(m_logFile);
+      nfb = m_buffer_manager[idx].preproc_buffers(m_logFile.get());
     } else {
       nfb = m_buffer_manager[idx].preproc_buffers(&m_host_list);
     }


### PR DESCRIPTION
Make the actual pointer value of Ptr<T> private so that code reaching
in to do unsafe direct manipulate has to do it explicitly. Also
remove the implicit conversions to the raw pointer value.

Ping @amc, @bgaff, @zwoop. There are a lot of changes here and I need to do some more testing. I *think* that this is worth doing, but would appreciate any early feedback.