### PR TITLE
Fix a wrong option charactar for access_key

### DIFF
--- a/plugins/s3_auth/s3_auth.cc
+++ b/plugins/s3_auth/s3_auth.cc
@@ -555,7 +555,7 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
     case 'c':
       s3->parse_config(optarg);
       break;
-    case 'k':
+    case 'a':
       s3->set_keyid(optarg);
       break;
     case 's':


### PR DESCRIPTION
The character doesn't match with line 536
```
{const_cast<char *>("access_key"), required_argument, nullptr, 'a'},
```