### PR TITLE
TS-4364: Address remnants from HTTP/2 refactoring

### DIFF
--- a/proxy/ProxyClientTransaction.cc
+++ b/proxy/ProxyClientTransaction.cc
@@ -23,6 +23,7 @@
 
 #include "http/HttpSM.h"
 #include "http/HttpServerSession.h"
+#include "Plugin.h"
 
 #define DebugHttpTxn(fmt, ...) DebugSsn(this, "http_txn", fmt, __VA_ARGS__)
 
@@ -44,6 +45,22 @@ ProxyClientTransaction::new_transaction()
   DebugHttpTxn("[%" PRId64 "] Starting transaction %d using sm [%" PRId64 "]", parent->connection_id(),
                parent->get_transact_count(), current_reader->sm_id);
 
+  // This is a temporary hack until we get rid of SPDY and can use virutal methods entirely
+  // to track protocol
+  PluginIdentity *pi = dynamic_cast<PluginIdentity *>(this->get_netvc());
+  if (pi) {
+    current_reader->plugin_tag = pi->getPluginTag();
+    current_reader->plugin_id = pi->getPluginId();
+  } else {
+    const char *protocol_str = this->get_protocol_string();
+    // We don't set the plugin_tag for http, though in future we should probably log http as protocol
+    if (strncmp("http", protocol_str, 4)) {
+      current_reader->plugin_tag = protocol_str;
+      // Since there is no more plugin, there is no plugin id for http/2
+      // We are copying along the plugin_tag as a standin for protocol name for logging
+      // and to detect a case in HttpTransaction (TS-3954)
+    }  
+  } 
   current_reader->attach_client_session(this, sm_reader);
 }
 

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -6999,11 +6999,12 @@ HttpTransact::handle_response_keep_alive_headers(State *s, HTTPVersion ver, HTTP
     // to the client to keep the connection alive.
     // Insert a Transfer-Encoding header in the response if necessary.
 
-    // check that the client is HTTP 1.1 and the conf allows chunking
+    // check that the client is HTTP 1.1 and the conf allows chunking or the client 
+    // protocol unchunks before returning to the user agent (i.e. is spdy or http/2)
     if (s->client_info.http_version == HTTPVersion(1, 1) &&
         (s->txn_conf->chunking_enabled == 1 ||
          (s->state_machine->plugin_tag &&
-          (!strcmp(s->state_machine->plugin_tag, "http/2") || !strncmp(s->state_machine->plugin_tag, "spdy", 4)))) &&
+          (!strncmp(s->state_machine->plugin_tag, "http/2", 6) || !strncmp(s->state_machine->plugin_tag, "spdy", 4)))) &&
         // if we're not sending a body, don't set a chunked header regardless of server response
         !is_response_body_precluded(s->hdr_info.client_response.status_get(), s->method) &&
         // we do not need chunked encoding for internal error messages

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -194,7 +194,7 @@ public:
   virtual const char *
   get_protocol_string() const
   {
-    return "http2";
+    return "http/2";
   }
 
   virtual void set_active_timeout(ink_hrtime timeout_in);


### PR DESCRIPTION
Add back in support for HttpSM->plugin_tag to enable protocol logging and fix for TS-3954