### PR TITLE
TS-5059: SSL_set_rbio() renamed SSL_set0_rbio()

### DIFF
--- a/build/crypto.m4
+++ b/build/crypto.m4
@@ -168,7 +168,7 @@ AC_DEFUN([TS_CHECK_CRYPTO_SET_RBIO], [
   enable_set_rbio=yes
 
   TS_ADDTO(LIBS, [$OPENSSL_LIBS])
-  AC_MSG_CHECKING([for SSL_set_rbio])
+  AC_MSG_CHECKING([for SSL_set0_rbio])
   AC_LINK_IFELSE(
   [
     AC_LANG_PROGRAM([[
@@ -179,7 +179,7 @@ AC_DEFUN([TS_CHECK_CRYPTO_SET_RBIO], [
 #include <openssl/tls1.h>
 #endif
       ]],
-      [[SSL_set_rbio(NULL, NULL);]])
+      [[SSL_set0_rbio(NULL, NULL);]])
   ],
   [
     AC_MSG_RESULT([yes])

--- a/configure.ac
+++ b/configure.ac
@@ -1122,7 +1122,7 @@ TS_CHECK_CRYPTO_SNI
 TS_CHECK_CRYPTO_CERT_CB
 
 #
-# Check for SSL_set_rbio call
+# Check for SSL_set0_rbio call
 TS_CHECK_CRYPTO_SET_RBIO
 
 # Check for DH_get_2048_256

--- a/iocore/net/SSLInternal.cc
+++ b/iocore/net/SSLInternal.cc
@@ -23,7 +23,7 @@
  */
 #include "ts/ink_config.h"
 #if TS_USE_SET_RBIO
-// No need to do anything, this version of openssl provides the SSL_set_rbio function
+// No need to do anything, this version of openssl provides the SSL_set0_rbio function
 #else
 
 #ifdef OPENSSL_NO_SSL_INTERN
@@ -35,7 +35,7 @@
 #include "P_SSLNetVConnection.h"
 
 void
-SSL_set_rbio(SSL *ssl, BIO *rbio)
+SSL_set0_rbio(SSL *ssl, BIO *rbio)
 {
   if (ssl->rbio != nullptr) {
     BIO_free(ssl->rbio);

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -37,7 +37,7 @@
 #if !TS_USE_SET_RBIO
 // Defined in SSLInternal.c, should probably make a separate include
 // file for this at some point
-void SSL_set_rbio(SSL *ssl, BIO *rbio);
+void SSL_set0_rbio(SSL *ssl, BIO *rbio);
 #endif
 
 // This is missing from BoringSSL
@@ -391,7 +391,7 @@ SSLNetVConnection::read_raw_data()
   // Must be reset on each read
   BIO *rbio = BIO_new_mem_buf(start, this->handShakeBioStored);
   BIO_set_mem_eof_return(rbio, -1);
-  SSL_set_rbio(this->ssl, rbio);
+  SSL_set0_rbio(this->ssl, rbio);
 
   return r;
 }
@@ -565,7 +565,7 @@ SSLNetVConnection::net_read_io(NetHandler *nh, EThread *lthread)
         // Must be reset on each read
         BIO *rbio = BIO_new_mem_buf(start, this->handShakeBioStored);
         BIO_set_mem_eof_return(rbio, -1);
-        SSL_set_rbio(this->ssl, rbio);
+        SSL_set0_rbio(this->ssl, rbio);
       }
     }
   }


### PR DESCRIPTION
It was renamed before OpenSSL 1.1.0 was released [1][2].

[1] https://github.com/openssl/openssl/commit/65e2d672548e7c4bcb28f1c5c835362830b1745b
[2] https://rt.openssl.org/Ticket/Display.html?id=4572