### PR TITLE
Adds a new condition, %{IP:<part>}

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -179,6 +179,8 @@ CLIENT-IP
 Remote IP address, as a string, of the client connection for the current
 transaction.
 
+This condition is *deprecated* as of ATS v7.2.x, please use %{IP:CLIENT} instead.
+
 CLIENT-URL
 ~~~~~~~~~~
 ::
@@ -290,6 +292,35 @@ INCOMING-PORT
 
 TCP port, as a decimal integer, on which the incoming client connection was
 made.
+
+IP
+~~
+::
+
+    cond %{IP:<part>} <operand>
+
+This is one of four possible IPs associated with the transaction, with the
+possible parts being
+::
+
+    %{IP:CLIENT}     Clients IP
+    %{IP:INBOUND}    ATS's server IP the client connected to
+    %{IP:SERVER}     Upstream (next-hop) server IP (typically origin, or parent)
+    %{IP:OUTBOUND}   ATS's outbound IP, that was used to connect upstream (next-hop)
+
+Note that both %{IP:SERVER} and %{IP:OUTBOUND} can be unset, in which case the
+empty string is returned. The common use for this condition is
+actually as a value to an operator, e.g.
+::
+
+   cond %{SEND_RESPONSE_HDR_HOOK}
+     set-header X-Client-IP %{IP:CLIENT}
+     set-header X-Inbound-IP %{IP:INBOUND}
+     set-header X-Server-IP %{IP:SERVER}
+     set-header X-Outbound-IP %{IP:OUTBOUND}
+
+Finally, this new condition replaces the old %{CLIENT-IP} condition, which is
+now properly deprecated. It will be removed as of ATS v8.0.0.
 
 INTERNAL-TRANSACTION
 ~~~~~~~~~~~~~~~~~~~~

--- a/plugins/header_rewrite/conditions.h
+++ b/plugins/header_rewrite/conditions.h
@@ -359,6 +359,24 @@ protected:
   bool eval(const Resources &res);
 };
 
+class ConditionIp : public Condition
+{
+  typedef Matchers<std::string> MatcherType;
+
+public:
+  explicit ConditionIp() : _ip_qual(IP_QUAL_CLIENT) { TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for ConditionIp"); };
+  void initialize(Parser &p);
+  void set_qualifier(const std::string &q);
+  void append_value(std::string &s, const Resources &res);
+
+protected:
+  bool eval(const Resources &res);
+
+private:
+  DISALLOW_COPY_AND_ASSIGN(ConditionIp);
+  IpQualifiers _ip_qual;
+};
+
 class ConditionClientIp : public Condition
 {
   typedef Matchers<std::string> MatcherType;

--- a/plugins/header_rewrite/factory.cc
+++ b/plugins/header_rewrite/factory.cc
@@ -123,7 +123,11 @@ condition_factory(const std::string &cond)
     c = new ConditionInternalTxn();
   } else if (c_name == "INTERNAL-TXN") {
     c = new ConditionInternalTxn();
+  } else if (c_name == "IP") {
+    c = new ConditionIp();
   } else if (c_name == "CLIENT-IP") {
+    TSDebug(PLUGIN_NAME, "\tWARNING: configuration uses deprecated condition, CLIENT-IP()");
+    TSError("warning: CLIENT-IP() is deprecated, use %%{IP:CLIENT} instead");
     c = new ConditionClientIp();
   } else if (c_name == "INCOMING-PORT") {
     c = new ConditionIncomingPort();

--- a/plugins/header_rewrite/lulu.cc
+++ b/plugins/header_rewrite/lulu.cc
@@ -17,6 +17,7 @@
 */
 
 #include <string>
+#include <netinet/in.h>
 
 #include "ts/ts.h"
 #include "lulu.h"
@@ -28,6 +29,14 @@ getIP(sockaddr const *s_sockaddr, char res[INET6_ADDRSTRLEN])
   res[0] = '\0';
 
   if (s_sockaddr == nullptr) {
+    return nullptr;
+  }
+
+  // This is a little kludgy, but the TS APIs that returns sockadd's don't return
+  // nullptr's in general (it seems). Maybe that should be fixed, or maybe we should
+  // export lib/ts/ink_inet.h as C APIs... (according to amc). But without this check,
+  // we get ::1 even when the sockaddr isn't populated (e.g. server addr on a cache hit).
+  if (AF_UNSPEC == s_sockaddr->sa_family) {
     return nullptr;
   }
 

--- a/plugins/header_rewrite/statement.h
+++ b/plugins/header_rewrite/statement.h
@@ -72,6 +72,15 @@ enum IdQualifiers {
   ID_QUAL_UNIQUE,
 };
 
+// IP
+enum IpQualifiers {
+  IP_QUAL_CLIENT,
+  IP_QUAL_INBOUND,
+  // These two might not necessarily get populated, e.g. on a cache hit.
+  IP_QUAL_SERVER,
+  IP_QUAL_OUTBOUND,
+};
+
 class Statement
 {
 public:


### PR DESCRIPTION
This replaces the old %{CLIENT-IP}, and generalizes the access to
all four IP addresses. E.g.

cond %{SEND_RESPONSE_HDR_HOOK}
     set-header X-Client-IP %{IP:CLIENT}
     set-header X-Inbound-IP %{IP:INBOUND}
     set-header X-Server-IP %{IP:SERVER}
     set-header X-Outbound-IP %{IP:OUTBOUND}

In the case of a sockaddr not being populated, e.g. IP:SERVER on
a cache hit, the string is "" (empty).