### PR TITLE
TS-5030: Add API to get the unique client request uuid from a transaction.

### DIFF
--- a/doc/developer-guide/api/functions/TSUuidCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSUuidCreate.en.rst
@@ -36,6 +36,7 @@ Synopsis
 .. function:: TSUuidVersion TSUuidVersionGet(const TSUuid uuid)
 .. function:: TSReturnCode TSUuidStringParse(TSUuid uuid, const char * uuid_str)
 .. function:: const TSUuid TSProcessUuidGet(void)
+.. function:: TSReturnCode TSClientRequestUuidGet(TSHttpTxn txnp, char* uuid_str)
 
 Description
 ===========
@@ -79,11 +80,14 @@ corresponding :type:`TSUuid` object is a serious error. The UUID object does
 not do any sort of reference counting on the string, and you must absolutely
 not free the memory as returned by this API.
 
-Finally, :func:`TSUuidStringParse` can be used to convert an existing
+:func:`TSUuidStringParse` can be used to convert an existing
 :type:`TSUuid` string to a Traffic Server UUID object. This will only succeed
 if the :type:`TSUuid` string is a proper *RFC 4122* UUID. The :type:`TSUuid`
 argument passed to this function must be a properly :func:`TSUuidCreate`
 object, but it does not need to be previously initialized.
+
+Finally, :func:`TSClientRequestUuidGet` can be used to extract
+the client request uuid from a transaction.
 
 Return Values
 =============

--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -1051,12 +1051,9 @@ ConditionId::append_value(std::string &s, const Resources &res ATS_UNUSED)
     }
   } break;
   case ID_QUAL_UNIQUE: {
-    std::ostringstream oss;
-    TSUuid process = TSProcessUuidGet();
-
-    if (process) {
-      oss << TSUuidStringGet(process) << '-' << TSHttpTxnIdGet(res.txnp);
-      s += oss.str();
+    char *uuid = nullptr;
+    if (TS_SUCCESS == TSClientRequestUuidGet(res.txnp, uuid)) {
+      s += uuid;
     }
   } break;
   }

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -9230,6 +9230,23 @@ TSUuidStringGet(const TSUuid uuid)
 }
 
 TSReturnCode
+TSClientRequestUuidGet(TSHttpTxn txnp, char *uuid_str)
+{
+  sdk_assert(sdk_sanity_check_null_ptr((void *)uuid_str) == TS_SUCCESS);
+
+  HttpSM *sm = (HttpSM *)txnp;
+  const char *machine = (char *)Machine::instance()->uuid.getString();
+  int len;
+
+  len = snprintf(uuid_str, sizeof(uuid_str), "%s-%" PRId64 "", machine, sm->sm_id);
+  if (len < (int)sizeof(uuid_str)) {
+    return TS_SUCCESS;
+  }
+
+  return TS_ERROR;;
+}
+
+TSReturnCode
 TSUuidStringParse(TSUuid uuid, const char *str)
 {
   sdk_assert(sdk_sanity_check_null_ptr((void *)uuid) == TS_SUCCESS);

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -2409,6 +2409,7 @@ tsapi TSReturnCode TSUuidCopy(TSUuid dest, const TSUuid src);
 tsapi const char *TSUuidStringGet(const TSUuid uuid);
 tsapi TSUuidVersion TSUuidVersionGet(const TSUuid uuid);
 tsapi TSReturnCode TSUuidStringParse(TSUuid uuid, const char *uuid_str);
+tsapi TSReturnCode TSClientRequestUuidGet(TSHttpTxn txnp, char *uuid_str);
 
 /* Get the process global UUID, resets on every startup */
 tsapi const TSUuid TSProcessUuidGet(void);


### PR DESCRIPTION
The new UUID api introduced in https://github.com/apache/trafficserver/pull/736 is great for tracing operations and requests. However, the most useful information for plugin developers, the unique client request id, is not exposed as an api endpoint. People need to understand very well how TrafficServer works internally to generate this value. By not having the API directly exposed, people need to repeat the same code every time they want to generate this unique identifier.

I'd like to add an API enpoint to generate this identifier based in a given http transaction for plugins to use.

This is be the signature:

```
tsapi const char * TSClientRequestUuidGet(TSHttpTxn txnp);
```

Signed-off-by: David Calavera <david.calavera@gmail.com>