### PR TITLE
Reset inactive timeout everytime H2 DATA frames are sent

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -575,7 +575,6 @@ Http2Stream::update_write_request(IOBufferReader *buf_reader, int64_t write_len,
             // As with update_read_request, should be safe to call handler directly here if
             // call_update is true.  Commented out for now while tracking a performance regression
             if (call_update) { // Coming from reenable.  Safe to call the handler directly
-              inactive_timeout_at = Thread::get_hrtime() + inactive_timeout;
               if (write_vio._cont && this->current_reader)
                 write_vio._cont->handleEvent(send_event, &write_vio);
             } else { // Called from do_io_write.  Might still be setting up state.  Send an event to let the dust settle
@@ -605,7 +604,6 @@ Http2Stream::update_write_request(IOBufferReader *buf_reader, int64_t write_len,
       } else {
         send_response_body();
         if (call_update) { // Coming from reenable.  Safe to call the handler directly
-          inactive_timeout_at = Thread::get_hrtime() + inactive_timeout;
           if (write_vio._cont && this->current_reader)
             write_vio._cont->handleEvent(send_event, &write_vio);
         } else { // Called from do_io_write.  Might still be setting up state.  Send an event to let the dust settle
@@ -638,6 +636,7 @@ Http2Stream::send_response_body()
     // Send DATA frames directly
     parent->connection_state.send_data_frames(this);
   }
+  inactive_timeout_at = Thread::get_hrtime() + inactive_timeout;
 }
 
 void


### PR DESCRIPTION
The timer wasn't reset if transmission was resumed by WINDOW_UPDATE frames.