### PR TITLE
Fix SSLCreateServerContext always returning null

### DIFF
--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1824,8 +1824,9 @@ fail:
 SSL_CTX *
 SSLCreateServerContext(const SSLConfigParams *params)
 {
-  const ssl_user_config sslMultCertSettings;
+  ssl_user_config sslMultCertSettings;
   Vec<X509 *> cert_list;
+  sslMultCertSettings.opt = SSLCertContext::OPT_TUNNEL;
   SSL_CTX *ctx = SSLInitServerContext(params, sslMultCertSettings, cert_list);
   ink_assert(cert_list.length() == 0);
   return ctx;


### PR DESCRIPTION
This fixes TS-4769 but would like @shinrich's thoughts on whether this makes sense semantically.

The fix is to let the `SSLCreateServerContext` set the `SSLCertContext::OPT_TUNNEL` option on the `sslMultCertSettings` object, which in this case makes the call to `SSLInitServerContext` do the right thing and not look for any certificates in the multicert settings object and just initialize the context. 

What I'm not certain of is whether using OPT_TUNNEL for this could cause any confusion in the future...