### PR TITLE
TS-5059: OpenSSL 1.1 EVP_MD_CTX and HMAC_CTX

### DIFF
--- a/example/cppapi/websocket/WSBuffer.cc
+++ b/example/cppapi/websocket/WSBuffer.cc
@@ -157,29 +157,54 @@ WSBuffer::read_buffered_message(std::string &message, int &code)
 std::string
 WSBuffer::ws_digest(std::string const &key)
 {
-  EVP_MD_CTX digest;
-  EVP_MD_CTX_init(&digest);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+  EVP_MD_CTX digest[1];
+  EVP_MD_CTX_init(digest);
+#else
+  EVP_MD_CTX *digest;
+  digest = EVP_MD_CTX_new();
+#endif
 
-  if (!EVP_DigestInit_ex(&digest, EVP_sha1(), nullptr)) {
-    EVP_MD_CTX_cleanup(&digest);
+  if (!EVP_DigestInit_ex(digest, EVP_sha1(), nullptr)) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    EVP_MD_CTX_cleanup(digest);
+#else
+    EVP_MD_CTX_free(digest);
+#endif
     return "init-failed";
   }
-  if (!EVP_DigestUpdate(&digest, key.data(), key.length())) {
-    EVP_MD_CTX_cleanup(&digest);
+  if (!EVP_DigestUpdate(digest, key.data(), key.length())) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    EVP_MD_CTX_cleanup(digest);
+#else
+    EVP_MD_CTX_free(digest);
+#endif
     return "update1-failed";
   }
-  if (!EVP_DigestUpdate(&digest, magic.data(), magic.length())) {
-    EVP_MD_CTX_cleanup(&digest);
+  if (!EVP_DigestUpdate(digest, magic.data(), magic.length())) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    EVP_MD_CTX_cleanup(digest);
+#else
+    EVP_MD_CTX_free(digest);
+#endif
     return "update2-failed";
   }
 
   unsigned char hash_buf[EVP_MAX_MD_SIZE];
   unsigned int hash_len = 0;
-  if (!EVP_DigestFinal_ex(&digest, hash_buf, &hash_len)) {
-    EVP_MD_CTX_cleanup(&digest);
+  if (!EVP_DigestFinal_ex(digest, hash_buf, &hash_len)) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    EVP_MD_CTX_cleanup(digest);
+#else
+    EVP_MD_CTX_free(digest);
+#endif
     return "final-failed";
   }
-  EVP_MD_CTX_cleanup(&digest);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+  EVP_MD_CTX_cleanup(digest);
+#else
+  EVP_MD_CTX_free(digest);
+#endif
   if (hash_len != 20) {
     return "bad-hash-length";
   }

--- a/lib/ts/HashMD5.cc
+++ b/lib/ts/HashMD5.cc
@@ -67,7 +67,10 @@ ATSHashMD5::size(void) const
 void
 ATSHashMD5::clear(void)
 {
-  int ret = EVP_MD_CTX_cleanup(ctx);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#define EVP_MD_CTX_reset(ctx) EVP_MD_CTX_cleanup((ctx))
+#endif
+  int ret = EVP_MD_CTX_reset(ctx);
   ink_assert(ret == 1);
   ret = EVP_DigestInit_ex(ctx, EVP_md5(), nullptr);
   ink_assert(ret == 1);


### PR DESCRIPTION
EVP_MD_CTX and HMAC_CTX were made opaque in OpenSSL 1.1 [1],
so allocating them on the stack is no longer supported.

Also EVP_MD_CTX_cleanup() was removed. EVP_MD_CTX_reset() should be
called instead, to reinitialise an already created structure.

[1] https://www.openssl.org/news/changelog#x4