### PR TITLE
TS-5058: Fix CONNECT handling without parent proxying.

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -469,7 +469,7 @@ how_to_open_connection(HttpTransact::State *s)
   // Setting up a direct CONNECT tunnel enters OriginServerRawOpen. We always do that if we
   // are not forwarding CONNECT and are not going to a parent proxy.
   if (s->method == HTTP_WKSIDX_CONNECT) {
-    if (s->txn_conf->forward_connect_method == 1 || s->parent_result.result != PARENT_SPECIFIED) {
+    if (s->txn_conf->forward_connect_method == 1 || s->parent_result.result == PARENT_SPECIFIED) {
       s->cdn_saved_next_action = HttpTransact::SM_ACTION_ORIGIN_SERVER_OPEN;
     } else {
       s->cdn_saved_next_action = HttpTransact::SM_ACTION_ORIGIN_SERVER_RAW_OPEN;


### PR DESCRIPTION
The change in TS-5040 broke direct CONNECT method handling by always
attempting to forward the CONNECT request. In fact, we should only be
forwarding the request if there is a parent specified or we have explicit
configuration to do so.