### PR TITLE
TS-4806: Fix up event processor thread stacks

### DIFF
--- a/iocore/aio/test_AIO.cc
+++ b/iocore/aio/test_AIO.cc
@@ -400,6 +400,10 @@ main(int /* argc ATS_UNUSED */, char *argv[])
   RecProcessInit(RECM_STAND_ALONE);
   ink_event_system_init(EVENT_SYSTEM_MODULE_VERSION);
   eventProcessor.start(ink_number_of_processors());
+
+  Thread *main_thread = new EThread;
+  main_thread->set_specific();
+
 #if AIO_MODE == AIO_MODE_NATIVE
   int etype            = ET_NET;
   int n_netthreads     = eventProcessor.n_threads_for_type[etype];
@@ -446,5 +450,8 @@ main(int /* argc ATS_UNUSED */, char *argv[])
     }
   }
 
-  this_thread()->execute();
+  while (!shutdown_event_system) {
+    sleep(1);
+  }
+  delete main_thread;
 }

--- a/iocore/eventsystem/I_Thread.h
+++ b/iocore/eventsystem/I_Thread.h
@@ -145,7 +145,8 @@ private:
   Thread &operator=(const Thread &);
 
 public:
-  ink_thread start(const char *name, size_t stacksize = DEFAULT_STACKSIZE, ThreadFunction f = NULL, void *a = NULL);
+  ink_thread start(const char *name, size_t stacksize = DEFAULT_STACKSIZE, ThreadFunction f = NULL, void *a = NULL,
+                   void *stack = NULL);
 
   virtual void
   execute()

--- a/iocore/eventsystem/Thread.cc
+++ b/iocore/eventsystem/Thread.cc
@@ -87,7 +87,7 @@ spawn_thread_internal(void *a)
 }
 
 ink_thread
-Thread::start(const char *name, size_t stacksize, ThreadFunction f, void *a)
+Thread::start(const char *name, size_t stacksize, ThreadFunction f, void *a, void *stack)
 {
   thread_data_internal *p = (thread_data_internal *)ats_malloc(sizeof(thread_data_internal));
 
@@ -96,7 +96,7 @@ Thread::start(const char *name, size_t stacksize, ThreadFunction f, void *a)
   p->me = this;
   memset(p->name, 0, MAX_THREAD_NAME_LENGTH);
   ink_strlcpy(p->name, name, MAX_THREAD_NAME_LENGTH);
-  tid = ink_thread_create(spawn_thread_internal, (void *)p, 0, stacksize);
+  tid = ink_thread_create(spawn_thread_internal, (void *)p, 0, stacksize, stack);
 
   return tid;
 }

--- a/iocore/eventsystem/test_Buffer.cc
+++ b/iocore/eventsystem/test_Buffer.cc
@@ -42,6 +42,9 @@ main(int /* argc ATS_UNUSED */, const char * /* argv ATS_UNUSED */ [])
   ink_event_system_init(EVENT_SYSTEM_MODULE_VERSION);
   eventProcessor.start(TEST_THREADS);
 
+  Thread *main_thread = new EThread;
+  main_thread->set_specific();
+
   for (unsigned i = 0; i < 100; ++i) {
     MIOBuffer *b1                       = new_MIOBuffer(default_large_iobuffer_size);
     IOBufferReader *b1reader ATS_UNUSED = b1->alloc_reader();
@@ -58,6 +61,4 @@ main(int /* argc ATS_UNUSED */, const char * /* argv ATS_UNUSED */ [])
   }
 
   exit(0);
-  this_thread()->execute();
-  return 0;
 }

--- a/iocore/eventsystem/test_Event.cc
+++ b/iocore/eventsystem/test_Event.cc
@@ -73,6 +73,8 @@ main(int /* argc ATS_UNUSED */, const char * /* argv ATS_UNUSED */ [])
   process_killer *killer = new process_killer(new_ProxyMutex());
   eventProcessor.schedule_in(killer, HRTIME_SECONDS(10));
   eventProcessor.schedule_every(alrm, HRTIME_SECONDS(1));
-  this_thread()->execute();
+  while (!shutdown_event_system) {
+    sleep(1);
+  }
   return 0;
 }

--- a/lib/ts/ink_thread.h
+++ b/lib/ts/ink_thread.h
@@ -49,6 +49,7 @@
 #endif
 
 #define INK_MUTEX_INIT PTHREAD_MUTEX_INITIALIZER
+#define INK_THREAD_STACK_MIN PTHREAD_STACK_MIN
 
 typedef pthread_t ink_thread;
 typedef pthread_cond_t ink_cond;

--- a/lib/ts/ink_thread.h
+++ b/lib/ts/ink_thread.h
@@ -127,7 +127,7 @@ ink_thread_key_delete(ink_thread_key key)
 }
 
 static inline ink_thread
-ink_thread_create(void *(*f)(void *), void *a, int detached = 0, size_t stacksize = 0)
+ink_thread_create(void *(*f)(void *), void *a, int detached = 0, size_t stacksize = 0, void *stack = NULL)
 {
   ink_thread t;
   int ret;
@@ -137,7 +137,11 @@ ink_thread_create(void *(*f)(void *), void *a, int detached = 0, size_t stacksiz
   pthread_attr_setscope(&attr, PTHREAD_SCOPE_SYSTEM);
 
   if (stacksize) {
-    pthread_attr_setstacksize(&attr, stacksize);
+    if (stack) {
+      pthread_attr_setstack(&attr, stack, stacksize);
+    } else {
+      pthread_attr_setstacksize(&attr, stacksize);
+    }
   }
 
   if (detached) {

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -1924,8 +1924,7 @@ main(int /* argc ATS_UNUSED */, const char **argv)
                                 reinterpret_cast<void *>(static_cast<int>(MGMT_EVENT_STORAGE_DEVICE_CMD_OFFLINE)));
     pmgmt->registerMgmtCallback(MGMT_EVENT_LIFECYCLE_MESSAGE, mgmt_lifecycle_msg_callback, NULL);
 
-    // The main thread also becomes a net thread.
-    ink_set_thread_name("[ET_NET 0]");
+    ink_set_thread_name("[TS_MAIN]");
 
     Note("traffic server running");
 
@@ -1944,7 +1943,10 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   }
 #endif
 
-  this_thread()->execute();
+  while (!shutdown_event_system) {
+    sleep(1);
+  }
+
   delete main_thread;
 }
 


### PR DESCRIPTION
Fix event processor to create stacks on the appropriate numa node and with the appropriate page size. Also, stop using the main thread as ET_NET 0 since we can't control any of these aspects of it.