### PR TITLE
TS-4961: Use default accept thread config for plugin accepts.

### DIFF
--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -8968,7 +8968,7 @@ TSPortDescriptorAccept(TSPortDescriptor descp, TSCont contp)
 {
   Action *action      = NULL;
   HttpProxyPort *port = (HttpProxyPort *)descp;
-  NetProcessor::AcceptOptions net(make_net_accept_options(port, 0 /* nthreads */));
+  NetProcessor::AcceptOptions net(make_net_accept_options(port, -1 /* nthreads */));
 
   if (port->isSSL()) {
     action = sslNetProcessor.main_accept((INKContInternal *)contp, port->m_fd, net);
@@ -8988,7 +8988,7 @@ TSPluginDescriptorAccept(TSCont contp)
   for (int i = 0, n = proxy_ports.length(); i < n; ++i) {
     HttpProxyPort &port = proxy_ports[i];
     if (port.isPlugin()) {
-      NetProcessor::AcceptOptions net(make_net_accept_options(&port, 0 /* nthreads */));
+      NetProcessor::AcceptOptions net(make_net_accept_options(&port, -1 /* nthreads */));
       action = netProcessor.main_accept((INKContInternal *)contp, port.m_fd, net);
     }
   }


### PR DESCRIPTION
Since TSPortDescriptorAccept and TSPluginDescriptorAccept don't have
a way to specify the number of threads, pass -1 to make_net_accept()
so that it uses the default from proxy.config.accept_threads.