### PR TITLE
TS-4900: con_id member variable is shadowed in Http2ClientSession

### DIFF
--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -59,8 +59,7 @@ ink_mutex debug_cs_list_mutex;
 ClassAllocator<Http1ClientSession> http1ClientSessionAllocator("http1ClientSessionAllocator");
 
 Http1ClientSession::Http1ClientSession()
-  : con_id(0),
-    client_vc(NULL),
+  : client_vc(NULL),
     magic(HTTP_CS_MAGIC_DEAD),
     transact_count(0),
     tcp_init_cwnd_set(false),

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -185,7 +185,6 @@ private:
     HCS_CLOSED,
   };
 
-  int64_t con_id;
   NetVConnection *client_vc;
   int magic;
   int transact_count;

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -59,8 +59,7 @@ send_connection_event(Continuation *cont, int event, void *edata)
 }
 
 Http2ClientSession::Http2ClientSession()
-  : con_id(0),
-    total_write_len(0),
+  : total_write_len(0),
     client_vc(NULL),
     read_buffer(NULL),
     sm_reader(NULL),

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -285,7 +285,6 @@ private:
   // if there are multiple frames ready on the wire
   int state_process_frame_read(int event, VIO *vio, bool inside_frame);
 
-  int64_t con_id;
   int64_t total_write_len;
   SessionHandler session_handler;
   NetVConnection *client_vc;


### PR DESCRIPTION
And Http1ClientSession too.