### PR TITLE
Fix a build issue that use of undeclared variables

### DIFF
--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -453,10 +453,11 @@ UnixNetVConnection::set_tcp_congestion_control(int side)
   RecString congestion_control;
   int ret;
 
-  if (side == CLIENT_SIDE)
+  if (side == CLIENT_SIDE) {
     ret = REC_ReadConfigStringAlloc(congestion_control, "proxy.config.net.tcp_congestion_control_in");
-  else
+  } else {
     ret = REC_ReadConfigStringAlloc(congestion_control, "proxy.config.net.tcp_congestion_control_out");
+  }
 
   if (ret == REC_ERR_OKAY) {
     int len = strlen(congestion_control);
@@ -475,7 +476,7 @@ UnixNetVConnection::set_tcp_congestion_control(int side)
   }
   return -1;
 #else
-  Debug("socket", "Setting TCP congestion control %.*s is not supported on this platform.", len, name);
+  Debug("socket", "Setting TCP congestion control is not supported on this platform.");
   return -1;
 #endif
 }


### PR DESCRIPTION
The change made with #1426 causes build error on some platforms which doesn't support congestion control. I fixed the issue and changed code style a bit.