### PR TITLE
TS-4955: Remove the global mutex from the plugin session acceptor.

### DIFF
--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -6345,12 +6345,11 @@ TSHttpConnectWithPluginId(sockaddr const *addr, char const *tag, int64_t id)
   sdk_assert(ats_ip_port_cast(addr));
 
   if (plugin_http_accept) {
-    PluginVCCore *new_pvc = PluginVCCore::alloc();
+    PluginVCCore *new_pvc = PluginVCCore::alloc(plugin_http_accept);
 
     new_pvc->set_active_addr(addr);
     new_pvc->set_plugin_id(id);
     new_pvc->set_plugin_tag(tag);
-    new_pvc->set_accept_cont(plugin_http_accept);
 
     PluginVC *return_vc = new_pvc->connect();
 
@@ -6385,14 +6384,13 @@ TSHttpConnectTransparent(sockaddr const *client_addr, sockaddr const *server_add
   sdk_assert(ats_ip_port_cast(server_addr));
 
   if (plugin_http_transparent_accept) {
-    PluginVCCore *new_pvc = PluginVCCore::alloc();
+    PluginVCCore *new_pvc = PluginVCCore::alloc(plugin_http_transparent_accept);
 
     // set active address expects host ordering and the above casts do not
     // swap when it is required
     new_pvc->set_active_addr(client_addr);
     new_pvc->set_passive_addr(server_addr);
     new_pvc->set_transparent(true, true);
-    new_pvc->set_accept_cont(plugin_http_transparent_accept);
 
     PluginVC *return_vc = new_pvc->connect();
 
@@ -6663,8 +6661,7 @@ TSHttpTxnServerIntercept(TSCont contp, TSHttpTxn txnp)
   sdk_assert(sdk_sanity_check_mutex(i->mutex) == TS_SUCCESS);
 
   http_sm->plugin_tunnel_type = HTTP_PLUGIN_AS_SERVER;
-  http_sm->plugin_tunnel      = PluginVCCore::alloc();
-  http_sm->plugin_tunnel->set_accept_cont(i);
+  http_sm->plugin_tunnel      = PluginVCCore::alloc(i);
 }
 
 void
@@ -6680,8 +6677,7 @@ TSHttpTxnIntercept(TSCont contp, TSHttpTxn txnp)
   sdk_assert(sdk_sanity_check_mutex(i->mutex) == TS_SUCCESS);
 
   http_sm->plugin_tunnel_type = HTTP_PLUGIN_AS_INTERCEPT;
-  http_sm->plugin_tunnel      = PluginVCCore::alloc();
-  http_sm->plugin_tunnel->set_accept_cont(i);
+  http_sm->plugin_tunnel      = PluginVCCore::alloc(i);
 }
 
 // The API below require timer values as TSHRTime parameters

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -664,12 +664,6 @@ sdk_sanity_check_null_ptr(void *ptr)
   return TS_SUCCESS;
 }
 
-static TSReturnCode
-sdk_sanity_check_mutex(Ptr<ProxyMutex> &m)
-{
-  return m ? TS_SUCCESS : TS_ERROR;
-}
-
 // Plugin metric IDs index the plugin RSB, so bounds check against that.
 static TSReturnCode
 sdk_sanity_check_stat_id(int id)
@@ -6651,33 +6645,25 @@ TSTransformOutputVConnGet(TSVConn connp)
 void
 TSHttpTxnServerIntercept(TSCont contp, TSHttpTxn txnp)
 {
+  HttpSM *http_sm = (HttpSM *)txnp;
+
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_continuation(contp) == TS_SUCCESS);
 
-  HttpSM *http_sm    = (HttpSM *)txnp;
-  INKContInternal *i = (INKContInternal *)contp;
-
-  // Must have a mutex
-  sdk_assert(sdk_sanity_check_mutex(i->mutex) == TS_SUCCESS);
-
   http_sm->plugin_tunnel_type = HTTP_PLUGIN_AS_SERVER;
-  http_sm->plugin_tunnel      = PluginVCCore::alloc(i);
+  http_sm->plugin_tunnel      = PluginVCCore::alloc((INKContInternal *)contp);
 }
 
 void
 TSHttpTxnIntercept(TSCont contp, TSHttpTxn txnp)
 {
+  HttpSM *http_sm = (HttpSM *)txnp;
+
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_continuation(contp) == TS_SUCCESS);
 
-  HttpSM *http_sm    = (HttpSM *)txnp;
-  INKContInternal *i = (INKContInternal *)contp;
-
-  // Must have a mutex
-  sdk_assert(sdk_sanity_check_mutex(i->mutex) == TS_SUCCESS);
-
   http_sm->plugin_tunnel_type = HTTP_PLUGIN_AS_INTERCEPT;
-  http_sm->plugin_tunnel      = PluginVCCore::alloc(i);
+  http_sm->plugin_tunnel      = PluginVCCore::alloc((INKContInternal *)contp);
 }
 
 // The API below require timer values as TSHRTime parameters

--- a/proxy/PluginVC.h
+++ b/proxy/PluginVC.h
@@ -196,9 +196,9 @@ public:
   PluginVCCore();
   ~PluginVCCore();
 
-  static PluginVCCore *alloc();
-  void init();
-  void set_accept_cont(Continuation *c);
+  // Allocate a PluginVCCore object, passing the continuation which
+  // will receive NET_EVENT_ACCEPT to accept the new session.
+  static PluginVCCore *alloc(Continuation *acceptor);
 
   int state_send_accept(int event, void *data);
   int state_send_accept_failed(int event, void *data);
@@ -241,6 +241,7 @@ public:
   PluginVC passive_vc;
 
 private:
+  void init();
   void destroy();
 
   Continuation *connect_to;

--- a/proxy/http/HttpProxyServerMain.cc
+++ b/proxy/http/HttpProxyServerMain.cc
@@ -40,7 +40,7 @@
 #include "http2/Http2SessionAccept.h"
 
 HttpSessionAccept *plugin_http_accept             = NULL;
-HttpSessionAccept *plugin_http_transparent_accept = 0;
+HttpSessionAccept *plugin_http_transparent_accept = NULL;
 
 static SLL<SSLNextProtocolAccept> ssl_plugin_acceptors;
 static Ptr<ProxyMutex> ssl_plugin_mutex;
@@ -245,16 +245,16 @@ init_HttpProxyServer(int n_accept_threads)
   //   port but without going through the operating system
   //
   if (plugin_http_accept == NULL) {
-    plugin_http_accept        = new HttpSessionAccept;
-    plugin_http_accept->mutex = new_ProxyMutex();
+    plugin_http_accept = new HttpSessionAccept();
   }
+
   // Same as plugin_http_accept except outbound transparent.
   if (!plugin_http_transparent_accept) {
     HttpSessionAccept::Options ha_opt;
     ha_opt.setOutboundTransparent(true);
-    plugin_http_transparent_accept        = new HttpSessionAccept(ha_opt);
-    plugin_http_transparent_accept->mutex = new_ProxyMutex();
+    plugin_http_transparent_accept = new HttpSessionAccept(ha_opt);
   }
+
   if (!ssl_plugin_mutex) {
     ssl_plugin_mutex = new_ProxyMutex();
   }


### PR DESCRIPTION
``plugin_http_accept`` has a global mutex which can be contended by protocol plugins. We don't require locking on ``HttpSessionAccept`` objects and the normal server port accept objects are not locked.
