### PR TITLE
TS-3245 : Changes optind = 1 to optind = 0 for all plugins to ensure

### DIFF
--- a/plugins/experimental/background_fetch/background_fetch.cc
+++ b/plugins/experimental/background_fetch/background_fetch.cc
@@ -554,7 +554,7 @@ TSPluginInit(int argc, const char *argv[])
   gConfig = new BgFetchConfig(cont);
   gConfig->acquire(); // Inc refcount, although this global config should never go out of scope
 
-  optind = 1;
+  optind = 0;
   while (true) {
     int opt = getopt_long(argc, (char *const *)argv, "lc", longopt, NULL);
 

--- a/plugins/experimental/regex_revalidate/regex_revalidate.c
+++ b/plugins/experimental/regex_revalidate/regex_revalidate.c
@@ -466,7 +466,7 @@ TSPluginInit(int argc, const char *argv[])
   init_plugin_state_t(pstate);
 
   int c;
-  optind = 1;
+  optind = 0;
   static const struct option longopts[] = {
     {"config", required_argument, NULL, 'c'}, {"log", required_argument, NULL, 'l'}, {NULL, 0, NULL, 0}};
 

--- a/plugins/experimental/remap_stats/remap_stats.c
+++ b/plugins/experimental/remap_stats/remap_stats.c
@@ -257,7 +257,7 @@ TSPluginInit(int argc, const char *argv[])
 
   if (argc > 1) {
     int c;
-    optind = 1;
+    optind = 0;
     static const struct option longopts[] = {
       {"post-remap-host", no_argument, NULL, 'P'}, {"persistent", no_argument, NULL, 'p'}, {NULL, 0, NULL, 0}};
 

--- a/plugins/experimental/stale_while_revalidate/stale_while_revalidate.c
+++ b/plugins/experimental/stale_while_revalidate/stale_while_revalidate.c
@@ -637,7 +637,7 @@ TSPluginInit(int argc, const char *argv[])
 
   if (argc > 1) {
     int c;
-    optind = 1;
+    optind = 0;
     static const struct option longopts[] = {{"log-all", no_argument, NULL, 'a'},
                                              {"log-stale-while-revalidate", no_argument, NULL, 'r'},
                                              {"log-stale-if-error", no_argument, NULL, 'e'},


### PR DESCRIPTION
          that multiples plugins in the global plugin.config can co-exist
          together. Note that all plugins were already optind = 0 except
          for the four that were modified in the this commit (background_fetch,
          regex_revalidate, remap_stats, and stale_while_revalidate).

          Note: This patch does NOT change ATS core so that future plugins
          must be sure to use optind = 0 also.

Understood preference is for ATS core change to cover all plugins, but this has been outstanding for more than one year and affects our usage of ATS. Also, I am not sure if an ATS core change can cover the plugins since according to the Linux man page setting optind=0 and calling getopt_long() causes an "internal" initialization process to run which looks at the optstring argument to getopt_long(). ATS core would not have pre-knowledge of each plugin's internals so this seems like this would be a road-block?