### PR TITLE
TS-3692: Remove code associated with proxy.config.url_remap.url_remap_mode.

### DIFF
--- a/proxy/ReverseProxy.cc
+++ b/proxy/ReverseProxy.cc
@@ -59,8 +59,6 @@ remap_plugin_info *remap_pi_list; // We never reload the remap plugins, just app
 #define URL_REMAP_MODE_CHANGED 8
 #define HTTP_DEFAULT_REDIRECT_CHANGED 9
 
-int url_remap_mode;
-
 //
 // Begin API Functions
 //
@@ -82,18 +80,6 @@ init_reverse_proxy()
   REC_RegisterConfigUpdateFunc("proxy.config.admin.synthetic_port", url_rewrite_CB, (void *)SYNTH_PORT_CHANGED);
   REC_RegisterConfigUpdateFunc("proxy.config.http.referer_default_redirect", url_rewrite_CB, (void *)HTTP_DEFAULT_REDIRECT_CHANGED);
   return 0;
-}
-
-// TODO: This function needs to be rewritten (or replaced) with something that uses the new
-// Remap Processor properly. Right now, we effectively don't support "remap" rules on a few
-// odd ball configs, for example if you use the "CONNECT" method, or if you set
-// set proxy.config.url_remap.url_remap_mode to "2" (which is a completely undocumented "feature").
-bool
-request_url_remap(HttpTransact::State * /* s ATS_UNUSED */, HTTPHdr * /* request_header ATS_UNUSED */,
-                  char ** /* redirect_url ATS_UNUSED */, unsigned int /* filter_mask ATS_UNUSED */)
-{
-  return false;
-  // return rewrite_table ? rewrite_table->Remap(s, request_header, redirect_url, orig_url, tag, filter_mask) : false;
 }
 
 /**

--- a/proxy/ReverseProxy.h
+++ b/proxy/ReverseProxy.h
@@ -47,19 +47,11 @@
 class url_mapping;
 struct host_hdr_info;
 
-// Variables for the CDN URL Remapping Feature
-extern int url_remap_mode;
-
 extern UrlRewrite *rewrite_table;
 extern remap_plugin_info *remap_pi_list;
 
 // API Functions
 int init_reverse_proxy();
-
-// Both Return true if a remapping was made and false otherwise
-// ebalsa@ Y! -- this happens in the remapProcessor now for the reverse proxy case (not CDN or BlindTunnel)
-bool request_url_remap(HttpTransact::State *s, HTTPHdr *request_header, char **redirect_url,
-                       unsigned int filter_mask = URL_REMAP_FILTER_NONE);
 
 mapping_type request_url_remap_redirect(HTTPHdr *request_header, URL *redirect_url);
 bool response_url_remap(HTTPHdr *response_header);

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -7249,12 +7249,6 @@ HttpSM::set_next_state()
       t_state.dns_info.lookup_success = true;
       call_transact_and_set_next_state(NULL);
       break;
-    } else if (url_remap_mode == HttpTransact::URL_REMAP_FOR_OS && t_state.first_dns_lookup) {
-      DebugSM("cdn", "Skipping DNS Lookup");
-      // skip the DNS lookup
-      t_state.first_dns_lookup = false;
-      call_transact_and_set_next_state(HttpTransact::HandleFiltering);
-      break;
     } else if (t_state.http_config_param->use_client_target_addr == 2 && !t_state.url_remap_success &&
                t_state.parent_result.result != PARENT_SPECIFIED && t_state.client_info.is_transparent &&
                t_state.dns_info.os_addr_style == HttpTransact::DNSLookupInfo::OS_ADDR_TRY_DEFAULT &&

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -262,12 +262,6 @@ const int32_t HTTP_UNDEFINED_CL = -1;
 class HttpTransact
 {
 public:
-  enum UrlRemapMode_t {
-    URL_REMAP_DEFAULT = 0, // which is the same as URL_REMAP_ALL
-    URL_REMAP_ALL,
-    URL_REMAP_FOR_OS
-  };
-
   enum AbortState_t {
     ABORT_UNDEFINED = 0,
     DIDNOT_ABORT,


### PR DESCRIPTION
@zwoop and @jpeach could you please review this.  I believe this removes the all the unused code associated with proxy.config.url_remap.url_remap_mode.

testing + regression tests ok.