### PR TITLE
TS-4882: TCP Fast Open support for server sessions.

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3405,12 +3405,18 @@ Sockets
         TCP_NODELAY  (1)
         SO_KEEPALIVE (2)
         SO_LINGER (4) - with a timeout of 0 seconds
+        TCP_FASTOPEN (8)
 
 .. note::
 
    This is a bitmask and you need to decide what bits to set.  Therefore,
    you must set the value to ``3`` if you want to enable nodelay and
    keepalive options above.
+
+.. note::
+
+   To allow TCP Fast Open for client sockets on Linux, bit 2 of
+   the ``net.ipv4.tcp_fastopen`` sysctl must be set.
 
 .. ts:cv:: CONFIG proxy.config.net.sock_send_buffer_size_out INT 0
    :overridable:
@@ -3431,6 +3437,7 @@ Sockets
         TCP_NODELAY  (1)
         SO_KEEPALIVE (2)
         SO_LINGER (4) - with a timeout of 0 seconds
+        TCP_FASTOPEN (8)
 
 .. note::
 
@@ -3442,6 +3449,11 @@ Sockets
    to 0. This is useful when Traffic Server and the origin server
    are co-located and large numbers of sockets are retained
    in the TIME_WAIT state.
+
+.. note::
+
+   To allow TCP Fast Open for server sockets on Linux, bit 1 of
+   the ``net.ipv4.tcp_fastopen`` sysctl must be set.
 
 .. ts:cv:: CONFIG proxy.config.net.sock_mss_in INT 0
 

--- a/iocore/net/BIO_fastopen.cc
+++ b/iocore/net/BIO_fastopen.cc
@@ -1,0 +1,162 @@
+/** @file
+ *
+ *  OpenSSL socket BIO that does TCP Fast Open.
+ *
+ *  @section license License
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "I_Net.h"
+#include "I_SocketManager.h"
+#include "ts/ink_assert.h"
+
+#include "BIO_fastopen.h"
+
+static int
+fastopen_create(BIO *bio)
+{
+  bio->init  = 0;
+  bio->num   = NO_FD;
+  bio->flags = 0;
+  bio->ptr   = NULL;
+
+  return 1;
+}
+
+static int
+fastopen_destroy(BIO *bio)
+{
+  if (bio) {
+    // We expect this BIO to not own the socket, so we must always
+    // be in NOCLOSE mode.
+    ink_assert(bio->shutdown == BIO_NOCLOSE);
+    fastopen_create(bio);
+  }
+
+  return 1;
+}
+
+static int
+fastopen_bwrite(BIO *bio, const char *in, int insz)
+{
+  int64_t err;
+
+  errno = 0;
+  BIO_clear_retry_flags(bio);
+  ink_assert(bio->num != NO_FD);
+
+  if (bio->ptr) {
+    // On the first write only, make a TFO request if TFO is enabled.
+    // The best documentation on the behavior of the Linux API is in
+    // RFC 7413. If we get EINPROGRESS it means that the SYN has been
+    // sent without data dn we sshould retry.
+    const sockaddr *dst = reinterpret_cast<const sockaddr *>(bio->ptr);
+
+    err = socketManager.sendto(bio->num, (void *)in, insz, MSG_FASTOPEN, dst, ats_ip_size(dst));
+
+    bio->ptr = NULL;
+  } else {
+    err = socketManager.write(bio->num, (void *)in, insz);
+  }
+
+  if (err < 0) {
+    errno = -err;
+    if (BIO_sock_non_fatal_error(errno)) {
+      BIO_set_retry_write(bio);
+    }
+  }
+
+  return err < 0 ? -1 : err;
+}
+
+static int
+fastopen_bread(BIO *bio, char *out, int outsz)
+{
+  int64_t err;
+
+  errno = 0;
+  BIO_clear_retry_flags(bio);
+  ink_assert(bio->num != NO_FD);
+
+  // TODO: If we haven't done the fastopen, ink_abort().
+
+  err = socketManager.read(bio->num, out, outsz);
+  if (err < 0) {
+    errno = -err;
+    if (BIO_sock_non_fatal_error(errno)) {
+      BIO_set_retry_write(bio);
+    }
+  }
+
+  return err < 0 ? -1 : err;
+}
+
+static long
+fastopen_ctrl(BIO *bio, int cmd, long larg, void *ptr)
+{
+  switch (cmd) {
+  case BIO_C_SET_FD:
+    ink_assert(larg == BIO_CLOSE || larg == BIO_NOCLOSE);
+    ink_assert(bio->num == NO_FD);
+
+    bio->init     = 1;
+    bio->shutdown = larg;
+    bio->num      = *reinterpret_cast<int *>(ptr);
+    return 0;
+
+  case BIO_C_SET_CONNECT:
+    // We only support BIO_set_conn_address(), which sets a sockaddr.
+    ink_assert(larg == 2);
+    bio->ptr = ptr;
+    return 0;
+
+  // We are unbuffered so unconditionally succeed on BIO_flush().
+  case BIO_CTRL_FLUSH:
+    return 1;
+
+  case BIO_CTRL_PUSH:
+  case BIO_CTRL_POP:
+    return 0;
+
+  default:
+#if DEBUG
+    ink_abort("unsupported BIO control cmd=%d larg=%ld ptr=%p", cmd, larg, ptr);
+#endif
+
+    return 0;
+  }
+}
+
+static const BIO_METHOD fastopen_methods = {
+  .type          = BIO_TYPE_SOCKET,
+  .name          = "fastopen",
+  .bwrite        = fastopen_bwrite,
+  .bread         = fastopen_bread,
+  .bputs         = NULL,
+  .bgets         = NULL,
+  .ctrl          = fastopen_ctrl,
+  .create        = fastopen_create,
+  .destroy       = fastopen_destroy,
+  .callback_ctrl = NULL,
+};
+
+const BIO_METHOD *
+BIO_s_fastopen()
+{
+  return &fastopen_methods;
+}

--- a/iocore/net/BIO_fastopen.cc
+++ b/iocore/net/BIO_fastopen.cc
@@ -21,7 +21,7 @@
  *  limitations under the License.
  */
 
