### PR TITLE
TS-4892: Metric wrong for http.current_active_client_connections

### DIFF
--- a/proxy/ProxyClientSession.cc
+++ b/proxy/ProxyClientSession.cc
@@ -28,9 +28,27 @@
 static int64_t next_cs_id = 0;
 
 ProxyClientSession::ProxyClientSession()
-  : VConnection(NULL), acl_record(NULL), host_res_style(HOST_RES_IPV4), debug_on(false), hooks_on(true), con_id(0)
+  : VConnection(NULL), acl_record(NULL), host_res_style(HOST_RES_IPV4), debug_on(false), hooks_on(true), con_id(0), m_active(false)
 {
   ink_zero(this->user_args);
+}
+
+void
+ProxyClientSession::set_session_active()
+{
+  if (!m_active) {
+    m_active = true;
+    HTTP_INCREMENT_DYN_STAT(http_current_active_client_connections_stat);
+  }
+}
+
+void
+ProxyClientSession::clear_session_active()
+{
+  if (m_active) {
+    m_active = false;
+    HTTP_DECREMENT_DYN_STAT(http_current_active_client_connections_stat);
+  }
 }
 
 int64_t

--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -204,6 +204,9 @@ public:
     return retval;
   }
 
+  void set_session_active();
+  void clear_session_active();
+
 protected:
   // XXX Consider using a bitwise flags variable for the following flags, so that we can make the best
   // use of internal alignment padding.
@@ -228,6 +231,12 @@ private:
   ProxyClientSession &operator=(const ProxyClientSession &); // noncopyable
 
   void handle_api_return(int event);
+
+  // for DI. An active connection is one that a request has
+  // been successfully parsed (PARSE_DONE) and it remains to
+  // be active until the transaction goes through or the client
+  // aborts.
+  bool m_active;
 
   friend void TSHttpSsnDebugSet(TSHttpSsn, int);
 };

--- a/proxy/ProxyClientTransaction.cc
+++ b/proxy/ProxyClientTransaction.cc
@@ -28,13 +28,7 @@
 #define DebugHttpTxn(fmt, ...) DebugSsn(this, "http_txn", fmt, __VA_ARGS__)
 
 ProxyClientTransaction::ProxyClientTransaction()
-  : VConnection(NULL),
-    m_active(false),
-    parent(NULL),
-    current_reader(NULL),
-    sm_reader(NULL),
-    host_res_style(HOST_RES_NONE),
-    restart_immediate(false)
+  : VConnection(NULL), parent(NULL), current_reader(NULL), sm_reader(NULL), host_res_style(HOST_RES_NONE), restart_immediate(false)
 {
 }
 

--- a/proxy/ProxyClientTransaction.h
+++ b/proxy/ProxyClientTransaction.h
@@ -103,11 +103,21 @@ public:
     return parent->has_hooks();
   }
 
-  // for DI. An active connection is one that a request has
-  // been successfully parsed (PARSE_DONE) and it remains to
-  // be active until the transaction goes through or the client
-  // aborts.
-  bool m_active;
+  virtual void
+  set_session_active()
+  {
+    if (parent) {
+      parent->set_session_active();
+    }
+  }
+
+  virtual void
+  clear_session_active()
+  {
+    if (parent) {
+      parent->clear_session_active();
+    }
+  }
 
   /// DNS resolution preferences.
   HostResStyle

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -249,10 +249,7 @@ Http1ClientSession::do_io_close(int alerrno)
   if (read_state == HCS_CLOSED)
     return; // Don't double call session close
   if (read_state == HCS_ACTIVE_READER) {
-    if (trans.m_active) {
-      trans.m_active = false;
-      HTTP_DECREMENT_DYN_STAT(http_current_active_client_connections_stat);
-    }
+    clear_session_active();
   }
 
   // Prevent double closing
@@ -506,10 +503,8 @@ Http1ClientSession::attach_server_session(HttpServerSession *ssession, bool tran
     ink_assert(ssession->get_netvc() != this->get_netvc());
 
     // handling potential keep-alive here
-    if (trans.m_active) {
-      trans.m_active = false;
-      HTTP_DECREMENT_DYN_STAT(http_current_active_client_connections_stat);
-    }
+    clear_session_active();
+
     // Since this our slave, issue an IO to detect a close and
     //  have it call the client session back.  This IO also prevent
     //  the server net conneciton from calling back a dead sm

--- a/proxy/http/Http1ClientTransaction.cc
+++ b/proxy/http/Http1ClientTransaction.cc
@@ -33,10 +33,7 @@ Http1ClientTransaction::release(IOBufferReader *r)
   MgmtInt ka_in = current_reader->t_state.txn_conf->keep_alive_no_activity_timeout_in;
   set_inactivity_timeout(HRTIME_SECONDS(ka_in));
 
-  if (m_active) {
-    m_active = false;
-    HTTP_DECREMENT_DYN_STAT(http_current_active_client_connections_stat);
-  }
+  parent->clear_session_active();
   parent->ssn_last_txn_time = Thread::get_hrtime();
 
   // Make sure that the state machine is returning

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -773,10 +773,7 @@ HttpSM::state_read_client_request_header(int event, void *data)
   case PARSE_RESULT_DONE:
     DebugSM("http", "[%" PRId64 "] done parsing client request header", sm_id);
 
-    if (ua_session->m_active == false) {
-      ua_session->m_active = true;
-      HTTP_INCREMENT_DYN_STAT(http_current_active_client_connections_stat);
-    }
+    ua_session->set_session_active();
 
     if (t_state.hdr_info.client_request.version_get() == HTTPVersion(1, 1) &&
         (t_state.hdr_info.client_request.method_get_wksidx() == HTTP_WKSIDX_POST ||

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1015,6 +1015,12 @@ Http2ConnectionState::release_stream(Http2Stream *stream)
   if (stream) {
     --total_client_streams_count;
   }
+
+  // If the number of clients is 0, then mark the connection as inactive
+  if (total_client_streams_count == 0 && ua_session) {
+    ua_session->clear_session_active();
+  }
+
   if (ua_session && fini_received && total_client_streams_count == 0) {
     // We were shutting down, go ahead and terminate the session
     ua_session->destroy();


### PR DESCRIPTION
Moved the m_active flag to ProxyClientSession.  Added set_session_activate and clear_session_activate methods which will only increment/decrement the current_active_client_connections counter if the m_active flag changes value.

In all cases, the set_session_action is called from HttpSM when the request header is successfully parsed.

For Http1, the clear_session_active is called when the transaction is completed and when the session is closed.  

For Http2, the clear_session_active is called when the number of active streams goes to zero.  The session may not necessarily be closing at this point, but it is idle until another stream comes in.

We have been running with this patch in production