### PR TITLE
TS-4993: Disables escaping and quotes inside regexes

### DIFF
--- a/plugins/header_rewrite/header_rewrite_test.cc
+++ b/plugins/header_rewrite/header_rewrite_test.cc
@@ -22,6 +22,8 @@
 
 #include <cstdio>
 #include <cstdarg>
+#include <iostream>
+#include <ostream>
 
 #include "parser.h"
 
@@ -31,209 +33,307 @@ const char PLUGIN_NAME_DBG[] = "TEST_dbg_header_rewrite";
 extern "C" void
 TSError(const char *fmt, ...)
 {
-  char buf[2048];
-  int bytes = 0;
-  va_list args;
-  va_start(args, fmt);
-  if ((bytes = vsnprintf(buf, sizeof(buf), fmt, args)) > 0) {
-    fprintf(stderr, "TSError: %s: %.*s\n", PLUGIN_NAME, bytes, buf);
-  }
-  va_end(args);
 }
-
-extern "C" void
-TSDebug(const char *tag, const char *fmt, ...)
-{
-  char buf[2048];
-  int bytes = 0;
-  va_list args;
-  va_start(args, fmt);
-  if ((bytes = vsnprintf(buf, sizeof(buf), fmt, args)) > 0) {
-    fprintf(stdout, "TSDebug: %s: %.*s\n", PLUGIN_NAME, bytes, buf);
-  }
-  va_end(args);
-}
-
-#define CHECK_EQ(x, y)                   \
-  do {                                   \
-    if ((x) != (y)) {                    \
-      fprintf(stderr, "CHECK FAILED\n"); \
-      return 1;                          \
-    }                                    \
-  } while (false);
 
 class ParserTest : public Parser
 {
 public:
-  ParserTest(std::string line) : Parser(line) {}
+  ParserTest(std::string line) : Parser(line), res(true) { std::cout << "Finished parser test: " << line << std::endl; }
   std::vector<std::string>
   getTokens()
   {
     return _tokens;
   }
+
+  template <typename T, typename U>
+  void
+  do_parser_check(T x, U y, int line = 0)
+  {
+    if (x != y) {
+      std::cerr << "CHECK FAILED on line " << line << ": " << x << " != " << y << std::endl;
+      res = false;
+    }
+  }
+
+  bool res;
 };
