### PR TITLE
TS-4440 fix truncated content-type for missing stats pages

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -3443,7 +3443,7 @@ HttpTransact::HandleStatPage(State *s)
   if (s->internal_msg_buffer) {
     status = HTTP_STATUS_OK;
   } else {
-    status = HTTP_STATUS_BAD_REQUEST;
+    status = HTTP_STATUS_NOT_FOUND;
   }
 
   build_response(s, &s->hdr_info.client_response, s->client_info.http_version, status);

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -3460,7 +3460,7 @@ HttpTransact::HandleStatPage(State *s)
       s->hdr_info.client_response.value_set(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE, s->internal_msg_buffer_type, len);
     }
   } else {
-    s->hdr_info.client_response.value_set(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE, "text/plain", 9);
+    s->hdr_info.client_response.value_set(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE, "text/plain", 10);
   }
 
   s->cache_info.action = CACHE_DO_NO_ACTION;


### PR DESCRIPTION
In addition, it seems odd that we are returning a `400` in this case, I'd think this should be a 404? I have a second commit for that as well (which we can definitely squash if we want).