### PR TITLE
TS-4649: Minor style improvement to the loggin system.

### DIFF
--- a/proxy/logging/Log.h
+++ b/proxy/logging/Log.h
@@ -404,6 +404,7 @@ public:
   // main interface
   static void init(int configFlags = 0);
   static void init_fields();
+
   inkcoreapi static bool
   transaction_logging_enabled()
   {
@@ -484,11 +485,16 @@ LogRollingEnabledIsValid(int enabled)
   return (enabled >= Log::NO_ROLLING || enabled < Log::INVALID_ROLLING_VALUE);
 }
 
-#define TraceIn(flag, ...) \
-  if (flag)                \
-  Log::trace_in(__VA_ARGS__)
-#define TraceOut(flag, ...) \
-  if (flag)                 \
-  Log::trace_out(__VA_ARGS__)
+#define TraceIn(flag, ...)        \
+  do {                            \
+    if (unlikely(flag))           \
+      Log::trace_in(__VA_ARGS__); \
+  } while (0)
+
+#define TraceOut(flag, ...)        \
+  do {                             \
+    if (unlikely(flag))            \
+      Log::trace_out(__VA_ARGS__); \
+  } while (0)
 
 #endif

--- a/proxy/logging/LogAccess.h
+++ b/proxy/logging/LogAccess.h
@@ -163,7 +163,7 @@ public:
   inkcoreapi virtual ~LogAccess() {}
   inkcoreapi virtual void init();
 
-  virtual LogEntryType entry_type() = 0;
+  virtual LogEntryType entry_type() const = 0;
 
   //
   // client -> proxy fields

--- a/proxy/logging/LogAccessHttp.h
+++ b/proxy/logging/LogAccessHttp.h
@@ -45,8 +45,9 @@ public:
   virtual ~LogAccessHttp();
 
   void init();
+
   LogEntryType
-  entry_type()
+  entry_type() const
   {
     return LOG_ENTRY_HTTP;
   }

--- a/proxy/logging/LogAccessICP.h
+++ b/proxy/logging/LogAccessICP.h
@@ -42,7 +42,7 @@ public:
   virtual ~LogAccessICP();
 
   LogEntryType
-  entry_type()
+  entry_type() const
   {
     return LOG_ENTRY_ICP;
   }

