### PR TITLE
When SSL connect fails, we return 502 success

### DIFF
--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -1321,7 +1321,7 @@ SSLNetVConnection::sslClientHandShakeEvent(int &err)
 
   case SSL_ERROR_SSL:
   default: {
-    err = errno;
+    err = (errno) ? errno : -ENET_CONNECT_FAILED;
     // FIXME -- This triggers a retry on cases of cert validation errors....
     Debug("ssl", "SSLNetVConnection::sslClientHandShakeEvent, SSL_ERROR_SSL");
     SSL_CLR_ERR_INCR_DYN_STAT(this, ssl_error_ssl, "SSLNetVConnection::sslClientHandShakeEvent, SSL_ERROR_SSL errno=%d", errno);

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -8347,6 +8347,8 @@ HttpTransact::get_error_string(int erno)
     //              when HttpSM.cc::state_origin_server_read_response
     //                 receives an HTTP_EVENT_EOS. (line 1729 in HttpSM.cc,
     //                 version 1.145.2.13.2.57)
+    case ENET_CONNECT_FAILED:
+      return ("connect failed");
     case UNKNOWN_INTERNAL_ERROR:
       return ("internal error - server connection terminated");
     default:


### PR DESCRIPTION
While debugging a failure in origin cert verification, we saw that the response header included

```
HTTP/1.1 502 Success
Date: Mon, 27 Feb 2017 15:18:29 GMT
Connection: keep-alive
```
502 Success seemed peculiar.  Tracked it down to the fact that errno was not set in the SSL_connect failure case.  Added a check to stuff in ENET_CONNECT_FAILED if errno is 0 so we get a reason that is in the ballpark.

