### PR TITLE
TS-4799: Allow minimum log rolling period to be as low as 30s.

### DIFF
--- a/proxy/logging/Log.h
+++ b/proxy/logging/Log.h
@@ -397,7 +397,7 @@ public:
   };
 
   enum {
-    MIN_ROLLING_INTERVAL_SEC = 60,   // 5 minute minimum rolling interval
+    MIN_ROLLING_INTERVAL_SEC = 30,   // 30 second minimum rolling interval
     MAX_ROLLING_INTERVAL_SEC = 86400 // 24 hrs rolling interval max
   };
 


### PR DESCRIPTION
Change the minimum allowed log rolling period from 60s to 30s.