### PR TITLE
TS-4598 : Coverity Null-Check after deref in NetworkUtilsRemote.cc

### DIFF
--- a/mgmt/api/NetworkUtilsRemote.cc
+++ b/mgmt/api/NetworkUtilsRemote.cc
@@ -674,9 +674,7 @@ event_callback_thread(void *arg)
 
   func_q = create_queue();
   if (!func_q) {
-    if (event_notice) {
-      TSEventDestroy(event_notice);
-    }
+    TSEventDestroy(event_notice);
     return NULL;
   }
 


### PR DESCRIPTION
This is fixing Coverity issue CID 1237320.