### PR TITLE
TS-4920: Consolidate accept socket options.

### DIFF
--- a/iocore/net/I_NetProcessor.h
+++ b/iocore/net/I_NetProcessor.h
@@ -86,6 +86,8 @@ public:
     uint32_t packet_mark;
     uint32_t packet_tos;
 
+    int tfo_queue_length;
+
     /** Transparency on client (user agent) connection.
         @internal This is irrelevant at a socket level (since inbound
         transparency must be set up when the listen socket is created)

--- a/iocore/net/P_Connection.h
+++ b/iocore/net/P_Connection.h
@@ -161,16 +161,8 @@ struct Server : public Connection {
   /// Client side (inbound) local IP address.
   IpEndpoint accept_addr;
 
-  /// If set, the related incoming connect was transparent.
-  bool f_inbound_transparent;
-
   /// If set, a kernel HTTP accept filter
   bool http_accept_filter;
-
-  //
-  // Use this call for the main proxy accept
-  //
-  int proxy_listen(bool non_blocking = false);
 
   int accept(Connection *c);
 
@@ -180,12 +172,10 @@ struct Server : public Connection {
   // converted into network byte order
   //
 
-  int listen(bool non_blocking = false, int recv_bufsize = 0, int send_bufsize = 0, bool transparent = false);
-  int setup_fd_for_listen(bool non_blocking = false, int recv_bufsize = 0, int send_bufsize = 0,
-                          bool transparent = false ///< Inbound transparent.
-                          );
+  int listen(bool non_blocking, const NetProcessor::AcceptOptions &opt);
+  int setup_fd_for_listen(bool non_blocking, const NetProcessor::AcceptOptions &opt);
 
-  Server() : Connection(), f_inbound_transparent(false) { ink_zero(accept_addr); }
+  Server() : Connection(), http_accept_filter(false) { ink_zero(accept_addr); }
 };
 
 #endif /*_Connection_h*/

--- a/iocore/net/P_NetAccept.h
+++ b/iocore/net/P_NetAccept.h
@@ -84,35 +84,30 @@ struct NetAccept : public Continuation {
   Server server;
   AcceptFunctionPtr accept_fn;
   int ifd;
-  bool callback_on_open;
-  bool backdoor;
   Ptr<NetAcceptAction> action_;
-  int recv_bufsize;
-  int send_bufsize;
-  uint32_t sockopt_flags;
-  uint32_t packet_mark;
-  uint32_t packet_tos;
-  EventType etype;
   UnixNetVConnection *epoll_vc; // only storage for epoll events
   EventIO ep;
+
+  NetProcessor::AcceptOptions opt;
 
   virtual NetProcessor *getNetProcessor() const;
 
   void init_accept_loop(const char *);
-  virtual void init_accept(EThread *t = NULL, bool isTransparent = false);
-  virtual void init_accept_per_thread(bool isTransparent);
+  virtual void init_accept(EThread *t = NULL);
+  virtual void init_accept_per_thread();
   virtual NetAccept *clone() const;
-  // 0 == success
-  int do_listen(bool non_blocking, bool transparent = false);
 
+  // 0 == success
+  int do_listen(bool non_blocking);
   int do_blocking_accept(EThread *t);
+
   virtual int acceptEvent(int event, void *e);
   virtual int acceptFastEvent(int event, void *e);
   int acceptLoopEvent(int event, Event *e);
   void cancel();
 
-  NetAccept();
-  virtual ~NetAccept() { action_ = NULL; };
+  explicit NetAccept(const NetProcessor::AcceptOptions &);
+  virtual ~NetAccept() { action_ = NULL; }
 };
 
 #endif

--- a/iocore/net/P_SSLNetAccept.h
+++ b/iocore/net/P_SSLNetAccept.h
@@ -51,8 +51,7 @@ struct SSLNetAccept : public NetAccept {
   virtual NetProcessor *getNetProcessor() const;
   virtual NetAccept *clone() const;
 
-  SSLNetAccept(){};
-
-  virtual ~SSLNetAccept(){};
+  SSLNetAccept(const NetProcessor::AcceptOptions &opt);
+  virtual ~SSLNetAccept();
 };
 #endif

--- a/iocore/net/P_SSLNetProcessor.h
+++ b/iocore/net/P_SSLNetProcessor.h
@@ -72,7 +72,7 @@ public:
   // Private
   //
 
-  virtual NetAccept *createNetAccept();
+  virtual NetAccept *createNetAccept(const NetProcessor::AcceptOptions &opt);
   virtual NetVConnection *allocate_vc(EThread *t);
 
 private:

