### PR TITLE
TS-4481: CPP API - clear handles and reload on demand.

### DIFF
--- a/lib/atscppapi/src/Transaction.cc
+++ b/lib/atscppapi/src/Transaction.cc
@@ -39,6 +39,7 @@ using namespace atscppapi;
  */
 struct atscppapi::TransactionState : noncopyable {
   TSHttpTxn txn_;
+  TSEvent event_; ///< Current event being dispatched.
   std::list<TransactionPlugin *> plugins_;
   TSMBuffer client_request_hdr_buf_;
   TSMLoc client_request_hdr_loc_;
@@ -62,6 +63,7 @@ struct atscppapi::TransactionState : noncopyable {
 
   TransactionState(TSHttpTxn txn, TSMBuffer client_request_hdr_buf, TSMLoc client_request_hdr_loc)
     : txn_(txn),
+      event_(TS_EVENT_NONE),
       client_request_hdr_buf_(client_request_hdr_buf),
       client_request_hdr_loc_(client_request_hdr_loc),
       client_request_(txn, client_request_hdr_buf, client_request_hdr_loc),
@@ -96,6 +98,12 @@ Transaction::~Transaction()
 {
   LOG_DEBUG("Transaction tshttptxn=%p destroying Transaction object %p", state_->txn_, this);
   delete state_;
+}
+
+void
+Transaction::setEvent(TSEvent event)
+{
+  state_->event_ = event;
 }
 
 bool
@@ -238,36 +246,7 @@ ClientRequest &
 Transaction::getClientRequest()
 {
   return state_->client_request_;
-}
-
-Request &
-Transaction::getServerRequest()
-{
-  return state_->server_request_;
-}
-
-Response &
-Transaction::getServerResponse()
-{
-  return state_->server_response_;
-}
-
-Response &
-Transaction::getClientResponse()
-{
-  return state_->client_response_;
-}
-
-Request &
-Transaction::getCachedRequest()
-{
-  return state_->cached_request_;
-}
-
-Response &
-Transaction::getCachedResponse()
-{
-  return state_->cached_response_;
+  ;
 }
 
 string
@@ -454,58 +433,91 @@ private:
 
 } // anonymous namespace
 
-void
-Transaction::initServerRequest(TSEvent event)
+Request &
+Transaction::getServerRequest()
 {
   static initializeHandles initializeServerRequestHandles(TSHttpTxnServerReqGet);
-  initializeServerRequestHandles(state_->txn_, state_->server_request_hdr_buf_, state_->server_request_hdr_loc_, "server request");
-  LOG_DEBUG("Initializing server request, event %d", event);
-  state_->server_request_.init(state_->server_request_hdr_buf_, state_->server_request_hdr_loc_);
+  if (NULL == state_->server_request_hdr_buf_) {
+    initializeServerRequestHandles(state_->txn_, state_->server_request_hdr_buf_, state_->server_request_hdr_loc_,
+                                   "server request");
+    LOG_DEBUG("Initializing server request, event %d", state_->event_);
+    state_->server_request_.init(state_->server_request_hdr_buf_, state_->server_request_hdr_loc_);
+  }
+  return state_->server_request_;
 }
 
-void
-Transaction::initServerResponse(TSEvent event)
+Response &
+Transaction::getServerResponse()
 {
   static initializeHandles initializeServerResponseHandles(TSHttpTxnServerRespGet);
-  initializeServerResponseHandles(state_->txn_, state_->server_response_hdr_buf_, state_->server_response_hdr_loc_,
-                                  "server response");
-  LOG_DEBUG("Initializing server response, event %d", event);
-  state_->server_response_.init(state_->server_response_hdr_buf_, state_->server_response_hdr_loc_);
+  if (NULL == state_->server_response_hdr_buf_) {
+    initializeServerResponseHandles(state_->txn_, state_->server_response_hdr_buf_, state_->server_response_hdr_loc_,
+                                    "server response");
+    LOG_DEBUG("Initializing server response, event %d", state_->event_);
+    state_->server_response_.init(state_->server_response_hdr_buf_, state_->server_response_hdr_loc_);
+  }
+  return state_->server_response_;
 }
 
-void
-Transaction::initClientResponse(TSEvent event)
+Response &
+Transaction::getClientResponse()
 {
   static initializeHandles initializeClientResponseHandles(TSHttpTxnClientRespGet);
-  initializeClientResponseHandles(state_->txn_, state_->client_response_hdr_buf_, state_->client_response_hdr_loc_,
-                                  "client response");
-  LOG_DEBUG("Initializing client response, event %d", event);
-  state_->client_response_.init(state_->client_response_hdr_buf_, state_->client_response_hdr_loc_);
+  if (NULL == state_->client_response_hdr_buf_) {
+    initializeClientResponseHandles(state_->txn_, state_->client_response_hdr_buf_, state_->client_response_hdr_loc_,
+                                    "client response");
+    LOG_DEBUG("Initializing client response, event %d", state_->event_);
+    state_->client_response_.init(state_->client_response_hdr_buf_, state_->client_response_hdr_loc_);
+  }
+  return state_->client_response_;
 }
 
-void
-Transaction::initCachedRequest(TSEvent event)
+Request &
+Transaction::getCachedRequest()
 {
   static initializeHandles initializeCachedRequestHandles(TSHttpTxnCachedReqGet);
 
-  if (event == TS_EVENT_HTTP_TXN_CLOSE) {
+  if (state_->event_ == TS_EVENT_HTTP_TXN_CLOSE) {
     // CachedRequest is destroyed in tunnel_handler_cache_read
     state_->cached_request_.reset();
-    LOG_DEBUG("Reset cached request, event %d", event);
-    return;
+    LOG_DEBUG("Reset cached request, event %d", state_->event_);
+  } else {
+    if (NULL == state_->cached_request_hdr_buf_) {
+      initializeCachedRequestHandles(state_->txn_, state_->cached_request_hdr_buf_, state_->cached_request_hdr_loc_,
+                                     "cached request");
+      LOG_DEBUG("Initializing cached request, event %d", state_->event_);
+      state_->cached_request_.init(state_->cached_request_hdr_buf_, state_->cached_request_hdr_loc_);
+    }
   }
+  return state_->cached_request_;
+}
 
-  initializeCachedRequestHandles(state_->txn_, state_->cached_request_hdr_buf_, state_->cached_request_hdr_loc_, "cached request");
-  LOG_DEBUG("Initializing cached request, event %d", event);
-  state_->cached_request_.init(state_->cached_request_hdr_buf_, state_->cached_request_hdr_loc_);
+Response &
+Transaction::getCachedResponse()
+{
+  static initializeHandles initializeCachedResponseHandles(TSHttpTxnCachedRespGet);
+  if (NULL == state_->cached_response_hdr_buf_) {
+    initializeCachedResponseHandles(state_->txn_, state_->cached_response_hdr_buf_, state_->cached_response_hdr_loc_,
+                                    "cached response");
+    LOG_DEBUG("Initializing cached response, event %d", state_->event_);
+    state_->cached_response_.init(state_->cached_response_hdr_buf_, state_->cached_response_hdr_loc_);
+  }
+  return state_->cached_response_;
 }
 
 void
-Transaction::initCachedResponse(TSEvent event)
+Transaction::resetHandles()
 {
-  static initializeHandles initializeCachedResponseHandles(TSHttpTxnCachedRespGet);
-  initializeCachedResponseHandles(state_->txn_, state_->cached_response_hdr_buf_, state_->cached_response_hdr_loc_,
-                                  "cached response");
-  LOG_DEBUG("Initializing cached response, event %d", event);
-  state_->cached_response_.init(state_->cached_response_hdr_buf_, state_->cached_response_hdr_loc_);
+  state_->cached_request_hdr_buf_ = NULL;
+  state_->cached_request_hdr_loc_ = NULL;
+  state_->cached_response_hdr_buf_ = NULL;
+  state_->cached_response_hdr_loc_ = NULL;
+
+  state_->client_response_hdr_buf_ = NULL;
+  state_->client_response_hdr_loc_ = NULL;
+
+  state_->server_request_hdr_buf_ = NULL;
+  state_->server_request_hdr_loc_ = NULL;
+  state_->server_response_hdr_buf_ = NULL;
+  state_->server_response_hdr_loc_ = NULL;
 }

--- a/lib/atscppapi/src/include/atscppapi/Transaction.h
+++ b/lib/atscppapi/src/include/atscppapi/Transaction.h
@@ -85,6 +85,11 @@ public:
   ~Transaction();
 
   /**
+   * Set the @a event for the currently active hook.
+   */
+  void setEvent(TSEvent event);
+
+  /**
    * Context Values are a way to share data between plugins, the key is always a string
    * and the value can be a shared_ptr to any type that extends ContextValue.
    * @param key the key to search for.
@@ -384,37 +389,16 @@ private:
    *
    * @private
    */
-  void initServerRequest(TSEvent event);
+  Request &initServerRequest();
 
   /**
-   * Used to initialize the Response object for the Server.
-   *
-   * @private
-   */
-  void initServerResponse(TSEvent event);
-
-  /**
-   * Used to initialize the Response object for the Client.
-   *
-   * @private
-   */
-  void initClientResponse(TSEvent event);
-
-  /**
-   * Used to initialize the Request object for the cache.
+   * Reset all the transaction handles (for response/requests).
+   * This is used to clear handles that may have gone stale.
    *
    * @private
    */
 
-  void initCachedRequest(TSEvent event);
-
-  /**
-   * Used to initialize the Response object for the cache.
-   *
-   * @private
-   */
-
-  void initCachedResponse(TSEvent event);
+  void resetHandles();
 
   /**
    * Returns a list of TransactionPlugin pointers bound to the current Transaction

--- a/lib/atscppapi/src/include/utils_internal.h
+++ b/lib/atscppapi/src/include/utils_internal.h
@@ -66,39 +66,21 @@ namespace utils
     }
 
     static void
+    setTransactionEvent(Transaction &transaction, TSEvent event)
+    {
+      transaction.setEvent(event);
+    }
+
+    static void
+    resetTransactionHandles(Transaction &transaction)
+    {
+      transaction.resetHandles();
+    }
+
+    static void
     initResponse(Response &response, TSMBuffer hdr_buf, TSMLoc hdr_loc)
     {
       response.init(hdr_buf, hdr_loc);
-    }
-
-    static void
-    initTransactionServerRequest(Transaction &transaction, TSEvent event)
-    {
-      transaction.initServerRequest(event);
-    }
-
-    static void
-    initTransactionServerResponse(Transaction &transaction, TSEvent event)
-    {
-      transaction.initServerResponse(event);
-    }
-
-    static void
-    initTransactionClientResponse(Transaction &transaction, TSEvent event)
-    {
-      transaction.initClientResponse(event);
-    }
-
-    static void
-    initTransactionCachedRequest(Transaction &transaction, TSEvent event)
-    {
-      transaction.initCachedRequest(event);
-    }
-
-    static void
-    initTransactionCachedResponse(Transaction &transaction, TSEvent event)
-    {
-      transaction.initCachedResponse(event);
     }
 
     static const std::list<TransactionPlugin *> &


### PR DESCRIPTION
The changes are

* The handles are cleared, not re-initialized, per hook.
* Handles are loaded from the transaction object on demand.
* The current event is stored in the `state_` rather than being passed around because only one method, as far as I can tell, actually needs it.
