### PR TITLE
get_creation_time() takes *time_t, not *long

### DIFF
--- a/lib/ts/BaseLogFile.cc
+++ b/lib/ts/BaseLogFile.cc
@@ -238,7 +238,7 @@ BaseLogFile::roll(long interval_start, long interval_end)
 int
 BaseLogFile::roll()
 {
-  long start;
+  time_t start;
   time_t now = time(nullptr);
 
   if (!m_meta_info || !m_meta_info->get_creation_time(&start))


### PR DESCRIPTION
time_t may or may not be equivalent to long,
it's up to the implementation.

Fixes #1311