### PR TITLE
TS-4659: Log format errors on startup.

### DIFF
--- a/proxy/logging/LogField.cc
+++ b/proxy/logging/LogField.cc
@@ -55,7 +55,6 @@ static const char *container_names[] = {
   "record",
   "ms",
   "msdms",
-  "",
 };
 
 static const char *aggregate_names[] = {
@@ -65,7 +64,6 @@ static const char *aggregate_names[] = {
   "AVG",
   "FIRST",
   "LAST",
-  "",
 };
 
 // clang-format on


### PR DESCRIPTION
Remove extraneous field name constants which accidentally match
with strstr().