### PR TITLE
TS-4800: Fix logging.config reloading.

### DIFF
--- a/lib/perl/lib/Apache/TS/AdminClient.pm
+++ b/lib/perl/lib/Apache/TS/AdminClient.pm
@@ -597,7 +597,7 @@ The Apache Traffic Server Administration Manual will explain what these strings 
  proxy.config.log.rolling_size_mb
  proxy.config.log.sampling_frequency
  proxy.config.log.space_used_frequency
- proxy.config.log.xml_config_file
+ proxy.config.log.config.filename
  proxy.config.manager_binary
  proxy.config.net.connections_throttle
  proxy.config.net.listen_backlog

--- a/proxy/logging/LogConfig.cc
+++ b/proxy/logging/LogConfig.cc
@@ -548,7 +548,7 @@ LogConfig::register_config_callbacks()
     "proxy.config.log.rolling_offset_hr",
     "proxy.config.log.rolling_size_mb",
     "proxy.config.log.auto_delete_rolled_files",
-    "proxy.config.log.xml_config_file",
+    "proxy.config.log.config.filename",
     "proxy.config.log.hosts_config_file",
     "proxy.config.log.sampling_frequency",
     "proxy.config.log.file_stat_frequency",


### PR DESCRIPTION
We were still listening for reconfiguration events on the old XML
log file record. Fix logging.config reload by listening on the
correct record name.