### PR TITLE
TS-4948: Adjust code to prevent NULL variable reference.

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -2122,6 +2122,8 @@ HttpSM::process_hostdb_info(HostDBInfo *r)
       t_state.dns_info.os_addr_style  = HttpTransact::DNSLookupInfo::OS_ADDR_TRY_CLIENT;
       t_state.dns_info.lookup_success = true;
       // Leave ret unassigned, so we don't overwrite the host_db_info
+    } else {
+      use_client_addr = false; // No client addr to use
     }
   }
 


### PR DESCRIPTION
Attempting to fix a coverity warning by clearing the user_client_addr bool when the client_addr variable cannot be reset from NULL.  The later references to uses of client_addr are covered by the use_client_addr bool.

Cannot directly run coverity, so not sure this makes the tool happy.
