### PR TITLE
Prefer setting AM_CPPFLAGS vs. CPPFLAGS, etc.

### DIFF
--- a/build/plugins.mk
+++ b/build/plugins.mk
@@ -35,5 +35,5 @@ TS_PLUGIN_CPPFLAGS = \
 # throws an error if we try to do the same with AM_LDFLAGS. Hence, we provide
 # TS_PLUGIN variables that can be used to construct the necessary automake
 # syntax.
-AM_CPPFLAGS = $(TS_PLUGIN_CPPFLAGS)
+AM_CPPFLAGS += $(TS_PLUGIN_CPPFLAGS)
 pkglibdir = $(pkglibexecdir)

--- a/cmd/traffic_cop/Makefile.am
+++ b/cmd/traffic_cop/Makefile.am
@@ -17,7 +17,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-AM_CPPFLAGS = $(iocore_include_dirs) \
+AM_CPPFLAGS += $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/lib/records \
   -I$(abs_top_srcdir)/mgmt \

--- a/cmd/traffic_crashlog/Makefile.am
+++ b/cmd/traffic_crashlog/Makefile.am
@@ -17,7 +17,7 @@
 
 bin_PROGRAMS = traffic_crashlog
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/lib/records \

--- a/cmd/traffic_ctl/Makefile.am
+++ b/cmd/traffic_ctl/Makefile.am
@@ -17,7 +17,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/lib/records \

--- a/cmd/traffic_layout/Makefile.am
+++ b/cmd/traffic_layout/Makefile.am
@@ -17,7 +17,7 @@
 
 bin_PROGRAMS = traffic_layout
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/lib/records \

--- a/cmd/traffic_manager/Makefile.am
+++ b/cmd/traffic_manager/Makefile.am
@@ -17,7 +17,7 @@
 
 bin_PROGRAMS = traffic_manager
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   $(LUAJIT_CPPFLAGS) \
   $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib/records \

--- a/cmd/traffic_top/Makefile.am
+++ b/cmd/traffic_top/Makefile.am
@@ -18,7 +18,7 @@
 # We only build traffic_top if libcurses and libcurl are available.
 if BUILD_TRAFFIC_TOP
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/mgmt/api/include \

--- a/cmd/traffic_via/Makefile.am
+++ b/cmd/traffic_via/Makefile.am
@@ -17,7 +17,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/mgmt/api/include

--- a/cmd/traffic_wccp/Makefile.am
+++ b/cmd/traffic_wccp/Makefile.am
@@ -17,7 +17,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-AM_CPPFLAGS = $(iocore_include_dirs) \
+AM_CPPFLAGS += $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/lib/records \
   -I$(abs_top_srcdir)/lib/wccp \

--- a/configure.ac
+++ b/configure.ac
@@ -582,8 +582,8 @@ CFLAGS="${_ts_saved_CFLAGS}"
 CXXFLAGS="${_ts_saved_CXXFLAGS}"
 
 # All compilers we support have 'gnu99' as an available C standard
-TS_ADDTO(CFLAGS, [-std=gnu99])
-TS_ADDTO(CXXFLAGS, [-std=c++11])
+TS_ADDTO(AM_CFLAGS, [-std=gnu99])
+TS_ADDTO(AM_CXXFLAGS, [-std=c++11])
 
 dnl AC_PROG_SED is only available from version 2.6 (released in 2003). CentosOS
 dnl 5.9 still has an ancient version, but we have macros that require
@@ -611,13 +611,13 @@ case $host_os in
   freebsd*)
     host_os_def="freebsd"
     AM_LDFLAGS="-rdynamic"
-    TS_ADDTO(CPPFLAGS, [-I/usr/local/include])
+    TS_ADDTO(AM_CPPFLAGS, [-I/usr/local/include])
     ;;
   kfreebsd*)
     host_os_def="freebsd"
     AM_LDFLAGS="-rdynamic"
