### PR TITLE
TS-5023 Allow diags.log and traffic.out to be rotated by size or time

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -297,6 +297,8 @@ System Variables
          The clock starts ticking on |TS| boot.
    ``2`` Enables output log rolling when the output log reaches a specific size
          (specified with :ts:cv:`proxy.config.output.logfile.rolling_size_mb`).
+   ``3`` Enables output log rolling at specific intervals or when the output log
+         reaches a specific size (whichever occurs first).
    ===== ======================================================================
 
 .. ts:cv:: CONFIG proxy.config.output.logfile.rolling_interval_sec INT 3600
@@ -2858,6 +2860,8 @@ Diagnostic Logging Configuration
    ``2`` Enables diagnostics log rolling when the diagnostics log reaches a
          specific size (specified with
          :ts:cv:`proxy.config.diags.logfile.rolling_size_mb`).
+   ``3`` Enables diagnostics log rolling at specific intervals or when the
+         diagnostics log reaches a specific size (whichever occurs first).
    ===== ======================================================================
 
 .. ts:cv:: CONFIG proxy.config.diags.logfile.rolling_interval_sec INT 3600

--- a/lib/ts/Diags.cc
+++ b/lib/ts/Diags.cc
@@ -620,7 +620,8 @@ Diags::should_roll_diagslog()
 
   // Roll diags_log if necessary
   if (diags_log && diags_log->is_init()) {
-    if (diagslog_rolling_enabled == RollingEnabledValues::ROLL_ON_SIZE) {
+    if (diagslog_rolling_enabled == RollingEnabledValues::ROLL_ON_SIZE ||
+        diagslog_rolling_enabled == RollingEnabledValues::ROLL_ON_TIME_OR_SIZE) {
       // if we can't even check the file, we can forget about rotating
       struct stat buf;
       if (fstat(fileno(diags_log->m_fp), &buf) != 0)
@@ -644,7 +645,10 @@ Diags::should_roll_diagslog()
           ret_val = true;
         }
       }
-    } else if (diagslog_rolling_enabled == RollingEnabledValues::ROLL_ON_TIME) {
+    }
+
+    if (diagslog_rolling_enabled == RollingEnabledValues::ROLL_ON_TIME ||
+        diagslog_rolling_enabled == RollingEnabledValues::ROLL_ON_TIME_OR_SIZE) {
       time_t now = time(nullptr);
       if (diagslog_rolling_interval != -1 && (now - diagslog_time_last_roll) >= diagslog_rolling_interval) {
         fflush(diags_log->m_fp);
@@ -702,7 +706,8 @@ Diags::should_roll_outputlog()
 
   // Roll stdout_log if necessary
   if (stdout_log->is_init()) {
-    if (outputlog_rolling_enabled == RollingEnabledValues::ROLL_ON_SIZE) {
+    if (outputlog_rolling_enabled == RollingEnabledValues::ROLL_ON_SIZE ||
+        outputlog_rolling_enabled == RollingEnabledValues::ROLL_ON_TIME_OR_SIZE) {
       // if we can't even check the file, we can forget about rotating
       struct stat buf;
       if (fstat(fileno(stdout_log->m_fp), &buf) != 0)
@@ -732,7 +737,10 @@ Diags::should_roll_outputlog()
           ret_val = true;
         }
       }
-    } else if (outputlog_rolling_enabled == RollingEnabledValues::ROLL_ON_TIME) {
+    }
+
+    if (outputlog_rolling_enabled == RollingEnabledValues::ROLL_ON_TIME ||
+        outputlog_rolling_enabled == RollingEnabledValues::ROLL_ON_TIME_OR_SIZE) {
       time_t now = time(nullptr);
       if (outputlog_rolling_interval != -1 && (now - outputlog_time_last_roll) >= outputlog_rolling_interval) {
         // since usually stdout and stderr are the same file on disk, we should just

--- a/lib/ts/Diags.h
+++ b/lib/ts/Diags.h
@@ -74,7 +74,7 @@ typedef enum {  // do not renumber --- used as array index
   DL_Undefined  // must be last, used for size!
 } DiagsLevel;
 
-enum RollingEnabledValues { NO_ROLLING = 0, ROLL_ON_TIME, ROLL_ON_SIZE, INVALID_ROLLING_VALUE };
+enum RollingEnabledValues { NO_ROLLING = 0, ROLL_ON_TIME, ROLL_ON_SIZE, ROLL_ON_TIME_OR_SIZE, INVALID_ROLLING_VALUE };
 
 enum DiagsShowLocation { SHOW_LOCATION_NONE = 0, SHOW_LOCATION_DEBUG, SHOW_LOCATION_ALL };
 


### PR DESCRIPTION
Create a third option for diagnostic logs: roll by time or size,
whichever comes first. This is useful in certain circumstances.