### PR TITLE
TS-4719: Make AIO threads interleave memory across NUMA nodes.

### DIFF
--- a/iocore/aio/AIO.cc
+++ b/iocore/aio/AIO.cc
@@ -186,6 +186,10 @@ struct AIOThreadInfo : public Continuation {
   {
     (void)event;
     (void)e;
+#if TS_USE_HWLOC
+    hwloc_set_membind_nodeset(ink_get_topology(), hwloc_topology_get_topology_nodeset(ink_get_topology()), HWLOC_MEMBIND_INTERLEAVE,
+                              HWLOC_MEMBIND_THREAD);
+#endif
     aio_thread_main(this);
     delete this;
     return EVENT_DONE;


### PR DESCRIPTION
(cherry picked from commit e5261f4d5edf557fe03571b46eacc61d430425e3)