### PR TITLE
SSL_CTX_remove_session() and external cache

### DIFF
--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -281,8 +281,6 @@ ssl_new_cached_session(SSL *ssl, SSL_SESSION *sess)
 static void
 ssl_rm_cached_session(SSL_CTX *ctx, SSL_SESSION *sess)
 {
-  SSL_CTX_remove_session(ctx, sess);
-
   unsigned int len        = 0;
   const unsigned char *id = SSL_SESSION_get_id(sess, &len);
   SSLSessionID sid(id, len);


### PR DESCRIPTION
The remove session callback is triggered when a session is removed,
so at best, calling SSL_CTX_remove_session() again is redundant.
In OpenSSL 1.1 it's recursive.

Fixes #1386

My theory is that this worked by coincidence until [1]. Before that, if OpenSSL couldn't find the session in its internal cache, it wouldn't trigger the callback -- so since the session was already removed, SSL_CTX_remove_session() wouldn't trigger the callback again. Now it triggers the callback regardless.

[1] https://github.com/openssl/openssl/commit/e4612d02c53cccd24fa97b08fc01250d1238cca1