### PR TITLE
TS-4716: OpenBSD mandir should be ${prefix}/man

### DIFF
--- a/config.layout
+++ b/config.layout
@@ -184,7 +184,7 @@
     bindir:        ${exec_prefix}/bin
     sbindir:       ${exec_prefix}/sbin
     libdir:        ${exec_prefix}/lib+
-    libexecdir:    ${exec_prefix}/lib/trafficserver/modules
+    libexecdir:    ${libdir}/modules
     infodir:       ${prefix}/share/info
     mandir:        ${prefix}/share/man
     sysconfdir:    /etc+

--- a/config.layout
+++ b/config.layout
@@ -228,7 +228,7 @@
     libdir:        ${exec_prefix}/lib
     libexecdir:    ${exec_prefix}/libexec+
     infodir:       ${prefix}/info
-    mandir:        ${prefix}/share/man
+    mandir:        ${prefix}/man
     sysconfdir:    /etc+
     datadir:       ${prefix}/share+
     docdir:        ${prefix}/share/doc+


### PR DESCRIPTION
Fixes #1353