### PR TITLE
TS-4377: update documentation links in default configuration files

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -247,26 +247,33 @@ A value of ``0`` means no signal will be sent.
    path, this directory is located in the Traffic Server ``SYSCONFDIR``
    directory.
 
+Thread Variables
+----------------
+
 .. ts:cv:: CONFIG proxy.config.exec_thread.autoconfig INT 1
 
-   When enabled (the default, ``1``), Traffic Server scales threads according to the available CPU cores. See the config option below.
+   When enabled (the default, ``1``), |TS| scales threads according to the
+   available CPU cores. See the config option below.
 
 .. ts:cv:: CONFIG proxy.config.exec_thread.autoconfig.scale FLOAT 1.5
 
-   Factor by which Traffic Server scales the number of threads. The multiplier is usually the number of available CPU cores. By default
-   this is scaling factor is ``1.5``.
+   Factor by which |TS| scales the number of threads. The multiplier is usually
+   the number of available CPU cores. By default this is scaling factor is
+   ``1.5``.
 
 .. ts:cv:: CONFIG proxy.config.exec_thread.limit INT 2
 
-   The number of threads Traffic Server will create if `proxy.config.exec_thread.autoconfig` is set to `0`, otherwise this option is ignored.
+   The number of threads |TS| will create if `proxy.config.exec_thread.autoconfig`
+   is set to ``0``, otherwise this option is ignored.
 
 .. ts:cv:: CONFIG proxy.config.accept_threads INT 1
 
-   The number of accept threads Traffic Server. If disabled (``0``), then accepts will be done in each of the worker threads.
+   The number of accept threads. If disabled (``0``), then accepts will be done
+   in each of the worker threads.
 
-.. ts:cv:: CONFIG proxy.config.thread.default.stacksize  INT 1048576
+.. ts:cv:: CONFIG proxy.config.thread.default.stacksize INT 1048576
 
-   The new default thread stack size, for all threads. The original default is set at 1 MB.
+   Default thread stack size, in bytes, for all threads (default is 1 MB).
 
 .. ts:cv:: CONFIG proxy.config.exec_thread.affinity INT 1
 

--- a/proxy/config/cache.config.default
+++ b/proxy/config/cache.config.default
@@ -1,12 +1,15 @@
 #
 # cache.config
 #
+# Documentation:
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/cache.config.en.html
+#
 # The purpose of this file is to alter caching parameters of
 #   specific objects or sets of objects
 #
 # Each line consists of a set of tag value pairs.  The pairs
 #   are in the format  <tag>=<value>
-# 
+#
 # Each line must include exactly one primary specifier
 #
 #   Primary destination specifiers are

--- a/proxy/config/congestion.config.default
+++ b/proxy/config/congestion.config.default
@@ -1,11 +1,14 @@
 #
 # congestion.config
 #
+# Documentation:
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/congestion.config.en.html
+#
 # The purpose of this file is to specify the congestion control rules.
 #
 # Each line consists of a set of tag value pairs.  The pairs
 #   are in the format  <tag>=<value>
-# 
+#
 # Each line must include exactly one primary specifier
 #
 #   Primary destination specifiers are
@@ -13,7 +16,7 @@
 #     dest_host=
 #     dest_ip=
 #     host_regex=
-# 
+#
 # Lines may include any number of the secondary specifiers but
 #   secondary specifiers may not be duplicated on the same line.
 #

--- a/proxy/config/hosting.config.default
+++ b/proxy/config/hosting.config.default
@@ -1,5 +1,9 @@
 #
-# 
+# hosting.config
+#
+# Documentation:
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/hosting.config.en.html
+#
 # The purpose of this file is to specify the volumes that 
 # specific hostnames or domains should be stored in.
 #

--- a/proxy/config/icp.config.default
+++ b/proxy/config/icp.config.default
@@ -2,6 +2,9 @@
 #
 # ICP Configuration -- Defines ICP parent/sibling configuration
 #
