### PR TITLE
TS-4845: NULL dereference in url_sig

### DIFF
--- a/plugins/experimental/url_sig/url_sig.c
+++ b/plugins/experimental/url_sig/url_sig.c
@@ -561,7 +561,9 @@ deny:
 
 /* ********* Allow ********* */
 allow:
-  app_qry = getAppQueryString(query, strlen(query));
+  if (query != NULL) {
+    app_qry = getAppQueryString(query, strlen(query));
+  }
 
   TSfree(url);
   /* drop the query string so we can cache-hit */


### PR DESCRIPTION
(cherry picked from commit 6b4100c1200e309e229c9fdd24004e1d4fb59c9a)

backport PR to 6.2.1