### PR TITLE
TS-4217: Change stream state after sending HEADERS frame

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1190,6 +1190,15 @@ Http2ConnectionState::send_headers_frame(Http2Stream *stream)
   headers.alloc(buffer_size_index[HTTP2_FRAME_TYPE_HEADERS]);
   http2_write_headers(buf, payload_length, headers.write());
   headers.finalize(payload_length);
+
+  // Change stream state
+  if (!stream->change_state(HTTP2_FRAME_TYPE_HEADERS, flags)) {
+    this->send_goaway_frame(stream->get_id(), HTTP2_ERROR_PROTOCOL_ERROR);
+    h2_hdr.destroy();
+    ats_free(buf);
+    return;
+  }
+
   // xmit event
   SCOPED_MUTEX_LOCK(lock, this->ua_session->mutex, this_ethread());
   this->ua_session->handleEvent(HTTP2_SESSION_EVENT_XMIT, &headers);

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -207,6 +207,9 @@ Http2Stream::change_state(uint8_t type, uint8_t flags)
     if (type == HTTP2_FRAME_TYPE_RST_STREAM || (type == HTTP2_FRAME_TYPE_HEADERS && flags & HTTP2_FLAGS_HEADERS_END_STREAM) ||
         (type == HTTP2_FRAME_TYPE_DATA && flags & HTTP2_FLAGS_DATA_END_STREAM)) {
       _state = HTTP2_STREAM_STATE_CLOSED;
+    } else if (type == HTTP2_FRAME_TYPE_HEADERS) { // w/o END_STREAM flag
+      // No state change here. Expect a following DATA frame with END_STREAM flag.
+      return true;
     } else {
       return false;
     }


### PR DESCRIPTION
Change stream state to CLOSED after sending a HEADERS w/ END_STREAM flag to
avoid sending a unnecessary DATA frame w/ END_STREAM flag.