### PR TITLE
TS-5036: use absolute path in autoconf/automake files to support YCM-…

### DIFF
--- a/build/plugins.mk
+++ b/build/plugins.mk
@@ -25,11 +25,11 @@ TS_PLUGIN_LD_FLAGS = \
   -export-symbols-regex '^(TSRemapInit|TSRemapDone|TSRemapDoRemap|TSRemapNewInstance|TSRemapDeleteInstance|TSRemapOSResponse|TSPluginInit)$$'
 
 TS_PLUGIN_CPPFLAGS = \
-  -I$(top_builddir)/proxy/api \
-  -I$(top_srcdir)/proxy/api \
-  -I$(top_srcdir)/lib/cppapi/include \
-  -I$(top_builddir)/lib/cppapi/include \
-  -I$(top_srcdir)/lib
+  -I$(abs_top_builddir)/proxy/api \
+  -I$(abs_top_srcdir)/proxy/api \
+  -I$(abs_top_srcdir)/lib/cppapi/include \
+  -I$(abs_top_builddir)/lib/cppapi/include \
+  -I$(abs_top_srcdir)/lib
 
 # Provide a default AM_CPPFLAGS. Automake handles this correctly, but libtool
 # throws an error if we try to do the same with AM_LDFLAGS. Hence, we provide

--- a/cmd/traffic_cop/Makefile.am
+++ b/cmd/traffic_cop/Makefile.am
@@ -18,11 +18,11 @@
 #  limitations under the License.
 
 AM_CPPFLAGS = $(iocore_include_dirs) \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/lib/records \
-  -I$(top_srcdir)/mgmt \
-  -I$(top_srcdir)/mgmt/cluster \
-  -I$(top_srcdir)/mgmt/api/include
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/cluster \
+  -I$(abs_top_srcdir)/mgmt/api/include
 
 AM_LDFLAGS = \
   @EXTRA_CXX_LDFLAGS@ \

--- a/cmd/traffic_crashlog/Makefile.am
+++ b/cmd/traffic_crashlog/Makefile.am
@@ -19,11 +19,11 @@ bin_PROGRAMS = traffic_crashlog
 
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/lib/records \
-  -I$(top_srcdir)/mgmt \
-  -I$(top_srcdir)/mgmt/utils \
-  -I$(top_srcdir)/mgmt/api/include
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/utils \
+  -I$(abs_top_srcdir)/mgmt/api/include
 
 AM_LDFLAGS = \
   @EXTRA_CXX_LDFLAGS@ \

--- a/cmd/traffic_ctl/Makefile.am
+++ b/cmd/traffic_ctl/Makefile.am
@@ -19,9 +19,9 @@
 
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/lib/records \
-  -I$(top_srcdir)/mgmt/api/include
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_top_srcdir)/mgmt/api/include
 
 bin_PROGRAMS = traffic_ctl
 

--- a/cmd/traffic_layout/Makefile.am
+++ b/cmd/traffic_layout/Makefile.am
@@ -19,10 +19,10 @@ bin_PROGRAMS = traffic_layout
 
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/lib/records \
-  -I$(top_srcdir)/mgmt \
-  -I$(top_srcdir)/mgmt/utils
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/utils
 
 AM_LDFLAGS = \
   @EXTRA_CXX_LDFLAGS@ \

--- a/cmd/traffic_manager/Makefile.am
+++ b/cmd/traffic_manager/Makefile.am
@@ -20,16 +20,16 @@ bin_PROGRAMS = traffic_manager
 AM_CPPFLAGS = \
   $(LUAJIT_CPPFLAGS) \
   $(iocore_include_dirs) \
-  -I$(top_srcdir)/lib/records \
-  -I$(top_srcdir)/proxy/hdrs \
-  -I$(top_srcdir)/proxy/shared \
-  -I$(top_srcdir)/mgmt \
-  -I$(top_srcdir)/mgmt/api \
-  -I$(top_srcdir)/mgmt/api/include \
-  -I$(top_srcdir)/mgmt/cluster \
-  -I$(top_srcdir)/mgmt/utils \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/lib/luajit/src
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_top_srcdir)/proxy/hdrs \
+  -I$(abs_top_srcdir)/proxy/shared \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/api \
+  -I$(abs_top_srcdir)/mgmt/api/include \
+  -I$(abs_top_srcdir)/mgmt/cluster \
+  -I$(abs_top_srcdir)/mgmt/utils \
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/luajit/src
 
 AM_LDFLAGS = \
   @EXTRA_CXX_LDFLAGS@ \

