### PR TITLE
Allow configure option: --enable-system-luajit

### DIFF
--- a/cmd/traffic_manager/Makefile.am
+++ b/cmd/traffic_manager/Makefile.am
@@ -28,8 +28,12 @@ AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/mgmt/api/include \
   -I$(abs_top_srcdir)/mgmt/cluster \
   -I$(abs_top_srcdir)/mgmt/utils \
-  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib
+
+if BUILD_LUAJIT
+AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/lib/luajit/src
+endif
 
 AM_LDFLAGS += \
   @OPENSSL_LDFLAGS@
@@ -59,8 +63,17 @@ traffic_manager_SOURCES += \
   metrics.cc
 
 traffic_manager_LDADD += \
-  $(top_builddir)/lib/bindings/libbindings.la \
+  $(top_builddir)/lib/bindings/libbindings.la
+
+if BUILD_LUAJIT
+traffic_manager_LDADD += \
   $(top_builddir)/lib/luajit/src/libluajit.a
+endif
+
+if SYSTEM_LUAJIT
+traffic_manager_LDADD +=\
+  @LIBLUAJIT@
+endif
 
 traffic_manager_LDADD +=\
   $(LIBUNWIND_LIBS) \

--- a/configure.ac
+++ b/configure.ac
@@ -307,6 +307,19 @@ AC_ARG_WITH([profiler],
 )
 AC_MSG_RESULT([$with_profiler])
 
+# System luajit
+AC_MSG_CHECKING([whether to enable system luajit])
+AC_ARG_ENABLE([system-luajit],
+  [AS_HELP_STRING([--enable-system-luajit],[enable support for system-installed luajit])],
+  [enable_system_luajit=yes],
+  [enable_system_luajit=no]
+)
+AC_MSG_RESULT([$enable_system_luajit])
+TS_ARG_ENABLE_VAR([has],[system_luajit])
+AM_CONDITIONAL([BUILD_LUAJIT], [test 0 -eq $has_system_luajit])
+AM_CONDITIONAL([SYSTEM_LUAJIT], [test 0 -ne $has_system_luajit])
+
+
 # Disable all static library builds
 AC_DISABLE_STATIC
 
@@ -1152,6 +1165,21 @@ TS_CHECK_ZLIB
 #
 # Check for lzma presence and usability
 TS_CHECK_LZMA
+
+#
+# System LuaJIT
+#
+
+if test "x$enable_system_luajit" == "xyes"; then
+    saveLIBS=$LIBS
+    LIBS=""
+    AC_CHECK_HEADER(lua.h, ,
+                    [AC_MSG_ERROR([*** system luajit requested and lua.h not found ***])])
+    AC_CHECK_LIB(luajit-5.1, luaL_newstate, [],
+                 [AC_MSG_ERROR([*** system luajit requested and libluajit-5.1 not found ***])])
+    AC_SUBST([LIBLUAJIT], [$LIBS])
+    LIBS=$saveLIBS
+fi
 
 #
 # Tcl macros provided by build/tcl.m4

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -26,6 +26,12 @@ if BUILD_WCCP
 SUBDIRS += wccp
 endif
 
+LOCAL =
+
+if BUILD_LUAJIT
+LOCAL += all-luajit
+endif
+
 # Support verbose LuaJIT builds with "make V=1".
 luajit__v_ = $(luajit__v_$(AM_DEFAULT_VERBOSITY))
 luajit__v_0 = @
@@ -39,7 +45,9 @@ luajit__v_1 =
 # Note: The LUAJIT_LDFLAGS is a bit of a hack, since LuaJIT on OmniOS needs
 #       the -m64 flag. See configure.ac.
 #
-all-local:
+all-local:	$(LOCAL)
+
+all-luajit:
 	@echo "Making all in luajit"
 	test -d "$(top_builddir)/$(subdir)/luajit/src" || cp -rf "$(srcdir)/luajit" "$(top_builddir)/$(subdir)/"
 	cd luajit && $(MAKE) $(AM_MAKEFLAGS) \

--- a/proxy/Makefile.am
+++ b/proxy/Makefile.am
@@ -205,8 +205,14 @@ traffic_server_LDADD = \
   $(top_builddir)/iocore/cache/libinkcache.a \
   $(top_builddir)/iocore/aio/libinkaio.a \
   $(top_builddir)/lib/ts/libtsutil.la \