-#include "I_Net.h"
+#include "P_Net.h"
 #include "I_SocketManager.h"
 #include "ts/ink_assert.h"
 
@@ -64,10 +64,16 @@ fastopen_bwrite(BIO *bio, const char *in, int insz)
     // On the first write only, make a TFO request if TFO is enabled.
     // The best documentation on the behavior of the Linux API is in
     // RFC 7413. If we get EINPROGRESS it means that the SYN has been
-    // sent without data dn we sshould retry.
+    // sent without data and we should retry.
     const sockaddr *dst = reinterpret_cast<const sockaddr *>(bio->ptr);
+    ProxyMutex *mutex   = this_ethread()->mutex.get();
+
+    NET_INCREMENT_DYN_STAT(net_fastopen_attempts_stat);
 
     err = socketManager.sendto(bio->num, (void *)in, insz, MSG_FASTOPEN, dst, ats_ip_size(dst));
+    if (err < 0) {
+      NET_INCREMENT_DYN_STAT(net_fastopen_failures_stat);
+    }
 
     bio->ptr = NULL;
   } else {

--- a/iocore/net/BIO_fastopen.h
+++ b/iocore/net/BIO_fastopen.h
@@ -1,0 +1,38 @@
+/** @file
+ *
+ *  OpenSSL socket BIO that does TCP Fast Open.
+ *
+ *  @section license License
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef BIO_FASTOPEN_H_DA87E080_DB75_4C9C_959A_40243592D454
+#define BIO_FASTOPEN_H_DA87E080_DB75_4C9C_959A_40243592D454
+
+#include <openssl/bio.h>
+
+// Return a BIO_METHOD for a socket BIO that implements TCP Fast Open.
+const BIO_METHOD *BIO_s_fastopen();
+
+// OpenSSL 1.0.2h has BIO_set_conn_ip(), but master has BIO_set_conn_address(). Use
+// the API from master since it makes more sense.
+#if !defined(BIO_set_conn_address)
+#define BIO_set_conn_address(b, addr) BIO_ctrl(b, BIO_C_SET_CONNECT, 2, (char *)addr)
+#endif
+
+#endif /* BIO_FASTOPEN_H_DA87E080_DB75_4C9C_959A_40243592D454 */

--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -142,6 +142,9 @@ struct NetVCOptions {
   /// Make socket block on connect (default: @c false)
   bool f_blocking_connect;
 
+  // Use TCP Fast Open on this socket. The connect(2) call will be omitted.
+  bool f_tcp_fastopen = false;
+
   /// Control use of SOCKS.
   /// Set to @c NO_SOCKS to disable use of SOCKS. Otherwise SOCKS is
   /// used if available.

--- a/iocore/net/Makefile.am
+++ b/iocore/net/Makefile.am
@@ -50,6 +50,8 @@ test_certlookup_LDADD = \
   $(top_builddir)/iocore/eventsystem/libinkevent.a
 
 libinknet_a_SOURCES = \
+  BIO_fastopen.cc \
+  BIO_fastopen.h \
   Connection.cc \
   I_Net.h \
   I_NetProcessor.h \

--- a/iocore/net/Net.cc
+++ b/iocore/net/Net.cc
@@ -29,6 +29,7 @@
 ************************************************************************/
 
 #include "P_Net.h"
+#include <utility>
 
 RecRawStatBlock *net_rsb = NULL;
 
@@ -56,82 +57,54 @@ configure_net(void)
 static inline void
 register_net_stats()
 {
-  //
-  // Register statistics
-  //
-  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.net_handler_run", RECD_INT, RECP_PERSISTENT,
-                     (int)net_handler_run_stat, RecRawStatSyncSum);
+  const std::pair<const char *, Net_Stats> persistent[] = {
+    {"proxy.process.net.calls_to_read", net_calls_to_read_stat},
+    {"proxy.process.net.calls_to_read_nodata", net_calls_to_read_nodata_stat},
+    {"proxy.process.net.calls_to_readfromnet", net_calls_to_readfromnet_stat},
+    {"proxy.process.net.calls_to_readfromnet_afterpoll", net_calls_to_readfromnet_afterpoll_stat},
+    {"proxy.process.net.calls_to_write", net_calls_to_write_stat},
+    {"proxy.process.net.calls_to_write_nodata", net_calls_to_write_nodata_stat},
+    {"proxy.process.net.calls_to_writetonet", net_calls_to_writetonet_stat},
+    {"proxy.process.net.calls_to_writetonet_afterpoll", net_calls_to_writetonet_afterpoll_stat},
+    {"proxy.process.net.inactivity_cop_lock_acquire_failure", inactivity_cop_lock_acquire_failure_stat},
+    {"proxy.process.net.net_handler_run", net_handler_run_stat},
+    {"proxy.process.net.read_bytes", net_read_bytes_stat},
+    {"proxy.process.net.write_bytes", net_write_bytes_stat},
+    {"proxy.process.socks.connections_successful", socks_connections_successful_stat},
+    {"proxy.process.socks.connections_unsuccessful", socks_connections_unsuccessful_stat},
+  };
+
+  const std::pair<const char *, Net_Stats> non_persistent[] = {
+    {"proxy.process.net.accepts_currently_open", net_accepts_currently_open_stat},
+    {"proxy.process.net.connections_currently_open", net_connections_currently_open_stat},
+    {"proxy.process.net.default_inactivity_timeout_applied", default_inactivity_timeout_stat},
+    {"proxy.process.net.dynamic_keep_alive_timeout_in_count", keep_alive_queue_timeout_count_stat},
+    {"proxy.process.net.dynamic_keep_alive_timeout_in_total", keep_alive_queue_timeout_total_stat},
+    {"proxy.process.socks.connections_currently_open", socks_connections_currently_open_stat},
+  };
+
+  for (auto &p : persistent) {
+    RecRegisterRawStat(net_rsb, RECT_PROCESS, p.first, RECD_INT, RECP_PERSISTENT, p.second, RecRawStatSyncSum);
+  }
+
+  for (auto &p : non_persistent) {
+    RecRegisterRawStat(net_rsb, RECT_PROCESS, p.first, RECD_INT, RECP_NON_PERSISTENT, p.second, RecRawStatSyncSum);
+  }
+
   NET_CLEAR_DYN_STAT(net_handler_run_stat);
-
-  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.read_bytes", RECD_INT, RECP_PERSISTENT, (int)net_read_bytes_stat,
-                     RecRawStatSyncSum);
-
-  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.write_bytes", RECD_INT, RECP_PERSISTENT, (int)net_write_bytes_stat,
-                     RecRawStatSyncSum);
-
-  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.connections_currently_open", RECD_INT, RECP_NON_PERSISTENT,
-                     (int)net_connections_currently_open_stat, RecRawStatSyncSum);
   NET_CLEAR_DYN_STAT(net_connections_currently_open_stat);
