### PR TITLE
TS-4442: Fix code coverage.

### DIFF
--- a/cmd/traffic_manager/traffic_manager.cc
+++ b/cmd/traffic_manager/traffic_manager.cc
@@ -319,13 +319,13 @@ init_dirs()
   if (access(sysconfdir, R_OK) == -1) {
     mgmt_elog(0, "unable to access() config directory '%s': %d, %s\n", (const char *)sysconfdir, errno, strerror(errno));
     mgmt_elog(0, "please set the 'TS_ROOT' environment variable\n");
-    _exit(1);
+    ::exit(1);
   }
 
   if (access(rundir, R_OK) == -1) {
     mgmt_elog(0, "unable to access() local state directory '%s': %d, %s\n", (const char *)rundir, errno, strerror(errno));
     mgmt_elog(0, "please set 'proxy.config.local_state_dir'\n");
-    _exit(1);
+    ::exit(1);
   }
 }
 
@@ -817,12 +817,12 @@ main(int argc, const char **argv)
     switch (lmgmt->mgmt_shutdown_outstanding) {
     case MGMT_PENDING_RESTART:
       lmgmt->mgmtShutdown();
-      _exit(0);
+      ::exit(0);
       break;
     case MGMT_PENDING_IDLE_RESTART:
       if (is_server_idle()) {
         lmgmt->mgmtShutdown();
-        _exit(0);
+        ::exit(0);
       }
       break;
     case MGMT_PENDING_BOUNCE:
@@ -988,11 +988,11 @@ SignalHandler(int sig)
   default:
     fprintf(stderr, "[TrafficManager] ==> signal #%d\n", sig);
     mgmt_elog(stderr, 0, "[TrafficManager] ==> signal #%d\n", sig);
-    _exit(sig);
+    ::exit(sig);
   }
   fprintf(stderr, "[TrafficManager] ==> signal2 #%d\n", sig);
   mgmt_elog(stderr, 0, "[TrafficManager] ==> signal2 #%d\n", sig);
-  _exit(sig);
+  ::exit(sig);
 } /* End SignalHandler */
 
 // void SigChldHandler(int sig)

--- a/cmd/traffic_wccp/wccp_client.cc
+++ b/cmd/traffic_wccp/wccp_client.cc
@@ -105,7 +105,7 @@ check_lockfile()
     } else {
       fprintf(stderr, "\n");
     }
-    _exit(1);
+    ::exit(1);
   }
 }
 
@@ -192,7 +192,7 @@ main(int argc, char **argv)
     pid_t pid = fork();
     if (pid > 0) {
       // Successful, the parent should go away
-      _exit(0);
+      ::exit(0);
     }
   }
 

--- a/configure.ac
+++ b/configure.ac
@@ -164,7 +164,7 @@ AC_MSG_RESULT([$enable_debug])
 
 # Enable code coverage instrumentation only if requested by the user.
 AC_MSG_CHECKING([whether to code coverage])
