### PR TITLE
TS-5046: Guard against the server_session server_vc being NULL

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -3105,7 +3105,10 @@ HttpSM::tunnel_handler_server(int event, HttpTunnelProducer *p)
       ua_session->attach_server_session(server_session);
     } else {
       // Release the session back into the shared session pool
-      server_session->get_netvc()->set_inactivity_timeout(HRTIME_SECONDS(t_state.txn_conf->keep_alive_no_activity_timeout_out));
+      NetVConnection *vc = server_session->get_netvc();
+      if (vc) {
+        vc->set_inactivity_timeout(HRTIME_SECONDS(t_state.txn_conf->keep_alive_no_activity_timeout_out));
+      }
       server_session->release();
     }
   }


### PR DESCRIPTION
Only happens with 6.2.x branch and I could not identify which commit fixed this in 7.0.x branch hence here is an bandaid. I'm happy to withdraw this PR if we can identify a commit in 7.0.x so that we can simply backport it to 6.2.x.