### PR TITLE
Set nullptr to ua_session after it is destoryed

### DIFF
--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -107,6 +107,12 @@ public:
     return this->api_hooks.has_hooks() || http_global_hooks->has_hooks();
   }
 
+  bool
+  is_active() const
+  {
+    return m_active;
+  }
+
   // Initiate an API hook invocation.
   void do_api_callout(TSHttpHookID id);
 


### PR DESCRIPTION
Issue:
Crash by EXC_BAD_ACCESS in Http2ConnectionState::release_stream() under heavy load

Cause:
While total_connections_in is larger than max_connections_per_thread_in (in NetHandler::manage_keep_alive_queue()),
Http2ConnectionState::release_stream() is called recurcively from add_to_keep_alive_queue().
At the bottom of recursion, ua_session is destroyed and Http2ConnectionState::release_stream() access to it.

Fix:
1. Set nullptr to ua_session after it is destoryed
2. Swap calls of add_to_keep_alive_queue() and cancel_active_timeout() for ua_session nullptr check
3. Check m_active of ua_session to reduce recursion