### PR TITLE
TS-5087: Updates the AL2 license on all .po files

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/admin-guide/files/icp.config.en.po
+++ b/doc/locale/ja/LC_MESSAGES/admin-guide/files/icp.config.en.po
@@ -1,8 +1,18 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2015, dev@trafficserver.apache.org
-# This file is distributed under the same license as the Apache Traffic
-# Server package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 #, fuzzy
 msgid ""

--- a/doc/locale/ja/LC_MESSAGES/admin-guide/files/logs_xml.config.en.po
+++ b/doc/locale/ja/LC_MESSAGES/admin-guide/files/logs_xml.config.en.po
@@ -1,8 +1,18 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2015, dev@trafficserver.apache.org
-# This file is distributed under the same license as the Apache Traffic
-# Server package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 #, fuzzy
 msgid ""

--- a/doc/locale/ja/LC_MESSAGES/admin-guide/plugins/cacheurl.en.po
+++ b/doc/locale/ja/LC_MESSAGES/admin-guide/plugins/cacheurl.en.po
@@ -1,8 +1,18 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2015, dev@trafficserver.apache.org
-# This file is distributed under the same license as the Apache Traffic
-# Server package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 #, fuzzy
 msgid ""

--- a/doc/locale/ja/LC_MESSAGES/developer-guide/api/functions/TSHttpIsInternalRequest.en.po
+++ b/doc/locale/ja/LC_MESSAGES/developer-guide/api/functions/TSHttpIsInternalRequest.en.po
@@ -1,8 +1,18 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2015, dev@trafficserver.apache.org
-# This file is distributed under the same license as the Apache Traffic
-# Server package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 #, fuzzy
 msgid ""


### PR DESCRIPTION
Fixes for 6.2.x branch that were not upstream.