### PR TITLE
TS-4436: Move hosts file implementation to `do_dns`

### DIFF
--- a/iocore/hostdb/P_HostDBProcessor.h
+++ b/iocore/hostdb/P_HostDBProcessor.h
@@ -197,11 +197,12 @@ struct CmpConstBuffferCaseInsensitive {
 };
 
 // Our own typedef for the host file mapping
-typedef std::map<ts::ConstBuffer, HostDBInfo, CmpConstBuffferCaseInsensitive> HostsFileMap;
+typedef std::map<ts::ConstBuffer, IpAddr, CmpConstBuffferCaseInsensitive> HostsFileMap;
 // A to hold a ref-counted map
 struct RefCountedHostsFileMap : public RefCountObj {
   HostsFileMap hosts_file_map;
   ats_scoped_str HostFileText;
+  ink_time_t next_sync_time; // time of the next sync
 };
 
 //
@@ -227,8 +228,6 @@ struct HostDBCache : public MultiCache<HostDBInfo> {
 
   // Map to contain all of the host file overrides, initialize it to empty
   Ptr<RefCountedHostsFileMap> hosts_file_ptr;
-  // Double buffer the hosts file becase it's small and it solves dangling reference problems.
-  Ptr<RefCountedHostsFileMap> prev_hosts_file_ptr;
 
   Queue<HostDBContinuation, Continuation::Link_link> pending_dns[MULTI_CACHE_PARTITIONS];
   Queue<HostDBContinuation, Continuation::Link_link> &pending_dns_for_hash(INK_MD5 &md5);


### PR DESCRIPTION
This moves the hosts file overrides down to the DNS layer instead of the HostDBInfo layer. This means that each port will get its own entry in hostdb, which will exist as its own HostDBInfo just like all the rest of the entries. This also means we only have to do the check in the map on DNS lookup instead of on each probe()

In addition to fixing the down status issues, this also means we no longer need to keep old copies of the strings etc. since they are copied once lookup_done is called.


Note: This patch is currently setting the TTL of the hosts file entry in HostDBInfo as `HOST_DB_TIMEOUT_INTERVAL` Ideally this would be the time remaining until the next hosts file sync, but I'm not sure if thats necessary-- thoughts?