### PR TITLE
Plugin debugging feature

### DIFF
--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -26,6 +26,7 @@ plugins = \
   blacklist-1.la \
   bnull-transform.la \
   cache-scan.la \
+  debug-plugins.la \
   file-1.la \
   hello.la \
   intercept.la \
@@ -61,6 +62,7 @@ blacklist_0_la_SOURCES = blacklist-0/blacklist-0.c
 blacklist_1_la_SOURCES = blacklist-1/blacklist-1.c
 bnull_transform_la_SOURCES = bnull-transform/bnull-transform.c
 cache_scan_la_SOURCES = cache-scan/cache-scan.cc
+debug_plugins_la_SOURCES = debug-plugins/debug-plugins.cc
 file_1_la_SOURCES = file-1/file-1.c
 hello_la_SOURCES = hello/hello.c
 intercept_la_SOURCES = intercept/intercept.cc

--- a/example/debug-plugins/debug-plugins.cc
+++ b/example/debug-plugins/debug-plugins.cc
@@ -1,0 +1,250 @@
+/** @file
+
+  A brief file description
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+/*
+ * debug-plugins.cc:  Example implementation of http request debug feature.
+ *                    Before and after plugin execution at every hook, logging headers
+ *                    information to a text log file.
+ */
+
+#include <ts/ts.h>
+#include <atscppapi/Headers.h>
+#include <pthread.h>
+#include <string>
+#include <dlfcn.h>
+
+static const char *LOG_FILE_NAME = "plugin_debug";
+static const char *DEBUG_TAG     = "http_plugin_hook";
+
+// Sensitive fields in header will not be logged.
+static bool
+isSensitiveField(const std::string &name)
+{
+  // Todo: black list and white list.
+  return false;
+}
+
+static std::string
+wireHeadersToStr(void *bufp, void *mloc)
+{
+  std::string retVal          = "";
+  atscppapi::Headers *headers = new atscppapi::Headers(bufp, mloc);
+
+  for (atscppapi::Headers::iterator header_iter = headers->begin(); header_iter != headers->end(); ++header_iter) {
+    atscppapi::HeaderField hf = *header_iter;
+    std::string name          = hf.name().str();
+    std::string value         = hf.values(", ");
+
+    retVal += name;
+    retVal += ": ";
+
+    if (isSensitiveField(name)) {
+      retVal += "******";
+    } else {
+      retVal += value;
+    }
+
+    retVal += "\\r\\n";
+  }
+
+  delete headers;
+  return retVal;
+}
+
+static std::string
+getPluginName(const void *addr)
+{
+  Dl_info dl_info;
+  int ret = 0;
+  if ((ret = dladdr(addr, &dl_info)) != 0) {
+    // the whole path of .so file
+    std::string path(dl_info.dli_fname);
+
+    // file name begin index
+    std::size_t first = path.find_last_of("/\\");
+    if (first == std::string::npos) {
+      first = 0;
+    } else {
+      first++;
+    }
+
+    // .so begin index
+    std::size_t end = path.rfind(".so");
+    if (end == std::string::npos) {
+      end = path.length();
+    }
+
+    return path.substr(first, end - first);
+  } else {
+    // we could not get the plugin file name
+    return "unknown";
+  }
+}
+
+static std::string
+createRecord(bool isBeforePlugin, TSHttpTxn txnp, TSHttpHookID id, TSEventFunc funcp, TSCont contp)
+{
+  TSMBuffer bufp;
+  TSMLoc hdr_loc;
+
+  std::string clientRequest  = "";
+  std::string serverRequest  = "";
+  std::string serverResponse = "";
+  std::string clientResponse = "";
+
+  std::string recordJson = "{";
+  recordJson += "\"hook_id\" : \"";
+  recordJson += TSHttpHookNameLookup(id);
+  recordJson += "\"";
+
+  recordJson += ", ";
+  recordJson += "\"plugin_name\" : \"";
+  recordJson += getPluginName((void *)funcp);
+  recordJson += "\"";
+
+  recordJson += ", ";
+  recordJson += "\"tag\" : \"";
+  recordJson += isBeforePlugin ? "beforePlugin" : "afterPlugin";
+  recordJson += "\"";
+
+  if (TSHttpTxnClientReqGet(txnp, &bufp, &hdr_loc) != TS_SUCCESS) {
+    TSDebug(DEBUG_TAG, "couldn't retrieve client request header");
+  } else {
+    TSDebug(DEBUG_TAG, "Retrieve client request header");
+    clientRequest = wireHeadersToStr(bufp, hdr_loc);
+  }
+  recordJson += ", ";
+  recordJson += "\"client_request\" : \"";
+  recordJson += clientRequest;
+  recordJson += "\"";
+
+  if (TSHttpTxnServerReqGet(txnp, &bufp, &hdr_loc) != TS_SUCCESS) {
+    TSDebug(DEBUG_TAG, "couldn't retrieve server request header");
+  } else {
+    TSDebug(DEBUG_TAG, "Retrieve server request header");
+    serverRequest = wireHeadersToStr(bufp, hdr_loc);
+  }
+  recordJson += ", ";
+  recordJson += "\"server_request\" : \"";
+  recordJson += serverRequest;
+  recordJson += "\"";
+
+  if (TSHttpTxnServerRespGet(txnp, &bufp, &hdr_loc) != TS_SUCCESS) {
+    TSDebug(DEBUG_TAG, "couldn't retrieve server response header");
+  } else {
+    TSDebug(DEBUG_TAG, "Retrieve server response header");
+    serverResponse = wireHeadersToStr(bufp, hdr_loc);
+  }
+  recordJson += ", ";
+  recordJson += "\"server_response\" : \"";
+  recordJson += serverResponse;
+  recordJson += "\"";
+
+  if (TSHttpTxnClientRespGet(txnp, &bufp, &hdr_loc) != TS_SUCCESS) {
+    TSDebug(DEBUG_TAG, "couldn't retrieve client response header");
+  } else {
+    TSDebug(DEBUG_TAG, "Retrieve client response header");
+    clientResponse = wireHeadersToStr(bufp, hdr_loc);
+  }
+  recordJson += ", ";
+  recordJson += "\"client_response\" : \"";
+  recordJson += clientResponse;
+  recordJson += "\"";
+
+  recordJson += "}";
+
+  return recordJson;
+}
+
+// Use this TSTextLogObject to write debug messages to log file.
+static TSTextLogObject *txtLogObj_;
+static pthread_once_t txtLogObjIsinitialized = PTHREAD_ONCE_INIT;
+
+// Init txtLogObj_, use pthread_once to make sure it is only executes once.
+static void
+initTxtLogObj()
+{
+  txtLogObj_          = new TSTextLogObject();
+  TSReturnCode result = TSTextLogObjectCreate(LOG_FILE_NAME, 0, txtLogObj_);
+  if (result != TS_SUCCESS) {
+    delete txtLogObj_;
+    txtLogObj_ = NULL;
+    TSDebug(DEBUG_TAG, "initTxtLogObj(): failed to create log object");
+  } else {
+    TSDebug(DEBUG_TAG, "initTxtLogObj(): successfully create log object");
+  }
+}
+
+// Record debug message before and after execution of plugin.
+static void
+record(bool isBeforePlugin, TSHttpTxn txnp, TSHttpHookID id, TSEventFunc funcp, TSCont contp)
+{
+  // init txtLogObj_;
+  (void)pthread_once(&txtLogObjIsinitialized, initTxtLogObj);
+
+  if (txtLogObj_ != NULL) {
+    std::string recordJson = createRecord(isBeforePlugin, txnp, id, funcp, contp);
+    TSTextLogObjectWrite(*txtLogObj_, "%s", recordJson.c_str());
+  }
+}
+
+// Only debug a request specified by a cookie __ts_debug=on.
+// For security reason, only allow request from certain IPs to use debug function.
+static bool
+shouldDebugRequest(const TSHttpTxn txnp)
+{
+  // Todo: check cookie and IPs.
+  return true;
+}
+
+// Function to use before plugin execution.
+extern "C" void
+TSHttpTxnPrePluginHook(TSHttpTxn txnp, TSHttpHookID id, TSEventFunc funcp, TSCont contp)
+{
+  if (shouldDebugRequest(txnp)) {
+    record(true, txnp, id, funcp, contp);
+  }
+}
+
+// Function to use after plugin execution.
+extern "C" void
+TSHttpTxnPostPluginHook(TSHttpTxn txnp, TSHttpHookID id, TSEventFunc funcp, TSCont contp)
+{
+  if (shouldDebugRequest(txnp)) {
+    record(false, txnp, id, funcp, contp);
+  }
+}
+
+extern "C" void
+TSHttpTxnBegin(TSHttpTxn txnp)
+{
+  // Todo: initialize this debug session.
+  TSDebug(DEBUG_TAG, "TSHttpTxnBegin()");
+}
+
+extern "C" void
+TSHttpTxnEnd(TSHttpTxn txnp)
+{
+  // Todo: this debug session expires.
+  TSDebug(DEBUG_TAG, "TSHttpTxnEnd()");
+}

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1389,6 +1389,13 @@ static const RecordElement RecordsConfig[] =
   {RECT_CONFIG, "proxy.config.plugin.load_elevated", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_READ_ONLY}
   ,
 
