### PR TITLE
The result of TSHttpTxnParentProxySet() maybe overwrite in ParentConfigParams::findParent()

### DIFF
--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -125,6 +125,7 @@ ParentConfigParams::findParent(HttpRequestData *rdata, ParentResult *result)
     result->last_parent  = 0;
 
     Debug("parent_select", "Result for %s was API set parent %s:%d", rdata->get_host(), result->hostname, result->port);
+    return;
   }
 
   tablePtr->Match(rdata, result);


### PR DESCRIPTION
The code next to apiParentExists(rdata)
```
  tablePtr->Match(rdata, result);
```

The result maybe overwrite if the rdata matched with tablePtr.

I could not found a document to describe the TSHttpTxnParentProxySet() in detail.
In my opinion the TSHttpTxnParentProxySet() is the highest priority.
