### PR TITLE
TS-4470: ASAN stack-buffer-overflow when slow log is enabled

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -6890,8 +6890,8 @@ HttpSM::update_stats()
     int offset = 0;
     int skip = 0;
 
-    t_state.hdr_info.client_request.url_print(url_string, sizeof(url_string), &offset, &skip);
-    url_string[sizeof(url_string) - 1] = 0; // NULL terminate the string
+    t_state.hdr_info.client_request.url_print(url_string, sizeof(url_string) - 1, &offset, &skip);
+    url_string[offset] = 0; // NULL terminate the string
 
     // unique id
     char unique_id_string[128] = "";


### PR DESCRIPTION
Update to use offset too