### PR TITLE
fix TS-4195: crash when stop trafficserver

### DIFF
--- a/iocore/eventsystem/I_EThread.h
+++ b/iocore/eventsystem/I_EThread.h
@@ -53,7 +53,7 @@ enum ThreadType {
   DEDICATED,
 };
 
-extern bool shutdown_event_system;
+extern volatile bool shutdown_event_system;
 
 /**
   Event System specific type of thread.

--- a/iocore/eventsystem/UnixEThread.cc
+++ b/iocore/eventsystem/UnixEThread.cc
@@ -39,7 +39,7 @@ struct AIOCallback;
 #define THREAD_MAX_HEARTBEAT_MSECONDS 60
 #define NO_ETHREAD_ID -1
 
-bool shutdown_event_system = false;
+volatile bool shutdown_event_system = false;
 
 EThread::EThread()
   : generator((uint64_t)Thread::get_hrtime_updated() ^ (uint64_t)(uintptr_t)this),

--- a/lib/ts/signals.cc
+++ b/lib/ts/signals.cc
@@ -162,13 +162,7 @@ signal_format_siginfo(int signo, siginfo_t *info, const char *msg)
   (void)info;
   (void)signo;
 
-#if HAVE_PSIGINFO
-  psiginfo(info, const_cast<char *>(msg));
-#elif HAVE_PSIGNAL
-  psignal(signo, msg);
-#else
   char buf[64];
-  size_t len;
 
 #if HAVE_STRSIGNAL
   snprintf(buf, sizeof(buf), "%s: received signal %d (%s)\n", msg, signo, strsignal(signo));
@@ -177,7 +171,6 @@ signal_format_siginfo(int signo, siginfo_t *info, const char *msg)
 #endif
 
   write(STDERR_FILENO, buf, strlen(buf));
-#endif
 }
 
 void

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -460,7 +460,7 @@ proxy_signal_handler(int signo, siginfo_t *info, void *ctx)
   shutdown_event_system = true;
   sleep(1);
 
-  ::exit(signo);
+  ::_exit(signo);
 }
 
 //


### PR DESCRIPTION
Because of `psiginfo`, `psignal` and `exit`, which call `malloc` and `free` inside `proxy_signal_handler`. ATS will crash from time to time when stop.

> A signal handler can be called at any time, including during times when another call to malloc is in progress. If this happens, one of two things will occur:
> 
> Your process will deadlock inside the signal handler, because malloc will be unable to acquire the heap lock.
> Your process will corrupt its heap, because malloc does acquire the lock (or doesn't think it needs it), then proceeds to render the heap inconsistent, leading to a later crash.

From [here](http://stackoverflow.com/questions/3366307/why-is-malloc-not-async-signal-safe)

Tested with a script repeating starting and stopping ATS on RHEL 6.6, the current master crashes after about 2~10 times. This patch doesn't crash after 6k+ tries.