### PR TITLE
TS-4840: Crash when reattaching to C++ API Stats.

### DIFF
--- a/doc/developer-guide/plugins/adding-statistics.en.rst
+++ b/doc/developer-guide/plugins/adding-statistics.en.rst
@@ -22,42 +22,23 @@
 Adding Statistics
 *****************
 
-This chapter describes how to add statistics to your plugins. Statistics
-can be coupled or uncoupled. *Coupled* statistics are quantities that
-are related and must therefore be updated together. The Traffic Server
-API statistics functions add your plugin's statistics to the Traffic
-Server statistics system. You can view your plugin statistics as you
-would any other |TS| statistic, using :program:`traffic_ctl`.
+This chapter describes how to add statistics to your plugins.  The
+|TS| statistics API functions add your plugin's statistics so you
+can view your plugin statistics as you would any other |TS| statistic,
+using :program:`traffic_ctl` or the c:func:`TSRecordDump` API.
 
-Uncoupled Statistics
-====================
+A statistic is an opaque object referred to by an integral handle
+returned by c:func:`TSStatCreate`. Only integer statistics are
+supported, so the :arg:`type` argument to c:func:`TSStatCreate` must
+be c:data:`TS_RECORDDATATYPE_INT`.
 
-A statistic is an object of type ``TSStat``. The value of the statistic
-is of type ``TSStatType``. The possible ``TSStatTypes`` are:
+The following example shows how to add custom statistics to your
+plugin. Typically, you would attempt to find the statistic by name
+before creating is. This technique is useful if you want to increment
+a statistic from multiple plugins. Once you have a handle to the
+statistic, set the value with c:func:`TSStatIntSet`, and increment it with
+c:func:`TSStatIntIncrement` or c:func:`TSStatIntDecrement`.
 
--  ``TSSTAT_TYPE_INT64``
-
--  ``TSSTAT_TYPE_FLOAT``
-
-There is *no* ``TSSTAT_TYPE_INT32``.
-
-To add uncoupled statistics, follow the steps below:
-
-1. Declare your statistic as a global variable in your plugin. For
-   example:
-
-   .. code-block:: c
-
-      static TSStat my_statistic;
-
-2. In ``TSPluginInit``, create new statistics using ``TSStatCreate``.
-   When you create a new statistic, you need to give it an "external"
-   name that :program:`traffic_ctl` uses to access the statistic.
-   For example:
-
-   .. code-block:: c
-
-      my_statistic = TSStatCreate ("my.statistic", TSSTAT_TYPE_INT64);
-
-3. Modify (increment, decrement, or other modification) your statistic
-   in plugin functions.
+.. literalinclude:: ../../../example/statistic/statistic.cc
+   :language: c
+   :lines: 30-

--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -32,8 +32,8 @@ plugins = \
   lifecycle-plugin.la \
   null-transform.la \
   output-header.la \
-  protocol.la \
   protocol-stack.la \
+  protocol.la \
   psi.la \
   query-remap.la \
   remap.la \
@@ -45,6 +45,7 @@ plugins = \
   ssl-preaccept.la \
   ssl-sni-whitelist.la \
   ssl-sni.la \
+  statistic.la \
   thread-1.la \
   txn-data-sink.la \
   version.la
@@ -81,6 +82,7 @@ server_transform_la_SOURCES = server-transform/server-transform.c
 ssl_preaccept_la_SOURCES = ssl-preaccept/ssl-preaccept.cc
 ssl_sni_la_SOURCES = ssl-sni/ssl-sni.cc
 ssl_sni_whitelist_la_SOURCES = ssl-sni-whitelist/ssl-sni-whitelist.cc
+statistic_la_SOURCES = statistic/statistic.cc
 thread_1_la_SOURCES = thread-1/thread-1.c
 txn_data_sink_la_SOURCES = txn-data-sink/txn-data-sink.c
 version_la_SOURCES = version/version.c

