### PR TITLE
issue #1401: Potential fix to the write_to_io_net crash.

### DIFF
--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -436,6 +436,11 @@ write_to_net_io(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
   NetState *s       = &vc->write;
   ProxyMutex *mutex = thread->mutex.get();
 
+  if (!s->vio.mutex) {
+    ink_release_assert(s->vio._cont == NULL && vc->write.error);
+    return;
+  }
+
   MUTEX_TRY_LOCK_FOR(lock, s->vio.mutex, thread, s->vio._cont);
 
   if (!lock.is_locked() || lock.get_mutex() != s->vio.mutex.get()) {


### PR DESCRIPTION
Not a super satisfying solution.  Without this change, ats 7.1 would crash immediately in our production environment.  With this patch, we run for a few minutes before hitting the next issue.