### PR TITLE
TS-5092: ATS handling of too many concurrent streams too agressive

### DIFF
--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -243,14 +243,17 @@ struct Http2FrameHeader {
 
 // [RFC 7540] 5.4. Error Handling
 struct Http2Error {
-  Http2Error(const Http2ErrorClass error_class = HTTP2_ERROR_CLASS_NONE, const Http2ErrorCode error_code = HTTP2_ERROR_NO_ERROR)
+  Http2Error(const Http2ErrorClass error_class = HTTP2_ERROR_CLASS_NONE, const Http2ErrorCode error_code = HTTP2_ERROR_NO_ERROR,
+             const char *err_msg = NULL)
   {
     cls  = error_class;
     code = error_code;
+    msg  = err_msg;
   };
 
   Http2ErrorClass cls;
   Http2ErrorCode code;
+  const char *msg;
 };
 
 // [RFC 7540] 6.5.1. SETTINGS Format

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -171,7 +171,7 @@ public:
   int state_closed(int, void *);
 
   // Stream control interfaces
-  Http2Stream *create_stream(Http2StreamId new_id);
+  Http2Stream *create_stream(Http2StreamId new_id, Http2Error &error);
   Http2Stream *find_stream(Http2StreamId id) const;
   void restart_streams();
   bool delete_stream(Http2Stream *stream);


### PR DESCRIPTION
This issue was identified while debugging new errors seen by an internal team after they enabled HTTP/2 in their client. On the backend, they saw an increase in the cases were ATS sends the origin the POST header but no POST body and then closes the connection.
With the addition of Error() messages we were able to see a case where the client is trying to open the 101'st stream on a session. This is beyond the 100 max concurrent stream limit, so ATS shuts down the session which kills the previous 100 streams.
A closer reading of section 5.1.2 of the spec (https://tools.ietf.org/html/rfc7540#section-5.1.2) indicates that this should be a stream error and not a connection error. Bryan Call, Masaori, and Maskit confirmed this interpretation. Maskit also noted that the other error case in the current createStream method must be treated as a connection error.
Presumably the client library is expecting the refused stream case so it can try again later.

The main change is in create_stream().  Added error messages through the H2Error() object to enable this debugging and future tracking down of error conditions.