### PR TITLE
Integrate clang-tidy into the build.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,1 +1,1 @@
-Checks: readability-braces-around-statements
+Checks: -*,readability-braces-around-statements

--- a/Makefile.am
+++ b/Makefile.am
@@ -140,21 +140,22 @@ clang-format-tools:
 	@$(top_srcdir)/tools/clang-format.sh $(top_srcdir)/tools
 
 help:
-	@echo 'all             default target for building the package' && \
-	echo 'check            run the test suite, if any' && \
-	echo 'clean            remove whatever make created' && \
-	echo 'distclean        remove whatever configure created' && \
-	echo 'dist             DEPRECATED: recreate source package' && \
-	echo 'examples         make examples' && \
-	echo 'asf-dist         recreate source package' && \
-	echo 'asf-dist-sign    recreate source package, with checksums and signature' && \
-	echo 'release          recreate a signed release source package and a signed git tag' && \
-	echo 'rel-candidate    recreate a signed relelease candidate source package and a signed git tag' && \
-	echo 'distcheck        verify dist by performing VPATH build and then distclean' && \
-	echo 'rat              produce a RAT licence compliance report of the source' && \
-	echo 'doxygen          generate doxygen docs in doc/html dir' && \
-	echo 'clang-format     run clang-format over most C and C++ files (not git subtrees)' && \
-	echo 'help             display this list of make targets' && \
-	echo 'install          install by copying the built files to system-wide dirs' && \
-	echo 'install-strip    same as install but then strips debugging symbols' && \
-	echo 'install-examples install examples by copying the built files to system-wide dirs'
+	@echo 'all              default target for building the package'
+	@echo 'asf-dist         recreate source package'
+	@echo 'asf-dist-sign    recreate source package, with checksums and signature'
+	@echo 'check            run the test suite, if any'
+	@echo 'clang-format     run clang-format over most C and C++ files (not git subtrees)'
+	@echo 'clean            remove whatever make created'
+	@echo 'dist             DEPRECATED: recreate source package'
+	@echo 'distcheck        verify dist by performing VPATH build and then distclean'
+	@echo 'distclean        remove whatever configure created'
+	@echo 'doxygen          generate doxygen docs in doc/html dir'
+	@echo 'examples         make examples'
+	@echo 'help             display this list of make targets'
+	@echo 'install          install by copying the built files to system-wide dirs'
+	@echo 'install-examples install examples by copying the built files to system-wide dirs'
+	@echo 'install-strip    same as install but then strips debugging symbols'
+	@echo 'rat              produce a RAT licence compliance report of the source'
+	@echo 'rel-candidate    recreate a signed relelease candidate source package and a signed git tag'
+	@echo 'release          recreate a signed release source package and a signed git tag'
+	@echo 'tidy             run clang-tidy in fix-it mode'

--- a/build/tidy.mk
+++ b/build/tidy.mk
@@ -14,14 +14,20 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-include $(top_srcdir)/build/plugins.mk
+Clang_Tidy_Options = -fix -fix-errors
 
-pkglib_LTLIBRARIES = custom_redirect.la
-custom_redirect_la_SOURCES = custom_redirect.cc
-custom_redirect_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+# Sort the filenames to remove duplicates, then filter to retain
+# just the C and C++ sources so we don't pick up lex and yacc files
+# for example.
 
+Clang_Tidy_Files = $(filter %.cc %.c %.h %.hpp,$(sort $(1)))
 
-include $(top_srcdir)/build/tidy.mk
+#clang-tidy rules. We expect these to be actions with something like
+#$(DIST_SOURCES) as the dependencies.rules. Note that $DIST_SOURCES
+#is not an automake API, it is an implementation detail, but it ought
+#to be stable enough.
+#
+#All this clearly requires GNU make.
 
-tidy-local: $(DIST_SOURCES)
-	$(CXX_Clang_Tidy)
+CXX_Clang_Tidy = $(CLANG_TIDY) $(Clang_Tidy_Options) $(call Clang_Tidy_Files,$^) -- $(CXXCOMPILE) -x c++
+CC_Clang_Tidy = $(CLANG_TIDY) $(Clang_Tidy_Options) $(call Clang_Tidy_Files,$^) -- $(COMPILE) -x c

