### PR TITLE
TS-2581: Standard library allocators and API to expose IOBuf memory allocation.

### DIFF
--- a/doc/developer-guide/api/functions/TSmalloc_pool.en.rst
+++ b/doc/developer-guide/api/functions/TSmalloc_pool.en.rst
@@ -1,0 +1,46 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+
+.. include:: ../../../common.defs
+
+.. default-domain:: c
+
+TSmalloc_pool
+********
+
+Traffic Server memory allocation API using underlying IOBuf memory pools.
+
+Synopsis
+========
+
+`#include <ts/ts.h>`
+
+.. function:: void * TSmalloc_pool(size_t size)
+.. function:: void * TSrealloc_pool(void * ptr , size_t size)
+.. function:: void TSfree_pool(void * ptr)
+
+Description
+===========
+
+:func:`TSmalloc_pool` returns a pointer to size bytes of memory allocated from the
+IOBuf memory pools. You must always use :func:`TSfree_pool` to free memory allocated
+via :func:`TSmalloc_pool` or :func:`TSrealloc_pool`.
+
+See also
+========
+
+:manpage:`TSAPI(3ts)`

--- a/example/output-header/output-header.c
+++ b/example/output-header/output-header.c
@@ -84,7 +84,7 @@ handle_dns(TSHttpTxn txnp, TSCont contp ATS_UNUSED)
 
   /* Allocate the string with an extra byte for the string
      terminator */
-  output_string = (char *)TSmalloc(total_avail + 1);
+  output_string = (char *)TSmalloc_pool(total_avail + 1);
   output_len = 0;
 
   /* We need to loop over all the buffer blocks to make
@@ -124,9 +124,9 @@ handle_dns(TSHttpTxn txnp, TSCont contp ATS_UNUSED)
 
   /* Although I'd never do this a production plugin, printf
      the header so that we can see it's all there */
-  TSDebug("debug-output-header", "%s", output_string);
+  TSDebug(DEBUG_TAG, "%s", output_string);
 
-  TSfree(output_string);
+  TSfree_pool(output_string);
 
 done:
   TSHttpTxnReenable(txnp, TS_EVENT_HTTP_CONTINUE);
@@ -138,7 +138,7 @@ hdr_plugin(TSCont contp, TSEvent event, void *edata)
   TSHttpTxn txnp = (TSHttpTxn)edata;
 
   switch (event) {
-  case TS_EVENT_HTTP_OS_DNS:
+  case TS_EVENT_HTTP_READ_REQUEST_HDR:
     handle_dns(txnp, contp);
     return 0;
   default:
@@ -163,7 +163,7 @@ TSPluginInit(int argc ATS_UNUSED, const char *argv[] ATS_UNUSED)
     goto error;
   }
 
-  TSHttpHookAdd(TS_HTTP_OS_DNS_HOOK, TSContCreate(hdr_plugin, NULL));
+  TSHttpHookAdd(TS_HTTP_READ_REQUEST_HDR_HOOK, TSContCreate(hdr_plugin, NULL));
 
 error:
   TSError("[output_header] Plugin not initialized");

