### PR TITLE
TS-4745: Initializes pRecord.failCount in ParentRecord::ProcessParents.

### DIFF
--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -434,6 +434,7 @@ ParentRecord::ProcessParents(char *val, bool isPrimary)
       this->parents[i].hostname[tmp - current] = '\0';
       this->parents[i].port                    = port;
       this->parents[i].failedAt                = 0;
+      this->parents[i].failCount               = 0;
       this->parents[i].scheme                  = scheme;
       this->parents[i].idx                     = i;
       this->parents[i].name                    = this->parents[i].hostname;
@@ -444,6 +445,7 @@ ParentRecord::ProcessParents(char *val, bool isPrimary)
       this->secondary_parents[i].hostname[tmp - current] = '\0';
       this->secondary_parents[i].port                    = port;
       this->secondary_parents[i].failedAt                = 0;
+      this->secondary_parents[i].failCount               = 0;
       this->secondary_parents[i].scheme                  = scheme;
       this->secondary_parents[i].idx                     = i;
       this->secondary_parents[i].name                    = this->secondary_parents[i].hostname;


### PR DESCRIPTION
New pull request on behalf of keith2008 to insure that pRecord.failCount is properly initialized.