### PR TITLE
TS-4875: Hoist SSL index creation into library initialization.

### DIFF
--- a/iocore/net/P_SSLClientUtils.h
+++ b/iocore/net/P_SSLClientUtils.h
@@ -37,7 +37,4 @@
 // Create and initialize a SSL client context.
 SSL_CTX *SSLInitClientContext(const struct SSLConfigParams *param);
 
-// Returns the index used to store our data on the SSL
-int get_ssl_client_data_index();
-
 #endif /* IOCORE_NET_P_SSLCLIENTUTILS_H_ */

--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -162,6 +162,15 @@ void SSLDebugBufferPrint(const char *tag, const char *buffer, unsigned buflen, c
 // Load the SSL certificate configuration.
 bool SSLParseCertificateConfiguration(const SSLConfigParams *params, SSLCertLookup *lookup);
 
+// Attach a SSL NetVC back pointer to a SSL session.
+void SSLNetVCAttach(SSL *ssl, SSLNetVConnection *vc);
+
+// Detach from SSL NetVC back pointer to a SSL session.
+void SSLNetVCDetach(SSL *ssl);
+
+// Return the SSLNetVConnection (if any) attached to this SSL session.
+SSLNetVConnection *SSLNetVCAccess(const SSL *ssl);
+
 namespace ssl
 {
 namespace detail

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1374,12 +1374,14 @@ UnixNetVConnection::migrateToCurrentThread(Continuation *cont, EThread *t)
     // We're already there!
     return this;
   }
+
   Connection hold_con;
   hold_con.move(this->con);
   SSLNetVConnection *sslvc = dynamic_cast<SSLNetVConnection *>(this);
-  SSL *save_ssl            = (sslvc) ? sslvc->ssl : NULL;
+
+  SSL *save_ssl = (sslvc) ? sslvc->ssl : NULL;
   if (save_ssl) {
-    SSL_set_ex_data(sslvc->ssl, get_ssl_client_data_index(), NULL);
+    SSLNetVCDetach(sslvc->ssl);
     sslvc->ssl = NULL;
   }
 


### PR DESCRIPTION
The SSL index used for server certificate validation can only be
created once, so we need to do it in the library initialization,
not the client context initialization. Following the SSL utilities
conventions, wrap a helper API around the raw SSL data index accesses.