### PR TITLE
TS-4461: SSL Client Connections not closed.

### DIFF
--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -372,7 +372,11 @@ UnixNetVConnection::set_inactivity_timeout(ink_hrtime timeout)
   } else
     inactivity_timeout = 0;
 #else
-  next_inactivity_timeout_at = Thread::get_hrtime() + timeout;
+  if (timeout) {
+    next_inactivity_timeout_at = Thread::get_hrtime() + timeout;
+  } else {
+    next_inactivity_timeout_at = 0;
+  }
 #endif
 }
 

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -266,7 +266,7 @@ Http1ClientSession::do_io_close(int alerrno)
       // Set the active timeout to the same as the inactive time so
       //   that this connection does not hang around forever if
       //   the ua hasn't closed
-      client_vc->set_active_timeout(HRTIME_SECONDS(trans.get_sm()->t_state.txn_conf->keep_alive_no_activity_timeout_out));
+      client_vc->set_active_timeout(HRTIME_SECONDS(trans.get_sm()->t_state.txn_conf->keep_alive_no_activity_timeout_in));
     }
 
     // [bug 2610799] Drain any data read.
@@ -427,9 +427,12 @@ Http1ClientSession::release(ProxyClientTransaction *trans)
     ka_vio = this->do_io_read(this, INT64_MAX, read_buffer);
     ink_assert(slave_ka_vio != ka_vio);
 
-    // Y!?
-    // client_vc->add_to_keep_alive_lru();
-    client_vc->cancel_active_timeout();
+    if (client_vc) {
+      client_vc->add_to_keep_alive_queue();
+      if (client_vc) {
+        client_vc->cancel_active_timeout();
+      }
+    }
     trans->destroy();
   }
 }
@@ -451,8 +454,8 @@ Http1ClientSession::new_transaction()
 
   trans.set_parent(this);
   transact_count++;
-  // Y!?
-  // client_vc->remove_from_keep_alive_lru();
+
+  client_vc->add_to_active_queue();
   trans.new_transaction();
 }
 

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -428,10 +428,8 @@ Http1ClientSession::release(ProxyClientTransaction *trans)
     ink_assert(slave_ka_vio != ka_vio);
 
     if (client_vc) {
+      client_vc->cancel_active_timeout();
       client_vc->add_to_keep_alive_queue();
-      if (client_vc) {
-        client_vc->cancel_active_timeout();
-      }
     }
     trans->destroy();
   }

--- a/proxy/http/Http1ClientTransaction.cc
+++ b/proxy/http/Http1ClientTransaction.cc
@@ -31,7 +31,7 @@ Http1ClientTransaction::release(IOBufferReader *r)
   // Must set this inactivity count here rather than in the session because the state machine
   // is not availble then
   MgmtInt ka_in = current_reader->t_state.txn_conf->keep_alive_no_activity_timeout_in;
-  get_netvc()->set_inactivity_timeout(HRTIME_SECONDS(ka_in));
+  set_inactivity_timeout(HRTIME_SECONDS(ka_in));
 
   if (m_active) {
     m_active = false;

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -5597,7 +5597,7 @@ HttpSM::do_setup_post_tunnel(HttpVC_t to_vc_type)
   if (chunked)
     tunnel.set_producer_chunking_action(p, 0, TCA_PASSTHRU_CHUNKED_CONTENT);
 
-  ua_session->get_netvc()->set_inactivity_timeout(HRTIME_SECONDS(t_state.txn_conf->transaction_no_activity_timeout_in));
+  ua_session->set_inactivity_timeout(HRTIME_SECONDS(t_state.txn_conf->transaction_no_activity_timeout_in));
   server_session->get_netvc()->set_inactivity_timeout(HRTIME_SECONDS(t_state.txn_conf->transaction_no_activity_timeout_out));
 
   tunnel.tunnel_run(p);


### PR DESCRIPTION
Ultimately the issue was that SSL connections that stall in the ProtocolTrampoline never have the inactivity timeout cleanup.  The problem was introduced in 6.0.0 via TS-3727 due to an unfortunately interaction between the addition of the ssl_handshake_timeout_in and inactivity_timeout mechanism.  

The problem occurs when ssl_handshake_timeout_in is set to 0, which is the scenario that @bcall and I were testing.  This causes vc->set_inactivity_timeout(0) to be called.  This sets vc->inactivity_timeout_in to 0 and vc->next_inactivity_timeout_at to current time.

Looking at UnixNetVConnection::mainEvent, the inactivity timeout event is not propagate if inactivity_timeout_in is 0 even if next_inactivity_timeout_at is non-zero and less than the current time.

Looking at check_inactivity, if next_inactivity_timeout_at is 0, it will call vc->set_inactivity_timeout with the default_inactivity_timeout.

But since next_inactivity_timeout_at is not 0, the default is never set and inactivity_timeout_in is never set to non-zero, so the inactivity_timeout signal is never propagated and thus the connection is never closed.
I adjusted set_inactivity_timeout to not set the next_inactivity_timeout_at if the argument is 0.  This fix has been tested in production against the 6.2 code, and the client connections all close after the box is removed from traffic.

This patch also includes a fix to add the Http1ClientSessions to the appropriate _queues.  That fix will be needed eventually, but wasn't essential for this particular scenario.
