### PR TITLE
TS-4546: Fix a build error on OmniOS

### DIFF
--- a/proxy/http2/test_HPACK.cc
+++ b/proxy/http2/test_HPACK.cc
@@ -328,8 +328,14 @@ prepare()
     cerr << "Cannot open " << input_dir << endl;
     return 1;
   }
+  struct stat st;
+  char name[PATH_MAX + 1] = "";
+  strcat(name, input_dir.c_str());
   while ((d = readdir(dir)) != NULL) {
-    if (d->d_type == DT_REG) {
+    name[input_dir.length()] = '\0';
+    ink_strlcat(name, d->d_name, sizeof(name));
+    stat(name, &st);
+    if (!S_ISDIR(st.st_mode)) {
       ++last;
     }
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TS-4546
OmniOS doesn't have d_type in dirent structure, so use stat() instead.