### PR TITLE
TS-4744: ParentConsistentHash::selectParent may select the unavailable parent

### DIFF
--- a/proxy/ParentConsistentHash.cc
+++ b/proxy/ParentConsistentHash.cc
@@ -143,6 +143,9 @@ ParentConsistentHash::selectParent(const ParentSelectionPolicy *policy, bool fir
         if (prtmp) {
           pRec = (parents[last_lookup] + prtmp->idx);
         }
+        else {
+          pRec = NULL;
+        }
       } while (prtmp && strcmp(prtmp->hostname, result->hostname) == 0);
     }
   }
@@ -166,7 +169,7 @@ ParentConsistentHash::selectParent(const ParentSelectionPolicy *policy, bool fir
       }
       Debug("parent_select", "wrap_around[PRIMARY]: %d, wrap_around[SECONDARY]: %d", wrap_around[PRIMARY], wrap_around[SECONDARY]);
       if (!wrap_around[PRIMARY] || (chash[SECONDARY] != NULL)) {
-        Debug("parent_select", "Selected parent %s is not available, looking up another parent.", pRec ? pRec->hostname:"[NULL]");
+        Debug("parent_select", "Selected parent %s is not available, looking up another parent.", pRec->hostname);
         if (chash[SECONDARY] != NULL && !wrap_around[SECONDARY]) {
           fhash       = chash[SECONDARY];
           last_lookup = SECONDARY;
@@ -184,6 +187,9 @@ ParentConsistentHash::selectParent(const ParentSelectionPolicy *policy, bool fir
         if (prtmp) {
           pRec = (parents[last_lookup] + prtmp->idx);
           Debug("parent_select", "Selected a new parent: %s.", pRec->hostname);
+        }
+        else {
+          pRec = NULL;
         }
       }
       if (wrap_around[PRIMARY] && chash[SECONDARY] == NULL) {


### PR DESCRIPTION
ParentConsistentHash::selectParent may select the unavailable parent