### PR TITLE
TS-4448 Remove superfluous \n in Debug() statements

### DIFF
--- a/cmd/traffic_manager/AddConfigFilesHere.cc
+++ b/cmd/traffic_manager/AddConfigFilesHere.cc
@@ -39,7 +39,7 @@ extern FileManager *configFiles;
 void
 testcall(char *foo, bool /* incVersion */)
 {
-  Debug("lm", "Received Callback that %s has changed\n", foo);
+  Debug("lm", "Received Callback that %s has changed", foo);
 }
 
 //

--- a/cmd/traffic_manager/StatProcessor.cc
+++ b/cmd/traffic_manager/StatProcessor.cc
@@ -84,7 +84,7 @@ elementStart(void * /* userData ATS_UNUSED */, const xmlchar *name, const xmlcha
   switch (currentTag) {
   case STAT_TAG:
     statObject = new StatObject(++statCount);
-    Debug(MODULE_INIT, "\nStat #: ----------------------- %d -----------------------\n", statCount);
+    Debug(MODULE_INIT, "\nStat #: ----------------------- %d -----------------------", statCount);
 
     if (atts)
       for (i = 0; atts[i]; i += 2) {
@@ -102,7 +102,7 @@ elementStart(void * /* userData ATS_UNUSED */, const xmlchar *name, const xmlcha
           statObject->m_debug = (atts[i + 1] && atts[i + 1][0] == '1');
         }
 
-        Debug(MODULE_INIT, "\tDESTINTATION w/ attribute: %s -> %s\n", atts[i], atts[i + 1]);
+        Debug(MODULE_INIT, "\tDESTINTATION w/ attribute: %s -> %s", atts[i], atts[i + 1]);
       }
     break;
 
@@ -124,13 +124,13 @@ elementStart(void * /* userData ATS_UNUSED */, const xmlchar *name, const xmlcha
           sumClusterVar = (!xml_strcmp(atts[i + 1], "sum") ? true : false);
         }
 
-        Debug(MODULE_INIT, "\tDESTINTATION w/ attribute: %s -> %s\n", atts[i], atts[i + 1]);
+        Debug(MODULE_INIT, "\tDESTINTATION w/ attribute: %s -> %s", atts[i], atts[i + 1]);
       }
 
     break;
 
   case INVALID_TAG:
-    Debug(MODULE_INIT, "==========================================>%s<=\n", name);
+    Debug(MODULE_INIT, "==========================================>%s<=", name);
     break;
 
   default:
@@ -196,7 +196,7 @@ StatProcessor::rereadConfig(FileManager *configFiles)
 
   int ret = configFiles->getRollbackObj(STAT_CONFIG_FILE, &fileRB);
   if (!ret) {
-    Debug(MODULE_INIT, " Can't get Rollback for file: %s\n", STAT_CONFIG_FILE);
+    Debug(MODULE_INIT, " Can't get Rollback for file: %s", STAT_CONFIG_FILE);
   }
   fileVersion = fileRB->getCurrentVersion();
   fileRB->getVersion(fileVersion, &fileContent);
@@ -259,7 +259,7 @@ StatProcessor::rereadConfig(FileManager *configFiles)
 
 StatProcessor::~StatProcessor()
 {
-  Debug(MODULE_INIT, "[StatProcessor] Destructing Statistics Processor\n");
+  Debug(MODULE_INIT, "[StatProcessor] Destructing Statistics Processor");
 }
 
 void
@@ -319,7 +319,7 @@ StatProcessor::processStat()
 {
   unsigned short result = 0;
 
-  Debug(MODULE_INIT, "[StatProcessor] Processing Statistics....\n");
+  Debug(MODULE_INIT, "[StatProcessor] Processing Statistics....");
 
   //    setTest();
   statObjectList.Eval();

--- a/cmd/traffic_manager/StatType.cc
+++ b/cmd/traffic_manager/StatType.cc
@@ -456,7 +456,7 @@ void
 StatObject::assignDst(const char *str, bool m_node_var, bool m_sum_var)
 {
   if (StatDebug) {
-    Debug(MODULE_INIT, "DESTINTATION: %s\n", str);
+    Debug(MODULE_INIT, "DESTINTATION: %s", str);
   }
 
   StatExprToken *statToken = new StatExprToken();
@@ -500,7 +500,7 @@ StatObject::assignExpr(char *str)
   StatExprToken *statToken = NULL;
 
   if (StatDebug) {
-    Debug(MODULE_INIT, "EXPRESSION: %s\n", str);
+    Debug(MODULE_INIT, "EXPRESSION: %s", str);
   }
   ink_assert(m_expr_string == NULL);
   // We take ownership here
@@ -522,7 +522,7 @@ StatObject::assignExpr(char *str)
       ink_assert(statToken->m_token_name == NULL);
 
       if (StatDebug) {
-        Debug(MODULE_INIT, "\toperator: ->%c<-\n", statToken->m_arith_symbol);
+        Debug(MODULE_INIT, "\toperator: ->%c<-", statToken->m_arith_symbol);
       }
 
     } else {
@@ -542,7 +542,7 @@ StatObject::assignExpr(char *str)
       statToken->assignTokenName(token);
 
       if (StatDebug) {
-        Debug(MODULE_INIT, "\toperand:  ->%s<-\n", token);
+        Debug(MODULE_INIT, "\toperand:  ->%s<-", token);
       }
     }
 
@@ -794,7 +794,7 @@ StatObject::setTokenValue(StatExprToken *token, bool cluster)
 
     default:
       if (StatDebug) {
-        Debug(MODULE, "Unrecognized token \"%s\" of type %d.\n", token->m_token_name, token->m_token_type);
+        Debug(MODULE, "Unrecognized token \"%s\" of type %d.", token->m_token_name, token->m_token_type);
       }
     } // switch
   }   // m_token_name?
@@ -999,7 +999,7 @@ StatObjectList::Eval()
     StatDebug = object->m_debug;
 
     if (StatDebug) {
-      Debug(MODULE, "\n##### %d #####\n", object->m_id);
+      Debug(MODULE, "\n##### %d #####", object->m_id);
     }
 
     if (object->m_update_interval <= 0) {
@@ -1025,8 +1025,7 @@ StatObjectList::Eval()
       delta = object->m_current_time - object->m_last_update;
 
       if (StatDebug) {
-        Debug(MODULE, "\tUPDATE:%" PRId64 " THRESHOLD:%" PRId64 ", DELTA:%" PRId64 "\n", object->m_update_interval, threshold,
-              delta);
+        Debug(MODULE, "\tUPDATE:%" PRId64 " THRESHOLD:%" PRId64 ", DELTA:%" PRId64 "", object->m_update_interval, threshold, delta);
       }
 
       /* Should we do the calculation? */
@@ -1036,19 +1035,19 @@ StatObjectList::Eval()
 
         if (StatDebug) {
           if (delta > threshold) {
-            Debug(MODULE, "\t\tdelta > threshold IS TRUE!\n");
+            Debug(MODULE, "\t\tdelta > threshold IS TRUE!");
           }
           if (object->m_last_update == -1) {
-            Debug(MODULE, "\t\tm_last_update = -1 IS TRUE!\n");
+            Debug(MODULE, "\t\tm_last_update = -1 IS TRUE!");
           }
           if (object->m_last_update > object->m_current_time) {
-            Debug(MODULE, "\t\tm_last_update > m_current_time IS TRUE\n");
+            Debug(MODULE, "\t\tm_last_update > m_current_time IS TRUE");
           }
         }
 
         if (!object->m_has_delta) {
           if (StatDebug) {
-            Debug(MODULE, "\tEVAL: Simple time-condition.\n");
+            Debug(MODULE, "\tEVAL: Simple time-condition.");
           }
 
           if (object->m_node_dest) {
@@ -1065,7 +1064,7 @@ StatObjectList::Eval()
         } else {
           /* has delta */
           if (StatDebug) {
-            Debug(MODULE, "\tEVAL: Complicated time-condition.\n");
+            Debug(MODULE, "\tEVAL: Complicated time-condition.");
           }
           // scroll old values
           for (StatExprToken *token = object->m_postfix->first(); token; token = object->m_expression->next(token)) {
@@ -1101,13 +1100,13 @@ StatObjectList::Eval()
             object->m_last_update = object->m_current_time;
           } else {
             if (StatDebug) {
-              Debug(MODULE, "\tEVAL: Timer not expired, do nothing\n");
+              Debug(MODULE, "\tEVAL: Timer not expired, do nothing");
             }
           }
         } /* delta? */
       } else {
         if (StatDebug) {
-          Debug(MODULE, "\tEVAL: Timer not expired, nor 1st time, nor wrapped, SORRY!\n");
+          Debug(MODULE, "\tEVAL: Timer not expired, nor 1st time, nor wrapped, SORRY!");
         }
       } /* timed event */
     }
@@ -1127,7 +1126,7 @@ StatObjectList::print(const char *prefix)
 {
   for (StatObject *object = first(); object; object = next(object)) {
     if (StatDebug) {
-      Debug(MODULE, "\n%sSTAT OBJECT#: %d\n", prefix, object->m_id);
+      Debug(MODULE, "\n%sSTAT OBJECT#: %d", prefix, object->m_id);
     }
 
     if (object->m_expression) {

--- a/doc/developer-guide/debugging/debug-tags.en.rst
+++ b/doc/developer-guide/debugging/debug-tags.en.rst
@@ -54,7 +54,7 @@ Example:
 
 .. code-block:: c
 
-       TSDebug ("my-plugin", "Starting my-plugin at %d\n", the_time);
+       TSDebug ("my-plugin", "Starting my-plugin at %d", the_time);
 
 The statement ``"Starting my-plugin at <time>"`` appears whenever you
 run Traffic Server with the ``my-plugin`` tag:

--- a/doc/developer-guide/plugins/example-plugins/blacklist/index.en.rst
+++ b/doc/developer-guide/plugins/example-plugins/blacklist/index.en.rst
@@ -86,7 +86,7 @@ that might be sent to it:
             handle_response (txnp);
             return 0;
          default:
-            TSDebug ("blacklist_plugin", "This event was unexpected: %d\n", );
+            TSDebug ("blacklist_plugin", "This event was unexpected: %d", );
             break;
       }
       return 0;

--- a/example/blacklist-1/blacklist-1.c
+++ b/example/blacklist-1/blacklist-1.c
@@ -107,7 +107,7 @@ handle_dns(TSHttpTxn txnp, TSCont contp)
       if (log) {
         TSTextLogObjectWrite(log, "blacklisting site: %s", sites[i]);
       } else {
-        TSDebug("blacklist-1", "blacklisting site: %s\n", sites[i]);
+        TSDebug("blacklist-1", "blacklisting site: %s", sites[i]);
       }
       TSHttpTxnHookAdd(txnp, TS_HTTP_SEND_RESPONSE_HDR_HOOK, contp);
       TSHandleMLocRelease(bufp, hdr_loc, url_loc);
@@ -270,7 +270,7 @@ blacklist_plugin(TSCont contp, TSEvent event, void *edata)
         handle_response(cd->txnp, contp);
         return 0;
       default:
-        TSDebug("blacklist_plugin", "This event was unexpected: %d\n", event);
+        TSDebug("blacklist_plugin", "This event was unexpected: %d", event);
         break;
       }
     } else {

--- a/example/hello/hello.c
+++ b/example/hello/hello.c
@@ -39,5 +39,5 @@ TSPluginInit(int argc ATS_UNUSED, const char *argv[] ATS_UNUSED)
     TSError("[hello-world] Plugin registration failed.");
   }
 
-  TSDebug("debug-hello", "Hello World!\n");
+  TSDebug("debug-hello", "Hello World!");
 }

--- a/example/redirect-1/redirect-1.c
+++ b/example/redirect-1/redirect-1.c
@@ -367,7 +367,7 @@ TSPluginInit(int argc, const char *argv[])
 
   TSDebug("redirect_init", "block_ip is %s, url_redirect is %s, and uri_redirect is %s", block_ip, url_redirect, uri_redirect);
   // ToDo: Should figure out how to print IPs which are IPv4 / v6.