-
-  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.accepts_currently_open", RECD_INT, RECP_NON_PERSISTENT,
-                     (int)net_accepts_currently_open_stat, RecRawStatSyncSum);
   NET_CLEAR_DYN_STAT(net_accepts_currently_open_stat);
-
-  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.calls_to_readfromnet", RECD_INT, RECP_PERSISTENT,
-                     (int)net_calls_to_readfromnet_stat, RecRawStatSyncSum);
   NET_CLEAR_DYN_STAT(net_calls_to_readfromnet_stat);
-
-  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.calls_to_readfromnet_afterpoll", RECD_INT, RECP_PERSISTENT,
-                     (int)net_calls_to_readfromnet_afterpoll_stat, RecRawStatSyncSum);
   NET_CLEAR_DYN_STAT(net_calls_to_readfromnet_afterpoll_stat);
-
-  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.calls_to_read", RECD_INT, RECP_PERSISTENT,
-                     (int)net_calls_to_read_stat, RecRawStatSyncSum);
   NET_CLEAR_DYN_STAT(net_calls_to_read_stat);
-
-  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.calls_to_read_nodata", RECD_INT, RECP_PERSISTENT,
-                     (int)net_calls_to_read_nodata_stat, RecRawStatSyncSum);
   NET_CLEAR_DYN_STAT(net_calls_to_read_nodata_stat);
