### PR TITLE
TS-5026: Update keep_alive_no_activity_timeout_in doc and template

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -1230,7 +1230,7 @@ Parent Proxy Configuration
 HTTP Connection Timeouts
 ========================
 
-.. ts:cv:: CONFIG proxy.config.http.keep_alive_no_activity_timeout_in INT 115
+.. ts:cv:: CONFIG proxy.config.http.keep_alive_no_activity_timeout_in INT 120
    :reloadable:
    :overridable:
 

--- a/doc/admin-guide/performance/index.en.rst
+++ b/doc/admin-guide/performance/index.en.rst
@@ -318,7 +318,7 @@ keepalive timeout which (if set lower) will likely take precedence.
 
 ::
 
-    CONFIG proxy.config.http.keep_alive_no_activity_timeout_in INT 115
+    CONFIG proxy.config.http.keep_alive_no_activity_timeout_in INT 120
     CONFIG proxy.config.http.keep_alive_no_activity_timeout_out INT 120
 
 Origin Connection Timeouts

--- a/proxy/config/records.config.default.in
+++ b/proxy/config/records.config.default.in
@@ -44,7 +44,7 @@ CONFIG proxy.config.http.uncacheable_requests_bypass_parent INT 1
 # HTTP connection timeouts (secs). Docs:
 #    https://docs.trafficserver.apache.org/records.config#http-connection-timeouts
 ##############################################################################
-CONFIG proxy.config.http.keep_alive_no_activity_timeout_in INT 115
+CONFIG proxy.config.http.keep_alive_no_activity_timeout_in INT 120
 CONFIG proxy.config.http.keep_alive_no_activity_timeout_out INT 120
 CONFIG proxy.config.http.transaction_no_activity_timeout_in INT 30
 CONFIG proxy.config.http.transaction_no_activity_timeout_out INT 30

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -425,7 +425,7 @@ struct OverridableHttpConfigParams {
       cache_guaranteed_min_lifetime(0),
       cache_guaranteed_max_lifetime(31536000),
       cache_max_stale_age(604800),
-      keep_alive_no_activity_timeout_in(115),
+      keep_alive_no_activity_timeout_in(120),
       keep_alive_no_activity_timeout_out(120),
       transaction_no_activity_timeout_in(30),
       transaction_no_activity_timeout_out(30),


### PR DESCRIPTION
TS-4700 made essential changes to update the default value. There are some
documents and a template for records.config need to be updated.

This will make `traffic_ctl config diff` output cleaner.