### PR TITLE
TS-5053 const char **argv passed to TSPluginInit is not null terminated

### DIFF
--- a/proxy/Plugin.cc
+++ b/proxy/Plugin.cc
@@ -293,6 +293,7 @@ plugin_init(bool validateOnly)
         argv[i] = vars[i];
       }
     }
+    argv[argc] = nullptr;
 
     retVal = plugin_load(argc, argv, validateOnly);
 


### PR DESCRIPTION
Typically **argv is null terminated in other systems. There's no
good reason for ATS to be any different.