-  // TSDebug("redirect_init", "ip_deny is %ld\n", ip_deny);
+  // TSDebug("redirect_init", "ip_deny is %ld", ip_deny);
 
   /*
    *  Demonstrate another tracing function.  This can be used to

--- a/example/remap/remap.cc
+++ b/example/remap/remap.cc
@@ -146,7 +146,7 @@ TSPluginInit(int argc ATS_UNUSED, const char *argv[] ATS_UNUSED)
   if (TSPluginRegister(&info) != TS_SUCCESS) {
     TSError("[remap] Plugin registration failed.");
   }
-  TSDebug("debug-remap", "TSPluginInit: Remap plugin started\n");
+  TSDebug("debug-remap", "TSPluginInit: Remap plugin started");
 }
 
 // Plugin initialization code. Called immediately after dlopen() Only once!

--- a/example/session-1/session-1.c
+++ b/example/session-1/session-1.c
@@ -79,7 +79,7 @@ ssn_handler(TSCont contp, TSEvent event, void *edata)
     return 0;
 
   default:
-    TSDebug("tag_session", "In the default case: event = %d\n", event);
+    TSDebug("tag_session", "In the default case: event = %d", event);
     break;
   }
   return 0;

--- a/example/version/version.c
+++ b/example/version/version.c
@@ -63,6 +63,6 @@ TSPluginInit(int argc, const char *argv[])
     TSError("[version] Plugin registration failed. \n");
   }
 
-  TSDebug("debug-version-plugin", "Running in Apache Traffic Server: v%d.%d.%d\n", major_ts_version, minor_ts_version,
+  TSDebug("debug-version-plugin", "Running in Apache Traffic Server: v%d.%d.%d", major_ts_version, minor_ts_version,
           patch_ts_version);
 }

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -2346,7 +2346,7 @@ CacheVC::handleReadDone(int event, Event *e)
       if (upgrade_doc_version(buf)) {
         doc = reinterpret_cast<Doc *>(buf->data()); // buf may be a new copy
       } else {
-        Debug("cache_bc", "Upgrade of fragment failed - disk %s - doc id = %" PRIx64 ":%" PRIx64 "\n", vol->hash_text.get(),
+        Debug("cache_bc", "Upgrade of fragment failed - disk %s - doc id = %" PRIx64 ":%" PRIx64 "", vol->hash_text.get(),
               read_key->slice64(0), read_key->slice64(1));
         doc->magic = DOC_CORRUPT;
         // Should really trash the directory entry for this, as it's never going to work in the future.

--- a/iocore/cache/CacheHosting.cc
+++ b/iocore/cache/CacheHosting.cc
@@ -671,7 +671,7 @@ ConfigVolumes::BuildListFromString(char *config_file_path, char *file_buf)
           num_http_volumes++;
         else
           num_stream_volumes++;
-        Debug("cache_hosting", "added volume=%d, scheme=%d, size=%d percent=%d\n", volume_number, scheme, size, in_percent);
+        Debug("cache_hosting", "added volume=%d, scheme=%d, size=%d percent=%d", volume_number, scheme, size, in_percent);
         break;
       }
 

--- a/iocore/cache/CachePages.cc
+++ b/iocore/cache/CachePages.cc
@@ -603,7 +603,7 @@ ShowCache::handleCacheScanCallback(int event, Event *e)
       int erroffset;
       pcre *preq = pcre_compile(show_cache_urlstrs[s], 0, &error, &erroffset, NULL);
 
-      Debug("cache_inspector", "matching url '%s' '%s' with regex '%s'\n", m, xx, show_cache_urlstrs[s]);
+      Debug("cache_inspector", "matching url '%s' '%s' with regex '%s'", m, xx, show_cache_urlstrs[s]);
 
       if (preq) {
         int r = pcre_exec(preq, NULL, xx, ib, 0, 0, NULL, 0);

--- a/iocore/cache/CacheWrite.cc
+++ b/iocore/cache/CacheWrite.cc
@@ -315,7 +315,7 @@ Vol::aggWriteDone(int event, Event *e)
     header->last_write_pos = header->write_pos;
     header->write_pos += io.aiocb.aio_nbytes;
     ink_assert(header->write_pos >= start);
-    DDebug("cache_agg", "Dir %s, Write: %" PRIu64 ", last Write: %" PRIu64 "\n", hash_text.get(), header->write_pos,
+    DDebug("cache_agg", "Dir %s, Write: %" PRIu64 ", last Write: %" PRIu64 "", hash_text.get(), header->write_pos,
            header->last_write_pos);
     ink_assert(header->write_pos == header->agg_pos);
     if (header->write_pos + EVACUATION_SIZE > scan_pos)
@@ -1073,14 +1073,14 @@ CacheVC::openWriteCloseDir(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED *
   if (is_debug_tag_set("cache_update")) {
     if (f.update && closed > 0) {
       if (!total_len && alternate_index != CACHE_ALT_REMOVED) {
-        Debug("cache_update", "header only %d (%" PRIu64 ", %" PRIu64 ")\n", DIR_MASK_TAG(first_key.slice32(2)), update_key.b[0],
+        Debug("cache_update", "header only %d (%" PRIu64 ", %" PRIu64 ")", DIR_MASK_TAG(first_key.slice32(2)), update_key.b[0],
               update_key.b[1]);
 
       } else if (total_len && alternate_index != CACHE_ALT_REMOVED) {
-        Debug("cache_update", "header body, %d, (%" PRIu64 ", %" PRIu64 "), (%" PRIu64 ", %" PRIu64 ")\n",
+        Debug("cache_update", "header body, %d, (%" PRIu64 ", %" PRIu64 "), (%" PRIu64 ", %" PRIu64 ")",
               DIR_MASK_TAG(first_key.slice32(2)), update_key.b[0], update_key.b[1], earliest_key.b[0], earliest_key.b[1]);
       } else if (!total_len && alternate_index == CACHE_ALT_REMOVED) {
-        Debug("cache_update", "alt delete, %d, (%" PRIu64 ", %" PRIu64 ")\n", DIR_MASK_TAG(first_key.slice32(2)), update_key.b[0],
+        Debug("cache_update", "alt delete, %d, (%" PRIu64 ", %" PRIu64 ")", DIR_MASK_TAG(first_key.slice32(2)), update_key.b[0],
               update_key.b[1]);
       }
     }

--- a/iocore/cluster/ClusterMachine.cc
+++ b/iocore/cluster/ClusterMachine.cc
@@ -101,7 +101,7 @@ ClusterMachine::ClusterMachine(char *ahostname, unsigned int aip, int aport)
 #endif
     if (clustering_enabled) {
       char *clusterIP = getenv("PROXY_CLUSTER_ADDR");
-      Debug("cluster_note", "[Machine::Machine] Cluster IP addr: %s\n", clusterIP);
+      Debug("cluster_note", "[Machine::Machine] Cluster IP addr: %s", clusterIP);
       ip = inet_addr(clusterIP);
     } else {
       ink_gethostbyname_r_data data;

--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -244,21 +244,21 @@ void
 DNSProcessor::dns_init()
 {
   gethostname(try_server_names[0], 255);
-  Debug("dns", "localhost=%s\n", try_server_names[0]);
-  Debug("dns", "Round-robin nameservers = %d\n", dns_ns_rr);
+  Debug("dns", "localhost=%s", try_server_names[0]);
+  Debug("dns", "Round-robin nameservers = %d", dns_ns_rr);
 
   IpEndpoint nameserver[MAX_NAMED];
   size_t nserv = 0;
 
   if (dns_ns_list) {
-    Debug("dns", "Nameserver list specified \"%s\"\n", dns_ns_list);
+    Debug("dns", "Nameserver list specified \"%s\"", dns_ns_list);
     int i;
     char *last;
     char *ns_list = ats_strdup(dns_ns_list);
     char *ns = (char *)strtok_r(ns_list, " ,;\t\r", &last);
 
     for (i = 0, nserv = 0; (i < MAX_NAMED) && ns; ++i) {
-      Debug("dns", "Nameserver list - parsing \"%s\"\n", ns);
+      Debug("dns", "Nameserver list - parsing \"%s\"", ns);
       bool err = false;
       int prt = DOMAIN_SERVICE_PORT;
       char *colon = 0; // where the port colon is.
@@ -479,7 +479,7 @@ DNSHandler::startEvent(int /* event ATS_UNUSED */, Event *e)
 {
   //
   // If this is for the default server, get it
-  Debug("dns", "DNSHandler::startEvent: on thread %d\n", e->ethread->id);
+  Debug("dns", "DNSHandler::startEvent: on thread %d", e->ethread->id);
 
   this->validate_ip();
 
@@ -525,7 +525,7 @@ DNSHandler::startEvent(int /* event ATS_UNUSED */, Event *e)
 int
 DNSHandler::startEvent_sdns(int /* event ATS_UNUSED */, Event *e)
 {
-  Debug("dns", "DNSHandler::startEvent_sdns: on thread %d\n", e->ethread->id);
+  Debug("dns", "DNSHandler::startEvent_sdns: on thread %d", e->ethread->id);
   this->validate_ip();
 
   SET_HANDLER(&DNSHandler::mainEvent);

--- a/iocore/dns/DNSConnection.cc
+++ b/iocore/dns/DNSConnection.cc
@@ -140,7 +140,7 @@ DNSConnection::connect(sockaddr const *addr, Options const &opt)
       uint32_t p = generator.random();
       p = static_cast<uint16_t>((p % (LAST_RANDOM_PORT - FIRST_RANDOM_PORT)) + FIRST_RANDOM_PORT);
       ats_ip_port_cast(&bind_addr.sa) = htons(p); // stuff port in sockaddr.
-      Debug("dns", "random port = %s\n", ats_ip_nptop(&bind_addr.sa, b, sizeof b));
+      Debug("dns", "random port = %s", ats_ip_nptop(&bind_addr.sa, b, sizeof b));
       if ((res = socketManager.ink_bind(fd, &bind_addr.sa, bind_size, Proto)) < 0) {
         continue;
       }

--- a/iocore/dns/SplitDNS.cc
+++ b/iocore/dns/SplitDNS.cc
@@ -168,8 +168,8 @@ SplitDNSConfig::print()
 {
   SplitDNS *params = SplitDNSConfig::acquire();
 
-  Debug("splitdns_config", "DNS Server Selection Config\n");
-  Debug("splitdns_config", "\tEnabled=%d \n", params->m_SplitDNSlEnable);
+  Debug("splitdns_config", "DNS Server Selection Config");
+  Debug("splitdns_config", "\tEnabled=%d", params->m_SplitDNSlEnable);
 
   params->m_DNSSrvrTable->Print();
   SplitDNSConfig::release(params);
@@ -275,7 +275,7 @@ SplitDNS::findServer(RequestData *rdata, SplitDNSResult *result)
       Debug("splitdns_config", "Result for %s was %s", host, SDNSResultStr[result->r]);
       break;
     case DNS_SRVR_SPECIFIED:
-      Debug("splitdns_config", "Result for %s was dns servers \n", host);
+      Debug("splitdns_config", "Result for %s was dns servers", host);
       result->m_rec->Print();
       break;
     default:
@@ -534,7 +534,7 @@ SplitDNSRecord::Print()
 {
   for (int i = 0; i < m_dnsSrvr_cnt; i++) {
     char ab[INET6_ADDRPORTSTRLEN];
-    Debug("splitdns_config", " %s ", ats_ip_ntop(&m_servers.x_server_ip[i].sa, ab, sizeof ab));
+    Debug("splitdns_config", " %s", ats_ip_ntop(&m_servers.x_server_ip[i].sa, ab, sizeof ab));
   }
 }
 

--- a/iocore/eventsystem/UnixEventProcessor.cc
+++ b/iocore/eventsystem/UnixEventProcessor.cc
@@ -148,9 +148,9 @@ EventProcessor::start(int n_event_threads, size_t stacksize)
       int cpu_mask_len = hwloc_bitmap_snprintf(NULL, 0, obj->cpuset) + 1;
       char *cpu_mask = (char *)alloca(cpu_mask_len);
       hwloc_bitmap_snprintf(cpu_mask, cpu_mask_len, obj->cpuset);
-      Debug("iocore_thread", "EThread: %d %s: %d CPU Mask: %s\n", i, obj_name, obj->logical_index, cpu_mask);
+      Debug("iocore_thread", "EThread: %d %s: %d CPU Mask: %s", i, obj_name, obj->logical_index, cpu_mask);
 #else
-      Debug("iocore_thread", "EThread: %d %s: %d\n", i, obj_name, obj->logical_index);
+      Debug("iocore_thread", "EThread: %d %s: %d", i, obj_name, obj->logical_index);
 #endif // HWLOC_API_VERSION
       hwloc_set_thread_cpubind(ink_get_topology(), tid, obj->cpuset, HWLOC_CPUBIND_STRICT);
     } else {

--- a/iocore/net/Connection.cc
+++ b/iocore/net/Connection.cc
@@ -83,7 +83,7 @@ Server::accept(Connection *c)
   c->fd = res;
   if (is_debug_tag_set("iocore_net_server")) {
     ip_port_text_buffer ipb1, ipb2;
-    Debug("iocore_net_server", "Connection accepted [Server]. %s -> %s\n", ats_ip_nptop(&c->addr, ipb2, sizeof(ipb2)),
+    Debug("iocore_net_server", "Connection accepted [Server]. %s -> %s", ats_ip_nptop(&c->addr, ipb2, sizeof(ipb2)),
           ats_ip_nptop(&addr, ipb1, sizeof(ipb1)));
   }
 
@@ -254,7 +254,7 @@ Server::setup_fd_for_listen(bool non_blocking, int recv_bufsize, int send_bufsiz
 
   if (transparent) {
 #if TS_USE_TPROXY
-    Debug("http_tproxy", "Listen port inbound transparency enabled.\n");
+    Debug("http_tproxy", "Listen port inbound transparency enabled.");
     if (safe_setsockopt(fd, SOL_IP, TS_IP_TRANSPARENT, SOCKOPT_ON, sizeof(int)) < 0) {
       Fatal("[Server::listen] Unable to set transparent socket option [%d] %s\n", errno, strerror(errno));
     }

--- a/iocore/net/NetTest-http-server.c
+++ b/iocore/net/NetTest-http-server.c
@@ -76,11 +76,11 @@ struct NetTesterSM : public Continuation {
       reader->read(&request[req_len], r);
       req_len += r;
       request[req_len] = 0;
-      Debug("net_test", "%s\n", request);
+      Debug("net_test", "%s", request);
       fflush(stdout);
       // vc->set_inactivity_timeout(HRTIME_SECONDS(30));
       if (strcmp(&request[req_len - 4], "\r\n\r\n") == 0) {
-        Debug("net_test", "The request header is :\n%s\n", request);
+        Debug("net_test", "The request header is :\n%s", request);
         // parse and get the doc size
         SET_HANDLER(&NetTesterSM::handle_write);
         ink_assert(doc_len == resp_reader->read_avail());
@@ -135,7 +135,7 @@ struct NetTesterAccept : public Continuation {
   int
   handle_accept(int event, void *data)
   {
-    Debug("net_test", "Accepted a connection\n");
+    Debug("net_test", "Accepted a connection");
     fflush(stdout);
     NetVConnection *vc = (NetVConnection *)data;
     new NetTesterSM(new_ProxyMutex(), vc);

--- a/iocore/net/P_NetAccept.h
+++ b/iocore/net/P_NetAccept.h
@@ -72,7 +72,7 @@ struct NetAcceptAction : public Action, public RefCountObj {
     return Action::operator=(acont);
   }
 
-  ~NetAcceptAction() { Debug("net_accept", "NetAcceptAction dying\n"); }
+  ~NetAcceptAction() { Debug("net_accept", "NetAcceptAction dying"); }
 };
 
 //

--- a/iocore/net/Socks.cc
+++ b/iocore/net/Socks.cc
@@ -247,7 +247,7 @@ SocksEntry::mainEvent(int event, void *data)
     if (auth_handler) {
       n_bytes = invokeSocksAuthHandler(auth_handler, SOCKS_AUTH_OPEN, p);
     } else {
-      // Debug("Socks", " Got NET_EVENT_OPEN to SOCKS server\n");
+      // Debug("Socks", " Got NET_EVENT_OPEN to SOCKS server");
 
       p[n_bytes++] = version;
       p[n_bytes++] = (socks_cmd == NORMAL_SOCKS) ? SOCKS_CONNECT : socks_cmd;
@@ -292,7 +292,7 @@ SocksEntry::mainEvent(int event, void *data)
     }
 
     netVConnection->do_io_write(this, n_bytes, reader, 0);
-    // Debug("Socks", "Sent the request to the SOCKS server\n");
+    // Debug("Socks", "Sent the request to the SOCKS server");
 
     ret = EVENT_CONT;
     break;
@@ -370,7 +370,7 @@ SocksEntry::mainEvent(int event, void *data)
       timeout->cancel(this);
       timeout = NULL;
     }
-    // Debug("Socks", "Successfully read the reply from the SOCKS server\n");
+    // Debug("Socks", "Successfully read the reply from the SOCKS server");
     p = (unsigned char *)buf->start();
 
     if (auth_handler) {

--- a/iocore/net/UnixConnection.cc
+++ b/iocore/net/UnixConnection.cc
@@ -285,7 +285,7 @@ Connection::open(NetVCOptions const &opt)
       int rbufsz = ROUNDUP(opt.socket_recv_bufsize, 1024);
       while (rbufsz && !socketManager.set_rcvbuf_size(fd, rbufsz))
         rbufsz -= 1024;
-      Debug("socket", "::open: recv_bufsize = %d of %d\n", rbufsz, opt.socket_recv_bufsize);
+      Debug("socket", "::open: recv_bufsize = %d of %d", rbufsz, opt.socket_recv_bufsize);
     }
   }
   if (opt.socket_send_bufsize > 0) {
@@ -294,7 +294,7 @@ Connection::open(NetVCOptions const &opt)
       int sbufsz = ROUNDUP(opt.socket_send_bufsize, 1024);
       while (sbufsz && !socketManager.set_sndbuf_size(fd, sbufsz))
         sbufsz -= 1024;
-      Debug("socket", "::open: send_bufsize = %d of %d\n", sbufsz, opt.socket_send_bufsize);
+      Debug("socket", "::open: send_bufsize = %d of %d", sbufsz, opt.socket_send_bufsize);
     }
   }
 

--- a/iocore/net/UnixNet.cc
+++ b/iocore/net/UnixNet.cc
@@ -647,7 +647,7 @@ NetHandler::manage_keep_alive_queue()
   }
 
   if (total_idle_count > 0) {
-    Debug("net_queue", "max cons: %d active: %d idle: %d already closed: %d, close event: %d mean idle: %d\n",
+    Debug("net_queue", "max cons: %d active: %d idle: %d already closed: %d, close event: %d mean idle: %d",
           max_connections_per_thread_in, total_connections_in, keep_alive_queue_size, closed, handle_event,
           total_idle_time / total_idle_count);
   }

--- a/iocore/net/UnixNetProcessor.cc
+++ b/iocore/net/UnixNetProcessor.cc
@@ -231,7 +231,7 @@ UnixNetProcessor::connect_re_internal(Continuation *cont, sockaddr const *target
 
   if (using_socks) {
     char buff[INET6_ADDRPORTSTRLEN];
-    Debug("Socks", "Using Socks ip: %s\n", ats_ip_nptop(target, buff, sizeof(buff)));
+    Debug("Socks", "Using Socks ip: %s", ats_ip_nptop(target, buff, sizeof(buff)));
     socksEntry = socksAllocator.alloc();
     socksEntry->init(cont->mutex, vc, opt->socks_support, opt->socks_version); /*XXXX remove last two args */
     socksEntry->action_ = cont;
@@ -245,7 +245,7 @@ UnixNetProcessor::connect_re_internal(Continuation *cont, sockaddr const *target
     result = &socksEntry->action_;
     vc->action_ = socksEntry;
   } else {
-    Debug("Socks", "Not Using Socks %d \n", socks_conf_stuff->socks_needed);
+    Debug("Socks", "Not Using Socks %d ", socks_conf_stuff->socks_needed);
     vc->action_ = cont;
   }
 

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1107,7 +1107,7 @@ UnixNetVConnection::acceptEvent(int event, Event *e)
   nh = get_NetHandler(thread);
   PollDescriptor *pd = get_PollDescriptor(thread);
   if (ep.start(pd, this, EVENTIO_READ | EVENTIO_WRITE) < 0) {
-    Debug("iocore_net", "acceptEvent : failed EventIO::start\n");
+    Debug("iocore_net", "acceptEvent : failed EventIO::start");
     close_UnixNetVConnection(this, e->ethread);
     return EVENT_DONE;
   }
@@ -1227,7 +1227,7 @@ UnixNetVConnection::populate(Connection &con_in, Continuation *c, void *arg)
   if (ep.start(get_PollDescriptor(t), this, EVENTIO_READ | EVENTIO_WRITE) < 0) {
     // EEXIST should be ok, though it should have been cleared before we got back here
     if (errno != EEXIST) {
-      Debug("iocore_net", "populate : Failed to add to epoll list\n");
+      Debug("iocore_net", "populate : Failed to add to epoll list");
       return EVENT_ERROR;
     }
   }
@@ -1269,7 +1269,7 @@ UnixNetVConnection::connectUp(EThread *t, int fd)
   //
   if (is_debug_tag_set("iocore_net")) {
     char addrbuf[INET6_ADDRSTRLEN];
-    Debug("iocore_net", "connectUp:: local_addr=%s:%d [%s]\n",
+    Debug("iocore_net", "connectUp:: local_addr=%s:%d [%s]",
           options.local_ip.isValid() ? options.local_ip.toString(addrbuf, sizeof(addrbuf)) : "*", options.local_port,
           NetVCOptions::toString(options.addr_binding));
   }
@@ -1298,7 +1298,7 @@ UnixNetVConnection::connectUp(EThread *t, int fd)
   // when edge triggering is used.
   if (ep.start(get_PollDescriptor(t), this, EVENTIO_READ | EVENTIO_WRITE) < 0) {
     lerrno = errno;
-    Debug("iocore_net", "connectUp : Failed to add to epoll list\n");
+    Debug("iocore_net", "connectUp : Failed to add to epoll list");
     action_.continuation->handleEvent(NET_EVENT_OPEN_FAILED, (void *)0); // 0 == res
     free(t);
     return CONNECT_FAILURE;

--- a/iocore/utils/OneWayTunnel.cc
+++ b/iocore/utils/OneWayTunnel.cc
@@ -145,7 +145,7 @@ OneWayTunnel::init(VConnection *vcSource, VConnection *vcTarget, Continuation *a
   else
     size_index = default_large_iobuffer_size;
 
-  Debug("one_way_tunnel", "buffer size index [%" PRId64 "] [%d]\n", size_index, size_estimate);
+  Debug("one_way_tunnel", "buffer size index [%" PRId64 "] [%d]", size_index, size_estimate);
 
   // enqueue read request on vcSource.
   MIOBuffer *buf1 = new_MIOBuffer(size_index);

--- a/lib/bindings/bindings.cc
+++ b/lib/bindings/bindings.cc
@@ -108,17 +108,17 @@ BindingInstance::bind_value(const char *name, int value)
 
   // XXX extract this code so that we can using it for binding constants
   // into an arbitrary table path ...
-  Debug("lua", "binding %s value at %d to %s\n", luaL_typename(this->lua, value), value, name);
+  Debug("lua", "binding %s value at %d to %s", luaL_typename(this->lua, value), value, name);
 
   for (; (end = ::strchr(start, '.')); start = end + 1) {
     std::string name(start, end);
 
-    Debug("lua", "checking for table '%s'\n", name.c_str());
+    Debug("lua", "checking for table '%s'", name.c_str());
     if (depth == 0) {
       lua_getglobal(this->lua, name.c_str());
       if (lua_isnil(this->lua, -1)) {
         // No table with this name, construct one.
-        Debug("lua", "creating global table '%s'\n", name.c_str());
+        Debug("lua", "creating global table '%s'", name.c_str());
 
         lua_pop(this->lua, 1); // Pop the nil.
         lua_newtable(this->lua);
@@ -133,7 +133,7 @@ BindingInstance::bind_value(const char *name, int value)
     } else {
       ink_assert(is_indexable(this->lua, -1));
 
-      Debug("lua", "checking for table key '%s'\n", name.c_str());
+      Debug("lua", "checking for table key '%s'", name.c_str());
 
       // Push the string key.
       lua_pushlstring(this->lua, &name[0], name.size());
@@ -141,7 +141,7 @@ BindingInstance::bind_value(const char *name, int value)
       lua_gettable(this->lua, -2);
 
       if (lua_isnil(this->lua, -1)) {
-        Debug("lua", "creating table key '%s'\n", name.c_str());
+        Debug("lua", "creating table key '%s'", name.c_str());
 
         lua_pop(this->lua, 1); // Pop the nil.
         lua_pushlstring(this->lua, &name[0], name.size());
@@ -168,8 +168,8 @@ BindingInstance::bind_value(const char *name, int value)
     ++depth;
   }
 
-  Debug("lua", "stack depth is %d (expected %d)\n", lua_gettop(this->lua), depth);
-  Debug("lua", "last name token is '%s'\n", start);
+  Debug("lua", "stack depth is %d (expected %d)", lua_gettop(this->lua), depth);
+  Debug("lua", "last name token is '%s'", start);
 
   // If we pushed a series of tables onto the stack, bind the name to a table
   // entry. otherwise bind it as a global name.
@@ -179,11 +179,11 @@ BindingInstance::bind_value(const char *name, int value)
     // At this point the top of stack should be something indexable.
     ink_assert(is_indexable(this->lua, -1));
 
-    Debug("lua", "stack depth is %d (expected %d)\n", lua_gettop(this->lua), depth);
+    Debug("lua", "stack depth is %d (expected %d)", lua_gettop(this->lua), depth);
     // Push the index name.
     lua_pushstring(this->lua, start);
 
-    Debug("lua", "stack depth is %d (expected %d)\n", lua_gettop(this->lua), depth);
+    Debug("lua", "stack depth is %d (expected %d)", lua_gettop(this->lua), depth);
     // Fetch the index (without metamethods);
     lua_gettable(this->lua, -2);
 
@@ -199,7 +199,7 @@ BindingInstance::bind_value(const char *name, int value)
       bound = true;
     }
 
-    Debug("lua", "stack depth is %d (expected %d)\n", lua_gettop(this->lua), depth);
+    Debug("lua", "stack depth is %d (expected %d)", lua_gettop(this->lua), depth);
     lua_pop(this->lua, depth);
   } else {
     bool isnil;

--- a/lib/records/RecRawStats.cc
+++ b/lib/records/RecRawStats.cc
@@ -122,7 +122,7 @@ raw_stat_sync_to_global(RecRawStatBlock *rsb, int id)
 static int
 raw_stat_clear(RecRawStatBlock *rsb, int id)
 {
-  Debug("stats", "raw_stat_clear(): rsb pointer:%p id:%d\n", rsb, id);
+  Debug("stats", "raw_stat_clear(): rsb pointer:%p id:%d", rsb, id);
 
   // the globals need to be reset too
   // lock so the setting of the globals and last values are atomic
@@ -156,7 +156,7 @@ raw_stat_clear(RecRawStatBlock *rsb, int id)
 static int
 raw_stat_clear_sum(RecRawStatBlock *rsb, int id)
 {
-  Debug("stats", "raw_stat_clear_sum(): rsb pointer:%p id:%d\n", rsb, id);
+  Debug("stats", "raw_stat_clear_sum(): rsb pointer:%p id:%d", rsb, id);
 
   // the globals need to be reset too
   // lock so the setting of the globals and last values are atomic
@@ -186,7 +186,7 @@ raw_stat_clear_sum(RecRawStatBlock *rsb, int id)
 static int
 raw_stat_clear_count(RecRawStatBlock *rsb, int id)
 {
-  Debug("stats", "raw_stat_clear_count(): rsb pointer:%p id:%d\n", rsb, id);
+  Debug("stats", "raw_stat_clear_count(): rsb pointer:%p id:%d", rsb, id);
 
   // the globals need to be reset too
   // lock so the setting of the globals and last values are atomic
@@ -242,7 +242,7 @@ int
 _RecRegisterRawStat(RecRawStatBlock *rsb, RecT rec_type, const char *name, RecDataT data_type, RecPersistT persist_type, int id,
                     RecRawStatSyncCb sync_cb)
 {
-  Debug("stats", "RecRawStatSyncCb(%s): rsb pointer:%p id:%d\n", name, rsb, id);
+  Debug("stats", "RecRawStatSyncCb(%s): rsb pointer:%p id:%d", name, rsb, id);
 
   // check to see if we're good to proceed
   ink_assert(id < rsb->max_stats);

--- a/lib/ts/ink_cap.cc
+++ b/lib/ts/ink_cap.cc
@@ -250,7 +250,7 @@ PreserveCapabilities()
 #if TS_USE_POSIX_CAP
   zret = prctl(PR_SET_KEEPCAPS, 1);
 #endif
-  Debug("privileges", "[PreserveCapabilities] zret : %d\n", zret);
+  Debug("privileges", "[PreserveCapabilities] zret : %d", zret);
   return zret == 0;
 }
 
@@ -272,7 +272,7 @@ RestrictCapabilities()
   zret = cap_set_proc(caps);
   cap_free(caps);
 #endif
-  Debug("privileges", "[RestrictCapabilities] zret : %d\n", zret);
+  Debug("privileges", "[RestrictCapabilities] zret : %d", zret);
   return zret == 0;
 }
 
@@ -291,7 +291,7 @@ EnableCoreFile(bool flag)
   }
 #endif // linux check
 
-  Debug("privileges", "[EnableCoreFile] zret : %d\n", zret);
+  Debug("privileges", "[EnableCoreFile] zret : %d", zret);
   return zret == 0;
 }
 
@@ -351,7 +351,7 @@ ElevateAccess::acquirePrivilege(unsigned priv_mask)
   cap_value_t cap_list[2];
   cap_t new_cap_state;
 
-  Debug("privileges", "[acquirePrivilege] level= %x\n", level);
+  Debug("privileges", "[acquirePrivilege] level= %x", level);
 
   ink_assert(NULL == cap_state);
 

--- a/mgmt/Alarms.cc
+++ b/mgmt/Alarms.cc
@@ -101,7 +101,7 @@ Alarms::registerCallback(AlarmCallbackFunc func)
 
   ink_mutex_acquire(&mutex);
   snprintf(cb_buf, sizeof(cb_buf), "%d", cur_cb++);
-  Debug("alarm", "[Alarms::registerCallback] Registering Alarms callback\n");
+  Debug("alarm", "[Alarms::registerCallback] Registering Alarms callback");
   ink_hash_table_insert(cblist, cb_buf, (void *)func);
   ink_mutex_release(&mutex);
 } /* End Alarms::registerCallback */

--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -306,7 +306,7 @@ LocalManager::initCCom(const AppVersionInfo &version, FileManager *configFiles, 
   }
 
   ats_ip_ntop(&cluster_ip, clusterAddrStr, sizeof(clusterAddrStr));
-  Debug("ccom", "Cluster Interconnect is %s : %s\n", intrName, clusterAddrStr);
+  Debug("ccom", "Cluster Interconnect is %s : %s", intrName, clusterAddrStr);
 
   // This an awful hack but I could not come up with a better way to
   //  pass the cluster address to the proxy
@@ -457,7 +457,7 @@ LocalManager::pollMgmtProcessServer()
           int estatus;
           pid_t tmp_pid = watched_process_pid;
 
-          Debug("lm", "[LocalManager::pollMgmtProcessServer] Lost process EOF!\n");
+          Debug("lm", "[LocalManager::pollMgmtProcessServer] Lost process EOF!");
 
           close_socket(watched_process_fd);
 
@@ -817,7 +817,7 @@ LocalManager::processEventQueue()
         ink_assert(enqueue(mgmt_event_queue, mh));
         return;
       }
-      Debug("lm", "[TrafficManager] ==> Sending signal event '%d' payload=%d\n", mh->msg_id, mh->data_len);
+      Debug("lm", "[TrafficManager] ==> Sending signal event '%d' payload=%d", mh->msg_id, mh->data_len);
       lmgmt->sendMgmtMsgToProcesses(mh);
     }
     ats_free(mh);
@@ -927,7 +927,7 @@ LocalManager::startProxy()
     // NUL-terminate for the benefit of strtok and printf.
     real_proxy_options.add(0);
 
-    Debug("lm", "[LocalManager::startProxy] Launching %s with options '%s'\n", absolute_proxy_binary, &real_proxy_options[0]);
+    Debug("lm", "[LocalManager::startProxy] Launching %s with options '%s'", absolute_proxy_binary, &real_proxy_options[0]);
 
     ink_zero(options);
     options[0] = absolute_proxy_binary;
@@ -935,7 +935,7 @@ LocalManager::startProxy()
     tok = strtok_r(&real_proxy_options[0], " ", &last);
     options[i++] = tok;
     while (i < 32 && (tok = strtok_r(NULL, " ", &last))) {
-      Debug("lm", "opt %d = '%s'\n", i, tok);
+      Debug("lm", "opt %d = '%s'", i, tok);
       options[i++] = tok;
     }
 
@@ -1034,12 +1034,12 @@ LocalManager::bindProxyPort(HttpProxyPort &port)
 
   if (port.m_inbound_transparent_p) {
 #if TS_USE_TPROXY
-    Debug("http_tproxy", "Listen port %d inbound transparency enabled.\n", port.m_port);
+    Debug("http_tproxy", "Listen port %d inbound transparency enabled.", port.m_port);
     if (setsockopt(port.m_fd, SOL_IP, TS_IP_TRANSPARENT, &one, sizeof(one)) == -1) {
       mgmt_fatal(stderr, 0, "[bindProxyPort] Unable to set transparent socket option [%d] %s\n", errno, strerror(errno));
     }
 #else
-    Debug("lm", "[bindProxyPort] Transparency requested but TPROXY not configured\n");
+    Debug("lm", "[bindProxyPort] Transparency requested but TPROXY not configured");
 #endif
   }
 
@@ -1064,7 +1064,7 @@ LocalManager::bindProxyPort(HttpProxyPort &port)
     mgmt_fatal(stderr, 0, "[bindProxyPort] Unable to bind socket: %d : %s\n", port.m_port, strerror(errno));
   }
 
-  Debug("lm", "[bindProxyPort] Successfully bound proxy port %d\n", port.m_port);
+  Debug("lm", "[bindProxyPort] Successfully bound proxy port %d", port.m_port);
 }
 
 void

--- a/mgmt/ProcessManager.cc
+++ b/mgmt/ProcessManager.cc
@@ -47,7 +47,7 @@ startProcessManager(void *arg)
   void *ret = arg;
 
   while (!pmgmt) { /* Avert race condition, thread spun during constructor */
-    Debug("pmgmt", "[startProcessManager] Waiting for initialization of object...\n");
+    Debug("pmgmt", "[startProcessManager] Waiting for initialization of object...");
     mgmt_sleep_sec(1);
   }
   if (pmgmt->require_lm) { /* Allow p. process to run w/o a lm */
@@ -133,7 +133,7 @@ ProcessManager::processEventQueue()
   while (!queue_is_empty(mgmt_event_queue)) {
     MgmtMessageHdr *mh = (MgmtMessageHdr *)dequeue(mgmt_event_queue);
 
-    Debug("pmgmt", "[ProcessManager] ==> Processing event id '%d' payload=%d\n", mh->msg_id, mh->data_len);
+    Debug("pmgmt", "[ProcessManager] ==> Processing event id '%d' payload=%d", mh->msg_id, mh->data_len);
     if (mh->data_len > 0) {
       executeMgmtCallback(mh->msg_id, (char *)mh + sizeof(MgmtMessageHdr), mh->data_len);
     } else {
@@ -156,7 +156,7 @@ ProcessManager::processSignalQueue()
   while (!queue_is_empty(mgmt_signal_queue)) {
     MgmtMessageHdr *mh = (MgmtMessageHdr *)dequeue(mgmt_signal_queue);
 
-    Debug("pmgmt", "[ProcessManager] ==> Signalling local manager '%d'\n", mh->msg_id);
+    Debug("pmgmt", "[ProcessManager] ==> Signalling local manager '%d'", mh->msg_id);
 
     if (require_lm && mgmt_write_pipe(local_manager_sockfd, (char *)mh, sizeof(MgmtMessageHdr) + mh->data_len) <= 0) {
       mgmt_fatal(stderr, errno, "[ProcessManager::processSignalQueue] Error writing message!");

--- a/mgmt/Rollback.cc
+++ b/mgmt/Rollback.cc
@@ -191,7 +191,7 @@ Rollback::Rollback(const char *fileName_, bool root_access_needed_, Rollback *pa
       }
     }
 
-    Debug("rollback", "[Rollback::Rollback] Current Version of %s is %d\n", fileName, currentVersion);
+    Debug("rollback", "[Rollback::Rollback] Current Version of %s is %d", fileName, currentVersion);
   }
 
   // Now that we'll got every thing set up, try opening
@@ -398,7 +398,7 @@ Rollback::internalUpdate(textBuffer *buf, version_t newVersion, bool notifyChang
     }
   }
 
-  Debug("rollback", "[Rollback::internalUpdate] Moving %s from version %d to version %d\n", this->fileName, this->currentVersion,
+  Debug("rollback", "[Rollback::internalUpdate] Moving %s from version %d to version %d", this->fileName, this->currentVersion,
         newVersion);
 
   currentVersion_local = createPathStr(this->currentVersion);

--- a/mgmt/WebMgmtUtils.cc
+++ b/mgmt/WebMgmtUtils.cc
@@ -782,7 +782,7 @@ varType(const char *varName)
     return RECD_NULL;
   }
 
-  Debug("RecOp", "[varType] %s is of type %d\n", varName, data_type);
+  Debug("RecOp", "[varType] %s is of type %d", varName, data_type);
   return data_type;
 }
 

--- a/mgmt/api/CfgContextManager.cc
+++ b/mgmt/api/CfgContextManager.cc
@@ -289,7 +289,7 @@ CfgContextGetEleAt(CfgContext *ctx, int index)
       continue;
     } else {
       if (count == index) { // got right ele
-        // Debug("config", "Get ele at index = %d\n", index);
+        // Debug("config", "Get ele at index = %d", index);
         cfg_ele = curr_ele->getCfgEle();
         return cfg_ele;
       }

--- a/mgmt/api/CoreAPI.cc
+++ b/mgmt/api/CoreAPI.cc
@@ -530,7 +530,7 @@ MgmtRecordGet(const char *rec_name, TSRecordEle *rec_ele)
   MgmtIntCounter counter_val;
   MgmtInt int_val;
 
-  Debug("RecOp", "[MgmtRecordGet] Start\n");
+  Debug("RecOp", "[MgmtRecordGet] Start");
 
   // initialize the record name
   rec_ele->rec_name = ats_strdup(rec_name);
@@ -545,7 +545,7 @@ MgmtRecordGet(const char *rec_name, TSRecordEle *rec_ele)
       return TS_ERR_FAIL;
     rec_ele->valueT.counter_val = (TSCounter)counter_val;
 
-    Debug("RecOp", "[MgmtRecordGet] Get Counter Var %s = %" PRId64 "\n", rec_ele->rec_name, rec_ele->valueT.counter_val);
+    Debug("RecOp", "[MgmtRecordGet] Get Counter Var %s = %" PRId64 "", rec_ele->rec_name, rec_ele->valueT.counter_val);
     break;
 
   case RECD_INT:
@@ -554,7 +554,7 @@ MgmtRecordGet(const char *rec_name, TSRecordEle *rec_ele)
       return TS_ERR_FAIL;
     rec_ele->valueT.int_val = (TSInt)int_val;
 
-    Debug("RecOp", "[MgmtRecordGet] Get Int Var %s = %" PRId64 "\n", rec_ele->rec_name, rec_ele->valueT.int_val);
+    Debug("RecOp", "[MgmtRecordGet] Get Int Var %s = %" PRId64 "", rec_ele->rec_name, rec_ele->valueT.int_val);
     break;
 
   case RECD_FLOAT:
@@ -562,7 +562,7 @@ MgmtRecordGet(const char *rec_name, TSRecordEle *rec_ele)
     if (!varFloatFromName(rec_name, &(rec_ele->valueT.float_val)))
       return TS_ERR_FAIL;
 
-    Debug("RecOp", "[MgmtRecordGet] Get Float Var %s = %f\n", rec_ele->rec_name, rec_ele->valueT.float_val);
+    Debug("RecOp", "[MgmtRecordGet] Get Float Var %s = %f", rec_ele->rec_name, rec_ele->valueT.float_val);
     break;
 
   case RECD_STRING:
@@ -578,11 +578,11 @@ MgmtRecordGet(const char *rec_name, TSRecordEle *rec_ele)
 
     rec_ele->rec_type = TS_REC_STRING;
     rec_ele->valueT.string_val = str_val;
-    Debug("RecOp", "[MgmtRecordGet] Get String Var %s = %s\n", rec_ele->rec_name, rec_ele->valueT.string_val);
+    Debug("RecOp", "[MgmtRecordGet] Get String Var %s = %s", rec_ele->rec_name, rec_ele->valueT.string_val);
     break;
 
   default: // UNKOWN TYPE
-    Debug("RecOp", "[MgmtRecordGet] Get Failed : %d is Unknown Var type %s\n", rec_type, rec_name);
+    Debug("RecOp", "[MgmtRecordGet] Get Failed : %d is Unknown Var type %s", rec_type, rec_name);
     return TS_ERR_FAIL;
   }
 
@@ -659,7 +659,7 @@ determine_action_need(const char *rec_name)
 TSMgmtError
 MgmtRecordSet(const char *rec_name, const char *val, TSActionNeedT *action_need)
 {
-  Debug("RecOp", "[MgmtRecordSet] Start\n");
+  Debug("RecOp", "[MgmtRecordSet] Start");
 
   if (!rec_name || !val || !action_need)
     return TS_ERR_PARAMS;
@@ -772,7 +772,7 @@ ReadFile(TSFileNameT file, char **text, int *size, int *version)
   char *old_file_lines;
   version_t ver;
 
-  Debug("FileOp", "[get_lines_from_file] START\n");
+  Debug("FileOp", "[get_lines_from_file] START");
 
   fname = filename_to_string(file);
   if (!fname)
@@ -780,7 +780,7 @@ ReadFile(TSFileNameT file, char **text, int *size, int *version)
 
   ret = configFiles->getRollbackObj(fname, &file_rb);
   if (ret != true) {
-    Debug("FileOp", "[get_lines_from_file] Can't get Rollback for file: %s\n", fname);
+    Debug("FileOp", "[get_lines_from_file] Can't get Rollback for file: %s", fname);
     return TS_ERR_READ_FILE;
   }
   ver = file_rb->getCurrentVersion();

--- a/mgmt/api/EventControlMain.cc
+++ b/mgmt/api/EventControlMain.cc
@@ -245,7 +245,7 @@ event_callback_main(void *arg)
   socket_fd = (int *)arg;
   con_socket_fd = *socket_fd; // the socket for event callbacks
 
-  Debug("event", "[event_callback_main] listen on socket = %d\n", con_socket_fd);
+  Debug("event", "[event_callback_main] listen on socket = %d", con_socket_fd);
 
   // initialize queue for accepted con
   accepted_clients = ink_hash_table_create(InkHashTableKeyType_Word);
@@ -279,7 +279,7 @@ event_callback_main(void *arg)
 
     if (con_socket_fd >= 0) {
       FD_SET(con_socket_fd, &selectFDs);
-      Debug("event", "[event_callback_main] add fd %d to select set\n", con_socket_fd);
+      Debug("event", "[event_callback_main] add fd %d to select set", con_socket_fd);
     }
     // see if there are more fd to set
     con_entry = ink_hash_table_iterator_first(accepted_clients, &con_state);
@@ -308,14 +308,14 @@ event_callback_main(void *arg)
         EventClientT *new_client_con = new_event_client();
 
         if (!new_client_con) {
-          // Debug ("TS_Control_Main", "can't create new EventClientT for new connection\n");
+          // Debug ("TS_Control_Main", "can't create new EventClientT for new connection");
         } else {
           // accept connection
           socklen_t addr_len = (sizeof(struct sockaddr));
           new_con_fd = mgmt_accept(con_socket_fd, new_client_con->adr, &addr_len);
           new_client_con->fd = new_con_fd;
           ink_hash_table_insert(accepted_clients, (char *)&new_client_con->fd, new_client_con);
-          Debug("event", "[event_callback_main] Accept new connection: fd=%d\n", new_con_fd);
+          Debug("event", "[event_callback_main] Accept new connection: fd=%d", new_con_fd);
         }
       } // end if (new_con_fd >= 0 && FD_ISSET(new_con_fd, &selectFDs))
 
@@ -334,7 +334,7 @@ event_callback_main(void *arg)
 
             ret = preprocess_msg(client_entry->fd, &req, &reqlen);
             if (ret == TS_ERR_NET_READ || ret == TS_ERR_NET_EOF) { // preprocess_msg FAILED!
-              Debug("event", "[event_callback_main] preprocess_msg FAILED; skip! \n");
+              Debug("event", "[event_callback_main] preprocess_msg FAILED; skip!");
               remove_event_client(client_entry, accepted_clients);
               con_entry = ink_hash_table_iterator_next(accepted_clients, &con_state);
               continue;
@@ -344,7 +344,7 @@ event_callback_main(void *arg)
             ats_free(req);
 
             if (ret == TS_ERR_NET_WRITE || ret == TS_ERR_NET_EOF) {
-              Debug("event", "[event_callback_main] ERROR: handle_control_message\n");
+              Debug("event", "[event_callback_main] ERROR: handle_control_message");
               remove_event_client(client_entry, accepted_clients);
               con_entry = ink_hash_table_iterator_next(accepted_clients, &con_state);
               continue;
@@ -367,7 +367,7 @@ event_callback_main(void *arg)
 
     if (!mgmt_events || queue_is_empty(mgmt_events)) { // no events to process
       // fprintf(stderr, "[event_callback_main] NO EVENTS TO PROCESS\n");
-      Debug("event", "[event_callback_main] NO EVENTS TO PROCESS\n");
+      Debug("event", "[event_callback_main] NO EVENTS TO PROCESS");
       continue;
     }
     // iterate through each event in mgmt_events
@@ -392,7 +392,7 @@ event_callback_main(void *arg)
 
           ret = send_mgmt_request(client_entry->fd, EVENT_NOTIFY, &optype, &name, &desc);
           if (ret != TS_ERR_OKAY) {
-            Debug("event", "sending even notification to fd [%d] failed.\n", client_entry->fd);
+            Debug("event", "sending even notification to fd [%d] failed.", client_entry->fd);
           }
         }
         // get next client connection, if any

--- a/mgmt/api/NetworkUtilsLocal.cc
+++ b/mgmt/api/NetworkUtilsLocal.cc
@@ -72,6 +72,6 @@ preprocess_msg(int fd, void **req, size_t *reqlen)
 
   *req = msg.ptr;
   *reqlen = msg.len;
-  Debug("ts_main", "[preprocess_msg] read message length = %zd\n", msg.len);
+  Debug("ts_main", "[preprocess_msg] read message length = %zd", msg.len);
   return TS_ERR_OKAY;
 }

--- a/mgmt/api/TSControlMain.cc
+++ b/mgmt/api/TSControlMain.cc
@@ -154,7 +154,7 @@ ts_ctrl_main(void *arg)
 
     if (con_socket_fd >= 0) {
       FD_SET(con_socket_fd, &selectFDs);
-      // Debug("ts_main", "[ts_ctrl_main] add fd %d to select set\n", con_socket_fd);
+      // Debug("ts_main", "[ts_ctrl_main] add fd %d to select set", con_socket_fd);
     }
     // see if there are more fd to set
     con_entry = ink_hash_table_iterator_first(accepted_con, &con_state);
@@ -164,7 +164,7 @@ ts_ctrl_main(void *arg)
       client_entry = (ClientT *)ink_hash_table_entry_value(accepted_con, con_entry);
       if (client_entry->fd >= 0) { // add fd to select set
         FD_SET(client_entry->fd, &selectFDs);
-        Debug("ts_main", "[ts_ctrl_main] add fd %d to select set\n", client_entry->fd);
+        Debug("ts_main", "[ts_ctrl_main] add fd %d to select set", client_entry->fd);
       }
       con_entry = ink_hash_table_iterator_next(accepted_con, &con_state);
     }
@@ -182,13 +182,13 @@ ts_ctrl_main(void *arg)
         ClientT *new_client_con = create_client();
         if (!new_client_con) {
           // return TS_ERR_SYS_CALL; WHAT TO DO? just keep going
-          Debug("ts_main", "[ts_ctrl_main] can't allocate new ClientT\n");
+          Debug("ts_main", "[ts_ctrl_main] can't allocate new ClientT");
         } else { // accept connection
           socklen_t addr_len = (sizeof(struct sockaddr));
           new_con_fd = mgmt_accept(con_socket_fd, new_client_con->adr, &addr_len);
           new_client_con->fd = new_con_fd;
           ink_hash_table_insert(accepted_con, (char *)&new_client_con->fd, new_client_con);
-          Debug("ts_main", "[ts_ctrl_main] Add new client connection \n");
+          Debug("ts_main", "[ts_ctrl_main] Add new client connection");
         }
       } // end if(new_con_fd >= 0 && FD_ISSET(new_con_fd, &selectFDs))
 
@@ -197,7 +197,7 @@ ts_ctrl_main(void *arg)
         // see if there are more fd to set - iterate through all entries in hash table
         con_entry = ink_hash_table_iterator_first(accepted_con, &con_state);
         while (con_entry) {
-          Debug("ts_main", "[ts_ctrl_main] We have a remote client request!\n");
+          Debug("ts_main", "[ts_ctrl_main] We have a remote client request!");
           client_entry = (ClientT *)ink_hash_table_entry_value(accepted_con, con_entry);
           // got information; check
           if (client_entry->fd && FD_ISSET(client_entry->fd, &selectFDs)) {
@@ -207,7 +207,7 @@ ts_ctrl_main(void *arg)
             ret = preprocess_msg(client_entry->fd, &req, &reqlen);
             if (ret == TS_ERR_NET_READ || ret == TS_ERR_NET_EOF) {
               // occurs when remote API client terminates connection
-              Debug("ts_main", "[ts_ctrl_main] ERROR: preprocess_msg - remove client %d \n", client_entry->fd);
+              Debug("ts_main", "[ts_ctrl_main] ERROR: preprocess_msg - remove client %d ", client_entry->fd);
               remove_client(client_entry, accepted_con);
               // get next client connection (if any)
               con_entry = ink_hash_table_iterator_next(accepted_con, &con_state);
@@ -238,7 +238,7 @@ ts_ctrl_main(void *arg)
   } // end while (1)
 
   // if we get here something's wrong, just clean up
-  Debug("ts_main", "[ts_ctrl_main] CLOSING AND SHUTTING DOWN OPERATIONS\n");
+  Debug("ts_main", "[ts_ctrl_main] CLOSING AND SHUTTING DOWN OPERATIONS");
   close_socket(con_socket_fd);
 
   // iterate through hash table; close client socket connections and remove entry

--- a/mgmt/cluster/ClusterCom.cc
+++ b/mgmt/cluster/ClusterCom.cc
@@ -277,7 +277,7 @@ drainIncomingChannel(void *arg)
               stat = false;
               mgmt_log(stderr, "[drainIncomingChannel] Failed file req: %s v: %d\n", fname, ver);
             } else {
-              Debug("ccom", "[drainIncomingChannel] file req: %s v: %d bytes: %d\n", fname, ver, (int)strlen(buff->bufPtr()));
+              Debug("ccom", "[drainIncomingChannel] file req: %s v: %d bytes: %d", fname, ver, (int)strlen(buff->bufPtr()));
             }
           } else {
             mgmt_elog(0, "[drainIncomingChannel] Error file req: %s ver: %d\n", fname, ver);
@@ -510,14 +510,14 @@ ClusterCom::checkPeers(time_t *ticker)
 
         ink_strlcpy(cip, inet_ntoa(addr), sizeof(cip));
 
-        Debug("ccom", "[ClusterCom::checkPeers] DEAD! %s idle since: %ld naddrs: %d\n", cip, idle_since, tmp->num_virt_addrs);
+        Debug("ccom", "[ClusterCom::checkPeers] DEAD! %s idle since: %ld naddrs: %d", cip, idle_since, tmp->num_virt_addrs);
 
         if ((idle_since = t - tmp->manager_idle_ticks) > peer_timeout) {
           if (tmp->manager_alive > 0) {
             Note("marking manager on node %s as down", cip);
           }
           tmp->manager_alive = -1;
-          Debug("ccom", "[ClusterCom::checkPeers] Manager DEAD! %s idle since: %ld\n", cip, idle_since);
+          Debug("ccom", "[ClusterCom::checkPeers] Manager DEAD! %s idle since: %ld", cip, idle_since);
         }
 
         if (tmp->num_virt_addrs >= 0) {
@@ -889,7 +889,7 @@ Lbogus:
   if (log_bogus_mc_msgs) {
     mgmt_elog(0, "[ClusterCom::handleMultiCastMessage] Bogus mc message-line\n");
     if (line) {
-      Debug("ccom", "[ClusterCom::handleMultiCastMessage] Bogus mc message-line %s\n", line);
+      Debug("ccom", "[ClusterCom::handleMultiCastMessage] Bogus mc message-line %s", line);
     }
     return;
   }
@@ -1030,7 +1030,7 @@ extract_locals(MgmtHashTable *local_ht, char *record_buffer)
   for (eof = false; !eof;) {
     line = q = p;
     eof = scan_and_terminate(p, '\r', '\n');
-    Debug("ccom_rec", "[extract_locals] %s\n", line);
+    Debug("ccom_rec", "[extract_locals] %s", line);
     while ((*q == ' ') || (*q == '\t'))
       q++;
     // is this line a LOCAL?
@@ -1041,7 +1041,7 @@ extract_locals(MgmtHashTable *local_ht, char *record_buffer)
         q++;
       name = q;
       if (scan_and_terminate(q, ' ', '\t')) {
-        Debug("ccom_rec", "[extract_locals] malformed line: %s\n", name);
+        Debug("ccom_rec", "[extract_locals] malformed line: %s", name);
         ats_free(line_cp);
         continue;
       }
@@ -1062,7 +1062,7 @@ insert_locals(textBuffer *rec_cfg_new, textBuffer *rec_cfg, MgmtHashTable *local
   for (eof = false; !eof;) {
     line = q = p;
     eof = scan_and_terminate(p, '\r', '\n');
-    Debug("ccom_rec", "[insert_locals] %s\n", line);
+    Debug("ccom_rec", "[insert_locals] %s", line);
     while ((*q == ' ') || (*q == '\t'))
       q++;
     // is this line a local?
@@ -1072,7 +1072,7 @@ insert_locals(textBuffer *rec_cfg_new, textBuffer *rec_cfg, MgmtHashTable *local
         q++;
       name = q;
       if (scan_and_terminate(q, ' ', '\t')) {
-        Debug("ccom_rec", "[insert_locals] malformed line: %s\n", name);
+        Debug("ccom_rec", "[insert_locals] malformed line: %s", name);
         continue;
       }
       if (local_ht->mgmt_hash_table_lookup(name, (void **)&line)) {
@@ -1255,7 +1255,7 @@ ClusterCom::handleMultiCastAlarmPacket(char *last, char *ip)
 
     /* Signalling will only re-issue if new */
     lmgmt->alarm_keeper->signalAlarm(a, desc, ip);
-    Debug("ccom", "[ClusterCom::handleMultiCastAlarmPacket] Alarm: ip: '%s' '%s'\n", ip, line);
+    Debug("ccom", "[ClusterCom::handleMultiCastAlarmPacket] Alarm: ip: '%s' '%s'", ip, line);
   }
   lmgmt->alarm_keeper->clearUnSeen(ip); /* Purge expired alarms */
   return;
@@ -1620,7 +1620,7 @@ ClusterCom::establishChannels()
     }
   }
 
-  Debug("ccom", "[ClusterCom::establishChannels] Channels setup\n");
+  Debug("ccom", "[ClusterCom::establishChannels] Channels setup");
   init = true;
   return;
 }
@@ -2014,7 +2014,7 @@ ClusterCom::sendReliableMessageReadTillClose(unsigned long addr, char *buf, int 
     close_socket(fd);
     return false;
   } else {
-    Debug("ccom", "[ClusterCom::sendReliableMessageREadTillClose] Sent '%s' len: %d on fd: %d\n", buf, len, fd);
+    Debug("ccom", "[ClusterCom::sendReliableMessageREadTillClose] Sent '%s' len: %d on fd: %d", buf, len, fd);
   }
 
   memset(tmp_reply, 0, 1024);

--- a/plugins/experimental/background_fetch/background_fetch.cc
+++ b/plugins/experimental/background_fetch/background_fetch.cc
@@ -59,7 +59,7 @@ public:
   void
   createLog(const char *log_name)
   {
-    TSDebug(PLUGIN_NAME, "Creating log name %s\n", log_name);
+    TSDebug(PLUGIN_NAME, "Creating log name %s", log_name);
     TSAssert(TS_SUCCESS == TSTextLogObjectCreate(log_name, TS_LOG_MODE_ADD_TIMESTAMP, &_log));
   }
 
@@ -83,7 +83,7 @@ public:
     }
     TSMutexUnlock(_lock);
 
-    TSDebug(PLUGIN_NAME, "BgFetchState.acquire(): ret = %d, url = %s\n", ret, url.c_str());
+    TSDebug(PLUGIN_NAME, "BgFetchState.acquire(): ret = %d, url = %s", ret, url.c_str());
 
     return ret;
   }

--- a/plugins/experimental/hipes/hipes.cc
+++ b/plugins/experimental/hipes/hipes.cc
@@ -365,7 +365,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
           redirect_flag = *(pos + 9) - '0';
           if ((redirect_flag < 0) || (redirect_flag > 2))
             redirect_flag = h_conf->default_redirect_flag;
-          TSDebug(PLUGIN_NAME, "Found _redirect flag in URL: %d\n", redirect_flag);
+          TSDebug(PLUGIN_NAME, "Found _redirect flag in URL: %d", redirect_flag);
           pos = NULL;
         }
       }

--- a/plugins/experimental/stale_while_revalidate/stale_while_revalidate.c
+++ b/plugins/experimental/stale_while_revalidate/stale_while_revalidate.c
@@ -621,7 +621,7 @@ TSPluginInit(int argc, const char *argv[])
 
     return;
   } else {
-    TSDebug(PLUGIN_NAME, "Plugin registration succeeded.\n");
+    TSDebug(PLUGIN_NAME, "Plugin registration succeeded.");
   }
 
   plugin_config = TSmalloc(sizeof(config_t));
@@ -677,5 +677,5 @@ TSPluginInit(int argc, const char *argv[])
   TSContDataSet(main_cont, (void *)plugin_config);
   TSHttpHookAdd(TS_HTTP_READ_REQUEST_HDR_HOOK, main_cont);
 
-  TSDebug(PLUGIN_NAME, "Plugin Init Complete.\n");
+  TSDebug(PLUGIN_NAME, "Plugin Init Complete.");
 }

--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -419,7 +419,7 @@ ConditionDBM::initialize(Parser &p)
     _file = _qualifier.substr(0, pos);
     //_dbm = mdbm_open(_file.c_str(), O_RDONLY, 0, 0, 0);
     // if (NULL != _dbm) {
-    //   TSDebug(PLUGIN_NAME, "Opened DBM file %s\n", _file.c_str());
+    //   TSDebug(PLUGIN_NAME, "Opened DBM file %s", _file.c_str());
     //   _key.set_value(_qualifier.substr(pos + 1));
     // } else {
     //   TSError("Failed to open DBM file: %s", _file.c_str());

--- a/plugins/header_rewrite/header_rewrite.cc
+++ b/plugins/header_rewrite/header_rewrite.cc
@@ -129,7 +129,7 @@ bool
 RulesConfig::add_rule(RuleSet *rule)
 {
   if (rule && rule->has_operator()) {
-    TSDebug(PLUGIN_NAME_DBG, "   Adding rule to hook=%s\n", TSHttpHookNameLookup(rule->get_hook()));
+    TSDebug(PLUGIN_NAME_DBG, "   Adding rule to hook=%s", TSHttpHookNameLookup(rule->get_hook()));
     if (NULL == _rules[rule->get_hook()]) {
       _rules[rule->get_hook()] = rule;
     } else {

--- a/plugins/header_rewrite/header_rewrite_test.cc
+++ b/plugins/header_rewrite/header_rewrite_test.cc
@@ -48,7 +48,7 @@ TSDebug(const char *tag, const char *fmt, ...)
   va_list args;
   va_start(args, fmt);
   if ((bytes = vsnprintf(buf, sizeof(buf), fmt, args)) > 0) {
-    fprintf(stdout, "TSDebug: %s: %.*s\n", PLUGIN_NAME, bytes, buf);
+    fprintf(stdout, "TSDebug: %s: %.*s", PLUGIN_NAME, bytes, buf);
   }
   va_end(args);
 }

--- a/plugins/header_rewrite/ruleset.cc
+++ b/plugins/header_rewrite/ruleset.cc
@@ -45,7 +45,7 @@ RuleSet::add_condition(Parser &p)
   Condition *c = condition_factory(p.get_op());
 
   if (NULL != c) {
-    TSDebug(PLUGIN_NAME, "   Adding condition: %%{%s} with arg: %s\n", p.get_op().c_str(), p.get_arg().c_str());
+    TSDebug(PLUGIN_NAME, "   Adding condition: %%{%s} with arg: %s", p.get_op().c_str(), p.get_arg().c_str());
     c->initialize(p);
     if (!c->set_hook(_hook)) {
       TSError("[%s] can't use this condition in this hook", PLUGIN_NAME);
@@ -70,7 +70,7 @@ RuleSet::add_operator(Parser &p)
 
   if (NULL != o) {
     // TODO: This should be extended to show both the "argument" and the "value" (if both are used)
-    TSDebug(PLUGIN_NAME, "   Adding operator: %s(%s)\n", p.get_op().c_str(), p.get_arg().c_str());
+    TSDebug(PLUGIN_NAME, "   Adding operator: %s(%s)", p.get_op().c_str(), p.get_arg().c_str());
     o->initialize(p);
     if (!o->set_hook(_hook)) {
       TSError("[%s] can't use this operator in this hook", PLUGIN_NAME);

--- a/plugins/libloader/libloader.c
+++ b/plugins/libloader/libloader.c
@@ -77,7 +77,7 @@ TSPluginInit(int argc, const char *argv[])
       l->handle = handle;
       l->next = libs;
       libs = l;
-      TSDebug("libloader", " loaded %s\n", lib);
+      TSDebug("libloader", " loaded %s", lib);
     } else {
       TSError("[libloader] failed to load %s: %s\n", lib, dlerror());
     }

--- a/proxy/FetchSM.cc
+++ b/proxy/FetchSM.cc
@@ -282,7 +282,7 @@ FetchSM::InvokePluginExt(int fetch_event)
     goto out;
   }
 
-  Debug(DEBUG_TAG, "[%s] chunked:%d, content_len: %" PRId64 ", received_len: %" PRId64 ", avail: %" PRId64 "\n", __FUNCTION__,
+  Debug(DEBUG_TAG, "[%s] chunked:%d, content_len: %" PRId64 ", received_len: %" PRId64 ", avail: %" PRId64 "", __FUNCTION__,
         resp_is_chunked, resp_content_length, resp_received_body_len,
         resp_is_chunked > 0 ? chunked_handler.chunked_reader->read_avail() : resp_reader->read_avail());
 

--- a/proxy/ICP.cc
+++ b/proxy/ICP.cc
@@ -401,7 +401,7 @@ ICPPeerReadCont::StaleCheck(int event, Event * /* e ATS_UNUSED */)
     break;
   }
   default: {
-    Debug("icp-stale", "ICPPeerReadCont::StaleCheck: Invalid Event %d\n", event);
+    Debug("icp-stale", "ICPPeerReadCont::StaleCheck: Invalid Event %d", event);
     _state->_queryResult = CACHE_EVENT_LOOKUP_FAILED;
     break;
   }

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -6832,7 +6832,7 @@ TSDebugSpecific(int debug_flag, const char *tag, const char *format_str, ...)
 }
 
 // Plugins would use TSDebug just as the TS internal uses Debug
-// e.g. TSDebug("plugin-cool", "Snoopy is a cool guy even after %d requests.\n", num_reqs);
+// e.g. TSDebug("plugin-cool", "Snoopy is a cool guy even after %d requests.", num_reqs);
 void
 TSDebug(const char *tag, const char *format_str, ...)
 {

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -358,7 +358,7 @@ init_memory_tracker(const char *config_var, RecDataT /* type ATS_UNUSED */, RecD
     dump_mem_info_frequency = REC_ConfigReadInteger("proxy.config.dump_mem_info_frequency");
   }
 
-  Debug("tracker", "init_memory_tracker called [%d]\n", dump_mem_info_frequency);
+  Debug("tracker", "init_memory_tracker called [%d]", dump_mem_info_frequency);
 
   if (preE) {
     eventProcessor.schedule_imm(preE->continuation, ET_CALL);
@@ -1208,7 +1208,7 @@ syslog_log_configure()
     if (facility < 0) {
       syslog(LOG_WARNING, "Bad syslog facility in records.config. Keeping syslog at LOG_DAEMON");
     } else {
-      Debug("server", "Setting syslog facility to %d\n", facility);
+      Debug("server", "Setting syslog facility to %d", facility);
       closelog();
       openlog("traffic_server", LOG_PID | LOG_NDELAY | LOG_NOWAIT, facility);
     }
@@ -1684,9 +1684,9 @@ main(int /* argc ATS_UNUSED */, const char **argv)
 #define SET_INTERVAL(scope, name, var)                    \
   do {                                                    \
     RecInt tmpint;                                        \
-    Debug("statsproc", "Looking for %s\n", name);         \
+    Debug("statsproc", "Looking for %s", name);           \
     if (RecGetRecordInt(name, &tmpint) == REC_ERR_OKAY) { \
-      Debug("statsproc", "Found %s\n", name);             \
+      Debug("statsproc", "Found %s", name);               \
       scope##_set_##var(tmpint);                          \
     }                                                     \
   } while (0)

--- a/proxy/Prefetch.cc
+++ b/proxy/Prefetch.cc
@@ -364,7 +364,7 @@ PrefetchTransform::PrefetchTransform(HttpSM *sm, HTTPHdr *resp)
 
   SET_HANDLER(&PrefetchTransform::handle_event);
 
-  Debug("PrefetchParser", "Created: transform for %s\n", url);
+  Debug("PrefetchParser", "Created: transform for %s", url);
 
   memset(&hash_table[0], 0, HASH_TABLE_LENGTH * sizeof(hash_table[0]));
 
@@ -397,12 +397,12 @@ PrefetchTransform::~PrefetchTransform()
   this_ethread()->schedule_imm_local(udp_url_list);
   this_ethread()->schedule_imm_local(tcp_url_list);
 
-  Debug("PrefetchParserURLs", "Unique URLs 0x%p (%s):\n", this, url);
+  Debug("PrefetchParserURLs", "Unique URLs 0x%p (%s):", this, url);
   int nurls = 0;
   for (int i = 0; i < HASH_TABLE_LENGTH; i++) {
     PrefetchUrlEntry *e = hash_table[i];
     while (e) {
-      Debug("PrefetchParserURLs", "(0x%p) %d: %s\n", this, i, e->url);
+      Debug("PrefetchParserURLs", "(0x%p) %d: %s", this, i, e->url);
       nurls++;
       PrefetchUrlEntry *next = e->hash_link;
       e->free();
@@ -410,7 +410,7 @@ PrefetchTransform::~PrefetchTransform()
     }
   }
 
-  Debug("PrefetchParserURLs", "Number of embedded objects extracted for %s: %d\n", url, nurls);
+  Debug("PrefetchParserURLs", "Number of embedded objects extracted for %s: %d", url, nurls);
 
   if (m_output_buf)
     free_MIOBuffer(m_output_buf);
@@ -491,7 +491,7 @@ PrefetchTransform::handle_event(int event, void *edata)
                                   "writing %" PRId64 " bytes to output",
                 towrite);
 
-          // Debug("PrefetchParser", "Read avail before = %d\n", avail);
+          // Debug("PrefetchParser", "Read avail before = %d", avail);
 
           m_output_buf->write(buf_reader, towrite);
 
@@ -545,7 +545,7 @@ PrefetchTransform::redirect(HTTPHdr *resp)
 
       redirect_url = (char *)alloca(redirect_url_len + 1);
       ink_strlcpy(redirect_url, tmp_url, redirect_url_len + 1);
-      Debug("PrefetchTransform", "redirect_url = %s\n", redirect_url);
+      Debug("PrefetchTransform", "redirect_url = %s", redirect_url);
     } else {
       response_status = -1;
     }
@@ -558,13 +558,13 @@ PrefetchTransform::redirect(HTTPHdr *resp)
       req = &m_sm->t_state.hdr_info.client_request;
       req_url = req->url_get()->string_get(NULL, NULL);
 
-      Debug("PrefetchTransform", "Received response status = %d\n", response_status);
-      Debug("PrefetchTransform", "Redirect from request = %s\n", req_url);
+      Debug("PrefetchTransform", "Received response status = %d", response_status);
+      Debug("PrefetchTransform", "Redirect from request = %s", req_url);
 
       int location_len = strlen(redirect_url);
-      Debug("PrefetchTransform", "Redirect url to HTTP Hdr Location: \'%s\'\n", redirect_url);
+      Debug("PrefetchTransform", "Redirect url to HTTP Hdr Location: \'%s\'", redirect_url);
       if (strncmp(redirect_url, req_url, location_len) == 0) {
-        Debug("PrefetchTransform", "'%s' -> '%s' - Could be a loop. Discontinuing this path.\n", req_url, redirect_url);
+        Debug("PrefetchTransform", "'%s' -> '%s' - Could be a loop. Discontinuing this path.", req_url, redirect_url);
         ats_free(req_url);
         return 0;
       }
@@ -617,7 +617,7 @@ PrefetchTransform::hash_add(char *s)
   int str_len = strlen(s);
 
   if (normalize_url(s, &str_len) > 0)
-    Debug("PrefetchParserURLs", "Normalized URL: %s\n", s);
+    Debug("PrefetchParserURLs", "Normalized URL: %s", s);
 
   INK_MD5 hash;
   MD5Context().hash_immediate(hash, s, str_len);
@@ -645,7 +645,7 @@ check_n_attach_prefetch_transform(HttpSM *sm, HTTPHdr *resp, bool from_cache)
   IpEndpoint client_ip = sm->t_state.client_info.src_addr;
 
   // we depend on this to setup @a client_ipb for all subsequent Debug().
-  Debug("PrefetchParser", "Checking response for request from %s\n", ats_ip_ntop(&client_ip, client_ipb, sizeof(client_ipb)));
+  Debug("PrefetchParser", "Checking response for request from %s", ats_ip_ntop(&client_ip, client_ipb, sizeof(client_ipb)));
 
   unsigned int rec_depth = 0;
   HTTPHdr *request = &sm->t_state.hdr_info.client_request;
@@ -677,7 +677,7 @@ check_n_attach_prefetch_transform(HttpSM *sm, HTTPHdr *resp, bool from_cache)
   const char *c_type = resp->value_get(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE, &c_type_len);
 
   if ((c_type == NULL) || strncmp("text/html", c_type, 9) != 0) {
-    Debug("PrefetchParserCT", "Content type is not text/html.. skipping\n");
+    Debug("PrefetchParserCT", "Content type is not text/html.. skipping");
     return;
   }
 
@@ -687,11 +687,11 @@ check_n_attach_prefetch_transform(HttpSM *sm, HTTPHdr *resp, bool from_cache)
     char type[64];
     memcpy(type, c_type, c_type_len);
     type[c_type_len] = 0;
-    Debug("PrefetchParserCT", "Content is encoded with %s .. skipping\n", type);
+    Debug("PrefetchParserCT", "Content is encoded with %s .. skipping", type);
     return;
   }
 
-  Debug("PrefetchParserCT", "Content type is text/html\n");
+  Debug("PrefetchParserCT", "Content type is text/html");
 
   if (prefetch_config->pre_parse_hook) {
     TSPrefetchInfo info;
@@ -720,7 +720,7 @@ check_n_attach_prefetch_transform(HttpSM *sm, HTTPHdr *resp, bool from_cache)
   prefetch_trans = new PrefetchTransform(sm, resp);
 
   if (prefetch_trans) {
-    Debug("PrefetchParser", "Adding Prefetch Parser 0x%p\n", prefetch_trans);
+    Debug("PrefetchParser", "Adding Prefetch Parser 0x%p", prefetch_trans);
     TSHttpTxnHookAdd(reinterpret_cast<TSHttpTxn>(sm), TS_HTTP_RESPONSE_TRANSFORM_HOOK, reinterpret_cast<TSCont>(prefetch_trans));
 
     DUMP_HEADER("PrefetchParserHdrs", &sm->t_state.hdr_info.client_request, (int64_t)0,
@@ -744,11 +744,11 @@ PrefetchPlugin(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
     TSHttpTxnCacheLookupStatusGet((TSHttpTxn)sm, &status);
 
     if (status == TS_CACHE_LOOKUP_HIT_FRESH) {
-      Debug("PrefetchPlugin", "Cached object is fresh\n");
+      Debug("PrefetchPlugin", "Cached object is fresh");
       resp = sm->t_state.cache_info.object_read->response_get();
       from_cache = true;
     } else {
-      Debug("PrefetchPlugin", "Cache lookup did not succeed\n");
+      Debug("PrefetchPlugin", "Cache lookup did not succeed");
     }
 
     break;
@@ -762,7 +762,7 @@ PrefetchPlugin(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
     break;
 
   default:
-    Debug("PrefetchPlugin", "Error: Received unexpected event\n");
+    Debug("PrefetchPlugin", "Error: Received unexpected event");
     return 0;
   }
 
@@ -771,7 +771,7 @@ PrefetchPlugin(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
 
   TSHttpTxnReenable(reinterpret_cast<TSHttpTxn>(sm), TS_EVENT_HTTP_CONTINUE);
 
-  // Debug("PrefetchPlugin", "Returning after check_n_attach_prefetch_transform()\n");
+  // Debug("PrefetchPlugin", "Returning after check_n_attach_prefetch_transform()");
 
   return 0;
 }
@@ -817,7 +817,7 @@ PrefetchProcessor::start()
 
     Note("PrefetchProcessor: Started the prefetch processor\n");
   } else {
-    Debug("PrefetchProcessor", "Prefetch processor is not started\n");
+    Debug("PrefetchProcessor", "Prefetch processor is not started");
   }
 }
 
@@ -1486,7 +1486,7 @@ PrefetchBlaster::handleEvent(int event, void *data)
   case CACHE_EVENT_OPEN_READ: {
     // action = NULL;
 
-    Debug("PrefetchBlaster", "Cache lookup succeded for %s\n", url_ent->url);
+    Debug("PrefetchBlaster", "Cache lookup succeded for %s", url_ent->url);
 
     serverVC = (VConnection *)data;
 
@@ -1497,7 +1497,7 @@ PrefetchBlaster::handleEvent(int event, void *data)
   }
   case CACHE_EVENT_OPEN_READ_FAILED:
     // action = NULL;
-    Debug("PrefetchBlaster", "Cache lookup failed for %s\n", url_ent->url);
+    Debug("PrefetchBlaster", "Cache lookup failed for %s", url_ent->url);
 
     invokeBlaster();
     break;
@@ -1583,7 +1583,7 @@ PrefetchBlaster::httpClient(int event, void *data)
   }
 
   case NET_EVENT_OPEN_FAILED:
-    Debug("PrefetchBlaster", "Open to local http port failed.. strange\n");
+    Debug("PrefetchBlaster", "Open to local http port failed.. strange");
     free();
     break;
 
@@ -1595,7 +1595,7 @@ PrefetchBlaster::httpClient(int event, void *data)
     break;
 
   default:
-    Debug("PrefetchBlaster", "Unexpected Event: %d(%s)\n", event, get_vc_event_name(event));
+    Debug("PrefetchBlaster", "Unexpected Event: %d(%s)", event, get_vc_event_name(event));
   case VC_EVENT_ERROR:
   case VC_EVENT_EOS:
     free();
@@ -1641,7 +1641,7 @@ PrefetchBlaster::bufferObject(int event, void * /* data ATS_UNUSED */)
     break;
 
   default:
-    Debug("PrefetchBlaster", "Error Event: %s\n", get_vc_event_name(event));
+    Debug("PrefetchBlaster", "Error Event: %s", get_vc_event_name(event));
   case VC_EVENT_READ_COMPLETE:
   case VC_EVENT_EOS:
     blastObject(EVENT_IMMEDIATE, NULL);
@@ -1846,7 +1846,7 @@ config_read_proto(TSPrefetchBlastData &blast, const char *str)
       } else {
         ip_text_buffer ipb;
         blast.type = TS_PREFETCH_MULTICAST_BLAST;
-        Debug("Prefetch", "Setting multicast address: %s\n", ats_ip_ntop(ats_ip_sa_cast(&blast.ip), ipb, sizeof(ipb)));
+        Debug("Prefetch", "Setting multicast address: %s", ats_ip_ntop(ats_ip_sa_cast(&blast.ip), ipb, sizeof(ipb)));
       }
     } else {
       Error("PrefetchProcessor: The protocol for Prefetch should of the form: "
@@ -1960,7 +1960,7 @@ PrefetchConfiguration::readHtmlTags(int fd, html_tag **ptags, html_tag **pattrs)
     // length(63) specified in sscanf, no need to worry about string overflow
     // coverity[secure_coding]
     if ((num = sscanf(buf, " html_tag %63s %63s %63s %63s", tag, attr, attr_tag, attr_attr)) >= 2) {
-      Debug("Prefetch", "Read html_tag: %s %s\n", tag, attr);
+      Debug("Prefetch", "Read html_tag: %s %s", tag, attr);
       tags[ntags].tag = ats_strdup(tag);
       tags[ntags].attr = ats_strdup(attr);
       if (num >= 4) {
@@ -2154,7 +2154,7 @@ KeepAliveConn::handleEvent(int event, void *data)
     break;
 
   case NET_EVENT_OPEN_FAILED:
-    Debug("PrefetchKeepAlive", "Connection to child %s failed\n", ats_ip_ntop(&ip.sa, ipb, sizeof(ipb)));
+    Debug("PrefetchKeepAlive", "Connection to child %s failed", ats_ip_ntop(&ip.sa, ipb, sizeof(ipb)));
     free();
     break;
 

--- a/proxy/SocksProxy.cc
+++ b/proxy/SocksProxy.cc
@@ -139,7 +139,7 @@ SocksProxy::mainEvent(int event, void *data)
   switch (event) {
   case NET_EVENT_ACCEPT:
     state = SOCKS_ACCEPT;
-    Debug("SocksProxy", "Proxy got accept event\n");
+    Debug("SocksProxy", "Proxy got accept event");
 
     clientVC = (NetVConnection *)data;
     clientVC->socks_addr.reset();
@@ -152,7 +152,7 @@ SocksProxy::mainEvent(int event, void *data)
       // This is a WRITE_COMPLETE. vio->nbytes == vio->ndone is true
 
       SOCKSPROXY_INC_STAT(socksproxy_http_connections_stat);
-      Debug("SocksProxy", "Handing over the HTTP request\n");
+      Debug("SocksProxy", "Handing over the HTTP request");
 
       ha_opt.transport_type = clientVC->attributes;
       HttpSessionAccept http_accept(ha_opt);
@@ -174,11 +174,11 @@ SocksProxy::mainEvent(int event, void *data)
     break;
 
   case VC_EVENT_WRITE_READY:
-    Debug("SocksProxy", "Received unexpected write_ready\n");
+    Debug("SocksProxy", "Received unexpected write_ready");
     break;
 
   case VC_EVENT_READ_COMPLETE:
-    Debug("SocksProxy", "Oops! We should never get Read_Complete.\n");
+    Debug("SocksProxy", "Oops! We should never get Read_Complete.");
   // FALLTHROUGH
   case VC_EVENT_READ_READY: {
     unsigned char *port_ptr = 0;
@@ -191,7 +191,7 @@ SocksProxy::mainEvent(int event, void *data)
     p = (unsigned char *)reader->start();
 
     if (n_read_avail >= 2) {
-      Debug(state == SOCKS_ACCEPT ? "SocksProxy" : "", "Accepted connection from a version %d client\n", (int)p[0]);
+      Debug(state == SOCKS_ACCEPT ? "SocksProxy" : "", "Accepted connection from a version %d client", (int)p[0]);
 
       // Most of the time request is just a single packet
       switch (p[0]) {
@@ -239,7 +239,7 @@ SocksProxy::mainEvent(int event, void *data)
               break;
             default:
               req_len = INT_MAX;
-              Debug("SocksProxy", "Illegal address type(%d)\n", (int)p[3]);
+              Debug("SocksProxy", "Illegal address type(%d)", (int)p[3]);
             }
 
             if (n_read_avail >= req_len) {
@@ -281,7 +281,7 @@ SocksProxy::mainEvent(int event, void *data)
 
           state = AUTH_DONE;
         } else {
-          Debug("SocksProxy", "Auth_handler returned error\n");
+          Debug("SocksProxy", "Auth_handler returned error");
           state = SOCKS_ERROR;
         }
 
@@ -338,7 +338,7 @@ SocksProxy::mainEvent(int event, void *data)
   case NET_EVENT_OPEN: {
     pending_action = NULL;
     ink_assert(state == SERVER_TUNNEL);
-    Debug("SocksProxy", "open to Socks server succeeded\n");
+    Debug("SocksProxy", "open to Socks server succeeded");
 
     NetVConnection *serverVC;
     serverVC = (NetVConnection *)data;
@@ -360,12 +360,12 @@ SocksProxy::mainEvent(int event, void *data)
     pending_action = NULL;
     sendResp(false);
     state = RESP_TO_CLIENT;
-    Debug("SocksProxy", "open to Socks server failed\n");
+    Debug("SocksProxy", "open to Socks server failed");
     break;
 
   case EVENT_INTERVAL:
     timeout = 0;
-    Debug("SocksProxy", "SocksProxy timeout, state = %d\n", state);
+    Debug("SocksProxy", "SocksProxy timeout, state = %d", state);
     state = SOCKS_ERROR;
     break;
 
@@ -373,7 +373,7 @@ SocksProxy::mainEvent(int event, void *data)
   case VC_EVENT_INACTIVITY_TIMEOUT:
   case VC_EVENT_ACTIVE_TIMEOUT:
   case VC_EVENT_EOS:
-    Debug("SocksProxy", "VC_EVENT (state: %d error: %s)\n", state, get_vc_event_name(event));
+    Debug("SocksProxy", "VC_EVENT (state: %d error: %s)", state, get_vc_event_name(event));
     state = SOCKS_ERROR;
     break;
 
@@ -390,7 +390,7 @@ SocksProxy::mainEvent(int event, void *data)
       timeout->cancel(this);
 
     if (clientVC) {
-      Debug("SocksProxy", "Closing clientVC on error\n");
+      Debug("SocksProxy", "Closing clientVC on error");
       clientVC->do_io_close();
       clientVC = NULL;
     }
@@ -496,7 +496,7 @@ struct SocksAccepter : public Continuation {
   mainEvent(int event, NetVConnection *netVC)
   {
     ink_assert(event == NET_EVENT_ACCEPT);
-    // Debug("Socks", "Accepter got ACCEPT event\n");
+    // Debug("Socks", "Accepter got ACCEPT event");
 
     new_SocksProxy(netVC);
 
@@ -510,7 +510,7 @@ struct SocksAccepter : public Continuation {
 void
 start_SocksProxy(int port)
 {
-  Debug("SocksProxy", "Accepting SocksProxy connections on port %d\n", port);
+  Debug("SocksProxy", "Accepting SocksProxy connections on port %d", port);
   NetProcessor::AcceptOptions opt;
   opt.local_port = port;
   netProcessor.main_accept(new SocksAccepter(), NO_FD, opt);
@@ -536,12 +536,12 @@ socks5ServerAuthHandler(int event, unsigned char *p, void (**h_ptr)(void))
   case SOCKS_AUTH_READ_COMPLETE:
 
     ink_assert(p[0] == SOCKS5_VERSION);
-    Debug("SocksProxy", "Socks read initial auth info\n");
+    Debug("SocksProxy", "Socks read initial auth info");
     // do nothing
     break;
 
   case SOCKS_AUTH_FILL_WRITE_BUF:
-    Debug("SocksProxy", "No authentication is required\n");
+    Debug("SocksProxy", "No authentication is required");
     p[0] = SOCKS5_VERSION;
     p[1] = 0; // no authentication necessary
     ret = 2;

--- a/proxy/StufferUdpReceiver.cc
+++ b/proxy/StufferUdpReceiver.cc
@@ -277,7 +277,7 @@ processPacket(const char *packet, int pkt_sz)
         return -1;
     }
 
-    Debug(("Writing %d bytes on socket %d\n", pkt_sz, sock_fd));
+    Debug(("Writing %d bytes on socket %d", pkt_sz, sock_fd));
     while (pkt_sz > 0) {
       int nsent = write(sock_fd, (char *)packet, pkt_sz);
       if (nsent < 0)
@@ -324,7 +324,7 @@ main(int argc, char *argv[])
     if (pkt_size < 0)
       return 0;
 
-    Debug(("Processing udp packet (size = %d)\n", pkt_size));
+    Debug(("Processing udp packet (size = %d)", pkt_size));
     processPacket(pkt_buf, pkt_size);
 
     time_t now = time(0);

--- a/proxy/hdrs/HTTP.cc
+++ b/proxy/hdrs/HTTP.cc
@@ -570,7 +570,7 @@ http_hdr_describe(HdrHeapObjImpl *raw, bool recurse)
   HTTPHdrImpl *obj = (HTTPHdrImpl *)raw;
 
   if (obj->m_polarity == HTTP_TYPE_REQUEST) {
-    Debug("http", "[TYPE: REQ, V: %04X, URL: %p, METHOD: \"%.*s\", METHOD_LEN: %d, FIELDS: %p]\n", obj->m_version,
+    Debug("http", "[TYPE: REQ, V: %04X, URL: %p, METHOD: \"%.*s\", METHOD_LEN: %d, FIELDS: %p]", obj->m_version,
           obj->u.req.m_url_impl, obj->u.req.m_len_method, (obj->u.req.m_ptr_method ? obj->u.req.m_ptr_method : "NULL"),
           obj->u.req.m_len_method, obj->m_fields_impl);
     if (recurse) {
@@ -580,7 +580,7 @@ http_hdr_describe(HdrHeapObjImpl *raw, bool recurse)
         obj_describe(obj->m_fields_impl, recurse);
     }
   } else {
-    Debug("http", "[TYPE: RSP, V: %04X, STATUS: %d, REASON: \"%.*s\", REASON_LEN: %d, FIELDS: %p]\n", obj->m_version,
+    Debug("http", "[TYPE: RSP, V: %04X, STATUS: %d, REASON: \"%.*s\", REASON_LEN: %d, FIELDS: %p]", obj->m_version,
           obj->u.resp.m_status, obj->u.resp.m_len_reason, (obj->u.resp.m_ptr_reason ? obj->u.resp.m_ptr_reason : "NULL"),
           obj->u.resp.m_len_reason, obj->m_fields_impl);
     if (recurse) {

--- a/proxy/hdrs/MIME.cc
+++ b/proxy/hdrs/MIME.cc
@@ -1290,14 +1290,14 @@ mime_hdr_field_find(MIMEHdrImpl *mh, const char *field_name_str, int field_name_
 ////////////////////////////////////////////
 
 #if TRACK_FIELD_FIND_CALLS
-  Debug("http", "mime_hdr_field_find(hdr 0x%X, field %.*s): is_wks = %d\n", mh, field_name_len, field_name_str, is_wks);
+  Debug("http", "mime_hdr_field_find(hdr 0x%X, field %.*s): is_wks = %d", mh, field_name_len, field_name_str, is_wks);
 #endif
 
   if (is_wks) {
     token_info = hdrtoken_wks_to_prefix(field_name_str);
     if ((token_info->wks_info.mask) && ((mh->m_presence_bits & token_info->wks_info.mask) == 0)) {
 #if TRACK_FIELD_FIND_CALLS
-      Debug("http", "mime_hdr_field_find(hdr 0x%X, field %.*s): MISS (due to presence bits)\n", mh, field_name_len, field_name_str);
+      Debug("http", "mime_hdr_field_find(hdr 0x%X, field %.*s): MISS (due to presence bits)", mh, field_name_len, field_name_str);
 #endif
       return NULL;
     }
@@ -1311,13 +1311,13 @@ mime_hdr_field_find(MIMEHdrImpl *mh, const char *field_name_str, int field_name_
         MIMEField *f = _mime_hdr_field_list_search_by_slotnum(mh, slotnum);
         ink_assert((f == NULL) || f->is_live());
 #if TRACK_FIELD_FIND_CALLS
-        Debug("http", "mime_hdr_field_find(hdr 0x%X, field %.*s): %s (due to slot accelerators)\n", mh, field_name_len,
+        Debug("http", "mime_hdr_field_find(hdr 0x%X, field %.*s): %s (due to slot accelerators)", mh, field_name_len,
               field_name_str, (f ? "HIT" : "MISS"));
 #endif
         return f;
       } else {
 #if TRACK_FIELD_FIND_CALLS
-        Debug("http", "mime_hdr_field_find(hdr 0x%X, field %.*s): UNKNOWN (slot too big)\n", mh, field_name_len, field_name_str);
+        Debug("http", "mime_hdr_field_find(hdr 0x%X, field %.*s): UNKNOWN (slot too big)", mh, field_name_len, field_name_str);
 #endif
       }
     }
@@ -1329,7 +1329,7 @@ mime_hdr_field_find(MIMEHdrImpl *mh, const char *field_name_str, int field_name_
     MIMEField *f = _mime_hdr_field_list_search_by_wks(mh, token_info->wks_idx);
     ink_assert((f == NULL) || f->is_live());
 #if TRACK_FIELD_FIND_CALLS
-    Debug("http", "mime_hdr_field_find(hdr 0x%X, field %.*s): %s (due to WKS list walk)\n", mh, field_name_len, field_name_str,
+    Debug("http", "mime_hdr_field_find(hdr 0x%X, field %.*s): %s (due to WKS list walk)", mh, field_name_len, field_name_str,
           (f ? "HIT" : "MISS"));
 #endif
     return f;
@@ -1338,7 +1338,7 @@ mime_hdr_field_find(MIMEHdrImpl *mh, const char *field_name_str, int field_name_
 
     ink_assert((f == NULL) || f->is_live());
 #if TRACK_FIELD_FIND_CALLS
-    Debug("http", "mime_hdr_field_find(hdr 0x%X, field %.*s): %s (due to strcmp list walk)\n", mh, field_name_len, field_name_str,
+    Debug("http", "mime_hdr_field_find(hdr 0x%X, field %.*s): %s (due to strcmp list walk)", mh, field_name_len, field_name_str,
           (f ? "HIT" : "MISS"));
 #endif
     return f;
@@ -2596,13 +2596,13 @@ mime_hdr_describe(HdrHeapObjImpl *raw, bool recurse)
   MIMEFieldBlockImpl *fblock;
   MIMEHdrImpl *obj = (MIMEHdrImpl *)raw;
 
-  Debug("http", "\n\t[PBITS: 0x%08X%08X, SLACC: 0x%04X%04X%04X%04X, HEADBLK: %p, TAILBLK: %p]\n",
+  Debug("http", "\n\t[PBITS: 0x%08X%08X, SLACC: 0x%04X%04X%04X%04X, HEADBLK: %p, TAILBLK: %p]",
         (uint32_t)((obj->m_presence_bits >> 32) & (TOK_64_CONST(0xFFFFFFFF))),
         (uint32_t)((obj->m_presence_bits >> 0) & (TOK_64_CONST(0xFFFFFFFF))), obj->m_slot_accelerators[0],
         obj->m_slot_accelerators[1], obj->m_slot_accelerators[2], obj->m_slot_accelerators[3], &(obj->m_first_fblock),
         obj->m_fblock_list_tail);
 
-  Debug("http", "\t[CBITS: 0x%08X, T_MAXAGE: %d, T_SMAXAGE: %d, T_MAXSTALE: %d, T_MINFRESH: %d, PNO$: %d]\n",
+  Debug("http", "\t[CBITS: 0x%08X, T_MAXAGE: %d, T_SMAXAGE: %d, T_MAXSTALE: %d, T_MINFRESH: %d, PNO$: %d]",
         obj->m_cooked_stuff.m_cache_control.m_mask, obj->m_cooked_stuff.m_cache_control.m_secs_max_age,
         obj->m_cooked_stuff.m_cache_control.m_secs_s_maxage, obj->m_cooked_stuff.m_cache_control.m_secs_max_stale,
         obj->m_cooked_stuff.m_cache_control.m_secs_min_fresh, obj->m_cooked_stuff.m_pragma.m_no_cache);
@@ -2620,7 +2620,7 @@ mime_field_block_describe(HdrHeapObjImpl *raw, bool /* recurse ATS_UNUSED */)
 
   MIMEFieldBlockImpl *obj = (MIMEFieldBlockImpl *)raw;
 
-  Debug("http", "[FREETOP: %d, NEXTBLK: %p]\n", obj->m_freetop, obj->m_next);
+  Debug("http", "[FREETOP: %d, NEXTBLK: %p]", obj->m_freetop, obj->m_next);
 
   for (i = 0; i < obj->m_freetop; i++) {
     MIMEField *f = &(obj->m_field_slots[i]);
@@ -3735,7 +3735,7 @@ MIMEHdrImpl::recompute_cooked_stuff(MIMEField *changing_field_or_null)
           // If >= 0 then this is a well known token
           if (hdrtoken_tokenize(s, tlen, &token_wks) >= 0) {
 #if TRACK_COOKING
-            Debug("http", "recompute_cooked_stuff: got field '%s'\n", token_wks);
+            Debug("http", "recompute_cooked_stuff: got field '%s'", token_wks);
 #endif
 
             HdrTokenHeapPrefix *p = hdrtoken_wks_to_prefix(token_wks);
@@ -3743,7 +3743,7 @@ MIMEHdrImpl::recompute_cooked_stuff(MIMEField *changing_field_or_null)
             m_cooked_stuff.m_cache_control.m_mask |= mask;
 
 #if TRACK_COOKING
-            Debug("http", "                        set mask 0x%0X\n", mask);
+            Debug("http", "                        set mask 0x%0X", mask);
 #endif
 
             if (mask & (MIME_COOKED_MASK_CC_MAX_AGE | MIME_COOKED_MASK_CC_S_MAXAGE | MIME_COOKED_MASK_CC_MAX_STALE |
@@ -3752,7 +3752,7 @@ MIMEHdrImpl::recompute_cooked_stuff(MIMEField *changing_field_or_null)
 
               if (mime_parse_integer(c, e, &value)) {
 #if TRACK_COOKING
-                Debug("http", "                        set integer value %d\n", value);
+                Debug("http", "                        set integer value %d", value);
 #endif
                 if (token_wks == MIME_VALUE_MAX_AGE)
                   m_cooked_stuff.m_cache_control.m_secs_max_age = value;
@@ -3764,7 +3764,7 @@ MIMEHdrImpl::recompute_cooked_stuff(MIMEField *changing_field_or_null)
                   m_cooked_stuff.m_cache_control.m_secs_s_maxage = value;
               } else {
 #if TRACK_COOKING
-                Debug("http", "                        set integer value %d\n", INT_MAX);
+                Debug("http", "                        set integer value %d", INT_MAX);
 #endif
                 if (token_wks == MIME_VALUE_MAX_STALE)
                   m_cooked_stuff.m_cache_control.m_secs_max_stale = INT_MAX;

--- a/proxy/hdrs/URL.cc
+++ b/proxy/hdrs/URL.cc
@@ -1571,24 +1571,21 @@ url_describe(HdrHeapObjImpl *raw, bool /* recurse ATS_UNUSED */)
 {
   URLImpl *obj = (URLImpl *)raw;
 
-  Debug("http", "[URLTYPE: %d, SWKSIDX: %d,\n", obj->m_url_type, obj->m_scheme_wks_idx);
-  Debug("http", "\tSCHEME: \"%.*s\", SCHEME_LEN: %d,\n", obj->m_len_scheme, (obj->m_ptr_scheme ? obj->m_ptr_scheme : "NULL"),
+  Debug("http", "[URLTYPE: %d, SWKSIDX: %d,", obj->m_url_type, obj->m_scheme_wks_idx);
+  Debug("http", "\tSCHEME: \"%.*s\", SCHEME_LEN: %d,", obj->m_len_scheme, (obj->m_ptr_scheme ? obj->m_ptr_scheme : "NULL"),
         obj->m_len_scheme);
-  Debug("http", "\tUSER: \"%.*s\", USER_LEN: %d,\n", obj->m_len_user, (obj->m_ptr_user ? obj->m_ptr_user : "NULL"),
-        obj->m_len_user);
-  Debug("http", "\tPASSWORD: \"%.*s\", PASSWORD_LEN: %d,\n", obj->m_len_password,
+  Debug("http", "\tUSER: \"%.*s\", USER_LEN: %d,", obj->m_len_user, (obj->m_ptr_user ? obj->m_ptr_user : "NULL"), obj->m_len_user);
+  Debug("http", "\tPASSWORD: \"%.*s\", PASSWORD_LEN: %d,", obj->m_len_password,
         (obj->m_ptr_password ? obj->m_ptr_password : "NULL"), obj->m_len_password);
-  Debug("http", "\tHOST: \"%.*s\", HOST_LEN: %d,\n", obj->m_len_host, (obj->m_ptr_host ? obj->m_ptr_host : "NULL"),
-        obj->m_len_host);
-  Debug("http", "\tPORT: \"%.*s\", PORT_LEN: %d, PORT_NUM: %d\n", obj->m_len_port, (obj->m_ptr_port ? obj->m_ptr_port : "NULL"),
+  Debug("http", "\tHOST: \"%.*s\", HOST_LEN: %d,", obj->m_len_host, (obj->m_ptr_host ? obj->m_ptr_host : "NULL"), obj->m_len_host);
+  Debug("http", "\tPORT: \"%.*s\", PORT_LEN: %d, PORT_NUM: %d", obj->m_len_port, (obj->m_ptr_port ? obj->m_ptr_port : "NULL"),
         obj->m_len_port, obj->m_port);
-  Debug("http", "\tPATH: \"%.*s\", PATH_LEN: %d,\n", obj->m_len_path, (obj->m_ptr_path ? obj->m_ptr_path : "NULL"),
-        obj->m_len_path);
-  Debug("http", "\tPARAMS: \"%.*s\", PARAMS_LEN: %d,\n", obj->m_len_params, (obj->m_ptr_params ? obj->m_ptr_params : "NULL"),
+  Debug("http", "\tPATH: \"%.*s\", PATH_LEN: %d,", obj->m_len_path, (obj->m_ptr_path ? obj->m_ptr_path : "NULL"), obj->m_len_path);
+  Debug("http", "\tPARAMS: \"%.*s\", PARAMS_LEN: %d,", obj->m_len_params, (obj->m_ptr_params ? obj->m_ptr_params : "NULL"),
         obj->m_len_params);
-  Debug("http", "\tQUERY: \"%.*s\", QUERY_LEN: %d,\n", obj->m_len_query, (obj->m_ptr_query ? obj->m_ptr_query : "NULL"),
+  Debug("http", "\tQUERY: \"%.*s\", QUERY_LEN: %d,", obj->m_len_query, (obj->m_ptr_query ? obj->m_ptr_query : "NULL"),
         obj->m_len_query);
-  Debug("http", "\tFRAGMENT: \"%.*s\", FRAGMENT_LEN: %d]\n", obj->m_len_fragment,
+  Debug("http", "\tFRAGMENT: \"%.*s\", FRAGMENT_LEN: %d]", obj->m_len_fragment,
         (obj->m_ptr_fragment ? obj->m_ptr_fragment : "NULL"), obj->m_len_fragment);
 }
 

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -196,7 +196,7 @@ Http1ClientSession::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader 
 {
   /* conditionally set the tcp initial congestion window
      before our first write. */
-  DebugHttpSsn("tcp_init_cwnd_set %d\n", (int)tcp_init_cwnd_set);
+  DebugHttpSsn("tcp_init_cwnd_set %d", (int)tcp_init_cwnd_set);
   if (!tcp_init_cwnd_set) {
     tcp_init_cwnd_set = true;
     set_tcp_init_cwnd();
@@ -211,7 +211,7 @@ void
 Http1ClientSession::set_tcp_init_cwnd()
 {
   int desired_tcp_init_cwnd = trans.get_sm()->t_state.txn_conf->server_tcp_init_cwnd;
-  DebugHttpSsn("desired TCP congestion window is %d\n", desired_tcp_init_cwnd);
+  DebugHttpSsn("desired TCP congestion window is %d", desired_tcp_init_cwnd);
   if (desired_tcp_init_cwnd == 0)
     return;
   if (get_netvc()->set_tcp_init_cwnd(desired_tcp_init_cwnd) != 0)

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -7140,7 +7140,7 @@ HttpSM::set_next_state()
        * then we can skip the lookup
        */
       ip_text_buffer ipb;
-      DebugSM("dns", "[HttpTransact::HandleRequest] Skipping DNS lookup for API supplied target %s.\n",
+      DebugSM("dns", "[HttpTransact::HandleRequest] Skipping DNS lookup for API supplied target %s.",
               ats_ip_ntop(&t_state.server_info.dst_addr, ipb, sizeof(ipb)));
       // this seems wasteful as we will just copy it right back
       ats_ip_copy(t_state.host_db_info.ip(), &t_state.server_info.dst_addr);
@@ -7165,7 +7165,7 @@ HttpSM::set_next_state()
        */
       if (is_debug_tag_set("dns")) {
         ip_text_buffer ipb;
-        DebugSM("dns", "[HttpTransact::HandleRequest] Skipping DNS lookup for client supplied target %s.\n",
+        DebugSM("dns", "[HttpTransact::HandleRequest] Skipping DNS lookup for client supplied target %s.",
                 ats_ip_ntop(addr, ipb, sizeof(ipb)));
       }
       ats_ip_copy(t_state.host_db_info.ip(), addr);

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -73,7 +73,7 @@ simple_or_unavailable_server_retry(HttpTransact::State *s)
   // reponse is from a parent origin server.
   HTTPStatus server_response = http_hdr_status_get(s->hdr_info.server_response.m_http);
 
-  DebugTxn("http_trans", "[simple_or_unavailabe_server_retry] server_response = %d, simple_retry_attempts: %d, numParents:%d \n",
+  DebugTxn("http_trans", "[simple_or_unavailabe_server_retry] server_response = %d, simple_retry_attempts: %d, numParents:%d ",
            server_response, s->current.simple_retry_attempts, s->parent_params->numParents(&s->parent_result));
 
   // simple retry is enabled, 0x1
@@ -86,7 +86,7 @@ simple_or_unavailable_server_retry(HttpTransact::State *s)
       s->current.retry_type = HttpTransact::PARENT_ORIGIN_SIMPLE_RETRY;
       return;
     } else {
-      DebugTxn("http_trans", "PARENT_ORIGIN_SIMPLE_RETRY: retried all parents, send response to client.\n");
+      DebugTxn("http_trans", "PARENT_ORIGIN_SIMPLE_RETRY: retried all parents, send response to client.");
       return;
     }
   }
@@ -100,7 +100,7 @@ simple_or_unavailable_server_retry(HttpTransact::State *s)
       s->current.retry_type = HttpTransact::PARENT_ORIGIN_UNAVAILABLE_SERVER_RETRY;
       return;
     } else {
-      DebugTxn("http_trans", "PARENT_ORIGIN_UNAVAILABLE_SERVER_RETRY: retried all parents, send error to client.\n");
+      DebugTxn("http_trans", "PARENT_ORIGIN_UNAVAILABLE_SERVER_RETRY: retried all parents, send error to client.");
       return;
     }
   }
@@ -3594,21 +3594,21 @@ HttpTransact::handle_response_from_parent(State *s)
     if (s->current.retry_type == PARENT_ORIGIN_SIMPLE_RETRY || s->current.retry_type == PARENT_ORIGIN_UNAVAILABLE_SERVER_RETRY) {
       if (s->current.retry_type == PARENT_ORIGIN_SIMPLE_RETRY) {
         if (s->current.simple_retry_attempts >= s->parent_result.max_retries(PARENT_RETRY_SIMPLE)) {
-          DebugTxn("http_trans", "PARENT_ORIGIN_SIMPLE_RETRY: retried all parents, send error to client.\n");
+          DebugTxn("http_trans", "PARENT_ORIGIN_SIMPLE_RETRY: retried all parents, send error to client.");
           s->current.retry_type = PARENT_ORIGIN_UNDEFINED_RETRY;
         } else {
           s->current.simple_retry_attempts++;
-          DebugTxn("http_trans", "PARENT_ORIGIN_SIMPLE_RETRY: try another parent.\n");
+          DebugTxn("http_trans", "PARENT_ORIGIN_SIMPLE_RETRY: try another parent.");
           s->current.retry_type = PARENT_ORIGIN_UNDEFINED_RETRY;
           next_lookup = find_server_and_update_current_info(s);
         }
       } else { // try unavailable server retry if we have a unavailable server retry response from the parent.
         if (s->current.unavailable_server_retry_attempts >= s->parent_result.max_retries(PARENT_RETRY_UNAVAILABLE_SERVER)) {
-          DebugTxn("http_trans", "PARENT_ORIGIN_UNAVAILABLE_SERVER_RETRY: retried all parents, send error to client.\n");
+          DebugTxn("http_trans", "PARENT_ORIGIN_UNAVAILABLE_SERVER_RETRY: retried all parents, send error to client.");
           s->current.retry_type = PARENT_ORIGIN_UNDEFINED_RETRY;
         } else {
           s->current.unavailable_server_retry_attempts++;
-          DebugTxn("http_trans", "PARENT_ORIGIN_UNAVAILABLE_SERVER_RETRY: marking parent down and trying another.\n");
+          DebugTxn("http_trans", "PARENT_ORIGIN_UNAVAILABLE_SERVER_RETRY: marking parent down and trying another.");
           s->current.retry_type = PARENT_ORIGIN_UNDEFINED_RETRY;
           s->parent_params->markParentDown(&s->parent_result);
           next_lookup = find_server_and_update_current_info(s);

--- a/proxy/http/HttpTransactCache.cc
+++ b/proxy/http/HttpTransactCache.cc
@@ -1202,7 +1202,7 @@ HttpTransactCache::CalcVariability(CacheLookupHttpConfig *http_config_params, HT
 
       Debug("http_match", "Vary: %s", field->str);
       if (((field->str[0] == '*') && (field->str[1] == NUL))) {
-        Debug("http_match", "Wildcard variability --- object not served from cache\n");
+        Debug("http_match", "Wildcard variability --- object not served from cache");
         variability = VARIABILITY_ALL;
         break;
       }


### PR DESCRIPTION
Debug() will check for this anyways, so for consistency, we should remove these since it sets a better precedence going forward.