### PR TITLE
Make clear the implicit relationship between configs

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -2639,6 +2639,11 @@ Logging Configuration
 
    The maximum amount of time before data in the buffer is flushed to disk.
 
+.. note::
+
+   The effective lower bound to this config is whatever :ts:cv:`proxy.config.log.periodic_tasks_interval`
+   is set to.
+
 .. ts:cv:: CONFIG proxy.config.log.max_space_mb_for_logs INT 25000
    :units: megabytes
    :reloadable:


### PR DESCRIPTION
`periodic_tasks_interval` is the gatekeeper for all periodic tasks.
Meaning, the implicit lower bound for all other log related periodic
intervals is the value of `periodic_tasks_interval`.