--- a/iocore/eventsystem/I_STLAllocator.h
+++ b/iocore/eventsystem/I_STLAllocator.h
@@ -1,0 +1,116 @@
+/** @file
+
+ A brief file description
+
+ @section license License
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#ifndef I_STLALLOCATOR_H_
+#define I_STLALLOCATOR_H_
+
+#include <string>
+#include <vector>
+#include <limits>
+#include <cmath>
+#include <cstdio>
+#include "I_IOBuffer.h"
+
+template <typename T> class ts_stl_std_allocator : public std::allocator<T>
+{
+public:
+  typedef size_t size_type;
+  typedef T *pointer;
+  typedef const T *const_pointer;
+
+  template <typename _Tp1> struct rebind {
+    typedef ts_stl_std_allocator<_Tp1> other;
+  };
+
+  pointer
+  allocate(size_type n, const void *hint = 0)
+  {
+    pointer p = std::allocator<T>::allocate(n, hint);
+    return p;
+  }
+
+  void
+  deallocate(pointer p, size_type n)
+  {
+    std::allocator<T>::deallocate(p, n);
+  }
+
+  ts_stl_std_allocator() throw() : std::allocator<T>() {}
+  ts_stl_std_allocator(const ts_stl_std_allocator &a) throw() : std::allocator<T>(a) {}
+  template <class U> ts_stl_std_allocator(const ts_stl_std_allocator<U> &a) throw() : std::allocator<T>(a) {}
+  ~ts_stl_std_allocator() throw() {}
+};
+
+template <typename T> class ts_stl_iobuf_allocator : public ts_stl_std_allocator<T>
+{
+public:
+  typedef size_t size_type;
+  typedef T *pointer;
+  typedef const T *const_pointer;
+
+  template <typename _Tp1> struct rebind {
+    typedef ts_stl_iobuf_allocator<_Tp1> other;
+  };
+
+  pointer
+  allocate(size_type n, const void *hint = 0)
+  {
+    if (unlikely((n * sizeof(T)) > DEFAULT_MAX_BUFFER_SIZE)) {
+      // we need to fall back to the ts_stl_std_allocator for large allocations
+      return ts_stl_std_allocator<T>::allocate(n, hint);
+    } else {
+      // we can pull from a iobuf for this allocation
+      int64_t iobuffer_index = iobuffer_size_to_index(n * sizeof(T));
+      ink_release_assert(iobuffer_index >= 0);
+
+      pointer p = reinterpret_cast<pointer>(ioBufAllocator[iobuffer_index].alloc_void());
+      return p;
+    }
+  }
+
+  void
+  deallocate(pointer p, size_type n)
+  {
+    if (unlikely((n * sizeof(T)) > DEFAULT_MAX_BUFFER_SIZE)) {
+      // we need to fall back to the ts_stl_std_allocator for large allocations
+      ts_stl_std_allocator<T>::deallocate(p, n);
+    } else {
+      // we need to return this block to the appropriate iobuffer
+      int64_t iobuffer_index = iobuffer_size_to_index(n * sizeof(T));
+      ink_release_assert(iobuffer_index >= 0);
+      ioBufAllocator[iobuffer_index].free_void(reinterpret_cast<void *>(p));
+    }
+  }
+
+  ts_stl_iobuf_allocator() throw() : ts_stl_std_allocator<T>() {}
+  ts_stl_iobuf_allocator(const ts_stl_iobuf_allocator &a) throw() : ts_stl_std_allocator<T>(a) {}
+  template <class U> ts_stl_iobuf_allocator(const ts_stl_iobuf_allocator<U> &a) throw() : ts_stl_std_allocator<T>(a) {}
+  ~ts_stl_iobuf_allocator() throw() {}
+};
+
+typedef std::basic_string<char, std::char_traits<char>, ts_stl_iobuf_allocator<char>> ts_string;
+
+// with c++11 this is much cleaner as you can do alias templates.
+// and then we could define a ts_vector, etc..
+
+#endif /* I_STLALLOCATOR_H_ */

--- a/lib/ts/ink_memory.h
+++ b/lib/ts/ink_memory.h
@@ -89,6 +89,11 @@ void *ats_free_null(void *ptr);
 void ats_memalign_free(void *ptr);
 int ats_mallopt(int param, int value);
 
+/* use IOBufs as the underlying allocation pool */
+void *ats_malloc_pool(size_t size);
+void *ats_realloc_pool(void *ptr, size_t size);
+void ats_free_pool(void *ptr);
+
 int ats_msync(caddr_t addr, size_t len, caddr_t end, int flags);
 int ats_madvise(caddr_t addr, size_t len, int flags);
 int ats_mlock(caddr_t addr, size_t len);

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -1653,6 +1653,24 @@ _TSfree(void *ptr)
   ats_free(ptr);
 }
 
