### PR TITLE
TS-4813: Fix lingering stream.

### DIFF
--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1211,8 +1211,6 @@ HttpTunnel::producer_handler(int event, HttpTunnelProducer *p)
 
   Debug("http_redirect", "[HttpTunnel::producer_handler] enable_redirection: [%d %d %d] event: %d", p->alive == true,
         sm->enable_redirection, (p->self_consumer && p->self_consumer->alive == true), event);
-  ink_assert(p->alive == true || event == HTTP_TUNNEL_EVENT_PRECOMPLETE || event == VC_EVENT_EOS || sm->enable_redirection ||
-             (p->self_consumer && p->self_consumer->alive == true));
 
   switch (event) {
   case VC_EVENT_READ_READY:
@@ -1268,14 +1266,16 @@ HttpTunnel::producer_handler(int event, HttpTunnelProducer *p)
   case VC_EVENT_ACTIVE_TIMEOUT:
   case VC_EVENT_INACTIVITY_TIMEOUT:
   case HTTP_TUNNEL_EVENT_CONSUMER_DETACH:
-    p->alive      = false;
-    p->bytes_read = p->read_vio->ndone;
-    // Interesting tunnel event, call SM
-    jump_point = p->vc_handler;
-    (sm->*jump_point)(event, p);
-    sm_callback = true;
-    // Failure case anyway
-    p->update_state_if_not_set(HTTP_SM_POST_UA_FAIL);
+    if (p->alive) {
+      p->alive      = false;
+      p->bytes_read = p->read_vio->ndone;
+      // Interesting tunnel event, call SM
+      jump_point = p->vc_handler;
+      (sm->*jump_point)(event, p);
+      sm_callback = true;
+      // Failure case anyway
+      p->update_state_if_not_set(HTTP_SM_POST_UA_FAIL);
+    }
     break;
 
   case VC_EVENT_WRITE_READY:

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -330,7 +330,7 @@ Http2Stream::do_io_close(int /* flags */)
       static_cast<Http2ClientSession *>(parent)->connection_state.send_data_frames(this);
     }
     // Check to see if the stream is in the closed state
-    ink_assert(get_state() == HTTP2_STREAM_STATE_CLOSED);
+    ink_assert(get_state() == HTTP2_STREAM_STATE_CLOSED || get_state() == HTTP2_STREAM_STATE_HALF_CLOSED_REMOTE);
 
     clear_timers();
     clear_io_events();


### PR DESCRIPTION
I think the crash is being caused by a stream in state HTTP2_STREAM_STATE_CLOSED not being cleaned up.  The timeout triggers later and takes a bad path through the HttpTunnel code.

The commit for TS-3535 (HTTP/2 priority support) adds a check at the beginning of Http2ConnectionState::send_data_frames to return immediately if _state is CLOSED or HALF_CLOSED local.  I removed that check and the frequent crashes stopped.  I think by going through send_a_data_frame, this case will return a HTTP2_SEND_A_DATA_FRAME_DONE return value which causes the this->delete_stream() to be called which will clean up the closed Http2Stream object.

I don't know the motivation for adding the earlier check.  Perhaps we should just call delete_stream in that case instead of returning immediately?