### PR TITLE
TS-4887 : Clean up Parent Selection URL feature

### DIFF
--- a/doc/developer-guide/api/functions/TSHttpTxnCacheParentSelectionUrlGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnCacheParentSelectionUrlGet.en.rst
@@ -39,11 +39,24 @@ The Parent Selection consistent hash feature selects among multiple
 parent caches based on hashing a URL (the HTTP request header URL).
 
 These API functions allow an over-ride URL to be defined such that the
-over-ride URL is hashed instead of the normal URL. In addition, the
-various filtering options that may be applied to the normal URL
-(fname, maxdirs, and qstring) are NOT applied when the over-ride is
-used since it is assumed that custom filtering has already been
-performed prior to explicitly setting the over-ride URL
+over-ride URL is hashed instead of the normal (header request) URL. In
+addition, any filtering options that may be applied to the normal URL
+(such as qstring) are NOT applied to the over-ride URL since it is
+assumed that custom filtering has already been performed prior to
+explicitly setting the over-ride URL.
+
+Note that the normal URL is only hashed on the path and query string
+portion (optionally excluded with the qstring option). However, the
+over-ride URL is hashed on the entire URL string as returned by
+URL::string_get_ref(). This includes the scheme and hostname such as
+"http://hostname" which occur prior to the path.
+
+If the non-path URL elements should not be hashed in a meaningful
+manner, then they should be normalized to some value (if they are
+required in a valid URL) or excluded (if they are optional) when
+generating the over-ride URL. For example, since the over-ride URL is
+arbitrary, the URL scheme and hostname can simply be set to
+"fake://fake.fake" when creating the over-ride URL.
 
 :func:`TSHttpTxnCacheParentSelectionUrlSet` will set the over-ride URL.
 

--- a/proxy/ParentConsistentHash.cc
+++ b/proxy/ParentConsistentHash.cc
@@ -61,22 +61,20 @@ ParentConsistentHash::~ParentConsistentHash()
 uint64_t
 ParentConsistentHash::getPathHash(HttpRequestData *hrdata, ATSHash64 *h)
 {
-  const char *tmp = NULL;
+  const char *url_string_ref = NULL;
   int len;
   URL *url = hrdata->hdr->url_get();
 
   // Use over-ride URL from HttpTransact::State's cache_info.parent_selection_url, if present.
   URL *ps_url = NULL;
-  Debug("parent_select", "hrdata->cache_info_parent_selection_url = %p", hrdata->cache_info_parent_selection_url);
   if (hrdata->cache_info_parent_selection_url) {
     ps_url = *(hrdata->cache_info_parent_selection_url);
-    Debug("parent_select", "ps_url = %p", ps_url);
     if (ps_url) {
-      tmp = ps_url->string_get_ref(&len);
-      if (tmp && len > 0) {
+      url_string_ref = ps_url->string_get_ref(&len);
+      if (url_string_ref && len > 0) {
         // Print the over-ride URL
-        Debug("parent_select", "Using Over-Ride String='%.*s'.", len, tmp);
-        h->update(tmp, len);
+        Debug("parent_select", "Using Over-Ride String='%.*s'.", len, url_string_ref);
+        h->update(url_string_ref, len);
         h->final();
         return h->get();
       }
@@ -86,16 +84,16 @@ ParentConsistentHash::getPathHash(HttpRequestData *hrdata, ATSHash64 *h)
   // Always hash on '/' because paths returned by ATS are always stripped of it
   h->update("/", 1);
 
-  tmp = url->path_get(&len);
-  if (tmp) {
-    h->update(tmp, len);
+  url_string_ref = url->path_get(&len);
+  if (url_string_ref) {
+    h->update(url_string_ref, len);
   }
 
   if (!ignore_query) {
-    tmp = url->query_get(&len);
-    if (tmp) {
+    url_string_ref = url->query_get(&len);
+    if (url_string_ref) {
       h->update("?", 1);
-      h->update(tmp, len);
+      h->update(url_string_ref, len);
     }
   }
 


### PR DESCRIPTION
* Updated TS API manual page.
* Renamed 'tmp' variable in ParentConsistentHash::getPathHash().
* Clean up debug messages (some excessive pointer value reporting).