### PR TITLE
TS-4399 TS-4400 Management API messes up proxy options

### DIFF
--- a/cmd/traffic_manager/traffic_manager.cc
+++ b/cmd/traffic_manager/traffic_manager.cc
@@ -866,6 +866,11 @@ main(int argc, const char **argv)
     }
   }
 
+  // Delete the proxy options we saved for CoreAPI.
+  // This probably isn't needed b/c the process dies here...
+  for (auto it = callback_proxy_options.begin(); it < callback_proxy_options.end(); ++it)
+    free(*it);
+
   if (binding) {
     metrics_binding_destroy(*binding);
     delete binding;

--- a/cmd/traffic_manager/traffic_manager.cc
+++ b/cmd/traffic_manager/traffic_manager.cc
@@ -810,7 +810,6 @@ main(int argc, const char **argv)
         just_started = 0;
         sleep_time   = 0;
       } else {
-        mgmt_log("in ProxyStateSet else branch");
         just_started++;
       }
       lmgmt->coreapi_sleep = true;

--- a/cmd/traffic_manager/traffic_manager.cc
+++ b/cmd/traffic_manager/traffic_manager.cc
@@ -805,6 +805,7 @@ main(int argc, const char **argv)
       } else {
         sleep_time = 1;
       }
+      lmgmt->coreapi_sleep = false;
       if (ProxyStateSet(TS_PROXY_ON, TS_CACHE_CLEAR_NONE) == TS_ERR_OKAY) {
         just_started = 0;
         sleep_time   = 0;
@@ -812,6 +813,7 @@ main(int argc, const char **argv)
         mgmt_log("in ProxyStateSet else branch");
         just_started++;
       }
+      lmgmt->coreapi_sleep = true;
     } else { /* Give the proxy a chance to fire up */
       just_started++;
     }

--- a/cmd/traffic_manager/traffic_manager.cc
+++ b/cmd/traffic_manager/traffic_manager.cc
@@ -805,14 +805,12 @@ main(int argc, const char **argv)
       } else {
         sleep_time = 1;
       }
-      lmgmt->coreapi_sleep = false;
       if (ProxyStateSet(TS_PROXY_ON, TS_CACHE_CLEAR_NONE) == TS_ERR_OKAY) {
         just_started = 0;
         sleep_time   = 0;
       } else {
         just_started++;
       }
-      lmgmt->coreapi_sleep = true;
     } else { /* Give the proxy a chance to fire up */
       just_started++;
     }

--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -189,7 +189,6 @@ LocalManager::LocalManager(bool proxy_on) : BaseManager(), run_proxy(proxy_on), 
   proxy_launch_outstanding  = false;
   mgmt_shutdown_outstanding = MGMT_PENDING_NONE;
   proxy_running             = 0;
-  coreapi_sleep             = true;
 
   RecRegisterStatInt(RECT_NODE, "proxy.node.proxy_running", 0, RECP_NON_PERSISTENT);
 

--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -189,6 +189,7 @@ LocalManager::LocalManager(bool proxy_on) : BaseManager(), run_proxy(proxy_on), 
   proxy_launch_outstanding  = false;
   mgmt_shutdown_outstanding = MGMT_PENDING_NONE;
   proxy_running             = 0;
+  coreapi_sleep             = true;
 
   RecRegisterStatInt(RECT_NODE, "proxy.node.proxy_running", 0, RECP_NON_PERSISTENT);
 

--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -240,8 +240,7 @@ LocalManager::LocalManager(bool proxy_on) : BaseManager(), run_proxy(proxy_on), 
   proxy_name                   = REC_readString("proxy.config.proxy_name", &found);
   proxy_binary                 = REC_readString("proxy.config.proxy_binary", &found);
   env_prep                     = REC_readString("proxy.config.env_prep", &found);
-  proxy_options                = new char[1];
-  strcpy(proxy_options, "");  // so later we can always `delete proxy_options` without worrying
+  proxy_options                = NULL;
 
   // Calculate proxy_binary from the absolute bin_path
   absolute_proxy_binary = Layout::relative_to(bindir, proxy_binary);
@@ -838,7 +837,7 @@ LocalManager::processEventQueue()
  *                    these options do not persist across reboots)
  */
 bool
