### PR TITLE
TS-4867: Only schedule the serializer after we have completely finished initializing

### DIFF
--- a/iocore/hostdb/P_RefCountCacheSerializer.h
+++ b/iocore/hostdb/P_RefCountCacheSerializer.h
@@ -92,11 +92,11 @@ RefCountCacheSerializer<C>::RefCountCacheSerializer(Continuation *acont, C *cc, 
     total_size(0),
     rsb(cc->get_rsb())
 {
-  eventProcessor.schedule_imm(this, ET_TASK);
   this->tmp_filename = this->filename + ".syncing"; // TODO tmp file extension configurable?
 
   Debug("refcountcache", "started serializer %p", this);
   SET_HANDLER(&RefCountCacheSerializer::initialize_storage);
+  eventProcessor.schedule_imm(this, ET_TASK);
 }
 
 template <class C> RefCountCacheSerializer<C>::~RefCountCacheSerializer()


### PR DESCRIPTION
Otherwise there is a race between initialization and the eventProcessor