### PR TITLE
TS-4976: Regularize plugins - protocol

### DIFF
--- a/doc/developer-guide/plugins/new-protocol-plugins.en.rst
+++ b/doc/developer-guide/plugins/new-protocol-plugins.en.rst
@@ -180,10 +180,10 @@ Database event flow, and the thick dashed lines show Cache event flow.
 Notice that this flow of events is independent of the Protocol plugin's
 design (i.e., whether you build **accept** or **transaction** state
 machines). Any plugin that supports network connections uses the net
-vconnection interfaces (``TSNetAccept``, ``TSNetConnect``) and thus
+vconnection interfaces (:c:func:`TSNetAccept`, :c:func:`TSNetConnect`) and thus
 receives events from the Net Processor. Any plugin that performs cache
-lookups or cache writes uses ``TSCacheRead``, ``TSCacheWrite``,
-``TSVConnRead``, and ``TSVConnWrite`` and thus receives events from the
+lookups or cache writes uses :c:func:`TSCacheRead`, :c:func:`TSCacheWrite`,
+:c:func:`TSVConnRead`, and :c:func:`TSVConnWrite` and thus receives events from the
 Cache Processor and Traffic Server event system. Similarly, any plugin
 that does DNS lookups receives events from the Host Database Processor.
 
@@ -269,105 +269,91 @@ The code is contained in the following files:
 
 -  ``Protocol.c`` and ``Protocol.h``
 
--  ``Accept.c`` and ``Accept.h``
-
 -  ``TxnSM.c`` and ``TxnSM.h``
 
 Below is a step-by-step walk-through of the code that processes a
 typical transaction.
 
-1.  The ``TSPluginInit`` function is in the ``Protocol.c`` file. It
-    checks the validity of the ``plugin.config`` entries (there must be
-    two: a client accept port and a server port) and runs an
-    initialization routine, ``init``.
+#. The :c:func:`TSPluginInit` function is in the ``Protocol.c`` file. It
+   checks the validity of the :file:`plugin.config` entries (there must be two: a client accept port
+   and a server port) and runs an initialization routine, ``init``.
 
-2.  The ``init`` function (in ``Protocol.c``) creates the plugin's
-    log file using ``TSTextLogObjectCreate``.
+#. The ``init`` function (in ``Protocol.c``) creates the plugin's
+   log file using :c:func:`TSTextLogObjectCreate`.
 
-3.  The ``init`` function creates the accept state machine using
-    ``AcceptCreate``. The code for ``AcceptCreate`` is in the
-    ``Accept.c`` file.
+#. The ``init`` function creates the accept state machine using
+   ``AcceptCreate``. The code for ``AcceptCreate`` is in the
+   ``Accept.c`` file.
 
-4.  The accept state machine, like the transaction state machine, keeps
-    track of its state with a data structure. This data structure,
-    ``Accept``, is defined in the ``Accept.h`` file. State data in
-    ``AcceptCreate`` is associated with the new accept state machine
-    via ``TSContDataSet``.
+#. The ``init`` function arranges the callback of the accept state
+   machine when there is a network connection by using
+   :c:func:`TSNetAccept`.
 
-5.  The ``init`` function arranges the callback of the accept state
-    machine when there is a network connection by using
-    ``TSNetAccept``.
+#. The handler for the accept state machine is ``accept_handler`` in
+   the ``Protocol.c`` file. When Traffic Server's Net Processor sends :c:macro:`TS_EVENT_NET_ACCEPT`
+   to the accept state machine, ``accept_handler`` creates a transaction state machine (``txn_sm``)
+   by calling ``TxnSMCreate``. Notice that ``accept_event`` creates a mutex for the transaction
+   state machine, since each transaction state machine has its own mutex.
 
-6.  The handler for the accept state machine is ``accept_event`` in
-    the ``Accept.c`` file. When Traffic Server's Net Processor sends
-    ``TS_EVENT_NET_ACCEPT`` to the accept state machine,
-    ``accept_event`` creates a transaction state machine
-    (``txn_sm``) by calling ``TxnSMCreate``. Notice that
-    ``accept_event`` creates a mutex for the transaction state
-    machine, since each transaction state machine has its own mutex.
+#. The ``TxnSMCreate`` function is in the ``TxnSM.c`` file. The
+   first thing it does is initialize the transaction's data, which is of type ``TxnSM`` (as defined
+   in ``TxnSM.h``). Notice that the current handler (``q_current_handler``) is set to
+   ``state_start``.
 
-7.  The ``TxnSMCreate`` function is in the ``TxnSM.c`` file. The
-    first thing it does is initialize the transaction's data, which is
-    of type ``TxnSM`` (as defined in ``TxnSM.h``). Notice that the
-    current handler (``q_current_handler``) is set to
-    ``state_start``.
+#. ``TxnSMCreate`` then creates a transaction state machine using
+   :c:func`TSContCreate`. The handler for the transaction state machine
+   is ``main_handler``, which is in the ``TxnSM.c`` file.
 
