### PR TITLE
TS-4566 Disabled clang-analyzer on LuaJIT

### DIFF
--- a/ci/jenkins/bin/clang-analyzer.sh
+++ b/ci/jenkins/bin/clang-analyzer.sh
@@ -21,9 +21,12 @@
 # to talk to the author of it, or ideally, figure out how to get clang-analyzer to
 # ignore them ?
 
+# Where are our LLVM tools?
+LLVM_BASE=${LLVM:-/opt/llvm}
+
 # Options
 options="--status-bugs --keep-empty"
-configure="--enable-experimental-plugins --enable-cppapi --disable-luajit"
+configure="--enable-experimental-plugins --enable-cppapi"
 
 # Additional checkers
 # Phil says these are all FP's: -enable-checker alpha.security.ArrayBoundV2
@@ -44,8 +47,8 @@ test -d "/home/jenkins/clang-analyzer" && output="/home/jenkins/clang-analyzer"
 
 autoreconf -fi
 #scan-build ./configure ${configure}
-./configure ${configure}
-/opt/llvm/bin/scan-build ${checkers} ${options} -o ${output} --html-title="ATS master branch"  ${ATS_MAKE} -j4
+./configure ${configure} CC=${LLVM_BASE}/bin/clang CXX=${LLVM_BASE}/bin/clang++
+${LLVM_BASE}/bin/scan-build ${checkers} ${options} -o ${output} --html-title="ATS master branch"  ${ATS_MAKE} -j4
 status=$?
 
 ${ATS_MAKE} distclean

--- a/configure.ac
+++ b/configure.ac
@@ -821,7 +821,7 @@ case $host_os_def in
       debug_opt="-ggdb3 $common_opt -Qunused-arguments"
       release_opt="-g $common_opt $optimizing_flags -fno-strict-aliasing -Qunused-arguments"
       cxx_opt="-Wno-invalid-offsetof"
-      lua_cflags="-Wno-parentheses-equality -Wno-tautological-compare"
+      lua_cflags="-Wno-parentheses-equality -Wno-tautological-compare -analyzer-disable-all-checks"
     ])
 
     AS_IF([test "x$ax_cv_c_compiler_vendor" = "xgnu"], [


### PR DESCRIPTION
This basically adds the clang flag  -analyzer-disable-all-checks to lua_cflags when we build with clang. It also fixes / cleans up the actual build script, such that it uses these flags properly.