### PR TITLE
[TS-4373] Add TSSslServerContextCreate and TSSslContextDestroy to the API.

### DIFF
--- a/doc/developer-guide/api/functions/TSSslContextCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSSslContextCreate.en.rst
@@ -1,0 +1,41 @@
+.. Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed
+   with this work for additional information regarding copyright
+   ownership.  The ASF licenses this file to you under the Apache
+   License, Version 2.0 (the "License"); you may not use this file
+   except in compliance with the License.  You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied.  See the License for the specific language governing
+   permissions and limitations under the License.
+
+.. include:: ../../../common.defs
+
+.. default-domain:: c
+
+TSSslContextCreate
+**********************
+
+Synopsis
+========
+
+`#include <ts/ts.h>`
+
+.. function:: TSSslContext TSSslContextCreate(void)
+
+Description
+===========
+
+Create a new SSL context. It also opulates cypher suite settings from records.config.
+
+Type
+====
+
+.. type:: TSSslContext
+
+Corresponds to the SSL_CTX * value in openssl.

--- a/doc/developer-guide/api/functions/TSSslContextDestroy.en.rst
+++ b/doc/developer-guide/api/functions/TSSslContextDestroy.en.rst
@@ -1,0 +1,34 @@
+.. Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed
+   with this work for additional information regarding copyright
+   ownership.  The ASF licenses this file to you under the Apache
+   License, Version 2.0 (the "License"); you may not use this file
+   except in compliance with the License.  You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied.  See the License for the specific language governing
+   permissions and limitations under the License.
+
+.. include:: ../../../common.defs
+
+.. default-domain:: c
+
+TSSslContextDestroy
+**********************
+
+Synopsis
+========
+
+`#include <ts/ts.h>`
+
+.. function:: void TSSslContextDestroy(TSSslContext ctx)
+
+Description
+===========
+
+Destroy a SSL context.

--- a/doc/developer-guide/api/functions/TSSslServerContextCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSSslServerContextCreate.en.rst
@@ -18,7 +18,7 @@
 
 .. default-domain:: c
 
-TSSslContextCreate
+TSSslServerContextCreate
 **********************
 
 Synopsis
@@ -26,12 +26,12 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. function:: TSSslContext TSSslContextCreate(void)
+.. function:: TSSslContext TSSslServerContextCreate(void)
 
 Description
 ===========
 
-Create a new SSL context. It also opulates cypher suite settings from records.config.
+Create a new server SSL context. It also populates cypher suite settings from records.config.
 
 Type
 ====

--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -117,6 +117,9 @@ extern RecRawStatBlock *ssl_rsb;
 // Create a default SSL server context.
 SSL_CTX *SSLDefaultServerContext();
 
+// Create a new SSL server context fully configured.
+SSL_CTX *SSLCreateServerContext(const SSLConfigParams *params);
+
 // Initialize the SSL library.
 void SSLInitializeLibrary();
 

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1281,6 +1281,129 @@ SSLCheckServerCertNow(X509 *cert, const char *certname)
 
 } /* CheckServerCertNow() */
 
