### PR TITLE
TS-4571: Fix "pointer to local outside scope" (CID 1356978)

### DIFF
--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -516,6 +516,7 @@ ParentRecord::Init(matcher_line *line_info)
   char *val;
   bool used              = false;
   ParentRR_t round_robin = P_NO_ROUND_ROBIN;
+  char buf[128];
 
   this->line_num = line_info->line_num;
   this->scheme   = NULL;
@@ -595,8 +596,8 @@ ParentRecord::Init(matcher_line *line_info)
         max_simple_retries = v;
         used               = true;
       } else {
-        char buf[128];
-        sprintf(buf, "invalid argument to max_simple_retries.  Argument must be between 1 and %d.", MAX_SIMPLE_RETRIES);
+        snprintf(buf, sizeof(buf), "invalid argument to max_simple_retries.  Argument must be between 1 and %d.",
+                 MAX_SIMPLE_RETRIES);
         errPtr = buf;
       }
     } else if (strcasecmp(label, "max_unavailable_server_retries") == 0) {
@@ -605,9 +606,8 @@ ParentRecord::Init(matcher_line *line_info)
         max_unavailable_server_retries = v;
         used                           = true;
       } else {
-        char buf[128];
-        sprintf(buf, "invalid argument to max_unavailable_server_retries.  Argument must be between 1 and %d.",
-                MAX_UNAVAILABLE_SERVER_RETRIES);
+        snprintf(buf, sizeof(buf), "invalid argument to max_unavailable_server_retries.  Argument must be between 1 and %d.",
+                 MAX_UNAVAILABLE_SERVER_RETRIES);
         errPtr = buf;
       }
     }


### PR DESCRIPTION
Dereferencing the returned or out-of-scope stack pointer will access an invalid location on the stack after its scope or after the function returns.
In ParentRecord::​Init(matcher_line *): Pointer to a local stack variable returned or used outside scope (CWE-562)