### PR TITLE
TS-4424: ASAN heap-buffer-overflow

### DIFF
--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -669,8 +669,10 @@ SSLNetVConnection::load_buffer_and_write(int64_t towrite, MIOBufferAccessor &buf
 
   do {
     // What is remaining left in the next block?
+    int l0 = buf.reader()->block_read_avail();
     char *current_block = buf.reader()->start();
     l = buf.reader()->block_read_avail();
+    ink_release_assert(l == l0);
 
     // check if to amount to write exceeds that in this buffer
     int64_t wavail = towrite - total_written;

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -669,8 +669,8 @@ SSLNetVConnection::load_buffer_and_write(int64_t towrite, MIOBufferAccessor &buf
 
   do {
     // What is remaining left in the next block?
-    l = buf.reader()->block_read_avail();
     char *current_block = buf.reader()->start();
+    l = buf.reader()->block_read_avail();
 
     // check if to amount to write exceeds that in this buffer
     int64_t wavail = towrite - total_written;

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -671,8 +671,11 @@ SSLNetVConnection::load_buffer_and_write(int64_t towrite, MIOBufferAccessor &buf
     // What is remaining left in the next block?
     int l0 = buf.reader()->block_read_avail();
     char *current_block = buf.reader()->start();
+    char *end_current_block = buf.reader()->end();
     l = buf.reader()->block_read_avail();
     ink_release_assert(l == l0);
+    ink_release_assert(current_block < end_current_block);
+    ink_release_assert((current_block + l) <= end_current_block);
 
     // check if to amount to write exceeds that in this buffer
     int64_t wavail = towrite - total_written;

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -528,12 +528,13 @@ void
 Http2Stream::send_response_body()
 {
   Http2ClientSession *parent = static_cast<Http2ClientSession *>(this->get_parent());
-
-  if (Http2::stream_priority_enabled) {
-    parent->connection_state.schedule_stream(this);
-  } else {
-    // Send DATA frames directly
-    parent->connection_state.send_data_frames(this);
+  if (parent) {
+    if (Http2::stream_priority_enabled) {
+      parent->connection_state.schedule_stream(this);
+    } else {
+      // Send DATA frames directly
+      parent->connection_state.send_data_frames(this);
+    }
   }
 }
 


### PR DESCRIPTION
Looking at the stack the only thing that seems feasible is that the reader is moving after we get the amount of data to read.  Changed the order of fetching the block pointer and the amount to read.  A bit disturbing if this is indeed happening.  I also added a release assert to catch in this case.