### PR TITLE
TS-4952: Improve abort messages for mutex failures.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1091,6 +1091,7 @@ dnl Linux has pthread symbol stubss in both libc and libpthread, so it's importa
 dnl specifically for pthread_yield() here. In addition, ASAN hijacks pthread_create() so
 dnl we can't use that anymore.
 AC_SEARCH_LIBS([pthread_yield], [pthread], [], [])
+AC_CHECK_FUNCS([pthread_mutexattr_settype])
 
 dnl XXX The following check incorrectly causes the build to succeed
 dnl on Darwin. We should be using AC_SEARCH_LIBS, but rest_init is

--- a/iocore/eventsystem/P_Thread.h
+++ b/iocore/eventsystem/P_Thread.h
@@ -36,10 +36,6 @@
 ///////////////////////////////////////////////
 // Common Interface impl                     //
 ///////////////////////////////////////////////
-TS_INLINE
-Thread::~Thread()
-{
-}
 
 TS_INLINE void
 Thread::set_specific()

--- a/iocore/eventsystem/Thread.cc
+++ b/iocore/eventsystem/Thread.cc
@@ -44,7 +44,14 @@ Thread::Thread()
 {
   mutex = new_ProxyMutex();
   MUTEX_TAKE_LOCK(mutex, (EThread *)this);
-  mutex->nthread_holding = THREAD_MUTEX_THREAD_HOLDING;
+  mutex->nthread_holding += THREAD_MUTEX_THREAD_HOLDING;
+}
+
+Thread::~Thread()
+{
+  ink_release_assert(mutex->thread_holding == (EThread *)this);
+  mutex->nthread_holding -= THREAD_MUTEX_THREAD_HOLDING;
+  MUTEX_UNTAKE_LOCK(mutex, (EThread *)this);
 }
 
 static void

--- a/lib/records/I_RecMutex.h
+++ b/lib/records/I_RecMutex.h
@@ -38,9 +38,9 @@ struct RecMutex {
   ink_mutex the_mutex;
 };
 
-int rec_mutex_init(RecMutex *m, const char *name = nullptr);
-int rec_mutex_destroy(RecMutex *m);
-int rec_mutex_acquire(RecMutex *m);
-int rec_mutex_release(RecMutex *m);
+void rec_mutex_init(RecMutex *m, const char *name = nullptr);
+void rec_mutex_destroy(RecMutex *m);
+void rec_mutex_acquire(RecMutex *m);
+void rec_mutex_release(RecMutex *m);
 
 #endif

--- a/lib/records/RecMutex.cc
+++ b/lib/records/RecMutex.cc
@@ -24,23 +24,23 @@
 #include "ts/ink_config.h"
 #include "I_RecMutex.h"
 
-int
+void
 rec_mutex_init(RecMutex *m, const char *name)
 {
   m->nthread_holding = 0;
   m->thread_holding  = ink_thread_null();
-  return ink_mutex_init(&(m->the_mutex), name);
+  ink_mutex_init(&(m->the_mutex), name);
 }
 
-int
+void
 rec_mutex_destroy(RecMutex *m)
 {
   ink_assert(m->nthread_holding == 0);
   ink_assert(m->thread_holding == ink_thread_null());
-  return ink_mutex_destroy(&(m->the_mutex));
+  ink_mutex_destroy(&(m->the_mutex));
 }
 
-int
+void
 rec_mutex_acquire(RecMutex *m)
 {
   ink_thread this_thread = ink_thread_self();
@@ -51,10 +51,9 @@ rec_mutex_acquire(RecMutex *m)
   }
 
   m->nthread_holding++;
-  return 0;
 }
 
-int
+void
 rec_mutex_release(RecMutex *m)
 {
   if (m->nthread_holding != 0) {
@@ -64,5 +63,4 @@ rec_mutex_release(RecMutex *m)
       ink_mutex_release(&(m->the_mutex));
     }
   }
-  return 0;
 }

--- a/lib/ts/ink_mutex.cc
+++ b/lib/ts/ink_mutex.cc
@@ -27,7 +27,21 @@
 #include <cstdio>
 #include "ts/ink_mutex.h"
 
-// Define the _g_mattr first to avoid static initialization order fiasco.
-x_pthread_mutexattr_t _g_mattr;
-
 ink_mutex __global_death = PTHREAD_MUTEX_INITIALIZER;
+
+x_pthread_mutexattr_t::x_pthread_mutexattr_t()
+{
+  pthread_mutexattr_init(&attr);
+#ifndef POSIX_THREAD_10031c
+  pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED);
+#endif
+
+#if DEBUG && HAVE_PTHREAD_MUTEXATTR_SETTYPE
+  pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
+#endif
+}
+
+x_pthread_mutexattr_t::~x_pthread_mutexattr_t()
+{
+  pthread_mutexattr_destroy(&attr);
+}