--- a/cmd/traffic_top/Makefile.am
+++ b/cmd/traffic_top/Makefile.am
@@ -20,8 +20,8 @@ if BUILD_TRAFFIC_TOP
 
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/mgmt/api/include \
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/mgmt/api/include \
   @CURL_CFLAGS@ \
   @CURSES_CFLAGS@
 

--- a/cmd/traffic_via/Makefile.am
+++ b/cmd/traffic_via/Makefile.am
@@ -19,8 +19,8 @@
 
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/mgmt/api/include
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/mgmt/api/include
 
 AM_LDFLAGS = \
   @EXTRA_CXX_LDFLAGS@ \

--- a/cmd/traffic_wccp/Makefile.am
+++ b/cmd/traffic_wccp/Makefile.am
@@ -19,9 +19,9 @@
 
 
 AM_CPPFLAGS = $(iocore_include_dirs) \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/lib/records \
-  -I$(top_srcdir)/lib/wccp \
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_top_srcdir)/lib/wccp \
   @OPENSSL_INCLUDES@
 
 AM_LDFLAGS = \

--- a/configure.ac
+++ b/configure.ac
@@ -1412,7 +1412,7 @@ esac
 
 # Flags for building and linking against our internal copy of LuaJIT.
 AC_SUBST([LUAJIT_LDFLAGS])
-AC_SUBST([LUAJIT_CPPFLAGS], ['-I$(top_srcdir)/lib/luajit/src'])
+AC_SUBST([LUAJIT_CPPFLAGS], ['-I$(abs_top_srcdir)/lib/luajit/src'])
 
 # We should be able to build http_load if epoll(2) is available.
 AM_CONDITIONAL([BUILD_HTTP_LOAD], [test x"$ac_cv_func_epoll_ctl" = x"yes"])
@@ -1809,14 +1809,14 @@ AM_CONDITIONAL([BUILD_REMAP_STATS_PLUGIN],
 # use modular IOCORE
 #
 iocore_include_dirs="\
--I\$(top_srcdir)/iocore/eventsystem \
--I\$(top_srcdir)/iocore/net \
--I\$(top_srcdir)/iocore/aio \
--I\$(top_srcdir)/iocore/hostdb \
--I\$(top_srcdir)/iocore/cache \
--I\$(top_srcdir)/iocore/cluster \
--I\$(top_srcdir)/iocore/utils \
--I\$(top_srcdir)/iocore/dns"
+-I\$(abs_top_srcdir)/iocore/eventsystem \
+-I\$(abs_top_srcdir)/iocore/net \
+-I\$(abs_top_srcdir)/iocore/aio \
+-I\$(abs_top_srcdir)/iocore/hostdb \
+-I\$(abs_top_srcdir)/iocore/cache \
+-I\$(abs_top_srcdir)/iocore/cluster \
+-I\$(abs_top_srcdir)/iocore/utils \
+-I\$(abs_top_srcdir)/iocore/dns"
 
 # Flags for buildit LuaJIT itself. We take the latest version
 # of the generic flags, plus any Lua-specific flags so that we

--- a/iocore/aio/Makefile.am
+++ b/iocore/aio/Makefile.am
@@ -17,9 +17,9 @@
 #  limitations under the License.
 
 AM_CPPFLAGS = \
-  -I$(top_srcdir)/iocore/eventsystem \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/lib/records
+  -I$(abs_top_srcdir)/iocore/eventsystem \
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/records
 
 TESTS = test_AIO.sample
 
@@ -43,14 +43,14 @@ test_AIO_SOURCES = \
 test_AIO_CPPFLAGS = \
   $(AM_CPPFLAGS) \
   $(iocore_include_dirs) \
-  -I$(top_srcdir)/proxy/api/ts \
-  -I$(top_srcdir)/proxy/api \
-  -I$(top_srcdir)/proxy \
-  -I$(top_srcdir)/proxy/hdrs \
-  -I$(top_srcdir)/proxy/http \
-  -I$(top_srcdir)/proxy/logging \
-  -I$(top_srcdir)/mgmt \
-  -I$(top_srcdir)/mgmt/utils \
+  -I$(abs_top_srcdir)/proxy/api/ts \
+  -I$(abs_top_srcdir)/proxy/api \
+  -I$(abs_top_srcdir)/proxy \
+  -I$(abs_top_srcdir)/proxy/hdrs \
+  -I$(abs_top_srcdir)/proxy/http \
+  -I$(abs_top_srcdir)/proxy/logging \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/utils \
   @OPENSSL_INCLUDES@
 
 test_AIO_LDADD = \

--- a/iocore/cache/Makefile.am
+++ b/iocore/cache/Makefile.am
@@ -18,16 +18,16 @@
 
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/lib/records \
-  -I$(top_srcdir)/proxy/api/ts \
-  -I$(top_srcdir)/proxy \
-  -I$(top_srcdir)/proxy/hdrs \
-  -I$(top_srcdir)/proxy/http \
-  -I$(top_srcdir)/proxy/shared \
-  -I$(top_srcdir)/proxy/http/remap \
-  -I$(top_srcdir)/mgmt \
-  -I$(top_srcdir)/mgmt/utils
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_top_srcdir)/proxy/api/ts \
+  -I$(abs_top_srcdir)/proxy \
+  -I$(abs_top_srcdir)/proxy/hdrs \
+  -I$(abs_top_srcdir)/proxy/http \
+  -I$(abs_top_srcdir)/proxy/shared \
+  -I$(abs_top_srcdir)/proxy/http/remap \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/utils
 
 ADD_SRC =
 if BUILD_TESTS

