### PR TITLE
TS-4507: Fix SSN and TXN hook ordering.

### DIFF
--- a/proxy/ProxyClientSession.cc
+++ b/proxy/ProxyClientSession.cc
@@ -67,7 +67,7 @@ is_valid_hook(TSHttpHookID hookid)
 }
 
 void
-ProxyClientSession::destroy()
+ProxyClientSession::free()
 {
   if (schedule_event) {
     schedule_event->cancel();
@@ -137,7 +137,7 @@ ProxyClientSession::state_api_callout(int event, void *data)
 
   // coverity[unterminated_default]
   default:
-    ink_assert(false);
+    ink_release_assert(false);
   }
 
   return 0;
@@ -185,7 +185,7 @@ ProxyClientSession::handle_api_return(int event)
       vc->do_io_close();
       this->release_netvc();
     }
-    this->destroy();
+    free(); // You can now clean things up
     break;
   }
   default:

--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -43,7 +43,8 @@ class ProxyClientSession : public VConnection
 public:
   ProxyClientSession();
 
-  virtual void destroy();
+  virtual void destroy() = 0;
+  virtual void free();
   virtual void start() = 0;
 
   virtual void new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader, bool backdoor) = 0;
@@ -188,6 +189,7 @@ protected:
   int64_t con_id;
 
   Event *schedule_event;
+  bool in_destroy;
 
 private:
   APIHookScope api_scope;

--- a/proxy/ProxyClientTransaction.cc
+++ b/proxy/ProxyClientTransaction.cc
@@ -63,7 +63,7 @@ ProxyClientTransaction::release(IOBufferReader *r)
   DebugHttpTxn("[%" PRId64 "] session released by sm [%" PRId64 "]", parent ? parent->connection_id() : 0,
                current_reader ? current_reader->sm_id : 0);
 
-  current_reader = NULL; // Clear reference to SM
+  // current_reader = NULL; // Clear reference to SM
 
   // Pass along the release to the session
   if (parent) {
@@ -75,6 +75,16 @@ void
 ProxyClientTransaction::attach_server_session(HttpServerSession *ssession, bool transaction_done)
 {
   parent->attach_server_session(ssession, transaction_done);
+}
+
+void
+ProxyClientTransaction::destroy()
+{
+  if (current_reader) {
+    current_reader->ua_session = NULL;
+    current_reader             = NULL;
+  }
+  this->mutex.clear();
 }
 
 Action *

--- a/proxy/ProxyClientTransaction.h
+++ b/proxy/ProxyClientTransaction.h
@@ -174,11 +174,9 @@ public:
     return true;
   }
 
-  virtual void
-  destroy()
-  {
-    this->mutex.clear();
-  }
+  virtual void destroy();
+
+  virtual void transaction_done() = 0;
 
   ProxyClientSession *
   get_parent()

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -56,6 +56,7 @@ public:
 
   // Implement ProxyClientSession interface.
   virtual void destroy();
+  virtual void free();
 
   virtual void
   start()
@@ -92,7 +93,14 @@ public:
   virtual void
   release_netvc()
   {
-    client_vc = NULL;
+    // Make sure the vio's are also released to avoid
+    // later surprises in inactivity timeout
+    if (client_vc) {
+      client_vc->do_io_read(NULL, 0, NULL);
+      client_vc->do_io_write(NULL, 0, NULL);
+      client_vc->set_action(NULL);
+      client_vc = NULL;
+    }
   }
 
   int
@@ -187,7 +195,12 @@ private:
 
   MIOBuffer *read_buffer;
   IOBufferReader *sm_reader;
-  C_Read_State read_state;
+
+  /*
+   * Volatile should not be necessary, but there appears to be a bug in the 4.9 rhel gcc
+   * compiler that was using an old version of read_state to make decisions in really_destroy
+   */
+  volatile C_Read_State read_state;
 
   VIO *ka_vio;
   VIO *slave_ka_vio;

