### PR TITLE
TS-4608: Fix memory leak in ProxyAllocator.cc.

### DIFF
--- a/iocore/eventsystem/ProxyAllocator.cc
+++ b/iocore/eventsystem/ProxyAllocator.cc
@@ -28,16 +28,12 @@ int thread_freelist_low_watermark = 32;
 void *
 thread_alloc(Allocator &a, ProxyAllocator &l)
 {
-#if TS_USE_FREELIST
   if (l.freelist) {
     void *v = (void *)l.freelist;
     l.freelist = *(void **)l.freelist;
     --(l.allocated);
     return v;
   }
-#else
-  (void)l;
-#endif
   return a.alloc_void();
 }
 


### PR DESCRIPTION
This removes the pre-processor flag TS_USE_FREELIST which is not defined since commit e56d1f9eb6f55b0257d1fb758b773dea468159ee to make freelists a runtime option.