--- a/iocore/net/P_UnixNetProcessor.h
+++ b/iocore/net/P_UnixNetProcessor.h
@@ -40,7 +40,7 @@ public:
   Action *connect_re_internal(Continuation *cont, sockaddr const *target, NetVCOptions *options = NULL);
   Action *connect(Continuation *cont, UnixNetVConnection **vc, sockaddr const *target, NetVCOptions *opt = NULL);
 
-  virtual NetAccept *createNetAccept();
+  virtual NetAccept *createNetAccept(const NetProcessor::AcceptOptions &opt);
   virtual NetVConnection *allocate_vc(EThread *t);
 
   virtual int start(int number_of_net_threads, size_t stacksize);

--- a/iocore/net/SSLNetAccept.cc
+++ b/iocore/net/SSLNetAccept.cc
@@ -22,6 +22,14 @@
 #include "ts/ink_config.h"
 #include "P_Net.h"
 
+SSLNetAccept::SSLNetAccept(const NetProcessor::AcceptOptions &opt) : NetAccept(opt)
+{
+}
+
+SSLNetAccept::~SSLNetAccept()
+{
+}
+
 NetProcessor *
 SSLNetAccept::getNetProcessor() const
 {
@@ -32,7 +40,7 @@ NetAccept *
 SSLNetAccept::clone() const
 {
   NetAccept *na;
-  na  = new SSLNetAccept;
+  na  = new SSLNetAccept(opt);
   *na = *this;
   return na;
 }

--- a/iocore/net/SSLNetProcessor.cc
+++ b/iocore/net/SSLNetProcessor.cc
@@ -92,9 +92,9 @@ SSLNetProcessor::start(int, size_t stacksize)
 }
 
 NetAccept *
-SSLNetProcessor::createNetAccept()
+SSLNetProcessor::createNetAccept(const NetProcessor::AcceptOptions &opt)
 {
-  return (NetAccept *)new SSLNetAccept;
+  return (NetAccept *)new SSLNetAccept(opt);
 }
 
 NetVConnection *

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -119,14 +119,14 @@ net_accept(NetAccept *na, void *ep, bool blockable)
     vc->submit_time = Thread::get_hrtime();
     vc->mutex       = new_ProxyMutex();
     vc->action_     = *na->action_;
-    vc->set_is_transparent(na->server.f_inbound_transparent);
+    vc->set_is_transparent(na->opt.f_inbound_transparent);
     vc->set_context(NET_VCONNECTION_IN);
     SET_CONTINUATION_HANDLER(vc, (NetVConnHandler)&UnixNetVConnection::acceptEvent);
 
-    if (e->ethread->is_event_type(na->etype))
+    if (e->ethread->is_event_type(na->opt.etype))
       vc->handleEvent(EVENT_NONE, e);
     else
-      eventProcessor.schedule_imm(vc, na->etype);
+      eventProcessor.schedule_imm(vc, na->opt.etype);
   } while (loop);
 
 Ldone:
@@ -157,33 +157,35 @@ NetAccept::init_accept_loop(const char *thr_name)
 // use it for high connection rates as well.
 //
 void
-NetAccept::init_accept(EThread *t, bool isTransparent)
+NetAccept::init_accept(EThread *t)
 {
   if (!t)
-    t = eventProcessor.assign_thread(etype);
+    t = eventProcessor.assign_thread(opt.etype);
 
   if (!action_->continuation->mutex) {
     action_->continuation->mutex = t->mutex;
     action_->mutex               = t->mutex;
   }
 
-  if (do_listen(NON_BLOCKING, isTransparent))
+  if (do_listen(NON_BLOCKING)) {
     return;
+  }
 
   SET_HANDLER((NetAcceptHandler)&NetAccept::acceptEvent);
   period = -HRTIME_MSECONDS(net_accept_period);
-  t->schedule_every(this, period, etype);
+  t->schedule_every(this, period, opt.etype);
 }
 
 void