--- a/proxy/logging/LogBuffer.cc
+++ b/proxy/logging/LogBuffer.cc
@@ -522,7 +522,7 @@ LogBuffer::resolve_custom_entry(LogFieldList *fieldlist, char *printf_str, char 
         bool non_aggregate_timestamp = false;
 
         if (field->aggregate() == LogField::NO_AGGREGATE) {
-          char *sym = field->symbol();
+          const char *sym = field->symbol();
 
           if (strcmp(sym, "cqts") == 0) {
             char *ptr = (char *)&timestamp;

--- a/proxy/logging/LogBuffer.h
+++ b/proxy/logging/LogBuffer.h
@@ -153,12 +153,13 @@ public:
   void force_full();
 
   LogBufferHeader *
-  header()
+  header() const
   {
     return m_header;
   }
+
   long
-  expiration_time()
+  expiration_time() const
   {
     return m_expiration_time;
   }
@@ -167,10 +168,11 @@ public:
   void update_header_data();
 
   uint32_t
-  get_id()
+  get_id() const
   {
     return m_id;
   }
+
   LogObject *
   get_owner() const
   {
@@ -178,7 +180,6 @@ public:
   }
 
   LINK(LogBuffer, link);
-  ;
 
   // static variables
   static vint32 M_ID;

--- a/proxy/logging/LogCollationAccept.h
+++ b/proxy/logging/LogCollationAccept.h
@@ -26,6 +26,7 @@
 
 #include "P_EventSystem.h"
 #include "P_Net.h"
+
 struct LogCollationAccept : public Continuation {
 public:
   LogCollationAccept(int port);

--- a/proxy/logging/LogConfig.cc
+++ b/proxy/logging/LogConfig.cc
@@ -676,7 +676,7 @@ LogConfig::register_mgmt_callbacks()
   -------------------------------------------------------------------------*/
 
 bool
-LogConfig::space_to_write(int64_t bytes_to_write)
+LogConfig::space_to_write(int64_t bytes_to_write) const
 {
   int64_t config_space, partition_headroom;
   int64_t logical_space_used, physical_space_left;

--- a/proxy/logging/LogConfig.h
+++ b/proxy/logging/LogConfig.h
@@ -114,15 +114,16 @@ public:
   static void register_stat_callbacks();
   static void register_mgmt_callbacks();
 
-  bool space_to_write(int64_t bytes_to_write);
+  bool space_to_write(int64_t bytes_to_write) const;
 
   bool
   am_collation_host() const
   {
     return collation_mode == Log::COLLATION_HOST;
   }
+
   bool
-  space_is_short()
+  space_is_short() const
   {
     return !space_to_write(max_space_mb_headroom * LOG_MEGABYTE);
   };
@@ -141,7 +142,7 @@ public:
   static void *reconfigure_mgmt_variables(void *token, char *data_raw, int data_len);
 
   int
-  get_max_space_mb()
+  get_max_space_mb() const
   {
     return (use_orphan_log_space_value ? max_space_mb_for_orphan_logs : max_space_mb_for_logs);
   }

--- a/proxy/logging/LogField.cc
+++ b/proxy/logging/LogField.cc
@@ -36,10 +36,39 @@
 #include "LogAccess.h"
 #include "Log.h"
 
-const char *container_names[] = {"not-a-container", "cqh",  "psh",  "pqh",    "ssh", "cssh",  "ecqh", "epsh", "epqh", "essh",
-                                 "ecssh",           "icfg", "scfg", "record", "ms",  "msdms", ""};
+// clang-format off
+//
+static const char *container_names[] = {
+  "not-a-container",
+  "cqh",
+  "psh",
+  "pqh",
+  "ssh",
+  "cssh",
+  "ecqh",
+  "epsh",
+  "epqh",
+  "essh",
+  "ecssh",
+  "icfg",
+  "scfg",
+  "record",
+  "ms",
+  "msdms",
+  "",
+};
 
-const char *aggregate_names[] = {"not-an-agg-op", "COUNT", "SUM", "AVG", "FIRST", "LAST", ""};
+static const char *aggregate_names[] = {
+  "not-an-agg-op",
+  "COUNT",
+  "SUM",
+  "AVG",
+  "FIRST",
+  "LAST",
+  "",
+};
+
+// clang-format on
 
 LogSlice::LogSlice(char *str)
 {
@@ -627,22 +656,24 @@ LogField::update_aggregate(int64_t val)
 LogField::Container
 LogField::valid_container_name(char *name)
 {
-  for (int i = 1; i < LogField::N_CONTAINERS; i++) {
+  for (unsigned i = 1; i < countof(container_names); i++) {
     if (strcmp(name, container_names[i]) == 0) {
       return (LogField::Container)i;
     }
   }
+
   return LogField::NO_CONTAINER;
 }
 
 LogField::Aggregate
 LogField::valid_aggregate_name(char *name)
 {
-  for (int i = 1; i < LogField::N_AGGREGATES; i++) {
+  for (unsigned i = 1; i < countof(aggregate_names); i++) {
     if (strcmp(name, aggregate_names[i]) == 0) {
       return (LogField::Aggregate)i;
     }
   }
+
   return LogField::NO_AGGREGATE;
 }
 
@@ -650,16 +681,17 @@ bool
 LogField::fieldlist_contains_aggregates(char *fieldlist)
 {
   char *match;
-  bool contains_aggregates = false;
-  for (int i = 1; i < LogField::N_AGGREGATES; i++) {
+
+  for (unsigned i = 1; i < countof(aggregate_names); i++) {
     if ((match = strstr(fieldlist, aggregate_names[i])) != NULL) {
       // verify that the aggregate string is not part of a container field name.
       if ((strchr(fieldlist, '{') == NULL) && (strchr(match, '}') == NULL)) {
-        contains_aggregates = true;
+        return true;
       }
     }
   }
-  return contains_aggregates;
+
+  return false;
 }
 
 /*-------------------------------------------------------------------------

--- a/proxy/logging/LogField.h
+++ b/proxy/logging/LogField.h
@@ -134,33 +134,38 @@ public:
   bool operator==(LogField &rhs);
   void updateField(LogAccess *lad, char *val, int len);
 
-  char *
-  name()
+  const char *
+  name() const
   {
     return m_name;
   }
-  char *
-  symbol()
+
+  const char *
+  symbol() const
   {
     return m_symbol;
   }
+
   Type
-  type()
+  type() const
   {
     return m_type;
   }
+
   Ptr<LogFieldAliasMap>
   map()
   {
     return m_alias_map;
-  };
+  }
+
   Aggregate
-  aggregate()
+  aggregate() const
   {
     return m_agg_op;
   }
+
   bool
-  is_time_field()
+  is_time_field() const
   {
     return m_time_field;
   }
@@ -204,9 +209,6 @@ private:
   LogField();
   LogField &operator=(const LogField &rhs);
 };
-
-extern const char *container_names[];
-extern const char *aggregate_names[];
 
 /*-------------------------------------------------------------------------
   LogFieldList

--- a/proxy/logging/LogFilter.h
+++ b/proxy/logging/LogFilter.h
@@ -77,11 +77,13 @@ public:
   {
     return m_name;
   }
+
   Type
   type() const
   {
     return m_type;
   }
+
   size_t
   get_num_values() const
   {
@@ -92,12 +94,6 @@ public:
   virtual bool wipe_this_entry(LogAccess *lad) = 0;
   virtual void display(FILE *fd = stdout) = 0;
   virtual void display_as_XML(FILE *fd = stdout) = 0;
-
-  void
-  reverse()
-  {
-    m_action = (m_action == REJECT ? ACCEPT : REJECT);
-  }
 
 protected:
   char *m_name;


### PR DESCRIPTION
- Make log field name arrays static.
- Make LogField members const.
- Remove unused LogFilter::reverse().
- Make various other trivial member functions const.