### PR TITLE
TS-4507: Fixes to ensure SSN_CLOSE called after TXN_CLOSE.

### DIFF
--- a/proxy/ProxyClientTransaction.cc
+++ b/proxy/ProxyClientTransaction.cc
@@ -72,7 +72,12 @@ ProxyClientTransaction::release(IOBufferReader *r)
   DebugHttpTxn("[%" PRId64 "] session released by sm [%" PRId64 "]", parent ? parent->connection_id() : 0,
                current_reader ? current_reader->sm_id : 0);
 
-  current_reader = NULL; // Clear reference to SM
+  // Clear reference to SM.
+  // And clear SM's reference to us.
+  if (current_reader) {
+    current_reader->ua_session = NULL;
+    current_reader = NULL;
+  }
 
   // Pass along the release to the session
   if (parent)
@@ -98,4 +103,14 @@ ProxyClientTransaction::adjust_thread(int event, void *data)
     }
   }
   return NULL;
+}
+
+void
+ProxyClientTransaction::destroy()
+{
+  if (current_reader) {
+    current_reader->ua_session = NULL;
+    current_reader = NULL;
+  }
+  this->mutex.clear();
 }

--- a/proxy/ProxyClientTransaction.h
+++ b/proxy/ProxyClientTransaction.h
@@ -174,10 +174,10 @@ public:
     return true;
   }
 
+  virtual void destroy();
   virtual void
-  destroy()
+  transaction_done()
   {
-    this->mutex.clear();
   }
 
   ProxyClientSession *

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -56,6 +56,7 @@ public:
 
   // Implement ProxyClientSession interface.
   virtual void destroy();
+  void really_destroy();
 
   virtual void
   start()
@@ -92,7 +93,14 @@ public:
   virtual void
   release_netvc()
   {
-    client_vc = NULL;
+    // Make sure the vio's are also released to avoid
+    // later surprises in inactivity timeout
+    if (client_vc) {
+      client_vc->do_io_read(NULL, 0, NULL);
+      client_vc->do_io_write(NULL, 0, NULL);
+      client_vc->set_action(NULL);
+      client_vc = NULL;
+    }
   }
 
   int
@@ -181,7 +189,12 @@ private:
 
   MIOBuffer *read_buffer;
   IOBufferReader *sm_reader;
-  C_Read_State read_state;
+
+  /*
+   * Volatile should not be necessary, but there appears to be a bug in the 4.9 rhel gcc
+   * compiler that was using an old version of read_state to make decisions in really_destroy
+   */
+  volatile C_Read_State read_state;
 
   VIO *ka_vio;
   VIO *slave_ka_vio;

--- a/proxy/http/Http1ClientTransaction.cc
+++ b/proxy/http/Http1ClientTransaction.cc
@@ -65,3 +65,10 @@ Http1ClientTransaction::set_parent(ProxyClientSession *new_parent)
   }
   super::set_parent(new_parent);
 }
+
+void
+Http1ClientTransaction::transaction_done()
+{
+  if (parent)
+    dynamic_cast<Http1ClientSession *>(parent)->really_destroy();
+}

--- a/proxy/http/Http1ClientTransaction.h
+++ b/proxy/http/Http1ClientTransaction.h
@@ -99,6 +99,7 @@ public:
   {
     return "http";
   }
+  virtual void transaction_done();
 
   void set_parent(ProxyClientSession *new_parent);
 

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -3296,12 +3296,12 @@ HttpSM::tunnel_handler_ua(int event, HttpTunnelConsumer *c)
     }
 
     ua_session->do_io_close();
-    ua_session = NULL;
+    // ua_session = NULL;
   } else {
     ink_assert(ua_buffer_reader != NULL);
     ua_session->release(ua_buffer_reader);
     ua_buffer_reader = NULL;
-    ua_session = NULL;
+    // ua_session = NULL;
   }
 
   return 0;
@@ -6114,7 +6114,7 @@ HttpSM::setup_error_transfer()
     DebugSM("http", "[setup_error_transfer] Now closing connection ...");
     vc_table.cleanup_entry(ua_entry);
     ua_entry = NULL;