-NetAccept::init_accept_per_thread(bool isTransparent)
+NetAccept::init_accept_per_thread()
 {
   int i, n;
 
-  ink_assert(etype >= 0);
+  ink_assert(opt.etype >= 0);
 
-  if (do_listen(NON_BLOCKING, isTransparent))
+  if (do_listen(NON_BLOCKING)) {
     return;
+  }
 
   if (accept_fn == net_accept)
     SET_HANDLER((NetAcceptHandler)&NetAccept::acceptFastEvent);
@@ -191,7 +193,7 @@ NetAccept::init_accept_per_thread(bool isTransparent)
     SET_HANDLER((NetAcceptHandler)&NetAccept::acceptEvent);
 
   period = -HRTIME_MSECONDS(net_accept_period);
-  n      = eventProcessor.n_threads_for_type[etype];
+  n      = eventProcessor.n_threads_for_type[opt.etype];
 
   for (i = 0; i < n; i++) {
     NetAccept *a;
@@ -202,39 +204,42 @@ NetAccept::init_accept_per_thread(bool isTransparent)
       a = this;
     }
 
-    EThread *t         = eventProcessor.eventthread[etype][i];
+    EThread *t         = eventProcessor.eventthread[opt.etype][i];
     PollDescriptor *pd = get_PollDescriptor(t);
 
     if (a->ep.start(pd, a, EVENTIO_READ) < 0)
       Warning("[NetAccept::init_accept_per_thread]:error starting EventIO");
 
     a->mutex = get_NetHandler(t)->mutex;
-    t->schedule_every(a, period, etype);
+    t->schedule_every(a, period, opt.etype);
   }
 }
 
 int
