### PR TITLE
TS-4866: Makes traffic_cop killing optional

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -262,6 +262,22 @@ System Variables
    this applies only during startup of Traffic Server and does not apply to the run
    time heartbeat checking.
 
+.. ts:cv:: CONFIG proxy.config.cop.active_health_checks INT 3
+
+   Specifies which, if any, of :program:`traffic_server` and
+   :program:`traffic_manager` that :program:`traffic_cop` is allowed to kill
+   in the event of failed health checks. The possible values are:
+
+   ===== ======================================================================
+   Value Description
+   ===== ======================================================================
+   ``0`` :program:`traffic_cop` is not allowed to kill any processes.
+   ``1`` Only :program:`traffic_manager` can be killed on failed health checks.
+   ``2`` Only :program:`traffic_server` can be killed on failed health checks.
+   ``3`` :program:`traffic_server` and :program:`traffic_manager` can be killed
+         on failures (default).
+   ===== ======================================================================
+
 .. ts:cv:: CONFIG proxy.config.output.logfile  STRING traffic.out
 
    The name and location of the file that contains warnings, status messages, and error messages produced by the Traffic Server

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -85,6 +85,8 @@ static const RecordElement RecordsConfig[] =
   ,                             // needed by traffic_cop
   {RECT_CONFIG, "proxy.config.cop.init_sleep_time", RECD_INT, "0", RECU_NULL, RR_NULL, RECC_NULL, "[0-900]", RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.cop.active_health_checks", RECD_INT, "3", RECU_NULL, RR_NULL, RECC_NULL, "[0-3]", RECA_NULL}
+  ,
   //# 0 = disable (seconds)
   {RECT_CONFIG, "proxy.config.dump_mem_info_frequency", RECD_INT, "0", RECU_NULL, RR_NULL, RECC_NULL, NULL, RECA_NULL}
   ,


### PR DESCRIPTION
This adds a new configuration option, proxy.config.cop.active_health_checks:

 0 - traffic_cop is not allowed to kill any processes
 1 - Only traffic_manager can be killed on failed health checks
 2 - Only traffic_server can be killed on failed health checks
 3 - traffic_server and traffic_manager can be killed on failure (default)