### PR TITLE
[TS-4270] Make stats_over_http a remap plugin.

### DIFF
--- a/proxy/http/remap/RemapConfig.cc
+++ b/proxy/http/remap/RemapConfig.cc
@@ -516,6 +516,7 @@ remap_validate_filter_args(acl_filter_rule **rule_pp, const char **argv, int arg
         }
         return (const char *)errStrBuf;
       }
+      Debug("url_rewrite", "[validate_src_ip]");
       for (j = 0; j < rule->src_ip_cnt; j++) {
         if (rule->src_ip_array[j].start == ipi->start && rule->src_ip_array[j].end == ipi->end) {
           ipi->reset();
@@ -527,6 +528,7 @@ remap_validate_filter_args(acl_filter_rule **rule_pp, const char **argv, int arg
         rule->src_ip_cnt++;
         rule->src_ip_valid = 1;
       }
+      Debug("url_rewrite", "[validate_src_ip] valid ip? %d", rule->src_ip_valid);
     }
 
     if (ul & REMAP_OPTFLG_IN_IP) { /* "dst_ip=" option */

--- a/proxy/http/remap/RemapProcessor.cc
+++ b/proxy/http/remap/RemapProcessor.cc
@@ -302,6 +302,12 @@ RemapProcessor::perform_remap(Continuation *cont, HttpTransact::State *s)
     return ACTION_RESULT_DONE;
   }
 
+  // Do fast ACL filtering (it is safe to check map here)
+  rewrite_table->PerformACLFiltering(s, map);
+  if (!s->client_connection_enabled) {
+    return ACTION_RESULT_DONE;
+  }
+
   if (_use_separate_remap_thread) {
     RemapPlugins *plugins = pluginAllocator.alloc();
 


### PR DESCRIPTION
I'm opening this Pull Request to get feedback about the current remap behavior.

I'd like to restrict all access to the stats over http using remap rules, like this one:

    map /_stats /_stats @plugin=stats_over_http.so @action=allow @src_ip=127.0.0.1

However, the remap action is validated after a plugin is loaded. This is problematic for plugins that intercept the server request, because they can send a response before this validation happen, like it's the case of stats_over_http.

I modified RemapProcessor to call `PerformACLFiltering` before a plugin is loaded, but I don't know if that's the right way to solve this problem. Specifically, because with this change, that filtering happens twice, before and after loading the plugin.

I'd really appreciate some feedback to solve this problem.

Signed-off-by: David Calavera <david.calavera@gmail.com>