--- a/iocore/cluster/Makefile.am
+++ b/iocore/cluster/Makefile.am
@@ -18,14 +18,14 @@
 
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/lib/records \
-  -I$(top_srcdir)/proxy/http \
-  -I$(top_srcdir)/proxy/hdrs \
-  -I$(top_srcdir)/proxy/api/ts \
-  -I$(top_srcdir)/proxy \
-  -I$(top_srcdir)/mgmt \
-  -I$(top_srcdir)/mgmt/utils
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_top_srcdir)/proxy/http \
+  -I$(abs_top_srcdir)/proxy/hdrs \
+  -I$(abs_top_srcdir)/proxy/api/ts \
+  -I$(abs_top_srcdir)/proxy \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/utils
 
 noinst_LIBRARIES = libinkcluster.a
 

--- a/iocore/dns/Makefile.am
+++ b/iocore/dns/Makefile.am
@@ -18,13 +18,13 @@
 
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/lib/records \
-  -I$(top_srcdir)/proxy \
-  -I$(top_srcdir)/proxy/http \
-  -I$(top_srcdir)/proxy/hdrs \
-  -I$(top_srcdir)/mgmt \
-  -I$(top_srcdir)/mgmt/utils 
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_top_srcdir)/proxy \
+  -I$(abs_top_srcdir)/proxy/http \
+  -I$(abs_top_srcdir)/proxy/hdrs \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/utils 
 
 noinst_LIBRARIES = libinkdns.a
 

--- a/iocore/eventsystem/Makefile.am
+++ b/iocore/eventsystem/Makefile.am
@@ -17,8 +17,8 @@
 #  limitations under the License.
 
 AM_CPPFLAGS = \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/lib/records
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/records
 
 TESTS = $(check_PROGRAMS)
 
@@ -78,14 +78,14 @@ test_LD_FLAGS = \
 test_CPP_FLAGS = \
   $(AM_CPPFLAGS) \
   $(iocore_include_dirs) \
-  -I$(top_srcdir)/proxy/api/ts \
-  -I$(top_srcdir)/proxy/api \
-  -I$(top_srcdir)/proxy \
-  -I$(top_srcdir)/proxy/hdrs \
-  -I$(top_srcdir)/proxy/http \
-  -I$(top_srcdir)/proxy/logging \
-  -I$(top_srcdir)/mgmt \
-  -I$(top_srcdir)/mgmt/utils \
+  -I$(abs_top_srcdir)/proxy/api/ts \
+  -I$(abs_top_srcdir)/proxy/api \
+  -I$(abs_top_srcdir)/proxy \
+  -I$(abs_top_srcdir)/proxy/hdrs \
+  -I$(abs_top_srcdir)/proxy/http \
+  -I$(abs_top_srcdir)/proxy/logging \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/utils \
   @OPENSSL_INCLUDES@
 
 test_LD_ADD = \

