### PR TITLE
[RFC] Diags scrubbing mechanism

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -2978,7 +2978,7 @@ Diagnostic Logging Configuration
 .. ts:cv:: CONFIG proxy.config.diags.scrubs STRING NULL
 
    Diagnostic log scrubbing is intended an extra security measure to prevent sensitive strings from leaking to
-   diagnistic logs. For example, if you wanted to scrub the regular expression ``string[a-z]`` from diagnostic
+   diagnostic logs. For example, if you wanted to scrub the regular expression ``string[a-z]`` from diagnostic
    logs and replace it with ``XXXXXX``, use as the config string ``string[a-z] -> XXXXXX``. Note that the spaces
    between the ``->`` are required.
 
@@ -2991,8 +2991,8 @@ Diagnostic Logging Configuration
 
 .. note::
 
-   Multiple captures are not supported. (ie. ``s/foo/bar/g`` is not suppored while ``s/foo/bar/`` is). Furthermore,
-   only the longest captured substring will be replaced for each line in the logs.
+   Multiple captures (eg capture groups) are not supported. (ie. ``s/foo/bar/g`` is not supported while ``s/foo/bar/``
+   is). Furthermore, only the longest captured substring will be replaced for each line in the logs.
 
 .. note::
 

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -2991,8 +2991,8 @@ Diagnostic Logging Configuration
 
 .. note::
 
-   Multiple captures (eg capture groups) are not supported. (ie. ``s/foo/bar/g`` is not supported while ``s/foo/bar/``
-   is). Furthermore, only the longest captured substring will be replaced for each line in the logs.
+   Only single capture/replace is supported. (ie. ``s/foo/bar/`` is supported while ``s/foo/bar/g``
+   is not). Furthermore, only the longest captured substring will be replaced for each line in the logs.
 
 .. note::
 

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -2985,6 +2985,9 @@ Diagnostic Logging Configuration
    If you want to scrub multiple regular expressions, use ``;`` to separate the pairs. For example:
    ``string[a-z] -> XXXXXX ; doge$ -> doggy``. Once again, the spaces before and after the ``;`` are required.
 
