### PR TITLE
TS-4494: Replace ink_code_md5_stringify to ink_code_to_hex_str

### DIFF
--- a/proxy/http/HttpConnectionCount.h
+++ b/proxy/http/HttpConnectionCount.h
@@ -145,8 +145,8 @@ public:
       char addrbuf2[INET6_ADDRSTRLEN];
       char md5buf1[33];
       char md5buf2[33];
-      ink_code_md5_stringify(md5buf1, sizeof(md5buf1), reinterpret_cast<const char *>(a._hostname_hash.u8));
-      ink_code_md5_stringify(md5buf2, sizeof(md5buf2), reinterpret_cast<const char *>(b._hostname_hash.u8));
+      ink_code_to_hex_str(md5buf1, a._hostname_hash.u8);
+      ink_code_to_hex_str(md5buf2, b._hostname_hash.u8);
       Debug("conn_count", "Comparing hostname hash %s dest %s match method %d to hostname hash %s dest %s match method %d", md5buf1,
             ats_ip_nptop(&a._addr.sa, addrbuf1, sizeof(addrbuf1)), a._match_type, md5buf2,
             ats_ip_nptop(&b._addr.sa, addrbuf2, sizeof(addrbuf2)), b._match_type);


### PR DESCRIPTION
- [TS-4494](https://issues.apache.org/jira/browse/TS-4494)
- It looks like `ink_code_md5_stringify` is broken. So using `ink_code_to_hex_str` looks better.