### PR TITLE
fix the memory leaks

### DIFF
--- a/iocore/dns/test_P_DNS.cc
+++ b/iocore/dns/test_P_DNS.cc
@@ -70,7 +70,7 @@ struct NetTesterSM : public Continuation {
     default:
       ink_release_assert(!"unknown event");
     }
-    delete(str);
+    delete [] str;
     return EVENT_CONT;
   }
 };

--- a/iocore/dns/test_P_DNS.cc
+++ b/iocore/dns/test_P_DNS.cc
@@ -70,6 +70,7 @@ struct NetTesterSM : public Continuation {
     default:
       ink_release_assert(!"unknown event");
     }
+    delete(str);
     return EVENT_CONT;
   }
 };

--- a/iocore/net/test_P_Net.cc
+++ b/iocore/net/test_P_Net.cc
@@ -68,7 +68,7 @@ struct NetTesterSM : public Continuation {
     default:
       ink_release_assert(!"unknown event");
     }
-    delete(str);
+    delete [] str;
     return EVENT_CONT;
   }
 };

--- a/iocore/net/test_P_Net.cc
+++ b/iocore/net/test_P_Net.cc
@@ -68,6 +68,7 @@ struct NetTesterSM : public Continuation {
     default:
       ink_release_assert(!"unknown event");
     }
+    delete(str);
     return EVENT_CONT;
   }
 };


### PR DESCRIPTION
On line #74 'test_P_DNS.cc' has a memory leak and on line #72 'test_P_Net.cc' has a memory leak -- both of which are errors.

Found by https://github.com/bryongloden/cppcheck