+   For this config option, diagnostic logs will most usually refer to (unless you've changed the default filenames):
+   ``diags.log``, ``traffic.out``, ``error.log``, & ``manager.log``.
+
 .. note::
 
    Diagnostic log scrubbing supports PCRE format regular expressions.

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -2975,6 +2975,38 @@ Diagnostic Logging Configuration
 
    Specifies at what size to roll the diagnostics log at.
 
+.. ts:cv:: CONFIG proxy.config.diags.scrubs STRING NULL
+
+   Diagnostic log scrubbing is intended an extra security measure to prevent sensitive strings from leaking to
+   diagnistic logs. For example, if you wanted to scrub the regular expression ``string[a-z]`` from diagnostic
+   logs and replace it with ``XXXXXX``, use as the config string ``string[a-z] -> XXXXXX``. Note that the spaces
+   between the ``->`` are required.
+
+   If you want to scrub multiple regular expressions, use ``;`` to separate the pairs. For example:
+   ``string[a-z] -> XXXXXX ; doge$ -> doggy``. Once again, the spaces before and after the ``;`` are required.
+
+.. note::
+
+   Diagnostic log scrubbing supports PCRE format regular expressions.
+
+.. note::
+
+   Multiple captures are not supported. (ie. ``s/foo/bar/g`` is not suppored while ``s/foo/bar/`` is). Furthermore,
+   only the longest captured substring will be replaced for each line in the logs.
+
+.. note::
+
+   If multiple pairs of replacements are supplied, the replacements are performed from leftmost pair to
+   rightmost pair. This means that latter replacements can affect the previously applied replacement strings.
+
+.. example::
+
+   Here are some valid config lines:
+
+      CONFIG proxy.config.diags.scrubs STRING string[a-z] -> XXXXXX
+
+      CONFIG proxy.config.diags.scrubs STRING pizza_party -> PIZZA__PARTY ; wonton.*party -> WONTONPARTY
+
 Reverse Proxy
 =============
 

--- a/lib/ts/Diags.h
+++ b/lib/ts/Diags.h
@@ -46,6 +46,7 @@
 
 #define DIAGS_MAGIC 0x12345678
 #define BYTES_IN_MB 1000000
+#define MAX_LOG_LINE_SIZE (16 * 1024) // 16K
 
 class Diags;
 

--- a/lib/ts/Diags.h
+++ b/lib/ts/Diags.h
@@ -34,16 +34,15 @@
 #ifndef __DIAGS_H___
 #define __DIAGS_H___
 
-#include <vector>
 #include <stdarg.h>
 #include "ink_mutex.h"
-#include "pcre.h"
 #include "Regex.h"
 #include "ink_apidefs.h"
 #include "ContFlags.h"
 #include "ink_inet.h"
 #include "BaseLogFile.h"
 #include "SourceLocation.h"
+#include "Scrubber.h"
 
 #define DIAGS_MAGIC 0x12345678
 #define BYTES_IN_MB 1000000
@@ -92,26 +91,6 @@ struct DiagsConfigState {
   // this is static to eliminate many loads from the critical path
   static bool enabled[2];                    // one debug, one action
   DiagsModeOutput outputs[DiagsLevel_Count]; // where each level prints
-};
-
-struct Scrub {
-  ~Scrub()
-  {
-    if (pattern) {
-      ats_free(const_cast<char *>(pattern));
-    }
-    if (replacement) {
-      ats_free(const_cast<char *>(replacement));
-    }
-    if (compiled_re) {
-      pcre_free(const_cast<pcre *>(compiled_re));
-    }
-  }
-  static const int OVECCOUNT = 30;
-  const char *pattern;
-  const char *replacement;
-  const pcre *compiled_re;
-  int ovector[OVECCOUNT];
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -248,28 +227,11 @@ public:
    * This really shouldn't be called by anyone other than DiagsConfig b/c there's inherent race conditions.
    */
   void
-  scrub_config(bool enable)
+  scrub_config(bool enable, const char *config)
   {
     scrub_enabled = enable;
+    scrubber      = new Scrubber(config);
   }
-  /*
-   * Add another expression to scrub from diagnostic logs.
-   *
-   * This really shouldn't be called by anyone other than DiagsConfig b/c there's inherent race conditions.
-   */
-  void scrub_add(const char *pattern, const char *replacement);
-
-  /*
-   * Heap allocates an identical buffer that is scrubbed.
-   * Caller should ats_free.
-   */
-  char *scrub_buffer(const char *buffer, Scrub *scrub) const;
-
-  /*
-   * Heap allocates an identical buffer that is scrubbed with multiple Scrubs.
-   * Caller should ats_free.
-   */
-  char *scrub_buffer(const char *buffer, const std::vector<Scrub *> &scrubs) const;
 
   const char *base_debug_tags;  // internal copy of default debug tags
   const char *base_action_tags; // internal copy of default action tags
@@ -281,7 +243,7 @@ private:
 
   // Scrubbing variables -- replaces predefined regexp matches with the replacement string
   bool scrub_enabled = false;
-  std::vector<Scrub *> scrubs;
+  Scrubber *scrubber = nullptr;
 
   // These are the default logfile permissions
   int diags_logfile_perm  = -1;

--- a/lib/ts/Makefile.am
+++ b/lib/ts/Makefile.am
@@ -176,6 +176,8 @@ libtsutil_la_SOURCES = \
   Regression.cc \
   Regression.h \
   Result.h \
+  Scrubber.cc \
+  Scrubber.h \
   signals.cc \
   signals.h \
   SimpleTokenizer.h \

--- a/lib/ts/Scrubber.cc
+++ b/lib/ts/Scrubber.cc
@@ -1,0 +1,134 @@
+#include "Scrubber.h"
+#include "MemView.h"
+
+Scrubber::Scrubber(const char *config)
+{
+  bool state_expecting_regex = true;
+  char *regex                = nullptr;
+  char *replacement          = nullptr;
+  const ts::StringView delimiters("->;,", ts::StringView::literal);
+  ts::StringView text(config);
+
+  // Loop over config string while extracting tokens
+  while (text) {
+    ts::StringView token = (text.ltrim(&isspace)).extractPrefix(&isspace);
+    if (token) {
+      // If we hit a delimiter, we change states and skip the token
+      if (!ts::StringView(token).ltrim(delimiters)) {
+        state_expecting_regex = !state_expecting_regex;
+        continue;
+      }
+
+      // Store our current token
+      if (state_expecting_regex) {
+        regex = static_cast<char *>(malloc(token.size() + 1));
+        sprintf(regex, "%.*s", static_cast<int>(token.size()), token.ptr());
+      } else {
+        replacement = static_cast<char *>(malloc(token.size() + 1));
+        sprintf(replacement, "%.*s", static_cast<int>(token.size()), token.ptr());
+      }
+
+      // If we have a pair of (regex, replacement) tokens, we can go ahead and store those values into Diags
+      if (regex && replacement) {
+        scrub_add(regex, replacement);
+        free(regex);
+        free(replacement);
+        regex       = nullptr;
+        replacement = nullptr;
+      }
+    }
+  }
+
+  // This means that there was some kind of config or parse error.
+  // This doesn't catch *all* errors, and is just a heuristic so we can't actually print any meaningful message.
+  if ((regex && !replacement) || (!regex && replacement)) {
+    // Error("Error in scrubbing config parsing. Not enabling scrubbing.");
+  }
+}
+
+Scrubber::Scrubber(Scrubber &other)
+{
+  scrubs = other.scrubs;
+}
+
+bool
+Scrubber::scrub_add(const char *pattern, const char *replacement)
+{
+  pcre *re;
+  const char *error;
+  int erroroffset;
+  Scrub *s;
+
+  // compile the regular expression
+  re = pcre_compile(pattern, 0, &error, &erroroffset, NULL);
+  if (!re) {
+    // Error("Unable to compile PCRE scrubbing pattern");
+    // Error("Scrubbing pattern failed at offset %d: %s.", erroroffset, error);
+    return false;
+  }
+
+  // add the scrub pattern to our list
+  s              = new Scrub;
+  s->pattern     = strdup(pattern);
+  s->replacement = strdup(replacement);
+  s->compiled_re = re;
+  scrubs.push_back(s);
+
+  return true;
+}
+
+char *
+Scrubber::scrub_buffer(const char *buffer) const
+{
+  // apply every Scrub in the vector, in order
+  char *scrubbed = strdup(buffer);
+  for (auto s : scrubs) {
+    char *new_scrubbed = scrub_buffer(scrubbed, s);
+    free(scrubbed);
+    scrubbed = new_scrubbed;
+  }
+  return scrubbed;
+}
+
+char *
+Scrubber::scrub_buffer(const char *buffer, Scrub *scrub) const
+{
+  int num_matched;
+  char *scrubbed;
+  char *scrubbed_idx;
+
+  // execute regex
+  num_matched = pcre_exec(scrub->compiled_re, nullptr, buffer, strlen(buffer), 0, 0, scrub->ovector, scrub->OVECCOUNT);
+  if (num_matched < 0) {
+    switch (num_matched) {
+    case PCRE_ERROR_NOMATCH:
+      return strdup(buffer);
+    default:
+      // Error("PCRE matching error %d\n", num_matched);
+      break;
+    }
+  }
+
+  // guaranteed to be big enough
+  scrubbed     = static_cast<char *>(malloc(strlen(buffer) + strlen(scrub->replacement) + 1));
+  scrubbed_idx = scrubbed;
+
+  // copy over all the stuff before the captured substing
+  memcpy(scrubbed_idx, buffer, scrub->ovector[0]);
+  scrubbed_idx += scrub->ovector[0];
+
+  // copy over the scrubbed stuff
+  int replacement_len = strlen(scrub->replacement);
+  memcpy(scrubbed_idx, scrub->replacement, replacement_len);
+  scrubbed_idx += replacement_len;
+
+  // copy over everything after the scrubbed stuff
+  int trailing_len = strlen(buffer + scrub->ovector[1]);
+  memcpy(scrubbed_idx, buffer + scrub->ovector[1], trailing_len);
+  scrubbed_idx += trailing_len;
+
+  // nul terminate
+  *scrubbed_idx = '\0';
+
+  return scrubbed;
+}

--- a/lib/ts/Scrubber.cc
+++ b/lib/ts/Scrubber.cc
@@ -48,6 +48,10 @@ Scrubber::~Scrubber()
   if (config) {
     ats_free(config);
   }
+
+  for (auto s : scrubs) {
+    delete s;
+  }
 }
 
 bool

--- a/lib/ts/Scrubber.cc
+++ b/lib/ts/Scrubber.cc
@@ -1,3 +1,26 @@
+/** @file
+
+  Implementation for Scrubber.h
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
 #include "Scrubber.h"
 
 Scrubber::Scrubber(const char *config)

--- a/lib/ts/Scrubber.h
+++ b/lib/ts/Scrubber.h
@@ -3,14 +3,16 @@
 #include <stdlib.h>
 #include "pcre.h"
 
+#include "ts/ink_memory.h"
+
 struct Scrub {
   ~Scrub()
   {
     if (pattern) {
-      free(const_cast<char *>(pattern));
+      ats_free(const_cast<char *>(pattern));
     }
     if (replacement) {
-      free(const_cast<char *>(replacement));
+      ats_free(const_cast<char *>(replacement));
     }
     if (compiled_re) {
       pcre_free(const_cast<pcre *>(compiled_re));
@@ -33,7 +35,8 @@ public:
    * Parses config & constructs Scrubber
    */
   Scrubber(const char *config);
-  Scrubber(Scrubber &other);
+  Scrubber(Scrubber &other) : Scrubber(other.config);  // delegate constructor
+  ~Scrubber();
 
   /*
    * Add another expression to scrub for
@@ -55,5 +58,6 @@ private:
    */
   char *scrub_buffer(const char *buffer, Scrub *scrub) const;
 
+  char *config = nullptr;
   std::vector<Scrub *> scrubs;
 };

