### PR TITLE
TS-4903: EISCONN errors when using TCP Fast Open.

### DIFF
--- a/iocore/net/BIO_fastopen.cc
+++ b/iocore/net/BIO_fastopen.cc
@@ -71,8 +71,8 @@ fastopen_bwrite(BIO *bio, const char *in, int insz)
     NET_INCREMENT_DYN_STAT(net_fastopen_attempts_stat);
 
     err = socketManager.sendto(bio->num, (void *)in, insz, MSG_FASTOPEN, dst, ats_ip_size(dst));
-    if (err < 0) {
-      NET_INCREMENT_DYN_STAT(net_fastopen_failures_stat);
+    if (err >= 0) {
+      NET_INCREMENT_DYN_STAT(net_fastopen_successes_stat);
     }
 
     bio->ptr = NULL;

--- a/iocore/net/Net.cc
+++ b/iocore/net/Net.cc
@@ -71,7 +71,7 @@ register_net_stats()
     {"proxy.process.net.read_bytes", net_read_bytes_stat},
     {"proxy.process.net.write_bytes", net_write_bytes_stat},
     {"proxy.process.net.fastopen_out.attempts", net_fastopen_attempts_stat},
-    {"proxy.process.net.fastopen_out.failures", net_fastopen_failures_stat},
+    {"proxy.process.net.fastopen_out.successes", net_fastopen_successes_stat},
     {"proxy.process.socks.connections_successful", socks_connections_successful_stat},
     {"proxy.process.socks.connections_unsuccessful", socks_connections_unsuccessful_stat},
   };

--- a/iocore/net/P_Net.h
+++ b/iocore/net/P_Net.h
@@ -54,7 +54,7 @@ enum Net_Stats {
   keep_alive_queue_timeout_count_stat,
   default_inactivity_timeout_stat,
   net_fastopen_attempts_stat,
-  net_fastopen_failures_stat,
+  net_fastopen_successes_stat,
   Net_Stat_Count
 };
 

--- a/proxy/config/metrics.config.default
+++ b/proxy/config/metrics.config.default
@@ -47,7 +47,7 @@
 --
 -- integer(NAME, FUNC), counter(NAME, FUNC), float(NAME, FUNC)
 --    These global functions register a metric of the corresponding name. Each
---    registered metric will be periodically recalculated by evaluating the 
+--    registered metric will be periodically recalculated by evaluating the
 --    given function.
 --
 --    The scope of a metric is derived from the name. 'proxy.cluster.*' metrics
@@ -1562,9 +1562,4 @@ integer 'proxy.cluster.log.bytes_received_from_network_avg_10s' [[
 
 counter 'proxy.process.ssl.total_success_handshake_count' [[
   return proxy.process.ssl.total_success_handshake_count_in
-]]
-
-counter 'proxy.process.net.fastopen_out.success' [[
-  return proxy.process.net.fastopen_out.attempts -
-    proxy.process.net.fastopen_out.failures
 ]]


### PR DESCRIPTION
The write VIO is reset when we reuse a VC, so we need to explicitly
track whether we have connected a TCP Fast Open socket. In the
previous patch we eschewed using the is_connected state of the
Connection, but that is explicitly what we want so we should just
use it and allow the Connection to be not connected until the Fast
Open connects it.