### PR TITLE
TS-4841:  Log field cqtr is inaccurate for HTTP/2

### DIFF
--- a/proxy/ProxyClientTransaction.h
+++ b/proxy/ProxyClientTransaction.h
@@ -59,6 +59,12 @@ public:
     return parent ? parent->get_transact_count() : 0;
   }
 
+  virtual bool
+  is_first_transaction() const
+  {
+    return get_transact_count() == 1;
+  }
+
   // Ask your session if this is allowed
   bool
   is_transparent_passthrough_allowed()

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -526,7 +526,7 @@ HttpSM::attach_client_session(ProxyClientTransaction *client_vc, IOBufferReader 
   ua_session = client_vc;
 
   // Collect log & stats information
-  client_tcp_reused         = (1 < ua_session->get_transact_count());
+  client_tcp_reused         = !(ua_session->is_first_transaction());
   SSLNetVConnection *ssl_vc = dynamic_cast<SSLNetVConnection *>(netvc);
   if (ssl_vc != NULL) {
     client_connection_is_ssl = true;

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -212,7 +212,7 @@ public:
   virtual int
   get_transact_count() const
   {
-    return (int)con_id;
+    return connection_state.get_stream_requests();
   }
   virtual void
   release(ProxyClientTransaction *trans)

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -922,7 +922,9 @@ Http2ConnectionState::create_stream(Http2StreamId new_id)
   ++total_client_streams_count;
 
   new_stream->set_parent(ua_session);
-  new_stream->mutex = ua_session->mutex;
+  new_stream->mutex                     = ua_session->mutex;
+  new_stream->is_first_transaction_flag = get_stream_requests() == 0;
+  increment_stream_requests();
   ua_session->get_netvc()->add_to_active_queue();
   // reset the activity timeout everytime a new stream is created
   ua_session->get_netvc()->set_active_timeout(HRTIME_SECONDS(Http2::active_timeout_in));

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -119,6 +119,7 @@ public:
       stream_list(),
       latest_streamid_in(0),
       latest_streamid_out(0),
+      stream_requests(0),
       client_streams_in_count(0),
       client_streams_out_count(0),
       total_client_streams_count(0),
@@ -189,6 +190,18 @@ public:
   get_latest_stream_id_out() const
   {
     return latest_streamid_out;
+  }
+
+  int
+  get_stream_requests() const
+  {
+    return stream_requests;
+  }
+
+  void
+  increment_stream_requests()
+  {
+    stream_requests++;
   }
 
   // Continuated header decoding
@@ -267,6 +280,7 @@ private:
   DLL<Http2Stream> stream_list;
   Http2StreamId latest_streamid_in;
   Http2StreamId latest_streamid_out;
+  int stream_requests;
 
   // Counter for current active streams which is started by client
   uint32_t client_streams_in_count;

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -50,6 +50,7 @@ public:
       sent_request_header(false),
       response_header_done(false),
       request_sent(false),
+      is_first_transaction_flag(false),
       response_reader(NULL),
       request_reader(NULL),
       request_buffer(CLIENT_CONNECTION_FIRST_READ_BUFFER_SIZE_INDEX),
@@ -204,6 +205,7 @@ public:
   bool sent_request_header;
   bool response_header_done;
   bool request_sent;
+  bool is_first_transaction_flag;
 
   HTTPHdr response_header;
   IOBufferReader *response_reader;
@@ -250,6 +252,12 @@ public:
   is_closed() const
   {
     return closed;
+  }
+
+  bool
+  is_first_transaction() const
+  {
+    return is_first_transaction_flag;
   }
 
 private:


### PR DESCRIPTION
Fixed Http/2 get transaction count.  Added is_first_transaction_flag to Http2Stream to mark one of the streams as first.  Otherwise, by the time HttpSM logs the transaction, other streams are also likely to have gone through making the transaction count > 1, so no transaction would be logged as first.

We have been running this patch internally and it seems to be more accurately logging first transactions on the stream.