### PR TITLE
TS-4458: disabling configuration modification breaks reloading

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -69,8 +69,9 @@ for all ``INT`` type configurations
 
 .. note::
 
-    Traffic Server currently writes back configurations to disk periodically,
-    and when doing so, will not preserve the prefixes.
+    Unless :ts:cv:`proxy.config.disable_configuration_modification`
+    is enabled, Traffic Server writes configurations to back disk
+    periodically. When doing so, the unit prefixes are not preserved.
 
 Examples
 ========
@@ -522,6 +523,14 @@ will still be restricted to root processes.
 
 This setting is not reloadable, since it is must be applied when
 program:`traffic_manager` initializes.
+
+.. ts:cv:: CONFIG proxy.config.disable_configuration_modification INT 0
+   :reloadable:
+
+This setting prevents Traffic Server rewriting the :file:`records.config`
+configuration file. Dynamic configuration changes can still be made
+using :program:`traffic_ctl config set`, but these changes will not
+be persisted.
 
 Process Manager
 ===============

--- a/doc/appendices/command-line/traffic_ctl.en.rst
+++ b/doc/appendices/command-line/traffic_ctl.en.rst
@@ -143,9 +143,10 @@ traffic_ctl config
 .. program:: traffic_ctl config
 .. option:: reload
 
-    Initiate a Traffic Server configuration reload. Use this
-    command to update the running configuration after any configuration
-    file modification.
+    Initiate a Traffic Server configuration reload. Use this command
+    to update the running configuration after any configuration
+    file modification. If no configuration files have been modified
+    since the previous configuration load, this command is a no-op.
 
     The timestamp of the last reconfiguration event (in seconds
     since epoch) is published in the `proxy.node.config.reconfigure_time`

