### PR TITLE
TS-4934: Remove invalid assert

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -329,8 +329,6 @@ Http2Stream::do_io_close(int /* flags */)
       // Wee will be removed at send_data_frames or closing connection phase
       static_cast<Http2ClientSession *>(parent)->connection_state.send_data_frames(this);
     }
-    // Check to see if the stream is in the closed state
-    ink_assert(get_state() == HTTP2_STREAM_STATE_CLOSED || get_state() == HTTP2_STREAM_STATE_HALF_CLOSED_REMOTE);
 
     clear_timers();
     clear_io_events();


### PR DESCRIPTION
[TS-4934](https://issues.apache.org/jira/browse/TS-4934)

The active timeout could be happen with any states of stream. So this assert doesn't make sense. 