### PR TITLE
TS-5027: Replace readdir_r with readdir.

### DIFF
--- a/cmd/traffic_manager/traffic_manager.cc
+++ b/cmd/traffic_manager/traffic_manager.cc
@@ -581,8 +581,7 @@ main(int argc, const char **argv)
       }
     }
 
-    // NOTE: do NOT call closelog() here.  Solaris gets confused
-    //   and some how it hoses later calls to readdir_r.
+    // NOTE: do NOT call closelog() here.  Solaris gets confused.
     openlog("traffic_manager", LOG_PID | LOG_NDELAY | LOG_NOWAIT, facility_int);
 
     lmgmt->syslog_facility = facility_int;

--- a/mgmt/FileManager.cc
+++ b/mgmt/FileManager.cc
@@ -372,7 +372,6 @@ FileManager::restoreSnap(const char *snapName, const char *snapDir)
 SnapResult
 FileManager::removeSnap(const char *snapName, const char *snapDir)
 {
-  struct dirent *dirEntrySpace;
   struct dirent *entryPtr;
   DIR *dir;
   char *snapPath;
@@ -389,13 +388,7 @@ FileManager::removeSnap(const char *snapName, const char *snapDir)
     return SNAP_NOT_FOUND;
   }
 
-  dirEntrySpace = (struct dirent *)ats_malloc(sizeof(struct dirent) + ink_file_namemax(".") + 1);
-
-  while (readdir_r(dir, dirEntrySpace, &entryPtr) == 0) {
-    if (!entryPtr) {
-      break;
-    }
-
+  while ((entryPtr = readdir(dir))) {
     if (strcmp(".", entryPtr->d_name) == 0 || strcmp("..", entryPtr->d_name) == 0) {
       continue;
     }
@@ -410,7 +403,6 @@ FileManager::removeSnap(const char *snapName, const char *snapDir)
     delete[] snapFilePath;
   }
 
-  ats_free(dirEntrySpace);
   closedir(dir);
 
   // If we managed to get everything, remove the directory

--- a/mgmt/MultiFile.cc
+++ b/mgmt/MultiFile.cc
@@ -108,19 +108,12 @@ MultiFile::WalkFiles(ExpandingArray *fileList)
     mgmt_log("[MultiFile::WalkFiles] Unable to open %s directory: %s: %s\n", dirDescript, managedDir, strerror(errno));
     return MF_NO_DIR;
   }
-  // The fun of Solaris - readdir_r requires a buffer passed into it
-  //   The man page says this obscene expression gives us the proper
-  //     size
-  dirEntry = (struct dirent *)ats_malloc(sizeof(struct dirent) + ink_file_namemax(".") + 1);
 
-  struct dirent *result;
-  while (readdir_r(dir, dirEntry, &result) == 0) {
-    if (!result) {
-      break;
-    }
+  while ((dirEntry = readdir(dir))) {
     fileName                = dirEntry->d_name;
     filePath                = newPathString(managedDir, fileName);
     records_config_filePath = newPathString(filePath, "records.config");
+
     if (stat(filePath, &fileInfo) < 0) {
       mgmt_log("[MultiFile::WalkFiles] Stat of a %s failed %s: %s\n", dirDescript, fileName, strerror(errno));
     } else {
@@ -137,11 +130,11 @@ MultiFile::WalkFiles(ExpandingArray *fileList)
         fileList->addEntry(fileListEntry);
       }
     }
+
     delete[] filePath;
     delete[] records_config_filePath;
   }
 
-  ats_free(dirEntry);
   closedir(dir);
 
   fileList->sortWithFunction(fileEntryCmpFunc);

--- a/mgmt/Rollback.cc
+++ b/mgmt/Rollback.cc
@@ -645,7 +645,6 @@ Rollback::findVersions_ml(ExpandingArray *listNames)
   ats_scoped_str sysconfdir(RecConfigReadConfigDir());
 
   DIR *dir;
-  struct dirent *dirEntrySpace;
   struct dirent *entryPtr;
 
   dir = opendir(sysconfdir);
@@ -655,16 +654,8 @@ Rollback::findVersions_ml(ExpandingArray *listNames)
              strerror(errno));
     return INVALID_VERSION;
   }
-  // The fun of Solaris - readdir_r requires a buffer passed into it
-  //   The man page says this obscene expression gives us the proper
-  //     size
-  dirEntrySpace = (struct dirent *)ats_malloc(sizeof(struct dirent) + ink_file_namemax(".") + 1);
 
