### PR TITLE
TS-4891: Initializing prefix_str on declaration

### DIFF
--- a/cmd/traffic_crashlog/traffic_crashlog.cc
+++ b/cmd/traffic_crashlog/traffic_crashlog.cc
@@ -92,7 +92,7 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   crashlog_target target;
   pid_t parent = getppid();
 
-  diags = new Diags("" /* tags */, "" /* actions */, new BaseLogFile("stderr"));
+  diags = new Diags("traffic_crashlog", "" /* tags */, "" /* actions */, new BaseLogFile("stderr"));
 
   appVersionInfo.setup(PACKAGE_NAME, "traffic_crashlog", PACKAGE_VERSION, __DATE__, __TIME__, BUILD_MACHINE, BUILD_PERSON, "");
 

--- a/cmd/traffic_ctl/traffic_ctl.cc
+++ b/cmd/traffic_ctl/traffic_ctl.cc
@@ -230,7 +230,7 @@ main(int argc, const char **argv)
   };
 
   BaseLogFile *base_log_file = new BaseLogFile("stderr");
-  diags                      = new Diags("" /* tags */, "" /* actions */, base_log_file);
+  diags                      = new Diags(program_name, "" /* tags */, "" /* actions */, base_log_file);
 
   // Process command line arguments and dump into variables
   if (!CtrlProcessArguments(argc, argv, argument_descriptions, countof(argument_descriptions))) {

--- a/cmd/traffic_manager/traffic_manager.cc
+++ b/cmd/traffic_manager/traffic_manager.cc
@@ -496,11 +496,10 @@ main(int argc, const char **argv)
 
   // Bootstrap the Diags facility so that we can use it while starting
   //  up the manager
-  diagsConfig = new DiagsConfig(DIAGS_LOG_FILENAME, debug_tags, action_tags, false);
+  diagsConfig = new DiagsConfig("Manager", DIAGS_LOG_FILENAME, debug_tags, action_tags, false);
   diags       = diagsConfig->diags;
   diags->set_stdout_output(bind_stdout);
   diags->set_stderr_output(bind_stderr);
-  diags->prefix_str = "Manager ";
 
   RecLocalInit();
   LibRecordsConfigInit();
@@ -542,10 +541,9 @@ main(int argc, const char **argv)
   }
   // INKqa11968: need to set up callbacks and diags data structures
   // using configuration in records.config
-  diagsConfig = new DiagsConfig(DIAGS_LOG_FILENAME, debug_tags, action_tags, true);
+  diagsConfig = new DiagsConfig("Manager", DIAGS_LOG_FILENAME, debug_tags, action_tags, true);
   diags       = diagsConfig->diags;
   RecSetDiags(diags);
-  diags->prefix_str = "Manager ";
   diags->set_stdout_output(bind_stdout);
   diags->set_stderr_output(bind_stderr);
 

