### PR TITLE
TS-5003: Compile fail for 64 bit systems without 128 bit CAS.

### DIFF
--- a/lib/ts/ink_queue.h
+++ b/lib/ts/ink_queue.h
@@ -91,6 +91,7 @@ typedef union {
   typedef int64_t version_type;
   typedef __int128_t data_type;
 #else
+  typedef int64_t version_type;
   typedef int64_t data_type;
 #endif
 


### PR DESCRIPTION
Talked with @jpeach about this and we think this is the correct type for {{version_type}} in this case.