### PR TITLE
TS-4732: Changing the do_io_read API so it can be called with NULL and

### DIFF
--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -182,8 +182,7 @@ public:
   virtual void
   release_netvc()
   {
-    // Make sure the vio's are also released to avoid
-    // later surprises in inactivity timeout
+    // Make sure the vio's are also released to avoid later surprises in inactivity timeout
     if (client_vc) {
       client_vc->do_io_read(NULL, 0, NULL);
       client_vc->do_io_write(NULL, 0, NULL);


### PR DESCRIPTION
0 byte values.  Allowing do_io_read and do_io_write to not warn on closed
connection when we are only trying to disable the reads and writes for it.
Removed some macros that were used in a few places (not all the time) and
a couple that were not used at all.