### PR TITLE
TS-4957: Make the use of madvise() with MADV_DONTDUMP configurable.

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3545,6 +3545,12 @@ Sockets
    For more information on the implications of enabling huge pages, see
    `Wikipedia <http://en.wikipedia.org/wiki/Page_%28computer_memory%29#Page_size_trade-off>_`.
 
+.. ts:cv:: CONFIG proxy.config.allocator.dontdump_iobuffers INT 1
+
+  Enable (1) the exclusion of IO buffers from core files when ATS crashes on supported
+  platforms.  (Currently only linux).  IO buffers are allocated with the MADV_DONTDUMP 
+  with madvise() on linux platforms that support MADV_DONTDUMP.  Enabled by default.
+
 .. ts:cv:: CONFIG proxy.config.http.enabled INT 1
 
    Turn on or off support for HTTP proxying. This is rarely used, the one

--- a/iocore/eventsystem/IOBuffer.cc
+++ b/iocore/eventsystem/IOBuffer.cc
@@ -43,14 +43,9 @@ int64_t max_iobuffer_size           = DEFAULT_BUFFER_SIZES - 1;
 // Initialization
 //
 void
-init_buffer_allocators()
+init_buffer_allocators(int iobuffer_advice)
 {
   char *name;
-  int advice = 0;
-
-#ifdef MADV_DONTDUMP // This should only exist on Linux 3.4 and higher.
-  advice = MADV_DONTDUMP;
-#endif
 
   for (int i = 0; i < DEFAULT_BUFFER_SIZES; i++) {
     int64_t s = DEFAULT_BUFFER_BASE_SIZE * (((int64_t)1) << i);
@@ -61,7 +56,7 @@ init_buffer_allocators()
 
     name = new char[64];
     snprintf(name, 64, "ioBufAllocator[%d]", i);
-    ioBufAllocator[i].re_init(name, s, n, a, advice);
+    ioBufAllocator[i].re_init(name, s, n, a, iobuffer_advice);
   }
 }
 

--- a/iocore/eventsystem/I_IOBuffer.h
+++ b/iocore/eventsystem/I_IOBuffer.h
@@ -125,7 +125,7 @@ enum AllocType {
 
 inkcoreapi extern Allocator ioBufAllocator[DEFAULT_BUFFER_SIZES];
 
-void init_buffer_allocators();
+void init_buffer_allocators(int iobuffer_advice);
 
 /**
   A reference counted wrapper around fast allocated or malloced memory.

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1449,6 +1449,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.allocator.hugepages", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_NULL, "[0-1]", RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.allocator.dontdump_iobuffers", RECD_INT, "1", RECU_RESTART_TS, RR_NULL, RECC_NULL, "[0-1]", RECA_NULL}
+  ,
 
   //############
   //#


### PR DESCRIPTION
We have seen high cpu loads and high time to serve problems in our production platform when using madvise() with the MADV_DONTDUMP option.   This appears to be a kernel issue with madvise().  in order to avoid having to rebuild ats, this PR uses a patch from TS-3417 to make the use of madvise() with the MADV_DONTDUMP flag configurable.