-
-  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.calls_to_writetonet", RECD_INT, RECP_PERSISTENT,
-                     (int)net_calls_to_writetonet_stat, RecRawStatSyncSum);
   NET_CLEAR_DYN_STAT(net_calls_to_writetonet_stat);
-
-  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.calls_to_writetonet_afterpoll", RECD_INT, RECP_PERSISTENT,
-                     (int)net_calls_to_writetonet_afterpoll_stat, RecRawStatSyncSum);
   NET_CLEAR_DYN_STAT(net_calls_to_writetonet_afterpoll_stat);
-
-  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.calls_to_write", RECD_INT, RECP_PERSISTENT,
-                     (int)net_calls_to_write_stat, RecRawStatSyncSum);
   NET_CLEAR_DYN_STAT(net_calls_to_write_stat);
-
-  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.calls_to_write_nodata", RECD_INT, RECP_PERSISTENT,
-                     (int)net_calls_to_write_nodata_stat, RecRawStatSyncSum);
   NET_CLEAR_DYN_STAT(net_calls_to_write_nodata_stat);
-
-  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.socks.connections_successful", RECD_INT, RECP_PERSISTENT,
-                     (int)socks_connections_successful_stat, RecRawStatSyncSum);
-
-  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.socks.connections_unsuccessful", RECD_INT, RECP_PERSISTENT,
-                     (int)socks_connections_unsuccessful_stat, RecRawStatSyncSum);
-
-  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.socks.connections_currently_open", RECD_INT, RECP_NON_PERSISTENT,
-                     (int)socks_connections_currently_open_stat, RecRawStatSyncSum);
   NET_CLEAR_DYN_STAT(socks_connections_currently_open_stat);
-
-  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.inactivity_cop_lock_acquire_failure", RECD_INT, RECP_PERSISTENT,
-                     (int)inactivity_cop_lock_acquire_failure_stat, RecRawStatSyncSum);
-
-  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.dynamic_keep_alive_timeout_in_total", RECD_INT, RECP_NON_PERSISTENT,
-                     (int)keep_alive_queue_timeout_total_stat, RecRawStatSyncSum);
   NET_CLEAR_DYN_STAT(keep_alive_queue_timeout_total_stat);
