### PR TITLE
TS-4703: Add API to retrieve client protocols

### DIFF
--- a/doc/reference/api/TSClientProtocolStack.en.rst
+++ b/doc/reference/api/TSClientProtocolStack.en.rst
@@ -1,0 +1,112 @@
+.. Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed
+   with this work for additional information regarding copyright
+   ownership.  The ASF licenses this file to you under the Apache
+   License, Version 2.0 (the "License"); you may not use this file
+   except in compliance with the License.  You may obtain a copy of
+   the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied.  See the License for the specific language governing
+   permissions and limitations under the License.
+
+
+.. include:: ../../../common.defs
+
+.. default-domain:: c
+
+TSClientProtocolStack
+*********************
+
+Synopsis
+========
+
+`#include <ts/ts.h>`
+
+.. function:: TSReturnCode TSHttpTxnClientProtocolStackGet(TSHttpTxn txnp, int n, char const** 
+result, int* actual)
+
+.. function:: TSReturnCode TSHttpSsnClientProtocolStackGet(TSHttpSsn ssnp, int n, char const** 
+result, int* actual)
+
+.. function:: char const* TSHttpTxnClientProtocolStackContains(TSHttpTxn txnp)
+
+.. function:: char const* TSHttpSsnClientProtocolStackContains(TSHttpSsn ssnp)
+
+.. function:: char const* TSNormalizedProtocolTag(char const* tag)
+
+.. function:: char const* TSRegisterProtocolTag(char const* tag)
+
+Description
+===========
+
+These functions are used to explore the protocol stack of the client (user agent) connection to 
+|TS|. The functions :func:`TSHttpTxnClientProtocolStackGet` and 
+:func:`TSHttpSsnClientProtocolStackGet` can be used to retrieve the entire protocol stack for the 
+user agent connection. :func:`TSHttpTxnClientProtocolStackContains` and 
+:func:`TSHttpSsnClientProtocolStackContains` will check for a specific protocol :arg:`tag` being 
+present in the stack.
+
+Each protocol is represented by tag which is a null terminated string. A particular tag will always 
+be returned as the same character pointer and so protocols can be reliably checked with pointer 
+comparisons. :func:`TSNormalizedProtocolTag` will return this character pointer for a specific 
+:arg:`tag`. A return value of :const:`NULL` indicates the provided :arg:`tag` is not registered as 
+a known protocol tag. :func:`TSRegisterProtocolTag` registers the :arg:`tag` and then returns its 
+normalized value. This is useful for plugins that provide custom protocols for user agents.
+
+The protocols are ordered from higher level protocols to the lower level ones on which the higher 
+operate. For instance a stack might look like "http/1.1,tls/1.2,tcp,ipv4". For 
+:func:`TSHttpTxnClientProtocolStackGet` and :func:`TSHttpSsnClientProtocolStackGet` these values 
+are placed in the array :arg:`result`. :arg:`count` is the maximum number of elements of 
+:arg:`result` that may be modified by the function call. If :arg:`actual` is not :const:`NULL` then 
+the actual number of elements in the protocol stack will be returned. If this is equal or less than 
+:arg:`count` then all elements were returned. If it is larger then some layers were omitted from 
+:arg:`result`. If the full stack is required :arg:`actual` can be used to resize :arg:`result` to 
+be sufficient to hold all of the elements and the function called again with updated :arg:`count` 
+and :arg:`result`. In practice the maximum number of elements will is almost certain to be less 
+than 10 which therefore should suffice. These functions return :const:`TS_SUCCESS` on success and 
+:const:`TS_ERROR` on failure which should only occurr if :arg:`txnp` or :arg:`ssnp` are invalid.
+
+The :func:`TSHttpTxnClientProtocolStackContains` and :func:`TSHttpSsnClientProtocolStackContains` 
+functions are provided for the convenience when only the presence of a protocol is of interest, not 
+its location or the presence of other protocols. These functions return NULL if the protocol 
+:arg:`tag` is not present, and a pointer to the normalized tag if it is present. The strings are
+matched with an anchor prefix search, as with debug tags. For instance if :arg:`tag` is "tls" then it
+will match "tls/1.2" or "tls/1.3". This makes checking for TLS or IP more convenient. If more precision
+is required the entire protocol stack can be retrieved and processed more thoroughly.
+
+The protocol tags defined by |TS|.
+
+=========== =========
+Protocol    Tag
+=========== =========
+HTTP/1.1    http/1.1
+HTTP/1.0    http/1.0
+HTTP/2      h2
+WebSocket   ws
+TLS 1.3     tls/1.3
+TLS 1.2     tls/1.2
+TLS 1.1     tls/1.1
+TLS 1.0     tls/1.0
+TCP         tcp
+UDP         udp
+IPv4        ipv4
+IPv6        ipv6
+QUIC        quic
+=========== =========
+
+Examples
+--------
+
+The example below is excerpted from `example/protocol-stack/protocol-stack.cc`
+in the Traffic Server source distribution. It demonstrates how to
+use :func:`TSHttpTxnClientProtocolStackGet` and :func:`TSHttpTxnClientProtocolStackContains`
+
+.. literalinclude:: ../../../example/protocol-stack/protocol-stack.cc
+  :language: c
+  :lines: 31-46
+

