### PR TITLE
TS-4187: Keep the currently_open connections in sync with open sockets

### DIFF
--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -897,7 +897,6 @@ SSLNetVConnection::do_io_close(int lerrno)
 void
 SSLNetVConnection::free(EThread *t)
 {
-  NET_SUM_GLOBAL_DYN_STAT(net_connections_currently_open_stat, -1);
   got_remote_addr = 0;
   got_local_addr = 0;
   read.vio.mutex.clear();

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -97,6 +97,9 @@ net_activity(UnixNetVConnection *vc, EThread *thread)
 void
 close_UnixNetVConnection(UnixNetVConnection *vc, EThread *t)
 {
+  if (vc->con.fd != NO_FD) {
+    NET_SUM_GLOBAL_DYN_STAT(net_connections_currently_open_stat, -1);
+  }
   NetHandler *nh = vc->nh;
   vc->cancel_OOB();
   vc->ep.stop();
@@ -1318,7 +1321,6 @@ void
 UnixNetVConnection::free(EThread *t)
 {
   ink_release_assert(t == this_ethread());
-  NET_SUM_GLOBAL_DYN_STAT(net_connections_currently_open_stat, -1);
   // clear variables for reuse
   this->mutex.clear();
   action_.mutex.clear();
@@ -1392,10 +1394,6 @@ UnixNetVConnection::migrateToCurrentThread(Continuation *cont, EThread *t)
   // processed on two threads simultaneously
   this->ep.stop();
   this->do_io_close();
-
-  // The do_io_close will decrement the current stat count but we are creating a new vc.
-  // Increment the currently open stat here so the net current count is unchanged
-  NET_SUM_GLOBAL_DYN_STAT(net_connections_currently_open_stat, 1);
 
   // Create new VC:
   if (save_ssl) {


### PR DESCRIPTION
This is an improvement on the original fix for TS-4187.  The original fix would in some case over count the open sockets.  It seems sometimes, the connection would have already been closed or rather be scheduled to be closed multiple times.  We would increase the currently_open count for every scheduled close, but only decrease it for the actual free.

I've changed things around to decrease in the do_io_close if it is called with a valid file descriptor.

This seems to better keep the currently_open count in sync with the established socket count on the systems.  However, both grow until we run out of memory on our production boxes.  But that is being tracked by TS-4330