+#  Documentation:
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/icp.config.en.html
+#
 #  Each line is formatted with a separator between fields. This can be
 #  a space, ':', ';', ',', or '|' but must be consistent for the
 #  entire line. There must be a terminating separator as the last

--- a/proxy/config/ip_allow.config.default
+++ b/proxy/config/ip_allow.config.default
@@ -1,10 +1,14 @@
+#
 # ip_allow.config
+#
+# Documentation:
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/ip_allow.config.en.html
 #
 # Rules:
 # src_ip=<range of IP addresses> action=<action> [method=<list of methods separated by '|'>]
 #
 # Actions: ip_allow, ip_deny
-# 
+#
 # Multiple method keywords can be specified (method=GET method=HEAD), or
 # multiple methods can be separated by an '|' (method=GET|HEAD).  The method
 # keyword is optional and it is defaulted to ALL.

--- a/proxy/config/log_hosts.config.default
+++ b/proxy/config/log_hosts.config.default
@@ -1,6 +1,8 @@
+#
 # log_hosts.config
 #
-# 
+# Documentation:
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/log_hosts.config.en.html
 #
 # This configuration file is used when the Traffic Server is configured in
 # reverse-proxy mode and access logs are to be separated by server host

--- a/proxy/config/logs_xml.config.default
+++ b/proxy/config/logs_xml.config.default
@@ -1,6 +1,8 @@
 <!------------------------------------------------------------------------
 logs.config, v2.0
 
+Documentation:
+    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/logs_xml.config.en.html
 
 This is the configuration file for Traffic Server logging.  This file
 defines log files, their formats, filters, and processing options.  The

--- a/proxy/config/parent.config.default
+++ b/proxy/config/parent.config.default
@@ -1,13 +1,15 @@
 #
 # parent.config
 #
+# Documentation:
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/parent.config.en.html
 #
 # The purpose of this file is to specify the parent proxy for
 #   specific objects or sets of objects
 #
 # Each line consists of a set of tag value pairs.  The pairs
 #   are in the format  <tag>=<value>
-# 
+#
 # Each line must include exactly one primary specifier
 #
 #   Primary destination specifiers are

--- a/proxy/config/plugin.config.default
+++ b/proxy/config/plugin.config.default
@@ -1,3 +1,9 @@
+#
+# plugin.config
+#
+# Documentation:
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/plugin.config.en.html
+#
 # Comments start with a '#' and continue to the end of the line
 # Blank lines are ignored
 #

--- a/proxy/config/records.config.default.in
+++ b/proxy/config/records.config.default.in
@@ -1,7 +1,7 @@
 ##############################################################################
 # *NOTE*: All options covered in this file should be documented in the docs:
 #
-#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.config.en.html
+#    https://docs.trafficserver.apache.org/records.config
 ##############################################################################
 
 ##############################################################################
@@ -19,7 +19,7 @@ CONFIG proxy.config.exec_thread.affinity INT 1
 
 ##############################################################################
 # Specify server addresses and ports to bind for HTTP and HTTPS. Docs:
-#  i  https://docs.trafficserver.apache.org/records.config#proxy.config.http.server_ports
+#    https://docs.trafficserver.apache.org/records.config#proxy.config.http.server_ports
 ##############################################################################
 CONFIG proxy.config.http.server_ports STRING 8080
 

--- a/proxy/config/records.config.default.in
+++ b/proxy/config/records.config.default.in
@@ -1,12 +1,12 @@
 ##############################################################################
 # *NOTE*: All options covered in this file should be documented in the docs:
 #
-#    https://docs.trafficserver.apache.org/en/latest/reference/configuration/records.config.en.html
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.config.en.html
 ##############################################################################
 
 ##############################################################################
 # Thread configurations. Docs:
-#    https://docs.trafficserver.apache.org/records.config#proxy-config-exec-thread-autoconfig
+#    https://docs.trafficserver.apache.org/records.config#thread-variables
 ##############################################################################
 CONFIG proxy.config.exec_thread.autoconfig INT 1
 CONFIG proxy.config.exec_thread.autoconfig.scale FLOAT 1.5
