### PR TITLE
TS-5005: CID 1364117: Explicit null dereferenced in HttpSM.cc

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -2122,6 +2122,8 @@ HttpSM::process_hostdb_info(HostDBInfo *r)
       t_state.dns_info.os_addr_style  = HttpTransact::DNSLookupInfo::OS_ADDR_TRY_CLIENT;
       t_state.dns_info.lookup_success = true;
       // Leave ret unassigned, so we don't overwrite the host_db_info
+    } else {
+      use_client_addr = false;
     }
   }
 


### PR DESCRIPTION
Probably benign, since the vc shouldn't be NULL, but coverity is ruling with an iron fist.