### PR TITLE
brotli support in gzip plugin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -449,6 +449,12 @@ AC_ARG_WITH([max-threads-per-type],
 )
 AC_SUBST(max_threads_per_type)
 
+# Check Brotli
+AC_CHECK_HEADERS([brotli/encode.h], [has_brotli=1],[has_brotli=0])
+AC_CHECK_LIB([brotlienc],[BrotliEncoderCreateInstance],[AC_SUBST([LIB_BROTLIENC],["-lbrotlienc"])],[has_brotli=0])
+AC_SUBST(has_brotli)
+AM_CONDITIONAL([HAS_BROTLI], [ test "x${has_brotli}" = "x1" ])
+
 #
 # Experimental plugins
 #

--- a/doc/admin-guide/plugins/gzip.en.rst
+++ b/doc/admin-guide/plugins/gzip.en.rst
@@ -141,6 +141,14 @@ will leave the header intact if the client provided it.
 - For when the proxy parses responses, and the resulting compression and
   decompression is wasteful.
 
+supported-algorithms
+----------------------
+
+Provides the compression algorithms that are supported. This will allow the proxy to selectively
+support certain compressions. The default is gzip. Multiple algorthims can be selected using ',' delimiter
+
+-- To selectively support only certain compression algorithms.
+
 Examples
 ========
 
@@ -161,6 +169,22 @@ might create a configuration with the following options::
     remove-accept-encoding true
     disallow /notthis/*.js
     flush true
+
+    # Allows brotli encoded response from origin but is not capable of brotli compression
+    [brotli.allowed.com]
+    enabled true
+    compressible-content-type text/*
+    compressible-content-type application/json
+    flush true
+    supported-algorithms gzip,deflate
+
+    # Supports brotli compression
+    [brotli.compress.com]
+    enabled true
+    compressible-content-type text/*
+    compressible-content-type application/json
+    flush true
+    supported-algorithms br, gzip
 
     # This origin does it all
     [bar.example.com]

--- a/plugins/gzip/Makefile.inc
+++ b/plugins/gzip/Makefile.inc
@@ -16,3 +16,7 @@
 
 pkglib_LTLIBRARIES += gzip/gzip.la
 gzip_gzip_la_SOURCES = gzip/gzip.cc gzip/configuration.cc gzip/misc.cc
+
+gzip_gzip_la_LDFLAGS = \
+  $(AM_LDFLAGS) $(LIB_BROTLIENC)
+

--- a/plugins/gzip/README
+++ b/plugins/gzip/README
@@ -44,6 +44,9 @@ a sample configuration (sample.gzip.config):
 # compressible-content-type: wildcard pattern for matching compressible content types
 #
 # disallow: wildcard pattern for disablign compression on urls
+#
+# supported-algorithms: compression algorithms supported. comma separated algorithms. Default is gzip
+#
 ######################################################################
 
 #first, we configure the default/global plugin behaviour
@@ -59,6 +62,9 @@ compressible-content-type !text/javascript
 disallow /notthis/*.js
 disallow /notthat*
 disallow */bla*
+
+#supported algorithms
+supported-algorithms br,gzip
 
 #override the global configuration for a host.
 #www.foo.nl does NOT inherit anything

--- a/plugins/gzip/configuration.h
+++ b/plugins/gzip/configuration.h
@@ -33,11 +33,24 @@ namespace Gzip
 {
 typedef std::vector<std::string> StringContainer;
 
+enum CompressionAlgorithm {
+  ALGORITHM_DEFAULT = 0,
+  ALGORITHM_DEFLATE = 1,
+  ALGORITHM_GZIP    = 2,
+  ALGORITHM_BROTLI  = 4 // For bit manipulations
+};
+
 class HostConfiguration
 {
 public:
   explicit HostConfiguration(const std::string &host)
-    : host_(host), enabled_(true), cache_(true), remove_accept_encoding_(false), flush_(false), ref_count_(0)
+    : host_(host),
+      enabled_(true),
+      cache_(true),
+      remove_accept_encoding_(false),
+      flush_(false),
+      compression_algorithms_(ALGORITHM_GZIP),
+      ref_count_(0)
   {
   }
 
@@ -96,6 +109,8 @@ public:
   void add_compressible_content_type(const std::string &content_type);
   bool is_url_allowed(const char *url, int url_len);
   bool is_content_type_compressible(const char *content_type, int content_type_length);
+  void add_compression_algorithms(const std::string &algorithms);
+  int compression_algorithms();
 
   // Ref-counting these host configuration objects
   void
@@ -118,6 +133,7 @@ private:
   bool cache_;
   bool remove_accept_encoding_;
   bool flush_;
+  int compression_algorithms_;
   volatile int ref_count_;
 
   StringContainer compressible_content_types_;


### PR DESCRIPTION
The requirements are outlined in
https://github.com/apache/trafficserver/issues/1555

For brotli to work the "proxy.config.http.normalize_ae_gzip" configuration should be set to '0'
Should we control this flag manually or through the gzip plugin?

@bryancall @shukitchan can you review.