### PR TITLE
TS-4763: Consistent request bytes logging tags.

### DIFF
--- a/doc/admin-guide/monitoring/logging/log-formats.en.rst
+++ b/doc/admin-guide/monitoring/logging/log-formats.en.rst
@@ -389,6 +389,12 @@ The following list describes |TS| custom logging fields.
     The client request header length; the header length in the client
     request to |TS|.
 
+.. _cqql:
+
+``cqql``
+    The total client request length; the header length and content length of
+    the client request to |TS|.
+
 .. _cqhm:
 
 ``cqhm``
@@ -577,8 +583,13 @@ The following list describes |TS| custom logging fields.
 .. _csshl:
 
 ``csshl``
-    The cached header length in the origin server response to Traffic
-    Server (in bytes).
+    The cached header length in the origin server response to |TS| (in bytes).
+
+.. _cssql:
+
+``cssql``
+    The total cached response length; the header length and content
+    length of a cached origin server response.
 
 .. _csshv:
 
@@ -677,6 +688,12 @@ The following list describes |TS| custom logging fields.
     The proxy request header length; the header length in Traffic
     Server's request to the origin server.
 
+.. _pqql:
+
+``pqql``
+    The total proxy request length; the header length and content length
+    of Traffic Server's request to the origin server.
+
 .. _pqsi:
 
 ``pqsi``
@@ -755,6 +772,12 @@ The following list describes |TS| custom logging fields.
 
 ``sshl``
     The header length (in bytes) in the origin server response to |TS|.
+
+.. _ssql:
+
+``ssql``
+    The total server response length; the header length and content length
+    of the origin server response to |TS|.
 
 .. _sshv:
 

--- a/doc/admin-guide/monitoring/logging/log-formats.en.rst
+++ b/doc/admin-guide/monitoring/logging/log-formats.en.rst
@@ -189,9 +189,9 @@ Field  Symbol    Description
 8      sssc      The origin server response status code.
 9      sshl      The server response transfer length; the body length in the
                  origin server response to |TS|, in bytes.
-10     cqbl      The client request transfer length; the body length in the
+10     cqcl      The client request transfer length; the body length in the
                  client request to |TS|, in bytes.
-11     pqbl      The proxy request transfer length; the body length in the |TS|
+11     pqcl      The proxy request transfer length; the body length in the |TS|
                  request to the origin server.
 12     cqhl      The client request header length; the header length in the
                  client request to |TS|.
@@ -377,10 +377,10 @@ The following list describes |TS| custom logging fields.
 ``chp``
     The port number of the client's host machine.
 
-.. _cqbl:
+.. _cqcl:
 
-``cqbl``
-    The client request transfer length; the body length in the client
+``cqcl``
+    The client request content length; the body length in the client
     request to |TS| (in bytes).
 
 .. _cqhl:
@@ -665,10 +665,10 @@ The following list describes |TS| custom logging fields.
    The plugin tag for the transaction. This is set for plugin driven
    transactions via :c:func:`TSHttpConnectWithPluginId`.
 
-.. _pqbl:
+.. _pqcl:
 
-``pqbl``
-    The proxy request transfer length; the body length in Traffic
+``pqcl``
+    The proxy request content length; the body length in Traffic
     Server's request to the origin server.
 
 .. _pqhl:
@@ -917,8 +917,8 @@ s1                `pssc`_
 c1                `pscl`_
 s2                `sssc`_
 c2                `sscl`_
-b1                `cqbl`_
-b2                `pqbl`_
+b1                `cqcl`_
+b2                `pqcl`_
 h1                `cqhl`_
 h2                `pshl`_
 h3                `pqhl`_
@@ -931,7 +931,7 @@ This is the equivalent XML configuration for the log above::
     <LogFormat>
       <Name = "extended"/>
       <Format = "%<chi> - %<caun> [%<cqtn>] \"%<cqtx>\" %<pssc> %<pscl>
-         %<sssc> %<sscl> %<cqbl> %<pqbl> %<cqhl> %<pshl> %<pqhl> %<sshl> %<tts>"/>
+         %<sssc> %<sscl> %<cqcl> %<pqcl> %<cqhl> %<pshl> %<pqhl> %<sshl> %<tts>"/>
     </LogFormat>
 
 .. _admin-log-formats-netscape-extended2:
@@ -953,8 +953,8 @@ Netscape Extended-2 Field Symbols
 ``c1``              ``pscl``
 ``s2``              ``sssc``
 ``c2``              ``sscl``