-    TS_ADDTO(CPPFLAGS, [-I/usr/local/include])
-    TS_ADDTO(CPPFLAGS, [-Dkfreebsd])
+    TS_ADDTO(AM_CPPFLAGS, [-I/usr/local/include])
+    TS_ADDTO(AM_CPPFLAGS, [-Dkfreebsd])
     ;;
   openbsd*)
     host_os_def="openbsd"
@@ -626,8 +626,8 @@ case $host_os in
     host_os_def="solaris"
     case "`isalist`" in
       *amd64*)
-        TS_ADDTO(CFLAGS, [-m64])
-        TS_ADDTO(CXXFLAGS, [-m64])
+        TS_ADDTO(AM_CFLAGS, [-m64])
+        TS_ADDTO(AM_CXXFLAGS, [-m64])
         TS_ADDTO(LUAJIT_LDFLAGS, [-m64])
         ;;
     esac
@@ -638,7 +638,7 @@ case $host_os in
     ;;
 esac
 
-TS_ADDTO(CPPFLAGS, [-D$host_os_def])
+TS_ADDTO(AM_CPPFLAGS, [-D$host_os_def])
 
 dnl AM_PROG_AR is not always available, but it doesn't seem to be needed in older versions.
 ifdef([AM_PROG_AR],
@@ -824,10 +824,10 @@ case $host_os_def in
 
     # NOTE: This seems semi-kludgy, but useful for MacPorts I think.
     AS_IF([test -d /opt/local/include], [
-      TS_ADDTO(CPPFLAGS, [-I/opt/local/include])
+      TS_ADDTO(AM_CPPFLAGS, [-I/opt/local/include])
     ])
     AS_IF([test -d /opt/local/lib], [
-      TS_ADDTO(LDFLAGS, [-L/opt/local/lib])
+      TS_ADDTO(AM_LDFLAGS, [-L/opt/local/lib])
     ])
 
     ;; # darwin)
@@ -849,7 +849,7 @@ case $host_os_def in
     ])
 
     AS_IF([test -d /usr/local/lib], [
-      TS_ADDTO(LDFLAGS, [-L/usr/local/lib])
+      TS_ADDTO(AM_LDFLAGS, [-L/usr/local/lib])
     ])
 
     ;; # freebsd|kfreebsd)
@@ -881,13 +881,13 @@ AS_IF([test x"$enable_coverage" = "xyes"], [
   # supported compiler to test coverage.
   AS_CASE("$ax_cv_c_compiler_vendor",
     [clang], [
-      TS_ADDTO(CXXFLAGS, "-fprofile-instr-generate")
-      TS_ADDTO(CXXFLAGS, "-fcoverage-mapping")
-      TS_ADDTO(CFLAGS, "-fprofile-instr-generate")
-      TS_ADDTO(CFLAGS, "-fcoverage-mapping")
+      TS_ADDTO(AM_CXXFLAGS, "-fprofile-instr-generate")
+      TS_ADDTO(AM_CXXFLAGS, "-fcoverage-mapping")
+      TS_ADDTO(AM_CFLAGS, "-fprofile-instr-generate")
+      TS_ADDTO(AM_CFLAGS, "-fcoverage-mapping")
     ], [gnu], [
-      TS_ADDTO(CXXFLAGS, "--coverage")
-      TS_ADDTO(CFLAGS, "--coverage")
+      TS_ADDTO(AM_CXXFLAGS, "--coverage")
+      TS_ADDTO(AM_CFLAGS, "--coverage")
       TS_ADDTO(LIBS, "-lgcov")
   ])
 ])
@@ -904,11 +904,6 @@ cc_oflag_dbg=$debug_opt
 cxx_oflag_opt="$release_opt $cxx_opt $cxx_rel"
 cxx_oflag_dbg="$debug_opt $cxx_opt $cxx_dbg"
 
-AM_CFLAGS="$ts_am_common_flags"
-AM_CXXFLAGS="$ts_am_common_flags"
-AC_SUBST(AM_CFLAGS)
-AC_SUBST(AM_CXXFLAGS)
-
 # Special compiler flag hacks for various pieces of the code
 AC_SUBST([FLEX_CFLAGS], $flex_cflags)
 
