### PR TITLE
TS-3474: HTTP/2 Server Push support

### DIFF
--- a/doc/developer-guide/api/functions/TSHttpTxnServerPush.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnServerPush.en.rst
@@ -1,0 +1,50 @@
+.. Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed
+   with this work for additional information regarding copyright
+   ownership.  The ASF licenses this file to you under the Apache
+   License, Version 2.0 (the "License"); you may not use this file
+   except in compliance with the License.  You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied.  See the License for the specific language governing
+   permissions and limitations under the License.
+
+.. include:: ../../../common.defs
+
+.. default-domain:: c
+
+TSHttpTxnServerPush
+*******************
+
+Synopsis
+========
+
+`#include <ts/experimental.h>`
+
+.. function:: void TSHttpTxnServerPush(TSHttpTxn txnp, const char *url, int url_len)
+
+Description
+===========
+
+Push a content to a client with Server Push mechanism.
+
+This API works only if the protocol of a transaction supports Server Push and it
+is not disabled by the client. You can call this API without checking whether
+Server Push is available on the transaction and it does nothing if Server Push
+is not available.
+
+
+Notes
+=====
+
+This API may be changed in the future version since it is experimental.
+
+See Also
+========
+
+:manpage:`TSAPI(3ts)`,

--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -46,6 +46,7 @@ plugins = \
   ssl-sni.la \
   thread-1.la \
   txn-data-sink.la \
+  server-push.la \
   version.la
 
 if BUILD_EXAMPLE_PLUGINS
@@ -82,6 +83,7 @@ ssl_sni_whitelist_la_SOURCES = ssl-sni-whitelist/ssl-sni-whitelist.cc
 thread_1_la_SOURCES = thread-1/thread-1.c
 txn_data_sink_la_SOURCES = txn-data-sink/txn-data-sink.c
 version_la_SOURCES = version/version.c
+server_push_la_SOURCES = server-push/server-push.c
 
 # The following examples do not build:
 #

--- a/example/server-push/server-push.c
+++ b/example/server-push/server-push.c
@@ -1,0 +1,110 @@
+/** @file
+
+  A brief file description
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+/*
+ *   server-push.c:
+ *    an example of server push.
+ *
+ *
+ *	Usage:
+ * 	  server-push.so http://example.com/favicon.ico
+ *
+ *
+ */
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+
+#include "ts/ts.h"
+#include "ts/experimental.h"
+#include "ts/ink_defs.h"
+
+const char *PLUGIN_NAME = "server-push";
+char url[256];
+
+bool
+should_push(TSHttpTxn txnp)
+{
+  TSMBuffer mbuf;
+  TSMLoc hdr, url;
+  TSHttpTxnClientReqGet(txnp, &mbuf, &hdr);
+  TSHttpHdrUrlGet(mbuf, hdr, &url);
+  int len;
+  TSUrlHttpQueryGet(mbuf, url, &len);
+  TSHandleMLocRelease(mbuf, hdr, url);
+  TSHandleMLocRelease(mbuf, TS_NULL_MLOC, hdr);
+  if (len > 0) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+static int
+server_push_plugin(TSCont contp, TSEvent event, void *edata)
+{
+  TSHttpSsn ssnp;
+  TSHttpTxn txnp;
+
+  switch (event) {
+  case TS_EVENT_HTTP_SSN_START:
+    ssnp = (TSHttpSsn)edata;
+    TSHttpSsnHookAdd(ssnp, TS_HTTP_TXN_START_HOOK, contp);
+    TSHttpSsnReenable(ssnp, TS_EVENT_HTTP_CONTINUE);
+    break;
+  case TS_EVENT_HTTP_TXN_START:
+    txnp = (TSHttpTxn)edata;
+    TSHttpTxnHookAdd(txnp, TS_HTTP_READ_REQUEST_HDR_HOOK, contp);
+    TSHttpTxnReenable(txnp, TS_EVENT_HTTP_CONTINUE);
+    break;
+  case TS_EVENT_HTTP_READ_REQUEST_HDR:
+    txnp = (TSHttpTxn)edata;
+    if (should_push(txnp)) {
+      TSHttpTxnServerPush(txnp, url, strlen(url));
+    }
+    TSHttpTxnReenable(txnp, TS_EVENT_HTTP_CONTINUE);
+    break;
+  default:
+    break;
+  }
+
+  return 0;
+}
+
+void
+TSPluginInit(int argc ATS_UNUSED, const char *argv[] ATS_UNUSED)
+{
+  TSPluginRegistrationInfo info;
+
+  info.plugin_name   = "server-push";
+  info.vendor_name   = "MyCompany";
+  info.support_email = "ts-api-support@MyCompany.com";
+
+  if (TSPluginRegister(&info) != TS_SUCCESS) {
+    TSError("[%s] Plugin registration failed.", PLUGIN_NAME);
+  }
+
+  TSstrlcpy(url, argv[1], sizeof(url));
+  TSCont handler = TSContCreate(server_push_plugin, NULL);
+  TSHttpHookAdd(TS_HTTP_SSN_START_HOOK, handler);
+}

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -7598,6 +7598,23 @@ TSHttpTxnIsInternal(TSHttpTxn txnp)
   return TSHttpSsnIsInternal(TSHttpTxnSsnGet(txnp));
 }
 
