### PR TITLE
TS-4833: Check stream is not closed when restart it

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -658,7 +658,7 @@ rcv_window_update_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
     stream->client_rwnd += size;
     ssize_t wnd = min(cstate.client_rwnd, stream->client_rwnd);
 
-    if (stream->get_state() == HTTP2_STREAM_STATE_HALF_CLOSED_REMOTE && wnd > 0) {
+    if (!stream->is_closed() && stream->get_state() == HTTP2_STREAM_STATE_HALF_CLOSED_REMOTE && wnd > 0) {
       stream->send_response_body();
     }
   }
@@ -948,7 +948,7 @@ Http2ConnectionState::restart_streams()
 
   while (s) {
     Http2Stream *next = s->link.next;
-    if (s->get_state() == HTTP2_STREAM_STATE_HALF_CLOSED_REMOTE && min(this->client_rwnd, s->client_rwnd) > 0) {
+    if (!s->is_closed() && s->get_state() == HTTP2_STREAM_STATE_HALF_CLOSED_REMOTE && min(this->client_rwnd, s->client_rwnd) > 0) {
       s->send_response_body();
     }
     s = next;

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -240,10 +240,16 @@ public:
   void clear_timers();
   void clear_io_events();
   bool
-  is_client_state_writeable()
+  is_client_state_writeable() const
   {
     return _state == HTTP2_STREAM_STATE_OPEN || _state == HTTP2_STREAM_STATE_HALF_CLOSED_REMOTE ||
            HTTP2_STREAM_STATE_RESERVED_LOCAL;
+  }
+
+  bool
+  is_closed() const
+  {
+    return closed;
   }
 
 private:


### PR DESCRIPTION
I found below in dumped stream object in [frame #0](https://issues.apache.org/jira/browse/TS-4833?focusedCommentId=15475142&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15475142)

```
_state=HTTP2_STREAM_STATE_HALF_CLOSED_REMOTE
closed=true
``` 

I think restarting closed stream is root cause.