### PR TITLE
TS-4957: Make the use of madvise() with MADV_DONTDUMP configurable.

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3332,6 +3332,12 @@ Sockets
    For more information on the implications of enabling huge pages, see
    `Wikipedia <http://en.wikipedia.org/wiki/Page_%28computer_memory%29#Page_size_trade-off>_`.
 
+.. ts:cv:: CONFIG proxy.config.allocator.dontdump_iobuffers INT 1
+
+  Enable (1) the exclusion of IO buffers from core files when ATS crashes on supported
+  platforms.  (Currently only linux).  IO buffers are allocated with the MADV_DONTDUMP 
+  with madvise() on linux platforms that support MADV_DONTDUMP.  Enabled by default.
+
 .. ts:cv:: CONFIG proxy.config.http.enabled INT 1
 
    Turn on or off support for HTTP proxying. This is rarely used, the one

--- a/iocore/eventsystem/EventSystem.cc
+++ b/iocore/eventsystem/EventSystem.cc
@@ -45,9 +45,21 @@ ink_event_system_init(ModuleVersion v)
   REC_ReadConfigInteger(config_max_iobuffer_size, "proxy.config.io.max_buffer_size");
 
   max_iobuffer_size = buffer_size_to_index(config_max_iobuffer_size, DEFAULT_BUFFER_SIZES - 1);
-  if (default_small_iobuffer_size > max_iobuffer_size)
+  if (default_small_iobuffer_size > max_iobuffer_size) {
     default_small_iobuffer_size = max_iobuffer_size;
-  if (default_large_iobuffer_size > max_iobuffer_size)
+  }
+  if (default_large_iobuffer_size > max_iobuffer_size) {
     default_large_iobuffer_size = max_iobuffer_size;
+  }
+
+#ifdef MADV_DONTDUMP // This should only exist on Linux 3.4 and higher.
+  RecBool dont_dump_enabled = true;
+  RecGetRecordBool("proxy.config.allocator.dontdump_iobuffers", &dont_dump_enabled, false);
+
+  if (dont_dump_enabled) {
+    iobuffer_advice |= MADV_DONTDUMP;
+  }
+#endif
+
   init_buffer_allocators();
 }

--- a/iocore/eventsystem/IOBuffer.cc
+++ b/iocore/eventsystem/IOBuffer.cc
@@ -38,6 +38,7 @@ inkcoreapi ClassAllocator<IOBufferBlock> ioBlockAllocator("ioBlockAllocator", DE
 int64_t default_large_iobuffer_size = DEFAULT_LARGE_BUFFER_SIZE;
 int64_t default_small_iobuffer_size = DEFAULT_SMALL_BUFFER_SIZE;
 int64_t max_iobuffer_size           = DEFAULT_BUFFER_SIZES - 1;
+int iobuffer_advice                 = 0;
 
 //
 // Initialization
@@ -46,11 +47,6 @@ void
 init_buffer_allocators()
 {
   char *name;
-  int advice = 0;
-
-#ifdef MADV_DONTDUMP // This should only exist on Linux 3.4 and higher.
-  advice = MADV_DONTDUMP;
-#endif
 
   for (int i = 0; i < DEFAULT_BUFFER_SIZES; i++) {
     int64_t s = DEFAULT_BUFFER_BASE_SIZE * (((int64_t)1) << i);
@@ -61,7 +57,7 @@ init_buffer_allocators()
 
     name = new char[64];
     snprintf(name, 64, "ioBufAllocator[%d]", i);
-    ioBufAllocator[i].re_init(name, s, n, a, advice);
+    ioBufAllocator[i].re_init(name, s, n, a, iobuffer_advice);
   }
 }
 

--- a/iocore/eventsystem/I_IOBuffer.h
+++ b/iocore/eventsystem/I_IOBuffer.h
@@ -58,6 +58,7 @@ class VIO;
 inkcoreapi extern int64_t max_iobuffer_size;
 extern int64_t default_small_iobuffer_size;
 extern int64_t default_large_iobuffer_size; // matched to size of OS buffers
+extern int iobuffer_advice;
 
 #if !defined(TRACK_BUFFER_USER)
 #define TRACK_BUFFER_USER 1

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -2029,6 +2029,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.allocator.hugepages", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_NULL, "[0-1]", RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.allocator.dontdump_iobuffers", RECD_INT, "1", RECU_RESTART_TS, RR_NULL, RECC_NULL, "[0-1]", RECA_NULL}
+  ,
 
   //############
   //#


### PR DESCRIPTION
(cherry picked from commit 514d3fd7de5841b8a74cd32bed001db9b479764f)

Backport PR to 6.2.x