### PR TITLE
TS-4340: Fix origin max connections

### DIFF
--- a/lib/ts/ink_inet.cc
+++ b/lib/ts/ink_inet.cc
@@ -307,6 +307,26 @@ ats_ip_hash(sockaddr const *addr)
   return zret.i;
 }
 
+uint64_t
+ats_ip_port_hash(sockaddr const *addr)
+{
+  union md5sum {
+    uint64_t i;
+    uint16_t b[4];
+    unsigned char c[16];
+  } zret;
+
+  zret.i = 0;
+  if (ats_is_ip4(addr)) {
+    zret.i = (static_cast<uint64_t>(ats_ip4_addr_cast(addr)) << 16) | (ats_ip_port_cast(addr));
+  } else if (ats_is_ip6(addr)) {
+    ink_code_md5(const_cast<uint8_t *>(ats_ip_addr8_cast(addr)), TS_IP6_SIZE, zret.c);
+    // now replace the bottom 16bits so we can account for the port.
+    zret.b[3] = ats_ip_port_cast(addr);
+  }
+  return zret.i;
+}
+
 int
 ats_ip_to_hex(sockaddr const *src, char *dst, size_t len)
 {

--- a/lib/ts/ink_inet.h
+++ b/lib/ts/ink_inet.h
@@ -1151,6 +1151,8 @@ int ats_ip_getbestaddrinfo(char const *name, ///< [in] Address name (IPv4, IPv6,
 */
 uint32_t ats_ip_hash(sockaddr const *addr);
 
+uint64_t ats_ip_port_hash(sockaddr const *addr);
+
 /** Convert address to string as a hexidecimal value.
     The string is always nul terminated, the output string is clipped
     if @a dst is insufficient.

--- a/proxy/http/HttpConnectionCount.h
+++ b/proxy/http/HttpConnectionCount.h
@@ -26,6 +26,10 @@
 #include "ts/ink_inet.h"
 #include "ts/ink_mutex.h"
 #include "ts/Map.h"
+#include "ts/Diags.h"
+#include "ts/INK_MD5.h"
+#include "ts/ink_config.h"
+#include "HttpProxyAPIEnums.h"
 
 #ifndef _HTTP_CONNECTION_COUNT_H_
 #define _HTTP_CONNECTION_COUNT_H_
@@ -52,10 +56,10 @@ public:
    * @return Number of connections
    */
   int
-  getCount(const IpEndpoint &addr)
+  getCount(const IpEndpoint &addr, const INK_MD5 &hostname_hash, TSServerSessionSharingMatchType match_type)
   {
     ink_mutex_acquire(&_mutex);
-    int count = _hostCount.get(ConnAddr(addr));
+    int count = _hostCount.get(ConnAddr(addr, hostname_hash, match_type));
     ink_mutex_release(&_mutex);
     return count;
   }
@@ -66,9 +70,10 @@ public:
    * @param delta Default is +1, can be set to negative to decrement
    */
   void
-  incrementCount(const IpEndpoint &addr, const int delta = 1)
+  incrementCount(const IpEndpoint &addr, const INK_MD5 &hostname_hash, TSServerSessionSharingMatchType match_type,
+                 const int delta = 1)
   {
-    ConnAddr caddr(addr);
+    ConnAddr caddr(addr, hostname_hash, match_type);
     ink_mutex_acquire(&_mutex);
     int count = _hostCount.get(caddr);
     _hostCount.put(caddr, count + delta);
@@ -77,14 +82,35 @@ public:
 
   struct ConnAddr {
     IpEndpoint _addr;
+    INK_MD5 _hostname_hash;
+    TSServerSessionSharingMatchType _match_type;
 
-    ConnAddr() { ink_zero(_addr); }
-    ConnAddr(int x)
+    ConnAddr() : _match_type(TS_SERVER_SESSION_SHARING_MATCH_NONE)
+    {
+      ink_zero(_addr);
+      ink_zero(_hostname_hash);
+    }
+
+    ConnAddr(int x) : _match_type(TS_SERVER_SESSION_SHARING_MATCH_NONE)
     {
       ink_release_assert(x == 0);
       ink_zero(_addr);
+      ink_zero(_hostname_hash);
     }
-    ConnAddr(const IpEndpoint &addr) : _addr(addr) {}
+
+    ConnAddr(const IpEndpoint &addr, const INK_MD5 &hostname_hash, TSServerSessionSharingMatchType match_type)
+      : _addr(addr), _hostname_hash(hostname_hash), _match_type(match_type)
+    {
+    }
+
+    ConnAddr(const IpEndpoint &addr, const char *hostname, TSServerSessionSharingMatchType match_type)
+      : _addr(addr), _match_type(match_type)
+    {
+      MD5Context md5_ctx;
+      md5_ctx.hash_immediate(_hostname_hash, static_cast<const void *>(hostname), strlen(hostname));
+    }
+
+
     operator bool() { return ats_is_ip(&_addr); }
   };
 
@@ -94,12 +120,66 @@ public:
     static uintptr_t
     hash(ConnAddr &addr)
     {
-      return (uintptr_t)ats_ip_hash(&addr._addr.sa);
+      if (addr._match_type == TS_SERVER_SESSION_SHARING_MATCH_IP) {
+        return (uintptr_t)ats_ip_port_hash(&addr._addr.sa);
+      } else if (addr._match_type == TS_SERVER_SESSION_SHARING_MATCH_HOST) {
+        return (uintptr_t)addr._hostname_hash.u64[0];
+      } else if (addr._match_type == TS_SERVER_SESSION_SHARING_MATCH_BOTH) {
+        return ((uintptr_t)ats_ip_port_hash(&addr._addr.sa) ^ (uintptr_t)addr._hostname_hash.u64[0]);
+      } else {
+        return 0; // they will never be equal() because of it returns false for NONE matches.
+      }
     }
+
     static int
     equal(ConnAddr &a, ConnAddr &b)
     {
-      return ats_ip_addr_eq(&a._addr, &b._addr);
+      char addrbuf1[INET6_ADDRSTRLEN];
+      char addrbuf2[INET6_ADDRSTRLEN];
+      char md5buf1[33];
+      char md5buf2[33];
+      ink_code_md5_stringify(md5buf1, sizeof(md5buf1), reinterpret_cast<const char *>(a._hostname_hash.u8));
+      ink_code_md5_stringify(md5buf2, sizeof(md5buf2), reinterpret_cast<const char *>(b._hostname_hash.u8));
+      Debug("conn_count", "Comparing hostname hash %s dest %s match method %d to hostname hash %s dest %s match method %d", md5buf1,
+            ats_ip_nptop(&a._addr.sa, addrbuf1, sizeof(addrbuf1)), a._match_type, md5buf2,
+            ats_ip_nptop(&b._addr.sa, addrbuf2, sizeof(addrbuf2)), b._match_type);
+
+      if (a._match_type != b._match_type || a._match_type == TS_SERVER_SESSION_SHARING_MATCH_NONE) {
+        Debug("conn_count", "result = 0, a._match_type != b._match_type || a._match_type == TS_SERVER_SESSION_SHARING_MATCH_NONE");
+        return 0;
+      }
+
+      if (a._match_type == TS_SERVER_SESSION_SHARING_MATCH_IP) {
+        if (ats_ip_addr_port_eq(&a._addr.sa, &b._addr.sa)) {
+          Debug("conn_count", "result = 1, a._match_type == TS_SERVER_SESSION_SHARING_MATCH_IP");
+          return 1;
+        } else {
+          Debug("conn_count", "result = 0, a._match_type == TS_SERVER_SESSION_SHARING_MATCH_IP");
+          return 0;
+        }
+      }
+
+      if (a._match_type == TS_SERVER_SESSION_SHARING_MATCH_HOST) {
+        if ((a._hostname_hash.u64[0] == b._hostname_hash.u64[0] && a._hostname_hash.u64[1] == b._hostname_hash.u64[1])) {
+          Debug("conn_count", "result = 1, a._match_type == TS_SERVER_SESSION_SHARING_MATCH_HOST");
+          return 1;
+        } else {
+          Debug("conn_count", "result = 0, a._match_type == TS_SERVER_SESSION_SHARING_MATCH_HOST");
+          return 0;
+        }
+      }
+
+      if (a._match_type == TS_SERVER_SESSION_SHARING_MATCH_BOTH) {
+        if ((ats_ip_addr_port_eq(&a._addr.sa, &b._addr.sa)) &&
+            (a._hostname_hash.u64[0] == b._hostname_hash.u64[0] && a._hostname_hash.u64[1] == b._hostname_hash.u64[1])) {
+          Debug("conn_count", "result = 1, a._match_type == TS_SERVER_SESSION_SHARING_MATCH_BOTH");
+
+          return 1;
+        }
+      }
+
+      Debug("conn_count", "result = 0, a._match_type == TS_SERVER_SESSION_SHARING_MATCH_BOTH");
+      return 0;
     }
   };
 

--- a/proxy/http/HttpServerSession.cc
+++ b/proxy/http/HttpServerSession.cc
@@ -77,10 +77,11 @@ HttpServerSession::new_connection(NetVConnection *new_vc)
   if (enable_origin_connection_limiting == true) {
     if (connection_count == NULL)
       connection_count = ConnectionCount::getInstance();
-    connection_count->incrementCount(server_ip);
-    char addrbuf[INET6_ADDRSTRLEN];
+    connection_count->incrementCount(server_ip, hostname_hash, sharing_match);
+    ip_port_text_buffer addrbuf;
     Debug("http_ss", "[%" PRId64 "] new connection, ip: %s, count: %u", con_id,
-          ats_ip_ntop(&server_ip.sa, addrbuf, sizeof(addrbuf)), connection_count->getCount(server_ip));
+          ats_ip_nptop(&server_ip.sa, addrbuf, sizeof(addrbuf)),
+          connection_count->getCount(server_ip, hostname_hash, sharing_match));
   }
 #ifdef LAZY_BUF_ALLOC
   read_buffer = new_empty_MIOBuffer(HTTP_SERVER_RESP_HDR_BUFFER_INDEX);
@@ -139,13 +140,15 @@ HttpServerSession::do_io_close(int alerrno)
   // Check to see if we are limiting the number of connections
   // per host
   if (enable_origin_connection_limiting == true) {
-    if (connection_count->getCount(server_ip) > 0) {
-      connection_count->incrementCount(server_ip, -1);
-      char addrbuf[INET6_ADDRSTRLEN];
+    if (connection_count->getCount(server_ip, hostname_hash, sharing_match) > 0) {
+      connection_count->incrementCount(server_ip, hostname_hash, sharing_match, -1);
+      ip_port_text_buffer addrbuf;
       Debug("http_ss", "[%" PRId64 "] connection closed, ip: %s, count: %u", con_id,
-            ats_ip_ntop(&server_ip.sa, addrbuf, sizeof(addrbuf)), connection_count->getCount(server_ip));
+            ats_ip_nptop(&server_ip.sa, addrbuf, sizeof(addrbuf)),
+            connection_count->getCount(server_ip, hostname_hash, sharing_match));
     } else {
-      Error("[%" PRId64 "] number of connections should be greater than zero: %u", con_id, connection_count->getCount(server_ip));
+      Error("[%" PRId64 "] number of connections should be greater than zero: %u", con_id,
+            connection_count->getCount(server_ip, hostname_hash, sharing_match));
     }
   }
 

--- a/proxy/http/HttpSessionManager.cc
+++ b/proxy/http/HttpSessionManager.cc
@@ -171,8 +171,8 @@ ServerSessionPool::eventHandler(int event, void *data)
       // origin, then reset the timeouts on our end and do not close the connection
       if ((event == VC_EVENT_INACTIVITY_TIMEOUT || event == VC_EVENT_ACTIVE_TIMEOUT) && s->state == HSS_KA_SHARED &&
           s->enable_origin_connection_limiting) {
-        bool connection_count_below_min =
-          s->connection_count->getCount(s->server_ip) <= http_config_params->origin_min_keep_alive_connections;
+        bool connection_count_below_min = s->connection_count->getCount(s->server_ip, s->hostname_hash, s->sharing_match) <=
+                                          http_config_params->origin_min_keep_alive_connections;
 
         if (connection_count_below_min) {
           Debug("http_ss", "[%" PRId64 "] [session_bucket] session received io notice [%s], "


### PR DESCRIPTION
This fixes issues related to max origin connections and makes them honor the same server matching config that is used for server session pools.

@jpeach @jacksontj @zwoop please review.

https://issues.apache.org/jira/browse/TS-4340