### PR TITLE
Update configuring-traffic-server.en.rst : 'config' option missing

### DIFF
--- a/doc/admin-guide/configuring-traffic-server.en.rst
+++ b/doc/admin-guide/configuring-traffic-server.en.rst
@@ -49,7 +49,7 @@ Change Configuration Options
 To change the value of a configuration setting, enter the following
 command::
 
-    traffic_ctl set VARIABLE VALUE
+    traffic_ctl config set VARIABLE VALUE
 
 where *var* is the variable associated with the configuration option
 and *value* is the value you want to use. For a list of the


### PR DESCRIPTION
The correct set command is 
traffic_ctl config set VARIABLE VALUE