-AC_ARG_ENABLE([debug],
+AC_ARG_ENABLE([coverage],
   [AS_HELP_STRING([--enable-coverage],[generate code coverage instrumentation])],
   [],
   [enable_coverage=no]
@@ -917,8 +917,10 @@ AS_IF([test x"$enable_coverage" = "xyes"], [
   # supported compiler to test coverage.
   AS_CASE("$ax_cv_c_compiler_vendor",
     [clang], [
-      TS_ADDTO(CXXFLAGS, "-fprofile-instr-generate -fcoverage-mapping")
-      TS_ADDTO(CFLAGS, "-fprofile-instr-generate -fcoverage-mapping")
+      TS_ADDTO(CXXFLAGS, "-fprofile-instr-generate")
+      TS_ADDTO(CXXFLAGS, "-fcoverage-mapping")
+      TS_ADDTO(CFLAGS, "-fprofile-instr-generate")
+      TS_ADDTO(CFLAGS, "-fcoverage-mapping")
     ], [gnu], [
       TS_ADDTO(CXXFLAGS, "--coverage")
       TS_ADDTO(CFLAGS, "--coverage")
@@ -945,10 +947,6 @@ AC_SUBST(AM_CXXFLAGS)
 
 # Special compiler flag hacks for various pieces of the code
 AC_SUBST([FLEX_CFLAGS], $flex_cflags)
-
-# Flags for buildit LuaJIT itself.
-AC_SUBST(LUA_LDFLAGS)
-AC_SUBST([LUA_CFLAGS], $lua_cflags)
 
 SHARED_CFLAGS=-fPIC
 SHARED_LDFLAGS=-shared
@@ -1892,6 +1890,17 @@ iocore_include_dirs="\
 -I\$(top_srcdir)/iocore/cluster \
 -I\$(top_srcdir)/iocore/utils \
 -I\$(top_srcdir)/iocore/dns"
+
+# Flags for buildit LuaJIT itself. We take the latest version
+# of the generic flags, plus any Lua-specific flags so that we
+# can strip the coverage flags from Lua while keeping them by
+# default everywhere else.
+AC_SUBST([LUA_CFLAGS], [$CFLAGS $lua_cflags])
+AC_SUBST(LUA_LDFLAGS)
+
+TS_REMOVEFROM(LUA_CFLAGS, "-fprofile-instr-generate")
+TS_REMOVEFROM(LUA_CFLAGS, "-fcoverage-mapping")
+TS_REMOVEFROM(LUA_CFLAGS, "--coverage")
 
 AC_SUBST([CC])
 AC_SUBST([CFLAGS])

--- a/iocore/net/Connection.cc
+++ b/iocore/net/Connection.cc
@@ -256,8 +256,7 @@ Server::setup_fd_for_listen(bool non_blocking, int recv_bufsize, int send_bufsiz
 #if TS_USE_TPROXY
     Debug("http_tproxy", "Listen port inbound transparency enabled.\n");
     if (safe_setsockopt(fd, SOL_IP, TS_IP_TRANSPARENT, SOCKOPT_ON, sizeof(int)) < 0) {
-      Error("[Server::listen] Unable to set transparent socket option [%d] %s\n", errno, strerror(errno));
-      _exit(1);
+      Fatal("[Server::listen] Unable to set transparent socket option [%d] %s\n", errno, strerror(errno));
     }
 #else
     Error("[Server::listen] Transparency requested but TPROXY not configured\n");

--- a/iocore/net/SSLClientUtils.cc
+++ b/iocore/net/SSLClientUtils.cc
@@ -115,7 +115,7 @@ SSLInitClientContext(const SSLConfigParams *params)
   SSL_CTX_set_options(client_ctx, params->ssl_ctx_options);
   if (!client_ctx) {
     SSLError("cannot create new client context");
-    _exit(1);
+    ::exit(1);
   }
 
   if (params->ssl_client_ctx_protocols) {
@@ -182,5 +182,5 @@ SSLInitClientContext(const SSLConfigParams *params)
 
 fail:
   SSLReleaseContext(client_ctx);
-  _exit(1);
+  ::exit(1);
 }

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -362,9 +362,9 @@ SSLCertificateConfig::startup()
   // proxy.config.ssl.server.multicert.exit_on_load_fail is true
   SSLConfig::scoped_config params;
   if (!reconfigure() && params->configExitOnLoadError) {
-    Error("Problems loading ssl certificate file, %s.  Exiting.", params->configFilePath);
-    _exit(1);
+    Fatal("failed to load SSL certificate file, %s", params->configFilePath);
   }
+
   return true;
 }
 

--- a/iocore/net/test_I_UDPNet.cc
+++ b/iocore/net/test_I_UDPNet.cc
@@ -80,7 +80,7 @@ EchoServer::handlePacket(int event, void *data)
 
   case NET_EVENT_DATAGRAM_READ_ERROR:
     printf("got Read Error exiting\n");
-    _exit(1);
+    ::exit(1);
 
   case NET_EVENT_DATAGRAM_WRITE_ERROR:
     printf("got write error: %d\n", (int)data);

--- a/iocore/net/test_P_UDPNet.cc
+++ b/iocore/net/test_P_UDPNet.cc
@@ -80,7 +80,7 @@ EchoServer::handlePacket(int event, void *data)
 
   case NET_EVENT_DATAGRAM_READ_ERROR:
     printf("got Read Error exiting\n");
-    _exit(1);
+    ::exit(1);
 
   case NET_EVENT_DATAGRAM_WRITE_ERROR:
     printf("got write error: %d\n", (int)data);

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -46,7 +46,7 @@ all-local:
 		BUILDMODE="static" \
 		PREFIX="$(prefix)" \
 		CC="$(CC)" \
-		CFLAGS="$(CFLAGS) $(LUA_CFLAGS)" \
+		CFLAGS="$(LUA_CFLAGS)" \
 		XCFLAGS="" \
 		LDFLAGS="$(LUA_LDFLAGS)"
 

--- a/lib/ts/ink_args.cc
+++ b/lib/ts/ink_args.cc
@@ -328,5 +328,5 @@ usage(const ArgumentDescription *argument_descriptions, unsigned n_argument_desc
     }
     fprintf(stderr, " %s\n", argument_descriptions[i].description);
   }
-  _exit(EX_USAGE);
+  ::exit(EX_USAGE);
 }

--- a/mgmt/ProcessManager.cc
+++ b/mgmt/ProcessManager.cc
@@ -140,8 +140,7 @@ ProcessManager::processEventQueue()
       executeMgmtCallback(mh->msg_id, NULL, 0);
     }
     if (mh->msg_id == MGMT_EVENT_SHUTDOWN) {
-      mgmt_log(stderr, "[ProcessManager::processEventQueue] Shutdown msg received, exiting\n");
-      _exit(0);
+      mgmt_fatal(stderr, 0, "[ProcessManager::processEventQueue] Shutdown msg received, exiting\n");
     } /* Exit on shutdown */
     ats_free(mh);
     ret = true;

--- a/mgmt/utils/MgmtUtils.cc
+++ b/mgmt/utils/MgmtUtils.cc
@@ -385,7 +385,7 @@ mgmt_fatal(FILE *log, const int lerrno, const char *message_format, ...)
   va_end(ap);
 
   mgmt_cleanup();
-  _exit(1);
+  ::exit(1);
 } /* End mgmt_fatal */
 
 void
@@ -423,7 +423,7 @@ mgmt_fatal(const int lerrno, const char *message_format, ...)
   va_end(ap);
 
   mgmt_cleanup();
-  _exit(1);
+  ::exit(1);
 } /* End mgmt_fatal */
 
 static inline int

--- a/proxy/CoreUtils.cc
+++ b/proxy/CoreUtils.cc
@@ -505,7 +505,7 @@ CoreUtils::load_http_hdr(HTTPHdr *core_hdr, HTTPHdr *live_hdr)
   do {
     if (read_from_core((intptr_t)heap, sizeof(HdrHeap), buf) == -1) {
       printf("Cannot read from core\n");
-      _exit(0);
+      ::exit(0);
     }
     heap = (HdrHeap *)buf;
     copy_size = (int)(heap->m_free_start - heap->m_data_start);
@@ -522,14 +522,14 @@ CoreUtils::load_http_hdr(HTTPHdr *core_hdr, HTTPHdr *live_hdr)
   do {
     if (read_from_core((intptr_t)heap_ptr, sizeof(HdrHeap), buf) == -1) {
       printf("Cannot read from core\n");
-      _exit(0);
+      ::exit(0);
     }
     heap_ptr = (HdrHeap *)buf;
     copy_size = (int)(heap_ptr->m_free_start - heap_ptr->m_data_start);
 
     if (read_from_core((intptr_t)heap_ptr->m_data_start, copy_size, ptr_data) == -1) {
       printf("Cannot read from core\n");
-      _exit(0);
+      ::exit(0);
     }
     // Expand ptr xlation table if necessary
     if (ptr_heaps >= ptr_xl_size) {
@@ -552,7 +552,7 @@ CoreUtils::load_http_hdr(HTTPHdr *core_hdr, HTTPHdr *live_hdr)
   heap = (HdrHeap *)http_hdr->m_heap;
   if (read_from_core((intptr_t)heap, sizeof(HdrHeap), buf) == -1) {
     printf("Cannot read from core\n");
-    _exit(0);
+    ::exit(0);
   }
   heap = (HdrHeap *)buf;
   // filling in the live_hdr
@@ -585,7 +585,7 @@ CoreUtils::load_http_hdr(HTTPHdr *core_hdr, HTTPHdr *live_hdr)
     char *str_hdr = (char *)ats_malloc(sizeof(char) * sizeof(HdrStrHeap));
     if (read_from_core((intptr_t)hdr, sizeof(HdrStrHeap), str_hdr) == -1) {
       printf("Cannot read from core\n");
-      _exit(0);
+      ::exit(0);
     }
 
     char *free_start = (char *)(((HdrStrHeap *)str_hdr)->m_free_start);
@@ -598,7 +598,7 @@ CoreUtils::load_http_hdr(HTTPHdr *core_hdr, HTTPHdr *live_hdr)
 #endif
     if (read_from_core((intptr_t)copy_start, nto_copy, rw_heap) == -1) {
       printf("Cannot read from core\n");
-      _exit(0);
+      ::exit(0);
     }
     // FIX ME - possible offset overflow issues?
     str_xlation[str_heaps].start = copy_start;
@@ -621,7 +621,7 @@ CoreUtils::load_http_hdr(HTTPHdr *core_hdr, HTTPHdr *live_hdr)
 #endif
       if (read_from_core((intptr_t)heap->m_ronly_heap[i].m_heap_start, heap->m_ronly_heap[i].m_heap_len, ro_heap) == -1) {
         printf("Cannot read from core\n");
-        _exit(0);
+        ::exit(0);
       }
       // Add translation table entry for string heaps
       str_xlation[str_heaps].start = heap->m_ronly_heap[i].m_heap_start;
@@ -811,13 +811,13 @@ process_core(char *fname)
   /* Open the input file */
   if (!(fp = fopen(fname, "r"))) {
     printf("cannot open file\n");
-    _exit(1);
+    ::exit(1);
   }
 
   /* Obtain the .shstrtab data buffer */
   if (fread(&ehdr, sizeof ehdr, 1, fp) != 1) {
     printf("Unable to read ehdr\n");
-    _exit(1);
+    ::exit(1);
   }
   // program header offset
   phoff = ehdr.e_phoff;
@@ -829,12 +829,12 @@ process_core(char *fname)
   for (int i = 0; i < phnum; i++) {
     if (fseek(fp, phoff + i * phentsize, SEEK_SET) == -1) {
       fprintf(stderr, "Unable to seek to Phdr %d\n", i);
-      _exit(1);
+      ::exit(1);
     }
 
     if (fread(&phdr, sizeof phdr, 1, fp) != 1) {
       fprintf(stderr, "Unable to read Phdr %d\n", i);
-      _exit(1);
+      ::exit(1);
     }
     int poffset, psize;
     int pvaddr;
@@ -882,7 +882,7 @@ process_core(char *fname)
               char *offset = (char *)(thdr + 1) + ((thdr->n_namesz + 3) & ~3);
 
               if (len < 0 || len > size) {
-                _exit(1);
+                ::exit(1);
               }
               printf("size=%d, len=%d\n", size, len);
 

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -402,7 +402,7 @@ proxy_signal_handler(int signo, siginfo_t *info, void *ctx)
   shutdown_event_system = true;
   sleep(1);
 
-  exit(signo);
+  ::exit(signo);
 }
 
 //
@@ -449,7 +449,7 @@ check_lockfile()
     } else {
       fprintf(stderr, "\n");
     }
-    _exit(1);
+    ::exit(1);
   }
 }
 
@@ -462,13 +462,13 @@ check_config_directories(void)
   if (access(sysconfdir, R_OK) == -1) {
     fprintf(stderr, "unable to access() config dir '%s': %d, %s\n", (const char *)sysconfdir, errno, strerror(errno));
     fprintf(stderr, "please set the 'TS_ROOT' environment variable\n");
-    _exit(1);
+    ::exit(1);
   }
 
   if (access(rundir, R_OK | W_OK) == -1) {
     fprintf(stderr, "unable to access() local state dir '%s': %d, %s\n", (const char *)rundir, errno, strerror(errno));
     fprintf(stderr, "please set 'proxy.config.local_state_dir'\n");
-    _exit(1);
+    ::exit(1);
   }
 }
 
