### PR TITLE
TS-5107: Changes to autolinking in Docutils 1.3

### DIFF
--- a/doc/admin-guide/configuration/cache-basics.en.rst
+++ b/doc/admin-guide/configuration/cache-basics.en.rst
@@ -683,7 +683,7 @@ cases the content will be buffered in ram while waiting to be sent to the
 client. This could potentially also happen for ``POST`` requests if the client
 connection is fast and the origin server connection slow. If very large objects
 are being used this can cause the memory usage of Traffic Server to become
-very large (See issue :ts:jira:`1496`).
+`very large :ts:jira:`1496``_.
 
 This problem can be ameliorated by controlling the amount of buffer space used
 by a transaction. A high water and low water mark are set in terms of bytes

--- a/doc/admin-guide/configuration/cache-basics.en.rst
+++ b/doc/admin-guide/configuration/cache-basics.en.rst
@@ -683,7 +683,7 @@ cases the content will be buffered in ram while waiting to be sent to the
 client. This could potentially also happen for ``POST`` requests if the client
 connection is fast and the origin server connection slow. If very large objects
 are being used this can cause the memory usage of Traffic Server to become
-`very large :ts:jira:`1496``_.
+`very large <https://issues.apache.org/jira/browse/TS-1496>`_.
 
 This problem can be ameliorated by controlling the amount of buffer space used
 by a transaction. A high water and low water mark are set in terms of bytes

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -1091,7 +1091,7 @@ ip-resolve
          performed. The result is cached (if allowed otherwise). This option is
          vulnerable to cache poisoning if an incorrect ``Host`` header is
          specified, so this option should be used with extreme caution.  See
-         bug :ts:jira:`2954` for details.
+         bug TS-2954 for details.
    ===== ======================================================================
 
    If all of these conditions are met, then the origin server IP address is

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -165,25 +165,54 @@ pygments_style = 'sphinx'
 
 nitpicky=1
 
-# Autolink issue references
+# Autolink issue references.
+# See Customizing the Parser in the docutils.parsers.rst module.
 
 from docutils import nodes
 from docutils.parsers.rst import states
+from docutils.utils import punctuation_chars
 from docutils.utils import unescape
 
 # Customize parser.inliner in the only way that Sphinx supports.
 # docutils.parsers.rst.Parser takes an instance of states.Inliner or a
-# subclass but Sphinx initializes it from
-# SphinxStandaloneReader.set_parser('restructuredtext') which is called
-# from Publisher.set_components() and initializes the parser without
-# arguments.
+# subclass, but Sphinx initializes the parser without any arguments,
+# in SphinxStandaloneReader.set_parser('restructuredtext'),
+# which is called from Publisher.set_components().
 
+# states.Inliner isn't a new-style class, so super() isn't an option.
 BaseInliner = states.Inliner
-class Inliner(BaseInliner):
-  def __init__(self):
-    BaseInliner.__init__(self)
+class Inliner(states.Inliner):
+  if hasattr(states.Inliner, 'init_customizations'):
+    def init_customizations(self, settings):
+      self.__class__ = BaseInliner
+      BaseInliner.init_customizations(self, settings)
+      self.__class__ = Inliner
 
