### PR TITLE
Socket fd is not closed while failed to connect in UnixNetVConnection::connectUp()

### DIFF
--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1387,12 +1387,14 @@ UnixNetVConnection::connectUp(EThread *t, int fd)
   if (ep.start(get_PollDescriptor(t), this, EVENTIO_READ | EVENTIO_WRITE) < 0) {
     res = -errno;
     Debug("iocore_net", "connectUp : Failed to add to epoll list : %s", strerror(errno));
+    con.close();
     goto fail;
   }
 
   if (fd == NO_FD) {
     res = con.connect(nullptr, options);
     if (res != 0) {
+      con.close();
       goto fail;
     }
   }


### PR DESCRIPTION
We call free(t) to free UnixNetVConnection while meet an error in connectUp().
But we only do con.close() in close_UnixNetVConnection().

This patch is just fix the socket fd leaks while failed to connect.

And I have a question about the free(t) called by connectUp():

- Can we call free(t) directly?
- or we should call close_UnixNetVConnection() here ?

@zwoop @mlibbey I think this is maybe useful and related to TS-4612. Can you have a try ?