+  //############
+  //#
+  //# Http transaction plugin hook library path
+  //#
+  //############
+  {RECT_CONFIG, "proxy.config.http.plugin_hook_library_path", RECD_STRING, NULL, RECU_RESTART_TS, RR_NULL, RECC_NULL, NULL, RECA_READ_ONLY}
+  ,
 
   //##############################################################################
   //#

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -100,6 +100,8 @@ extern "C" int plock(int);
 #include <gperftools/heap-profiler.h>
 #endif
 
+#include "HttpPluginHook.h"
+
 //
 // Global Data
 //
@@ -1802,6 +1804,9 @@ main(int /* argc ATS_UNUSED */, const char **argv)
     SSLConfigParams::init_ssl_ctx_cb  = init_ssl_ctx_callback;
     SSLConfigParams::load_ssl_file_cb = load_ssl_file_callback;
     sslNetProcessor.start(getNumSSLThreads(), stacksize);
+
+    // Init http transaction plugin hook
+    initHttpTxnPluginHook();
 
     pmgmt->registerPluginCallbacks(global_config_cbs);
 

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -2385,6 +2385,31 @@ tsapi const char *TSHttpHookNameLookup(TSHttpHookID hook);
 */
 tsapi const char *TSHttpEventNameLookup(TSEvent event);
 
