### PR TITLE
TS-4520 header_rewrite: Add a new ID condition, with 3 types

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -261,6 +261,26 @@ separated string of the values from every occurrence of the header. Refer to
 If you wish to use a client request header, regardless of hook context, you may
 consider using the `CLIENT-HEADER`_ condition instead.
 
+ID
+~~
+::
+   cond %{ID:REQUEST} >100
+
+This condition provides access to three identifier values that ATS uses
+internally for things like logging and debugging. Since these are IDs, they
+are mostly useful as a value (operand) to other operators. The three types of
+IDs are
+
+    %{ID:REQUEST}    A unique, sequence number for the transaction
+    %{ID:PROCESS}    A UUID string, generated every time ATS restarts
+    %{ID:UNIQUE}     The combination of the previous two IDs
+
+Now, even though these are conditionals, their primary use are as value
+arguments to another operator. For example::
+
+    set-header ATS-Req-UUID %{ID:UNIQUE}
+
+
 INCOMING-PORT
 ~~~~~~~~~~~~~
 ::

--- a/plugins/header_rewrite/conditions.h
+++ b/plugins/header_rewrite/conditions.h
@@ -438,7 +438,7 @@ public:
   void set_qualifier(const std::string &q);
   void append_value(std::string &s, const Resources &res);
 
-  // These are special for this sub-class
+  // Make sure we know if the type is an int-type or a string.
   bool
   is_int_type() const
   {
@@ -461,6 +461,23 @@ private:
   const char *get_geo_string(const sockaddr *addr) const;
   GeoQualifiers _geo_qual;
   bool _int_type;
+};
+
+// id: Various identifiers for the requests, server process etc.
+class ConditionId : public Condition
+{
+public:
+  explicit ConditionId() : _id_qual(ID_QUAL_UNIQUE) { TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for ConditionId"); };
+  void initialize(Parser &p);
+  void set_qualifier(const std::string &q);
+  void append_value(std::string &s, const Resources &res);
+
+protected:
+  bool eval(const Resources &res);
+
+private:
+  DISALLOW_COPY_AND_ASSIGN(ConditionId);
+  IdQualifiers _id_qual;
 };
 
 #endif // __CONDITIONS_H

--- a/plugins/header_rewrite/factory.cc
+++ b/plugins/header_rewrite/factory.cc
@@ -135,6 +135,8 @@ condition_factory(const std::string &cond)
     c = new ConditionNow();
   } else if (c_name == "GEO") {
     c = new ConditionGeo();
+  } else if (c_name == "ID") {
+    c = new ConditionId();
   } else {
     TSError("[%s] Unknown condition: %s", PLUGIN_NAME, c_name.c_str());
     return NULL;

--- a/plugins/header_rewrite/statement.h
+++ b/plugins/header_rewrite/statement.h
@@ -57,11 +57,19 @@ enum NowQualifiers {
   NOW_QUAL_YEARDAY
 };
 
+// GEO data
 enum GeoQualifiers {
   GEO_QUAL_COUNTRY,
   GEO_QUAL_COUNTRY_ISO,
   GEO_QUAL_ASN,
   GEO_QUAL_ASN_NAME,
+};
+
+// ID data
+enum IdQualifiers {
+  ID_QUAL_REQUEST,
+  ID_QUAL_PROCESS,
+  ID_QUAL_UNIQUE,
 };
 
 class Statement


### PR DESCRIPTION
This gives header_rewrite the functionality to get / use the
same UUID / IDs as the new log-formats in TS-4519.