### PR TITLE
Doc: Cleanup for build errors.

### DIFF
--- a/doc/admin-guide/storage/index.en.rst
+++ b/doc/admin-guide/storage/index.en.rst
@@ -185,8 +185,7 @@ Partitioning the Cache
 You can manage your cache space more efficiently and restrict disk usage
 by creating :term:`cache volumes <cache volume>` with different sizes for
 specific protocols. You can further configure these volumes to store data from
-specific :term:`origin servers <origin server>` and/or domains. The volume
-configuration must be the same on all nodes in a :ref:`cluster <traffic-server-cluster>`.
+specific :term:`origin servers <origin server>` and/or domains.
 
 Creating Cache Partitions for Specific Protocols
 ------------------------------------------------

--- a/doc/developer-guide/api/functions/TSTypes.en.rst
+++ b/doc/developer-guide/api/functions/TSTypes.en.rst
@@ -16,6 +16,10 @@
 
 .. include:: ../../../common.defs
 
+.. Many types are here simply to avoid build errors in the documentation. It is reasonable to,
+   when providing additional documentation on the type, to move it from here to a more appropriate
+   file.
+
 .. default-domain:: c
 
 TSAPI Types
@@ -145,3 +149,15 @@ more widely. Those are described on this page.
 .. type:: TSVConn
 
 .. type:: TSVIO
+
+.. type:: ModuleVersion
+
+    A module version.
+    
+.. cpp:type:: ModuleVersion
+
+    A module version.
+    
+.. cpp:class:: template<typename T> DLL
+
+    An anchor for a double linked instrusive list of instance of :arg:`T`.

--- a/doc/developer-guide/api/functions/TSUrlStringGet.en.rst
+++ b/doc/developer-guide/api/functions/TSUrlStringGet.en.rst
@@ -30,6 +30,7 @@ Synopsis
 `#include <ts/ts.h>`
 
 .. function:: char * TSUrlStringGet(TSMBuffer bufp, TSMLoc offset, int * length)
+.. function:: char * TSHttpEffectiveUrlStringGet(TSHttpTxn txn, int * length)
 .. function:: int TSUrlLengthGet(TSMBuffer bufp, TSMLoc offset)
 .. function:: void TSUrlPrint(TSMBuffer bufp, TSMLoc offset, TSIOBuffer iobufp)
 
@@ -49,6 +50,15 @@ parameter :arg:`length`. This is the same length that :func:`TSUrlLengthGet`
 returns. The returned string is allocated by a call to :func:`TSmalloc` and
 must be freed by a call to :func:`TSfree`. If length is :literal:`NULL` then no
 attempt is made to de-reference it.
+
+:func:`TSHttpEffectiveUrlStringGet` is similar to :func:`TSUrlStringGet`. The two differences are
+
+*  The source is transaction :arg:`txn` in order to have access to the full request.
+*  It combines, if needed, both the explicit url and the ``Host`` field. This is
+   done if the explicit URL does not have a host and the ``Host`` field does.
+
+This function is useful to guarantee a URL that is as complete as possible given
+the specific request.
 
 :func:`TSUrlLengthGet` calculates the length of the URL located at
 :arg:`offset` within the marshal buffer bufp as if it were returned as a

--- a/doc/developer-guide/architecture/architecture.en.rst
+++ b/doc/developer-guide/architecture/architecture.en.rst
@@ -17,6 +17,8 @@
 
 .. include:: ../../common.defs
 
+.. default-domain:: cpp
+
 .. _developer-cache-architecture:
 
 Cache Architecture
@@ -990,7 +992,7 @@ is put in to the aggregation buffer.
 
 When no more cache virtual connections can be processed (due to an empty queue
 or the aggregation buffer filling) then :cpp:member:`Vol::evac_range` is called
