### PR TITLE
TS-4899: Http2ClientSession object leaks.

### DIFF
--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -314,7 +314,8 @@ Http2ClientSession::main_event_handler(int event, void *edata)
   case VC_EVENT_ERROR:
   case VC_EVENT_EOS:
     this->do_io_close();
-    return 0;
+    retval = 0;
+    break;
 
   case VC_EVENT_WRITE_READY:
     retval = 0;

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -807,9 +807,7 @@ Http2ConnectionState::main_event_handler(int event, void *edata)
     SCOPED_MUTEX_LOCK(lock, this->mutex, this_ethread());
     send_data_frames_depends_on_priority();
     _scheduled = false;
-
-    return 0;
-  }
+  } break;
 
   // Parse received HTTP/2 frames
   case HTTP2_SESSION_EVENT_RECV: {


### PR DESCRIPTION
There were returns in the middle of handlers.  When taken the object recursion count would not go to zero and the object would not be lost.

This needs to go with the fix for TS-4813.  Otherwise, the system will crash before you see the leak.