@@ -922,12 +917,12 @@ SHARED_CXXLINKFLAGS=-shared
 #  existing CFLAGS/CXXFLAGS if some special values had been set.
 #
 if test "x${enable_debug}" = "xyes"; then
-  TS_ADDTO(CFLAGS, [${cc_oflag_dbg}])
-  TS_ADDTO(CXXFLAGS, [${cxx_oflag_dbg}])
-  TS_ADDTO(CPPFLAGS, [-DDEBUG -D_DEBUG])
+  TS_ADDTO(AM_CFLAGS, [${cc_oflag_dbg}])
+  TS_ADDTO(AM_CXXFLAGS, [${cxx_oflag_dbg}])
+  TS_ADDTO(AM_CPPFLAGS, [-DDEBUG -D_DEBUG])
 else
-  TS_ADDTO(CFLAGS, [${cc_oflag_opt}])
-  TS_ADDTO(CXXFLAGS, [${cxx_oflag_opt}])
+  TS_ADDTO(AM_CFLAGS, [${cc_oflag_opt}])
+  TS_ADDTO(AM_CXXFLAGS, [${cxx_oflag_opt}])
 fi
 
 # Flags for ASAN
@@ -935,14 +930,14 @@ if test "x${enable_asan}" = "xyes"; then
   if test "x${enable_tsan}" = "xyes"; then
     AC_ERROR([Cannot have ASAN and TSAN options at the same time, pick one])
   fi
-  TS_ADDTO(CFLAGS, [-fno-omit-frame-pointer -fsanitize=address])
-  TS_ADDTO(CXXFLAGS, [-fno-omit-frame-pointer -fsanitize=address])
+  TS_ADDTO(AM_CFLAGS, [-fno-omit-frame-pointer -fsanitize=address])
+  TS_ADDTO(AM_CXXFLAGS, [-fno-omit-frame-pointer -fsanitize=address])
 fi
 
 # Flags for TSAN
 if test "x${enable_tsan}" = "xyes"; then
-  TS_ADDTO(CFLAGS, [-fsanitize=thread])
-  TS_ADDTO(CXXFLAGS, [-fsanitize=thread])
+  TS_ADDTO(AM_CFLAGS, [-fsanitize=thread])
+  TS_ADDTO(AM_CXXFLAGS, [-fsanitize=thread])
 fi
 
 # Checks for pointer size.
