### PR TITLE
TS-4735: Fix race condition in traffic_server startup.

### DIFF
--- a/mgmt/ProcessManager.cc
+++ b/mgmt/ProcessManager.cc
@@ -68,7 +68,7 @@ startProcessManager(void *arg)
   return ret;
 } /* End startProcessManager */
 
-ProcessManager::ProcessManager(bool rlm) : BaseManager(), require_lm(rlm), local_manager_sockfd(0), cbtable(NULL)
+ProcessManager::ProcessManager(bool rlm) : BaseManager(), require_lm(rlm), local_manager_sockfd(0), cbtable(NULL), max_msgs_in_a_row(1)
 {
   mgmt_signal_queue = create_queue();
 
@@ -83,6 +83,7 @@ void
 ProcessManager::reconfigure()
 {
   bool found;
+  max_msgs_in_a_row = MAX_MSGS_IN_A_ROW;
   timeout = REC_readInteger("proxy.config.process_manager.timeout", &found);
   ink_assert(found);
 
@@ -227,7 +228,7 @@ ProcessManager::pollLMConnection()
 
   // Avoid getting stuck enqueuing too many requests in a row, limit to MAX_MSGS_IN_A_ROW.
   int count;
-  for (count = 0; count < MAX_MSGS_IN_A_ROW; ++count) {
+  for (count = 0; count < max_msgs_in_a_row; ++count) {
     int num;
 
     num = mgmt_read_timeout(local_manager_sockfd, 1 /* sec */, 0 /* usec */);
@@ -263,7 +264,7 @@ ProcessManager::pollLMConnection()
     }
   }
 
-  Debug("pmgmt", "[ProcessManager::pollLMConnection] enqueued %d of max %d messages in a row", count, MAX_MSGS_IN_A_ROW);
+  Debug("pmgmt", "[ProcessManager::pollLMConnection] enqueued %d of max %d messages in a row", count, max_msgs_in_a_row);
 } /* End ProcessManager::pollLMConnection */
 
 void

--- a/mgmt/ProcessManager.cc
+++ b/mgmt/ProcessManager.cc
@@ -68,7 +68,8 @@ startProcessManager(void *arg)
   return ret;
 } /* End startProcessManager */
 
-ProcessManager::ProcessManager(bool rlm) : BaseManager(), require_lm(rlm), local_manager_sockfd(0), cbtable(NULL), max_msgs_in_a_row(1)
+ProcessManager::ProcessManager(bool rlm)
+  : BaseManager(), require_lm(rlm), local_manager_sockfd(0), cbtable(NULL), max_msgs_in_a_row(1)
 {
   mgmt_signal_queue = create_queue();
 
@@ -84,7 +85,7 @@ ProcessManager::reconfigure()
 {
   bool found;
   max_msgs_in_a_row = MAX_MSGS_IN_A_ROW;
-  timeout = REC_readInteger("proxy.config.process_manager.timeout", &found);
+  timeout           = REC_readInteger("proxy.config.process_manager.timeout", &found);
   ink_assert(found);
 
   return;

--- a/mgmt/ProcessManager.h
+++ b/mgmt/ProcessManager.h
@@ -103,6 +103,7 @@ private:
   static const int MAX_MSGS_IN_A_ROW = 10000;
 
   ConfigUpdateCbTable *cbtable;
+  int max_msgs_in_a_row;
 }; /* End class ProcessManager */
 
 inkcoreapi extern ProcessManager *pmgmt;


### PR DESCRIPTION
Set max_msgs_in_row to 1 temporarily during traffic_server startup to avoid a hitting race condition when we receive configurations continuously from traffic_manager while coming up. We will reset this limit back to 10,000 in reconfigure() once the initial synchronization is done.