--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -33,6 +33,7 @@ plugins = \
   null-transform.la \
   output-header.la \
   protocol.la \
+  protocol-stack.la \
   psi.la \
   query-remap.la \
   remap.la \
@@ -68,6 +69,7 @@ lifecycle_plugin_la_SOURCES = lifecycle-plugin/lifecycle-plugin.c
 null_transform_la_SOURCES = null-transform/null-transform.c
 output_header_la_SOURCES = output-header/output-header.c
 protocol_la_SOURCES = protocol/Protocol.c protocol/TxnSM.c
+protocol_stack_la_SOURCES = protocol-stack/protocol-stack.cc
 psi_la_SOURCES = thread-pool/psi.c thread-pool/thread.c
 query_remap_la_SOURCES = query-remap/query-remap.c
 remap_header_add_la_SOURCES = remap_header_add/remap_header_add.cc

--- a/example/protocol-stack/protocol-stack.cc
+++ b/example/protocol-stack/protocol-stack.cc
@@ -1,0 +1,62 @@
+/** @file
+
+  an example protocol-stack plugin
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include <stdio.h>
+
+#include "ts/ts.h"
+#include "ts/ink_defs.h"
+
+#define DEBUG_TAG "protocol-stack"
+
+static int
+proto_stack_cb(TSCont contp ATS_UNUSED, TSEvent event, void *edata)
+{
+  TSHttpTxn txnp = (TSHttpTxn)edata;
+  char const *results[10];
+  int count = 0;
+  TSDebug(DEBUG_TAG, "Protocols:");
+  TSHttpTxnClientProtocolStackGet(txnp, 10, results, &count);
+  for (int i = 0; i < count; i++) {
+    TSDebug(DEBUG_TAG, "\t%d: %s", i, results[i]);
+  }
+  const char *ret_tag = TSHttpTxnClientProtocolStackContains(txnp, "h2");
+  TSDebug(DEBUG_TAG, "Stack %s HTTP/2", ret_tag != NULL ? "contains" : "does not contain");
+  TSHttpTxnReenable(txnp, TS_EVENT_HTTP_CONTINUE);
+  return 0;
+}
+
+void
+TSPluginInit(int argc ATS_UNUSED, const char *argv[] ATS_UNUSED)
+{
+  TSPluginRegistrationInfo info;
+
+  info.plugin_name   = const_cast<char *>("protocol-stack");
+  info.vendor_name   = const_cast<char *>("MyCompany");
+  info.support_email = const_cast<char *>("ts-api-support@MyCompany.com");
+
+  if (TSPluginRegister(&info) != TS_SUCCESS) {
+    TSError("[protocol-stack] Plugin registration failed.");
+  }
+
+  TSHttpHookAdd(TS_HTTP_READ_REQUEST_HDR_HOOK, TSContCreate(proto_stack_cb, NULL));
+}

--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -207,6 +207,10 @@ struct NetVCOptions {
     return *this;
   }
 
+  const char *get_family_string() const;
+
+  const char *get_proto_string() const;
+
   /// @name Debugging
   //@{
   /// Convert @a s to its string equivalent.
@@ -564,6 +568,18 @@ public:
   set_is_transparent(bool state = true)
   {
     is_transparent = state;
+  }
+
+  virtual int
+  populate_protocol(char const **results, int n) const
+  {
+    return 0;
+  }
+
+  virtual const char *
+  protocol_contains(const char *tag) const
+  {
+    return NULL;
   }
 
 private:

--- a/iocore/net/NetVConnection.cc
+++ b/iocore/net/NetVConnection.cc
@@ -31,6 +31,7 @@
  ****************************************************************************/
 
 #include "P_Net.h"
