### PR TITLE
TS-4472 Fixes http_current_active_client_connections_stat metric

### DIFF
--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -77,8 +77,7 @@ Http1ClientSession::Http1ClientSession()
     bound_ss(NULL),
     outbound_port(0),
     f_outbound_transparent(false),
-    f_transparent_passthrough(false),
-    m_active(false)
+    f_transparent_passthrough(false)
 {
 }
 
@@ -235,8 +234,8 @@ Http1ClientSession::do_io_close(int alerrno)
 {
   if (read_state == HCS_ACTIVE_READER) {
     HTTP_DECREMENT_DYN_STAT(http_current_client_transactions_stat);
-    if (m_active) {
-      m_active = false;
+    if (trans.m_active) {
+      trans.m_active = false;
       HTTP_DECREMENT_DYN_STAT(http_current_active_client_connections_stat);
     }
   }
@@ -475,8 +474,8 @@ Http1ClientSession::attach_server_session(HttpServerSession *ssession, bool tran
     ink_assert(ssession->get_netvc() != this->get_netvc());
 
     // handling potential keep-alive here
-    if (m_active) {
-      m_active = false;
+    if (trans.m_active) {
+      trans.m_active = false;
       HTTP_DECREMENT_DYN_STAT(http_current_active_client_connections_stat);
     }
     // Since this our slave, issue an IO to detect a close and

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -203,11 +203,6 @@ public:
   /// Transparently pass-through non-HTTP traffic.
   bool f_transparent_passthrough;
 
-  // for DI. An active connection is one that a request has
-  // been successfully parsed (PARSE_DONE) and it remains to
-  // be active until the transaction goes through or the client
-  // aborts.
-  bool m_active;
   Http1ClientTransaction trans;
 };
 


### PR DESCRIPTION
The issue here is that there are two m_active member variables, in
both Http1ClientSession and Http1ClientTransaction. However, the former
contains the latter, so this patch eliminates the m_active from the
session class, and then consistently sets and checks the m_active from
the http1ClientTransaction class.