### PR TITLE
TS-4365: Prevent invalid clang-analyzer memory leak warnings

### DIFF
--- a/lib/atscppapi/examples/async_http_fetch/AsyncHttpFetch.cc
+++ b/lib/atscppapi/examples/async_http_fetch/AsyncHttpFetch.cc
@@ -33,6 +33,11 @@ using std::string;
 // To view the debug messages ./traffic_server -T "async_http_fetch_example.*"
 #define TAG "async_http_fetch_example"
 
+namespace
+{
+GlobalPlugin *plugin;
+}
+
 class AsyncHttpFetch2 : public AsyncHttpFetch
 {
 public:
@@ -213,7 +218,5 @@ TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
   TS_DEBUG(TAG, "Loaded async_http_fetch_example plugin");
   RegisterGlobalPlugin("CPP_Example_AsyncHttpFetch", "apache", "dev@trafficserver.apache.org");
-  GlobalPlugin *instance = new GlobalHookPlugin();
-
-  (void)instance;
+  plugin = new GlobalHookPlugin();
 }

--- a/lib/atscppapi/examples/async_http_fetch_streaming/AsyncHttpFetchStreaming.cc
+++ b/lib/atscppapi/examples/async_http_fetch_streaming/AsyncHttpFetchStreaming.cc
@@ -34,6 +34,11 @@ using std::string;
 // To view the debug messages ./traffic_server -T "async_http_fetch_example.*"
 #define TAG "async_http_fetch_example"
 
+namespace
+{
+GlobalPlugin *plugin;
+}
+
 class Intercept : public InterceptPlugin, public AsyncReceiver<AsyncHttpFetch>
 {
 public:

--- a/lib/atscppapi/examples/async_timer/AsyncTimer.cc
+++ b/lib/atscppapi/examples/async_timer/AsyncTimer.cc
@@ -84,4 +84,10 @@ TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
     new TimerEventReceiver(AsyncTimer::TYPE_PERIODIC, period_in_ms, initial_period_in_ms, max_instances, true /* cancel */);
   TS_DEBUG(TAG, "Created canceling timer %p with initial period %d, regular period %d and max instances %d", timer5,
            initial_period_in_ms, period_in_ms, max_instances);
+
+  (void)timer1;
+  (void)timer2;
+  (void)timer3;
+  (void)timer4;
+  (void)timer5;
 }

--- a/lib/atscppapi/examples/boom/boom.cc
+++ b/lib/atscppapi/examples/boom/boom.cc
@@ -93,6 +93,11 @@ const std::string DEFAULT_BOOM_HTTP_STATUS = "OK (BOOM)";
 Stat boom_counter;
 }
 
+namespace
+{
+GlobalPlugin *plugin;
+}
+
 // Functor that decides whether the HTTP error can be rewritten or not.
 // Rewritable codes are: 2xx, 3xx, 4xx, 5xx and 6xx.
 // 1xx is NOT rewritable!
@@ -434,5 +439,5 @@ TSPluginInit(int argc, const char *argv[])
     TS_ERROR(TAG, "Invalid number of command line arguments, using compile time defaults.");
   }
 
-  new BoomGlobalPlugin(pregistry);
+  plugin = new BoomGlobalPlugin(pregistry);
 }

--- a/lib/atscppapi/examples/clientredirect/ClientRedirect.cc
+++ b/lib/atscppapi/examples/clientredirect/ClientRedirect.cc
@@ -28,6 +28,11 @@ using std::endl;
 using std::list;
 using std::string;
 
+namespace
+{
+GlobalPlugin *plugin;
+}
+
 class ClientRedirectTransactionPlugin : public atscppapi::TransactionPlugin
 {
 public:
@@ -75,5 +80,5 @@ void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
   RegisterGlobalPlugin("CPP_Example_ClientDirect", "apache", "dev@trafficserver.apache.org");
-  new ClientRedirectGlobalPlugin();
+  plugin = new ClientRedirectGlobalPlugin();
 }

--- a/lib/atscppapi/examples/clientrequest/ClientRequest.cc
+++ b/lib/atscppapi/examples/clientrequest/ClientRequest.cc
@@ -28,6 +28,11 @@ using std::endl;
 using std::list;
 using std::string;
 
