### PR TITLE
TS-4496: Remove ink_code_md5_stringify

### DIFF
--- a/lib/ts/ink_code.cc
+++ b/lib/ts/ink_code.cc
@@ -95,33 +95,6 @@ ink_code_md5(unsigned char const *input, int input_length, unsigned char *sixtee
   @brief Converts a MD5 to a null-terminated string
 
   Externalizes an INK_MD5 as a null-terminated string into the first argument.
-  Side Effects: none
-  Reentrancy:     n/a.
-  Thread Safety:  safe.
-  Mem Management: stomps the passed dest char*.
-
-  @return returns the passed destination string ptr.
-*/
-/* reentrant version */
-char *
-ink_code_md5_stringify(char *dest33, const size_t destSize, const char *md5)
-{
-  ink_assert(destSize >= 33);
-
-  int i;
-  for (i = 0; i < 16; i++) {
-    // we check the size of the destination buffer above
-    // coverity[secure_coding]
-    sprintf(&(dest33[i * 2]), "%02X", md5[i]);
-  }
-  ink_assert(dest33[32] == '\0');
-  return (dest33);
-} /* End ink_code_stringify_md5(const char *md5) */
-
-/**
-  @brief Converts a MD5 to a null-terminated string
-
-  Externalizes an INK_MD5 as a null-terminated string into the first argument.
   Does so without intenal procedure calls.
   Side Effects: none.
   Reentrancy:     n/a.

--- a/lib/ts/ink_code.h
+++ b/lib/ts/ink_code.h
@@ -36,7 +36,6 @@ typedef MD5_CTX INK_DIGEST_CTX;
 */
 
 inkcoreapi int ink_code_md5(unsigned char const *input, int input_length, unsigned char *sixteen_byte_hash_pointer);
-inkcoreapi char *ink_code_md5_stringify(char *dest33, const size_t destSize, const char *md5);
 inkcoreapi char *ink_code_to_hex_str(char *dest33, uint8_t const *md5);
 
 inkcoreapi int ink_code_incr_md5_init(INK_DIGEST_CTX *context);

--- a/mgmt/WebMgmtUtils.cc
+++ b/mgmt/WebMgmtUtils.cc
@@ -1221,18 +1221,6 @@ recordRestartCheck(const char *varName)
   return false;
 }
 
-void
-fileCheckSum(char *buffer, int size, char *checksum, const size_t checksumSize)
-{
-  INK_DIGEST_CTX md5_context;
-  char checksum_md5[16];
-
-  ink_code_incr_md5_init(&md5_context);
-  ink_code_incr_md5_update(&md5_context, buffer, size);
-  ink_code_incr_md5_final(checksum_md5, &md5_context);
-  ink_code_md5_stringify(checksum, checksumSize, checksum_md5);
-}
-
 //-------------------------------------------------------------------------
 // getFilesInDirectory
 //

--- a/mgmt/WebMgmtUtils.h
+++ b/mgmt/WebMgmtUtils.h
@@ -113,8 +113,6 @@ bool recordRangeCheck(const char *pattern, const char *value);
 bool recordIPCheck(const char *pattern, const char *value);
 bool recordRestartCheck(const char *varName);
 
-void fileCheckSum(char *buffer, int size, char *checksum, const size_t checksumSize);
-
 // file management
 int getFilesInDirectory(char *managedDir, ExpandingArray *fileList);
 char *newPathString(const char *s1, const char *s2);

--- a/mgmt/api/INKMgmtAPI.cc
+++ b/mgmt/api/INKMgmtAPI.cc
@@ -1861,33 +1861,6 @@ TSGetErrorMessage(TSMgmtError err_id)
   return err_msg;
 }
 
-/*--- password operations -------------------------------------------------*/
-tsapi TSMgmtError
-TSEncryptPassword(char *passwd, char **e_passwd)
-{
-  INK_DIGEST_CTX md5_context;
-  char passwd_md5[16];
-  char *passwd_md5_str;
-  int passwd_md5_str_len = 32;
-
-  ink_assert(passwd);
-  ink_assert(TS_ENCRYPT_PASSWD_LEN <= passwd_md5_str_len);
-
-  const size_t md5StringSize = (passwd_md5_str_len + 1) * sizeof(char);
-  passwd_md5_str = (char *)ats_malloc(md5StringSize);
-
-  ink_code_incr_md5_init(&md5_context);
-  ink_code_incr_md5_update(&md5_context, passwd, strlen(passwd));
-  ink_code_incr_md5_final(passwd_md5, &md5_context);
-  ink_code_md5_stringify(passwd_md5_str, md5StringSize, passwd_md5);
-
-  // use only a subset of the MD5 string
-  passwd_md5_str[TS_ENCRYPT_PASSWD_LEN] = '\0';
-  *e_passwd = passwd_md5_str;
-
-  return TS_ERR_OKAY;
-}
-
 /*--- direct file operations ----------------------------------------------*/
 tsapi TSMgmtError
 TSConfigFileRead(TSFileNameT file, char **text, int *size, int *version)

--- a/mgmt/api/include/mgmtapi.h
+++ b/mgmt/api/include/mgmtapi.h
@@ -967,13 +967,6 @@ tsapi void TSDiags(TSDiagsT mode, const char *fmt, ...);
  */
 char *TSGetErrorMessage(TSMgmtError error_id);
 
-/*--- password operations -------------------------------------------------*/
-/* TSEncryptPassword: encrypts a password
- * Input: passwd - a password string to encrypt (can be NULL)
- * Output: e_passwd - an encrypted passwd (ats_malloc's memory)
- */
-tsapi TSMgmtError TSEncryptPassword(char *passwd, char **e_passwd);
-
 /*--- direct file operations ----------------------------------------------*/
 /* TSConfigFileRead: reads a config file into a buffer
  * Input:  file - the config file to read


### PR DESCRIPTION
[TS-4496](https://issues.apache.org/jira/browse/TS-4496)
- Remove ink_code_md5_stringify
- Remove unused functions (fileCheckSum and TSEncryptPassword)