### PR TITLE
TS-4728 Null pointer error in LogHost.cc (backport 6.2.x)

### DIFF
--- a/proxy/logging/LogConfig.cc
+++ b/proxy/logging/LogConfig.cc
@@ -1471,7 +1471,7 @@ LogConfig::read_xml_log_config()
           while (failover_str = failover_tok.getNext(), failover_str != 0) {
             LogHost *lh = new LogHost(obj->get_full_filename(), obj->get_signature());
 
-            if (lh->set_name_or_ipstr(failover_str)) {
+            if (lh->set_name_or_ipstr(failover_str) == false) {
               Warning("Could not set \"%s\" as collation host", host);
               delete lh;
             } else if (!prev) {

--- a/proxy/logging/LogHost.cc
+++ b/proxy/logging/LogHost.cc
@@ -94,12 +94,12 @@ LogHost::~LogHost()
 // - by specifying a hostname and a port (as separate arguments).
 // - by specifying an ip and a port (as separate arguments).
 //
-int
-LogHost::set_name_port(char *hostname, unsigned int pt)
+bool
+LogHost::set_name_port(const char *hostname, unsigned int pt)
 {
   if (!hostname || hostname[0] == 0) {
     Note("Cannot establish LogHost with NULL hostname");
-    return 1;
+    return false;
   }
 
   clear(); // remove all previous state for this LogHost
@@ -109,38 +109,38 @@ LogHost::set_name_port(char *hostname, unsigned int pt)
 
   Debug("log-host", "LogHost established as %s:%u", this->name(), this->port());
 
-  create_orphan_LogFile_object();
-  return 0;
+  m_orphan_file = make_orphan_logfile(this, m_object_filename);
+  return true;
 }
 
-int
-LogHost::set_ipstr_port(char *ipstr, unsigned int pt)
+bool
+LogHost::set_ipstr_port(const char *ipstr, unsigned int pt)
 {
   if (!ipstr || ipstr[0] == 0) {
     Note("Cannot establish LogHost with NULL ipstr");
-    return 1;
+    return false;
   }
 
   clear(); // remove all previous state for this LogHost
 
-  if (0 != m_ip.load(ipstr))
+  if (0 != m_ip.load(ipstr)) {
     Note("Log host failed to parse IP address %s", ipstr);
+  }
+
   m_port = pt;
   ink_strlcpy(m_ipstr, ipstr, sizeof(m_ipstr));
   m_name = ats_strdup(ipstr);
 
   Debug("log-host", "LogHost established as %s:%u", name(), pt);
 
-  create_orphan_LogFile_object();
-  return 0;
+  m_orphan_file = make_orphan_logfile(this, m_object_filename);
+  return true;
 }
 
-int
-LogHost::set_name_or_ipstr(char *name_or_ip)
+bool
+LogHost::set_name_or_ipstr(const char *name_or_ip)
 {
-  int retVal = 1;
-
-  if (name_or_ip && name_or_ip[0] != 0) {
+  if (name_or_ip && name_or_ip[0] != '\0') {
     ts::ConstBuffer addr, port;
     if (ats_ip_parse(ts::ConstBuffer(name_or_ip, strlen(name_or_ip)), &addr, &port) == 0) {
       uint16_t p = port ? atoi(port.data()) : Log::config->collation_port;
@@ -149,13 +149,14 @@ LogHost::set_name_or_ipstr(char *name_or_ip)
       // string is followed by either a nul or a colon.
       n[addr.size()] = 0;
       if (AF_UNSPEC == ats_ip_check_characters(addr)) {
-        retVal = set_name_port(n, p);
+        return set_name_port(n, p);
       } else {
-        retVal = set_ipstr_port(n, p);
+        return set_ipstr_port(n, p);
       }
     }
   }
-  return retVal;
+
+  return false;
 }
 
 bool

--- a/proxy/logging/LogHost.cc
+++ b/proxy/logging/LogHost.cc
@@ -46,6 +46,25 @@
 #define PING true
 #define NOPING false
 
+static Ptr<LogFile>
+make_orphan_logfile(LogHost *lh, const char *filename)
+{
+  const char *ext   = "orphan";
+  unsigned name_len = (unsigned)(strlen(filename) + strlen(lh->name()) + strlen(ext) + 16);
+  char *name_buf    = (char *)ats_malloc(name_len);
+
+  // NT: replace ':'s with '-'s.  This change is necessary because
+  // NT doesn't like filenames with ':'s in them.  ^_^
+  snprintf(name_buf, name_len, "%s%s%s-%u.%s", filename, LOGFILE_SEPARATOR_STRING, lh->name(), lh->port(), ext);
+
+  // XXX should check for conflicts with orphan filename
+
+  Ptr<LogFile> orphan(new LogFile(name_buf, NULL, LOG_FILE_ASCII, lh->signature()));
+
+  ats_free(name_buf);
+  return orphan;
+}
+
 /*-------------------------------------------------------------------------
   LogHost
   -------------------------------------------------------------------------*/
@@ -78,7 +97,7 @@ LogHost::LogHost(const LogHost &rhs)
     m_log_collation_client_sm(NULL)
 {
   memcpy(m_ipstr, rhs.m_ipstr, sizeof(m_ipstr));
-  create_orphan_LogFile_object();
+  m_orphan_file = make_orphan_logfile(this, m_object_filename);
 }
 
 LogHost::~LogHost()
@@ -224,26 +243,6 @@ LogHost::disconnect()
     m_log_collation_client_sm = NULL;
   }
   m_connected = false;
-}
-
-void
-LogHost::create_orphan_LogFile_object()
-{
-  delete m_orphan_file;
-
-  const char *orphan_ext = "orphan";
-  unsigned name_len      = (unsigned)(strlen(m_object_filename) + strlen(name()) + strlen(orphan_ext) + 16);
-  char *name_buf         = (char *)ats_malloc(name_len);
-
-  // NT: replace ':'s with '-'s.  This change is necessary because
-  // NT doesn't like filenames with ':'s in them.  ^_^
-  snprintf(name_buf, name_len, "%s%s%s-%u.%s", m_object_filename, LOGFILE_SEPARATOR_STRING, name(), port(), orphan_ext);
-
-  // should check for conflicts with orphan filename
-  //
-  m_orphan_file = new LogFile(name_buf, NULL, LOG_FILE_ASCII, m_object_signature);
-  ink_assert(m_orphan_file != NULL);
-  ats_free(name_buf);
 }
 
 //

--- a/proxy/logging/LogHost.h
+++ b/proxy/logging/LogHost.h
@@ -42,9 +42,9 @@ public:
   LogHost(const LogHost &);
   ~LogHost();
 
-  int set_name_or_ipstr(char *name_or_ipstr);
-  int set_ipstr_port(char *ipstr, unsigned int port);
-  int set_name_port(char *hostname, unsigned int port);
+  bool set_name_or_ipstr(const char *name_or_ipstr);
+  bool set_ipstr_port(const char *ipstr, unsigned int port);
+  bool set_name_port(const char *hostname, unsigned int port);
 
   bool connected(bool ping);
   bool connect();

--- a/proxy/logging/LogHost.h
+++ b/proxy/logging/LogHost.h
@@ -61,21 +61,30 @@ public:
   //
   void orphan_write_and_try_delete(LogBuffer *lb);
 
-  char const *
+  const char *
   name() const
   {
     return m_name ? m_name : "UNKNOWN";
   }
+
+  uint64_t
+  signature() const
+  {
+    return m_object_signature;
+  }
+
   IpAddr const &
   ip_addr() const
   {
     return m_ip;
   }
+
   in_port_t
   port() const
   {
     return m_port;
   }
+
   char const *
   ipstr() const
   {
@@ -99,7 +108,6 @@ public:
 private:
   void clear();
   bool authenticated();
-  void create_orphan_LogFile_object();
 
 private:
   char *m_object_filename;
@@ -143,6 +151,7 @@ public:
   {
     return m_host_list.head;
   }
+
   LogHost *
   next(LogHost *here)
   {


### PR DESCRIPTION
@PSUdaemon -- As requested, this is a PR to backport the commits for this issue to 6.2.x. However, I'm not sure that I can fully vouch for this because IIRC the crash bug that I reported in the Jira was present in 7.0.x but not in 6.1.x or 6.2.x.

It was @zwoop who requested the back-port originally and @jpeach who wrote the commits in this PR.