### PR TITLE
TS-4847: Local manager needs to register proxy.node.proxy_running.

### DIFF
--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -189,7 +189,8 @@ LocalManager::LocalManager(bool proxy_on) : BaseManager(), run_proxy(proxy_on), 
   proxy_launch_outstanding  = false;
   mgmt_shutdown_outstanding = MGMT_PENDING_NONE;
   proxy_running             = 0;
-  RecSetRecordInt("proxy.node.proxy_running", 0, REC_SOURCE_DEFAULT);
+
+  RecRegisterStatInt(RECT_NODE, "proxy.node.proxy_running", 0, RECP_NON_PERSISTENT);
 
   virt_map = NULL;
 


### PR DESCRIPTION
traffic_cop checks proxy.node.proxy_running to verify the manager
is running. Since this metric is not in RecordsConfig.cc any more,
we need to register it before setting the value.