-LocalManager::startProxy(char *onetime_options)
+LocalManager::startProxy(const char *onetime_options)
 {
   if (proxy_launch_outstanding) {
     return false;
@@ -907,8 +906,10 @@ LocalManager::startProxy(char *onetime_options)
     Vec<char> real_proxy_options;
 
     real_proxy_options.append(proxy_options, strlen(proxy_options));
-    real_proxy_options.append(" ", strlen(" "));
-    real_proxy_options.append(onetime_options, strlen(onetime_options));
+    if (onetime_options && *onetime_options) {
+      real_proxy_options.append(" ", strlen(" "));
+      real_proxy_options.append(onetime_options, strlen(onetime_options));
+    }
 
     // Make sure we're starting the proxy in mgmt mode
     if (!strstr(proxy_options, MGMT_OPT) && !strstr(onetime_options, MGMT_OPT)) {

--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -912,7 +912,7 @@ LocalManager::startProxy(const char *onetime_options)
     }
 
     // Make sure we're starting the proxy in mgmt mode
-    if (!strstr(proxy_options, MGMT_OPT) && !strstr(onetime_options, MGMT_OPT)) {
+    if (strstr(proxy_options, MGMT_OPT) == 0 && strstr(onetime_options, MGMT_OPT) == 0) {
       real_proxy_options.append(" ", strlen(" "));
       real_proxy_options.append(MGMT_OPT, sizeof(MGMT_OPT) - 1);
     }

--- a/mgmt/LocalManager.h
+++ b/mgmt/LocalManager.h
@@ -90,7 +90,6 @@ public:
   bool processRunning();
   bool clusterOk();
 
-  volatile bool coreapi_sleep;
   volatile bool run_proxy;
   volatile time_t manager_started_at;
   volatile time_t proxy_started_at;

--- a/mgmt/LocalManager.h
+++ b/mgmt/LocalManager.h
@@ -74,7 +74,7 @@ public:
   void signalAlarm(int alarm_id, const char *desc = NULL, const char *ip = NULL);
 
   void processEventQueue();
-  bool startProxy();
+  bool startProxy(char *onetime_options);
   void listenForProxy();
   void bindProxyPort(HttpProxyPort &);
   void closeProxyPorts();
@@ -108,7 +108,7 @@ public:
   char *absolute_proxy_binary;
   char *proxy_name;
   char *proxy_binary;
-  char *proxy_options;
+  char *proxy_options;  // These options should persist across proxy reboots
   char *env_prep;
 
   int process_server_sockfd;

--- a/mgmt/LocalManager.h
+++ b/mgmt/LocalManager.h
@@ -109,7 +109,7 @@ public:
   char *absolute_proxy_binary;
   char *proxy_name;
   char *proxy_binary;
-  char *proxy_options;  // These options should persist across proxy reboots
+  char *proxy_options; // These options should persist across proxy reboots
   char *env_prep;
 
   int process_server_sockfd;

--- a/mgmt/LocalManager.h
+++ b/mgmt/LocalManager.h
@@ -90,6 +90,7 @@ public:
   bool processRunning();
   bool clusterOk();
 
+  volatile bool coreapi_sleep;
   volatile bool run_proxy;
   volatile time_t manager_started_at;
   volatile time_t proxy_started_at;

--- a/mgmt/LocalManager.h
+++ b/mgmt/LocalManager.h
@@ -74,7 +74,7 @@ public:
   void signalAlarm(int alarm_id, const char *desc = NULL, const char *ip = NULL);
 
   void processEventQueue();
-  bool startProxy(char *onetime_options);
+  bool startProxy(const char *onetime_options);
   void listenForProxy();
   void bindProxyPort(HttpProxyPort &);
   void closeProxyPorts();

--- a/mgmt/api/CoreAPI.cc
+++ b/mgmt/api/CoreAPI.cc
@@ -188,30 +188,11 @@ ProxyStateSet(TSProxyStateT state, TSCacheClearT clear)
       ink_strlcat(tsArgs, " -k", sizeof(tsArgs));
     }
 
-    // If we've been provided an options callback, then we call the callback and
-    // put all the extra options we receive into tsArgs
-    //
-    // proxy_options_callback is given to us by traffic_manager
-    if (proxy_options_callback) {
-      std::vector<char*> options;
-      proxy_options_callback(options);
-
-      for (auto it = options.begin(); it < options.end(); ++it) {
-        ink_strlcat(tsArgs, " ", sizeof(tsArgs));
-        ink_strlcat(tsArgs, static_cast<const char*>(*it), sizeof(tsArgs));
-        free(*it);
-      }
-    }
-
-    // We always want to delete the previous run's proxy_options
-    // because we to repopulate with the most up to date options each TS restart
-    ats_free(lmgmt->proxy_options);
-    lmgmt->proxy_options = ats_strdup(tsArgs);
-    mgmt_log("[ProxyStateSet] Traffic Server Args: '%s'\n", lmgmt->proxy_options);
+    mgmt_log("[ProxyStateSet] Traffic Server Args: '%s %s'\n", lmgmt->proxy_options ? lmgmt->proxy_options : "", tsArgs);
 
     lmgmt->run_proxy = true;
-    lmgmt->startProxy();
     lmgmt->listenForProxy();
+    lmgmt->startProxy(tsArgs);
 
     do {
       mgmt_sleep_sec(1);

--- a/mgmt/api/CoreAPI.cc
+++ b/mgmt/api/CoreAPI.cc
@@ -188,18 +188,12 @@ ProxyStateSet(TSProxyStateT state, TSCacheClearT clear)
 
     lmgmt->run_proxy = true;
     lmgmt->listenForProxy();
-    lmgmt->startProxy(tsArgs);
-
-    if (lmgmt->coreapi_sleep) {
-      do {
-        mgmt_sleep_sec(1);
-      } while (i++ < 20 && (lmgmt->proxy_running == 0));
-
-      if (!lmgmt->processRunning())
-        goto Lerror;
+    if (!lmgmt->startProxy(tsArgs)) {
+      goto Lerror;
     }
 
     break;
+
   default:
     goto Lerror;
   }

--- a/mgmt/api/CoreAPI.cc
+++ b/mgmt/api/CoreAPI.cc
@@ -210,6 +210,7 @@ ProxyStateSet(TSProxyStateT state, TSCacheClearT clear)
     mgmt_log("[ProxyStateSet] Traffic Server Args: '%s'\n", lmgmt->proxy_options);
 
     lmgmt->run_proxy = true;
+    lmgmt->startProxy();
     lmgmt->listenForProxy();
 
     do {

--- a/mgmt/api/CoreAPI.cc
+++ b/mgmt/api/CoreAPI.cc
@@ -41,7 +41,6 @@
 #include "ts/Diags.h"
 #include "ts/ink_hash_table.h"
 #include "ExpandingArray.h"
-#include <vector>
 //#include "I_AccCrypto.h"
 
 #include "CoreAPI.h"
@@ -53,9 +52,6 @@
 
 // global variable
 CallbackTable *local_event_callbacks;
-
-// Used to get any proxy options that traffic_manager might want to tack on
-std::function<void(std::vector<char*>&)> proxy_options_callback;
 
 extern FileManager *configFiles; // global in traffic_manager
 

--- a/mgmt/api/CoreAPI.cc
+++ b/mgmt/api/CoreAPI.cc
@@ -190,12 +190,13 @@ ProxyStateSet(TSProxyStateT state, TSCacheClearT clear)
     lmgmt->listenForProxy();
     lmgmt->startProxy(tsArgs);
 
-    do {
-      mgmt_sleep_sec(1);
-    } while (i++ < 20 && (lmgmt->proxy_running == 0));
+    if (lmgmt->coreapi_sleep) {
+      do {
+        mgmt_sleep_sec(1);
+      } while (i++ < 20 && (lmgmt->proxy_running == 0));
 
-    if (!lmgmt->processRunning()) {
-      goto Lerror;
+      if (!lmgmt->processRunning())
+        goto Lerror;
     }
 
     break;

--- a/mgmt/api/CoreAPI.cc
+++ b/mgmt/api/CoreAPI.cc
@@ -199,6 +199,7 @@ ProxyStateSet(TSProxyStateT state, TSCacheClearT clear)
       for (auto it = options.begin(); it < options.end(); ++it) {
         ink_strlcat(tsArgs, " ", sizeof(tsArgs));
         ink_strlcat(tsArgs, static_cast<const char*>(*it), sizeof(tsArgs));
+        free(*it);
       }
     }
 

--- a/mgmt/api/CoreAPI.cc
+++ b/mgmt/api/CoreAPI.cc
@@ -153,7 +153,6 @@ ProxyStateGet()
 TSMgmtError
 ProxyStateSet(TSProxyStateT state, TSCacheClearT clear)
 {
-  int i = 0;
   char tsArgs[MAX_BUF_SIZE];
   char *proxy_options;
 


### PR DESCRIPTION
TS-4399: Management API breaks diagnostic log rotation
TS-4400: TSProxyStateSet persist cache clearing across restart

The two issues are related in that they both deal with the
management API not correctly handling proxy flags.

For TS-4399, it was because the management API was not aware
of traffic_manager setting extra proxy options. This was fixed
by providing CoreAPI a callback to get extra proxy options from
traffic_manager.

For TS-4400, it was because the management API was not properly
clearing optional flags between proxy reboots. This was fixed
by resetting the proxy options before each reboot.
