### PR TITLE
TS-4332: proxy.config.net.connections_throttle should allow for immed…

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -674,6 +674,7 @@ HTTP Engine
    tr-in                       Inbound transparent.
    tr-out                      Outbound transparent.
    tr-pass                     Pass through enabled.
+   no-throttle                 Port should not be throttled
    =========== =============== ========================================
 
 *number*
@@ -722,6 +723,8 @@ tr-out
 tr-pass
    Transparent pass through. This option is useful only for inbound transparent proxy ports. If the parsing of the expected HTTP header fails, then the transaction is switched to a blind tunnel instead of generating an error response to the client. It effectively enables :ts:cv:`proxy.config.http.use_client_target_addr` for the transaction as there is no other place to obtain the origin server address.
 
+no-throttle
+   Do not throttle requests that come to this port even when  the  :ts:cv:`proxy.config.net.connections_throttle` limit is reached.
 ip-in
    Set the local IP address for the port. This is the address to which clients will connect. This forces the IP address family for the port. The ``ipv4`` or ``ipv6`` can be used but it is optional and is an error for it to disagree with the IP address family of this value. An IPv6 address **must** be enclosed in square brackets. If this option is omitted :ts:cv:`proxy.local.incoming_ip_to_bind` is used.
 

--- a/doc/admin-guide/monitoring/statistics/core/network-io.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/network-io.en.rst
@@ -60,6 +60,9 @@ Network I/O
 .. ts:stat:: global proxy.process.net.connections_currently_open integer
    :type: counter
 
+Number of connections currently open.  Includes both connections from client to ATS and from ATS to origin.
+Used by :ts:cv:`proxy.config.net.connections_throttle` to determine when to throttle new connections.
+
 .. ts:stat:: global proxy.process.net.default_inactivity_timeout_applied integer
 .. ts:stat:: global proxy.process.net.dynamic_keep_alive_timeout_in_count integer
 .. ts:stat:: global proxy.process.net.dynamic_keep_alive_timeout_in_total integer
@@ -75,3 +78,12 @@ Network I/O
    :type: counter
    :unit: bytes
 
+.. ts:stat:: global proxy.process.net.connections_throttled_in integer
+   :type: counter
+
+Number of connections from client that have been throttled due to being over the  :ts:cv:`proxy.config.net.connections_throttle` limit.
+
+.. ts:stat:: global proxy.process.net.connections_throttled_out integer
+   :type: counter
+
+Number of connections to origin that have been throttled due to being over the  :ts:cv:`proxy.config.net.connections_throttle` limit.

--- a/iocore/net/I_NetProcessor.h
+++ b/iocore/net/I_NetProcessor.h
@@ -95,6 +95,8 @@ public:
     */
     bool f_inbound_transparent;
 
+    bool f_no_throttle;
+
     /// Default constructor.
     /// Instance is constructed with default values.
     AcceptOptions() { this->reset(); }

--- a/iocore/net/Net.cc
+++ b/iocore/net/Net.cc
@@ -77,6 +77,11 @@ register_net_stats()
                      (int)net_accepts_currently_open_stat, RecRawStatSyncSum);
   NET_CLEAR_DYN_STAT(net_accepts_currently_open_stat);
 
+  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.connections_throttled_in", RECD_INT, RECP_PERSISTENT,
+                     (int)net_connections_throttled_in_stat, RecRawStatSyncSum);
+  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.connections_throttled_out", RECD_INT, RECP_PERSISTENT,
+                     (int)net_connections_throttled_out_stat, RecRawStatSyncSum);
+
   RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.calls_to_readfromnet", RECD_INT, RECP_PERSISTENT,
                      (int)net_calls_to_readfromnet_stat, RecRawStatSyncSum);
   NET_CLEAR_DYN_STAT(net_calls_to_readfromnet_stat);

--- a/iocore/net/P_Connection.h
+++ b/iocore/net/P_Connection.h
@@ -167,6 +167,9 @@ struct Server : public Connection {
   /// If set, a kernel HTTP accept filter
   bool http_accept_filter;
 
+  // If set this server is free from connection throttling
+  bool no_throttle;
+
   //
   // Use this call for the main proxy accept
   //
@@ -185,7 +188,7 @@ struct Server : public Connection {
                           bool transparent = false ///< Inbound transparent.
                           );
 
-  Server() : Connection(), f_inbound_transparent(false) { ink_zero(accept_addr); }
+  Server() : Connection(), f_inbound_transparent(false), no_throttle(false) { ink_zero(accept_addr); }
 };
 
 #endif /*_Connection_h*/

--- a/iocore/net/P_Net.h
+++ b/iocore/net/P_Net.h
@@ -53,6 +53,8 @@ enum Net_Stats {
   keep_alive_queue_timeout_total_stat,
   keep_alive_queue_timeout_count_stat,
   default_inactivity_timeout_stat,
+  net_connections_throttled_in_stat,
+  net_connections_throttled_out_stat,
   Net_Stat_Count
 };
 

