### PR TITLE
TS-5027: Replace readdir_r with readdir.

### DIFF
--- a/cmd/traffic_manager/traffic_manager.cc
+++ b/cmd/traffic_manager/traffic_manager.cc
@@ -591,8 +591,7 @@ main(int argc, const char **argv)
       }
     }
 
-    // NOTE: do NOT call closelog() here.  Solaris gets confused
-    //   and some how it hoses later calls to readdir_r.
+    // NOTE: do NOT call closelog() here.  Solaris gets confused.
     openlog("traffic_manager", LOG_PID | LOG_NDELAY | LOG_NOWAIT, facility_int);
 
     lmgmt->syslog_facility = facility_int;

--- a/mgmt/FileManager.cc
+++ b/mgmt/FileManager.cc
@@ -386,7 +386,6 @@ FileManager::restoreSnap(const char *snapName, const char *snapDir)
 SnapResult
 FileManager::removeSnap(const char *snapName, const char *snapDir)
 {
-  struct dirent *dirEntrySpace;
   struct dirent *entryPtr;
   DIR *dir;
   char *snapPath;
@@ -403,12 +402,7 @@ FileManager::removeSnap(const char *snapName, const char *snapDir)
     return SNAP_NOT_FOUND;
   }
 
-  dirEntrySpace = (struct dirent *)ats_malloc(sizeof(struct dirent) + ink_file_namemax(".") + 1);
-
-  while (readdir_r(dir, dirEntrySpace, &entryPtr) == 0) {
-    if (!entryPtr)
-      break;
-
+  while ((entryPtr = readdir(dir))) {
     if (strcmp(".", entryPtr->d_name) == 0 || strcmp("..", entryPtr->d_name) == 0) {
       continue;
     }
@@ -423,7 +417,6 @@ FileManager::removeSnap(const char *snapName, const char *snapDir)
     delete[] snapFilePath;
   }
 
-  ats_free(dirEntrySpace);
   closedir(dir);
 
   // If we managed to get everything, remove the directory

--- a/mgmt/MultiFile.cc
+++ b/mgmt/MultiFile.cc
@@ -108,18 +108,12 @@ MultiFile::WalkFiles(ExpandingArray *fileList)
     mgmt_log(stderr, "[MultiFile::WalkFiles] Unable to open %s directory: %s: %s\n", dirDescript, managedDir, strerror(errno));
     return MF_NO_DIR;
   }
-  // The fun of Solaris - readdir_r requires a buffer passed into it
-  //   The man page says this obscene expression gives us the proper
-  //     size
-  dirEntry = (struct dirent *)ats_malloc(sizeof(struct dirent) + ink_file_namemax(".") + 1);
 
-  struct dirent *result;
-  while (readdir_r(dir, dirEntry, &result) == 0) {
-    if (!result)
-      break;
+  while ((dirEntry = readdir(dir))) {
     fileName                = dirEntry->d_name;
     filePath                = newPathString(managedDir, fileName);
     records_config_filePath = newPathString(filePath, "records.config");
+
     if (stat(filePath, &fileInfo) < 0) {
       mgmt_log(stderr, "[MultiFile::WalkFiles] Stat of a %s failed %s: %s\n", dirDescript, fileName, strerror(errno));
     } else {
@@ -136,11 +130,11 @@ MultiFile::WalkFiles(ExpandingArray *fileList)
         fileList->addEntry(fileListEntry);
       }
     }
+
     delete[] filePath;
     delete[] records_config_filePath;
   }
 
-  ats_free(dirEntry);
   closedir(dir);
 
   fileList->sortWithFunction(fileEntryCmpFunc);

--- a/mgmt/Rollback.cc
+++ b/mgmt/Rollback.cc
@@ -649,7 +649,6 @@ Rollback::findVersions_ml(ExpandingArray *listNames)
   ats_scoped_str sysconfdir(RecConfigReadConfigDir());
 
   DIR *dir;
-  struct dirent *dirEntrySpace;
   struct dirent *entryPtr;
 
   dir = opendir(sysconfdir);
@@ -659,15 +658,8 @@ Rollback::findVersions_ml(ExpandingArray *listNames)
              strerror(errno));
     return INVALID_VERSION;
   }
-  // The fun of Solaris - readdir_r requires a buffer passed into it
-  //   The man page says this obscene expression gives us the proper
-  //     size
-  dirEntrySpace = (struct dirent *)ats_malloc(sizeof(struct dirent) + ink_file_namemax(".") + 1);
 
-  while (readdir_r(dir, dirEntrySpace, &entryPtr) == 0) {
-    if (!entryPtr)
-      break;
-
+  while ((entryPtr = readdir(dir))) {
     if ((version = extractVersionInfo(listNames, entryPtr->d_name)) != INVALID_VERSION) {
       count++;
 
@@ -677,7 +669,6 @@ Rollback::findVersions_ml(ExpandingArray *listNames)
     }
   }
 
-  ats_free(dirEntrySpace);
   closedir(dir);
 
   numVersions = count;

--- a/mgmt/WebMgmtUtils.cc
+++ b/mgmt/WebMgmtUtils.cc
@@ -1288,19 +1288,10 @@ getFilesInDirectory(char *managedDir, ExpandingArray *fileList)
     mgmt_log(stderr, "[getFilesInDirectory] Unable to open %s directory: %s\n", managedDir, strerror(errno));
     return -1;
   }
-  // The fun of Solaris - readdir_r requires a buffer passed into it
-  //   The man page says this obscene expression gives us the proper
-  //     size
-  dirEntry = (struct dirent *)alloca(sizeof(struct dirent) + ink_file_namemax(".") + 1);
 
-  struct dirent *result;
-  while (readdir_r(dir, dirEntry, &result) == 0) {
-    if (!result)
-      break;
+  while ((dirEntry = readdir(dir))) {
     fileName = dirEntry->d_name;
-    if (!fileName || !*fileName) {
-      continue;
-    }
+
     filePath = newPathString(managedDir, fileName);
     if (stat(filePath, &fileInfo) < 0) {
       mgmt_log(stderr, "[getFilesInDirectory] Stat of a %s failed : %s\n", fileName, strerror(errno));


### PR DESCRIPTION
Glibc deprecated readdir_r(3), so replace it with readdir(3). We
were already using readdir(3) in many places so this is just accepting
the inevitable.

(cherry picked from commit 25b16f763267546c0585fb15f43da4a7803ac984)

 Conflicts:
	mgmt/FileManager.cc
	mgmt/MultiFile.cc
	mgmt/Rollback.cc
	mgmt/WebMgmtUtils.cc
	proxy/http/HttpBodyFactory.cc
	proxy/logging/LogConfig.cc