### PR TITLE
TS-4724: Added new server_request APIs to set/get host name and schem…

### DIFF
--- a/doc/admin-guide/plugins/ts_lua.en.rst
+++ b/doc/admin-guide/plugins/ts_lua.en.rst
@@ -1459,6 +1459,122 @@ Here is an example:
 
 `TOP <#ts-lua-plugin>`_
 
+ts.server_request.get_url_host
+------------------------------
+**syntax:** *host = ts.server_request.get_url_host()*
+
+**context:** function @ TS_LUA_HOOK_SEND_REQUEST_HDR hook point
+
+**description:** Return the ``host`` field of the request url.
+
+Here is an example:
+
+::
+
+    function send_request()
+        local url_host = ts.server_request.get_url_host()
+        print(url_host)
+    end
+
+    function do_remap()
+        ts.hook(TS_LUA_HOOK_SEND_REQUEST_HDR, send_request) 
+        return 0 
+    end
+
+Then ``GET http://abc.com/p2/a.txt HTTP/1.1`` will yield the output:
+
+``abc.com``
+
+`TOP <#ts-lua-plugin>`_
+
+ts.server_request.set_url_host
+------------------------------
+**syntax:** *ts.server_request.set_url_host(str)*
+
+**context:** function @ TS_LUA_HOOK_SEND_REQUEST_HDR hook point
+
+**description:** Set ``host`` field of the request url with ``str``. This function is used to change the host name in the GET request to next tier
+
+Here is an example:
+
+::
+
+    function send_request()
+        ts.server_request.set_url_host("")
+        ts.server_request.set_url_scheme("")
+    end
+
+    function do_remap()
+        ts.hook(TS_LUA_HOOK_SEND_REQUEST_HDR, send_request)
+        return 0
+    end
+
+The GET request like this:
+
+::
+
+    +++++++++ Proxy's Request +++++++++
+    – State Machine Id: 5593
+    GET http://origin.com/dir1/a.txt HTTP/1.1
+    User-Agent: curl/7.29.0
+    Host: abc.com
+    Accept: /
+    Client-ip: 135.xx.xx.xx
+    X-Forwarded-For: 135.xx.xx.xx
+
+Will be changed to:
+
+::
+
+    +++++++++ Proxy's Request +++++++++
+    – State Machine Id: 5593
+    GET /dir1/a.txt HTTP/1.1
+    User-Agent: curl/7.29.0
+    Host: abc.com
+    Accept: /
+    Client-ip: 135.xx.xx.xx
+    X-Forwarded-For: 135.xx.xx.xx
+
+`TOP <#ts-lua-plugin>`_
+
+ts.server_request.get_url_scheme
+--------------------------------
+**syntax:** *scheme = ts.server_request.get_url_scheme()*
+
+**context:** function @ TS_LUA_HOOK_SEND_REQUEST_HDR hook point 
+
+**description:** Return the ``scheme`` field of the request url.
+
+Here is an example:
+
+::
+
+    function send_request()
+        local url_scheme = ts.server_request.get_url_scheme()
+        print(url_host)
+    end
+
+    function do_remap()
+        ts.hook(TS_LUA_HOOK_SEND_REQUEST_HDR, send_request)
+        return 0
+    end
+
+Then ``GET /liuyurou.txt HTTP/1.1\r\nHost: 192.168.231.129:8080\r\n...`` will yield the output:
+
+``http``
+
+`TOP <#ts-lua-plugin>`_
+
+ts.server_request.set_url_scheme
+--------------------------------
+**syntax:** *ts.server_request.set_url_scheme(str)*
+
+**context:** function @ TS_LUA_HOOK_SEND_REQUEST_HDR hook point 
+
+**description:** Set ``scheme`` field of the request url with ``str``. This function is used to change the scheme of the server request.
+
+`TOP <#ts-lua-plugin>`_
+
 ts.server_response.get_status
 -----------------------------
 **syntax:** *status = ts.server_response.get_status()*

--- a/plugins/experimental/ts_lua/ts_lua_server_request.c
+++ b/plugins/experimental/ts_lua/ts_lua_server_request.c
@@ -50,6 +50,7 @@ static void ts_lua_inject_server_request_get_body_size_api(lua_State *L);
 static void ts_lua_inject_server_request_uri_api(lua_State *L);
 static void ts_lua_inject_server_request_uri_args_api(lua_State *L);
 static void ts_lua_inject_server_request_uri_params_api(lua_State *L);
+static void ts_lua_inject_server_request_url_api(lua_State *L);
 
 static int ts_lua_server_request_header_get(lua_State *L);
 static int ts_lua_server_request_header_set(lua_State *L);