+namespace
+{
+GlobalPlugin *plugin;
+}
+
 class GlobalHookPlugin : public GlobalPlugin
 {
 public:
@@ -134,5 +139,5 @@ void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
   RegisterGlobalPlugin("CPP_Example_ClientRequest", "apache", "dev@trafficserver.apache.org");
-  new GlobalHookPlugin();
+  plugin = new GlobalHookPlugin();
 }

--- a/lib/atscppapi/examples/custom_error_remap_plugin/CustomErrorRemapPlugin.cc
+++ b/lib/atscppapi/examples/custom_error_remap_plugin/CustomErrorRemapPlugin.cc
@@ -23,6 +23,11 @@
 using namespace std;
 using namespace atscppapi;
 
+namespace
+{
+RemapPlugin *plugin;
+}
+
 class MyRemapPlugin : public RemapPlugin
 {
 public:
@@ -51,6 +56,6 @@ TSReturnCode
 TSRemapNewInstance(int argc ATSCPPAPI_UNUSED, char *argv[] ATSCPPAPI_UNUSED, void **instance_handle, char *errbuf ATSCPPAPI_UNUSED,
                    int errbuf_size ATSCPPAPI_UNUSED)
 {
-  new MyRemapPlugin(instance_handle);
+  plugin = new MyRemapPlugin(instance_handle);
   return TS_SUCCESS;
 }

--- a/lib/atscppapi/examples/customresponse/CustomResponse.cc
+++ b/lib/atscppapi/examples/customresponse/CustomResponse.cc
@@ -37,6 +37,11 @@ using std::string;
  *
  */
 
+namespace
+{
+GlobalPlugin *plugin;
+}
+
 class CustomResponseTransactionPlugin : public atscppapi::TransactionPlugin
 {
 public:
@@ -83,5 +88,5 @@ void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
   RegisterGlobalPlugin("CPP_Example_CustomResponse", "apache", "dev@trafficserver.apache.org");
-  new ClientRedirectGlobalPlugin();
+  plugin = new ClientRedirectGlobalPlugin();
 }

--- a/lib/atscppapi/examples/globalhook/GlobalHookPlugin.cc
+++ b/lib/atscppapi/examples/globalhook/GlobalHookPlugin.cc
@@ -24,6 +24,11 @@
 using namespace atscppapi;
 using namespace std;
 
+namespace
+{
+GlobalPlugin *plugin;
+}
+
 class GlobalHookPlugin : public GlobalPlugin
 {
 public:
@@ -41,5 +46,5 @@ TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
   RegisterGlobalPlugin("CPP_Example_GlobalHookPplugin", "apache", "dev@trafficserver.apache.org");
   std::cout << "Hello from " << argv[0] << std::endl;
-  new GlobalHookPlugin();
+  plugin = new GlobalHookPlugin();
 }

--- a/lib/atscppapi/examples/gzip_transformation/GzipTransformationPlugin.cc
+++ b/lib/atscppapi/examples/gzip_transformation/GzipTransformationPlugin.cc
@@ -31,6 +31,11 @@ using std::string;
 
 #define TAG "gzip_transformation"
 
+namespace
+{
+GlobalPlugin *plugin;
+}
+
 /*
  * Note, the GzipInflateTransformation and GzipDeflateTransformation do not
  * check headers to determine if the content was gziped and it doesn't check
@@ -193,5 +198,5 @@ TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
   RegisterGlobalPlugin("CPP_Example_GzipTransformation", "apache", "dev@trafficserver.apache.org");
   TS_DEBUG(TAG, "TSPluginInit");
-  new GlobalHookPlugin();
+  plugin = new GlobalHookPlugin();
 }

--- a/lib/atscppapi/examples/helloworld/HelloWorldPlugin.cc
+++ b/lib/atscppapi/examples/helloworld/HelloWorldPlugin.cc
@@ -19,6 +19,13 @@
 #include <iostream>
 #include <atscppapi/GlobalPlugin.h>
 #include <atscppapi/PluginInit.h>
+
+using namespace atscppapi;
+namespace
+{
+GlobalPlugin *plugin;
+}
+
 class HelloWorldPlugin : public atscppapi::GlobalPlugin
 {
 public:
@@ -30,5 +37,5 @@ TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
   std::cout << "Hello from " << argv[0] << std::endl;
   atscppapi::RegisterGlobalPlugin("CPP_Example_HelloWorld", "apache", "dev@trafficserver.apache.org");
-  new HelloWorldPlugin();
+  plugin = new HelloWorldPlugin();
 }

--- a/lib/atscppapi/examples/intercept/intercept.cc
+++ b/lib/atscppapi/examples/intercept/intercept.cc
@@ -27,6 +27,11 @@ using std::string;
 using std::cout;
 using std::endl;
 
+namespace
+{
+GlobalPlugin *plugin;
+}
+
 class Intercept : public InterceptPlugin
 {
 public:
@@ -56,7 +61,7 @@ void
 TSPluginInit(int /* argc ATS_UNUSED */, const char * /* argv ATS_UNUSED */ [])
 {
   RegisterGlobalPlugin("CPP_Example_Intercept", "apache", "dev@trafficserver.apache.org");
-  new InterceptInstaller();
+  plugin = new InterceptInstaller();
 }
 
 void