--- a/lib/ts/Scrubber.h
+++ b/lib/ts/Scrubber.h
@@ -1,0 +1,59 @@
+#pragma once
+#include <vector>
+#include <stdlib.h>
+#include "pcre.h"
+
+struct Scrub {
+  ~Scrub()
+  {
+    if (pattern) {
+      free(const_cast<char *>(pattern));
+    }
+    if (replacement) {
+      free(const_cast<char *>(replacement));
+    }
+    if (compiled_re) {
+      pcre_free(const_cast<pcre *>(compiled_re));
+    }
+  }
+  static const int OVECCOUNT = 30;
+  const char *pattern;
+  const char *replacement;
+  const pcre *compiled_re;
+  int ovector[OVECCOUNT];
+};
+
+/*
+ * Class that helps scrub specific strings from buffers
+ */
+class Scrubber
+{
+public:
+  /*
+   * Parses config & constructs Scrubber
+   */
+  Scrubber(const char *config);
+  Scrubber(Scrubber &other);
+
+  /*
+   * Add another expression to scrub for
+   *
+   * @returns whether or not the addition was successful
+   */
+  bool scrub_add(const char *pattern, const char *replacement);
+
+  /*
+   * Heap allocates an identical buffer that is scrubbed with multiple Scrubs.
+   * Caller should ats_free.
+   */
+  char *scrub_buffer(const char *buffer) const;
+
+private:
+  /*
+   * Heap allocates an identical buffer that is scrubbed.
+   * Caller should ats_free.
+   */
+  char *scrub_buffer(const char *buffer, Scrub *scrub) const;
+
+  std::vector<Scrub *> scrubs;
+};