--- a/cmd/traffic_cop/Makefile.am
+++ b/cmd/traffic_cop/Makefile.am
@@ -40,3 +40,8 @@ traffic_cop_LDADD = \
   $(top_builddir)/lib/ts/libtsutil.la \
   $(top_builddir)/lib/records/librecords_cop.a \
   @LIBRESOLV@
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/cmd/traffic_crashlog/Makefile.am
+++ b/cmd/traffic_crashlog/Makefile.am
@@ -43,3 +43,8 @@ traffic_crashlog_LDADD = \
   $(top_builddir)/mgmt/api/libtsmgmt.la \
   $(top_builddir)/lib/ts/libtsutil.la \
   @LIBTCL@ @HWLOC_LIBS@
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/cmd/traffic_ctl/Makefile.am
+++ b/cmd/traffic_ctl/Makefile.am
@@ -39,3 +39,8 @@ traffic_ctl_LDADD = \
   $(top_builddir)/mgmt/api/libtsmgmt.la \
   $(top_builddir)/lib/ts/libtsutil.la \
   @LIBRESOLV@ @LIBTCL@
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/cmd/traffic_layout/Makefile.am
+++ b/cmd/traffic_layout/Makefile.am
@@ -39,3 +39,8 @@ traffic_layout_LDADD = \
   $(top_builddir)/proxy/shared/libUglyLogStubs.a \
   $(top_builddir)/lib/ts/libtsutil.la \
   @LIBTCL@ @HWLOC_LIBS@
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/cmd/traffic_manager/Makefile.am
+++ b/cmd/traffic_manager/Makefile.am
@@ -81,3 +81,8 @@ traffic_manager_LDADD += \
   $(top_builddir)/lib/tsconfig/libtsconfig.la \
   @OPENSSL_LIBS@
 endif
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/cmd/traffic_top/Makefile.am
+++ b/cmd/traffic_top/Makefile.am
@@ -39,3 +39,8 @@ traffic_top_LDADD = \
   @CURL_LIBS@ @CURSES_LIB@
 
 endif
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/cmd/traffic_via/Makefile.am
+++ b/cmd/traffic_via/Makefile.am
@@ -38,3 +38,8 @@ traffic_via_LDADD = \
 
 TESTS = \
   test_traffic_via
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/cmd/traffic_wccp/Makefile.am
+++ b/cmd/traffic_wccp/Makefile.am
@@ -39,3 +39,8 @@ traffic_wccp_LDADD = \
   $(top_builddir)/lib/wccp/libwccp.a \
   $(top_builddir)/lib/ts/libtsutil.la \
   @OPENSSL_LIBS@
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/configure.ac
+++ b/configure.ac
@@ -41,10 +41,15 @@ AC_CONFIG_AUX_DIR([build/_aux])
 AC_CONFIG_SRCDIR([proxy/Main.cc])
 AC_CONFIG_MACRO_DIR([build])
 
-AM_INIT_AUTOMAKE([-Wall -Werror tar-ustar foreign no-installinfo no-installman subdir-objects 1.9.2])
+# NOTE: we turn off portability warnings because the clang-tidy targets use
+# GNU make extensions to filter the sources list.
+AM_INIT_AUTOMAKE([-Wall -Werror -Wno-portability tar-ustar foreign no-installinfo no-installman subdir-objects 1.9.2])
 
 # See discussion at https://autotools.io/automake/maintainer.html.
 AM_MAINTAINER_MODE([enable])
+
+# Enable a recursive "tidy" rule for clang-tidy.
+AM_EXTRA_RECURSIVE_TARGETS([tidy])
 
 AC_CONFIG_HEADERS([lib/ink_autoconf.h])
 
@@ -694,6 +699,11 @@ AC_ARG_VAR(RPATH, [path to be added to rpath])
 AC_ARG_VAR(SPHINXBUILD, [the sphinx-build documentation generator])
 AC_ARG_VAR(SPHINXOPTS, [additional sphinx-build options])
 AC_CHECK_PROG([SPHINXBUILD], [sphinx-build], [sphinx-build], [false])
+
+AC_ARG_VAR([CLANG_TIDY], [clang-tidy command])
+
+# Default CLANG_TIDY to "clang-tidy", or "false" if it is not present.
+AC_PATH_PROG([CLANG_TIDY], [clang-tidy],[false])
 
 AC_SUBST(TS_MAN1_MANPAGES)
 AC_SUBST(TS_MAN3_MANPAGES)

--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -89,3 +89,8 @@ version_la_SOURCES = version/version.c
 #
 # redirect_1_la_SOURCES = redirect-1/redirect-1.c
 # session_1_la_SOURCES = session-1/session-1.c
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/iocore/Makefile.am
+++ b/iocore/Makefile.am
@@ -17,3 +17,8 @@
 #  limitations under the License.
 
 SUBDIRS = eventsystem net aio dns hostdb utils cache cluster
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/iocore/aio/Makefile.am
+++ b/iocore/aio/Makefile.am
@@ -61,3 +61,8 @@ test_AIO_LDADD = \
   $(top_builddir)/lib/ts/libtsutil.la \
   $(top_builddir)/proxy/shared/libUglyLogStubs.a \
   @LIBTCL@ @HWLOC_LIBS@
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/iocore/cache/Makefile.am
+++ b/iocore/cache/Makefile.am
@@ -65,3 +65,8 @@ libinkcache_a_SOURCES = \
   RamCacheLRU.cc \
   Store.cc \
   $(ADD_SRC)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/iocore/cluster/Makefile.am
