### PR TITLE
HostDB memory fixes

### DIFF
--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -276,8 +276,8 @@ struct HostDBSync : public HostDBBackgroundTask {
     SET_HANDLER(&HostDBSync::wait_event);
     start_time = Thread::get_hrtime();
 
-    new RefCountCacheSerializer<RefCountCache<HostDBInfo>>(this, hostDBProcessor.cache()->refcountcache, this->frequency,
-                                                           this->storage_path, this->full_path);
+    new RefCountCacheSerializer<HostDBInfo>(this, hostDBProcessor.cache()->refcountcache, this->frequency, this->storage_path,
+                                            this->full_path);
     return EVENT_DONE;
   }
 };

--- a/iocore/hostdb/RefCountCache.cc
+++ b/iocore/hostdb/RefCountCache.cc
@@ -22,9 +22,21 @@
 #include <P_RefCountCache.h>
 
 // Since the hashing values are all fixed size, we can simply use a classAllocator to avoid mallocs
-ClassAllocator<RefCountCacheHashEntry> refCountCacheHashingValueAllocator("refCountCacheHashingValueAllocator");
+static ClassAllocator<RefCountCacheHashEntry> refCountCacheHashingValueAllocator("refCountCacheHashingValueAllocator");
 
 ClassAllocator<PriorityQueueEntry<RefCountCacheHashEntry *>> expiryQueueEntry("expiryQueueEntry");
+
+RefCountCacheHashEntry *
+RefCountCacheHashEntry::alloc()
+{
+  return refCountCacheHashingValueAllocator.alloc();
+}
+
+void
+RefCountCacheHashEntry::dealloc(RefCountCacheHashEntry *e)
+{
+  return refCountCacheHashingValueAllocator.free(e);
+}
 
 RefCountCacheHeader::RefCountCacheHeader(VersionNumber object_version)
   : magic(REFCOUNTCACHE_MAGIC_NUMBER), object_version(object_version)


### PR DESCRIPTION
[TS-5065](https://issues.apache.org/jira/browse/TS-5066) Use after free clearing HostDB.
[TS-5066](https://issues.apache.org/jira/browse/TS-5065) HostDB serialization leaks on error path.