### PR TITLE
Assertion in state_read_server_response_header (v7.1.0)

### DIFF
--- a/iocore/net/UnixNet.cc
+++ b/iocore/net/UnixNet.cc
@@ -454,15 +454,20 @@ NetHandler::mainNetEvent(int event, Event *e)
         vc->read.triggered = 1;
         if (get_ev_events(pd, x) & EVENTIO_ERROR) {
           vc->read.error = 1;
+          if (vc->read.enabled) {
+            if (!read_ready_list.in(vc)) {
+                read_ready_list.enqueue(vc);
+            }
+          } else if (vc->write.enabled) {
+            if (!write_ready_list.in(vc)) {
+              write_ready_list.enqueue(vc);
+            }
+          }
         } else {
           vc->read.error = 0;
-        }
-        if (!read_ready_list.in(vc)) {
-          read_ready_list.enqueue(vc);
-        } else if (get_ev_events(pd, x) & EVENTIO_ERROR) {
-          // check for unhandled epoll events that should be handled
-          Debug("iocore_net_main", "Unhandled epoll event on read: 0x%04x read.enabled=%d closed=%d read.netready_queue=%d",
-                get_ev_events(pd, x), vc->read.enabled, vc->closed, read_ready_list.in(vc));
+          if (!read_ready_list.in(vc)) {
+              read_ready_list.enqueue(vc);
+          }
         }
       }
       vc = epd->data.vc;
@@ -470,15 +475,20 @@ NetHandler::mainNetEvent(int event, Event *e)
         vc->write.triggered = 1;
         if (get_ev_events(pd, x) & EVENTIO_ERROR) {
           vc->write.error = 1;
+          if (vc->read.enabled) {
+            if (!read_ready_list.in(vc)) {
+                read_ready_list.enqueue(vc);
+            }
+          } else if (vc->write.enabled) {
+            if (!write_ready_list.in(vc)) {
+              write_ready_list.enqueue(vc);
+            }
+          }
         } else {
           vc->write.error = 0;
-        }
-        if (!write_ready_list.in(vc)) {
-          write_ready_list.enqueue(vc);
-        } else if (get_ev_events(pd, x) & EVENTIO_ERROR) {
-          // check for unhandled epoll events that should be handled
-          Debug("iocore_net_main", "Unhandled epoll event on write: 0x%04x write.enabled=%d closed=%d write.netready_queue=%d",
-                get_ev_events(pd, x), vc->write.enabled, vc->closed, write_ready_list.in(vc));
+          if (!write_ready_list.in(vc)) {
+            write_ready_list.enqueue(vc);
+          }
         }
       } else if (!(get_ev_events(pd, x) & EVENTIO_READ)) {
         Debug("iocore_net_main", "Unhandled epoll event: 0x%04x", get_ev_events(pd, x));


### PR DESCRIPTION
In my opinion, the EPOLLERR always with read.enabled or write.enabled(otherwise, there is no sm could handle this event, we just ignore). So when EPOLLERR happens, we could push the vc into read_ready_list if the read.enabled == 1, otherwise push it into write_ready_list.