### PR TITLE
TS-4664: Fix crash by unifying event handlers for ClientSession.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,7 +49,7 @@ AM_INIT_AUTOMAKE([-Wall -Werror -Wno-portability tar-ustar foreign no-installinf
 AM_MAINTAINER_MODE([enable])
 
 # Enable a recursive "tidy" rule for clang-tidy.
-AM_EXTRA_RECURSIVE_TARGETS([tidy])
+#AM_EXTRA_RECURSIVE_TARGETS([tidy])
 
 AC_CONFIG_HEADERS([lib/ink_autoconf.h])
 

--- a/proxy/ProxyClientSession.cc
+++ b/proxy/ProxyClientSession.cc
@@ -140,7 +140,7 @@ ProxyClientSession::do_api_callout(TSHttpHookID id)
   this->api_scope   = API_HOOK_SCOPE_GLOBAL;
   this->api_current = NULL;
 
-  if (this->hooks_on && this->has_hooks()) {
+  if (this->hooks_enabled() && this->has_hooks()) {
     if (!this->handler) {
       SET_HANDLER(&ProxyClientSession::state_api_callout);
     }

--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -152,8 +152,6 @@ public:
   /// DNS resolution preferences.
   HostResStyle host_res_style;
 
-  virtual int state_api_callout(int event, void *edata);
-
   TSHttpHookID
   get_hookid() const
   {
@@ -177,6 +175,8 @@ public:
   }
 
 protected:
+  int state_api_callout(int event, void *edata);
+
   // XXX Consider using a bitwise flags variable for the following flags, so that we can make the best
   // use of internal alignment padding.
 

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -307,6 +307,15 @@ Http1ClientSession::state_wait_for_close(int event, void *data)
     // Drain any data read
     sm_reader->consume(sm_reader->read_avail());
     break;
+
+  // If this is hook stuff, call the hook handler
+  case EVENT_NONE:
+  case EVENT_INTERVAL:
+  case TS_EVENT_HTTP_CONTINUE:
+  case TS_EVENT_HTTP_ERROR:
+    return this->state_api_callout(event, data);
+    break;
+
   default:
     ink_release_assert(0);
     break;
@@ -381,6 +390,14 @@ Http1ClientSession::state_keep_alive(int event, void *data)
     //} else {
     this->do_io_close();
     //}
+    break;
+
+  // If this is hook stuff, call the hook handler
+  case EVENT_NONE:
+  case EVENT_INTERVAL:
+  case TS_EVENT_HTTP_CONTINUE:
+  case TS_EVENT_HTTP_ERROR:
+    return this->state_api_callout(event, data);
     break;
 
   case VC_EVENT_READ_COMPLETE:

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -277,6 +277,13 @@ Http2ClientSession::main_event_handler(int event, void *edata)
     }
     return 0;
 
+  // If this is hook stuff, call the hook handler
+  case EVENT_NONE:
+  case EVENT_INTERVAL:
+  case TS_EVENT_HTTP_CONTINUE:
+  case TS_EVENT_HTTP_ERROR:
+    return this->state_api_callout(event, edata);
+
   default:
     DebugHttp2Ssn("unexpected event=%d edata=%p", event, edata);
     ink_release_assert(0);


### PR DESCRIPTION
Combining the handlers for ClientSession so both IO events and plugin events can be handled.
