### PR TITLE
TS-4855: Make `const char` consistent across the project.

### DIFF
--- a/cmd/traffic_cop/traffic_cop.cc
+++ b/cmd/traffic_cop/traffic_cop.cc
@@ -142,7 +142,7 @@ static int child_status = 0;
 
 AppVersionInfo appVersionInfo;
 
-static char const localhost[] = "127.0.0.1";
+static const char localhost[] = "127.0.0.1";
 
 static void cop_log(int priority, const char *format, ...) TS_PRINTFLIKE(2, 3);
 
@@ -821,7 +821,7 @@ poll_write(int fd, int timeout)
 }
 
 static int
-open_socket(int port, const char *ip = NULL, char const *ip_to_bind = NULL)
+open_socket(int port, const char *ip = NULL, const char *ip_to_bind = NULL)
 {
   int sock = 0;
   struct addrinfo hints;
@@ -935,8 +935,8 @@ getaddrinfo_error:
 }
 
 static int
-test_port(int port, const char *request, char *buffer, int bufsize, int64_t test_timeout, char const *ip = NULL,
-          char const *ip_to_bind = NULL)
+test_port(int port, const char *request, char *buffer, int bufsize, int64_t test_timeout, const char *ip = NULL,
+          const char *ip_to_bind = NULL)
 {
   int64_t start_time, timeout;
   int sock;
@@ -1187,7 +1187,7 @@ test_mgmt_cli_port()
 }
 
 static int
-test_http_port(int port, char *request, int timeout, char const *ip = NULL, char const *ip_to_bind = NULL)
+test_http_port(int port, char *request, int timeout, const char *ip = NULL, char const *ip_to_bind = NULL)
 {
   char buffer[4096];
   char *p;

--- a/cmd/traffic_wccp/wccp_client.cc
+++ b/cmd/traffic_wccp/wccp_client.cc
@@ -47,7 +47,7 @@
 bool do_debug  = false;
 bool do_daemon = false;
 
-static char const USAGE_TEXT[] = "%s\n"
+static const char USAGE_TEXT[] = "%s\n"
                                  "--address IP address to bind.\n"
                                  "--router Booststrap IP address for routers.\n"
                                  "--service Path to service group definitions.\n"
@@ -139,7 +139,7 @@ main(int argc, char **argv)
   int zret; // getopt return.
   int zidx; // option index.
   bool fail            = false;
-  char const *FAIL_MSG = "";
+  const char *FAIL_MSG = "";
 
   while (-1 != (zret = getopt_long_only(argc, argv, "", OPTIONS, &zidx))) {
     switch (zret) {

--- a/example/protocol-stack/protocol-stack.cc
+++ b/example/protocol-stack/protocol-stack.cc
@@ -32,7 +32,7 @@ static int
 proto_stack_cb(TSCont contp ATS_UNUSED, TSEvent event, void *edata)
 {
   TSHttpTxn txnp = (TSHttpTxn)edata;
-  char const *results[10];
+  const char *results[10];
   int count = 0;
   TSDebug(DEBUG_TAG, "Protocols:");
   TSHttpTxnClientProtocolStackGet(txnp, 10, results, &count);

--- a/example/ssl-preaccept/ssl-preaccept.cc
+++ b/example/ssl-preaccept/ssl-preaccept.cc
@@ -69,7 +69,7 @@ Parse_Addr_String(ts::ConstBuffer const &text, IpRange &range)
 
 /// Get a string value from a config node.
 void
-Load_Config_Value(Value const &parent, char const *name, IpRangeQueue &addrs)
+Load_Config_Value(Value const &parent, const char *name, IpRangeQueue &addrs)
 {
   Value v = parent[name];
   std::string zret;
@@ -178,7 +178,7 @@ TSPluginInit(int argc, const char *argv[])
     }
   }
   if (ConfigPath.length() == 0) {
-    static char const *const DEFAULT_CONFIG_PATH = "ssl_preaccept.config";
+    static const char *const DEFAULT_CONFIG_PATH = "ssl_preaccept.config";
     ConfigPath                                   = std::string(TSConfigDirGet()) + '/' + std::string(DEFAULT_CONFIG_PATH);
     TSDebug(PN, "No config path set in arguments, using default: %s", DEFAULT_CONFIG_PATH);
   }

--- a/example/ssl-sni-whitelist/ssl-sni-whitelist.cc
+++ b/example/ssl-sni-whitelist/ssl-sni-whitelist.cc
@@ -127,7 +127,7 @@ TSPluginInit(int argc, const char *argv[])
     }
   }
   if (ConfigPath.length() == 0) {
-    static char const *const DEFAULT_CONFIG_PATH = "ssl_sni_whitelist.config";
+    static const char *const DEFAULT_CONFIG_PATH = "ssl_sni_whitelist.config";
     ConfigPath                                   = std::string(TSConfigDirGet()) + '/' + std::string(DEFAULT_CONFIG_PATH);
     TSDebug(PN, "No config path set in arguments, using default: %s", DEFAULT_CONFIG_PATH);
   }

--- a/example/ssl-sni/ssl-sni.cc
+++ b/example/ssl-sni/ssl-sni.cc
@@ -148,7 +148,7 @@ TSPluginInit(int argc, const char *argv[])
     }
   }
   if (ConfigPath.length() == 0) {
-    static char const *const DEFAULT_CONFIG_PATH = "ssl_sni.config";
+    static const char *const DEFAULT_CONFIG_PATH = "ssl_sni.config";
     ConfigPath                                   = std::string(TSConfigDirGet()) + '/' + std::string(DEFAULT_CONFIG_PATH);
     TSDebug(PN, "No config path set in arguments, using default: %s", DEFAULT_CONFIG_PATH);
   }

--- a/example/txn-data-sink/txn-data-sink.c
+++ b/example/txn-data-sink/txn-data-sink.c
@@ -40,7 +40,7 @@
 #define PCP "[" PLUGIN_NAME "]"
 
 // Activate the data sink if this field is present in the request.
-static char const FLAG_MIME_FIELD[] = "TS-Agent";
+static const char FLAG_MIME_FIELD[] = "TS-Agent";
 static size_t const FLAG_MIME_LEN   = sizeof(FLAG_MIME_FIELD) - 1;
 
 typedef struct {

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -2509,7 +2509,7 @@ LmemHit:
 }
 
 Action *
