### PR TITLE
TS-4838: CONNECT requests get forgotten across threads.

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -1113,6 +1113,14 @@ HttpSM::state_raw_http_server_open(int event, void *data)
 
   pending_action = NULL;
   switch (event) {
+  case EVENT_INTERVAL:
+    // If we get EVENT_INTERNAL it means that we moved the transaction
+    // to a different thread in do_http_server_open.  Since we didn't
+    // do any of the actual work in do_http_server_open, we have to
+    // go back and do it now.
+    do_http_server_open(true);
+    return 0;
+
   case NET_EVENT_OPEN:
 
     if (t_state.pCongestionEntry != NULL) {
@@ -1147,11 +1155,6 @@ HttpSM::state_raw_http_server_open(int event, void *data)
   case CONGESTION_EVENT_CONGESTED_ON_M:
     t_state.current.state = HttpTransact::CONGEST_CONTROL_CONGESTED_ON_M;
     break;
-
-  case EVENT_INTERVAL:
-    Error("[HttpSM::state_raw_http_server_open] event: EVENT_INTERVAL state: %d server_entry: %p", t_state.current.state,
-          server_entry);
-    return 0;
 
   default:
     ink_release_assert(0);


### PR DESCRIPTION
What happens here is that ProxyClientTransaction::adjust_thread
reschedules the transaction onto a new thread at the start of
HttpSM::do_http_server_open.

Unfortunately, at this point the default handler is
HttpSM::state_raw_http_server_open. When the transaction is
rescheduled, the default handler runs, and receives the EVENT_INTERVAL
that it so fortuitously logs an error for. We have never actually
completed do_http_server_open, so we never make any more progress
on this transaction.

(cherry picked from commit 8fddd77c085d1a64f11de61bb42a50562cd23229)