@@ -62,6 +63,10 @@ static int ts_lua_server_request_set_uri_args(lua_State *L);
 static int ts_lua_server_request_get_uri_args(lua_State *L);
 static int ts_lua_server_request_set_uri_params(lua_State *L);
 static int ts_lua_server_request_get_uri_params(lua_State *L);
+static int ts_lua_server_request_get_url_host(lua_State *L);
+static int ts_lua_server_request_set_url_host(lua_State *L);
+static int ts_lua_server_request_get_url_scheme(lua_State *L);
+static int ts_lua_server_request_set_url_scheme(lua_State *L);
 
 static int ts_lua_server_request_server_addr_get_ip(lua_State *L);
 static int ts_lua_server_request_server_addr_get_port(lua_State *L);
@@ -82,6 +87,8 @@ ts_lua_inject_server_request_api(lua_State *L)
   ts_lua_inject_server_request_uri_api(L);
   ts_lua_inject_server_request_uri_args_api(L);
   ts_lua_inject_server_request_uri_params_api(L);
+
+  ts_lua_inject_server_request_url_api(L);
 
   lua_setfield(L, -2, "server_request");
 }
@@ -525,6 +532,111 @@ ts_lua_server_request_get_uri_params(lua_State *L)
   }
 
   return 1;
+}
+
+static void
+ts_lua_inject_server_request_url_api(lua_State *L)
+{
+  lua_pushcfunction(L, ts_lua_server_request_get_url_host);
+  lua_setfield(L, -2, "get_url_host");
+  lua_pushcfunction(L, ts_lua_server_request_set_url_host);
+  lua_setfield(L, -2, "set_url_host");
+
+  lua_pushcfunction(L, ts_lua_server_request_get_url_scheme);
+  lua_setfield(L, -2, "get_url_scheme");
+  lua_pushcfunction(L, ts_lua_server_request_set_url_scheme);
+  lua_setfield(L, -2, "set_url_scheme");
+
+}
+
+static int
+ts_lua_server_request_get_url_host(lua_State *L)
+{
+  const char *host;
+  int len = 0;
+
+  ts_lua_http_ctx *http_ctx;
+
+  GET_HTTP_CONTEXT(http_ctx, L);
+
+  host = TSUrlHostGet(http_ctx->server_request_bufp, http_ctx->server_request_url, &len);
+
+  if (len == 0) {
+    char *key   = "Host";
+    char *l_key = "host";
+    int key_len = 4;
+
+    TSMLoc field_loc;
+
+    field_loc = TSMimeHdrFieldFind(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, key, key_len);
+    if (field_loc) {
+      host = TSMimeHdrFieldValueStringGet(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc, -1, &len);
+      TSHandleMLocRelease(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc);
+
+    } else {
+      field_loc = TSMimeHdrFieldFind(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, l_key, key_len);
+      if (field_loc) {
+        host = TSMimeHdrFieldValueStringGet(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc, -1, &len);
+        TSHandleMLocRelease(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc);
+      }
+    }
+  }
+
+  lua_pushlstring(L, host, len);
+
+  return 1;
+}
+
+static int
+ts_lua_server_request_set_url_host(lua_State *L)
+{
+  const char *host;
+  size_t len;
+
+  ts_lua_http_ctx *http_ctx;
+
+  GET_HTTP_CONTEXT(http_ctx, L);
+  TS_LUA_CHECK_SERVER_REQUEST_URL(http_ctx);
+
+  host = luaL_checklstring(L, 1, &len);
+
+  TSUrlHostSet(http_ctx->server_request_bufp, http_ctx->server_request_url, host, len);
+
+  return 0;
+}
+
+static int
+ts_lua_server_request_get_url_scheme(lua_State *L)
+{
+  const char *scheme;
+  int len;
+
+  ts_lua_http_ctx *http_ctx;
+
+  GET_HTTP_CONTEXT(http_ctx, L);
+
+  scheme = TSUrlSchemeGet(http_ctx->server_request_bufp, http_ctx->server_request_url, &len);
+
+  lua_pushlstring(L, scheme, len);
+
+  return 1;
+}
+
+static int
+ts_lua_server_request_set_url_scheme(lua_State *L)
+{
+  const char *scheme;
+  size_t len;
+
+  ts_lua_http_ctx *http_ctx;
+
+  GET_HTTP_CONTEXT(http_ctx, L);
+
+  scheme = luaL_checklstring(L, 1, &len);
+
+  TSUrlSchemeSet(http_ctx->server_request_bufp, http_ctx->server_request_url, scheme, len);
+
+  return 0;
 }
 
 static int


### PR DESCRIPTION
Created new lua APIs "ts.server_request.set_url_host", "ts.server_request.get_url_host", "ts.server_request.set_url_scheme", and "ts.server_request.get_url_scheme " to Set/Get scheme and host name in the server request to next tier.

Refer Jira ticket TS-4724 for more information