+void *
+_TSmalloc_pool(size_t size, const char * /* path ATS_UNUSED */)
+{
+  return ats_malloc_pool(size);
+}
+
+void
+_TSfree_pool(void *ptr)
+{
+  ats_free_pool(ptr);
+}
+
+void *
+_TSrealloc_pool(void *ptr, size_t size, const char * /* path ATS_UNUSED */)
+{
+  return ats_realloc_pool(ptr, size);
+}
+
 ////////////////////////////////////////////////////////////////////
 //
 // Encoding utility

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -45,6 +45,9 @@ extern "C" {
 #define TSstrlcpy(d, s, l) _TSstrlcpy((d), (s), (l))
 #define TSstrlcat(d, s, l) _TSstrlcat((d), (s), (l))
 #define TSfree(p) _TSfree(p)
+#define TSmalloc_pool(s) _TSmalloc_pool((s), TS_RES_MEM_PATH)
+#define TSrealloc_pool(p, s) _TSrealloc_pool((p), (s), TS_RES_MEM_PATH)
+#define TSfree_pool(p) _TSfree_pool(p)
 
 tsapi void *_TSmalloc(size_t size, const char *path);
 tsapi void *_TSrealloc(void *ptr, size_t size, const char *path);
@@ -52,6 +55,9 @@ tsapi char *_TSstrdup(const char *str, int64_t length, const char *path);
 tsapi size_t _TSstrlcpy(char *dst, const char *str, size_t siz);
 tsapi size_t _TSstrlcat(char *dst, const char *str, size_t siz);
 tsapi void _TSfree(void *ptr);
+tsapi void *_TSmalloc_pool(size_t size, const char *path);
+tsapi void *_TSrealloc_pool(void *ptr, size_t size, const char *path);
+tsapi void _TSfree_pool(void *ptr);
 
 /* --------------------------------------------------------------------------
    Component object handles */

--- a/proxy/spdy/SpdyCallbacks.cc
+++ b/proxy/spdy/SpdyCallbacks.cc
@@ -23,6 +23,7 @@
 
 #include "SpdyCallbacks.h"
 #include "SpdyClientSession.h"
+#include "I_STLAllocator.h"
 #include <arpa/inet.h>
 
 void
@@ -59,7 +60,7 @@ spdy_prepare_status_response_and_clean_request(SpdyClientSession *sm, int stream
           sm->sm_id, stream_id);
     return;
   }
-  string date_str = http_date(time(0));
+  ts_string date_str = http_date(time(0));
   const char **nv = new const char *[8 + req->headers.size() * 2 + 1];
 
   nv[0] = ":status";
