### PR TITLE
TS-4883: Thread start signature

### DIFF
--- a/cmd/traffic_manager/MgmtHandlers.cc
+++ b/cmd/traffic_manager/MgmtHandlers.cc
@@ -266,7 +266,7 @@ mgmt_synthetic_main(void *)
       mgmt_log("[SyntheticHealthServer] Connect by disallowed client %s, closing\n", inet_ntoa(clientInfo.sin_addr));
       close_socket(clientFD);
     } else {
-      ink_thread thrId = ink_thread_create(synthetic_thread, (void *)&clientFD, 1);
+      ink_thread thrId = ink_thread_create(synthetic_thread, (void *)&clientFD, 1, 0, NULL);
 
       if (thrId <= 0) {
         mgmt_log("[SyntheticHealthServer] Failed to create worker thread");

--- a/cmd/traffic_manager/traffic_manager.cc
+++ b/cmd/traffic_manager/traffic_manager.cc
@@ -688,7 +688,7 @@ main(int argc, const char **argv)
   // can keep a consistent euid when create mgmtapi/eventapi unix
   // sockets in mgmt_synthetic_main thread.
   //
-  synthThrId = ink_thread_create(mgmt_synthetic_main, NULL); /* Spin web agent thread */
+  synthThrId = ink_thread_create(mgmt_synthetic_main, NULL, 0, 0, NULL); /* Spin web agent thread */
   Debug("lm", "Created Web Agent thread (%" PRId64 ")", (int64_t)synthThrId);
 
   // Setup the API and event sockets
@@ -717,8 +717,8 @@ main(int argc, const char **argv)
   }
 
   umask(oldmask);
-  ink_thread_create(ts_ctrl_main, &mgmtapiFD);
-  ink_thread_create(event_callback_main, &eventapiFD);
+  ink_thread_create(ts_ctrl_main, &mgmtapiFD, 0, 0, NULL);
+  ink_thread_create(event_callback_main, &eventapiFD, 0, 0, NULL);
 
   ticker = time(NULL);
   mgmt_log("[TrafficManager] Setup complete\n");

--- a/iocore/eventsystem/I_Thread.h
+++ b/iocore/eventsystem/I_Thread.h
@@ -145,8 +145,7 @@ private:
   Thread &operator=(const Thread &);
 
 public:
-  ink_thread start(const char *name, size_t stacksize = DEFAULT_STACKSIZE, ThreadFunction f = NULL, void *a = NULL,
-                   void *stack = NULL);
+  ink_thread start(const char *name, size_t stacksize, ThreadFunction f, void *a, void *stack);
 
   virtual void
   execute()

--- a/iocore/eventsystem/Thread.cc
+++ b/iocore/eventsystem/Thread.cc
@@ -96,6 +96,9 @@ Thread::start(const char *name, size_t stacksize, ThreadFunction f, void *a, voi
   p->me = this;
   memset(p->name, 0, MAX_THREAD_NAME_LENGTH);
   ink_strlcpy(p->name, name, MAX_THREAD_NAME_LENGTH);
+  if (stacksize == 0) {
+    stacksize = DEFAULT_STACKSIZE;
+  }
   tid = ink_thread_create(spawn_thread_internal, (void *)p, 0, stacksize, stack);
 
   return tid;

--- a/iocore/eventsystem/UnixEventProcessor.cc
+++ b/iocore/eventsystem/UnixEventProcessor.cc
@@ -55,7 +55,7 @@ EventProcessor::spawn_event_threads(int n_threads, const char *et_name, size_t s
   n_threads_for_type[new_thread_group_id] = n_threads;
   for (i = 0; i < n_threads; i++) {
     snprintf(thr_name, MAX_THREAD_NAME_LENGTH, "[%s %d]", et_name, i);
-    eventthread[new_thread_group_id][i]->start(thr_name, stacksize);
+    eventthread[new_thread_group_id][i]->start(thr_name, stacksize, NULL, NULL, NULL);
   }
 
   n_thread_groups++;
@@ -273,7 +273,7 @@ EventProcessor::spawn_thread(Continuation *cont, const char *thr_name, size_t st
   e->ethread               = all_dthreads[n_dthreads];
   e->mutex = e->continuation->mutex = all_dthreads[n_dthreads]->mutex;
   n_dthreads++;
-  e->ethread->start(thr_name, stacksize);
+  e->ethread->start(thr_name, stacksize, NULL, NULL, NULL);
 
   return e;
 }

--- a/lib/records/RecLocal.cc
+++ b/lib/records/RecLocal.cc
@@ -216,8 +216,8 @@ RecLocalInitMessage()
 int
 RecLocalStart(FileManager *configFiles)
 {
-  ink_thread_create(sync_thr, configFiles);
-  ink_thread_create(config_update_thr, NULL);
+  ink_thread_create(sync_thr, configFiles, 0, 0, NULL);
+  ink_thread_create(config_update_thr, NULL, 0, 0, NULL);
   return REC_ERR_OKAY;
 }
 

--- a/lib/ts/ink_thread.h
+++ b/lib/ts/ink_thread.h
@@ -128,7 +128,7 @@ ink_thread_key_delete(ink_thread_key key)
 }
 
 static inline ink_thread
-ink_thread_create(void *(*f)(void *), void *a, int detached = 0, size_t stacksize = 0, void *stack = NULL)
+ink_thread_create(void *(*f)(void *), void *a, int detached, size_t stacksize, void *stack)
 {
   ink_thread t;
   int ret;

--- a/lib/ts/signals.cc
+++ b/lib/ts/signals.cc
@@ -116,7 +116,7 @@ check_signal_thread(void *ptr)
 void
 signal_start_check_thread(signal_handler_t handler)
 {
-  ink_thread_create(check_signal_thread, (void *)handler);
+  ink_thread_create(check_signal_thread, (void *)handler, 0, 0, NULL);
 }
 
 bool

--- a/lib/ts/test_freelist.cc
+++ b/lib/ts/test_freelist.cc
@@ -74,7 +74,7 @@ main(int /* argc ATS_UNUSED */, char * /*argv ATS_UNUSED */ [])
 
   for (i = 0; i < NTHREADS; i++) {
     fprintf(stderr, "Create thread %d\n", i);
-    ink_thread_create(test, (void *)((intptr_t)i));
+    ink_thread_create(test, (void *)((intptr_t)i), 0, 0, NULL);
   }
 
   test((void *)NTHREADS);

--- a/mgmt/ProcessManager.h
+++ b/mgmt/ProcessManager.h
@@ -62,7 +62,7 @@ public:
   void
   start()
   {
-    ink_thread_create(startProcessManager, 0);
+    ink_thread_create(startProcessManager, NULL, 0, 0, NULL);
   }
 
   void

--- a/mgmt/api/CoreAPIRemote.cc
+++ b/mgmt/api/CoreAPIRemote.cc
@@ -226,7 +226,7 @@ Init(const char *socket_path, TSInitOptionT options)
 
   // if connected, create event thread that listens for events from TM
   if (0 == (ts_init_options & TS_MGMT_OPT_NO_EVENTS)) {
-    ts_event_thread = ink_thread_create(event_poll_thread_main, &event_socket_fd);
+    ts_event_thread = ink_thread_create(event_poll_thread_main, &event_socket_fd, 0, 0, NULL);
   } else {
     ts_event_thread = static_cast<ink_thread>(NULL);
   }
@@ -236,7 +236,7 @@ END:
   // create thread that periodically checks the socket connection
   // with TM alive - reconnects if not alive
   if (0 == (ts_init_options & TS_MGMT_OPT_NO_SOCK_TESTS)) {
-    ts_test_thread = ink_thread_create(socket_test_thread, NULL);
+    ts_test_thread = ink_thread_create(socket_test_thread, NULL, 0, 0, NULL);
   } else {
     ts_test_thread = static_cast<ink_thread>(NULL);
   }

--- a/mgmt/api/NetworkUtilsRemote.cc
+++ b/mgmt/api/NetworkUtilsRemote.cc
@@ -231,7 +231,7 @@ reconnect()
 
   // relaunch a new event thread since socket_fd changed
   if (0 == (ts_init_options & TS_MGMT_OPT_NO_EVENTS)) {
-    ts_event_thread = ink_thread_create(event_poll_thread_main, &event_socket_fd);
+    ts_event_thread = ink_thread_create(event_poll_thread_main, &event_socket_fd, 0, 0, NULL);
     // reregister the callbacks on the TM side for this new client connection
     if (remote_event_callbacks) {
       err = send_register_all_callbacks(event_socket_fd, remote_event_callbacks);
@@ -645,7 +645,7 @@ event_poll_thread_main(void *arg)
     event->description = desc;
 
     // got event notice; spawn new thread to handle the event's callback functions
-    ink_thread_create(event_callback_thread, (void *)event);
+    ink_thread_create(event_callback_thread, (void *)event, 0, 0, NULL);
   }
 
   ink_thread_exit(NULL);

--- a/mgmt/cluster/ClusterCom.cc
+++ b/mgmt/cluster/ClusterCom.cc
@@ -444,8 +444,8 @@ ClusterCom::ClusterCom(unsigned long oip, char *host, int mcport, char *group, i
   mismatchLog = ink_hash_table_create(InkHashTableKeyType_String);
 
   if (cluster_type != NO_CLUSTER) {
-    ink_thread_create(drainIncomingChannel_broadcast, this); /* Spin drainer thread */
-    ink_thread_create(drainIncomingChannel, this);           /* Spin drainer thread */
+    ink_thread_create(drainIncomingChannel_broadcast, this, 0, 0, NULL); /* Spin drainer thread */
+    ink_thread_create(drainIncomingChannel, this, 0, 0, NULL);           /* Spin drainer thread */
   }
   return;
 } /* End ClusterCom::ClusterCom */

--- a/proxy/InkIOCoreAPI.cc
+++ b/proxy/InkIOCoreAPI.cc
@@ -129,7 +129,7 @@ TSThreadCreate(TSThreadFunc func, void *data)
   thread->func = func;
   thread->data = data;
 
-  if (!(ink_thread_create(ink_thread_trampoline, (void *)thread, 1))) {
+  if (!(ink_thread_create(ink_thread_trampoline, (void *)thread, 1, 0, NULL))) {
     return (TSThread)NULL;
   }
 


### PR DESCRIPTION
Remove defaults from both `Thread::start` and `ink_thread_create`.