@@ -599,10 +599,10 @@ CB_cmd_cache_clear()
 {
   if (cacheProcessor.IsCacheEnabled() == CACHE_INITIALIZED) {
     Note("CLEAR, succeeded");
-    _exit(0);
+    ::exit(0);
   } else if (cacheProcessor.IsCacheEnabled() == CACHE_INIT_FAILED) {
     Note("unable to open Cache, CLEAR failed");
-    _exit(1);
+    ::exit(1);
   }
 }
 
@@ -617,14 +617,14 @@ CB_cmd_cache_check()
 
     if (res) {
       printf("\n%s failed", n);
-      _exit(1);
+      ::exit(1);
     } else {
       printf("\n%s succeeded\n", n);
-      _exit(0);
+      ::exit(0);
     }
   } else if (cacheProcessor.IsCacheEnabled() == CACHE_INIT_FAILED) {
     Note("unable to open Cache, Check failed");
-    _exit(1);
+    ::exit(1);
   }
 }
 
@@ -781,7 +781,7 @@ cmd_verify(char * /* cmd ATS_UNUSED */)
 
   // TODO: Add more config validation..
 
-  _exit(exitStatus);
+  ::exit(exitStatus);
 
   return 0;
 }
@@ -1236,7 +1236,7 @@ struct AutoStopCont : public Continuation {
   {
     (void)event;
     (void)e;
-    _exit(0);
+    ::exit(0);
     return 0;
   }
   AutoStopCont() : Continuation(new_ProxyMutex()) { SET_HANDLER(&AutoStopCont::mainEvent); }
@@ -1272,7 +1272,7 @@ struct RegressionCont : public Continuation {
     if ((res = RegressionTest::check_status()) == REGRESSION_TEST_INPROGRESS)
       return EVENT_CONT;
     fprintf(stderr, "REGRESSION_TEST DONE: %s\n", regression_status_string(res));
-    _exit(res == REGRESSION_TEST_PASSED ? 0 : 1);
+    ::exit(res == REGRESSION_TEST_PASSED ? 0 : 1);
     return EVENT_CONT;
   }
   RegressionCont() : Continuation(new_ProxyMutex()), initialized(0), waits(0), started(0)
@@ -1298,7 +1298,7 @@ chdir_root()
     fprintf(stderr, "%s: unable to change to root directory \"%s\" [%d '%s']\n", appVersionInfo.AppStr, prefix, errno,
             strerror(errno));
     fprintf(stderr, "%s: please correct the path or set the TS_ROOT environment variable\n", appVersionInfo.AppStr);
-    _exit(1);
+    ::exit(1);
   } else {
     printf("%s: using root directory '%s'\n", appVersionInfo.AppStr, prefix);
   }
