### PR TITLE
TS-4759: Fix stream states management

### DIFF
--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -35,6 +35,7 @@ enum Http2SendADataFrameResult {
   HTTP2_SEND_A_DATA_FRAME_NO_ERROR   = 0,
   HTTP2_SEND_A_DATA_FRAME_NO_WINDOW  = 1,
   HTTP2_SEND_A_DATA_FRAME_NO_PAYLOAD = 2,
+  HTTP2_SEND_A_DATA_FRAME_DONE       = 3,
 };
 
 class Http2ConnectionSettings

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -45,7 +45,8 @@ public:
       header_blocks(NULL),
       header_blocks_length(0),
       request_header_length(0),
-      end_stream(false),
+      recv_end_stream(false),
+      send_end_stream(false),
       sent_request_header(false),
       response_header_done(false),
       request_sent(false),
@@ -190,7 +191,8 @@ public:
                                   // Padding or other fields)
   uint32_t request_header_length; // total length of payload (include Padding
                                   // and other fields)
-  bool end_stream;
+  bool recv_end_stream;
+  bool send_end_stream;
 
   bool sent_request_header;
   bool response_header_done;


### PR DESCRIPTION
Below is the situation when this failure is happen.

1. h2spec sends a HEADERS frame with END_HEADERS flag and without END_STREAM flag.
2. TS returns a HEADERS frame and two DATA frames immediately. And TS set server side stream state `closed`.
3. h2spec sends RST_STREAM with a length other than 4 cotets.
4. TS ignores RST_STREAM to closed stream. 

There are two problems.

- h2spec assumes server side stream state is open. ( This is fixed by h2spec v1.5.0 )
- At no. 2 , TS should change server side stream state to `half-close (local)`.
   And send RST_STREAM frame to client and make state `closed`.

To fix this

- Change stream state to `half-close (local)` from `idle` or `open` when send a frame w/ END_STREAM flag
- Make send_a_data_frame to return HTTP2_SEND_A_DATA_FRAME_DONE when send DATA frame w/ END_STREAM flag
- Set stream state CLOSED when error is happen