-``b1``              ``cqbl``
-``b2``              ``pqbl``
+``b1``              ``cqcl``
+``b2``              ``pqcl``
 ``h1``              ``cqhl``
 ``h2``              ``pshl``
 ``h3``              ``pqhl``
@@ -971,7 +971,7 @@ This is the equivalent XML configuration for the log above::
     <LogFormat>
       <Name = "extended2"/>
       <Format = "%<chi> - %<caun> [%<cqtn>] \"%<cqtx>\" %<pssc> %<pscl>
-                 %<sssc> %<sscl> %<cqbl> %<pqbl> %<cqhl> %<pshl> %<pqhl> %<sshl> %<tts> %<phr> %<cfsc> %<pfsc> %<crc>"/>
+                 %<sssc> %<sscl> %<cqcl> %<pqcl> %<cqhl> %<pshl> %<pqhl> %<sshl> %<tts> %<phr> %<cfsc> %<pfsc> %<crc>"/>
     </LogFormat>
 
 .. _log-field-slicing:

--- a/proxy/config/logging.config.default
+++ b/proxy/config/logging.config.default
@@ -143,12 +143,12 @@ common = format {
 
 -- Extended Log Format.
 extended = format {
-  Format = '%<chi> - %<caun> [%<cqtn>] "%<cqtx>" %<pssc> %<pscl> %<sssc> %<sscl> %<cqbl> %<pqbl> %<cqhl> %<pshl> %<pqhl> %<sshl> %<tts>'
+  Format = '%<chi> - %<caun> [%<cqtn>] "%<cqtx>" %<pssc> %<pscl> %<sssc> %<sscl> %<cqcl> %<pqcl> %<cqhl> %<pshl> %<pqhl> %<sshl> %<tts>'
 }
 
 -- Extended2 Log Formats
 extended2 = format {
-  Format = '%<chi> - %<caun> [%<cqtn>] "%<cqtx>" %<pssc> %<pscl> %<sssc> %<sscl> %<cqbl> %<pqbl> %<cqhl> %<pshl> %<pqhl> %<sshl> %<tts> %<phr> %<cfsc> %<pfsc> %<crc>'
+  Format = '%<chi> - %<caun> [%<cqtn>] "%<cqtx>" %<pssc> %<pscl> %<sssc> %<sscl> %<cqcl> %<pqcl> %<cqhl> %<pshl> %<pqhl> %<sshl> %<tts> %<phr> %<cfsc> %<pfsc> %<crc>'
 }
 
 log.binary {

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -481,7 +481,7 @@ Log::init_fields()
   global_field_list.add(field, false);
   ink_hash_table_insert(field_symbol_hash, "puuid", field);
 
-  field = new LogField("client_req_body_len", "cqbl", LogField::sINT, &LogAccess::marshal_client_req_body_len,
+  field = new LogField("client_req_body_len", "cqbl", LogField::sINT, &LogAccess::marshal_client_req_content_len,
                        &LogAccess::unmarshal_int_to_str);
   global_field_list.add(field, false);
   ink_hash_table_insert(field_symbol_hash, "cqbl", field);
@@ -617,7 +617,7 @@ Log::init_fields()
   global_field_list.add(field, false);
   ink_hash_table_insert(field_symbol_hash, "pqhl", field);
 
-  field = new LogField("proxy_req_body_len", "pqbl", LogField::sINT, &LogAccess::marshal_proxy_req_body_len,
+  field = new LogField("proxy_req_body_len", "pqbl", LogField::sINT, &LogAccess::marshal_proxy_req_content_len,
                        &LogAccess::unmarshal_int_to_str);
   global_field_list.add(field, false);
   ink_hash_table_insert(field_symbol_hash, "pqbl", field);

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -471,6 +471,11 @@ Log::init_fields()
   global_field_list.add(field, false);
   ink_hash_table_insert(field_symbol_hash, "cqhl", field);
 
+  field = new LogField("client_req_squid_len", "cqql", LogField::sINT, &LogAccess::marshal_client_req_squid_len,
+                       &LogAccess::unmarshal_int_to_str);
+  global_field_list.add(field, false);
+  ink_hash_table_insert(field_symbol_hash, "cqql", field);
+
   field = new LogField("cache_lookup_url_canonical", "cluc", LogField::STRING, &LogAccess::marshal_cache_lookup_url_canon,
                        (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
   global_field_list.add(field, false);
@@ -623,6 +628,11 @@ Log::init_fields()
   global_field_list.add(field, false);
   ink_hash_table_insert(field_symbol_hash, "pqhl", field);
 
+  field = new LogField("proxy_req_squid_len", "pqql", LogField::sINT, &LogAccess::marshal_proxy_req_squid_len,
+                       &LogAccess::unmarshal_int_to_str);
+  global_field_list.add(field, false);
+  ink_hash_table_insert(field_symbol_hash, "pqql", field);
+
   // TS-4765: This alias is deprecated to be removed in 8.0.
   field = new LogField("proxy_req_body_len", "pqbl", LogField::sINT, &LogAccess::marshal_proxy_req_content_len,
                        &LogAccess::unmarshal_int_to_str);
@@ -719,6 +729,11 @@ Log::init_fields()
   global_field_list.add(field, false);
   ink_hash_table_insert(field_symbol_hash, "sshl", field);
 
+  field = new LogField("server_resp_squid_len", "ssql", LogField::sINT, &LogAccess::marshal_server_resp_squid_len,
+                       &LogAccess::unmarshal_int_to_str);
+  global_field_list.add(field, false);
+  ink_hash_table_insert(field_symbol_hash, "ssql", field);
+
   field = new LogField("server_resp_http_version", "sshv", LogField::dINT, &LogAccess::marshal_server_resp_http_version,
                        &LogAccess::unmarshal_http_version);
   global_field_list.add(field, false);
@@ -768,6 +783,11 @@ Log::init_fields()
                        &LogAccess::unmarshal_int_to_str);
   global_field_list.add(field, false);
   ink_hash_table_insert(field_symbol_hash, "csshl", field);
+
+  field = new LogField("cached_resp_squid_len", "cssql", LogField::sINT, &LogAccess::marshal_cache_resp_squid_len,
+                       &LogAccess::unmarshal_int_to_str);
+  global_field_list.add(field, false);
+  ink_hash_table_insert(field_symbol_hash, "cssql", field);
 
   field = new LogField("cached_resp_http_version", "csshv", LogField::dINT, &LogAccess::marshal_cache_resp_http_version,
                        &LogAccess::unmarshal_http_version);

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -481,10 +481,16 @@ Log::init_fields()
   global_field_list.add(field, false);
   ink_hash_table_insert(field_symbol_hash, "puuid", field);
 
+  // TS-4765: This alias is deprecated to be removed in 8.0.
   field = new LogField("client_req_body_len", "cqbl", LogField::sINT, &LogAccess::marshal_client_req_content_len,
                        &LogAccess::unmarshal_int_to_str);
   global_field_list.add(field, false);
   ink_hash_table_insert(field_symbol_hash, "cqbl", field);
+
+  field = new LogField("client_req_content_len", "cqcl", LogField::sINT, &LogAccess::marshal_client_req_content_len,
+                       &LogAccess::unmarshal_int_to_str);
+  global_field_list.add(field, false);
+  ink_hash_table_insert(field_symbol_hash, "cqcl", field);
 
   field = new LogField("client_req_tcp_reused", "cqtr", LogField::dINT, &LogAccess::marshal_client_req_tcp_reused,
                        &LogAccess::unmarshal_int_to_str);
@@ -617,10 +623,16 @@ Log::init_fields()
   global_field_list.add(field, false);
   ink_hash_table_insert(field_symbol_hash, "pqhl", field);
 
+  // TS-4765: This alias is deprecated to be removed in 8.0.
   field = new LogField("proxy_req_body_len", "pqbl", LogField::sINT, &LogAccess::marshal_proxy_req_content_len,
                        &LogAccess::unmarshal_int_to_str);
   global_field_list.add(field, false);
   ink_hash_table_insert(field_symbol_hash, "pqbl", field);
+
+  field = new LogField("proxy_req_content_len", "pqcl", LogField::sINT, &LogAccess::marshal_proxy_req_content_len,
+                       &LogAccess::unmarshal_int_to_str);
+  global_field_list.add(field, false);
+  ink_hash_table_insert(field_symbol_hash, "pqcl", field);
 
   field = new LogField("proxy_req_server_name", "pqsn", LogField::STRING, &LogAccess::marshal_proxy_req_server_name,
                        (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -49,6 +49,8 @@
 #include "LogBuffer.h"
 #include "Log.h"
 
+#define LOG_ACCESS_DEFAULT_FIELD(name, impl) \
+  int LogAccess::name(char *buf) { impl; }
 /*-------------------------------------------------------------------------
   LogAccess::init
   -------------------------------------------------------------------------*/
@@ -326,11 +328,11 @@ LogAccess::marshal_proxy_resp_content_type(char *buf)
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_proxy_resp_squid_len(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_proxy_resp_squid_len, DEFAULT_INT_FIELD)
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_squid_len, DEFAULT_INT_FIELD)
+LOG_ACCESS_DEFAULT_FIELD(marshal_proxy_req_squid_len, DEFAULT_INT_FIELD)
+LOG_ACCESS_DEFAULT_FIELD(marshal_server_resp_squid_len, DEFAULT_INT_FIELD)
+LOG_ACCESS_DEFAULT_FIELD(marshal_cache_resp_squid_len, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -241,7 +241,7 @@ LogAccess::marshal_client_req_header_len(char *buf)
   -------------------------------------------------------------------------*/
 
 int
-LogAccess::marshal_client_req_body_len(char *buf)
+LogAccess::marshal_client_req_content_len(char *buf)
 {
   DEFAULT_INT_FIELD;
 }
@@ -399,7 +399,7 @@ LogAccess::marshal_proxy_req_header_len(char *buf)
   -------------------------------------------------------------------------*/
 
 int
-LogAccess::marshal_proxy_req_body_len(char *buf)
+LogAccess::marshal_proxy_req_content_len(char *buf)
 {
   DEFAULT_INT_FIELD;
 }

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -75,135 +75,73 @@ LogAccess::init()
   implementation.
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_plugin_identity_id(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_plugin_identity_id, DEFAULT_INT_FIELD)
 
-int
-LogAccess::marshal_plugin_identity_tag(char *buf)
-{
-  DEFAULT_STR_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_plugin_identity_tag, DEFAULT_STR_FIELD)
 
-int
-LogAccess::marshal_client_host_ip(char *buf)
-{
-  DEFAULT_IP_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_host_ip, DEFAULT_IP_FIELD)
 
-int
-LogAccess::marshal_host_interface_ip(char *buf)
-{
-  DEFAULT_IP_FIELD;
-}
-
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-int
-LogAccess::marshal_cache_lookup_url_canon(char *buf)
-{
-  DEFAULT_STR_FIELD;
-}
-
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-int
-LogAccess::marshal_client_host_port(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_host_interface_ip, DEFAULT_IP_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_client_auth_user_name(char *buf)
-{
-  DEFAULT_STR_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_cache_lookup_url_canon, DEFAULT_STR_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_client_req_text(char *buf)
-{
-  DEFAULT_STR_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_host_port, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_client_req_http_method(char *buf)
-{
-  DEFAULT_STR_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_auth_user_name, DEFAULT_STR_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_client_req_url(char *buf)
-{
-  DEFAULT_STR_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_text, DEFAULT_STR_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_client_req_url_canon(char *buf)
-{
-  DEFAULT_STR_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_http_method, DEFAULT_STR_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_client_req_unmapped_url_canon(char *buf)
-{
-  DEFAULT_STR_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_url, DEFAULT_STR_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_client_req_unmapped_url_path(char *buf)
-{
-  DEFAULT_STR_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_url_canon, DEFAULT_STR_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_client_req_unmapped_url_host(char *buf)
-{
-  DEFAULT_STR_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_unmapped_url_canon, DEFAULT_STR_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_client_req_url_path(char *buf)
-{
-  DEFAULT_STR_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_unmapped_url_path, DEFAULT_STR_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_client_req_url_scheme(char *buf)
-{
-  DEFAULT_STR_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_unmapped_url_host, DEFAULT_STR_FIELD)
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_url_path, DEFAULT_STR_FIELD)
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_url_scheme, DEFAULT_STR_FIELD)
 
 /*-------------------------------------------------------------------------
   This case is special because it really stores 2 ints.
@@ -224,106 +162,59 @@ LogAccess::marshal_client_req_http_version(char *buf)
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_client_req_protocol_version(char *buf)
-{
-  DEFAULT_STR_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_protocol_version, DEFAULT_STR_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_client_req_header_len(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_header_len, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_client_req_content_len(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_content_len, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_client_req_tcp_reused(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_tcp_reused, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_client_req_is_ssl(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_is_ssl, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_client_req_ssl_reused(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_ssl_reused, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
 -------------------------------------------------------------------------*/
-int
-LogAccess::marshal_client_security_protocol(char *buf)
-{
-  DEFAULT_STR_FIELD;
-}
 
-int
-LogAccess::marshal_client_security_cipher_suite(char *buf)
-{
-  DEFAULT_STR_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_security_protocol, DEFAULT_STR_FIELD)
+
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_security_cipher_suite, DEFAULT_STR_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_client_finish_status_code(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_finish_status_code, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_client_req_id(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_id, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_client_req_uuid(char *buf)
-{
-  DEFAULT_STR_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_uuid, DEFAULT_STR_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_proxy_resp_content_type(char *buf)
-{
-  DEFAULT_STR_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_proxy_resp_content_type, DEFAULT_STR_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
@@ -337,121 +228,64 @@ LOG_ACCESS_DEFAULT_FIELD(marshal_cache_resp_squid_len, DEFAULT_INT_FIELD)
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_proxy_resp_content_len(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_proxy_resp_content_len, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_proxy_resp_status_code(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_proxy_resp_status_code, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_proxy_resp_header_len(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_proxy_resp_header_len, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_proxy_finish_status_code(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_proxy_finish_status_code, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_cache_result_code(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_cache_result_code, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_cache_hit_miss(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_cache_hit_miss, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_proxy_req_header_len(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_proxy_req_header_len, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_proxy_req_content_len(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_proxy_req_content_len, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_proxy_req_server_name(char *buf)
-{
-  DEFAULT_STR_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_proxy_req_server_name, DEFAULT_STR_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_proxy_req_server_ip(char *buf)
-{
-  DEFAULT_IP_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_proxy_req_server_ip, DEFAULT_IP_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_proxy_req_server_port(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_proxy_req_server_port, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_proxy_hierarchy_route(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_proxy_hierarchy_route, DEFAULT_INT_FIELD)
 
-#ifndef INK_NO_CONGESTION_CONTROL
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-
-int
-LogAccess::marshal_client_retry_after_time(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
-#endif
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_retry_after_time, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
@@ -488,56 +322,32 @@ LogAccess::marshal_proxy_host_ip(char *buf)
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_proxy_req_is_ssl(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_proxy_req_is_ssl, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_server_host_ip(char *buf)
-{
-  DEFAULT_IP_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_server_host_ip, DEFAULT_IP_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_server_host_name(char *buf)
-{
-  DEFAULT_STR_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_server_host_name, DEFAULT_STR_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_server_resp_status_code(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_server_resp_status_code, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_server_resp_content_len(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_server_resp_content_len, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_server_resp_header_len(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_server_resp_header_len, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   This case is special because it really stores 2 ints.
@@ -557,60 +367,35 @@ LogAccess::marshal_server_resp_http_version(char *buf)
 
 /*-------------------------------------------------------------------------
 -------------------------------------------------------------------------*/
-int
-LogAccess::marshal_server_resp_time_ms(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
 
-int
-LogAccess::marshal_server_resp_time_s(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_server_resp_time_ms, DEFAULT_INT_FIELD)
+
+LOG_ACCESS_DEFAULT_FIELD(marshal_server_resp_time_s, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
 -------------------------------------------------------------------------*/
-int
-LogAccess::marshal_server_transact_count(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+
+LOG_ACCESS_DEFAULT_FIELD(marshal_server_transact_count, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
 -------------------------------------------------------------------------*/
-int
-LogAccess::marshal_server_connect_attempts(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+
+LOG_ACCESS_DEFAULT_FIELD(marshal_server_connect_attempts, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_cache_resp_status_code(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_cache_resp_status_code, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_cache_resp_content_len(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_cache_resp_content_len, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_cache_resp_header_len(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_cache_resp_header_len, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   This case is special because it really stores 2 ints.
@@ -628,41 +413,21 @@ LogAccess::marshal_cache_resp_http_version(char *buf)
   return (2 * INK_MIN_ALIGN);
 }
 
-int
-LogAccess::marshal_cache_write_code(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_cache_write_code, DEFAULT_INT_FIELD)
 
-int
-LogAccess::marshal_cache_write_transform_code(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_cache_write_transform_code, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_transfer_time_ms(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_transfer_time_ms, DEFAULT_INT_FIELD)
 
-int
-LogAccess::marshal_transfer_time_s(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_transfer_time_s, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_file_size(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_file_size, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
@@ -682,11 +447,7 @@ LogAccess::marshal_http_header_field_escapify(LogField::Container /* container A
   DEFAULT_STR_FIELD;
 }
 
-int
-LogAccess::marshal_proxy_host_port(char *buf)
-{
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_proxy_host_port, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
 
@@ -699,13 +460,7 @@ LogAccess::marshal_proxy_host_port(char *buf)
   This does nothing because the timestamp is already in the LogEntryHeader.
   -------------------------------------------------------------------------*/
 
-int
-LogAccess::marshal_client_req_timestamp_sec(char *buf)
-{
-  // in the case of aggregate fields, we need the space, so we'll always
-  // reserve it.  For a non-aggregate timestamp, this space is not used.
-  DEFAULT_INT_FIELD;
-}
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_timestamp_sec, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/

--- a/proxy/logging/LogAccess.h
+++ b/proxy/logging/LogAccess.h
@@ -185,6 +185,7 @@ public:
   inkcoreapi virtual int marshal_client_req_url_scheme(char *);         // STR
   inkcoreapi virtual int marshal_client_req_http_version(char *);       // INT
   inkcoreapi virtual int marshal_client_req_protocol_version(char *);   // STR
+  inkcoreapi virtual int marshal_client_req_squid_len(char *);          // INT
   inkcoreapi virtual int marshal_client_req_header_len(char *);         // INT
   inkcoreapi virtual int marshal_client_req_content_len(char *);        // INT
   inkcoreapi virtual int marshal_client_req_tcp_reused(char *);         // INT
@@ -213,6 +214,7 @@ public:
   // proxy -> server fields
   //
   inkcoreapi virtual int marshal_proxy_req_header_len(char *);  // INT
+  inkcoreapi virtual int marshal_proxy_req_squid_len(char *);   // INT
   inkcoreapi virtual int marshal_proxy_req_content_len(char *); // INT
   inkcoreapi virtual int marshal_proxy_req_server_name(char *); // STR
   inkcoreapi virtual int marshal_proxy_req_server_ip(char *);   // INT
@@ -228,6 +230,7 @@ public:
   inkcoreapi virtual int marshal_server_host_ip(char *);           // INT
   inkcoreapi virtual int marshal_server_host_name(char *);         // STR
   inkcoreapi virtual int marshal_server_resp_status_code(char *);  // INT
+  inkcoreapi virtual int marshal_server_resp_squid_len(char *);    // INT
   inkcoreapi virtual int marshal_server_resp_content_len(char *);  // INT
   inkcoreapi virtual int marshal_server_resp_header_len(char *);   // INT
   inkcoreapi virtual int marshal_server_resp_http_version(char *); // INT
@@ -240,6 +243,7 @@ public:
   // cache -> client fields
   //
   inkcoreapi virtual int marshal_cache_resp_status_code(char *);  // INT
+  inkcoreapi virtual int marshal_cache_resp_squid_len(char *);    // INT
   inkcoreapi virtual int marshal_cache_resp_content_len(char *);  // INT
   inkcoreapi virtual int marshal_cache_resp_header_len(char *);   // INT
   inkcoreapi virtual int marshal_cache_resp_http_version(char *); // INT

--- a/proxy/logging/LogAccess.h
+++ b/proxy/logging/LogAccess.h
@@ -186,7 +186,7 @@ public:
   inkcoreapi virtual int marshal_client_req_http_version(char *);       // INT
   inkcoreapi virtual int marshal_client_req_protocol_version(char *);   // STR
   inkcoreapi virtual int marshal_client_req_header_len(char *);         // INT
-  inkcoreapi virtual int marshal_client_req_body_len(char *);           // INT
+  inkcoreapi virtual int marshal_client_req_content_len(char *);        // INT
   inkcoreapi virtual int marshal_client_req_tcp_reused(char *);         // INT
   inkcoreapi virtual int marshal_client_req_is_ssl(char *);             // INT
   inkcoreapi virtual int marshal_client_req_ssl_reused(char *);         // INT
@@ -213,7 +213,7 @@ public:
   // proxy -> server fields
   //
   inkcoreapi virtual int marshal_proxy_req_header_len(char *);  // INT
-  inkcoreapi virtual int marshal_proxy_req_body_len(char *);    // INT
+  inkcoreapi virtual int marshal_proxy_req_content_len(char *); // INT
   inkcoreapi virtual int marshal_proxy_req_server_name(char *); // STR
   inkcoreapi virtual int marshal_proxy_req_server_ip(char *);   // INT
   inkcoreapi virtual int marshal_proxy_req_server_port(char *); // INT

--- a/proxy/logging/LogAccessHttp.cc
+++ b/proxy/logging/LogAccessHttp.cc
@@ -667,7 +667,7 @@ LogAccessHttp::marshal_client_req_header_len(char *buf)
   -------------------------------------------------------------------------*/
 
 int
-LogAccessHttp::marshal_client_req_body_len(char *buf)
+LogAccessHttp::marshal_client_req_content_len(char *buf)
 {
   if (buf) {
     int64_t len = 0;
@@ -978,7 +978,7 @@ LogAccessHttp::marshal_proxy_req_header_len(char *buf)
   -------------------------------------------------------------------------*/
 
 int
-LogAccessHttp::marshal_proxy_req_body_len(char *buf)
+LogAccessHttp::marshal_proxy_req_content_len(char *buf)
 {
   if (buf) {
     int64_t val = 0;

--- a/proxy/logging/LogAccessHttp.cc
+++ b/proxy/logging/LogAccessHttp.cc
@@ -679,6 +679,19 @@ LogAccessHttp::marshal_client_req_content_len(char *buf)
   return INK_MIN_ALIGN;
 }
 
+int
+LogAccessHttp::marshal_client_req_squid_len(char *buf)
+{
+  if (buf) {
+    int64_t val = 0;
+    if (m_client_request) {
+      val = m_client_request->length_get() + m_http_sm->client_request_body_bytes;
+    }
+    marshal_int(buf, val);
+  }
+  return INK_MIN_ALIGN;
+}
+
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
@@ -991,6 +1004,19 @@ LogAccessHttp::marshal_proxy_req_content_len(char *buf)
 }
 
 int
+LogAccessHttp::marshal_proxy_req_squid_len(char *buf)
+{
+  if (buf) {
+    int64_t val = 0;
+    if (m_proxy_request) {
+      val = m_proxy_request->length_get() + m_http_sm->server_request_body_bytes;
+    }
+    marshal_int(buf, val);
+  }
+  return INK_MIN_ALIGN;
+}
+
+int
 LogAccessHttp::marshal_proxy_req_server_name(char *buf)
 {
   char *str = NULL;
@@ -1147,6 +1173,19 @@ LogAccessHttp::marshal_server_resp_header_len(char *buf)
 }
 
 int
+LogAccessHttp::marshal_server_resp_squid_len(char *buf)
+{
+  if (buf) {
+    int64_t val = 0;
+    if (m_server_response) {
+      val = m_server_response->length_get() + m_http_sm->server_response_body_bytes;
+    }
+    marshal_int(buf, val);
+  }
+  return INK_MIN_ALIGN;
+}
+
+int
 LogAccessHttp::marshal_server_resp_http_version(char *buf)
 {
   if (buf) {
@@ -1241,6 +1280,19 @@ LogAccessHttp::marshal_cache_resp_content_len(char *buf)
     int64_t val = 0;
     if (m_cache_response) {
       val = m_http_sm->cache_response_body_bytes;
+    }
+    marshal_int(buf, val);
+  }
+  return INK_MIN_ALIGN;
+}
+
+int
+LogAccessHttp::marshal_cache_resp_squid_len(char *buf)
+{
+  if (buf) {
+    int64_t val = 0;
+    if (m_cache_response) {
+      val = m_cache_response->length_get() + m_http_sm->cache_response_body_bytes;
     }
     marshal_int(buf, val);
   }

--- a/proxy/logging/LogAccessHttp.h
+++ b/proxy/logging/LogAccessHttp.h
@@ -72,6 +72,7 @@ public:
   virtual int marshal_client_req_protocol_version(char *);   // STR
   virtual int marshal_client_req_header_len(char *);         // INT
   virtual int marshal_client_req_content_len(char *);        // INT
+  virtual int marshal_client_req_squid_len(char *);          // INT
   virtual int marshal_client_req_tcp_reused(char *);         // INT
   virtual int marshal_client_req_is_ssl(char *);             // INT
   virtual int marshal_client_req_ssl_reused(char *);         // INT
@@ -85,10 +86,10 @@ public:
   // proxy -> client fields
   //
   virtual int marshal_proxy_resp_content_type(char *);  // STR
-  virtual int marshal_proxy_resp_squid_len(char *);     // INT
-  virtual int marshal_proxy_resp_content_len(char *);   // INT
-  virtual int marshal_proxy_resp_status_code(char *);   // INT
   virtual int marshal_proxy_resp_header_len(char *);    // INT
+  virtual int marshal_proxy_resp_content_len(char *);   // INT
+  virtual int marshal_proxy_resp_squid_len(char *);     // INT
+  virtual int marshal_proxy_resp_status_code(char *);   // INT
   virtual int marshal_proxy_finish_status_code(char *); // INT
   virtual int marshal_cache_result_code(char *);        // INT
   virtual int marshal_cache_hit_miss(char *);           // INT
@@ -98,6 +99,7 @@ public:
   //
   virtual int marshal_proxy_req_header_len(char *);  // INT
   virtual int marshal_proxy_req_content_len(char *); // INT
+  virtual int marshal_proxy_req_squid_len(char *);   // INT
   virtual int marshal_proxy_req_server_name(char *); // STR
   virtual int marshal_proxy_req_server_ip(char *);   // INT
   virtual int marshal_proxy_req_server_port(char *); // INT
@@ -111,8 +113,9 @@ public:
   virtual int marshal_server_host_ip(char *);           // INT
   virtual int marshal_server_host_name(char *);         // STR
   virtual int marshal_server_resp_status_code(char *);  // INT
-  virtual int marshal_server_resp_content_len(char *);  // INT
   virtual int marshal_server_resp_header_len(char *);   // INT
+  virtual int marshal_server_resp_content_len(char *);  // INT
+  virtual int marshal_server_resp_squid_len(char *);    // INT
   virtual int marshal_server_resp_http_version(char *); // INT
   virtual int marshal_server_resp_time_ms(char *);      // INT
   virtual int marshal_server_resp_time_s(char *);       // INT
@@ -123,8 +126,9 @@ public:
   // cache -> client fields
   //
   virtual int marshal_cache_resp_status_code(char *);  // INT
-  virtual int marshal_cache_resp_content_len(char *);  // INT
   virtual int marshal_cache_resp_header_len(char *);   // INT
+  virtual int marshal_cache_resp_content_len(char *);  // INT
+  virtual int marshal_cache_resp_squid_len(char *);    // INT
   virtual int marshal_cache_resp_http_version(char *); // INT
 
   //

--- a/proxy/logging/LogAccessHttp.h
+++ b/proxy/logging/LogAccessHttp.h
@@ -71,7 +71,7 @@ public:
   virtual int marshal_client_req_http_version(char *);       // INT
   virtual int marshal_client_req_protocol_version(char *);   // STR
   virtual int marshal_client_req_header_len(char *);         // INT
-  virtual int marshal_client_req_body_len(char *);           // INT
+  virtual int marshal_client_req_content_len(char *);        // INT
   virtual int marshal_client_req_tcp_reused(char *);         // INT
   virtual int marshal_client_req_is_ssl(char *);             // INT
   virtual int marshal_client_req_ssl_reused(char *);         // INT
@@ -97,7 +97,7 @@ public:
   // proxy -> server fields
   //
   virtual int marshal_proxy_req_header_len(char *);  // INT
-  virtual int marshal_proxy_req_body_len(char *);    // INT
+  virtual int marshal_proxy_req_content_len(char *); // INT
   virtual int marshal_proxy_req_server_name(char *); // STR
   virtual int marshal_proxy_req_server_ip(char *);   // INT
   virtual int marshal_proxy_req_server_port(char *); // INT

--- a/proxy/logging/LogAccessTest.cc
+++ b/proxy/logging/LogAccessTest.cc
@@ -156,7 +156,7 @@ LogAccessTest::marshal_client_req_header_len(char *buf)
   -------------------------------------------------------------------------*/
 
 int
-LogAccessTest::marshal_client_req_body_len(char *buf)
+LogAccessTest::marshal_client_req_content_len(char *buf)
 {
   if (buf) {
     int64_t val = 4;
@@ -300,7 +300,7 @@ LogAccessTest::marshal_proxy_req_header_len(char *buf)
   -------------------------------------------------------------------------*/
 
 int
-LogAccessTest::marshal_proxy_req_body_len(char *buf)
+LogAccessTest::marshal_proxy_req_content_len(char *buf)
 {
   if (buf) {
     int64_t val = 12;

--- a/proxy/logging/LogAccessTest.h
+++ b/proxy/logging/LogAccessTest.h
@@ -55,7 +55,7 @@ public:
   virtual int marshal_client_req_url(char *);            // STR
   virtual int marshal_client_req_http_version(char *);   // INT
   virtual int marshal_client_req_header_len(char *);     // INT
-  virtual int marshal_client_req_body_len(char *);       // INT
+  virtual int marshal_client_req_content_len(char *);    // INT
   virtual int marshal_client_finish_status_code(char *); // INT
 
   //
@@ -74,7 +74,7 @@ public:
   // proxy -> server fields
   //
   virtual int marshal_proxy_req_header_len(char *);  // INT
-  virtual int marshal_proxy_req_body_len(char *);    // INT
+  virtual int marshal_proxy_req_content_len(char *); // INT
   virtual int marshal_proxy_hierarchy_route(char *); // INT
 
   //


### PR DESCRIPTION
Make the byte count logging tags consistent. We have

- ``cqbl`` - client request body length
- ``cqhl`` - client request header length
- ``pscl`` - client response body length
- ``pshl`` - client response header length
- ``psql`` - client response total length
- ``pqbl`` - server request body length
- ``pqhl`` - server request header length
- ``sscl`` - server response body length
- ``sshl`` - server response header length

We should add ``*ql`` to get the missing totals and standardize on ``*cl`` for the content length (``csscl`` marginally tips the balance towards "content length" in favor of "body length").