### PR TITLE
TS-4853 : Parent Consistent Hash Selection - add parent selection URL and API.

### DIFF
--- a/doc/admin-guide/plugins/ts_lua.en.rst
+++ b/doc/admin-guide/plugins/ts_lua.en.rst
@@ -932,6 +932,41 @@ ts.http.set_cache_lookup_url
 
 `TOP <#ts-lua-plugin>`_
 
+ts.http.get_parent_selection_url
+--------------------------------
+**syntax:** *ts.http.get_parent_selection_url()*
+
+**context:** do_global_cache_lookup_complete
+
+**description:** This function can be used to get the parent selection url for the client request.
+
+Here is an example
+
+::
+
+    function cache_lookup()
+        ts.http.set_parent_selection_url('http://bad.com/bad.html')
+        local cache = ts.http.get_parent_selection_url()
+        ts.debug(cache)
+    end
+
+    function do_remap()
+        ts.hook(TS_LUA_HOOK_CACHE_LOOKUP_COMPLETE, cache_lookup)
+        return 0
+    end
+
+`TOP <#ts-lua-plugin>`_
+
+ts.http.set_parent_selection_url
+--------------------------------
+**syntax:** *ts.http.set_parent_selection_url()*
+
+**context:** do_global_cache_lookup_complete
+
+**description:** This function can be used to set the parent selection url for the client request.
+
+`TOP <#ts-lua-plugin>`_
+
 ts.http.set_server_resp_no_store
 --------------------------------
 **syntax:** *ts.http.set_server_resp_no_store(status)*

--- a/doc/developer-guide/api/functions/TSHttpTxnCacheParentSelectionUrlGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnCacheParentSelectionUrlGet.en.rst
@@ -1,0 +1,63 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+
+.. include:: ../../../common.defs
+
+.. default-domain:: c
+
+TSHttpTxnCacheParentSelectionUrlSet
+***********************************
+
+Traffic Server Parent Selection consistent hash URL manipulation API.
+
+Synopsis
+========
+
+`#include <ts/ts.h>`
+
+.. function:: TSReturnCode TSHttpTxnCacheParentSelectionUrlSet(TSHttpTxn txnp, TSMBuffer bufp, TSMLoc offset)
+.. function:: TSReturnCode TSHttpTxnCacheParentSelectionUrlGet(TSHttpTxn txnp, TSMBuffer bufp, TSMLoc offset)
+
+Description
+===========
+
+The Parent Selection consistent hash feature selects among multiple
+parent caches based on hashing a URL (the HTTP request header URL).
+
+These API functions allow an over-ride URL to be defined such that the
+over-ride URL is hashed instead of the normal URL. In addition, the
+various filtering options that may be applied to the normal URL
+(fname, maxdirs, and qstring) are NOT applied when the over-ride is
+used since it is assumed that custom filtering has already been
+performed prior to explicitly setting the over-ride URL
+
+:func:`TSHttpTxnCacheParentSelectionUrlSet` will set the over-ride URL.
+
+:func:`TSHttpTxnCacheParentSelectionUrlGet` will get the over-ride URL.
+
+Return Values
+=============
+
+All these APIs returns a :type:`TSReturnCode`, indicating success
+(:data:`TS_SUCCESS`) or failure (:data:`TS_ERROR`) of the operation.
+
+See Also
+========
+
+:manpage:`TSAPI(3ts)`,
+:manpage:`TSUrlCreate(3ts)`,
+:manpage:`TSUrlStringGet(3ts)`

--- a/plugins/experimental/ts_lua/ts_lua_http.c
+++ b/plugins/experimental/ts_lua/ts_lua_http.c
@@ -77,6 +77,8 @@ static int ts_lua_http_set_cache_lookup_status(lua_State *L);
 static int ts_lua_http_set_cache_url(lua_State *L);
 static int ts_lua_http_get_cache_lookup_url(lua_State *L);
 static int ts_lua_http_set_cache_lookup_url(lua_State *L);
