### PR TITLE
TS-3245: Allow multiple plugins to safely use getopt(3).

### DIFF
--- a/plugins/experimental/acme/acme.c
+++ b/plugins/experimental/acme/acme.c
@@ -307,7 +307,6 @@ TSPluginInit(int argc, const char *argv[])
   };
 
   memset(&gConfig, 0, sizeof(gConfig));
-  optind = 0;
   while (true) {
     int opt = getopt_long(argc, (char *const *)argv, "", longopt, NULL);
 

--- a/plugins/experimental/authproxy/authproxy.cc
+++ b/plugins/experimental/authproxy/authproxy.cc
@@ -692,11 +692,6 @@ AuthParseOptions(int argc, const char **argv)
 
   options->transform = AuthWriteRedirectedRequest;
 
-  // We might parse arguments multiple times if we are loaded as a global
-  // plugin and a remap plugin. Reset optind so that getopt_long() does the
-  // right thing (ie. work instead of crash).
-  optind = 0;
-
   for (;;) {
     int opt;
 

--- a/plugins/experimental/background_fetch/background_fetch.cc
+++ b/plugins/experimental/background_fetch/background_fetch.cc
@@ -568,7 +568,6 @@ TSPluginInit(int argc, const char *argv[])
   gConfig = new BgFetchConfig(cont);
   gConfig->acquire(); // Inc refcount, although this global config should never go out of scope
 
-  optind = 1;
   while (true) {
     int opt = getopt_long(argc, (char *const *)argv, "lc", longopt, NULL);
 

--- a/plugins/experimental/balancer/balancer.cc
+++ b/plugins/experimental/balancer/balancer.cc
@@ -111,7 +111,6 @@ TSRemapNewInstance(int argc, char *argv[], void **instance, char *errbuf, int er
   argc--;
   argv++;
 
-  optind = 0;
   for (;;) {
     int opt;
 

--- a/plugins/experimental/cache_promote/cache_promote.cc
+++ b/plugins/experimental/cache_promote/cache_promote.cc
@@ -349,7 +349,6 @@ public:
   bool
   factory(int argc, char *argv[])
   {
-    optind = 0;
     while (true) {
       int opt = getopt_long(argc, (char *const *)argv, "psbh", longopt, NULL);
 

--- a/plugins/experimental/cachekey/configs.cc
+++ b/plugins/experimental/cachekey/configs.cc
@@ -343,7 +343,6 @@ Configs::init(int argc, char *argv[])
                                           {0, 0, 0, 0}};
 
   bool status = true;
-  optind      = 0;
 
   /* argv contains the "to" and "from" URLs. Skip the first so that the second one poses as the program name. */
   argc--;

--- a/plugins/experimental/esi/esi.cc
+++ b/plugins/experimental/esi/esi.cc
@@ -1604,9 +1604,7 @@ esiPluginInit(int argc, const char *argv[], struct OptionInfo *pOptionInfo)
                                              {const_cast<char *>("handler-filename"), required_argument, NULL, 'f'},
                                              {NULL, 0, NULL, 0}};
 
-    optarg = NULL;
-    optind = opterr = optopt = 0;
-    int longindex            = 0;
+    int longindex = 0;
     while ((c = getopt_long(argc, (char *const *)argv, "npzbf:", longopts, &longindex)) != -1) {
       switch (c) {
       case 'n':

--- a/plugins/experimental/regex_revalidate/regex_revalidate.c
+++ b/plugins/experimental/regex_revalidate/regex_revalidate.c
@@ -466,7 +466,6 @@ TSPluginInit(int argc, const char *argv[])
   init_plugin_state_t(pstate);
 
   int c;
-  optind                                = 1;
   static const struct option longopts[] = {
     {"config", required_argument, NULL, 'c'}, {"log", required_argument, NULL, 'l'}, {NULL, 0, NULL, 0}};
 

--- a/plugins/experimental/remap_stats/remap_stats.c
+++ b/plugins/experimental/remap_stats/remap_stats.c
@@ -251,7 +251,6 @@ TSPluginInit(int argc, const char *argv[])
 
   if (argc > 1) {
     int c;
-    optind                                = 1;
     static const struct option longopts[] = {
       {"post-remap-host", no_argument, NULL, 'P'}, {"persistent", no_argument, NULL, 'p'}, {NULL, 0, NULL, 0}};
 

--- a/plugins/experimental/s3_auth/s3_auth.cc
+++ b/plugins/experimental/s3_auth/s3_auth.cc
@@ -524,7 +524,6 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
   // second one poses as the program name.
   --argc;
   ++argv;
-  optind = 0;
 
   while (true) {
     int opt = getopt_long(argc, static_cast<char *const *>(argv), "", longopt, NULL);

--- a/plugins/experimental/sslheaders/sslheaders.cc
+++ b/plugins/experimental/sslheaders/sslheaders.cc
@@ -170,11 +170,6 @@ SslHdrParseOptions(int argc, const char **argv)
 
   ats_scoped_obj<SslHdrInstance> hdr(new SslHdrInstance());
 
-  // We might parse arguments multiple times if we are loaded as a global
-  // plugin and a remap plugin. Reset optind so that getopt_long() does the
-  // right thing (ie. work instead of crash).
-  optind = 0;
-
   for (;;) {
     int opt;
 

--- a/plugins/experimental/stale_while_revalidate/stale_while_revalidate.c
+++ b/plugins/experimental/stale_while_revalidate/stale_while_revalidate.c
@@ -637,7 +637,6 @@ TSPluginInit(int argc, const char *argv[])
 
   if (argc > 1) {
     int c;
-    optind                                = 1;
     static const struct option longopts[] = {{"log-all", no_argument, NULL, 'a'},
                                              {"log-stale-while-revalidate", no_argument, NULL, 'r'},
                                              {"log-stale-if-error", no_argument, NULL, 'e'},

--- a/plugins/experimental/xdebug/xdebug.cc
+++ b/plugins/experimental/xdebug/xdebug.cc
@@ -369,8 +369,6 @@ TSPluginInit(int argc, const char *argv[])
     TSError("[xdebug] Plugin registration failed");
   }
 
-  optind = 0;
-
   // Parse the arguments
   while (true) {
     int opt = getopt_long(argc, (char *const *)argv, "", longopt, NULL);

--- a/plugins/stats_over_http/stats_over_http.c
+++ b/plugins/stats_over_http/stats_over_http.c
@@ -299,7 +299,6 @@ TSPluginInit(int argc, const char *argv[])
     TSError("[%s] registration failed", PLUGIN_NAME);
   }
 
-  optind = 0;
   for (;;) {
     switch (getopt_long(argc, (char *const *)argv, "iw", longopts, NULL)) {
     case 'i':

--- a/plugins/tcpinfo/tcpinfo.cc
+++ b/plugins/tcpinfo/tcpinfo.cc
@@ -319,7 +319,6 @@ TSPluginInit(int argc, const char *argv[])
     TSError("[tcpinfo] plugin registration failed");
   }
 
-  optind = 0;
   for (;;) {
     unsigned long lval;
 

--- a/proxy/Plugin.cc
+++ b/proxy/Plugin.cc
@@ -123,6 +123,16 @@ plugin_load(int argc, char *argv[], bool validateOnly)
       return false; // this line won't get called since Fatal brings down ATS
     }
 
+#if defined(freebsd) || defined(darwin)
+    optreset = 1;
+#endif
+#if defined(__GLIBC__)
+    optind = 0;
+#else
+    optind = 1;
+#endif
+    opterr = 0;
+    optarg = NULL;
     init(argc, argv);
   } // done elevating access
 

--- a/proxy/http/remap/RemapConfig.cc
+++ b/proxy/http/remap/RemapConfig.cc
@@ -858,6 +858,17 @@ remap_load_plugin(const char **argv, int argc, url_mapping *mp, char *errbuf, in
   void *ih         = NULL;
   TSReturnCode res = TS_SUCCESS;
   if (pi->fp_tsremap_new_instance) {
+#if defined(freebsd) || defined(darwin)
+    optreset = 1;
+#endif
+#if defined(__GLIBC__)
+    optind = 0;
+#else
+    optind = 1;
+#endif
+    opterr = 0;
+    optarg = NULL;
+
     res = pi->fp_tsremap_new_instance(parc, parv, &ih, tmpbuf, sizeof(tmpbuf) - 1);
   }
 


### PR DESCRIPTION
Request back-port to 6.2.x branch. This was cherry-picked from "master", and it was clean except for some spacing issues introduced by clang-format setting changes.
