### PR TITLE
TS-4896: TSHttp***ClientAddrGet/TSHttp***IncomingAddrGet may return NULL

### DIFF
--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -5433,13 +5433,7 @@ TSHttpSsnClientAddrGet(TSHttpSsn ssnp)
   if (cs == nullptr) {
     return nullptr;
   }
-
-  NetVConnection *vc = cs->get_netvc();
-  if (vc == nullptr) {
-    return nullptr;
-  }
-
-  return vc->get_remote_addr();
+  return cs->get_client_addr();
 }
 sockaddr const *
 TSHttpTxnClientAddrGet(TSHttpTxn txnp)
@@ -5458,12 +5452,7 @@ TSHttpSsnIncomingAddrGet(TSHttpSsn ssnp)
   if (cs == nullptr) {
     return nullptr;
   }
-
-  NetVConnection *vc = cs->get_netvc();
-  if (vc == nullptr) {
-    return nullptr;
-  }
-  return vc->get_local_addr();
+  return cs->get_local_addr();
 }
 sockaddr const *
 TSHttpTxnIncomingAddrGet(TSHttpTxn txnp)

--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -214,6 +214,19 @@ public:
   ink_hrtime ssn_start_time;
   ink_hrtime ssn_last_txn_time;
 
+  virtual sockaddr const *
+  get_client_addr()
+  {
+    NetVConnection *netvc = get_netvc();
+    return netvc ? netvc->get_remote_addr() : nullptr;
+  }
+  virtual sockaddr const *
+  get_local_addr()
+  {
+    NetVConnection *netvc = get_netvc();
+    return netvc ? netvc->get_local_addr() : nullptr;
+  }
+
 protected:
   // XXX Consider using a bitwise flags variable for the following flags, so
   // that we can make the best use of internal alignment padding.

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -266,6 +266,9 @@ Http2ClientSession::do_io_close(int alerrno)
   // Don't send the SSN_CLOSE_HOOK until we got rid of all the streams
   // And handled all the TXN_CLOSE_HOOK's
   if (client_vc) {
+    // Copy aside the client address before releasing the vc
+    cached_client_addr.assign(client_vc->get_remote_addr());
+    cached_local_addr.assign(client_vc->get_local_addr());
     this->release_netvc();
     client_vc->do_io_close();
     client_vc = nullptr;

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -195,7 +195,13 @@ public:
   sockaddr const *
   get_client_addr()
   {
-    return client_vc->get_remote_addr();
+    return client_vc ? client_vc->get_remote_addr() : &cached_client_addr.sa;
+  }
+
+  sockaddr const *
+  get_local_addr()
+  {
+    return client_vc ? client_vc->get_local_addr() : &cached_local_addr.sa;
   }
 
   void
@@ -299,6 +305,9 @@ private:
   MIOBuffer *write_buffer;
   IOBufferReader *sm_writer;
   Http2FrameHeader current_hdr;
+
+  IpEndpoint cached_client_addr;
+  IpEndpoint cached_local_addr;
 
   // For Upgrade: h2c
   Http2UpgradeContext upgrade_context;


### PR DESCRIPTION
Several of our plugins would experience crashes once we tightened up clean up on session shutdown.  They assumed that the TSHttp{Txn|Ssn}ClientAddrGet and TSHttp{Txn|Ssn}IncomingAddrGet calls would never return NULL.   If the client initiates the shutdown, the underlying netvc may get cleaned up before the sessions, transactions, and state machines were completely shutdown.  The original code would return NULL in that case.  

In our version, we added this logic to cache the address information and use that data if the vc has been cleaned up.  This avoided spinning changes in the plugins.