### PR TITLE
TS-5106: Create ParentRoundRobin object as ParentRecord->selection_strategy for default parent proxy server

### DIFF
--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -501,6 +501,9 @@ ParentRecord::DefaultInit(char *val)
     ats_free(errBuf);
     return false;
   } else {
+    ParentRR_t round_robin = P_NO_ROUND_ROBIN;
+    TSDebug("parent_select", "allocating ParentRoundRobin() lookup strategy.");
+    selection_strategy = new ParentRoundRobin(this, round_robin);
     return true;
   }
 }


### PR DESCRIPTION
(cherry picked from commit 7ffe037845f45497aa9e95919a3a7bc0ca288163)

To fix a bug that related to "proxy.config.socks.default_servers".

This a backport to 6.2.x for TS-5106.