### PR TITLE
TS-4626: LogFile::close_file should not delete m_log handle

### DIFF
--- a/proxy/logging/LogFile.cc
+++ b/proxy/logging/LogFile.cc
@@ -237,8 +237,6 @@ LogFile::close_file()
     } else if (m_log) {
       m_log->close_file();
       Debug("log-file", "LogFile %s is closed", m_log->get_name());
-      delete m_log;
-      m_log = NULL;
     } else {
       Warning("LogFile %s is open but was not closed", m_name);
     }


### PR DESCRIPTION
LogFile::close_file was incorrectly deleting the m_log object.
This caused potential race conditions when flushing m_log since
there aren't any locks protecting m_log accesses.

When the underlying log file on disk is deleted, it is fine to
not delete m_log. It's fine because the actual flush function
in Log::flush_thread_main checks to see if m_log is open before
doing any writes.