--- a/lib/ts/Scrubber.h
+++ b/lib/ts/Scrubber.h
@@ -30,6 +30,10 @@
 #include "ts/ink_memory.h"
 #include "ts/MemView.h"
 
+// Used by PCRE library to store match indicies
+// Must be a multiple of 3
+#define OVECCOUNT 30
+
 struct Scrub {
   ~Scrub()
   {
@@ -37,7 +41,6 @@ struct Scrub {
       pcre_free(const_cast<pcre *>(compiled_re));
     }
   }
-  static const int OVECCOUNT = 30;
   ts::StringView pattern;
   ts::StringView replacement;
   const pcre *compiled_re;
@@ -84,6 +87,6 @@ private:
    */
   void scrub_buffer(char *buffer, Scrub *scrub) const;
 
-  char *config = nullptr;
+  ats_scoped_str config;
   std::vector<Scrub *> scrubs;
 };

--- a/lib/ts/Scrubber.h
+++ b/lib/ts/Scrubber.h
@@ -3,23 +3,18 @@
 #include "pcre.h"
 
 #include "ts/ink_memory.h"
+#include "ts/MemView.h"
 
 struct Scrub {
   ~Scrub()
   {
-    if (pattern) {
-      ats_free(const_cast<char *>(pattern));
-    }
-    if (replacement) {
-      ats_free(const_cast<char *>(replacement));
-    }
     if (compiled_re) {
       pcre_free(const_cast<pcre *>(compiled_re));
     }
   }
   static const int OVECCOUNT = 30;
-  const char *pattern;
-  const char *replacement;
+  ts::StringView pattern;
+  ts::StringView replacement;
   const pcre *compiled_re;
   int ovector[OVECCOUNT];
 };
