### PR TITLE
Docs: Minor tweaks to fix warnings.

### DIFF
--- a/doc/admin-guide/files/index.en.rst
+++ b/doc/admin-guide/files/index.en.rst
@@ -92,5 +92,3 @@ Configuration Files
 
 :doc:`volume.config.en`
     Defines cache space usage by individual protocols.
-
-

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -1245,6 +1245,8 @@ Parent Proxy Configuration
 
    Don't try to resolve DNS, forward all DNS requests to the parent. This is off (``0``) by default.
 
+.. ts:cv:: CONFIG proxy.local.http.parent_proxy.disable_connect_tunneling INT 0
+
 HTTP Connection Timeouts
 ========================
 
@@ -1417,9 +1419,9 @@ Origin Server Connect Attempts
    :overridable:
 
    Limits the number of requests to be queued when the :ts:cv:`proxy.config.http.origin_max_connections` is reached.
-   When disabled (``-1``) requests are will wait indefinitely for an available connection. When set to ``0`` all 
-   requests past the :ts:cv:`proxy.config.http.origin_max_connections` will immediately fail. When set to ``>0`` 
-   ATS will queue that many requests to go to the origin, any additional requests past the limit will immediately fail. 
+   When disabled (``-1``) requests are will wait indefinitely for an available connection. When set to ``0`` all
+   requests past the :ts:cv:`proxy.config.http.origin_max_connections` will immediately fail. When set to ``>0``
+   ATS will queue that many requests to go to the origin, any additional requests past the limit will immediately fail.
 
 .. ts:cv:: CONFIG proxy.config.http.origin_min_keep_alive_connections INT 0
    :reloadable:
@@ -2826,7 +2828,7 @@ Diagnostic Logging Configuration
    ``O`` Log to standard output.
    ``E`` Log to standard error.
    ``S`` Log to syslog.
-   ``L`` Log to ``diags.log``.
+   ``L`` Log to :file:`diags.log`.
    ===== ======================================================================
 
 .. topic:: Example
@@ -3035,7 +3037,7 @@ SSL Termination
 
 .. ts:cv:: CONFIG proxy.config.ssl.server.ticket_key.filename STRING ssl_ticket.key
 
-   The filename of the default and global ticket key for SSL sessions. The location of the :file:`ssl_ticket.key` file, relative to the
+   The filename of the default and global ticket key for SSL sessions. The location is relative to the
    :ts:cv:`proxy.config.ssl.server.cert.path` directory.
 
 .. ts:cv:: CONFIG proxy.config.ssl.max_record_size INT 0
@@ -3575,7 +3577,7 @@ Sockets
 .. ts:cv:: CONFIG proxy.config.allocator.dontdump_iobuffers INT 1
 
   Enable (1) the exclusion of IO buffers from core files when ATS crashes on supported
-  platforms.  (Currently only linux).  IO buffers are allocated with the MADV_DONTDUMP 
+  platforms.  (Currently only linux).  IO buffers are allocated with the MADV_DONTDUMP
   with madvise() on linux platforms that support MADV_DONTDUMP.  Enabled by default.
 
 .. ts:cv:: CONFIG proxy.config.http.enabled INT 1

