### PR TITLE
TS-4880: Fix missing utils::internal::initTransactionManagement() call

### DIFF
--- a/lib/atscppapi/src/RemapPlugin.cc
+++ b/lib/atscppapi/src/RemapPlugin.cc
@@ -68,5 +68,6 @@ TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 
 RemapPlugin::RemapPlugin(void **instance_handle)
 {
+  utils::internal::initTransactionManagement();
   *instance_handle = static_cast<void *>(this);
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TS-4880