--- a/proxy/http/Http1ClientTransaction.cc
+++ b/proxy/http/Http1ClientTransaction.cc
@@ -62,3 +62,22 @@ Http1ClientTransaction::set_parent(ProxyClientSession *new_parent)
   }
   super::set_parent(new_parent);
 }
+
+void
+Http1ClientTransaction::transaction_done()
+{
+  current_reader = NULL;
+  // If the parent session is not in the closed state, the destroy will not occur.
+  if (parent) {
+    parent->destroy();
+  }
+}
+
+void
+Http1ClientTransaction::destroy()
+{
+  if (current_reader) {
+    current_reader->ua_session = NULL;
+    current_reader             = NULL;
+  }
+}

--- a/proxy/http/Http1ClientTransaction.h
+++ b/proxy/http/Http1ClientTransaction.h
@@ -55,10 +55,7 @@ public:
 
   // Don't destroy your elements.  Rely on the Http1ClientSession to clean up the
   // Http1ClientTransaction class as necessary
-  virtual void
-  destroy()
-  {
-  }
+  virtual void destroy();
 
   // Clean up the transaction elements when the ClientSession shuts down
   void
@@ -164,6 +161,7 @@ public:
     if (parent)
       parent->cancel_inactivity_timeout();
   }
+  void transaction_done();
 
 protected:
   uint16_t outbound_port;

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -910,11 +910,7 @@ HttpSM::state_watch_for_client_abort(int event, void *data)
       }
       ua_entry->eos = true;
     } else {
-      if (netvc) {
-        netvc->do_io_close();
-      }
       ua_session->do_io_close();
-      ua_session       = NULL;
       ua_buffer_reader = NULL;
       vc_table.cleanup_entry(ua_entry);
       ua_entry = NULL;
@@ -3007,9 +3003,8 @@ HttpSM::tunnel_handler_server(int event, HttpTunnelProducer *p)
       // Note: This is a hack. The correct solution is for the UA session to signal back to the SM
       // when the UA is about to be destroyed and clean up the pointer there. That should be done once
       // the TS-3612 changes are in place (and similarly for the server session).
-      if (ua_entry->in_tunnel) {
-        ua_session = NULL;
-      }
+      /*if (ua_entry->in_tunnel)
+        ua_session = NULL; */
 
       t_state.current.server->abort      = HttpTransact::ABORTED;
       t_state.client_info.keep_alive     = HTTP_NO_KEEPALIVE;
@@ -3325,12 +3320,11 @@ HttpSM::tunnel_handler_ua(int event, HttpTunnelConsumer *c)
     }
 
     ua_session->do_io_close();
-    ua_session = NULL;
   } else {
     ink_assert(ua_buffer_reader != NULL);
     ua_session->release(ua_buffer_reader);
     ua_buffer_reader = NULL;
-    ua_session       = NULL;
+    // ua_session       = NULL;
   }
 
   return 0;
@@ -6160,8 +6154,8 @@ HttpSM::setup_error_transfer()
   } else {
     DebugSM("http", "[setup_error_transfer] Now closing connection ...");
     vc_table.cleanup_entry(ua_entry);
-    ua_entry       = NULL;
-    ua_session     = NULL;
+    ua_entry = NULL;
+    // ua_session     = NULL;
     terminate_sm   = true;
     t_state.source = HttpTransact::SOURCE_INTERNAL;
   }
@@ -6775,7 +6769,6 @@ HttpSM::kill_this()
       plugin_tunnel = NULL;
     }
 
-    ua_session     = NULL;
     server_session = NULL;
 
     // So we don't try to nuke the state machine
