### PR TITLE
TS-5060: Fix DNAME support for OSX and FreeBSD.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1491,6 +1491,7 @@ AC_CHECK_HEADERS([sys/types.h \
                   sys/sockio.h \
                   sys/prctl.h \
                   arpa/nameser.h \
+                  arpa/nameser_compat.h \
                   execinfo.h \
                   netdb.h \
                   ctype.h \
@@ -1535,6 +1536,7 @@ AC_SUBST(sys_sysinfoh)
 AC_SUBST(sys_systeminfoh)
 AC_SUBST(arpa_ineth)
 AC_SUBST(arpa_nameserh)
+AC_SUBST(arpa_nameser_compath)
 AC_SUBST(execinfoh)
 AC_SUBST(netdbh)
 AC_SUBST(ctypeh)

--- a/iocore/dns/I_DNSProcessor.h
+++ b/iocore/dns/I_DNSProcessor.h
@@ -156,25 +156,25 @@ extern DNSProcessor dnsProcessor;
 inline Action *
 DNSProcessor::getSRVbyname(Continuation *cont, const char *name, Options const &opt)
 {
-  return getby(name, 0, ns_t_srv, cont, opt);
+  return getby(name, 0, T_SRV, cont, opt);
 }
 
 inline Action *
 DNSProcessor::gethostbyname(Continuation *cont, const char *name, Options const &opt)
 {
-  return getby(name, 0, ns_t_a, cont, opt);
+  return getby(name, 0, T_A, cont, opt);
 }
 
 inline Action *
 DNSProcessor::gethostbyname(Continuation *cont, const char *name, int len, Options const &opt)
 {
-  return getby(name, len, ns_t_a, cont, opt);
+  return getby(name, len, T_A, cont, opt);
 }
 
 inline Action *
 DNSProcessor::gethostbyaddr(Continuation *cont, IpAddr const *addr, Options const &opt)
 {
-  return getby(reinterpret_cast<const char *>(addr), 0, ns_t_ptr, cont, opt);
+  return getby(reinterpret_cast<const char *>(addr), 0, T_PTR, cont, opt);
 }
 
 inline DNSProcessor::Options::Options() : handler(0), timeout(0), host_res_style(HOST_RES_IPV4)

--- a/lib/ts/ink_platform.h
+++ b/lib/ts/ink_platform.h
@@ -93,6 +93,9 @@
 #ifdef HAVE_ARPA_NAMESER_H
 #include <arpa/nameser.h>
 #endif
+#ifdef HAVE_ARPA_NAMESER_COMPAT_H
+#include <arpa/nameser_compat.h>
+#endif
 
 #include <signal.h>
 #ifdef HAVE_SIGINFO_H

--- a/lib/ts/ink_res_init.cc
+++ b/lib/ts/ink_res_init.cc
@@ -74,6 +74,9 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <arpa/nameser.h>
+#ifdef HAVE_ARPA_NAMESER_COMPAT_H
+#include <arpa/nameser_compat.h>
+#endif
 #include <stdio.h>
 #include <ctype.h>
 #include <resolv.h>

--- a/lib/ts/ink_res_mkquery.cc
+++ b/lib/ts/ink_res_mkquery.cc
@@ -71,6 +71,9 @@
 #include <sys/param.h>
 #include <netinet/in.h>
 #include <arpa/nameser.h>
+#ifdef HAVE_ARPA_NAMESER_COMPAT_H
+#include <arpa/nameser_compat.h>
+#endif
 #include <netdb.h>
 #include <resolv.h>
 #include <stdio.h>
@@ -141,7 +144,7 @@ int ink_res_mkquery(ink_res_state statp, int op,               /*!< opcode of qu
     if (n < 0)
       return (-1);
     cp += n;
-    NS_PUT16(ns_t_null, cp);
+    NS_PUT16(T_NULL, cp);
     NS_PUT16(_class, cp);
     NS_PUT32(0, cp);
     NS_PUT16(0, cp);

--- a/lib/ts/ink_resolver.h
+++ b/lib/ts/ink_resolver.h
@@ -85,6 +85,9 @@
 #define NS_PUT32 PUTLONG
 #endif
 
+#ifndef T_DNAME
+#define T_DNAME ns_t_dname
+#endif
 #define INK_RES_F_VC 0x00000001       /*%< socket is TCP */
 #define INK_RES_F_CONN 0x00000002     /*%< socket is connected */
 #define INK_RES_F_EDNS0ERR 0x00000004 /*%< EDNS0 caused errors */


### PR DESCRIPTION
This PR fixes the build errors found for OSX caused by removing nameser_compat.h in the PR that adds DNAME support.  nameser_compat.h is being added back in and T_DNAME is defined in lib/ts/ink_resolver.h for OSX and FreeBSD.