--- a/iocore/hostdb/Makefile.am
+++ b/iocore/hostdb/Makefile.am
@@ -18,13 +18,13 @@
 
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/lib/records \
-  -I$(top_srcdir)/proxy \
-  -I$(top_srcdir)/proxy/hdrs \
-  -I$(top_srcdir)/proxy/http \
-  -I$(top_srcdir)/mgmt \
-  -I$(top_srcdir)/mgmt/utils
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_top_srcdir)/proxy \
+  -I$(abs_top_srcdir)/proxy/hdrs \
+  -I$(abs_top_srcdir)/proxy/http \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/utils
 
 EXTRA_DIST = I_HostDB.h
 
@@ -61,14 +61,14 @@ test_LD_FLAGS = \
 test_CPP_FLAGS = \
   $(AM_CPPFLAGS) \
   $(iocore_include_dirs) \
-  -I$(top_srcdir)/proxy/api/ts \
-  -I$(top_srcdir)/proxy/api \
-  -I$(top_srcdir)/proxy \
-  -I$(top_srcdir)/proxy/hdrs \
-  -I$(top_srcdir)/proxy/http \
-  -I$(top_srcdir)/proxy/logging \
-  -I$(top_srcdir)/mgmt \
-  -I$(top_srcdir)/mgmt/utils \
+  -I$(abs_top_srcdir)/proxy/api/ts \
+  -I$(abs_top_srcdir)/proxy/api \
+  -I$(abs_top_srcdir)/proxy \
+  -I$(abs_top_srcdir)/proxy/hdrs \
+  -I$(abs_top_srcdir)/proxy/http \
+  -I$(abs_top_srcdir)/proxy/logging \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/utils \
   @OPENSSL_INCLUDES@
 
 test_LD_ADD = \

--- a/iocore/net/Makefile.am
+++ b/iocore/net/Makefile.am
@@ -18,16 +18,16 @@
 
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/lib/records \
-  -I$(top_srcdir)/proxy \
-  -I$(top_srcdir)/proxy/hdrs \
-  -I$(top_srcdir)/proxy/shared \
-  -I$(top_srcdir)/proxy/logging \
-  -I$(top_srcdir)/mgmt \
-  -I$(top_srcdir)/mgmt/utils \
-  -I$(top_srcdir)/proxy/api/ts \
-  -I$(top_srcdir)/proxy/http \
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_top_srcdir)/proxy \
+  -I$(abs_top_srcdir)/proxy/hdrs \
+  -I$(abs_top_srcdir)/proxy/shared \
+  -I$(abs_top_srcdir)/proxy/logging \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/utils \
+  -I$(abs_top_srcdir)/proxy/api/ts \
+  -I$(abs_top_srcdir)/proxy/http \
   @OPENSSL_INCLUDES@
 
 TESTS = $(check_PROGRAMS)

--- a/iocore/utils/Makefile.am
+++ b/iocore/utils/Makefile.am
@@ -17,9 +17,9 @@
 #  limitations under the License.
 
 AM_CPPFLAGS = \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/lib/records \
-  -I$(top_srcdir)/iocore/eventsystem
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_top_srcdir)/iocore/eventsystem
 
 noinst_LIBRARIES = libinkutils.a
 

--- a/lib/bindings/Makefile.am
+++ b/lib/bindings/Makefile.am
@@ -20,8 +20,8 @@ include $(top_srcdir)/build/tidy.mk
 
 AM_CPPFLAGS = \
   $(LUAJIT_CPPFLAGS) \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/lib/records
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/records
 
 noinst_LTLIBRARIES = libbindings.la
 

--- a/lib/records/Makefile.am
+++ b/lib/records/Makefile.am
@@ -19,12 +19,12 @@
 include $(top_srcdir)/build/tidy.mk
 
 AM_CPPFLAGS = \
-  -I$(top_srcdir)/iocore/eventsystem \
-  -I$(top_srcdir)/iocore/utils \
-  -I$(top_srcdir)/mgmt \
-  -I$(top_srcdir)/mgmt/api/include \
-  -I$(top_srcdir)/mgmt/utils \
-  -I$(top_srcdir)/lib
+  -I$(abs_top_srcdir)/iocore/eventsystem \
+  -I$(abs_top_srcdir)/iocore/utils \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/api/include \
+  -I$(abs_top_srcdir)/mgmt/utils \
+  -I$(abs_top_srcdir)/lib
 
 noinst_LIBRARIES = librecords_lm.a librecords_p.a librecords_cop.a
 

