### PR TITLE
Doc: Updates to prevent dangling references.

### DIFF
--- a/doc/developer-guide/api/functions/TSHttpOverridableConfig.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpOverridableConfig.en.rst
@@ -29,7 +29,6 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. type:: TSOverridableConfigKey
 
 .. function:: TSReturnCode TSHttpTxnConfigIntSet(TSHttpTxn txnp, TSOverridableConfigKey key, TSMgmtInt value)
 .. function:: TSReturnCode TSHttpTxnConfigIntGet(TSHttpTxn txnp, TSOverridableConfigKey key, TSMgmtInt* value)

--- a/doc/developer-guide/api/functions/TSTypes.en.rst
+++ b/doc/developer-guide/api/functions/TSTypes.en.rst
@@ -118,35 +118,15 @@ more widely. Those are described on this page.
 
 .. type:: TSMutex
 
-.. type:: TSParseResult
-
-   This set of enums are possible values returned by
-   :func:`TSHttpHdrParseReq` and :func:`TSHttpHdrParseResp`.
-
 .. type:: TSPluginRegistrationInfo
 
    The following struct is used by :func:`TSPluginRegister`.
 
    It stores registration information about the plugin.
 
-.. type:: TSRecordDataType
-
-   An enumeration that specifies the type of a value in an internal data structure that is accessible via the API.
-
 .. type:: TSRemapInterface
 
 .. type:: TSRemapRequestInfo
-
-.. type:: TSReturnCode
-
-   An indicator of the results of an API call. A value of :const:`TS_SUCCESS` means the call was successful. Any other value
-   indicates a failure and is specific to the API call.
-
-.. type:: TSSDKVersion
-
-   Starting 2.0, SDK now follows same versioning as Traffic Server.
-
-.. type:: TSServerState
 
 .. type:: TSTextLogObject
 
@@ -159,12 +139,6 @@ more widely. Those are described on this page.
 .. type:: TSThread
 
 .. type:: TSThreadFunc
-
-.. type:: TSThreadPool
-
-.. type:: TSUuid
-
-   Opaque type that refers to an allocated UUID.
 
 .. type:: TSUuidVersion
 

--- a/doc/developer-guide/api/types/CoreTypes.en.rst
+++ b/doc/developer-guide/api/types/CoreTypes.en.rst
@@ -33,23 +33,16 @@ Description
 
 These types are provided by the compiler ("built-in") or from a required operating system, POSIX, or package header.
 
-.. c:type:: off_t
 
-   `Reference <https://linux.die.net/include/unistd.h>`__.
-
-.. cpp:type:: off_t
-
-   `Reference <https://linux.die.net/include/unistd.h>`__.
    
-.. cpp:type:: uint64_t
-
-   `Reference <https://linux.die.net/include/stdint.h>`__.
+.. cpp:type:: uint24_t
    
-.. cpp:type:: uint32_t
 
-   `Reference <https://linux.die.net/include/stdint.h>`__.
    
-.. cpp:type:: uint8_t
+.. cpp:type:: Event
 
-   `Reference <https://linux.die.net/include/stdint.h>`__.
-   
+
+.. cpp:type:: DLL
+
+
+.. cpp:type:: INK_MD5


### PR DESCRIPTION
Set up ancillary file to hold system types to move toward a clean doc build.