@@ -15,12 +15,11 @@ CONFIG proxy.config.ssl.number.threads INT -1
 CONFIG proxy.config.accept_threads INT 1
 CONFIG proxy.config.task_threads INT 2
 CONFIG proxy.config.cache.threads_per_disk INT 8
-    # https://docs.trafficserver.apache.org/records.config#proxy-config-exec-thread-affinity
 CONFIG proxy.config.exec_thread.affinity INT 1
 
 ##############################################################################
 # Specify server addresses and ports to bind for HTTP and HTTPS. Docs:
-#    https://docs.trafficserver.apache.org/records.config#proxy-config-http-server-ports
+#  i  https://docs.trafficserver.apache.org/records.config#proxy.config.http.server_ports
 ##############################################################################
 CONFIG proxy.config.http.server_ports STRING 8080
 
@@ -40,7 +39,7 @@ CONFIG proxy.config.http.insert_response_via_str INT 0
 ##############################################################################
 # Parent proxy configuration, in addition to these settings also see parent.config. Docs:
 #    https://docs.trafficserver.apache.org/records.config#parent-proxy-configuration
-#    https://docs.trafficserver.apache.org/en/latest/reference/configuration/parent.config.en.html
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/parent.config.en.html
 ##############################################################################
 CONFIG proxy.config.http.parent_proxy_routing_enable INT 0
 CONFIG proxy.config.http.parent_proxy.retry_time INT 300
@@ -102,7 +101,7 @@ CONFIG proxy.config.http.cache.http INT 1
 ##############################################################################
 # Cache control. Docs:
 #    https://docs.trafficserver.apache.org/records.config#cache-control
-#    https://docs.trafficserver.apache.org/en/latest/reference/configuration/cache.config.en.html
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/cache.config.en.html
 ##############################################################################
 CONFIG proxy.config.http.cache.ignore_client_cc_max_age INT 1
 CONFIG proxy.config.http.normalize_ae_gzip INT 1
@@ -132,7 +131,7 @@ CONFIG proxy.config.net.max_connections_active_in INT 10000
 ##############################################################################
 # RAM and disk cache configurations. Docs:
 #    https://docs.trafficserver.apache.org/records.config#ram-cache
-#    https://docs.trafficserver.apache.org/en/latest/reference/configuration/storage.config.en.html
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/storage.config.en.html
 ##############################################################################
 CONFIG proxy.config.cache.ram_cache.size INT -1
 CONFIG proxy.config.cache.ram_cache_cutoff INT 4194304
@@ -145,7 +144,7 @@ CONFIG proxy.config.cache.min_average_object_size INT 8000
 ##############################################################################
 # Logging Config. Docs:
 #    https://docs.trafficserver.apache.org/records.config#logging-configuration
-#    https://docs.trafficserver.apache.org/en/latest/reference/configuration/logs_xml.config.en.html
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/logs_xml.config.en.html
 ##############################################################################
 CONFIG proxy.config.log.logging_enabled INT 3
 CONFIG proxy.config.log.max_space_mb_for_logs INT 25000
@@ -159,7 +158,7 @@ CONFIG proxy.config.log.periodic_tasks_interval INT 5
 ##############################################################################
 # These settings control remapping, and if the proxy allows (open) forward proxy or not. Docs:
 #    https://docs.trafficserver.apache.org/records.config#url-remap-rules
-#    https://docs.trafficserver.apache.org/en/latest/reference/configuration/remap.config.en.html
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/remap.config.en.html
 ##############################################################################
 CONFIG proxy.config.url_remap.remap_required INT 1
     # https://docs.trafficserver.apache.org/records.config#proxy-config-url-remap-pristine-host-hdr
@@ -170,7 +169,7 @@ CONFIG proxy.config.reverse_proxy.enabled INT 1
 ##############################################################################
 # SSL Termination. Docs:
 #    https://docs.trafficserver.apache.org/records.config#client-related-configuration
