### PR TITLE
TS-4720 back port

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -794,7 +794,7 @@ HttpSM::state_read_client_request_header(int event, void *data)
     }
 
     if (t_state.hdr_info.client_request.method_get_wksidx() == HTTP_WKSIDX_TRACE ||
-        (t_state.hdr_info.request_content_length == 0 && t_state.client_info.transfer_encoding != HttpTransact::CHUNKED_ENCODING)) {
+        (t_state.hdr_info.request_content_length <= 0 && t_state.client_info.transfer_encoding != HttpTransact::CHUNKED_ENCODING)) {
       // Enable further IO to watch for client aborts
       ua_entry->read_vio->reenable();
     } else {
@@ -5169,7 +5169,7 @@ HttpSM::mark_server_down_on_client_abort()
   //  that upstream proxy may be working but         //
   //  the actual origin server is one that is hung   //
   /////////////////////////////////////////////////////
-  if (t_state.current.request_to == HttpTransact::ORIGIN_SERVER && t_state.hdr_info.request_content_length == 0) {
+  if (t_state.current.request_to == HttpTransact::ORIGIN_SERVER && t_state.hdr_info.request_content_length <= 0) {
     if (milestones[TS_MILESTONE_SERVER_FIRST_CONNECT] != 0 && milestones[TS_MILESTONE_SERVER_FIRST_READ] == 0) {
       // Check to see if client waited for the threshold
       //  to declare the origin server as down


### PR DESCRIPTION
HttpTransact defaults content length to `-1`, meaning that if the request has no content length header it will be `-1`. These checks weren't taking that into consideration -- meaning client aborts during requests with no content length (GET for example) would leave the origin session open until another timeout kicked in.

(cherry picked from commit a075556602d77d79f5a02e2a36053abfa92703f0)