### PR TITLE
TS-4441: Stop dumping core on fatal errors.

### DIFF
--- a/lib/ts/ink_assert.cc
+++ b/lib/ts/ink_assert.cc
@@ -34,5 +34,5 @@ Assertions
 void
 _ink_assert(const char *expression, const char *file, int line)
 {
-  ink_fatal("%s:%d: failed assert `%s`", file, line, expression);
+  ink_abort("%s:%d: failed assertion `%s`", file, line, expression);
 }

--- a/lib/ts/ink_error.h
+++ b/lib/ts/ink_error.h
@@ -38,7 +38,7 @@
 
 void ink_fatal_va(const char *message_format, va_list ap) TS_NORETURN;
 void ink_fatal(const char *message_format, ...) TS_PRINTFLIKE(1, 2) TS_NORETURN;
-void ink_pfatal(const char *message_format, ...) TS_PRINTFLIKE(1, 2) TS_NORETURN;
+void ink_abort(const char *message_format, ...) TS_PRINTFLIKE(1, 2) TS_NORETURN;
 void ink_warning(const char *message_format, ...) TS_PRINTFLIKE(1, 2);
 void ink_pwarning(const char *message_format, ...) TS_PRINTFLIKE(1, 2);
 void ink_notice(const char *message_format, ...) TS_PRINTFLIKE(1, 2);

--- a/lib/ts/ink_memory.cc
+++ b/lib/ts/ink_memory.cc
@@ -57,8 +57,7 @@ ats_malloc(size_t size)
   // ink_stack_trace_dump();
   if (likely(size > 0)) {
     if (unlikely((ptr = malloc(size)) == NULL)) {
-      ink_stack_trace_dump();
-      ink_fatal("ats_malloc: couldn't allocate %zu bytes", size);
+      ink_abort("couldn't allocate %zu bytes", size);
     }
   }
   return ptr;
@@ -69,8 +68,7 @@ ats_calloc(size_t nelem, size_t elsize)
 {
   void *ptr = calloc(nelem, elsize);
   if (unlikely(ptr == NULL)) {
-    ink_stack_trace_dump();
-    ink_fatal("ats_calloc: couldn't allocate %zu %zu byte elements", nelem, elsize);
+    ink_abort("couldn't allocate %zu %zu byte elements", nelem, elsize);
   }
   return ptr;
 } /* End ats_calloc */
@@ -80,8 +78,7 @@ ats_realloc(void *ptr, size_t size)
 {
   void *newptr = realloc(ptr, size);
   if (unlikely(newptr == NULL)) {
-    ink_stack_trace_dump();
-    ink_fatal("ats_realloc: couldn't reallocate %zu bytes", size);
+    ink_abort("couldn't reallocate %zu bytes", size);
   }
   return newptr;
 } /* End ats_realloc */
@@ -106,17 +103,17 @@ ats_memalign(size_t alignment, size_t size)
 
   if (unlikely(retcode)) {
     if (retcode == EINVAL) {
-      ink_fatal("ats_memalign: couldn't allocate %zu bytes at alignment %zu - invalid alignment parameter", size, alignment);
+      ink_abort("couldn't allocate %zu bytes at alignment %zu - invalid alignment parameter", size, alignment);
     } else if (retcode == ENOMEM) {
-      ink_fatal("ats_memalign: couldn't allocate %zu bytes at alignment %zu - insufficient memory", size, alignment);
+      ink_abort("couldn't allocate %zu bytes at alignment %zu - insufficient memory", size, alignment);
     } else {
-      ink_fatal("ats_memalign: couldn't allocate %zu bytes at alignment %zu - unknown error %d", size, alignment, retcode);
+      ink_abort("couldn't allocate %zu bytes at alignment %zu - unknown error %d", size, alignment, retcode);
     }
   }
 #else
   ptr = memalign(alignment, size);
   if (unlikely(ptr == NULL)) {
-    ink_fatal("ats_memalign: couldn't allocate %zu bytes at alignment %zu", size, alignment);
+    ink_abort("couldn't allocate %zu bytes at alignment %zu", size, alignment);
   }
 #endif
   return ptr;

--- a/lib/ts/ink_queue.cc
+++ b/lib/ts/ink_queue.cc
@@ -235,9 +235,9 @@ freelist_new(InkFreeList *f)
 #ifdef SANITY
       if (result) {
         if (FREELIST_POINTER(item) == TO_PTR(FREELIST_POINTER(next)))
-          ink_fatal("ink_freelist_new: loop detected");
+          ink_abort("ink_freelist_new: loop detected");
         if (((uintptr_t)(TO_PTR(FREELIST_POINTER(next)))) & 3)
-          ink_fatal("ink_freelist_new: bad list");
+          ink_abort("ink_freelist_new: bad list");
         if (TO_PTR(FREELIST_POINTER(next)))
           fake_global_for_ink_queue = *(int *)TO_PTR(FREELIST_POINTER(next));
       }
@@ -296,9 +296,9 @@ freelist_free(InkFreeList *f, void *item)
     INK_QUEUE_LD(h, f->head);
 #ifdef SANITY
     if (TO_PTR(FREELIST_POINTER(h)) == item)
-      ink_fatal("ink_freelist_free: trying to free item twice");
+      ink_abort("ink_freelist_free: trying to free item twice");
     if (((uintptr_t)(TO_PTR(FREELIST_POINTER(h)))) & 3)
-      ink_fatal("ink_freelist_free: bad list");
+      ink_abort("ink_freelist_free: bad list");
     if (TO_PTR(FREELIST_POINTER(h)))
       fake_global_for_ink_queue = *(int *)TO_PTR(FREELIST_POINTER(h));
 #endif /* SANITY */
@@ -356,9 +356,9 @@ freelist_bulkfree(InkFreeList *f, void *head, void *tail, size_t num_item)
     INK_QUEUE_LD(h, f->head);
 #ifdef SANITY
     if (TO_PTR(FREELIST_POINTER(h)) == head)
-      ink_fatal("ink_freelist_free: trying to free item twice");
+      ink_abort("ink_freelist_free: trying to free item twice");
     if (((uintptr_t)(TO_PTR(FREELIST_POINTER(h)))) & 3)
-      ink_fatal("ink_freelist_free: bad list");
+      ink_abort("ink_freelist_free: bad list");
     if (TO_PTR(FREELIST_POINTER(h)))
       fake_global_for_ink_queue = *(int *)TO_PTR(FREELIST_POINTER(h));
 #endif /* SANITY */


### PR DESCRIPTION
On a fatal error, the core file is rarely useful, and there is a
real risk of filling up a disk with cores when we get a bad
configuration. Rather than dumping core when logging a fatal error,
just exit.