-
-  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.dynamic_keep_alive_timeout_in_count", RECD_INT, RECP_NON_PERSISTENT,
-                     (int)keep_alive_queue_timeout_count_stat, RecRawStatSyncSum);
   NET_CLEAR_DYN_STAT(keep_alive_queue_timeout_count_stat);
-
-  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.default_inactivity_timeout_applied", RECD_INT, RECP_NON_PERSISTENT,
-                     (int)default_inactivity_timeout_stat, RecRawStatSyncSum);
   NET_CLEAR_DYN_STAT(default_inactivity_timeout_stat);
 }
 

--- a/iocore/net/Net.cc
+++ b/iocore/net/Net.cc
@@ -70,6 +70,8 @@ register_net_stats()
     {"proxy.process.net.net_handler_run", net_handler_run_stat},
     {"proxy.process.net.read_bytes", net_read_bytes_stat},
     {"proxy.process.net.write_bytes", net_write_bytes_stat},
+    {"proxy.process.net.fastopen_out.attempts", net_fastopen_attempts_stat},
+    {"proxy.process.net.fastopen_out.failures", net_fastopen_failures_stat},
     {"proxy.process.socks.connections_successful", socks_connections_successful_stat},
     {"proxy.process.socks.connections_unsuccessful", socks_connections_unsuccessful_stat},
   };

--- a/iocore/net/P_Net.h
+++ b/iocore/net/P_Net.h
@@ -53,6 +53,8 @@ enum Net_Stats {
   keep_alive_queue_timeout_total_stat,
   keep_alive_queue_timeout_count_stat,
   default_inactivity_timeout_stat,
+  net_fastopen_attempts_stat,
+  net_fastopen_failures_stat,
   Net_Stat_Count
 };
 