+static char *
+asn1_strdup(ASN1_STRING *s)
+{
+  // Make sure we have an 8-bit encoding.
+  ink_assert(ASN1_STRING_type(s) == V_ASN1_IA5STRING || ASN1_STRING_type(s) == V_ASN1_UTF8STRING ||
+             ASN1_STRING_type(s) == V_ASN1_PRINTABLESTRING || ASN1_STRING_type(s) == V_ASN1_T61STRING);
+
+  return ats_strndup((const char *)ASN1_STRING_data(s), ASN1_STRING_length(s));
+}
+
+// Given a certificate and it's corresponding SSL_CTX context, insert hash
+// table aliases for subject CN and subjectAltNames DNS without wildcard,
+// insert trie aliases for those with wildcard.
+static bool
+ssl_index_certificate(SSLCertLookup *lookup, SSLCertContext const &cc, X509 *cert, const char *certname)
+{
+  X509_NAME *subject = NULL;
+  bool inserted = false;
+
+  if (NULL == cert) {
+    Error("Failed to load certificate %s", certname);
+    lookup->is_valid = false;
+    return false;
+  }
+
+  // Insert a key for the subject CN.
+  subject = X509_get_subject_name(cert);
+  ats_scoped_str subj_name;
+  if (subject) {
+    int pos = -1;
+    for (;;) {
+      pos = X509_NAME_get_index_by_NID(subject, NID_commonName, pos);
+      if (pos == -1) {
+        break;
+      }
+
+      X509_NAME_ENTRY *e = X509_NAME_get_entry(subject, pos);
+      ASN1_STRING *cn = X509_NAME_ENTRY_get_data(e);
+      subj_name = asn1_strdup(cn);
+
+      Debug("ssl", "mapping '%s' to certificate %s", (const char *)subj_name, certname);
+      if (lookup->insert(subj_name, cc) >= 0)
+        inserted = true;
+    }
+  }
+
+#if HAVE_OPENSSL_TS_H
+  // Traverse the subjectAltNames (if any) and insert additional keys for the SSL context.
+  GENERAL_NAMES *names = (GENERAL_NAMES *)X509_get_ext_d2i(cert, NID_subject_alt_name, NULL, NULL);
+  if (names) {
+    unsigned count = sk_GENERAL_NAME_num(names);
+    for (unsigned i = 0; i < count; ++i) {
+      GENERAL_NAME *name;
+
+      name = sk_GENERAL_NAME_value(names, i);
+      if (name->type == GEN_DNS) {
+        ats_scoped_str dns(asn1_strdup(name->d.dNSName));
+        // only try to insert if the alternate name is not the main name
+        if (strcmp(dns, subj_name) != 0) {
+          Debug("ssl", "mapping '%s' to certificates %s", (const char *)dns, certname);
+          if (lookup->insert(dns, cc) >= 0)
+            inserted = true;
+        }
+      }
+    }
+
+    GENERAL_NAMES_free(names);
+  }
+#endif // HAVE_OPENSSL_TS_H
+  return inserted;
+}
+
+// This callback function is executed while OpenSSL processes the SSL
+// handshake and does SSL record layer stuff.  It's used to trap
+// client-initiated renegotiations and update cipher stats
+static void
+ssl_callback_info(const SSL *ssl, int where, int ret)
+{
+  Debug("ssl", "ssl_callback_info ssl: %p where: %d ret: %d", ssl, where, ret);
+  SSLNetVConnection *netvc = (SSLNetVConnection *)SSL_get_app_data(ssl);
+
+  if ((where & SSL_CB_ACCEPT_LOOP) && netvc->getSSLHandShakeComplete() == true &&
+      SSLConfigParams::ssl_allow_client_renegotiation == false) {
+    int state = SSL_get_state(ssl);
+
+// TODO: ifdef can be removed in the future
+// Support for SSL23 only if we have it
+#ifdef SSL23_ST_SR_CLNT_HELLO_A
+    if (state == SSL3_ST_SR_CLNT_HELLO_A || state == SSL23_ST_SR_CLNT_HELLO_A) {
+#else
+    if (state == SSL3_ST_SR_CLNT_HELLO_A) {
+#endif
+      netvc->setSSLClientRenegotiationAbort(true);
+      Debug("ssl", "ssl_callback_info trying to renegotiate from the client");
+    }
+  }
+  if (where & SSL_CB_HANDSHAKE_DONE) {
+    // handshake is complete
+    const SSL_CIPHER *cipher = SSL_get_current_cipher(ssl);
+    if (cipher) {
+      const char *cipherName = SSL_CIPHER_get_name(cipher);
+      // lookup index of stat by name and incr count
+      InkHashTableValue data;
+      if (ink_hash_table_lookup(ssl_cipher_name_table, cipherName, &data)) {
+        SSL_INCREMENT_DYN_STAT((intptr_t)data);
+      }
+    }
+  }
+}
+
+static void
+ssl_set_handshake_callbacks(SSL_CTX *ctx)
+{
+#if TS_USE_TLS_SNI
+// Make sure the callbacks are set
+#if TS_USE_CERT_CB
+  SSL_CTX_set_cert_cb(ctx, ssl_cert_callback, NULL);
+#else
+  SSL_CTX_set_tlsext_servername_callback(ctx, ssl_servername_callback);
+#endif
+#endif
+}
+
 SSL_CTX *
 SSLInitServerContext(const SSLConfigParams *params, const ssl_user_config &sslMultCertSettings, Vec<X509 *> &certList)
 {
@@ -1550,146 +1673,7 @@ SSLInitServerContext(const SSLConfigParams *params, const ssl_user_config &sslMu
   if (!ssl_context_enable_dhe(params->dhparamsFile, ctx)) {
     goto fail;
   }
-  return ssl_context_enable_ecdh(ctx);
-
-fail:
-  SSL_CLEAR_PW_REFERENCES(ud, ctx)
-  SSLReleaseContext(ctx);
-  for (unsigned int i = 0; i < certList.length(); i++) {
-    X509_free(certList[i]);
-  }
-
-  return NULL;
-}
-
-static char *
-asn1_strdup(ASN1_STRING *s)
-{
-  // Make sure we have an 8-bit encoding.
-  ink_assert(ASN1_STRING_type(s) == V_ASN1_IA5STRING || ASN1_STRING_type(s) == V_ASN1_UTF8STRING ||
-             ASN1_STRING_type(s) == V_ASN1_PRINTABLESTRING || ASN1_STRING_type(s) == V_ASN1_T61STRING);
-
-  return ats_strndup((const char *)ASN1_STRING_data(s), ASN1_STRING_length(s));
-}
-
-// Given a certificate and it's corresponding SSL_CTX context, insert hash
-// table aliases for subject CN and subjectAltNames DNS without wildcard,
-// insert trie aliases for those with wildcard.
-static bool
-ssl_index_certificate(SSLCertLookup *lookup, SSLCertContext const &cc, X509 *cert, const char *certname)
-{
-  X509_NAME *subject = NULL;
-  bool inserted = false;
-
-  if (NULL == cert) {
-    Error("Failed to load certificate %s", certname);
-    lookup->is_valid = false;
-    return false;
-  }
-
-  // Insert a key for the subject CN.
-  subject = X509_get_subject_name(cert);
-  ats_scoped_str subj_name;
-  if (subject) {
-    int pos = -1;
-    for (;;) {
-      pos = X509_NAME_get_index_by_NID(subject, NID_commonName, pos);
-      if (pos == -1) {
-        break;
-      }
-
-      X509_NAME_ENTRY *e = X509_NAME_get_entry(subject, pos);
-      ASN1_STRING *cn = X509_NAME_ENTRY_get_data(e);
-      subj_name = asn1_strdup(cn);
-
-      Debug("ssl", "mapping '%s' to certificate %s", (const char *)subj_name, certname);
-      if (lookup->insert(subj_name, cc) >= 0)
-        inserted = true;
-    }
-  }
-
-#if HAVE_OPENSSL_TS_H
-  // Traverse the subjectAltNames (if any) and insert additional keys for the SSL context.
-  GENERAL_NAMES *names = (GENERAL_NAMES *)X509_get_ext_d2i(cert, NID_subject_alt_name, NULL, NULL);
-  if (names) {
-    unsigned count = sk_GENERAL_NAME_num(names);
-    for (unsigned i = 0; i < count; ++i) {
-      GENERAL_NAME *name;
-
-      name = sk_GENERAL_NAME_value(names, i);
-      if (name->type == GEN_DNS) {
-        ats_scoped_str dns(asn1_strdup(name->d.dNSName));
-        // only try to insert if the alternate name is not the main name
-        if (strcmp(dns, subj_name) != 0) {
-          Debug("ssl", "mapping '%s' to certificates %s", (const char *)dns, certname);
-          if (lookup->insert(dns, cc) >= 0)
-            inserted = true;
-        }
-      }
-    }
-
-    GENERAL_NAMES_free(names);
-  }
-#endif // HAVE_OPENSSL_TS_H
-  return inserted;
-}
-
-// This callback function is executed while OpenSSL processes the SSL
-// handshake and does SSL record layer stuff.  It's used to trap
-// client-initiated renegotiations and update cipher stats
-static void
-ssl_callback_info(const SSL *ssl, int where, int ret)
-{
-  Debug("ssl", "ssl_callback_info ssl: %p where: %d ret: %d", ssl, where, ret);
-  SSLNetVConnection *netvc = (SSLNetVConnection *)SSL_get_app_data(ssl);
-
-  if ((where & SSL_CB_ACCEPT_LOOP) && netvc->getSSLHandShakeComplete() == true &&
-      SSLConfigParams::ssl_allow_client_renegotiation == false) {
-    int state = SSL_get_state(ssl);
-
-// TODO: ifdef can be removed in the future
-// Support for SSL23 only if we have it
-#ifdef SSL23_ST_SR_CLNT_HELLO_A
-    if (state == SSL3_ST_SR_CLNT_HELLO_A || state == SSL23_ST_SR_CLNT_HELLO_A) {
-#else
-    if (state == SSL3_ST_SR_CLNT_HELLO_A) {
-#endif
-      netvc->setSSLClientRenegotiationAbort(true);
-      Debug("ssl", "ssl_callback_info trying to renegotiate from the client");
-    }
-  }
-  if (where & SSL_CB_HANDSHAKE_DONE) {
-    // handshake is complete
-    const SSL_CIPHER *cipher = SSL_get_current_cipher(ssl);
-    if (cipher) {
-      const char *cipherName = SSL_CIPHER_get_name(cipher);
-      // lookup index of stat by name and incr count
-      InkHashTableValue data;
-      if (ink_hash_table_lookup(ssl_cipher_name_table, cipherName, &data)) {
-        SSL_INCREMENT_DYN_STAT((intptr_t)data);
-      }
-    }
-  }
-}
-
-static void
-ssl_set_handshake_callbacks(SSL_CTX *ctx)
-{
-#if TS_USE_TLS_SNI
-// Make sure the callbacks are set
-#if TS_USE_CERT_CB
-  SSL_CTX_set_cert_cb(ctx, ssl_cert_callback, NULL);
-#else
-  SSL_CTX_set_tlsext_servername_callback(ctx, ssl_servername_callback);
-#endif
-#endif
-}
-
-SSL_CTX *
-SSLCreateServerContext(const SSLConfigParams *params) {
-  Vec<X509 *> cert_list;
-  const ssl_user_config sslMultCertSettings;
-  SSL_CTX *ctx = SSLInitServerContext(params, sslMultCertSettings, cert_list);
+  ssl_context_enable_ecdh(ctx);
 
   // The certificate callbacks are set by the caller only
   // for the default certificate
@@ -1702,9 +1686,6 @@ SSLCreateServerContext(const SSLConfigParams *params) {
 #if TS_USE_TLS_ALPN
   SSL_CTX_set_alpn_select_cb(ctx, SSLNetVConnection::select_next_protocol, NULL);
 #endif /* TS_USE_TLS_ALPN */
-
-  // TODO: Allow control over tickets and ticket path when using SSLCreateServerContext
-  ssl_context_enable_tickets(ctx, NULL);
 
 #ifdef HAVE_OPENSSL_OCSP_STAPLING
   if (SSLConfigParams::ssl_ocsp_enabled) {
@@ -1719,11 +1700,26 @@ SSLCreateServerContext(const SSLConfigParams *params) {
   }
 #endif /* HAVE_OPENSSL_OCSP_STAPLING */
 
-
   if (SSLConfigParams::init_ssl_ctx_cb) {
     SSLConfigParams::init_ssl_ctx_cb(ctx, true);
   }
   return ctx;
+
+fail:
+  SSL_CLEAR_PW_REFERENCES(ud, ctx)
+  SSLReleaseContext(ctx);
+  for (unsigned int i = 0; i < certList.length(); i++) {
+    X509_free(certList[i]);
+  }
+
+  return NULL;
+}
+
+SSL_CTX *
+SSLCreateServerContext(const SSLConfigParams *params) {
+  const ssl_user_config sslMultCertSettings;
+  Vec<X509 *> cert_list;
+  return SSLInitServerContext(params, sslMultCertSettings, cert_list);
 }
 
 static SSL_CTX *

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -8837,6 +8837,19 @@ TSSslContextFindByAddr(struct sockaddr const *addr)
   return ret;
 }
 
+tsapi TSSslContext
+TSSslContextCreate()
+{
+  TSSslContext ret = NULL;
+  SSLConfigParams *config = SSLConfig::acquire();
+  if (config != NULL) {
+    ret = reinterpret_cast<TSSslContext>(SSLCreateServerContext(config));
+    SSLConfig::release(config);
+  }
+  return ret;
+}
+
+
 tsapi int
 TSVConnIsSsl(TSVConn sslp)
 {

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -8838,7 +8838,7 @@ TSSslContextFindByAddr(struct sockaddr const *addr)
 }
 
 tsapi TSSslContext
-TSSslContextCreate()
+TSSslServerContextCreate()
 {
   TSSslContext ret = NULL;
   SSLConfigParams *config = SSLConfig::acquire();

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -8849,6 +8849,12 @@ TSSslContextCreate()
   return ret;
 }
 
+tsapi void
+TSSslContextDestroy(TSSslContext ctx)
+{
+  SSL_CTX *ssl_ctx = reinterpret_cast<SSL_CTX*>(ctx);
+  SSL_CTX_free(ssl_ctx);
+}
 
 tsapi int
 TSVConnIsSsl(TSVConn sslp)

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -1224,8 +1224,12 @@ tsapi TSSslConnection TSVConnSSLConnectionGet(TSVConn sslp);
 // Fetch a SSL context from the global lookup table
 tsapi TSSslContext TSSslContextFindByName(const char *name);
 tsapi TSSslContext TSSslContextFindByAddr(struct sockaddr const *);
+// Create a new SSL context based on the settings in records.config
+tsapi TSSslContext TSSslContextCreate();
+
 // Returns 1 if the sslp argument refers to a SSL connection
 tsapi int TSVConnIsSsl(TSVConn sslp);
+
 
 /* --------------------------------------------------------------------------
    HTTP transactions */

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -1226,6 +1226,7 @@ tsapi TSSslContext TSSslContextFindByName(const char *name);
 tsapi TSSslContext TSSslContextFindByAddr(struct sockaddr const *);
 // Create a new SSL context based on the settings in records.config
 tsapi TSSslContext TSSslContextCreate(void);
+tsapi void TSSslContextDestroy(TSSslContext ctx);
 
 // Returns 1 if the sslp argument refers to a SSL connection
 tsapi int TSVConnIsSsl(TSVConn sslp);

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -1225,7 +1225,7 @@ tsapi TSSslConnection TSVConnSSLConnectionGet(TSVConn sslp);
 tsapi TSSslContext TSSslContextFindByName(const char *name);
 tsapi TSSslContext TSSslContextFindByAddr(struct sockaddr const *);
 // Create a new SSL context based on the settings in records.config
-tsapi TSSslContext TSSslContextCreate(void);
+tsapi TSSslContext TSSslServerContextCreate(void);
 tsapi void TSSslContextDestroy(TSSslContext ctx);
 
 // Returns 1 if the sslp argument refers to a SSL connection

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -1225,7 +1225,7 @@ tsapi TSSslConnection TSVConnSSLConnectionGet(TSVConn sslp);
 tsapi TSSslContext TSSslContextFindByName(const char *name);
 tsapi TSSslContext TSSslContextFindByAddr(struct sockaddr const *);
 // Create a new SSL context based on the settings in records.config
-tsapi TSSslContext TSSslContextCreate();
+tsapi TSSslContext TSSslContextCreate(void);
 
 // Returns 1 if the sslp argument refers to a SSL connection
 tsapi int TSVConnIsSsl(TSVConn sslp);


### PR DESCRIPTION
This PR supersedes #402. I added documentation and rebased the code
on top of the current master. I'm going to send an email to the DEV@ list to formally propose this change.