### PR TITLE
TS-4705: Proposal: NetVC Context

### DIFF
--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -40,6 +40,13 @@
 #define SSL_EVENT_SERVER 0
 #define SSL_EVENT_CLIENT 1
 
+// Indicator the context for a NetVConnection
+typedef enum {
+  NET_VCONNECTION_UNSET = 0,
+  NET_VCONNECTION_IN,  // Client <--> ATS, Client-Side
+  NET_VCONNECTION_OUT, // ATS <--> Server, Server-Side
+} NetVConnectionContext_t;
+
 /** Holds client options for NetVConnection.
 
     This class holds various options a user can specify for
@@ -496,6 +503,27 @@ public:
   /** Returns remote port. */
   uint16_t get_remote_port();
 
+  /** Set the context of NetVConnection.
+   * The context is ONLY set once and will not be changed.
+   *
+   * @param context The context to be set.
+   */
+  void
+  set_context(NetVConnectionContext_t context)
+  {
+    ink_assert(NET_VCONNECTION_UNSET == netvc_context);
+    netvc_context = context;
+  }
+
+  /** Get the context.
+   * @return the context of current NetVConnection
+   */
+  NetVConnectionContext_t
+  get_context() const
+  {
+    return netvc_context;
+  }
+
   /** Structure holding user options. */
   NetVCOptions options;
 
@@ -598,6 +626,8 @@ protected:
   bool is_transparent;
   /// Set if the next write IO that empties the write buffer should generate an event.
   int write_buffer_empty_event;
+  /// NetVConnection Context.
+  NetVConnectionContext_t netvc_context;
 };
 
 inline NetVConnection::NetVConnection()
@@ -608,7 +638,8 @@ inline NetVConnection::NetVConnection()
     got_remote_addr(0),
     is_internal_request(false),
     is_transparent(false),
-    write_buffer_empty_event(0)
+    write_buffer_empty_event(0),
+    netvc_context(NET_VCONNECTION_UNSET)
 {
   ink_zero(local_addr);
   ink_zero(remote_addr);

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -109,18 +109,6 @@ public:
     sslHandShakeComplete = state;
   }
 
-  virtual bool
-  getSSLClientConnection() const
-  {
-    return sslClientConnection;
-  }
-
-  virtual void
-  setSSLClientConnection(bool state)
-  {
-    sslClientConnection = state;
-  }
-
   void
   setSSLSessionCacheHit(bool state)
   {
@@ -277,7 +265,6 @@ private:
   const char *map_tls_protocol_to_tag(char const *proto_string) const;
 
   bool sslHandShakeComplete;
-  bool sslClientConnection;
   bool sslClientRenegotiationAbort;
   bool sslSessionCacheHit;
   MIOBuffer *handShakeBuffer;

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -229,18 +229,6 @@ public:
     return (true);
   }
 
-  virtual bool
-  getSSLClientConnection() const
-  {
-    return (false);
-  }
-
-  virtual void
-  setSSLClientConnection(bool state)
-  {
-    (void)state;
-  }
-
   virtual void net_read_io(NetHandler *nh, EThread *lthread);
   virtual int64_t load_buffer_and_write(int64_t towrite, MIOBufferAccessor &buf, int64_t &total_written, int &needs);
   void readDisable(NetHandler *nh);
@@ -283,8 +271,6 @@ public:
   EventIO ep;
   NetHandler *nh;
   unsigned int id;
