### PR TITLE
TS-4794 fix the memory leaks

### DIFF
--- a/iocore/dns/test_P_DNS.cc
+++ b/iocore/dns/test_P_DNS.cc
@@ -45,7 +45,7 @@ struct NetTesterSM : public Continuation {
   handle_read(int event, void *data)
   {
     int r;
-    char *str;
+    char *str = NULL;
     switch (event) {
     case VC_EVENT_READ_READY:
       r   = reader->read_avail();

--- a/iocore/dns/test_P_DNS.cc
+++ b/iocore/dns/test_P_DNS.cc
@@ -70,7 +70,7 @@ struct NetTesterSM : public Continuation {
     default:
       ink_release_assert(!"unknown event");
     }
-    delete [] str;
+    delete[] str;
     return EVENT_CONT;
   }
 };

--- a/iocore/dns/test_P_DNS.cc
+++ b/iocore/dns/test_P_DNS.cc
@@ -70,6 +70,7 @@ struct NetTesterSM : public Continuation {
     default:
       ink_release_assert(!"unknown event");
     }
+    delete [] str;
     return EVENT_CONT;
   }
 };

--- a/iocore/net/test_P_Net.cc
+++ b/iocore/net/test_P_Net.cc
@@ -68,6 +68,7 @@ struct NetTesterSM : public Continuation {
     default:
       ink_release_assert(!"unknown event");
     }
+    delete [] str;
     return EVENT_CONT;
   }
 };

--- a/iocore/net/test_P_Net.cc
+++ b/iocore/net/test_P_Net.cc
@@ -45,7 +45,7 @@ struct NetTesterSM : public Continuation {
   handle_read(int event, void *data)
   {
     int r;
-    char *str;
+    char *str = NULL;
     switch (event) {
     case VC_EVENT_READ_READY:
       r   = reader->read_avail();

--- a/iocore/net/test_P_Net.cc
+++ b/iocore/net/test_P_Net.cc
@@ -68,7 +68,7 @@ struct NetTesterSM : public Continuation {
     default:
       ink_release_assert(!"unknown event");
     }
-    delete [] str;
+    delete[] str;
     return EVENT_CONT;
   }
 };


### PR DESCRIPTION
On line no. 74 of '[test_P_DNS.cc](https://github.com/apache/trafficserver/blob/master/iocore/dns/test_P_DNS.cc#L74)' there is a memory leak and on line no. 72 of '[test_P_Net.cc](https://github.com/apache/trafficserver/blob/master/iocore/net/test_P_Net.cc#L72)' there is memory leak -- both memory leaks are errors.

Found by https://github.com/bryongloden/cppcheck