### PR TITLE
TS-2109: Allows CC: no-cache objects to be stored in cache

### DIFF
--- a/proxy/http/HttpTransactHeaders.cc
+++ b/proxy/http/HttpTransactHeaders.cc
@@ -431,7 +431,7 @@ HttpTransactHeaders::calculate_document_age(ink_time_t request_time, ink_time_t 
 bool
 HttpTransactHeaders::does_server_allow_response_to_be_stored(HTTPHdr *resp)
 {
-  uint32_t cc_mask = (MIME_COOKED_MASK_CC_NO_CACHE | MIME_COOKED_MASK_CC_NO_STORE | MIME_COOKED_MASK_CC_PRIVATE);
+  uint32_t cc_mask = (MIME_COOKED_MASK_CC_NO_STORE | MIME_COOKED_MASK_CC_PRIVATE);
 
   if ((resp->get_cooked_cc_mask() & cc_mask) || (resp->get_cooked_pragma_no_cache())) {
     return false;


### PR DESCRIPTION
However, we still honor the no-cache header, such that we perform an IMS
request against the origin to validate the request before serving.