### PR TITLE
TS-4931: Add process limits to crash logs.

### DIFF
--- a/cmd/traffic_crashlog/traffic_crashlog.cc
+++ b/cmd/traffic_crashlog/traffic_crashlog.cc
@@ -205,6 +205,9 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   crashlog_write_procstatus(fp, target);
 
   fprintf(fp, "\n");
+  crashlog_write_proclimits(fp, target);
+
+  fprintf(fp, "\n");
   crashlog_write_regions(fp, target);
 
   fprintf(fp, "\n");

--- a/cmd/traffic_crashlog/traffic_crashlog.h
+++ b/cmd/traffic_crashlog/traffic_crashlog.h
@@ -65,14 +65,15 @@ struct crashlog_target {
 };
 
 bool crashlog_write_backtrace(FILE *, const crashlog_target &);
-bool crashlog_write_regions(FILE *, const crashlog_target &);
-bool crashlog_write_exename(FILE *, const crashlog_target &);
-bool crashlog_write_uname(FILE *, const crashlog_target &);
 bool crashlog_write_datime(FILE *, const crashlog_target &);
+bool crashlog_write_exename(FILE *, const crashlog_target &);
+bool crashlog_write_proclimits(FILE *, const crashlog_target &);
 bool crashlog_write_procname(FILE *, const crashlog_target &);
 bool crashlog_write_procstatus(FILE *, const crashlog_target &);
 bool crashlog_write_records(FILE *, const crashlog_target &);
-bool crashlog_write_siginfo(FILE *, const crashlog_target &);
+bool crashlog_write_regions(FILE *, const crashlog_target &);
 bool crashlog_write_registers(FILE *, const crashlog_target &);
+bool crashlog_write_siginfo(FILE *, const crashlog_target &);
+bool crashlog_write_uname(FILE *, const crashlog_target &);
 
 #endif /* __TRAFFIC_CRASHLOG_H__ */


### PR DESCRIPTION
Add /proc/$PID/limits to the crash log. This helps give context to
malloc failures because we can get a reliable snapshot of any process
limits in effect at the time.