### PR TITLE
TS-4629: Fix use of invalid iterator in ServerSessionPool::purge.

### DIFF
--- a/lib/ts/Map.h
+++ b/lib/ts/Map.h
@@ -1306,7 +1306,7 @@ public:
 
   /** Standard iterator for walking the table.
       This iterates over all elements.
-      @internal Iterator is end if m_value is NULL.
+      @internal Iterator is @a end if @a m_value is @c NULL.
    */
   struct iterator {
     Value *m_value;   ///< Current location.
@@ -1314,6 +1314,7 @@ public:
 
     iterator() : m_value(0), m_bucket(0) {}
     iterator &operator++();
+    iterator operator++(int);
     Value &operator*() { return *m_value; }
     Value *operator->() { return m_value; }
     bool
@@ -1493,6 +1494,13 @@ template <typename H> typename TSHashTable<H>::iterator &TSHashTable<H>::iterato
     }
   }
   return *this;
+}
+
+template <typename H> typename TSHashTable<H>::iterator TSHashTable<H>::iterator::operator++(int)
+{
+  iterator prev(*this);
+  ++*this;
+  return prev;
 }
 
 template <typename H>

--- a/proxy/http/HttpSessionManager.cc
+++ b/proxy/http/HttpSessionManager.cc
@@ -55,9 +55,10 @@ ServerSessionPool::ServerSessionPool() : Continuation(new_ProxyMutex()), m_ip_po
 void
 ServerSessionPool::purge()
 {
-  for (IPHashTable::iterator last = m_ip_pool.end(), spot = m_ip_pool.begin(); spot != last; ++spot) {
-    spot->do_io_close();
-  }
+  // @c do_io_close can free the instance which clears the intrusive links and breaks the iterator.
+  // Therefore @c do_io_close is called on a post-incremented iterator.
+  for (IPHashTable::iterator last = m_ip_pool.end(), spot = m_ip_pool.begin(); spot != last ; spot++->do_io_close())
+    ; // empty
   m_ip_pool.clear();
   m_host_pool.clear();
 }


### PR DESCRIPTION
Add postfix increment to IPHashTable::iterator.