### PR TITLE
TS-4716: Install manpages in $PREFIX/share/man.

### DIFF
--- a/config.layout
+++ b/config.layout
@@ -36,7 +36,7 @@
     libdir:        ${exec_prefix}/lib
     libexecdir:    ${exec_prefix}/libexec+
     infodir:       ${prefix}/info
-    mandir:        ${prefix}/man
+    mandir:        ${prefix}/share/man
     sysconfdir:    ${prefix}/etc+
     datadir:       ${prefix}/share+
     docdir:        ${prefix}/share/doc+
@@ -57,7 +57,7 @@
     libdir:        ${exec_prefix}/lib
     libexecdir:    ${exec_prefix}/modules
     infodir:       ${prefix}/info
-    mandir:        ${prefix}/man
+    mandir:        ${prefix}/share/man
     sysconfdir:    ${prefix}/conf
     datadir:       ${prefix}/share
     docdir:        ${prefix}/share/doc+
@@ -79,7 +79,7 @@
     libdir:        ${exec_prefix}/lib
     libexecdir:    ${exec_prefix}/libexec
     infodir:       ${prefix}/info
-    mandir:        ${prefix}/man
+    mandir:        ${prefix}/share/man
     sysconfdir:    ${prefix}/etc+
     datadir:       ${prefix}/share+
     docdir:        ${prefix}/share/doc+
@@ -142,7 +142,7 @@
     libdir:        ${exec_prefix}/lib
     libexecdir:    ${exec_prefix}/libexec
     infodir:       ${prefix}/info
-    mandir:        ${prefix}/man
+    mandir:        ${prefix}/share/man
     sysconfdir:    /etc${prefix}
     datadir:       ${prefix}/share
     docdir:        ${prefix}/share/doc+
@@ -228,7 +228,7 @@
     libdir:        ${exec_prefix}/lib
     libexecdir:    ${exec_prefix}/libexec+
     infodir:       ${prefix}/info
-    mandir:        ${prefix}/man
+    mandir:        ${prefix}/share/man
     sysconfdir:    /etc+
     datadir:       ${prefix}/share+
     docdir:        ${prefix}/share/doc+

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -19,7 +19,7 @@ import sys, os
 man_pages = [
   # Add all files in the reference/api directory to the list of manual
   # pages
-  ('developer-guide/api/' + filename[:-4], filename.split('.', 1)[0], '', None, '3ts') for filename in os.listdir('developer-guide/api') if filename != 'index.en.rst' and filename.endswith('.rst')] + [
+  ('developer-guide/api/functions/' + filename[:-4], filename.split('.', 1)[0], '', None, '3ts') for filename in os.listdir('developer-guide/api/functions/') if filename != 'index.en.rst' and filename.endswith('.rst')] + [
 
   ('appendices/command-line/traffic_cop.en', 'traffic_cop', u'Traffic Server watchdog', None, '8'),
   ('appendices/command-line/traffic_ctl.en', 'traffic_ctl', u'Traffic Server command line tool', None, '8'),

--- a/lib/perl/Makefile.am
+++ b/lib/perl/Makefile.am
@@ -16,11 +16,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+# Default INSTALLDIRS to "perl" so that INSTALLMAN3DIR works.
+INSTALLDIRS=perl
+
 all-local: Makefile-pl
 	$(MAKE) -f Makefile-pl INSTALLDIRS=$(INSTALLDIRS) PREFIX=$(prefix) DESTDIR=$(DESTDIR)
 
 install-exec-local: Makefile-pl
-	$(MAKE) -f Makefile-pl INSTALLDIRS=$(INSTALLDIRS) PREFIX=$(prefix) DESTDIR=$(DESTDIR) install
+	$(MAKE) -f Makefile-pl INSTALLMAN3DIR=$(mandir)/man3 INSTALLDIRS=$(INSTALLDIRS) PREFIX=$(prefix) DESTDIR=$(DESTDIR) install
 
 # The perl build needs to have the source files in the current working directory, so we need to
 # copy them to the build directory if we are building out of tree.


### PR DESCRIPTION
Update various layouts to default to installing manpages into
$PREFIX/share/man. Some layouts already did this, but it is probably
worth making it the default for people who just configure with
--prefix=/PATH.