--- a/doc/admin-guide/monitoring/diagnostic-files.en.rst
+++ b/doc/admin-guide/monitoring/diagnostic-files.en.rst
@@ -1,0 +1,59 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+
+=============
+traffic.out
+=============
+
+.. logfile:: traffic.out
+
+Debug level messages are written to this file. In particular if a :ref:`debug
+tag <proxy.config.diags.debug.tags>` is enabled output for that tag is placed in
+this file. This applies to both the |TS| core and plugins. This file also
+contains some generic operational messages which track |TS| starting and
+stopping. If |TS| crashes a stack trace should be put in this file.
+
+Most messages will have a timestamp, process tag, and a thread pointer.::
+
+   [Oct 13 14:40:46.134] Server {0x2ae95ff5ce80} DIAG: (header_freq.init) initializing plugin
+
+The process tag is "Server" indicating :program:`traffic_server`. It was logged
+from the thread with an instance address of `0x2ae95ff5ce80` and had a priority
+level of "DIAG" ("diagnostic"). The message is from a plugin, logged because the
+debug tag "header_freq.init" was active.
+
+=============
+diags.log
+=============
+
+.. logfile:: diags.log
+
+Diagnostic output file. Logging messages with a priority higher than "DEBUG" are
+sent to this file. If there is an problem that may cause |TS| to malfunction or
+not start up this is the first file that should be checked for logging messages.
+
+Messages in this file follow the same general format as for :file:`traffic.out`.
+
+=============
+error.log
+=============
+
+.. logfile:: error.log
+
+Operational error messages are placed here. These messages are about errors in
+transactions, not |TS| itself. For instance if a user agent request is denied
+that will be logged here.

--- a/doc/admin-guide/monitoring/index.en.rst
+++ b/doc/admin-guide/monitoring/index.en.rst
@@ -29,4 +29,4 @@ Monitoring
    statistics/index.en
    monitoring/index.en
    error-messages.en
-
+   diagnostic-files.en

--- a/doc/admin-guide/monitoring/statistics/core/hostdb.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/hostdb.en.rst
@@ -105,3 +105,7 @@ origin servers' hostnames prior to object revalidation or retrieval.
    :type: gauge
    :unit: seconds
 
+.. ts:stat:: global proxy.process.hostdb.cache.current_items integer
+   :type: gauge
+
+   The number of distinct host records in the HostDB cache.

--- a/doc/appendices/command-line/traffic_top.en.rst
+++ b/doc/appendices/command-line/traffic_top.en.rst
@@ -256,7 +256,7 @@ A high percentage of cold misses indicates that your origin servers are setting
 expirations on their responses which are too short, as compared to the actual
 lifetime of the content in those responses.
 
-Statistic: :ts:stat:`proxy.process.http.transaction_counts.miss_col`.
+Statistic: :ts:stat:`proxy.process.http.transaction_counts.miss_cold`.
 
 Changed
 ~~~~~~~
@@ -678,4 +678,3 @@ requests not fulfilled by the |TS| cache.
 Statistics:
 :ts:stat:`proxy.process.http.origin_server_response_header_total_size`,
 :ts:stat:`proxy.process.http.origin_server_response_document_total_size`.
-

--- a/doc/developer-guide/api/functions/TSNetAcceptNamedProtocol.en.rst
+++ b/doc/developer-guide/api/functions/TSNetAcceptNamedProtocol.en.rst
@@ -36,7 +36,7 @@ Description
 :type:`TSNetAcceptNamedProtocol` registers the specified :arg:`protocol`
 for all statically configured TLS ports.  When a client using the TLS
 Next Protocol Negotiation extension negotiates the requested protocol,
-:type:`TrafficServer` will route the request to the given handler :arg:`contp`.
+|TS| will route the request to the given handler :arg:`contp`.
 
 .. note::
 

--- a/doc/ext/traffic-server.py
+++ b/doc/ext/traffic-server.py
@@ -19,9 +19,9 @@
 """
     TS Sphinx Directives
     ~~~~~~~~~~~~~~~~~~~~~~~~~
-    
+
     Sphinx Docs directives for Apache Traffic Server
-    
+
     :copyright: Copyright 2013 by the Apache Software Foundation
     :license: Apache
 """
@@ -375,6 +375,9 @@ def setup(app):
     app.add_crossref_type('configfile', 'file',
                         objname='Configuration file',
                         indextemplate='pair: %s; Configuration files')
+    app.add_crossref_type('logfile', 'file',
+                        objname='Log file',
+                        indextemplate='pair: %s; Log files')
 
     rst.roles.register_generic_role('arg', nodes.emphasis)
     rst.roles.register_generic_role('const', nodes.literal)


### PR DESCRIPTION
Added "logfile" type to prevent dangling reference warnings.

Also cleaned up some white space issues because my editor does that automatically.