-Cache::lookup(Continuation *cont, const CacheKey *key, CacheFragType type, char const *hostname, int host_len)
+Cache::lookup(Continuation *cont, const CacheKey *key, CacheFragType type, const char *hostname, int host_len)
 {
   if (!CacheProcessor::IsCacheReady(type)) {
     cont->handleEvent(CACHE_EVENT_LOOKUP_FAILED, 0);
@@ -3086,7 +3086,7 @@ rebuild_host_table(Cache *cache)
 
 // if generic_host_rec.vols == NULL, what do we do???
 Vol *
-Cache::key_to_vol(const CacheKey *key, char const *hostname, int host_len)
+Cache::key_to_vol(const CacheKey *key, const char *hostname, int host_len)
 {
   uint32_t h                 = (key->slice32(2) >> DIR_TAG_WIDTH) % VOL_HASH_TABLE_SIZE;
   unsigned short *hash_table = hosttable->gen_host_rec.vol_hash_table;
@@ -3326,7 +3326,7 @@ CacheProcessor::remove(Continuation *cont, const HttpCacheKey *key, bool cluster
 }
 
 CacheDisk *
-CacheProcessor::find_by_path(char const *path, int len)
+CacheProcessor::find_by_path(const char *path, int len)
 {
   if (CACHE_INITIALIZED == initialized) {
     // If no length is passed in, assume it's null terminated.

--- a/iocore/cache/CacheHosting.cc
+++ b/iocore/cache/CacheHosting.cc
@@ -95,7 +95,7 @@ CacheHostMatcher::AllocateSpace(int num_entries)
 //    arg hostname
 //
 void
-CacheHostMatcher::Match(char const *rdata, int rlen, CacheHostResult *result)
+CacheHostMatcher::Match(const char *rdata, int rlen, CacheHostResult *result)
 {
   void *opaque_ptr;
   CacheHostRecord *data_ptr;
@@ -224,7 +224,7 @@ CacheHostTable::Print()
 //   Queries each table for the Result*
 //
 void
-CacheHostTable::Match(char const *rdata, int rlen, CacheHostResult *result)
+CacheHostTable::Match(const char *rdata, int rlen, CacheHostResult *result)
 {
   hostMatch->Match(rdata, rlen, result);
 }

--- a/iocore/cache/I_Cache.h
+++ b/iocore/cache/I_Cache.h
@@ -121,7 +121,7 @@ struct CacheProcessor : public Processor {
       If @a len is 0 then @a path is presumed null terminated.
       @return @c NULL if the path does not match any defined storage.
    */
-  CacheDisk *find_by_path(char const *path, int len = 0);
+  CacheDisk *find_by_path(const char *path, int len = 0);
 
   /** Check if there are any online storage devices.
       If this returns @c false then the cache should be disabled as there is no storage available.

--- a/iocore/cache/I_Store.h
+++ b/iocore/cache/I_Store.h
@@ -150,7 +150,7 @@ public:
            char *buf, int buflen); // where to store the path
 
   /// Set the hash seed string.
-  void hash_base_string_set(char const *s);
+  void hash_base_string_set(const char *s);
   /// Set the volume number.
   void volume_number_set(int n);
 
@@ -267,8 +267,8 @@ struct Store {
   int write_config_data(int fd) const;
 
   /// Additional configuration key values.
-  static char const VOLUME_KEY[];
-  static char const HASH_BASE_STRING_KEY[];
+  static const char VOLUME_KEY[];
+  static const char HASH_BASE_STRING_KEY[];
 };
 
 // store either free or in the cache, can be stolen for reconfiguration

--- a/iocore/cache/P_CacheHosting.h
+++ b/iocore/cache/P_CacheHosting.h
@@ -81,7 +81,7 @@ public:
   CacheHostMatcher(const char *name, CacheType typ);
   ~CacheHostMatcher();
 
-  void Match(char const *rdata, int rlen, CacheHostResult *result);
+  void Match(const char *rdata, int rlen, CacheHostResult *result);
   void AllocateSpace(int num_entries);
   void NewEntry(matcher_line *line_info);
   void Print();
@@ -120,7 +120,7 @@ public:
   ~CacheHostTable();
   int BuildTable(const char *config_file_path);
   int BuildTableFromString(const char *config_file_path, char *str);
-  void Match(char const *rdata, int rlen, CacheHostResult *result);
+  void Match(const char *rdata, int rlen, CacheHostResult *result);
   void Print();
 
   int

--- a/iocore/cache/P_CacheInternal.h
+++ b/iocore/cache/P_CacheInternal.h
@@ -995,7 +995,7 @@ struct Cache {
 
   int open_done();
 
-  Vol *key_to_vol(const CacheKey *key, char const *hostname, int host_len);
+  Vol *key_to_vol(const CacheKey *key, const char *hostname, int host_len);
 
   Cache()
     : cache_read_done(0),

--- a/iocore/cache/Store.cc
+++ b/iocore/cache/Store.cc
@@ -36,8 +36,8 @@
 // Store
 //
 
-char const Store::VOLUME_KEY[]           = "volume";
-char const Store::HASH_BASE_STRING_KEY[] = "id";
+const char Store::VOLUME_KEY[]           = "volume";
+const char Store::HASH_BASE_STRING_KEY[] = "id";
 
 static span_error_t
 make_span_error(int error)
@@ -233,7 +233,7 @@ Span::path(char *filename, int64_t *aoffset, char *buf, int buflen)
 }
 
 void
-Span::hash_base_string_set(char const *s)
+Span::hash_base_string_set(const char *s)
 {
   hash_base_string = s ? ats_strdup(s) : NULL;
 }
@@ -330,8 +330,8 @@ Store::read_config()
   char line[1024];
   int len;
   while ((len = ink_file_fd_readline(fd, sizeof(line), line)) > 0) {
-    char const *path;
-    char const *seed = 0;
+    const char *path;
+    const char *seed = 0;
     // update lines
 
     ++ln;
@@ -354,7 +354,7 @@ Store::read_config()
 
     int64_t size   = -1;
     int volume_num = -1;
-    char const *e;
+    const char *e;
     while (0 != (e = tokens.getNext())) {
       if (ParseRules::is_digit(*e)) {
         if ((size = ink_atoi64(e)) <= 0) {

--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -59,7 +59,7 @@ int dns_prefer_ipv6                  = 0;
 namespace
 {
 // Currently only used for A and AAAA.
-inline char const *
+inline const char *
 QtypeName(int qtype)
 {
   return T_AAAA == qtype ? "AAAA" : T_A == qtype ? "A" : "*";
@@ -1171,8 +1171,8 @@ dns_result(DNSHandler *h, DNSEntry *e, HostEnt *ent, bool retry)
   if (is_debug_tag_set("dns")) {
     if (is_addr_query(e->qtype)) {
       ip_text_buffer buff;
-      char const *ptr    = "<none>";
-      char const *result = "FAIL";
+      const char *ptr    = "<none>";
+      const char *result = "FAIL";
       if (ent) {
         result = "SUCCESS";
         ptr    = inet_ntop(e->qtype == T_AAAA ? AF_INET6 : AF_INET, ent->ent.h_addr_list[0], buff, sizeof(buff));

--- a/iocore/dns/I_DNSProcessor.h
+++ b/iocore/dns/I_DNSProcessor.h
@@ -174,7 +174,7 @@ DNSProcessor::gethostbyname(Continuation *cont, const char *name, int len, Optio
 inline Action *
 DNSProcessor::gethostbyaddr(Continuation *cont, IpAddr const *addr, Options const &opt)
 {
-  return getby(reinterpret_cast<char const *>(addr), 0, T_PTR, cont, opt);
+  return getby(reinterpret_cast<const char *>(addr), 0, T_PTR, cont, opt);
 }
 
 inline DNSProcessor::Options::Options() : handler(0), timeout(0), host_res_style(HOST_RES_IPV4)

--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -75,7 +75,7 @@ ClassAllocator<HostDBContinuation> hostDBContAllocator("hostDBContAllocator");
 
 HostDBCache hostDB;
 
-void ParseHostFile(char const *path, unsigned int interval);
+void ParseHostFile(const char *path, unsigned int interval);
 
 char *
 HostDBInfo::srvname(HostDBRoundRobin *rr) const
@@ -149,10 +149,10 @@ check_for_retry(HostDBMark &mark, HostResStyle style)
   return zret;
 }
 
-char const *
+const char *
 string_for(HostDBMark mark)
 {
-  static char const *STRING[] = {"Generic", "IPv4", "IPv6", "SRV"};
+  static const char *STRING[] = {"Generic", "IPv4", "IPv6", "SRV"};
   return STRING[mark];
 }
 
@@ -162,7 +162,7 @@ string_for(HostDBMark mark)
 static Action *register_ShowHostDB(Continuation *c, HTTPHdr *h);
 
 HostDBMD5 &
-HostDBMD5::set_host(char const *name, int len)
+HostDBMD5::set_host(const char *name, int len)
 {
   host_name = name;
   host_len  = len;
@@ -194,7 +194,7 @@ HostDBMD5::refresh()
   MD5Context ctx;
 
   if (host_name) {
-    char const *server_line = dns_server ? dns_server->x_dns_ip_line : 0;
+    const char *server_line = dns_server ? dns_server->x_dns_ip_line : 0;
     uint8_t m               = static_cast<uint8_t>(db_mark); // be sure of the type.
 
     ctx.update(host_name, host_len);
@@ -1055,7 +1055,7 @@ HostDBContinuation::removeEvent(int /* event ATS_UNUSED */, Event *e)
 // NOTE: if "i" exists it means we already allocated the space etc, just return
 //
 HostDBInfo *
-HostDBContinuation::lookup_done(IpAddr const &ip, char const *aname, bool around_robin, unsigned int ttl_seconds, SRVHosts *srv,
+HostDBContinuation::lookup_done(IpAddr const &ip, const char *aname, bool around_robin, unsigned int ttl_seconds, SRVHosts *srv,
                                 HostDBInfo *r)
 {
   ink_assert(this_ethread() == hostDB.refcountcache->lock_for_key(md5.hash.fold())->thread_holding);
@@ -2489,14 +2489,14 @@ ink_hostdb_init(ModuleVersion v)
 struct HostFilePair {
   typedef HostFilePair self;
   IpAddr ip;
-  char const *name;
+  const char *name;
 };
 
 struct HostDBFileContinuation : public Continuation {
   typedef HostDBFileContinuation self;
 
   int idx;          ///< Working index.
-  char const *name; ///< Host name (just for debugging)
+  const char *name; ///< Host name (just for debugging)
   INK_MD5 md5;      ///< Key for entry.
   typedef std::vector<INK_MD5> Keys;
   Keys *keys;          ///< Entries from file.
@@ -2547,7 +2547,7 @@ ParseHostLine(Ptr<RefCountedHostsFileMap> &map, char *l)
 }
 
 void
-ParseHostFile(char const *path, unsigned int hostdb_hostfile_check_interval)
+ParseHostFile(const char *path, unsigned int hostdb_hostfile_check_interval)
 {
   Ptr<RefCountedHostsFileMap> parsed_hosts_file_ptr;
 

--- a/iocore/hostdb/P_HostDB.h
+++ b/iocore/hostdb/P_HostDB.h
@@ -51,5 +51,5 @@
 #define HOSTDB_MODULE_VERSION makeModuleVersion(HOSTDB_MODULE_MAJOR_VERSION, HOSTDB_MODULE_MINOR_VERSION, PRIVATE_MODULE_HEADER)
 Ptr<HostDBInfo> probe(ProxyMutex *mutex, HostDBMD5 const &md5, bool ignore_timeout);
 
-void make_md5(INK_MD5 &md5, const char *hostname, int len, int port, char const *pDNSServers, HostDBMark mark);
+void make_md5(INK_MD5 &md5, const char *hostname, int len, int port, const char *pDNSServers, HostDBMark mark);
 #endif

--- a/iocore/hostdb/P_HostDBProcessor.h
+++ b/iocore/hostdb/P_HostDBProcessor.h
@@ -75,7 +75,7 @@ enum HostDBMark {
 /** Convert a HostDB @a mark to a string.
     @return A static string.
  */
-extern char const *string_for(HostDBMark mark);
+extern const char *string_for(HostDBMark mark);
 
 inline unsigned int
 HOSTDB_CLIENT_IP_HASH(sockaddr const *lhs, sockaddr const *rhs)
@@ -399,7 +399,7 @@ struct HostDBMD5 {
 
   INK_MD5 hash; ///< The hash value.
 
-  char const *host_name; ///< Host name.
+  const char *host_name; ///< Host name.
   int host_len;          ///< Length of @a _host_name
   IpAddr ip;             ///< IP address.
   in_port_t port;        ///< IP port (host order).
@@ -419,7 +419,7 @@ struct HostDBMD5 {
   /** Assign a hostname.
       This updates the split DNS data as well.
   */
-  self &set_host(char const *name, int len);
+  self &set_host(const char *name, int len);
 };
 
 //
@@ -482,7 +482,7 @@ struct HostDBContinuation : public Continuation {
   {
     return md5.db_mark == HOSTDB_MARK_SRV;
   }
-  HostDBInfo *lookup_done(IpAddr const &ip, char const *aname, bool round_robin, unsigned int attl, SRVHosts *s = NULL,
+  HostDBInfo *lookup_done(IpAddr const &ip, const char *aname, bool round_robin, unsigned int attl, SRVHosts *s = NULL,
                           HostDBInfo *r = NULL);
   bool do_get_response(Event *e);
   void do_put_response(ClusterMachine *m, HostDBInfo *r, Continuation *cont);

--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -224,7 +224,7 @@ struct NetVCOptions {
   /// @name Debugging
   //@{
   /// Convert @a s to its string equivalent.
-  static char const *toString(addr_bind_style s);
+  static const char *toString(addr_bind_style s);
   //@}
 
 private:
@@ -610,7 +610,7 @@ public:
   }
 
   virtual int
-  populate_protocol(char const **results, int n) const
+  populate_protocol(const char **results, int n) const
   {
     return 0;
   }

--- a/iocore/net/P_SSLCertLookup.h
+++ b/iocore/net/P_SSLCertLookup.h
@@ -91,7 +91,7 @@ struct SSLCertLookup : public ConfigInfo {
       Exact matches have priority, then wildcards. Only destination based matches are checked.
       @return @c A pointer to the matched context, @c NULL if no match is found.
   */
-  SSLCertContext *find(char const *name) const;
+  SSLCertContext *find(const char *name) const;
 
   // Return the last-resort default TLS context if there is no name or address match.
   SSL_CTX *

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -240,7 +240,7 @@ public:
     return ssl ? SSL_get_cipher_name(ssl) : NULL;
   }
 
-  int populate_protocol(char const **results, int n) const;
+  int populate_protocol(const char **results, int n) const;
   const char *protocol_contains(const char *tag) const;
 
   /**
@@ -262,7 +262,7 @@ private:
   SSLNetVConnection(const SSLNetVConnection &);
   SSLNetVConnection &operator=(const SSLNetVConnection &);
 
-  const char *map_tls_protocol_to_tag(char const *proto_string) const;
+  const char *map_tls_protocol_to_tag(const char *proto_string) const;
 
   bool sslHandShakeComplete;
   bool sslClientRenegotiationAbort;

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -172,7 +172,7 @@ public:
   UnixNetVConnection();
 
   int
-  populate_protocol(char const **results, int n) const
+  populate_protocol(const char **results, int n) const
   {
     int retval = 0;
     if (n > 0) {

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -1519,7 +1519,7 @@ SSLNetVConnection::populate(Connection &con, Continuation *c, void *arg)
 }
 
 const char *
-SSLNetVConnection::map_tls_protocol_to_tag(char const *proto_string) const
+SSLNetVConnection::map_tls_protocol_to_tag(const char *proto_string) const
 {
   const char *retval    = NULL;
   const char *ssl_proto = getSSLProtocol();
@@ -1540,7 +1540,7 @@ SSLNetVConnection::map_tls_protocol_to_tag(char const *proto_string) const
 }
 
 int
-SSLNetVConnection::populate_protocol(char const **results, int n) const
+SSLNetVConnection::populate_protocol(const char **results, int n) const
 {
   int retval = 0;
   if (n > 0) {

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1502,7 +1502,7 @@ SSLInitServerContext(const SSLConfigParams *params, const ssl_user_config *sslMu
   STACK_OF(X509_NAME) *ca_list = NULL;
   unsigned char hash_buf[EVP_MAX_MD_SIZE];
   unsigned int hash_len    = 0;
-  char const *setting_cert = sslMultCertSettings ? sslMultCertSettings->cert.get() : NULL;
+  const char *setting_cert = sslMultCertSettings ? sslMultCertSettings->cert.get() : NULL;
 
   // disable selected protocols
   SSL_CTX_set_options(ctx, params->ssl_ctx_options);

--- a/lib/records/I_RecHttp.h
+++ b/lib/records/I_RecHttp.h
@@ -31,7 +31,7 @@
 #include <ts/apidefs.h>
 
 /// Load default inbound IP addresses from the configuration file.
-void RecHttpLoadIp(char const *name, ///< Name of value in configuration file.
+void RecHttpLoadIp(const char *name, ///< Name of value in configuration file.
                    IpAddr &ip4,      ///< [out] IPv4 address.
                    IpAddr &ip6       ///< [out] Ipv6 address.
                    );
@@ -169,33 +169,33 @@ public:
       The name is copied internally.
       @return The index for the registered @a name.
   */
-  int toIndex(char const *name);
+  int toIndex(const char *name);
 
   /** Get the index for @a name, registering it if needed.
       The caller @b guarantees @a name is persistent and immutable.
       @return The index for the registered @a name.
   */
-  int toIndexConst(char const *name);
+  int toIndexConst(const char *name);
 
   /** Convert a @a name to an index.
       @return The index for @a name or @c INVALID if it is not registered.
   */
-  int indexFor(char const *name) const;
+  int indexFor(const char *name) const;
 
   /** Convert an @a index to the corresponding name.
       @return A pointer to the name or @c NULL if the index isn't registered.
   */
-  char const *nameFor(int index) const;
+  const char *nameFor(int index) const;
 
   /// Mark protocols as present in @a sp_set based on the names in @a value.
   /// The names can be separated by ;/|,: and space.
   /// @internal This is separated out to make it easy to access from the plugin API
   /// implementation.
-  void markIn(char const *value, SessionProtocolSet &sp_set);
+  void markIn(const char *value, SessionProtocolSet &sp_set);
 
 protected:
   unsigned int m_n;         ///< Index of first unused slot.
-  char const *m_names[MAX]; ///< Pointers to registered names.
+  const char *m_names[MAX]; ///< Pointers to registered names.
   uint8_t m_flags[MAX];     ///< Flags for each name.
 
   static uint8_t const F_ALLOCATED = 0x1; ///< Flag for allocated by this instance.
@@ -279,7 +279,7 @@ public:
   /// @a opts should not contain any whitespace, only the option string.
   /// This object's internal state is updated as specified by @a opts.
   /// @return @c true if a port option was successfully processed, @c false otherwise.
-  bool processOptions(char const *opts ///< String containing the options.
+  bool processOptions(const char *opts ///< String containing the options.
                       );
 
   /** Global instance.
@@ -326,7 +326,7 @@ public:
       @return @c true if a valid port was found, @c false if none.
   */
   static bool loadValue(Vec<self> &ports, ///< Destination for found port data.
-                        char const *value ///< Source port data.
+                        const char *value ///< Source port data.
                         );
 
   /** Load ports from a value string into the global ports.
@@ -336,7 +336,7 @@ public:
 
       @return @c true if a valid port was found, @c false if none.
   */
-  static bool loadValue(char const *value ///< Source port data.
+  static bool loadValue(const char *value ///< Source port data.
                         );
 
   /// Load default value if @a ports is empty.
@@ -373,43 +373,43 @@ public:
             size_t n   ///< Maximum output length.
             );
 
-  static char const *const PORTS_CONFIG_NAME; ///< New unified port descriptor.
+  static const char *const PORTS_CONFIG_NAME; ///< New unified port descriptor.
 
   /// Default value if no other values can be found.
-  static char const *const DEFAULT_VALUE;
+  static const char *const DEFAULT_VALUE;
 
   // Keywords (lower case versions, but compares should be case insensitive)
-  static char const *const OPT_FD_PREFIX;               ///< Prefix for file descriptor value.
-  static char const *const OPT_OUTBOUND_IP_PREFIX;      ///< Prefix for inbound IP address.
-  static char const *const OPT_INBOUND_IP_PREFIX;       ///< Prefix for outbound IP address.
-  static char const *const OPT_IPV6;                    ///< IPv6.
-  static char const *const OPT_IPV4;                    ///< IPv4
-  static char const *const OPT_TRANSPARENT_INBOUND;     ///< Inbound transparent.
-  static char const *const OPT_TRANSPARENT_OUTBOUND;    ///< Outbound transparent.
-  static char const *const OPT_TRANSPARENT_FULL;        ///< Full transparency.
-  static char const *const OPT_TRANSPARENT_PASSTHROUGH; ///< Pass-through non-HTTP.
-  static char const *const OPT_SSL;                     ///< SSL (experimental)
-  static char const *const OPT_PLUGIN;                  ///< Protocol Plugin handle (experimental)
-  static char const *const OPT_BLIND_TUNNEL;            ///< Blind tunnel.
-  static char const *const OPT_COMPRESSED;              ///< Compressed.
-  static char const *const OPT_HOST_RES_PREFIX;         ///< Set DNS family preference.
-  static char const *const OPT_PROTO_PREFIX;            ///< Transport layer protocols.
+  static const char *const OPT_FD_PREFIX;               ///< Prefix for file descriptor value.
+  static const char *const OPT_OUTBOUND_IP_PREFIX;      ///< Prefix for inbound IP address.
+  static const char *const OPT_INBOUND_IP_PREFIX;       ///< Prefix for outbound IP address.
+  static const char *const OPT_IPV6;                    ///< IPv6.
+  static const char *const OPT_IPV4;                    ///< IPv4
+  static const char *const OPT_TRANSPARENT_INBOUND;     ///< Inbound transparent.
+  static const char *const OPT_TRANSPARENT_OUTBOUND;    ///< Outbound transparent.
+  static const char *const OPT_TRANSPARENT_FULL;        ///< Full transparency.
+  static const char *const OPT_TRANSPARENT_PASSTHROUGH; ///< Pass-through non-HTTP.
+  static const char *const OPT_SSL;                     ///< SSL (experimental)
+  static const char *const OPT_PLUGIN;                  ///< Protocol Plugin handle (experimental)
+  static const char *const OPT_BLIND_TUNNEL;            ///< Blind tunnel.
+  static const char *const OPT_COMPRESSED;              ///< Compressed.
+  static const char *const OPT_HOST_RES_PREFIX;         ///< Set DNS family preference.
+  static const char *const OPT_PROTO_PREFIX;            ///< Transport layer protocols.
 
   static Vec<self> &m_global; ///< Global ("default") data.
 
 protected:
   /// Process @a value for DNS resolution family preferences.
-  void processFamilyPreference(char const *value);
+  void processFamilyPreference(const char *value);
   /// Process @a value for session protocol preferences.
-  void processSessionProtocolPreference(char const *value);
+  void processSessionProtocolPreference(const char *value);
 
   /** Check a prefix option and find the value.
       @return The address of the start of the value, or @c NULL if the prefix doesn't match.
   */
 
-  char const *checkPrefix(char const *src ///< Input text
+  const char *checkPrefix(char const *src ///< Input text
                           ,
-                          char const *prefix ///< Keyword prefix
+                          const char *prefix ///< Keyword prefix
                           ,
                           size_t prefix_len ///< Length of keyword prefix.
                           );
@@ -439,7 +439,7 @@ HttpProxyPort::outboundIp(uint16_t family)
 }
 
 inline bool
-HttpProxyPort::loadValue(char const *value)
+HttpProxyPort::loadValue(const char *value)
 {
   return self::loadValue(m_global, value);
 }

--- a/lib/records/RecConfigParse.cc
+++ b/lib/records/RecConfigParse.cc
@@ -124,7 +124,7 @@ RecConfigFileParse(const char *path, RecConfigEntryCallback handler, bool inc_ve
   int line_num;
 
   char *rec_type_str, *name_str, *data_type_str, *data_str;
-  char const *value_str;
+  const char *value_str;
   RecT rec_type;
   RecDataT data_type;
 

--- a/lib/records/RecCore.cc
+++ b/lib/records/RecCore.cc
@@ -1258,7 +1258,7 @@ void
 RecConfigWarnIfUnregistered()
 {
   RecDumpRecords(RECT_CONFIG,
-                 [](RecT, void *, int registered_p, char const *name, int, RecData *) -> void {
+                 [](RecT, void *, int registered_p, const char *name, int, RecData *) -> void {
                    if (!registered_p)
                      Warning("Unrecognized configuration value '%s'", name);
                  },

--- a/lib/records/RecHttp.cc
+++ b/lib/records/RecHttp.cc
@@ -69,7 +69,7 @@ SessionProtocolSet DEFAULT_NON_TLS_SESSION_PROTOCOL_SET;
 SessionProtocolSet DEFAULT_TLS_SESSION_PROTOCOL_SET;
 
 void
-RecHttpLoadIp(char const *value_name, IpAddr &ip4, IpAddr &ip6)
+RecHttpLoadIp(const char *value_name, IpAddr &ip4, IpAddr &ip6)
 {
   char value[1024];
   ip4.invalidate();
@@ -78,7 +78,7 @@ RecHttpLoadIp(char const *value_name, IpAddr &ip4, IpAddr &ip6)
     Tokenizer tokens(", ");
     int n_addrs = tokens.Initialize(value);
     for (int i = 0; i < n_addrs; ++i) {
-      char const *host = tokens[i];
+      const char *host = tokens[i];
       IpEndpoint tmp4, tmp6;
       // For backwards compatibility we need to support the use of host names
       // for the address to bind.
@@ -104,30 +104,30 @@ RecHttpLoadIp(char const *value_name, IpAddr &ip4, IpAddr &ip6)
   }
 }
 
-char const *const HttpProxyPort::DEFAULT_VALUE = "8080";
+const char *const HttpProxyPort::DEFAULT_VALUE = "8080";
 
-char const *const HttpProxyPort::PORTS_CONFIG_NAME = "proxy.config.http.server_ports";
+const char *const HttpProxyPort::PORTS_CONFIG_NAME = "proxy.config.http.server_ports";
 
 // "_PREFIX" means the option contains additional data.
 // Each has a corresponding _LEN value that is the length of the option text.
 // Options without _PREFIX are just flags with no additional data.
 
-char const *const HttpProxyPort::OPT_FD_PREFIX          = "fd";
-char const *const HttpProxyPort::OPT_OUTBOUND_IP_PREFIX = "ip-out";
-char const *const HttpProxyPort::OPT_INBOUND_IP_PREFIX  = "ip-in";
-char const *const HttpProxyPort::OPT_HOST_RES_PREFIX    = "ip-resolve";
-char const *const HttpProxyPort::OPT_PROTO_PREFIX       = "proto";
+const char *const HttpProxyPort::OPT_FD_PREFIX          = "fd";
+const char *const HttpProxyPort::OPT_OUTBOUND_IP_PREFIX = "ip-out";
+const char *const HttpProxyPort::OPT_INBOUND_IP_PREFIX  = "ip-in";
+const char *const HttpProxyPort::OPT_HOST_RES_PREFIX    = "ip-resolve";
+const char *const HttpProxyPort::OPT_PROTO_PREFIX       = "proto";
 
-char const *const HttpProxyPort::OPT_IPV6                    = "ipv6";
-char const *const HttpProxyPort::OPT_IPV4                    = "ipv4";
-char const *const HttpProxyPort::OPT_TRANSPARENT_INBOUND     = "tr-in";
-char const *const HttpProxyPort::OPT_TRANSPARENT_OUTBOUND    = "tr-out";
-char const *const HttpProxyPort::OPT_TRANSPARENT_FULL        = "tr-full";
-char const *const HttpProxyPort::OPT_TRANSPARENT_PASSTHROUGH = "tr-pass";
-char const *const HttpProxyPort::OPT_SSL                     = "ssl";
-char const *const HttpProxyPort::OPT_PLUGIN                  = "plugin";
-char const *const HttpProxyPort::OPT_BLIND_TUNNEL            = "blind";
-char const *const HttpProxyPort::OPT_COMPRESSED              = "compressed";
+const char *const HttpProxyPort::OPT_IPV6                    = "ipv6";
+const char *const HttpProxyPort::OPT_IPV4                    = "ipv4";
+const char *const HttpProxyPort::OPT_TRANSPARENT_INBOUND     = "tr-in";
+const char *const HttpProxyPort::OPT_TRANSPARENT_OUTBOUND    = "tr-out";
+const char *const HttpProxyPort::OPT_TRANSPARENT_FULL        = "tr-full";
+const char *const HttpProxyPort::OPT_TRANSPARENT_PASSTHROUGH = "tr-pass";
+const char *const HttpProxyPort::OPT_SSL                     = "ssl";
+const char *const HttpProxyPort::OPT_PLUGIN                  = "plugin";
+const char *const HttpProxyPort::OPT_BLIND_TUNNEL            = "blind";
+const char *const HttpProxyPort::OPT_COMPRESSED              = "compressed";
 
 // File local constants.
 namespace
@@ -192,10 +192,10 @@ HttpProxyPort::findHttp(Group const &ports, uint16_t family)
   return zret;
 }
 
-char const *
-HttpProxyPort::checkPrefix(char const *src, char const *prefix, size_t prefix_len)
+const char *
+HttpProxyPort::checkPrefix(const char *src, char const *prefix, size_t prefix_len)
 {
-  char const *zret = 0;
+  const char *zret = 0;
   if (0 == strncasecmp(prefix, src, prefix_len)) {
     src += prefix_len;
     if ('-' == *src || '=' == *src) {
@@ -232,7 +232,7 @@ HttpProxyPort::loadDefaultIfEmpty(Group &ports)
 }
 
 bool
-HttpProxyPort::loadValue(Vec<self> &ports, char const *text)
+HttpProxyPort::loadValue(Vec<self> &ports, const char *text)
 {
   unsigned old_port_length = ports.length(); // remember this.
   if (text && *text) {
@@ -240,7 +240,7 @@ HttpProxyPort::loadValue(Vec<self> &ports, char const *text)
     int n_ports = tokens.Initialize(text);
     if (n_ports > 0) {
       for (int p = 0; p < n_ports; ++p) {
-        char const *elt = tokens[p];
+        const char *elt = tokens[p];
         HttpProxyPort entry;
         if (entry.processOptions(elt)) {
           ports.push_back(entry);
@@ -254,14 +254,14 @@ HttpProxyPort::loadValue(Vec<self> &ports, char const *text)
 }
 
 bool
-HttpProxyPort::processOptions(char const *opts)
+HttpProxyPort::processOptions(const char *opts)
 {
   bool zret           = false; // found a port?
   bool af_set_p       = false; // AF explicitly specified?
   bool host_res_set_p = false; // Host resolution order set explicitly?
   bool sp_set_p       = false; // Session protocol set explicitly?
   bool bracket_p      = false; // found an open bracket in the input?
-  char const *value;           // Temp holder for value of a prefix option.
+  const char *value;           // Temp holder for value of a prefix option.
   IpAddr ip;                   // temp for loading IP addresses.
   Vec<char *> values;          // Pointers to single option values.
 
@@ -296,7 +296,7 @@ HttpProxyPort::processOptions(char const *opts)
   }
 
   for (int i = 0, n_items = values.length(); i < n_items; ++i) {
-    char const *item = values[i];
+    const char *item = values[i];
     if (isdigit(item[0])) { // leading digit -> port value
       char *ptr;
       int port = strtoul(item, &ptr, 10);
@@ -420,20 +420,20 @@ HttpProxyPort::processOptions(char const *opts)
 }
 
 void
-HttpProxyPort::processFamilyPreference(char const *value)
+HttpProxyPort::processFamilyPreference(const char *value)
 {
   parse_host_res_preference(value, m_host_res_preference);
 }
 
 void
-HttpProxyPort::processSessionProtocolPreference(char const *value)
+HttpProxyPort::processSessionProtocolPreference(const char *value)
 {
   m_session_protocol_preference.markAllOut();
   globalSessionProtocolNameRegistry.markIn(value, m_session_protocol_preference);
 }
 
 void
-SessionProtocolNameRegistry::markIn(char const *value, SessionProtocolSet &sp_set)
+SessionProtocolNameRegistry::markIn(const char *value, SessionProtocolSet &sp_set)
 {
   int n; // # of tokens
   Tokenizer tokens(" ;|,:");
@@ -441,7 +441,7 @@ SessionProtocolNameRegistry::markIn(char const *value, SessionProtocolSet &sp_se
   n = tokens.Initialize(value);
 
   for (int i = 0; i < n; ++i) {
-    char const *elt = tokens[i];
+    const char *elt = tokens[i];
 
     /// Check special cases
     if (0 == strcasecmp(elt, TS_ALPN_PROTOCOL_GROUP_HTTP)) {
@@ -651,10 +651,10 @@ ts_session_protocol_well_known_name_indices_init()
 const char *
 RecNormalizeProtoTag(const char *tag)
 {
-  char const *retval = NULL;
+  const char *retval = NULL;
   InkHashTableValue value;
   if (ink_hash_table_lookup(TSProtoTags, tag, &value)) {
-    retval = reinterpret_cast<char const *>(value);
+    retval = reinterpret_cast<const char *>(value);
   }
   return retval;
 }
@@ -669,13 +669,13 @@ SessionProtocolNameRegistry::~SessionProtocolNameRegistry()
 {
   for (size_t i = 0; i < m_n; ++i) {
     if (m_flags[i] & F_ALLOCATED) {
-      ats_free(const_cast<char *>(m_names[i])); // blech - ats_free won't take a char const*
+      ats_free(const_cast<char *>(m_names[i])); // blech - ats_free won't take a const char*
     }
   }
 }
 
 int
-SessionProtocolNameRegistry::toIndex(char const *name)
+SessionProtocolNameRegistry::toIndex(const char *name)
 {
   int zret = this->indexFor(name);
   if (INVALID == zret) {
@@ -691,7 +691,7 @@ SessionProtocolNameRegistry::toIndex(char const *name)
 }
 
 int
-SessionProtocolNameRegistry::toIndexConst(char const *name)
+SessionProtocolNameRegistry::toIndexConst(const char *name)
 {
   int zret = this->indexFor(name);
   if (INVALID == zret) {
@@ -706,7 +706,7 @@ SessionProtocolNameRegistry::toIndexConst(char const *name)
 }
 
 int
-SessionProtocolNameRegistry::indexFor(char const *name) const
+SessionProtocolNameRegistry::indexFor(const char *name) const
 {
   for (size_t i = 0; i < m_n; ++i) {
     if (0 == strcasecmp(name, m_names[i])) {
@@ -716,7 +716,7 @@ SessionProtocolNameRegistry::indexFor(char const *name) const
   return INVALID;
 }
 
-char const *
+const char *
 SessionProtocolNameRegistry::nameFor(int idx) const
 {
   return 0 <= idx && idx < static_cast<int>(m_n) ? m_names[idx] : 0;

--- a/lib/ts/MMH.cc
+++ b/lib/ts/MMH.cc
@@ -368,7 +368,7 @@ MMHContext::MMHContext()
 bool
 MMHContext::update(void const *data, int length)
 {
-  return 0 == ink_code_incr_MMH_update(&_ctx, static_cast<char const *>(data), length);
+  return 0 == ink_code_incr_MMH_update(&_ctx, static_cast<const char *>(data), length);
 }
 
 bool

--- a/lib/ts/MatcherUtils.cc
+++ b/lib/ts/MatcherUtils.cc
@@ -156,11 +156,11 @@ unescapifyStr(char *buffer)
   return (write - buffer);
 }
 
-char const *
+const char *
 ExtractIpRange(char *match_str, in_addr_t *min, in_addr_t *max)
 {
   IpEndpoint ip_min, ip_max;
-  char const *zret = ExtractIpRange(match_str, &ip_min.sa, &ip_max.sa);
+  const char *zret = ExtractIpRange(match_str, &ip_min.sa, &ip_max.sa);
   if (0 == zret) { // success
     if (ats_is_ip4(&ip_min) && ats_is_ip4(&ip_max)) {
       if (min)

--- a/lib/ts/MatcherUtils.h
+++ b/lib/ts/MatcherUtils.h
@@ -44,16 +44,16 @@ int unescapifyStr(char *buffer);
     @a min and @a max should be at least the size of @c sockaddr_in6 to hold
     an IP address.
 */
-char const *ExtractIpRange(char *match_str, sockaddr *min, sockaddr *max);
+const char *ExtractIpRange(char *match_str, sockaddr *min, sockaddr *max);
 
 /// Convenience overload for IPv4.
-char const *ExtractIpRange(char *match_str,
+const char *ExtractIpRange(char *match_str,
                            in_addr_t *addr1, ///< [in,out] Returned address in host order.
                            in_addr_t *addr2  ///< [in,out] Returned address in host order.
                            );
 
 /// Convenience overload for IPv6.
-inline char const *
+inline const char *
 ExtractIpRange(char *match_str,
                sockaddr_in6 *addr1, ///< [in,out] Returned address in network order.
                sockaddr_in6 *addr2  ///< [in,out] Returned address in network order.

--- a/lib/ts/ink_cap.cc
+++ b/lib/ts/ink_cap.cc
@@ -138,7 +138,7 @@ death_signal()
 }
 
 void
-DebugCapabilities(char const *tag)
+DebugCapabilities(const char *tag)
 {
   DEBUG_CREDENTIALS(tag);
   DEBUG_PRIVILEGES(tag);
@@ -308,7 +308,7 @@ EnableDeathSignal(int signum)
 }
 
 int
-elevating_open(char const *path, unsigned int flags, unsigned int fperms)
+elevating_open(const char *path, unsigned int flags, unsigned int fperms)
 {
   int fd = open(path, flags, fperms);
   if (fd < 0 && (EPERM == errno || EACCES == errno)) {
@@ -319,7 +319,7 @@ elevating_open(char const *path, unsigned int flags, unsigned int fperms)
 }
 
 int
-elevating_open(char const *path, unsigned int flags)
+elevating_open(const char *path, unsigned int flags)
 {
   int fd = open(path, flags);
   if (fd < 0 && (EPERM == errno || EACCES == errno)) {
@@ -330,7 +330,7 @@ elevating_open(char const *path, unsigned int flags)
 }
 
 FILE *
-elevating_fopen(char const *path, const char *mode)
+elevating_fopen(const char *path, const char *mode)
 {
   FILE *f = fopen(path, mode);
   if (NULL == f && (EPERM == errno || EACCES == errno)) {

--- a/lib/ts/ink_cap.h
+++ b/lib/ts/ink_cap.h
@@ -30,7 +30,7 @@
 #include "ts/ink_mutex.h"
 
 /// Generate a debug message with the current capabilities for the process.
-extern void DebugCapabilities(char const *tag ///< Debug message tag.
+extern void DebugCapabilities(const char *tag ///< Debug message tag.
                               );
 /// Set capabilities to persist across change of user id.
 /// @return true on success
@@ -45,11 +45,11 @@ extern bool RestrictCapabilities();
     the @c open would succeed without elevation. So, try that first and ask for
     elevation only on an explicit permission failure.
 */
-extern int elevating_open(char const *path, unsigned int flags, unsigned int fperms);
+extern int elevating_open(const char *path, unsigned int flags, unsigned int fperms);
 /// Open a file, elevating privilege only if needed.
-extern int elevating_open(char const *path, unsigned int flags);
+extern int elevating_open(const char *path, unsigned int flags);
 /// Open a file, elevating privilege only if needed.
-extern FILE *elevating_fopen(char const *path, const char *mode);
+extern FILE *elevating_fopen(const char *path, const char *mode);
 
 /** Control generate of core file on crash.
     @a flag sets whether core files are enabled on crash.

--- a/lib/ts/ink_code.cc
+++ b/lib/ts/ink_code.cc
@@ -80,7 +80,7 @@ ink_code_incr_md5_final(char *sixteen_byte_hash_pointer, INK_DIGEST_CTX *context
   @return always returns 0, maybe some error checking should be done
 */
 int
-ink_code_md5(unsigned char const *input, int input_length, unsigned char *sixteen_byte_hash_pointer)
+ink_code_md5(unsigned const char *input, int input_length, unsigned char *sixteen_byte_hash_pointer)
 {
   MD5_CTX context;
 

--- a/lib/ts/ink_code.h
+++ b/lib/ts/ink_code.h
@@ -35,7 +35,7 @@ typedef MD5_CTX INK_DIGEST_CTX;
   Wrappers around the MD5 functions, all of this should be depericated and just use the functions directly
 */
 
-inkcoreapi int ink_code_md5(unsigned char const *input, int input_length, unsigned char *sixteen_byte_hash_pointer);
+inkcoreapi int ink_code_md5(unsigned const char *input, int input_length, unsigned char *sixteen_byte_hash_pointer);
 inkcoreapi char *ink_code_to_hex_str(char *dest33, uint8_t const *md5);
 
 inkcoreapi int ink_code_incr_md5_init(INK_DIGEST_CTX *context);

--- a/lib/ts/ink_file.cc
+++ b/lib/ts/ink_file.cc
@@ -176,7 +176,7 @@ ink_filepath_merge(char *path, int pathsz, const char *rootpath, const char *add
   if (!rootpath) {
     // Start with the current working path.  This is bass akwards,
     // but required since the compiler (at least vc) doesn't like
-    // passing the address of a char const* for a char** arg.
+    // passing the address of a const char* for a char** arg.
     //
     if (!getcwd(curdir, sizeof(curdir))) {
       return errno;

--- a/lib/ts/ink_inet.cc
+++ b/lib/ts/ink_inet.cc
@@ -155,7 +155,7 @@ ink_inet_addr(const char *s)
 const char *
 ats_ip_ntop(const struct sockaddr *addr, char *dst, size_t size)
 {
-  char const *zret = 0;
+  const char *zret = 0;
 
   switch (addr->sa_family) {
   case AF_INET:
@@ -172,13 +172,13 @@ ats_ip_ntop(const struct sockaddr *addr, char *dst, size_t size)
   return zret;
 }
 
-char const *
+const char *
 ats_ip_family_name(int family)
 {
   return AF_INET == family ? "IPv4" : AF_INET6 == family ? "IPv6" : "Unspec";
 }
 
-char const *
+const char *
 ats_ip_nptop(sockaddr const *addr, char *dst, size_t size)
 {
   char buff[INET6_ADDRPORTSTRLEN];
@@ -332,7 +332,7 @@ ats_ip_to_hex(sockaddr const *src, char *dst, size_t len)
 {
   int zret = 0;
   ink_assert(len);
-  char const *dst_limit = dst + len - 1; // reserve null space.
+  const char *dst_limit = dst + len - 1; // reserve null space.
   if (ats_is_ip(src)) {
     uint8_t const *data = ats_ip_addr8_cast(src);
     for (uint8_t const *src_limit = data + ats_ip_addr_size(src); data < src_limit && dst + 1 < dst_limit; ++data, zret += 2) {
@@ -360,7 +360,7 @@ ats_ip_set(sockaddr *dst, IpAddr const &addr, uint16_t port)
 }
 
 int
-IpAddr::load(char const *text)
+IpAddr::load(const char *text)
 {
   IpEndpoint ip;
   int zret = ats_ip_pton(text, &ip);
@@ -464,7 +464,7 @@ IpAddr::cmp(self const &that) const
 }
 
 int
-ats_ip_getbestaddrinfo(char const *host, IpEndpoint *ip4, IpEndpoint *ip6)
+ats_ip_getbestaddrinfo(const char *host, IpEndpoint *ip4, IpEndpoint *ip6)
 {
   int zret = -1;
   int port = 0; // port value to assign if we find an address.
@@ -564,7 +564,7 @@ ats_ip_check_characters(ts::ConstBuffer text)
 {
   bool found_colon = false;
   bool found_hex   = false;
-  for (char const *p = text.data(), *limit = p + text.size(); p < limit; ++p)
+  for (const char *p = text.data(), *limit = p + text.size(); p < limit; ++p)
     if (':' == *p)
       found_colon = true;
     else if ('.' == *p || isdigit(*p)) /* empty */
@@ -579,10 +579,10 @@ ats_ip_check_characters(ts::ConstBuffer text)
 
 // Need to declare this type globally so gcc 4.4 can use it in the countof() template ...
 struct ip_parse_spec {
-  char const *hostspec;
-  char const *host;
-  char const *port;
-  char const *rest;
+  const char *hostspec;
+  const char *host;
+  const char *port;
+  const char *rest;
 };
 
 REGRESSION_TEST(Ink_Inet)(RegressionTest *t, int /* atype */, int *pstatus)

--- a/lib/ts/ink_inet.h
+++ b/lib/ts/ink_inet.h
@@ -213,7 +213,7 @@ ats_ip_invalidate(IpEndpoint *ip)
 /** Get a string name for an IP address family.
     @return The string name (never @c NULL).
 */
-char const *ats_ip_family_name(int family);
+const char *ats_ip_family_name(int family);
 
 /// Test for IP protocol.
 /// @return @c true if the address is IP, @c false otherwise.
@@ -1009,7 +1009,7 @@ ats_ip6_set(IpEndpoint *dst,      ///< Destination storage.
 /** Write a null terminated string for @a addr to @a dst.
     A buffer of size INET6_ADDRSTRLEN suffices, including a terminating nul.
  */
-char const *ats_ip_ntop(const sockaddr *addr, ///< Address.
+const char *ats_ip_ntop(const sockaddr *addr, ///< Address.
                         char *dst,            ///< Output buffer.
                         size_t size           ///< Length of buffer.
                         );
@@ -1017,7 +1017,7 @@ char const *ats_ip_ntop(const sockaddr *addr, ///< Address.
 /** Write a null terminated string for @a addr to @a dst.
     A buffer of size INET6_ADDRSTRLEN suffices, including a terminating nul.
  */
-inline char const *
+inline const char *
 ats_ip_ntop(IpEndpoint const *addr, ///< Address.
             char *dst,              ///< Output buffer.
             size_t size             ///< Length of buffer.
@@ -1036,7 +1036,7 @@ typedef char ip_port_text_buffer[INET6_ADDRPORTSTRLEN];
 /** Write a null terminated string for @a addr to @a dst with port.
     A buffer of size INET6_ADDRPORTSTRLEN suffices, including a terminating nul.
  */
-char const *ats_ip_nptop(const sockaddr *addr, ///< Address.
+const char *ats_ip_nptop(const sockaddr *addr, ///< Address.
                          char *dst,            ///< Output buffer.
                          size_t size           ///< Length of buffer.
                          );
@@ -1044,7 +1044,7 @@ char const *ats_ip_nptop(const sockaddr *addr, ///< Address.
 /** Write a null terminated string for @a addr to @a dst with port.
     A buffer of size INET6_ADDRPORTSTRLEN suffices, including a terminating nul.
  */
-inline char const *
+inline const char *
 ats_ip_nptop(IpEndpoint const *addr, ///< Address.
              char *dst,              ///< Output buffer.
              size_t size             ///< Length of buffer.
@@ -1085,7 +1085,7 @@ int ats_ip_pton(const ts::ConstBuffer &text, ///< [in] text.
     @return 0 on success, non-zero on failure.
 */
 inline int
-ats_ip_pton(char const *text,  ///< [in] text.
+ats_ip_pton(const char *text,  ///< [in] text.
             sockaddr_in6 *addr ///< [out] address
             )
 {
@@ -1141,7 +1141,7 @@ ats_ip_pton(const char *text, ///< [in] text.
     @see getaddrinfo
  */
 
-int ats_ip_getbestaddrinfo(char const *name, ///< [in] Address name (IPv4, IPv6, or host name)
+int ats_ip_getbestaddrinfo(const char *name, ///< [in] Address name (IPv4, IPv6, or host name)
                            IpEndpoint *ip4,  ///< [out] Storage for IPv4 address.
                            IpEndpoint *ip6   ///< [out] Storage for IPv6 address
                            );
@@ -1217,7 +1217,7 @@ struct IpAddr {
       otherwise this object is invalidated.
       @return 0 on success, non-zero on failure.
   */
-  int load(char const *str ///< Nul terminated input string.
+  int load(const char *str ///< Nul terminated input string.
            );
 
   /** Load from string.
@@ -1467,7 +1467,7 @@ sockaddr *ats_ip_set(sockaddr *dst,      ///< Destination storage.
     @return 0 on success, non-zero on failure.
 */
 inline int
-ats_ip_pton(char const *text, ///< [in] text.
+ats_ip_pton(const char *text, ///< [in] text.
             IpAddr &addr      ///< [out] address
             )
 {

--- a/lib/ts/ink_memory.h
+++ b/lib/ts/ink_memory.h
@@ -505,7 +505,7 @@ path_join(ats_scoped_str const &lhs, ats_scoped_str const &rhs)
 {
   size_t ln        = strlen(lhs);
   size_t rn        = strlen(rhs);
-  char const *rptr = rhs; // May need to be modified.
+  const char *rptr = rhs; // May need to be modified.
 
   if (ln && lhs[ln - 1] == '/')
     --ln; // drop trailing separator.

--- a/lib/ts/ink_res_init.cc
+++ b/lib/ts/ink_res_init.cc
@@ -97,9 +97,9 @@ HostResPreferenceOrder const HOST_RES_DEFAULT_PREFERENCE_ORDER = {HOST_RES_PREFE
 
 HostResPreferenceOrder host_res_default_preference_order;
 
-char const *const HOST_RES_PREFERENCE_STRING[N_HOST_RES_PREFERENCE] = {"only", "client", "ipv4", "ipv6"};
+const char *const HOST_RES_PREFERENCE_STRING[N_HOST_RES_PREFERENCE] = {"only", "client", "ipv4", "ipv6"};
 
-char const *const HOST_RES_STYLE_STRING[] = {"invalid", "IPv4", "IPv4 only", "IPv6", "IPv6 only"};
+const char *const HOST_RES_STYLE_STRING[] = {"invalid", "IPv4", "IPv4 only", "IPv6", "IPv6 only"};
 
 /*%
  * This routine is for closing the socket if a virtual circuit is used and
@@ -561,7 +561,7 @@ ink_res_init(ink_res_state statp,         ///< State object to update.
 }
 
 void
-parse_host_res_preference(char const *value, HostResPreferenceOrder order)
+parse_host_res_preference(const char *value, HostResPreferenceOrder order)
 {
   Tokenizer tokens(";/|");
   // preference from the config string.
@@ -576,7 +576,7 @@ parse_host_res_preference(char const *value, HostResPreferenceOrder order)
     found[i] = false;
 
   for (i = 0; i < n && np < N_HOST_RES_PREFERENCE_ORDER; ++i) {
-    char const *elt = tokens[i];
+    const char *elt = tokens[i];
     // special case none/only because that terminates the sequence.
     if (0 == strcasecmp(elt, HOST_RES_PREFERENCE_STRING[HOST_RES_PREFER_NONE])) {
       found[HOST_RES_PREFER_NONE] = true;

--- a/lib/ts/ink_resolver.h
+++ b/lib/ts/ink_resolver.h
@@ -164,7 +164,7 @@ extern HostResPreferenceOrder const HOST_RES_DEFAULT_PREFERENCE_ORDER;
 /// Global (configurable) default.
 extern HostResPreferenceOrder host_res_default_preference_order;
 /// String versions of @c FamilyPreference
-extern char const *const HOST_RES_PREFERENCE_STRING[N_HOST_RES_PREFERENCE];
+extern const char *const HOST_RES_PREFERENCE_STRING[N_HOST_RES_PREFERENCE];
 
 /// IP family to use in a DNS query for a host address.
 /// Used during DNS query operations.
@@ -177,7 +177,7 @@ enum HostResStyle {
 };
 
 /// Strings for host resolution styles
-extern char const *const HOST_RES_STYLE_STRING[];
+extern const char *const HOST_RES_STYLE_STRING[];
 
 /// Caclulate the effective resolution preferences.
 extern HostResStyle ats_host_res_from(int family,            ///< Connection family
@@ -188,7 +188,7 @@ extern HostResStyle ats_host_res_match(sockaddr const *addr);
 
 /** Parse a host resolution configuration string.
  */
-extern void parse_host_res_preference(char const *value,           ///< [in] Configuration string.
+extern void parse_host_res_preference(const char *value,           ///< [in] Configuration string.
                                       HostResPreferenceOrder order /// [out] Order to update.
                                       );
 

--- a/lib/tsconfig/TsConfigGrammar.c
+++ b/lib/tsconfig/TsConfigGrammar.c
@@ -232,7 +232,7 @@ int tsconfigparse ();
 int tsconfigerror(
   yyscan_t lexer ATS_UNUSED,
   struct TsConfigHandlers* handlers,
-  char const* text
+  const char* text
 ) {
   return (handlers && handlers->error._f)
     ? handlers->error._f(handlers->error._data, text)
@@ -985,7 +985,7 @@ yytnamerr (char *yyres, const char *yystr)
   if (*yystr == '"')
     {
       YYSIZE_T yyn = 0;
-      char const *yyp = yystr;
+      const char *yyp = yystr;
 
       for (;;)
 	switch (*++yyp)
@@ -1037,7 +1037,7 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
   /* Internationalized format string. */
   const char *yyformat = YY_NULL;
   /* Arguments of yyformat. */
-  char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
+  const char *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
   /* Number of reported tokens (one for the "unexpected", one per
      "expected"). */
   int yycount = 0;
@@ -1605,7 +1605,7 @@ yyerrlab:
 # define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, \
                                         yyssp, yytoken)
       {
-        char const *yymsgp = YY_("syntax error");
+        const char *yymsgp = YY_("syntax error");
         int yysyntax_error_status;
         yysyntax_error_status = YYSYNTAX_ERROR;
         if (yysyntax_error_status == 0)

--- a/lib/wccp/WccpConfig.cc
+++ b/lib/wccp/WccpConfig.cc
@@ -56,29 +56,29 @@ using namespace wccp;
 std::vector<uint32_t> Seed_Router;
 
 // Names used for various elements and properties.
-static char const *const SVC_NAME = "service";
+static const char *const SVC_NAME = "service";
 
-static char const *const SVC_PROP_ID           = "id";
-static char const *const SVC_PROP_TYPE         = "type";
-static char const *const SVC_PROP_PRIORITY     = "priority";
-static char const *const SVC_PROP_PROTOCOL     = "protocol";
-static char const *const SVC_PROP_PRIMARY_HASH = "primary-hash";
-static char const *const SVC_PROP_ALT_HASH     = "alt-hash";
-static char const *const SVC_PROP_PORTS        = "ports";
-static char const *const SVC_PROP_PORT_TYPE    = "port-type";
-static char const *const SVC_PROP_SECURITY     = "security";
-static char const *const SVC_PROP_ROUTERS      = "routers";
-static char const *const SVC_PROP_FORWARD      = "forward";
-static char const *const SVC_PROP_RETURN       = "return";
-static char const *const SVC_PROP_ASSIGN       = "assignment";
-static char const *const SVC_PROP_PROC         = "proc-name";
+static const char *const SVC_PROP_ID           = "id";
+static const char *const SVC_PROP_TYPE         = "type";
+static const char *const SVC_PROP_PRIORITY     = "priority";
+static const char *const SVC_PROP_PROTOCOL     = "protocol";
+static const char *const SVC_PROP_PRIMARY_HASH = "primary-hash";
+static const char *const SVC_PROP_ALT_HASH     = "alt-hash";
+static const char *const SVC_PROP_PORTS        = "ports";
+static const char *const SVC_PROP_PORT_TYPE    = "port-type";
+static const char *const SVC_PROP_SECURITY     = "security";
+static const char *const SVC_PROP_ROUTERS      = "routers";
+static const char *const SVC_PROP_FORWARD      = "forward";
+static const char *const SVC_PROP_RETURN       = "return";
+static const char *const SVC_PROP_ASSIGN       = "assignment";
+static const char *const SVC_PROP_PROC         = "proc-name";
 
-static char const *const SECURITY_PROP_OPTION = "option";
-static char const *const SECURITY_PROP_KEY    = "key";
+static const char *const SECURITY_PROP_OPTION = "option";
+static const char *const SECURITY_PROP_KEY    = "key";
 
 /// Helper structure for processing configuration strings.
 struct CfgString {
-  char const *m_text; ///< Text value of the option.
+  const char *m_text; ///< Text value of the option.
   bool m_found;       ///< String was found.
 };
 typedef std::vector<CfgString> CfgOpts;
@@ -123,7 +123,7 @@ operator<<(std::ostream &out, ValueNamePrinter const &v)
 }
 
 #if 0 /* silence -Wunused-function */
-ts::Errata::Message File_Syntax_Error(int line, char const* text) {
+ts::Errata::Message File_Syntax_Error(int line, const char* text) {
   std::ostringstream out;
   out << "Service configuration error. Line "
       << line
@@ -132,7 +132,7 @@ ts::Errata::Message File_Syntax_Error(int line, char const* text) {
   return ts::Errata::Message(1, LVL_FATAL, out.str());
 }
 
-ts::Errata::Message File_Read_Error(char const* text) {
+ts::Errata::Message File_Read_Error(const char* text) {
   std::ostringstream out;
   out << "Failed to parse configuration file."
       << ": " << text
@@ -187,7 +187,7 @@ Service_Type_Invalid(ts::ConstBuffer const &text, int line)
 }
 
 ts::Errata::Message
-Prop_Not_Found(char const *prop_name, char const *group_name, int line)
+Prop_Not_Found(const char *prop_name, char const *group_name, int line)
 {
   std::ostringstream out;
   out << "Required '" << prop_name << "' property not found in '" << group_name << "' at line " << line << ".";
@@ -215,7 +215,7 @@ Prop_List_Invalid_Type(Value const &elt_cfg, ///< List element.
 }
 
 ts::Errata::Message
-Svc_Prop_Out_Of_Range(char const *name, Value const &elt_cfg, int v, int min, int max)
+Svc_Prop_Out_Of_Range(const char *name, Value const &elt_cfg, int v, int min, int max)
 {
   std::ostringstream out;
   out << "Service property '" << name << "' at line " << elt_cfg.getSourceLine() << " has a value " << v
@@ -224,7 +224,7 @@ Svc_Prop_Out_Of_Range(char const *name, Value const &elt_cfg, int v, int min, in
 }
 
 ts::Errata::Message
-Svc_Prop_Ignored(char const *name, int line)
+Svc_Prop_Ignored(const char *name, int line)
 {
   std::ostringstream out;
   out << "Service property '" << name << "' at line " << line << " ignored because the service is of type standard.";
@@ -298,7 +298,7 @@ Security_Opt_Invalid(ts::ConstBuffer const &text, int line)
 }
 
 ts::Errata::Message
-Value_Malformed(char const *name, char const *text, int line)
+Value_Malformed(const char *name, char const *text, int line)
 {
   std::ostringstream out;
   out << "'" << name << "' value '" << text << "' malformed at line " << line << ".";
@@ -322,7 +322,7 @@ Ignored_Option_Value(ts::ConstBuffer const &text, ts::ConstBuffer const &name, i
 }
 
 ts::Errata::Message
-Ignored_Opt_Errors(char const *name, int line)
+Ignored_Opt_Errors(const char *name, int line)
 {
   std::ostringstream out;
   out << "Errors in  '" << name << "' at line " << line << " were ignored.";
@@ -355,13 +355,13 @@ Port_Type_Invalid(ts::ConstBuffer const &text, int line)
 namespace wccp
 {
 inline bool
-operator==(ts::ConstBuffer const &b, char const *text)
+operator==(ts::ConstBuffer const &b, const char *text)
 {
   return 0 == strncasecmp(text, b._ptr, b._size);
 }
 
 inline bool
-operator==(char const *text, ts::ConstBuffer const &b)
+operator==(const char *text, ts::ConstBuffer const &b)
 {
   return 0 == strncasecmp(text, b._ptr, b._size);
 }
@@ -463,8 +463,8 @@ load_routers(Value const &setting,        ///< Source of addresses.
              )
 {
   ts::Errata zret;
-  char const *text;
-  static char const *const NAME = "IPv4 Address";
+  const char *text;
+  static const char *const NAME = "IPv4 Address";
 
   if (setting.isContainer()) {
     int nr = setting.childCount();
@@ -489,7 +489,7 @@ load_routers(Value const &setting,        ///< Source of addresses.
 }
 
 ts::Errata
-CacheImpl::loadServicesFromFile(char const *path)
+CacheImpl::loadServicesFromFile(const char *path)
 {
   ts::Errata zret;
   int src_line = 0;              // scratch for local source line caching.
@@ -525,7 +525,7 @@ CacheImpl::loadServicesFromFile(char const *path)
   int idx, nsvc;
   for (idx = 0, nsvc = svc_list.childCount(); idx < nsvc; ++idx) {
     int x; // scratch int.
-    char const *md5_key = 0;
+    const char *md5_key = 0;
     ts::ConstBuffer text;
     SecurityOption security_style = SECURITY_NONE;
     bool use_group_local_security = false;

--- a/lib/wccp/WccpEndPoint.cc
+++ b/lib/wccp/WccpEndPoint.cc
@@ -46,7 +46,7 @@ Impl::GroupData::GroupData() : m_generation(0), m_use_security_opt(false), m_use
 }
 
 Impl::GroupData &
-Impl::GroupData::setKey(char const *key)
+Impl::GroupData::setKey(const char *key)
 {
   m_use_security_key = true;
   strncpy(m_security_key, key, SecurityComp::KEY_SIZE);
@@ -312,7 +312,7 @@ CacheImpl::GroupData::removeSeedRouter(uint32_t addr)
 }
 
 CacheImpl::GroupData &
-CacheImpl::GroupData::setKey(char const *key)
+CacheImpl::GroupData::setKey(const char *key)
 {
   return static_cast<self &>(this->super::setKey(key));
 }
@@ -504,7 +504,7 @@ CacheImpl::GroupData::viewChanged(time_t now)
 }
 
 Cache::Service &
-Cache::Service::setKey(char const *key)
+Cache::Service::setKey(const char *key)
 {
   m_group->setKey(key);
   return *this;
@@ -758,7 +758,7 @@ CacheImpl::handleISeeYou(IpHeader const & /* ip_hdr ATS_UNUSED */, ts::Buffer co
     // Validate capabilities.
     ServiceGroup::PacketStyle ps;
     ServiceGroup::CacheAssignmentStyle as;
-    char const *caps_tag = caps.isEmpty() ? "default" : "router";
+    const char *caps_tag = caps.isEmpty() ? "default" : "router";
 
     // No caps -> use GRE forwarding.
     ps = caps.isEmpty() ? ServiceGroup::GRE : caps.getPacketForwardStyle();
@@ -1231,7 +1231,7 @@ Cache::addSeedRouter(uint8_t id, uint32_t addr)
 }
 
 ts::Errata
-Cache::loadServicesFromFile(char const *path)
+Cache::loadServicesFromFile(const char *path)
 {
   return this->instance()->loadServicesFromFile(path);
 }

--- a/lib/wccp/WccpLocal.h
+++ b/lib/wccp/WccpLocal.h
@@ -119,7 +119,7 @@ public:
   /// Get address of first byte.
   char *getBase();
   /// Get address of first byte.
-  char const *getBase() const;
+  const char *getBase() const;
   /// Get the remaining space in the buffer.
   size_t getSpace() const;
   /// Mark additional space in use.
@@ -1027,13 +1027,13 @@ public:
   /// Set the global / default security key.
   /// This is used for the security hash unless the local key is set.
   /// @a key is copied to a global buffer and clipped to @c KEY_SIZE bytes.
-  static void setDefaultKey(char const *key ///< Shared key.
+  static void setDefaultKey(const char *key ///< Shared key.
                             );
   static void setDefaultOption(Option opt ///< Type of security.
                                );
 
   /// Set messsage local security key.
-  self &setKey(char const *key ///< Shared key.
+  self &setKey(const char *key ///< Shared key.
                );
 
   /// Compute and set the security data.
@@ -1891,7 +1891,7 @@ struct IpHeader {
 };
 
 // Various static values.
-char const *const BUFFER_TOO_SMALL_FOR_COMP_TEXT = "Unable to write component -- buffer too small";
+const char *const BUFFER_TOO_SMALL_FOR_COMP_TEXT = "Unable to write component -- buffer too small";
 
 // ------------------------------------------------------
 namespace detail
@@ -1991,7 +1991,7 @@ namespace detail
       /// Default constructor.
       GroupData();
       /// Use @a key instead of global default.
-      self &setKey(char const *key ///< Shared key.
+      self &setKey(const char *key ///< Shared key.
                    );
       /// Use security @a style instead of global default.
       self &setSecurity(SecurityOption style ///< Security style to use.
@@ -2421,7 +2421,7 @@ namespace detail
       self &viewChanged(time_t now);
 
       /// Use @a key instead of global default.
-      self &setKey(char const *key ///< Shared key.
+      self &setKey(const char *key ///< Shared key.
                    );
       /// Use security @a style instead of global default.
       self &setSecurity(SecurityOption style ///< Security style to use.
@@ -2478,7 +2478,7 @@ public:
                    );
 
   /// Define services from a configuration file.
-  ts::Errata loadServicesFromFile(char const *path ///< Path to file.
+  ts::Errata loadServicesFromFile(const char *path ///< Path to file.
                                   );
 
   /// Override.
@@ -3305,7 +3305,7 @@ MsgBuffer::getBase()
 {
   return _ptr;
 }
-inline char const *
+inline const char *
 MsgBuffer::getBase() const
 {
   return _ptr;

--- a/mgmt/api/CoreAPI.cc
+++ b/mgmt/api/CoreAPI.cc
@@ -460,7 +460,7 @@ StorageDeviceCmdOffline(const char *dev)
  * Signal plugins.
  */
 TSMgmtError
-LifecycleMessage(char const *tag, void const *data, size_t data_size)
+LifecycleMessage(const char *tag, void const *data, size_t data_size)
 {
   ink_release_assert(!"Not expected to reach here");
   lmgmt->signalEvent(MGMT_EVENT_LIFECYCLE_MESSAGE, tag);

--- a/mgmt/api/CoreAPI.h
+++ b/mgmt/api/CoreAPI.h
@@ -47,7 +47,7 @@ TSMgmtError Reconfigure();                                                      
 TSMgmtError Restart(unsigned options);                                             // restart TM
 TSMgmtError Bounce(unsigned options);                                              // restart traffic_server
 TSMgmtError StorageDeviceCmdOffline(const char *dev);                              // Storage device operation.
-TSMgmtError LifecycleMessage(char const *tag, void const *data, size_t data_size); // Lifecycle alert to plugins.
+TSMgmtError LifecycleMessage(const char *tag, void const *data, size_t data_size); // Lifecycle alert to plugins.
 
 /***************************************************************************
  * Record Operations

--- a/mgmt/api/CoreAPIRemote.cc
+++ b/mgmt/api/CoreAPIRemote.cc
@@ -438,7 +438,7 @@ Bounce(unsigned options)
  * Disable a storage device.
  */
 TSMgmtError
-StorageDeviceCmdOffline(char const *dev)
+StorageDeviceCmdOffline(const char *dev)
 {
   TSMgmtError ret;
   MgmtMarshallInt optype  = STORAGE_DEVICE_CMD_OFFLINE;
@@ -454,7 +454,7 @@ StorageDeviceCmdOffline(char const *dev)
  * Send alert to plugins
  */
 TSMgmtError
-LifecycleMessage(char const *tag, void const *data, size_t data_size)
+LifecycleMessage(const char *tag, void const *data, size_t data_size)
 {
   TSMgmtError ret;
   MgmtMarshallInt optype  = LIFECYCLE_MESSAGE;

--- a/mgmt/api/INKMgmtAPI.cc
+++ b/mgmt/api/INKMgmtAPI.cc
@@ -1736,13 +1736,13 @@ TSBounce(unsigned options)
 }
 
 tsapi TSMgmtError
-TSStorageDeviceCmdOffline(char const *dev)
+TSStorageDeviceCmdOffline(const char *dev)
 {
   return StorageDeviceCmdOffline(dev);
 }
 
 tsapi TSMgmtError
-TSLifecycleMessage(char const *tag, void const *data, size_t data_size)
+TSLifecycleMessage(const char *tag, void const *data, size_t data_size)
 {
   return LifecycleMessage(tag, data, data_size);
 }

--- a/mgmt/api/include/mgmtapi.h
+++ b/mgmt/api/include/mgmtapi.h
@@ -872,13 +872,13 @@ tsapi TSMgmtError TSBounce(unsigned options);
  * @arg dev Target device, specified by path to device.
  * @return Success.
  */
-tsapi TSMgmtError TSStorageDeviceCmdOffline(char const *dev);
+tsapi TSMgmtError TSStorageDeviceCmdOffline(const char *dev);
 
 /* TSLifecycleMessage: Send a lifecycle message to the plugins.
  * @arg tag Alert tag string (null-terminated)
  * @return Success
  */
-tsapi TSMgmtError TSLifecycleMessage(char const *tag, void const *data, size_t data_size);
+tsapi TSMgmtError TSLifecycleMessage(const char *tag, void const *data, size_t data_size);
 
 /* TSGetErrorMessage: convert error id to error message
  * Input:  error id (defined in TSMgmtError)

--- a/plugins/experimental/header_freq/header_freq.cc
+++ b/plugins/experimental/header_freq/header_freq.cc
@@ -188,14 +188,14 @@ handle_hook(TSCont contp, TSEvent event, void *edata)
     if (0 == strcasecmp(ctl_tag, msgp->tag)) {
       // identify the command
       if (msgp->data_size >= CONTROL_MSG_LOG_LEN &&
-          0 == strncasecmp(CONTROL_MSG_LOG, static_cast<char const *>(msgp->data), CONTROL_MSG_LOG_LEN)) {
+          0 == strncasecmp(CONTROL_MSG_LOG, static_cast<const char *>(msgp->data), CONTROL_MSG_LOG_LEN)) {
         TSDebug(DEBUG_TAG_HOOK, "Scheduled execution of '%s' command", CONTROL_MSG_LOG);
         TSCont c = TSContCreate(CB_Command_Log, TSMutexCreate());
-        TSContDataSet(c, new std::string(static_cast<char const *>(msgp->data), msgp->data_size));
+        TSContDataSet(c, new std::string(static_cast<const char *>(msgp->data), msgp->data_size));
         TSContSchedule(c, 0, TS_THREAD_POOL_TASK);
       } else {
         TSError("[%s] Unknown command '%.*s'", PLUGIN_NAME, static_cast<int>(msgp->data_size),
-                static_cast<char const *>(msgp->data));
+                static_cast<const char *>(msgp->data));
       }
     }
   } break;

--- a/plugins/experimental/ssl_cert_loader/ssl-cert-loader.cc
+++ b/plugins/experimental/ssl_cert_loader/ssl-cert-loader.cc
@@ -504,7 +504,7 @@ TSPluginInit(int argc, const char *argv[])
     }
   }
   if (ConfigPath.length() == 0) {
-    static char const *const DEFAULT_CONFIG_PATH = "ssl_start.cfg";
+    static const char *const DEFAULT_CONFIG_PATH = "ssl_start.cfg";
     ConfigPath                                   = std::string(TSConfigDirGet()) + '/' + std::string(DEFAULT_CONFIG_PATH);
     TSDebug(PN, "No config path set in arguments, using default: %s", DEFAULT_CONFIG_PATH);
   }

--- a/proxy/ControlBase.cc
+++ b/proxy/ControlBase.cc
@@ -52,8 +52,8 @@
     @internal Need to move these to a common header.
  */
 #define TS_IP_OCTETS(x)                                                                               \
-  reinterpret_cast<unsigned char const *>(&(x))[0], reinterpret_cast<unsigned char const *>(&(x))[1], \
-    reinterpret_cast<unsigned char const *>(&(x))[2], reinterpret_cast<unsigned char const *>(&(x))[3]
+  reinterpret_cast<unsigned const char *>(&(x))[0], reinterpret_cast<unsigned char const *>(&(x))[1], \
+    reinterpret_cast<unsigned const char *>(&(x))[2], reinterpret_cast<unsigned char const *>(&(x))[3]
 
 // ----------
 ControlBase::Modifier::~Modifier()
@@ -72,23 +72,23 @@ struct TimeMod : public ControlBase::Modifier {
   time_t start_time;
   time_t end_time;
 
-  static char const *const NAME;
+  static const char *const NAME;
 
   virtual Type type() const;
-  virtual char const *name() const;
+  virtual const char *name() const;
   virtual bool check(HttpRequestData *req) const;
   virtual void print(FILE *f) const;
-  static TimeMod *make(char *value, char const **error);
+  static TimeMod *make(char *value, const char **error);
   static const char *timeOfDayToSeconds(const char *time_str, time_t *seconds);
 };
 
-char const *const TimeMod::NAME = "Time";
+const char *const TimeMod::NAME = "Time";
 ControlBase::Modifier::Type
 TimeMod::type() const
 {
   return MOD_TIME;
 }
-char const *
+const char *
 TimeMod::name() const
 {
   return NAME;
@@ -114,7 +114,7 @@ TimeMod::check(HttpRequestData *req) const
 }
 
 TimeMod *
-TimeMod::make(char *value, char const **error)
+TimeMod::make(char *value, const char **error)
 {
   Tokenizer rangeTok("-");
   TimeMod *mod = 0;
@@ -178,17 +178,17 @@ struct PortMod : public ControlBase::Modifier {
   int start_port;
   int end_port;
 
-  static char const *const NAME;
+  static const char *const NAME;
 
-  virtual char const *name() const;
+  virtual const char *name() const;
   virtual bool check(HttpRequestData *req) const;
   virtual void print(FILE *f) const;
 
-  static PortMod *make(char *value, char const **error);
+  static PortMod *make(char *value, const char **error);
 };
 
-char const *const PortMod::NAME = "Port";
-char const *
+const char *const PortMod::NAME = "Port";
+const char *
 PortMod::name() const
 {
   return NAME;
@@ -208,7 +208,7 @@ PortMod::check(HttpRequestData *req) const
 }
 
 PortMod *
-PortMod::make(char *value, char const **error)
+PortMod::make(char *value, const char **error)
 {
   Tokenizer rangeTok("-");
   PortMod tmp;
@@ -240,21 +240,21 @@ PortMod::make(char *value, char const **error)
 struct IPortMod : public ControlBase::Modifier {
   int _port;
 
-  static char const *const NAME;
+  static const char *const NAME;
 
   IPortMod(int port);
 
-  virtual char const *name() const;
+  virtual const char *name() const;
   virtual bool check(HttpRequestData *req) const;
   virtual void print(FILE *f) const;
-  static IPortMod *make(char *value, char const **error);
+  static IPortMod *make(char *value, const char **error);
 };
 
-char const *const IPortMod::NAME = "IPort";
+const char *const IPortMod::NAME = "IPort";
 IPortMod::IPortMod(int port) : _port(port)
 {
 }
-char const *
+const char *
 IPortMod::name() const
 {
   return NAME;
@@ -272,7 +272,7 @@ IPortMod::check(HttpRequestData *req) const
 }
 
 IPortMod *
-IPortMod::make(char *value, char const **error)
+IPortMod::make(char *value, const char **error)
 {
   IPortMod *zret = 0;
   int port;
@@ -290,22 +290,22 @@ struct SrcIPMod : public ControlBase::Modifier {
   IpEndpoint start_addr; ///< Start address in HOST order.
   IpEndpoint end_addr;   ///< End address in HOST order.
 
-  static char const *const NAME;
+  static const char *const NAME;
 
   virtual Type type() const;
-  virtual char const *name() const;
+  virtual const char *name() const;
   virtual bool check(HttpRequestData *req) const;
   virtual void print(FILE *f) const;
-  static SrcIPMod *make(char *value, char const **error);
+  static SrcIPMod *make(char *value, const char **error);
 };
 
-char const *const SrcIPMod::NAME = "SrcIP";
+const char *const SrcIPMod::NAME = "SrcIP";
 ControlBase::Modifier::Type
 SrcIPMod::type() const
 {
   return MOD_SRC_IP;
 }
-char const *
+const char *
 SrcIPMod::name() const
 {
   return NAME;
@@ -324,7 +324,7 @@ SrcIPMod::check(HttpRequestData *req) const
   return ats_ip_addr_cmp(&start_addr, &req->src_ip) <= 0 && ats_ip_addr_cmp(&req->src_ip, &end_addr) <= 0;
 }
 SrcIPMod *
-SrcIPMod::make(char *value, char const **error)
+SrcIPMod::make(char *value, const char **error)
 {
   SrcIPMod tmp;
   SrcIPMod *zret = 0;
@@ -339,21 +339,21 @@ SrcIPMod::make(char *value, char const **error)
 struct SchemeMod : public ControlBase::Modifier {
   int _scheme; ///< Tokenized scheme.
 
-  static char const *const NAME;
+  static const char *const NAME;
 
   SchemeMod(int scheme);
 
   virtual Type type() const;
-  virtual char const *name() const;
+  virtual const char *name() const;
   virtual bool check(HttpRequestData *req) const;
   virtual void print(FILE *f) const;
 
-  char const *getWksText() const;
+  const char *getWksText() const;
 
-  static SchemeMod *make(char *value, char const **error);
+  static SchemeMod *make(char *value, const char **error);
 };
 
-char const *const SchemeMod::NAME = "Scheme";
+const char *const SchemeMod::NAME = "Scheme";
 
 SchemeMod::SchemeMod(int scheme) : _scheme(scheme)
 {
@@ -364,12 +364,12 @@ SchemeMod::type() const
 {
   return MOD_SCHEME;
 }
-char const *
+const char *
 SchemeMod::name() const
 {
   return NAME;
 }
-char const *
+const char *
 SchemeMod::getWksText() const
 {
   return hdrtoken_index_to_wks(_scheme);
@@ -386,7 +386,7 @@ SchemeMod::print(FILE *f) const
   fprintf(f, "%s=%s  ", this->name(), hdrtoken_index_to_wks(_scheme));
 }
 SchemeMod *
-SchemeMod::make(char *value, char const **error)
+SchemeMod::make(char *value, const char **error)
 {
   SchemeMod *zret = 0;
   int scheme      = hdrtoken_tokenize(value, strlen(value));
@@ -476,21 +476,21 @@ MultiTextMod::set(char *value)
 
 // ----------
 struct MethodMod : public TextMod {
-  static char const *const NAME;
+  static const char *const NAME;
 
   virtual Type type() const;
-  virtual char const *name() const;
+  virtual const char *name() const;
   virtual bool check(HttpRequestData *req) const;
 
-  static MethodMod *make(char *value, char const **error);
+  static MethodMod *make(char *value, const char **error);
 };
-char const *const MethodMod::NAME = "Method";
+const char *const MethodMod::NAME = "Method";
 ControlBase::Modifier::Type
 MethodMod::type() const
 {
   return MOD_METHOD;
 }
-char const *
+const char *
 MethodMod::name() const
 {
   return NAME;
@@ -499,11 +499,11 @@ bool
 MethodMod::check(HttpRequestData *req) const
 {
   int method_len;
-  char const *method = req->hdr->method_get(&method_len);
+  const char *method = req->hdr->method_get(&method_len);
   return method_len >= static_cast<int>(text.size()) && 0 == strncasecmp(method, text.data(), text.size());
 }
 MethodMod *
-MethodMod::make(char *value, char const **)
+MethodMod::make(char *value, const char **)
 {
   MethodMod *mod = new MethodMod();
   mod->set(value);
@@ -512,21 +512,21 @@ MethodMod::make(char *value, char const **)
 
 // ----------
 struct PrefixMod : public TextMod {
-  static char const *const NAME;
+  static const char *const NAME;
 
   virtual Type type() const;
-  virtual char const *name() const;
+  virtual const char *name() const;
   virtual bool check(HttpRequestData *req) const;
-  static PrefixMod *make(char *value, char const **error);
+  static PrefixMod *make(char *value, const char **error);
 };
 
-char const *const PrefixMod::NAME = "Prefix";
+const char *const PrefixMod::NAME = "Prefix";
 ControlBase::Modifier::Type
 PrefixMod::type() const
 {
   return MOD_PREFIX;
 }
-char const *
+const char *
 PrefixMod::name() const
 {
   return NAME;
@@ -535,7 +535,7 @@ bool
 PrefixMod::check(HttpRequestData *req) const
 {
   int path_len;
-  char const *path = req->hdr->url_get()->path_get(&path_len);
+  const char *path = req->hdr->url_get()->path_get(&path_len);
   bool zret        = path_len >= static_cast<int>(text.size()) && 0 == memcmp(path, text.data(), text.size());
   /*
     Debug("cache_control", "Prefix check: URL=%0.*s Mod=%0.*s Z=%s",
@@ -546,7 +546,7 @@ PrefixMod::check(HttpRequestData *req) const
   return zret;
 }
 PrefixMod *
-PrefixMod::make(char *value, char const ** /* error ATS_UNUSED */)
+PrefixMod::make(char *value, const char ** /* error ATS_UNUSED */)
 {
   PrefixMod *mod = new PrefixMod();
   // strip leading slashes because get_path which is used later
@@ -560,20 +560,20 @@ PrefixMod::make(char *value, char const ** /* error ATS_UNUSED */)
 
 // ----------
 struct SuffixMod : public MultiTextMod {
-  static char const *const NAME;
+  static const char *const NAME;
 
   virtual Type type() const;
-  virtual char const *name() const;
+  virtual const char *name() const;
   virtual bool check(HttpRequestData *req) const;
-  static SuffixMod *make(char *value, char const **error);
+  static SuffixMod *make(char *value, const char **error);
 };
-char const *const SuffixMod::NAME = "Suffix";
+const char *const SuffixMod::NAME = "Suffix";
 ControlBase::Modifier::Type
 SuffixMod::type() const
 {
   return MOD_SUFFIX;
 }
-char const *
+const char *
 SuffixMod::name() const
 {
   return NAME;
@@ -582,7 +582,7 @@ bool
 SuffixMod::check(HttpRequestData *req) const
 {
   int path_len;
-  char const *path = req->hdr->url_get()->path_get(&path_len);
+  const char *path = req->hdr->url_get()->path_get(&path_len);
   if (1 == static_cast<int>(this->text_vec.count()) && 1 == static_cast<int>(this->text_vec[0].size()) &&
       0 == strcmp(this->text_vec[0].data(), "*")) {
     return true;
@@ -597,7 +597,7 @@ SuffixMod::check(HttpRequestData *req) const
   return false;
 }
 SuffixMod *
-SuffixMod::make(char *value, char const ** /* error ATS_UNUSED */)
+SuffixMod::make(char *value, const char ** /* error ATS_UNUSED */)
 {
   SuffixMod *mod = new SuffixMod();
   mod->set(value);
@@ -606,20 +606,20 @@ SuffixMod::make(char *value, char const ** /* error ATS_UNUSED */)
 
 // ----------
 struct TagMod : public TextMod {
-  static char const *const NAME;
+  static const char *const NAME;
 
   virtual Type type() const;
-  virtual char const *name() const;
+  virtual const char *name() const;
   virtual bool check(HttpRequestData *req) const;
-  static TagMod *make(char *value, char const **error);
+  static TagMod *make(char *value, const char **error);
 };
-char const *const TagMod::NAME = "Tag";
+const char *const TagMod::NAME = "Tag";
 ControlBase::Modifier::Type
 TagMod::type() const
 {
   return MOD_TAG;
 }
-char const *
+const char *
 TagMod::name() const
 {
   return NAME;
@@ -630,7 +630,7 @@ TagMod::check(HttpRequestData *req) const
   return 0 == strcmp(req->tag, text.data());
 }
 TagMod *
-TagMod::make(char *value, char const ** /* error ATS_UNUSED */)
+TagMod::make(char *value, const char ** /* error ATS_UNUSED */)
 {
   TagMod *mod = new TagMod();
   mod->set(value);
@@ -640,14 +640,14 @@ TagMod::make(char *value, char const ** /* error ATS_UNUSED */)
 // ----------
 struct InternalMod : public ControlBase::Modifier {
   bool flag;
-  static char const *const NAME;
+  static const char *const NAME;
 
   virtual Type
   type() const
   {
     return MOD_INTERNAL;
   }
-  virtual char const *
+  virtual const char *
   name() const
   {
     return NAME;
@@ -662,13 +662,13 @@ struct InternalMod : public ControlBase::Modifier {
   {
     fprintf(f, "%s=%s  ", this->name(), flag ? "true" : "false");
   }
-  static InternalMod *make(char *value, char const **error);
+  static InternalMod *make(char *value, const char **error);
 };
 
-char const *const InternalMod::NAME = "Internal";
+const char *const InternalMod::NAME = "Internal";
 
 InternalMod *
-InternalMod::make(char *value, char const **error)
+InternalMod::make(char *value, const char **error)
 {
   InternalMod tmp;
 
@@ -724,10 +724,10 @@ ControlBase::Print()
   printf("\n");
 }
 
-char const *
+const char *
 ControlBase::getSchemeModText() const
 {
-  char const *zret = 0;
+  const char *zret = 0;
   Modifier *mod    = this->findModOfType(Modifier::MOD_SCHEME);
   if (mod) {
     zret = static_cast<SchemeMod *>(mod)->getWksText();

--- a/proxy/ControlBase.h
+++ b/proxy/ControlBase.h
@@ -61,7 +61,7 @@ public:
     /// Return the modifier type.
     virtual Type type() const;
     /// Return the name for the modifier type.
-    virtual char const *name() const = 0;
+    virtual const char *name() const = 0;
     /** Test if the modifier matches the request.
         @return @c true if the request is matched, @c false if not.
     */
@@ -85,7 +85,7 @@ protected:
   /// Get the text for the Scheme modifier, if any.
   /// @return The text if present, 0 otherwise.
   /// @internal Ugly but it's the only place external access is needed.
-  char const *getSchemeModText() const;
+  const char *getSchemeModText() const;
 
 private:
   typedef Vec<Modifier *> Array;

--- a/proxy/FetchSM.cc
+++ b/proxy/FetchSM.cc
@@ -60,7 +60,7 @@ void
 FetchSM::httpConnect()
 {
   PluginIdentity *pi = dynamic_cast<PluginIdentity *>(contp);
-  char const *tag    = pi ? pi->getPluginTag() : "fetchSM";
+  const char *tag    = pi ? pi->getPluginTag() : "fetchSM";
   int64_t id         = pi ? pi->getPluginId() : 0;
 
   Debug(DEBUG_TAG, "[%s] calling httpconnect write pi=%p tag=%s id=%" PRId64, __FUNCTION__, pi, tag, id);
@@ -162,7 +162,7 @@ FetchSM::check_body_done()
 }
 
 bool
-FetchSM::check_for_field_value(char const *name, size_t name_len, char const *value, size_t value_len)
+FetchSM::check_for_field_value(const char *name, size_t name_len, char const *value, size_t value_len)
 {
   bool zret = false; // not found.
   StrList slist;
@@ -187,7 +187,7 @@ FetchSM::check_for_field_value(char const *name, size_t name_len, char const *va
 bool
 FetchSM::check_chunked()
 {
-  static char const CHUNKED_TEXT[] = "chunked";
+  static const char CHUNKED_TEXT[] = "chunked";
   static size_t const CHUNKED_LEN  = sizeof(CHUNKED_TEXT) - 1;
 
   if (resp_is_chunked < 0) {
@@ -208,7 +208,7 @@ FetchSM::check_chunked()
 bool
 FetchSM::check_connection_close()
 {
-  static char const CLOSE_TEXT[] = "close";
+  static const char CLOSE_TEXT[] = "close";
   static size_t const CLOSE_LEN  = sizeof(CLOSE_TEXT) - 1;
 
   if (resp_received_close < 0) {

--- a/proxy/FetchSM.h
+++ b/proxy/FetchSM.h
@@ -147,7 +147,7 @@ private:
     return req_reader->read_avail();
   }
   /// Check if the comma supproting MIME field @a name has @a value in it.
-  bool check_for_field_value(char const *name, size_t name_len, char const *value, size_t value_len);
+  bool check_for_field_value(const char *name, size_t name_len, char const *value, size_t value_len);
 
   bool has_body();
   bool check_body_done();

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -6320,7 +6320,7 @@ TSHttpAltInfoQualitySet(TSHttpAltInfo infop, float quality)
 extern HttpSessionAccept *plugin_http_accept;
 extern HttpSessionAccept *plugin_http_transparent_accept;
 
-char const *
+const char *
 TSHttpTxnPluginTagGet(TSHttpTxn txnp)
 {
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
@@ -6330,7 +6330,7 @@ TSHttpTxnPluginTagGet(TSHttpTxn txnp)
 }
 
 TSVConn
-TSHttpConnectWithPluginId(sockaddr const *addr, char const *tag, int64_t id)
+TSHttpConnectWithPluginId(sockaddr const *addr, const char *tag, int64_t id)
 {
   sdk_assert(addr);
 
@@ -9247,7 +9247,7 @@ TSHttpTxnIdGet(TSHttpTxn txnp)
 
 // Return information about the protocols used by the client
 TSReturnCode
-TSHttpTxnClientProtocolStackGet(TSHttpTxn txnp, int n, char const **result, int *actual)
+TSHttpTxnClientProtocolStackGet(TSHttpTxn txnp, int n, const char **result, int *actual)
 {
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
   sdk_assert(n == 0 || result != NULL);
@@ -9263,7 +9263,7 @@ TSHttpTxnClientProtocolStackGet(TSHttpTxn txnp, int n, char const **result, int 
 }
 
 TSReturnCode
-TSHttpSsnClientProtocolStackGet(TSHttpSsn ssnp, int n, char const **result, int *actual)
+TSHttpSsnClientProtocolStackGet(TSHttpSsn ssnp, int n, const char **result, int *actual)
 {
   sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
   sdk_assert(n == 0 || result != NULL);
@@ -9278,30 +9278,30 @@ TSHttpSsnClientProtocolStackGet(TSHttpSsn ssnp, int n, char const **result, int 
   return TS_SUCCESS;
 }
 
-char const *
-TSNormalizedProtocolTag(char const *tag)
+const char *
+TSNormalizedProtocolTag(const char *tag)
 {
   return RecNormalizeProtoTag(tag);
 }
 
-char const *
-TSHttpTxnClientProtocolStackContains(TSHttpTxn txnp, char const *tag)
+const char *
+TSHttpTxnClientProtocolStackContains(TSHttpTxn txnp, const char *tag)
 {
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
   HttpSM *sm = (HttpSM *)txnp;
   return sm->client_protocol_contains(tag);
 }
 
-char const *
-TSHttpSsnClientProtocolStackContains(TSHttpSsn ssnp, char const *tag)
+const char *
+TSHttpSsnClientProtocolStackContains(TSHttpSsn ssnp, const char *tag)
 {
   sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
   ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
   return cs->protocol_contains(tag);
 }
 
-char const *
-TSRegisterProtocolTag(char const *tag)
+const char *
+TSRegisterProtocolTag(const char *tag)
 {
   return NULL;
 }

--- a/proxy/InkAPITest.cc
+++ b/proxy/InkAPITest.cc
@@ -2031,7 +2031,7 @@ static int
 checkHttpTxnClientProtocolStackGet(SocketTest *test, void *data)
 {
   TSHttpTxn txnp = (TSHttpTxn)data;
-  char const *results[10];
+  const char *results[10];
   int count = 0;
   TSHttpTxnClientProtocolStackGet(txnp, 10, results, &count);
   // Should return results[0] = "http/1.0", results[1] = "tcp", results[2] = "ipv4"
@@ -5144,7 +5144,7 @@ REGRESSION_TEST(SDK_API_TSMimeHdrParse)(RegressionTest *test, int /* atype ATS_U
 
 REGRESSION_TEST(SDK_API_TSUrlParse)(RegressionTest *test, int /* atype ATS_UNUSED */, int *pstatus)
 {
-  static char const *const urls[] = {
+  static const char *const urls[] = {
     "file:///test.dat;ab?abc=def#abc",
     "http://www.example.com/",
     "http://abc:def@www.example.com/",
@@ -5178,7 +5178,7 @@ REGRESSION_TEST(SDK_API_TSUrlParse)(RegressionTest *test, int /* atype ATS_UNUSE
 
   int idx;
   for (idx = 0; idx < num_urls; idx++) {
-    char const *url = urls[idx];
+    const char *url = urls[idx];
 
     bufp = TSMBufferCreate();
     if (TSUrlCreate(bufp, &url_loc) != TS_SUCCESS) {

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -140,7 +140,7 @@ int command_flag                = DEFAULT_COMMAND_FLAG;
 int command_index               = -1;
 bool command_valid              = false;
 // Commands that have special processing / requirements.
-static char const *CMD_VERIFY_CONFIG = "verify_config";
+static const char *CMD_VERIFY_CONFIG = "verify_config";
 #if TS_HAS_TESTS
 static char regression_test[1024] = "";
 static int regression_list        = 0;
@@ -910,14 +910,14 @@ static const struct CMD {
 };
 
 static int
-find_cmd_index(char const *p)
+find_cmd_index(const char *p)
 {
   p += strspn(p, " \t");
   for (unsigned c = 0; c < countof(commands); c++) {
-    char const *l = commands[c].n;
+    const char *l = commands[c].n;
     while (l) {
-      char const *s = strchr(l, '/');
-      char const *e = strpbrk(p, " \t\n");
+      const char *s = strchr(l, '/');
+      const char *e = strpbrk(p, " \t\n");
       int len       = s ? s - l : strlen(l);
       int lenp      = e ? e - p : strlen(p);
       if ((len == lenp) && !strncasecmp(p, l, len)) {

--- a/proxy/PluginVC.cc
+++ b/proxy/PluginVC.cc
@@ -1218,7 +1218,7 @@ PluginVCCore::set_plugin_id(int64_t id)
 }
 
 void
-PluginVCCore::set_plugin_tag(char const *tag)
+PluginVCCore::set_plugin_tag(const char *tag)
 {
   passive_vc.plugin_tag = active_vc.plugin_tag = tag;
 }

--- a/proxy/PluginVC.h
+++ b/proxy/PluginVC.h
@@ -119,7 +119,7 @@ public:
 
   //@{ @name Plugin identity.
   /// Override for @c PluginIdentity.
-  virtual char const *
+  virtual const char *
   getPluginTag() const
   {
     return plugin_tag;
@@ -133,7 +133,7 @@ public:
 
   /// Setter for plugin tag.
   virtual void
-  setPluginTag(char const *tag)
+  setPluginTag(const char *tag)
   {
     plugin_tag = tag;
   }
@@ -184,7 +184,7 @@ private:
   ink_hrtime inactive_timeout_at;
   Event *inactive_event;
 
-  char const *plugin_tag;
+  const char *plugin_tag;
   int64_t plugin_id;
 };
 
@@ -232,7 +232,7 @@ public:
   /// Set the plugin ID for the internal VCs.
   void set_plugin_id(int64_t id);
   /// Set the plugin tag for the internal VCs.
-  void set_plugin_tag(char const *tag);
+  void set_plugin_tag(const char *tag);
 
   // The active vc is handed to the initiator of
   //   connection.  The passive vc is handled to

--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -177,7 +177,7 @@ public:
   }
 
   virtual int
-  populate_protocol(char const **result, int size) const
+  populate_protocol(const char **result, int size) const
   {
     int retval = 0;
 

--- a/proxy/ProxyClientTransaction.h
+++ b/proxy/ProxyClientTransaction.h
@@ -243,7 +243,7 @@ public:
   }
 
   virtual int
-  populate_protocol(char const **result, int size) const
+  populate_protocol(const char **result, int size) const
   {
     int retval = 0;
     if (parent) {

--- a/proxy/api/ts/TsException.h
+++ b/proxy/api/ts/TsException.h
@@ -47,10 +47,10 @@ public:
   Exception(const char *text ///< Alternate text for exception.
             );
 
-  static char const *const DEFAULT_TEXT;
+  static const char *const DEFAULT_TEXT;
 
 protected:
-  char const *m_text;
+  const char *m_text;
 };
 
 // ----------------------------------------------------------
@@ -59,7 +59,7 @@ protected:
 inline Exception::Exception() : m_text(DEFAULT_TEXT)
 {
 }
-inline Exception::Exception(char const *text) : m_text(text)
+inline Exception::Exception(const char *text) : m_text(text)
 {
 }
 }

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -1645,7 +1645,7 @@ tsapi void TSHttpTxnServerIntercept(TSCont contp, TSHttpTxn txnp);
     @param tag A logging tag that can be accessed via the pitag field. May be @c NULL.
     @param id A logging id that can be access via the piid field.
  */
-tsapi TSVConn TSHttpConnectWithPluginId(struct sockaddr const *addr, char const *tag, int64_t id);
+tsapi TSVConn TSHttpConnectWithPluginId(struct sockaddr const *addr, const char *tag, int64_t id);
 
 /** Backwards compatible version.
     This provides a @a tag of "plugin" and an @a id of 0.
@@ -2421,12 +2421,12 @@ tsapi const char *TSHttpTxnPluginTagGet(TSHttpTxn txnp);
 /*
  * Return information about the client protocols
  */
-tsapi TSReturnCode TSHttpTxnClientProtocolStackGet(TSHttpTxn txnp, int n, char const **result, int *actual);
-tsapi TSReturnCode TSHttpSsnClientProtocolStackGet(TSHttpSsn ssnp, int n, char const **result, int *actual);
-tsapi char const *TSHttpTxnClientProtocolStackContains(TSHttpTxn txnp, char const *tag);
-tsapi char const *TSHttpSsnClientProtocolStackContains(TSHttpSsn ssnp, char const *tag);
-tsapi char const *TSNormalizedProtocolTag(char const *tag);
-tsapi char const *TSRegisterProtocolTag(char const *tag);
+tsapi TSReturnCode TSHttpTxnClientProtocolStackGet(TSHttpTxn txnp, int n, const char **result, int *actual);
+tsapi TSReturnCode TSHttpSsnClientProtocolStackGet(TSHttpSsn ssnp, int n, const char **result, int *actual);
+tsapi const char *TSHttpTxnClientProtocolStackContains(TSHttpTxn txnp, char const *tag);
+tsapi const char *TSHttpSsnClientProtocolStackContains(TSHttpSsn ssnp, char const *tag);
+tsapi const char *TSNormalizedProtocolTag(char const *tag);
+tsapi const char *TSRegisterProtocolTag(char const *tag);
 
 #ifdef __cplusplus
 }

--- a/proxy/congest/Congestion.cc
+++ b/proxy/congest/Congestion.cc
@@ -437,7 +437,7 @@ make_key(char *hostname, int len, sockaddr const *ip, CongestionControlRecord *r
   if (record->congestion_scheme == PER_HOST && len > 0) {
     ink_code_incr_md5_update(&ctx, hostname, len);
   } else {
-    ink_code_incr_md5_update(&ctx, reinterpret_cast<char const *>(ats_ip_addr8_cast(ip)), ats_ip_addr_size(ip));
+    ink_code_incr_md5_update(&ctx, reinterpret_cast<const char *>(ats_ip_addr8_cast(ip)), ats_ip_addr_size(ip));
   }
   if (record->port != 0) {
     unsigned short p = record->port;
@@ -462,7 +462,7 @@ make_key(char *hostname, int len, sockaddr const *ip, char *prefix, int prelen, 
   if (hostname && len > 0) {
     ink_code_incr_md5_update(&ctx, hostname, len);
   } else {
-    ink_code_incr_md5_update(&ctx, reinterpret_cast<char const *>(ats_ip_addr8_cast(ip)), ats_ip_addr_size(ip));
+    ink_code_incr_md5_update(&ctx, reinterpret_cast<const char *>(ats_ip_addr8_cast(ip)), ats_ip_addr_size(ip));
   }
   if (port != 0) {
     unsigned short p = port;

--- a/proxy/hdrs/HTTP.cc
+++ b/proxy/hdrs/HTTP.cc
@@ -1136,7 +1136,7 @@ validate_hdr_host(HTTPHdrImpl *hh)
       ret = PARSE_RESULT_ERROR; // can't have more than 1 host field.
     } else {
       int host_len         = 0;
-      char const *host_val = host_field->value_get(&host_len);
+      const char *host_val = host_field->value_get(&host_len);
       ts::ConstBuffer addr, port, rest, host(host_val, host_len);
       if (0 == ats_ip_parse(host, &addr, &port, &rest)) {
         if (port) {
@@ -1550,7 +1550,7 @@ void
 HTTPHdr::_fill_target_cache() const
 {
   URL *url = this->url_get();
-  char const *port_ptr;
+  const char *port_ptr;
 
   m_target_in_url  = false;
   m_port_in_header = false;
@@ -1592,7 +1592,7 @@ HTTPHdr::set_url_target_from_host_field(URL *url)
     }
   } else {
     int host_len     = 0;
-    char const *host = NULL;
+    const char *host = NULL;
     host             = host_get(&host_len);
     url->host_set(host, host_len);
     if (m_port_in_header) {

--- a/proxy/hdrs/HTTP.h
+++ b/proxy/hdrs/HTTP.h
@@ -564,7 +564,7 @@ public:
       This is a reference, not allocated.
       @return A pointer to the path or @c NULL if there is no valid URL.
   */
-  char const *path_get(int *length ///< Storage for path length.
+  const char *path_get(int *length ///< Storage for path length.
                        );
 
   /** Get the target host name.
@@ -572,7 +572,7 @@ public:
       @note The results are cached so this is fast after the first call.
       @return A pointer to the host name.
   */
-  char const *host_get(int *length = 0);
+  const char *host_get(int *length = 0);
 
   /** Get the target port.
       If the target port is not found then it is adjusted to the
@@ -586,7 +586,7 @@ public:
       This is a reference, not allocated.
       @return A pointer to the scheme or @c NULL if there is no valid URL.
   */
-  char const *scheme_get(int *length ///< Storage for path length.
+  const char *scheme_get(int *length ///< Storage for path length.
                          );
   void url_set(URL *url);
   void url_set_as_server_url(URL *url);
@@ -881,7 +881,7 @@ HTTPHdr::_test_and_fill_target_cache() const
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-inline char const *
+inline const char *
 HTTPHdr::host_get(int *length)
 {
   this->_test_and_fill_target_cache();
@@ -1286,14 +1286,14 @@ HTTPHdr::url_string_get_ref(int *length)
   return this->url_string_get(USE_HDR_HEAP_MAGIC, length);
 }
 
-inline char const *
+inline const char *
 HTTPHdr::path_get(int *length)
 {
   URL *url = this->url_get();
   return url ? url->path_get(length) : 0;
 }
 
-inline char const *
+inline const char *
 HTTPHdr::scheme_get(int *length)
 {
   URL *url = this->url_get();

--- a/proxy/hdrs/HdrTest.cc
+++ b/proxy/hdrs/HdrTest.cc
@@ -371,7 +371,7 @@ HdrTest::test_url()
     "/finance/external/cbsm/*http://cbs.marketwatch.com/archive/19990713/news/current/net.htx?source=blq/yhoo&dist=yhoo",
     "http://a.b.com/xx.jpg?newpath=http://bob.dave.com"};
 
-  static char const *bad[] = {
+  static const char *bad[] = {
     "http://[1:2:3:4:5:6:7:8:9]",
     "http://1:2:3:4:5:6:7:8:A:B",
     "http://bob.com[::1]",
@@ -439,7 +439,7 @@ HdrTest::test_url()
   }
 
   for (unsigned i = 0; i < countof(bad); ++i) {
-    char const *x = bad[i];
+    const char *x = bad[i];
     url.create(NULL);
     err = url.parse(x, strlen(x));
     url.destroy();
@@ -455,7 +455,7 @@ HdrTest::test_url()
     Note("URL performance test start");
     for (int j = 0 ; j < 100000 ; ++j) {
       for (i = 0 ; i < countof(strs) ; ++i) {
-        char const* x = strs[i];
+        const char* x = strs[i];
         url.create(NULL);
         err = url.parse(x, strlen(x));
         url.destroy();

--- a/proxy/hdrs/MIME.cc
+++ b/proxy/hdrs/MIME.cc
@@ -1746,7 +1746,7 @@ mime_field_name_set(HdrHeap *heap, MIMEHdrImpl * /* mh ATS_UNUSED */, MIMEField 
 }
 
 int
-MIMEField::value_get_index(char const *value, int length) const
+MIMEField::value_get_index(const char *value, int length) const
 {
   int retval = -1;
 
@@ -2235,9 +2235,9 @@ mime_field_value_append(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField *field, const 
 }
 
 MIMEField *
-MIMEHdr::get_host_port_values(char const **host_ptr, ///< Pointer to host.
+MIMEHdr::get_host_port_values(const char **host_ptr, ///< Pointer to host.
                               int *host_len,         ///< Length of host.
-                              char const **port_ptr, ///< Pointer to port.
+                              const char **port_ptr, ///< Pointer to port.
                               int *port_len)
 {
   MIMEField *field = this->field_find(MIME_FIELD_HOST, MIME_LEN_HOST);
@@ -2259,10 +2259,10 @@ MIMEHdr::get_host_port_values(char const **host_ptr, ///< Pointer to host.
     ts::ConstBuffer host, port;
 
     if (b) {
-      char const *x;
+      const char *x;
 
       if ('[' == *b) {
-        x = static_cast<char const *>(memchr(b._ptr, ']', b._size));
+        x = static_cast<const char *>(memchr(b._ptr, ']', b._size));
         if (x && b.contains(x + 1) && ':' == x[1]) {
           host = b.splitOn(x + 1);
           port = b;
@@ -2270,7 +2270,7 @@ MIMEHdr::get_host_port_values(char const **host_ptr, ///< Pointer to host.
           host = b;
         }
       } else {
-        x = static_cast<char const *>(memchr(b._ptr, ':', b._size));
+        x = static_cast<const char *>(memchr(b._ptr, ':', b._size));
         if (x) {
           host = b.splitOn(x);
           port = b;
@@ -2375,7 +2375,7 @@ mime_scanner_get(MIMEScanner *S, const char **raw_input_s, const char *raw_input
   const char *raw_input_c, *lf_ptr;
   ParseResult zret = PARSE_RESULT_CONT;
   // Need this for handling dangling CR.
-  static char const RAW_CR = ParseRules::CHAR_CR;
+  static const char RAW_CR = ParseRules::CHAR_CR;
 
   ink_assert((raw_input_s != NULL) && (*raw_input_s != NULL));
   ink_assert(raw_input_e != NULL);
@@ -2419,7 +2419,7 @@ mime_scanner_get(MIMEScanner *S, const char **raw_input_s, const char *raw_input
       }
       break;
     case MIME_PARSE_INSIDE:
-      lf_ptr = static_cast<char const *>(memchr(raw_input_c, ParseRules::CHAR_LF, runway));
+      lf_ptr = static_cast<const char *>(memchr(raw_input_c, ParseRules::CHAR_LF, runway));
       if (lf_ptr) {
         raw_input_c = lf_ptr + 1;
         if (MIME_SCANNER_TYPE_LINE == raw_input_scan_type) {

--- a/proxy/hdrs/MIME.h
+++ b/proxy/hdrs/MIME.h
@@ -155,7 +155,7 @@ struct MIMEField {
 
      @return The index of @a value.
   */
-  int value_get_index(char const *value, int length) const;
+  int value_get_index(const char *value, int length) const;
 
   const char *value_get(int *length) const;
   int32_t value_get_int() const;
@@ -1002,9 +1002,9 @@ public:
       This parses the host field for brackets and port value.
       @return The mime HOST field if it has a value, @c NULL otherwise.
   */
-  MIMEField *get_host_port_values(char const **host_ptr, ///< [out] Pointer to host.
+  MIMEField *get_host_port_values(const char **host_ptr, ///< [out] Pointer to host.
                                   int *host_len,         ///< [out] Length of host.
-                                  char const **port_ptr, ///< [out] Pointer to port.
+                                  const char **port_ptr, ///< [out] Pointer to port.
                                   int *port_len          ///< [out] Length of port.
                                   );
 

--- a/proxy/hdrs/URL.cc
+++ b/proxy/hdrs/URL.cc
@@ -1232,15 +1232,15 @@ url_parse_no_path_component_breakdown(HdrHeap *heap, URLImpl *url, const char **
 */
 
 ParseResult
-url_parse_internet(HdrHeap *heap, URLImpl *url, char const **start, char const *end, bool copy_strings_p)
+url_parse_internet(HdrHeap *heap, URLImpl *url, const char **start, char const *end, bool copy_strings_p)
 {
-  char const *cur = *start;
-  char const *base;        // Base for host/port field.
-  char const *bracket = 0; // marker for open bracket, if any.
+  const char *cur = *start;
+  const char *base;        // Base for host/port field.
+  const char *bracket = 0; // marker for open bracket, if any.
   ts::ConstBuffer user, passw, host, port;
   static size_t const MAX_COLON = 8; // max # of valid colons.
   size_t n_colon                = 0;
-  char const *last_colon        = 0; // pointer to last colon seen.
+  const char *last_colon        = 0; // pointer to last colon seen.
 
   // Do a quick check for "://"
   if (end - cur > 3 && (((':' ^ *cur) | ('/' ^ cur[1]) | ('/' ^ cur[2])) == 0)) {
@@ -1475,7 +1475,7 @@ ParseResult
 url_parse_http_no_path_component_breakdown(HdrHeap *heap, URLImpl *url, const char **start, const char *end, bool copy_strings)
 {
   const char *cur = *start;
-  char const *host_end;
+  const char *host_end;
 
   // Do a quick check for "://" - our only format check.
   if (end - cur > 3 && (((':' ^ *cur) | ('/' ^ cur[1]) | ('/' ^ cur[2])) == 0)) {
@@ -1485,8 +1485,8 @@ url_parse_http_no_path_component_breakdown(HdrHeap *heap, URLImpl *url, const ch
   }
 
   // Grab everything until EOS or slash.
-  char const *base = cur;
-  cur              = static_cast<char const *>(memchr(cur, '/', end - cur));
+  const char *base = cur;
+  cur              = static_cast<const char *>(memchr(cur, '/', end - cur));
   if (cur) {
     host_end = cur;
     ++cur;
@@ -1496,13 +1496,13 @@ url_parse_http_no_path_component_breakdown(HdrHeap *heap, URLImpl *url, const ch
 
   // Did we find something for the host?
   if (base != host_end) {
-    char const *port = 0;
+    const char *port = 0;
     int port_len     = 0;
 
     // Check for port. Search from the end stopping on the first non-digit
     // or more than 5 digits and a delimiter.
     port                   = host_end - 1;
-    char const *port_limit = host_end - 6;
+    const char *port_limit = host_end - 6;
     if (port_limit < base) {
       port_limit = base; // don't go past start.
     }

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -66,7 +66,7 @@ public:
 /// Data item for enumerated type config value.
 template <typename T> struct ConfigEnumPair {
   T _value;
-  char const *_key;
+  const char *_key;
 };
 
 /// Convert a string to an enumeration value.
@@ -75,7 +75,7 @@ template <typename T> struct ConfigEnumPair {
 /// If found @a value is set to the corresponding value in @a list.
 template <typename T, unsigned N>
 static bool
-http_config_enum_search(char const *key, const ConfigEnumPair<T> (&list)[N], MgmtByte &value)
+http_config_enum_search(const char *key, const ConfigEnumPair<T> (&list)[N], MgmtByte &value)
 {
   // We don't expect any of these lists to be more than 10 long, so a linear search is the best choice.
   for (unsigned i = 0; i < N; ++i) {
@@ -93,7 +93,7 @@ http_config_enum_search(char const *key, const ConfigEnumPair<T> (&list)[N], Mgm
 /// If found @a value is set to the corresponding value in @a list.
 template <typename T, unsigned N>
 static bool
-http_config_enum_read(char const *name, const ConfigEnumPair<T> (&list)[N], MgmtByte &value)
+http_config_enum_read(const char *name, const ConfigEnumPair<T> (&list)[N], MgmtByte &value)
 {
   char key[512]; // it's just one key - painful UI if keys are longer than this
   if (REC_ERR_OKAY == RecGetRecordString(name, key, sizeof(key))) {
@@ -154,7 +154,7 @@ http_config_cb(const char * /* name ATS_UNUSED */, RecDataT /* data_type ATS_UNU
 // Oh, how I long for when we can use C++eleventy lambdas without compiler problems!
 // I think for 5.0 when the BC stuff is yanked, we should probably revert this to independent callbacks.
 static int
-http_server_session_sharing_cb(char const *name, RecDataT dtype, RecData data, void *cookie)
+http_server_session_sharing_cb(const char *name, RecDataT dtype, RecData data, void *cookie)
 {
   bool valid_p        = true;
   HttpConfigParams *c = static_cast<HttpConfigParams *>(cookie);

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -510,7 +510,7 @@ public:
   // The next two enable plugins to tag the state machine for
   // the purposes of logging so the instances can be correlated
   // with the source plugin.
-  char const *plugin_tag;
+  const char *plugin_tag;
   int64_t plugin_id;
 
   // hooks_set records whether there are any hooks relevant

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -1901,8 +1901,8 @@ HttpTransact::DecideCacheLookup(State *s)
       // We could a) have 6000 alts (barf, puke, vomit) or b) use the original
       // host header in the url before doing all cache actions (lookups, writes, etc.)
       if (s->txn_conf->maintain_pristine_host_hdr) {
-        char const *host_hdr;
-        char const *port_hdr;
+        const char *host_hdr;
+        const char *port_hdr;
         int host_len, port_len;
         // So, the host header will have the original host header.
         if (incoming_request->get_host_port_values(&host_hdr, &host_len, &port_hdr, &port_len)) {

--- a/proxy/http/HttpTransactHeaders.cc
+++ b/proxy/http/HttpTransactHeaders.cc
@@ -814,7 +814,7 @@ HttpTransactHeaders::insert_via_header_in_response(HttpTransact::State *s, HTTPH
 
   char *incoming_via = s->via_string;
 
-  char const *proto_buf[10]; // 10 seems like a reasonable number of protos to print
+  const char *proto_buf[10]; // 10 seems like a reasonable number of protos to print
   int retval = s->state_machine->populate_client_protocol(proto_buf, countof(proto_buf));
   for (int i = 0; i < retval; i++) {
     memcpy(via_string, proto_buf[i], strlen(proto_buf[i]));

--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -38,7 +38,7 @@
 #include "ts/ParseRules.h"
 
 static const int min_block_transfer_bytes = 256;
-static char const *const CHUNK_HEADER_FMT = "%" PRIx64 "\r\n";
+static const char *const CHUNK_HEADER_FMT = "%" PRIx64 "\r\n";
 // This should be as small as possible because it will only hold the
 // header and trailer per chunk - the chunk body will be a reference to
 // a block in the input stream.

--- a/proxy/http2/HTTP2.cc
+++ b/proxy/http2/HTTP2.cc
@@ -47,19 +47,19 @@ static size_t HTTP2_LEN_STATUS_VALUE_STR = 3;
 
 // Statistics
 RecRawStatBlock *http2_rsb;
-static char const *const HTTP2_STAT_CURRENT_CLIENT_SESSION_NAME  = "proxy.process.http2.current_client_sessions";
-static char const *const HTTP2_STAT_CURRENT_CLIENT_STREAM_NAME   = "proxy.process.http2.current_client_streams";
-static char const *const HTTP2_STAT_TOTAL_CLIENT_STREAM_NAME     = "proxy.process.http2.total_client_streams";
-static char const *const HTTP2_STAT_TOTAL_TRANSACTIONS_TIME_NAME = "proxy.process.http2.total_transactions_time";
-static char const *const HTTP2_STAT_TOTAL_CLIENT_CONNECTION_NAME = "proxy.process.http2.total_client_connections";
-static char const *const HTTP2_STAT_CONNECTION_ERRORS_NAME       = "proxy.process.http2.connection_errors";
-static char const *const HTTP2_STAT_STREAM_ERRORS_NAME           = "proxy.process.http2.stream_errors";
-static char const *const HTTP2_STAT_SESSION_DIE_DEFAULT_NAME     = "proxy.process.http2.session_die_default";
-static char const *const HTTP2_STAT_SESSION_DIE_OTHER_NAME       = "proxy.process.http2.session_die_other";
-static char const *const HTTP2_STAT_SESSION_DIE_ACTIVE_NAME      = "proxy.process.http2.session_die_active";
-static char const *const HTTP2_STAT_SESSION_DIE_INACTIVE_NAME    = "proxy.process.http2.session_die_inactive";
-static char const *const HTTP2_STAT_SESSION_DIE_EOS_NAME         = "proxy.process.http2.session_die_eos";
-static char const *const HTTP2_STAT_SESSION_DIE_ERROR_NAME       = "proxy.process.http2.session_die_error";
+static const char *const HTTP2_STAT_CURRENT_CLIENT_SESSION_NAME  = "proxy.process.http2.current_client_sessions";
+static const char *const HTTP2_STAT_CURRENT_CLIENT_STREAM_NAME   = "proxy.process.http2.current_client_streams";
+static const char *const HTTP2_STAT_TOTAL_CLIENT_STREAM_NAME     = "proxy.process.http2.total_client_streams";
+static const char *const HTTP2_STAT_TOTAL_TRANSACTIONS_TIME_NAME = "proxy.process.http2.total_transactions_time";
+static const char *const HTTP2_STAT_TOTAL_CLIENT_CONNECTION_NAME = "proxy.process.http2.total_client_connections";
+static const char *const HTTP2_STAT_CONNECTION_ERRORS_NAME       = "proxy.process.http2.connection_errors";
+static const char *const HTTP2_STAT_STREAM_ERRORS_NAME           = "proxy.process.http2.stream_errors";
+static const char *const HTTP2_STAT_SESSION_DIE_DEFAULT_NAME     = "proxy.process.http2.session_die_default";
+static const char *const HTTP2_STAT_SESSION_DIE_OTHER_NAME       = "proxy.process.http2.session_die_other";
+static const char *const HTTP2_STAT_SESSION_DIE_ACTIVE_NAME      = "proxy.process.http2.session_die_active";
+static const char *const HTTP2_STAT_SESSION_DIE_INACTIVE_NAME    = "proxy.process.http2.session_die_inactive";
+static const char *const HTTP2_STAT_SESSION_DIE_EOS_NAME         = "proxy.process.http2.session_die_eos";
+static const char *const HTTP2_STAT_SESSION_DIE_ERROR_NAME       = "proxy.process.http2.session_die_error";
 
 union byte_pointer {
   byte_pointer(void *p) : ptr(p) {}

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -249,7 +249,7 @@ public:
   }
 
   virtual int
-  populate_protocol(char const **result, int size) const
+  populate_protocol(const char **result, int size) const
   {
     int retval = 0;
     if (size > 0) {

--- a/proxy/logging/LogAccess.h
+++ b/proxy/logging/LogAccess.h
@@ -341,7 +341,7 @@ public:
   // so that there are no alignment problems with the int values.
   //
   static int round_strlen(int len);
-  static int strlen(char const *str);
+  static int strlen(const char *str);
 
 public:
   inkcoreapi static void marshal_int(char *dest, int64_t source);
@@ -371,7 +371,7 @@ LogAccess::round_strlen(int len)
   -------------------------------------------------------------------------*/
 
 inline int
-LogAccess::strlen(char const *str)
+LogAccess::strlen(const char *str)
 {
   if (str == NULL || str[0] == 0) {
     return round_strlen(sizeof(DEFAULT_STR));

--- a/proxy/logging/LogAccessHttp.cc
+++ b/proxy/logging/LogAccessHttp.cc
@@ -234,7 +234,7 @@ int
 LogAccessHttp::marshal_plugin_identity_tag(char *buf)
 {
   int len         = INK_MIN_ALIGN;
-  char const *tag = m_http_sm->plugin_tag;
+  const char *tag = m_http_sm->plugin_tag;
 
   if (!tag) {
     tag = "*";
@@ -1104,7 +1104,7 @@ LogAccessHttp::marshal_server_host_ip(char *buf)
 int
 LogAccessHttp::marshal_server_host_name(char *buf)
 {
-  char const *str = NULL;
+  const char *str = NULL;
   int padded_len  = INK_MIN_ALIGN;
   int actual_len  = 0;
 

--- a/proxy/logging/LogHost.h
+++ b/proxy/logging/LogHost.h
@@ -85,7 +85,7 @@ public:
     return m_port;
   }
 
-  char const *
+  const char *
   ipstr() const
   {
     return m_ipstr;

--- a/proxy/logging/test_LogUtils.cc
+++ b/proxy/logging/test_LogUtils.cc
@@ -77,7 +77,7 @@ main(int argc, const char **argv)
 // Stub
 //
 void
-RecSignalManager(int, char const *, unsigned long)
+RecSignalManager(int, const char *, unsigned long)
 {
   ink_release_assert(false);
 }


### PR DESCRIPTION
This change makes `const char` the default format before `char const`.
Searching through the code, it looks like there are more usages of `const char`, so it looks normal and easier to adopt that terminology:

```
➜  trafficserver git:(fix_const_char_inconsistency) ag 'char const' -o --nogroup | wc -l
577
➜  trafficserver git:(fix_const_char_inconsistency) ag 'const char' -o --nogroup | wc -l                                                                           
6897
➜  trafficserver git:(fix_const_char_inconsistency)
```

Signed-off-by: David Calavera <david.calavera@gmail.com>