### PR TITLE
TS-4195: double free on exit

### DIFF
--- a/iocore/eventsystem/I_EThread.h
+++ b/iocore/eventsystem/I_EThread.h
@@ -53,7 +53,7 @@ enum ThreadType {
   DEDICATED,
 };
 
-extern bool shutdown_event_system;
+extern volatile bool shutdown_event_system;
 
 /**
   Event System specific type of thread.

--- a/iocore/eventsystem/UnixEThread.cc
+++ b/iocore/eventsystem/UnixEThread.cc
@@ -39,7 +39,7 @@ struct AIOCallback;
 #define THREAD_MAX_HEARTBEAT_MSECONDS 60
 #define NO_ETHREAD_ID -1
 
-bool shutdown_event_system = false;
+volatile bool shutdown_event_system = false;
 
 EThread::EThread()
   : generator((uint64_t)Thread::get_hrtime_updated() ^ (uint64_t)(uintptr_t)this),

--- a/lib/ts/signals.cc
+++ b/lib/ts/signals.cc
@@ -162,13 +162,7 @@ signal_format_siginfo(int signo, siginfo_t *info, const char *msg)
   (void)info;
   (void)signo;
 
-#if HAVE_PSIGINFO
-  psiginfo(info, const_cast<char *>(msg));
-#elif HAVE_PSIGNAL
-  psignal(signo, msg);
-#else
   char buf[64];
-  size_t len;
 
 #if HAVE_STRSIGNAL
   snprintf(buf, sizeof(buf), "%s: received signal %d (%s)\n", msg, signo, strsignal(signo));
@@ -178,7 +172,6 @@ signal_format_siginfo(int signo, siginfo_t *info, const char *msg)
 
   ssize_t ignored = write(STDERR_FILENO, buf, strlen(buf));
   (void)ignored; // because gcc and glibc are stupid, "(void)write(...)" doesn't suffice.
-#endif
 }
 
 void

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -462,8 +462,6 @@ proxy_signal_handler(int signo, siginfo_t *info, void *ctx)
 
   shutdown_event_system = true;
   sleep(1);
-
-  ::exit(signo);
 }
 
 //


### PR DESCRIPTION
Rework on fixing crash on exit.
The previous commit https://github.com/apache/trafficserver/commit/e0e39fc5026f0f5bcd6c0884adde91bcccab6bf8 is reverted because it affects Asan report generating.

Tried self-pipe trick as @jpeach suggested, it still had a race condition between `return from main()` and `exit()` in the pipe handler. It seems exit is not necessary as we already have `sleep` loop waiting on `shutdown_event_system` before the end of `main()`

We can get the Asan report and get no crash with the current patch.

Thank @jaaju for helping.