### PR TITLE
TS-4356 Deprecate cacheurl plugin

### DIFF
--- a/doc/admin-guide/plugins/cachekey.en.rst
+++ b/doc/admin-guide/plugins/cachekey.en.rst
@@ -1,5 +1,3 @@
-.. _admin-plugins-cachekey:
-
 .. Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
@@ -16,6 +14,11 @@
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
+
+
+.. include:: ../../common.defs
+
+.. _admin-plugins-cachekey:
 
 
 Cache Key Manipulation Plugin
@@ -108,7 +111,7 @@ Cache key structure and related plugin parameters
 * ``--include-headers`` (default: empty list) - comma separated list of headers to be added to the cache key. The list of headers defined by ``--include-headers`` are always sorted before adding them to the cache  key.
 
 "Cookies" section
-^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^
 
 ::
 

--- a/doc/admin-guide/plugins/cacheurl.en.rst
+++ b/doc/admin-guide/plugins/cacheurl.en.rst
@@ -22,6 +22,12 @@
 Cache URL Plugin
 ****************
 
+.. note::
+
+   This plugin is deprecated as of v6.2.0 and will be removed as of v7.0.0. 
+   It is replaced by a new :ref:`admin-plugins-cachekey` and you should change your configurations to use the new plugin instead.
+   Please find some examples below.
+    
 This plugin allows you to change the :term:`cache key` that is used for caching
 a request by using any portion of the URL via regular expressions.
 
@@ -100,6 +106,14 @@ will effectively share cache objects. Adding a unique suffix (``TSINTERNAL`` in
 this example) to the cache key guarantees that it won't clash with a real URL
 should s.example.com exist.
 
+Converting to :ref:`admin-plugins-cachekey`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You could do the same with :ref:`admin-plugins-cachekey` by adding the following to the mapping rules::
+
+    @plugin=cachekey.so @pparam=--capture-prefix=/s[123].example.com:.*/s.example.com.TSINTERNAL/
+
+
 Ignoring Some Query Parameters
 ------------------------------
 
@@ -110,6 +124,14 @@ generating a cache key, while still retaining important query parameters::
 
     http://www.example.com/video\?.*?\&?(id=[0-9a-f]*).*?\&(format=[a-z]*)  http://video-srv.example.com.ATSINTERNAL/$1&$2
 
+Converting to :ref:`admin-plugins-cachekey`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You could do the same with :ref:`admin-plugins-cachekey` by adding the following to the mapping rules:: 
+
+    @plugin=cachekey.so @pparam=--include-params=id,format
+
+
 Ignore Query String on Specific Pages
 -------------------------------------
 
@@ -119,3 +141,9 @@ of the URL::
 
     http://www.example.com/some/page(?:\?|$)  http://www.example.com/some/page
 
+Converting to :ref:`admin-plugins-cachekey`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You could do the same with :ref:`admin-plugins-cachekey` by adding the following to the mapping rules::
+
+    @plugin=cachekey.so @pparam=--remove-all-params

--- a/plugins/cacheurl/cacheurl.cc
+++ b/plugins/cacheurl/cacheurl.cc
@@ -395,6 +395,9 @@ TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
   }
 
   TSDebug(PLUGIN_NAME, "remap plugin is successfully initialized");
+
+  TSError("[%s] is deprecated and will be removed as of v7.0.0", PLUGIN_NAME);
+
   return TS_SUCCESS;
 }
 
@@ -456,4 +459,6 @@ TSPluginInit(int argc, const char *argv[])
     initialization_error("Plugin config load failed.");
     return;
   }
+
+  TSError("[%s] is deprecated and will be removed as of v7.0.0", PLUGIN_NAME);
 }


### PR DESCRIPTION
Added a "deprecated" message and `cachekey` examples to the `cacheurl` doc.