### PR TITLE
Insure that parent health stats are updated properly on a markdown

### DIFF
--- a/proxy/ParentRoundRobin.cc
+++ b/proxy/ParentRoundRobin.cc
@@ -220,7 +220,7 @@ ParentRoundRobin::markParentDown(const ParentSelectionPolicy *policy, ParentResu
     //   it relates to how long the parent has been down.
     now = time(nullptr);
 
-    // Mark the parent as down
+    // Mark the parent failure time.
     ink_atomic_swap(&pRec->failedAt, now);
 
     // If this is clean mark down and not a failed retry, we
@@ -232,7 +232,17 @@ ParentRoundRobin::markParentDown(const ParentSelectionPolicy *policy, ParentResu
     Note("Parent %s marked as down %s:%d", (result->retry) ? "retry" : "initially", pRec->hostname, pRec->port);
 
   } else {
-    int old_count = ink_atomic_increment(&pRec->failCount, 1);
+    int old_count = 0;
+    now           = time(NULL);
+
+    // if the last failure was outside the retry window, set the failcount to 1
+    // and failedAt to now.
+    if ((pRec->failedAt + policy->ParentRetryTime) < now) {
+      ink_atomic_swap(&pRec->failCount, 1);
+      ink_atomic_swap(&pRec->failedAt, now);
+    } else {
+      old_count = ink_atomic_increment(&pRec->failCount, 1);
+    }
 
     Debug("parent_select", "Parent fail count increased to %d for %s:%d", old_count + 1, pRec->hostname, pRec->port);
     new_fail_count = old_count + 1;


### PR DESCRIPTION
Parents may be marked down prematurely because the health stats are not reset when the retry window has elapsed.  This adds a check when a parent is marked down to make sure that the health stats are updated appropriately.