@@ -168,7 +169,7 @@ spdy_show_ctl_frame(const char *head_str, spdylay_session * /*session*/, spdylay
 static int
 spdy_fetcher_launch(SpdyRequest *req)
 {
-  string url;
+  ts_string url;
   int fetch_flags;
   const sockaddr *client_addr;
   SpdyClientSession *sm = req->spdy_sm;
@@ -267,8 +268,8 @@ spdy_process_syn_stream_frame(SpdyClientSession *sm, SpdyRequest *req)
   bool acceptEncodingRecvd = false;
   // validate request headers
   for (size_t i = 0; i < req->headers.size(); ++i) {
-    const std::string &field = req->headers[i].first;
-    const std::string &value = req->headers[i].second;
+    const ts_string &field = req->headers[i].first;
+    const ts_string &value = req->headers[i].second;
 
     if (field == ":path")
       req->path = value;
@@ -370,8 +371,8 @@ unsigned
 spdy_session_delta_window_size(SpdyClientSession *sm)
 {
   unsigned sess_delta_window_size = 0;
-  map<int, SpdyRequest *>::iterator iter = sm->req_map.begin();
-  map<int, SpdyRequest *>::iterator endIter = sm->req_map.end();
+  request_map::iterator iter = sm->req_map.begin();
+  request_map::iterator endIter = sm->req_map.end();
   for (; iter != endIter; ++iter) {
     SpdyRequest *req = iter->second;
     sess_delta_window_size += req->delta_window_size;

--- a/proxy/spdy/SpdyCallbacks.h
+++ b/proxy/spdy/SpdyCallbacks.h
@@ -25,6 +25,7 @@
 #define __P_SPDY_CALLBACKS_H__
 
 #include <spdylay/spdylay.h>
+#include "I_STLAllocator.h"
 class SpdyClientSession;
 
 void spdy_callbacks_init(spdylay_session_callbacks *callbacks);

--- a/proxy/spdy/SpdyClientSession.cc
+++ b/proxy/spdy/SpdyClientSession.cc
@@ -24,6 +24,7 @@
 #include "SpdyClientSession.h"
 #include "SpdySessionAccept.h"
 #include "I_Net.h"
+#include "I_STLAllocator.h"
 
 static ClassAllocator<SpdyClientSession> spdyClientSessionAllocator("spdyClientSessionAllocator");
 ClassAllocator<SpdyRequest> spdyRequestAllocator("spdyRequestAllocator");
@@ -90,14 +91,14 @@ SpdyRequest::clear()
     fetch_sm = NULL;
   }
 
-  vector<pair<string, string>>().swap(headers);
+  header_vector().swap(headers);
 
-  std::string().swap(url);
-  std::string().swap(host);
-  std::string().swap(path);
-  std::string().swap(scheme);
-  std::string().swap(method);
-  std::string().swap(version);
+  ts_string().swap(url);
+  ts_string().swap(host);
+  ts_string().swap(path);
+  ts_string().swap(scheme);
+  ts_string().swap(method);
+  ts_string().swap(version);
 
   Debug("spdy", "****Delete Request[%" PRIu64 ":%d]", spdy_sm->sm_id, stream_id);
 }
@@ -144,8 +145,8 @@ SpdyClientSession::clear()
   // SpdyRequest depends on SpdyClientSession,
   // we should delete it firstly to avoid race.
   //
-  map<int, SpdyRequest *>::iterator iter = req_map.begin();
-  map<int, SpdyRequest *>::iterator endIter = req_map.end();
+  request_map::iterator iter = req_map.begin();
+  request_map::iterator endIter = req_map.end();
   for (; iter != endIter; ++iter) {
     SpdyRequest *req = iter->second;
     if (req) {

--- a/proxy/spdy/SpdyCommon.cc
+++ b/proxy/spdy/SpdyCommon.cc
@@ -42,13 +42,13 @@ uint32_t spdy_initial_window_size = 1048576;
 int32_t spdy_accept_no_activity_timeout = 120;
 int32_t spdy_no_activity_timeout_in = 115;
 
-string
+ts_string
 http_date(time_t t)
 {
   char buf[32];
   tm *tms = gmtime(&t); // returned struct is statically allocated.
   size_t r = strftime(buf, sizeof(buf), "%a, %d %b %Y %H:%M:%S GMT", tms);
-  return std::string(&buf[0], &buf[r]);
+  return ts_string(&buf[0], &buf[r]);
 }
 
 int

--- a/proxy/spdy/SpdyCommon.h
+++ b/proxy/spdy/SpdyCommon.h
@@ -38,6 +38,7 @@
 #include "ts/ts.h"
 #include "ts/ink_platform.h"
 #include "ts/experimental.h"
+#include "I_STLAllocator.h"
 #include <spdylay/spdylay.h>
 using namespace std;
 
@@ -100,7 +101,7 @@ private:
   char version[64];
 };
 
-string http_date(time_t t);
+ts_string http_date(time_t t);
 int spdy_config_load();
 
 // Stat helper functions. ToDo: These probably should be turned into #define's as we do elsewhere


### PR DESCRIPTION
This is a continuation of the pull request #556 (Adding STL Io Buf Allocators). This pull request contains that same code and it also adds three new memory related APIs for plugins, TSmalloc_pool, TSrealloc_pool, and TSfree_pool. It also modifies a plugin to show the usage. Also see the related ticket: https://issues.apache.org/jira/browse/TS-2581