### PR TITLE
TS-2095: TS_HAS_LIBZ and TS_HAS_LZMA are always false

### DIFF
--- a/build/lzma.m4
+++ b/build/lzma.m4
@@ -73,7 +73,6 @@ else
   fi
 fi
 
-lzmah=0
 if test "$enable_lzma" != "no"; then
   saved_ldflags=$LDFLAGS
   saved_cppflags=$CPPFLAGS
@@ -96,5 +95,4 @@ if test "$enable_lzma" != "no"; then
     LDFLAGS=$saved_ldflags
   fi
 fi
-AC_SUBST(lzmah)
 ])

--- a/build/pcre.m4
+++ b/build/pcre.m4
@@ -83,8 +83,6 @@ else
   fi
 fi
 
-pcreh=0
-pcre_pcreh=0
 if test "$enable_pcre" != "no"; then
   saved_ldflags=$LDFLAGS
   saved_cppflags=$CPPFLAGS
@@ -109,6 +107,4 @@ if test "$enable_pcre" != "no"; then
     LDFLAGS=$saved_ldflags
   fi
 fi
-AC_SUBST(pcreh)
-AC_SUBST(pcre_pcreh)
 ])

--- a/build/zlib.m4
+++ b/build/zlib.m4
@@ -73,7 +73,6 @@ else
   fi
 fi
 
-zlibh=0
 if test "$enable_zlib" != "no"; then
   saved_ldflags=$LDFLAGS
   saved_cppflags=$CPPFLAGS
@@ -96,5 +95,4 @@ if test "$enable_zlib" != "no"; then
     LDFLAGS=$saved_ldflags
   fi
 fi
-AC_SUBST(zlibh)
 ])

--- a/cmd/traffic_layout/traffic_layout.cc
+++ b/cmd/traffic_layout/traffic_layout.cc
@@ -77,8 +77,16 @@ produce_features(bool json)
   print_feature("BUILD_PERSON", BUILD_PERSON, json);
   print_feature("BUILD_GROUP", BUILD_GROUP, json);
   print_feature("BUILD_NUMBER", BUILD_NUMBER, json);
-  print_feature("TS_HAS_LIBZ", TS_HAS_LIBZ, json);
-  print_feature("TS_HAS_LZMA", TS_HAS_LZMA, json);
+#ifdef HAVE_ZLIB_H
+  print_feature("TS_HAS_LIBZ", 1, json);
+#else
+  print_feature("TS_HAS_LIBZ", 0, json);
+#endif
+#ifdef HAVE_LZMA_H
+  print_feature("TS_HAS_LZMA", 1, json);
+#else
+  print_feature("TS_HAS_LZMA", 0, json);
+#endif
   print_feature("TS_HAS_JEMALLOC", TS_HAS_JEMALLOC, json);
   print_feature("TS_HAS_TCMALLOC", TS_HAS_TCMALLOC, json);
   print_feature("TS_HAS_IN6_IS_ADDR_UNSPECIFIED", TS_HAS_IN6_IS_ADDR_UNSPECIFIED, json);

--- a/configure.ac
+++ b/configure.ac
@@ -1229,7 +1229,6 @@ if test "${has_backtrace}" = "1"; then
 else
   AC_MSG_WARN([No backtrace() support found])
 fi
-AC_SUBST(execinfoh)
 AC_SUBST(has_backtrace)
 
 # Remote process unwinding is only implemented on Linux because it depends on various Linux-specific
@@ -1547,48 +1546,6 @@ AC_CHECK_HEADERS([sys/types.h \
                   editline/readline.h \
                   ucred.h ])
 
-AC_SUBST(sys_epollh)
-AC_SUBST(sys_eventh)
-AC_SUBST(machine_endianh)
-AC_SUBST(endianh)
-AC_SUBST(pthread_nph)
-AC_SUBST(sys_paramh)
-AC_SUBST(sys_cpuseth)
-AC_SUBST(sys_pseth)
-AC_SUBST(schedh)
-AC_SUBST(netinet_inh)
-AC_SUBST(netinet_in_systmh)
-AC_SUBST(netinet_tcph)
-AC_SUBST(sys_ioctlh)
-AC_SUBST(sys_byteorderh)
-AC_SUBST(sys_sockioh)
-AC_SUBST(sys_sysctlh)
-AC_SUBST(sys_sysinfoh)
-AC_SUBST(sys_systeminfoh)
-AC_SUBST(arpa_ineth)
-AC_SUBST(arpa_nameserh)
-AC_SUBST(arpa_nameser_compath)
-AC_SUBST(execinfoh)
-AC_SUBST(netdbh)
-AC_SUBST(ctypeh)
-
-AC_SUBST(siginfoh)
-AC_SUBST(malloch)
-AC_SUBST(waith)
-AC_SUBST(floath)
-AC_SUBST(libgenh)
-AC_SUBST(valuesh)
-AC_SUBST(allocah)
-AC_SUBST(cpioh)
-AC_SUBST(stroptsh)
-AC_SUBST(sys_mounth)
-AC_SUBST(sys_paramh)
-AC_SUBST(sys_sysmacrosh)
-AC_SUBST(mathh)
-AC_SUBST(net_ppp_defsh)
-AC_SUBST(ifaddrsh)
-AC_SUBST(readline_readlineh)
-
 AC_CHECK_HEADERS([sys/statfs.h sys/statvfs.h sys/disk.h sys/disklabel.h])
 AC_CHECK_HEADERS([linux/hdreg.h linux/fs.h linux/major.h])
 
