### PR TITLE
Fix build by ordering the linked libraries.

### DIFF
--- a/cmd/traffic_crashlog/Makefile.am
+++ b/cmd/traffic_crashlog/Makefile.am
@@ -36,8 +36,8 @@ traffic_crashlog_SOURCES = \
 traffic_crashlog_LDADD = \
   $(top_builddir)/lib/records/librecords_p.a \
   $(top_builddir)/mgmt/libmgmt_p.la \
-  $(top_builddir)/iocore/eventsystem/libinkevent.a \
   $(top_builddir)/proxy/shared/libUglyLogStubs.a \
+  $(top_builddir)/iocore/eventsystem/libinkevent.a \
   $(top_builddir)/mgmt/api/libtsmgmt.la \
   $(top_builddir)/lib/ts/libtsutil.la \
   @LIBTCL@ @HWLOC_LIBS@

--- a/cmd/traffic_layout/Makefile.am
+++ b/cmd/traffic_layout/Makefile.am
@@ -33,8 +33,8 @@ traffic_layout_SOURCES = \
 traffic_layout_LDADD = \
   $(top_builddir)/lib/records/librecords_p.a \
   $(top_builddir)/mgmt/libmgmt_p.la \
-  $(top_builddir)/iocore/eventsystem/libinkevent.a \
   $(top_builddir)/proxy/shared/libUglyLogStubs.a \
+  $(top_builddir)/iocore/eventsystem/libinkevent.a \
   $(top_builddir)/lib/ts/libtsutil.la \
   @LIBTCL@ @HWLOC_LIBS@
 


### PR DESCRIPTION
With wl-asneeded as default and UglyLogStubs using inkevent, linking them in the wrong order
makes the latter stripped by the linker