### PR TITLE
TestCase fix: Fix retry counter

### DIFF
--- a/ci/tsqa/tests/test_tls_ticket_key_rotation.py
+++ b/ci/tsqa/tests/test_tls_ticket_key_rotation.py
@@ -150,7 +150,7 @@ class TestTLSTicketKeyRotation(helpers.EnvironmentCase):
                 old_renewed = stdout
                 break
             except Exception:
-                ++count
+                count += 1
                 # If we have tried 30 times and the command still failed, quit here.
                 if count > 30:
                     self.assertTrue(False, "Failed to get the number of renewed keys!")


### PR DESCRIPTION
++count in python adds nothing to count, it does not incr the count variable. This simply fixes that to increment so it doesn't retry forever