-8.  ``TxnSMCreate`` then creates a transaction state machine using
-    ``TSContCreate``. The handler for the transaction state machine
-    is ``main_handler``, which is in the ``TxnSM.c`` file.
+#. When ``accept_event`` receives :c:macro`TS_EVENT_NET_ACCEPT`, it
+   calls the transaction state machine (
+   ``TSContCall (txn_sm, 0, NULL);`` ). The event passed to
+   ``main_handler`` is ``0`` (:c:macro`TS_EVENT_NONE`).
 
-9.  When ``accept_event`` receives ``TS_EVENT_NET_ACCEPT``, it
-    calls the transaction state machine (
-    ``TSContCall (txn_sm, 0, NULL);`` ). The event passed to
-    ``main_handler`` is ``0`` (``TS_EVENT_NONE``).
+#. The first thing ``main_handler`` does is examine the current
+   ``txn_sm`` state by calling :c:func:`TSContDataGet`. The state is
+   ``state_start``.
 
-10. The first thing ``main_handler`` does is examine the current
-    ``txn_sm`` state by calling ``TSContDataGet``. The state is
-    ``state_start``.
+#. ``main_handler`` then invokes the handler for
+   ``state_start`` by using the function pointer
+   ``TxnSMHandler`` (as defined in ``TxnSM.h``).
 
-11. ``main_handler`` then invokes the handler for
-    ``state_start`` by using the function pointer
-    ``TxnSMHandler`` (as defined in ``TxnSM.h``).
+#. The ``state_start`` handler function (in the ``TxnSM.c`` file)
+   is handed an event (at this stage, the event is :c:macro:`TS_EVENT_NET_ACCEPT`) and a client
+   vconnection. ``state_start`` checks to see if this client vconnection is closed; if it is not,
+   then ``state_start`` attempts to read data from the client vconnection into an
+   :c:type:`TSIOBuffer` (``state_start`` is handling the event it receives).
 
-12. The ``state_start`` handler function (in the ``TxnSM.c`` file)
-    is handed an event (at this stage, the event is
-    ``TS_EVENT_NET_ACCEPT``) and a client vconnection.
-    ``state_start`` checks to see if this client vconnection is
-    closed; if it is not, then ``state_start`` attempts to read data
-    from the client vconnection into an ``TSIOBuffer``
-    (``state_start`` is handling the event it receives).
+#. ``state_start`` changes the current handler to
+   ``state_interface_with_client`` (that is, it updates the state of the transaction to the next
+   state).
 
-13. ``state_start`` changes the current handler to
-    ``state_interface_with_client`` (that is, it updates the state
-    of the transaction to the next state).
+#. ``state_start`` initiates a read of the client vconnection
+   (arranges for Traffic Server to send
+   :c:macro:`TS_EVENT_VCONN_READ_READY` events to the TSM) by calling
+   :c:func:`TSVConnRead`.
 
-14. ``state_start`` initiates a read of the client vconnection
-    (arranges for Traffic Server to send
-    ``TS_EVENT_VCONN_READ_READY`` events to the TSM) by calling
-    ``TSVConnRead``.
+#. ``state_interface_with_client`` is activated by the next event
+   from Traffic Server. It checks for errors and examines the read VIO
+   for the read operation initiated by :c:func:`TSVConnRead`.
 
-15. ``state_interface_with_client`` is activated by the next event
-    from Traffic Server. It checks for errors and examines the read VIO
-    for the read operation initiated by ``TSVConnRead``.
+#. If the read VIO is the ``client_read_VIO`` (which we are
+   expecting at this stage in the transaction), then
+   ``state_interface_with_client`` updates the state to
+   ``state_read_request_from_client`` .
 
-16. If the read VIO is the ``client_read_VIO`` (which we are
-    expecting at this stage in the transaction), then
-    ``state_interface_with_client`` updates the state to
-    ``state_read_request_from_client`` .
+#. ``state_read_request_from_client`` handles actual
+   :c:macro:`TS_EVENT_VCONN_READ_READY` events and reads the client request.
 
-17. ``state_read_request_from_client`` handles actual
-    ``TS_EVENT_READ_READY`` events and reads the client request.
+#. ``state_read_request_from_client`` parses the client request.
 
-18. ``state_read_request_from_client`` parses the client request.
+#. ``state_read_request_from_client`` updates the current state to
+   the next state, ``state_handle_cache_lookup`` .
 
-19. ``state_read_request_from_client`` updates the current state to
-    the next state, ``state_handle_cache_lookup`` .
+#. ``state_read_request_from_client`` arranges for Traffic Server
+   to call back the TSM with the next set of events (initiating the
+   cache lookup) by calling :c:func:`TSCacheRead`.
 