@@ -1007,32 +1002,32 @@ AC_ARG_WITH(architecture, [AC_HELP_STRING([--with-architecture=ARCH],[use a spec
 ])
 
 if test "x$cpu_architecture" != "x"; then
-  TS_ADDTO(CFLAGS, [$cpu_architecture])
-  TS_ADDTO(CXXFLAGS, [$cpu_architecture])
+  TS_ADDTO(AM_CFLAGS, [$cpu_architecture])
+  TS_ADDTO(AM_CXXFLAGS, [$cpu_architecture])
 fi
 
 # 64-bit LFS support
 #
-TS_ADDTO(CPPFLAGS, [-D_LARGEFILE64_SOURCE=1])
+TS_ADDTO(AM_CPPFLAGS, [-D_LARGEFILE64_SOURCE=1])
 if test "${ac_cv_sizeof_voidp}" = "8"; then
-  TS_ADDTO(CPPFLAGS, [-D_COMPILE64BIT_SOURCE=1])
+  TS_ADDTO(AM_CPPFLAGS, [-D_COMPILE64BIT_SOURCE=1])
 else
-  TS_ADDTO(CPPFLAGS, [-D_FILE_OFFSET_BITS=64])
+  TS_ADDTO(AM_CPPFLAGS, [-D_FILE_OFFSET_BITS=64])
 fi
 TS_ADDTO(CPPFLAGS, [-D_GNU_SOURCE])
-TS_ADDTO(CPPFLAGS, [-D_REENTRANT])
-TS_ADDTO(CPPFLAGS, [-D__STDC_LIMIT_MACROS=1])
-TS_ADDTO(CPPFLAGS, [-D__STDC_FORMAT_MACROS=1])
+TS_ADDTO(AM_CPPFLAGS, [-D_REENTRANT])
+TS_ADDTO(AM_CPPFLAGS, [-D__STDC_LIMIT_MACROS=1])
+TS_ADDTO(AM_CPPFLAGS, [-D__STDC_FORMAT_MACROS=1])
 
 AC_MSG_NOTICE([Build for host OS: $host_os, arch: $host_cpu, optimization: $host_os_def])
 
 # Add hardening options to flags
 AS_IF([test "x${enable_hardening}" = "xyes"], [
-  TS_ADDTO(CPPFLAGS, [-D_FORTIFY_SOURCE=2])
-  TS_ADDTO(CXXFLAGS, [-fPIE -fstack-protector])
-  TS_ADDTO(CFLAGS, [-fPIE -fstack-protector])
+  TS_ADDTO(AM_CPPFLAGS, [-D_FORTIFY_SOURCE=2])
+  TS_ADDTO(AM_CXXFLAGS, [-fPIE -fstack-protector])
+  TS_ADDTO(AM_CFLAGS, [-fPIE -fstack-protector])
   AS_CASE("$host_os_def",
-    [linux], [TS_ADDTO(LDFLAGS, [-pie -Wl,-z,relro -Wl,-z,now])]
+    [linux], [TS_ADDTO(AM_LDFLAGS, [-pie -Wl,-z,relro -Wl,-z,now])]
   )
 ])
 
@@ -1175,7 +1170,7 @@ AC_SUBST([LIBTCL],[$TCL_LIB_SPEC])
 
 
 if test "x${TCL_INCLUDE_SPEC}" != "x-I/usr/include"; then
-   TS_ADDTO(CPPFLAGS, [$TCL_INCLUDE_SPEC])
+   TS_ADDTO(AM_CPPFLAGS, [$TCL_INCLUDE_SPEC])
 fi
 
 AC_CHECK_FUNCS([clock_gettime kqueue epoll_ctl posix_memalign posix_fadvise posix_madvise posix_fallocate inotify_init])
@@ -1340,8 +1335,8 @@ AC_SUBST(has_128bit_cas)
 
 AS_IF([test "x$has_128bit_cas" = "x1"], [
   AS_IF([test "x$ax_cv_c_compiler_vendor" != "xintel"], [
-    TS_ADDTO(CFLAGS, [-mcx16])
-    TS_ADDTO(CXXFLAGS, [-mcx16])
+    TS_ADDTO(AM_CFLAGS, [-mcx16])
+    TS_ADDTO(AM_CXXFLAGS, [-mcx16])
   ])
 ])
 
@@ -1844,13 +1839,11 @@ TS_REMOVEFROM(LUAJIT_CFLAGS, "-fprofile-instr-generate")
 TS_REMOVEFROM(LUAJIT_CFLAGS, "-fcoverage-mapping")
 TS_REMOVEFROM(LUAJIT_CFLAGS, "--coverage")
 
-AC_SUBST([CC])
-AC_SUBST([CFLAGS])
-AC_SUBST([CXX])
-AC_SUBST([CXXFLAGS])
+AC_SUBST([AM_CPPFLAGS])
+AC_SUBST([AM_CFLAGS])
+AC_SUBST([AM_CXXFLAGS])
 AC_SUBST([AM_LDFLAGS])
 AC_SUBST([iocore_include_dirs])
-AC_SUBST([LDFLAGS])
 AC_SUBST([SHARED_CFLAGS])
 AC_SUBST([SHARED_CXXFLAGS])
 AC_SUBST([SHARED_CXXLINKFLAGS])
@@ -1935,10 +1928,10 @@ AC_MSG_NOTICE([Build option summary:
     CC:                 $CC
     CXX:                $CXX
     CPP:                $CPP
-    CFLAGS:             $CFLAGS
-    CXXFLAGS:           $CXXFLAGS
-    CPPFLAGS:           $CPPFLAGS
-    LDFLAGS:            $LDFLAGS
+    AM@&t@_CFLAGS:          $AM_CFLAGS
+    AM@&t@_CXXFLAGS:        $AM_CXXFLAGS
+    AM@&t@_CPPFLAGS:        $AM_CPPFLAGS
+    AM@&t@_LDFLAGS:         $AM_LDFLAGS
     SHARED_CFLAGS:      $SHARED_CFLAGS
     SHARED_CXXFLAGS:    $SHARED_CXXFLAGS
     SHARED_CXXLINKFLAGS:$SHARED_LINKCXXFLAGS
@@ -1948,5 +1941,4 @@ AC_MSG_NOTICE([Build option summary:
     LUAJIT_CFLAGS:      $LUAJIT_CFLAGS
     LUAJIT_CPPFLAGS:	$LUAJIT_CPPFLAGS
     LUAJIT_LDFLAGS:     $LUAJIT_LDFLAGS
-    AM@&t@_LDFLAGS:         $AM_LDFLAGS
 ])

--- a/iocore/aio/Makefile.am
+++ b/iocore/aio/Makefile.am
@@ -16,7 +16,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/iocore/eventsystem \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/lib/records

--- a/iocore/cache/Makefile.am
+++ b/iocore/cache/Makefile.am
@@ -16,7 +16,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/lib/records \

--- a/iocore/cluster/Makefile.am
+++ b/iocore/cluster/Makefile.am
@@ -16,7 +16,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/lib/records \

--- a/iocore/dns/Makefile.am
+++ b/iocore/dns/Makefile.am
@@ -16,7 +16,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/lib/records \

--- a/iocore/eventsystem/Makefile.am
+++ b/iocore/eventsystem/Makefile.am
@@ -16,7 +16,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/lib/records
 

--- a/iocore/hostdb/Makefile.am
+++ b/iocore/hostdb/Makefile.am
@@ -16,7 +16,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/lib/records \

--- a/iocore/net/Makefile.am
+++ b/iocore/net/Makefile.am
@@ -16,7 +16,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/lib/records \

--- a/iocore/utils/Makefile.am
+++ b/iocore/utils/Makefile.am
@@ -16,7 +16,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/lib/records \
   -I$(abs_top_srcdir)/iocore/eventsystem

--- a/lib/bindings/Makefile.am
+++ b/lib/bindings/Makefile.am
@@ -18,7 +18,7 @@
 
 include $(top_srcdir)/build/tidy.mk
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   $(LUAJIT_CPPFLAGS) \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/lib/records

--- a/lib/records/Makefile.am
+++ b/lib/records/Makefile.am
@@ -18,7 +18,7 @@
 
 include $(top_srcdir)/build/tidy.mk
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/iocore/eventsystem \
   -I$(abs_top_srcdir)/iocore/utils \
   -I$(abs_top_srcdir)/mgmt \

--- a/lib/ts/Makefile.am
+++ b/lib/ts/Makefile.am
@@ -29,7 +29,7 @@ TESTS_ENVIRONMENT = LSAN_OPTIONS=suppressions=suppression.txt
 
 TESTS = $(check_PROGRAMS)
 
-AM_CPPFLAGS = -I$(abs_top_srcdir)/lib
+AM_CPPFLAGS += -I$(abs_top_srcdir)/lib
 
 lib_LTLIBRARIES = libtsutil.la
 

--- a/lib/tsconfig/Makefile.am
+++ b/lib/tsconfig/Makefile.am
@@ -23,7 +23,7 @@ libtsconfig_la_LDFLAGS = -no-undefined -version-info @TS_LIBTOOL_VERSION@
 AM_CFLAGS += @FLEX_CFLAGS@
 AM_YFLAGS = --yacc -d -p tsconfig
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/lib
 
 BUILT_SOURCES = \

--- a/lib/wccp/Makefile.am
+++ b/lib/wccp/Makefile.am
@@ -19,7 +19,7 @@
 
 include $(top_srcdir)/build/tidy.mk
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/proxy/api/ts
 

--- a/mgmt/Makefile.am
+++ b/mgmt/Makefile.am
@@ -25,7 +25,7 @@ SUBDIRS = cluster utils api
 # 	libmgmt_p.la	libmgmt for Process Manager applications (everything else)
 noinst_LTLIBRARIES = libmgmt_c.la libmgmt_p.la libmgmt_lm.la
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/mgmt/api/include \
   -I$(abs_top_srcdir)/mgmt/cluster \

--- a/mgmt/api/Makefile.am
+++ b/mgmt/api/Makefile.am
@@ -21,7 +21,7 @@ include $(top_srcdir)/build/tidy.mk
 
 SUBDIRS = include
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib/records \
   -I$(abs_top_srcdir)/mgmt \

--- a/mgmt/cluster/Makefile.am
+++ b/mgmt/cluster/Makefile.am
@@ -19,7 +19,7 @@
 
 include $(top_srcdir)/build/tidy.mk
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/lib/records \
   -I$(abs_top_srcdir)/mgmt \
   -I$(abs_top_srcdir)/mgmt/api/include \

--- a/mgmt/utils/Makefile.am
+++ b/mgmt/utils/Makefile.am
@@ -17,7 +17,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/iocore/utils \
   -I$(abs_top_srcdir)/mgmt \
   -I$(abs_top_srcdir)/mgmt/api \

--- a/plugins/esi/Makefile.inc
+++ b/plugins/esi/Makefile.inc
@@ -19,7 +19,7 @@ ESI_CPPFLAGS = \
 	-I$(srcdir)/esi/lib \
 	-I$(srcdir)/esi/fetcher \
 	-I$(srcdir)/esi/test \
-	$(TS_PLUGIN_CPPFLAGS)
+	$(AM_CPPFLAGS)
 
 # Add -Wno-deprecated because ESI uses ext/hash_map.
 ESI_CXXFLAGS = \
@@ -99,7 +99,6 @@ esi_esi_la_SOURCES =  \
 
 esi_esi_la_CPPFLAGS = $(ESI_CPPFLAGS)
 esi_esi_la_CXXFLAGS = $(ESI_CXXFLAGS)
-esi_esi_la_LDFLAGS = $(TS_PLUGIN_LD_FLAGS)
 esi_esi_la_LIBADD = esi/libesicore.la
 
 esi_combo_handler_la_SOURCES = \
@@ -109,7 +108,6 @@ esi_combo_handler_la_SOURCES = \
 
 esi_combo_handler_la_CPPFLAGS = $(ESI_CPPFLAGS)
 esi_combo_handler_la_CXXFLAGS = $(ESI_CXXFLAGS)
-esi_combo_handler_la_LDFLAGS = $(TS_PLUGIN_LD_FLAGS)
 esi_combo_handler_la_LIBADD = esi/libesicore.la
 
 esi_docnode_test_CPPFLAGS = $(ESI_CPPFLAGS)

--- a/plugins/experimental/cache_key_genid/Makefile.inc
+++ b/plugins/experimental/cache_key_genid/Makefile.inc
@@ -20,4 +20,4 @@ experimental_cache_key_genid_cache_key_genid_la_SOURCES = \
   experimental/cache_key_genid/cache_key_genid.c
 
 experimental_cache_key_genid_cache_key_genid_la_LDFLAGS = \
-    $(TS_PLUGIN_LD_FLAGS) $(LIB_KYOTOCABINET)
+    $(AM_LDFLAGS) $(LIB_KYOTOCABINET)

--- a/plugins/experimental/mysql_remap/Makefile.inc
+++ b/plugins/experimental/mysql_remap/Makefile.inc
@@ -24,6 +24,6 @@ experimental_mysql_remap_mysql_remap_la_SOURCES = \
 	experimental/mysql_remap/lib/iniparser.h
 
 experimental_mysql_remap_mysql_remap_la_LDFLAGS = \
-	$(TS_PLUGIN_LD_FLAGS) $(LIB_MYSQLCLIENT)
+	$(AM_LDFLAGS) $(LIB_MYSQLCLIENT)
 
 # vim: ft=make ts=8 sw=8 et:

--- a/plugins/experimental/sslheaders/Makefile.inc
+++ b/plugins/experimental/sslheaders/Makefile.inc
@@ -37,8 +37,6 @@ experimental_sslheaders_sslheaders_la_SOURCES = \
 experimental_sslheaders_sslheaders_la_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
 	@OPENSSL_INCLUDES@
-experimental_sslheaders_sslheaders_la_LDFLAGS = \
-        $(TS_PLUGIN_LD_FLAGS)
 experimental_sslheaders_sslheaders_la_LIBADD = \
         experimental/sslheaders/libsslhdr.la
 

--- a/plugins/experimental/webp_transform/Makefile.inc
+++ b/plugins/experimental/webp_transform/Makefile.inc
@@ -24,7 +24,7 @@ experimental_webp_transform_WebpTransform_la_SOURCES = \
   experimental/webp_transform/ImageTransform.cc
 
 experimental_webp_transform_WebpTransform_la_LDFLAGS = \
-  $(TS_PLUGIN_LD_FLAGS) \
+  $(AM_LDFLAGS) \
   -L$(top_builddir)/lib/cppapi
 
 experimental_webp_transform_WebpTransform_la_LIBADD = \

--- a/proxy/Makefile.am
+++ b/proxy/Makefile.am
@@ -30,7 +30,7 @@ TESTS = \
   tests/test_logstats_json \
   tests/test_logstats_summary
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib/records \
   -I$(abs_srcdir)/http \

--- a/proxy/congest/Makefile.am
+++ b/proxy/congest/Makefile.am
@@ -16,7 +16,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/lib/records \

--- a/proxy/hdrs/Makefile.am
+++ b/proxy/hdrs/Makefile.am
@@ -18,7 +18,7 @@
 
 include $(top_srcdir)/build/tidy.mk
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/lib/records

--- a/proxy/http/Makefile.am
+++ b/proxy/http/Makefile.am
@@ -20,7 +20,7 @@ include $(top_srcdir)/build/tidy.mk
 
 SUBDIRS = remap
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/proxy/api/ts \
   -I$(abs_top_srcdir)/proxy \

--- a/proxy/http/remap/Makefile.am
+++ b/proxy/http/remap/Makefile.am
@@ -18,7 +18,7 @@
 
 include $(top_srcdir)/build/tidy.mk
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/lib/records \

--- a/proxy/http2/Makefile.am
+++ b/proxy/http2/Makefile.am
@@ -18,7 +18,7 @@
 
 include $(top_srcdir)/build/tidy.mk
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/proxy/api/ts \
   -I$(abs_top_srcdir)/lib \

--- a/proxy/logging/Makefile.am
+++ b/proxy/logging/Makefile.am
@@ -18,7 +18,7 @@
 
 include $(top_srcdir)/build/tidy.mk
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/lib/luajit/src \

--- a/proxy/shared/Makefile.am
+++ b/proxy/shared/Makefile.am
@@ -23,7 +23,7 @@ noinst_LIBRARIES = \
   libdiagsconfig.a \
   libUglyLogStubs.a
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib/records \
   -I$(abs_top_srcdir)/mgmt \

--- a/rc/Makefile.am
+++ b/rc/Makefile.am
@@ -16,7 +16,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/lib/records \
   -I$(abs_top_srcdir)/proxy \
   -I$(abs_top_srcdir)/mgmt \

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -22,7 +22,7 @@ bin_SCRIPTS = tsxs tspush
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = trafficserver.pc
 
-AM_CPPFLAGS = $(iocore_include_dirs) \
+AM_CPPFLAGS += $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/lib/wccp
 


### PR DESCRIPTION
Autoconf and Automake discourage setting some Makefile variables [1].
They encourage setting their AM_ variants instead.

[1] https://www.gnu.org/software/automake/manual/automake#User-Variables

This change covers most but not all of these cases -- in a few cases, 1) we set CPPFLAGS because AC_LINK_IFELSE (etc.) doesn't know about AM_CPPFLAGS, and 2) macros update these variables internally. We can easily work around both cases with some creative save/restoring (or alternatively, by updating the macro definition), but I think the benefit isn't worth the complexity, and there are only a few of these cases.