--- a/lib/ts/ink_mutex.h
+++ b/lib/ts/ink_mutex.h
@@ -32,57 +32,22 @@
 
 
 ***********************************************************************/
-#include <stdio.h>
 
 #include "ts/ink_defs.h"
 #include "ts/ink_error.h"
 
-#if defined(POSIX_THREAD)
 #include <pthread.h>
 #include <stdlib.h>
 
 typedef pthread_mutex_t ink_mutex;
 
-// just a wrapper so that the constructor gets executed
-// before the first call to ink_mutex_init();
-class x_pthread_mutexattr_t
-{
-public:
-  pthread_mutexattr_t attr;
-
-  x_pthread_mutexattr_t();
-  ~x_pthread_mutexattr_t();
-};
-
-static inline void
-ink_mutex_init(ink_mutex *m, const char * /* name */)
-{
-  int error;
-  x_pthread_mutexattr_t attr;
-
-  error = pthread_mutex_init(m, &attr.attr);
-  if (unlikely(error != 0)) {
-    ink_abort("pthread_mutex_init(%p) failed: %s (%d)", m, strerror(error), error);
-  }
-}
-
-static inline void
-ink_mutex_destroy(ink_mutex *m)
-{
-  int error;
-
-  error = pthread_mutex_destroy(m);
-  if (unlikely(error != 0)) {
-    ink_abort("pthread_mutex_destroy(%p) failed: %s (%d)", m, strerror(error), error);
-  }
-}
+void ink_mutex_init(ink_mutex *m, const char * /* name */);
+void ink_mutex_destroy(ink_mutex *m);
 
 static inline void
 ink_mutex_acquire(ink_mutex *m)
 {
-  int error;
-
-  error = pthread_mutex_lock(m);
+  int error = pthread_mutex_lock(m);
   if (unlikely(error != 0)) {
     ink_abort("pthread_mutex_lock(%p) failed: %s (%d)", m, strerror(error), error);
   }
@@ -91,9 +56,7 @@ ink_mutex_acquire(ink_mutex *m)
 static inline void
 ink_mutex_release(ink_mutex *m)
 {
-  int error;
-
-  error = pthread_mutex_unlock(m);
+  int error = pthread_mutex_unlock(m);
   if (unlikely(error != 0)) {
     ink_abort("pthread_mutex_unlock(%p) failed: %s (%d)", m, strerror(error), error);
   }
@@ -105,5 +68,4 @@ ink_mutex_try_acquire(ink_mutex *m)
   return pthread_mutex_trylock(m) == 0;
 }
 
-#endif /* #if defined(POSIX_THREAD) */
 #endif /* _ink_mutex_h_ */

--- a/lib/ts/ink_thread.h
+++ b/lib/ts/ink_thread.h
@@ -244,6 +244,7 @@ ink_cond_wait(ink_cond *cp, ink_mutex *mp)
 {
   ink_assert(pthread_cond_wait(cp, mp) == 0);
 }
+
 static inline int
 ink_cond_timedwait(ink_cond *cp, ink_mutex *mp, ink_timestruc *t)
 {

--- a/mgmt/api/EventControlMain.cc
+++ b/mgmt/api/EventControlMain.cc
@@ -122,13 +122,7 @@ remove_event_client(EventClientT *client, InkHashTable *table)
 TSMgmtError
 init_mgmt_events()
 {
-  int ret;
-
-  ret = ink_mutex_init(&mgmt_events_lock, "mgmt_event_notice");
-
-  if (ret) {
-    return TS_ERR_SYS_CALL;
-  }
+  ink_mutex_init(&mgmt_events_lock, "mgmt_event_notice");
 
   // initialize queue
   mgmt_events = create_queue();

--- a/proxy/InkAPITest.cc
+++ b/proxy/InkAPITest.cc
@@ -1279,6 +1279,11 @@ REGRESSION_TEST(SDK_API_TSThread)(RegressionTest *test, int /* atype ATS_UNUSED 
   } else {
     SDK_RPRINT(test, "TSThreadCreate", "TestCase1", TC_PASS, "ok");
   }
+
+  if (created_thread != nullptr) {
+    TSThreadWait(created_thread);
+    TSThreadDestroy(created_thread);
+  }
 }
 
 //////////////////////////////////////////////

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -1120,6 +1120,7 @@ tsapi const char *TSHttpHdrReasonLookup(TSHttpStatus status);
 tsapi TSThread TSThreadCreate(TSThreadFunc func, void *data);
 tsapi TSThread TSThreadInit(void);
 tsapi void TSThreadDestroy(TSThread thread);
+tsapi void TSThreadWait(TSThread thread);
 tsapi TSThread TSThreadSelf(void);
 
 /* --------------------------------------------------------------------------


### PR DESCRIPTION
Although the ink_mutex APIs claimed to return error values, they actually
abort on failure. Improve the abort to format a message that includes
the error, and don't bother to return error values any more since these
can't fail.
