### PR TITLE
Crash at HttpSM::state_request_wait_for_transform_read

### DIFF
--- a/proxy/Transform.cc
+++ b/proxy/Transform.cc
@@ -254,7 +254,7 @@ TransformTerminus::handle_event(int event, void * /* edata ATS_UNUSED */)
 
         if (!m_called_user) {
           m_called_user = 1;
-          m_tvc->m_cont->handleEvent(ev, nullptr);
+          m_tvc->m_cont->handleEvent(ev, &m_read_vio);
         } else {
           ink_assert(m_read_vio._cont != nullptr);
           m_read_vio._cont->handleEvent(ev, &m_read_vio);

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -1186,10 +1186,11 @@ int
 HttpSM::state_request_wait_for_transform_read(int event, void *data)
 {
   STATE_ENTER(&HttpSM::state_request_wait_for_transform_read, event);
-  int64_t size = *((int64_t *)data);
+  int64_t size;
 
   switch (event) {
   case TRANSFORM_READ_READY:
+    size = *((int64_t *)data);
     if (size != INT64_MAX && size >= 0) {
       // We got a content length so update our internal
       //   data as well as fix up the request header


### PR DESCRIPTION
In the function, it is try to get int64_t from 'data':

  int64_t size = *((int64_t)data);

But TransformTerminus::handle_event callback m_tvc->m_cont (HttpSM)
with 'data == nullptr'. ATS will crash at here.

We only get size from data when the event is TRANSFORM_READ_READY, otherwise we do not.