### PR TITLE
TS-5070 Add configuration variables to set file permissions for diags.log & traffic.out

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -285,7 +285,6 @@ System Variables
 
 
 .. ts:cv:: CONFIG proxy.config.output.logfile_perm STRING rw-r--r--
-   :reloadable:
 
    The log file permissions. The standard UNIX file permissions are used (owner, group, other). Permissible values are:
 
@@ -2891,7 +2890,6 @@ Diagnostic Logging Configuration
 
 
 .. ts:cv:: CONFIG proxy.config.diags.logfile_perm STRING rw-r--r--
-   :reloadable:
 
    The log file permissions. The standard UNIX file permissions are used (owner, group, other). Permissible values are:
 

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -283,6 +283,27 @@ System Variables
    The name and location of the file that contains warnings, status messages, and error messages produced by the Traffic Server
    processes. If no path is specified, then Traffic Server creates the file in its logging directory.
 
+
+.. ts:cv:: CONFIG proxy.config.output.logfile_perm STRING rw-r--r--
+   :reloadable:
+
+   The log file permissions. The standard UNIX file permissions are used (owner, group, other). Permissible values are:
+
+   ===== ======================================================================
+   Value Description
+   ===== ======================================================================
+   ``-`` No permissions.
+   ``r`` Read permission.
+   ``w`` Write permission.
+   ``x`` Execute permission.
+   ===== ======================================================================
+
+   Permissions are subject to the umask settings for the |TS| process. This
+   means that a umask setting of ``002`` will not allow write permission for
+   others, even if specified in the configuration file. Permissions for
+   existing log files are not changed when the configuration is modified.
+
+
 .. ts:cv:: CONFIG proxy.config.output.logfile.rolling_enabled INT 0
    :reloadable:
 
@@ -2867,6 +2888,27 @@ Diagnostic Logging Configuration
 
    |TS| plugins will typically log debug messages using the :c:func:`TSDebug`
    API, passing the plugin name as the debug tag.
+
+
+.. ts:cv:: CONFIG proxy.config.diags.logfile_perm STRING rw-r--r--
+   :reloadable:
+
+   The log file permissions. The standard UNIX file permissions are used (owner, group, other). Permissible values are:
+
+   ===== ======================================================================
+   Value Description
+   ===== ======================================================================
+   ``-`` No permissions.
+   ``r`` Read permission.
+   ``w`` Write permission.
+   ``x`` Execute permission.
+   ===== ======================================================================
+
+   Permissions are subject to the umask settings for the |TS| process. This
+   means that a umask setting of ``002`` will not allow write permission for
+   others, even if specified in the configuration file. Permissions for
+   existing log files are not changed when the configuration is modified.
+
 
 .. ts:cv:: CONFIG proxy.config.diags.logfile.rolling_enabled INT 0
    :reloadable:

--- a/lib/ts/BaseLogFile.cc
+++ b/lib/ts/BaseLogFile.cc
@@ -342,7 +342,8 @@ BaseLogFile::open_file(int perm)
   // set permissions if necessary
   if (perm != -1) {
     // means LogFile passed in some permissions we need to set
-    if (chmod(m_name.get(), perm) != 0)
+    log_log_trace("BaseLogFile attempting to change %s's permissions to %o\n", m_name.get(), perm);
+    if (elevating_chmod(m_name.get(), perm) != 0)
       log_log_error("Error changing logfile=%s permissions: %s\n", m_name.get(), strerror(errno));
   }
 

--- a/lib/ts/Diags.cc
+++ b/lib/ts/Diags.cc
@@ -98,7 +98,7 @@ vprintline(FILE *fp, char (&buffer)[Size], va_list ap)
 //
 //////////////////////////////////////////////////////////////////////////////
 
-Diags::Diags(const char *prefix_string, const char *bdt, const char *bat, BaseLogFile *_diags_log)
+Diags::Diags(const char *prefix_string, const char *bdt, const char *bat, BaseLogFile *_diags_log, int dl_perm, int ol_perm)
   : diags_log(nullptr),
     stdout_log(nullptr),
     stderr_log(nullptr),