+static int ts_lua_http_get_parent_selection_url(lua_State *L);
+static int ts_lua_http_set_parent_selection_url(lua_State *L);
 static int ts_lua_http_set_server_resp_no_store(lua_State *L);
 
 static void ts_lua_inject_cache_lookup_result_variables(lua_State *L);
@@ -143,6 +145,12 @@ ts_lua_inject_http_cache_api(lua_State *L)
 
   lua_pushcfunction(L, ts_lua_http_set_cache_lookup_url);
   lua_setfield(L, -2, "set_cache_lookup_url");
+
+  lua_pushcfunction(L, ts_lua_http_get_parent_selection_url);
+  lua_setfield(L, -2, "get_parent_selection_url");
+
+  lua_pushcfunction(L, ts_lua_http_set_parent_selection_url);
+  lua_setfield(L, -2, "set_parent_selection_url");
 
   lua_pushcfunction(L, ts_lua_http_set_server_resp_no_store);
   lua_setfield(L, -2, "set_server_resp_no_store");
@@ -368,6 +376,78 @@ ts_lua_http_set_cache_lookup_url(lua_State *L)
       TSDebug(TS_LUA_DEBUG_TAG, "Set cache lookup URL");
     } else {
       TSError("[ts_lua] Failed to set cache lookup URL");
+    }
+  }
+
+  return 0;
+}
+
+static int
+ts_lua_http_get_parent_selection_url(lua_State *L)
+{
+  char output[TS_LUA_MAX_URL_LENGTH];
+  int output_len;
+  TSMLoc url = TS_NULL_MLOC;
+  char *str  = NULL;
+  int len;
+
+  ts_lua_http_ctx *http_ctx;
+
+  GET_HTTP_CONTEXT(http_ctx, L);
+
+  if (TSUrlCreate(http_ctx->client_request_bufp, &url) != TS_SUCCESS) {
+    lua_pushnil(L);
+    goto done;
+  }
+
+  if (TSHttpTxnParentSelectionUrlGet(http_ctx->txnp, http_ctx->client_request_bufp, url) != TS_SUCCESS) {
+    lua_pushnil(L);
+    goto done;
+  }
+
+  str = TSUrlStringGet(http_ctx->client_request_bufp, url, &len);
+
+  output_len = snprintf(output, TS_LUA_MAX_URL_LENGTH, "%.*s", len, str);
+  if (output_len >= TS_LUA_MAX_URL_LENGTH) {
+    lua_pushlstring(L, output, TS_LUA_MAX_URL_LENGTH - 1);
+  } else {
+    lua_pushlstring(L, output, output_len);
+  }
+
+done:
+  if (url != TS_NULL_MLOC) {
+    TSHandleMLocRelease(http_ctx->client_request_bufp, TS_NULL_MLOC, url);
+  }
+
+  if (str != NULL) {
+    TSfree(str);
+  }
+
+  return 1;
+}
+
+static int
+ts_lua_http_set_parent_selection_url(lua_State *L)
+{
+  const char *url;
+  size_t url_len;
+
+  ts_lua_http_ctx *http_ctx;
+
+  GET_HTTP_CONTEXT(http_ctx, L);
+
+  url = luaL_checklstring(L, 1, &url_len);
+
+  if (url && url_len) {
+    const char *start = url;
+    const char *end   = url + url_len;
+    TSMLoc new_url_loc;
+    if (TSUrlCreate(http_ctx->client_request_bufp, &new_url_loc) == TS_SUCCESS &&
+        TSUrlParse(http_ctx->client_request_bufp, new_url_loc, &start, end) == TS_PARSE_DONE &&
+        TSHttpTxnParentSelectionUrlSet(http_ctx->txnp, http_ctx->client_request_bufp, new_url_loc) == TS_SUCCESS) {
+      TSDebug(TS_LUA_DEBUG_TAG, "Set parent selection URL");
+    } else {
+      TSError("[ts_lua] Failed to set parent selection URL");
     }
   }
 

--- a/proxy/ControlMatcher.h
+++ b/proxy/ControlMatcher.h
@@ -96,6 +96,7 @@
 #include "ts/ink_defs.h"
 #include "HTTP.h"
 #include "ts/Regex.h"
+#include "URL.h"
 
 #ifdef HAVE_CTYPE_H
 #include <ctype.h>
@@ -136,7 +137,16 @@ public:
   inkcoreapi sockaddr const *get_ip();
   inkcoreapi sockaddr const *get_client_ip();
 
-  HttpRequestData() : hdr(NULL), hostname_str(NULL), api_info(NULL), xact_start(0), incoming_port(0), tag(NULL), internal_txn(false)
+  HttpRequestData()
+    : hdr(NULL),
+      hostname_str(NULL),
+      api_info(NULL),
+      xact_start(0),
+      incoming_port(0),
+      tag(NULL),
+      internal_txn(false),
+      cache_info_lookup_url(NULL),
+      cache_info_parent_selection_url(NULL)
   {
     ink_zero(src_ip);
     ink_zero(dest_ip);
@@ -151,6 +161,8 @@ public:
   uint16_t incoming_port;
   char *tag;
   bool internal_txn;
+  URL **cache_info_lookup_url;
+  URL **cache_info_parent_selection_url;
 };
 
 template <class Data, class Result> class UrlMatcher

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -5731,6 +5731,65 @@ TSHttpTxnParentProxySet(TSHttpTxn txnp, const char *hostname, int port)
   sm->t_state.api_info.parent_proxy_port = port;
 }
 
