### PR TITLE
TS-4601: Connection error from origin_max_connection with origin_max_…

### DIFF
--- a/doc/admin-guide/monitoring/statistics/core/http-connection.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/http-connection.en.rst
@@ -139,3 +139,7 @@ HTTP Connection
 .. ts:stat:: global proxy.process.http.total_server_connections integer
    :type: counter
 
+.. ts:stat:: global proxy.process.http.origin_connections_throttled_out integer
+   :type: counter
+
+This tracks the number of origin connections denied due to being over the :ts:cv`proxy.config.http.origin_max_connections` limit.

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -810,6 +810,8 @@ register_stat_callbacks()
                      (int)https_incoming_requests_stat, RecRawStatSyncCount);
   RecRegisterRawStat(http_rsb, RECT_PROCESS, "proxy.process.https.total_client_connections", RECD_COUNTER, RECP_PERSISTENT,
                      (int)https_total_client_connections_stat, RecRawStatSyncCount);
+  RecRegisterRawStat(http_rsb, RECT_PROCESS, "proxy.process.http.origin_connections_throttled_out", RECD_COUNTER, RECP_PERSISTENT,
+                     (int)http_origin_connections_throttled_stat, RecRawStatSyncCount);
   RecRegisterRawStat(http_rsb, RECT_PROCESS, "proxy.process.http.post_body_too_large", RECD_COUNTER, RECP_PERSISTENT,
                      (int)http_post_body_too_large, RecRawStatSyncCount);
   // milestones

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -312,6 +312,8 @@ enum {
   http_sm_start_time_stat,
   http_sm_finish_time_stat,
 
+  http_origin_connections_throttled_stat,
+
   http_stat_count
 };
 

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -408,6 +408,7 @@ protected:
   void do_hostdb_reverse_lookup();
   void do_cache_lookup_and_read();
   void do_http_server_open(bool raw = false);
+  void send_origin_throttled_response();
   void do_setup_post_tunnel(HttpVC_t to_vc_type);
   void do_cache_prepare_write();
   void do_cache_prepare_write_transform();


### PR DESCRIPTION
…connections_queue set to 0 should not retry

In addition to changing the connect attempts to not retry in the case of an over limit origin connection that is closed, added a stat to track how many origin connections are being closed.