### PR TITLE
Add TCP accept metric which tracks the total number of TCP connections accepted.

### DIFF
--- a/doc/admin-guide/monitoring/statistics/core/network-io.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/network-io.en.rst
@@ -75,3 +75,9 @@ Network I/O
    :type: counter
    :unit: bytes
 
+.. ts:stat:: global proxy.process.tcp.total_accepts integer
+   :type: counter
+
+   The total number of times a TCP connection was accepted on a proxy port. This may differ from the
+   total of other network connection counters. For example if a user agent connects via TLS but
+   sends a malformed ``CLIENT_HELLO`` this will count as a TCP connect but not an SSL connect.

--- a/iocore/net/Net.cc
+++ b/iocore/net/Net.cc
@@ -108,6 +108,10 @@ register_net_stats()
   NET_CLEAR_DYN_STAT(keep_alive_queue_timeout_total_stat);
   NET_CLEAR_DYN_STAT(keep_alive_queue_timeout_count_stat);
   NET_CLEAR_DYN_STAT(default_inactivity_timeout_stat);
+
+  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.tcp.total_accepts", RECD_INT, RECP_NON_PERSISTENT,
+                     static_cast<int>(net_tcp_accept_stat), RecRawStatSyncSum);
+  NET_CLEAR_DYN_STAT(net_tcp_accept_stat);
 }
 
 void

--- a/iocore/net/P_Net.h
+++ b/iocore/net/P_Net.h
@@ -55,6 +55,7 @@ enum Net_Stats {
   default_inactivity_timeout_stat,
   net_fastopen_attempts_stat,
   net_fastopen_successes_stat,
+  net_tcp_accept_stat,
   Net_Stat_Count
 };
 

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -75,6 +75,7 @@ net_accept(NetAccept *na, void *ep, bool blockable)
       count = res;
       goto Ldone;
     }
+    NET_SUM_GLOBAL_DYN_STAT(net_tcp_accept_stat, 1);
 
     vc = static_cast<UnixNetVConnection *>(na->getNetProcessor()->allocate_vc(e->ethread));
     if (!vc)
@@ -269,6 +270,7 @@ NetAccept::do_blocking_accept(EThread *t)
     }
 
     NET_SUM_GLOBAL_DYN_STAT(net_connections_currently_open_stat, 1);
+    NET_SUM_GLOBAL_DYN_STAT(net_tcp_accept_stat, 1);
     vc->id = net_next_connection_number();
     vc->con.move(con);
     vc->submit_time = now;
@@ -356,6 +358,7 @@ NetAccept::acceptFastEvent(int event, void *ep)
 
     if (likely(fd >= 0)) {
       Debug("iocore_net", "accepted a new socket: %d", fd);
+      NET_SUM_GLOBAL_DYN_STAT(net_tcp_accept_stat, 1);
       if (opt.send_bufsize > 0) {
         if (unlikely(socketManager.set_sndbuf_size(fd, opt.send_bufsize))) {
           bufsz = ROUNDUP(opt.send_bufsize, 1024);


### PR DESCRIPTION
`proxy.process.net.tcp.accept`

This is useful to track the rate of inbound connections accepted. This can be compared to transactions, open connections, or other OS network metrics to better identify performance issues.