--- a/lib/ts/Makefile.am
+++ b/lib/ts/Makefile.am
@@ -29,7 +29,7 @@ TESTS_ENVIRONMENT = LSAN_OPTIONS=suppressions=suppression.txt
 
 TESTS = $(check_PROGRAMS)
 
-AM_CPPFLAGS = -I$(top_srcdir)/lib
+AM_CPPFLAGS = -I$(abs_top_srcdir)/lib
 
 lib_LTLIBRARIES = libtsutil.la
 

--- a/lib/tsconfig/Makefile.am
+++ b/lib/tsconfig/Makefile.am
@@ -24,7 +24,7 @@ AM_CFLAGS += @FLEX_CFLAGS@
 AM_YFLAGS = --yacc -d -p tsconfig
 
 AM_CPPFLAGS = \
-  -I$(top_srcdir)/lib
+  -I$(abs_top_srcdir)/lib
 
 BUILT_SOURCES = \
   TsConfigGrammar.hpp

--- a/lib/wccp/Makefile.am
+++ b/lib/wccp/Makefile.am
@@ -20,8 +20,8 @@
 include $(top_srcdir)/build/tidy.mk
 
 AM_CPPFLAGS = \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/proxy/api/ts
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/proxy/api/ts
 
 #WCCP_DEFS = @WCCP_DEFS@
 #DEFS += $(WCCP_DEFS)

--- a/mgmt/Makefile.am
+++ b/mgmt/Makefile.am
@@ -27,14 +27,14 @@ noinst_LTLIBRARIES = libmgmt_c.la libmgmt_p.la libmgmt_lm.la
 
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
-  -I$(top_srcdir)/mgmt/api/include \
-  -I$(top_srcdir)/mgmt/cluster \
-  -I$(top_srcdir)/mgmt/utils \
-  -I$(top_srcdir)/proxy/api/ts \
-  -I$(top_srcdir)/proxy \
-  -I$(top_srcdir)/proxy/hdrs \
-  -I$(top_srcdir)/lib/records \
-  -I$(top_srcdir)/lib
+  -I$(abs_top_srcdir)/mgmt/api/include \
+  -I$(abs_top_srcdir)/mgmt/cluster \
+  -I$(abs_top_srcdir)/mgmt/utils \
+  -I$(abs_top_srcdir)/proxy/api/ts \
+  -I$(abs_top_srcdir)/proxy \
+  -I$(abs_top_srcdir)/proxy/hdrs \
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_top_srcdir)/lib
 
 libmgmt_c_la_SOURCES = \
   RecordsConfig.cc \

--- a/mgmt/api/Makefile.am
+++ b/mgmt/api/Makefile.am
@@ -23,12 +23,12 @@ SUBDIRS = include
 
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
-  -I$(top_srcdir)/lib/records \
-  -I$(top_srcdir)/mgmt \
-  -I$(top_srcdir)/mgmt/cluster \
-  -I$(top_srcdir)/mgmt/utils \
-  -I$(top_srcdir)/mgmt/api/include \
-  -I$(top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/cluster \
+  -I$(abs_top_srcdir)/mgmt/utils \
+  -I$(abs_top_srcdir)/mgmt/api/include \
+  -I$(abs_top_srcdir)/lib \
   $(LIBUNWIND_CFLAGS)
 
 noinst_LTLIBRARIES = libmgmtapilocal.la libmgmtapi.la

--- a/mgmt/cluster/Makefile.am
+++ b/mgmt/cluster/Makefile.am
@@ -20,11 +20,11 @@
 include $(top_srcdir)/build/tidy.mk
 
 AM_CPPFLAGS = \
-  -I$(top_srcdir)/lib/records \
-  -I$(top_srcdir)/mgmt \
-  -I$(top_srcdir)/mgmt/api/include \
-  -I$(top_srcdir)/mgmt/utils \
-  -I$(top_srcdir)/lib
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/api/include \
+  -I$(abs_top_srcdir)/mgmt/utils \
+  -I$(abs_top_srcdir)/lib
 
 noinst_LTLIBRARIES = libcluster.la
 

--- a/mgmt/utils/Makefile.am
+++ b/mgmt/utils/Makefile.am
@@ -18,14 +18,14 @@
 #  limitations under the License.
 
 AM_CPPFLAGS = \
-  -I$(top_srcdir)/iocore/utils \
-  -I$(top_srcdir)/mgmt \
-  -I$(top_srcdir)/mgmt/api \
-  -I$(top_srcdir)/mgmt/api/include \
-  -I$(top_srcdir)/lib/tsconfig \
-  -I$(top_srcdir)/proxy \
-  -I$(top_srcdir)/lib/records \
-  -I$(top_srcdir)/lib \
+  -I$(abs_top_srcdir)/iocore/utils \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/api \
+  -I$(abs_top_srcdir)/mgmt/api/include \
+  -I$(abs_top_srcdir)/lib/tsconfig \
+  -I$(abs_top_srcdir)/proxy \
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_top_srcdir)/lib \
   @OPENSSL_INCLUDES@
 
 # header files used by other libraries

