### PR TITLE
TS-4485 schedule HostDBSyncer in ET_TASK threads instead of ET_NET threads

### DIFF
--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -394,9 +394,9 @@ HostDBSyncer::wait_event(int, void *)
 
   SET_HANDLER(&HostDBSyncer::sync_event);
   if (next_sync > HRTIME_MSECONDS(100))
-    mutex->thread_holding->schedule_in_local(this, next_sync);
+    eventProcessor.schedule_in(this, next_sync, ET_TASK);
   else
-    mutex->thread_holding->schedule_imm_local(this);
+    eventProcessor.schedule_imm(this, ET_TASK);
   return EVENT_DONE;
 }
 
@@ -526,7 +526,8 @@ HostDBProcessor::start(int, size_t)
   // Sync HostDB, if we've asked for it.
   //
   if (hostdb_sync_frequency > 0)
-    eventProcessor.schedule_imm(new HostDBSyncer);
+    eventProcessor.schedule_imm(new HostDBSyncer, ET_TASK);
+
   return 0;
 }
 

--- a/iocore/hostdb/MultiCache.cc
+++ b/iocore/hostdb/MultiCache.cc
@@ -1177,9 +1177,9 @@ MultiCacheBase::sync_partitions(Continuation *cont)
   // don't try to sync if we were not correctly initialized
   if (data && mapped_header) {
     if (heap_used[heap_halfspace] > halfspace_size() * MULTI_CACHE_HEAP_HIGH_WATER)
-      eventProcessor.schedule_imm(new MultiCacheHeapGC(cont, this), ET_CALL);
+      eventProcessor.schedule_imm(new MultiCacheHeapGC(cont, this), ET_TASK);
     else
-      eventProcessor.schedule_imm(new MultiCacheSync(cont, this), ET_CALL);
+      eventProcessor.schedule_imm(new MultiCacheSync(cont, this), ET_TASK);
   }
 }
 


### PR DESCRIPTION
Since the syncer is on ET_NET threads this effectively means every sync interval an ET_NET thread is blocked however long it takes to msync() your partition to disk (meaning we are doing blocking IO in the ET_NET threads!!!).

What I'm seeing is in-flight requests and intercepts are stalled out waiting on the ET_NET. This simply schedules the syncer on an ET_TASK thread, although this make make syncs to disk slower (waiting longer on the lock) it will mean we don't have to stall 1/nth of ET_NET threads waiting on a disk.

My thoughts is that we can get this in before my rewrite-- and backport this to 6.2.x-- to make MultiCache less of a burden on performance.

cc @SolidWallOfCode 