### PR TITLE
Doc conditional build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,7 +29,10 @@ export CCACHE_BASEDIR
 # proxy/api/ts has to be built first, since so much of libraries and "core
 # depends on the generates ts/ts.h include file.
 
-SUBDIRS = proxy/api/ts iocore lib proxy/hdrs proxy/shared mgmt proxy cmd plugins tools example rc doc
+SUBDIRS = proxy/api/ts iocore lib proxy/hdrs proxy/shared mgmt proxy cmd plugins tools example rc
+if BUILD_DOCS
+SUBDIRS += doc
+endif
 
 
 DIST_BUILD_USER=`id -nu`

--- a/ci/jenkins/bin/docs.sh
+++ b/ci/jenkins/bin/docs.sh
@@ -22,7 +22,7 @@ test ! -z "${WORKSPACE}" && cd "${WORKSPACE}/src"
 
 # This avoids redoing the configure on every doc build, which is somewhat annoying
 [ ! -f configure ] && autoreconf -fi
-[ ! -f config.nice ] && ./configure
+[ ! -f config.nice ] && ./configure --enable-docs
 
 cd doc
 

--- a/configure.ac
+++ b/configure.ac
@@ -248,6 +248,19 @@ TS_ARG_ENABLE_VAR([has], [tests])
 AM_CONDITIONAL([BUILD_TESTS], [test 0 -ne $has_tests])
 
 #
+# Build documentation?
+#
+
+AC_MSG_CHECKING([whether to build documentation])
+AC_ARG_ENABLE([docs],
+  [AS_HELP_STRING([--enable-docs],[enable documentation building])],
+  [],
+  [enable_doc_build=no]
+)
+AC_MSG_RESULT([$enable_doc_build])
+AM_CONDITIONAL([BUILD_DOCS], [test "xyes" = "x$enable_doc_build"])
+
+#
 # Remote Coverity Prevent commit
 #
 AC_MSG_CHECKING([whether to commit cov defects to remote host])


### PR DESCRIPTION
Make the docs not build by default, require a "--enable-docs" argument to ./config.