### PR TITLE
Remove unneeded malloc from url_rewrite debug path for HOST header.

### DIFF
--- a/proxy/http/remap/RemapProcessor.cc
+++ b/proxy/http/remap/RemapProcessor.cc
@@ -240,18 +240,11 @@ RemapProcessor::finish_remap(HttpTransact::State *s)
   const char *host_hdr = request_header->value_get(MIME_FIELD_HOST, MIME_LEN_HOST, &host_len);
 
   if (request_url && host_hdr != nullptr && s->txn_conf->maintain_pristine_host_hdr == 0) {
-    // Debug code to print out old host header.  This was easier before
-    //  the header conversion.  Now we have to copy to gain null
-    //  termination for the Debug() call
     if (is_debug_tag_set("url_rewrite")) {
       int old_host_hdr_len;
       char *old_host_hdr = (char *)request_header->value_get(MIME_FIELD_HOST, MIME_LEN_HOST, &old_host_hdr_len);
-
-      if (old_host_hdr) {
-        old_host_hdr = ats_strndup(old_host_hdr, old_host_hdr_len);
+      if (old_host_hdr)
         Debug("url_rewrite", "Host: Header before rewrite %.*s", old_host_hdr_len, old_host_hdr);
-        ats_free(old_host_hdr);
-      }
     }
     //
     // Create the new host header field being careful that our


### PR DESCRIPTION
The comments claim to copy to get the terminating null, but that's not needed. I tested it and as expected it works fine without the allocation & copy.