### PR TITLE
TS-4514: Transaction hangs when no_dns_just_forward is configured but…

### DIFF
--- a/proxy/ParentRoundRobin.cc
+++ b/proxy/ParentRoundRobin.cc
@@ -56,7 +56,6 @@ ParentRoundRobin::selectParent(const ParentSelectionPolicy *policy, bool first_c
   int cur_index = 0;
   bool parentUp = false;
   bool parentRetry = false;
-  bool bypass_ok = (result->rec->go_direct == true && policy->DNS_ParentOnly == 0);
 
   HttpRequestData *request_info = static_cast<HttpRequestData *>(rdata);
 
@@ -109,9 +108,9 @@ ParentRoundRobin::selectParent(const ParentSelectionPolicy *policy, bool first_c
     // Check to see if we have wrapped around
     if ((unsigned int)cur_index == result->start_parent) {
       // We've wrapped around so bypass if we can
-      if (bypass_ok == true) {
+      if (result->rec->go_direct == true) {
         // Could not find a parent
-        if (result->rec->go_direct == true && result->rec->parent_is_proxy == true) {
+        if (result->rec->parent_is_proxy == true) {
           result->result = PARENT_DIRECT;
         } else {
           result->result = PARENT_FAIL;
@@ -119,10 +118,6 @@ ParentRoundRobin::selectParent(const ParentSelectionPolicy *policy, bool first_c
         result->hostname = NULL;
         result->port = 0;
         return;
-      } else {
-        // Bypass disabled so keep trying, ignoring whether we think
-        //   a parent is down or not
-        result->wrap_around = true;
       }
     }
   }

--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -46,7 +46,6 @@ static const char *default_var = "proxy.config.http.parent_proxies";
 static const char *retry_var = "proxy.config.http.parent_proxy.retry_time";
 static const char *enable_var = "proxy.config.http.parent_proxy_routing_enable";
 static const char *threshold_var = "proxy.config.http.parent_proxy.fail_threshold";
-static const char *dns_parent_only_var = "proxy.config.http.no_dns_just_forward_to_parent";
 
 static const char *ParentResultStr[] = {"PARENT_UNDEFINED", "PARENT_DIRECT", "PARENT_SPECIFIED", "PARENT_AGENT", "PARENT_FAIL"};
 
@@ -67,7 +66,6 @@ ParentSelectionPolicy::ParentSelectionPolicy()
   bool enable = false;
   int32_t retry_time = 0;
   int32_t fail_threshold = 0;
-  int32_t dns_parent_only = 0;
 
   // Handle parent timeout
   REC_ReadConfigInteger(retry_time, retry_var);
@@ -80,10 +78,6 @@ ParentSelectionPolicy::ParentSelectionPolicy()
   // Handle the fail threshold
   REC_ReadConfigInteger(fail_threshold, threshold_var);
   FailThreshold = fail_threshold;
-
-  // Handle dns parent only
-  REC_ReadConfigInteger(dns_parent_only, dns_parent_only_var);
-  DNS_ParentOnly = dns_parent_only;
 }
 
 ParentConfigParams::ParentConfigParams(P_table *_parent_table) : parent_table(_parent_table), DefaultParent(NULL), policy()
@@ -267,9 +261,6 @@ ParentConfig::startup()
 
   //   Fail Threshold
   parentConfigUpdate->attach(threshold_var);
-
-  //   DNS Parent Only
-  parentConfigUpdate->attach(dns_parent_only_var);
 }
 
 void
@@ -300,8 +291,7 @@ ParentConfig::print()
   ParentConfigParams *params = ParentConfig::acquire();
 
   printf("Parent Selection Config\n");
-  printf("\tEnabled %d\tRetryTime %d\tParent DNS Only %d\n", params->policy.ParentEnable, params->policy.ParentRetryTime,
-         params->policy.DNS_ParentOnly);
+  printf("\tEnabled %d\tRetryTime %d\n", params->policy.ParentEnable, params->policy.ParentRetryTime);
   if (params->DefaultParent == NULL) {
     printf("\tNo Default Parent\n");
   } else {
@@ -842,10 +832,6 @@ SocksServerConfig::reconfigure()
   REC_ReadConfigInteger(fail_threshold, "proxy.config.socks.server_fail_threshold");
   params->policy.FailThreshold = fail_threshold;
 
-  // Handle dns parent only
-  // PARENT_ReadConfigInteger(dns_parent_only, dns_parent_only_var);
-  params->policy.DNS_ParentOnly = 0;
-
   m_id = configProcessor.set(m_id, params);
 
   if (is_debug_tag_set("parent_config")) {
@@ -859,8 +845,7 @@ SocksServerConfig::print()
   ParentConfigParams *params = SocksServerConfig::acquire();
 
   printf("Parent Selection Config for Socks Server\n");
-  printf("\tEnabled %d\tRetryTime %d\tParent DNS Only %d\n", params->policy.ParentEnable, params->policy.ParentRetryTime,
-         params->policy.DNS_ParentOnly);
+  printf("\tEnabled %d\tRetryTime %d\n", params->policy.ParentEnable, params->policy.ParentRetryTime);
   if (params->DefaultParent == NULL) {
     printf("\tNo Default Parent\n");
   } else {

--- a/proxy/ParentSelection.h
+++ b/proxy/ParentSelection.h
@@ -280,7 +280,6 @@ struct ParentSelectionPolicy {
   int32_t ParentRetryTime;
   int32_t ParentEnable;
   int32_t FailThreshold;
-  int32_t DNS_ParentOnly;
   ParentSelectionPolicy();
 };
 

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -1545,14 +1545,15 @@ HttpTransact::PPDNSLookup(State *s)
 
   ink_assert(s->dns_info.looking_up == PARENT_PROXY);
   if (!s->dns_info.lookup_success) {
+    // Mark parent as down due to resolving failure
+    s->parent_params->markParentDown(&s->parent_result);
     // DNS lookup of parent failed, find next parent or o.s.
     find_server_and_update_current_info(s);
     if (!s->current.server->dst_addr.isValid()) {
       if (s->current.request_to == PARENT_PROXY) {
         TRANSACT_RETURN(SM_ACTION_DNS_LOOKUP, PPDNSLookup);
       } else {
-        // We could be out of parents here if all the parents
-        // failed DNS lookup
+        // We could be out of parents here if all the parents failed DNS lookup
         ink_assert(s->current.request_to == HOST_NONE);
         handle_parent_died(s);
       }


### PR DESCRIPTION
… parent proxy is unresolvable

It doesn't really make sense for the parent selection layer to be aware of the no_dns flag.
Calling code takes the flag into account.