### PR TITLE
heap-use-after-free: Access ua_session after HttpTunnel::chain_abort_all called due to bad post chunked data

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -5741,7 +5741,8 @@ HttpSM::do_setup_post_tunnel(HttpVC_t to_vc_type)
 
   // If we're half closed, we got a FIN from the client. Forward it on to the origin server
   // now that we have the tunnel operational.
-  if (ua_session->get_half_close_flag()) {
+  // HttpTunnel could broken due to bad chunked data and close all vc by chain_abort_all().
+  if (p->handler_state != HTTP_SM_POST_UA_FAIL && ua_session->get_half_close_flag()) {
     p->vc->do_io_shutdown(IO_SHUTDOWN_READ);
   }
 }


### PR DESCRIPTION
with ASAN and disable freelist, make a POST request with bad chunked data to ATS:

```
POST http://172.21.23.24/post_test.php HTTP/1.1
Host: 172.21.23.24
Transfer-Encoding: chunked

c
123456789012
5
1
0


```

save the request to a file named "req.txt" then send it by "nc" command. ASAN report heap-use-after-free.

"nc" send all the request in one "packet" and HttpSM read the request header and post body into ua_entry iobuffer. HttpTunnel.tunnel_run read post body from ua_entry iobuffer and met bad chunked data.

HttpTunnel::chain_abort_all() is called due to bad chunked data, therefore producer(ua_entry) and comsumer is closed by do_io_close() immediately.

The ua_session is closed and freed when returned from HttpTunnel.tunnel_run().
Then ATS do a half-closed check leads a heap-use-after-free error.