### PR TITLE
[TS-4444] Prevent segfault dealocating a NULL buffer_reader.

### DIFF
--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1336,8 +1336,10 @@ HttpTunnel::consumer_handler(int event, HttpTunnelConsumer *c)
     // Deallocate the reader after calling back the sm
     //  because buffer problems are easier to debug
     //  in the sm when the reader is still valid
-    c->buffer_reader->mbuf->dealloc_reader(c->buffer_reader);
-    c->buffer_reader = NULL;
+    if (c->buffer_reader) {
+      c->buffer_reader->mbuf->dealloc_reader(c->buffer_reader);
+      c->buffer_reader = NULL;
+    }
 
     // Since we removed a consumer, it may now be
     //   possbile to put more stuff in the buffer


### PR DESCRIPTION
Signed-off-by: David Calavera <david.calavera@gmail.com>