### PR TITLE
TS-5062: Fix traffic_ctl to track plugin supplied configuration variables.

### DIFF
--- a/cmd/traffic_ctl/config.cc
+++ b/cmd/traffic_ctl/config.cc
@@ -150,6 +150,8 @@ rec_sourceof(int rec_source)
     return "built in default";
   case REC_SOURCE_EXPLICIT:
     return "administratively set";
+  case REC_SOURCE_PLUGIN:
+    return "plugin default";
   case REC_SOURCE_ENV:
     return "environment";
   default:

--- a/doc/developer-guide/api/functions/TSMgmtSourceGet.en.rst
+++ b/doc/developer-guide/api/functions/TSMgmtSourceGet.en.rst
@@ -1,0 +1,71 @@
+.. Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed
+   with this work for additional information regarding copyright
+   ownership.  The ASF licenses this file to you under the Apache
+   License, Version 2.0 (the "License"); you may not use this file
+   except in compliance with the License.  You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied.  See the License for the specific language governing
+   permissions and limitations under the License.
+
+.. include:: ../../../common.defs
+
+.. default-domain:: c
+
+TSMgmtSourceGet
+***************
+
+Synopsis
+========
+
+`#include <ts/ts.h>`
+
+.. function:: TSReturnCode TSMgmtSourceGet(const char * var_name, TSMgmtSource * result)
+
+Description
+===========
+
+Get the source of a value for a configuration variable. :arg:`var_name` is the name of the variable
+as a nul terminated string. The source value is stored in :arg:`result`. The function can return
+failure if :arg:`var_name` is not found.
+
+Types
+=====
+
+.. type:: TSMgmtSource
+
+   Source of the current value for a management (configuration) value.
+
+   .. macro:: TS_MGMT_SOURCE_NULL
+
+      Invalid value, no source available. This is primarily used as an initialization or error value
+      and should be returned only when the API call fails.
+
+   .. macro:: TS_MGMT_SOURCE_DEFAULT
+
+      The default value provided by the |TS| core.
+
+   .. macro:: TS_MGMT_SOURCE_PLUGIN
+
+      The configuration variable was created by a plugin and the value is the default value provided
+      by a plugin.
+
+   .. macro:: TS_MGMT_SOURCE_EXPLICIT
+
+      The value has been set in :file:`records.config`. Note this value is returned even if the
+      variable was explicitly set to the default value.
+
+   .. macro:: TS_MGMT_SOURCE_ENV
+
+      The value was retrieved from the process environment, overriding the default value.
+
+Return Values
+=============
+
+:data:`TS_SUCCESS` if the :arg:`var_name` was found, :data:`TS_ERROR` if not.

--- a/lib/records/I_RecDefs.h
+++ b/lib/records/I_RecDefs.h
@@ -121,9 +121,11 @@ enum RecCheckT {
 
 /// The source of the value.
 /// @internal @c REC_SOURCE_NULL is useful for a return value, I don't see using it in the actual data.
+/// @internal If this is changed, TSMgmtSource in apidefs.h.in must also be changed.
 enum RecSourceT {
   REC_SOURCE_NULL,     ///< No source / value not set.
   REC_SOURCE_DEFAULT,  ///< Built in default.
+  REC_SOURCE_PLUGIN,   ///< Plugin supplied default.
   REC_SOURCE_EXPLICIT, ///< Set by administrator (config file, external API, cluster, etc.)
   REC_SOURCE_ENV       ///< Process environment variable.
 };

--- a/lib/records/P_RecCore.cc
+++ b/lib/records/P_RecCore.cc
@@ -220,7 +220,8 @@ recv_message_cb(RecMessage *msg, RecMessageT msg_type, void * /* cookie */)
           RecRegisterStat(r->rec_type, r->name, r->data_type, r->data_default, r->stat_meta.persist_type);
         } else if (REC_TYPE_IS_CONFIG(r->rec_type)) {
           RecRegisterConfig(r->rec_type, r->name, r->data_type, r->data_default, r->config_meta.update_type,
-                            r->config_meta.check_type, r->config_meta.check_expr, REC_SOURCE_EXPLICIT, r->config_meta.access_type);
+                            r->config_meta.check_type, r->config_meta.check_expr, r->config_meta.source,
+                            r->config_meta.access_type);
         }
       } while (RecMessageUnmarshalNext(msg, &itr, &r) != REC_ERR_FAIL);
     }