@@ -42,7 +37,7 @@ public:
    *
    * @returns whether or not the addition was successful
    */
-  bool scrub_add(const char *pattern, const char *replacement);
+  bool scrub_add(const ts::StringView pattern, const ts::StringView replacement);
 
   /*
    * Heap allocates an identical buffer that is scrubbed with multiple Scrubs.
@@ -50,6 +45,9 @@ public:
    */
   char *scrub_buffer(const char *buffer) const;
 
+  /*
+   * Config getter. Caller should NOT free
+   */
   char *get_config() { return config; };
 
 private:

--- a/lib/ts/Scrubber.h
+++ b/lib/ts/Scrubber.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <vector>
-#include <stdlib.h>
 #include "pcre.h"
 
 #include "ts/ink_memory.h"
@@ -35,7 +34,7 @@ public:
    * Parses config & constructs Scrubber
    */
   Scrubber(const char *config);
-  Scrubber(Scrubber &other) : Scrubber(other.config);  // delegate constructor
+  Scrubber(Scrubber &other) = delete;
   ~Scrubber();
 
   /*
@@ -50,6 +49,8 @@ public:
    * Caller should ats_free.
    */
   char *scrub_buffer(const char *buffer) const;
+
+  char *get_config() { return config; };
 
 private:
   /*

--- a/lib/ts/Scrubber.h
+++ b/lib/ts/Scrubber.h
@@ -2,6 +2,7 @@
 #include <vector>
 #include "pcre.h"
 
+#include "ts/ink_assert.h"
 #include "ts/ink_memory.h"
 #include "ts/MemView.h"
 
@@ -40,10 +41,9 @@ public:
   bool scrub_add(const ts::StringView pattern, const ts::StringView replacement);
 
   /*
-   * Heap allocates an identical buffer that is scrubbed with multiple Scrubs.
-   * Caller should ats_free.
+   * Scrubs the buffer in place with all the Scrub objects stored in this class.
    */