-    ua_session = NULL;
+    // ua_session = NULL;
     terminate_sm = true;
     t_state.source = HttpTransact::SOURCE_INTERNAL;
   }
@@ -6723,7 +6723,9 @@ HttpSM::kill_this()
       plugin_tunnel = NULL;
     }
 
-    ua_session = NULL;
+    if (ua_session) {
+      ua_session->transaction_done();
+    }
     server_session = NULL;
 
     // So we don't try to nuke the state machine

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -164,6 +164,7 @@ public:
   // Implement ProxyClientSession interface.
   void start();
   virtual void destroy();
+  virtual void really_destroy();
   void new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader, bool backdoor);
 
   // Implement VConnection interface.
@@ -183,9 +184,7 @@ public:
     // Make sure the vio's are also released to avoid
     // later surprises in inactivity timeout
     if (client_vc) {
-      client_vc->do_io_read(NULL, 0, NULL);
-      client_vc->do_io_write(NULL, 0, NULL);
-      client_vc = NULL;
+      client_vc->set_action(NULL);
     }
   }
 
@@ -232,6 +231,16 @@ public:
   {
     return dying_event;
   }
+  bool
+  do_destroy() const
+  {
+    return kill_me == true;
+  }
+  bool
+  is_recursing() const
+  {
+    return recursion > 0;
+  }
 
 private:
   Http2ClientSession(Http2ClientSession &);                  // noncopyable
@@ -258,6 +267,8 @@ private:
 
   VIO *write_vio;
   int dying_event;
+  bool kill_me;
+  int recursion;
 };
 
 extern ClassAllocator<Http2ClientSession> http2ClientSessionAllocator;

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -120,6 +120,8 @@ public:
       latest_streamid(0),
       client_streams_count(0),
       continued_stream_id(0),
+      fini_received(false),
+      recursion(0),
       _scheduled(false)
   {
     SET_HANDLER(&Http2ConnectionState::main_event_handler);
@@ -169,6 +171,7 @@ public:
   Http2Stream *find_stream(Http2StreamId id) const;
   void restart_streams();
   void delete_stream(Http2Stream *stream);
+  void release_stream(Http2Stream *stream);
   void cleanup_streams();
 
   void update_initial_rwnd(Http2WindowSize new_size);
@@ -214,7 +217,13 @@ public:
   bool
   is_state_closed() const
   {
-    return ua_session == NULL;
+    return ua_session == NULL || fini_received;
+  }
+
+  bool
+  is_recursing() const
+  {
+    return recursion > 0;
   }
 
 private:
@@ -232,8 +241,10 @@ private:
   DLL<Http2Stream> stream_list;
   Http2StreamId latest_streamid;
 
-  // Counter for current acive streams which is started by client
+  // Counter for current active streams which is started by client
   uint32_t client_streams_count;
+  // Counter for current active streams and streams in the process of shutting down
+  uint32_t total_client_streams_count;
 
   // NOTE: Id of stream which MUST receive CONTINUATION frame.
   //   - [RFC 7540] 6.2 HEADERS
@@ -244,6 +255,8 @@ private:
   //     another CONTINUATION frame."
   Http2StreamId continued_stream_id;
   IOVec continued_buffer;
+  bool fini_received;
+  int recursion;
   bool _scheduled;
 };
 

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -203,12 +203,7 @@ public:
   bool response_process_data();
   bool response_is_data_available() const;
   // For Http2 releasing the transaction should go ahead and delete it
-  void
-  release(IOBufferReader *r)
-  {
-    current_reader = NULL; // State machine is on its own way down.
-    this->do_io_close();
-  }
+  void release(IOBufferReader *r);
 
   virtual bool
   allow_half_open() const


### PR DESCRIPTION
Adding logic to ensure that SSN_CLOSE doesn't get called before TXN_CLOSE. This involved deferring the session destroy further.  Had to add some recursion checks in HTTP2 to make sure we don't destroy the ssn object on the stack.