+/**
+ * Declaration of Http transaction Begin/End.
+ * Definitions of the interfaces are in a library whose path is configured in records.config.
+ * TS will initialize two TxnSession function pointers of implementation of the interfaces in the library.
+ * Begin and End transaction execution, TS will call these two hooks respectively.
+ *
+ * @param txnp, current transaction
+ */
+tsapi void TSHttpTxnBegin(TSHttpTxn txnp);
+tsapi void TSHttpTxnEnd(TSHttpTxn txnp);
+
+/**
+ * Declaration of Http transaction plugin hook interfaces.
+ * Definitions of the interfaces are in a library whose path is configured in records.config.
+ * TS will initialize two PluginHook_t function pointers of implementation of the interfaces in the library.
+ * Pre and post plugin execution, TS will call these two hooks respectively.
+ *
+ * @param txnp, current transaction
+ * @param id current hook id
+ * @param funcp the event handle function, use this address to specify the execution plugin
+ * @param contp continuation that is called
+ */
+tsapi void TSHttpTxnPrePluginHook(TSHttpTxn txnp, TSHttpHookID id, TSEventFunc funcp, TSCont contp);
+tsapi void TSHttpTxnPostPluginHook(TSHttpTxn txnp, TSHttpHookID id, TSEventFunc funcp, TSCont contp);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/proxy/config/records.config.default.in
+++ b/proxy/config/records.config.default.in
@@ -203,3 +203,9 @@ CONFIG proxy.config.cluster.cluster_port INT 8086
 CONFIG proxy.config.cluster.rsport INT 8088
 CONFIG proxy.config.cluster.mcport INT 8089
 CONFIG proxy.config.cluster.mc_group_addr STRING 224.0.1.37
+
+##############################################################################
+# Http transaction plugin hook library path
+#
+##############################################################################
+CONFIG proxy.config.http.plugin_hook_library_path STRING NULL

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -1112,6 +1112,10 @@ HttpConfig::startup()
   // Local Manager
   HttpEstablishStaticConfigLongLong(c.synthetic_port, "proxy.config.admin.synthetic_port");
 
