### PR TITLE
TS-4744: ParentConsistentHash::selectParent may select the unavailable parent.

### DIFF
--- a/proxy/ParentConsistentHash.cc
+++ b/proxy/ParentConsistentHash.cc
@@ -142,6 +142,8 @@ ParentConsistentHash::selectParent(const ParentSelectionPolicy *policy, bool fir
         prtmp = (pRecord *)fhash->lookup(NULL, &result->chashIter[last_lookup], &wrap_around[last_lookup], &hash);
         if (prtmp) {
           pRec = (parents[last_lookup] + prtmp->idx);
+        } else {
+          pRec = NULL;
         }
       } while (prtmp && strcmp(prtmp->hostname, result->hostname) == 0);
     }
@@ -184,6 +186,8 @@ ParentConsistentHash::selectParent(const ParentSelectionPolicy *policy, bool fir
         if (prtmp) {
           pRec = (parents[last_lookup] + prtmp->idx);
           Debug("parent_select", "Selected a new parent: %s.", pRec->hostname);
+        } else {
+          pRec = NULL;
         }
       }
       if (wrap_around[PRIMARY] && chash[SECONDARY] == NULL) {


### PR DESCRIPTION
I've created this pull request on behalf of @keith2008 who found the issue and opened the JIRA.  His pull request had merge conflicts and he has asked me to resolve them and submit this new PR for TS-4744.