+++ b/iocore/cluster/Makefile.am
@@ -57,3 +57,8 @@ libinkcluster_a_SOURCES = \
 #test_Cluster_SOURCES = \
 #  test_I_Cluster.cc \
 #  test_P_Cluster.cc
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/iocore/dns/Makefile.am
+++ b/iocore/dns/Makefile.am
@@ -47,3 +47,8 @@ libinkdns_a_SOURCES = \
 #test_UNUSED_SOURCES = \
 #  test_I_DNS.cc \
 #  test_P_DNS.cc
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/iocore/eventsystem/Makefile.am
+++ b/iocore/eventsystem/Makefile.am
@@ -119,3 +119,8 @@ test_Event_LDFLAGS = $(test_LD_FLAGS)
 
 test_Buffer_LDADD = $(test_LD_ADD)
 test_Event_LDADD = $(test_LD_ADD)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/iocore/hostdb/Makefile.am
+++ b/iocore/hostdb/Makefile.am
@@ -31,8 +31,6 @@ EXTRA_DIST = I_HostDB.h
 noinst_LIBRARIES = libinkhostdb.a
 
 libinkhostdb_a_SOURCES = \
-  I_SplitDNS.h \
-  I_SplitDNSProcessor.h \
   HostDB.cc \
   I_HostDB.h \
   I_HostDBProcessor.h \
@@ -85,3 +83,8 @@ test_RefCountCache_CPPFLAGS = $(test_CPP_FLAGS)
 test_RefCountCache_LDFLAGS = $(test_LD_FLAGS)
 
 test_RefCountCache_LDADD = $(test_LD_ADD)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/iocore/net/Makefile.am
+++ b/iocore/net/Makefile.am
@@ -130,3 +130,8 @@ if BUILD_TESTS
      NetVCTest.cc \
      P_NetVCTest.h
 endif
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/iocore/utils/Makefile.am
+++ b/iocore/utils/Makefile.am
@@ -30,3 +30,8 @@ libinkutils_a_SOURCES = \
   Machine.cc \
   OneWayMultiTunnel.cc \
   OneWayTunnel.cc
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/lib/atscppapi/examples/Makefile.am
+++ b/lib/atscppapi/examples/Makefile.am
@@ -16,6 +16,7 @@
 #  limitations under the License.
 
 include $(top_srcdir)/build/plugins.mk
+include $(top_srcdir)/build/tidy.mk
 
 plugins = \
 	AsyncHttpFetch.la \
@@ -98,3 +99,6 @@ TimeoutExamplePlugin_la_LIBADD = $(libatscppai)
 TransactionHookPlugin_la_LIBADD = $(libatscppai)
 boom_la_LIBADD = $(libatscppai)
 intercept_la_LIBADD = $(libatscppai)
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/lib/atscppapi/src/Makefile.am
+++ b/lib/atscppapi/src/Makefile.am
@@ -55,33 +55,39 @@ libatscppapi_la_SOURCES = GlobalPlugin.cc \
 library_includedir=$(includedir)/atscppapi
 base_include_folder = $(top_srcdir)/$(subdir)/include/atscppapi
 
-library_include_HEADERS = $(base_include_folder)/GlobalPlugin.h \
-			  $(base_include_folder)/Plugin.h \
-			  $(base_include_folder)/PluginInit.h \
-			  $(base_include_folder)/Transaction.h \
-			  $(base_include_folder)/TransactionPlugin.h \
-			  $(base_include_folder)/HttpMethod.h \
-			  $(base_include_folder)/HttpStatus.h \
-			  $(base_include_folder)/HttpVersion.h \
-			  $(base_include_folder)/Headers.h \
-			  $(base_include_folder)/Request.h \
-			  $(base_include_folder)/CaseInsensitiveStringComparator.h \
-			  $(base_include_folder)/ClientRequest.h \
-	 		  $(base_include_folder)/Url.h \
-		 	  $(base_include_folder)/Response.h \
-			  $(base_include_folder)/utils.h \
-			  $(base_include_folder)/TransformationPlugin.h \
-			  $(base_include_folder)/Logger.h \
-			  $(base_include_folder)/noncopyable.h \
-			  $(base_include_folder)/Stat.h \
-			  $(base_include_folder)/Mutex.h \
-			  $(base_include_folder)/RemapPlugin.h \
-			  $(base_include_folder)/Async.h \
-			  $(base_include_folder)/AsyncHttpFetch.h \
-			  $(base_include_folder)/GzipDeflateTransformation.h \
-			  $(base_include_folder)/GzipInflateTransformation.h \
-			  $(base_include_folder)/AsyncTimer.h \
-			  $(base_include_folder)/InterceptPlugin.h
+library_include_HEADERS = \
+	$(base_include_folder)/GlobalPlugin.h \
+	$(base_include_folder)/Plugin.h \
+	$(base_include_folder)/PluginInit.h \
+	$(base_include_folder)/Transaction.h \
+	$(base_include_folder)/TransactionPlugin.h \
+	$(base_include_folder)/HttpMethod.h \
+	$(base_include_folder)/HttpStatus.h \
+	$(base_include_folder)/HttpVersion.h \
+	$(base_include_folder)/Headers.h \
+	$(base_include_folder)/Request.h \
+	$(base_include_folder)/CaseInsensitiveStringComparator.h \
+	$(base_include_folder)/ClientRequest.h \
+	$(base_include_folder)/Url.h \
+	$(base_include_folder)/Response.h \
+	$(base_include_folder)/utils.h \
+	$(base_include_folder)/TransformationPlugin.h \
+	$(base_include_folder)/Logger.h \
+	$(base_include_folder)/noncopyable.h \
+	$(base_include_folder)/Stat.h \
+	$(base_include_folder)/Mutex.h \
+	$(base_include_folder)/RemapPlugin.h \
+	$(base_include_folder)/Async.h \
+	$(base_include_folder)/AsyncHttpFetch.h \
+	$(base_include_folder)/GzipDeflateTransformation.h \
+	$(base_include_folder)/GzipInflateTransformation.h \
+	$(base_include_folder)/AsyncTimer.h \
+	$(base_include_folder)/InterceptPlugin.h
 
 library_include_HEADERS += \
