### PR TITLE
TS-5009 CID 1022011 Logically dead code removal

### DIFF
--- a/iocore/eventsystem/P_IOBuffer.h
+++ b/iocore/eventsystem/P_IOBuffer.h
@@ -684,8 +684,7 @@ IOBufferReader::consume(int64_t n)
 
 TS_INLINE char &IOBufferReader::operator[](int64_t i)
 {
-  static char _error = '\0';
-  IOBufferBlock *b   = block.get();
+  IOBufferBlock *b = block.get();
 
   i += start_offset;
   while (b) {
@@ -696,12 +695,7 @@ TS_INLINE char &IOBufferReader::operator[](int64_t i)
     b = b->next.get();
   }
 
-  ink_assert(!"out of range");
-  if (unlikely(b)) {
-    return *b->start();
-  }
-
-  return _error;
+  ink_release_assert(!"out of range");
 }
 
 TS_INLINE void


### PR DESCRIPTION
Please review - I changed this code to ink_release_assert instead of the following code, which seems to either return '\0' or *b->start(); but will ink_assert in debug mode.

  ink_assert(!"out of range");
    const: At condition !!b, the value of b must be equal to 0.
    null: At condition !!b, the value of b must be NULL.
    dead_error_condition: The condition !!b cannot be true.
700  if (unlikely(b)) {

CID 1022011 (#1 of 1): Logically dead code (DEADCODE)
dead_error_line: Execution cannot reach this statement: return b->start();.
701    return *b->start();
702  }