-#    https://docs.trafficserver.apache.org/en/latest/reference/configuration/ssl_multicert.config.en.html
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/ssl_multicert.config.en.html
 ##############################################################################
 CONFIG proxy.config.ssl.client.verify.server INT 0
 CONFIG proxy.config.ssl.client.CA.cert.filename STRING NULL
@@ -179,7 +178,7 @@ CONFIG proxy.config.ssl.server.cipher_suite STRING ECDHE-ECDSA-AES256-GCM-SHA384
 ##############################################################################
 # ICP Configuration. Docs:
 #    https://docs.trafficserver.apache.org/records.config#icp-configuration
-#    https://docs.trafficserver.apache.org/en/latest/reference/configuration/icp.config.en.html
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/icp.config.en.html
 ##############################################################################
 CONFIG proxy.config.icp.enabled INT 0
 

--- a/proxy/config/remap.config.default
+++ b/proxy/config/remap.config.default
@@ -1,5 +1,8 @@
 #
-#  URL Remapping Config File
+# remap.config - URL Remapping Config File
+#
+# Documentation:
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/remap.config.en.html
 #
 # Using remap.config allows you to accomplish two things:
 #

--- a/proxy/config/splitdns.config.default
+++ b/proxy/config/splitdns.config.default
@@ -1,6 +1,8 @@
 #
 # splitdns.config
 #
+# Documentation:
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/splitdns.config.en.html
 #
 # The purpose of this file is to specify the dns server for
 #   specific objects or sets of objects.

--- a/proxy/config/ssl_multicert.config.default
+++ b/proxy/config/ssl_multicert.config.default
@@ -1,12 +1,15 @@
 #
 # ssl_multicert.config
 #
+# Documentation:
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/ssl_multicert.config.en.html
+#
 # Allows a TLS certificate and private key to be tied to a specific
 # hostname or IP address. At load time, the certificate is parsed to
 # extract the subject CN and all the DNS subjectAltNames.  The
 # certificate will be presented for connections requesting any of the
 # hostnames found in the certificate. Wildcard names in the certificates
-# are supported, but only of the form '*.domain.com', ie. where '*' 
+# are supported, but only of the form '*.domain.com', ie. where '*'
 # is the leftmost domain component.
 #
 # The certificate file path, CA path and key path specified in

--- a/proxy/config/storage.config.default.in
+++ b/proxy/config/storage.config.default.in
@@ -1,6 +1,8 @@
 #
-# Storage Configuration file
+# storage.config - Storage Configuration file
 #
+# Documentation:
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/storage.config.en.html
 #
 # The storage configuration is a list of all the storage to
 # be used by the cache.
@@ -43,10 +45,7 @@
 #
 # Also note that when using these raw devices in O_DIRECT mode, you
 # do not need to specify the partition size. It's automatically
-# detected. For more examples and a complete documentation see
-#
-#  https://docs.trafficserver.apache.org/en/latest/reference/configuration/storage.config.en.html
-#
+# detected.
 #
 # A small default cache (256MB). This is set to allow for the regression test to succeed
 # most likely you'll want to use a larger cache. And, we definitely recommend the use

--- a/proxy/config/volume.config.default
+++ b/proxy/config/volume.config.default
@@ -1,7 +1,11 @@
 #
-# 
-# This file specifies the various volumes, their sizes and the 
-# protocol they belong to. Use this file in conjunction with the 
+# volume.config
+#
+# Documentation:
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/volume.config.en.html
+#
+# This file specifies the various volumes, their sizes and the
+# protocol they belong to. Use this file in conjunction with the
 # hosting.config file.
 #
 #  Each line consists of a tag value pair.


### PR DESCRIPTION
- Updates existing links in default configuration files to point to current Administrator's Guide documentation URLs.
- Adds links to TS documentation for all default configuration files which a) did not already have them, and b) which have documentation.