### PR TITLE
TS-4498: Enhanced the error message appearing in diags.log when a rem…

### DIFF
--- a/proxy/http/remap/RemapConfig.cc
+++ b/proxy/http/remap/RemapConfig.cc
@@ -802,7 +802,8 @@ remap_load_plugin(const char **argv, int argc, url_mapping *mp, char *errbuf, in
       ri.tsremap_version = TSREMAP_VERSION;
 
       if (pi->fp_tsremap_init(&ri, tmpbuf, sizeof(tmpbuf) - 1) != TS_SUCCESS) {
-        Warning("Failed to initialize plugin %s (non-zero retval) ... bailing out", pi->path);
+        Warning("Failed to initialize plugin %s (non-zero retval) ... bailing out - %s", pi->path,
+                tmpbuf[0] ? tmpbuf : "Unknown plugin error");
         return -5;
       }
     } // done elevating access

--- a/proxy/http/remap/RemapConfig.cc
+++ b/proxy/http/remap/RemapConfig.cc
@@ -802,8 +802,8 @@ remap_load_plugin(const char **argv, int argc, url_mapping *mp, char *errbuf, in
       ri.tsremap_version = TSREMAP_VERSION;
 
       if (pi->fp_tsremap_init(&ri, tmpbuf, sizeof(tmpbuf) - 1) != TS_SUCCESS) {
-        Warning("Failed to initialize plugin %s (non-zero retval) ... bailing out - %s", pi->path,
-                tmpbuf[0] ? tmpbuf : "Unknown plugin error");
+        snprintf(errbuf, errbufsize, "Failed to initialize plugin %s (non-zero retval) ... bailing out - %s", pi->path,
+                 tmpbuf[0] ? tmpbuf : "Unknown plugin error");
         return -5;
       }
     } // done elevating access
@@ -1349,7 +1349,7 @@ remap_parse_config_bti(const char *path, BUILD_TABLE_INFO *bti)
 
   // Deal with error / warning scenarios
   MAP_ERROR:
-    Warning("Could not add rule at line #%d; Aborting!", cln + 1);
+    Error("Could not add rule at line #%d; Aborting!", cln + 1);
     snprintf(errBuf, sizeof(errBuf), "%s %s at line %d", modulePrefix, errStr, cln + 1);
     SignalError(errBuf, alarm_already);
     delete reg_map;


### PR DESCRIPTION
…ap plugin

         fails during initialization, i.e., print out tmpbuf which may contain
         error information set by the plugin.