@@ -1514,7 +1514,7 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   // Specific validity checks.
   if (*conf_dir && command_index != find_cmd_index(CMD_VERIFY_CONFIG)) {
     fprintf(stderr, "-D option can only be used with the %s command\n", CMD_VERIFY_CONFIG);
-    _exit(1);
+    ::exit(1);
   }
 
   // Bootstrap syslog.  Since we haven't read records.config
@@ -1645,7 +1645,7 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   // Check for core file
   if (core_file[0] != '\0') {
     process_core(core_file);
-    _exit(0);
+    ::exit(0);
   }
 
   // We need to do this early so we can initialize the Machine
@@ -1759,9 +1759,9 @@ main(int /* argc ATS_UNUSED */, const char **argv)
 
     if (cmd_ret != CMD_IN_PROGRESS) {
       if (cmd_ret >= 0)
-        _exit(0); // everything is OK
+        ::exit(0); // everything is OK
       else
-        _exit(1); // in error
+        ::exit(1); // in error
     }
   } else {
     remapProcessor.start(num_remap_threads, stacksize);

--- a/proxy/ReverseProxy.cc
+++ b/proxy/ReverseProxy.cc
@@ -74,10 +74,7 @@ init_reverse_proxy()
   rewrite_table = new UrlRewrite();
 
   if (!rewrite_table->is_valid()) {
-    Warning("Can not load the remap table, exiting out!");
-    // TODO: For now, I _exit() out of here, because otherwise we'll keep generating
-    // core files (if enabled) when starting up with a bad remap.config file.
-    _exit(-1);
+    Fatal("unable to load remap.config");
   }
 
   REC_RegisterConfigUpdateFunc("proxy.config.url_remap.filename", url_rewrite_CB, (void *)FILE_CHANGED);

--- a/proxy/logcat.cc
+++ b/proxy/logcat.cc
@@ -219,7 +219,7 @@ main(int /* argc ATS_UNUSED */, const char *argv[])
   //
   if (output_file[0] != 0 && auto_filenames) {
     fprintf(stderr, "Error: specify only one of -o <file> and -a\n");
-    _exit(CMD_LINE_OPTION_ERROR);
+    ::exit(CMD_LINE_OPTION_ERROR);
   }
   // initialize this application for standalone logging operation
   //
@@ -234,7 +234,7 @@ main(int /* argc ATS_UNUSED */, const char *argv[])
     out_fd = open_output_file(output_file);
 
     if (out_fd < 0) {
-      _exit(DATA_PROCESSING_ERROR);
+      ::exit(DATA_PROCESSING_ERROR);
     }
   } else if (!auto_filenames) {
     out_fd = STDOUT_FILENO;
@@ -305,5 +305,5 @@ main(int /* argc ATS_UNUSED */, const char *argv[])
     }
   }
 