--- a/iocore/net/P_NetAccept.h
+++ b/iocore/net/P_NetAccept.h
@@ -111,6 +111,11 @@ struct NetAccept : public Continuation {
   virtual int acceptFastEvent(int event, void *e);
   int acceptLoopEvent(int event, Event *e);
   void cancel();
+  bool
+  no_throttle() const
+  {
+    return server.no_throttle;
+  }
 
   NetAccept();
   virtual ~NetAccept() { action_ = NULL; };

--- a/iocore/net/P_UnixNet.h
+++ b/iocore/net/P_UnixNet.h
@@ -122,7 +122,6 @@ typedef unsigned int uint32;
 
 extern ink_hrtime last_throttle_warning;
 extern ink_hrtime last_shedding_warning;
-extern ink_hrtime emergency_throttle_time;
 extern int net_connections_throttle;
 extern int fds_throttle;
 extern int fds_limit;
@@ -265,12 +264,6 @@ check_shedding_warning()
 }
 
 TS_INLINE int
-emergency_throttle(ink_hrtime now)
-{
-  return emergency_throttle_time > now;
-}
-
-TS_INLINE int
 check_net_throttle(ThrottleType t, ink_hrtime now)
 {
   int connections = net_connections_to_throttle(t);
@@ -278,48 +271,20 @@ check_net_throttle(ThrottleType t, ink_hrtime now)
   if (connections >= net_connections_throttle)
     return true;
 
-  if (emergency_throttle(now))
-    return true;
-
   return false;
 }
 
 TS_INLINE void
-check_throttle_warning()
+check_throttle_warning(ThrottleType type)
 {
   ink_hrtime t = Thread::get_hrtime();
   if (t - last_throttle_warning > NET_THROTTLE_MESSAGE_EVERY) {
     last_throttle_warning = t;
-    RecSignalWarning(REC_SIGNAL_SYSTEM_ERROR, "too many connections, throttling");
+    int connections       = net_connections_to_throttle(type);
+    RecSignalWarning(REC_SIGNAL_SYSTEM_ERROR,
+                     "too many connections, throttling.  connection_type=%s, current_connections=%d, net_connections_throttle=%d",
+                     type == ACCEPT ? "ACCEPT" : "CONNECT", connections, net_connections_throttle);
   }
-}
-
-//
-// Emergency throttle when we are close to exhausting file descriptors.
-// Block all accepts or connects for N seconds where N
-// is the amount into the emergency fd stack squared
-// (e.g. on the last file descriptor we have 14 * 14 = 196 seconds
-// of emergency throttle).
-//
-// Hyper Emergency throttle when we are very close to exhausting file
-// descriptors.  Close the connection immediately, the upper levels
-// will recover.
-//
-TS_INLINE int
-check_emergency_throttle(Connection &con)
-{
-  int fd        = con.fd;
-  int emergency = fds_limit - EMERGENCY_THROTTLE;
-  if (fd > emergency) {
-    int over                = fd - emergency;
-    emergency_throttle_time = Thread::get_hrtime() + (over * over) * HRTIME_SECOND;
-    RecSignalWarning(REC_SIGNAL_SYSTEM_ERROR, "too many open file descriptors, emergency throttling");
-    int hyper_emergency = fds_limit - HYPER_EMERGENCY_THROTTLE;
-    if (fd > hyper_emergency)
-      con.close();
-    return true;
-  }
-  return false;
 }
 
 TS_INLINE int

--- a/iocore/net/P_UnixNetProcessor.h
+++ b/iocore/net/P_UnixNetProcessor.h
@@ -49,7 +49,6 @@ public:
 
   virtual int start(int number_of_net_threads, size_t stacksize);
 
-  char *throttle_error_message;
   Event *accept_thread_event;
 
   // offsets for per thread data structures

--- a/iocore/net/UnixNet.cc
+++ b/iocore/net/UnixNet.cc
@@ -25,7 +25,6 @@
 
 ink_hrtime last_throttle_warning;
 ink_hrtime last_shedding_warning;
-ink_hrtime emergency_throttle_time;
 int net_connections_throttle;
 int fds_throttle;
 int fds_limit = 8000;