-to clear the range to be overwritten plus an additional :const:`EVACUATION_SIZE`
+to clear the range to be overwritten plus an additional :c:macro:`EVACUATION_SIZE`
 range. The buckets covering that range are checked. If there are any items in
 the buckets a new cache virtual connection (a *doc evacuator*) is created and
 used to read the evacuation item closest to the write cursor (i.e. with the
@@ -1085,7 +1087,7 @@ ID to internal linked lists attached to the :cpp:member:`Store::disk`
 array[#store-disk-array]_. Spans that refer to the same directory, disk, or raw
 device are coalesced in to a single span. Spans that refer to the same file
 with overlapping offsets are also coalesced [#coalesced-spans]_. This is all done in
-:c:func:`ink_cache_init()` called during startup.
+:func:`ink_cache_init` called during startup.
 
 .. note::
 
@@ -1101,7 +1103,7 @@ blocking operations on the span. The primary use of these is to be passed to
 the AIO threads as the callback when an I/O operation completes. These are then
 dispatched to AIO threads to perform :term:`storage unit` initialization. After
 all of those have completed, the resulting storage is distributed across the
-:term:`volumes <cache volume>` in :c:func:`cplist_reconfigure`. The
+:term:`volumes <cache volume>` in :func:`cplist_reconfigure`. The
 :cpp:class:`CacheVol` instances are created at this time.
 
 :term:`Cache stripe <cache stripe>` assignment setup is done once all stripes
@@ -1123,7 +1125,7 @@ only those stripes marked as default are placed in the generic record.
    If hosting records are specified, it is an error to not specify at least one
    default cache volume.
 
-The assignment table is initialized in :c:func:`build_vol_hash_table` which is
+The assignment table is initialized in :func:`build_vol_hash_table` which is
 called for each :cpp:class:`CacheHostRecord` instance. For each stripe in the
 host record, a sequence of pseudo-random numbers is generated. This begins with
 the folded hash of the stripe hash identifier, which is the device path followed

--- a/doc/developer-guide/architecture/core-cache-functions.en.rst
+++ b/doc/developer-guide/architecture/core-cache-functions.en.rst
@@ -1,0 +1,104 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+
+.. include:: ../../common.defs
+
+.. _core_cache_functions:
+
+Core Cache
+**********
+
+Core Cache Constants
+====================
+
+.. c:macro:: EVACUATION_SIZE
+
+   The size of the contiguous area to check for evacuation.
+
+Core Cache Types
+================
+
+.. cpp:class:: CacheKey
+
+  The hash value for a cache object. Currently a 128 bit MD5 hash.
+  
+.. cpp:class:: EvacuationBlock
+
+   A range of content to be evacuated.
+
+.. cpp:class:: Vol
+
+   A representation of a :term:`cache stripe`.
+
+   .. cpp:member:: off_t data_blocks
+
+      The number of blocks of storage in the stripe.
+
+   .. cpp:member:: DLL<EvacuationBlock> evacuate
+
+      A list of blocks to evacuate.
+
+   .. cpp:member:: int aggWrite(int event, void * e)
+
+      Schedule the aggregation buffer to be written to disk.
+      
+.. cpp:class:: CacheProcessor
+
+   The singleton cache management object. This handles threads and global initialization for the cache.
+   
+   .. cpp:member:: int start(int n_threads, size_t stacksize)
+   
+      Starts the cache processing threads, :arg:`n_threads` are created each with a stack of size :arg:`stacksize`.
+
+.. cpp:class:: Span
+
+   A representation of a unit of cache storage, a single physical device, file, or directory.
+
+.. cpp:class:: Store
+
+   A representation of a collection of cache storage.
+   
+   .. cpp:member:: Span ** disk
+   
+      List of :cpp:class:`Span` instances that describe the physical storage.
+
+.. cpp:class:: CacheDisk
+
+   A representation of the physical device used for a :cpp:class:`Span`.
+  
+.. cpp:class:: CacheHostRecord
+
+   A record from :file:`hosting.config`.
+
+Core Cache Functions
+====================
+
+.. cpp:function:: int dir_probe(const CacheKey * key, Vol * d, Dir * result, Dir ** last_collision)
+
+  Probe the stripe directory for a candidate directory entry.
+  
+.. cpp:function:: void build_vol_hash_table(CacheHostRecord * r)
+
+   Based on the configuration record :arg:`r`, construct the global stripe assignment table.
+   
+.. cpp:function:: int cplist_reconfigure()
+
+   Rebuild the assignment of stripes to volumes.
+   
+.. cpp:function:: void ink_cache_init(ModuleVersion v)
+
+   Top level cache initialization logic.

--- a/doc/ext/traffic-server.py
+++ b/doc/ext/traffic-server.py
@@ -352,7 +352,7 @@ EXTERNAL_TYPES = set((
     'int8_t', 'int16_t', 'int24_t', 'int32_t', 'int64_t',
     'unsigned', 'unsigned int',
     'off_t', 'size_t', 'time_t',
-    'Event', 'INK_MD5', 'DLL<EvacuationBlock>',
+    'Event', 'INK_MD5',
     'sockaddr'
     ))
 


### PR DESCRIPTION
Added a new file to hold cache internal types to prevent undefined type errors.
Cleaned up some other dangling references, mostly in the cache architecture area.