@@ -162,6 +162,9 @@ Diags::Diags(const char *prefix_string, const char *bdt, const char *bat, BaseLo
 
   outputlog_time_last_roll = time(nullptr);
   diagslog_time_last_roll  = time(nullptr);
+
+  diags_logfile_perm = dl_perm;
+  output_logfile_perm = ol_perm;
 
   if (setup_diagslog(_diags_log)) {
     diags_log = _diags_log;
@@ -517,18 +520,6 @@ Diags::level_name(DiagsLevel dl) const
 //      void Diags::dump(FILE *fp)
 //
 //////////////////////////////////////////////////////////////////////////////
-
-void
-Diags::set_diags_log_perms(int perms)
-{
-  diags_logfile_perm = perms;
-}
-
-void
-Diags::set_output_log_perms(int perms)
-{
-  output_logfile_perm = perms;
-}
 
 void
 Diags::dump(FILE *fp) const

--- a/lib/ts/Diags.cc
+++ b/lib/ts/Diags.cc
@@ -163,7 +163,7 @@ Diags::Diags(const char *prefix_string, const char *bdt, const char *bat, BaseLo
   outputlog_time_last_roll = time(nullptr);
   diagslog_time_last_roll  = time(nullptr);
 
-  diags_logfile_perm = dl_perm;
+  diags_logfile_perm  = dl_perm;
   output_logfile_perm = ol_perm;
 
   if (setup_diagslog(_diags_log)) {

--- a/lib/ts/Diags.cc
+++ b/lib/ts/Diags.cc
@@ -50,8 +50,6 @@ bool DiagsConfigState::enabled[2] = {false, false};
 // Global, used for all diagnostics
 inkcoreapi Diags *diags = nullptr;
 
-static bool setup_diagslog(BaseLogFile *blf);
-
 static bool
 location(const SourceLocation *loc, DiagsShowLocation show, DiagsLevel level)
 {
@@ -521,6 +519,18 @@ Diags::level_name(DiagsLevel dl) const
 //////////////////////////////////////////////////////////////////////////////
 
 void
+Diags::set_diags_log_perms(int perms)
+{
+  diags_logfile_perm = perms;
+}
+
+void
+Diags::set_output_log_perms(int perms)
+{
+  output_logfile_perm = perms;
+}
+
+void
 Diags::dump(FILE *fp) const
 {
   int i;
@@ -564,11 +574,11 @@ Diags::error_va(DiagsLevel level, const SourceLocation *loc, const char *format_
  *
  * Returns true on success, false otherwise
  */
-static bool
-setup_diagslog(BaseLogFile *blf)
+bool
+Diags::setup_diagslog(BaseLogFile *blf)
 {
   if (blf != nullptr) {
-    if (blf->open_file() != BaseLogFile::LOG_FILE_NO_ERROR) {
+    if (blf->open_file(diags_logfile_perm) != BaseLogFile::LOG_FILE_NO_ERROR) {
       log_log_error("Could not open diags log file: %s\n", strerror(errno));
       delete blf;
       return false;
@@ -803,7 +813,7 @@ Diags::set_stdout_output(const char *stdout_path)
   BaseLogFile *new_stdout_log = new BaseLogFile(stdout_path);
 
   // on any errors we quit
-  if (!new_stdout_log || new_stdout_log->open_file() != BaseLogFile::LOG_FILE_NO_ERROR) {
+  if (!new_stdout_log || new_stdout_log->open_file(output_logfile_perm) != BaseLogFile::LOG_FILE_NO_ERROR) {
     log_log_error("[Warning]: unable to open file=%s to bind stdout to\n", stdout_path);
     log_log_error("[Warning]: stdout is currently not bound to anything\n");
     delete new_stdout_log;
@@ -853,7 +863,7 @@ Diags::set_stderr_output(const char *stderr_path)
   BaseLogFile *new_stderr_log = new BaseLogFile(stderr_path);
 
   // on any errors we quit
-  if (!new_stderr_log || new_stderr_log->open_file() != BaseLogFile::LOG_FILE_NO_ERROR) {
+  if (!new_stderr_log || new_stderr_log->open_file(output_logfile_perm) != BaseLogFile::LOG_FILE_NO_ERROR) {
     log_log_error("[Warning]: unable to open file=%s to bind stderr to\n", stderr_path);
     log_log_error("[Warning]: stderr is currently not bound to anything\n");
     delete new_stderr_log;

--- a/lib/ts/Diags.h
+++ b/lib/ts/Diags.h
@@ -110,7 +110,7 @@ struct DiagsConfigState {
 class Diags
 {
 public:
-  Diags(const char *prefix_string, const char *base_debug_tags, const char *base_action_tags, BaseLogFile *_diags_log);
+  Diags(const char *prefix_string, const char *base_debug_tags, const char *base_action_tags, BaseLogFile *_diags_log, int diags_log_perm = -1, int output_log_perm = -1);
   ~Diags();
 
   BaseLogFile *diags_log;
@@ -209,8 +209,6 @@ public:
   void deactivate_all(DiagsTagType mode = DiagsTagType_Debug);
 
   bool setup_diagslog(BaseLogFile *blf);
-  void set_diags_log_perms(int perms);
-  void set_output_log_perms(int perms);
 
   void config_roll_diagslog(RollingEnabledValues re, int ri, int rs);
   void config_roll_outputlog(RollingEnabledValues re, int ri, int rs);

--- a/lib/ts/Diags.h
+++ b/lib/ts/Diags.h
@@ -208,6 +208,10 @@ public:
 
   void deactivate_all(DiagsTagType mode = DiagsTagType_Debug);
 
+  bool setup_diagslog(BaseLogFile *blf);
+  void set_diags_log_perms(int perms);
+  void set_output_log_perms(int perms);
+
   void config_roll_diagslog(RollingEnabledValues re, int ri, int rs);
   void config_roll_outputlog(RollingEnabledValues re, int ri, int rs);
   bool should_roll_diagslog();
@@ -223,6 +227,10 @@ private:
   const char *prefix_str;
   mutable ink_mutex tag_table_lock; // prevents reconfig/read races
   DFA *activated_tags[2];           // 1 table for debug, 1 for action
+
+  // These are the default logfile permissions
+  int diags_logfile_perm = -1;
+  int output_logfile_perm = -1;
 
   // log rotation variables
   RollingEnabledValues outputlog_rolling_enabled;

--- a/lib/ts/Diags.h
+++ b/lib/ts/Diags.h
@@ -210,7 +210,6 @@ public:
   void deactivate_all(DiagsTagType mode = DiagsTagType_Debug);
 
   bool setup_diagslog(BaseLogFile *blf);
-
   void config_roll_diagslog(RollingEnabledValues re, int ri, int rs);
   void config_roll_outputlog(RollingEnabledValues re, int ri, int rs);
   bool should_roll_diagslog();

--- a/lib/ts/Diags.h
+++ b/lib/ts/Diags.h
@@ -110,7 +110,8 @@ struct DiagsConfigState {
 class Diags
 {
 public:
-  Diags(const char *prefix_string, const char *base_debug_tags, const char *base_action_tags, BaseLogFile *_diags_log, int diags_log_perm = -1, int output_log_perm = -1);
+  Diags(const char *prefix_string, const char *base_debug_tags, const char *base_action_tags, BaseLogFile *_diags_log,
+        int diags_log_perm = -1, int output_log_perm = -1);
   ~Diags();
 
   BaseLogFile *diags_log;
@@ -227,7 +228,7 @@ private:
   DFA *activated_tags[2];           // 1 table for debug, 1 for action
 
   // These are the default logfile permissions
-  int diags_logfile_perm = -1;
+  int diags_logfile_perm  = -1;
   int output_logfile_perm = -1;
 
   // log rotation variables

--- a/lib/ts/ink_cap.h
+++ b/lib/ts/ink_cap.h
@@ -51,6 +51,9 @@ extern int elevating_open(const char *path, unsigned int flags);
 /// Open a file, elevating privilege only if needed.
 extern FILE *elevating_fopen(const char *path, const char *mode);
 
+// chmod a file, elevating if necessary
+extern int elevating_chmod(const char *path, int perm);
+
 /** Control generate of core file on crash.
     @a flag sets whether core files are enabled on crash.
     @return true on success
@@ -74,7 +77,9 @@ public:
   typedef enum {
     FILE_PRIVILEGE     = 0x1u, ///< Access filesystem objects with privilege
     TRACE_PRIVILEGE    = 0x2u, ///< Trace other processes with privilege
-    LOW_PORT_PRIVILEGE = 0x4u  ///< Bind to privilege ports.
+    LOW_PORT_PRIVILEGE = 0x4u, ///< Bind to privilege ports.
+    OWNER_PRIVILEGE    = 0x8u  ///< Bypass permission checks on operations that normally require
+                               ///  filesystem UID & process UID to match
   } privilege_level;
 
   ElevateAccess(unsigned level = FILE_PRIVILEGE);

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -98,6 +98,8 @@ static const RecordElement RecordsConfig[] =
   {RECT_CONFIG, "proxy.config.output.logfile", RECD_STRING, "traffic.out", RECU_RESTART_TC, RR_REQUIRED, RECC_NULL, nullptr,
    RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.output.logfile_perm", RECD_STRING, "rw-r--r--", RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
   // traffic.out rotation, default is 0 (aka rolling turned off) to preserve compatibility
   {RECT_CONFIG, "proxy.config.output.logfile.rolling_enabled", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-2]", RECA_NULL}
   ,
@@ -223,6 +225,8 @@ static const RecordElement RecordsConfig[] =
   {RECT_CONFIG, "proxy.config.diags.output.alert", RECD_STRING, "L", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.diags.output.emergency", RECD_STRING, "L", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
+  {RECT_CONFIG, "proxy.config.diags.logfile_perm", RECD_STRING, "rw-r--r--", RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
   // diags.log rotation, default is 0 (aka rolling turned off) to preserve compatibility
   {RECT_CONFIG, "proxy.config.diags.logfile.rolling_enabled", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-2]", RECA_NULL}

--- a/proxy/shared/DiagsConfig.cc
+++ b/proxy/shared/DiagsConfig.cc
@@ -306,9 +306,9 @@ DiagsConfig::DiagsConfig(const char *prefix_string, const char *filename, const 
   int diags_log_roll_enable  = (int)REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_enabled");
 
   // Grab some perms for the actual files on disk
-  char *diags_perm = REC_ConfigReadString("proxy.config.diags.logfile_perm");
-  char *output_perm = REC_ConfigReadString("proxy.config.output.logfile_perm");
-  int diags_perm_parsed = diags_perm ? ink_fileperm_parse(diags_perm) : -1;
+  char *diags_perm       = REC_ConfigReadString("proxy.config.diags.logfile_perm");
+  char *output_perm      = REC_ConfigReadString("proxy.config.output.logfile_perm");
+  int diags_perm_parsed  = diags_perm ? ink_fileperm_parse(diags_perm) : -1;
   int output_perm_parsed = diags_perm ? ink_fileperm_parse(output_perm) : -1;
 
   ats_free(diags_perm);

--- a/proxy/shared/DiagsConfig.cc
+++ b/proxy/shared/DiagsConfig.cc
@@ -306,23 +306,19 @@ DiagsConfig::DiagsConfig(const char *prefix_string, const char *filename, const 
   int diags_log_roll_enable  = (int)REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_enabled");
 
   // Grab some perms for the actual files on disk
-  char *diags_perms = REC_ConfigReadString("proxy.config.diags.logfile_perms");
-  char *output_perms = REC_ConfigReadString("proxy.config.output.logfile_perms");
-  int diags_perms_parsed = ink_fileperm_parse(diags_perms);
-  int output_perms_parsed = ink_fileperm_parse(output_perms);
-  ats_free(diags_perms);
-  ats_free(output_perms);
+  char *diags_perm = REC_ConfigReadString("proxy.config.diags.logfile_perm");
+  char *output_perm = REC_ConfigReadString("proxy.config.output.logfile_perm");
+  int diags_perm_parsed = diags_perm ? ink_fileperm_parse(diags_perm) : -1;
+  int output_perm_parsed = diags_perm ? ink_fileperm_parse(output_perm) : -1;
+
+  ats_free(diags_perm);
+  ats_free(output_perm);
 
   // Set up diags, FILE streams are opened in Diags constructor
   diags_log = new BaseLogFile(diags_logpath);
-  diags     = new Diags(prefix_string, tags, actions, diags_log);
+  diags     = new Diags(prefix_string, tags, actions, diags_log, diags_perm_parsed, output_perm_parsed);
   diags->config_roll_diagslog((RollingEnabledValues)diags_log_roll_enable, diags_log_roll_int, diags_log_roll_size);
   diags->config_roll_outputlog((RollingEnabledValues)output_log_roll_enable, output_log_roll_int, output_log_roll_size);
-  if (diags_perms_parsed != -1)
-    diags->set_diags_log_perms(diags_perms_parsed);
-  if (output_perms_parsed != -1)
-    diags->set_output_log_perms(output_perms_parsed);
-
 
   Status("opened %s", diags_logpath);
 

--- a/proxy/shared/DiagsConfig.cc
+++ b/proxy/shared/DiagsConfig.cc
@@ -305,11 +305,24 @@ DiagsConfig::DiagsConfig(const char *prefix_string, const char *filename, const 
   int diags_log_roll_size    = (int)REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_size_mb");
   int diags_log_roll_enable  = (int)REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_enabled");
 
+  // Grab some perms for the actual files on disk
+  char *diags_perms = REC_ConfigReadString("proxy.config.diags.logfile_perms");
+  char *output_perms = REC_ConfigReadString("proxy.config.output.logfile_perms");
+  int diags_perms_parsed = ink_fileperm_parse(diags_perms);
+  int output_perms_parsed = ink_fileperm_parse(output_perms);
+  ats_free(diags_perms);
+  ats_free(output_perms);
+
   // Set up diags, FILE streams are opened in Diags constructor
   diags_log = new BaseLogFile(diags_logpath);
   diags     = new Diags(prefix_string, tags, actions, diags_log);
   diags->config_roll_diagslog((RollingEnabledValues)diags_log_roll_enable, diags_log_roll_int, diags_log_roll_size);
   diags->config_roll_outputlog((RollingEnabledValues)output_log_roll_enable, output_log_roll_int, output_log_roll_size);
+  if (diags_perms_parsed != -1)
+    diags->set_diags_log_perms(diags_perms_parsed);
+  if (output_perms_parsed != -1)
+    diags->set_output_log_perms(output_perms_parsed);
+
 
   Status("opened %s", diags_logpath);
 


### PR DESCRIPTION
We add 2 more config variables to control file permissions for
diagnostics logs. These are not reloadable.