### PR TITLE
Calling setrlimit() twice is redundant

### DIFF
--- a/cmd/traffic_manager/traffic_manager.cc
+++ b/cmd/traffic_manager/traffic_manager.cc
@@ -342,12 +342,12 @@ set_process_limits(RecInt fds_throttle)
   rlim_t maxfiles;
 
   // Set needed rlimits (root)
-  ink_max_out_rlimit(RLIMIT_NOFILE, true, false);
-  ink_max_out_rlimit(RLIMIT_STACK, true, true);
-  ink_max_out_rlimit(RLIMIT_DATA, true, true);
-  ink_max_out_rlimit(RLIMIT_FSIZE, true, false);
+  ink_max_out_rlimit(RLIMIT_NOFILE, false);
+  ink_max_out_rlimit(RLIMIT_STACK, true);
+  ink_max_out_rlimit(RLIMIT_DATA, true);
+  ink_max_out_rlimit(RLIMIT_FSIZE, false);
 #ifdef RLIMIT_RSS
-  ink_max_out_rlimit(RLIMIT_RSS, true, true);
+  ink_max_out_rlimit(RLIMIT_RSS, true);
 #endif
 
   maxfiles = ink_get_max_files();

--- a/lib/ts/ink_sys_control.cc
+++ b/lib/ts/ink_sys_control.cc
@@ -24,6 +24,7 @@
 #include "ts/ink_defs.h"
 #include "ts/ink_assert.h"
 #include "ts/ink_sys_control.h"
+#include "ts/Diags.h"
 
 rlim_t
 ink_max_out_rlimit(int which, bool max_it, bool unlim_it)
@@ -47,7 +48,10 @@ ink_max_out_rlimit(int which, bool max_it, bool unlim_it)
 #else
       rl.rlim_cur = rl.rlim_max;
 #endif
-      ink_release_assert(setrlimit(MAGIC_CAST(which), &rl) >= 0);
+      if (setrlimit(MAGIC_CAST(which), &rl) != 0) {
+        Warning("Failed to set resource limits: %s\nresource = %d, .rlim_cur = %lu, .rlim_max = %lu", strerror(errno), which,
+                rl.rlim_cur, rl.rlim_max);
+      }
     }
   }
 
@@ -56,7 +60,10 @@ ink_max_out_rlimit(int which, bool max_it, bool unlim_it)
     ink_release_assert(getrlimit(MAGIC_CAST(which), &rl) >= 0);
     if (rl.rlim_cur != (rlim_t)RLIM_INFINITY) {
       rl.rlim_cur = (rl.rlim_max = RLIM_INFINITY);
-      ink_release_assert(setrlimit(MAGIC_CAST(which), &rl) >= 0);
+      if (setrlimit(MAGIC_CAST(which), &rl) != 0) {
+        Warning("Failed to set resource limits: %s\nresource = %d, .rlim_cur = %lu, .rlim_max = %lu", strerror(errno), which,
+                rl.rlim_cur, rl.rlim_max);
+      }
     }
   }
 #endif

--- a/lib/ts/ink_sys_control.h
+++ b/lib/ts/ink_sys_control.h
@@ -26,7 +26,7 @@
 
 #include <sys/resource.h>
 
-rlim_t ink_max_out_rlimit(int which, bool max_it = true, bool unlim_it = true);
+rlim_t ink_max_out_rlimit(int which, bool unlim_it = true);
 rlim_t ink_get_max_files();
 
 #endif /*_INK_SYS_CONTROL_H*/

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -474,7 +474,7 @@ init_system()
   //
   // Delimit file Descriptors
   //
-  fds_limit = ink_max_out_rlimit(RLIMIT_NOFILE, true, false);
+  fds_limit = ink_max_out_rlimit(RLIMIT_NOFILE, false);
 }
 
 static void
@@ -1085,12 +1085,12 @@ adjust_sys_settings(void)
     }
   }
 
-  ink_max_out_rlimit(RLIMIT_STACK, true, true);
-  ink_max_out_rlimit(RLIMIT_DATA, true, true);
-  ink_max_out_rlimit(RLIMIT_FSIZE, true, false);
+  ink_max_out_rlimit(RLIMIT_STACK, true);
+  ink_max_out_rlimit(RLIMIT_DATA, true);
+  ink_max_out_rlimit(RLIMIT_FSIZE, false);
 
 #ifdef RLIMIT_RSS
-  ink_max_out_rlimit(RLIMIT_RSS, true, true);
+  ink_max_out_rlimit(RLIMIT_RSS, true);
 #endif
 }
 

--- a/proxy/logging/LogStandalone.cc
+++ b/proxy/logging/LogStandalone.cc
@@ -81,7 +81,7 @@ logging_crash_handler(int signo, siginfo_t *info, void *ptr)
 static void
 init_system(bool notify_syslog)
 {
-  fds_limit = ink_max_out_rlimit(RLIMIT_NOFILE, true, false);
+  fds_limit = ink_max_out_rlimit(RLIMIT_NOFILE, false);
 
   signal_register_crash_handler(logging_crash_handler);
   if (notify_syslog) {


### PR DESCRIPTION
Set .rlim_cur to either .rlim_max or RLIM_INFINITY.
Doing both is redundant.

This is a follow-up to #1362. The first commit belongs to that PR.