+void
+TSHttpTxnServerPush(TSHttpTxn txnp, const char *url, int url_len)
+{
+  sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
+
+  URL url_obj;
+  url_obj.create(NULL);
+  if (url_obj.parse(url, url_len) == PARSE_RESULT_ERROR) {
+    return;
+  }
+  HttpSM *sm          = reinterpret_cast<HttpSM *>(txnp);
+  Http2Stream *stream = dynamic_cast<Http2Stream *>(sm->ua_session);
+  if (stream) {
+    stream->push_promise(url_obj);
+  }
+}
+
 TSReturnCode
 TSAIORead(int fd, off_t offset, char *buf, size_t buffSize, TSCont contp)
 {

--- a/proxy/api/ts/experimental.h
+++ b/proxy/api/ts/experimental.h
@@ -229,6 +229,8 @@ tsapi TSReturnCode TSHttpTxnUpdateCachedObject(TSHttpTxn txnp);
  ****************************************************************************/
 tsapi int TSHttpTxnLookingUpTypeGet(TSHttpTxn txnp);
 
+tsapi void TSHttpTxnServerPush(TSHttpTxn txnp, const char *url, int url_len);
+
 /**
    Attempt to attach the contp continuation to sockets that have already been
    opened by the traffic manager and defined as belonging to plugins (based on

--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -54,6 +54,7 @@ const size_t HTTP2_SETTINGS_PARAMETER_LEN = 6;
 // SETTINGS initial values. NOTE: These should not be modified
 // unless the protocol changes! Do not change this thinking you
 // are changing server defaults. that is done via RecordsConfig.cc
+const uint32_t HTTP2_ENABLE_PUSH            = 1;
 const uint32_t HTTP2_MAX_CONCURRENT_STREAMS = UINT_MAX;
 const uint32_t HTTP2_INITIAL_WINDOW_SIZE    = 65535;
 const uint32_t HTTP2_MAX_FRAME_SIZE         = 16384;
@@ -295,6 +296,13 @@ struct Http2RstStream {
   uint32_t error_code;
 };
 
+// [RFC 7540] 6.6 PUSH_PROMISE Format
+struct Http2PushPromise {
+  Http2PushPromise() : pad_length(0), promised_streamid(0) {}
+  uint8_t pad_length;
+  Http2StreamId promised_streamid;
+};
+
 static inline bool
 http2_is_client_streamid(Http2StreamId streamid)
 {
@@ -324,6 +332,8 @@ bool http2_write_ping(const uint8_t *, IOVec);
 bool http2_write_goaway(const Http2Goaway &, IOVec);
 
 bool http2_write_window_update(const uint32_t new_size, const IOVec &);
+
+bool http2_write_push_promise(const Http2PushPromise &push_promise, const uint8_t *src, size_t length, const IOVec &iov);
 
 bool http2_frame_header_is_valid(const Http2FrameHeader &, unsigned);
 

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -155,6 +155,12 @@ public:
                                       trailing_header);
   }
 
+  void
+  set_request_headers(HTTPHdr &h2_headers)
+  {
+    _req_header.copy(&h2_headers);
+  }
+
   // Check entire DATA payload length if content-length: header is exist
   void
   increment_data_length(uint64_t length)
@@ -180,6 +186,7 @@ public:
   void reenable(VIO *vio);
   virtual void transaction_done();
   void send_response_body();
+  void push_promise(URL &url);
 
   // Stream level window size
   ssize_t client_rwnd, server_rwnd;
@@ -235,7 +242,8 @@ public:
   bool
   is_client_state_writeable()
   {
-    return _state == HTTP2_STREAM_STATE_OPEN || _state == HTTP2_STREAM_STATE_HALF_CLOSED_REMOTE;
+    return _state == HTTP2_STREAM_STATE_OPEN || _state == HTTP2_STREAM_STATE_HALF_CLOSED_REMOTE ||
+           HTTP2_STREAM_STATE_RESERVED_LOCAL;
   }
 
 private:


### PR DESCRIPTION
This PR adds an experimental API for server push, and an example plugin for it.
```c
void TSHttpTxnServerPush(TSHttpTxn txnp, const char *url, int url_len)
````
The API is experimental because we don't know whether it fits practical use cases yet.

Also, this PR don't add any concrete implementations into ATS core that are used to determine which contents should be pushed with the API.

https://issues.apache.org/jira/browse/TS-3474