### PR TITLE
TS-4397: Fix build on i386 caused by type mismatch

### DIFF
--- a/cmd/traffic_manager/metrics.cc
+++ b/cmd/traffic_manager/metrics.cc
@@ -336,7 +336,7 @@ metrics_binding_initialize(BindingInstance &binding)
   binding.bind_function("metrics.cluster.sum", metrics_cluster_sum);
 
   binding.bind_constant("metrics.now.msec", timestamp_now_msec());
-  binding.bind_constant("metrics.update.pass", int64_t(0));
+  binding.bind_constant("metrics.update.pass", lua_Integer(0));
 
   // Stash a backpointer to the evaluators.
   binding.attach_ptr("evaluators", new EvaluatorList());


### PR DESCRIPTION
It seems lua_Integer is 32-Bit on i386 while it's 54-Bit on x86-64 causing the existing code to fail with:

```
metrics.cc: In function ‘bool metrics_binding_initialize(BindingInstance&)’:
metrics.cc:339:58: error: call of overloaded ‘bind_constant(const char [20], int64_t)’ is ambiguous
   binding.bind_constant("metrics.update.pass", int64_t(0));
                                                          ^
metrics.cc:339:58: note: candidates are:
In file included from metrics.cc:29:0:
../../lib/bindings/bindings.h:44:8: note: bool BindingInstance::bind_constant(const char*, lua_Integer)
   bool bind_constant(const char *name, lua_Integer value);
        ^
../../lib/bindings/bindings.h:45:8: note: bool BindingInstance::bind_constant(const char*, const char*)
   bool bind_constant(const char *name, const char *value);
        ^
```

See [Bug TS-4397](https://issues.apache.org/jira/browse/TS-4397) for more info.