### PR TITLE
TS-4570: Return to TS_HTTP_OS_DNS_HOOK if server address is set.

### DIFF
--- a/doc/developer-guide/api/functions/TSHttpTxnServerAddrGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnServerAddrGet.en.rst
@@ -38,3 +38,9 @@ Get the origin server address for transaction :arg:`txnp`.
    The pointer is valid only for the current callback. Clients that
    need to keep the value across callbacks must maintain their own
    storage.
+
+See Also
+========
+
+:manpage:`TSAPI(3ts)`,
+:manpage:`TSHttpTxnServerAddrSet(3ts)`

--- a/doc/developer-guide/api/functions/TSHttpTxnServerAddrSet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnServerAddrSet.en.rst
@@ -35,8 +35,32 @@ Set the origin server address for transaction :arg:`txnp`. This includes the por
 The address family is also set by the contents of :arg:`addr`. The address data is copied out of
 :arg:`addr` so there is no dependency on the lifetime of that object.
 
-This hook must be called no later than TS_HTTP_OS_DNS_HOOK. If this is called then DNS resolution
-will not be done as the address of the server is already know.
+This hook must be called no later than TS_HTTP_OS_DNS_HOOK. If this
+is called prior to TS_HTTP_OS_DNS_HOOK, DNS resolution will not be
+done as the address of the server is already known.
 
-An error value is returned if :arg:`addr` does not contain a valid IPv4 or IPv6 address with a valid
-(non-zero) port.
+Return Value
+============
+
+:data:`TS_ERROR` is returned if :arg:`addr` does not contain a valid
+IPv4 or IPv6 address with a valid (non-zero) port.
+
+Notes
+=====
+
+If |TS| is configured to retry connections to origin servers and
+:func:`TSHttpTxnServerAddrGet` has been called, |TS| will return
+to TS_HTTP_OS_DNS_HOOK so to let the plugin set a different server
+address. Plugins should be prepared for TS_HTTP_OS_DNS_HOOK and any
+subsequent hooks to be called multiple times.
+
+Once a plugin calls :func:`TSHttpTxnServerAddrGet` any prior DNS
+resolution results are lost. The plugin should use
+:func:`TSHttpTxnServerAddrGet` to preserve any DNS Results that
+might need.
+
+See Also
+========
+
+:manpage:`TSAPI(3ts)`,
+:manpage:`TSHttpTxnServerAddrGet(3ts)`


### PR DESCRIPTION
Using HostDB, Traffic Server will try to connect to all the resolved
IP addresses if the connection fail. However if a plugin sets the
address using some out-of-band knowledge and TSHttpTxnServerAddrSet,
it onlt gets to set the address once.

This change returns the state machine to the OS_DNS_HOOK API callout
so that the plugin can have an opportunity to set a different server
address.