@@ -1646,8 +1603,6 @@ AC_CHECK_HEADERS([netinet/ip_icmp.h], [], [],
                    #endif
                  ]])
 
-AC_SUBST(netinet_iph)
-AC_SUBST(netinet_ip_icmph)
 
 # Test for additional pthread interfaces.
 

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -1041,12 +1041,12 @@ CacheProcessor::cacheInitialized()
       case CACHE_COMPRESSION_FASTLZ:
         break;
       case CACHE_COMPRESSION_LIBZ:
-#if !TS_HAS_LIBZ
+#ifndef HAVE_ZLIB_H
         Fatal("libz not available for RAM cache compression");
 #endif
         break;
       case CACHE_COMPRESSION_LIBLZMA:
-#if !TS_HAS_LZMA
+#ifndef HAVE_LZMA_H
         Fatal("lzma not available for RAM cache compression");
 #endif
         break;

--- a/iocore/cache/RamCacheCLFUS.cc
+++ b/iocore/cache/RamCacheCLFUS.cc
@@ -27,10 +27,10 @@
 #include "P_Cache.h"
 #include "I_Tasks.h"
 #include "ts/fastlz.h"
-#if TS_HAS_LIBZ
+#ifdef HAVE_ZLIB_H
 #include <zlib.h>
 #endif
-#if TS_HAS_LZMA
+#ifdef HAVE_LZMA_H
 #include <lzma.h>
 #endif
 
@@ -154,12 +154,12 @@ RamCacheCLFUSCompressor::mainEvent(int /* event ATS_UNUSED */, Event *e)
   case CACHE_COMPRESSION_FASTLZ:
     break;
   case CACHE_COMPRESSION_LIBZ:
-#if !TS_HAS_LIBZ
+#ifndef HAVE_ZLIB_H
     Warning("libz not available for RAM cache compression");
 #endif
     break;
   case CACHE_COMPRESSION_LIBLZMA:
-#if !TS_HAS_LZMA
+#ifndef HAVE_LZMA_H
     Warning("lzma not available for RAM cache compression");
 #endif
     break;
@@ -270,7 +270,7 @@ RamCacheCLFUS::get(INK_MD5 *key, Ptr<IOBufferData> *ret_data, uint32_t auxkey1, 
             ram_hit_state = RAM_HIT_COMPRESS_FASTLZ;
             break;
           }
-#if TS_HAS_LIBZ
+#ifdef HAVE_ZLIB_H
           case CACHE_COMPRESSION_LIBZ: {
             uLongf l = e->len;
             if (Z_OK != uncompress((Bytef *)b, &l, (Bytef *)e->data->data(), e->compressed_len))
@@ -279,7 +279,7 @@ RamCacheCLFUS::get(INK_MD5 *key, Ptr<IOBufferData> *ret_data, uint32_t auxkey1, 
             break;
           }
 #endif
-#if TS_HAS_LZMA
+#ifdef HAVE_LZMA_H
           case CACHE_COMPRESSION_LIBLZMA: {
             size_t l = (size_t)e->len, ipos = 0, opos = 0;
             uint64_t memlimit = e->len * 2 + LZMA_BASE_MEMLIMIT;
@@ -435,12 +435,12 @@ RamCacheCLFUS::compress_entries(EThread *thread, int do_at_most)
       case CACHE_COMPRESSION_FASTLZ:
         l = (uint32_t)((double)e->len * 1.05 + 66);
         break;
-#if TS_HAS_LIBZ
+#ifdef HAVE_ZLIB_H
       case CACHE_COMPRESSION_LIBZ:
         l = (uint32_t)compressBound(e->len);
         break;
 #endif
-#if TS_HAS_LZMA
+#ifdef HAVE_LZMA_H
       case CACHE_COMPRESSION_LIBLZMA:
         l = e->len;
         break;
@@ -462,7 +462,7 @@ RamCacheCLFUS::compress_entries(EThread *thread, int do_at_most)
         if ((l = fastlz_compress(edata->data(), elen, b)) <= 0)
           failed = true;
         break;
-#if TS_HAS_LIBZ
+#ifdef HAVE_ZLIB_H
       case CACHE_COMPRESSION_LIBZ: {
         uLongf ll = l;
         if ((Z_OK != compress((Bytef *)b, &ll, (Bytef *)edata->data(), elen)))
@@ -471,7 +471,7 @@ RamCacheCLFUS::compress_entries(EThread *thread, int do_at_most)
         break;
       }
 #endif
-#if TS_HAS_LZMA
+#ifdef HAVE_LZMA_H
       case CACHE_COMPRESSION_LIBLZMA: {
         size_t pos = 0, ll = l;
         if (LZMA_OK != lzma_easy_buffer_encode(LZMA_PRESET_DEFAULT, LZMA_CHECK_NONE, nullptr, (uint8_t *)edata->data(), elen,

--- a/lib/ts/ink_config.h.in
+++ b/lib/ts/ink_config.h.in
@@ -51,8 +51,6 @@
 #define BUILD_NUMBER "@build_number@"
 
 /* Libraries */
-#define TS_HAS_LIBZ @zlibh@
-#define TS_HAS_LZMA @lzmah@
 #define TS_HAS_JEMALLOC @jemalloch@
 #define TS_HAS_TCMALLOC @has_tcmalloc@
 


### PR DESCRIPTION
Since replacing TS_FLAG_HEADERS, zlibh and lzmah are always false.
Just use HAVE_ZLIB_H and HAVE_LZMA_H directly.