### PR TITLE
TS-4497: fix fetch api to release async item sooner

### DIFF
--- a/plugins/experimental/ts_lua/ts_lua_coroutine.c
+++ b/plugins/experimental/ts_lua/ts_lua_coroutine.c
@@ -79,6 +79,8 @@ ts_lua_release_cont_info(ts_lua_cont_info *ci)
   crt = &ci->routine;
   mctx = crt->mctx;
 
+  TSMutexLock(mctx->mutexp);
+
   ts_lua_async_destroy_chain(&ci->async_chain);
 
   if (ci->contp) {
@@ -86,8 +88,8 @@ ts_lua_release_cont_info(ts_lua_cont_info *ci)
   }
 
   if (crt->lua) {
-    TSMutexLock(mctx->mutexp);
     luaL_unref(crt->lua, LUA_REGISTRYINDEX, crt->ref);
-    TSMutexUnlock(mctx->mutexp);
   }
+
+  TSMutexUnlock(mctx->mutexp);
 }

--- a/plugins/experimental/ts_lua/ts_lua_fetch.c
+++ b/plugins/experimental/ts_lua/ts_lua_fetch.c
@@ -546,6 +546,8 @@ ts_lua_fetch_multi_handler(TSCont contp, TSEvent event ATS_UNUSED, void *edata)
     TSContCall(ci->contp, TS_LUA_EVENT_COROUTINE_CONT, (void *)1);
   }
 
+  ts_lua_fetch_multi_cleanup(ai);
+
   TSMutexUnlock(lmutex);
   return 0;
 }
@@ -586,6 +588,9 @@ static int
 ts_lua_fetch_multi_cleanup(ts_lua_async_item *ai)
 {
   ts_lua_fetch_multi_info *fmi;
+
+  if (ai->deleted)
+    return 0;
 
   if (ai->data) {
     fmi = (ts_lua_fetch_multi_info *)ai->data;


### PR DESCRIPTION
@sudheerv this is what we have been discussing for a while. With TS-3777, the ts.fetch() of ts_lua is no longer working fine. I finally figure out that the original plugin code committed is not performing cleanup correctly.

Thanks. please take a look.