### PR TITLE
TS-4818: Ensure the plugin tag is set on the HttpSM.

### DIFF
--- a/proxy/ProxyClientTransaction.cc
+++ b/proxy/ProxyClientTransaction.cc
@@ -52,6 +52,12 @@ ProxyClientTransaction::new_transaction()
   DebugHttpTxn("[%" PRId64 "] Starting transaction %d using sm [%" PRId64 "]", parent->connection_id(),
                parent->get_transact_count(), current_reader->sm_id);
 
+  PluginIdentity *pi = dynamic_cast<PluginIdentity *>(this->get_netvc());
+  if (pi) {
+    current_reader->plugin_tag = pi->getPluginTag();
+    current_reader->plugin_id  = pi->getPluginId();
+  }
+
   current_reader->attach_client_session(this, sm_reader);
 }
 


### PR DESCRIPTION
Unless we copy the plugin information when creating the proxy
transaction, the %<pitag> logging field always emits "*".