### PR TITLE
TS-4755: Header Frequency plugin. Initial version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1986,6 +1986,7 @@ AC_CONFIG_FILES([
   plugins/experimental/epic/Makefile
   plugins/experimental/escalate/Makefile
   plugins/experimental/geoip_acl/Makefile
+  plugins/experimental/header_freq/Makefile
   plugins/experimental/header_normalize/Makefile
   plugins/experimental/hipes/Makefile
   plugins/experimental/inliner/Makefile

--- a/doc/admin-guide/plugins/header_freq.en.rst
+++ b/doc/admin-guide/plugins/header_freq.en.rst
@@ -1,0 +1,40 @@
+.. _header_freq-plugin:
+
+Header Frequency Plugin
+***********************
+
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+
+The Header Frequency plugin keeps track of the number of times headers
+have been seen in transactions. Two separate counteres are kept for
+the origin and the client. This information is accessible via ::
+
+    traffic_ctl plugin msg header_freq log
+
+Installation
+------------
+
+This plugin is only built if the configure option ::
+
+    --enable-experimental-plugins
+
+is given at build time.
+
+Add the following line to :file:`plugin.config`::
+
+    header_freq.so

--- a/doc/admin-guide/plugins/index.en.rst
+++ b/doc/admin-guide/plugins/index.en.rst
@@ -132,6 +132,7 @@ directory of the |TS| source tree. Experimental plugins can be compiled by passi
    Epic <epic.en>
    Escalate <escalate.en>
    GeoIP ACL <geoip_acl.en>
+   Header Frequency <header_freq.en>
    HIPES <hipes.en>
    Memcache <memcache.en>
    Metalink <metalink.en>
@@ -170,6 +171,9 @@ directory of the |TS| source tree. Experimental plugins can be compiled by passi
 
 :doc:`GeoIP ACL <geoip_acl.en>`
    Deny or allow requests based on the source IP geo-location.
+
+:doc:`Header Frequency <header_freq.en>`
+   Count the frequency of headers.
 
 :doc:`HIPES <hipes.en>`
    Adds support for HTTP Pipes.

--- a/plugins/experimental/header_freq/Makefile.am
+++ b/plugins/experimental/header_freq/Makefile.am
@@ -14,50 +14,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-SUBDIRS = \
- acme \
- balancer \
- buffer_upload \
- cache_promote \
- cache_range_requests \
- cachekey \
- collapsed_connection \
- collapsed_forwarding \
- custom_redirect \
- epic \
- escalate \
- geoip_acl \
- header_normalize \
- header_freq \
- hipes \
- inliner \
- memcache \
- memcached_remap \
- metalink \
- mp4 \
- multiplexer \
- remap_stats \
- remap_purge \
- ssl_cert_loader \
- sslheaders \
- stale_while_revalidate \
- stream_editor \
- ts_lua \
- url_sig
+include $(top_srcdir)/build/plugins.mk
 
-if ENABLE_CPPAPI
-if BUILD_WEBP_TRANSFORM_PLUGIN
- SUBDIRS += webp_transform
-endif
-endif
+pkglib_LTLIBRARIES = header_freq.la
+header_freq_la_SOURCES = header_freq.cc
+header_freq_la_LDFLAGS = $(TS_PLUGIN_LDFLAGS)
 
-if HAS_MYSQL
-  SUBDIRS += mysql_remap
-endif
-
-if HAS_KYOTOCABINET
-  SUBDIRS += cache_key_genid
-endif
 
 include $(top_srcdir)/build/tidy.mk
 

--- a/plugins/experimental/header_freq/header_freq.cc
+++ b/plugins/experimental/header_freq/header_freq.cc
@@ -1,0 +1,222 @@
+/** @file
+
+  This plugin counts the number of times every header has appeared.
+  Maintains separate counts for client and origin headers.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <stdlib.h>
+#include <string.h>
+#include <string>
+#include <ts/ts.h>
+
+
+// plugin registration info
+static char plugin_name[]   = "header_freq";
+static char vendor_name[]   = "Apache Software Foundation";
+static char support_email[] = "dev@trafficserver.apache.org";
+
+// debug messages during one-time initialization
+static const char DEBUG_TAG_INIT[] = "header_freq.init";
+
+// debug messages in continuation callbacks
+static const char DEBUG_TAG_HOOK[] = "header_freq.hook";
+
+// maps from header name to # of times encountered
+static std::map<std::string, unsigned int> client_freq;
+static std::map<std::string, unsigned int> origin_freq;
+
+// for traffic_ctl, name is a convenient identifier
+static const char *ctl_tag = plugin_name;
+static const char *ctl_log = "log"; // log all data
+
+/**
+ * Logs the data collected, first the client, and then
+ * the origin headers.
+ */
+void
+log()
+{
+  std::stringstream ss("");
+
+  ss << std::endl << std::string(100, '+') << std::endl;
+
+  ss << "CLIENT HEADERS" << std::endl;
+  for (auto &elem: client_freq) {
+    ss << elem.first << ": " << elem.second << std::endl;
+  }
+
+  ss << std::endl;
+
+  ss << "ORIGIN HEADERS" << std::endl;
+  for (auto &elem: origin_freq) {
+    ss << elem.first << ": " << elem.second << std::endl;
+  }
+
+  ss << std::string(100, '+') << std::endl;
+  std::cout << ss.str() << std::endl; 
+}
+
+/**
+ * Records all headers found in the buffer in the map provided. Comparison
+ * against existing entries is case-insensitive.
+ */
+void
+count_all_headers(TSMBuffer &bufp, TSMLoc &hdr_loc, std::map<std::string, unsigned int> &map)
+{
+  TSMLoc hdr, next_hdr;
+  hdr = TSMimeHdrFieldGet(bufp, hdr_loc, 0);
+  int n_headers = TSMimeHdrFieldsCount(bufp, hdr_loc);
+  TSDebug(DEBUG_TAG_HOOK, "%d headers found", n_headers);
+
+  // iterate through all headers
+  for (int i = 0; i < n_headers; ++i) {
+    if (hdr == NULL)
+      break;
+    next_hdr = TSMimeHdrFieldNext(bufp, hdr_loc, hdr);
+    int hdr_len;
+    const char *hdr_name = TSMimeHdrFieldNameGet(bufp, hdr_loc, hdr, &hdr_len);
+
+    std::string str = std::string(hdr_name, hdr_len);
+
+    // make case-insensitive by converting to lowercase
+    for (auto &c: str) {
+      c = tolower(c);
+    }
+
+    // count the header
+    if (map.find(str) == map.end()) {
+      // Not found.
+      map[str] = 1;
+     } else {
+      // Found.
+      ++map[str];
+    }
+
+    TSHandleMLocRelease(bufp, hdr_loc, hdr);
+    hdr = next_hdr;
+  }
+
+  TSHandleMLocRelease(bufp, TS_NULL_MLOC, hdr_loc);
+}
+
+/**
+ * Continuation callback. Invoked to count headers on READ_REQUEST_HDR and
+ * SEND_RESPONSE_HDR hooks and to log through traffic_ctl's LIFECYCLE_MSG.
+ */
+static int
+handle_hook(TSCont contp, TSEvent event, void *edata)
+{
+  TSHttpTxn txnp;
+  TSMBuffer bufp;
+  TSMLoc hdr_loc;
+  int ret_val = 0;
+  switch(event){
+  case TS_EVENT_HTTP_READ_REQUEST_HDR: // count client headers
+    {
+      TSDebug(DEBUG_TAG_HOOK, "event TS_EVENT_HTTP_READ_REQUEST_HDR");
+      txnp = reinterpret_cast<TSHttpTxn>(edata);
+      // get the client request so we can loop through the headers
+      if (TSHttpTxnClientReqGet(txnp, &bufp, &hdr_loc) != TS_SUCCESS) {
+        TSError("(%s) could not get request headers", plugin_name);
+        TSHttpTxnReenable(txnp, TS_EVENT_HTTP_ERROR);
+        ret_val = -1;
+        break;
+      }
+      count_all_headers(bufp, hdr_loc, client_freq);
+      TSHttpTxnReenable(txnp, TS_EVENT_HTTP_CONTINUE);
+    }
+    break;
+  case TS_EVENT_HTTP_SEND_RESPONSE_HDR: // count origin headers
+    {
+      TSDebug(DEBUG_TAG_HOOK, "event TS_EVENT_HTTP_SEND_RESPONSE_HDR");
+      // get the response so we can loop through the headers
+      txnp = reinterpret_cast<TSHttpTxn>(edata);
+      if (TSHttpTxnClientRespGet(txnp, &bufp, &hdr_loc) != TS_SUCCESS) {
+        TSError("(%s) could not get response headers", plugin_name);
+        TSHttpTxnReenable(txnp, TS_EVENT_HTTP_ERROR);
+        ret_val = -2;
+        break;
+      }
+      count_all_headers(bufp, hdr_loc, origin_freq);
+      TSHttpTxnReenable(txnp, TS_EVENT_HTTP_CONTINUE);
+    }
+    break;
+  case TS_EVENT_LIFECYCLE_MSG:
+    {
+      TSDebug(DEBUG_TAG_HOOK, "event TS_EVENT_LIFECYCLE_MSG");
+      TSPluginMsg* msgp = reinterpret_cast<TSPluginMsg*>(edata);
+
+      if (strcmp(ctl_tag, msgp->tag))
+        {
+          TSDebug(DEBUG_TAG_HOOK, "tag %s does not concern us", msgp->tag);
+          return 0;
+        }
+
+      // identify the command
+      if (strncmp(ctl_log, reinterpret_cast<const char*>(msgp->data),
+          strlen(ctl_log)) == 0) {
+        log();
+      }
+
+    }
+    break;
+  // do nothing in any of the other states
+  default:
+    break;
+  }
+  return ret_val;
+}
+
+/**
+ * Entry point for the plugin.
+ */
+void
+TSPluginInit(int argc, const char *argv[])
+{
+  TSDebug(DEBUG_TAG_INIT, "initializing plugin");
+
+  TSPluginRegistrationInfo info;
+
+  info.plugin_name = plugin_name;
+  info.vendor_name = vendor_name;
+  info.support_email = support_email;
+
+  if (TSPluginRegister(&info) != TS_SUCCESS) {
+    TSError("[%s](%s) Plugin registration failed. \n", plugin_name,
+    __FUNCTION__);
+  }
+
+  TSCont contp = TSContCreate(handle_hook, NULL);
+  if (contp == NULL) {
+    // Continuation initialization failed. Unrecoverable, report and exit.
+    TSError("(%s)[%s] could not create continuation", plugin_name,
+            __FUNCTION__);
+    abort();
+  } else {
+    // Continuation initialization succeeded
+    TSHttpHookAdd(TS_HTTP_READ_REQUEST_HDR_HOOK, contp);
+    TSHttpHookAdd(TS_HTTP_SEND_RESPONSE_HDR_HOOK, contp);
+    TSLifecycleHookAdd(TS_LIFECYCLE_MSG_HOOK, contp);
+  }
+}

--- a/plugins/experimental/header_freq/header_freq.cc
+++ b/plugins/experimental/header_freq/header_freq.cc
@@ -50,24 +50,6 @@ static std::map<std::string, unsigned int> origin_freq;
 static const char *ctl_tag = plugin_name;
 static const char *ctl_log = "log"; // log all data
 
-static TSMutex freq_mutex;          // lock on global data
-static const int retry_time = 10;   // spin after TSMutexLockTry failures
-
-static const char *log_name = plugin_name;
-static TSTextLogObject log;
-
-static bool
-freq_lock_try(TSCont contp)
-{
-  if (TSMutexLockTry(freq_mutex) != TS_SUCCESS) {
-    TSDebug(DEBUG_TAG_HOOK, "Unable to acquire lock. Retrying in %d "
-                            "milliseconds", retry_time);
-    TSContSchedule(contp, retry_time, TS_THREAD_POOL_DEFAULT);
-    return false;
-  }
-  return true;
-}
-
 /**
  * Logs the data collected, first the client, and then
  * the origin headers.
@@ -92,7 +74,7 @@ log_frequencies()
   }
 
   ss << std::string(100, '+') << std::endl;
-  TSTextLogObjectWrite(log, "%s", ss.str().c_str());
+  std::cout << ss.str() << std::endl;
 }
 
 /**
@@ -122,14 +104,7 @@ count_all_headers(TSMBuffer &bufp, TSMLoc &hdr_loc, std::map<std::string, unsign
       c = tolower(c);
     }
 
-    // count the header
-    if (map.find(str) == map.end()) {
-      // Not found.
-      map[str] = 1;
-     } else {
-      // Found.
-      ++map[str];
-    }
+    ++map[str];
 
     TSHandleMLocRelease(bufp, hdr_loc, hdr);
     hdr = next_hdr;
@@ -150,13 +125,6 @@ handle_hook(TSCont contp, TSEvent event, void *edata)
   TSMLoc hdr_loc;
   int ret_val = 0;
 
-  // Treats the handler as a critical section because all events touch global
-  // data
-  if (!freq_lock_try(contp)) {
-    ret_val = -1;
-    return ret_val;
-  }
-
   switch(event){
   case TS_EVENT_HTTP_READ_REQUEST_HDR: // count client headers
     {
@@ -166,7 +134,7 @@ handle_hook(TSCont contp, TSEvent event, void *edata)
       if (TSHttpTxnClientReqGet(txnp, &bufp, &hdr_loc) != TS_SUCCESS) {
         TSError("(%s) could not get request headers", plugin_name);
         TSHttpTxnReenable(txnp, TS_EVENT_HTTP_ERROR);
-        ret_val = -2;
+        ret_val = -1;
         break;
       }
       count_all_headers(bufp, hdr_loc, client_freq);
@@ -181,7 +149,7 @@ handle_hook(TSCont contp, TSEvent event, void *edata)
       if (TSHttpTxnClientRespGet(txnp, &bufp, &hdr_loc) != TS_SUCCESS) {
         TSError("(%s) could not get response headers", plugin_name);
         TSHttpTxnReenable(txnp, TS_EVENT_HTTP_ERROR);
-        ret_val = -3;
+        ret_val = -2;
         break;
       }
       count_all_headers(bufp, hdr_loc, origin_freq);
@@ -212,7 +180,6 @@ handle_hook(TSCont contp, TSEvent event, void *edata)
     break;
   }
 
-  TSMutexUnlock(freq_mutex);
   return ret_val;
 }
 
@@ -235,17 +202,7 @@ TSPluginInit(int argc, const char *argv[])
     __FUNCTION__);
   }
   
-  TSDebug(DEBUG_TAG_INIT, "initializing log with name %s", log_name);
-  if (TSTextLogObjectCreate(log_name, TS_LOG_MODE_ADD_TIMESTAMP, &log) !=
-      TS_SUCCESS) {
-    // Log initialization failed. Unrecoverable, report and exit.
-    TSError("(%s)[%s] could not initialize log with name %s", plugin_name,
-            __FUNCTION__, log_name);
-    abort();
-  }
-
-  freq_mutex = TSMutexCreate();
-  TSCont contp = TSContCreate(handle_hook, NULL);
+  TSCont contp = TSContCreate(handle_hook, TSMutexCreate());
   if (contp == NULL) {
     // Continuation initialization failed. Unrecoverable, report and exit.
     TSError("(%s)[%s] could not create continuation", plugin_name,


### PR DESCRIPTION
Very basic version of the plugin. Additional options can be added to traffic_ctl to reset the counters, to print specific headers, maybe regex support. Additionally, the simple counters can be converted to decimal fractions.

Also, I am not convinced I am retrieving the relevant headers via TSHttpClientRespGet. Any feedback would be great.