-20. ``state_read_request_from_client`` arranges for Traffic Server
-    to call back the TSM with the next set of events (initiating the
-    cache lookup) by calling ``TSCacheRead``.
-
-21. When the ``TSCacheRead`` sends the TSM either
-    ``TS_EVENT_OPEN_READ`` (a cache hit) or
-    ``TS_EVENT_OPEN_READ_FAILED`` (a cache miss),
-    ``main_handler`` calls ``state_handle_cache_lookup``.
+#. When the :c:func:`TSCacheRead` sends the TSM either
+   :c:macro:`TS_EVENT_CACHE_OPEN_READ` (a cache hit) or
+   :c:macro:`TS_EVENT_CACHE_OPEN_READ_FAILED` (a cache miss),
+   ``main_handler`` calls ``state_handle_cache_lookup``.

--- a/example/protocol/Protocol.c
+++ b/example/protocol/Protocol.c
@@ -80,15 +80,15 @@ protocol_init(int accept_port, int server_port ATS_UNUSED)
   int ret_val;
 
   /* create customized log */
-  ret_val = TSTextLogObjectCreate("protocol", TS_LOG_MODE_ADD_TIMESTAMP, &protocol_plugin_log);
+  ret_val = TSTextLogObjectCreate(PLUGIN_NAME, TS_LOG_MODE_ADD_TIMESTAMP, &protocol_plugin_log);
   if (ret_val != TS_SUCCESS) {
-    TSError("[protocol] Failed to create log");
+    TSError("[%s] Failed to create log", PLUGIN_NAME);
   }
 
   /* format of the log entries, for caching_status, 1 for HIT and 0 for MISS */
   ret_val = TSTextLogObjectWrite(protocol_plugin_log, "timestamp filename servername caching_status\n\n");
   if (ret_val != TS_SUCCESS) {
-    TSError("[protocol] Failed to write into log");
+    TSError("[%s] Failed to write into log", PLUGIN_NAME);
   }
 
   contp = TSContCreate(accept_handler, TSMutexCreate());
@@ -107,12 +107,12 @@ TSPluginInit(int argc, const char *argv[])
   char *end;
   int tmp;
 
-  info.plugin_name   = "output-header";
-  info.vendor_name   = "MyCompany";
-  info.support_email = "ts-api-support@MyCompany.com";
+  info.plugin_name   = PLUGIN_NAME;
+  info.vendor_name   = "Apache Software Foundation";
+  info.support_email = "dev@trafficserver.apache.org";
 
   if (TSPluginRegister(&info) != TS_SUCCESS) {
-    TSError("[protocol] Plugin registration failed.");
+    TSError("[%s] Plugin registration failed.", PLUGIN_NAME);
 
     goto error;
   }
@@ -122,33 +122,28 @@ TSPluginInit(int argc, const char *argv[])
   server_port = 4666;
 
   if (argc < 3) {
-    TSDebug("protocol", "Usage: protocol.so accept_port server_port");
-    printf("[protocol_plugin] Usage: protocol.so accept_port server_port\n");
-    printf("[protocol_plugin] Wrong arguments. Using deafult ports.\n");
+    TSDebug(PLUGIN_NAME, "Usage: protocol.so <accept_port> <server_port>. Using default ports accept=%d server=%d", accept_port,
+            server_port);
   } else {
     tmp = strtol(argv[1], &end, 10);
     if (*end == '\0') {
       accept_port = tmp;
-      TSDebug("protocol", "using accept_port %d", accept_port);
-      printf("[protocol_plugin] using accept_port %d\n", accept_port);
+      TSDebug(PLUGIN_NAME, "using accept_port %d", accept_port);
     } else {
-      printf("[protocol_plugin] Wrong argument for accept_port.");
-      printf("Using deafult port %d\n", accept_port);
+      TSError("[%s] Wrong argument for accept_port, using default port %d.", PLUGIN_NAME, accept_port);
     }
 
     tmp = strtol(argv[2], &end, 10);
     if (*end == '\0') {
       server_port = tmp;
-      TSDebug("protocol", "using server_port %d", server_port);
-      printf("[protocol_plugin] using server_port %d\n", server_port);
+      TSDebug(PLUGIN_NAME, "using server_port %d", server_port);
     } else {
-      printf("[protocol_plugin] Wrong argument for server_port.");
-      printf("Using deafult port %d\n", server_port);
+      TSError("[%s] Wrong argument for server_port, using default port %d.", PLUGIN_NAME, server_port);
     }
   }
 
   protocol_init(accept_port, server_port);
 
 error:
-  TSError("[protocol] Plugin not initialized");
+  TSError("[%s] Plugin not initialized", PLUGIN_NAME);
 }

--- a/example/protocol/Protocol.h
+++ b/example/protocol/Protocol.h
@@ -35,6 +35,8 @@
 
 #include <ts/ts.h>
 
+#define PLUGIN_NAME "protocol"
+
 #define MAX_SERVER_NAME_LENGTH 1024
 #define MAX_FILE_NAME_LENGTH 1024
 


### PR DESCRIPTION
Incremental work on #1114.

This also updates the documentation on building a protocol plugin. In addition to changes required by the standardization of the plugin code, other errors were correct. Literal references were converted to links as much as possible.