### PR TITLE
TS-4870: Avoid marking storage offline multiple times

### DIFF
--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -2000,6 +2000,13 @@ CacheProcessor::mark_storage_offline(CacheDisk *d ///< Target disk
   uint64_t total_dir_delete   = 0;
   uint64_t used_dir_delete    = 0;
 
+  /* Don't mark it again, it will invalidate the stats! */
+  if (!d->online) {
+    return this->has_online_storage();
+  }
+
+  d->online = false;
+
   if (!DISK_BAD(d))
     SET_DISK_BAD(d);
 
@@ -2052,7 +2059,7 @@ CacheProcessor::has_online_storage() const
 {
   CacheDisk **dptr = gdisks;
   for (int disk_no = 0; disk_no < gndisks; ++disk_no, ++dptr) {
-    if (!DISK_BAD(*dptr))
+    if (!DISK_BAD(*dptr) && (*dptr)->online)
       return true;
   }
   return false;

--- a/iocore/cache/P_CacheDisk.h
+++ b/iocore/cache/P_CacheDisk.h
@@ -97,6 +97,7 @@ struct CacheDisk : public Continuation {
   int num_errors;
   int cleared;
   bool read_only_p;
+  bool online; /* flag marking cache disk online or offline (because of too many failures or by the operator). */
 
   // Extra configuration values
   int forced_volume_num;           ///< Volume number for this disk.
@@ -119,6 +120,7 @@ struct CacheDisk : public Continuation {
       num_errors(0),
       cleared(0),
       read_only_p(false),
+      online(true),
       forced_volume_num(-1)
   {
   }


### PR DESCRIPTION
Currently storage can be marked offline multiple times which breaks related metrics.