### PR TITLE
TS-4263: keyblock variable configurable via records.config

### DIFF
--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -2055,9 +2055,12 @@ SSLParseCertificateConfiguration(const SSLConfigParams *params, SSLCertLookup *l
 
   // load the global ticket key for later use
   REC_ReadConfigStringAlloc(ticket_key_filename, "proxy.config.ssl.server.ticket_key.filename");
-  ats_scoped_str ticket_key_path(Layout::relative_to(params->serverCertPathOnly, ticket_key_filename));
-  global_default_keyblock = ssl_create_ticket_keyblock(ticket_key_path); // this function just returns a keyblock
-
+  if (ticket_key_filename != NULL) {
+    ats_scoped_str ticket_key_path(Layout::relative_to(params->serverCertPathOnly, ticket_key_filename));
+    global_default_keyblock = ssl_create_ticket_keyblock(ticket_key_path); // this function just returns a keyblock
+  } else {
+    global_default_keyblock = ssl_create_ticket_keyblock(NULL); // this function just returns a keyblock
+  }
   Note("loading SSL certificate configuration from %s", params->configFilePath);
 
   if (params->configFilePath) {

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1243,7 +1243,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.ssl.server.multicert.exit_on_load_fail", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_NULL, "[0-1]", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.ssl.server.ticket_key.filename", RECD_STRING, "ssl_ticket.key", RECU_DYNAMIC, RR_NULL, RECC_NULL, NULL, RECA_NULL}
+  {RECT_CONFIG, "proxy.config.ssl.server.ticket_key.filename", RECD_STRING, NULL, RECU_DYNAMIC, RR_NULL, RECC_NULL, NULL, RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.ssl.server.private_key.path", RECD_STRING, TS_BUILD_SYSCONFDIR, RECU_RESTART_TS, RR_NULL, RECC_NULL, NULL, RECA_NULL}
   ,


### PR DESCRIPTION
Default value proxy.config.ssl.server.ticket_key.filename is set to NULL
* If the ticket_key_filename is not set by the user , then a random keyblock will be used
* If user sets the ticket_key_filename but the the file is either not present or the file contains <48 bytes, then keyblock will be NULL and assertion will fail