### PR TITLE
TS-4435: Enable compilation with openssl 1.1

### DIFF
--- a/build/crypto.m4
+++ b/build/crypto.m4
@@ -196,3 +196,37 @@ AC_DEFUN([TS_CHECK_CRYPTO_SET_RBIO], [
   TS_ARG_ENABLE_VAR([use], [set-rbio])
   AC_SUBST(use_set_rbio)
 ])
+
+AC_DEFUN([TS_CHECK_CRYPTO_DH_GET_2048_256], [
+  _dh_saved_LIBS=$LIBS
+  enable_dh_get_2048_256=yes
+
+  TS_ADDTO(LIBS, [$OPENSSL_LIBS])
+  AC_MSG_CHECKING([for DH_get_2048_256])
+  AC_LINK_IFELSE(
+  [
+    AC_LANG_PROGRAM([[
+#if HAVE_OPENSSL_SSL_H
+#include <openssl/ssl.h>
+#endif
+#if HAVE_OPENSSL_TLS1_H
+#include <openssl/tls1.h>
+#endif
+      ]],
+      [[DH_get_2048_256();]])
+  ],
+  [
+    AC_MSG_RESULT([yes])
+  ],
+  [
+    AC_MSG_RESULT([no])
+    enable_dh_get_2048_256=no
+  ])
+
+  LIBS=$_dh_saved_LIBS
+
+  AC_MSG_CHECKING(whether to enable DH_get_2048_256)
+  AC_MSG_RESULT([$enable_dh_get_2048_256])
+  TS_ARG_ENABLE_VAR([use], [dh_get_2048_256])
+  AC_SUBST(use_dh_get_2048_256)
+])

--- a/configure.ac
+++ b/configure.ac
@@ -1157,6 +1157,9 @@ TS_CHECK_CRYPTO_CERT_CB
 # Check for SSL_set_rbio call
 TS_CHECK_CRYPTO_SET_RBIO
 
+# Check for DH_get_2048_256
+TS_CHECK_CRYPTO_DH_GET_2048_256
+
 #
 # Check for zlib presence and usability
 TS_CHECK_ZLIB

--- a/iocore/net/SSLDynlock.cc
+++ b/iocore/net/SSLDynlock.cc
@@ -43,6 +43,8 @@ ssl_dyn_create_callback(const char *file, int line)
   return value;
 }
 
+// The locking callback goes away with openssl 1.1 and CRYPTO_LOCK is on longer defined
+#ifdef CRYPTO_LOCK
 void
 ssl_dyn_lock_callback(int mode, struct CRYPTO_dynlock_value *value, const char *file, int line)
 {
@@ -57,6 +59,7 @@ ssl_dyn_lock_callback(int mode, struct CRYPTO_dynlock_value *value, const char *
     ink_release_assert(0);
   }
 }
+#endif
 
 void
 ssl_dyn_destroy_callback(struct CRYPTO_dynlock_value *value, const char *file, int line)

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -131,12 +131,18 @@ static InkHashTable *ssl_cipher_name_table = NULL;
  * may use pthreads and openssl without confusing us here. (TS-2271).
  */
 
+// Only define this function if the version of openssl really has a
+// CRYPTO_THREADID_set_callback function.  openssl 1.1.0 defines it to 0
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 static void
 SSL_pthreads_thread_id(CRYPTO_THREADID *id)
 {
   CRYPTO_THREADID_set_numeric(id, (unsigned long)pthread_self());
 }
+#endif
 
+// The locking callback goes away with openssl 1.1 and CRYPTO_LOCK is on longer defined
+#ifdef CRYPTO_LOCK
 static void
 SSL_locking_callback(int mode, int type, const char *file, int line)
 {
@@ -159,6 +165,7 @@ SSL_locking_callback(int mode, int type, const char *file, int line)
     ink_assert(0);
   }
 }
+#endif
 
 #ifndef SSL_CTX_add0_chain_cert
 static bool
@@ -195,7 +202,11 @@ ssl_session_timed_out(SSL_SESSION *session)
 static void ssl_rm_cached_session(SSL_CTX *ctx, SSL_SESSION *sess);
 
 static SSL_SESSION *
