### PR TITLE
TS-4633: Fix an erroneous warning message when reading the parent.con…

### DIFF
--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -629,13 +629,13 @@ ParentRecord::Init(matcher_line *line_info)
   // parent_retry may only be enabled if the parents are origin servers, parent_is_proxy is false.
   if (parent_is_proxy == true) {
     if (parent_retry > 0) {
+      Warning("%s disabling parent_retry on line %d because parent_is_proxy is true", modulePrefix, line_num);
       parent_retry = PARENT_RETRY_NONE;
       if (unavailable_server_retry_responses != NULL) {
         delete unavailable_server_retry_responses;
         unavailable_server_retry_responses = NULL;
       }
     }
-    Warning("%s disabling parent_retry on line %d because parent_is_proxy is true", modulePrefix, line_num);
   } else {
     // delete unavailable_server_retry_responses if unavailable_server_retry is not enabled.
     if (unavailable_server_retry_responses != NULL && !(parent_retry & PARENT_RETRY_UNAVAILABLE_SERVER)) {


### PR DESCRIPTION
An erroneous warning message is logged when at startup when reading the parent.config file:

"WARNING: <ParentSelection.cc:653 (Init)> [ParentSelection] disabling parent_retry on line 24 because parent_is_proxy is true"

This warning should only be logged when parent_retry is set in the parent.config and when parent_is_proxy is true.