### PR TITLE
TS-4046: Prevent memory leak of HTTP heap for server intercept case.

### DIFF
--- a/proxy/hdrs/HTTP.h
+++ b/proxy/hdrs/HTTP.h
@@ -507,7 +507,7 @@ public:
   int valid() const;
 
   void create(HTTPType polarity, HdrHeap *heap = NULL);
-  void clear();
+  void destroy();
   void reset();
   void copy(const HTTPHdr *hdr);
   void copy_shallow(const HTTPHdr *hdr);
@@ -796,12 +796,13 @@ HTTPHdr::create(HTTPType polarity, HdrHeap *heap)
 }
 
 inline void
-HTTPHdr::clear()
+HTTPHdr::destroy()
 {
   if (m_http && m_http->m_polarity == HTTP_TYPE_REQUEST) {
     m_url_cached.clear();
   }
-  this->HdrHeapSDKHandle::clear();
+  // Removing the only pointers to this data therefore it needs to get cleaned up or leak.
+  this->HdrHeapSDKHandle::destroy();
   m_http = NULL;
   m_mime = NULL;
 }

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -935,7 +935,7 @@ done:
     HTTP_INCREMENT_DYN_STAT(http_invalid_client_requests_stat);
     TRANSACT_RETURN(SM_ACTION_SEND_ERROR_CACHE_NOOP, NULL);
   } else {
-    s->hdr_info.client_response.clear(); // anything previously set is invalid from this point forward
+    s->hdr_info.client_response.destroy(); // anything previously set is invalid from this point forward
     DebugTxn("http_trans", "END HttpTransact::EndRemapRequest");
 
     if (s->is_upgrade_request && s->post_remap_upgrade_return_point) {


### PR DESCRIPTION
In the case of an intercept plugin the `client_response` can be leaked. I changed the method used to be `destroy` to be clearer and changed it to destroy the heap, not just drop the pointers.  This has been tested in production and should be isolated as there is only one place this method is invoked.