+#include "ts/apidefs.h"
 
 Action *
 NetVConnection::send_OOB(Continuation *, char *, int)
@@ -42,4 +43,35 @@ void
 NetVConnection::cancel_OOB()
 {
   return;
+}
+
+const char *
+NetVCOptions::get_proto_string() const
+{
+  switch (ip_proto) {
+  case USE_TCP:
+    return TS_PROTO_TAG_TCP;
+  case USE_UDP:
+    return TS_PROTO_TAG_UDP;
+  default:
+    return NULL;
+  }
+}
+
+const char *
+NetVCOptions::get_family_string() const
+{
+  const char *retval;
+  switch (ip_family) {
+  case AF_INET:
+    retval = TS_PROTO_TAG_IPV4;
+    break;
+  case AF_INET6:
+    retval = TS_PROTO_TAG_IPV6;
+    break;
+  default:
+    retval = NULL;
+    break;
+  }
+  return retval;
 }

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -252,6 +252,9 @@ public:
     return ssl ? SSL_get_cipher_name(ssl) : NULL;
   }
 
+  int populate_protocol(char const **results, int n) const;
+  const char *protocol_contains(const char *tag) const;
+
   /**
    * Populate the current object based on the socket information in in the
    * con parameter and the ssl object in the arg parameter
@@ -270,6 +273,8 @@ public:
 private:
   SSLNetVConnection(const SSLNetVConnection &);
   SSLNetVConnection &operator=(const SSLNetVConnection &);
+
+  const char *map_tls_protocol_to_tag(char const *proto_string) const;
 
   bool sslHandShakeComplete;
   bool sslClientConnection;

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -170,6 +170,36 @@ public:
   /////////////////////////////////////////////////////////////////
   UnixNetVConnection();
 
+  int
+  populate_protocol(char const **results, int n) const
+  {
+    int retval = 0;
+    if (n > 0) {
+      results[retval++] = options.get_proto_string();
+      if (n > 1) {
+        results[retval++] = options.get_family_string();
+      }
+    }
+    return retval;
+  }
+
+  const char *
+  protocol_contains(const char *tag) const
+  {
+    const char *retval   = NULL;
+    unsigned int tag_len = strlen(tag);
+    const char *test_tag = options.get_proto_string();
+    if (strncmp(tag, test_tag, tag_len) == 0) {
+      retval = test_tag;
+    } else {
+      test_tag = options.get_family_string();
+      if (strncmp(tag, test_tag, tag_len) == 0) {
+        retval = test_tag;
+      }
+    }
+    return retval;
+  }
+
 private:
   UnixNetVConnection(const NetVConnection &);
   UnixNetVConnection &operator=(const NetVConnection &);

--- a/lib/records/I_RecHttp.h
+++ b/lib/records/I_RecHttp.h
@@ -136,6 +136,8 @@ extern SessionProtocolSet HTTP2_PROTOCOL_SET;
 extern SessionProtocolSet DEFAULT_NON_TLS_SESSION_PROTOCOL_SET;
 extern SessionProtocolSet DEFAULT_TLS_SESSION_PROTOCOL_SET;
 
+const char *RecNormalizeProtoTag(const char *tag);
+
 /** Registered session protocol names.
 
     We do this to avoid lots of string compares. By normalizing the

--- a/lib/records/RecHttp.cc
+++ b/lib/records/RecHttp.cc
@@ -24,6 +24,7 @@
 #include <records/I_RecCore.h>
 #include <records/I_RecHttp.h>
 #include <ts/ink_defs.h>
+#include <ts/ink_hash_table.h>
 #include <ts/Tokenizer.h>
 #include <strings.h>
 
@@ -40,6 +41,20 @@ const char *const TS_ALPN_PROTOCOL_HTTP_2_0 = "h2"; // HTTP/2 over TLS
 
 const char *const TS_ALPN_PROTOCOL_GROUP_HTTP  = "http";
 const char *const TS_ALPN_PROTOCOL_GROUP_HTTP2 = "http2";
+
+const char *const TS_PROTO_TAG_HTTP_1_0 = TS_ALPN_PROTOCOL_HTTP_1_0;
+const char *const TS_PROTO_TAG_HTTP_1_1 = TS_ALPN_PROTOCOL_HTTP_1_1;
+const char *const TS_PROTO_TAG_HTTP_2_0 = TS_ALPN_PROTOCOL_HTTP_2_0;
+const char *const TS_PROTO_TAG_TLS_1_3  = "tls/1.3";
+const char *const TS_PROTO_TAG_TLS_1_2  = "tls/1.2";
+const char *const TS_PROTO_TAG_TLS_1_1  = "tls/1.1";
+const char *const TS_PROTO_TAG_TLS_1_0  = "tls/1.0";
+const char *const TS_PROTO_TAG_TCP      = "tcp";
+const char *const TS_PROTO_TAG_UDP      = "udp";
+const char *const TS_PROTO_TAG_IPV4     = "ipv4";
+const char *const TS_PROTO_TAG_IPV6     = "ipv6";
+
+InkHashTable *TSProtoTags;
 
 // Precomputed indices for ease of use.
 int TS_ALPN_PROTOCOL_INDEX_HTTP_0_9 = SessionProtocolNameRegistry::INVALID;
@@ -618,6 +633,30 @@ ts_session_protocol_well_known_name_indices_init()
   DEFAULT_TLS_SESSION_PROTOCOL_SET.markAllIn();
 
   DEFAULT_NON_TLS_SESSION_PROTOCOL_SET = HTTP_PROTOCOL_SET;
+
+  TSProtoTags = ink_hash_table_create(InkHashTableKeyType_String);
+  ink_hash_table_insert(TSProtoTags, TS_PROTO_TAG_HTTP_1_0, reinterpret_cast<void *>(const_cast<char *>(TS_PROTO_TAG_HTTP_1_0)));
+  ink_hash_table_insert(TSProtoTags, TS_PROTO_TAG_HTTP_1_1, reinterpret_cast<void *>(const_cast<char *>(TS_PROTO_TAG_HTTP_1_1)));
+  ink_hash_table_insert(TSProtoTags, TS_PROTO_TAG_HTTP_2_0, reinterpret_cast<void *>(const_cast<char *>(TS_PROTO_TAG_HTTP_2_0)));
+  ink_hash_table_insert(TSProtoTags, TS_PROTO_TAG_TLS_1_3, reinterpret_cast<void *>(const_cast<char *>(TS_PROTO_TAG_TLS_1_3)));
+  ink_hash_table_insert(TSProtoTags, TS_PROTO_TAG_TLS_1_2, reinterpret_cast<void *>(const_cast<char *>(TS_PROTO_TAG_TLS_1_2)));
+  ink_hash_table_insert(TSProtoTags, TS_PROTO_TAG_TLS_1_1, reinterpret_cast<void *>(const_cast<char *>(TS_PROTO_TAG_TLS_1_1)));
+  ink_hash_table_insert(TSProtoTags, TS_PROTO_TAG_TLS_1_0, reinterpret_cast<void *>(const_cast<char *>(TS_PROTO_TAG_TLS_1_0)));
+  ink_hash_table_insert(TSProtoTags, TS_PROTO_TAG_TCP, reinterpret_cast<void *>(const_cast<char *>(TS_PROTO_TAG_TCP)));
+  ink_hash_table_insert(TSProtoTags, TS_PROTO_TAG_UDP, reinterpret_cast<void *>(const_cast<char *>(TS_PROTO_TAG_UDP)));
+  ink_hash_table_insert(TSProtoTags, TS_PROTO_TAG_IPV4, reinterpret_cast<void *>(const_cast<char *>(TS_PROTO_TAG_IPV4)));
+  ink_hash_table_insert(TSProtoTags, TS_PROTO_TAG_IPV6, reinterpret_cast<void *>(const_cast<char *>(TS_PROTO_TAG_IPV6)));
+}
+
+const char *
+RecNormalizeProtoTag(const char *tag)
+{
+  char const *retval = NULL;
+  InkHashTableValue value;
+  if (ink_hash_table_lookup(TSProtoTags, tag, &value)) {
+    retval = reinterpret_cast<char const *>(value);
+  }
+  return retval;
 }
 
 SessionProtocolNameRegistry::SessionProtocolNameRegistry() : m_n(0)

--- a/lib/ts/apidefs.h.in
+++ b/lib/ts/apidefs.h.in
@@ -1142,6 +1142,19 @@ extern tsapi int TS_ALPN_PROTOCOL_INDEX_HTTP_2_0;
 extern tsapi const char *const TS_ALPN_PROTOCOL_GROUP_HTTP;
 extern tsapi const char *const TS_ALPN_PROTOCOL_GROUP_HTTP2;
 
+extern tsapi const char *const TS_PROTO_TAG_HTTP_1_0;
+extern tsapi const char *const TS_PROTO_TAG_HTTP_1_1;
+extern tsapi const char *const TS_PROTO_TAG_HTTP_2_0;
+extern tsapi const char *const TS_PROTO_TAG_TLS_1_3;
+extern tsapi const char *const TS_PROTO_TAG_TLS_1_2;
+extern tsapi const char *const TS_PROTO_TAG_TLS_1_1;
+extern tsapi const char *const TS_PROTO_TAG_TLS_1_0;
+extern tsapi const char *const TS_PROTO_TAG_TCP;
+extern tsapi const char *const TS_PROTO_TAG_UDP;
+extern tsapi const char *const TS_PROTO_TAG_IPV4;
+extern tsapi const char *const TS_PROTO_TAG_IPV6;
+
+
 /* --------------------------------------------------------------------------
    MLoc Constants */
 /**

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -9193,3 +9193,64 @@ TSHttpTxnIdGet(TSHttpTxn txnp)
 
   return (uint64_t)sm->sm_id;
 }
+
+// Return information about the protocols used by the client
+TSReturnCode
+TSHttpTxnClientProtocolStackGet(TSHttpTxn txnp, int n, char const **result, int *actual)
+{
+  sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
+  sdk_assert(n == 0 || result != NULL);
+  HttpSM *sm = (HttpSM *)txnp;
+  int count  = 0;
+  if (sm) {
+    count = sm->populate_client_protocol(result, n);
+  }
+  if (actual) {
+    *actual = count;
+  }
+  return TS_SUCCESS;
+}
+
+TSReturnCode
+TSHttpSsnClientProtocolStackGet(TSHttpSsn ssnp, int n, char const **result, int *actual)
+{
+  sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
+  sdk_assert(n == 0 || result != NULL);
+  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
+  int count              = 0;
+  if (cs) {
+    count = cs->populate_protocol(result, n);
+  }
+  if (actual) {
+    *actual = count;
+  }
+  return TS_SUCCESS;
+}
+
+char const *
+TSNormalizedProtocolTag(char const *tag)
+{
+  return RecNormalizeProtoTag(tag);
+}
+
+char const *
+TSHttpTxnClientProtocolStackContains(TSHttpTxn txnp, char const *tag)
+{
+  sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
+  HttpSM *sm = (HttpSM *)txnp;
+  return sm->client_protocol_contains(tag);
+}
+
+char const *
+TSHttpSsnClientProtocolStackContains(TSHttpSsn ssnp, char const *tag)
+{
+  sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
+  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
+  return cs->protocol_contains(tag);
+}
+
+char const *
+TSRegisterProtocolTag(char const *tag)
+{
+  return NULL;
+}

--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -184,6 +184,26 @@ public:
     return get_netvc() == NULL;
   }
 
+  virtual int
+  populate_protocol(char const **result, int size) const
+  {
+    int retval = 0;
+    if (get_netvc()) {
+      retval += this->get_netvc()->populate_protocol(result, size);
+    }
+    return retval;
+  }
+
+  virtual const char *
+  protocol_contains(const char *tag_prefix) const
+  {
+    const char *retval = NULL;
+    if (get_netvc()) {
+      retval = this->get_netvc()->protocol_contains(tag_prefix);
+    }
+    return retval;
+  }
+
 protected:
   // XXX Consider using a bitwise flags variable for the following flags, so that we can make the best
   // use of internal alignment padding.

--- a/proxy/ProxyClientTransaction.h
+++ b/proxy/ProxyClientTransaction.h
@@ -226,6 +226,26 @@ public:
     return restart_immediate;
   }
 
+  virtual int
+  populate_protocol(char const **result, int size) const
+  {
+    int retval = 0;
+    if (parent) {
+      retval = parent->populate_protocol(result, size);
+    }
+    return retval;
+  }
+  virtual const char *
+  protocol_contains(const char *tag_prefix) const
+  {
+    const char *retval = NULL;
+    if (parent) {
+      retval = parent->protocol_contains(tag_prefix);
+    }
+    return retval;
+  }
+
+protected:
 protected:
   ProxyClientSession *parent;
   HttpSM *current_reader;

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -2419,6 +2419,16 @@ tsapi const TSUuid TSProcessUuidGet(void);
 */
 tsapi const char *TSHttpTxnPluginTagGet(TSHttpTxn txnp);
 
