### PR TITLE
If setrlimit() fails, log the details

### DIFF
--- a/lib/ts/ink_sys_control.cc
+++ b/lib/ts/ink_sys_control.cc
@@ -24,6 +24,7 @@
 #include "ts/ink_defs.h"
 #include "ts/ink_assert.h"
 #include "ts/ink_sys_control.h"
+#include "ts/Diags.h"
 
 rlim_t
 ink_max_out_rlimit(int which, bool max_it, bool unlim_it)
@@ -47,7 +48,10 @@ ink_max_out_rlimit(int which, bool max_it, bool unlim_it)
 #else
       rl.rlim_cur = rl.rlim_max;
 #endif
-      ink_release_assert(setrlimit(MAGIC_CAST(which), &rl) >= 0);
+      if (setrlimit(MAGIC_CAST(which), &rl) != 0) {
+        Warning("Failed to set resource limits: %s\nresource = %d, .rlim_cur = %lu, .rlim_max = %lu", strerror(errno), which,
+                rl.rlim_cur, rl.rlim_max);
+      }
     }
   }
 
@@ -56,7 +60,10 @@ ink_max_out_rlimit(int which, bool max_it, bool unlim_it)
     ink_release_assert(getrlimit(MAGIC_CAST(which), &rl) >= 0);
     if (rl.rlim_cur != (rlim_t)RLIM_INFINITY) {
       rl.rlim_cur = (rl.rlim_max = RLIM_INFINITY);
-      ink_release_assert(setrlimit(MAGIC_CAST(which), &rl) >= 0);
+      if (setrlimit(MAGIC_CAST(which), &rl) != 0) {
+        Warning("Failed to set resource limits: %s\nresource = %d, .rlim_cur = %lu, .rlim_max = %lu", strerror(errno), which,
+                rl.rlim_cur, rl.rlim_max);
+      }
     }
   }
 #endif


### PR DESCRIPTION
I guess this is the same error as TS-882 [1] and TS-3074 [2]. The relevant commits are 8d7bb47419b25e50a5c50b53e54ce6dc5b342ef4 and 10a361304cf8e121a8c6dfaf1fa0dd19089fef90.

But I don't know why there's a problem with setrlimit() and RLIM_INFINITY on FreeBSD, OpenBSD, etc. So my thought is to replace the assert with a log message, as suggested by @SolidWallOfCode in TS-882. That'll fix the failing assertion immediately, and maybe provide enough details to fix the underlying failure?

Can we drop the ``#if !(defined(darwin) || defined(freebsd))`` as well?

@jirib what happens when you apply this patch?

Fixes #1354

[1] https://issues.apache.org/jira/browse/TS-882
[2] https://issues.apache.org/jira/browse/TS-3074