### PR TITLE
TS-4769: TSSslServerContextCreate always returns null

### DIFF
--- a/proxy/InkAPITest.cc
+++ b/proxy/InkAPITest.cc
@@ -7990,11 +7990,6 @@ REGRESSION_TEST(SDK_API_TSSslServerContextCreate)(RegressionTest *test, int leve
   TSSslContext ctx;
 
   // See TS-4769: TSSslServerContextCreate always returns null.
-  if (level < REGRESSION_TEST_EXTENDED) {
-    *pstatus = REGRESSION_TEST_NOT_RUN;
-    return;
-  }
-
   ctx = TSSslServerContextCreate();
 
   *pstatus = ctx ? REGRESSION_TEST_PASSED : REGRESSION_TEST_FAILED;


### PR DESCRIPTION
Activated the regression test created by @jpeach.

@biilmann let me know if this PR works for you.  Basically used the sslMultCertSettings argument as a indicator of whether we expected SSLInitServerContext to be a fully specified context at the end or not.

The volume of changes looks worse in the diff than reality.  Most of the changes in SSLInitServerContext are indentation changes.  I add an outer check on whether sslMultCertSettings is NULL or not.