### PR TITLE
is_transparent_passthrough_allowed always returns false

### DIFF
--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -174,6 +174,12 @@ public:
     return "http";
   }
 
+  virtual bool
+  is_transparent_passthrough_allowed() const
+  {
+    return f_transparent_passthrough;
+  }
+
 private:
   Http1ClientSession(Http1ClientSession &);
 


### PR DESCRIPTION
In the "parent" class "ProxyClientSession.h" the function "is_transparent_passthrough_allowed()" always return false (hard-coded). The inherited class "Http1ClientSession.h" contains internal variable "f_transparent_passthrough" but doesn't implement the "is_transparent_passthrough_allowed()" function to return this its value.
My commit, just implement the function in the inherited class.