### PR TITLE
fix 5 bugs about parent strategy

### DIFF
--- a/proxy/ParentConsistentHash.cc
+++ b/proxy/ParentConsistentHash.cc
@@ -168,7 +168,7 @@ ParentConsistentHash::selectParent(const ParentSelectionPolicy *policy, bool fir
       }
       Debug("parent_select", "wrap_around[PRIMARY]: %d, wrap_around[SECONDARY]: %d", wrap_around[PRIMARY], wrap_around[SECONDARY]);
       if (!wrap_around[PRIMARY] || (chash[SECONDARY] != NULL)) {
-        Debug("parent_select", "Selected parent %s is not available, looking up another parent.", pRec->hostname);
+        Debug("parent_select", "Selected parent %s is not available, looking up another parent.", pRec ? pRec->hostname:"[NULL]");
         if (chash[SECONDARY] != NULL && !wrap_around[SECONDARY]) {
           fhash       = chash[SECONDARY];
           last_lookup = SECONDARY;

--- a/proxy/ParentConsistentHash.cc
+++ b/proxy/ParentConsistentHash.cc
@@ -144,7 +144,7 @@ ParentConsistentHash::selectParent(const ParentSelectionPolicy *policy, bool fir
           pRec = (parents[last_lookup] + prtmp->idx);
         }
         else  
->         pRec = NULL; 
+          pRec = NULL; 
       } while (prtmp && strcmp(prtmp->hostname, result->hostname) == 0);
     }
   }
@@ -188,7 +188,7 @@ ParentConsistentHash::selectParent(const ParentSelectionPolicy *policy, bool fir
           Debug("parent_select", "Selected a new parent: %s.", pRec->hostname);
         }
         else
->         pRec = NULL;
+          pRec = NULL;
       }
       if (wrap_around[PRIMARY] && chash[SECONDARY] == NULL) {
         Debug("parent_select", "No available parents.");

--- a/proxy/ParentConsistentHash.cc
+++ b/proxy/ParentConsistentHash.cc
@@ -143,6 +143,8 @@ ParentConsistentHash::selectParent(const ParentSelectionPolicy *policy, bool fir
         if (prtmp) {
           pRec = (parents[last_lookup] + prtmp->idx);
         }
+        else  
+>         pRec = NULL; 
       } while (prtmp && strcmp(prtmp->hostname, result->hostname) == 0);
     }
   }
@@ -185,6 +187,8 @@ ParentConsistentHash::selectParent(const ParentSelectionPolicy *policy, bool fir
           pRec = (parents[last_lookup] + prtmp->idx);
           Debug("parent_select", "Selected a new parent: %s.", pRec->hostname);
         }
+        else
+>         pRec = NULL;
       }
       if (wrap_around[PRIMARY] && chash[SECONDARY] == NULL) {
         Debug("parent_select", "No available parents.");

--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -717,8 +717,8 @@ ParentRecord::~ParentRecord()
   if(parents != NULL) {
     ats_free(parents);
   }
-  if(second_parents != NULL) {
-    ats_free(second_parents);
+  if(secondary_parents != NULL) {
+    ats_free(secondary_parents);
   }
   delete selection_strategy;
   delete unavailable_server_retry_responses;

--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -714,7 +714,12 @@ ParentRecord::UpdateMatch(ParentResult *result, RequestData *rdata)
 
 ParentRecord::~ParentRecord()
 {
-  ats_free(parents);
+  if(parents != NULL) {
+    ats_free(parents);
+  }
+  if(second_parents != NULL) {
+    ats_free(second_parents);
+  }
   delete selection_strategy;
   delete unavailable_server_retry_responses;
 }

--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -434,6 +434,7 @@ ParentRecord::ProcessParents(char *val, bool isPrimary)
       this->parents[i].hostname[tmp - current] = '\0';
       this->parents[i].port                    = port;
       this->parents[i].failedAt                = 0;
+      this->parents[i].failCount               = 0;
       this->parents[i].scheme                  = scheme;
       this->parents[i].idx                     = i;
       this->parents[i].name                    = this->parents[i].hostname;
@@ -444,6 +445,7 @@ ParentRecord::ProcessParents(char *val, bool isPrimary)
       this->secondary_parents[i].hostname[tmp - current] = '\0';
       this->secondary_parents[i].port                    = port;
       this->secondary_parents[i].failedAt                = 0;
+      this->parents[i].failCount                         = 0;
       this->secondary_parents[i].scheme                  = scheme;
       this->secondary_parents[i].idx                     = i;
       this->secondary_parents[i].name                    = this->secondary_parents[i].hostname;

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -3607,6 +3607,7 @@ HttpTransact::handle_response_from_parent(State *s)
   default: {
     LookingUp_t next_lookup = UNDEFINED_LOOKUP;
     DebugTxn("http_trans", "[hrfp] connection not alive");
+    s->state_machine->do_hostdb_update_if_necessary();
     SET_VIA_STRING(VIA_DETAIL_PP_CONNECT, VIA_DETAIL_PP_FAILURE);
 
     ink_assert(s->hdr_info.server_request.valid());


### PR DESCRIPTION
Fix the following bugs:
(TS-4743) parent use consistent_hash Strategy may cause crash while first parent is not set
(TS-4744) ParentConsistentHash::selectParent may select the unavailable parent
(TS-4745) pRecord.failCount not init inParentRecord::ProcessParents
(TS-4746) ParentRecord *secondary_parents malloc, but no place free,which will cause memery leak
(TS-4747) if the connection of parent is notalive, not make the parent host down,which will select the the unavailablehost again