### PR TITLE
TS-4370: Add regression list option to traffic_server.

### DIFF
--- a/doc/appendices/command-line/traffic_server.en.rst
+++ b/doc/appendices/command-line/traffic_server.en.rst
@@ -57,7 +57,12 @@ environments or where the working set is highly variable.
 
 .. option:: -R LEVEL, --regression LEVEL
 
-.. option:: -r TEST, --regression_rest TEST
+.. option:: -r TEST, --regression_test TEST
+
+.. option:: -l, --regression_list
+
+If Traffic Server was built with tests enabled, this option lists
+the available tests.
 
 .. option:: -T TAGS, --debug_tags TAGS
 

--- a/iocore/eventsystem/I_Lock.h
+++ b/iocore/eventsystem/I_Lock.h
@@ -50,7 +50,7 @@
 
 */
 #ifdef DEBUG
-#define SCOPED_MUTEX_LOCK(_l, _m, _t) MutexLock _l(DiagsMakeLocation(), NULL, _m, _t)
+#define SCOPED_MUTEX_LOCK(_l, _m, _t) MutexLock _l(MakeSourceLocation(), NULL, _m, _t)
 #else
 #define SCOPED_MUTEX_LOCK(_l, _m, _t) MutexLock _l(_m, _t)
 #endif // DEBUG
@@ -69,7 +69,7 @@
   @param _t The current EThread executing your code.
 
 */
-#define MUTEX_TRY_LOCK(_l, _m, _t) MutexTryLock _l(DiagsMakeLocation(), (char *)NULL, _m, _t)
+#define MUTEX_TRY_LOCK(_l, _m, _t) MutexTryLock _l(MakeSourceLocation(), (char *)NULL, _m, _t)
 
 /**
   Attempts to acquire the lock to the ProxyMutex.
@@ -85,7 +85,7 @@
   @param _sc The number of attempts or spin count. It must be a positive value.
 
 */
-#define MUTEX_TRY_LOCK_SPIN(_l, _m, _t, _sc) MutexTryLock _l(DiagsMakeLocation(), (char *)NULL, _m, _t, _sc)
+#define MUTEX_TRY_LOCK_SPIN(_l, _m, _t, _sc) MutexTryLock _l(MakeSourceLocation(), (char *)NULL, _m, _t, _sc)
 
 /**
   Attempts to acquire the lock to the ProxyMutex.
@@ -102,7 +102,7 @@
 
 */
 
-#define MUTEX_TRY_LOCK_FOR(_l, _m, _t, _c) MutexTryLock _l(DiagsMakeLocation(), NULL, _m, _t)
+#define MUTEX_TRY_LOCK_FOR(_l, _m, _t, _c) MutexTryLock _l(MakeSourceLocation(), NULL, _m, _t)
 #else // DEBUG
 #define MUTEX_TRY_LOCK(_l, _m, _t) MutexTryLock _l(_m, _t)
 #define MUTEX_TRY_LOCK_SPIN(_l, _m, _t, _sc) MutexTryLock _l(_m, _t, _sc)
@@ -126,9 +126,9 @@
 /////////////////////////////////////
 // DEPRECATED DEPRECATED DEPRECATED
 #ifdef DEBUG
-#define MUTEX_TAKE_TRY_LOCK(_m, _t) Mutex_trylock(DiagsMakeLocation(), (char *)NULL, _m, _t)
-#define MUTEX_TAKE_TRY_LOCK_FOR(_m, _t, _c) Mutex_trylock(DiagsMakeLocation(), (char *)NULL, _m, _t)
-#define MUTEX_TAKE_TRY_LOCK_FOR_SPIN(_m, _t, _c, _sc) Mutex_trylock_spin(DiagsMakeLocation(), NULL, _m, _t, _sc)
+#define MUTEX_TAKE_TRY_LOCK(_m, _t) Mutex_trylock(MakeSourceLocation(), (char *)NULL, _m, _t)
+#define MUTEX_TAKE_TRY_LOCK_FOR(_m, _t, _c) Mutex_trylock(MakeSourceLocation(), (char *)NULL, _m, _t)
+#define MUTEX_TAKE_TRY_LOCK_FOR_SPIN(_m, _t, _c, _sc) Mutex_trylock_spin(MakeSourceLocation(), NULL, _m, _t, _sc)
 #else
 #define MUTEX_TAKE_TRY_LOCK(_m, _t) Mutex_trylock(_m, _t)
 #define MUTEX_TAKE_TRY_LOCK_FOR(_m, _t, _c) Mutex_trylock(_m, _t)