--- a/iocore/net/UnixConnection.cc
+++ b/iocore/net/UnixConnection.cc
@@ -325,6 +325,10 @@ Connection::connect(sockaddr const *target, NetVCOptions const &opt)
   cleaner<Connection> cleanup(this, &Connection::_cleanup); // mark for close until we succeed.
 
   if (opt.f_tcp_fastopen && !opt.f_blocking_connect) {
+    ProxyMutex *mutex = this_ethread()->mutex.get();
+
+    NET_INCREMENT_DYN_STAT(net_fastopen_attempts_stat);
+
     // TCP Fast Open is (effectively) a non-blocking connect, so set the
     // return value we would see in that case.
     errno = EINPROGRESS;

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1006,6 +1006,10 @@ UnixNetVConnection::load_buffer_and_write(int64_t towrite, MIOBufferAccessor &bu
       msg.msg_iovlen  = niov;
 
       r = socketManager.sendmsg(con.fd, &msg, MSG_FASTOPEN);
+      if (r < 0) {
+        NET_INCREMENT_DYN_STAT(net_fastopen_failures_stat);
+      }
+
     } else {
       r = socketManager.writev(con.fd, &tiovec[0], niov);
     }

--- a/proxy/config/metrics.config.default
+++ b/proxy/config/metrics.config.default
@@ -1563,3 +1563,8 @@ integer 'proxy.cluster.log.bytes_received_from_network_avg_10s' [[
 counter 'proxy.process.ssl.total_success_handshake_count' [[
   return proxy.process.ssl.total_success_handshake_count_in
 ]]
+
+counter 'proxy.process.net.fastopen_out.success' [[
+  return proxy.process.net.fastopen_out.attempts -
+    proxy.process.net.fastopen_out.failures
+]]

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -1231,9 +1231,15 @@ HttpConfig::reconfigure()
 
   params->oride.sock_recv_buffer_size_out = m_master.oride.sock_recv_buffer_size_out;
   params->oride.sock_send_buffer_size_out = m_master.oride.sock_send_buffer_size_out;
-  params->oride.sock_option_flag_out      = m_master.oride.sock_option_flag_out;
   params->oride.sock_packet_mark_out      = m_master.oride.sock_packet_mark_out;
   params->oride.sock_packet_tos_out       = m_master.oride.sock_packet_tos_out;
+  params->oride.sock_option_flag_out      = m_master.oride.sock_option_flag_out;
+
+  // Clear the TCP Fast Open option if it is not supported on this host.
+  if ((params->oride.sock_option_flag_out & NetVCOptions::SOCK_OPT_TCP_FAST_OPEN) && !SocketManager::fastopen_supported()) {
+    Status("disabling unsupported TCP Fast Open flag on proxy.config.net.sock_option_flag_out");
+    params->oride.sock_option_flag_out &= ~NetVCOptions::SOCK_OPT_TCP_FAST_OPEN;
+  }
 
   params->oride.fwd_proxy_auth_to_parent = INT_TO_BOOL(m_master.oride.fwd_proxy_auth_to_parent);
 

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -4961,13 +4961,22 @@ HttpSM::do_http_server_open(bool raw)
     }
   }
 
+  // draft-stenberg-httpbis-tcp recommends only enabling TFO on safe, indempotent methods or
+  // those with intervening protocol layers (eg. TLS).
+  if (scheme_to_use == URL_WKSIDX_HTTPS || t_state.method == HTTP_WKSIDX_CONNECT || t_state.method == HTTP_WKSIDX_DELETE ||
+      t_state.method == HTTP_WKSIDX_GET || t_state.method == HTTP_WKSIDX_HEAD || t_state.method == HTTP_WKSIDX_PUT) {
+    opt.f_tcp_fastopen = (t_state.txn_conf->sock_option_flag_out & NetVCOptions::SOCK_OPT_TCP_FAST_OPEN);
+  }
+
   if (scheme_to_use == URL_WKSIDX_HTTPS) {
     DebugSM("http", "calling sslNetProcessor.connect_re");
+
     int len          = 0;
     const char *host = t_state.hdr_info.server_request.host_get(&len);
     if (host && len > 0) {
       opt.set_sni_servername(host, len);
     }
+
     connect_action_handle = sslNetProcessor.connect_re(this,                                 // state machine
                                                        &t_state.current.server->dst_addr.sa, // addr + port
                                                        &opt);
@@ -4976,21 +4985,23 @@ HttpSM::do_http_server_open(bool raw)
     connect_action_handle = netProcessor.connect_re(this,                                 // state machine
                                                     &t_state.current.server->dst_addr.sa, // addr + port
                                                     &opt);
-  } else { // CONNECT method
-    // Setup the timeouts
-    // Set the inactivity timeout to the connect timeout so that we
-    //   we fail this server if it doesn't start sending the response
-    //   header
+  } else {
+    // CONNECT method
     MgmtInt connect_timeout;
+
+    ink_assert(t_state.method == HTTP_WKSIDX_CONNECT);
+
+    // Set the inactivity timeout to the connect timeout so that we
+    // we fail this server if it doesn't start sending the response
+    // header
     if (t_state.current.server == &t_state.parent_info) {
       connect_timeout = t_state.http_config_param->parent_connect_timeout;
+    } else if (t_state.pCongestionEntry != NULL) {
+      connect_timeout = t_state.pCongestionEntry->connect_timeout();
     } else {
-      if (t_state.pCongestionEntry != NULL) {
-        connect_timeout = t_state.pCongestionEntry->connect_timeout();
-      } else {
-        connect_timeout = t_state.txn_conf->connect_attempts_timeout;
-      }
+      connect_timeout = t_state.txn_conf->connect_attempts_timeout;
     }
+
     DebugSM("http", "calling netProcessor.connect_s");
     connect_action_handle = netProcessor.connect_s(this,                                 // state machine
                                                    &t_state.current.server->dst_addr.sa, // addr + port


### PR DESCRIPTION
Add TCP Fast Open support to the proxy.config.net.sock_option_flag_out
configuration option.

Implement detection of TFO support in SocketManager and use that
to guarantee that we don't try to use TFO on hosts where is is not
supported or enabled.

Add TFO support to both SSLNetVConnection and UnixNetVConnection,
enabling it if the corresponding NetVCOption is set. We only enable
TFO on server sessions that are going to do TLS or are handling
idempotent HTTP methods.