--- a/plugins/experimental/memcache/Makefile.inc
+++ b/plugins/experimental/memcache/Makefile.inc
@@ -16,15 +16,15 @@
 
 experimental_memcache_tsmemcache_la_CPPFLAGS = \
   $(AM_CPPFLAGS) \
-  -I$(top_srcdir)/proxy/api/ts \
-  -I$(top_srcdir)/iocore/aio \
-  -I$(top_srcdir)/iocore/cache \
-  -I$(top_srcdir)/iocore/eventsystem \
-  -I$(top_srcdir)/iocore/net \
-  -I$(top_srcdir)/iocore/utils \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/lib/records \
-  -I$(top_srcdir)/lib/ts
+  -I$(abs_top_srcdir)/proxy/api/ts \
+  -I$(abs_top_srcdir)/iocore/aio \
+  -I$(abs_top_srcdir)/iocore/cache \
+  -I$(abs_top_srcdir)/iocore/eventsystem \
+  -I$(abs_top_srcdir)/iocore/net \
+  -I$(abs_top_srcdir)/iocore/utils \
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_top_srcdir)/lib/ts
 
 pkglib_LTLIBRARIES += experimental/memcache/tsmemcache.la
 

--- a/plugins/experimental/sslheaders/Makefile.inc
+++ b/plugins/experimental/sslheaders/Makefile.inc
@@ -17,7 +17,7 @@
 sslheaders_CPP_FLAGS = \
 	$(AM_CPPFLAGS) \
 	@OPENSSL_INCLUDES@ \
-	-I$(top_srcdir)/lib
+	-I$(abs_top_srcdir)/lib
 
 noinst_LTLIBRARIES += experimental/sslheaders/libsslhdr.la
 pkglib_LTLIBRARIES += experimental/sslheaders/sslheaders.la
@@ -48,12 +48,12 @@ experimental_sslheaders_test_sslheaders_SOURCES = \
 experimental_sslheaders_test_sslheaders_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
 	@OPENSSL_INCLUDES@ \
-	-I$(top_srcdir)/lib
+	-I$(abs_top_srcdir)/lib
 experimental_sslheaders_test_sslheaders_LDFLAGS = @OPENSSL_LDFLAGS@
 experimental_sslheaders_test_sslheaders_LDADD = \
 	@LIBTOOL_LINK_FLAGS@ \
 	experimental/sslheaders/libsslhdr.la \
-	$(top_builddir)/lib/ts/libtsutil.la \
+	$(abs_top_builddir)/lib/ts/libtsutil.la \
 	@OPENSSL_LIBS@
 
 # vim: ft=make ts=8 sw=8 et:

--- a/proxy/Makefile.am
+++ b/proxy/Makefile.am
@@ -32,17 +32,17 @@ TESTS = \
 
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
-  -I$(top_srcdir)/lib/records \
-  -I$(srcdir)/http \
-  -I$(srcdir)/http2 \
-  -I$(srcdir)/logging \
-  -I$(srcdir)/http/remap  \
-  -I$(srcdir)/hdrs \
-  -I$(srcdir)/shared \
-  -I$(top_srcdir)/mgmt \
-  -I$(top_srcdir)/mgmt/utils \
-  -I$(top_srcdir)/proxy/api/ts \
-  -I$(top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_srcdir)/http \
+  -I$(abs_srcdir)/http2 \
+  -I$(abs_srcdir)/logging \
+  -I$(abs_srcdir)/http/remap  \
+  -I$(abs_srcdir)/hdrs \
+  -I$(abs_srcdir)/shared \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/utils \
+  -I$(abs_top_srcdir)/proxy/api/ts \
+  -I$(abs_top_srcdir)/lib \
   @OPENSSL_INCLUDES@
 
 # NOTE: it is safe to use AM_LDFLAGS here because we are only building executables. If we start