@@ -136,8 +136,8 @@
 #endif
 
 #ifdef DEBUG
-#define MUTEX_TAKE_LOCK(_m, _t) Mutex_lock(DiagsMakeLocation(), (char *)NULL, _m, _t)
-#define MUTEX_TAKE_LOCK_FOR(_m, _t, _c) Mutex_lock(DiagsMakeLocation(), NULL, _m, _t)
+#define MUTEX_TAKE_LOCK(_m, _t) Mutex_lock(MakeSourceLocation(), (char *)NULL, _m, _t)
+#define MUTEX_TAKE_LOCK_FOR(_m, _t, _c) Mutex_lock(MakeSourceLocation(), NULL, _m, _t)
 #else
 #define MUTEX_TAKE_LOCK(_m, _t) Mutex_lock(_m, _t)
 #define MUTEX_TAKE_LOCK_FOR(_m, _t, _c) Mutex_lock(_m, _t)
@@ -152,9 +152,9 @@ typedef EThread *EThreadPtr;
 typedef volatile EThreadPtr VolatileEThreadPtr;
 
 #if DEBUG
-inkcoreapi extern void lock_waiting(const SrcLoc &, const char *handler);
-inkcoreapi extern void lock_holding(const SrcLoc &, const char *handler);
-inkcoreapi extern void lock_taken(const SrcLoc &, const char *handler);
+inkcoreapi extern void lock_waiting(const SourceLocation &, const char *handler);
+inkcoreapi extern void lock_holding(const SourceLocation &, const char *handler);
+inkcoreapi extern void lock_taken(const SourceLocation &, const char *handler);
 #endif
 
 /**
@@ -209,7 +209,7 @@ public:
 
 #ifdef DEBUG
   ink_hrtime hold_time;
-  SrcLoc srcloc;
+  SourceLocation srcloc;
   const char *handler;
 
 #ifdef MAX_LOCK_TAKEN
@@ -280,7 +280,7 @@ extern inkcoreapi ClassAllocator<ProxyMutex> mutexAllocator;
 inline bool
 Mutex_trylock(
 #ifdef DEBUG
-  const SrcLoc &location, const char *ahandler,
+  const SourceLocation &location, const char *ahandler,
 #endif
   ProxyMutex *m, EThread *t)
 {
@@ -324,7 +324,7 @@ Mutex_trylock(
 inline bool
 Mutex_trylock_spin(
 #ifdef DEBUG
-  const SrcLoc &location, const char *ahandler,
+  const SourceLocation &location, const char *ahandler,
 #endif
   ProxyMutex *m, EThread *t, int spincnt = 1)
 {
@@ -373,7 +373,7 @@ Mutex_trylock_spin(
 inline int
 Mutex_lock(
 #ifdef DEBUG
-  const SrcLoc &location, const char *ahandler,
+  const SourceLocation &location, const char *ahandler,
 #endif
   ProxyMutex *m, EThread *t)
 {
@@ -416,7 +416,7 @@ Mutex_unlock(ProxyMutex *m, EThread *t)
       if (m->taken > MAX_LOCK_TAKEN)
         lock_taken(m->srcloc, m->handler);
 #endif // MAX_LOCK_TAKEN
-      m->srcloc = SrcLoc(NULL, NULL, 0);
+      m->srcloc = SourceLocation(NULL, NULL, 0);
       m->handler = NULL;
 #endif // DEBUG
       ink_assert(m->thread_holding);
@@ -436,7 +436,7 @@ private:
 public:
   MutexLock(
 #ifdef DEBUG
-    const SrcLoc &location, const char *ahandler,
+    const SourceLocation &location, const char *ahandler,
 #endif // DEBUG
     ProxyMutex *am, EThread *t)
     : m(am)
@@ -462,7 +462,7 @@ private:
 public:
   MutexTryLock(
 #ifdef DEBUG
-    const SrcLoc &location, const char *ahandler,
+    const SourceLocation &location, const char *ahandler,
 #endif // DEBUG
     ProxyMutex *am, EThread *t)
     : m(am)
@@ -476,7 +476,7 @@ public:
 
   MutexTryLock(
 #ifdef DEBUG
-    const SrcLoc &location, const char *ahandler,
+    const SourceLocation &location, const char *ahandler,
 #endif // DEBUG
     ProxyMutex *am, EThread *t, int sp)
     : m(am)

--- a/iocore/eventsystem/Lock.cc
+++ b/iocore/eventsystem/Lock.cc
@@ -34,7 +34,7 @@
 ClassAllocator<ProxyMutex> mutexAllocator("mutexAllocator");
 
 void
-lock_waiting(const SrcLoc &srcloc, const char *handler)
+lock_waiting(const SourceLocation &srcloc, const char *handler)
 {
   if (is_diags_on("locks")) {
     char buf[128];
@@ -43,7 +43,7 @@ lock_waiting(const SrcLoc &srcloc, const char *handler)
 }
 
 void
-lock_holding(const SrcLoc &srcloc, const char *handler)
+lock_holding(const SourceLocation &srcloc, const char *handler)
 {
   if (is_diags_on("locks")) {
     char buf[128];
@@ -52,7 +52,7 @@ lock_holding(const SrcLoc &srcloc, const char *handler)
 }
 
 void
-lock_taken(const SrcLoc &srcloc, const char *handler)
+lock_taken(const SourceLocation &srcloc, const char *handler)
 {
   if (is_diags_on("locks")) {
     char buf[128];

--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -133,11 +133,11 @@ ssl_error_t SSLAccept(SSL *ssl);
 ssl_error_t SSLConnect(SSL *ssl);
 
 // Log an SSL error.
-#define SSLError(fmt, ...) SSLDiagnostic(DiagsMakeLocation(), false, NULL, fmt, ##__VA_ARGS__)
-#define SSLErrorVC(vc, fmt, ...) SSLDiagnostic(DiagsMakeLocation(), false, (vc), fmt, ##__VA_ARGS__)
+#define SSLError(fmt, ...) SSLDiagnostic(MakeSourceLocation(), false, NULL, fmt, ##__VA_ARGS__)
+#define SSLErrorVC(vc, fmt, ...) SSLDiagnostic(MakeSourceLocation(), false, (vc), fmt, ##__VA_ARGS__)
 // Log a SSL diagnostic using the "ssl" diagnostic tag.
-#define SSLDebug(fmt, ...) SSLDiagnostic(DiagsMakeLocation(), true, NULL, fmt, ##__VA_ARGS__)
-#define SSLDebugVC(vc, fmt, ...) SSLDiagnostic(DiagsMakeLocation(), true, (vc), fmt, ##__VA_ARGS__)
+#define SSLDebug(fmt, ...) SSLDiagnostic(MakeSourceLocation(), true, NULL, fmt, ##__VA_ARGS__)
+#define SSLDebugVC(vc, fmt, ...) SSLDiagnostic(MakeSourceLocation(), true, (vc), fmt, ##__VA_ARGS__)
 
 #define SSL_CLR_ERR_INCR_DYN_STAT(vc, x, fmt, ...) \
   do {                                             \
@@ -145,7 +145,7 @@ ssl_error_t SSLConnect(SSL *ssl);
     RecIncrRawStat(ssl_rsb, NULL, (int)x, 1);      \
   } while (0)
 
-void SSLDiagnostic(const SrcLoc &loc, bool debug, SSLNetVConnection *vc, const char *fmt, ...) TS_PRINTFLIKE(4, 5);
+void SSLDiagnostic(const SourceLocation &loc, bool debug, SSLNetVConnection *vc, const char *fmt, ...) TS_PRINTFLIKE(4, 5);
 
 // Return a static string name for a SSL_ERROR constant.
 const char *SSLErrorName(int ssl_error);

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1116,7 +1116,7 @@ increment_ssl_server_error(unsigned long err)
 }
 
 void
-SSLDiagnostic(const SrcLoc &loc, bool debug, SSLNetVConnection *vc, const char *fmt, ...)
+SSLDiagnostic(const SourceLocation &loc, bool debug, SSLNetVConnection *vc, const char *fmt, ...)
 {
   unsigned long l;
   char buf[256];

--- a/lib/ts/Diags.cc
+++ b/lib/ts/Diags.cc
@@ -67,39 +67,6 @@ vprintline(FILE *fp, char (&buffer)[Size], va_list ap)
 
 //////////////////////////////////////////////////////////////////////////////
 //
-//      char *SrcLoc::str(char *buf, int buflen)
-//
-//      This method takes a SrcLoc source location data structure and
-//      converts it to a human-readable representation, in the buffer <buf>
-//      with length <buflen>.  The buffer will always be NUL-terminated, and
-//      must always have a length of at least 1.  The buffer address is
-//      returned on success.  The routine will only fail if the SrcLoc is
-//      not valid, or the buflen is less than 1.
-//
-//////////////////////////////////////////////////////////////////////////////
-
-char *
-SrcLoc::str(char *buf, int buflen) const
-{
-  const char *shortname;
-
-  if (!this->valid() || buflen < 1)
-    return (NULL);
-
-  shortname = strrchr(file, '/');
-  shortname = shortname ? (shortname + 1) : file;
-
-  if (func != NULL) {
-    snprintf(buf, buflen, "%s:%d (%s)", shortname, line, func);
-  } else {
-    snprintf(buf, buflen, "%s:%d", shortname, line);
-  }
-  buf[buflen - 1] = NUL;
-  return (buf);
-}
-
-//////////////////////////////////////////////////////////////////////////////
-//
 //      Diags::Diags(char *bdt, char *bat)
 //
 //      This is the constructor for the Diags class.  The constructor takes
@@ -229,7 +196,7 @@ Diags::~Diags()
 //////////////////////////////////////////////////////////////////////////////
 
 void
-Diags::print_va(const char *debug_tag, DiagsLevel diags_level, const SrcLoc *loc, const char *format_string, va_list ap) const
+Diags::print_va(const char *debug_tag, DiagsLevel diags_level, const SourceLocation *loc, const char *format_string, va_list ap) const
 {
   struct timeval tp;
   const char *s;
@@ -545,7 +512,7 @@ Diags::log(const char *tag, DiagsLevel level, const char *file, const char *func
   va_list ap;
   va_start(ap, format_string);
   if (show_location) {
-    SrcLoc lp(file, func, line);
+    SourceLocation lp(file, func, line);
     print_va(tag, level, &lp, format_string, ap);
   } else {
     print_va(tag, level, NULL, format_string, ap);
@@ -563,7 +530,7 @@ Diags::error_va(DiagsLevel level, const char *file, const char *func, const int 
   }
 
   if (show_location) {
-    SrcLoc lp(file, func, line);
+    SourceLocation lp(file, func, line);
     print_va(NULL, level, &lp, format_string, ap);
   } else {
     print_va(NULL, level, NULL, format_string, ap);

--- a/lib/ts/Diags.h
+++ b/lib/ts/Diags.h
@@ -42,6 +42,7 @@
 #include "ContFlags.h"
 #include "ink_inet.h"
 #include "BaseLogFile.h"
+#include "SourceLocation.h"
 
 #define DIAGS_MAGIC 0x12345678
 #define BYTES_IN_MB 1000000
@@ -88,45 +89,6 @@ struct DiagsConfigState {
   // this is static to eliminate many loads from the critical path
   static bool enabled[2];                    // one debug, one action
   DiagsModeOutput outputs[DiagsLevel_Count]; // where each level prints
-};
-
-//////////////////////////////////////////////////////////////////////////////
-//
-//      class SrcLoc
-//
-//      The SrcLoc class wraps up a source code location, including file
-//      name, function name, and line number, and contains a method to
-//      format the result into a string buffer.
-//
-//////////////////////////////////////////////////////////////////////////////
-
-#define DiagsMakeLocation() SrcLoc(__FILE__, __FUNCTION__, __LINE__)
-
-class SrcLoc
-{
-public:
-  const char *file;
-  const char *func;
-  int line;
-
-  bool
-  valid() const
-  {
-    return file && line;
-  }
-
-  SrcLoc(const SrcLoc &rhs) : file(rhs.file), func(rhs.func), line(rhs.line) {}
-  SrcLoc(const char *_file, const char *_func, int _line) : file(_file), func(_func), line(_line) {}
-  SrcLoc &
-  operator=(const SrcLoc &rhs)
-  {
-    this->file = rhs.file;
-    this->func = rhs.func;
-    this->line = rhs.line;
-    return *this;
-  }
-
-  char *str(char *buf, int buflen) const;
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -194,7 +156,7 @@ public:
 
   const char *level_name(DiagsLevel dl) const;
 
-  inkcoreapi void print_va(const char *tag, DiagsLevel dl, const SrcLoc *loc, const char *format_string, va_list ap) const;
+  inkcoreapi void print_va(const char *tag, DiagsLevel dl, const SourceLocation *loc, const char *format_string, va_list ap) const;
 
   //////////////////////////////
   // user printing interfaces //
@@ -207,7 +169,7 @@ public:
     va_list ap;
     va_start(ap, format_string);
     if (show_location) {
-      SrcLoc lp(file, func, line);
+      SourceLocation lp(file, func, line);
       print_va(tag, dl, &lp, format_string, ap);
     } else {
       print_va(tag, dl, NULL, format_string, ap);
@@ -221,7 +183,7 @@ public:
   ///////////////////////////////////////////////////////////////////////
 
   void
-  log_va(const char *tag, DiagsLevel dl, const SrcLoc *loc, const char *format_string, va_list ap)
+  log_va(const char *tag, DiagsLevel dl, const SourceLocation *loc, const char *format_string, va_list ap)
   {
     if (!on(tag))
       return;

--- a/lib/ts/Makefile.am
+++ b/lib/ts/Makefile.am
@@ -53,6 +53,8 @@ libtsutil_la_SOURCES = \
   ContFlags.h \
   Diags.cc \
   Diags.h \
+  SourceLocation.h \
+  SourceLocation.cc \
   DynArray.h \
   EventNotify.cc \
   EventNotify.h \

--- a/lib/ts/Regression.h
+++ b/lib/ts/Regression.h
@@ -26,6 +26,7 @@
 
 #include "ts/ink_platform.h"
 #include "ts/Regex.h"
+#include "ts/Diags.h"
 
 //   Each module should provide one or more regression tests
 //
@@ -60,37 +61,41 @@
 // regression options
 #define REGRESSION_OPT_EXCLUSIVE (1 << 0)
 
+#define RegressionMakeLocation(f) SourceLocation(__FILE__, f, __LINE__)
+
 struct RegressionTest;
 
 typedef void TestFunction(RegressionTest *t, int type, int *status);
 
 struct RegressionTest {
   const char *name;
+  const SourceLocation location;
   TestFunction *function;
   RegressionTest *next;
   int status;
-  int printed;
+  bool printed;
   int opt;
 
-  RegressionTest(const char *name_arg, TestFunction *function_arg, int aopt);
+  RegressionTest(const char *name_arg, const SourceLocation &loc, TestFunction *function_arg, int aopt);
 
   static int final_status;
   static int ran_tests;
   static DFA dfa;
   static RegressionTest *current;
   static int run(const char *name = NULL);
+  static void list();
   static int run_some();
   static int check_status();
 };
 
 #define REGRESSION_TEST(_f)                                             \
   void RegressionTest_##_f(RegressionTest *t, int atype, int *pstatus); \
-  RegressionTest regressionTest_##_f(#_f, &RegressionTest_##_f, 0);     \
+  RegressionTest regressionTest_##_f(#_f, RegressionMakeLocation("RegressionTest_" #_f), &RegressionTest_##_f, 0);     \
   void RegressionTest_##_f
 
 #define EXCLUSIVE_REGRESSION_TEST(_f)                                                      \
   void RegressionTest_##_f(RegressionTest *t, int atype, int *pstatus);                    \
-  RegressionTest regressionTest_##_f(#_f, &RegressionTest_##_f, REGRESSION_OPT_EXCLUSIVE); \
+  RegressionTest regressionTest_##_f(#_f, RegressionMakeLocation("RegressionTest_" #_f), &RegressionTest_##_f, REGRESSION_OPT_EXCLUSIVE); \
   void RegressionTest_##_f
 
 int rprintf(RegressionTest *t, const char *format, ...);

--- a/lib/ts/SourceLocation.cc
+++ b/lib/ts/SourceLocation.cc
@@ -1,0 +1,54 @@
+/** @file
+ *
+ *  A brief file description
+ *
+ *  @section license License
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "SourceLocation.h"
+#include "ink_defs.h"
+#include <stdio.h>
+#include <string.h>
+
+// This method takes a SourceLocation source location data structure and
+// converts it to a human-readable representation, in the buffer <buf>
+// with length <buflen>.  The buffer will always be NUL-terminated, and
+// must always have a length of at least 1.  The buffer address is
+// returned on success.  The routine will only fail if the SourceLocation is
+// not valid, or the buflen is less than 1.
+
+char *
+SourceLocation::str(char *buf, int buflen) const
+{
+  const char *shortname;
+
+  if (!this->valid() || buflen < 1)
+    return (NULL);
+
+  shortname = strrchr(file, '/');
+  shortname = shortname ? (shortname + 1) : file;
+
+  if (func != NULL) {
+    snprintf(buf, buflen, "%s:%d (%s)", shortname, line, func);
+  } else {
+    snprintf(buf, buflen, "%s:%d", shortname, line);
+  }
+  buf[buflen - 1] = NUL;
+  return (buf);
+}

--- a/lib/ts/SourceLocation.h
+++ b/lib/ts/SourceLocation.h
@@ -1,0 +1,60 @@
+/** @file
+ *
+ *  A brief file description
+ *
+ *  @section license License
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef SOURCELOCATION_H_88F6E38C_ACBB_4EFE_8819_71FCB162AE9B
+#define SOURCELOCATION_H_88F6E38C_ACBB_4EFE_8819_71FCB162AE9B
+
+// The SourceLocation class wraps up a source code location, including
+// file name, function name, and line number, and contains a method to
+// format the result into a string buffer.
+
+#define MakeSourceLocation() SourceLocation(__FILE__, __FUNCTION__, __LINE__)
+
+class SourceLocation
+{
+public:
+  const char *file;
+  const char *func;
+  int line;
+
+  bool
+  valid() const
+  {
+    return file && line;
+  }
+
+  SourceLocation(const SourceLocation &rhs) : file(rhs.file), func(rhs.func), line(rhs.line) {}
+  SourceLocation(const char *_file, const char *_func, int _line) : file(_file), func(_func), line(_line) {}
+  SourceLocation &
+  operator=(const SourceLocation &rhs)
+  {
+    this->file = rhs.file;
+    this->func = rhs.func;
+    this->line = rhs.line;
+    return *this;
+  }
+
+  char *str(char *buf, int buflen) const;
+};
+
+#endif /* SOURCELOCATION_H_88F6E38C_ACBB_4EFE_8819_71FCB162AE9B */

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -143,6 +143,7 @@ bool command_valid = false;
 static char const *CMD_VERIFY_CONFIG = "verify_config";
 #if TS_HAS_TESTS
 static char regression_test[1024] = "";
