### PR TITLE
TS-4963: Add option to obey keepalive on internal transactions.

### DIFF
--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1339,6 +1339,9 @@ static const RecordElement RecordsConfig[] =
   {RECT_CONFIG, "proxy.config.plugin.load_elevated", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_READ_ONLY}
   ,
 
+  // Interim configuration setting for obeying keepalive requests on internal
+  // (PLuginVC) sessions. See TS-4960 and friends.
+  {RECT_LOCAL, "proxy.config.http.keepalive_internal_vc", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-1]", RECA_NULL},
 
   //##############################################################################
   //#

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -1037,6 +1037,9 @@ HttpConfig::startup()
   HttpEstablishStaticConfigByte(c.send_100_continue_response, "proxy.config.http.send_100_continue_response");
   HttpEstablishStaticConfigByte(c.disallow_post_100_continue, "proxy.config.http.disallow_post_100_continue");
   HttpEstablishStaticConfigByte(c.parser_allow_non_http, "proxy.config.http.parse.allow_non_http");
+
+  HttpEstablishStaticConfigByte(c.keepalive_internal_vc, "proxy.config.http.keepalive_internal_vc");
+
   HttpEstablishStaticConfigByte(c.oride.cache_open_write_fail_action, "proxy.config.http.cache.open_write_fail_action");
 
   HttpEstablishStaticConfigByte(c.oride.cache_when_to_revalidate, "proxy.config.http.cache.when_to_revalidate");
@@ -1310,9 +1313,11 @@ HttpConfig::reconfigure()
   params->ignore_accept_encoding_mismatch = m_master.ignore_accept_encoding_mismatch;
   params->ignore_accept_charset_mismatch  = m_master.ignore_accept_charset_mismatch;
 
-  params->send_100_continue_response         = INT_TO_BOOL(m_master.send_100_continue_response);
-  params->disallow_post_100_continue         = INT_TO_BOOL(m_master.disallow_post_100_continue);
-  params->parser_allow_non_http              = INT_TO_BOOL(m_master.parser_allow_non_http);
+  params->send_100_continue_response = INT_TO_BOOL(m_master.send_100_continue_response);
+  params->disallow_post_100_continue = INT_TO_BOOL(m_master.disallow_post_100_continue);
+  params->parser_allow_non_http      = INT_TO_BOOL(m_master.parser_allow_non_http);
+  params->keepalive_internal_vc      = INT_TO_BOOL(m_master.keepalive_internal_vc);
+
   params->oride.cache_open_write_fail_action = m_master.oride.cache_open_write_fail_action;
 
   params->oride.cache_when_to_revalidate = m_master.oride.cache_when_to_revalidate;

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -798,6 +798,7 @@ public:
   MgmtByte send_100_continue_response;
   MgmtByte disallow_post_100_continue;
   MgmtByte parser_allow_non_http;
+  MgmtByte keepalive_internal_vc;
 
   MgmtByte server_session_sharing_pool;
 
@@ -905,6 +906,7 @@ inline HttpConfigParams::HttpConfigParams()
     send_100_continue_response(0),
     disallow_post_100_continue(0),
     parser_allow_non_http(1),
+    keepalive_internal_vc(0),
     server_session_sharing_pool(TS_SERVER_SESSION_SHARING_POOL_THREAD)
 {
 }

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -5622,10 +5622,17 @@ HttpTransact::initialize_state_variables_from_request(State *s, HTTPHdr *obsolet
     s->request_data.incoming_port = vc->get_local_port();
     s->request_data.internal_txn  = vc->get_is_internal_request();
   }
+
   // If this is an internal request, never keep alive
-  if (!s->txn_conf->keep_alive_enabled_in || (vc && vc->get_is_internal_request()) ||
-      (s->state_machine->ua_session && s->state_machine->ua_session->ignore_keep_alive())) {
+  if (!s->txn_conf->keep_alive_enabled_in || (s->state_machine->ua_session && s->state_machine->ua_session->ignore_keep_alive())) {
     s->client_info.keep_alive = HTTP_NO_KEEPALIVE;
+  } else if (vc && vc->get_is_internal_request()) {
+    // Following the trail of JIRAs back from TS-4960, there can be issues with
+    // EOS event delivery when using keepalive on internal PluginVC session. As
+    // an interim measure, if proxy.config.http.keepalive_internal_vc is set,
+    // we will obey the incoming transaction's keepalive request.
+    s->client_info.keep_alive =
+      s->http_config_param->keepalive_internal_vc ? incoming_request->keep_alive_get() : HTTP_NO_KEEPALIVE;
   } else {
     s->client_info.keep_alive = incoming_request->keep_alive_get();
   }


### PR DESCRIPTION
Add the proxy.config.http.keepalive_internal_vc configuration option
to obey the keepalive state on internal transactions. This should be
considered an interim measure until the problems around event delivery
on half-closed internal sessions are investigated.