### PR TITLE
Add return values to hash operations

### DIFF
--- a/lib/ts/Hash.h
+++ b/lib/ts/Hash.h
@@ -27,9 +27,9 @@
 #include <ctype.h>
 
 struct ATSHashBase {
-  virtual void update(const void *, size_t) = 0;
-  virtual void final(void) = 0;
-  virtual void clear(void) = 0;
+  virtual bool update(const void *, size_t) = 0;
+  virtual bool final(void) = 0;
+  virtual bool clear(void) = 0;
   virtual ~ATSHashBase();
 };
 

--- a/lib/ts/HashFNV.cc
+++ b/lib/ts/HashFNV.cc
@@ -18,9 +18,10 @@ ATSHash32FNV1a::ATSHash32FNV1a(void)
   this->clear();
 }
 
-void
+bool
 ATSHash32FNV1a::final(void)
 {
+  return true;
 }
 
 uint32_t
@@ -29,10 +30,11 @@ ATSHash32FNV1a::get(void) const
   return hval;
 }
 
-void
+bool
 ATSHash32FNV1a::clear(void)
 {
   hval = FNV_INIT_32;
+  return true;
 }
 
 // FNV-1a 64bit
@@ -40,9 +42,11 @@ ATSHash64FNV1a::ATSHash64FNV1a(void)
 {
   this->clear();
 }
-void
+
+bool
 ATSHash64FNV1a::final(void)
 {
+  return true;
 }
 
 uint64_t
@@ -51,8 +55,9 @@ ATSHash64FNV1a::get(void) const
   return hval;
 }
 
-void
+bool
 ATSHash64FNV1a::clear(void)
 {
   hval = FNV_INIT_64;
+  return true;
 }

--- a/lib/ts/HashFNV.h
+++ b/lib/ts/HashFNV.h
@@ -34,23 +34,23 @@
 struct ATSHash32FNV1a : ATSHash32 {
   ATSHash32FNV1a(void);
 
-  template <typename Transform> void update(const void *data, size_t len, Transform xfrm);
-  void
+  template <typename Transform> bool update(const void *data, size_t len, Transform xfrm);
+  bool
   update(const void *data, size_t len)
   {
-    update(data, len, ATSHash::nullxfrm());
+    return update(data, len, ATSHash::nullxfrm());
   }
 
-  void final(void);
+  bool final(void);
   uint32_t get(void) const;
-  void clear(void);
+  bool clear(void);
 
 private:
   uint32_t hval;
 };
 
 template <typename Transform>
-void
+bool
 ATSHash32FNV1a::update(const void *data, size_t len, Transform xfrm)
 {
   uint8_t *bp = (uint8_t *)data;
@@ -60,28 +60,29 @@ ATSHash32FNV1a::update(const void *data, size_t len, Transform xfrm)
     hval ^= (uint32_t)xfrm(*bp);
     hval += (hval << 1) + (hval << 4) + (hval << 7) + (hval << 8) + (hval << 24);
   }
+  return true;
 }
 
 struct ATSHash64FNV1a : ATSHash64 {
   ATSHash64FNV1a(void);
 
-  template <typename Transform> void update(const void *data, size_t len, Transform xfrm);
-  void
+  template <typename Transform> bool update(const void *data, size_t len, Transform xfrm);
+  bool
   update(const void *data, size_t len)
   {
-    update(data, len, ATSHash::nullxfrm());
+    return update(data, len, ATSHash::nullxfrm());
   }
 
-  void final(void);
+  bool final(void);
   uint64_t get(void) const;
-  void clear(void);
+  bool clear(void);
 
 private:
   uint64_t hval;
 };
 
 template <typename Transform>
-void
+bool
 ATSHash64FNV1a::update(const void *data, size_t len, Transform xfrm)
 {
   uint8_t *bp = (uint8_t *)data;
@@ -91,6 +92,7 @@ ATSHash64FNV1a::update(const void *data, size_t len, Transform xfrm)
     hval ^= (uint64_t)xfrm(*bp);
     hval += (hval << 1) + (hval << 4) + (hval << 5) + (hval << 7) + (hval << 8) + (hval << 40);
   }
+  return true;
 }
 
 #endif

--- a/lib/ts/HashMD5.h
+++ b/lib/ts/HashMD5.h
@@ -27,11 +27,11 @@
 
 struct ATSHashMD5 : ATSHash {
   ATSHashMD5(void);
-  void update(const void *data, size_t len);
-  void final(void);
+  bool update(const void *data, size_t len);
+  bool final(void);
   const void *get(void) const;
   size_t size(void) const;
-  void clear(void);
+  bool clear(void);
   ~ATSHashMD5();
 
 private:

--- a/lib/ts/HashSip.cc
+++ b/lib/ts/HashSip.cc
@@ -54,7 +54,7 @@ ATSHash64Sip24::ATSHash64Sip24(uint64_t key0, uint64_t key1)
   this->clear();
 }
 
-void
+bool
 ATSHash64Sip24::update(const void *data, size_t len)
 {
   size_t i, blocks;
@@ -92,10 +92,12 @@ ATSHash64Sip24::update(const void *data, size_t len)
       block_buffer_len = (len - block_off) & (SIP_BLOCK_SIZE - 1);
       memcpy(block_buffer, m + block_off + blocks, block_buffer_len);
     }
+    return true;
   }
+  return false;
 }
 
-void
+bool
 ATSHash64Sip24::final(void)
 {
   uint64_t last7;
@@ -119,7 +121,9 @@ ATSHash64Sip24::final(void)
     SIPCOMPRESS(v0, v1, v2, v3);
     hfinal    = v0 ^ v1 ^ v2 ^ v3;
     finalized = true;
+    return true;
   }
+  return false;
 }
 
 uint64_t
@@ -132,7 +136,7 @@ ATSHash64Sip24::get(void) const
   }
 }
 
-void
+bool
 ATSHash64Sip24::clear(void)
 {
   v0               = k0 ^ 0x736f6d6570736575ull;
@@ -142,4 +146,5 @@ ATSHash64Sip24::clear(void)
   finalized        = false;
   total_len        = 0;
   block_buffer_len = 0;
+  return true;
 }

--- a/lib/ts/HashSip.h
+++ b/lib/ts/HashSip.h
@@ -36,10 +36,10 @@ struct ATSHash64Sip24 : ATSHash64 {
   ATSHash64Sip24(void);
   ATSHash64Sip24(const unsigned char key[16]);
   ATSHash64Sip24(uint64_t key0, uint64_t key1);
-  void update(const void *data, size_t len);
-  void final(void);
+  bool update(const void *data, size_t len);
+  bool final(void);
   uint64_t get(void) const;
-  void clear(void);
+  bool clear(void);
 
 private:
   unsigned char block_buffer[8];


### PR DESCRIPTION
I made this PR due to a coverity issue where we weren't checking the return value on an EVP hash function. An alternative to this approach is just to continue to ignore that return code and convert the other usage in the code base to also ignore it.