### PR TITLE
TS-4490: Prevent regression test from always running.

### DIFF
--- a/iocore/net/test_certlookup.cc
+++ b/iocore/net/test_certlookup.cc
@@ -225,7 +225,7 @@ main(int argc, const char **argv)
 
   } else {
     // Standard regression tests.
-    RegressionTest::run();
+    RegressionTest::run(NULL, REGRESSION_TEST_QUICK);
   }
 
   ink_freelists_dump(stdout);

--- a/lib/ts/Regression.cc
+++ b/lib/ts/Regression.cc
@@ -204,13 +204,13 @@ check_test_list:
 }
 
 int
-RegressionTest::main(int /* argc */, const char **argv)
+RegressionTest::main(int /* argc */, const char **argv, int level)
 {
-  static char regression_test[1024] = "";
-  static int regression_list = 0;
-  static int regression_level = 1;
+  char regression_test[1024] = "";
+  int regression_list = 0;
+  int regression_level = level;
 
-  static const ArgumentDescription argument_descriptions[] = {
+  const ArgumentDescription argument_descriptions[] = {
     {"regression", 'R', "Regression Level (quick:1..long:3)", "I", &regression_level, "PROXY_REGRESSION", NULL},
     {"regression_test", 'r', "Run Specific Regression Test", "S512", regression_test, "PROXY_REGRESSION_TEST", NULL},
     {"regression_list", 'l', "List Regression Tests", "T", &regression_list, "PROXY_REGRESSION_LIST", NULL},

--- a/lib/ts/Regression.h
+++ b/lib/ts/Regression.h
@@ -82,12 +82,12 @@ struct RegressionTest {
   static int ran_tests;
   static DFA dfa;
   static RegressionTest *current;
-  static int run(const char *name = NULL, int regression_level = 1);
+  static int run(const char *name, int regression_level);
   static void list();
-  static int run_some(int regression_level = 1);
-  static int check_status(int regression_level = 1);
+  static int run_some(int regression_level);
+  static int check_status(int regression_level);
 
-  static int main(int argc, const char **argv);
+  static int main(int argc, const char **argv, int level);
 };
 
 #define REGRESSION_TEST(_f)                                                                                        \

--- a/lib/ts/test_X509HostnameValidator.cc
+++ b/lib/ts/test_X509HostnameValidator.cc
@@ -193,7 +193,7 @@ main(int argc, const char **argv)
   SSL_library_init();
   ink_freelists_snap_baseline();
 
-  int status = RegressionTest::main(argc, argv);
+  int status = RegressionTest::main(argc, argv, REGRESSION_TEST_QUICK);
   ink_freelists_dump(stdout);
 
   return status;

--- a/lib/ts/tests.cc
+++ b/lib/ts/tests.cc
@@ -24,5 +24,5 @@
 int
 main(int argc, const char **argv)
 {
-  return RegressionTest::main(argc, argv);
+  return RegressionTest::main(argc, argv, REGRESSION_TEST_QUICK);
 }

--- a/mgmt/utils/test_marshall.cc
+++ b/mgmt/utils/test_marshall.cc
@@ -321,8 +321,7 @@ REGRESSION_TEST(MessageLength)(RegressionTest *t, int /* atype ATS_UNUSED */, in
 }
 
 int
-main(void)
+main(int argc, const char ** argv)
 {
-  RegressionTest::run();
-  return RegressionTest::final_status == REGRESSION_TEST_PASSED ? 0 : 1;
+  return RegressionTest::main(argc, argv, REGRESSION_TEST_QUICK);
 }

--- a/plugins/experimental/sslheaders/test_sslheaders.cc
+++ b/plugins/experimental/sslheaders/test_sslheaders.cc
@@ -247,9 +247,8 @@ REGRESSION_TEST(ParseX509Fields)(RegressionTest *t, int /* atype ATS_UNUSED */, 
 }
 
 int
-main(void)
+main(int argc, const char ** argv)
 {
   SSL_library_init();
-  RegressionTest::run();
-  return RegressionTest::final_status == REGRESSION_TEST_PASSED ? 0 : 1;
+  return RegressionTest::main(argc, argv, REGRESSION_TEST_QUICK);
 }

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -145,7 +145,7 @@ static char const *CMD_VERIFY_CONFIG = "verify_config";
 #if TS_HAS_TESTS
 static char regression_test[1024] = "";
 static int regression_list = 0;
-static int regression_level = 1;
+static int regression_level = REGRESSION_TEST_NONE;
 #endif
 int auto_clear_hostdb_flag = 0;
 extern int fds_limit;

--- a/proxy/hdrs/test_mime.cc
+++ b/proxy/hdrs/test_mime.cc
@@ -53,12 +53,11 @@ REGRESSION_TEST(MIME)(RegressionTest *t, int /* atype ATS_UNUSED */, int *pstatu
 }
 
 int
-main(int argc, char *argv[])
+main(int argc, const char **argv)
 {
   Thread *main_thread = new EThread();
   main_thread->set_specific();
   mime_init();
 
-  RegressionTest::run();
-  return RegressionTest::final_status == REGRESSION_TEST_PASSED ? 0 : 1;
+  return RegressionTest::main(argc, argv, REGRESSION_TEST_QUICK);
 }

--- a/proxy/http2/test_Http2DependencyTree.cc
+++ b/proxy/http2/test_Http2DependencyTree.cc
@@ -321,7 +321,7 @@ int
 main(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   const char *name = "Http2DependencyTree";
-  RegressionTest::run(name);
+  RegressionTest::run(name, REGRESSION_TEST_QUICK);
 
   return RegressionTest::final_status == REGRESSION_TEST_PASSED ? 0 : 1;
 }


### PR DESCRIPTION
If we default the regression level to QUICK, then they always run.
Default the level to NONE and remove default parameters to make it
explicit that automake test programs will run tests by default.