### PR TITLE
Fix potential spin loop in perl management library.

### DIFF
--- a/lib/perl/lib/Apache/TS/AdminClient.pm
+++ b/lib/perl/lib/Apache/TS/AdminClient.pm
@@ -184,6 +184,16 @@ sub _do_read {
 
     while ($self->{_select}->can_read($timeout)) {
         my $rc = $self->{_socket}->sysread($res, 1024, length($res));
+
+        # If the server dies we get into a infinite loop because
+        # IO::Select::can_read keeps returning true
+        # In this condition sysread returns 0 or undef
+        # Also, we want to return an undef rather than a partial response
+        # to avoid unmarshalling errors in the callers
+        if (!defined($rc) || ($rc == 0)) {
+            $res = undef;
+            last;
+        }
     }
 
     return $res || undef;


### PR DESCRIPTION
This is a bug where the AdminClient perl interface can get trapped in a spin loop. This has been an internal problem with Yahoo! monitoring applications.