### PR TITLE
TS-4488: fix Segmentation fault at HttpSM::tunnel_handler_ua

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -3209,7 +3209,9 @@ HttpSM::tunnel_handler_ua(int event, HttpTunnelConsumer *c)
       //  detach the user agent
       ink_assert(server_entry->vc == server_session);
       ink_assert(c->is_downstream_from(server_session));
-      server_session->get_netvc()->set_active_timeout(HRTIME_SECONDS(t_state.txn_conf->background_fill_active_timeout));
+      if (server_session != NULL) {
+        server_session->get_netvc()->set_active_timeout(HRTIME_SECONDS(t_state.txn_conf->background_fill_active_timeout));
+      }
     } else {
       // No background fill
       p = c->producer;


### PR DESCRIPTION
Returning to [PR](https://github.com/apache/trafficserver/pull/674). It seems I found how to reproduce this bug. It happens when transformation is used (for example from null transform plugin) and client terminates connection before the transformation consumes all data from upstream vconnection.