-			  $(top_builddir)/$(subdir)/include/atscppapi/shared_ptr.h
+	$(top_builddir)/$(subdir)/include/atscppapi/shared_ptr.h
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/lib/bindings/Makefile.am
+++ b/lib/bindings/Makefile.am
@@ -16,6 +16,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+include $(top_srcdir)/build/tidy.mk
+
 AM_CPPFLAGS = \
   $(LUAJIT_CPPFLAGS) \
   -I$(top_srcdir)/lib \
@@ -36,3 +38,5 @@ libbindings_la_SOURCES = \
   repl.cc \
   repl.h
 
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/lib/records/Makefile.am
+++ b/lib/records/Makefile.am
@@ -16,6 +16,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+include $(top_srcdir)/build/tidy.mk
+
 AM_CPPFLAGS = \
   -I$(top_srcdir)/iocore/eventsystem \
   -I$(top_srcdir)/iocore/utils \
@@ -67,3 +69,6 @@ librecords_cop_a_SOURCES = \
   RecConfigParse.cc \
   RecFile.cc \
   RecDebug.cc
+
+tidy-local: $(sort $(DIST_SOURCES))
+	$(CXX_Clang_Tidy)

--- a/lib/ts/Makefile.am
+++ b/lib/ts/Makefile.am
@@ -16,6 +16,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+include $(top_srcdir)/build/tidy.mk
+
 library_includedir=$(includedir)/ts
 
 library_include_HEADERS = apidefs.h
@@ -242,3 +244,7 @@ CompileParseRules_SOURCES = CompileParseRules.cc
 
 clean-local:
 	rm -f ParseRulesCType ParseRulesCTypeToLower ParseRulesCTypeToUpper
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)
+

--- a/lib/tsconfig/Makefile.am
+++ b/lib/tsconfig/Makefile.am
@@ -68,3 +68,8 @@ test_tsconfig_LDADD = libtsconfig.la ../ts/libtsutil.la
 # it more easily in C++.
 TsConfigGrammar.hpp: TsConfigGrammar.h BisonHeaderToC++.sed
 	$(SED) -f $(srcdir)/BisonHeaderToC++.sed $(srcdir)/TsConfigGrammar.h > $@
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/lib/wccp/Makefile.am
+++ b/lib/wccp/Makefile.am
@@ -17,6 +17,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+include $(top_srcdir)/build/tidy.mk
+
 AM_CPPFLAGS = \
   -I$(top_srcdir)/lib \
   -I$(top_srcdir)/proxy/api/ts
@@ -41,3 +43,6 @@ libwccp_a_SOURCES = \
 #   wccp-test-cache.cc
 
 # test_cache_LDADD = $(LDADD) -L$(top_builddir)/lib/tsconfig -ltsconfig -L$(top_builddir)/lib/wccp -lwccp -L$(top_builddir)/lib/ts -ltsutil
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/mgmt/Makefile.am
+++ b/mgmt/Makefile.am
@@ -76,3 +76,8 @@ libmgmt_lm_la_LIBADD = \
 libmgmt_p_la_LIBADD = \
   libmgmt_c.la \
   $(top_builddir)/mgmt/utils/libutils_p.la
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/mgmt/api/Makefile.am
+++ b/mgmt/api/Makefile.am
@@ -17,6 +17,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+include $(top_srcdir)/build/tidy.mk
+
 SUBDIRS = include
 
 AM_CPPFLAGS = \
@@ -88,3 +90,6 @@ traffic_api_cli_remote_LDADD = \
   libtsmgmt.la \
   $(top_builddir)/lib/ts/libtsutil.la \
   @LIBTCL@ @OPENSSL_LIBS@
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/mgmt/cluster/Makefile.am
+++ b/mgmt/cluster/Makefile.am
@@ -17,6 +17,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+include $(top_srcdir)/build/tidy.mk
+
 AM_CPPFLAGS = \
   -I$(top_srcdir)/lib/records \
   -I$(top_srcdir)/mgmt \
