### PR TITLE
TS-4861: Turn ECONNRESET into an end-of-file.

### DIFF
--- a/mgmt/utils/MgmtSocket.cc
+++ b/mgmt/utils/MgmtSocket.cc
@@ -42,15 +42,27 @@
 bool
 mgmt_transient_error()
 {
-  bool transient = false;
-  transient      = (errno == EINTR);
+  switch (errno) {
+  case EINTR:
+  case EAGAIN:
+
 #ifdef ENOMEM
-  transient = transient || (errno == ENOMEM);
+  case ENOMEM:
 #endif
+
 #ifdef ENOBUF
-  transient = transient || (errno == ENOBUF);
+  case ENOBUF:
 #endif
-  return transient;
+
+#if defined(EWOULDBLOCK) && (EWOULDBLOCK != EAGAIN)
+  case EWOULDBLOCK:
+#endif
+
+    return true;
+
+  default:
+    return false;
+  }
 }
 
 //-------------------------------------------------------------------------


### PR DESCRIPTION
If you do traffic_ctl server restart, then traffic_manager is getting
an ECONNRESET error on the management socket after traffic_server
exits. traffic_manager takes this as a fatal error and exits too.

The fix is to turn ECONNRESET into an EOF (0) return from
mgmt_read_pipe() so that traffic_manager correctly sees that
traffic_server has gone away.