### PR TITLE
TS-4776: Emulate the effect of O_DIRECTORY if it is not defined

### DIFF
--- a/iocore/hostdb/P_RefCountCacheSerializer.h
+++ b/iocore/hostdb/P_RefCountCacheSerializer.h
@@ -255,7 +255,16 @@ RefCountCacheSerializer<C>::finalize_sync()
     return error;
   }
 
+#ifdef O_DIRECTORY
   dirfd = socketManager.open(this->dirname.c_str(), O_DIRECTORY);
+#else
+  struct stat st;
+  stat(this->dirname.c_str(), &st);
+  if (!S_ISDIR(st.st_mode)) {
+    return -ENOTDIR;
+  }
+  dirfd = socketManager.open(this->dirname.c_str(), 0);
+#endif
   if (dirfd == -1) {
     return -errno;
   }


### PR DESCRIPTION
Emulate the effect of `O_DIRECTORY` with `stat()` if it is not defined. According to man page of `open()`, it returns `ENOTDIR` if the specified pass was not a directory.

> ENOTDIR
> A component used as a directory in pathname is not, in fact, a directory, or O_DIRECTORY was specified and pathname was not a directory.