+static int regression_list = 0;
 #endif
 int auto_clear_hostdb_flag = 0;
 extern int fds_limit;
@@ -192,6 +193,7 @@ static const ArgumentDescription argument_descriptions[] = {
 #if TS_HAS_TESTS
   {"regression", 'R', "Regression Level (quick:1..long:3)", "I", &regression_level, "PROXY_REGRESSION", NULL},
   {"regression_test", 'r', "Run Specific Regression Test", "S512", regression_test, "PROXY_REGRESSION_TEST", NULL},
+  {"regression_list", 'l', "List Regression Tests", "T", &regression_list, "PROXY_REGRESSION_LIST", NULL},
 #endif // TS_HAS_TESTS
 
 #if TS_USE_DIAGS
@@ -211,7 +213,7 @@ static const ArgumentDescription argument_descriptions[] = {
   {"read_core", 'c', "Read Core file", "S255", &core_file, NULL, NULL},
 #endif
 
-  {"accept_mss", ' ', "MSS for client connections", "I", &accept_mss, NULL, NULL},
+  {"accept_mss", '-', "MSS for client connections", "I", &accept_mss, NULL, NULL},
   {"poll_timeout", 't', "poll timeout in milliseconds", "I", &poll_timeout, NULL, NULL},
   HELP_ARGUMENT_DESCRIPTION(),
   VERSION_ARGUMENT_DESCRIPTION()};
@@ -1495,6 +1497,14 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   if (cmd_disable_freelist) {
     ink_freelist_init_ops(ink_freelist_malloc_ops());
   }
+
+#if TS_HAS_TESTS
+  if (regression_list) {
+    RegressionTest::list();
+    ::exit(0);
+  }
+#endif
+
   // Specific validity checks.
   if (*conf_dir && command_index != find_cmd_index(CMD_VERIFY_CONFIG)) {
     fprintf(stderr, "-D option can only be used with the %s command\n", CMD_VERIFY_CONFIG);

--- a/proxy/shared/Error.cc
+++ b/proxy/shared/Error.cc
@@ -54,7 +54,7 @@ ErrorClass::operator()(const char *aformat_string, ...)
 void
 ErrorClass::raise(va_list ap, const char * /* prefix ATS_UNUSED */)
 {
-  SrcLoc loc(filename, function_name, line_number);
+  SourceLocation loc(filename, function_name, line_number);
   diags->print_va(NULL, DL_Fatal, &loc, format_string, ap);
 }
 


### PR DESCRIPTION
This looks like:
```
$ ./proxy/traffic_server -l
traffic_server: using root directory '/opt/ats'
SSLReverseHostname SSLCertLookup.cc:432 (RegressionTest_SSLReverseHostname)
SSLWildcardMatch SSLCertLookup.cc:418 (RegressionTest_SSLWildcardMatch)
ram_cache CacheTest.cc:614 (RegressionTest_ram_cache)
cache_disk_replacement_stability CacheTest.cc:402 (RegressionTest_cache_disk_replacement_stability)
DNS DNS.cc:1697 (RegressionTest_DNS)
...
```
We emit the name (for the ``-r`` option) as well as the source location for easy code lookup and the generated function name for easy setting of breakpoints.