### PR TITLE
TS-4388: Fix TSHttpTxnParentProxySet

### DIFF
--- a/iocore/net/Socks.cc
+++ b/iocore/net/Socks.cc
@@ -87,7 +87,7 @@ SocksEntry::findServer()
 
 #ifdef SOCKS_WITH_TS
   if (nattempts == 1) {
-    ink_assert(server_result.r == PARENT_UNDEFINED);
+    ink_assert(server_result.result == PARENT_UNDEFINED);
     server_params->findParent(&req_data, &server_result);
   } else {
     socks_conf_struct *conf = netProcessor.socks_conf_stuff;
@@ -97,12 +97,12 @@ SocksEntry::findServer()
     server_params->markParentDown(&server_result);
 
     if (nattempts > conf->connection_attempts)
-      server_result.r = PARENT_FAIL;
+      server_result.result = PARENT_FAIL;
     else
       server_params->nextParent(&req_data, &server_result);
   }
 
-  switch (server_result.r) {
+  switch (server_result.result) {
   case PARENT_SPECIFIED:
     // Original was inet_addr, but should hostnames work?
     // ats_ip_pton only supports numeric (because other clients

--- a/proxy/InkAPITest.cc
+++ b/proxy/InkAPITest.cc
@@ -55,6 +55,39 @@
 
 #define UTDBG_TAG "sdk_ut"
 
+// Since there's no way to unregister global hooks, tests that register a hook
+// have to co-operate once they are complete by re-enabling and transactions
+// and getting out of the way.
+#define CHECK_SPURIOUS_EVENT(cont, event, edata)                     \
+  if (TSContDataGet(cont) == NULL) {                                 \
+    switch (event) {                                                 \
+    case TS_EVENT_IMMEDIATE:                                         \
+    case TS_EVENT_TIMEOUT:                                           \
+      return TS_EVENT_NONE;                                          \
+    case TS_EVENT_HTTP_SELECT_ALT:                                   \
+      return TS_EVENT_NONE;                                          \
+    case TS_EVENT_HTTP_READ_REQUEST_HDR:                             \
+    case TS_EVENT_HTTP_OS_DNS:                                       \
+    case TS_EVENT_HTTP_SEND_REQUEST_HDR:                             \
+    case TS_EVENT_HTTP_READ_CACHE_HDR:                               \
+    case TS_EVENT_HTTP_READ_RESPONSE_HDR:                            \
+    case TS_EVENT_HTTP_SEND_RESPONSE_HDR:                            \
+    case TS_EVENT_HTTP_REQUEST_TRANSFORM:                            \
+    case TS_EVENT_HTTP_RESPONSE_TRANSFORM:                           \
+    case TS_EVENT_HTTP_TXN_START:                                    \
+    case TS_EVENT_HTTP_TXN_CLOSE:                                    \
+    case TS_EVENT_HTTP_SSN_START:                                    \
+    case TS_EVENT_HTTP_SSN_CLOSE:                                    \
+    case TS_EVENT_HTTP_CACHE_LOOKUP_COMPLETE:                        \
+    case TS_EVENT_HTTP_PRE_REMAP:                                    \
+    case TS_EVENT_HTTP_POST_REMAP:                                   \
+      TSHttpTxnReenable((TSHttpTxn)(edata), TS_EVENT_HTTP_CONTINUE); \
+      return TS_EVENT_NONE;                                          \
+    default:                                                         \
+      break;                                                         \
+    }                                                                \
+  }
+
 /******************************************************************************/
 
 /* Use SDK_RPRINT to report failure or success for each test case */
@@ -2303,6 +2336,7 @@ mytest_handler(TSCont contp, TSEvent event, void *data)
       // transaction is over. clean up.
       synclient_txn_delete(test->browser);
       synserver_delete(test->os);
+      test->os = NULL;
 
       test->magic = MAGIC_DEAD;
       TSfree(test);
@@ -5804,6 +5838,7 @@ ssn_handler(TSCont contp, TSEvent event, void *edata)
       /* Don't need it as didn't initialize the server
          synserver_delete(data->os);
        */
+      data->os = NULL;
       data->magic = MAGIC_DEAD;
       TSfree(data);
       TSContDataSet(contp, NULL);
@@ -5871,8 +5906,11 @@ struct ParentTest {
 static int
 parent_proxy_handler(TSCont contp, TSEvent event, void *edata)
 {
-  ParentTest *ptest = (ParentTest *)TSContDataGet(contp);
+  ParentTest *ptest = NULL;
   TSHttpTxn txnp = (TSHttpTxn)edata;
+
+  CHECK_SPURIOUS_EVENT(contp, event, edata);
+  ptest = (ParentTest *)TSContDataGet(contp);
 
   switch (event) {
   case TS_EVENT_HTTP_READ_REQUEST_HDR:
@@ -5914,11 +5952,13 @@ parent_proxy_handler(TSCont contp, TSEvent event, void *edata)
       // Otherwise the test completed so clean up.
       RecSetRecordInt("proxy.config.http.parent_proxy_routing_enable", ptest->parent_proxy_routing_enable, REC_SOURCE_EXPLICIT);
 
-      ptest->magic = MAGIC_DEAD;
+      TSContDataSet(contp, NULL);
+
       synclient_txn_delete(ptest->browser);
       synserver_delete(ptest->os);
+      ptest->os = NULL;
+      ptest->magic = MAGIC_DEAD;
       TSfree(ptest);
-      TSContDataSet(contp, NULL);
     }
     break;
 
@@ -6017,20 +6057,10 @@ static int
 cache_hook_handler(TSCont contp, TSEvent event, void *edata)
 {
   TSHttpTxn txnp = NULL;
-  CacheTestData *data = (CacheTestData *)TSContDataGet(contp);
+  CacheTestData *data = NULL;
 
-  if (data == NULL) {
-    switch (event) {
-    case TS_EVENT_IMMEDIATE:
-    case TS_EVENT_TIMEOUT:
-      break;
-    case TS_EVENT_HTTP_READ_CACHE_HDR:
-    default:
-      TSHttpTxnReenable((TSHttpTxn)edata, TS_EVENT_HTTP_CONTINUE);
-      break;
-    }
-    return 0;
-  }
+  CHECK_SPURIOUS_EVENT(contp, event, edata);
+  data = (CacheTestData *)TSContDataGet(contp);
 
   switch (event) {
   case TS_EVENT_HTTP_READ_REQUEST_HDR:
@@ -6139,6 +6169,7 @@ cache_hook_handler(TSCont contp, TSEvent event, void *edata)
         data->first_time = false;
         /* Kill the origin server */
         synserver_delete(data->os);
+        data->os = NULL;
 
         /* Send another similar client request */
         synclient_txn_send_request(data->browser2, data->request);
@@ -6523,19 +6554,9 @@ transform_hook_handler(TSCont contp, TSEvent event, void *edata)
 {
   TSHttpTxn txnp = NULL;
   TransformTestData *data = NULL;
+
+  CHECK_SPURIOUS_EVENT(contp, event, edata);
   data = (TransformTestData *)TSContDataGet(contp);
-  if (data == NULL) {
-    switch (event) {
-    case TS_EVENT_IMMEDIATE:
-    case TS_EVENT_TIMEOUT:
-      break;
-    case TS_EVENT_HTTP_READ_RESPONSE_HDR:
-    default:
-      TSHttpTxnReenable((TSHttpTxn)edata, TS_EVENT_HTTP_CONTINUE);
-      break;
-    }
-    return 0;
-  }
 
   switch (event) {
   case TS_EVENT_HTTP_READ_REQUEST_HDR:
@@ -6651,6 +6672,7 @@ transform_hook_handler(TSCont contp, TSEvent event, void *edata)
         return 0;
       }
       synserver_delete(data->os);
+      data->os = NULL;
       data->req_no++;
       TSfree(data->request1);
       TSfree(data->request2);
@@ -6823,20 +6845,8 @@ altinfo_hook_handler(TSCont contp, TSEvent event, void *edata)
   AltInfoTestData *data = NULL;
   TSHttpTxn txnp = NULL;
 
+  CHECK_SPURIOUS_EVENT(contp, event, edata);
   data = (AltInfoTestData *)TSContDataGet(contp);
-  if (data == NULL) {
-    switch (event) {
-    case TS_EVENT_IMMEDIATE:
-    case TS_EVENT_TIMEOUT:
-      break;
-    case TS_EVENT_HTTP_SELECT_ALT:
-      break;
-    default:
-      TSHttpTxnReenable((TSHttpTxn)edata, TS_EVENT_HTTP_CONTINUE);
-      break;
-    }
-    return 0;
-  }
 
   switch (event) {
   case TS_EVENT_HTTP_READ_REQUEST_HDR:
@@ -6928,6 +6938,7 @@ altinfo_hook_handler(TSCont contp, TSEvent event, void *edata)
         data->first_time = false;
         /* Kill the origin server */
         synserver_delete(data->os);
+        data->os = NULL;
         // ink_release_assert(0);
         /* Send another similar client request */
         synclient_txn_send_request(data->browser3, data->request3);
@@ -7044,8 +7055,6 @@ EXCLUSIVE_REGRESSION_TEST(SDK_API_HttpAltInfo)(RegressionTest *test, int /* atyp
 #define TEST_CASE_CONNECT_ID1 9  // TSHttpTxnIntercept
 #define TEST_CASE_CONNECT_ID2 10 // TSHttpTxnServerIntercept
 
-#define SYNSERVER_DUMMY_PORT -1
-
 typedef struct {
   RegressionTest *test;
   int *pstatus;
@@ -7061,8 +7070,11 @@ static int
 cont_test_handler(TSCont contp, TSEvent event, void *edata)
 {
   TSHttpTxn txnp = (TSHttpTxn)edata;
-  ConnectTestData *data = (ConnectTestData *)TSContDataGet(contp);
+  ConnectTestData *data = NULL;
   int request_id = -1;
+
+  CHECK_SPURIOUS_EVENT(contp, event, edata);
+  data = (ConnectTestData *)TSContDataGet(contp);
 
   TSReleaseAssert(data->magic == MAGIC_ALIVE);
   TSReleaseAssert((data->test_case == TEST_CASE_CONNECT_ID1) || (data->test_case == TEST_CASE_CONNECT_ID2));
@@ -7139,12 +7151,10 @@ cont_test_handler(TSCont contp, TSEvent event, void *edata)
       // transaction is over. clean it up.
       synclient_txn_delete(data->browser);
       synserver_delete(data->os);
-
-      // As we registered to a global hook, we may be called back again.
-      // Do not destroy the continuation...
-      // data->magic = MAGIC_DEAD;
-      // TSfree(data);
-      // TSContDataSet(contp, NULL);
+      data->os = NULL;
+      data->magic = MAGIC_DEAD;
+      TSfree(data);
+      TSContDataSet(contp, NULL);
     }
     break;
 

--- a/proxy/InkAPITest.cc
+++ b/proxy/InkAPITest.cc
@@ -5982,12 +5982,6 @@ parent_proxy_handler(TSCont contp, TSEvent event, void *edata)
 
 EXCLUSIVE_REGRESSION_TEST(SDK_API_HttpParentProxySet)(RegressionTest *test, int level, int *pstatus)
 {
-  // Don't enable this test by default until it passes.
-  if (level < REGRESSION_TEST_FATAL) {
-    *pstatus = REGRESSION_TEST_NOT_RUN;
-    return;
-  }
-
   *pstatus = REGRESSION_TEST_INPROGRESS;
 
   TSCont cont = TSContCreate(parent_proxy_handler, TSMutexCreate());

--- a/proxy/ParentConsistentHash.cc
+++ b/proxy/ParentConsistentHash.cc
@@ -236,7 +236,7 @@ ParentConsistentHash::markParentDown(const ParentSelectionPolicy *policy, Parent
   }
   // If we were set through the API we currently have not failover
   //   so just return fail
-  if (result->rec == extApiRecord) {
+  if (result->is_api_result()) {
     return;
   }
 
@@ -312,7 +312,7 @@ ParentConsistentHash::markParentUp(ParentResult *result)
   }
   // If we were set through the API we currently have not failover
   //   so just return fail
-  if (result->rec == extApiRecord) {
+  if (result->is_api_result()) {
     ink_assert(0);
     return;
   }

--- a/proxy/ParentConsistentHash.cc
+++ b/proxy/ParentConsistentHash.cc
@@ -105,9 +105,9 @@ ParentConsistentHash::selectParent(const ParentSelectionPolicy *policy, bool fir
   // Should only get into this state if we are supposed to go direct.
   if (parents[PRIMARY] == NULL && parents[SECONDARY] == NULL) {
     if (result->rec->go_direct == true && result->rec->parent_is_proxy == true) {
-      result->r = PARENT_DIRECT;
+      result->result = PARENT_DIRECT;
     } else {
-      result->r = PARENT_FAIL;
+      result->result = PARENT_FAIL;
     }
     result->hostname = NULL;
     result->port = 0;
@@ -156,7 +156,7 @@ ParentConsistentHash::selectParent(const ParentSelectionPolicy *policy, bool fir
           result->last_parent = pRec->idx;
           result->last_lookup = last_lookup;
           result->retry = parentRetry;
-          result->r = PARENT_SPECIFIED;
+          result->result = PARENT_SPECIFIED;
           Debug("parent_select", "Down parent %s is now retryable, marked it available.", pRec->hostname);
           break;
         }
@@ -196,7 +196,7 @@ ParentConsistentHash::selectParent(const ParentSelectionPolicy *policy, bool fir
 
   // use the available or marked for retry parent.
   if (pRec && (pRec->available || result->retry)) {
-    result->r = PARENT_SPECIFIED;
+    result->result = PARENT_SPECIFIED;
     result->hostname = pRec->hostname;
     result->port = pRec->port;
     result->last_parent = pRec->idx;
@@ -207,9 +207,9 @@ ParentConsistentHash::selectParent(const ParentSelectionPolicy *policy, bool fir
     Debug("parent_select", "Chosen parent: %s.%d", result->hostname, result->port);
   } else {
     if (result->rec->go_direct == true && result->rec->parent_is_proxy == true) {
-      result->r = PARENT_DIRECT;
+      result->result = PARENT_DIRECT;
     } else {
-      result->r = PARENT_FAIL;
+      result->result = PARENT_FAIL;
     }
     result->hostname = NULL;
     result->port = 0;
@@ -230,8 +230,8 @@ ParentConsistentHash::markParentDown(const ParentSelectionPolicy *policy, Parent
 
   //  Make sure that we are being called back with with a
   //   result structure with a parent
-  ink_assert(result->r == PARENT_SPECIFIED);
-  if (result->r != PARENT_SPECIFIED) {
+  ink_assert(result->result == PARENT_SPECIFIED);
+  if (result->result != PARENT_SPECIFIED) {
     return;
   }
   // If we were set through the API we currently have not failover
@@ -306,8 +306,8 @@ ParentConsistentHash::markParentUp(ParentResult *result)
   //  Make sure that we are being called back with with a
   //   result structure with a parent that is being retried
   ink_release_assert(result->retry == true);
-  ink_assert(result->r == PARENT_SPECIFIED);
-  if (result->r != PARENT_SPECIFIED) {
+  ink_assert(result->result == PARENT_SPECIFIED);
+  if (result->result != PARENT_SPECIFIED) {
     return;
   }
   // If we were set through the API we currently have not failover

--- a/proxy/ParentRoundRobin.cc
+++ b/proxy/ParentRoundRobin.cc
@@ -198,7 +198,7 @@ ParentRoundRobin::markParentDown(const ParentSelectionPolicy *policy, ParentResu
   }
   // If we were set through the API we currently have not failover
   //   so just return fail
-  if (result->rec == extApiRecord) {
+  if (result->is_api_result()) {
     return;
   }
 
@@ -257,7 +257,7 @@ ParentRoundRobin::markParentUp(ParentResult *result)
   }
   // If we were set through the API we currently have not failover
   //   so just return fail
-  if (result->rec == extApiRecord) {
+  if (result->is_api_result()) {
     ink_assert(0);
     return;
   }

--- a/proxy/ParentRoundRobin.cc
+++ b/proxy/ParentRoundRobin.cc
@@ -69,9 +69,9 @@ ParentRoundRobin::selectParent(const ParentSelectionPolicy *policy, bool first_c
       ink_assert(result->rec->go_direct == true);
       // Could not find a parent
       if (result->rec->go_direct == true && result->rec->parent_is_proxy == true) {
-        result->r = PARENT_DIRECT;
+        result->result = PARENT_DIRECT;
       } else {
-        result->r = PARENT_FAIL;
+        result->result = PARENT_FAIL;
       }
 
       result->hostname = NULL;
@@ -112,9 +112,9 @@ ParentRoundRobin::selectParent(const ParentSelectionPolicy *policy, bool first_c
       if (bypass_ok == true) {
         // Could not find a parent
         if (result->rec->go_direct == true && result->rec->parent_is_proxy == true) {
-          result->r = PARENT_DIRECT;
+          result->result = PARENT_DIRECT;
         } else {
-          result->r = PARENT_FAIL;
+          result->result = PARENT_FAIL;
         }
         result->hostname = NULL;
         result->port = 0;
@@ -153,7 +153,7 @@ ParentRoundRobin::selectParent(const ParentSelectionPolicy *policy, bool first_c
     }
 
     if (parentUp == true) {
-      result->r = PARENT_SPECIFIED;
+      result->result = PARENT_SPECIFIED;
       result->hostname = result->rec->parents[cur_index].hostname;
       result->port = result->rec->parents[cur_index].port;
       result->last_parent = cur_index;
@@ -167,9 +167,9 @@ ParentRoundRobin::selectParent(const ParentSelectionPolicy *policy, bool first_c
   } while ((unsigned int)cur_index != result->start_parent);
 
   if (result->rec->go_direct == true && result->rec->parent_is_proxy == true) {
-    result->r = PARENT_DIRECT;
+    result->result = PARENT_DIRECT;
   } else {
-    result->r = PARENT_FAIL;
+    result->result = PARENT_FAIL;
   }
 
   result->hostname = NULL;
@@ -192,8 +192,8 @@ ParentRoundRobin::markParentDown(const ParentSelectionPolicy *policy, ParentResu
   Debug("parent_select", "Starting ParentRoundRobin::markParentDown()");
   //  Make sure that we are being called back with with a
   //   result structure with a parent
-  ink_assert(result->r == PARENT_SPECIFIED);
-  if (result->r != PARENT_SPECIFIED) {
+  ink_assert(result->result == PARENT_SPECIFIED);
+  if (result->result != PARENT_SPECIFIED) {
     return;
   }
   // If we were set through the API we currently have not failover
@@ -251,8 +251,8 @@ ParentRoundRobin::markParentUp(ParentResult *result)
   //  Make sure that we are being called back with with a
   //   result structure with a parent that is being retried
   ink_release_assert(result->retry == true);
-  ink_assert(result->r == PARENT_SPECIFIED);
-  if (result->r != PARENT_SPECIFIED) {
+  ink_assert(result->result == PARENT_SPECIFIED);
+  if (result->result != PARENT_SPECIFIED) {
     return;
   }
   // If we were set through the API we currently have not failover

--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -119,11 +119,7 @@ ParentConfigParams::findParent(HttpRequestData *rdata, ParentResult *result)
     return;
   }
   // Initialize the result structure
-  result->rec = NULL;
-  result->line_number = 0xffffffff;
-  result->wrap_around = false;
-  result->start_parent = 0;
-  result->last_parent = 0;
+  result->reset();
 
   // Check to see if the parent was set through the
   //   api

--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -195,7 +195,7 @@ ParentConfigParams::nextParent(HttpRequestData *rdata, ParentResult *result)
   }
   // If we were set through the API we currently have not failover
   //   so just return fail
-  if (result->rec == extApiRecord) {
+  if (result->is_api_result()) {
     Debug("parent_select", "Retry result for %s was %s", rdata->get_host(), ParentResultStr[result->result]);
     result->result = PARENT_FAIL;
     return;

--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -110,12 +110,12 @@ ParentConfigParams::findParent(HttpRequestData *rdata, ParentResult *result)
   ParentRecord *rec;
 
   Debug("parent_select", "In ParentConfigParams::findParent(): parent_table: %p.", parent_table);
-  ink_assert(result->r == PARENT_UNDEFINED);
+  ink_assert(result->result == PARENT_UNDEFINED);
 
   // Check to see if we are enabled
   Debug("parent_select", "policy.ParentEnable: %d", policy.ParentEnable);
   if (policy.ParentEnable == 0) {
-    result->r = PARENT_DIRECT;
+    result->result = PARENT_DIRECT;
     return;
   }
   // Initialize the result structure
@@ -128,7 +128,7 @@ ParentConfigParams::findParent(HttpRequestData *rdata, ParentResult *result)
   // Check to see if the parent was set through the
   //   api
   if (apiParentExists(rdata)) {
-    result->r = PARENT_SPECIFIED;
+    result->result = PARENT_SPECIFIED;
     result->hostname = rdata->api_info->parent_proxy_name;
     result->port = rdata->api_info->parent_proxy_port;
     result->rec = extApiRecord;
@@ -148,7 +148,7 @@ ParentConfigParams::findParent(HttpRequestData *rdata, ParentResult *result)
     if (defaultPtr != NULL) {
       rec = result->rec = defaultPtr;
     } else {
-      result->r = PARENT_DIRECT;
+      result->result = PARENT_DIRECT;
       Debug("parent_select", "Returning PARENT_DIRECT (no parents were found)");
       return;
     }
@@ -160,17 +160,17 @@ ParentConfigParams::findParent(HttpRequestData *rdata, ParentResult *result)
 
   const char *host = rdata->get_host();
 
-  switch (result->r) {
+  switch (result->result) {
   case PARENT_UNDEFINED:
     Debug("parent_select", "PARENT_UNDEFINED");
-    Debug("parent_select", "Result for %s was %s", host, ParentResultStr[result->r]);
+    Debug("parent_select", "Result for %s was %s", host, ParentResultStr[result->result]);
     break;
   case PARENT_FAIL:
     Debug("parent_select", "PARENT_FAIL");
     break;
   case PARENT_DIRECT:
     Debug("parent_select", "PARENT_DIRECT");
-    Debug("parent_select", "Result for %s was %s", host, ParentResultStr[result->r]);
+    Debug("parent_select", "Result for %s was %s", host, ParentResultStr[result->result]);
     break;
   case PARENT_SPECIFIED:
     Debug("parent_select", "PARENT_SPECIFIED");
@@ -192,19 +192,19 @@ ParentConfigParams::nextParent(HttpRequestData *rdata, ParentResult *result)
 
   //  Make sure that we are being called back with a
   //   result structure with a parent
-  ink_assert(result->r == PARENT_SPECIFIED);
-  if (result->r != PARENT_SPECIFIED) {
-    result->r = PARENT_FAIL;
+  ink_assert(result->result == PARENT_SPECIFIED);
+  if (result->result != PARENT_SPECIFIED) {
+    result->result = PARENT_FAIL;
     return;
   }
   // If we were set through the API we currently have not failover
   //   so just return fail
   if (result->rec == extApiRecord) {
-    Debug("parent_select", "Retry result for %s was %s", rdata->get_host(), ParentResultStr[result->r]);
-    result->r = PARENT_FAIL;
+    Debug("parent_select", "Retry result for %s was %s", rdata->get_host(), ParentResultStr[result->result]);
+    result->result = PARENT_FAIL;
     return;
   }
-  Debug("parent_select", "ParentConfigParams::nextParent(): result->r: %d, tablePtr: %p", result->r, tablePtr);
+  Debug("parent_select", "ParentConfigParams::nextParent(): result->r: %d, tablePtr: %p", result->result, tablePtr);
 
   // Find the next parent in the array
   Debug("parent_select", "Calling selectParent() from nextParent");
@@ -212,18 +212,18 @@ ParentConfigParams::nextParent(HttpRequestData *rdata, ParentResult *result)
 
   const char *host = rdata->get_host();
 
-  switch (result->r) {
+  switch (result->result) {
   case PARENT_UNDEFINED:
     Debug("parent_select", "PARENT_UNDEFINED");
-    Debug("parent_select", "Retry result for %s was %s", host, ParentResultStr[result->r]);
+    Debug("parent_select", "Retry result for %s was %s", host, ParentResultStr[result->result]);
     break;
   case PARENT_FAIL:
     Debug("parent_select", "PARENT_FAIL");
-    Debug("parent_select", "Retry result for %s was %s", host, ParentResultStr[result->r]);
+    Debug("parent_select", "Retry result for %s was %s", host, ParentResultStr[result->result]);
     break;
   case PARENT_DIRECT:
     Debug("parent_select", "PARENT_DIRECT");
-    Debug("parent_select", "Retry result for %s was %s", host, ParentResultStr[result->r]);
+    Debug("parent_select", "Retry result for %s was %s", host, ParentResultStr[result->result]);
     break;
   case PARENT_SPECIFIED:
     Debug("parent_select", "Retry result for %s was parent %s:%d", host, result->hostname, result->port);
@@ -242,7 +242,7 @@ ParentConfigParams::parentExists(HttpRequestData *rdata)
 
   findParent(rdata, &result);
 
-  if (result.r == PARENT_SPECIFIED) {
+  if (result.result == PARENT_SPECIFIED) {
     return true;
   } else {
     return false;
@@ -1308,7 +1308,7 @@ verify(ParentResult *r, ParentResultType e, const char *h, int p)
 {
   if (is_debug_tag_set("parent_select"))
     show_result(r);
-  return (r->r != e) ? 0 : ((e != PARENT_SPECIFIED) ? 1 : (strcmp(r->hostname, h) ? 0 : ((r->port == p) ? 1 : 0)));
+  return (r->result != e) ? 0 : ((e != PARENT_SPECIFIED) ? 1 : (strcmp(r->hostname, h) ? 0 : ((r->port == p) ? 1 : 0)));
 }
 
 // br creates an HttpRequestData object
@@ -1330,7 +1330,7 @@ br(HttpRequestData *h, const char *os_hostname, sockaddr const *dest_ip)
 void
 show_result(ParentResult *p)
 {
-  switch (p->r) {
+  switch (p->result) {
   case PARENT_UNDEFINED:
     printf("result is PARENT_UNDEFINED\n");
     break;

--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -31,10 +31,6 @@
 #include "HTTP.h"
 #include "HttpTransact.h"
 
-#define PARENT_RegisterConfigUpdateFunc REC_RegisterConfigUpdateFunc
-#define PARENT_ReadConfigInteger REC_ReadConfigInteger
-#define PARENT_ReadConfigStringAlloc REC_ReadConfigStringAlloc
-
 #define MAX_SIMPLE_RETRIES 5
 #define MAX_UNAVAILABLE_SERVER_RETRIES 5
 
@@ -74,19 +70,19 @@ ParentSelectionPolicy::ParentSelectionPolicy()
   int32_t dns_parent_only = 0;
 
   // Handle parent timeout
-  PARENT_ReadConfigInteger(retry_time, retry_var);
+  REC_ReadConfigInteger(retry_time, retry_var);
   ParentRetryTime = retry_time;
 
   // Handle parent enable
-  PARENT_ReadConfigInteger(enable, enable_var);
+  REC_ReadConfigInteger(enable, enable_var);
   ParentEnable = enable;
 
   // Handle the fail threshold
-  PARENT_ReadConfigInteger(fail_threshold, threshold_var);
+  REC_ReadConfigInteger(fail_threshold, threshold_var);
   FailThreshold = fail_threshold;
 
   // Handle dns parent only
-  PARENT_ReadConfigInteger(dns_parent_only, dns_parent_only_var);
+  REC_ReadConfigInteger(dns_parent_only, dns_parent_only_var);
   DNS_ParentOnly = dns_parent_only;
 }
 
@@ -95,7 +91,7 @@ ParentConfigParams::ParentConfigParams(P_table *_parent_table) : parent_table(_p
   char *default_val = NULL;
 
   // Handle default parent
-  PARENT_ReadConfigStringAlloc(default_val, default_var);
+  REC_ReadConfigStringAlloc(default_val, default_var);
   DefaultParent = createDefaultParent(default_val);
   ats_free(default_val);
 }
@@ -829,7 +825,7 @@ SocksServerConfig::reconfigure()
   ink_assert(params != NULL);
 
   // Handle default parent
-  PARENT_ReadConfigStringAlloc(default_val, "proxy.config.socks.default_servers");
+  REC_ReadConfigStringAlloc(default_val, "proxy.config.socks.default_servers");
   params->DefaultParent = createDefaultParent(default_val);
   ats_free(default_val);
 
@@ -839,7 +835,7 @@ SocksServerConfig::reconfigure()
     setup_socks_servers(params->parent_table->ipMatch->data_array, params->parent_table->ipMatch->array_len);
 
   // Handle parent timeout
-  PARENT_ReadConfigInteger(retry_time, "proxy.config.socks.server_retry_time");
+  REC_ReadConfigInteger(retry_time, "proxy.config.socks.server_retry_time");
   params->policy.ParentRetryTime = retry_time;
 
   // Handle parent enable
@@ -847,7 +843,7 @@ SocksServerConfig::reconfigure()
   params->policy.ParentEnable = 1;
 
   // Handle the fail threshold
-  PARENT_ReadConfigInteger(fail_threshold, "proxy.config.socks.server_fail_threshold");
+  REC_ReadConfigInteger(fail_threshold, "proxy.config.socks.server_fail_threshold");
   params->policy.FailThreshold = fail_threshold;
 
   // Handle dns parent only

--- a/proxy/ParentSelection.h
+++ b/proxy/ParentSelection.h
@@ -115,8 +115,8 @@ class ParentRecord : public ControlBase
 public:
   ParentRecord()
     : parents(NULL), secondary_parents(NULL), num_parents(0), num_secondary_parents(0), ignore_query(false), rr_next(0),
-      go_direct(true), parent_is_proxy(true), selection_strategy(NULL), unavailable_server_retry_responses(NULL), parent_retry(0),
-      max_simple_retries(1), max_unavailable_server_retries(1)
+      go_direct(true), parent_is_proxy(true), selection_strategy(NULL), unavailable_server_retry_responses(NULL),
+      parent_retry(PARENT_RETRY_NONE), max_simple_retries(1), max_unavailable_server_retries(1)
   {
   }
 
@@ -146,7 +146,7 @@ public:
   bool parent_is_proxy;
   ParentSelectionStrategy *selection_strategy;
   UnavailableServerResponseCodes *unavailable_server_retry_responses;
-  int parent_retry;
+  ParentRetry_t parent_retry;
   int max_simple_retries;
   int max_unavailable_server_retries;
 };
@@ -173,6 +173,82 @@ struct ParentResult {
     result = PARENT_UNDEFINED;
   }
 
+  bool
+  is_api_result() const
+  {
+    return rec == extApiRecord;
+  }
+
+  // Do we have some result?
+  bool
+  is_some() const
+  {
+    if (rec == NULL) {
+      // If we don't have a result, we either haven't done a parent
+      // lookup yet (PARENT_UNDEFINED), or the lookup didn't match
+      // anything (PARENT_DIRECT).
+      ink_assert(result == PARENT_UNDEFINED || result == PARENT_DIRECT);
+      return false;
+    }
+
+    return true;
+  }
+
+  bool
+  parent_is_proxy() const
+  {
+    // Parents set by the TSHttpTxnParentProxySet API are always considered proxies rather than origins.
+    return is_api_result() ? true : rec->parent_is_proxy;
+  }
+
+  unsigned
+  retry_type() const
+  {
+    return is_api_result() ? PARENT_RETRY_NONE : rec->parent_retry;
+  }
+
+  unsigned
+  max_retries(ParentRetry_t method) const
+  {
+    // There's no API for specifying the retries, so you get 0.
+    if (is_api_result()) {
+      return 0;
+    }
+
+    switch (method) {
+    case PARENT_RETRY_NONE:
+      return 0;
+    case PARENT_RETRY_SIMPLE:
+      return rec->max_simple_retries;
+    case PARENT_RETRY_UNAVAILABLE_SERVER:
+      return rec->max_unavailable_server_retries;
+    case PARENT_RETRY_BOTH:
+      return std::max(rec->max_unavailable_server_retries, rec->max_simple_retries);
+    }
+
+    return 0;
+  }
+
+  bool
+  response_is_retryable(HTTPStatus response_code) const
+  {
+    return (retry_type() & PARENT_RETRY_UNAVAILABLE_SERVER) && rec->unavailable_server_retry_responses->contains(response_code);
+  }
+
+  bool
+  bypass_ok() const
+  {
+    if (is_api_result()) {
+      return false;
+    } else {
+      // Caller should check for a valid result beforehand.
+      ink_assert(result != PARENT_UNDEFINED);
+      ink_assert(is_some());
+      return rec->bypass_ok();
+    }
+  }
+
+private:
   // Internal use only
   //   Not to be modified by HTTP
   int line_number;
@@ -181,6 +257,11 @@ struct ParentResult {
   uint32_t start_parent;
   bool wrap_around;
   int last_lookup; // state for for consistent hash.
+
+  friend class ParentConsistentHash;
+  friend class ParentRoundRobin;
+  friend class ParentConfigParams;
+  friend class ParentRecord;
 };
 
 struct ParentSelectionPolicy {

--- a/proxy/ParentSelection.h
+++ b/proxy/ParentSelection.h
@@ -158,17 +158,20 @@ public:
 ParentRecord *const extApiRecord = (ParentRecord *)0xeeeeffff;
 
 struct ParentResult {
-  ParentResult()
-    : result(PARENT_UNDEFINED), hostname(NULL), port(0), retry(false), line_number(0), rec(NULL), last_parent(0), start_parent(0),
-      wrap_around(false), last_lookup(0)
-  {
-  }
-
+  ParentResult() { reset(); }
   // For outside consumption
   ParentResultType result;
   const char *hostname;
   int port;
   bool retry;
+
+  void
+  reset()
+  {
+    ink_zero(*this);
+    line_number = -1;
+    result = PARENT_UNDEFINED;
+  }
 
   // Internal use only
   //   Not to be modified by HTTP

--- a/proxy/ParentSelection.h
+++ b/proxy/ParentSelection.h
@@ -159,13 +159,13 @@ ParentRecord *const extApiRecord = (ParentRecord *)0xeeeeffff;
 
 struct ParentResult {
   ParentResult()
-    : r(PARENT_UNDEFINED), hostname(NULL), port(0), retry(false), line_number(0), rec(NULL), last_parent(0), start_parent(0),
+    : result(PARENT_UNDEFINED), hostname(NULL), port(0), retry(false), line_number(0), rec(NULL), last_parent(0), start_parent(0),
       wrap_around(false), last_lookup(0)
   {
   }
 
   // For outside consumption
-  ParentResultType r;
+  ParentResultType result;
   const char *hostname;
   int port;
   bool retry;

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -888,8 +888,6 @@ HttpConfig::startup()
   HttpEstablishStaticConfigLongLong(c.origin_min_keep_alive_connections, "proxy.config.http.origin_min_keep_alive_connections");
   HttpEstablishStaticConfigLongLong(c.oride.attach_server_session_to_client, "proxy.config.http.attach_server_session_to_client");
 
-  HttpEstablishStaticConfigByte(c.parent_proxy_routing_enable, "proxy.config.http.parent_proxy_routing_enable");
-
   // Wank me.
   HttpEstablishStaticConfigByte(c.disable_ssl_parenting, "proxy.local.http.parent_proxy.disable_connect_tunneling");
   HttpEstablishStaticConfigByte(c.no_dns_forward_to_parent, "proxy.config.http.no_dns_just_forward_to_parent");
@@ -1173,7 +1171,6 @@ HttpConfig::reconfigure()
     params->origin_min_keep_alive_connections = params->oride.origin_max_connections;
   }
 
-  params->parent_proxy_routing_enable = INT_TO_BOOL(m_master.parent_proxy_routing_enable);
   params->enable_url_expandomatic = INT_TO_BOOL(m_master.enable_url_expandomatic);
 
   params->oride.insert_request_via_string = m_master.oride.insert_request_via_string;

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -638,7 +638,6 @@ public:
   MgmtInt origin_min_keep_alive_connections; // TODO: This one really ought to be overridable, but difficult right now.
   MgmtInt max_websocket_connections;
 
-  MgmtByte parent_proxy_routing_enable;
   MgmtByte disable_ssl_parenting;
 
   MgmtByte enable_url_expandomatic;
@@ -852,9 +851,9 @@ extern volatile int32_t icp_dynamic_enabled;
 /////////////////////////////////////////////////////////////
 inline HttpConfigParams::HttpConfigParams()
   : proxy_hostname(NULL), proxy_hostname_len(0), server_max_connections(0), origin_min_keep_alive_connections(0),
-    max_websocket_connections(-1), parent_proxy_routing_enable(0), disable_ssl_parenting(0), enable_url_expandomatic(0),
-    no_dns_forward_to_parent(0), uncacheable_requests_bypass_parent(1), no_origin_server_dns(0), use_client_target_addr(0),
-    use_client_source_port(0), proxy_request_via_string(NULL), proxy_request_via_string_len(0), proxy_response_via_string(NULL),
+    max_websocket_connections(-1), disable_ssl_parenting(0), enable_url_expandomatic(0), no_dns_forward_to_parent(0),
+    uncacheable_requests_bypass_parent(1), no_origin_server_dns(0), use_client_target_addr(0), use_client_source_port(0),
+    proxy_request_via_string(NULL), proxy_request_via_string_len(0), proxy_response_via_string(NULL),
     proxy_response_via_string_len(0), url_expansions_string(NULL), url_expansions(NULL), num_url_expansions(0),
     session_auth_cache_keep_alive_enabled(1), transaction_active_timeout_in(900), accept_no_activity_timeout(120),
     parent_connect_attempts(4), per_parent_connect_attempts(2), parent_connect_timeout(30), anonymize_other_header_list(NULL),

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -7107,7 +7107,7 @@ HttpSM::set_next_state()
       call_transact_and_set_next_state(HttpTransact::HandleFiltering);
       break;
     } else if (t_state.http_config_param->use_client_target_addr == 2 && !t_state.url_remap_success &&
-               t_state.parent_result.r != PARENT_SPECIFIED && t_state.client_info.is_transparent &&
+               t_state.parent_result.result != PARENT_SPECIFIED && t_state.client_info.is_transparent &&
                t_state.dns_info.os_addr_style == HttpTransact::DNSLookupInfo::OS_ADDR_TRY_DEFAULT &&
                ats_is_ip(addr = t_state.state_machine->ua_session->get_netvc()->get_local_addr())) {
       /* If the connection is client side transparent and the URL
@@ -7135,7 +7135,7 @@ HttpSM::set_next_state()
       t_state.dns_info.os_addr_style = HttpTransact::DNSLookupInfo::OS_ADDR_TRY_CLIENT;
       call_transact_and_set_next_state(NULL);
       break;
-    } else if (t_state.parent_result.r == PARENT_UNDEFINED && t_state.dns_info.lookup_success) {
+    } else if (t_state.parent_result.result == PARENT_UNDEFINED && t_state.dns_info.lookup_success) {
       // Already set, and we don't have a parent proxy to lookup
       ink_assert(ats_is_ip(t_state.host_db_info.ip()));
       DebugSM("dns", "[HttpTransact::HandleRequest] Skipping DNS lookup, provided by plugin");
@@ -7647,7 +7647,7 @@ HttpSM::redirect_request(const char *redirect_url, const int redirect_len)
   // we want to close the server session
   // will do that in handle_api_return under the
   // HttpTransact::SM_ACTION_REDIRECT_READ state
-  t_state.parent_result.r = PARENT_UNDEFINED;
+  t_state.parent_result.result = PARENT_UNDEFINED;
   t_state.request_sent_time = 0;
   t_state.response_received_time = 0;
   t_state.cache_info.write_lock_state = HttpTransact::CACHE_WL_INIT;

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -7647,7 +7647,7 @@ HttpSM::redirect_request(const char *redirect_url, const int redirect_len)
   // we want to close the server session
   // will do that in handle_api_return under the
   // HttpTransact::SM_ACTION_REDIRECT_READ state
-  t_state.parent_result.result = PARENT_UNDEFINED;
+  t_state.parent_result.reset();
   t_state.request_sent_time = 0;
   t_state.response_received_time = 0;
   t_state.cache_info.write_lock_state = HttpTransact::CACHE_WL_INIT;

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -686,9 +686,9 @@ public:
     ConnectionAttributes *server;
     ink_time_t now;
     ServerState_t state;
-    int attempts;
-    int simple_retry_attempts;
-    int unavailable_server_retry_attempts;
+    unsigned attempts;
+    unsigned simple_retry_attempts;
+    unsigned unavailable_server_retry_attempts;
     ParentOriginRetry_t retry_type;
 
     _CurrentInfo()
@@ -1114,7 +1114,7 @@ public:
   static void handle_response_from_parent(State *s);
   static void handle_response_from_server(State *s);
   static void delete_server_rr_entry(State *s, int max_retries);
-  static void retry_server_connection_not_open(State *s, ServerState_t conn_state, int max_retries);
+  static void retry_server_connection_not_open(State *s, ServerState_t conn_state, unsigned max_retries);
   static void handle_server_connection_not_open(State *s);
   static void handle_forward_server_connection_open(State *s);
   static void handle_cache_operation_on_forward_server_response(State *s);


### PR DESCRIPTION
This PR fixes ``TSHttpTxnParentProxySet``.

The first two commits are minor cleanups of cruft. The third one fixes the API tests so that they don't interfere with each other when they register multiple global hooks. The final one actually fixes the ``TSHttpTxnParentProxySet`` API, primarily by restricting access to private ``ParentResult`` data and providing accessors that enforce the correct policy.

I've tested that this works correctly with the tests and with my plugin. I don't have any way to test that I haven't broken the various parent retry features.