### PR TITLE
Doc: Update to malloc, cache-promote plugin.

### DIFF
--- a/doc/admin-guide/plugins/cache_promote.en.rst
+++ b/doc/admin-guide/plugins/cache_promote.en.rst
@@ -20,7 +20,7 @@
 Cache Promote Plugin
 ********************
 
-The `cache_promote` plugin provides a means to control when an object should
+The :program:`cache_promote` plugin provides a means to control when an object should
 be allowed to enter the cache. This is orthogonal from normal Cache-Control
 directives, providing a different set of policies to apply. The typical use
 case for this plugin is when you have a very large data set, where you want to
@@ -29,13 +29,25 @@ avoid churning the ATS cache for the long tail content.
 All configuration is done via :file:`remap.config`, and the following options
 are available:
 
-    --policy   The promotion policy. `lru` and `chance` are supported
-    --sample   The sampling rate for the request to be considered
+.. program:: cache-promote
 
-For the `lru` plugin, the following options are also available:
+.. option:: --policy
 
-    --hits     The minimum number of hits before promotion
-    --buckets  The size (entries) of the LRU
+   The promotion policy. The values ``lru`` and ``chance`` are supported.
+
+.. option:: --sample
+
+   The sampling rate for the request to be considered
+
+If :option:`--policy` is set to ``lru`` the following options are also available:
+
+.. option:: --hits
+
+   The minimum number of hits before promotion.
+
+.. option:: --buckets
+
+   The size (number of entries) of the LRU.
 
 These two options combined with your usage patterns will control how likely a
 URL is to become promoted to enter the cache.
@@ -43,7 +55,7 @@ URL is to become promoted to enter the cache.
 Examples
 --------
 
-These two examples shows how to use the chance and LRU policies, respectively:
+These two examples shows how to use the chance and LRU policies, respectively::
 
     map http://cdn.example.com/ http://some-server.example.com \
       @plugin=cache_promote.so @pparam=--policy=chance @pparam=--sample=10%
@@ -52,5 +64,4 @@ These two examples shows how to use the chance and LRU policies, respectively:
       @plugin=cache_promote.so @pparam=--policy=lru \
       @pparam=--hits=10 @pparam=--buckets=10000
 
-Note that the `--sample` option is available for all policies, and when used
-to reduce pressure on the under heavy load.
+Note :option:`--sample` is available for all policies and can be used to reduce pressure under heavy load.

--- a/doc/developer-guide/api/functions/TSmalloc.en.rst
+++ b/doc/developer-guide/api/functions/TSmalloc.en.rst
@@ -42,10 +42,10 @@ Description
 
 Traffic Server provides a number of routines for allocating and freeing
 memory. These routines correspond to similar routines in the C library.
-For example, :func:`TSrealloc` behaves like the C library routine :func:`realloc`.
+For example, :func:`TSrealloc` behaves like the C library routine :code:`realloc`.
 There are two reasons to use the routines provided by Traffic Server. The
 first is portability. The Traffic Server API routines behave the same on
-all of Traffic Servers supported platforms. For example, :func:`realloc` does
+all of Traffic Servers supported platforms. For example, :code:`realloc` does
 not accept an argument of ``NULL`` on some platforms. The second reason is
 that the Traffic Server routines actually track the memory allocations by
 file and line number. This tracking is very efficient, is always turned
@@ -54,7 +54,7 @@ on, and is useful for tracking down memory leaks.
 :func:`TSmalloc` returns a pointer to size bytes of memory allocated from the
 heap. Traffic Server uses :func:`TSmalloc` internally for memory allocations.
 Always use :func:`TSfree` to release memory allocated by :func:`TSmalloc`; do not use
-:func:`free`.
+:code:`free`.
 
 :func:`TSstrdup` returns a pointer to a new string that is a duplicate
 of the string pointed to by str. The memory for the new string is


### PR DESCRIPTION
I got bikeshedded by @zwoop on this. This is the fourth or or so version of these changes to get acceptable formatting.

I think the use of `option` markup is overall the best approach. It sets off the options, fixes the double dash issue, and supports linking directly to the option definition. Unfortunately github cannot at present render that markup so it is necessary to build the docs locally to see what this actually looks like.