### PR TITLE
Allow overriding proxy.config.config_dir.

### DIFF
--- a/lib/records/RecCore.cc
+++ b/lib/records/RecCore.cc
@@ -204,19 +204,18 @@ RecCoreInit(RecModeT mode_type, Diags *_diags)
   if (!g_records_ht) {
     return REC_ERR_FAIL;
   }
+
   // read stats
   if ((mode_type == RECM_SERVER) || (mode_type == RECM_STAND_ALONE)) {
     RecReadStatsFile();
   }
+
   // read configs
   if ((mode_type == RECM_SERVER) || (mode_type == RECM_STAND_ALONE)) {
+    bool file_exists = true;
+
     ink_mutex_init(&g_rec_config_lock, nullptr);
-    // Import the file into memory; try the following in this order:
-    // ./etc/trafficserver/records.config.shadow
-    // ./records.config.shadow
-    // ./etc/trafficserver/records.config
-    // ./records.config
-    bool file_exists   = true;
+
     g_rec_config_fpath = RecConfigReadConfigPath(nullptr, REC_CONFIG_FILE REC_SHADOW_EXT);
     if (RecFileExists(g_rec_config_fpath) == REC_ERR_FAIL) {
       ats_free((char *)g_rec_config_fpath);
@@ -226,6 +225,7 @@ RecCoreInit(RecModeT mode_type, Diags *_diags)
         file_exists = false;
       }
     }
+
     if (file_exists) {
       RecReadConfigFile(true);
     }
@@ -1120,16 +1120,21 @@ REC_readString(const char *name, bool *found, bool lock)
   return _tmp;
 }
 
-//-------------------------------------------------------------------------
-// RecConfigReadConfigDir
-//-------------------------------------------------------------------------
+// RecConfigReadConfigDir. Note that we handle environmental configuration
+// overrides specially here. Normally we would override the configuration
+// variable when we read records.config but to avoid the bootstrapping
+// problem, we make an explicit check here.
 char *
 RecConfigReadConfigDir()
 {
-  char buf[PATH_NAME_MAX];
+  char buf[PATH_NAME_MAX] = {0};
 
-  buf[0] = '\0';
-  RecGetRecordString("proxy.config.config_dir", buf, PATH_NAME_MAX);
+  if (const char *env = getenv("PROXY_CONFIG_CONFIG_DIR")) {
+    ink_strlcpy(buf, env, sizeof(buf));
+  } else {
+    RecGetRecordString("proxy.config.config_dir", buf, sizeof(buf));
+  }
+
   if (strlen(buf) > 0) {
     return Layout::get()->relative(buf);
   } else {

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -207,7 +207,7 @@ static const ArgumentDescription argument_descriptions[] = {
   {"command", 'C', "Maintenance Command to Execute\n"
                    "      Commands: list, check, clear, clear_cache, clear_hostdb, verify_config, help",
    "S511", &command_string, "PROXY_COMMAND_STRING", nullptr},
-  {"conf_dir", 'D', "config dir to verify", "S511", &conf_dir, "PROXY_SYS_CONFIG_DIR", nullptr},
+  {"conf_dir", 'D', "config dir to verify", "S511", &conf_dir, "PROXY_CONFIG_CONFIG_DIR", nullptr},
   {"clear_hostdb", 'k', "Clear HostDB on Startup", "F", &auto_clear_hostdb_flag, "PROXY_CLEAR_HOSTDB", nullptr},
   {"clear_cache", 'K', "Clear Cache on Startup", "F", &cacheProcessor.auto_clear_flag, "PROXY_CLEAR_CACHE", nullptr},
   {"bind_stdout", '-', "Regular file to bind stdout to", "S512", &bind_stdout, "PROXY_BIND_STDOUT", nullptr},

--- a/proxy/http/HttpBodyFactory.cc
+++ b/proxy/http/HttpBodyFactory.cc
@@ -299,16 +299,12 @@ HttpBodyFactory::reconfigure()
   all_found                 = all_found && (rec_err == REC_ERR_OKAY);
   Debug("body_factory", "response_suppression_mode = %d (found = %" PRId64 ")", response_suppression_mode, e);
 
-  ats_scoped_str directory_of_template_sets;
+  ats_scoped_str directory_of_template_sets(RecConfigReadConfigPath("proxy.config.body_factory.template_sets_dir", "body_factory"));
 
-  rec_err   = RecGetRecordString_Xmalloc("proxy.config.body_factory.template_sets_dir", &s);
-  all_found = all_found && (rec_err == REC_ERR_OKAY);
-  if (rec_err == REC_ERR_OKAY) {
-    directory_of_template_sets = Layout::get()->relative(s);
-    if (access(directory_of_template_sets, R_OK) < 0) {
-      Warning("Unable to access() directory '%s': %d, %s", (const char *)directory_of_template_sets, errno, strerror(errno));
-      Warning(" Please set 'proxy.config.body_factory.template_sets_dir' ");
-    }
+  directory_of_template_sets = Layout::get()->relative(s);
+  if (access(directory_of_template_sets, R_OK) < 0) {
+    Warning("Unable to access() directory '%s': %d, %s", (const char *)directory_of_template_sets, errno, strerror(errno));
+    Warning(" Please set 'proxy.config.body_factory.template_sets_dir' ");
   }
 
   Debug("body_factory", "directory_of_template_sets = '%s' (found = %s)", (const char *)directory_of_template_sets, s);


### PR DESCRIPTION
Explicitly check whether proxy.config.config_dir has been overridden in
the environment before trying to load any configuration files.

This fixes #1425.