### PR TITLE
TS-4743: parent use consistent_hash Strategy may cause crash while first parent is not set

### DIFF
--- a/proxy/ParentConsistentHash.cc
+++ b/proxy/ParentConsistentHash.cc
@@ -166,7 +166,7 @@ ParentConsistentHash::selectParent(const ParentSelectionPolicy *policy, bool fir
       }
       Debug("parent_select", "wrap_around[PRIMARY]: %d, wrap_around[SECONDARY]: %d", wrap_around[PRIMARY], wrap_around[SECONDARY]);
       if (!wrap_around[PRIMARY] || (chash[SECONDARY] != NULL)) {
-        Debug("parent_select", "Selected parent %s is not available, looking up another parent.", pRec->hostname);
+        Debug("parent_select", "Selected parent %s is not available, looking up another parent.", pRec ? pRec->hostname:"[NULL]");
         if (chash[SECONDARY] != NULL && !wrap_around[SECONDARY]) {
           fhash       = chash[SECONDARY];
           last_lookup = SECONDARY;


### PR DESCRIPTION
parent use consistent_hash Strategy may cause crash while first parent is not set, due to the pRec is null.