-  _exit(error);
+  ::exit(error);
 }

--- a/proxy/logging/LogConfig.cc
+++ b/proxy/logging/LogConfig.cc
@@ -168,7 +168,7 @@ LogConfig::read_configuration_variables()
     // Try 'system_root_dir/var/log/trafficserver' directory
     fprintf(stderr, "unable to access log directory '%s': %d, %s\n", logfile_dir, errno, strerror(errno));
     fprintf(stderr, "please set 'proxy.config.log.logfile_dir'\n");
-    _exit(1);
+    ::exit(1);
   }
 
   // COLLATION

--- a/proxy/logging/LogStandalone.cc
+++ b/proxy/logging/LogStandalone.cc
@@ -152,7 +152,7 @@ check_lockfile()
   if (access(Layout::get()->runtimedir, R_OK | W_OK) == -1) {
     fprintf(stderr, "unable to access() dir'%s': %d, %s\n", Layout::get()->runtimedir, errno, strerror(errno));
     fprintf(stderr, " please set correct path in env variable TS_ROOT \n");
-    _exit(1);
+    ::exit(1);
   }
   lockfile = Layout::relative_to(Layout::get()->runtimedir, SERVER_LOCK);
 
@@ -176,7 +176,7 @@ check_lockfile()
     } else {
       fprintf(stderr, "\n");
     }