+  // http transaction plugin hook
+  HttpEstablishStaticConfigStringAlloc(c.http_plugin_hook_library_path, "proxy.config.http.plugin_hook_library_path");
+  c.http_plugin_hook_library_path_len = -1;
+
   // Cluster time delta gets it own callback since it needs
   //  to use ink_atomic_swap
   c.cluster_time_delta = 0;
@@ -1378,6 +1382,11 @@ HttpConfig::reconfigure()
   params->redirection_host_no_port          = INT_TO_BOOL(m_master.redirection_host_no_port);
   params->oride.number_of_redirections      = m_master.oride.number_of_redirections;
   params->post_copy_size                    = m_master.post_copy_size;
+
+  // Http transaction debug
+  params->http_plugin_hook_library_path = ats_strdup(m_master.http_plugin_hook_library_path);
+  params->http_plugin_hook_library_path_len =
+    (params->http_plugin_hook_library_path) ? strlen(params->http_plugin_hook_library_path) : 0;
 
   // Local Manager
   params->synthetic_port = m_master.synthetic_port;

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -845,6 +845,12 @@ public:
   ////////////////////
   MgmtInt synthetic_port;
 
+  //////////////////////////////
+  // Transaction plugin hook  //
+  //////////////////////////////
+  char *http_plugin_hook_library_path;
+  int http_plugin_hook_library_path_len;
+
 private:
   /////////////////////////////////////
   // operator = and copy constructor //
@@ -984,7 +990,9 @@ inline HttpConfigParams::HttpConfigParams()
     parser_allow_non_http(1),
     max_post_size(0),
     server_session_sharing_pool(TS_SERVER_SESSION_SHARING_POOL_THREAD),
-    synthetic_port(0)
+    synthetic_port(0),
+    http_plugin_hook_library_path(NULL),
+    http_plugin_hook_library_path_len(0)
 {
 }
 

--- a/proxy/http/HttpPluginHook.cc
+++ b/proxy/http/HttpPluginHook.cc
@@ -1,0 +1,125 @@
+/** @file
+
+  A brief file description
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+/****************************************************************************
+
+   HttpPluginHook.cc
+
+   Description:
+       Http transaction debugging interfaces.
+
+
+ ****************************************************************************/
+#include "HttpConfig.h"
+#include "HttpPluginHook.h"
+#include <dlfcn.h>
+#include <cstddef>
+
+TxnSession_t txnBegin       = NULL;
+TxnSession_t txnEnd         = NULL;
+PluginHook_t prePluginHook  = NULL;
+PluginHook_t postPluginHook = NULL;
+static const char *DBG_TAG  = "http_plugin_hook";
+
+void
+initHttpTxnPluginHook()
+{
+  // Get http configuration
+  static HttpConfigParams *httpConfig = HttpConfig::acquire();
+
+  // If user does not configure http plugin hook library path, this feature is disabled.
+  // prePluginHook and postPluginHook will be checked before using.
+  if (!httpConfig->http_plugin_hook_library_path) {
+    Debug(DBG_TAG, "Http transaction plugin hook library path is not specified");
+    return;
+  }
+
+  // Open http plugin hook library
+  void *handle = dlopen(httpConfig->http_plugin_hook_library_path, RTLD_LAZY);
+  if (!handle) {
+    Debug(DBG_TAG, "Cannot open http transaction plugin hook library: %s", dlerror());
+    return;
+  }
+  Debug(DBG_TAG, "Successfully open http transaction plugin hook library");
+
+  // Clear any existing error
+  dlerror();
+
+  // For TSHttpTxnBegin/TSHttpTxnEnd, both are required;
+  // For prePluginHook/postPluginHook, only require one;
+
+  // Set up txnBegin
+  txnBegin                = (TxnSession_t)dlsym(handle, "TSHttpTxnBegin");
+  const char *dlsym_error = dlerror();
+  if (dlsym_error) {
+    txnBegin = NULL;
+    Error(DBG_TAG, "Cannot load symbol 'TSHttpTxnBegin': %s", dlsym_error);
+    // Close library
+    dlclose(handle);
+    return;
+  } else {
+    Debug(DBG_TAG, "Successfully load symbol 'TSHttpTxnBegin'");
+  }
+
+  // Set up txnEnd
+  txnEnd      = (TxnSession_t)dlsym(handle, "TSHttpTxnEnd");
+  dlsym_error = dlerror();
+  if (dlsym_error) {
+    txnEnd = NULL;
+    // Both of txnBegin and txnEnd are required.
+    txnBegin = NULL;
+    // Close library
+    dlclose(handle);
+    Error(DBG_TAG, "Cannot load symbol 'TSHttpTxnEnd': %s", dlsym_error);
+    return;
+  } else {
+    Debug(DBG_TAG, "Successfully load symbol 'TSHttpTxnEnd");
+  }
+
+  // Set up prePluginHook
+  prePluginHook = (PluginHook_t)dlsym(handle, "TSHttpTxnPrePluginHook");
+  dlsym_error   = dlerror();
+  if (dlsym_error) {
+    prePluginHook = NULL;
+    Debug(DBG_TAG, "Cannot load symbol 'TSHttpTxnPrePluginHook': %s", dlsym_error);
+  } else {
+    Debug(DBG_TAG, "Successfully load symbol 'TSHttpTxnPrePluginHook");
+  }
+
+  // Set up postPluginHook
+  postPluginHook = (PluginHook_t)dlsym(handle, "TSHttpTxnPostPluginHook");
+  dlsym_error    = dlerror();
+  if (dlsym_error) {
+    postPluginHook = NULL;
+    Debug(DBG_TAG, "Cannot load symbol 'TSHttpTxnPostPluginHook': %s", dlsym_error);
+  } else {
+    Debug(DBG_TAG, "Successfully load symbol 'TSHttpTxnPostPluginHook");
+  }
+
+  // Neither of the hooks is defined, so close the library.
+  if (!prePluginHook && !postPluginHook) {
+    txnBegin = NULL;
+    txnEnd   = NULL;
+    dlclose(handle);
+  }
+}