-  // amc - what is this for? Why not use remote_addr or con.addr?
-  IpEndpoint server_addr; /// Server address and port.
 
   union {
     unsigned int flags;

--- a/iocore/net/SSLClientUtils.cc
+++ b/iocore/net/SSLClientUtils.cc
@@ -79,7 +79,7 @@ verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
     // Otherwise match by IP
     else {
       char buff[INET6_ADDRSTRLEN];
-      ats_ip_ntop(netvc->server_addr, buff, INET6_ADDRSTRLEN);
+      ats_ip_ntop(netvc->get_remote_addr(), buff, INET6_ADDRSTRLEN);
       if (validate_hostname(cert, reinterpret_cast<unsigned char *>(buff), true, NULL)) {
         SSLDebug("IP %s verified OK", buff);
         return preverify_ok;

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -142,7 +142,7 @@ make_ssl_connection(SSL_CTX *ctx, SSLNetVConnection *netvc)
     netvc->ssl = ssl;
 
     // Only set up the bio stuff for the server side
-    if (netvc->getSSLClientConnection()) {
+    if (netvc->get_context() == NET_VCONNECTION_OUT) {
       SSL_set_fd(ssl, netvc->get_socket());
     } else {
       netvc->initialize_handshake_buffers();
@@ -432,7 +432,7 @@ SSLNetVConnection::net_read_io(NetHandler *nh, EThread *lthread)
   if (!getSSLHandShakeComplete()) {
     int err;
 
-    if (getSSLClientConnection()) {
+    if (get_context() == NET_VCONNECTION_OUT) {
       ret = sslStartHandShake(SSL_EVENT_CLIENT, err);
     } else {
       ret = sslStartHandShake(SSL_EVENT_SERVER, err);
@@ -786,7 +786,6 @@ SSLNetVConnection::SSLNetVConnection()
     sslTotalBytesSent(0),
     hookOpRequested(SSL_HOOK_OP_DEFAULT),
     sslHandShakeComplete(false),
-    sslClientConnection(false),
     sslClientRenegotiationAbort(false),
     sslSessionCacheHit(false),
     handShakeBuffer(NULL),
@@ -876,7 +875,6 @@ SSLNetVConnection::free(EThread *t)
   }
 
   sslHandShakeComplete        = false;
-  sslClientConnection         = false;
   sslHandshakeBeginTime       = 0;
   sslLastWriteTime            = 0;
   sslTotalBytesSent           = 0;
@@ -1502,8 +1500,6 @@ SSLNetVConnection::populate(Connection &con, Continuation *c, void *arg)
   // Maybe bring over the stats?
 
   this->sslHandShakeComplete = true;
-  this->sslClientConnection  = true;
-
   SSLNetVCAttach(this->ssl, this);
   return EVENT_DONE;
 }

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1283,8 +1283,8 @@ SSLDiagnostic(const SourceLocation &loc, bool debug, SSLNetVConnection *vc, cons
     // Tally desired stats (only client/server connection stats, not init
     // issues where vc is NULL)
     if (vc) {
-      // getSSLClientConnection - true if ats is client (we update server stats)
-      if (vc->getSSLClientConnection()) {
+      // get_context() == NET_VCONNECTION_OUT if ats is client (we update server stats)
+      if (vc->get_context() == NET_VCONNECTION_OUT) {
         increment_ssl_server_error(l); // update server error stats
       } else {
         increment_ssl_client_error(l); // update client error stat

--- a/iocore/net/Socks.cc
+++ b/iocore/net/Socks.cc
@@ -160,7 +160,7 @@ SocksEntry::free()
       netVConnection->do_io_read(this, 0, 0);
       netVConnection->do_io_write(this, 0, 0);
       netVConnection->action_ = action_; // assign the original continuation
-      ats_ip_copy(&netVConnection->server_addr, &server_addr);
+      netVConnection->con.setRemote(&server_addr.sa);
       Debug("Socks", "Sent success to HTTP");
       NET_INCREMENT_DYN_STAT(socks_connections_successful_stat);
       action_.continuation->handleEvent(NET_EVENT_OPEN, netVConnection);

--- a/iocore/net/UnixConnection.cc
+++ b/iocore/net/UnixConnection.cc
@@ -316,14 +316,15 @@ Connection::connect(sockaddr const *target, NetVCOptions const &opt)
 
   int res;
 
-  this->setRemote(target);
+  if (target != NULL)
+    this->setRemote(target);
 
   // apply dynamic options with this.addr initialized
   apply_options(opt);
 
   cleaner<Connection> cleanup(this, &Connection::_cleanup); // mark for close until we succeed.
 
-  res = ::connect(fd, target, ats_ip_size(target));
+  res = ::connect(fd, &this->addr.sa, ats_ip_size(&this->addr.sa));
 
   // It's only really an error if either the connect was blocking
   // or it wasn't blocking and the error was other than EINPROGRESS.

--- a/iocore/net/UnixNetPages.cc
+++ b/iocore/net/UnixNetPages.cc
@@ -64,12 +64,12 @@ struct ShowNet : public ShowCont {
     forl_LL(UnixNetVConnection, vc, nh->open_list)
     {
       //      uint16_t port = ats_ip_port_host_order(&addr.sa);
-      if (ats_is_ip(&addr) && addr != vc->server_addr)
+      if (ats_is_ip(&addr) && !ats_ip_addr_port_eq(&addr.sa, vc->get_remote_addr()))
         continue;
       //      if (port && port != ats_ip_port_host_order(&vc->server_addr.sa) && port != vc->accept_port)
       //        continue;
       char ipbuf[INET6_ADDRSTRLEN];
-      ats_ip_ntop(&vc->server_addr.sa, ipbuf, sizeof(ipbuf));
+      ats_ip_ntop(vc->get_remote_addr(), ipbuf, sizeof(ipbuf));
       char opt_ipbuf[INET6_ADDRSTRLEN];
       char interbuf[80];
       snprintf(interbuf, sizeof(interbuf), "[%s] %s:%d", vc->options.toString(vc->options.addr_binding),
@@ -95,7 +95,7 @@ struct ShowNet : public ShowCont {
                       "<td>%d</td>"          // shutdown
                       "<td>-%s</td>"         // comments
                       "</tr>\n",
-                      vc->id, ipbuf, ats_ip_port_host_order(&vc->server_addr), vc->con.fd, interbuf,
+                      vc->id, ipbuf, ats_ip_port_host_order(vc->get_remote_addr()), vc->con.fd, interbuf,
                       //                      vc->accept_port,
                       (int)((now - vc->submit_time) / HRTIME_SECOND), ethread->id, vc->read.enabled, vc->read.vio.nbytes,
                       vc->read.vio.ndone, vc->write.enabled, vc->write.vio.nbytes, vc->write.vio.ndone,

--- a/proxy/CoreUtils.cc
+++ b/proxy/CoreUtils.cc
@@ -768,8 +768,8 @@ CoreUtils::process_NetVC(UnixNetVConnection *nvc_test)
     char addrbuf[INET6_ADDRSTRLEN];
 
     printf("----------- UnixNetVConnection @ 0x%p ----------\n", nvc_test);
-    printf("     ip: %s    port: %d\n", ats_ip_ntop(&loaded_nvc->server_addr.sa, addrbuf, sizeof(addrbuf)),
-           ats_ip_port_host_order(&loaded_nvc->server_addr));
+    printf("     ip: %s    port: %d\n", ats_ip_ntop(loaded_nvc->get_remote_addr(), addrbuf, sizeof(addrbuf)),
+           ats_ip_port_host_order(loaded_nvc->get_remote_addr()));
     printf("     closed: %d\n\n", loaded_nvc->closed);
     printf("     read state: \n");
     print_netstate(&loaded_nvc->read);

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -6484,6 +6484,7 @@ TSVConnFdCreate(int fd)
   vc->submit_time = Thread::get_hrtime();
   vc->set_is_transparent(false);
   vc->mutex = new_ProxyMutex();
+  vc->set_context(NET_VCONNECTION_OUT);
 
   if (vc->connectUp(this_ethread(), fd) != CONNECT_SUCCESS) {
     return NULL;


### PR DESCRIPTION
Goal 1st:
In the NetVConnection, we have get_local_addr() and get_remote_addr() methods.
Also have members local_addr, remote_addr and netvc->con.addr.

Thus, we should using netvc->con.addr or remote_addr to replace member server_addr in UnixNetVConnection.

Goal 2nd:
SSLNetVConnection has member sslClientConnection with 2 methods setSSLClientConnection() and getSSLClientConnection() to indictor ATS is a client or server in a SSL session.

To abstract above two goals, I'm design the netvc context function.

As a proxy, there has two side: client side ( Client <-> Proxy ) and server side ( Proxy <-> Server ). With the netvc context funtion to indicate which side the NetVC working on.

Goal 3rd:
Fix a minor bug in NetAccept::do_blocking_accept, call to check_emergency_throttle(con) first then allocate vc.

Goal 4th:
NetAccept Optimize, remove dup code, etc...
