### PR TITLE
Log crc field and psql field correctly with H2

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -585,7 +585,6 @@ Http2Stream::update_write_request(IOBufferReader *buf_reader, int64_t write_len,
             this->mark_body_done();
             // Send the data frame
             send_response_body();
-            retval = false;
           }
         }
         break;


### PR DESCRIPTION
The two field values were logged incorrectly if a resopnse body is short.

Because a write VIO isn't pass to a consumer if whole response body was sent before calling `update_write_request `, the field values aren't collected. The flag `retval` is used for switching whether a VIO will be passed.

Also, 6.2.x has the same problem.