@@ -31,3 +33,6 @@ libcluster_la_SOURCES = \
   ClusterCom.h \
   VMap.cc \
   VMap.h
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/mgmt/utils/Makefile.am
+++ b/mgmt/utils/Makefile.am
@@ -63,3 +63,8 @@ test_marshall_SOURCES = test_marshall.cc
 test_marshall_LDADD = \
   libutils_p.la \
   $(top_builddir)/lib/ts/libtsutil.la
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/cacheurl/Makefile.am
+++ b/plugins/cacheurl/Makefile.am
@@ -19,3 +19,8 @@ include $(top_srcdir)/build/plugins.mk
 pkglib_LTLIBRARIES = cacheurl.la
 cacheurl_la_SOURCES = cacheurl.cc
 cacheurl_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/conf_remap/Makefile.am
+++ b/plugins/conf_remap/Makefile.am
@@ -19,3 +19,8 @@ include $(top_srcdir)/build/plugins.mk
 pkglib_LTLIBRARIES = conf_remap.la
 conf_remap_la_SOURCES = conf_remap.cc
 conf_remap_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/Makefile.am
+++ b/plugins/experimental/Makefile.am
@@ -64,3 +64,8 @@ endif
 if HAS_KYOTOCABINET
   SUBDIRS += cache_key_genid
 endif
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/acme/Makefile.am
+++ b/plugins/experimental/acme/Makefile.am
@@ -19,3 +19,8 @@ include $(top_srcdir)/build/plugins.mk
 pkglib_LTLIBRARIES = acme.la
 acme_la_SOURCES = acme.c
 acme_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CC_Clang_Tidy)

--- a/plugins/experimental/authproxy/Makefile.am
+++ b/plugins/experimental/authproxy/Makefile.am
@@ -20,3 +20,8 @@ pkglib_LTLIBRARIES = authproxy.la
 authproxy_la_SOURCES = authproxy.cc utils.cc utils.h
 authproxy_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
 
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/background_fetch/Makefile.am
+++ b/plugins/experimental/background_fetch/Makefile.am
@@ -19,3 +19,8 @@ include $(top_srcdir)/build/plugins.mk
 pkglib_LTLIBRARIES = background_fetch.la
 background_fetch_la_SOURCES = background_fetch.cc headers.cc rules.cc configs.cc
 background_fetch_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/balancer/Makefile.am
+++ b/plugins/experimental/balancer/Makefile.am
@@ -20,3 +20,8 @@ pkglib_LTLIBRARIES = balancer.la
 balancer_la_SOURCES = balancer.cc roundrobin.cc hash.cc balancer.h
 balancer_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
 
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/buffer_upload/Makefile.am
+++ b/plugins/experimental/buffer_upload/Makefile.am
@@ -19,3 +19,8 @@ include $(top_srcdir)/build/plugins.mk
 pkglib_LTLIBRARIES = buffer_upload.la
 buffer_upload_la_SOURCES = buffer_upload.cc
 buffer_upload_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/cache_key_genid/Makefile.am
+++ b/plugins/experimental/cache_key_genid/Makefile.am
@@ -20,3 +20,8 @@ pkglib_LTLIBRARIES = cache_key_genid.la
 cache_key_genid_la_SOURCES = cache_key_genid.c
 cache_key_genid_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS) $(LIB_KYOTOCABINET)
 
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CC_Clang_Tidy)

--- a/plugins/experimental/cache_promote/Makefile.am
+++ b/plugins/experimental/cache_promote/Makefile.am
@@ -19,3 +19,8 @@ include $(top_srcdir)/build/plugins.mk
 pkglib_LTLIBRARIES = cache_promote.la
 cache_promote_la_SOURCES = cache_promote.cc
 cache_promote_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/cache_range_requests/Makefile.am
+++ b/plugins/experimental/cache_range_requests/Makefile.am
@@ -19,3 +19,8 @@ include $(top_srcdir)/build/plugins.mk
 pkglib_LTLIBRARIES = cache_range_requests.la
 cache_range_requests_la_SOURCES = cache_range_requests.cc
 cache_range_requests_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/cachekey/Makefile.am
+++ b/plugins/experimental/cachekey/Makefile.am
@@ -23,3 +23,8 @@ cachekey_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
 VIRTUALENV_DIR = ../../../ci/tsqa/virtualenv
 tsqa: $(VIRTUALENV_DIR)
 	@. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/nosetests --with-xunit -sv --logging-level=INFO
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/channel_stats/Makefile.am
+++ b/plugins/experimental/channel_stats/Makefile.am
@@ -19,3 +19,8 @@ include $(top_srcdir)/build/plugins.mk
 pkglib_LTLIBRARIES = channel_stats.la
 channel_stats_la_SOURCES = channel_stats.cc
 channel_stats_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/collapsed_connection/Makefile.am
+++ b/plugins/experimental/collapsed_connection/Makefile.am
@@ -19,3 +19,8 @@ include $(top_srcdir)/build/plugins.mk
 pkglib_LTLIBRARIES = collapsed_connection.la
 collapsed_connection_la_SOURCES = collapsed_connection.cc MurmurHash3.cc
 collapsed_connection_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/collapsed_forwarding/Makefile.am
