### PR TITLE
TS-4478: AsyncHttpFetch hangs since ProxyClientSession changes.

### DIFF
--- a/proxy/ProxyClientTransaction.cc
+++ b/proxy/ProxyClientTransaction.cc
@@ -84,3 +84,18 @@ ProxyClientTransaction::attach_server_session(HttpServerSession *ssession, bool 
 {
   parent->attach_server_session(ssession, transaction_done);
 }
+
+Action *
+ProxyClientTransaction::adjust_thread(int event, void *data)
+{
+  NetVConnection *vc = this->get_netvc();
+  EThread *this_thread = this_ethread();
+  if (vc && vc->thread != this_thread) {
+    if (vc->thread->is_event_type(ET_NET) || vc->thread->is_event_type(SSLNetProcessor::ET_SSL)) {
+      return vc->thread->schedule_imm(this, event, data);
+    } else { // Not a net thread, take over this thread
+      vc->thread = this_thread;
+    }
+  }
+  return NULL;
+}

--- a/proxy/ProxyClientTransaction.h
+++ b/proxy/ProxyClientTransaction.h
@@ -49,6 +49,10 @@ public:
 
   virtual void attach_server_session(HttpServerSession *ssession, bool transaction_done = true);
 
+  // See if we need to schedule on the primary thread for the transaction or change the thread that is associated with the VC.
+  // If we reschedule, the scheduled action is returned.  Otherwise, NULL is returned
+  Action *adjust_thread(int event, void *data);
+
   int
   get_transact_count() const
   {

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -2437,10 +2437,8 @@ HttpSM::state_cache_open_write(int event, void *data)
 
   // Make sure we are on the "right" thread
   if (ua_session) {
-    NetVConnection *vc = ua_session->get_netvc();
-    if (vc && vc->thread != this_ethread()) {
-      pending_action = vc->thread->schedule_imm(this, event, data); // Stay on the same thread!
-      return 0;
+    if ((pending_action = ua_session->adjust_thread(event, data))) {
+      return 0; // Go away if we reschedule
     }
   }
 
@@ -4645,10 +4643,8 @@ HttpSM::do_http_server_open(bool raw)
 
   // Make sure we are on the "right" thread
   if (ua_session) {
-    NetVConnection *vc = ua_session->get_netvc();
-    if (vc && vc->thread != this_ethread()) {
-      pending_action = vc->thread->schedule_imm(this, EVENT_INTERVAL);
-      return;
+    if ((pending_action = ua_session->adjust_thread(EVENT_INTERVAL, NULL))) {
+      return; // Go away if we reschedule
     }
   }
   pending_action = NULL;


### PR DESCRIPTION
If the original thread is not a ET_NET thread, we should be rescheduling on it.  Otherwise, take over the current ET_NET thread as the operating thread for this transaction.