--- a/lib/records/I_RecCore.h
+++ b/lib/records/I_RecCore.h
@@ -86,19 +86,19 @@ const char *RecConfigOverrideFromEnvironment(const char *name, const char *value
 //-------------------------------------------------------------------------
 // Stat Registration
 //-------------------------------------------------------------------------
-int _RecRegisterStatInt(RecT rec_type, const char *name, RecInt data_default, RecPersistT persist_type);
+RecErrT _RecRegisterStatInt(RecT rec_type, const char *name, RecInt data_default, RecPersistT persist_type);
 #define RecRegisterStatInt(rec_type, name, data_default, persist_type) \
   _RecRegisterStatInt((rec_type), (name), (data_default), REC_PERSISTENCE_TYPE(persist_type))
 
-int _RecRegisterStatFloat(RecT rec_type, const char *name, RecFloat data_default, RecPersistT persist_type);
+RecErrT _RecRegisterStatFloat(RecT rec_type, const char *name, RecFloat data_default, RecPersistT persist_type);
 #define RecRegisterStatFloat(rec_type, name, data_default, persist_type) \
   _RecRegisterStatFloat((rec_type), (name), (data_default), REC_PERSISTENCE_TYPE(persist_type))
 
-int _RecRegisterStatString(RecT rec_type, const char *name, RecString data_default, RecPersistT persist_type);
+RecErrT _RecRegisterStatString(RecT rec_type, const char *name, RecString data_default, RecPersistT persist_type);
 #define RecRegisterStatString(rec_type, name, data_default, persist_type) \
   _RecRegisterStatString((rec_type), (name), (data_default), REC_PERSISTENCE_TYPE(persist_type))
 
-int _RecRegisterStatCounter(RecT rec_type, const char *name, RecCounter data_default, RecPersistT persist_type);
+RecErrT _RecRegisterStatCounter(RecT rec_type, const char *name, RecCounter data_default, RecPersistT persist_type);
 #define RecRegisterStatCounter(rec_type, name, data_default, persist_type) \
   _RecRegisterStatCounter((rec_type), (name), (data_default), REC_PERSISTENCE_TYPE(persist_type))
 
@@ -106,33 +106,35 @@ int _RecRegisterStatCounter(RecT rec_type, const char *name, RecCounter data_def
 // Config Registration
 //-------------------------------------------------------------------------
 
-int RecRegisterConfigInt(RecT rec_type, const char *name, RecInt data_default, RecUpdateT update_type, RecCheckT check_type,
-                         const char *ccheck_regex, RecSourceT source, RecAccessT access_type = RECA_NULL);
+RecErrT RecRegisterConfigInt(RecT rec_type, const char *name, RecInt data_default, RecUpdateT update_type, RecCheckT check_type,
+                             const char *ccheck_regex, RecSourceT source, RecAccessT access_type = RECA_NULL);
 
-int RecRegisterConfigFloat(RecT rec_type, const char *name, RecFloat data_default, RecUpdateT update_type, RecCheckT check_type,
-                           const char *check_regex, RecSourceT source, RecAccessT access_type = RECA_NULL);
+RecErrT RecRegisterConfigFloat(RecT rec_type, const char *name, RecFloat data_default, RecUpdateT update_type, RecCheckT check_type,
+                               const char *check_regex, RecSourceT source, RecAccessT access_type = RECA_NULL);
 
-int RecRegisterConfigString(RecT rec_type, const char *name, const char *data_default, RecUpdateT update_type, RecCheckT check_type,
-                            const char *check_regex, RecSourceT source, RecAccessT access_type = RECA_NULL);
+RecErrT RecRegisterConfigString(RecT rec_type, const char *name, const char *data_default, RecUpdateT update_type,
+                                RecCheckT check_type, const char *check_regex, RecSourceT source,
+                                RecAccessT access_type = RECA_NULL);
 
-int RecRegisterConfigCounter(RecT rec_type, const char *name, RecCounter data_default, RecUpdateT update_type, RecCheckT check_type,
-                             const char *check_regex, RecSourceT source, RecAccessT access_type = RECA_NULL);
+RecErrT RecRegisterConfigCounter(RecT rec_type, const char *name, RecCounter data_default, RecUpdateT update_type,
+                                 RecCheckT check_type, const char *check_regex, RecSourceT source,
+                                 RecAccessT access_type = RECA_NULL);
 
 //-------------------------------------------------------------------------
 // Config Change Notification
 //-------------------------------------------------------------------------
 
-int RecLinkConfigInt(const char *name, RecInt *rec_int);
-int RecLinkConfigInt32(const char *name, int32_t *p_int32);
-int RecLinkConfigUInt32(const char *name, uint32_t *p_uint32);
-int RecLinkConfigFloat(const char *name, RecFloat *rec_float);
-int RecLinkConfigCounter(const char *name, RecCounter *rec_counter);
-int RecLinkConfigString(const char *name, RecString *rec_string);
-int RecLinkConfigByte(const char *name, RecByte *rec_byte);
-int RecLinkConfigBool(const char *name, RecBool *rec_byte);
+RecErrT RecLinkConfigInt(const char *name, RecInt *rec_int);
+RecErrT RecLinkConfigInt32(const char *name, int32_t *p_int32);
+RecErrT RecLinkConfigUInt32(const char *name, uint32_t *p_uint32);
+RecErrT RecLinkConfigFloat(const char *name, RecFloat *rec_float);
+RecErrT RecLinkConfigCounter(const char *name, RecCounter *rec_counter);
+RecErrT RecLinkConfigString(const char *name, RecString *rec_string);
+RecErrT RecLinkConfigByte(const char *name, RecByte *rec_byte);
+RecErrT RecLinkConfigBool(const char *name, RecBool *rec_byte);
 
-int RecRegisterConfigUpdateCb(const char *name, RecConfigUpdateCb update_cb, void *cookie);
-int RecRegisterRawStatUpdateFunc(const char *name, RecRawStatBlock *rsb, int id, RecStatUpdateFunc update_func, void *cookie);
+RecErrT RecRegisterConfigUpdateCb(const char *name, RecConfigUpdateCb update_cb, void *cookie);
+RecErrT RecRegisterRawStatUpdateFunc(const char *name, RecRawStatBlock *rsb, int id, RecStatUpdateFunc update_func, void *cookie);
 
 //-------------------------------------------------------------------------
 // Record Reading/Writing
@@ -145,11 +147,13 @@ int RecRegisterRawStatUpdateFunc(const char *name, RecRawStatBlock *rsb, int id,
 // already been taken out for the callback.
 
 // RecSetRecordConvert -> WebMgmtUtils.cc::varSetFromStr()
-int RecSetRecordConvert(const char *name, const RecString rec_string, RecSourceT source, bool lock = true, bool inc_version = true);
-int RecSetRecordInt(const char *name, RecInt rec_int, RecSourceT source, bool lock = true, bool inc_version = true);
-int RecSetRecordFloat(const char *name, RecFloat rec_float, RecSourceT source, bool lock = true, bool inc_version = true);
-int RecSetRecordString(const char *name, const RecString rec_string, RecSourceT source, bool lock = true, bool inc_version = true);
-int RecSetRecordCounter(const char *name, RecCounter rec_counter, RecSourceT source, bool lock = true, bool inc_version = true);
+RecErrT RecSetRecordConvert(const char *name, const RecString rec_string, RecSourceT source, bool lock = true,
+                            bool inc_version = true);
+RecErrT RecSetRecordInt(const char *name, RecInt rec_int, RecSourceT source, bool lock = true, bool inc_version = true);
+RecErrT RecSetRecordFloat(const char *name, RecFloat rec_float, RecSourceT source, bool lock = true, bool inc_version = true);
+RecErrT RecSetRecordString(const char *name, const RecString rec_string, RecSourceT source, bool lock = true,
+                           bool inc_version = true);
+RecErrT RecSetRecordCounter(const char *name, RecCounter rec_counter, RecSourceT source, bool lock = true, bool inc_version = true);
 
 int RecGetRecordInt(const char *name, RecInt *rec_int, bool lock = true);
 int RecGetRecordFloat(const char *name, RecFloat *rec_float, bool lock = true);
@@ -298,13 +302,13 @@ RecString REC_readString(const char *name, bool *found, bool lock = true);
 //------------------------------------------------------------------------
 // Clear Statistics
 //------------------------------------------------------------------------
-int RecResetStatRecord(const char *name);
-int RecResetStatRecord(RecT type = RECT_NULL, bool all = false);
+RecErrT RecResetStatRecord(const char *name);
+RecErrT RecResetStatRecord(RecT type = RECT_NULL, bool all = false);
 
 //------------------------------------------------------------------------
 // Set RecRecord attributes
 //------------------------------------------------------------------------
-int RecSetSyncRequired(char *name, bool lock = true);
+RecErrT RecSetSyncRequired(char *name, bool lock = true);
 
 //------------------------------------------------------------------------
 // Manager Callback

--- a/lib/records/P_RecCore.cc
+++ b/lib/records/P_RecCore.cc
@@ -39,7 +39,7 @@ RecModeT g_mode_type = RECM_NULL;
 //-------------------------------------------------------------------------
 // send_reset_message
 //-------------------------------------------------------------------------
-static int
+static RecErrT
 send_reset_message(RecRecord *record)
 {
   RecMessage *m;
@@ -58,7 +58,7 @@ send_reset_message(RecRecord *record)
 //-------------------------------------------------------------------------
 // send_set_message
 //-------------------------------------------------------------------------
-static int
+static RecErrT
 send_set_message(RecRecord *record)
 {
   RecMessage *m;
@@ -77,7 +77,7 @@ send_set_message(RecRecord *record)
 //-------------------------------------------------------------------------
 // send_register_message
 //-------------------------------------------------------------------------
-int
+RecErrT
 send_register_message(RecRecord *record)
 {
   RecMessage *m;
@@ -96,7 +96,7 @@ send_register_message(RecRecord *record)
 //-------------------------------------------------------------------------
 // send_push_message
 //-------------------------------------------------------------------------
-int
+RecErrT
 send_push_message()
 {
   RecRecord *r;
@@ -130,7 +130,7 @@ send_push_message()
 //-------------------------------------------------------------------------
 // send_pull_message
 //-------------------------------------------------------------------------
-int
+RecErrT
 send_pull_message(RecMessageT msg_type)
 {
   RecRecord *r;
@@ -177,7 +177,7 @@ send_pull_message(RecMessageT msg_type)
 //-------------------------------------------------------------------------
 // recv_message_cb
 //-------------------------------------------------------------------------
-int
+RecErrT
 recv_message_cb(RecMessage *msg, RecMessageT msg_type, void * /* cookie */)
 {
   RecRecord *r;
@@ -277,25 +277,25 @@ recv_message_cb(RecMessage *msg, RecMessageT msg_type, void * /* cookie */)
     return REC_ERR_FAIL;                                                                                                        \
   }
 
-int
+RecErrT
 _RecRegisterStatInt(RecT rec_type, const char *name, RecInt data_default, RecPersistT persist_type)
 {
   REC_REGISTER_STAT_XXX(rec_int, RECD_INT);
 }
 
-int
+RecErrT
 _RecRegisterStatFloat(RecT rec_type, const char *name, RecFloat data_default, RecPersistT persist_type)
 {
   REC_REGISTER_STAT_XXX(rec_float, RECD_FLOAT);
 }
 
-int
+RecErrT
 _RecRegisterStatString(RecT rec_type, const char *name, RecString data_default, RecPersistT persist_type)
 {
   REC_REGISTER_STAT_XXX(rec_string, RECD_STRING);
 }
 
-int
+RecErrT
 _RecRegisterStatCounter(RecT rec_type, const char *name, RecCounter data_default, RecPersistT persist_type)
 {
   REC_REGISTER_STAT_XXX(rec_counter, RECD_COUNTER);
@@ -320,7 +320,7 @@ _RecRegisterStatCounter(RecT rec_type, const char *name, RecCounter data_default
     return REC_ERR_FAIL;                                                                                                        \
   }
 
-int
+RecErrT
 RecRegisterConfigInt(RecT rec_type, const char *name, RecInt data_default, RecUpdateT update_type, RecCheckT check_type,
                      const char *check_regex, RecSourceT source, RecAccessT access_type)
 {
@@ -328,7 +328,7 @@ RecRegisterConfigInt(RecT rec_type, const char *name, RecInt data_default, RecUp
   REC_REGISTER_CONFIG_XXX(rec_int, RECD_INT);
 }
 
-int
+RecErrT
 RecRegisterConfigFloat(RecT rec_type, const char *name, RecFloat data_default, RecUpdateT update_type, RecCheckT check_type,
                        const char *check_regex, RecSourceT source, RecAccessT access_type)
 {
@@ -336,7 +336,7 @@ RecRegisterConfigFloat(RecT rec_type, const char *name, RecFloat data_default, R
   REC_REGISTER_CONFIG_XXX(rec_float, RECD_FLOAT);
 }
 
-int
+RecErrT
 RecRegisterConfigString(RecT rec_type, const char *name, const char *data_default_tmp, RecUpdateT update_type, RecCheckT check_type,
                         const char *check_regex, RecSourceT source, RecAccessT access_type)
 {
@@ -345,7 +345,7 @@ RecRegisterConfigString(RecT rec_type, const char *name, const char *data_defaul
   REC_REGISTER_CONFIG_XXX(rec_string, RECD_STRING);
 }
 
-int
+RecErrT
 RecRegisterConfigCounter(RecT rec_type, const char *name, RecCounter data_default, RecUpdateT update_type, RecCheckT check_type,
                          const char *check_regex, RecSourceT source, RecAccessT access_type)
 {
@@ -356,11 +356,11 @@ RecRegisterConfigCounter(RecT rec_type, const char *name, RecCounter data_defaul
 //-------------------------------------------------------------------------
 // RecSetRecordXXX
 //-------------------------------------------------------------------------
-int
+RecErrT
 RecSetRecord(RecT rec_type, const char *name, RecDataT data_type, RecData *data, RecRawStat *data_raw, RecSourceT source, bool lock,
              bool inc_version)
 {
-  int err = REC_ERR_OKAY;
+  RecErrT err = REC_ERR_OKAY;
   RecRecord *r1;
 
   // FIXME: Most of the time we set, we don't actually need to wrlock
@@ -452,7 +452,7 @@ Ldone:
   return err;
 }
 
-int
+RecErrT
 RecSetRecordConvert(const char *name, const RecString rec_string, RecSourceT source, bool lock, bool inc_version)
 {
   RecData data;
@@ -460,7 +460,7 @@ RecSetRecordConvert(const char *name, const RecString rec_string, RecSourceT sou
   return RecSetRecord(RECT_NULL, name, RECD_NULL, &data, NULL, source, lock, inc_version);
 }
 
-int
+RecErrT
 RecSetRecordInt(const char *name, RecInt rec_int, RecSourceT source, bool lock, bool inc_version)
 {
   RecData data;
@@ -468,7 +468,7 @@ RecSetRecordInt(const char *name, RecInt rec_int, RecSourceT source, bool lock, 
   return RecSetRecord(RECT_NULL, name, RECD_INT, &data, NULL, source, lock, inc_version);
 }
 
-int
+RecErrT
 RecSetRecordFloat(const char *name, RecFloat rec_float, RecSourceT source, bool lock, bool inc_version)
 {
   RecData data;
@@ -476,7 +476,7 @@ RecSetRecordFloat(const char *name, RecFloat rec_float, RecSourceT source, bool 
   return RecSetRecord(RECT_NULL, name, RECD_FLOAT, &data, NULL, source, lock, inc_version);
 }
 
-int
+RecErrT
 RecSetRecordString(const char *name, const RecString rec_string, RecSourceT source, bool lock, bool inc_version)
 {
   RecData data;
@@ -484,7 +484,7 @@ RecSetRecordString(const char *name, const RecString rec_string, RecSourceT sour
   return RecSetRecord(RECT_NULL, name, RECD_STRING, &data, NULL, source, lock, inc_version);
 }
 
-int
+RecErrT
 RecSetRecordCounter(const char *name, RecCounter rec_counter, RecSourceT source, bool lock, bool inc_version)
 {
   RecData data;
@@ -495,7 +495,7 @@ RecSetRecordCounter(const char *name, RecCounter rec_counter, RecSourceT source,
 //-------------------------------------------------------------------------
 // RecReadStatsFile
 //-------------------------------------------------------------------------
-int
+RecErrT
 RecReadStatsFile()
 {
   RecRecord *r;
@@ -551,7 +551,7 @@ RecReadStatsFile()
 //-------------------------------------------------------------------------
 // RecSyncStatsFile
 //-------------------------------------------------------------------------
-int
+RecErrT
 RecSyncStatsFile()
 {
   RecRecord *r;
@@ -606,7 +606,7 @@ RecConsumeConfigEntry(RecT rec_type, RecDataT data_type, const char *name, const
 //-------------------------------------------------------------------------
 // RecReadConfigFile
 //-------------------------------------------------------------------------
-int
+RecErrT
 RecReadConfigFile(bool inc_version)
 {
   RecDebug(DL_Note, "Reading '%s'", g_rec_config_fpath);
@@ -626,14 +626,15 @@ RecReadConfigFile(bool inc_version)
 //-------------------------------------------------------------------------
 // RecSyncConfigFile
 //-------------------------------------------------------------------------
-int
+RecErrT
 RecSyncConfigToTB(textBuffer *tb, bool *inc_version)
 {
-  int err = REC_ERR_FAIL;
+  RecErrT err = REC_ERR_FAIL;
 
   if (inc_version != NULL) {
     *inc_version = false;
   }
+
   /*
    * g_mode_type should be initialized by
    * RecLocalInit() or RecProcessInit() earlier.
@@ -808,11 +809,11 @@ RecExecConfigUpdateCbs(unsigned int update_required_type)
 //------------------------------------------------------------------------
 // RecResetStatRecord
 //------------------------------------------------------------------------
-int
+RecErrT
 RecResetStatRecord(const char *name)
 {
   RecRecord *r1 = NULL;
-  int err = REC_ERR_OKAY;
+  RecErrT err = REC_ERR_OKAY;
 
   if (ink_hash_table_lookup(g_records_ht, name, (void **)&r1)) {
     if (i_am_the_record_owner(r1->rec_type)) {
@@ -843,11 +844,11 @@ RecResetStatRecord(const char *name)
 //------------------------------------------------------------------------
 // RecResetStatRecord
 //------------------------------------------------------------------------
-int
+RecErrT
 RecResetStatRecord(RecT type, bool all)
 {
   int i, num_records;
-  int err = REC_ERR_OKAY;
+  RecErrT err = REC_ERR_OKAY;
 
   RecDebug(DL_Note, "Reset Statistics Records");
 
@@ -881,10 +882,10 @@ RecResetStatRecord(RecT type, bool all)
   return err;
 }
 
-int
+RecErrT
 RecSetSyncRequired(char *name, bool lock)
 {
-  int err = REC_ERR_FAIL;
+  RecErrT err = REC_ERR_FAIL;
   RecRecord *r1;
 
   // FIXME: Most of the time we set, we don't actually need to wrlock
@@ -930,7 +931,7 @@ RecSetSyncRequired(char *name, bool lock)
   return err;
 }
 
-int
+RecErrT
 RecWriteConfigFile(textBuffer *tb)
 {
 #define TMP_FILENAME_EXT_STR ".tmp"
@@ -939,7 +940,7 @@ RecWriteConfigFile(textBuffer *tb)
   int nbytes;
   int filename_len;
   int tmp_filename_len;
-  int result;
+  RecErrT result;
   char buff[1024];
   char *tmp_filename;
 
@@ -1002,5 +1003,6 @@ RecWriteConfigFile(textBuffer *tb)
   if (tmp_filename != buff) {
     ats_free(tmp_filename);
   }
+
   return result;
 }

--- a/lib/records/P_RecCore.h
+++ b/lib/records/P_RecCore.h
@@ -68,33 +68,31 @@ RecRecord *RecForceInsert(RecRecord *record);
 // Setting/Getting
 //-------------------------------------------------------------------------
 
-int RecSetRecord(RecT rec_type, const char *name, RecDataT data_type, RecData *data, RecRawStat *raw_stat, RecSourceT source,
-                 bool lock = true, bool inc_version = true);
+RecErrT RecSetRecord(RecT rec_type, const char *name, RecDataT data_type, RecData *data, RecRawStat *raw_stat, RecSourceT source,
+                     bool lock = true, bool inc_version = true);
 
-int RecGetRecord_Xmalloc(const char *name, RecDataT data_type, RecData *data, bool lock = true);
+RecErrT RecGetRecord_Xmalloc(const char *name, RecDataT data_type, RecData *data, bool lock = true);
 
 //-------------------------------------------------------------------------
 // Read/Sync to Disk
 //-------------------------------------------------------------------------
 
-int RecReadStatsFile();
-int RecSyncStatsFile();
-int RecReadConfigFile(bool inc_version);
-int RecWriteConfigFile(textBuffer *tb);
-int RecSyncConfigToTB(textBuffer *tb, bool *inc_version = NULL);
+RecErrT RecReadStatsFile();
+RecErrT RecSyncStatsFile();
+RecErrT RecReadConfigFile(bool inc_version);
+RecErrT RecWriteConfigFile(textBuffer *tb);
+RecErrT RecSyncConfigToTB(textBuffer *tb, bool *inc_version = NULL);
 
 //-------------------------------------------------------------------------
 // Misc
 //-------------------------------------------------------------------------
 
 bool i_am_the_record_owner(RecT rec_type);
-int send_push_message();
-int send_pull_message(RecMessageT msg_type);
-int send_register_message(RecRecord *record);
-int recv_message_cb(RecMessage *msg, RecMessageT msg_type, void *cookie);
+RecErrT send_push_message();
+RecErrT send_pull_message(RecMessageT msg_type);
+RecErrT send_register_message(RecRecord *record);
+RecErrT recv_message_cb(RecMessage *msg, RecMessageT msg_type, void *cookie);
 RecUpdateT RecExecConfigUpdateCbs(unsigned int update_required_type);
-int RecExecStatUpdateFuncs();
-int RecExecRawStatUpdateFuncs();
 
 void RecDumpRecordsHt(RecT rec_type = RECT_NULL);
 

--- a/lib/records/P_RecDefs.h
+++ b/lib/records/P_RecDefs.h
@@ -161,6 +161,6 @@ typedef RecMessageHdr RecMessage;
 
 typedef void (*RecDumpEntryCb)(RecT rec_type, void *edata, int registered, const char *name, int data_type, RecData *datum);
 
-typedef int (*RecMessageRecvCb)(RecMessage *msg, RecMessageT msg_type, void *cookie);
+typedef RecErrT (*RecMessageRecvCb)(RecMessage *msg, RecMessageT msg_type, void *cookie);
 
 #endif

--- a/lib/records/RecCore.cc
+++ b/lib/records/RecCore.cc
@@ -239,7 +239,7 @@ RecCoreInit(RecModeT mode_type, Diags *_diags)
 //-------------------------------------------------------------------------
 // RecLinkCnfigXXX
 //-------------------------------------------------------------------------
-int
+RecErrT
 RecLinkConfigInt(const char *name, RecInt *rec_int)
 {
   if (RecGetRecordInt(name, rec_int) == REC_ERR_FAIL) {
@@ -248,19 +248,19 @@ RecLinkConfigInt(const char *name, RecInt *rec_int)
   return RecRegisterConfigUpdateCb(name, link_int, (void *)rec_int);
 }
 
-int
+RecErrT
 RecLinkConfigInt32(const char *name, int32_t *p_int32)
 {
   return RecRegisterConfigUpdateCb(name, link_int32, (void *)p_int32);
 }
 
-int
+RecErrT
 RecLinkConfigUInt32(const char *name, uint32_t *p_uint32)
 {
   return RecRegisterConfigUpdateCb(name, link_uint32, (void *)p_uint32);
 }
 
-int
+RecErrT
 RecLinkConfigFloat(const char *name, RecFloat *rec_float)
 {
   if (RecGetRecordFloat(name, rec_float) == REC_ERR_FAIL) {
@@ -269,7 +269,7 @@ RecLinkConfigFloat(const char *name, RecFloat *rec_float)
   return RecRegisterConfigUpdateCb(name, link_float, (void *)rec_float);
 }
 
-int
+RecErrT
 RecLinkConfigCounter(const char *name, RecCounter *rec_counter)
 {
   if (RecGetRecordCounter(name, rec_counter) == REC_ERR_FAIL) {
@@ -278,7 +278,7 @@ RecLinkConfigCounter(const char *name, RecCounter *rec_counter)
   return RecRegisterConfigUpdateCb(name, link_counter, (void *)rec_counter);
 }
 
-int
+RecErrT
 RecLinkConfigString(const char *name, RecString *rec_string)
 {
   if (RecGetRecordString_Xmalloc(name, rec_string) == REC_ERR_FAIL) {
@@ -287,7 +287,7 @@ RecLinkConfigString(const char *name, RecString *rec_string)
   return RecRegisterConfigUpdateCb(name, link_string_alloc, (void *)rec_string);
 }
 
-int
+RecErrT
 RecLinkConfigByte(const char *name, RecByte *rec_byte)
 {
   if (RecGetRecordByte(name, rec_byte) == REC_ERR_FAIL) {
@@ -296,7 +296,7 @@ RecLinkConfigByte(const char *name, RecByte *rec_byte)
   return RecRegisterConfigUpdateCb(name, link_byte, (void *)rec_byte);
 }
 
-int
+RecErrT
 RecLinkConfigBool(const char *name, RecBool *rec_bool)
 {
   if (RecGetRecordBool(name, rec_bool) == REC_ERR_FAIL) {
@@ -308,10 +308,10 @@ RecLinkConfigBool(const char *name, RecBool *rec_bool)
 //-------------------------------------------------------------------------
 // RecRegisterConfigUpdateCb
 //-------------------------------------------------------------------------
-int
+RecErrT
 RecRegisterConfigUpdateCb(const char *name, RecConfigUpdateCb update_cb, void *cookie)
 {
-  int err = REC_ERR_FAIL;
+  RecErrT err = REC_ERR_FAIL;
   RecRecord *r;
 
   ink_rwlock_rdlock(&g_records_rwlock);
@@ -861,10 +861,10 @@ RecRegisterConfig(RecT rec_type, const char *name, RecDataT data_type, RecData d
 //-------------------------------------------------------------------------
 // RecGetRecord_Xmalloc
 //-------------------------------------------------------------------------
-int
+RecErrT
 RecGetRecord_Xmalloc(const char *name, RecDataT data_type, RecData *data, bool lock)
 {
-  int err = REC_ERR_OKAY;
+  RecErrT err = REC_ERR_OKAY;
   RecRecord *r;
 
   if (lock) {

--- a/lib/records/RecProcess.cc
+++ b/lib/records/RecProcess.cc
@@ -190,11 +190,16 @@ struct sync_cont : public Continuation {
   int
   sync(int /* event */, Event * /* e */)
   {
+    RecBool disabled = false;
+    RecGetRecordBool("proxy.config.disable_configuration_modification", &disabled);
+
     send_push_message();
     RecSyncStatsFile();
-    if (RecSyncConfigToTB(m_tb) == REC_ERR_OKAY) {
+
+    if (!disabled && RecSyncConfigToTB(m_tb) == REC_ERR_OKAY) {
       RecWriteConfigFile(m_tb);
     }
+
     Debug("statsproc", "sync_cont() processed");
 
     return EVENT_CONT;
@@ -295,16 +300,9 @@ RecProcessStart(void)
   Debug("statsproc", "raw-stat syncer");
   raw_stat_sync_cont_event = eventProcessor.schedule_every(rssc, HRTIME_MSECONDS(g_rec_raw_stat_sync_interval_ms), ET_TASK);
 
-  RecInt disable_modification = 0;
-  RecGetRecordInt("proxy.config.disable_configuration_modification", &disable_modification);
-  // Schedule continuation to call the configuration callbacks if we are allowed to modify configuration in RAM
-  if (disable_modification == 1) {
-    Debug("statsproc", "Disabled configuration modification");
-  } else {
-    config_update_cont *cuc = new config_update_cont(new_ProxyMutex());
-    Debug("statsproc", "config syncer");
-    config_update_cont_event = eventProcessor.schedule_every(cuc, HRTIME_MSECONDS(g_rec_config_update_interval_ms), ET_TASK);
-  }
+  config_update_cont *cuc = new config_update_cont(new_ProxyMutex());
+  Debug("statsproc", "config syncer");
+  config_update_cont_event = eventProcessor.schedule_every(cuc, HRTIME_MSECONDS(g_rec_config_update_interval_ms), ET_TASK);
 
   sync_cont *sc = new sync_cont(new_ProxyMutex());
   Debug("statsproc", "remote syncer");

--- a/lib/records/RecProcess.cc
+++ b/lib/records/RecProcess.cc
@@ -122,10 +122,10 @@ RecProcess_set_remote_sync_interval_ms(int ms)
 //-------------------------------------------------------------------------
 // recv_message_cb__process
 //-------------------------------------------------------------------------
-static int
+static RecErrT
 recv_message_cb__process(RecMessage *msg, RecMessageT msg_type, void *cookie)
 {
-  int err;
+  RecErrT err;
 
   if ((err = recv_message_cb(msg, msg_type, cookie)) == REC_ERR_OKAY) {
     if (msg_type == RECG_PULL_ACK) {

--- a/mgmt/FileManager.cc
+++ b/mgmt/FileManager.cc
@@ -38,18 +38,6 @@
 
 typedef fileEntry snapshot;
 
-const char *SnapshotStrings[] = {"Request Successful\n",
-                                 "No Snapshot Directory",
-                                 "Snapshot was not found\n",
-                                 "Creation of snapshot directory failed\n",
-                                 "Creation of snapshot file failed\n",
-                                 "Access to snapshot file Failed\n",
-                                 "Unable to write to snapshot file\n",
-                                 "Remove of Snapshot failed\n",
-                                 "Internal Error: Form Submission was invalid\n",
-                                 "No Snapshot Name Was Given\n",
-                                 "Invalid Snapshot name\n"};
-
 FileManager::FileManager()
 {
   bindings = ink_hash_table_create(InkHashTableKeyType_String);

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1095,7 +1095,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.hostdb.host_file.interval", RECD_INT, "86400", RECU_DYNAMIC, RR_NULL, RECC_NULL, NULL, RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.disable_configuration_modification", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_NULL, "[0-1]", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.disable_configuration_modification", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_NULL, "[0-1]", RECA_NULL}
   ,
   //##########################################################################
   //#

--- a/mgmt/WebMgmtUtils.cc
+++ b/mgmt/WebMgmtUtils.cc
@@ -254,7 +254,7 @@ varSetInt(const char *varName, RecInt value, bool convert)
 bool
 varSetData(RecDataT varType, const char *varName, RecData value)
 {
-  int err = REC_ERR_FAIL;
+  RecErrT err = REC_ERR_FAIL;
 
   switch (varType) {
   case RECD_INT:


### PR DESCRIPTION
If you set ``proxy.config.disable_configuration_modification`` to 1, records configuration callbacks are never registered, so if you update records.config and then reload with ``traffic_ctl config reload``, the new configuration is not actually applied.
