### PR TITLE
TS-5060: Add support for DNAME record type.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1491,7 +1491,6 @@ AC_CHECK_HEADERS([sys/types.h \
                   sys/sockio.h \
                   sys/prctl.h \
                   arpa/nameser.h \
-                  arpa/nameser_compat.h \
                   execinfo.h \
                   netdb.h \
                   ctype.h \
@@ -1536,7 +1535,6 @@ AC_SUBST(sys_sysinfoh)
 AC_SUBST(sys_systeminfoh)
 AC_SUBST(arpa_ineth)
 AC_SUBST(arpa_nameserh)
-AC_SUBST(arpa_nameser_compath)
 AC_SUBST(execinfoh)
 AC_SUBST(netdbh)
 AC_SUBST(ctypeh)

--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -62,12 +62,12 @@ namespace
 inline const char *
 QtypeName(int qtype)
 {
-  return T_AAAA == qtype ? "AAAA" : T_A == qtype ? "A" : "*";
+  return ns_t_aaaa == qtype ? "AAAA" : ns_t_a == qtype ? "A" : "*";
 }
 inline bool
 is_addr_query(int qtype)
 {
-  return qtype == T_A || qtype == T_AAAA;
+  return qtype == ns_t_a || qtype == ns_t_aaaa;
 }
 }
 
@@ -361,9 +361,9 @@ DNSEntry::init(const char *x, int len, int qtype_arg, Continuation *acont, DNSPr
   if (is_addr_query(qtype)) {
     // adjust things based on family preference.
     if (HOST_RES_IPV4 == host_res_style || HOST_RES_IPV4_ONLY == host_res_style) {
-      qtype = T_A;
+      qtype = ns_t_a;
     } else if (HOST_RES_IPV6 == host_res_style || HOST_RES_IPV6_ONLY == host_res_style) {
-      qtype = T_AAAA;
+      qtype = ns_t_aaaa;
     }
   }
   submit_time   = Thread::get_hrtime();
@@ -384,7 +384,7 @@ DNSEntry::init(const char *x, int len, int qtype_arg, Continuation *acont, DNSPr
 
   mutex = dnsH->mutex;
 
-  if (is_addr_query(qtype) || qtype == T_SRV) {
+  if (is_addr_query(qtype) || qtype == ns_t_srv) {
     if (len) {
       len = len > (MAXDNAME - 1) ? (MAXDNAME - 1) : len;
       memcpy(qname, x, len);
@@ -394,14 +394,14 @@ DNSEntry::init(const char *x, int len, int qtype_arg, Continuation *acont, DNSPr
       qname_len      = ink_strlcpy(qname, x, MAXDNAME);
       orig_qname_len = qname_len;
     }
-  } else { // T_PTR
+  } else { // ns_t_ptr
     IpAddr const *ip = reinterpret_cast<IpAddr const *>(x);
     if (ip->isIp6())
       make_ipv6_ptr(&ip->_addr._ip6, qname);
     else if (ip->isIp4())
       make_ipv4_ptr(ip->_addr._ip4, qname);
     else
-      ink_assert(!"T_PTR query to DNS must be IP address.");
+      ink_assert(!"ns_t_ptr query to DNS must be IP address.");
   }
 
   SET_HANDLER((DNSEntryHandler)&DNSEntry::mainEvent);
@@ -564,7 +564,7 @@ DNSHandler::retry_named(int ndx, ink_hrtime t, bool reopen)
 
   char buffer[MAX_DNS_PACKET_LEN];
   Debug("dns", "trying to resolve '%s' from DNS connection, ndx %d", try_server_names[try_servers], ndx);
-  int r       = _ink_res_mkquery(m_res, try_server_names[try_servers], T_A, buffer);
+  int r       = _ink_res_mkquery(m_res, try_server_names[try_servers], ns_t_a, buffer);
   try_servers = (try_servers + 1) % countof(try_server_names);
   ink_assert(r >= 0);
   if (r >= 0) { // looking for a bounce
@@ -587,7 +587,7 @@ DNSHandler::try_primary_named(bool reopen)
 
     last_primary_retry = t;
     Debug("dns", "trying to resolve '%s' from primary DNS connection", try_server_names[try_servers]);
-    int r = _ink_res_mkquery(m_res, try_server_names[try_servers], T_A, buffer);
+    int r = _ink_res_mkquery(m_res, try_server_names[try_servers], ns_t_a, buffer);
     // if try_server_names[] is not full, round-robin within the
     // filled entries.
     if (local_num_entries < DEFAULT_NUM_TRY_SERVER)
@@ -1089,7 +1089,7 @@ Action *
 DNSProcessor::getby(const char *x, int len, int type, Continuation *cont, Options const &opt)
 {
   Debug("dns", "received query %s type = %d, timeout = %d", x, type, opt.timeout);
-  if (type == T_SRV) {
+  if (type == ns_t_srv) {
     Debug("dns_srv", "DNSProcessor::getby attempting an SRV lookup for %s, timeout = %d", x, opt.timeout);
   }
   DNSEntry *e = dnsEntryAllocator.alloc();
@@ -1175,7 +1175,7 @@ dns_result(DNSHandler *h, DNSEntry *e, HostEnt *ent, bool retry)
       const char *result = "FAIL";
       if (ent) {
         result = "SUCCESS";
-        ptr    = inet_ntop(e->qtype == T_AAAA ? AF_INET6 : AF_INET, ent->ent.h_addr_list[0], buff, sizeof(buff));
+        ptr    = inet_ntop(e->qtype == ns_t_aaaa ? AF_INET6 : AF_INET, ent->ent.h_addr_list[0], buff, sizeof(buff));
       }
       Debug("dns", "%s result for %s = %s retry %d", result, e->qname, ptr, retry);
     } else {
@@ -1423,7 +1423,7 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
        this skips the query section (qdcount)
      */
     unsigned char *here = (unsigned char *)buf->buf + HFIXEDSZ;
-    if (e->qtype == T_SRV) {
+    if (e->qtype == ns_t_srv) {
       for (int ctr = ntohs(h->qdcount); ctr > 0; ctr--) {
         int strlen = dn_skipname(here, eom);
         here += strlen + QFIXEDSZ;
@@ -1444,7 +1444,7 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
       short int type;
       NS_GET16(type, cp);
       cp += NS_INT16SZ;       // NS_GET16(cls, cp);
-      NS_GET32(temp_ttl, cp); // NOTE: this is not a "long" but 32-bits (from nameser_compat.h)
+      NS_GET32(temp_ttl, cp); // NOTE: this is not a "long" but 32-bits (from nameser.h)
       if ((temp_ttl < buf->ttl) || (buf->ttl == 0))
         buf->ttl = temp_ttl;
       NS_GET16(n, cp);
@@ -1452,7 +1452,7 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
       //
       // Decode cname
       //
-      if (is_addr_query(e->qtype) && type == T_CNAME) {
+      if (is_addr_query(e->qtype) && (type == ns_t_cname || type == ns_t_dname)) {
         if (ap >= &buf->host_aliases[DNS_MAX_ALIASES - 1])
           continue;
         n = ink_dn_expand((u_char *)h, eom, cp, tbuf, sizeof(tbuf));
@@ -1473,7 +1473,16 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
         ink_strlcpy((char *)bp, (char *)tbuf, buflen);
         bp += n;
         buflen -= n;
-        Debug("dns", "received cname = %s", tbuf);
+        if (is_debug_tag_set("dns")) {
+          switch (type) {
+          case ns_t_cname:
+            Debug("dns", "received cname = %s", tbuf);
+            break;
+          case ns_t_dname:
+            Debug("dns", "received dname = %s", tbuf);
+            break;
+          }
+        }
         continue;
       }
       if (e->qtype != type) {
@@ -1483,7 +1492,7 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
       //
       // Decode names
       //
-      if (type == T_PTR) {
+      if (type == ns_t_ptr) {
         n = ink_dn_expand((u_char *)h, eom, cp, bp, buflen);
         if (n < 0) {
           ++error;
@@ -1503,7 +1512,7 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
           bp += n;
           buflen -= n;
         }
-      } else if (type == T_SRV) {
+      } else if (type == ns_t_srv) {
         if (num_srv >= HOST_DB_MAX_ROUND_ROBIN_INFO)
           break;
         cp         = here; /* hack */
@@ -1544,7 +1553,7 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
         } else {
           int nn;
           buf->ent.h_length   = n;
-          buf->ent.h_addrtype = T_A == type ? AF_INET : AF_INET6;
+          buf->ent.h_addrtype = ns_t_a == type ? AF_INET : AF_INET6;
           buf->ent.h_name     = (char *)bp;
           nn                  = strlen((char *)bp) + 1;
           Debug("dns", "received %s name = %s", QtypeName(type), bp);
@@ -1564,7 +1573,7 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
           }
           memcpy((*hap++ = bp), cp, n);
           Debug("dns", "received %s = %s", QtypeName(type),
-                inet_ntop(T_AAAA == type ? AF_INET6 : AF_INET, bp, ip_string, sizeof(ip_string)));
+                inet_ntop(ns_t_aaaa == type ? AF_INET6 : AF_INET, bp, ip_string, sizeof(ip_string)));
           bp += n;
           cp += n;
         }

--- a/iocore/dns/I_DNSProcessor.h
+++ b/iocore/dns/I_DNSProcessor.h
@@ -156,25 +156,25 @@ extern DNSProcessor dnsProcessor;
 inline Action *
 DNSProcessor::getSRVbyname(Continuation *cont, const char *name, Options const &opt)
 {
-  return getby(name, 0, T_SRV, cont, opt);
+  return getby(name, 0, ns_t_srv, cont, opt);
 }
 
 inline Action *
 DNSProcessor::gethostbyname(Continuation *cont, const char *name, Options const &opt)
 {
-  return getby(name, 0, T_A, cont, opt);
+  return getby(name, 0, ns_t_a, cont, opt);
 }
 
 inline Action *
 DNSProcessor::gethostbyname(Continuation *cont, const char *name, int len, Options const &opt)
 {
-  return getby(name, len, T_A, cont, opt);
+  return getby(name, len, ns_t_a, cont, opt);
 }
 
 inline Action *
 DNSProcessor::gethostbyaddr(Continuation *cont, IpAddr const *addr, Options const &opt)
 {
-  return getby(reinterpret_cast<const char *>(addr), 0, T_PTR, cont, opt);
+  return getby(reinterpret_cast<const char *>(addr), 0, ns_t_ptr, cont, opt);
 }
 
 inline DNSProcessor::Options::Options() : handler(0), timeout(0), host_res_style(HOST_RES_IPV4)

--- a/lib/ts/ink_platform.h
+++ b/lib/ts/ink_platform.h
@@ -93,9 +93,6 @@
 #ifdef HAVE_ARPA_NAMESER_H
 #include <arpa/nameser.h>
 #endif
-#ifdef HAVE_ARPA_NAMESER_COMPAT_H
-#include <arpa/nameser_compat.h>
-#endif
 
 #include <signal.h>
 #ifdef HAVE_SIGINFO_H

--- a/lib/ts/ink_res_init.cc
+++ b/lib/ts/ink_res_init.cc
@@ -74,9 +74,6 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <arpa/nameser.h>
-#ifdef HAVE_ARPA_NAMESER_COMPAT_H
-#include <arpa/nameser_compat.h>
-#endif
 #include <stdio.h>
 #include <ctype.h>
 #include <resolv.h>

--- a/lib/ts/ink_res_mkquery.cc
+++ b/lib/ts/ink_res_mkquery.cc
@@ -71,9 +71,6 @@
 #include <sys/param.h>
 #include <netinet/in.h>
 #include <arpa/nameser.h>
-#ifdef HAVE_ARPA_NAMESER_COMPAT_H
-#include <arpa/nameser_compat.h>
-#endif
 #include <netdb.h>
 #include <resolv.h>
 #include <stdio.h>
@@ -144,7 +141,7 @@ int ink_res_mkquery(ink_res_state statp, int op,               /*!< opcode of qu
     if (n < 0)
       return (-1);
     cp += n;
-    NS_PUT16(T_NULL, cp);
+    NS_PUT16(ns_t_null, cp);
     NS_PUT16(_class, cp);
     NS_PUT32(0, cp);
     NS_PUT16(0, cp);


### PR DESCRIPTION
This is a patch suggested by @zwoop that adds support for resolving DNAME record types.  I've tested this patch with a delivery service we were trying to deploy that uses DNAME record types.  This patch solves the problem where queries using DNAME failed due to ATS inability to resolve DNAME's.