### PR TITLE
TS-5108-SSL requests might stall because enabled write is ignored

### DIFF
--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -1246,15 +1246,18 @@ SSLNetVConnection::sslClientHandShakeEvent(int &err)
       X509 *cert = SSL_get_peer_certificate(ssl);
 
       Debug("ssl", "SSL client handshake completed successfully");
-      // if the handshake is complete and write is enabled reschedule the write
-      if (closed == 0 && write.enabled)
-        writeReschedule(nh);
+
       if (cert) {
         debug_certificate_name("server certificate subject CN is", X509_get_subject_name(cert));
         debug_certificate_name("server certificate issuer CN is", X509_get_issuer_name(cert));
         X509_free(cert);
       }
     }
+
+    // if the handshake is complete and write is enabled reschedule the write
+    if (closed == 0 && write.enabled)
+      writeReschedule(nh);
+
     SSL_INCREMENT_DYN_STAT(ssl_total_success_handshake_count_out_stat);
 
     TraceIn(trace, get_remote_addr(), get_remote_port(), "SSL client handshake completed successfully");


### PR DESCRIPTION
In non-debug mode an enabled write is ignored resulting in a stalled request. In debug mode the writeReschedule is fired.

A fix is to move the conditional writeReschedule out of the conditional debug code.
Addendum to:
https://issues.apache.org/jira/browse/TS-2815
https://github.com/apache/trafficserver/commit/f3a3edb048fc5f96163d1c4a26c1523383786f5d
For more context:
https://github.com/apache/trafficserver/blob/6.2.0/iocore/net/SSLNetVConnection.cc#L1279