### PR TITLE
Cleans up ICC options, and some build issues

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -779,24 +779,10 @@ AS_IF([test "x${has_optimizer_flags}" = "xno"],
 case $host_os_def in
   linux)
     AS_IF([test "x$ax_cv_c_compiler_vendor" = "xintel"], [
-      # -Wall goes crazy, so turned these specific checks off for now:
+      # -Wall is overzealous for us, so need to turn this off for now:
       #
-      #  111 is "statement is unreachable"
-      #  279 is "controlling expression is constant", triggered by our asserts
-      #  383 is "value copied to temporary, reference to temporary used"
-      #  444 is "destructor for base class is not virtual"
-      #  522 is "function "xyz" redeclared "inline" after being called
-      #  873 is "has no corresponding operator delete". ToDo: we should fix.
-      #  981 is "operands are evaluated in unspecified order"
-      # 1418 is "external function definition with no prior declaration"
-      # 1419 is "external declaration in primary source file"
-      # 1572 is "floating-point equality and inequality comparisons are unreliable"
-      # 1720 is "operator new" has no corresponding member operator delete"
-      # 2256 is "non-pointer conversion from "int" to "unsigned char" "
-      # 2259 is "non-pointer conversion from "int" to "unsigned char" "
-      #
-      # TODO: We should try to eliminate more of these -wd exclusions.
-      common_opt="-pipe -Wall -wd111 -wd279 -wd383 -wd522 -wd444 -wd873 -wd981 -wd1418 -wd1419 -wd1572 -wd1720 -wd2256 -wd2259"
+      #  #873 is "has no corresponding operator delete"
+      common_opt="-pipe -Wall -wd873"
       debug_opt="-ggdb3 $common_opt"
       release_opt="-g $common_opt $optimization_flags -axsse4.2 -fno-strict-aliasing"
       cxx_opt="-Wno-invalid-offsetof"
@@ -1333,7 +1319,7 @@ TS_TRY_COMPILE_NO_WARNING([],[
     has_128bit_cas=1
   ], [
     dnl If 128bit CAS fails, try again with the -mcx16 option. GCC needs this;
-    dnl clang doesn't; icc is unknown but presumed sane.
+    dnl clang doesn't; icc does not support -mcx16 (but gives a non-fatal warning).
     TS_ADDTO(CXXFLAGS, [-mcx16])
     TS_ADDTO(CFLAGS, [-mcx16])
     TS_TRY_COMPILE_NO_WARNING([],[
@@ -1353,8 +1339,10 @@ AC_LANG_POP
 AC_SUBST(has_128bit_cas)
 
 AS_IF([test "x$has_128bit_cas" = "x1"], [
-  TS_ADDTO(CFLAGS, [-mcx16])
-  TS_ADDTO(CXXFLAGS, [-mcx16])
+  AS_IF([test "x$ax_cv_c_compiler_vendor" != "xintel"], [
+    TS_ADDTO(CFLAGS, [-mcx16])
+    TS_ADDTO(CXXFLAGS, [-mcx16])
+  ])
 ])
 
 # Check for POSIX capabilities library.

--- a/iocore/eventsystem/P_IOBuffer.h
+++ b/iocore/eventsystem/P_IOBuffer.h
@@ -682,7 +682,8 @@ IOBufferReader::consume(int64_t n)
 
 TS_INLINE char &IOBufferReader::operator[](int64_t i)
 {
-  IOBufferBlock *b = block.get();
+  static char default_ret = '\0'; // This is just to avoid compiler warnings...
+  IOBufferBlock *b        = block.get();
 
   i += start_offset;
   while (b) {
@@ -694,6 +695,8 @@ TS_INLINE char &IOBufferReader::operator[](int64_t i)
   }
 
   ink_release_assert(!"out of range");
+  // Never used, just to satisfy compilers not undersatnding the fatality of ink_release_assert().
+  return default_ret;
 }
 
 TS_INLINE void

--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -260,7 +260,7 @@ class NetVConnection : public VConnection
 public:
   // How many bytes have been queued to the OS for sending by haven't been sent yet
   // Not all platforms support this, and if they don't we'll return -1 for them
-  virtual const int64_t
+  virtual int64_t
   outstanding()
   {
     return -1;

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -103,7 +103,7 @@ enum tcp_congestion_control_t { CLIENT_SIDE, SERVER_SIDE };
 class UnixNetVConnection : public NetVConnection
 {
 public:
-  virtual const int64_t outstanding();
+  virtual int64_t outstanding();
   virtual VIO *do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf);
   virtual VIO *do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool owner = false);
 

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -656,7 +656,7 @@ UnixNetVConnection::get_data(int id, void *data)
   }
 }
 
-const int64_t
+int64_t
 UnixNetVConnection::outstanding()
 {
   int n;

--- a/lib/ts/PriorityQueue.h
+++ b/lib/ts/PriorityQueue.h
@@ -47,7 +47,7 @@ template <typename T, class Comp = PriorityQueueLess<T>> class PriorityQueue
 public:
   PriorityQueue() {}
   ~PriorityQueue() {}
-  const bool empty();
+  bool empty();
   PriorityQueueEntry<T> *top();
   void pop();
   void push(PriorityQueueEntry<T> *);
@@ -72,7 +72,7 @@ PriorityQueue<T, Comp>::dump() const
 }
 
 template <typename T, typename Comp>
-const bool
+bool
 PriorityQueue<T, Comp>::empty()
 {
   return _v.length() == 0;

--- a/lib/ts/signals.cc
+++ b/lib/ts/signals.cc
@@ -46,7 +46,7 @@ signal_check_handler(int signal, signal_handler_t handler)
     sigact = (void *)oact.sa_sigaction;
   }
 
-  if (sigact != handler) {
+  if (sigact != (void *)handler) {
     Warning("handler for signal %d was %p, not %p as expected", signal, sigact, handler);
     return false;
   }

--- a/plugins/experimental/balancer/hash.cc
+++ b/plugins/experimental/balancer/hash.cc
@@ -43,6 +43,8 @@ sockaddrlen(const struct sockaddr *sa)
   default:
     TSReleaseAssert(0 && "unsupported socket type");
   }
+
+  return 0;
 }
 
 struct md5_key {

--- a/plugins/header_rewrite/condition.h
+++ b/plugins/header_rewrite/condition.h
@@ -101,7 +101,7 @@ public:
     return _matcher;
   }
 
-  const MatcherOps
+  MatcherOps
   get_cond_op() const
   {
     return _cond_op;

--- a/plugins/header_rewrite/operator.cc
+++ b/plugins/header_rewrite/operator.cc
@@ -23,7 +23,7 @@
 #include "ts/ts.h"
 #include "operator.h"
 
-const OperModifiers
+OperModifiers
 Operator::get_oper_modifiers() const
 {
   if (_next) {

--- a/plugins/header_rewrite/operator.h
+++ b/plugins/header_rewrite/operator.h
@@ -45,7 +45,7 @@ class Operator : public Statement
 {
 public:
   Operator() : _mods(OPER_NONE) { TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for Operator"); }
-  const OperModifiers get_oper_modifiers() const;
+  OperModifiers get_oper_modifiers() const;
   virtual void initialize(Parser &p);
 
   void

--- a/plugins/header_rewrite/ruleset.h
+++ b/plugins/header_rewrite/ruleset.h
@@ -68,13 +68,13 @@ public:
     _hook = hook;
   }
 
-  const TSHttpHookID
+  TSHttpHookID
   get_hook() const
   {
     return _hook;
   }
 
-  const ResourceIDs
+  ResourceIDs
   get_all_resource_ids() const
   {
     return _ids;

--- a/plugins/header_rewrite/statement.cc
+++ b/plugins/header_rewrite/statement.cc
@@ -33,7 +33,7 @@ Statement::append(Statement *stmt)
   tmp->_next = stmt;
 }
 
-const ResourceIDs
+ResourceIDs
 Statement::get_resource_ids() const
 {
   const Statement *stmt = this;

--- a/plugins/header_rewrite/statement.h
+++ b/plugins/header_rewrite/statement.h
@@ -108,7 +108,7 @@ public:
 
   // Which hook are we adding this statement to?
   bool set_hook(TSHttpHookID hook);
-  const TSHttpHookID
+  TSHttpHookID
   get_hook() const
   {
     return _hook;
@@ -124,7 +124,7 @@ public:
   // Linked list.
   void append(Statement *stmt);
 
-  const ResourceIDs get_resource_ids() const;
+  ResourceIDs get_resource_ids() const;
 
   virtual void
   initialize(Parser &)

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -9246,7 +9246,7 @@ TSUuidInitialize(TSUuid uuid, TSUuidVersion v)
   return u->valid() ? TS_SUCCESS : TS_ERROR;
 }
 
-const TSUuid
+TSUuid
 TSProcessUuidGet(void)
 {
   Machine *machine = Machine::instance();

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -2412,7 +2412,7 @@ tsapi TSReturnCode TSUuidStringParse(TSUuid uuid, const char *uuid_str);
 tsapi TSReturnCode TSClientRequestUuidGet(TSHttpTxn txnp, char *uuid_str);
 
 /* Get the process global UUID, resets on every startup */
-tsapi const TSUuid TSProcessUuidGet(void);
+tsapi TSUuid TSProcessUuidGet(void);
 
 /**
    Returns the plugin_tag.

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -117,13 +117,13 @@ public:
     bytes_sent += num_bytes;
   }
 
-  const Http2StreamId
+  Http2StreamId
   get_id() const
   {
     return _id;
   }
 
-  const Http2StreamState
+  Http2StreamState
   get_state() const
   {
     return _state;


### PR DESCRIPTION
This removes a number of the previous warning exclusions that we
we used to do. We then also have to clean up the core code in a
few places, sometimes looking slightly odd (e.g. the meaningless
const that we have in a few places).