### PR TITLE
TS-4475 Fix Log Collation Crash (back-port).

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -2427,6 +2427,14 @@ refer to :ref:`admin-monitoring-logging-formats` and :file:`logs_xml.config`.
 
    The number of seconds between collation server connection retries.
 
+.. ts:cv:: CONFIG proxy.config.log.collation_host_timeout INT 86390
+
+   The number of seconds before active or inactivity time-out events for the server side.
+
+.. ts:cv:: CONFIG proxy.config.log.collation_client_timeout INT 86400
+
+   The number of seconds before active or inactivity time-out events for the client side.
+
 .. ts:cv:: CONFIG proxy.config.log.rolling_enabled INT 1
    :reloadable:
 

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -2429,11 +2429,21 @@ refer to :ref:`admin-monitoring-logging-formats` and :file:`logs_xml.config`.
 
 .. ts:cv:: CONFIG proxy.config.log.collation_host_timeout INT 86390
 
-   The number of seconds before active or inactivity time-out events for the server side.
+   The number of seconds before inactivity time-out events for the host side.
+   This setting over-rides the default set with proxy.config.net.default_inactivity_timeout
+   for log collation connections.
+
+   The default is set for 10s less on the host side to help prevent any possible race
+   conditions. If the host disconnects first, the client will see the disconnect
+   before its own time-out and re-connect automatically. If the client does not see
+   the disconnect, i.e., connection is "locked-up" for some reason, it will disconnect
+   when it reaches its own time-out and then re-connect automatically.
 
 .. ts:cv:: CONFIG proxy.config.log.collation_client_timeout INT 86400
 
-   The number of seconds before active or inactivity time-out events for the client side.
+   The number of seconds before inactivity time-out events for the client side.
+   This setting over-rides the default set with proxy.config.net.default_inactivity_timeout
+   for log collation connections.
 
 .. ts:cv:: CONFIG proxy.config.log.rolling_enabled INT 1
    :reloadable:

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1172,6 +1172,10 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.log.collation_preproc_threads", RECD_INT, "1", RECU_DYNAMIC, RR_REQUIRED, RECC_INT, "[1-128]", RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.log.collation_host_timeout", RECD_INT, "86390", RECU_NULL, RR_NULL, RECC_NULL, NULL, RECA_NULL}
+  ,
+  {RECT_CONFIG, "proxy.config.log.collation_client_timeout", RECD_INT, "86400", RECU_NULL, RR_NULL, RECC_NULL, NULL, RECA_NULL}
+  ,
   {RECT_CONFIG, "proxy.config.log.rolling_enabled", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-4]", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.log.rolling_interval_sec", RECD_INT, "86400", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}

--- a/proxy/logging/LogCollationClientSM.cc
+++ b/proxy/logging/LogCollationClientSM.cc
@@ -266,6 +266,9 @@ LogCollationClientSM::client_auth(int event, VIO * /* vio ATS_UNUSED */)
 
     return client_send(LOG_COLL_EVENT_SWITCH, NULL);
 
