### PR TITLE
TS-5061 TS use ats_malloc instead of malloc in log module

### DIFF
--- a/mgmt/ProcessManager.cc
+++ b/mgmt/ProcessManager.cc
@@ -68,7 +68,8 @@ startProcessManager(void *arg)
   return ret;
 } /* End startProcessManager */
 
-ProcessManager::ProcessManager(bool rlm) : BaseManager(), require_lm(rlm), local_manager_sockfd(0), cbtable(NULL), max_msgs_in_a_row(1)
+ProcessManager::ProcessManager(bool rlm)
+  : BaseManager(), require_lm(rlm), local_manager_sockfd(0), cbtable(NULL), max_msgs_in_a_row(1)
 {
   mgmt_signal_queue = create_queue();
 
@@ -84,7 +85,7 @@ ProcessManager::reconfigure()
 {
   bool found;
   max_msgs_in_a_row = MAX_MSGS_IN_A_ROW;
-  timeout = REC_readInteger("proxy.config.process_manager.timeout", &found);
+  timeout           = REC_readInteger("proxy.config.process_manager.timeout", &found);
   ink_assert(found);
 
   return;

--- a/proxy/logging/LogFile.cc
+++ b/proxy/logging/LogFile.cc
@@ -452,9 +452,9 @@ LogFile::write_ascii_logbuffer3(LogBufferHeader *buffer_header, const char *alt_
     fmt_buf_bytes   = 0;
 
     if (m_file_format == LOG_FILE_PIPE) {
-      ascii_buffer = (char *)malloc(m_max_line_size);
+      ascii_buffer = (char *)ats_malloc(m_max_line_size);
     } else {
-      ascii_buffer = (char *)malloc(m_ascii_buffer_size);
+      ascii_buffer = (char *)ats_malloc(m_ascii_buffer_size);
     }
 
     // fill the buffer with as many records as possible


### PR DESCRIPTION
It should be abort immediately while malloc failed . So why do not use ats_malloc instead of malloc?