### PR TITLE
TS-3959: requests are retryable only if bytes were sent and there was no connection error

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -6473,8 +6473,8 @@ HttpTransact::is_request_valid(State *s, HTTPHdr *incoming_request)
 bool
 HttpTransact::is_request_retryable(State *s)
 {
-  // If the connection was established-- we cannot retry
-  if (s->state_machine->server_request_hdr_bytes > 0) {
+  // If there was no error establishing the connection (and we sent bytes)-- we cannot retry
+  if (s->current.state != CONNECTION_ERROR && s->state_machine->server_request_hdr_bytes > 0) {
     return false;
   }
 


### PR DESCRIPTION
The root issue that TS-4328 and TS-3440 were trying to fix was that ATS was too aggressive in retries to origin (namely after the origin had already recieved the request). The previous patches attempted to have ATS not retry assuming bytes were sent on the wire-- sadly TS-4328 actually only checks that we set bytes to be written to the wire. To fix this we simply check if there was a connection failure to origin, if so we'll assume that it is retryable (since connection failures to origin should only be due to errors writing/connecting etc.).