+  case VC_EVENT_INACTIVITY_TIMEOUT:
+    Debug("log-coll", "[%d]client::client_auth - Ignoring VC_EVENT_INACTIVITY_TIMEOUT", m_id);
+    return EVENT_CONT;
   case VC_EVENT_EOS:
   case VC_EVENT_ERROR: {
     Debug("log-coll", "[%d]client::client_auth - EOS|ERROR", m_id);
@@ -449,6 +452,9 @@ LogCollationClientSM::client_idle(int event, void * /* data ATS_UNUSED */)
     m_client_state = LOG_COLL_CLIENT_IDLE;
     return EVENT_CONT;
 
+  case VC_EVENT_INACTIVITY_TIMEOUT:
+    Debug("log-coll", "[%d]client::client_idle - Ignoring VC_EVENT_INACTIVITY_TIMEOUT", m_id);
+    return EVENT_CONT;
   case VC_EVENT_EOS:
   case VC_EVENT_ERROR:
     Debug("log-coll", "[%d]client::client_idle - EOS|ERROR", m_id);
@@ -663,6 +669,9 @@ LogCollationClientSM::client_send(int event, VIO * /* vio ATS_UNUSED */)
     // switch back to client_send
     return client_send(LOG_COLL_EVENT_SWITCH, NULL);
 
+  case VC_EVENT_INACTIVITY_TIMEOUT:
+    Debug("log-coll", "[%d]client::client_send - Ignoring VC_EVENT_INACTIVITY_TIMEOUT", m_id);
+    return EVENT_CONT;
   case VC_EVENT_EOS:
   case VC_EVENT_ERROR: {
     Debug("log-coll", "[%d]client::client_send - EOS|ERROR", m_id);

--- a/proxy/logging/LogCollationClientSM.cc
+++ b/proxy/logging/LogCollationClientSM.cc
@@ -266,12 +266,11 @@ LogCollationClientSM::client_auth(int event, VIO * /* vio ATS_UNUSED */)
 
     return client_send(LOG_COLL_EVENT_SWITCH, NULL);
 
+  case VC_EVENT_ACTIVE_TIMEOUT:
   case VC_EVENT_INACTIVITY_TIMEOUT:
-    Debug("log-coll", "[%d]client::client_auth - closing on VC_EVENT_INACTIVITY_TIMEOUT", m_id);
-    return client_fail(LOG_COLL_EVENT_SWITCH, NULL);
   case VC_EVENT_EOS:
   case VC_EVENT_ERROR: {
-    Debug("log-coll", "[%d]client::client_auth - EOS|ERROR", m_id);
+    Debug("log-coll", "[%d]client::client_auth - TIMEOUT|EOS|ERROR", m_id);
     int64_t read_avail = m_auth_reader->read_avail();
 
     if (read_avail > 0) {
@@ -452,12 +451,11 @@ LogCollationClientSM::client_idle(int event, void * /* data ATS_UNUSED */)
     m_client_state = LOG_COLL_CLIENT_IDLE;
     return EVENT_CONT;
 
+  case VC_EVENT_ACTIVE_TIMEOUT:
   case VC_EVENT_INACTIVITY_TIMEOUT:
-    Debug("log-coll", "[%d]client::client_idle - closing on VC_EVENT_INACTIVITY_TIMEOUT", m_id);
-    return client_fail(LOG_COLL_EVENT_SWITCH, NULL);
   case VC_EVENT_EOS:
   case VC_EVENT_ERROR:
-    Debug("log-coll", "[%d]client::client_idle - EOS|ERROR", m_id);
+    Debug("log-coll", "[%d]client::client_idle - TIMEOUT|EOS|ERROR", m_id);
     return client_fail(LOG_COLL_EVENT_SWITCH, NULL);
 
   default:
@@ -672,12 +670,11 @@ LogCollationClientSM::client_send(int event, VIO * /* vio ATS_UNUSED */)
     // switch back to client_send
     return client_send(LOG_COLL_EVENT_SWITCH, NULL);
 
+  case VC_EVENT_ACTIVE_TIMEOUT:
   case VC_EVENT_INACTIVITY_TIMEOUT:
-    Debug("log-coll", "[%d]client::client_send - closing on VC_EVENT_INACTIVITY_TIMEOUT", m_id);
-    return client_fail(LOG_COLL_EVENT_SWITCH, NULL);
   case VC_EVENT_EOS:
   case VC_EVENT_ERROR: {
-    Debug("log-coll", "[%d]client::client_send - EOS|ERROR", m_id);
+    Debug("log-coll", "[%d]client::client_send - TIMEOUT|EOS|ERROR", m_id);
     int64_t read_avail = m_send_reader->read_avail();
 
     if (read_avail > 0) {

--- a/proxy/logging/LogCollationClientSM.cc
+++ b/proxy/logging/LogCollationClientSM.cc
@@ -267,8 +267,8 @@ LogCollationClientSM::client_auth(int event, VIO * /* vio ATS_UNUSED */)
     return client_send(LOG_COLL_EVENT_SWITCH, NULL);
 
   case VC_EVENT_INACTIVITY_TIMEOUT:
-    Debug("log-coll", "[%d]client::client_auth - Ignoring VC_EVENT_INACTIVITY_TIMEOUT", m_id);
-    return EVENT_CONT;
+    Debug("log-coll", "[%d]client::client_auth - closing on VC_EVENT_INACTIVITY_TIMEOUT", m_id);
+    return client_fail(LOG_COLL_EVENT_SWITCH, NULL);
   case VC_EVENT_EOS:
   case VC_EVENT_ERROR: {
     Debug("log-coll", "[%d]client::client_auth - EOS|ERROR", m_id);
@@ -453,8 +453,8 @@ LogCollationClientSM::client_idle(int event, void * /* data ATS_UNUSED */)
     return EVENT_CONT;
 
   case VC_EVENT_INACTIVITY_TIMEOUT:
-    Debug("log-coll", "[%d]client::client_idle - Ignoring VC_EVENT_INACTIVITY_TIMEOUT", m_id);
-    return EVENT_CONT;
+    Debug("log-coll", "[%d]client::client_idle - closing on VC_EVENT_INACTIVITY_TIMEOUT", m_id);
+    return client_fail(LOG_COLL_EVENT_SWITCH, NULL);
   case VC_EVENT_EOS:
   case VC_EVENT_ERROR:
     Debug("log-coll", "[%d]client::client_idle - EOS|ERROR", m_id);
@@ -552,6 +552,9 @@ LogCollationClientSM::client_open(int event, NetVConnection *net_vc)
 
     ink_assert(net_vc != NULL);
     m_host_vc = net_vc;
+
+    // assign a non-default-inactivity-timeout
+    net_vc->set_inactivity_timeout(HRTIME_SECONDS(86400));
 
     // setup a client reader just for detecting a host disconnnect
     // (iocore should call back this function with and EOS/ERROR)
@@ -670,8 +673,8 @@ LogCollationClientSM::client_send(int event, VIO * /* vio ATS_UNUSED */)
     return client_send(LOG_COLL_EVENT_SWITCH, NULL);
 
   case VC_EVENT_INACTIVITY_TIMEOUT:
-    Debug("log-coll", "[%d]client::client_send - Ignoring VC_EVENT_INACTIVITY_TIMEOUT", m_id);
-    return EVENT_CONT;
+    Debug("log-coll", "[%d]client::client_send - closing on VC_EVENT_INACTIVITY_TIMEOUT", m_id);
+    return client_fail(LOG_COLL_EVENT_SWITCH, NULL);
   case VC_EVENT_EOS:
   case VC_EVENT_ERROR: {
     Debug("log-coll", "[%d]client::client_send - EOS|ERROR", m_id);

--- a/proxy/logging/LogCollationClientSM.cc
+++ b/proxy/logging/LogCollationClientSM.cc
@@ -551,8 +551,8 @@ LogCollationClientSM::client_open(int event, NetVConnection *net_vc)
     ink_assert(net_vc != NULL);
     m_host_vc = net_vc;
 
-    // assign a non-default-inactivity-timeout
-    net_vc->set_inactivity_timeout(HRTIME_SECONDS(86400));
+    // assign an explicit inactivity timeout so that it will not get the default value later
+    m_host_vc->set_inactivity_timeout(HRTIME_SECONDS(86400));
 
     // setup a client reader just for detecting a host disconnnect
     // (iocore should call back this function with and EOS/ERROR)

--- a/proxy/logging/LogCollationClientSM.cc
+++ b/proxy/logging/LogCollationClientSM.cc
@@ -520,6 +520,8 @@ LogCollationClientSM::client_init(int event, void * /* data ATS_UNUSED */)
 int
 LogCollationClientSM::client_open(int event, NetVConnection *net_vc)
 {
+  RecInt rec_timeout;
+  int timeout = 86400;
   ip_port_text_buffer ipb;
   Debug("log-coll", "[%d]client::client_open", m_id);
 
@@ -552,7 +554,10 @@ LogCollationClientSM::client_open(int event, NetVConnection *net_vc)
     m_host_vc = net_vc;
 
     // assign an explicit inactivity timeout so that it will not get the default value later
-    m_host_vc->set_inactivity_timeout(HRTIME_SECONDS(86400));
+    if (RecGetRecordInt("proxy.config.log.collation_client_timeout", &rec_timeout) == REC_ERR_OKAY) {
+      timeout = rec_timeout;
+    }
+    m_host_vc->set_inactivity_timeout(HRTIME_SECONDS(timeout));
 
     // setup a client reader just for detecting a host disconnnect
     // (iocore should call back this function with and EOS/ERROR)


### PR DESCRIPTION
@shinrich @oknet -- Susan, this PR is just a back-port to 6.2.x of the Log Collation crash fix. I believe Oknet already +1 the back-port as part of the previous PR #831 . I think this should be back-ported as this is a crash bug and 6.2.x is a LTS release.
