### PR TITLE
TS-4905: Set parent NULL after destroy() is called

### DIFF
--- a/proxy/http/Http1ClientTransaction.cc
+++ b/proxy/http/Http1ClientTransaction.cc
@@ -67,6 +67,7 @@ Http1ClientTransaction::transaction_done()
   // If the parent session is not in the closed state, the destroy will not occur.
   if (parent) {
     parent->destroy();
+    parent = NULL;
   }
 }
 


### PR DESCRIPTION
(cherry picked from commit 60d3d1fc542f9d33317e35ced399bef1f9c89516)