--- a/example/statistic/statistic.cc
+++ b/example/statistic/statistic.cc
@@ -1,0 +1,69 @@
+/** @file
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+// This plugin demonstrates the statistics API and also serves as a
+// regression test for TS-4840. If traffic_server is restarted, a
+// plugin ought to be able to safely reattach to its statistics.
+//
+// This source is included as an example in the developers so if you
+// change it, you may have to update the line numbers on
+// doc/developer-guide/plugins/adding-statistics.en.rst
+
+#include <ts/ts.h>
+#include <inttypes.h>
+#include <time.h>
+
+#define PLUGIN_NAME "statistics"
+
+void
+TSPluginInit(int /* argc */, const char * /* argv */ [])
+{
+  TSPluginRegistrationInfo info;
+
+  info.plugin_name   = (char *)PLUGIN_NAME;
+  info.vendor_name   = (char *)"Apache Software Foundation";
+  info.support_email = (char *)"dev@trafficserver.apache.org";
+
+  int id;
+  const char name[] = "example.statistic.now";
+
+  if (TSStatFindName(name, &id) == TS_ERROR) {
+    id = TSStatCreate(name, TS_RECORDDATATYPE_INT, TS_STAT_NON_PERSISTENT, TS_STAT_SYNC_SUM);
+    if (id == TS_ERROR) {
+      TSError("%s: failed to register '%s'", PLUGIN_NAME, name);
+    }
+  }
+
+  TSError("%s: %s registered with id %d", PLUGIN_NAME, name, id);
+
+#if DEBUG
+  TSReleaseAssert(id != TS_ERROR);
+#endif
+
+  // Set an initial value for our statistic.
+  TSStatIntSet(id, time(NULL));
+
+  // Increment the statistic as time passes.
+  TSStatIntIncrement(id, 1);
+
+  TSDebug(PLUGIN_NAME, "%s is set to %" PRId64, name, TSStatIntGet(id));
+  TSReleaseAssert(TSPluginRegister(&info) == TS_SUCCESS);
+}

--- a/lib/records/I_RecDefs.h
+++ b/lib/records/I_RecDefs.h
@@ -157,7 +157,7 @@ union RecData {
 struct RecRawStat {
   int64_t sum;
   int64_t count;
-  // XXX - these will waist some space because they are only needed for the globals
+  // XXX - these will waste some space because they are only needed for the globals
   // this is a fix for bug TS-162, so I am trying to do as few code changes as
   // possible, this should be revisted -bcall
   int64_t last_sum;   // value from the last global sync

--- a/lib/records/I_RecProcess.h
+++ b/lib/records/I_RecProcess.h
@@ -84,11 +84,9 @@ int RecRawStatUpdateSum(RecRawStatBlock *rsb, int id);
 inline int RecIncrRawStat(RecRawStatBlock *rsb, EThread *ethread, int id, int64_t incr = 1);
 inline int RecIncrRawStatSum(RecRawStatBlock *rsb, EThread *ethread, int id, int64_t incr = 1);
 inline int RecIncrRawStatCount(RecRawStatBlock *rsb, EThread *ethread, int id, int64_t incr = 1);
-int RecIncrRawStatBlock(RecRawStatBlock *rsb, EThread *ethread, RecRawStat *stat_array);
 
 int RecSetRawStatSum(RecRawStatBlock *rsb, int id, int64_t data);
 int RecSetRawStatCount(RecRawStatBlock *rsb, int id, int64_t data);
-int RecSetRawStatBlock(RecRawStatBlock *rsb, RecRawStat *stat_array);
 
 int RecGetRawStatSum(RecRawStatBlock *rsb, int id, int64_t *data);
 int RecGetRawStatCount(RecRawStatBlock *rsb, int id, int64_t *data);

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -6948,13 +6948,20 @@ TSStatIntSet(int the_stat, TSMgmtInt value)
 TSReturnCode
 TSStatFindName(const char *name, int *idp)
 {
+  int id;
+
   sdk_assert(sdk_sanity_check_null_ptr((void *)name) == TS_SUCCESS);
 
-  if (RecGetRecordOrderAndId(name, NULL, idp) == REC_ERR_OKAY) {
-    return TS_SUCCESS;
+  if (RecGetRecordOrderAndId(name, NULL, &id) != REC_ERR_OKAY) {
+    return TS_ERROR;
   }
 
-  return TS_ERROR;
+  if (RecGetGlobalRawStatPtr(api_rsb, id) == NULL) {
+    return TS_ERROR;
+  }
+
+  *idp = id;
+  return TS_SUCCESS;
 }
 
 /**************************    Stats API    ****************************/


### PR DESCRIPTION
The change in TS-4793 regressed the C++ API Stat object. What happens is that if you restart traffic_server without traffic_manager, the TSStatFindName call finds the metric in the records hash table, but traffic_server has not set up the RSB entry so actually incrementing it crashes.
