### PR TITLE
[TS-4529] Adjust thread with the right continuation.

### DIFF
--- a/proxy/ProxyClientTransaction.cc
+++ b/proxy/ProxyClientTransaction.cc
@@ -86,13 +86,13 @@ ProxyClientTransaction::attach_server_session(HttpServerSession *ssession, bool 
 }
 
 Action *
-ProxyClientTransaction::adjust_thread(int event, void *data)
+ProxyClientTransaction::adjust_thread(Continuation *cont, int event, void *data)
 {
   NetVConnection *vc = this->get_netvc();
   EThread *this_thread = this_ethread();
   if (vc && vc->thread != this_thread) {
     if (vc->thread->is_event_type(ET_NET) || vc->thread->is_event_type(SSLNetProcessor::ET_SSL)) {
-      return vc->thread->schedule_imm(this, event, data);
+      return vc->thread->schedule_imm(cont, event, data);
     } else { // Not a net thread, take over this thread
       vc->thread = this_thread;
     }

--- a/proxy/ProxyClientTransaction.h
+++ b/proxy/ProxyClientTransaction.h
@@ -51,7 +51,7 @@ public:
 
   // See if we need to schedule on the primary thread for the transaction or change the thread that is associated with the VC.
   // If we reschedule, the scheduled action is returned.  Otherwise, NULL is returned
-  Action *adjust_thread(int event, void *data);
+  Action *adjust_thread(Continuation *cont, int event, void *data);
 
   int
   get_transact_count() const

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -2437,7 +2437,7 @@ HttpSM::state_cache_open_write(int event, void *data)
 
   // Make sure we are on the "right" thread
   if (ua_session) {
-    if ((pending_action = ua_session->adjust_thread(event, data))) {
+    if ((pending_action = ua_session->adjust_thread(this, event, data))) {
       return 0; // Go away if we reschedule
     }
   }
@@ -4643,7 +4643,7 @@ HttpSM::do_http_server_open(bool raw)
 
   // Make sure we are on the "right" thread
   if (ua_session) {
-    if ((pending_action = ua_session->adjust_thread(EVENT_INTERVAL, NULL))) {
+    if ((pending_action = ua_session->adjust_thread(this, EVENT_INTERVAL, NULL))) {
       return; // Go away if we reschedule
     }
   }


### PR DESCRIPTION
This patch seems to fix our issues with HttpAsync calls.

https://issues.apache.org/jira/browse/TS-4529

Signed-off-by: David Calavera <david.calavera@gmail.com>