### PR TITLE
TS-4905: Set parent NULL after destroy() is called

### DIFF
--- a/proxy/http/Http1ClientTransaction.cc
+++ b/proxy/http/Http1ClientTransaction.cc
@@ -67,6 +67,7 @@ Http1ClientTransaction::transaction_done()
   // If the parent session is not in the closed state, the destroy will not occur.
   if (parent) {
     parent->destroy();
+    parent = NULL;
   }
 }
 


### PR DESCRIPTION
[TS-4905](https://issues.apache.org/jira/browse/TS-4905)

IMO, the problem is calling `Http1ClientSession::get_netvc()` after `Http1ClientSession::free()` is called.
So set pointer to Http1ClientSession NULL after `Http1ClientSession::destroy()` is called in `Http1ClientTransaction::transaction_done()`