--- a/proxy/congest/Makefile.am
+++ b/proxy/congest/Makefile.am
@@ -18,14 +18,14 @@
 
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/lib/records \
-  -I$(top_srcdir)/proxy \
-  -I$(top_srcdir)/proxy/http \
-  -I$(top_srcdir)/mgmt \
-  -I$(top_srcdir)/mgmt/utils \
-  -I$(top_srcdir)/proxy/shared \
-  -I$(top_srcdir)/proxy/hdrs
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_top_srcdir)/proxy \
+  -I$(abs_top_srcdir)/proxy/http \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/utils \
+  -I$(abs_top_srcdir)/proxy/shared \
+  -I$(abs_top_srcdir)/proxy/hdrs
 
 noinst_LIBRARIES = libCongestionControl.a
 

--- a/proxy/hdrs/Makefile.am
+++ b/proxy/hdrs/Makefile.am
@@ -20,8 +20,8 @@ include $(top_srcdir)/build/tidy.mk
 
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/lib/records
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/records
 
 noinst_LIBRARIES = libhdrs.a
 EXTRA_PROGRAMS = load_http_hdr

--- a/proxy/http/Makefile.am
+++ b/proxy/http/Makefile.am
@@ -22,17 +22,17 @@ SUBDIRS = remap
 
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
-  -I$(top_srcdir)/proxy/api/ts \
-  -I$(top_srcdir)/proxy \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/lib/records \
-  -I$(top_srcdir)/mgmt \
-  -I$(top_srcdir)/mgmt/utils \
-  -I$(top_srcdir)/proxy/hdrs \
-  -I$(top_srcdir)/proxy/shared \
-  -I$(top_srcdir)/proxy/http/remap \
-  -I$(top_srcdir)/proxy/logging \
-  -I$(top_srcdir)/proxy/http2
+  -I$(abs_top_srcdir)/proxy/api/ts \
+  -I$(abs_top_srcdir)/proxy \
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/utils \
+  -I$(abs_top_srcdir)/proxy/hdrs \
+  -I$(abs_top_srcdir)/proxy/shared \
+  -I$(abs_top_srcdir)/proxy/http/remap \
+  -I$(abs_top_srcdir)/proxy/logging \
+  -I$(abs_top_srcdir)/proxy/http2
 
 noinst_HEADERS = HttpProxyServerMain.h
 noinst_LIBRARIES = libhttp.a

--- a/proxy/http/remap/Makefile.am
+++ b/proxy/http/remap/Makefile.am
@@ -20,15 +20,15 @@ include $(top_srcdir)/build/tidy.mk
 
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/lib/records \
-  -I$(top_srcdir)/proxy/api/ts \
-  -I$(top_srcdir)/proxy \
-  -I$(top_srcdir)/mgmt \
-  -I$(top_srcdir)/mgmt/utils \
-  -I$(top_srcdir)/proxy/hdrs \
-  -I$(top_srcdir)/proxy/shared \
-  -I$(top_srcdir)/proxy/http
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_top_srcdir)/proxy/api/ts \
+  -I$(abs_top_srcdir)/proxy \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/utils \
+  -I$(abs_top_srcdir)/proxy/hdrs \
+  -I$(abs_top_srcdir)/proxy/shared \
+  -I$(abs_top_srcdir)/proxy/http
 
 noinst_LIBRARIES = libhttp_remap.a
 

--- a/proxy/http2/Makefile.am
+++ b/proxy/http2/Makefile.am
@@ -20,16 +20,16 @@ include $(top_srcdir)/build/tidy.mk
 
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
-  -I$(top_srcdir)/proxy/api/ts \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/lib/records \
-  -I$(top_srcdir)/mgmt \
-  -I$(top_srcdir)/mgmt/utils \
-  -I$(top_srcdir)/proxy \
-  -I$(top_srcdir)/proxy/http \
-  -I$(top_srcdir)/proxy/hdrs \
-  -I$(top_srcdir)/proxy/shared \
-  -I$(top_srcdir)/proxy/http/remap
+  -I$(abs_top_srcdir)/proxy/api/ts \
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/utils \
+  -I$(abs_top_srcdir)/proxy \
+  -I$(abs_top_srcdir)/proxy/http \
+  -I$(abs_top_srcdir)/proxy/hdrs \
+  -I$(abs_top_srcdir)/proxy/shared \
+  -I$(abs_top_srcdir)/proxy/http/remap
 
 noinst_LIBRARIES = libhttp2.a
 