-  $(top_builddir)/lib/bindings/libbindings.la \
-  $(top_builddir)/lib/luajit/src/libluajit.a \
+  $(top_builddir)/lib/bindings/libbindings.la
+
+if BUILD_LUAJIT
+traffic_server_LDADD += \
+  $(top_builddir)/lib/luajit/src/libluajit.a
+endif
+
+traffic_server_LDADD += \
   $(top_builddir)/iocore/net/libinknet.a \
   $(top_builddir)/iocore/eventsystem/libinkevent.a \
   $(top_builddir)/lib/records/librecords_p.a \
@@ -221,7 +227,13 @@ traffic_server_LDADD = \
   @OPENSSL_LIBS@ \
   -lm
 
+if BUILD_LUAJIT
 traffic_server_LDADD += $(LUAJIT:%=$(top_builddir)/lib/luajit/src/%)
+endif
+
+if SYSTEM_LUAJIT
+traffic_server_LDADD += @LIBLUAJIT@
+endif
 
 traffic_logcat_SOURCES = logcat.cc
 traffic_logcat_LDADD = \
@@ -232,10 +244,20 @@ traffic_logcat_LDADD = \
   $(top_builddir)/lib/records/librecords_p.a \
   $(top_builddir)/iocore/eventsystem/libinkevent.a \
   $(top_builddir)/lib/ts/libtsutil.la \
-  $(top_builddir)/lib/bindings/libbindings.la \
-  $(top_builddir)/lib/luajit/src/libluajit.a \
+  $(top_builddir)/lib/bindings/libbindings.la
+
+if BUILD_LUAJIT
+traffic_logcat_LDADD += \
+  $(top_builddir)/lib/luajit/src/libluajit.a
+endif
+
+traffic_logcat_LDADD += \
   @LIBTCL@ @HWLOC_LIBS@\
   @LIBPROFILER@ -lm
+
+if SYSTEM_LUAJIT
+traffic_logcat_LDADD += @LIBLUAJIT@
+endif
 
 traffic_logstats_SOURCES = logstats.cc
 traffic_logstats_LDADD = \
@@ -246,10 +268,20 @@ traffic_logstats_LDADD = \
   $(top_builddir)/lib/records/librecords_p.a \
   $(top_builddir)/iocore/eventsystem/libinkevent.a \
   $(top_builddir)/lib/ts/libtsutil.la \
-  $(top_builddir)/lib/bindings/libbindings.la \
-  $(top_builddir)/lib/luajit/src/libluajit.a \
+  $(top_builddir)/lib/bindings/libbindings.la
+
+if BUILD_LUAJIT
+traffic_logstats_LDADD += \
+  $(top_builddir)/lib/luajit/src/libluajit.a
+endif
+
+traffic_logstats_LDADD += \
   @LIBTCL@ @HWLOC_LIBS@ \
   @LIBPROFILER@ -lm
+
+if SYSTEM_LUAJIT
+traffic_logstats_LDADD += @LIBLUAJIT@
+endif
 
 versiondir = $(pkgsysconfdir)
 

--- a/proxy/logging/Makefile.am
+++ b/proxy/logging/Makefile.am
@@ -21,7 +21,6 @@ include $(top_srcdir)/build/tidy.mk
 AM_CPPFLAGS += \
   $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib \
-  -I$(abs_top_srcdir)/lib/luajit/src \
   -I$(abs_top_srcdir)/lib/records \
   -I$(abs_top_srcdir)/proxy \
   -I$(abs_top_srcdir)/proxy/http \
@@ -30,6 +29,11 @@ AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/proxy/shared \
   -I$(abs_top_srcdir)/mgmt \
   -I$(abs_top_srcdir)/mgmt/utils
+
+if BUILD_LUAJIT
+AM_CPPFLAGS += \
+  -I$(abs_top_srcdir)/lib/luajit/src
+endif
 
 EXTRA_DIST = LogStandalone.cc
 


### PR DESCRIPTION
This option will elide the internal libluajit build and use
a system installed one assuming that it can be found based
on appropriate LDFLAGS and CPPFLAGS when configuring.  The
default remains unchanged: use the in-tree libluajit.