### PR TITLE
TS 4593: Extend ip_allow.config to filter destination IPs

### DIFF
--- a/doc/admin-guide/files/ip_allow.config.en.rst
+++ b/doc/admin-guide/files/ip_allow.config.en.rst
@@ -22,10 +22,12 @@ ip_allow.config
 .. configfile:: ip_allow.config
 
 The :file:`ip_allow.config` file controls client access to the Traffic
-Server proxy cache. You can specify ranges of IP addresses that are
-allowed to use the Traffic Server as a web proxy cache. After you modify
-the :file:`ip_allow.config` file, navigate to the Traffic Server bin
-directory and run the :option:`traffic_ctl config reload` command to apply changes. When
+Server proxy cache and Traffic Server connections to the servers. You
+can specify ranges of IP addresses that are allowed to use the Traffic
+Server as a web proxy cache or that are allowed to be remapped by
+Traffic Server. After you modify the :file:`ip_allow.config` file,
+navigate to the Traffic Server bin directory and run the
+:option:`traffic_ctl config reload` command to apply changes. When
 you apply the changes to a node in a cluster, Traffic Server
 automatically applies the changes to all other nodes in the cluster.
 
@@ -36,13 +38,18 @@ Each line in the :file:`ip_allow.config` file must have the following
 format::
 
     src_ip=<range of IP addresses> action=<action> [method=<list of methods separated by '|'>]
+    dest_ip=<range of IP addresses> action=<action> [method=<list of methods separated by '|'>]
 
 where src_ip is the IP address or range of IP addresses of the
-client(s). The action ``ip_allow`` enables the specified client(s) to
-access the Traffic Server proxy cache, and ``ip_deny`` denies the
-specified client(s) to access the Traffic Server proxy cache. Multiple
-method keywords can be specified (method=GET method=HEAD), or multiple
-methods can be separated by an '\|' (method=GET\|HEAD). The method
+client(s) and dest_ip is the IP address or range of IP addresses of the
+server(s). When src_ip is indicated, the action ``ip_allow`` enables
+the specified client(s) to access the Traffic Server proxy cache,
+and ``ip_deny`` denies the specified client(s) to access the Traffic
+Server proxy cache. When dest_ip is indicated, the action ``ip_allow``
+enables the Traffic Server to access the specified server(s), and
+``ip_deny`` denies the Traffic Server to access the specified server(s).
+Multiple method keywords can be specified (method=GET method=HEAD), or
+multiple methods can be separated by an '\|' (method=GET\|HEAD). The method
 keyword is optional and it is defaulted to ALL. This supports ANY string
 as the HTTP method, meaning no validation is done to check whether it
 is a valid HTTP method. This allows you to create filters for any method
@@ -78,3 +85,11 @@ the Traffic Server proxy cache::
 
     src_ip=123.45.6.0-123.45.6.123 action=ip_deny
 
+The following example enables the Traffic Server to access all servers::
+
+    dest_ip=0.0.0.0-255.255.255.255 action=ip_allow
+
+The following example denies the Traffic Server to access all servers
+on a specific subnet::
+
+    dest_ip=10.0.0.0-10.0.0.255 action=ip_deny

--- a/iocore/net/SessionAccept.cc
+++ b/iocore/net/SessionAccept.cc
@@ -31,8 +31,8 @@ SessionAccept::testIpAllowPolicy(sockaddr const *client_ip)
   IpAllow::scoped_config ipallow;
   const AclRecord *acl_record = nullptr;
   if (ipallow) {
-    acl_record = ipallow->match(client_ip);
-    if (acl_record && acl_record->isEmpty()) {
+    acl_record = ipallow->match(client_ip, IpAllow::SRC_ADDR);
+    if (acl_record && acl_record->isEmpty() && ipallow->isAcceptCheckEnabled()) {
       acl_record = nullptr;
     }
   }

--- a/lib/ts/MatcherUtils.cc
+++ b/lib/ts/MatcherUtils.cc
@@ -401,7 +401,9 @@ processDurationString(char *str, int *seconds)
 
 const matcher_tags http_dest_tags = {"dest_host", "dest_domain", "dest_ip", "url_regex", "url", "host_regex", true};
 
-const matcher_tags ip_allow_tags = {nullptr, nullptr, "src_ip", nullptr, nullptr, nullptr, false};
+const matcher_tags ip_allow_src_tags = {nullptr, nullptr, "src_ip", nullptr, nullptr, nullptr, false};
+
+const matcher_tags ip_allow_dest_tags = {nullptr, nullptr, "dest_ip", nullptr, nullptr, nullptr, true};
 
 const matcher_tags socks_server_tags = {nullptr, nullptr, "dest_ip", nullptr, nullptr, nullptr, false};
 

--- a/lib/ts/MatcherUtils.h
+++ b/lib/ts/MatcherUtils.h
@@ -108,7 +108,8 @@ struct matcher_tags {
 };
 
 extern const matcher_tags http_dest_tags;
-extern const matcher_tags ip_allow_tags;
+extern const matcher_tags ip_allow_src_tags;
+extern const matcher_tags ip_allow_dest_tags;
 extern const matcher_tags socks_server_tags;
 
 const char *parseConfigLine(char *line, matcher_line *p_line, const matcher_tags *tags);

--- a/proxy/IPAllow.h
+++ b/proxy/IPAllow.h
@@ -110,12 +110,14 @@ class IpAllow : public ConfigInfo
 
 public:
   typedef IpAllow self; ///< Self reference type.
+  // indicator for whether we should be checking the acl record for src ip or dest ip
+  enum match_key_t { SRC_ADDR, DEST_ADDR };
 
   IpAllow(const char *config_var, const char *name, const char *action_val);
   ~IpAllow();
   void Print();
-  AclRecord *match(IpEndpoint const *ip) const;
-  AclRecord *match(sockaddr const *ip) const;
+  AclRecord *match(IpEndpoint const *ip, match_key_t key) const;
+  AclRecord *match(sockaddr const *ip, match_key_t key) const;
 
   static void startup();
   static void reconfigure();
@@ -130,35 +132,59 @@ public:
     return &ALL_METHOD_ACL;
   }
 
