### PR TITLE
Undo most of the previous clang-format config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,7 +2,7 @@
 Language:        Cpp
 AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: true
+AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
 AlignEscapedNewlinesLeft: true
 AlignOperands:   true

--- a/lib/ts/apidefs.h.in
+++ b/lib/ts/apidefs.h.in
@@ -143,6 +143,7 @@ typedef enum { TS_HTTP_TYPE_UNKNOWN, TS_HTTP_TYPE_REQUEST, TS_HTTP_TYPE_RESPONSE
     the TSHttpStatus of a response header using TSHttpHdrStatusSet().
 
  */
+/* clang-format off */
 typedef enum {
   TS_HTTP_STATUS_NONE                            = 0,
   TS_HTTP_STATUS_CONTINUE                        = 100,
@@ -202,6 +203,7 @@ typedef enum {
   TS_HTTP_STATUS_NOT_EXTENDED                    = 510,
   TS_HTTP_STATUS_NETWORK_AUTHENTICATION_REQUIRED = 511
 } TSHttpStatus;
+  /* clang-format on */
 
 /**
     This set of enums represents the possible hooks where you can
@@ -363,6 +365,7 @@ typedef enum {
     the handler function can decide what to do.
 
  */
+/* clang-format off */
 typedef enum {
   TS_EVENT_NONE                                 = 0,
   TS_EVENT_IMMEDIATE                            = 1,
@@ -443,6 +446,7 @@ typedef enum {
   TS_EVENT_INTERNAL_60202                       = 60202
 } TSEvent;
 #define TS_EVENT_HTTP_READ_REQUEST_PRE_REMAP TS_EVENT_HTTP_PRE_REMAP /* backwards compat */
+/* clang-format on */
 
 typedef enum {
   TS_SRVSTATE_STATE_UNDEFINED = 0,
@@ -501,6 +505,7 @@ typedef enum {
 
 typedef enum { TS_VC_CLOSE_ABORT = -1, TS_VC_CLOSE_NORMAL = 1 } TSVConnCloseFlags;
 
+/* clang-format off */
 typedef enum {
   TS_IOBUFFER_SIZE_INDEX_128  = 0,
   TS_IOBUFFER_SIZE_INDEX_256  = 1,
@@ -518,6 +523,7 @@ typedef enum {
   TS_IOBUFFER_SIZE_INDEX_1M   = 13,
   TS_IOBUFFER_SIZE_INDEX_2M   = 14
 } TSIOBufferSizeIndex;
+/* clang-format on */
 
 typedef enum { TS_ERROR = -1, TS_SUCCESS = 0 } TSReturnCode;
 
@@ -542,6 +548,7 @@ typedef enum { TS_SERVER_SESSION_SHARING_POOL_GLOBAL, TS_SERVER_SESSION_SHARING_
 /* librecords types */
 
 /* The values of this enum must match enum RecT in I_RecDefs.h */
+/* clang-format off */
 typedef enum {
   TS_RECORDTYPE_NULL    = 0x00,
   TS_RECORDTYPE_CONFIG  = 0x01,
@@ -552,6 +559,7 @@ typedef enum {
   TS_RECORDTYPE_PLUGIN  = 0x20,
   TS_RECORDTYPE_ALL     = 0x3F
 } TSRecordType;
+/* clang-format on */
 
 /* The values of this enum must match enum RecDataT in I_RecDefs.h */
 typedef enum {


### PR DESCRIPTION
It retains the nicely formatted apidefs.h though.