### PR TITLE
Perform the config reload on ET_TASK threads

### DIFF
--- a/mgmt/ProxyConfig.h
+++ b/mgmt/ProxyConfig.h
@@ -35,6 +35,7 @@
 #include "ts/ink_memory.h"
 #include "ProcessManager.h"
 #include "I_EventSystem.h"
+#include "I_Tasks.h"
 
 class ProxyMutex;
 
@@ -111,7 +112,7 @@ template <typename UpdateClass>
 int
 ConfigScheduleUpdate(Ptr<ProxyMutex> &mutex)
 {
-  eventProcessor.schedule_imm(new ConfigUpdateContinuation<UpdateClass>(mutex), ET_CALL);
+  eventProcessor.schedule_imm(new ConfigUpdateContinuation<UpdateClass>(mutex), ET_TASK);
   return 0;
 }
 


### PR DESCRIPTION
Config reload on a main thread could potentially block the requests on the thread if the reload takes longer time. 