+++ b/plugins/experimental/collapsed_forwarding/Makefile.am
@@ -19,3 +19,8 @@ include $(top_srcdir)/build/plugins.mk
 pkglib_LTLIBRARIES = collapsed_forwarding.la
 collapsed_forwarding_la_SOURCES = collapsed_forwarding.cc
 collapsed_forwarding_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/epic/Makefile.am
+++ b/plugins/experimental/epic/Makefile.am
@@ -20,3 +20,8 @@ pkglib_LTLIBRARIES = epic.la
 epic_la_SOURCES = epic.cc
 epic_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
 
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/escalate/Makefile.am
+++ b/plugins/experimental/escalate/Makefile.am
@@ -20,3 +20,8 @@ pkglib_LTLIBRARIES = escalate.la
 escalate_la_SOURCES = escalate.cc
 escalate_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
 
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/esi/Makefile.am
+++ b/plugins/experimental/esi/Makefile.am
@@ -102,3 +102,8 @@ TESTS = $(check_PROGRAMS)
 
 test:: $(TESTS)
 	for f in $(TESTS) ; do ./$$f; if [ $$? -ne 0 ]; then break; fi done
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/generator/Makefile.am
+++ b/plugins/experimental/generator/Makefile.am
@@ -20,3 +20,8 @@ pkglib_LTLIBRARIES = generator.la
 generator_la_SOURCES = generator.cc
 generator_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
 
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/geoip_acl/Makefile.am
+++ b/plugins/experimental/geoip_acl/Makefile.am
@@ -20,3 +20,8 @@ pkglib_LTLIBRARIES = geoip_acl.la
 geoip_acl_la_SOURCES = acl.cc geoip_acl.cc
 geoip_acl_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
 geoip_acl_la_LIBADD = $(GEO_LIBS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/header_normalize/Makefile.am
+++ b/plugins/experimental/header_normalize/Makefile.am
@@ -19,3 +19,8 @@ include $(top_srcdir)/build/plugins.mk
 pkglib_LTLIBRARIES = header_normalize.la
 header_normalize_la_SOURCES = header_normalize.cc
 header_normalize_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/hipes/Makefile.am
+++ b/plugins/experimental/hipes/Makefile.am
@@ -20,3 +20,8 @@ pkglib_LTLIBRARIES = hipes.la
 
 hipes_la_SOURCES = hipes.cc
 hipes_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CC_Clang_Tidy)

--- a/plugins/experimental/inliner/Makefile.am
+++ b/plugins/experimental/inliner/Makefile.am
@@ -31,3 +31,8 @@ inliner_la_SOURCES = \
 
 inliner_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
 
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/memcache/Makefile.am
+++ b/plugins/experimental/memcache/Makefile.am
@@ -33,3 +33,8 @@ tsmemcache_la_SOURCES = \
   tsmemcache.cc
 
 tsmemcache_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/memcached_remap/Makefile.am
+++ b/plugins/experimental/memcached_remap/Makefile.am
@@ -26,3 +26,8 @@ memcached_remap_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
 memcached_remap_la_LIBADD = $(LIBMEMCACHED_LIBS)
 
 endif
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/metalink/Makefile.am
+++ b/plugins/experimental/metalink/Makefile.am
@@ -19,3 +19,8 @@ include $(top_srcdir)/build/plugins.mk
 pkglib_LTLIBRARIES = metalink.la
 metalink_la_SOURCES = metalink.cc
 metalink_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/mp4/Makefile.am
+++ b/plugins/experimental/mp4/Makefile.am
@@ -19,3 +19,8 @@ include $(top_srcdir)/build/plugins.mk
 pkglib_LTLIBRARIES = mp4.la
 mp4_la_SOURCES = mp4.cc mp4_common.h mp4_meta.cc mp4_meta.h
 mp4_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/multiplexer/Makefile.am
+++ b/plugins/experimental/multiplexer/Makefile.am
@@ -30,3 +30,8 @@ multiplexer_la_SOURCES = \
   ts.cc
 
 multiplexer_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/mysql_remap/Makefile.am
+++ b/plugins/experimental/mysql_remap/Makefile.am
@@ -30,3 +30,8 @@ libmysql_remap_la_SOURCES = \
 
 mysql_remap_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS) $(LIB_MYSQLCLIENT)
 mysql_remap_la_LIBADD = libmysql_remap.la
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CC_Clang_Tidy)

--- a/plugins/experimental/regex_revalidate/Makefile.am
+++ b/plugins/experimental/regex_revalidate/Makefile.am
@@ -19,3 +19,8 @@ include $(top_srcdir)/build/plugins.mk
 pkglib_LTLIBRARIES = regex_revalidate.la
 regex_revalidate_la_SOURCES = regex_revalidate.c
 regex_revalidate_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/remap_stats/Makefile.am
+++ b/plugins/experimental/remap_stats/Makefile.am
@@ -23,3 +23,8 @@ remap_stats_la_SOURCES = remap_stats.c
 remap_stats_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
 
 endif
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CC_Clang_Tidy)

