### PR TITLE
TS-4632: Fix ParentSelection regressions on 6.2.x

### DIFF
--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -208,7 +208,6 @@ ParentConfigParams::nextParent(HttpRequestData *rdata, ParentResult *result)
   }
   Debug("parent_select", "ParentConfigParams::nextParent(): result->result: %d, tablePtr: %p, result->epoch: %p", result->result,
         tablePtr, result->epoch);
-  ink_release_assert(tablePtr == result->epoch);
 
   // Find the next parent in the array
   Debug("parent_select", "Calling selectParent() from nextParent");


### PR DESCRIPTION
Remove an ink_release_assert artifact not needed that causes ParentSelection::nextParent() to fail with an assertion error.