### PR TITLE
TS-2237: Fix double encoding of URLs in squid logs.

### DIFF
--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -2339,7 +2339,12 @@ TSStringPercentEncode(const char *str, int str_len, char *dst, size_t dst_size, 
   sdk_assert(str_len < static_cast<int>(dst_size));
 
   // TODO: Perhaps we should make escapify_url() deal with const properly...
-  if (NULL == LogUtils::escapify_url(NULL, const_cast<char *>(str), str_len, &new_len, dst, dst_size, map)) {
+  // You would think making escapify_url const correct for the source argument would be easy, but in the case where
+  // No escaping is needed, the source argument is returned.  If there is a destination argument, the source is copied over
+  // However, if there is no destination argument, none is allocated.  I don't understand the full possibility of calling cases.
+  // It seems like we might want to review how this is being called and perhaps create a number of smaller accessor methods that
+  // can be set up correctly.
+  if (NULL == LogUtils::pure_escapify_url(NULL, const_cast<char *>(str), str_len, &new_len, dst, dst_size, map)) {
     if (length) {
       *length = 0;
     }

--- a/proxy/logging/LogUtils.h
+++ b/proxy/logging/LogUtils.h
@@ -51,6 +51,8 @@ void manager_alarm(AlarmType alarm_type, const char *msg, ...) TS_PRINTFLIKE(2, 
 void strip_trailing_newline(char *buf);
 char *escapify_url(Arena *arena, char *url, size_t len_in, int *len_out, char *dst = NULL, size_t dst_size = 0,
                    const unsigned char *map = NULL);
+char *pure_escapify_url(Arena *arena, char *url, size_t len_in, int *len_out, char *dst = NULL, size_t dst_size = 0,
+                        const unsigned char *map = NULL);
 char *int64_to_str(char *buf, unsigned int buf_size, int64_t val, unsigned int *total_chars, unsigned int req_width = 0,
                    char pad_char = '0');
 void remove_content_type_attributes(char *type_str, int *type_len);


### PR DESCRIPTION
Resurrecting @sudheerv's fix.  We've been running with this fix for over a year.  The logic to lookup the character in the bitfield array is a bit odd, but it is the same indexing done for the original character lookup.