### PR TITLE
TS-4747: if the connection of parent is not alive, update the hostdb to mark the server down.

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -3611,6 +3611,7 @@ HttpTransact::handle_response_from_parent(State *s)
     ink_assert(s->hdr_info.server_request.valid());
 
     s->current.server->connect_result = ENOTCONN;
+    s->state_machine->do_hostdb_update_if_necessary();
 
     char addrbuf[INET6_ADDRSTRLEN];
     DebugTxn("http_trans", "[%d] failed to connect to parent %s", s->current.attempts,


### PR DESCRIPTION
I've opened this pull request on behalf of @keith2008 and at his request.  His original pull request https://github.com/apache/trafficserver/pull/903 had merge conflicts due to other commits.  I'll close pull request #903.