### PR TITLE
TS-4701: Add a new latched parent selection strategy.

### DIFF
--- a/doc/admin-guide/files/parent.config.en.rst
+++ b/doc/admin-guide/files/parent.config.en.rst
@@ -207,6 +207,13 @@ The following list shows the possible actions and their allowed values.
        The other traffic is unaffected. Once the downed parent becomes
        available, the traffic distribution returns to the pre-down
        state.
+    - ``latched`` - The first parent in the list is marked as primary and is 
+      always chosen until connection errors cause it to be marked down.  When 
+      this occurs the next parent in the list then becomes primary.  The primary
+      will wrap back to the first parent in the list when it is the last parent
+      in the list and is marked down due to a connection error.  Newly chosen
+      primary parents marked as unavailable will then be restored if the failure
+      retry time has elapsed and the transaction using the primary succeeds.
 
 .. _parent-config-format-go-direct:
 

--- a/proxy/ParentRoundRobin.h
+++ b/proxy/ParentRoundRobin.h
@@ -35,6 +35,7 @@
 class ParentRoundRobin : public ParentSelectionStrategy
 {
   ParentRR_t round_robin_type;
+  int latched_parent;
 
 public:
   ParentRoundRobin(ParentRecord *_parent_record, ParentRR_t _round_robin_type);

--- a/proxy/ParentSelection.h
+++ b/proxy/ParentSelection.h
@@ -64,6 +64,7 @@ enum ParentRR_t {
   P_STRICT_ROUND_ROBIN,
   P_HASH_ROUND_ROBIN,
   P_CONSISTENT_HASH,
+  P_LATCHED_ROUND_ROBIN,
 };
 
 enum ParentRetry_t {


### PR DESCRIPTION
Add a new "latched" round  robin parent selection strategy.  A primary parent is chosen from the first parent in the parent list and is always returned as the resulting call to findParent().  When connection failure occurs and the primary parent is marked down, the state changes the primary to the next parent in the list and remains latched until the state is changed when a error causes the primary parent to be marked down.  

This strategy is helpful for delivery of live video.  A failure and switch to a new parent origin will cause a video client to retune as the manifest and video fragment names between origins are different.  With the other strategies, once the retry time for a marked down parent has elapsed, another switch and retune may occur.  To keep retunes to a minimum, this strategy "latches" state to always use the same healthy parent.