### PR TITLE
TS-4572: Fix "Unchecked return value" (CID 1356972)

### DIFF
--- a/plugins/experimental/remap_stats/remap_stats.c
+++ b/plugins/experimental/remap_stats/remap_stats.c
@@ -100,7 +100,10 @@ get_effective_host(TSHttpTxn txn)
 
   effective_url = TSHttpTxnEffectiveUrlStringGet(txn, &len);
   buf           = TSMBufferCreate();
-  TSUrlCreate(buf, &url_loc);
+  if (TS_SUCCESS != TSUrlCreate(buf, &url_loc)) {
+    TSDebug(DEBUG_TAG, "unable to create url");
+    return NULL;
+  }
   tmp = effective_url;
   TSUrlParse(buf, url_loc, (const char **)(&tmp), (const char *)(effective_url + len));
   TSfree(effective_url);


### PR DESCRIPTION
If the function returns an error value, the error value may be mistaken for a normal value.
In get_effective_host: Value returned from a function is not checked for errors before being used (CWE-252)