--- a/plugins/experimental/s3_auth/Makefile.am
+++ b/plugins/experimental/s3_auth/Makefile.am
@@ -19,3 +19,8 @@ include $(top_srcdir)/build/plugins.mk
 pkglib_LTLIBRARIES = s3_auth.la
 s3_auth_la_SOURCES = s3_auth.cc
 s3_auth_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/ssl_cert_loader/Makefile.am
+++ b/plugins/experimental/ssl_cert_loader/Makefile.am
@@ -23,3 +23,8 @@ pkglib_LTLIBRARIES = ssl_cert_loader.la
 ssl_cert_loader_la_SOURCES = ssl-cert-loader.cc domain-tree.cc
 ssl_cert_loader_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
 ssl_cert_loader_la_LIBADD = $(top_builddir)/lib/tsconfig/libtsconfig.la
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/sslheaders/Makefile.am
+++ b/plugins/experimental/sslheaders/Makefile.am
@@ -37,3 +37,8 @@ test_sslheaders_LDADD = \
   @OPENSSL_LIBS@
 
 TESTS = $(check_PROGRAMS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/stale_while_revalidate/Makefile.am
+++ b/plugins/experimental/stale_while_revalidate/Makefile.am
@@ -19,3 +19,8 @@ include $(top_srcdir)/build/plugins.mk
 pkglib_LTLIBRARIES = stale_while_revalidate.la
 stale_while_revalidate_la_SOURCES = stale_while_revalidate.c
 stale_while_revalidate_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/stream_editor/Makefile.am
+++ b/plugins/experimental/stream_editor/Makefile.am
@@ -19,3 +19,8 @@ include $(top_srcdir)/build/plugins.mk
 pkglib_LTLIBRARIES = stream_editor.la
 stream_editor_la_SOURCES = stream_editor.cc
 stream_editor_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/ts_lua/Makefile.am
+++ b/plugins/experimental/ts_lua/Makefile.am
@@ -52,3 +52,8 @@ tslua_la_SOURCES = \
   ts_lua_constant.c
 
 tslua_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CC_Clang_Tidy)

--- a/plugins/experimental/url_sig/Makefile.am
+++ b/plugins/experimental/url_sig/Makefile.am
@@ -19,3 +19,8 @@ include $(top_srcdir)/build/plugins.mk
 pkglib_LTLIBRARIES = url_sig.la
 url_sig_la_SOURCES = url_sig.c
 url_sig_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/webp_transform/Makefile.am
