### PR TITLE
TS-4750: Fix Connection Leak warnings.

### DIFF
--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -482,6 +482,7 @@ public:
 
   /** Returns remote sockaddr storage. */
   sockaddr const *get_remote_addr();
+  IpEndpoint const &get_remote_endpoint();
 
   /** Returns remote ip.
       @deprecated get_remote_addr() should be used instead for AF_INET6 compatibility.

--- a/iocore/net/P_NetVConnection.h
+++ b/iocore/net/P_NetVConnection.h
@@ -33,6 +33,13 @@ NetVConnection::get_remote_addr()
   return &remote_addr.sa;
 }
 
+TS_INLINE IpEndpoint const &
+NetVConnection::get_remote_endpoint()
+{
+  get_remote_addr(); // Make sure the vallue is filled in
+  return remote_addr;
+}
+
 TS_INLINE in_addr_t
 NetVConnection::get_remote_ip()
 {

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -1738,7 +1738,6 @@ HttpSM::state_http_server_open(int event, void *data)
        printf("client fd is :%d , server fd is %d\n",vc->con.fd,
        server_vc->con.fd); */
     session->attach_hostname(t_state.current.server->name);
-    ats_ip_copy(&session->server_ip, &t_state.current.server->dst_addr);
     session->new_connection(static_cast<NetVConnection *>(data));
     session->state = HSS_ACTIVE;
 
@@ -4809,7 +4808,7 @@ HttpSM::do_http_server_open(bool raw)
       // so there's no point in further checking on the match or pool values. But why check anything? The
       // client has already exchanged a request with this specific origin server and has sent another one
       // shouldn't we just automatically keep the association?
-      if (ats_ip_addr_port_eq(&existing_ss->server_ip.sa, &t_state.current.server->dst_addr.sa)) {
+      if (ats_ip_addr_port_eq(&existing_ss->get_server_ip().sa, &t_state.current.server->dst_addr.sa)) {
         ua_session->attach_server_session(NULL);
         existing_ss->state = HSS_ACTIVE;
         this->attach_server_session(existing_ss);

--- a/proxy/http/HttpServerSession.h
+++ b/proxy/http/HttpServerSession.h
@@ -86,7 +86,6 @@ public:
       magic(HTTP_SS_MAGIC_DEAD),
       buf_reader(NULL)
   {
-    ink_zero(server_ip);
   }
 
   void destroy();
@@ -131,7 +130,12 @@ public:
   }
 
   // Keys for matching hostnames
-  IpEndpoint server_ip;
+  IpEndpoint const &
+  get_server_ip() const
+  {
+    ink_release_assert(server_vc != NULL);
+    return server_vc->get_remote_endpoint();
+  }
   INK_MD5 hostname_hash;
 
   int64_t con_id;

--- a/proxy/http/HttpSessionManager.h
+++ b/proxy/http/HttpSessionManager.h
@@ -82,11 +82,7 @@ protected:
     static Key
     key(Value const *value)
     {
-      // Might be better to just fetch the comparing address from the
-      // netvc.  That is what the event_handler will be using to
-      // looking elements in the m_ip_pool
-      // return value->get_netvc()->get_remote_addr();
-      return &value->server_ip.sa;
+      return &value->get_server_ip().sa;
     }
     static bool
     equal(Key lhs, Key rhs)


### PR DESCRIPTION
Removing secondary server address cache in HttpServerSession.  Instead pull that information from netvc.  Use the same address to add server sessions to cache to and remove server sessions from cache.