+  /* @return The previous accept check state
+   * This is a global variable that is independent of
+   * the ip_allow configuration
+   */
+  static bool
+  enableAcceptCheck(bool state)
+  {
+    bool temp      = accept_check_p;
+    accept_check_p = state;
+    return temp;
+  }
+  /* @return The current accept check state
+   * This is a global variable that is independent of
+   * the ip_allow configuration
+   */
+  static bool
+  isAcceptCheckEnabled()
+  {
+    return accept_check_p;
+  }
+
   typedef ConfigProcessor::scoped_config<IpAllow, IpAllow> scoped_config;
 
 private:
   static int configid;
   static const AclRecord ALL_METHOD_ACL;
+  static bool accept_check_p;
 
+  void PrintMap(IpMap *map);
   int BuildTable();
 
   char config_file_path[PATH_NAME_MAX];
   const char *module_name;
   const char *action;
-  IpMap _map;
-  Vec<AclRecord> _acls;
+  IpMap _src_map;
+  IpMap _dest_map;
+  Vec<AclRecord> _src_acls;
+  Vec<AclRecord> _dest_acls;
 };
 
 inline AclRecord *
-IpAllow::match(IpEndpoint const *ip) const
+IpAllow::match(IpEndpoint const *ip, match_key_t key) const
 {
-  return this->match(&ip->sa);
+  return this->match(&ip->sa, key);
 }
 
 inline AclRecord *
-IpAllow::match(sockaddr const *ip) const
+IpAllow::match(sockaddr const *ip, match_key_t key) const
 {
-  void *raw;
-  if (_map.contains(ip, &raw)) {
-    return static_cast<AclRecord *>(raw);
-  }
-  return nullptr;
+  void *raw        = nullptr;
+  const IpMap &map = (key == SRC_ADDR) ? _src_map : _dest_map;
+  map.contains(ip, &raw);
+  return static_cast<AclRecord *>(raw);
 }
 
 #endif

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -7298,7 +7298,7 @@ const char *
 TSMatcherParseSrcIPConfigLine(char *line, TSMatcherLine ml)
 {
   sdk_assert(sdk_sanity_check_null_ptr((void *)line) == TS_SUCCESS);
-  return parseConfigLine(line, (matcher_line *)ml, &ip_allow_tags);
+  return parseConfigLine(line, (matcher_line *)ml, &ip_allow_src_tags);
 }
 
 char *

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -1200,6 +1200,7 @@ public:
   static void StartAuth(State *s);
   static void HandleRequestAuthorized(State *s);
   static void BadRequest(State *s);
+  static void Forbidden(State *s);
   static void HandleFiltering(State *s);
   static void DecideCacheLookup(State *s);
   static void LookupSkipOpenServer(State *s);

--- a/proxy/http/remap/RemapConfig.h
+++ b/proxy/http/remap/RemapConfig.h
@@ -53,6 +53,8 @@ struct BUILD_TABLE_INFO {
   char *paramv[BUILD_TABLE_MAX_ARGS];
   char *argv[BUILD_TABLE_MAX_ARGS];
 
+  bool ip_allow_check_enabled_p;
+  bool accept_check_p;
   acl_filter_rule *rules_list; // all rules defined in config files as .define_filter foobar @src_ip=.....
   UrlRewrite *rewrite;         // Pointer to the UrlRewrite object we are parsing for.
 

--- a/proxy/http/remap/UrlMapping.h
+++ b/proxy/http/remap/UrlMapping.h
@@ -107,6 +107,7 @@ public:
   unsigned int map_id;
   referer_info *referer_list;
   redirect_tag_str *redir_chunk_list;
+  bool ip_allow_check_enabled_p;
   acl_filter_rule *filter; // acl filtering (list of rules)
   unsigned int _plugin_count;
   LINK(url_mapping, link); // For use with the main Queue linked list holding all the mapping


### PR DESCRIPTION
Documentation for extending ip_allow.config to filter destination IP addresses, as proposed by Edge. @SolidWallOfCode @shinrich 
