### PR TITLE
TS-4499: balancer plugin cannot use port number over 32767

### DIFF
--- a/plugins/experimental/balancer/balancer.cc
+++ b/plugins/experimental/balancer/balancer.cc
@@ -81,7 +81,7 @@ MakeBalancerTarget(const char *strval)
     }
   }
 
-  if (target.port > INT16_MAX) {
+  if (target.port > UINT16_MAX) {
     TSError("[balancer] Ignoring invalid port number for target '%s'", strval);
     target.port = 0;
   }


### PR DESCRIPTION
[TS-4499](https://issues.apache.org/jira/browse/TS-4499)