--- a/iocore/net/test_certlookup.cc
+++ b/iocore/net/test_certlookup.cc
@@ -214,7 +214,7 @@ int
 main(int argc, const char **argv)
 {
   BaseLogFile *blf = new BaseLogFile("stdout");
-  diags            = new Diags(NULL, NULL, blf);
+  diags            = new Diags("test_certlookup", NULL, NULL, blf);
   res_track_memory = 1;
 
   SSL_library_init();

--- a/iocore/utils/diags.i
+++ b/iocore/utils/diags.i
@@ -91,7 +91,7 @@ init_diags(const char *bdt, const char *bat)
   char diags_logpath[500];
   strcpy(diags_logpath, DIAGS_LOG_FILE);
 
-  diags = new Diags(bdt, bat, new BaseLogFile(diags_logpath));
+  diags = new Diags("test", bdt, bat, new BaseLogFile(diags_logpath));
   Status("opened %s", diags_logpath);
 
   reconfigure_diags();

--- a/lib/ts/Diags.cc
+++ b/lib/ts/Diags.cc
@@ -100,7 +100,7 @@ vprintline(FILE *fp, char (&buffer)[Size], va_list ap)
 //
 //////////////////////////////////////////////////////////////////////////////
 
-Diags::Diags(const char *bdt, const char *bat, BaseLogFile *_diags_log)
+Diags::Diags(const char *prefix_string, const char *bdt, const char *bat, BaseLogFile *_diags_log)
   : diags_log(NULL),
     stdout_log(NULL),
     stderr_log(NULL),
@@ -128,6 +128,7 @@ Diags::Diags(const char *bdt, const char *bat, BaseLogFile *_diags_log)
   config.enabled[DiagsTagType_Debug]  = (base_debug_tags != NULL);
   config.enabled[DiagsTagType_Action] = (base_action_tags != NULL);
   diags_on_for_plugins                = config.enabled[DiagsTagType_Debug];
+  prefix_str                          = prefix_string;
 
   for (i = 0; i < DiagsLevel_Count; i++) {
     config.outputs[i].to_stdout   = false;
@@ -143,17 +144,12 @@ Diags::Diags(const char *bdt, const char *bat, BaseLogFile *_diags_log)
   stdout_log->open_file(); // should never fail
   stderr_log->open_file(); // should never fail
 
-  if (setup_diagslog(_diags_log)) {
-    diags_log = _diags_log;
-  }
-
   //////////////////////////////////////////////////////////////////
   // start off with empty tag tables, will build in reconfigure() //
   //////////////////////////////////////////////////////////////////
 
   activated_tags[DiagsTagType_Debug]  = NULL;
   activated_tags[DiagsTagType_Action] = NULL;
-  prefix_str                          = "";
 
   outputlog_rolling_enabled  = RollingEnabledValues::NO_ROLLING;
   outputlog_rolling_interval = -1;
@@ -164,6 +160,10 @@ Diags::Diags(const char *bdt, const char *bat, BaseLogFile *_diags_log)
 
   outputlog_time_last_roll = time(0);
   diagslog_time_last_roll  = time(0);
+
+  if (setup_diagslog(_diags_log)) {
+    diags_log = _diags_log;
+  }
 }
 
 Diags::~Diags()
@@ -309,6 +309,7 @@ Diags::print_va(const char *debug_tag, DiagsLevel diags_level, const SourceLocat
 
   for (int k = 0; prefix_str[k]; k++)
     *d++ = prefix_str[k];
+  *d++   = ' ';
   for (s = format_buf; *s; *d++ = *s++)
     ;
   *d++ = NUL;

--- a/lib/ts/Diags.h
+++ b/lib/ts/Diags.h
@@ -110,7 +110,7 @@ struct DiagsConfigState {
 class Diags
 {
 public:
-  Diags(const char *base_debug_tags, const char *base_action_tags, BaseLogFile *_diags_log);
+  Diags(const char *prefix_string, const char *base_debug_tags, const char *base_action_tags, BaseLogFile *_diags_log);
   ~Diags();
 
   BaseLogFile *diags_log;
@@ -121,7 +121,6 @@ public:
   volatile DiagsConfigState config;
   DiagsShowLocation show_location;
   DiagsCleanupFunc cleanup_func;
-  const char *prefix_str;
 
   ///////////////////////////
   // conditional debugging //
@@ -221,6 +220,7 @@ public:
   const char *base_action_tags; // internal copy of default action tags
 
 private:
+  const char *prefix_str;
   mutable ink_mutex tag_table_lock; // prevents reconfig/read races
   DFA *activated_tags[2];           // 1 table for debug, 1 for action
 

--- a/lib/ts/test_X509HostnameValidator.cc
+++ b/lib/ts/test_X509HostnameValidator.cc
@@ -187,7 +187,7 @@ int
 main(int argc, const char **argv)
 {
   BaseLogFile *blf = new BaseLogFile("stdout");
-  diags            = new Diags(NULL, NULL, blf);
+  diags            = new Diags("test_x509", NULL, NULL, blf);
   res_track_memory = 1;
 
   SSL_library_init();

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -1507,9 +1507,8 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   // re-start it again, TS will crash.
   // This is also needed for log rotation - setting up the file can cause privilege
   // related errors and if diagsConfig isn't get up yet that will crash on a NULL pointer.
-  diagsConfig       = new DiagsConfig(DIAGS_LOG_FILENAME, error_tags, action_tags, false);
-  diags             = diagsConfig->diags;
-  diags->prefix_str = "Server ";
+  diagsConfig = new DiagsConfig("Server", DIAGS_LOG_FILENAME, error_tags, action_tags, false);
+  diags       = diagsConfig->diags;
   diags->set_stdout_output(bind_stdout);
   diags->set_stderr_output(bind_stderr);
   if (is_debug_tag_set("diags")) {
@@ -1597,10 +1596,9 @@ main(int /* argc ATS_UNUSED */, const char **argv)
     RecDebugOff();
     delete (diagsConfig);
   }
-  diagsConfig = new DiagsConfig(DIAGS_LOG_FILENAME, error_tags, action_tags, true);
+  diagsConfig = new DiagsConfig("Server", DIAGS_LOG_FILENAME, error_tags, action_tags, true);
   diags       = diagsConfig->diags;
   RecSetDiags(diags);
-  diags->prefix_str = "Server ";
   diags->set_stdout_output(bind_stdout);
   diags->set_stderr_output(bind_stderr);
   if (is_debug_tag_set("diags")) {

--- a/proxy/logging/LogStandalone.cc
+++ b/proxy/logging/LogStandalone.cc
@@ -209,7 +209,7 @@ init_log_standalone(const char *pgm_name, bool one_copy)
 
   init_system(true);
   initialize_process_manager();
-  diagsConfig = new DiagsConfig(logfile, error_tags, action_tags);
+  diagsConfig = new DiagsConfig(pgm_name, logfile, error_tags, action_tags);
   diags       = diagsConfig->diags;
 }
 
@@ -237,7 +237,7 @@ init_log_standalone_basic(const char *pgm_name)
 
   init_system(false);
   const bool use_records = false;
-  diagsConfig            = new DiagsConfig(logfile, error_tags, action_tags, use_records);
+  diagsConfig            = new DiagsConfig(pgm_name, logfile, error_tags, action_tags, use_records);
   diags                  = diagsConfig->diags;
   // set stdin/stdout to be unbuffered
   //

--- a/proxy/shared/DiagsConfig.cc
+++ b/proxy/shared/DiagsConfig.cc
@@ -262,7 +262,8 @@ DiagsConfig::RegisterDiagConfig()
   RecRegisterConfigString(RECT_CONFIG, "proxy.config.diags.output.emergency", "SL", RECU_NULL, RECC_NULL, NULL, REC_SOURCE_DEFAULT);
 }
 
-DiagsConfig::DiagsConfig(const char *filename, const char *tags, const char *actions, bool use_records) : diags_log(NULL)
+DiagsConfig::DiagsConfig(const char *prefix_string, const char *filename, const char *tags, const char *actions, bool use_records)
+  : diags_log(NULL)
 {
   char diags_logpath[PATH_NAME_MAX];
   ats_scoped_str logpath;
@@ -277,7 +278,7 @@ DiagsConfig::DiagsConfig(const char *filename, const char *tags, const char *act
   ////////////////////////////////////////////////////////////////////
 
   if (!use_records) {
-    diags = new Diags(tags, actions, NULL);
+    diags = new Diags(prefix_string, tags, actions, NULL);
     config_diags_norecords();
     return;
   }
@@ -305,7 +306,7 @@ DiagsConfig::DiagsConfig(const char *filename, const char *tags, const char *act
 
   // Set up diags, FILE streams are opened in Diags constructor
   diags_log = new BaseLogFile(diags_logpath);
-  diags     = new Diags(tags, actions, diags_log);
+  diags     = new Diags(prefix_string, tags, actions, diags_log);
   diags->config_roll_diagslog((RollingEnabledValues)diags_log_roll_enable, diags_log_roll_int, diags_log_roll_size);
   diags->config_roll_outputlog((RollingEnabledValues)output_log_roll_enable, output_log_roll_int, output_log_roll_size);
 

--- a/proxy/shared/DiagsConfig.h
+++ b/proxy/shared/DiagsConfig.h
@@ -33,7 +33,7 @@ struct DiagsConfig {
   void RegisterDiagConfig();
   void register_diags_callbacks();
 
-  DiagsConfig(const char *filename, const char *tags, const char *actions, bool use_records = true);
+  DiagsConfig(const char *prefix_string, const char *filename, const char *tags, const char *actions, bool use_records = true);
   ~DiagsConfig();
 
 private:


### PR DESCRIPTION
prefix_str should be initialized before setup_diagslog() is called in Diags.cc:146 since a failure in setup_diagslog can lead to a call of print_va which reads from prefix_str.

Following trace might be helpful to understand the issue
https://gist.github.com/persiaAziz/48a321a1c1913af1580261fa40d14df0