### PR TITLE
TS-4380: traffic_ctl support for server start and stop

### DIFF
--- a/cmd/traffic_ctl/server.cc
+++ b/cmd/traffic_ctl/server.cc
@@ -26,16 +26,16 @@
 static int drain = 0;
 static int manager = 0;
 
-const ArgumentDescription opts[] = {
-  {"drain", '-', "Wait for client connections to drain before restarting", "F", &drain, NULL, NULL},
-  {"manager", '-', "Restart traffic_manager as well as traffic_server", "F", &manager, NULL, NULL},
-};
-
 static int
 restart(unsigned argc, const char **argv, unsigned flags)
 {
   TSMgmtError error;
   const char *usage = (flags & TS_RESTART_OPT_CLUSTER) ? "cluster restart [OPTIONS]" : "server restart [OPTIONS]";
+
+  const ArgumentDescription opts[] = {
+    {"drain", '-', "Wait for client connections to drain before restarting", "F", &drain, NULL, NULL},
+    {"manager", '-', "Restart traffic_manager as well as traffic_server", "F", &manager, NULL, NULL},
+  };
 
   if (!CtrlProcessArguments(argc, argv, opts, countof(opts)) || n_file_arguments != 0) {
     return CtrlCommandUsage(usage, opts, countof(opts));
@@ -116,6 +116,57 @@ server_status(unsigned argc, const char **argv)
   return CTRL_EX_OK;
 }
 
+static int
+server_stop(unsigned argc, const char **argv)
+{
+  TSMgmtError error;
+
+  // I am not sure whether it really makes sense to add the --drain option here.
+  // TSProxyStateSet() is a synchronous API, returning only after the proxy has
+  // been shut down. However, draining can take a long time and we don't want
+  // to wait for it. Maybe the right approach is to make the stop async.
+  if (!CtrlProcessArguments(argc, argv, NULL, 0) || n_file_arguments != 0) {
+    return CtrlCommandUsage("server stop");
+  }
+
+  error = TSProxyStateSet(TS_PROXY_OFF, TS_CACHE_CLEAR_NONE);
+  if (error != TS_ERR_OKAY) {
+    CtrlMgmtError(error, "server stop failed");
+    return CTRL_EX_ERROR;
+  }
+
+  return CTRL_EX_OK;
+}
+
+static int
+server_start(unsigned argc, const char **argv)
+{
+  TSMgmtError error;
+  int cache = 0;
+  int hostdb = 0;
+  unsigned clear = TS_CACHE_CLEAR_NONE;
+
+  const ArgumentDescription opts[] = {
+    {"clear-cache", '-', "Clear the disk cache on startup", "F", &cache, NULL, NULL},
+    {"clear-hostdb", '-', "Clear the DNS cache on startup", "F", &hostdb, NULL, NULL},
+  };
+
+  if (!CtrlProcessArguments(argc, argv, opts, countof(opts)) || n_file_arguments != 0) {
+    return CtrlCommandUsage("server start [OPTIONS]", opts, countof(opts));
+  }
+
+  clear |= cache ? TS_CACHE_CLEAR_CACHE : TS_CACHE_CLEAR_NONE;
+  clear |= hostdb ? TS_CACHE_CLEAR_HOSTDB : TS_CACHE_CLEAR_NONE;
+
+  error = TSProxyStateSet(TS_PROXY_ON, clear);
+  if (error != TS_ERR_OKAY) {
+    CtrlMgmtError(error, "server start failed");
+    return CTRL_EX_ERROR;
+  }
+
+  return CTRL_EX_OK;
+}
+
 int
 subcommand_cluster(unsigned argc, const char **argv)
 {
@@ -131,11 +182,11 @@ int
 subcommand_server(unsigned argc, const char **argv)
 {
   const subcommand commands[] = {
-    {server_restart, "restart", "Restart Traffic Server"},
     {server_backtrace, "backtrace", "Show a full stack trace of the traffic_server process"},
+    {server_restart, "restart", "Restart Traffic Server"},
+    {server_start, "start", "Start the proxy"},
     {server_status, "status", "Show the proxy status"},
-
-    /* XXX do the 'shutdown' and 'startup' commands make sense? */
+    {server_stop, "stop", "Stop the proxy"},
   };
 
   return CtrlGenericSubcommand("server", commands, countof(commands), argc, argv);

--- a/cmd/traffic_line/traffic_line.cc
+++ b/cmd/traffic_line/traffic_line.cc
@@ -66,13 +66,13 @@ handleArgInvocation()
   } else if (ShutdownMgmtLocal == 1) {
     return TSRestart(restart);
   } else if (Shutdown == 1) {
-    return TSProxyStateSet(TS_PROXY_OFF, TS_CACHE_CLEAR_OFF);
+    return TSProxyStateSet(TS_PROXY_OFF, TS_CACHE_CLEAR_NONE);
   } else if (BounceCluster == 1) {
     return TSBounce(restart | TS_RESTART_OPT_CLUSTER);
   } else if (BounceLocal == 1) {
     return TSBounce(restart);
   } else if (Startup == 1) {
-    return TSProxyStateSet(TS_PROXY_ON, TS_CACHE_CLEAR_OFF);
+    return TSProxyStateSet(TS_PROXY_ON, TS_CACHE_CLEAR_NONE);
   } else if (ClearCluster == 1) {
     return TSStatsReset(true, NULL);
   } else if (ClearNode == 1) {

--- a/doc/appendices/command-line/traffic_ctl.en.rst
+++ b/doc/appendices/command-line/traffic_ctl.en.rst
@@ -213,9 +213,28 @@ traffic_ctl server
     :program:`traffic_manager` is also restarted.
 
 .. program:: traffic_ctl server
+.. option:: start
+
+   Start :program:`traffic_server` if it is already running.
+
+.. program:: traffic_ctl server start
+.. option:: --clear-cache
+
+   Clear the disk cache upon startup.
+
+.. option:: --clear-hostdb
+
+   Clear the DNS resolver cache upon startup.
+
+.. program:: traffic_ctl server
 .. option:: status
 
    Show the current proxy server status, indicating if we're running or not.
+
+.. program:: traffic_ctl server
+.. option:: stop
+
+   Stop the running :program:`traffic_server` process.
 
 .. program:: traffic_ctl server
 .. option:: backtrace

--- a/mgmt/WebMgmtUtils.cc
+++ b/mgmt/WebMgmtUtils.cc
@@ -1011,38 +1011,6 @@ substituteForHTMLChars(const char *buffer)
   return safeBuf;
 }
 
-// bool ProxyShutdown()
-//
-//  Attempts to turn the proxy off.  Returns
-//    true if the proxy is off when the call returns
-//    and false if it is still on
-//
-bool
-ProxyShutdown()
-{
-  int i = 0;
-
-  // Check to make sure that we are not already down
-  if (!lmgmt->processRunning()) {
-    return true;
-  }
-  // Send the shutdown event
-  lmgmt->signalEvent(MGMT_EVENT_SHUTDOWN, "shutdown");
-
-  // Wait for awhile for shtudown to happen
-  do {
-    mgmt_sleep_sec(1);
-    i++;
-  } while (i < 10 && lmgmt->processRunning());
-
-  // See if we succeeded
-  if (lmgmt->processRunning()) {
-    return false;
-  } else {
-    return true;
-  }
-}
-
 //
 //
 //  Sets the LocalManager variable:  proxy.node.hostname

--- a/mgmt/WebMgmtUtils.h
+++ b/mgmt/WebMgmtUtils.h
@@ -98,8 +98,6 @@ char *substituteForHTMLChars(const char *buffer);
 InkHashTable *processFormSubmission(char *submission);
 InkHashTable *processFormSubmission_noSubstitute(char *submission);
 
-// Shutdown the proxy
-bool ProxyShutdown();
 int setHostnameVar();
 void appendDefaultDomain(char *hostname, int bufLength);
 

--- a/mgmt/api/APITestCliRemote.cc
+++ b/mgmt/api/APITestCliRemote.cc
@@ -859,18 +859,18 @@ void
 start_TS(char *tsArgs)
 {
   TSMgmtError ret;
-  TSCacheClearT clear = TS_CACHE_CLEAR_OFF;
+  TSCacheClearT clear = TS_CACHE_CLEAR_NONE;
   char *args;
 
   strtok(tsArgs, ":");
   args = strtok(NULL, ":");
   if (args) {
     if (strcmp(args, "all\n") == 0)
-      clear = TS_CACHE_CLEAR_ON;
+      clear = TS_CACHE_CLEAR_CACHE;
     else if (strcmp(args, "hostdb\n") == 0)
       clear = TS_CACHE_CLEAR_HOSTDB;
   } else {
-    clear = TS_CACHE_CLEAR_OFF;
+    clear = TS_CACHE_CLEAR_NONE;
   }
 
   printf("STARTING PROXY with cache: %d\n", clear);
@@ -886,7 +886,7 @@ stop_TS()
   TSMgmtError ret;
 
   printf("STOPPING PROXY\n");
-  if ((ret = TSProxyStateSet(TS_PROXY_OFF, TS_CACHE_CLEAR_OFF)) != TS_ERR_OKAY)
+  if ((ret = TSProxyStateSet(TS_PROXY_OFF, TS_CACHE_CLEAR_NONE)) != TS_ERR_OKAY)
     printf("[TSProxyStateSet] turn off FAILED\n");
   print_err("stop_TS", ret);
 }
@@ -2267,7 +2267,7 @@ sync_test()
     printf("[TSRecordSet] proxy.config.http.cache.fuzz.probability=-0.3333\n");
 
   TSMgmtError ret;
-  if ((ret = TSProxyStateSet(TS_PROXY_OFF, TS_CACHE_CLEAR_OFF)) != TS_ERR_OKAY)
+  if ((ret = TSProxyStateSet(TS_PROXY_OFF, TS_CACHE_CLEAR_NONE)) != TS_ERR_OKAY)
     printf("[TSProxyStateSet] turn off FAILED\n");
   print_err("stop_TS", ret);
 }

--- a/mgmt/api/CoreAPI.cc
+++ b/mgmt/api/CoreAPI.cc
@@ -142,6 +142,38 @@ DiagnosticMessage(TSDiagsT mode, const char *fmt, va_list ap)
 /***************************************************************************
  * Control Operations
  ***************************************************************************/
+
+// bool ProxyShutdown()
+//
+//  Attempts to turn the proxy off.  Returns
+//    true if the proxy is off when the call returns
+//    and false if it is still on
+//
+static bool
+ProxyShutdown()
+{
+  int i = 0;
+
+  // Check to make sure that we are not already down
+  if (!lmgmt->processRunning()) {
+    return true;
+  }
+
+  lmgmt->processShutdown(false /* only shut down the proxy*/);
+
+  // Wait for awhile for shtudown to happen
+  do {
+    mgmt_sleep_sec(1);
+    i++;
+  } while (i < 10 && lmgmt->processRunning());
+
+  // See if we succeeded
+  if (lmgmt->processRunning()) {
+    return false;
+  } else {
+    return true;
+  }
+}
 /*-------------------------------------------------------------------------
  * ProxyStateGet
  *-------------------------------------------------------------------------
@@ -161,7 +193,7 @@ ProxyStateGet()
  * ProxyStateSet
  *-------------------------------------------------------------------------
  * If state == TS_PROXY_ON, will turn on TS (unless it's already running).
- * If steat == TS_PROXY_OFF, will turn off TS (unless it's already off).
+ * If state == TS_PROXY_OFF, will turn off TS (unless it's already off).
  * tsArgs  - (optional) a string with space delimited options that user
  *            wants to start traffic Server with
  */

--- a/mgmt/api/INKMgmtAPI.cc
+++ b/mgmt/api/INKMgmtAPI.cc
@@ -1686,13 +1686,19 @@ TSProxyStateGet()
 /* TSProxyStateSet: set the proxy state (on/off)
  * Input:  proxy_state - set to on/off
  *         clear - start TS with cache clearing option,
- *                 when stopping TS should always be TS_CACHE_CLEAR_OFF
+ *                 when stopping TS should always be TS_CACHE_CLEAR_NONE
  * Output: TSMgmtError
  */
 tsapi TSMgmtError
-TSProxyStateSet(TSProxyStateT proxy_state, TSCacheClearT clear)
+TSProxyStateSet(TSProxyStateT proxy_state, unsigned clear)
 {
-  return ProxyStateSet(proxy_state, clear);
+  unsigned mask = TS_CACHE_CLEAR_NONE | TS_CACHE_CLEAR_CACHE | TS_CACHE_CLEAR_HOSTDB;
+
+  if (clear & ~mask) {
+    return TS_ERR_PARAMS;
+  }
+
+  return ProxyStateSet(proxy_state, static_cast<TSCacheClearT>(clear));
 }
 
 tsapi TSMgmtError

--- a/mgmt/api/include/mgmtapi.h
+++ b/mgmt/api/include/mgmtapi.h
@@ -144,9 +144,9 @@ typedef enum {
 
 /* used when starting Traffic Server process */
 typedef enum {
-  TS_CACHE_CLEAR_ON,     /* run TS in  "clear entire cache" mode */
-  TS_CACHE_CLEAR_HOSTDB, /* run TS in "only clear the host db cache" mode */
-  TS_CACHE_CLEAR_OFF     /* starts TS in regualr mode w/o any options */
+  TS_CACHE_CLEAR_NONE = 0,          /* starts TS in regular mode w/o any options */
+  TS_CACHE_CLEAR_CACHE = (1 << 0),  /* run TS in  "clear cache" mode */
+  TS_CACHE_CLEAR_HOSTDB = (1 << 1), /* run TS in "clear the host db cache" mode */
 } TSCacheClearT;
 
 /*--- diagnostic output operations ----------------------------------------*/
@@ -900,12 +900,13 @@ tsapi TSProxyStateT TSProxyStateGet();
 
 /* TSProxyStateSet: set the proxy state (on/off)
  * Input:  proxy_state - set to on/off
- *         clear - specifies if want to start TS with clear_cache or
- *                 clear_cache_hostdb option, or just run TS with no options;
- *                  only applies when turning proxy on
+ *         clear - a TSCacheClearT bitmask,
+ *            specifies if want to start TS with clear_cache or
+ *            clear_cache_hostdb option, or just run TS with no options;
+ *            only applies when turning proxy on
  * Output: TSMgmtError
  */
-tsapi TSMgmtError TSProxyStateSet(TSProxyStateT proxy_state, TSCacheClearT clear);
+tsapi TSMgmtError TSProxyStateSet(TSProxyStateT proxy_state, unsigned clear);
 
 /* TSProxyBacktraceGet: get a backtrace of the proxy
  * Input:  unsigned options - stack trace options


### PR DESCRIPTION
Add ``traffic_ctl`` support for ``server start`` and ``server stop`` subcommands. Initially I thought that these weren't used, but the SaltStack traffic server module use them.