--- a/proxy/logging/Makefile.am
+++ b/proxy/logging/Makefile.am
@@ -20,17 +20,17 @@ include $(top_srcdir)/build/tidy.mk
 
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/lib/luajit/src \
-  -I$(top_srcdir)/lib/records \
-  -I$(top_srcdir)/proxy/api/ts \
-  -I$(top_srcdir)/proxy \
-  -I$(top_srcdir)/proxy/http \
-  -I$(top_srcdir)/proxy/http/remap \
-  -I$(top_srcdir)/proxy/hdrs \
-  -I$(top_srcdir)/proxy/shared \
-  -I$(top_srcdir)/mgmt \
-  -I$(top_srcdir)/mgmt/utils
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/luajit/src \
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_top_srcdir)/proxy/api/ts \
+  -I$(abs_top_srcdir)/proxy \
+  -I$(abs_top_srcdir)/proxy/http \
+  -I$(abs_top_srcdir)/proxy/http/remap \
+  -I$(abs_top_srcdir)/proxy/hdrs \
+  -I$(abs_top_srcdir)/proxy/shared \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/utils
 
 EXTRA_DIST = LogStandalone.cc
 

--- a/proxy/shared/Makefile.am
+++ b/proxy/shared/Makefile.am
@@ -25,18 +25,18 @@ noinst_LIBRARIES = \
 
 AM_CPPFLAGS = \
   $(iocore_include_dirs) \
-  -I$(top_srcdir)/lib/records \
-  -I$(top_srcdir)/mgmt \
-  -I$(top_srcdir)/mgmt/api \
-  -I$(top_srcdir)/mgmt/api/include \
-  -I$(top_srcdir)/mgmt/utils \
-  -I$(top_srcdir) \
-  -I$(top_srcdir)/proxy/api/ts \
-  -I$(top_srcdir)/proxy \
-  -I$(top_srcdir)/proxy/http \
-  -I$(top_srcdir)/proxy/hdrs \
-  -I$(top_srcdir)/proxy/logging \
-  -I$(top_srcdir)/lib
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/api \
+  -I$(abs_top_srcdir)/mgmt/api/include \
+  -I$(abs_top_srcdir)/mgmt/utils \
+  -I$(abs_top_srcdir) \
+  -I$(abs_top_srcdir)/proxy/api/ts \
+  -I$(abs_top_srcdir)/proxy \
+  -I$(abs_top_srcdir)/proxy/http \
+  -I$(abs_top_srcdir)/proxy/hdrs \
+  -I$(abs_top_srcdir)/proxy/logging \
+  -I$(abs_top_srcdir)/lib
 
 
 

--- a/rc/Makefile.am
+++ b/rc/Makefile.am
@@ -17,12 +17,12 @@
 #  limitations under the License.
 
 AM_CPPFLAGS = \
-  -I$(top_srcdir)/lib/records \
-  -I$(top_srcdir)/proxy \
-  -I$(top_srcdir)/mgmt \
-  -I$(top_srcdir)/mgmt/utils \
-  -I$(top_srcdir)/proxy/cache \
-  -I$(top_srcdir)/proxy/logging
+  -I$(abs_top_srcdir)/lib/records \
+  -I$(abs_top_srcdir)/proxy \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/utils \
+  -I$(abs_top_srcdir)/proxy/cache \
+  -I$(abs_top_srcdir)/proxy/logging
 
 dist_bin_SCRIPTS = \
   trafficserver

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -24,8 +24,8 @@ pkgconfig_DATA = trafficserver.pc
 
 AM_LDFLAGS = @EXTRA_CXX_LDFLAGS@ @LIBTOOL_LINK_FLAGS@
 AM_CPPFLAGS = $(iocore_include_dirs) \
-  -I$(top_srcdir)/lib \
-  -I$(top_srcdir)/lib/wccp
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/wccp
 
 if BUILD_TEST_TOOLS
 bin_PROGRAMS = jtest/jtest


### PR DESCRIPTION
Some VIMers wish to use YCM(http://valloric.github.io/YouCompleteMe/) to read code, because the codebase is so large. But when using YCM-Generator(https://github.com/rdnetto/YCM-Generator), the .ycm_extra_conf.py will get many relative path, which causes it to fail.