### PR TITLE
Improve cache test debugging.

### DIFF
--- a/iocore/cache/CacheTest.cc
+++ b/iocore/cache/CacheTest.cc
@@ -29,10 +29,19 @@
 
 using namespace std;
 
-CacheTestSM::CacheTestSM(RegressionTest *t)
-  : RegressionSM(t), timeout(0), cache_action(0), start_time(0), cache_vc(0), cvio(0), buffer(0), buffer_reader(0), nbytes(-1),
-    repeat_count(0), expect_event(EVENT_NONE), expect_initial_event(EVENT_NONE), initial_event(EVENT_NONE), content_salt(0)
+CacheTestSM::CacheTestSM(RegressionTest *t, const char *name)
+  : RegressionSM(t), cache_test_name(name), timeout(0), cache_action(0), start_time(0), cache_vc(0), cvio(0), buffer(0),
+    buffer_reader(0), nbytes(-1), repeat_count(0), expect_event(EVENT_NONE), expect_initial_event(EVENT_NONE),
+    initial_event(EVENT_NONE), content_salt(0)
 {
+  SET_HANDLER(&CacheTestSM::event_handler);
+}
+
+CacheTestSM::CacheTestSM(const CacheTestSM &ao) : RegressionSM(ao)
+{
+  int o = (int)(((char *)&start_memcpy_on_clone) - ((char *)this));
+  int s = (int)(((char *)&end_memcpy_on_clone) - ((char *)&start_memcpy_on_clone));
+  memcpy(((char *)this) + o, ((char *)&ao) + o, s);
   SET_HANDLER(&CacheTestSM::event_handler);
 }
 
@@ -270,14 +279,6 @@ CacheTestSM::complete(int event)
   return EVENT_DONE;
 }
 
-CacheTestSM::CacheTestSM(const CacheTestSM &ao) : RegressionSM(ao)
-{
-  int o = (int)(((char *)&start_memcpy_on_clone) - ((char *)this));
-  int s = (int)(((char *)&end_memcpy_on_clone) - ((char *)&start_memcpy_on_clone));
-  memcpy(((char *)this) + o, ((char *)&ao) + o, s);
-  SET_HANDLER(&CacheTestSM::event_handler);
-}
-
 EXCLUSIVE_REGRESSION_TEST(cache)(RegressionTest *t, int /* atype ATS_UNUSED */, int *pstatus)
 {
   if (cacheProcessor.IsCacheEnabled() != CACHE_INITIALIZED) {
@@ -385,10 +386,24 @@ EXCLUSIVE_REGRESSION_TEST(cache)(RegressionTest *t, int /* atype ATS_UNUSED */, 
   pread_test.nbytes = 100;
   pread_test.key = large_write_test.key;
 
-  r_sequential(t, write_test.clone(), lookup_test.clone(), r_sequential(t, 10, read_test.clone()), remove_test.clone(),
-               lookup_fail_test.clone(), read_fail_test.clone(), remove_fail_test.clone(), replace_write_test.clone(),
-               replace_test.clone(), replace_read_test.clone(), large_write_test.clone(), pread_test.clone(), NULL_PTR)
-    ->run(pstatus);
+  // clang-format off
+  r_sequential(t,
+      write_test.clone(),
+      lookup_test.clone(),
+      r_sequential(t, 10, read_test.clone()) /* run read_test 10 times */,
+      remove_test.clone(),
+      lookup_fail_test.clone(),
+      read_fail_test.clone(),
+      remove_fail_test.clone(),
+      replace_write_test.clone(),
+      replace_test.clone(),
+      replace_read_test.clone(),
+      large_write_test.clone(),
+      pread_test.clone(),
+      NULL_PTR)
+  ->run(pstatus);
+  // clang-format on
+
   return;
 }
 

--- a/iocore/cache/P_CacheTest.h
+++ b/iocore/cache/P_CacheTest.h
@@ -63,6 +63,10 @@ struct CacheTestHeader {
 
 struct CacheTestSM : public RegressionSM {
   int start_memcpy_on_clone; // place all variables to be copied between these markers
+
+  // Cache test instance name. This is a pointer to a string literal, so copying is safe.
+  const char *cache_test_name;
+
   Action *timeout;
   Action *cache_action;
   ink_hrtime start_time;
@@ -113,12 +117,14 @@ struct CacheTestSM : public RegressionSM {
   void
   run()
   {
+    rprintf(this->t, "running %s (%p)\n", this->cache_test_name, this);
     SCOPED_MUTEX_LOCK(lock, mutex, this_ethread());
     timeout = eventProcessor.schedule_imm(this);
   }
+
   virtual RegressionSM *clone() = 0;
 
-  CacheTestSM(RegressionTest *t);
+  CacheTestSM(RegressionTest *t, const char *name);
   CacheTestSM(const CacheTestSM &ao);
   ~CacheTestSM();
 };
@@ -127,10 +133,13 @@ struct CacheTestSM : public RegressionSM {
 #define CACHE_SM(_t, _sm, _f)                                               \
   struct CacheTestSM__##_sm : public CacheTestSM {                          \
     void                                                                    \
-    make_request_internal() _f CacheTestSM__##_sm(RegressionTest *t)        \
-      : CacheTestSM(t)                                                      \
+    make_request_internal() _f                                              \
+                                                                            \
+      CacheTestSM__##_sm(RegressionTest *t)                                 \
+      : CacheTestSM(t, #_sm)                                                \
     {                                                                       \
     }                                                                       \
+                                                                            \
     CacheTestSM__##_sm(const CacheTestSM__##_sm &xsm) : CacheTestSM(xsm) {} \
     RegressionSM *                                                          \
     clone()                                                                 \

--- a/proxy/RegressionSM.h
+++ b/proxy/RegressionSM.h
@@ -58,7 +58,8 @@ struct RegressionSM : public Continuation {
   int nchildren;
   DynArray<RegressionSM *> children;
   intptr_t n, ichild;
-  bool par, rep;
+  bool parallel;
+  bool repeat;
   Action *pending_action;
 
   int regression_sm_start(int event, void *data);
@@ -69,7 +70,7 @@ struct RegressionSM : public Continuation {
 
   RegressionSM(RegressionTest *at = NULL)
     : t(at), status(REGRESSION_TEST_INPROGRESS), pstatus(0), parent(0), nwaiting(0), nchildren(0), children(0), ichild(0),
-      par(false), rep(false), pending_action(0)
+      parallel(false), repeat(false), pending_action(0)
   {
     mutex = new_ProxyMutex();
   }


### PR DESCRIPTION
The "cache" regression tests consists of a collection of interdependent
test state machines, but there's no test-level debugging. Add some
logging to show when a test state machine is starting up.