+/*
+ * Return information about the client protocols
+ */
+tsapi TSReturnCode TSHttpTxnClientProtocolStackGet(TSHttpTxn txnp, int n, char const **result, int *actual);
+tsapi TSReturnCode TSHttpSsnClientProtocolStackGet(TSHttpSsn ssnp, int n, char const **result, int *actual);
+tsapi char const *TSHttpTxnClientProtocolStackContains(TSHttpTxn txnp, char const *tag);
+tsapi char const *TSHttpSsnClientProtocolStackContains(TSHttpSsn ssnp, char const *tag);
+tsapi char const *TSNormalizedProtocolTag(char const *tag);
+tsapi char const *TSRegisterProtocolTag(char const *tag);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -263,6 +263,10 @@ public:
   bool is_private();
   bool is_redirect_required();
 
+  int populate_client_protocol(const char **result, int n) const;
+  const char *client_protocol_contains(const char *tag_prefix) const;
+  const char *find_proto_string(HTTPVersion version) const;
+
   int64_t sm_id;
   unsigned int magic;
 

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -243,6 +243,33 @@ public:
     return "http/2";
   }
 
+  virtual int
+  populate_protocol(char const **result, int size) const
+  {
+    int retval = 0;
+    if (size > 0) {
+      result[0] = TS_PROTO_TAG_HTTP_2_0;
+      retval    = 1;
+      if (size > 1) {
+        retval += super::populate_protocol(result + 1, size - 1);
+      }
+    }
+    return retval;
+  }
+
+  virtual const char *
+  protocol_contains(const char *tag_prefix) const
+  {
+    const char *retval   = NULL;
+    unsigned int tag_len = strlen(tag_prefix);
+    if (tag_len <= strlen(TS_PROTO_TAG_HTTP_2_0) && strncmp(tag_prefix, TS_PROTO_TAG_HTTP_2_0, tag_len) == 0) {
+      retval = TS_PROTO_TAG_HTTP_2_0;
+    } else {
+      retval = super::protocol_contains(tag_prefix);
+    }
+    return retval;
+  }
+
 private:
   Http2ClientSession(Http2ClientSession &);                  // noncopyable
   Http2ClientSession &operator=(const Http2ClientSession &); // noncopyable


### PR DESCRIPTION
Added API's as discussed on the API review (also on the bug).

Added regression test and example plugin to exercise the options.