### PR TITLE
TS-4614: avoid e->schedule_in for dummy event.  (backport for 6.2.x)

### DIFF
--- a/iocore/net/UnixNet.cc
+++ b/iocore/net/UnixNet.cc
@@ -681,8 +681,9 @@ NetHandler::_close_vc(UnixNetVConnection *vc, ink_hrtime now, int &handle_event,
     // create a dummy event
     Event event;
     event.ethread = this_ethread();
-    vc->handleEvent(EVENT_IMMEDIATE, &event);
-    ++handle_event;
+    if (vc->handleEvent(EVENT_IMMEDIATE, &event) == EVENT_DONE) {
+      ++handle_event;
+    }
   }
 }
 

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1137,8 +1137,8 @@ UnixNetVConnection::mainEvent(int event, Event *e)
       (write.vio.mutex.m_ptr && wlock.get_mutex() != write.vio.mutex.m_ptr)) {
 #ifdef INACTIVITY_TIMEOUT
     if (e == active_timeout)
-#endif
       e->schedule_in(HRTIME_MSECONDS(net_retry_delay));
+#endif
     return EVENT_CONT;
   }
 


### PR DESCRIPTION
(cherry picked from commit 002432344fdb6a0adedcc6fa696b49545800de39)