--- a/lib/ts/apidefs.h.in
+++ b/lib/ts/apidefs.h.in
@@ -798,6 +798,16 @@ typedef int64_t TSMgmtCounter;
 typedef float TSMgmtFloat;
 typedef char *TSMgmtString;
 
+/// The source of a management value.
+typedef enum {
+  TS_MGMT_SOURCE_NULL,     ///< No source / value not found.
+  TS_MGMT_SOURCE_DEFAULT,  ///< Built in core default.
+  TS_MGMT_SOURCE_PLUGIN,   ///< Plugin supplied default.
+  TS_MGMT_SOURCE_EXPLICIT, ///< Set by administrator (config file, external API, cluster, etc.)
+  TS_MGMT_SOURCE_ENV       ///< Process environment variable.
+} TSMgmtSource;
+
+
 typedef struct tsapi_file *TSFile;
 
 typedef struct tsapi_mloc *TSMLoc;

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -4304,6 +4304,12 @@ TSMgmtStringGet(const char *var_name, TSMgmtString *result)
   return TS_ERROR;
 }
 
+TSReturnCode
+TSMgmtSourceGet(const char *var_name, TSMgmtSource *source)
+{
+  return REC_ERR_OKAY == RecGetRecordSource(var_name, reinterpret_cast<RecSourceT *>(source)) ? TS_SUCCESS : TS_ERROR;
+}
+
 ////////////////////////////////////////////////////////////////////
 //
 // Continuations
@@ -8893,7 +8899,7 @@ TSMgmtStringCreate(TSRecordType rec_type, const char *name, const TSMgmtString d
     return TS_ERROR;
   }
   if (REC_ERR_OKAY != RecRegisterConfigString((enum RecT)rec_type, name, data_default, (enum RecUpdateT)update_type,
-                                              (enum RecCheckT)check_type, check_regex, REC_SOURCE_EXPLICIT,
+                                              (enum RecCheckT)check_type, check_regex, REC_SOURCE_PLUGIN,
                                               (enum RecAccessT)access_type)) {
     return TS_ERROR;
   }
@@ -8909,7 +8915,7 @@ TSMgmtIntCreate(TSRecordType rec_type, const char *name, TSMgmtInt data_default,
     return TS_ERROR;
   }
   if (REC_ERR_OKAY != RecRegisterConfigInt((enum RecT)rec_type, name, (RecInt)data_default, (enum RecUpdateT)update_type,
-                                           (enum RecCheckT)check_type, check_regex, REC_SOURCE_EXPLICIT,
+                                           (enum RecCheckT)check_type, check_regex, REC_SOURCE_PLUGIN,
                                            (enum RecAccessT)access_type)) {
     return TS_ERROR;
   }

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -1194,7 +1194,7 @@ tsapi TSReturnCode TSMgmtIntGet(const char *var_name, TSMgmtInt *result);
 tsapi TSReturnCode TSMgmtCounterGet(const char *var_name, TSMgmtCounter *result);
 tsapi TSReturnCode TSMgmtFloatGet(const char *var_name, TSMgmtFloat *result);
 tsapi TSReturnCode TSMgmtStringGet(const char *var_name, TSMgmtString *result);
-
+tsapi TSReturnCode TSMgmtSourceGet(const char *var_name, TSMgmtSource *source);
 /* --------------------------------------------------------------------------
    Continuations */
 tsapi TSCont TSContCreate(TSEventFunc funcp, TSMutex mutexp);


### PR DESCRIPTION
It would be nice if `traffic_ctl` could show that a particular configuration value was created by a plugin and whether it was overridden in `records.config` as it does for core defined variables.