+#if OPENSSL_VERSION_NUMBER > 0x10100000L
+ssl_get_cached_session(SSL *ssl, const unsigned char *id, int len, int *copy)
+#else
 ssl_get_cached_session(SSL *ssl, unsigned char *id, int len, int *copy)
+#endif
 {
   SSLSessionID sid(id, len);
 
@@ -428,9 +439,10 @@ done:
 #endif
 #endif /* TS_USE_TLS_SNI */
 
+#if TS_USE_GET_DH_2048_256 == 0
 /* Build 2048-bit MODP Group with 256-bit Prime Order Subgroup from RFC 5114 */
 static DH *
-get_dh2048()
+DH_get_2048_256()
 {
   static const unsigned char dh2048_p[] = {
     0x87, 0xA8, 0xE6, 0x1D, 0xB4, 0xB6, 0x66, 0x3C, 0xFF, 0xBB, 0xD1, 0x9C, 0x65, 0x19, 0x59, 0x99, 0x8C, 0xEE, 0xF6, 0x08,
@@ -472,6 +484,7 @@ get_dh2048()
   }
   return (dh);
 }
+#endif
 
 static SSL_CTX *
 ssl_context_enable_dhe(const char *dhparams_file, SSL_CTX *ctx)
@@ -482,7 +495,7 @@ ssl_context_enable_dhe(const char *dhparams_file, SSL_CTX *ctx)
     scoped_BIO bio(BIO_new_file(dhparams_file, "r"));
     server_dh = PEM_read_bio_DHparams(bio.get(), NULL, NULL, NULL);
   } else {
-    server_dh = get_dh2048();
+    server_dh = DH_get_2048_256();
   }
 
   if (!server_dh) {
@@ -788,21 +801,68 @@ SSLRecRawStatSyncCount(const char *name, RecDataT data_type, RecData *data, RecR
   SSL_SET_COUNT_DYN_STAT(ssl_user_agent_session_timeout_stat, timeouts);
   return RecRawStatSyncCount(name, data_type, data, rsb, id);
 }
-
+#if OPENSSL_VERSION_NUMBER > 0x10100000L
+void *
+ssl_malloc(size_t size, const char * /*filename */, int /*lineno*/)
+#else
 void *
 ssl_malloc(size_t size)
+#endif
+{
+  return ats_malloc(size);
+}
+
+#if OPENSSL_VERSION_NUMBER > 0x10100000L
+void *
+ssl_realloc(void *ptr, size_t size, const char * /*filename*/, int /*lineno*/)
+#else
+void *
+ssl_realloc(void *ptr, size_t size)
+#endif
+{
+  return ats_realloc(ptr, size);
+}
+
+#if OPENSSL_VERSION_NUMBER > 0x10100000L
+void
+ssl_free(void *ptr, const char * /*filename*/, int /*lineno*/)
+#else
+void
+ssl_free(void *ptr)
+#endif
+{
+  ats_free(ptr);
+}
+
+#if OPENSSL_VERSION_NUMBER > 0x10100000L
+void *
+ssl_track_malloc(size_t size, const char * /*filename*/, int /*lineno*/)
+#else
+void *
+ssl_track_malloc(size_t size)
+#endif
 {
   return ats_track_malloc(size, &ssl_memory_allocated);
 }
 
+#if OPENSSL_VERSION_NUMBER > 0x10100000L
 void *
-ssl_realloc(void *ptr, size_t size)
+ssl_track_realloc(void *ptr, size_t size, const char * /*filename*/, int /*lineno*/)
+#else
+void *
+ssl_track_realloc(void *ptr, size_t size)
+#endif
 {
   return ats_track_realloc(ptr, size, &ssl_memory_allocated, &ssl_memory_freed);
 }
 
+#if OPENSSL_VERSION_NUMBER > 0x10100000L
 void
-ssl_free(void *ptr)
+ssl_track_free(void *ptr, const char * /*filename*/, int /*lineno*/)
+#else
+void
+ssl_track_free(void *ptr)
+#endif
 {
   ats_track_free(ptr, &ssl_memory_freed);
 }
@@ -814,9 +874,9 @@ SSLInitializeLibrary()
 // BoringSSL does not have the memory functions
 #ifndef OPENSSL_IS_BORINGSSL
     if (res_track_memory >= 2) {
-      CRYPTO_set_mem_functions(ssl_malloc, ssl_realloc, ssl_free);
+      CRYPTO_set_mem_functions(ssl_track_malloc, ssl_track_realloc, ssl_track_free);
     } else {
-      CRYPTO_set_mem_functions(ats_malloc, ats_realloc, ats_free);
+      CRYPTO_set_mem_functions(ssl_malloc, ssl_realloc, ssl_free);
     }
 #endif
 
@@ -1038,30 +1098,42 @@ increment_ssl_client_error(unsigned long err)
   // (we ignore FUNCTION with the prejudice that we don't care what function
   // the error came from, hope that's ok?)
   switch (ERR_GET_REASON(err)) {
+#ifdef SSL_R_SSLV3_ALERT_CERTIFICATE_EXPIRED
   case SSL_R_SSLV3_ALERT_CERTIFICATE_EXPIRED:
     SSL_INCREMENT_DYN_STAT(ssl_user_agent_expired_cert_stat);
     break;
+#endif
+#ifdef SSL_R_SSLV3_ALERT_CERTIFICATE_REVOKED
   case SSL_R_SSLV3_ALERT_CERTIFICATE_REVOKED:
     SSL_INCREMENT_DYN_STAT(ssl_user_agent_revoked_cert_stat);
     break;
+#endif
+#ifdef SSL_R_SSLV3_ALERT_CERTIFICATE_UNKNOWN
   case SSL_R_SSLV3_ALERT_CERTIFICATE_UNKNOWN:
     SSL_INCREMENT_DYN_STAT(ssl_user_agent_unknown_cert_stat);
     break;
+#endif
   case SSL_R_CERTIFICATE_VERIFY_FAILED:
     SSL_INCREMENT_DYN_STAT(ssl_user_agent_cert_verify_failed_stat);
     break;
+#ifdef SSL_R_SSLV3_ALERT_BAD_CERTIFICATE
   case SSL_R_SSLV3_ALERT_BAD_CERTIFICATE:
     SSL_INCREMENT_DYN_STAT(ssl_user_agent_bad_cert_stat);
     break;
+#endif
+#ifdef SSL_R_TLSV1_ALERT_DECRYPTION_FAILED
   case SSL_R_TLSV1_ALERT_DECRYPTION_FAILED:
     SSL_INCREMENT_DYN_STAT(ssl_user_agent_decryption_failed_stat);
     break;
+#endif
   case SSL_R_WRONG_VERSION_NUMBER:
     SSL_INCREMENT_DYN_STAT(ssl_user_agent_wrong_version_stat);
     break;
+#ifdef SSL_R_TLSV1_ALERT_UNKNOWN_CA
   case SSL_R_TLSV1_ALERT_UNKNOWN_CA:
     SSL_INCREMENT_DYN_STAT(ssl_user_agent_unknown_ca_stat);
     break;
+#endif
   default:
     SSL_INCREMENT_DYN_STAT(ssl_user_agent_other_errors_stat);
     return false;
@@ -1085,30 +1157,42 @@ increment_ssl_server_error(unsigned long err)
   // (we ignore FUNCTION with the prejudice that we don't care what function
   // the error came from, hope that's ok?)
   switch (ERR_GET_REASON(err)) {
+#ifdef SSL_R_SSLV3_ALERT_CERTIFICATE_EXPIRED
   case SSL_R_SSLV3_ALERT_CERTIFICATE_EXPIRED:
     SSL_INCREMENT_DYN_STAT(ssl_origin_server_expired_cert_stat);
     break;
+#endif
+#ifdef SSL_R_SSLV3_ALERT_CERTIFICATE_REVOKED
   case SSL_R_SSLV3_ALERT_CERTIFICATE_REVOKED:
     SSL_INCREMENT_DYN_STAT(ssl_origin_server_revoked_cert_stat);
     break;
+#endif
+#ifdef SSL_R_SSLV3_ALERT_CERTIFICATE_UNKNOWN
   case SSL_R_SSLV3_ALERT_CERTIFICATE_UNKNOWN:
     SSL_INCREMENT_DYN_STAT(ssl_origin_server_unknown_cert_stat);
     break;
+#endif
   case SSL_R_CERTIFICATE_VERIFY_FAILED:
     SSL_INCREMENT_DYN_STAT(ssl_origin_server_cert_verify_failed_stat);
     break;
+#ifdef SSL_R_SSLV3_ALERT_BAD_CERTIFICATE
   case SSL_R_SSLV3_ALERT_BAD_CERTIFICATE:
     SSL_INCREMENT_DYN_STAT(ssl_origin_server_bad_cert_stat);
     break;
+#endif
+#ifdef SSL_R_TLSV1_ALERT_DECRYPTION_FAILED
   case SSL_R_TLSV1_ALERT_DECRYPTION_FAILED:
     SSL_INCREMENT_DYN_STAT(ssl_origin_server_decryption_failed_stat);
     break;
+#endif
   case SSL_R_WRONG_VERSION_NUMBER:
     SSL_INCREMENT_DYN_STAT(ssl_origin_server_wrong_version_stat);
     break;
+#ifdef SSL_R_TLSV1_ALERT_UNKNOWN_CA
   case SSL_R_TLSV1_ALERT_UNKNOWN_CA:
     SSL_INCREMENT_DYN_STAT(ssl_origin_server_unknown_ca_stat);
     break;
+#endif
   default:
     SSL_INCREMENT_DYN_STAT(ssl_origin_server_other_errors_stat);
     return false;
@@ -1373,7 +1457,11 @@ ssl_callback_info(const SSL *ssl, int where, int ret)
 #ifdef SSL23_ST_SR_CLNT_HELLO_A
     if (state == SSL3_ST_SR_CLNT_HELLO_A || state == SSL23_ST_SR_CLNT_HELLO_A) {
 #else
+#ifdef SSL3_ST_SR_CLNT_HELLO_A
     if (state == SSL3_ST_SR_CLNT_HELLO_A) {
+#else
+    if (state == TLS_ST_SR_CLNT_HELLO) {
+#endif
 #endif
       netvc->setSSLClientRenegotiationAbort(true);
       Debug("ssl", "ssl_callback_info trying to renegotiate from the client");
@@ -1412,7 +1500,7 @@ SSLInitServerContext(const SSLConfigParams *params, const ssl_user_config &sslMu
   int server_verify_client;
   ats_scoped_str completeServerCertPath;
   SSL_CTX *ctx = SSLDefaultServerContext();
-  EVP_MD_CTX digest;
+  EVP_MD_CTX *digest = EVP_MD_CTX_create();
   STACK_OF(X509_NAME) *ca_list = NULL;
   unsigned char hash_buf[EVP_MAX_MD_SIZE];
   unsigned int hash_len = 0;
@@ -1645,9 +1733,9 @@ SSLInitServerContext(const SSLConfigParams *params, const ssl_user_config &sslMu
       SSL_CTX_set_client_CA_list(ctx, ca_list);
     }
   }
-  EVP_MD_CTX_init(&digest);
+  EVP_MD_CTX_init(digest);
 
-  if (EVP_DigestInit_ex(&digest, evp_md_func, NULL) == 0) {
+  if (EVP_DigestInit_ex(digest, evp_md_func, NULL) == 0) {
     SSLError("EVP_DigestInit_ex failed");
     goto fail;
   }
@@ -1655,7 +1743,7 @@ SSLInitServerContext(const SSLConfigParams *params, const ssl_user_config &sslMu
   Debug("ssl", "Using '%s' in hash for session id context", sslMultCertSettings.cert.get());
 
   if (NULL != setting_cert) {
-    if (EVP_DigestUpdate(&digest, sslMultCertSettings.cert, strlen(setting_cert)) == 0) {
+    if (EVP_DigestUpdate(digest, sslMultCertSettings.cert, strlen(setting_cert)) == 0) {
       SSLError("EVP_DigestUpdate failed");
       goto fail;
     }
@@ -1667,19 +1755,18 @@ SSLInitServerContext(const SSLConfigParams *params, const ssl_user_config &sslMu
     for (size_t i = 0; i < num_certs; i++) {
       X509_NAME *name = sk_X509_NAME_value(ca_list, i);
       if (X509_NAME_digest(name, evp_md_func, hash_buf /* borrow our final hash buffer. */, &hash_len) == 0 ||
-          EVP_DigestUpdate(&digest, hash_buf, hash_len) == 0) {
+          EVP_DigestUpdate(digest, hash_buf, hash_len) == 0) {
         SSLError("Adding X509 name to digest failed");
         goto fail;
       }
     }
   }
 
-  if (EVP_DigestFinal_ex(&digest, hash_buf, &hash_len) == 0) {
+  if (EVP_DigestFinal_ex(digest, hash_buf, &hash_len) == 0) {
     SSLError("EVP_DigestFinal_ex failed");
     goto fail;
   }
 
-  EVP_MD_CTX_cleanup(&digest);
   if (SSL_CTX_set_session_id_context(ctx, hash_buf, hash_len) == 0) {
     SSLError("SSL_CTX_set_session_id_context failed");
     goto fail;
@@ -1733,6 +1820,8 @@ SSLInitServerContext(const SSLConfigParams *params, const ssl_user_config &sslMu
   return ctx;
 
 fail:
+  // EVP_MD_CTX_destroy calls EVP_MD_CTX_cleanup too
+  EVP_MD_CTX_destroy(digest);
   SSL_CLEAR_PW_REFERENCES(ud, ctx)
   SSLReleaseContext(ctx);
   for (unsigned int i = 0; i < certList.length(); i++) {

--- a/lib/ts/HashMD5.cc
+++ b/lib/ts/HashMD5.cc
@@ -23,7 +23,8 @@
 
 ATSHashMD5::ATSHashMD5(void)
 {
-  EVP_DigestInit(&ctx, EVP_md5());
+  ctx = EVP_MD_CTX_create();
+  EVP_DigestInit(ctx, EVP_md5());
   md_len = 0;
   finalized = false;
 }
@@ -32,7 +33,7 @@ void
 ATSHashMD5::update(const void *data, size_t len)
 {
   if (!finalized) {
-    EVP_DigestUpdate(&ctx, data, len);
+    EVP_DigestUpdate(ctx, data, len);
   }
 }
 
@@ -40,7 +41,7 @@ void
 ATSHashMD5::final(void)
 {
   if (!finalized) {
-    EVP_DigestFinal_ex(&ctx, md_value, &md_len);
+    EVP_DigestFinal_ex(ctx, md_value, &md_len);
     finalized = true;
   }
 }
@@ -58,19 +59,20 @@ ATSHashMD5::get(void) const
 size_t
 ATSHashMD5::size(void) const
 {
-  return EVP_MD_CTX_size(&ctx);
+  return EVP_MD_CTX_size(ctx);
 }
 
 void
 ATSHashMD5::clear(void)
 {
-  EVP_MD_CTX_cleanup(&ctx);
-  EVP_DigestInit(&ctx, EVP_md5());
+  EVP_MD_CTX_destroy(ctx);
+  ctx = EVP_MD_CTX_create();
+  EVP_DigestInit(ctx, EVP_md5());
   md_len = 0;
   finalized = false;
 }
 
 ATSHashMD5::~ATSHashMD5()
 {
-  EVP_MD_CTX_cleanup(&ctx);
+  EVP_MD_CTX_destroy(ctx);
 }

--- a/lib/ts/HashMD5.h
+++ b/lib/ts/HashMD5.h
@@ -35,7 +35,7 @@ struct ATSHashMD5 : ATSHash {
   ~ATSHashMD5();
 
 private:
-  EVP_MD_CTX ctx;
+  EVP_MD_CTX *ctx;
   unsigned char md_value[EVP_MAX_MD_SIZE];
   unsigned int md_len;
   bool finalized;

--- a/lib/ts/ink_config.h.in
+++ b/lib/ts/ink_config.h.in
@@ -76,6 +76,7 @@
 #define TS_USE_TLS_SNI                 @use_tls_sni@
 #define TS_USE_CERT_CB                 @use_cert_cb@
 #define TS_USE_SET_RBIO                @use_set_rbio@
+#define TS_USE_GET_DH_2048_256         @use_dh_get_2048_256@
 #define TS_USE_TLS_ECKEY               @use_tls_eckey@
 #define TS_USE_LINUX_NATIVE_AIO        @use_linux_native_aio@
 #define TS_USE_REMOTE_UNWINDING	       @use_remote_unwinding@


### PR DESCRIPTION
Openssl 1.1 removes the locking and thread id callbacks.  It deduces system you are on and uses the appropriate threading interface.

Openssl 1.1 removes the ability to define objects on the stack, so we must create EVP digest objects.

Openssl 1.1 removes a number of client alert reason defines.