### PR TITLE
TS-4355: Change assert condition for TS-3612

### DIFF
--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1568,7 +1568,7 @@ HttpTunnel::main_handler(int event, void *data)
     sm_callback = producer_handler(event, p);
   } else {
     if ((c = get_consumer((VIO *)data)) != 0) {
-      ink_assert(c->write_vio == (VIO *)data);
+      ink_assert(c->write_vio == (VIO *)data || c->vc == ((VIO *)data)->vc_server);
       sm_callback = consumer_handler(event, c);
     } else {
       internal_error(); // do nothing


### PR DESCRIPTION
Originall, the condition of assert in HttpTunnel::main_handler(int event, void *data)
was same to the condition in HttpTunnel::get_consumer(VIO *vio) before TS-3612.
This commit make the condition in HttpTunnel::main_handler(int event, void *data)
same as condition in HttpTunnel::get_consumer(VIO *vio).