### PR TITLE
Adding a stat page for HTTP connection count

### DIFF
--- a/proxy/http/HttpConnectionCount.cc
+++ b/proxy/http/HttpConnectionCount.cc
@@ -25,3 +25,54 @@
 
 ConnectionCount ConnectionCount::_connectionCount;
 ConnectionCountQueue ConnectionCountQueue::_connectionCount;
+
+std::string
+ConnectionCount::dumpToJSON()
+{
+  Vec<ConnAddr> keys;
+  ink_mutex_acquire(&_mutex);
+  _hostCount.get_keys(keys);
+  std::ostringstream oss;
+  oss << '{';
+  appendJSONPair(oss, "connectionCountSize", keys.n);
+  oss << ", \"connectionCountList\": [";
+  for (size_t i = 0; i < keys.n; i++) {
+    oss << '{';
+
+    appendJSONPair(oss, "ip", keys[i].getIpStr());
+    oss << ',';
+
+    appendJSONPair(oss, "port", keys[i]._addr.host_order_port());
+    oss << ',';
+
+    appendJSONPair(oss, "hostname_hash", keys[i].getHostnameHashStr());
+    oss << ',';
+
+    appendJSONPair(oss, "connection_count", _hostCount.get(keys[i]));
+    oss << "}";
+
+    if (i < keys.n - 1)
+      oss << ',';
+  }
+  ink_mutex_release(&_mutex);
+  oss << "]}";
+  return oss.str();
+}
+
+struct ShowConnectionCount : public ShowCont {
+  ShowConnectionCount(Continuation *c, HTTPHdr *h) : ShowCont(c, h) { SET_HANDLER(&ShowConnectionCount::showHandler); }
+  int
+  showHandler(int event, Event *e)
+  {
+    CHECK_SHOW(show(ConnectionCount::getInstance()->dumpToJSON().c_str()));
+    return completeJson(event, e);
+  }
+};
+
+Action *
+register_ShowConnectionCount(Continuation *c, HTTPHdr *h)
+{
+  ShowConnectionCount *s = new ShowConnectionCount(c, h);
+  this_ethread()->schedule_imm(s);
+  return &s->action;
+}

--- a/proxy/http/HttpProxyServerMain.cc
+++ b/proxy/http/HttpProxyServerMain.cc
@@ -38,6 +38,7 @@
 #include "P_SSLNextProtocolAccept.h"
 #include "ProtocolProbeSessionAccept.h"
 #include "http2/Http2SessionAccept.h"
+#include "HttpConnectionCount.h"
 
 HttpSessionAccept *plugin_http_accept             = nullptr;
 HttpSessionAccept *plugin_http_transparent_accept = nullptr;
@@ -299,6 +300,9 @@ start_HttpProxyServer()
     init_http_update_test();
   }
 #endif
+
+  // Set up stat page for http connection count
+  statPagesManager.register_http("connection_count", register_ShowConnectionCount);
 
   // Alert plugins that connections will be accepted.
   APIHook *hook = lifecycle_hooks->get(TS_LIFECYCLE_PORTS_READY_HOOK);


### PR DESCRIPTION
Adding a stat page for HTTP connection count.
This is useful to monitor connections between ATS and origin server. The format of the JSON output is as follows:
```
{
	connectionCountSize: 1,
	connectionCountList: [{
		ip: "127.127.127.127",
		port: 8080,
		hostname_hash: "07F5F13EFFBE8CD71C778A67A95AE5XX",
		connection_count: 97
	}]
}
```