### PR TITLE
TS-4888: collapsed_forwarding plugin should return TSREMAP_NO_REMAP.

### DIFF
--- a/plugins/experimental/collapsed_forwarding/collapsed_forwarding.cc
+++ b/plugins/experimental/collapsed_forwarding/collapsed_forwarding.cc
@@ -309,5 +309,11 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
   TSHttpTxnHookAdd(rh, TS_HTTP_READ_RESPONSE_HDR_HOOK, cont);
   TSHttpTxnHookAdd(rh, TS_HTTP_OS_DNS_HOOK, cont);
 
-  return TSREMAP_DID_REMAP;
+  return TSREMAP_NO_REMAP;
+}
+
+void
+TSRemapDeleteInstance(void *ih)
+{
+  // To resolve run time error
 }


### PR DESCRIPTION
Modified collapsed_forwarding plugin to return TSREMAP_DID_REMAP. And also created TSRemapDeleteInstance() to avoid the runtime/loading error.