-  char *scrub_buffer(const char *buffer) const;
+  void scrub_buffer(char *buffer) const;
 
   /*
    * Config getter. Caller should NOT free
@@ -56,10 +56,9 @@ public:
 
 private:
   /*
-   * Heap allocates an identical buffer that is scrubbed.
-   * Caller should ats_free.
+   * Scrubs the buffer in place with the passed in Scrub object
    */
-  char *scrub_buffer(const char *buffer, Scrub *scrub) const;
+  void scrub_buffer(char *buffer, Scrub *scrub) const;
 
   char *config = nullptr;
   std::vector<Scrub *> scrubs;

--- a/lib/ts/Scrubber.h
+++ b/lib/ts/Scrubber.h
@@ -1,3 +1,27 @@
+/** @file
+
+  The Scrubber class helps replace patterns of text inside a buffer with
+  replacement text.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
 #pragma once
 #include <vector>
 #include "pcre.h"

--- a/lib/ts/Scrubber.h
+++ b/lib/ts/Scrubber.h
@@ -48,7 +48,11 @@ public:
   /*
    * Config getter. Caller should NOT free
    */
-  char *get_config() { return config; };
+  char *
+  get_config()
+  {
+    return config;
+  };
 
 private:
   /*

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -235,6 +235,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.diags.logfile.rolling_size_mb", RECD_INT, "10", RECU_DYNAMIC, RR_NULL, RECC_STR, "^0*[1-9][0-9]*$", RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.diags.scrubs", RECD_STRING, nullptr, RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
 
   //##############################################################################
   //#

--- a/proxy/logging/LogObject.cc
+++ b/proxy/logging/LogObject.cc
@@ -125,10 +125,10 @@ LogObject::LogObject(const LogFormat *format, const char *log_dir, const char *b
   SET_FREELIST_POINTER_VERSION(m_log_buffer, b, 0);
 
   // set up scrubbing object
-  char *scrubs = REC_ConfigReadString("proxy.config.diags.scrubs");
-  if (scrubs) {
+  char *conf_scrubs = REC_ConfigReadString("proxy.config.diags.scrubs");
+  if (conf_srubs) {
     scrub_enabled = true;
-    scrubber      = new Scrubber(scrubs);
+    scrubber      = new Scrubber(conf_srubs);
   }
 
   _setup_rolling(rolling_enabled, rolling_interval_sec, rolling_offset_hr, rolling_size_mb);
@@ -594,6 +594,7 @@ LogObject::log(LogAccess *lad, const char *text_entry)
     bytes_needed = m_format->m_field_list.marshal_len(lad);
   } else if (text_entry) {
     if (scrub_enabled) {
+      // we're not leaking memory here since the caller was passing in a const buffer anyways
       text_entry = scrubber->scrub_buffer(text_entry);
     }
     bytes_needed = LogAccess::strlen(text_entry);

--- a/proxy/logging/LogObject.cc
+++ b/proxy/logging/LogObject.cc
@@ -126,9 +126,9 @@ LogObject::LogObject(const LogFormat *format, const char *log_dir, const char *b
 
   // set up scrubbing object
   char *conf_scrubs = REC_ConfigReadString("proxy.config.diags.scrubs");
-  if (conf_srubs) {
+  if (conf_scrubs) {
     scrub_enabled = true;
-    scrubber      = new Scrubber(conf_srubs);
+    scrubber      = new Scrubber(conf_scrubs);
   }
 
   _setup_rolling(rolling_enabled, rolling_interval_sec, rolling_offset_hr, rolling_size_mb);
@@ -167,7 +167,9 @@ LogObject::LogObject(LogObject &rhs)
   }
 
   scrub_enabled = rhs.scrub_enabled;
-  scrubber      = new Scrubber(*(rhs.scrubber));
+  if (scrub_enabled && rhs.scrubber) {
+    scrubber = new Scrubber(rhs.scrubber->get_config());
+  }
 
   // copy gets a fresh log buffer
   //

--- a/proxy/logging/LogObject.cc
+++ b/proxy/logging/LogObject.cc
@@ -596,8 +596,11 @@ LogObject::log(LogAccess *lad, const char *text_entry)
     bytes_needed = m_format->m_field_list.marshal_len(lad);
   } else if (text_entry) {
     if (scrub_enabled) {
-      // we're not leaking memory here since the caller was passing in a const buffer anyways
-      text_entry = scrubber->scrub_buffer(text_entry);
+      char _buf[strlen(text_entry) + 1];
+      strcpy(_buf, text_entry);
+      scrubber->scrub_buffer(_buf);
+      text_entry = _buf;
+      // we didn't leak memory here because the caller gave us a const buffer
     }
     bytes_needed = LogAccess::strlen(text_entry);
   }

--- a/proxy/logging/LogObject.h
+++ b/proxy/logging/LogObject.h
@@ -301,7 +301,7 @@ private:
 
   // scrubbing data -- helps us scrub buffers of sensitive data
   bool scrub_enabled = false;
-  Scrubber *scrubber;
+  Scrubber *scrubber = nullptr;
 
   void generate_filenames(const char *log_dir, const char *basename, LogFileFormat file_format);
   void _setup_rolling(Log::RollingEnabledValues rolling_enabled, int rolling_interval_sec, int rolling_offset_hr,

--- a/proxy/logging/LogObject.h
+++ b/proxy/logging/LogObject.h
@@ -299,6 +299,10 @@ private:
   unsigned m_buffer_manager_idx;
   LogBufferManager *m_buffer_manager;
 
+  // scrubbing data -- helps us scrub buffers of sensitive data
+  bool scrub_enabled = false;
+  Scrubber *scrubber;
+
   void generate_filenames(const char *log_dir, const char *basename, LogFileFormat file_format);
   void _setup_rolling(Log::RollingEnabledValues rolling_enabled, int rolling_interval_sec, int rolling_offset_hr,
                       int rolling_size_mb);

--- a/proxy/shared/DiagsConfig.cc
+++ b/proxy/shared/DiagsConfig.cc
@@ -315,7 +315,7 @@ DiagsConfig::DiagsConfig(const char *prefix_string, const char *filename, const 
   ats_free(output_perm);
 
   // Grab scrubs config
-  char *scrubs = REC_ConfigReadString("proxy.config.diags.scrubs");
+  char *config_scrubs = REC_ConfigReadString("proxy.config.diags.scrubs");
 
   // Set up diags, FILE streams are opened in Diags constructor
   diags_log = new BaseLogFile(diags_logpath);
@@ -325,8 +325,8 @@ DiagsConfig::DiagsConfig(const char *prefix_string, const char *filename, const 
 
   Status("opened %s", diags_logpath);
 
-  if (scrubs) {
-    diags->scrub_config(true, scrubs);
+  if (config_scrubs) {
+    diags->scrub_config(true, config_scrubs);
   }
 
   register_diags_callbacks();

--- a/proxy/shared/DiagsConfig.h
+++ b/proxy/shared/DiagsConfig.h
@@ -37,6 +37,7 @@ struct DiagsConfig {
   ~DiagsConfig();
 
 private:
+  void config_scrubbing(Diags *d, const char *config);
   bool callbacks_established;
   BaseLogFile *diags_log;
 

--- a/proxy/shared/DiagsConfig.h
+++ b/proxy/shared/DiagsConfig.h
@@ -37,7 +37,6 @@ struct DiagsConfig {
   ~DiagsConfig();
 
 private:
-  void config_scrubbing(Diags *d, const char *config);
   bool callbacks_established;
   BaseLogFile *diags_log;
 


### PR DESCRIPTION
This should be the squashed commit message:

Diagnostic log scrubbing is intended an extra security measure to prevent sensitive strings from leaking to diagnostic logs. This is provided via a config option `proxy.config.diags.scrubs`.

For each line that is to be written to diagnostic logs, a regular expression(s) is applied to the line. If there are any matches, the matched substring is replaced with the replacement string.