-    _exit(1);
+    ::exit(1);
   }
   ats_free(lockfile);
 }

--- a/proxy/logstats.cc
+++ b/proxy/logstats.cc
@@ -2097,7 +2097,7 @@ my_exit(const ExitStatus &status)
       std::cout << "}" << std::endl;
     else
       std::cout << "]" << std::endl;
-    _exit(status.level);
+    ::exit(status.level);
   }
 
   if (cl.json) {
@@ -2111,11 +2111,11 @@ my_exit(const ExitStatus &status)
       break;
     case EXIT_CRITICAL:
       std::cout << "critical: " << status.notice << std::endl;
-      _exit(status.level);
+      ::exit(status.level);
       break;
     case EXIT_UNKNOWN:
       std::cout << "unknown: " << status.notice << std::endl;
-      _exit(status.level);
+      ::exit(status.level);
       break;
     }
   }
@@ -2190,7 +2190,7 @@ my_exit(const ExitStatus &status)
     std::cout << std::endl << "}" << std::endl;
   }
 
-  _exit(status.level);
+  ::exit(status.level);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2283,7 +2283,7 @@ main(int /* argc ATS_UNUSED */, const char *argv[])
     if (!fs.is_open()) {
       std::cerr << "can't read " << cl.origin_file << std::endl;
       usage(argument_descriptions, countof(argument_descriptions), USAGE_LINE);
-      _exit(0);
+      ::exit(0);
     }
 
     while (!fs.eof()) {

--- a/proxy/sac.cc
+++ b/proxy/sac.cc
@@ -71,7 +71,7 @@ sac_signal_handler(int signo, siginfo_t *info, void *)
   }
 
   signal_format_siginfo(signo, info, appVersionInfo.AppStr);
-  _exit(signo);
+  ::exit(signo);
 }
 
 int

--- a/proxy/shared/DiagsConfig.cc
+++ b/proxy/shared/DiagsConfig.cc
@@ -282,7 +282,7 @@ DiagsConfig::DiagsConfig(const char *filename, const char *tags, const char *act
   if (access(logpath, W_OK | R_OK) == -1) {
     fprintf(stderr, "unable to access log directory '%s': %d, %s\n", (const char *)logpath, errno, strerror(errno));
     fprintf(stderr, "please set 'proxy.config.log.logfile_dir'\n");
-    _exit(1);
+    ::exit(1);
   }
 
   ink_filepath_make(diags_logpath, sizeof(diags_logpath), logpath, filename);


### PR DESCRIPTION
This fixes the code coverage configuration and removes calls to ``_exit`` that prevent coverage data being emitted. Note that we assume the fix for [TS-4441](https://issues.apache.org/jira/browse/TS-4441) and replace a couple of manual exits with ``Fatal``.