### PR TITLE
TS-4510: support multiple header with same name

### DIFF
--- a/plugins/experimental/ts_lua/ts_lua_cached_response.c
+++ b/plugins/experimental/ts_lua/ts_lua_cached_response.c
@@ -141,8 +141,9 @@ ts_lua_cached_response_header_get(lua_State *L)
   const char *val;
   int val_len;
   size_t key_len;
+  int count;
 
-  TSMLoc field_loc;
+  TSMLoc field_loc, next_field_loc;
   ts_lua_http_ctx *http_ctx;
 
   GET_HTTP_CONTEXT(http_ctx, L);
@@ -155,11 +156,22 @@ ts_lua_cached_response_header_get(lua_State *L)
   if (key && key_len) {
     field_loc = TSMimeHdrFieldFind(http_ctx->cached_response_bufp, http_ctx->cached_response_hdrp, key, key_len);
 
-    if (field_loc) {
-      val = TSMimeHdrFieldValueStringGet(http_ctx->cached_response_bufp, http_ctx->cached_response_hdrp, field_loc, -1, &val_len);
-      lua_pushlstring(L, val, val_len);
-      TSHandleMLocRelease(http_ctx->cached_response_bufp, http_ctx->cached_response_hdrp, field_loc);
-
+    if (field_loc != TS_NULL_MLOC) {
+      count = 0;
+      while (field_loc != TS_NULL_MLOC) {
+        val = TSMimeHdrFieldValueStringGet(http_ctx->cached_response_bufp, http_ctx->cached_response_hdrp, field_loc, -1, &val_len);
+        next_field_loc = TSMimeHdrFieldNextDup(http_ctx->cached_response_bufp, http_ctx->cached_response_hdrp, field_loc);
+        lua_pushlstring(L, val, val_len);
+        count++;
+        // multiple headers with the same name must be semantically the same as one value which is comma seperated
+        if (next_field_loc != TS_NULL_MLOC) {
+          lua_pushlstring(L, ",", 1);
+          count++;
+        }
+        TSHandleMLocRelease(http_ctx->cached_response_bufp, http_ctx->cached_response_hdrp, field_loc);
+        field_loc = next_field_loc;
+      }
+      lua_concat(L, count);
     } else {
       lua_pushnil(L);
     }
@@ -185,6 +197,8 @@ ts_lua_cached_response_get_headers(lua_State *L)
   int value_len;
   TSMLoc field_loc;
   TSMLoc next_field_loc;
+  const char *tvalue;
+  size_t tvalue_len;
 
   ts_lua_http_ctx *http_ctx;
 
@@ -196,14 +210,33 @@ ts_lua_cached_response_get_headers(lua_State *L)
 
   field_loc = TSMimeHdrFieldGet(http_ctx->cached_response_bufp, http_ctx->cached_response_hdrp, 0);
 
-  while (field_loc) {
+  while (field_loc != TS_NULL_MLOC) {
     name = TSMimeHdrFieldNameGet(http_ctx->cached_response_bufp, http_ctx->cached_response_hdrp, field_loc, &name_len);
     if (name && name_len) {
-      value =
-        TSMimeHdrFieldValueStringGet(http_ctx->cached_response_bufp, http_ctx->cached_response_hdrp, field_loc, -1, &value_len);
+      // retrieve the header name from table
       lua_pushlstring(L, name, name_len);
-      lua_pushlstring(L, value, value_len);
-      lua_rawset(L, -3);
+      lua_gettable(L, -2);
+      if (lua_isnil(L, -1)) {
+        // if header name does not exist in the table, insert it
+        lua_pop(L, 1);
+        value =
+          TSMimeHdrFieldValueStringGet(http_ctx->cached_response_bufp, http_ctx->cached_response_hdrp, field_loc, -1, &value_len);
+        lua_pushlstring(L, name, name_len);
+        lua_pushlstring(L, value, value_len);
+        lua_rawset(L, -3);
+      } else {
+        // if header name exists in the table, append a command and the new value to the end of the existing value
+        tvalue = lua_tolstring(L, -1, &tvalue_len);
+        lua_pop(L, 1);
+        value =
+          TSMimeHdrFieldValueStringGet(http_ctx->cached_response_bufp, http_ctx->cached_response_hdrp, field_loc, -1, &value_len);
+        lua_pushlstring(L, name, name_len);
+        lua_pushlstring(L, tvalue, tvalue_len);
+        lua_pushlstring(L, ",", 1);
+        lua_pushlstring(L, value, value_len);
+        lua_concat(L, 3);
+        lua_rawset(L, -3);
+      }
     }
 
     next_field_loc = TSMimeHdrFieldNext(http_ctx->cached_response_bufp, http_ctx->cached_response_hdrp, field_loc);

--- a/plugins/experimental/ts_lua/ts_lua_client_request.c
+++ b/plugins/experimental/ts_lua/ts_lua_client_request.c
@@ -143,8 +143,9 @@ ts_lua_client_request_header_get(lua_State *L)
   const char *val;
   int val_len;
   size_t key_len;
+  int count;
 
-  TSMLoc field_loc;
+  TSMLoc field_loc, next_field_loc;
   ts_lua_http_ctx *http_ctx;
 
   GET_HTTP_CONTEXT(http_ctx, L);
@@ -154,11 +155,23 @@ ts_lua_client_request_header_get(lua_State *L)
 
   if (key && key_len) {
     field_loc = TSMimeHdrFieldFind(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, key, key_len);
-    if (field_loc) {
-      val = TSMimeHdrFieldValueStringGet(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, field_loc, -1, &val_len);
-      lua_pushlstring(L, val, val_len);
-      TSHandleMLocRelease(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, field_loc);
 
+    if (field_loc != TS_NULL_MLOC) {
+      count = 0;
+      while (field_loc != TS_NULL_MLOC) {
+        val = TSMimeHdrFieldValueStringGet(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, field_loc, -1, &val_len);
+        next_field_loc = TSMimeHdrFieldNextDup(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, field_loc);
+        lua_pushlstring(L, val, val_len);
+        count++;
+        // multiple headers with the same name must be semantically the same as one value which is comma seperated
+        if (next_field_loc != TS_NULL_MLOC) {
+          lua_pushlstring(L, ",", 1);
+          count++;
+        }
+        TSHandleMLocRelease(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, field_loc);
+        field_loc = next_field_loc;
+      }
+      lua_concat(L, count);
     } else {
       lua_pushnil(L);
     }
@@ -178,8 +191,9 @@ ts_lua_client_request_header_set(lua_State *L)
   size_t val_len;
   size_t key_len;
   int remove;
+  int first;
 
-  TSMLoc field_loc;
+  TSMLoc field_loc, tmp;
 
   ts_lua_http_ctx *http_ctx;
 
@@ -199,13 +213,25 @@ ts_lua_client_request_header_set(lua_State *L)
   field_loc = TSMimeHdrFieldFind(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, key, key_len);
 
   if (remove) {
-    if (field_loc) {
+    while (field_loc != TS_NULL_MLOC) {
+      tmp = TSMimeHdrFieldNextDup(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, field_loc);
       TSMimeHdrFieldDestroy(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, field_loc);
+      TSHandleMLocRelease(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, field_loc);
+      field_loc = tmp;
     }
-
-  } else if (field_loc) {
-    TSMimeHdrFieldValueStringSet(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, field_loc, -1, val, val_len);
-
+  } else if (field_loc != TS_NULL_MLOC) {
+    first = 1;
+    while (field_loc != TS_NULL_MLOC) {
+      tmp = TSMimeHdrFieldNextDup(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, field_loc);
+      if (first) {
+        first = 0;
+        TSMimeHdrFieldValueStringSet(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, field_loc, -1, val, val_len);
+      } else {
+        TSMimeHdrFieldDestroy(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, field_loc);
+      }
+      TSHandleMLocRelease(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, field_loc);
+      field_loc = tmp;
+    }
   } else if (TSMimeHdrFieldCreateNamed(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, key, key_len, &field_loc) !=
              TS_SUCCESS) {
     TSError("[ts_lua][%s] TSMimeHdrFieldCreateNamed error", __FUNCTION__);
@@ -216,7 +242,7 @@ ts_lua_client_request_header_set(lua_State *L)
     TSMimeHdrFieldAppend(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, field_loc);
   }
 
-  if (field_loc)
+  if (field_loc != TS_NULL_MLOC)
     TSHandleMLocRelease(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, field_loc);
 
   return 0;
@@ -238,6 +264,8 @@ ts_lua_client_request_get_headers(lua_State *L)
   int value_len;
   TSMLoc field_loc;
   TSMLoc next_field_loc;
+  const char *tvalue;
+  size_t tvalue_len;
 
   ts_lua_http_ctx *http_ctx;
 
@@ -247,13 +275,33 @@ ts_lua_client_request_get_headers(lua_State *L)
 
   field_loc = TSMimeHdrFieldGet(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, 0);
 
-  while (field_loc) {
+  while (field_loc != TS_NULL_MLOC) {
     name = TSMimeHdrFieldNameGet(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, field_loc, &name_len);
     if (name && name_len) {
-      value = TSMimeHdrFieldValueStringGet(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, field_loc, -1, &value_len);
+      // retrieve the header name from table
       lua_pushlstring(L, name, name_len);
-      lua_pushlstring(L, value, value_len);
-      lua_rawset(L, -3);
+      lua_gettable(L, -2);
+      if (lua_isnil(L, -1)) {
+        // if header name does not exist in the table, insert it
+        lua_pop(L, 1);
+        value =
+          TSMimeHdrFieldValueStringGet(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, field_loc, -1, &value_len);
+        lua_pushlstring(L, name, name_len);
+        lua_pushlstring(L, value, value_len);
+        lua_rawset(L, -3);
+      } else {
+        // if header name exists in the table, append a command and the new value to the end of the existing value
+        tvalue = lua_tolstring(L, -1, &tvalue_len);
+        lua_pop(L, 1);
+        value =
+          TSMimeHdrFieldValueStringGet(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, field_loc, -1, &value_len);
+        lua_pushlstring(L, name, name_len);
+        lua_pushlstring(L, tvalue, tvalue_len);
+        lua_pushlstring(L, ",", 1);
+        lua_pushlstring(L, value, value_len);
+        lua_concat(L, 3);
+        lua_rawset(L, -3);
+      }
     }
 
     next_field_loc = TSMimeHdrFieldNext(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, field_loc);

--- a/plugins/experimental/ts_lua/ts_lua_client_response.c
+++ b/plugins/experimental/ts_lua/ts_lua_client_response.c
@@ -81,8 +81,9 @@ ts_lua_client_response_header_get(lua_State *L)
   const char *val;
   int val_len;
   size_t key_len;
+  int count;
 
-  TSMLoc field_loc;
+  TSMLoc field_loc, next_field_loc;
 
   ts_lua_http_ctx *http_ctx;
 
@@ -100,11 +101,22 @@ ts_lua_client_response_header_get(lua_State *L)
 
   if (key && key_len) {
     field_loc = TSMimeHdrFieldFind(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, key, key_len);
-    if (field_loc) {
-      val = TSMimeHdrFieldValueStringGet(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, field_loc, -1, &val_len);
-      lua_pushlstring(L, val, val_len);
-      TSHandleMLocRelease(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, field_loc);
-
+    if (field_loc != TS_NULL_MLOC) {
+      count = 0;
+      while (field_loc != TS_NULL_MLOC) {
+        val = TSMimeHdrFieldValueStringGet(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, field_loc, -1, &val_len);
+        next_field_loc = TSMimeHdrFieldNextDup(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, field_loc);
+        lua_pushlstring(L, val, val_len);
+        count++;
+        // multiple headers with the same name must be semantically the same as one value which is comma seperated
+        if (next_field_loc != TS_NULL_MLOC) {
+          lua_pushlstring(L, ",", 1);
+          count++;
+        }
+        TSHandleMLocRelease(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, field_loc);
+        field_loc = next_field_loc;
+      }
+      lua_concat(L, count);
     } else {
       lua_pushnil(L);
     }
@@ -124,8 +136,9 @@ ts_lua_client_response_header_set(lua_State *L)
   size_t val_len;
   size_t key_len;
   int remove;
+  int first;
 
-  TSMLoc field_loc;
+  TSMLoc field_loc, tmp;
 
   ts_lua_http_ctx *http_ctx;
 
@@ -151,13 +164,26 @@ ts_lua_client_response_header_set(lua_State *L)
   field_loc = TSMimeHdrFieldFind(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, key, key_len);
 
   if (remove) {
-    if (field_loc) {
+    while (field_loc != TS_NULL_MLOC) {
+      tmp = TSMimeHdrFieldNextDup(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, field_loc);
       TSMimeHdrFieldDestroy(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, field_loc);
+      TSHandleMLocRelease(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, field_loc);
+      field_loc = tmp;
     }
 
-  } else if (field_loc) {
-    TSMimeHdrFieldValueStringSet(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, field_loc, -1, val, val_len);
-
+  } else if (field_loc != TS_NULL_MLOC) {
+    first = 1;
+    while (field_loc != TS_NULL_MLOC) {
+      tmp = TSMimeHdrFieldNextDup(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, field_loc);
+      if (first) {
+        first = 0;
+        TSMimeHdrFieldValueStringSet(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, field_loc, -1, val, val_len);
+      } else {
+        TSMimeHdrFieldDestroy(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, field_loc);
+      }
+      TSHandleMLocRelease(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, field_loc);
+      field_loc = tmp;
+    }
   } else if (TSMimeHdrFieldCreateNamed(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, key, key_len, &field_loc) !=
              TS_SUCCESS) {
     TSError("[ts_lua][%s] TSMimeHdrFieldCreateNamed error", __FUNCTION__);
@@ -168,7 +194,7 @@ ts_lua_client_response_header_set(lua_State *L)
     TSMimeHdrFieldAppend(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, field_loc);
   }
 
-  if (field_loc)
+  if (field_loc != TS_NULL_MLOC)
     TSHandleMLocRelease(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, field_loc);
 
   return 0;
@@ -190,6 +216,8 @@ ts_lua_client_response_get_headers(lua_State *L)
   int value_len;
   TSMLoc field_loc;
   TSMLoc next_field_loc;
+  const char *tvalue;
+  size_t tvalue_len;
 
   ts_lua_http_ctx *http_ctx;
 
@@ -201,14 +229,33 @@ ts_lua_client_response_get_headers(lua_State *L)
 
   field_loc = TSMimeHdrFieldGet(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, 0);
 
-  while (field_loc) {
+  while (field_loc != TS_NULL_MLOC) {
     name = TSMimeHdrFieldNameGet(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, field_loc, &name_len);
     if (name && name_len) {
-      value =
-        TSMimeHdrFieldValueStringGet(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, field_loc, -1, &value_len);
+      // retrieve the header name from table
       lua_pushlstring(L, name, name_len);
-      lua_pushlstring(L, value, value_len);
-      lua_rawset(L, -3);
+      lua_gettable(L, -2);
+      if (lua_isnil(L, -1)) {
+        // if header name does not exist in the table, insert it
+        lua_pop(L, 1);
+        value =
+          TSMimeHdrFieldValueStringGet(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, field_loc, -1, &value_len);
+        lua_pushlstring(L, name, name_len);
+        lua_pushlstring(L, value, value_len);
+        lua_rawset(L, -3);
+      } else {
+        // if header name exists in the table, append a command and the new value to the end of the existing value
+        tvalue = lua_tolstring(L, -1, &tvalue_len);
+        lua_pop(L, 1);
+        value =
+          TSMimeHdrFieldValueStringGet(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, field_loc, -1, &value_len);
+        lua_pushlstring(L, name, name_len);
+        lua_pushlstring(L, tvalue, tvalue_len);
+        lua_pushlstring(L, ",", 1);
+        lua_pushlstring(L, value, value_len);
+        lua_concat(L, 3);
+        lua_rawset(L, -3);
+      }
     }
 
     next_field_loc = TSMimeHdrFieldNext(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, field_loc);

--- a/plugins/experimental/ts_lua/ts_lua_server_request.c
+++ b/plugins/experimental/ts_lua/ts_lua_server_request.c
@@ -136,8 +136,9 @@ ts_lua_server_request_header_get(lua_State *L)
   const char *val;
   int val_len;
   size_t key_len;
+  int count;
 
-  TSMLoc field_loc;
+  TSMLoc field_loc, next_field_loc;
   ts_lua_http_ctx *http_ctx;
 
   GET_HTTP_CONTEXT(http_ctx, L);
@@ -154,11 +155,23 @@ ts_lua_server_request_header_get(lua_State *L)
 
   if (key && key_len) {
     field_loc = TSMimeHdrFieldFind(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, key, key_len);
-    if (field_loc) {
-      val = TSMimeHdrFieldValueStringGet(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc, -1, &val_len);
-      lua_pushlstring(L, val, val_len);
-      TSHandleMLocRelease(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc);
 
+    if (field_loc != TS_NULL_MLOC) {
+      count = 0;
+      while (field_loc != TS_NULL_MLOC) {
+        val = TSMimeHdrFieldValueStringGet(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc, -1, &val_len);
+        next_field_loc = TSMimeHdrFieldNextDup(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc);
+        lua_pushlstring(L, val, val_len);
+        count++;
+        // multiple headers with the same name must be semantically the same as one value which is comma seperated
+        if (next_field_loc != TS_NULL_MLOC) {
+          lua_pushlstring(L, ",", 1);
+          count++;
+        }
+        TSHandleMLocRelease(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc);
+        field_loc = next_field_loc;
+      }
+      lua_concat(L, count);
     } else {
       lua_pushnil(L);
     }
@@ -178,8 +191,9 @@ ts_lua_server_request_header_set(lua_State *L)
   size_t val_len;
   size_t key_len;
   int remove;
+  int first;
 
-  TSMLoc field_loc;
+  TSMLoc field_loc, tmp;
 
   ts_lua_http_ctx *http_ctx;
 
@@ -205,13 +219,25 @@ ts_lua_server_request_header_set(lua_State *L)
   field_loc = TSMimeHdrFieldFind(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, key, key_len);
 
   if (remove) {
-    if (field_loc) {
+    while (field_loc != TS_NULL_MLOC) {
+      tmp = TSMimeHdrFieldNextDup(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc);
       TSMimeHdrFieldDestroy(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc);
+      TSHandleMLocRelease(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc);
+      field_loc = tmp;
     }
-
-  } else if (field_loc) {
-    TSMimeHdrFieldValueStringSet(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc, -1, val, val_len);
-
+  } else if (field_loc != TS_NULL_MLOC) {
+    first = 1;
+    while (field_loc != TS_NULL_MLOC) {
+      tmp = TSMimeHdrFieldNextDup(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc);
+      if (first) {
+        first = 0;
+        TSMimeHdrFieldValueStringSet(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc, -1, val, val_len);
+      } else {
+        TSMimeHdrFieldDestroy(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc);
+      }
+      TSHandleMLocRelease(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc);
+      field_loc = tmp;
+    }
   } else if (TSMimeHdrFieldCreateNamed(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, key, key_len, &field_loc) !=
              TS_SUCCESS) {
     TSError("[ts_lua][%s] TSMimeHdrFieldCreateNamed error", __FUNCTION__);
@@ -222,7 +248,7 @@ ts_lua_server_request_header_set(lua_State *L)
     TSMimeHdrFieldAppend(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc);
   }
 
-  if (field_loc)
+  if (field_loc != TS_NULL_MLOC)
     TSHandleMLocRelease(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc);
 
   return 0;
@@ -244,6 +270,8 @@ ts_lua_server_request_get_headers(lua_State *L)
   int value_len;
   TSMLoc field_loc;
   TSMLoc next_field_loc;
+  const char *tvalue;
+  size_t tvalue_len;
 
   ts_lua_http_ctx *http_ctx;
 
@@ -255,13 +283,33 @@ ts_lua_server_request_get_headers(lua_State *L)
 
   field_loc = TSMimeHdrFieldGet(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, 0);
 
-  while (field_loc) {
+  while (field_loc != TS_NULL_MLOC) {
     name = TSMimeHdrFieldNameGet(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc, &name_len);
     if (name && name_len) {
-      value = TSMimeHdrFieldValueStringGet(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc, -1, &value_len);
+      // retrieve the header name from table
       lua_pushlstring(L, name, name_len);
-      lua_pushlstring(L, value, value_len);
-      lua_rawset(L, -3);
+      lua_gettable(L, -2);
+      if (lua_isnil(L, -1)) {
+        // if header name does not exist in the table, insert it
+        lua_pop(L, 1);
+        value =
+          TSMimeHdrFieldValueStringGet(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc, -1, &value_len);
+        lua_pushlstring(L, name, name_len);
+        lua_pushlstring(L, value, value_len);
+        lua_rawset(L, -3);
+      } else {
+        // if header name exists in the table, append a command and the new value to the end of the existing value
+        tvalue = lua_tolstring(L, -1, &tvalue_len);
+        lua_pop(L, 1);
+        value =
+          TSMimeHdrFieldValueStringGet(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc, -1, &value_len);
+        lua_pushlstring(L, name, name_len);
+        lua_pushlstring(L, tvalue, tvalue_len);
+        lua_pushlstring(L, ",", 1);
+        lua_pushlstring(L, value, value_len);
+        lua_concat(L, 3);
+        lua_rawset(L, -3);
+      }
     }
 
     next_field_loc = TSMimeHdrFieldNext(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc);

--- a/plugins/experimental/ts_lua/ts_lua_server_response.c
+++ b/plugins/experimental/ts_lua/ts_lua_server_response.c
@@ -88,6 +88,8 @@ ts_lua_server_response_get_headers(lua_State *L)
   int value_len;
   TSMLoc field_loc;
   TSMLoc next_field_loc;
+  const char *tvalue;
+  size_t tvalue_len;
 
   ts_lua_http_ctx *http_ctx;
 
@@ -99,14 +101,33 @@ ts_lua_server_response_get_headers(lua_State *L)
 
   field_loc = TSMimeHdrFieldGet(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, 0);
 
-  while (field_loc) {
+  while (field_loc != TS_NULL_MLOC) {
     name = TSMimeHdrFieldNameGet(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, field_loc, &name_len);
     if (name && name_len) {
-      value =
-        TSMimeHdrFieldValueStringGet(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, field_loc, -1, &value_len);
+      // retrieve the header name from table
       lua_pushlstring(L, name, name_len);
-      lua_pushlstring(L, value, value_len);
-      lua_rawset(L, -3);
+      lua_gettable(L, -2);
+      if (lua_isnil(L, -1)) {
+        // if header name does not exist in the table, insert it
+        lua_pop(L, 1);
+        value =
+          TSMimeHdrFieldValueStringGet(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, field_loc, -1, &value_len);
+        lua_pushlstring(L, name, name_len);
+        lua_pushlstring(L, value, value_len);
+        lua_rawset(L, -3);
+      } else {
+        // if header name exists in the table, append a command and the new value to the end of the existing value
+        tvalue = lua_tolstring(L, -1, &tvalue_len);
+        lua_pop(L, 1);
+        value =
+          TSMimeHdrFieldValueStringGet(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, field_loc, -1, &value_len);
+        lua_pushlstring(L, name, name_len);
+        lua_pushlstring(L, tvalue, tvalue_len);
+        lua_pushlstring(L, ",", 1);
+        lua_pushlstring(L, value, value_len);
+        lua_concat(L, 3);
+        lua_rawset(L, -3);
+      }
     }
 
     next_field_loc = TSMimeHdrFieldNext(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, field_loc);
@@ -138,8 +159,10 @@ ts_lua_server_response_header_get(lua_State *L)
   const char *val;
   int val_len;
   size_t key_len;
+  int count;
 
-  TSMLoc field_loc;
+  TSMLoc field_loc, next_field_loc;
+
   ts_lua_http_ctx *http_ctx;
 
   GET_HTTP_CONTEXT(http_ctx, L);
@@ -151,11 +174,22 @@ ts_lua_server_response_header_get(lua_State *L)
 
   if (key && key_len) {
     field_loc = TSMimeHdrFieldFind(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, key, key_len);
-    if (field_loc) {
-      val = TSMimeHdrFieldValueStringGet(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, field_loc, -1, &val_len);
-      lua_pushlstring(L, val, val_len);
-      TSHandleMLocRelease(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, field_loc);
-
+    if (field_loc != TS_NULL_MLOC) {
+      count = 0;
+      while (field_loc != TS_NULL_MLOC) {
+        val = TSMimeHdrFieldValueStringGet(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, field_loc, -1, &val_len);
+        next_field_loc = TSMimeHdrFieldNextDup(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, field_loc);
+        lua_pushlstring(L, val, val_len);
+        count++;
+        // multiple headers with the same name must be semantically the same as one value which is comma seperated
+        if (next_field_loc != TS_NULL_MLOC) {
+          lua_pushlstring(L, ",", 1);
+          count++;
+        }
+        TSHandleMLocRelease(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, field_loc);
+        field_loc = next_field_loc;
+      }
+      lua_concat(L, count);
     } else {
       lua_pushnil(L);
     }
@@ -175,8 +209,9 @@ ts_lua_server_response_header_set(lua_State *L)
   size_t val_len;
   size_t key_len;
   int remove;
+  int first;
 
-  TSMLoc field_loc;
+  TSMLoc field_loc, tmp;
 
   ts_lua_http_ctx *http_ctx;
 
@@ -198,13 +233,25 @@ ts_lua_server_response_header_set(lua_State *L)
   field_loc = TSMimeHdrFieldFind(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, key, key_len);
 
   if (remove) {
-    if (field_loc) {
+    while (field_loc != TS_NULL_MLOC) {
+      tmp = TSMimeHdrFieldNextDup(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, field_loc);
       TSMimeHdrFieldDestroy(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, field_loc);
+      TSHandleMLocRelease(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, field_loc);
+      field_loc = tmp;
     }
-
-  } else if (field_loc) {
-    TSMimeHdrFieldValueStringSet(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, field_loc, -1, val, val_len);
-
+  } else if (field_loc != TS_NULL_MLOC) {
+    first = 1;
+    while (field_loc != TS_NULL_MLOC) {
+      tmp = TSMimeHdrFieldNextDup(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, field_loc);
+      if (first) {
+        first = 0;
+        TSMimeHdrFieldValueStringSet(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, field_loc, -1, val, val_len);
+      } else {
+        TSMimeHdrFieldDestroy(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, field_loc);
+      }
+      TSHandleMLocRelease(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, field_loc);
+      field_loc = tmp;
+    }
   } else if (TSMimeHdrFieldCreateNamed(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, key, key_len, &field_loc) !=
              TS_SUCCESS) {
     TSError("[ts_lua][%s] TSMimeHdrFieldCreateNamed error", __FUNCTION__);
@@ -215,7 +262,7 @@ ts_lua_server_response_header_set(lua_State *L)
     TSMimeHdrFieldAppend(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, field_loc);
   }
 
-  if (field_loc)
+  if (field_loc != TS_NULL_MLOC)
     TSHandleMLocRelease(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, field_loc);
 
   return 0;


### PR DESCRIPTION
Currently ts_lua plugin does not handle well when the request or response contains multiple header with the same name. 

We either retrieve the last value of first value of these headers and when we set new value to the header, we only change the first one and leave the rest there still.

@jpeach , pls help to take a look. I think I can refactor later on to reduce the amount of copy-paste but I think I should do that in a separate exercise with broader scope. Thanks.