### PR TITLE
This allows old ssl_multicert.config to still function on reload

### DIFF
--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -2007,7 +2007,10 @@ SSLParseCertificateConfiguration(const SSLConfigParams *params, SSLCertLookup *l
         if (ssl_extract_certificate(&line_info, sslMultiCertSettings)) {
           // There must be a certificate specified unless the tunnel action is set
           if (sslMultiCertSettings.cert || sslMultiCertSettings.opt != SSLCertContext::OPT_TUNNEL) {
-            ssl_store_ssl_context(params, lookup, &sslMultiCertSettings);
+            if (ssl_store_ssl_context(params, lookup, &sslMultiCertSettings) == nullptr) {
+              Error("failed to load SSL server contexts");
+              return false;
+            }
           } else {
             Warning("No ssl_cert_name specified and no tunnel action set");
           }


### PR DESCRIPTION
The problem is that if a certificate fails to load, for whatever reason that might be, ATS still switches the configuration, leaving the server in a crippled state. This patch fixes this, to the normal behavior of ATS retaining the old configurations if the new fails to load.