### PR TITLE
Fix Assertion failure in the regex_revalidate plugin.

### DIFF
--- a/plugins/experimental/regex_revalidate/regex_revalidate.c
+++ b/plugins/experimental/regex_revalidate/regex_revalidate.c
@@ -348,7 +348,7 @@ config_handler(TSCont cont, TSEvent event ATS_UNUSED, void *edata ATS_UNUSED)
     iptr = __sync_val_compare_and_swap(&(pstate->invalidate_list), pstate->invalidate_list, i);
 
     if (iptr) {
-      free_cont = TSContCreate(free_handler, NULL);
+      free_cont = TSContCreate(free_handler, TSMutexCreate());
       TSContDataSet(free_cont, (void *)iptr);
       TSContSchedule(free_cont, FREE_TMOUT, TS_THREAD_POOL_TASK);
     }


### PR DESCRIPTION
When using the regex_revalidate plugin, we see an assertion failure in TSContSchedule() at InkAPI.cc:4232

Since TS-4387, Calls to TSContSchedule/TSContScheduleEvery(), require
that the continuation associated with the TSCont parameter must have a mutex.