### PR TITLE
Fix string compare for protocol tag logic in UnixNetVConnection.

### DIFF
--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -175,33 +175,8 @@ public:
   /////////////////////////////////////////////////////////////////
   UnixNetVConnection();
 
-  int
-  populate_protocol(ts::StringView *results, int n) const override
-  {
-    int retval = 0;
-    if (n > retval) {
-      if (!(results[retval] = options.get_proto_string()).isEmpty())
-        ++retval;
-      if (n > retval) {
-        if (!(results[retval] = options.get_family_string()).isEmpty())
-          ++retval;
-      }
-    }
-    return retval;
-  }
-
-  const char *
-  protocol_contains(ts::StringView tag) const override
-  {
-    ts::StringView retval = options.get_proto_string();
-    if (strncmp(tag.ptr(), retval.ptr(), tag.size()) != 0) {
-      retval = options.get_family_string();
-      if (strncmp(tag.ptr(), retval.ptr(), tag.size()) != 0) {
-        retval.clear();
-      }
-    }
-    return retval.ptr();
-  }
+  int populate_protocol(ts::StringView *results, int n) const override;
+  const char *protocol_contains(ts::StringView tag) const override;
 
 private:
   UnixNetVConnection(const NetVConnection &);

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -1546,13 +1546,13 @@ ts::StringView
 SSLNetVConnection::map_tls_protocol_to_tag(const char *proto_string) const
 {
   // Prefix for the string the SSL library hands back.
-  static const ts::StringView PREFIX("TLSv1");
+  static const ts::StringView PREFIX("TLSv1", ts::StringView::literal);
 
   ts::StringView retval;
   ts::StringView proto(proto_string);
 
-  if (proto.size() >= PREFIX.size() && strncmp(proto.ptr(), PREFIX.ptr(), PREFIX.size()) == 0) {
-    proto += PREFIX.size();
+  if (PREFIX.isNoCasePrefixOf(proto)) {
+    proto += PREFIX.size(); // skip the prefix part.
     if (proto.size() <= 0) {
       retval = IP_PROTO_TAG_TLS_1_0;
     } else if (*proto == '.') {

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1597,3 +1597,31 @@ UnixNetVConnection::remove_from_active_queue()
 {
   nh->remove_from_active_queue(this);
 }
+
+int
+UnixNetVConnection::populate_protocol(ts::StringView *results, int n) const
+{
+  int retval = 0;
+  if (n > retval) {
+    if (!(results[retval] = options.get_proto_string()).isEmpty())
+      ++retval;
+    if (n > retval) {
+      if (!(results[retval] = options.get_family_string()).isEmpty())
+        ++retval;
+    }
+  }
+  return retval;
+}
+
+const char *
+UnixNetVConnection::protocol_contains(ts::StringView tag) const
+{
+  ts::StringView retval = options.get_proto_string();
+  if (!tag.isNoCasePrefixOf(retval)) { // didn't match IP level, check TCP level
+    retval = options.get_family_string();
+    if (!tag.isNoCasePrefixOf(retval)) { // no match here either, return empty.
+      retval.clear();
+    }
+  }
+  return retval.ptr();
+}

--- a/lib/records/RecHttp.cc
+++ b/lib/records/RecHttp.cc
@@ -378,7 +378,7 @@ HttpProxyPort::processOptions(const char *opts)
       this->processSessionProtocolPreference(value);
       sp_set_p = true;
     } else {
-      Warning("Invalid option '%s' in proxy port configuration '%s'", item, opts);
+      Warning("Invalid option '%s' in proxy port descriptor '%s'", item, opts);
     }
   }
 
@@ -386,9 +386,11 @@ HttpProxyPort::processOptions(const char *opts)
 
   if (af_set_p) {
     if (in_ip_set_p && m_family != m_inbound_ip.family()) {
-      Warning(
-        "Invalid port descriptor '%s' - the inbound adddress family [%s] is not the same type as the explicit family value [%s]",
-        opts, ats_ip_family_name(m_inbound_ip.family()).ptr(), ats_ip_family_name(m_family).ptr());
+      ts::StringView iname{ats_ip_family_name(m_inbound_ip.family())};
+      ts::StringView fname{ats_ip_family_name(m_family)};
+      Warning("Invalid port descriptor '%s' - the inbound adddress family [%.*s] is not the same type as the explicit family value "
+              "[%.*s]",
+              opts, static_cast<int>(iname.size()), iname.ptr(), static_cast<int>(fname.size()), fname.ptr());
       zret = false;
     }
   } else if (in_ip_set_p) {

--- a/lib/ts/MemView.h
+++ b/lib/ts/MemView.h
@@ -403,6 +403,16 @@ public:
    */
   bool operator!=(self const &that) const;
 
+  /** Prefix check.
+      @return @c true if @a this is a prefix of @a that.
+  */
+  bool isPrefixOf(self const &that) const;
+
+  /** Case ignoring prefix check.
+      @return @c true if @a this is a prefix of @a that, ignoring case.
+  */
+  bool isNoCasePrefixOf(self const &that) const;
+
   /// Assignment - the view is copied, not the content.
   self &operator=(self const &that);
 
@@ -1308,6 +1318,18 @@ StringView::trim(std::function<bool(char)> const &pred)
 {
   this->ltrim(pred);
   return this->rtrim(pred);
+}
+
+inline bool
+StringView::isPrefixOf(self const &that) const
+{
+  return _size <= that._size && 0 == memcmp(_ptr, that._ptr, _size);
+}
+
+inline bool
+StringView::isNoCasePrefixOf(self const &that) const
+{
+  return _size <= that._size && 0 == strncasecmp(_ptr, that._ptr, _size);
 }
 
 inline int

--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -1030,14 +1030,14 @@ LocalManager::listenForProxy()
 
     // read backlong configuration value and overwrite the default value if found
     bool found;
+    ts::StringView fam{ats_ip_family_name(p.m_family)};
     RecInt backlog = REC_readInteger("proxy.config.net.listen_backlog", &found);
     backlog        = (found && backlog >= 0) ? backlog : ats_tcp_somaxconn();
 
     if ((listen(p.m_fd, backlog)) < 0) {
-      mgmt_fatal(errno, "[LocalManager::listenForProxy] Unable to listen on port: %d (%s)\n", p.m_port,
-                 ats_ip_family_name(p.m_family).ptr());
+      mgmt_fatal(errno, "[LocalManager::listenForProxy] Unable to listen on port: %d (%.*s)\n", p.m_port, fam.size(), fam.ptr());
     }
-    mgmt_log("[LocalManager::listenForProxy] Listening on port: %d (%s)\n", p.m_port, ats_ip_family_name(p.m_family).ptr());
+    mgmt_log("[LocalManager::listenForProxy] Listening on port: %d (%.*s)\n", p.m_port, fam.size(), fam.ptr());
   }
   return;
 }


### PR DESCRIPTION
Switch to using the `StringView` based `strcmp` which handles length issues. The current code is a bit weak on that (it assumes the incoming `tag` is never longer). Make the implementation not inline, it's a bit big for that.