### PR TITLE
TS-4560: Fix C++ API shared_ptr detection.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -604,9 +604,13 @@ AC_COMPILE_IFELSE([
 )
 
 AC_MSG_RESULT([$have_std_shared_ptr])
-if test "x${have_std_shared_ptr}" = "xyes" ; then
-  AC_DEFINE(HAVE_STD_SHARED_PTR, 1, [whether std::shared_ptr is available])
-fi
+AS_IF([test "x${have_std_shared_ptr}" = "xyes"], [
+    AC_DEFINE(HAVE_STD_SHARED_PTR, 1, [whether std::shared_ptr is available])
+    AC_SUBST(have_std_shared_ptr, 1)
+  ], [
+    AC_SUBST(have_std_shared_ptr, 0)
+  ]
+)
 
 AC_LANG_POP()
 
@@ -1975,6 +1979,7 @@ AC_CONFIG_FILES([
   lib/atscppapi/examples/timeout_example/Makefile
   lib/atscppapi/examples/transactionhook/Makefile
   lib/atscppapi/src/Makefile
+  lib/atscppapi/src/include/atscppapi/shared_ptr.h
   lib/bindings/Makefile
   lib/perl/Makefile
   lib/perl/lib/Apache/TS.pm
@@ -2004,6 +2009,7 @@ AC_CONFIG_FILES([
   plugins/experimental/cachekey/Makefile
   plugins/experimental/channel_stats/Makefile
   plugins/experimental/collapsed_connection/Makefile
+  plugins/experimental/collapsed_forwarding/Makefile
   plugins/experimental/custom_redirect/Makefile
   plugins/experimental/epic/Makefile
   plugins/experimental/escalate/Makefile
@@ -2011,7 +2017,6 @@ AC_CONFIG_FILES([
   plugins/experimental/generator/Makefile
   plugins/experimental/geoip_acl/Makefile
   plugins/experimental/header_normalize/Makefile
-  plugins/experimental/collapsed_forwarding/Makefile
   plugins/experimental/hipes/Makefile
   plugins/experimental/inliner/Makefile
   plugins/experimental/memcache/Makefile

--- a/lib/atscppapi/src/include/atscppapi/shared_ptr.h.in
+++ b/lib/atscppapi/src/include/atscppapi/shared_ptr.h.in
@@ -22,12 +22,12 @@
  */
 
 #pragma once
-#ifndef ASTCPPAPI_SHARED_PTR_H_
-#define ASTCPPAPI_SHARED_PTR_H_
+#ifndef ATSCPPAPI_SHARED_PTR_H_
+#define ATSCPPAPI_SHARED_PTR_H_
 
-#include "ink_autoconf.h"
+#define ATSCPPAPI_USE_STD_SHARED_PTR @have_std_shared_ptr@
 
-#if HAVE_STD_SHARED_PTR
+#if ATSCPPAPI_USE_STD_SHARED_PTR
 #include <memory>
 #else
 #include <tr1/memory>
@@ -40,7 +40,7 @@ namespace atscppapi
  * \todo Consider adding a simple macro to check if c++0x/11 is enabled
  * and if so change it to std::shared_ptr and #include <memory>s
  */
-#if HAVE_STD_SHARED_PTR
+#if ATSCPPAPI_USE_STD_SHARED_PTR
 using std::shared_ptr;
 using std::unique_ptr;
 #else
@@ -50,4 +50,4 @@ using std::tr1::unique_ptr;
 
 } /* atscppapi */
 
-#endif /* SHARED_PTR_H_ */
+#endif /* ATSCPPAPI_SHARED_PTR_H_ */


### PR DESCRIPTION
Since ink_autoconf.h is not installed, we can't use it to figure
out which shared_ptr implementation to use. Further, Traffic Server
might not have been built with the same toolchain that 3rd party
plugins are using.

Since shared_ptr is used in the C++ API headers, both Traffic Server
and the plugins need to agree on which implementation to use. The
best (but not perfect) solution is to hardcode it into the header
file during the Traffic Server build. This means that both parties
are consistent and any remaining problems could be attributed to
C++ standard library compatibility.