--- a/lib/atscppapi/examples/internal_transaction_handling/InternalTransactionHandling.cc
+++ b/lib/atscppapi/examples/internal_transaction_handling/InternalTransactionHandling.cc
@@ -24,6 +24,12 @@
 using namespace atscppapi;
 using std::string;
 
+namespace
+{
+GlobalPlugin *plugin;
+GlobalPlugin *plugin2;
+}
+
 #define TAG "internal_transaction_handling"
 
 class AllTransactionsGlobalPlugin : public GlobalPlugin
@@ -72,6 +78,6 @@ TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
   RegisterGlobalPlugin("CPP_Example_InternalTransactionHandling", "apache", "dev@trafficserver.apache.org");
   TS_DEBUG(TAG, "Loaded async_http_fetch_example plugin");
-  new AllTransactionsGlobalPlugin();
-  new NoInternalTransactionsGlobalPlugin();
+  plugin = new AllTransactionsGlobalPlugin();
+  plugin2 = new NoInternalTransactionsGlobalPlugin();
 }

--- a/lib/atscppapi/examples/logger_example/LoggerExample.cc
+++ b/lib/atscppapi/examples/logger_example/LoggerExample.cc
@@ -34,6 +34,7 @@ using std::string;
 namespace
 {
 Logger log;
+GlobalPlugin *plugin;
 }
 
 /*
@@ -134,5 +135,5 @@ TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
   // once every second. You should really avoid flushing the log unless it's really necessary.
   log.flush();
 
-  new GlobalHookPlugin();
+  plugin = new GlobalHookPlugin();
 }

--- a/lib/atscppapi/examples/multiple_transaction_hooks/MultipleTransactionHookPlugins.cc
+++ b/lib/atscppapi/examples/multiple_transaction_hooks/MultipleTransactionHookPlugins.cc
@@ -23,6 +23,10 @@
 #include <atscppapi/PluginInit.h>
 
 using namespace atscppapi;
+namespace
+{
+GlobalPlugin *plugin;
+}
 
 class MultipleTransactionHookPluginsOne : public atscppapi::TransactionPlugin
 {
@@ -102,5 +106,5 @@ void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
   RegisterGlobalPlugin("CPP_Example_MultipleTransactionHook", "apache", "dev@trafficserver.apache.org");
-  new GlobalHookPlugin();
+  plugin = new GlobalHookPlugin();
 }

--- a/lib/atscppapi/examples/null_transformation_plugin/NullTransformationPlugin.cc
+++ b/lib/atscppapi/examples/null_transformation_plugin/NullTransformationPlugin.cc
@@ -29,6 +29,7 @@ using std::string;
 namespace
 {
 #define TAG "null_transformation"
+GlobalPlugin *plugin;
 }
 
 class NullTransformationPlugin : public TransformationPlugin
@@ -100,5 +101,5 @@ TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
   RegisterGlobalPlugin("CPP_Example_NullTransformation", "apache", "dev@trafficserver.apache.org");
   TS_DEBUG(TAG, "TSPluginInit");
-  new GlobalHookPlugin();
+  plugin = new GlobalHookPlugin();
 }

--- a/lib/atscppapi/examples/post_buffer/PostBuffer.cc
+++ b/lib/atscppapi/examples/post_buffer/PostBuffer.cc
@@ -27,6 +27,11 @@ using std::cerr;
 using std::endl;
 using std::string;
 
+namespace
+{
+GlobalPlugin *plugin;
+}
+
 class PostBufferTransformationPlugin : public TransformationPlugin
 {
 public:
@@ -78,5 +83,5 @@ void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
   RegisterGlobalPlugin("CPP_Example_PostBuffer", "apache", "dev@trafficserver.apache.org");
-  new GlobalHookPlugin();
+  plugin = new GlobalHookPlugin();
 }

--- a/lib/atscppapi/examples/remap_plugin/RemapPlugin.cc
+++ b/lib/atscppapi/examples/remap_plugin/RemapPlugin.cc
@@ -28,6 +28,11 @@ using namespace atscppapi;
 
 #define LOG_TAG "remapplugin"
 
+namespace
+{
+RemapPlugin *plugin;
+}
+
 class MyRemapPlugin : public RemapPlugin
 {
 public:
@@ -86,6 +91,6 @@ TSReturnCode
 TSRemapNewInstance(int argc ATSCPPAPI_UNUSED, char *argv[] ATSCPPAPI_UNUSED, void **instance_handle, char *errbuf ATSCPPAPI_UNUSED,
                    int errbuf_size ATSCPPAPI_UNUSED)
 {
-  new MyRemapPlugin(instance_handle);
+  plugin = new MyRemapPlugin(instance_handle);
   return TS_SUCCESS;
 }

--- a/lib/atscppapi/examples/serverresponse/ServerResponse.cc
+++ b/lib/atscppapi/examples/serverresponse/ServerResponse.cc
@@ -28,6 +28,11 @@ using std::endl;
 using std::list;
 using std::string;
 
+namespace
+{
+GlobalPlugin *plugin;
+}
+
 class ServerResponsePlugin : public GlobalPlugin
 {
 public:
@@ -115,5 +120,5 @@ void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
   RegisterGlobalPlugin("CPP_Example_ServerResponse", "apache", "dev@trafficserver.apache.org");
-  new ServerResponsePlugin();
+  plugin = new ServerResponsePlugin();
 }

--- a/lib/atscppapi/examples/stat_example/StatExample.cc
+++ b/lib/atscppapi/examples/stat_example/StatExample.cc
@@ -38,6 +38,8 @@ const string STAT_NAME = "stat_example";
 // This is the stat we'll be using, you can view it's value
 // using traffic_line -r stat_example
 Stat stat;
+
+GlobalPlugin *plugin;
 }
 
 /*
@@ -73,5 +75,5 @@ TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
   stat.init(STAT_NAME, Stat::SYNC_COUNT, true);
   stat.set(0);
 
-  new GlobalHookPlugin();
+  plugin = new GlobalHookPlugin();
 }

--- a/lib/atscppapi/examples/timeout_example/TimeoutExamplePlugin.cc
+++ b/lib/atscppapi/examples/timeout_example/TimeoutExamplePlugin.cc
@@ -25,6 +25,11 @@ using namespace atscppapi;
 
 #define TAG "timeout_example_plugin"
 
+namespace
+{
+GlobalPlugin *plugin;
+}
+
 class TimeoutExamplePlugin : public GlobalPlugin
 {
 public:
@@ -58,5 +63,5 @@ TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
   RegisterGlobalPlugin("CPP_Example_Timeout", "apache", "dev@trafficserver.apache.org");
   TS_DEBUG(TAG, "TSPluginInit");
-  new TimeoutExamplePlugin();
+  plugin = new TimeoutExamplePlugin();
 }

--- a/lib/atscppapi/examples/transactionhook/TransactionHookPlugin.cc
+++ b/lib/atscppapi/examples/transactionhook/TransactionHookPlugin.cc
@@ -23,6 +23,11 @@
 
 using namespace atscppapi;
 
+namespace
+{
+GlobalPlugin *plugin;
+}
+
 class TransactionHookPlugin : public atscppapi::TransactionPlugin
 {
 public:
@@ -65,5 +70,5 @@ void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
   RegisterGlobalPlugin("CPP_Example_TransactionHook", "apache", "dev@trafficserver.apache.org");
-  new GlobalHookPlugin();
+  plugin = new GlobalHookPlugin();
 }


### PR DESCRIPTION
clang-analyzer is currently detecting an invalid memory leak, this PR fixes those warnings by saving the plugin pointers.