### PR TITLE
TS-5091: Crash if server session from global pool is not alive

### DIFF
--- a/proxy/http/HttpSessionManager.cc
+++ b/proxy/http/HttpSessionManager.cc
@@ -328,7 +328,6 @@ HttpSessionManager::acquire_session(Continuation * /* cont ATS_UNUSED */, sockad
             // The VC moved, free up the original one
             if (new_vc != server_vc) {
               ink_assert(new_vc == nullptr || new_vc->nh != nullptr);
-              to_return->set_netvc(new_vc);
               if (!new_vc) {
                 // Close out to_return, we were't able to get a connection
                 to_return->do_io_close();
@@ -337,6 +336,7 @@ HttpSessionManager::acquire_session(Continuation * /* cont ATS_UNUSED */, sockad
               } else {
                 // Keep things from timing out on us
                 new_vc->set_inactivity_timeout(new_vc->get_inactivity_timeout());
+                to_return->set_netvc(new_vc);
               }
             } else {
               // Keep things from timing out on us


### PR DESCRIPTION
The Jira contains a stack track we have seen in production. The problem is the migration fails, but we set the netvc to null before calling do_io_close. This causes the get_server_ip() call in HttpServerSession::do_io_close to dereference a NULL.  Only setting the netvc in the non-null case solves the problem.  In the null case we are shutting down anyway.  The old netvc is marked for close, but won't be closed until the stack unwinds.