### PR TITLE
TS-5008 CID 1022007 Logically dead code

### DIFF
--- a/mgmt/cluster/VMap.cc
+++ b/mgmt/cluster/VMap.cc
@@ -617,11 +617,7 @@ VMap::rl_checkGlobConflict(char *virt_ip)
   }
 
   if (ink_hash_table_lookup(our_map, virt_ip, &hash_value) != 0) {
-    if (in_ext_map) {
-      ret = true;
-    } else {
-      ret = false;
-    }
+    ret = false;
   }
 
   return ret;


### PR DESCRIPTION
The first  "if (in_ext_map)" and if (ret) return ret; causes the following code if (in_ext_map) to never execute.  Modified to clean it up.

 if (in_ext_map) {
612    ret = true;
613  }
614
615  if (ret) {
616    return ret;
617  }
618
619  if (ink_hash_table_lookup(our_map, virt_ip, &hash_value) != 0) {
   	const: At condition in_ext_map, the value of in_ext_map must be equal to 0.
   	dead_error_condition: The condition in_ext_map cannot be true.
620    if (in_ext_map) {
   	
CID 1022007 (#1 of 1): Logically dead code (DEADCODE)
dead_error_line: Execution cannot reach this statement: ret = true;.
621      ret = true;
622    } else {
623      ret = false;
624    }
625  }