### PR TITLE
TS-4588: Require braces around statements.

### DIFF
--- a/cmd/traffic_cop/traffic_cop.cc
+++ b/cmd/traffic_cop/traffic_cop.cc
@@ -456,8 +456,9 @@ transient_error(int error, int wait_ms)
 #if defined(ENOSR) && !defined(freebsd) && !defined(darwin)
   case ENOSR:
 #endif
-    if (wait_ms)
+    if (wait_ms) {
       millisleep(wait_ms);
+    }
     break;
 
   default:
@@ -491,10 +492,11 @@ config_read_string(const char *name, char *val, size_t val_len, bool miss_ok = f
 
   config = configTable.find(name);
   if (config == configTable.end()) {
-    if (miss_ok)
+    if (miss_ok) {
       return;
-    else
+    } else {
       goto ConfigStrFatalError;
+    }
   }
 
   if (config->second.data_type != RECD_STRING) {
@@ -516,10 +518,11 @@ config_read_int(const char *name, int *val, bool miss_ok = false)
 
   config = configTable.find(name);
   if (config == configTable.end()) {
-    if (miss_ok)
+    if (miss_ok) {
       return;
-    else
+    } else {
       goto ConfigIntFatalError;
+    }
   }
 
   if (config->second.data_type != RECD_INT) {
@@ -675,8 +678,9 @@ get_admin_user()
 {
   struct passwd *pwd = NULL;
 
-  if (!admin_user)
+  if (!admin_user) {
     admin_user = (char *)ats_malloc(MAX_LOGIN);
+  }
 
   config_read_string("proxy.config.admin.user_id", admin_user, MAX_LOGIN);
 
@@ -684,8 +688,9 @@ get_admin_user()
     char *end = admin_user + strlen(admin_user) - 1;
 
     // Trim trailing spaces.
-    while (end >= admin_user && isspace(*end))
+    while (end >= admin_user && isspace(*end)) {
       end--;
+    }
     *(end + 1) = '\0';
 
     if (*admin_user == '#') {
@@ -1149,8 +1154,9 @@ test_mgmt_cli_port()
     }
   }
 
-  if (val)
+  if (val) {
     TSfree(val);
+  }
   return ret;
 }
 
@@ -1232,8 +1238,9 @@ heartbeat_manager()
   cop_log_trace("Entering heartbeat_manager()\n");
   // the CLI, and the rsport if cluster is enabled.
   err = test_mgmt_cli_port();
-  if ((0 == err) && (cluster_type != NO_CLUSTER))
+  if ((0 == err) && (cluster_type != NO_CLUSTER)) {
     err = test_rs_port();
+  }
 
   if (err < 0) {
     // See heartbeat_server()'s comments for how we determine a server/manager failure.
@@ -1292,8 +1299,9 @@ heartbeat_server()
       millisleep(init_sleep_time * 1000);
     }
   } else {
-    if (server_failures)
+    if (server_failures) {
       cop_log(COP_WARNING, "server heartbeat succeeded\n");
+    }
     server_failures = 0;
   }
 

--- a/cmd/traffic_manager/WebOverview.cc
+++ b/cmd/traffic_manager/WebOverview.cc
@@ -249,8 +249,9 @@ overviewRecord::readData(RecDataT varType, const char *name, bool *found)
     } else {
       Fatal("node variables '%s' not found!\n", name);
     }
-  } else
+  } else {
     rec_status = RecGetRecord_Xmalloc(name, varType, &rec, true);
+  }
 
   if (found) {
     *found = (rec_status == REC_ERR_OKAY);
@@ -265,8 +266,9 @@ overviewRecord::varFloatFromName(const char *name, MgmtFloat *value)
 {
   bool found = false;
 
-  if (value)
+  if (value) {
     *value = readFloat((char *)name, &found);
+  }
 
   return found;
 }

--- a/cmd/traffic_manager/traffic_manager.cc
+++ b/cmd/traffic_manager/traffic_manager.cc
@@ -136,12 +136,14 @@ rotateLogs()
     // synced across processes
     mgmt_log("Sending SIGUSR2 to TS");
     pid_t tspid = lmgmt->watched_process_pid;
-    if (tspid <= 0)
+    if (tspid <= 0) {
       return;
-    if (kill(tspid, SIGUSR2) != 0)
+    }
+    if (kill(tspid, SIGUSR2) != 0) {
       mgmt_log("Could not send SIGUSR2 to TS: %s", strerror(errno));
-    else
+    } else {
       mgmt_log("Succesfully sent SIGUSR2 to TS!");
+    }
   }
 }
 
@@ -483,11 +485,13 @@ main(int argc, const char **argv)
   // Line buffer standard output & standard error
   int status;
   status = setvbuf(stdout, NULL, _IOLBF, 0);
-  if (status != 0)
+  if (status != 0) {
     perror("WARNING: can't line buffer stdout");
+  }
   status = setvbuf(stderr, NULL, _IOLBF, 0);
-  if (status != 0)
+  if (status != 0) {
     perror("WARNING: can't line buffer stderr");
+  }
 
   initSignalHandlers();
 
@@ -554,8 +558,9 @@ main(int argc, const char **argv)
   diags->set_stdout_output(bind_stdout);
   diags->set_stderr_output(bind_stderr);
 
-  if (is_debug_tag_set("diags"))
+  if (is_debug_tag_set("diags")) {
     diags->dump();
+  }
   diags->cleanup_func = mgmt_cleanup;
 
   // Setup the exported manager version records.

--- a/cmd/traffic_top/traffic_top.cc
+++ b/cmd/traffic_top/traffic_top.cc
@@ -112,8 +112,9 @@ prettyPrint(const int x, const int y, const double number, const int type)
       color = colorPair::green;
     }
     snprintf(buffer, sizeof(buffer), "%6.1f%%%%", (double)my_number);
-  } else
+  } else {
     snprintf(buffer, sizeof(buffer), "%6.1f%c", (double)my_number, exp);
+  }
   attron(COLOR_PAIR(color));
   attron(A_BOLD);
   mvprintw(y, x, buffer);
@@ -253,8 +254,9 @@ help(const string &host, const string &version)
     attroff(A_BOLD);
     refresh();
     int x = getch();
-    if (x == 'b')
+    if (x == 'b') {
       break;
+    }
   }
 }
 

--- a/cmd/traffic_via/traffic_via.cc
+++ b/cmd/traffic_via/traffic_via.cc
@@ -293,8 +293,9 @@ filterViaHeader()
       pcre_exec(compiledReg, extraReg, viaHeader, (int)sizeof(viaHeader), 0, 0, subStringVector, SUBSTRING_VECTOR_COUNT);
 
     // Match failed, don't worry. Continue to next line.
-    if (pcreExecCode < 0)
+    if (pcreExecCode < 0) {
       continue;
+    }
 
     // Match successful, but too many substrings
     if (pcreExecCode == 0) {

--- a/example/cache-scan/cache-scan.cc
+++ b/example/cache-scan/cache-scan.cc
@@ -217,11 +217,13 @@ cleanup(TSCont contp)
   if (cstate) {
     // cancel any pending cache scan actions, since we will be destroying the
     // continuation
-    if (cstate->pending_action)
+    if (cstate->pending_action) {
       TSActionCancel(cstate->pending_action);
+    }
 
-    if (cstate->net_vc)
+    if (cstate->net_vc) {
       TSVConnShutdown(cstate->net_vc, 1, 1);
+    }
 
     if (cstate->req_buffer) {
       TSIOBufferDestroy(cstate->req_buffer);
@@ -423,8 +425,9 @@ setup_request(TSCont contp, TSHttpTxn txnp)
       start = strstr(querybuf, "remove_url=");
       if (start && (start == querybuf || *(start - 1) == '&')) {
         start += 11;
-        if ((end = strstr(start, "&")) != NULL)
-          *end      = '\0';
+        if ((end = strstr(start, "&")) != NULL) {
+          *end = '\0';
+        }
         del_url_len = unescapifyStr(start);
         end         = start + del_url_len;
 

--- a/example/remap/remap.cc
+++ b/example/remap/remap.cc
@@ -73,9 +73,10 @@ remap_entry::remap_entry(int _argc, char *_argv[]) : next(NULL), argc(0), argv(N
 
   if (_argc > 0 && _argv && (argv = (char **)TSmalloc(sizeof(char *) * (_argc + 1))) != 0) {
     argc = _argc;
-    for (i    = 0; i < argc; i++)
+    for (i = 0; i < argc; i++) {
       argv[i] = TSstrdup(_argv[i]);
-    argv[i]   = NULL;
+    }
+    argv[i] = NULL;
   }
 }
 
@@ -85,8 +86,9 @@ remap_entry::~remap_entry()
   int i;
 
   if (argc && argv) {
-    for (i = 0; i < argc; i++)
+    for (i = 0; i < argc; i++) {
       TSfree(argv[i]);
+    }
     TSfree(argv);
   }
 }
@@ -254,8 +256,9 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
   remap_entry *ri = (remap_entry *)ih;
   fprintf(stderr, "Remap Plugin: TSRemapDoRemap()\n");
 
-  if (!ri || !rri)
+  if (!ri || !rri) {
     return TSREMAP_NO_REMAP; /* TS must remap this request */
+  }
 
   fprintf(stderr, "[TSRemapDoRemap] From: \"%s\"  To: \"%s\"\n", ri->argv[0], ri->argv[1]);
 
@@ -322,20 +325,24 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
     char new_path[8192];
 
     // Ugly, but so is the rest of this "example"
-    if (len2 + 7 >= 8192)
+    if (len2 + 7 >= 8192) {
       return TSREMAP_NO_REMAP;
+    }
 
-    if (TSUrlPortSet(rri->requestBufp, rri->mapToUrl, TSUrlPortGet(rri->requestBufp, rri->mapToUrl)) != TS_SUCCESS)
+    if (TSUrlPortSet(rri->requestBufp, rri->mapToUrl, TSUrlPortGet(rri->requestBufp, rri->mapToUrl)) != TS_SUCCESS) {
       return TSREMAP_NO_REMAP;
+    }
 
-    if (TSUrlHostSet(rri->requestBufp, rri->requestUrl, "foo.bar.com", 11) != TS_SUCCESS)
+    if (TSUrlHostSet(rri->requestBufp, rri->requestUrl, "foo.bar.com", 11) != TS_SUCCESS) {
       return TSREMAP_NO_REMAP;
+    }
 
     memcpy(new_path, "47_copy", 7);
     memcpy(&new_path[7], &temp2[2], len2 - 2);
 
-    if (TSUrlPathSet(rri->requestBufp, rri->requestUrl, new_path, len2 + 5) == TS_SUCCESS)
+    if (TSUrlPathSet(rri->requestBufp, rri->requestUrl, new_path, len2 + 5) == TS_SUCCESS) {
       return TSREMAP_DID_REMAP;
+    }
   }
 
   // Failure ...
@@ -349,8 +356,9 @@ TSRemapOSResponse(void *ih ATS_UNUSED, TSHttpTxn rh, int os_response_type)
   int request_id = -1;
   void *data     = TSHttpTxnArgGet((TSHttpTxn)rh, arg_index); // read counter (we store it in TSRemapDoRemap function call)
 
-  if (data)
+  if (data) {
     request_id = *((int *)data);
+  }
   fprintf(stderr, "[TSRemapOSResponse] Read processing counter %d from request processing block\n", request_id);
   fprintf(stderr, "[TSRemapOSResponse] OS response status: %d\n", os_response_type);
 }

--- a/iocore/aio/AIO.cc
+++ b/iocore/aio/AIO.cc
@@ -245,10 +245,11 @@ aio_init_fildes(int fildes, int fromAPI = 0)
 
   REC_ReadConfigInteger(stacksize, "proxy.config.thread.default.stacksize");
   for (i = 0; i < thread_num; i++) {
-    if (i == (thread_num - 1))
+    if (i == (thread_num - 1)) {
       thr_info = new AIOThreadInfo(request, 1);
-    else
+    } else {
       thr_info = new AIOThreadInfo(request, 0);
+    }
     snprintf(thr_name, MAX_THREAD_NAME_LENGTH, "[ET_AIO %d:%d]", i, fildes);
     ink_assert(eventProcessor.spawn_thread(thr_info, thr_name, stacksize));
   }
@@ -273,10 +274,11 @@ aio_insert(AIOCallback *op, AIO_Reqs *req)
   if (op->aiocb.aio_reqprio == AIO_LOWEST_PRIORITY) // http request
   {
     AIOCallback *cb = (AIOCallback *)req->http_aio_todo.tail;
-    if (!cb)
+    if (!cb) {
       req->http_aio_todo.push(op);
-    else
+    } else {
       req->http_aio_todo.insert(op, cb);
+    }
   } else {
     AIOCallback *cb = (AIOCallback *)req->aio_todo.tail;
 
@@ -298,8 +300,9 @@ aio_move(AIO_Reqs *req)
 {
   AIOCallback *next = NULL, *prev = NULL, *cb = (AIOCallback *)ink_atomiclist_popall(&req->aio_temp_list);
   /* flip the list */
-  if (!cb)
+  if (!cb) {
     return;
+  }
   while (cb->link.next) {
     next          = (AIOCallback *)cb->link.next;
     cb->link.next = prev;
@@ -352,8 +355,9 @@ aio_queue_req(AIOCallbackInternal *op, int fromAPI = 0)
             break;
           }
         }
-        if (!req)
+        if (!req) {
           req = aio_init_fildes(op->aiocb.aio_fildes);
+        }
       }
       ink_mutex_release(&insert_mutex);
     }
@@ -380,8 +384,9 @@ aio_queue_req(AIOCallbackInternal *op, int fromAPI = 0)
 #ifdef AIO_STATS
     ink_atomic_increment(&data->num_queue, 1);
 #endif
-    if (!INK_ATOMICLIST_EMPTY(req->aio_temp_list))
+    if (!INK_ATOMICLIST_EMPTY(req->aio_temp_list)) {
       aio_move(req);
+    }
     /* now put the new request */
     aio_insert(op, req);
     ink_cond_signal(&req->aio_cond);
@@ -399,10 +404,11 @@ cache_op(AIOCallbackInternal *op)
 
     while (a->aio_nbytes - res > 0) {
       do {
-        if (read)
+        if (read) {
           err = pread(a->aio_fildes, ((char *)a->aio_buf) + res, a->aio_nbytes - res, a->aio_offset + res);
-        else
+        } else {
           err = pwrite(a->aio_fildes, ((char *)a->aio_buf) + res, a->aio_nbytes - res, a->aio_offset + res);
+        }
       } while ((err < 0) && (errno == EINTR || errno == ENOBUFS || errno == ENOMEM));
       if (err <= 0) {
         Warning("cache disk operation failed %s %zd %d\n", (a->aio_lio_opcode == LIO_READ) ? "READ" : "WRITE", err, errno);
@@ -462,10 +468,12 @@ aio_thread_main(void *arg)
       }
       current_req = my_aio_req;
       /* check if any pending requests on the atomic list */
-      if (!INK_ATOMICLIST_EMPTY(my_aio_req->aio_temp_list))
+      if (!INK_ATOMICLIST_EMPTY(my_aio_req->aio_temp_list)) {
         aio_move(my_aio_req);
-      if (!(op = my_aio_req->aio_todo.pop()) && !(op = my_aio_req->http_aio_todo.pop()))
+      }
+      if (!(op = my_aio_req->aio_todo.pop()) && !(op = my_aio_req->http_aio_todo.pop())) {
         break;
+      }
 #ifdef AIO_STATS
       num_requests--;
       current_req->queued--;
@@ -498,12 +506,14 @@ aio_thread_main(void *arg)
       op->mutex     = op->action.mutex;
       if (op->thread == AIO_CALLBACK_THREAD_AIO) {
         SCOPED_MUTEX_LOCK(lock, op->mutex, thr_info->mutex->thread_holding);
-        if (!op->action.cancelled)
+        if (!op->action.cancelled) {
           op->action.continuation->handleEvent(AIO_EVENT_DONE, op);
-      } else if (op->thread == AIO_CALLBACK_THREAD_ANY)
+        }
+      } else if (op->thread == AIO_CALLBACK_THREAD_ANY) {
         eventProcessor.schedule_imm_signal(op);
-      else
+      } else {
         op->thread->schedule_imm_signal(op);
+      }
       ink_mutex_acquire(&my_aio_req->aio_mutex);
     } while (1);
     timespec timedwait_msec = ink_hrtime_to_timespec(Thread::get_hrtime_updated() + HRTIME_MSECONDS(net_config_poll_timeout));

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -213,10 +213,11 @@ cache_bytes_used(int volume)
 
   for (int i = 0; i < gnvol; i++) {
     if (!DISK_BAD(gvol[i]->disk) && (volume == -1 || gvol[i]->cache_vol->vol_number == volume)) {
-      if (!gvol[i]->header->cycle)
+      if (!gvol[i]->header->cycle) {
         used += gvol[i]->header->write_pos - gvol[i]->start;
-      else
+      } else {
         used += gvol[i]->len - vol_dirlen(gvol[i]) - EVACUATION_SIZE;
+      }
     }
   }
 
@@ -330,8 +331,9 @@ CacheVC::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *abuf)
 #ifdef DEBUG
   ink_assert(c->mutex->thread_holding);
 #endif
-  if (!trigger && !recursive)
+  if (!trigger && !recursive) {
     trigger = c->mutex->thread_holding->schedule_imm_local(this);
+  }
   return &vio;
 }
 
@@ -348,8 +350,9 @@ CacheVC::do_io_pread(Continuation *c, int64_t nbytes, MIOBuffer *abuf, int64_t o
 #ifdef DEBUG
   ink_assert(c->mutex->thread_holding);
 #endif
-  if (!trigger && !recursive)
+  if (!trigger && !recursive) {
     trigger = c->mutex->thread_holding->schedule_imm_local(this);
+  }
   return &vio;
 }
 
@@ -366,8 +369,9 @@ CacheVC::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *abuf, bool
 #ifdef DEBUG
   ink_assert(c->mutex->thread_holding);
 #endif
-  if (!trigger && !recursive)
+  if (!trigger && !recursive) {
     trigger = c->mutex->thread_holding->schedule_imm_local(this);
+  }
   return &vio;
 }
 
@@ -378,8 +382,9 @@ CacheVC::do_io_close(int alerrno)
   int previous_closed = closed;
   closed              = (alerrno == -1) ? 1 : -1; // Stupid default arguments
   DDebug("cache_close", "do_io_close %p %d %d", this, alerrno, closed);
-  if (!previous_closed && !recursive)
+  if (!previous_closed && !recursive) {
     die();
+  }
 }
 
 void
@@ -413,8 +418,9 @@ CacheVC::reenable_re(VIO *avio)
   if (!trigger) {
     if (!is_io_in_progress() && !recursive) {
       handleEvent(EVENT_NONE, (void *)0);
-    } else
+    } else {
       trigger = avio->mutex->thread_holding->schedule_imm_local(this);
+    }
   }
 }
 
@@ -473,12 +479,14 @@ CacheVC::set_http_info(CacheHTTPInfo *ainfo)
   }
   if (enable_cache_empty_http_doc) {
     MIMEField *field = ainfo->m_alt->m_response_hdr.field_find(MIME_FIELD_CONTENT_LENGTH, MIME_LEN_CONTENT_LENGTH);
-    if (field && !field->value_get_int64())
+    if (field && !field->value_get_int64()) {
       f.allow_empty_doc = 1;
-    else
+    } else {
       f.allow_empty_doc = 0;
-  } else
+    }
+  } else {
     f.allow_empty_doc = 0;
+  }
   alternate.copy_shallow(ainfo);
   ainfo->clear();
 }
@@ -529,15 +537,18 @@ Vol::begin_read(CacheVC *cont)
   stat_cache_vcs.enqueue(cont, cont->stat_link);
 #endif
   // no need for evacuation as the entire document is already in memory
-  if (cont->f.single_fragment)
+  if (cont->f.single_fragment) {
     return 0;
+  }
   int i = dir_evac_bucket(&cont->earliest_dir);
   EvacuationBlock *b;
   for (b = evacuate[i].head; b; b = b->link.next) {
-    if (dir_offset(&b->dir) != dir_offset(&cont->earliest_dir))
+    if (dir_offset(&b->dir) != dir_offset(&cont->earliest_dir)) {
       continue;
-    if (b->readers)
+    }
+    if (b->readers) {
       b->readers = b->readers + 1;
+    }
     return 0;
   }
   // we don't actually need to preserve this block as it is already in
@@ -557,8 +568,9 @@ Vol::close_read(CacheVC *cont)
   EThread *t = cont->mutex->thread_holding;
   ink_assert(t == this_ethread());
   ink_assert(t == mutex->thread_holding);
-  if (dir_is_empty(&cont->earliest_dir))
+  if (dir_is_empty(&cont->earliest_dir)) {
     return 1;
+  }
   int i = dir_evac_bucket(&cont->earliest_dir);
   EvacuationBlock *b;
   for (b = evacuate[i].head; b;) {
@@ -662,8 +674,9 @@ CacheProcessor::start_internal(int flags)
     int fd         = open(path, opts, 0644);
     int64_t blocks = sd->blocks;
 
-    if (fd < 0 && (opts & O_CREAT)) // Try without O_DIRECT if this is a file on filesystem, e.g. tmpfs.
+    if (fd < 0 && (opts & O_CREAT)) { // Try without O_DIRECT if this is a file on filesystem, e.g. tmpfs.
       fd = open(path, DEFAULT_CACHE_OPTIONS | O_CREAT, 0644);
+    }
 
     if (fd >= 0) {
       if (!sd->file_pathname) {
@@ -689,11 +702,13 @@ CacheProcessor::start_internal(int flags)
         int sector_size = sd->hw_sector_size;
 
         gdisks[gndisks] = new CacheDisk();
-        if (check)
-          gdisks[gndisks]->read_only_p     = true;
+        if (check) {
+          gdisks[gndisks]->read_only_p = true;
+        }
         gdisks[gndisks]->forced_volume_num = sd->forced_volume_num;
-        if (sd->hash_base_string)
+        if (sd->hash_base_string) {
           gdisks[gndisks]->hash_base_string = ats_strdup(sd->hash_base_string);
+        }
 
         Debug("cache_hosting", "Disk: %d, blocks: %" PRId64 "", gndisks, blocks);
 
@@ -720,10 +735,11 @@ CacheProcessor::start_internal(int flags)
         gndisks++;
       }
     } else {
-      if (errno == EINVAL)
+      if (errno == EINVAL) {
         Warning("cache unable to open '%s': It must be placed on a file system that supports direct I/O.", path);
-      else
+      } else {
         Warning("cache unable to open '%s': %s", path, strerror(errno));
+      }
     }
     if (fd >= 0) {
       close(fd);
@@ -735,8 +751,9 @@ CacheProcessor::start_internal(int flags)
   if (gndisks == 0) {
     CacheProcessor::initialized = CACHE_INIT_FAILED;
     // Have to do this here because no IO events were scheduled and so @c diskInitialized() won't be called.
-    if (cb_after_init)
+    if (cb_after_init) {
       cb_after_init();
+    }
 
     if (this->waitForCache() > 1) {
       Fatal("Cache initialization failed - no disks available but cache required");
@@ -746,8 +763,9 @@ CacheProcessor::start_internal(int flags)
     }
   } else if (this->waitForCache() == 3 && static_cast<unsigned int>(gndisks) < theCacheStore.n_disks_in_config) {
     CacheProcessor::initialized = CACHE_INIT_FAILED;
-    if (cb_after_init)
+    if (cb_after_init) {
       cb_after_init();
+    }
     Fatal("Cache initialization failed - only %d out of %d disks were valid and all were required.", gndisks,
           theCacheStore.n_disks_in_config);
   }
@@ -764,8 +782,9 @@ CacheProcessor::diskInitialized()
   if (n_init == gndisks - 1) {
     int i;
     for (i = 0; i < gndisks; i++) {
-      if (DISK_BAD(gdisks[i]))
+      if (DISK_BAD(gdisks[i])) {
         bad_disks++;
+      }
     }
 
     if (bad_disks != 0) {
@@ -774,17 +793,19 @@ CacheProcessor::diskInitialized()
         // This could be passed off to @c cacheInitialized (as with volume config problems) but I think
         // the more specific error message here is worth the extra code.
         CacheProcessor::initialized = CACHE_INIT_FAILED;
-        if (cb_after_init)
+        if (cb_after_init) {
           cb_after_init();
+        }
         Fatal("Cache initialization failed - only %d of %d disks were available.", gndisks, theCacheStore.n_disks_in_config);
       }
 
       // still good, create a new array to hold the valid disks.
       CacheDisk **p_good_disks;
-      if ((gndisks - bad_disks) > 0)
+      if ((gndisks - bad_disks) > 0) {
         p_good_disks = (CacheDisk **)ats_malloc((gndisks - bad_disks) * sizeof(CacheDisk *));
-      else
+      } else {
         p_good_disks = 0;
+      }
 
       int insert_at = 0;
       for (i = 0; i < gndisks; i++) {
@@ -845,8 +866,9 @@ CacheProcessor::diskInitialized()
                 d->header->vol_info[j].len, d->header->vol_info[j].free);
         }
       }
-      if (!check)
+      if (!check) {
         d->sync();
+      }
     }
     if (config_volumes.num_volumes == 0) {
       theCache         = new Cache();
@@ -873,8 +895,9 @@ CacheProcessor::cacheInitialized()
 {
   int i;
 
-  if ((theCache && (theCache->ready == CACHE_INITIALIZING)) || (theStreamCache && (theStreamCache->ready == CACHE_INITIALIZING)))
+  if ((theCache && (theCache->ready == CACHE_INITIALIZING)) || (theStreamCache && (theStreamCache->ready == CACHE_INITIALIZING))) {
     return;
+  }
   int caches_ready  = 0;
   int cache_init_ok = 0;
   /* allocate ram size in proportion to the disk space the
@@ -923,15 +946,18 @@ CacheProcessor::cacheInitialized()
   }
 
   // Update stripe version data.
-  if (gnvol) // start with whatever the first stripe is.
+  if (gnvol) { // start with whatever the first stripe is.
     cacheProcessor.min_stripe_version = cacheProcessor.max_stripe_version = gvol[0]->header->version;
+  }
   // scan the rest of the stripes.
   for (i = 1; i < gnvol; i++) {
     Vol *v = gvol[i];
-    if (v->header->version < cacheProcessor.min_stripe_version)
+    if (v->header->version < cacheProcessor.min_stripe_version) {
       cacheProcessor.min_stripe_version = v->header->version;
-    if (cacheProcessor.max_stripe_version < v->header->version)
+    }
+    if (cacheProcessor.max_stripe_version < v->header->version) {
       cacheProcessor.max_stripe_version = v->header->version;
+    }
   }
 
   if (caches_ready) {
@@ -1051,11 +1077,13 @@ CacheProcessor::cacheInitialized()
       GLOBAL_CACHE_SET_DYN_STAT(cache_bytes_total_stat, total_cache_bytes);
       GLOBAL_CACHE_SET_DYN_STAT(cache_direntries_total_stat, total_direntries);
       GLOBAL_CACHE_SET_DYN_STAT(cache_direntries_used_stat, used_direntries);
-      if (!check)
+      if (!check) {
         dir_sync_init();
+      }
       cache_init_ok = 1;
-    } else
+    } else {
       Warning("cache unable to open any vols, disabled");
+    }
   }
   if (cache_init_ok) {
     // Initialize virtual cache
@@ -1074,8 +1102,9 @@ CacheProcessor::cacheInitialized()
   }
 
   // Fire callback to signal initialization finished.
-  if (cb_after_init)
+  if (cb_after_init) {
     cb_after_init();
+  }
 
   // TS-3848
   if (CACHE_INIT_FAILED == CacheProcessor::initialized && cacheProcessor.waitForCache() > 1) {
@@ -1091,16 +1120,18 @@ CacheProcessor::stop()
 int
 CacheProcessor::dir_check(bool afix)
 {
-  for (int i = 0; i < gnvol; i++)
+  for (int i = 0; i < gnvol; i++) {
     gvol[i]->dir_check(afix);
+  }
   return 0;
 }
 
 int
 CacheProcessor::db_check(bool afix)
 {
-  for (int i = 0; i < gnvol; i++)
+  for (int i = 0; i < gnvol; i++) {
     gvol[i]->db_check(afix);
+  }
   return 0;
 }
 
@@ -1144,9 +1175,10 @@ CacheProcessor::open_write(Continuation *cont, CacheKey *key, bool cluster_cache
 #ifdef CLUSTER_CACHE
   if (cache_clustering_enabled > 0 && !cluster_cache_local) {
     ClusterMachine *m = cluster_machine_at_depth(cache_hash(*key));
-    if (m)
+    if (m) {
       return Cluster_write(cont, expected_size, (MIOBuffer *)0, m, key, frag_type, options, pin_in_cache, CACHE_OPEN_WRITE,
                            (CacheHTTPHdr *)0, (CacheHTTPInfo *)0, hostname, host_len);
+    }
   }
 #endif
   return caches[frag_type]->open_write(cont, key, frag_type, options, pin_in_cache, hostname, host_len);
@@ -1230,8 +1262,9 @@ CacheProcessor::IsCacheEnabled()
 bool
 CacheProcessor::IsCacheReady(CacheFragType type)
 {
-  if (IsCacheEnabled() != CACHE_INITIALIZED)
+  if (IsCacheEnabled() != CACHE_INITIALIZED) {
     return 0;
+  }
   return (bool)(cache_ready & (1 << type));
 }
 
@@ -1374,10 +1407,12 @@ Vol::init(char *s, off_t blocks, off_t dir_skip, bool clear)
         (double)vol_dirlen(this) / (double)this->len * 100.0);
 
   raw_dir = NULL;
-  if (ats_hugepage_enabled())
+  if (ats_hugepage_enabled()) {
     raw_dir = (char *)ats_alloc_hugepage(vol_dirlen(this));
-  if (raw_dir == NULL)
+  }
+  if (raw_dir == NULL) {
     raw_dir = (char *)ats_memalign(ats_pagesize(), vol_dirlen(this));
+  }
 
   dir    = (Dir *)(raw_dir + vol_headerlen(this));
   header = (VolHeaderFooter *)raw_dir;
@@ -1393,8 +1428,9 @@ Vol::init(char *s, off_t blocks, off_t dir_skip, bool clear)
   off_t footer_offset = vol_dirlen(this) - footerlen;
   // try A
   off_t as = skip;
-  if (is_debug_tag_set("cache_init"))
+  if (is_debug_tag_set("cache_init")) {
     Note("reading directory '%s'", hash_text.get());
+  }
   SET_HANDLER(&Vol::handle_header_read);
   init_info->vol_aio[0].aiocb.aio_offset = as;
   init_info->vol_aio[1].aiocb.aio_offset = as + footer_offset;
@@ -1543,8 +1579,9 @@ Vol::handle_recover_from_data(int event, void * /* data ATS_UNUSED */)
     }
     io.aiocb.aio_buf    = (char *)ats_memalign(ats_pagesize(), RECOVERY_SIZE);
     io.aiocb.aio_nbytes = RECOVERY_SIZE;
-    if ((off_t)(recover_pos + io.aiocb.aio_nbytes) > (off_t)(skip + len))
+    if ((off_t)(recover_pos + io.aiocb.aio_nbytes) > (off_t)(skip + len)) {
       io.aiocb.aio_nbytes = (skip + len) - recover_pos;
+    }
   } else if (event == AIO_EVENT_DONE) {
     if ((size_t)io.aiocb.aio_nbytes != (size_t)io.aio_result) {
       Warning("disk read error on recover '%s', clearing", hash_text.get());
@@ -1567,8 +1604,9 @@ Vol::handle_recover_from_data(int event, void * /* data ATS_UNUSED */)
           goto Lclear;
         }
         done += round_to_approx_size(doc->len);
-        if (doc->sync_serial > last_write_serial)
+        if (doc->sync_serial > last_write_serial) {
           last_sync_serial = doc->sync_serial;
+        }
       }
       ink_assert(done == to_check);
 
@@ -1600,8 +1638,9 @@ Vol::handle_recover_from_data(int event, void * /* data ATS_UNUSED */)
 
       if (doc->magic != DOC_MAGIC || doc->sync_serial != last_sync_serial) {
         if (doc->magic == DOC_MAGIC) {
-          if (doc->sync_serial > header->sync_serial)
+          if (doc->sync_serial > header->sync_serial) {
             max_sync_serial = doc->sync_serial;
+          }
 
           /*
              doc->magic == DOC_MAGIC, but doc->sync_serial != last_sync_serial
@@ -1675,20 +1714,23 @@ Vol::handle_recover_from_data(int event, void * /* data ATS_UNUSED */)
     if (s >= e) {
       /* In the last iteration, we increment s by doc->len...need to undo
          that change */
-      if (s > e)
+      if (s > e) {
         s -= round_to_approx_size(doc->len);
+      }
       recover_pos -= e - s;
       if (recover_pos >= skip + len) {
         recover_wrapped = 1;
         recover_pos     = start;
       }
       io.aiocb.aio_nbytes = RECOVERY_SIZE;
-      if ((off_t)(recover_pos + io.aiocb.aio_nbytes) > (off_t)(skip + len))
+      if ((off_t)(recover_pos + io.aiocb.aio_nbytes) > (off_t)(skip + len)) {
         io.aiocb.aio_nbytes = (skip + len) - recover_pos;
+      }
     }
   }
-  if (recover_pos == prev_recover_pos) // this should never happen, but if it does break the loop
+  if (recover_pos == prev_recover_pos) { // this should never happen, but if it does break the loop
     goto Lclear;
+  }
   prev_recover_pos    = recover_pos;
   io.aiocb.aio_offset = recover_pos;
   ink_assert(ink_aio_read(&io));
@@ -1698,8 +1740,9 @@ Ldone : {
   /* if we come back to the starting position, then we don't have to recover anything */
   if (recover_pos == header->write_pos && recover_wrapped) {
     SET_HANDLER(&Vol::handle_recover_write_dir);
-    if (is_debug_tag_set("cache_init"))
+    if (is_debug_tag_set("cache_init")) {
       Note("recovery wrapped around. nothing to clear\n");
+    }
     return handle_recover_write_dir(EVENT_IMMEDIATE, 0);
   }
 
@@ -1710,25 +1753,28 @@ Ldone : {
     goto Lclear;
   }
 
-  if (recover_pos > skip + len)
+  if (recover_pos > skip + len) {
     recover_pos -= skip + len;
+  }
   // bump sync number so it is different from that in the Doc structs
   uint32_t next_sync_serial = max_sync_serial + 1;
   // make that the next sync does not overwrite our good copy!
-  if (!(header->sync_serial & 1) == !(next_sync_serial & 1))
+  if (!(header->sync_serial & 1) == !(next_sync_serial & 1)) {
     next_sync_serial++;
+  }
   // clear effected portion of the cache
   off_t clear_start = offset_to_vol_offset(this, header->write_pos);
   off_t clear_end   = offset_to_vol_offset(this, recover_pos);
-  if (clear_start <= clear_end)
+  if (clear_start <= clear_end) {
     dir_clear_range(clear_start, clear_end, this);
-  else {
+  } else {
     dir_clear_range(clear_end, DIR_OFFSET_MAX, this);
     dir_clear_range(1, clear_start, this);
   }
-  if (is_debug_tag_set("cache_init"))
+  if (is_debug_tag_set("cache_init")) {
     Note("recovery clearing offsets [%" PRIu64 ", %" PRIu64 "] sync_serial %d next %d\n", header->write_pos, recover_pos,
          header->sync_serial, next_sync_serial);
+  }
   footer->sync_serial = header->sync_serial = next_sync_serial;
 
   for (int i = 0; i < 3; i++) {
@@ -1773,8 +1819,9 @@ Lclear:
 int
 Vol::handle_recover_write_dir(int /* event ATS_UNUSED */, void * /* data ATS_UNUSED */)
 {
-  if (io.aiocb.aio_buf)
+  if (io.aiocb.aio_buf) {
     free((char *)io.aiocb.aio_buf);
+  }
   delete init_info;
   init_info = 0;
   set_io_not_in_progress();
@@ -1812,16 +1859,18 @@ Vol::handle_header_read(int event, void *data)
     if (hf[0]->sync_serial == hf[1]->sync_serial &&
         (hf[0]->sync_serial >= hf[2]->sync_serial || hf[2]->sync_serial != hf[3]->sync_serial)) {
       SET_HANDLER(&Vol::handle_dir_read);
-      if (is_debug_tag_set("cache_init"))
+      if (is_debug_tag_set("cache_init")) {
         Note("using directory A for '%s'", hash_text.get());
+      }
       io.aiocb.aio_offset = skip;
       ink_assert(ink_aio_read(&io));
     }
     // try B
     else if (hf[2]->sync_serial == hf[3]->sync_serial) {
       SET_HANDLER(&Vol::handle_dir_read);
-      if (is_debug_tag_set("cache_init"))
+      if (is_debug_tag_set("cache_init")) {
         Note("using directory B for '%s'", hash_text.get());
+      }
       io.aiocb.aio_offset = skip + vol_dirlen(this);
       ink_assert(ink_aio_read(&io));
     } else {
@@ -1848,10 +1897,11 @@ Vol::dir_init_done(int /* event ATS_UNUSED */, void * /* data ATS_UNUSED */)
     ink_assert(!gvol[vol_no]);
     gvol[vol_no] = this;
     SET_HANDLER(&Vol::aggWrite);
-    if (fd == -1)
+    if (fd == -1) {
       cache->vol_initialized(0);
-    else
+    } else {
       cache->vol_initialized(1);
+    }
     return EVENT_DONE;
   }
 }
@@ -1869,10 +1919,12 @@ cmprtable(const void *aa, const void *bb)
 {
   rtable_pair *a = (rtable_pair *)aa;
   rtable_pair *b = (rtable_pair *)bb;
-  if (a->rval < b->rval)
+  if (a->rval < b->rval) {
     return -1;
-  if (a->rval > b->rval)
+  }
+  if (a->rval > b->rval) {
     return 1;
+  }
   return 0;
 }
 
@@ -1931,25 +1983,28 @@ build_vol_hash_table(CacheHostRecord *cp)
   }
   // spread around the excess
   int extra = VOL_HASH_TABLE_SIZE - used;
-  for (int i = 0; i < extra; i++)
+  for (int i = 0; i < extra; i++) {
     forvol[i % num_vols]++;
+  }
   // seed random number generator
   for (int i = 0; i < num_vols; i++) {
     uint64_t x = p[i]->hash_id.fold();
     rnd[i]     = (unsigned int)x;
   }
   // initialize table to "empty"
-  for (int i  = 0; i < VOL_HASH_TABLE_SIZE; i++)
+  for (int i = 0; i < VOL_HASH_TABLE_SIZE; i++) {
     ttable[i] = VOL_HASH_EMPTY;
+  }
   // generate random numbers proportaion to allocation
   rtable_pair *rtable = (rtable_pair *)ats_malloc(sizeof(rtable_pair) * rtable_size);
   int rindex          = 0;
-  for (int i = 0; i < num_vols; i++)
+  for (int i = 0; i < num_vols; i++) {
     for (int j = 0; j < (int)rtable_entries[i]; j++) {
       rtable[rindex].rval = next_rand(&rnd[i]);
       rtable[rindex].idx  = i;
       rindex++;
     }
+  }
   ink_assert(rindex == (int)rtable_size);
   // sort (rand #, vol $ pairs)
   qsort(rtable, rtable_size, sizeof(rtable_pair), cmprtable);
@@ -1959,8 +2014,9 @@ build_vol_hash_table(CacheHostRecord *cp)
   int i = 0; // index moving through the random numbers
   for (int j = 0; j < VOL_HASH_TABLE_SIZE; j++) {
     pos = width / 2 + j * width; // position to select closest to
-    while (pos > rtable[i].rval && i < (int)rtable_size - 1)
+    while (pos > rtable[i].rval && i < (int)rtable_size - 1) {
       i++;
+    }
     ttable[j] = mapping[rtable[i].idx];
     gotvol[rtable[i].idx]++;
   }
@@ -1968,8 +2024,9 @@ build_vol_hash_table(CacheHostRecord *cp)
     Debug("cache_init", "build_vol_hash_table index %d mapped to %d requested %d got %d", i, mapping[i], forvol[i], gotvol[i]);
   }
   // install new table
-  if (0 != (old_table = ink_atomic_swap(&(cp->vol_hash_table), ttable)))
+  if (0 != (old_table = ink_atomic_swap(&(cp->vol_hash_table), ttable))) {
     new_Freer(old_table, CACHE_MEM_FREE_TIMEOUT);
+  }
   ats_free(mapping);
   ats_free(p);
   ats_free(forvol);
@@ -1982,10 +2039,12 @@ build_vol_hash_table(CacheHostRecord *cp)
 void
 Cache::vol_initialized(bool result)
 {
-  if (result)
+  if (result) {
     ink_atomic_increment(&total_good_nvol, 1);
-  if (total_nvol == ink_atomic_increment(&total_initialized_vol, 1) + 1)
+  }
+  if (total_nvol == ink_atomic_increment(&total_initialized_vol, 1) + 1) {
     open_done();
+  }
 }
 
 /** Set the state of a disk programmatically.
@@ -2000,8 +2059,9 @@ CacheProcessor::mark_storage_offline(CacheDisk *d ///< Target disk
   uint64_t total_dir_delete   = 0;
   uint64_t used_dir_delete    = 0;
 
-  if (!DISK_BAD(d))
+  if (!DISK_BAD(d)) {
     SET_DISK_BAD(d);
+  }
 
   for (p = 0; p < gnvol; p++) {
     if (d->fd == gvol[p]->fd) {
@@ -2052,8 +2112,9 @@ CacheProcessor::has_online_storage() const
 {
   CacheDisk **dptr = gdisks;
   for (int disk_no = 0; disk_no < gndisks; ++disk_no, ++dptr) {
-    if (!DISK_BAD(*dptr))
+    if (!DISK_BAD(*dptr)) {
       return true;
+    }
   }
   return false;
 }
@@ -2062,8 +2123,9 @@ int
 AIO_Callback_handler::handle_disk_failure(int /* event ATS_UNUSED */, void *data)
 {
   /* search for the matching file descriptor */
-  if (!CacheProcessor::cache_ready)
+  if (!CacheProcessor::cache_ready) {
     return EVENT_DONE;
+  }
   int disk_no     = 0;
   AIOCallback *cb = (AIOCallback *)data;
 
@@ -2110,10 +2172,11 @@ Cache::open_done()
   hosttable = new CacheHostTable(this, scheme);
   hosttable->register_config_callback(&hosttable);
 
-  if (hosttable->gen_host_rec.num_cachevols == 0)
+  if (hosttable->gen_host_rec.num_cachevols == 0) {
     ready = CACHE_INIT_FAILED;
-  else
+  } else {
     ready = CACHE_INITIALIZED;
+  }
 
   // TS-3848
   if (ready == CACHE_INIT_FAILED && cacheProcessor.waitForCache() >= 2) {
@@ -2169,8 +2232,9 @@ Cache::open(bool clear, bool /* fix ATS_UNUSED */)
       total_nvol += vol_no;
     }
   }
-  if (total_nvol == 0)
+  if (total_nvol == 0) {
     return open_done();
+  }
   cache_read_done = 1;
   return 0;
 }
@@ -2266,8 +2330,9 @@ upgrade_doc_version(Ptr<IOBufferData> &buf)
         n -= sizeofDoc;
 
         // We copy the fragment table iff there is a fragment table and there is only one alternate.
-        if (frag_count > 0 && cache_bc::HTTPInfo_v21::marshalled_length(src) > doc->hlen)
+        if (frag_count > 0 && cache_bc::HTTPInfo_v21::marshalled_length(src) > doc->hlen) {
           frag_count = 0; // inhibit fragment table insertion.
+        }
 
         while (zret && src < hdr_limit) {
           zret = cache_bc::HTTPInfo_v21::copy_and_upgrade_unmarshalled_to_v23(dst, src, n, frag_count, frags);
@@ -2308,14 +2373,16 @@ CacheVC::handleReadDone(int event, Event *e)
   ink_assert(this_ethread() == mutex->thread_holding);
 
   Doc *doc = NULL;
-  if (event == AIO_EVENT_DONE)
+  if (event == AIO_EVENT_DONE) {
     set_io_not_in_progress();
-  else if (is_io_in_progress())
+  } else if (is_io_in_progress()) {
     return EVENT_CONT;
+  }
   {
     MUTEX_TRY_LOCK(lock, vol->mutex, mutex->thread_holding);
-    if (!lock.is_locked())
+    if (!lock.is_locked()) {
       VC_SCHED_LOCK_RETRY();
+    }
     if ((!dir_valid(vol, &dir)) || (!io.ok())) {
       if (!io.ok()) {
         Debug("cache_disk_error", "Read error on disk %s\n \
@@ -2376,13 +2443,15 @@ CacheVC::handleReadDone(int event, Event *e)
     // put into ram cache?
     if (io.ok() && ((doc->first_key == *read_key) || (doc->key == *read_key) || STORE_COLLISION) && doc->magic == DOC_MAGIC) {
       int okay = 1;
-      if (!f.doc_from_ram_cache)
+      if (!f.doc_from_ram_cache) {
         f.not_from_ram_cache = 1;
+      }
       if (cache_config_enable_checksum && doc->checksum != DOC_NO_CHECKSUM) {
         // verify that the checksum matches
         uint32_t checksum = 0;
-        for (char *b = doc->hdr(); b < (char *)doc + doc->len; b++)
+        for (char *b = doc->hdr(); b < (char *)doc + doc->len; b++) {
           checksum += *b;
+        }
         ink_assert(checksum == doc->checksum);
         if (checksum != doc->checksum) {
           Note("cache: checksum error for [%" PRIu64 " %" PRIu64 "] len %d, hlen %d, disk %s, offset %" PRIu64 " size %zu",
@@ -2399,8 +2468,9 @@ CacheVC::handleReadDone(int event, Event *e)
         cache_config_ram_cache_compress && !f.doc_from_ram_cache && doc->doc_type == CACHE_FRAG_TYPE_HTTP && doc->hlen;
       // If http doc we need to unmarshal the headers before putting in the ram cache
       // unless it could be compressed
-      if (!http_copy_hdr && doc->doc_type == CACHE_FRAG_TYPE_HTTP && doc->hlen && okay)
+      if (!http_copy_hdr && doc->doc_type == CACHE_FRAG_TYPE_HTTP && doc->hlen && okay) {
         unmarshal_helper(doc, buf, okay);
+      }
 #endif
       // Put the request in the ram cache only if its a open_read or lookup
       if (vio.op == VIO::READ && okay) {
@@ -2428,8 +2498,9 @@ CacheVC::handleReadDone(int event, Event *e)
       } // end VIO::READ check
 #ifdef HTTP_CACHE
       // If it could be compressed, unmarshal after
-      if (http_copy_hdr && doc->doc_type == CACHE_FRAG_TYPE_HTTP && doc->hlen && okay)
+      if (http_copy_hdr && doc->doc_type == CACHE_FRAG_TYPE_HTTP && doc->hlen && okay) {
         unmarshal_helper(doc, buf, okay);
+      }
 #endif
     } // end io.ok() check
   }
@@ -2474,12 +2545,13 @@ CacheVC::handleRead(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
 
   io.aiocb.aio_fildes = vol->fd;
   io.aiocb.aio_offset = vol_offset(vol, &dir);
-  if ((off_t)(io.aiocb.aio_offset + io.aiocb.aio_nbytes) > (off_t)(vol->skip + vol->len))
+  if ((off_t)(io.aiocb.aio_offset + io.aiocb.aio_nbytes) > (off_t)(vol->skip + vol->len)) {
     io.aiocb.aio_nbytes = vol->skip + vol->len - io.aiocb.aio_offset;
-  buf                   = new_IOBufferData(iobuffer_size_to_index(io.aiocb.aio_nbytes, MAX_BUFFER_SIZE_INDEX), MEMALIGNED);
-  io.aiocb.aio_buf      = buf->data();
-  io.action             = this;
-  io.thread             = mutex->thread_holding->tt == DEDICATED ? AIO_CALLBACK_THREAD_ANY : mutex->thread_holding;
+  }
+  buf              = new_IOBufferData(iobuffer_size_to_index(io.aiocb.aio_nbytes, MAX_BUFFER_SIZE_INDEX), MEMALIGNED);
+  io.aiocb.aio_buf = buf->data();
+  io.action        = this;
+  io.thread        = mutex->thread_holding->tt == DEDICATED ? AIO_CALLBACK_THREAD_ANY : mutex->thread_holding;
   SET_HANDLER(&CacheVC::handleReadDone);
   ink_assert(ink_aio_read(&io) >= 0);
   CACHE_DEBUG_INCREMENT_DYN_STAT(cache_pread_count_stat);
@@ -2522,10 +2594,11 @@ Cache::lookup(Continuation *cont, const CacheKey *key, CacheFragType type, char 
   c->vol                = vol;
   c->last_collision     = NULL;
 
-  if (c->handleEvent(EVENT_INTERVAL, 0) == EVENT_CONT)
+  if (c->handleEvent(EVENT_INTERVAL, 0) == EVENT_CONT) {
     return &c->_action;
-  else
+  } else {
     return ACTION_RESULT_DONE;
+  }
 }
 
 int
@@ -2535,8 +2608,9 @@ CacheVC::removeEvent(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   set_io_not_in_progress();
   {
     MUTEX_TRY_LOCK(lock, vol->mutex, mutex->thread_holding);
-    if (!lock.is_locked())
+    if (!lock.is_locked()) {
       VC_SCHED_LOCK_RETRY();
+    }
     if (_action.cancelled) {
       if (od) {
         vol->close_write(this);
@@ -2557,15 +2631,17 @@ CacheVC::removeEvent(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     }
   Lread:
     SET_HANDLER(&CacheVC::removeEvent);
-    if (!buf)
+    if (!buf) {
       goto Lcollision;
+    }
     if (!dir_valid(vol, &dir)) {
       last_collision = NULL;
       goto Lcollision;
     }
     // check read completed correct FIXME: remove bad vols
-    if ((size_t)io.aio_result != (size_t)io.aiocb.aio_nbytes)
+    if ((size_t)io.aio_result != (size_t)io.aiocb.aio_nbytes) {
       goto Ldone;
+    }
     {
       // verify that this is our document
       Doc *doc = (Doc *)buf->data();
@@ -2573,8 +2649,9 @@ CacheVC::removeEvent(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
       if (doc->first_key == key) {
         ink_assert(doc->magic == DOC_MAGIC);
         if (dir_delete(&key, vol, &dir) > 0) {
-          if (od)
+          if (od) {
             vol->close_write(this);
+          }
           od = NULL;
           goto Lremoved;
         }
@@ -2585,14 +2662,16 @@ CacheVC::removeEvent(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     // check for collision
     if (dir_probe(&key, vol, &dir, &last_collision) > 0) {
       int ret = do_read_call(&key);
-      if (ret == EVENT_RETURN)
+      if (ret == EVENT_RETURN) {
         goto Lread;
+      }
       return ret;
     }
   Ldone:
     CACHE_INCREMENT_DYN_STAT(cache_remove_failure_stat);
-    if (od)
+    if (od) {
       vol->close_write(this);
+    }
   }
   ink_assert(!vol || this_ethread() != vol->mutex->thread_holding);
   _action.continuation->handleEvent(CACHE_EVENT_REMOVE_FAILED, (void *)-ECACHE_NO_DOC);
@@ -2607,14 +2686,16 @@ Action *
 Cache::remove(Continuation *cont, const CacheKey *key, CacheFragType type, const char *hostname, int host_len)
 {
   if (!CacheProcessor::IsCacheReady(type)) {
-    if (cont)
+    if (cont) {
       cont->handleEvent(CACHE_EVENT_REMOVE_FAILED, 0);
+    }
     return ACTION_RESULT_DONE;
   }
 
   Ptr<ProxyMutex> mutex;
-  if (!cont)
+  if (!cont) {
     cont = new_CacheRemoveCont();
+  }
 
   CACHE_TRY_LOCK(lock, cont->mutex, this_ethread());
   ink_assert(lock.is_locked());
@@ -2636,10 +2717,11 @@ Cache::remove(Continuation *cont, const CacheKey *key, CacheFragType type, const
 
   SET_CONTINUATION_HANDLER(c, &CacheVC::removeEvent);
   int ret = c->removeEvent(EVENT_IMMEDIATE, 0);
-  if (ret == EVENT_DONE)
+  if (ret == EVENT_DONE) {
     return ACTION_RESULT_DONE;
-  else
+  } else {
     return &c->_action;
+  }
 }
 // CacheVConnection
 
@@ -2727,8 +2809,9 @@ cplist_update()
       // Delete hte volume from the cache vol list
       int d_no;
       for (d_no = 0; d_no < gndisks; d_no++) {
-        if (cp->disk_vols[d_no])
+        if (cp->disk_vols[d_no]) {
           cp->disk_vols[d_no]->disk->delete_volume(cp->vol_number);
+        }
       }
       CacheVol *temp_cp = cp;
       cp                = cp->link.next;
@@ -2736,8 +2819,9 @@ cplist_update()
       cp_list_len--;
       delete temp_cp;
       continue;
-    } else
+    } else {
       cp = cp->link.next;
+    }
   }
 }
 
@@ -2844,8 +2928,9 @@ cplist_reconfigure()
     off_t blocks_per_vol    = VOL_BLOCK_SIZE / STORE_BLOCK_SIZE;
     /* sum up the total space available on all the disks.
        round down the space to 128 megabytes */
-    for (int i = 0; i < gndisks; i++)
+    for (int i = 0; i < gndisks; i++) {
       tot_space_in_blks += (gdisks[i]->num_usable_blocks / blocks_per_vol) * blocks_per_vol;
+    }
 
     double percent_remaining = 100.00;
     for (config_vol = config_volumes.cp_queue.head; config_vol; config_vol = config_vol->link.next) {
@@ -2884,8 +2969,9 @@ cplist_reconfigure()
 
     for (config_vol = config_volumes.cp_queue.head; config_vol; config_vol = config_vol->link.next) {
       size = config_vol->size;
-      if (size < 128)
+      if (size < 128) {
         continue;
+      }
 
       volume_number = config_vol->number;
 
@@ -2923,8 +3009,9 @@ cplist_reconfigure()
       /* search the cp_list */
 
       int *sorted_vols = new int[gndisks];
-      for (int i       = 0; i < gndisks; i++)
+      for (int i = 0; i < gndisks; i++) {
         sorted_vols[i] = i;
+      }
       for (int i = 0; i < gndisks - 1; i++) {
         int smallest     = sorted_vols[i];
         int smallest_ndx = i;
@@ -2963,8 +3050,9 @@ cplist_reconfigure()
         size_diff         = (size_diff < size_to_alloc) ? size_diff : size_to_alloc;
         /* if size_diff == 0, then then the disks have volumes of the
            same sizes, so we don't need to balance the disks */
-        if (size_diff == 0)
+        if (size_diff == 0) {
           break;
+        }
 
         DiskVolBlock *dpb;
         do {
@@ -2976,12 +3064,14 @@ cplist_reconfigure()
             size_diff -= dpb->len;
             cp->size += dpb->len;
             cp->num_vols++;
-          } else
+          } else {
             break;
+          }
         } while ((size_diff > 0));
 
-        if (!dpb)
+        if (!dpb) {
           disk_full++;
+        }
 
         size_to_alloc = size_in_blocks - cp->size;
       }
@@ -2989,8 +3079,9 @@ cplist_reconfigure()
       delete[] sorted_vols;
 
       if (size_to_alloc) {
-        if (create_volume(volume_number, size_to_alloc, cp->scheme, cp))
+        if (create_volume(volume_number, size_to_alloc, cp->scheme, cp)) {
           return -1;
+        }
       }
       gnvol += cp->num_vols;
     }
@@ -3028,12 +3119,13 @@ create_volume(int volume_number, off_t size_in_blocks, int scheme, CacheVol *cp)
       if (full_disks == gndisks) {
         char config_file[PATH_NAME_MAX];
         REC_ReadConfigString(config_file, "proxy.config.cache.volume_filename", PATH_NAME_MAX);
-        if (cp->size)
+        if (cp->size) {
           Warning("not enough space to increase volume: [%d] to size: [%" PRId64 "]", volume_number,
                   (int64_t)((to_create + cp->size) >> (20 - STORE_BLOCK_SHIFT)));
-        else
+        } else {
           Warning("not enough space to create volume: [%d], size: [%" PRId64 "]", volume_number,
                   (int64_t)(to_create >> (20 - STORE_BLOCK_SHIFT)));
+        }
 
         Note("edit the %s file and restart traffic_server", config_file);
         delete[] sp;
@@ -3054,8 +3146,9 @@ create_volume(int volume_number, off_t size_in_blocks, int scheme, CacheVol *cp)
         cp->num_vols++;
         cp->size += p->len;
       }
-      if (!cp->disk_vols[i])
+      if (!cp->disk_vols[i]) {
         cp->disk_vols[i] = gdisks[i]->get_diskvol(volume_number);
+      }
     }
   }
   delete[] sp;
@@ -3107,8 +3200,9 @@ Cache::key_to_vol(const CacheKey *key, char const *hostname, int host_len)
       Debug("cache_hosting", format_str, host_rec, hostname);
     }
     return host_rec->vols[hash_table[h]];
-  } else
+  } else {
     return host_rec->vols[0];
+  }
 }
 
 static void
@@ -3231,8 +3325,9 @@ ink_cache_init(ModuleVersion v)
   REC_EstablishStaticConfigInt32(cache_config_force_sector_size, "proxy.config.cache.force_sector_size");
   REC_EstablishStaticConfigInt32(cache_config_target_fragment_size, "proxy.config.cache.target_fragment_size");
 
-  if (cache_config_target_fragment_size == 0)
+  if (cache_config_target_fragment_size == 0) {
     cache_config_target_fragment_size = DEFAULT_TARGET_FRAGMENT_SIZE;
+  }
 
 #ifdef HTTP_CACHE
   REC_EstablishStaticConfigInt32(enable_cache_empty_http_doc, "proxy.config.http.cache.allow_empty_doc");
@@ -3323,12 +3418,14 @@ CacheProcessor::find_by_path(char const *path, int len)
 {
   if (CACHE_INITIALIZED == initialized) {
     // If no length is passed in, assume it's null terminated.
-    if (0 >= len && 0 != *path)
+    if (0 >= len && 0 != *path) {
       len = strlen(path);
+    }
 
     for (int i = 0; i < gndisks; ++i) {
-      if (0 == strncmp(path, gdisks[i]->path, len))
+      if (0 == strncmp(path, gdisks[i]->path, len)) {
         return gdisks[i];
+      }
     }
   }
 
@@ -3371,8 +3468,9 @@ HTTPInfo_v21::copy_and_upgrade_unmarshalled_to_v23(char *&dst, char *&src, size_
   HdrHeap_v23 *d_hdr;
   size_t hdr_size;
 
-  if (length < HTTP_ALT_MARSHAL_SIZE)
+  if (length < HTTP_ALT_MARSHAL_SIZE) {
     return false; // Absolutely no hope in this case.
+  }
 
   memcpy(dst, src, OLD_OFFSET); // initially same data
   // Now data that's now after extra
@@ -3385,8 +3483,9 @@ HTTPInfo_v21::copy_and_upgrade_unmarshalled_to_v23(char *&dst, char *&src, size_
     static size_t const IFT_SIZE = HTTPCacheAlt_v23::N_INTEGRAL_FRAG_OFFSETS * sizeof(FragOffset);
     size_t ift_actual            = min(n_frags, HTTPCacheAlt_v23::N_INTEGRAL_FRAG_OFFSETS) * sizeof(FragOffset);
 
-    if (length < (HTTP_ALT_MARSHAL_SIZE + n_frags * sizeof(FragOffset) - IFT_SIZE))
+    if (length < (HTTP_ALT_MARSHAL_SIZE + n_frags * sizeof(FragOffset) - IFT_SIZE)) {
       return false; // can't place fragment table.
+    }
 
     d_alt->m_frag_offset_count = n_frags;
     d_alt->m_frag_offsets      = reinterpret_cast<FragOffset *>(dst - reinterpret_cast<char *>(d_alt));
@@ -3412,8 +3511,9 @@ HTTPInfo_v21::copy_and_upgrade_unmarshalled_to_v23(char *&dst, char *&src, size_
     reinterpret_cast<HdrHeap_v23 *>(reinterpret_cast<char *>(s_alt) + reinterpret_cast<uintptr_t>(s_alt->m_request_hdr.m_heap));
   d_hdr    = reinterpret_cast<HdrHeap_v23 *>(dst);
   hdr_size = ROUND(s_hdr->unmarshal_size(), HDR_PTR_SIZE);
-  if (hdr_size > length)
+  if (hdr_size > length) {
     return false;
+  }
   memcpy(d_hdr, s_hdr, hdr_size);
   d_alt->m_request_hdr.m_heap = reinterpret_cast<HdrHeap_v23 *>(reinterpret_cast<char *>(d_hdr) - reinterpret_cast<char *>(d_alt));
   dst += hdr_size;
@@ -3423,8 +3523,9 @@ HTTPInfo_v21::copy_and_upgrade_unmarshalled_to_v23(char *&dst, char *&src, size_
     reinterpret_cast<HdrHeap_v23 *>(reinterpret_cast<char *>(s_alt) + reinterpret_cast<uintptr_t>(s_alt->m_response_hdr.m_heap));
   d_hdr    = reinterpret_cast<HdrHeap_v23 *>(dst);
   hdr_size = ROUND(s_hdr->unmarshal_size(), HDR_PTR_SIZE);
-  if (hdr_size > length)
+  if (hdr_size > length) {
     return false;
+  }
   memcpy(d_hdr, s_hdr, hdr_size);
   d_alt->m_response_hdr.m_heap = reinterpret_cast<HdrHeap_v23 *>(reinterpret_cast<char *>(d_hdr) - reinterpret_cast<char *>(d_alt));
   dst += hdr_size;

--- a/iocore/cache/CacheDir.cc
+++ b/iocore/cache/CacheDir.cc
@@ -75,8 +75,9 @@ OpenDir::open_write(CacheVC *cont, int allow_if_writers, int max_writers)
   unsigned int h = cont->first_key.slice32(0);
   int b          = h % OPEN_DIR_BUCKETS;
   for (OpenDirEntry *d = bucket[b].head; d; d = d->link.next) {
-    if (!(d->writers.head->first_key == cont->first_key))
+    if (!(d->writers.head->first_key == cont->first_key)) {
       continue;
+    }
     if (allow_if_writers && d->num_writers < d->max_writers) {
       d->writers.push(cont);
       d->num_writers++;
@@ -121,8 +122,9 @@ OpenDir::signal_readers(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   if (newly_delayed_readers.head) {
     delayed_readers = newly_delayed_readers;
     EThread *t1     = newly_delayed_readers.head->mutex->thread_holding;
-    if (!t1)
+    if (!t1) {
       t1 = mutex->thread_holding;
+    }
     t1->schedule_in(this, HRTIME_MSECONDS(cache_config_mutex_retry_delay));
   }
   return 0;
@@ -152,9 +154,11 @@ OpenDir::open_read(const CryptoHash *key)
 {
   unsigned int h = key->slice32(0);
   int b          = h % OPEN_DIR_BUCKETS;
-  for (OpenDirEntry *d = bucket[b].head; d; d = d->link.next)
-    if (d->writers.head->first_key == *key)
+  for (OpenDirEntry *d = bucket[b].head; d; d = d->link.next) {
+    if (d->writers.head->first_key == *key) {
       return d;
+    }
+  }
   return NULL;
 }
 
@@ -178,8 +182,9 @@ OpenDirEntry::wait(CacheVC *cont, int msec)
 int
 dir_bucket_loop_check(Dir *start_dir, Dir *seg)
 {
-  if (start_dir == NULL)
+  if (start_dir == NULL) {
     return 1;
+  }
 
   Dir *p1 = start_dir;
   Dir *p2 = start_dir;
@@ -189,13 +194,15 @@ dir_bucket_loop_check(Dir *start_dir, Dir *seg)
     p1 = next_dir(p1, seg);
     // p2 moves by two entries per iteration
     p2 = next_dir(p2, seg);
-    if (p2)
+    if (p2) {
       p2 = next_dir(p2, seg);
-    else
+    } else {
       return 1;
+    }
 
-    if (p2 == p1)
+    if (p2 == p1) {
       return 0; // we have a loop
+    }
   }
   return 1;
 }
@@ -236,8 +243,9 @@ dir_freelist_length(Vol *d, int s)
   int free = 0;
   Dir *seg = dir_segment(s, d);
   Dir *e   = dir_from_offset(d->header->freelist[s], seg);
-  if (dir_bucket_loop_fix(e, s, d))
+  if (dir_bucket_loop_fix(e, s, d)) {
     return (DIR_DEPTH - 1) * d->buckets;
+  }
   while (e) {
     free++;
     e = next_dir(e, seg);
@@ -257,8 +265,9 @@ dir_bucket_length(Dir *b, int s, Vol *d)
 #endif
   while (e) {
     i++;
-    if (i > 100)
+    if (i > 100) {
       return -1;
+    }
     e = next_dir(e, seg);
   }
   return i;
@@ -273,12 +282,15 @@ check_dir(Vol *d)
     Dir *seg = dir_segment(s, d);
     for (i = 0; i < d->buckets; i++) {
       Dir *b = dir_bucket(i, seg);
-      if (!(dir_bucket_length(b, s, d) >= 0))
+      if (!(dir_bucket_length(b, s, d) >= 0)) {
         return 0;
-      if (!(!dir_next(b) || dir_offset(b)))
+      }
+      if (!(!dir_next(b) || dir_offset(b))) {
         return 0;
-      if (!(dir_bucket_loop_check(b, seg)))
+      }
+      if (!(dir_bucket_loop_check(b, seg))) {
         return 0;
+      }
     }
   }
   return 1;
@@ -289,13 +301,15 @@ unlink_from_freelist(Dir *e, int s, Vol *d)
 {
   Dir *seg = dir_segment(s, d);
   Dir *p   = dir_from_offset(dir_prev(e), seg);
-  if (p)
+  if (p) {
     dir_set_next(p, dir_next(e));
-  else
+  } else {
     d->header->freelist[s] = dir_next(e);
-  Dir *n                   = dir_from_offset(dir_next(e), seg);
-  if (n)
+  }
+  Dir *n = dir_from_offset(dir_next(e), seg);
+  if (n) {
     dir_set_prev(n, dir_prev(e));
+  }
 }
 
 inline Dir *
@@ -310,8 +324,9 @@ dir_delete_entry(Dir *e, Dir *p, int s, Vol *d)
     dir_clear(e);
     dir_set_next(p, no);
     dir_set_next(e, fo);
-    if (fo)
+    if (fo) {
       dir_set_prev(dir_from_offset(fo, seg), eo);
+    }
     d->header->freelist[s] = eo;
   } else {
     Dir *n = next_dir(e, seg);
@@ -347,8 +362,9 @@ dir_clean_bucket(Dir *b, int s, Vol *vol)
       if (is_debug_tag_set("dir_clean"))
         Debug("dir_clean", "cleaning %p tag %X boffset %" PRId64 " b %p p %p l %d", e, dir_tag(e), dir_offset(e), b, p,
               dir_bucket_length(b, s, vol));
-      if (dir_offset(e))
+      if (dir_offset(e)) {
         CACHE_DEC_DIR_USED(vol->mutex);
+      }
       e = dir_delete_entry(e, p, s, vol);
       continue;
     }
@@ -370,8 +386,9 @@ dir_clean_segment(int s, Vol *d)
 void
 dir_clean_vol(Vol *d)
 {
-  for (int64_t i = 0; i < d->segments; i++)
+  for (int64_t i = 0; i < d->segments; i++) {
     dir_clean_segment(i, d);
+  }
   CHECK_DIR(d);
 }
 
@@ -393,8 +410,9 @@ check_bucket_not_contains(Dir *b, Dir *e, Dir *seg)
 {
   Dir *x = b;
   do {
-    if (x == e)
+    if (x == e) {
       break;
+    }
     x = next_dir(x, seg);
   } while (x);
   ink_assert(!x);
@@ -404,8 +422,9 @@ void
 freelist_clean(int s, Vol *vol)
 {
   dir_clean_segment(s, vol);
-  if (vol->header->freelist[s])
+  if (vol->header->freelist[s]) {
     return;
+  }
   Warning("cache directory overflow on '%s' segment %d, purging...", vol->path, s);
   int n    = 0;
   Dir *seg = dir_segment(s, vol);
@@ -438,8 +457,9 @@ freelist_pop(int s, Vol *d)
     return NULL;
   }
   Dir *h = dir_from_offset(d->header->freelist[s], seg);
-  if (h)
+  if (h) {
     dir_set_prev(h, 0);
+  }
   return e;
 }
 
@@ -460,29 +480,38 @@ dir_segment_accounted(int s, Vol *d, int offby, int *f, int *u, int *et, int *v,
         empty++;
       } else {
         used++;
-        if (dir_valid(d, e))
+        if (dir_valid(d, e)) {
           valid++;
-        if (dir_agg_valid(d, e))
+        }
+        if (dir_agg_valid(d, e)) {
           agg_valid++;
+        }
         agg_size += dir_approx_size(e);
       }
       e = next_dir(e, seg);
-      if (!e)
+      if (!e) {
         break;
+      }
     }
   }
-  if (f)
+  if (f) {
     *f = free;
-  if (u)
+  }
+  if (u) {
     *u = used;
-  if (et)
+  }
+  if (et) {
     *et = empty;
-  if (v)
+  }
+  if (v) {
     *v = valid;
-  if (av)
+  }
+  if (av) {
     *av = agg_valid;
-  if (as)
+  }
+  if (as) {
     *as = used ? (int)(agg_size / used) : 0;
+  }
   ink_assert(d->buckets * DIR_DEPTH - (free + used + empty) <= offby);
   return d->buckets * DIR_DEPTH - (free + used + empty) <= offby;
 }
@@ -494,8 +523,9 @@ dir_free_entry(Dir *e, int s, Vol *d)
   unsigned int fo = d->header->freelist[s];
   unsigned int eo = dir_to_offset(e, seg);
   dir_set_next(e, fo);
-  if (fo)
+  if (fo) {
     dir_set_prev(dir_from_offset(fo, seg), eo);
+  }
   d->header->freelist[s] = eo;
 }
 
@@ -515,7 +545,7 @@ dir_probe(const CacheKey *key, Vol *d, Dir *result, Dir **last_collision)
 #endif
 Lagain:
   e = dir_bucket(b, seg);
-  if (dir_offset(e))
+  if (dir_offset(e)) {
     do {
       if (dir_compare_tag(e, key)) {
         ink_assert(dir_offset(e));
@@ -553,6 +583,7 @@ Lagain:
       p = e;
       e = next_dir(e, seg);
     } while (e);
+  }
   if (collision) { // last collision no longer in the list, retry
     DDebug("cache_stats", "Incrementing dir collisions");
     CACHE_INC_DIR_COLLISIONS(d->mutex);
@@ -588,8 +619,9 @@ dir_insert(const CacheKey *key, Vol *d, Dir *to_part)
 Lagain:
   // get from this row first
   e = b;
-  if (dir_is_empty(e))
+  if (dir_is_empty(e)) {
     goto Lfill;
+  }
   for (l = 1; l < DIR_DEPTH; l++) {
     e = dir_bucket_row(b, l);
     if (dir_is_empty(e)) {
@@ -599,8 +631,9 @@ Lagain:
   }
   // get one from the freelist
   e = freelist_pop(s, d);
-  if (!e)
+  if (!e) {
     goto Lagain;
+  }
 Llink:
   dir_set_next(e, dir_next(b));
   dir_set_next(b, dir_to_offset(e, seg));
@@ -638,7 +671,7 @@ dir_overwrite(const CacheKey *key, Vol *d, Dir *dir, Dir *overwrite, bool must_o
 Lagain:
   // find entry to overwrite
   e = b;
-  if (dir_offset(e))
+  if (dir_offset(e)) {
     do {
 #ifdef LOOP_CHECK_MODE
       loop_count++;
@@ -649,12 +682,15 @@ Lagain:
         }
       }
 #endif
-      if (dir_tag(e) == t && dir_offset(e) == dir_offset(overwrite))
+      if (dir_tag(e) == t && dir_offset(e) == dir_offset(overwrite)) {
         goto Lfill;
+      }
       e = next_dir(e, seg);
     } while (e);
-  if (must_overwrite)
+  }
+  if (must_overwrite) {
     return 0;
+  }
   res = 0;
   // get from this row first
   e = b;
@@ -671,8 +707,9 @@ Lagain:
   }
   // get one from the freelist
   e = freelist_pop(s, d);
-  if (!e)
+  if (!e) {
     goto Lagain;
+  }
 Llink:
   CACHE_INC_DIR_USED(d->mutex);
   dir_set_next(e, dir_next(b));
@@ -703,7 +740,7 @@ dir_delete(const CacheKey *key, Vol *d, Dir *del)
   CHECK_DIR(d);
 
   e = dir_bucket(b, seg);
-  if (dir_offset(e))
+  if (dir_offset(e)) {
     do {
 #ifdef LOOP_CHECK_MODE
       loop_count++;
@@ -721,6 +758,7 @@ dir_delete(const CacheKey *key, Vol *d, Dir *del)
       p = e;
       e = next_dir(e, seg);
     } while (e);
+  }
   CHECK_DIR(d);
   return 0;
 }
@@ -738,8 +776,9 @@ dir_lookaside_probe(const CacheKey *key, Vol *d, Dir *result, EvacuationBlock **
       if (dir_valid(d, &b->new_dir)) {
         *result = b->new_dir;
         DDebug("dir_lookaside", "probe %X success", key->slice32(0));
-        if (eblock)
+        if (eblock) {
           *eblock = b;
+        }
         return 1;
       }
     }
@@ -871,11 +910,13 @@ dir_entries_used(Vol *d)
         break;
       }
       while (e) {
-        if (dir_offset(e))
+        if (dir_offset(e)) {
           sfull++;
+        }
         e = next_dir(e, seg);
-        if (!e)
+        if (!e) {
           break;
+        }
       }
     }
   }
@@ -940,10 +981,11 @@ sync_cache_dir_on_shutdown(void)
 
     if (buflen < dirlen) {
       if (buf) {
-        if (buf_huge)
+        if (buf_huge) {
           ats_free_hugepage(buf, buflen);
-        else
+        } else {
           ats_memalign_free(buf);
+        }
         buf = NULL;
       }
       buflen = dirlen;
@@ -974,10 +1016,11 @@ sync_cache_dir_on_shutdown(void)
   }
   Debug("cache_dir_sync", "sync done");
   if (buf) {
-    if (buf_huge)
+    if (buf_huge) {
       ats_free_hugepage(buf, buflen);
-    else
+    } else {
       ats_memalign_free(buf);
+    }
     buf = NULL;
   }
 }
@@ -994,19 +1037,21 @@ Lrestart:
   if (vol_idx >= gnvol) {
     vol_idx = 0;
     if (buf) {
-      if (buf_huge)
+      if (buf_huge) {
         ats_free_hugepage(buf, buflen);
-      else
+      } else {
         ats_memalign_free(buf);
+      }
       buflen   = 0;
       buf      = NULL;
       buf_huge = false;
     }
     Debug("cache_dir_sync", "sync done");
-    if (event == EVENT_INTERVAL)
+    if (event == EVENT_INTERVAL) {
       trigger = e->ethread->schedule_in(this, HRTIME_SECONDS(cache_config_dir_sync_frequency));
-    else
+    } else {
       trigger = eventProcessor.schedule_in(this, HRTIME_SECONDS(cache_config_dir_sync_frequency));
+    }
     return EVENT_CONT;
   }
 
@@ -1031,14 +1076,16 @@ Lrestart:
       return EVENT_CONT;
     }
 
-    if (!vol->dir_sync_in_progress)
+    if (!vol->dir_sync_in_progress) {
       start_time = Thread::get_hrtime();
+    }
 
     // recompute hit_evacuate_window
     vol->hit_evacuate_window = (vol->data_blocks * cache_config_hit_evacuate_percent) / 100;
 
-    if (DISK_BAD(vol->disk))
+    if (DISK_BAD(vol->disk)) {
       goto Ldone;
+    }
 
     int headerlen = ROUND_TO_STORE_BLOCK(sizeof(VolHeaderFooter));
     size_t dirlen = vol_dirlen(vol);
@@ -1058,18 +1105,20 @@ Lrestart:
       if (vol->is_io_in_progress() || vol->agg_buf_pos) {
         Debug("cache_dir_sync", "Dir %s: waiting for agg buffer", vol->hash_text.get());
         vol->dir_sync_waiting = 1;
-        if (!vol->is_io_in_progress())
+        if (!vol->is_io_in_progress()) {
           vol->aggWrite(EVENT_IMMEDIATE, 0);
+        }
         return EVENT_CONT;
       }
       Debug("cache_dir_sync", "pos: %" PRIu64 " Dir %s dirty...syncing to disk", vol->header->write_pos, vol->hash_text.get());
       vol->header->dirty = 0;
       if (buflen < dirlen) {
         if (buf) {
-          if (buf_huge)
+          if (buf_huge) {
             ats_free_hugepage(buf, buflen);
-          else
+          } else {
             ats_memalign_free(buf);
+          }
           buf = NULL;
         }
         buflen = dirlen;
@@ -1098,8 +1147,9 @@ Lrestart:
     } else if (writepos < (off_t)dirlen - headerlen) {
       // write part of body
       int l = SYNC_MAX_WRITE;
-      if (writepos + l > (off_t)dirlen - headerlen)
+      if (writepos + l > (off_t)dirlen - headerlen) {
         l = dirlen - headerlen - writepos;
+      }
       aio_write(vol->fd, buf + writepos, l, start + writepos);
       writepos += l;
     } else if (writepos < (off_t)dirlen) {
@@ -1205,16 +1255,18 @@ int Vol::dir_check(bool /* fix ATS_UNUSED */) // TODO: we should eliminate this 
             ++seg_stale;
           } else {
             uint64_t size = dir_approx_size(e);
-            if (dir_head(e))
+            if (dir_head(e)) {
               ++head;
+            }
             ++seg_in_use;
             seg_bytes_in_use += size;
             ++frag_demographics[dir_size(e)][dir_big(e)];
           }
         }
         e = next_dir(e, seg);
-        if (!e)
+        if (!e) {
           break;
+        }
       }
 
       // Check for duplicates (identical tags in the same bucket).
@@ -1223,8 +1275,9 @@ int Vol::dir_check(bool /* fix ATS_UNUSED */) // TODO: we should eliminate this 
         qsort(chain_tag, h, sizeof(chain_tag[0]), &compare_ushort);
         last = chain_tag[0];
         for (int k = 1; k < h; ++k) {
-          if (last == chain_tag[k])
+          if (last == chain_tag[k]) {
             ++seg_dups;
+          }
           last = chain_tag[k];
         }
       }
@@ -1250,8 +1303,9 @@ int Vol::dir_check(bool /* fix ATS_UNUSED */) // TODO: we should eliminate this 
          max_chain_length, buckets_in_use ? static_cast<float>(in_use + stale) / buckets_in_use : 0);
 
   printf("    Chain lengths:  ");
-  for (j = 0; j < SEGMENT_HISTOGRAM_WIDTH; ++j)
+  for (j = 0; j < SEGMENT_HISTOGRAM_WIDTH; ++j) {
     printf(" %d=%d ", j, hist[j]);
+  }
   printf(" %d>=%d\n", SEGMENT_HISTOGRAM_WIDTH, hist[SEGMENT_HISTOGRAM_WIDTH]);
 
   char tt[256];
@@ -1337,8 +1391,9 @@ static void
 regress_rand_CacheKey(const CacheKey *key)
 {
   unsigned int *x = (unsigned int *)key;
-  for (int i = 0; i < 4; i++)
-    x[i]     = next_rand(&regress_rand_seed);
+  for (int i = 0; i < 4; i++) {
+    x[i] = next_rand(&regress_rand_seed);
+  }
 }
 
 void
@@ -1394,24 +1449,29 @@ EXCLUSIVE_REGRESSION_TEST(Cache_dir)(RegressionTest *t, int /* atype ATS_UNUSED 
   int n        = free;
   rprintf(t, "free: %d\n", free);
   while (n--) {
-    if (!dir_insert(&key, d, &dir))
+    if (!dir_insert(&key, d, &dir)) {
       break;
+    }
     inserted++;
   }
   rprintf(t, "inserted: %d\n", inserted);
-  if ((unsigned int)(inserted - free) > 1)
+  if ((unsigned int)(inserted - free) > 1) {
     ret = REGRESSION_TEST_FAILED;
+  }
 
   // test delete
   rprintf(t, "delete test\n");
-  for (i = 0; i < d->buckets; i++)
-    for (j = 0; j < DIR_DEPTH; j++)
+  for (i = 0; i < d->buckets; i++) {
+    for (j = 0; j < DIR_DEPTH; j++) {
       dir_set_offset(dir_bucket_row(dir_bucket(i, seg), j), 0); // delete
+    }
+  }
   dir_clean_segment(s, d);
   int newfree = dir_freelist_length(d, s);
   rprintf(t, "newfree: %d\n", newfree);
-  if ((unsigned int)(newfree - free) > 1)
+  if ((unsigned int)(newfree - free) > 1) {
     ret = REGRESSION_TEST_FAILED;
+  }
 
   // test insert-delete
   rprintf(t, "insert-delete test\n");
@@ -1424,21 +1484,24 @@ EXCLUSIVE_REGRESSION_TEST(Cache_dir)(RegressionTest *t, int /* atype ATS_UNUSED 
   uint64_t us = (Thread::get_hrtime_updated() - ttime) / HRTIME_USECOND;
   // On windows us is sometimes 0. I don't know why.
   // printout the insert rate only if its not 0
-  if (us)
+  if (us) {
     rprintf(t, "insert rate = %d / second\n", (int)((newfree * (uint64_t)1000000) / us));
+  }
   regress_rand_init(13);
   ttime = Thread::get_hrtime_updated();
   for (i = 0; i < newfree; i++) {
     Dir *last_collision = 0;
     regress_rand_CacheKey(&key);
-    if (!dir_probe(&key, d, &dir, &last_collision))
+    if (!dir_probe(&key, d, &dir, &last_collision)) {
       ret = REGRESSION_TEST_FAILED;
+    }
   }
   us = (Thread::get_hrtime_updated() - ttime) / HRTIME_USECOND;
   // On windows us is sometimes 0. I don't know why.
   // printout the probe rate only if its not 0
-  if (us)
+  if (us) {
     rprintf(t, "probe rate = %d / second\n", (int)((newfree * (uint64_t)1000000) / us));
+  }
 
   for (int c = 0; c < vol_direntries(d) * 0.75; c++) {
     regress_rand_CacheKey(&key);
@@ -1519,8 +1582,9 @@ EXCLUSIVE_REGRESSION_TEST(Cache_dir)(RegressionTest *t, int /* atype ATS_UNUSED 
     dir_insert(&key, d, &dir1);
     dir_insert(&key, d, &dir1);
     dir_corrupt_bucket(dir_bucket(b1, dir_segment(s1, d)), s1, d);
-    if (check_dir(d))
+    if (check_dir(d)) {
       ret = REGRESSION_TEST_FAILED;
+    }
 #endif
   }
   vol_dir_clear(d);

--- a/iocore/cache/CacheDisk.cc
+++ b/iocore/cache/CacheDisk.cc
@@ -213,14 +213,16 @@ CacheDisk::syncDone(int event, void * /* data ATS_UNUSED */)
 DiskVolBlock *
 CacheDisk::create_volume(int number, off_t size_in_blocks, int scheme)
 {
-  if (size_in_blocks == 0)
+  if (size_in_blocks == 0) {
     return NULL;
+  }
 
   DiskVolBlockQueue *q             = free_blocks->dpb_queue.head;
   DiskVolBlockQueue *closest_match = q;
 
-  if (!q)
+  if (!q) {
     return NULL;
+  }
 
   off_t max_blocks = MAX_VOL_SIZE >> STORE_BLOCK_SHIFT;
   size_in_blocks   = (size_in_blocks <= max_blocks) ? size_in_blocks : max_blocks;
@@ -234,13 +236,15 @@ CacheDisk::create_volume(int number, off_t size_in_blocks, int scheme)
       q->new_block = 1;
       break;
     } else {
-      if (closest_match->b->len < q->b->len)
+      if (closest_match->b->len < q->b->len) {
         closest_match = q;
+      }
     }
   }
 
-  if (!p && !closest_match)
+  if (!p && !closest_match) {
     return NULL;
+  }
 
   if (!p && closest_match) {
     /* allocate from the closest match */
@@ -272,8 +276,9 @@ CacheDisk::create_volume(int number, off_t size_in_blocks, int scheme)
     free_blocks->size += dpb->len;
     free_space += dpb->len;
     header->num_diskvol_blks++;
-  } else
+  } else {
     header->num_free--;
+  }
 
   p->len    = size_in_blocks;
   p->free   = 0;

--- a/iocore/cache/CacheHosting.cc
+++ b/iocore/cache/CacheHosting.cc
@@ -107,8 +107,9 @@ CacheHostMatcher::Match(char const *rdata, int rlen, CacheHostResult *result)
     return;
   }
 
-  if (rlen == 0)
+  if (rlen == 0) {
     return;
+  }
   char *data = (char *)ats_malloc(rlen + 1);
   memcpy(data, rdata, rlen);
   *(data + rlen) = '\0';
@@ -154,8 +155,9 @@ CacheHostMatcher::NewEntry(matcher_line *line_info)
   ink_assert(match_data != NULL);
 
   // Remove our consumed label from the parsed line
-  if (line_info->dest_entry < MATCHER_MAX_TOKENS)
+  if (line_info->dest_entry < MATCHER_MAX_TOKENS) {
     line_info->line[0][line_info->dest_entry] = NULL;
+  }
   line_info->num_el--;
 
   // Fill in the parameter info
@@ -267,8 +269,9 @@ CacheHostTable::BuildTableFromString(const char *config_file_path, char *file_bu
     // We have an empty file
     /* no hosting customers -- put all the volumes in the
        generic table */
-    if (gen_host_rec.Init(type))
+    if (gen_host_rec.Init(type)) {
       Warning("Problems encountered while initializing the Generic Volume");
+    }
     return 0;
   }
   // First get the number of entries
@@ -351,16 +354,18 @@ CacheHostTable::BuildTableFromString(const char *config_file_path, char *file_bu
         ink_assert(current->dest_entry < MATCHER_MAX_TOKENS);
 
         // Remove our consumed label from the parsed line
-        if (current->dest_entry < MATCHER_MAX_TOKENS)
+        if (current->dest_entry < MATCHER_MAX_TOKENS) {
           current->line[0][current->dest_entry] = NULL;
-        else
+        } else {
           Warning("Problems encountered while initializing the Generic Volume");
+        }
 
         current->num_el--;
-        if (!gen_host_rec.Init(current, type))
+        if (!gen_host_rec.Init(current, type)) {
           generic_rec_initd = 1;
-        else
+        } else {
           Warning("Problems encountered while initializing the Generic Volume");
+        }
 
       } else {
         hostMatch->NewEntry(current);
@@ -461,8 +466,9 @@ CacheHostRecord::Init(matcher_line *line_info, CacheType typ)
   type = typ;
   for (i = 0; i < MATCHER_MAX_TOKENS; i++) {
     char *label = line_info->line[0][i];
-    if (!label)
+    if (!label) {
       continue;
+    }
     char *val;
 
     if (!strcasecmp(label, "volume")) {
@@ -531,8 +537,9 @@ CacheHostRecord::Init(matcher_line *line_info, CacheType typ)
             }
             return -1;
           }
-          if (c == '\0')
+          if (c == '\0') {
             break;
+          }
           vol_no = s + 1;
         }
         s++;
@@ -653,12 +660,13 @@ ConfigVolumes::BuildListFromString(char *config_file_path, char *file_buf)
       }
 
       end = (char *)tmp;
-      while (*end && !isspace(*end))
+      while (*end && !isspace(*end)) {
         end++;
+      }
 
-      if (!(*end))
+      if (!(*end)) {
         line_end = end;
-      else {
+      } else {
         line_end = end + 1;
         *end     = '\0';
       }
@@ -707,8 +715,9 @@ ConfigVolumes::BuildListFromString(char *config_file_path, char *file_buf)
         tmp += 5;
         size = atoi(tmp);
 
-        while (ParseRules::is_digit(*tmp))
+        while (ParseRules::is_digit(*tmp)) {
           tmp++;
+        }
 
         if (*tmp == '%') {
           // added by YTS Team, yamsat for bug id 59632
@@ -726,8 +735,9 @@ ConfigVolumes::BuildListFromString(char *config_file_path, char *file_buf)
       }
 
       // ends here
-      if (end < line_end)
+      if (end < line_end) {
         tmp++;
+      }
     }
 
     if (err) {
@@ -822,8 +832,9 @@ create_config(RegressionTest *t, int num)
       }
       /* create 128 MB volumes */
       for (; blocks >= STORE_BLOCKS_PER_VOL; blocks -= STORE_BLOCKS_PER_VOL) {
-        if (vol_num > 255)
+        if (vol_num > 255) {
           break;
+        }
         ConfigVol *cp  = new ConfigVol();
         cp->number     = vol_num++;
         cp->scheme     = CACHE_HTTP_TYPE;
@@ -904,8 +915,9 @@ create_config(RegressionTest *t, int num)
       }
     }
     while (total_space > 0) {
-      if (vol_num > 255)
+      if (vol_num > 255) {
         break;
+      }
       off_t modu = MAX_VOL_SIZE;
       if (total_space < (MAX_VOL_SIZE >> STORE_BLOCK_SHIFT)) {
         modu = total_space * STORE_BLOCK_SIZE;
@@ -952,8 +964,9 @@ execute_and_verify(RegressionTest *t)
   cplist_reconfigure();
 
   /* compare the volumes */
-  if (cp_list_len != config_volumes.num_volumes)
+  if (cp_list_len != config_volumes.num_volumes) {
     return REGRESSION_TEST_FAILED;
+  }
 
   /* check that the volumes and sizes
      match the configuration */

--- a/iocore/cache/CacheHttp.cc
+++ b/iocore/cache/CacheHttp.cc
@@ -57,8 +57,9 @@ CacheHTTPInfoVector::~CacheHTTPInfoVector()
 int
 CacheHTTPInfoVector::insert(CacheHTTPInfo *info, int index)
 {
-  if (index == CACHE_ALT_INDEX_DEFAULT)
+  if (index == CACHE_ALT_INDEX_DEFAULT) {
     index = xcount++;
+  }
 
   data(index).alternate.copy_shallow(info);
   return index;
@@ -91,11 +92,13 @@ CacheHTTPInfoVector::detach(int idx, CacheHTTPInfo *r)
 void
 CacheHTTPInfoVector::remove(int idx, bool destroy)
 {
-  if (destroy)
+  if (destroy) {
     data[idx].alternate.destroy();
+  }
 
-  for (; idx < (xcount - 1); idx++)
+  for (; idx < (xcount - 1); idx++) {
     data[idx] = data[idx + 1];
+  }
 
   xcount--;
 }

--- a/iocore/cache/CacheLink.cc
+++ b/iocore/cache/CacheLink.cc
@@ -48,10 +48,11 @@ Cache::link(Continuation *cont, const CacheKey *from, const CacheKey *to, CacheF
 
   SET_CONTINUATION_HANDLER(c, &CacheVC::linkWrite);
 
-  if (c->do_write_lock() == EVENT_DONE)
+  if (c->do_write_lock() == EVENT_DONE) {
     return ACTION_RESULT_DONE;
-  else
+  } else {
     return &c->_action;
+  }
 }
 
 int
@@ -60,12 +61,14 @@ CacheVC::linkWrite(int event, Event * /* e ATS_UNUSED */)
   ink_assert(event == AIO_EVENT_DONE);
   set_io_not_in_progress();
   dir_insert(&first_key, vol, &dir);
-  if (_action.cancelled)
+  if (_action.cancelled) {
     goto Ldone;
-  if (io.ok())
+  }
+  if (io.ok()) {
     _action.continuation->handleEvent(CACHE_EVENT_LINK, NULL);
-  else
+  } else {
     _action.continuation->handleEvent(CACHE_EVENT_LINK_FAILED, NULL);
+  }
 Ldone:
   return free_CacheVC(this);
 }
@@ -114,10 +117,11 @@ Cache::deref(Continuation *cont, const CacheKey *key, CacheFragType type, const 
     }
   }
 Lcallreturn:
-  if (c->handleEvent(AIO_EVENT_DONE, 0) == EVENT_DONE)
+  if (c->handleEvent(AIO_EVENT_DONE, 0) == EVENT_DONE) {
     return ACTION_RESULT_DONE;
-  else
+  } else {
     return &c->_action;
+  }
 }
 
 int
@@ -127,19 +131,23 @@ CacheVC::derefRead(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
 
   cancel_trigger();
   set_io_not_in_progress();
-  if (_action.cancelled)
+  if (_action.cancelled) {
     return free_CacheVC(this);
-  if (!buf)
+  }
+  if (!buf) {
     goto Lcollision;
-  if ((int)io.aio_result != (int)io.aiocb.aio_nbytes)
+  }
+  if ((int)io.aio_result != (int)io.aiocb.aio_nbytes) {
     goto Ldone;
+  }
   if (!dir_agg_valid(vol, &dir)) {
     last_collision = NULL;
     goto Lcollision;
   }
   doc = (Doc *)buf->data();
-  if (!(doc->first_key == key))
+  if (!(doc->first_key == key)) {
     goto Lcollision;
+  }
 #ifdef DEBUG
   ink_assert(!memcmp(doc->data(), &doc->key, sizeof(doc->key)));
 #endif
@@ -154,8 +162,9 @@ Lcollision : {
   }
   if (dir_probe(&key, vol, &dir, &last_collision)) {
     int ret = do_read_call(&first_key);
-    if (ret == EVENT_RETURN)
+    if (ret == EVENT_RETURN) {
       goto Lcallreturn;
+    }
     return ret;
   }
 }

--- a/iocore/cache/CachePages.cc
+++ b/iocore/cache/CachePages.cc
@@ -111,10 +111,11 @@ struct ShowCache : public ShowCont {
       if (p) {
         while ((p = strstr(p, "\n"))) {
           nstrings++;
-          if ((size_t)(p - query) >= strlen(query) - 1)
+          if ((size_t)(p - query) >= strlen(query) - 1) {
             break;
-          else
+          } else {
             p++;
+          }
         }
       }
       // initialize url array
@@ -126,13 +127,15 @@ struct ShowCache : public ShowCont {
       if (p) {
         p += 4; // 4 ==> strlen("url=")
         t = strchr(p, '&');
-        if (!t)
+        if (!t) {
           t = (char *)unescapedQuery + strlen(unescapedQuery);
+        }
         for (int s = 0; p < t; s++) {
           show_cache_urlstrs[s][0] = '\0';
           q                        = strstr(p, "%0D%0A" /* \r\n */); // we used this in the JS to separate urls
-          if (!q)
+          if (!q) {
             q = t;
+          }
           ink_strlcpy(show_cache_urlstrs[s], p, q - p + 1);
           p = q + 6; // +6 ==> strlen(%0D%0A)
         }
@@ -155,8 +158,9 @@ struct ShowCache : public ShowCont {
 
   ~ShowCache()
   {
-    if (show_cache_urlstrs)
+    if (show_cache_urlstrs) {
       delete[] show_cache_urlstrs;
+    }
     url.destroy();
   }
 };
@@ -419,8 +423,9 @@ ShowCache::handleCacheEvent(int event, Event *e)
       buffer_reader  = buffer->alloc_reader();
       content_length = cache_vc->get_object_size();
       cvio           = cache_vc->do_io_read(this, content_length, buffer);
-    } else
+    } else {
       buffer_reader->consume(buffer_reader->read_avail());
+    }
     return EVENT_DONE;
   case CACHE_EVENT_OPEN_READ_FAILED:
     // something strange happen, or cache miss in cluster mode.
@@ -452,15 +457,17 @@ ShowCache::lookup_url(int event, Event *e)
   SET_HANDLER(&ShowCache::handleCacheEvent);
   Action *lookup_result =
     cacheProcessor.open_read(this, &key.hash, getClusterCacheLocal(&url), CACHE_FRAG_TYPE_HTTP, key.hostname, key.hostlen);
-  if (!lookup_result)
+  if (!lookup_result) {
     lookup_result = ACTION_IO_ERROR;
-  if (lookup_result == ACTION_RESULT_DONE)
+  }
+  if (lookup_result == ACTION_RESULT_DONE) {
     return EVENT_DONE; // callback complete
-  else if (lookup_result == ACTION_IO_ERROR) {
+  } else if (lookup_result == ACTION_IO_ERROR) {
     handleEvent(CACHE_EVENT_OPEN_READ_FAILED, 0);
     return EVENT_DONE; // callback complete
-  } else
+  } else {
     return EVENT_CONT; // callback pending, will be a cluster read.
+  }
 }
 
 int
@@ -655,12 +662,13 @@ ShowCache::handleCacheScanCallback(int event, Event *e)
   }
   case CACHE_EVENT_SCAN_DONE:
     CHECK_SHOW(show("</TABLE></B>\n"));
-    if (scan_flag == 0)
+    if (scan_flag == 0) {
       if (linecount) {
         CHECK_SHOW(show("<P><INPUT TYPE=button value=\"Delete\" "
                         "onClick=\"setUrls(window.document.f)\"></P>"
                         "</FORM>\n"));
       }
+    }
     CHECK_SHOW(show("<H3>Done</H3>\n"));
     Debug("cache_inspector", "scan done");
     complete(event, e);

--- a/iocore/cache/CachePagesInternal.cc
+++ b/iocore/cache/CachePagesInternal.cc
@@ -85,10 +85,11 @@ register_ShowCacheInternal(Continuation *c, HTTPHdr *h)
     SET_CONTINUATION_HANDLER(theshowcacheInternal, &ShowCacheInternal::showVolumes);
   }
 
-  if (theshowcacheInternal->mutex->thread_holding)
+  if (theshowcacheInternal->mutex->thread_holding) {
     CONT_SCHED_LOCK_RETRY(theshowcacheInternal);
-  else
+  } else {
     eventProcessor.schedule_imm(theshowcacheInternal, ET_TASK);
+  }
   return &theshowcacheInternal->action;
 }
 
@@ -199,8 +200,9 @@ ShowCacheInternal::showVolEvacuations(int event, Event *e)
 {
   Vol *p = gvol[vol_index];
   CACHE_TRY_LOCK(lock, p->mutex, mutex->thread_holding);
-  if (!lock.is_locked())
+  if (!lock.is_locked()) {
     CONT_SCHED_LOCK_RETRY_RET(this);
+  }
 
   EvacuationBlock *b;
   int last = (p->len - (p->start - p->skip)) / EVACUATION_BUCKET_SIZE;
@@ -218,9 +220,9 @@ ShowCacheInternal::showVolEvacuations(int event, Event *e)
     }
   }
   vol_index++;
-  if (vol_index < gnvol)
+  if (vol_index < gnvol) {
     CONT_SCHED_LOCK_RETRY(this);
-  else {
+  } else {
     CHECK_SHOW(show("</table>\n"));
     return complete(event, e);
   }
@@ -255,8 +257,9 @@ ShowCacheInternal::showVolVolumes(int event, Event *e)
 {
   Vol *p = gvol[vol_index];
   CACHE_TRY_LOCK(lock, p->mutex, mutex->thread_holding);
-  if (!lock.is_locked())
+  if (!lock.is_locked()) {
     CONT_SCHED_LOCK_RETRY_RET(this);
+  }
 
   char ctime[256];
   ink_ctime_r(&p->header->create_time, ctime);
@@ -264,8 +267,9 @@ ShowCacheInternal::showVolVolumes(int event, Event *e)
   int agg_todo             = 0;
   int agg_done             = p->agg_buf_pos;
   CacheVC *c               = 0;
-  for (c = p->agg.head; c; c = (CacheVC *)c->link.next)
+  for (c = p->agg.head; c; c = (CacheVC *)c->link.next) {
     agg_todo++;
+  }
   CHECK_SHOW(show("<tr>"
                   "<td>%s</td>"          // ID
                   "<td>%" PRId64 "</td>" // blocks
@@ -311,8 +315,9 @@ ShowCacheInternal::showSegSegment(int event, Event *e)
 {
   Vol *p = gvol[vol_index];
   CACHE_TRY_LOCK(lock, p->mutex, mutex->thread_holding);
-  if (!lock.is_locked())
+  if (!lock.is_locked()) {
     CONT_SCHED_LOCK_RETRY_RET(this);
+  }
   int free = 0, used = 0, empty = 0, valid = 0, agg_valid = 0, avg_size = 0;
   dir_segment_accounted(seg_index, p, 0, &free, &used, &empty, &valid, &agg_valid, &avg_size);
   CHECK_SHOW(show("<tr>"
@@ -325,16 +330,17 @@ ShowCacheInternal::showSegSegment(int event, Event *e)
                   "</tr>\n",
                   free, used, empty, valid, agg_valid, avg_size));
   seg_index++;
-  if (seg_index < p->segments)
+  if (seg_index < p->segments) {
     CONT_SCHED_LOCK_RETRY(this);
-  else {
+  } else {
     CHECK_SHOW(show("</table>\n"));
     seg_index = 0;
     vol_index++;
-    if (vol_index < gnvol)
+    if (vol_index < gnvol) {
       CONT_SCHED_LOCK_RETRY(this);
-    else
+    } else {
       return complete(event, e);
+    }
   }
   return EVENT_CONT;
 }

--- a/iocore/cache/CacheRead.cc
+++ b/iocore/cache/CacheRead.cc
@@ -57,14 +57,16 @@ Cache::open_read(Continuation *cont, const CacheKey *key, CacheFragType type, co
       c->frag_type                            = type;
       c->od                                   = od;
     }
-    if (!c)
+    if (!c) {
       goto Lmiss;
+    }
     if (!lock.is_locked()) {
       CONT_SCHED_LOCK_RETRY(c);
       return &c->_action;
     }
-    if (c->od)
+    if (c->od) {
       goto Lwriter;
+    }
     c->dir            = result;
     c->last_collision = last_collision;
     switch (c->do_read_call(&c->key)) {
@@ -82,12 +84,14 @@ Lmiss:
   return ACTION_RESULT_DONE;
 Lwriter:
   SET_CONTINUATION_HANDLER(c, &CacheVC::openReadFromWriter);
-  if (c->handleEvent(EVENT_IMMEDIATE, 0) == EVENT_DONE)
+  if (c->handleEvent(EVENT_IMMEDIATE, 0) == EVENT_DONE) {
     return ACTION_RESULT_DONE;
+  }
   return &c->_action;
 Lcallreturn:
-  if (c->handleEvent(AIO_EVENT_DONE, 0) == EVENT_DONE)
+  if (c->handleEvent(AIO_EVENT_DONE, 0) == EVENT_DONE) {
     return ACTION_RESULT_DONE;
+  }
   return &c->_action;
 }
 
@@ -127,10 +131,12 @@ Cache::open_read(Continuation *cont, const CacheKey *key, CacheHTTPHdr *request,
       CONT_SCHED_LOCK_RETRY(c);
       return &c->_action;
     }
-    if (!c)
+    if (!c) {
       goto Lmiss;
-    if (c->od)
+    }
+    if (c->od) {
       goto Lwriter;
+    }
     // hit
     c->dir = c->first_dir = result;
     c->last_collision     = last_collision;
@@ -152,12 +158,14 @@ Lwriter:
   // this is a horrible violation of the interface and should be fixed (FIXME)
   ((HttpCacheSM *)cont)->set_readwhilewrite_inprogress(true);
   SET_CONTINUATION_HANDLER(c, &CacheVC::openReadFromWriter);
-  if (c->handleEvent(EVENT_IMMEDIATE, 0) == EVENT_DONE)
+  if (c->handleEvent(EVENT_IMMEDIATE, 0) == EVENT_DONE) {
     return ACTION_RESULT_DONE;
+  }
   return &c->_action;
 Lcallreturn:
-  if (c->handleEvent(AIO_EVENT_DONE, 0) == EVENT_DONE)
+  if (c->handleEvent(AIO_EVENT_DONE, 0) == EVENT_DONE) {
     return ACTION_RESULT_DONE;
+  }
   return &c->_action;
 }
 #endif
@@ -197,8 +205,9 @@ CacheVC::openReadChooseWriter(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSE
 
   ink_assert(vol->mutex->thread_holding == mutex->thread_holding && write_vc == NULL);
 
-  if (!od)
+  if (!od) {
     return EVENT_RETURN;
+  }
 
   if (frag_type != CACHE_FRAG_TYPE_HTTP) {
     ink_assert(od->num_writers == 1);
@@ -207,26 +216,30 @@ CacheVC::openReadChooseWriter(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSE
       od = NULL;
       return EVENT_RETURN;
     }
-    if (!w->closed)
+    if (!w->closed) {
       return -err;
+    }
     write_vc = w;
   }
 #ifdef HTTP_CACHE
   else {
     write_vector      = &od->vector;
     int write_vec_cnt = write_vector->count();
-    for (int c = 0; c < write_vec_cnt; c++)
+    for (int c = 0; c < write_vec_cnt; c++) {
       vector.insert(write_vector->get(c));
+    }
     // check if all the writers who came before this reader have
     // set the http_info.
     for (w = (CacheVC *)od->writers.head; w; w = (CacheVC *)w->opendir_link.next) {
-      if (w->start_time > start_time || w->closed < 0)
+      if (w->start_time > start_time || w->closed < 0) {
         continue;
+      }
       if (!w->closed && !cache_config_read_while_writer) {
         return -err;
       }
-      if (w->alternate_index != CACHE_ALT_INDEX_DEFAULT)
+      if (w->alternate_index != CACHE_ALT_INDEX_DEFAULT) {
         continue;
+      }
 
       if (!w->closed && !w->alternate.valid()) {
         od = NULL;
@@ -241,14 +254,16 @@ CacheVC::openReadChooseWriter(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSE
         alt_ndx = get_alternate_index(&vector, w->update_key);
         // if its an alternate delete
         if (!w->alternate.valid()) {
-          if (alt_ndx >= 0)
+          if (alt_ndx >= 0) {
             vector.remove(alt_ndx, false);
+          }
           continue;
         }
       }
       ink_assert(w->alternate.valid());
-      if (w->alternate.valid())
+      if (w->alternate.valid()) {
         vector.insert(&w->alternate, alt_ndx);
+      }
     }
 
     if (!vector.count()) {
@@ -263,10 +278,12 @@ CacheVC::openReadChooseWriter(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSE
     }
     if (cache_config_select_alternate) {
       alternate_index = HttpTransactCache::SelectFromAlternates(&vector, &request, params);
-      if (alternate_index < 0)
+      if (alternate_index < 0) {
         return -ECACHE_ALT_MISS;
-    } else
-      alternate_index  = 0;
+      }
+    } else {
+      alternate_index = 0;
+    }
     CacheHTTPInfo *obj = vector.get(alternate_index);
     for (w = (CacheVC *)od->writers.head; w; w = (CacheVC *)w->opendir_link.next) {
       if (obj->m_alt == w->alternate.m_alt) {
@@ -314,16 +331,18 @@ CacheVC::openReadFromWriter(int event, Event *e)
     return free_CacheVC(this);
   }
   CACHE_TRY_LOCK(lock, vol->mutex, mutex->thread_holding);
-  if (!lock.is_locked())
+  if (!lock.is_locked()) {
     VC_SCHED_LOCK_RETRY();
+  }
   od = vol->open_read(&first_key); // recheck in case the lock failed
   if (!od) {
     MUTEX_RELEASE(lock);
     write_vc = NULL;
     SET_HANDLER(&CacheVC::openReadStartHead);
     return openReadStartHead(event, e);
-  } else
+  } else {
     ink_assert(od == vol->open_read(&first_key));
+  }
   if (!write_vc) {
     int ret = openReadChooseWriter(event, e);
     if (ret < 0) {
@@ -341,8 +360,9 @@ CacheVC::openReadFromWriter(int event, Event *e)
       } else {
         return openReadFromWriterFailure(CACHE_EVENT_OPEN_READ_FAILED, (Event *)-err);
       }
-    } else
+    } else {
       ink_assert(write_vc);
+    }
   } else {
     if (writer_done()) {
       MUTEX_RELEASE(lock);
@@ -385,24 +405,27 @@ CacheVC::openReadFromWriter(int event, Event *e)
   }
   MUTEX_RELEASE(lock);
 
-  if (!write_vc->io.ok())
+  if (!write_vc->io.ok()) {
     return openReadFromWriterFailure(CACHE_EVENT_OPEN_READ_FAILED, (Event *)-err);
+  }
 #ifdef HTTP_CACHE
   if (frag_type == CACHE_FRAG_TYPE_HTTP) {
     DDebug("cache_read_agg", "%p: key: %X http passed stage 1, closed: %d, frag: %d", this, first_key.slice32(1), write_vc->closed,
            write_vc->fragment);
-    if (!write_vc->alternate.valid())
+    if (!write_vc->alternate.valid()) {
       return openReadFromWriterFailure(CACHE_EVENT_OPEN_READ_FAILED, (Event *)-err);
+    }
     alternate.copy(&write_vc->alternate);
     vector.insert(&alternate);
     alternate.object_key_get(&key);
     write_vc->f.readers = 1;
     if (!(write_vc->f.update && write_vc->total_len == 0)) {
       key = write_vc->earliest_key;
-      if (!write_vc->closed)
+      if (!write_vc->closed) {
         alternate.object_size_set(write_vc->vio.nbytes);
-      else
+      } else {
         alternate.object_size_set(write_vc->total_len);
+      }
     } else {
       key = write_vc->update_key;
       ink_assert(write_vc->closed);
@@ -481,8 +504,9 @@ CacheVC::openReadFromWriterMain(int /* event ATS_UNUSED */, Event * /* e ATS_UNU
   }
   IOBufferBlock *b = NULL;
   int64_t ntodo    = vio.ntodo();
-  if (ntodo <= 0)
+  if (ntodo <= 0) {
     return EVENT_CONT;
+  }
   if (length < ((int64_t)doc_len) - vio.ndone) {
     DDebug("cache_read_agg", "truncation %X", first_key.slice32(1));
     if (is_action_tag_set("cache")) {
@@ -498,8 +522,9 @@ CacheVC::openReadFromWriterMain(int /* event ATS_UNUSED */, Event * /* e ATS_UNU
     iobufferblock_skip(writer_buf.get(), &writer_offset, &length, skip_bytes);
   }
   int64_t bytes = length;
-  if (bytes > vio.ntodo())
+  if (bytes > vio.ntodo()) {
     bytes = vio.ntodo();
+  }
   if (vio.ndone >= (int64_t)doc_len) {
     ink_assert(bytes <= 0);
     // reached the end of the document and the user still wants more
@@ -509,10 +534,11 @@ CacheVC::openReadFromWriterMain(int /* event ATS_UNUSED */, Event * /* e ATS_UNU
   writer_buf = iobufferblock_skip(writer_buf.get(), &writer_offset, &length, bytes);
   vio.buffer.writer()->append_block(b);
   vio.ndone += bytes;
-  if (vio.ntodo() <= 0)
+  if (vio.ntodo() <= 0) {
     return calluser(VC_EVENT_READ_COMPLETE);
-  else
+  } else {
     return calluser(VC_EVENT_READ_READY);
+  }
 }
 
 int
@@ -520,17 +546,19 @@ CacheVC::openReadClose(int event, Event * /* e ATS_UNUSED */)
 {
   cancel_trigger();
   if (is_io_in_progress()) {
-    if (event != AIO_EVENT_DONE)
+    if (event != AIO_EVENT_DONE) {
       return EVENT_CONT;
+    }
     set_io_not_in_progress();
   }
   CACHE_TRY_LOCK(lock, vol->mutex, mutex->thread_holding);
-  if (!lock.is_locked())
+  if (!lock.is_locked()) {
     VC_SCHED_LOCK_RETRY();
+  }
   if (f.hit_evacuate && dir_valid(vol, &first_dir) && closed > 0) {
-    if (f.single_fragment)
+    if (f.single_fragment) {
       vol->force_evacuate_head(&first_dir, dir_pinned(&first_dir));
-    else if (dir_valid(vol, &earliest_dir)) {
+    } else if (dir_valid(vol, &earliest_dir)) {
       vol->force_evacuate_head(&first_dir, dir_pinned(&first_dir));
       vol->force_evacuate_head(&earliest_dir, dir_pinned(&earliest_dir));
     }
@@ -545,13 +573,15 @@ CacheVC::openReadReadDone(int event, Event *e)
   Doc *doc = NULL;
 
   cancel_trigger();
-  if (event == EVENT_IMMEDIATE)
+  if (event == EVENT_IMMEDIATE) {
     return EVENT_CONT;
+  }
   set_io_not_in_progress();
   {
     CACHE_TRY_LOCK(lock, vol->mutex, mutex->thread_holding);
-    if (!lock.is_locked())
+    if (!lock.is_locked()) {
       VC_SCHED_LOCK_RETRY();
+    }
     if (event == AIO_EVENT_DONE && !io.ok()) {
       dir_delete(&earliest_key, vol, &earliest_dir);
       goto Lerror;
@@ -562,21 +592,25 @@ CacheVC::openReadReadDone(int event, Event *e)
       doc = (Doc *)buf->data();
       if (doc->magic != DOC_MAGIC) {
         char tmpstring[100];
-        if (doc->magic == DOC_CORRUPT)
+        if (doc->magic == DOC_CORRUPT) {
           Warning("Middle: Doc checksum does not match for %s", key.toHexStr(tmpstring));
-        else
+        } else {
           Warning("Middle: Doc magic does not match for %s", key.toHexStr(tmpstring));
+        }
         goto Lerror;
       }
-      if (doc->key == key)
+      if (doc->key == key) {
         goto LreadMain;
+      }
     }
-    if (last_collision && dir_offset(&dir) != dir_offset(last_collision))
+    if (last_collision && dir_offset(&dir) != dir_offset(last_collision)) {
       last_collision = 0; // object has been/is being overwritten
+    }
     if (dir_probe(&key, vol, &dir, &last_collision)) {
       int ret = do_read_call(&key);
-      if (ret == EVENT_RETURN)
+      if (ret == EVENT_RETURN) {
         goto Lcallreturn;
+      }
       return EVENT_CONT;
     } else if (write_vc) {
       if (writer_done()) {
@@ -659,8 +693,9 @@ CacheVC::openReadMain(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
         while (seek_to >= next_off && target < lfi) {
           next_off = frags[++target];
         }
-        if (target == lfi && seek_to >= next_off)
+        if (target == lfi && seek_to >= next_off) {
           ++target;
+        }
       } else { // shortcut if we are in the fragment already
         target = fragment;
       }
@@ -687,8 +722,9 @@ CacheVC::openReadMain(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
       }
     }
     doc_pos = doc->prefix_len() + seek_to;
-    if (fragment)
+    if (fragment) {
       doc_pos -= static_cast<int64_t>(frags[fragment - 1]);
+    }
     vio.ndone = 0;
     seek_to   = 0;
     ntodo     = vio.ntodo();
@@ -700,34 +736,41 @@ CacheVC::openReadMain(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     }
 #endif
   }
-  if (ntodo <= 0)
+  if (ntodo <= 0) {
     return EVENT_CONT;
-  if (vio.buffer.writer()->max_read_avail() > vio.buffer.writer()->water_mark && vio.ndone) // initiate read of first block
+  }
+  if (vio.buffer.writer()->max_read_avail() > vio.buffer.writer()->water_mark && vio.ndone) { // initiate read of first block
     return EVENT_CONT;
-  if ((bytes <= 0) && vio.ntodo() >= 0)
+  }
+  if ((bytes <= 0) && vio.ntodo() >= 0) {
     goto Lread;
-  if (bytes > vio.ntodo())
-    bytes     = vio.ntodo();
+  }
+  if (bytes > vio.ntodo()) {
+    bytes = vio.ntodo();
+  }
   b           = new_IOBufferBlock(buf, bytes, doc_pos);
   b->_buf_end = b->_end;
   vio.buffer.writer()->append_block(b);
   vio.ndone += bytes;
   doc_pos += bytes;
-  if (vio.ntodo() <= 0)
+  if (vio.ntodo() <= 0) {
     return calluser(VC_EVENT_READ_COMPLETE);
-  else {
-    if (calluser(VC_EVENT_READ_READY) == EVENT_DONE)
+  } else {
+    if (calluser(VC_EVENT_READ_READY) == EVENT_DONE) {
       return EVENT_DONE;
+    }
     // we have to keep reading until we give the user all the
     // bytes it wanted or we hit the watermark.
-    if (vio.ntodo() > 0 && !vio.buffer.writer()->high_water())
+    if (vio.ntodo() > 0 && !vio.buffer.writer()->high_water()) {
       goto Lread;
+    }
     return EVENT_CONT;
   }
 Lread : {
-  if (vio.ndone >= (int64_t)doc_len)
+  if (vio.ndone >= (int64_t)doc_len) {
     // reached the end of the document and the user still wants more
     return calluser(VC_EVENT_EOS);
+  }
   last_collision    = 0;
   writer_lock_retry = 0;
   // if the state machine calls reenable on the callback from the cache,
@@ -743,8 +786,9 @@ Lread : {
   if (dir_probe(&key, vol, &dir, &last_collision)) {
     SET_HANDLER(&CacheVC::openReadReadDone);
     int ret = do_read_call(&key);
-    if (ret == EVENT_RETURN)
+    if (ret == EVENT_RETURN) {
       goto Lcallreturn;
+    }
     return EVENT_CONT;
   } else if (write_vc) {
     if (writer_done()) {
@@ -763,8 +807,9 @@ Lread : {
     SET_HANDLER(&CacheVC::openReadMain);
     VC_SCHED_WRITER_RETRY();
   }
-  if (is_action_tag_set("cache"))
+  if (is_action_tag_set("cache")) {
     ink_release_assert(false);
+  }
   Warning("Document %X truncated at %d of %d, missing fragment %X", first_key.slice32(1), (int)vio.ndone, (int)doc_len,
           key.slice32(1));
   // remove the directory entry
@@ -789,22 +834,27 @@ CacheVC::openReadStartEarliest(int /* event ATS_UNUSED */, Event * /* e ATS_UNUS
   Doc *doc = NULL;
   cancel_trigger();
   set_io_not_in_progress();
-  if (_action.cancelled)
+  if (_action.cancelled) {
     return free_CacheVC(this);
+  }
   {
     CACHE_TRY_LOCK(lock, vol->mutex, mutex->thread_holding);
-    if (!lock.is_locked())
+    if (!lock.is_locked()) {
       VC_SCHED_LOCK_RETRY();
-    if (!buf)
+    }
+    if (!buf) {
       goto Lread;
-    if (!io.ok())
+    }
+    if (!io.ok()) {
       goto Ldone;
+    }
     // an object needs to be outside the aggregation window in order to be
     // be evacuated as it is read
     if (!dir_agg_valid(vol, &dir)) {
       // a directory entry which is nolonger valid may have been overwritten
-      if (!dir_valid(vol, &dir))
+      if (!dir_valid(vol, &dir)) {
         last_collision = NULL;
+      }
       goto Lread;
     }
     doc = (Doc *)buf->data();
@@ -813,10 +863,11 @@ CacheVC::openReadStartEarliest(int /* event ATS_UNUSED */, Event * /* e ATS_UNUS
       if (is_action_tag_set("cache")) {
         ink_release_assert(false);
       }
-      if (doc->magic == DOC_CORRUPT)
+      if (doc->magic == DOC_CORRUPT) {
         Warning("Earliest: Doc checksum does not match for %s", key.toHexStr(tmpstring));
-      else
+      } else {
         Warning("Earliest : Doc magic does not match for %s", key.toHexStr(tmpstring));
+      }
       // remove the dir entry
       dir_delete(&key, vol, &dir);
       // try going through the directory entries again
@@ -826,8 +877,9 @@ CacheVC::openReadStartEarliest(int /* event ATS_UNUSED */, Event * /* e ATS_UNUS
       last_collision = NULL;
       goto Lread;
     }
-    if (!(doc->key == key)) // collisiion
+    if (!(doc->key == key)) { // collisiion
       goto Lread;
+    }
     // success
     earliest_key = key;
     doc_pos      = doc->prefix_len();
@@ -843,8 +895,9 @@ CacheVC::openReadStartEarliest(int /* event ATS_UNUSED */, Event * /* e ATS_UNUS
   Lread:
     if (dir_probe(&key, vol, &earliest_dir, &last_collision) || dir_lookaside_probe(&key, vol, &earliest_dir, NULL)) {
       dir = earliest_dir;
-      if ((ret = do_read_call(&key)) == EVENT_RETURN)
+      if ((ret = do_read_call(&key)) == EVENT_RETURN) {
         goto Lcallreturn;
+      }
       return ret;
     }
 // read has detected that alternate does not exist in the cache.
@@ -895,8 +948,9 @@ CacheVC::openReadStartEarliest(int /* event ATS_UNUSED */, Event * /* e ATS_UNUS
             dir_set_tag(&od->single_doc_dir, od->single_doc_key.slice32(2));
           }
           SET_HANDLER(&CacheVC::openReadVecWrite);
-          if ((ret = do_write_call()) == EVENT_RETURN)
+          if ((ret = do_write_call()) == EVENT_RETURN) {
             goto Lcallreturn;
+          }
           return ret;
         }
       }
@@ -904,8 +958,9 @@ CacheVC::openReadStartEarliest(int /* event ATS_UNUSED */, Event * /* e ATS_UNUS
 #endif
   // open write failure - another writer, so don't modify the vector
   Ldone:
-    if (od)
+    if (od) {
       vol->close_write(this);
+    }
   }
   CACHE_INCREMENT_DYN_STAT(cache_read_failure_stat);
   _action.continuation->handleEvent(CACHE_EVENT_OPEN_READ_FAILED, (void *)-ECACHE_NO_DOC);
@@ -929,12 +984,14 @@ CacheVC::openReadVecWrite(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */
   set_io_not_in_progress();
   ink_assert(od);
   od->writing_vec = 0;
-  if (_action.cancelled)
+  if (_action.cancelled) {
     return openWriteCloseDir(EVENT_IMMEDIATE, 0);
+  }
   {
     CACHE_TRY_LOCK(lock, vol->mutex, mutex->thread_holding);
-    if (!lock.is_locked())
+    if (!lock.is_locked()) {
       VC_SCHED_LOCK_RETRY();
+    }
     if (io.ok()) {
       ink_assert(f.evac_vector);
       ink_assert(frag_type == CACHE_FRAG_TYPE_HTTP);
@@ -946,8 +1003,9 @@ CacheVC::openReadVecWrite(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */
       f.use_first_key = 0;
       vio.op          = VIO::READ;
       dir_overwrite(&first_key, vol, &dir, &od->first_dir);
-      if (od->move_resident_alt)
+      if (od->move_resident_alt) {
         dir_insert(&od->single_doc_key, vol, &od->single_doc_dir);
+      }
       int alt_ndx = HttpTransactCache::SelectFromAlternates(write_vector, &request, params);
       vol->close_write(this);
       if (alt_ndx >= 0) {
@@ -982,22 +1040,27 @@ CacheVC::openReadStartHead(int event, Event *e)
   Doc *doc     = NULL;
   cancel_trigger();
   set_io_not_in_progress();
-  if (_action.cancelled)
+  if (_action.cancelled) {
     return free_CacheVC(this);
+  }
   {
     CACHE_TRY_LOCK(lock, vol->mutex, mutex->thread_holding);
-    if (!lock.is_locked())
+    if (!lock.is_locked()) {
       VC_SCHED_LOCK_RETRY();
-    if (!buf)
+    }
+    if (!buf) {
       goto Lread;
-    if (!io.ok())
+    }
+    if (!io.ok()) {
       goto Ldone;
+    }
     // an object needs to be outside the aggregation window in order to be
     // be evacuated as it is read
     if (!dir_agg_valid(vol, &dir)) {
       // a directory entry which is nolonger valid may have been overwritten
-      if (!dir_valid(vol, &dir))
+      if (!dir_valid(vol, &dir)) {
         last_collision = NULL;
+      }
       goto Lread;
     }
     doc = (Doc *)buf->data();
@@ -1006,10 +1069,11 @@ CacheVC::openReadStartHead(int event, Event *e)
       if (is_action_tag_set("cache")) {
         ink_release_assert(false);
       }
-      if (doc->magic == DOC_CORRUPT)
+      if (doc->magic == DOC_CORRUPT) {
         Warning("Head: Doc checksum does not match for %s", key.toHexStr(tmpstring));
-      else
+      } else {
         Warning("Head : Doc magic does not match for %s", key.toHexStr(tmpstring));
+      }
       // remove the dir entry
       dir_delete(&key, vol, &dir);
       // try going through the directory entries again
@@ -1019,18 +1083,21 @@ CacheVC::openReadStartHead(int event, Event *e)
       last_collision = NULL;
       goto Lread;
     }
-    if (!(doc->first_key == key))
+    if (!(doc->first_key == key)) {
       goto Lread;
-    if (f.lookup)
+    }
+    if (f.lookup) {
       goto Lookup;
+    }
     earliest_dir = dir;
 #ifdef HTTP_CACHE
     CacheHTTPInfo *alternate_tmp;
     if (frag_type == CACHE_FRAG_TYPE_HTTP) {
       uint32_t uml;
       ink_assert(doc->hlen);
-      if (!doc->hlen)
+      if (!doc->hlen) {
         goto Ldone;
+      }
       if ((uml = this->load_http_info(&vector, doc)) != doc->hlen) {
         if (buf) {
           HTTPCacheAlt *alt  = reinterpret_cast<HTTPCacheAlt *>(doc->hdr());
@@ -1039,8 +1106,9 @@ CacheVC::openReadStartHead(int event, Event *e)
           // by bad disk data - count should be the number of successfully unmarshalled alts.
           for (int32_t i = 0; i < vector.count(); ++i) {
             CacheHTTPInfo *info = vector.get(i);
-            if (info && info->m_alt)
+            if (info && info->m_alt) {
               alt_length += info->m_alt->m_unmarshal_len;
+            }
           }
           Note("OpenReadHead failed for cachekey %X : vector inconsistency - "
                "unmarshalled %d expecting %d in %d (base=%d, ver=%d:%d) "
@@ -1062,9 +1130,10 @@ CacheVC::openReadStartHead(int event, Event *e)
           err = ECACHE_ALT_MISS;
           goto Ldone;
         }
-      } else
+      } else {
         alternate_index = 0;
-      alternate_tmp     = vector.get(alternate_index);
+      }
+      alternate_tmp = vector.get(alternate_index);
       if (!alternate_tmp->valid()) {
         if (buf) {
           Note("OpenReadHead failed for cachekey %X : alternate inconsistency", key.slice32(0));
@@ -1107,8 +1176,9 @@ CacheVC::openReadStartHead(int event, Event *e)
     }
     // the first fragment might have been gc'ed. Make sure the first
     // fragment is there before returning CACHE_EVENT_OPEN_READ
-    if (!f.single_fragment)
+    if (!f.single_fragment) {
       goto Learliest;
+    }
 
     if (vol->within_hit_evacuate_window(&dir) &&
         (!cache_config_hit_evacuate_size_limit || doc_len <= (uint64_t)cache_config_hit_evacuate_size_limit)) {
@@ -1142,8 +1212,9 @@ CacheVC::openReadStartHead(int event, Event *e)
     if (dir_probe(&key, vol, &dir, &last_collision)) {
       first_dir = dir;
       int ret   = do_read_call(&key);
-      if (ret == EVENT_RETURN)
+      if (ret == EVENT_RETURN) {
         goto Lcallreturn;
+      }
       return ret;
     }
   }

--- a/iocore/cache/CacheTest.cc
+++ b/iocore/cache/CacheTest.cc
@@ -64,10 +64,12 @@ CacheTestSM::~CacheTestSM()
 {
   ink_assert(!cache_action);
   ink_assert(!cache_vc);
-  if (buffer_reader)
+  if (buffer_reader) {
     buffer->dealloc_reader(buffer_reader);
-  if (buffer)
+  }
+  if (buffer) {
     free_MIOBuffer(buffer);
+  }
 }
 
 int
@@ -114,24 +116,27 @@ CacheTestSM::event_handler(int event, void *data)
     cache_vc      = (CacheVConnection *)data;
     buffer        = new_empty_MIOBuffer();
     buffer_reader = buffer->alloc_reader();
-    if (open_read_callout() < 0)
+    if (open_read_callout() < 0) {
       goto Lclose_error_next;
-    else
+    } else {
       return EVENT_DONE;
+    }
 
   case CACHE_EVENT_OPEN_READ_FAILED:
     goto Lcancel_next;
 
   case VC_EVENT_READ_READY:
-    if (!check_buffer())
+    if (!check_buffer()) {
       goto Lclose_error_next;
+    }
     buffer_reader->consume(buffer_reader->read_avail());
     ((VIO *)data)->reenable();
     return EVENT_CONT;
 
   case VC_EVENT_READ_COMPLETE:
-    if (!check_buffer())
+    if (!check_buffer()) {
       goto Lclose_error_next;
+    }
     goto Lclose_next;
 
   case VC_EVENT_ERROR:
@@ -145,10 +150,11 @@ CacheTestSM::event_handler(int event, void *data)
     cache_vc      = (CacheVConnection *)data;
     buffer        = new_empty_MIOBuffer();
     buffer_reader = buffer->alloc_reader();
-    if (open_write_callout() < 0)
+    if (open_write_callout() < 0) {
       goto Lclose_error_next;
-    else
+    } else {
       return EVENT_DONE;
+    }
 
   case CACHE_EVENT_OPEN_WRITE_FAILED:
     goto Lcancel_next;
@@ -159,8 +165,9 @@ CacheTestSM::event_handler(int event, void *data)
     return EVENT_CONT;
 
   case VC_EVENT_WRITE_COMPLETE:
-    if (nbytes != cvio->ndone)
+    if (nbytes != cvio->ndone) {
       goto Lclose_error_next;
+    }
     goto Lclose_next;
 
   case CACHE_EVENT_REMOVE:
@@ -220,8 +227,9 @@ Lnext:
     repeat_count--;
     timeout = eventProcessor.schedule_imm(this);
     return EVENT_DONE;
-  } else
+  } else {
     return complete(event);
+  }
 }
 
 void
@@ -233,14 +241,16 @@ CacheTestSM::fill_buffer()
   int64_t sk = (int64_t)sizeof(key);
   while (avail > 0) {
     int64_t l = avail;
-    if (l > sk)
+    if (l > sk) {
       l = sk;
+    }
 
     int64_t pos = cvio->ndone + buffer_reader->read_avail();
     int64_t o   = pos % sk;
 
-    if (l > sk - o)
-      l     = sk - o;
+    if (l > sk - o) {
+      l = sk - o;
+    }
     k.b[0]  = pos / sk;
     char *x = ((char *)&k) + o;
     buffer->write(x, l);
@@ -260,16 +270,19 @@ CacheTestSM::check_buffer()
   int64_t pos = cvio->ndone - buffer_reader->read_avail();
   while (avail > 0) {
     int64_t l = avail;
-    if (l > sk)
-      l       = sk;
+    if (l > sk) {
+      l = sk;
+    }
     int64_t o = pos % sk;
-    if (l > sk - o)
-      l     = sk - o;
+    if (l > sk - o) {
+      l = sk - o;
+    }
     k.b[0]  = pos / sk;
     char *x = ((char *)&k) + o;
     buffer_reader->read(&b[0], l);
-    if (::memcmp(b, x, l))
+    if (::memcmp(b, x, l)) {
       return 0;
+    }
     buffer_reader->consume(l);
     pos += l;
     avail -= l;
@@ -286,10 +299,11 @@ CacheTestSM::check_result(int event)
 int
 CacheTestSM::complete(int event)
 {
-  if (!check_result(event))
+  if (!check_result(event)) {
     done(REGRESSION_TEST_FAILED);
-  else
+  } else {
     done(REGRESSION_TEST_PASSED);
+  }
   delete this;
   return EVENT_DONE;
 }
@@ -479,15 +493,18 @@ REGRESSION_TEST(cache_disk_replacement_stability)(RegressionTest *t, int level, 
   int to = 0, from = 0;
   int then = 0, now = 0;
   for (int i = 0; i < VOL_HASH_TABLE_SIZE; ++i) {
-    if (hr1.vol_hash_table[i] == sample_idx)
+    if (hr1.vol_hash_table[i] == sample_idx) {
       ++then;
-    if (hr2.vol_hash_table[i] == sample_idx)
+    }
+    if (hr2.vol_hash_table[i] == sample_idx) {
       ++now;
+    }
     if (hr1.vol_hash_table[i] != hr2.vol_hash_table[i]) {
-      if (hr1.vol_hash_table[i] == sample_idx)
+      if (hr1.vol_hash_table[i] == sample_idx) {
         ++from;
-      else
+      } else {
         ++to;
+      }
     }
   }
   rprintf(t, "Cache stability difference - "
@@ -509,16 +526,20 @@ static double *zipf_table = NULL;
 static void
 build_zipf()
 {
-  if (zipf_table)
+  if (zipf_table) {
     return;
+  }
   zipf_table = (double *)ats_malloc(ZIPF_SIZE * sizeof(double));
-  for (int i      = 0; i < ZIPF_SIZE; i++)
+  for (int i = 0; i < ZIPF_SIZE; i++) {
     zipf_table[i] = 1.0 / pow(i + 2, zipf_alpha);
-  for (int i      = 1; i < ZIPF_SIZE; i++)
+  }
+  for (int i = 1; i < ZIPF_SIZE; i++) {
     zipf_table[i] = zipf_table[i - 1] + zipf_table[i];
-  double x        = zipf_table[ZIPF_SIZE - 1];
-  for (int i      = 0; i < ZIPF_SIZE; i++)
+  }
+  double x = zipf_table[ZIPF_SIZE - 1];
+  for (int i = 0; i < ZIPF_SIZE; i++) {
     zipf_table[i] = zipf_table[i] / x;
+  }
 }
 
 static int
@@ -527,13 +548,15 @@ get_zipf(double v)
   int l = 0, r = ZIPF_SIZE - 1, m;
   do {
     m = (r + l) / 2;
-    if (v < zipf_table[m])
+    if (v < zipf_table[m]) {
       r = m - 1;
-    else
+    } else {
       l = m + 1;
+    }
   } while (l < r);
-  if (zipf_bucket_size == 1)
+  if (zipf_bucket_size == 1) {
     return m;
+  }
   double x = zipf_table[m], y = zipf_table[m + 1];
   m += static_cast<int>((v - x) / (y - x));
   return m;
@@ -586,9 +609,10 @@ test_RamCache(RegressionTest *t, RamCache *cache, const char *name, int64_t cach
   build_zipf();
   srand48(13);
   int *r = (int *)ats_malloc(sample_size * sizeof(int));
-  for (int i = 0; i < sample_size; i++)
+  for (int i = 0; i < sample_size; i++) {
     // coverity[dont_call]
     r[i] = get_zipf(drand48());
+  }
   data.clear();
   int misses = 0;
   for (int i = 0; i < sample_size; i++) {
@@ -601,8 +625,9 @@ test_RamCache(RegressionTest *t, RamCache *cache, const char *name, int64_t cach
       d->alloc(BUFFER_SIZE_INDEX_16K);
       data.push_back(make_ptr(d));
       cache->put(&md5, data.back().get(), 1 << 15);
-      if (i >= sample_size / 2)
+      if (i >= sample_size / 2) {
         misses++; // Sample last half of the gets.
+      }
     }
   }
   double fixed_hit_rate = 1.0 - (((double)(misses)) / (sample_size / 2));
@@ -620,8 +645,9 @@ test_RamCache(RegressionTest *t, RamCache *cache, const char *name, int64_t cach
       d->alloc(BUFFER_SIZE_INDEX_8K + (r[i] % 3));
       data.push_back(make_ptr(d));
       cache->put(&md5, data.back().get(), d->block_size());
-      if (i >= sample_size / 2)
+      if (i >= sample_size / 2) {
         misses++; // Sample last half of the gets.
+      }
     }
   }
   double variable_hit_rate = 1.0 - (((double)(misses)) / (sample_size / 2));
@@ -629,10 +655,12 @@ test_RamCache(RegressionTest *t, RamCache *cache, const char *name, int64_t cach
 
   rprintf(t, "RamCache %s Nominal Size %lld Size %lld\n", name, cache_size, cache->size());
 
-  if (fixed_hit_rate < 0.55 || variable_hit_rate < 0.55)
+  if (fixed_hit_rate < 0.55 || variable_hit_rate < 0.55) {
     return false;
-  if (abs(cache_size - cache->size()) > 0.02 * cache_size)
+  }
+  if (abs(cache_size - cache->size()) > 0.02 * cache_size) {
     return false;
+  }
 
   ats_free(r);
 
@@ -657,7 +685,8 @@ REGRESSION_TEST(ram_cache)(RegressionTest *t, int level, int *pstatus)
   for (int s = 20; s <= 28; s += 4) {
     int64_t cache_size = 1LL << s;
     *pstatus           = REGRESSION_TEST_PASSED;
-    if (!test_RamCache(t, new_RamCacheLRU(), "LRU", cache_size) || !test_RamCache(t, new_RamCacheCLFUS(), "CLFUS", cache_size))
+    if (!test_RamCache(t, new_RamCacheLRU(), "LRU", cache_size) || !test_RamCache(t, new_RamCacheCLFUS(), "CLFUS", cache_size)) {
       *pstatus = REGRESSION_TEST_FAILED;
+    }
   }
 }

--- a/iocore/cache/CacheVol.cc
+++ b/iocore/cache/CacheVol.cc
@@ -54,25 +54,29 @@ int
 CacheVC::scanVol(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
 {
   Debug("cache_scan_truss", "inside %p:scanVol", this);
-  if (_action.cancelled)
+  if (_action.cancelled) {
     return free_CacheVC(this);
+  }
   CacheHostRecord *rec = &theCache->hosttable->gen_host_rec;
   if (host_len) {
     CacheHostResult res;
     theCache->hosttable->Match(hostname, host_len, &res);
-    if (res.record)
+    if (res.record) {
       rec = res.record;
+    }
   }
   if (!vol) {
-    if (!rec->num_vols)
+    if (!rec->num_vols) {
       goto Ldone;
+    }
     vol = rec->vols[0];
   } else {
-    for (int i = 0; i < rec->num_vols - 1; i++)
+    for (int i = 0; i < rec->num_vols - 1; i++) {
       if (vol == rec->vols[i]) {
         vol = rec->vols[i + 1];
         goto Lcont;
       }
+    }
     goto Ldone;
   }
 Lcont:
@@ -98,10 +102,12 @@ next_in_map(Vol *d, char *vol_map, off_t offset)
   off_t new_off      = (offset - start_offset);
   off_t vol_len      = vol_relative_length(d, start_offset);
 
-  while (new_off < vol_len && !vol_map[new_off / SCAN_BUF_SIZE])
+  while (new_off < vol_len && !vol_map[new_off / SCAN_BUF_SIZE]) {
     new_off += SCAN_BUF_SIZE;
-  if (new_off >= vol_len)
+  }
+  if (new_off >= vol_len) {
     return vol_len + start_offset;
+  }
   return new_off + start_offset;
 }
 
@@ -137,12 +143,14 @@ make_vol_map(Vol *d)
       while (e) {
         if (dir_offset(e) && dir_valid(d, e) && dir_agg_valid(d, e) && dir_head(e)) {
           off_t offset = vol_offset(d, e) - start_offset;
-          if (offset <= vol_len)
+          if (offset <= vol_len) {
             vol_map[offset / SCAN_BUF_SIZE] = 1;
+          }
         }
         e = next_dir(e, seg);
-        if (!e)
+        if (!e) {
           break;
+        }
       }
     }
   }
@@ -166,8 +174,9 @@ CacheVC::scanObject(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
 
   cancel_trigger();
   set_io_not_in_progress();
-  if (_action.cancelled)
+  if (_action.cancelled) {
     return free_CacheVC(this);
+  }
 
   CACHE_TRY_LOCK(lock, vol->mutex, mutex->thread_holding);
   if (!lock.is_locked()) {
@@ -180,8 +189,9 @@ CacheVC::scanObject(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     fragment            = 1;
     scan_vol_map        = make_vol_map(vol);
     io.aiocb.aio_offset = next_in_map(vol, scan_vol_map, vol_offset_to_offset(vol, 0));
-    if (io.aiocb.aio_offset >= (off_t)(vol->skip + vol->len))
+    if (io.aiocb.aio_offset >= (off_t)(vol->skip + vol->len)) {
       goto Lnext_vol;
+    }
     io.aiocb.aio_nbytes = SCAN_BUF_SIZE;
     io.aiocb.aio_buf    = buf->data();
     io.action           = this;
@@ -219,16 +229,19 @@ CacheVC::scanObject(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
       continue;
     }
 
-    if (doc->doc_type != CACHE_FRAG_TYPE_HTTP || !doc->hlen)
+    if (doc->doc_type != CACHE_FRAG_TYPE_HTTP || !doc->hlen) {
       goto Lskip;
+    }
 
     last_collision = NULL;
     while (1) {
-      if (!dir_probe(&doc->first_key, vol, &dir, &last_collision))
+      if (!dir_probe(&doc->first_key, vol, &dir, &last_collision)) {
         goto Lskip;
+      }
       if (!dir_agg_valid(vol, &dir) || !dir_head(&dir) ||
-          (vol_offset(vol, &dir) != io.aiocb.aio_offset + ((char *)doc - buf->data())))
+          (vol_offset(vol, &dir) != io.aiocb.aio_offset + ((char *)doc - buf->data()))) {
         continue;
+      }
       break;
     }
     if (doc->data() - buf->data() > (int)io.aiocb.aio_nbytes) {
@@ -248,13 +261,15 @@ CacheVC::scanObject(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
         tmp += r;
       }
     }
-    if (this->load_http_info(&vector, doc) != doc->hlen)
+    if (this->load_http_info(&vector, doc) != doc->hlen) {
       goto Lskip;
+    }
     changed         = false;
     hostinfo_copied = 0;
     for (i = 0; i < vector.count(); i++) {
-      if (!vector.get(i)->valid())
+      if (!vector.get(i)->valid()) {
         goto Lskip;
+      }
       if (!hostinfo_copied) {
         memccpy(hname, vector.get(i)->request_get()->host_get(&hlen), 0, 500);
         hname[hlen] = 0;
@@ -266,8 +281,9 @@ CacheVC::scanObject(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
       // verify that the earliest block exists, reducing 'false hit' callbacks
       if (!(key == doc->key)) {
         last_collision = NULL;
-        if (!dir_probe(&key, vol, &earliest_dir, &last_collision))
+        if (!dir_probe(&key, vol, &earliest_dir, &last_collision)) {
           continue;
+        }
       }
       earliest_key = key;
       int result1  = _action.continuation->handleEvent(CACHE_EVENT_SCAN_OBJECT, vector.get(i));
@@ -287,8 +303,9 @@ CacheVC::scanObject(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
       case CACHE_SCAN_RESULT_UPDATE:
         ink_assert(alternate_index >= 0);
         vector.insert(&alternate, alternate_index);
-        if (!vector.get(alternate_index)->valid())
+        if (!vector.get(alternate_index)->valid()) {
           continue;
+        }
         changed = true;
         continue;
       case EVENT_DONE:
@@ -356,9 +373,10 @@ CacheVC::scanObject(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
 
 Lread:
   io.aiocb.aio_fildes = vol->fd;
-  if ((off_t)(io.aiocb.aio_offset + io.aiocb.aio_nbytes) > (off_t)(vol->skip + vol->len))
+  if ((off_t)(io.aiocb.aio_offset + io.aiocb.aio_nbytes) > (off_t)(vol->skip + vol->len)) {
     io.aiocb.aio_nbytes = vol->skip + vol->len - io.aiocb.aio_offset;
-  offset                = 0;
+  }
+  offset = 0;
   ink_assert(ink_aio_read(&io) >= 0);
   Debug("cache_scan_truss", "read %p:scanObject %" PRId64 " %zu", this, (int64_t)io.aiocb.aio_offset, (size_t)io.aiocb.aio_nbytes);
   return EVENT_CONT;
@@ -461,13 +479,15 @@ CacheVC::scanOpenWrite(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     // the document was not modified
     // we are safe from now on as we hold the
     // writer lock on the doc
-    if (f.evac_vector)
+    if (f.evac_vector) {
       header_len = write_vector->marshal_length();
+    }
     SET_HANDLER(&CacheVC::scanUpdateDone);
     ret = do_write_call();
   }
-  if (ret == EVENT_RETURN)
+  if (ret == EVENT_RETURN) {
     return handleEvent(AIO_EVENT_DONE, 0);
+  }
   return ret;
 }
 

--- a/iocore/cache/RamCacheLRU.cc
+++ b/iocore/cache/RamCacheLRU.cc
@@ -91,8 +91,9 @@ RamCacheLRU::resize_hashtable()
   if (bucket) {
     for (int64_t i = 0; i < nbuckets; i++) {
       RamCacheLRUEntry *e = 0;
-      while ((e = bucket[i].pop()))
+      while ((e = bucket[i].pop())) {
         new_bucket[e->key.slice32(3) % anbuckets].push(e);
+      }
     }
     ats_free(bucket);
   }
@@ -112,16 +113,18 @@ RamCacheLRU::init(int64_t abytes, Vol *avol)
   vol       = avol;
   max_bytes = abytes;
   DDebug("ram_cache", "initializing ram_cache %" PRId64 " bytes", abytes);
-  if (!max_bytes)
+  if (!max_bytes) {
     return;
+  }
   resize_hashtable();
 }
 
 int
 RamCacheLRU::get(INK_MD5 *key, Ptr<IOBufferData> *ret_data, uint32_t auxkey1, uint32_t auxkey2)
 {
-  if (!max_bytes)
+  if (!max_bytes) {
     return 0;
+  }
   uint32_t i          = key->slice32(3) % nbuckets;
   RamCacheLRUEntry *e = bucket[i].head;
   while (e) {
@@ -160,8 +163,9 @@ RamCacheLRU::remove(RamCacheLRUEntry *e)
 int
 RamCacheLRU::put(INK_MD5 *key, IOBufferData *data, uint32_t len, bool, uint32_t auxkey1, uint32_t auxkey2)
 {
-  if (!max_bytes)
+  if (!max_bytes) {
     return 0;
+  }
   uint32_t i = key->slice32(3) % nbuckets;
   if (cache_config_ram_cache_use_seen_filter) {
     uint16_t k  = key->slice32(3) >> 16;
@@ -198,10 +202,11 @@ RamCacheLRU::put(INK_MD5 *key, IOBufferData *data, uint32_t len, bool, uint32_t 
   CACHE_SUM_DYN_STAT_THREAD(cache_ram_cache_bytes_stat, ENTRY_OVERHEAD + data->block_size());
   while (bytes > max_bytes) {
     RamCacheLRUEntry *ee = lru.dequeue();
-    if (ee)
+    if (ee) {
       remove(ee);
-    else
+    } else {
       break;
+    }
   }
   DDebug("ram_cache", "put %X %d %d INSERTED", key->slice32(3), auxkey1, auxkey2);
   if (objects > nbuckets) {
@@ -214,8 +219,9 @@ RamCacheLRU::put(INK_MD5 *key, IOBufferData *data, uint32_t len, bool, uint32_t 
 int
 RamCacheLRU::fixup(const INK_MD5 *key, uint32_t old_auxkey1, uint32_t old_auxkey2, uint32_t new_auxkey1, uint32_t new_auxkey2)
 {
-  if (!max_bytes)
+  if (!max_bytes) {
     return 0;
+  }
   uint32_t i          = key->slice32(3) % nbuckets;
   RamCacheLRUEntry *e = bucket[i].head;
   while (e) {

--- a/iocore/cache/Store.cc
+++ b/iocore/cache/Store.cc
@@ -101,14 +101,17 @@ Store::free(Store &s)
 {
   for (unsigned i = 0; i < s.n_disks; i++) {
     for (Span *sd = s.disk[i]; sd; sd = sd->link.next) {
-      for (unsigned j = 0; j < n_disks; j++)
-        for (Span *d = disk[j]; d; d = d->link.next)
+      for (unsigned j = 0; j < n_disks; j++) {
+        for (Span *d = disk[j]; d; d = d->link.next) {
           if (!strcmp(sd->pathname, d->pathname)) {
-            if (sd->offset < d->offset)
+            if (sd->offset < d->offset) {
               d->offset = sd->offset;
+            }
             d->blocks += sd->blocks;
             goto Lfound;
           }
+        }
+      }
       ink_release_assert(!"Store::free failed");
     Lfound:;
     }
@@ -178,8 +181,9 @@ Store::sort()
         if (!sd->file_pathname) {
           sd->blocks += next->blocks;
         } else if (next->offset <= sd->end()) {
-          if (next->end() >= sd->end())
+          if (next->end() >= sd->end()) {
             sd->blocks += (next->end() - sd->end());
+          }
         } else {
           sd = next;
           continue;
@@ -187,8 +191,9 @@ Store::sort()
         sd->link.next = next->link.next;
         delete next;
         sd = sd->link.next;
-      } else
+      } else {
         sd = next;
+      }
     }
   }
 }
@@ -221,8 +226,9 @@ Span::path(char *filename, int64_t *aoffset, char *buf, int buflen)
   ink_assert(!aoffset);
   Span *ds = this;
 
-  if ((strlen(ds->pathname) + strlen(filename) + 2) > (size_t)buflen)
+  if ((strlen(ds->pathname) + strlen(filename) + 2) > (size_t)buflen) {
     return -1;
+  }
   if (!ds->file_pathname) {
     ink_filepath_make(buf, buflen, ds->pathname, filename);
   } else {
@@ -248,8 +254,9 @@ void
 Store::delete_all()
 {
   for (unsigned i = 0; i < n_disks; i++) {
-    if (disk[i])
+    if (disk[i]) {
       delete disk[i];
+    }
   }
   n_disks = 0;
   ats_free(disk);
@@ -263,16 +270,18 @@ Store::~Store()
 
 Span::~Span()
 {
-  if (link.next)
+  if (link.next) {
     delete link.next;
+  }
 }
 
 static int
 get_int64(int fd, int64_t &data)
 {
   char buf[PATH_NAME_MAX];
-  if (ink_file_fd_readline(fd, PATH_NAME_MAX, buf) <= 0)
+  if (ink_file_fd_readline(fd, PATH_NAME_MAX, buf) <= 0) {
     return (-1);
+  }
   // the above line will guarantee buf to be no longer than PATH_NAME_MAX
   // so the next statement should be a safe use of sscanf
   // coverity[secure_coding]
@@ -292,10 +301,11 @@ Lagain:
     for (Span *sd = disk[i]; sd; sd = sd->link.next) {
       if (!strcmp(n, sd->pathname)) {
         found = true;
-        if (p)
+        if (p) {
           p->link.next = sd->link.next;
-        else
-          disk[i]     = sd->link.next;
+        } else {
+          disk[i] = sd->link.next;
+        }
         sd->link.next = NULL;
         delete sd;
         goto Lagain;
@@ -337,16 +347,18 @@ Store::read_config()
     ++ln;
 
     // Because the SimpleTokenizer is a bit too simple, we have to normalize whitespace.
-    for (char *spot = line, *limit = line + len; spot < limit; ++spot)
-      if (ParseRules::is_space(*spot))
+    for (char *spot = line, *limit = line + len; spot < limit; ++spot) {
+      if (ParseRules::is_space(*spot)) {
         *spot = ' '; // force whitespace to literal space.
-
+      }
+    }
     SimpleTokenizer tokens(line, ' ', SimpleTokenizer::OVERWRITE_INPUT_STRING);
 
     // skip comments and blank lines
     path = tokens.getNext();
-    if (0 == path || '#' == path[0])
+    if (0 == path || '#' == path[0]) {
       continue;
+    }
 
     // parse
     Debug("cache_init", "Store::read_config: \"%s\"", path);
@@ -363,14 +375,17 @@ Store::read_config()
         }
       } else if (0 == strncasecmp(HASH_BASE_STRING_KEY, e, sizeof(HASH_BASE_STRING_KEY) - 1)) {
         e += sizeof(HASH_BASE_STRING_KEY) - 1;
-        if ('=' == *e)
+        if ('=' == *e) {
           ++e;
-        if (*e && !ParseRules::is_space(*e))
+        }
+        if (*e && !ParseRules::is_space(*e)) {
           seed = e;
+        }
       } else if (0 == strncasecmp(VOLUME_KEY, e, sizeof(VOLUME_KEY) - 1)) {
         e += sizeof(VOLUME_KEY) - 1;
-        if ('=' == *e)
+        if ('=' == *e) {
           ++e;
+        }
         if (!*e || !ParseRules::is_digit(*e) || 0 >= (volume_num = ink_atoi(e))) {
           err = "error parsing volume number";
           goto Lfail;
@@ -394,19 +409,22 @@ Store::read_config()
     n_dsstore++;
 
     // Set side values if present.
-    if (seed)
+    if (seed) {
       ns->hash_base_string_set(seed);
-    if (volume_num > 0)
+    }
+    if (volume_num > 0) {
       ns->volume_number_set(volume_num);
+    }
 
     // new Span
     {
       Span *prev = cur;
       cur        = ns;
-      if (!sd)
+      if (!sd) {
         sd = cur;
-      else
+      } else {
         prev->link.next = cur;
+      }
     }
   }
 
@@ -425,8 +443,9 @@ Store::read_config()
 
 Lfail:
   // Do clean up.
-  if (sd)
+  if (sd) {
     delete sd;
+  }
 
   return err;
 }
@@ -434,13 +453,15 @@ Lfail:
 int
 Store::write_config_data(int fd) const
 {
-  for (unsigned i = 0; i < n_disks; i++)
+  for (unsigned i = 0; i < n_disks; i++) {
     for (Span *sd = disk[i]; sd; sd = sd->link.next) {
       char buf[PATH_NAME_MAX + 64];
       snprintf(buf, sizeof(buf), "%s %" PRId64 "\n", sd->pathname.get(), (int64_t)sd->blocks * (int64_t)STORE_BLOCK_SIZE);
-      if (ink_file_fd_writestring(fd, buf) == -1)
+      if (ink_file_fd_writestring(fd, buf) == -1) {
         return (-1);
+      }
     }
+  }
   return 0;
 }
 
@@ -588,8 +609,9 @@ Store::normalize()
 {
   unsigned ndisks = 0;
   for (unsigned i = 0; i < n_disks; i++) {
-    if (disk[i])
+    if (disk[i]) {
       disk[ndisks++] = disk[i];
+    }
   }
   n_disks = ndisks;
 }
@@ -602,27 +624,31 @@ try_alloc(Store &target, Span *source, unsigned int start_blocks, bool one_only 
   while (source && blocks) {
     if (source->blocks) {
       unsigned int a; // allocated
-      if (blocks > source->blocks)
+      if (blocks > source->blocks) {
         a = source->blocks;
-      else
-        a     = blocks;
+      } else {
+        a = blocks;
+      }
       Span *d = new Span(*source);
 
       d->blocks    = a;
       d->link.next = ds;
 
-      if (d->file_pathname)
+      if (d->file_pathname) {
         source->offset += a;
+      }
       source->blocks -= a;
       ds = d;
       blocks -= a;
-      if (one_only)
+      if (one_only) {
         break;
+      }
     }
     source = source->link.next;
   }
-  if (ds)
+  if (ds) {
     target.add(ds);
+  }
   return start_blocks - blocks;
 }
 
@@ -653,8 +679,9 @@ Store::spread_alloc(Store &s, unsigned int blocks, bool mmapable)
   for (unsigned i = 0; blocks && disks_left && i < n_disks; i++) {
     if (!(mmapable && !disk[i]->is_mmapable())) {
       unsigned int target = blocks / disks_left;
-      if (blocks - target > total_blocks(i + 1))
+      if (blocks - target > total_blocks(i + 1)) {
         target = blocks - total_blocks(i + 1);
+      }
       blocks -= try_alloc(s, disk[i], target);
       disks_left--;
     }
@@ -667,8 +694,8 @@ Store::try_realloc(Store &s, Store &diff)
   for (unsigned i = 0; i < s.n_disks; i++) {
     Span *prev = 0;
     for (Span *sd = s.disk[i]; sd;) {
-      for (unsigned j = 0; j < n_disks; j++)
-        for (Span *d = disk[j]; d; d = d->link.next)
+      for (unsigned j = 0; j < n_disks; j++) {
+        for (Span *d = disk[j]; d; d = d->link.next) {
           if (!strcmp(sd->pathname, d->pathname)) {
             if (sd->offset >= d->offset && (sd->end() <= d->end())) {
               if (!sd->file_pathname || (sd->end() == d->end())) {
@@ -690,11 +717,14 @@ Store::try_realloc(Store &s, Store &diff)
               }
             }
           }
+        }
+      }
       {
-        if (!prev)
+        if (!prev) {
           s.disk[i] = s.disk[i]->link.next;
-        else
+        } else {
           prev->link.next = sd->link.next;
+        }
         diff.extend(i + 1);
         sd->link.next = diff.disk[i];
         diff.disk[i]  = sd;
@@ -721,8 +751,9 @@ Store::alloc(Store &s, unsigned int blocks, bool one_only, bool mmapable)
   for (unsigned i = 0; blocks && i < n_disks; i++) {
     if (!(mmapable && !disk[i]->is_mmapable())) {
       blocks -= try_alloc(s, disk[i], blocks, one_only);
-      if (one_only && oblocks != blocks)
+      if (one_only && oblocks != blocks) {
         break;
+      }
     }
   }
 }
@@ -732,26 +763,32 @@ Span::write(int fd) const
 {
   char buf[32];
 
-  if (ink_file_fd_writestring(fd, (pathname ? pathname.get() : ")")) == -1)
+  if (ink_file_fd_writestring(fd, (pathname ? pathname.get() : ")")) == -1) {
     return (-1);
-  if (ink_file_fd_writestring(fd, "\n") == -1)
+  }
+  if (ink_file_fd_writestring(fd, "\n") == -1) {
     return (-1);
+  }
 
   snprintf(buf, sizeof(buf), "%" PRId64 "\n", blocks);
-  if (ink_file_fd_writestring(fd, buf) == -1)
+  if (ink_file_fd_writestring(fd, buf) == -1) {
     return (-1);
+  }
 
   snprintf(buf, sizeof(buf), "%d\n", file_pathname);
-  if (ink_file_fd_writestring(fd, buf) == -1)
+  if (ink_file_fd_writestring(fd, buf) == -1) {
     return (-1);
+  }
 
   snprintf(buf, sizeof(buf), "%" PRId64 "\n", offset);
-  if (ink_file_fd_writestring(fd, buf) == -1)
+  if (ink_file_fd_writestring(fd, buf) == -1) {
     return (-1);
+  }
 
   snprintf(buf, sizeof(buf), "%d\n", (int)is_mmapable());
-  if (ink_file_fd_writestring(fd, buf) == -1)
+  if (ink_file_fd_writestring(fd, buf) == -1) {
     return (-1);
+  }
 
   return 0;
 }
@@ -761,14 +798,17 @@ Store::write(int fd, const char *name) const
 {
   char buf[32];
 
-  if (ink_file_fd_writestring(fd, name) == -1)
+  if (ink_file_fd_writestring(fd, name) == -1) {
     return (-1);
-  if (ink_file_fd_writestring(fd, "\n") == -1)
+  }
+  if (ink_file_fd_writestring(fd, "\n") == -1) {
     return (-1);
+  }
 
   snprintf(buf, sizeof(buf), "%d\n", n_disks);
-  if (ink_file_fd_writestring(fd, buf) == -1)
+  if (ink_file_fd_writestring(fd, buf) == -1) {
     return (-1);
+  }
 
   for (unsigned i = 0; i < n_disks; i++) {
     int n    = 0;
@@ -778,12 +818,14 @@ Store::write(int fd, const char *name) const
     }
 
     snprintf(buf, sizeof(buf), "%d\n", n);
-    if (ink_file_fd_writestring(fd, buf) == -1)
+    if (ink_file_fd_writestring(fd, buf) == -1) {
       return (-1);
+    }
 
     for (sd = disk[i]; sd; sd = sd->link.next) {
-      if (sd->write(fd))
+      if (sd->write(fd)) {
         return -1;
+      }
     }
   }
   return 0;
@@ -794,8 +836,9 @@ Span::read(int fd)
 {
   char buf[PATH_NAME_MAX], p[PATH_NAME_MAX];
 
-  if (ink_file_fd_readline(fd, PATH_NAME_MAX, buf) <= 0)
+  if (ink_file_fd_readline(fd, PATH_NAME_MAX, buf) <= 0) {
     return (-1);
+  }
   // the above line will guarantee buf to be no longer than PATH_NAME_MAX
   // so the next statement should be a safe use of sscanf
   // coverity[secure_coding]
@@ -808,13 +851,15 @@ Span::read(int fd)
   }
 
   int b = 0;
-  if (ink_file_fd_readline(fd, PATH_NAME_MAX, buf) <= 0)
+  if (ink_file_fd_readline(fd, PATH_NAME_MAX, buf) <= 0) {
     return (-1);
+  }
   // the above line will guarantee buf to be no longer than PATH_NAME_MAX
   // so the next statement should be a safe use of sscanf
   // coverity[secure_coding]
-  if (sscanf(buf, "%d", &b) != 1)
+  if (sscanf(buf, "%d", &b) != 1) {
     return (-1);
+  }
   file_pathname = (b ? true : false);
 
   if (get_int64(fd, offset) < 0) {
@@ -822,13 +867,15 @@ Span::read(int fd)
   }
 
   int tmp;
-  if (ink_file_fd_readline(fd, PATH_NAME_MAX, buf) <= 0)
+  if (ink_file_fd_readline(fd, PATH_NAME_MAX, buf) <= 0) {
     return (-1);
+  }
   // the above line will guarantee buf to be no longer than PATH_NAME_MAX
   // so the next statement should be a safe use of sscanf
   // coverity[secure_coding]
-  if (sscanf(buf, "%d", &tmp) != 1)
+  if (sscanf(buf, "%d", &tmp) != 1) {
     return (-1);
+  }
   set_mmapable(tmp != 0);
 
   return (0);
@@ -840,58 +887,69 @@ Store::read(int fd, char *aname)
   char *name = aname;
   char tname[PATH_NAME_MAX];
   char buf[PATH_NAME_MAX];
-  if (!aname)
+  if (!aname) {
     name = tname;
+  }
 
-  if (ink_file_fd_readline(fd, PATH_NAME_MAX, buf) <= 0)
+  if (ink_file_fd_readline(fd, PATH_NAME_MAX, buf) <= 0) {
     return (-1);
+  }
   // the above line will guarantee buf to be no longer than PATH_NAME_MAX
   // so the next statement should be a safe use of sscanf
   // coverity[secure_coding]
-  if (sscanf(buf, "%s\n", name) != 1)
+  if (sscanf(buf, "%s\n", name) != 1) {
     return (-1);
+  }
 
-  if (ink_file_fd_readline(fd, PATH_NAME_MAX, buf) <= 0)
+  if (ink_file_fd_readline(fd, PATH_NAME_MAX, buf) <= 0) {
     return (-1);
+  }
   // the above line will guarantee buf to be no longer than PATH_NAME_MAX
   // so the next statement should be a safe use of sscanf
   // coverity[secure_coding]
-  if (sscanf(buf, "%d\n", &n_disks) != 1)
+  if (sscanf(buf, "%d\n", &n_disks) != 1) {
     return (-1);
+  }
 
   disk = (Span **)ats_malloc(sizeof(Span *) * n_disks);
-  if (!disk)
+  if (!disk) {
     return -1;
+  }
   memset(disk, 0, sizeof(Span *) * n_disks);
   for (unsigned i = 0; i < n_disks; i++) {
     int n = 0;
 
-    if (ink_file_fd_readline(fd, PATH_NAME_MAX, buf) <= 0)
+    if (ink_file_fd_readline(fd, PATH_NAME_MAX, buf) <= 0) {
       return (-1);
+    }
     // the above line will guarantee buf to be no longer than PATH_NAME_MAX
     // so the next statement should be a safe use of sscanf
     // coverity[secure_coding]
-    if (sscanf(buf, "%d\n", &n) != 1)
+    if (sscanf(buf, "%d\n", &n) != 1) {
       return (-1);
+    }
 
     Span *sd = NULL;
     while (n--) {
       Span *last = sd;
       sd         = new Span;
 
-      if (!last)
+      if (!last) {
         disk[i] = sd;
-      else
+      } else {
         last->link.next = sd;
-      if (sd->read(fd))
+      }
+      if (sd->read(fd)) {
         goto Lbail;
+      }
     }
   }
   return 0;
 Lbail:
   for (unsigned i = 0; i < n_disks; i++) {
-    if (disk[i])
+    if (disk[i]) {
       delete disk[i];
+    }
   }
   return -1;
 }
@@ -900,8 +958,9 @@ Span *
 Span::dup()
 {
   Span *ds = new Span(*this);
-  if (this->link.next)
+  if (this->link.next) {
     ds->link.next = this->link.next->dup();
+  }
   return ds;
 }
 
@@ -925,19 +984,23 @@ Store::clear(char *filename, bool clear_dirs)
     for (unsigned j = 0; j < disk[i]->paths(); j++) {
       char path[PATH_NAME_MAX];
       Span *d = ds->nth(j);
-      if (!clear_dirs && !d->file_pathname)
+      if (!clear_dirs && !d->file_pathname) {
         continue;
+      }
       int r = d->path(filename, NULL, path, PATH_NAME_MAX);
-      if (r < 0)
+      if (r < 0) {
         return -1;
+      }
       int fd = ::open(path, O_RDWR | O_CREAT, 0644);
-      if (fd < 0)
+      if (fd < 0) {
         return -1;
-      for (int b = 0; d->blocks; b++)
+      }
+      for (int b = 0; d->blocks; b++) {
         if (socketManager.pwrite(fd, z, STORE_BLOCK_SIZE, d->offset + (b * STORE_BLOCK_SIZE)) < 0) {
           close(fd);
           return -1;
         }
+      }
       close(fd);
     }
   }

--- a/iocore/cluster/ClusterAPI.cc
+++ b/iocore/cluster/ClusterAPI.cc
@@ -427,8 +427,9 @@ TSAddClusterRPCFunction(TSClusterRPCKey_t k, TSClusterRPCFunction func, TSCluste
   handle.u.internal.magic            = RPC_HANDLE_MAGIC;
 
   MUTEX_TAKE_LOCK(ClusterAPI_mutex, e);
-  if (n < API_END_CLUSTER_FUNCTION)
+  if (n < API_END_CLUSTER_FUNCTION) {
     RPC_Functions[n] = func;
+  }
   MUTEX_UNTAKE_LOCK(ClusterAPI_mutex, e);
 
   *h = handle.u.external;

--- a/iocore/cluster/ClusterConfig.cc
+++ b/iocore/cluster/ClusterConfig.cc
@@ -205,8 +205,9 @@ machine_config_change(const char * /* name ATS_UNUSED */, RecDataT /* data_type 
   cluster_config  = l;
   make_cluster_connections(l);
 #endif
-  if (old)
+  if (old) {
     free_MachineList(old);
+  }
   return 0;
 }
 
@@ -292,14 +293,16 @@ configuration_add_machine(ClusterConfiguration *c, ClusterMachine *m)
   // Find the place to insert this new machine
   //
   for (i = 0; i < cc->n_machines; i++) {
-    if (cc->machines[i]->ip > m->ip)
+    if (cc->machines[i]->ip > m->ip) {
       break;
+    }
   }
 
   // Move the other machines out of the way
   //
-  for (int j            = cc->n_machines - 1; j >= i; j--)
+  for (int j = cc->n_machines - 1; j >= i; j--) {
     cc->machines[j + 1] = cc->machines[j];
+  }
 
   // Insert it
   //
@@ -330,9 +333,11 @@ configuration_remove_machine(ClusterConfiguration *c, ClusterMachine *m)
   //
   // remove m and move others down
   //
-  for (int i = 0; i < cc->n_machines - 1; i++)
-    if (m == cc->machines[i])
+  for (int i = 0; i < cc->n_machines - 1; i++) {
+    if (m == cc->machines[i]) {
       m = cc->machines[i] = cc->machines[i + 1];
+    }
+  }
   cc->n_machines--;
 
   ink_assert(cc->n_machines > 0);
@@ -360,8 +365,9 @@ ClusterMachine *
 cluster_machine_at_depth(unsigned int hash, int *pprobe_depth, ClusterMachine **past_probes)
 {
 #ifdef CLUSTER_TOMCAT
-  if (!cache_clustering_enabled)
+  if (!cache_clustering_enabled) {
     return NULL;
+  }
 #endif
   ClusterConfiguration *cc      = this_cluster()->current_configuration();
   ClusterConfiguration *next_cc = cc;
@@ -383,13 +389,15 @@ cluster_machine_at_depth(unsigned int hash, int *pprobe_depth, ClusterMachine **
   while (1) {
     // If we are out of our depth, fail
     //
-    if (probe_depth > CONFIGURATION_HISTORY_PROBE_DEPTH)
+    if (probe_depth > CONFIGURATION_HISTORY_PROBE_DEPTH) {
       break;
+    }
 
     // If there is no configuration, fail
     //
-    if (!cc || !next_cc)
+    if (!cc || !next_cc) {
       break;
+    }
 
     cc      = next_cc;
     next_cc = next_cc->link.next;
@@ -397,8 +405,9 @@ cluster_machine_at_depth(unsigned int hash, int *pprobe_depth, ClusterMachine **
     // Find the correct configuration
     //
     if (tprobe_depth) {
-      if (cc->changed > (now + CLUSTER_CONFIGURATION_TIMEOUT))
+      if (cc->changed > (now + CLUSTER_CONFIGURATION_TIMEOUT)) {
         break;
+      }
       tprobe_depth--;
       continue;
     }
@@ -413,13 +422,15 @@ cluster_machine_at_depth(unsigned int hash, int *pprobe_depth, ClusterMachine **
     // Store the all but the last probe, so that we never return
     // the same machine
     //
-    if (past_probes && probe_depth < CONFIGURATION_HISTORY_PROBE_DEPTH)
+    if (past_probes && probe_depth < CONFIGURATION_HISTORY_PROBE_DEPTH) {
       past_probes[probe_depth] = m;
+    }
     probe_depth++;
 
     if (!ok) {
-      if (!pprobe_depth)
+      if (!pprobe_depth) {
         break; // don't go down if we don't have a depth
+      }
       continue;
     }
 

--- a/iocore/cluster/ClusterHandlerBase.cc
+++ b/iocore/cluster/ClusterHandlerBase.cc
@@ -187,8 +187,9 @@ OutgoingControl::startEvent(int event, Event *e)
   (void)event;
   (void)e;
   // verify that the machine has not gone down
-  if (!ch || !ch->thread)
+  if (!ch || !ch->thread) {
     return EVENT_DONE;
+  }
 
   int32_t cluster_fn = *(int32_t *)this->data;
   int32_t pri        = ClusterFuncToQpri(cluster_fn);
@@ -584,8 +585,9 @@ ClusterHandler::cluster_signal_and_update_locked(int event, ClusterVConnection *
       close_free_lock(vc, s);
     }
     return EVENT_DONE;
-  } else
+  } else {
     return EVENT_CONT;
+  }
 }
 
 int
@@ -786,8 +788,9 @@ ClusterHandler::connectClusterEvent(int event, Event *e)
     // Initiated via ClusterProcessor::connect().
     //
     MachineList *cc = the_cluster_config();
-    if (!machine)
+    if (!machine) {
       machine = new ClusterMachine(hostname, ip, port);
+    }
 #ifdef LOCAL_CLUSTER_TEST_MODE
     if (!(cc && cc->find(ip, port))) {
 #else
@@ -873,8 +876,9 @@ ClusterHandler::startClusterEvent(int event, Event *e)
         nodeClusteringVersion._port = cluster_port;
 #endif
         cluster_connect_state = ClusterHandler::CLCON_SEND_MSG_COMPLETE;
-        if (connector)
+        if (connector) {
           nodeClusteringVersion._id = id;
+        }
         build_data_vector((char *)&nodeClusteringVersion, sizeof(nodeClusteringVersion), false);
         if (!write.doIO()) {
           // i/o not initiated, delay and retry
@@ -967,9 +971,10 @@ ClusterHandler::startClusterEvent(int event, Event *e)
           if (proto_major == clusteringVersion._major) {
             proto_minor = clusteringVersion._minor;
 
-            if (proto_minor != nodeClusteringVersion._minor)
+            if (proto_minor != nodeClusteringVersion._minor) {
               Warning("Different clustering minor versions (%d,%d) for node %u.%u.%u.%u, continuing", proto_minor,
                       nodeClusteringVersion._minor, DOT_SEPARATED(ip));
+            }
           } else {
             proto_minor = 0;
           }
@@ -984,8 +989,9 @@ ClusterHandler::startClusterEvent(int event, Event *e)
 #ifdef LOCAL_CLUSTER_TEST_MODE
         port = clusteringVersion._port & 0xffff;
 #endif
-        if (!connector)
+        if (!connector) {
           id = clusteringVersion._id & 0xffff;
+        }
 
         machine->msg_proto_major = proto_major;
         machine->msg_proto_minor = proto_minor;
@@ -1012,14 +1018,18 @@ ClusterHandler::startClusterEvent(int event, Event *e)
         vc->ep.stop();
         vc->nh->open_list.remove(vc);
         vc->thread = NULL;
-        if (vc->nh->read_ready_list.in(vc))
+        if (vc->nh->read_ready_list.in(vc)) {
           vc->nh->read_ready_list.remove(vc);
-        if (vc->nh->write_ready_list.in(vc))
+        }
+        if (vc->nh->write_ready_list.in(vc)) {
           vc->nh->write_ready_list.remove(vc);
-        if (vc->read.in_enabled_list)
+        }
+        if (vc->read.in_enabled_list) {
           vc->nh->read_enable_list.remove(vc);
-        if (vc->write.in_enabled_list)
+        }
+        if (vc->write.in_enabled_list) {
           vc->nh->write_enable_list.remove(vc);
+        }
 
         // CLCON_CONN_BIND handle in bind vc->thread (bind thread nh)
         cluster_connect_state = ClusterHandler::CLCON_CONN_BIND;
@@ -1039,10 +1049,12 @@ ClusterHandler::startClusterEvent(int event, Event *e)
       MUTEX_TRY_LOCK(lock, nh->mutex, e->ethread);
       MUTEX_TRY_LOCK(lock1, vc->mutex, e->ethread);
       if (lock.is_locked() && lock1.is_locked()) {
-        if (vc->read.in_enabled_list)
+        if (vc->read.in_enabled_list) {
           nh->read_enable_list.push(vc);
-        if (vc->write.in_enabled_list)
+        }
+        if (vc->write.in_enabled_list) {
           nh->write_enable_list.push(vc);
+        }
 
         vc->nh             = nh;
         vc->thread         = e->ethread;

--- a/iocore/cluster/ClusterHash.cc
+++ b/iocore/cluster/ClusterHash.cc
@@ -101,13 +101,15 @@ build_hash_table_machine(ClusterConfiguration *c)
   // seed the random number generator with the ip address
   // do a little xor folding to get it into 15 bits
   //
-  for (m   = 0; m < c->n_machines; m++)
+  for (m = 0; m < c->n_machines; m++) {
     rnd[m] = (((c->machines[m]->ip >> 15) & 0x7FFF) ^ (c->machines[m]->ip & 0x7FFF)) ^ (c->machines[m]->ip >> 30);
+  }
 
   // Initialize the table to "empty"
   //
-  for (i             = 0; i < CLUSTER_HASH_TABLE_SIZE; i++)
+  for (i = 0; i < CLUSTER_HASH_TABLE_SIZE; i++) {
     c->hash_table[i] = 255;
+  }
 
   // Until we have hit every element of the table, give each
   // machine a chance to select it's favorites.
@@ -121,8 +123,9 @@ build_hash_table_machine(ClusterConfiguration *c)
     do {
       if (randClusterHash) {
         i = ink_rand_r(&rnd[m]) % CLUSTER_HASH_TABLE_SIZE;
-      } else
+      } else {
         i = next_rand(&rnd[m]) % CLUSTER_HASH_TABLE_SIZE;
+      }
     } while (c->hash_table[i] != 255);
     mach[m]--;
     c->hash_table[i] = m;
@@ -145,16 +148,18 @@ build_hash_table_bucket(ClusterConfiguration *c)
     total -= mine;
   }
 
-  for (i   = 0; i < CLUSTER_HASH_TABLE_SIZE; i++)
+  for (i = 0; i < CLUSTER_HASH_TABLE_SIZE; i++) {
     rnd[i] = i;
+  }
 
   for (i = 0; i < CLUSTER_HASH_TABLE_SIZE; i++) {
     unsigned char x = 0;
     do {
       if (randClusterHash) {
         x = ink_rand_r(&rnd[i]) % CLUSTER_MAX_MACHINES;
-      } else
+      } else {
         x = next_rand(&rnd[i]) % CLUSTER_MAX_MACHINES;
+      }
     } while (x >= c->n_machines || (!mach[x] && boundClusterHash));
     mach[x]--;
     c->hash_table[i] = x;
@@ -164,8 +169,9 @@ build_hash_table_bucket(ClusterConfiguration *c)
 void
 build_cluster_hash_table(ClusterConfiguration *c)
 {
-  if (machineClusterHash)
+  if (machineClusterHash) {
     build_hash_table_machine(c);
-  else
+  } else {
     build_hash_table_bucket(c);
+  }
 }

--- a/iocore/cluster/ClusterLib.cc
+++ b/iocore/cluster/ClusterLib.cc
@@ -42,8 +42,9 @@ cluster_schedule(ClusterHandler *ch, ClusterVConnection *vc, ClusterVConnState *
   //
   int new_bucket = ch->cur_vcs;
 
-  if (vc->type == VC_NULL)
+  if (vc->type == VC_NULL) {
     vc->type = VC_CLUSTER;
+  }
   if (ns == &vc->read) {
     ClusterVC_enqueue_read(ch->read_vcs[new_bucket], vc);
   } else {
@@ -55,12 +56,14 @@ void
 cluster_reschedule_offset(ClusterHandler *ch, ClusterVConnection *vc, ClusterVConnState *ns, int offset)
 {
   if (ns == &vc->read) {
-    if (vc->read.queue)
+    if (vc->read.queue) {
       ClusterVC_remove_read(vc);
+    }
     ClusterVC_enqueue_read(ch->read_vcs[(ch->cur_vcs + offset) % CLUSTER_BUCKETS], vc);
   } else {
-    if (vc->write.queue)
+    if (vc->write.queue) {
       ClusterVC_remove_write(vc);
+    }
     ClusterVC_enqueue_write(ch->write_vcs[(ch->cur_vcs + offset) % CLUSTER_BUCKETS], vc);
   }
 }

--- a/iocore/cluster/ClusterLoadMonitor.cc
+++ b/iocore/cluster/ClusterLoadMonitor.cc
@@ -120,8 +120,9 @@ ClusterLoadMonitor::~ClusterLoadMonitor()
 void
 ClusterLoadMonitor::cancel_monitor()
 {
-  if (!cancel_periodic)
+  if (!cancel_periodic) {
     cancel_periodic = 1;
+  }
 }
 
 bool
@@ -180,8 +181,9 @@ ClusterLoadMonitor::compute_cluster_load()
   ink_hrtime ping_latency_threshold = HRTIME_MSECONDS(ping_latency_threshold_msecs);
 
   start = ping_history_buf_head - 1;
-  if (start < 0)
+  if (start < 0) {
     start += ping_history_buf_length;
+  }
   end = start;
 
   if (cluster_overloaded) {
@@ -189,26 +191,31 @@ ClusterLoadMonitor::compute_cluster_load()
   } else {
     end -= (cluster_load_exceed_duration <= ping_history_buf_length ? cluster_load_exceed_duration : ping_history_buf_length);
   }
-  if (end < 0)
+  if (end < 0) {
     end += ping_history_buf_length;
+  }
 
   int threshold_clear    = 0;
   int threshold_exceeded = 0;
   do {
-    if (ping_response_history_buf[start] >= ping_latency_threshold)
+    if (ping_response_history_buf[start] >= ping_latency_threshold) {
       ++threshold_exceeded;
-    else
+    } else {
       ++threshold_clear;
-    if (--start < 0)
+    }
+    if (--start < 0) {
       start = start + ping_history_buf_length;
+    }
   } while (start != end);
 
   if (cluster_overloaded) {
-    if (threshold_exceeded == 0)
+    if (threshold_exceeded == 0) {
       cluster_overloaded = 0;
+    }
   } else {
-    if (threshold_exceeded && (threshold_clear == 0))
+    if (threshold_exceeded && (threshold_clear == 0)) {
       cluster_overloaded = 1;
+    }
   }
   Debug("cluster_monitor", "[%u.%u.%u.%u] overload=%d, clear=%d, exceed=%d, latency=%d", DOT_SEPARATED(this->ch->machine->ip),
         cluster_overloaded, threshold_clear, threshold_exceeded, n_bucket);
@@ -225,8 +232,9 @@ ClusterLoadMonitor::note_ping_response_time(ink_hrtime response_time, int sequen
   int bucket = (int)(response_time / HRTIME_MSECONDS(msecs_per_ping_response_bucket));
   Debug("cluster_monitor_ping", "[%u.%u.%u.%u] ping: %d %d", DOT_SEPARATED(this->ch->machine->ip), bucket, sequence_number);
 
-  if (bucket >= num_ping_response_buckets)
+  if (bucket >= num_ping_response_buckets) {
     bucket = num_ping_response_buckets - 1;
+  }
   ink_atomic_increment(&ping_response_buckets[bucket], 1);
 }
 

--- a/iocore/cluster/ClusterMachine.cc
+++ b/iocore/cluster/ClusterMachine.cc
@@ -113,11 +113,14 @@ ClusterMachine::ClusterMachine(char *ahostname, unsigned int aip, int aport)
         // lowest IP address
 
         ip = (unsigned int)-1; // 0xFFFFFFFF
-        for (int i = 0; r->h_addr_list[i]; i++)
-          if (ip > *(unsigned int *)r->h_addr_list[i])
+        for (int i = 0; r->h_addr_list[i]; i++) {
+          if (ip > *(unsigned int *)r->h_addr_list[i]) {
             ip = *(unsigned int *)r->h_addr_list[i];
-        if (ip == (unsigned int)-1)
+          }
+        }
+        if (ip == (unsigned int)-1) {
           ip = 0;
+        }
       }
       // ip = htonl(ip); for the alpha!
     }
@@ -132,13 +135,15 @@ ClusterMachine::ClusterMachine(char *ahostname, unsigned int aip, int aport)
       Alias32 x;
       memcpy(&x.u32, &ip, sizeof(x.u32));
       Debug("machine_debug", "unable to reverse DNS %u.%u.%u.%u: %d", x.byte[0], x.byte[1], x.byte[2], x.byte[3], data.herrno);
-    } else
+    } else {
       hostname = ats_strdup(r->h_name);
+    }
   }
-  if (hostname)
+  if (hostname) {
     hostname_len = strlen(hostname);
-  else
+  } else {
     hostname_len = 0;
+  }
 
   num_connections = num_of_cluster_threads;
   clusterHandlers = (ClusterHandler **)ats_calloc(num_connections, sizeof(ClusterHandler *));
@@ -216,8 +221,9 @@ read_MachineList(const char *filename, int afd)
   if (fd >= 0) {
     while (ink_file_fd_readline(fd, sizeof(line) - 1, line) > 0) {
       ln++;
-      if (*line == '#')
+      if (*line == '#') {
         continue;
+      }
       if (n == -1 && ParseRules::is_digit(*line)) {
         n = atoi(line);
         if (n > 0) {
@@ -230,8 +236,9 @@ read_MachineList(const char *filename, int afd)
       }
       if (l && ParseRules::is_digit(*line) && i < n) {
         char *port = strchr(line, ':');
-        if (!port)
+        if (!port) {
           goto Lfail;
+        }
         *port++          = 0;
         l->machine[i].ip = inet_addr(line);
         if (-1 == (int)l->machine[i].ip) {
@@ -245,8 +252,9 @@ read_MachineList(const char *filename, int afd)
           }
         }
         l->machine[i].port = atoi(port);
-        if (!l->machine[i].port)
+        if (!l->machine[i].port) {
           goto Lfail;
+        }
         i++;
         l->n++;
         continue;
@@ -271,8 +279,9 @@ read_MachineList(const char *filename, int afd)
       if (afd == -1) {
         Warning("read machine list failure, length mismatch");
         return NULL;
-      } else
+      } else {
         ats_free(l);
+      }
       return (MachineList *)ats_strdup("number of machines does not match length of list\n");
     }
   }

--- a/iocore/cluster/ClusterProcessor.cc
+++ b/iocore/cluster/ClusterProcessor.cc
@@ -129,12 +129,14 @@ ClusterProcessor::internal_invoke_remote(ClusterHandler *ch, int cluster_fn, voi
 
       MUTEX_TRY_LOCK(lock, ch->mutex, tt);
       if (!lock.is_locked()) {
-        if (ch->thread && ch->thread->signal_hook)
+        if (ch->thread && ch->thread->signal_hook) {
           ch->thread->signal_hook(ch->thread);
+        }
         return 1;
       }
-      if (steal)
+      if (steal) {
         ch->steal_thread(tt);
+      }
       return 1;
     }
   } else {
@@ -231,11 +233,13 @@ ClusterProcessor::open_local(Continuation *cont, ClusterMachine * /* m ATS_UNUSE
   bool allow_immediate = ((options & CLUSTER_OPT_ALLOW_IMMEDIATE) ? true : false);
 
   ClusterHandler *ch = ((CacheContinuation *)cont)->ch;
-  if (!ch)
+  if (!ch) {
     return NULL;
+  }
   EThread *t = ch->thread;
-  if (!t)
+  if (!t) {
     return NULL;
+  }
 
   EThread *thread        = this_ethread();
   ProxyMutex *mutex      = thread->mutex.get();
@@ -259,14 +263,16 @@ ClusterProcessor::open_local(Continuation *cont, ClusterMachine * /* m ATS_UNUSE
     }
     vc->action_ = cont;
     ink_atomiclist_push(&ch->external_incoming_open_local, (void *)vc);
-    if (ch->thread && ch->thread->signal_hook)
+    if (ch->thread && ch->thread->signal_hook) {
       ch->thread->signal_hook(ch->thread);
+    }
     return CLUSTER_DELAYED_OPEN;
 
 #ifdef CLUSTER_THREAD_STEALING
   } else {
-    if (!(immediate || allow_immediate))
+    if (!(immediate || allow_immediate)) {
       vc->action_ = cont;
+    }
     if (vc->start(thread) < 0) {
       return NULL;
     }
@@ -296,16 +302,20 @@ ClusterProcessor::connect_local(Continuation *cont, ClusterVCToken *token, int c
 #else
   ClusterMachine *m = this_cluster->current_configuration()->find(token->ip_created);
 #endif
-  if (!m)
+  if (!m) {
     return NULL;
-  if (token->ch_id >= (uint32_t)m->num_connections)
+  }
+  if (token->ch_id >= (uint32_t)m->num_connections) {
     return NULL;
+  }
   ClusterHandler *ch = m->clusterHandlers[token->ch_id];
-  if (!ch)
+  if (!ch) {
     return NULL;
+  }
   EThread *t = ch->thread;
-  if (!t)
+  if (!t) {
     return NULL;
+  }
 
   EThread *thread        = this_ethread();
   ProxyMutex *mutex      = thread->mutex.get();
@@ -332,8 +342,9 @@ ClusterProcessor::connect_local(Continuation *cont, ClusterVCToken *token, int c
     return CLUSTER_DELAYED_OPEN;
 #ifdef CLUSTER_THREAD_STEALING
   } else {
-    if (!(immediate || allow_immediate))
+    if (!(immediate || allow_immediate)) {
       vc->action_ = cont;
+    }
     if (vc->start(thread) < 0) {
       return NULL;
     }
@@ -603,13 +614,14 @@ ClusterProcessor::init()
   //
   // Configuration callbacks
   //
-  if (cluster_port_number != DEFAULT_CLUSTER_PORT_NUMBER)
+  if (cluster_port_number != DEFAULT_CLUSTER_PORT_NUMBER) {
     cluster_port = cluster_port_number;
-  else {
+  } else {
     REC_ReadConfigInteger(cluster_port, "proxy.config.cluster.cluster_port");
   }
-  if (num_of_cluster_threads == DEFAULT_NUMBER_OF_CLUSTER_THREADS)
+  if (num_of_cluster_threads == DEFAULT_NUMBER_OF_CLUSTER_THREADS) {
     REC_ReadConfigInteger(num_of_cluster_threads, "proxy.config.cluster.threads");
+  }
 
   REC_EstablishStaticConfigInt32(CacheClusterMonitorEnabled, "proxy.config.cluster.enable_monitor");
   REC_EstablishStaticConfigInt32(CacheClusterMonitorIntervalSecs, "proxy.config.cluster.monitor_interval_secs");
@@ -712,10 +724,11 @@ ClusterProcessor::connect(unsigned int ip, int port, int16_t id, bool delay)
   ch->port      = port;
   ch->connector = true;
   ch->id        = id;
-  if (delay)
+  if (delay) {
     eventProcessor.schedule_in(ch, CLUSTER_MEMBER_DELAY, ET_CLUSTER);
-  else
+  } else {
     eventProcessor.schedule_imm(ch, ET_CLUSTER);
+  }
 }
 
 void

--- a/iocore/cluster/ClusterRPC.cc
+++ b/iocore/cluster/ClusterRPC.cc
@@ -63,8 +63,9 @@ machine_list_ClusterFunction(ClusterHandler *from, void *data, int len)
     ////////////////////////////////////////////////
     ink_release_assert(!"machine_list_ClusterFunction() bad msg version");
   }
-  if (m->NeedByteSwap())
+  if (m->NeedByteSwap()) {
     m->SwapBytes();
+  }
 
   ink_assert(m->n_ip == ((len - m->sizeof_fixedlen_msg()) / sizeof(uint32_t)));
 
@@ -76,8 +77,9 @@ machine_list_ClusterFunction(ClusterHandler *from, void *data, int len)
 
   for (unsigned int i = 0; i < m->n_ip; i++) {
     for (int j = 0; j < cc->n_machines; j++) {
-      if (cc->machines[j]->ip == m->ip[i])
+      if (cc->machines[j]->ip == m->ip[i]) {
         goto Lfound;
+      }
     }
     // not found, must be a new machine
     {
@@ -101,15 +103,17 @@ close_channel_ClusterFunction(ClusterHandler *ch, void *data, int len)
     ////////////////////////////////////////////////
     ink_release_assert(!"close_channel_ClusterFunction() bad msg version");
   }
-  if (m->NeedByteSwap())
+  if (m->NeedByteSwap()) {
     m->SwapBytes();
+  }
 
   //
   // Close the remote side of a VC connection (remote node is originator)
   //
   ink_assert(len >= (int)sizeof(CloseMessage));
-  if (!ch || !ch->channels)
+  if (!ch || !ch->channels) {
     return;
+  }
   ClusterVConnection *vc = ch->channels[m->channel];
   if (VALID_CHANNEL(vc) && vc->token.sequence_number == m->sequence_number) {
     vc->remote_closed = m->status;
@@ -124,8 +128,9 @@ test_ClusterFunction(ClusterHandler *ch, void *data, int len)
   //
   // Note: Only for testing.
   //
-  if (ptest_ClusterFunction)
+  if (ptest_ClusterFunction) {
     ptest_ClusterFunction(ch, data, len);
+  }
 }
 
 CacheVC *
@@ -185,8 +190,9 @@ set_channel_data_ClusterFunction(ClusterHandler *ch, void *tdata, int tlen)
     ////////////////////////////////////////////////
     ink_release_assert(!"set_channel_data_ClusterFunction() bad msg version");
   }
-  if (m->NeedByteSwap())
+  if (m->NeedByteSwap()) {
     m->SwapBytes();
+  }
 
   ClusterVConnection *cvc;
   CacheVC *cache_vc;
@@ -269,8 +275,9 @@ set_channel_pin_ClusterFunction(ClusterHandler *ch, void *data, int /* len ATS_U
     ink_release_assert(!"set_channel_pin_ClusterFunction() bad msg version");
   }
 
-  if (m->NeedByteSwap())
+  if (m->NeedByteSwap()) {
     m->SwapBytes();
+  }
 
   ClusterVConnection *cvc = NULL; // Just to make GCC happy
   CacheVC *cache_vc;
@@ -329,8 +336,9 @@ set_channel_priority_ClusterFunction(ClusterHandler *ch, void *data, int /* len 
     ////////////////////////////////////////////////
     ink_release_assert(!"set_channel_priority_ClusterFunction() bad msg version");
   }
-  if (m->NeedByteSwap())
+  if (m->NeedByteSwap()) {
     m->SwapBytes();
+  }
 
   ClusterVConnection *cvc = NULL; // Just to make GCC happy
   CacheVC *cache_vc;

--- a/iocore/cluster/ClusterVConnection.cc
+++ b/iocore/cluster/ClusterVConnection.cc
@@ -140,8 +140,9 @@ ClusterVConnectionBase::do_io_close(int alerrno)
   read.vio.buffer.clear();
   write.vio.buffer.clear();
   INK_WRITE_MEMORY_BARRIER;
-  if (alerrno && alerrno != -1)
+  if (alerrno && alerrno != -1) {
     this->lerrno = alerrno;
+  }
 
   if (alerrno == -1) {
     closed = 1;
@@ -153,8 +154,9 @@ ClusterVConnectionBase::do_io_close(int alerrno)
 void
 ClusterVConnection::reenable(VIO *vio)
 {
-  if (type == VC_CLUSTER_WRITE)
+  if (type == VC_CLUSTER_WRITE) {
     ch->vcs_push(this, VC_CLUSTER_WRITE);
+  }
 
   ClusterVConnectionBase::reenable(vio);
 }
@@ -166,14 +168,16 @@ ClusterVConnectionBase::reenable(VIO *vio)
   if (vio == &read.vio) {
     read.enabled = 1;
 #ifdef DEBUG
-    if (enable_debug_trace && (vio->buffer.writer() && !vio->buffer.writer()->write_avail()))
+    if (enable_debug_trace && (vio->buffer.writer() && !vio->buffer.writer()->write_avail())) {
       printf("NetVConnection re-enabled for read when full\n");
+    }
 #endif
   } else if (vio == &write.vio) {
     write.enabled = 1;
 #ifdef DEBUG
-    if (enable_debug_trace && (vio->buffer.writer() && !vio->buffer.reader()->read_avail()))
+    if (enable_debug_trace && (vio->buffer.writer() && !vio->buffer.reader()->read_avail())) {
       printf("NetVConnection re-enabled for write when empty\n");
+    }
 #endif
   } else {
     ink_assert(!"bad vio");
@@ -249,8 +253,9 @@ ClusterVConnection::free()
 VIO *
 ClusterVConnection::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
 {
-  if (type == VC_CLUSTER)
+  if (type == VC_CLUSTER) {
     type = VC_CLUSTER_READ;
+  }
   ch->vcs_push(this, VC_CLUSTER_READ);
 
   return ClusterVConnectionBase::do_io_read(c, nbytes, buf);
@@ -259,8 +264,9 @@ ClusterVConnection::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
 VIO *
 ClusterVConnection::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool owner)
 {
-  if (type == VC_CLUSTER)
+  if (type == VC_CLUSTER) {
     type = VC_CLUSTER_WRITE;
+  }
   ch->vcs_push(this, VC_CLUSTER_WRITE);
 
   return ClusterVConnectionBase::do_io_write(c, nbytes, buf, owner);
@@ -270,10 +276,11 @@ void
 ClusterVConnection::do_io_close(int alerrno)
 {
   if ((type == VC_CLUSTER) && current_cont) {
-    if (((CacheContinuation *)current_cont)->read_cluster_vc == this)
+    if (((CacheContinuation *)current_cont)->read_cluster_vc == this) {
       type = VC_CLUSTER_READ;
-    else if (((CacheContinuation *)current_cont)->write_cluster_vc == this)
+    } else if (((CacheContinuation *)current_cont)->write_cluster_vc == this) {
       type = VC_CLUSTER_WRITE;
+    }
   }
   ch->vcs_push(this, type);
 
@@ -374,8 +381,9 @@ ClusterVConnection::start(EThread *t)
 
     } else {
       Debug(CL_TRACE, "VC start alloc local chan=%d VC=%p", channel, this);
-      if (new_connect_read)
+      if (new_connect_read) {
         this->pending_remote_fill = 1;
+      }
     }
 
   } else {
@@ -386,9 +394,10 @@ ClusterVConnection::start(EThread *t)
       return status; // Channel active or no more channels
     } else {
       Debug(CL_TRACE, "VC start alloc remote chan=%d VC=%p", channel, this);
-      if (new_connect_read)
+      if (new_connect_read) {
         this->pending_remote_fill = 1;
-      this->iov_map               = CLUSTER_IOV_NONE; // disable connect timeout
+      }
+      this->iov_map = CLUSTER_IOV_NONE; // disable connect timeout
     }
   }
   cluster_schedule(ch, this, &read);
@@ -421,10 +430,11 @@ ClusterVConnection::disable_close()
 int
 ClusterVConnection::was_remote_closed()
 {
-  if (!byte_bank_q.head && !remote_close_disabled)
+  if (!byte_bank_q.head && !remote_close_disabled) {
     return remote_closed;
-  else
+  } else {
     return 0;
+  }
 }
 
 void

--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -96,8 +96,9 @@ char try_server_names[DEFAULT_NUM_TRY_SERVER][MAXDNAME];
 static inline char *
 strnchr(char *s, char c, int len)
 {
-  while (*s && *s != c && len)
+  while (*s && *s != c && len) {
     ++s, --len;
+  }
   return *s == c ? s : (char *)NULL;
 }
 
@@ -122,30 +123,38 @@ make_ipv4_ptr(in_addr_t addr, char *buffer)
   char *p          = buffer;
   uint8_t const *u = reinterpret_cast<uint8_t *>(&addr);
 
-  if (u[3] > 99)
+  if (u[3] > 99) {
     *p++ = (u[3] / 100) + '0';
-  if (u[3] > 9)
+  }
+  if (u[3] > 9) {
     *p++ = ((u[3] / 10) % 10) + '0';
-  *p++   = u[3] % 10 + '0';
-  *p++   = '.';
-  if (u[2] > 99)
+  }
+  *p++ = u[3] % 10 + '0';
+  *p++ = '.';
+  if (u[2] > 99) {
     *p++ = (u[2] / 100) + '0';
-  if (u[2] > 9)
+  }
+  if (u[2] > 9) {
     *p++ = ((u[2] / 10) % 10) + '0';
-  *p++   = u[2] % 10 + '0';
-  *p++   = '.';
-  if (u[1] > 99)
+  }
+  *p++ = u[2] % 10 + '0';
+  *p++ = '.';
+  if (u[1] > 99) {
     *p++ = (u[1] / 100) + '0';
-  if (u[1] > 9)
+  }
+  if (u[1] > 9) {
     *p++ = ((u[1] / 10) % 10) + '0';
-  *p++   = u[1] % 10 + '0';
-  *p++   = '.';
-  if (u[0] > 99)
+  }
+  *p++ = u[1] % 10 + '0';
+  *p++ = '.';
+  if (u[0] > 99) {
     *p++ = (u[0] / 100) + '0';
-  if (u[0] > 9)
+  }
+  if (u[0] > 9) {
     *p++ = ((u[0] / 10) % 10) + '0';
-  *p++   = u[0] % 10 + '0';
-  *p++   = '.';
+  }
+  *p++ = u[0] % 10 + '0';
+  *p++ = '.';
   ink_strlcpy(p, "in-addr.arpa", MAXDNAME - (p - buffer + 1));
 }
 
@@ -225,13 +234,15 @@ DNSProcessor::open(sockaddr const *target)
   ats_ip_copy(&h->local_ipv4.sa, &local_ipv4.sa);
   ats_ip_copy(&h->local_ipv6.sa, &local_ipv6.sa);
 
-  if (target)
+  if (target) {
     ats_ip_copy(&h->ip, target);
-  else
+  } else {
     ats_ip_invalidate(&h->ip); // marked to use default.
+  }
 
-  if (!dns_handler_initialized)
+  if (!dns_handler_initialized) {
     handler = h;
+  }
 
   SET_CONTINUATION_HANDLER(h, &DNSHandler::startEvent);
   thread->schedule_imm(h);
@@ -266,14 +277,16 @@ DNSProcessor::dns_init()
       if ('[' == *ns) {
         char *ndx = strchr(ns + 1, ']');
         if (ndx) {
-          if (':' == ndx[1])
+          if (':' == ndx[1]) {
             colon = ndx + 1;
+          }
         } else {
           err = true;
           Warning("Unmatched '[' in address for nameserver '%s', discarding.", ns);
         }
-      } else
+      } else {
         colon = strchr(ns, ':');
+      }
 
       if (!err && colon) {
         *colon = '\0';
@@ -306,8 +319,9 @@ DNSProcessor::dns_init()
   }
   // The default domain (5th param) and search list (6th param) will
   // come from /etc/resolv.conf.
-  if (ink_res_init(&l_res, nameserver, nserv, dns_search, NULL, NULL, dns_resolv_conf) < 0)
+  if (ink_res_init(&l_res, nameserver, nserv, dns_search, NULL, NULL, dns_resolv_conf) < 0) {
     Warning("Failed to build DNS res records for the servers (%s).  Using resolv.conf.", dns_ns_list);
+  }
 
   // Check for local forced bindings.
 
@@ -396,12 +410,13 @@ DNSEntry::init(const char *x, int len, int qtype_arg, Continuation *acont, DNSPr
     }
   } else { // T_PTR
     IpAddr const *ip = reinterpret_cast<IpAddr const *>(x);
-    if (ip->isIp6())
+    if (ip->isIp6()) {
       make_ipv6_ptr(&ip->_addr._ip6, qname);
-    else if (ip->isIp4())
+    } else if (ip->isIp4()) {
       make_ipv4_ptr(ip->_addr._ip4, qname);
-    else
+    } else {
       ink_assert(!"T_PTR query to DNS must be IP address.");
+    }
   }
 
   SET_HANDLER((DNSEntryHandler)&DNSEntry::mainEvent);
@@ -440,10 +455,11 @@ DNSHandler::open_con(sockaddr const *target, bool failed, int icon)
                                   .setLocalIpv4(&local_ipv4.sa)) < 0) {
     Debug("dns", "opening connection %s FAILED for %d", ip_text, icon);
     if (!failed) {
-      if (dns_ns_rr)
+      if (dns_ns_rr) {
         rr_failure(icon);
-      else
+      } else {
         failover();
+      }
     }
     return;
   } else {
@@ -492,9 +508,10 @@ DNSHandler::startEvent(int /* event ATS_UNUSED */, Event *e)
     SET_HANDLER(&DNSHandler::mainEvent);
     if (dns_ns_rr) {
       int max_nscount = m_res->nscount;
-      if (max_nscount > MAX_NAMED)
+      if (max_nscount > MAX_NAMED) {
         max_nscount = MAX_NAMED;
-      n_con         = 0;
+      }
+      n_con = 0;
       for (int i = 0; i < max_nscount; i++) {
         ip_port_text_buffer buff;
         sockaddr *sa = &m_res->nsaddr_list[i].sa;
@@ -590,10 +607,11 @@ DNSHandler::try_primary_named(bool reopen)
     int r = _ink_res_mkquery(m_res, try_server_names[try_servers], T_A, buffer);
     // if try_server_names[] is not full, round-robin within the
     // filled entries.
-    if (local_num_entries < DEFAULT_NUM_TRY_SERVER)
+    if (local_num_entries < DEFAULT_NUM_TRY_SERVER) {
       try_servers = (try_servers + 1) % local_num_entries;
-    else
+    } else {
       try_servers = (try_servers + 1) % countof(try_server_names);
+    }
     ink_assert(r >= 0);
     if (r >= 0) { // looking for a bounce
       int res = socketManager.send(con[0].fd, buffer, r, 0);
@@ -607,8 +625,9 @@ DNSHandler::switch_named(int ndx)
 {
   for (DNSEntry *e = entries.head; e; e = (DNSEntry *)e->link.next) {
     e->written_flag = 0;
-    if (e->retries < dns_retries)
+    if (e->retries < dns_retries) {
       ++(e->retries); // give them another chance
+    }
   }
   in_flight = 0;
   received_one(ndx); // reset failover counters
@@ -624,8 +643,9 @@ DNSHandler::failover()
     ip_text_buffer buff1, buff2;
     int max_nscount = m_res->nscount;
 
-    if (max_nscount > MAX_NAMED)
-      max_nscount            = MAX_NAMED;
+    if (max_nscount > MAX_NAMED) {
+      max_nscount = MAX_NAMED;
+    }
     sockaddr const *old_addr = &m_res->nsaddr_list[name_server].sa;
     name_server              = (name_server + 1) % max_nscount;
     Debug("dns", "failover: failing over to name_server=%d", name_server);
@@ -636,12 +656,14 @@ DNSHandler::failover()
     Warning("failover: connection to DNS server %s lost, move to %s", ats_ip_ntop(old_addr, buff1, sizeof(buff1)),
             ats_ip_ntop(&target.sa, buff2, sizeof(buff2)));
 
-    if (!target.isValid())
+    if (!target.isValid()) {
       target.setToLoopback(AF_INET);
+    }
 
     open_con(&target.sa, true, name_server);
-    if (n_con <= name_server)
+    if (n_con <= name_server) {
       n_con = name_server + 1;
+    }
     switch_named(name_server);
   } else {
     ip_text_buffer buff;
@@ -663,8 +685,9 @@ DNSHandler::rr_failure(int ndx)
   }
 
   int nscount = m_res->nscount;
-  if (nscount > MAX_NAMED)
+  if (nscount > MAX_NAMED) {
     nscount = MAX_NAMED;
+  }
 
   // See if all nameservers are down
   int all_down = 1;
@@ -682,8 +705,9 @@ DNSHandler::rr_failure(int ndx)
     // mark any outstanding requests as not sent for later retry
     for (DNSEntry *e = entries.head; e; e = (DNSEntry *)e->link.next) {
       e->written_flag = 0;
-      if (e->retries < dns_retries)
+      if (e->retries < dns_retries) {
         ++(e->retries); // give them another chance
+      }
       --in_flight;
       DNS_DECREMENT_DYN_STAT(dns_in_flight_stat);
     }
@@ -692,8 +716,9 @@ DNSHandler::rr_failure(int ndx)
     for (DNSEntry *e = entries.head; e; e = (DNSEntry *)e->link.next) {
       if (e->which_ns == ndx) {
         e->written_flag = 0;
-        if (e->retries < dns_retries)
+        if (e->retries < dns_retries) {
           ++(e->retries); // give them another chance
+        }
         --in_flight;
         DNS_DECREMENT_DYN_STAT(dns_in_flight_stat);
       }
@@ -731,20 +756,23 @@ DNSHandler::recv_dns(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
       IpEndpoint from_ip;
       socklen_t from_length = sizeof(from_ip);
 
-      if (!hostent_cache)
+      if (!hostent_cache) {
         hostent_cache = dnsBufAllocator.alloc();
-      HostEnt *buf    = hostent_cache;
+      }
+      HostEnt *buf = hostent_cache;
 
       int res = socketManager.recvfrom(dnsc->fd, buf->buf, MAX_DNS_PACKET_LEN, 0, &from_ip.sa, &from_length);
 
-      if (res == -EAGAIN)
+      if (res == -EAGAIN) {
         break;
+      }
       if (res <= 0) {
         Debug("dns", "named error: %d", res);
-        if (dns_ns_rr)
+        if (dns_ns_rr) {
           rr_failure(dnsc->num);
-        else if (dnsc->num == name_server)
+        } else if (dnsc->num == name_server) {
           failover();
+        }
         break;
       }
 
@@ -771,17 +799,19 @@ DNSHandler::recv_dns(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
         if (!dnsc->num) {
           Debug("dns", "primary DNS response code = %d", get_rcode(buf));
           if (good_rcode(buf->buf)) {
-            if (name_server)
+            if (name_server) {
               recover();
-            else
+            } else {
               received_one(name_server);
+            }
           }
         }
       }
       Ptr<HostEnt> protect_hostent = make_ptr(buf);
       if (dns_process(this, buf, res)) {
-        if (dnsc->num == name_server)
+        if (dnsc->num == name_server) {
           received_one(name_server);
+        }
       }
     }
   }
@@ -806,9 +836,9 @@ DNSHandler::mainEvent(int event, Event *e)
     for (int i = 0; i < n_con; i++) {
       if (!ns_down[i] && failover_soon(i)) {
         Debug("dns", "mainEvent: nameserver = %d failover soon", name_server);
-        if (failover_now(i))
+        if (failover_now(i)) {
           rr_failure(i);
-        else {
+        } else {
           Debug("dns", "mainEvent: nameserver = %d no failover now - retrying", i);
           retry_named(i, t, false);
           ++failover_soon_number[i];
@@ -825,12 +855,14 @@ DNSHandler::mainEvent(int event, Event *e)
         try_primary_named(false);
         ++failover_soon_number[name_server];
       }
-    } else if (name_server) // not on the primary named
+    } else if (name_server) { // not on the primary named
       try_primary_named(true);
+    }
   }
 
-  if (entries.head)
+  if (entries.head) {
     write_dns(this);
+  }
 
   return EVENT_CONT;
 }
@@ -861,10 +893,12 @@ get_entry(DNSHandler *h, char *qname, int qtype)
   for (DNSEntry *e = h->entries.head; e; e = (DNSEntry *)e->link.next) {
     if (e->qtype == qtype) {
       if (is_addr_query(qtype)) {
-        if (!strcmp(qname, e->qname))
+        if (!strcmp(qname, e->qname)) {
           return e;
-      } else if (0 == memcmp(qname, e->qname, e->qname_len))
+        }
+      } else if (0 == memcmp(qname, e->qname, e->qname_len)) {
         return e;
+      }
     }
   }
   return NULL;
@@ -877,8 +911,9 @@ write_dns(DNSHandler *h)
   ProxyMutex *mutex = h->mutex.get();
   DNS_INCREMENT_DYN_STAT(dns_total_lookups_stat);
   int max_nscount = h->m_res->nscount;
-  if (max_nscount > MAX_NAMED)
+  if (max_nscount > MAX_NAMED) {
     max_nscount = MAX_NAMED;
+  }
   if (max_nscount <= 0) {
     Warning("There is no name server found in the resolv.conf");
     if (h->entries.head) {
@@ -887,8 +922,9 @@ write_dns(DNSHandler *h)
     return;
   }
 
-  if (h->in_write_dns)
+  if (h->in_write_dns) {
     return;
+  }
   h->in_write_dns = true;
   // Debug("dns", "in_flight: %d, dns_max_dns_in_flight: %d", h->in_flight, dns_max_dns_in_flight);
   if (h->in_flight < dns_max_dns_in_flight) {
@@ -902,11 +938,13 @@ write_dns(DNSHandler *h)
             h->name_server = (h->name_server + 1) % max_nscount;
           } while (h->ns_down[h->name_server] && h->name_server != ns_start);
         }
-        if (!write_dns_event(h, e))
+        if (!write_dns_event(h, e)) {
           break;
+        }
       }
-      if (h->in_flight >= dns_max_dns_in_flight)
+      if (h->in_flight >= dns_max_dns_in_flight) {
         break;
+      }
       e = n;
     }
   }
@@ -982,10 +1020,11 @@ write_dns_event(DNSHandler *h, DNSEntry *e)
     Debug("dns", "send() failed: qname = %s, %d != %d, nameserver= %d", e->qname, s, r, h->name_server);
     // changed if condition from 'r < 0' to 's < 0' - 8/2001 pas
     if (s < 0) {
-      if (dns_ns_rr)
+      if (dns_ns_rr) {
         h->rr_failure(h->name_server);
-      else
+      } else {
         h->failover();
+      }
     }
     return false;
   }
@@ -998,8 +1037,9 @@ write_dns_event(DNSHandler *h, DNSEntry *e)
 
   e->send_time = Thread::get_hrtime();
 
-  if (e->timeout)
+  if (e->timeout) {
     e->timeout->cancel();
+  }
 
   if (h->txn_lookup_timeout) {
     e->timeout = h->mutex->thread_holding->schedule_in(e, HRTIME_MSECONDS(h->txn_lookup_timeout)); // this is in msec
@@ -1033,8 +1073,9 @@ DNSEntry::mainEvent(int event, Event *e)
     ink_assert(!"bad case");
     return EVENT_DONE;
   case EVENT_IMMEDIATE: {
-    if (!dnsH)
+    if (!dnsH) {
       dnsH = dnsProcessor.handler;
+    }
     if (!dnsH) {
       Debug("dns", "handler not found, retrying...");
       SET_HANDLER((DNSEntryHandler)&DNSEntry::delayEvent);
@@ -1096,10 +1137,11 @@ DNSProcessor::getby(const char *x, int len, int type, Continuation *cont, Option
   e->retries  = dns_retries;
   e->init(x, len, type, cont, opt);
   MUTEX_TRY_LOCK(lock, e->mutex, this_ethread());
-  if (!lock.is_locked())
+  if (!lock.is_locked()) {
     thread->schedule_imm(e);
-  else
+  } else {
     e->handleEvent(EVENT_IMMEDIATE, 0);
+  }
   return &e->action;
 }
 
@@ -1157,8 +1199,9 @@ dns_result(DNSHandler *h, DNSEntry *e, HostEnt *ent, bool retry)
       DNS_INCREMENT_DYN_STAT(dns_max_retries_exceeded_stat);
     }
   }
-  if (ent == BAD_DNS_RESULT)
+  if (ent == BAD_DNS_RESULT) {
     ent = NULL;
+  }
   if (!cancelled) {
     if (!ent) {
       DNS_SUM_DYN_STAT(dns_fail_time_stat, Thread::get_hrtime() - e->submit_time);
@@ -1214,15 +1257,17 @@ dns_result(DNSHandler *h, DNSEntry *e, HostEnt *ent, bool retry)
       goto Lretry;
     }
     for (int i = 0; i < MAX_DNS_RETRIES; i++) {
-      if (e->id[i] < 0)
+      if (e->id[i] < 0) {
         break;
+      }
       h->release_query_id(e->id[i]);
     }
     e->postEvent(0, 0);
   } else {
     for (int i = 0; i < MAX_DNS_RETRIES; i++) {
-      if (e->id[i] < 0)
+      if (e->id[i] < 0) {
         break;
+      }
       h->release_query_id(e->id[i]);
     }
     e->mutex = e->action.mutex;
@@ -1233,8 +1278,9 @@ dns_result(DNSHandler *h, DNSEntry *e, HostEnt *ent, bool retry)
 Lretry:
   e->result_ent = ent;
   e->retries    = 0;
-  if (e->timeout)
+  if (e->timeout) {
     e->timeout->cancel();
+  }
   e->timeout = h->mutex->thread_holding->schedule_in(e, DNS_PERIOD);
 }
 
@@ -1351,8 +1397,9 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
     //
     // Expand name
     //
-    if ((n = ink_dn_expand((u_char *)h, eom, cp, bp, buflen)) < 0)
+    if ((n = ink_dn_expand((u_char *)h, eom, cp, bp, buflen)) < 0) {
       goto Lerror;
+    }
 
     // Should we validate the query name?
     if (dns_validate_qname) {
@@ -1360,10 +1407,12 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
       int rlen = strlen((char *)bp);
 
       rname_len = rlen; // Save for later use
-      if ((qlen > 0) && ('.' == e->qname[qlen - 1]))
+      if ((qlen > 0) && ('.' == e->qname[qlen - 1])) {
         --qlen;
-      if ((rlen > 0) && ('.' == bp[rlen - 1]))
+      }
+      if ((rlen > 0) && ('.' == bp[rlen - 1])) {
         --rlen;
+      }
       // TODO: At some point, we might want to care about the case here, and use an algorithm
       // to randomly pick upper case characters in the query, and validate the response with
       // case sensitivity.
@@ -1378,10 +1427,11 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
 
     cp += n + QFIXEDSZ;
     if (is_addr_query(e->qtype)) {
-      if (-1 == rname_len)
+      if (-1 == rname_len) {
         n = strlen((char *)bp) + 1;
-      else
-        n             = rname_len + 1;
+      } else {
+        n = rname_len + 1;
+      }
       buf->ent.h_name = (char *)bp;
       bp += n;
       buflen -= n;
@@ -1445,16 +1495,18 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
       NS_GET16(type, cp);
       cp += NS_INT16SZ;       // NS_GET16(cls, cp);
       NS_GET32(temp_ttl, cp); // NOTE: this is not a "long" but 32-bits (from nameser_compat.h)
-      if ((temp_ttl < buf->ttl) || (buf->ttl == 0))
+      if ((temp_ttl < buf->ttl) || (buf->ttl == 0)) {
         buf->ttl = temp_ttl;
+      }
       NS_GET16(n, cp);
 
       //
       // Decode cname
       //
       if (is_addr_query(e->qtype) && type == T_CNAME) {
-        if (ap >= &buf->host_aliases[DNS_MAX_ALIASES - 1])
+        if (ap >= &buf->host_aliases[DNS_MAX_ALIASES - 1]) {
           continue;
+        }
         n = ink_dn_expand((u_char *)h, eom, cp, tbuf, sizeof(tbuf));
         if (n < 0) {
           ++error;
@@ -1504,8 +1556,9 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
           buflen -= n;
         }
       } else if (type == T_SRV) {
-        if (num_srv >= HOST_DB_MAX_ROUND_ROBIN_INFO)
+        if (num_srv >= HOST_DB_MAX_ROUND_ROBIN_INFO) {
           break;
+        }
         cp         = here; /* hack */
         int strlen = dn_skipname(cp, eom);
         cp += strlen;
@@ -1530,10 +1583,11 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
         srv->host[r - 1] = '\0';
         srv->key         = makeHostHash(srv->host);
 
-        if (srv->host[0] != '\0')
+        if (srv->host[0] != '\0') {
           buf->srv_hosts.srv_hosts_length += r;
-        else
+        } else {
           continue;
+        }
         ++num_srv;
       } else if (is_addr_query(type)) {
         if (answer) {
@@ -1568,8 +1622,9 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
           bp += n;
           cp += n;
         }
-      } else
+      } else {
         goto Lerror;
+      }
       ++answer;
     }
     if (answer) {
@@ -1604,8 +1659,9 @@ ink_dns_init(ModuleVersion v)
   Debug("dns", "ink_dns_init: called with init_called = %d", init_called);
 
   ink_release_assert(!checkModuleVersion(v, HOSTDB_MODULE_VERSION));
-  if (init_called)
+  if (init_called) {
     return;
+  }
 
   init_called = 1;
   // do one time stuff
@@ -1676,10 +1732,11 @@ struct DNSRegressionContinuation : public Continuation {
       ++i;
       return EVENT_CONT;
     } else {
-      if (found == tofind)
+      if (found == tofind) {
         *status = REGRESSION_TEST_PASSED;
-      else
+      } else {
         *status = REGRESSION_TEST_FAILED;
+      }
       return EVENT_DONE;
     }
   }

--- a/iocore/dns/DNSConnection.cc
+++ b/iocore/dns/DNSConnection.cc
@@ -92,12 +92,14 @@ DNSConnection::connect(sockaddr const *addr, Options const &opt)
 
   if (opt._use_tcp) {
     Proto = IPPROTO_TCP;
-    if ((res = socketManager.socket(af, SOCK_STREAM, 0)) < 0)
+    if ((res = socketManager.socket(af, SOCK_STREAM, 0)) < 0) {
       goto Lerror;
+    }
   } else {
     Proto = IPPROTO_UDP;
-    if ((res = socketManager.socket(af, SOCK_DGRAM, 0)) < 0)
+    if ((res = socketManager.socket(af, SOCK_DGRAM, 0)) < 0) {
       goto Lerror;
+    }
   }
 
   fd = res;
@@ -113,11 +115,12 @@ DNSConnection::connect(sockaddr const *addr, Options const &opt)
     }
     bind_size = sizeof(sockaddr_in6);
   } else if (AF_INET == af) {
-    if (ats_is_ip4(opt._local_ipv4))
+    if (ats_is_ip4(opt._local_ipv4)) {
       ats_ip_copy(&bind_addr.sa, opt._local_ipv4);
-    else
+    } else {
       bind_addr.sin.sin_addr.s_addr = INADDR_ANY;
-    bind_size                       = sizeof(sockaddr_in);
+    }
+    bind_size = sizeof(sockaddr_in);
   } else {
     ink_assert(!"Target DNS address must be IP.");
   }
@@ -151,19 +154,24 @@ DNSConnection::connect(sockaddr const *addr, Options const &opt)
   } else if (ats_is_ip(&bind_addr.sa)) {
     ip_text_buffer b;
     res = socketManager.ink_bind(fd, &bind_addr.sa, bind_size, Proto);
-    if (res < 0)
+    if (res < 0) {
       Warning("Unable to bind local address to %s.", ats_ip_ntop(&bind_addr.sa, b, sizeof b));
+    }
   }
 
-  if (opt._non_blocking_connect)
-    if ((res = safe_nonblocking(fd)) < 0)
+  if (opt._non_blocking_connect) {
+    if ((res = safe_nonblocking(fd)) < 0) {
       goto Lerror;
+    }
+  }
 
 // cannot do this after connection on non-blocking connect
 #ifdef SET_TCP_NO_DELAY
-  if (opt._use_tcp)
-    if ((res = safe_setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, SOCKOPT_ON, sizeof(int))) < 0)
+  if (opt._use_tcp) {
+    if ((res = safe_setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, SOCKOPT_ON, sizeof(int))) < 0) {
       goto Lerror;
+    }
+  }
 #endif
 #ifdef RECV_BUF_SIZE
   socketManager.set_rcvbuf_size(fd, RECV_BUF_SIZE);
@@ -178,18 +186,22 @@ DNSConnection::connect(sockaddr const *addr, Options const &opt)
   res = ::connect(fd, addr, ats_ip_size(addr));
 
   if (!res || ((res < 0) && (errno == EINPROGRESS || errno == EWOULDBLOCK))) {
-    if (!opt._non_blocking_connect && opt._non_blocking_io)
-      if ((res = safe_nonblocking(fd)) < 0)
+    if (!opt._non_blocking_connect && opt._non_blocking_io) {
+      if ((res = safe_nonblocking(fd)) < 0) {
         goto Lerror;
+      }
+    }
     // Shouldn't we turn off non-blocking when it's a non-blocking connect
     // and blocking IO?
-  } else
+  } else {
     goto Lerror;
+  }
 
   return 0;
 
 Lerror:
-  if (fd != NO_FD)
+  if (fd != NO_FD) {
     close();
+  }
   return res;
 }

--- a/iocore/dns/SplitDNS.cc
+++ b/iocore/dns/SplitDNS.cc
@@ -130,8 +130,9 @@ SplitDNSConfig::startup()
 void
 SplitDNSConfig::reconfigure()
 {
-  if (0 == gsplit_dns_enabled)
+  if (0 == gsplit_dns_enabled) {
     return;
+  }
 
   SplitDNS *params = new SplitDNS;
 
@@ -233,19 +234,22 @@ SplitDNS::findServer(RequestData *rdata, SplitDNSResult *result)
     int len        = strlen(pHost);
     HostLeaf *pxHL = (HostLeaf *)m_pxLeafArray;
     for (int i = 0; i < m_numEle; i++) {
-      if (0 == pxHL)
+      if (0 == pxHL) {
         break;
+      }
 
-      if (false == pxHL[i].isNot && pxHL[i].len > len)
+      if (false == pxHL[i].isNot && pxHL[i].len > len) {
         continue;
+      }
 
       int idx      = len - pxHL[i].len;
       char *pH     = &pHost[idx];
       char *pMatch = (char *)pxHL[i].match;
       char cNot    = *pMatch;
 
-      if ('!' == cNot)
+      if ('!' == cNot) {
         pMatch++;
+      }
 
       int res = memcmp(pH, pMatch, pxHL[i].len);
 
@@ -325,10 +329,12 @@ SplitDNSRecord::ProcessDNSHosts(char *val)
        ---------------------------------------- */
     if (tmp) {
       char *scan = tmp + 1;
-      for (; *scan != '\0' && ParseRules::is_digit(*scan); scan++)
+      for (; *scan != '\0' && ParseRules::is_digit(*scan); scan++) {
         ;
-      for (; *scan != '\0' && ParseRules::is_wslfcr(*scan); scan++)
+      }
+      for (; *scan != '\0' && ParseRules::is_wslfcr(*scan); scan++) {
         ;
+      }
 
       if (*scan != '\0') {
         return "Garbage trailing entry or invalid separator";
@@ -411,8 +417,9 @@ SplitDNSRecord::ProcessDomainSrchList(char *val)
     current = pTok[i];
     cnt     = sz += strlen(current);
 
-    if (MAXDNAME - 1 < sz)
+    if (MAXDNAME - 1 < sz) {
       break;
+    }
 
     memcpy(pSp, current, cnt);
     pSp += (cnt + 1);
@@ -544,8 +551,9 @@ ink_split_dns_init(ModuleVersion v)
   static int init_called = 0;
 
   ink_release_assert(!checkModuleVersion(v, SPLITDNS_MODULE_VERSION));
-  if (init_called)
+  if (init_called) {
     return;
+  }
 
   init_called = 1;
 }

--- a/iocore/eventsystem/EventSystem.cc
+++ b/iocore/eventsystem/EventSystem.cc
@@ -45,9 +45,11 @@ ink_event_system_init(ModuleVersion v)
   REC_ReadConfigInteger(config_max_iobuffer_size, "proxy.config.io.max_buffer_size");
 
   max_iobuffer_size = buffer_size_to_index(config_max_iobuffer_size, DEFAULT_BUFFER_SIZES - 1);
-  if (default_small_iobuffer_size > max_iobuffer_size)
+  if (default_small_iobuffer_size > max_iobuffer_size) {
     default_small_iobuffer_size = max_iobuffer_size;
-  if (default_large_iobuffer_size > max_iobuffer_size)
+  }
+  if (default_large_iobuffer_size > max_iobuffer_size) {
     default_large_iobuffer_size = max_iobuffer_size;
+  }
   init_buffer_allocators();
 }

--- a/iocore/eventsystem/IOBuffer.cc
+++ b/iocore/eventsystem/IOBuffer.cc
@@ -56,8 +56,9 @@ init_buffer_allocators()
     int64_t s = DEFAULT_BUFFER_BASE_SIZE * (((int64_t)1) << i);
     int64_t a = DEFAULT_BUFFER_ALIGNMENT;
     int n     = i <= default_large_iobuffer_size ? DEFAULT_BUFFER_NUMBER : DEFAULT_HUGE_BUFFER_NUMBER;
-    if (s < a)
+    if (s < a) {
       a = s;
+    }
 
     name = new char[64];
     snprintf(name, 64, "ioBufAllocator[%d]", i);
@@ -91,8 +92,9 @@ MIOBuffer::write(const void *abuf, int64_t alen)
   const char *buf = (const char *)abuf;
   int64_t len     = alen;
   while (len) {
-    if (!_writer)
+    if (!_writer) {
       add_block();
+    }
     int64_t f = _writer->write_avail();
     f         = f < len ? f : len;
     if (f > 0) {
@@ -102,10 +104,11 @@ MIOBuffer::write(const void *abuf, int64_t alen)
       len -= f;
     }
     if (len) {
-      if (!_writer->next)
+      if (!_writer->next) {
         add_block();
-      else
+      } else {
         _writer = _writer->next;
+      }
     }
   }
   return alen;
@@ -175,8 +178,9 @@ MIOBuffer::puts(char *s, int64_t len)
   char *pc = end();
   char *pb = s;
   while (pc < buf_end()) {
-    if (len-- <= 0)
+    if (len-- <= 0) {
       return -1;
+    }
     if (!*pb || *pb == '\n') {
       int64_t n = (int64_t)(pb - s);
       memcpy(end(), s, n + 1); // Upto and including '\n'
@@ -200,8 +204,9 @@ IOBufferReader::read(void *ab, int64_t len)
 
   while (n) {
     int64_t l = block_read_avail();
-    if (n < l)
+    if (n < l) {
       l = n;
+    }
     ::memcpy(b, start(), l);
     consume(l);
     b += l;
@@ -227,14 +232,16 @@ IOBufferReader::memchr(char c, int64_t len, int64_t offset)
       continue;
     }
     int64_t bytes;
-    if (len < 0 || len >= max_bytes)
+    if (len < 0 || len >= max_bytes) {
       bytes = max_bytes;
-    else
+    } else {
       bytes = len;
+    }
     char *s = b->start() + offset;
     char *p = (char *)::memchr(s, c, bytes);
-    if (p)
+    if (p) {
       return (int64_t)(o - start_offset + p - s);
+    }
     o += bytes;
     len -= bytes;
     b      = b->next.get();
@@ -260,10 +267,11 @@ IOBufferReader::memcpy(const void *ap, int64_t len, int64_t offset)
       continue;
     }
     int64_t bytes;
-    if (len < 0 || len >= max_bytes)
+    if (len < 0 || len >= max_bytes) {
       bytes = max_bytes;
-    else
+    } else {
       bytes = len;
+    }
     ::memcpy(p, b->start() + offset, bytes);
     p += bytes;
     len -= bytes;

--- a/iocore/eventsystem/PQ-List.cc
+++ b/iocore/eventsystem/PQ-List.cc
@@ -53,8 +53,9 @@ PriorityEventQueue::check_ready(ink_hrtime now, EThread *t)
         EVENT_FREE(e, eventAllocator, t);
       } else {
         ink_hrtime tt = e->timeout_at - now;
-        for (j = i; j > 0 && tt <= PQ_BUCKET_TIME(j - 1);)
+        for (j = i; j > 0 && tt <= PQ_BUCKET_TIME(j - 1);) {
           j--;
+        }
         e->in_heap = j;
         after[j].enqueue(e);
       }

--- a/iocore/eventsystem/ProtectedQueue.cc
+++ b/iocore/eventsystem/ProtectedQueue.cc
@@ -59,8 +59,9 @@ ProtectedQueue::enqueue(Event *e, bool fast_signal)
       if (!inserting_thread || !inserting_thread->ethreads_to_be_signalled) {
         signal();
         if (fast_signal) {
-          if (e_ethread->signal_hook)
+          if (e_ethread->signal_hook) {
             e_ethread->signal_hook(e_ethread);
+          }
         }
       } else {
 #ifdef EAGER_SIGNALLING
@@ -69,8 +70,9 @@ ProtectedQueue::enqueue(Event *e, bool fast_signal)
           return;
 #endif
         if (fast_signal) {
-          if (e_ethread->signal_hook)
+          if (e_ethread->signal_hook) {
             e_ethread->signal_hook(e_ethread);
+          }
         }
         int &t          = inserting_thread->n_ethreads_to_be_signalled;
         EThread **sig_e = inserting_thread->ethreads_to_be_signalled;
@@ -83,22 +85,25 @@ ProtectedQueue::enqueue(Event *e, bool fast_signal)
               EThread *cur = sig_e[i]; // put this ethread
               while (cur) {
                 EThread *next = sig_e[cur->id]; // into this location
-                if (next == cur)
+                if (next == cur) {
                   break;
+                }
                 sig_e[cur->id] = cur;
                 cur            = next;
               }
               // if not overwritten
-              if (sig_e[i] && sig_e[i]->id != i)
+              if (sig_e[i] && sig_e[i]->id != i) {
                 sig_e[i] = 0;
+              }
             }
             t++;
           }
           // we have a direct map, insert this EThread
           sig_e[e_ethread->id] = e_ethread;
-        } else
+        } else {
           // insert into vector
           sig_e[t++] = e_ethread;
+        }
       }
     }
   }
@@ -109,8 +114,9 @@ flush_signals(EThread *thr)
 {
   ink_assert(this_ethread() == thr);
   int n = thr->n_ethreads_to_be_signalled;
-  if (n > eventProcessor.n_ethreads)
+  if (n > eventProcessor.n_ethreads) {
     n = eventProcessor.n_ethreads; // MAX
+  }
   int i;
 
 // Since the lock is only there to prevent a race in ink_cond_timedwait
@@ -128,8 +134,9 @@ flush_signals(EThread *thr)
   for (i = 0; i < n; i++) {
     if (thr->ethreads_to_be_signalled[i]) {
       thr->ethreads_to_be_signalled[i]->EventQueueExternal.signal();
-      if (thr->ethreads_to_be_signalled[i]->signal_hook)
+      if (thr->ethreads_to_be_signalled[i]->signal_hook) {
         thr->ethreads_to_be_signalled[i]->signal_hook(thr->ethreads_to_be_signalled[i]);
+      }
       thr->ethreads_to_be_signalled[i] = 0;
     }
   }
@@ -154,13 +161,14 @@ ProtectedQueue::dequeue_timed(ink_hrtime cur_time, ink_hrtime timeout, bool slee
   // invert the list, to preserve order
   SLL<Event, Event::Link_link> l, t;
   t.head = e;
-  while ((e = t.pop()))
+  while ((e = t.pop())) {
     l.push(e);
+  }
   // insert into localQueue
   while ((e = l.pop())) {
-    if (!e->cancelled)
+    if (!e->cancelled) {
       localQueue.enqueue(e);
-    else {
+    } else {
       e->mutex = NULL;
       eventAllocator.free(e);
     }

--- a/iocore/eventsystem/SocketManager.cc
+++ b/iocore/eventsystem/SocketManager.cc
@@ -51,15 +51,17 @@ SocketManager::close(int s)
 {
   int res;
 
-  if (s == 0)
+  if (s == 0) {
     return -EACCES;
-  else if (s < 0)
+  } else if (s < 0) {
     return -EINVAL;
+  }
 
   do {
     res = ::close(s);
-    if (res == -1)
+    if (res == -1) {
       res = -errno;
+    }
   } while (res == -EINTR);
   return res;
 }

--- a/iocore/eventsystem/Thread.cc
+++ b/iocore/eventsystem/Thread.cc
@@ -78,10 +78,11 @@ spawn_thread_internal(void *a)
 
   p->me->set_specific();
   ink_set_thread_name(p->name);
-  if (p->f)
+  if (p->f) {
     p->f(p->a);
-  else
+  } else {
     p->me->execute();
+  }
   ats_free(a);
   return NULL;
 }

--- a/iocore/eventsystem/UnixEThread.cc
+++ b/iocore/eventsystem/UnixEThread.cc
@@ -112,8 +112,9 @@ EThread::EThread(ThreadType att, Event *e)
 // threads won't have to deal with EThread memory deallocation.
 EThread::~EThread()
 {
-  if (n_ethreads_to_be_signalled > 0)
+  if (n_ethreads_to_be_signalled > 0) {
     flush_signals(this);
+  }
   ats_free(ethreads_to_be_signalled);
   // TODO: This can't be deleted ....
   // delete[]l1_hash;
@@ -151,18 +152,20 @@ EThread::process_event(Event *e, int calling_code)
     MUTEX_RELEASE(lock);
     if (e->period) {
       if (!e->in_the_prot_queue && !e->in_the_priority_queue) {
-        if (e->period < 0)
+        if (e->period < 0) {
           e->timeout_at = e->period;
-        else {
+        } else {
           this->get_hrtime_updated();
           e->timeout_at = cur_time + e->period;
-          if (e->timeout_at < cur_time)
+          if (e->timeout_at < cur_time) {
             e->timeout_at = cur_time;
+          }
         }
         EventQueueExternal.enqueue_local(e);
       }
-    } else if (!e->in_the_prot_queue && !e->in_the_priority_queue)
+    } else if (!e->in_the_prot_queue && !e->in_the_priority_queue) {
       free_event(e);
+    }
   }
 }
 
@@ -195,24 +198,25 @@ EThread::execute()
       // already been dequeued
       cur_time = Thread::get_hrtime_updated();
       while ((e = EventQueueExternal.dequeue_local())) {
-        if (e->cancelled)
+        if (e->cancelled) {
           free_event(e);
-        else if (!e->timeout_at) { // IMMEDIATE
+        } else if (!e->timeout_at) { // IMMEDIATE
           ink_assert(e->period == 0);
           process_event(e, e->callback_event);
-        } else if (e->timeout_at > 0) // INTERVAL
+        } else if (e->timeout_at > 0) { // INTERVAL
           EventQueue.enqueue(e, cur_time);
-        else { // NEGATIVE
+        } else { // NEGATIVE
           Event *p = NULL;
           Event *a = NegativeQueue.head;
           while (a && a->timeout_at > e->timeout_at) {
             p = a;
             a = a->link.next;
           }
-          if (!a)
+          if (!a) {
             NegativeQueue.enqueue(e);
-          else
+          } else {
             NegativeQueue.insert(e, p);
+          }
         }
       }
       bool done_one;
@@ -223,9 +227,9 @@ EThread::execute()
         while ((e = EventQueue.dequeue_ready(cur_time))) {
           ink_assert(e);
           ink_assert(e->timeout_at > 0);
-          if (e->cancelled)
+          if (e->cancelled) {
             free_event(e);
-          else {
+          } else {
             done_one = true;
             process_event(e, e->callback_event);
           }
@@ -233,20 +237,22 @@ EThread::execute()
       } while (done_one);
       // execute any negative (poll) events
       if (NegativeQueue.head) {
-        if (n_ethreads_to_be_signalled)
+        if (n_ethreads_to_be_signalled) {
           flush_signals(this);
+        }
         // dequeue all the external events and put them in a local
         // queue. If there are no external events available, don't
         // do a cond_timedwait.
-        if (!INK_ATOMICLIST_EMPTY(EventQueueExternal.al))
+        if (!INK_ATOMICLIST_EMPTY(EventQueueExternal.al)) {
           EventQueueExternal.dequeue_timed(cur_time, next_time, false);
+        }
         while ((e = EventQueueExternal.dequeue_local())) {
-          if (!e->timeout_at)
+          if (!e->timeout_at) {
             process_event(e, e->callback_event);
-          else {
-            if (e->cancelled)
+          } else {
+            if (e->cancelled) {
               free_event(e);
-            else {
+            } else {
               // If its a negative event, it must be a result of
               // a negative event, which has been turned into a
               // timed-event (because of a missed lock), executed
@@ -261,20 +267,24 @@ EThread::execute()
                   p = a;
                   a = a->link.next;
                 }
-                if (!a)
+                if (!a) {
                   NegativeQueue.enqueue(e);
-                else
+                } else {
                   NegativeQueue.insert(e, p);
-              } else
+                }
+              } else {
                 EventQueue.enqueue(e, cur_time);
+              }
             }
           }
         }
         // execute poll events
-        while ((e = NegativeQueue.dequeue()))
+        while ((e = NegativeQueue.dequeue())) {
           process_event(e, EVENT_POLL);
-        if (!INK_ATOMICLIST_EMPTY(EventQueueExternal.al))
+        }
+        if (!INK_ATOMICLIST_EMPTY(EventQueueExternal.al)) {
           EventQueueExternal.dequeue_timed(cur_time, next_time, false);
+        }
       } else { // Means there are no negative events
         next_time             = EventQueue.earliest_timeout();
         ink_hrtime sleep_time = next_time - cur_time;
@@ -285,8 +295,9 @@ EThread::execute()
         // dequeue all the external events and put them in a local
         // queue. If there are no external events available, do a
         // cond_timedwait.
-        if (n_ethreads_to_be_signalled)
+        if (n_ethreads_to_be_signalled) {
           flush_signals(this);
+        }
         EventQueueExternal.dequeue_timed(cur_time, next_time, true);
       }
     }

--- a/iocore/eventsystem/UnixEvent.cc
+++ b/iocore/eventsystem/UnixEvent.cc
@@ -36,14 +36,16 @@ Event::schedule_imm(int acallback_event)
 {
   callback_event = acallback_event;
   ink_assert(ethread == this_ethread());
-  if (in_the_priority_queue)
+  if (in_the_priority_queue) {
     ethread->EventQueue.remove(this);
+  }
   timeout_at = 0;
   period     = 0;
   immediate  = true;
   mutex      = continuation->mutex;
-  if (!in_the_prot_queue)
+  if (!in_the_prot_queue) {
     ethread->EventQueueExternal.enqueue_local(this);
+  }
 }
 
 void
@@ -52,14 +54,16 @@ Event::schedule_at(ink_hrtime atimeout_at, int acallback_event)
   callback_event = acallback_event;
   ink_assert(ethread == this_ethread());
   ink_assert(atimeout_at > 0);
-  if (in_the_priority_queue)
+  if (in_the_priority_queue) {
     ethread->EventQueue.remove(this);
+  }
   timeout_at = atimeout_at;
   period     = 0;
   immediate  = false;
   mutex      = continuation->mutex;
-  if (!in_the_prot_queue)
+  if (!in_the_prot_queue) {
     ethread->EventQueueExternal.enqueue_local(this);
+  }
 }
 
 void
@@ -67,14 +71,16 @@ Event::schedule_in(ink_hrtime atimeout_in, int acallback_event)
 {
   callback_event = acallback_event;
   ink_assert(ethread == this_ethread());
-  if (in_the_priority_queue)
+  if (in_the_priority_queue) {
     ethread->EventQueue.remove(this);
+  }
   timeout_at = Thread::get_hrtime() + atimeout_in;
   period     = 0;
   immediate  = false;
   mutex      = continuation->mutex;
-  if (!in_the_prot_queue)
+  if (!in_the_prot_queue) {
     ethread->EventQueueExternal.enqueue_local(this);
+  }
 }
 
 void
@@ -83,8 +89,9 @@ Event::schedule_every(ink_hrtime aperiod, int acallback_event)
   callback_event = acallback_event;
   ink_assert(ethread == this_ethread());
   ink_assert(aperiod != 0);
-  if (in_the_priority_queue)
+  if (in_the_priority_queue) {
     ethread->EventQueue.remove(this);
+  }
   if (aperiod < 0) {
     timeout_at = aperiod;
   } else {
@@ -93,6 +100,7 @@ Event::schedule_every(ink_hrtime aperiod, int acallback_event)
   period    = aperiod;
   immediate = false;
   mutex     = continuation->mutex;
-  if (!in_the_prot_queue)
+  if (!in_the_prot_queue) {
     ethread->EventQueueExternal.enqueue_local(this);
+  }
 }

--- a/iocore/net/Connection.cc
+++ b/iocore/net/Connection.cc
@@ -78,8 +78,9 @@ Server::accept(Connection *c)
   socklen_t sz = sizeof(c->addr);
 
   res = socketManager.accept(fd, &c->addr.sa, &sz);
-  if (res < 0)
+  if (res < 0) {
     return res;
+  }
   c->fd = res;
   if (is_debug_tag_set("iocore_net_server")) {
     ip_port_text_buffer ipb1, ipb2;
@@ -91,8 +92,9 @@ Server::accept(Connection *c)
   if ((res = safe_fcntl(fd, F_SETFD, FD_CLOEXEC)) < 0)
     goto Lerror;
 #endif
-  if ((res = safe_nonblocking(c->fd)) < 0)
+  if ((res = safe_nonblocking(c->fd)) < 0) {
     goto Lerror;
+  }
 #ifdef SEND_BUF_SIZE
   socketManager.set_sndbuf_size(c->fd, SEND_BUF_SIZE);
 #endif

--- a/iocore/net/SSLCertLookup.cc
+++ b/iocore/net/SSLCertLookup.cc
@@ -322,8 +322,9 @@ SSLContextStorage::insert(const char *name, SSLCertContext const &cc)
 {
   int idx = this->store(cc);
   idx     = this->insert(name, idx);
-  if (idx < 0)
+  if (idx < 0) {
     this->ctx_store.drop();
+  }
   return idx;
 }
 

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -162,8 +162,9 @@ SSLConfigParams::initialize()
   int options;
   int client_ssl_options;
   REC_ReadConfigInteger(options, "proxy.config.ssl.TLSv1");
-  if (!options)
+  if (!options) {
     ssl_ctx_options |= SSL_OP_NO_TLSv1;
+  }
 
 #if TS_USE_SSLV3_CLIENT
   REC_ReadConfigInteger(client_ssl_options, "proxy.config.ssl.client.SSLv3");
@@ -171,33 +172,39 @@ SSLConfigParams::initialize()
     ssl_client_ctx_protocols &= ~SSL_OP_NO_SSLv3;
 #endif
   REC_ReadConfigInteger(client_ssl_options, "proxy.config.ssl.client.TLSv1");
-  if (!client_ssl_options)
+  if (!client_ssl_options) {
     ssl_client_ctx_protocols |= SSL_OP_NO_TLSv1;
+  }
 
 // These are not available in all versions of OpenSSL (e.g. CentOS6). Also see http://s.apache.org/TS-2355.
 #ifdef SSL_OP_NO_TLSv1_1
   REC_ReadConfigInteger(options, "proxy.config.ssl.TLSv1_1");
-  if (!options)
+  if (!options) {
     ssl_ctx_options |= SSL_OP_NO_TLSv1_1;
+  }
 
   REC_ReadConfigInteger(client_ssl_options, "proxy.config.ssl.client.TLSv1_1");
-  if (!client_ssl_options)
+  if (!client_ssl_options) {
     ssl_client_ctx_protocols |= SSL_OP_NO_TLSv1_1;
+  }
 #endif
 #ifdef SSL_OP_NO_TLSv1_2
   REC_ReadConfigInteger(options, "proxy.config.ssl.TLSv1_2");
-  if (!options)
+  if (!options) {
     ssl_ctx_options |= SSL_OP_NO_TLSv1_2;
+  }
 
   REC_ReadConfigInteger(client_ssl_options, "proxy.config.ssl.client.TLSv1_2");
-  if (!client_ssl_options)
+  if (!client_ssl_options) {
     ssl_client_ctx_protocols |= SSL_OP_NO_TLSv1_2;
+  }
 #endif
 
 #ifdef SSL_OP_CIPHER_SERVER_PREFERENCE
   REC_ReadConfigInteger(options, "proxy.config.ssl.server.honor_cipher_order");
-  if (options)
+  if (options) {
     ssl_ctx_options |= SSL_OP_CIPHER_SERVER_PREFERENCE;
+  }
 #endif
 
   REC_ReadConfigInteger(options, "proxy.config.ssl.compression");

--- a/iocore/net/SSLNetAccept.cc
+++ b/iocore/net/SSLNetAccept.cc
@@ -45,19 +45,22 @@ SSLNetAccept::init_accept_per_thread(bool isTransparent)
   int i, n;
   NetAccept *a;
 
-  if (do_listen(NON_BLOCKING, isTransparent))
+  if (do_listen(NON_BLOCKING, isTransparent)) {
     return;
-  if (accept_fn == net_accept)
+  }
+  if (accept_fn == net_accept) {
     SET_HANDLER((SSLNetAcceptHandler)&SSLNetAccept::acceptFastEvent);
-  else
+  } else {
     SET_HANDLER((SSLNetAcceptHandler)&SSLNetAccept::acceptEvent);
+  }
   period = -HRTIME_MSECONDS(net_accept_period);
   n      = eventProcessor.n_threads_for_type[SSLNetProcessor::ET_SSL];
   for (i = 0; i < n; i++) {
-    if (i < n - 1)
+    if (i < n - 1) {
       a = clone();
-    else
-      a        = this;
+    } else {
+      a = this;
+    }
     EThread *t = eventProcessor.eventthread[SSLNetProcessor::ET_SSL][i];
 
     PollDescriptor *pd = get_PollDescriptor(t);

--- a/iocore/net/SSLNetProcessor.cc
+++ b/iocore/net/SSLNetProcessor.cc
@@ -63,8 +63,9 @@ SSLNetProcessor::start(int number_of_ssl_threads, size_t stacksize)
   SSLInitializeLibrary();
   SSLConfig::startup();
 
-  if (!SSLCertificateConfig::startup())
+  if (!SSLCertificateConfig::startup()) {
     return -1;
+  }
 
   // Acquire a SSLConfigParams instance *after* we start SSL up.
   SSLConfig::scoped_config params;

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -338,13 +338,15 @@ SSLNetVConnection::read_raw_data()
         if (a > 0) {
           tiovec[niov].iov_base = b->_end;
           int64_t togo          = toread - total_read - rattempted;
-          if (a > togo)
-            a                  = togo;
+          if (a > togo) {
+            a = togo;
+          }
           tiovec[niov].iov_len = a;
           rattempted += a;
           niov++;
-          if (a >= togo)
+          if (a >= togo) {
             break;
+          }
         }
         b = b->next.get();
       }
@@ -359,10 +361,11 @@ SSLNetVConnection::read_raw_data()
 
     // if we have already moved some bytes successfully, summarize in r
     if (total_read != rattempted) {
-      if (r <= 0)
+      if (r <= 0) {
         r = total_read - rattempted;
-      else
+      } else {
         r = total_read - rattempted + r;
+      }
     }
     // check for errors
     if (r <= 0) {
@@ -516,8 +519,9 @@ SSLNetVConnection::net_read_io(NetHandler *nh, EThread *lthread)
         readSignalDone(VC_EVENT_READ_COMPLETE, nh);
       } else {
         read.triggered = 1;
-        if (read.enabled)
+        if (read.enabled) {
           nh->read_ready_list.in_or_enqueue(this);
+        }
       }
     } else if (ret == SSL_WAIT_FOR_HOOK) {
       // avoid readReschedule - done when the plugin calls us back to reenable
@@ -593,10 +597,11 @@ SSLNetVConnection::net_read_io(NetHandler *nh, EThread *lthread)
   case SSL_READ_WOULD_BLOCK:
     if (lock.get_mutex() != s->vio.mutex.get()) {
       Debug("ssl", "ssl_read_from_net, mutex switched");
-      if (ret == SSL_READ_WOULD_BLOCK)
+      if (ret == SSL_READ_WOULD_BLOCK) {
         readReschedule(nh);
-      else
+      } else {
         writeReschedule(nh);
+      }
       return;
     }
     // reset the trigger and remove from the ready queue
@@ -605,10 +610,11 @@ SSLNetVConnection::net_read_io(NetHandler *nh, EThread *lthread)
     nh->read_ready_list.remove(this);
     Debug("ssl", "read_from_net, read finished - would block");
 #ifdef TS_USE_PORT
-    if (ret == SSL_READ_WOULD_BLOCK)
+    if (ret == SSL_READ_WOULD_BLOCK) {
       readReschedule(nh);
-    else
+    } else {
       writeReschedule(nh);
+    }
 #endif
     break;
 
@@ -1236,8 +1242,9 @@ SSLNetVConnection::sslClientHandShakeEvent(int &err)
 
       Debug("ssl", "SSL client handshake completed successfully");
       // if the handshake is complete and write is enabled reschedule the write
-      if (closed == 0 && write.enabled)
+      if (closed == 0 && write.enabled) {
         writeReschedule(nh);
+      }
       if (cert) {
         debug_certificate_name("server certificate subject CN is", X509_get_subject_name(cert));
         debug_certificate_name("server certificate issuer CN is", X509_get_issuer_name(cert));
@@ -1397,10 +1404,11 @@ SSLNetVConnection::sslContextSet(void *ctx)
 {
 #if TS_USE_TLS_SNI
   bool zret = true;
-  if (ssl)
+  if (ssl) {
     SSL_set_SSL_CTX(ssl, static_cast<SSL_CTX *>(ctx));
-  else
+  } else {
     zret = false;
+  }
 #else
   bool zret      = false;
 #endif
@@ -1497,8 +1505,9 @@ int
 SSLNetVConnection::populate(Connection &con, Continuation *c, void *arg)
 {
   int retval = super::populate(con, c, arg);
-  if (retval != EVENT_DONE)
+  if (retval != EVENT_DONE) {
     return retval;
+  }
   // Add in the SSL data
   this->ssl = (SSL *)arg;
   // Maybe bring over the stats?

--- a/iocore/net/SSLSessionCache.cc
+++ b/iocore/net/SSLSessionCache.cc
@@ -128,8 +128,9 @@ SSLSessionBucket::insertSession(const SSLSessionID &id, SSL_SESSION *sess)
   MUTEX_TRY_LOCK(lock, mutex, this_ethread());
   if (!lock.is_locked()) {
     SSL_INCREMENT_DYN_STAT(ssl_session_cache_lock_contention);
-    if (SSLConfigParams::session_cache_skip_on_lock_contention)
+    if (SSLConfigParams::session_cache_skip_on_lock_contention) {
       return;
+    }
 
     lock.acquire(this_ethread());
   }
@@ -159,8 +160,9 @@ SSLSessionBucket::getSession(const SSLSessionID &id, SSL_SESSION **sess)
   MUTEX_TRY_LOCK(lock, mutex, this_ethread());
   if (!lock.is_locked()) {
     SSL_INCREMENT_DYN_STAT(ssl_session_cache_lock_contention);
-    if (SSLConfigParams::session_cache_skip_on_lock_contention)
+    if (SSLConfigParams::session_cache_skip_on_lock_contention) {
       return false;
+    }
 
     lock.acquire(this_ethread());
   }

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -312,8 +312,9 @@ set_context_cert(SSL *ssl)
   // already made a best effort to find the best match.
   if (likely(servername)) {
     cc = lookup->find((char *)servername);
-    if (cc && cc->ctx)
+    if (cc && cc->ctx) {
       ctx = cc->ctx;
+    }
     if (cc && SSLCertContext::OPT_TUNNEL == cc->opt && netvc->get_is_transparent()) {
       netvc->attributes = HttpProxyPort::TRANSPORT_BLIND_TUNNEL;
       netvc->setSSLHandShakeComplete(true);
@@ -329,8 +330,9 @@ set_context_cert(SSL *ssl)
 
     safe_getsockname(netvc->get_socket(), &ip.sa, &namelen);
     cc = lookup->find(ip);
-    if (cc && cc->ctx)
+    if (cc && cc->ctx) {
       ctx = cc->ctx;
+    }
   }
 
   if (ctx != NULL) {
@@ -760,8 +762,9 @@ ssl_private_key_validate_exec(const char *cmdLine)
   char *cmdLineCopy = ats_strdup(cmdLine);
   char *ptr         = cmdLineCopy;
 
-  while (*ptr && !isspace(*ptr))
+  while (*ptr && !isspace(*ptr)) {
     ++ptr;
+  }
   *ptr = 0;
   if (access(cmdLineCopy, X_OK) != -1) {
     bReturn = true;
@@ -1408,8 +1411,9 @@ ssl_index_certificate(SSLCertLookup *lookup, SSLCertContext const &cc, X509 *cer
       subj_name          = asn1_strdup(cn);
 
       Debug("ssl", "mapping '%s' to certificate %s", (const char *)subj_name, certname);
-      if (lookup->insert(subj_name, cc) >= 0)
+      if (lookup->insert(subj_name, cc) >= 0) {
         inserted = true;
+      }
     }
   }
 
@@ -1427,8 +1431,9 @@ ssl_index_certificate(SSLCertLookup *lookup, SSLCertContext const &cc, X509 *cer
         // only try to insert if the alternate name is not the main name
         if (strcmp(dns, subj_name) != 0) {
           Debug("ssl", "mapping '%s' to certificates %s", (const char *)dns, certname);
-          if (lookup->insert(dns, cc) >= 0)
+          if (lookup->insert(dns, cc) >= 0) {
             inserted = true;
+          }
         }
       }
     }
@@ -1647,8 +1652,9 @@ SSLInitServerContext(const SSLConfigParams *params, const ssl_user_config &sslMu
         scoped_BIO bio(BIO_new_file(completeServerCertChainPath, "r"));
         X509 *intermediate_cert = PEM_read_bio_X509(bio.get(), NULL, 0, NULL);
         if (!intermediate_cert || !SSL_CTX_add0_chain_cert(ctx, intermediate_cert)) {
-          if (intermediate_cert)
+          if (intermediate_cert) {
             X509_free(intermediate_cert);
+          }
 #else
         if (!SSL_CTX_add_extra_chain_cert_file(ctx, completeServerCertChainPath)) {
 #endif
@@ -1668,8 +1674,9 @@ SSLInitServerContext(const SSLConfigParams *params, const ssl_user_config &sslMu
         scoped_BIO bio(BIO_new_file(completeServerCertChainPath, "r"));
         X509 *intermediate_cert = PEM_read_bio_X509(bio.get(), NULL, 0, NULL);
         if (!intermediate_cert || !SSL_CTX_add0_chain_cert(ctx, intermediate_cert)) {
-          if (intermediate_cert)
+          if (intermediate_cert) {
             X509_free(intermediate_cert);
+          }
 #else
         if (!SSL_CTX_add_extra_chain_cert_file(ctx, completeServerCertChainPath)) {
 #endif
@@ -2148,8 +2155,9 @@ ssl_callback_session_ticket(SSL *ssl, unsigned char *keyname, unsigned char *iv,
         // Increase the total number of decrypted tickets.
         SSL_INCREMENT_DYN_STAT(ssl_total_tickets_verified_stat);
 
-        if (i != 0) // The number of tickets decrypted with "older" keys.
+        if (i != 0) { // The number of tickets decrypted with "older" keys.
           SSL_INCREMENT_DYN_STAT(ssl_total_tickets_verified_old_key_stat);
+        }
 
         SSLNetVConnection *netvc = (SSLNetVConnection *)SSL_get_app_data(ssl);
         netvc->setSSLSessionCacheHit(true);

--- a/iocore/net/Socks.cc
+++ b/iocore/net/Socks.cc
@@ -49,10 +49,11 @@ SocksEntry::init(Ptr<ProxyMutex> &m, SocksNetVC *vc, unsigned char socks_support
 
   socks_cmd = socks_support;
 
-  if (ver == SOCKS_DEFAULT_VERSION)
+  if (ver == SOCKS_DEFAULT_VERSION) {
     version = netProcessor.socks_conf_stuff->default_version;
-  else
+  } else {
     version = ver;
+  }
 
   SET_HANDLER(&SocksEntry::startEvent);
 
@@ -91,15 +92,17 @@ SocksEntry::findServer()
     server_params->findParent(&req_data, &server_result);
   } else {
     socks_conf_struct *conf = netProcessor.socks_conf_stuff;
-    if ((nattempts - 1) % conf->per_server_connection_attempts)
+    if ((nattempts - 1) % conf->per_server_connection_attempts) {
       return; // attempt again
+    }
 
     server_params->markParentDown(&server_result);
 
-    if (nattempts > conf->connection_attempts)
+    if (nattempts > conf->connection_attempts) {
       server_result.result = PARENT_FAIL;
-    else
+    } else {
       server_params->nextParent(&req_data, &server_result);
+    }
   }
 
   switch (server_result.result) {
@@ -143,16 +146,19 @@ SocksEntry::free()
     return;
   }
 
-  if (timeout)
+  if (timeout) {
     timeout->cancel(this);
+  }
 
 #ifdef SOCKS_WITH_TS
-  if (!lerrno && netVConnection && server_result.retry)
+  if (!lerrno && netVConnection && server_result.retry) {
     server_params->markParentUp(&server_result);
+  }
 #endif
 
-  if ((action_.cancelled || lerrno) && netVConnection)
+  if ((action_.cancelled || lerrno) && netVConnection) {
     netVConnection->do_io_close();
+  }
 
   if (!action_.cancelled) {
     if (lerrno || !netVConnection) {
@@ -185,8 +191,9 @@ SocksEntry::startEvent(int event, void *data)
   if (event == NET_EVENT_OPEN) {
     netVConnection = (SocksNetVC *)data;
 
-    if (version == SOCKS5_VERSION)
+    if (version == SOCKS5_VERSION) {
       auth_handler = &socks5BasicAuthHandler;
+    }
 
     SET_HANDLER((SocksEntryHandler)&SocksEntry::mainEvent);
     mainEvent(NET_EVENT_OPEN, data);
@@ -311,11 +318,11 @@ SocksEntry::mainEvent(int event, void *data)
 
     buf->reset(); // Use the same buffer for a read now
 
-    if (auth_handler)
+    if (auth_handler) {
       n_bytes = invokeSocksAuthHandler(auth_handler, SOCKS_AUTH_WRITE_COMPLETE, NULL);
-    else if (socks_cmd == NORMAL_SOCKS)
+    } else if (socks_cmd == NORMAL_SOCKS) {
       n_bytes = (version == SOCKS5_VERSION) ? SOCKS5_REP_LEN : SOCKS4_REP_LEN;
-    else {
+    } else {
       Debug("Socks", "Tunnelling the connection");
       // let the client handle the response
       free();
@@ -362,8 +369,9 @@ SocksEntry::mainEvent(int event, void *data)
       }
     }
 
-    if (ret == EVENT_CONT)
+    if (ret == EVENT_CONT) {
       break;
+    }
   // Fall Through
   case VC_EVENT_READ_COMPLETE:
     if (timeout) {
@@ -390,8 +398,9 @@ SocksEntry::mainEvent(int event, void *data)
       if (version == SOCKS5_VERSION) {
         success = (p[0] == SOCKS5_VERSION && p[1] == SOCKS5_REQ_GRANTED);
         Debug("Socks", "received reply of length %" PRId64 " addr type %d", ((VIO *)data)->ndone, (int)p[3]);
-      } else
+      } else {
         success = (p[0] == 0 && p[1] == SOCKS4_REQ_GRANTED);
+      }
 
       // ink_assert(*(p) == 0);
       if (!success) { // SOCKS request failed
@@ -525,8 +534,9 @@ error:
 
   socks_conf_stuff->socks_needed   = 0;
   socks_conf_stuff->accept_enabled = 0;
-  if (socks_config_fd >= 0)
+  if (socks_config_fd >= 0) {
     ::close(socks_config_fd);
+  }
 }
 
 int
@@ -545,11 +555,13 @@ loadSocksAuthInfo(int fd, socks_conf_struct *socks_stuff)
   bool end_of_file = false;
   do {
     int n = 0, rc;
-    while (((rc = read(fd, &c, 1)) == 1) && (c != '\n') && (n < 254))
+    while (((rc = read(fd, &c, 1)) == 1) && (c != '\n') && (n < 254)) {
       line[n++] = c;
-    if (rc <= 0)
+    }
+    if (rc <= 0) {
       end_of_file = true;
-    line[n]       = '\0';
+    }
+    line[n] = '\0';
 
     // coverity[secure_coding]
     rc = sscanf(line, " auth u %255s %255s ", user_name, passwd);
@@ -588,8 +600,9 @@ socks5BasicAuthHandler(int event, unsigned char *p, void (**h_ptr)(void))
     p[ret++] = SOCKS5_VERSION;        // version
     p[ret++] = (pass_phrase) ? 2 : 1; //#Methods
     p[ret++] = 0;                     // no authentication
-    if (pass_phrase)
+    if (pass_phrase) {
       p[ret++] = 2;
+    }
 
     break;
 
@@ -615,8 +628,9 @@ socks5BasicAuthHandler(int event, unsigned char *p, void (**h_ptr)(void))
                          "when not supplied as an option");
           ret    = -1;
           *h_ptr = NULL;
-        } else
+        } else {
           *(SocksAuthHandler *)h_ptr = &socks5PasswdAuthHandler;
+        }
 
         break;
 

--- a/iocore/net/UnixNet.cc
+++ b/iocore/net/UnixNet.cc
@@ -381,8 +381,9 @@ NetHandler::process_enabled_list(NetHandler *nh)
     vc->ep.modify(EVENTIO_READ);
     vc->ep.refresh(EVENTIO_READ);
     vc->read.in_enabled_list = 0;
-    if ((vc->read.enabled && vc->read.triggered) || vc->closed)
+    if ((vc->read.enabled && vc->read.triggered) || vc->closed) {
       nh->read_ready_list.in_or_enqueue(vc);
+    }
   }
 
   SListM(UnixNetVConnection, NetState, write, enable_link) wq(nh->write_enable_list.popall());
@@ -390,8 +391,9 @@ NetHandler::process_enabled_list(NetHandler *nh)
     vc->ep.modify(EVENTIO_WRITE);
     vc->ep.refresh(EVENTIO_WRITE);
     vc->write.in_enabled_list = 0;
-    if ((vc->write.enabled && vc->write.triggered) || vc->closed)
+    if ((vc->write.enabled && vc->write.triggered) || vc->closed) {
       nh->write_ready_list.in_or_enqueue(vc);
+    }
   }
 }
 
@@ -412,10 +414,11 @@ NetHandler::mainNetEvent(int event, Event *e)
   NET_INCREMENT_DYN_STAT(net_handler_run_stat);
 
   process_enabled_list(this);
-  if (likely(!read_ready_list.empty() || !write_ready_list.empty() || !read_enable_list.empty() || !write_enable_list.empty()))
+  if (likely(!read_ready_list.empty() || !write_ready_list.empty() || !read_enable_list.empty() || !write_enable_list.empty())) {
     poll_timeout = 0; // poll immediately returns -- we have triggered stuff to process right now
-  else
+  } else {
     poll_timeout = net_config_poll_timeout;
+  }
 
   PollDescriptor *pd     = get_PollDescriptor(trigger_event->ethread);
   UnixNetVConnection *vc = NULL;
@@ -508,11 +511,11 @@ NetHandler::mainNetEvent(int event, Event *e)
   while ((vc = read_ready_list.dequeue())) {
     // Initialize the thread-local continuation flags
     set_cont_flags(vc->control_flags);
-    if (vc->closed)
+    if (vc->closed) {
       close_UnixNetVConnection(vc, trigger_event->ethread);
-    else if (vc->read.enabled && vc->read.triggered)
+    } else if (vc->read.enabled && vc->read.triggered) {
       vc->net_read_io(this, trigger_event->ethread);
-    else if (!vc->read.enabled) {
+    } else if (!vc->read.enabled) {
       read_ready_list.remove(vc);
 #if defined(solaris)
       if (vc->read.triggered && vc->write.enabled) {
@@ -525,11 +528,11 @@ NetHandler::mainNetEvent(int event, Event *e)
   }
   while ((vc = write_ready_list.dequeue())) {
     set_cont_flags(vc->control_flags);
-    if (vc->closed)
+    if (vc->closed) {
       close_UnixNetVConnection(vc, trigger_event->ethread);
-    else if (vc->write.enabled && vc->write.triggered)
+    } else if (vc->write.enabled && vc->write.triggered) {
       write_to_net(this, vc, trigger_event->ethread);
-    else if (!vc->write.enabled) {
+    } else if (!vc->write.enabled) {
       write_ready_list.remove(vc);
 #if defined(solaris)
       if (vc->write.triggered && vc->read.enabled) {

--- a/iocore/net/UnixNetPages.cc
+++ b/iocore/net/UnixNetPages.cc
@@ -64,8 +64,9 @@ struct ShowNet : public ShowCont {
     forl_LL(UnixNetVConnection, vc, nh->open_list)
     {
       //      uint16_t port = ats_ip_port_host_order(&addr.sa);
-      if (ats_is_ip(&addr) && addr != vc->server_addr)
+      if (ats_is_ip(&addr) && addr != vc->server_addr) {
         continue;
+      }
       //      if (port && port != ats_ip_port_host_order(&vc->server_addr.sa) && port != vc->accept_port)
       //        continue;
       char ipbuf[INET6_ADDRSTRLEN];
@@ -103,9 +104,9 @@ struct ShowNet : public ShowCont {
                       vc->f.shutdown, vc->closed ? "closed " : ""));
     }
     ithread++;
-    if (ithread < eventProcessor.n_threads_for_type[ET_NET])
+    if (ithread < eventProcessor.n_threads_for_type[ET_NET]) {
       eventProcessor.eventthread[ET_NET][ithread]->schedule_imm(this);
-    else {
+    } else {
       CHECK_SHOW(show("</table>\n"));
       return complete(event, e);
     }
@@ -166,10 +167,11 @@ struct ShowNet : public ShowCont {
     CHECK_SHOW(show("<tr><th>#</th><th>Read Priority</th><th>Read Bucket</th><th>Write Priority</th><th>Write Bucket</th></tr>\n"));
     CHECK_SHOW(show("</table>\n"));
     ithread++;
-    if (ithread < eventProcessor.n_threads_for_type[ET_NET])
+    if (ithread < eventProcessor.n_threads_for_type[ET_NET]) {
       eventProcessor.eventthread[ET_NET][ithread]->schedule_imm(this);
-    else
+    } else {
       return complete(event, e);
+    }
     return EVENT_CONT;
   }
 
@@ -220,20 +222,24 @@ register_ShowNet(Continuation *c, HTTPHdr *h)
     const char *query = h->url_get()->query_get(&query_len);
     s->sarg           = ats_strndup(query, query_len);
     char *gn          = NULL;
-    if (s->sarg)
+    if (s->sarg) {
       gn = (char *)memchr(s->sarg, '=', strlen(s->sarg));
-    if (gn)
+    }
+    if (gn) {
       ats_ip_pton(gn + 1, &s->addr);
+    }
     SET_CONTINUATION_HANDLER(s, &ShowNet::showConnections);
   } else if (STREQ_PREFIX(path, path_len, "ports")) {
     int query_len;
     const char *query = h->url_get()->query_get(&query_len);
     s->sarg           = ats_strndup(query, query_len);
     char *gn          = NULL;
-    if (s->sarg)
+    if (s->sarg) {
       gn = (char *)memchr(s->sarg, '=', strlen(s->sarg));
-    if (gn)
+    }
+    if (gn) {
       ats_ip_port_cast(&s->addr.sa) = htons(atoi(gn + 1));
+    }
     SET_CONTINUATION_HANDLER(s, &ShowNet::showConnections);
   }
   eventProcessor.schedule_imm(s, ET_TASK);

--- a/iocore/net/UnixNetProcessor.cc
+++ b/iocore/net/UnixNetProcessor.cc
@@ -125,8 +125,9 @@ UnixNetProcessor::accept_internal(Continuation *cont, int fd, AcceptOptions cons
   int should_filter_int         = 0;
   na->server.http_accept_filter = false;
   REC_ReadConfigInteger(should_filter_int, "proxy.config.net.defer_accept");
-  if (should_filter_int > 0 && opt.etype == ET_NET)
+  if (should_filter_int > 0 && opt.etype == ET_NET) {
     na->server.http_accept_filter = true;
+  }
 
   na->action_          = new NetAcceptAction();
   *na->action_         = cont;
@@ -139,8 +140,9 @@ UnixNetProcessor::accept_internal(Continuation *cont, int fd, AcceptOptions cons
   na->packet_tos       = opt.packet_tos;
   na->etype            = upgraded_etype;
   na->backdoor         = opt.backdoor;
-  if (na->callback_on_open)
+  if (na->callback_on_open) {
     na->mutex = cont->mutex;
+  }
   if (opt.frequent_accept) { // true
     if (accept_threads > 0) {
       if (0 == na->do_listen(BLOCKING, opt.f_inbound_transparent)) {
@@ -201,10 +203,11 @@ UnixNetProcessor::connect_re_internal(Continuation *cont, sockaddr const *target
   EThread *t             = cont->mutex->thread_holding;
   UnixNetVConnection *vc = (UnixNetVConnection *)this->allocate_vc(t);
 
-  if (opt)
+  if (opt) {
     vc->options = *opt;
-  else
+  } else {
     opt = &vc->options;
+  }
 
   // virtual function used to upgrade etype to ET_SSL for SSLNetProcessor.
   upgradeEtype(opt->etype);
@@ -256,18 +259,20 @@ UnixNetProcessor::connect_re_internal(Continuation *cont, sockaddr const *target
       if (lock2.is_locked()) {
         int ret;
         ret = vc->connectUp(t, NO_FD);
-        if ((using_socks) && (ret == CONNECT_SUCCESS))
+        if ((using_socks) && (ret == CONNECT_SUCCESS)) {
           return &socksEntry->action_;
-        else
+        } else {
           return ACTION_RESULT_DONE;
+        }
       }
     }
   }
   t->schedule_imm(vc);
   if (using_socks) {
     return &socksEntry->action_;
-  } else
+  } else {
     return result;
+  }
 }
 
 Action *
@@ -302,8 +307,9 @@ struct CheckConnect : public Continuation {
 
     case NET_EVENT_OPEN_FAILED:
       Debug("iocore_net_connect", "connect Net open failed");
-      if (!action_.cancelled)
+      if (!action_.cancelled) {
         action_.continuation->handleEvent(NET_EVENT_OPEN_FAILED, (void *)e);
+      }
       break;
 
     case VC_EVENT_WRITE_READY:
@@ -329,22 +335,26 @@ struct CheckConnect : public Continuation {
         }
       }
       vc->do_io_close();
-      if (!action_.cancelled)
+      if (!action_.cancelled) {
         action_.continuation->handleEvent(NET_EVENT_OPEN_FAILED, (void *)-ENET_CONNECT_FAILED);
+      }
       break;
     case VC_EVENT_INACTIVITY_TIMEOUT:
       Debug("iocore_net_connect", "connect timed out");
       vc->do_io_close();
-      if (!action_.cancelled)
+      if (!action_.cancelled) {
         action_.continuation->handleEvent(NET_EVENT_OPEN_FAILED, (void *)-ENET_CONNECT_TIMEOUT);
+      }
       break;
     default:
       ink_assert(!"unknown connect event");
-      if (!action_.cancelled)
+      if (!action_.cancelled) {
         action_.continuation->handleEvent(NET_EVENT_OPEN_FAILED, (void *)-ENET_CONNECT_FAILED);
+      }
     }
-    if (!recursion)
+    if (!recursion) {
       delete this;
+    }
     return EVENT_DONE;
   }
 
@@ -356,9 +366,9 @@ struct CheckConnect : public Continuation {
     recursion++;
     netProcessor.connect_re(this, target, opt);
     recursion--;
-    if (connect_status != NET_EVENT_OPEN_FAILED)
+    if (connect_status != NET_EVENT_OPEN_FAILED) {
       return &action_;
-    else {
+    } else {
       delete this;
       return ACTION_RESULT_DONE;
     }
@@ -440,8 +450,9 @@ UnixNetProcessor::start(int, size_t)
    * Stat pages
    */
   extern Action *register_ShowNet(Continuation * c, HTTPHdr * h);
-  if (etype == ET_NET)
+  if (etype == ET_NET) {
     statPagesManager.register_http("net", register_ShowNet);
+  }
   return 1;
 }
 

--- a/iocore/net/UnixUDPConnection.cc
+++ b/iocore/net/UnixUDPConnection.cc
@@ -36,8 +36,9 @@ UnixUDPConnection::~UnixUDPConnection()
 {
   UDPPacketInternal *p = (UDPPacketInternal *)ink_atomiclist_popall(&inQueue);
 
-  if (!tobedestroyed)
+  if (!tobedestroyed) {
     tobedestroyed = 1;
+  }
 
   if (p) {
     UDPPacketInternal *pnext = NULL;
@@ -67,12 +68,14 @@ UnixUDPConnection::callbackHandler(int event, void *data)
   (void)event;
   (void)data;
   callbackAction = NULL;
-  if (continuation == NULL)
+  if (continuation == NULL) {
     return EVENT_CONT;
+  }
 
   if (m_errno) {
-    if (!shouldDestroy())
+    if (!shouldDestroy()) {
       continuation->handleEvent(NET_EVENT_DATAGRAM_ERROR, this);
+    }
     destroy(); // don't destroy until after calling back with error
     Release();
     return EVENT_CONT;
@@ -88,11 +91,12 @@ UnixUDPConnection::callbackHandler(int event, void *data)
         result.push(p);
         p = pnext;
       }
-      if (!shouldDestroy())
+      if (!shouldDestroy()) {
         continuation->handleEvent(NET_EVENT_DATAGRAM_READ_READY, &result);
-      else {
-        while ((p = result.dequeue()))
+      } else {
+        while ((p = result.dequeue())) {
           p->free();
+        }
       }
     }
   }

--- a/iocore/net/UnixUDPNet.cc
+++ b/iocore/net/UnixUDPNet.cc
@@ -88,18 +88,21 @@ initialize_thread_for_udp_net(EThread *thread)
 int
 UDPNetProcessorInternal::start(int n_upd_threads, size_t stacksize)
 {
-  if (n_upd_threads < 1)
+  if (n_upd_threads < 1) {
     return -1;
+  }
 
   ET_UDP = eventProcessor.spawn_event_threads(n_upd_threads, "ET_UDP", stacksize);
-  if (ET_UDP < 0) // Probably can't happen, maybe at some point EventType should be unsigned ?
+  if (ET_UDP < 0) { // Probably can't happen, maybe at some point EventType should be unsigned ?
     return -1;
+  }
 
   pollCont_offset      = eventProcessor.allocate(sizeof(PollCont));
   udpNetHandler_offset = eventProcessor.allocate(sizeof(UDPNetHandler));
 
-  for (int i = 0; i < eventProcessor.n_threads_for_type[ET_UDP]; i++)
+  for (int i = 0; i < eventProcessor.n_threads_for_type[ET_UDP]; i++) {
     initialize_thread_for_udp_net(eventProcessor.eventthread[ET_UDP][i]);
+  }
 
   return 0;
 }
@@ -228,10 +231,11 @@ UDPReadContinuation::UDPReadContinuation(Event *completionToken)
     elapsed_time(0),
     timeout_interval(0)
 {
-  if (completionToken->continuation)
+  if (completionToken->continuation) {
     this->mutex = completionToken->continuation->mutex;
-  else
+  } else {
     this->mutex = new_ProxyMutex();
+  }
 }
 
 UDPReadContinuation::UDPReadContinuation()
@@ -528,11 +532,13 @@ UDPNetProcessor::CreateUDPSocket(int *resfd, sockaddr const *remote_addr, sockad
   ink_assert(ats_ip_are_compatible(remote_addr, local_addr));
 
   *resfd = -1;
-  if ((res = socketManager.socket(remote_addr->sa_family, SOCK_DGRAM, 0)) < 0)
+  if ((res = socketManager.socket(remote_addr->sa_family, SOCK_DGRAM, 0)) < 0) {
     goto HardError;
+  }
   fd = res;
-  if ((res = safe_fcntl(fd, F_SETFL, O_NONBLOCK)) < 0)
+  if ((res = safe_fcntl(fd, F_SETFL, O_NONBLOCK)) < 0) {
     goto HardError;
+  }
   if ((res = socketManager.ink_bind(fd, remote_addr, ats_ip_size(remote_addr), IPPROTO_UDP)) < 0) {
     char buff[INET6_ADDRPORTSTRLEN];
     Debug("udpnet", "ink bind failed on %s", ats_ip_nptop(remote_addr, buff, sizeof(buff)));
@@ -558,15 +564,17 @@ UDPNetProcessor::CreateUDPSocket(int *resfd, sockaddr const *remote_addr, sockad
   return true;
 SoftError:
   Debug("udpnet", "creating a udp socket port = %d---soft failure", ats_ip_port_host_order(local_addr));
-  if (fd != -1)
+  if (fd != -1) {
     socketManager.close(fd);
+  }
   *resfd  = -1;
   *status = NULL;
   return false;
 HardError:
   Debug("udpnet", "creating a udp socket port = %d---hard failure", ats_ip_port_host_order(local_addr));
-  if (fd != -1)
+  if (fd != -1) {
     socketManager.close(fd);
+  }
   *resfd  = -1;
   *status = ACTION_IO_ERROR;
   return false;
@@ -581,11 +589,13 @@ UDPNetProcessor::UDPBind(Continuation *cont, sockaddr const *addr, int send_bufs
   IpEndpoint myaddr;
   int myaddr_len = sizeof(myaddr);
 
-  if ((res = socketManager.socket(addr->sa_family, SOCK_DGRAM, 0)) < 0)
+  if ((res = socketManager.socket(addr->sa_family, SOCK_DGRAM, 0)) < 0) {
     goto Lerror;
+  }
   fd = res;
-  if ((res = fcntl(fd, F_SETFL, O_NONBLOCK) < 0))
+  if ((res = fcntl(fd, F_SETFL, O_NONBLOCK) < 0)) {
     goto Lerror;
+  }
 
   // If this is a class D address (i.e. multicast address), use REUSEADDR.
   if (ats_is_ip_multicast(addr)) {
@@ -620,8 +630,9 @@ UDPNetProcessor::UDPBind(Continuation *cont, sockaddr const *addr, int send_bufs
   cont->handleEvent(NET_EVENT_DATAGRAM_OPEN, n);
   return ACTION_RESULT_DONE;
 Lerror:
-  if (fd != NO_FD)
+  if (fd != NO_FD) {
     socketManager.close(fd);
+  }
   cont->handleEvent(NET_EVENT_DATAGRAM_ERROR, NULL);
   return ACTION_IO_ERROR;
 }
@@ -713,10 +724,12 @@ sendPackets:
     p      = pipeInfo.getFirstPacket();
     pktLen = p->getPktLength();
 
-    if (p->conn->shouldDestroy())
+    if (p->conn->shouldDestroy()) {
       goto next_pkt;
-    if (p->conn->GetSendGenerationNumber() != p->reqGenerationNum)
+    }
+    if (p->conn->GetSendGenerationNumber() != p->reqGenerationNum) {
       goto next_pkt;
+    }
 
     SendUDPPacket(p, pktLen);
     bytesUsed += pktLen;
@@ -725,8 +738,9 @@ sendPackets:
     sentOne = true;
     p->free();
 
-    if (bytesThisPipe < 0)
+    if (bytesThisPipe < 0) {
       break;
+    }
   }
 
   bytesThisSlot -= bytesUsed;
@@ -779,9 +793,10 @@ UDPQueue::SendUDPPacket(UDPPacketInternal *p, int32_t /* pktLen ATS_UNUSED */)
   while (1) {
     // stupid Linux problem: sendmsg can return EAGAIN
     n = ::sendmsg(p->conn->getFd(), &msg, 0);
-    if ((n >= 0) || ((n < 0) && (errno != EAGAIN)))
+    if ((n >= 0) || ((n < 0) && (errno != EAGAIN))) {
       // send succeeded or some random error happened.
       break;
+    }
     if (errno == EAGAIN) {
       ++count;
       if ((g_udp_numSendRetries > 0) && (count >= g_udp_numSendRetries)) {

--- a/iocore/utils/Machine.cc
+++ b/iocore/utils/Machine.cc
@@ -127,20 +127,22 @@ Machine::Machine(char const *the_hostname, sockaddr const *addr)
         else
           ifflags = 0; // flags not available, default to just looking at IP
 #endif
-        if (!ats_is_ip(ifip))
+        if (!ats_is_ip(ifip)) {
           spot_type = NA;
-        else if (ats_is_ip_loopback(ifip) || (IFF_LOOPBACK & ifflags))
+        } else if (ats_is_ip_loopback(ifip) || (IFF_LOOPBACK & ifflags)) {
           spot_type = LO;
-        else if (ats_is_ip_linklocal(ifip))
+        } else if (ats_is_ip_linklocal(ifip)) {
           spot_type = LL;
-        else if (ats_is_ip_private(ifip))
+        } else if (ats_is_ip_private(ifip)) {
           spot_type = PR;
-        else if (ats_is_ip_multicast(ifip))
+        } else if (ats_is_ip_multicast(ifip)) {
           spot_type = MC;
-        else
+        } else {
           spot_type = GL;
-        if (spot_type == NA)
+        }
+        if (spot_type == NA) {
           continue; // Next!
+        }
 
         if (ats_is_ip4(ifip)) {
           if (spot_type > ip4_type) {
@@ -160,20 +162,22 @@ Machine::Machine(char const *the_hostname, sockaddr const *addr)
 #endif
 
       // What about the general address? Prefer IPv4?
-      if (ip4_type >= ip6_type)
+      if (ip4_type >= ip6_type) {
         ats_ip_copy(&ip.sa, &ip4.sa);
-      else
+      } else {
         ats_ip_copy(&ip.sa, &ip6.sa);
+      }
     }
 #if !HAVE_IFADDRS_H
     close(s);
 #endif
   } else { // address provided.
     ats_ip_copy(&ip, addr);
-    if (ats_is_ip4(addr))
+    if (ats_is_ip4(addr)) {
       ats_ip_copy(&ip4, addr);
-    else if (ats_is_ip6(addr))
+    } else if (ats_is_ip6(addr)) {
       ats_ip_copy(&ip6, addr);
+    }
 
     status = getnameinfo(addr, ats_ip_size(addr), localhost, sizeof(localhost) - 1, 0, 0, // do not request service info
                          0                                                                // no flags.
@@ -182,8 +186,9 @@ Machine::Machine(char const *the_hostname, sockaddr const *addr)
     if (0 != status) {
       ip_text_buffer ipbuff;
       Warning("Failed to find hostname for address '%s' - %s", ats_ip_ntop(addr, ipbuff, sizeof(ipbuff)), gai_strerror(status));
-    } else
+    } else {
       hostname = ats_strdup(localhost);
+    }
   }
 
   hostname_len = hostname ? strlen(hostname) : 0;

--- a/iocore/utils/OneWayMultiTunnel.cc
+++ b/iocore/utils/OneWayMultiTunnel.cc
@@ -75,10 +75,11 @@ OneWayMultiTunnel::init(VConnection *vcSource, VConnection **vcTargets, int n_vc
   n_connections = n_vioTargets + 1;
 
   int64_t size_index = 0;
-  if (size_estimate)
+  if (size_estimate) {
     size_index = buffer_size_to_index(size_estimate, default_large_iobuffer_size);
-  else
+  } else {
     size_index = default_large_iobuffer_size;
+  }
 
   tunnel_till_done = (nbytes == TUNNEL_TILL_DONE);
 
@@ -87,10 +88,11 @@ OneWayMultiTunnel::init(VConnection *vcSource, VConnection **vcTargets, int n_vc
 
   single_buffer = asingle_buffer;
 
-  if (single_buffer)
+  if (single_buffer) {
     buf2 = buf1;
-  else
+  } else {
     buf2 = new_MIOBuffer(size_index);
+  }
   topOutBuffer.writer_for(buf2);
 
   buf1->water_mark = water_mark;
@@ -98,8 +100,9 @@ OneWayMultiTunnel::init(VConnection *vcSource, VConnection **vcTargets, int n_vc
   vioSource = vcSource->do_io(VIO::READ, this, nbytes, buf1, 0);
 
   ink_assert(n_vcTargets <= ONE_WAY_MULTI_TUNNEL_LIMIT);
-  for (int i      = 0; i < n_vcTargets; i++)
+  for (int i = 0; i < n_vcTargets; i++) {
     vioTargets[i] = vcTargets[i]->do_io(VIO::WRITE, this, INT64_MAX, buf2, 0);
+  }
 
   return;
 }
@@ -160,37 +163,43 @@ OneWayMultiTunnel::startEvent(int event, void *data)
   switch (event) {
   case VC_EVENT_READ_READY: { // SunCC uses old scoping rules
     transform(vioSource->buffer, topOutBuffer);
-    for (int i = 0; i < n_vioTargets; i++)
-      if (vioTargets[i])
+    for (int i = 0; i < n_vioTargets; i++) {
+      if (vioTargets[i]) {
         vioTargets[i]->reenable();
+      }
+    }
     ret = VC_EVENT_CONT;
     break;
   }
 
   case VC_EVENT_WRITE_READY:
-    if (vioSource)
+    if (vioSource) {
       vioSource->reenable();
+    }
     ret = VC_EVENT_CONT;
     break;
 
   case VC_EVENT_EOS:
-    if (!tunnel_till_done && vio->ntodo())
+    if (!tunnel_till_done && vio->ntodo()) {
       goto Lerror;
+    }
     if (vio == vioSource) {
       transform(vioSource->buffer, topOutBuffer);
       goto Lread_complete;
-    } else
+    } else {
       goto Lwrite_complete;
+    }
 
   Lread_complete:
   case VC_EVENT_READ_COMPLETE: { // SunCC uses old scoping rules
     // set write nbytes to the current buffer size
     //
-    for (int i = 0; i < n_vioTargets; i++)
+    for (int i = 0; i < n_vioTargets; i++) {
       if (vioTargets[i]) {
         vioTargets[i]->nbytes = vioTargets[i]->ndone + vioTargets[i]->buffer.reader()->read_avail();
         vioTargets[i]->reenable();
       }
+    }
     close_source_vio(0);
     ret = VC_EVENT_DONE;
     break;
@@ -199,10 +208,11 @@ OneWayMultiTunnel::startEvent(int event, void *data)
   Lwrite_complete:
   case VC_EVENT_WRITE_COMPLETE:
     close_target_vio(0, (VIO *)data);
-    if ((n_connections == 0) || (n_connections == 1 && source_read_previously_completed))
+    if ((n_connections == 0) || (n_connections == 1 && source_read_previously_completed)) {
       goto Ldone;
-    else if (vioSource)
+    } else if (vioSource) {
       vioSource->reenable();
+    }
     break;
 
   Lerror:
@@ -232,10 +242,12 @@ OneWayMultiTunnel::close_target_vio(int result, VIO *vio)
   for (int i = 0; i < n_vioTargets; i++) {
     VIO *v = vioTargets[i];
     if (v && (!vio || v == vio)) {
-      if (last_connection() || !single_buffer)
+      if (last_connection() || !single_buffer) {
         free_MIOBuffer(v->buffer.writer());
-      if (close_target)
+      }
+      if (close_target) {
         v->vc_server->do_io(result ? VIO::ABORT : VIO::CLOSE);
+      }
       vioTargets[i] = NULL;
       n_connections--;
     }
@@ -245,9 +257,12 @@ OneWayMultiTunnel::close_target_vio(int result, VIO *vio)
 void
 OneWayMultiTunnel::reenable_all()
 {
-  for (int i = 0; i < n_vioTargets; i++)
-    if (vioTargets[i])
+  for (int i = 0; i < n_vioTargets; i++) {
+    if (vioTargets[i]) {
       vioTargets[i]->reenable();
-  if (vioSource)
+    }
+  }
+  if (vioSource) {
     vioSource->reenable();
+  }
 }

--- a/iocore/utils/OneWayTunnel.cc
+++ b/iocore/utils/OneWayTunnel.cc
@@ -53,10 +53,12 @@ transfer_data(MIOBufferAccessor &in_buf, MIOBufferAccessor &out_buf)
   int64_t n = in_buf.reader()->read_avail();
   int64_t o = out_buf.writer()->write_avail();
 
-  if (n > o)
+  if (n > o) {
     n = o;
-  if (!n)
+  }
+  if (!n) {
     return;
+  }
   memcpy(in_buf.reader()->start(), out_buf.writer()->end(), n);
   in_buf.reader()->consume(n);
   out_buf.writer()->fill(n);
@@ -140,20 +142,22 @@ OneWayTunnel::init(VConnection *vcSource, VConnection *vcTarget, Continuation *a
 
   int64_t size_index = 0;
 
-  if (size_estimate)
+  if (size_estimate) {
     size_index = buffer_size_to_index(size_estimate);
-  else
+  } else {
     size_index = default_large_iobuffer_size;
+  }
 
   Debug("one_way_tunnel", "buffer size index [%" PRId64 "] [%d]", size_index, size_estimate);
 
   // enqueue read request on vcSource.
   MIOBuffer *buf1 = new_MIOBuffer(size_index);
   MIOBuffer *buf2 = NULL;
-  if (single_buffer)
+  if (single_buffer) {
     buf2 = buf1;
-  else
+  } else {
     buf2 = new_MIOBuffer(size_index);
+  }
 
   buf1->water_mark = water_mark;
 
@@ -220,10 +224,11 @@ OneWayTunnel::init(Continuation *aCont, VIO *SourceVio, VIO *TargetVio, bool acl
 void
 OneWayTunnel::transform(MIOBufferAccessor &in_buf, MIOBufferAccessor &out_buf)
 {
-  if (manipulate_fn)
+  if (manipulate_fn) {
     manipulate_fn(in_buf, out_buf);
-  else if (in_buf.writer() != out_buf.writer())
+  } else if (in_buf.writer() != out_buf.writer()) {
     transfer_data(in_buf, out_buf);
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -247,8 +252,9 @@ OneWayTunnel::startEvent(int event, void *data)
   printf("OneWayTunnel --- %s received from %s VC\n", event_name, event_origin);
 #endif
 
-  if (!vioTarget)
+  if (!vioTarget) {
     goto Lerror;
+  }
 
   // handle the event
   //
@@ -267,30 +273,35 @@ OneWayTunnel::startEvent(int event, void *data)
     break;
 
   case VC_EVENT_WRITE_READY:
-    if (vioSource)
+    if (vioSource) {
       vioSource->reenable();
+    }
     ret = VC_EVENT_CONT;
     break;
 
   case VC_EVENT_EOS:
-    if (!tunnel_till_done && vio->ntodo())
+    if (!tunnel_till_done && vio->ntodo()) {
       goto Lerror;
+    }
     if (vio == vioSource) {
       transform(vioSource->buffer, vioTarget->buffer);
       goto Lread_complete;
-    } else
+    } else {
       goto Ldone;
+    }
 
   Lread_complete:
   case VC_EVENT_READ_COMPLETE:
     // set write nbytes to the current buffer size
     //
     vioTarget->nbytes = vioTarget->ndone + vioTarget->buffer.reader()->read_avail();
-    if (vioTarget->nbytes == vioTarget->ndone)
+    if (vioTarget->nbytes == vioTarget->ndone) {
       goto Ldone;
+    }
     vioTarget->reenable();
-    if (!tunnel_peer)
+    if (!tunnel_peer) {
       close_source_vio(0);
+    }
     break;
 
   Lerror:
@@ -376,10 +387,12 @@ OneWayTunnel::connection_closed(int result)
 void
 OneWayTunnel::reenable_all()
 {
-  if (vioSource)
+  if (vioSource) {
     vioSource->reenable();
-  if (vioTarget)
+  }
+  if (vioTarget) {
     vioTarget->reenable();
+  }
 }
 
 bool

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -47,7 +47,7 @@ all-local:
 		CC="$(CC)" \
 		CFLAGS="$(LUA_CFLAGS)" \
 		XCFLAGS="" \
-		LDFLAGS="$(LUA_LDFLAGS)"
+		LDFLAGS="$(LUA_LDFLAGS) $(LDFLAGS)"
 
 clean-local:
 	test "$(top_srcdir)" != "$(top_builddir)" || (cd "$(top_builddir)/$(subdir)/luajit" && $(MAKE) clean)

--- a/lib/records/RecConfigParse.cc
+++ b/lib/records/RecConfigParse.cc
@@ -160,8 +160,9 @@ RecConfigFileParse(const char *path, RecConfigEntryCallback handler, bool inc_ve
     char *lt = lc;
     char *ln;
 
-    while (isspace(*lt))
+    while (isspace(*lt)) {
       lt++;
+    }
     rec_type_str = strtok_r(lt, " \t", &ln);
 
     // check for blank lines and comments
@@ -180,17 +181,20 @@ RecConfigFileParse(const char *path, RecConfigEntryCallback handler, bool inc_ve
       // know we didn't have a valid value.  If not, set 'data_str' to
       // the start of the token and scan until we find the end.  Once
       // the end is found, back-peddle to remove any trailing spaces.
-      while (isspace(*ln))
+      while (isspace(*ln)) {
         ln++;
+      }
       if (*ln == '\0') {
         data_str = NULL;
       } else {
         data_str = ln;
-        while (*ln != '\0')
+        while (*ln != '\0') {
           ln++;
+        }
         ln--;
-        while (isspace(*ln) && (ln > data_str))
+        while (isspace(*ln) && (ln > data_str)) {
           ln--;
+        }
         ln++;
         *ln = '\0';
       }

--- a/lib/records/RecCore.cc
+++ b/lib/records/RecCore.cc
@@ -366,8 +366,9 @@ RecGetRecordInt(const char *name, RecInt *rec_int, bool lock)
 {
   int err;
   RecData data;
-  if ((err = RecGetRecord_Xmalloc(name, RECD_INT, &data, lock)) == REC_ERR_OKAY)
+  if ((err = RecGetRecord_Xmalloc(name, RECD_INT, &data, lock)) == REC_ERR_OKAY) {
     *rec_int = data.rec_int;
+  }
   return err;
 }
 
@@ -376,8 +377,9 @@ RecGetRecordFloat(const char *name, RecFloat *rec_float, bool lock)
 {
   int err;
   RecData data;
-  if ((err = RecGetRecord_Xmalloc(name, RECD_FLOAT, &data, lock)) == REC_ERR_OKAY)
+  if ((err = RecGetRecord_Xmalloc(name, RECD_FLOAT, &data, lock)) == REC_ERR_OKAY) {
     *rec_float = data.rec_float;
+  }
   return err;
 }
 
@@ -415,8 +417,9 @@ RecGetRecordString_Xmalloc(const char *name, RecString *rec_string, bool lock)
 {
   int err;
   RecData data;
-  if ((err = RecGetRecord_Xmalloc(name, RECD_STRING, &data, lock)) == REC_ERR_OKAY)
+  if ((err = RecGetRecord_Xmalloc(name, RECD_STRING, &data, lock)) == REC_ERR_OKAY) {
     *rec_string = data.rec_string;
+  }
   return err;
 }
 
@@ -425,8 +428,9 @@ RecGetRecordCounter(const char *name, RecCounter *rec_counter, bool lock)
 {
   int err;
   RecData data;
-  if ((err = RecGetRecord_Xmalloc(name, RECD_COUNTER, &data, lock)) == REC_ERR_OKAY)
+  if ((err = RecGetRecord_Xmalloc(name, RECD_COUNTER, &data, lock)) == REC_ERR_OKAY) {
     *rec_counter = data.rec_counter;
+  }
   return err;
 }
 
@@ -435,8 +439,9 @@ RecGetRecordByte(const char *name, RecByte *rec_byte, bool lock)
 {
   int err;
   RecData data;
-  if ((err = RecGetRecord_Xmalloc(name, RECD_INT, &data, lock)) == REC_ERR_OKAY)
+  if ((err = RecGetRecord_Xmalloc(name, RECD_INT, &data, lock)) == REC_ERR_OKAY) {
     *rec_byte = data.rec_int;
+  }
   return err;
 }
 
@@ -445,8 +450,9 @@ RecGetRecordBool(const char *name, RecBool *rec_bool, bool lock)
 {
   int err;
   RecData data;
-  if ((err = RecGetRecord_Xmalloc(name, RECD_INT, &data, lock)) == REC_ERR_OKAY)
+  if ((err = RecGetRecord_Xmalloc(name, RECD_INT, &data, lock)) == REC_ERR_OKAY) {
     *rec_bool = 0 != data.rec_int;
+  }
   return err;
 }
 
@@ -601,11 +607,13 @@ RecGetRecordOrderAndId(const char *name, int *order, int *id, bool lock)
   if (ink_hash_table_lookup(g_records_ht, name, (void **)&r)) {
     if (r->registered) {
       rec_mutex_acquire(&(r->lock));
-      if (order)
+      if (order) {
         *order = r->order;
-      if (id)
+      }
+      if (id) {
         *id = r->rsb_id;
-      err   = REC_ERR_OKAY;
+      }
+      err = REC_ERR_OKAY;
       rec_mutex_release(&(r->lock));
     }
   }
@@ -850,8 +858,9 @@ RecRegisterConfig(RecT rec_type, const char *name, RecDataT data_type, RecData d
     r->config_meta.check_expr     = ats_strdup(check_expr);
     r->config_meta.update_cb_list = NULL;
     r->config_meta.access_type    = access_type;
-    if (!updated_p)
+    if (!updated_p) {
       r->config_meta.source = source;
+    }
   }
   ink_rwlock_unlock(&g_records_rwlock);
 
@@ -1041,8 +1050,9 @@ REC_readInteger(const char *name, bool *found, bool lock)
   RecInt _tmp = 0;
   bool _found;
   _found = (RecGetRecordInt(name, &_tmp, lock) == REC_ERR_OKAY);
-  if (found)
+  if (found) {
     *found = _found;
+  }
   return _tmp;
 }
 
@@ -1053,8 +1063,9 @@ REC_readFloat(char *name, bool *found, bool lock)
   RecFloat _tmp = 0.0;
   bool _found;
   _found = (RecGetRecordFloat(name, &_tmp, lock) == REC_ERR_OKAY);
-  if (found)
+  if (found) {
     *found = _found;
+  }
   return _tmp;
 }
 
@@ -1065,8 +1076,9 @@ REC_readCounter(char *name, bool *found, bool lock)
   RecCounter _tmp = 0;
   bool _found;
   _found = (RecGetRecordCounter(name, &_tmp, lock) == REC_ERR_OKAY);
-  if (found)
+  if (found) {
     *found = _found;
+  }
   return _tmp;
 }
 
@@ -1077,8 +1089,9 @@ REC_readString(const char *name, bool *found, bool lock)
   RecString _tmp = NULL;
   bool _found;
   _found = (RecGetRecordString_Xmalloc(name, &_tmp, lock) == REC_ERR_OKAY);
-  if (found)
+  if (found) {
     *found = _found;
+  }
   return _tmp;
 }
 

--- a/lib/records/RecHttp.cc
+++ b/lib/records/RecHttp.cc
@@ -80,16 +80,18 @@ RecHttpLoadIp(char const *value_name, IpAddr &ip4, IpAddr &ip6)
       // for the address to bind.
       if (0 == ats_ip_getbestaddrinfo(host, &tmp4, &tmp6)) {
         if (ats_is_ip4(&tmp4)) {
-          if (!ip4.isValid())
+          if (!ip4.isValid()) {
             ip4 = tmp4;
-          else
+          } else {
             Warning("'%s' specifies more than one IPv4 address, ignoring %s.", value_name, host);
+          }
         }
         if (ats_is_ip6(&tmp6)) {
-          if (!ip6.isValid())
+          if (!ip6.isValid()) {
             ip6 = tmp6;
-          else
+          } else {
             Warning("'%s' specifies more than one IPv6 address, ignoring %s.", value_name, host);
+          }
         }
       } else {
         Warning("'%s' has an value '%s' that is not recognized as an IP address, ignored.", value_name, host);
@@ -162,8 +164,9 @@ HttpProxyPort::hasSSL(Group const &ports)
 {
   bool zret = false;
   for (int i = 0, n = ports.length(); i < n && !zret; ++i) {
-    if (ports[i].isSSL())
+    if (ports[i].isSSL()) {
       zret = true;
+    }
   }
   return zret;
 }
@@ -178,9 +181,9 @@ HttpProxyPort::findHttp(Group const &ports, uint16_t family)
     if (p.m_port &&                               // has a valid port
         TRANSPORT_DEFAULT == p.m_type &&          // is normal HTTP
         (!check_family_p || p.m_family == family) // right address family
-        )
+        ) {
       zret = &p;
-    ;
+    };
   }
   return zret;
 }
@@ -191,8 +194,9 @@ HttpProxyPort::checkPrefix(char const *src, char const *prefix, size_t prefix_le
   char const *zret = 0;
   if (0 == strncasecmp(prefix, src, prefix_len)) {
     src += prefix_len;
-    if ('-' == *src || '=' == *src)
+    if ('-' == *src || '=' == *src) {
       ++src; // permit optional '-' or '='
+    }
     zret = src;
   }
   return zret;
@@ -205,8 +209,9 @@ HttpProxyPort::loadConfig(Vec<self> &entries)
   bool found_p;
 
   text = REC_readString(PORTS_CONFIG_NAME, &found_p);
-  if (found_p)
+  if (found_p) {
     self::loadValue(entries, text);
+  }
   ats_free(text);
 
   return 0 < entries.length();
@@ -215,8 +220,9 @@ HttpProxyPort::loadConfig(Vec<self> &entries)
 bool
 HttpProxyPort::loadDefaultIfEmpty(Group &ports)
 {
-  if (0 == ports.length())
+  if (0 == ports.length()) {
     self::loadValue(ports, DEFAULT_VALUE);
+  }
 
   return 0 < ports.length();
 }
@@ -232,10 +238,11 @@ HttpProxyPort::loadValue(Vec<self> &ports, char const *text)
       for (int p = 0; p < n_ports; ++p) {
         char const *elt = tokens[p];
         HttpProxyPort entry;
-        if (entry.processOptions(elt))
+        if (entry.processOptions(elt)) {
           ports.push_back(entry);
-        else
+        } else {
           Warning("No valid definition was found in proxy port configuration element '%s'", elt);
+        }
       }
     }
   }
@@ -263,8 +270,9 @@ HttpProxyPort::processOptions(char const *opts)
   char *token = 0;
   for (char *spot = text; *spot; ++spot) {
     if (bracket_p) {
-      if (']' == *spot)
+      if (']' == *spot) {
         bracket_p = false;
+      }
     } else if (':' == *spot) {
       *spot = 0;
       token = 0;
@@ -273,8 +281,9 @@ HttpProxyPort::processOptions(char const *opts)
         token = spot;
         values.push_back(token);
       }
-      if ('[' == *spot)
+      if ('[' == *spot) {
         bracket_p = true;
+      }
     }
   }
   if (bracket_p) {
@@ -306,15 +315,17 @@ HttpProxyPort::processOptions(char const *opts)
         zret = true;
       }
     } else if (0 != (value = this->checkPrefix(item, OPT_INBOUND_IP_PREFIX, OPT_INBOUND_IP_PREFIX_LEN))) {
-      if (0 == ip.load(value))
+      if (0 == ip.load(value)) {
         m_inbound_ip = ip;
-      else
+      } else {
         Warning("Invalid IP address value '%s' in port descriptor '%s'", item, opts);
+      }
     } else if (0 != (value = this->checkPrefix(item, OPT_OUTBOUND_IP_PREFIX, OPT_OUTBOUND_IP_PREFIX_LEN))) {
-      if (0 == ip.load(value))
+      if (0 == ip.load(value)) {
         this->outboundIp(ip.family()) = ip;
-      else
+      } else {
         Warning("Invalid IP address value '%s' in port descriptor '%s'", item, opts);
+      }
     } else if (0 == strcasecmp(OPT_COMPRESSED, item)) {
       m_type = TRANSPORT_COMPRESSED;
     } else if (0 == strcasecmp(OPT_BLIND_TUNNEL, item)) {
@@ -397,8 +408,9 @@ HttpProxyPort::processOptions(char const *opts)
   }
 
   // Set the default session protocols.
-  if (!sp_set_p)
+  if (!sp_set_p) {
     m_session_protocol_preference = this->isSSL() ? DEFAULT_TLS_SESSION_PROTOCOL_SET : DEFAULT_NON_TLS_SESSION_PROTOCOL_SET;
+  }
 
   return zret;
 }
@@ -452,72 +464,87 @@ HttpProxyPort::print(char *out, size_t n)
     zret += snprintf(out + zret, n - zret, "%s=[%s]", OPT_INBOUND_IP_PREFIX, m_inbound_ip.toString(ipb, sizeof(ipb)));
     need_colon_p = true;
   }
-  if (zret >= n)
+  if (zret >= n) {
     return n;
+  }
 
   if (m_outbound_ip4.isValid()) {
-    if (need_colon_p)
+    if (need_colon_p) {
       out[zret++] = ':';
+    }
     zret += snprintf(out + zret, n - zret, "%s=[%s]", OPT_OUTBOUND_IP_PREFIX, m_outbound_ip4.toString(ipb, sizeof(ipb)));
     need_colon_p = true;
   }
-  if (zret >= n)
+  if (zret >= n) {
     return n;
+  }
 
   if (m_outbound_ip6.isValid()) {
-    if (need_colon_p)
+    if (need_colon_p) {
       out[zret++] = ':';
+    }
     zret += snprintf(out + zret, n - zret, "%s=[%s]", OPT_OUTBOUND_IP_PREFIX, m_outbound_ip6.toString(ipb, sizeof(ipb)));
     need_colon_p = true;
   }
-  if (zret >= n)
+  if (zret >= n) {
     return n;
+  }
 
   if (0 != m_port) {
-    if (need_colon_p)
+    if (need_colon_p) {
       out[zret++] = ':';
+    }
     zret += snprintf(out + zret, n - zret, "%d", m_port);
     need_colon_p = true;
   }
-  if (zret >= n)
+  if (zret >= n) {
     return n;
+  }
 
   if (ts::NO_FD != m_fd) {
-    if (need_colon_p)
+    if (need_colon_p) {
       out[zret++] = ':';
+    }
     zret += snprintf(out + zret, n - zret, "fd=%d", m_fd);
   }
-  if (zret >= n)
+  if (zret >= n) {
     return n;
+  }
 
   // After this point, all of these options require other options which we've already
   // generated so all of them need a leading colon and we can stop checking for that.
 
-  if (AF_INET6 == m_family)
+  if (AF_INET6 == m_family) {
     zret += snprintf(out + zret, n - zret, ":%s", OPT_IPV6);
-  if (zret >= n)
+  }
+  if (zret >= n) {
     return n;
+  }
 
-  if (TRANSPORT_BLIND_TUNNEL == m_type)
+  if (TRANSPORT_BLIND_TUNNEL == m_type) {
     zret += snprintf(out + zret, n - zret, ":%s", OPT_BLIND_TUNNEL);
-  else if (TRANSPORT_SSL == m_type)
+  } else if (TRANSPORT_SSL == m_type) {
     zret += snprintf(out + zret, n - zret, ":%s", OPT_SSL);
-  else if (TRANSPORT_PLUGIN == m_type)
+  } else if (TRANSPORT_PLUGIN == m_type) {
     zret += snprintf(out + zret, n - zret, ":%s", OPT_PLUGIN);
-  else if (TRANSPORT_COMPRESSED == m_type)
+  } else if (TRANSPORT_COMPRESSED == m_type) {
     zret += snprintf(out + zret, n - zret, ":%s", OPT_COMPRESSED);
-  if (zret >= n)
+  }
+  if (zret >= n) {
     return n;
+  }
 
-  if (m_outbound_transparent_p && m_inbound_transparent_p)
+  if (m_outbound_transparent_p && m_inbound_transparent_p) {
     zret += snprintf(out + zret, n - zret, ":%s", OPT_TRANSPARENT_FULL);
-  else if (m_inbound_transparent_p)
+  } else if (m_inbound_transparent_p) {
     zret += snprintf(out + zret, n - zret, ":%s", OPT_TRANSPARENT_INBOUND);
-  else if (m_outbound_transparent_p)
+  } else if (m_outbound_transparent_p) {
     zret += snprintf(out + zret, n - zret, ":%s", OPT_TRANSPARENT_OUTBOUND);
+  }
 
-  if (m_transparent_passthrough)
+  if (m_transparent_passthrough) {
     zret += snprintf(out + zret, n - zret, ":%s", OPT_TRANSPARENT_PASSTHROUGH);
+  }
 
   /* Don't print the IP resolution preferences if the port is outbound
    * transparent (which means the preference order is forced) or if
@@ -546,27 +573,30 @@ HttpProxyPort::print(char *out, size_t n)
     need_colon_p = false;
   }
   if (sp_set.contains(SPDY_PROTOCOL_SET)) {
-    if (need_colon_p)
+    if (need_colon_p) {
       zret += snprintf(out + zret, n - zret, ":%s=", OPT_PROTO_PREFIX);
-    else
+    } else {
       out[zret++] = ';';
+    }
     zret += snprintf(out + zret, n - zret, TS_NPN_PROTOCOL_GROUP_SPDY);
     sp_set.markOut(SPDY_PROTOCOL_SET);
     need_colon_p = false;
   }
   if (sp_set.contains(HTTP2_PROTOCOL_SET)) {
-    if (need_colon_p)
+    if (need_colon_p) {
       zret += snprintf(out + zret, n - zret, ":%s=", OPT_PROTO_PREFIX);
-    else
+    } else {
       out[zret++] = ';';
+    }
     zret += snprintf(out + zret, n - zret, "%s", TS_NPN_PROTOCOL_GROUP_HTTP2);
     sp_set.markOut(HTTP2_PROTOCOL_SET);
     need_colon_p = false;
   }
   // now enumerate what's left.
   if (!sp_set.isEmpty()) {
-    if (need_colon_p)
+    if (need_colon_p) {
       zret += snprintf(out + zret, n - zret, ":%s=", OPT_PROTO_PREFIX);
+    }
     bool sep_p = !need_colon_p;
     for (int k = 0; k < SessionProtocolSet::MAX; ++k) {
       if (sp_set.contains(k)) {
@@ -635,8 +665,9 @@ SessionProtocolNameRegistry::SessionProtocolNameRegistry() : m_n(0)
 SessionProtocolNameRegistry::~SessionProtocolNameRegistry()
 {
   for (size_t i = 0; i < m_n; ++i) {
-    if (m_flags[i] & F_ALLOCATED)
+    if (m_flags[i] & F_ALLOCATED) {
       ats_free(const_cast<char *>(m_names[i])); // blech - ats_free won't take a char const*
+    }
   }
 }
 
@@ -675,8 +706,9 @@ int
 SessionProtocolNameRegistry::indexFor(char const *name) const
 {
   for (size_t i = 0; i < m_n; ++i) {
-    if (0 == strcasecmp(name, m_names[i]))
+    if (0 == strcasecmp(name, m_names[i])) {
       return i;
+    }
   }
   return INVALID;
 }

--- a/lib/records/RecLocal.cc
+++ b/lib/records/RecLocal.cc
@@ -244,8 +244,9 @@ RecMessageSend(RecMessage *msg)
 {
   int msg_size;
 
-  if (!message_initialized_p)
+  if (!message_initialized_p) {
     return REC_ERR_OKAY;
+  }
 
   // Make a copy of the record, but truncate it to the size actually used
   if (g_mode_type == RECM_CLIENT || g_mode_type == RECM_SERVER) {

--- a/lib/records/RecProcess.cc
+++ b/lib/records/RecProcess.cc
@@ -335,8 +335,9 @@ RecMessageSend(RecMessage *msg)
 {
   int msg_size;
 
-  if (!message_initialized_p)
+  if (!message_initialized_p) {
     return REC_ERR_OKAY;
+  }
 
   // Make a copy of the record, but truncate it to the size actually used
   if (g_mode_type == RECM_CLIENT || g_mode_type == RECM_SERVER) {

--- a/lib/records/RecRawStats.cc
+++ b/lib/records/RecRawStats.cc
@@ -271,8 +271,9 @@ _RecRegisterRawStat(RecRawStatBlock *rsb, RecT rec_type, const char *name, RecDa
   rsb->global[id]->last_count = 0;
 
   // setup the periodic sync callback
-  if (sync_cb)
+  if (sync_cb) {
     RecRegisterRawStatSyncCb(name, sync_cb, rsb, id);
+  }
 
 Ldone:
   return err;
@@ -322,8 +323,9 @@ RecRawStatSyncAvg(const char *name, RecDataT data_type, RecData *data, RecRawSta
   raw_stat_sync_to_global(rsb, id);
   total.sum   = rsb->global[id]->sum;
   total.count = rsb->global[id]->count;
-  if (total.count != 0)
+  if (total.count != 0) {
     avg = (float)((double)total.sum / (double)total.count);
+  }
   RecDataSetFromFloat(data_type, data, avg);
   return REC_ERR_OKAY;
 }

--- a/lib/records/RecUtils.cc
+++ b/lib/records/RecUtils.cc
@@ -140,16 +140,18 @@ RecDataSet(RecDataT data_type, RecData *data_dst, RecData *data_src)
       }
     } else if (((data_dst->rec_string) && (strcmp(data_dst->rec_string, data_src->rec_string) != 0)) ||
                ((data_dst->rec_string == NULL) && (data_src->rec_string != NULL))) {
-      if (data_dst->rec_string)
+      if (data_dst->rec_string) {
         ats_free(data_dst->rec_string);
+      }
 
       data_dst->rec_string = ats_strdup(data_src->rec_string);
       rec_set              = true;
       // Chop trailing spaces
       char *end = data_dst->rec_string + strlen(data_dst->rec_string) - 1;
 
-      while (end >= data_dst->rec_string && isspace(*end))
+      while (end >= data_dst->rec_string && isspace(*end)) {
         end--;
+      }
       *(end + 1) = '\0';
     }
     break;
@@ -186,22 +188,24 @@ RecDataCmp(RecDataT type, RecData left, RecData right)
 #endif
   case RECD_INT:
   case RECD_COUNTER:
-    if (left.rec_int > right.rec_int)
+    if (left.rec_int > right.rec_int) {
       return 1;
-    else if (left.rec_int == right.rec_int)
+    } else if (left.rec_int == right.rec_int) {
       return 0;
-    else
+    } else {
       return -1;
+    }
 #if defined(STAT_PROCESSOR)
   case RECD_CONST:
 #endif
   case RECD_FLOAT:
-    if (left.rec_float > right.rec_float)
+    if (left.rec_float > right.rec_float) {
       return 1;
-    else if (left.rec_float == right.rec_float)
+    } else if (left.rec_float == right.rec_float) {
       return 0;
-    else
+    } else {
       return -1;
+    }
   default:
     Fatal("unsupport type:%d\n", type);
     return 0;

--- a/lib/ts/BaseLogFile.cc
+++ b/lib/ts/BaseLogFile.cc
@@ -70,10 +70,11 @@ BaseLogFile::~BaseLogFile()
 {
   log_log_trace("entering BaseLogFile destructor, m_name=%s, this=%p\n", m_name.get(), this);
 
-  if (m_is_regfile)
+  if (m_is_regfile) {
     close_file();
-  else
+  } else {
     log_log_trace("not a regular file, not closing, m_name=%s, this=%p\n", m_name.get(), this);
+  }
 
   log_log_trace("exiting BaseLogFile destructor, this=%p\n", this);
 }
@@ -179,10 +180,11 @@ BaseLogFile::roll(long interval_start, long interval_end)
     // no easy way of keeping track of the timestamp of the first
     // transaction
     log_log_trace("in BaseLogFile::roll(..), didn't use metadata starttime, used earlist available starttime\n");
-    if (interval_start == 0)
+    if (interval_start == 0) {
       start = m_start_time;
-    else
+    } else {
       start = (m_start_time < interval_start) ? m_start_time : interval_start;
+    }
   }
   log_log_trace("in BaseLogFile::roll(..), start = %ld, m_start_time = %ld, interval_start = %ld\n", start, m_start_time,
                 interval_start);
@@ -244,8 +246,9 @@ BaseLogFile::roll()
   long start;
   time_t now = time(NULL);
 
-  if (!m_meta_info || !m_meta_info->get_creation_time(&start))
+  if (!m_meta_info || !m_meta_info->get_creation_time(&start)) {
     start = 0L;
+  }
 
   return roll(start, now);
 }
@@ -322,10 +325,11 @@ BaseLogFile::open_file(int perm)
   } else {
     // The log file does not exist, so we create a new MetaInfo object
     //  which will save itself to disk right away (in the constructor)
-    if (m_has_signature)
+    if (m_has_signature) {
       m_meta_info = new BaseMetaInfo(m_name.get(), (long)time(0), m_signature);
-    else
+    } else {
       m_meta_info = new BaseMetaInfo(m_name.get(), (long)time(0));
+    }
   }
 
   // open actual log file (not metainfo)
@@ -345,8 +349,9 @@ BaseLogFile::open_file(int perm)
   // set permissions if necessary
   if (perm != -1) {
     // means LogFile passed in some permissions we need to set
-    if (chmod(m_name.get(), perm) != 0)
+    if (chmod(m_name.get(), perm) != 0) {
       log_log_error("Error changing logfile=%s permissions: %s\n", m_name.get(), strerror(errno));
+    }
   }
 
   // set m_bytes_written to force the rolling based on filesize.

--- a/lib/ts/CompileParseRules.cc
+++ b/lib/ts/CompileParseRules.cc
@@ -58,71 +58,103 @@ main()
     tparseRulesCTypeToLower[c] = ParseRules::ink_tolower(c);
     tparseRulesCTypeToUpper[c] = ParseRules::ink_toupper(c);
 
-    if (ParseRules::is_char(c))
+    if (ParseRules::is_char(c)) {
       tparseRulesCType[c] |= is_char_BIT;
-    if (ParseRules::is_upalpha(c))
+    }
+    if (ParseRules::is_upalpha(c)) {
       tparseRulesCType[c] |= is_upalpha_BIT;
-    if (ParseRules::is_loalpha(c))
+    }
+    if (ParseRules::is_loalpha(c)) {
       tparseRulesCType[c] |= is_loalpha_BIT;
-    if (ParseRules::is_alpha(c))
+    }
+    if (ParseRules::is_alpha(c)) {
       tparseRulesCType[c] |= is_alpha_BIT;
-    if (ParseRules::is_digit(c))
+    }
+    if (ParseRules::is_digit(c)) {
       tparseRulesCType[c] |= is_digit_BIT;
-    if (ParseRules::is_ctl(c))
+    }
+    if (ParseRules::is_ctl(c)) {
       tparseRulesCType[c] |= is_ctl_BIT;
-    if (ParseRules::is_ws(c))
+    }
+    if (ParseRules::is_ws(c)) {
       tparseRulesCType[c] |= is_ws_BIT;
-    if (ParseRules::is_hex(c))
+    }
+    if (ParseRules::is_hex(c)) {
       tparseRulesCType[c] |= is_hex_BIT;
+    }
     char cc = c;
-    if (ParseRules::is_pchar(&cc))
+    if (ParseRules::is_pchar(&cc)) {
       tparseRulesCType[c] |= is_pchar_BIT;
-    if (ParseRules::is_extra(c))
+    }
+    if (ParseRules::is_extra(c)) {
       tparseRulesCType[c] |= is_extra_BIT;
-    if (ParseRules::is_safe(c))
+    }
+    if (ParseRules::is_safe(c)) {
       tparseRulesCType[c] |= is_safe_BIT;
-    if (ParseRules::is_unsafe(c))
+    }
+    if (ParseRules::is_unsafe(c)) {
       tparseRulesCType[c] |= is_unsafe_BIT;
-    if (ParseRules::is_national(c))
+    }
+    if (ParseRules::is_national(c)) {
       tparseRulesCType[c] |= is_national_BIT;
-    if (ParseRules::is_reserved(c))
+    }
+    if (ParseRules::is_reserved(c)) {
       tparseRulesCType[c] |= is_reserved_BIT;
-    if (ParseRules::is_unreserved(c))
+    }
+    if (ParseRules::is_unreserved(c)) {
       tparseRulesCType[c] |= is_unreserved_BIT;
-    if (ParseRules::is_punct(c))
+    }
+    if (ParseRules::is_punct(c)) {
       tparseRulesCType[c] |= is_punct_BIT;
-    if (ParseRules::is_end_of_url(c))
+    }
+    if (ParseRules::is_end_of_url(c)) {
       tparseRulesCType[c] |= is_end_of_url_BIT;
-    if (ParseRules::is_tspecials(c))
+    }
+    if (ParseRules::is_tspecials(c)) {
       tparseRulesCType[c] |= is_tspecials_BIT;
-    if (ParseRules::is_spcr(c))
+    }
+    if (ParseRules::is_spcr(c)) {
       tparseRulesCType[c] |= is_spcr_BIT;
-    if (ParseRules::is_splf(c))
+    }
+    if (ParseRules::is_splf(c)) {
       tparseRulesCType[c] |= is_splf_BIT;
-    if (ParseRules::is_wslfcr(c))
+    }
+    if (ParseRules::is_wslfcr(c)) {
       tparseRulesCType[c] |= is_wslfcr_BIT;
-    if (ParseRules::is_eow(c))
+    }
+    if (ParseRules::is_eow(c)) {
       tparseRulesCType[c] |= is_eow_BIT;
-    if (ParseRules::is_token(c))
+    }
+    if (ParseRules::is_token(c)) {
       tparseRulesCType[c] |= is_token_BIT;
-    if (ParseRules::is_uri(c))
+    }
+    if (ParseRules::is_uri(c)) {
       tparseRulesCType[c] |= is_uri_BIT;
-    if (ParseRules::is_sep(c))
+    }
+    if (ParseRules::is_sep(c)) {
       tparseRulesCType[c] |= is_sep_BIT;
-    if (ParseRules::is_empty(c))
+    }
+    if (ParseRules::is_empty(c)) {
       tparseRulesCType[c] |= is_empty_BIT;
-    if (ParseRules::is_alnum(c))
+    }
+    if (ParseRules::is_alnum(c)) {
       tparseRulesCType[c] |= is_alnum_BIT;
-    if (ParseRules::is_space(c))
+    }
+    if (ParseRules::is_space(c)) {
       tparseRulesCType[c] |= is_space_BIT;
-    if (ParseRules::is_control(c))
+    }
+    if (ParseRules::is_control(c)) {
       tparseRulesCType[c] |= is_control_BIT;
-    if (ParseRules::is_mime_sep(c))
+    }
+    if (ParseRules::is_mime_sep(c)) {
       tparseRulesCType[c] |= is_mime_sep_BIT;
-    if (ParseRules::is_http_field_name(c))
+    }
+    if (ParseRules::is_http_field_name(c)) {
       tparseRulesCType[c] |= is_http_field_name_BIT;
-    if (ParseRules::is_http_field_value(c))
+    }
+    if (ParseRules::is_http_field_value(c)) {
       tparseRulesCType[c] |= is_http_field_value_BIT;
+    }
   }
 
   FILE *fp = fopen("ParseRulesCType", "w");
@@ -133,12 +165,14 @@ main()
   }
   fclose(fp);
   fp = fopen("ParseRulesCTypeToUpper", "w");
-  for (c = 0; c < 256; c++)
+  for (c = 0; c < 256; c++) {
     fprintf(fp, "%d%c\n", tparseRulesCTypeToUpper[c], c != 255 ? ',' : ' ');
+  }
   fclose(fp);
   fp = fopen("ParseRulesCTypeToLower", "w");
-  for (c = 0; c < 256; c++)
+  for (c = 0; c < 256; c++) {
     fprintf(fp, "%d%c\n", tparseRulesCTypeToLower[c], c != 255 ? ',' : ' ');
+  }
   fclose(fp);
 
   return (0);

--- a/lib/ts/Diags.cc
+++ b/lib/ts/Diags.cc
@@ -235,8 +235,9 @@ Diags::print_va(const char *debug_tag, DiagsLevel diags_level, const SourceLocat
   // start with the diag level prefix //
   //////////////////////////////////////
 
-  for (s = level_name(diags_level); *s; *end_of_format++ = *s++)
+  for (s = level_name(diags_level); *s; *end_of_format++ = *s++) {
     ;
+  }
   *end_of_format++ = ':';
   *end_of_format++ = ' ';
 
@@ -249,8 +250,9 @@ Diags::print_va(const char *debug_tag, DiagsLevel diags_level, const SourceLocat
     lp = loc->str(buf, sizeof(buf));
     if (lp) {
       *end_of_format++ = '<';
-      for (s = lp; *s; *end_of_format++ = *s++)
+      for (s = lp; *s; *end_of_format++ = *s++) {
         ;
+      }
       *end_of_format++ = '>';
       *end_of_format++ = ' ';
     }
@@ -261,8 +263,9 @@ Diags::print_va(const char *debug_tag, DiagsLevel diags_level, const SourceLocat
 
   if (debug_tag) {
     *end_of_format++ = '(';
-    for (s = debug_tag; *s; *end_of_format++ = *s++)
+    for (s = debug_tag; *s; *end_of_format++ = *s++) {
       ;
+    }
     *end_of_format++ = ')';
     *end_of_format++ = ' ';
   }
@@ -270,8 +273,9 @@ Diags::print_va(const char *debug_tag, DiagsLevel diags_level, const SourceLocat
   // append original format string, and NUL terminate //
   //////////////////////////////////////////////////////
 
-  for (s = format_string; *s; *end_of_format++ = *s++)
+  for (s = format_string; *s; *end_of_format++ = *s++) {
     ;
+  }
   *end_of_format++ = NUL;
 
   //////////////////////////////////////////////////////////////////
@@ -285,15 +289,18 @@ Diags::print_va(const char *debug_tag, DiagsLevel diags_level, const SourceLocat
 
   d    = format_buf_w_ts;
   *d++ = '[';
-  for (int i = 4; buffer[i]; i++)
+  for (int i = 4; buffer[i]; i++) {
     *d++ = buffer[i];
-  *d++   = ']';
-  *d++   = ' ';
+  }
+  *d++ = ']';
+  *d++ = ' ';
 
-  for (int k = 0; prefix_str[k]; k++)
+  for (int k = 0; prefix_str[k]; k++) {
     *d++ = prefix_str[k];
-  for (s = format_buf; *s; *d++ = *s++)
+  }
+  for (s = format_buf; *s; *d++ = *s++) {
     ;
+  }
   *d++ = NUL;
 
   //////////////////////////////////////
@@ -392,12 +399,14 @@ Diags::tag_activated(const char *tag, DiagsTagType mode) const
 {
   bool activated = false;
 
-  if (tag == NULL)
+  if (tag == NULL) {
     return (true);
+  }
 
   lock();
-  if (activated_tags[mode])
+  if (activated_tags[mode]) {
     activated = (activated_tags[mode]->match(tag) != -1);
+  }
   unlock();
 
   return (activated);
@@ -512,8 +521,9 @@ void
 Diags::log(const char *tag, DiagsLevel level, const char *file, const char *func, const int line,
            const char *format_string...) const
 {
-  if (!on(tag))
+  if (!on(tag)) {
     return;
+  }
 
   va_list ap;
   va_start(ap, format_string);
@@ -617,8 +627,9 @@ Diags::should_roll_diagslog()
     if (diagslog_rolling_enabled == RollingEnabledValues::ROLL_ON_SIZE) {
       // if we can't even check the file, we can forget about rotating
       struct stat buf;
-      if (fstat(fileno(diags_log->m_fp), &buf) != 0)
+      if (fstat(fileno(diags_log->m_fp), &buf) != 0) {
         return false;
+      }
 
       int size = buf.st_size;
       if (diagslog_rolling_size != -1 && size >= (diagslog_rolling_size * BYTES_IN_MB)) {
@@ -695,15 +706,17 @@ Diags::should_roll_outputlog()
     if (outputlog_rolling_enabled == RollingEnabledValues::ROLL_ON_SIZE) {
       // if we can't even check the file, we can forget about rotating
       struct stat buf;
-      if (fstat(fileno(stdout_log->m_fp), &buf) != 0)
+      if (fstat(fileno(stdout_log->m_fp), &buf) != 0) {
         return false;
+      }
 
       int size = buf.st_size;
       if (outputlog_rolling_size != -1 && size >= outputlog_rolling_size * BYTES_IN_MB) {
         // since usually stdout and stderr are the same file on disk, we should just
         // play it safe and just flush both BaseLogFiles
-        if (stderr_log->is_init())
+        if (stderr_log->is_init()) {
           fflush(stderr_log->m_fp);
+        }
         fflush(stdout_log->m_fp);
 
         if (stdout_log->roll()) {
@@ -727,8 +740,9 @@ Diags::should_roll_outputlog()
       if (outputlog_rolling_interval != -1 && (now - outputlog_time_last_roll) >= outputlog_rolling_interval) {
         // since usually stdout and stderr are the same file on disk, we should just
         // play it safe and just flush both BaseLogFiles
-        if (stderr_log->is_init())
+        if (stderr_log->is_init()) {
           fflush(stderr_log->m_fp);
+        }
         fflush(stdout_log->m_fp);
 
         if (stdout_log->roll()) {
@@ -760,8 +774,9 @@ Diags::should_roll_outputlog()
   // disk, and stderr pointing to a different file on disk, and then also wants both files to
   // rotate according to the (same || different) scheme, it would not be difficult to add
   // some more config options in records.config and said feature into this function.
-  if (ret_val)
+  if (ret_val) {
     ink_assert(!need_consider_stderr);
+  }
 
   return ret_val;
 }
@@ -778,8 +793,9 @@ Diags::should_roll_outputlog()
 bool
 Diags::set_stdout_output(const char *_bind_stdout)
 {
-  if (strcmp(_bind_stdout, "") == 0)
+  if (strcmp(_bind_stdout, "") == 0) {
     return false;
+  }
 
   if (stdout_log) {
     delete stdout_log;
@@ -815,8 +831,9 @@ Diags::set_stdout_output(const char *_bind_stdout)
 bool
 Diags::set_stderr_output(const char *_bind_stderr)
 {
-  if (strcmp(_bind_stderr, "") == 0)
+  if (strcmp(_bind_stderr, "") == 0) {
     return false;
+  }
 
   if (stderr_log) {
     delete stderr_log;
@@ -851,9 +868,9 @@ Diags::set_stderr_output(const char *_bind_stderr)
 bool
 Diags::rebind_stdout(int new_fd)
 {
-  if (new_fd < 0)
+  if (new_fd < 0) {
     fprintf(stdout, "[Warning]: TS unable to bind stdout to new file descriptor=%d", new_fd);
-  else {
+  } else {
     dup2(new_fd, STDOUT_FILENO);
     return true;
   }
@@ -868,9 +885,9 @@ Diags::rebind_stdout(int new_fd)
 bool
 Diags::rebind_stderr(int new_fd)
 {
-  if (new_fd < 0)
+  if (new_fd < 0) {
     fprintf(stdout, "[Warning]: TS unable to bind stderr to new file descriptor=%d", new_fd);
-  else {
+  } else {
     dup2(new_fd, STDERR_FILENO);
     return true;
   }

--- a/lib/ts/HostLookup.cc
+++ b/lib/ts/HostLookup.cc
@@ -623,8 +623,9 @@ hostArray::Lookup(const char *match_data_in, bool bNotProcess)
 
     if (bNotProcess && '!' == *pMD) {
       char *cp = ++pMD;
-      if ('\0' == *cp)
+      if ('\0' == *cp) {
         continue;
+      }
 
       if (strcmp(cp, match_data_in) != 0) {
         r = branch_array[i];

--- a/lib/ts/IpMap.cc
+++ b/lib/ts/IpMap.cc
@@ -282,14 +282,15 @@ namespace detail
     N *n    = _root; // current node to test.
     N *zret = 0;     // best node so far.
     while (n) {
-      if (target < n->_min)
+      if (target < n->_min) {
         n = left(n);
-      else {
+      } else {
         zret = n; // this is a better candidate.
-        if (n->_max < target)
+        if (n->_max < target) {
           n = right(n);
-        else
+        } else {
           break;
+        }
       }
     }
     return zret;
@@ -413,8 +414,9 @@ namespace detail
               y->decrementMax();
               this->insertBefore(n, y);
             }
-            if (max <= n->_max) // nothing past node
+            if (max <= n->_max) { // nothing past node
               return *this;
+            }
             min = n->_max;
             N::inc(min);
             n = next(n);
@@ -489,15 +491,16 @@ namespace detail
         // min_1 is safe here because n->_min < min so min is not zero.
         x = n;
         // If the existing span covers the requested span, we're done.
-        if (x->_max >= max)
+        if (x->_max >= max) {
           return *this;
+        }
         x->setMax(max);
       } else if (n->_max <= max) {
         // Can only have left skew overlap, otherwise disjoint.
         // Clip if overlap.
-        if (n->_max >= min)
+        if (n->_max >= min) {
           n->setMax(min_1);
-        else if (next(n) && n->_max <= max) {
+        } else if (next(n) && n->_max <= max) {
           // request region covers next span so we can re-use that node.
           x = next(n);
           x->setMin(min).setMax(max).setData(payload);
@@ -518,10 +521,11 @@ namespace detail
       n = next(n); // lower bound span handled, move on.
       if (!x) {
         x = new N(min, max, payload);
-        if (n)
+        if (n) {
           this->insertBefore(n, x);
-        else
+        } else {
           this->append(x); // note that since n == 0 we'll just return.
+        }
       }
     } else if (0 != (n = this->getHead()) &&           // at least one node in tree.
                n->_data == payload &&                  // payload matches
@@ -531,8 +535,9 @@ namespace detail
       x = n;
       n = next(n);
       x->setMin(min);
-      if (x->_max < max)
+      if (x->_max < max) {
         x->setMax(max);
+      }
     } else {
       x = new N(min, max, payload);
       this->prepend(x);
@@ -605,10 +610,11 @@ namespace detail
   IpMapBase<N>::insertAfter(N *spot, N *n)
   {
     N *c = right(spot);
-    if (!c)
+    if (!c) {
       spot->setChild(n, N::RIGHT);
-    else
+    } else {
       spot->_next->setChild(n, N::LEFT);
+    }
 
     _list.insertAfter(spot, n);
     _root = static_cast<N *>(n->rebalanceAfterInsert());
@@ -619,10 +625,11 @@ namespace detail
   IpMapBase<N>::insertBefore(N *spot, N *n)
   {
     N *c = left(spot);
-    if (!c)
+    if (!c) {
       spot->setChild(n, N::LEFT);
-    else
+    } else {
       spot->_prev->setChild(n, N::RIGHT);
+    }
 
     _list.insertBefore(spot, n);
     _root = static_cast<N *>(n->rebalanceAfterInsert());
@@ -632,10 +639,11 @@ namespace detail
   void
   IpMapBase<N>::prepend(N *n)
   {
-    if (!_root)
+    if (!_root) {
       _root = n;
-    else
+    } else {
       _root = static_cast<N *>(_list.getHead()->setChild(n, N::LEFT)->rebalanceAfterInsert());
+    }
     _list.prepend(n);
   }
 
@@ -643,10 +651,11 @@ namespace detail
   void
   IpMapBase<N>::append(N *n)
   {
-    if (!_root)
+    if (!_root) {
       _root = n;
-    else
+    } else {
       _root = static_cast<N *>(_list.getTail()->setChild(n, N::RIGHT)->rebalanceAfterInsert());
+    }
     _list.append(n);
   }
 
@@ -666,14 +675,15 @@ namespace detail
     bool zret = false;
     N *n      = _root; // current node to test.
     while (n) {
-      if (x < n->_min)
+      if (x < n->_min) {
         n = left(n);
-      else if (n->_max < x)
+      } else if (n->_max < x) {
         n = right(n);
-      else {
-        if (ptr)
+      } else {
+        if (ptr) {
           *ptr = n->_data;
-        zret   = true;
+        }
+        zret = true;
         break;
       }
     }
@@ -1064,16 +1074,18 @@ IpMap::~IpMap()
 inline ts::detail::Ip4Map *
 IpMap::force4()
 {
-  if (!_m4)
+  if (!_m4) {
     _m4 = new ts::detail::Ip4Map;
+  }
   return _m4;
 }
 
 inline ts::detail::Ip6Map *
 IpMap::force6()
 {
-  if (!_m6)
+  if (!_m6) {
     _m6 = new ts::detail::Ip6Map;
+  }
   return _m6;
 }
 
@@ -1119,11 +1131,13 @@ IpMap::unmark(sockaddr const *min, sockaddr const *max)
 {
   ink_assert(min->sa_family == max->sa_family);
   if (AF_INET == min->sa_family) {
-    if (_m4)
+    if (_m4) {
       _m4->unmark(ntohl(ats_ip4_addr_cast(min)), ntohl(ats_ip4_addr_cast(max)));
+    }
   } else if (AF_INET6 == min->sa_family) {
-    if (_m6)
+    if (_m6) {
       _m6->unmark(ats_ip6_cast(min), ats_ip6_cast(max));
+    }
   }
   return *this;
 }
@@ -1131,8 +1145,9 @@ IpMap::unmark(sockaddr const *min, sockaddr const *max)
 IpMap &
 IpMap::unmark(in_addr_t min, in_addr_t max)
 {
-  if (_m4)
+  if (_m4) {
     _m4->unmark(ntohl(min), ntohl(max));
+  }
   return *this;
 }
 
@@ -1159,20 +1174,24 @@ size_t
 IpMap::getCount() const
 {
   size_t zret = 0;
-  if (_m4)
+  if (_m4) {
     zret += _m4->getCount();
-  if (_m6)
+  }
+  if (_m6) {
     zret += _m6->getCount();
+  }
   return zret;
 }
 
 IpMap &
 IpMap::clear()
 {
-  if (_m4)
+  if (_m4) {
     _m4->clear();
-  if (_m6)
+  }
+  if (_m6) {
     _m6->clear();
+  }
   return *this;
 }
 
@@ -1180,10 +1199,12 @@ IpMap::iterator
 IpMap::begin() const
 {
   Node *x = 0;
-  if (_m4)
+  if (_m4) {
     x = _m4->getHead();
-  if (!x && _m6)
+  }
+  if (!x && _m6) {
     x = _m6->getHead();
+  }
   return iterator(this, x);
 }
 
@@ -1193,8 +1214,9 @@ IpMap::iterator &IpMap::iterator::operator++()
     // If we go past the end of the list see if it was the v4 list
     // and if so, move to the v6 list (if it's there).
     Node *x = static_cast<Node *>(_node->_next);
-    if (!x && _tree->_m4 && _tree->_m6 && _node == _tree->_m4->getTail())
-      x   = _tree->_m6->getHead();
+    if (!x && _tree->_m4 && _tree->_m6 && _node == _tree->_m4->getTail()) {
+      x = _tree->_m6->getHead();
+    }
     _node = x;
   }
   return *this;
@@ -1206,15 +1228,18 @@ inline IpMap::iterator &IpMap::iterator::operator--()
     // At a node, try to back up. Handle the case where we back over the
     // start of the v6 addresses and switch to the v4, if there are any.
     Node *x = static_cast<Node *>(_node->_prev);
-    if (!x && _tree->_m4 && _tree->_m6 && _node == _tree->_m6->getHead())
-      x   = _tree->_m4->getTail();
+    if (!x && _tree->_m4 && _tree->_m6 && _node == _tree->_m6->getHead()) {
+      x = _tree->_m4->getTail();
+    }
     _node = x;
   } else if (_tree) {
     // We were at the end. Back up to v6 if possible, v4 if not.
-    if (_tree->_m6)
+    if (_tree->_m6) {
       _node = _tree->_m6->getTail();
-    if (!_node && _tree->_m4)
+    }
+    if (!_node && _tree->_m4) {
       _node = _tree->_m4->getTail();
+    }
   }
   return *this;
 }

--- a/lib/ts/IpMapConf.cc
+++ b/lib/ts/IpMapConf.cc
@@ -79,8 +79,9 @@ Load_IpMap_From_File(IpMap *map, int fd, const char *key_str)
   int fd2    = dup(fd); // dup to avoid closing the original file.
   FILE *f    = NULL;
 
-  if (fd2 >= 0)
+  if (fd2 >= 0) {
     f = fdopen(fd2, "r");
+  }
 
   if (f != NULL) {
     zret = Load_IpMap_From_File(map, f, key_str);
@@ -101,8 +102,9 @@ Load_IpMap_From_File(IpMap *map, int fd, const char *key_str)
 static inline bool
 skip_space(char *line, int n, int &offset)
 {
-  while (offset < n && isspace(line[offset]))
+  while (offset < n && isspace(line[offset])) {
     ++offset;
+  }
   return offset < n;
 }
 
@@ -124,14 +126,17 @@ Load_IpMap_From_File(IpMap *map, FILE *f, const char *key_str)
     ++line_no;
     n = strlen(line);
     // Find first white space which terminates the line key.
-    for (i = 0; i < n && !isspace(line[i]); ++i)
+    for (i = 0; i < n && !isspace(line[i]); ++i) {
       ;
-    if (i != key_len || 0 != strncmp(line, key_str, key_len))
+    }
+    if (i != key_len || 0 != strncmp(line, key_str, key_len)) {
       continue;
+    }
     // Now look for IP address
     while (true) {
-      if (!skip_space(line, n, i))
+      if (!skip_space(line, n, i)) {
         break;
+      }
 
       if (0 != read_addr(line, n, &i, &laddr.sa, err_buff)) {
         char *error_str = (char *)ats_malloc(ERR_STRING_LEN);
@@ -143,10 +148,11 @@ Load_IpMap_From_File(IpMap *map, FILE *f, const char *key_str)
       if (!skip_space(line, n, i) || line[i] == ',') {
         // You have read an IP address. Enter it in the table
         map->mark(&laddr);
-        if (i == n)
+        if (i == n) {
           break;
-        else
+        } else {
           ++i;
+        }
       } else if (line[i] == '-') {
         // What you have just read is the start of the range,
         // Now, read the end of the IP range
@@ -161,8 +167,9 @@ Load_IpMap_From_File(IpMap *map, FILE *f, const char *key_str)
           return error_str;
         }
         map->mark(&laddr.sa, &raddr.sa);
-        if (!skip_space(line, n, i))
+        if (!skip_space(line, n, i)) {
           break;
+        }
         if (line[i] != ',') {
           char *error_str = (char *)ats_malloc(ERR_STRING_LEN);
           snprintf(error_str, ERR_STRING_LEN, "Invalid input (expecting comma) at line %d offset %d - '%s'", line_no, i, line);

--- a/lib/ts/MMH.cc
+++ b/lib/ts/MMH.cc
@@ -236,11 +236,13 @@ ink_code_incr_MMH_update(MMH_CTX *ctx, const char *ainput, int input_length)
       memcpy(ctx->buffer + ctx->buffer_size, in, l);
       ctx->buffer_size = 0;
       in += l;
-      if (ctx->buffer_size & 0x0f)
+      if (ctx->buffer_size & 0x0f) {
         return 0;
+      }
       MMH_update(ctx, ctx->buffer);
-    } else
+    } else {
       goto Lstore;
+    }
   }
   {
     // check alignment
@@ -265,11 +267,12 @@ ink_code_incr_MMH_update(MMH_CTX *ctx, const char *ainput, int input_length)
             MMH_updateb2(ctx, in);
             in += 16;
           }
-        } else if (alignment == 3)
+        } else if (alignment == 3) {
           while (in + 16 <= end) {
             MMH_updateb3(ctx, in);
             in += 16;
           }
+        }
       } else {
         if (alignment == 1) {
           while (in + 16 <= end) {
@@ -281,11 +284,12 @@ ink_code_incr_MMH_update(MMH_CTX *ctx, const char *ainput, int input_length)
             MMH_updatel2(ctx, in);
             in += 16;
           }
-        } else if (alignment == 3)
+        } else if (alignment == 3) {
           while (in + 16 <= end) {
             MMH_updatel3(ctx, in);
             in += 16;
           }
+        }
       }
     } else {
       while (in + 16 <= end) {

--- a/lib/ts/MatcherUtils.cc
+++ b/lib/ts/MatcherUtils.cc
@@ -163,10 +163,12 @@ ExtractIpRange(char *match_str, in_addr_t *min, in_addr_t *max)
   char const *zret = ExtractIpRange(match_str, &ip_min.sa, &ip_max.sa);
   if (0 == zret) { // success
     if (ats_is_ip4(&ip_min) && ats_is_ip4(&ip_max)) {
-      if (min)
+      if (min) {
         *min = ntohl(ats_ip4_addr_cast(&ip_min));
-      if (max)
+      }
+      if (max) {
         *max = ntohl(ats_ip4_addr_cast(&ip_max));
+      }
     } else {
       zret = "The addresses were not IPv4 addresses.";
     }

--- a/lib/ts/ParseRules.cc
+++ b/lib/ts/ParseRules.cc
@@ -47,8 +47,9 @@ ParseRules::ink_tolower_buffer(char *ptr, unsigned int n)
   unsigned int i;
 
   if (n < 8) {
-    for (i   = 0; i < n; i++)
+    for (i = 0; i < n; i++) {
       ptr[i] = ParseRules::ink_tolower(ptr[i]);
+    }
   } else {
     uintptr_t fpad  = 4 - ((uintptr_t)ptr & 3);
     uintptr_t words = (n - fpad) >> 2;
@@ -106,13 +107,15 @@ ink_atoi64(const char *str)
   int64_t num  = 0;
   int negative = 0;
 
-  while (*str && ParseRules::is_wslfcr(*str))
+  while (*str && ParseRules::is_wslfcr(*str)) {
     str += 1;
+  }
 
   if (unlikely(str[0] == '0' && str[1] == 'x')) {
     str += 2;
-    while (*str && ParseRules::is_hex(*str))
+    while (*str && ParseRules::is_hex(*str)) {
       num = (num << 4) + ink_get_hex(*str++);
+    }
   } else {
     if (unlikely(*str == '-')) {
       negative = 1;
@@ -123,22 +126,25 @@ ink_atoi64(const char *str)
       NOTE: we first compute the value as negative then correct the
       sign back to positive. This enables us to correctly parse MININT.
     */
-    while (*str && ParseRules::is_digit(*str))
+    while (*str && ParseRules::is_digit(*str)) {
       num = (num * 10) - (*str++ - '0');
+    }
 #if USE_SI_MULTILIERS
     if (*str) {
-      if (*str == 'K')
+      if (*str == 'K') {
         num = num * (1LL << 10);
-      else if (*str == 'M')
+      } else if (*str == 'M') {
         num = num * (1LL << 20);
-      else if (*str == 'G')
+      } else if (*str == 'G') {
         num = num * (1LL << 30);
-      else if (*str == 'T')
+      } else if (*str == 'T') {
         num = num * (1LL << 40);
+      }
     }
 #endif
-    if (!negative)
+    if (!negative) {
       num = -num;
+    }
   }
   return num;
 }
@@ -148,26 +154,30 @@ ink_atoui64(const char *str)
 {
   uint64_t num = 0;
 
-  while (*str && ParseRules::is_wslfcr(*str))
+  while (*str && ParseRules::is_wslfcr(*str)) {
     str += 1;
+  }
 
   if (unlikely(str[0] == '0' && str[1] == 'x')) {
     str += 2;
-    while (*str && ParseRules::is_hex(*str))
+    while (*str && ParseRules::is_hex(*str)) {
       num = (num << 4) + ink_get_hex(*str++);
+    }
   } else {
-    while (*str && ParseRules::is_digit(*str))
+    while (*str && ParseRules::is_digit(*str)) {
       num = (num * 10) + (*str++ - '0');
+    }
 #if USE_SI_MULTILIERS
     if (*str) {
-      if (*str == 'K')
+      if (*str == 'K') {
         num = num * (1LL << 10);
-      else if (*str == 'M')
+      } else if (*str == 'M') {
         num = num * (1LL << 20);
-      else if (*str == 'G')
+      } else if (*str == 'G') {
         num = num * (1LL << 30);
-      else if (*str == 'T')
+      } else if (*str == 'T') {
         num = num * (1LL << 40);
+      }
     }
 #endif
   }
@@ -185,8 +195,9 @@ ink_atoi64(const char *str, int len)
     len--;
   }
 
-  if (len < 1)
+  if (len < 1) {
     return 0;
+  }
 
   if (unlikely(str[0] == '0' && len > 1 && str[1] == 'x')) {
     str += 2;
@@ -210,17 +221,19 @@ ink_atoi64(const char *str, int len)
     }
 #if USE_SI_MULTILIERS
     if (len > 0 && *str) {
-      if (*str == 'K')
+      if (*str == 'K') {
         num = num * (1 << 10);
-      else if (*str == 'M')
+      } else if (*str == 'M') {
         num = num * (1 << 20);
-      else if (*str == 'G')
+      } else if (*str == 'G') {
         num = num * (1 << 30);
+      }
     }
 #endif
 
-    if (!negative)
+    if (!negative) {
       num = -num;
+    }
   }
   return num;
 }

--- a/lib/ts/RbTree.cc
+++ b/lib/ts/RbTree.cc
@@ -77,12 +77,14 @@ namespace detail
   RBNode *
   RBNode::setChild(self *n, Direction d)
   {
-    if (n)
+    if (n) {
       n->_parent = this;
-    if (d == RIGHT)
+    }
+    if (d == RIGHT) {
       _right = n;
-    else if (d == LEFT)
+    } else if (d == LEFT) {
       _left = n;
+    }
     return n;
   }
 
@@ -107,16 +109,19 @@ namespace detail
     if (_parent) {
       Direction d = _parent->getChildDirection(this);
       _parent->setChild(0, d);
-      if (_parent != n)
+      if (_parent != n) {
         _parent->setChild(n, d);
+      }
     } else {
       n->_parent = 0;
     }
     n->_left = n->_right = 0;
-    if (_left && _left != n)
+    if (_left && _left != n) {
       n->setChild(_left, LEFT);
-    if (_right && _right != n)
+    }
+    if (_right && _right != n) {
       n->setChild(_right, RIGHT);
+    }
     _left = _right = 0;
   }
 
@@ -129,10 +134,11 @@ namespace detail
     while (x && x->_parent == RED) {
       Direction child_dir = NONE;
 
-      if (x->_parent->_parent)
+      if (x->_parent->_parent) {
         child_dir = x->_parent->_parent->getChildDirection(x->_parent);
-      else
+      } else {
         break;
+      }
       Direction other_dir(flip(child_dir));
 
       self *y = x->_parent->_parent->getChild(other_dir);
@@ -230,8 +236,9 @@ namespace detail
     // node in liu of copying the data over.
     if (remove_node != this) {
       // Don't leave @a splice_node referring to a removed node
-      if (splice_node == this)
+      if (splice_node == this) {
         splice_node = remove_node;
+      }
       this->replaceWith(remove_node);
     }
 

--- a/lib/ts/Regex.cc
+++ b/lib/ts/Regex.cc
@@ -56,8 +56,9 @@ Regex::compile(const char *pattern, const unsigned flags)
   int options    = 0;
   int study_opts = 0;
 
-  if (regex)
+  if (regex) {
     return false;
+  }
 
   if (flags & RE_CASE_INSENSITIVE) {
     options |= PCRE_CASELESS;
@@ -80,8 +81,9 @@ Regex::compile(const char *pattern, const unsigned flags)
   regex_extra = pcre_study(regex, study_opts, &error);
 
 #ifdef PCRE_CONFIG_JIT
-  if (regex_extra)
+  if (regex_extra) {
     pcre_assign_jit_stack(regex_extra, &get_jit_stack, NULL);
+  }
 #endif
 
   return true;
@@ -122,14 +124,16 @@ Regex::exec(const char *str, int length, int *ovector, int ovecsize)
 
 Regex::~Regex()
 {
-  if (regex_extra)
+  if (regex_extra) {
 #ifdef PCRE_CONFIG_JIT
     pcre_free_study(regex_extra);
+  }
 #else
     pcre_free(regex_extra);
 #endif
-  if (regex)
+  if (regex) {
     pcre_free(regex);
+  }
 }
 
 DFA::~DFA()
@@ -138,10 +142,12 @@ DFA::~DFA()
   dfa_pattern *t;
 
   while (p) {
-    if (p->_re)
+    if (p->_re) {
       delete p->_re;
-    if (p->_p)
+    }
+    if (p->_p) {
       ats_free(p->_p);
+    }
     t = p->_next;
     ats_free(p);
     p = t;
@@ -180,10 +186,11 @@ DFA::compile(const char *pattern, unsigned flags)
 {
   ink_assert(_my_patterns == NULL);
   _my_patterns = build(pattern, flags);
-  if (_my_patterns)
+  if (_my_patterns) {
     return 0;
-  else
+  } else {
     return -1;
+  }
 }
 
 int

--- a/lib/ts/Regression.cc
+++ b/lib/ts/Regression.cc
@@ -62,13 +62,15 @@ RegressionTest::RegressionTest(const char *_n, const SourceLocation &_l, TestFun
   : name(_n), location(_l), function(_f), next(0), status(REGRESSION_TEST_NOT_RUN), printed(false), opt(_o)
 {
   if (opt == REGRESSION_OPT_EXCLUSIVE) {
-    if (exclusive_test)
-      this->next   = exclusive_test;
+    if (exclusive_test) {
+      this->next = exclusive_test;
+    }
     exclusive_test = this;
   } else {
-    if (test)
+    if (test) {
       this->next = test;
-    test         = this;
+    }
+    test = this;
   }
 }
 
@@ -91,18 +93,20 @@ start_test(RegressionTest *t, int regression_level)
 int
 RegressionTest::run(const char *atest, int regression_level)
 {
-  if (atest)
+  if (atest) {
     dfa.compile(atest);
-  else
+  } else {
     dfa.compile(".*");
+  }
 
   fprintf(stderr, "REGRESSION_TEST initialization begun\n");
   // start the non exclusive tests
   for (RegressionTest *t = test; t; t = t->next) {
     if ((dfa.match(t->name) >= 0)) {
       int res = start_test(t, regression_level);
-      if (res == REGRESSION_TEST_FAILED)
+      if (res == REGRESSION_TEST_FAILED) {
         final_status = REGRESSION_TEST_FAILED;
+      }
     }
   }
 
@@ -151,10 +155,12 @@ RegressionTest::run_some(int regression_level)
   for (; current; current = current->next) {
     if ((dfa.match(current->name) >= 0)) {
       int res = start_test(current, regression_level);
-      if (res == REGRESSION_TEST_INPROGRESS)
+      if (res == REGRESSION_TEST_INPROGRESS) {
         return res;
-      if (res == REGRESSION_TEST_FAILED)
+      }
+      if (res == REGRESSION_TEST_FAILED) {
         final_status = REGRESSION_TEST_FAILED;
+      }
     }
   }
   return REGRESSION_TEST_INPROGRESS;
@@ -166,8 +172,9 @@ RegressionTest::check_status(int regression_level)
   int status = REGRESSION_TEST_PASSED;
   if (current) {
     status = run_some(regression_level);
-    if (!current)
+    if (!current) {
       return status;
+    }
   }
 
   RegressionTest *t = test;
@@ -265,8 +272,9 @@ REGRESSION_TEST(Regression)(RegressionTest *t, int atype, int *status)
   (void)atype;
   rprintf(t, "regression test\n");
   rperf(t, "speed", 100.0);
-  if (!test)
+  if (!test) {
     *status = REGRESSION_TEST_FAILED;
-  else
+  } else {
     *status = REGRESSION_TEST_PASSED;
+  }
 }

--- a/lib/ts/SourceLocation.cc
+++ b/lib/ts/SourceLocation.cc
@@ -38,8 +38,9 @@ SourceLocation::str(char *buf, int buflen) const
 {
   const char *shortname;
 
-  if (!this->valid() || buflen < 1)
+  if (!this->valid() || buflen < 1) {
     return (NULL);
+  }
 
   shortname = strrchr(file, '/');
   shortname = shortname ? (shortname + 1) : file;

--- a/lib/ts/Tokenizer.cc
+++ b/lib/ts/Tokenizer.cc
@@ -71,8 +71,9 @@ Tokenizer::~Tokenizer()
 
   while (cur != NULL) {
     if (options & COPY_TOKS) {
-      for (int i = 0; i < TOK_NODE_ELEMENTS; i++)
+      for (int i = 0; i < TOK_NODE_ELEMENTS; i++) {
         ats_free(cur->el[i]);
+      }
     }
 
     next = cur->next;
@@ -100,8 +101,9 @@ Tokenizer::isDelimiter(char c)
     quoteFound = !quoteFound;
   }
 
-  if (quoteFound)
+  if (quoteFound) {
     return 0;
+  }
 
   while (strOfDelimit[i] != '\0') {
     if (c == strOfDelimit[i]) {
@@ -196,14 +198,16 @@ Tokenizer::Initialize(char *str, unsigned opt)
       // Go till either we hit a delimiter or we've
       //   come to the end of the string, then
       //   set for copying
-      for (; *str != '\0' && !isDelimiter(*str); str++)
+      for (; *str != '\0' && !isDelimiter(*str); str++) {
         ;
+      }
       priorCharWasDelimit = 0;
 
     } else {
       // First, skip the delimiters
-      for (; *str != '\0' && isDelimiter(*str); str++)
+      for (; *str != '\0' && isDelimiter(*str); str++) {
         ;
+      }
 
       // If there are only delimiters remaining, bail and set
       //   so that we do not add the empty token
@@ -215,12 +219,14 @@ Tokenizer::Initialize(char *str, unsigned opt)
         priorCharWasDelimit = 0;
 
         // Advance until the end of the string
-        for (; *str != '\0'; str++)
+        for (; *str != '\0'; str++) {
           ;
+        }
 
         // Now back off all trailing delimiters
-        for (; isDelimiter(*(str - 1)); str--)
+        for (; isDelimiter(*(str - 1)); str--) {
           ;
+        }
       }
     }
   }
@@ -356,8 +362,9 @@ Tokenizer::ReUse()
 
   while (cur_node != NULL) {
     if (options & COPY_TOKS) {
-      for (int i = 0; i < TOK_NODE_ELEMENTS; i++)
+      for (int i = 0; i < TOK_NODE_ELEMENTS; i++) {
         ats_free(cur_node->el[i]);
+      }
     }
     memset(cur_node->el, 0, sizeof(char *) * TOK_NODE_ELEMENTS);
     cur_node = cur_node->next;

--- a/lib/ts/Vec.cc
+++ b/lib/ts/Vec.cc
@@ -66,10 +66,12 @@ i_find(const Intervals *i, int x)
   int l = 0, h = i->n;
 Lrecurse:
   if (h <= l + 2) {
-    if (h <= l)
+    if (h <= l) {
       return -(l + 1);
-    if (x < i->v[l] || x > i->v[l + 1])
+    }
+    if (x < i->v[l] || x > i->v[l + 1]) {
       return -(l + 1);
+    }
     return h;
   }
   int m = (((h - l) / 4) * 2) + l;
@@ -87,10 +89,12 @@ Lrecurse:
 bool
 Intervals::in(int x) const
 {
-  if (!n)
+  if (!n) {
     return false;
-  if (i_find(this, x) > 0)
+  }
+  if (i_find(this, x) > 0) {
     return true;
+  }
   return false;
 }
 
@@ -104,8 +108,9 @@ Intervals::insert(int x)
     return;
   }
   int l = i_find(this, x);
-  if (l > 0)
+  if (l > 0) {
     return;
+  }
   l = -l - 1;
 
   if (x > v[l + 1]) {
@@ -127,8 +132,9 @@ Intervals::insert(int x)
       v[l]--;
       goto Lmerge;
     }
-    if (!l)
+    if (!l) {
       goto Lmore;
+    }
     l -= 2;
     if (x == v[l + 1] + 1) {
       v[l + 1]++;
@@ -137,8 +143,9 @@ Intervals::insert(int x)
   }
 Lmore:
   fill(n + 2);
-  if (n - 2 - l > 0)
+  if (n - 2 - l > 0) {
     memmove(v + l + 2, v + l, sizeof(int) * (n - 2 - l));
+  }
   v[l]     = x;
   v[l + 1] = x;
   return;
@@ -150,8 +157,9 @@ Lmerge:
     }
   }
   if (l < (int)(n - 2)) {
-    if (v[l + 2] - v[l + 1] < 2)
+    if (v[l + 2] - v[l + 1] < 2) {
       goto Ldomerge;
+    }
   }
   return;
 Ldomerge:
@@ -165,16 +173,18 @@ UnionFind::size(int s)
 {
   size_t nn = n;
   fill(s);
-  for (size_t i = nn; i < n; i++)
-    v[i]        = -1;
+  for (size_t i = nn; i < n; i++) {
+    v[i] = -1;
+  }
 }
 
 int
 UnionFind::find(int n)
 {
   int i, t;
-  for (i = n; v[i] >= 0; i = v[i])
+  for (i = n; v[i] >= 0; i = v[i]) {
     ;
+  }
   while (v[n] >= 0) {
     t    = n;
     n    = v[n];

--- a/lib/ts/Version.cc
+++ b/lib/ts/Version.cc
@@ -56,8 +56,9 @@ AppVersionInfo::setup(const char *pkg_name, const char *app_name, const char *ap
 
   // Jan=1, Feb=2 ... Dec=12, ???=13
   for (month = 0; month < 11; month++) {
-    if (strcasecmp(months[month], month_name) == 0)
+    if (strcasecmp(months[month], month_name) == 0) {
       break;
+    }
   }
   month++;
 
@@ -87,26 +88,36 @@ AppVersionInfo::setup(const char *pkg_name, const char *app_name, const char *ap
   /////////////////////////////////////////////////////////////
   // the manager doesn't like empty strings, so prevent them //
   /////////////////////////////////////////////////////////////
-  if (PkgStr[0] == '\0')
+  if (PkgStr[0] == '\0') {
     ink_strlcpy(PkgStr, "?", sizeof(PkgStr));
-  if (AppStr[0] == '\0')
+  }
+  if (AppStr[0] == '\0') {
     ink_strlcpy(AppStr, "?", sizeof(AppStr));
-  if (VersionStr[0] == '\0')
+  }
+  if (VersionStr[0] == '\0') {
     ink_strlcpy(VersionStr, "?", sizeof(VersionStr));
-  if (BldNumStr[0] == '\0')
+  }
+  if (BldNumStr[0] == '\0') {
     ink_strlcpy(BldNumStr, "?", sizeof(BldNumStr));
-  if (BldTimeStr[0] == '\0')
+  }
+  if (BldTimeStr[0] == '\0') {
     ink_strlcpy(BldTimeStr, "?", sizeof(BldTimeStr));
-  if (BldDateStr[0] == '\0')
+  }
+  if (BldDateStr[0] == '\0') {
     ink_strlcpy(BldDateStr, "?", sizeof(BldDateStr));
-  if (BldMachineStr[0] == '\0')
+  }
+  if (BldMachineStr[0] == '\0') {
     ink_strlcpy(BldMachineStr, "?", sizeof(BldMachineStr));
-  if (BldPersonStr[0] == '\0')
+  }
+  if (BldPersonStr[0] == '\0') {
     ink_strlcpy(BldPersonStr, "?", sizeof(BldPersonStr));
-  if (BldCompileFlagsStr[0] == '\0')
+  }
+  if (BldCompileFlagsStr[0] == '\0') {
     ink_strlcpy(BldCompileFlagsStr, "?", sizeof(BldCompileFlagsStr));
-  if (FullVersionInfoStr[0] == '\0')
+  }
+  if (FullVersionInfoStr[0] == '\0') {
     ink_strlcpy(FullVersionInfoStr, "?", sizeof(FullVersionInfoStr));
+  }
 
   snprintf(FullVersionInfoStr, sizeof(FullVersionInfoStr), "%s - %s - %s - (build # %s on %s at %s)", PkgStr, AppStr, VersionStr,
            BldNumStr, BldDateStr, BldTimeStr);

--- a/lib/ts/X509HostnameValidator.cc
+++ b/lib/ts/X509HostnameValidator.cc
@@ -61,8 +61,9 @@ find_wildcard_in_hostname(const unsigned char *p, size_t len, bool idna_subject)
     }
   }
   // Final dot minimal pos is a.b.xxxxxx
-  if (final_dot_pos < 3)
+  if (final_dot_pos < 3) {
     return NULL;
+  }
 
   for (i = 0; i < final_dot_pos; i++) {
     /*
@@ -76,8 +77,9 @@ find_wildcard_in_hostname(const unsigned char *p, size_t len, bool idna_subject)
                  ((i < final_dot_pos - 1) && (p[i + 1] == '.'))) { // Found a trailing wildcard in the first label
 
         // IDNA hostnames must match a full label
-        if (idna_subject && (i != 0 || p[i + 1] != '.'))
+        if (idna_subject && (i != 0 || p[i + 1] != '.')) {
           break;
+        }
 
         wildcard_pos = i;
       } else {
@@ -87,8 +89,9 @@ find_wildcard_in_hostname(const unsigned char *p, size_t len, bool idna_subject)
     }
     // String contains at least two dots.
     if (p[i] == '.') {
-      if (wildcard_pos != -1)
+      if (wildcard_pos != -1) {
         return &p[wildcard_pos];
+      }
       // Only valid wildcard is in the first label
       break;
     }
@@ -106,8 +109,9 @@ find_wildcard_in_hostname(const unsigned char *p, size_t len, bool idna_subject)
 static bool
 equal_nocase(const unsigned char *pattern, size_t pattern_len, const unsigned char *subject, size_t subject_len)
 {
-  if (pattern_len != subject_len)
+  if (pattern_len != subject_len) {
     return 0;
+  }
   return (strncasecmp((char *)pattern, (char *)subject, pattern_len) == 0);
 }
 
@@ -115,8 +119,9 @@ equal_nocase(const unsigned char *pattern, size_t pattern_len, const unsigned ch
 static bool
 equal_case(const unsigned char *pattern, size_t pattern_len, const unsigned char *subject, size_t subject_len)
 {
-  if (pattern_len != subject_len)
+  if (pattern_len != subject_len) {
     return 0;
+  }
   return (memcmp(pattern, subject, pattern_len) == 0);
 }
 
@@ -132,32 +137,39 @@ wildcard_match(const unsigned char *prefix, size_t prefix_len, const unsigned ch
   const unsigned char *wildcard_end;
   const unsigned char *p;
 
-  if (subject_len < prefix_len + suffix_len)
+  if (subject_len < prefix_len + suffix_len) {
     return false;
-  if (!equal_nocase(prefix, prefix_len, subject, prefix_len))
+  }
+  if (!equal_nocase(prefix, prefix_len, subject, prefix_len)) {
     return false;
+  }
   wildcard_start = subject + prefix_len;
   wildcard_end   = subject + (subject_len - suffix_len);
-  if (!equal_nocase(wildcard_end, suffix_len, suffix, suffix_len))
+  if (!equal_nocase(wildcard_end, suffix_len, suffix, suffix_len)) {
     return false;
+  }
   /*
    * If the wildcard makes up the entire first label, it must match at
    * least one character.
    */
   if (prefix_len == 0 && *suffix == '.') {
-    if (wildcard_start == wildcard_end)
+    if (wildcard_start == wildcard_end) {
       return false;
+    }
   }
   /* The wildcard may match a literal '*' */
-  if (wildcard_end == wildcard_start + 1 && *wildcard_start == '*')
+  if (wildcard_end == wildcard_start + 1 && *wildcard_start == '*') {
     return true;
+  }
   /*
    * Check that the part matched by the wildcard contains only
    * permitted characters and only matches a single label
    */
-  for (p = wildcard_start; p != wildcard_end; ++p)
-    if (!(('0' <= *p && *p <= '9') || ('A' <= *p && *p <= 'Z') || ('a' <= *p && *p <= 'z') || *p == '-'))
+  for (p = wildcard_start; p != wildcard_end; ++p) {
+    if (!(('0' <= *p && *p <= '9') || ('A' <= *p && *p <= 'Z') || ('a' <= *p && *p <= 'z') || *p == '-')) {
       return false;
+    }
+  }
   return true;
 }
 
@@ -172,11 +184,13 @@ equal_wildcard(const unsigned char *pattern, size_t pattern_len, const unsigned 
    * Subject names starting with '.' can only match a wildcard pattern
    * via a subject sub-domain pattern suffix match (that we don't allow).
    */
-  if (subject_len > 5 && subject[0] != '.')
+  if (subject_len > 5 && subject[0] != '.') {
     wildcard = find_wildcard_in_hostname(pattern, pattern_len, is_idna);
+  }
 
-  if (wildcard == NULL)
+  if (wildcard == NULL) {
     return equal_nocase(pattern, pattern_len, subject, subject_len);
+  }
   return wildcard_match(pattern, wildcard - pattern, wildcard + 1, (pattern + pattern_len) - wildcard - 1, subject, subject_len);
 }
 
@@ -191,11 +205,13 @@ do_check_string(ASN1_STRING *a, int cmp_type, equal_fn equal, const unsigned cha
 {
   bool retval = false;
 
-  if (!a->data || !a->length || cmp_type != a->type)
+  if (!a->data || !a->length || cmp_type != a->type) {
     return false;
+  }
   retval = equal(a->data, a->length, b, blen);
-  if (retval && peername)
+  if (retval && peername) {
     *peername = ats_strndup((char *)a->data, a->length);
+  }
   return retval;
 }
 
@@ -236,13 +252,15 @@ validate_hostname(X509 *x, const unsigned char *hostname, bool is_ip, char **pee
         continue;
       }
 
-      if ((retval = do_check_string(cstr, alt_type, equal, hostname, hostname_len, peername)) == true)
+      if ((retval = do_check_string(cstr, alt_type, equal, hostname, hostname_len, peername)) == true) {
         // We got a match
         break;
+      }
     }
     GENERAL_NAMES_free(gens);
-    if (retval)
+    if (retval) {
       return retval;
+    }
   }
   // No SAN match -- check the subject
   i    = -1;
@@ -256,11 +274,13 @@ validate_hostname(X509 *x, const unsigned char *hostname, bool is_ip, char **pee
     // Convert to UTF-8
     astrlen = ASN1_STRING_to_UTF8(&astr, str);
 
-    if (astrlen < 0)
+    if (astrlen < 0) {
       return -1;
+    }
     retval = equal(astr, astrlen, hostname, hostname_len);
-    if (retval && peername)
+    if (retval && peername) {
       *peername = ats_strndup((char *)astr, astrlen);
+    }
     OPENSSL_free(astr);
     return retval;
   }

--- a/lib/ts/ink_args.cc
+++ b/lib/ts/ink_args.cc
@@ -176,12 +176,13 @@ process_args_ex(const AppVersionInfo *appinfo, const ArgumentDescription *argume
   //
   // Grab Environment Variables
   //
-  for (i = 0; i < n_argument_descriptions; i++)
+  for (i = 0; i < n_argument_descriptions; i++) {
     if (argument_descriptions[i].env) {
       char type = argument_descriptions[i].type[0];
       char *env = getenv(argument_descriptions[i].env);
-      if (!env)
+      if (!env) {
         continue;
+      }
       switch (type) {
       case 'f':
       case 'F':
@@ -199,6 +200,7 @@ process_args_ex(const AppVersionInfo *appinfo, const ArgumentDescription *argume
         break;
       }
     }
+  }
   //
   // Grab Command Line Arguments
   //
@@ -218,7 +220,7 @@ process_args_ex(const AppVersionInfo *appinfo, const ArgumentDescription *argume
 
     if ((*argv)[1] == '-') {
       // Deal with long options ...
-      for (i = 0; i < n_argument_descriptions; i++)
+      for (i = 0; i < n_argument_descriptions; i++) {
         if (!strcmp(argument_descriptions[i].name, (*argv) + 2)) {
           *argv += strlen(*argv) - 1;
           if (!process_arg(appinfo, argument_descriptions, n_argument_descriptions, i, &argv)) {
@@ -226,6 +228,7 @@ process_args_ex(const AppVersionInfo *appinfo, const ArgumentDescription *argume
           }
           break;
         }
+      }
       if (i >= n_argument_descriptions) {
         return false;
       }
@@ -264,21 +267,24 @@ usage(const ArgumentDescription *argument_descriptions, unsigned n_argument_desc
   (void)argument_descriptions;
   (void)n_argument_descriptions;
   (void)usage_string;
-  if (usage_string)
+  if (usage_string) {
     fprintf(stderr, "%s\n", usage_string);
-  else
+  } else {
     fprintf(stderr, "Usage: %s [--SWITCH [ARG]]\n", program_name);
+  }
   fprintf(stderr, "  switch__________________type__default___description\n");
   for (unsigned i = 0; i < n_argument_descriptions; i++) {
-    if (!argument_descriptions[i].description)
+    if (!argument_descriptions[i].description) {
       continue;
+    }
 
     fprintf(stderr, "  ");
 
-    if ('-' == argument_descriptions[i].key)
+    if ('-' == argument_descriptions[i].key) {
       fprintf(stderr, "   ");
-    else
+    } else {
       fprintf(stderr, "-%c,", argument_descriptions[i].key);
+    }
 
     fprintf(stderr, " --%-17s %s", argument_descriptions[i].name,
             argument_types_descriptions[argument_descriptions[i].type ?

--- a/lib/ts/ink_base64.cc
+++ b/lib/ts/ink_base64.cc
@@ -44,8 +44,9 @@ ats_base64_encode(const unsigned char *inBuffer, size_t inBufferSize, char *outB
   char *obuf                   = outBuffer;
   char in_tail[4];
 
-  if (outBufSize < ATS_BASE64_ENCODE_DSTLEN(inBufferSize))
+  if (outBufSize < ATS_BASE64_ENCODE_DSTLEN(inBufferSize)) {
     return false;
+  }
 
   while (inBufferSize > 2) {
     *obuf++ = _codes[(inBuffer[0] >> 2) & 077];
@@ -67,8 +68,9 @@ ats_base64_encode(const unsigned char *inBuffer, size_t inBufferSize, char *outB
    */
   if (inBufferSize == 0) {
     *obuf = '\0';
-    if (length)
+    if (length) {
       *length = (obuf - outBuffer);
+    }
   } else {
     memset(in_tail, 0, sizeof(in_tail));
     memcpy(in_tail, inBuffer, inBufferSize);
@@ -78,13 +80,15 @@ ats_base64_encode(const unsigned char *inBuffer, size_t inBufferSize, char *outB
     *(obuf + 2) = _codes[((in_tail[1] & 017) << 2) | ((in_tail[2] >> 6) & 017)];
     *(obuf + 3) = _codes[in_tail[2] & 077];
 
-    if (inBufferSize == 1)
+    if (inBufferSize == 1) {
       *(obuf + 2) = '=';
-    *(obuf + 3)   = '=';
-    *(obuf + 4)   = '\0';
+    }
+    *(obuf + 3) = '=';
+    *(obuf + 4) = '\0';
 
-    if (length)
+    if (length) {
       *length = (obuf + 4) - outBuffer;
+    }
   }
 
   return true;
@@ -126,13 +130,15 @@ ats_base64_decode(const char *inBuffer, size_t inBufferSize, unsigned char *outB
   int inputBytesDecoded = 0;
 
   // Make sure there is sufficient space in the output buffer
-  if (outBufSize < ATS_BASE64_DECODE_DSTLEN(inBufferSize))
+  if (outBufSize < ATS_BASE64_DECODE_DSTLEN(inBufferSize)) {
     return false;
+  }
 
   // Ignore any trailing ='s or other undecodable characters.
   // TODO: Perhaps that ought to be an error instead?
-  while (printableToSixBit[(uint8_t)inBuffer[inBytes]] <= MAX_PRINT_VAL)
+  while (printableToSixBit[(uint8_t)inBuffer[inBytes]] <= MAX_PRINT_VAL) {
     ++inBytes;
+  }
 
   for (size_t i = 0; i < inBytes; i += 4) {
     buf[0] = (unsigned char)(DECODE(inBuffer[0]) << 2 | DECODE(inBuffer[1]) >> 4);
@@ -156,8 +162,9 @@ ats_base64_decode(const char *inBuffer, size_t inBufferSize, unsigned char *outB
   }
   outBuffer[decodedBytes] = '\0';
 
-  if (length)
+  if (length) {
     *length = decodedBytes;
+  }
 
   return true;
 }

--- a/lib/ts/ink_defs.cc
+++ b/lib/ts/ink_defs.cc
@@ -79,15 +79,17 @@ ink_sys_name_release(char *name, int namelen, char *release, int releaselen)
   mib[0]     = CTL_KERN;
   mib[1]     = KERN_OSTYPE;
 
-  if (sysctl(mib, 2, name, &len, NULL, 0) == -1)
+  if (sysctl(mib, 2, name, &len, NULL, 0) == -1) {
     return -1;
+  }
 
   len    = releaselen;
   mib[0] = CTL_KERN;
   mib[1] = KERN_OSRELEASE;
 
-  if (sysctl(mib, 2, release, &len, NULL, 0) == -1)
+  if (sysctl(mib, 2, release, &len, NULL, 0) == -1) {
     return -1;
+  }
 
   return 0;
 #elif defined(linux)

--- a/lib/ts/ink_file.cc
+++ b/lib/ts/ink_file.cc
@@ -67,11 +67,13 @@ ink_fputln(FILE *stream, const char *s)
 {
   if (stream && s) {
     int rc = fputs(s, stream);
-    if (rc > 0)
+    if (rc > 0) {
       rc += fputc('\n', stream);
+    }
     return rc;
-  } else
+  } else {
     return -EINVAL;
+  }
 } /* End ink_fgets */
 
 /*---------------------------------------------------------------------------*
@@ -99,18 +101,22 @@ ink_file_fd_readline(int fd, int bufsz, char *buf)
   char c;
   int i = 0;
 
-  if (bufsz < 2)
+  if (bufsz < 2) {
     return (-EINVAL); /* bufsz must by >= 2 */
+  }
 
   while (i < bufsz - 1) {    /* leave 1 byte for NUL */
     int n = read(fd, &c, 1); /* read 1 byte */
-    if (n == 0)
+    if (n == 0) {
       break; /* EOF */
-    if (n < 0)
+    }
+    if (n < 0) {
       return (n); /* error */
+    }
     buf[i++] = c; /* store in buffer */
-    if (c == '\n')
+    if (c == '\n') {
       break; /* stop if stored a LF */
+    }
   }
 
   buf[i] = '\0'; /* NUL terminate buffer */
@@ -123,8 +129,9 @@ ink_file_fd_writestring(int fd, const char *buf)
 {
   int len, i = 0;
 
-  if (buf && (len = strlen(buf)) > 0 && (i = (int)write(fd, buf, (size_t)len) != len))
+  if (buf && (len = strlen(buf)) > 0 && (i = (int)write(fd, buf, (size_t)len) != len)) {
     i = -1;
+  }
 
   return i; /* return chars written */
 } /* End ink_file_fd_writestring */
@@ -141,25 +148,28 @@ ink_filepath_merge(char *path, int pathsz, const char *rootpath, const char *add
 
   /* Treat null as an empty path.
   */
-  if (!addpath)
+  if (!addpath) {
     addpath = "";
-
+  }
   if (addpath[0] == '/') {
     // If addpath is rooted, then rootpath is unused.
     // Ths violates any INK_FILEPATH_SECUREROOTTEST and
     // INK_FILEPATH_NOTABSOLUTE flags specified.
     //
-    if (flags & INK_FILEPATH_SECUREROOTTEST)
+    if (flags & INK_FILEPATH_SECUREROOTTEST) {
       return EACCES; // APR_EABOVEROOT;
-    if (flags & INK_FILEPATH_NOTABSOLUTE)
+    }
+    if (flags & INK_FILEPATH_NOTABSOLUTE) {
       return EISDIR; // APR_EABSOLUTE;
+    }
 
     // If INK_FILEPATH_NOTABOVEROOT wasn't specified,
     // we won't test the root again, it's ignored.
     // Waste no CPU retrieving the working path.
     //
-    if (!rootpath && !(flags & INK_FILEPATH_NOTABOVEROOT))
+    if (!rootpath && !(flags & INK_FILEPATH_NOTABOVEROOT)) {
       rootpath = "";
+    }
   } else {
     // If INK_FILEPATH_NOTABSOLUTE is specified, the caller
     // requires a relative result.  If the rootpath is
@@ -167,10 +177,11 @@ ink_filepath_merge(char *path, int pathsz, const char *rootpath, const char *add
     // if rootpath was supplied as absolute then fail.
     //
     if (flags & INK_FILEPATH_NOTABSOLUTE) {
-      if (!rootpath)
+      if (!rootpath) {
         rootpath = "";
-      else if (rootpath[0] == '/')
+      } else if (rootpath[0] == '/') {
         return EISDIR; // APR_EABSOLUTE;
+      }
     }
   }
   if (!rootpath) {
@@ -196,15 +207,17 @@ ink_filepath_merge(char *path, int pathsz, const char *rootpath, const char *add
     // and leave addpath at the first non-'/' character.
     //
     keptlen = 0;
-    while (addpath[0] == '/')
+    while (addpath[0] == '/') {
       ++addpath;
+    }
     path[0] = '/';
     pathlen = 1;
   } else {
     // If both paths are relative, fail early
     //
-    if (rootpath[0] != '/' && (flags & INK_FILEPATH_NOTRELATIVE))
+    if (rootpath[0] != '/' && (flags & INK_FILEPATH_NOTRELATIVE)) {
       return EBADF; // APR_ERELATIVE;
+    }
 
     // Base the result path on the rootpath
     //
@@ -330,9 +343,9 @@ ink_filepath_make(char *path, int pathsz, const char *rootpath, const char *addp
 
   /* Treat null as an empty path.
   */
-  if (!addpath)
+  if (!addpath) {
     addpath = "";
-
+  }
   if (addpath[0] == '/') {
     // If addpath is rooted, then rootpath is unused.
     ink_strlcpy(path, addpath, pathsz);
@@ -517,32 +530,41 @@ ink_fileperm_parse(const char *perms)
   if (perms && strlen(perms) == 9) {
     int re  = 0;
     char *c = (char *)perms;
-    if (*c == 'r')
+    if (*c == 'r') {
       re |= S_IRUSR;
+    }
     c++;
-    if (*c == 'w')
+    if (*c == 'w') {
       re |= S_IWUSR;
+    }
     c++;
-    if (*c == 'x')
+    if (*c == 'x') {
       re |= S_IXUSR;
+    }
     c++;
-    if (*c == 'r')
+    if (*c == 'r') {
       re |= S_IRGRP;
+    }
     c++;
-    if (*c == 'w')
+    if (*c == 'w') {
       re |= S_IWGRP;
+    }
     c++;
-    if (*c == 'x')
+    if (*c == 'x') {
       re |= S_IXGRP;
+    }
     c++;
-    if (*c == 'r')
+    if (*c == 'r') {
       re |= S_IROTH;
+    }
     c++;
-    if (*c == 'w')
+    if (*c == 'w') {
       re |= S_IWOTH;
+    }
     c++;
-    if (*c == 'x')
+    if (*c == 'x') {
       re |= S_IXOTH;
+    }
     return re;
   }
   return -1;

--- a/lib/ts/ink_hash_table.cc
+++ b/lib/ts/ink_hash_table.cc
@@ -60,12 +60,13 @@ ink_hash_table_create(InkHashTableKeyType key_type)
 
   tcl_ht_ptr = (Tcl_HashTable *)ats_malloc(sizeof(Tcl_HashTable));
 
-  if (key_type == InkHashTableKeyType_String)
+  if (key_type == InkHashTableKeyType_String) {
     tcl_key_type = TCL_STRING_KEYS;
-  else if (key_type == InkHashTableKeyType_Word)
+  } else if (key_type == InkHashTableKeyType_Word) {
     tcl_key_type = TCL_ONE_WORD_KEYS;
-  else
+  } else {
     ink_fatal("ink_hash_table_create: bad key_type %d", key_type);
+  }
 
   Tcl_InitHashTable(tcl_ht_ptr, tcl_key_type);
 
@@ -159,8 +160,9 @@ ink_hash_table_lookup(InkHashTable *ht_ptr, const char *key, InkHashTableValue *
   InkHashTableValue value;
 
   he_ptr = ink_hash_table_lookup_entry(ht_ptr, key);
-  if (he_ptr == NULL)
+  if (he_ptr == NULL) {
     return (0);
+  }
 
   value      = ink_hash_table_entry_value(ht_ptr, he_ptr);
   *value_ptr = value;
@@ -188,8 +190,9 @@ ink_hash_table_delete(InkHashTable *ht_ptr, const char *key)
   tcl_ht_ptr = (Tcl_HashTable *)ht_ptr;
   tcl_he_ptr = Tcl_FindHashEntry(tcl_ht_ptr, tcl_key);
 
-  if (!tcl_he_ptr)
+  if (!tcl_he_ptr) {
     return (0);
+  }
   Tcl_DeleteHashEntry(tcl_he_ptr);
 
   return (1);
@@ -310,8 +313,9 @@ ink_hash_table_map(InkHashTable *ht_ptr, InkHashTableEntryFunction map)
 
   for (e = ink_hash_table_iterator_first(ht_ptr, &state); e != NULL; e = ink_hash_table_iterator_next(ht_ptr, &state)) {
     retcode = (*map)(ht_ptr, e);
-    if (retcode != 0)
+    if (retcode != 0) {
       break;
+    }
   }
 } /* End ink_hash_table_map */
 
@@ -412,8 +416,9 @@ ink_hash_table_replace_string(InkHashTable *ht_ptr, char *string_key, char *stri
   he_ptr = ink_hash_table_get_entry(ht_ptr, (InkHashTableKey)string_key, &new_value);
   if (new_value == 0) {
     old_str = (char *)ink_hash_table_entry_value(ht_ptr, he_ptr);
-    if (old_str)
+    if (old_str) {
       ats_free(old_str);
+    }
   }
 
   ink_hash_table_set_entry(ht_ptr, he_ptr, (InkHashTableValue)(ats_strdup(string_value)));

--- a/lib/ts/ink_hrtime.cc
+++ b/lib/ts/ink_hrtime.cc
@@ -85,8 +85,9 @@ int64_to_str(char *buf, unsigned int buf_size, int64_t val, unsigned int *total_
     } else {
       out_buf++;
     }
-    if (req_width > buf_size)
-      req_width              = buf_size;
+    if (req_width > buf_size) {
+      req_width = buf_size;
+    }
     unsigned int num_padding = 0;
     if (req_width > num_chars) {
       num_padding = req_width - num_chars;
@@ -99,8 +100,9 @@ int64_to_str(char *buf, unsigned int buf_size, int64_t val, unsigned int *total_
         *--out_buf = pad_char;
         break;
       default:
-        for (unsigned int i = 0; i < num_padding; ++i, *--out_buf = pad_char)
+        for (unsigned int i = 0; i < num_padding; ++i, *--out_buf = pad_char) {
           ;
+        }
       }
       num_chars += num_padding;
     }
@@ -130,8 +132,9 @@ int64_to_str(char *buf, unsigned int buf_size, int64_t val, unsigned int *total_
     }
   }
 
-  if (total_chars)
+  if (total_chars) {
     *total_chars = num_chars;
+  }
   return out_buf;
 }
 

--- a/lib/ts/ink_inet.cc
+++ b/lib/ts/ink_inet.cc
@@ -45,8 +45,9 @@ ink_gethostbyname_r(char *hostname, ink_gethostbyname_r_data *data)
 {
 #ifdef RENTRENT_GETHOSTBYNAME
   struct hostent *r = gethostbyname(hostname);
-  if (r)
-    data->ent  = *r;
+  if (r) {
+    data->ent = *r;
+  }
   data->herrno = errno;
 
 #else // RENTRENT_GETHOSTBYNAME
@@ -104,10 +105,11 @@ ink_inet_addr(const char *s)
     // handle hex, octal
 
     if (*pc == '0') {
-      if (*++pc == 'x' || *pc == 'X')
+      if (*++pc == 'x' || *pc == 'X') {
         base = 16, pc++;
-      else
+      } else {
         base = 8;
+      }
     }
     // handle hex, octal, decimal
 
@@ -124,29 +126,34 @@ ink_inet_addr(const char *s)
     }
 
     n++;
-    if (*pc == '.')
+    if (*pc == '.') {
       pc++;
-    else
+    } else {
       break;
+    }
   }
 
-  if (*pc && !ParseRules::is_wslfcr(*pc))
+  if (*pc && !ParseRules::is_wslfcr(*pc)) {
     return htonl((uint32_t)-1);
+  }
 
   switch (n) {
   case 1:
     return htonl(u[0]);
   case 2:
-    if (u[0] > 0xff || u[1] > 0xffffff)
+    if (u[0] > 0xff || u[1] > 0xffffff) {
       return htonl((uint32_t)-1);
+    }
     return htonl((u[0] << 24) | u[1]);
   case 3:
-    if (u[0] > 0xff || u[1] > 0xff || u[2] > 0xffff)
+    if (u[0] > 0xff || u[1] > 0xff || u[2] > 0xffff) {
       return htonl((uint32_t)-1);
+    }
     return htonl((u[0] << 24) | (u[1] << 16) | u[2]);
   case 4:
-    if (u[0] > 0xff || u[1] > 0xff || u[2] > 0xff || u[3] > 0xff)
+    if (u[0] > 0xff || u[1] > 0xff || u[2] > 0xff || u[3] > 0xff) {
       return htonl((uint32_t)-1);
+    }
     return htonl((u[0] << 24) | (u[1] << 16) | (u[2] << 8) | u[3]);
   }
   return htonl((uint32_t)-1);
@@ -191,20 +198,24 @@ ats_ip_parse(ts::ConstBuffer src, ts::ConstBuffer *addr, ts::ConstBuffer *port, 
 {
   // In case the incoming arguments are null.
   ts::ConstBuffer localAddr, localPort;
-  if (!addr)
+  if (!addr) {
     addr = &localAddr;
-  if (!port)
+  }
+  if (!port) {
     port = &localPort;
+  }
   addr->reset();
   port->reset();
-  if (rest)
+  if (rest) {
     rest->reset();
+  }
 
   // Let's see if we can find out what's in the address string.
   if (src) {
     bool colon_p = false;
-    while (src && ParseRules::is_ws(*src))
+    while (src && ParseRules::is_ws(*src)) {
       ++src;
+    }
     // Check for brackets.
     if ('[' == *src) {
       /* Ugly. In a number of places we must use bracket notation
@@ -239,8 +250,9 @@ ats_ip_parse(ts::ConstBuffer src, ts::ConstBuffer *addr, ts::ConstBuffer *port, 
     }
     if (colon_p) {
       ts::ConstBuffer tmp(src);
-      while (src && ParseRules::is_digit(*src))
+      while (src && ParseRules::is_digit(*src)) {
         ++src;
+      }
 
       if (tmp.data() == src.data()) {            // no digits at all
         src.set(tmp.data() - 1, tmp.size() + 1); // back up to include colon
@@ -248,8 +260,9 @@ ats_ip_parse(ts::ConstBuffer src, ts::ConstBuffer *addr, ts::ConstBuffer *port, 
         *port = tmp.clip(src.data());
       }
     }
-    if (rest)
+    if (rest) {
       *rest = src;
+    }
   }
   return *addr ? 0 : -1; // true if we found an address.
 }
@@ -283,8 +296,9 @@ ats_ip_pton(const ts::ConstBuffer &src, sockaddr *ip)
       }
     }
     // If we had a successful conversion, set the port.
-    if (ats_is_ip(ip))
+    if (ats_is_ip(ip)) {
       ats_ip_port_cast(ip) = port ? htons(atoi(port.data())) : 0;
+    }
   }
 
   return zret;
@@ -350,12 +364,13 @@ ats_ip_to_hex(sockaddr const *src, char *dst, size_t len)
 sockaddr *
 ats_ip_set(sockaddr *dst, IpAddr const &addr, uint16_t port)
 {
-  if (AF_INET == addr._family)
+  if (AF_INET == addr._family) {
     ats_ip4_set(dst, addr._addr._ip4, port);
-  else if (AF_INET6 == addr._family)
+  } else if (AF_INET6 == addr._family) {
     ats_ip6_set(dst, addr._addr._ip6, port);
-  else
+  } else {
     ats_ip_invalidate(dst);
+  }
   return dst;
 }
 
@@ -436,12 +451,13 @@ IpAddr::cmp(self const &that) const
     if (AF_INET == rtype) {
       in_addr_t la = ntohl(_addr._ip4);
       in_addr_t ra = ntohl(that._addr._ip4);
-      if (la < ra)
+      if (la < ra) {
         zret = -1;
-      else if (la > ra)
+      } else if (la > ra) {
         zret = 1;
-      else
+      } else {
         zret = 0;
+      }
     } else if (AF_INET6 == rtype) { // IPv4 < IPv6
       zret = -1;
     } else { // IP > not IP
@@ -473,10 +489,12 @@ ats_ip_getbestaddrinfo(char const *host, IpEndpoint *ip4, IpEndpoint *ip6)
   ts::ConstBuffer addr_text, port_text;
   ts::ConstBuffer src(host, strlen(host) + 1);
 
-  if (ip4)
+  if (ip4) {
     ats_ip_invalidate(ip4);
-  if (ip6)
+  }
+  if (ip6) {
     ats_ip_invalidate(ip6);
+  }
 
   if (0 == ats_ip_parse(src, &addr_text, &port_text)) {
     // Copy if not terminated.
@@ -507,21 +525,23 @@ ats_ip_getbestaddrinfo(char const *host, IpEndpoint *ip4, IpEndpoint *ip6)
 
       for (addrinfo *ai_spot = ai_result; ai_spot; ai_spot = ai_spot->ai_next) {
         sockaddr const *ai_ip = ai_spot->ai_addr;
-        if (!ats_is_ip(ai_ip))
+        if (!ats_is_ip(ai_ip)) {
           spot_type = NA;
-        else if (ats_is_ip_loopback(ai_ip))
+        } else if (ats_is_ip_loopback(ai_ip)) {
           spot_type = LO;
-        else if (ats_is_ip_linklocal(ai_ip))
+        } else if (ats_is_ip_linklocal(ai_ip)) {
           spot_type = LL;
-        else if (ats_is_ip_private(ai_ip))
+        } else if (ats_is_ip_private(ai_ip)) {
           spot_type = PR;
-        else if (ats_is_ip_multicast(ai_ip))
+        } else if (ats_is_ip_multicast(ai_ip)) {
           spot_type = MC;
-        else
+        } else {
           spot_type = GL;
+        }
 
-        if (spot_type == NA)
+        if (spot_type == NA) {
           continue; // Next!
+        }
 
         if (ats_is_ip4(ai_ip)) {
           if (spot_type > ip4_type) {
@@ -535,10 +555,12 @@ ats_ip_getbestaddrinfo(char const *host, IpEndpoint *ip4, IpEndpoint *ip6)
           }
         }
       }
-      if (ip4_type > NA)
+      if (ip4_type > NA) {
         ats_ip_copy(ip4, ip4_src);
-      if (ip6_type > NA)
+      }
+      if (ip6_type > NA) {
         ats_ip_copy(ip6, ip6_src);
+      }
       freeaddrinfo(ai_result); // free *after* the copy.
     }
   }
@@ -546,15 +568,19 @@ ats_ip_getbestaddrinfo(char const *host, IpEndpoint *ip4, IpEndpoint *ip6)
   // We don't really care if the port is null terminated - the parser
   // would get all the digits so the next character is a non-digit (null or
   // not) and atoi will do the right thing in either case.
-  if (port_text.size())
+  if (port_text.size()) {
     port = htons(atoi(port_text.data()));
-  if (ats_is_ip(ip4))
+  }
+  if (ats_is_ip(ip4)) {
     ats_ip_port_cast(ip4) = port;
-  if (ats_is_ip(ip6))
+  }
+  if (ats_is_ip(ip6)) {
     ats_ip_port_cast(ip6) = port;
+  }
 
-  if (!ats_is_ip(ip4) && !ats_is_ip(ip6))
+  if (!ats_is_ip(ip4) && !ats_is_ip(ip6)) {
     zret = -1;
+  }
 
   return zret;
 }
@@ -564,15 +590,17 @@ ats_ip_check_characters(ts::ConstBuffer text)
 {
   bool found_colon = false;
   bool found_hex   = false;
-  for (char const *p = text.data(), *limit = p + text.size(); p < limit; ++p)
-    if (':' == *p)
+  for (char const *p = text.data(), *limit = p + text.size(); p < limit; ++p) {
+    if (':' == *p) {
       found_colon = true;
-    else if ('.' == *p || isdigit(*p)) /* empty */
+    } else if ('.' == *p || isdigit(*p)) { /* empty */
       ;
-    else if (isxdigit(*p))
+    } else if (isxdigit(*p)) {
       found_hex = true;
-    else
+    } else {
       return AF_UNSPEC;
+    }
+  }
 
   return found_hex && !found_colon ? AF_UNSPEC : found_colon ? AF_INET6 : AF_INET;
 }

--- a/lib/ts/ink_memory.cc
+++ b/lib/ts/ink_memory.cc
@@ -91,8 +91,9 @@ ats_memalign(size_t alignment, size_t size)
   void *ptr;
 
 #if HAVE_POSIX_MEMALIGN || TS_HAS_JEMALLOC
-  if (alignment <= 8)
+  if (alignment <= 8) {
     return ats_malloc(size);
+  }
 
 #if defined(openbsd)
   if (alignment > PAGE_SIZE)
@@ -122,23 +123,26 @@ ats_memalign(size_t alignment, size_t size)
 void
 ats_free(void *ptr)
 {
-  if (likely(ptr != NULL))
+  if (likely(ptr != NULL)) {
     free(ptr);
+  }
 } /* End ats_free */
 
 void *
 ats_free_null(void *ptr)
 {
-  if (likely(ptr != NULL))
+  if (likely(ptr != NULL)) {
     free(ptr);
+  }
   return NULL;
 } /* End ats_free_null */
 
 void
 ats_memalign_free(void *ptr)
 {
-  if (likely(ptr))
+  if (likely(ptr)) {
     free(ptr);
+  }
 }
 
 // This effectively makes mallopt() a no-op (currently) when tcmalloc
@@ -172,8 +176,9 @@ ats_msync(caddr_t addr, size_t len, caddr_t end, int flags)
   caddr_t a = (caddr_t)(((uintptr_t)addr) & ~(pagesize - 1));
   // align length to page boundry covering region
   size_t l = (len + (addr - a) + (pagesize - 1)) & ~(pagesize - 1);
-  if ((a + l) > end)
+  if ((a + l) > end) {
     l = end - a; // strict limit
+  }
 #if defined(linux)
 /* Fix INKqa06500
    Under Linux, msync(..., MS_SYNC) calls are painfully slow, even on
@@ -262,8 +267,9 @@ _xstrdup(const char *str, int length, const char * /* path ATS_UNUSED */)
   char *newstr;
 
   if (likely(str)) {
-    if (length < 0)
+    if (length < 0) {
       length = strlen(str);
+    }
 
     newstr = (char *)ats_malloc(length + 1);
     // If this is a zero length string just null terminate and return.

--- a/lib/ts/ink_rand.cc
+++ b/lib/ts/ink_rand.cc
@@ -74,8 +74,9 @@ void
 InkRand::seed(uint64_t seed)
 {
   mt[0] = seed;
-  for (mti  = 1; mti < NN; mti++)
+  for (mti = 1; mti < NN; mti++) {
     mt[mti] = (6364136223846793005ULL * (mt[mti - 1] ^ (mt[mti - 1] >> 62)) + mti);
+  }
 }
 
 uint64_t

--- a/lib/ts/ink_res_init.cc
+++ b/lib/ts/ink_res_init.cc
@@ -136,8 +136,9 @@ ink_res_setservers(ink_res_state statp, IpEndpoint const *set, int cnt)
     IpEndpoint *dst = &statp->nsaddr_list[nserv];
 
     if (dst == set) {
-      if (ats_is_ip(&set->sa))
+      if (ats_is_ip(&set->sa)) {
         ++nserv;
+      }
     } else if (ats_ip_copy(&dst->sa, &set->sa)) {
       ++nserv;
     }
@@ -167,33 +168,39 @@ ink_res_setoptions(ink_res_state statp, const char *options, const char *source 
   int i;
 
 #ifdef DEBUG
-  if (statp->options & INK_RES_DEBUG)
+  if (statp->options & INK_RES_DEBUG) {
     printf(";; res_setoptions(\"%s\", \"%s\")...\n", options, source);
+  }
 #endif
   while (*cp) {
     /* skip leading and inner runs of spaces */
-    while (*cp == ' ' || *cp == '\t')
+    while (*cp == ' ' || *cp == '\t') {
       cp++;
+    }
     /* search for and process individual options */
     if (!strncmp(cp, "ndots:", sizeof("ndots:") - 1)) {
       i = atoi(cp + sizeof("ndots:") - 1);
-      if (i <= INK_RES_MAXNDOTS)
+      if (i <= INK_RES_MAXNDOTS) {
         statp->ndots = i;
-      else
+      } else {
         statp->ndots = INK_RES_MAXNDOTS;
+      }
 #ifdef DEBUG
-      if (statp->options & INK_RES_DEBUG)
+      if (statp->options & INK_RES_DEBUG) {
         printf(";;\tndots=%d\n", statp->ndots);
+      }
 #endif
     } else if (!strncmp(cp, "timeout:", sizeof("timeout:") - 1)) {
       i = atoi(cp + sizeof("timeout:") - 1);
-      if (i <= INK_RES_MAXRETRANS)
+      if (i <= INK_RES_MAXRETRANS) {
         statp->retrans = i;
-      else
+      } else {
         statp->retrans = INK_RES_MAXRETRANS;
+      }
 #ifdef DEBUG
-      if (statp->options & INK_RES_DEBUG)
+      if (statp->options & INK_RES_DEBUG) {
         printf(";;\ttimeout=%d\n", statp->retrans);
+      }
 #endif
 #ifdef SOLARIS2
     } else if (!strncmp(cp, "retrans:", sizeof("retrans:") - 1)) {
@@ -213,13 +220,15 @@ ink_res_setoptions(ink_res_state statp, const char *options, const char *source 
 #endif /* SOLARIS2 */
     } else if (!strncmp(cp, "attempts:", sizeof("attempts:") - 1)) {
       i = atoi(cp + sizeof("attempts:") - 1);
-      if (i <= INK_RES_MAXRETRY)
+      if (i <= INK_RES_MAXRETRY) {
         statp->retry = i;
-      else
+      } else {
         statp->retry = INK_RES_MAXRETRY;
+      }
 #ifdef DEBUG
-      if (statp->options & INK_RES_DEBUG)
+      if (statp->options & INK_RES_DEBUG) {
         printf(";;\tattempts=%d\n", statp->retry);
+      }
 #endif
     } else if (!strncmp(cp, "debug", sizeof("debug") - 1)) {
 #ifdef DEBUG
@@ -250,8 +259,9 @@ ink_res_setoptions(ink_res_state statp, const char *options, const char *source 
       /* XXX - print a warning here? */
     }
     /* skip to next run of spaces */
-    while (*cp && *cp != ' ' && *cp != '\t')
+    while (*cp && *cp != ' ' && *cp != '\t') {
       cp++;
+    }
   }
 }
 
@@ -358,9 +368,9 @@ ink_res_init(ink_res_state statp,         ///< State object to update.
     pp    = statp->dnsrch;
     *pp++ = cp;
     for (n = 0; *cp && pp < statp->dnsrch + INK_MAXDNSRCH; cp++) {
-      if (*cp == '\n') /*%< silly backwards compat */
+      if (*cp == '\n') { /*%< silly backwards compat */
         break;
-      else if (*cp == ' ' || *cp == '\t') {
+      } else if (*cp == ' ' || *cp == '\t') {
         *cp = 0;
         n   = 1;
       } else if (n) {
@@ -370,8 +380,9 @@ ink_res_init(ink_res_state statp,         ///< State object to update.
       }
     }
     /* null terminate last domain if there are excess */
-    while (*cp != '\0' && *cp != ' ' && *cp != '\t' && *cp != '\n')
+    while (*cp != '\0' && *cp != ' ' && *cp != '\t' && *cp != '\n') {
       cp++;
+    }
     *cp   = '\0';
     *pp++ = 0;
   }
@@ -387,17 +398,19 @@ ink_res_init(ink_res_state statp,         ///< State object to update.
 
   if (pDefDomain && '\0' != *pDefDomain && '\n' != *pDefDomain) {
     ink_strlcpy(statp->defdname, pDefDomain, sizeof(statp->defdname));
-    if ((cp = strpbrk(statp->defdname, " \t\n")) != NULL)
+    if ((cp = strpbrk(statp->defdname, " \t\n")) != NULL) {
       *cp = '\0';
+    }
   }
   if (pSearchList && '\0' != *pSearchList && '\n' != *pSearchList) {
     ink_strlcpy(statp->defdname, pSearchList, sizeof(statp->defdname));
-    if ((cp = strchr(statp->defdname, '\n')) != NULL)
+    if ((cp = strchr(statp->defdname, '\n')) != NULL) {
       *cp = '\0';
-    /*
-     * Set search list to be blank-separated strings
-     * on rest of line.
-     */
+      /*
+       * Set search list to be blank-separated strings
+       * on rest of line.
+       */
+    }
     cp    = statp->defdname;
     pp    = statp->dnsrch;
     *pp++ = cp;
@@ -411,8 +424,9 @@ ink_res_init(ink_res_state statp,         ///< State object to update.
       }
     }
     /* null terminate last domain if there are excess */
-    while (*cp != '\0' && *cp != ' ' && *cp != '\t')
+    while (*cp != '\0' && *cp != ' ' && *cp != '\t') {
       cp++;
+    }
     *cp        = '\0';
     *pp++      = 0;
     havesearch = 1;
@@ -422,8 +436,9 @@ ink_res_init(ink_res_state statp,         ///< State object to update.
      we must be provided with atleast a named!
      ------------------------------------------- */
   if (pHostList) {
-    if (pHostListSize > INK_MAXNS)
+    if (pHostListSize > INK_MAXNS) {
       pHostListSize = INK_MAXNS;
+    }
     for (; nserv < pHostListSize && ats_is_ip(&pHostList[nserv].sa); ++nserv) {
       ats_ip_copy(&statp->nsaddr_list[nserv].sa, &pHostList[nserv].sa);
     }
@@ -436,39 +451,48 @@ ink_res_init(ink_res_state statp,         ///< State object to update.
     /* read the config file */
     while (fgets(buf, sizeof(buf), fp) != NULL) {
       /* skip comments */
-      if (*buf == ';' || *buf == '#')
+      if (*buf == ';' || *buf == '#') {
         continue;
+      }
       /* read default domain name */
       if (MATCH(buf, "domain")) {
-        if (haveenv) /*%< skip if have from environ */
+        if (haveenv) { /*%< skip if have from environ */
           continue;
+        }
         cp = buf + sizeof("domain") - 1;
-        while (*cp == ' ' || *cp == '\t')
+        while (*cp == ' ' || *cp == '\t') {
           cp++;
-        if ((*cp == '\0') || (*cp == '\n'))
+        }
+        if ((*cp == '\0') || (*cp == '\n')) {
           continue;
+        }
         ink_strlcpy(statp->defdname, cp, sizeof(statp->defdname));
-        if ((cp = strpbrk(statp->defdname, " \t\n")) != NULL)
-          *cp      = '\0';
+        if ((cp = strpbrk(statp->defdname, " \t\n")) != NULL) {
+          *cp = '\0';
+        }
         havesearch = 0;
         continue;
       }
       /* set search list */
       if (MATCH(buf, "search")) {
-        if (haveenv) /*%< skip if have from environ */
+        if (haveenv) { /*%< skip if have from environ */
           continue;
+        }
         cp = buf + sizeof("search") - 1;
-        while (*cp == ' ' || *cp == '\t')
+        while (*cp == ' ' || *cp == '\t') {
           cp++;
-        if ((*cp == '\0') || (*cp == '\n'))
+        }
+        if ((*cp == '\0') || (*cp == '\n')) {
           continue;
+        }
         ink_strlcpy(statp->defdname, cp, sizeof(statp->defdname));
-        if ((cp = strchr(statp->defdname, '\n')) != NULL)
+        if ((cp = strchr(statp->defdname, '\n')) != NULL) {
           *cp = '\0';
-        /*
-         * Set search list to be blank-separated strings
-         * on rest of line.
-         */
+          /*
+           * Set search list to be blank-separated strings
+           * on rest of line.
+           */
+        }
         cp    = statp->defdname;
         pp    = statp->dnsrch;
         *pp++ = cp;
@@ -482,8 +506,9 @@ ink_res_init(ink_res_state statp,         ///< State object to update.
           }
         }
         /* null terminate last domain if there are excess */
-        while (*cp != '\0' && *cp != ' ' && *cp != '\t')
+        while (*cp != '\0' && *cp != ' ' && *cp != '\t') {
           cp++;
+        }
         *cp        = '\0';
         *pp++      = 0;
         havesearch = 1;
@@ -492,8 +517,9 @@ ink_res_init(ink_res_state statp,         ///< State object to update.
       /* read nameservers to query */
       if (MATCH(buf, "nameserver") && nserv < maxns) {
         cp = buf + sizeof("nameserver") - 1;
-        while (*cp == ' ' || *cp == '\t')
+        while (*cp == ' ' || *cp == '\t') {
           cp++;
+        }
         if ((*cp != '\0') && (*cp != '\n')) {
           ts::ConstBuffer host(cp, strcspn(cp, ";# \t\n"));
           if (0 == ats_ip_pton(host, &statp->nsaddr_list[nserv].sa)) {
@@ -514,11 +540,13 @@ ink_res_init(ink_res_state statp,         ///< State object to update.
     (void)fclose(fp);
   }
 
-  if (nserv > 0)
+  if (nserv > 0) {
     statp->nscount = nserv;
+  }
 
-  if (statp->defdname[0] == 0 && gethostname(buf, sizeof(statp->defdname) - 1) == 0 && (cp = strchr(buf, '.')) != NULL)
+  if (statp->defdname[0] == 0 && gethostname(buf, sizeof(statp->defdname) - 1) == 0 && (cp = strchr(buf, '.')) != NULL) {
     ink_strlcpy(statp->defdname, cp + 1, sizeof(statp->defdname));
+  }
 
   /* find components of local domain that might be searched */
   if (havesearch == 0) {
@@ -528,13 +556,15 @@ ink_res_init(ink_res_state statp,         ///< State object to update.
 
     if (dnsSearch == 1) {
       dots = 0;
-      for (cp = statp->defdname; *cp; cp++)
+      for (cp = statp->defdname; *cp; cp++) {
         dots += (*cp == '.');
+      }
 
       cp = statp->defdname;
       while (pp < statp->dnsrch + INK_MAXDFLSRCH) {
-        if (dots < INK_LOCALDOMAINPARTS)
+        if (dots < INK_LOCALDOMAINPARTS) {
           break;
+        }
         cp    = strchr(cp, '.') + 1; /*%< we know there is one */
         *pp++ = cp;
         dots--;
@@ -544,8 +574,9 @@ ink_res_init(ink_res_state statp,         ///< State object to update.
 #ifdef DEBUG
     if (statp->options & INK_RES_DEBUG) {
       printf(";; res_init()... default dnsrch list:\n");
-      for (pp = statp->dnsrch; *pp; pp++)
+      for (pp = statp->dnsrch; *pp; pp++) {
         printf(";;\t%s\n", *pp);
+      }
       printf(";;\t..END..\n");
     }
 #endif
@@ -554,8 +585,9 @@ ink_res_init(ink_res_state statp,         ///< State object to update.
   /* export all ns servers to DNSprocessor. */
   ink_res_setservers(statp, &statp->nsaddr_list[0], statp->nscount);
 
-  if ((cp = getenv("RES_OPTIONS")) != NULL)
+  if ((cp = getenv("RES_OPTIONS")) != NULL) {
     ink_res_setoptions(statp, cp, "env");
+  }
   statp->options |= INK_RES_INIT;
   return (statp->res_h_errno);
 }
@@ -572,8 +604,9 @@ parse_host_res_preference(char const *value, HostResPreferenceOrder order)
 
   n = tokens.Initialize(value);
 
-  for (i     = 0; i < N_HOST_RES_PREFERENCE; ++i)
+  for (i = 0; i < N_HOST_RES_PREFERENCE; ++i) {
     found[i] = false;
+  }
 
   for (i = 0; i < n && np < N_HOST_RES_PREFERENCE_ORDER; ++i) {
     char const *elt = tokens[i];
@@ -600,12 +633,15 @@ parse_host_res_preference(char const *value, HostResPreferenceOrder order)
 
   if (!found[HOST_RES_PREFER_NONE]) {
     // If 'only' wasn't explicit, fill in the rest by default.
-    if (!found[HOST_RES_PREFER_IPV4])
+    if (!found[HOST_RES_PREFER_IPV4]) {
       order[np++] = HOST_RES_PREFER_IPV4;
-    if (!found[HOST_RES_PREFER_IPV6])
+    }
+    if (!found[HOST_RES_PREFER_IPV6]) {
       order[np++] = HOST_RES_PREFER_IPV6;
-    if (np < N_HOST_RES_PREFERENCE_ORDER) // was N_HOST_RES_PREFERENCE)
+    }
+    if (np < N_HOST_RES_PREFERENCE_ORDER) { // was N_HOST_RES_PREFERENCE)
       order[np] = HOST_RES_PREFER_NONE;
+    }
   }
 }
 
@@ -621,8 +657,9 @@ ts_host_res_order_to_string(HostResPreferenceOrder const &order, char *out, int 
      * resolution key words.
      */
     zret += snprintf(out + zret, size - zret, "%s%s", !first ? ";" : "", HOST_RES_PREFERENCE_STRING[order[i]]);
-    if (HOST_RES_PREFER_NONE == order[i])
+    if (HOST_RES_PREFER_NONE == order[i]) {
       break;
+    }
     first = false;
   }
   return zret;

--- a/lib/ts/ink_res_mkquery.cc
+++ b/lib/ts/ink_res_mkquery.cc
@@ -105,8 +105,9 @@ int ink_res_mkquery(ink_res_state statp, int op,               /*!< opcode of qu
   /*
    * Initialize header fields.
    */
-  if ((buf == NULL) || (buflen < HFIXEDSZ))
+  if ((buf == NULL) || (buflen < HFIXEDSZ)) {
     return (-1);
+  }
   memset(buf, 0, HFIXEDSZ);
   hp         = (HEADER *)buf;
   hp->id     = htons(++statp->id);
@@ -125,24 +126,29 @@ int ink_res_mkquery(ink_res_state statp, int op,               /*!< opcode of qu
   switch (op) {
   case QUERY: /*FALLTHROUGH*/
   case NS_NOTIFY_OP:
-    if (ep - cp < QFIXEDSZ)
+    if (ep - cp < QFIXEDSZ) {
       return (-1);
-    if ((n = dn_comp(dname, cp, ep - cp - QFIXEDSZ, dnptrs, lastdnptr)) < 0)
+    }
+    if ((n = dn_comp(dname, cp, ep - cp - QFIXEDSZ, dnptrs, lastdnptr)) < 0) {
       return (-1);
+    }
     cp += n;
     NS_PUT16(type, cp);
     NS_PUT16(_class, cp);
     hp->qdcount = htons(1);
-    if (op == QUERY || data == NULL)
+    if (op == QUERY || data == NULL) {
       break;
+    }
     /*
      * Make an additional record for completion domain.
      */
-    if ((ep - cp) < RRFIXEDSZ)
+    if ((ep - cp) < RRFIXEDSZ) {
       return (-1);
+    }
     n = dn_comp((const char *)data, cp, ep - cp - RRFIXEDSZ, dnptrs, lastdnptr);
-    if (n < 0)
+    if (n < 0) {
       return (-1);
+    }
     cp += n;
     NS_PUT16(T_NULL, cp);
     NS_PUT16(_class, cp);
@@ -155,8 +161,9 @@ int ink_res_mkquery(ink_res_state statp, int op,               /*!< opcode of qu
     /*
      * Initialize answer section
      */
-    if (ep - cp < 1 + RRFIXEDSZ + datalen)
+    if (ep - cp < 1 + RRFIXEDSZ + datalen) {
       return (-1);
+    }
     *cp++ = '\0'; /*%< no domain name */
     NS_PUT16(type, cp);
     NS_PUT16(_class, cp);
@@ -205,8 +212,9 @@ labellen(const u_char *lp)
 
   if ((l & NS_CMPRSFLGS) == INK_NS_TYPE_ELT) {
     if (l == INK_DNS_LABELTYPE_BITSTRING) {
-      if ((bitlen = *(lp + 1)) == 0)
+      if ((bitlen = *(lp + 1)) == 0) {
         bitlen = 256;
+      }
       return ((bitlen + 7) / 8 + 1);
     }
     return (-1); /*%< unknwon ELT */
@@ -221,40 +229,47 @@ decode_bitstring(const unsigned char **cpp, char *dn, const char *eom)
   char *beg               = dn, tc;
   int b, blen, plen, i;
 
-  if ((blen = (*cp & 0xff)) == 0)
+  if ((blen = (*cp & 0xff)) == 0) {
     blen = 256;
-  plen   = (blen + 3) / 4;
+  }
+  plen = (blen + 3) / 4;
   plen += sizeof("\\[x/]") + (blen > 99 ? 3 : (blen > 9) ? 2 : 1);
-  if (dn + plen >= eom)
+  if (dn + plen >= eom) {
     return (-1);
+  }
 
   cp++;
   i = SPRINTF((dn, "\\[x"));
-  if (i < 0)
+  if (i < 0) {
     return (-1);
+  }
   dn += i;
   for (b = blen; b > 7; b -= 8, cp++) {
     i = SPRINTF((dn, "%02x", *cp & 0xff));
-    if (i < 0)
+    if (i < 0) {
       return (-1);
+    }
     dn += i;
   }
   if (b > 4) {
     tc = *cp++;
     i  = SPRINTF((dn, "%02x", tc & (0xff << (8 - b))));
-    if (i < 0)
+    if (i < 0) {
       return (-1);
+    }
     dn += i;
   } else if (b > 0) {
     tc = *cp++;
     i  = SPRINTF((dn, "%1x", ((tc >> 4) & 0x0f) & (0x0f << (4 - b))));
-    if (i < 0)
+    if (i < 0) {
       return (-1);
+    }
     dn += i;
   }
   i = SPRINTF((dn, "/%d]", blen));
-  if (i < 0)
+  if (i < 0) {
     return (-1);
+  }
   dn += i;
 
   *cpp = cp;
@@ -502,26 +517,30 @@ ats_host_res_from(int family, HostResPreferenceOrder order)
 
   for (int i = 0; i < N_HOST_RES_PREFERENCE_ORDER; ++i) {
     HostResPreference p = order[i];
-    if (HOST_RES_PREFER_CLIENT == p)
+    if (HOST_RES_PREFER_CLIENT == p) {
       p = client; // CLIENT -> actual value
+    }
     if (HOST_RES_PREFER_IPV4 == p) {
-      if (v6)
+      if (v6) {
         return HOST_RES_IPV6;
-      else
+      } else {
         v4 = true;
+      }
     } else if (HOST_RES_PREFER_IPV6 == p) {
-      if (v4)
+      if (v4) {
         return HOST_RES_IPV4;
-      else
+      } else {
         v6 = true;
+      }
     } else {
       break;
     }
   }
-  if (v4)
+  if (v4) {
     return HOST_RES_IPV4_ONLY;
-  else if (v6)
+  } else if (v6) {
     return HOST_RES_IPV6_ONLY;
+  }
   return HOST_RES_NONE;
 }
 
@@ -529,9 +548,10 @@ HostResStyle
 ats_host_res_match(sockaddr const *addr)
 {
   HostResStyle zret = HOST_RES_NONE;
-  if (ats_is_ip6(addr))
+  if (ats_is_ip6(addr)) {
     zret = HOST_RES_IPV6_ONLY;
-  else if (ats_is_ip4(addr))
+  } else if (ats_is_ip4(addr)) {
     zret = HOST_RES_IPV4_ONLY;
+  }
   return zret;
 }

--- a/lib/ts/ink_sock.cc
+++ b/lib/ts/ink_sock.cc
@@ -91,8 +91,9 @@ int
 safe_set_fl(int fd, int arg)
 {
   int flags = safe_fcntl(fd, F_GETFL, 0);
-  if (flags < 0)
+  if (flags < 0) {
     return flags;
+  }
   flags |= arg;
   flags = safe_fcntl(fd, F_SETFL, flags);
   return flags;
@@ -102,8 +103,9 @@ int
 safe_clr_fl(int fd, int arg)
 {
   int flags = safe_fcntl(fd, F_GETFL, 0);
-  if (flags < 0)
+  if (flags < 0) {
     return flags;
+  }
   flags &= ~arg;
   flags = safe_fcntl(fd, F_SETFL, flags);
   return flags;
@@ -128,12 +130,15 @@ write_ready(int fd, int timeout_msec)
   p.events = POLLOUT;
   p.fd     = fd;
   int r    = poll(&p, 1, timeout_msec);
-  if (r <= 0)
+  if (r <= 0) {
     return r;
-  if (p.revents & (POLLERR | POLLNVAL))
+  }
+  if (p.revents & (POLLERR | POLLNVAL)) {
     return -1;
-  if (p.revents & (POLLOUT | POLLHUP))
+  }
+  if (p.revents & (POLLOUT | POLLHUP)) {
     return 1;
+  }
   return 0;
 }
 
@@ -144,12 +149,15 @@ read_ready(int fd, int timeout_msec)
   p.events = POLLIN;
   p.fd     = fd;
   int r    = poll(&p, 1, timeout_msec);
-  if (r <= 0)
+  if (r <= 0) {
     return r;
-  if (p.revents & (POLLERR | POLLNVAL))
+  }
+  if (p.revents & (POLLERR | POLLNVAL)) {
     return -1;
-  if (p.revents & (POLLIN | POLLHUP))
+  }
+  if (p.revents & (POLLIN | POLLHUP)) {
     return 1;
+  }
   return 0;
 }
 
@@ -211,8 +219,9 @@ fd_read_char(int fd)
   int r;
   do {
     r = read(fd, &c, 1);
-    if (r > 0)
+    if (r > 0) {
       return c;
+    }
   } while (r < 0 && (errno == EAGAIN || errno == EINTR));
   perror("fd_read_char");
   ink_assert(!"fd_read_char");
@@ -226,18 +235,21 @@ fd_read_line(int fd, char *s, int len)
   int numread = 0, r;
   // char *buf = s;
   do {
-    do
+    do {
       r = read(fd, &c, 1);
-    while (r < 0 && (errno == EAGAIN || errno == EINTR));
+    } while (r < 0 && (errno == EAGAIN || errno == EINTR));
 
-    if (r <= 0 && numread)
+    if (r <= 0 && numread) {
       break;
+    }
 
-    if (r <= 0)
+    if (r <= 0) {
       return r;
+    }
 
-    if (c == '\n')
+    if (c == '\n') {
       break;
+    }
 
     s[numread++] = c;
   } while (numread < len - 1);

--- a/lib/ts/ink_sprintf.cc
+++ b/lib/ts/ink_sprintf.cc
@@ -79,22 +79,24 @@ ink_bvsprintf(char *buffer, const char *format, va_list ap)
     // handle non-% characters //
     /////////////////////////////
 
-    if (buffer) // if have output buffer
+    if (buffer) { // if have output buffer
       while (*s && (*s != '%')) {
         *d++ = *s++;
       } //   really copy, else
-    else
+    } else {
       while (*s && (*s != '%')) {
         d++;
         s++;
       } //   pass over string
+    }
 
     ///////////////////////////
     // handle NUL characters //
     ///////////////////////////
 
-    if (*s == NUL)
+    if (*s == NUL) {
       break; // end of string
+    }
 
     /////////////////////////
     // handle % characters //
@@ -108,42 +110,46 @@ ink_bvsprintf(char *buffer, const char *format, va_list ap)
       ++s;                              // consume 's'
       s_val = va_arg(ap_local, char *); // grab string argument
       p     = s_val;                    // temporary pointer
-      if (buffer)                       // if have output buffer
+      if (buffer) {                     // if have output buffer
         while (*p) {
           *d++ = *p++;
-        }  //   copy value
-      else // else
+        }      //   copy value
+      } else { // else
         while (*p) {
           d++;
           p++;
         } //   pass over value
+      }
       break;
     case 'd':                                            // %d pattern
       ++s;                                               // consume 'd'
       d_val = va_arg(ap_local, int);                     // grab integer argument
       snprintf(d_buffer, sizeof(d_buffer), "%d", d_val); // stringify integer
       p = d_buffer;                                      // temporary pointer
-      if (buffer)                                        // if have output buffer
+      if (buffer) {                                      // if have output buffer
         while (*p) {
           *d++ = *p++;
-        }  //   copy value
-      else // else
+        }      //   copy value
+      } else { // else
         while (*p) {
           d++;
           p++;
         } //   pass over value
+      }
       break;
     default: // something else
-      if (buffer)
+      if (buffer) {
         *d = *s; // copy unknown character
+      }
       ++d;
       ++s;
       break;
     }
   }
 
-  if (buffer)
+  if (buffer) {
     *d = NUL;
+  }
   ++d;
 
   va_end(ap_local);

--- a/lib/ts/ink_stack_trace.cc
+++ b/lib/ts/ink_stack_trace.cc
@@ -46,10 +46,12 @@ ink_stack_trace_dump()
 
   // Recopy and re-terminate the app name in case it has been trashed.
   const char *msg = " - STACK TRACE: \n";
-  if (write(STDERR_FILENO, program_name, strlen(program_name)) == -1)
+  if (write(STDERR_FILENO, program_name, strlen(program_name)) == -1) {
     return;
-  if (write(STDERR_FILENO, msg, strlen(msg)) == -1)
+  }
+  if (write(STDERR_FILENO, msg, strlen(msg)) == -1) {
     return;
+  }
 
   // In certain situations you can get stuck in malloc waiting for a lock
   // that your program held when it segfaulted. We set an alarm so that

--- a/lib/ts/ink_string++.cc
+++ b/lib/ts/ink_string++.cc
@@ -50,8 +50,9 @@ StrList::dump(FILE *fp)
 {
   Str *str;
 
-  for (str = head; str != NULL; str = str->next)
+  for (str = head; str != NULL; str = str->next) {
     str->dump(fp);
+  }
 }
 
 /*-------------------------------------------------------------------------
@@ -69,8 +70,9 @@ StrList::_new_cell(const char *s, int len_not_counting_nul)
     cell = &(base_cells[cells_allocated]);
   } else {
     p = (char *)alloc(sizeof(Str) + 7);
-    if (p == NULL)
-      return (NULL);                            // FIX: scale heap
+    if (p == NULL) {
+      return (NULL); // FIX: scale heap
+    }
     p    = (char *)((((uintptr_t)p) + 7) & ~7); // round up to multiple of 8
     cell = (Str *)p;
   }
@@ -79,8 +81,9 @@ StrList::_new_cell(const char *s, int len_not_counting_nul)
   // are we supposed to copy the string?
   if (copy_when_adding_string) {
     char *buf = (char *)alloc(l + 1);
-    if (buf == NULL)
+    if (buf == NULL) {
       return (NULL); // FIX: need to grow heap!
+    }
     memcpy(buf, s, l);
     buf[l] = '\0';
 
@@ -113,8 +116,9 @@ StrList::overflow_heap_alloc(int size)
 void
 StrList::overflow_heap_clean()
 {
-  if (overflow_first)
+  if (overflow_first) {
     overflow_first->clean();
+  }
 }
 
 #define INIT_OVERFLOW_ALIGNMENT 8

--- a/lib/ts/ink_string.cc
+++ b/lib/ts/ink_string.cc
@@ -37,8 +37,9 @@ char *
 ink_memcpy_until_char(char *dst, char *src, unsigned int n, unsigned char c)
 {
   unsigned int i = 0;
-  for (; ((i < n) && (((unsigned char)src[i]) != c)); i++)
+  for (; ((i < n) && (((unsigned char)src[i]) != c)); i++) {
     dst[i] = src[i];
+  }
   return &src[i];
 }
 
@@ -64,11 +65,13 @@ ink_string_concatenate_strings(char *dest, ...)
 
   while (1) {
     s = va_arg(ap, char *);
-    if (s == NULL)
+    if (s == NULL) {
       break;
+    }
 
-    while (*s)
+    while (*s) {
       *d++ = *s++;
+    }
   }
   *d++ = '\0';
   va_end(ap);
@@ -98,15 +101,17 @@ ink_string_concatenate_strings_n(char *dest, int n, ...)
 
   while (n > 1) {
     s = va_arg(ap, char *);
-    if (s == NULL)
+    if (s == NULL) {
       break;
+    }
     while (*s && (n > 1)) {
       *d++ = *s++;
       n--;
     }
   }
-  if (n >= 1)
+  if (n >= 1) {
     *d = '\0';
+  }
   va_end(ap);
   return (dest);
 } /* End ink_string_concatenate_strings_n */
@@ -130,15 +135,17 @@ ink_string_append(char *dest, char *src, int n)
   ink_assert(dest != NULL);
   ink_assert(n >= 0);
 
-  if (n == 0)
+  if (n == 0) {
     return (dest);
+  }
 
   last_valid_char = dest + n - 1;
 
   /* Scan For End Of Dest */
 
-  for (d = dest; (d <= last_valid_char) && (*d != '\0'); d++)
+  for (d = dest; (d <= last_valid_char) && (*d != '\0'); d++) {
     ;
+  }
 
   /* If At End Of String, NUL Terminate & Exit */
 
@@ -150,16 +157,17 @@ ink_string_append(char *dest, char *src, int n)
   /* Append src To String */
 
   s = src;
-  while ((d < last_valid_char) && (*s != '\0'))
+  while ((d < last_valid_char) && (*s != '\0')) {
     *d++ = *s++;
+  }
 
   /* If At End Of String, NUL Terminate & Exit */
 
-  if (d > last_valid_char)
+  if (d > last_valid_char) {
     dest[n - 1] = '\0';
-  else
+  } else {
     *d = '\0';
-
+  }
   return (dest);
 } /* End ink_string_append */
 

--- a/lib/ts/ink_sys_control.cc
+++ b/lib/ts/ink_sys_control.cc
@@ -40,10 +40,11 @@ ink_max_out_rlimit(int which, bool max_it, bool unlim_it)
     ink_release_assert(getrlimit(MAGIC_CAST(which), &rl) >= 0);
     if (rl.rlim_cur != rl.rlim_max) {
 #if defined(darwin)
-      if (which == RLIMIT_NOFILE)
+      if (which == RLIMIT_NOFILE) {
         rl.rlim_cur = fmin(OPEN_MAX, rl.rlim_max);
-      else
+      } else {
         rl.rlim_cur = rl.rlim_max;
+      }
 #else
       rl.rlim_cur = rl.rlim_max;
 #endif

--- a/lib/ts/ink_thread.cc
+++ b/lib/ts/ink_thread.cc
@@ -78,8 +78,9 @@ void
 ink_sem_wait(ink_semaphore *sp)
 {
   int r;
-  while (EINTR == (r = sem_wait(sp->get())))
+  while (EINTR == (r = sem_wait(sp->get()))) {
     ;
+  }
   ink_assert(!r);
 }
 
@@ -87,8 +88,9 @@ bool
 ink_sem_trywait(ink_semaphore *sp)
 {
   int r;
-  while (EINTR == (r = sem_trywait(sp->get())))
+  while (EINTR == (r = sem_trywait(sp->get()))) {
     ;
+  }
   ink_assert(r == 0 || (errno == EAGAIN));
   return r == 0;
 }

--- a/lib/ts/ink_time.cc
+++ b/lib/ts/ink_time.cc
@@ -149,13 +149,15 @@ convert_tm(const struct tm *tp)
   mday  = tp->tm_mday;
 
   /* what should we do? */
-  if ((year < 70) || (year > 137))
+  if ((year < 70) || (year > 137)) {
     return (ink_time_t)UNDEFINED_TIME;
+  }
 
   mday += days[month];
   /* month base == march */
-  if (month < 2)
+  if (month < 2) {
     year -= 1;
+  }
   mday += (year * 365) + (year / 4) - (year / 100) + (year / 100 + 3) / 4;
   mday -= DAYS_OFFSET;
 

--- a/lib/ts/llqueue.cc
+++ b/lib/ts/llqueue.cc
@@ -108,16 +108,19 @@ enqueue(LLQ *Q, void *data)
   new_val->data = data;
   new_val->next = NULL;
 
-  if (Q->tail)
+  if (Q->tail) {
     Q->tail->next = new_val;
-  Q->tail         = new_val;
+  }
+  Q->tail = new_val;
 
-  if (Q->head == NULL)
+  if (Q->head == NULL) {
     Q->head = Q->tail;
+  }
 
   Q->len++;
-  if (Q->len > Q->highwater)
+  if (Q->len > Q->highwater) {
     Q->highwater = Q->len;
+  }
   ink_mutex_release(&(Q->mux));
   ink_sem_post(&(Q->sema));
   return 1;
@@ -193,8 +196,9 @@ dequeue(LLQ *Q)
   rec = Q->head;
 
   Q->head = Q->head->next;
-  if (Q->head == NULL)
+  if (Q->head == NULL) {
     Q->tail = NULL;
+  }
 
   d = rec->data;
   // freerec(Q, rec);

--- a/lib/ts/lockfile.cc
+++ b/lib/ts/lockfile.cc
@@ -53,8 +53,9 @@ Lockfile::Open(pid_t *holding_pid)
     fd = open(fname, O_RDWR | O_CREAT, 0644);
   } while ((fd < 0) && (errno == EINTR));
 
-  if (fd < 0)
+  if (fd < 0) {
     return (-errno);
+  }
 
   // Lock it. Note that if we can't get the lock EAGAIN will be the
   // error we receive.
@@ -79,8 +80,9 @@ Lockfile::Open(pid_t *holding_pid)
 
       if (err < 0)
         FAIL(-errno);
-      if (err == 0)
+      if (err == 0) {
         break;
+      }
 
       size -= err;
       t += err;
@@ -135,8 +137,9 @@ Lockfile::Get(pid_t *holding_pid)
   // Open the Lockfile and get the lock. If we are successful, the
   // return value will be the file descriptor of the opened Lockfile.
   err = Open(holding_pid);
-  if (err != 1)
+  if (err != 1) {
     return err;
+  }
 
   if (fd < 0) {
     return -1;
@@ -204,8 +207,9 @@ lockfile_kill_internal(pid_t init_pid, int init_sig, pid_t pid, const char * /* 
     // Wait for children to exit
     do {
       err = waitpid(-1, &status, WNOHANG);
-      if (err == -1)
+      if (err == -1) {
         break;
+      }
     } while (!WIFEXITED(status) && !WIFSIGNALED(status));
   }
 

--- a/lib/tsconfig/Errata.cc
+++ b/lib/tsconfig/Errata.cc
@@ -113,7 +113,8 @@ Errata::pre_write() {
 // Just create an instance if needed.
 Errata::Data*
 Errata::instance() {
-  if (!m_data) m_data = new Data;
+  if (!m_data) { m_data = new Data;
+}
   return m_data.get();
 }
 
@@ -220,15 +221,17 @@ Errata::write(
         spot != limit;
         ++spot
   ) {
-    if ((offset + indent) > 0)
+    if ((offset + indent) > 0) {
       out << std::setw(indent + offset) << std::setfill(' ')
           << ((indent > 0 && lead) ? lead : " ");
+}
 
     out << spot->m_id << " [" << spot->m_code << "]: " << spot->m_text
         << std::endl
       ;
-    if (spot->getErrata().size())
+    if (spot->getErrata().size()) {
       spot->getErrata().write(out, offset, indent+shift, shift, lead);
+}
 
   }
   return out;

--- a/lib/tsconfig/TsBuilder.cc
+++ b/lib/tsconfig/TsBuilder.cc
@@ -41,11 +41,13 @@ size_t unescape_string(char* text, size_t len) {
   if (dst) {
     char* limit = text + len;
     char* src = dst + 1; // skip escape char
-    for ( *dst++ = *src++ ; src < limit ; ++src )
-      if ('\\' != *src) *dst++ = *src;
-      else if (++src < limit) *dst++ = *src;
-      else *dst++ = '\\'; // trailing backslash.
-    zret = dst - text;
+    for ( *dst++ = *src++ ; src < limit ; ++src ) {
+      if ('\\' != *src) { *dst++ = *src;
+      } else if (++src < limit) { *dst++ = *src;
+      } else { *dst++ = '\\'; // trailing backslash.
+    
+}
+}zret = dst - text;
   }
   return zret;
 }
@@ -167,8 +169,9 @@ void Builder::pathIndex(Token const& token){
     // digit string that is followed by a non-digit or the FLEX
     // required double null at the end of the input buffer.
     _path.append(Buffer(0, static_cast<size_t>(atol(token._s))));
-    if (_extent._ptr) _extent._size = token._s - _extent._ptr + token._n;
-    else _extent.set(token._s, token._n);
+    if (_extent._ptr) { _extent._size = token._s - _extent._ptr + token._n;
+    } else { _extent.set(token._s, token._n);
+}
 }
 
 void Builder::pathClose(Token const&) {
@@ -206,8 +209,10 @@ void Builder::literalValue(Token const& token) {
     } else {
         msg::logf(_errata, msg::WARN, PRE "Unexpected literal type %d.", token._type);
     }
-    if (!cv.isOK()) _errata.pull(cv.errata());
-    if (cv.result()) cv.result().setSource(token._loc._line, token._loc._col);
+    if (!cv.isOK()) { _errata.pull(cv.errata());
+}
+    if (cv.result()) { cv.result().setSource(token._loc._line, token._loc._col);
+}
     _name.set(0,0); // used, so clear it.
 }
 void Builder::invalidToken(Token const&) { }

--- a/lib/tsconfig/TsValue.cc
+++ b/lib/tsconfig/TsValue.cc
@@ -55,21 +55,24 @@ unsigned int const detail::Type_Property[N_VALUE_TYPES] = {
 // ---------------------------------------------------------------------------
 detail::ValueTableImpl::ValueTableImpl() : _generation(0) { }
 detail::ValueTableImpl::~ValueTableImpl() {
-  for ( BufferGroup::iterator spot(_buffers.begin()), limit(_buffers.end()) ; spot != limit ; ++spot)
+  for ( BufferGroup::iterator spot(_buffers.begin()), limit(_buffers.end()) ; spot != limit ; ++spot) {
     free(spot->_ptr);
+}
 }
 // ---------------------------------------------------------------------------
 detail::ValueTable::ImplType*
 detail::ValueTable::instance() {
-  if (! _ptr) _ptr.reset(new ImplType);
+  if (! _ptr) { _ptr.reset(new ImplType);
+}
   return _ptr.get();
 }
 
 detail::ValueTable&
 detail::ValueTable::forceRootItem() {
   ImplType* imp = this->instance();
-  if (0 == imp->_values.size())
+  if (0 == imp->_values.size()) {
     imp->_values.push_back(ValueItem(GroupValue));
+}
   return *this;
 }
 
@@ -91,7 +94,8 @@ detail::ValueTable::make(ValueIndex pidx, ValueType type, ConstBuffer const& nam
         parent->_children.push_back(n);
         item->_local_index = parent->_children.size() - 1;
         // Only use the name if the parent is a group.
-        if (GroupValue == parent->_type) item->_name = name;
+        if (GroupValue == parent->_type) { item->_name = name;
+}
         zret = n; // mark for return to caller.
       } else {
         msg::log(zret.errata(), msg::WARN, "Add child failed because parent is not a container.");
@@ -114,7 +118,8 @@ Buffer
 detail::ValueTable::alloc(size_t n) {
   ImplType* imp = this->instance();
   Buffer zret(static_cast<char*>(malloc(n)), n);
-  if (zret._ptr) imp->_buffers.push_back(zret);
+  if (zret._ptr) { imp->_buffers.push_back(zret);
+}
   return zret;
 }
 
@@ -125,7 +130,8 @@ Value::operator [] (size_t idx) const {
   detail::ValueItem const* item = this->item();
   if (item && idx < item->_children.size()) {
     zret = Value(_config, item->_children[idx]);
-    if (PathValue == zret.getType()) zret = _config.getRoot().find(_config._table[zret._vidx]._path);
+    if (PathValue == zret.getType()) { zret = _config.getRoot().find(_config._table[zret._vidx]._path);
+}
   }
   return zret;
 }
@@ -138,7 +144,8 @@ Value::operator [] (ConstBuffer const& name) const {
     for ( detail::ValueItem::ChildGroup::const_iterator spot = item->_children.begin(), limit = item->_children.end(); spot != limit; ++spot ) {
       if (_config._table[*spot]._name == name) {
         zret = Value(_config, *spot);
-        if (PathValue == zret.getType()) zret = _config.getRoot().find(_config._table[zret._vidx]._path);
+        if (PathValue == zret.getType()) { zret = _config.getRoot().find(_config._table[zret._vidx]._path);
+}
         break;
       }
     }
@@ -153,11 +160,13 @@ Value::find( ConstBuffer const& path ) {
   Rv<Path::Parser::Result> x;
   ConstBuffer elt;
   for ( x = parser.parse(&elt) ; zret && Path::Parser::EOP != x && Path::Parser::ERROR != x ; x = parser.parse(&elt) ) {
-    if (Path::Parser::TAG == x) zret = zret[elt];
-    else if (Path::Parser::INDEX == x) zret = zret[elt._size];
-    else zret.reset();
+    if (Path::Parser::TAG == x) { zret = zret[elt];
+    } else if (Path::Parser::INDEX == x) { zret = zret[elt._size];
+    } else { zret.reset();
+}
   }
-  if (Path::Parser::EOP != x) zret.reset();
+  if (Path::Parser::EOP != x) { zret.reset();
+}
   return zret;
 }
 
@@ -166,8 +175,9 @@ Value::find(Path const& path ) {
   Value zret = *this;
   for ( size_t i = 0, n = path.count() ; i < n && zret ; ++i ) {
     ConstBuffer const& elt = path[i];
-    if (elt._ptr) zret = zret[elt];
-    else zret = zret[elt._size];
+    if (elt._ptr) { zret = zret[elt];
+    } else { zret = zret[elt._size];
+}
   }
   return zret;
 }
@@ -176,8 +186,9 @@ Rv<Value>
 Value::makeChild(ValueType type, ConstBuffer const& name) {
   Rv<Value> zret;
   Rv<detail::ValueIndex> vr = _config._table.make(this->_vidx, type, name);
-  if (vr.isOK()) zret = Value(_config, vr.result());
-  else zret.errata() = vr.errata();
+  if (vr.isOK()) { zret = Value(_config, vr.result());
+  } else { zret.errata() = vr.errata();
+}
   return zret;
 }
 
@@ -194,29 +205,32 @@ Value::makeList(ConstBuffer const& name) {
 Rv<Value>
 Value::makeString(ConstBuffer const& text, ConstBuffer const& name) {
   Rv<Value> zret = this->makeChild(StringValue, name);
-  if (zret.isOK()) zret.result().setText(text);
+  if (zret.isOK()) { zret.result().setText(text);
+}
   return zret;
 }
 
 Rv<Value>
 Value::makeInteger(ConstBuffer const& text, ConstBuffer const& name) {
   Rv<Value> zret = this->makeChild(IntegerValue, name);
-  if (zret.isOK()) zret.result().setText(text);
+  if (zret.isOK()) { zret.result().setText(text);
+}
   return zret;
 }
 
 Rv<Value>
 Value::makePath(Path const& path, ConstBuffer const& name) {
   Rv<Value> zret = this->makeChild(PathValue, name);
-  if (zret.isOK()) _config._table[zret.result()._vidx]._path = path;
+  if (zret.isOK()) { _config._table[zret.result()._vidx]._path = path;
+}
   return zret;
 }
 // ---------------------------------------------------------------------------
 Path& Path::reset() {
   if (_ptr) {
     // If we're sharing the instance, make a new one for us.
-    if (_ptr.isShared()) _ptr = new ImplType;
-    else { // clear out the existing instance.
+    if (_ptr.isShared()) { _ptr = new ImplType;
+    } else { // clear out the existing instance.
       _ptr->_elements.clear();
     }
   }
@@ -242,22 +256,24 @@ Path::Parser::parse(ConstBuffer *cbuff) {
     C_DOT, // A dot (period).
   };
 
-  if (cbuff) cbuff->reset();
+  if (cbuff) { cbuff->reset();
+}
   char const* start = _c; // save starting character location.
   size_t idx = 0; // accumulator for index value.
 
   bool final = false;
   while (! final && this->hasInput()) {
     Bucket cb;
-    if (isdigit(*_c)) cb = C_DIGIT;
-    else if ('_' == *_c || isalpha(*_c)) cb = C_IDENT;
-    else if ('-' == *_c) cb = C_DASH;
-    else if ('.' == *_c) cb = C_DOT;
-    else cb = C_INVALID;
+    if (isdigit(*_c)) { cb = C_DIGIT;
+    } else if ('_' == *_c || isalpha(*_c)) { cb = C_IDENT;
+    } else if ('-' == *_c) { cb = C_DASH;
+    } else if ('.' == *_c) { cb = C_DOT;
+    } else { cb = C_INVALID;
+}
 
     if (C_INVALID == cb) {
       msg::logf(zret, msg::WARN, "Invalid character '%c' [%u] in path.", *_c, *_c);
-    } else switch (state) {
+    } else { switch (state) {
       case S_INIT:
         switch (cb) {
         case C_DIGIT: state = S_INDEX; idx = *_c - '0'; break;
@@ -268,25 +284,25 @@ Path::Parser::parse(ConstBuffer *cbuff) {
         }
         break;
       case S_INDEX: // reading an index.
-        if (C_DIGIT == cb) idx = 10 * idx + *_c - '0';
-        else if (C_DOT == cb) { final = true; }
+        if (C_DIGIT == cb) { idx = 10 * idx + *_c - '0';
+        } else if (C_DOT == cb) { final = true; }
         else {
           msg::logf(zret, msg::WARN, "Invalid character '%c' [%u] in index element.", *_c, *_c);
           final = true;
         }
         break;
       case S_TAG: // reading a tag.
-        if (C_IDENT == cb || C_DIGIT == cb) ; // continue
-        else if (C_DASH == cb) state = S_DASH;
-        else if (C_DOT == cb) { final = true; }
+        if (C_IDENT == cb || C_DIGIT == cb) { ; // continue
+        } else if (C_DASH == cb) { state = S_DASH;
+        } else if (C_DOT == cb) { final = true; }
         else { // should never happen, but be safe.
           msg::logf(zret, msg::WARN, "Invalid character '%c' [%u] in index element.", *_c, *_c);
           final = true;
         }
         break;
       case S_DASH: // dashes inside tag.
-        if (C_IDENT == cb || C_DIGIT == cb) state = S_TAG;
-        else if (C_DOT == cb) {
+        if (C_IDENT == cb || C_DIGIT == cb) { state = S_TAG;
+        } else if (C_DOT == cb) {
           msg::log(zret, msg::WARN, "Trailing dash not allowed in tag element.");
           final = true;
         } else if (C_DASH != cb) { // should never happen, but be safe.
@@ -295,11 +311,13 @@ Path::Parser::parse(ConstBuffer *cbuff) {
         }
         break;
       }
+}
     ++_c;
   }
   if (!zret.isOK()) {
     zret = ERROR;
-    if (cbuff) cbuff->set(_c - 1, 1);
+    if (cbuff) { cbuff->set(_c - 1, 1);
+}
     _c = 0;
     _input.reset();
   } else if (S_INIT == state) {
@@ -310,15 +328,18 @@ Path::Parser::parse(ConstBuffer *cbuff) {
       cbuff->set(start, _c - start);
       // if @a final is set, then we parsed a dot separator.
       // don't include it in the returned tag.
-      if (final) cbuff->_size -= 1;
+      if (final) { cbuff->_size -= 1;
+}
     }
   } else if (S_INDEX == state) {
     zret = INDEX;
-    if (cbuff) cbuff->_size = idx;
+    if (cbuff) { cbuff->_size = idx;
+}
   } else if (S_DASH == state) {
     zret = ERROR;
     msg::log(zret, msg::WARN, "Trailing dash not allowed in tag element.");
-    if (cbuff) cbuff->set(start, _c - start);
+    if (cbuff) { cbuff->set(start, _c - start);
+}
   }
   return zret;
 }

--- a/mgmt/Alarms.cc
+++ b/mgmt/Alarms.cc
@@ -289,11 +289,12 @@ Alarms::signalAlarm(alarm_t a, const char *desc, const char *ip)
   time(&my_time_t);
   ink_ctime_r(&my_time_t, my_ctime_str);
   char *p = my_ctime_str;
-  while (*p != '\n' && *p != '\0')
+  while (*p != '\n' && *p != '\0') {
     p++;
-  if (*p == '\n')
+  }
+  if (*p == '\n') {
     *p = '\0';
-
+  }
   const size_t sz = sizeof(char) * (strlen(desc) + strlen(my_ctime_str) + 4);
   ats_free(atmp->description);
   atmp->description = (char *)ats_malloc(sz);
@@ -519,8 +520,9 @@ Alarms::execAlarmBin(const char *desc)
 const char *
 Alarms::getAlarmText(alarm_t id)
 {
-  if (id < alarmTextNum)
+  if (id < alarmTextNum) {
     return alarmText[id];
-  else
+  } else {
     return alarmText[0]; // "Unknown Alarm";
+  }
 }

--- a/mgmt/BaseManager.cc
+++ b/mgmt/BaseManager.cc
@@ -96,8 +96,9 @@ BaseManager::registerMgmtCallback(int msg_id, MgmtCallback cb, void *opaque_cb_d
   if (cb_list) {
     MgmtCallbackList *tmp;
 
-    for (tmp = cb_list; tmp->next; tmp = tmp->next)
+    for (tmp = cb_list; tmp->next; tmp = tmp->next) {
       ;
+    }
     tmp->next              = (MgmtCallbackList *)ats_malloc(sizeof(MgmtCallbackList));
     tmp->next->func        = cb;
     tmp->next->opaque_data = opaque_cb_data;

--- a/mgmt/FileManager.cc
+++ b/mgmt/FileManager.cc
@@ -394,8 +394,9 @@ FileManager::removeSnap(const char *snapName, const char *snapDir)
   dirEntrySpace = (struct dirent *)ats_malloc(sizeof(struct dirent) + ink_file_namemax(".") + 1);
 
   while (readdir_r(dir, dirEntrySpace, &entryPtr) == 0) {
-    if (!entryPtr)
+    if (!entryPtr) {
       break;
+    }
 
     if (strcmp(".", entryPtr->d_name) == 0 || strcmp("..", entryPtr->d_name) == 0) {
       continue;
@@ -526,8 +527,9 @@ FileManager::readFile(const char *filePath, textBuffer *contents)
 
   fcntl(diskFD, F_SETFD, 1);
 
-  while ((readResult = contents->readFromFD(diskFD)) > 0)
+  while ((readResult = contents->readFromFD(diskFD)) > 0) {
     ;
+  }
   close(diskFD);
 
   if (readResult < 0) {
@@ -644,8 +646,9 @@ FileManager::rereadConfig()
 
   Vec<Rollback *> childFileNeedDelete;
   for (size_t i = 0; i < changedFiles.n; i++) {
-    if (changedFiles[i]->isChildRollback())
+    if (changedFiles[i]->isChildRollback()) {
       continue;
+    }
     // for each parent file, if it is changed, then delete all its children
     for (entry = ink_hash_table_iterator_first(bindings, &iterator_state); entry != NULL;
          entry = ink_hash_table_iterator_next(bindings, &iterator_state)) {
@@ -779,10 +782,12 @@ FileManager::checkValidName(const char *name)
   int length = strlen(name);
 
   for (int i = 0; i < length; i++) {
-    if (!isprint(name[i]))
+    if (!isprint(name[i])) {
       return false; // invalid - unprintable char
-    if (!isspace(name[i]))
+    }
+    if (!isspace(name[i])) {
       return true; // has non-white space that is printable
+    }
   }
 
   return false; // all white spaces

--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -391,8 +391,9 @@ LocalManager::pollMgmtProcessServer()
     timeout.tv_usec = process_server_timeout_msecs * 1000;
     FD_ZERO(&fdlist);
     FD_SET(process_server_sockfd, &fdlist);
-    if (watched_process_fd != ts::NO_FD)
+    if (watched_process_fd != ts::NO_FD) {
       FD_SET(watched_process_fd, &fdlist);
+    }
 
 #if TS_HAS_WCCP
     // Only run WCCP housekeeping while we have a server process.
@@ -971,8 +972,9 @@ LocalManager::closeProxyPorts()
 void
 LocalManager::listenForProxy()
 {
-  if (!run_proxy)
+  if (!run_proxy) {
     return;
+  }
 
   // We are not already bound, bind the port
   for (int i = 0, n = lmgmt->m_proxy_ports.length(); i < n; ++i) {
@@ -1047,15 +1049,17 @@ LocalManager::bindProxyPort(HttpProxyPort &port)
   if (port.m_inbound_ip.isValid()) {
     ip.assign(port.m_inbound_ip);
   } else if (AF_INET6 == port.m_family) {
-    if (m_inbound_ip6.isValid())
+    if (m_inbound_ip6.isValid()) {
       ip.assign(m_inbound_ip6);
-    else
+    } else {
       ip.setToAnyAddr(AF_INET6);
+    }
   } else if (AF_INET == port.m_family) {
-    if (m_inbound_ip4.isValid())
+    if (m_inbound_ip4.isValid()) {
       ip.assign(m_inbound_ip4);
-    else
+    } else {
       ip.setToAnyAddr(AF_INET);
+    }
   } else {
     mgmt_fatal(stderr, 0, "[bindProxyPort] Proxy port with invalid address type %d\n", port.m_family);
   }
@@ -1070,6 +1074,7 @@ LocalManager::bindProxyPort(HttpProxyPort &port)
 void
 LocalManager::signalAlarm(int alarm_id, const char *desc, const char *ip)
 {
-  if (alarm_keeper)
+  if (alarm_keeper) {
     alarm_keeper->signalAlarm((alarm_t)alarm_id, desc, ip);
+  }
 }

--- a/mgmt/MultiFile.cc
+++ b/mgmt/MultiFile.cc
@@ -115,8 +115,9 @@ MultiFile::WalkFiles(ExpandingArray *fileList)
 
   struct dirent *result;
   while (readdir_r(dir, dirEntry, &result) == 0) {
-    if (!result)
+    if (!result) {
       break;
+    }
     fileName                = dirEntry->d_name;
     filePath                = newPathString(managedDir, fileName);
     records_config_filePath = newPathString(filePath, "records.config");
@@ -217,8 +218,9 @@ MultiFile::newPathString(const char *s1, const char *s2)
   int addLen; // maximum total path length
 
   // Treat null as an empty path.
-  if (!s2)
-    s2   = "";
+  if (!s2) {
+    s2 = "";
+  }
   addLen = strlen(s2) + 1;
   if (*s2 == '/') {
     // If addpath is rooted, then rootpath is unused.
@@ -237,8 +239,9 @@ MultiFile::newPathString(const char *s1, const char *s2)
   ink_assert(newStr != NULL);
 
   ink_strlcpy(newStr, s1, addLen);
-  if (newStr[srcLen - 1] != '/')
+  if (newStr[srcLen - 1] != '/') {
     newStr[srcLen++] = '/';
+  }
   ink_strlcpy(&newStr[srcLen], s2, addLen - srcLen);
 
   return newStr;

--- a/mgmt/ProxyConfig.cc
+++ b/mgmt/ProxyConfig.cc
@@ -83,8 +83,9 @@ config_string_alloc_cb(void *data, void *value)
   *(char **)data = _new_value;
 
   // free old data
-  if (_temp2 != 0)
+  if (_temp2 != 0) {
     new_Freer(_temp2, HRTIME_DAY);
+  }
 
   return NULL;
 }

--- a/mgmt/Rollback.cc
+++ b/mgmt/Rollback.cc
@@ -665,8 +665,9 @@ Rollback::findVersions_ml(ExpandingArray *listNames)
   dirEntrySpace = (struct dirent *)ats_malloc(sizeof(struct dirent) + ink_file_namemax(".") + 1);
 
   while (readdir_r(dir, dirEntrySpace, &entryPtr) == 0) {
-    if (!entryPtr)
+    if (!entryPtr) {
       break;
+    }
 
     if ((version = extractVersionInfo(listNames, entryPtr->d_name)) != INVALID_VERSION) {
       count++;
@@ -710,8 +711,9 @@ Rollback::extractVersionInfo(ExpandingArray *listNames, const char *testFileName
         // Check for the integer version number
         currentVersionStr = str = testFileName + fileNameLen + 1;
 
-        for (; isdigit(*str) && *str != '\0'; str++)
+        for (; isdigit(*str) && *str != '\0'; str++) {
           ;
+        }
 
         // Do not tolerate anything but numbers on the end
         //   of the file

--- a/mgmt/WebMgmtUtils.cc
+++ b/mgmt/WebMgmtUtils.cc
@@ -701,8 +701,9 @@ MgmtData::MgmtData()
 
 MgmtData::~MgmtData()
 {
-  if (type == RECD_STRING)
+  if (type == RECD_STRING) {
     ats_free(data.rec_string);
+  }
 }
 
 // MgmtData::compareFromString(const char* str, strLen)
@@ -1251,8 +1252,9 @@ getFilesInDirectory(char *managedDir, ExpandingArray *fileList)
 
   struct dirent *result;
   while (readdir_r(dir, dirEntry, &result) == 0) {
-    if (!result)
+    if (!result) {
       break;
+    }
     fileName = dirEntry->d_name;
     if (!fileName || !*fileName) {
       continue;
@@ -1292,8 +1294,9 @@ newPathString(const char *s1, const char *s2)
   int addLen; // maximum total path length
 
   // Treat null as an empty path.
-  if (!s2)
-    s2   = "";
+  if (!s2) {
+    s2 = "";
+  }
   addLen = strlen(s2) + 1;
   if (*s2 == '/') {
     // If addpath is rooted, then rootpath is unused.
@@ -1312,8 +1315,9 @@ newPathString(const char *s1, const char *s2)
   ink_assert(newStr != NULL);
 
   ink_strlcpy(newStr, s1, srcLen + addLen + 1);
-  if (newStr[srcLen - 1] != '/')
+  if (newStr[srcLen - 1] != '/') {
     newStr[srcLen++] = '/';
+  }
   ink_strlcpy(&newStr[srcLen], s2, srcLen + addLen + 1);
 
   return newStr;

--- a/mgmt/api/APITestCliRemote.cc
+++ b/mgmt/api/APITestCliRemote.cc
@@ -136,8 +136,9 @@ print_err(const char *module, TSMgmtError err)
   err_msg = TSGetErrorMessage(err);
   printf("(%s) ERROR: %s\n", module, err_msg);
 
-  if (err_msg)
+  if (err_msg) {
     TSfree(err_msg);
+  }
 }
 
 /*--------------------------------------------------------------
@@ -153,8 +154,9 @@ print_ports(TSPortList list)
   for (i = 0; i < count; i++) {
     port_ele = TSPortListDequeue(list);
     printf(" %d \n", port_ele->port_a);
-    if (port_ele->port_b != -1)
+    if (port_ele->port_b != -1) {
       printf(" %d - %d \n", port_ele->port_a, port_ele->port_b);
+    }
     TSPortListEnqueue(list, port_ele);
   }
 
@@ -171,8 +173,9 @@ print_string_list(TSStringList list)
   char *str;
   char buf[1000];
 
-  if (!list)
+  if (!list) {
     return;
+  }
   count = TSStringListLen(list);
   for (i = 0; i < count; i++) {
     str = TSStringListDequeue(list);
@@ -215,8 +218,9 @@ print_domain_list(TSDomainList list)
   count = TSDomainListLen(list);
   for (i = 0; i < count; i++) {
     proxy = TSDomainListDequeue(list);
-    if (proxy->domain_val)
+    if (proxy->domain_val) {
       printf("%s:%d\n", proxy->domain_val, proxy->port);
+    }
     TSDomainListEnqueue(list, proxy);
   }
 }
@@ -224,19 +228,22 @@ print_domain_list(TSDomainList list)
 void
 print_ip_addr_ele(TSIpAddrEle *ele)
 {
-  if (!ele)
+  if (!ele) {
     return;
+  }
 
   if (ele->type == TS_IP_RANGE) {
-    if (ele->cidr_a != -1)
+    if (ele->cidr_a != -1) {
       printf("IP_addr: %s/%d - %s/%d\n", ele->ip_a, ele->cidr_a, ele->ip_b, ele->cidr_b);
-    else
+    } else {
       printf("IP_addr: %s - %s\n", ele->ip_a, ele->ip_b);
+    }
   } else {
-    if (ele->cidr_a != -1)
+    if (ele->cidr_a != -1) {
       printf("IP_addr: %s/%d \n", ele->ip_a, ele->cidr_a);
-    else
+    } else {
       printf("IP_addr: %s \n", ele->ip_a);
+    }
   }
 }
 
@@ -307,14 +314,17 @@ print_pd_sspec(TSPdSsFormat info)
   printf("\ttime: %d:%d-%d:%d\n", info.sec_spec.time.hour_a, info.sec_spec.time.min_a, info.sec_spec.time.hour_b,
          info.sec_spec.time.min_b);
 
-  if (info.sec_spec.src_ip)
+  if (info.sec_spec.src_ip) {
     printf("\tsrc_ip: %s\n", info.sec_spec.src_ip);
+  }
 
-  if (info.sec_spec.prefix)
+  if (info.sec_spec.prefix) {
     printf("\tprefix: %s\n", info.sec_spec.prefix);
+  }
 
-  if (info.sec_spec.suffix)
+  if (info.sec_spec.suffix) {
     printf("\tsuffix: %s\n", info.sec_spec.suffix);
+  }
 
   printf("\tport-a: %d\n", info.sec_spec.port->port_a);
   printf("\tport-b: %d\n", info.sec_spec.port->port_b);
@@ -409,15 +419,17 @@ print_cache_ele(TSCacheEle *ele)
     break;
   case TS_CACHE_PIN_IN_CACHE:
     time_str = hms_time_to_string(ele->time_period);
-    if (!time_str)
+    if (!time_str) {
       return;
+    }
     snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "pin-in-cache=%s", time_str);
     ats_free(time_str);
     break;
   case TS_CACHE_REVALIDATE:
     time_str = hms_time_to_string(ele->time_period);
-    if (!time_str)
+    if (!time_str) {
       return;
+    }
     snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "revalidate=%s", time_str);
     ats_free(time_str);
     break;
@@ -748,8 +760,9 @@ print_storage_ele(TSStorageEle *ele)
     return;
   }
 
-  if (ele->pathname)
+  if (ele->pathname) {
     printf("pathname=%s, size=%d\n", ele->pathname, ele->size);
+  }
 }
 
 void
@@ -865,17 +878,19 @@ start_TS(char *tsArgs)
   strtok(tsArgs, ":");
   args = strtok(NULL, ":");
   if (args) {
-    if (strcmp(args, "all\n") == 0)
+    if (strcmp(args, "all\n") == 0) {
       clear = TS_CACHE_CLEAR_CACHE;
-    else if (strcmp(args, "hostdb\n") == 0)
+    } else if (strcmp(args, "hostdb\n") == 0) {
       clear = TS_CACHE_CLEAR_HOSTDB;
+    }
   } else {
     clear = TS_CACHE_CLEAR_NONE;
   }
 
   printf("STARTING PROXY with cache: %d\n", clear);
-  if ((ret = TSProxyStateSet(TS_PROXY_ON, clear)) != TS_ERR_OKAY)
+  if ((ret = TSProxyStateSet(TS_PROXY_ON, clear)) != TS_ERR_OKAY) {
     printf("[TSProxyStateSet] turn on FAILED\n");
+  }
   print_err("start_TS", ret);
 }
 
@@ -886,8 +901,9 @@ stop_TS()
   TSMgmtError ret;
 
   printf("STOPPING PROXY\n");
-  if ((ret = TSProxyStateSet(TS_PROXY_OFF, TS_CACHE_CLEAR_NONE)) != TS_ERR_OKAY)
+  if ((ret = TSProxyStateSet(TS_PROXY_OFF, TS_CACHE_CLEAR_NONE)) != TS_ERR_OKAY) {
     printf("[TSProxyStateSet] turn off FAILED\n");
+  }
   print_err("stop_TS", ret);
 }
 
@@ -898,8 +914,9 @@ restart()
   TSMgmtError ret;
 
   printf("RESTART - Cluster wide\n");
-  if ((ret = TSRestart(true)) != TS_ERR_OKAY)
+  if ((ret = TSRestart(true)) != TS_ERR_OKAY) {
     printf("[TSRestart] FAILED\n");
+  }
 
   print_err("restart", ret);
 }
@@ -911,8 +928,9 @@ reconfigure()
   TSMgmtError ret;
 
   printf("RECONFIGURE\n");
-  if ((ret = TSReconfigure()) != TS_ERR_OKAY)
+  if ((ret = TSReconfigure()) != TS_ERR_OKAY) {
     printf("[TSReconfigure] FAILED\n");
+  }
 
   print_err("reconfigure", ret);
 }
@@ -945,8 +963,9 @@ bounce()
   TSMgmtError ret;
 
   printf("BOUNCER - Cluster wide\n");
-  if ((ret = TSBounce(true)) != TS_ERR_OKAY)
+  if ((ret = TSBounce(true)) != TS_ERR_OKAY) {
     printf("[TSBounce] FAILED\n");
+  }
 
   print_err("bounce", ret);
 }
@@ -977,24 +996,27 @@ test_error_records()
   ret = TSRecordGetInt("proy.config.cop.core_signal", &port1);
   if (ret != TS_ERR_OKAY) {
     print_err("TSRecordGetInt", ret);
-  } else
+  } else {
     printf("[TSRecordGetInt] proxy.config.cop.core_signal=%" PRId64 " \n", port1);
+  }
 
   // test set integer
   ret = TSRecordSetInt("proy.config.cop.core_signal", new_port, &action);
   print_err("TSRecordSetInt", ret);
 
   printf("\n");
-  if (TSRecordGetCounter("proxy.press.socks.connections_successful", &ctr1) != TS_ERR_OKAY)
+  if (TSRecordGetCounter("proxy.press.socks.connections_successful", &ctr1) != TS_ERR_OKAY) {
     printf("TSRecordGetCounter FAILED!\n");
-  else
+  } else {
     printf("[TSRecordGetCounter]proxy.process.socks.connections_successful=%" PRId64 " \n", ctr1);
+  }
 
   printf("\n");
-  if (TSRecordGetFloat("proxy.conig.http.cache.fuzz.probability", &flt1) != TS_ERR_OKAY)
+  if (TSRecordGetFloat("proxy.conig.http.cache.fuzz.probability", &flt1) != TS_ERR_OKAY) {
     printf("TSRecordGetFloat FAILED!\n");
-  else
+  } else {
     printf("[TSRecordGetFloat] proxy.config.http.cache.fuzz.probability=%f\n", flt1);
+  }
 }
 
 /* ------------------------------------------------------------------------
@@ -1054,26 +1076,29 @@ test_records()
 #if TEST_STRING
   // retrieve an string value record using GetString
   err = TSRecordGetString("proxy.config.proxy_name", &rec_value);
-  if (err != TS_ERR_OKAY)
+  if (err != TS_ERR_OKAY) {
     print_err("TSRecordGetString", err);
-  else
+  } else {
     printf("[TSRecordGetString] proxy.config.proxy_name=%s\n", rec_value);
+  }
   TSfree(rec_value);
   rec_value = NULL;
 
   // test RecordSet
   err = TSRecordSetString("proxy.config.proxy_name", (TSString)new_str, &action);
-  if (err != TS_ERR_OKAY)
+  if (err != TS_ERR_OKAY) {
     print_err("TSRecordSetString", err);
-  else
+  } else {
     printf("[TSRecordSetString] proxy.config.proxy_name=%s\n", new_str);
+  }
 
   // get
   err = TSRecordGetString("proxy.config.proxy_name", &rec_value);
-  if (err != TS_ERR_OKAY)
+  if (err != TS_ERR_OKAY) {
     print_err("TSRecordGetString", err);
-  else
+  } else {
     printf("[TSRecordGetString] proxy.config.proxy_name=%s\n", rec_value);
+  }
   printf("\n");
   TSfree(rec_value);
 #endif
@@ -1081,74 +1106,85 @@ test_records()
 #if TEST_INT
   printf("\n");
   // test get integer
-  if (TSRecordGetInt("proxy.config.cop.core_signal", &port1) != TS_ERR_OKAY)
+  if (TSRecordGetInt("proxy.config.cop.core_signal", &port1) != TS_ERR_OKAY) {
     printf("TSRecordGetInt FAILED!\n");
-  else
+  } else {
     printf("[TSRecordGetInt] proxy.config.cop.core_signal=%" PRId64 " \n", port1);
+  }
 
   // test set integer
-  if (TSRecordSetInt("proxy.config.cop.core_signal", new_port, &action) != TS_ERR_OKAY)
+  if (TSRecordSetInt("proxy.config.cop.core_signal", new_port, &action) != TS_ERR_OKAY) {
     printf("TSRecordSetInt FAILED!\n");
-  else
+  } else {
     printf("[TSRecordSetInt] proxy.config.cop.core_signal=%" PRId64 " \n", new_port);
+  }
 
-  if (TSRecordGetInt("proxy.config.cop.core_signal", &port2) != TS_ERR_OKAY)
+  if (TSRecordGetInt("proxy.config.cop.core_signal", &port2) != TS_ERR_OKAY) {
     printf("TSRecordGetInt FAILED!\n");
-  else
+  } else {
     printf("[TSRecordGetInt] proxy.config.cop.core_signal=%" PRId64 " \n", port2);
+  }
   printf("\n");
 #endif
 
 #if TEST_COUNTER
   printf("\n");
 
-  if (TSRecordGetCounter("proxy.process.socks.connections_successful", &ctr1) != TS_ERR_OKAY)
+  if (TSRecordGetCounter("proxy.process.socks.connections_successful", &ctr1) != TS_ERR_OKAY) {
     printf("TSRecordGetCounter FAILED!\n");
-  else
+  } else {
     printf("[TSRecordGetCounter]proxy.process.socks.connections_successful=%" PRId64 " \n", ctr1);
+  }
 
-  if (TSRecordSetCounter("proxy.process.socks.connections_successful", new_ctr, &action) != TS_ERR_OKAY)
+  if (TSRecordSetCounter("proxy.process.socks.connections_successful", new_ctr, &action) != TS_ERR_OKAY) {
     printf("TSRecordSetCounter FAILED!\n");
-  else
+  } else {
     printf("[TSRecordSetCounter] proxy.process.socks.connections_successful=%" PRId64 " \n", new_ctr);
+  }
 
-  if (TSRecordGetCounter("proxy.process.socks.connections_successful", &ctr2) != TS_ERR_OKAY)
+  if (TSRecordGetCounter("proxy.process.socks.connections_successful", &ctr2) != TS_ERR_OKAY) {
     printf("TSRecordGetCounter FAILED!\n");
-  else
+  } else {
     printf("[TSRecordGetCounter]proxy.process.socks.connections_successful=%" PRId64 " \n", ctr2);
+  }
   printf("\n");
 #endif
 
 #if TEST_FLOAT
   printf("\n");
-  if (TSRecordGetFloat("proxy.config.http.cache.fuzz.probability", &flt1) != TS_ERR_OKAY)
+  if (TSRecordGetFloat("proxy.config.http.cache.fuzz.probability", &flt1) != TS_ERR_OKAY) {
     printf("TSRecordGetFloat FAILED!\n");
-  else
+  } else {
     printf("[TSRecordGetFloat] proxy.config.http.cache.fuzz.probability=%f\n", flt1);
+  }
 
-  if (TSRecordSetFloat("proxy.config.http.cache.fuzz.probability", new_flt, &action) != TS_ERR_OKAY)
+  if (TSRecordSetFloat("proxy.config.http.cache.fuzz.probability", new_flt, &action) != TS_ERR_OKAY) {
     printf("TSRecordSetFloat FAILED!\n");
-  else
+  } else {
     printf("[TSRecordSetFloat] proxy.config.http.cache.fuzz.probability=%f\n", new_flt);
+  }
 
-  if (TSRecordGetFloat("proxy.config.http.cache.fuzz.probability", &flt2) != TS_ERR_OKAY)
+  if (TSRecordGetFloat("proxy.config.http.cache.fuzz.probability", &flt2) != TS_ERR_OKAY) {
     printf("TSRecordGetFloat FAILED!\n");
-  else
+  } else {
     printf("[TSRecordGetFloat] proxy.config.http.cache.fuzz.probability=%f\n", flt2);
+  }
   printf("\n");
 #endif
 
 #if TEST_REC_SET
   printf("\n");
-  if (TSRecordSet("proxy.config.http.cache.fuzz.probability", "-0.3456", &action) != TS_ERR_OKAY)
+  if (TSRecordSet("proxy.config.http.cache.fuzz.probability", "-0.3456", &action) != TS_ERR_OKAY) {
     printf("TSRecordSet FAILED!\n");
-  else
+  } else {
     printf("[TSRecordSet] proxy.config.http.cache.fuzz.probability=-0.3456\n");
+  }
 
-  if (TSRecordGetFloat("proxy.config.http.cache.fuzz.probability", &flt2) != TS_ERR_OKAY)
+  if (TSRecordGetFloat("proxy.config.http.cache.fuzz.probability", &flt2) != TS_ERR_OKAY) {
     printf("TSRecordGetFloat FAILED!\n");
-  else
+  } else {
     printf("[TSRecordGetFloat] proxy.config.http.cache.fuzz.probability=%f\n", flt2);
+  }
 #endif
 }
 
@@ -1165,9 +1201,9 @@ test_rec_get(char *rec_name)
 
   // retrieve a string value record using generic RecordGet
   rec_ele = TSRecordEleCreate();
-  if ((ret = TSRecordGet(name, rec_ele)) != TS_ERR_OKAY)
+  if ((ret = TSRecordGet(name, rec_ele)) != TS_ERR_OKAY) {
     printf("TSRecordGet FAILED!\n");
-  else {
+  } else {
     switch (rec_ele->rec_type) {
     case TS_REC_INT:
       printf("[TSRecordGet] %s=%" PRId64 "\n", name, rec_ele->valueT.int_val);
@@ -1368,10 +1404,12 @@ test_read_url(bool valid)
       printf("--------------------------------------------------------------\n");
       printf("The body...\n%s\n%d\n", body, bodySize);
     }
-    if (body)
+    if (body) {
       TSfree(body);
-    if (header)
+    }
+    if (header) {
       TSfree(header);
+    }
 
     err = TSReadFromUrlEx("http://sadfasdfi.com:80/", &header, &headerSize, &body, &bodySize, 50000);
     if (err != TS_ERR_OKAY) {
@@ -1382,10 +1420,12 @@ test_read_url(bool valid)
       printf("-------------------------------------------------------------\n");
       printf("The body...\n%s\n%d\n", body, bodySize);
     }
-    if (header)
+    if (header) {
       TSfree(header);
-    if (body)
+    }
+    if (body) {
       TSfree(body);
+    }
 
   } else { // use valid urls
     err = TSReadFromUrlEx("lakota.example.com:80/", &header, &headerSize, &body, &bodySize, 50000);
@@ -1398,10 +1438,12 @@ test_read_url(bool valid)
       printf("-------------------------------------------------------------\n");
       printf("The body...\n%s\n%d\n", body, bodySize);
     }
-    if (header)
+    if (header) {
       TSfree(header);
-    if (body)
+    }
+    if (body) {
       TSfree(body);
+    }
 
     // read second url
     err = TSReadFromUrlEx("http://www.apache.org:80/index.html", &header, &headerSize, &body, &bodySize, 50000);
@@ -1413,10 +1455,12 @@ test_read_url(bool valid)
       printf("-------------------------------------------------------------\n");
       printf("The body...\n%s\n%d\n", body, bodySize);
     }
-    if (header)
+    if (header) {
       TSfree(header);
-    if (body)
+    }
+    if (body) {
       TSfree(body);
+    }
   }
 }
 
@@ -1433,9 +1477,9 @@ test_read_file()
   int f_ver    = -1;
 
   printf("\n");
-  if (TSConfigFileRead(TS_FNAME_HOSTING, &f_text, &f_size, &f_ver) != TS_ERR_OKAY)
+  if (TSConfigFileRead(TS_FNAME_HOSTING, &f_text, &f_size, &f_ver) != TS_ERR_OKAY) {
     printf("[TSConfigFileRead] FAILED!\n");
-  else {
+  } else {
     printf("[TSConfigFileRead]\n\tFile Size=%d, Version=%d\n%s\n", f_size, f_ver, f_text);
     TSfree(f_text);
   }
@@ -1457,16 +1501,17 @@ test_write_file()
   int new_f_size    = strlen(new_f_text);
 
   printf("\n");
-  if (TSConfigFileWrite(TS_FNAME_HOSTING, new_f_text, new_f_size, -1) != TS_ERR_OKAY)
+  if (TSConfigFileWrite(TS_FNAME_HOSTING, new_f_text, new_f_size, -1) != TS_ERR_OKAY) {
     printf("[TSConfigFileWrite] FAILED!\n");
-  else
+  } else {
     printf("[TSConfigFileWrite] SUCCESS!\n");
+  }
   printf("\n");
 
   // should free f_text???
-  if (TSConfigFileRead(TS_FNAME_HOSTING, &f_text, &f_size, &f_ver) != TS_ERR_OKAY)
+  if (TSConfigFileRead(TS_FNAME_HOSTING, &f_text, &f_size, &f_ver) != TS_ERR_OKAY) {
     printf("[TSConfigFileRead] FAILED!\n");
-  else {
+  } else {
     printf("[TSConfigFileRead]\n\tFile Size=%d, Version=%d\n%s\n", f_size, f_ver, f_text);
     TSfree(f_text);
   }
@@ -1526,8 +1571,9 @@ test_cfg_context_get(char *args)
   }
 
   ctx = TSCfgContextCreate(file);
-  if (TSCfgContextGet(ctx) != TS_ERR_OKAY)
+  if (TSCfgContextGet(ctx) != TS_ERR_OKAY) {
     printf("ERROR READING FILE\n");
+  }
 
   int count = TSCfgContextGetCount(ctx);
   printf("%d rules in file: %s\n", count, name);
@@ -1593,8 +1639,9 @@ test_cfg_context_move(char *args)
   }
 
   ctx = TSCfgContextCreate(file);
-  if (TSCfgContextGet(ctx) != TS_ERR_OKAY)
+  if (TSCfgContextGet(ctx) != TS_ERR_OKAY) {
     printf("ERROR READING FILE\n");
+  }
 
   int count = TSCfgContextGetCount(ctx);
   printf("%d rules in file: %s\n", count, name);
@@ -1643,8 +1690,9 @@ test_cfg_context_ops()
 
   ctx = TSCfgContextCreate(TS_FNAME_VADDRS);
 
-  if (TSCfgContextGet(ctx) != TS_ERR_OKAY)
+  if (TSCfgContextGet(ctx) != TS_ERR_OKAY) {
     printf("ERROR READING FILE\n");
+  }
 
   printf("\nBEFORE CHANGE:\n");
   //  print_VirtIpAddr_ele_list(ctx);
@@ -1763,8 +1811,9 @@ test_cfg_plugin()
   TSPluginEle *ele;
 
   ctx = TSCfgContextCreate(TS_FNAME_PLUGIN);
-  if (TSCfgContextGet(ctx) != TS_ERR_OKAY)
+  if (TSCfgContextGet(ctx) != TS_ERR_OKAY) {
     printf("ERROR READING FILE\n");
+  }
 
   // retrieve and modify ele
   printf("test_cfg_plugin: modifying the first ele...\n");
@@ -1812,16 +1861,18 @@ test_cfg_socks()
   TSSocksEle *ele;
 
   ctx = TSCfgContextCreate(TS_FNAME_SOCKS);
-  if (TSCfgContextGet(ctx) != TS_ERR_OKAY)
+  if (TSCfgContextGet(ctx) != TS_ERR_OKAY) {
     printf("ERROR READING FILE\n");
+  }
 
   // retrieving an ele
   printf("test_socks_set: modifying the fourth ele...\n");
   cfg_ele = TSCfgContextGetEleAt(ctx, 3);
   ele     = (TSSocksEle *)cfg_ele;
   if (ele) {
-    if (ele->rr != TS_RR_NONE)
+    if (ele->rr != TS_RR_NONE) {
       ele->rr = TS_RR_FALSE;
+    }
   }
 
   // remove the second ele
@@ -1922,10 +1973,11 @@ check_active(char *event_name)
   ret = TSEventIsActive(event_name, &active);
   print_err("TSEventIsActive", ret);
 
-  if (active)
+  if (active) {
     printf("%s is ACTIVE\n", event_name);
-  else
+  } else {
     printf("%s is NOT-ACTIVE\n", event_name);
+  }
 
   return active;
 }
@@ -2025,8 +2077,9 @@ print_snapshots()
     int num = TSStringListLen(list);
     for (int i = 0; i < num; i++) {
       name = TSStringListDequeue(list);
-      if (name)
+      if (name) {
         printf("%s\n", name);
+      }
       TSfree(name);
     }
   }
@@ -2261,14 +2314,16 @@ sync_test()
   printf("[TSRecordSetInt] proxy.config.cluster.cluster_port\n\tAction Should: [%d]\n\tAction is    : [%d]\n", TS_ACTION_RESTART,
          action);
 
-  if (TSRecordSet("proxy.config.http.cache.fuzz.probability", "-0.3333", &action) != TS_ERR_OKAY)
+  if (TSRecordSet("proxy.config.http.cache.fuzz.probability", "-0.3333", &action) != TS_ERR_OKAY) {
     printf("TSRecordSet FAILED!\n");
-  else
+  } else {
     printf("[TSRecordSet] proxy.config.http.cache.fuzz.probability=-0.3333\n");
+  }
 
   TSMgmtError ret;
-  if ((ret = TSProxyStateSet(TS_PROXY_OFF, TS_CACHE_CLEAR_NONE)) != TS_ERR_OKAY)
+  if ((ret = TSProxyStateSet(TS_PROXY_OFF, TS_CACHE_CLEAR_NONE)) != TS_ERR_OKAY) {
     printf("[TSProxyStateSet] turn off FAILED\n");
+  }
   print_err("stop_TS", ret);
 }
 

--- a/mgmt/api/CfgContextImpl.cc
+++ b/mgmt/api/CfgContextImpl.cc
@@ -233,8 +233,9 @@ CacheObj::isValid()
     break;
   }
 
-  if (!m_valid)
+  if (!m_valid) {
     m_ele->cfg_ele.error = TS_ERR_INVALID_CONFIG_RULE;
+  }
 
   return m_valid;
 }
@@ -382,50 +383,64 @@ CongestionObj::formatEleToRule()
       // TS_PD_UNDEFINED
       break;
     }
-    if (psize > 0)
+    if (psize > 0) {
       pos += psize;
+    }
   }
   // secondary specifiers
   if (m_ele->prefix) {
-    if (pos < sizeof(buf) && (psize = snprintf(buf + pos, sizeof(buf) - pos, "prefix=%s ", m_ele->prefix)) > 0)
+    if (pos < sizeof(buf) && (psize = snprintf(buf + pos, sizeof(buf) - pos, "prefix=%s ", m_ele->prefix)) > 0) {
       pos += psize;
+    }
   }
   if (m_ele->port > 0) {
-    if (pos < sizeof(buf) && (psize = snprintf(buf + pos, sizeof(buf) - pos, "port=%d ", m_ele->port)) > 0)
+    if (pos < sizeof(buf) && (psize = snprintf(buf + pos, sizeof(buf) - pos, "port=%d ", m_ele->port)) > 0) {
       pos += psize;
+    }
   }
 
   if (pos < sizeof(buf) &&
-      (psize = snprintf(buf + pos, sizeof(buf) - pos, "max_connection_failures=%d ", m_ele->max_connection_failures)) > 0)
+      (psize = snprintf(buf + pos, sizeof(buf) - pos, "max_connection_failures=%d ", m_ele->max_connection_failures)) > 0) {
     pos += psize;
-  if (pos < sizeof(buf) && (psize = snprintf(buf + pos, sizeof(buf) - pos, "fail_window=%d ", m_ele->fail_window)) > 0)
+  }
+  if (pos < sizeof(buf) && (psize = snprintf(buf + pos, sizeof(buf) - pos, "fail_window=%d ", m_ele->fail_window)) > 0) {
     pos += psize;
+  }
   if (pos < sizeof(buf) &&
-      (psize = snprintf(buf + pos, sizeof(buf) - pos, "proxy_retry_interval=%d ", m_ele->proxy_retry_interval)) > 0)
+      (psize = snprintf(buf + pos, sizeof(buf) - pos, "proxy_retry_interval=%d ", m_ele->proxy_retry_interval)) > 0) {
     pos += psize;
+  }
   if (pos < sizeof(buf) &&
-      (psize = snprintf(buf + pos, sizeof(buf) - pos, "client_wait_interval=%d ", m_ele->client_wait_interval)) > 0)
+      (psize = snprintf(buf + pos, sizeof(buf) - pos, "client_wait_interval=%d ", m_ele->client_wait_interval)) > 0) {
     pos += psize;
+  }
   if (pos < sizeof(buf) &&
-      (psize = snprintf(buf + pos, sizeof(buf) - pos, "wait_interval_alpha=%d ", m_ele->wait_interval_alpha)) > 0)
+      (psize = snprintf(buf + pos, sizeof(buf) - pos, "wait_interval_alpha=%d ", m_ele->wait_interval_alpha)) > 0) {
     pos += psize;
+  }
   if (pos < sizeof(buf) &&
-      (psize = snprintf(buf + pos, sizeof(buf) - pos, "live_os_conn_timeout=%d ", m_ele->live_os_conn_timeout)) > 0)
+      (psize = snprintf(buf + pos, sizeof(buf) - pos, "live_os_conn_timeout=%d ", m_ele->live_os_conn_timeout)) > 0) {
     pos += psize;
+  }
   if (pos < sizeof(buf) &&
-      (psize = snprintf(buf + pos, sizeof(buf) - pos, "live_os_conn_retries=%d ", m_ele->live_os_conn_retries)) > 0)
+      (psize = snprintf(buf + pos, sizeof(buf) - pos, "live_os_conn_retries=%d ", m_ele->live_os_conn_retries)) > 0) {
     pos += psize;
+  }
   if (pos < sizeof(buf) &&
-      (psize = snprintf(buf + pos, sizeof(buf) - pos, "dead_os_conn_timeout=%d ", m_ele->dead_os_conn_timeout)) > 0)
+      (psize = snprintf(buf + pos, sizeof(buf) - pos, "dead_os_conn_timeout=%d ", m_ele->dead_os_conn_timeout)) > 0) {
     pos += psize;
+  }
   if (pos < sizeof(buf) &&
-      (psize = snprintf(buf + pos, sizeof(buf) - pos, "dead_os_conn_retries=%d ", m_ele->dead_os_conn_retries)) > 0)
+      (psize = snprintf(buf + pos, sizeof(buf) - pos, "dead_os_conn_retries=%d ", m_ele->dead_os_conn_retries)) > 0) {
     pos += psize;
-  if (pos < sizeof(buf) && (psize = snprintf(buf + pos, sizeof(buf) - pos, "max_connection=%d ", m_ele->max_connection)) > 0)
+  }
+  if (pos < sizeof(buf) && (psize = snprintf(buf + pos, sizeof(buf) - pos, "max_connection=%d ", m_ele->max_connection)) > 0) {
     pos += psize;
+  }
   if (m_ele->error_page_uri) {
-    if (pos < sizeof(buf) && (psize = snprintf(buf + pos, sizeof(buf) - pos, "error_page=%s ", m_ele->error_page_uri)) > 0)
+    if (pos < sizeof(buf) && (psize = snprintf(buf + pos, sizeof(buf) - pos, "error_page=%s ", m_ele->error_page_uri)) > 0) {
       pos += psize;
+    }
   }
   switch (m_ele->scheme) {
   case TS_HTTP_CONGEST_PER_IP:
@@ -448,11 +463,13 @@ CongestionObj::isValid()
     m_valid = false;
   }
   // all Congestion Ele's should have a prim dest, sec specs are optional
-  if (!m_ele->pd_val)
+  if (!m_ele->pd_val) {
     m_valid = false;
+  }
 
-  if (!m_valid)
+  if (!m_valid) {
     m_ele->cfg_ele.error = TS_ERR_INVALID_CONFIG_RULE;
+  }
   return m_valid;
 }
 
@@ -644,14 +661,16 @@ IcpObj::IcpObj(TokenList *tokens)
 
     switch (i) {
     case 0:
-      if (strlen(alias) > 0)
+      if (strlen(alias) > 0) {
         m_ele->peer_hostname = ats_strdup(alias);
+      }
       break;
     case 1:
       if (strlen(alias) > 0) {
         m_ele->peer_host_ip_addr = string_to_ip_addr(alias);
-        if (!m_ele->peer_host_ip_addr)
+        if (!m_ele->peer_host_ip_addr) {
           goto FORMAT_ERR;
+        }
       }
       break;
     case 2:
@@ -689,8 +708,9 @@ IcpObj::IcpObj(TokenList *tokens)
       break;
     case 6:
       m_ele->mc_ip_addr = string_to_ip_addr(alias);
-      if (!m_ele->mc_ip_addr)
+      if (!m_ele->mc_ip_addr) {
         goto FORMAT_ERR;
+      }
       break;
     case 7:
       mc_ttl = ink_atoi(alias);
@@ -751,16 +771,18 @@ IcpObj::formatEleToRule()
   }
 
   // optional field
-  if (m_ele->peer_host_ip_addr)
+  if (m_ele->peer_host_ip_addr) {
     ip_str1 = ip_addr_to_string(m_ele->peer_host_ip_addr);
-  else
+  } else {
     ip_str1 = ats_strdup("");
+  }
 
   // optional field
-  if (m_ele->mc_ip_addr)
+  if (m_ele->mc_ip_addr) {
     ip_str2 = ip_addr_to_string(m_ele->mc_ip_addr);
-  else
+  } else {
     ip_str2 = ats_strdup("0.0.0.0");
+  }
 
   if (m_ele->peer_hostname) {
     snprintf(buf, sizeof(buf), "%s:%s:%d:%d:%d:%d:%s:", m_ele->peer_hostname, ip_str1, peer_type, m_ele->peer_proxy_port,
@@ -817,11 +839,13 @@ IcpObj::isValid()
   // check valid multicast values: mc_ttl, mc_ip, if enabled
   if (m_ele->is_multicast) {
     // a valid multicast address must be between 224.0.0.0-239.255.255.255
-    if (!ccu_checkIpAddr(m_ele->mc_ip_addr, "224.0.0.0", "239.255.255.255") || m_ele->mc_ttl == TS_MC_TTL_UNDEFINED)
+    if (!ccu_checkIpAddr(m_ele->mc_ip_addr, "224.0.0.0", "239.255.255.255") || m_ele->mc_ttl == TS_MC_TTL_UNDEFINED) {
       m_valid = false;
+    }
   } else { // multicast disabled; only valid mc ip is "0.0.0.0"
-    if (m_ele->mc_ip_addr && strcmp(m_ele->mc_ip_addr, "0.0.0.0") != 0)
+    if (m_ele->mc_ip_addr && strcmp(m_ele->mc_ip_addr, "0.0.0.0") != 0) {
       m_valid = false;
+    }
   }
 
   if (!m_valid) {
@@ -1084,8 +1108,9 @@ ParentProxyObj::formatEleToRule()
   memset(buf, 0, MAX_RULE_SIZE);
 
   pd_str = pdest_sspec_to_string(m_ele->parent_info.pd_type, m_ele->parent_info.pd_val, &(m_ele->parent_info.sec_spec));
-  if (!pd_str)
+  if (!pd_str) {
     return NULL;
+  }
   ink_strlcat(buf, pd_str, sizeof(buf));
   ats_free(pd_str);
 
@@ -1157,8 +1182,9 @@ ParentProxyObj::isValid()
     m_valid = false;
   }
 
-  if (!m_valid)
+  if (!m_valid) {
     m_ele->cfg_ele.error = TS_ERR_INVALID_CONFIG_RULE;
+  }
 
   return m_valid;
 }
@@ -1321,8 +1347,9 @@ VolumeObj::isValid()
     }
   }
 
-  if (!m_valid)
+  if (!m_valid) {
     m_ele->cfg_ele.error = TS_ERR_INVALID_CONFIG_RULE;
+  }
 
   return m_valid;
 }
@@ -1369,10 +1396,12 @@ PluginObj::PluginObj(TokenList *tokens)
   // arguments
   token = tokens->next(token);
   while (token) {
-    if (m_ele->args == TS_INVALID_LIST)
+    if (m_ele->args == TS_INVALID_LIST) {
       m_ele->args = TSStringListCreate();
-    if (token->name)
+    }
+    if (token->name) {
       TSStringListEnqueue(m_ele->args, ats_strdup(token->name));
+    }
     token = tokens->next(token);
   }
 
@@ -1730,8 +1759,9 @@ RemapObj::isValid()
     m_valid = false;
   }
 
-  if (!m_valid)
+  if (!m_valid) {
     m_ele->cfg_ele.error = TS_ERR_INVALID_CONFIG_RULE;
+  }
 
   return m_valid;
 }
@@ -1954,8 +1984,9 @@ SocksObj::isValid()
     break;
   }
 
-  if (!m_valid)
+  if (!m_valid) {
     m_ele->cfg_ele.error = TS_ERR_INVALID_CONFIG_RULE;
+  }
 
   return m_valid;
 }
@@ -2186,8 +2217,9 @@ SplitDnsObj::isValid()
     m_valid = false;
   }
 
-  if (!m_valid)
+  if (!m_valid) {
     m_ele->cfg_ele.error = TS_ERR_INVALID_CONFIG_RULE;
+  }
 
   return m_valid;
 }
@@ -2234,8 +2266,9 @@ StorageObj::StorageObj(TokenList *tokens)
   }
 
   // check if size is specified
-  if (tok->value) // size is specified in second token
+  if (tok->value) { // size is specified in second token
     m_ele->size = ink_atoi(tok->value);
+  }
 
   return;
 
@@ -2276,11 +2309,13 @@ StorageObj::isValid()
     m_valid = false;
   }
 
-  if (!(m_ele->pathname))
+  if (!(m_ele->pathname)) {
     m_valid = false;
+  }
 
-  if (!m_valid)
+  if (!m_valid) {
     m_ele->cfg_ele.error = TS_ERR_INVALID_CONFIG_RULE;
+  }
 
   return m_valid;
 }
@@ -2388,8 +2423,9 @@ VirtIpAddrObj::isValid()
     m_valid = false;
   }
 
-  if (!m_valid)
+  if (!m_valid) {
     m_ele->cfg_ele.error = TS_ERR_INVALID_CONFIG_RULE;
+  }
 
   return m_valid;
 }

--- a/mgmt/api/CfgContextManager.cc
+++ b/mgmt/api/CfgContextManager.cc
@@ -67,8 +67,9 @@ CfgContextCreate(TSFileNameT file)
 TSMgmtError
 CfgContextDestroy(CfgContext *ctx)
 {
-  if (!ctx)
+  if (!ctx) {
     return TS_ERR_PARAMS;
+  }
   delete ctx;
   return TS_ERR_OKAY;
 }
@@ -97,8 +98,9 @@ CfgContextCommit(CfgContext *ctx, LLQ *errRules)
   int len           = 0;
 
   ink_assert(ctx);
-  if (!ctx)
+  if (!ctx) {
     return TS_ERR_PARAMS;
+  }
 
   new_text    = (char *)ats_malloc(max_file_size + 1);
   new_text[0] = '\0';
@@ -126,8 +128,9 @@ CfgContextCommit(CfgContext *ctx, LLQ *errRules)
     ink_strlcat(new_text, "\n", max_file_size + 1);
 
     ats_free(rule);
-    if (ele->getRuleType() != TS_TYPE_COMMENT)
+    if (ele->getRuleType() != TS_TYPE_COMMENT) {
       index++;
+    }
     ele = ctx->next(ele);
   }
 
@@ -135,8 +138,9 @@ CfgContextCommit(CfgContext *ctx, LLQ *errRules)
   ver = ctx->getVersion();
   ret = WriteFile(ctx->getFilename(), new_text, size, ver);
   ats_free(new_text);
-  if (ret != TS_ERR_OKAY)
+  if (ret != TS_ERR_OKAY) {
     return TS_ERR_FAIL; // couldn't write file
+  }
 
   return err;
 }
@@ -159,16 +163,18 @@ CfgContextGet(CfgContext *ctx)
   CfgEleObj *ele      = NULL;
 
   ink_assert(ctx);
-  if (!ctx)
+  if (!ctx) {
     return TS_ERR_PARAMS;
+  }
 
   // get copy of the file
   ret = ReadFile(ctx->getFilename(), &old_text, &size, &ver);
   if (ret != TS_ERR_OKAY) {
     // TODO: Hmmm, this looks almost like a memory leak, why the strcmp ??
-    if (old_text && strcmp(old_text, "") != 0)
+    if (old_text && strcmp(old_text, "") != 0) {
       ats_free(old_text); // need to free memory
-    return ret;           // Pass the error code along
+    }
+    return ret; // Pass the error code along
   }
   // store version number
   ctx->setVersion(ver);
@@ -192,8 +198,9 @@ CfgContextGet(CfgContext *ctx)
   }
   delete (rule_list); // free RuleList memory
   // TODO: Hmmm, this looks almost like a memory leak, why the strcmp ??
-  if (old_text && strcmp(old_text, "") != 0)
+  if (old_text && strcmp(old_text, "") != 0) {
     ats_free(old_text); // need to free memory
+  }
   return TS_ERR_OKAY;
 }
 
@@ -213,8 +220,9 @@ CfgContextGetCount(CfgContext *ctx)
   int count = 0;
 
   ink_assert(ctx);
-  if (!ctx)
+  if (!ctx) {
     return -1;
+  }
 
   // iterate CfgContext; return the first EleObj that's not a comment
   curr_ele = ctx->first(); // get head of ele
@@ -242,8 +250,9 @@ CfgContextGetObjAt(CfgContext *ctx, int index)
   int count = 0; // start counting from 0
 
   ink_assert(ctx);
-  if (!ctx)
+  if (!ctx) {
     return NULL;
+  }
 
   // iterate through the ctx, keep count of all NON-Comment Obj Objects
   curr_ele = ctx->first(); // get head of ele
@@ -278,8 +287,9 @@ CfgContextGetEleAt(CfgContext *ctx, int index)
   int count = 0; // start counting from 0
 
   ink_assert(ctx);
-  if (!ctx)
+  if (!ctx) {
     return NULL;
+  }
 
   // iterate through the ctx, keep count of all NON-Comment Ele Objects
   curr_ele = ctx->first(); // get head of ele
@@ -313,8 +323,9 @@ CfgContextGetFirst(CfgContext *ctx, TSCfgIterState *state)
   CfgEleObj *curr_ele;
 
   ink_assert(ctx && state);
-  if (!ctx || !state)
+  if (!ctx || !state) {
     return NULL;
+  }
 
   // iterate; return the first CfgEleObj that's not a comment
   curr_ele = ctx->first(); // get head of ele
@@ -343,8 +354,9 @@ CfgContextGetNext(CfgContext *ctx, TSCfgIterState *state)
   CfgEleObj *curr_ele;
 
   ink_assert(ctx && state);
-  if (!ctx || !state)
+  if (!ctx || !state) {
     return NULL;
+  }
 
   // iterate through the ctx, keep count of all NON-Comment Ele Objects
   // when count == state->index, then return next ele
@@ -387,12 +399,14 @@ CfgContextMoveEleUp(CfgContext *ctx, int index)
   TSMgmtError ret;
 
   ink_assert(ctx && index >= 0);
-  if (!ctx || index < 0)
+  if (!ctx || index < 0) {
     return TS_ERR_PARAMS;
+  }
 
   // moving the first Ele up does nothing
-  if (index == 0)
+  if (index == 0) {
     return TS_ERR_OKAY;
+  }
 
   // retrieve the ELe and make a copy of it
   curr_ele_obj = ctx->first(); // get head of ele
@@ -414,8 +428,9 @@ CfgContextMoveEleUp(CfgContext *ctx, int index)
     }
   }
   // reached end of CfgContext before hit index
-  if (count != index)
+  if (count != index) {
     return TS_ERR_FAIL;
+  }
 
   // reinsert  the ele at index-1
   ret = CfgContextInsertEleAt(ctx, ele_copy, index - 1);
@@ -440,16 +455,19 @@ CfgContextMoveEleDown(CfgContext *ctx, int index)
   int tot_ele;
 
   ink_assert(ctx);
-  if (!ctx)
+  if (!ctx) {
     return TS_ERR_PARAMS;
+  }
 
   tot_ele = CfgContextGetCount(ctx); // inefficient!
-  if (index < 0 || index >= tot_ele)
+  if (index < 0 || index >= tot_ele) {
     return TS_ERR_PARAMS;
+  }
 
   // moving the last ele down does nothing
-  if (index == (tot_ele - 1))
+  if (index == (tot_ele - 1)) {
     return TS_ERR_OKAY;
+  }
 
   // retrieve the ELe and make a copy of it
   curr_ele_obj = ctx->first(); // get head of ele
@@ -471,8 +489,9 @@ CfgContextMoveEleDown(CfgContext *ctx, int index)
     }
   }
   // reached end of CfgContext before hit index
-  if (count != index)
+  if (count != index) {
     return TS_ERR_FAIL;
+  }
 
   // reinsert  the ele at index+1
   ret = CfgContextInsertEleAt(ctx, ele_copy, index + 1);

--- a/mgmt/api/CfgContextUtils.cc
+++ b/mgmt/api/CfgContextUtils.cc
@@ -52,12 +52,14 @@ string_to_ip_addr_ele(const char *str)
   char buf[MAX_BUF_SIZE];
 
   // ink_assert(str);
-  if (!str)
+  if (!str) {
     return NULL;
+  }
 
   ele = TSIpAddrEleCreate();
-  if (!ele)
+  if (!ele) {
     return NULL;
+  }
 
   memset(buf, 0, MAX_BUF_SIZE);
   snprintf(buf, sizeof(buf), "%s", str);
@@ -73,13 +75,15 @@ string_to_ip_addr_ele(const char *str)
     if (numTokens == 1) { // Single, NON-CIDR TYPE
       ele->ip_a = string_to_ip_addr(str);
     } else { // Single, CIDR TYPE
-      if (!isNumber(cidr_tokens[1]))
+      if (!isNumber(cidr_tokens[1])) {
         goto Lerror;
+      }
       ele->ip_a   = string_to_ip_addr(cidr_tokens[0]);
       ele->cidr_a = ink_atoi(cidr_tokens[1]);
     }
-    if (!ele->ip_a) // ERROR: Invalid ip
+    if (!ele->ip_a) { // ERROR: Invalid ip
       goto Lerror;
+    }
   } else { // RANGE TYPE
     ele->type  = TS_IP_RANGE;
     const_ip_a = range_tokens[0];
@@ -99,11 +103,13 @@ string_to_ip_addr_ele(const char *str)
       cidr_tokens2.Initialize(ip_b, COPY_TOKS);
       ele->ip_b   = string_to_ip_addr(cidr_tokens2[0]);
       ele->cidr_b = ink_atoi(cidr_tokens2[1]);
-      if (!isNumber(cidr_tokens[1]) || !isNumber(cidr_tokens2[1]))
+      if (!isNumber(cidr_tokens[1]) || !isNumber(cidr_tokens2[1])) {
         goto Lerror;
+      }
     }
-    if (!ele->ip_a || !ele->ip_b) // ERROR: invalid IP
+    if (!ele->ip_a || !ele->ip_b) { // ERROR: invalid IP
       goto Lerror;
+    }
   }
 
   ats_free(ip_a);
@@ -135,18 +141,21 @@ ip_addr_ele_to_string(TSIpAddrEle *ele)
   char *str, *ip_a_str = NULL, *ip_b_str = NULL;
 
   // ink_assert(ele);
-  if (!ele)
+  if (!ele) {
     goto Lerror;
+  }
 
   memset(buf, 0, MAX_BUF_SIZE);
 
-  if (ele->ip_a == TS_INVALID_IP_ADDR)
+  if (ele->ip_a == TS_INVALID_IP_ADDR) {
     goto Lerror; // invalid ip_addr
+  }
 
   if (ele->type == TS_IP_SINGLE) { // SINGLE TYPE
     ip_a_str = ip_addr_to_string(ele->ip_a);
-    if (!ip_a_str) // ERROR: invalid IP address
+    if (!ip_a_str) { // ERROR: invalid IP address
       goto Lerror;
+    }
     if (ele->cidr_a != TS_INVALID_IP_CIDR) { // a cidr type
       snprintf(buf, sizeof(buf), "%s%c%d", ip_a_str, CIDR_DELIMITER, ele->cidr_a);
     } else { // not cidr type
@@ -161,8 +170,9 @@ ip_addr_ele_to_string(TSIpAddrEle *ele)
     ip_a_str = ip_addr_to_string(ele->ip_a);
     ip_b_str = ip_addr_to_string(ele->ip_b);
 
-    if (!ip_a_str || !ip_b_str)
+    if (!ip_a_str || !ip_b_str) {
       goto Lerror;
+    }
 
     if (ele->cidr_a != TS_INVALID_IP_CIDR && ele->cidr_b != TS_INVALID_IP_CIDR) {
       // a cidr type
@@ -214,8 +224,9 @@ TSIpAddr
 string_to_ip_addr(const char *str)
 {
   // ink_assert(str);
-  if (!ccu_checkIpAddr(str))
+  if (!ccu_checkIpAddr(str)) {
     return TS_INVALID_IP_ADDR;
+  }
 
   char *copy;
   copy = ats_strdup(str);
@@ -239,8 +250,9 @@ ip_addr_list_to_string(IpAddrList *list, const char *delimiter)
   int num, i;
 
   // ink_assert(list && delimiter);
-  if (!list || !delimiter)
+  if (!list || !delimiter) {
     return NULL;
+  }
 
   num = queue_len((LLQ *)list);
 
@@ -252,10 +264,11 @@ ip_addr_list_to_string(IpAddrList *list, const char *delimiter)
       enqueue((LLQ *)list, ip_ele);
       return NULL;
     }
-    if (i == num - 1)
+    if (i == num - 1) {
       snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "%s", ip_str);
-    else
+    } else {
       snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "%s%s", ip_str, delimiter);
+    }
     buf_pos = strlen(buf);
     ats_free(ip_str);
 
@@ -283,8 +296,9 @@ string_to_ip_addr_list(const char *str_list, const char *delimiter)
   TSIpAddrEle *ip_ele;
 
   // ink_assert(str_list && delimiter);
-  if (!str_list || !delimiter)
+  if (!str_list || !delimiter) {
     return TS_INVALID_LIST;
+  }
 
   tokens.Initialize(str_list);
   numToks = tokens.count();
@@ -323,8 +337,9 @@ port_list_to_string(PortList *ports, const char *delimiter)
   char *str;
 
   // ink_assert(ports && delimiter);
-  if (!ports || !delimiter)
+  if (!ports || !delimiter) {
     goto Lerror;
+  }
 
   num_ports = queue_len((LLQ *)ports);
   if (num_ports <= 0) { // no ports specified
@@ -380,8 +395,9 @@ string_to_port_list(const char *str_list, const char *delimiter)
   TSPortEle *port_ele;
 
   // ink_assert(str_list && delimiter);
-  if (!str_list || !delimiter)
+  if (!str_list || !delimiter) {
     return TS_INVALID_LIST;
+  }
 
   tokens.Initialize(str_list);
 
@@ -415,8 +431,9 @@ port_ele_to_string(TSPortEle *ele)
   char *str;
 
   // ink_assert(ele);
-  if (!ele || !ccu_checkPortEle(ele))
+  if (!ele || !ccu_checkPortEle(ele)) {
     return NULL;
+  }
 
   memset(buf, 0, MAX_BUF_SIZE);
 
@@ -444,22 +461,26 @@ string_to_port_ele(const char *str)
   char copy[MAX_BUF_SIZE];
 
   // ink_assert(str);
-  if (!str)
+  if (!str) {
     return NULL;
+  }
 
   memset(copy, 0, MAX_BUF_SIZE);
   snprintf(copy, sizeof(copy), "%s", str);
 
   ele = TSPortEleCreate();
-  if (tokens.Initialize(copy, COPY_TOKS) > 2)
+  if (tokens.Initialize(copy, COPY_TOKS) > 2) {
     goto Lerror;
+  }
   if (tokens.count() == 1) { // Not a Range of ports
-    if (!isNumber(str))
+    if (!isNumber(str)) {
       goto Lerror;
+    }
     ele->port_a = ink_atoi(str);
   } else {
-    if (!isNumber(tokens[0]) || !isNumber(tokens[1]))
+    if (!isNumber(tokens[0]) || !isNumber(tokens[1])) {
       goto Lerror;
+    }
     ele->port_a = ink_atoi(tokens[0]);
     ele->port_b = ink_atoi(tokens[1]);
   }
@@ -491,8 +512,9 @@ string_list_to_string(TSStringList str_list, const char *delimiter)
   char *str_ele, *list_str;
 
   // ink_assert(str_list != TS_INVALID_LIST && delimiter);
-  if (str_list == TS_INVALID_LIST || !delimiter)
+  if (str_list == TS_INVALID_LIST || !delimiter) {
     return NULL;
+  }
 
   memset(buf, 0, MAX_BUF_SIZE);
   numElems = queue_len((LLQ *)str_list);
@@ -500,11 +522,13 @@ string_list_to_string(TSStringList str_list, const char *delimiter)
     str_ele = (char *)dequeue((LLQ *)str_list);
 
     if (i == numElems - 1) { // the last element shouldn't print comma
-      if (buf_pos < sizeof(buf) && (psize = snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "%s", str_ele)) > 0)
+      if (buf_pos < sizeof(buf) && (psize = snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "%s", str_ele)) > 0) {
         buf_pos += psize;
+      }
     } else {
-      if (buf_pos < sizeof(buf) && (psize = snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "%s%s", str_ele, delimiter)) > 0)
+      if (buf_pos < sizeof(buf) && (psize = snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "%s%s", str_ele, delimiter)) > 0) {
         buf_pos += psize;
+      }
     }
 
     enqueue((LLQ *)str_list, str_ele);
@@ -528,8 +552,9 @@ string_to_string_list(const char *str, const char *delimiter)
   tokens.Initialize(str);
 
   // ink_assert(str && delimiter);
-  if (!str || !delimiter)
+  if (!str || !delimiter) {
     return TS_INVALID_LIST;
+  }
 
   TSStringList str_list = TSStringListCreate();
   for (unsigned i = 0; i < tokens.count(); i++) {
@@ -556,8 +581,9 @@ int_list_to_string(TSIntList list, const char *delimiter)
   int *elem;
 
   // ink_assert(list != TS_INVALID_LIST && delimiter);
-  if (list == TS_INVALID_LIST || !delimiter)
+  if (list == TS_INVALID_LIST || !delimiter) {
     return NULL;
+  }
 
   numElems = queue_len((LLQ *)list);
 
@@ -565,11 +591,13 @@ int_list_to_string(TSIntList list, const char *delimiter)
   for (i = 0; i < numElems; i++) {
     elem = (int *)dequeue((LLQ *)list);
     if (i == numElems - 1) {
-      if (buf_pos < sizeof(buf) && (psize = snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "%d", *elem)) > 0)
+      if (buf_pos < sizeof(buf) && (psize = snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "%d", *elem)) > 0) {
         buf_pos += psize;
+      }
     } else {
-      if (buf_pos < sizeof(buf) && (psize = snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "%d%s", *elem, delimiter)) > 0)
+      if (buf_pos < sizeof(buf) && (psize = snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "%d%s", *elem, delimiter)) > 0) {
         buf_pos += psize;
+      }
     }
     enqueue((LLQ *)list, elem);
   }
@@ -592,8 +620,9 @@ string_to_int_list(const char *str_list, const char *delimiter)
   int *ele;
 
   // ink_assert (str_list  && delimiter);
-  if (!str_list || !delimiter)
+  if (!str_list || !delimiter) {
     return TS_INVALID_LIST;
+  }
 
   tokens.Initialize(str_list);
 
@@ -601,8 +630,9 @@ string_to_int_list(const char *str_list, const char *delimiter)
   list    = TSIntListCreate();
 
   for (i = 0; i < numToks; i++) {
-    if (!isNumber(tokens[i]))
+    if (!isNumber(tokens[i])) {
       goto Lerror;
+    }
     ele  = (int *)ats_malloc(sizeof(int));
     *ele = ink_atoi(tokens[i]); // What about we can't convert? ERROR?
     TSIntListEnqueue(list, ele);
@@ -630,8 +660,9 @@ string_to_domain_list(const char *str_list, const char *delimiter)
   TSDomain *ele;
 
   // ink_assert(str_list && delimiter);
-  if (!str_list || !delimiter)
+  if (!str_list || !delimiter) {
     return TS_INVALID_LIST;
+  }
 
   tokens.Initialize(str_list);
 
@@ -670,8 +701,9 @@ domain_list_to_string(TSDomainList list, const char *delimiter)
   TSDomain *domain;
 
   // ink_assert(list != TS_INVALID_LIST && delimiter);
-  if (list == TS_INVALID_LIST || !delimiter)
+  if (list == TS_INVALID_LIST || !delimiter) {
     return NULL;
+  }
 
   numElems = queue_len((LLQ *)list);
 
@@ -685,11 +717,13 @@ domain_list_to_string(TSDomainList list, const char *delimiter)
       return NULL;
     }
     if (i == numElems - 1) { // the last element shouldn't print comma
-      if (buf_pos < sizeof(buf) && (psize = snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "%s", dom_str)) > 0)
+      if (buf_pos < sizeof(buf) && (psize = snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "%s", dom_str)) > 0) {
         buf_pos += psize;
+      }
     } else {
-      if (buf_pos < sizeof(buf) && (psize = snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "%s%s", dom_str, delimiter)) > 0)
+      if (buf_pos < sizeof(buf) && (psize = snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "%s%s", dom_str, delimiter)) > 0) {
         buf_pos += psize;
+      }
     }
 
     ats_free(dom_str);
@@ -713,14 +747,16 @@ domain_to_string(TSDomain *domain)
   char *dom_str;
 
   // ink_assert(domain);
-  if (!domain)
+  if (!domain) {
     return NULL;
+  }
 
   if (domain->domain_val) {
-    if (domain->port != TS_INVALID_PORT) // host:port
+    if (domain->port != TS_INVALID_PORT) { // host:port
       snprintf(buf, sizeof(buf), "%s:%d", domain->domain_val, domain->port);
-    else // host
+    } else { // host
       snprintf(buf, sizeof(buf), "%s", domain->domain_val);
+    }
   } else {
     return NULL; // invalid TSDomain
   }
@@ -746,8 +782,9 @@ string_to_domain(const char *str)
   char buf[MAX_BUF_SIZE];
 
   // ink_assert(str);
-  if (!str)
+  if (!str) {
     return NULL;
+  }
 
   dom = TSDomainCreate();
 
@@ -755,16 +792,18 @@ string_to_domain(const char *str)
   ink_strlcpy(buf, str, sizeof(buf));
   token  = strtok_r(buf, ":", &token_pos);
   remain = token_pos;
-  if (token)
+  if (token) {
     dom->domain_val = ats_strdup(token);
-  else
+  } else {
     goto Lerror;
+  }
 
   // get port, if exists
   if (remain) {
     // check if the "remain" consist of all integers
-    if (!isNumber(remain))
+    if (!isNumber(remain)) {
       goto Lerror;
+    }
     dom->port = ink_atoi(remain);
   } else {
     dom->port = TS_INVALID_PORT;
@@ -796,8 +835,9 @@ pdest_sspec_to_string(TSPrimeDestT pd, char *pd_val, TSSspec *sspec)
   char *src_ip, *str;
 
   // ink_assert(pd != TS_PD_UNDEFINED && pd_val && sspec);
-  if (pd == TS_PD_UNDEFINED || !pd_val || !sspec)
+  if (pd == TS_PD_UNDEFINED || !pd_val || !sspec) {
     return NULL;
+  }
 
   memset(buf, 0, MAX_BUF_SIZE);
 
@@ -825,10 +865,12 @@ pdest_sspec_to_string(TSPrimeDestT pd, char *pd_val, TSSspec *sspec)
       // TS_PD_UNDEFINED
       break;
     }
-    if (psize > 0)
+    if (psize > 0) {
       buf_pos += psize;
-    if (buf_pos + 1 >= sizeof(buf))
+    }
+    if (buf_pos + 1 >= sizeof(buf)) {
       break;
+    }
 
     // if there are secondary specifiers
     if (sspec) {
@@ -873,8 +915,9 @@ pdest_sspec_to_string(TSPrimeDestT pd, char *pd_val, TSSspec *sspec)
       if (!(sspec->time.hour_a == 0 && sspec->time.min_a == 0 && sspec->time.hour_b == 0 && sspec->time.min_b == 0)) {
         // time is specified
         if (buf_pos < sizeof(buf) &&
-            (psize = snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "time=%s:%s-%s:%s ", hour_a, min_a, hour_b, min_b)) > 0)
+            (psize = snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "time=%s:%s-%s:%s ", hour_a, min_a, hour_b, min_b)) > 0) {
           buf_pos += psize;
+        }
       }
       // src_ip
       if (sspec->src_ip != TS_INVALID_IP_ADDR) {
@@ -882,26 +925,30 @@ pdest_sspec_to_string(TSPrimeDestT pd, char *pd_val, TSSspec *sspec)
         if (!src_ip) {
           return NULL;
         }
-        if (buf_pos < sizeof(buf) && (psize = snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "src_ip=%s ", src_ip)) > 0)
+        if (buf_pos < sizeof(buf) && (psize = snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "src_ip=%s ", src_ip)) > 0) {
           buf_pos += psize;
+        }
         ats_free(src_ip);
       }
       // prefix?
       if (sspec->prefix) {
-        if (buf_pos < sizeof(buf) && (psize = snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "prefix=%s ", sspec->prefix)) > 0)
+        if (buf_pos < sizeof(buf) && (psize = snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "prefix=%s ", sspec->prefix)) > 0) {
           buf_pos += psize;
+        }
       }
       // suffix?
       if (sspec->suffix) {
-        if (buf_pos < sizeof(buf) && (psize = snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "suffix=%s ", sspec->suffix)) > 0)
+        if (buf_pos < sizeof(buf) && (psize = snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "suffix=%s ", sspec->suffix)) > 0) {
           buf_pos += psize;
+        }
       }
       // port?
       if (sspec->port) {
         char *portStr = port_ele_to_string(sspec->port);
         if (portStr) {
-          if (buf_pos < sizeof(buf) && (psize = snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "port=%s ", portStr)) > 0)
+          if (buf_pos < sizeof(buf) && (psize = snprintf(buf + buf_pos, sizeof(buf) - buf_pos, "port=%s ", portStr)) > 0) {
             buf_pos += psize;
+          }
           ats_free(portStr);
         }
       }
@@ -927,10 +974,12 @@ pdest_sspec_to_string(TSPrimeDestT pd, char *pd_val, TSSspec *sspec)
           psize = 0;
           break;
         }
-        if (psize > 0)
+        if (psize > 0) {
           buf_pos += psize;
-      } else
+        }
+      } else {
         break;
+      }
 
       // scheme
       if (buf_pos < sizeof(buf)) {
@@ -969,8 +1018,9 @@ string_to_pdss_format(const char *str, TSPdSsFormat *pdss)
   char copy[MAX_BUF_SIZE];
 
   // ink_assert(str && pdss);
-  if (!str || !pdss)
+  if (!str || !pdss) {
     return TS_ERR_PARAMS;
+  }
 
   memset(copy, 0, MAX_BUF_SIZE);
   snprintf(copy, sizeof(copy), "%s", str);
@@ -993,15 +1043,17 @@ string_to_pdss_format(const char *str, TSPdSsFormat *pdss)
   }
 
   // pd_value
-  if (!tokens[2])
+  if (!tokens[2]) {
     goto Lerror;
+  }
   pdss->pd_val = ats_strdup(tokens[2]);
 
   // check secondary specifiers; exists only if not empty string
   // time
   if (strlen(tokens[3]) > 0) {
-    if (string_to_time_struct(tokens[3], &(pdss->sec_spec)) != TS_ERR_OKAY)
+    if (string_to_time_struct(tokens[3], &(pdss->sec_spec)) != TS_ERR_OKAY) {
       goto Lerror;
+    }
   }
   // src_ip
   if (strlen(tokens[4]) > 0) {
@@ -1046,10 +1098,11 @@ hms_time_to_string(TSHmsTime time)
 
   s = snprintf(buf, sizeof(buf), "%dd%dh%dm%ds", time.d, time.h, time.m, time.s);
 
-  if ((s > 0) && (s < sizeof(buf)))
+  if ((s > 0) && (s < sizeof(buf))) {
     return ats_strdup(buf);
-  else
+  } else {
     return NULL;
+  }
 }
 
 /*----------------------------------------------------------------------------
@@ -1068,8 +1121,9 @@ string_to_hms_time(const char *str, TSHmsTime *time)
   bool valid = false;
 
   // ink_assert(str && time);
-  if (!str || !time)
+  if (!str || !time) {
     return TS_ERR_PARAMS;
+  }
 
   memset(unit, 0, 10);
   len     = strlen(str);
@@ -1077,29 +1131,33 @@ string_to_hms_time(const char *str, TSHmsTime *time)
   for (i = 0; i < len; i++) {
     valid = false;
     if ((*str) == 'd') {
-      if (time->d > 0 || !isNumber(unit))
+      if (time->d > 0 || !isNumber(unit)) {
         goto Lerror;
+      }
       time->d = ink_atoi(unit);
       memset(unit, 0, 10);
       pos   = 0;
       valid = true;
     } else if ((*str) == 'h') {
-      if (time->h > 0 || !isNumber(unit))
+      if (time->h > 0 || !isNumber(unit)) {
         goto Lerror;
+      }
       time->h = ink_atoi(unit);
       memset(unit, 0, 10);
       pos   = 0;
       valid = true;
     } else if ((*str) == 'm') {
-      if (time->m > 0 || !isNumber(unit))
+      if (time->m > 0 || !isNumber(unit)) {
         goto Lerror;
+      }
       time->m = ink_atoi(unit);
       memset(unit, 0, 10);
       pos   = 0;
       valid = true;
     } else if ((*str) == 's') {
-      if (time->s > 0 || !isNumber(unit))
+      if (time->s > 0 || !isNumber(unit)) {
         goto Lerror;
+      }
       time->s = ink_atoi(unit);
       memset(unit, 0, 10);
       pos   = 0;
@@ -1112,8 +1170,9 @@ string_to_hms_time(const char *str, TSHmsTime *time)
     ++str;
   }
 
-  if (!valid)
+  if (!valid) {
     goto Lerror;
+  }
   return TS_ERR_OKAY;
 
 Lerror:
@@ -1144,35 +1203,40 @@ string_to_time_struct(const char *str, TSSspec *sspec)
   if (strcmp(time_tokens[0], "00") == 0) {
     sspec->time.hour_a = 0;
   } else {
-    if (!isNumber(time_tokens[0]))
+    if (!isNumber(time_tokens[0])) {
       goto Lerror;
+    }
     sspec->time.hour_a = ink_atoi(time_tokens[0]);
   }
   if (strcmp(time_tokens[1], "00") == 0) {
     sspec->time.min_a = 0;
   } else {
-    if (!isNumber(time_tokens[1]))
+    if (!isNumber(time_tokens[1])) {
       goto Lerror;
+    }
     sspec->time.min_a = ink_atoi(time_tokens[1]);
   }
   if (strcmp(time_tokens[2], "00") == 0) {
     sspec->time.hour_b = 0;
   } else {
-    if (!isNumber(time_tokens[2]))
+    if (!isNumber(time_tokens[2])) {
       goto Lerror;
+    }
     sspec->time.hour_b = ink_atoi(time_tokens[2]);
   }
   if (strcmp(time_tokens[3], "00") == 0) {
     sspec->time.min_b = 0;
   } else {
-    if (!isNumber(time_tokens[3]))
+    if (!isNumber(time_tokens[3])) {
       goto Lerror;
+    }
     sspec->time.min_b = ink_atoi(time_tokens[3]);
   }
 
   // check valid time values
-  if (!ccu_checkTimePeriod(sspec))
+  if (!ccu_checkTimePeriod(sspec)) {
     goto Lerror;
+  }
 
   return TS_ERR_OKAY;
 
@@ -1189,8 +1253,9 @@ TSHdrT
 string_to_header_type(const char *str)
 {
   // ink_assert(str);
-  if (!str)
+  if (!str) {
     return TS_HDR_UNDEFINED;
+  }
 
   if (strcmp(str, "date") == 0) {
     return TS_HDR_DATE;
@@ -1355,12 +1420,13 @@ multicast_type_to_string(TSMcTtlT mc)
 TSRrT
 string_to_round_robin_type(const char *rr)
 {
-  if (strcmp(rr, "true") == 0)
+  if (strcmp(rr, "true") == 0) {
     return TS_RR_TRUE;
-  else if (strcmp(rr, "false") == 0)
+  } else if (strcmp(rr, "false") == 0) {
     return TS_RR_FALSE;
-  else if (strcmp(rr, "strict") == 0)
+  } else if (strcmp(rr, "strict") == 0) {
     return TS_RR_STRICT;
+  }
 
   return TS_RR_UNDEFINED;
 }
@@ -1502,8 +1568,9 @@ tokens_to_pdss_format(TokenList *tokens, Token *first_tok, TSPdSsFormat *pdss)
   const char *sspecs[NUM_SEC_SPECS] = {"time", "src_ip", "prefix", "suffix", "port", "method", "scheme", "tag"};
 
   // ink_assert(tokens && first_tok && pdss);
-  if (!tokens || !first_tok || !pdss)
+  if (!tokens || !first_tok || !pdss) {
     return NULL;
+  }
 
   // tokens->Print();
 
@@ -1618,14 +1685,16 @@ ccu_checkIpAddr(const char *addr, const char *min_addr, const char *max_addr)
   Tokenizer maxToks(".");
   int len, addrQ, minQ, maxQ;
 
-  if (!addr || !min_addr || !max_addr)
+  if (!addr || !min_addr || !max_addr) {
     return false;
+  }
   // BZ47440
   // truncate any leading or trailing white spaces from addr,
   // which can occur if IP is from a list of IP addresses
   char *new_addr = chopWhiteSpaces_alloc((char *)addr);
-  if (new_addr == NULL)
+  if (new_addr == NULL) {
     return false;
+  }
 
   if ((addrToks.Initialize(new_addr, ALLOW_EMPTY_TOKS)) != 4 || (minToks.Initialize((char *)min_addr, ALLOW_EMPTY_TOKS)) != 4 ||
       (maxToks.Initialize((char *)max_addr, ALLOW_EMPTY_TOKS)) != 4) {
@@ -1669,8 +1738,9 @@ ccu_checkIpAddr(const char *addr, const char *min_addr, const char *max_addr)
 bool
 ccu_checkIpAddrEle(TSIpAddrEle *ele)
 {
-  if (!ele || ele->ip_a == TS_INVALID_IP_ADDR)
+  if (!ele || ele->ip_a == TS_INVALID_IP_ADDR) {
     return false;
+  }
 
   if (ele->type == TS_IP_SINGLE) { // SINGLE TYPE
     return (ccu_checkIpAddr(ele->ip_a));
@@ -1692,14 +1762,16 @@ ccu_checkPortNum(int port)
 bool
 ccu_checkPortEle(TSPortEle *ele)
 {
-  if (!ele)
+  if (!ele) {
     return false;
+  }
 
   if (ele->port_b == 0) { // single port
     return (ccu_checkPortNum(ele->port_a));
   } else { // range of ports
-    if (ele->port_a >= ele->port_b)
+    if (ele->port_a >= ele->port_b) {
       return false;
+    }
     return (ccu_checkPortNum(ele->port_a) && ccu_checkPortNum(ele->port_b));
   }
 }
@@ -1726,19 +1798,22 @@ ccu_checkPdSspec(TSPdSsFormat pdss)
   // if pdest is IP type, check if valid IP (could be single or range)
   if (pdss.pd_type == TS_PD_IP) {
     TSIpAddrEle *ip = string_to_ip_addr_ele(pdss.pd_val);
-    if (!ip)
+    if (!ip) {
       goto Lerror;
-    else
+    } else {
       TSIpAddrEleDestroy(ip);
+    }
   }
   // if src_ip specified, check if valid IP address
   if (pdss.sec_spec.src_ip) {
-    if (!ccu_checkIpAddr(pdss.sec_spec.src_ip))
+    if (!ccu_checkIpAddr(pdss.sec_spec.src_ip)) {
       goto Lerror;
+    }
   }
 
-  if (!ccu_checkTimePeriod(&(pdss.sec_spec)))
+  if (!ccu_checkTimePeriod(&(pdss.sec_spec))) {
     goto Lerror;
+  }
 
   return true;
 
@@ -1765,16 +1840,18 @@ ccu_checkUrl(char *url)
 
   // check if there's a second occurrence
   slashStr = strstr(url, ":/");
-  if (slashStr)
+  if (slashStr) {
     return false;
+  }
 
   // make sure that after the first solo "/", there are no more ":"
   // to specify ports
   slashStr = strstr(url, "/"); // begin path prefix
   if (slashStr) {
     url = slashStr++;
-    if (strstr(url, ":"))
+    if (strstr(url, ":")) {
       return false; // the port must be specified before the prefix
+    }
   }
 
   return true;
@@ -1792,15 +1869,17 @@ ccu_checkTimePeriod(TSSspec *sspec)
 {
   // check valid time values
   if (sspec->time.hour_a < 0 || sspec->time.hour_a > 23 || sspec->time.hour_b < 0 || sspec->time.hour_b > 23 ||
-      sspec->time.min_a < 0 || sspec->time.min_a > 59 || sspec->time.min_b < 0 || sspec->time.min_b > 59)
+      sspec->time.min_a < 0 || sspec->time.min_a > 59 || sspec->time.min_b < 0 || sspec->time.min_b > 59) {
     return false;
+  }
 
   // check time_a < time_b
   if (sspec->time.hour_a > sspec->time.hour_b) {
     return false;
   } else if (sspec->time.hour_a == sspec->time.hour_b) {
-    if (sspec->time.min_a > sspec->time.min_b)
+    if (sspec->time.min_a > sspec->time.min_b) {
       return false;
+    }
   }
 
   return true;
@@ -1817,8 +1896,9 @@ chopWhiteSpaces_alloc(char *str)
 {
   int len;
 
-  if (!str)
+  if (!str) {
     return NULL;
+  }
 
   // skip any leading white spaces
   while (*str != '\0') {
@@ -1853,8 +1933,9 @@ create_ele_obj_from_rule_node(Rule *rule)
 
   // sanity check
   // ink_assert(rule != NULL);
-  if (!rule)
+  if (!rule) {
     return NULL;
+  }
 
   // first check if the rule node is a comment
   if (rule->getComment()) {
@@ -1950,8 +2031,9 @@ create_ele_obj_from_ele(TSCfgEle *ele)
 {
   CfgEleObj *ele_obj = NULL;
 
-  if (!ele)
+  if (!ele) {
     return NULL;
+  }
 
   switch (ele->type) {
   case TS_CACHE_NEVER:           /* cache.config */
@@ -2045,8 +2127,9 @@ get_rule_type(TokenList *token_list, TSFileNameT file)
   Token *tok;
 
   // ink_asser(ttoken_list);
-  if (!token_list)
+  if (!token_list) {
     return TS_TYPE_UNDEFINED;
+  }
 
   /* Depending on the file and rule type, need to find out which
      token specifies which type of rule it is */
@@ -2170,8 +2253,9 @@ void
 copy_cfg_ele(TSCfgEle *src_ele, TSCfgEle *dst_ele)
 {
   // ink_assert (src_ele && dst_ele);
-  if (!src_ele || !dst_ele)
+  if (!src_ele || !dst_ele) {
     return;
+  }
 
   dst_ele->type  = src_ele->type;
   dst_ele->error = src_ele->error;
@@ -2181,43 +2265,50 @@ void
 copy_sspec(TSSspec *src, TSSspec *dst)
 {
   // ink_assert(src && dst);
-  if (!src || !dst)
+  if (!src || !dst) {
     return;
+  }
 
   dst->active      = src->active;
   dst->time.hour_a = src->time.hour_a;
   dst->time.min_a  = src->time.min_a;
   dst->time.hour_b = src->time.hour_b;
   dst->time.min_b  = src->time.min_b;
-  if (src->src_ip)
+  if (src->src_ip) {
     dst->src_ip = ats_strdup(src->src_ip);
-  if (src->prefix)
+  }
+  if (src->prefix) {
     dst->prefix = ats_strdup(src->prefix);
-  if (src->suffix)
+  }
+  if (src->suffix) {
     dst->suffix = ats_strdup(src->suffix);
-  dst->port     = copy_port_ele(src->port);
-  dst->method   = src->method;
-  dst->scheme   = src->scheme;
+  }
+  dst->port   = copy_port_ele(src->port);
+  dst->method = src->method;
+  dst->scheme = src->scheme;
 }
 
 void
 copy_pdss_format(TSPdSsFormat *src_pdss, TSPdSsFormat *dst_pdss)
 {
   // ink_assert (src_pdss && dst_pdss);
-  if (!src_pdss || !dst_pdss)
+  if (!src_pdss || !dst_pdss) {
     return;
+  }
 
   dst_pdss->pd_type = src_pdss->pd_type;
-  if (src_pdss->pd_val)
+  if (src_pdss->pd_val) {
     dst_pdss->pd_val = ats_strdup(src_pdss->pd_val);
+  }
   copy_sspec(&(src_pdss->sec_spec), &(dst_pdss->sec_spec));
 }
 
 void
 copy_hms_time(TSHmsTime *src, TSHmsTime *dst)
 {
-  if (!src || !dst)
+  if (!src || !dst) {
     return;
+  }
 
   dst->d = src->d;
   dst->h = src->h;
@@ -2230,17 +2321,20 @@ copy_ip_addr_ele(TSIpAddrEle *src_ele)
 {
   TSIpAddrEle *dst_ele;
 
-  if (!src_ele)
+  if (!src_ele) {
     return NULL;
+  }
 
   dst_ele       = TSIpAddrEleCreate();
   dst_ele->type = src_ele->type;
-  if (src_ele->ip_a)
+  if (src_ele->ip_a) {
     dst_ele->ip_a = ats_strdup(src_ele->ip_a);
+  }
   dst_ele->cidr_a = src_ele->cidr_a;
   dst_ele->port_a = src_ele->port_a;
-  if (src_ele->ip_b)
+  if (src_ele->ip_b) {
     dst_ele->ip_b = ats_strdup(src_ele->ip_b);
+  }
   dst_ele->cidr_b = src_ele->cidr_b;
   dst_ele->port_b = src_ele->port_b;
 
@@ -2252,8 +2346,9 @@ copy_port_ele(TSPortEle *src_ele)
 {
   TSPortEle *dst_ele;
 
-  if (!src_ele)
+  if (!src_ele) {
     return NULL;
+  }
 
   dst_ele         = TSPortEleCreate();
   dst_ele->port_a = src_ele->port_a;
@@ -2267,13 +2362,15 @@ copy_domain(TSDomain *src_dom)
 {
   TSDomain *dst_dom;
 
-  if (!src_dom)
+  if (!src_dom) {
     return NULL;
+  }
 
   dst_dom = TSDomainCreate();
-  if (src_dom->domain_val)
+  if (src_dom->domain_val) {
     dst_dom->domain_val = ats_strdup(src_dom->domain_val);
-  dst_dom->port         = src_dom->port;
+  }
+  dst_dom->port = src_dom->port;
 
   return dst_dom;
 }
@@ -2285,8 +2382,9 @@ copy_ip_addr_list(TSIpAddrList list)
   TSIpAddrEle *ele, *nele;
   int count, i;
 
-  if (list == TS_INVALID_LIST)
+  if (list == TS_INVALID_LIST) {
     return TS_INVALID_LIST;
+  }
 
   nlist = TSIpAddrListCreate();
   count = TSIpAddrListLen(list);
@@ -2307,8 +2405,9 @@ copy_port_list(TSPortList list)
   TSPortEle *ele, *nele;
   int count, i;
 
-  if (list == TS_INVALID_LIST)
+  if (list == TS_INVALID_LIST) {
     return TS_INVALID_LIST;
+  }
 
   nlist = TSPortListCreate();
   count = TSPortListLen(list);
@@ -2329,8 +2428,9 @@ copy_domain_list(TSDomainList list)
   TSDomain *ele, *nele;
   int count, i;
 
-  if (list == TS_INVALID_LIST)
+  if (list == TS_INVALID_LIST) {
     return TS_INVALID_LIST;
+  }
 
   nlist = TSDomainListCreate();
   count = TSDomainListLen(list);
@@ -2351,8 +2451,9 @@ copy_string_list(TSStringList list)
   char *ele, *nele;
   int count, i;
 
-  if (list == TS_INVALID_LIST)
+  if (list == TS_INVALID_LIST) {
     return TS_INVALID_LIST;
+  }
 
   nlist = TSStringListCreate();
   count = TSStringListLen(list);
@@ -2373,8 +2474,9 @@ copy_int_list(TSIntList list)
   int *elem, *nelem;
   int count, i;
 
-  if (list == TS_INVALID_LIST)
+  if (list == TS_INVALID_LIST) {
     return TS_INVALID_LIST;
+  }
 
   nlist = TSIntListCreate();
   count = TSIntListLen(list);
@@ -2397,8 +2499,9 @@ copy_cache_ele(TSCacheEle *ele)
   }
 
   TSCacheEle *nele = TSCacheEleCreate(ele->cfg_ele.type);
-  if (!nele)
+  if (!nele) {
     return NULL;
+  }
 
   copy_cfg_ele(&(ele->cfg_ele), &(nele->cfg_ele));
   copy_pdss_format(&(ele->cache_info), &(nele->cache_info));
@@ -2415,14 +2518,16 @@ copy_congestion_ele(TSCongestionEle *ele)
   }
 
   TSCongestionEle *nele = TSCongestionEleCreate();
-  if (!nele)
+  if (!nele) {
     return NULL;
+  }
   copy_cfg_ele(&(ele->cfg_ele), &(nele->cfg_ele));
   // copy_pdss_format(&(ele->congestion_info), &(nele->congestion_info));
   nele->pd_type = ele->pd_type;
   nele->pd_val  = ats_strdup(ele->pd_val);
-  if (ele->prefix)
-    nele->prefix                = ats_strdup(ele->prefix);
+  if (ele->prefix) {
+    nele->prefix = ats_strdup(ele->prefix);
+  }
   nele->port                    = ele->port;
   nele->scheme                  = ele->scheme;
   nele->max_connection_failures = ele->max_connection_failures;
@@ -2435,8 +2540,9 @@ copy_congestion_ele(TSCongestionEle *ele)
   nele->dead_os_conn_timeout    = ele->dead_os_conn_timeout;
   nele->dead_os_conn_retries    = ele->dead_os_conn_retries;
   nele->max_connection          = ele->max_connection;
-  if (ele->error_page_uri)
+  if (ele->error_page_uri) {
     nele->error_page_uri = ats_strdup(ele->error_page_uri);
+  }
 
   return nele;
 }
@@ -2449,14 +2555,16 @@ copy_hosting_ele(TSHostingEle *ele)
   }
 
   TSHostingEle *nele = TSHostingEleCreate();
-  if (!nele)
+  if (!nele) {
     return NULL;
+  }
 
   copy_cfg_ele(&(ele->cfg_ele), &(nele->cfg_ele));
   nele->pd_type = ele->pd_type;
-  if (ele->pd_val)
+  if (ele->pd_val) {
     nele->pd_val = ats_strdup(ele->pd_val);
-  ele->volumes   = copy_int_list(ele->volumes);
+  }
+  ele->volumes = copy_int_list(ele->volumes);
 
   return nele;
 }
@@ -2469,21 +2577,25 @@ copy_icp_ele(TSIcpEle *ele)
   }
 
   TSIcpEle *nele = TSIcpEleCreate();
-  if (!nele)
+  if (!nele) {
     return NULL;
+  }
 
   copy_cfg_ele(&(ele->cfg_ele), &(nele->cfg_ele));
-  if (ele->peer_hostname)
+  if (ele->peer_hostname) {
     nele->peer_hostname = ats_strdup(ele->peer_hostname);
-  if (ele->peer_host_ip_addr)
+  }
+  if (ele->peer_host_ip_addr) {
     nele->peer_host_ip_addr = ats_strdup(ele->peer_host_ip_addr);
-  nele->peer_type           = ele->peer_type;
-  nele->peer_proxy_port     = ele->peer_proxy_port;
-  nele->peer_icp_port       = ele->peer_icp_port;
-  nele->is_multicast        = ele->is_multicast;
-  if (ele->mc_ip_addr)
+  }
+  nele->peer_type       = ele->peer_type;
+  nele->peer_proxy_port = ele->peer_proxy_port;
+  nele->peer_icp_port   = ele->peer_icp_port;
+  nele->is_multicast    = ele->is_multicast;
+  if (ele->mc_ip_addr) {
     nele->mc_ip_addr = ats_strdup(ele->mc_ip_addr);
-  nele->mc_ttl       = ele->mc_ttl;
+  }
+  nele->mc_ttl = ele->mc_ttl;
 
   return nele;
 }
@@ -2496,11 +2608,13 @@ copy_ip_allow_ele(TSIpAllowEle *ele)
   }
 
   TSIpAllowEle *nele = TSIpAllowEleCreate();
-  if (!nele)
+  if (!nele) {
     return NULL;
-  if (ele->src_ip_addr)
+  }
+  if (ele->src_ip_addr) {
     nele->src_ip_addr = copy_ip_addr_ele(ele->src_ip_addr);
-  nele->action        = ele->action;
+  }
+  nele->action = ele->action;
   return nele;
 }
 
@@ -2512,19 +2626,23 @@ copy_log_filter_ele(TSLogFilterEle *ele)
   }
 
   TSLogFilterEle *nele = TSLogFilterEleCreate();
-  if (!nele)
+  if (!nele) {
     return NULL;
+  }
 
   copy_cfg_ele(&(ele->cfg_ele), &(nele->cfg_ele));
   nele->action = ele->action;
-  if (ele->filter_name)
+  if (ele->filter_name) {
     ele->filter_name = ats_strdup(nele->filter_name);
-  if (ele->log_field)
+  }
+  if (ele->log_field) {
     nele->log_field = ats_strdup(ele->log_field);
-  nele->compare_op  = ele->compare_op;
-  if (ele->compare_str)
+  }
+  nele->compare_op = ele->compare_op;
+  if (ele->compare_str) {
     nele->compare_str = ats_strdup(ele->compare_str);
-  nele->compare_int   = ele->compare_int;
+  }
+  nele->compare_int = ele->compare_int;
 
   return nele;
 }
@@ -2537,14 +2655,17 @@ copy_log_format_ele(TSLogFormatEle *ele)
   }
 
   TSLogFormatEle *nele = TSLogFormatEleCreate();
-  if (!nele)
+  if (!nele) {
     return NULL;
+  }
 
   copy_cfg_ele(&(ele->cfg_ele), &(nele->cfg_ele));
-  if (ele->name)
+  if (ele->name) {
     nele->name = ats_strdup(ele->name);
-  if (ele->format)
-    nele->format                = ats_strdup(ele->format);
+  }
+  if (ele->format) {
+    nele->format = ats_strdup(ele->format);
+  }
   nele->aggregate_interval_secs = ele->aggregate_interval_secs;
 
   return nele;
@@ -2558,14 +2679,17 @@ copy_log_object_ele(TSLogObjectEle *ele)
   }
 
   TSLogObjectEle *nele = TSLogObjectEleCreate();
-  if (!nele)
+  if (!nele) {
     return NULL;
+  }
 
   copy_cfg_ele(&(ele->cfg_ele), &(nele->cfg_ele));
-  if (ele->format_name)
+  if (ele->format_name) {
     nele->format_name = ats_strdup(ele->format_name);
-  if (ele->file_name)
-    nele->file_name     = ats_strdup(ele->file_name);
+  }
+  if (ele->file_name) {
+    nele->file_name = ats_strdup(ele->file_name);
+  }
   nele->log_mode        = ele->log_mode;
   nele->collation_hosts = copy_domain_list(ele->collation_hosts);
   nele->filters         = copy_string_list(ele->filters);
@@ -2583,8 +2707,9 @@ copy_parent_proxy_ele(TSParentProxyEle *ele)
   }
 
   TSParentProxyEle *nele = TSParentProxyEleCreate(TS_TYPE_UNDEFINED);
-  if (!nele)
+  if (!nele) {
     return NULL;
+  }
 
   copy_cfg_ele(&(ele->cfg_ele), &(nele->cfg_ele));
   copy_pdss_format(&(ele->parent_info), &(nele->parent_info));
@@ -2603,8 +2728,9 @@ copy_volume_ele(TSVolumeEle *ele)
   }
 
   TSVolumeEle *nele = TSVolumeEleCreate();
-  if (!nele)
+  if (!nele) {
     return NULL;
+  }
 
   copy_cfg_ele(&(ele->cfg_ele), &(nele->cfg_ele));
   nele->volume_num  = ele->volume_num;
@@ -2623,13 +2749,15 @@ copy_plugin_ele(TSPluginEle *ele)
   }
 
   TSPluginEle *nele = TSPluginEleCreate();
-  if (!nele)
+  if (!nele) {
     return NULL;
+  }
 
   copy_cfg_ele(&(ele->cfg_ele), &(nele->cfg_ele));
-  if (ele->name)
+  if (ele->name) {
     nele->name = ats_strdup(ele->name);
-  nele->args   = copy_string_list(ele->args);
+  }
+  nele->args = copy_string_list(ele->args);
 
   return nele;
 }
@@ -2642,23 +2770,28 @@ copy_remap_ele(TSRemapEle *ele)
   }
 
   TSRemapEle *nele = TSRemapEleCreate(TS_TYPE_UNDEFINED);
-  if (!nele)
+  if (!nele) {
     return NULL;
+  }
 
   copy_cfg_ele(&(ele->cfg_ele), &(nele->cfg_ele));
   nele->map         = ele->map;
   nele->from_scheme = ele->from_scheme;
-  if (ele->from_host)
+  if (ele->from_host) {
     nele->from_host = ats_strdup(ele->from_host);
-  nele->from_port   = ele->from_port;
-  if (ele->from_path_prefix)
+  }
+  nele->from_port = ele->from_port;
+  if (ele->from_path_prefix) {
     nele->from_path_prefix = ats_strdup(ele->from_path_prefix);
-  nele->to_scheme          = ele->to_scheme;
-  if (ele->to_host)
+  }
+  nele->to_scheme = ele->to_scheme;
+  if (ele->to_host) {
     nele->to_host = ats_strdup(ele->to_host);
-  nele->to_port   = ele->to_port;
-  if (ele->to_path_prefix)
+  }
+  nele->to_port = ele->to_port;
+  if (ele->to_path_prefix) {
     nele->to_path_prefix = ats_strdup(ele->to_path_prefix);
+  }
 
   return nele;
 }
@@ -2671,18 +2804,21 @@ copy_socks_ele(TSSocksEle *ele)
   }
 
   TSSocksEle *nele = TSSocksEleCreate(TS_TYPE_UNDEFINED);
-  if (!nele)
+  if (!nele) {
     return NULL;
+  }
 
   copy_cfg_ele(&(ele->cfg_ele), &(nele->cfg_ele));
   nele->ip_addrs      = copy_ip_addr_list(ele->ip_addrs);
   nele->dest_ip_addr  = copy_ip_addr_ele(ele->dest_ip_addr);
   nele->socks_servers = copy_domain_list(ele->socks_servers);
   nele->rr            = ele->rr;
-  if (ele->username)
+  if (ele->username) {
     nele->username = ats_strdup(ele->username);
-  if (ele->password)
+  }
+  if (ele->password) {
     nele->password = ats_strdup(ele->password);
+  }
 
   return nele;
 }
@@ -2695,17 +2831,20 @@ copy_split_dns_ele(TSSplitDnsEle *ele)
   }
 
   TSSplitDnsEle *nele = TSSplitDnsEleCreate();
-  if (!nele)
+  if (!nele) {
     return NULL;
+  }
 
   copy_cfg_ele(&(ele->cfg_ele), &(nele->cfg_ele));
   nele->pd_type = ele->pd_type;
-  if (ele->pd_val)
-    nele->pd_val          = ats_strdup(ele->pd_val);
+  if (ele->pd_val) {
+    nele->pd_val = ats_strdup(ele->pd_val);
+  }
   nele->dns_servers_addrs = copy_domain_list(ele->dns_servers_addrs);
-  if (ele->def_domain)
+  if (ele->def_domain) {
     nele->def_domain = ats_strdup(ele->def_domain);
-  nele->search_list  = copy_domain_list(ele->search_list);
+  }
+  nele->search_list = copy_domain_list(ele->search_list);
 
   return nele;
 }
@@ -2718,13 +2857,15 @@ copy_storage_ele(TSStorageEle *ele)
   }
 
   TSStorageEle *nele = TSStorageEleCreate();
-  if (!nele)
+  if (!nele) {
     return NULL;
+  }
 
   copy_cfg_ele(&(ele->cfg_ele), &(nele->cfg_ele));
-  if (ele->pathname)
+  if (ele->pathname) {
     nele->pathname = ats_strdup(ele->pathname);
-  nele->size       = ele->size;
+  }
+  nele->size = ele->size;
 
   return nele;
 }
@@ -2739,8 +2880,9 @@ copy_virt_ip_addr_ele(TSVirtIpAddrEle *ele)
   }
 
   new_ele = TSVirtIpAddrEleCreate();
-  if (!new_ele)
+  if (!new_ele) {
     return NULL;
+  }
 
   // copy cfg ele
   copy_cfg_ele(&(ele->cfg_ele), &(new_ele->cfg_ele));
@@ -2754,8 +2896,9 @@ copy_virt_ip_addr_ele(TSVirtIpAddrEle *ele)
 INKCommentEle *
 copy_comment_ele(INKCommentEle *ele)
 {
-  if (!ele)
+  if (!ele) {
     return NULL;
+  }
 
   INKCommentEle *nele = comment_ele_create(ele->comment);
   return nele;
@@ -2773,10 +2916,11 @@ comment_ele_create(char *comment)
 
   ele->cfg_ele.type  = TS_TYPE_COMMENT;
   ele->cfg_ele.error = TS_ERR_OKAY;
-  if (comment)
+  if (comment) {
     ele->comment = ats_strdup(comment);
-  else // comment is NULL
+  } else { // comment is NULL
     ele->comment = NULL;
+  }
 
   return ele;
 }

--- a/mgmt/api/CoreAPI.cc
+++ b/mgmt/api/CoreAPI.cc
@@ -67,8 +67,9 @@ Init(const char * /* socket_path ATS_UNUSED */, TSInitOptionT options)
   // socket_path should be null; only applies to remote clients
   if (0 == (options & TS_MGMT_OPT_NO_EVENTS)) {
     local_event_callbacks = create_callback_table("local_callbacks");
-    if (!local_event_callbacks)
+    if (!local_event_callbacks) {
       return TS_ERR_SYS_CALL;
+    }
   } else {
     local_event_callbacks = NULL;
   }
@@ -183,10 +184,11 @@ ProxyShutdown()
 TSProxyStateT
 ProxyStateGet()
 {
-  if (!lmgmt->processRunning())
+  if (!lmgmt->processRunning()) {
     return TS_PROXY_OFF;
-  else
+  } else {
     return TS_PROXY_ON;
+  }
 }
 
 /*-------------------------------------------------------------------------
@@ -208,8 +210,9 @@ ProxyStateSet(TSProxyStateT state, TSCacheClearT clear)
 
   switch (state) {
   case TS_PROXY_OFF:
-    if (!ProxyShutdown()) // from WebMgmtUtils
-      goto Lerror;        // unsuccessful shutdown
+    if (!ProxyShutdown()) { // from WebMgmtUtils
+      goto Lerror;          // unsuccessful shutdown
+    }
     break;
   case TS_PROXY_ON:
     if (lmgmt->processRunning()) { // already on
@@ -541,8 +544,9 @@ MgmtRecordGet(const char *rec_name, TSRecordEle *rec_ele)
   switch (rec_type) {
   case RECD_COUNTER:
     rec_ele->rec_type = TS_REC_COUNTER;
-    if (!varCounterFromName(rec_name, &(counter_val)))
+    if (!varCounterFromName(rec_name, &(counter_val))) {
       return TS_ERR_FAIL;
+    }
     rec_ele->valueT.counter_val = (TSCounter)counter_val;
 
     Debug("RecOp", "[MgmtRecordGet] Get Counter Var %s = %" PRId64 "", rec_ele->rec_name, rec_ele->valueT.counter_val);
@@ -550,8 +554,9 @@ MgmtRecordGet(const char *rec_name, TSRecordEle *rec_ele)
 
   case RECD_INT:
     rec_ele->rec_type = TS_REC_INT;
-    if (!varIntFromName(rec_name, &(int_val)))
+    if (!varIntFromName(rec_name, &(int_val))) {
       return TS_ERR_FAIL;
+    }
     rec_ele->valueT.int_val = (TSInt)int_val;
 
     Debug("RecOp", "[MgmtRecordGet] Get Int Var %s = %" PRId64 "", rec_ele->rec_name, rec_ele->valueT.int_val);
@@ -559,15 +564,17 @@ MgmtRecordGet(const char *rec_name, TSRecordEle *rec_ele)
 
   case RECD_FLOAT:
     rec_ele->rec_type = TS_REC_FLOAT;
-    if (!varFloatFromName(rec_name, &(rec_ele->valueT.float_val)))
+    if (!varFloatFromName(rec_name, &(rec_ele->valueT.float_val))) {
       return TS_ERR_FAIL;
+    }
 
     Debug("RecOp", "[MgmtRecordGet] Get Float Var %s = %f", rec_ele->rec_name, rec_ele->valueT.float_val);
     break;
 
   case RECD_STRING:
-    if (!varStrFromName(rec_name, rec_val, MAX_BUF_SIZE))
+    if (!varStrFromName(rec_name, rec_val, MAX_BUF_SIZE)) {
       return TS_ERR_FAIL;
+    }
 
     if (rec_val[0] != '\0') { // non-NULL string value
       // allocate memory & duplicate string value
@@ -621,8 +628,9 @@ determine_action_need(const char *rec_name)
 {
   RecUpdateT update_t;
 
-  if (REC_ERR_OKAY != RecGetRecordUpdateType(rec_name, &update_t))
+  if (REC_ERR_OKAY != RecGetRecordUpdateType(rec_name, &update_t)) {
     return TS_ACTION_UNDEFINED;
+  }
 
   switch (update_t) {
   case RECU_NULL: // default:don't know behaviour
@@ -661,14 +669,16 @@ MgmtRecordSet(const char *rec_name, const char *val, TSActionNeedT *action_need)
 {
   Debug("RecOp", "[MgmtRecordSet] Start");
 
-  if (!rec_name || !val || !action_need)
+  if (!rec_name || !val || !action_need) {
     return TS_ERR_PARAMS;
+  }
 
   *action_need = determine_action_need(rec_name);
 
   if (recordValidityCheck(rec_name, val)) {
-    if (varSetFromStr(rec_name, val))
+    if (varSetFromStr(rec_name, val)) {
       return TS_ERR_OKAY;
+    }
   }
 
   return TS_ERR_FAIL;
@@ -684,8 +694,9 @@ MgmtRecordSet(const char *rec_name, const char *val, TSActionNeedT *action_need)
 TSMgmtError
 MgmtRecordSetInt(const char *rec_name, MgmtInt int_val, TSActionNeedT *action_need)
 {
-  if (!rec_name || !action_need)
+  if (!rec_name || !action_need) {
     return TS_ERR_PARAMS;
+  }
 
   // convert int value to string for validity check
   char str_val[MAX_RECORD_SIZE];
@@ -704,8 +715,9 @@ MgmtRecordSetInt(const char *rec_name, MgmtInt int_val, TSActionNeedT *action_ne
 TSMgmtError
 MgmtRecordSetCounter(const char *rec_name, MgmtIntCounter counter_val, TSActionNeedT *action_need)
 {
-  if (!rec_name || !action_need)
+  if (!rec_name || !action_need) {
     return TS_ERR_PARAMS;
+  }
 
   // convert int value to string for validity check
   char str_val[MAX_RECORD_SIZE];
@@ -725,8 +737,9 @@ MgmtRecordSetCounter(const char *rec_name, MgmtIntCounter counter_val, TSActionN
 TSMgmtError
 MgmtRecordSetFloat(const char *rec_name, MgmtFloat float_val, TSActionNeedT *action_need)
 {
-  if (!rec_name || !action_need)
+  if (!rec_name || !action_need) {
     return TS_ERR_PARAMS;
+  }
 
   // convert float value to string for validity check
   char str_val[MAX_RECORD_SIZE];
@@ -775,8 +788,9 @@ ReadFile(TSFileNameT file, char **text, int *size, int *version)
   Debug("FileOp", "[get_lines_from_file] START");
 
   fname = filename_to_string(file);
-  if (!fname)
+  if (!fname) {
     return TS_ERR_READ_FILE;
+  }
 
   ret = configFiles->getRollbackObj(fname, &file_rb);
   if (ret != true) {
@@ -821,8 +835,9 @@ WriteFile(TSFileNameT file, const char *text, int size, int version)
   version_t ver;
 
   fname = filename_to_string(file);
-  if (!fname)
+  if (!fname) {
     return TS_ERR_WRITE_FILE;
+  }
 
   // get rollback object for config file
   mgmt_log(stderr, "[CfgFileIO::WriteFile] %s\n", fname);
@@ -837,8 +852,9 @@ WriteFile(TSFileNameT file, const char *text, int size, int version)
     // check that the current version is equal to or less than the version
     // that wants to be written
     ver = file_rb->getCurrentVersion();
-    if (ver != version) // trying to commit an old version
+    if (ver != version) { // trying to commit an old version
       return TS_ERR_WRITE_FILE;
+    }
   }
   // use rollback object to update file with new content
   file_content = new textBuffer(size + 1);
@@ -894,8 +910,9 @@ EventResolve(const char *event_name)
 {
   alarm_t a;
 
-  if (!event_name)
+  if (!event_name) {
     return TS_ERR_PARAMS;
+  }
 
   a = get_event_id(event_name);
   lmgmt->alarm_keeper->resolveAlarm(a);
@@ -919,8 +936,9 @@ ActiveEventGetMlt(LLQ *active_events)
   int event_id;
   char *event_name;
 
-  if (!active_events)
+  if (!active_events) {
     return TS_ERR_PARAMS;
+  }
 
   // Alarms stores a hashtable of all active alarms where:
   // key = alarm_t,
@@ -936,8 +954,9 @@ ActiveEventGetMlt(LLQ *active_events)
     event_id   = ink_atoi(key);
     event_name = get_event_name(event_id);
     if (event_name) {
-      if (!enqueue(active_events, event_name)) // returns true if successful
+      if (!enqueue(active_events, event_name)) { // returns true if successful
         return TS_ERR_FAIL;
+      }
     }
   }
 
@@ -955,17 +974,20 @@ EventIsActive(const char *event_name, bool *is_current)
 {
   alarm_t a;
 
-  if (!event_name || !is_current)
+  if (!event_name || !is_current) {
     return TS_ERR_PARAMS;
+  }
 
   a = get_event_id(event_name);
   // consider an invalid event_name an error
-  if (a < 0)
+  if (a < 0) {
     return TS_ERR_PARAMS;
-  if (lmgmt->alarm_keeper->isCurrentAlarm(a))
+  }
+  if (lmgmt->alarm_keeper->isCurrentAlarm(a)) {
     *is_current = true; // currently an event
-  else
+  } else {
     *is_current = false;
+  }
 
   return TS_ERR_OKAY;
 }
@@ -1006,16 +1028,18 @@ SnapshotTake(const char *snapshot_name)
 {
   ats_scoped_str snapdir;
 
-  if (!snapshot_name)
+  if (!snapshot_name) {
     return TS_ERR_PARAMS;
+  }
 
   snapdir = RecConfigReadSnapshotDir();
 
   SnapResult result = configFiles->takeSnap(snapshot_name, snapdir);
-  if (result != SNAP_OK)
+  if (result != SNAP_OK) {
     return TS_ERR_FAIL;
-  else
+  } else {
     return TS_ERR_OKAY;
+  }
 }
 
 TSMgmtError
@@ -1023,16 +1047,18 @@ SnapshotRestore(const char *snapshot_name)
 {
   ats_scoped_str snapdir;
 
-  if (!snapshot_name)
+  if (!snapshot_name) {
     return TS_ERR_PARAMS;
+  }
 
   snapdir = RecConfigReadSnapshotDir();
 
   SnapResult result = configFiles->restoreSnap(snapshot_name, snapdir);
-  if (result != SNAP_OK)
+  if (result != SNAP_OK) {
     return TS_ERR_FAIL;
-  else
+  } else {
     return TS_ERR_OKAY;
+  }
 }
 
 TSMgmtError
@@ -1040,16 +1066,18 @@ SnapshotRemove(const char *snapshot_name)
 {
   ats_scoped_str snapdir;
 
-  if (!snapshot_name)
+  if (!snapshot_name) {
     return TS_ERR_PARAMS;
+  }
 
   snapdir = RecConfigReadSnapshotDir();
 
   SnapResult result = configFiles->removeSnap(snapshot_name, snapdir);
-  if (result != SNAP_OK)
+  if (result != SNAP_OK) {
     return TS_ERR_FAIL;
-  else
+  } else {
     return TS_ERR_OKAY;
+  }
 }
 
 /* based on FileManager.cc::displaySnapOption() */
@@ -1062,14 +1090,16 @@ SnapshotGetMlt(LLQ *snapshots)
   char *snap_name;
 
   snap_result = configFiles->WalkSnaps(&snap_list);
-  if (snap_result != SNAP_OK)
+  if (snap_result != SNAP_OK) {
     return TS_ERR_FAIL;
+  }
 
   num_snaps = snap_list.getNumEntries();
   for (int i = 0; i < num_snaps; i++) {
     snap_name = (char *)(snap_list[i]);
-    if (snap_name)
+    if (snap_name) {
       enqueue(snapshots, ats_strdup(snap_name));
+    }
   }
 
   return TS_ERR_OKAY;
@@ -1087,10 +1117,11 @@ SnapshotGetMlt(LLQ *snapshots)
 TSMgmtError
 StatsReset(bool cluster, const char *name)
 {
-  if (cluster)
+  if (cluster) {
     lmgmt->ccom->sendClusterMessage(CLUSTER_MSG_CLEAR_STATS, name);
-  else
+  } else {
     lmgmt->clearStats(name);
+  }
   return TS_ERR_OKAY;
 }
 

--- a/mgmt/api/CoreAPIShared.cc
+++ b/mgmt/api/CoreAPIShared.cc
@@ -56,17 +56,21 @@ parseHTTPResponse(char *buffer, char **header, int *hdr_size, char **body, int *
     goto END;
   }
   // calculate header info
-  if (header)
+  if (header) {
     *header = buffer;
-  if (hdr_size)
+  }
+  if (hdr_size) {
     *hdr_size = buf - buffer;
+  }
 
   // calculate body info
   buf += strlen(HTTP_DIVIDER);
-  if (body)
+  if (body) {
     *body = buf;
-  if (bdy_size)
+  }
+  if (bdy_size) {
     *bdy_size = strlen(buf);
+  }
 
 END:
   return err;

--- a/mgmt/api/EventCallback.cc
+++ b/mgmt/api/EventCallback.cc
@@ -83,8 +83,9 @@ create_callback_table(const char *lock_name)
 {
   CallbackTable *cb_table = (CallbackTable *)ats_malloc(sizeof(CallbackTable));
 
-  for (int i                      = 0; i < NUM_EVENTS; i++)
+  for (int i = 0; i < NUM_EVENTS; i++) {
     cb_table->event_callback_l[i] = NULL;
+  }
 
   // initialize the mutex
   ink_mutex_init(&cb_table->event_callback_lock, lock_name);
@@ -186,8 +187,9 @@ cb_table_register(CallbackTable *cb_table, const char *event_name, TSEventSignal
   EventCallbackT *event_cb; // create new EventCallbackT EACH TIME enqueue
 
   // the data and event_name can be NULL
-  if (func == NULL || !cb_table)
+  if (func == NULL || !cb_table) {
     return TS_ERR_PARAMS;
+  }
 
   ink_mutex_acquire(&(cb_table->event_callback_lock));
 
@@ -230,8 +232,9 @@ cb_table_register(CallbackTable *cb_table, const char *event_name, TSEventSignal
   // release lock on callback table
   ink_mutex_release(&cb_table->event_callback_lock);
 
-  if (first_cb)
+  if (first_cb) {
     *first_cb = first_time;
+  }
 
   return TS_ERR_OKAY;
 }
@@ -260,8 +263,9 @@ cb_table_unregister(CallbackTable *cb_table, const char *event_name, TSEventSign
   if (event_name == NULL) { // unregister the callback for ALL EVENTS
     // for each event
     for (int i = 0; i < NUM_EVENTS; i++) {
-      if (!cb_table->event_callback_l[i]) // this event has no callbacks
+      if (!cb_table->event_callback_l[i]) { // this event has no callbacks
         continue;
+      }
 
       // func == NULL means unregister all functions associated with alarm
       if (func == NULL) {

--- a/mgmt/api/EventControlMain.cc
+++ b/mgmt/api/EventControlMain.cc
@@ -61,8 +61,9 @@ new_event_client()
   EventClientT *ele = (EventClientT *)ats_malloc(sizeof(EventClientT));
 
   // now set the alarms registered section
-  for (int i                  = 0; i < NUM_EVENTS; i++)
+  for (int i = 0; i < NUM_EVENTS; i++) {
     ele->events_registered[i] = 0;
+  }
 
   ele->adr = (struct sockaddr *)ats_malloc(sizeof(struct sockaddr));
   return ele;
@@ -125,8 +126,9 @@ init_mgmt_events()
 
   ret = ink_mutex_init(&mgmt_events_lock, "mgmt_event_notice");
 
-  if (ret)
+  if (ret) {
     return TS_ERR_SYS_CALL;
+  }
 
   // initialize queue
   mgmt_events = create_queue();
@@ -177,8 +179,9 @@ delete_mgmt_events()
 void
 delete_event_queue(LLQ *q)
 {
-  if (!q)
+  if (!q) {
     return;
+  }
 
   // now for every element, dequeue and free
   TSMgmtEvent *ele;
@@ -213,10 +216,11 @@ apiEventCallback(alarm_t newAlarm, const char * /* ip ATS_UNUSED */, const char 
   newEvent->id   = newAlarm;
   newEvent->name = get_event_name(newEvent->id);
   // newEvent->ip   = ats_strdup(ip);
-  if (desc)
+  if (desc) {
     newEvent->description = ats_strdup(desc);
-  else
+  } else {
     newEvent->description = ats_strdup("None");
+  }
 
   // add it to the mgmt_events list
   ink_mutex_acquire(&mgmt_events_lock);
@@ -376,8 +380,9 @@ event_callback_main(void *arg)
       event = (TSMgmtEvent *)dequeue(mgmt_events); // get what we want
       ink_mutex_release(&mgmt_events_lock);        // release lock
 
-      if (!event)
+      if (!event) {
         continue;
+      }
 
       // fprintf(stderr, "[event_callback_main] have an EVENT TO PROCESS\n");
 

--- a/mgmt/api/INKMgmtAPI.cc
+++ b/mgmt/api/INKMgmtAPI.cc
@@ -89,8 +89,9 @@ TSListCreate(void)
 tsapi void
 TSListDestroy(TSList l)
 {
-  if (!l)
+  if (!l) {
     return;
+  }
 
   delete_queue((LLQ *)l);
   return;
@@ -102,8 +103,9 @@ TSListEnqueue(TSList l, void *data)
   int ret;
 
   ink_assert(l && data);
-  if (!l || !data)
+  if (!l || !data) {
     return TS_ERR_PARAMS;
+  }
 
   ret = enqueue((LLQ *)l, data); /* returns TRUE=1 or FALSE=0 */
   if (ret == 0) {
@@ -117,8 +119,9 @@ tsapi void *
 TSListDequeue(TSList l)
 {
   ink_assert(l);
-  if (!l || queue_is_empty((LLQ *)l))
+  if (!l || queue_is_empty((LLQ *)l)) {
     return NULL;
+  }
 
   return dequeue((LLQ *)l);
 }
@@ -127,8 +130,9 @@ tsapi bool
 TSListIsEmpty(TSList l)
 {
   ink_assert(l);
-  if (!l)
+  if (!l) {
     return true; // list doesn't exist, so it's empty
+  }
 
   return queue_is_empty((LLQ *)l);
 }
@@ -137,8 +141,9 @@ tsapi int
 TSListLen(TSList l)
 {
   ink_assert(l);
-  if (!l)
+  if (!l) {
     return -1;
+  }
 
   return queue_len((LLQ *)l);
 }
@@ -149,14 +154,16 @@ TSListIsValid(TSList l)
   int i, len;
   void *ele;
 
-  if (!l)
+  if (!l) {
     return false;
+  }
 
   len = queue_len((LLQ *)l);
   for (i = 0; i < len; i++) {
     ele = (void *)dequeue((LLQ *)l);
-    if (!ele)
+    if (!ele) {
       return false;
+    }
     enqueue((LLQ *)l, ele);
   }
   return true;
@@ -184,8 +191,9 @@ TSIpAddrListDestroy(TSIpAddrList ip_addrl)
   while (!queue_is_empty((LLQ *)ip_addrl)) {
     ipaddr_ele = (TSIpAddrEle *)dequeue((LLQ *)ip_addrl);
 
-    if (!ipaddr_ele)
+    if (!ipaddr_ele) {
       continue;
+    }
 
     TSIpAddrEleDestroy(ipaddr_ele);
   }
@@ -201,8 +209,9 @@ TSIpAddrListEnqueue(TSIpAddrList ip_addrl, TSIpAddrEle *ip_addr)
   int ret;
 
   ink_assert(ip_addrl && ip_addr);
-  if (!ip_addrl || !ip_addr)
+  if (!ip_addrl || !ip_addr) {
     return TS_ERR_PARAMS;
+  }
 
   ret = enqueue((LLQ *)ip_addrl, ip_addr);
   if (ret == 0) {
@@ -217,8 +226,9 @@ tsapi TSIpAddrEle *
 TSIpAddrListDequeue(TSIpAddrList ip_addrl)
 {
   ink_assert(ip_addrl);
-  if (!ip_addrl || queue_is_empty((LLQ *)ip_addrl))
+  if (!ip_addrl || queue_is_empty((LLQ *)ip_addrl)) {
     return NULL;
+  }
 
   return (TSIpAddrEle *)dequeue((LLQ *)ip_addrl);
 }
@@ -227,8 +237,9 @@ tsapi int
 TSIpAddrListLen(TSIpAddrList ip_addrl)
 {
   ink_assert(ip_addrl);
-  if (!ip_addrl)
+  if (!ip_addrl) {
     return -1;
+  }
 
   return queue_len((LLQ *)ip_addrl);
 }
@@ -237,8 +248,9 @@ tsapi bool
 TSIpAddrListIsEmpty(TSIpAddrList ip_addrl)
 {
   ink_assert(ip_addrl);
-  if (!ip_addrl)
+  if (!ip_addrl) {
     return true;
+  }
 
   return queue_is_empty((LLQ *)ip_addrl);
 }
@@ -252,8 +264,9 @@ TSIpAddrListIsValid(TSIpAddrList ip_addrl)
   int i, len;
   TSIpAddrEle *ele;
 
-  if (!ip_addrl)
+  if (!ip_addrl) {
     return false;
+  }
 
   len = queue_len((LLQ *)ip_addrl);
   for (i = 0; i < len; i++) {
@@ -286,8 +299,9 @@ TSPortListDestroy(TSPortList portl)
   while (!queue_is_empty((LLQ *)portl)) {
     port_ele = (TSPortEle *)dequeue((LLQ *)portl);
 
-    if (!port_ele)
+    if (!port_ele) {
       continue;
+    }
 
     TSPortEleDestroy(port_ele);
   }
@@ -303,8 +317,9 @@ TSPortListEnqueue(TSPortList portl, TSPortEle *port)
   int ret;
 
   ink_assert(portl && port);
-  if (!portl || !port)
+  if (!portl || !port) {
     return TS_ERR_PARAMS;
+  }
 
   ret = enqueue((LLQ *)portl, port); /* returns TRUE=1 or FALSE=0 */
   if (ret == 0) {
@@ -318,8 +333,9 @@ tsapi TSPortEle *
 TSPortListDequeue(TSPortList portl)
 {
   ink_assert(portl);
-  if (!portl || queue_is_empty((LLQ *)portl))
+  if (!portl || queue_is_empty((LLQ *)portl)) {
     return NULL;
+  }
 
   return (TSPortEle *)dequeue((LLQ *)portl);
 }
@@ -328,8 +344,9 @@ tsapi int
 TSPortListLen(TSPortList portl)
 {
   ink_assert(portl);
-  if (!portl)
+  if (!portl) {
     return -1;
+  }
 
   return queue_len((LLQ *)portl);
 }
@@ -338,8 +355,9 @@ tsapi bool
 TSPortListIsEmpty(TSPortList portl)
 {
   ink_assert(portl);
-  if (!portl)
+  if (!portl) {
     return true;
+  }
 
   return queue_is_empty((LLQ *)portl);
 }
@@ -353,8 +371,9 @@ TSPortListIsValid(TSPortList portl)
   int i, len;
   TSPortEle *ele;
 
-  if (!portl)
+  if (!portl) {
     return false;
+  }
 
   len = queue_len((LLQ *)portl);
   for (i = 0; i < len; i++) {
@@ -388,8 +407,9 @@ TSDomainListDestroy(TSDomainList domainl)
   while (!queue_is_empty((LLQ *)domainl)) {
     domain = (TSDomain *)dequeue((LLQ *)domainl);
 
-    if (!domain)
+    if (!domain) {
       continue;
+    }
 
     TSDomainDestroy(domain);
   }
@@ -403,8 +423,9 @@ TSDomainListEnqueue(TSDomainList domainl, TSDomain *domain)
   int ret;
 
   ink_assert(domainl && domain);
-  if (!domainl || !domain)
+  if (!domainl || !domain) {
     return TS_ERR_PARAMS;
+  }
 
   ret = enqueue((LLQ *)domainl, domain); /* returns TRUE=1 or FALSE=0 */
   if (ret == 0) {
@@ -418,8 +439,9 @@ tsapi TSDomain *
 TSDomainListDequeue(TSDomainList domainl)
 {
   ink_assert(domainl);
-  if (!domainl || queue_is_empty((LLQ *)domainl))
+  if (!domainl || queue_is_empty((LLQ *)domainl)) {
     return NULL;
+  }
 
   return (TSDomain *)dequeue((LLQ *)domainl);
 }
@@ -428,8 +450,9 @@ tsapi bool
 TSDomainListIsEmpty(TSDomainList domainl)
 {
   ink_assert(domainl);
-  if (!domainl)
+  if (!domainl) {
     return true;
+  }
 
   return queue_is_empty((LLQ *)domainl);
 }
@@ -438,8 +461,9 @@ tsapi int
 TSDomainListLen(TSDomainList domainl)
 {
   ink_assert(domainl);
-  if (!domainl)
+  if (!domainl) {
     return -1;
+  }
 
   return queue_len((LLQ *)domainl);
 }
@@ -451,8 +475,9 @@ TSDomainListIsValid(TSDomainList domainl)
   int i, len;
   TSDomain *dom;
 
-  if (!domainl)
+  if (!domainl) {
     return false;
+  }
 
   len = queue_len((LLQ *)domainl);
   for (i = 0; i < len; i++) {
@@ -500,8 +525,9 @@ TSStringListEnqueue(TSStringList strl, char *str)
   int ret;
 
   ink_assert(strl && str);
-  if (!strl || !str)
+  if (!strl || !str) {
     return TS_ERR_PARAMS;
+  }
 
   ret = enqueue((LLQ *)strl, str); /* returns TRUE=1 or FALSE=0 */
   if (ret == 0) {
@@ -515,8 +541,9 @@ tsapi char *
 TSStringListDequeue(TSStringList strl)
 {
   ink_assert(strl);
-  if (!strl || queue_is_empty((LLQ *)strl))
+  if (!strl || queue_is_empty((LLQ *)strl)) {
     return NULL;
+  }
 
   return (char *)dequeue((LLQ *)strl);
 }
@@ -525,8 +552,9 @@ tsapi bool
 TSStringListIsEmpty(TSStringList strl)
 {
   ink_assert(strl);
-  if (!strl)
+  if (!strl) {
     return true;
+  }
 
   return queue_is_empty((LLQ *)strl);
 }
@@ -535,8 +563,9 @@ tsapi int
 TSStringListLen(TSStringList strl)
 {
   ink_assert(strl);
-  if (!strl)
+  if (!strl) {
     return -1;
+  }
 
   return queue_len((LLQ *)strl);
 }
@@ -548,14 +577,16 @@ TSStringListIsValid(TSStringList strl)
   int i, len;
   char *str;
 
-  if (!strl)
+  if (!strl) {
     return false;
+  }
 
   len = queue_len((LLQ *)strl);
   for (i = 0; i < len; i++) {
     str = (char *)dequeue((LLQ *)strl);
-    if (!str)
+    if (!str) {
       return false;
+    }
     enqueue((LLQ *)strl, str);
   }
   return true;
@@ -574,8 +605,9 @@ TSIntListDestroy(TSIntList intl)
 {
   int *iPtr;
 
-  if (!intl)
+  if (!intl) {
     return;
+  }
 
   /* dequeue each element and free it */
   while (!queue_is_empty((LLQ *)intl)) {
@@ -593,8 +625,9 @@ TSIntListEnqueue(TSIntList intl, int *elem)
   int ret;
 
   ink_assert(intl && elem);
-  if (!intl || !elem)
+  if (!intl || !elem) {
     return TS_ERR_PARAMS;
+  }
 
   ret = enqueue((LLQ *)intl, elem); /* returns TRUE=1 or FALSE=0 */
   if (ret == 0) {
@@ -608,8 +641,9 @@ tsapi int *
 TSIntListDequeue(TSIntList intl)
 {
   ink_assert(intl);
-  if (!intl || queue_is_empty((LLQ *)intl))
+  if (!intl || queue_is_empty((LLQ *)intl)) {
     return NULL;
+  }
 
   return (int *)dequeue((LLQ *)intl);
 }
@@ -618,8 +652,9 @@ tsapi bool
 TSIntListIsEmpty(TSIntList intl)
 {
   ink_assert(intl);
-  if (!intl)
+  if (!intl) {
     return true;
+  }
 
   return queue_is_empty((LLQ *)intl);
 }
@@ -628,8 +663,9 @@ tsapi int
 TSIntListLen(TSIntList intl)
 {
   ink_assert(intl);
-  if (!intl)
+  if (!intl) {
     return -1;
+  }
 
   return queue_len((LLQ *)intl);
 }
@@ -637,8 +673,9 @@ TSIntListLen(TSIntList intl)
 tsapi bool
 TSIntListIsValid(TSIntList intl, int min, int max)
 {
-  if (!intl)
+  if (!intl) {
     return false;
+  }
 
   for (unsigned long i = 0; i < queue_len((LLQ *)intl); i++) {
     int *item = (int *)dequeue((LLQ *)intl);
@@ -713,8 +750,9 @@ TSRecordEleDestroy(TSRecordEle *ele)
 {
   if (ele) {
     ats_free(ele->rec_name);
-    if (ele->rec_type == TS_REC_STRING && ele->valueT.string_val)
+    if (ele->rec_type == TS_REC_STRING && ele->valueT.string_val) {
       ats_free(ele->valueT.string_val);
+    }
     ats_free(ele);
   }
   return;
@@ -812,8 +850,9 @@ TSSspecDestroy(TSSspec *ele)
   if (ele) {
     ats_free(ele->prefix);
     ats_free(ele->suffix);
-    if (ele->port)
+    if (ele->port) {
       TSPortEleDestroy(ele->port);
+    }
     ats_free(ele);
   }
   return;
@@ -850,8 +889,9 @@ TSPdSsFormatDestroy(TSPdSsFormat &ele)
   ats_free(ele.sec_spec.src_ip);
   ats_free(ele.sec_spec.prefix);
   ats_free(ele.sec_spec.suffix);
-  if (ele.sec_spec.port)
+  if (ele.sec_spec.port) {
     TSPortEleDestroy(ele.sec_spec.port);
+  }
 }
 
 /*-------------------------------------------------------------
@@ -864,8 +904,9 @@ TSCacheEleCreate(TSRuleTypeT type)
 
   if (type != TS_CACHE_NEVER && type != TS_CACHE_IGNORE_NO_CACHE && type != TS_CACHE_CLUSTER_CACHE_LOCAL &&
       type != TS_CACHE_IGNORE_CLIENT_NO_CACHE && type != TS_CACHE_IGNORE_SERVER_NO_CACHE && type != TS_CACHE_PIN_IN_CACHE &&
-      type != TS_CACHE_REVALIDATE && type != TS_CACHE_TTL_IN_CACHE && type != TS_CACHE_AUTH_CONTENT && type != TS_TYPE_UNDEFINED)
+      type != TS_CACHE_REVALIDATE && type != TS_CACHE_TTL_IN_CACHE && type != TS_CACHE_AUTH_CONTENT && type != TS_TYPE_UNDEFINED) {
     return NULL; // invalid type
+  }
 
   ele = (TSCacheEle *)ats_malloc(sizeof(TSCacheEle));
 
@@ -960,8 +1001,9 @@ TSHostingEleDestroy(TSHostingEle *ele)
 {
   if (ele) {
     ats_free(ele->pd_val);
-    if (ele->volumes)
+    if (ele->volumes) {
       TSIntListDestroy(ele->volumes);
+    }
     ats_free(ele);
   }
   return;
@@ -1022,8 +1064,9 @@ tsapi void
 TSIpAllowEleDestroy(TSIpAllowEle *ele)
 {
   if (ele) {
-    if (ele->src_ip_addr)
+    if (ele->src_ip_addr) {
       TSIpAddrEleDestroy(ele->src_ip_addr);
+    }
     ats_free(ele);
   }
   return;
@@ -1115,14 +1158,18 @@ TSLogObjectEleDestroy(TSLogObjectEle *ele)
   if (ele) {
     ats_free(ele->format_name);
     ats_free(ele->file_name);
-    if (ele->collation_hosts)
+    if (ele->collation_hosts) {
       TSDomainListDestroy(ele->collation_hosts);
-    if (ele->filters)
+    }
+    if (ele->filters) {
       TSStringListDestroy(ele->filters);
-    if (ele->protocols)
+    }
+    if (ele->protocols) {
       TSStringListDestroy(ele->protocols);
-    if (ele->server_hosts)
+    }
+    if (ele->server_hosts) {
       TSStringListDestroy(ele->server_hosts);
+    }
     ats_free(ele);
   }
   return;
@@ -1136,8 +1183,9 @@ TSParentProxyEleCreate(TSRuleTypeT type)
 {
   TSParentProxyEle *ele;
 
-  if (type != TS_PP_PARENT && type != TS_PP_GO_DIRECT && type != TS_TYPE_UNDEFINED)
+  if (type != TS_PP_PARENT && type != TS_PP_GO_DIRECT && type != TS_TYPE_UNDEFINED) {
     return NULL;
+  }
 
   ele = (TSParentProxyEle *)ats_malloc(sizeof(TSParentProxyEle));
 
@@ -1156,8 +1204,9 @@ TSParentProxyEleDestroy(TSParentProxyEle *ele)
 {
   if (ele) {
     TSPdSsFormatDestroy(ele->parent_info);
-    if (ele->proxy_list)
+    if (ele->proxy_list) {
       TSDomainListDestroy(ele->proxy_list);
+    }
     ats_free(ele);
   }
 
@@ -1210,8 +1259,9 @@ TSPluginEleDestroy(TSPluginEle *ele)
 {
   if (ele) {
     ats_free(ele->name);
-    if (ele->args)
+    if (ele->args) {
       TSStringListDestroy(ele->args);
+    }
     ats_free(ele);
   }
   return;
@@ -1226,8 +1276,9 @@ TSRemapEleCreate(TSRuleTypeT type)
   TSRemapEle *ele;
 
   if (type != TS_REMAP_MAP && type != TS_REMAP_REVERSE_MAP && type != TS_REMAP_REDIRECT && type != TS_REMAP_REDIRECT_TEMP &&
-      type != TS_TYPE_UNDEFINED)
+      type != TS_TYPE_UNDEFINED) {
     return NULL;
+  }
 
   ele                   = (TSRemapEle *)ats_malloc(sizeof(TSRemapEle));
   ele->cfg_ele.type     = type;
@@ -1281,12 +1332,15 @@ void
 TSSocksEleDestroy(TSSocksEle *ele)
 {
   if (ele) {
-    if (ele->ip_addrs)
+    if (ele->ip_addrs) {
       TSIpAddrListDestroy(ele->ip_addrs);
-    if (ele->dest_ip_addr)
+    }
+    if (ele->dest_ip_addr) {
       TSIpAddrEleDestroy(ele->dest_ip_addr);
-    if (ele->socks_servers)
+    }
+    if (ele->socks_servers) {
       TSDomainListDestroy(ele->socks_servers);
+    }
     ats_free(ele->username);
     ats_free(ele->password);
     ats_free(ele);
@@ -1317,11 +1371,13 @@ TSSplitDnsEleDestroy(TSSplitDnsEle *ele)
 {
   if (ele) {
     ats_free(ele->pd_val);
-    if (ele->dns_servers_addrs)
+    if (ele->dns_servers_addrs) {
       TSDomainListDestroy(ele->dns_servers_addrs);
+    }
     ats_free(ele->def_domain);
-    if (ele->search_list)
+    if (ele->search_list) {
       TSDomainListDestroy(ele->search_list);
+    }
     ats_free(ele);
   }
   return;
@@ -1407,8 +1463,9 @@ TSRecordGetInt(const char *rec_name, TSInt *int_val)
 
   TSRecordEle *ele = TSRecordEleCreate();
   ret              = MgmtRecordGet(rec_name, ele);
-  if (ret != TS_ERR_OKAY)
+  if (ret != TS_ERR_OKAY) {
     goto END;
+  }
 
   *int_val = ele->valueT.int_val;
 
@@ -1424,8 +1481,9 @@ TSRecordGetCounter(const char *rec_name, TSCounter *counter_val)
 
   TSRecordEle *ele = TSRecordEleCreate();
   ret              = MgmtRecordGet(rec_name, ele);
-  if (ret != TS_ERR_OKAY)
+  if (ret != TS_ERR_OKAY) {
     goto END;
+  }
   *counter_val = ele->valueT.counter_val;
 
 END:
@@ -1440,8 +1498,9 @@ TSRecordGetFloat(const char *rec_name, TSFloat *float_val)
 
   TSRecordEle *ele = TSRecordEleCreate();
   ret              = MgmtRecordGet(rec_name, ele);
-  if (ret != TS_ERR_OKAY)
+  if (ret != TS_ERR_OKAY) {
     goto END;
+  }
   *float_val = ele->valueT.float_val;
 
 END:
@@ -1456,8 +1515,9 @@ TSRecordGetString(const char *rec_name, TSString *string_val)
 
   TSRecordEle *ele = TSRecordEleCreate();
   ret              = MgmtRecordGet(rec_name, ele);
-  if (ret != TS_ERR_OKAY)
+  if (ret != TS_ERR_OKAY) {
     goto END;
+  }
 
   *string_val = ats_strdup(ele->valueT.string_val);
 
@@ -1492,14 +1552,16 @@ TSRecordGetMlt(TSStringList rec_names, TSList rec_vals)
   int num_recs, i, j;
   TSMgmtError ret;
 
-  if (!rec_names || !rec_vals)
+  if (!rec_names || !rec_vals) {
     return TS_ERR_PARAMS;
+  }
 
   num_recs = queue_len((LLQ *)rec_names);
   for (i = 0; i < num_recs; i++) {
     rec_name = (char *)dequeue((LLQ *)rec_names); // remove name from list
-    if (!rec_name)
+    if (!rec_name) {
       return TS_ERR_PARAMS; // NULL is invalid record name
+    }
 
     ele = TSRecordEleCreate();
 
@@ -1511,8 +1573,9 @@ TSRecordGetMlt(TSStringList rec_names, TSList rec_vals)
       TSRecordEleDestroy(ele);
       for (j = 0; j < i; j++) {
         ele = (TSRecordEle *)dequeue((LLQ *)rec_vals);
-        if (ele)
+        if (ele) {
           TSRecordEleDestroy(ele);
+        }
       }
       return ret;
     }
@@ -1586,8 +1649,9 @@ TSRecordSetMlt(TSList rec_list, TSActionNeedT *action_need)
   TSMgmtError status           = TS_ERR_OKAY;
   TSActionNeedT top_action_req = TS_ACTION_UNDEFINED;
 
-  if (!rec_list || !action_need)
+  if (!rec_list || !action_need) {
     return TS_ERR_PARAMS;
+  }
 
   num_recs = queue_len((LLQ *)rec_list);
 
@@ -1611,14 +1675,16 @@ TSRecordSetMlt(TSList rec_list, TSActionNeedT *action_need)
         ret = TS_ERR_FAIL;
         break;
       }; /* end of switch (ele->rec_type) */
-      if (ret != TS_ERR_OKAY)
+      if (ret != TS_ERR_OKAY) {
         status = TS_ERR_FAIL;
+      }
 
       // keep track of most severe action; reset if needed
       // the TSACtionNeedT should be listed such that most severe actions have
       // a lower number (so most severe action == 0)
-      if (*action_need < top_action_req) // a more severe action
+      if (*action_need < top_action_req) { // a more severe action
         top_action_req = *action_need;
+      }
     }
     enqueue((LLQ *)rec_list, ele);
   }
@@ -1913,8 +1979,9 @@ TSReadFromUrlEx(const char *url, char **header, int *headerSize, char **body, in
   TSMgmtError status = TS_ERR_OKAY;
 
   // Sanity check
-  if (!url)
+  if (!url) {
     return TS_ERR_FAIL;
+  }
   if (timeout < 0) {
     timeout = URL_TIMEOUT;
   }
@@ -1941,8 +2008,9 @@ TSReadFromUrlEx(const char *url, char **header, int *headerSize, char **body, in
     httpHost = ats_strndup(host_and_port, strlen(host_and_port) - strlen(colon));
     colon += 1; // advance one position to get rid of leading ':'
     httpPort = ink_atoi(colon);
-    if (httpPort <= 0)
+    if (httpPort <= 0) {
       httpPort = HTTP_PORT;
+    }
   } else {
     httpHost = ats_strdup(host_and_port);
   }
@@ -1956,19 +2024,23 @@ TSReadFromUrlEx(const char *url, char **header, int *headerSize, char **body, in
 
   /* sending the HTTP request via the established socket */
   snprintf(request, BUFSIZE, "http://%s:%d/%s", httpHost, httpPort, httpPath);
-  if ((status = sendHTTPRequest(hFD, request, (uint64_t)timeout)) != TS_ERR_OKAY)
+  if ((status = sendHTTPRequest(hFD, request, (uint64_t)timeout)) != TS_ERR_OKAY) {
     goto END;
+  }
 
   memset(buffer, 0, bufsize); /* empty the buffer */
-  if ((status = readHTTPResponse(hFD, buffer, bufsize, (uint64_t)timeout)) != TS_ERR_OKAY)
+  if ((status = readHTTPResponse(hFD, buffer, bufsize, (uint64_t)timeout)) != TS_ERR_OKAY) {
     goto END;
+  }
 
-  if ((status = parseHTTPResponse(buffer, &hdr_temp, headerSize, &bdy_temp, bodySize)) != TS_ERR_OKAY)
+  if ((status = parseHTTPResponse(buffer, &hdr_temp, headerSize, &bdy_temp, bodySize)) != TS_ERR_OKAY) {
     goto END;
+  }
 
-  if (header && headerSize)
+  if (header && headerSize) {
     *header = ats_strndup(hdr_temp, *headerSize);
-  *body     = ats_strndup(bdy_temp, *bodySize);
+  }
+  *body = ats_strndup(bdy_temp, *bodySize);
 
 END:
   ats_free(httpHost);
@@ -1993,23 +2065,27 @@ TSLookupFromCacheUrl(TSString url, TSString *info)
   int timeout   = URL_TIMEOUT;
   TSInt ts_port = 8080;
 
-  if ((err = TSRecordGetInt("proxy.config.http.server_port", &ts_port)) != TS_ERR_OKAY)
+  if ((err = TSRecordGetInt("proxy.config.http.server_port", &ts_port)) != TS_ERR_OKAY) {
     goto END;
+  }
 
   if ((fd = connectDirect("localhost", ts_port, timeout)) < 0) {
     err = TS_ERR_FAIL;
     goto END;
   }
   snprintf(request, BUFSIZE, "http://{cache}/lookup_url?url=%s", url);
-  if ((err = sendHTTPRequest(fd, request, (uint64_t)timeout)) != TS_ERR_OKAY)
+  if ((err = sendHTTPRequest(fd, request, (uint64_t)timeout)) != TS_ERR_OKAY) {
     goto END;
+  }
 
   memset(response, 0, URL_BUFSIZE);
-  if ((err = readHTTPResponse(fd, response, URL_BUFSIZE, (uint64_t)timeout)) != TS_ERR_OKAY)
+  if ((err = readHTTPResponse(fd, response, URL_BUFSIZE, (uint64_t)timeout)) != TS_ERR_OKAY) {
     goto END;
+  }
 
-  if ((err = parseHTTPResponse(response, &header, &hdr_size, &body, &bdy_size)) != TS_ERR_OKAY)
+  if ((err = parseHTTPResponse(response, &header, &hdr_size, &body, &bdy_size)) != TS_ERR_OKAY) {
     goto END;
+  }
 
   *info = ats_strndup(body, bdy_size);
 
@@ -2031,23 +2107,27 @@ TSLookupFromCacheUrlRegex(TSString url_regex, TSString *list)
   int timeout   = -1;
   TSInt ts_port = 8080;
 
-  if ((err = TSRecordGetInt("proxy.config.http.server_port", &ts_port)) != TS_ERR_OKAY)
+  if ((err = TSRecordGetInt("proxy.config.http.server_port", &ts_port)) != TS_ERR_OKAY) {
     goto END;
+  }
 
   if ((fd = connectDirect("localhost", ts_port, timeout)) < 0) {
     err = TS_ERR_FAIL;
     goto END;
   }
   snprintf(request, BUFSIZE, "http://{cache}/lookup_regex?url=%s", url_regex);
-  if ((err = sendHTTPRequest(fd, request, (uint64_t)timeout)) != TS_ERR_OKAY)
+  if ((err = sendHTTPRequest(fd, request, (uint64_t)timeout)) != TS_ERR_OKAY) {
     goto END;
+  }
 
   memset(response, 0, URL_BUFSIZE);
-  if ((err = readHTTPResponse(fd, response, URL_BUFSIZE, (uint64_t)timeout)) != TS_ERR_OKAY)
+  if ((err = readHTTPResponse(fd, response, URL_BUFSIZE, (uint64_t)timeout)) != TS_ERR_OKAY) {
     goto END;
+  }
 
-  if ((err = parseHTTPResponse(response, &header, &hdr_size, &body, &bdy_size)) != TS_ERR_OKAY)
+  if ((err = parseHTTPResponse(response, &header, &hdr_size, &body, &bdy_size)) != TS_ERR_OKAY) {
     goto END;
+  }
 
   *list = ats_strndup(body, bdy_size);
 END:
@@ -2068,23 +2148,27 @@ TSDeleteFromCacheUrl(TSString url, TSString *info)
   int timeout   = URL_TIMEOUT;
   TSInt ts_port = 8080;
 
-  if ((err = TSRecordGetInt("proxy.config.http.server_port", &ts_port)) != TS_ERR_OKAY)
+  if ((err = TSRecordGetInt("proxy.config.http.server_port", &ts_port)) != TS_ERR_OKAY) {
     goto END;
+  }
 
   if ((fd = connectDirect("localhost", ts_port, timeout)) < 0) {
     err = TS_ERR_FAIL;
     goto END;
   }
   snprintf(request, BUFSIZE, "http://{cache}/delete_url?url=%s", url);
-  if ((err = sendHTTPRequest(fd, request, (uint64_t)timeout)) != TS_ERR_OKAY)
+  if ((err = sendHTTPRequest(fd, request, (uint64_t)timeout)) != TS_ERR_OKAY) {
     goto END;
+  }
 
   memset(response, 0, URL_BUFSIZE);
-  if ((err = readHTTPResponse(fd, response, URL_BUFSIZE, (uint64_t)timeout)) != TS_ERR_OKAY)
+  if ((err = readHTTPResponse(fd, response, URL_BUFSIZE, (uint64_t)timeout)) != TS_ERR_OKAY) {
     goto END;
+  }
 
-  if ((err = parseHTTPResponse(response, &header, &hdr_size, &body, &bdy_size)) != TS_ERR_OKAY)
+  if ((err = parseHTTPResponse(response, &header, &hdr_size, &body, &bdy_size)) != TS_ERR_OKAY) {
     goto END;
+  }
 
   *info = ats_strndup(body, bdy_size);
 
@@ -2106,23 +2190,27 @@ TSDeleteFromCacheUrlRegex(TSString url_regex, TSString *list)
   int timeout   = -1;
   TSInt ts_port = 8080;
 
-  if ((err = TSRecordGetInt("proxy.config.http.server_port", &ts_port)) != TS_ERR_OKAY)
+  if ((err = TSRecordGetInt("proxy.config.http.server_port", &ts_port)) != TS_ERR_OKAY) {
     goto END;
+  }
 
   if ((fd = connectDirect("localhost", ts_port, timeout)) < 0) {
     err = TS_ERR_FAIL;
     goto END;
   }
   snprintf(request, BUFSIZE, "http://{cache}/delete_regex?url=%s", url_regex);
-  if ((err = sendHTTPRequest(fd, request, (uint64_t)timeout)) != TS_ERR_OKAY)
+  if ((err = sendHTTPRequest(fd, request, (uint64_t)timeout)) != TS_ERR_OKAY) {
     goto END;
+  }
 
   memset(response, 0, URL_BUFSIZE);
-  if ((err = readHTTPResponse(fd, response, URL_BUFSIZE, (uint64_t)timeout)) != TS_ERR_OKAY)
+  if ((err = readHTTPResponse(fd, response, URL_BUFSIZE, (uint64_t)timeout)) != TS_ERR_OKAY) {
     goto END;
+  }
 
-  if ((err = parseHTTPResponse(response, &header, &hdr_size, &body, &bdy_size)) != TS_ERR_OKAY)
+  if ((err = parseHTTPResponse(response, &header, &hdr_size, &body, &bdy_size)) != TS_ERR_OKAY) {
     goto END;
+  }
 
   *list = ats_strndup(body, bdy_size);
 END:
@@ -2143,23 +2231,27 @@ TSInvalidateFromCacheUrlRegex(TSString url_regex, TSString *list)
   int timeout   = -1;
   TSInt ts_port = 8080;
 
-  if ((err = TSRecordGetInt("proxy.config.http.server_port", &ts_port)) != TS_ERR_OKAY)
+  if ((err = TSRecordGetInt("proxy.config.http.server_port", &ts_port)) != TS_ERR_OKAY) {
     goto END;
+  }
 
   if ((fd = connectDirect("localhost", ts_port, timeout)) < 0) {
     err = TS_ERR_FAIL;
     goto END;
   }
   snprintf(request, BUFSIZE, "http://{cache}/invalidate_regex?url=%s", url_regex);
-  if ((err = sendHTTPRequest(fd, request, (uint64_t)timeout)) != TS_ERR_OKAY)
+  if ((err = sendHTTPRequest(fd, request, (uint64_t)timeout)) != TS_ERR_OKAY) {
     goto END;
+  }
 
   memset(response, 0, URL_BUFSIZE);
-  if ((err = readHTTPResponse(fd, response, URL_BUFSIZE, (uint64_t)timeout)) != TS_ERR_OKAY)
+  if ((err = readHTTPResponse(fd, response, URL_BUFSIZE, (uint64_t)timeout)) != TS_ERR_OKAY) {
     goto END;
+  }
 
-  if ((err = parseHTTPResponse(response, &header, &hdr_size, &body, &bdy_size)) != TS_ERR_OKAY)
+  if ((err = parseHTTPResponse(response, &header, &hdr_size, &body, &bdy_size)) != TS_ERR_OKAY) {
     goto END;
+  }
 
   *list = ats_strndup(body, bdy_size);
 END:
@@ -2336,8 +2428,9 @@ TSIsValid(TSCfgEle *ele)
 {
   CfgEleObj *ele_obj;
 
-  if (!ele)
+  if (!ele) {
     return false;
+  }
 
   ele_obj = create_ele_obj_from_ele(ele);
   return (ele_obj->isValid());

--- a/mgmt/cluster/ClusterCom.cc
+++ b/mgmt/cluster/ClusterCom.cc
@@ -287,8 +287,9 @@ drainIncomingChannel(void *arg)
             const char *msg = "file: failed";
             mgmt_writeline(req_fd, msg, strlen(msg));
           }
-          if (buff)
+          if (buff) {
             delete buff;
+          }
         } else if (strstr(message, "cmd: shutdown_manager")) {
           mgmt_log("[ClusterCom::drainIncomingChannel] Received manager shutdown request\n");
           lmgmt->mgmt_shutdown_outstanding = MGMT_PENDING_RESTART;
@@ -485,8 +486,9 @@ ClusterCom::checkPeers(time_t *ticker)
   // a hack, but it helps break the dependency on global FileManager in traffic_manager.
   cluster_file_rb->configFiles = configFiles;
 
-  if (cluster_type == NO_CLUSTER)
+  if (cluster_type == NO_CLUSTER) {
     return;
+  }
 
   if ((t - *ticker) > 5) {
     int num_peers = 0;
@@ -663,8 +665,9 @@ ClusterCom::generateClusterDelta(void)
   InkHashTableEntry *entry;
   InkHashTableIteratorState iterator_state;
 
-  if (cluster_type == NO_CLUSTER)
+  if (cluster_type == NO_CLUSTER) {
     return;
+  }
 
   ink_mutex_acquire(&(mutex));
   for (entry = ink_hash_table_iterator_first(peers, &iterator_state); entry != NULL;
@@ -712,12 +715,14 @@ ClusterCom::handleMultiCastMessage(char *message)
 
   /* Grab the ip address, we need to know this so that we only complain
      once about a cluster name or traffic server version mismatch */
-  if ((line = strtok_r(message, "\n", &last)) == NULL)
+  if ((line = strtok_r(message, "\n", &last)) == NULL) {
     goto Lbogus; /* IP of sender */
+  }
 
   // coverity[secure_coding]
-  if (strlen(line) >= sizeof(ip) || sscanf(line, "ip: %s", ip) != 1)
+  if (strlen(line) >= sizeof(ip) || sscanf(line, "ip: %s", ip) != 1) {
     goto Lbogus;
+  }
 
   // FIX THIS: elam 02/23/1999
   //   Loopback disable is currently not working on NT.
@@ -727,12 +732,14 @@ ClusterCom::handleMultiCastMessage(char *message)
   }
 
   /* Make sure this is a message for the cluster we belong to */
-  if ((line = strtok_r(NULL, "\n", &last)) == NULL)
+  if ((line = strtok_r(NULL, "\n", &last)) == NULL) {
     goto Lbogus; /* ClusterName of sender */
+  }
 
   // coverity[secure_coding]
-  if (strlen(line) >= sizeof(cluster_name) || sscanf(line, "cluster: %s", cluster_name) != 1)
+  if (strlen(line) >= sizeof(cluster_name) || sscanf(line, "cluster: %s", cluster_name) != 1) {
     goto Lbogus;
+  }
 
   if (strcmp(cluster_name, lmgmt->proxy_name) != 0) {
     logClusterMismatch(ip, TS_NAME_MISMATCH, cluster_name);
@@ -740,8 +747,9 @@ ClusterCom::handleMultiCastMessage(char *message)
   }
 
   /* Make sure this a message from a Traffic Server of the same version */
-  if ((line = strtok_r(NULL, "\n", &last)) == NULL)
+  if ((line = strtok_r(NULL, "\n", &last)) == NULL) {
     goto Lbogus; /* TS version of sender */
+  }
 
   // coverity[secure_coding]
   if (strlen(line) >= sizeof(tsver) || sscanf(line, "tsver: %s", tsver) != 1 || strcmp(line + 7, appVersionInfo.VersionStr) != 0) {
@@ -750,8 +758,9 @@ ClusterCom::handleMultiCastMessage(char *message)
   }
 
   /* Figure out what type of message this is */
-  if ((line = strtok_r(NULL, "\n", &last)) == NULL)
+  if ((line = strtok_r(NULL, "\n", &last)) == NULL) {
     goto Lbogus;
+  }
   if (strcmp("type: files", line) == 0) { /* Config Files report */
     handleMultiCastFilePacket(last, ip);
     return;
@@ -769,8 +778,9 @@ ClusterCom::handleMultiCastMessage(char *message)
   }
 
   /* Check OS and version info */
-  if ((line = strtok_r(NULL, "\n", &last)) == NULL)
+  if ((line = strtok_r(NULL, "\n", &last)) == NULL) {
     goto Lbogus; /* OS of sender */
+  }
   if (!strstr(line, "os: ") || !strstr(line, sys_name)) {
     /*
     lmgmt->alarm_keeper->signalAlarm(MGMT_ALARM_PROXY_SYSTEM_ERROR,
@@ -782,8 +792,9 @@ ClusterCom::handleMultiCastMessage(char *message)
           line, sys_name, sys_release);
   }
 
-  if ((line = strtok_r(NULL, "\n", &last)) == NULL)
+  if ((line = strtok_r(NULL, "\n", &last)) == NULL) {
     goto Lbogus; /* OS-Version of sender */
+  }
   if (!strstr(line, "rel: ") || !strstr(line, sys_release)) {
     /*
     lmgmt->alarm_keeper->signalAlarm(MGMT_ALARM_PROXY_SYSTEM_ERROR,
@@ -795,30 +806,34 @@ ClusterCom::handleMultiCastMessage(char *message)
           line, sys_name, sys_release);
   }
 
-  if ((line = strtok_r(NULL, "\n", &last)) == NULL)
+  if ((line = strtok_r(NULL, "\n", &last)) == NULL) {
     goto Lbogus; /* Hostname of sender */
+  }
   if (strlen(line) >= sizeof(hostname) || sscanf(line, "hostname: %s", hostname) != 1) {
     mgmt_elog(0, "[ClusterCom::handleMultiCastMessage] Invalid message-line(%d) '%s'\n", __LINE__, line);
     return;
   }
 
-  if ((line = strtok_r(NULL, "\n", &last)) == NULL)
+  if ((line = strtok_r(NULL, "\n", &last)) == NULL) {
     goto Lbogus; /* mc_port of sender */
+  }
   if (sscanf(line, "port: %d", &peer_cluster_port) != 1) {
     mgmt_elog(0, "[ClusterCom::handleMultiCastMessage] Invalid message-line(%d) '%s'\n", __LINE__, line);
     return;
   }
 
-  if ((line = strtok_r(NULL, "\n", &last)) == NULL)
+  if ((line = strtok_r(NULL, "\n", &last)) == NULL) {
     goto Lbogus; /* rs_port of sender */
+  }
   if (sscanf(line, "ccomport: %d", &ccom_port) != 1) {
     mgmt_elog(0, "[ClusterCom::handleMultiCastMessage] Invalid message-line(%d) '%s'\n", __LINE__, line);
     return;
   }
 
   /* Their wall clock time and last config change time */
-  if ((line = strtok_r(NULL, "\n", &last)) == NULL)
+  if ((line = strtok_r(NULL, "\n", &last)) == NULL) {
     goto Lbogus;
+  }
   int64_t tt;
   if (sscanf(line, "time: %" PRId64 "", &tt) != 1) {
     mgmt_elog(0, "[ClusterCom::handleMultiCastMessage] Invalid message-line(%d) '%s'\n", __LINE__, line);
@@ -926,8 +941,9 @@ ClusterCom::handleMultiCastStatPacket(char *last, ClusterPeerInfo *peer)
       if (v2) {
         tmp_type = (RecDataT)ink_atoi(v2 + 1);
         v3       = strchr(v2 + 1, ':');
-        if (v3)
+        if (v3) {
           tmp_msg_val = ink_atoi64(v3 + 1);
+        }
       }
       if (!v2 || !v3) {
         mgmt_elog(0, "[ClusterCom::handleMultiCastStatPacket] Invalid message-line(%d) '%s'\n", __LINE__, line);
@@ -1007,16 +1023,19 @@ bool
 scan_and_terminate(char *&p, char a, char b)
 {
   bool eob = false; // 'eob' is end-of-buffer
-  while ((*p != a) && (*p != b) && (*p != '\0'))
+  while ((*p != a) && (*p != b) && (*p != '\0')) {
     p++;
+  }
   if (*p == '\0') {
     eob = true;
   } else {
     *(p++) = '\0';
-    while ((*p == a) || ((*p == b) && (*p != '\0')))
+    while ((*p == a) || ((*p == b) && (*p != '\0'))) {
       p++;
-    if (*p == '\0')
+    }
+    if (*p == '\0') {
       eob = true;
+    }
   }
   return eob;
 }
@@ -1031,14 +1050,16 @@ extract_locals(MgmtHashTable *local_ht, char *record_buffer)
     line = q = p;
     eof      = scan_and_terminate(p, '\r', '\n');
     Debug("ccom_rec", "[extract_locals] %s", line);
-    while ((*q == ' ') || (*q == '\t'))
+    while ((*q == ' ') || (*q == '\t')) {
       q++;
+    }
     // is this line a LOCAL?
     if (strncmp(q, "LOCAL", strlen("LOCAL")) == 0) {
       line_cp = ats_strdup(line);
       q += strlen("LOCAL");
-      while ((*q == ' ') || (*q == '\t'))
+      while ((*q == ' ') || (*q == '\t')) {
         q++;
+      }
       name = q;
       if (scan_and_terminate(q, ' ', '\t')) {
         Debug("ccom_rec", "[extract_locals] malformed line: %s", name);
@@ -1063,13 +1084,15 @@ insert_locals(textBuffer *rec_cfg_new, textBuffer *rec_cfg, MgmtHashTable *local
     line = q = p;
     eof      = scan_and_terminate(p, '\r', '\n');
     Debug("ccom_rec", "[insert_locals] %s", line);
-    while ((*q == ' ') || (*q == '\t'))
+    while ((*q == ' ') || (*q == '\t')) {
       q++;
+    }
     // is this line a local?
     if (strncmp(q, "LOCAL", strlen("LOCAL")) == 0) {
       q += strlen("LOCAL");
-      while ((*q == ' ') || (*q == '\t'))
+      while ((*q == ' ') || (*q == '\t')) {
         q++;
+      }
       name = q;
       if (scan_and_terminate(q, ' ', '\t')) {
         Debug("ccom_rec", "[insert_locals] malformed line: %s", name);

--- a/mgmt/cluster/VMap.cc
+++ b/mgmt/cluster/VMap.cc
@@ -47,8 +47,9 @@ vmapEnableHandler(const char *tok, RecDataT /* data_type ATS_UNUSED */, RecData 
 {
   bool before = true;
   ink_assert(!tok);
-  if (!lmgmt->virt_map->enabled)
-    before                 = false;
+  if (!lmgmt->virt_map->enabled) {
+    before = false;
+  }
   lmgmt->virt_map->enabled = (RecInt)data.rec_int;
   if (!lmgmt->virt_map->enabled && before) {
     lmgmt->virt_map->turning_off = true; // turing VIP from off to on
@@ -211,8 +212,9 @@ VMap::VMap(char *interface, unsigned long ip, ink_mutex *m)
 
 VMap::~VMap()
 {
-  if (id_map)
+  if (id_map) {
     ink_hash_table_destroy_and_free_values(id_map);
+  }
 
   ink_hash_table_destroy_and_free_values(interface_realip_map);
   ink_hash_table_destroy(our_map);

--- a/mgmt/utils/MgmtSocket.cc
+++ b/mgmt/utils/MgmtSocket.cc
@@ -68,10 +68,12 @@ mgmt_accept(int s, struct sockaddr *addr, socklen_t *addrlen)
   ink_assert(*addrlen != 0);
   for (retries = 0; retries < MGMT_MAX_TRANSIENT_ERRORS; retries++) {
     r = ::accept(s, addr, (socklen_t *)addrlen);
-    if (r >= 0)
+    if (r >= 0) {
       return r;
-    if (!mgmt_transient_error())
+    }
+    if (!mgmt_transient_error()) {
       break;
+    }
   }
   return r;
 }
@@ -89,10 +91,12 @@ mgmt_fopen(const char *filename, const char *mode)
     // no leak here as f will be returned if it is > 0
     // coverity[overwrite_var]
     f = ::fopen(filename, mode);
-    if (f > 0)
+    if (f > 0) {
       return f;
-    if (!mgmt_transient_error())
+    }
+    if (!mgmt_transient_error()) {
       break;
+    }
   }
   return f;
 }
@@ -107,10 +111,12 @@ mgmt_open(const char *path, int oflag)
   int r, retries;
   for (retries = 0; retries < MGMT_MAX_TRANSIENT_ERRORS; retries++) {
     r = ::open(path, oflag);
-    if (r >= 0)
+    if (r >= 0) {
       return r;
-    if (!mgmt_transient_error())
+    }
+    if (!mgmt_transient_error()) {
       break;
+    }
   }
   return r;
 }
@@ -125,10 +131,12 @@ mgmt_open_mode(const char *path, int oflag, mode_t mode)
   int r, retries;
   for (retries = 0; retries < MGMT_MAX_TRANSIENT_ERRORS; retries++) {
     r = ::open(path, oflag, mode);
-    if (r >= 0)
+    if (r >= 0) {
       return r;
-    if (!mgmt_transient_error())
+    }
+    if (!mgmt_transient_error()) {
       break;
+    }
   }
   return r;
 }
@@ -174,10 +182,12 @@ mgmt_sendto(int fd, void *buf, int len, int flags, struct sockaddr *to, int tole
   int r, retries;
   for (retries = 0; retries < MGMT_MAX_TRANSIENT_ERRORS; retries++) {
     r = ::sendto(fd, (char *)buf, len, flags, to, tolen);
-    if (r >= 0)
+    if (r >= 0) {
       return r;
-    if (!mgmt_transient_error())
+    }
+    if (!mgmt_transient_error()) {
       break;
+    }
   }
   return r;
 }
@@ -192,10 +202,12 @@ mgmt_socket(int domain, int type, int protocol)
   int r, retries;
   for (retries = 0; retries < MGMT_MAX_TRANSIENT_ERRORS; retries++) {
     r = ::socket(domain, type, protocol);
-    if (r >= 0)
+    if (r >= 0) {
       return r;
-    if (!mgmt_transient_error())
+    }
+    if (!mgmt_transient_error()) {
       break;
+    }
   }
   return r;
 }
@@ -228,11 +240,12 @@ mgmt_write_timeout(int fd, int sec, int usec)
   FD_ZERO(&writeSet);
   FD_SET(fd, &writeSet);
 
-  if (sec < 0 && usec < 0)
+  if (sec < 0 && usec < 0) {
     // blocking select; only returns when fd is ready to write
     return (mgmt_select(fd + 1, NULL, &writeSet, NULL, NULL));
-  else
+  } else {
     return (mgmt_select(fd + 1, NULL, &writeSet, NULL, &timeout));
+  }
 }
 
 /***************************************************************************

--- a/plugins/cacheurl/cacheurl.cc
+++ b/plugins/cacheurl/cacheurl.cc
@@ -192,8 +192,9 @@ regex_compile(regex_info **buf, char *pattern, char *replacement)
     /* Something went wrong, clean up */
     TSfree(tokens);
     TSfree(tokenoffset);
-    if (info->re)
+    if (info->re) {
       pcre_free(info->re);
+    }
     TSfree(info);
   }
   return status;
@@ -336,10 +337,12 @@ rewrite_cacheurl(pr_list *prl, TSHttpTxn txnp)
   }
 
   /* Clean up */
-  if (url)
+  if (url) {
     TSfree(url);
-  if (newurl)
+  }
+  if (newurl) {
     TSfree(newurl);
+  }
 
   return ok;
 }

--- a/plugins/conf_remap/conf_remap.cc
+++ b/plugins/conf_remap/conf_remap.cc
@@ -55,8 +55,9 @@ str_to_datatype(const char *str)
 {
   TSRecordDataType type = TS_RECORDDATATYPE_NULL;
 
-  if (!str || !*str)
+  if (!str || !*str) {
     return TS_RECORDDATATYPE_NULL;
+  }
 
   if (!strcmp(str, "INT")) {
     type = TS_RECORDDATATYPE_INT;
@@ -128,8 +129,9 @@ RemapConfigs::parse_file(const char *filename)
 
   std::string path;
 
-  if (!filename || ('\0' == *filename))
+  if (!filename || ('\0' == *filename)) {
     return false;
+  }
 
   if (*filename == '/') {
     // Absolute path, just use it.
@@ -153,13 +155,15 @@ RemapConfigs::parse_file(const char *filename)
     char *s = buf;
 
     ++line_num; // First line is #1 ...
-    while (isspace(*s))
+    while (isspace(*s)) {
       ++s;
+    }
     tok = strtok_r(s, " \t", &ln);
 
     // check for blank lines and comments
-    if ((!tok) || (tok && ('#' == *tok)))
+    if ((!tok) || (tok && ('#' == *tok))) {
       continue;
+    }
 
     if (strncmp(tok, "CONFIG", 6)) {
       TSError("[%s] File %s, line %d: non-CONFIG line encountered", PLUGIN_NAME, path.c_str(), line_num);
@@ -187,17 +191,20 @@ RemapConfigs::parse_file(const char *filename)
 
     // Find the value (which depends on the type above)
     if (ln) {
-      while (isspace(*ln))
+      while (isspace(*ln)) {
         ++ln;
+      }
       if ('\0' == *ln) {
         tok = NULL;
       } else {
         tok = ln;
-        while (*ln != '\0')
+        while (*ln != '\0') {
           ++ln;
+        }
         --ln;
-        while (isspace(*ln) && (ln > tok))
+        while (isspace(*ln) && (ln > tok)) {
           --ln;
+        }
         ++ln;
         *ln = '\0';
       }
@@ -294,8 +301,9 @@ TSRemapDeleteInstance(void *ih)
   RemapConfigs *conf = static_cast<RemapConfigs *>(ih);
 
   for (int ix = 0; ix < conf->_current; ++ix) {
-    if (TS_RECORDDATATYPE_STRING == conf->_items[ix]._type)
+    if (TS_RECORDDATATYPE_STRING == conf->_items[ix]._type) {
       TSfree(conf->_items[ix]._data.rec_string);
+    }
   }
 
   delete conf;

--- a/plugins/experimental/buffer_upload/buffer_upload.cc
+++ b/plugins/experimental/buffer_upload/buffer_upload.cc
@@ -594,8 +594,9 @@ convert_url_func(TSMBuffer req_bufp, TSMLoc req_loc)
   const char *str;
   int len, port;
 
-  if (TSHttpHdrUrlGet(req_bufp, req_loc, &url_loc) == TS_ERROR)
+  if (TSHttpHdrUrlGet(req_bufp, req_loc, &url_loc) == TS_ERROR) {
     return;
+  }
 
   char *hostname = (char *)getenv("HOSTNAME");
 
@@ -962,18 +963,21 @@ create_directory()
       }
     }
     dir = opendir(".");
-    if (dir == NULL)
+    if (dir == NULL) {
       goto error_out;
+    }
     while ((d = readdir(dir))) {
       remove(d->d_name);
     }
     closedir(dir);
-    if (chdir("..") == -1)
+    if (chdir("..") == -1) {
       return 0;
+    }
   }
 
-  if (chdir(cwd) == -1)
+  if (chdir(cwd) == -1) {
     return 0;
+  }
 
   return 1;
 
@@ -982,8 +986,9 @@ error_out:
       value of chdir() and cannot be silenced
       The reason is the combination of -D_FORTIFY_SOURCE=2 -O
    */
-  if (chdir(cwd) == -1)
+  if (chdir(cwd) == -1) {
     return 0;
+  }
 
   return 0;
 }
@@ -1098,10 +1103,11 @@ parse_config_line(char *line, const struct config_val_ul *cv)
         case TYPE_BOOL: {
           size_t len = strlen(tok);
           if (len > 0) {
-            if (*tok == '1' || *tok == 't')
+            if (*tok == '1' || *tok == 't') {
               *((bool *)cv->val) = true;
-            else
+            } else {
               *((bool *)cv->val) = false;
+            }
             TSError("[buffer_upload] Parsed bool config value %s : %d", cv->str, *((bool *)cv->val));
             TSDebug(DEBUG_TAG, "Parsed bool config value %s : %d", cv->str, *((bool *)cv->val));
           }

--- a/plugins/experimental/cache_range_requests/cache_range_requests.cc
+++ b/plugins/experimental/cache_range_requests/cache_range_requests.cc
@@ -102,8 +102,9 @@ range_header_check(TSHttpTxn txnp)
           req_url = TSHttpTxnEffectiveUrlStringGet(txnp, &url_length);
           snprintf(cache_key_url, 8192, "%s-%s", req_url, txn_state->range_value);
           DEBUG_LOG("Rewriting cache URL for %s to %s", req_url, cache_key_url);
-          if (req_url != NULL)
+          if (req_url != NULL) {
             TSfree(req_url);
+          }
 
           // set the cache key.
           if (TS_SUCCESS != TSCacheUrlSet(txnp, cache_key_url, strlen(cache_key_url))) {
@@ -397,10 +398,12 @@ transaction_handler(TSCont contp, TSEvent event, void *edata)
     handle_client_send_response(txnp, txn_state);
     break;
   case TS_EVENT_HTTP_TXN_CLOSE:
-    if (txn_state != NULL && txn_state->range_value != NULL)
+    if (txn_state != NULL && txn_state->range_value != NULL) {
       TSfree(txn_state->range_value);
-    if (txn_state != NULL)
+    }
+    if (txn_state != NULL) {
       TSfree(txn_state);
+    }
     TSContDestroy(contp);
     break;
   default:

--- a/plugins/experimental/collapsed_connection/collapsed_connection.cc
+++ b/plugins/experimental/collapsed_connection/collapsed_connection.cc
@@ -47,8 +47,9 @@ str_to_datatype(const char *str)
 {
   TSRecordDataType type = TS_RECORDDATATYPE_NULL;
 
-  if (!str || !*str)
+  if (!str || !*str) {
     return TS_RECORDDATATYPE_NULL;
+  }
 
   if (!strcmp(str, "INT")) {
     type = TS_RECORDDATATYPE_INT;
@@ -75,8 +76,9 @@ CcHttpTxnConfigFind(const char *name, int length, CcConfigKey *conf, TSRecordDat
 {
   *type = TS_RECORDDATATYPE_NULL;
 
-  if (length == -1)
+  if (length == -1) {
     length = strlen(name);
+  }
 
   switch (length) {
   case 46:
@@ -169,13 +171,15 @@ initConfig(const char *fn)
           char *s = buf;
 
           ++line_num; // First line is #1 ...
-          while (isspace(*s))
+          while (isspace(*s)) {
             ++s;
+          }
           tok = strtok_r(s, " \t", &ln);
 
           // check for blank lines and comments
-          if ((!tok) || (tok && ('#' == *tok)))
+          if ((!tok) || (tok && ('#' == *tok))) {
             continue;
+          }
 
           if (strncmp(tok, "CONFIG", 6)) {
             TSError("[collapsed_connection] File %s, line %d: non-CONFIG line encountered", fn, line_num);
@@ -200,17 +204,20 @@ initConfig(const char *fn)
           }
           // Find the value (which depends on the type above)
           if (ln) {
-            while (isspace(*ln))
+            while (isspace(*ln)) {
               ++ln;
+            }
             if ('\0' == *ln) {
               tok = NULL;
             } else {
               tok = ln;
-              while (*ln != '\0')
+              while (*ln != '\0') {
                 ++ln;
+              }
               --ln;
-              while (isspace(*ln) && (ln > tok))
+              while (isspace(*ln) && (ln > tok)) {
                 --ln;
+              }
               ++ln;
               *ln = '\0';
             }

--- a/plugins/experimental/esi/lib/EsiParser.cc
+++ b/plugins/experimental/esi/lib/EsiParser.cc
@@ -638,8 +638,9 @@ EsiParser::parse(DocNodeList &node_list, const char *ext_data_ptr, int data_len 
     // adjust all pointers to addresses in input parameter
     const char *int_data_start      = data.data();
     DocNodeList::iterator node_iter = node_list.begin();
-    for (size_t i = 0; i < orig_output_list_size; ++i, ++node_iter)
+    for (size_t i = 0; i < orig_output_list_size; ++i, ++node_iter) {
       ;
+    }
     _adjustPointers(node_iter, node_list.end(), ext_data_ptr, int_data_start);
   }
   return retval;

--- a/plugins/experimental/esi/lib/EsiProcessor.cc
+++ b/plugins/experimental/esi/lib/EsiProcessor.cc
@@ -273,8 +273,9 @@ EsiProcessor::process(const char *&data, int &data_len)
   bool attempt_succeeded;
   std::vector<std::string> attemptUrls;
   TryBlockList::iterator try_iter = _try_blocks.begin();
-  for (int i = 0; i < _n_try_blocks_processed; ++i, ++try_iter)
+  for (int i = 0; i < _n_try_blocks_processed; ++i, ++try_iter) {
     ;
+  }
   for (; _n_try_blocks_processed < static_cast<int>(_try_blocks.size()); ++try_iter) {
     ++_n_try_blocks_processed;
     attempt_succeeded = true;
@@ -297,8 +298,9 @@ EsiProcessor::process(const char *&data, int &data_len)
 
     for (iter = try_iter->attempt_nodes.begin(); iter != try_iter->attempt_nodes.end(); ++iter) {
       if ((iter->type == DocNode::TYPE_INCLUDE) || iter->type == DocNode::TYPE_SPECIAL_INCLUDE) {
-        if (!attempt_succeeded && iter == node_iter)
+        if (!attempt_succeeded && iter == node_iter) {
           continue;
+        }
         const Attribute &url = (*iter).attr_list.front();
         string raw_url(url.value, url.value_len);
         attemptUrls.push_back(_expression.expand(raw_url));
@@ -323,8 +325,9 @@ EsiProcessor::process(const char *&data, int &data_len)
         info = it->second;
         // Should be registered only if attemp was made
         // and it failed
-        if (_reqAdded)
+        if (_reqAdded) {
           info->registerSuccFail(attempt_succeeded);
+        }
       }
     }
     if (attempt_succeeded) {
@@ -387,8 +390,9 @@ EsiProcessor::flush(string &data, int &overall_len)
   std::vector<std::string> attemptUrls;
   _output_data.clear();
   TryBlockList::iterator try_iter = _try_blocks.begin();
-  for (int i = 0; i < _n_try_blocks_processed; ++i, ++try_iter)
+  for (int i = 0; i < _n_try_blocks_processed; ++i, ++try_iter) {
     ;
+  }
   for (; _n_try_blocks_processed < static_cast<int>(_try_blocks.size()); ++try_iter) {
     attempt_pending = false;
     for (node_iter = try_iter->attempt_nodes.begin(); node_iter != try_iter->attempt_nodes.end(); ++node_iter) {
@@ -424,8 +428,9 @@ EsiProcessor::flush(string &data, int &overall_len)
 
     for (iter = try_iter->attempt_nodes.begin(); iter != try_iter->attempt_nodes.end(); ++iter) {
       if ((iter->type == DocNode::TYPE_INCLUDE) || iter->type == DocNode::TYPE_SPECIAL_INCLUDE) {
-        if (!attempt_succeeded && iter == node_iter)
+        if (!attempt_succeeded && iter == node_iter) {
           continue;
+        }
         const Attribute &url = (*iter).attr_list.front();
         string raw_url(url.value, url.value_len);
         attemptUrls.push_back(_expression.expand(raw_url));
@@ -450,8 +455,9 @@ EsiProcessor::flush(string &data, int &overall_len)
         info = it->second;
         // Should be registered only if attemp was made
         // and it failed
-        if (_reqAdded)
+        if (_reqAdded) {
           info->registerSuccFail(attempt_succeeded);
+        }
       }
     }
     if (attempt_succeeded) {
@@ -476,8 +482,9 @@ EsiProcessor::flush(string &data, int &overall_len)
 
   node_pending = false;
   node_iter    = _node_list.begin();
-  for (int i = 0; i < _n_processed_nodes; ++i, ++node_iter)
+  for (int i = 0; i < _n_processed_nodes; ++i, ++node_iter) {
     ;
+  }
   for (; node_iter != _node_list.end(); ++node_iter) {
     DocNode &doc_node = *node_iter; // handy reference
     _debugLog(_debug_tag, "[%s] Processing ESI node [%s] with data of size %d starting with [%.10s...]", __FUNCTION__,
@@ -691,8 +698,9 @@ EsiProcessor::_preprocess(DocNodeList &node_list, int &n_prescanned_nodes)
   string raw_url;
 
   // skip previously examined nodes
-  for (int i = 0; i < n_prescanned_nodes; ++i, ++list_iter)
+  for (int i = 0; i < n_prescanned_nodes; ++i, ++list_iter) {
     ;
+  }
 
   for (; list_iter != node_list.end(); ++list_iter, ++n_prescanned_nodes) {
     switch (list_iter->type) {

--- a/plugins/experimental/esi/lib/FailureInfo.cc
+++ b/plugins/experimental/esi/lib/FailureInfo.cc
@@ -86,8 +86,9 @@ FailureInfo::isAttemptReq()
       prob = mapFactor / 1000;
     }
 
-    if (static_cast<int>(prob))
+    if (static_cast<int>(prob)) {
       prob = _avgOverWindow;
+    }
 
     _debugLog(_debug_tag, "[%s] Calculated probability is %lf", __FUNCTION__, prob);
     // coverity[dont_call]

--- a/plugins/experimental/esi/lib/Utils.cc
+++ b/plugins/experimental/esi/lib/Utils.cc
@@ -150,8 +150,9 @@ Utils::parseAttributes(const char *data, int data_len, AttributeList &attr_list,
   Attribute attr;
   bool inside_quotes = false, end_of_attribute;
   bool escape_on     = false;
-  for (i = 0; (i < data_len) && ((isspace(data[i]) || separator_lookup[static_cast<uint8_t>(data[i])])); ++i)
+  for (i = 0; (i < data_len) && ((isspace(data[i]) || separator_lookup[static_cast<uint8_t>(data[i])])); ++i) {
     ;
+  }
   attr.name  = data + i;
   attr.value = 0;
   for (; i <= data_len; ++i) {
@@ -178,8 +179,9 @@ Utils::parseAttributes(const char *data, int data_len, AttributeList &attr_list,
           } // else ignore empty name/value
         }   // else ignore attribute with no value
       }     // else ignore variable with unterminated quotes
-      for (; (i < data_len) && ((isspace(data[i]) || separator_lookup[static_cast<uint8_t>(data[i])])); ++i)
+      for (; (i < data_len) && ((isspace(data[i]) || separator_lookup[static_cast<uint8_t>(data[i])])); ++i) {
         ;
+      }
       attr.name     = data + i;
       attr.value    = 0;
       inside_quotes = false;

--- a/plugins/experimental/esi/lib/Variables.cc
+++ b/plugins/experimental/esi/lib/Variables.cc
@@ -379,21 +379,24 @@ void
 Variables::_parseAcceptLangString(const char *str, int str_len)
 {
   int i;
-  for (i = 0; (i < str_len) && ((isspace(str[i]) || str[i] == ',')); ++i)
+  for (i = 0; (i < str_len) && ((isspace(str[i]) || str[i] == ',')); ++i) {
     ;
+  }
   const char *lang = str + i;
   int lang_len;
   for (; i <= str_len; ++i) {
     if ((i == str_len) || (str[i] == ',')) {
       lang_len = str + i - lang;
-      for (; lang_len && isspace(lang[lang_len - 1]); --lang_len)
+      for (; lang_len && isspace(lang[lang_len - 1]); --lang_len) {
         ;
+      }
       if (lang_len) {
         _insert(_dict_data[HTTP_ACCEPT_LANGUAGE], string(lang, lang_len), EMPTY_STRING);
         _debugLog(_debug_tag, "[%s] Added language [%.*s]", __FUNCTION__, lang_len, lang);
       }
-      for (; (i < str_len) && ((isspace(str[i]) || str[i] == ',')); ++i)
+      for (; (i < str_len) && ((isspace(str[i]) || str[i] == ',')); ++i) {
         ;
+      }
       lang = str + i;
     }
   }

--- a/plugins/experimental/geoip_acl/acl.cc
+++ b/plugins/experimental/geoip_acl/acl.cc
@@ -199,8 +199,9 @@ RegexAcl::append(RegexAcl *ra)
   } else {
     RegexAcl *cur = _next;
 
-    while (cur->_next)
-      cur      = cur->_next;
+    while (cur->_next) {
+      cur = cur->_next;
+    }
     cur->_next = ra;
   }
 }

--- a/plugins/experimental/header_normalize/header_normalize.cc
+++ b/plugins/experimental/header_normalize/header_normalize.cc
@@ -191,8 +191,9 @@ read_request_hook(TSCont /* contp */, TSEvent /* event */, void *edata)
     TSDebug(PLUGIN_NAME, "*** Camel Casing %u hdrs in the request", n_mime_headers);
 
     for (int i = 0; i < n_mime_headers; ++i) {
-      if (hdr == NULL)
+      if (hdr == NULL) {
         break;
+      }
       next_hdr = TSMimeHdrFieldNext(hdr_bufp, req_hdrs, hdr);
       int old_hdr_len;
       const char *old_hdr_name = TSMimeHdrFieldNameGet(hdr_bufp, req_hdrs, hdr, &old_hdr_len);

--- a/plugins/experimental/hipes/hipes.cc
+++ b/plugins/experimental/hipes/hipes.cc
@@ -51,14 +51,16 @@ escapify_url(const char *src, int src_len, char *dst, int dst_len)
   int len          = 0;
 
   // Sanity check
-  if (!src)
+  if (!src) {
     return -1;
+  }
 
   while (from < (src + src_len)) {
     unsigned char c = *from;
 
-    if (len >= dst_len)
+    if (len >= dst_len) {
       return -1; // Does not fit.... abort!
+    }
 
     if (codes_to_escape[c / 8] & (1 << (7 - c % 8))) {
       *to++ = '%';
@@ -202,10 +204,11 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
         ri->url_param = arg_val;
       } else if (arg.compare(0, 4, "path") == 0) {
         ri->path = arg_val;
-        if (arg_val[0] == '/')
+        if (arg_val[0] == '/') {
           ri->path = arg_val.substr(1);
-        else
+        } else {
           ri->path = arg_val;
+        }
       } else if (arg.compare(0, 3, "ssl") == 0) {
         ri->ssl = true;
       } else if (arg.compare(0, 7, "service") == 0) {
@@ -328,9 +331,9 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
     query_len = (slash - param);
     memcpy(new_query, param, query_len);
     ptr = new_query;
-    while ((ptr = static_cast<char *>(memchr(ptr, ';', (new_query + query_len) - ptr))))
+    while ((ptr = static_cast<char *>(memchr(ptr, ';', (new_query + query_len) - ptr)))) {
       *ptr = '&';
-
+    }
     new_query[query_len++] = '&';
     memcpy(new_query + query_len, h_conf->url_param.c_str(), h_conf->url_param.size());
     query_len += h_conf->url_param.size();
@@ -344,9 +347,9 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
     new_query_size = param_len;
     memcpy(new_query, param, param_len);
     ptr = new_query;
-    while ((ptr = static_cast<char *>(memchr(ptr, ';', (new_query + new_query_size) - ptr))))
+    while ((ptr = static_cast<char *>(memchr(ptr, ';', (new_query + new_query_size) - ptr)))) {
       *ptr = '&';
-
+    }
     TSDebug(PLUGIN_NAME, "New query is %.*s(%d)", new_query_size, new_query, new_query_size);
   }
 
@@ -363,8 +366,9 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
       } else {
         if ((*pos == 'r') && (!strncmp(pos, "redirect=", 9))) {
           redirect_flag = *(pos + 9) - '0';
-          if ((redirect_flag < 0) || (redirect_flag > 2))
+          if ((redirect_flag < 0) || (redirect_flag > 2)) {
             redirect_flag = h_conf->default_redirect_flag;
+          }
           TSDebug(PLUGIN_NAME, "Found _redirect flag in URL: %d", redirect_flag);
           pos = NULL;
         }
@@ -423,8 +427,9 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
       TSHttpTxnSetHttpRetStatus(rh, TS_HTTP_STATUS_BAD_REQUEST);
       has_error = true;
     }
-    if (has_error)
+    if (has_error) {
       return TSREMAP_NO_REMAP;
+    }
   }
 
   // If we redirect, just generate a 302 URL, otherwise update the RRI struct properly.
@@ -451,13 +456,15 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
       if (h_conf->ssl) {
         memcpy(pos, "https://", 8);
         pos += 8;
-        if (h_conf->svc_port != 443)
+        if (h_conf->svc_port != 443) {
           port = h_conf->svc_port;
+        }
       } else {
         memcpy(pos, "http://", 7);
         pos += 7;
-        if (h_conf->svc_port != 80)
+        if (h_conf->svc_port != 80) {
           port = h_conf->svc_port;
+        }
       }
 
       // Server
@@ -465,8 +472,9 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
       pos += h_conf->svc_server.size();
 
       // Port
-      if (port != -1)
+      if (port != -1) {
         pos += snprintf(pos, 6, ":%d", port);
+      }
 
       // Path
       *(pos++) = '/';
@@ -525,8 +533,9 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
     TSDebug(PLUGIN_NAME, "New path is %.*s", (int)h_conf->path.size(), h_conf->path.c_str());
 
     // Enable SSL?
-    if (h_conf->ssl)
+    if (h_conf->ssl) {
       TSUrlSchemeSet(rri->requestBufp, rri->requestUrl, "https", 5);
+    }
 
     // Clear previous matrix params
     TSUrlHttpParamsSet(rri->requestBufp, rri->requestUrl, "", 0);

--- a/plugins/experimental/memcache/tsmemcache.cc
+++ b/plugins/experimental/memcache/tsmemcache.cc
@@ -62,12 +62,15 @@ static char *
 mc_string(const char *s, int len)
 {
   int l = len;
-  while (l && (s[l - 1] == '\r' || s[l - 1] == '\n'))
+  while (l && (s[l - 1] == '\r' || s[l - 1] == '\n')) {
     l--;
-  if (l > TSMEMCACHE_TMP_CMD_BUFFER_SIZE - 1)
+  }
+  if (l > TSMEMCACHE_TMP_CMD_BUFFER_SIZE - 1) {
     l = TSMEMCACHE_TMP_CMD_BUFFER_SIZE - 1;
-  if (l)
+  }
+  if (l) {
     memcpy(debug_string_buffer, s, l);
+  }
   debug_string_buffer[l] = 0;
   return debug_string_buffer;
 }
@@ -110,8 +113,9 @@ ink_hton64(uint64_t in)
     SWP1B(x.b[3], x.b[4]);
 #undef SWP1B
     return x.rv;
-  } else
+  } else {
     return in;
+  }
 }
 #define ink_ntoh64 ink_hton64
 
@@ -121,10 +125,11 @@ MCAccept::main_event(int event, void *data)
   if (event == NET_EVENT_ACCEPT) {
     NetVConnection *netvc = (NetVConnection *)data;
     MC *mc                = theMCAllocator.alloc();
-    if (!mutex->thread_holding)
+    if (!mutex->thread_holding) {
       mc->new_connection(netvc, netvc->thread);
-    else
+    } else {
       mc->new_connection(netvc, mutex->thread_holding);
+    }
     return EVENT_CONT;
   } else {
     Fatal("tsmemcache accept received fatal error: errno = %d", -((int)(intptr_t)data));
@@ -153,22 +158,30 @@ MC::new_connection(NetVConnection *netvc, EThread *thread)
 int
 MC::die()
 {
-  if (pending_action && pending_action != ACTION_RESULT_DONE)
+  if (pending_action && pending_action != ACTION_RESULT_DONE) {
     pending_action->cancel();
-  if (nvc)
+  }
+  if (nvc) {
     nvc->do_io_close(1); // abort
-  if (crvc)
+  }
+  if (crvc) {
     crvc->do_io_close(1); // abort
-  if (cwvc)
+  }
+  if (cwvc) {
     cwvc->do_io_close(1); // abort
-  if (rbuf)
+  }
+  if (rbuf) {
     free_MIOBuffer(rbuf);
-  if (wbuf)
+  }
+  if (wbuf) {
     free_MIOBuffer(wbuf);
-  if (cbuf)
+  }
+  if (cbuf) {
     free_MIOBuffer(cbuf);
-  if (tbuf)
+  }
+  if (tbuf) {
     ats_free(tbuf);
+  }
   mutex = NULL;
   theMCAllocator.free(this);
   return EVENT_DONE;
@@ -317,8 +330,9 @@ MC::protocol_error()
 int
 MC::read_from_client()
 {
-  if (swallow_bytes)
+  if (swallow_bytes) {
     return TS_SET_CALL(&MC::swallow_then_read_event, VC_EVENT_READ_READY, rvio);
+  }
   read_offset = 0;
   end_of_cmd  = 0;
   ngets       = 0;
@@ -333,11 +347,13 @@ MC::read_from_client()
     cwvc  = 0;
     cwvio = NULL;
   }
-  if (cbuf)
+  if (cbuf) {
     cbuf->clear();
+  }
   ink_assert(!crvc && !cwvc);
-  if (tbuf)
+  if (tbuf) {
     ats_free(tbuf);
+  }
   return TS_SET_CALL(&MC::read_from_client_event, VC_EVENT_READ_READY, rvio);
 }
 
@@ -389,8 +405,9 @@ MC::write_binary_response(const void *d, int hlen, int keylen, int dlen)
 static char *
 get_pointer(MC *mc, int start, int len)
 {
-  if (mc->reader->block_read_avail() >= start + len)
+  if (mc->reader->block_read_avail() >= start + len) {
     return mc->reader->start() + start;
+  }
   // the block of data straddles an IOBufferBlock boundary, exceptional case, malloc
   ink_assert(!mc->tbuf);
   mc->tbuf = (char *)ats_malloc(len);
@@ -411,19 +428,24 @@ MC::cache_read_event(int event, void *data)
   case CACHE_EVENT_OPEN_READ: {
     crvc     = (CacheVConnection *)data;
     int hlen = 0;
-    if (crvc->get_header((void **)&rcache_header, &hlen) < 0)
+    if (crvc->get_header((void **)&rcache_header, &hlen) < 0) {
       goto Lfail;
-    if (hlen < (int)sizeof(MCCacheHeader) || rcache_header->magic != TSMEMCACHE_HEADER_MAGIC)
+    }
+    if (hlen < (int)sizeof(MCCacheHeader) || rcache_header->magic != TSMEMCACHE_HEADER_MAGIC) {
       goto Lfail;
-    if (header.nkey != rcache_header->nkey || hlen < (int)(sizeof(MCCacheHeader) + rcache_header->nkey))
+    }
+    if (header.nkey != rcache_header->nkey || hlen < (int)(sizeof(MCCacheHeader) + rcache_header->nkey)) {
       goto Lfail;
-    if (memcmp(key, rcache_header->key(), header.nkey))
+    }
+    if (memcmp(key, rcache_header->key(), header.nkey)) {
       goto Lfail;
+    }
     {
       ink_hrtime t = Thread::get_hrtime();
       if (((ink_hrtime)rcache_header->settime) <= last_flush ||
-          t >= ((ink_hrtime)rcache_header->settime) + HRTIME_SECONDS(rcache_header->exptime))
+          t >= ((ink_hrtime)rcache_header->settime) + HRTIME_SECONDS(rcache_header->exptime)) {
         goto Lfail;
+      }
     }
     break;
   Lfail:
@@ -479,14 +501,16 @@ MC::binary_get_event(int event, void *data)
     header.nkey = binary_header.request.keylen;
     return get_item();
   } else if (event == CACHE_EVENT_OPEN_READ_FAILED) {
-    if (f.noreply)
+    if (f.noreply) {
       return read_from_client();
+    }
     if (binary_header.request.opcode == PROTOCOL_BINARY_CMD_GETK) {
       add_binary_header(PROTOCOL_BINARY_RESPONSE_KEY_ENOENT, 0, header.nkey, header.nkey);
       wbuf->write(key, header.nkey);
       return write_then_read_from_client();
-    } else
+    } else {
       return write_binary_error(PROTOCOL_BINARY_RESPONSE_KEY_ENOENT, 0);
+    }
   } else if (event == CACHE_EVENT_OPEN_READ) {
     protocol_binary_response_get *rsp = &res.get;
     uint16_t keylen                   = 0;
@@ -501,12 +525,14 @@ MC::binary_get_event(int event, void *data)
     rsp->message.header.response.cas = ink_hton64(rcache_header->cas);
     rsp->message.body.flags          = htonl(rcache_header->flags);
     wbuf->write(&rsp->message.body, sizeof(rsp->message.body));
-    if (getk)
+    if (getk) {
       wbuf->write(key, header.nkey);
+    }
     crvio = crvc->do_io_read(this, rcache_header->nbytes, wbuf);
     return stream_then_read_from_client(rcache_header->nbytes);
-  } else
+  } else {
     return unexpected_event();
+  }
   return 0;
 }
 
@@ -519,8 +545,9 @@ MC::bin_read_key()
 int
 MC::read_binary_from_client_event(int event, void *data)
 {
-  if (reader->read_avail() < (int)sizeof(binary_header))
+  if (reader->read_avail() < (int)sizeof(binary_header)) {
     return EVENT_CONT;
+  }
   reader->memcpy(&binary_header, sizeof(binary_header));
   if (binary_header.request.magic != PROTOCOL_BINARY_REQ) {
     Warning("tsmemcache: bad binary magic: %x", binary_header.request.magic);
@@ -577,8 +604,9 @@ MC::read_binary_from_client_event(int event, void *data)
   case PROTOCOL_BINARY_CMD_SET: {
     CHECK_PROTOCOL(extlen == 8 && keylen != 0 && bodylen >= keylen + 8);
   Lset:
-    if (bin_read_key() < 0)
+    if (bin_read_key() < 0) {
       return EVENT_CONT;
+    }
     key                              = binary_get_key(this);
     header.nkey                      = keylen;
     protocol_binary_request_set *req = (protocol_binary_request_set *)&binary_header;
@@ -602,8 +630,9 @@ MC::read_binary_from_client_event(int event, void *data)
   case PROTOCOL_BINARY_CMD_QUITQ:
     f.noreply = 1; // fall through
   case PROTOCOL_BINARY_CMD_QUIT:
-    if (f.noreply)
+    if (f.noreply) {
       return die();
+    }
     return write_then_close(write_binary_response(NULL, 0, 0, 0));
   case PROTOCOL_BINARY_CMD_FLUSHQ:
     f.noreply = 1; // fall through
@@ -651,10 +680,11 @@ MC::ascii_response(const char *s, int len)
   if (end_of_cmd > 0) {
     reader->consume(end_of_cmd);
     return read_from_client();
-  } else if (end_of_cmd < 0)
+  } else if (end_of_cmd < 0) {
     return read_from_client();
-  else
+  } else {
     return TS_SET_CALL(&MC::swallow_cmd_then_read_from_client_event, EVENT_NONE, NULL);
+  }
 }
 
 char *
@@ -667,12 +697,14 @@ MC::get_ascii_input(int n, int *end)
     return reader->start();
   }
   int read_avail = reader->read_avail();
-  if (block_read_avail == read_avail)
+  if (block_read_avail == read_avail) {
     goto Lblock;
+  }
   char *c = tmp_cmd_buffer;
   int e   = read_avail;
-  if (e > n)
+  if (e > n) {
     e = n;
+  }
   reader->memcpy(c, e);
   *end = e;
   return c;
@@ -736,62 +768,76 @@ MC::ascii_set_event(int event, void *data)
     cwvc     = (CacheVConnection *)data;
     int hlen = 0;
     if (cwvc->get_header((void **)&wcache_header, &hlen) >= 0) {
-      if (hlen < (int)sizeof(MCCacheHeader) || wcache_header->magic != TSMEMCACHE_HEADER_MAGIC)
+      if (hlen < (int)sizeof(MCCacheHeader) || wcache_header->magic != TSMEMCACHE_HEADER_MAGIC) {
         goto Lfail;
-      if (header.nkey != wcache_header->nkey || hlen < (int)(sizeof(MCCacheHeader) + wcache_header->nkey))
+      }
+      if (header.nkey != wcache_header->nkey || hlen < (int)(sizeof(MCCacheHeader) + wcache_header->nkey)) {
         goto Lfail;
+      }
       ink_hrtime t = Thread::get_hrtime();
       if (((ink_hrtime)wcache_header->settime) <= last_flush ||
-          t >= ((ink_hrtime)wcache_header->settime) + HRTIME_SECONDS(wcache_header->exptime))
+          t >= ((ink_hrtime)wcache_header->settime) + HRTIME_SECONDS(wcache_header->exptime)) {
         goto Lstale;
-      if (f.set_add)
+      }
+      if (f.set_add) {
         return ASCII_RESPONSE("NOT_STORED");
+      }
     } else {
     Lstale:
-      if (f.set_replace)
+      if (f.set_replace) {
         return ASCII_RESPONSE("NOT_STORED");
+      }
     }
     memcpy(tmp_cache_header_key, key, header.nkey);
     header.settime = Thread::get_hrtime();
     if (exptime) {
       if (exptime > REALTIME_MAXDELTA) {
-        if (HRTIME_SECONDS(exptime) <= ((ink_hrtime)header.settime))
+        if (HRTIME_SECONDS(exptime) <= ((ink_hrtime)header.settime)) {
           header.exptime = 0;
-        else
+        } else {
           header.exptime = (int32_t)(exptime - (header.settime / HRTIME_SECOND));
-      } else
+        }
+      } else {
         header.exptime = exptime;
-    } else
+      }
+    } else {
       header.exptime = UINT32_MAX; // 136 years
+    }
     if (f.set_cas) {
-      if (!wcache_header)
+      if (!wcache_header) {
         return ASCII_RESPONSE("NOT_FOUND");
-      if (header.cas && header.cas != wcache_header->cas)
+      }
+      if (header.cas && header.cas != wcache_header->cas) {
         return ASCII_RESPONSE("EXISTS");
+      }
     }
     header.cas = ink_atomic_increment(&next_cas, 1);
-    if (f.set_append || f.set_prepend)
+    if (f.set_append || f.set_prepend) {
       header.nbytes = nbytes + rcache_header->nbytes;
-    else
+    } else {
       header.nbytes = nbytes;
+    }
     cwvc->set_header(&header, header.len());
     reader->consume(end_of_cmd);
     end_of_cmd    = -1;
     swallow_bytes = 2; // \r\n
     if (f.set_append) {
       TS_PUSH_HANDLER(&MC::tunnel_event);
-      if (!cbuf)
-        cbuf  = new_empty_MIOBuffer();
+      if (!cbuf) {
+        cbuf = new_empty_MIOBuffer();
+      }
       creader = cbuf->alloc_reader();
       crvio   = crvc->do_io_read(this, rcache_header->nbytes, cbuf);
       cwvio   = cwvc->do_io_write(this, header.nbytes, creader);
     } else {
       if (f.set_prepend) {
         int64_t a = reader->read_avail();
-        if (a >= (int64_t)nbytes)
+        if (a >= (int64_t)nbytes) {
           a = (int64_t)nbytes;
-        if (!cbuf)
-          cbuf  = new_empty_MIOBuffer();
+        }
+        if (!cbuf) {
+          cbuf = new_empty_MIOBuffer();
+        }
         creader = cbuf->alloc_reader();
         if (a) {
           cbuf->write(reader, a);
@@ -802,8 +848,9 @@ MC::ascii_set_event(int event, void *data)
           goto Lstreamdone;
         }
         rvio->nbytes = rvio->ndone + (int64_t)nbytes - a;
-      } else
+      } else {
         creader = reader;
+      }
       TS_PUSH_HANDLER(&MC::stream_event);
       cwvio = cwvc->do_io_write(this, header.nbytes, creader);
     }
@@ -824,8 +871,9 @@ MC::ascii_set_event(int event, void *data)
     crvio = NULL;
     if (f.set_append) {
       int64_t a = reader->read_avail();
-      if (a > (int64_t)nbytes)
+      if (a > (int64_t)nbytes) {
         a = (int64_t)nbytes;
+      }
       if (a) {
         cbuf->write(reader, a);
         reader->consume(a);
@@ -880,44 +928,53 @@ MC::ascii_incr_decr_event(int event, void *data)
     cwvc     = (CacheVConnection *)data;
     {
       if (cwvc->get_header((void **)&wcache_header, &hlen) >= 0) {
-        if (hlen < (int)sizeof(MCCacheHeader) || wcache_header->magic != TSMEMCACHE_HEADER_MAGIC)
+        if (hlen < (int)sizeof(MCCacheHeader) || wcache_header->magic != TSMEMCACHE_HEADER_MAGIC) {
           goto Lfail;
-        if (header.nkey != wcache_header->nkey || hlen < (int)(sizeof(MCCacheHeader) + wcache_header->nkey))
+        }
+        if (header.nkey != wcache_header->nkey || hlen < (int)(sizeof(MCCacheHeader) + wcache_header->nkey)) {
           goto Lfail;
+        }
         ink_hrtime t = Thread::get_hrtime();
         if (((ink_hrtime)wcache_header->settime) <= last_flush ||
-            t >= ((ink_hrtime)wcache_header->settime) + HRTIME_SECONDS(wcache_header->exptime))
+            t >= ((ink_hrtime)wcache_header->settime) + HRTIME_SECONDS(wcache_header->exptime)) {
           goto Lfail;
-      } else
+        }
+      } else {
         goto Lfail;
+      }
       memcpy(tmp_cache_header_key, key, header.nkey);
       header.settime = Thread::get_hrtime();
       if (exptime) {
         if (exptime > REALTIME_MAXDELTA) {
-          if (HRTIME_SECONDS(exptime) <= ((ink_hrtime)header.settime))
+          if (HRTIME_SECONDS(exptime) <= ((ink_hrtime)header.settime)) {
             header.exptime = 0;
-          else
+          } else {
             header.exptime = (int32_t)(exptime - (header.settime / HRTIME_SECOND));
-        } else
+          }
+        } else {
           header.exptime = exptime;
-      } else
+        }
+      } else {
         header.exptime = UINT32_MAX; // 136 years
+      }
     }
     header.cas = ink_atomic_increment(&next_cas, 1);
     {
       char *data = 0;
       int len    = 0;
       // must be huge, why convert to a counter ??
-      if (cwvc->get_single_data((void **)&data, &len) < 0)
+      if (cwvc->get_single_data((void **)&data, &len) < 0) {
         goto Lfail;
+      }
       uint64_t new_value = xatoull(data, data + len);
-      if (f.set_incr)
+      if (f.set_incr) {
         new_value += delta;
-      else {
-        if (delta > new_value)
+      } else {
+        if (delta > new_value) {
           new_value = 0;
-        else
+        } else {
           new_value -= delta;
+        }
       }
       char new_value_str_buffer[32], *e = &new_value_str_buffer[30];
       e[0]    = '\r';
@@ -925,10 +982,11 @@ MC::ascii_incr_decr_event(int event, void *data)
       char *s = xutoa(new_value, e);
       creader = wbuf->clone_reader(writer);
       wbuf->write(s, e - s + 2);
-      if (f.noreply)
+      if (f.noreply) {
         writer->consume(e - s + 2);
-      else
+      } else {
         wvio->reenable();
+      }
       MCDebugBuf("tsmemcache_ascii_response", s, e - s + 2);
       header.nbytes = e - s;
       cwvc->set_header(&header, header.len());
@@ -960,8 +1018,9 @@ MC::get_ascii_key(char *as, char *e)
   while (*s == ' ') {
     s++;
     if (s >= e) {
-      if (as - e >= TSMEMCACHE_TMP_CMD_BUFFER_SIZE)
+      if (as - e >= TSMEMCACHE_TMP_CMD_BUFFER_SIZE) {
         return ASCII_CLIENT_ERROR("bad command line");
+      }
       return EVENT_CONT;
     }
   }
@@ -969,21 +1028,25 @@ MC::get_ascii_key(char *as, char *e)
   key = s;
   while (!isspace(*s)) {
     if (s >= e) {
-      if (as - e >= TSMEMCACHE_TMP_CMD_BUFFER_SIZE)
+      if (as - e >= TSMEMCACHE_TMP_CMD_BUFFER_SIZE) {
         return ASCII_RESPONSE("key too large");
+      }
       return EVENT_CONT;
     }
     s++;
   }
-  if (s - key > TSMEMCACHE_MAX_KEY_LEN)
+  if (s - key > TSMEMCACHE_MAX_KEY_LEN) {
     return ASCII_CLIENT_ERROR("bad command line");
+  }
   header.nkey = s - key;
   if (!header.nkey) {
     if (e - s >= 2) {
-      if (*s == '\r')
+      if (*s == '\r') {
         s++;
-      if (*s == '\n' && ngets)
+      }
+      if (*s == '\n' && ngets) {
         return ASCII_RESPONSE("END");
+      }
       return ASCII_CLIENT_ERROR("bad command line");
     }
     return EVENT_CONT; // get some more
@@ -1087,27 +1150,33 @@ MC::ascii_set(char *s, char *e)
   if (f.set_cas) {
     SKIP_SPACE;
     GET_NUM(header.cas);
-  } else
+  } else {
     header.cas = 0;
+  }
   SKIP_SPACE;
   if (*s == 'n' && !STRCMP_REST("oreply", s + 1, e)) {
     f.noreply = 1;
     s += 7;
-    if (s >= e)
+    if (s >= e) {
       return ASCII_CLIENT_ERROR("bad command line");
+    }
     SKIP_SPACE;
   }
-  if (*s == '\r')
+  if (*s == '\r') {
     s++;
-  if (*s == '\n')
+  }
+  if (*s == '\n') {
     s++;
-  if (s != e)
+  }
+  if (s != e) {
     return ASCII_CLIENT_ERROR("bad command line");
+  }
   SET_HANDLER(&MC::ascii_set_event);
-  if (f.set_append || f.set_prepend)
+  if (f.set_append || f.set_prepend) {
     return get_item();
-  else
+  } else {
     return set_item();
+  }
 }
 
 int
@@ -1121,16 +1190,20 @@ MC::ascii_delete(char *s, char *e)
   if (*s == 'n' && !STRCMP_REST("oreply", s + 1, e)) {
     f.noreply = 1;
     s += 7;
-    if (s >= e)
+    if (s >= e) {
       return ASCII_CLIENT_ERROR("bad command line");
+    }
     SKIP_SPACE;
   }
-  if (*s == '\r')
+  if (*s == '\r') {
     s++;
-  if (*s == '\n')
+  }
+  if (*s == '\n') {
     s++;
-  if (s != e)
+  }
+  if (s != e) {
     return ASCII_CLIENT_ERROR("bad command line");
+  }
   SET_HANDLER(&MC::ascii_delete_event);
   return delete_item();
 }
@@ -1148,16 +1221,20 @@ MC::ascii_incr_decr(char *s, char *e)
   if (*s == 'n' && !STRCMP_REST("oreply", s + 1, e)) {
     f.noreply = 1;
     s += 7;
-    if (s >= e)
+    if (s >= e) {
       return ASCII_CLIENT_ERROR("bad command line");
+    }
     SKIP_SPACE;
   }
-  if (*s == '\r')
+  if (*s == '\r') {
     s++;
-  if (*s == '\n')
+  }
+  if (*s == '\n') {
     s++;
-  if (s != e)
+  }
+  if (s != e) {
     return ASCII_CLIENT_ERROR("bad command line");
+  }
   SET_HANDLER(&MC::ascii_incr_decr_event);
   return set_item();
 }
@@ -1165,12 +1242,15 @@ MC::ascii_incr_decr(char *s, char *e)
 static int
 is_end_of_cmd(char *t, char *e)
 {
-  while (*t == ' ' && t < e)
+  while (*t == ' ' && t < e) {
     t++; // skip spaces
-  if (*t == '\r')
+  }
+  if (*t == '\r') {
     t++;
-  if (t != e - 1)
+  }
+  if (t != e - 1) {
     return 0;
+  }
   return 1;
 }
 
@@ -1181,8 +1261,9 @@ is_noreply(char **pt, char *e)
   char *t = *pt;
   if (t < e - 8) {
     while (*t == ' ') {
-      if (t > e - 8)
+      if (t > e - 8) {
         return 0;
+      }
       t++;
     }
     if (t[0] == 'n' && !STRCMP(t + 1, "oreply") && isspace(t[7])) {
@@ -1200,11 +1281,13 @@ MC::read_ascii_from_client_event(int event, void *data)
   char *c = get_ascii_input(TSMEMCACHE_TMP_CMD_BUFFER_SIZE, &len), *s = c;
   MCDebugBuf("tsmemcache_ascii_cmd", c, len);
   char *e = c + len - 5; // at least 6 chars
-  while (*s == ' ' && s < e)
+  while (*s == ' ' && s < e) {
     s++; // skip leading spaces
+  }
   if (s >= e) {
-    if (len >= TSMEMCACHE_TMP_CMD_BUFFER_SIZE || memchr(c, '\n', len))
+    if (len >= TSMEMCACHE_TMP_CMD_BUFFER_SIZE || memchr(c, '\n', len)) {
       return ASCII_CLIENT_ERROR("bad command line");
+    }
     return EVENT_CONT;
   }
   // gets can be large, so do not require the full cmd fit in the buffer
@@ -1219,15 +1302,17 @@ MC::read_ascii_from_client_event(int event, void *data)
       read_offset = 4;
     Lget:
       reader->consume(read_offset);
-      if (c != tmp_cmd_buffer) // all in the block
+      if (c != tmp_cmd_buffer) { // all in the block
         return ascii_get(s + read_offset, e);
-      else
+      } else {
         return ascii_gets();
+      }
     }
     break;
   case 'b': // bget
-    if (s[4] != ' ')
+    if (s[4] != ' ') {
       break;
+    }
     read_offset = 5;
     goto Lget;
     break;
@@ -1237,35 +1322,41 @@ MC::read_ascii_from_client_event(int event, void *data)
   // find the end of the command
   e = (char *)memchr(s, '\n', len);
   if (!e) {
-    if (reader->read_avail() > TSMEMCACHE_MAX_CMD_SIZE)
+    if (reader->read_avail() > TSMEMCACHE_MAX_CMD_SIZE) {
       return ASCII_CLIENT_ERROR("bad command line");
+    }
     return EVENT_CONT;
   }
   e++; // skip nl
   end_of_cmd = e - c;
   switch (*s) {
   case 's': // set stats
-    if (s[1] == 'e' && s[2] == 't' && s[3] == ' ')
+    if (s[1] == 'e' && s[2] == 't' && s[3] == ' ') {
       return ascii_set(s + sizeof("set") - 1, e);
-    if (STRCMP_REST("tats", s + 1, e))
+    }
+    if (STRCMP_REST("tats", s + 1, e)) {
       break;
+    }
     s += sizeof("stats") - 1;
-    if (is_noreply(&s, e))
+    if (is_noreply(&s, e)) {
       break; // to please memcapable
-    else
+    } else {
       return ASCII_RESPONSE("END");
+    }
   case 'a': // add
     if (s[1] == 'd' && s[2] == 'd' && s[3] == ' ') {
       f.set_add = 1;
       return ascii_set(s + sizeof("add") - 1, e);
     }
-    if (STRCMP_REST("ppend", s + 1, e))
+    if (STRCMP_REST("ppend", s + 1, e)) {
       break;
+    }
     f.set_append = 1;
     return ascii_set(s + sizeof("append") - 1, e);
   case 'p': // prepend
-    if (STRCMP_REST("repend", s + 1, e))
+    if (STRCMP_REST("repend", s + 1, e)) {
       break;
+    }
     f.set_prepend = 1;
     return ascii_set(s + sizeof("prepend") - 1, e);
   case 'c': // cas
@@ -1281,13 +1372,15 @@ MC::read_ascii_from_client_event(int event, void *data)
     }
     break;
   case 'f': { // flush_all
-    if (STRCMP_REST("lush_all", s + 1, e))
+    if (STRCMP_REST("lush_all", s + 1, e)) {
       break;
+    }
     s += sizeof("flush_all") - 1;
     SKIP_SPACE;
     int32_t time_offset = 0;
-    if (isdigit(*s))
+    if (isdigit(*s)) {
       GET_NUM(time_offset);
+    }
     f.noreply                 = is_noreply(&s, e);
     ink_hrtime new_last_flush = Thread::get_hrtime() + HRTIME_SECONDS(time_offset);
 #if __WORDSIZE == 64
@@ -1295,50 +1388,61 @@ MC::read_ascii_from_client_event(int event, void *data)
 #else
     ink_atomic_swap(&last_flush, new_last_flush);
 #endif
-    if (!is_end_of_cmd(s, e))
+    if (!is_end_of_cmd(s, e)) {
       break;
+    }
     return ASCII_RESPONSE("OK");
   }
   case 'd': // delete decr
-    if (e - s < 5)
+    if (e - s < 5) {
       break;
+    }
     if (s[2] == 'l') {
-      if (s[1] == 'e' && s[3] == 'e' && s[4] == 't' && s[5] == 'e' && s[6] == ' ')
+      if (s[1] == 'e' && s[3] == 'e' && s[4] == 't' && s[5] == 'e' && s[6] == ' ') {
         return ascii_delete(s + sizeof("delete") - 1, e);
+      }
     } else if (s[1] == 'e' && s[2] == 'c' && s[3] == 'r' && s[4] == ' ') { // decr
       f.set_decr = 1;
       return ascii_incr_decr(s + sizeof("decr") - 1, e);
     }
     break;
   case 'r': // replace
-    if (STRCMP_REST("eplace", s + 1, e))
+    if (STRCMP_REST("eplace", s + 1, e)) {
       break;
+    }
     f.set_replace = 1;
     return ascii_set(s + sizeof("replace") - 1, e);
   case 'q': // quit
-    if (STRCMP_REST("uit", s + 1, e))
+    if (STRCMP_REST("uit", s + 1, e)) {
       break;
-    if (!is_end_of_cmd(s + sizeof("quit") - 1, e))
+    }
+    if (!is_end_of_cmd(s + sizeof("quit") - 1, e)) {
       break;
+    }
     return die();
   case 'v': { // version
     if (s[3] == 's') {
-      if (STRCMP_REST("ersion", s + 1, e))
+      if (STRCMP_REST("ersion", s + 1, e)) {
         break;
-      if (!is_end_of_cmd(s + sizeof("version") - 1, e))
+      }
+      if (!is_end_of_cmd(s + sizeof("version") - 1, e)) {
         break;
+      }
       return ASCII_RESPONSE("VERSION " TSMEMCACHE_VERSION);
     } else if (s[3] == 'b') {
-      if (STRCMP_REST("erbosity", s + 1, e))
+      if (STRCMP_REST("erbosity", s + 1, e)) {
         break;
+      }
       s += sizeof("verbosity") - 1;
       SKIP_SPACE;
-      if (!isdigit(*s))
+      if (!isdigit(*s)) {
         break;
+      }
       GET_NUM(verbosity);
       f.noreply = is_noreply(&s, e);
-      if (!is_end_of_cmd(s, e))
+      if (!is_end_of_cmd(s, e)) {
         break;
+      }
       return ASCII_RESPONSE("OK");
     }
     break;
@@ -1352,14 +1456,16 @@ MC::write_then_close_event(int event, void *data)
 {
   switch (event) {
   case VC_EVENT_EOS:
-    if ((VIO *)data == wvio)
+    if ((VIO *)data == wvio) {
       break;
+    }
   // fall through
   case VC_EVENT_READ_READY:
     return EVENT_DONE; // no more of that stuff
   case VC_EVENT_WRITE_READY:
-    if (wvio->buffer.reader()->read_avail() > 0)
+    if (wvio->buffer.reader()->read_avail() > 0) {
       return EVENT_CONT;
+    }
     break;
   default:
     break;
@@ -1375,12 +1481,14 @@ MC::read_from_client_event(int event, void *data)
     return read_from_client();
   case VC_EVENT_READ_READY:
   case VC_EVENT_EOS:
-    if (reader->read_avail() < 1)
+    if (reader->read_avail() < 1) {
       return EVENT_CONT;
-    if ((uint8_t)reader->start()[0] == (uint8_t)PROTOCOL_BINARY_REQ)
+    }
+    if ((uint8_t)reader->start()[0] == (uint8_t)PROTOCOL_BINARY_REQ) {
       return TS_SET_CALL(&MC::read_binary_from_client_event, event, data);
-    else
+    } else {
       return TS_SET_CALL(&MC::read_ascii_from_client_event, event, data);
+    }
   case VC_EVENT_WRITE_READY:
   case VC_EVENT_WRITE_COMPLETE:
     break;
@@ -1415,8 +1523,9 @@ MC::stream_event(int event, void *data)
       if (cwvio) {
         if (creader != reader && creader->read_avail() < cwvio->nbytes) {
           int64_t a = reader->read_avail();
-          if (a > (int64_t)nbytes)
+          if (a > (int64_t)nbytes) {
             a = (int64_t)nbytes;
+          }
           if (a) {
             cbuf->write(reader, a);
             reader->consume(a);
@@ -1426,8 +1535,9 @@ MC::stream_event(int event, void *data)
       }
       break;
     case VC_EVENT_WRITE_READY:
-      if (crvio)
+      if (crvio) {
         crvio->reenable();
+      }
       break;
     case VC_EVENT_WRITE_COMPLETE:
     case VC_EVENT_READ_COMPLETE:

--- a/plugins/experimental/mp4/mp4.cc
+++ b/plugins/experimental/mp4/mp4.cc
@@ -97,8 +97,9 @@ TSRemapDoRemap(void * /* ih ATS_UNUSED */, TSHttpTxn rh, TSRemapRequestInfo *rri
   val = ts_arg(query, query_len, "start", sizeof("start") - 1, &val_len);
   if (val != NULL) {
     ret = sscanf(val, "%f", &start);
-    if (ret != 1)
+    if (ret != 1) {
       start = 0;
+    }
   }
 
   if (start == 0) {
@@ -194,8 +195,9 @@ mp4_cache_lookup_complete(Mp4Context *mc, TSHttpTxn txnp)
     return;
   }
 
-  if (obj_status != TS_CACHE_LOOKUP_HIT_STALE && obj_status != TS_CACHE_LOOKUP_HIT_FRESH)
+  if (obj_status != TS_CACHE_LOOKUP_HIT_STALE && obj_status != TS_CACHE_LOOKUP_HIT_FRESH) {
     return;
+  }
 
   if (TSHttpTxnCachedRespGet(txnp, &bufp, &hdrp) != TS_SUCCESS) {
     TSError("[%s] Couldn't get cache resp", __FUNCTION__);
@@ -215,8 +217,9 @@ mp4_cache_lookup_complete(Mp4Context *mc, TSHttpTxn txnp)
     TSHandleMLocRelease(bufp, hdrp, cl_field);
   }
 
-  if (n <= 0)
+  if (n <= 0) {
     goto release;
+  }
 
   mc->cl = n;
   mp4_add_transform(mc, txnp);
@@ -241,8 +244,9 @@ mp4_read_response(Mp4Context *mc, TSHttpTxn txnp)
   }
 
   status = TSHttpHdrStatusGet(bufp, hdrp);
-  if (status != TS_HTTP_STATUS_OK)
+  if (status != TS_HTTP_STATUS_OK) {
     goto release;
+  }
 
   n        = 0;
   cl_field = TSMimeHdrFieldFind(bufp, hdrp, TS_MIME_FIELD_CONTENT_LENGTH, TS_MIME_LEN_CONTENT_LENGTH);
@@ -251,8 +255,9 @@ mp4_read_response(Mp4Context *mc, TSHttpTxn txnp)
     TSHandleMLocRelease(bufp, hdrp, cl_field);
   }
 
-  if (n <= 0)
+  if (n <= 0) {
     goto release;
+  }
 
   mc->cl = n;
   mp4_add_transform(mc, txnp);
@@ -267,8 +272,9 @@ mp4_add_transform(Mp4Context *mc, TSHttpTxn txnp)
 {
   TSVConn connp;
 
-  if (mc->transform_added)
+  if (mc->transform_added) {
     return;
+  }
 
   mc->mtc = new Mp4TransformContext(mc->start, mc->cl);
 
@@ -349,8 +355,9 @@ mp4_transform_handler(TSCont contp, Mp4Context *mc)
 
   if (!mtc->parse_over) {
     ret = mp4_parse_meta(mtc, toread <= 0);
-    if (ret == 0)
+    if (ret == 0) {
       goto trans;
+    }
 
     mtc->parse_over    = true;
     mtc->output.buffer = TSIOBufferCreate();
@@ -414,8 +421,9 @@ mp4_transform_handler(TSCont contp, Mp4Context *mc)
 
 trans:
 
-  if (write_down)
+  if (write_down) {
     TSVIOReenable(mtc->output.vio);
+  }
 
   if (toread > 0) {
     TSContCall(TSVIOContGet(input_vio), TS_EVENT_VCONN_WRITE_READY, input_vio);
@@ -477,8 +485,9 @@ ts_arg(const char *param, size_t param_len, const char *key, size_t key_len, siz
 
   *val_len = 0;
 
-  if (!param || !param_len)
+  if (!param || !param_len) {
     return NULL;
+  }
 
   p    = param;
   last = p + param_len;
@@ -486,16 +495,18 @@ ts_arg(const char *param, size_t param_len, const char *key, size_t key_len, siz
   for (; p < last; p++) {
     p = (char *)memmem(p, last - p, key, key_len);
 
-    if (p == NULL)
+    if (p == NULL) {
       return NULL;
+    }
 
     if ((p == param || *(p - 1) == '&') && *(p + key_len) == '=') {
       val = p + key_len + 1;
 
       p = (char *)memchr(p, '&', last - p);
 
-      if (p == NULL)
+      if (p == NULL) {
         p = param + param_len;
+      }
 
       *val_len = p - val;
 

--- a/plugins/experimental/mp4/mp4_meta.cc
+++ b/plugins/experimental/mp4/mp4_meta.cc
@@ -66,8 +66,9 @@ Mp4Meta::parse_meta(bool body_complete)
     wait_next = 0;
   }
 
-  if (meta_avail < MP4_MIN_BUFFER_SIZE && !body_complete)
+  if (meta_avail < MP4_MIN_BUFFER_SIZE && !body_complete) {
     return 0;
+  }
 
   ret = this->parse_root_atoms();
 
@@ -157,8 +158,9 @@ Mp4Meta::post_process_meta()
     }
 
     if (trak->atoms[MP4_CO64_DATA].buffer) {
-      if (mp4_update_co64_atom(trak) != 0)
+      if (mp4_update_co64_atom(trak) != 0) {
         return -1;
+      }
 
     } else if (mp4_update_stco_atom(trak) != 0) {
       return -1;
@@ -174,8 +176,9 @@ Mp4Meta::post_process_meta()
 
     this->moov_size += trak->size;
 
-    if (start_offset > trak->start_offset)
+    if (start_offset > trak->start_offset) {
       start_offset = trak->start_offset;
+    }
 
     for (j = 0; j <= MP4_LAST_ATOM; j++) {
       if (trak->atoms[j].buffer) {
@@ -228,8 +231,9 @@ Mp4Meta::parse_root_atoms()
   memset(buf, 0, sizeof(buf));
 
   for (;;) {
-    if (meta_avail < (int64_t)sizeof(uint32_t))
+    if (meta_avail < (int64_t)sizeof(uint32_t)) {
       return 0;
+    }
 
     copied_size = IOBufferReaderCopy(meta_reader, buf, sizeof(mp4_atom_header64));
     atom_size   = copied_size > 0 ? mp4_get_32value(buf) : 0;
@@ -255,8 +259,9 @@ Mp4Meta::parse_root_atoms()
 
     } else { // regular atom
 
-      if (meta_avail < (int64_t)sizeof(mp4_atom_header)) // not enough for atom header
+      if (meta_avail < (int64_t)sizeof(mp4_atom_header)) { // not enough for atom header
         return 0;
+      }
 
       atom_header_size = sizeof(mp4_atom_header);
     }
@@ -323,12 +328,14 @@ Mp4Meta::mp4_read_atom(mp4_atom_handler *atom, int64_t size)
   char buf[32];
   char *atom_header, *atom_name;
 
-  if (meta_avail < size) // data insufficient, not reasonable for internal atom box.
+  if (meta_avail < size) { // data insufficient, not reasonable for internal atom box.
     return -1;
+  }
 
   while (size > 0) {
-    if (meta_avail < (int64_t)sizeof(uint32_t)) // data insufficient, not reasonable for internal atom box.
+    if (meta_avail < (int64_t)sizeof(uint32_t)) { // data insufficient, not reasonable for internal atom box.
       return -1;
+    }
 
     copied_size = IOBufferReaderCopy(meta_reader, buf, sizeof(mp4_atom_header64));
     atom_size   = copied_size > 0 ? mp4_get_32value(buf) : 0;
@@ -354,8 +361,9 @@ Mp4Meta::mp4_read_atom(mp4_atom_handler *atom, int64_t size)
 
     } else { // regular atom
 
-      if (meta_avail < (int64_t)sizeof(mp4_atom_header))
+      if (meta_avail < (int64_t)sizeof(mp4_atom_header)) {
         return -1;
+      }
 
       atom_header_size = sizeof(mp4_atom_header);
     }
@@ -368,8 +376,9 @@ Mp4Meta::mp4_read_atom(mp4_atom_handler *atom, int64_t size)
 
     for (i = 0; atom[i].name; i++) {
       if (memcmp(atom_name, atom[i].name, 4) == 0) {
-        if (meta_avail < atom_size)
+        if (meta_avail < atom_size) {
           return -1;
+        }
 
         ret = (this->*atom[i].handler)(atom_header_size, atom_size - atom_header_size); // -1: error, 0: success.
 
@@ -400,8 +409,9 @@ Mp4Meta::mp4_read_ftyp_atom(int64_t atom_header_size, int64_t atom_data_size)
 {
   int64_t atom_size;
 
-  if (atom_data_size > MP4_MIN_BUFFER_SIZE)
+  if (atom_data_size > MP4_MIN_BUFFER_SIZE) {
     return -1;
+  }
 
   atom_size = atom_header_size + atom_data_size;
 
@@ -427,13 +437,15 @@ Mp4Meta::mp4_read_moov_atom(int64_t atom_header_size, int64_t atom_data_size)
   int64_t atom_size;
   int ret;
 
-  if (mdat_atom.buffer != NULL) // not reasonable for streaming media
+  if (mdat_atom.buffer != NULL) { // not reasonable for streaming media
     return -1;
+  }
 
   atom_size = atom_header_size + atom_data_size;
 
-  if (atom_data_size >= MP4_MAX_BUFFER_SIZE)
+  if (atom_data_size >= MP4_MAX_BUFFER_SIZE) {
     return -1;
+  }
 
   if (meta_avail < atom_size) { // data unsufficient, wait
     return 0;
@@ -458,8 +470,9 @@ Mp4Meta::mp4_read_mvhd_atom(int64_t atom_header_size, int64_t atom_data_size)
   mp4_mvhd_atom *mvhd;
   mp4_mvhd64_atom mvhd64;
 
-  if (sizeof(mp4_mvhd_atom) - 8 > (size_t)atom_data_size)
+  if (sizeof(mp4_mvhd_atom) - 8 > (size_t)atom_data_size) {
     return -1;
+  }
 
   memset(&mvhd64, 0, sizeof(mvhd64));
   IOBufferReaderCopy(meta_reader, &mvhd64, sizeof(mp4_mvhd64_atom));
@@ -491,8 +504,9 @@ Mp4Meta::mp4_read_trak_atom(int64_t atom_header_size, int64_t atom_data_size)
   int rc;
   Mp4Trak *trak;
 
-  if (trak_num >= MP4_MAX_TRAK_NUM - 1)
+  if (trak_num >= MP4_MAX_TRAK_NUM - 1) {
     return -1;
+  }
 
   trak                 = new Mp4Trak();
   trak_vec[trak_num++] = trak;
@@ -732,15 +746,17 @@ Mp4Meta::mp4_read_stts_atom(int64_t atom_header_size, int64_t atom_data_size)
   mp4_stts_atom stts;
   Mp4Trak *trak;
 
-  if (sizeof(mp4_stts_atom) - 8 > (size_t)atom_data_size)
+  if (sizeof(mp4_stts_atom) - 8 > (size_t)atom_data_size) {
     return -1;
+  }
 
   copied_size = IOBufferReaderCopy(meta_reader, &stts, sizeof(mp4_stts_atom));
   entries     = copied_size > 0 ? mp4_get_32value(stts.entries) : 0;
   esize       = entries * sizeof(mp4_stts_entry);
 
-  if (sizeof(mp4_stts_atom) - 8 + esize > (size_t)atom_data_size)
+  if (sizeof(mp4_stts_atom) - 8 + esize > (size_t)atom_data_size) {
     return -1;
+  }
 
   trak                         = trak_vec[trak_num - 1];
   trak->time_to_sample_entries = entries;
@@ -766,15 +782,17 @@ Mp4Meta::mp4_read_stss_atom(int64_t atom_header_size, int64_t atom_data_size)
   mp4_stss_atom stss;
   Mp4Trak *trak;
 
-  if (sizeof(mp4_stss_atom) - 8 > (size_t)atom_data_size)
+  if (sizeof(mp4_stss_atom) - 8 > (size_t)atom_data_size) {
     return -1;
+  }
 
   copied_size = IOBufferReaderCopy(meta_reader, &stss, sizeof(mp4_stss_atom));
   entries     = copied_size > 0 ? mp4_get_32value(stss.entries) : 0;
   esize       = entries * sizeof(int32_t);
 
-  if (sizeof(mp4_stss_atom) - 8 + esize > (size_t)atom_data_size)
+  if (sizeof(mp4_stss_atom) - 8 + esize > (size_t)atom_data_size) {
     return -1;
+  }
 
   trak                       = trak_vec[trak_num - 1];
   trak->sync_samples_entries = entries;
@@ -800,15 +818,17 @@ Mp4Meta::mp4_read_ctts_atom(int64_t atom_header_size, int64_t atom_data_size)
   mp4_ctts_atom ctts;
   Mp4Trak *trak;
 
-  if (sizeof(mp4_ctts_atom) - 8 > (size_t)atom_data_size)
+  if (sizeof(mp4_ctts_atom) - 8 > (size_t)atom_data_size) {
     return -1;
+  }
 
   copied_size = IOBufferReaderCopy(meta_reader, &ctts, sizeof(mp4_ctts_atom));
   entries     = copied_size > 0 ? mp4_get_32value(ctts.entries) : 0;
   esize       = entries * sizeof(mp4_ctts_entry);
 
-  if (sizeof(mp4_ctts_atom) - 8 + esize > (size_t)atom_data_size)
+  if (sizeof(mp4_ctts_atom) - 8 + esize > (size_t)atom_data_size) {
     return -1;
+  }
 
   trak                             = trak_vec[trak_num - 1];
   trak->composition_offset_entries = entries;
@@ -834,15 +854,17 @@ Mp4Meta::mp4_read_stsc_atom(int64_t atom_header_size, int64_t atom_data_size)
   mp4_stsc_atom stsc;
   Mp4Trak *trak;
 
-  if (sizeof(mp4_stsc_atom) - 8 > (size_t)atom_data_size)
+  if (sizeof(mp4_stsc_atom) - 8 > (size_t)atom_data_size) {
     return -1;
+  }
 
   copied_size = IOBufferReaderCopy(meta_reader, &stsc, sizeof(mp4_stsc_atom));
   entries     = copied_size > 0 ? mp4_get_32value(stsc.entries) : 0;
   esize       = entries * sizeof(mp4_stsc_entry);
 
-  if (sizeof(mp4_stsc_atom) - 8 + esize > (size_t)atom_data_size)
+  if (sizeof(mp4_stsc_atom) - 8 + esize > (size_t)atom_data_size) {
     return -1;
+  }
 
   trak                          = trak_vec[trak_num - 1];
   trak->sample_to_chunk_entries = entries;
@@ -868,8 +890,9 @@ Mp4Meta::mp4_read_stsz_atom(int64_t atom_header_size, int64_t atom_data_size)
   mp4_stsz_atom stsz;
   Mp4Trak *trak;
 
-  if (sizeof(mp4_stsz_atom) - 8 > (size_t)atom_data_size)
+  if (sizeof(mp4_stsz_atom) - 8 > (size_t)atom_data_size) {
     return -1;
+  }
 
   copied_size = IOBufferReaderCopy(meta_reader, &stsz, sizeof(mp4_stsz_atom));
   entries     = copied_size > 0 ? mp4_get_32value(stsz.entries) : 0;
@@ -885,8 +908,9 @@ Mp4Meta::mp4_read_stsz_atom(int64_t atom_header_size, int64_t atom_data_size)
   TSIOBufferCopy(trak->atoms[MP4_STSZ_ATOM].buffer, meta_reader, sizeof(mp4_stsz_atom), 0);
 
   if (size == 0) {
-    if (sizeof(mp4_stsz_atom) - 8 + esize > (size_t)atom_data_size)
+    if (sizeof(mp4_stsz_atom) - 8 + esize > (size_t)atom_data_size) {
       return -1;
+    }
 
     trak->atoms[MP4_STSZ_DATA].buffer = TSIOBufferCreate();
     trak->atoms[MP4_STSZ_DATA].reader = TSIOBufferReaderAlloc(trak->atoms[MP4_STSZ_DATA].buffer);
@@ -911,15 +935,17 @@ Mp4Meta::mp4_read_stco_atom(int64_t atom_header_size, int64_t atom_data_size)
   mp4_stco_atom stco;
   Mp4Trak *trak;
 
-  if (sizeof(mp4_stco_atom) - 8 > (size_t)atom_data_size)
+  if (sizeof(mp4_stco_atom) - 8 > (size_t)atom_data_size) {
     return -1;
+  }
 
   copied_size = IOBufferReaderCopy(meta_reader, &stco, sizeof(mp4_stco_atom));
   entries     = copied_size > 0 ? mp4_get_32value(stco.entries) : 0;
   esize       = entries * sizeof(int32_t);
 
-  if (sizeof(mp4_stco_atom) - 8 + esize > (size_t)atom_data_size)
+  if (sizeof(mp4_stco_atom) - 8 + esize > (size_t)atom_data_size) {
     return -1;
+  }
 
   trak         = trak_vec[trak_num - 1];
   trak->chunks = entries;
@@ -945,15 +971,17 @@ Mp4Meta::mp4_read_co64_atom(int64_t atom_header_size, int64_t atom_data_size)
   mp4_co64_atom co64;
   Mp4Trak *trak;
 
-  if (sizeof(mp4_co64_atom) - 8 > (size_t)atom_data_size)
+  if (sizeof(mp4_co64_atom) - 8 > (size_t)atom_data_size) {
     return -1;
+  }
 
   copied_size = IOBufferReaderCopy(meta_reader, &co64, sizeof(mp4_co64_atom));
   entries     = copied_size > 0 ? mp4_get_32value(co64.entries) : 0;
   esize       = entries * sizeof(int64_t);
 
-  if (sizeof(mp4_co64_atom) - 8 + esize > (size_t)atom_data_size)
+  if (sizeof(mp4_co64_atom) - 8 + esize > (size_t)atom_data_size) {
     return -1;
+  }
 
   trak         = trak_vec[trak_num - 1];
   trak->chunks = entries;
@@ -990,8 +1018,9 @@ Mp4Meta::mp4_update_stts_atom(Mp4Trak *trak)
   int64_t atom_size;
   TSIOBufferReader readerp;
 
-  if (trak->atoms[MP4_STTS_DATA].buffer == NULL)
+  if (trak->atoms[MP4_STTS_DATA].buffer == NULL) {
     return -1;
+  }
 
   sum = start_count = 0;
 
@@ -1078,8 +1107,9 @@ Mp4Meta::mp4_update_stss_atom(Mp4Trak *trak)
   uint32_t i, j, entries, sample, start_sample, left;
   TSIOBufferReader readerp;
 
-  if (trak->atoms[MP4_STSS_DATA].buffer == NULL)
+  if (trak->atoms[MP4_STSS_DATA].buffer == NULL) {
     return 0;
+  }
 
   readerp = TSIOBufferReaderClone(trak->atoms[MP4_STSS_DATA].reader);
 
@@ -1132,8 +1162,9 @@ Mp4Meta::mp4_update_ctts_atom(Mp4Trak *trak)
   uint32_t count;
   TSIOBufferReader readerp;
 
-  if (trak->atoms[MP4_CTTS_DATA].buffer == NULL)
+  if (trak->atoms[MP4_CTTS_DATA].buffer == NULL) {
     return 0;
+  }
 
   readerp = TSIOBufferReaderClone(trak->atoms[MP4_CTTS_DATA].reader);
 
@@ -1194,11 +1225,13 @@ Mp4Meta::mp4_update_stsc_atom(Mp4Trak *trak)
   mp4_stsc_entry *first;
   TSIOBufferReader readerp;
 
-  if (trak->atoms[MP4_STSC_DATA].buffer == NULL)
+  if (trak->atoms[MP4_STSC_DATA].buffer == NULL) {
     return -1;
+  }
 
-  if (trak->sample_to_chunk_entries == 0)
+  if (trak->sample_to_chunk_entries == 0) {
     return -1;
+  }
 
   start_sample = (uint32_t)trak->start_sample;
 
@@ -1241,8 +1274,9 @@ found:
   TSIOBufferReaderFree(readerp);
 
   entries = trak->sample_to_chunk_entries - i + 1;
-  if (samples == 0)
+  if (samples == 0) {
     return -1;
+  }
 
   readerp = TSIOBufferReaderClone(trak->atoms[MP4_STSC_DATA].reader);
   TSIOBufferReaderConsume(readerp, sizeof(mp4_stsc_entry) * (i - 1));
@@ -1302,11 +1336,13 @@ Mp4Meta::mp4_update_stsz_atom(Mp4Trak *trak)
   uint32_t pass;
   TSIOBufferReader readerp;
 
-  if (trak->atoms[MP4_STSZ_DATA].buffer == NULL)
+  if (trak->atoms[MP4_STSZ_DATA].buffer == NULL) {
     return 0;
+  }
 
-  if (trak->start_sample > trak->sample_sizes_entries)
+  if (trak->start_sample > trak->sample_sizes_entries) {
     return -1;
+  }
 
   readerp = TSIOBufferReaderClone(trak->atoms[MP4_STSZ_DATA].reader);
   avail   = TSIOBufferReaderAvail(readerp);
@@ -1339,11 +1375,13 @@ Mp4Meta::mp4_update_co64_atom(Mp4Trak *trak)
   int64_t atom_size, avail, pass;
   TSIOBufferReader readerp;
 
-  if (trak->atoms[MP4_CO64_DATA].buffer == NULL)
+  if (trak->atoms[MP4_CO64_DATA].buffer == NULL) {
     return -1;
+  }
 
-  if (trak->start_chunk > trak->chunks)
+  if (trak->start_chunk > trak->chunks) {
     return -1;
+  }
 
   readerp = trak->atoms[MP4_CO64_DATA].reader;
   avail   = TSIOBufferReaderAvail(readerp);
@@ -1370,11 +1408,13 @@ Mp4Meta::mp4_update_stco_atom(Mp4Trak *trak)
   uint32_t pass;
   TSIOBufferReader readerp;
 
-  if (trak->atoms[MP4_STCO_DATA].buffer == NULL)
+  if (trak->atoms[MP4_STCO_DATA].buffer == NULL) {
     return -1;
+  }
 
-  if (trak->start_chunk > trak->chunks)
+  if (trak->start_chunk > trak->chunks) {
     return -1;
+  }
 
   readerp = trak->atoms[MP4_STCO_DATA].reader;
   avail   = TSIOBufferReaderAvail(readerp);
@@ -1517,8 +1557,9 @@ Mp4Meta::mp4_find_key_sample(uint32_t start_sample, Mp4Trak *trak)
   uint32_t sample, prev_sample, entries;
   TSIOBufferReader readerp;
 
-  if (trak->atoms[MP4_STSS_DATA].buffer == NULL)
+  if (trak->atoms[MP4_STSS_DATA].buffer == NULL) {
     return start_sample;
+  }
 
   prev_sample = 1;
   entries     = trak->sync_samples_entries;
@@ -1552,8 +1593,9 @@ Mp4Meta::mp4_update_mvhd_duration()
 
   need = TSIOBufferReaderAvail(mvhd_atom.reader);
 
-  if (need > (int64_t)sizeof(mp4_mvhd64_atom))
+  if (need > (int64_t)sizeof(mp4_mvhd64_atom)) {
     need = sizeof(mp4_mvhd64_atom);
+  }
 
   memset(&mvhd64, 0, sizeof(mvhd64));
   IOBufferReaderCopy(mvhd_atom.reader, &mvhd64, need);
@@ -1588,8 +1630,9 @@ Mp4Meta::mp4_update_tkhd_duration(Mp4Trak *trak)
 
   need = TSIOBufferReaderAvail(trak->atoms[MP4_TKHD_ATOM].reader);
 
-  if (need > (int64_t)sizeof(mp4_tkhd64_atom))
+  if (need > (int64_t)sizeof(mp4_tkhd64_atom)) {
     need = sizeof(mp4_tkhd64_atom);
+  }
 
   memset(&tkhd64_atom, 0, sizeof(tkhd64_atom));
   IOBufferReaderCopy(trak->atoms[MP4_TKHD_ATOM].reader, &tkhd64_atom, need);
@@ -1625,8 +1668,9 @@ Mp4Meta::mp4_update_mdhd_duration(Mp4Trak *trak)
 
   need = TSIOBufferReaderAvail(trak->atoms[MP4_MDHD_ATOM].reader);
 
-  if (need > (int64_t)sizeof(mp4_mdhd64_atom))
+  if (need > (int64_t)sizeof(mp4_mdhd64_atom)) {
     need = sizeof(mp4_mdhd64_atom);
+  }
 
   IOBufferReaderCopy(trak->atoms[MP4_MDHD_ATOM].reader, &mdhd64, need);
   mdhd = (mp4_mdhd_atom *)&mdhd64;
@@ -1676,8 +1720,9 @@ mp4_reader_set_32value(TSIOBufferReader readerp, int64_t offset, uint32_t n)
         left--;
       }
 
-      if (pos >= 4)
+      if (pos >= 4) {
         return;
+      }
 
       offset = 0;
     }
@@ -1714,8 +1759,9 @@ mp4_reader_set_64value(TSIOBufferReader readerp, int64_t offset, uint64_t n)
         left--;
       }
 
-      if (pos >= 4)
+      if (pos >= 4) {
         return;
+      }
 
       offset = 0;
     }
@@ -1828,8 +1874,9 @@ IOBufferReaderCopy(TSIOBufferReader readerp, void *buf, int64_t length)
       n += need;
     }
 
-    if (length == 0)
+    if (length == 0) {
       break;
+    }
 
     blk = TSIOBufferBlockNext(blk);
   }

--- a/plugins/experimental/s3_auth/s3_auth.cc
+++ b/plugins/experimental/s3_auth/s3_auth.cc
@@ -170,8 +170,9 @@ S3Config::parse_config(const char *config)
 
       // Skip leading white spaces
       pos1 = line;
-      while (*pos1 && isspace(*pos1))
+      while (*pos1 && isspace(*pos1)) {
         ++pos1;
+      }
       if (!*pos1 || ('#' == *pos1)) {
         continue;
       }
@@ -179,8 +180,9 @@ S3Config::parse_config(const char *config)
       // Skip trailig white spaces
       pos2 = pos1;
       pos1 = pos2 + strlen(pos2) - 1;
-      while ((pos1 > pos2) && isspace(*pos1))
+      while ((pos1 > pos2) && isspace(*pos1)) {
         *(pos1--) = '\0';
+      }
       if (pos1 == pos2) {
         continue;
       }
@@ -296,8 +298,9 @@ str_concat(char *dst, size_t dst_len, const char *src, size_t src_len)
 {
   size_t to_copy = (src_len < dst_len) ? src_len : dst_len;
 
-  if (to_copy > 0)
+  if (to_copy > 0) {
     (void)strncat(dst, src, to_copy);
+  }
 
   return to_copy;
 }
@@ -382,11 +385,13 @@ S3Request::authorize(S3Config *s3)
     TSDebug(PLUGIN_NAME, "Signature string is:");
     // ToDo: This should include the Content-MD5 and Content-Type (for POST)
     TSDebug(PLUGIN_NAME, "%.*s", method_len, method);
-    if (con_md5)
+    if (con_md5) {
       TSDebug(PLUGIN_NAME, "%.*s", con_md5_len, con_md5);
+    }
 
-    if (con_type)
+    if (con_type) {
       TSDebug(PLUGIN_NAME, "%.*s", con_type_len, con_type);
+    }
 
     TSDebug(PLUGIN_NAME, "%.*s", date_len, date);
 

--- a/plugins/experimental/ssl_cert_loader/ssl-cert-loader.cc
+++ b/plugins/experimental/ssl_cert_loader/ssl-cert-loader.cc
@@ -520,10 +520,12 @@ TSPluginInit(int argc, const char *argv[])
   }
 
   if (!success) {
-    if (cb_pa)
+    if (cb_pa) {
       TSContDestroy(cb_pa);
-    if (cb_lc)
+    }
+    if (cb_lc) {
       TSContDestroy(cb_lc);
+    }
     TSError(PCP "not initialized");
   }
   TSDebug(PN, "Plugin %s", success ? "online" : "offline");

--- a/plugins/experimental/stream_editor/stream_editor.cc
+++ b/plugins/experimental/stream_editor/stream_editor.cc
@@ -125,8 +125,9 @@ struct edit_t {
        * and comparing to ourself then re-throws.
        * Need to exclude that case.
        */
-      if (*this != x)
+      if (*this != x) {
         throw x;
+      }
     }
     return start < x.start;
   }
@@ -246,8 +247,9 @@ public:
   strscope(const bool u, const bool i, const char *pattern, int len) : scope_t(u), icase(i) { str = TSstrndup(pattern, len); }
   virtual ~strscope()
   {
-    if (str)
+    if (str) {
       TSfree(str);
+    }
   }
 };
 
@@ -283,8 +285,9 @@ public:
   strmatch(const bool i, const char *pattern, int len) : icase(i), slen(len) { str = TSstrndup(pattern, len); }
   virtual ~strmatch()
   {
-    if (str)
+    if (str) {
       TSfree(str);
+    }
   }
 
   virtual size_t
@@ -497,12 +500,15 @@ public:
   {
     if (refcount) {
       if (!--*refcount) {
-        if (scope)
+        if (scope) {
           delete scope;
-        if (from)
+        }
+        if (from) {
           delete from;
-        if (to)
+        }
+        if (to) {
           TSfree(to);
+        }
         delete refcount;
       }
     }
@@ -558,18 +564,22 @@ typedef struct contdata_t {
   contdata_t() : cont(NULL), out_buf(NULL), out_rd(NULL), out_vio(NULL), contbuf_sz(0), bytes_in(0), bytes_out(0) {}
   ~contdata_t()
   {
-    if (out_rd)
+    if (out_rd) {
       TSIOBufferReaderFree(out_rd);
-    if (out_buf)
+    }
+    if (out_buf) {
       TSIOBufferDestroy(out_buf);
-    if (cont)
+    }
+    if (cont) {
       TSContDestroy(cont);
+    }
   }
   void
   set_cont_size(size_t sz)
   {
-    if (contbuf_sz < 2 * sz)
+    if (contbuf_sz < 2 * sz) {
       contbuf_sz = 2 * sz - 1;
+    }
   }
 } contdata_t;
 
@@ -612,8 +622,9 @@ process_block(contdata_t *contdata, TSIOBufferReader reader)
 
   for (edit_p p = edits.begin(); p != edits.end(); ++p) {
     /* Preserve continuity buffer */
-    if (p->start >= buflen - keep)
+    if (p->start >= buflen - keep) {
       break;
+    }
 
     /* pass through bytes before edit */
     start = p->start - bytes_read;

--- a/plugins/gzip/configuration.cc
+++ b/plugins/gzip/configuration.cc
@@ -236,12 +236,14 @@ Configuration::Parse(const char *path)
       trim_if(token, isspace);
 
       // should not happen
-      if (!token.size())
+      if (!token.size()) {
         continue;
+      }
 
       // once a comment is encountered, we are done processing the line
-      if (token[0] == '#')
+      if (token[0] == '#') {
         break;
+      }
 
       switch (state) {
       case kParseStart:

--- a/plugins/gzip/gzip.cc
+++ b/plugins/gzip/gzip.cc
@@ -290,8 +290,9 @@ gzip_transform_one(GzipData *data, TSIOBufferReader upstream_reader, int amount)
         err = deflate(&data->zstrm, Z_SYNC_FLUSH);
       }
 
-      if (err != Z_OK)
+      if (err != Z_OK) {
         warning("deflate() call failed: %d", err);
+      }
 
       if (downstream_length > data->zstrm.avail_out) {
         TSIOBufferProduce(data->downstream_buffer, downstream_length - data->zstrm.avail_out);

--- a/plugins/gzip/misc.cc
+++ b/plugins/gzip/misc.cc
@@ -63,10 +63,11 @@ normalize_accept_encoding(TSHttpTxn /* txnp ATS_UNUSED */, TSMBuffer reqp, TSMLo
         --value_count;
         val = TSMimeHdrFieldValueStringGet(reqp, hdr_loc, field, value_count, &val_len);
 
-        if (val_len == (int)strlen("gzip"))
+        if (val_len == (int)strlen("gzip")) {
           gzip = !strncmp(val, "gzip", val_len);
-        else if (val_len == (int)strlen("deflate"))
+        } else if (val_len == (int)strlen("deflate")) {
           deflate = !strncmp(val, "deflate", val_len);
+        }
       }
     }
 

--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -272,8 +272,9 @@ ConditionPath::append_value(std::string &s, const Resources &res)
     int path_length;
     const char *path = TSUrlPathGet(bufp, url_loc, &path_length);
 
-    if (path && path_length)
+    if (path && path_length) {
       s.append(path, path_length);
+    }
 
     TSHandleMLocRelease(bufp, TS_NULL_MLOC, url_loc);
   }
@@ -495,23 +496,27 @@ ConditionCookie::append_value(std::string &s, const Resources &res)
   const int cookie_name_len     = _qualifier.length();
 
   // Sanity
-  if (bufp == NULL || hdr_loc == NULL)
+  if (bufp == NULL || hdr_loc == NULL) {
     return;
+  }
 
   // Find Cookie
   field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, TS_MIME_FIELD_COOKIE, TS_MIME_LEN_COOKIE);
-  if (field_loc == NULL)
+  if (field_loc == NULL) {
     return;
+  }
 
   // Get all cookies
   cookies = TSMimeHdrFieldValueStringGet(bufp, hdr_loc, field_loc, -1, &cookies_len);
-  if (cookies == NULL || cookies_len <= 0)
+  if (cookies == NULL || cookies_len <= 0) {
     goto out_release_field;
+  }
 
   // Find particular cookie's value
   error = get_cookie_value(cookies, cookies_len, cookie_name, cookie_name_len, &cookie_value, &cookie_value_len);
-  if (error == TS_ERROR)
+  if (error == TS_ERROR) {
     goto out_release_field;
+  }
 
   TSDebug(PLUGIN_NAME, "Appending COOKIE(%s) to evaluation value -> %.*s", cookie_name, cookie_value_len, cookie_value);
   s.append(cookie_value, cookie_value_len);

--- a/plugins/header_rewrite/expander.cc
+++ b/plugins/header_rewrite/expander.cc
@@ -40,12 +40,14 @@ VariableExpander::expand(const Resources &res)
 
   while (true) {
     std::string::size_type start = result.find("%<");
-    if (start == std::string::npos)
+    if (start == std::string::npos) {
       break;
+    }
 
     std::string::size_type end = result.find(">", start);
-    if (end == std::string::npos)
+    if (end == std::string::npos) {
       break;
+    }
 
     std::string first_part = result.substr(0, start);
     std::string last_part  = result.substr(end + 1);

--- a/plugins/header_rewrite/header_rewrite.cc
+++ b/plugins/header_rewrite/header_rewrite.cc
@@ -103,8 +103,9 @@ public:
   void
   release()
   {
-    if (1 >= ink_atomic_decrement(&_ref_count, 1))
+    if (1 >= ink_atomic_decrement(&_ref_count, 1)) {
       delete this;
+    }
   }
 
 private:

--- a/plugins/header_rewrite/operator.cc
+++ b/plugins/header_rewrite/operator.cc
@@ -26,8 +26,9 @@
 const OperModifiers
 Operator::get_oper_modifiers() const
 {
-  if (_next)
+  if (_next) {
     return static_cast<OperModifiers>(_mods | static_cast<Operator *>(_next)->get_oper_modifiers());
+  }
 
   return _mods;
 }

--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -612,8 +612,9 @@ void
 OperatorCounter::exec(const Resources & /* ATS_UNUSED res */) const
 {
   // Sanity
-  if (_counter == TS_ERROR)
+  if (_counter == TS_ERROR) {
     return;
+  }
 
   TSDebug(PLUGIN_NAME, "OperatorCounter::exec() invoked on counter %s", _counter_name.c_str());
   TSStatIntIncrement(_counter, 1);
@@ -761,23 +762,27 @@ CookieHelper::cookieModifyHelper(const char *cookies, const size_t cookies_len, 
 
   for (size_t idx = 0; idx < cookies_len;) {
     // advance any leading spaces
-    for (; idx < cookies_len && std::isspace(cookies[idx]); idx++)
+    for (; idx < cookies_len && std::isspace(cookies[idx]); idx++) {
       ;
+    }
     if (0 == strncmp(cookies + idx, cookie_key.c_str(), cookie_key.size())) {
       size_t key_start_idx = idx;
       // advance to past the name and any subsequent spaces
-      for (idx += cookie_key.size(); idx < cookies_len && std::isspace(cookies[idx]); idx++)
+      for (idx += cookie_key.size(); idx < cookies_len && std::isspace(cookies[idx]); idx++) {
         ;
+      }
       if (idx < cookies_len && cookies[idx++] == '=') {
         // cookie_key is found, then we don't need to add it.
         if (CookieHelper::COOKIE_OP_ADD == cookie_op) {
           return false;
         }
-        for (; idx < cookies_len && std::isspace(cookies[idx]); idx++)
+        for (; idx < cookies_len && std::isspace(cookies[idx]); idx++) {
           ;
+        }
         size_t value_start_idx = idx;
-        for (; idx < cookies_len && cookies[idx] != ';'; idx++)
+        for (; idx < cookies_len && cookies[idx] != ';'; idx++) {
           ;
+        }
         // cookie value is found
         size_t value_end_idx = idx;
         if (CookieHelper::COOKIE_OP_SET == cookie_op) {
@@ -814,8 +819,9 @@ CookieHelper::cookieModifyHelper(const char *cookies, const size_t cookies_len, 
       }
     }
     // find the next cookie pair followed by semi-colon
-    while (idx < cookies_len && cookies[idx++] != ';')
+    while (idx < cookies_len && cookies[idx++] != ';') {
       ;
+    }
   }
 
   if (CookieHelper::COOKIE_OP_ADD == cookie_op || CookieHelper::COOKIE_OP_SET == cookie_op) {

--- a/plugins/header_rewrite/parser.cc
+++ b/plugins/header_rewrite/parser.cc
@@ -128,8 +128,11 @@ Parser::preprocess(std::vector<std::string> tokens)
         _arg = tokens[1] + tokens[2];
       } else if (tokens.size() > 1) {
         _arg = tokens[1];
-      } else
-        _arg = "";
+      } else {
+        {
+          _arg = "";
+        }
+      }
     } else {
       TSError("[%s] conditions must be embraced in %%{}", PLUGIN_NAME);
       return;
@@ -139,10 +142,15 @@ Parser::preprocess(std::vector<std::string> tokens)
     _op = tokens[0];
     if (tokens.size() > 1) {
       _arg = tokens[1];
-      if (tokens.size() > 2)
-        _val = tokens[2];
-      else
-        _val = "";
+      if (tokens.size() > 2) {
+        {
+          _val = tokens[2];
+        }
+      } else {
+        {
+          _val = "";
+        }
+      }
     } else {
       _arg = "";
       _val = "";

--- a/plugins/header_rewrite/regex_helper.cc
+++ b/plugins/header_rewrite/regex_helper.cc
@@ -34,8 +34,9 @@ regexHelper::setRegexMatch(const std::string &s)
   if ((regexExtra == NULL) && (errorStudy != 0)) {
     return false;
   }
-  if (pcre_fullinfo(regex, regexExtra, PCRE_INFO_CAPTURECOUNT, &regexCcount) != 0)
+  if (pcre_fullinfo(regex, regexExtra, PCRE_INFO_CAPTURECOUNT, &regexCcount) != 0) {
     return false;
+  }
   return true;
 }
 

--- a/plugins/header_rewrite/resources.cc
+++ b/plugins/header_rewrite/resources.cc
@@ -110,13 +110,15 @@ void
 Resources::destroy()
 {
   if (bufp) {
-    if (hdr_loc)
+    if (hdr_loc) {
       TSHandleMLocRelease(bufp, TS_NULL_MLOC, hdr_loc);
+    }
   }
 
   if (client_bufp && (client_bufp != bufp)) {
-    if (client_hdr_loc && (client_hdr_loc != hdr_loc)) // TODO: Is this check really necessary?
+    if (client_hdr_loc && (client_hdr_loc != hdr_loc)) { // TODO: Is this check really necessary?
       TSHandleMLocRelease(client_bufp, TS_NULL_MLOC, client_hdr_loc);
+    }
   }
 
   _ready = false;

--- a/plugins/header_rewrite/ruleset.cc
+++ b/plugins/header_rewrite/ruleset.cc
@@ -34,8 +34,9 @@ RuleSet::append(RuleSet *rule)
 
   TSReleaseAssert(rule->next == NULL);
 
-  while (tmp->next)
-    tmp     = tmp->next;
+  while (tmp->next) {
+    tmp = tmp->next;
+  }
   tmp->next = rule;
 }
 

--- a/plugins/header_rewrite/statement.cc
+++ b/plugins/header_rewrite/statement.cc
@@ -27,8 +27,9 @@ Statement::append(Statement *stmt)
   Statement *tmp = this;
 
   TSReleaseAssert(stmt->_next == NULL);
-  while (tmp->_next)
-    tmp      = tmp->_next;
+  while (tmp->_next) {
+    tmp = tmp->_next;
+  }
   tmp->_next = stmt;
 }
 

--- a/plugins/regex_remap/regex_remap.cc
+++ b/plugins/regex_remap/regex_remap.cc
@@ -307,8 +307,9 @@ RemapRegex::initialize(const std::string &reg, const std::string &sub, const std
 
   if (!reg.empty()) {
     _rex_string = TSstrdup(reg.c_str());
-  } else
+  } else {
     _rex_string = NULL;
+  }
 
   if (!sub.empty()) {
     _subst     = TSstrdup(sub.c_str());
@@ -816,14 +817,16 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
         pos1  = line.find_first_not_of(" \t\n#", pos2);
         if (pos1 != std::string::npos) {
           pos2 = line.find_first_of(" \t\n", pos1);
-          if (pos2 == std::string::npos)
+          if (pos2 == std::string::npos) {
             pos2 = line.length();
-          subst  = line.substr(pos1, pos2 - pos1);
-          pos1   = line.find_first_not_of(" \t\n#", pos2);
+          }
+          subst = line.substr(pos1, pos2 - pos1);
+          pos1  = line.find_first_not_of(" \t\n#", pos2);
           if (pos1 != std::string::npos) {
             pos2 = line.find_first_of("\n#", pos1);
-            if (pos2 == std::string::npos)
-              pos2  = line.length();
+            if (pos2 == std::string::npos) {
+              pos2 = line.length();
+            }
             options = line.substr(pos1, pos2 - pos1);
           }
         }

--- a/proxy/CacheControl.cc
+++ b/proxy/CacheControl.cc
@@ -234,8 +234,9 @@ CacheControlRecord::Print()
     printf("\t\tDirective: INVALID\n");
     break;
   }
-  if (cache_responses_to_cookies >= 0)
+  if (cache_responses_to_cookies >= 0) {
     printf("\t\t  - " TWEAK_CACHE_RESPONSES_TO_COOKIES ":%d\n", cache_responses_to_cookies);
+  }
   ControlBase::Print();
 }
 
@@ -264,8 +265,9 @@ CacheControlRecord::Init(matcher_line *line_info)
     bool used = false;
     label     = line_info->line[0][i];
     val       = line_info->line[1][i];
-    if (!label)
+    if (!label) {
       continue;
+    }
 
     if (strcasecmp(label, TWEAK_CACHE_RESPONSES_TO_COOKIES) == 0) {
       char *ptr = 0;
@@ -450,15 +452,17 @@ CacheControlRecord::UpdateMatch(CacheControlResult *result, RequestData *rdata)
     break;
   }
 
-  if (cache_responses_to_cookies >= 0)
+  if (cache_responses_to_cookies >= 0) {
     result->cache_responses_to_cookies = cache_responses_to_cookies;
+  }
 
   if (match == true) {
     char crtc_debug[80];
-    if (result->cache_responses_to_cookies >= 0)
+    if (result->cache_responses_to_cookies >= 0) {
       snprintf(crtc_debug, sizeof(crtc_debug), " [" TWEAK_CACHE_RESPONSES_TO_COOKIES "=%d]", result->cache_responses_to_cookies);
-    else
+    } else {
       crtc_debug[0] = 0;
+    }
 
     Debug("cache_control", "Matched with for %s at line %d%s", CC_directive_str[this->directive], this->line_num, crtc_debug);
   }

--- a/proxy/ControlBase.cc
+++ b/proxy/ControlBase.cc
@@ -154,19 +154,19 @@ TimeMod::timeOfDayToSeconds(const char *time_str, time_t *seconds)
     }
   }
 
-  if (!(hour >= 0 && hour <= 23))
+  if (!(hour >= 0 && hour <= 23)) {
     return "Illegal hour specification";
-
+  }
   tmp = hour * 60;
 
-  if (!(min >= 0 && min <= 59))
+  if (!(min >= 0 && min <= 59)) {
     return "Illegal minute specification";
-
+  }
   tmp = (tmp + min) * 60;
 
-  if (!(sec >= 0 && sec <= 59))
+  if (!(sec >= 0 && sec <= 59)) {
     return "Illegal second specification";
-
+  }
   tmp += sec;
 
   *seconds = tmp;
@@ -222,10 +222,11 @@ PortMod::make(char *value, char const **error)
     *error = "Invalid start port";
   } else if (num_tok == 2) {
     // coverity[secure_coding]
-    if (sscanf(rangeTok[1], "%d", &tmp.end_port) != 1)
+    if (sscanf(rangeTok[1], "%d", &tmp.end_port) != 1) {
       *error = "Invalid end port";
-    else if (tmp.end_port < tmp.start_port)
+    } else if (tmp.end_port < tmp.start_port) {
       *error = "Malformed Range: end port < start port";
+    }
   } else {
     tmp.end_port = tmp.start_port;
   }
@@ -329,8 +330,9 @@ SrcIPMod::make(char *value, char const **error)
   SrcIPMod *zret = 0;
   *error         = ExtractIpRange(value, &tmp.start_addr.sa, &tmp.end_addr.sa);
 
-  if (!*error)
+  if (!*error) {
     zret = new SrcIPMod(tmp);
+  }
   return zret;
 }
 // ----------
@@ -549,8 +551,9 @@ PrefixMod::make(char *value, char const ** /* error ATS_UNUSED */)
   PrefixMod *mod = new PrefixMod();
   // strip leading slashes because get_path which is used later
   // doesn't include them from the URL.
-  while ('/' == *value)
+  while ('/' == *value) {
     ++value;
+  }
   mod->set(value);
   return mod;
 }
@@ -581,13 +584,15 @@ SuffixMod::check(HttpRequestData *req) const
   int path_len;
   char const *path = req->hdr->url_get()->path_get(&path_len);
   if (1 == static_cast<int>(this->text_vec.count()) && 1 == static_cast<int>(this->text_vec[0].size()) &&
-      0 == strcmp(this->text_vec[0].data(), "*"))
+      0 == strcmp(this->text_vec[0].data(), "*")) {
     return true;
+  }
   for_Vec(ts::Buffer, text_iter, this->text_vec)
   {
     if (path_len >= static_cast<int>(text_iter.size()) &&
-        0 == strncasecmp(path + path_len - text_iter.size(), text_iter.data(), text_iter.size()))
+        0 == strncasecmp(path + path_len - text_iter.size(), text_iter.data(), text_iter.size())) {
       return true;
+    }
   }
   return false;
 }
@@ -703,16 +708,18 @@ ControlBase::Print()
 {
   int n = _mods.length();
 
-  if (0 >= n)
+  if (0 >= n) {
     return;
+  }
 
   printf("\t\t\t");
   for (intptr_t i = 0; i < n; ++i) {
     Modifier *cur_mod = _mods[i];
-    if (!cur_mod)
+    if (!cur_mod) {
       printf("INVALID  ");
-    else
+    } else {
       cur_mod->print(stdout);
+    }
   }
   printf("\n");
 }
@@ -722,8 +729,9 @@ ControlBase::getSchemeModText() const
 {
   char const *zret = 0;
   Modifier *mod    = this->findModOfType(Modifier::MOD_SCHEME);
-  if (mod)
+  if (mod) {
     zret = static_cast<SchemeMod *>(mod)->getWksText();
+  }
   return zret;
 }
 
@@ -738,11 +746,11 @@ ControlBase::CheckModifiers(HttpRequestData *request_data)
 
   // If the incoming request has no tag but the entry does, or both
   // have tags that do not match, then we do NOT have a match.
-  if (!request_data->tag && findModOfType(Modifier::MOD_TAG))
+  if (!request_data->tag && findModOfType(Modifier::MOD_TAG)) {
     return false;
+  }
 
-  forv_Vec(Modifier, cur_mod, _mods) if (cur_mod && !cur_mod->check(request_data)) return false;
-
+  forv_Vec(Modifier, cur_mod, _mods) if (cur_mod && !cur_mod->check(request_data)) { return false; }
   return true;
 }
 
@@ -760,7 +768,7 @@ static const char *errorFormats[] = {
 ControlBase::Modifier *
 ControlBase::findModOfType(Modifier::Type t) const
 {
-  forv_Vec(Modifier, m, _mods) if (m && t == m->type()) return m;
+  forv_Vec(Modifier, m, _mods) if (m && t == m->type()) { return m; }
   return 0;
 }
 
@@ -774,8 +782,9 @@ ControlBase::ProcessModifiers(matcher_line *line_info)
   int n_elts = line_info->num_el; // Element count for line.
 
   // No elements -> no modifiers.
-  if (0 >= n_elts)
+  if (0 >= n_elts) {
     return 0;
+  }
   // Can't have more modifiers than elements, so reasonable upper bound.
   _mods.clear();
   _mods.reserve(n_elts);
@@ -790,8 +799,9 @@ ControlBase::ProcessModifiers(matcher_line *line_info)
     char *label = line_info->line[0][i];
     char *value = line_info->line[1][i];
 
-    if (!label)
+    if (!label) {
       continue; // Already use.
+    }
     if (!value) {
       err = ME_PARSE_FAILED;
       break;
@@ -821,8 +831,9 @@ ControlBase::ProcessModifiers(matcher_line *line_info)
       err = ME_BAD_MOD;
     }
 
-    if (errBuf)
+    if (errBuf) {
       err = ME_CALLEE_GENERATED; // Mod make failed.
+    }
 
     // If nothing went wrong, add the mod and bump the element count.
     if (ME_UNKNOWN == err) {

--- a/proxy/ControlMatcher.cc
+++ b/proxy/ControlMatcher.cc
@@ -59,8 +59,9 @@ HttpRequestData::get_string()
 {
   char *str = hdr->url_string_get(NULL);
 
-  if (str)
+  if (str) {
     unescapifyStr(str);
+  }
   return str;
 }
 

--- a/proxy/CoreUtils.cc
+++ b/proxy/CoreUtils.cc
@@ -144,15 +144,17 @@ CoreUtils::find_vaddr(intptr_t vaddr, intptr_t upper, intptr_t lower)
     // no match
   } else if (index == lower) {
     inTable = false;
-    if ((index == 0) && (arrayMem[index].vaddr > vaddr))
+    if ((index == 0) && (arrayMem[index].vaddr > vaddr)) {
       return 0;
-    else
+    } else {
       return index + 1;
+    }
   } else {
-    if (arrayMem[index].vaddr > vaddr)
+    if (arrayMem[index].vaddr > vaddr) {
       return find_vaddr(vaddr, index, lower);
-    else
+    } else {
       return find_vaddr(vaddr, upper, index);
+    }
   }
   assert(0);
   return -1;
@@ -217,9 +219,9 @@ CoreUtils::read_from_core(intptr_t vaddr, intptr_t bytes, char *buf)
   intptr_t size    = arrayMem[index - 1].fsize;
   intptr_t offset2 = std::abs(vaddr - vadd);
 
-  if (bytes > (size - offset2))
+  if (bytes > (size - offset2)) {
     return -1;
-  else {
+  } else {
     if (fseek(fp, offset2 + offset, SEEK_SET) != -1) {
       char *frameoff;
       if ((frameoff = (char *)ats_malloc(sizeof(char) * bytes))) {
@@ -234,8 +236,9 @@ CoreUtils::read_from_core(intptr_t vaddr, intptr_t bytes, char *buf)
         }
         ats_free(frameoff);
       }
-    } else
+    } else {
       return -1;
+    }
   }
 
   return -1;
@@ -389,8 +392,9 @@ CoreUtils::test_HttpSM_from_tunnel(void *arg)
   HttpSM **hsm_ptr = (HttpSM **)(tmp + offset);
   HttpSM *hsm_test;
 
-  if (read_from_core((intptr_t)hsm_ptr, sizeof(HttpSM *), (char *)&hsm_test) == 0)
+  if (read_from_core((intptr_t)hsm_ptr, sizeof(HttpSM *), (char *)&hsm_test) == 0) {
     return;
+  }
 
   unsigned int *magic_ptr = &(hsm_test->magic);
   unsigned int magic      = 0;
@@ -459,8 +463,9 @@ CoreUtils::process_HttpSM(HttpSM *core_ptr)
       }
     }
     ats_free(http_sm);
-  } else
+  } else {
     printf("process_HttpSM : last_seen_http_sm == core_ptr\n");
+  }
 }
 
 void
@@ -569,8 +574,9 @@ CoreUtils::load_http_hdr(HTTPHdr *core_hdr, HTTPHdr *live_hdr)
   swizzle_heap->m_ronly_heap[0].m_heap_start          = (char *)(intptr_t)swizzle_heap->m_size; // offset
   swizzle_heap->m_ronly_heap[0].m_ref_count_ptr.m_ptr = NULL;
 
-  for (int i                                   = 1; i < HDR_BUF_RONLY_HEAPS; i++)
+  for (int i = 1; i < HDR_BUF_RONLY_HEAPS; i++) {
     swizzle_heap->m_ronly_heap[i].m_heap_start = NULL;
+  }
 
   // Next order of business is to copy over string heaps
   //   As we are copying over the string heaps, build

--- a/proxy/ICPConfig.cc
+++ b/proxy/ICPConfig.cc
@@ -216,8 +216,9 @@ BitMap::~BitMap()
 void
 BitMap::SetBit(int bit)
 {
-  if (bit >= _bitmap_size)
+  if (bit >= _bitmap_size) {
     return;
+  }
 
   char *pbyte = &_bitmap[bit / BITS_PER_BYTE];
   *pbyte |= (1 << (bit % BITS_PER_BYTE));
@@ -226,8 +227,9 @@ BitMap::SetBit(int bit)
 void
 BitMap::ClearBit(int bit)
 {
-  if (bit >= _bitmap_size)
+  if (bit >= _bitmap_size) {
     return;
+  }
 
   char *pbyte = &_bitmap[bit / BITS_PER_BYTE];
   *pbyte &= ~(1 << (bit % BITS_PER_BYTE));
@@ -236,14 +238,16 @@ BitMap::ClearBit(int bit)
 int
 BitMap::IsBitSet(int bit)
 {
-  if (bit >= _bitmap_size)
+  if (bit >= _bitmap_size) {
     return 0;
+  }
 
   char *pbyte = &_bitmap[bit / BITS_PER_BYTE];
-  if (*pbyte & (1 << (bit % BITS_PER_BYTE)))
+  if (*pbyte & (1 << (bit % BITS_PER_BYTE))) {
     return 1;
-  else
+  } else {
     return 0;
+  }
 }
 
 //-----------------------------------------------------------------------
@@ -254,24 +258,33 @@ BitMap::IsBitSet(int bit)
 int
 ICPConfigData::operator==(ICPConfigData &ICPData)
 {
-  if (ICPData._icp_enabled != _icp_enabled)
+  if (ICPData._icp_enabled != _icp_enabled) {
     return 0;
-  if (ICPData._icp_port != _icp_port)
+  }
+  if (ICPData._icp_port != _icp_port) {
     return 0;
-  if (ICPData._icp_interface != _icp_interface)
+  }
+  if (ICPData._icp_interface != _icp_interface) {
     return 0;
-  if (ICPData._multicast_enabled != _multicast_enabled)
+  }
+  if (ICPData._multicast_enabled != _multicast_enabled) {
     return 0;
-  if (ICPData._icp_query_timeout != _icp_query_timeout)
+  }
+  if (ICPData._icp_query_timeout != _icp_query_timeout) {
     return 0;
-  if (ICPData._cache_lookup_local != _cache_lookup_local)
+  }
+  if (ICPData._cache_lookup_local != _cache_lookup_local) {
     return 0;
-  if (ICPData._stale_lookup != _stale_lookup)
+  }
+  if (ICPData._stale_lookup != _stale_lookup) {
     return 0;
-  if (ICPData._reply_to_unknown_peer != _reply_to_unknown_peer)
+  }
+  if (ICPData._reply_to_unknown_peer != _reply_to_unknown_peer) {
     return 0;
-  if (ICPData._default_reply_port != _default_reply_port)
+  }
+  if (ICPData._default_reply_port != _default_reply_port) {
     return 0;
+  }
   return 1;
 }
 
@@ -307,8 +320,9 @@ int
 PeerConfigData::GetHostIPByName(char *hostname, IpAddr &rip)
 {
   // Short circuit NULL hostname case
-  if (0 == hostname || 0 == *hostname)
+  if (0 == hostname || 0 == *hostname) {
     return 1; // Unable to map to IP address
+  }
 
   addrinfo hints;
   addrinfo *ai;
@@ -325,8 +339,9 @@ PeerConfigData::GetHostIPByName(char *hostname, IpAddr &rip)
         best = spot->ai_addr;
       }
     }
-    if (best)
+    if (best) {
       rip.assign(best);
+    }
     freeaddrinfo(ai);
   }
   return best ? 0 : 1;
@@ -335,22 +350,30 @@ PeerConfigData::GetHostIPByName(char *hostname, IpAddr &rip)
 bool
 PeerConfigData::operator==(PeerConfigData &PeerData)
 {
-  if (strncmp(PeerData._hostname, _hostname, PeerConfigData::HOSTNAME_SIZE) != 0)
+  if (strncmp(PeerData._hostname, _hostname, PeerConfigData::HOSTNAME_SIZE) != 0) {
     return false;
-  if (PeerData._ctype != _ctype)
+  }
+  if (PeerData._ctype != _ctype) {
     return false;
-  if (PeerData._ip_addr != _ip_addr)
+  }
+  if (PeerData._ip_addr != _ip_addr) {
     return false;
-  if (PeerData._proxy_port != _proxy_port)
+  }
+  if (PeerData._proxy_port != _proxy_port) {
     return false;
-  if (PeerData._icp_port != _icp_port)
+  }
+  if (PeerData._icp_port != _icp_port) {
     return false;
-  if (PeerData._mc_member != _mc_member)
+  }
+  if (PeerData._mc_member != _mc_member) {
     return false;
-  if (PeerData._mc_ip_addr != _mc_ip_addr)
+  }
+  if (PeerData._mc_ip_addr != _mc_ip_addr) {
     return false;
-  if (PeerData._mc_ttl != _mc_ttl)
+  }
+  if (PeerData._mc_ttl != _mc_ttl) {
     return false;
+  }
   return true;
 }
 
@@ -456,8 +479,9 @@ ICPConfiguration::PeerConfigChange()
 {
   // Note: Entry zero reserved for "localhost"
   for (int i = 1; i <= MAX_DEFINED_PEERS; ++i) {
-    if (!(*_peer_cdata[i] == *_peer_cdata_current[i]))
+    if (!(*_peer_cdata[i] == *_peer_cdata_current[i])) {
       return 1;
+    }
   }
   return 0;
 }
@@ -507,9 +531,11 @@ next_field(char *text, char fs)
 {
   text = strchr(text, fs);
   // Compress contiguous whitespace by leaving zret pointing at the last space.
-  if (text && *text == fs)
-    while (text[1] == fs)
+  if (text && *text == fs) {
+    while (text[1] == fs) {
       ++text;
+    }
+  }
   return text;
 }
 }
@@ -590,10 +616,12 @@ ICPConfiguration::icp_config_change_callback(void *data, void *value, int startu
   while ((len = ink_file_fd_readline(fd, sizeof(line) - 1, line)) > 0) {
     ln++;
     cur = line;
-    while (isspace(*cur))
+    while (isspace(*cur)) {
       ++cur, --len; // skip leading space.
-    if (!*cur || *cur == '#')
+    }
+    if (!*cur || *cur == '#') {
       continue;
+    }
 
     if (n >= MAX_DEFINED_PEERS) {
       RecSignalWarning(REC_SIGNAL_CONFIG_ERROR, "read icp.config, maximum peer entries exceeded");
@@ -609,8 +637,9 @@ ICPConfiguration::icp_config_change_callback(void *data, void *value, int startu
        consistent. It still must be an acceptable character.
     */
     char *last = cur + len - 1; // last character.
-    if ('\n' == *last)
+    if ('\n' == *last) {
       --last; // back over trailing LF.
+    }
     if (NULL == strchr(" ;:|,", *last)) {
       RecSignalWarning(REC_SIGNAL_CONFIG_ERROR, "read icp.config, invalid separator [value %d]", *last);
       error = 1;
@@ -777,12 +806,14 @@ ICPConfiguration::icp_config_change_callback(void *data, void *value, int startu
   close(fd);
 
   if (!error) {
-    for (int i                           = 0; i <= MAX_DEFINED_PEERS; i++)
+    for (int i = 0; i <= MAX_DEFINED_PEERS; i++) {
       *ICPconfig->_peer_cdata_current[i] = P[i];
+    }
   }
   delete[] P; // free working buffer
-  if (!startup)
+  if (!startup) {
     ICPconfig->Unlock();
+  }
   return EVENT_DONE;
 }
 
@@ -1086,8 +1117,9 @@ MultiCastPeer::LogSendMsg(ICPMsg_t *m, sockaddr const *sa)
     //
     Peer *p;
     p = FindMultiCastChild(IpAddr(sa), ats_ip_port_host_order(sa));
-    if (p)
+    if (p) {
       ((ParentSiblingPeer *)p)->LogSendMsg(m, sa);
+    }
 
   } else {
     // Note numerous stats on MultiCast peer and each member peer
@@ -1174,8 +1206,9 @@ ICPPeriodicCont::PeriodicEvent(int /* event ATS_UNUSED */, Event * /* e ATS_UNUS
   int do_reconfig     = 0;
   ICPConfiguration *C = _ICPpr->GetConfig();
 
-  if (C->GlobalConfigChange())
+  if (C->GlobalConfigChange()) {
     do_reconfig = 1;
+  }
 
   int configcallouts = C->ICPConfigCallouts();
   if (_last_icp_config_callouts != configcallouts) {
@@ -1293,10 +1326,11 @@ ICPlog::GetClientPort()
 SquidLogCode
 ICPlog::GetAction()
 {
-  if (_s->_queryResult == CACHE_EVENT_LOOKUP)
+  if (_s->_queryResult == CACHE_EVENT_LOOKUP) {
     return SQUID_LOG_UDP_HIT;
-  else
+  } else {
     return SQUID_LOG_UDP_MISS;
+  }
 }
 
 const char *

--- a/proxy/IPAllow.cc
+++ b/proxy/IPAllow.cc
@@ -132,8 +132,9 @@ IpAllow::Print()
       uint32_t test_mask = 1;     // mask for current method.
       for (int i = 0; i < HTTP_WKSIDX_METHODS_CNT; ++i, test_mask <<= 1) {
         if (mask & test_mask) {
-          if (leader)
+          if (leader) {
             s << '|';
+          }
           s << hdrtoken_index_to_wks(i + HTTP_WKSIDX_CONNECT);
           leader = true;
         }

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -475,11 +475,11 @@ inline MIMEHdrImpl *
 _hdr_obj_to_mime_hdr_impl(HdrHeapObjImpl *obj)
 {
   MIMEHdrImpl *impl;
-  if (obj->m_type == HDR_HEAP_OBJ_HTTP_HEADER)
+  if (obj->m_type == HDR_HEAP_OBJ_HTTP_HEADER) {
     impl = ((HTTPHdrImpl *)obj)->m_fields_impl;
-  else if (obj->m_type == HDR_HEAP_OBJ_MIME_HEADER)
+  } else if (obj->m_type == HDR_HEAP_OBJ_MIME_HEADER) {
     impl = (MIMEHdrImpl *)obj;
-  else {
+  } else {
     ink_release_assert(!"mloc not a header type");
     impl = NULL; /* gcc does not know about 'ink_release_assert' - make it happy */
   }
@@ -495,17 +495,20 @@ _hdr_mloc_to_mime_hdr_impl(TSMLoc mloc)
 TSReturnCode
 sdk_sanity_check_field_handle(TSMLoc field, TSMLoc parent_hdr = NULL)
 {
-  if (field == TS_NULL_MLOC)
+  if (field == TS_NULL_MLOC) {
     return TS_ERROR;
+  }
 
   MIMEFieldSDKHandle *field_handle = (MIMEFieldSDKHandle *)field;
-  if (field_handle->m_type != HDR_HEAP_OBJ_FIELD_SDK_HANDLE)
+  if (field_handle->m_type != HDR_HEAP_OBJ_FIELD_SDK_HANDLE) {
     return TS_ERROR;
+  }
 
   if (parent_hdr != NULL) {
     MIMEHdrImpl *mh = _hdr_mloc_to_mime_hdr_impl(parent_hdr);
-    if (field_handle->mh != mh)
+    if (field_handle->mh != mh) {
       return TS_ERROR;
+    }
   }
   return TS_SUCCESS;
 }
@@ -514,8 +517,9 @@ TSReturnCode
 sdk_sanity_check_mbuffer(TSMBuffer bufp)
 {
   HdrHeapSDKHandle *handle = (HdrHeapSDKHandle *)bufp;
-  if ((handle == NULL) || (handle->m_heap == NULL) || (handle->m_heap->m_magic != HDR_BUF_MAGIC_ALIVE))
+  if ((handle == NULL) || (handle->m_heap == NULL) || (handle->m_heap->m_magic != HDR_BUF_MAGIC_ALIVE)) {
     return TS_ERROR;
+  }
 
   return TS_SUCCESS;
 }
@@ -523,12 +527,14 @@ sdk_sanity_check_mbuffer(TSMBuffer bufp)
 TSReturnCode
 sdk_sanity_check_mime_hdr_handle(TSMLoc field)
 {
-  if (field == TS_NULL_MLOC)
+  if (field == TS_NULL_MLOC) {
     return TS_ERROR;
+  }
 
   MIMEFieldSDKHandle *field_handle = (MIMEFieldSDKHandle *)field;
-  if (field_handle->m_type != HDR_HEAP_OBJ_MIME_HEADER)
+  if (field_handle->m_type != HDR_HEAP_OBJ_MIME_HEADER) {
     return TS_ERROR;
+  }
 
   return TS_SUCCESS;
 }
@@ -536,12 +542,14 @@ sdk_sanity_check_mime_hdr_handle(TSMLoc field)
 TSReturnCode
 sdk_sanity_check_url_handle(TSMLoc field)
 {
-  if (field == TS_NULL_MLOC)
+  if (field == TS_NULL_MLOC) {
     return TS_ERROR;
+  }
 
   MIMEFieldSDKHandle *field_handle = (MIMEFieldSDKHandle *)field;
-  if (field_handle->m_type != HDR_HEAP_OBJ_URL)
+  if (field_handle->m_type != HDR_HEAP_OBJ_URL) {
     return TS_ERROR;
+  }
 
   return TS_SUCCESS;
 }
@@ -549,12 +557,14 @@ sdk_sanity_check_url_handle(TSMLoc field)
 TSReturnCode
 sdk_sanity_check_http_hdr_handle(TSMLoc field)
 {
-  if (field == TS_NULL_MLOC)
+  if (field == TS_NULL_MLOC) {
     return TS_ERROR;
+  }
 
   HTTPHdrImpl *field_handle = (HTTPHdrImpl *)field;
-  if (field_handle->m_type != HDR_HEAP_OBJ_HTTP_HEADER)
+  if (field_handle->m_type != HDR_HEAP_OBJ_HTTP_HEADER) {
     return TS_ERROR;
+  }
 
   return TS_SUCCESS;
 }
@@ -562,8 +572,9 @@ sdk_sanity_check_http_hdr_handle(TSMLoc field)
 TSReturnCode
 sdk_sanity_check_continuation(TSCont cont)
 {
-  if ((cont == NULL) || (((INKContInternal *)cont)->m_free_magic == INKCONT_INTERN_MAGIC_DEAD))
+  if ((cont == NULL) || (((INKContInternal *)cont)->m_free_magic == INKCONT_INTERN_MAGIC_DEAD)) {
     return TS_ERROR;
+  }
 
   return TS_SUCCESS;
 }
@@ -571,8 +582,9 @@ sdk_sanity_check_continuation(TSCont cont)
 TSReturnCode
 sdk_sanity_check_fetch_sm(TSFetchSM fetch_sm)
 {
-  if (fetch_sm == NULL)
+  if (fetch_sm == NULL) {
     return TS_ERROR;
+  }
 
   return TS_SUCCESS;
 }
@@ -580,8 +592,9 @@ sdk_sanity_check_fetch_sm(TSFetchSM fetch_sm)
 TSReturnCode
 sdk_sanity_check_http_ssn(TSHttpSsn ssnp)
 {
-  if (ssnp == NULL)
+  if (ssnp == NULL) {
     return TS_ERROR;
+  }
 
   return TS_SUCCESS;
 }
@@ -589,32 +602,36 @@ sdk_sanity_check_http_ssn(TSHttpSsn ssnp)
 TSReturnCode
 sdk_sanity_check_txn(TSHttpTxn txnp)
 {
-  if ((txnp != NULL) && (((HttpSM *)txnp)->magic == HTTP_SM_MAGIC_ALIVE))
+  if ((txnp != NULL) && (((HttpSM *)txnp)->magic == HTTP_SM_MAGIC_ALIVE)) {
     return TS_SUCCESS;
+  }
   return TS_ERROR;
 }
 
 TSReturnCode
 sdk_sanity_check_mime_parser(TSMimeParser parser)
 {
-  if (parser == NULL)
+  if (parser == NULL) {
     return TS_ERROR;
+  }
   return TS_SUCCESS;
 }
 
 TSReturnCode
 sdk_sanity_check_http_parser(TSHttpParser parser)
 {
-  if (parser == NULL)
+  if (parser == NULL) {
     return TS_ERROR;
+  }
   return TS_SUCCESS;
 }
 
 TSReturnCode
 sdk_sanity_check_alt_info(TSHttpAltInfo info)
 {
-  if (info == NULL)
+  if (info == NULL) {
     return TS_ERROR;
+  }
   return TS_SUCCESS;
 }
 
@@ -633,16 +650,18 @@ sdk_sanity_check_lifecycle_hook_id(TSLifecycleHookID id)
 TSReturnCode
 sdk_sanity_check_ssl_hook_id(TSHttpHookID id)
 {
-  if (id < TS_SSL_FIRST_HOOK || id > TS_SSL_LAST_HOOK)
+  if (id < TS_SSL_FIRST_HOOK || id > TS_SSL_LAST_HOOK) {
     return TS_ERROR;
+  }
   return TS_SUCCESS;
 }
 
 TSReturnCode
 sdk_sanity_check_null_ptr(void *ptr)
 {
-  if (ptr == NULL)
+  if (ptr == NULL) {
     return TS_ERROR;
+  }
   return TS_SUCCESS;
 }
 
@@ -1303,8 +1322,9 @@ ConfigUpdateCbTable::insert(INKContInternal *contp, const char *name)
 {
   ink_assert(cb_table != NULL);
 
-  if (contp && name)
+  if (contp && name) {
     ink_hash_table_insert(cb_table, (InkHashTableKey)name, (InkHashTableValue)contp);
+  }
 }
 
 void
@@ -1879,8 +1899,9 @@ TSHandleMLocRelease(TSMBuffer bufp, TSMLoc parent, TSMLoc mloc)
   MIMEFieldSDKHandle *field_handle;
   HdrHeapObjImpl *obj = (HdrHeapObjImpl *)mloc;
 
-  if (mloc == TS_NULL_MLOC)
+  if (mloc == TS_NULL_MLOC) {
     return TS_SUCCESS;
+  }
 
   sdk_assert(sdk_sanity_check_mbuffer(bufp) == TS_SUCCESS);
 
@@ -1892,8 +1913,9 @@ TSHandleMLocRelease(TSMBuffer bufp, TSMLoc parent, TSMLoc mloc)
 
   case HDR_HEAP_OBJ_FIELD_SDK_HANDLE:
     field_handle = (MIMEFieldSDKHandle *)obj;
-    if (sdk_sanity_check_field_handle(mloc, parent) != TS_SUCCESS)
+    if (sdk_sanity_check_field_handle(mloc, parent) != TS_SUCCESS) {
       return TS_ERROR;
+    }
 
     sdk_free_field_handle(bufp, field_handle);
     return TS_SUCCESS;
@@ -1932,8 +1954,9 @@ TSMBufferDestroy(TSMBuffer bufp)
   // if bufp is modifiable. If bufp is not modifiable return
   // TS_ERROR. If allowed, return TS_SUCCESS. Changed the
   // return value of function from void to TSReturnCode.
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
   sdk_assert(sdk_sanity_check_mbuffer(bufp) == TS_SUCCESS);
   HdrHeapSDKHandle *sdk_heap = (HdrHeapSDKHandle *)bufp;
@@ -1977,8 +2000,9 @@ TSUrlClone(TSMBuffer dest_bufp, TSMBuffer src_bufp, TSMLoc src_url, TSMLoc *locp
   sdk_assert(sdk_sanity_check_url_handle(src_url) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_null_ptr(locp) == TS_SUCCESS);
 
-  if (!isWriteable(dest_bufp))
+  if (!isWriteable(dest_bufp)) {
     return TS_ERROR;
+  }
 
   HdrHeap *s_heap, *d_heap;
   URLImpl *s_url, *d_url;
@@ -2000,8 +2024,9 @@ TSUrlCopy(TSMBuffer dest_bufp, TSMLoc dest_obj, TSMBuffer src_bufp, TSMLoc src_o
   sdk_assert(sdk_sanity_check_url_handle(src_obj) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_url_handle(dest_obj) == TS_SUCCESS);
 
-  if (!isWriteable(dest_bufp))
+  if (!isWriteable(dest_bufp)) {
     return TS_ERROR;
+  }
 
   HdrHeap *s_heap, *d_heap;
   URLImpl *s_url, *d_url;
@@ -2059,8 +2084,9 @@ TSUrlParse(TSMBuffer bufp, TSMLoc obj, const char **start, const char *end)
   sdk_assert(sdk_sanity_check_null_ptr((void *)*start) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_null_ptr((void *)end) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_PARSE_ERROR;
+  }
 
   URL u;
   u.m_heap     = ((HdrHeapSDKHandle *)bufp)->m_heap;
@@ -2114,17 +2140,19 @@ URLPartSet(TSMBuffer bufp, TSMLoc obj, const char *value, int length, URLPartSet
   sdk_assert(sdk_sanity_check_mbuffer(bufp) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_url_handle(obj) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
   URL u;
   u.m_heap     = ((HdrHeapSDKHandle *)bufp)->m_heap;
   u.m_url_impl = (URLImpl *)obj;
 
-  if (!value)
+  if (!value) {
     length = 0;
-  else if (length < 0)
+  } else if (length < 0) {
     length = strlen(value);
+  }
   (u.*url_f)(value, length);
 
   return TS_SUCCESS;
@@ -2199,8 +2227,9 @@ TSUrlPortSet(TSMBuffer bufp, TSMLoc obj, int port)
   sdk_assert(sdk_sanity_check_mbuffer(bufp) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_url_handle(obj) == TS_SUCCESS);
 
-  if (!isWriteable(bufp) || (port < 0))
+  if (!isWriteable(bufp) || (port < 0)) {
     return TS_ERROR;
+  }
 
   URL u;
 
@@ -2305,20 +2334,23 @@ TSStringPercentEncode(const char *str, int str_len, char *dst, size_t dst_size, 
 
   int new_len; // Unfortunately, a lot of the core uses "int" for length's internally...
 
-  if (str_len < 0)
+  if (str_len < 0) {
     str_len = strlen(str);
+  }
 
   sdk_assert(str_len < static_cast<int>(dst_size));
 
   // TODO: Perhaps we should make escapify_url() deal with const properly...
   if (NULL == LogUtils::escapify_url(NULL, const_cast<char *>(str), str_len, &new_len, dst, dst_size, map)) {
-    if (length)
+    if (length) {
       *length = 0;
+    }
     return TS_ERROR;
   }
 
-  if (length)
+  if (length) {
     *length = new_len;
+  }
 
   return TS_SUCCESS;
 }
@@ -2329,8 +2361,9 @@ TSStringPercentDecode(const char *str, size_t str_len, char *dst, size_t dst_siz
   sdk_assert(sdk_sanity_check_null_ptr((void *)str) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_null_ptr((void *)dst) == TS_SUCCESS);
 
-  if (0 == str_len)
+  if (0 == str_len) {
     str_len = strlen(str);
+  }
 
   // return unescapifyStr(str);
   char *buffer    = dst;
@@ -2340,8 +2373,9 @@ TSStringPercentDecode(const char *str, size_t str_len, char *dst, size_t dst_siz
   // TODO: We should check for "failures" here?
   unescape_str(buffer, buffer + dst_size, src, src + str_len, s);
   *buffer = '\0';
-  if (length)
+  if (length) {
     *length = (buffer - dst);
+  }
 
   return TS_SUCCESS;
 }
@@ -2417,8 +2451,9 @@ TSMimeHdrCreate(TSMBuffer bufp, TSMLoc *locp)
   sdk_assert(sdk_sanity_check_mbuffer(bufp) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_null_ptr((void *)locp) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
   *locp = reinterpret_cast<TSMLoc>(mime_hdr_create(((HdrHeapSDKHandle *)bufp)->m_heap));
   return TS_SUCCESS;
@@ -2434,8 +2469,9 @@ TSMimeHdrDestroy(TSMBuffer bufp, TSMLoc obj)
   sdk_assert(sdk_sanity_check_mbuffer(bufp) == TS_SUCCESS);
   sdk_assert((sdk_sanity_check_mime_hdr_handle(obj) == TS_SUCCESS) || (sdk_sanity_check_http_hdr_handle(obj) == TS_SUCCESS));
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
   MIMEHdrImpl *mh = _hdr_mloc_to_mime_hdr_impl(obj);
 
@@ -2455,8 +2491,9 @@ TSMimeHdrClone(TSMBuffer dest_bufp, TSMBuffer src_bufp, TSMLoc src_hdr, TSMLoc *
   sdk_assert(sdk_sanity_check_http_hdr_handle(src_hdr) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_null_ptr((void *)locp) == TS_SUCCESS);
 
-  if (!isWriteable(dest_bufp))
+  if (!isWriteable(dest_bufp)) {
     return TS_ERROR;
+  }
 
   HdrHeap *s_heap, *d_heap;
   MIMEHdrImpl *s_mh, *d_mh;
@@ -2485,8 +2522,9 @@ TSMimeHdrCopy(TSMBuffer dest_bufp, TSMLoc dest_obj, TSMBuffer src_bufp, TSMLoc s
   sdk_assert((sdk_sanity_check_mime_hdr_handle(dest_obj) == TS_SUCCESS) ||
              (sdk_sanity_check_http_hdr_handle(dest_obj) == TS_SUCCESS));
 
-  if (!isWriteable(dest_bufp))
+  if (!isWriteable(dest_bufp)) {
     return TS_ERROR;
+  }
 
   HdrHeap *s_heap, *d_heap;
   MIMEHdrImpl *s_mh, *d_mh;
@@ -2541,8 +2579,9 @@ TSMimeHdrParse(TSMimeParser parser, TSMBuffer bufp, TSMLoc obj, const char **sta
   sdk_assert(sdk_sanity_check_null_ptr((void *)*start) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_null_ptr((void *)end) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_PARSE_ERROR;
+  }
 
   MIMEHdrImpl *mh = _hdr_mloc_to_mime_hdr_impl(obj);
 
@@ -2565,8 +2604,9 @@ TSMimeHdrFieldsClear(TSMBuffer bufp, TSMLoc obj)
   sdk_assert(sdk_sanity_check_mbuffer(bufp) == TS_SUCCESS);
   sdk_assert((sdk_sanity_check_mime_hdr_handle(obj) == TS_SUCCESS) || (sdk_sanity_check_http_hdr_handle(obj) == TS_SUCCESS));
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
   MIMEHdrImpl *mh = _hdr_mloc_to_mime_hdr_impl(obj);
 
@@ -2604,13 +2644,15 @@ TSMimeFieldValueSet(TSMBuffer bufp, TSMLoc field_obj, int idx, const char *value
   MIMEFieldSDKHandle *handle = (MIMEFieldSDKHandle *)field_obj;
   HdrHeap *heap              = ((HdrHeapSDKHandle *)bufp)->m_heap;
 
-  if (length == -1)
+  if (length == -1) {
     length = strlen(value);
+  }
 
-  if (idx >= 0)
+  if (idx >= 0) {
     mime_field_value_set_comma_val(heap, handle->mh, handle->field_ptr, idx, value, length);
-  else
+  } else {
     mime_field_value_set(heap, handle->mh, handle->field_ptr, value, length, true);
+  }
 }
 
 void
@@ -2619,8 +2661,9 @@ TSMimeFieldValueInsert(TSMBuffer bufp, TSMLoc field_obj, const char *value, int 
   MIMEFieldSDKHandle *handle = (MIMEFieldSDKHandle *)field_obj;
   HdrHeap *heap              = ((HdrHeapSDKHandle *)bufp)->m_heap;
 
-  if (length == -1)
+  if (length == -1) {
     length = strlen(value);
+  }
 
   mime_field_value_insert_comma_val(heap, handle->mh, handle->field_ptr, idx, value, length);
 }
@@ -2642,8 +2685,9 @@ TSMimeHdrFieldEqual(TSMBuffer bufp, TSMLoc hdr_obj, TSMLoc field1_obj, TSMLoc fi
   MIMEFieldSDKHandle *field1_handle = (MIMEFieldSDKHandle *)field1_obj;
   MIMEFieldSDKHandle *field2_handle = (MIMEFieldSDKHandle *)field2_obj;
 
-  if ((field1_handle == NULL) || (field2_handle == NULL))
+  if ((field1_handle == NULL) || (field2_handle == NULL)) {
     return (field1_handle == field2_handle);
+  }
   return (field1_handle->field_ptr == field2_handle->field_ptr);
 }
 
@@ -2658,8 +2702,9 @@ TSMimeHdrFieldGet(TSMBuffer bufp, TSMLoc hdr_obj, int idx)
   MIMEHdrImpl *mh = _hdr_mloc_to_mime_hdr_impl(hdr_obj);
   MIMEField *f    = mime_hdr_field_get(mh, idx);
 
-  if (f == NULL)
+  if (f == NULL) {
     return TS_NULL_MLOC;
+  }
 
   MIMEFieldSDKHandle *h = sdk_alloc_field_handle(bufp, mh);
 
@@ -2675,14 +2720,16 @@ TSMimeHdrFieldFind(TSMBuffer bufp, TSMLoc hdr_obj, const char *name, int length)
              (sdk_sanity_check_http_hdr_handle(hdr_obj) == TS_SUCCESS));
   sdk_assert(sdk_sanity_check_null_ptr((void *)name) == TS_SUCCESS);
 
-  if (length == -1)
+  if (length == -1) {
     length = strlen(name);
+  }
 
   MIMEHdrImpl *mh = _hdr_mloc_to_mime_hdr_impl(hdr_obj);
   MIMEField *f    = mime_hdr_field_find(mh, name, length);
 
-  if (f == NULL)
+  if (f == NULL) {
     return TS_NULL_MLOC;
+  }
 
   MIMEFieldSDKHandle *h = sdk_alloc_field_handle(bufp, mh);
 
@@ -2702,8 +2749,9 @@ TSMimeHdrFieldAppend(TSMBuffer bufp, TSMLoc mh_mloc, TSMLoc field_mloc)
              (sdk_sanity_check_http_hdr_handle(mh_mloc) == TS_SUCCESS));
   sdk_assert(sdk_sanity_check_field_handle(field_mloc) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
   MIMEField *mh_field;
   MIMEHdrImpl *mh                  = _hdr_mloc_to_mime_hdr_impl(mh_mloc);
@@ -2752,8 +2800,9 @@ TSMimeHdrFieldRemove(TSMBuffer bufp, TSMLoc mh_mloc, TSMLoc field_mloc)
              (sdk_sanity_check_http_hdr_handle(mh_mloc) == TS_SUCCESS));
   sdk_assert(sdk_sanity_check_field_handle(field_mloc, mh_mloc) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
   MIMEFieldSDKHandle *field_handle = (MIMEFieldSDKHandle *)field_mloc;
 
@@ -2778,8 +2827,9 @@ TSMimeHdrFieldDestroy(TSMBuffer bufp, TSMLoc mh_mloc, TSMLoc field_mloc)
              (sdk_sanity_check_http_hdr_handle(mh_mloc) == TS_SUCCESS));
   sdk_assert(sdk_sanity_check_field_handle(field_mloc, mh_mloc) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
   MIMEFieldSDKHandle *field_handle = (MIMEFieldSDKHandle *)field_mloc;
 
@@ -2790,8 +2840,9 @@ TSMimeHdrFieldDestroy(TSMBuffer bufp, TSMLoc mh_mloc, TSMLoc field_mloc)
     HdrHeap *heap   = (HdrHeap *)(((HdrHeapSDKHandle *)bufp)->m_heap);
 
     ink_assert(mh == field_handle->mh);
-    if (sdk_sanity_check_field_handle(field_mloc, mh_mloc) != TS_SUCCESS)
+    if (sdk_sanity_check_field_handle(field_mloc, mh_mloc) != TS_SUCCESS) {
       return TS_ERROR;
+    }
 
     // detach and delete this field, but not all dups
     mime_hdr_field_delete(heap, mh, field_handle->field_ptr, false);
@@ -2812,8 +2863,9 @@ TSMimeHdrFieldCreate(TSMBuffer bufp, TSMLoc mh_mloc, TSMLoc *locp)
              (sdk_sanity_check_http_hdr_handle(mh_mloc) == TS_SUCCESS));
   sdk_assert(sdk_sanity_check_null_ptr((void *)locp) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
   MIMEHdrImpl *mh       = _hdr_mloc_to_mime_hdr_impl(mh_mloc);
   HdrHeap *heap         = (HdrHeap *)(((HdrHeapSDKHandle *)bufp)->m_heap);
@@ -2833,11 +2885,13 @@ TSMimeHdrFieldCreateNamed(TSMBuffer bufp, TSMLoc mh_mloc, const char *name, int 
   sdk_assert(sdk_sanity_check_null_ptr((void *)name) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_null_ptr((void *)locp) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
-  if (name_len == -1)
+  if (name_len == -1) {
     name_len = strlen(name);
+  }
 
   MIMEHdrImpl *mh       = _hdr_mloc_to_mime_hdr_impl(mh_mloc);
   HdrHeap *heap         = (HdrHeap *)(((HdrHeapSDKHandle *)bufp)->m_heap);
@@ -2863,8 +2917,9 @@ TSMimeHdrFieldCopy(TSMBuffer dest_bufp, TSMLoc dest_hdr, TSMLoc dest_field, TSMB
   sdk_assert(sdk_sanity_check_field_handle(src_field, src_hdr) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_field_handle(dest_field, dest_hdr) == TS_SUCCESS);
 
-  if (!isWriteable(dest_bufp))
+  if (!isWriteable(dest_bufp)) {
     return TS_ERROR;
+  }
 
   bool dest_attached;
   MIMEFieldSDKHandle *s_handle = (MIMEFieldSDKHandle *)src_field;
@@ -2879,15 +2934,17 @@ TSMimeHdrFieldCopy(TSMBuffer dest_bufp, TSMLoc dest_hdr, TSMLoc dest_field, TSMB
   // src_attached = (s_handle->mh && s_handle->field_ptr->is_live());
   dest_attached = (d_handle->mh && d_handle->field_ptr->is_live());
 
-  if (dest_attached)
+  if (dest_attached) {
     mime_hdr_field_detach(d_handle->mh, d_handle->field_ptr, false);
+  }
 
   mime_field_name_value_set(d_heap, d_handle->mh, d_handle->field_ptr, s_handle->field_ptr->m_wks_idx,
                             s_handle->field_ptr->m_ptr_name, s_handle->field_ptr->m_len_name, s_handle->field_ptr->m_ptr_value,
                             s_handle->field_ptr->m_len_value, 0, 0, true);
 
-  if (dest_attached)
+  if (dest_attached) {
     mime_hdr_field_attach(d_handle->mh, d_handle->field_ptr, 1, NULL);
+  }
   return TS_SUCCESS;
 }
 
@@ -2906,8 +2963,9 @@ TSMimeHdrFieldClone(TSMBuffer dest_bufp, TSMLoc dest_hdr, TSMBuffer src_bufp, TS
   sdk_assert(sdk_sanity_check_field_handle(src_field, src_hdr) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_null_ptr((void *)locp) == TS_SUCCESS);
 
-  if (!isWriteable(dest_bufp))
+  if (!isWriteable(dest_bufp)) {
     return TS_ERROR;
+  }
 
   // This is sort of sub-optimal, since we'll check the args again. TODO.
   if (TSMimeHdrFieldCreate(dest_bufp, dest_hdr, locp) == TS_SUCCESS) {
@@ -2935,8 +2993,9 @@ TSMimeHdrFieldCopyValues(TSMBuffer dest_bufp, TSMLoc dest_hdr, TSMLoc dest_field
   sdk_assert(sdk_sanity_check_field_handle(src_field, src_hdr) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_field_handle(dest_field, dest_hdr) == TS_SUCCESS);
 
-  if (!isWriteable(dest_bufp))
+  if (!isWriteable(dest_bufp)) {
     return TS_ERROR;
+  }
 
   MIMEFieldSDKHandle *s_handle = (MIMEFieldSDKHandle *)src_field;
   MIMEFieldSDKHandle *d_handle = (MIMEFieldSDKHandle *)dest_field;
@@ -2962,19 +3021,22 @@ TSMimeHdrFieldNext(TSMBuffer bufp, TSMLoc hdr, TSMLoc field)
 
   MIMEFieldSDKHandle *handle = (MIMEFieldSDKHandle *)field;
 
-  if (handle->mh == NULL)
+  if (handle->mh == NULL) {
     return TS_NULL_MLOC;
+  }
 
   int slotnum = mime_hdr_field_slotnum(handle->mh, handle->field_ptr);
-  if (slotnum == -1)
+  if (slotnum == -1) {
     return TS_NULL_MLOC;
+  }
 
   while (1) {
     ++slotnum;
     MIMEField *f = mime_hdr_field_get_slotnum(handle->mh, slotnum);
 
-    if (f == NULL)
+    if (f == NULL) {
       return TS_NULL_MLOC;
+    }
     if (f->is_live()) {
       MIMEFieldSDKHandle *h = sdk_alloc_field_handle(bufp, handle->mh);
 
@@ -2995,8 +3057,9 @@ TSMimeHdrFieldNextDup(TSMBuffer bufp, TSMLoc hdr, TSMLoc field)
   MIMEHdrImpl *mh                  = _hdr_mloc_to_mime_hdr_impl(hdr);
   MIMEFieldSDKHandle *field_handle = (MIMEFieldSDKHandle *)field;
   MIMEField *next                  = field_handle->field_ptr->m_next_dup;
-  if (next == NULL)
+  if (next == NULL) {
     return TS_NULL_MLOC;
+  }
 
   MIMEFieldSDKHandle *next_handle = sdk_alloc_field_handle(bufp, mh);
   next_handle->field_ptr          = next;
@@ -3038,24 +3101,28 @@ TSMimeHdrFieldNameSet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, const char *name
   sdk_assert(sdk_sanity_check_field_handle(field, hdr) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_null_ptr((void *)name) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
-  if (length == -1)
+  if (length == -1) {
     length = strlen(name);
+  }
 
   MIMEFieldSDKHandle *handle = (MIMEFieldSDKHandle *)field;
   HdrHeap *heap              = ((HdrHeapSDKHandle *)bufp)->m_heap;
 
   int attached = (handle->mh && handle->field_ptr->is_live());
 
-  if (attached)
+  if (attached) {
     mime_hdr_field_detach(handle->mh, handle->field_ptr, false);
+  }
 
   handle->field_ptr->name_set(heap, handle->mh, name, length);
 
-  if (attached)
+  if (attached) {
     mime_hdr_field_attach(handle->mh, handle->field_ptr, 1, NULL);
+  }
   return TS_SUCCESS;
 }
 
@@ -3070,8 +3137,9 @@ TSMimeHdrFieldValuesClear(TSMBuffer bufp, TSMLoc hdr, TSMLoc field)
   sdk_assert((sdk_sanity_check_mime_hdr_handle(hdr) == TS_SUCCESS) || (sdk_sanity_check_http_hdr_handle(hdr) == TS_SUCCESS));
   sdk_assert(sdk_sanity_check_field_handle(field, hdr) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
   MIMEFieldSDKHandle *handle = (MIMEFieldSDKHandle *)field;
   HdrHeap *heap              = ((HdrHeapSDKHandle *)bufp)->m_heap;
@@ -3117,8 +3185,9 @@ TSMimeHdrFieldValueDateGet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field)
   int value_len;
   const char *value_str = TSMimeFieldValueGet(bufp, field, -1, &value_len);
 
-  if (value_str == NULL)
+  if (value_str == NULL) {
     return (time_t)0;
+  }
 
   return mime_parse_date(value_str, value_str + value_len);
 }
@@ -3133,8 +3202,9 @@ TSMimeHdrFieldValueIntGet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx)
   int value_len;
   const char *value_str = TSMimeFieldValueGet(bufp, field, idx, &value_len);
 
-  if (value_str == NULL)
+  if (value_str == NULL) {
     return 0;
+  }
 
   return mime_parse_int(value_str, value_str + value_len);
 }
@@ -3149,8 +3219,9 @@ TSMimeHdrFieldValueInt64Get(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx)
   int value_len;
   const char *value_str = TSMimeFieldValueGet(bufp, field, idx, &value_len);
 
-  if (value_str == NULL)
+  if (value_str == NULL) {
     return 0;
+  }
 
   return mime_parse_int64(value_str, value_str + value_len);
 }
@@ -3165,8 +3236,9 @@ TSMimeHdrFieldValueUintGet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx)
   int value_len;
   const char *value_str = TSMimeFieldValueGet(bufp, field, idx, &value_len);
 
-  if (value_str == NULL)
+  if (value_str == NULL) {
     return 0;
+  }
 
   return mime_parse_uint(value_str, value_str + value_len);
 }
@@ -3183,11 +3255,13 @@ TSMimeHdrFieldValueStringSet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx, 
   sdk_assert(sdk_sanity_check_field_handle(field, hdr) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_null_ptr((void *)value) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
-  if (length == -1)
+  if (length == -1) {
     length = strlen(value);
+  }
 
   TSMimeFieldValueSet(bufp, field, idx, value, length);
   return TS_SUCCESS;
@@ -3204,8 +3278,9 @@ TSMimeHdrFieldValueDateSet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, time_t valu
   sdk_assert((sdk_sanity_check_mime_hdr_handle(hdr) == TS_SUCCESS) || (sdk_sanity_check_http_hdr_handle(hdr) == TS_SUCCESS));
   sdk_assert(sdk_sanity_check_field_handle(field, hdr) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
   char tmp[33];
   int len = mime_format_date(tmp, value);
@@ -3227,8 +3302,9 @@ TSMimeHdrFieldValueIntSet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx, int
   sdk_assert((sdk_sanity_check_mime_hdr_handle(hdr) == TS_SUCCESS) || (sdk_sanity_check_http_hdr_handle(hdr) == TS_SUCCESS));
   sdk_assert(sdk_sanity_check_field_handle(field, hdr) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
   char tmp[16];
   int len = mime_format_int(tmp, value, sizeof(tmp));
@@ -3248,8 +3324,9 @@ TSMimeHdrFieldValueInt64Set(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx, i
   sdk_assert((sdk_sanity_check_mime_hdr_handle(hdr) == TS_SUCCESS) || (sdk_sanity_check_http_hdr_handle(hdr) == TS_SUCCESS));
   sdk_assert(sdk_sanity_check_field_handle(field, hdr) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
   char tmp[20];
   int len = mime_format_int64(tmp, value, sizeof(tmp));
@@ -3269,8 +3346,9 @@ TSMimeHdrFieldValueUintSet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx, un
   sdk_assert((sdk_sanity_check_mime_hdr_handle(hdr) == TS_SUCCESS) || (sdk_sanity_check_http_hdr_handle(hdr) == TS_SUCCESS));
   sdk_assert(sdk_sanity_check_field_handle(field, hdr) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
   char tmp[16];
   int len = mime_format_uint(tmp, value, sizeof(tmp));
@@ -3292,14 +3370,16 @@ TSMimeHdrFieldValueAppend(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx, con
   sdk_assert(sdk_sanity_check_null_ptr((void *)value) == TS_SUCCESS);
   sdk_assert(idx >= 0);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
   MIMEFieldSDKHandle *handle = (MIMEFieldSDKHandle *)field;
   HdrHeap *heap              = ((HdrHeapSDKHandle *)bufp)->m_heap;
 
-  if (length == -1)
+  if (length == -1) {
     length = strlen(value);
+  }
   mime_field_value_extend_comma_val(heap, handle->mh, handle->field_ptr, idx, value, length);
   return TS_SUCCESS;
 }
@@ -3315,11 +3395,13 @@ TSMimeHdrFieldValueStringInsert(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int id
   sdk_assert(sdk_sanity_check_field_handle(field, hdr) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_null_ptr((void *)value) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
-  if (length == -1)
+  if (length == -1) {
     length = strlen(value);
+  }
   TSMimeFieldValueInsert(bufp, field, value, length, idx);
   return TS_SUCCESS;
 }
@@ -3334,8 +3416,9 @@ TSMimeHdrFieldValueIntInsert(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx, 
   sdk_assert((sdk_sanity_check_mime_hdr_handle(hdr) == TS_SUCCESS) || (sdk_sanity_check_http_hdr_handle(hdr) == TS_SUCCESS));
   sdk_assert(sdk_sanity_check_field_handle(field, hdr) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
   char tmp[16];
   int len = mime_format_int(tmp, value, sizeof(tmp));
@@ -3354,8 +3437,9 @@ TSMimeHdrFieldValueUintInsert(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx,
   sdk_assert((sdk_sanity_check_mime_hdr_handle(hdr) == TS_SUCCESS) || (sdk_sanity_check_http_hdr_handle(hdr) == TS_SUCCESS));
   sdk_assert(sdk_sanity_check_field_handle(field, hdr) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
   char tmp[16];
   int len = mime_format_uint(tmp, value, sizeof(tmp));
@@ -3374,11 +3458,13 @@ TSMimeHdrFieldValueDateInsert(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, time_t v
   sdk_assert((sdk_sanity_check_mime_hdr_handle(hdr) == TS_SUCCESS) || (sdk_sanity_check_http_hdr_handle(hdr) == TS_SUCCESS));
   sdk_assert(sdk_sanity_check_field_handle(field, hdr) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
-  if (TSMimeHdrFieldValuesClear(bufp, hdr, field) == TS_ERROR)
+  if (TSMimeHdrFieldValuesClear(bufp, hdr, field) == TS_ERROR) {
     return TS_ERROR;
+  }
 
   char tmp[33];
   int len = mime_format_date(tmp, value);
@@ -3400,8 +3486,9 @@ TSMimeHdrFieldValueDelete(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx)
   sdk_assert(sdk_sanity_check_field_handle(field, hdr) == TS_SUCCESS);
   sdk_assert(idx >= 0);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
   MIMEFieldSDKHandle *handle = (MIMEFieldSDKHandle *)field;
   HdrHeap *heap              = ((HdrHeapSDKHandle *)bufp)->m_heap;
@@ -3474,8 +3561,9 @@ TSHttpHdrClone(TSMBuffer dest_bufp, TSMBuffer src_bufp, TSMLoc src_hdr, TSMLoc *
   sdk_assert(sdk_sanity_check_mbuffer(src_bufp) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_http_hdr_handle(src_hdr) == TS_SUCCESS);
 
-  if (!isWriteable(dest_bufp))
+  if (!isWriteable(dest_bufp)) {
     return TS_ERROR;
+  }
 
   HdrHeap *s_heap, *d_heap;
   HTTPHdrImpl *s_hh, *d_hh;
@@ -3484,8 +3572,9 @@ TSHttpHdrClone(TSMBuffer dest_bufp, TSMBuffer src_bufp, TSMLoc src_hdr, TSMLoc *
   d_heap = ((HdrHeapSDKHandle *)dest_bufp)->m_heap;
   s_hh   = (HTTPHdrImpl *)src_hdr;
 
-  if (s_hh->m_type != HDR_HEAP_OBJ_HTTP_HEADER)
+  if (s_hh->m_type != HDR_HEAP_OBJ_HTTP_HEADER) {
     return TS_ERROR;
+  }
 
   // TODO: This is never used
   // inherit_strs = (s_heap != d_heap ? true : false);
@@ -3507,8 +3596,9 @@ TSHttpHdrCopy(TSMBuffer dest_bufp, TSMLoc dest_obj, TSMBuffer src_bufp, TSMLoc s
   sdk_assert(sdk_sanity_check_http_hdr_handle(dest_obj) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_http_hdr_handle(src_obj) == TS_SUCCESS);
 
-  if (!isWriteable(dest_bufp))
+  if (!isWriteable(dest_bufp)) {
     return TS_ERROR;
+  }
 
   bool inherit_strs;
   HdrHeap *s_heap, *d_heap;
@@ -3519,8 +3609,9 @@ TSHttpHdrCopy(TSMBuffer dest_bufp, TSMLoc dest_obj, TSMBuffer src_bufp, TSMLoc s
   s_hh   = (HTTPHdrImpl *)src_obj;
   d_hh   = (HTTPHdrImpl *)dest_obj;
 
-  if ((s_hh->m_type != HDR_HEAP_OBJ_HTTP_HEADER) || (d_hh->m_type != HDR_HEAP_OBJ_HTTP_HEADER))
+  if ((s_hh->m_type != HDR_HEAP_OBJ_HTTP_HEADER) || (d_hh->m_type != HDR_HEAP_OBJ_HTTP_HEADER)) {
     return TS_ERROR;
+  }
 
   inherit_strs = (s_heap != d_heap ? true : false);
   TSHttpHdrTypeSet(dest_bufp, dest_obj, (TSHttpType)(s_hh->m_polarity));
@@ -3572,8 +3663,9 @@ TSHttpHdrParseReq(TSHttpParser parser, TSMBuffer bufp, TSMLoc obj, const char **
   sdk_assert(sdk_sanity_check_null_ptr((void *)*start) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_null_ptr((void *)end) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_PARSE_ERROR;
+  }
 
   HTTPHdr h;
 
@@ -3592,8 +3684,9 @@ TSHttpHdrParseResp(TSHttpParser parser, TSMBuffer bufp, TSMLoc obj, const char *
   sdk_assert(sdk_sanity_check_null_ptr((void *)*start) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_null_ptr((void *)end) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_PARSE_ERROR;
+  }
 
   HTTPHdr h;
 
@@ -3641,8 +3734,9 @@ TSHttpHdrTypeSet(TSMBuffer bufp, TSMLoc obj, TSHttpType type)
   sdk_assert(sdk_sanity_check_http_hdr_handle(obj) == TS_SUCCESS);
   sdk_assert((type >= TS_HTTP_TYPE_UNKNOWN) && (type <= TS_HTTP_TYPE_RESPONSE));
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
   HTTPHdr h;
 
@@ -3691,8 +3785,9 @@ TSHttpHdrVersionSet(TSMBuffer bufp, TSMLoc obj, int ver)
   sdk_assert(sdk_sanity_check_mbuffer(bufp) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_http_hdr_handle(obj) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
   HTTPHdr h;
   HTTPVersion version(ver);
@@ -3728,14 +3823,16 @@ TSHttpHdrMethodSet(TSMBuffer bufp, TSMLoc obj, const char *value, int length)
   sdk_assert(sdk_sanity_check_http_hdr_handle(obj) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_null_ptr((void *)value) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
   HTTPHdr h;
 
   SET_HTTP_HDR(h, bufp, obj);
-  if (length < 0)
+  if (length < 0) {
     length = strlen(value);
+  }
 
   h.method_set(value, length);
   return TS_SUCCESS;
@@ -3762,8 +3859,9 @@ TSHttpHdrUrlGet(TSMBuffer bufp, TSMLoc obj, TSMLoc *locp)
 
   HTTPHdrImpl *hh = (HTTPHdrImpl *)obj;
 
-  if (hh->m_polarity != HTTP_TYPE_REQUEST)
+  if (hh->m_polarity != HTTP_TYPE_REQUEST) {
     return TS_ERROR;
+  }
 
   *locp = ((TSMLoc)hh->u.req.m_url_impl);
   return TS_SUCCESS;
@@ -3780,14 +3878,16 @@ TSHttpHdrUrlSet(TSMBuffer bufp, TSMLoc obj, TSMLoc url)
   sdk_assert(sdk_sanity_check_http_hdr_handle(obj) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_url_handle(url) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
   HdrHeap *heap   = ((HdrHeapSDKHandle *)bufp)->m_heap;
   HTTPHdrImpl *hh = (HTTPHdrImpl *)obj;
 
-  if (hh->m_type != HDR_HEAP_OBJ_HTTP_HEADER)
+  if (hh->m_type != HDR_HEAP_OBJ_HTTP_HEADER) {
     return TS_ERROR;
+  }
 
   URLImpl *url_impl = (URLImpl *)url;
   http_hdr_url_set(heap, hh, url_impl);
@@ -3816,8 +3916,9 @@ TSHttpHdrStatusSet(TSMBuffer bufp, TSMLoc obj, TSHttpStatus status)
   sdk_assert(sdk_sanity_check_mbuffer(bufp) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_http_hdr_handle(obj) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
   HTTPHdr h;
 
@@ -3851,8 +3952,9 @@ TSHttpHdrReasonSet(TSMBuffer bufp, TSMLoc obj, const char *value, int length)
   sdk_assert(sdk_sanity_check_http_hdr_handle(obj) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_null_ptr((void *)value) == TS_SUCCESS);
 
-  if (!isWriteable(bufp))
+  if (!isWriteable(bufp)) {
     return TS_ERROR;
+  }
 
   HTTPHdr h;
 
@@ -3861,8 +3963,9 @@ TSHttpHdrReasonSet(TSMBuffer bufp, TSMLoc obj, const char *value, int length)
      ink_assert(h.m_http->m_type == HDR_HEAP_OBJ_HTTP_HEADER);
   */
 
-  if (length < 0)
+  if (length < 0) {
     length = strlen(value);
+  }
   h.reason_set(value, length);
   return TS_SUCCESS;
 }
@@ -3882,8 +3985,9 @@ TSHttpHdrReasonLookup(TSHttpStatus status)
 inline TSReturnCode
 sdk_sanity_check_cachekey(TSCacheKey key)
 {
-  if (NULL == key)
+  if (NULL == key) {
     return TS_ERROR;
+  }
 
   return TS_SUCCESS;
 }
@@ -3906,8 +4010,9 @@ TSCacheKeyDigestSet(TSCacheKey key, const char *input, int length)
   sdk_assert(length > 0);
   CacheInfo *ci = reinterpret_cast<CacheInfo *>(key);
 
-  if (ci->magic != CACHE_INFO_MAGIC_ALIVE)
+  if (ci->magic != CACHE_INFO_MAGIC_ALIVE) {
     return TS_ERROR;
+  }
 
   MD5Context().hash_immediate(ci->cache_key, input, length);
   return TS_SUCCESS;
@@ -3918,8 +4023,9 @@ TSCacheKeyDigestFromUrlSet(TSCacheKey key, TSMLoc url)
 {
   sdk_assert(sdk_sanity_check_cachekey(key) == TS_SUCCESS);
 
-  if (((CacheInfo *)key)->magic != CACHE_INFO_MAGIC_ALIVE)
+  if (((CacheInfo *)key)->magic != CACHE_INFO_MAGIC_ALIVE) {
     return TS_ERROR;
+  }
 
   url_MD5_get((URLImpl *)url, &((CacheInfo *)key)->cache_key);
   return TS_SUCCESS;
@@ -3930,8 +4036,9 @@ TSCacheKeyDataTypeSet(TSCacheKey key, TSCacheDataType type)
 {
   sdk_assert(sdk_sanity_check_cachekey(key) == TS_SUCCESS);
 
-  if (((CacheInfo *)key)->magic != CACHE_INFO_MAGIC_ALIVE)
+  if (((CacheInfo *)key)->magic != CACHE_INFO_MAGIC_ALIVE) {
     return TS_ERROR;
+  }
 
   switch (type) {
   case TS_CACHE_DATA_TYPE_NONE:
@@ -3955,8 +4062,9 @@ TSCacheKeyHostNameSet(TSCacheKey key, const char *hostname, int host_len)
   sdk_assert(sdk_sanity_check_null_ptr((void *)hostname) == TS_SUCCESS);
   sdk_assert(host_len > 0);
 
-  if (((CacheInfo *)key)->magic != CACHE_INFO_MAGIC_ALIVE)
+  if (((CacheInfo *)key)->magic != CACHE_INFO_MAGIC_ALIVE) {
     return TS_ERROR;
+  }
 
   CacheInfo *i = (CacheInfo *)key;
   /* need to make a copy of the hostname. The caller
@@ -3972,8 +4080,9 @@ TSCacheKeyPinnedSet(TSCacheKey key, time_t pin_in_cache)
 {
   sdk_assert(sdk_sanity_check_cachekey(key) == TS_SUCCESS);
 
-  if (((CacheInfo *)key)->magic != CACHE_INFO_MAGIC_ALIVE)
+  if (((CacheInfo *)key)->magic != CACHE_INFO_MAGIC_ALIVE) {
     return TS_ERROR;
+  }
 
   CacheInfo *i    = (CacheInfo *)key;
   i->pin_in_cache = pin_in_cache;
@@ -3985,8 +4094,9 @@ TSCacheKeyDestroy(TSCacheKey key)
 {
   sdk_assert(sdk_sanity_check_cachekey(key) == TS_SUCCESS);
 
-  if (((CacheInfo *)key)->magic != CACHE_INFO_MAGIC_ALIVE)
+  if (((CacheInfo *)key)->magic != CACHE_INFO_MAGIC_ALIVE) {
     return TS_ERROR;
+  }
 
   CacheInfo *i = (CacheInfo *)key;
 
@@ -4078,9 +4188,10 @@ TSCacheHttpInfoVector(TSCacheHttpInfo infop, void *data, int length)
 
   int size = vector.marshal_length();
 
-  if (size > length)
+  if (size > length) {
     // error
     return 0;
+  }
 
   return vector.marshal((char *)data, length);
 }
@@ -4191,8 +4302,9 @@ TSCont
 TSContCreate(TSEventFunc funcp, TSMutex mutexp)
 {
   // mutexp can be NULL
-  if (mutexp != NULL)
+  if (mutexp != NULL) {
     sdk_assert(sdk_sanity_check_mutex(mutexp) == TS_SUCCESS);
+  }
 
   INKContInternal *i = INKContAllocator.alloc();
 
@@ -4240,8 +4352,9 @@ TSContSchedule(TSCont contp, ink_hrtime timeout, TSThreadPool tp)
   INKContInternal *i = (INKContInternal *)contp;
   TSAction action;
 
-  if (ink_atomic_increment((int *)&i->m_event_count, 1) < 0)
+  if (ink_atomic_increment((int *)&i->m_event_count, 1) < 0) {
     ink_assert(!"not reached");
+  }
 
   EventType etype;
 
@@ -4294,8 +4407,9 @@ TSContScheduleEvery(TSCont contp, ink_hrtime every, TSThreadPool tp)
   INKContInternal *i = (INKContInternal *)contp;
   TSAction action;
 
-  if (ink_atomic_increment((int *)&i->m_event_count, 1) < 0)
+  if (ink_atomic_increment((int *)&i->m_event_count, 1) < 0) {
     ink_assert(!"not reached");
+  }
 
   EventType etype;
 
@@ -4328,8 +4442,9 @@ TSHttpSchedule(TSCont contp, TSHttpTxn txnp, ink_hrtime timeout)
 
   INKContInternal *i = (INKContInternal *)contp;
 
-  if (ink_atomic_increment((int *)&i->m_event_count, 1) < 0)
+  if (ink_atomic_increment((int *)&i->m_event_count, 1) < 0) {
     ink_assert(!"not reached");
+  }
 
   TSAction action;
   Continuation *cont = (Continuation *)contp;
@@ -4399,8 +4514,9 @@ TSHttpIcpDynamicSet(int value)
   new_value = (value == 0) ? 0 : 1;
   old_value = icp_dynamic_enabled;
   while (old_value != new_value) {
-    if (ink_atomic_cas(&icp_dynamic_enabled, old_value, new_value))
+    if (ink_atomic_cas(&icp_dynamic_enabled, old_value, new_value)) {
       break;
+    }
     old_value = icp_dynamic_enabled;
   }
 }
@@ -4728,15 +4844,18 @@ TSHttpTxnCachedRespModifiableGet(TSHttpTxn txnp, TSMBuffer *bufp, TSMLoc *obj)
   HTTPInfo *cached_obj       = sm->t_state.cache_info.object_read;
   HTTPInfo *cached_obj_store = &(sm->t_state.cache_info.object_store);
 
-  if ((!cached_obj) || (!cached_obj->valid()))
+  if ((!cached_obj) || (!cached_obj->valid())) {
     return TS_ERROR;
+  }
 
-  if (!cached_obj_store->valid())
+  if (!cached_obj_store->valid()) {
     cached_obj_store->create();
+  }
 
   c_resp = cached_obj_store->response_get();
-  if (c_resp == NULL || !c_resp->valid())
+  if (c_resp == NULL || !c_resp->valid()) {
     cached_obj_store->response_set(cached_obj->response_get());
+  }
   c_resp                        = cached_obj_store->response_get();
   s->api_modifiable_cached_resp = true;
 
@@ -4802,8 +4921,9 @@ TSHttpTxnCacheLookupStatusSet(TSHttpTxn txnp, int cachelookup)
   HttpTransact::CacheLookupResult_t *sm_status = &(sm->t_state.cache_lookup_result);
 
   // converting from a miss to a hit is not allowed
-  if (*sm_status == HttpTransact::CACHE_LOOKUP_MISS && cachelookup != TS_CACHE_LOOKUP_MISS)
+  if (*sm_status == HttpTransact::CACHE_LOOKUP_MISS && cachelookup != TS_CACHE_LOOKUP_MISS) {
     return TS_ERROR;
+  }
 
   // here is to handle converting a hit to a miss
   if (cachelookup == TS_CACHE_LOOKUP_MISS && *sm_status != HttpTransact::CACHE_LOOKUP_MISS) {
@@ -4876,8 +4996,9 @@ TSHttpTxnCacheLookupUrlGet(TSHttpTxn txnp, TSMBuffer bufp, TSMLoc obj)
 
   u.m_heap     = ((HdrHeapSDKHandle *)bufp)->m_heap;
   u.m_url_impl = (URLImpl *)obj;
-  if (!u.valid())
+  if (!u.valid()) {
     return TS_ERROR;
+  }
 
   l_url = sm->t_state.cache_info.lookup_url;
   if (l_url && l_url->valid()) {
@@ -4933,15 +5054,17 @@ TSHttpTxnNewCacheLookupDo(TSHttpTxn txnp, TSMBuffer bufp, TSMLoc url_loc)
 
   new_url.m_heap     = ((HdrHeapSDKHandle *)bufp)->m_heap;
   new_url.m_url_impl = (URLImpl *)url_loc;
-  if (!new_url.valid())
+  if (!new_url.valid()) {
     return TS_ERROR;
+  }
 
   HttpSM *sm             = (HttpSM *)txnp;
   HttpTransact::State *s = &(sm->t_state);
 
   client_url = s->hdr_info.client_request.url_get();
-  if (!(client_url->valid()))
+  if (!(client_url->valid())) {
     return TS_ERROR;
+  }
 
   // if l_url is not valid, then no cache lookup has been done yet
   // so we shouldn't be calling TSHttpTxnNewCacheLookupDo right now
@@ -4953,8 +5076,9 @@ TSHttpTxnNewCacheLookupDo(TSHttpTxn txnp, TSMBuffer bufp, TSMLoc url_loc)
   } else {
     l_url->hash_get(&md51);
     new_url.hash_get(&md52);
-    if (md51 == md52)
+    if (md51 == md52) {
       return TS_ERROR;
+    }
     o_url = &(s->cache_info.original_url);
     if (!o_url->valid()) {
       o_url->create(NULL);
@@ -4983,8 +5107,9 @@ TSHttpTxnSecondUrlTryLock(TSHttpTxn txnp)
   HttpSM *sm             = (HttpSM *)txnp;
   HttpTransact::State *s = &(sm->t_state);
   // TSHttpTxnNewCacheLookupDo didn't continue
-  if (!s->cache_info.original_url.valid())
+  if (!s->cache_info.original_url.valid()) {
     return TS_ERROR;
+  }
   sm->add_cache_sm();
   s->api_lock_url = HttpTransact::LOCK_URL_SECOND;
 
@@ -5009,12 +5134,14 @@ TSHttpTxnRedirectRequest(TSHttpTxn txnp, TSMBuffer bufp, TSMLoc url_loc)
 
   u.m_heap     = ((HdrHeapSDKHandle *)bufp)->m_heap;
   u.m_url_impl = (URLImpl *)url_loc;
-  if (!u.valid())
+  if (!u.valid()) {
     return TS_ERROR;
+  }
 
   client_url = s->hdr_info.client_request.url_get();
-  if (!(client_url->valid()))
+  if (!(client_url->valid())) {
     return TS_ERROR;
+  }
 
   s->redirect_info.redirect_in_process = true;
   o_url                                = &(s->redirect_info.original_url);
@@ -5025,8 +5152,9 @@ TSHttpTxnRedirectRequest(TSHttpTxn txnp, TSMBuffer bufp, TSMLoc url_loc)
   client_url->copy(&u);
 
   r_url = &(s->redirect_info.redirect_url);
-  if (!r_url->valid())
+  if (!r_url->valid()) {
     r_url->create(NULL);
+  }
   r_url->copy(&u);
 
   s->hdr_info.server_request.destroy();
@@ -5112,12 +5240,14 @@ TSHttpTxnServerRespIgnore(TSHttpTxn txnp)
   HTTPInfo *cached_obj   = s->cache_info.object_read;
   HTTPHdr *cached_resp;
 
-  if (cached_obj == NULL || !cached_obj->valid())
+  if (cached_obj == NULL || !cached_obj->valid()) {
     return TS_ERROR;
+  }
 
   cached_resp = cached_obj->response_get();
-  if (cached_resp == NULL || !cached_resp->valid())
+  if (cached_resp == NULL || !cached_resp->valid()) {
     return TS_ERROR;
+  }
 
   s->api_server_response_ignore = true;
 
@@ -5129,8 +5259,9 @@ TSHttpTxnShutDown(TSHttpTxn txnp, TSEvent event)
 {
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
 
-  if (event == TS_EVENT_HTTP_TXN_CLOSE)
+  if (event == TS_EVENT_HTTP_TXN_CLOSE) {
     return TS_ERROR;
+  }
 
   HttpTransact::State *s  = &(((HttpSM *)txnp)->t_state);
   s->api_http_sm_shutdown = true;
@@ -5207,14 +5338,17 @@ TSHttpTxnUpdateCachedObject(TSHttpTxn txnp)
   HTTPInfo *cached_obj_store = &(sm->t_state.cache_info.object_store);
   HTTPHdr *client_request    = &(sm->t_state.hdr_info.client_request);
 
-  if (!cached_obj_store->valid() || !cached_obj_store->response_get())
+  if (!cached_obj_store->valid() || !cached_obj_store->response_get()) {
     return TS_ERROR;
+  }
 
-  if (!cached_obj_store->request_get() && !client_request->valid())
+  if (!cached_obj_store->request_get() && !client_request->valid()) {
     return TS_ERROR;
+  }
 
-  if (s->cache_info.write_lock_state == HttpTransact::CACHE_WL_READ_RETRY)
+  if (s->cache_info.write_lock_state == HttpTransact::CACHE_WL_READ_RETRY) {
     return TS_ERROR;
+  }
 
   s->api_update_cached_object = HttpTransact::UPDATE_CACHED_OBJECT_PREPARE;
   return TS_SUCCESS;
@@ -5260,12 +5394,14 @@ TSHttpSsnClientAddrGet(TSHttpSsn ssnp)
 {
   ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
 
-  if (cs == NULL)
+  if (cs == NULL) {
     return 0;
+  }
 
   NetVConnection *vc = cs->get_netvc();
-  if (vc == NULL)
+  if (vc == NULL) {
     return 0;
+  }
 
   return vc->get_remote_addr();
 }
@@ -5283,12 +5419,14 @@ TSHttpSsnIncomingAddrGet(TSHttpSsn ssnp)
 {
   ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
 
-  if (cs == NULL)
+  if (cs == NULL) {
     return 0;
+  }
 
   NetVConnection *vc = cs->get_netvc();
-  if (vc == NULL)
+  if (vc == NULL) {
     return 0;
+  }
 
   return vc->get_local_addr();
 }
@@ -5376,8 +5514,9 @@ TSHttpTxnNextHopAddrGet(TSHttpTxn txnp)
   /**
    * Return zero if the server structure is not yet constructed.
    */
-  if (sm->t_state.current.server == NULL)
+  if (sm->t_state.current.server == NULL) {
     return NULL;
+  }
 
   return &sm->t_state.current.server->dst_addr.sa;
 }
@@ -5385,8 +5524,9 @@ TSHttpTxnNextHopAddrGet(TSHttpTxn txnp)
 TSReturnCode
 TSHttpTxnOutgoingTransparencySet(TSHttpTxn txnp, int flag)
 {
-  if (TS_SUCCESS != sdk_sanity_check_txn(txnp))
+  if (TS_SUCCESS != sdk_sanity_check_txn(txnp)) {
     return TS_ERROR;
+  }
 
   HttpSM *sm = reinterpret_cast<HttpSM *>(txnp);
   if (NULL == sm || NULL == sm->ua_session) {
@@ -5669,9 +5809,10 @@ TSHttpArgIndexReserve(const char *name, const char *description, int *arg_idx)
   if (ix < HTTP_SSN_TXN_MAX_USER_ARG) {
     state_arg_table[ix].name     = ats_strdup(name);
     state_arg_table[ix].name_len = strlen(state_arg_table[ix].name);
-    if (description)
+    if (description) {
       state_arg_table[ix].description = ats_strdup(description);
-    *arg_idx                          = ix;
+    }
+    *arg_idx = ix;
 
     return TS_SUCCESS;
   }
@@ -5684,8 +5825,9 @@ TSHttpArgIndexLookup(int arg_idx, const char **name, const char **description)
   if (sdk_sanity_check_null_ptr(name) == TS_SUCCESS) {
     if (state_arg_table[arg_idx].name) {
       *name = state_arg_table[arg_idx].name;
-      if (description)
+      if (description) {
         *description = state_arg_table[arg_idx].description;
+      }
       return TS_SUCCESS;
     }
   }
@@ -5702,9 +5844,10 @@ TSHttpArgIndexNameLookup(const char *name, int *arg_idx, const char **descriptio
 
   for (int ix = 0; ix < next_argv_index; ++ix) {
     if ((len == state_arg_table[ix].name_len) && (0 == strcmp(name, state_arg_table[ix].name))) {
-      if (description)
+      if (description) {
         *description = state_arg_table[ix].description;
-      *arg_idx       = ix;
+      }
+      *arg_idx = ix;
       return TS_SUCCESS;
     }
   }
@@ -5771,8 +5914,9 @@ TSHttpTxnCntl(TSHttpTxn txnp, TSHttpCntlType cntl, void *data)
 
   switch (cntl) {
   case TS_HTTP_CNTL_GET_LOGGING_MODE: {
-    if (data == NULL)
+    if (data == NULL) {
       return TS_ERROR;
+    }
 
     intptr_t *rptr = (intptr_t *)data;
 
@@ -5795,8 +5939,9 @@ TSHttpTxnCntl(TSHttpTxn txnp, TSHttpCntlType cntl, void *data)
     break;
 
   case TS_HTTP_CNTL_GET_INTERCEPT_RETRY_MODE: {
-    if (data == NULL)
+    if (data == NULL) {
       return TS_ERROR;
+    }
 
     intptr_t *rptr = (intptr_t *)data;
 
@@ -5981,8 +6126,9 @@ TSHttpTxnCachedRespTimeGet(TSHttpTxn txnp, time_t *resp_time)
   HttpSM *sm           = (HttpSM *)txnp;
   HTTPInfo *cached_obj = sm->t_state.cache_info.object_read;
 
-  if (cached_obj == NULL || !cached_obj->valid())
+  if (cached_obj == NULL || !cached_obj->valid()) {
     return TS_ERROR;
+  }
 
   *resp_time = cached_obj->response_received_time_get();
   return TS_SUCCESS;
@@ -6026,8 +6172,9 @@ TSHttpCurrentIdleClientConnectionsGet(void)
   HTTP_READ_DYN_SUM(http_current_client_connections_stat, total);
   HTTP_READ_DYN_SUM(http_current_active_client_connections_stat, active);
 
-  if (total >= active)
+  if (total >= active) {
     return (int)(total - active);
+  }
 
   return 0;
 }
@@ -6207,8 +6354,9 @@ TSActionDone(TSAction actionp)
 TSVConn
 TSVConnCreate(TSEventFunc event_funcp, TSMutex mutexp)
 {
-  if (mutexp == NULL)
+  if (mutexp == NULL) {
     mutexp = (TSMutex)new_ProxyMutex();
+  }
 
   // TODO: probably don't need this if memory allocations fails properly
   sdk_assert(sdk_sanity_check_mutex(mutexp) == TS_SUCCESS);
@@ -6386,8 +6534,9 @@ TSVConnCacheHttpInfoSet(TSVConn connp, TSCacheHttpInfo infop)
   sdk_assert(sdk_sanity_check_iocore_structure(connp) == TS_SUCCESS);
 
   CacheVC *vc = (CacheVC *)connp;
-  if (vc->base_stat == cache_scan_active_stat)
+  if (vc->base_stat == cache_scan_active_stat) {
     vc->set_http_info((CacheHTTPInfo *)infop);
+  }
 }
 
 /* Transformations */
@@ -6728,8 +6877,9 @@ TSStatCreate(const char *the_name, TSRecordDataType the_type, TSStatPersistence 
   // interfaces only supports integers. Going forward, we could extend either the "Raw"
   // stats APIs, or make non-int use the direct (synchronous) stats APIs (slower).
   if ((sdk_sanity_check_null_ptr((void *)the_name) != TS_SUCCESS) || (sdk_sanity_check_null_ptr((void *)api_rsb) != TS_SUCCESS) ||
-      (id >= api_rsb->max_stats))
+      (id >= api_rsb->max_stats)) {
     return TS_ERROR;
+  }
 
   switch (sync) {
   case TS_STAT_SYNC_SUM:
@@ -6792,8 +6942,9 @@ TSStatFindName(const char *name, int *idp)
 {
   sdk_assert(sdk_sanity_check_null_ptr((void *)name) == TS_SUCCESS);
 
-  if (RecGetRecordOrderAndId(name, NULL, idp) == REC_ERR_OKAY)
+  if (RecGetRecordOrderAndId(name, NULL, idp) == REC_ERR_OKAY) {
     return TS_SUCCESS;
+  }
 
   return TS_ERROR;
 }
@@ -6805,8 +6956,9 @@ TSStatFindName(const char *name, int *idp)
 inline TSReturnCode
 ink_sanity_check_stat_structure(void *obj)
 {
-  if (obj == NULL)
+  if (obj == NULL) {
     return TS_ERROR;
+  }
 
   return TS_SUCCESS;
 }
@@ -6921,8 +7073,9 @@ TSTextLogObjectDestroy(TSTextLogObject the_object)
 {
   sdk_assert(sdk_sanity_check_iocore_structure(the_object) == TS_SUCCESS);
 
-  if (Log::config->log_object_manager.unmanage_api_object((TextLogObject *)the_object))
+  if (Log::config->log_object_manager.unmanage_api_object((TextLogObject *)the_object)) {
     return TS_SUCCESS;
+  }
 
   return TS_ERROR;
 }
@@ -6980,12 +7133,14 @@ TSHttpSsnClientFdGet(TSHttpSsn ssnp, int *fdp)
   VConnection *basecs    = reinterpret_cast<VConnection *>(ssnp);
   ProxyClientSession *cs = dynamic_cast<ProxyClientSession *>(basecs);
 
-  if (cs == NULL)
+  if (cs == NULL) {
     return TS_ERROR;
+  }
 
   NetVConnection *vc = cs->get_netvc();
-  if (vc == NULL)
+  if (vc == NULL) {
     return TS_ERROR;
+  }
 
   *fdp = vc->get_socket();
   return TS_SUCCESS;
@@ -7094,8 +7249,9 @@ TSMgmtConfigIntSet(const char *var_name, TSMgmtInt value)
   char *buffer;
 
   // is this a valid integer?
-  if (TSMgmtIntGet(var_name, &result) != TS_SUCCESS)
+  if (TSMgmtIntGet(var_name, &result) != TS_SUCCESS) {
     return TS_ERROR;
+  }
 
   // construct a buffer
   int buffer_size = strlen(var_name) + 1 + 32 + 1 + 64 + 1;
@@ -7128,13 +7284,14 @@ TSICPCachedReqGet(TSCont contp, TSMBuffer *bufp, TSMLoc *obj)
   HTTPInfo *cached_obj;
 
   cached_obj = sm->_object_read;
-  if (cached_obj == NULL || !cached_obj->valid())
+  if (cached_obj == NULL || !cached_obj->valid()) {
     return TS_ERROR;
+  }
 
   HTTPHdr *cached_hdr = cached_obj->request_get();
-  if (!cached_hdr->valid())
+  if (!cached_hdr->valid()) {
     return TS_ERROR;
-  ;
+  };
 
   // We can't use the HdrHeapSDKHandle structure in the RamCache since multiple
   //  threads can access.  We need to create our own for the transaction and return that.
@@ -7162,12 +7319,14 @@ TSICPCachedRespGet(TSCont contp, TSMBuffer *bufp, TSMLoc *obj)
   HTTPInfo *cached_obj;
 
   cached_obj = sm->_object_read;
-  if (cached_obj == NULL || !cached_obj->valid())
+  if (cached_obj == NULL || !cached_obj->valid()) {
     return TS_ERROR;
+  }
 
   HTTPHdr *cached_hdr = cached_obj->response_get();
-  if (!cached_hdr->valid())
+  if (!cached_hdr->valid()) {
     return TS_ERROR;
+  }
 
   // We can't use the HdrHeapSDKHandle structure in the RamCache since multiple
   //  threads can access.  We need to create our own for the transaction and return that.
@@ -7195,8 +7354,9 @@ TSCacheUrlSet(TSHttpTxn txnp, const char *url, int length)
   if (sm->t_state.cache_info.lookup_url == NULL) {
     Debug("cache_url", "[TSCacheUrlSet] changing the cache url to: %s", url);
 
-    if (length == -1)
+    if (length == -1) {
       length = strlen(url);
+    }
 
     sm->t_state.cache_info.lookup_url_storage.create(NULL);
     sm->t_state.cache_info.lookup_url = &(sm->t_state.cache_info.lookup_url_storage);
@@ -7532,8 +7692,9 @@ TSAIORead(int fd, off_t offset, char *buf, size_t buffSize, TSCont contp)
   Continuation *pCont = (Continuation *)contp;
   AIOCallback *pAIO   = new_AIOCallback();
 
-  if (pAIO == NULL)
+  if (pAIO == NULL) {
     return TS_ERROR;
+  }
 
   pAIO->aiocb.aio_fildes = fd;
   pAIO->aiocb.aio_offset = offset;
@@ -7543,8 +7704,9 @@ TSAIORead(int fd, off_t offset, char *buf, size_t buffSize, TSCont contp)
   pAIO->action        = pCont;
   pAIO->thread        = pCont->mutex->thread_holding;
 
-  if (ink_aio_read(pAIO, 1) == 1)
+  if (ink_aio_read(pAIO, 1) == 1) {
     return TS_SUCCESS;
+  }
 
   return TS_ERROR;
 }
@@ -7581,8 +7743,9 @@ TSAIOWrite(int fd, off_t offset, char *buf, const size_t bufSize, TSCont contp)
   pAIO->action           = pCont;
   pAIO->thread           = pCont->mutex->thread_holding;
 
-  if (ink_aio_write(pAIO, 1) == 1)
+  if (ink_aio_write(pAIO, 1) == 1) {
     return TS_SUCCESS;
+  }
 
   return TS_ERROR;
 }
@@ -7594,8 +7757,9 @@ TSAIOThreadNumSet(int thread_num)
   (void)thread_num;
   return TS_SUCCESS;
 #else
-  if (ink_aio_thread_num_set(thread_num))
+  if (ink_aio_thread_num_set(thread_num)) {
     return TS_SUCCESS;
+  }
 
   return TS_ERROR;
 #endif
@@ -8011,8 +8175,9 @@ TSHttpTxnConfigIntSet(TSHttpTxn txnp, TSOverridableConfigKey conf, TSMgmtInt val
 
   void *dest = _conf_to_memberp(conf, s->t_state.txn_conf, &type);
 
-  if (!dest)
+  if (!dest) {
     return TS_ERROR;
+  }
 
   switch (type) {
   case OVERRIDABLE_TYPE_INT:
@@ -8038,8 +8203,9 @@ TSHttpTxnConfigIntGet(TSHttpTxn txnp, TSOverridableConfigKey conf, TSMgmtInt *va
   OverridableDataType type;
   void *src = _conf_to_memberp(conf, s->t_state.txn_conf, &type);
 
-  if (!src)
+  if (!src) {
     return TS_ERROR;
+  }
 
   switch (type) {
   case OVERRIDABLE_TYPE_INT:
@@ -8067,8 +8233,9 @@ TSHttpTxnConfigFloatSet(TSHttpTxn txnp, TSOverridableConfigKey conf, TSMgmtFloat
 
   TSMgmtFloat *dest = static_cast<TSMgmtFloat *>(_conf_to_memberp(conf, s->t_state.txn_conf, &type));
 
-  if (type != OVERRIDABLE_TYPE_FLOAT)
+  if (type != OVERRIDABLE_TYPE_FLOAT) {
     return TS_ERROR;
+  }
 
   if (dest) {
     *dest = value;
@@ -8087,8 +8254,9 @@ TSHttpTxnConfigFloatGet(TSHttpTxn txnp, TSOverridableConfigKey conf, TSMgmtFloat
   OverridableDataType type;
   TSMgmtFloat *dest = static_cast<TSMgmtFloat *>(_conf_to_memberp(conf, ((HttpSM *)txnp)->t_state.txn_conf, &type));
 
-  if (type != OVERRIDABLE_TYPE_FLOAT)
+  if (type != OVERRIDABLE_TYPE_FLOAT) {
     return TS_ERROR;
+  }
 
   if (dest) {
     *value = *dest;
@@ -8103,8 +8271,9 @@ TSHttpTxnConfigStringSet(TSHttpTxn txnp, TSOverridableConfigKey conf, const char
 {
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
 
-  if (length == -1)
+  if (length == -1) {
     length = strlen(value);
+  }
 
   HttpSM *s = (HttpSM *)txnp;
 
@@ -8186,47 +8355,55 @@ TSHttpTxnConfigFind(const char *name, int length, TSOverridableConfigKey *conf, 
   TSOverridableConfigKey cnf = TS_CONFIG_NULL;
   TSRecordDataType typ       = TS_RECORDDATATYPE_INT;
 
-  if (length == -1)
+  if (length == -1) {
     length = strlen(name);
+  }
 
   // Lots of string comparisons here, but we avoid quite a few by checking lengths
   switch (length) {
   case 28:
-    if (!strncmp(name, "proxy.config.http.cache.http", length))
+    if (!strncmp(name, "proxy.config.http.cache.http", length)) {
       cnf = TS_CONFIG_HTTP_CACHE_HTTP;
+    }
     break;
 
   case 29:
-    if (!strncmp(name, "proxy.config.ssl.hsts_max_age", length))
+    if (!strncmp(name, "proxy.config.ssl.hsts_max_age", length)) {
       cnf = TS_CONFIG_SSL_HSTS_MAX_AGE;
+    }
     break;
 
   case 31:
-    if (!strncmp(name, "proxy.config.http.chunking.size", length))
+    if (!strncmp(name, "proxy.config.http.chunking.size", length)) {
       cnf = TS_CONFIG_HTTP_CHUNKING_SIZE;
+    }
     break;
 
   case 33:
-    if (!strncmp(name, "proxy.config.http.cache.fuzz.time", length))
+    if (!strncmp(name, "proxy.config.http.cache.fuzz.time", length)) {
       cnf = TS_CONFIG_HTTP_CACHE_FUZZ_TIME;
+    }
     break;
 
   case 34:
-    if (!strncmp(name, "proxy.config.http.chunking_enabled", length))
+    if (!strncmp(name, "proxy.config.http.chunking_enabled", length)) {
       cnf = TS_CONFIG_HTTP_CHUNKING_ENABLED;
-    else if (!strncmp(name, "proxy.config.http.cache.generation", length))
+    } else if (!strncmp(name, "proxy.config.http.cache.generation", length)) {
       cnf = TS_CONFIG_HTTP_CACHE_GENERATION;
+    }
     break;
 
   case 35:
     switch (name[length - 1]) {
     case 'e':
-      if (!strncmp(name, "proxy.config.http.cache.range.write", length))
+      if (!strncmp(name, "proxy.config.http.cache.range.write", length)) {
         cnf = TS_CONFIG_HTTP_CACHE_RANGE_WRITE;
+      }
       break;
     case 'p':
-      if (!strncmp(name, "proxy.config.http.normalize_ae_gzip", length))
+      if (!strncmp(name, "proxy.config.http.normalize_ae_gzip", length)) {
         cnf = TS_CONFIG_HTTP_NORMALIZE_AE_GZIP;
+      }
       break;
     }
     break;
@@ -8234,16 +8411,19 @@ TSHttpTxnConfigFind(const char *name, int length, TSOverridableConfigKey *conf, 
   case 36:
     switch (name[length - 1]) {
     case 'p':
-      if (!strncmp(name, "proxy.config.http.cache.range.lookup", length))
+      if (!strncmp(name, "proxy.config.http.cache.range.lookup", length)) {
         cnf = TS_CONFIG_HTTP_CACHE_RANGE_LOOKUP;
+      }
       break;
     case 't':
-      if (!strncmp(name, "proxy.config.net.sock_packet_tos_out", length))
+      if (!strncmp(name, "proxy.config.net.sock_packet_tos_out", length)) {
         cnf = TS_CONFIG_NET_SOCK_PACKET_TOS_OUT;
+      }
       break;
     case 'd':
-      if (!strncmp(name, "proxy.config.http.slow.log.threshold", length))
+      if (!strncmp(name, "proxy.config.http.slow.log.threshold", length)) {
         cnf = TS_CONFIG_HTTP_SLOW_LOG_THRESHOLD;
+      }
       break;
     }
     break;
@@ -8256,12 +8436,13 @@ TSHttpTxnConfigFind(const char *name, int length, TSOverridableConfigKey *conf, 
       }
       break;
     case 'e':
-      if (!strncmp(name, "proxy.config.http.cache.max_stale_age", length))
+      if (!strncmp(name, "proxy.config.http.cache.max_stale_age", length)) {
         cnf = TS_CONFIG_HTTP_CACHE_MAX_STALE_AGE;
-      else if (!strncmp(name, "proxy.config.http.cache.fuzz.min_time", length))
+      } else if (!strncmp(name, "proxy.config.http.cache.fuzz.min_time", length)) {
         cnf = TS_CONFIG_HTTP_CACHE_FUZZ_MIN_TIME;
-      else if (!strncmp(name, "proxy.config.http.default_buffer_size", length))
+      } else if (!strncmp(name, "proxy.config.http.default_buffer_size", length)) {
         cnf = TS_CONFIG_HTTP_DEFAULT_BUFFER_SIZE;
+      }
       break;
     case 'r':
       if (!strncmp(name, "proxy.config.http.response_server_str", length)) {
@@ -8270,14 +8451,15 @@ TSHttpTxnConfigFind(const char *name, int length, TSOverridableConfigKey *conf, 
       }
       break;
     case 't':
-      if (!strncmp(name, "proxy.config.http.keep_alive_post_out", length))
+      if (!strncmp(name, "proxy.config.http.keep_alive_post_out", length)) {
         cnf = TS_CONFIG_HTTP_KEEP_ALIVE_POST_OUT;
-      else if (!strncmp(name, "proxy.config.net.sock_option_flag_out", length))
+      } else if (!strncmp(name, "proxy.config.net.sock_option_flag_out", length)) {
         cnf = TS_CONFIG_NET_SOCK_OPTION_FLAG_OUT;
-      else if (!strncmp(name, "proxy.config.net.sock_packet_mark_out", length))
+      } else if (!strncmp(name, "proxy.config.net.sock_packet_mark_out", length)) {
         cnf = TS_CONFIG_NET_SOCK_PACKET_MARK_OUT;
-      else if (!strncmp(name, "proxy.config.websocket.active_timeout", length))
+      } else if (!strncmp(name, "proxy.config.websocket.active_timeout", length)) {
         cnf = TS_CONFIG_WEBSOCKET_ACTIVE_TIMEOUT;
+      }
       break;
     }
     break;
@@ -8285,15 +8467,17 @@ TSHttpTxnConfigFind(const char *name, int length, TSOverridableConfigKey *conf, 
   case 38:
     switch (name[length - 1]) {
     case 'd':
-      if (!strncmp(name, "proxy.config.http.server_tcp_init_cwnd", length))
+      if (!strncmp(name, "proxy.config.http.server_tcp_init_cwnd", length)) {
         cnf = TS_CONFIG_HTTP_SERVER_TCP_INIT_CWND;
-      else if (!strncmp(name, "proxy.config.http.flow_control.enabled", length))
+      } else if (!strncmp(name, "proxy.config.http.flow_control.enabled", length)) {
         cnf = TS_CONFIG_HTTP_FLOW_CONTROL_ENABLED;
+      }
       break;
       break;
     case 's':
-      if (!strncmp(name, "proxy.config.http.send_http11_requests", length))
+      if (!strncmp(name, "proxy.config.http.send_http11_requests", length)) {
         cnf = TS_CONFIG_HTTP_SEND_HTTP11_REQUESTS;
+      }
       break;
     }
     break;
@@ -8307,16 +8491,19 @@ TSHttpTxnConfigFind(const char *name, int length, TSOverridableConfigKey *conf, 
       }
       break;
     case 'm':
-      if (!strncmp(name, "proxy.config.http.anonymize_remove_from", length))
+      if (!strncmp(name, "proxy.config.http.anonymize_remove_from", length)) {
         cnf = TS_CONFIG_HTTP_ANONYMIZE_REMOVE_FROM;
+      }
       break;
     case 'n':
-      if (!strncmp(name, "proxy.config.http.keep_alive_enabled_in", length))
+      if (!strncmp(name, "proxy.config.http.keep_alive_enabled_in", length)) {
         cnf = TS_CONFIG_HTTP_KEEP_ALIVE_ENABLED_IN;
+      }
       break;
     case 's':
-      if (!strncmp(name, "proxy.config.http.doc_in_cache_skip_dns", length))
+      if (!strncmp(name, "proxy.config.http.doc_in_cache_skip_dns", length)) {
         cnf = TS_CONFIG_HTTP_DOC_IN_CACHE_SKIP_DNS;
+      }
       break;
     }
     break;
@@ -8324,32 +8511,36 @@ TSHttpTxnConfigFind(const char *name, int length, TSOverridableConfigKey *conf, 
   case 40:
     switch (name[length - 1]) {
     case 'e':
-      if (!strncmp(name, "proxy.config.http.down_server.cache_time", length))
+      if (!strncmp(name, "proxy.config.http.down_server.cache_time", length)) {
         cnf = TS_CONFIG_HTTP_DOWN_SERVER_CACHE_TIME;
-      else if (!strncmp(name, "proxy.config.http.insert_age_in_response", length))
+      } else if (!strncmp(name, "proxy.config.http.insert_age_in_response", length)) {
         cnf = TS_CONFIG_HTTP_INSERT_AGE_IN_RESPONSE;
+      }
       break;
     case 'r':
-      if (!strncmp(name, "proxy.config.url_remap.pristine_host_hdr", length))
+      if (!strncmp(name, "proxy.config.url_remap.pristine_host_hdr", length)) {
         cnf = TS_CONFIG_URL_REMAP_PRISTINE_HOST_HDR;
-      else if (!strncmp(name, "proxy.config.http.insert_request_via_str", length))
+      } else if (!strncmp(name, "proxy.config.http.insert_request_via_str", length)) {
         cnf = TS_CONFIG_HTTP_INSERT_REQUEST_VIA_STR;
-      else if (!strncmp(name, "proxy.config.http.flow_control.low_water", length))
+      } else if (!strncmp(name, "proxy.config.http.flow_control.low_water", length)) {
         cnf = TS_CONFIG_HTTP_FLOW_CONTROL_LOW_WATER_MARK;
+      }
       break;
     case 's':
-      if (!strncmp(name, "proxy.config.http.origin_max_connections", length))
+      if (!strncmp(name, "proxy.config.http.origin_max_connections", length)) {
         cnf = TS_CONFIG_HTTP_ORIGIN_MAX_CONNECTIONS;
-      else if (!strncmp(name, "proxy.config.http.cache.required_headers", length))
+      } else if (!strncmp(name, "proxy.config.http.cache.required_headers", length)) {
         cnf = TS_CONFIG_HTTP_CACHE_REQUIRED_HEADERS;
-      else if (!strncmp(name, "proxy.config.ssl.hsts_include_subdomains", length))
+      } else if (!strncmp(name, "proxy.config.ssl.hsts_include_subdomains", length)) {
         cnf = TS_CONFIG_SSL_HSTS_INCLUDE_SUBDOMAINS;
-      else if (!strncmp(name, "proxy.config.http.number_of_redirections", length))
+      } else if (!strncmp(name, "proxy.config.http.number_of_redirections", length)) {
         cnf = TS_CONFIG_HTTP_NUMBER_OF_REDIRECTIONS;
+      }
       break;
     case 't':
-      if (!strncmp(name, "proxy.config.http.keep_alive_enabled_out", length))
+      if (!strncmp(name, "proxy.config.http.keep_alive_enabled_out", length)) {
         cnf = TS_CONFIG_HTTP_KEEP_ALIVE_ENABLED_OUT;
+      }
       break;
     case 'y':
       if (!strncmp(name, "proxy.config.http.cache.fuzz.probability", length)) {
@@ -8363,20 +8554,23 @@ TSHttpTxnConfigFind(const char *name, int length, TSOverridableConfigKey *conf, 
   case 41:
     switch (name[length - 1]) {
     case 'd':
-      if (!strncmp(name, "proxy.config.http.response_server_enabled", length))
+      if (!strncmp(name, "proxy.config.http.response_server_enabled", length)) {
         cnf = TS_CONFIG_HTTP_RESPONSE_SERVER_ENABLED;
+      }
       break;
     case 'e':
-      if (!strncmp(name, "proxy.config.http.anonymize_remove_cookie", length))
+      if (!strncmp(name, "proxy.config.http.anonymize_remove_cookie", length)) {
         cnf = TS_CONFIG_HTTP_ANONYMIZE_REMOVE_COOKIE;
-      else if (!strncmp(name, "proxy.config.http.request_header_max_size", length))
+      } else if (!strncmp(name, "proxy.config.http.request_header_max_size", length)) {
         cnf = TS_CONFIG_HTTP_REQUEST_HEADER_MAX_SIZE;
+      }
       break;
     case 'r':
-      if (!strncmp(name, "proxy.config.http.insert_response_via_str", length))
+      if (!strncmp(name, "proxy.config.http.insert_response_via_str", length)) {
         cnf = TS_CONFIG_HTTP_INSERT_RESPONSE_VIA_STR;
-      else if (!strncmp(name, "proxy.config.http.flow_control.high_water", length))
+      } else if (!strncmp(name, "proxy.config.http.flow_control.high_water", length)) {
         cnf = TS_CONFIG_HTTP_FLOW_CONTROL_HIGH_WATER_MARK;
+      }
       break;
     }
     break;
@@ -8384,32 +8578,35 @@ TSHttpTxnConfigFind(const char *name, int length, TSOverridableConfigKey *conf, 
   case 42:
     switch (name[length - 1]) {
     case 'd':
-      if (!strncmp(name, "proxy.config.http.negative_caching_enabled", length))
+      if (!strncmp(name, "proxy.config.http.negative_caching_enabled", length)) {
         cnf = TS_CONFIG_HTTP_NEGATIVE_CACHING_ENABLED;
+      }
       break;
     case 'e':
-      if (!strncmp(name, "proxy.config.http.cache.when_to_revalidate", length))
+      if (!strncmp(name, "proxy.config.http.cache.when_to_revalidate", length)) {
         cnf = TS_CONFIG_HTTP_CACHE_WHEN_TO_REVALIDATE;
-      else if (!strncmp(name, "proxy.config.http.response_header_max_size", length))
+      } else if (!strncmp(name, "proxy.config.http.response_header_max_size", length)) {
         cnf = TS_CONFIG_HTTP_RESPONSE_HEADER_MAX_SIZE;
+      }
       break;
     case 'r':
-      if (!strncmp(name, "proxy.config.http.anonymize_remove_referer", length))
+      if (!strncmp(name, "proxy.config.http.anonymize_remove_referer", length)) {
         cnf = TS_CONFIG_HTTP_ANONYMIZE_REMOVE_REFERER;
-      else if (!strncmp(name, "proxy.config.http.global_user_agent_header", length)) {
+      } else if (!strncmp(name, "proxy.config.http.global_user_agent_header", length)) {
         cnf = TS_CONFIG_HTTP_GLOBAL_USER_AGENT_HEADER;
         typ = TS_RECORDDATATYPE_STRING;
       }
       break;
     case 't':
-      if (!strncmp(name, "proxy.config.net.sock_recv_buffer_size_out", length))
+      if (!strncmp(name, "proxy.config.net.sock_recv_buffer_size_out", length)) {
         cnf = TS_CONFIG_NET_SOCK_RECV_BUFFER_SIZE_OUT;
-      else if (!strncmp(name, "proxy.config.net.sock_send_buffer_size_out", length))
+      } else if (!strncmp(name, "proxy.config.net.sock_send_buffer_size_out", length)) {
         cnf = TS_CONFIG_NET_SOCK_SEND_BUFFER_SIZE_OUT;
-      else if (!strncmp(name, "proxy.config.http.connect_attempts_timeout", length))
+      } else if (!strncmp(name, "proxy.config.http.connect_attempts_timeout", length)) {
         cnf = TS_CONFIG_HTTP_CONNECT_ATTEMPTS_TIMEOUT;
-      else if (!strncmp(name, "proxy.config.websocket.no_activity_timeout", length))
+      } else if (!strncmp(name, "proxy.config.websocket.no_activity_timeout", length)) {
         cnf = TS_CONFIG_WEBSOCKET_NO_ACTIVITY_TIMEOUT;
+      }
       break;
     }
     break;
@@ -8417,16 +8614,19 @@ TSHttpTxnConfigFind(const char *name, int length, TSOverridableConfigKey *conf, 
   case 43:
     switch (name[length - 1]) {
     case 'e':
-      if (!strncmp(name, "proxy.config.http.negative_caching_lifetime", length))
+      if (!strncmp(name, "proxy.config.http.negative_caching_lifetime", length)) {
         cnf = TS_CONFIG_HTTP_NEGATIVE_CACHING_LIFETIME;
+      }
       break;
     case 'k':
-      if (!strncmp(name, "proxy.config.http.default_buffer_water_mark", length))
+      if (!strncmp(name, "proxy.config.http.default_buffer_water_mark", length)) {
         cnf = TS_CONFIG_HTTP_DEFAULT_BUFFER_WATER_MARK;
+      }
       break;
     case 'l':
-      if (!strncmp(name, "proxy.config.http.cache.cluster_cache_local", length))
+      if (!strncmp(name, "proxy.config.http.cache.cluster_cache_local", length)) {
         cnf = TS_CONFIG_HTTP_CACHE_CLUSTER_CACHE_LOCAL;
+      }
       break;
     case 'r':
       if (!strncmp(name, "proxy.config.http.cache.heuristic_lm_factor", length)) {
@@ -8440,14 +8640,16 @@ TSHttpTxnConfigFind(const char *name, int length, TSOverridableConfigKey *conf, 
   case 44:
     switch (name[length - 1]) {
     case 'p':
-      if (!strncmp(name, "proxy.config.http.anonymize_remove_client_ip", length))
+      if (!strncmp(name, "proxy.config.http.anonymize_remove_client_ip", length)) {
         cnf = TS_CONFIG_HTTP_ANONYMIZE_REMOVE_CLIENT_IP;
-      else if (!strncmp(name, "proxy.config.http.anonymize_insert_client_ip", length))
+      } else if (!strncmp(name, "proxy.config.http.anonymize_insert_client_ip", length)) {
         cnf = TS_CONFIG_HTTP_ANONYMIZE_INSERT_CLIENT_IP;
+      }
       break;
     case 'e':
-      if (!strncmp(name, "proxy.config.http.cache.open_read_retry_time", length))
+      if (!strncmp(name, "proxy.config.http.cache.open_read_retry_time", length)) {
         cnf = TS_CONFIG_HTTP_CACHE_OPEN_READ_RETRY_TIME;
+      }
       break;
     }
     break;
@@ -8455,30 +8657,36 @@ TSHttpTxnConfigFind(const char *name, int length, TSOverridableConfigKey *conf, 
   case 45:
     switch (name[length - 1]) {
     case 'd':
-      if (!strncmp(name, "proxy.config.http.down_server.abort_threshold", length))
+      if (!strncmp(name, "proxy.config.http.down_server.abort_threshold", length)) {
         cnf = TS_CONFIG_HTTP_DOWN_SERVER_ABORT_THRESHOLD;
+      }
       break;
     case 'n':
-      if (!strncmp(name, "proxy.config.http.cache.ignore_authentication", length))
+      if (!strncmp(name, "proxy.config.http.cache.ignore_authentication", length)) {
         cnf = TS_CONFIG_HTTP_CACHE_IGNORE_AUTHENTICATION;
+      }
       break;
     case 't':
-      if (!strncmp(name, "proxy.config.http.anonymize_remove_user_agent", length))
+      if (!strncmp(name, "proxy.config.http.anonymize_remove_user_agent", length)) {
         cnf = TS_CONFIG_HTTP_ANONYMIZE_REMOVE_USER_AGENT;
+      }
       break;
     case 's':
-      if (!strncmp(name, "proxy.config.http.connect_attempts_rr_retries", length))
+      if (!strncmp(name, "proxy.config.http.connect_attempts_rr_retries", length)) {
         cnf = TS_CONFIG_HTTP_CONNECT_ATTEMPTS_RR_RETRIES;
-      else if (!strncmp(name, "proxy.config.http.cache.max_open_read_retries", length))
+      } else if (!strncmp(name, "proxy.config.http.cache.max_open_read_retries", length)) {
         cnf = TS_CONFIG_HTTP_CACHE_MAX_OPEN_READ_RETRIES;
+      }
       break;
     case 'e':
-      if (0 == strncmp(name, "proxy.config.http.auth_server_session_private", length))
+      if (0 == strncmp(name, "proxy.config.http.auth_server_session_private", length)) {
         cnf = TS_CONFIG_HTTP_AUTH_SERVER_SESSION_PRIVATE;
+      }
       break;
     case 'y':
-      if (!strncmp(name, "proxy.config.http.redirect_use_orig_cache_key", length))
+      if (!strncmp(name, "proxy.config.http.redirect_use_orig_cache_key", length)) {
         cnf = TS_CONFIG_HTTP_REDIRECT_USE_ORIG_CACHE_KEY;
+      }
       break;
     }
     break;
@@ -8486,40 +8694,46 @@ TSHttpTxnConfigFind(const char *name, int length, TSOverridableConfigKey *conf, 
   case 46:
     switch (name[length - 1]) {
     case 'e':
-      if (!strncmp(name, "proxy.config.http.cache.ignore_client_no_cache", length))
+      if (!strncmp(name, "proxy.config.http.cache.ignore_client_no_cache", length)) {
         cnf = TS_CONFIG_HTTP_CACHE_IGNORE_CLIENT_NO_CACHE;
-      else if (!strncmp(name, "proxy.config.http.cache.ims_on_client_no_cache", length))
+      } else if (!strncmp(name, "proxy.config.http.cache.ims_on_client_no_cache", length)) {
         cnf = TS_CONFIG_HTTP_CACHE_IMS_ON_CLIENT_NO_CACHE;
-      else if (!strncmp(name, "proxy.config.http.cache.ignore_server_no_cache", length))
+      } else if (!strncmp(name, "proxy.config.http.cache.ignore_server_no_cache", length)) {
         cnf = TS_CONFIG_HTTP_CACHE_IGNORE_SERVER_NO_CACHE;
-      else if (!strncmp(name, "proxy.config.http.cache.heuristic_min_lifetime", length))
+      } else if (!strncmp(name, "proxy.config.http.cache.heuristic_min_lifetime", length)) {
         cnf = TS_CONFIG_HTTP_CACHE_HEURISTIC_MIN_LIFETIME;
-      else if (!strncmp(name, "proxy.config.http.cache.heuristic_max_lifetime", length))
+      } else if (!strncmp(name, "proxy.config.http.cache.heuristic_max_lifetime", length)) {
         cnf = TS_CONFIG_HTTP_CACHE_HEURISTIC_MAX_LIFETIME;
-      else if (!strncmp(name, "proxy.config.http.origin_max_connections_queue", length))
+      } else if (!strncmp(name, "proxy.config.http.origin_max_connections_queue", length)) {
         cnf = TS_CONFIG_HTTP_ORIGIN_MAX_CONNECTIONS_QUEUE;
+      }
       break;
     case 'r':
-      if (!strncmp(name, "proxy.config.http.insert_squid_x_forwarded_for", length))
+      if (!strncmp(name, "proxy.config.http.insert_squid_x_forwarded_for", length)) {
         cnf = TS_CONFIG_HTTP_INSERT_SQUID_X_FORWARDED_FOR;
+      }
       break;
     case 's':
-      if (!strncmp(name, "proxy.config.http.connect_attempts_max_retries", length))
+      if (!strncmp(name, "proxy.config.http.connect_attempts_max_retries", length)) {
         cnf = TS_CONFIG_HTTP_CONNECT_ATTEMPTS_MAX_RETRIES;
-      else if (!strncmp(name, "proxy.config.http.cache.max_open_write_retries", length))
+      } else if (!strncmp(name, "proxy.config.http.cache.max_open_write_retries", length)) {
         cnf = TS_CONFIG_HTTP_CACHE_MAX_OPEN_WRITE_RETRIES;
+      }
       break;
     case 't':
-      if (!strncmp(name, "proxy.config.http.forward.proxy_auth_to_parent", length))
+      if (!strncmp(name, "proxy.config.http.forward.proxy_auth_to_parent", length)) {
         cnf = TS_CONFIG_HTTP_FORWARD_PROXY_AUTH_TO_PARENT;
+      }
       break;
     case 'h':
-      if (0 == strncmp(name, "proxy.config.http.server_session_sharing.match", length))
+      if (0 == strncmp(name, "proxy.config.http.server_session_sharing.match", length)) {
         cnf = TS_CONFIG_HTTP_SERVER_SESSION_SHARING_MATCH;
+      }
       break;
     case 'n':
-      if (!strncmp(name, "proxy.config.http.cache.open_write_fail_action", length))
+      if (!strncmp(name, "proxy.config.http.cache.open_write_fail_action", length)) {
         cnf = TS_CONFIG_HTTP_CACHE_OPEN_WRITE_FAIL_ACTION;
+      }
       break;
     }
     break;
@@ -8527,22 +8741,26 @@ TSHttpTxnConfigFind(const char *name, int length, TSOverridableConfigKey *conf, 
   case 47:
     switch (name[length - 1]) {
     case 'd':
-      if (!strncmp(name, "proxy.config.http.negative_revalidating_enabled", length))
+      if (!strncmp(name, "proxy.config.http.negative_revalidating_enabled", length)) {
         cnf = TS_CONFIG_HTTP_NEGATIVE_REVALIDATING_ENABLED;
+      }
       break;
     case 'e':
-      if (!strncmp(name, "proxy.config.http.cache.guaranteed_min_lifetime", length))
+      if (!strncmp(name, "proxy.config.http.cache.guaranteed_min_lifetime", length)) {
         cnf = TS_CONFIG_HTTP_CACHE_GUARANTEED_MIN_LIFETIME;
-      else if (!strncmp(name, "proxy.config.http.cache.guaranteed_max_lifetime", length))
+      } else if (!strncmp(name, "proxy.config.http.cache.guaranteed_max_lifetime", length)) {
         cnf = TS_CONFIG_HTTP_CACHE_GUARANTEED_MAX_LIFETIME;
+      }
       break;
     case 'n':
-      if (!strncmp(name, "proxy.config.http.transaction_active_timeout_in", length))
+      if (!strncmp(name, "proxy.config.http.transaction_active_timeout_in", length)) {
         cnf = TS_CONFIG_HTTP_TRANSACTION_ACTIVE_TIMEOUT_IN;
+      }
       break;
     case 't':
-      if (!strncmp(name, "proxy.config.http.post_connect_attempts_timeout", length))
+      if (!strncmp(name, "proxy.config.http.post_connect_attempts_timeout", length)) {
         cnf = TS_CONFIG_HTTP_POST_CONNECT_ATTEMPTS_TIMEOUT;
+      }
       break;
     }
     break;
@@ -8550,20 +8768,23 @@ TSHttpTxnConfigFind(const char *name, int length, TSOverridableConfigKey *conf, 
   case 48:
     switch (name[length - 1]) {
     case 'd':
-      if (!strncmp(name, "proxy.config.http.accept_encoding_filter_enabled", length))
+      if (!strncmp(name, "proxy.config.http.accept_encoding_filter_enabled", length)) {
         cnf = TS_CONFIG_HTTP_ACCEPT_ENCODING_FILTER_ENABLED;
+      }
       break;
     case 'e':
-      if (!strncmp(name, "proxy.config.http.cache.ignore_client_cc_max_age", length))
+      if (!strncmp(name, "proxy.config.http.cache.ignore_client_cc_max_age", length)) {
         cnf = TS_CONFIG_HTTP_CACHE_IGNORE_CLIENT_CC_MAX_AGE;
-      else if (!strncmp(name, "proxy.config.http.negative_revalidating_lifetime", length))
+      } else if (!strncmp(name, "proxy.config.http.negative_revalidating_lifetime", length)) {
         cnf = TS_CONFIG_HTTP_NEGATIVE_REVALIDATING_LIFETIME;
+      }
       break;
     case 't':
       switch (name[length - 4]) {
       case '_':
-        if (!strncmp(name, "proxy.config.http.transaction_active_timeout_out", length))
+        if (!strncmp(name, "proxy.config.http.transaction_active_timeout_out", length)) {
           cnf = TS_CONFIG_HTTP_TRANSACTION_ACTIVE_TIMEOUT_OUT;
+        }
         break;
       case 'e':
         if (!strncmp(name, "proxy.config.http.background_fill_active_timeout", length)) {
@@ -8576,24 +8797,28 @@ TSHttpTxnConfigFind(const char *name, int length, TSOverridableConfigKey *conf, 
     break;
 
   case 49:
-    if (!strncmp(name, "proxy.config.http.attach_server_session_to_client", length))
+    if (!strncmp(name, "proxy.config.http.attach_server_session_to_client", length)) {
       cnf = TS_CONFIG_HTTP_ATTACH_SERVER_SESSION_TO_CLIENT;
+    }
     break;
 
   case 50:
-    if (!strncmp(name, "proxy.config.http.cache.cache_responses_to_cookies", length))
+    if (!strncmp(name, "proxy.config.http.cache.cache_responses_to_cookies", length)) {
       cnf = TS_CONFIG_HTTP_CACHE_CACHE_RESPONSES_TO_COOKIES;
+    }
     break;
 
   case 51:
     switch (name[length - 1]) {
     case 'n':
-      if (!strncmp(name, "proxy.config.http.keep_alive_no_activity_timeout_in", length))
+      if (!strncmp(name, "proxy.config.http.keep_alive_no_activity_timeout_in", length)) {
         cnf = TS_CONFIG_HTTP_KEEP_ALIVE_NO_ACTIVITY_TIMEOUT_IN;
+      }
       break;
     case 'd':
-      if (!strncmp(name, "proxy.config.http.post.check.content_length.enabled", length))
+      if (!strncmp(name, "proxy.config.http.post.check.content_length.enabled", length)) {
         cnf = TS_CONFIG_HTTP_POST_CHECK_CONTENT_LENGTH_ENABLED;
+      }
       break;
     }
     break;
@@ -8601,18 +8826,21 @@ TSHttpTxnConfigFind(const char *name, int length, TSOverridableConfigKey *conf, 
   case 52:
     switch (name[length - 1]) {
     case 'c':
-      if (!strncmp(name, "proxy.config.http.cache.cache_urls_that_look_dynamic", length))
+      if (!strncmp(name, "proxy.config.http.cache.cache_urls_that_look_dynamic", length)) {
         cnf = TS_CONFIG_HTTP_CACHE_CACHE_URLS_THAT_LOOK_DYNAMIC;
+      }
       break;
     case 'n':
-      if (!strncmp(name, "proxy.config.http.transaction_no_activity_timeout_in", length))
+      if (!strncmp(name, "proxy.config.http.transaction_no_activity_timeout_in", length)) {
         cnf = TS_CONFIG_HTTP_TRANSACTION_NO_ACTIVITY_TIMEOUT_IN;
+      }
       break;
     case 't':
-      if (!strncmp(name, "proxy.config.http.keep_alive_no_activity_timeout_out", length))
+      if (!strncmp(name, "proxy.config.http.keep_alive_no_activity_timeout_out", length)) {
         cnf = TS_CONFIG_HTTP_KEEP_ALIVE_NO_ACTIVITY_TIMEOUT_OUT;
-      else if (!strncmp(name, "proxy.config.http.uncacheable_requests_bypass_parent", length))
+      } else if (!strncmp(name, "proxy.config.http.uncacheable_requests_bypass_parent", length)) {
         cnf = TS_CONFIG_HTTP_UNCACHEABLE_REQUESTS_BYPASS_PARENT;
+      }
       break;
     }
     break;
@@ -8620,8 +8848,9 @@ TSHttpTxnConfigFind(const char *name, int length, TSOverridableConfigKey *conf, 
   case 53:
     switch (name[length - 1]) {
     case 't':
-      if (!strncmp(name, "proxy.config.http.transaction_no_activity_timeout_out", length))
+      if (!strncmp(name, "proxy.config.http.transaction_no_activity_timeout_out", length)) {
         cnf = TS_CONFIG_HTTP_TRANSACTION_NO_ACTIVITY_TIMEOUT_OUT;
+      }
       break;
     case 'd':
       if (!strncmp(name, "proxy.config.http.background_fill_completed_threshold", length)) {
@@ -8638,14 +8867,16 @@ TSHttpTxnConfigFind(const char *name, int length, TSOverridableConfigKey *conf, 
     break;
 
   case 58:
-    if (!strncmp(name, "proxy.config.http.connect_attempts_max_retries_dead_server", length))
+    if (!strncmp(name, "proxy.config.http.connect_attempts_max_retries_dead_server", length)) {
       cnf = TS_CONFIG_HTTP_CONNECT_ATTEMPTS_MAX_RETRIES_DEAD_SERVER;
+    }
     break;
   }
 
   *conf = cnf;
-  if (type)
+  if (type) {
     *type = typ;
+  }
 
   return ((cnf != TS_CONFIG_NULL) ? TS_SUCCESS : TS_ERROR);
 }
@@ -8668,12 +8899,14 @@ TSReturnCode
 TSMgmtStringCreate(TSRecordType rec_type, const char *name, const TSMgmtString data_default, TSRecordUpdateType update_type,
                    TSRecordCheckType check_type, const char *check_regex, TSRecordAccessType access_type)
 {
-  if (check_regex == NULL && check_type != TS_RECORDCHECK_NULL)
+  if (check_regex == NULL && check_type != TS_RECORDCHECK_NULL) {
     return TS_ERROR;
+  }
   if (REC_ERR_OKAY != RecRegisterConfigString((enum RecT)rec_type, name, data_default, (enum RecUpdateT)update_type,
                                               (enum RecCheckT)check_type, check_regex, REC_SOURCE_EXPLICIT,
-                                              (enum RecAccessT)access_type))
+                                              (enum RecAccessT)access_type)) {
     return TS_ERROR;
+  }
 
   return TS_SUCCESS;
 }
@@ -8682,12 +8915,14 @@ TSReturnCode
 TSMgmtIntCreate(TSRecordType rec_type, const char *name, TSMgmtInt data_default, TSRecordUpdateType update_type,
                 TSRecordCheckType check_type, const char *check_regex, TSRecordAccessType access_type)
 {
-  if (check_regex == NULL && check_type != TS_RECORDCHECK_NULL)
+  if (check_regex == NULL && check_type != TS_RECORDCHECK_NULL) {
     return TS_ERROR;
+  }
   if (REC_ERR_OKAY != RecRegisterConfigInt((enum RecT)rec_type, name, (RecInt)data_default, (enum RecUpdateT)update_type,
                                            (enum RecCheckT)check_type, check_regex, REC_SOURCE_EXPLICIT,
-                                           (enum RecAccessT)access_type))
+                                           (enum RecAccessT)access_type)) {
     return TS_ERROR;
+  }
 
   return TS_SUCCESS;
 }
@@ -8702,8 +8937,9 @@ TSHttpTxnCloseAfterResponse(TSHttpTxn txnp, int should_close)
   HttpSM *sm = (HttpSM *)txnp;
   if (should_close) {
     sm->t_state.client_info.keep_alive = HTTP_NO_KEEPALIVE;
-    if (sm->ua_session)
+    if (sm->ua_session) {
       sm->set_ua_half_close_flag();
+    }
   }
   // Don't change if PIPELINE is set...
   else if (sm->t_state.client_info.keep_alive == HTTP_NO_KEEPALIVE) {

--- a/proxy/InkAPITest.cc
+++ b/proxy/InkAPITest.cc
@@ -780,8 +780,9 @@ cache_handler(TSCont contp, TSEvent event, void *data)
         // no need to continue, return
         *SDK_Cache_pstatus = REGRESSION_TEST_FAILED;
         return 1;
-      } else
+      } else {
         SDK_RPRINT(SDK_Cache_test, "TSVIONDoneSet", "TestCase1", TC_PASS, "ok");
+      }
 
       Debug(UTDBG_TAG "_cache_write", "finishing up [i]");
 
@@ -965,8 +966,9 @@ REGRESSION_TEST(SDK_API_TSfopen)(RegressionTest *test, int /* atype ATS_UNUSED *
     // no need to continue, return
     *pstatus = REGRESSION_TEST_FAILED;
     return;
-  } else
+  } else {
     SDK_RPRINT(test, "TSfopen", "TestCase1", TC_PASS, "ok");
+  }
 
   // Create unique tmp _file_name_, do not use any TS file_name
   snprintf(write_file_name, PATH_NAME_MAX, "/tmp/%sXXXXXX", PFX);
@@ -976,8 +978,9 @@ REGRESSION_TEST(SDK_API_TSfopen)(RegressionTest *test, int /* atype ATS_UNUSED *
 
     // no need to continue, return
     *pstatus = REGRESSION_TEST_FAILED;
-    if (source_read_file != NULL)
+    if (source_read_file != NULL) {
       TSfclose(source_read_file);
+    }
     return;
   }
   close(write_file_fd);
@@ -988,8 +991,9 @@ REGRESSION_TEST(SDK_API_TSfopen)(RegressionTest *test, int /* atype ATS_UNUSED *
 
     // no need to continue, return
     *pstatus = REGRESSION_TEST_FAILED;
-    if (source_read_file != NULL)
+    if (source_read_file != NULL) {
       TSfclose(source_read_file);
+    }
     return;
   }
   SDK_RPRINT(test, "TSfopen", "TestCase2", TC_PASS, "ok");
@@ -1002,10 +1006,12 @@ REGRESSION_TEST(SDK_API_TSfopen)(RegressionTest *test, int /* atype ATS_UNUSED *
 
     // no need to continue, return
     *pstatus = REGRESSION_TEST_FAILED;
-    if (source_read_file != NULL)
+    if (source_read_file != NULL) {
       TSfclose(source_read_file);
-    if (write_file != NULL)
+    }
+    if (write_file != NULL) {
       TSfclose(write_file);
+    }
     return;
   }
 
@@ -1017,10 +1023,12 @@ REGRESSION_TEST(SDK_API_TSfopen)(RegressionTest *test, int /* atype ATS_UNUSED *
 
     // no need to continue, return
     *pstatus = REGRESSION_TEST_FAILED;
-    if (source_read_file != NULL)
+    if (source_read_file != NULL) {
       TSfclose(source_read_file);
-    if (write_file != NULL)
+    }
+    if (write_file != NULL) {
       TSfclose(write_file);
+    }
     return;
   } else {
     if (ret_val != input_buffer) {
@@ -1028,13 +1036,16 @@ REGRESSION_TEST(SDK_API_TSfopen)(RegressionTest *test, int /* atype ATS_UNUSED *
 
       // no need to continue, return
       *pstatus = REGRESSION_TEST_FAILED;
-      if (source_read_file != NULL)
+      if (source_read_file != NULL) {
         TSfclose(source_read_file);
-      if (write_file != NULL)
+      }
+      if (write_file != NULL) {
         TSfclose(write_file);
+      }
       return;
-    } else
+    } else {
       SDK_RPRINT(test, "TSfgets", "TestCase1", TC_PASS, "ok");
+    }
   }
 
   // TSfwrite
@@ -1044,10 +1055,12 @@ REGRESSION_TEST(SDK_API_TSfopen)(RegressionTest *test, int /* atype ATS_UNUSED *
 
     // no need to continue, return
     *pstatus = REGRESSION_TEST_FAILED;
-    if (source_read_file != NULL)
+    if (source_read_file != NULL) {
       TSfclose(source_read_file);
-    if (write_file != NULL)
+    }
+    if (write_file != NULL) {
       TSfclose(write_file);
+    }
     return;
   }
 
@@ -1059,10 +1072,12 @@ REGRESSION_TEST(SDK_API_TSfopen)(RegressionTest *test, int /* atype ATS_UNUSED *
 
     // no need to continue, return
     *pstatus = REGRESSION_TEST_FAILED;
-    if (source_read_file != NULL)
+    if (source_read_file != NULL) {
       TSfclose(source_read_file);
-    if (write_file != NULL)
+    }
+    if (write_file != NULL) {
       TSfclose(write_file);
+    }
     return;
   }
 
@@ -1073,10 +1088,12 @@ REGRESSION_TEST(SDK_API_TSfopen)(RegressionTest *test, int /* atype ATS_UNUSED *
 
     // no need to continue, return
     *pstatus = REGRESSION_TEST_FAILED;
-    if (source_read_file != NULL)
+    if (source_read_file != NULL) {
       TSfclose(source_read_file);
-    if (write_file != NULL)
+    }
+    if (write_file != NULL) {
       TSfclose(write_file);
+    }
     return;
   }
 
@@ -1087,10 +1104,12 @@ REGRESSION_TEST(SDK_API_TSfopen)(RegressionTest *test, int /* atype ATS_UNUSED *
 
     // no need to continue, return
     *pstatus = REGRESSION_TEST_FAILED;
-    if (source_read_file != NULL)
+    if (source_read_file != NULL) {
       TSfclose(source_read_file);
-    if (write_file != NULL)
+    }
+    if (write_file != NULL) {
       TSfclose(write_file);
+    }
     return;
   }
 
@@ -1102,10 +1121,12 @@ REGRESSION_TEST(SDK_API_TSfopen)(RegressionTest *test, int /* atype ATS_UNUSED *
 
     // no need to continue, return
     *pstatus = REGRESSION_TEST_FAILED;
-    if (source_read_file != NULL)
+    if (source_read_file != NULL) {
       TSfclose(source_read_file);
-    if (write_file != NULL)
+    }
+    if (write_file != NULL) {
       TSfclose(write_file);
+    }
     return;
   }
 
@@ -1118,15 +1139,19 @@ REGRESSION_TEST(SDK_API_TSfopen)(RegressionTest *test, int /* atype ATS_UNUSED *
 
     // no need to continue, return
     *pstatus = REGRESSION_TEST_FAILED;
-    if (source_read_file != NULL)
+    if (source_read_file != NULL) {
       TSfclose(source_read_file);
-    if (write_file != NULL)
+    }
+    if (write_file != NULL) {
       TSfclose(write_file);
-    if (cmp_read_file != NULL)
+    }
+    if (cmp_read_file != NULL) {
       TSfclose(cmp_read_file);
+    }
     return;
-  } else
+  } else {
     SDK_RPRINT(test, "TSfread", "TestCase1", TC_PASS, "ok");
+  }
 
   // compare input_buffer and cmp_buffer buffers
   if (memcmp(input_buffer, cmp_buffer, read_amount) != 0) {
@@ -1134,15 +1159,19 @@ REGRESSION_TEST(SDK_API_TSfopen)(RegressionTest *test, int /* atype ATS_UNUSED *
 
     // no need to continue, return
     *pstatus = REGRESSION_TEST_FAILED;
-    if (source_read_file != NULL)
+    if (source_read_file != NULL) {
       TSfclose(source_read_file);
-    if (write_file != NULL)
+    }
+    if (write_file != NULL) {
       TSfclose(write_file);
-    if (cmp_read_file != NULL)
+    }
+    if (cmp_read_file != NULL) {
       TSfclose(cmp_read_file);
+    }
     return;
-  } else
+  } else {
     SDK_RPRINT(test, "TSfread", "TestCase2", TC_PASS, "ok");
+  }
 
   // remove the tmp file
   if (unlink(write_file_name) != 0) {
@@ -1157,8 +1186,9 @@ REGRESSION_TEST(SDK_API_TSfopen)(RegressionTest *test, int /* atype ATS_UNUSED *
   SDK_RPRINT(test, "TSfclose", "TestCase2", TC_PASS, "ok");
 
   *pstatus = REGRESSION_TEST_PASSED;
-  if (cmp_read_file != NULL)
+  if (cmp_read_file != NULL) {
     TSfclose(cmp_read_file);
+  }
 }
 
 /* TSThread */
@@ -1190,10 +1220,11 @@ thread_create_handler(void * /* arg ATS_UNUSED */)
     SDK_RPRINT(SDK_Thread_test, "TSThreadCreate", "TestCase2", TC_PASS, "ok");
   }
 
-  if (thread_err_count > 0)
+  if (thread_err_count > 0) {
     *SDK_Thread_pstatus = REGRESSION_TEST_FAILED;
-  else
+  } else {
     *SDK_Thread_pstatus = REGRESSION_TEST_PASSED;
+  }
 
   return NULL;
 }
@@ -1256,17 +1287,20 @@ pthread_start_func(void * /* arg ATS_UNUSED */)
   if (!temp_thread) {
     SDK_RPRINT(SDK_ThreadInit_test, "TSThreadInit", "TestCase2", TC_FAIL, "can't init thread");
     thread_init_err_count++;
-  } else
+  } else {
     SDK_RPRINT(SDK_ThreadInit_test, "TSThreadInit", "TestCase2", TC_PASS, "ok");
+  }
 
   // Clean up this thread
-  if (temp_thread)
+  if (temp_thread) {
     TSThreadDestroy(temp_thread);
+  }
 
-  if (thread_init_err_count > 0)
+  if (thread_init_err_count > 0) {
     *SDK_ThreadInit_pstatus = REGRESSION_TEST_FAILED;
-  else
+  } else {
     *SDK_ThreadInit_pstatus = REGRESSION_TEST_PASSED;
+  }
 
   return NULL;
 }
@@ -1287,8 +1321,9 @@ REGRESSION_TEST(SDK_API_TSThreadInit)(RegressionTest *test, int /* atype ATS_UNU
   if (ret != 0) {
     thread_init_err_count++;
     SDK_RPRINT(test, "TSThreadInit", "TestCase1", TC_FAIL, "can't create pthread");
-  } else
+  } else {
     SDK_RPRINT(test, "TSThreadInit", "TestCase1", TC_PASS, "ok");
+  }
 }
 
 /* Action */
@@ -1486,8 +1521,9 @@ REGRESSION_TEST(SDK_API_TSContMutexGet)(RegressionTest *test, int /* atype ATS_U
   if (mutexp_input == mutexp_output) {
     SDK_RPRINT(test, "TSContMutexGet", "TestCase1", TC_PASS, "ok");
     test_passed = true;
-  } else
+  } else {
     SDK_RPRINT(test, "TSContMutexGet", "TestCase1", TC_FAIL, "Continutation's mutex corrupted");
+  }
 
   // Status of the whole test
   *pstatus = ((test_passed == true) ? REGRESSION_TEST_PASSED : REGRESSION_TEST_FAILED);
@@ -3421,8 +3457,9 @@ REGRESSION_TEST(SDK_API_TSHttpHdr)(RegressionTest *test, int /* atype ATS_UNUSED
           int64_t block_size;
 
           block_start = TSIOBufferBlockReadStart(iobufblock, iobufreader, &block_size);
-          if (block_size <= 0)
+          if (block_size <= 0) {
             break;
+          }
 
           memcpy(actual_iobuf + bytes_read, block_start, block_size);
           bytes_read += block_size;
@@ -7325,8 +7362,9 @@ EXCLUSIVE_REGRESSION_TEST(SDK_API_TSHttpConnectIntercept)(RegressionTest *test, 
   sockaddr_in addr;
   ats_ip4_set(&addr, 1, 1);
   data->vc = TSHttpConnect(ats_ip_sa_cast(&addr));
-  if (TSVConnClosedGet(data->vc))
+  if (TSVConnClosedGet(data->vc)) {
     SDK_RPRINT(data->test, "TSHttpConnect", "TestCase 1", TC_FAIL, "Connect reported as closed immediately after open");
+  }
   synclient_txn_send_request_to_vc(data->browser, data->request, data->vc);
 
   /* Wait until transaction is done */

--- a/proxy/InkIOCoreAPI.cc
+++ b/proxy/InkIOCoreAPI.cc
@@ -49,15 +49,18 @@
 TSReturnCode
 sdk_sanity_check_mutex(TSMutex mutex)
 {
-  if (mutex == NULL)
+  if (mutex == NULL) {
     return TS_ERROR;
+  }
 
   ProxyMutex *mutexp = (ProxyMutex *)mutex;
 
-  if (mutexp->refcount() < 0)
+  if (mutexp->refcount() < 0) {
     return TS_ERROR;
-  if (mutexp->nthread_holding < 0)
+  }
+  if (mutexp->nthread_holding < 0) {
     return TS_ERROR;
+  }
 
   return TS_SUCCESS;
 }
@@ -65,8 +68,9 @@ sdk_sanity_check_mutex(TSMutex mutex)
 TSReturnCode
 sdk_sanity_check_hostlookup_structure(TSHostLookupResult data)
 {
-  if (data == NULL)
+  if (data == NULL) {
     return TS_ERROR;
+  }
 
   return TS_SUCCESS;
 }
@@ -74,8 +78,9 @@ sdk_sanity_check_hostlookup_structure(TSHostLookupResult data)
 TSReturnCode
 sdk_sanity_check_iocore_structure(void *data)
 {
-  if (data == NULL)
+  if (data == NULL) {
     return TS_ERROR;
+  }
 
   return TS_SUCCESS;
 }
@@ -139,8 +144,9 @@ TSThreadInit()
   thread = new INKThreadInternal;
 
 #ifdef DEBUG
-  if (thread == NULL)
+  if (thread == NULL) {
     return (TSThread)NULL;
+  }
 #endif
 
   thread->set_specific();
@@ -210,10 +216,12 @@ TSMutexCheck(TSMutex mutex)
 {
   ProxyMutex *mutexp = (ProxyMutex *)mutex;
 
-  if (mutexp->refcount() < 0)
+  if (mutexp->refcount() < 0) {
     return -1;
-  if (mutexp->nthread_holding < 0)
+  }
+  if (mutexp->nthread_holding < 0) {
     return -1;
+  }
   return 1;
 }
 
@@ -520,8 +528,9 @@ TSIOBufferStart(TSIOBuffer bufp)
   MIOBuffer *b       = (MIOBuffer *)bufp;
   IOBufferBlock *blk = b->get_current_block();
 
-  if (!blk || (blk->write_avail() == 0))
+  if (!blk || (blk->write_avail() == 0)) {
     b->add_block();
+  }
   blk = b->get_current_block();
 
   // TODO: Remove when memory allocations can't fail.
@@ -612,8 +621,9 @@ TSIOBufferBlockReadStart(TSIOBufferBlock blockp, TSIOBufferReader readerp, int64
   char *p;
 
   p = blk->start();
-  if (avail)
+  if (avail) {
     *avail = blk->read_avail();
+  }
 
   if (reader->block.get() == blk) {
     p += reader->start_offset;
@@ -657,8 +667,9 @@ TSIOBufferBlockWriteStart(TSIOBufferBlock blockp, int64_t *avail)
 
   IOBufferBlock *blk = (IOBufferBlock *)blockp;
 
-  if (avail)
+  if (avail) {
     *avail = blk->write_avail();
+  }
   return blk->end();
 }
 

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -241,10 +241,12 @@ public:
       // TODO: TS-567 Integrate with debugging allocators "dump" features?
       ink_freelists_dump(stderr);
       ResourceTracker::dump(stderr);
-      if (!end)
+      if (!end) {
         end = (char *)sbrk(0);
-      if (!snap)
-        snap    = (char *)sbrk(0);
+      }
+      if (!snap) {
+        snap = (char *)sbrk(0);
+      }
       char *now = (char *)sbrk(0);
       // TODO: Use logging instead directly writing to stderr
       //       This is not error condition at the first place
@@ -553,8 +555,9 @@ skip(char *cmd, int null_ok = 0)
   cmd += strspn(cmd, " \t");
   cmd = strpbrk(cmd, " \t");
   if (!cmd) {
-    if (!null_ok)
+    if (!null_ok) {
       printf("Error: argument missing\n");
+    }
     return cmd;
   }
   cmd += strspn(cmd, " \t");
@@ -685,8 +688,9 @@ cmd_clear(char *cmd)
     ats_scoped_str config(Layout::relative_to(rundir, "hostdb.config"));
 
     Note("Clearing HostDB Configuration");
-    if (unlink(config) < 0)
+    if (unlink(config) < 0) {
       Note("unable to unlink %s", (const char *)config);
+    }
   }
 
   if (c_hdb || c_all) {
@@ -696,8 +700,9 @@ cmd_clear(char *cmd)
       return CMD_FAILED;
     }
     hostDBProcessor.cache()->reset();
-    if (c_hdb)
+    if (c_hdb) {
       return CMD_OK;
+    }
   }
 
   //#ifndef INK_NO_ACC
@@ -862,8 +867,9 @@ find_cmd_index(char const *p)
       char const *e = strpbrk(p, " \t\n");
       int len       = s ? s - l : strlen(l);
       int lenp      = e ? e - p : strlen(p);
-      if ((len == lenp) && !strncasecmp(p, l, len))
+      if ((len == lenp) && !strncasecmp(p, l, len)) {
         return c;
+      }
       l = s ? s + 1 : 0;
     }
   }
@@ -899,8 +905,9 @@ check_fd_limit()
   REC_ReadConfigInteger(fds_throttle, "proxy.config.net.connections_throttle");
   if (fds_throttle > fds_limit + THROTTLE_FD_HEADROOM) {
     int new_fds_throttle = fds_limit - THROTTLE_FD_HEADROOM;
-    if (new_fds_throttle < 1)
+    if (new_fds_throttle < 1) {
       MachineFatal("too few file descritors (%d) available", fds_limit);
+    }
     char msg[256];
     snprintf(msg, sizeof(msg), "connection throttle too high, "
                                "%d (throttle) + %d (internal use) > %d (file descriptor limit), "
@@ -1064,8 +1071,9 @@ struct ShowStats : public Continuation {
   {
     (void)event;
     (void)e;
-    if (!(cycle++ % 24))
+    if (!(cycle++ % 24)) {
       printf("r:rr w:ww r:rbs w:wbs open polls\n");
+    }
     int64_t sval, cval;
 
     NET_READ_DYN_SUM(net_calls_to_readfromnet_stat, sval);
@@ -1245,8 +1253,9 @@ struct AutoStopCont : public Continuation {
 static void
 run_AutoStop()
 {
-  if (getenv("PROXY_AUTO_EXIT"))
+  if (getenv("PROXY_AUTO_EXIT")) {
     eventProcessor.schedule_in(new AutoStopCont(), HRTIME_SECONDS(atoi(getenv("PROXY_AUTO_EXIT"))));
+  }
 }
 
 #if TS_HAS_TESTS
@@ -1290,8 +1299,9 @@ struct RegressionCont : public Continuation {
 static void
 run_RegressionTest()
 {
-  if (regression_level)
+  if (regression_level) {
     eventProcessor.schedule_every(new RegressionCont(), HRTIME_SECONDS(1));
+  }
 }
 #endif // TS_HAS_TESTS
 
@@ -1335,8 +1345,9 @@ getNumSSLThreads(void)
       num_of_ssl_threads = (int)((float)ink_number_of_processors() * autoconfig_scale);
 
       // Last resort
-      if (num_of_ssl_threads <= 0)
+      if (num_of_ssl_threads <= 0) {
         num_of_ssl_threads = config_num_ssl_threads * 2;
+      }
     }
   }
 
@@ -1543,8 +1554,9 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   diags->prefix_str = "Server ";
   diags->set_stdout_output(bind_stdout);
   diags->set_stderr_output(bind_stderr);
-  if (is_debug_tag_set("diags"))
+  if (is_debug_tag_set("diags")) {
     diags->dump();
+  }
 
   // Bind stdout and stderr to specified switches
   // Still needed despite the set_std{err,out}_output() calls later since there are
@@ -1556,8 +1568,9 @@ main(int /* argc ATS_UNUSED */, const char **argv)
 
   // Ensure only one copy of traffic server is running, unless it's a command
   // that doesn't require a lock.
-  if (!(command_valid && commands[command_index].no_process_lock))
+  if (!(command_valid && commands[command_index].no_process_lock)) {
     check_lockfile();
+  }
 
   // Set the core limit for the process
   init_core_size();
@@ -1576,11 +1589,13 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   Debug("hugepages", "ats_pagesize reporting %zu", ats_pagesize());
   Debug("hugepages", "ats_hugepage_size reporting %zu", ats_hugepage_size());
 
-  if (!num_accept_threads)
+  if (!num_accept_threads) {
     REC_ReadConfigInteger(num_accept_threads, "proxy.config.accept_threads");
+  }
 
-  if (!num_task_threads)
+  if (!num_task_threads) {
     REC_ReadConfigInteger(num_task_threads, "proxy.config.task_threads");
+  }
 
   // Set up crash logging. We need to do this while we are still privileged so that the crash
   // logging helper runs as root. Don't bother setting up a crash logger if we are going into
@@ -1630,8 +1645,9 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   diags->prefix_str = "Server ";
   diags->set_stdout_output(bind_stdout);
   diags->set_stderr_output(bind_stderr);
-  if (is_debug_tag_set("diags"))
+  if (is_debug_tag_set("diags")) {
     diags->dump();
+  }
 
   DebugCapabilities("privileges"); // Can do this now, logging is up.
 
@@ -1641,9 +1657,9 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   REC_ReadConfigInteger(mlock_flags, "proxy.config.mlock_enabled");
 
   if (mlock_flags == 2) {
-    if (0 != mlockall(MCL_CURRENT | MCL_FUTURE))
+    if (0 != mlockall(MCL_CURRENT | MCL_FUTURE)) {
       Warning("Unable to mlockall() on startup");
-    else
+    } else
       Debug("server", "Successfully called mlockall()");
   }
 #endif
@@ -1664,14 +1680,15 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   */
   IpEndpoint machine_addr;
   ink_zero(machine_addr);
-  if (HttpConfig::m_master.outbound_ip4.isValid())
+  if (HttpConfig::m_master.outbound_ip4.isValid()) {
     machine_addr.assign(HttpConfig::m_master.outbound_ip4);
-  else if (HttpConfig::m_master.outbound_ip6.isValid())
+  } else if (HttpConfig::m_master.outbound_ip6.isValid()) {
     machine_addr.assign(HttpConfig::m_master.outbound_ip6);
-  else if (HttpConfig::m_master.inbound_ip4.isValid())
+  } else if (HttpConfig::m_master.inbound_ip4.isValid()) {
     machine_addr.assign(HttpConfig::m_master.inbound_ip4);
-  else if (HttpConfig::m_master.inbound_ip6.isValid())
+  } else if (HttpConfig::m_master.inbound_ip6.isValid()) {
     machine_addr.assign(HttpConfig::m_master.inbound_ip6);
+  }
   Machine::init(0, &machine_addr.sa);
 
   // pmgmt->start() must occur after initialization of Diags but
@@ -1711,8 +1728,9 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   cache_clustering_enabled = 0;
 
   if (RecGetRecordInt("proxy.local.cluster.type", &cluster_type) == REC_ERR_OKAY) {
-    if (cluster_type == 1)
+    if (cluster_type == 1) {
       cache_clustering_enabled = 1;
+    }
   }
   Note("cache clustering %s", cache_clustering_enabled ? "enabled" : "disabled");
 
@@ -1745,8 +1763,9 @@ main(int /* argc ATS_UNUSED */, const char **argv)
 
   int num_remap_threads = 0;
   REC_ReadConfigInteger(num_remap_threads, "proxy.config.remap.num_remap_threads");
-  if (num_remap_threads < 1)
+  if (num_remap_threads < 1) {
     num_remap_threads = 0;
+  }
 
   if (num_remap_threads > 0) {
     Note("using the new remap processor system with %d threads", num_remap_threads);
@@ -1764,10 +1783,11 @@ main(int /* argc ATS_UNUSED */, const char **argv)
     int cmd_ret = cmd_mode();
 
     if (cmd_ret != CMD_IN_PROGRESS) {
-      if (cmd_ret >= 0)
+      if (cmd_ret >= 0) {
         ::exit(0); // everything is OK
-      else
+      } else {
         ::exit(1); // in error
+      }
     }
   } else {
     remapProcessor.start(num_remap_threads, stacksize);
@@ -1789,12 +1809,14 @@ main(int /* argc ATS_UNUSED */, const char **argv)
     Http2::init();
 
     // Load HTTP port data. getNumSSLThreads depends on this.
-    if (!HttpProxyPort::loadValue(http_accept_port_descriptor))
+    if (!HttpProxyPort::loadValue(http_accept_port_descriptor)) {
       HttpProxyPort::loadConfig();
+    }
     HttpProxyPort::loadDefaultIfEmpty();
 
-    if (!accept_mss)
+    if (!accept_mss) {
       REC_ReadConfigInteger(accept_mss, "proxy.config.net.sock_mss_in");
+    }
 
     NetProcessor::accept_mss = accept_mss;
     netProcessor.start(0, stacksize);
@@ -1820,10 +1842,12 @@ main(int /* argc ATS_UNUSED */, const char **argv)
     cacheProcessor.start();
 
     // UDP net-threads are turned off by default.
-    if (!num_of_udp_threads)
+    if (!num_of_udp_threads) {
       REC_ReadConfigInteger(num_of_udp_threads, "proxy.config.udp.threads");
-    if (num_of_udp_threads)
+    }
+    if (num_of_udp_threads) {
       udpNet.start(num_of_udp_threads, stacksize);
+    }
 
     // acc.init();
     // if (auto_clear_authdb_flag)
@@ -1847,8 +1871,9 @@ main(int /* argc ATS_UNUSED */, const char **argv)
     //   Raft::init();
 
     // Continuation Statistics Dump
-    if (show_statistics)
+    if (show_statistics) {
       eventProcessor.schedule_every(new ShowStats(), HRTIME_SECONDS(show_statistics), ET_CALL);
+    }
 
     //////////////////////////////////////
     // main server logic initiated here //
@@ -1882,8 +1907,9 @@ main(int /* argc ATS_UNUSED */, const char **argv)
       } else {
         start_HttpProxyServer(); // PORTS_READY_HOOK called from in here
       }
-      if (icp_enabled)
+      if (icp_enabled) {
         icpProcessor.start();
+      }
     }
 
     // "Task" processor, possibly with its own set of task threads
@@ -1891,8 +1917,9 @@ main(int /* argc ATS_UNUSED */, const char **argv)
 
     int back_door_port = NO_FD;
     REC_ReadConfigInteger(back_door_port, "proxy.config.process_manager.mgmt_port");
-    if (back_door_port != NO_FD)
+    if (back_door_port != NO_FD) {
       start_HttpProxyServerBackDoor(back_door_port, num_accept_threads > 0 ? 1 : 0); // One accept thread is enough
+    }
 
     if (netProcessor.socks_conf_stuff->accept_enabled) {
       start_SocksProxy(netProcessor.socks_conf_stuff->accept_port);

--- a/proxy/ParentConsistentHash.cc
+++ b/proxy/ParentConsistentHash.cc
@@ -121,8 +121,9 @@ ParentConsistentHash::selectParent(const ParentSelectionPolicy *policy, bool fir
     fhash       = chash[PRIMARY];
     if (path_hash) {
       prtmp = (pRecord *)fhash->lookup_by_hashval(path_hash, &result->chashIter[last_lookup], &wrap_around[last_lookup]);
-      if (prtmp)
+      if (prtmp) {
         pRec = (parents[last_lookup] + prtmp->idx);
+      }
     }
     // else called by nextParent().
   } else {
@@ -131,15 +132,17 @@ ParentConsistentHash::selectParent(const ParentSelectionPolicy *policy, bool fir
       fhash       = chash[SECONDARY];
       path_hash   = getPathHash(request_info, (ATSHash64 *)&hash);
       prtmp       = (pRecord *)fhash->lookup_by_hashval(path_hash, &result->chashIter[last_lookup], &wrap_around[last_lookup]);
-      if (prtmp)
+      if (prtmp) {
         pRec = (parents[last_lookup] + prtmp->idx);
+      }
     } else {
       last_lookup = PRIMARY;
       fhash       = chash[PRIMARY];
       do { // search until we've selected a different parent.
         prtmp = (pRecord *)fhash->lookup(NULL, &result->chashIter[last_lookup], &wrap_around[last_lookup], &hash);
-        if (prtmp)
+        if (prtmp) {
           pRec = (parents[last_lookup] + prtmp->idx);
+        }
       } while (prtmp && strcmp(prtmp->hostname, result->hostname) == 0);
     }
   }

--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -317,8 +317,9 @@ UnavailableServerResponseCodes::UnavailableServerResponseCodes(char *val)
   numTok = pTok.Initialize(val, SHARE_TOKS);
   if (numTok == 0) {
     c = atoi(val);
-    if (c > 500 && c < 600)
+    if (c > 500 && c < 600) {
       codes.push_back(HTTP_STATUS_SERVICE_UNAVAILABLE);
+    }
   }
   for (int i = 0; i < numTok; i++) {
     c = atoi(pTok[i]);
@@ -408,10 +409,12 @@ ParentRecord::ProcessParents(char *val, bool isPrimary)
     } else {
       scan = tmp + 1;
     }
-    for (; *scan != '\0' && (ParseRules::is_digit(*scan) || *scan == '.'); scan++)
+    for (; *scan != '\0' && (ParseRules::is_digit(*scan) || *scan == '.'); scan++) {
       ;
-    for (; *scan != '\0' && ParseRules::is_wslfcr(*scan); scan++)
+    }
+    for (; *scan != '\0' && ParseRules::is_wslfcr(*scan); scan++) {
       ;
+    }
     if (*scan != '\0') {
       errPtr = "Garbage trailing entry or invalid separator";
       goto MERROR;
@@ -815,10 +818,12 @@ SocksServerConfig::reconfigure()
   params->DefaultParent = createDefaultParent(default_val);
   ats_free(default_val);
 
-  if (params->DefaultParent)
+  if (params->DefaultParent) {
     setup_socks_servers(params->DefaultParent, 1);
-  if (params->parent_table->ipMatch)
+  }
+  if (params->parent_table->ipMatch) {
     setup_socks_servers(params->parent_table->ipMatch->data_array, params->parent_table->ipMatch->array_len);
+  }
 
   // Handle parent timeout
   REC_ReadConfigInteger(retry_time, "proxy.config.socks.server_retry_time");
@@ -1287,8 +1292,9 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
 int
 verify(ParentResult *r, ParentResultType e, const char *h, int p)
 {
-  if (is_debug_tag_set("parent_select"))
+  if (is_debug_tag_set("parent_select")) {
     show_result(r);
+  }
   return (r->result != e) ? 0 : ((e != PARENT_SPECIFIED) ? 1 : (strcmp(r->hostname, h) ? 0 : ((r->port == p) ? 1 : 0)));
 }
 

--- a/proxy/Plugin.cc
+++ b/proxy/Plugin.cc
@@ -66,8 +66,9 @@ PluginRegInfo::~PluginRegInfo()
   ats_free(this->plugin_name);
   ats_free(this->vendor_name);
   ats_free(this->support_email);
-  if (dlh)
+  if (dlh) {
     dlclose(dlh);
+  }
 }
 
 static bool
@@ -245,17 +246,21 @@ plugin_init(bool validateOnly)
     p    = line;
 
     // strip leading white space and test for comment or blank line
-    while (*p && ParseRules::is_wslfcr(*p))
+    while (*p && ParseRules::is_wslfcr(*p)) {
       ++p;
-    if ((*p == '\0') || (*p == '#'))
+    }
+    if ((*p == '\0') || (*p == '#')) {
       continue;
+    }
 
     // not comment or blank, so rip line into tokens
     while (1) {
-      while (*p && ParseRules::is_wslfcr(*p))
+      while (*p && ParseRules::is_wslfcr(*p)) {
         ++p;
-      if ((*p == '\0') || (*p == '#'))
+      }
+      if ((*p == '\0') || (*p == '#')) {
         break; // EOL
+      }
 
       if (*p == '\"') {
         p += 1;
@@ -291,8 +296,9 @@ plugin_init(bool validateOnly)
 
     retVal = plugin_load(argc, argv, validateOnly);
 
-    for (i = 0; i < argc; i++)
+    for (i = 0; i < argc; i++) {
       ats_free(vars[i]);
+    }
   }
 
   close(fd);

--- a/proxy/PluginVC.cc
+++ b/proxy/PluginVC.cc
@@ -140,8 +140,9 @@ PluginVC::main_handler(int event, void *data)
     read_mutex_held = MUTEX_TAKE_TRY_LOCK(read_side_mutex, my_ethread);
 
     if (!read_mutex_held) {
-      if (call_event != inactive_event)
+      if (call_event != inactive_event) {
         call_event->schedule_in(PVC_LOCK_RETRY_TIME);
+      }
       return 0;
     }
 
@@ -149,8 +150,9 @@ PluginVC::main_handler(int event, void *data)
       // It's possible some swapped the mutex on us before
       //  we were able to grab it
       Mutex_unlock(read_side_mutex, my_ethread);
-      if (call_event != inactive_event)
+      if (call_event != inactive_event) {
         call_event->schedule_in(PVC_LOCK_RETRY_TIME);
+      }
       return 0;
     }
   }
@@ -162,8 +164,9 @@ PluginVC::main_handler(int event, void *data)
       if (read_mutex_held) {
         Mutex_unlock(read_side_mutex, my_ethread);
       }
-      if (call_event != inactive_event)
+      if (call_event != inactive_event) {
         call_event->schedule_in(PVC_LOCK_RETRY_TIME);
+      }
       return 0;
     }
 
@@ -174,8 +177,9 @@ PluginVC::main_handler(int event, void *data)
       if (read_mutex_held) {
         Mutex_unlock(read_side_mutex, my_ethread);
       }
-      if (call_event != inactive_event)
+      if (call_event != inactive_event) {
         call_event->schedule_in(PVC_LOCK_RETRY_TIME);
+      }
       return 0;
     }
   }
@@ -375,8 +379,9 @@ PluginVC::do_io_close(int /* flag ATS_UNUSED */)
 
     // If re-entered then that earlier handler will clean up, otherwise set up a ping
     // to drive that process (too dangerous to do it here).
-    if (reentrancy_count <= 0)
+    if (reentrancy_count <= 0) {
       setup_event_cb(0, &sm_lock_retry_event);
+    }
   }
 }
 

--- a/proxy/ProxyClientTransaction.cc
+++ b/proxy/ProxyClientTransaction.cc
@@ -82,8 +82,9 @@ ProxyClientTransaction::release(IOBufferReader *r)
   current_reader = NULL; // Clear reference to SM
 
   // Pass along the release to the session
-  if (parent)
+  if (parent) {
     parent->release(this);
+  }
 }
 
 void

--- a/proxy/RegressionSM.cc
+++ b/proxy/RegressionSM.cc
@@ -33,8 +33,9 @@ RegressionSM::set_status(int astatus)
   // INPROGRESS < NOT_RUN < PASSED < FAILED
   if (status != REGRESSION_TEST_FAILED) {
     if (status == REGRESSION_TEST_PASSED) {
-      if (astatus != REGRESSION_TEST_NOT_RUN)
+      if (astatus != REGRESSION_TEST_NOT_RUN) {
         status = astatus;
+      }
     } else {
       // INPROGRESS or NOT_RUN
       status = astatus;
@@ -50,10 +51,12 @@ RegressionSM::done(int astatus)
     pending_action = 0;
   }
   set_status(astatus);
-  if (pstatus)
+  if (pstatus) {
     *pstatus = status;
-  if (parent)
+  }
+  if (parent) {
     parent->child_done(status);
+  }
 }
 
 void
@@ -185,8 +188,9 @@ RegressionSM::run()
   // TODO: Why introduce another scope here?
   {
     MUTEX_TRY_LOCK(l, mutex, this_ethread());
-    if (!l.is_locked() || nwaiting > 1)
+    if (!l.is_locked() || nwaiting > 1) {
       goto Lretry;
+    }
     RegressionSM *x = 0;
     while (ichild < n) {
       if (!repeat) {
@@ -198,12 +202,14 @@ RegressionSM::run()
           x = children[(intptr_t)0];
         }
       }
-      if (!ichild)
+      if (!ichild) {
         nwaiting++;
+      }
       x->xrun(this);
       ichild++;
-      if (!parallel && nwaiting > 1)
+      if (!parallel && nwaiting > 1) {
         goto Lretry;
+      }
     }
   }
   nwaiting--;
@@ -226,13 +232,14 @@ RegressionSM::RegressionSM(const RegressionSM &ao)
   parent          = &o;
   nwaiting        = o.nwaiting;
   nchildren       = o.nchildren;
-  for (intptr_t i = 0; i < nchildren; i++)
-    children(i)   = o.children[i]->clone();
-  n               = o.n;
-  ichild          = o.ichild;
-  parallel        = o.parallel;
-  repeat          = o.repeat;
-  pending_action  = o.pending_action;
+  for (intptr_t i = 0; i < nchildren; i++) {
+    children(i) = o.children[i]->clone();
+  }
+  n              = o.n;
+  ichild         = o.ichild;
+  parallel       = o.parallel;
+  repeat         = o.repeat;
+  pending_action = o.pending_action;
   ink_assert(status == REGRESSION_TEST_INPROGRESS);
   ink_assert(nwaiting == 0);
   ink_assert(ichild == 0);
@@ -246,8 +253,9 @@ struct ReRegressionSM : public RegressionSM {
     if (time(NULL) < 1) { // example test
       rprintf(t, "impossible");
       done(REGRESSION_TEST_FAILED);
-    } else
+    } else {
       done(REGRESSION_TEST_PASSED);
+    }
   }
   ReRegressionSM(RegressionTest *at) : RegressionSM(at) {}
   virtual RegressionSM *

--- a/proxy/SocksProxy.cc
+++ b/proxy/SocksProxy.cc
@@ -116,8 +116,9 @@ SocksProxy::init(NetVConnection *netVC)
 void
 SocksProxy::free()
 {
-  if (buf)
+  if (buf) {
     free_MIOBuffer(buf);
+  }
 
   mutex = NULL;
 
@@ -201,8 +202,9 @@ SocksProxy::mainEvent(int event, void *data)
         if (n_read_avail > 8) {
           // read the user name
           int i = 8;
-          while (p[i] != 0 && n_read_avail > i)
+          while (p[i] != 0 && n_read_avail > i) {
             i++;
+          }
 
           if (p[i] == 0) {
             port_ptr                  = &p[2];
@@ -383,11 +385,13 @@ SocksProxy::mainEvent(int event, void *data)
   }
 
   if (state == SOCKS_ERROR) {
-    if (pending_action)
+    if (pending_action) {
       pending_action->cancel();
+    }
 
-    if (timeout)
+    if (timeout) {
       timeout->cancel(this);
+    }
 
     if (clientVC) {
       Debug("SocksProxy", "Closing clientVC on error");

--- a/proxy/StatPages.cc
+++ b/proxy/StatPages.cc
@@ -75,8 +75,9 @@ StatPagesManager::handle_http(Continuation *cont, HTTPHdr *header)
     int i;
 
     h = url->host_get(&host_len);
-    if (host_len > MAXDNAME)
+    if (host_len > MAXDNAME) {
       host_len = MAXDNAME;
+    }
     memcpy(host, h, host_len);
     host[host_len] = '\0';
     host_len       = unescapifyStr(host);
@@ -96,22 +97,25 @@ bool
 StatPagesManager::is_stat_page(URL *url)
 {
   // This gets called from the state machine, so we should optimize here and not in caller.
-  if (m_enabled <= 0)
+  if (m_enabled <= 0) {
     return false;
+  }
 
   int length;
   const char *h = url->host_get(&length);
   char host[MAXDNAME + 1];
 
-  if (h == NULL || length < 2 || length > MAXDNAME)
+  if (h == NULL || length < 2 || length > MAXDNAME) {
     return false;
+  }
 
   memcpy(host, h, length);
   host[length] = '\0';
   length       = unescapifyStr(host);
 
-  if ((host[0] == '{') && (host[length - 1] == '}'))
+  if ((host[0] == '{') && (host[length - 1] == '}')) {
     return true;
+  }
 
   return false;
 }
@@ -123,17 +127,19 @@ StatPagesManager::is_cache_inspector_page(URL *url)
   const char *h = url->host_get(&length);
   char host[MAXDNAME + 1];
 
-  if (h == NULL || length < 2 || length > MAXDNAME)
+  if (h == NULL || length < 2 || length > MAXDNAME) {
     return false;
+  }
 
   memcpy(host, h, length);
   host[length] = '\0';
   length       = unescapifyStr(host);
 
-  if (strncmp(host, "{cache}", length) == 0)
+  if (strncmp(host, "{cache}", length) == 0) {
     return true;
-  else
+  } else {
     return false;
+  }
 }
 
 void

--- a/proxy/Transform.cc
+++ b/proxy/Transform.cc
@@ -500,20 +500,25 @@ TransformVConnection::backlog(uint64_t limit)
   MIOBuffer *w;
   while (raw_vc && raw_vc != &m_terminus) {
     INKVConnInternal *vc = static_cast<INKVConnInternal *>(raw_vc);
-    if (0 != (w = vc->m_read_vio.buffer.writer()))
+    if (0 != (w = vc->m_read_vio.buffer.writer())) {
       b += w->max_read_avail();
-    if (b >= limit)
+    }
+    if (b >= limit) {
       return b;
+    }
     raw_vc = vc->m_output_vc;
   }
-  if (0 != (w = m_terminus.m_read_vio.buffer.writer()))
+  if (0 != (w = m_terminus.m_read_vio.buffer.writer())) {
     b += w->max_read_avail();
-  if (b >= limit)
+  }
+  if (b >= limit) {
     return b;
+  }
 
   IOBufferReader *r = m_terminus.m_write_vio.get_reader();
-  if (r)
+  if (r) {
     b += r->read_avail();
+  }
   return b;
 }
 
@@ -758,8 +763,9 @@ RangeTransform::RangeTransform(ProxyMutex *mut, RangeRecord *ranges, int num_fie
 
 RangeTransform::~RangeTransform()
 {
-  if (m_output_buf)
+  if (m_output_buf) {
     free_MIOBuffer(m_output_buf);
+  }
 }
 
 /*-------------------------------------------------------------------------
@@ -846,8 +852,9 @@ RangeTransform::transform_to_range()
     if (*done_byte < (*start - 1)) {
       toskip = *start - *done_byte - 1;
 
-      if (toskip > avail)
+      if (toskip > avail) {
         toskip = avail;
+      }
 
       if (toskip > 0) {
         reader->consume(toskip);
@@ -859,8 +866,9 @@ RangeTransform::transform_to_range()
     if (avail > 0) {
       tosend = *end - *done_byte;
 
-      if (tosend > avail)
+      if (tosend > avail) {
         tosend = avail;
+      }
 
       m_output_buf->write(reader, tosend);
       reader->consume(tosend);
@@ -869,8 +877,9 @@ RangeTransform::transform_to_range()
       *done_byte += tosend;
     }
 
-    if (*done_byte == *end)
+    if (*done_byte == *end) {
       prev_end = *end;
+    }
 
     // move to next Range if done one
     // ignore bad Range: _done_byte -1, _end -1
@@ -921,8 +930,9 @@ RangeTransform::transform_to_range()
 
     // When we need to read and there is nothing available
     avail = reader->read_avail();
-    if (avail == 0)
+    if (avail == 0) {
       break;
+    }
   }
 
   m_output_vio->reenable();
@@ -947,8 +957,9 @@ RangeTransform::add_boundary(bool end)
   m_done += m_output_buf->write("--", 2);
   m_done += m_output_buf->write(bound, sizeof(bound) - 1);
 
-  if (end)
+  if (end) {
     m_done += m_output_buf->write("--", 2);
+  }
 
   m_done += m_output_buf->write("\r\n", 2);
 }
@@ -966,16 +977,18 @@ RangeTransform::add_sub_header(int index)
   int len;
 
   m_done += m_output_buf->write(cont_type, sizeof(cont_type) - 1);
-  if (m_content_type)
+  if (m_content_type) {
     m_done += m_output_buf->write(m_content_type, m_content_type_len);
+  }
   m_done += m_output_buf->write("\r\n", 2);
   m_done += m_output_buf->write(cont_range, sizeof(cont_range) - 1);
 
   snprintf(numbers, sizeof(numbers), "%" PRId64 "-%" PRId64 "/%" PRId64 "", m_ranges[index]._start, m_ranges[index]._end,
            m_output_cl);
   len = strlen(numbers);
-  if (len < RANGE_NUMBERS_LENGTH)
+  if (len < RANGE_NUMBERS_LENGTH) {
     m_done += m_output_buf->write(numbers, len);
+  }
   m_done += m_output_buf->write("\r\n\r\n", 4);
 }
 
@@ -1005,8 +1018,9 @@ RangeTransform::change_response_header()
     // set the right Content-Type for multiple entry Range
     field = m_transform_resp->field_find(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE);
 
-    if (field != NULL)
+    if (field != NULL) {
       m_transform_resp->field_delete(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE);
+    }
 
     field = m_transform_resp->field_create(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE);
     field->value_append(m_transform_resp->m_heap, m_transform_resp->m_mime, range_type, sizeof(range_type) - 1);

--- a/proxy/congest/Congestion.cc
+++ b/proxy/congest/Congestion.cc
@@ -135,8 +135,9 @@ CongestionControlRecord::validate()
     return error;                                                                                 \
   }
 
-  if (error_page == NULL)
+  if (error_page == NULL) {
     error_page = ats_strdup(DEFAULT_error_page);
+  }
   if (max_connection_failures >= CONG_RULE_MAX_max_connection_failures ||
       (max_connection_failures <= 0 && max_connection_failures != CONG_RULE_ULIMITED_max_connection_failures)) {
     config_parse_error error("line %d: invalid %s = %d not in [1, %d) range", line_num, "max_connection_failures",
@@ -221,8 +222,9 @@ CongestionControlRecord::Init(matcher_line *line_info)
       rank += 2;
       // port will be used in the ControlBase;
       continue;
-    } else
+    } else {
       continue;
+    }
     // Consume the label/value pair we used
     line_info->line[0][i] = NULL;
     line_info->num_el--;
@@ -259,12 +261,15 @@ CongestionControlRecord::UpdateMatch(CongestionControlRule *pRule, RequestData *
       CongestionEntry *entry = dynamic_cast<CongestionEntry *>(rdata);
       if (entry) {
         // Enforce the same port and prefix
-        if (port != 0 && port != entry->pRecord->port)
+        if (port != 0 && port != entry->pRecord->port) {
           return;
-        if (prefix != NULL && entry->pRecord->prefix == NULL)
+        }
+        if (prefix != NULL && entry->pRecord->prefix == NULL) {
           return;
-        if (prefix != NULL && strncmp(prefix, entry->pRecord->prefix, prefix_len))
+        }
+        if (prefix != NULL && strncmp(prefix, entry->pRecord->prefix, prefix_len)) {
           return;
+        }
       } else {
         HttpRequestData *h = dynamic_cast<HttpRequestData *>(rdata);
         if (h && !this->CheckModifiers(h)) {
@@ -429,10 +434,11 @@ make_key(char *hostname, int len, sockaddr const *ip, CongestionControlRecord *r
   INK_MD5 md5;
   INK_DIGEST_CTX ctx;
   ink_code_incr_md5_init(&ctx);
-  if (record->congestion_scheme == PER_HOST && len > 0)
+  if (record->congestion_scheme == PER_HOST && len > 0) {
     ink_code_incr_md5_update(&ctx, hostname, len);
-  else
+  } else {
     ink_code_incr_md5_update(&ctx, reinterpret_cast<char const *>(ats_ip_addr8_cast(ip)), ats_ip_addr_size(ip));
+  }
   if (record->port != 0) {
     unsigned short p = record->port;
     p                = htons(p);
@@ -453,10 +459,11 @@ make_key(char *hostname, int len, sockaddr const *ip, char *prefix, int prelen, 
   INK_MD5 md5;
   INK_DIGEST_CTX ctx;
   ink_code_incr_md5_init(&ctx);
-  if (hostname && len > 0)
+  if (hostname && len > 0) {
     ink_code_incr_md5_update(&ctx, hostname, len);
-  else
+  } else {
     ink_code_incr_md5_update(&ctx, reinterpret_cast<char const *>(ats_ip_addr8_cast(ip)), ats_ip_addr_size(ip));
+  }
   if (port != 0) {
     unsigned short p = port;
     p                = htons(p);
@@ -477,9 +484,10 @@ void
 FailHistory::init(int window)
 {
   bin_len = (window + CONG_HIST_ENTRIES) / CONG_HIST_ENTRIES;
-  if (bin_len <= 0)
+  if (bin_len <= 0) {
     bin_len = 1;
-  length    = bin_len * CONG_HIST_ENTRIES;
+  }
+  length = bin_len * CONG_HIST_ENTRIES;
   for (int i = 0; i < CONG_HIST_ENTRIES; i++) {
     bins[i] = 0;
   }
@@ -505,8 +513,9 @@ FailHistory::init_event(long t, int n)
 int
 FailHistory::regist_event(long t, int n)
 {
-  if (t < start)
+  if (t < start) {
     return events;
+  }
   if (t > last_event + length) {
     init_event(t, n);
     return events;
@@ -517,16 +526,18 @@ FailHistory::regist_event(long t, int n)
     do {
       start += bin_len;
       cur_index++;
-      if (cur_index == CONG_HIST_ENTRIES)
+      if (cur_index == CONG_HIST_ENTRIES) {
         cur_index = 0;
+      }
       events -= bins[cur_index];
       bins[cur_index] = 0;
     } while (start + length < t);
     bins[cur_index] = n;
   }
   events += n;
-  if (last_event < t)
+  if (last_event < t) {
     last_event = t;
+  }
   return events;
 }
 
@@ -558,8 +569,9 @@ CongestionEntry::CongestionEntry(const char *hostname, sockaddr const *ip, Conge
 void
 CongestionEntry::init(CongestionControlRecord *rule)
 {
-  if (pRecord)
+  if (pRecord) {
     pRecord->put();
+  }
   rule->get();
   pRecord = rule;
   clearFailHistory();
@@ -681,8 +693,9 @@ CongestionEntry::sprint(char *buf, int buflen, int format)
 void
 CongestionEntry::failed_at(ink_hrtime t)
 {
-  if (pRecord->max_connection_failures == -1)
+  if (pRecord->max_connection_failures == -1) {
     return;
+  }
   // long time = ink_hrtime_to_sec(t);
   long time = t;
   Debug("congestion_control", "failed_at: %ld", time);

--- a/proxy/congest/CongestionDB.cc
+++ b/proxy/congest/CongestionDB.cc
@@ -169,8 +169,9 @@ CongestionDB::addRecord(uint64_t key, CongestionEntry *pEntry)
   if (lock.is_locked()) {
     RunTodoList(part_num(key));
     CongestionEntry *tmp = insert_entry(key, pEntry);
-    if (tmp)
+    if (tmp) {
       tmp->put();
+    }
   } else {
     CongestRequestParam *param = CongestRequestParamAllocator.alloc();
     param->m_op                = CongestRequestParam::ADD_RECORD;
@@ -214,8 +215,9 @@ CongestionDB::removeRecord(uint64_t key)
   if (lock.is_locked()) {
     RunTodoList(part_num(key));
     tmp = remove_entry(key);
-    if (tmp)
+    if (tmp) {
       tmp->put();
+    }
   } else {
     CongestRequestParam *param = CongestRequestParamAllocator.alloc();
     param->m_op                = CongestRequestParam::REMOVE_RECORD;
@@ -249,8 +251,9 @@ CongestionDB::process(int buckId, CongestRequestParam *param)
   }
   case CongestRequestParam::REMOVE_RECORD:
     pEntry = remove_entry(param->m_key);
-    if (pEntry)
+    if (pEntry) {
       pEntry->put();
+    }
     break;
   case CongestRequestParam::REVALIDATE_BUCKET:
     revalidateBucket(buckId);
@@ -293,8 +296,9 @@ CongestionDB::revalidateBucket(int buckId)
       // the next entry has been moved to the current pos
       // because of the remove_entry
       cur = cur_entry(buckId, &it);
-    } else
+    } else {
       cur = next_entry(buckId, &it);
+    }
   }
 }
 
@@ -306,8 +310,9 @@ int
 CongestionDBCont::GC(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
 {
   if (congestionControlEnabled == 1 || congestionControlEnabled == 2) {
-    if (theCongestionDB == NULL)
+    if (theCongestionDB == NULL) {
       goto Ldone;
+    }
     for (; CDBC_pid < theCongestionDB->getSize(); CDBC_pid++) {
       ProxyMutex *bucket_mutex = theCongestionDB->lock_for_key(CDBC_pid);
       {
@@ -454,14 +459,16 @@ revalidateCongestionDB()
 Action *
 get_congest_entry(Continuation *cont, HttpRequestData *data, CongestionEntry **ppEntry)
 {
-  if (congestionControlEnabled != 1 && congestionControlEnabled != 2)
+  if (congestionControlEnabled != 1 && congestionControlEnabled != 2) {
     return ACTION_RESULT_DONE;
+  }
   Debug("congestion_control", "congestion control get_congest_entry start");
 
   CongestionControlRecord *p = CongestionControlled(data);
   Debug("congestion_control", "Control Matcher matched rule_num %d", p == NULL ? -1 : p->line_num);
-  if (p == NULL)
+  if (p == NULL) {
     return ACTION_RESULT_DONE;
+  }
   // if the fail_window <= 0 and the max_connection == -1, then no congestion control
   if (p->max_connection_failures <= 0 && p->max_connection < 0) {
     return ACTION_RESULT_DONE;
@@ -507,8 +514,9 @@ get_congest_entry(Continuation *cont, HttpRequestData *data, CongestionEntry **p
 Action *
 get_congest_list(Continuation *cont, MIOBuffer *buffer, int format)
 {
-  if (theCongestionDB == NULL || (congestionControlEnabled != 1 && congestionControlEnabled != 2))
+  if (theCongestionDB == NULL || (congestionControlEnabled != 1 && congestionControlEnabled != 2)) {
     return ACTION_RESULT_DONE;
+  }
   for (int i = 0; i < theCongestionDB->getSize(); i++) {
     ProxyMutex *bucket_mutex = theCongestionDB->lock_for_key(i);
     {

--- a/proxy/congest/CongestionTest.cc
+++ b/proxy/congest/CongestionTest.cc
@@ -49,16 +49,18 @@ EXCLUSIVE_REGRESSION_TEST(Congestion_HashTable)(RegressionTest *t, int /* atype 
   rprintf(t, "adding data into the hash table .", count);
   for (i = 1; i <= count; i++) {
     htable->insert_entry(i, i);
-    if (i % (count / 50) == 0)
+    if (i % (count / 50) == 0) {
       fprintf(stderr, ".");
+    }
   }
   fprintf(stderr, "done\n");
   rprintf(t, "%d data added into the hash table\n", count);
   rprintf(t, "verifying the content");
   for (i = 1; i <= count; i++) {
     long data = htable->lookup_entry(i);
-    if (i % (count / 50) == 0)
+    if (i % (count / 50) == 0) {
       fprintf(stderr, ".");
+    }
     if (data != i) {
       rprintf(t, "verify content failed: key(%d) data(%d)\n", i, data);
       *pstatus = REGRESSION_TEST_FAILED;
@@ -71,8 +73,9 @@ EXCLUSIVE_REGRESSION_TEST(Congestion_HashTable)(RegressionTest *t, int /* atype 
   rprintf(t, "removing data.");
   for (i = 1; i < count / 2; i++) {
     htable->remove_entry(i * 2);
-    if (i % (count / 50) == 0)
+    if (i % (count / 50) == 0) {
       fprintf(stderr, ".");
+    }
     removed_count++;
   }
   fprintf(stderr, "done\n");
@@ -93,8 +96,9 @@ EXCLUSIVE_REGRESSION_TEST(Congestion_HashTable)(RegressionTest *t, int /* atype 
       delete htable;
       return;
     }
-    if (i % (count / 50) == 0)
+    if (i % (count / 50) == 0) {
       fprintf(stderr, ".");
+    }
   }
   fprintf(stderr, "done\n");
 
@@ -105,15 +109,17 @@ EXCLUSIVE_REGRESSION_TEST(Congestion_HashTable)(RegressionTest *t, int /* atype 
     int data = htable->first_entry(j, &it);
     while (data > 0) {
       new_count++;
-      if (new_count % (count / 25) == 0)
+      if (new_count % (count / 25) == 0) {
         fprintf(stderr, ".");
+      }
 
       if (new_count % 2 == 0) {
         htable->remove_entry(j, &it);
         data = htable->cur_entry(j, &it);
         removed_count++;
-      } else
+      } else {
         data = htable->next_entry(j, &it);
+      }
     }
   }
   fprintf(stderr, "done\n");
@@ -124,8 +130,9 @@ EXCLUSIVE_REGRESSION_TEST(Congestion_HashTable)(RegressionTest *t, int /* atype 
     int data = htable->first_entry(j, &it);
     while (data > 0) {
       new_count--;
-      if (new_count % (count / 25) == 0)
+      if (new_count % (count / 25) == 0) {
         fprintf(stderr, ".");
+      }
       data = htable->next_entry(j, &it);
       if (data != htable->lookup_entry(data)) {
         rprintf(t, "verify content failed: key(%d) data(%d)\n", data, htable->lookup_entry(data));
@@ -150,8 +157,9 @@ EXCLUSIVE_REGRESSION_TEST(Congestion_HashTable)(RegressionTest *t, int /* atype 
     int data = htable->first_entry(j, &it);
     while (data > 0) {
       new_count--;
-      if (new_count % (count / 25) == 0)
+      if (new_count % (count / 25) == 0) {
         fprintf(stderr, ".");
+      }
       htable->remove_entry(j, &it);
       data = htable->cur_entry(j, &it);
     }
@@ -287,8 +295,9 @@ CCFailHistoryTestCont::init_events()
 int
 CCFailHistoryTestCont::schedule_event(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
 {
-  if (failEvents == NULL)
+  if (failEvents == NULL) {
     return EVENT_DONE;
+  }
   CCFailHistoryTestCont::FailEvents *f = (CCFailHistoryTestCont::FailEvents *)ink_atomiclist_pop(failEvents);
   if (f != NULL) {
     entry->failed_at(f->time);
@@ -316,8 +325,9 @@ CCFailHistoryTestCont::check_history(bool print)
     entry->sprint(buf, 1024, 10);
     rprintf(test, "%s", buf);
   }
-  if (test_mode == CCFailHistoryTestCont::SIMPLE_TEST && entry->m_history.events == 65536)
+  if (test_mode == CCFailHistoryTestCont::SIMPLE_TEST && entry->m_history.events == 65536) {
     return 0;
+  }
   return 0;
 }
 
@@ -327,8 +337,9 @@ CCFailHistoryTestCont::mainEvent(int /* event ATS_UNUSED */, Event * /* e ATS_UN
   test_mode = CCFailHistoryTestCont::SIMPLE_TEST;
   init_events();
   entry->init(rule->pRecord);
-  while (schedule_event(0, NULL) == EVENT_CONT)
+  while (schedule_event(0, NULL) == EVENT_CONT) {
     ;
+  }
   if (check_history(true) == 0) {
     final_status = REGRESSION_TEST_PASSED;
   } else {
@@ -339,8 +350,9 @@ CCFailHistoryTestCont::mainEvent(int /* event ATS_UNUSED */, Event * /* e ATS_UN
   test_mode = CCFailHistoryTestCont::ROTATING_TEST;
   init_events();
   entry->init(rule->pRecord);
-  while (schedule_event(0, NULL) == EVENT_CONT)
+  while (schedule_event(0, NULL) == EVENT_CONT) {
     ;
+  }
   if (check_history(true) == 0) {
     final_status = REGRESSION_TEST_PASSED;
   } else {
@@ -397,8 +409,9 @@ struct CCCongestionDBTestCont : public Continuation {
       db->removeAllRecords();
       delete db;
     }
-    if (rule)
+    if (rule) {
       delete rule;
+    }
   }
 };
 
@@ -419,10 +432,11 @@ void
 CCCongestionDBTestCont::init()
 {
   // create/clear db
-  if (!db)
+  if (!db) {
     db = new CongestionDB(dbsize / MT_HASHTABLE_PARTITIONS);
-  else
+  } else {
     db->removeAllRecords();
+  }
   if (!rule) {
     rule                          = new CongestionControlRecord;
     rule->fail_window             = 300;
@@ -435,8 +449,9 @@ int
 CCCongestionDBTestCont::get_congest_list()
 {
   int cnt = 0;
-  if (db == NULL)
+  if (db == NULL) {
     return 0;
+  }
   for (int i = 0; i < db->getSize(); i++) {
     db->RunTodoList(i);
     char buf[1024];
@@ -465,8 +480,9 @@ CCCongestionDBTestCont::mainEvent(int /* event ATS_UNUSED */, Event * /* e ATS_U
   rprintf(test, "Add %d records into the db", dbsize);
 
   for (i = 0; i < dbsize; i++) {
-    if (i % (dbsize / 25) == 0)
+    if (i % (dbsize / 25) == 0) {
       fprintf(stderr, ".");
+    }
 
     IpEndpoint ip;
     ats_ip4_set(&ip, i + 255);
@@ -484,8 +500,9 @@ CCCongestionDBTestCont::mainEvent(int /* event ATS_UNUSED */, Event * /* e ATS_U
 
   rprintf(test, "Add %d records into the db", to_add);
   for (i = 0; i < to_add; i++) {
-    if (i % (to_add / 25) == 0)
+    if (i % (to_add / 25) == 0) {
       fprintf(stderr, ".");
+    }
 
     IpEndpoint ip;
     ats_ip4_set(&ip, i + 255);
@@ -502,8 +519,9 @@ CCCongestionDBTestCont::mainEvent(int /* event ATS_UNUSED */, Event * /* e ATS_U
   rprintf(test, "Add %d congested records into the db", to_add);
 
   for (i = 0; i < to_add; i++) {
-    if (i % (to_add / 25) == 0)
+    if (i % (to_add / 25) == 0) {
       fprintf(stderr, ".");
+    }
 
     IpEndpoint ip;
     ats_ip4_set(&ip, i + 255);

--- a/proxy/hdrs/HTTP.cc
+++ b/proxy/hdrs/HTTP.cc
@@ -358,8 +358,9 @@ http_hdr_copy_onto(HTTPHdrImpl *s_hh, HdrHeap *s_heap, HTTPHdrImpl *d_hh, HdrHea
   }
 
   mime_hdr_copy_onto(s_mh, s_heap, d_mh, d_heap, false);
-  if (inherit_strs)
+  if (inherit_strs) {
     d_heap->inherit_string_heaps(s_heap);
+  }
 }
 
 /*-------------------------------------------------------------------------
@@ -436,8 +437,9 @@ http_hdr_print(HdrHeap *heap, HTTPHdrImpl *hdr, char *buf, int bufsize, int *buf
   ink_assert((hdr->m_polarity == HTTP_TYPE_REQUEST) || (hdr->m_polarity == HTTP_TYPE_RESPONSE));
 
   if (hdr->m_polarity == HTTP_TYPE_REQUEST) {
-    if (hdr->u.req.m_ptr_method == NULL)
+    if (hdr->u.req.m_ptr_method == NULL) {
       return 1;
+    }
 
     if ((buf != NULL) && (*dumpoffset == 0) && (bufsize - *bufindex >= hdr->u.req.m_len_method + 1)) { // fastpath
 
@@ -574,18 +576,21 @@ http_hdr_describe(HdrHeapObjImpl *raw, bool recurse)
           obj->u.req.m_url_impl, obj->u.req.m_len_method, (obj->u.req.m_ptr_method ? obj->u.req.m_ptr_method : "NULL"),
           obj->u.req.m_len_method, obj->m_fields_impl);
     if (recurse) {
-      if (obj->u.req.m_url_impl)
+      if (obj->u.req.m_url_impl) {
         obj_describe(obj->u.req.m_url_impl, recurse);
-      if (obj->m_fields_impl)
+      }
+      if (obj->m_fields_impl) {
         obj_describe(obj->m_fields_impl, recurse);
+      }
     }
   } else {
     Debug("http", "[TYPE: RSP, V: %04X, STATUS: %d, REASON: \"%.*s\", REASON_LEN: %d, FIELDS: %p]", obj->m_version,
           obj->u.resp.m_status, obj->u.resp.m_len_reason, (obj->u.resp.m_ptr_reason ? obj->u.resp.m_ptr_reason : "NULL"),
           obj->u.resp.m_len_reason, obj->m_fields_impl);
     if (recurse) {
-      if (obj->m_fields_impl)
+      if (obj->m_fields_impl) {
         obj_describe(obj->m_fields_impl, recurse);
+      }
     }
   }
 }
@@ -898,18 +903,22 @@ http_parser_parse_req(HTTPParser *parser, HdrHeap *heap, HTTPHdrImpl *hh, const 
     hh->m_polarity = HTTP_TYPE_REQUEST;
 
     // Make sure the line is not longer than 64K
-    if (scanner->m_line_length >= UINT16_MAX)
+    if (scanner->m_line_length >= UINT16_MAX) {
       return PARSE_ERROR;
+    }
 
     err = mime_scanner_get(scanner, start, real_end, &line_start, &end, &line_is_real, eof, MIME_SCANNER_TYPE_LINE);
-    if (err < 0)
+    if (err < 0) {
       return err;
+    }
     // We have to get a request line.  If we get parse done here,
     //   that meas we got an empty request
-    if (err == PARSE_DONE)
+    if (err == PARSE_DONE) {
       return PARSE_ERROR;
-    if (err == PARSE_CONT)
+    }
+    if (err == PARSE_CONT) {
       return err;
+    }
 
     cur = line_start;
     ink_assert((end - cur) >= 0);
@@ -920,18 +929,23 @@ http_parser_parse_req(HTTPParser *parser, HdrHeap *heap, HTTPHdrImpl *hh, const 
 #if (ENABLE_PARSER_FAST_PATHS)
     // first try fast path
     if (end - cur >= 16) {
-      if (((cur[0] ^ 'G') | (cur[1] ^ 'E') | (cur[2] ^ 'T')) != 0)
+      if (((cur[0] ^ 'G') | (cur[1] ^ 'E') | (cur[2] ^ 'T')) != 0) {
         goto slow_case;
+      }
       if (((end[-10] ^ 'H') | (end[-9] ^ 'T') | (end[-8] ^ 'T') | (end[-7] ^ 'P') | (end[-6] ^ '/') | (end[-4] ^ '.') |
-           (end[-2] ^ '\r') | (end[-1] ^ '\n')) != 0)
+           (end[-2] ^ '\r') | (end[-1] ^ '\n')) != 0) {
         goto slow_case;
-      if (!(is_digit(end[-5]) && is_digit(end[-3])))
+      }
+      if (!(is_digit(end[-5]) && is_digit(end[-3]))) {
         goto slow_case;
+      }
       if (!(ParseRules::is_space(cur[3]) && (!ParseRules::is_space(cur[4])) && (!ParseRules::is_space(end[-12])) &&
-            ParseRules::is_space(end[-11])))
+            ParseRules::is_space(end[-11]))) {
         goto slow_case;
-      if (&(cur[4]) >= &(end[-11]))
+      }
+      if (&(cur[4]) >= &(end[-11])) {
         goto slow_case;
+      }
 
       int32_t version = HTTP_VERSION(end[-5] - '0', end[-3] - '0');
 
@@ -940,18 +954,21 @@ http_parser_parse_req(HTTPParser *parser, HdrHeap *heap, HTTPHdrImpl *hh, const 
       url       = hh->u.req.m_url_impl;
       url_start = &(cur[4]);
       err       = ::url_parse(heap, url, &url_start, &(end[-11]), must_copy_strings, strict_uri_parsing);
-      if (err < 0)
+      if (err < 0) {
         return err;
+      }
       http_hdr_version_set(hh, version);
 
       end                    = real_end;
       parser->m_parsing_http = false;
-      if (version == HTTP_VERSION(0, 9))
+      if (version == HTTP_VERSION(0, 9)) {
         return PARSE_ERROR;
+      }
 
       MIMEParseResult ret = mime_parser_parse(&parser->m_mime_parser, heap, hh->m_fields_impl, start, end, must_copy_strings, eof);
-      if (ret == PARSE_DONE)
+      if (ret == PARSE_DONE) {
         ret = validate_hdr_host(hh); // if we're done with the main parse, check HOST.
+      }
       return ret;
     }
 #endif
@@ -968,8 +985,9 @@ http_parser_parse_req(HTTPParser *parser, HdrHeap *heap, HTTPHdrImpl *hh, const 
 
     if (ParseRules::is_cr(*cur))
       GETNEXT(done);
-    if (ParseRules::is_lf(*cur))
+    if (ParseRules::is_lf(*cur)) {
       goto start;
+    }
 
   parse_method1:
 
@@ -1061,22 +1079,25 @@ http_parser_parse_req(HTTPParser *parser, HdrHeap *heap, HTTPHdrImpl *hh, const 
     url_end += 1;
 
   done:
-    if (!method_start || !method_end)
+    if (!method_start || !method_end) {
       return PARSE_ERROR;
+    }
 
     int method_wks_idx = hdrtoken_tokenize(method_start, (int)(method_end - method_start));
     http_hdr_method_set(heap, hh, method_start, method_wks_idx, (int)(method_end - method_start), must_copy_strings);
 
-    if (!url_start || !url_end)
+    if (!url_start || !url_end) {
       return PARSE_ERROR;
+    }
 
     ink_assert(hh->u.req.m_url_impl != NULL);
 
     url = hh->u.req.m_url_impl;
     err = ::url_parse(heap, url, &url_start, url_end, must_copy_strings, strict_uri_parsing);
 
-    if (err < 0)
+    if (err < 0) {
       return err;
+    }
 
     int32_t version;
     if (version_start && version_end) {
@@ -1095,8 +1116,9 @@ http_parser_parse_req(HTTPParser *parser, HdrHeap *heap, HTTPHdrImpl *hh, const 
     parser->m_parsing_http = false;
 
     MIMEParseResult ret = mime_parser_parse(&parser->m_mime_parser, heap, hh->m_fields_impl, start, end, must_copy_strings, eof);
-    if (ret == PARSE_DONE)
+    if (ret == PARSE_DONE) {
       ret = validate_hdr_host(hh); // if we're done with the main parse, check HOST.
+    }
     return ret;
   }
 
@@ -1117,17 +1139,21 @@ validate_hdr_host(HTTPHdrImpl *hh)
       ts::ConstBuffer addr, port, rest, host(host_val, host_len);
       if (0 == ats_ip_parse(host, &addr, &port, &rest)) {
         if (port) {
-          if (port.size() > 5)
+          if (port.size() > 5) {
             return PARSE_ERROR;
+          }
           int port_i = ink_atoi(port.data(), port.size());
-          if (port_i >= 65536 || port_i <= 0)
+          if (port_i >= 65536 || port_i <= 0) {
             return PARSE_ERROR;
+          }
         }
-        if (!validate_host_name(addr))
+        if (!validate_host_name(addr)) {
           return PARSE_ERROR;
+        }
         while (rest && PARSE_DONE == ret) {
-          if (!ParseRules::is_ws(*rest))
+          if (!ParseRules::is_ws(*rest)) {
             return PARSE_ERROR;
+          }
           ++rest;
         }
       } else {
@@ -1167,14 +1193,17 @@ http_parser_parse_resp(HTTPParser *parser, HdrHeap *heap, HTTPHdrImpl *hh, const
     hh->m_polarity = HTTP_TYPE_RESPONSE;
 
     // Make sure the line is not longer than 64K
-    if (scanner->m_line_length >= UINT16_MAX)
+    if (scanner->m_line_length >= UINT16_MAX) {
       return PARSE_ERROR;
+    }
 
     err = mime_scanner_get(scanner, start, real_end, &line_start, &end, &line_is_real, eof, MIME_SCANNER_TYPE_LINE);
-    if (err < 0)
+    if (err < 0) {
       return err;
-    if ((err == PARSE_DONE) || (err == PARSE_CONT))
+    }
+    if ((err == PARSE_DONE) || (err == PARSE_CONT)) {
       return err;
+    }
 
     cur = line_start;
     ink_assert((end - cur) >= 0);
@@ -1194,8 +1223,9 @@ http_parser_parse_resp(HTTPParser *parser, HdrHeap *heap, HTTPHdrImpl *hh, const
 
       reason_start = &(cur[13]);
       reason_end   = end - 1;
-      while ((reason_end > reason_start + 1) && (ParseRules::is_space(reason_end[-1])))
+      while ((reason_end > reason_start + 1) && (ParseRules::is_space(reason_end[-1]))) {
         --reason_end;
+      }
 
       int32_t version   = HTTP_VERSION(cur[5] - '0', cur[7] - '0');
       HTTPStatus status = (HTTPStatus)((cur[9] - '0') * 100 + (cur[10] - '0') * 10 + (cur[11] - '0'));
@@ -1294,10 +1324,11 @@ http_parser_parse_resp(HTTPParser *parser, HdrHeap *heap, HTTPHdrImpl *hh, const
 
   eoh:
     *start = old_start;
-    if (parser->m_allow_non_http)
+    if (parser->m_allow_non_http) {
       return PARSE_DONE;
-    else
+    } else {
       return PARSE_ERROR;
+    }
 
   done:
     if (!version_start || !version_end) {
@@ -1313,8 +1344,9 @@ http_parser_parse_resp(HTTPParser *parser, HdrHeap *heap, HTTPHdrImpl *hh, const
 
     http_hdr_version_set(hh, version);
 
-    if (status_start && status_end)
+    if (status_start && status_end) {
       http_hdr_status_set(hh, http_parse_status(status_start, status_end));
+    }
 
     if (reason_start && reason_end) {
       http_hdr_reason_set(heap, hh, reason_start, (int)(reason_end - reason_start), must_copy_strings);
@@ -1531,8 +1563,9 @@ HTTPHdr::_fill_target_cache() const
   } else if (0 != (m_host_mime = const_cast<HTTPHdr *>(this)->get_host_port_values(0, &m_host_length, &port_ptr, 0))) {
     m_port = 0;
     if (port_ptr) {
-      for (; is_digit(*port_ptr); ++port_ptr)
+      for (; is_digit(*port_ptr); ++port_ptr) {
         m_port = m_port * 10 + *port_ptr - '0';
+      }
     }
     m_port_in_header = (0 != m_port);
     m_port           = url_canonicalize_port(url->m_url_impl->m_url_type, m_port);
@@ -1551,8 +1584,9 @@ HTTPHdr::set_url_target_from_host_field(URL *url)
     // is already there.
     if (!m_target_in_url && m_host_mime && m_host_length) {
       m_url_cached.host_set(m_host_mime->m_ptr_value, m_host_length);
-      if (m_port_in_header)
+      if (m_port_in_header) {
         m_url_cached.port_set(m_port);
+      }
       m_target_in_url = true; // it's there now.
     }
   } else {
@@ -1560,8 +1594,9 @@ HTTPHdr::set_url_target_from_host_field(URL *url)
     char const *host = NULL;
     host             = host_get(&host_len);
     url->host_set(host, host_len);
-    if (m_port_in_header)
+    if (m_port_in_header) {
       url->port_set(m_port);
+    }
   }
 }
 
@@ -1857,8 +1892,9 @@ HTTPCacheAlt::copy_frag_offsets_from(HTTPCacheAlt *src)
          So we'll do it for now. The relative overhead is tiny.
       */
       int bcount = HTTPCacheAlt::N_INTEGRAL_FRAG_OFFSETS * 2;
-      while (bcount < m_frag_offset_count)
+      while (bcount < m_frag_offset_count) {
         bcount *= 2;
+      }
       m_frag_offsets = static_cast<FragOffset *>(ats_malloc(sizeof(FragOffset) * bcount));
     } else {
       m_frag_offsets = m_integral_frag_offsets;
@@ -1889,8 +1925,9 @@ HTTPInfo::copy(HTTPInfo *hi)
 void
 HTTPInfo::copy_frag_offsets_from(HTTPInfo *src)
 {
-  if (m_alt && src->m_alt)
+  if (m_alt && src->m_alt) {
     m_alt->copy_frag_offsets_from(src->m_alt);
+  }
 }
 
 int
@@ -2023,8 +2060,9 @@ HTTPInfo::unmarshal(char *buf, int len, RefCountObj *block_ref)
     // future.
     int bcount = HTTPCacheAlt::N_INTEGRAL_FRAG_OFFSETS * 2;
 
-    while (bcount < alt->m_frag_offset_count)
+    while (bcount < alt->m_frag_offset_count) {
       bcount *= 2;
+    }
     alt->m_frag_offsets =
       static_cast<FragOffset *>(ats_malloc(bcount * sizeof(FragOffset))); // WRONG - must round up to next power of 2.
     memcpy(alt->m_frag_offsets, alt->m_integral_frag_offsets, sizeof(alt->m_integral_frag_offsets));
@@ -2184,8 +2222,9 @@ HTTPInfo::push_frag_offset(FragOffset offset)
     // size (power of 2).
     FragOffset *nf = static_cast<FragOffset *>(ats_malloc(sizeof(FragOffset) * (m_alt->m_frag_offset_count * 2)));
     memcpy(nf, m_alt->m_frag_offsets, sizeof(FragOffset) * m_alt->m_frag_offset_count);
-    if (m_alt->m_frag_offsets != m_alt->m_integral_frag_offsets)
+    if (m_alt->m_frag_offsets != m_alt->m_integral_frag_offsets) {
       ats_free(m_alt->m_frag_offsets);
+    }
     m_alt->m_frag_offsets = nf;
   }
 

--- a/proxy/hdrs/HdrHeap.cc
+++ b/proxy/hdrs/HdrHeap.cc
@@ -176,8 +176,9 @@ HdrHeap::destroy()
   }
 
   m_read_write_heap = NULL;
-  for (int i                        = 0; i < HDR_BUF_RONLY_HEAPS; i++)
+  for (int i = 0; i < HDR_BUF_RONLY_HEAPS; i++) {
     m_ronly_heap[i].m_ref_count_ptr = NULL;
+  }
 
   if (m_size == HDR_HEAP_DEFAULT_SIZE) {
     THREAD_FREE(this, hdrHeapAllocator, this_thread());
@@ -296,8 +297,9 @@ FAILED:
 char *
 HdrHeap::expand_str(const char *old_str, int old_len, int new_len)
 {
-  if (m_read_write_heap && m_read_write_heap->contains(old_str))
+  if (m_read_write_heap && m_read_write_heap->contains(old_str)) {
     return m_read_write_heap->expand((char *)old_str, old_len, new_len);
+  }
 
   return NULL;
 }
@@ -675,8 +677,9 @@ HdrHeap::marshal(char *buf, int len)
   marshal_hdr->m_ronly_heap[0].m_heap_start = (char *)(intptr_t)marshal_hdr->m_size; // offset
   marshal_hdr->m_ronly_heap[0].m_ref_count_ptr.detach();
 
-  for (int i                                  = 1; i < HDR_BUF_RONLY_HEAPS; i++)
+  for (int i = 1; i < HDR_BUF_RONLY_HEAPS; i++) {
     marshal_hdr->m_ronly_heap[i].m_heap_start = NULL;
+  }
 
   // Next order of business is to copy over string heaps
   //   As we are copying over the string heaps, build
@@ -978,8 +981,9 @@ HdrHeap::attach_str_heap(char *h_start, int h_len, RefCountObj *h_ref_obj, int *
       //   read-only and the copy we are attaching from could be
       //   read-write and have expanded since the last time
       //   to was attached
-      if (h_len > m_ronly_heap[z].m_heap_len)
+      if (h_len > m_ronly_heap[z].m_heap_len) {
         m_ronly_heap[z].m_heap_len = h_len;
+      }
       return true;
     }
   }
@@ -1002,8 +1006,9 @@ void
 HdrHeap::inherit_string_heaps(const HdrHeap *inherit_from)
 {
   // if heaps are the same, this is a no-op
-  if (inherit_from == (const HdrHeap *)this)
+  if (inherit_from == (const HdrHeap *)this) {
     return;
+  }
 
   int index;
   int first_free       = HDR_BUF_RONLY_HEAPS; // default is out of array bounds

--- a/proxy/hdrs/HdrTest.cc
+++ b/proxy/hdrs/HdrTest.cc
@@ -402,8 +402,9 @@ HdrTest::test_url()
     const char *fail_text = NULL;
 
     if (old_length == new_length) {
-      if (memcmp(print_buf, strs[i], new_length) != 0)
+      if (memcmp(print_buf, strs[i], new_length) != 0) {
         fail_text = "URLS DIFFER";
+      }
     } else if (old_length == new_length - 1) {
       // Check to see if the difference is the trailing
       //   slash we add
@@ -504,8 +505,9 @@ HdrTest::test_mime()
   hdr.create(NULL);
   err = hdr.parse(&parser, &start, end, must_copy_strs, false);
 
-  if (err < 0)
+  if (err < 0) {
     return (failures_to_status("test_mime", 1));
+  }
 
   hdr.field_delete("not_there", 9);
   hdr.field_delete("accept", 6);
@@ -697,8 +699,9 @@ HdrTest::test_http_aux(const char *request, const char *response)
   printf("======== parsing\n\n");
   while (1) {
     err = req_hdr.parse_req(&parser, &start, end, true);
-    if (err != PARSE_CONT)
+    if (err != PARSE_CONT) {
       break;
+    }
   }
   if (err == PARSE_ERROR) {
     req_hdr.destroy();
@@ -737,8 +740,9 @@ HdrTest::test_http_aux(const char *request, const char *response)
 
   while (1) {
     err = rsp_hdr.parse_resp(&parser, &start, end, true);
-    if (err != PARSE_CONT)
+    if (err != PARSE_CONT) {
       break;
+    }
   }
   if (err == PARSE_ERROR) {
     req_hdr.destroy();
@@ -777,10 +781,11 @@ HdrTest::test_http_aux(const char *request, const char *response)
       // printf("test_header: tmp = %d  err = %d  bufindex = %d\n", tmp, err, bufindex);
       putchar('{');
       for (i = 0; i < bufindex - last_bufindex; i++) {
-        if (!iscntrl(buf[i]))
+        if (!iscntrl(buf[i])) {
           putchar(buf[i]);
-        else
+        } else {
           printf("\\%o", buf[i]);
+        }
       }
       putchar('}');
     } while (!err);
@@ -948,19 +953,22 @@ HdrTest::test_http_hdr_print_and_copy()
 
   for (i = 0; i < ntests; i++) {
     int status = test_http_hdr_print_and_copy_aux(i + 1, tests[i].req, tests[i].req_tgt, tests[i].rsp, tests[i].rsp_tgt);
-    if (status == 0)
+    if (status == 0) {
       ++failures;
+    }
 
     // Test for expected failures
     // parse with a '\0' in the header.  Should fail
     status = test_http_hdr_null_char(i + 1, tests[i].req, tests[i].req_tgt);
-    if (status == 0)
+    if (status == 0) {
       ++failures;
+    }
 
     // Parse with a CTL character in the method name.  Should fail
     status = test_http_hdr_ctl_char(i + 1, tests[i].req, tests[i].req_tgt);
-    if (status == 0)
+    if (status == 0) {
       ++failures;
+    }
   }
 
   return (failures_to_status("test_http_hdr_print_and_copy", failures));
@@ -1040,8 +1048,9 @@ HdrTest::test_http_hdr_copy_over_aux(int testnum, const char *request, const cha
 
   while (1) {
     err = req_hdr.parse_req(&parser, &start, end, true);
-    if (err != PARSE_CONT)
+    if (err != PARSE_CONT) {
       break;
+    }
   }
 
   if (err == PARSE_ERROR) {
@@ -1061,8 +1070,9 @@ HdrTest::test_http_hdr_copy_over_aux(int testnum, const char *request, const cha
 
   while (1) {
     err = resp_hdr.parse_resp(&parser, &start, end, true);
-    if (err != PARSE_CONT)
+    if (err != PARSE_CONT) {
       break;
+    }
   }
 
   if (err == PARSE_ERROR) {
@@ -1074,14 +1084,16 @@ HdrTest::test_http_hdr_copy_over_aux(int testnum, const char *request, const cha
   copy1.create(HTTP_TYPE_REQUEST);
   copy1.copy(&req_hdr);
   comp_str = comp_http_hdr(&req_hdr, &copy1);
-  if (comp_str)
+  if (comp_str) {
     goto done;
+  }
 
   copy2.create(HTTP_TYPE_RESPONSE);
   copy2.copy(&resp_hdr);
   comp_str = comp_http_hdr(&resp_hdr, &copy2);
-  if (comp_str)
+  if (comp_str) {
     goto done;
+  }
 
 // The APIs for copying headers uses memcpy() which can be unsafe for
 // overlapping memory areas. It's unclear to me why these tests were
@@ -1102,13 +1114,15 @@ HdrTest::test_http_hdr_copy_over_aux(int testnum, const char *request, const cha
   /*** (5) Gender bending copying ***/
   copy1.copy(&resp_hdr);
   comp_str = comp_http_hdr(&resp_hdr, &copy1);
-  if (comp_str)
+  if (comp_str) {
     goto done;
+  }
 
   copy2.copy(&req_hdr);
   comp_str = comp_http_hdr(&req_hdr, &copy2);
-  if (comp_str)
+  if (comp_str) {
     goto done;
+  }
 
 done:
   req_hdr.destroy();
@@ -1157,8 +1171,9 @@ HdrTest::test_http_hdr_null_char(int testnum, const char *request, const char * 
 
   while (1) {
     err = hdr.parse_req(&parser, &cpy_buf_ptr, cpy_buf_ptr + length, true);
-    if (err != PARSE_CONT)
+    if (err != PARSE_CONT) {
       break;
+    }
   }
   if (err != PARSE_ERROR) {
     printf("FAILED: (test #%d) no parse error parsing request with null char\n", testnum);
@@ -1198,8 +1213,9 @@ HdrTest::test_http_hdr_ctl_char(int testnum, const char *request, const char * /
 
   while (1) {
     err = hdr.parse_req(&parser, &cpy_buf_ptr, cpy_buf_ptr + strlen(start), true);
-    if (err != PARSE_CONT)
+    if (err != PARSE_CONT) {
       break;
+    }
   }
 
   if (err != PARSE_ERROR) {
@@ -1244,8 +1260,9 @@ HdrTest::test_http_hdr_print_and_copy_aux(int testnum, const char *request, cons
 
   while (1) {
     err = hdr.parse_req(&parser, &start, end, true);
-    if (err != PARSE_CONT)
+    if (err != PARSE_CONT) {
       break;
+    }
   }
 
   if (err == PARSE_ERROR) {
@@ -1317,8 +1334,9 @@ HdrTest::test_http_hdr_print_and_copy_aux(int testnum, const char *request, cons
 
   while (1) {
     err = hdr.parse_resp(&parser, &start, end, true);
-    if (err != PARSE_CONT)
+    if (err != PARSE_CONT) {
       break;
+    }
   }
 
   if (err == PARSE_ERROR) {
@@ -1576,8 +1594,9 @@ HdrTest::test_http_mutation()
 
   while (1) {
     err = resp_hdr.parse_resp(&parser, &start, end, true);
-    if (err != PARSE_CONT)
+    if (err != PARSE_CONT) {
       break;
+    }
   }
 
   printf("\n======== before mutation ==========\n\n");
@@ -2082,8 +2101,9 @@ HdrTest::test_parse_comma_list()
 
     for (j = 0; j < tests[i].count; j++) {
       Str *cell = list.get_idx(j);
-      if (cell != NULL)
+      if (cell != NULL) {
         offset = cell->str - tests[i].value;
+      }
 
       if (tests[i].pieces[j].offset == -1) // should not have a piece
       {
@@ -2120,13 +2140,15 @@ HdrTest::bri_box(const char *s)
 
   len = (int)strlen(s);
   printf("\n+-");
-  for (i = 0; i < len; i++)
+  for (i = 0; i < len; i++) {
     putchar('-');
+  }
   printf("-+\n");
   printf("| %s |\n", s);
   printf("+-");
-  for (i = 0; i < len; i++)
+  for (i = 0; i < len; i++) {
     putchar('-');
+  }
   printf("-+\n\n");
 }
 

--- a/proxy/hdrs/HdrToken.cc
+++ b/proxy/hdrs/HdrToken.cc
@@ -381,8 +381,9 @@ hdrtoken_hash_init()
     hdrtoken_hash_table[slot].hash = hash;
   }
 
-  if (num_collisions > 0)
+  if (num_collisions > 0) {
     abort();
+  }
 }
 
 /***********************************************************************
@@ -512,13 +513,15 @@ hdrtoken_tokenize_dfa(const char *string, int string_len, const char **wks_strin
 
   wks_idx = hdrtoken_strs_dfa->match(string, string_len);
 
-  if (wks_idx < 0)
+  if (wks_idx < 0) {
     wks_idx = -1;
+  }
   if (wks_string_out) {
-    if (wks_idx >= 0)
+    if (wks_idx >= 0) {
       *wks_string_out = hdrtoken_index_to_wks(wks_idx);
-    else
+    } else {
       *wks_string_out = NULL;
+    }
   }
   // printf("hdrtoken_tokenize_dfa(%d,*s) - return %d\n",string_len,string,wks_idx);
 
@@ -538,8 +541,9 @@ hdrtoken_tokenize(const char *string, int string_len, const char **wks_string_ou
 
   if (hdrtoken_is_wks(string)) {
     wks_idx = hdrtoken_wks_to_index(string);
-    if (wks_string_out)
+    if (wks_string_out) {
       *wks_string_out = string;
+    }
     return wks_idx;
   }
 
@@ -549,8 +553,9 @@ hdrtoken_tokenize(const char *string, int string_len, const char **wks_string_ou
   bucket = &(hdrtoken_hash_table[slot]);
   if ((bucket->wks != NULL) && (bucket->hash == hash) && (hdrtoken_wks_to_length(bucket->wks) == string_len)) {
     wks_idx = hdrtoken_wks_to_index(bucket->wks);
-    if (wks_string_out)
+    if (wks_string_out) {
       *wks_string_out = bucket->wks;
+    }
     return wks_idx;
   }
 

--- a/proxy/hdrs/HdrUtils.cc
+++ b/proxy/hdrs/HdrUtils.cc
@@ -66,11 +66,12 @@ skip_leading_whitespace:
 parse_value:
   // ink_assert((',' > '"') && (',' > ' ') && (',' > '\t'));
   // Cookie/Set-Cookie use ';' as the separator
-  if (m_separator == ',')
+  if (m_separator == ',') {
     while ((cur < end - 1) && (*cur > ',')) {
       last_data = cur;
       cur++;
     }
+  }
 
   if (*cur == m_separator) {
     goto done;

--- a/proxy/hdrs/HttpCompat.cc
+++ b/proxy/hdrs/HttpCompat.cc
@@ -43,8 +43,9 @@
 void
 HttpCompat::parse_tok_list(StrList *list, int trim_quotes, const char *string, char sep)
 {
-  if (string == NULL)
+  if (string == NULL) {
     return;
+  }
   HttpCompat::parse_tok_list(list, trim_quotes, string, (int)strlen(string), sep);
 }
 
@@ -56,8 +57,9 @@ HttpCompat::parse_tok_list(StrList *list, int trim_quotes, const char *string, i
   const char *s, *e, *l, *s_before_skipping_ws;
   int index, byte_length, hit_sep;
 
-  if ((string == NULL) || (list == NULL) || (sep == NUL))
+  if ((string == NULL) || (list == NULL) || (sep == NUL)) {
     return;
+  }
 
   s     = string;
   l     = s + len - 1;
@@ -73,8 +75,9 @@ HttpCompat::parse_tok_list(StrList *list, int trim_quotes, const char *string, i
     // a NUL, a character, or a double quote.               //
     //////////////////////////////////////////////////////////
 
-    while ((s <= l) && ParseRules::is_ws(*s))
+    while ((s <= l) && ParseRules::is_ws(*s)) {
       ++s; // skip whitespace
+    }
 
     //////////////////////////////////////////////////////////
     // if we are pointing at a separator, this was an empty //
@@ -96,8 +99,9 @@ HttpCompat::parse_tok_list(StrList *list, int trim_quotes, const char *string, i
     // or just exit.                                                //
     //////////////////////////////////////////////////////////////////
 
-    if (s > l)
+    if (s > l) {
       break;
+    }
 
 ///////////////////////////////////////////////////////////////////
 // we are pointing to the first character of a token now, either //
@@ -111,8 +115,9 @@ HttpCompat::parse_tok_list(StrList *list, int trim_quotes, const char *string, i
     if (*s == quot) {
       in_quote = 1;
       e        = s + 1; // start after quote
-      if (trim_quotes)
+      if (trim_quotes) {
         ++s; // trim starting quote
+      }
     } else {
       in_quote = 0;
       e        = s;
@@ -134,10 +139,12 @@ HttpCompat::parse_tok_list(StrList *list, int trim_quotes, const char *string, i
     hit_sep = (e <= l); // must have hit a separator if still inside string
 
     s_before_skipping_ws = e + 1; // where to start next time
-    while ((e > s) && ParseRules::is_ws(*(e - 1)))
+    while ((e > s) && ParseRules::is_ws(*(e - 1))) {
       --e; // eat trailing ws
-    if ((e > s) && (*(e - 1) == quot) && trim_quotes)
+    }
+    if ((e > s) && (*(e - 1) == quot) && trim_quotes) {
       --e; // eat trailing quote
+    }
 
     /////////////////////////////////////////////////////////////////////
     // now <e> points to the character AFTER the last character of the //
@@ -225,17 +232,21 @@ HttpCompat::lookup_param_in_strlist(StrList *param_list, const char *param_name,
     if (is_match) {
       param_val[0] = '\0';
 
-      while (*s && ParseRules::is_ws(*s))
+      while (*s && ParseRules::is_ws(*s)) {
         s++; // skip white
+      }
       if (*s == '=') {
         ++s; // skip '='
-        while (*s && ParseRules::is_ws(*s))
+        while (*s && ParseRules::is_ws(*s)) {
           s++; // skip white
+        }
 
-        for (cnt         = 0; *s && (cnt < param_val_length - 1); s++, cnt++)
+        for (cnt = 0; *s && (cnt < param_val_length - 1); s++, cnt++) {
           param_val[cnt] = *s;
-        if (cnt < param_val_length)
+        }
+        if (cnt < param_val_length) {
           param_val[cnt++] = '\0';
+        }
       }
       return (true);
     }
@@ -298,8 +309,9 @@ HttpCompat::parse_mime_type(const char *mime_string, char *type, char *subtype, 
   // skip whitespace //
   /////////////////////
 
-  for (s = mime_string; *s && ParseRules::is_ws(*s); s++)
+  for (s = mime_string; *s && ParseRules::is_ws(*s); s++) {
     ;
+  }
 
   ///////////////////////////////////////////////////////////////////////
   // scan type (until NUL, out of room, comma/semicolon, space, slash) //
@@ -316,12 +328,15 @@ HttpCompat::parse_mime_type(const char *mime_string, char *type, char *subtype, 
   // skip remainder of text and space, then slash, then space //
   //////////////////////////////////////////////////////////////
 
-  while (*s && (*s != ';') && (*s != ',') && (*s != '/'))
+  while (*s && (*s != ';') && (*s != ',') && (*s != '/')) {
     ++s;
-  if (*s == '/')
+  }
+  if (*s == '/') {
     ++s;
-  while (*s && ParseRules::is_ws(*s))
+  }
+  while (*s && ParseRules::is_ws(*s)) {
     ++s;
+  }
 
   //////////////////////////////////////////////////////////////////////////
   // scan subtype (until NUL, out of room, comma/semicolon, space, slash) //
@@ -349,8 +364,9 @@ HttpCompat::parse_mime_type_with_len(const char *mime_string, int mime_string_le
   // skip whitespace //
   /////////////////////
 
-  for (s = mime_string; (s < s_toofar) && ParseRules::is_ws(*s); s++)
+  for (s = mime_string; (s < s_toofar) && ParseRules::is_ws(*s); s++) {
     ;
+  }
 
   ///////////////////////////////////////////////////////////////////////
   // scan type (until NUL, out of room, comma/semicolon, space, slash) //
@@ -367,12 +383,15 @@ HttpCompat::parse_mime_type_with_len(const char *mime_string, int mime_string_le
   // skip remainder of text and space, then slash, then space //
   //////////////////////////////////////////////////////////////
 
-  while ((s < s_toofar) && (*s != ';') && (*s != ',') && (*s != '/'))
+  while ((s < s_toofar) && (*s != ';') && (*s != ',') && (*s != '/')) {
     ++s;
-  if ((s < s_toofar) && (*s == '/'))
+  }
+  if ((s < s_toofar) && (*s == '/')) {
     ++s;
-  while ((s < s_toofar) && ParseRules::is_ws(*s))
+  }
+  while ((s < s_toofar) && ParseRules::is_ws(*s)) {
     ++s;
+  }
 
   //////////////////////////////////////////////////////////////////////////
   // scan subtype (until NUL, out of room, comma/semicolon, space, slash) //
@@ -414,26 +433,30 @@ bool
 HttpCompat::do_header_values_rfc2068_14_43_match(MIMEField *hdr1, MIMEField *hdr2)
 {
   // If both headers are missing, the headers match.
-  if (!hdr1 && !hdr2)
+  if (!hdr1 && !hdr2) {
     return true;
+  }
 
   // If one header is missing, the headers do not match.
-  if (!hdr1 || !hdr2)
+  if (!hdr1 || !hdr2) {
     return false;
+  }
 
   // Make sure both headers have the same number of comma-
   // separated elements.
   HdrCsvIter iter1, iter2;
-  if (iter1.count_values(hdr1) != iter2.count_values(hdr2))
+  if (iter1.count_values(hdr1) != iter2.count_values(hdr2)) {
     return false;
+  }
 
   int hdr1_val_len, hdr2_val_len;
   const char *hdr1_val = iter1.get_first(hdr1, &hdr1_val_len);
   const char *hdr2_val = iter2.get_first(hdr2, &hdr2_val_len);
 
   while (hdr1_val || hdr2_val) {
-    if (hdr1_val_len != hdr2_val_len || ParseRules::strncasecmp_eow(hdr1_val, hdr2_val, hdr1_val_len) == false)
+    if (hdr1_val_len != hdr2_val_len || ParseRules::strncasecmp_eow(hdr1_val, hdr2_val, hdr1_val_len) == false) {
       return false;
+    }
 
     hdr1_val = iter1.get_next(&hdr1_val_len);
     hdr2_val = iter2.get_next(&hdr2_val_len);
@@ -460,8 +483,9 @@ HttpCompat::find_Q_param_in_strlist(StrList *strlist)
   this_q = 1.0;
   if (HttpCompat::lookup_param_in_strlist(strlist, (char *)"q", q_string, sizeof(q_string))) {
     // coverity[secure_coding]
-    if (sscanf(q_string, "%f", &f) == 1) // parse q
+    if (sscanf(q_string, "%f", &f) == 1) { // parse q
       this_q = (f < 0 ? 0 : (f > 1 ? 1 : f));
+    }
   }
 
   return (this_q);
@@ -498,10 +522,11 @@ does_language_range_match(const char *pattern, int pattern_len, const char *tag,
   }
 
   // matches if range equals tag, or if range is a lang prefix of tag
-  if ((((pattern_len == 0) && (tag_len == 0)) || ((pattern_len == 0) && (*tag == '-'))))
+  if ((((pattern_len == 0) && (tag_len == 0)) || ((pattern_len == 0) && (*tag == '-')))) {
     match = true;
-  else
+  } else {
     match = false;
+  }
 
   return (match);
 }
@@ -529,8 +554,9 @@ HttpCompat::match_accept_language(const char *lang_str, int lang_len, StrList *a
   ///////////////////////////////////////////////////////
   // rip the accept string into comma-separated values //
   ///////////////////////////////////////////////////////
-  if (acpt_lang_list->count == 0)
+  if (acpt_lang_list->count == 0) {
     return (0.0);
+  }
 
   ////////////////////////////////////////
   // loop over each Accept-Language tag //
@@ -538,16 +564,18 @@ HttpCompat::match_accept_language(const char *lang_str, int lang_len, StrList *a
   for (a_value = acpt_lang_list->head; a_value; a_value = a_value->next) {
     ++index;
 
-    if (a_value->len == 0)
+    if (a_value->len == 0) {
       continue; // blank tag
+    }
 
     ///////////////////////////////////////////////////////////
     // now rip the Accept-Language tag into head and Q parts //
     ///////////////////////////////////////////////////////////
     StrList a_param_list(false);
     HttpCompat::parse_semicolon_list(&a_param_list, a_value->str, (int)a_value->len);
-    if (!a_param_list.head)
+    if (!a_param_list.head) {
       continue;
+    }
 
     /////////////////////////////////////////////////////////////////////
     // This algorithm is a bit wierd --- the resulting Q factor is     //
@@ -642,24 +670,27 @@ HttpCompat::match_accept_charset(const char *charset_str, int charset_len, StrLi
   ///////////////////////////////////////////////////////
   // rip the accept string into comma-separated values //
   ///////////////////////////////////////////////////////
-  if (acpt_charset_list->count == 0)
+  if (acpt_charset_list->count == 0) {
     return (0.0);
+  }
 
   ///////////////////////////////////////
   // loop over each Accept-Charset tag //
   ///////////////////////////////////////
   for (a_value = acpt_charset_list->head; a_value; a_value = a_value->next) {
     ++index;
-    if (a_value->len == 0)
+    if (a_value->len == 0) {
       continue; // blank tag
+    }
 
     //////////////////////////////////////////////////////////
     // now rip the Accept-Charset tag into head and Q parts //
     //////////////////////////////////////////////////////////
     StrList a_param_list(false);
     HttpCompat::parse_semicolon_list(&a_param_list, a_value->str, (int)a_value->len);
-    if (!a_param_list.head)
+    if (!a_param_list.head) {
       continue;
+    }
 
     ///////////////////////////////////////////////////////////////
     // see if the Accept-Charset tag matches the current charset //
@@ -747,8 +778,9 @@ HttpCompat::determine_set_by_language(RawHashTable *table_of_sets, StrList *acpt
       body_set       = (HttpBodySetRawData *)v1;
       table_of_pages = body_set->table_of_pages;
 
-      if ((set_name == NULL) || (table_of_pages == NULL))
+      if ((set_name == NULL) || (table_of_pages == NULL)) {
         continue;
+      }
 
       //////////////////////////////////////////////////////////////////////
       // Take this error page language and match it against the           //
@@ -830,8 +862,9 @@ HttpCompat::determine_set_by_language(RawHashTable *table_of_sets, StrList *acpt
 
       if (is_the_default_set) {
         Q = Q + -0.00005;
-        if (Q < 0.00001)
+        if (Q < 0.00001) {
           Q = 0.00001;
+        }
       }
 
       Debug("body_factory_determine_set", "      NEW: [ set='%s', Q=%g, La=%d, Lc=%d, I=%d ]", set_name, Q, La, Lc, I);

--- a/proxy/hdrs/MIME.cc
+++ b/proxy/hdrs/MIME.cc
@@ -397,8 +397,9 @@ void
 mime_hdr_presence_set(MIMEHdrImpl *h, const char *well_known_str)
 {
   uint64_t mask = mime_field_presence_mask(well_known_str);
-  if (mask != 0)
+  if (mask != 0) {
     h->m_presence_bits |= mask;
+  }
 }
 
 void
@@ -412,8 +413,9 @@ void
 mime_hdr_presence_unset(MIMEHdrImpl *h, const char *well_known_str)
 {
   uint64_t mask = mime_field_presence_mask(well_known_str);
-  if (mask != 0)
+  if (mask != 0) {
     h->m_presence_bits &= (~mask);
+  }
 }
 
 void
@@ -472,8 +474,9 @@ mime_hdr_set_accelerators_and_presence_bits(MIMEHdrImpl *mh, MIMEField *field)
 {
   int slot_id;
   ptrdiff_t slot_num;
-  if (field->m_wks_idx < 0)
+  if (field->m_wks_idx < 0) {
     return;
+  }
 
   mime_hdr_presence_set(mh, field->m_wks_idx);
 
@@ -500,14 +503,16 @@ inline void
 mime_hdr_unset_accelerators_and_presence_bits(MIMEHdrImpl *mh, MIMEField *field)
 {
   int slot_id;
-  if (field->m_wks_idx < 0)
+  if (field->m_wks_idx < 0) {
     return;
+  }
 
   mime_hdr_presence_unset(mh, field->m_wks_idx);
 
   slot_id = hdrtoken_index_to_slotid(field->m_wks_idx);
-  if (slot_id != MIME_SLOTID_NONE)
+  if (slot_id != MIME_SLOTID_NONE) {
     mime_hdr_set_accelerator_slotnum(mh, slot_id, MIME_FIELD_SLOTNUM_MAX);
+  }
 }
 
 /// Reset data in the header.
@@ -522,8 +527,9 @@ mime_hdr_reset_accelerators_and_presence_bits(MIMEHdrImpl *mh)
     for (MIMEField *field = fblock->m_field_slots, *limit = field + fblock->m_freetop; field < limit; ++field) {
       if (field->is_live()) {
         field->m_wks_idx = hdrtoken_tokenize(field->m_ptr_name, field->m_len_name);
-        if (field->is_dup_head())
+        if (field->is_dup_head()) {
           mime_hdr_set_accelerators_and_presence_bits(mh, field);
+        }
       }
     }
   }
@@ -533,8 +539,9 @@ int
 checksum_block(const char *s, int len)
 {
   int sum = 0;
-  while (len--)
+  while (len--) {
     sum ^= *s++;
+  }
   return sum;
 }
 
@@ -558,8 +565,9 @@ mime_hdr_sanity_check(MIMEHdrImpl *mh)
       if (field->is_live()) {
         // dummy operations just to make sure deref doesn't crash
         checksum_block(field->m_ptr_name, field->m_len_name);
-        if (field->m_ptr_value)
+        if (field->m_ptr_value) {
           checksum_block(field->m_ptr_value, field->m_len_value);
+        }
 
         if (field->m_n_v_raw_printable) {
           int total_len = field->m_len_name + field->m_len_value + field->m_n_v_raw_printable_pad;
@@ -584,8 +592,9 @@ mime_hdr_sanity_check(MIMEHdrImpl *mh)
           const char *wks = hdrtoken_index_to_wks(field->m_wks_idx);
           int len         = hdrtoken_index_to_length(field->m_wks_idx);
 
-          if (field->m_len_name != len || strncasecmp(field->m_ptr_name, wks, field->m_len_name) != 0)
+          if (field->m_len_name != len || strncasecmp(field->m_ptr_name, wks, field->m_len_name) != 0) {
             Warning("Encountered WKS hash collision on '%.*s'", field->m_len_name, field->m_ptr_name);
+          }
 
           uint64_t mask = mime_field_presence_mask(field->m_wks_idx);
           masksum |= mask;
@@ -594,8 +603,9 @@ mime_hdr_sanity_check(MIMEHdrImpl *mh)
           if ((slot_id != MIME_SLOTID_NONE) && (slot_index < MIME_FIELD_SLOTNUM_UNKNOWN) &&
               (field->m_flags & MIME_FIELD_SLOT_FLAGS_DUP_HEAD)) {
             uint32_t slot_num = mime_hdr_get_accelerator_slotnum(mh, slot_id);
-            if (slot_num <= 14)
+            if (slot_num <= 14) {
               ink_release_assert(slot_num == slot_index);
+            }
           }
         } else {
           int idx = hdrtoken_tokenize(field->m_ptr_name, field->m_len_name, NULL);
@@ -617,10 +627,11 @@ mime_hdr_sanity_check(MIMEHdrImpl *mh)
         // re-find the field --- should always find the head dup
         MIMEField *mf = mime_hdr_field_find(mh, field->m_ptr_name, field->m_len_name);
         ink_release_assert(mf != NULL);
-        if (mf == field)
+        if (mf == field) {
           ink_release_assert((field->m_flags & MIME_FIELD_SLOT_FLAGS_DUP_HEAD) != 0);
-        else
+        } else {
           ink_release_assert((field->m_flags & MIME_FIELD_SLOT_FLAGS_DUP_HEAD) == 0);
+        }
       }
 
       ++slot_index;
@@ -1118,8 +1129,9 @@ mime_hdr_copy_onto(MIMEHdrImpl *s_mh, HdrHeap *s_heap, MIMEHdrImpl *d_mh, HdrHea
     d_mh->m_fblock_list_tail = prev_d_fblock;
   }
 
-  if (inherit_strs)
+  if (inherit_strs) {
     d_heap->inherit_string_heaps(s_heap);
+  }
 
   mime_hdr_field_block_list_adjust(block_count, &(s_mh->m_first_fblock), &(d_mh->m_first_fblock));
 
@@ -1217,8 +1229,9 @@ _mime_hdr_field_list_search_by_wks(MIMEHdrImpl *mh, int wks_idx)
 
     too_far_field = &(fblock->m_field_slots[fblock->m_freetop]);
     while (field < too_far_field) {
-      if (field->is_live() && (field->m_wks_idx == wks_idx))
+      if (field->is_live() && (field->m_wks_idx == wks_idx)) {
         return field;
+      }
       ++field;
     }
   }
@@ -1268,12 +1281,14 @@ _mime_hdr_field_list_search_by_slotnum(MIMEHdrImpl *mh, int slotnum)
     block_index = slotnum % MIME_FIELD_BLOCK_SLOTS;
 
     fblock = &(mh->m_first_fblock);
-    while (block_num-- && fblock)
+    while (block_num-- && fblock) {
       fblock = fblock->m_next;
-    if ((fblock == NULL) || (block_index >= fblock->m_freetop))
+    }
+    if ((fblock == NULL) || (block_index >= fblock->m_freetop)) {
       return NULL;
-    else
+    } else {
       return &(fblock->m_field_slots[block_index]);
+    }
   }
 }
 
@@ -1358,10 +1373,12 @@ mime_hdr_field_get(MIMEHdrImpl *mh, int idx)
   for (fblock = &(mh->m_first_fblock); fblock != NULL; fblock = fblock->m_next) {
     for (index = 0; index < fblock->m_freetop; index++) {
       field = &(fblock->m_field_slots[index]);
-      if (field->is_live())
+      if (field->is_live()) {
         ++got_idx;
-      if (got_idx == idx)
+      }
+      if (got_idx == idx) {
         return field;
+      }
     }
   }
 
@@ -1387,8 +1404,9 @@ mime_hdr_fields_count(MIMEHdrImpl *mh)
   for (fblock = &(mh->m_first_fblock); fblock != NULL; fblock = fblock->m_next) {
     for (index = 0; index < fblock->m_freetop; index++) {
       field = &(fblock->m_field_slots[index]);
-      if (field->is_live())
+      if (field->is_live()) {
         ++count;
+      }
     }
   }
 
@@ -1486,10 +1504,12 @@ mime_hdr_field_attach(MIMEHdrImpl *mh, MIMEField *field, int check_for_dups, MIM
 
     while (prev_slotnum < field_slotnum) // break if prev after field
     {
-      if (next_dup == NULL)
+      if (next_dup == NULL) {
         break; // no next dup, we're done
-      if (next_slotnum > field_slotnum)
+      }
+      if (next_slotnum > field_slotnum) {
         break; // next dup is after us, we're done
+      }
       prev_dup     = next_dup;
       prev_slotnum = next_slotnum;
       next_dup     = prev_dup->m_next_dup;
@@ -1529,8 +1549,9 @@ mime_hdr_field_attach(MIMEHdrImpl *mh, MIMEField *field, int check_for_dups, MIM
 
   // Now keep the cooked cache consistent
   ink_assert(field->is_live());
-  if (field->m_ptr_value && field->is_cooked())
+  if (field->m_ptr_value && field->is_cooked()) {
     mh->recompute_cooked_stuff(field);
+  }
 
   MIME_HDR_SANITY_CHECK(mh);
 }
@@ -1572,12 +1593,14 @@ mime_hdr_field_detach(MIMEHdrImpl *mh, MIMEField *field, bool detach_all_dups)
     const char *name = mime_field_name_get(field, &name_length);
     MIMEField *prev  = mime_hdr_field_find(mh, name, name_length);
 
-    while (prev && (prev->m_next_dup != field))
+    while (prev && (prev->m_next_dup != field)) {
       prev = prev->m_next_dup;
+    }
     ink_assert(prev != NULL);
 
-    if (prev->m_next_dup == field)
+    if (prev->m_next_dup == field) {
       prev->m_next_dup = next_dup;
+    }
   }
 
   // Field is now detached and alone
@@ -1585,8 +1608,9 @@ mime_hdr_field_detach(MIMEHdrImpl *mh, MIMEField *field, bool detach_all_dups)
   field->m_next_dup  = NULL;
 
   // Because we changed the values through detaching,update the cooked cache
-  if (field->is_cooked())
+  if (field->is_cooked()) {
     mh->recompute_cooked_stuff(field);
+  }
 
   MIME_HDR_SANITY_CHECK(mh);
 
@@ -1595,8 +1619,9 @@ mime_hdr_field_detach(MIMEHdrImpl *mh, MIMEField *field, bool detach_all_dups)
   // or an interior dup detached and patched around.  If we are requested
   // to delete the whole dup list, we tail-recurse to delete it.
 
-  if (detach_all_dups && next_dup)
+  if (detach_all_dups && next_dup) {
     mime_hdr_field_detach(mh, next_dup, detach_all_dups);
+  }
 }
 
 void
@@ -1699,10 +1724,11 @@ const char *
 mime_field_name_get(const MIMEField *field, int *length)
 {
   *length = field->m_len_name;
-  if (field->m_wks_idx >= 0)
+  if (field->m_wks_idx >= 0) {
     return hdrtoken_index_to_wks(field->m_wks_idx);
-  else
+  } else {
     return field->m_ptr_name;
+  }
 }
 
 void
@@ -1795,10 +1821,11 @@ mime_field_value_get_comma_val(const MIMEField *field, int *length, int idx)
 {
   // some fields (like Date) contain commas but should not be ripped apart
   if (!field->supports_commas()) {
-    if (idx == 0)
+    if (idx == 0) {
       return mime_field_value_get(field, length);
-    else
+    } else {
       return NULL;
+    }
   } else {
     Str *str;
     StrList list(false);
@@ -1837,10 +1864,11 @@ mime_field_value_get_comma_list(const MIMEField *field, StrList *list)
   str = mime_field_value_get(field, &len);
 
   // if field doesn't support commas, don't rip apart.
-  if (!field->supports_commas())
+  if (!field->supports_commas()) {
     list->append_string(str, len);
-  else
+  } else {
     HttpCompat::parse_tok_list(list, 1, str, len, ',');
+  }
 
   return list->count;
 }
@@ -1863,8 +1891,9 @@ mime_field_value_str_from_strlist(HdrHeap *heap, int *new_str_len_return, StrLis
     new_value_len += cell->len;
     cell = cell->next;
   }
-  if (list->count > 1)
+  if (list->count > 1) {
     new_value_len += (2 * (list->count - 1));
+  }
 
   // (2) allocate new heap string
   new_value = heap->allocate_str(new_value_len);
@@ -1899,8 +1928,9 @@ mime_field_value_set_comma_val(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField *field,
   HttpCompat::parse_tok_list(&list, 0, field->m_ptr_value, field->m_len_value, ',');
 
   // (2) if desired index isn't valid, then don't change the field
-  if ((idx < 0) || (idx >= list.count))
+  if ((idx < 0) || (idx >= list.count)) {
     return;
+  }
 
   // (3) mutate cell idx
   cell = list.get_idx(idx);
@@ -1914,8 +1944,9 @@ mime_field_value_set_comma_val(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField *field,
 
   // (5) keep stuff fields consistent
   field->m_n_v_raw_printable = 0;
-  if (field->is_live() && field->is_cooked())
+  if (field->is_live() && field->is_cooked()) {
     mh->recompute_cooked_stuff(field);
+  }
 }
 
 void
@@ -1929,8 +1960,9 @@ mime_field_value_delete_comma_val(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField *fie
   HttpCompat::parse_tok_list(&list, 0, field->m_ptr_value, field->m_len_value, ',');
 
   // (2) if desired index isn't valid, then don't change the field
-  if ((idx < 0) || (idx >= list.count))
+  if ((idx < 0) || (idx >= list.count)) {
     return;
+  }
 
   // (3) delete cell idx
   cell = list.get_idx(idx);
@@ -1958,8 +1990,9 @@ mime_field_value_delete_comma_val(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField *fie
 
   // (5) keep stuff fields consistent
   field->m_n_v_raw_printable = 0;
-  if (field->is_live() && field->is_cooked())
+  if (field->is_live() && field->is_cooked()) {
     mh->recompute_cooked_stuff(field);
+  }
 }
 
 void
@@ -1974,10 +2007,12 @@ mime_field_value_insert_comma_val(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField *fie
   HttpCompat::parse_tok_list(&list, 0, field->m_ptr_value, field->m_len_value, ',');
 
   // (2) if desired index isn't valid, then don't change the field
-  if (idx < 0)
+  if (idx < 0) {
     idx = list.count;
-  if (idx > list.count)
+  }
+  if (idx > list.count) {
     return;
+  }
 
   // (3) create a new cell
   cell = list.new_cell(new_piece_str, new_piece_len);
@@ -1996,8 +2031,9 @@ mime_field_value_insert_comma_val(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField *fie
 
   // (6) keep stuff fields consistent
   field->m_n_v_raw_printable = 0;
-  if (field->is_live() && field->is_cooked())
+  if (field->is_live() && field->is_cooked()) {
     mh->recompute_cooked_stuff(field);
+  }
 }
 
 void
@@ -2014,8 +2050,9 @@ mime_field_value_extend_comma_val(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField *fie
   HttpCompat::parse_tok_list(&list, 0, field->m_ptr_value, field->m_len_value, ',');
 
   // (2) if desired index isn't valid, then don't change the field
-  if ((idx < 0) || (idx >= list.count))
+  if ((idx < 0) || (idx >= list.count)) {
     return;
+  }
 
   // (3) get the cell we want to modify
   cell = list.get_idx(idx);
@@ -2034,21 +2071,24 @@ mime_field_value_extend_comma_val(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField *fie
   extended_len = cell->len + new_piece_len + (trimmed ? 2 : 0);
 
   // (6) allocate temporary space to construct new value
-  if (extended_len <= sizeof(temp_buf))
+  if (extended_len <= sizeof(temp_buf)) {
     temp_ptr = temp_buf;
-  else
+  } else {
     temp_ptr = (char *)ats_malloc(extended_len);
+  }
 
   // (7) construct new extended token
   dest = temp_ptr;
-  if (trimmed)
+  if (trimmed) {
     *dest++ = '\"';
+  }
   memcpy(dest, cell->str, cell->len);
   dest += cell->len;
   memcpy(dest, new_piece_str, new_piece_len);
   dest += new_piece_len;
-  if (trimmed)
+  if (trimmed) {
     *dest++ = '\"';
+  }
   ink_assert((size_t)(dest - temp_ptr) == extended_len);
 
   // (8) assign the new token to the cell
@@ -2061,12 +2101,14 @@ mime_field_value_extend_comma_val(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField *fie
 
   // (10) keep stuff fields consistent
   field->m_n_v_raw_printable = 0;
-  if (field->is_live() && field->is_cooked())
+  if (field->is_live() && field->is_cooked()) {
     mh->recompute_cooked_stuff(field);
+  }
 
   // (11) free up any temporary storage
-  if (extended_len > sizeof(temp_buf))
+  if (extended_len > sizeof(temp_buf)) {
     ats_free(temp_ptr);
+  }
 }
 
 void
@@ -2074,17 +2116,19 @@ mime_field_value_set(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField *field, const cha
 {
   heap->free_string(field->m_ptr_value, field->m_len_value);
 
-  if (must_copy_string && value)
+  if (must_copy_string && value) {
     field->m_ptr_value = heap->duplicate_str(value, length);
-  else
+  } else {
     field->m_ptr_value = value;
+  }
 
   field->m_len_value         = length;
   field->m_n_v_raw_printable = 0;
 
   // Now keep the cooked cache consistent
-  if (field->is_live() && field->is_cooked())
+  if (field->is_live() && field->is_cooked()) {
     mh->recompute_cooked_stuff(field);
+  }
 }
 
 void
@@ -2148,8 +2192,9 @@ mime_field_name_value_set(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField *field, int1
     if ((name_wks_idx_or_neg1 == MIME_WKSIDX_CACHE_CONTROL) || (name_wks_idx_or_neg1 == MIME_WKSIDX_PRAGMA)) {
       field->m_flags |= MIME_FIELD_SLOT_FLAGS_COOKED;
     }
-    if (field->is_live() && field->is_cooked())
+    if (field->is_live() && field->is_cooked()) {
       mh->recompute_cooked_stuff(field);
+    }
   }
 }
 
@@ -2158,8 +2203,9 @@ mime_field_value_append(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField *field, const 
                         const char separator)
 {
   int new_length = field->m_len_value + length;
-  if (prepend_comma && field->m_len_value)
+  if (prepend_comma && field->m_len_value) {
     new_length += 2;
+  }
 
   // Start by trying expand the string we already  have
   char *new_str = heap->expand_str(field->m_ptr_value, field->m_len_value, new_length);
@@ -2183,8 +2229,9 @@ mime_field_value_append(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField *field, const 
   field->m_n_v_raw_printable = 0;
 
   // Now keep the cooked cache consistent
-  if (field->is_live() && field->is_cooked())
+  if (field->is_live() && field->is_cooked()) {
     mh->recompute_cooked_stuff(field);
+  }
 }
 
 MIMEField *
@@ -2194,14 +2241,18 @@ MIMEHdr::get_host_port_values(char const **host_ptr, ///< Pointer to host.
                               int *port_len)
 {
   MIMEField *field = this->field_find(MIME_FIELD_HOST, MIME_LEN_HOST);
-  if (host_ptr)
+  if (host_ptr) {
     *host_ptr = 0;
-  if (host_len)
+  }
+  if (host_len) {
     *host_len = 0;
-  if (port_ptr)
+  }
+  if (port_ptr) {
     *port_ptr = 0;
-  if (port_len)
+  }
+  if (port_len) {
     *port_len = 0;
+  }
 
   if (field) {
     ts::ConstBuffer b(field->m_ptr_value, field->m_len_value);
@@ -2229,16 +2280,20 @@ MIMEHdr::get_host_port_values(char const **host_ptr, ///< Pointer to host.
       }
 
       if (host) {
-        if (host_ptr)
+        if (host_ptr) {
           *host_ptr = host._ptr;
-        if (host_len)
+        }
+        if (host_len) {
           *host_len = static_cast<int>(host._size);
+        }
       }
       if (port) {
-        if (port_ptr)
+        if (port_ptr) {
           *port_ptr = port._ptr;
-        if (port_len)
+        }
+        if (port_len) {
           *port_len = static_cast<int>(port._size);
+        }
       }
     } else {
       field = 0; // no value in field, signal fail.
@@ -2287,9 +2342,10 @@ mime_scanner_append(MIMEScanner *scanner, const char *data, int data_size)
   //////////////////////////////////////////////////////
   // if not enough space, allocate or grow the buffer //
   //////////////////////////////////////////////////////
-  if (data_size > free_size) {     // need to allocate/grow the buffer
-    if (scanner->m_line_size == 0) // buffer should be at least 128 bytes
+  if (data_size > free_size) {       // need to allocate/grow the buffer
+    if (scanner->m_line_size == 0) { // buffer should be at least 128 bytes
       scanner->m_line_size = 128;
+    }
 
     while (free_size < data_size) { // grow buffer by powers of 2
       scanner->m_line_size *= 2;
@@ -2443,8 +2499,9 @@ mime_scanner_get(MIMEScanner *S, const char **raw_input_s, const char *raw_input
   }
 
   // Make sure there are no '\0' in the input scanned so far
-  if (zret != PARSE_ERROR && memchr(*raw_input_s, '\0', raw_input_c - *raw_input_s) != NULL)
+  if (zret != PARSE_ERROR && memchr(*raw_input_s, '\0', raw_input_c - *raw_input_s) != NULL) {
     zret = PARSE_ERROR;
+  }
 
   *raw_input_s = raw_input_c; // mark input consumed.
   return zret;
@@ -2501,8 +2558,9 @@ mime_parser_parse(MIMEParser *parser, HdrHeap *heap, MIMEHdrImpl *mh, const char
     ////////////////////////////////////////////////////////////////////////////
 
     err = mime_scanner_get(scanner, real_s, real_e, &line_s, &line_e, &line_is_real, eof, MIME_SCANNER_TYPE_FIELD);
-    if (err != PARSE_OK)
+    if (err != PARSE_OK) {
       return err;
+    }
 
     line_c = line_s;
 
@@ -2510,11 +2568,13 @@ mime_parser_parse(MIMEParser *parser, HdrHeap *heap, MIMEHdrImpl *mh, const char
     // if got a LF or CR on its own, end the header //
     //////////////////////////////////////////////////
 
-    if ((line_e - line_c >= 2) && (line_c[0] == ParseRules::CHAR_CR) && (line_c[1] == ParseRules::CHAR_LF))
+    if ((line_e - line_c >= 2) && (line_c[0] == ParseRules::CHAR_CR) && (line_c[1] == ParseRules::CHAR_LF)) {
       return PARSE_DONE;
+    }
 
-    if ((line_e - line_c >= 1) && (line_c[0] == ParseRules::CHAR_LF))
+    if ((line_e - line_c >= 1) && (line_c[0] == ParseRules::CHAR_LF)) {
       return PARSE_DONE;
+    }
 
     /////////////////////////////////////////////
     // find pointers into the name:value field //
@@ -2531,33 +2591,39 @@ mime_parser_parse(MIMEParser *parser, HdrHeap *heap, MIMEHdrImpl *mh, const char
      * have to add one more check to see if the first parameter is '@'
      * character then, the header name is valid.
      **/
-    if ((!ParseRules::is_token(*field_name_first)) && (*field_name_first != '@'))
+    if ((!ParseRules::is_token(*field_name_first)) && (*field_name_first != '@')) {
       continue; // toss away garbage line
+    }
 
     // find name last
     colon = (char *)memchr(line_c, ':', (line_e - line_c));
-    if (!colon)
+    if (!colon) {
       continue; // toss away garbage line
+    }
     field_name_last = colon - 1;
-    while ((field_name_last >= field_name_first) && is_ws(*field_name_last))
+    while ((field_name_last >= field_name_first) && is_ws(*field_name_last)) {
       --field_name_last;
+    }
 
     // find value first
     field_value_first = colon + 1;
-    while ((field_value_first < line_e) && is_ws(*field_value_first))
+    while ((field_value_first < line_e) && is_ws(*field_value_first)) {
       ++field_value_first;
+    }
 
     // find_value_last
     field_value_last = line_e - 1;
-    while ((field_value_last >= field_value_first) && ParseRules::is_wslfcr(*field_value_last))
+    while ((field_value_last >= field_value_first) && ParseRules::is_wslfcr(*field_value_last)) {
       --field_value_last;
+    }
 
     field_name_length  = (int)(field_name_last - field_name_first + 1);
     field_value_length = (int)(field_value_last - field_value_first + 1);
 
     // Make sure the name or value is not longer than 64K
-    if (field_name_length >= UINT16_MAX || field_value_length >= UINT16_MAX)
+    if (field_name_length >= UINT16_MAX || field_value_length >= UINT16_MAX) {
       return PARSE_ERROR;
+    }
 
     int total_line_length = (int)(field_line_last - field_line_first + 1);
 
@@ -2607,8 +2673,9 @@ mime_hdr_describe(HdrHeapObjImpl *raw, bool recurse)
         obj->m_cooked_stuff.m_cache_control.m_secs_s_maxage, obj->m_cooked_stuff.m_cache_control.m_secs_max_stale,
         obj->m_cooked_stuff.m_cache_control.m_secs_min_fresh, obj->m_cooked_stuff.m_pragma.m_no_cache);
   for (fblock = &(obj->m_first_fblock); fblock != NULL; fblock = fblock->m_next) {
-    if (recurse || (fblock == &(obj->m_first_fblock)))
+    if (recurse || (fblock == &(obj->m_first_fblock))) {
       obj_describe((HdrHeapObjImpl *)fblock, recurse);
+    }
   }
 }
 
@@ -2657,8 +2724,9 @@ mime_hdr_print(HdrHeap * /* heap ATS_UNUSED */, MIMEHdrImpl *mh, char *buf_start
     for (index = 0; index < fblock->m_freetop; index++) {
       field = &(fblock->m_field_slots[index]);
       if (field->is_live()) {
-        if (!mime_field_print(field, buf_start, buf_length, buf_index_inout, buf_chars_to_skip_inout))
+        if (!mime_field_print(field, buf_start, buf_length, buf_index_inout, buf_chars_to_skip_inout)) {
           return 0;
+        }
       }
     }
   }
@@ -2708,8 +2776,9 @@ mime_mem_print(const char *src_d, int src_l, char *buf_start, int buf_length, in
   if (buf_start == NULL) { // this case should only be used by test_header
     ink_release_assert(buf_index_inout == NULL);
     ink_release_assert(buf_chars_to_skip_inout == NULL);
-    while (src_l--)
+    while (src_l--) {
       putchar(*src_d++);
+    }
     return 1;
   }
 
@@ -2878,12 +2947,13 @@ mime_days_since_epoch_to_mdy_slowcase(unsigned int days_since_jan_1_1970, int *m
 
   /* convert the days */
   d = mday - d;
-  if ((d < 0) || (d > 366))
+  if ((d < 0) || (d > 366)) {
     ink_assert(!"bad date");
-  else {
+  } else {
     month = months[d];
-    if (month > 1)
+    if (month > 1) {
       year -= 1;
+    }
 
     mday = d - days[month] - 1;
     year += 1900;
@@ -3052,21 +3122,24 @@ mime_parse_int(const char *buf, const char *end)
   int32_t num;
   bool negative;
 
-  if (!buf || (buf == end))
+  if (!buf || (buf == end)) {
     return 0;
+  }
 
   if (is_digit(*buf)) // fast case
   {
     num = *buf++ - '0';
-    while ((buf != end) && is_digit(*buf))
+    while ((buf != end) && is_digit(*buf)) {
       num = (num * 10) + (*buf++ - '0');
+    }
     return num;
   } else {
     num      = 0;
     negative = false;
 
-    while ((buf != end) && ParseRules::is_space(*buf))
+    while ((buf != end) && ParseRules::is_space(*buf)) {
       buf += 1;
+    }
 
     if ((buf != end) && (*buf == '-')) {
       negative = true;
@@ -3074,11 +3147,13 @@ mime_parse_int(const char *buf, const char *end)
     }
     // NOTE: we first compute the value as negative then correct the
     // sign back to positive. This enables us to correctly parse MININT.
-    while ((buf != end) && is_digit(*buf))
+    while ((buf != end) && is_digit(*buf)) {
       num = (num * 10) - (*buf++ - '0');
+    }
 
-    if (!negative)
+    if (!negative) {
       num = -num;
+    }
 
     return num;
   }
@@ -3089,21 +3164,25 @@ mime_parse_uint(const char *buf, const char *end)
 {
   uint32_t num;
 
-  if (!buf || (buf == end))
+  if (!buf || (buf == end)) {
     return 0;
+  }
 
   if (is_digit(*buf)) // fast case
   {
     num = *buf++ - '0';
-    while ((buf != end) && is_digit(*buf))
+    while ((buf != end) && is_digit(*buf)) {
       num = (num * 10) + (*buf++ - '0');
+    }
     return num;
   } else {
     num = 0;
-    while ((buf != end) && ParseRules::is_space(*buf))
+    while ((buf != end) && ParseRules::is_space(*buf)) {
       buf += 1;
-    while ((buf != end) && is_digit(*buf))
+    }
+    while ((buf != end) && is_digit(*buf)) {
       num = (num * 10) + (*buf++ - '0');
+    }
     return num;
   }
 }
@@ -3114,21 +3193,24 @@ mime_parse_int64(const char *buf, const char *end)
   int64_t num;
   bool negative;
 
-  if (!buf || (buf == end))
+  if (!buf || (buf == end)) {
     return 0;
+  }
 
   if (is_digit(*buf)) // fast case
   {
     num = *buf++ - '0';
-    while ((buf != end) && is_digit(*buf))
+    while ((buf != end) && is_digit(*buf)) {
       num = (num * 10) + (*buf++ - '0');
+    }
     return num;
   } else {
     num      = 0;
     negative = false;
 
-    while ((buf != end) && ParseRules::is_space(*buf))
+    while ((buf != end) && ParseRules::is_space(*buf)) {
       buf += 1;
+    }
 
     if ((buf != end) && (*buf == '-')) {
       negative = true;
@@ -3136,11 +3218,13 @@ mime_parse_int64(const char *buf, const char *end)
     }
     // NOTE: we first compute the value as negative then correct the
     // sign back to positive. This enables us to correctly parse MININT.
-    while ((buf != end) && is_digit(*buf))
+    while ((buf != end) && is_digit(*buf)) {
       num = (num * 10) - (*buf++ - '0');
+    }
 
-    if (!negative)
+    if (!negative) {
       num = -num;
+    }
 
     return num;
   }
@@ -3195,26 +3279,29 @@ mime_parse_rfc822_date_fastcase(const char *buf, int length, struct tm *tp)
   tp->tm_wday     = -1;
   three_char_wday = (buf[0] << 16) | (buf[1] << 8) | buf[2];
   if (three_char_wday <= 0x53756E) {
-    if (three_char_wday == 0x467269)
+    if (three_char_wday == 0x467269) {
       tp->tm_wday = 5;
-    else if (three_char_wday == 0x4D6F6E)
+    } else if (three_char_wday == 0x4D6F6E) {
       tp->tm_wday = 1;
-    else if (three_char_wday == 0x536174)
+    } else if (three_char_wday == 0x536174) {
       tp->tm_wday = 6;
-    else if (three_char_wday == 0x53756E)
+    } else if (three_char_wday == 0x53756E) {
       tp->tm_wday = 0;
+    }
   } else {
-    if (three_char_wday == 0x546875)
+    if (three_char_wday == 0x546875) {
       tp->tm_wday = 4;
-    else if (three_char_wday == 0x547565)
+    } else if (three_char_wday == 0x547565) {
       tp->tm_wday = 2;
-    else if (three_char_wday == 0x576564)
+    } else if (three_char_wday == 0x576564) {
       tp->tm_wday = 3;
+    }
   }
   if (tp->tm_wday < 0) {
     tp->tm_wday = day_names_dfa->match(buf, length);
-    if (tp->tm_wday < 0)
+    if (tp->tm_wday < 0) {
       return 0;
+    }
   }
   //////////////////////////
   // extract day of month //
@@ -3228,41 +3315,46 @@ mime_parse_rfc822_date_fastcase(const char *buf, int length, struct tm *tp)
   three_char_mon = (buf[8] << 16) | (buf[9] << 8) | buf[10];
   if (three_char_mon <= 0x4A756C) {
     if (three_char_mon <= 0x446563) {
-      if (three_char_mon == 0x417072)
+      if (three_char_mon == 0x417072) {
         tp->tm_mon = 3;
-      else if (three_char_mon == 0x417567)
+      } else if (three_char_mon == 0x417567) {
         tp->tm_mon = 7;
-      else if (three_char_mon == 0x446563)
+      } else if (three_char_mon == 0x446563) {
         tp->tm_mon = 11;
+      }
     } else {
-      if (three_char_mon == 0x466562)
+      if (three_char_mon == 0x466562) {
         tp->tm_mon = 1;
-      else if (three_char_mon == 0x4A616E)
+      } else if (three_char_mon == 0x4A616E) {
         tp->tm_mon = 0;
-      else if (three_char_mon == 0x4A756C)
+      } else if (three_char_mon == 0x4A756C) {
         tp->tm_mon = 6;
+      }
     }
   } else {
     if (three_char_mon <= 0x4D6179) {
-      if (three_char_mon == 0x4A756E)
+      if (three_char_mon == 0x4A756E) {
         tp->tm_mon = 5;
-      else if (three_char_mon == 0x4D6172)
+      } else if (three_char_mon == 0x4D6172) {
         tp->tm_mon = 2;
-      else if (three_char_mon == 0x4D6179)
+      } else if (three_char_mon == 0x4D6179) {
         tp->tm_mon = 4;
+      }
     } else {
-      if (three_char_mon == 0x4E6F76)
+      if (three_char_mon == 0x4E6F76) {
         tp->tm_mon = 10;
-      else if (three_char_mon == 0x4F6374)
+      } else if (three_char_mon == 0x4F6374) {
         tp->tm_mon = 9;
-      else if (three_char_mon == 0x536570)
+      } else if (three_char_mon == 0x536570) {
         tp->tm_mon = 8;
+      }
     }
   }
   if (tp->tm_mon < 0) {
     tp->tm_mon = month_names_dfa->match(buf, length);
-    if (tp->tm_mon < 0)
+    if (tp->tm_mon < 0) {
       return 0;
+    }
   }
   //////////////////
   // extract year //
@@ -3275,8 +3367,9 @@ mime_parse_rfc822_date_fastcase(const char *buf, int length, struct tm *tp)
   tp->tm_hour = (buf[17] - '0') * 10 + (buf[18] - '0');
   tp->tm_min  = (buf[20] - '0') * 10 + (buf[21] - '0');
   tp->tm_sec  = (buf[23] - '0') * 10 + (buf[24] - '0');
-  if ((buf[19] != ':') || (buf[22] != ':'))
+  if ((buf[19] != ':') || (buf[22] != ':')) {
     return 0;
+  }
   return 1;
 }
 
@@ -3298,11 +3391,13 @@ mime_parse_date(const char *buf, const char *end)
   int month;
   int mday;
 
-  if (!buf)
+  if (!buf) {
     return (time_t)0;
+  }
 
-  while ((buf != end) && is_ws(*buf))
+  while ((buf != end) && is_ws(*buf)) {
     buf += 1;
+  }
 
   if ((buf != end) && is_digit(*buf)) { // NNTP date
     if (!mime_parse_mday(buf, end, &tp.tm_mday)) {
@@ -3318,8 +3413,9 @@ mime_parse_date(const char *buf, const char *end)
       return (time_t)0;
     }
   } else if (end && (end - buf >= 29) && (buf[3] == ',')) {
-    if (!mime_parse_rfc822_date_fastcase(buf, end - buf, &tp))
+    if (!mime_parse_rfc822_date_fastcase(buf, end - buf, &tp)) {
       return (time_t)0;
+    }
   } else {
     if (!mime_parse_day(buf, end, &tp.tm_wday)) {
       return (time_t)0;
@@ -3728,8 +3824,9 @@ MIMEHdrImpl::recompute_cooked_stuff(MIMEField *changing_field_or_null)
 
         for (s = csv_iter.get_first(field, &len); s != NULL; s = csv_iter.get_next(&len)) {
           e = s + len;
-          for (c = s; (c < e) && (ParseRules::is_token(*c)); c++)
+          for (c = s; (c < e) && (ParseRules::is_token(*c)); c++) {
             ;
+          }
           tlen = c - s;
 
           // If >= 0 then this is a well known token
@@ -3754,20 +3851,22 @@ MIMEHdrImpl::recompute_cooked_stuff(MIMEField *changing_field_or_null)
 #if TRACK_COOKING
                 Debug("http", "                        set integer value %d", value);
 #endif
-                if (token_wks == MIME_VALUE_MAX_AGE)
+                if (token_wks == MIME_VALUE_MAX_AGE) {
                   m_cooked_stuff.m_cache_control.m_secs_max_age = value;
-                else if (token_wks == MIME_VALUE_MIN_FRESH)
+                } else if (token_wks == MIME_VALUE_MIN_FRESH) {
                   m_cooked_stuff.m_cache_control.m_secs_min_fresh = value;
-                else if (token_wks == MIME_VALUE_MAX_STALE)
+                } else if (token_wks == MIME_VALUE_MAX_STALE) {
                   m_cooked_stuff.m_cache_control.m_secs_max_stale = value;
-                else if (token_wks == MIME_VALUE_S_MAXAGE)
+                } else if (token_wks == MIME_VALUE_S_MAXAGE) {
                   m_cooked_stuff.m_cache_control.m_secs_s_maxage = value;
+                }
               } else {
 #if TRACK_COOKING
                 Debug("http", "                        set integer value %d", INT_MAX);
 #endif
-                if (token_wks == MIME_VALUE_MAX_STALE)
+                if (token_wks == MIME_VALUE_MAX_STALE) {
                   m_cooked_stuff.m_cache_control.m_secs_max_stale = INT_MAX;
+                }
               }
             }
           }
@@ -3795,13 +3894,15 @@ MIMEHdrImpl::recompute_cooked_stuff(MIMEField *changing_field_or_null)
 
         for (s = csv_iter.get_first(field, &len); s != NULL; s = csv_iter.get_next(&len)) {
           e = s + len;
-          for (c = s; (c < e) && (ParseRules::is_token(*c)); c++)
+          for (c = s; (c < e) && (ParseRules::is_token(*c)); c++) {
             ;
+          }
           tlen = c - s;
 
           if (hdrtoken_tokenize(s, tlen, &token_wks) >= 0) {
-            if (token_wks == MIME_VALUE_NO_CACHE)
+            if (token_wks == MIME_VALUE_NO_CACHE) {
               m_cooked_stuff.m_pragma.m_no_cache = 1;
+            }
           }
         }
       }

--- a/proxy/hdrs/URL.cc
+++ b/proxy/hdrs/URL.cc
@@ -112,8 +112,9 @@ bool
 validate_host_name(ts::ConstBuffer addr)
 {
   while (addr) {
-    if (!(is_host_char(*addr)))
+    if (!(is_host_char(*addr))) {
       return false;
+    }
     ++addr;
   }
   return true;
@@ -273,8 +274,9 @@ url_copy_onto(URLImpl *s_url, HdrHeap *s_heap, URLImpl *d_url, HdrHeap *d_heap, 
 {
   if (s_url != d_url) {
     obj_copy_data((HdrHeapObjImpl *)s_url, (HdrHeapObjImpl *)d_url);
-    if (inherit_strs && (s_heap != d_heap))
+    if (inherit_strs && (s_heap != d_heap)) {
       d_heap->inherit_string_heaps(s_heap);
+    }
   }
 }
 
@@ -327,8 +329,9 @@ url_copy_onto_as_server_url(URLImpl *s_url, HdrHeap *s_heap, URLImpl *d_url, Hdr
   d_url->m_url_type  = s_url->m_url_type;
   d_url->m_type_code = s_url->m_type_code;
 
-  if (inherit_strs && (s_heap != d_heap))
+  if (inherit_strs && (s_heap != d_heap)) {
     d_heap->inherit_string_heaps(s_heap);
+  }
 }
 
 /*-------------------------------------------------------------------------
@@ -429,23 +432,26 @@ url_scheme_set(HdrHeap *heap, URLImpl *url, const char *scheme_str, int scheme_w
 {
   const char *scheme_wks;
   url_called_set(url);
-  if (length == 0)
+  if (length == 0) {
     scheme_str = NULL;
+  }
 
   mime_str_u16_set(heap, scheme_str, length, &(url->m_ptr_scheme), &(url->m_len_scheme), copy_string);
 
   url->m_scheme_wks_idx = scheme_wks_idx;
-  if (scheme_wks_idx >= 0)
+  if (scheme_wks_idx >= 0) {
     scheme_wks = hdrtoken_index_to_wks(scheme_wks_idx);
-  else
+  } else {
     scheme_wks = NULL;
+  }
 
-  if (scheme_wks == URL_SCHEME_HTTP || scheme_wks == URL_SCHEME_WS)
+  if (scheme_wks == URL_SCHEME_HTTP || scheme_wks == URL_SCHEME_WS) {
     url->m_url_type = URL_TYPE_HTTP;
-  else if (scheme_wks == URL_SCHEME_HTTPS || scheme_wks == URL_SCHEME_WSS)
+  } else if (scheme_wks == URL_SCHEME_HTTPS || scheme_wks == URL_SCHEME_WSS) {
     url->m_url_type = URL_TYPE_HTTPS;
-  else
+  } else {
     url->m_url_type = URL_TYPE_HTTP;
+  }
 
   return scheme_wks; // tokenized string or NULL if not well known
 }
@@ -457,8 +463,9 @@ void
 url_user_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string)
 {
   url_called_set(url);
-  if (length == 0)
+  if (length == 0) {
     value = NULL;
+  }
   mime_str_u16_set(heap, value, length, &(url->m_ptr_user), &(url->m_len_user), copy_string);
 }
 
@@ -469,8 +476,9 @@ void
 url_password_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string)
 {
   url_called_set(url);
-  if (length == 0)
+  if (length == 0) {
     value = NULL;
+  }
   mime_str_u16_set(heap, value, length, &(url->m_ptr_password), &(url->m_len_password), copy_string);
 }
 
@@ -481,8 +489,9 @@ void
 url_host_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string)
 {
   url_called_set(url);
-  if (length == 0)
+  if (length == 0) {
     value = NULL;
+  }
   mime_str_u16_set(heap, value, length, &(url->m_ptr_host), &(url->m_len_host), copy_string);
 }
 
@@ -493,14 +502,16 @@ void
 url_port_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string)
 {
   url_called_set(url);
-  if (length == 0)
+  if (length == 0) {
     value = NULL;
+  }
   mime_str_u16_set(heap, value, length, &(url->m_ptr_port), &(url->m_len_port), copy_string);
 
   url->m_port = 0;
   for (int i = 0; i < length; i++) {
-    if (!ParseRules::is_digit(value[i]))
+    if (!ParseRules::is_digit(value[i])) {
       break;
+    }
     url->m_port = url->m_port * 10 + (value[i] - '0');
   }
 }
@@ -531,8 +542,9 @@ void
 url_path_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string)
 {
   url_called_set(url);
-  if (length == 0)
+  if (length == 0) {
     value = NULL;
+  }
   mime_str_u16_set(heap, value, length, &(url->m_ptr_path), &(url->m_len_path), copy_string);
 }
 
@@ -611,12 +623,14 @@ url_clear_string_ref(URLImpl *url)
 char *
 url_string_get_ref(HdrHeap *heap, URLImpl *url, int *length)
 {
-  if (!url)
+  if (!url) {
     return NULL;
+  }
 
   if (url->m_ptr_printed_string && url->m_clean) {
-    if (length)
+    if (length) {
       *length = url->m_len_printed_string;
+    }
     return (char *)url->m_ptr_printed_string;
   } else { // either not clean or never printed
     int len = url_length_get(url);
@@ -682,13 +696,15 @@ url_string_get_buf(URLImpl *url, char *dstbuf, int dstbuf_size, int *length)
 
   if (dstbuf && dstbuf_size > 0) {
     buf = dstbuf;
-    if (len >= dstbuf_size)
+    if (len >= dstbuf_size) {
       len = dstbuf_size - 1;
+    }
     url_print(url, dstbuf, len, &index, &offset);
     buf[len] = 0;
 
-    if (length)
+    if (length) {
       *length = len;
+    }
   }
   return buf;
 }
@@ -817,22 +833,25 @@ url_length_get(URLImpl *url)
   int length = 0;
 
   if (url->m_ptr_scheme) {
-    if ((url->m_scheme_wks_idx >= 0) && (hdrtoken_index_to_wks(url->m_scheme_wks_idx) == URL_SCHEME_FILE))
+    if ((url->m_scheme_wks_idx >= 0) && (hdrtoken_index_to_wks(url->m_scheme_wks_idx) == URL_SCHEME_FILE)) {
       length += url->m_len_scheme + 1; // +1 for ":"
-    else
+    } else {
       length += url->m_len_scheme + 3; // +3 for "://"
+    }
   }
 
   if (url->m_ptr_user) {
     length += url->m_len_user + 1; // +1 for "@"
-    if (url->m_ptr_password)
+    if (url->m_ptr_password) {
       length += url->m_len_password + 1; // +1 for ":"
+    }
   }
 
   if (url->m_ptr_host) {
     length += url->m_len_host;
-    if (url->m_ptr_port && url->m_port)
+    if (url->m_ptr_port && url->m_port) {
       length += url->m_len_port + 1; // +1 for ":"
+    }
   }
 
   if (url->m_ptr_path) {
@@ -868,13 +887,15 @@ url_to_string(URLImpl *url, Arena *arena, int *length)
 
   len = url_length_get(url) + 1;
 
-  if (length)
+  if (length) {
     *length = len;
+  }
 
-  if (arena)
+  if (arena) {
     str = arena->str_alloc(len);
-  else
+  } else {
     str = (char *)ats_malloc(len + 1);
+  }
 
   idx = 0;
 
@@ -961,8 +982,9 @@ unescape_str(char *&buf, char *buf_e, const char *&str, const char *str_e, int &
   copy_len  = (int)(first_pct - str);
   str += copy_len;
   buf += copy_len;
-  if (copy_len == min_len)
+  if (copy_len == min_len) {
     return;
+  }
 
   while (str < str_e && (buf != buf_e)) {
     switch (state) {
@@ -1082,8 +1104,9 @@ url_unescapify(Arena *arena, const char *str, int length)
   char *t, *e;
   int s;
 
-  if (length == -1)
+  if (length == -1) {
     length = (int)strlen(str);
+  }
 
   buffer = arena->str_alloc(length);
   t      = buffer;
@@ -1122,8 +1145,9 @@ url_parse_scheme(HdrHeap *heap, URLImpl *url, const char **start, const char *en
   const char *scheme_end   = NULL;
   int scheme_wks_idx;
 
-  while (' ' == *cur && ++cur < end)
+  while (' ' == *cur && ++cur < end) {
     ;
+  }
   if (cur < end) {
     scheme_start = scheme_end = cur;
     // special case 'http:' for performance
@@ -1134,8 +1158,9 @@ url_parse_scheme(HdrHeap *heap, URLImpl *url, const char **start, const char *en
       // For forward transparent mode, the URL for the method can just be a path,
       // so don't scan that for a scheme, as we could find a false positive if there
       // is a URL in the parameters (which is legal).
-      while (':' != *cur && ++cur < end)
+      while (':' != *cur && ++cur < end) {
         ;
+      }
       if (cur < end) { // found a colon
         scheme_wks_idx = hdrtoken_tokenize(scheme_start, cur - scheme_start, &scheme_wks);
 
@@ -1175,8 +1200,9 @@ url_is_strictly_compliant(const char *start, const char *end)
 MIMEParseResult
 url_parse(HdrHeap *heap, URLImpl *url, const char **start, const char *end, bool copy_strings_p, bool strict_uri_parsing)
 {
-  if (strict_uri_parsing && !url_is_strictly_compliant(*start, end))
+  if (strict_uri_parsing && !url_is_strictly_compliant(*start, end)) {
     return PARSE_ERROR;
+  }
 
   MIMEParseResult zret = url_parse_scheme(heap, url, start, end, copy_strings_p);
   return PARSE_CONT == zret ? url_parse_http(heap, url, start, end, copy_strings_p) : zret;
@@ -1229,8 +1255,9 @@ url_parse_internet(HdrHeap *heap, URLImpl *url, char const **start, char const *
     // appropriate!
     switch (*cur) {
     case ']': // address close
-      if (0 == bracket || n_colon >= MAX_COLON)
+      if (0 == bracket || n_colon >= MAX_COLON) {
         return PARSE_ERROR;
+      }
       ++cur;
       /* We keep the brackets because there are too many other places
          that depend on them and it's too painful to keep track if
@@ -1253,14 +1280,16 @@ url_parse_internet(HdrHeap *heap, URLImpl *url, char const **start, char const *
       n_colon = MAX_COLON - 1;
     // FALL THROUGH
     case ':': // track colons, fail if too many.
-      if (++n_colon > MAX_COLON)
+      if (++n_colon > MAX_COLON) {
         return PARSE_ERROR;
+      }
       last_colon = cur;
       ++cur;
       break;
     case '@': // user/password marker.
-      if (user || n_colon > 1)
+      if (user || n_colon > 1) {
         return PARSE_ERROR; // we already got one, or too many colons.
+      }
       if (n_colon) {
         user.set(base, last_colon);
         passw.set(last_colon + 1, cur);
@@ -1272,9 +1301,10 @@ url_parse_internet(HdrHeap *heap, URLImpl *url, char const **start, char const *
       ++cur;
       base = cur;
       break;
-    case '[':                     // address open
-      if (bracket || base != cur) // must be first char in field
+    case '[':                       // address open
+      if (bracket || base != cur) { // must be first char in field
         return PARSE_ERROR;
+      }
       bracket = cur; // location and flag.
       ++cur;
       break;
@@ -1291,8 +1321,9 @@ url_parse_internet(HdrHeap *heap, URLImpl *url, char const **start, char const *
 
   if (user) {
     url_user_set(heap, url, user._ptr, user._size, copy_strings_p);
-    if (passw)
+    if (passw) {
       url_password_set(heap, url, passw._ptr, passw._size, copy_strings_p);
+    }
   }
 
   // @a host not set means no brackets to mark explicit host.
@@ -1305,21 +1336,24 @@ url_parse_internet(HdrHeap *heap, URLImpl *url, char const **start, char const *
     }
   }
   if (host._size) {
-    if (validate_host_name(host))
+    if (validate_host_name(host)) {
       url_host_set(heap, url, host._ptr, host._size, copy_strings_p);
-    else
+    } else {
       return PARSE_ERROR;
+    }
   }
 
   if (last_colon) {
     ink_assert(n_colon);
     port.set(last_colon + 1, cur);
-    if (!port._size)
+    if (!port._size) {
       return PARSE_ERROR; // colon w/o port value.
+    }
     url_port_set(heap, url, port._ptr, port._size, copy_strings_p);
   }
-  if ('/' == *cur)
+  if ('/' == *cur) {
     ++cur; // must do this after filling in host/port.
+  }
   *start = cur;
   return PARSE_DONE;
 }
@@ -1345,12 +1379,14 @@ url_parse_http(HdrHeap *heap, URLImpl *url, const char **start, const char *end,
   char mask;
 
   err = url_parse_internet(heap, url, start, end, copy_strings);
-  if (err < 0)
+  if (err < 0) {
     return err;
+  }
 
   cur = *start;
-  if (*start == end)
+  if (*start == end) {
     goto done;
+  }
 
   path_start = cur;
   mask       = ';' & '?' & '#';
@@ -1407,23 +1443,27 @@ parse_fragment1:
 
 done:
   if (path_start) {
-    if (!path_end)
+    if (!path_end) {
       path_end = cur;
+    }
     url_path_set(heap, url, path_start, path_end - path_start, copy_strings);
   }
   if (params_start) {
-    if (!params_end)
+    if (!params_end) {
       params_end = cur;
+    }
     url_params_set(heap, url, params_start, params_end - params_start, copy_strings);
   }
   if (query_start) {
-    if (!query_end)
+    if (!query_end) {
       query_end = cur;
+    }
     url_query_set(heap, url, query_start, query_end - query_start, copy_strings);
   }
   if (fragment_start) {
-    if (!fragment_end)
+    if (!fragment_end) {
       fragment_end = cur;
+    }
     url_fragment_set(heap, url, fragment_start, fragment_end - fragment_start, copy_strings);
   }
 
@@ -1463,10 +1503,12 @@ url_parse_http_no_path_component_breakdown(HdrHeap *heap, URLImpl *url, const ch
     // or more than 5 digits and a delimiter.
     port                   = host_end - 1;
     char const *port_limit = host_end - 6;
-    if (port_limit < base)
+    if (port_limit < base) {
       port_limit = base; // don't go past start.
-    while (port >= port_limit && isdigit(*port))
+    }
+    while (port >= port_limit && isdigit(*port)) {
       --port;
+    }
     // A port if we're still in the host area and we found a ':' as
     // the immediately preceeding character.
     if (port >= base && ':' == *port) {
@@ -1529,11 +1571,13 @@ url_print(URLImpl *url, char *buf_start, int buf_length, int *buf_index_inout, i
     // But it can be less (e.g. "::1").
     int n          = url->m_len_host;
     bool bracket_p = '[' != *url->m_ptr_host && (0 != memchr(url->m_ptr_host, ':', n > 5 ? 5 : n));
-    if (bracket_p)
+    if (bracket_p) {
       TRY(mime_mem_print("[", 1, buf_start, buf_length, buf_index_inout, buf_chars_to_skip_inout));
+    }
     TRY(mime_mem_print(url->m_ptr_host, url->m_len_host, buf_start, buf_length, buf_index_inout, buf_chars_to_skip_inout));
-    if (bracket_p)
+    if (bracket_p) {
       TRY(mime_mem_print("]", 1, buf_start, buf_length, buf_index_inout, buf_chars_to_skip_inout));
+    }
     if (url->m_ptr_port && url->m_port) {
       TRY(mime_mem_print(":", 1, buf_start, buf_length, buf_index_inout, buf_chars_to_skip_inout));
       TRY(mime_mem_print(url->m_ptr_port, url->m_len_port, buf_start, buf_length, buf_index_inout, buf_chars_to_skip_inout));
@@ -1714,8 +1758,9 @@ url_MD5_get_general(const URLImpl *url, CryptoContext &ctx, CryptoHash &hash, ca
     }
   }
 
-  if (p != buffer)
+  if (p != buffer) {
     ctx.update(buffer, p - buffer);
+  }
 
   port = url_canonicalize_port(url->m_url_type, url->m_port);
 

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -204,10 +204,11 @@ Http1ClientSession::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader 
     tcp_init_cwnd_set = true;
     set_tcp_init_cwnd();
   }
-  if (client_vc)
+  if (client_vc) {
     return client_vc->do_io_write(c, nbytes, buf, owner);
-  else
+  } else {
     return NULL;
+  }
 }
 
 void
@@ -215,10 +216,12 @@ Http1ClientSession::set_tcp_init_cwnd()
 {
   int desired_tcp_init_cwnd = trans.get_sm()->t_state.txn_conf->server_tcp_init_cwnd;
   DebugHttpSsn("desired TCP congestion window is %d", desired_tcp_init_cwnd);
-  if (desired_tcp_init_cwnd == 0)
+  if (desired_tcp_init_cwnd == 0) {
     return;
-  if (get_netvc()->set_tcp_init_cwnd(desired_tcp_init_cwnd) != 0)
+  }
+  if (get_netvc()->set_tcp_init_cwnd(desired_tcp_init_cwnd) != 0) {
     DebugHttpSsn("set_tcp_init_cwnd(%d) failed", desired_tcp_init_cwnd);
+  }
 }
 
 void

--- a/proxy/http/HttpBodyFactory.cc
+++ b/proxy/http/HttpBodyFactory.cc
@@ -90,11 +90,13 @@ HttpBodyFactory::fabricate_with_old_api(const char *type, HttpTransact::State *c
     if (u->valid()) { /* if url exists, copy the string into buffer */
       size_t i;
       char *s = u->string_get(&context->arena);
-      for (i   = 0; (i < sizeof(url) - 1) && s[i]; i++)
+      for (i = 0; (i < sizeof(url) - 1) && s[i]; i++) {
         url[i] = s[i];
-      url[i]   = '\0';
-      if (s)
+      }
+      url[i] = '\0';
+      if (s) {
         context->arena.str_free(s);
+      }
     }
   }
   ///////////////////////////////////////////////
@@ -327,8 +329,9 @@ HttpBodyFactory::reconfigure()
   // building a new one, by scanning the template directory. //
   /////////////////////////////////////////////////////////////
 
-  if (directory_of_template_sets)
+  if (directory_of_template_sets) {
     table_of_sets = load_sets_from_directory(directory_of_template_sets);
+  }
 
   unlock();
 }
@@ -401,8 +404,9 @@ HttpBodyFactory::fabricate(StrList *acpt_language_list, StrList *acpt_charset_li
   HttpBodySet *body_set;
   char template_base[PATH_NAME_MAX];
 
-  if (set_return)
-    *set_return            = "???";
+  if (set_return) {
+    *set_return = "???";
+  }
   *content_language_return = NULL;
   *content_charset_return  = NULL;
 
@@ -421,15 +425,16 @@ HttpBodyFactory::fabricate(StrList *acpt_language_list, StrList *acpt_charset_li
   }
 
   // what set should we use (language target if enable_customizations == 2)
-  if (enable_customizations == 2)
+  if (enable_customizations == 2) {
     set = determine_set_by_language(acpt_language_list, acpt_charset_list);
-  else if (enable_customizations == 3) {
+  } else if (enable_customizations == 3) {
     set = determine_set_by_host(context);
-  } else
+  } else {
     set = "default";
-
-  if (set_return)
+  }
+  if (set_return) {
     *set_return = set;
+  }
   if (pType != NULL && 0 != *pType && 0 != strncmp(pType, "NONE", 4)) {
     sprintf(template_base, "%s_%s", pType, type);
   } else {
@@ -437,8 +442,9 @@ HttpBodyFactory::fabricate(StrList *acpt_language_list, StrList *acpt_charset_li
   }
   // see if we have a custom error page template
   t = find_template(set, template_base, &body_set);
-  if (t == NULL)
+  if (t == NULL) {
     t = find_template(set, type, &body_set); // this executes if the template_base is wrong and doesn't exist
+  }
   if (t == NULL) {
     Debug("body_factory", "  can't find template, returning NULL template");
     return (NULL);
@@ -494,19 +500,22 @@ HttpBodyFactory::find_template(const char *set, const char *type, HttpBodySet **
 
   *body_set_return = NULL;
 
-  if (table_of_sets == NULL)
+  if (table_of_sets == NULL) {
     return (NULL);
+  }
   if (table_of_sets->getValue((RawHashTable_Key)set, &v)) {
     HttpBodySet *body_set        = (HttpBodySet *)v;
     RawHashTable *table_of_types = body_set->table_of_pages;
 
-    if (table_of_types == NULL)
+    if (table_of_types == NULL) {
       return (NULL);
+    }
 
     if (table_of_types->getValue((RawHashTable_Key)type, &v)) {
       HttpBodyTemplate *t = (HttpBodyTemplate *)v;
-      if ((t == NULL) || (!t->is_sane()))
+      if ((t == NULL) || (!t->is_sane())) {
         return (NULL);
+      }
       *body_set_return = body_set;
 
       Debug("body_factory", "find_template(%s,%s) -> (file %s, length %" PRId64 ", lang '%s', charset '%s')", set, type,
@@ -539,10 +548,11 @@ HttpBodyFactory::is_response_suppressed(HttpTransact::State *context)
   } else if (response_suppression_mode == 1) {
     return (true);
   } else if (response_suppression_mode == 2) {
-    if (context->req_flavor == HttpTransact::REQ_FLAVOR_INTERCEPTED)
+    if (context->req_flavor == HttpTransact::REQ_FLAVOR_INTERCEPTED) {
       return (true);
-    else
+    } else {
       return (false);
+    }
   } else {
     return (false);
   }
@@ -613,8 +623,9 @@ HttpBodyFactory::load_sets_from_directory(char *set_dir)
   struct dirent *entry_buffer, *result;
   RawHashTable *new_table_of_sets;
 
-  if (set_dir == NULL)
+  if (set_dir == NULL) {
     return (NULL);
+  }
 
   Debug("body_factory", "load_sets_from_directory(%s)", set_dir);
 
@@ -645,14 +656,17 @@ HttpBodyFactory::load_sets_from_directory(char *set_dir)
     // ensure a subdirectory, and not starting with '.' //
     //////////////////////////////////////////////////////
 
-    if ((entry_buffer->d_name)[0] == '.')
+    if ((entry_buffer->d_name)[0] == '.') {
       continue;
+    }
     ink_filepath_make(subdir, sizeof(subdir), set_dir, entry_buffer->d_name);
     status = stat(subdir, &stat_buf);
-    if (status != 0)
+    if (status != 0) {
       continue; // can't stat
-    if (!S_ISDIR(stat_buf.st_mode))
+    }
+    if (!S_ISDIR(stat_buf.st_mode)) {
       continue; // not a dir
+    }
 
     ///////////////////////////////////////////////////////////
     // at this point, 'subdir' might be a valid template dir //
@@ -687,8 +701,9 @@ HttpBodyFactory::load_body_set_from_directory(char *set_name, char *tmpl_dir)
 
   Debug("body_factory", "  load_body_set_from_directory(%s)", tmpl_dir);
   dir = opendir(tmpl_dir);
-  if (dir == NULL)
+  if (dir == NULL) {
     return (NULL);
+  }
 
   /////////////////////////////////////////////
   // ensure a .body_factory_info file exists //
@@ -720,15 +735,18 @@ HttpBodyFactory::load_body_set_from_directory(char *set_name, char *tmpl_dir)
     // all template files have name of the form <type>#<subtype> //
     ///////////////////////////////////////////////////////////////
 
-    if ((strchr(entry_buffer->d_name, '#') == NULL) && (strcmp(entry_buffer->d_name, "default") != 0))
+    if ((strchr(entry_buffer->d_name, '#') == NULL) && (strcmp(entry_buffer->d_name, "default") != 0)) {
       continue;
+    }
 
     snprintf(path, sizeof(path), "%s/%s", tmpl_dir, entry_buffer->d_name);
     status = stat(path, &stat_buf);
-    if (status != 0)
+    if (status != 0) {
       continue; // can't stat
-    if (!S_ISREG(stat_buf.st_mode))
+    }
+    if (!S_ISREG(stat_buf.st_mode)) {
       continue; // not a file
+    }
 
     ////////////////////////////////
     // read in this template file //
@@ -769,8 +787,9 @@ HttpBodySet::~HttpBodySet()
   ats_free(set_name);
   ats_free(content_language);
   ats_free(content_charset);
-  if (table_of_pages)
+  if (table_of_pages) {
     delete table_of_pages;
+  }
 }
 
 int
@@ -783,13 +802,15 @@ HttpBodySet::init(char *set, char *dir)
 
   ink_filepath_make(info_path, sizeof(info_path), dir, ".body_factory_info");
   fd = open(info_path, O_RDONLY);
-  if (fd < 0)
+  if (fd < 0) {
     return (-1);
+  }
 
   this->set_name = ats_strdup(set);
 
-  if (this->table_of_pages)
+  if (this->table_of_pages) {
     delete (this->table_of_pages);
+  }
   this->table_of_pages = new RawHashTable(RawHashTable_KeyType_String);
 
   lineno = 0;
@@ -799,49 +820,56 @@ HttpBodySet::init(char *set, char *dir)
 
     ++lineno;
     int bytes = ink_file_fd_readline(fd, sizeof(buffer), buffer);
-    if (bytes <= 0)
+    if (bytes <= 0) {
       break;
+    }
 
     ///////////////////////////////////////////////
     // chop anything on and after first '#' sign //
     ///////////////////////////////////////////////
 
     hash = index(buffer, '#');
-    if (hash)
+    if (hash) {
       *hash = '\0';
 
-    ////////////////////////////////
-    // find start and end of name //
-    ////////////////////////////////
-
+      ////////////////////////////////
+      // find start and end of name //
+      ////////////////////////////////
+    }
     name_s = buffer;
-    while (*name_s && ParseRules::is_wslfcr(*name_s))
+    while (*name_s && ParseRules::is_wslfcr(*name_s)) {
       ++name_s;
+    }
 
     name_e = name_s;
-    while (*name_e && ParseRules::is_http_field_name(*name_e))
+    while (*name_e && ParseRules::is_http_field_name(*name_e)) {
       ++name_e;
+    }
 
-    if (name_s == name_e)
+    if (name_s == name_e) {
       continue; // blank line
+    }
 
     /////////////////////////////////
     // find start and end of value //
     /////////////////////////////////
 
     value_s = name_e;
-    while (*value_s && (ParseRules::is_wslfcr(*value_s)))
+    while (*value_s && (ParseRules::is_wslfcr(*value_s))) {
       ++value_s;
+    }
     if (*value_s != ':') {
       Warning("ignoring invalid body factory info line #%d in %s", lineno, info_path);
       continue;
     }
     ++value_s; // skip the colon
-    while (*value_s && (ParseRules::is_wslfcr(*value_s)))
+    while (*value_s && (ParseRules::is_wslfcr(*value_s))) {
       ++value_s;
+    }
     value_e = buffer + strlen(buffer) - 1;
-    while ((value_e > value_s) && ParseRules::is_wslfcr(*(value_e - 1)))
+    while ((value_e > value_s) && ParseRules::is_wslfcr(*(value_e - 1))) {
       --value_e;
+    }
 
     /////////////////////////////////
     // insert line into hash table //
@@ -871,13 +899,15 @@ HttpBodySet::init(char *set, char *dir)
   ////////////////////////////////////////////////////
 
   if (!this->content_language) {
-    if (strcmp(set, "default") == 0)
+    if (strcmp(set, "default") == 0) {
       this->content_language = ats_strdup("en");
-    else
+    } else {
       this->content_language = ats_strdup(set);
+    }
   }
-  if (!this->content_charset)
+  if (!this->content_charset) {
     this->content_charset = ats_strdup("utf-8");
+  }
 
   close(fd);
   return (lines_added);
@@ -890,13 +920,15 @@ HttpBodySet::get_template_by_name(const char *name)
 
   Debug("body_factory", "    calling get_template_by_name(%s)", name);
 
-  if (table_of_pages == NULL)
+  if (table_of_pages == NULL) {
     return (NULL);
+  }
 
   if (table_of_pages->getValue((RawHashTable_Key)name, &v)) {
     HttpBodyTemplate *t = (HttpBodyTemplate *)v;
-    if ((t == NULL) || (!t->is_sane()))
+    if ((t == NULL) || (!t->is_sane())) {
       return (NULL);
+    }
     Debug("body_factory", "    get_template_by_name(%s) -> (file %s, length %" PRId64 ")", name, t->template_pathname,
           t->byte_count);
     return (t);
@@ -956,10 +988,12 @@ HttpBodyTemplate::load_from_file(char *dir, char *file)
   snprintf(path, sizeof(path), "%s/%s", dir, file);
   // coverity[fs_check_call]
   status = stat(path, &stat_buf);
-  if (status != 0)
+  if (status != 0) {
     return (0);
-  if (!S_ISREG(stat_buf.st_mode))
+  }
+  if (!S_ISREG(stat_buf.st_mode)) {
     return (0);
+  }
 
   ///////////////////
   // open the file //
@@ -967,8 +1001,9 @@ HttpBodyTemplate::load_from_file(char *dir, char *file)
 
   // coverity[toctou]
   fd = open(path, O_RDONLY);
-  if (fd < 0)
+  if (fd < 0) {
     return (0);
+  }
 
   ////////////////////////////////////////
   // read in the template file contents //

--- a/proxy/http/HttpCacheSM.cc
+++ b/proxy/http/HttpCacheSM.cc
@@ -56,8 +56,9 @@ HttpCacheAction::cancel(Continuation *c)
   ink_assert(this->cancelled == 0);
 
   this->cancelled = 1;
-  if (sm->pending_action)
+  if (sm->pending_action) {
     sm->pending_action->cancel();
+  }
 }
 
 HttpCacheSM::HttpCacheSM()
@@ -298,8 +299,9 @@ HttpCacheSM::open_read(const HttpCacheKey *key, URL *url, HTTPHdr *hdr, CacheLoo
     ink_assert(current_lookup_level < lookup_max_recursive);
     current_lookup_level--;
 
-    if (current_lookup_level == 0)
+    if (current_lookup_level == 0) {
       lookup_max_recursive = 0;
+    }
 
     return ACTION_RESULT_DONE;
   }

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -174,8 +174,9 @@ http_server_session_sharing_cb(char const *name, RecDataT dtype, RecData data, v
   }
 
   // Signal an update if valid value arrived.
-  if (valid_p)
+  if (valid_p) {
     http_config_cb(name, dtype, data, cookie);
+  }
 
   return REC_ERR_OKAY;
 }
@@ -1198,10 +1199,12 @@ HttpConfig::reconfigure()
   params->oride.flow_high_water_mark = m_master.oride.flow_high_water_mark;
   params->oride.flow_low_water_mark  = m_master.oride.flow_low_water_mark;
   // If not set (zero) then make values the same.
-  if (params->oride.flow_low_water_mark <= 0)
+  if (params->oride.flow_low_water_mark <= 0) {
     params->oride.flow_low_water_mark = params->oride.flow_high_water_mark;
-  if (params->oride.flow_high_water_mark <= 0)
+  }
+  if (params->oride.flow_high_water_mark <= 0) {
     params->oride.flow_high_water_mark = params->oride.flow_low_water_mark;
+  }
   if (params->oride.flow_high_water_mark < params->oride.flow_low_water_mark) {
     Warning("Flow control low water mark is greater than high water mark, flow control disabled");
     params->oride.flow_control_enabled = 0;
@@ -1422,8 +1425,9 @@ HttpConfig::parse_ports_list(char *ports_string)
 {
   HttpConfigPortRange *ports_list = 0;
 
-  if (!ports_string)
+  if (!ports_string) {
     return (0);
+  }
 
   if (strchr(ports_string, '*')) {
     ports_list       = new HttpConfigPortRange;
@@ -1441,42 +1445,49 @@ HttpConfig::parse_ports_list(char *ports_string)
     start = ports_string;
 
     while (1) { // eat whitespace
-      while ((start[0] != '\0') && ParseRules::is_space(start[0]))
+      while ((start[0] != '\0') && ParseRules::is_space(start[0])) {
         start++;
+      }
 
       // locate the end of the next number
       end = start;
-      while ((end[0] != '\0') && ParseRules::is_digit(end[0]))
+      while ((end[0] != '\0') && ParseRules::is_digit(end[0])) {
         end++;
+      }
 
       // if there is no next number we're done
-      if (start == end)
+      if (start == end) {
         break;
+      }
 
       pr       = new HttpConfigPortRange;
       pr->low  = atoi(start);
       pr->high = pr->low;
       pr->next = NULL;
 
-      if (prev)
+      if (prev) {
         prev->next = pr;
-      else
+      } else {
         ports_list = pr;
-      prev         = pr;
+      }
+      prev = pr;
 
       // if the next character after the current port
       //  number is a dash then we are parsing a range
       if (end[0] == '-') {
         start = end + 1;
-        while ((start[0] != '\0') && ParseRules::is_space(start[0]))
+        while ((start[0] != '\0') && ParseRules::is_space(start[0])) {
           start++;
+        }
 
         end = start;
-        while ((end[0] != '\0') && ParseRules::is_digit(end[0]))
+        while ((end[0] != '\0') && ParseRules::is_digit(end[0])) {
           end++;
+        }
 
-        if (start == end)
+        if (start == end) {
           break;
+        }
 
         pr->high = atoi(start);
       }
@@ -1508,16 +1519,19 @@ HttpConfig::parse_url_expansions(char *url_expansions_str, int *num_expansions)
   char *start = url_expansions_str, *end;
   while (1) {
     // Skip whitespace
-    while (isspace(*start))
+    while (isspace(*start)) {
       start++;
-    if (*start == '\0')
+    }
+    if (*start == '\0') {
       break;
+    }
     count++;
     end = start + 1;
 
     // Find end of expansion
-    while (!isspace(*end) && *end != '\0')
+    while (!isspace(*end) && *end != '\0') {
       end++;
+    }
     start = end;
   }
 
@@ -1527,17 +1541,20 @@ HttpConfig::parse_url_expansions(char *url_expansions_str, int *num_expansions)
     start      = url_expansions_str;
     for (i = 0; i < count; i++) {
       // Skip whitespace
-      while (isspace(*start))
+      while (isspace(*start)) {
         start++;
+      }
       expansions[i] = start;
       end           = start + 1;
 
       // Find end of expansion
-      while (!isspace(*end) && *end != '\0')
+      while (!isspace(*end) && *end != '\0') {
         end++;
+      }
       *end = '\0';
-      if (i < (count - 1))
+      if (i < (count - 1)) {
         start = end + 1;
+      }
     }
   }
 

--- a/proxy/http/HttpProxyServerMain.cc
+++ b/proxy/http/HttpProxyServerMain.cc
@@ -293,11 +293,13 @@ start_HttpProxyServer()
     HttpProxyAcceptor &acceptor = HttpProxyAcceptors[i];
     HttpProxyPort &port         = proxy_ports[i];
     if (port.isSSL()) {
-      if (NULL == sslNetProcessor.main_accept(acceptor._accept, port.m_fd, acceptor._net_opt))
+      if (NULL == sslNetProcessor.main_accept(acceptor._accept, port.m_fd, acceptor._net_opt)) {
         return;
+      }
     } else if (!port.isPlugin()) {
-      if (NULL == netProcessor.main_accept(acceptor._accept, port.m_fd, acceptor._net_opt))
+      if (NULL == netProcessor.main_accept(acceptor._accept, port.m_fd, acceptor._net_opt)) {
         return;
+      }
     }
     // XXX although we make a good pretence here, I don't believe that NetProcessor::main_accept() ever actually returns
     // NULL. It would be useful to be able to detect errors and spew them here though.

--- a/proxy/http/HttpServerSession.cc
+++ b/proxy/http/HttpServerSession.cc
@@ -50,10 +50,11 @@ HttpServerSession::destroy()
   }
 
   mutex.clear();
-  if (TS_SERVER_SESSION_SHARING_POOL_THREAD == sharing_pool)
+  if (TS_SERVER_SESSION_SHARING_POOL_THREAD == sharing_pool) {
     THREAD_FREE(this, httpServerSessionAllocator, this_thread());
-  else
+  } else {
     httpServerSessionAllocator.free(this);
+  }
 }
 
 void
@@ -74,8 +75,9 @@ HttpServerSession::new_connection(NetVConnection *new_vc)
   // Check to see if we are limiting the number of connections
   // per host
   if (enable_origin_connection_limiting == true) {
-    if (connection_count == NULL)
+    if (connection_count == NULL) {
       connection_count = ConnectionCount::getInstance();
+    }
     connection_count->incrementCount(server_ip, hostname_hash, sharing_match);
     ip_port_text_buffer addrbuf;
     Debug("http_ss", "[%" PRId64 "] new connection, ip: %s, count: %u", con_id,

--- a/proxy/http/HttpSessionManager.cc
+++ b/proxy/http/HttpSessionManager.cc
@@ -83,8 +83,9 @@ ServerSessionPool::acquireSession(sockaddr const *addr, INK_MD5 const &hostname_
     // This is broken out because only in this case do we check the host hash first.
     HostHashTable::Location loc = m_host_pool.find(hostname_hash);
     in_port_t port              = ats_ip_port_cast(addr);
-    while (loc && port != ats_ip_port_cast(loc->server_ip))
+    while (loc && port != ats_ip_port_cast(loc->server_ip)) {
       ++loc; // scan for matching port.
+    }
     if (loc) {
       to_return = loc;
       m_host_pool.remove(loc);
@@ -96,8 +97,9 @@ ServerSessionPool::acquireSession(sockaddr const *addr, INK_MD5 const &hostname_
     // Otherwise we need to scan further matches to match the host name as well.
     // Note we don't have to check the port because it's checked as part of the IP address key.
     if (TS_SERVER_SESSION_SHARING_MATCH_IP != match_style) {
-      while (loc && loc->hostname_hash != hostname_hash)
+      while (loc && loc->hostname_hash != hostname_hash) {
         ++loc;
+      }
     }
     if (loc) {
       to_return = loc;

--- a/proxy/http/HttpTransactCache.cc
+++ b/proxy/http/HttpTransactCache.cc
@@ -59,8 +59,9 @@ find_etag(const char *raw_tag_field, int raw_tag_field_len, int *length)
     ++etag_start;
     --etag_length;
     quote = (const char *)memchr(etag_start, '"', etag_length);
-    if (quote)
+    if (quote) {
       etag_length = quote - etag_start;
+    }
   }
   *length = etag_length;
   return etag_start;
@@ -92,8 +93,9 @@ do_strings_match_strongly(const char *raw_tag_field, int raw_tag_field_len, cons
   // Loop over all the tags in the tag list
   for (Str *tag = tag_list.head; tag; tag = tag->next) {
     // If field is "*", then we got a match
-    if ((tag->len == 1) && (tag->str[0] == '*'))
+    if ((tag->len == 1) && (tag->str[0] == '*')) {
       return true;
+    }
 
     n = 0;
 
@@ -127,14 +129,16 @@ do_strings_match_weakly(const char *raw_tag_field, int raw_tag_field_len, const 
 
   for (Str *tag = tag_list.head; tag; tag = tag->next) {
     // If field is "*", then we got a match
-    if ((tag->len == 1) && (tag->str[0] == '*'))
+    if ((tag->len == 1) && (tag->str[0] == '*')) {
       return true;
+    }
 
     // strip off the leading 'W/' and quotation marks from the
     // current tag, then compare for equality with above tag.
     cur_tag = find_etag(tag->str, tag->len, &cur_tag_len);
-    if ((cur_tag_len == etag_length) && (strncmp(cur_tag, etag_start, cur_tag_len) == 0))
+    if ((cur_tag_len == etag_length) && (strncmp(cur_tag, etag_start, cur_tag_len) == 0)) {
       return true;
+    }
   }
   return false;
 }
@@ -186,8 +190,9 @@ HttpTransactCache::SelectFromAlternates(CacheHTTPInfoVector *cache_vector, HTTPH
     RELEASE_PRINT_LOCK()
   }
   // used by ICP to bypass this function
-  if (http_config_params == &global_cache_lookup_config)
+  if (http_config_params == &global_cache_lookup_config) {
     return 0;
+  }
 
   if (!client_request->valid()) {
     return 0;
@@ -211,8 +216,9 @@ HttpTransactCache::SelectFromAlternates(CacheHTTPInfoVector *cache_vector, HTTPH
       Q = calculate_quality_of_match(http_config_params, client_request, cached_request, cached_response);
 
       if (alt_count > 1) {
-        if (t_now == 0)
-          t_now     = ink_cluster_time();
+        if (t_now == 0) {
+          t_now = ink_cluster_time();
+        }
         current_age = HttpTransactHeaders::calculate_document_age(obj->request_sent_time_get(), obj->response_received_time_get(),
                                                                   cached_response, cached_response->get_date(), t_now);
         // Overflow?
@@ -298,8 +304,9 @@ HttpTransactCache::calculate_quality_of_match(CacheLookupHttpConfig *http_config
                                               HTTPHdr *obj_client_request, HTTPHdr *obj_origin_server_response)
 {
   // For PURGE requests, any alternate is good really.
-  if (client_request->method_get_wksidx() == HTTP_WKSIDX_PURGE)
+  if (client_request->method_get_wksidx() == HTTP_WKSIDX_PURGE) {
     return (float)1.0;
+  }
 
   // Now calculate a quality based on all sorts of logic
   float q[4], Q;
@@ -442,8 +449,9 @@ HttpTransactCache::calculate_quality_of_match(CacheLookupHttpConfig *http_config
         if (info.m_qvalue < 0.0) {
           info.m_qvalue = 0.0;
         } else if (info.m_qvalue > 1.0) {
-          if (info.m_qvalue == FLT_MAX)
-            force_alt   = 1;
+          if (info.m_qvalue == FLT_MAX) {
+            force_alt = 1;
+          }
           info.m_qvalue = 1.0;
         }
         qvalue *= info.m_qvalue;
@@ -549,8 +557,9 @@ HttpTransactCache::calculate_quality_of_accept_match(MIMEField *accept_field, MI
 
     // Read the next type/subtype media-range
     Str *a_param = a_param_list.head;
-    if (!a_param)
+    if (!a_param) {
       continue;
+    }
 
     // Parse the type and subtype of the Accept field
     char a_type[32], a_subtype[32];
@@ -666,8 +675,9 @@ HttpTransactCache::calculate_quality_of_accept_charset_match(MIMEField *accept_f
     if (a_param_list.head) {
       a_charset     = (char *)a_param_list.head->str;
       a_charset_len = a_param_list.head->len;
-    } else
+    } else {
       continue;
+    }
 
     //      printf("matching Content-type; '%s' with Accept-Charset value '%s'\n",
     //             c_charset,a_charset);
@@ -733,8 +743,9 @@ HttpTransactCache::calculate_quality_of_accept_charset_match(MIMEField *accept_f
 static inline bool
 does_encoding_match(char *enc1, const char *enc2)
 {
-  if (is_asterisk(enc1) || ((strcasecmp(enc1, enc2)) == 0))
+  if (is_asterisk(enc1) || ((strcasecmp(enc1, enc2)) == 0)) {
     return true;
+  }
 
   // rfc2616,sec3.5: applications SHOULD consider "x-gzip" and "x-compress" to be
   //                equivalent to "gzip" and "compress" respectively
@@ -764,10 +775,11 @@ HttpTransactCache::match_gzip(MIMEField *accept_field)
     StrList a_param_list;
     a_raw = a_value->str;
     HttpCompat::parse_semicolon_list(&a_param_list, a_raw);
-    if (a_param_list.head)
+    if (a_param_list.head) {
       a_encoding = (char *)a_param_list.head->str;
-    else
+    } else {
       continue;
+    }
     float q;
     q = HttpCompat::find_Q_param_in_strlist(&a_param_list);
     if (q != 0 && does_encoding_match(a_encoding, "gzip")) {
@@ -801,10 +813,11 @@ match_accept_content_encoding(const char *c_raw, MIMEField *accept_field, bool *
 
     // break Accept-Encoding piece into semi-colon separated parts //
     HttpCompat::parse_semicolon_list(&a_param_list, a_raw);
-    if (a_param_list.head)
+    if (a_param_list.head) {
       a_encoding = (char *)a_param_list.head->str;
-    else
+    } else {
       continue;
+    }
 
     if (is_asterisk(a_encoding)) {
       *wildcard_present = true;
@@ -1191,8 +1204,9 @@ HttpTransactCache::CalcVariability(CacheLookupHttpConfig *http_config_params, HT
 
     // for each field that varies, see if current & original hdrs match //
     for (Str *field = vary_list.head; field != NULL; field = field->next) {
-      if (field->len == 0)
+      if (field->len == 0) {
         continue;
+      }
 
       /////////////////////////////////////////////////////////////
       // If the field name is unhandled, we should probably do a //
@@ -1210,13 +1224,15 @@ HttpTransactCache::CalcVariability(CacheLookupHttpConfig *http_config_params, HT
       // Special case: if 'proxy.config.http.global_user_agent_header' set                  //
       // we should ignore Vary: User-Agent.                                                 //
       ////////////////////////////////////////////////////////////////////////////////////////
-      if (http_config_params->cache_global_user_agent_header && !strcasecmp((char *)field->str, "User-Agent"))
+      if (http_config_params->cache_global_user_agent_header && !strcasecmp((char *)field->str, "User-Agent")) {
         continue;
+      }
 
       // Disable Vary mismatch checking for Accept-Encoding.  This is only safe to
       // set if you are promising to fix any Accept-Encoding/Content-Encoding mismatches.
-      if (http_config_params->ignore_accept_encoding_mismatch && !strcasecmp((char *)field->str, "Accept-Encoding"))
+      if (http_config_params->ignore_accept_encoding_mismatch && !strcasecmp((char *)field->str, "Accept-Encoding")) {
         continue;
+      }
 
       ///////////////////////////////////////////////////////////////////
       // Take the current vary field and look up the headers in        //
@@ -1236,8 +1252,9 @@ HttpTransactCache::CalcVariability(CacheLookupHttpConfig *http_config_params, HT
       ink_assert(strlen(field->str) == field->len);
 
       char *field_name_str = (char *)hdrtoken_string_to_wks(field->str, field->len);
-      if (field_name_str == NULL)
+      if (field_name_str == NULL) {
         field_name_str = (char *)field->str;
+      }
 
       MIMEField *cached_hdr_field  = obj_client_request->field_find(field_name_str, field->len);
       MIMEField *current_hdr_field = client_request->field_find(field_name_str, field->len);
@@ -1472,28 +1489,32 @@ CacheLookupHttpConfig::marshal(char *buf, int length)
   char *p = buf;
   int len;
 
-  if ((length -= sizeof(int32_t)) < 0)
+  if ((length -= sizeof(int32_t)) < 0) {
     return -1;
+  }
 
   i32_tmp = (int32_t)cache_enable_default_vary_headers;
   memcpy(p, &i32_tmp, sizeof(int32_t));
   p += sizeof(int32_t);
 
   len = (cache_vary_default_text ? strlen(cache_vary_default_text) + 1 : 1);
-  if ((length -= len) < 0)
+  if ((length -= len) < 0) {
     return -1;
+  }
   ink_strlcpy(p, (cache_vary_default_text ? cache_vary_default_text : ""), length);
   p += len;
 
   len = (cache_vary_default_images ? strlen(cache_vary_default_images) + 1 : 1);
-  if ((length -= len) < 0)
+  if ((length -= len) < 0) {
     return -1;
+  }
   ink_strlcpy(p, (cache_vary_default_images ? cache_vary_default_images : ""), length);
   p += len;
 
   len = (cache_vary_default_other ? strlen(cache_vary_default_other) + 1 : 1);
-  if ((length -= len) < 0)
+  if ((length -= len) < 0) {
     return -1;
+  }
   ink_strlcpy(p, (cache_vary_default_other ? cache_vary_default_other : ""), length);
   p += len;
 
@@ -1508,28 +1529,32 @@ CacheLookupHttpConfig::unmarshal(Arena *arena, const char *buf, int buflen)
   int len;
   int32_t i32_tmp;
 
-  if ((length -= sizeof(int32_t)) < 0)
+  if ((length -= sizeof(int32_t)) < 0) {
     return -1;
+  }
 
   memcpy(&i32_tmp, p, sizeof(int32_t));
   cache_enable_default_vary_headers = (bool)i32_tmp;
   p += sizeof(int32_t);
 
   len = strlen(p) + 1;
-  if ((length -= len) < 0)
+  if ((length -= len) < 0) {
     return -1;
+  }
   cache_vary_default_text = arena->str_store(((len == 2) ? "" : p), len - 1);
   p += len;
 
   len = strlen(p) + 1;
-  if ((length -= len) < 0)
+  if ((length -= len) < 0) {
     return -1;
+  }
   cache_vary_default_images = arena->str_store(((len == 2) ? "" : p), len - 1);
   p += len;
 
   len = strlen(p) + 1;
-  if ((length -= len) < 0)
+  if ((length -= len) < 0) {
     return -1;
+  }
   cache_vary_default_other = arena->str_store(((len == 2) ? "" : p), len - 1);
   p += len;
 

--- a/proxy/http/HttpTransactHeaders.cc
+++ b/proxy/http/HttpTransactHeaders.cc
@@ -49,8 +49,9 @@ HttpTransactHeaders::is_method_cache_lookupable(int method)
 bool
 HttpTransactHeaders::is_this_a_hop_by_hop_header(const char *field_name)
 {
-  if (!hdrtoken_is_wks(field_name))
+  if (!hdrtoken_is_wks(field_name)) {
     return (false);
+  }
   if ((hdrtoken_wks_to_flags(field_name) & MIME_FLAGS_HOPBYHOP) && (field_name != MIME_FIELD_KEEP_ALIVE)) {
     return (true);
   } else {
@@ -67,8 +68,9 @@ HttpTransactHeaders::is_this_method_supported(int the_scheme, int the_method)
     return is_this_http_method_supported(the_method);
   } else if ((the_scheme == URL_WKSIDX_WS || the_scheme == URL_WKSIDX_WSS) && the_method == HTTP_WKSIDX_GET) {
     return true;
-  } else
+  } else {
     return false;
+  }
 }
 
 void
@@ -102,8 +104,9 @@ HttpTransactHeaders::insert_supported_methods_in_response(HTTPHdr *response, int
       ++num_methods_supported;
       method_output_lengths[i] = hdrtoken_wks_to_length(method_wks);
       bytes += method_output_lengths[i];
-      if (num_methods_supported > 1)
+      if (num_methods_supported > 1) {
         bytes += 2; // +2 if need leading ", "
+      }
     } else {
       method_output_lengths[i] = 0;
     }
@@ -196,8 +199,9 @@ HttpTransactHeaders::copy_header_fields(HTTPHdr *src_hdr, HTTPHdr *new_hdr, bool
   //         should be modified when when the decision is made to dechunk it
 
   for (field = new_hdr->iter_get_first(&field_iter); field != NULL; field = new_hdr->iter_get_next(&field_iter)) {
-    if (field->m_wks_idx == -1)
+    if (field->m_wks_idx == -1) {
       continue;
+    }
 
     int field_flags = hdrtoken_index_to_flags(field->m_wks_idx);
 
@@ -212,8 +216,9 @@ HttpTransactHeaders::copy_header_fields(HTTPHdr *src_hdr, HTTPHdr *new_hdr, bool
   }
 
   // Set date hdr if not already set and valid value passed in
-  if ((date_hdr == false) && (date > 0))
+  if ((date_hdr == false) && (date > 0)) {
     new_hdr->set_date(date);
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -427,10 +432,11 @@ HttpTransactHeaders::does_server_allow_response_to_be_stored(HTTPHdr *resp)
 {
   uint32_t cc_mask = (MIME_COOKED_MASK_CC_NO_CACHE | MIME_COOKED_MASK_CC_NO_STORE | MIME_COOKED_MASK_CC_PRIVATE);
 
-  if ((resp->get_cooked_cc_mask() & cc_mask) || (resp->get_cooked_pragma_no_cache()))
+  if ((resp->get_cooked_cc_mask() & cc_mask) || (resp->get_cooked_pragma_no_cache())) {
     return false;
-  else
+  } else {
     return true;
+  }
 }
 
 bool
@@ -482,10 +488,10 @@ HttpTransactHeaders::generate_and_set_squid_codes(HTTPHdr *header, char *via_str
     int reason_len;
     const char *reason = header->reason_get(&reason_len);
 
-    if (reason != NULL && reason_len >= 24 && reason[0] == '!' && reason[1] == SQUID_HIT_RESERVED)
+    if (reason != NULL && reason_len >= 24 && reason[0] == '!' && reason[1] == SQUID_HIT_RESERVED) {
       hit_miss_code = SQUID_HIT_RESERVED;
-    // its a miss in the cache. find out why.
-    else if (via_string[VIA_DETAIL_CACHE_LOOKUP] == VIA_DETAIL_MISS_EXPIRED) {
+      // its a miss in the cache. find out why.
+    } else if (via_string[VIA_DETAIL_CACHE_LOOKUP] == VIA_DETAIL_MISS_EXPIRED) {
       hit_miss_code = SQUID_MISS_PRE_EXPIRED;
     } else if (via_string[VIA_DETAIL_CACHE_LOOKUP] == VIA_DETAIL_MISS_CONFIG) {
       hit_miss_code = SQUID_MISS_NONE;
@@ -628,10 +634,11 @@ HttpTransactHeaders::insert_warning_header(HttpConfigParams *http_config_param, 
   // + 23 for 20 possible digits of warning code (long long max
   //  digits) & 2 spaces & the string terminator
   bufsize = http_config_param->proxy_response_via_string_len + 23;
-  if (warn_text != NULL)
+  if (warn_text != NULL) {
     bufsize += warn_text_len;
-  else
+  } else {
     warn_text_len = 0; // Make sure it's really zero
+  }
 
   char *warning_text = (char *)alloca(bufsize);
 
@@ -651,8 +658,9 @@ HttpTransactHeaders::insert_time_and_age_headers_in_response(ink_time_t request_
 
   // FIX: should handle missing date when response is received, not here.
   //      See INKqa09852.
-  if (date <= 0)
+  if (date <= 0) {
     outgoing->set_date(now);
+  }
 }
 
 void
@@ -926,12 +934,14 @@ HttpTransactHeaders::add_global_user_agent_header_to_request(OverridableHttpConf
 
     Debug("http_trans", "Adding User-Agent: %s", http_txn_conf->global_user_agent_header);
     if ((ua_field = header->field_find(MIME_FIELD_USER_AGENT, MIME_LEN_USER_AGENT)) == NULL) {
-      if (likely((ua_field = header->field_create(MIME_FIELD_USER_AGENT, MIME_LEN_USER_AGENT)) != NULL))
+      if (likely((ua_field = header->field_create(MIME_FIELD_USER_AGENT, MIME_LEN_USER_AGENT)) != NULL)) {
         header->field_attach(ua_field);
+      }
     }
     // This will remove any old string (free it), and set our User-Agent.
-    if (likely(ua_field))
+    if (likely(ua_field)) {
       header->field_value_set(ua_field, http_txn_conf->global_user_agent_header, http_txn_conf->global_user_agent_header_size);
+    }
   }
 }
 
@@ -943,8 +953,9 @@ HttpTransactHeaders::add_server_header_to_response(OverridableHttpConfigParams *
     bool do_add = true;
 
     if ((ua_field = header->field_find(MIME_FIELD_SERVER, MIME_LEN_SERVER)) == NULL) {
-      if (likely((ua_field = header->field_create(MIME_FIELD_SERVER, MIME_LEN_SERVER)) != NULL))
+      if (likely((ua_field = header->field_create(MIME_FIELD_SERVER, MIME_LEN_SERVER)) != NULL)) {
         header->field_attach(ua_field);
+      }
     } else {
       // There was an existing header from Origin, so only add if setting allows to overwrite.
       do_add = (1 == http_txn_conf->proxy_response_server_enabled);
@@ -963,8 +974,9 @@ void
 HttpTransactHeaders::remove_privacy_headers_from_request(HttpConfigParams *http_config_param,
                                                          OverridableHttpConfigParams *http_txn_conf, HTTPHdr *header)
 {
-  if (!header)
+  if (!header) {
     return;
+  }
 
   // From
   if (http_txn_conf->anonymize_remove_from) {

--- a/proxy/http/remap/AclFiltering.cc
+++ b/proxy/http/remap/AclFiltering.cc
@@ -134,8 +134,9 @@ acl_filter_rule::find_byname(acl_filter_rule *list, const char *_name)
   acl_filter_rule *rp = 0;
   if (likely(list && _name && (_name_size = strlen(_name)) > 0)) {
     for (rp = list; rp; rp = rp->next) {
-      if (strcasecmp(rp->filter_name, _name) == 0)
+      if (strcasecmp(rp->filter_name, _name) == 0) {
         break;
+      }
     }
   }
   return rp;
@@ -170,8 +171,9 @@ acl_filter_rule::requeue_in_active_list(acl_filter_rule **list, acl_filter_rule 
         }
       }
       for (rpp = list; ((r = *rpp) != NULL); rpp = &(r->next)) {
-        if (r->active_queue_flag == 0)
+        if (r->active_queue_flag == 0) {
           break;
+        }
       }
       (*rpp = rp)->next     = r;
       rp->active_queue_flag = 1;
@@ -191,8 +193,9 @@ acl_filter_rule::requeue_in_passive_list(acl_filter_rule **list, acl_filter_rule
           break;
         }
       }
-      for (rpp = list; *rpp; rpp = &((*rpp)->next))
+      for (rpp = list; *rpp; rpp = &((*rpp)->next)) {
         ;
+      }
       (*rpp = rp)->next     = NULL;
       rp->active_queue_flag = 0;
     }

--- a/proxy/http/remap/RemapConfig.cc
+++ b/proxy/http/remap/RemapConfig.cc
@@ -108,16 +108,19 @@ process_filter_opt(url_mapping *mp, const BUILD_TABLE_INFO *bti, char *errStrBuf
     if (rp->active_queue_flag) {
       Debug("url_rewrite", "[process_filter_opt] Add active main filter \"%s\" (argc=%d)",
             rp->filter_name ? rp->filter_name : "<NULL>", rp->argc);
-      for (rpp = &mp->filter; *rpp; rpp = &((*rpp)->next))
+      for (rpp = &mp->filter; *rpp; rpp = &((*rpp)->next)) {
         ;
-      if ((errStr = remap_validate_filter_args(rpp, (const char **)rp->argv, rp->argc, errStrBuf, errStrBufSize)) != NULL)
+      }
+      if ((errStr = remap_validate_filter_args(rpp, (const char **)rp->argv, rp->argc, errStrBuf, errStrBufSize)) != NULL) {
         break;
+      }
     }
   }
   if (!errStr && (bti->remap_optflg & REMAP_OPTFLG_ALL_FILTERS) != 0) {
     Debug("url_rewrite", "[process_filter_opt] Add per remap filter");
-    for (rpp = &mp->filter; *rpp; rpp = &((*rpp)->next))
+    for (rpp = &mp->filter; *rpp; rpp = &((*rpp)->next)) {
       ;
+    }
     errStr = remap_validate_filter_args(rpp, (const char **)bti->argv, bti->argc, errStrBuf, errStrBufSize);
   }
   return errStr;
@@ -172,8 +175,9 @@ parse_define_directive(const char *directive, BUILD_TABLE_INFO *bti, char *errbu
   if ((cstr = remap_validate_filter_args(&rp, (const char **)bti->argv, bti->argc, errbuf, errbufsize)) == NULL && rp) {
     if (flg) { // new filter - add to list
       Debug("url_rewrite", "[parse_directive] new rule \"%s\" was created", bti->paramv[1]);
-      for (rpp = &bti->rules_list; *rpp; rpp = &((*rpp)->next))
+      for (rpp = &bti->rules_list; *rpp; rpp = &((*rpp)->next)) {
         ;
+      }
       (*rpp = rp)->name(bti->paramv[1]);
     }
     Debug("url_rewrite", "[parse_directive] %d argument(s) were added to rule \"%s\"", bti->argc, bti->paramv[1]);
@@ -411,8 +415,9 @@ remap_validate_filter_args(acl_filter_rule **rule_pp, const char **argv, int arg
 
   if (is_debug_tag_set("url_rewrite")) {
     printf("validate_filter_args: ");
-    for (i = 0; i < argc; i++)
+    for (i = 0; i < argc; i++) {
       printf("\"%s\" ", argv[i]);
+    }
     printf("\n");
   }
 
@@ -458,28 +463,29 @@ remap_validate_filter_args(acl_filter_rule **rule_pp, const char **argv, int arg
       // Please remember that the order of hash idx creation is very important and it is defined
       // in HTTP.cc file
       m = -1;
-      if (!strcasecmp(argptr, "CONNECT"))
+      if (!strcasecmp(argptr, "CONNECT")) {
         m = HTTP_WKSIDX_CONNECT;
-      else if (!strcasecmp(argptr, "DELETE"))
+      } else if (!strcasecmp(argptr, "DELETE")) {
         m = HTTP_WKSIDX_DELETE;
-      else if (!strcasecmp(argptr, "GET"))
+      } else if (!strcasecmp(argptr, "GET")) {
         m = HTTP_WKSIDX_GET;
-      else if (!strcasecmp(argptr, "HEAD"))
+      } else if (!strcasecmp(argptr, "HEAD")) {
         m = HTTP_WKSIDX_HEAD;
-      else if (!strcasecmp(argptr, "ICP_QUERY"))
+      } else if (!strcasecmp(argptr, "ICP_QUERY")) {
         m = HTTP_WKSIDX_ICP_QUERY;
-      else if (!strcasecmp(argptr, "OPTIONS"))
+      } else if (!strcasecmp(argptr, "OPTIONS")) {
         m = HTTP_WKSIDX_OPTIONS;
-      else if (!strcasecmp(argptr, "POST"))
+      } else if (!strcasecmp(argptr, "POST")) {
         m = HTTP_WKSIDX_POST;
-      else if (!strcasecmp(argptr, "PURGE"))
+      } else if (!strcasecmp(argptr, "PURGE")) {
         m = HTTP_WKSIDX_PURGE;
-      else if (!strcasecmp(argptr, "PUT"))
+      } else if (!strcasecmp(argptr, "PUT")) {
         m = HTTP_WKSIDX_PUT;
-      else if (!strcasecmp(argptr, "TRACE"))
+      } else if (!strcasecmp(argptr, "TRACE")) {
         m = HTTP_WKSIDX_TRACE;
-      else if (!strcasecmp(argptr, "PUSH"))
+      } else if (!strcasecmp(argptr, "PUSH")) {
         m = HTTP_WKSIDX_PUSH;
+      }
       if (m != -1) {
         m                               = m - HTTP_WKSIDX_CONNECT; // get method index
         rule->standard_method_lookup[m] = true;
@@ -502,8 +508,9 @@ remap_validate_filter_args(acl_filter_rule **rule_pp, const char **argv, int arg
         return (const char *)errStrBuf;
       }
       ipi = &rule->src_ip_array[rule->src_ip_cnt];
-      if (ul & REMAP_OPTFLG_INVERT)
+      if (ul & REMAP_OPTFLG_INVERT) {
         ipi->invert = true;
+      }
       ink_strlcpy(tmpbuf, argptr, sizeof(tmpbuf));
       // important! use copy of argument
       if (ExtractIpRange(tmpbuf, &ipi->start.sa, &ipi->end.sa) != NULL) {
@@ -541,8 +548,9 @@ remap_validate_filter_args(acl_filter_rule **rule_pp, const char **argv, int arg
         return (const char *)errStrBuf;
       }
       ipi = &rule->in_ip_array[rule->in_ip_cnt];
-      if (ul & REMAP_OPTFLG_INVERT)
+      if (ul & REMAP_OPTFLG_INVERT) {
         ipi->invert = true;
+      }
       ink_strlcpy(tmpbuf, argptr, sizeof(tmpbuf));
       // important! use copy of argument
       if (ExtractIpRange(tmpbuf, &ipi->start.sa, &ipi->end.sa) != NULL) {
@@ -590,8 +598,9 @@ remap_validate_filter_args(acl_filter_rule **rule_pp, const char **argv, int arg
     }
   }
 
-  if (is_debug_tag_set("url_rewrite"))
+  if (is_debug_tag_set("url_rewrite")) {
     rule->print();
+  }
 
   return NULL; /* success */
 }
@@ -602,67 +611,87 @@ remap_check_option(const char **argv, int argc, unsigned long findmode, int *_re
   unsigned long ret_flags = 0;
   int idx                 = 0;
 
-  if (argptr)
+  if (argptr) {
     *argptr = NULL;
+  }
   if (argv && argc > 0) {
     for (int i = 0; i < argc; i++) {
       if (!strcasecmp(argv[i], "map_with_referer")) {
-        if ((findmode & REMAP_OPTFLG_MAP_WITH_REFERER) != 0)
+        if ((findmode & REMAP_OPTFLG_MAP_WITH_REFERER) != 0) {
           idx = i;
+        }
         ret_flags |= REMAP_OPTFLG_MAP_WITH_REFERER;
       } else if (!strncasecmp(argv[i], "plugin=", 7)) {
-        if ((findmode & REMAP_OPTFLG_PLUGIN) != 0)
+        if ((findmode & REMAP_OPTFLG_PLUGIN) != 0) {
           idx = i;
-        if (argptr)
+        }
+        if (argptr) {
           *argptr = &argv[i][7];
+        }
         ret_flags |= REMAP_OPTFLG_PLUGIN;
       } else if (!strncasecmp(argv[i], "pparam=", 7)) {
-        if ((findmode & REMAP_OPTFLG_PPARAM) != 0)
+        if ((findmode & REMAP_OPTFLG_PPARAM) != 0) {
           idx = i;
-        if (argptr)
+        }
+        if (argptr) {
           *argptr = &argv[i][7];
+        }
         ret_flags |= REMAP_OPTFLG_PPARAM;
       } else if (!strncasecmp(argv[i], "method=", 7)) {
-        if ((findmode & REMAP_OPTFLG_METHOD) != 0)
+        if ((findmode & REMAP_OPTFLG_METHOD) != 0) {
           idx = i;
-        if (argptr)
+        }
+        if (argptr) {
           *argptr = &argv[i][7];
+        }
         ret_flags |= REMAP_OPTFLG_METHOD;
       } else if (!strncasecmp(argv[i], "src_ip=~", 8)) {
-        if ((findmode & REMAP_OPTFLG_SRC_IP) != 0)
+        if ((findmode & REMAP_OPTFLG_SRC_IP) != 0) {
           idx = i;
-        if (argptr)
+        }
+        if (argptr) {
           *argptr = &argv[i][8];
+        }
         ret_flags |= (REMAP_OPTFLG_SRC_IP | REMAP_OPTFLG_INVERT);
       } else if (!strncasecmp(argv[i], "src_ip=", 7)) {
-        if ((findmode & REMAP_OPTFLG_SRC_IP) != 0)
+        if ((findmode & REMAP_OPTFLG_SRC_IP) != 0) {
           idx = i;
-        if (argptr)
+        }
+        if (argptr) {
           *argptr = &argv[i][7];
+        }
         ret_flags |= REMAP_OPTFLG_SRC_IP;
       } else if (!strncasecmp(argv[i], "in_ip=~", 7)) {
-        if ((findmode & REMAP_OPTFLG_IN_IP) != 0)
+        if ((findmode & REMAP_OPTFLG_IN_IP) != 0) {
           idx = i;
-        if (argptr)
+        }
+        if (argptr) {
           *argptr = &argv[i][7];
+        }
         ret_flags |= (REMAP_OPTFLG_IN_IP | REMAP_OPTFLG_INVERT);
       } else if (!strncasecmp(argv[i], "in_ip=", 6)) {
-        if ((findmode & REMAP_OPTFLG_IN_IP) != 0)
+        if ((findmode & REMAP_OPTFLG_IN_IP) != 0) {
           idx = i;
-        if (argptr)
+        }
+        if (argptr) {
           *argptr = &argv[i][6];
+        }
         ret_flags |= REMAP_OPTFLG_IN_IP;
       } else if (!strncasecmp(argv[i], "action=", 7)) {
-        if ((findmode & REMAP_OPTFLG_ACTION) != 0)
+        if ((findmode & REMAP_OPTFLG_ACTION) != 0) {
           idx = i;
-        if (argptr)
+        }
+        if (argptr) {
           *argptr = &argv[i][7];
+        }
         ret_flags |= REMAP_OPTFLG_ACTION;
       } else if (!strncasecmp(argv[i], "mapid=", 6)) {
-        if ((findmode & REMAP_OPTFLG_MAP_ID) != 0)
+        if ((findmode & REMAP_OPTFLG_MAP_ID) != 0) {
           idx = i;
-        if (argptr)
+        }
+        if (argptr) {
           *argptr = &argv[i][6];
+        }
         ret_flags |= REMAP_OPTFLG_MAP_ID;
       } else if (!strncasecmp(argv[i], "internal", 8)) {
         if ((findmode & REMAP_OPTFLG_INTERNAL) != 0) {
@@ -674,14 +703,16 @@ remap_check_option(const char **argv, int argc, unsigned long findmode, int *_re
       }
 
       if ((findmode & ret_flags) && !argptr) {
-        if (_ret_idx)
+        if (_ret_idx) {
           *_ret_idx = idx;
+        }
         return ret_flags;
       }
     }
   }
-  if (_ret_idx)
+  if (_ret_idx) {
     *_ret_idx = idx;
+  }
   return ret_flags;
 }
 
@@ -1014,8 +1045,9 @@ remap_parse_config_bti(const char *path, BUILD_TABLE_INFO *bti)
     bti->reset();
 
     // Strip leading whitespace
-    while (*cur_line && isascii(*cur_line) && isspace(*cur_line))
+    while (*cur_line && isascii(*cur_line) && isspace(*cur_line)) {
       ++cur_line;
+    }
 
     if ((cur_line_size = strlen((char *)cur_line)) <= 0) {
       cur_line = tokLine(NULL, &tok_state, '\\');
@@ -1042,8 +1074,9 @@ remap_parse_config_bti(const char *path, BUILD_TABLE_INFO *bti)
 
     for (int j = 0; j < tok_count; j++) {
       if (((char *)whiteTok[j])[0] == '@') {
-        if (((char *)whiteTok[j])[1])
+        if (((char *)whiteTok[j])[1]) {
           bti->argv[bti->argc++] = ats_strdup(&(((char *)whiteTok[j])[1]));
+        }
       } else {
         bti->paramv[bti->paramc++] = ats_strdup((char *)whiteTok[j]);
       }
@@ -1186,9 +1219,10 @@ remap_parse_config_bti(const char *path, BUILD_TABLE_INFO *bti)
       if (maptype == FORWARD_MAP_REFERER) {
         new_mapping->filter_redirect_url = ats_strdup(bti->paramv[3]);
         if (!strcasecmp(bti->paramv[3], "<default>") || !strcasecmp(bti->paramv[3], "default") ||
-            !strcasecmp(bti->paramv[3], "<default_redirect_url>") || !strcasecmp(bti->paramv[3], "default_redirect_url"))
+            !strcasecmp(bti->paramv[3], "<default_redirect_url>") || !strcasecmp(bti->paramv[3], "default_redirect_url")) {
           new_mapping->default_redirect_url = true;
-        new_mapping->redir_chunk_list       = redirect_tag_str::parse_format_redirect_url(bti->paramv[3]);
+        }
+        new_mapping->redir_chunk_list = redirect_tag_str::parse_format_redirect_url(bti->paramv[3]);
         for (int j = bti->paramc; j > 4; j--) {
           if (bti->paramv[j - 1] != NULL) {
             char refinfo_error_buf[1024];

--- a/proxy/http/remap/RemapPluginInfo.cc
+++ b/proxy/http/remap/RemapPluginInfo.cc
@@ -39,15 +39,17 @@ remap_plugin_info::remap_plugin_info(char *_path)
 {
   // coverity did not see ats_free
   // coverity[ctor_dtor_leak]
-  if (_path && likely((path = ats_strdup(_path)) > 0))
+  if (_path && likely((path = ats_strdup(_path)) > 0)) {
     path_size = strlen(path);
+  }
 }
 
 remap_plugin_info::~remap_plugin_info()
 {
   ats_free(path);
-  if (dlh)
+  if (dlh) {
     dlclose(dlh);
+  }
 }
 
 //
@@ -61,8 +63,9 @@ remap_plugin_info::find_by_path(char *_path)
 
   if (likely(_path && (_path_size = strlen(_path)) > 0)) {
     for (pi = this; pi; pi = pi->next) {
-      if (pi->path && pi->path_size == _path_size && !strcmp(pi->path, _path))
+      if (pi->path && pi->path_size == _path_size && !strcmp(pi->path, _path)) {
         break;
+      }
     }
   }
 
@@ -78,8 +81,9 @@ remap_plugin_info::add_to_list(remap_plugin_info *pi)
   remap_plugin_info *p = this;
 
   if (likely(pi)) {
-    while (p->next)
+    while (p->next) {
       p = p->next;
+    }
 
     p->next  = pi;
     pi->next = NULL;

--- a/proxy/http/remap/RemapPlugins.cc
+++ b/proxy/http/remap/RemapPlugins.cc
@@ -74,12 +74,14 @@ RemapPlugins::run_plugin(remap_plugin_info *plugin)
 
   plugin_retcode = plugin->fp_tsremap_do_remap(ih, _s ? reinterpret_cast<TSHttpTxn>(_s->state_machine) : NULL, &rri);
   // TODO: Deal with negative return codes here
-  if (plugin_retcode < 0)
+  if (plugin_retcode < 0) {
     plugin_retcode = TSREMAP_NO_REMAP;
+  }
 
   // First step after plugin remap must be "redirect url" check
-  if ((TSREMAP_DID_REMAP == plugin_retcode || TSREMAP_DID_REMAP_STOP == plugin_retcode) && rri.redirect)
+  if ((TSREMAP_DID_REMAP == plugin_retcode || TSREMAP_DID_REMAP_STOP == plugin_retcode) && rri.redirect) {
     _s->remap_redirect = _request_url->string_get(NULL);
+  }
 
   return plugin_retcode;
 }

--- a/proxy/http/remap/RemapProcessor.cc
+++ b/proxy/http/remap/RemapProcessor.cc
@@ -29,8 +29,9 @@ extern ClassAllocator<RemapPlugins> pluginAllocator;
 int
 RemapProcessor::start(int num_threads, size_t stacksize)
 {
-  if (_use_separate_remap_thread)
+  if (_use_separate_remap_thread) {
     ET_REMAP = eventProcessor.spawn_event_threads(num_threads, "ET_REMAP", stacksize); // ET_REMAP is a class member
+  }
 
   return 0;
 }
@@ -166,15 +167,17 @@ RemapProcessor::finish_remap(HttpTransact::State *s)
 
     if (request_header->presence(MIME_PRESENCE_REFERER) &&
         (referer_hdr = request_header->value_get(MIME_FIELD_REFERER, MIME_LEN_REFERER, &referer_len)) != NULL) {
-      if (referer_len >= (int)sizeof(tmp_referer_buf))
+      if (referer_len >= (int)sizeof(tmp_referer_buf)) {
         referer_len = (int)(sizeof(tmp_referer_buf) - 1);
+      }
       memcpy(tmp_referer_buf, referer_hdr, referer_len);
       tmp_referer_buf[referer_len] = 0;
       for (enabled_flag = false; ri; ri = ri->next) {
         if (ri->any) {
           enabled_flag = true;
-          if (!map->negative_referer)
+          if (!map->negative_referer) {
             break;
+          }
         } else if (ri->regx_valid && (pcre_exec(ri->regx, NULL, tmp_referer_buf, referer_len, 0, 0, NULL, 0) != -1)) {
           enabled_flag = ri->negative ? false : true;
           break;

--- a/proxy/http/remap/UrlMapping.cc
+++ b/proxy/http/remap/UrlMapping.cc
@@ -56,8 +56,9 @@ url_mapping::url_mapping(int rank /* = 0 */)
 bool
 url_mapping::add_plugin(remap_plugin_info *i, void *ih)
 {
-  if (_plugin_count >= MAX_REMAP_PLUGIN_CHAIN)
+  if (_plugin_count >= MAX_REMAP_PLUGIN_CHAIN) {
     return false;
+  }
 
   _plugin_list[_plugin_count]   = i;
   _instance_data[_plugin_count] = ih;
@@ -73,8 +74,9 @@ remap_plugin_info *
 url_mapping::get_plugin(unsigned int index) const
 {
   Debug("url_rewrite", "get_plugin says we have %d plugins and asking for plugin %d", _plugin_count, index);
-  if ((_plugin_count == 0) || unlikely(index > _plugin_count))
+  if ((_plugin_count == 0) || unlikely(index > _plugin_count)) {
     return NULL;
+  }
 
   return _plugin_list[index];
 }
@@ -116,8 +118,9 @@ url_mapping::~url_mapping()
   }
 
   // Delete all instance data
-  for (unsigned int i = 0; i < _plugin_count; ++i)
+  for (unsigned int i = 0; i < _plugin_count; ++i) {
     delete_instance(i);
+  }
 
   // Delete filters
   while ((afr = filter) != NULL) {
@@ -158,8 +161,9 @@ redirect_tag_str::parse_format_redirect_url(char *url)
         if (c[0] == '%') {
           char tmp_type = (char)tolower((int)c[1]);
           if (tmp_type == 'r' || tmp_type == 'f' || tmp_type == 't' || tmp_type == 'o') {
-            if (url == c)
+            if (url == c) {
               type = tmp_type;
+            }
             break;
           }
         }
@@ -172,13 +176,15 @@ redirect_tag_str::parse_format_redirect_url(char *url)
           r->chunk_str = ats_strdup(url);
           *c           = svd;
           url          = c;
-        } else
+        } else {
           url += 2;
+        }
         (*rr = r)->next = 0;
         rr              = &(r->next);
         // printf("\t***********'%c' - '%s'*******\n",r->type,r->chunk_str ? r->chunk_str : "<NULL>");
-      } else
+      } else {
         break; /* memory allocation error */
+      }
     }
   }
   return list;
@@ -193,9 +199,10 @@ referer_info::referer_info(char *_ref, bool *error_flag, char *errmsgbuf, int er
   const char *error;
   int erroffset;
 
-  if (error_flag)
+  if (error_flag) {
     *error_flag = false;
-  regx          = NULL;
+  }
+  regx = NULL;
 
   if (_ref) {
     if (*_ref == '~') {
@@ -204,17 +211,20 @@ referer_info::referer_info(char *_ref, bool *error_flag, char *errmsgbuf, int er
     }
     if ((referer = ats_strdup(_ref)) != 0) {
       referer_size = strlen(referer);
-      if (!strcmp(referer, "*"))
+      if (!strcmp(referer, "*")) {
         any = true;
-      else {
+      } else {
         regx = pcre_compile(referer, PCRE_CASELESS, &error, &erroffset, NULL);
         if (!regx) {
-          if (errmsgbuf && (errmsgbuf_size - 1) > 0)
+          if (errmsgbuf && (errmsgbuf_size - 1) > 0) {
             ink_strlcpy(errmsgbuf, error, errmsgbuf_size);
-          if (error_flag)
+          }
+          if (error_flag) {
             *error_flag = true;
-        } else
+          }
+        } else {
           regx_valid = true;
+        }
       }
     }
   }

--- a/proxy/http/remap/UrlMappingPathIndex.cc
+++ b/proxy/http/remap/UrlMappingPathIndex.cc
@@ -24,8 +24,9 @@
 
 UrlMappingPathIndex::~UrlMappingPathIndex()
 {
-  for (UrlMappingGroup::iterator group_iter = m_tries.begin(); group_iter != m_tries.end(); ++group_iter)
+  for (UrlMappingGroup::iterator group_iter = m_tries.begin(); group_iter != m_tries.end(); ++group_iter) {
     delete group_iter->second; // Delete the Trie
+  }
   m_tries.clear();
 }
 
@@ -85,6 +86,7 @@ lFail:
 void
 UrlMappingPathIndex::Print()
 {
-  for (UrlMappingGroup::iterator group_iter = m_tries.begin(); group_iter != m_tries.end(); ++group_iter)
+  for (UrlMappingGroup::iterator group_iter = m_tries.begin(); group_iter != m_tries.end(); ++group_iter) {
     group_iter->second->Print();
+  }
 }

--- a/proxy/http/remap/UrlRewrite.cc
+++ b/proxy/http/remap/UrlRewrite.cc
@@ -125,8 +125,9 @@ void
 UrlRewrite::SetReverseFlag(int flag)
 {
   reverse_proxy = flag;
-  if (is_debug_tag_set("url_rewrite"))
+  if (is_debug_tag_set("url_rewrite")) {
     Print();
+  }
 }
 
 /**
@@ -369,8 +370,9 @@ UrlRewrite::ReverseMap(HTTPHdr *response_header)
     UrlMappingContainer reverse_mapping(response_header->m_heap);
 
     if (reverseMappingLookup(&location_url, location_url.port_get(), host, host_len, reverse_mapping)) {
-      if (i == 0)
+      if (i == 0) {
         remap_found = true;
+      }
       url_rewrite_remap_request(reverse_mapping, &location_url);
       new_loc_hdr = location_url.string_get_ref(&new_loc_length);
       response_header->value_set(url_headers[i].field, url_headers[i].len, new_loc_hdr, new_loc_length);
@@ -493,8 +495,9 @@ UrlRewrite::Remap_redirect(HTTPHdr *request_header, URL *redirect_url)
   prt = (num_rules_redirect_permanent != 0);
   trt = (num_rules_redirect_temporary != 0);
 
-  if (prt + trt == 0)
+  if (prt + trt == 0) {
     return NONE;
+  }
 
   // Since are called before request validity checking
   //  occurs, make sure that we have both a valid request

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -143,8 +143,9 @@ rcv_data_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
   IOBufferReader *myreader = frame.reader()->clone();
   while (nbytes < payload_length - pad_length) {
     size_t read_len = sizeof(buf);
-    if (nbytes + read_len > unpadded_length)
+    if (nbytes + read_len > unpadded_length) {
       read_len -= nbytes + read_len - unpadded_length;
+    }
     nbytes += stream->request_buffer.write(myreader, read_len);
     myreader->consume(nbytes);
     // If there is an outstanding read, update the buffer
@@ -897,8 +898,9 @@ Http2Stream *
 Http2ConnectionState::find_stream(Http2StreamId id) const
 {
   for (Http2Stream *s = stream_list.head; s; s = s->link.next) {
-    if (s->get_id() == id)
+    if (s->get_id() == id) {
       return s;
+    }
   }
   return NULL;
 }

--- a/proxy/http2/HuffmanCodec.cc
+++ b/proxy/http2/HuffmanCodec.cc
@@ -101,13 +101,15 @@ make_huffman_tree()
     current = root;
     while (bit_len > 0) {
       if (huffman_table[i].code_as_hex & (1 << (bit_len - 1))) {
-        if (!current->right)
+        if (!current->right) {
           current->right = make_huffman_tree_node();
-        current          = current->right;
+        }
+        current = current->right;
       } else {
-        if (!current->left)
+        if (!current->left) {
           current->left = make_huffman_tree_node();
-        current         = current->left;
+        }
+        current = current->left;
       }
       bit_len--;
     }
@@ -120,10 +122,12 @@ make_huffman_tree()
 static void
 free_huffman_tree(Node *node)
 {
-  if (node->left)
+  if (node->left) {
     free_huffman_tree(node->left);
-  if (node->right)
+  }
+  if (node->right) {
     free_huffman_tree(node->right);
+  }
 
   ats_free(node);
 }
@@ -131,15 +135,17 @@ free_huffman_tree(Node *node)
 void
 hpack_huffman_init()
 {
-  if (!HUFFMAN_TREE_ROOT)
+  if (!HUFFMAN_TREE_ROOT) {
     HUFFMAN_TREE_ROOT = make_huffman_tree();
+  }
 }
 
 void
 hpack_huffman_fin()
 {
-  if (HUFFMAN_TREE_ROOT)
+  if (HUFFMAN_TREE_ROOT) {
     free_huffman_tree(HUFFMAN_TREE_ROOT);
+  }
 }
 
 int64_t

--- a/proxy/http2/RegressionHPACK.cc
+++ b/proxy/http2/RegressionHPACK.cc
@@ -403,8 +403,9 @@ REGRESSION_TEST(HPACK_Encode)(RegressionTest *t, int, int *pstatus)
     for (unsigned int j = 0; j < sizeof(raw_field_response_test_case[i]) / sizeof(raw_field_response_test_case[i][0]); j++) {
       const char *expected_name  = raw_field_response_test_case[i][j].raw_name;
       const char *expected_value = raw_field_response_test_case[i][j].raw_value;
-      if (strlen(expected_name) == 0)
+      if (strlen(expected_name) == 0) {
         break;
+      }
 
       MIMEField *field = mime_field_create(headers->m_heap, headers->m_http->m_fields_impl);
       field->name_set(headers->m_heap, headers->m_http->m_fields_impl, expected_name, strlen(expected_name));
@@ -434,8 +435,9 @@ REGRESSION_TEST(HPACK_Encode)(RegressionTest *t, int, int *pstatus)
       int expected_name_len      = strlen(expected_name);
       int expected_value_len     = strlen(expected_value);
 
-      if (expected_name_len == 0)
+      if (expected_name_len == 0) {
         break;
+      }
 
       HpackLookupResult lookupResult = indexing_table.lookup(expected_name, expected_name_len, expected_value, expected_value_len);
       box.check(lookupResult.match_type == HPACK_EXACT_MATCH && lookupResult.index_type == HPACK_INDEX_TYPE_DYNAMIC,
@@ -567,8 +569,9 @@ REGRESSION_TEST(HPACK_Decode)(RegressionTest *t, int, int *pstatus)
     for (unsigned int j = 0; j < sizeof(raw_field_request_test_case[i]) / sizeof(raw_field_request_test_case[i][0]); j++) {
       const char *expected_name  = raw_field_request_test_case[i][j].raw_name;
       const char *expected_value = raw_field_request_test_case[i][j].raw_value;
-      if (strlen(expected_name) == 0)
+      if (strlen(expected_name) == 0) {
         break;
+      }
 
       MIMEField *field = headers->field_find(expected_name, strlen(expected_name));
       box.check(field != NULL, "A MIMEField that has \"%s\" as name doesn't exist", expected_name);

--- a/proxy/logcat.cc
+++ b/proxy/logcat.cc
@@ -91,8 +91,9 @@ process_file(int in_fd, int out_fd)
     LogBufferHeader *header  = (LogBufferHeader *)&buffer[0];
 
     nread = read(in_fd, buffer, first_read_size);
-    if (!nread || nread == EOF)
+    if (!nread || nread == EOF) {
       return 0;
+    }
 
     // ensure that this is a valid logbuffer header
     //
@@ -106,8 +107,9 @@ process_file(int in_fd, int out_fd)
 
     nread = read(in_fd, &buffer[first_read_size], second_read_size);
     if (!nread || nread == EOF) {
-      if (follow_flag)
+      if (follow_flag) {
         return 0;
+      }
 
       fprintf(stderr, "Bad LogBufferHeader read!\n");
       return 1;
@@ -121,8 +123,9 @@ process_file(int in_fd, int out_fd)
       return 1;
     }
     buffer_bytes = byte_count - header_size;
-    if (buffer_bytes == 0)
+    if (buffer_bytes == 0) {
       return 0;
+    }
     if (buffer_bytes < 0) {
       fprintf(stderr, "No buffer body!\n");
       return 1;
@@ -137,8 +140,9 @@ process_file(int in_fd, int out_fd)
         return 1;
       }
 
-      if (rc > 0)
+      if (rc > 0) {
         nread += rc;
+      }
     }
 
     if (nread > buffer_bytes) {
@@ -280,18 +284,20 @@ main(int /* argc ATS_UNUSED */, const char *argv[])
             continue;
           }
         }
-        if (follow_flag)
+        if (follow_flag) {
           lseek(in_fd, 0, SEEK_END);
+        }
 
         while (true) {
           if (process_file(in_fd, out_fd) != 0) {
             error = DATA_PROCESSING_ERROR;
             break;
           }
-          if (!follow_flag)
+          if (!follow_flag) {
             break;
-          else
+          } else {
             usleep(10000); // This avoids burning CPU, using poll() would have been nice, but doesn't work I think.
+          }
         }
       }
     }
@@ -300,8 +306,9 @@ main(int /* argc ATS_UNUSED */, const char *argv[])
     //
     int tries = 3;
     while (--tries >= 0) {
-      if (process_file(STDIN_FILENO, out_fd) != 0)
+      if (process_file(STDIN_FILENO, out_fd) != 0) {
         tries = -1;
+      }
     }
   }
 

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -321,8 +321,9 @@ struct LoggingCollateContinuation : public Continuation {
 void
 Log::init_fields()
 {
-  if (init_status & FIELDS_INITIALIZED)
+  if (init_status & FIELDS_INITIALIZED) {
     return;
+  }
 
   LogField *field;
 
@@ -1209,8 +1210,9 @@ Log::flush_thread_main(void * /* args ATS_UNUSED */)
     // invert the list
     //
     link.head = fdata;
-    while ((fdata = link.pop()))
+    while ((fdata = link.pop())) {
       invert_link.push(fdata);
+    }
 
     // process each flush data
     //
@@ -1276,8 +1278,9 @@ Log::flush_thread_main(void * /* args ATS_UNUSED */)
 
       RecIncrRawStat(log_rsb, mutex->thread_holding, log_stat_bytes_written_to_disk_stat, bytes_written);
 
-      if (logfile->m_log)
+      if (logfile->m_log) {
         ink_atomic_increment(&logfile->m_log->m_bytes_written, bytes_written);
+      }
 
       delete fdata;
     }
@@ -1430,8 +1433,9 @@ Log::collate_thread_main(void * /* args ATS_UNUSED */)
 LogObject *
 Log::match_logobject(LogBufferHeader *header)
 {
-  if (!header)
+  if (!header) {
     return NULL;
+  }
 
   LogObject *obj;
   obj = Log::config->log_object_manager.get_object_with_signature(header->log_object_signature);

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -970,8 +970,9 @@ LogAccess::marshal_ip(char *dest, sockaddr const *ip)
     data._ip._family = AF_UNSPEC;
   }
 
-  if (dest)
+  if (dest) {
     memcpy(dest, &data, len);
+  }
   return INK_ALIGN_DEFAULT(len);
 }
 
@@ -1158,11 +1159,13 @@ LogAccess::unmarshal_str(char **buf, char *dest, int len, LogSlice *slice)
     int offset, n;
 
     n = slice->toStrOffset(val_len, &offset);
-    if (n <= 0)
+    if (n <= 0) {
       return 0;
+    }
 
-    if (n >= len)
+    if (n >= len) {
       return -1;
+    }
 
     memcpy(dest, (val_buf + offset), n);
     return n;
@@ -1586,8 +1589,9 @@ resolve_logfield_string(LogAccess *context, const char *format_str)
   if (!bytes_resolved) {
     ats_free(result);
     result = NULL;
-  } else
+  } else {
     result[bytes_resolved] = 0; // NULL terminate
+  }
 
   ats_free(printf_str);
   ats_free(fields_str);

--- a/proxy/logging/LogAccessHttp.cc
+++ b/proxy/logging/LogAccessHttp.cc
@@ -224,8 +224,9 @@ LogAccessHttp::set_client_req_url_path(char *buf, int len)
 int
 LogAccessHttp::marshal_plugin_identity_id(char *buf)
 {
-  if (buf)
+  if (buf) {
     marshal_int(buf, m_http_sm->plugin_id);
+  }
   return INK_MIN_ALIGN;
 }
 
@@ -235,13 +236,15 @@ LogAccessHttp::marshal_plugin_identity_tag(char *buf)
   int len         = INK_MIN_ALIGN;
   char const *tag = m_http_sm->plugin_tag;
 
-  if (!tag)
+  if (!tag) {
     tag = "*";
-  else
+  } else {
     len = LogAccess::strlen(tag);
+  }
 
-  if (buf)
+  if (buf) {
     marshal_str(buf, tag, len);
+  }
 
   return len;
 }
@@ -433,8 +436,9 @@ LogAccessHttp::marshal_client_req_http_method(char *buf)
     }
   }
 
-  if (buf)
+  if (buf) {
     marshal_mem(buf, str, alen, plen);
+  }
   return plen;
 }
 
@@ -1021,8 +1025,9 @@ LogAccessHttp::marshal_server_host_ip(char *buf)
   if (!ats_is_ip(ip)) {
     if (m_http_sm->t_state.current.server) {
       ip = &m_http_sm->t_state.current.server->dst_addr.sa;
-      if (!ats_is_ip(ip))
+      if (!ats_is_ip(ip)) {
         ip = 0;
+      }
     } else {
       ip = 0;
     }
@@ -1043,8 +1048,9 @@ LogAccessHttp::marshal_server_host_name(char *buf)
   if (m_client_request) {
     str = m_client_request->host_get(&actual_len);
 
-    if (str)
+    if (str) {
       padded_len = round_strlen(actual_len + 1); // +1 for trailing 0
+    }
   }
   if (buf) {
     marshal_mem(buf, str, actual_len, padded_len);
@@ -1347,10 +1353,11 @@ LogAccessHttp::marshal_file_size(char *buf)
       }
     } else {
       // This is semi-broken when we serveq zero length objects. See TS-2213
-      if (m_http_sm->server_response_body_bytes > 0)
+      if (m_http_sm->server_response_body_bytes > 0) {
         marshal_int(buf, m_http_sm->server_response_body_bytes);
-      else if (m_http_sm->cache_response_body_bytes > 0)
+      } else if (m_http_sm->cache_response_body_bytes > 0) {
         marshal_int(buf, m_http_sm->cache_response_body_bytes);
+      }
     }
   }
   // Else, we don't set the value at all (so, -)

--- a/proxy/logging/LogAccessICP.cc
+++ b/proxy/logging/LogAccessICP.cc
@@ -159,8 +159,9 @@ LogAccessICP::marshal_client_req_url_canon(char *buf)
   char *str     = LogUtils::escapify_url(&arena, uri_str, uri_len, &escapified_len);
 
   int len = round_strlen(escapified_len + 1); // the padded len
-  if (buf)
+  if (buf) {
     marshal_str(buf, str, len);
+  }
   return len;
 }
 
@@ -179,8 +180,9 @@ LogAccessICP::marshal_proxy_resp_content_type(char *buf)
   //
   LogUtils::remove_content_type_attributes(ct_str, &ct_len);
   int len = LogAccess::strlen(ct_str);
-  if (buf)
+  if (buf) {
     marshal_str(buf, ct_str, len);
+  }
   return len;
 }
 

--- a/proxy/logging/LogBuffer.cc
+++ b/proxy/logging/LogBuffer.cc
@@ -464,8 +464,9 @@ LogBuffer::resolve_custom_entry(LogFieldList *fieldlist, char *printf_str, char 
                                 long timestamp, long timestamp_usec, unsigned buffer_version, LogFieldList *alt_fieldlist,
                                 char *alt_printf_str)
 {
-  if (fieldlist == NULL || printf_str == NULL)
+  if (fieldlist == NULL || printf_str == NULL) {
     return 0;
+  }
 
   int *readfrom_map = NULL;
 
@@ -546,8 +547,9 @@ LogBuffer::resolve_custom_entry(LogFieldList *fieldlist, char *printf_str, char 
           } else if (strcmp(sym, "cqtq") == 0) {
             // From lib/ts
             res = squid_timestamp_to_buf(to, write_to_len - bytes_written, timestamp, timestamp_usec);
-            if (res < 0)
+            if (res < 0) {
               res = -1;
+            }
 
             if (buffer_version > 1) {
               // space was reserved in read buffer; remove it
@@ -743,8 +745,9 @@ LogBuffer::to_ascii(LogEntryHeader *entry, LogFormatType type, char *buf, int bu
   delete alt_fieldlist;
   ats_free(alt_printf_str);
   ats_free(alt_symbol_str);
-  if (delete_fieldlist_p)
+  if (delete_fieldlist_p) {
     delete fieldlist;
+  }
 
   return ret;
 }

--- a/proxy/logging/LogConfig.cc
+++ b/proxy/logging/LogConfig.cc
@@ -151,8 +151,9 @@ LogConfig::read_configuration_variables()
 
   ptr                     = REC_ConfigReadString("proxy.config.log.logfile_perm");
   int logfile_perm_parsed = ink_fileperm_parse(ptr);
-  if (logfile_perm_parsed != -1)
+  if (logfile_perm_parsed != -1) {
     logfile_perm = logfile_perm_parsed;
+  }
   ats_free(ptr);
 
   ptr = REC_ConfigReadString("proxy.config.log.hostname");
@@ -721,8 +722,9 @@ LogConfig::update_space_used()
 {
   // no need to update space used if log directory is inaccessible
   //
-  if (m_log_directory_inaccessible)
+  if (m_log_directory_inaccessible) {
     return;
+  }
 
   static const int MAX_CANDIDATES = 128;
   LogDeleteCandidate candidates[MAX_CANDIDATES];
@@ -875,8 +877,9 @@ LogConfig::update_space_used()
   //
 
   if (!space_to_write(headroom)) {
-    if (!logging_space_exhausted)
+    if (!logging_space_exhausted) {
       Note("Logging space exhausted, any logs writing to local disk will be dropped!");
+    }
 
     logging_space_exhausted = true;
     //
@@ -922,8 +925,9 @@ LogConfig::update_space_used()
     //
     // We have enough space to log again; clear any previous messages
     //
-    if (logging_space_exhausted)
+    if (logging_space_exhausted) {
       Note("Logging space is no longer exhausted.");
+    }
 
     logging_space_exhausted = false;
     if (m_disk_full || m_partition_full) {
@@ -1145,8 +1149,9 @@ LogConfig::read_xml_log_config()
       if (strlen(field_str) > 2 && field_str[0] == '%' && field_str[1] == '<') {
         Debug("xml", "Field symbol has <> form: %s", field_str);
         char *end = field_str;
-        while (*end && *end != '>')
+        while (*end && *end != '>') {
           end++;
+        }
         *end = '\0';
         field_str += 2;
         Debug("xml", "... now field symbol is %s", field_str);

--- a/proxy/logging/LogField.cc
+++ b/proxy/logging/LogField.cc
@@ -49,32 +49,39 @@ LogSlice::LogSlice(char *str)
   m_start  = 0;
   m_end    = INT_MAX;
 
-  if ((a = strchr(str, '[')) == NULL)
+  if ((a = strchr(str, '[')) == NULL) {
     return;
+  }
 
   *a++ = '\0';
-  if ((b = strchr(a, ':')) == NULL)
+  if ((b = strchr(a, ':')) == NULL) {
     return;
+  }
 
   *b++ = '\0';
-  if ((c = strchr(b, ']')) == NULL)
+  if ((c = strchr(b, ']')) == NULL) {
     return;
+  }
 
   m_enable = true;
 
   // eat space
-  while (a != b && *a == ' ')
+  while (a != b && *a == ' ') {
     a++;
+  }
 
-  if (a != b)
+  if (a != b) {
     m_start = atoi(a);
+  }
 
   // eat space
-  while (b != c && *b == ' ')
+  while (b != c && *b == ' ') {
     b++;
+  }
 
-  if (b != c)
+  if (b != c) {
     m_end = atoi(b);
+  }
 }
 
 int
@@ -83,34 +90,41 @@ LogSlice::toStrOffset(int strlen, int *offset)
   int i, j, len;
 
   // letf index
-  if (m_start >= 0)
+  if (m_start >= 0) {
     i = m_start;
-  else
+  } else {
     i = m_start + strlen;
+  }
 
-  if (i >= strlen)
+  if (i >= strlen) {
     return 0;
+  }
 
-  if (i < 0)
+  if (i < 0) {
     i = 0;
+  }
 
   // right index
-  if (m_end >= 0)
+  if (m_end >= 0) {
     j = m_end;
-  else
+  } else {
     j = m_end + strlen;
+  }
 
-  if (j <= 0)
+  if (j <= 0) {
     return 0;
+  }
 
-  if (j > strlen)
+  if (j > strlen) {
     j = strlen;
+  }
 
   // available length
   len = j - i;
 
-  if (len > 0)
+  if (len > 0) {
     *offset = i;
+  }
 
   return len;
 }
@@ -236,8 +250,9 @@ LogField::milestone_from_m_name()
   TSMilestonesType result = TS_MILESTONE_LAST_ENTRY;
 
   it = m_milestone_map.find(ts::ConstBuffer(m_name, strlen(m_name)));
-  if (it != m_milestone_map.end())
+  if (it != m_milestone_map.end()) {
     result = it->second;
+  }
 
   return result;
 }
@@ -317,15 +332,17 @@ LogField::LogField(const char *field, Container container, SetFunc _setfunc)
 
   case MS:
     m_milestone1 = milestone_from_m_name();
-    if (TS_MILESTONE_LAST_ENTRY == m_milestone1)
+    if (TS_MILESTONE_LAST_ENTRY == m_milestone1) {
       Note("Invalid milestone name in LogField ctor: %s", m_name);
+    }
     m_unmarshal_func = &(LogAccess::unmarshal_int_to_str);
     break;
 
   case MSDMS: {
     int rv = milestones_from_m_name(&m_milestone1, &m_milestone2);
-    if (0 != rv)
+    if (0 != rv) {
       Note("Invalid milestone range in LogField ctor: %s", m_name);
+    }
     m_unmarshal_func = &(LogAccess::unmarshal_int_to_str);
     break;
   }
@@ -378,8 +395,9 @@ LogField::~LogField()
 unsigned
 LogField::marshal_len(LogAccess *lad)
 {
-  if (m_container == NO_CONTAINER)
+  if (m_container == NO_CONTAINER) {
     return (lad->*m_marshal_func)(NULL);
+  }
 
   switch (m_container) {
   case CQH:
@@ -636,8 +654,9 @@ LogField::fieldlist_contains_aggregates(char *fieldlist)
   for (int i = 1; i < LogField::N_AGGREGATES; i++) {
     if ((match = strstr(fieldlist, aggregate_names[i])) != NULL) {
       // verify that the aggregate string is not part of a container field name.
-      if ((strchr(fieldlist, '{') == NULL) && (strchr(match, '}') == NULL))
+      if ((strchr(fieldlist, '{') == NULL) && (strchr(match, '}') == NULL)) {
         contains_aggregates = true;
+      }
     }
   }
   return contains_aggregates;

--- a/proxy/logging/LogFile.cc
+++ b/proxy/logging/LogFile.cc
@@ -128,8 +128,9 @@ void
 LogFile::change_name(const char *new_name)
 {
   ats_free(m_name);
-  if (m_log)
+  if (m_log) {
     m_log->change_name(new_name);
+  }
   m_name = ats_strdup(new_name);
 }
 
@@ -185,8 +186,9 @@ LogFile::open_file()
   } else {
     if (m_log) {
       int status = m_log->open_file(Log::config->logfile_perm);
-      if (status == BaseLogFile::LOG_FILE_COULD_NOT_OPEN_FILE)
+      if (status == BaseLogFile::LOG_FILE_COULD_NOT_OPEN_FILE) {
         return LOG_FILE_COULD_NOT_OPEN_FILE;
+      }
     } else {
       return LOG_FILE_COULD_NOT_OPEN_FILE;
     }
@@ -452,10 +454,11 @@ LogFile::write_ascii_logbuffer3(LogBufferHeader *buffer_header, const char *alt_
     fmt_entry_count = 0;
     fmt_buf_bytes   = 0;
 
-    if (m_file_format == LOG_FILE_PIPE)
+    if (m_file_format == LOG_FILE_PIPE) {
       ascii_buffer = (char *)malloc(m_max_line_size);
-    else
+    } else {
       ascii_buffer = (char *)malloc(m_ascii_buffer_size);
+    }
 
     // fill the buffer with as many records as possible
     //
@@ -483,11 +486,13 @@ LogFile::write_ascii_logbuffer3(LogBufferHeader *buffer_header, const char *alt_
       // record to avoid as much as possible overflowing the
       // pipe buffer
       //
-      if (m_file_format == LOG_FILE_PIPE)
+      if (m_file_format == LOG_FILE_PIPE) {
         break;
+      }
 
-      if (m_ascii_buffer_size - fmt_buf_bytes < m_max_line_size)
+      if (m_ascii_buffer_size - fmt_buf_bytes < m_max_line_size) {
         break;
+      }
     } while ((entry_header = iter.next()));
 
     // send the buffer to flush thread
@@ -557,8 +562,9 @@ LogFile::writeln(char *data, int len, int fd, const char *path)
 
     if ((bytes_this_write = (int)::writev(fd, (const struct iovec *)wvec, vcnt)) < 0) {
       Warning("An error was encountered in writing to %s: %s.", ((path) ? path : "logfile"), strerror(errno));
-    } else
+    } else {
       total_bytes = bytes_this_write;
+    }
   }
   return total_bytes;
 }
@@ -616,10 +622,11 @@ LogFile::display(FILE *fd)
 bool
 LogFile::is_open()
 {
-  if (m_file_format == LOG_FILE_PIPE)
+  if (m_file_format == LOG_FILE_PIPE) {
     return m_fd >= 0;
-  else
+  } else {
     return m_log && m_log->is_open();
+  }
 }
 
 /*

--- a/proxy/logging/LogFilter.cc
+++ b/proxy/logging/LogFilter.cc
@@ -385,8 +385,9 @@ int
 LogFilterInt::_convertStringToInt(char *value, int64_t *ival, LogFieldAliasMap *map)
 {
   size_t i, l = strlen(value);
-  for (i = 0; i < l && ParseRules::is_digit(value[i]); i++)
+  for (i = 0; i < l && ParseRules::is_digit(value[i]); i++) {
     ;
+  }
 
   if (i < l) {
     // not all characters of value are digits, assume that
@@ -630,8 +631,9 @@ LogFilterIP::LogFilterIP(const char *name, LogField *field, LogFilter::Action ac
                          IpAddr *value)
   : LogFilter(name, field, action, oper)
 {
-  for (IpAddr *limit = value + num_values; value != limit; ++value)
+  for (IpAddr *limit = value + num_values; value != limit; ++value) {
     m_map.mark(*value, *value);
+  }
   this->init();
 }
 
@@ -649,8 +651,9 @@ LogFilterIP::LogFilterIP(const char *name, LogField *field, LogFilter::Action ac
     while (t = tok.getNext(), t != NULL) {
       IpAddr min, max;
       char *x = strchr(t, '-');
-      if (x)
+      if (x) {
         *x++ = 0;
+      }
       if (0 == min.load(t)) {
         if (x) {
           if (0 != max.load(x)) {
@@ -721,8 +724,9 @@ LogFilterIP::operator==(LogFilterIP &rhs)
     IpMap::iterator right_limit(rhs.m_map.end());
 
     while (left_spot != left_limit && right_spot != right_limit) {
-      if (!ats_ip_addr_eq(left_spot->min(), right_spot->min()) || !ats_ip_addr_eq(left_spot->max(), right_spot->max()))
+      if (!ats_ip_addr_eq(left_spot->min(), right_spot->min()) || !ats_ip_addr_eq(left_spot->max(), right_spot->max())) {
         break;
+      }
       ++left_spot;
       ++right_spot;
     }
@@ -784,8 +788,9 @@ LogFilterIP::displayRange(FILE *fd, IpMap::iterator const &iter)
 
   fprintf(fd, "%s", ats_ip_ntop(iter->min(), ipb, sizeof(ipb)));
 
-  if (!ats_ip_addr_eq(iter->min(), iter->max()))
+  if (!ats_ip_addr_eq(iter->min(), iter->max())) {
     fprintf(fd, "-%s", ats_ip_ntop(iter->max(), ipb, sizeof(ipb)));
+  }
 }
 
 void

--- a/proxy/logging/LogFormat.cc
+++ b/proxy/logging/LogFormat.cc
@@ -440,8 +440,9 @@ LogFormat::parse_symbol_string(const char *symbol_string, LogFieldList *field_li
   LogField::Container container;
   LogField::Aggregate aggregate;
 
-  if (symbol_string == NULL)
+  if (symbol_string == NULL) {
     return 0;
+  }
   ink_assert(field_list != NULL);
   ink_assert(contains_aggregates != NULL);
 
@@ -587,14 +588,16 @@ LogFormat::parse_escape_string(const char *str, int len)
   int sum, start = 0;
   unsigned char a, b, c;
 
-  if (str[start] != '\\' || len < 2)
+  if (str[start] != '\\' || len < 2) {
     return -1;
+  }
 
-  if (str[start + 1] == '\\')
+  if (str[start + 1] == '\\') {
     return '\\';
-
-  if (len < 4)
+  }
+  if (len < 4) {
     return -1;
+  }
 
   a = (unsigned char)str[start + 1];
   b = (unsigned char)str[start + 2];
@@ -606,28 +609,32 @@ LogFormat::parse_escape_string(const char *str, int len)
     if (sum == 0 || sum >= 255) {
       Warning("Octal escape sequence out of range: \\%c%c%c, treat it as normal string\n", a, b, c);
       return -1;
-    } else
+    } else {
       return sum;
+    }
 
   } else if (tolower(a) == 'x' && isxdigit(b) && isxdigit(c)) {
     int i, j;
-    if (isdigit(b))
+    if (isdigit(b)) {
       i = b - '0';
-    else
+    } else {
       i = toupper(b) - 'A' + 10;
+    }
 
-    if (isdigit(c))
+    if (isdigit(c)) {
       j = c - '0';
-    else
+    } else {
       j = toupper(c) - 'A' + 10;
+    }
 
     sum = i * 16 + j;
 
     if (sum == 0 || sum >= 255) {
       Warning("Hex escape sequence out of range: \\%c%c%c, treat it as normal string\n", a, b, c);
       return -1;
-    } else
+    } else {
       return sum;
+    }
   }
 
   return -1;

--- a/proxy/logging/LogHost.cc
+++ b/proxy/logging/LogHost.cc
@@ -123,8 +123,9 @@ LogHost::set_ipstr_port(char *ipstr, unsigned int pt)
 
   clear(); // remove all previous state for this LogHost
 
-  if (0 != m_ip.load(ipstr))
+  if (0 != m_ip.load(ipstr)) {
     Note("Log host failed to parse IP address %s", ipstr);
+  }
   m_port = pt;
   ink_strlcpy(m_ipstr, ipstr, sizeof(m_ipstr));
   m_name = ats_strdup(ipstr);
@@ -277,8 +278,9 @@ LogHost::preproc_and_try_delete(LogBuffer *lb)
   }
 
   // send log_buffer;
-  if (m_log_collation_client_sm->send(lb) <= 0)
+  if (m_log_collation_client_sm->send(lb) <= 0) {
     goto done;
+  }
 
   return 0;
 

--- a/proxy/logging/LogObject.cc
+++ b/proxy/logging/LogObject.cc
@@ -464,14 +464,16 @@ LogObject::_checkout_write(size_t *write_offset, size_t bytes_needed)
       head_p old_h;
       do {
         INK_QUEUE_LD(old_h, m_log_buffer);
-        if (FREELIST_POINTER(old_h) != FREELIST_POINTER(h))
+        if (FREELIST_POINTER(old_h) != FREELIST_POINTER(h)) {
           break;
+        }
         head_p tmp_h;
         SET_FREELIST_POINTER_VERSION(tmp_h, FREELIST_POINTER(h), FREELIST_VERSION(old_h) - 1);
         result = ink_atomic_cas(&m_log_buffer.data, old_h.data, tmp_h.data);
       } while (!result);
-      if (FREELIST_POINTER(old_h) != FREELIST_POINTER(h))
+      if (FREELIST_POINTER(old_h) != FREELIST_POINTER(h)) {
         ink_atomic_increment(&buffer->m_references, -1);
+      }
     }
   } while (retry && write_offset); // if write_offset is null, we do
   // not retry because we really do
@@ -655,8 +657,9 @@ LogObject::_setup_rolling(Log::RollingEnabledValues rolling_enabled, int rolling
       } else {
         m_rolling_interval_sec = rolling_interval_sec;
         // increase so it divides day evenly
-        while (Log::MAX_ROLLING_INTERVAL_SEC % ++m_rolling_interval_sec)
+        while (Log::MAX_ROLLING_INTERVAL_SEC % ++m_rolling_interval_sec) {
           ;
+        }
       }
 
       if (m_rolling_interval_sec != rolling_interval_sec) {
@@ -690,15 +693,17 @@ LogObject::_setup_rolling(Log::RollingEnabledValues rolling_enabled, int rolling
 unsigned
 LogObject::roll_files(long time_now)
 {
-  if (!m_rolling_enabled)
+  if (!m_rolling_enabled) {
     return 0;
+  }
 
   unsigned num_rolled = 0;
   bool roll_on_time   = false;
   bool roll_on_size   = false;
 
-  if (!time_now)
+  if (!time_now) {
     time_now = LogUtils::timestamp();
+  }
 
   if (m_rolling_enabled != Log::ROLL_ON_SIZE_ONLY) {
     if (m_rolling_interval_sec > 0) {
@@ -1309,8 +1314,9 @@ LogObjectManager::log(LogAccess *lad)
     // data received from network in collation host. It should
     // be ignored here.
     //
-    if (_objects[i]->m_auto_created)
+    if (_objects[i]->m_auto_created) {
       continue;
+    }
 
     ret |= _objects[i]->log(lad);
   }

--- a/proxy/logging/LogUtils.cc
+++ b/proxy/logging/LogUtils.cc
@@ -299,8 +299,9 @@ LogUtils::escapify_url(Arena *arena, char *url, size_t len_in, int *len_out, cha
     return NULL;
   }
 
-  if (!map)
+  if (!map) {
     map = codes_to_escape;
+  }
 
   // Count specials in the url, assuming that there won't be any.
   //
@@ -320,8 +321,9 @@ LogUtils::escapify_url(Arena *arena, char *url, size_t len_in, int *len_out, cha
     // The common case, no escapes, so just return the source string.
     //
     *len_out = len_in;
-    if (dst)
+    if (dst) {
       ink_strlcpy(dst, url, dst_size);
+    }
     return url;
   }
 
@@ -345,10 +347,11 @@ LogUtils::escapify_url(Arena *arena, char *url, size_t len_in, int *len_out, cha
   //
   char *new_url;
 
-  if (dst)
+  if (dst) {
     new_url = dst;
-  else
+  } else {
     new_url = (char *)arena->str_alloc(out_len + 1);
+  }
 
   char *from = url;
   char *to   = new_url;
@@ -414,8 +417,9 @@ LogUtils::timestamp_to_hex_str(unsigned ip, char *buf, size_t bufLen, size_t *nu
   int retVal               = 1;
   int shift                = 28;
   if (buf && bufLen > 0) {
-    if (bufLen > 8)
+    if (bufLen > 8) {
       bufLen = 8;
+    }
     for (retVal = 0; retVal < (int)bufLen;) {
       buf[retVal++] = (char)table[((ip >> shift) & 0xf)];
       shift -= 4;
@@ -493,8 +497,9 @@ LogUtils::file_is_writeable(const char *full_filename, off_t *size_bytes, bool *
       errno   = EACCES;
       ret_val = -1;
     }
-    if (size_bytes)
+    if (size_bytes) {
       *size_bytes = stat_data.st_size;
+    }
   } else {
     // stat failed
     //
@@ -529,8 +534,9 @@ LogUtils::file_is_writeable(const char *full_filename, off_t *size_bytes, bool *
       if (e < 0) {
         ret_val = -1;
       } else {
-        if (size_bytes)
+        if (size_bytes) {
           *size_bytes = 0;
+        }
       }
 
       if (prefix) {
@@ -548,13 +554,16 @@ LogUtils::file_is_writeable(const char *full_filename, off_t *size_bytes, bool *
       ret_val = -1;
     } else {
       if (limit_data.rlim_cur != (rlim_t)RLIM_INFINITY) {
-        if (has_size_limit)
+        if (has_size_limit) {
           *has_size_limit = true;
-        if (current_size_limit_bytes)
+        }
+        if (current_size_limit_bytes) {
           *current_size_limit_bytes = limit_data.rlim_cur;
+        }
       } else {
-        if (has_size_limit)
+        if (has_size_limit) {
           *has_size_limit = false;
+        }
       }
     }
   }

--- a/proxy/logstats.cc
+++ b/proxy/logstats.cc
@@ -357,8 +357,9 @@ public:
   void
   resize(int size = 0)
   {
-    if (0 != size)
+    if (0 != size) {
       _size = size;
+    }
 
     _init();
     _reset(true);
@@ -370,16 +371,19 @@ public:
   {
     int show = _stack.size();
 
-    if (_show_urls > 0 && _show_urls < show)
+    if (_show_urls > 0 && _show_urls < show) {
       show = _show_urls;
+    }
 
     _stack.sort();
-    for (LruStack::iterator u = _stack.begin(); NULL != u->url && --show >= 0; ++u)
+    for (LruStack::iterator u = _stack.begin(); NULL != u->url && --show >= 0; ++u) {
       _dump_url(u, as_object);
-    if (as_object)
+    }
+    if (as_object) {
       std::cout << "  \"_timestamp\" : \"" << static_cast<int>(ink_time_wall_seconds()) << "\"" << std::endl;
-    else
+    } else {
       std::cout << "  { \"_timestamp\" : \"" << static_cast<int>(ink_time_wall_seconds()) << "\" }" << std::endl;
+    }
   }
 
   void
@@ -393,16 +397,17 @@ public:
       ++(l->req.count);
       l->req.bytes += bytes;
 
-      if ((http_code >= 600) || (http_code < 200))
+      if ((http_code >= 600) || (http_code < 200)) {
         ++(l->c_000);
-      else if (http_code >= 500)
+      } else if (http_code >= 500) {
         ++(l->c_5xx);
-      else if (http_code >= 400)
+      } else if (http_code >= 400) {
         ++(l->c_4xx);
-      else if (http_code >= 300)
+      } else if (http_code >= 300) {
         ++(l->c_3xx);
-      else // http_code >= 200
+      } else { // http_code >= 200
         ++(l->c_2xx);
+      }
 
       switch (result) {
       case SQUID_LOG_TCP_HIT:
@@ -435,8 +440,9 @@ public:
 
       update_elapsed(l->time, time, l->req);
       // Move this entry to the top of the stack (hence, LRU)
-      if (_size > 0)
+      if (_size > 0) {
         _stack.splice(_stack.begin(), _stack, l);
+      }
     } else {                                  // "new" URL
       const char *u        = ats_strdup(url); // We own it.
       LruStack::iterator l = _stack.end();
@@ -445,10 +451,12 @@ public:
         if (_cur == l) { // LRU is full, take the last one
           --l;
           h = _hash.find(l->url);
-          if (h != _hash.end())
+          if (h != _hash.end()) {
             _hash.erase(h);
-          if (0 == _show_urls)
+          }
+          if (0 == _show_urls) {
             _dump_url(l, as_object);
+          }
         } else {
           l = _cur++;
         }
@@ -462,16 +470,17 @@ public:
       l->req.bytes = bytes;
       l->req.count = 1;
 
-      if ((http_code >= 600) || (http_code < 200))
+      if ((http_code >= 600) || (http_code < 200)) {
         l->c_000 = 1;
-      else if (http_code >= 500)
+      } else if (http_code >= 500) {
         l->c_5xx = 1;
-      else if (http_code >= 400)
+      } else if (http_code >= 400) {
         l->c_4xx = 1;
-      else if (http_code >= 300)
+      } else if (http_code >= 300) {
         l->c_3xx = 1;
-      else // http_code >= 200
+      } else { // http_code >= 200
         l->c_2xx = 1;
+      }
 
       switch (result) {
       case SQUID_LOG_TCP_HIT:
@@ -508,8 +517,9 @@ public:
       _hash[u] = l;
 
       // We running a real LRU or not?
-      if (_size > 0)
+      if (_size > 0) {
         _stack.splice(_stack.begin(), _stack, l); // Move this to the top of the stack
+      }
     }
   }
 
@@ -527,8 +537,9 @@ private:
   _reset(bool free = false)
   {
     for (LruStack::iterator l = _stack.begin(); l != _stack.end(); ++l) {
-      if (free && l->url)
+      if (free && l->url) {
         ats_free(const_cast<char *>(l->url));
+      }
       memset(&(*l), 0, sizeof(UrlStats));
     }
   }
@@ -536,11 +547,12 @@ private:
   void
   _dump_url(LruStack::iterator &u, int as_object)
   {
-    if (as_object)
+    if (as_object) {
       std::cout << "  \"" << u->url << "\" : { ";
-    else
+    } else {
       std::cout << "  { \"" << u->url << "\" : { ";
-    // Requests
+      // Requests
+    }
     std::cout << "\"req\" : { \"total\" : \"" << u->req.count << "\", \"hits\" : \"" << u->hits << "\", \"misses\" : \""
               << u->misses << "\", \"errors\" : \"" << u->errors << "\", \"000\" : \"" << u->c_000 << "\", \"2xx\" : \"" << u->c_2xx
               << "\", \"3xx\" : \"" << u->c_3xx << "\", \"4xx\" : \"" << u->c_4xx << "\", \"5xx\" : \"" << u->c_5xx << "\" }, ";
@@ -550,10 +562,11 @@ private:
               << std::setiosflags(ios::fixed) << std::setprecision(2) << u->time.avg << "\", \"dev\" : \""
               << std::setiosflags(ios::fixed) << std::setprecision(2) << u->time.stddev;
 
-    if (as_object)
+    if (as_object) {
       std::cout << "\" } }," << std::endl;
-    else
+    } else {
       std::cout << "\" } } }," << std::endl;
+    }
   }
 
   LruHash _hash;
@@ -704,10 +717,12 @@ struct ExitStatus {
   void
   set(ExitLevel l, const char *n = NULL)
   {
-    if (l > level)
+    if (l > level) {
       level = l;
-    if (n)
+    }
+    if (n) {
       ink_strlcat(notice, n, sizeof(notice));
+    }
   }
 
   void
@@ -795,15 +810,18 @@ update_elapsed(ElapsedStats &stat, const int elapsed, const StatsCounter &counte
   float oldavg, newavg, sum_of_squares;
 
   // Skip all the "0" values.
-  if (0 == elapsed)
+  if (0 == elapsed) {
     return;
-  if (-1 == stat.min)
+  }
+  if (-1 == stat.min) {
     stat.min = elapsed;
-  else if (stat.min > elapsed)
+  } else if (stat.min > elapsed) {
     stat.min = elapsed;
+  }
 
-  if (stat.max < elapsed)
+  if (stat.max < elapsed) {
     stat.max = elapsed;
+  }
 
   // update_counter should have been called on counter.count before calling
   // update_elapsed.
@@ -815,10 +833,11 @@ update_elapsed(ElapsedStats &stat, const int elapsed, const StatsCounter &counte
   newavg   = (oldavg * oldcount + elapsed) / newcount;
   // Now find the new standard deviation from the old one
 
-  if (oldcount != 0)
+  if (oldcount != 0) {
     sum_of_squares = (stat.stddev * stat.stddev * oldcount);
-  else
+  } else {
     sum_of_squares = 0;
+  }
 
   // Find the old sum of squares.
   sum_of_squares = sum_of_squares + 2 * oldavg * oldcount * (oldavg - newavg) + oldcount * (newavg * newavg - oldavg * oldavg);
@@ -916,8 +935,9 @@ update_results_elapsed(OriginStats *stat, int result, int elapsed, int size)
     if ((result >= SQUID_LOG_ERR_READ_TIMEOUT) && (result <= SQUID_LOG_ERR_UNKNOWN)) {
       update_counter(stat->results.errors.other, size);
       update_counter(stat->results.errors.total, size);
-    } else
+    } else {
       update_counter(stat->results.other, size);
+    }
     break;
   }
 }
@@ -1057,16 +1077,17 @@ update_codes(OriginStats *stat, int code, int size)
     break;
   }
 
-  if ((code >= 600) || (code < 200))
+  if ((code >= 600) || (code < 200)) {
     update_counter(stat->codes.c_000, size);
-  else if (code >= 500)
+  } else if (code >= 500) {
     update_counter(stat->codes.c_5xx, size);
-  else if (code >= 400)
+  } else if (code >= 400) {
     update_counter(stat->codes.c_4xx, size);
-  else if (code >= 300)
+  } else if (code >= 300) {
     update_counter(stat->codes.c_3xx, size);
-  else if (code >= 200)
+  } else if (code >= 200) {
     update_counter(stat->codes.c_2xx, size);
+  }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1127,14 +1148,15 @@ update_methods(OriginStats *stat, int method, int size)
 inline void
 update_schemes(OriginStats *stat, int scheme, int size)
 {
-  if (SCHEME_HTTP == scheme)
+  if (SCHEME_HTTP == scheme) {
     update_counter(stat->schemes.http, size);
-  else if (SCHEME_HTTPS == scheme)
+  } else if (SCHEME_HTTPS == scheme) {
     update_counter(stat->schemes.https, size);
-  else if (SCHEME_NONE == scheme)
+  } else if (SCHEME_NONE == scheme) {
     update_counter(stat->schemes.none, size);
-  else
+  } else {
     update_counter(stat->schemes.other, size);
+  }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1173,10 +1195,11 @@ parse_log_buff(LogBufferHeader *buf_header, bool summary = false)
   while ((entry = buf_iter.next())) {
     read_from = (char *)entry + sizeof(LogEntryHeader);
     // We read and skip over the first field, which is the timestamp.
-    if ((field = fieldlist->first()))
+    if ((field = fieldlist->first())) {
       read_from += INK_MIN_ALIGN;
-    else // This shouldn't happen, buffer must be messed up.
+    } else { // This shouldn't happen, buffer must be messed up.
       break;
+    }
 
     state    = P_STATE_ELAPSED;
     o_stats  = NULL;
@@ -1198,10 +1221,11 @@ parse_log_buff(LogBufferHeader *buf_header, bool summary = false)
         {
           LogFieldIp *ip = reinterpret_cast<LogFieldIp *>(read_from);
           int len        = sizeof(LogFieldIp);
-          if (AF_INET == ip->_family)
+          if (AF_INET == ip->_family) {
             len = sizeof(LogFieldIp4);
-          else if (AF_INET6 == ip->_family)
+          } else if (AF_INET6 == ip->_family) {
             len = sizeof(LogFieldIp6);
+          }
           read_from += INK_ALIGN_DEFAULT(len);
         }
         break;
@@ -1258,22 +1282,24 @@ parse_log_buff(LogBufferHeader *buf_header, bool summary = false)
           break;
         default:
           tok_len = strlen(read_from);
-          if ((5 == tok_len) && (0 == strncmp(read_from, "PURGE", 5)))
+          if ((5 == tok_len) && (0 == strncmp(read_from, "PURGE", 5))) {
             method = METHOD_PURGE;
-          else if ((6 == tok_len) && (0 == strncmp(read_from, "DELETE", 6)))
+          } else if ((6 == tok_len) && (0 == strncmp(read_from, "DELETE", 6))) {
             method = METHOD_DELETE;
-          else if ((7 == tok_len) && (0 == strncmp(read_from, "OPTIONS", 7)))
+          } else if ((7 == tok_len) && (0 == strncmp(read_from, "OPTIONS", 7))) {
             method = METHOD_OPTIONS;
-          else if ((1 == tok_len) && ('-' == *read_from)) {
+          } else if ((1 == tok_len) && ('-' == *read_from)) {
             method = METHOD_NONE;
             flag   = 1; // No method, so no need to parse the URL
           } else {
             ptr = read_from;
-            while (*ptr && isupper(*ptr))
+            while (*ptr && isupper(*ptr)) {
               ++ptr;
+            }
             // Skip URL if it doesn't look like an HTTP method
-            if (*ptr != '\0')
+            if (*ptr != '\0') {
               flag = 1;
+            }
           }
           read_from += LogAccess::round_strlen(tok_len + 1);
           break;
@@ -1282,8 +1308,9 @@ parse_log_buff(LogBufferHeader *buf_header, bool summary = false)
 
       case P_STATE_URL:
         state = P_STATE_RFC931;
-        if (urls)
+        if (urls) {
           urls->add_stat(read_from, size, elapsed, result, http_code, cl.as_object);
+        }
 
         // TODO check for read_from being empty string
         if (0 == flag) {
@@ -1298,15 +1325,18 @@ parse_log_buff(LogBufferHeader *buf_header, bool summary = false)
               scheme = SCHEME_HTTPS;
               tok += 4;
               tok_len = strlen(tok) + 8;
-            } else
+            } else {
               tok_len = strlen(tok) + 4;
+            }
           } else {
-            if ('/' == *tok)
+            if ('/' == *tok) {
               scheme = SCHEME_NONE;
-            tok_len  = strlen(tok);
+            }
+            tok_len = strlen(tok);
           }
-          if ('/' == *tok) // This is to handle crazy stuff like http:///origin.com
+          if ('/' == *tok) { // This is to handle crazy stuff like http:///origin.com
             tok++;
+          }
           ptr = strchr(tok, '/');
           if (ptr && !summary) { // Find the origin
             *ptr = '\0';
@@ -1324,15 +1354,17 @@ parse_log_buff(LogBufferHeader *buf_header, bool summary = false)
                   o_stats->server   = o_server;
                   origins[o_server] = o_stats;
                 }
-              } else
+              } else {
                 o_stats = o_iter->second;
+              }
             }
           }
         } else {
           // No method given
-          if ('/' == *read_from)
+          if ('/' == *read_from) {
             scheme = SCHEME_NONE;
-          tok_len  = strlen(read_from);
+          }
+          tok_len = strlen(read_from);
         }
         read_from += LogAccess::round_strlen(tok_len + 1);
 
@@ -1353,10 +1385,11 @@ parse_log_buff(LogBufferHeader *buf_header, bool summary = false)
 
       case P_STATE_RFC931:
         state = P_STATE_HIERARCHY;
-        if ('-' == *read_from)
+        if ('-' == *read_from) {
           read_from += LogAccess::round_strlen(1 + 1);
-        else
+        } else {
           read_from += LogAccess::strlen(read_from);
+        }
         break;
 
       case P_STATE_HIERARCHY:
@@ -1365,38 +1398,45 @@ parse_log_buff(LogBufferHeader *buf_header, bool summary = false)
         switch (hier) {
         case SQUID_HIER_NONE:
           update_counter(totals.hierarchies.none, size);
-          if (o_stats != NULL)
+          if (o_stats != NULL) {
             update_counter(o_stats->hierarchies.none, size);
+          }
           break;
         case SQUID_HIER_DIRECT:
           update_counter(totals.hierarchies.direct, size);
-          if (o_stats != NULL)
+          if (o_stats != NULL) {
             update_counter(o_stats->hierarchies.direct, size);
+          }
           break;
         case SQUID_HIER_SIBLING_HIT:
           update_counter(totals.hierarchies.sibling, size);
-          if (o_stats != NULL)
+          if (o_stats != NULL) {
             update_counter(o_stats->hierarchies.sibling, size);
+          }
           break;
         case SQUID_HIER_PARENT_HIT:
           update_counter(totals.hierarchies.parent, size);
-          if (o_stats != NULL)
+          if (o_stats != NULL) {
             update_counter(o_stats->hierarchies.direct, size);
+          }
           break;
         case SQUID_HIER_EMPTY:
           update_counter(totals.hierarchies.empty, size);
-          if (o_stats != NULL)
+          if (o_stats != NULL) {
             update_counter(o_stats->hierarchies.empty, size);
+          }
           break;
         default:
           if ((hier >= SQUID_HIER_EMPTY) && (hier < SQUID_HIER_INVALID_ASSIGNED_CODE)) {
             update_counter(totals.hierarchies.other, size);
-            if (o_stats != NULL)
+            if (o_stats != NULL) {
               update_counter(o_stats->hierarchies.other, size);
+            }
           } else {
             update_counter(totals.hierarchies.invalid, size);
-            if (o_stats != NULL)
+            if (o_stats != NULL) {
               update_counter(o_stats->hierarchies.invalid, size);
+            }
           }
           break;
         }
@@ -1405,189 +1445,220 @@ parse_log_buff(LogBufferHeader *buf_header, bool summary = false)
 
       case P_STATE_PEER:
         state = P_STATE_TYPE;
-        if ('-' == *read_from)
+        if ('-' == *read_from) {
           read_from += LogAccess::round_strlen(1 + 1);
-        else
+        } else {
           read_from += LogAccess::strlen(read_from);
+        }
         break;
 
       case P_STATE_TYPE:
         state = P_STATE_END;
         if (IMAG_AS_INT == *reinterpret_cast<int *>(read_from)) {
           update_counter(totals.content.image.total, size);
-          if (o_stats != NULL)
+          if (o_stats != NULL) {
             update_counter(o_stats->content.image.total, size);
+          }
           tok = read_from + 6;
           switch (*reinterpret_cast<int *>(tok)) {
           case JPEG_AS_INT:
             tok_len = 10;
             update_counter(totals.content.image.jpeg, size);
-            if (o_stats != NULL)
+            if (o_stats != NULL) {
               update_counter(o_stats->content.image.jpeg, size);
+            }
             break;
           case JPG_AS_INT:
             tok_len = 9;
             update_counter(totals.content.image.jpeg, size);
-            if (o_stats != NULL)
+            if (o_stats != NULL) {
               update_counter(o_stats->content.image.jpeg, size);
+            }
             break;
           case GIF_AS_INT:
             tok_len = 9;
             update_counter(totals.content.image.gif, size);
-            if (o_stats != NULL)
+            if (o_stats != NULL) {
               update_counter(o_stats->content.image.gif, size);
+            }
             break;
           case PNG_AS_INT:
             tok_len = 9;
             update_counter(totals.content.image.png, size);
-            if (o_stats != NULL)
+            if (o_stats != NULL) {
               update_counter(o_stats->content.image.png, size);
+            }
             break;
           case BMP_AS_INT:
             tok_len = 9;
             update_counter(totals.content.image.bmp, size);
-            if (o_stats != NULL)
+            if (o_stats != NULL) {
               update_counter(o_stats->content.image.bmp, size);
+            }
             break;
           default:
             tok_len = 6 + strlen(tok);
             update_counter(totals.content.image.other, size);
-            if (o_stats != NULL)
+            if (o_stats != NULL) {
               update_counter(o_stats->content.image.other, size);
+            }
             break;
           }
         } else if (TEXT_AS_INT == *reinterpret_cast<int *>(read_from)) {
           tok = read_from + 5;
           update_counter(totals.content.text.total, size);
-          if (o_stats != NULL)
+          if (o_stats != NULL) {
             update_counter(o_stats->content.text.total, size);
+          }
           switch (*reinterpret_cast<int *>(tok)) {
           case JAVA_AS_INT:
             // TODO verify if really "javascript"
             tok_len = 15;
             update_counter(totals.content.text.javascript, size);
-            if (o_stats != NULL)
+            if (o_stats != NULL) {
               update_counter(o_stats->content.text.javascript, size);
+            }
             break;
           case CSS_AS_INT:
             tok_len = 8;
             update_counter(totals.content.text.css, size);
-            if (o_stats != NULL)
+            if (o_stats != NULL) {
               update_counter(o_stats->content.text.css, size);
+            }
             break;
           case XML_AS_INT:
             tok_len = 8;
             update_counter(totals.content.text.xml, size);
-            if (o_stats != NULL)
+            if (o_stats != NULL) {
               update_counter(o_stats->content.text.xml, size);
+            }
             break;
           case HTML_AS_INT:
             tok_len = 9;
             update_counter(totals.content.text.html, size);
-            if (o_stats != NULL)
+            if (o_stats != NULL) {
               update_counter(o_stats->content.text.html, size);
+            }
             break;
           case PLAI_AS_INT:
             tok_len = 10;
             update_counter(totals.content.text.plain, size);
-            if (o_stats != NULL)
+            if (o_stats != NULL) {
               update_counter(o_stats->content.text.plain, size);
+            }
             break;
           default:
             tok_len = 5 + strlen(tok);
             ;
             update_counter(totals.content.text.other, size);
-            if (o_stats != NULL)
+            if (o_stats != NULL) {
               update_counter(o_stats->content.text.other, size);
+            }
             break;
           }
         } else if (0 == strncmp(read_from, "application", 11)) {
           tok = read_from + 12;
           update_counter(totals.content.application.total, size);
-          if (o_stats != NULL)
+          if (o_stats != NULL) {
             update_counter(o_stats->content.application.total, size);
+          }
           switch (*reinterpret_cast<int *>(tok)) {
           case ZIP_AS_INT:
             tok_len = 15;
             update_counter(totals.content.application.zip, size);
-            if (o_stats != NULL)
+            if (o_stats != NULL) {
               update_counter(o_stats->content.application.zip, size);
+            }
             break;
           case JAVA_AS_INT:
             update_counter(totals.content.application.javascript, size);
-            if (o_stats != NULL)
+            if (o_stats != NULL) {
               update_counter(o_stats->content.application.javascript, size);
+            }
           case X_JA_AS_INT:
             tok_len = 24;
             update_counter(totals.content.application.javascript, size);
-            if (o_stats != NULL)
+            if (o_stats != NULL) {
               update_counter(o_stats->content.application.javascript, size);
+            }
             break;
           case RSSp_AS_INT:
             if (0 == strcmp(tok + 4, "xml")) {
               tok_len = 19;
               update_counter(totals.content.application.rss_xml, size);
-              if (o_stats != NULL)
+              if (o_stats != NULL) {
                 update_counter(o_stats->content.application.rss_xml, size);
+              }
             } else if (0 == strcmp(tok + 4, "atom")) {
               tok_len = 20;
               update_counter(totals.content.application.rss_atom, size);
-              if (o_stats != NULL)
+              if (o_stats != NULL) {
                 update_counter(o_stats->content.application.rss_atom, size);
+              }
             } else {
               tok_len = 12 + strlen(tok);
               update_counter(totals.content.application.rss_other, size);
-              if (o_stats != NULL)
+              if (o_stats != NULL) {
                 update_counter(o_stats->content.application.rss_other, size);
+              }
             }
             break;
           default:
             if (0 == strcmp(tok, "x-shockwave-flash")) {
               tok_len = 29;
               update_counter(totals.content.application.shockwave_flash, size);
-              if (o_stats != NULL)
+              if (o_stats != NULL) {
                 update_counter(o_stats->content.application.shockwave_flash, size);
+              }
             } else if (0 == strcmp(tok, "x-quicktimeplayer")) {
               tok_len = 29;
               update_counter(totals.content.application.quicktime, size);
-              if (o_stats != NULL)
+              if (o_stats != NULL) {
                 update_counter(o_stats->content.application.quicktime, size);
+              }
             } else {
               tok_len = 12 + strlen(tok);
               update_counter(totals.content.application.other, size);
-              if (o_stats != NULL)
+              if (o_stats != NULL) {
                 update_counter(o_stats->content.application.other, size);
+              }
             }
           }
         } else if (0 == strncmp(read_from, "audio", 5)) {
           tok     = read_from + 6;
           tok_len = 6 + strlen(tok);
           update_counter(totals.content.audio.total, size);
-          if (o_stats != NULL)
+          if (o_stats != NULL) {
             update_counter(o_stats->content.audio.total, size);
+          }
           if ((0 == strcmp(tok, "x-wav")) || (0 == strcmp(tok, "wav"))) {
             update_counter(totals.content.audio.wav, size);
-            if (o_stats != NULL)
+            if (o_stats != NULL) {
               update_counter(o_stats->content.audio.wav, size);
+            }
           } else if ((0 == strcmp(tok, "x-mpeg")) || (0 == strcmp(tok, "mpeg"))) {
             update_counter(totals.content.audio.mpeg, size);
-            if (o_stats != NULL)
+            if (o_stats != NULL) {
               update_counter(o_stats->content.audio.mpeg, size);
+            }
           } else {
             update_counter(totals.content.audio.other, size);
-            if (o_stats != NULL)
+            if (o_stats != NULL) {
               update_counter(o_stats->content.audio.other, size);
+            }
           }
         } else if ('-' == *read_from) {
           tok_len = 1;
           update_counter(totals.content.none, size);
-          if (o_stats != NULL)
+          if (o_stats != NULL) {
             update_counter(o_stats->content.none, size);
+          }
         } else {
           tok_len = strlen(read_from);
           update_counter(totals.content.other, size);
-          if (o_stats != NULL)
+          if (o_stats != NULL) {
             update_counter(o_stats->content.other, size);
+          }
         }
         read_from += LogAccess::round_strlen(tok_len + 1);
         flag = 0; // We exited this state without errors
@@ -1651,8 +1722,9 @@ process_file(int in_fd, off_t offset, unsigned max_age)
       }
     } else {
       nread = read(in_fd, buffer, first_read_size);
-      if (!nread || EOF == nread || !header->cookie)
+      if (!nread || EOF == nread || !header->cookie) {
         return 0;
+      }
 
       // ensure that this is a valid logbuffer header
       if (header->cookie != LOG_SEGMENT_COOKIE) {
@@ -1662,8 +1734,9 @@ process_file(int in_fd, off_t offset, unsigned max_age)
     }
 
     Debug("logstats", "LogBuffer version %d, current = %d", header->version, LOG_SEGMENT_VERSION);
-    if (header->version != LOG_SEGMENT_VERSION)
+    if (header->version != LOG_SEGMENT_VERSION) {
       return 1;
+    }
 
     // read the rest of the header
     unsigned second_read_size = sizeof(LogBufferHeader) - first_read_size;
@@ -1757,12 +1830,14 @@ format_int(int64_t num)
       div = num / mult;
       ss << div << std::setw(3);
       num -= (div * mult);
-      if (mult /= 1000)
+      if (mult /= 1000) {
         ss << std::setw(0) << ',' << std::setw(3);
+      }
     }
     std::cout << ss.str();
-  } else
+  } else {
     std::cout << '0';
+  }
 }
 
 void
@@ -1852,8 +1927,9 @@ void
 print_detail_stats(const OriginStats *stat, bool json = false)
 {
   // Cache hit/misses etc.
-  if (!json)
+  if (!json) {
     format_detail_header("Request Result");
+  }
 
   format_line(json ? "hit.direct" : "Cache hit", stat->results.hits.hit, stat->total, json);
   format_line(json ? "hit.ram" : "Cache hit RAM", stat->results.hits.hit_ram, stat->total, json);
@@ -1862,8 +1938,9 @@ print_detail_stats(const OriginStats *stat, bool json = false)
   format_line(json ? "hit.other" : "Cache hit other", stat->results.hits.other, stat->total, json);
   format_line(json ? "hit.total" : "Cache hit total", stat->results.hits.total, stat->total, json);
 
-  if (!json)
+  if (!json) {
     std::cout << std::endl;
+  }
 
   format_line(json ? "miss.direct" : "Cache miss", stat->results.misses.miss, stat->total, json);
   format_line(json ? "miss.ims" : "Cache miss IMS", stat->results.misses.ims, stat->total, json);
@@ -1871,8 +1948,9 @@ print_detail_stats(const OriginStats *stat, bool json = false)
   format_line(json ? "miss.other" : "Cache miss other", stat->results.misses.other, stat->total, json);
   format_line(json ? "miss.total" : "Cache miss total", stat->results.misses.total, stat->total, json);
 
-  if (!json)
+  if (!json) {
     std::cout << std::endl;
+  }
 
   format_line(json ? "error.client_abort" : "Client aborted", stat->results.errors.client_abort, stat->total, json);
   format_line(json ? "error.connect_failed" : "Connect failed", stat->results.errors.connect_fail, stat->total, json);
@@ -1901,8 +1979,9 @@ print_detail_stats(const OriginStats *stat, bool json = false)
   format_line(json ? "status.206" : "206 Partial content", stat->codes.c_206, stat->total, json);
   format_line(json ? "status.2xx" : "2xx Total", stat->codes.c_2xx, stat->total, json);
 
-  if (!json)
+  if (!json) {
     std::cout << std::endl;
+  }
 
   format_line(json ? "status.300" : "300 Multiple Choices", stat->codes.c_300, stat->total, json);
   format_line(json ? "status.301" : "301 Moved permanently", stat->codes.c_301, stat->total, json);
@@ -1913,8 +1992,9 @@ print_detail_stats(const OriginStats *stat, bool json = false)
   format_line(json ? "status.307" : "307 Temporary Redirect", stat->codes.c_307, stat->total, json);
   format_line(json ? "status.3xx" : "3xx Total", stat->codes.c_3xx, stat->total, json);
 
-  if (!json)
+  if (!json) {
     std::cout << std::endl;
+  }
 
   format_line(json ? "status.400" : "400 Bad request", stat->codes.c_400, stat->total, json);
   format_line(json ? "status.401" : "401 Unauthorized", stat->codes.c_401, stat->total, json);
@@ -1936,8 +2016,9 @@ print_detail_stats(const OriginStats *stat, bool json = false)
   format_line(json ? "status.417" : "417 Expectation Failed", stat->codes.c_417, stat->total, json);
   format_line(json ? "status.4xx" : "4xx Total", stat->codes.c_4xx, stat->total, json);
 
-  if (!json)
+  if (!json) {
     std::cout << std::endl;
+  }
 
   format_line(json ? "status.500" : "500 Internal Server Error", stat->codes.c_500, stat->total, json);
   format_line(json ? "status.501" : "501 Not implemented", stat->codes.c_501, stat->total, json);
@@ -1947,8 +2028,9 @@ print_detail_stats(const OriginStats *stat, bool json = false)
   format_line(json ? "status.505" : "505 HTTP Ver. Not Supported", stat->codes.c_505, stat->total, json);
   format_line(json ? "status.5xx" : "5xx Total", stat->codes.c_5xx, stat->total, json);
 
-  if (!json)
+  if (!json) {
     std::cout << std::endl;
+  }
 
   format_line(json ? "status.000" : "000 Unknown", stat->codes.c_000, stat->total, json);
 
@@ -2013,8 +2095,9 @@ print_detail_stats(const OriginStats *stat, bool json = false)
   format_line(json ? "content.text.other" : "text/ other", stat->content.text.other, stat->total, json);
   format_line(json ? "content.text.total" : "text/ total", stat->content.text.total, stat->total, json);
 
-  if (!json)
+  if (!json) {
     std::cout << std::endl;
+  }
 
   format_line(json ? "content.image.jpeg" : "image/jpeg", stat->content.image.jpeg, stat->total, json);
   format_line(json ? "content.image.gif" : "image/gif", stat->content.image.gif, stat->total, json);
@@ -2023,16 +2106,18 @@ print_detail_stats(const OriginStats *stat, bool json = false)
   format_line(json ? "content.image.other" : "image/ other", stat->content.image.other, stat->total, json);
   format_line(json ? "content.image.total" : "image/ total", stat->content.image.total, stat->total, json);
 
-  if (!json)
+  if (!json) {
     std::cout << std::endl;
+  }
 
   format_line(json ? "content.audio.x-wav" : "audio/x-wav", stat->content.audio.wav, stat->total, json);
   format_line(json ? "content.audio.x-mpeg" : "audio/x-mpeg", stat->content.audio.mpeg, stat->total, json);
   format_line(json ? "content.audio.other" : "audio/ other", stat->content.audio.other, stat->total, json);
   format_line(json ? "content.audio.total" : "audio/ total", stat->content.audio.total, stat->total, json);
 
-  if (!json)
+  if (!json) {
     std::cout << std::endl;
+  }
 
   format_line(json ? "content.application.shockwave" : "application/x-shockwave", stat->content.application.shockwave_flash,
               stat->total, json);
@@ -2047,8 +2132,9 @@ print_detail_stats(const OriginStats *stat, bool json = false)
   format_line(json ? "content.application.other" : "application/ other", stat->content.application.other, stat->total, json);
   format_line(json ? "content.application.total" : "application/ total", stat->content.application.total, stat->total, json);
 
-  if (!json)
+  if (!json) {
     std::cout << std::endl;
+  }
 
   format_line(json ? "content.none" : "none", stat->content.none, stat->total, json);
   format_line(json ? "content.other" : "other", stat->content.other, stat->total, json);
@@ -2093,10 +2179,11 @@ my_exit(const ExitStatus &status)
   // Special case for URLs output.
   if (urls) {
     urls->dump(cl.as_object);
-    if (cl.as_object)
+    if (cl.as_object) {
       std::cout << "}" << std::endl;
-    else
+    } else {
       std::cout << "]" << std::endl;
+    }
     ::exit(status.level);
   }
 
@@ -2122,9 +2209,11 @@ my_exit(const ExitStatus &status)
 
   if (!origins.empty()) {
     // Sort the Origins by 'traffic'
-    for (OriginStorage::iterator i = origins.begin(); i != origins.end(); i++)
-      if (use_origin(i->second))
+    for (OriginStorage::iterator i = origins.begin(); i != origins.end(); i++) {
+      if (use_origin(i->second)) {
         vec.push_back(*i);
+      }
+    }
     sort(vec.begin(), vec.end());
 
     if (!cl.json) {
@@ -2294,8 +2383,9 @@ main(int /* argc ATS_UNUSED */, const char *argv[])
       start = line.find_first_not_of(" \t");
       if (start != std::string::npos) {
         end = line.find_first_of(" \t#/");
-        if (std::string::npos == end)
+        if (std::string::npos == end) {
           end = line.length();
+        }
 
         if (end > start) {
           char *buf;
@@ -2318,10 +2408,11 @@ main(int /* argc ATS_UNUSED */, const char *argv[])
   // Should we calculate per URL data;
   if (cl.urls != 0) {
     urls = new UrlLru(cl.urls, cl.show_urls);
-    if (cl.as_object)
+    if (cl.as_object) {
       std::cout << "{" << std::endl;
-    else
+    } else {
       std::cout << "[" << std::endl;
+    }
   }
 
   // Do the incremental parse of the default squid log.
@@ -2415,8 +2506,9 @@ main(int /* argc ATS_UNUSED */, const char *argv[])
       my_exit(exit_status);
     }
     // Make sure the last_state.st_ino is sane.
-    if (last_state.st_ino <= 0)
+    if (last_state.st_ino <= 0) {
       last_state.st_ino = stat_buf.st_ino;
+    }
 
     // Check if the main log file was rotated, and if so, locate
     // the old file first, and parse the remaining log data.
@@ -2459,8 +2551,9 @@ main(int /* argc ATS_UNUSED */, const char *argv[])
       last_state.offset = 0;
     } else {
       // Make sure the last_state.offset is sane, stat_buf is for the main_fd.
-      if (last_state.offset > stat_buf.st_size)
+      if (last_state.offset > stat_buf.st_size) {
         last_state.offset = stat_buf.st_size;
+      }
     }
 
     // Process the main file (always)
@@ -2516,7 +2609,8 @@ main(int /* argc ATS_UNUSED */, const char *argv[])
   }
 
   // All done.
-  if (EXIT_OK == exit_status.level)
+  if (EXIT_OK == exit_status.level) {
     exit_status.append(" OK");
+  }
   my_exit(exit_status);
 }

--- a/proxy/sac.cc
+++ b/proxy/sac.cc
@@ -102,10 +102,12 @@ main(int /* argc ATS_UNUSED */, const char *argv[])
   //
   int config_max_iobuffer_size = DEFAULT_MAX_BUFFER_SIZE;
   max_iobuffer_size            = buffer_size_to_index(config_max_iobuffer_size, DEFAULT_BUFFER_SIZES - 1);
-  if (default_small_iobuffer_size > max_iobuffer_size)
+  if (default_small_iobuffer_size > max_iobuffer_size) {
     default_small_iobuffer_size = max_iobuffer_size;
-  if (default_large_iobuffer_size > max_iobuffer_size)
+  }
+  if (default_large_iobuffer_size > max_iobuffer_size) {
     default_large_iobuffer_size = max_iobuffer_size;
+  }
   init_buffer_allocators();
 
   // initialize the event and net processor

--- a/proxy/shared/DiagsConfig.cc
+++ b/proxy/shared/DiagsConfig.cc
@@ -70,14 +70,16 @@ DiagsConfig::reconfigure_diags()
   // enabled if records.config set
 
   e = (int)REC_readInteger("proxy.config.diags.debug.enabled", &found);
-  if (e && found)
+  if (e && found) {
     c.enabled[DiagsTagType_Debug] = 1; // implement OR logic
-  all_found                       = all_found && found;
+  }
+  all_found = all_found && found;
 
   e = (int)REC_readInteger("proxy.config.diags.action.enabled", &found);
-  if (e && found)
+  if (e && found) {
     c.enabled[DiagsTagType_Action] = 1; // implement OR logic
-  all_found                        = all_found && found;
+  }
+  all_found = all_found && found;
 
   e                    = (int)REC_readInteger("proxy.config.diags.show_location", &found);
   diags->show_location = ((e && found) ? 1 : 0);
@@ -88,8 +90,9 @@ DiagsConfig::reconfigure_diags()
     const char *record_name = output_records[i].config_name;
     DiagsLevel l            = output_records[i].level;
 
-    if (!record_name)
+    if (!record_name) {
       break;
+    }
     p         = REC_readString(record_name, &found);
     all_found = all_found && found;
     if (found) {

--- a/proxy/shared/InkXml.cc
+++ b/proxy/shared/InkXml.cc
@@ -215,11 +215,13 @@ InkXmlConfigFile::display(FILE *fd)
   size_t i;
 
   fprintf(fd, "\n");
-  for (i = 0; i < strlen(m_config_file) + 13; i++)
+  for (i = 0; i < strlen(m_config_file) + 13; i++) {
     fputc('-', fd);
+  }
   fprintf(fd, "\nConfig File: %s\n", m_config_file);
-  for (i = 0; i < strlen(m_config_file) + 13; i++)
+  for (i = 0; i < strlen(m_config_file) + 13; i++) {
     fputc('-', fd);
+  }
   fprintf(fd, "\n");
   for (InkXmlObject *obj = first(); obj; obj = next(obj)) {
     obj->display(fd);
@@ -256,8 +258,9 @@ InkXmlConfigFile::get_next_xml_object(int fd)
       break;
 
     case '!':
-      if (!start_object)
+      if (!start_object) {
         return parse_error();
+      }
       if ((token = scan_comment(fd)) == EOF) {
         return NULL;
       }
@@ -266,8 +269,9 @@ InkXmlConfigFile::get_next_xml_object(int fd)
       break;
 
     default:
-      if (!start_object)
+      if (!start_object) {
         return parse_error();
+      }
       return scan_object(fd, token);
     }
   }
@@ -296,8 +300,9 @@ InkXmlConfigFile::scan_object(int fd, char token)
   while (token != '>' && ident_len < max_ident_len) {
     ident[ident_len++] = token;
     token              = next_token(fd);
-    if (token == EOF)
+    if (token == EOF) {
       return parse_error();
+    }
   }
   if (!ident_len || ident_len >= max_ident_len) {
     return parse_error();
@@ -344,8 +349,9 @@ InkXmlConfigFile::scan_attr(int fd, const char *id)
     switch (token) {
     case '<':
       if (in_quotes && write_to) {
-        if (write_len >= buf_size)
+        if (write_len >= buf_size) {
           return BAD_ATTR;
+        }
         write_to[write_len++] = token;
         break;
       }
@@ -356,13 +362,15 @@ InkXmlConfigFile::scan_attr(int fd, const char *id)
 
     case '=':
       if (in_quotes && write_to) {
-        if (write_len >= buf_size)
+        if (write_len >= buf_size) {
           return BAD_ATTR;
+        }
         write_to[write_len++] = token;
         break;
       }
-      if (!start_attr)
+      if (!start_attr) {
         return BAD_ATTR;
+      }
       write_to[write_len] = 0;
       write_to            = value;
       write_len           = 0;
@@ -382,34 +390,39 @@ InkXmlConfigFile::scan_attr(int fd, const char *id)
 
     case '/':
       if (in_quotes && write_to) {
-        if (write_len >= buf_size)
+        if (write_len >= buf_size) {
           return BAD_ATTR;
+        }
         write_to[write_len++] = token;
         break;
       }
-      if (!start_attr)
+      if (!start_attr) {
         return BAD_ATTR;
+      }
       if (prev == '<') {
         write_len = 0;
         token     = next_token(fd, !in_quotes);
         while (token != '>' && write_len < buf_size) {
           ident[write_len++] = token;
           token              = next_token(fd, !in_quotes);
-          if (token == EOF)
+          if (token == EOF) {
             return BAD_ATTR;
+          }
         }
         if (!write_len || write_len >= buf_size) {
           return BAD_ATTR;
         }
         ident[write_len] = 0;
-        if (strcmp(ident, id) != 0)
+        if (strcmp(ident, id) != 0) {
           return BAD_ATTR;
+        }
         return NULL;
       }
 
       next = next_token(fd, !in_quotes);
-      if (next != '>')
+      if (next != '>') {
         return BAD_ATTR;
+      }
       write_to[write_len] = 0;
       attr                = new InkXmlAttr(name, value);
       ink_assert(attr != NULL);
@@ -417,8 +430,9 @@ InkXmlConfigFile::scan_attr(int fd, const char *id)
 
     case '>':
       if (in_quotes && write_to) {
-        if (write_len >= buf_size)
+        if (write_len >= buf_size) {
           return BAD_ATTR;
+        }
         write_to[write_len++] = token;
         break;
       }
@@ -427,10 +441,12 @@ InkXmlConfigFile::scan_attr(int fd, const char *id)
       return BAD_ATTR;
 
     default:
-      if (!start_attr)
+      if (!start_attr) {
         return BAD_ATTR;
-      if (write_len >= buf_size)
+      }
+      if (write_len >= buf_size) {
         return BAD_ATTR;
+      }
       write_to[write_len++] = token;
       break;
     }
@@ -450,8 +466,9 @@ InkXmlConfigFile::next_token(int fd, bool eat_whitespace)
       continue;
     }
     m_col++;
-    if (eat_whitespace && ParseRules::is_space(ch))
+    if (eat_whitespace && ParseRules::is_space(ch)) {
       continue;
+    }
     return ch;
   }
   return EOF;

--- a/tools/jtest/jtest.cc
+++ b/tools/jtest/jtest.cc
@@ -351,23 +351,25 @@ struct FD {
     ready    = 0;
     req_pos  = 0;
     length   = 0;
-    if (!urls_mode)
+    if (!urls_mode) {
       response = NULL;
-    if (response_header)
+    }
+    if (response_header) {
       response_header[0] = 0;
-    response_length      = 0;
-    response_remaining   = 0;
-    count                = NULL;
-    bytes                = 0;
-    doc                  = 0.0;
-    doc_length           = 0;
-    ims                  = 0;
-    drop_after_CL        = ::drop_after_CL;
-    client_abort         = 0;
-    jg_compressed        = 0;
-    ftp_mode             = FTP_NULL;
-    ftp_peer_addr        = 0;
-    ftp_peer_port        = 0;
+    }
+    response_length    = 0;
+    response_remaining = 0;
+    count              = NULL;
+    bytes              = 0;
+    doc                = 0.0;
+    doc_length         = 0;
+    ims                = 0;
+    drop_after_CL      = ::drop_after_CL;
+    client_abort       = 0;
+    jg_compressed      = 0;
+    ftp_mode           = FTP_NULL;
+    ftp_peer_addr      = 0;
+    ftp_peer_port      = 0;
   }
 
   void close();
@@ -383,20 +385,25 @@ FD *fd = NULL;
 void
 FD::close()
 {
-  if (verbose)
+  if (verbose) {
     printf("close: %d\n", fd);
+  }
   ::close(fd);
-  if (is_done())
+  if (is_done()) {
     done();
+  }
   keepalive = 0;
   ip        = 0;
-  if (count)
+  if (count) {
     (*count)--;
-  if (count == &clients)
+  }
+  if (count == &clients) {
     current_clients--;
+  }
   reset();
-  if (urls_mode)
+  if (urls_mode) {
     undefer_url();
+  }
   ftp_data_fd = 0;
 }
 
@@ -443,12 +450,15 @@ static void
 remove_last_seg(char *src, char *dest)
 {
   char *ptr;
-  for (ptr = src + strlen(src) - 1; ptr >= src; ptr--)
-    if (*ptr == '/')
+  for (ptr = src + strlen(src) - 1; ptr >= src; ptr--) {
+    if (*ptr == '/') {
       break;
-  while (src <= ptr)
+    }
+  }
+  while (src <= ptr) {
     *dest++ = *src++;
-  *dest     = '\0';
+  }
+  *dest = '\0';
 }
 
 static inline void
@@ -473,8 +483,9 @@ static inline void
 append_string(char *dest, const char *src, int *offset_ptr, int max_len)
 {
   int num = strlen(src);
-  if (*offset_ptr + num > max_len)
+  if (*offset_ptr + num > max_len) {
     num = max_len - *offset_ptr;
+  }
   strncpy(dest + *offset_ptr, src, num + 1);
   (*offset_ptr) += num;
 }
@@ -523,37 +534,45 @@ read_ready(int fd)
   p.events = POLLIN;
   p.fd     = fd;
   int r    = poll(&p, 1, 0);
-  if (r <= 0)
+  if (r <= 0) {
     return r;
-  if (p.revents & (POLLERR | POLLNVAL))
+  }
+  if (p.revents & (POLLERR | POLLNVAL)) {
     return -1;
-  if (p.revents & (POLLIN | POLLHUP))
+  }
+  if (p.revents & (POLLIN | POLLHUP)) {
     return 1;
+  }
   return 0;
 }
 
 static void
 poll_init(int sock)
 {
-  if (!fd[sock].req_header)
+  if (!fd[sock].req_header) {
     fd[sock].req_header = (char *)malloc(HEADER_SIZE * pipeline);
-  if (!fd[sock].response_header)
+  }
+  if (!fd[sock].response_header) {
     fd[sock].response_header = (char *)malloc(HEADER_SIZE);
-  if (!fd[sock].base_url)
+  }
+  if (!fd[sock].base_url) {
     fd[sock].base_url = (char *)malloc(HEADER_SIZE);
+  }
   fd[sock].reset();
 }
 
 static void
 poll_set(int sock, poll_cb read_cb, poll_cb write_cb = NULL)
 {
-  if (verbose)
+  if (verbose) {
     printf("adding poll %d\n", sock);
+  }
   fd[sock].fd       = sock;
   fd[sock].read_cb  = read_cb;
   fd[sock].write_cb = write_cb;
-  if (last_fd < sock)
+  if (last_fd < sock) {
     last_fd = sock;
+  }
 }
 
 static void
@@ -566,8 +585,9 @@ poll_init_set(int sock, poll_cb read_cb, poll_cb write_cb = NULL)
 static int
 fast(int sock, int speed, int d)
 {
-  if (!speed)
+  if (!speed) {
     return 0;
+  }
   int64_t t  = now - fd[sock].start + 1;
   int target = (int)(((t / HRTIME_MSECOND) * speed) / 1000);
   int delta  = d - target;
@@ -575,8 +595,9 @@ fast(int sock, int speed, int d)
     int mwait      = (delta * 1000) / speed;
     fd[sock].ready = now + (mwait * HRTIME_MSECOND);
     return 1;
-  } else
+  } else {
     fd[sock].ready = now;
+  }
   return 0;
 }
 
@@ -591,13 +612,15 @@ elapsed_from_start(int sock)
 static int
 faster_than(int sock, int speed, int d)
 {
-  if (!speed)
+  if (!speed) {
     return 1;
+  }
   int64_t t  = now - fd[sock].start + 1;
   int target = (int)(((t / HRTIME_MSECOND) * speed) / 1000);
   int delta  = d - target;
-  if (delta > 0)
+  if (delta > 0) {
     return 1;
+  }
   return 0;
 }
 
@@ -609,15 +632,18 @@ get_path_from_req(char *buf, char **purl_start, char **purl_end)
   if (!strncasecmp(url_start, "GET ", sizeof("GET ") - 1)) {
     url_start += sizeof("GET ") - 1;
     url_end = (char *)memchr(url_start, ' ', 70);
-  } else
+  } else {
     url_end = (char *)memchr(url_start, 0, 70);
-  if (!url_end)
+  }
+  if (!url_end) {
     panic("malformed request\n");
-  if (url_end - url_start > 10)
+  }
+  if (url_end - url_start > 10) {
     if (!strncasecmp(url_start, "http://", sizeof("http://") - 1)) {
       url_start += sizeof("http://") - 1;
       url_start = (char *)memchr(url_start, '/', 70);
     }
+  }
   *purl_start = url_start;
   *purl_end   = url_end;
 }
@@ -659,7 +685,7 @@ send_response(int sock)
                                     "\r\n",
                             content_type, fd[sock].keepalive > 0 ? "Connection: Keep-Alive\r\n" : "");
         url_len = 0;
-      } else
+      } else {
         print_len = sprintf(header, "HTTP/1.0 200 OK\r\n"
                                     "Content-Type: %s\r\n"
                                     "Cache-Control: max-age=630720000\r\n"
@@ -670,31 +696,38 @@ send_response(int sock)
                                     "\r\n%s",
                             content_type, fd[sock].keepalive > 0 ? "Connection: Keep-Alive\r\n" : "", fd[sock].response_length,
                             no_cache ? "Pragma: no-cache\r\nCache-Control: no-cache\r\n" : "", url_start ? url_start : "");
-    } else
+      }
+    } else {
       url_len = print_len = sprintf(header, "ftp://%s:%d/%12.10f/%d", local_host, server_port, fd[sock].doc, fd[sock].length);
-    if (show_headers)
+    }
+    if (show_headers) {
       printf("Response to Proxy: {\n%s}\n", header);
+    }
     int len = print_len - fd[sock].req_pos;
     ink_assert(len > 0);
     do {
       err = write(sock, header + fd[sock].req_pos, len);
     } while ((err == -1) && (errno == EINTR));
     if (err <= 0) {
-      if (!err)
+      if (!err) {
         return -1;
-      if (errno == EAGAIN || errno == ENOTCONN)
+      }
+      if (errno == EAGAIN || errno == ENOTCONN) {
         return 0;
+      }
       return -1;
     }
-    if (verbose)
+    if (verbose) {
       printf("wrote %d %d\n", sock, err);
+    }
     new_tbytes += err;
     fd[sock].req_pos += err;
     fd[sock].bytes += err;
-    if (fd[sock].req_pos >= len)
+    if (fd[sock].req_pos >= len) {
       fd[sock].req_pos = -1;
-    else
+    } else {
       return 0;
+    }
     fd[sock].response += url_len;
     fd[sock].length -= url_len;
     total_server_response_header_bytes += print_len - url_len;
@@ -703,23 +736,27 @@ send_response(int sock)
 
   /* then the response */
   towrite = server_speed ? server_speed : MAX_RESPONSE_LENGTH;
-  if (fd[sock].length < towrite)
+  if (fd[sock].length < towrite) {
     towrite = fd[sock].length;
+  }
   if (towrite > 0) {
-    if (fast(sock, server_speed, fd[sock].bytes))
+    if (fast(sock, server_speed, fd[sock].bytes)) {
       return 0;
+    }
     do {
       err = write(sock, fd[sock].response, towrite);
     } while ((err == -1) && (errno == EINTR));
     if (err < 0) {
-      if (errno == EAGAIN || errno == ENOTCONN)
+      if (errno == EAGAIN || errno == ENOTCONN) {
         return 0;
+      }
       fprintf(stderr, "write errno %d length %d sock %d\n", errno, towrite, sock);
       errors++;
       return -1;
     }
-    if (verbose)
+    if (verbose) {
       printf("wrote %d %d\n", sock, err);
+    }
 
     new_tbytes += err;
     total_server_response_body_bytes += err;
@@ -728,13 +765,16 @@ send_response(int sock)
     fd[sock].bytes += err;
   }
 
-  if (fast(sock, server_speed, fd[sock].bytes))
+  if (fast(sock, server_speed, fd[sock].bytes)) {
     return 0;
+  }
   if (fd[sock].length <= 0 || !err) {
-    if (fd[sock].response)
+    if (fd[sock].response) {
       new_sops++;
-    if (verbose)
+    }
+    if (verbose) {
       printf("write %d done\n", sock);
+    }
     if (fd[sock].keepalive > 0 && !ftp) {
       poll_init_set(sock, read_request);
       fd[sock].start = now;
@@ -755,15 +795,18 @@ strncasestr(char *s, const char *find, int len)
   while (1) {
     char *x = (char *)memchr(s, *find, e - s);
     if (!x) {
-      if (ParseRules::is_upalpha(*find))
+      if (ParseRules::is_upalpha(*find)) {
         x = (char *)memchr(s, ParseRules::ink_tolower(*find), e - s);
-      else
+      } else {
         x = (char *)memchr(s, ParseRules::ink_toupper(*find), e - s);
-      if (!x)
+      }
+      if (!x) {
         break;
+      }
     }
-    if (!strncasecmp(find, x, findlen))
+    if (!strncasecmp(find, x, findlen)) {
       return x;
+    }
     s = x + 1;
   }
   return NULL;
@@ -776,10 +819,12 @@ check_keepalive(char *r, int length)
   if (ka) {
     int l   = length - (ka - r);
     char *e = (char *)memchr(ka, '\n', l);
-    if (!e)
+    if (!e) {
       e = (char *)memchr(ka, '\r', l);
-    if (strncasestr(ka, "close", e - ka))
+    }
+    if (strncasestr(ka, "close", e - ka)) {
       return NULL;
+    }
   }
   return ka;
 }
@@ -790,23 +835,29 @@ check_alt(char *r, int length)
   char *s = strncasestr(r, "Cookie:", length);
   if (!s) {
     s = strncasestr(r, "User-Agent:", length);
-    if (s)
+    if (s) {
       s += sizeof("User-Agent:");
-  } else
+    }
+  } else {
     s += sizeof("Cookie:");
+  }
   if (s) {
     int l   = length - (s - r);
     char *e = (char *)memchr(s, '\n', l);
-    if (!e)
+    if (!e) {
       e = (char *)memchr(s, '\r', l);
-    if (!(s = strncasestr(s, "jtest", e - s)))
+    }
+    if (!(s = strncasestr(s, "jtest", e - s))) {
       return 0;
+    }
     s = (char *)memchr(s, '-', l);
-    if (!s)
+    if (!s) {
       return 0;
+    }
     s = (char *)memchr(s + 1, '-', l);
-    if (!s)
+    if (!s) {
       return 0;
+    }
     return ink_atoi(s + 1);
   }
   return 0;
@@ -837,8 +888,9 @@ send_ftp_data_when_ready(int sock)
   if (fd[sock].state == STATE_FTP_DATA_READY && fd[sock].doc_length) {
     fd[sock].response        = fd[sock].req_header;
     fd[sock].response_length = fd[sock].length = fd[sock].doc_length;
-    if (verbose)
+    if (verbose) {
       printf("ftp data %d >-< %d\n", sock, fd[sock].ftp_data_fd);
+    }
     fd[sock].response = response_buffer + fd[sock].doc_length % 256;
     fd[sock].req_pos  = 0;
     poll_set(sock, NULL, send_response);
@@ -850,8 +902,9 @@ static int
 send_ftp_data(int sock, char *start /*, char * end */)
 {
   int data_fd = fd[sock].ftp_data_fd;
-  if (sscanf(start, "%d", &fd[data_fd].doc_length) != 1)
+  if (sscanf(start, "%d", &fd[data_fd].doc_length) != 1) {
     return -1;
+  }
   fd[data_fd].doc = fd[sock].doc;
   send_ftp_data_when_ready(data_fd);
   return 0;
@@ -860,8 +913,9 @@ send_ftp_data(int sock, char *start /*, char * end */)
 static int
 read_request(int sock)
 {
-  if (verbose)
+  if (verbose) {
     printf("read_request %d\n", sock);
+  }
   int err = 0;
   int i;
 
@@ -872,18 +926,22 @@ read_request(int sock)
   } while ((err < 0) && (errno == EINTR));
 
   if (err < 0) {
-    if (errno == EAGAIN || errno == ENOTCONN)
+    if (errno == EAGAIN || errno == ENOTCONN) {
       return 0;
-    if (fd[sock].req_pos || errno != ECONNRESET)
+    }
+    if (fd[sock].req_pos || errno != ECONNRESET) {
       perror("read");
+    }
     return -1;
   } else if (err == 0) {
-    if (verbose)
+    if (verbose) {
       printf("eof\n");
+    }
     return -1;
   } else {
-    if (verbose)
+    if (verbose) {
       printf("read %d got %d\n", sock, err);
+    }
     total_proxy_request_bytes += err;
     new_tbytes += err;
     fd[sock].req_pos += err;
@@ -892,48 +950,55 @@ read_request(int sock)
     for (i = fd[sock].req_pos - err; i < fd[sock].req_pos; i++) {
       switch (fd[sock].state) {
       case 0:
-        if (buffer[i] == '\r')
+        if (buffer[i] == '\r') {
           fd[sock].state = 1;
-        else if (buffer[i] == '\n')
+        } else if (buffer[i] == '\n') {
           fd[sock].state = 2;
+        }
         break;
       case 1:
-        if (buffer[i] == '\n')
+        if (buffer[i] == '\n') {
           fd[sock].state = 2;
-        else
+        } else {
           fd[sock].state = 0;
+        }
         break;
       case 2:
-        if (buffer[i] == '\r')
+        if (buffer[i] == '\r') {
           fd[sock].state = 3;
-        else if (buffer[i] == '\n') {
+        } else if (buffer[i] == '\n') {
           fd[sock].state = 3;
           goto L3;
-        } else
+        } else {
           fd[sock].state = 0;
+        }
         break;
       L3:
       case 3:
         if (buffer[i] == '\n') {
-          if (show_headers)
+          if (show_headers) {
             printf("Request from Proxy: {\n%s}\n", buffer);
+          }
           char host[80];
           int port, length;
           float r;
           if (sscanf(buffer, "GET http://%[^:]:%d/%f/%d", host, &port, &r, &length) == 4) {
           } else if (sscanf(buffer, "GET /%f/%d", &r, &length) == 2) {
           } else {
-            if (verbose)
+            if (verbose) {
               printf("misscan: %s\n", buffer);
+            }
             fd[sock].close();
             return 0;
           }
-          if (verbose)
+          if (verbose) {
             printf("read_request %d got request %d\n", sock, length);
+          }
           char *ims = strncasestr(buffer, "If-Modified-Since:", i);
           // coverity[dont_call]
-          if (drand48() > ims_rate)
-            ims        = NULL;
+          if (drand48() > ims_rate) {
+            ims = NULL;
+          }
           fd[sock].ims = ims ? 1 : 0;
           if (!ims) {
             fd[sock].response_length = fd[sock].length = length;
@@ -941,16 +1006,18 @@ read_request(int sock)
             fd[sock].response                          = response_buffer + length % 256 + fd[sock].nalternate;
           } else {
             fd[sock].nalternate = 0;
-            if (verbose)
+            if (verbose) {
               printf("sending IMS 304: Not-Modified\n");
+            }
             fd[sock].response        = NULL;
             fd[sock].response_length = fd[sock].length = 0;
           }
           fd[sock].req_pos = 0;
-          if (!check_keepalive(fd[sock].req_header, strlen(fd[sock].req_header)))
+          if (!check_keepalive(fd[sock].req_header, strlen(fd[sock].req_header))) {
             fd[sock].keepalive = 0;
-          else
+          } else {
             fd[sock].keepalive--;
+          }
           // coverity[dont_call]
           if (fd[sock].length && drand48() < server_abort_rate) {
             // coverity[dont_call]
@@ -959,8 +1026,9 @@ read_request(int sock)
           }
           poll_set(sock, NULL, send_response);
           return 0;
-        } else
+        } else {
           fd[sock].state = 0;
+        }
         break;
       }
     }
@@ -985,17 +1053,20 @@ send_compd_response(int sock)
     } while ((err == -1) && (errno == EINTR));
     if (err <= 0) {
       if (!err) {
-        if (verbose_errors)
+        if (verbose_errors) {
           printf("write %d closed early\n", sock);
+        }
         goto Lerror;
       }
-      if (errno == EAGAIN || errno == ENOTCONN)
+      if (errno == EAGAIN || errno == ENOTCONN) {
         return 0;
+      }
       perror("write");
       goto Lerror;
     }
-    if (verbose)
+    if (verbose) {
       printf("write %d %d\n", sock, err);
+    }
 
     new_tbytes += err;
     fd[sock].req_pos += err;
@@ -1009,20 +1080,23 @@ send_compd_response(int sock)
     if (towrite > desired) {
       towrite = desired;
     }
-    if (fast(sock, client_speed, fd[sock].bytes))
+    if (fast(sock, client_speed, fd[sock].bytes)) {
       return 0;
+    }
     do {
       err = write(sock, fd[sock].response + fd[sock].req_pos - sizeof(compd_header), towrite);
     } while ((err == -1) && (errno == EINTR));
     if (err < 0) {
-      if (errno == EAGAIN || errno == ENOTCONN)
+      if (errno == EAGAIN || errno == ENOTCONN) {
         return 0;
+      }
       fprintf(stderr, "write errno %d length %d sock %d\n", errno, towrite, sock);
       errors++;
       return -1;
     }
-    if (verbose)
+    if (verbose) {
       printf("wrote %d %d\n", sock, err);
+    }
 
     new_tbytes += err;
     total_server_response_body_bytes += err;
@@ -1030,8 +1104,9 @@ send_compd_response(int sock)
     fd[sock].bytes += err;
   }
 
-  if (fd[sock].req_pos >= ((fd[sock].length * 2) / 3) + 4)
+  if (fd[sock].req_pos >= ((fd[sock].length * 2) / 3) + 4) {
     return -1;
+  }
 
   return 0;
 Lerror:
@@ -1042,8 +1117,9 @@ Lerror:
 static int
 read_compd_request(int sock)
 {
-  if (verbose)
+  if (verbose) {
     printf("read_compd_request %d\n", sock);
+  }
   int err = 0;
 
   if (fd[sock].req_pos < 4) {
@@ -1053,51 +1129,60 @@ read_compd_request(int sock)
     } while ((err < 0) && (errno == EINTR));
 
     if (err < 0) {
-      if (errno == EAGAIN || errno == ENOTCONN)
+      if (errno == EAGAIN || errno == ENOTCONN) {
         return 0;
+      }
       perror("read");
       return -1;
     } else if (err == 0) {
-      if (verbose)
+      if (verbose) {
         printf("eof\n");
+      }
       return -1;
     } else {
-      if (verbose)
+      if (verbose) {
         printf("read %d got %d\n", sock, err);
+      }
       total_proxy_request_bytes += err;
       new_tbytes += err;
       fd[sock].req_pos += err;
-      if (fd[sock].req_pos < 4)
+      if (fd[sock].req_pos < 4) {
         return 0;
+      }
       fd[sock].length = ntohl(*(unsigned int *)fd[sock].req_header);
     }
   }
 
-  if (fd[sock].req_pos >= fd[sock].length + 4)
+  if (fd[sock].req_pos >= fd[sock].length + 4) {
     goto Lcont;
+  }
 
   {
     char buf[MAX_BUFSIZE];
     int toread = cbuffersize;
-    if (fast(sock, client_speed, fd[sock].bytes))
+    if (fast(sock, client_speed, fd[sock].bytes)) {
       return 0;
+    }
     do {
       err = read(sock, buf, toread);
     } while ((err == -1) && (errno == EINTR));
     if (err < 0) {
-      if (errno == EAGAIN || errno == ENOTCONN)
+      if (errno == EAGAIN || errno == ENOTCONN) {
         return 0;
+      }
       if (errno == ECONNRESET) {
-        if (verbose || verbose_errors)
+        if (verbose || verbose_errors) {
           perror("read");
+        }
         errors++;
         return -1;
       }
       panic_perror("read");
     }
     if (!err) {
-      if (verbose || verbose_errors)
+      if (verbose || verbose_errors) {
         perror("read");
+      }
       errors++;
       return -1;
     }
@@ -1106,8 +1191,9 @@ read_compd_request(int sock)
     fd[sock].req_pos += err;
   }
 
-  if (fd[sock].req_pos >= fd[sock].length + 4)
+  if (fd[sock].req_pos >= fd[sock].length + 4) {
     goto Lcont;
+  }
 
   return 0;
 
@@ -1121,8 +1207,9 @@ Lcont:
 static int
 read_ftp_request(int sock)
 {
-  if (verbose)
+  if (verbose) {
     printf("read_ftp_request %d\n", sock);
+  }
   int err = 0;
   int i;
 
@@ -1133,25 +1220,29 @@ read_ftp_request(int sock)
   } while ((err < 0) && (errno == EINTR));
 
   if (err < 0) {
-    if (errno == EAGAIN || errno == ENOTCONN)
+    if (errno == EAGAIN || errno == ENOTCONN) {
       return 0;
+    }
     perror("read");
     return -1;
   } else if (err == 0) {
-    if (verbose)
+    if (verbose) {
       printf("eof\n");
+    }
     return -1;
   } else {
-    if (verbose)
+    if (verbose) {
       printf("read %d got %d\n", sock, err);
+    }
     new_tbytes += err;
     fd[sock].req_pos += err;
     fd[sock].req_header[fd[sock].req_pos] = 0;
     char *buffer                          = fd[sock].req_header, *n;
     int res                               = 0;
     buffer[fd[sock].req_pos]              = 0;
-    if (verbose)
+    if (verbose) {
       printf("buffer [%s]\n", buffer);
+    }
 #define STREQ(_x, _s) (!strncasecmp(_x, _s, sizeof(_s) - 1))
     if (STREQ(buffer, "USER")) {
       res = 331;
@@ -1169,8 +1260,9 @@ read_ftp_request(int sock)
       res = 200;
     Lhere:
       n = (char *)memchr(buffer, '\n', fd[sock].req_pos);
-      if (!n)
+      if (!n) {
         return 0;
+      }
       make_response(sock, res);
       return 0;
     } else if (STREQ(buffer, "SIZE")) {
@@ -1180,8 +1272,9 @@ read_ftp_request(int sock)
     } else if (STREQ(buffer, "MDTM")) {
       double err_rand = 1.0;
       // coverity[dont_call]
-      if (ftp_mdtm_err_rate != 0.0)
+      if (ftp_mdtm_err_rate != 0.0) {
         err_rand = drand48();
+      }
       if (err_rand < ftp_mdtm_err_rate) {
         fd[sock].length = sprintf(fd[sock].req_header, "550 mdtm file not found\r\n");
       } else {
@@ -1204,40 +1297,48 @@ read_ftp_request(int sock)
       return 0;
     } else if (STREQ(buffer, "PASV")) {
       n = (char *)memchr(buffer, '\n', fd[sock].req_pos);
-      if (!n)
+      if (!n) {
         return 0;
-      if ((fd[sock].ftp_data_fd = open_server(0, accept_ftp_data)) < 0)
+      }
+      if ((fd[sock].ftp_data_fd = open_server(0, accept_ftp_data)) < 0) {
         panic("could not open ftp data PASV accept port\n");
+      }
       fd[fd[sock].ftp_data_fd].ftp_data_fd = sock;
-      if (verbose)
+      if (verbose) {
         printf("ftp PASV %d <-> %d\n", sock, fd[sock].ftp_data_fd);
+      }
       unsigned short p = fd[fd[sock].ftp_data_fd].name.sin_port;
       fd[sock].length  = sprintf(fd[sock].req_header, "227 (%u,%u,%u,%u,%u,%u)\r\n", ((unsigned char *)&local_addr)[0],
                                 ((unsigned char *)&local_addr)[1], ((unsigned char *)&local_addr)[2],
                                 ((unsigned char *)&local_addr)[3], ((unsigned char *)&p)[0], ((unsigned char *)&p)[1]);
-      if (verbose)
+      if (verbose) {
         puts(fd[sock].req_header);
+      }
       make_long_response(sock);
       fd[sock].ftp_mode = FTP_PASV;
       return 0;
     } else if (STREQ(buffer, "PORT")) {
       // watch out for an endian problems !!!
       char *start, *stop;
-      for (start = buffer; !ParseRules::is_digit(*start); start++)
+      for (start = buffer; !ParseRules::is_digit(*start); start++) {
         ;
-      for (stop = start; *stop != ','; stop++)
+      }
+      for (stop = start; *stop != ','; stop++) {
         ;
+      }
       for (i = 0; i < 4; i++) {
         ((unsigned char *)&(fd[sock].ftp_peer_addr))[i] = strtol(start, &stop, 10);
-        for (start = ++stop; *stop != ','; stop++)
+        for (start = ++stop; *stop != ','; stop++) {
           ;
+        }
       }
       ((unsigned char *)&(fd[sock].ftp_peer_port))[0] = strtol(start, &stop, 10);
       start                                           = ++stop;
       ((unsigned char *)&(fd[sock].ftp_peer_port))[1] = strtol(start, NULL, 10);
       fd[sock].length                                 = sprintf(fd[sock].req_header, "200 Okay\r\n");
-      if (verbose)
+      if (verbose) {
         puts(fd[sock].req_header);
+      }
       make_long_response(sock);
       fd[sock].ftp_mode = FTP_PORT;
       return 0;
@@ -1261,21 +1362,25 @@ read_ftp_request(int sock)
         fd[sock].ftp_mode      = FTP_PORT;
       }
       if (fd[sock].ftp_mode == FTP_PORT) {
-        if ((fd[sock].ftp_data_fd = make_client(fd[sock].ftp_peer_addr, fd[sock].ftp_peer_port)) < 0)
+        if ((fd[sock].ftp_data_fd = make_client(fd[sock].ftp_peer_addr, fd[sock].ftp_peer_port)) < 0) {
           panic("could not open ftp PORT data connection to client\n");
+        }
         fd[fd[sock].ftp_data_fd].ftp_data_fd = sock;
         fd[fd[sock].ftp_data_fd].state       = STATE_FTP_DATA_READY;
-        if (verbose)
+        if (verbose) {
           printf("ftp PORT %d <-> %d\n", sock, fd[sock].ftp_data_fd);
+        }
       }
       n = (char *)memchr(buffer, '\n', fd[sock].req_pos);
-      if (!n)
+      if (!n) {
         return 0;
+      }
       if (send_ftp_data(sock, buffer + 5 /*, n */) < 0) {
         errors++;
         *n = 0;
-        if (verbose)
+        if (verbose) {
           printf("badly formed ftp request: %s\n", buffer);
+        }
         return 1;
       }
       fd[sock].response        = fd[sock].req_header;
@@ -1285,8 +1390,9 @@ read_ftp_request(int sock)
       poll_set(sock, NULL, write_ftp_response);
       return 0;
     } else {
-      if (verbose || verbose_errors)
+      if (verbose || verbose_errors) {
         printf("ftp junk : %s\n", buffer);
+      }
       fd[sock].req_pos = 0;
       return 0;
     }
@@ -1308,17 +1414,20 @@ accept_sock(int sock)
 #endif
                     );
     if (new_fd < 0) {
-      if (errno == EAGAIN || errno == ENOTCONN)
+      if (errno == EAGAIN || errno == ENOTCONN) {
         return 0;
-      if (errno == EINTR || errno == ECONNABORTED)
+      }
+      if (errno == EINTR || errno == ECONNABORTED) {
         continue;
+      }
       printf("accept socket was %d\n", sock);
       panic_perror("accept");
     }
   } while (new_fd < 0);
 
-  if (fcntl(new_fd, F_SETFL, O_NONBLOCK) < 0)
+  if (fcntl(new_fd, F_SETFL, O_NONBLOCK) < 0) {
     panic_perror("fcntl");
+  }
 
 #if 0
 #ifdef BUFSIZE //  make default
@@ -1370,8 +1479,9 @@ accept_read(int sock)
   if (ftp) {
     poll_init_set(new_fd, NULL, write_ftp_response);
     make_response(new_fd, 220);
-  } else
+  } else {
     poll_init_set(new_fd, read_request);
+  }
   fd[new_fd].count     = &servers;
   fd[new_fd].start     = now;
   fd[new_fd].ready     = now + server_delay * HRTIME_MSECOND;
@@ -1397,8 +1507,9 @@ accept_ftp_data(int sock)
   fd[new_fd].state                     = STATE_FTP_DATA_READY;
   fd[new_fd].doc                       = fd[sock].doc;
   fd[new_fd].doc_length                = fd[sock].doc_length;
-  if (verbose)
+  if (verbose) {
     printf("accept_ftp_data %d for %d\n", new_fd, sock);
+  }
   send_ftp_data_when_ready(new_fd);
   return 1;
 }
@@ -1468,8 +1579,9 @@ open_server(unsigned short int port, accept_fn_t accept_fn)
     exit(EXIT_FAILURE);
   }
 
-  if (verbose)
+  if (verbose) {
     printf("opening server on %d port %d\n", sock, name.sin_port);
+  }
 
   poll_init_set(sock, accept_fn);
 
@@ -1481,8 +1593,9 @@ static int
 poll_loop()
 {
   if (server_fd > 0) {
-    while (read_ready(server_fd) > 0)
+    while (read_ready(server_fd) > 0) {
       accept_read(server_fd);
+    }
   }
   pollfd pfd[POLL_GROUP_SIZE];
   int ip = 0;
@@ -1492,10 +1605,12 @@ poll_loop()
       pfd[ip].fd      = i;
       pfd[ip].events  = 0;
       pfd[ip].revents = 0;
-      if (fd[i].read_cb)
+      if (fd[i].read_cb) {
         pfd[ip].events |= POLLIN;
-      if (fd[i].write_cb)
+      }
+      if (fd[i].write_cb) {
         pfd[ip].events |= POLLOUT;
+      }
       ip++;
     }
     if (ip >= POLL_GROUP_SIZE || i == last_fd) {
@@ -1503,16 +1618,18 @@ poll_loop()
       if (n > 0) {
         for (int j = 0; j < ip; j++) {
           if (pfd[j].revents & (POLLIN | POLLERR | POLLHUP | POLLNVAL)) {
-            if (verbose)
+            if (verbose) {
               printf("poll read %d %X\n", pfd[j].fd, pfd[j].revents);
+            }
             if (fd[pfd[j].fd].read_cb && fd[pfd[j].fd].read_cb(pfd[j].fd)) {
               fd[pfd[j].fd].close();
               continue;
             }
           }
           if (pfd[j].revents & (POLLOUT | POLLERR | POLLHUP | POLLNVAL)) {
-            if (verbose)
+            if (verbose) {
               printf("poll write %d %X\n", pfd[j].fd, pfd[j].revents);
+            }
             if (fd[pfd[j].fd].write_cb && fd[pfd[j].fd].write_cb(pfd[j].fd)) {
               fd[pfd[j].fd].close();
               continue;
@@ -1529,8 +1646,9 @@ poll_loop()
 static int
 gen_bfc_dist(double f = 10.0)
 {
-  if (docsize >= 0)
+  if (docsize >= 0) {
     return docsize;
+  }
 
   double rand  = 0.0;
   double rand2 = 0.0;
@@ -1556,8 +1674,9 @@ gen_bfc_dist(double f = 10.0)
     class_no = 2;
   } else {
     class_no = 3;
-    if (f_given)
+    if (f_given) {
       rand2 = (f * 113.0) - floor(f * 113.0);
+    }
   }
 
   if (rand2 < 0.018) {
@@ -1588,11 +1707,13 @@ gen_bfc_dist(double f = 10.0)
   size          = size * (file_no + 1);
   // vary about the mean doc size for
   // that class/size
-  if (!f_given)
+  if (!f_given) {
     // coverity[dont_call]
     size += (int)((-increment * 0.5) + (increment * drand48()));
-  if (verbose)
+  }
+  if (verbose) {
     printf("gen_bfc_dist %d\n", size);
+  }
   return size;
 }
 
@@ -1601,30 +1722,34 @@ build_response()
 {
   int maxsize     = docsize > MAX_RESPONSE_LENGTH ? docsize : MAX_RESPONSE_LENGTH;
   response_buffer = (char *)malloc(maxsize + HEADER_SIZE);
-  for (int i           = 0; i < maxsize + HEADER_SIZE; i++)
+  for (int i = 0; i < maxsize + HEADER_SIZE; i++) {
     response_buffer[i] = i % 256;
+  }
 }
 
 static void
 put_ka(int sock)
 {
   int i = 0;
-  for (; i < n_ka_cache; i++)
-    if (!ka_cache_head[i] || fd[ka_cache_head[i]].ip == fd[sock].ip)
+  for (; i < n_ka_cache; i++) {
+    if (!ka_cache_head[i] || fd[ka_cache_head[i]].ip == fd[sock].ip) {
       goto Lpush;
+    }
+  }
   i = n_ka_cache++;
 Lpush:
-  if (ka_cache_tail[i])
+  if (ka_cache_tail[i]) {
     fd[ka_cache_tail[i]].next = sock;
-  else
+  } else {
     ka_cache_head[i] = sock;
-  ka_cache_tail[i]   = sock;
+  }
+  ka_cache_tail[i] = sock;
 }
 
 static int
 get_ka(unsigned int ip)
 {
-  for (int i = 0; i < n_ka_cache; i++)
+  for (int i = 0; i < n_ka_cache; i++) {
     if (fd[ka_cache_head[i]].ip == ip) {
       int res          = ka_cache_head[i];
       ka_cache_head[i] = fd[ka_cache_head[i]].next;
@@ -1634,16 +1759,18 @@ get_ka(unsigned int ip)
       }
       return res;
     }
+  }
   return -1;
 }
 
 static void
 defer_url(char *url)
 {
-  if (n_defered_urls < MAX_DEFERED_URLS - 1)
+  if (n_defered_urls < MAX_DEFERED_URLS - 1) {
     defered_urls[n_defered_urls++] = strdup(url);
-  else
+  } else {
     fprintf(stderr, "too many defered urls, dropping '%s'\n", url);
+  }
 }
 
 static int
@@ -1673,12 +1800,15 @@ undefer_url(bool unthrottled)
     char *url = defered_urls[n_defered_urls];
     make_url_client(url, 0, true, unthrottled);
     free(url);
-    if (verbose)
+    if (verbose) {
       printf("undefer_url: made client %d clients\n", current_clients);
-  } else if (verbose)
+    }
+  } else if (verbose) {
     printf("undefer_url: throttle\n");
-  if (is_done())
+  }
+  if (is_done()) {
     done();
+  }
 }
 
 static void
@@ -1713,42 +1843,53 @@ static char *
 find_href_end(char *start, int len)
 {
   char *end = start;
-  if (!start)
+  if (!start) {
     return NULL;
+  }
 
   while (*end && len > 0) {
-    if (*end == '\"')
+    if (*end == '\"') {
       break; /* " */
-    if (*end == '\'')
+    }
+    if (*end == '\'') {
       break;
-    if (*end == '>')
+    }
+    if (*end == '>') {
       break;
-    if (*end == ' ')
+    }
+    if (*end == ' ') {
       break;
-    if (*end == '\t')
+    }
+    if (*end == '\t') {
       break;
-    if (*end == '\n')
+    }
+    if (*end == '\n') {
       break;
-    if (*end == '<')
+    }
+    if (*end == '<') {
       break;
-    if (*end & 0x80)
+    }
+    if (*end & 0x80) {
       break; /* hi order bit! */
+    }
     len--;
     end++;
   }
 
-  if (*end == 0 || len == 0)
+  if (*end == 0 || len == 0) {
     return NULL;
-  else
+  } else {
     return end;
+  }
 } // find_href_end
 
 static char *
 find_href_start(const char *tag, char *base, int len)
 {
   int taglen = strlen(tag);
-  if (base == NULL)
+  if (base == NULL) {
     return NULL;
+  }
 
   char *start = base;
   char *end   = base + len;
@@ -1850,11 +1991,13 @@ extract_urls(char *buf, int buflen, char *base_url)
       char *rover = strncasestr(start, "href", end - start);
       if (rover) {
         rover += 4;
-        while (rover < end && (ParseRules::is_ws(*rover) || *rover == '=' || *rover == '\'' || *rover == '\"')) /* " */
+        while (rover < end && (ParseRules::is_ws(*rover) || *rover == '=' || *rover == '\'' || *rover == '\"')) { /* " */
           rover++;
+        }
         start = rover;
-        while (rover < end && !(ParseRules::is_ws(*rover) || *rover == '\'' || *rover == '\"'))
+        while (rover < end && !(ParseRules::is_ws(*rover) || *rover == '\'' || *rover == '\"')) {
           rover++;
+        }
         *rover = 0;
         compose_url(base_url, old_base, start);
         // fixup unqualified hostnames (e.g. http://internal/foo)
@@ -1878,8 +2021,9 @@ extract_urls(char *buf, int buflen, char *base_url)
   }
 
   end = buf;
-  if (follow)
+  if (follow) {
     compose_all_urls("href", buf, start, end, buflen, base_url);
+  }
   if (fullpage) {
     const char *tags[] = {
       "src", "image", "object", "archive", "background",
@@ -1895,35 +2039,41 @@ static void
 follow_links(int sock)
 {
   if (urls_mode) {
-    if (fd[sock].binary)
+    if (fd[sock].binary) {
       return;
+    }
     int l   = fd[sock].response_remaining;
     char *r = fd[sock].response, *p = r, *n = r;
-    if (r)
+    if (r) {
       extract_urls(r, l, fd[sock].base_url);
+    }
     if (l < MAX_BUFSIZE) {
       while (n) {
         n = (char *)memchr(p, '\n', l - (p - r));
-        if (!n)
+        if (!n) {
           n = (char *)memchr(p, '\r', l - (p - r));
-        if (n)
+        }
+        if (n) {
           p = n + 1;
+        }
       }
       int done = p - r, remaining = l - done;
       if (done) {
         memmove(r, p, remaining);
         fd[sock].response_remaining = remaining;
       }
-    } else // bail
+    } else { // bail
       fd[sock].response_length = 0;
+    }
   }
 }
 
 static int
 verify_content(int sock, char *buf, int done)
 {
-  if (urls_mode && !check_content)
+  if (urls_mode && !check_content) {
     return 1;
+  }
   int l    = fd[sock].response_length;
   char *d  = response_buffer + (l % 256) + fd[sock].nalternate;
   int left = fd[sock].length;
@@ -1933,8 +2083,9 @@ verify_content(int sock, char *buf, int done)
         char *url_end = NULL, *url_start = NULL;
         get_path_from_req(fd[sock].base_url, &url_start, &url_end);
         if (url_end - url_start < done) {
-          if (memcmp(url_start, buf, url_end - url_start))
+          if (memcmp(url_start, buf, url_end - url_start)) {
             return 0;
+          }
         }
       }
       // skip past the URL which is embedded in the document
@@ -1944,16 +2095,20 @@ verify_content(int sock, char *buf, int done)
         left -= skip;
         done -= skip;
         buf += skip;
-        if (done < 0)
+        if (done < 0) {
           done = 0;
+        }
       }
     }
-    if (!check_content)
+    if (!check_content) {
       return 1;
-    if (done > left)
+    }
+    if (done > left) {
       done = left;
-    if (memcmp(buf, d + (fd[sock].response_length - left), done))
+    }
+    if (memcmp(buf, d + (fd[sock].response_length - left), done)) {
       return 0;
+    }
   }
   return 1;
 }
@@ -1964,13 +2119,16 @@ static void
 build_zipf()
 {
   zipf_table = (double *)malloc(ZIPF_SIZE * sizeof(double));
-  for (int i      = 0; i < ZIPF_SIZE; i++)
+  for (int i = 0; i < ZIPF_SIZE; i++) {
     zipf_table[i] = 1.0 / pow(i + 2, zipf);
-  for (int i      = 1; i < ZIPF_SIZE; i++)
+  }
+  for (int i = 1; i < ZIPF_SIZE; i++) {
     zipf_table[i] = zipf_table[i - 1] + zipf_table[i];
-  double x        = zipf_table[ZIPF_SIZE - 1];
-  for (int i      = 0; i < ZIPF_SIZE; i++)
+  }
+  double x = zipf_table[ZIPF_SIZE - 1];
+  for (int i = 0; i < ZIPF_SIZE; i++) {
     zipf_table[i] = zipf_table[i] / x;
+  }
 }
 
 static int
@@ -1979,13 +2137,15 @@ get_zipf(double v)
   int l = 0, r = ZIPF_SIZE - 1, m;
   do {
     m = (r + l) / 2;
-    if (v < zipf_table[m])
+    if (v < zipf_table[m]) {
       r = m - 1;
-    else
+    } else {
       l = m + 1;
+    }
   } while (l < r);
-  if (zipf_bucket_size == 1)
+  if (zipf_bucket_size == 1) {
     return m;
+  }
   double x = zipf_table[m], y = zipf_table[m + 1];
   m += static_cast<int>((v - x) / (y - x));
   return m;
@@ -1996,8 +2156,9 @@ read_response_error(int sock)
 {
   errors++;
   fd[sock].close();
-  if (!urls_mode)
+  if (!urls_mode) {
     make_bfc_client(proxy_addr, proxy_port);
+  }
   return 0;
 }
 
@@ -2007,42 +2168,49 @@ read_response(int sock)
   int err = 0;
 
   if (fd[sock].req_pos >= 0) {
-    if (!fd[sock].req_pos)
+    if (!fd[sock].req_pos) {
       memset(fd[sock].req_header, 0, HEADER_SIZE);
+    }
     do {
       int l = HEADER_SIZE - fd[sock].req_pos - 1;
       if (l <= 0) {
-        if (verbose || verbose_errors)
+        if (verbose || verbose_errors) {
           // coverity[string_null_argument]
           printf("header too long '%s'", fd[sock].req_header);
+        }
         return read_response_error(sock);
       }
       err = read(sock, fd[sock].req_header + fd[sock].req_pos, HEADER_SIZE - fd[sock].req_pos - 1);
     } while ((err == -1) && (errno == EINTR));
     if (err <= 0) {
       if (!err) {
-        if (verbose_errors)
+        if (verbose_errors) {
           printf("read_response %d closed during header for '%s' after %d%s\n", sock, fd[sock].base_url, fd[sock].req_pos,
                  (keepalive && (fd[sock].keepalive != keepalive) && !fd[sock].req_pos) ? " -- keepalive timeout" : "");
+        }
         return read_response_error(sock);
       }
-      if (errno == EAGAIN || errno == ENOTCONN)
+      if (errno == EAGAIN || errno == ENOTCONN) {
         return 0;
+      }
       if (errno == ECONNRESET) {
         if (!fd[sock].req_pos && keepalive > 0 && fd[sock].keepalive != keepalive) {
           fd[sock].close();
-          if (!urls_mode)
+          if (!urls_mode) {
             make_bfc_client(proxy_addr, proxy_port);
+          }
           return 0;
         }
-        if (verbose || verbose_errors)
+        if (verbose || verbose_errors) {
           perror("read");
+        }
         goto Ldone;
       }
       panic_perror("read");
     }
-    if (verbose)
+    if (verbose) {
       printf("read %d header %d [%s]\n", sock, err, fd[sock].req_header);
+    }
     b1_ops++;
 
     strcpy(fd[sock].response_header, fd[sock].req_header);
@@ -2058,8 +2226,9 @@ read_response(int sock)
     char *cl        = NULL;
     int cli         = 0;
     while ((p = strchr(p, '\n'))) {
-      if (verbose)
+      if (verbose) {
         printf("read header end? [%s]\n", p);
+      }
       if (p[1] == '\n' || (p[1] == '\r' && p[2] == '\n')) {
         int off = 1 + (p[1] == '\r' ? 2 : 1);
         p += off;
@@ -2076,14 +2245,16 @@ read_response(int sock)
               expected_length        = (fd[sock].response_length * 2) / 3;
             }
           }
-          if (fd[sock].response_length && verbose_errors && expected_length != cli && !nocheck_length)
+          if (fd[sock].response_length && verbose_errors && expected_length != cli && !nocheck_length) {
             fprintf(stderr, "bad Content-Length expected %d got %d orig %d\n", expected_length, cli, fd[sock].response_length);
+          }
           fd[sock].response_length = fd[sock].length = cli;
         }
         if (fd[sock].req_header[9] == '2') {
           if (!verify_content(sock, p, lbody)) {
-            if (verbose || verbose_errors)
+            if (verbose || verbose_errors) {
               printf("content verification error '%s'\n", fd[sock].base_url);
+            }
             return read_response_error(sock);
           }
         }
@@ -2099,30 +2270,34 @@ read_response(int sock)
           fd[sock].keepalive     = 0;
           fd[sock].drop_after_CL = 1;
         }
-        if (verbose)
+        if (verbose) {
           printf("read %d header done\n", sock);
+        }
         break;
       }
       p++;
     }
-    if (!p)
+    if (!p) {
       return 0;
+    }
     int hlen = p - fd[sock].req_header;
     if (show_headers) {
       printf("Response From Proxy: {\n");
-      for (char *c = fd[sock].req_header; c < p; c++)
+      for (char *c = fd[sock].req_header; c < p; c++) {
         putc(*c, stdout);
+      }
       printf("}\n");
     }
     if (obey_redirects && urls_mode && fd[sock].req_header[9] == '3' && fd[sock].req_header[10] == '0' &&
         (fd[sock].req_header[11] == '1' || fd[sock].req_header[11] == '2')) {
       char *redirect = strstr(fd[sock].req_header, "http://");
       char *e        = redirect ? (char *)memchr(redirect, '\n', hlen) : 0;
-      if (!redirect || !e)
+      if (!redirect || !e) {
         fprintf(stderr, "bad redirect '%s'", fd[sock].req_header);
-      else {
-        if (e[-1] == '\r')
+      } else {
+        if (e[-1] == '\r') {
           e--;
+        }
         *e = 0;
         make_url_client(redirect);
       }
@@ -2132,14 +2307,15 @@ read_response(int sock)
     if (fd[sock].req_header[9] != '2') {
       if (verbose_errors) {
         char *e = (char *)memchr(fd[sock].req_header, '\r', hlen);
-        if (e)
+        if (e) {
           *e = 0;
-        else {
+        } else {
           char *e = (char *)memchr(fd[sock].req_header, '\n', hlen);
-          if (e)
+          if (e) {
             *e = 0;
-          else
+          } else {
             *p = 0;
+          }
         }
         printf("error response %d after %dms: '%s':'%s'\n", sock, (int)elapsed_from_start(sock), fd[sock].base_url,
                fd[sock].req_header);
@@ -2151,72 +2327,87 @@ read_response(int sock)
     char *ka   = check_keepalive(r, length);
     if (urls_mode) {
       fd[sock].response_remaining = total_read - length;
-      if (fd[sock].response_remaining)
+      if (fd[sock].response_remaining) {
         memcpy(fd[sock].response, p, fd[sock].response_remaining);
+      }
       if (check_content && !cl) {
-        if (verbose || verbose_errors)
+        if (verbose || verbose_errors) {
           printf("missiing Content-Length '%s'\n", fd[sock].base_url);
+        }
         return read_response_error(sock);
       }
-    } else
+    } else {
       fd[sock].response = 0;
-    if (!cl || !ka)
+    }
+    if (!cl || !ka) {
       fd[sock].keepalive = -1;
-    if (!cl)
+    }
+    if (!cl) {
       fd[sock].length = INT_MAX;
+    }
   }
 
-  if (fd[sock].length <= 0 && (fd[sock].keepalive > 0 || fd[sock].drop_after_CL))
+  if (fd[sock].length <= 0 && (fd[sock].keepalive > 0 || fd[sock].drop_after_CL)) {
     goto Ldone;
+  }
 
   {
     char *r = NULL;
     char buf[MAX_BUFSIZE];
     int toread = cbuffersize;
     if (urls_mode) {
-      if (fd[sock].response_remaining + cbuffersize < MAX_BUFSIZE)
+      if (fd[sock].response_remaining + cbuffersize < MAX_BUFSIZE) {
         r = fd[sock].response + fd[sock].response_remaining;
-      else {
+      } else {
         toread = MAX_BUFSIZE - fd[sock].response_remaining;
         if (!toread) {
-          if (verbose_errors || verbose)
+          if (verbose_errors || verbose) {
             fprintf(stderr, "line exceeds buffer, unable to follow links\n");
+          }
           toread                      = cbuffersize;
           r                           = fd[sock].response;
           fd[sock].response_remaining = 0;
-        } else
+        } else {
           r = fd[sock].response + fd[sock].response_remaining;
+        }
       }
-    } else
+    } else {
       r = buf;
-    if (fast(sock, client_speed, fd[sock].bytes))
+    }
+    if (fast(sock, client_speed, fd[sock].bytes)) {
       return 0;
+    }
     if (fd[sock].bytes > abort_retry_bytes && (((now - fd[sock].start + 1) / HRTIME_SECOND) > abort_retry_secs) &&
         !faster_than(sock, abort_retry_speed, fd[sock].bytes)) {
       fd[sock].client_abort = 1;
       fd[sock].keepalive    = 0;
-      if (!urls_mode && !client_rate)
+      if (!urls_mode && !client_rate) {
         make_bfc_client(proxy_addr, proxy_port);
+      }
       goto Ldone;
     }
     do {
       err = read(sock, r, toread);
     } while ((err == -1) && (errno == EINTR));
     if (err < 0) {
-      if (errno == EAGAIN || errno == ENOTCONN)
+      if (errno == EAGAIN || errno == ENOTCONN) {
         return 0;
+      }
       if (errno == ECONNRESET) {
-        if (verbose || verbose_errors)
+        if (verbose || verbose_errors) {
           perror("read");
+        }
         goto Ldone;
       }
       panic_perror("read");
     }
-    if (!err)
+    if (!err) {
       goto Ldone;
+    }
     if (!verify_content(sock, buf, err)) {
-      if (verbose || verbose_errors)
+      if (verbose || verbose_errors) {
         printf("content verification error '%s'\n", fd[sock].base_url);
+      }
       return read_response_error(sock);
     }
     total_proxy_response_body_bytes += err;
@@ -2225,27 +2416,32 @@ read_response(int sock)
     fd[sock].response_remaining += err;
     fd[sock].bytes += err;
     follow_links(sock);
-    if (fd[sock].length != INT_MAX)
+    if (fd[sock].length != INT_MAX) {
       fd[sock].length -= err;
+    }
     fd[sock].active = ink_get_hrtime_internal();
-    if (verbose)
+    if (verbose) {
       printf("read %d got %d togo %d %d %d\n", sock, err, fd[sock].length, fd[sock].keepalive, fd[sock].drop_after_CL);
+    }
   }
 
-  if (fd[sock].length <= 0 && (fd[sock].keepalive > 0 || fd[sock].drop_after_CL))
+  if (fd[sock].length <= 0 && (fd[sock].keepalive > 0 || fd[sock].drop_after_CL)) {
     goto Ldone;
+  }
 
   return 0;
 
 Ldone:
   if (!fd[sock].client_abort && !(server_abort_rate > 0) && fd[sock].length && fd[sock].length != INT_MAX) {
-    if (verbose || verbose_errors)
+    if (verbose || verbose_errors) {
       printf("bad length %d wanted %d after %d ms: '%s'\n", fd[sock].response_length - fd[sock].length, fd[sock].response_length,
              (int)((ink_get_hrtime_internal() - fd[sock].active) / HRTIME_MSECOND), fd[sock].base_url);
+    }
     return read_response_error(sock);
   }
-  if (verbose)
+  if (verbose) {
     printf("read %d done\n", sock);
+  }
   new_ops++;
   double thislatency = elapsed_from_start(sock);
   latency += (int)thislatency;
@@ -2258,10 +2454,12 @@ Ldone:
       undefer_url();
       return 0;
     }
-  } else
+  } else {
     fd[sock].close();
-  if (!urls_mode && !client_rate)
+  }
+  if (!urls_mode && !client_rate) {
     make_bfc_client(proxy_addr, proxy_port);
+  }
   return 0;
 }
 
@@ -2275,17 +2473,20 @@ write_request(int sock)
   } while ((err == -1) && (errno == EINTR));
   if (err <= 0) {
     if (!err) {
-      if (verbose_errors)
+      if (verbose_errors) {
         printf("write %d closed early\n", sock);
+      }
       goto Lerror;
     }
-    if (errno == EAGAIN || errno == ENOTCONN)
+    if (errno == EAGAIN || errno == ENOTCONN) {
       return 0;
+    }
     perror("write");
     goto Lerror;
   }
-  if (verbose)
+  if (verbose) {
     printf("write %d %d\n", sock, err);
+  }
 
   new_tbytes += err;
   total_client_request_bytes += err;
@@ -2293,8 +2494,9 @@ write_request(int sock)
   fd[sock].active = ink_get_hrtime_internal();
 
   if (fd[sock].req_pos >= fd[sock].length) {
-    if (verbose)
+    if (verbose) {
       printf("write complete %d %d\n", sock, fd[sock].length);
+    }
     fd[sock].req_pos = 0;
     fd[sock].length  = fd[sock].response_length;
     poll_set(sock, read_response);
@@ -2303,8 +2505,9 @@ write_request(int sock)
 Lerror:
   errors++;
 #ifndef RETRY_CLIENT_WRITE_ERRORS
-  if (!--nclients)
+  if (!--nclients) {
     panic("no more clients\n");
+  }
   return 1;
 #else
   if (!urls_mode)
@@ -2325,24 +2528,28 @@ write_ftp_response(int sock)
 
   if (err <= 0) {
     if (!err) {
-      if (verbose_errors)
+      if (verbose_errors) {
         printf("write %d closed early\n", sock);
+      }
       goto Lerror;
     }
-    if (errno == EAGAIN || errno == ENOTCONN)
+    if (errno == EAGAIN || errno == ENOTCONN) {
       return 0;
+    }
     perror("write");
     goto Lerror;
   }
-  if (verbose)
+  if (verbose) {
     printf("write %d %d\n", sock, err);
+  }
 
   new_tbytes += err;
   fd[sock].req_pos += err;
 
   if (fd[sock].req_pos >= fd[sock].length) {
-    if (verbose)
+    if (verbose) {
       printf("write complete %d %d\n", sock, fd[sock].length);
+    }
     fd[sock].req_pos = 0;
     fd[sock].length  = fd[sock].response_length;
     poll_set(sock, read_ftp_request);
@@ -2359,11 +2566,13 @@ make_client(unsigned int addr, int port)
   struct linger lngr;
 
   int sock = socket(PF_INET, SOCK_STREAM, 0);
-  if (sock < 0)
+  if (sock < 0) {
     panic_perror("socket");
+  }
 
-  if (fcntl(sock, F_SETFL, O_NONBLOCK) < 0)
+  if (fcntl(sock, F_SETFL, O_NONBLOCK) < 0) {
     panic_perror("fcntl");
+  }
 
 /* tweak buffer size so that remote end can't close connection too fast */
 
@@ -2377,8 +2586,9 @@ make_client(unsigned int addr, int port)
     panic_perror("setsockopt");
 #endif
   int enable = 1;
-  if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (const char *)&enable, sizeof(enable)) < 0)
+  if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (const char *)&enable, sizeof(enable)) < 0) {
     panic_perror("setsockopt");
+  }
 
   /* Tell the socket not to linger on exit */
   lngr.l_onoff  = 1;
@@ -2397,17 +2607,21 @@ make_client(unsigned int addr, int port)
   name.sin_port        = htons(port);
   name.sin_addr.s_addr = addr;
 
-  if (verbose)
+  if (verbose) {
     printf("connecting to %u.%u.%u.%u:%d\n", ((unsigned char *)&addr)[0], ((unsigned char *)&addr)[1], ((unsigned char *)&addr)[2],
            ((unsigned char *)&addr)[3], port);
+  }
 
   while (connect(sock, (struct sockaddr *)&name, sizeof(name)) < 0) {
-    if (errno == EINTR)
+    if (errno == EINTR) {
       continue;
-    if (errno == EINPROGRESS)
+    }
+    if (errno == EINPROGRESS) {
       break;
-    if (verbose_errors)
+    }
+    if (verbose_errors) {
       fprintf(stderr, "connect failed errno = %d\n", errno);
+    }
     errors++;
     close(sock);
     return -1;
@@ -2425,10 +2639,12 @@ static void
 make_bfc_client(unsigned int addr, int port)
 {
   int sock = -1;
-  if (bandwidth_test && bandwidth_test_to_go-- <= 0)
+  if (bandwidth_test && bandwidth_test_to_go-- <= 0) {
     return;
-  if (keepalive)
+  }
+  if (keepalive) {
     sock = get_ka(addr);
+  }
   if (sock < 0) {
     sock               = make_client(addr, port);
     fd[sock].keepalive = keepalive;
@@ -2437,8 +2653,9 @@ make_bfc_client(unsigned int addr, int port)
     current_clients++;
     fd[sock].keepalive--;
   }
-  if (sock < 0)
+  if (sock < 0) {
     panic("unable to open client connection\n");
+  }
   // coverity[dont_call]
   double h = drand48();
   // coverity[dont_call]
@@ -2447,8 +2664,9 @@ make_bfc_client(unsigned int addr, int port)
     if (h < hitrate) {
       dr                       = 1.0 + (floor(dr * hotset) / hotset);
       fd[sock].response_length = gen_bfc_dist(dr - 1.0);
-    } else
+    } else {
       fd[sock].response_length = gen_bfc_dist(dr);
+    }
   } else {
     unsigned long long int doc = get_zipf(dr);
     // Some large randomish number.
@@ -2459,8 +2677,9 @@ make_bfc_client(unsigned int addr, int port)
     fd[sock].response_length = gen_bfc_dist(y);
     dr                       = doc;
   }
-  if (verbose)
+  if (verbose) {
     printf("gen_bfc_dist %d\n", fd[sock].response_length);
+  }
   char eheaders[16384];
   *eheaders    = 0;
   int nheaders = extra_headers;
@@ -2470,10 +2689,12 @@ make_bfc_client(unsigned int addr, int port)
       eh += sprintf(eh, "User-Agent: Mozilla/4.04 [en] (X11; I; Linux 2.0.31 i586)\r\n");
       nheaders--;
     }
-    if (nheaders > 0)
+    if (nheaders > 0) {
       eh += sprintf(eh, "Accept: image/gif, image/x-xbitmap, image/jpeg, image/pjpeg, image/png, */*\r\n");
-    while (--nheaders > 0)
+    }
+    while (--nheaders > 0) {
       eh += sprintf(eh, "Extra-Header%d: a lot of junk for header %d\r\n", nheaders, nheaders);
+    }
   }
   char cookie[256];
   *cookie = 0;
@@ -2547,8 +2768,9 @@ make_bfc_client(unsigned int addr, int port)
             // coverity[dont_call]
             reload_rate > drand48() ? "Pragma: no-cache\r\n" : "", eheaders, cookie);
   }
-  if (verbose)
+  if (verbose) {
     printf("request %d [%s]\n", sock, fd[sock].req_header);
+  }
   fd[sock].length = strlen(fd[sock].req_header);
   {
     char *s   = fd[sock].req_header;
@@ -2556,11 +2778,13 @@ make_bfc_client(unsigned int addr, int port)
     char *url = fd[sock].base_url;
     memcpy(url, s, e - s);
     url[e - s] = 0;
-    if (show_before)
+    if (show_before) {
       printf("%s\n", url);
+    }
   }
-  if (show_headers)
+  if (show_headers) {
     printf("Request to Proxy: {\n%s}\n", fd[sock].req_header);
+  }
 }
 
 #define RUNNING(_n)                                                               \
@@ -2577,8 +2801,9 @@ interval_report()
 {
   static int here = 0;
   now             = ink_get_hrtime_internal();
-  if (!(here++ % 20))
+  if (!(here++ % 20)) {
     printf(" con  new     ops   1B  lat      bytes/per     svrs  new  ops      total   time  err\n");
+  }
   RUNNING(clients);
   RUNNING_AVG(running_latency, latency, lat_ops);
   lat_ops = 0;
@@ -2705,16 +2930,18 @@ struct UrlHashTable {
   {
     BEGIN_HASH_LOOP
     {
-      if (ENTRY_TAG(e) == tag)
+      if (ENTRY_TAG(e) == tag) {
         return 1;
+      }
     }
     END_HASH_LOOP;
 
     if (ENTRY_TAG((last))) {
       BEGIN_OVERFLOW_HASH_LOOP
       {
-        if (ENTRY_TAG(e) == tag)
+        if (ENTRY_TAG(e) == tag) {
           return 1;
+        }
       }
       END_HASH_LOOP;
     }
@@ -2731,8 +2958,9 @@ UrlHashTable::UrlHashTable() : numbytes(0), bytes(NULL), fd(-1)
 {
   off_t len = 0;
 
-  if (!url_hash_entries)
+  if (!url_hash_entries) {
     return;
+  }
 
   if (*url_hash_filename) {
     if ((fd = open(url_hash_filename, O_RDWR | O_CREAT, 0644)) == -1) {
@@ -2748,14 +2976,16 @@ UrlHashTable::UrlHashTable() : numbytes(0), bytes(NULL), fd(-1)
     numbytes         = URL_HASH_BYTES;
 
     // ensure it is either a new file or the correct size
-    if (len != 0 && len != numbytes)
+    if (len != 0 && len != numbytes) {
       panic("specified size != file size\n");
+    }
 
   } else {
     // otherwise make sure the file is non-zero and then use its
     // size as the size
-    if (!len)
+    if (!len) {
       panic("zero size URL Hash Table\n");
+    }
     if (len != URL_HASH_BYTES) {
       fprintf(stderr, "FATAL: hash file length (%jd) != URL_HASH_BYTES (%jd)\n", (intmax_t)len, (intmax_t)URL_HASH_BYTES);
       exit(1);
@@ -2769,8 +2999,9 @@ UrlHashTable::UrlHashTable() : numbytes(0), bytes(NULL), fd(-1)
     }
 
     bytes = (unsigned char *)mmap(NULL, numbytes, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-    if (bytes == (unsigned char *)MAP_FAILED || !bytes)
+    if (bytes == (unsigned char *)MAP_FAILED || !bytes) {
       panic("unable to map URL Hash file\n");
+    }
   } else {
     bytes = (unsigned char *)malloc(numbytes);
     ink_assert(bytes);
@@ -2791,28 +3022,32 @@ UrlHashTable::~UrlHashTable()
 static int
 seen_it(char *url)
 {
-  if (!url_hash_entries)
+  if (!url_hash_entries) {
     return 0;
+  }
   union {
     unsigned char md5[16];
     uint64_t i[2];
   } u;
   int l      = 0;
   char *para = strrchr(url, '#');
-  if (para)
+  if (para) {
     l = para - url;
-  else
+  } else {
     l = strlen(url);
+  }
   ink_code_md5((unsigned char *)url, l, u.md5);
   uint64_t x = u.i[0] + u.i[1];
   if (uniq_urls->is_set(x)) {
-    if (verbose)
+    if (verbose) {
       printf("YES: seen it '%s'\n", url);
+    }
     return 1;
   }
   uniq_urls->set(x);
-  if (verbose)
+  if (verbose) {
     printf("NO: marked it '%s'\n", url);
+  }
   return 0;
 }
 
@@ -2828,20 +3063,25 @@ make_url_client(const char *url, const char *base_url, bool seen, bool unthrottl
   if (base_url) {
     ink_web_canonicalize_url(base_url, url, curl, 512);
     // hack for our own web server!
-    if (curl[strlen(curl) - 1] == 13)
+    if (curl[strlen(curl) - 1] == 13) {
       curl[strlen(curl) - 1] = 0;
-    if (curl[strlen(curl) - 1] == 12)
+    }
+    if (curl[strlen(curl) - 1] == 12) {
       curl[strlen(curl) - 1] = 0;
-  } else
+    }
+  } else {
     strcpy(curl, url);
-  if (!seen && seen_it(curl))
+  }
+  if (!seen && seen_it(curl)) {
     return -1;
+  }
   ink_web_decompose_url(curl, sche, host, port, path, frag, quer, para, &xsche, &xhost, &xport, &xpath, &xfrag, &xquer, &xpar, &rel,
                         &slash);
   if (follow_same) {
     if (!xhost || strcasecmp(host, current_host)) {
-      if (verbose)
+      if (verbose) {
         printf("skipping %s\n", curl);
+      }
       return -1;
     }
   }
@@ -2853,23 +3093,27 @@ make_url_client(const char *url, const char *base_url, bool seen, bool unthrottl
     iport = proxy_port;
     ip    = proxy_addr;
   } else {
-    if (xport)
+    if (xport) {
       iport = atoi(port);
+    }
     if (!xhost) {
-      if (verbose)
+      if (verbose) {
         fprintf(stderr, "bad url '%s'\n", curl);
+      }
       return -1;
     }
     ip = get_addr(host);
     if ((int)ip == -1) {
-      if (verbose || verbose_errors)
+      if (verbose || verbose_errors) {
         fprintf(stderr, "bad host '%s'\n", host);
+      }
       return -1;
     }
   }
   int sock = -1;
-  if (keepalive)
+  if (keepalive) {
     sock = get_ka(ip);
+  }
   if (sock < 0) {
     sock               = make_client(ip, iport);
     fd[sock].keepalive = keepalive;
@@ -2878,8 +3122,9 @@ make_url_client(const char *url, const char *base_url, bool seen, bool unthrottl
     current_clients++;
     fd[sock].keepalive--;
   }
-  if (sock < 0)
+  if (sock < 0) {
     panic("cannot make client\n");
+  }
   char eheaders[16384];
   *eheaders    = 0;
   int nheaders = extra_headers;
@@ -2890,12 +3135,14 @@ make_url_client(const char *url, const char *base_url, bool seen, bool unthrottl
       eh += sprintf(eh, "User-Agent: Mozilla/4.04 [en] (X11; I; Linux 2.0.31 i586)\r\n");
       nheaders--;
     }
-    if (nheaders > 0)
+    if (nheaders > 0) {
       eh += sprintf(eh, "Accept: image/gif, image/x-xbitmap, image/jpeg, image/pjpeg, image/png, */*\r\n");
-    while (--nheaders > 0)
+    }
+    while (--nheaders > 0) {
       eh += sprintf(eh, "Extra-Header%d: a lot of junk for header %d\r\n", nheaders, nheaders);
+    }
   }
-  if (proxy_port)
+  if (proxy_port) {
     sprintf(fd[sock].req_header, "GET %s HTTP/1.0\r\n"
                                  "%s"
                                  "%s"
@@ -2906,7 +3153,7 @@ make_url_client(const char *url, const char *base_url, bool seen, bool unthrottl
             // coverity[dont_call]
             reload_rate > drand48() ? "Pragma: no-cache\r\n" : "", fd[sock].keepalive ? "Proxy-Connection: Keep-Alive\r\n" : "",
             eheaders);
-  else
+  } else {
     sprintf(fd[sock].req_header, "GET /%s%s%s%s%s HTTP/1.0\r\n"
                                  "Host: %s\r\n"
                                  "%s"
@@ -2918,15 +3165,20 @@ make_url_client(const char *url, const char *base_url, bool seen, bool unthrottl
             // coverity[dont_call]
             reload_rate > drand48() ? "Pragma: no-cache\r\n" : "", fd[sock].keepalive ? "Connection: Keep-Alive\r\n" : "",
             eheaders);
+  }
 
-  if (verbose)
+  if (verbose) {
     printf("curl = '%s'\n", curl);
-  if (show_before)
+  }
+  if (show_before) {
     printf("%s\n", curl);
-  if (urlsdump_fp)
+  }
+  if (urlsdump_fp) {
     fprintf(urlsdump_fp, "%s\n", curl);
-  if (show_headers)
+  }
+  if (show_headers) {
     printf("Request to Proxy: {\n%s}\n", fd[sock].req_header);
+  }
 
   {
     const char *ext = strrchr(path, '.');
@@ -2939,8 +3191,9 @@ make_url_client(const char *url, const char *base_url, bool seen, bool unthrottl
 
   fd[sock].response_length = 0;
   fd[sock].length          = strlen(fd[sock].req_header);
-  if (!fd[sock].response)
+  if (!fd[sock].response) {
     fd[sock].response = (char *)malloc(MAX_BUFSIZE);
+  }
   strcpy(fd[sock].base_url, curl);
   return sock;
 }
@@ -2950,11 +3203,13 @@ get_defered_urls(FILE *fp)
 {
   char url[512];
   while (fgets(url, 512, fp)) {
-    if (n_defered_urls > MAX_DEFERED_URLS - 2)
+    if (n_defered_urls > MAX_DEFERED_URLS - 2) {
       return NULL;
+    }
     char *e = (char *)memchr(url, '\n', 512);
-    if (e)
+    if (e) {
       *e = 0;
+    }
     make_url_client(url);
   }
   return fp;
@@ -2974,17 +3229,20 @@ main(int argc __attribute__((unused)), const char *argv[])
   memset(fd, 0, MAXFDS * sizeof(FD));
   process_args(&appVersionInfo, argument_descriptions, n_argument_descriptions, argv);
 
-  if (!drand_seed)
+  if (!drand_seed) {
     // coverity[dont_call]
     srand48((long)time(NULL));
-  else
+  } else {
     // coverity[dont_call]
     srand48((long)drand_seed);
-  if (zipf != 0.0)
+  }
+  if (zipf != 0.0) {
     build_zipf();
+  }
   int max_fds = max_limit_fd();
-  if (verbose)
+  if (verbose) {
     printf("maximum of %d connections\n", max_fds);
+  }
   signal(SIGPIPE, SIG_IGN);
   start_time = now = ink_get_hrtime_internal();
 
@@ -3011,8 +3269,9 @@ main(int argc __attribute__((unused)), const char *argv[])
       build_response();
       open_server(compd_port, accept_compd);
     } else {
-      if (!server_port)
+      if (!server_port) {
         server_port = proxy_port + 1000;
+      }
       build_response();
       if (!only_clients) {
         for (int retry = 0; retry < 20; retry++) {
@@ -3029,14 +3288,16 @@ main(int argc __attribute__((unused)), const char *argv[])
       bandwidth_test_to_go = bandwidth_test;
       if (!only_server) {
         if (proxy_port) {
-          for (int i = 0; i < nclients; i++)
+          for (int i = 0; i < nclients; i++) {
             make_bfc_client(proxy_addr, proxy_port);
+          }
         }
       }
     }
   } else {
-    if (check_content)
+    if (check_content) {
       build_response();
+    }
     follow       = follow_arg;
     follow_same  = follow_same_arg;
     uniq_urls    = new UrlHashTable;
@@ -3044,17 +3305,20 @@ main(int argc __attribute__((unused)), const char *argv[])
     average_over = 1;
     if (*urlsdump_file) {
       urlsdump_fp = fopen(urlsdump_file, "w");
-      if (!urlsdump_fp)
+      if (!urlsdump_fp) {
         panic_perror("fopen urlsdump file");
+      }
     }
     if (*urls_file) {
       FILE *fp = fopen(urls_file, "r");
-      if (!fp)
+      if (!fp) {
         panic_perror("fopen urls file");
-      if (get_defered_urls(fp))
+      }
+      if (get_defered_urls(fp)) {
         fclose(fp);
-      else
+      } else {
         urls_fp = fp;
+      }
     }
     for (unsigned i = 0; i < n_file_arguments; i++) {
       char sche[8], host[512], port[10], path[512], frag[512], quer[512], para[512];
@@ -3074,8 +3338,9 @@ main(int argc __attribute__((unused)), const char *argv[])
   int tclient = now / HRTIME_SECOND;
   int start   = now / HRTIME_SECOND;
   while (1) {
-    if (poll_loop())
+    if (poll_loop()) {
       break;
+    }
     int t2 = now / HRTIME_SECOND;
     if (urls_fp && n_defered_urls < MAX_DEFERED_URLS - DEFERED_URLS_BLOCK - 2) {
       if (get_defered_urls(urls_fp)) {
@@ -3088,18 +3353,23 @@ main(int argc __attribute__((unused)), const char *argv[])
       interval_report();
     }
     if (t2 != tclient) {
-      for (int i = 0; i < client_rate * (t2 - tclient); i++)
-        if (!urls_mode)
+      for (int i = 0; i < client_rate * (t2 - tclient); i++) {
+        if (!urls_mode) {
           make_bfc_client(proxy_addr, proxy_port);
-        else
+        } else {
           undefer_url(true);
+        }
+      }
       tclient = t2;
     }
-    if (test_time)
-      if (t2 - start > test_time)
+    if (test_time) {
+      if (t2 - start > test_time) {
         done();
-    if (is_done())
+      }
+    }
+    if (is_done()) {
       done();
+    }
   }
 
   return 0;
@@ -3220,8 +3490,9 @@ ink_web_decompose_url(const char *src_url, char *sche, char *host, char *port, c
       ptr++;
     }
   }
-  if (sche_exists == 0)
+  if (sche_exists == 0) {
     ptr = temp2;
+  }
 
   /* find start of host */
   fail  = false;
@@ -3253,8 +3524,9 @@ ink_web_decompose_url(const char *src_url, char *sche, char *host, char *port, c
         ptr++;
       }
     }
-    if (host2 == NULL)
+    if (host2 == NULL) {
       host2 = end;
+    }
 
     if (host_exists == 1) {
       temp = host2 - 1;
@@ -3278,8 +3550,9 @@ ink_web_decompose_url(const char *src_url, char *sche, char *host, char *port, c
       }
     }
   }
-  if (host_exists == 0)
+  if (host_exists == 0) {
     ptr = temp2;
+  }
 
   temp2 = ptr;
   /* strip query "?" off the end */
@@ -3326,18 +3599,20 @@ ink_web_decompose_url(const char *src_url, char *sche, char *host, char *port, c
     path_exists = 0;
   }
 
-  if (sche_exists != 1)
+  if (sche_exists != 1) {
     *real_relative_url = 1;
-  else
+  } else {
     *real_relative_url = 0;
+  }
 
   /* extract strings for scheme, host, port, path, etc */
 
   if (sche != NULL) {
     if (sche_exists) {
       num = sche2 - sche1;
-      if (num > MAX_URL_LEN - 1)
+      if (num > MAX_URL_LEN - 1) {
         num = MAX_URL_LEN - 1;
+      }
       strncpy(sche, sche1, num + 1);
       *(sche + num) = '\0';
 
@@ -3355,8 +3630,9 @@ ink_web_decompose_url(const char *src_url, char *sche, char *host, char *port, c
   if (host != NULL) {
     if (host_exists) {
       num = host2 - host1;
-      if (num > MAX_URL_LEN - 1)
+      if (num > MAX_URL_LEN - 1) {
         num = MAX_URL_LEN - 1;
+      }
       strncpy(host, host1, num + 1);
       *(host + num) = '\0';
 
@@ -3374,8 +3650,9 @@ ink_web_decompose_url(const char *src_url, char *sche, char *host, char *port, c
   if (port != NULL) {
     if (port_exists) {
       num = port2 - port1;
-      if (num > MAX_URL_LEN - 1)
+      if (num > MAX_URL_LEN - 1) {
         num = MAX_URL_LEN - 1;
+      }
       strncpy(port, port1, num + 1);
       *(port + num) = '\0';
     } else {
@@ -3386,8 +3663,9 @@ ink_web_decompose_url(const char *src_url, char *sche, char *host, char *port, c
   if (path != NULL) {
     if (path_exists) {
       num = path2 - path1;
-      if (num > MAX_URL_LEN - 1)
+      if (num > MAX_URL_LEN - 1) {
         num = MAX_URL_LEN - 1;
+      }
       strncpy(path, path1, num + 1);
       *(path + num) = '\0';
     } else {
@@ -3398,8 +3676,9 @@ ink_web_decompose_url(const char *src_url, char *sche, char *host, char *port, c
   if (frag != NULL) {
     if (frag_exists) {
       num = frag2 - frag1;
-      if (num > MAX_URL_LEN - 1)
+      if (num > MAX_URL_LEN - 1) {
         num = MAX_URL_LEN - 1;
+      }
       strncpy(frag, frag1, num + 1);
       *(frag + num) = '\0';
     } else {
@@ -3410,8 +3689,9 @@ ink_web_decompose_url(const char *src_url, char *sche, char *host, char *port, c
   if (quer != NULL) {
     if (quer_exists) {
       num = quer2 - quer1;
-      if (num > MAX_URL_LEN - 1)
+      if (num > MAX_URL_LEN - 1) {
         num = MAX_URL_LEN - 1;
+      }
       strncpy(quer, quer1, num + 1);
       *(quer + num) = '\0';
     } else {
@@ -3422,8 +3702,9 @@ ink_web_decompose_url(const char *src_url, char *sche, char *host, char *port, c
   if (para != NULL) {
     if (para_exists) {
       num = para2 - para1;
-      if (num > MAX_URL_LEN - 1)
+      if (num > MAX_URL_LEN - 1) {
         num = MAX_URL_LEN - 1;
+      }
       strncpy(para, para1, num + 1);
       *(para + num) = '\0';
     } else {
@@ -3660,8 +3941,9 @@ ink_web_canonicalize_url(const char *base_url, const char *emb_url, char *dest_u
 
   if (use_base_path) {
     if (base.path_exists) {
-      if (base.leading_slash)
+      if (base.leading_slash) {
         append_string(dest_url, "/", &doff, MAX_URL_LEN);
+      }
 
       ink_web_unescapify_string(temp, base.path, MAX_URL_LEN);
       ink_web_escapify_string(base.path, temp, max_dest_url_len);
@@ -3670,8 +3952,9 @@ ink_web_canonicalize_url(const char *base_url, const char *emb_url, char *dest_u
     }
   } else {
     if (emb.path_exists) {
-      if (emb.leading_slash)
+      if (emb.leading_slash) {
         append_string(dest_url, "/", &doff, MAX_URL_LEN);
+      }
       ink_web_unescapify_string(temp, emb.path, MAX_URL_LEN);
       ink_web_escapify_string(emb.path, temp, max_dest_url_len);
       append_string(dest_url, emb.path, &doff, MAX_URL_LEN);
@@ -3721,8 +4004,9 @@ ink_web_canonicalize_url(const char *base_url, const char *emb_url, char *dest_u
     }
   }
 
-  if (host_last)
+  if (host_last) {
     append_string(dest_url, "/", &doff, MAX_URL_LEN);
+  }
 }
 
 /*---------------------------------------------------------------------------*
@@ -3816,8 +4100,9 @@ ink_web_remove_dots(char *src, char *dest, int *leadingslash, int max_dest_len)
   end    = src + strlen(src);
   scount = 0;
   while (ptr < end) {
-    if (*ptr++ == '/')
+    if (*ptr++ == '/') {
       scount++;
+    }
   }
   scount++; /* adding one to this makes it a lower bound for any case */
 
@@ -3848,9 +4133,10 @@ ink_web_remove_dots(char *src, char *dest, int *leadingslash, int max_dest_len)
   while (ptr < end) {
     if (*ptr == '/') {
       /* include leading '/' in first segment */
-      if (ptr == src)
+      if (ptr == src) {
         *leadingslash = 1;
-      segstart        = 1;
+      }
+      segstart = 1;
     } else if (segstart == 1) {
       seg[scount++] = ptr;
       segstart      = 0;
@@ -3989,10 +4275,12 @@ ink_web_unescapify_string(char *dest_in, char *src_in, int max_dest_len)
           /* check if hex digits lowercase */
           dig1 = (int)(c1 - hexdigits);
           dig2 = (int)(c2 - hexdigits);
-          if (dig1 > 15)
+          if (dig1 > 15) {
             dig1 -= 6;
-          if (dig2 > 15)
+          }
+          if (dig2 > 15) {
             dig2 -= 6;
+          }
           /* this is the ascii char */
           num = 16 * dig1 + dig2;
 
@@ -4042,10 +4330,11 @@ ink_web_unescapify_string(char *dest_in, char *src_in, int max_dest_len)
     src++;
   }
   /* terminate string */
-  if (dcount < max_dest_len)
+  if (dcount < max_dest_len) {
     *dest = 0;
-  else
+  } else {
     *(dest_in + max_dest_len) = 0;
+  }
 
   return (quit);
 }
@@ -4108,10 +4397,11 @@ ink_web_escapify_string(char *dest_in, char *src_in, int max_dest_len)
     src++;
   }
   /* terminate string */
-  if (dcount < max_dest_len)
+  if (dcount < max_dest_len) {
     *dest = 0;
-  else
+  } else {
     *(dest_in + max_dest_len - 1) = 0;
+  }
 
   return (quit);
 }


### PR DESCRIPTION
Require bodies of if statements and loops (for, range-for, do-while,
and while) to be inside braces.

This is a automated change made with clang-tidy and clang-format.
Header files are not included because they are not emitted into the
compilation database.