### PR TITLE
TS-4504 healthchecks.so: Use the default config dir for configs

### DIFF
--- a/plugins/healthchecks/healthchecks.c
+++ b/plugins/healthchecks/healthchecks.c
@@ -301,8 +301,23 @@ parse_configs(const char *fname)
   char buf[2 * 1024];
   HCFileInfo *head_finfo = NULL, *finfo = NULL, *prev_finfo = NULL;
 
-  if (NULL == (fd = fopen(fname, "r")))
+  if (!fname) {
     return NULL;
+  }
+
+  if ('/' == *fname) {
+    fd = fopen(fname, "r");
+  } else {
+    char filename[PATH_MAX + 1];
+
+    snprintf(filename, sizeof(filename), "%s/%s", fname, TSConfigDirGet());
+    fd = fopen(filename, "r");
+  }
+
+  if (NULL == fd) {
+    TSError("%s: Could not open config file", PLUGIN_NAME);
+    return NULL;
+  }
 
   while (!feof(fd)) {
     char *str, *save;


### PR DESCRIPTION
When a config file is given, and it's not an absolute path, we
should default to the TSConfigDirGet() base dir.