### PR TITLE
rectify a minor error in healthchecks.c

### DIFF
--- a/plugins/healthchecks/healthchecks.c
+++ b/plugins/healthchecks/healthchecks.c
@@ -313,7 +313,7 @@ parse_configs(const char *fname)
   } else {
     char filename[PATH_MAX + 1];
 
-    snprintf(filename, sizeof(filename), "%s/%s", fname, TSConfigDirGet());
+    snprintf(filename, sizeof(filename), "%s/%s", TSConfigDirGet(), fname);
     fd = fopen(filename, "r");
   }
 


### PR DESCRIPTION
line 316:
snprintf(filename, sizeof(filename), "%s/%s", fname, TSConfigDirGet());
should be modified as
snprintf(filename, sizeof(filename), "%s/%s", TSConfigDirGet(), fname);