### PR TITLE
[TS-4383] Allow group and others to read from the log pipe.

### DIFF
--- a/proxy/logging/LogFile.cc
+++ b/proxy/logging/LogFile.cc
@@ -159,7 +159,7 @@ LogFile::open_file()
 
   if (m_file_format == LOG_FILE_PIPE) {
     // setup pipe
-    if (mkfifo(m_name, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH) < 0) {
+    if (mkfifo(m_name, S_IRUSR | S_IWUSR | S_IRGRP) < 0) {
       if (errno != EEXIST) {
         Error("Could not create named pipe %s for logging: %s", m_name, strerror(errno));
         return LOG_FILE_COULD_NOT_CREATE_PIPE;

--- a/proxy/logging/LogFile.cc
+++ b/proxy/logging/LogFile.cc
@@ -159,7 +159,7 @@ LogFile::open_file()
 
   if (m_file_format == LOG_FILE_PIPE) {
     // setup pipe
-    if (mkfifo(m_name, S_IRUSR | S_IWUSR) < 0) {
+    if (mkfifo(m_name, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH) < 0) {
       if (errno != EEXIST) {
         Error("Could not create named pipe %s for logging: %s", m_name, strerror(errno));
         return LOG_FILE_COULD_NOT_CREATE_PIPE;


### PR DESCRIPTION
ASCII_PIPE logs are created with 0600 privileges.
The owner of this pipe is `nobody` and the group is `nogroup`.
This is very limiting and it makes impossible to use the pipe to read
logs.

Signed-off-by: David Calavera <david.calavera@gmail.com>