### PR TITLE
TS-4403: Fix stale-while-revalidate on DNS lookup failures

### DIFF
--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -1501,7 +1501,12 @@ HostDBContinuation::dnsEvent(int event, HostEnt *e)
     HostDBInfo *r = NULL;
     IpAddr tip; // temp storage if needed.
 
-    if (is_byname()) {
+    // If the DNS lookup failed (errors such as NXDOMAIN, SERVFAIL, etc.) but we have an old record
+    // which is okay with being served stale-- lets continue to serve the stale record as long as
+    // the record is willing to be served.
+    if (failed && old_r && old_r->serve_stale_but_revalidate()) {
+      r = old_r;
+    } else if (is_byname()) {
       if (first)
         ip_addr_set(tip, af, first);
       r = lookup_done(tip, md5.host_name, is_rr, ttl_seconds, failed ? 0 : &e->srv_hosts);


### PR DESCRIPTION
HostDB's "stale-while-revalidate" feature allows hostdb to return stale records while doing the DNS lookup in the background. This works properly in the case where the resolver goes away, but in the case that an error was returned from the resolver the record in cache was thrown away. This means that a transient error out in the DNS infrastructure would cause ATS to drop its stale record it would have contently served-- this patch simply makes hostdb honor its stale-while-revalidate contract (if configured). So, in the event that the DNS result comes back as `failed` hostdb will keep the old one if it is okay with being served stale.