### PR TITLE
TS-3577: Remove the --enable-static-proxy build option.

### DIFF
--- a/ci/tsqa/tests/test_buildoptions.py
+++ b/ci/tsqa/tests/test_buildoptions.py
@@ -45,12 +45,3 @@ class TestBuildOptionDisableDiags(TestBuildOption):
 class TestBuildOptionDisableTests(TestBuildOption):
     '''Build with --disable-tests'''
     environment_factory = {'configure': {'disable-tests': None}}
-
-
-class TestBuildOptionEnableStaticProxy(TestBuildOption):
-    '''Build with --enable-static-proxy'''
-    environment_factory = {'configure': {'enable-static-proxy': None}}
-
-    @classmethod
-    def setUpClass(cls):
-        raise helpers.unittest.SkipTest('Skip until TS-3577 is resolved')

--- a/configure.ac
+++ b/configure.ac
@@ -231,21 +231,6 @@ TS_ARG_ENABLE_VAR([has], [tests])
 AM_CONDITIONAL([BUILD_TESTS], [test 0 -ne $has_tests])
 
 #
-# Force some static linkage (for testing / development only)
-#
-AC_MSG_CHECKING([whether to build a static traffic_server binary])
-AC_ARG_ENABLE([static-proxy], [AS_HELP_STRING([--enable-static-proxy],[build a static traffic_server binary])], [
-    AC_ENABLE_STATIC
-  ], [
-    AC_DISABLE_STATIC
-    enable_static_proxy=no
-  ]
-)
-AC_MSG_RESULT([$enable_static_proxy])
-TS_ARG_ENABLE_VAR([has],[static-proxy])
-AM_CONDITIONAL([BUILD_STATIC_PROXY], [test 0 -ne $has_static_proxy])
-
-#
 # Remote Coverity Prevent commit
 #
 AC_MSG_CHECKING([whether to commit cov defects to remote host])

--- a/proxy/Makefile.am
+++ b/proxy/Makefile.am
@@ -191,10 +191,6 @@ endif
 
 traffic_server_LDFLAGS = $(AM_LDFLAGS)
 
-if BUILD_STATIC_PROXY
-traffic_server_LDFLAGS += -all-static
-endif
-
 traffic_server_LDADD = \
   http/libhttp.a \
   http2/libhttp2.a \


### PR DESCRIPTION
The --enable-static-proxy build option was theorized to help
performance on register-starved 32bit architectures. We don't support
32bit any more and no-one uses this option.