### PR TITLE
Use Autoconf checks vs. OPENSSL_VERSION_NUMBER

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1128,6 +1128,37 @@ TS_CHECK_CRYPTO_SET_RBIO
 # Check for DH_get_2048_256
 TS_CHECK_CRYPTO_DH_GET_2048_256
 
+saved_LIBS = "$LIBS"
+TS_ADDTO([LIBS], ["$OPENSSL_LIBS"])
+
+AC_CHECK_FUNCS([ \
+  BIO_meth_new \
+  CRYPTO_set_mem_functions \
+  HMAC_CTX_new \
+])
+
+AC_CHECK_FUNC([BIO_set_data], [],
+              [AC_DEFINE([BIO_set_data(a, _ptr)], [((a)->ptr = (_ptr))], [Added in OpenSSL 1.1])])
+AC_CHECK_FUNC([BIO_get_data], [],
+              [AC_DEFINE([BIO_get_data(a)], [((a)->ptr)], [Added in OpenSSL 1.1])])
+AC_CHECK_FUNC([BIO_get_shutdown], [],
+              [AC_DEFINE([BIO_get_shutdown(a)], [((a)->shutdown)], [Added in OpenSSL 1.1])])
+AC_CHECK_FUNC([BIO_meth_get_ctrl], [],
+              [AC_DEFINE([BIO_meth_get_ctrl(biom)], [((biom)->ctrl)], [Added in OpenSSL 1.1])])
+AC_CHECK_FUNC([BIO_meth_get_create], [],
+              [AC_DEFINE([BIO_meth_get_create(biom)], [((biom)->create)], [Added in OpenSSL 1.1])])
+AC_CHECK_FUNC([BIO_meth_get_destroy], [],
+              [AC_DEFINE([BIO_meth_get_destroy(biom)], [((biom)->destroy)], [Added in OpenSSL 1.1])])
+
+AC_CHECK_FUNC([EVP_MD_CTX_new], [],
+              [AC_DEFINE([EVP_MD_CTX_new], [EVP_MD_CTX_create], [Renamed in OpenSSL 1.1])])
+AC_CHECK_FUNC([EVP_MD_CTX_reset], [],
+              [AC_DEFINE([EVP_MD_CTX_reset], [EVP_MD_CTX_cleanup], [Renamed in OpenSSL 1.1])])
+AC_CHECK_FUNC([EVP_MD_CTX_free], [],
+              [AC_DEFINE([EVP_MD_CTX_free], [EVP_MD_CTX_destroy], [Renamed in OpenSSL 1.1])])
+
+LIBS = "$saved_LIBS"
+
 #
 # Check for zlib presence and usability
 TS_CHECK_ZLIB

--- a/iocore/net/BIO_fastopen.cc
+++ b/iocore/net/BIO_fastopen.cc
@@ -27,15 +27,6 @@
 
 #include "BIO_fastopen.h"
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-#define BIO_set_data(a, _ptr) ((a)->ptr = (_ptr))
-#define BIO_get_data(a) ((a)->ptr)
-#define BIO_get_shutdown(a) ((a)->shutdown)
-#define BIO_meth_get_ctrl(biom) ((biom)->ctrl)
-#define BIO_meth_get_create(biom) ((biom)->create)
-#define BIO_meth_get_destroy(biom) ((biom)->destroy)
-#endif
-
 static int (*fastopen_create)(BIO *) = BIO_meth_get_create(const_cast<BIO_METHOD *>(BIO_s_socket()));
 
 static int
@@ -127,7 +118,7 @@ fastopen_ctrl(BIO *bio, int cmd, long larg, void *ptr)
   return BIO_meth_get_ctrl(const_cast<BIO_METHOD *>(BIO_s_socket()))(bio, cmd, larg, ptr);
 }
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#ifndef HAVE_BIO_METH_NEW
 static const BIO_METHOD fastopen_methods[] = {{
   .type          = BIO_TYPE_SOCKET,
   .name          = "fastopen",

--- a/lib/ts/HashMD5.cc
+++ b/lib/ts/HashMD5.cc
@@ -24,7 +24,7 @@
 
 ATSHashMD5::ATSHashMD5(void) : md_len(0), finalized(false)
 {
-  ctx     = EVP_MD_CTX_create();
+  ctx     = EVP_MD_CTX_new();
   int ret = EVP_DigestInit_ex(ctx, EVP_md5(), nullptr);
   ink_assert(ret == 1);
 }
@@ -67,9 +67,6 @@ ATSHashMD5::size(void) const
 void
 ATSHashMD5::clear(void)
 {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
-#define EVP_MD_CTX_reset(ctx) EVP_MD_CTX_cleanup((ctx))
-#endif
   int ret = EVP_MD_CTX_reset(ctx);
   ink_assert(ret == 1);
   ret = EVP_DigestInit_ex(ctx, EVP_md5(), nullptr);
@@ -80,5 +77,5 @@ ATSHashMD5::clear(void)
 
 ATSHashMD5::~ATSHashMD5()
 {
-  EVP_MD_CTX_destroy(ctx);
+  EVP_MD_CTX_free(ctx);
 }

--- a/plugins/s3_auth/s3_auth.cc
+++ b/plugins/s3_auth/s3_auth.cc
@@ -33,6 +33,7 @@
 
 #include <ts/ts.h>
 #include <ts/remap.h>
+#include <ts/ink_config.h>
 
 ///////////////////////////////////////////////////////////////////////////////
 // Some constants.
@@ -417,7 +418,7 @@ S3Request::authorize(S3Config *s3)
   }
 
 // Produce the SHA1 MAC digest
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#ifndef HAVE_HMAC_CTX_NEW
   HMAC_CTX ctx[1];
 #else
   HMAC_CTX *ctx;
@@ -427,7 +428,7 @@ S3Request::authorize(S3Config *s3)
   unsigned char hmac[SHA_DIGEST_LENGTH];
   char hmac_b64[SHA_DIGEST_LENGTH * 2];
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#ifndef HAVE_HMAC_CTX_NEW
   HMAC_CTX_init(ctx);
 #else
   ctx = HMAC_CTX_new();
@@ -454,7 +455,7 @@ S3Request::authorize(S3Config *s3)
   }
 
   HMAC_Final(ctx, hmac, &hmac_len);
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#ifndef HAVE_HMAC_CTX_NEW
   HMAC_CTX_cleanup(ctx);
 #else
   HMAC_CTX_free(ctx);


### PR DESCRIPTION
This will work better with the various OpenSSL forks.