### PR TITLE
TS-4674: Remove useless assert statement

### DIFF
--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -1332,9 +1332,6 @@ HostDBContinuation::dnsEvent(int event, HostEnt *e)
       r = lookup_done(md5.ip, e->ent.h_name, false, ttl_seconds, &e->srv_hosts, r);
     }
 
-    // @c lookup_done should always return a valid value so @a r should be null @c NULL.
-    ink_assert(r && r->app.allotment.application1 == 0 && r->app.allotment.application2 == 0);
-
     // Conditionally make rr record entries
     if (is_rr) {
       r->app.rr.offset = offset;


### PR DESCRIPTION
Now that we have clean allocations (instead of clobbering existing things) there is no need to have this assertion. In practice this assertion is actually incorrect, because in the case where we want to extend the lifetime of a stale record (since the response we got was broken) we'll fail this assert.