### PR TITLE
TS-1768: AC_SEARCH_LIBS vs. AC_CHECK_LIB

### DIFF
--- a/build/crypto.m4
+++ b/build/crypto.m4
@@ -22,7 +22,7 @@ dnl
 dnl TS_CHECK_CRYPTO: look for crypto libraries and headers
 dnl
 AC_DEFUN([TS_CHECK_CRYPTO], [
-  AC_SEARCH_LIBS([crypt], [crypt], [AC_SUBST([LIBCRYPT],["-lcrypt"])])
+  AC_CHECK_LIB([crypt], [crypt], [AC_SUBST([LIBCRYPT],["-lcrypt"])])
 
   AX_CHECK_OPENSSL([
     enable_crypto=yes

--- a/build/lzma.m4
+++ b/build/lzma.m4
@@ -84,7 +84,7 @@ if test "$enable_lzma" != "no"; then
     TS_ADDTO(LDFLAGS, [-L${lzma_ldflags}])
     TS_ADDTO_RPATH(${lzma_ldflags})
   fi
-  AC_SEARCH_LIBS([lzma_code], [lzma], [lzma_have_libs=1])
+  AC_CHECK_LIB([lzma], [lzma_code], [lzma_have_libs=1])
   if test "$lzma_have_libs" != "0"; then
     AC_CHECK_HEADERS(lzma.h, [lzma_have_headers=1])
   fi

--- a/build/pcre.m4
+++ b/build/pcre.m4
@@ -95,7 +95,7 @@ if test "$enable_pcre" != "no"; then
     TS_ADDTO(LDFLAGS, [-L${pcre_ldflags}])
     TS_ADDTO_RPATH(${pcre_ldflags})
   fi
-  AC_SEARCH_LIBS([pcre_exec], [pcre], [pcre_have_libs=1])
+  AC_CHECK_LIB([pcre], [pcre_exec], [pcre_have_libs=1])
   if test "$pcre_have_libs" != "0"; then
     AC_CHECK_HEADERS(pcre.h, [pcre_have_headers=1])
     AC_CHECK_HEADERS(pcre/pcre.h, [pcre_have_headers=1])

--- a/build/zlib.m4
+++ b/build/zlib.m4
@@ -84,7 +84,7 @@ if test "$enable_zlib" != "no"; then
     TS_ADDTO(LDFLAGS, [-L${zlib_ldflags}])
     TS_ADDTO_RPATH(${zlib_ldflags})
   fi
-  AC_SEARCH_LIBS([compressBound], [z], [zlib_have_libs=1])
+  AC_CHECK_LIB([z], [compressBound], [zlib_have_libs=1])
   if test "$zlib_have_libs" != "0"; then
     AC_CHECK_HEADERS(zlib.h, [zlib_have_headers=1])
   fi

--- a/configure.ac
+++ b/configure.ac
@@ -1300,7 +1300,7 @@ AC_SUBST(use_port)
 # Profiler support
 has_profiler=0
 if test "x${with_profiler}" = "xyes"; then
-  AC_SEARCH_LIBS([ProfilerStart], [profiler],
+  AC_CHECK_LIB([profiler], [ProfilerStart],
     [AC_SUBST([LIBPROFILER], ["-lprofiler"])
      has_profiler=1
     ],
@@ -1356,7 +1356,7 @@ AS_IF([test "x$has_128bit_cas" = "x1"], [
 # If we don't find it, disable checking for header.
 use_posix_cap=0
 AS_IF([test "x$enable_posix_cap" != "xno"],
-  AC_SEARCH_LIBS([cap_set_proc],[cap],
+  AC_CHECK_LIB([cap], [cap_set_proc],
     [AC_SUBST([LIBCAP], ["-lcap"])
      use_posix_cap=1
     ],[


### PR DESCRIPTION
AC_SEARCH_LIBS always adds -llibrary to LIBS, but AC_CHECK_LIB doesn't
check that the function isn't already available -- in which case the
library isn't required. So prefer AC_SEARCH_LIBS. Use AC_CHECK_LIB only
if 1) we want to leave LIBS alone, and 2) the function isn't likely to
be provided by some other library -- the standard C library, for
example. If there's a chance that the function might already be
available, use AC_SEARCH_LIBS, but save and restore LIBS as needed.