### PR TITLE
TS-4583: Null-pointer dereference after check

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -7390,7 +7390,7 @@ HttpSM::set_next_state()
   }
 
   case HttpTransact::SM_ACTION_INTERNAL_CACHE_NOOP: {
-    if (server_entry == NULL || server_entry->in_tunnel == false) {
+    if (server_entry != NULL && server_entry->in_tunnel == false) {
       release_server_session();
     }
     // If we're in state SEND_API_RESPONSE_HDR, it means functions


### PR DESCRIPTION
Fixes Coverity issue CID 1021958: HttpSM.cc checks server_entry against
NULL, suggesting it might be NULL, before calling
release_server_session(), which dereferences server_entry.
