### PR TITLE
Doc: change .svg to .png.

### DIFF
--- a/doc/developer-guide/plugins/hooks-and-transactions/trafficserver-timers.en.rst
+++ b/doc/developer-guide/plugins/hooks-and-transactions/trafficserver-timers.en.rst
@@ -29,7 +29,7 @@ picture illustrates the specific timers run at various states in the current imp
 The picture only depicts the HTTP transaction level timers and does not include the TLS handshake
 states and other more detailed/internal timers in each individual state.
 
-.. figure:: ../../../static/images/admin/transaction_states_timers.svg
+.. figure:: ../../../static/images/admin/transaction_states_timers.png
    :align: center
    :alt: Transaction Timers in various states
 


### PR DESCRIPTION
There is a bug with .svg images - https://github.com/sphinx-doc/sphinx/issues/3266
If we use .svg then we also need to require Sphinx 1.5.1.