### PR TITLE
TS-3429: Fix reference counting for TSContScheduleEvery.

### DIFF
--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -991,7 +991,14 @@ INKContInternal::handle_event(int event, void *edata)
       Warning("INKCont Deletable but not deleted %d", m_event_count);
     }
   } else {
-    return m_event_func((TSCont)this, (TSEvent)event, edata);
+    int retval = m_event_func((TSCont)this, (TSEvent)event, edata);
+    if (event == EVENT_INTERVAL) {
+      // In the interval case, we must re-increment the m_event_count for
+      // the next go around.  Otherwise, our event count will go negative.
+      if (ink_atomic_increment((int *)&this->m_event_count, 1) < 0)
+        ink_assert(!"not reached");
+    }
+    return retval;
   }
   return EVENT_DONE;
 }

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -992,10 +992,13 @@ INKContInternal::handle_event(int event, void *edata)
     }
   } else {
     int retval = m_event_func((TSCont)this, (TSEvent)event, edata);
-    if (event == EVENT_INTERVAL) {
-      // In the interval case, we must re-increment the m_event_count for
-      // the next go around.  Otherwise, our event count will go negative.
-      ink_release_assert(ink_atomic_increment((int *)&this->m_event_count, 1) < 0)
+    if (edata && event == EVENT_INTERVAL) {
+      Event *e = reinterpret_cast<Event *>(edata);
+      if (e->period != 0) {
+        // In the interval case, we must re-increment the m_event_count for
+        // the next go around.  Otherwise, our event count will go negative.
+        ink_release_assert(ink_atomic_increment((int *)&this->m_event_count, 1) >- 0);
+      }
     }
     return retval;
   }

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -995,8 +995,7 @@ INKContInternal::handle_event(int event, void *edata)
     if (event == EVENT_INTERVAL) {
       // In the interval case, we must re-increment the m_event_count for
       // the next go around.  Otherwise, our event count will go negative.
-      if (ink_atomic_increment((int *)&this->m_event_count, 1) < 0)
-        ink_assert(!"not reached");
+      ink_release_assert(ink_atomic_increment((int *)&this->m_event_count, 1) < 0)
     }
     return retval;
   }

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -997,7 +997,7 @@ INKContInternal::handle_event(int event, void *edata)
       if (e->period != 0) {
         // In the interval case, we must re-increment the m_event_count for
         // the next go around.  Otherwise, our event count will go negative.
-        ink_release_assert(ink_atomic_increment((int *)&this->m_event_count, 1) >- 0);
+        ink_release_assert(ink_atomic_increment((int *)&this->m_event_count, 1) >= 0);
       }
     }
     return retval;


### PR DESCRIPTION
Changed the logic at the end of the INKContInternal event handler to bump up the ref-count at the end if it was invoked for an interval event.  This enables the ref count to be incremented before every call to the event handler.

I ran with the Epic plugin (referenced by related bug), and its stats handler function executed multiple times without assertion failures.