### PR TITLE
TS-4947: Fix log collation hosts configuration.

### DIFF
--- a/lib/bindings/bindings.cc
+++ b/lib/bindings/bindings.cc
@@ -250,6 +250,21 @@ BindingInstance::require(const char *path)
   return true;
 }
 
+bool
+BindingInstance::eval(const char *chunk)
+{
+  ink_release_assert(this->lua != NULL);
+
+  if (luaL_dostring(this->lua, chunk) != 0) {
+    const char *w = lua_tostring(this->lua, -1);
+    Warning("%s", w);
+    lua_pop(this->lua, 1);
+    return false;
+  }
+
+  return true;
+}
+
 BindingInstance *
 BindingInstance::self(lua_State *lua)
 {

--- a/lib/bindings/bindings.h
+++ b/lib/bindings/bindings.h
@@ -38,6 +38,9 @@ struct BindingInstance {
   // Import a Lua file.
   bool require(const char *path);
 
+  // Eval a chunk of Lua code.
+  bool eval(const char *chunk);
+
   // Bind values to the specified global name. If the name contains '.'
   // separators, intermediate tables are constucted and the value is bound
   // to the final path component.

--- a/lib/bindings/lua.h
+++ b/lib/bindings/lua.h
@@ -89,6 +89,7 @@ struct lua_scoped_stack {
   push_value(int value)
   {
     lua_pushvalue(L, value);
+    nvals++;
   }
 
 private:

--- a/proxy/logging/LogHost.cc
+++ b/proxy/logging/LogHost.cc
@@ -310,6 +310,12 @@ void
 LogHost::display(FILE *fd)
 {
   fprintf(fd, "LogHost: %s:%u, %s\n", name(), port(), (connected(NOPING)) ? "connected" : "not connected");
+
+  LogHost *host = this;
+  while (host->failover_link.next != NULL) {
+    fprintf(fd, "Failover: %s:%u, %s\n", host->name(), host->port(), (host->connected(NOPING)) ? "connected" : "not connected");
+    host = host->failover_link.next;
+  }
 }
 
 void


### PR DESCRIPTION
In the Lua logging configuration, we were failing to correctly
configure log collation hosts. The main fix is to simply return
true when we actually succeeded.

Fixed a bug in lua_scoped_stack where we failed to count the number
of values we pushed, which messes up the stack on return.

Updated the LogHost display to show failover hosts.

Added some tests for the supported syntaxes.