### PR TITLE
TS-4536 Don't always refresh an IP when serving stale

### DIFF
--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -691,7 +691,6 @@ probe(ProxyMutex *mutex, HostDBMD5 const &md5, bool ignore_timeout)
       if ((!ignore_timeout && r->is_ip_stale() && !cluster_machine_at_depth(master_hash(md5.hash)) && !r->reverse_dns) ||
           (r->is_ip_timeout() && r->serve_stale_but_revalidate())) {
         Debug("hostdb", "stale %u %u %u, using it and refreshing it", r->ip_interval(), r->ip_timestamp, r->ip_timeout_interval);
-        r->refresh_ip();
         if (!is_dotted_form_hostname(md5.host_name)) {
           HostDBContinuation *c = hostDBContAllocator.alloc();
           HostDBContinuation::Options copt;


### PR DESCRIPTION
With this as it stands, if a record is configured to serve stale the "creation" timeout keeps getting moved. This means if requests are made every second a record would NEVER expire-- which isn't what we want.