-    issue_pattern = re.compile(u'''
+      # Copied from states.Inliner.init_customizations().
+      # In Docutils 0.13 these are locals.
+      if settings.character_level_inline_markup:
+        self.start_string_prefix = u'(^|(?<!\x00))'
+        self.end_string_suffix = u''
+      else:
+        self.start_string_prefix = (u'(^|(?<=\\s|[%s%s]))' %
+                                    (punctuation_chars.openers,
+                                     punctuation_chars.delimiters))
+        self.end_string_suffix = (u'($|(?=\\s|[\x00%s%s%s]))' %
+                                  (punctuation_chars.closing_delimiters,
+                                   punctuation_chars.delimiters,
+                                   punctuation_chars.closers))
+
+      self.init()
+  else:
+    def __init__(self):
+      BaseInliner.__init__(self)
+      self.init()
+
+  # Called from __init__() in Docutils < 0.13, otherwise from
+  # init_customizations(), which was added in Docutils 0.13.
+  def init(self):
+    issue = re.compile(
+      ur'''
       {start_string_prefix}
       TS-\d+
       {end_string_suffix}'''.format(
@@ -191,7 +220,7 @@ class Inliner(BaseInliner):
         end_string_suffix=self.end_string_suffix),
       re.VERBOSE | re.UNICODE)
 
-    self.implicit_dispatch.append((issue_pattern, self.issue_reference))
+    self.implicit_dispatch.append((issue, self.issue_reference))
 
   def issue_reference(self, match, lineno):
     text = match.group(0)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -166,9 +166,44 @@ pygments_style = 'sphinx'
 nitpicky=1
 
 # Autolink issue references
-# moved into traffic_server Sphinx extension
-trafficserver_jira_url='https://issues.apache.org/jira/browse/'
-trafficserver_github_url='https://github.com/apache/trafficserver/issues/'
+
+from docutils import nodes
+from docutils.parsers.rst import states
+from docutils.utils import unescape
+
+# Customize parser.inliner in the only way that Sphinx supports.
+# docutils.parsers.rst.Parser takes an instance of states.Inliner or a
+# subclass but Sphinx initializes it from
+# SphinxStandaloneReader.set_parser('restructuredtext') which is called
+# from Publisher.set_components() and initializes the parser without
+# arguments.
+
+BaseInliner = states.Inliner
+class Inliner(BaseInliner):
+  def __init__(self):
+    BaseInliner.__init__(self)
+
+    issue_pattern = re.compile(u'''
+      {start_string_prefix}
+      TS-\d+
+      {end_string_suffix}'''.format(
+        start_string_prefix=self.start_string_prefix,
+        end_string_suffix=self.end_string_suffix),
+      re.VERBOSE | re.UNICODE)
+
+    self.implicit_dispatch.append((issue_pattern, self.issue_reference))
+
+  def issue_reference(self, match, lineno):
+    text = match.group(0)
+
+    rawsource = unescape(text, True)
+    text = unescape(text, False)
+
+    refuri = 'https://issues.apache.org/jira/browse/' + text
+
+    return [nodes.reference(rawsource, text, refuri=refuri)]
+
+states.Inliner = Inliner
 
 # -- Options for HTML output ---------------------------------------------------
 
@@ -317,8 +352,6 @@ latex_documents = [
 # documents and includes the same brief description in both the HTML
 # and manual page outputs.
 
-from docutils import nodes
-from docutils.utils import unescape
 from docutils.transforms import frontmatter
 from sphinx.writers import manpage
 

--- a/doc/developer-guide/api/functions/TSHttpTxnClientPacketMarkSet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnClientPacketMarkSet.en.rst
@@ -41,4 +41,4 @@ See Also
 
 .. _Traffic Shaping:
                  https://cwiki.apache.org/confluence/display/TS/Traffic+Shaping
-   :ts:cv:`proxy.config.net.sock_packet_mark_in` and :ts:jira:`1090`
+   :ts:cv:`proxy.config.net.sock_packet_mark_in` and TS-1090

--- a/doc/developer-guide/api/functions/TSHttpTxnClientPacketTosSet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnClientPacketTosSet.en.rst
@@ -47,4 +47,4 @@ See Also
 
 .. _Traffic Shaping:
                  https://cwiki.apache.org/confluence/display/TS/Traffic+Shaping
-   :ts:cv:`proxy.config.net.sock_packet_tos_in` and :ts:jira:`1090`
+   :ts:cv:`proxy.config.net.sock_packet_tos_in` and TS-1090

--- a/doc/developer-guide/api/functions/TSHttpTxnServerPacketMarkSet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnServerPacketMarkSet.en.rst
@@ -45,4 +45,4 @@ See Also
 
 .. _Traffic Shaping:
                  https://cwiki.apache.org/confluence/display/TS/Traffic+Shaping
-   :ts:cv:`proxy.config.net.sock_packet_mark_out` and :ts:jira:`1090`
+   :ts:cv:`proxy.config.net.sock_packet_mark_out` and TS-1090

--- a/doc/developer-guide/api/functions/TSHttpTxnServerPacketTosSet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnServerPacketTosSet.en.rst
@@ -49,4 +49,4 @@ See Also
 
 .. _Traffic Shaping:
                  https://cwiki.apache.org/confluence/display/TS/Traffic+Shaping
-   :ts:cv:`proxy.config.net.sock_packet_tos_out` and :ts:jira:`1090`
+   :ts:cv:`proxy.config.net.sock_packet_tos_out` and TS-1090

--- a/doc/developer-guide/api/functions/TSLifecycleHookAdd.en.rst
+++ b/doc/developer-guide/api/functions/TSLifecycleHookAdd.en.rst
@@ -162,7 +162,7 @@ History
 =======
 
 Lifecycle hooks were introduced to solve process initialization ordering issues
-:ts:jira:`1487`. Different API calls required different modules of |TS| to be
+(TS-1487). Different API calls required different modules of |TS| to be
 initialized for the call to work, but others did not work that late in
 initialization, which was problematic because all of them could effectively
 only be called from :func:`TSPluginInit` . The solution was to move

--- a/doc/developer-guide/architecture/architecture.en.rst
+++ b/doc/developer-guide/architecture/architecture.en.rst
@@ -1147,12 +1147,12 @@ including the size of each stripe.
 
 .. [#store-disk-array]
 
-   `Work is under way :ts:jira:`2020``_ on
+   `Work is under way <https://issues.apache.org/jira/browse/TS-2020>`_ on
    extending this to include objects that are in the memory cache.
 
 .. [#coalesced-spans]
 
    This linked list is mostly ignored in later processing, causing all but one
    file or directory storage units on the same device to be ignored. See
-   :ts:jira:`1869`.
+   `TS-1869 <https://issues.apache.org/jira/browse/TS-1869>`_.
 

--- a/doc/developer-guide/architecture/architecture.en.rst
+++ b/doc/developer-guide/architecture/architecture.en.rst
@@ -1147,8 +1147,8 @@ including the size of each stripe.
 
 .. [#store-disk-array]
 
-   Work is under way on extending this to include objects that are in the
-   memory cache. (See issue :ts:jira:`2020`)
+   `Work is under way :ts:jira:`2020``_ on
+   extending this to include objects that are in the memory cache.
 
 .. [#coalesced-spans]
 

--- a/doc/developer-guide/architecture/consistency.en.rst
+++ b/doc/developer-guide/architecture/consistency.en.rst
@@ -59,7 +59,7 @@ Volume Tagging
 ~~~~~~~~~~~~~~
 
 Currently, :term:`cache volumes <cache volume>` are allocated somewhat
-arbitrarily from storage elements. `This enhancement :ts:jira:`1728``__
+arbitrarily from storage elements. `This enhancement <https://issues.apache.org/jira/browse/TS-1728>`__
 allows :file:`storage.config` to assign :term:`storage units <storage unit>` to
 specific :term:`volumes <cache volume>` although the volumes must still be
 listed in :file:`volume.config` in general and in particular to map domains to


### PR DESCRIPTION
Restore the autolinking code and update it for Docutils 1.3, which added the init_customizations() method. It works with Docutils 1.2 and 1.3 now.

@jbfavre already fixed this in #1296, thanks! I realize it would've been much better if I'd had this ready at the beginning of the week ...