--- a/proxy/http/HttpPluginHook.h
+++ b/proxy/http/HttpPluginHook.h
@@ -1,0 +1,55 @@
+/** @file
+
+  A brief file description
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+/****************************************************************************
+
+   HttpPluginHook.h
+
+   Description:
+       Http transaction debugging interfaces.
+
+
+ ****************************************************************************/
+
+#ifndef _HTTP_PLUGIN_HOOK_H
+#define _HTTP_PLUGIN_HOOK_H
+
+#include "ts.h"
+
+// Define transaction session function type.
+typedef void (*TxnSession_t)(TSHttpTxn txnp);
+// Define the plugin hook function type.
+typedef void (*PluginHook_t)(TSHttpTxn txnp, TSHttpHookID id, TSEventFunc funcp, TSCont contp);
+
+// Define two TxnSession functions to be called in init and kill_this function of Http state machine.
+extern TxnSession_t txnBegin;
+extern TxnSession_t txnEnd;
+
+// Define two hook functions to handle before and after plugin execution.
+extern PluginHook_t prePluginHook;
+extern PluginHook_t postPluginHook;
+
+// Initialize the two hook functions based on user provided library.
+extern void initHttpTxnPluginHook();
+
+#endif

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -517,6 +517,10 @@ protected:
   TSHttpHookID cur_hook_id;
   APIHook *cur_hook;
 
+  // Used to remember hook when plugin executes, because this hook
+  // will lose after execution of plugin.
+  APIHook *plugin_hook;
+
   //
   // Continuation time keeper
   int64_t prev_hook_start_time;

--- a/proxy/http/Makefile.am
+++ b/proxy/http/Makefile.am
@@ -55,6 +55,8 @@ libhttp_a_SOURCES = \
   HttpDebugNames.h \
   HttpPages.cc \
   HttpPages.h \
+  HttpPluginHook.h \
+  HttpPluginHook.cc \
   HttpProxyServerMain.cc \
   HttpProxyServerMain.h \
   HttpSM.cc \


### PR DESCRIPTION
  1. Add http plugin hook library path configuration in records.config:
   "CONFIG proxy.config.http.plugin_hook_library_path STRING [path_of_httpdebugger.so]"
  2. Add http debug interfaces in ts.h
  3. Init the four interfaces in Main.cc
  4. Modify Http state machine to call debug interfaces.
  5. Add an example to implement http debug shared library.