+
+#define CHECK_EQ(x, y)                     \
+  do {                                     \
+    p.do_parser_check((x), (y), __LINE__); \
+  } while (false);
+
+#define END_TEST(s) \
+  do {              \
+    if (!p.res) {   \
+      ++errors;     \
+    }               \
+  } while (false);
 
 int
 test_parsing()
 {
+  int errors = 0;
+
   {
     ParserTest p("cond      %{READ_REQUEST_HDR_HOOK}");
-    CHECK_EQ(p.getTokens().size(), 2);
+
+    CHECK_EQ(p.getTokens().size(), 2U);
     CHECK_EQ(p.getTokens()[0], "cond");
     CHECK_EQ(p.getTokens()[1], "%{READ_REQUEST_HDR_HOOK}");
+
+    END_TEST();
   }
 
   {
     ParserTest p("cond %{CLIENT-HEADER:Host}    =a");
-    CHECK_EQ(p.getTokens().size(), 4);
+
+    CHECK_EQ(p.getTokens().size(), 4UL);
     CHECK_EQ(p.getTokens()[0], "cond");
     CHECK_EQ(p.getTokens()[1], "%{CLIENT-HEADER:Host}");
     CHECK_EQ(p.getTokens()[2], "=");
     CHECK_EQ(p.getTokens()[3], "a");
+
+    END_TEST();
   }
 
   {
     ParserTest p(" # COMMENT!");
-    CHECK_EQ(p.getTokens().size(), 0);
+
+    CHECK_EQ(p.getTokens().size(), 0UL);
     CHECK_EQ(p.empty(), true);
+
+    END_TEST();
   }
 
   {
     ParserTest p("# COMMENT");
-    CHECK_EQ(p.getTokens().size(), 0);
+
+    CHECK_EQ(p.getTokens().size(), 0UL);
     CHECK_EQ(p.empty(), true);
+
+    END_TEST();
   }
 
   {
     ParserTest p("cond %{Client-HEADER:Foo} =b");
-    CHECK_EQ(p.getTokens().size(), 4);
+
+    CHECK_EQ(p.getTokens().size(), 4UL);
     CHECK_EQ(p.getTokens()[0], "cond");
     CHECK_EQ(p.getTokens()[1], "%{Client-HEADER:Foo}");
     CHECK_EQ(p.getTokens()[2], "=");
     CHECK_EQ(p.getTokens()[3], "b");
+
+    END_TEST();
   }
 
   {
     ParserTest p("cond %{Client-HEADER:Blah}       =        x");
-    CHECK_EQ(p.getTokens().size(), 4);
+
+    CHECK_EQ(p.getTokens().size(), 4UL);
     CHECK_EQ(p.getTokens()[0], "cond");
     CHECK_EQ(p.getTokens()[1], "%{Client-HEADER:Blah}");
     CHECK_EQ(p.getTokens()[2], "=");
     CHECK_EQ(p.getTokens()[3], "x");
+
+    END_TEST();
   }
 
   {
-    ParserTest p("cond %{CLIENT-HEADER:non_existent_header} =  \"shouldnt_   exist    _anyway\"          [AND]");
-    CHECK_EQ(p.getTokens().size(), 5);
+    ParserTest p(R"(cond %{CLIENT-HEADER:non_existent_header} =  "shouldnt_   exist    _anyway"          [AND])");
+
+    CHECK_EQ(p.getTokens().size(), 5UL);
     CHECK_EQ(p.getTokens()[0], "cond");
     CHECK_EQ(p.getTokens()[1], "%{CLIENT-HEADER:non_existent_header}");
     CHECK_EQ(p.getTokens()[2], "=");
     CHECK_EQ(p.getTokens()[3], "shouldnt_   exist    _anyway");
     CHECK_EQ(p.getTokens()[4], "[AND]");
+
+    END_TEST();
   }
 
   {
-    ParserTest p("cond %{CLIENT-HEADER:non_existent_header} =  \"shouldnt_   =    _anyway\"          [AND]");
-    CHECK_EQ(p.getTokens().size(), 5);
+    ParserTest p(R"(cond %{CLIENT-HEADER:non_existent_header} =  "shouldnt_   =    _anyway"          [AND])");
+
+    CHECK_EQ(p.getTokens().size(), 5UL);
     CHECK_EQ(p.getTokens()[0], "cond");
     CHECK_EQ(p.getTokens()[1], "%{CLIENT-HEADER:non_existent_header}");
     CHECK_EQ(p.getTokens()[2], "=");
     CHECK_EQ(p.getTokens()[3], "shouldnt_   =    _anyway");
     CHECK_EQ(p.getTokens()[4], "[AND]");
+
+    END_TEST();
   }
 
   {
-    ParserTest p("cond %{CLIENT-HEADER:non_existent_header} =\"=\"          [AND]");
-    CHECK_EQ(p.getTokens().size(), 5);
+    ParserTest p(R"(cond %{CLIENT-HEADER:non_existent_header} ="="          [AND])");
+
+    CHECK_EQ(p.getTokens().size(), 5UL);
     CHECK_EQ(p.getTokens()[0], "cond");
     CHECK_EQ(p.getTokens()[1], "%{CLIENT-HEADER:non_existent_header}");
     CHECK_EQ(p.getTokens()[2], "=");
     CHECK_EQ(p.getTokens()[3], "=");
     CHECK_EQ(p.getTokens()[4], "[AND]");
+
+    END_TEST();
   }
 
   {
-    ParserTest p("cond %{CLIENT-HEADER:non_existent_header} =\"\"          [AND]");
-    CHECK_EQ(p.getTokens().size(), 5);
+    ParserTest p(R"(cond %{CLIENT-HEADER:non_existent_header} =""          [AND])");
+
+    CHECK_EQ(p.getTokens().size(), 5UL);
     CHECK_EQ(p.getTokens()[0], "cond");
     CHECK_EQ(p.getTokens()[1], "%{CLIENT-HEADER:non_existent_header}");
     CHECK_EQ(p.getTokens()[2], "=");
     CHECK_EQ(p.getTokens()[3], "");
     CHECK_EQ(p.getTokens()[4], "[AND]");
+
+    END_TEST();
+  }
+
+  {
+    ParserTest p(R"(cond %{PATH} /\/foo\/bar/ [OR])");
+
+    CHECK_EQ(p.getTokens().size(), 4UL);
+    CHECK_EQ(p.getTokens()[0], "cond");
+    CHECK_EQ(p.getTokens()[1], "%{PATH}");
+    CHECK_EQ(p.getTokens()[2], R"(/\/foo\/bar/)");
+    CHECK_EQ(p.getTokens()[3], "[OR]");
+
+    END_TEST();
   }
 
   {
     ParserTest p("add-header X-HeaderRewriteApplied true");
-    CHECK_EQ(p.getTokens().size(), 3);
+
+    CHECK_EQ(p.getTokens().size(), 3UL);
     CHECK_EQ(p.getTokens()[0], "add-header");
     CHECK_EQ(p.getTokens()[1], "X-HeaderRewriteApplied");
     CHECK_EQ(p.getTokens()[2], "true");
+
+    END_TEST();
   }
 
   /* backslash-escape */
   {
-    ParserTest p("add-header foo \\ \\=\\<\\>\\\"\\#\\\\");
-    CHECK_EQ(p.getTokens().size(), 3);
+    ParserTest p(R"(add-header foo \ \=\<\>\"\#\\)");
+
+    CHECK_EQ(p.getTokens().size(), 3UL);
     CHECK_EQ(p.getTokens()[0], "add-header");
     CHECK_EQ(p.getTokens()[1], "foo");
-    CHECK_EQ(p.getTokens()[2], " =<>\"#\\");
+    CHECK_EQ(p.getTokens()[2], R"( =<>"#\)");
+
+    END_TEST();
   }
 
   {
-    ParserTest p("add-header foo \\<bar\\>");
-    CHECK_EQ(p.getTokens().size(), 3);
+    ParserTest p(R"(add-header foo \<bar\>)");
+
+    CHECK_EQ(p.getTokens().size(), 3UL);
     CHECK_EQ(p.getTokens()[0], "add-header");
     CHECK_EQ(p.getTokens()[1], "foo");
     CHECK_EQ(p.getTokens()[2], "<bar>");
+
+    END_TEST();
   }
 
   {
-    ParserTest p("add-header foo \\bar\\");
-    CHECK_EQ(p.getTokens().size(), 3);
+    ParserTest p(R"(add-header foo \bar\)");
+
+    CHECK_EQ(p.getTokens().size(), 3UL);
     CHECK_EQ(p.getTokens()[0], "add-header");
     CHECK_EQ(p.getTokens()[1], "foo");
     CHECK_EQ(p.getTokens()[2], "bar");
+
+    END_TEST();
   }
 
   {
-    ParserTest p("add-header foo \"bar\"");
-    CHECK_EQ(p.getTokens().size(), 3);
+    ParserTest p(R"(add-header foo "bar")");
+
+    CHECK_EQ(p.getTokens().size(), 3UL);
     CHECK_EQ(p.getTokens()[0], "add-header");
     CHECK_EQ(p.getTokens()[1], "foo");
     CHECK_EQ(p.getTokens()[2], "bar");
+
+    END_TEST();
   }
 
   {
-    ParserTest p("add-header foo \"\\\"bar\\\"\"");
-    CHECK_EQ(p.getTokens().size(), 3);
+    ParserTest p(R"(add-header foo "\"bar\"")");
+
+    CHECK_EQ(p.getTokens().size(), 3UL);
     CHECK_EQ(p.getTokens()[0], "add-header");
     CHECK_EQ(p.getTokens()[1], "foo");
-    CHECK_EQ(p.getTokens()[2], "\"bar\"");
+    CHECK_EQ(p.getTokens()[2], R"("bar")");
+
+    END_TEST();
   }
 
   {
-    ParserTest p("add-header foo \"\\\"\\\\\\\"bar\\\\\\\"\\\"\"");
-    CHECK_EQ(p.getTokens().size(), 3);
+    ParserTest p(R"(add-header foo "\"\\\"bar\\\"\"")");
+
+    CHECK_EQ(p.getTokens().size(), 3UL);
     CHECK_EQ(p.getTokens()[0], "add-header");
     CHECK_EQ(p.getTokens()[1], "foo");
-    CHECK_EQ(p.getTokens()[2], "\"\\\"bar\\\"\"");
+    CHECK_EQ(p.getTokens()[2], R"("\"bar\"")");
+
+    END_TEST();
   }
 
   {
-    ParserTest p("add-header Public-Key-Pins \"max-age=3000; pin-sha256=\\\"d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=\\\"\"");
-    CHECK_EQ(p.getTokens().size(), 3);
+    ParserTest p(R"(add-header Public-Key-Pins "max-age=3000; pin-sha256=\"d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=\"")");
+
+    CHECK_EQ(p.getTokens().size(), 3UL);
     CHECK_EQ(p.getTokens()[0], "add-header");
     CHECK_EQ(p.getTokens()[1], "Public-Key-Pins");
-    CHECK_EQ(p.getTokens()[2], "max-age=3000; pin-sha256=\"d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=\"");
+    CHECK_EQ(p.getTokens()[2], R"(max-age=3000; pin-sha256="d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=")");
+
+    END_TEST();
   }
 
   {
-    ParserTest p(
-      "add-header Public-Key-Pins max-age\\=3000;\\ pin-sha256\\=\\\"d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM\\=\\\"");
-    CHECK_EQ(p.getTokens().size(), 3);
+    ParserTest p(R"(add-header Public-Key-Pins max-age\=3000;\ pin-sha256\=\"d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM\=\")");
+
+    CHECK_EQ(p.getTokens().size(), 3UL);
     CHECK_EQ(p.getTokens()[0], "add-header");
     CHECK_EQ(p.getTokens()[1], "Public-Key-Pins");
-    CHECK_EQ(p.getTokens()[2], "max-age=3000; pin-sha256=\"d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=\"");
+    CHECK_EQ(p.getTokens()[2], R"(max-age=3000; pin-sha256="d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=")");
+
+    END_TEST();
+  }
+
+  {
+    ParserTest p(R"(add-header Client-IP "%<chi>")");
+
+    CHECK_EQ(p.getTokens().size(), 3UL);
+    CHECK_EQ(p.getTokens()[0], "add-header");
+    CHECK_EQ(p.getTokens()[1], "Client-IP");
+    CHECK_EQ(p.getTokens()[2], R"(%<chi>)");
+
+    END_TEST();
+  }
+
+  {
+    ParserTest p(R"(add-header X-Url "http://trafficserver.apache.org/")");
+
+    CHECK_EQ(p.getTokens().size(), 3UL);
+    CHECK_EQ(p.getTokens()[0], "add-header");
+    CHECK_EQ(p.getTokens()[1], "X-Url");
+    CHECK_EQ(p.getTokens()[2], "http://trafficserver.apache.org/");
+
+    END_TEST();
+  }
+
+  {
+    ParserTest p(R"(add-header X-Url http://trafficserver.apache.org/)");
+
+    CHECK_EQ(p.getTokens().size(), 3UL);
+    CHECK_EQ(p.getTokens()[0], "add-header");
+    CHECK_EQ(p.getTokens()[1], "X-Url");
+    CHECK_EQ(p.getTokens()[2], "http://trafficserver.apache.org/");
+
+    END_TEST();
   }
 
   /*
@@ -241,64 +341,95 @@ test_parsing()
    */
 
   { /* unterminated quote */
-    ParserTest p("cond %{CLIENT-HEADER:non_existent_header} =\" [AND]");
-    CHECK_EQ(p.getTokens().size(), 0);
+    ParserTest p(R"(cond %{CLIENT-HEADER:non_existent_header} =" [AND])");
+
+    CHECK_EQ(p.getTokens().size(), 0UL);
+
+    END_TEST();
   }
 
   { /* quote in a token */
-    ParserTest p("cond %{CLIENT-HEADER:non_existent_header} =a\"b [AND]");
-    CHECK_EQ(p.getTokens().size(), 0);
+    ParserTest p(R"(cond %{CLIENT-HEADER:non_existent_header} =a"b [AND])");
+
+    CHECK_EQ(p.getTokens().size(), 0UL);
+
+    END_TEST();
   }
 
-  return 0;
+  return errors;
 }
 
 int
 test_processing()
 {
+  int errors = 0;
   /*
    * These tests are designed to verify that the processing of the parsed input is correct.
    */
   {
-    ParserTest p("cond %{CLIENT-HEADER:non_existent_header} =\"=\"          [AND]");
-    CHECK_EQ(p.getTokens().size(), 5);
+    ParserTest p(R"(cond %{CLIENT-HEADER:non_existent_header} ="="          [AND])");
+
+    CHECK_EQ(p.getTokens().size(), 5UL);
     CHECK_EQ(p.get_op(), "CLIENT-HEADER:non_existent_header");
     CHECK_EQ(p.get_arg(), "==");
     CHECK_EQ(p.is_cond(), true);
+
+    END_TEST();
   }
 
   {
-    ParserTest p("cond %{CLIENT-HEADER:non_existent_header} =  \"shouldnt_   =    _anyway\"          [AND]");
-    CHECK_EQ(p.getTokens().size(), 5);
+    ParserTest p(R"(cond %{CLIENT-HEADER:non_existent_header} =  "shouldnt_   =    _anyway"          [AND])");
+
+    CHECK_EQ(p.getTokens().size(), 5UL);
     CHECK_EQ(p.get_op(), "CLIENT-HEADER:non_existent_header");
     CHECK_EQ(p.get_arg(), "=shouldnt_   =    _anyway");
     CHECK_EQ(p.is_cond(), true);
+
+    END_TEST();
+  }
+
+  {
+    ParserTest p(R"(cond %{PATH} /\.html|\.txt/)");
+
+    CHECK_EQ(p.getTokens().size(), 3UL);
+    CHECK_EQ(p.get_op(), "PATH");
+    CHECK_EQ(p.get_arg(), R"(/\.html|\.txt/)");
+    CHECK_EQ(p.is_cond(), true);
+
+    END_TEST();
+  }
+
+  {
+    ParserTest p(R"(cond %{PATH} /\/foo\/bar/)");
+
+    CHECK_EQ(p.getTokens().size(), 3UL);
+    CHECK_EQ(p.get_op(), "PATH");
+    CHECK_EQ(p.get_arg(), R"(/\/foo\/bar/)");
+    CHECK_EQ(p.is_cond(), true);
+
+    END_TEST();
   }
 
   {
     ParserTest p("add-header X-HeaderRewriteApplied true");
-    CHECK_EQ(p.getTokens().size(), 3);
+
+    CHECK_EQ(p.getTokens().size(), 3UL);
     CHECK_EQ(p.get_op(), "add-header");
     CHECK_EQ(p.get_arg(), "X-HeaderRewriteApplied");
-    CHECK_EQ(p.get_value(), "true")
+    CHECK_EQ(p.get_value(), "true");
     CHECK_EQ(p.is_cond(), false);
+
+    END_TEST();
   }
 
-  return 0;
+  return errors;
 }
-
 int
-tests()
+main()
 {
   if (test_parsing() || test_processing()) {
     return 1;
   }
 
   return 0;
-}
-
-int
-main()
-{
-  return tests();
 }


### PR DESCRIPTION
In addition, this cleans up the unit tests a bit, to make it more useful from
the command line when testing/debugging. New tests are also added for regular
expression parse testing.

Note: This restores 6.1.x functionality in 7.x, however, it's not compatible with 5.3.x. I do feel that this is the right approach, because it retains PCRE compatibility within the // that indicates a regex.