+TSReturnCode
+TSHttpTxnParentSelectionUrlGet(TSHttpTxn txnp, TSMBuffer bufp, TSMLoc obj)
+{
+  sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
+  sdk_assert(sdk_sanity_check_mbuffer(bufp) == TS_SUCCESS);
+  sdk_assert(sdk_sanity_check_url_handle(obj) == TS_SUCCESS);
+
+  HttpSM *sm = (HttpSM *)txnp;
+  URL u, *l_url;
+
+  u.m_heap     = ((HdrHeapSDKHandle *)bufp)->m_heap;
+  u.m_url_impl = (URLImpl *)obj;
+  if (!u.valid())
+    return TS_ERROR;
+
+  l_url = sm->t_state.cache_info.parent_selection_url;
+  if (l_url && l_url->valid()) {
+    u.copy(l_url);
+    return TS_SUCCESS;
+  }
+
+  return TS_ERROR;
+}
+
+TSReturnCode
+TSHttpTxnParentSelectionUrlSet(TSHttpTxn txnp, TSMBuffer bufp, TSMLoc obj)
+{
+  sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
+  sdk_assert(sdk_sanity_check_mbuffer(bufp) == TS_SUCCESS);
+  sdk_assert(sdk_sanity_check_url_handle(obj) == TS_SUCCESS);
+
+  HttpSM *sm = (HttpSM *)txnp;
+  URL u, *l_url;
+
+  u.m_heap     = ((HdrHeapSDKHandle *)bufp)->m_heap;
+  u.m_url_impl = (URLImpl *)obj;
+  if (!u.valid()) {
+    return TS_ERROR;
+  }
+
+  l_url = sm->t_state.cache_info.parent_selection_url;
+  if (!l_url) {
+    sm->t_state.cache_info.parent_selection_url_storage.create(NULL);
+    sm->t_state.cache_info.parent_selection_url = &(sm->t_state.cache_info.parent_selection_url_storage);
+    l_url                                       = sm->t_state.cache_info.parent_selection_url;
+  }
+
+  if (!l_url || !l_url->valid()) {
+    return TS_ERROR;
+  } else {
+    l_url->copy(&u);
+  }
+
+  Debug("parent_select", "TSHttpTxnParentSelectionUrlSet() parent_selection_url : addr = %p val = %p",
+        &(sm->t_state.cache_info.parent_selection_url), sm->t_state.cache_info.parent_selection_url);
+
+  return TS_SUCCESS;
+}
+
 void
 TSHttpTxnUntransformedRespCache(TSHttpTxn txnp, int on)
 {

--- a/proxy/ParentConsistentHash.cc
+++ b/proxy/ParentConsistentHash.cc
@@ -65,6 +65,24 @@ ParentConsistentHash::getPathHash(HttpRequestData *hrdata, ATSHash64 *h)
   int len;
   URL *url = hrdata->hdr->url_get();
 
+  // Use over-ride URL from HttpTransact::State's cache_info.parent_selection_url, if present.
+  URL *ps_url = NULL;
+  Debug("parent_select", "hrdata->cache_info_parent_selection_url = %p", hrdata->cache_info_parent_selection_url);
+  if (hrdata->cache_info_parent_selection_url) {
+    ps_url = *(hrdata->cache_info_parent_selection_url);
+    Debug("parent_select", "ps_url = %p", ps_url);
+    if (ps_url) {
+      tmp = ps_url->string_get_ref(&len);
+      if (tmp && len > 0) {
+        // Print the over-ride URL
+        Debug("parent_select", "Using Over-Ride String='%.*s'.", len, tmp);
+        h->update(tmp, len);
+        h->final();
+        return h->get();
+      }
+    }
+  }
+
   // Always hash on '/' because paths returned by ATS are always stripped of it
   h->update("/", 1);
 

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -1481,6 +1481,9 @@ tsapi TSReturnCode TSHttpTxnParentProxyGet(TSHttpTxn txnp, const char **hostname
  */
 tsapi void TSHttpTxnParentProxySet(TSHttpTxn txnp, const char *hostname, int port);
 
+tsapi TSReturnCode TSHttpTxnParentSelectionUrlGet(TSHttpTxn txnp, TSMBuffer bufp, TSMLoc obj);
+tsapi TSReturnCode TSHttpTxnParentSelectionUrlSet(TSHttpTxn txnp, TSMBuffer bufp, TSMLoc obj);
+
 tsapi void TSHttpTxnUntransformedRespCache(TSHttpTxn txnp, int on);
 tsapi void TSHttpTxnTransformedRespCache(TSHttpTxn txnp, int on);
 

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -5801,8 +5801,10 @@ HttpTransact::initialize_state_variables_from_request(State *s, HTTPHdr *obsolet
       s->request_data.incoming_port = netvc->get_local_port();
     }
   }
-  s->request_data.xact_start = s->client_request_time;
-  s->request_data.api_info   = &s->api_info;
+  s->request_data.xact_start                      = s->client_request_time;
+  s->request_data.api_info                        = &s->api_info;
+  s->request_data.cache_info_lookup_url           = &s->cache_info.lookup_url;
+  s->request_data.cache_info_parent_selection_url = &s->cache_info.parent_selection_url;
 
   /////////////////////////////////////////////
   // Do dns lookup for the host. We need     //

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -605,6 +605,8 @@ public:
     CacheWriteLock_t write_lock_state;
     int lookup_count;
     SquidHitMissCode hit_miss_code;
+    URL *parent_selection_url;
+    URL parent_selection_url_storage;
 
     _CacheLookupInfo()
       : action(CACHE_DO_UNDEFINED),
@@ -624,7 +626,9 @@ public:
         open_write_retries(0),
         write_lock_state(CACHE_WL_INIT),
         lookup_count(0),
-        hit_miss_code(SQUID_MISS_NONE)
+        hit_miss_code(SQUID_MISS_NONE),
+        parent_selection_url(NULL),
+        parent_selection_url_storage()
     {
     }
   } CacheLookupInfo;
@@ -1131,6 +1135,7 @@ public:
       hdr_info.transform_response.destroy();
       hdr_info.cache_response.destroy();
       cache_info.lookup_url_storage.destroy();
+      cache_info.parent_selection_url_storage.destroy();
       cache_info.original_url.destroy();
       cache_info.object_store.destroy();
       cache_info.transform_store.destroy();


### PR DESCRIPTION
Adds a parent selection URL to be used in generating the hash in the Parent Consistent Hash Selection feature.

Also adds the related TS and Lua API calls to set/get the parent selection URL.