-NetAccept::do_listen(bool non_blocking, bool transparent)
+NetAccept::do_listen(bool non_blocking)
 {
   int res = 0;
 
   if (server.fd != NO_FD) {
-    if ((res = server.setup_fd_for_listen(non_blocking, recv_bufsize, send_bufsize, transparent))) {
+    if ((res = server.setup_fd_for_listen(non_blocking, opt))) {
       Warning("unable to listen on main accept port %d: errno = %d, %s", ntohs(server.accept_addr.port()), errno, strerror(errno));
       goto Lretry;
     }
   } else {
   Lretry:
-    if ((res = server.listen(non_blocking, recv_bufsize, send_bufsize, transparent)))
+    if ((res = server.listen(non_blocking, opt))) {
       Warning("unable to listen on port %d: %d %d, %s", ntohs(server.accept_addr.port()), res, errno, strerror(errno));
+    }
   }
-  if (callback_on_open && !action_->cancelled) {
+
+  if (opt.f_callback_on_open && !action_->cancelled) {
     if (res)
       action_->continuation->handleEvent(NET_EVENT_ACCEPT_FAILED, this);
     else
       action_->continuation->handleEvent(NET_EVENT_ACCEPT_SUCCEED, this);
     mutex = NULL;
   }
+
   return res;
 }
 
@@ -253,7 +258,7 @@ NetAccept::do_blocking_accept(EThread *t)
 
     // Throttle accepts
 
-    while (!backdoor && check_net_throttle(ACCEPT, now)) {
+    while (!opt.backdoor && check_net_throttle(ACCEPT, now)) {
       check_throttle_warning();
       if (!unix_netProcessor.throttle_error_message) {
         safe_delay(net_throttle_delay);
@@ -300,14 +305,14 @@ NetAccept::do_blocking_accept(EThread *t)
     vc->submit_time = now;
     vc->mutex       = new_ProxyMutex();
     vc->action_     = *action_;
-    vc->set_is_transparent(server.f_inbound_transparent);
-    vc->options.packet_mark = packet_mark;
-    vc->options.packet_tos  = packet_tos;
+    vc->set_is_transparent(opt.f_inbound_transparent);
+    vc->options.packet_mark = opt.packet_mark;
+    vc->options.packet_tos  = opt.packet_tos;
     vc->apply_options();
     vc->set_context(NET_VCONNECTION_IN);
     SET_CONTINUATION_HANDLER(vc, (NetVConnHandler)&UnixNetVConnection::acceptEvent);
     // eventProcessor.schedule_imm(vc, getEtype());
-    eventProcessor.schedule_imm_signal(vc, etype);
+    eventProcessor.schedule_imm_signal(vc, opt.etype);
   } while (loop);
 
   return 1;
@@ -370,7 +375,7 @@ NetAccept::acceptFastEvent(int event, void *ep)
   int loop               = accept_till_done;
 
   do {
-    if (!backdoor && check_net_throttle(ACCEPT, Thread::get_hrtime())) {
+    if (!opt.backdoor && check_net_throttle(ACCEPT, Thread::get_hrtime())) {
       ifd = NO_FD;
       return EVENT_CONT;
     }
@@ -381,9 +386,9 @@ NetAccept::acceptFastEvent(int event, void *ep)
 
     if (likely(fd >= 0)) {
       Debug("iocore_net", "accepted a new socket: %d", fd);
-      if (send_bufsize > 0) {
-        if (unlikely(socketManager.set_sndbuf_size(fd, send_bufsize))) {
-          bufsz = ROUNDUP(send_bufsize, 1024);
+      if (opt.send_bufsize > 0) {
+        if (unlikely(socketManager.set_sndbuf_size(fd, opt.send_bufsize))) {
+          bufsz = ROUNDUP(opt.send_bufsize, 1024);
           while (bufsz > 0) {
             if (!socketManager.set_sndbuf_size(fd, bufsz))
               break;
@@ -391,9 +396,9 @@ NetAccept::acceptFastEvent(int event, void *ep)
           }
         }
       }
-      if (recv_bufsize > 0) {
-        if (unlikely(socketManager.set_rcvbuf_size(fd, recv_bufsize))) {
-          bufsz = ROUNDUP(recv_bufsize, 1024);
+      if (opt.recv_bufsize > 0) {
+        if (unlikely(socketManager.set_rcvbuf_size(fd, opt.recv_bufsize))) {
+          bufsz = ROUNDUP(opt.recv_bufsize, 1024);
           while (bufsz > 0) {
             if (!socketManager.set_rcvbuf_size(fd, bufsz))
               break;
@@ -401,11 +406,13 @@ NetAccept::acceptFastEvent(int event, void *ep)
           }
         }
       }
-      if (sockopt_flags & 1) { // we have to disable Nagle
+
+      if (opt.sockopt_flags & NetVCOptions::SOCK_OPT_NO_DELAY) {
         safe_setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, SOCKOPT_ON, sizeof(int));
         Debug("socket", "::acceptFastEvent: setsockopt() TCP_NODELAY on socket");
       }
-      if (sockopt_flags & 2) {
+
+      if (opt.sockopt_flags & NetVCOptions::SOCK_OPT_KEEP_ALIVE) {
         safe_setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, SOCKOPT_ON, sizeof(int));
         Debug("socket", "::acceptFastEvent: setsockopt() SO_KEEPALIVE on socket");
       }
@@ -441,9 +448,9 @@ NetAccept::acceptFastEvent(int event, void *ep)
     vc->submit_time = Thread::get_hrtime();
     vc->mutex       = new_ProxyMutex();
     // no need to set vc->action_
-    vc->set_is_transparent(server.f_inbound_transparent);
-    vc->options.packet_mark = packet_mark;
-    vc->options.packet_tos  = packet_tos;
+    vc->set_is_transparent(opt.f_inbound_transparent);
+    vc->options.packet_mark = opt.packet_mark;
+    vc->options.packet_tos  = opt.packet_tos;
     vc->apply_options();
     vc->set_context(NET_VCONNECTION_IN);
     SET_CONTINUATION_HANDLER(vc, (NetVConnHandler)&UnixNetVConnection::mainEvent);
@@ -512,18 +519,7 @@ NetAccept::acceptLoopEvent(int event, Event *e)
 //
 //
 
-NetAccept::NetAccept()
-  : Continuation(NULL),
-    period(0),
-    ifd(NO_FD),
-    callback_on_open(false),
-    backdoor(false),
-    recv_bufsize(0),
-    send_bufsize(0),
-    sockopt_flags(0),
-    packet_mark(0),
-    packet_tos(0),
-    etype(0)
+NetAccept::NetAccept(const NetProcessor::AcceptOptions &_opt) : Continuation(NULL), period(0), ifd(NO_FD), opt(_opt)
 {
 }
 
@@ -542,7 +538,7 @@ NetAccept *
 NetAccept::clone() const
 {
   NetAccept *na;
-  na  = new NetAccept;
+  na  = new NetAccept(opt);
   *na = *this;
   return na;
 }

--- a/iocore/net/UnixNetProcessor.cc
+++ b/iocore/net/UnixNetProcessor.cc
@@ -47,6 +47,7 @@ NetProcessor::AcceptOptions::reset()
   sockopt_flags         = 0;
   packet_mark           = 0;
   packet_tos            = 0;
+  tfo_queue_length      = 0;
   f_inbound_transparent = false;
   return *this;
 }
@@ -84,13 +85,12 @@ NetProcessor::main_accept(Continuation *cont, SOCKET fd, AcceptOptions const &op
 Action *
 UnixNetProcessor::accept_internal(Continuation *cont, int fd, AcceptOptions const &opt)
 {
-  EventType upgraded_etype = opt.etype; // setEtype requires non-const ref.
-  ProxyMutex *mutex        = this_ethread()->mutex.get();
-  int accept_threads       = opt.accept_threads; // might be changed.
-  IpEndpoint accept_ip;                          // local binding address.
+  ProxyMutex *mutex  = this_ethread()->mutex.get();
+  int accept_threads = opt.accept_threads; // might be changed.
+  IpEndpoint accept_ip;                    // local binding address.
   char thr_name[MAX_THREAD_NAME_LENGTH];
 
-  NetAccept *na = createNetAccept();
+  NetAccept *na = createNetAccept(opt);
 
   // Fill in accept thread from configuration if necessary.
   if (opt.accept_threads < 0) {
@@ -114,9 +114,9 @@ UnixNetProcessor::accept_internal(Continuation *cont, int fd, AcceptOptions cons
   na->accept_fn = net_accept; // All callers used this.
   na->server.fd = fd;
   ats_ip_copy(&na->server.accept_addr, &accept_ip);
-  na->server.f_inbound_transparent = opt.f_inbound_transparent;
+
   if (opt.f_inbound_transparent) {
-    Debug("http_tproxy", "Marking accept server %p on port %d as inbound transparent", na, opt.local_port);
+    Debug("http_tproxy", "Marked accept server %p on port %d as inbound transparent", na, opt.local_port);
   }
 
   int should_filter_int         = 0;
@@ -125,22 +125,17 @@ UnixNetProcessor::accept_internal(Continuation *cont, int fd, AcceptOptions cons
   if (should_filter_int > 0 && opt.etype == ET_NET)
     na->server.http_accept_filter = true;
 
-  na->action_          = new NetAcceptAction();
-  *na->action_         = cont;
-  na->action_->server  = &na->server;
-  na->callback_on_open = opt.f_callback_on_open;
-  na->recv_bufsize     = opt.recv_bufsize;
-  na->send_bufsize     = opt.send_bufsize;
-  na->sockopt_flags    = opt.sockopt_flags;
-  na->packet_mark      = opt.packet_mark;
-  na->packet_tos       = opt.packet_tos;
-  na->etype            = upgraded_etype;
-  na->backdoor         = opt.backdoor;
-  if (na->callback_on_open)
+  na->action_         = new NetAcceptAction();
+  *na->action_        = cont;
+  na->action_->server = &na->server;
+
+  if (na->opt.f_callback_on_open) {
     na->mutex = cont->mutex;
+  }
+
   if (opt.frequent_accept) { // true
     if (accept_threads > 0) {
-      if (0 == na->do_listen(BLOCKING, opt.f_inbound_transparent)) {
+      if (0 == na->do_listen(BLOCKING)) {
         for (int i = 1; i < accept_threads; ++i) {
           NetAccept *a = na->clone();
 
@@ -164,10 +159,10 @@ UnixNetProcessor::accept_internal(Continuation *cont, int fd, AcceptOptions cons
 #endif // TS_USE_POSIX_CAP
       }
     } else {
-      na->init_accept_per_thread(opt.f_inbound_transparent);
+      na->init_accept_per_thread();
     }
   } else {
-    na->init_accept(NULL, opt.f_inbound_transparent);
+    na->init_accept(NULL);
   }
 
 #ifdef TCP_DEFER_ACCEPT
@@ -438,9 +433,9 @@ UnixNetProcessor::start(int, size_t)
 // Virtual function allows creation of an
 // SSLNetAccept or NetAccept transparent to NetProcessor.
 NetAccept *
-UnixNetProcessor::createNetAccept()
+UnixNetProcessor::createNetAccept(const NetProcessor::AcceptOptions &opt)
 {
-  return new NetAccept;
+  return new NetAccept(opt);
 }
 
 NetVConnection *

--- a/proxy/http/HttpProxyServerMain.h
+++ b/proxy/http/HttpProxyServerMain.h
@@ -34,4 +34,4 @@ void start_HttpProxyServer();
 
 void start_HttpProxyServerBackDoor(int port, int accept_threads = 0);
 
-NetProcessor::AcceptOptions make_net_accept_options(const HttpProxyPort &port, unsigned nthreads);
+NetProcessor::AcceptOptions make_net_accept_options(const HttpProxyPort *port, unsigned nthreads);

--- a/proxy/shared/UglyLogStubs.cc
+++ b/proxy/shared/UglyLogStubs.cc
@@ -116,7 +116,7 @@ LogCollationClientSM::send(LogBuffer * /* log_buffer ATS_UNUSED */)
 }
 
 NetAccept *
-UnixNetProcessor::createNetAccept()
+UnixNetProcessor::createNetAccept(const NetProcessor::AcceptOptions &opt)
 {
   ink_release_assert(false);
   return NULL;


### PR DESCRIPTION
We have an object AcceptOptions that contains the options to apply
to listening sockets, but in many places, the individual options
are passed around. Consolidate this so that we pass a AcceptOptions
to provide better guarantees that all listening sockets are created
equal.