@@ -6804,6 +6797,10 @@ HttpSM::kill_this()
   //   then the value of kill_this_async_done has changed so
   //   we must check it again
   if (kill_this_async_done == true) {
+    if (ua_session) {
+      ua_session->transaction_done();
+    }
+
     // In the async state, the plugin could have been
     // called resulting in the creation of a plugin_tunnel.
     // So it needs to be deleted now.

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -119,8 +119,11 @@ public:
       stream_list(),
       latest_streamid(0),
       client_streams_count(0),
+      total_client_streams_count(0),
       continued_stream_id(0),
-      _scheduled(false)
+      _scheduled(false),
+      fini_received(false),
+      recursion(0)
   {
     SET_HANDLER(&Http2ConnectionState::main_event_handler);
   }
@@ -169,6 +172,7 @@ public:
   Http2Stream *find_stream(Http2StreamId id) const;
   void restart_streams();
   void delete_stream(Http2Stream *stream);
+  void release_stream(Http2Stream *stream);
   void cleanup_streams();
 
   void update_initial_rwnd(Http2WindowSize new_size);
@@ -214,7 +218,13 @@ public:
   bool
   is_state_closed() const
   {
-    return ua_session == NULL;
+    return ua_session == NULL || fini_received;
+  }
+
+  bool
+  is_recursing() const
+  {
+    return recursion > 0;
   }
 
 private:
@@ -232,8 +242,10 @@ private:
   DLL<Http2Stream> stream_list;
   Http2StreamId latest_streamid;
 
-  // Counter for current acive streams which is started by client
+  // Counter for current active streams which is started by client
   uint32_t client_streams_count;
+  // Counter for current active streams and streams in the process of shutting down
+  uint32_t total_client_streams_count;
 
   // NOTE: Id of stream which MUST receive CONTINUATION frame.
   //   - [RFC 7540] 6.2 HEADERS
@@ -245,6 +257,8 @@ private:
   Http2StreamId continued_stream_id;
   IOVec continued_buffer;
   bool _scheduled;
+  bool fini_received;
+  int recursion;
 };
 
 #endif // __HTTP2_CONNECTION_STATE_H__

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -172,6 +172,7 @@ public:
   void update_read_request(int64_t read_len, bool send_update);
   bool update_write_request(IOBufferReader *buf_reader, int64_t write_len, bool send_update);
   void reenable(VIO *vio);
+  virtual void transaction_done();
   void send_response_body();
 
   // Stream level window size
@@ -211,13 +212,7 @@ public:
   bool response_initialize_data_handling();
   bool response_process_data();
   bool response_is_data_available() const;
-  // For Http2 releasing the transaction should go ahead and delete it
-  void
-  release(IOBufferReader *r)
-  {
-    current_reader = NULL; // State machine is on its own way down.
-    this->do_io_close();
-  }
+  void release(IOBufferReader *r);
 
   virtual bool
   allow_half_open() const


### PR DESCRIPTION
This change was motivated by dealing with ordering problems between SSN_CLOSE and TXN_CLOSE causing problems (crashes).  This we addressed as follows
  * The TXN_CLOSE is kicked off in the State Machine kill_this.  This is the point were we know that the TXN really is going away.  This is unchanged.  What this patch adds is a call to transaction_done to let the ClientTransaction know that TXN_CLOSE has completed so the calculation about whether is it time to execute SSN_CLOSE or not.  As such we cannot null out ua_session early.

* To support SSN_CLOSE accurately, we split the destroy logic into two parts: destroy and free.  Destroy commits to deleting the session and it kicks off the SSN_CLOSE plugin. free performs the final resource reclamation of the session object.

In addition this PR includes the following fixes.

* In ProxyClientSession::state_api_callout we schedule_in 10ms in the future if the plugin lock is not acquired. Saw ASAN use-after-free crashes when the Http2ClientSession is deleted but the schedule event remains and is triggered. Added a schedule_event member to track this case and cancel any outstanding schedule events on free.

* Cleaned up handling regular events at the same time as plugin events. The original code relied on the subclasses overriding handle_api_event to handle the regular events, but the handler only handled the TIMEOUT event. Changed that to augment the subclasses' main event handler to call out to state_api_callout in the event of the plugin events.