-  while (readdir_r(dir, dirEntrySpace, &entryPtr) == 0) {
-    if (!entryPtr) {
-      break;
-    }
-
+  while ((entryPtr = readdir(dir))) {
     if ((version = extractVersionInfo(listNames, entryPtr->d_name)) != INVALID_VERSION) {
       count++;
 
@@ -674,7 +665,6 @@ Rollback::findVersions_ml(ExpandingArray *listNames)
     }
   }
 
-  ats_free(dirEntrySpace);
   closedir(dir);
 
   numVersions = count;

--- a/mgmt/WebMgmtUtils.cc
+++ b/mgmt/WebMgmtUtils.cc
@@ -1245,20 +1245,10 @@ getFilesInDirectory(char *managedDir, ExpandingArray *fileList)
     mgmt_log("[getFilesInDirectory] Unable to open %s directory: %s\n", managedDir, strerror(errno));
     return -1;
   }
-  // The fun of Solaris - readdir_r requires a buffer passed into it
-  //   The man page says this obscene expression gives us the proper
-  //     size
-  dirEntry = (struct dirent *)alloca(sizeof(struct dirent) + ink_file_namemax(".") + 1);
 
-  struct dirent *result;
-  while (readdir_r(dir, dirEntry, &result) == 0) {
-    if (!result) {
-      break;
-    }
+  while ((dirEntry = readdir(dir))) {
     fileName = dirEntry->d_name;
-    if (!fileName || !*fileName) {
-      continue;
-    }
+
     filePath = newPathString(managedDir, fileName);
     if (stat(filePath, &fileInfo) < 0) {
       mgmt_log("[getFilesInDirectory] Stat of a %s failed : %s\n", fileName, strerror(errno));

--- a/proxy/http/HttpBodyFactory.cc
+++ b/proxy/http/HttpBodyFactory.cc
@@ -620,7 +620,7 @@ RawHashTable *
 HttpBodyFactory::load_sets_from_directory(char *set_dir)
 {
   DIR *dir;
-  struct dirent *entry_buffer, *result;
+  struct dirent *dirEntry;
   RawHashTable *new_table_of_sets;
 
   if (set_dir == nullptr) {
@@ -641,13 +641,12 @@ HttpBodyFactory::load_sets_from_directory(char *set_dir)
   }
 
   new_table_of_sets = new RawHashTable(RawHashTable_KeyType_String);
-  entry_buffer      = (struct dirent *)ats_malloc(sizeof(struct dirent) + MAXPATHLEN + 1);
 
   //////////////////////////////////////////
   // loop over each language subdirectory //
   //////////////////////////////////////////
 
-  while ((readdir_r(dir, entry_buffer, &result) == 0) && (result != nullptr)) {
+  while ((dirEntry = readdir(dir))) {
     int status;
     struct stat stat_buf;
     char subdir[MAXPATHLEN + 1];
@@ -656,14 +655,16 @@ HttpBodyFactory::load_sets_from_directory(char *set_dir)
     // ensure a subdirectory, and not starting with '.' //
     //////////////////////////////////////////////////////
 
-    if ((entry_buffer->d_name)[0] == '.') {
+    if ((dirEntry->d_name)[0] == '.') {
       continue;
     }
-    ink_filepath_make(subdir, sizeof(subdir), set_dir, entry_buffer->d_name);
+
+    ink_filepath_make(subdir, sizeof(subdir), set_dir, dirEntry->d_name);
     status = stat(subdir, &stat_buf);
     if (status != 0) {
       continue; // can't stat
     }
+
     if (!S_ISDIR(stat_buf.st_mode)) {
       continue; // not a dir
     }
@@ -672,14 +673,13 @@ HttpBodyFactory::load_sets_from_directory(char *set_dir)
     // at this point, 'subdir' might be a valid template dir //
     ///////////////////////////////////////////////////////////
 
-    HttpBodySet *body_set = load_body_set_from_directory(entry_buffer->d_name, subdir);
+    HttpBodySet *body_set = load_body_set_from_directory(dirEntry->d_name, subdir);
     if (body_set != nullptr) {
-      Debug("body_factory", "  %s -> %p", entry_buffer->d_name, body_set);
-      new_table_of_sets->setValue((RawHashTable_Key)(entry_buffer->d_name), (RawHashTable_Value)body_set);
+      Debug("body_factory", "  %s -> %p", dirEntry->d_name, body_set);
+      new_table_of_sets->setValue((RawHashTable_Key)(dirEntry->d_name), (RawHashTable_Value)body_set);
     }
   }
 
-  ats_free(entry_buffer);
   closedir(dir);
 
   return (new_table_of_sets);
@@ -693,7 +693,7 @@ HttpBodyFactory::load_body_set_from_directory(char *set_name, char *tmpl_dir)
   int status;
   struct stat stat_buf;
   char path[MAXPATHLEN + 1];
-  struct dirent *entry_buffer, *result;
+  struct dirent *dirEntry;
 
   ////////////////////////////////////////////////
   // ensure we can open tmpl_dir as a directory //
@@ -726,24 +726,24 @@ HttpBodyFactory::load_body_set_from_directory(char *set_name, char *tmpl_dir)
 
   Debug("body_factory", "  body_set = %p (set_name '%s', lang '%s', charset '%s')", body_set, body_set->set_name,
         body_set->content_language, body_set->content_charset);
-  entry_buffer = (struct dirent *)ats_malloc(sizeof(struct dirent) + MAXPATHLEN + 1);
 
-  while ((readdir_r(dir, entry_buffer, &result) == 0) && (result != nullptr)) {
+  while ((dirEntry = readdir(dir))) {
     HttpBodyTemplate *tmpl;
 
     ///////////////////////////////////////////////////////////////
     // all template files have name of the form <type>#<subtype> //
     ///////////////////////////////////////////////////////////////
 
-    if ((strchr(entry_buffer->d_name, '#') == nullptr) && (strcmp(entry_buffer->d_name, "default") != 0)) {
+    if ((strchr(dirEntry->d_name, '#') == nullptr) && (strcmp(dirEntry->d_name, "default") != 0)) {
       continue;
     }
 
-    snprintf(path, sizeof(path), "%s/%s", tmpl_dir, entry_buffer->d_name);
+    snprintf(path, sizeof(path), "%s/%s", tmpl_dir, dirEntry->d_name);
     status = stat(path, &stat_buf);
     if (status != 0) {
       continue; // can't stat
     }
+
     if (!S_ISREG(stat_buf.st_mode)) {
       continue; // not a file
     }
@@ -753,14 +753,14 @@ HttpBodyFactory::load_body_set_from_directory(char *set_name, char *tmpl_dir)
     ////////////////////////////////
 
     tmpl = new HttpBodyTemplate();
-    if (!tmpl->load_from_file(tmpl_dir, entry_buffer->d_name)) {
+    if (!tmpl->load_from_file(tmpl_dir, dirEntry->d_name)) {
       delete tmpl;
     } else {
-      Debug("body_factory", "      %s -> %p", entry_buffer->d_name, tmpl);
-      body_set->set_template_by_name(entry_buffer->d_name, tmpl);
+      Debug("body_factory", "      %s -> %p", dirEntry->d_name, tmpl);
+      body_set->set_template_by_name(dirEntry->d_name, tmpl);
     }
   }
-  ats_free(entry_buffer);
+
   closedir(dir);
   return (body_set);
 }

--- a/proxy/logging/LogConfig.cc
+++ b/proxy/logging/LogConfig.cc
@@ -708,8 +708,7 @@ LogConfig::update_space_used()
   int64_t total_space_used, partition_space_left;
   char path[MAXPATHLEN];
   int sret;
-  struct dirent entry;
-  struct dirent *result;
+  struct dirent *entry;
   struct stat sbuf;
   DIR *ld;
 
@@ -722,8 +721,8 @@ LogConfig::update_space_used()
     m_log_directory_inaccessible = true;
     return;
   }
+
   // check if logging directory exists and is searchable readable & writable
-  //
   int err;
   do {
     err = access(logfile_dir, R_OK | W_OK | X_OK);
@@ -749,18 +748,14 @@ LogConfig::update_space_used()
   total_space_used = 0LL;
   candidate_count  = 0;
 
-  while (readdir_r(ld, &entry, &result) == 0) {
-    if (!result) {
-      break;
-    }
-
-    snprintf(path, MAXPATHLEN, "%s/%s", logfile_dir, entry.d_name);
+  while ((entry = readdir(ld))) {
+    snprintf(path, MAXPATHLEN, "%s/%s", logfile_dir, entry->d_name);
 
     sret = ::stat(path, &sbuf);
     if (sret != -1 && S_ISREG(sbuf.st_mode)) {
       total_space_used += (int64_t)sbuf.st_size;
 
-      if (auto_delete_rolled_files && LogFile::rolled_logfile(entry.d_name) && candidate_count < MAX_CANDIDATES) {
+      if (auto_delete_rolled_files && LogFile::rolled_logfile(entry->d_name) && candidate_count < MAX_CANDIDATES) {
         //
         // then add this entry to the candidate list
         //
@@ -771,6 +766,7 @@ LogConfig::update_space_used()
       }
     }
   }
+
   ::closedir(ld);
 
   //


### PR DESCRIPTION
Glibc deprecated readdir_r(3), so replace it with readdir(3). We
were already using readdir(3) in many places so this is just accepting
the inevitable.