+++ b/plugins/experimental/webp_transform/Makefile.am
@@ -31,3 +31,8 @@ WebpTransform_la_LDFLAGS = \
 WebpTransform_la_LIBADD = \
   -latscppapi \
   $(LIBMAGICKCPP_LIBS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/experimental/xdebug/Makefile.am
+++ b/plugins/experimental/xdebug/Makefile.am
@@ -20,3 +20,8 @@ pkglib_LTLIBRARIES = xdebug.la
 xdebug_la_SOURCES = xdebug.cc
 xdebug_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
 
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/gzip/Makefile.am
+++ b/plugins/gzip/Makefile.am
@@ -19,3 +19,8 @@ include $(top_srcdir)/build/plugins.mk
 pkglib_LTLIBRARIES = gzip.la
 gzip_la_SOURCES = gzip.cc configuration.cc misc.cc
 gzip_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/header_rewrite/Makefile.am
+++ b/plugins/header_rewrite/Makefile.am
@@ -38,3 +38,8 @@ header_rewrite_la_LIBADD = $(GEO_LIBS)
 bin_PROGRAMS = header_rewrite_test
 header_rewrite_test_SOURCES = parser.cc header_rewrite_test.cc
 header_rewrite_test_CXXFLAGS = $(AM_CXXFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/healthchecks/Makefile.am
+++ b/plugins/healthchecks/Makefile.am
@@ -23,3 +23,8 @@ healthchecks_la_SOURCES = healthchecks.c
 healthchecks_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
 
 endif
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CC_Clang_Tidy)

--- a/plugins/libloader/Makefile.am
+++ b/plugins/libloader/Makefile.am
@@ -19,3 +19,8 @@ include $(top_srcdir)/build/plugins.mk
 pkglib_LTLIBRARIES = libloader.la
 libloader_la_SOURCES = libloader.c
 libloader_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/regex_remap/Makefile.am
+++ b/plugins/regex_remap/Makefile.am
@@ -19,3 +19,8 @@ include $(top_srcdir)/build/plugins.mk
 pkglib_LTLIBRARIES = regex_remap.la
 regex_remap_la_SOURCES = regex_remap.cc
 regex_remap_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/stats_over_http/Makefile.am
+++ b/plugins/stats_over_http/Makefile.am
@@ -19,3 +19,8 @@ include $(top_srcdir)/build/plugins.mk
 pkglib_LTLIBRARIES = stats_over_http.la
 stats_over_http_la_SOURCES = stats_over_http.c
 stats_over_http_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/plugins/tcpinfo/Makefile.am
+++ b/plugins/tcpinfo/Makefile.am
@@ -20,3 +20,8 @@ pkglib_LTLIBRARIES = tcpinfo.la
 tcpinfo_la_SOURCES = tcpinfo.cc
 tcpinfo_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
 
+
+include $(top_srcdir)/build/tidy.mk
+
+tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/proxy/Makefile.am
+++ b/proxy/Makefile.am
@@ -16,6 +16,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+include $(top_srcdir)/build/tidy.mk
+
 # Note that hdrs is targeted from ../Makefile.am
 SUBDIRS = congest http http2 spdy logging config
 noinst_LIBRARIES =
@@ -278,6 +280,9 @@ test_xml_parser_LDADD = \
   @LIBTCL@
 
 versiondir = $(pkgsysconfdir)
+
+tidy-local: $(noinst_HEADERS) $(traffic_server_SOURCES)
+	$(CXX_Clang_Tidy)
 
 install-data-local:
 	if [ `id -un` != "root" ]; then \

--- a/proxy/hdrs/Makefile.am
+++ b/proxy/hdrs/Makefile.am
@@ -16,6 +16,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+include $(top_srcdir)/build/tidy.mk
+
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
   -I$(top_srcdir)/lib \
@@ -79,3 +81,6 @@ test_mime_SOURCES = test_mime.cc
 #test_UNUSED_SOURCES = \
 #  test_header.cc \
 #  test_urlhash.cc
+
+tidy-local: $(libhdrs_a_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/proxy/http/Makefile.am
+++ b/proxy/http/Makefile.am
@@ -16,6 +16,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+include $(top_srcdir)/build/tidy.mk
+
 SUBDIRS = remap
 
 AM_CPPFLAGS = \
@@ -78,6 +80,9 @@ if BUILD_TESTS
   libhttp_a_SOURCES += HttpUpdateTester.cc \
     RegressionHttpTransact.cc
 endif
+
+tidy-local: $(libhttp_a_SOURCES) $(noinst_HEADERS)
+	$(CXX_Clang_Tidy)
 
 #test_UNUSED_SOURCES = \
 #  TestHttpTransact.cc \

--- a/proxy/http/remap/Makefile.am
+++ b/proxy/http/remap/Makefile.am
@@ -16,6 +16,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+include $(top_srcdir)/build/tidy.mk
+
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
   -I$(top_srcdir)/lib \
@@ -47,3 +49,6 @@ libhttp_remap_a_SOURCES = \
   UrlMappingPathIndex.h \
   UrlRewrite.cc \
   UrlRewrite.h
+
+tidy-local: $(libhttp_remap_a_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/proxy/http2/Makefile.am
+++ b/proxy/http2/Makefile.am
@@ -16,6 +16,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+include $(top_srcdir)/build/tidy.mk
+
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
   -I$(top_srcdir)/proxy/api/ts \
@@ -95,3 +97,7 @@ test_HPACK_SOURCES = \
   HuffmanCodec.h \
   HPACK.cc \
   HPACK.h
+
+tidy-local: $(libhttp2_a_SOURCES) $(test_Huffmancode_SOURCES) \
+		$(test_Http2DependencyTree_SOURCES) $(test_HPACK_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/proxy/logging/Makefile.am
+++ b/proxy/logging/Makefile.am
@@ -16,6 +16,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+include $(top_srcdir)/build/tidy.mk
+
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
   -I$(top_srcdir)/lib \
@@ -79,3 +81,6 @@ liblogcollation_a_SOURCES = \
 #test_UNUSED_SOURCES = \
 #  LogAccessTest.cc \
 #  LogAccessTest.h
+
+tidy-local: $(liblogging_a_SOURCES) $(liblogcollation_a_SOURCES) $(EXTRA_DIST)
+	$(CXX_Clang_Tidy)

--- a/proxy/shared/Makefile.am
+++ b/proxy/shared/Makefile.am
@@ -16,6 +16,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+include $(top_srcdir)/build/tidy.mk
+
 # Note that hdrs is targeted from ../Makefile.am
 noinst_LIBRARIES = \
   liberror.a \
@@ -50,3 +52,7 @@ libUglyLogStubs_a_SOURCES = \
 libxml_a_SOURCES = \
   InkXml.cc \
   InkXml.h
+
+tidy-local: $(liberror_a_SOURCES) $(libdiagsconfig_a_SOURCES) \
+		$(libUglyLogStubs_a_SOURCES) $(libxml_a_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/proxy/spdy/Makefile.am
+++ b/proxy/spdy/Makefile.am
@@ -16,6 +16,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+include $(top_srcdir)/build/tidy.mk
+
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
   -I$(top_srcdir)/proxy/api/ts \
@@ -46,3 +48,6 @@ libspdy_a_SOURCES += \
   SpdyCommon.cc \
   SpdyCommon.h
 endif
+
+tidy-local: $(libspdy_a_SOURCES)
+	$(CXX_Clang_Tidy)


### PR DESCRIPTION
Add a recursive tidy rule to run clang-tidy over all the source.
The mor recommended way to do this is to build a compilation database,
however the tools for doing that are not very portable, and the
compilation database doesn't easilt let you fix code in header
files.