### PR TITLE
TS-4915: Crash from hostdb in PriorityQueueLess

### DIFF
--- a/iocore/hostdb/P_RefCountCache.h
+++ b/iocore/hostdb/P_RefCountCache.h
@@ -293,7 +293,6 @@ RefCountCachePartition<C>::make_space_for(unsigned int size)
     // If the first item has expired, lets evict it, and then go around again
     if (top_item->node->meta.expiry_time < now) {
       this->erase(top_item->node->meta.key);
-      expiry_queue.pop();
     } else { // if the first item isn't expired-- the rest won't be either (queue is sorted)
       return false;
     }

--- a/lib/ts/PriorityQueue.h
+++ b/lib/ts/PriorityQueue.h
@@ -110,7 +110,7 @@ PriorityQueue<T, Comp>::pop()
     return;
   }
 
-  _v[0] = _v[_v.length() - 1];
+  _swap(0, _v.length() - 1);
   _v.pop();
   _bubble_down(0);
 }
@@ -123,11 +123,16 @@ PriorityQueue<T, Comp>::erase(PriorityQueueEntry<T> *entry)
     return;
   }
 
-  _v[entry->index] = _v[_v.length() - 1];
-  _v.pop();
-  _bubble_down(entry->index);
-  if (!empty()) {
-    _bubble_up(entry->index);
+  ink_release_assert(entry->index < _v.length());
+  const uint32_t original_index = entry->index;
+  if (original_index != (_v.length() - 1)) {
+    // Move the erased item to the end to be popped off
+    _swap(original_index, _v.length() - 1);
+    _v.pop();
+    _bubble_down(original_index);
+    _bubble_up(original_index);
+  } else { // Otherwise, we are already at the end, just pop
+    _v.pop();
   }
 }
 

--- a/lib/ts/test_PriorityQueue.cc
+++ b/lib/ts/test_PriorityQueue.cc
@@ -384,4 +384,79 @@ REGRESSION_TEST(PriorityQueue_6)(RegressionTest *t, int /* atype ATS_UNUSED */, 
   delete entry_a;
   delete entry_b;
   delete entry_c;
+
+  PQ *pq2 = new PQ();
+
+  N *w = new N(10, "W");
+  N *x = new N(20, "X");
+  N *y = new N(30, "Y");
+  N *z = new N(40, "Z");
+
+  Entry *entry_w = new Entry(w);
+  Entry *entry_x = new Entry(x);
+  Entry *entry_y = new Entry(y);
+  Entry *entry_z = new Entry(z);
+
+  pq2->push(entry_z);
+  pq2->push(entry_y);
+  pq2->push(entry_x);
+  pq2->push(entry_w);
+
+  box.check(pq2->top() == entry_w, "top should be entry_w 1");
+  pq2->erase(entry_x);
+  box.check(pq2->top() == entry_w, "top should be entry_w 2");
+  // The following two cases should test that erase preserves the index
+  pq2->erase(entry_y);
+  box.check(pq2->top() == entry_w, "top should be entry_w 3");
+  pq2->erase(entry_z);
+  box.check(pq2->top() == entry_w, "top should be entry_w 4");
+
+  delete pq2;
+
+  delete w;
+  delete x;
+  delete y;
+  delete z;
+
+  delete entry_w;
+  delete entry_x;
+  delete entry_y;
+  delete entry_z;
+}
+
+// Test erase and pop method to ensure the index entries are updated (TS-4915)
+REGRESSION_TEST(PriorityQueue_7)(RegressionTest *t, int /* atype ATS_UNUSED */, int *pstatus)
+{
+  TestBox box(t, pstatus);
+  box = REGRESSION_TEST_PASSED;
+
+  PQ *pq2 = new PQ();
+
+  N *x = new N(20, "X");
+  N *y = new N(30, "Y");
+  N *z = new N(40, "Z");
+
+  Entry *entry_x = new Entry(x);
+  Entry *entry_y = new Entry(y);
+  Entry *entry_z = new Entry(z);
+
+  pq2->push(entry_z);
+  pq2->push(entry_y);
+  pq2->push(entry_x);
+
+  box.check(pq2->top() == entry_x, "top should be entry_x");
+  pq2->pop();
+  box.check(pq2->top() == entry_y, "top should be entry_y");
+  pq2->erase(entry_y);
+  box.check(pq2->top() == entry_z, "top should be entry_z");
+
+  delete pq2;
+
+  delete x;
+  delete y;
+  delete z;
+
+  delete entry_x;
+  delete entry_y;
+  delete entry_z;
 }


### PR DESCRIPTION
These changes have been running on my production box since leaving work Monday night.  Will keep an eye on it.  Lower traffic overnight might not be stressing it sufficiently.

The main change was in PriorityQueueLess<>::erase.  The assignment of the end item to the erase point was not preserving the entry index.  So the assumption that entry->index is less than _v.length() was made invalid the next time around.  I think breaking this entry->index == _v index assignment can also harm the bubble_sorting logic.  I think PriorityQueueLess<>::pop also has a problem, but my work load was not triggering that function, so I didn't dive in there.

The other change was in RefCountCachePartition<C>::make_space_for.  There was an extra pop which I believe was doubly removing an entry already removed in PriorityQueueLess::erase (called from RefCountCachePartition<C>::erase).