### PR TITLE
TS-4724: Modified ts_lua plugin to provide ts.server_request.remove_h…

### DIFF
--- a/doc/admin-guide/plugins/ts_lua.en.rst
+++ b/doc/admin-guide/plugins/ts_lua.en.rst
@@ -1295,6 +1295,34 @@ ts.server_request.set_uri_params
 
 `TOP <#ts-lua-plugin>`_
 
+ts.server_request.remove_host_name_from_url
+-------------------------------------------
+**syntax:** *ts.server_request.remove_host_name_from_url()*
+
+**context:** function @ TS_LUA_HOOK_SEND_REQUEST_HDR hook point
+
+**description:** This function can be used to remove host name from GET request send to next-tier.
+
+Here is an example:
+
+::
+
+    function send_request()
+        ts.server_request.remove_host_name_from_url()
+    end
+
+    function do_remap()
+        ts.hook(TS_LUA_HOOK_SEND_REQUEST_HDR, send_request)
+        return 0
+    end
+
+Then ``GET http://origin.com/dir1/a.txt`` will yield the output:
+
+``GET /dir1/a.txt``
+
+
+`TOP <#ts-lua-plugin>`_
+
 ts.server_request.header.HEADER
 -------------------------------
 **syntax:** *ts.server_request.header.HEADER = VALUE*

--- a/plugins/experimental/ts_lua/ts_lua_server_request.c
+++ b/plugins/experimental/ts_lua/ts_lua_server_request.c
@@ -51,6 +51,7 @@ static void ts_lua_inject_server_request_get_body_size_api(lua_State *L);
 static void ts_lua_inject_server_request_uri_api(lua_State *L);
 static void ts_lua_inject_server_request_uri_args_api(lua_State *L);
 static void ts_lua_inject_server_request_uri_params_api(lua_State *L);
+static void ts_lua_inject_server_request_url_api(lua_State *L);
 
 static int ts_lua_server_request_header_get(lua_State *L);
 static int ts_lua_server_request_header_set(lua_State *L);
@@ -63,6 +64,7 @@ static int ts_lua_server_request_set_uri_args(lua_State *L);
 static int ts_lua_server_request_get_uri_args(lua_State *L);
 static int ts_lua_server_request_set_uri_params(lua_State *L);
 static int ts_lua_server_request_get_uri_params(lua_State *L);
+static int ts_lua_server_request_host_name_remove(lua_State *L);
 
 static int ts_lua_server_request_server_addr_get_ip(lua_State *L);
 static int ts_lua_server_request_server_addr_get_port(lua_State *L);
@@ -83,6 +85,8 @@ ts_lua_inject_server_request_api(lua_State *L)
   ts_lua_inject_server_request_uri_api(L);
   ts_lua_inject_server_request_uri_args_api(L);
   ts_lua_inject_server_request_uri_params_api(L);
+
+  ts_lua_inject_server_request_url_api(L);
 
   lua_setfield(L, -2, "server_request");
 }
@@ -478,6 +482,27 @@ ts_lua_server_request_get_uri_params(lua_State *L)
   }
 
   return 1;
+}
+
+static void
+ts_lua_inject_server_request_url_api(lua_State *L)
+{
+  lua_pushcfunction(L, ts_lua_server_request_host_name_remove);
+  lua_setfield(L, -2, "remove_host_name_from_url");
+}
+
+static int
+ts_lua_server_request_host_name_remove(lua_State *L)
+{
+  ts_lua_http_ctx *http_ctx;
+
+  GET_HTTP_CONTEXT(http_ctx, L);
+
+  TS_LUA_CHECK_SERVER_REQUEST_URL(http_ctx);
+
+  TSUrlRemoveHostName(http_ctx->server_request_bufp, http_ctx->server_request_url);
+
+  return 0;
 }
 
 static int

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -2208,6 +2208,20 @@ TSUrlPathSet(TSMBuffer bufp, TSMLoc obj, const char *value, int length)
   return URLPartSet(bufp, obj, value, length, &URL::path_set);
 }
 
+void
+TSUrlRemoveHostName(TSMBuffer bufp, TSMLoc obj)
+{
+  sdk_assert(sdk_sanity_check_mbuffer(bufp) == TS_SUCCESS);
+  sdk_assert(sdk_sanity_check_url_handle(obj) == TS_SUCCESS);
+  URL u;
+  Debug("cache_url", "[TSUrlRemoveHostName] Removing host name from url");
+
+  u.m_heap = ((HdrHeapSDKHandle *)bufp)->m_heap;
+  u.m_url_impl = (URLImpl *)obj;
+
+  u.nuke_proxy_stuff();
+}
+
 /* FTP specific URLs */
 
 int

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -462,6 +462,14 @@ tsapi const char *TSUrlUserGet(TSMBuffer bufp, TSMLoc offset, int *length);
 tsapi TSReturnCode TSUrlUserSet(TSMBuffer bufp, TSMLoc offset, const char *value, int length);
 
 /**
+    Removes host name from the URL located at url_loc within bufp.
+
+    @param bufp marshal buffer containing the URL.
+    @param offset location of the URL.
+*/
+tsapi void TSUrlRemoveHostName(TSMBuffer bufp, TSMLoc obj);
+
+/**
     Retrieves the password portion of the URL located at url_loc
     within bufp. TSUrlPasswordGet() places the length of the returned
     string in the length argument. Note: the returned string is


### PR DESCRIPTION
TS_LUA and InkAPI.cc are modified to create a new ts_lua API to remove host name from URL in GET request to next-tier.