--- a/iocore/net/UnixNetProcessor.cc
+++ b/iocore/net/UnixNetProcessor.cc
@@ -118,6 +118,7 @@ UnixNetProcessor::accept_internal(Continuation *cont, int fd, AcceptOptions cons
   na->server.fd = fd;
   ats_ip_copy(&na->server.accept_addr, &accept_ip);
   na->server.f_inbound_transparent = opt.f_inbound_transparent;
+  na->server.no_throttle           = opt.f_no_throttle;
   if (opt.f_inbound_transparent) {
     Debug("http_tproxy", "Marking accept server %p on port %d as inbound transparent", na, opt.local_port);
   }

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1241,8 +1241,10 @@ UnixNetVConnection::connectUp(EThread *t, int fd)
 
   thread = t;
   if (check_net_throttle(CONNECT, submit_time)) {
-    check_throttle_warning();
+    check_throttle_warning(CONNECT);
     action_.continuation->handleEvent(NET_EVENT_OPEN_FAILED, (void *)-ENET_THROTTLING);
+    ProxyMutex *mutex = thread->mutex.get(); // Faking out the stat increment macro below
+    NET_INCREMENT_DYN_STAT(net_connections_throttled_out_stat);
     free(t);
     return CONNECT_FAILURE;
   }
@@ -1296,8 +1298,6 @@ UnixNetVConnection::connectUp(EThread *t, int fd)
       goto fail;
     }
   }
-
-  check_emergency_throttle(con);
 
   // start up next round immediately
 

--- a/lib/records/I_RecHttp.h
+++ b/lib/records/I_RecHttp.h
@@ -243,6 +243,8 @@ public:
   bool m_outbound_transparent_p;
   // True if transparent pass-through is enabled on this port.
   bool m_transparent_passthrough;
+  // True if the port should not be throttled when connection limits are encountered
+  bool m_no_throttle;
   /// Local address for inbound connections (listen address).
   IpAddr m_inbound_ip;
   /// Local address for outbound connections (to origin server).
@@ -391,6 +393,7 @@ public:
   static char const *const OPT_PLUGIN;                  ///< Protocol Plugin handle (experimental)
   static char const *const OPT_BLIND_TUNNEL;            ///< Blind tunnel.
   static char const *const OPT_COMPRESSED;              ///< Compressed.
+  static char const *const OPT_NO_THROTTLE;             ///< Port should not be throttled
   static char const *const OPT_HOST_RES_PREFIX;         ///< Set DNS family preference.
   static char const *const OPT_PROTO_PREFIX;            ///< Transport layer protocols.
 

--- a/lib/records/RecHttp.cc
+++ b/lib/records/RecHttp.cc
@@ -124,6 +124,7 @@ char const *const HttpProxyPort::OPT_SSL                     = "ssl";
 char const *const HttpProxyPort::OPT_PLUGIN                  = "plugin";
 char const *const HttpProxyPort::OPT_BLIND_TUNNEL            = "blind";
 char const *const HttpProxyPort::OPT_COMPRESSED              = "compressed";
+char const *const HttpProxyPort::OPT_NO_THROTTLE             = "no-throttle";
 
 // File local constants.
 namespace
@@ -154,7 +155,8 @@ HttpProxyPort::HttpProxyPort()
     m_family(AF_INET),
     m_inbound_transparent_p(false),
     m_outbound_transparent_p(false),
-    m_transparent_passthrough(false)
+    m_transparent_passthrough(false),
+    m_no_throttle(false)
 {
   memcpy(m_host_res_preference, host_res_default_preference_order, sizeof(m_host_res_preference));
 }
@@ -365,6 +367,8 @@ HttpProxyPort::processOptions(char const *opts)
 #else
       Warning("Transparent pass-through requested [%s] in port descriptor '%s' but TPROXY was not configured.", item, opts);
 #endif
+    } else if (0 == strcasecmp(OPT_NO_THROTTLE, item)) {
+      m_no_throttle = true;
     } else if (0 != (value = this->checkPrefix(item, OPT_HOST_RES_PREFIX, OPT_HOST_RES_PREFIX_LEN))) {
       this->processFamilyPreference(value);
       host_res_set_p = true;

--- a/proxy/http/HttpProxyServerMain.cc
+++ b/proxy/http/HttpProxyServerMain.cc
@@ -117,6 +117,7 @@ make_net_accept_options(const HttpProxyPort &port, unsigned nthreads)
   net.accept_threads = nthreads;
 
   net.f_inbound_transparent = port.m_inbound_transparent_p;
+  net.f_no_throttle         = port.m_no_throttle;
   net.ip_family             = port.m_family;
   net.local_port            = port.m_port;
 

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -409,6 +409,7 @@ protected:
   void do_hostdb_reverse_lookup();
   void do_cache_lookup_and_read();
   void do_http_server_open(bool raw = false);
+  void send_origin_throttled_response();
   void do_setup_post_tunnel(HttpVC_t to_vc_type);
   void do_cache_prepare_write();
   void do_cache_prepare_write_transform();


### PR DESCRIPTION
…iate error return when accepts reach throttle limit

Removed emergency_throttle logic because we have had problems getting things to recover after going into emergency.  Need to reconsider how to do tiers of throttling that are recoverable.

Changed the inbound over limit requests to close the connection immediately.  This reduces load on the ATS process which is reasonable if we are trying to shed connections.  

Added metrics to track how inbound and outbound connections are throttled.

Added port decoration to indicate that a port should not be throttled.  Useful to protect health check and other internal communication.

Updated documentation.
