### PR TITLE
Uses an enum class for the Mgmt OpType

### DIFF
--- a/mgmt/api/CoreAPIRemote.cc
+++ b/mgmt/api/CoreAPIRemote.cc
@@ -80,7 +80,7 @@ send_and_parse_list(OpType op, LLQ *list)
   Tokenizer tokens(REMOTE_DELIM_STR);
   tok_iter_state i_state;
 
-  MgmtMarshallInt optype = op;
+  OpType optype = op;
   MgmtMarshallInt err;
   MgmtMarshallData reply    = {nullptr, 0};
   MgmtMarshallString strval = nullptr;
@@ -142,7 +142,7 @@ mgmt_record_set(const char *rec_name, const char *rec_val, TSActionNeedT *action
 {
   TSMgmtError ret;
 
-  MgmtMarshallInt optype   = RECORD_SET;
+  OpType optype            = OpType::RECORD_SET;
   MgmtMarshallString name  = const_cast<MgmtMarshallString>(rec_name);
   MgmtMarshallString value = const_cast<MgmtMarshallString>(rec_val);
 
@@ -157,7 +157,7 @@ mgmt_record_set(const char *rec_name, const char *rec_val, TSActionNeedT *action
   *action_need = TS_ACTION_UNDEFINED;
 
   // create and send request
-  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, RECORD_SET, &optype, &name, &value);
+  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::RECORD_SET, &optype, &name, &value);
   if (ret != TS_ERR_OKAY) {
     return ret;
   }
@@ -167,7 +167,7 @@ mgmt_record_set(const char *rec_name, const char *rec_val, TSActionNeedT *action
     return ret;
   }
 
-  ret = recv_mgmt_response(reply.ptr, reply.len, RECORD_SET, &err, &action);
+  ret = recv_mgmt_response(reply.ptr, reply.len, OpType::RECORD_SET, &err, &action);
   ats_free(reply.ptr);
 
   if (ret != TS_ERR_OKAY) {
@@ -298,12 +298,12 @@ TSProxyStateT
 ProxyStateGet()
 {
   TSMgmtError ret;
-  MgmtMarshallInt optype = PROXY_STATE_GET;
+  OpType optype          = OpType::PROXY_STATE_GET;
   MgmtMarshallData reply = {nullptr, 0};
   MgmtMarshallInt err;
   MgmtMarshallInt state;
 
-  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, PROXY_STATE_GET, &optype);
+  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::PROXY_STATE_GET, &optype);
   if (ret != TS_ERR_OKAY) {
     return TS_PROXY_UNDEFINED;
   }
@@ -313,7 +313,7 @@ ProxyStateGet()
     return TS_PROXY_UNDEFINED;
   }
 
-  ret = recv_mgmt_response(reply.ptr, reply.len, PROXY_STATE_GET, &err, &state);
+  ret = recv_mgmt_response(reply.ptr, reply.len, OpType::PROXY_STATE_GET, &err, &state);
   ats_free(reply.ptr);
 
   if (ret != TS_ERR_OKAY || err != TS_ERR_OKAY) {
@@ -327,12 +327,12 @@ TSMgmtError
 ProxyStateSet(TSProxyStateT state, TSCacheClearT clear)
 {
   TSMgmtError ret;
-  MgmtMarshallInt optype = PROXY_STATE_SET;
+  OpType optype          = OpType::PROXY_STATE_SET;
   MgmtMarshallInt pstate = state;
   MgmtMarshallInt pclear = clear;
 
-  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, PROXY_STATE_SET, &optype, &pstate, &pclear);
-  return (ret == TS_ERR_OKAY) ? parse_generic_response(PROXY_STATE_SET, main_socket_fd) : ret;
+  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::PROXY_STATE_SET, &optype, &pstate, &pclear);
+  return (ret == TS_ERR_OKAY) ? parse_generic_response(OpType::PROXY_STATE_SET, main_socket_fd) : ret;
 }
 
 TSMgmtError
@@ -340,13 +340,13 @@ ServerBacktrace(unsigned options, char **trace)
 {
   ink_release_assert(trace != nullptr);
   TSMgmtError ret;
-  MgmtMarshallInt optype = SERVER_BACKTRACE;
   MgmtMarshallInt err;
+  OpType optype             = OpType::SERVER_BACKTRACE;
   MgmtMarshallInt flags     = options;
   MgmtMarshallData reply    = {nullptr, 0};
   MgmtMarshallString strval = nullptr;
 
-  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, SERVER_BACKTRACE, &optype, &flags);
+  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::SERVER_BACKTRACE, &optype, &flags);
   if (ret != TS_ERR_OKAY) {
     goto fail;
   }
@@ -356,7 +356,7 @@ ServerBacktrace(unsigned options, char **trace)
     goto fail;
   }
 
-  ret = recv_mgmt_response(reply.ptr, reply.len, SERVER_BACKTRACE, &err, &strval);
+  ret = recv_mgmt_response(reply.ptr, reply.len, OpType::SERVER_BACKTRACE, &err, &strval);
   if (ret != TS_ERR_OKAY) {
     goto fail;
   }
@@ -380,10 +380,10 @@ TSMgmtError
 Reconfigure()
 {
   TSMgmtError ret;
-  MgmtMarshallInt optype = RECONFIGURE;
+  OpType optype = OpType::RECONFIGURE;
 
-  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, RECONFIGURE, &optype);
-  return (ret == TS_ERR_OKAY) ? parse_generic_response(RECONFIGURE, main_socket_fd) : ret;
+  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::RECONFIGURE, &optype);
+  return (ret == TS_ERR_OKAY) ? parse_generic_response(OpType::RECONFIGURE, main_socket_fd) : ret;
 }
 
 /*-------------------------------------------------------------------------
@@ -399,15 +399,15 @@ TSMgmtError
 Restart(unsigned options)
 {
   TSMgmtError ret;
-  MgmtMarshallInt optype = RESTART;
-  MgmtMarshallInt oval   = options;
+  OpType optype        = OpType::RESTART;
+  MgmtMarshallInt oval = options;
 
-  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, RESTART, &optype, &oval);
+  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::RESTART, &optype, &oval);
   if (ret != TS_ERR_OKAY) {
     return ret;
   }
 
-  ret = parse_generic_response(RESTART, main_socket_fd);
+  ret = parse_generic_response(OpType::RESTART, main_socket_fd);
   if (ret == TS_ERR_OKAY) {
     ret = reconnect_loop(MAX_CONN_TRIES);
   }
@@ -424,12 +424,12 @@ TSMgmtError
 Bounce(unsigned options)
 {
   TSMgmtError ret;
-  MgmtMarshallInt optype = BOUNCE;
-  MgmtMarshallInt oval   = options;
+  OpType optype        = OpType::BOUNCE;
+  MgmtMarshallInt oval = options;
 
-  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, BOUNCE, &optype, &oval);
+  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::BOUNCE, &optype, &oval);
 
-  return (ret == TS_ERR_OKAY) ? parse_generic_response(BOUNCE, main_socket_fd) : ret;
+  return (ret == TS_ERR_OKAY) ? parse_generic_response(OpType::BOUNCE, main_socket_fd) : ret;
 }
 
 /*-------------------------------------------------------------------------
@@ -441,11 +441,11 @@ TSMgmtError
 StorageDeviceCmdOffline(const char *dev)
 {
   TSMgmtError ret;
-  MgmtMarshallInt optype  = STORAGE_DEVICE_CMD_OFFLINE;
+  OpType optype           = OpType::STORAGE_DEVICE_CMD_OFFLINE;
   MgmtMarshallString name = const_cast<MgmtMarshallString>(dev);
 
-  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, STORAGE_DEVICE_CMD_OFFLINE, &optype, &name);
-  return (ret == TS_ERR_OKAY) ? parse_generic_response(STORAGE_DEVICE_CMD_OFFLINE, main_socket_fd) : ret;
+  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::STORAGE_DEVICE_CMD_OFFLINE, &optype, &name);
+  return (ret == TS_ERR_OKAY) ? parse_generic_response(OpType::STORAGE_DEVICE_CMD_OFFLINE, main_socket_fd) : ret;
 }
 
 /*-------------------------------------------------------------------------
@@ -457,12 +457,12 @@ TSMgmtError
 LifecycleMessage(const char *tag, void const *data, size_t data_size)
 {
   TSMgmtError ret;
-  MgmtMarshallInt optype  = LIFECYCLE_MESSAGE;
+  OpType optype           = OpType::LIFECYCLE_MESSAGE;
   MgmtMarshallString mtag = const_cast<MgmtMarshallString>(tag);
   MgmtMarshallData mdata  = {const_cast<void *>(data), data_size};
 
-  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, LIFECYCLE_MESSAGE, &optype, &mtag, &mdata);
-  return (ret == TS_ERR_OKAY) ? parse_generic_response(LIFECYCLE_MESSAGE, main_socket_fd) : ret;
+  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::LIFECYCLE_MESSAGE, &optype, &mtag, &mdata);
+  return (ret == TS_ERR_OKAY) ? parse_generic_response(OpType::LIFECYCLE_MESSAGE, main_socket_fd) : ret;
 }
 
 /***************************************************************************
@@ -567,8 +567,8 @@ mgmt_record_describe_reply(TSConfigRecordDescription *val)
   MgmtMarshallInt checktype;
   MgmtMarshallInt source;
 
-  ret = recv_mgmt_response(reply.ptr, reply.len, RECORD_DESCRIBE_CONFIG, &err, &name, &value, &deflt, &rtype, &rclass, &version,
-                           &rsb, &order, &access, &update, &updatetype, &checktype, &source, &expr);
+  ret = recv_mgmt_response(reply.ptr, reply.len, OpType::RECORD_DESCRIBE_CONFIG, &err, &name, &value, &deflt, &rtype, &rclass,
+                           &version, &rsb, &order, &access, &update, &updatetype, &checktype, &source, &expr);
 
   ats_free(reply.ptr);
 
@@ -611,7 +611,7 @@ TSMgmtError
 MgmtRecordGet(const char *rec_name, TSRecordEle *rec_ele)
 {
   TSMgmtError ret;
-  MgmtMarshallInt optype    = RECORD_GET;
+  OpType optype             = OpType::RECORD_GET;
   MgmtMarshallString record = const_cast<MgmtMarshallString>(rec_name);
 
   if (!rec_name || !rec_ele) {
@@ -619,20 +619,20 @@ MgmtRecordGet(const char *rec_name, TSRecordEle *rec_ele)
   }
 
   // create and send request
-  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, RECORD_GET, &optype, &record);
-  return (ret == TS_ERR_OKAY) ? mgmt_record_get_reply(RECORD_GET, rec_ele) : ret;
+  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::RECORD_GET, &optype, &record);
+  return (ret == TS_ERR_OKAY) ? mgmt_record_get_reply(OpType::RECORD_GET, rec_ele) : ret;
 }
 
 TSMgmtError
 MgmtConfigRecordDescribeMatching(const char *rec_name, unsigned options, TSList rec_vals)
 {
   TSMgmtError ret;
-  MgmtMarshallInt optype    = RECORD_DESCRIBE_CONFIG;
+  OpType optype             = OpType::RECORD_DESCRIBE_CONFIG;
   MgmtMarshallInt flags     = options | RECORD_DESCRIBE_FLAGS_MATCH;
   MgmtMarshallString record = const_cast<MgmtMarshallString>(rec_name);
 
   // create and send request
-  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, RECORD_DESCRIBE_CONFIG, &optype, &record, &flags);
+  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::RECORD_DESCRIBE_CONFIG, &optype, &record, &flags);
   if (ret != TS_ERR_OKAY) {
     return ret;
   }
@@ -673,12 +673,12 @@ TSMgmtError
 MgmtConfigRecordDescribe(const char *rec_name, unsigned options, TSConfigRecordDescription *val)
 {
   TSMgmtError ret;
-  MgmtMarshallInt optype    = RECORD_DESCRIBE_CONFIG;
+  OpType optype             = OpType::RECORD_DESCRIBE_CONFIG;
   MgmtMarshallInt flags     = options & ~RECORD_DESCRIBE_FLAGS_MATCH;
   MgmtMarshallString record = const_cast<MgmtMarshallString>(rec_name);
 
   // create and send request
-  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, RECORD_DESCRIBE_CONFIG, &optype, &record, &flags);
+  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::RECORD_DESCRIBE_CONFIG, &optype, &record, &flags);
   if (ret != TS_ERR_OKAY) {
     return ret;
   }
@@ -692,14 +692,14 @@ MgmtRecordGetMatching(const char *regex, TSList rec_vals)
   TSMgmtError ret;
   TSRecordEle *rec_ele;
 
-  MgmtMarshallInt optype    = RECORD_MATCH_GET;
+  OpType optype             = OpType::RECORD_MATCH_GET;
   MgmtMarshallString record = const_cast<MgmtMarshallString>(regex);
 
   if (!regex || !rec_vals) {
     return TS_ERR_PARAMS;
   }
 
-  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, RECORD_MATCH_GET, &optype, &record);
+  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::RECORD_MATCH_GET, &optype, &record);
   if (ret != TS_ERR_OKAY) {
     return ret;
   }
@@ -708,7 +708,7 @@ MgmtRecordGetMatching(const char *regex, TSList rec_vals)
     rec_ele = TSRecordEleCreate();
 
     // parse the reply to get record value and type
-    ret = mgmt_record_get_reply(RECORD_MATCH_GET, rec_ele);
+    ret = mgmt_record_get_reply(OpType::RECORD_MATCH_GET, rec_ele);
     if (ret != TS_ERR_OKAY) {
       TSRecordEleDestroy(rec_ele);
       goto fail;
@@ -833,8 +833,8 @@ TSMgmtError
 ReadFile(TSFileNameT file, char **text, int *size, int *version)
 {
   TSMgmtError ret;
-  MgmtMarshallInt optype = FILE_READ;
-  MgmtMarshallInt fid    = file;
+  OpType optype       = OpType::FILE_READ;
+  MgmtMarshallInt fid = file;
 
   MgmtMarshallData reply = {nullptr, 0};
   MgmtMarshallInt err;
@@ -844,7 +844,7 @@ ReadFile(TSFileNameT file, char **text, int *size, int *version)
   *text = nullptr;
   *size = *version = 0;
 
-  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, FILE_READ, &optype, &fid);
+  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::FILE_READ, &optype, &fid);
   if (ret != TS_ERR_OKAY) {
     return ret;
   }
@@ -854,7 +854,7 @@ ReadFile(TSFileNameT file, char **text, int *size, int *version)
     return ret;
   }
 
-  ret = recv_mgmt_response(reply.ptr, reply.len, FILE_READ, &err, &vers, &data);
+  ret = recv_mgmt_response(reply.ptr, reply.len, OpType::FILE_READ, &err, &vers, &data);
   ats_free(reply.ptr);
 
   if (ret != TS_ERR_OKAY) {
@@ -890,13 +890,13 @@ WriteFile(TSFileNameT file, const char *text, int size, int version)
 {
   TSMgmtError ret;
 
-  MgmtMarshallInt optype = FILE_WRITE;
-  MgmtMarshallInt fid    = file;
-  MgmtMarshallInt vers   = version;
-  MgmtMarshallData data  = {(void *)text, (size_t)size};
+  OpType optype         = OpType::FILE_WRITE;
+  MgmtMarshallInt fid   = file;
+  MgmtMarshallInt vers  = version;
+  MgmtMarshallData data = {(void *)text, (size_t)size};
 
-  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, FILE_WRITE, &optype, &fid, &vers, &data);
-  return (ret == TS_ERR_OKAY) ? parse_generic_response(FILE_WRITE, main_socket_fd) : ret;
+  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::FILE_WRITE, &optype, &fid, &vers, &data);
+  return (ret == TS_ERR_OKAY) ? parse_generic_response(OpType::FILE_WRITE, main_socket_fd) : ret;
 }
 
 /***************************************************************************
@@ -924,15 +924,15 @@ TSMgmtError
 EventResolve(const char *event_name)
 {
   TSMgmtError ret;
-  MgmtMarshallInt optype  = EVENT_RESOLVE;
+  OpType optype           = OpType::EVENT_RESOLVE;
   MgmtMarshallString name = const_cast<MgmtMarshallString>(event_name);
 
   if (!event_name) {
     return TS_ERR_PARAMS;
   }
 
-  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, EVENT_RESOLVE, &optype, &name);
-  return (ret == TS_ERR_OKAY) ? parse_generic_response(EVENT_RESOLVE, main_socket_fd) : ret;
+  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::EVENT_RESOLVE, &optype, &name);
+  return (ret == TS_ERR_OKAY) ? parse_generic_response(OpType::EVENT_RESOLVE, main_socket_fd) : ret;
 }
 
 /*-------------------------------------------------------------------------
@@ -948,7 +948,7 @@ ActiveEventGetMlt(LLQ *active_events)
     return TS_ERR_PARAMS;
   }
 
-  return (send_and_parse_list(EVENT_GET_MLT, active_events));
+  return (send_and_parse_list(OpType::EVENT_GET_MLT, active_events));
 }
 
 /*-------------------------------------------------------------------------
@@ -960,7 +960,7 @@ TSMgmtError
 EventIsActive(const char *event_name, bool *is_current)
 {
   TSMgmtError ret;
-  MgmtMarshallInt optype  = EVENT_ACTIVE;
+  OpType optype           = OpType::EVENT_ACTIVE;
   MgmtMarshallString name = const_cast<MgmtMarshallString>(event_name);
 
   MgmtMarshallData reply = {nullptr, 0};
@@ -972,7 +972,7 @@ EventIsActive(const char *event_name, bool *is_current)
   }
 
   // create and send request
-  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, EVENT_ACTIVE, &optype, &name);
+  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::EVENT_ACTIVE, &optype, &name);
   if (ret != TS_ERR_OKAY) {
     return ret;
   }
@@ -982,7 +982,7 @@ EventIsActive(const char *event_name, bool *is_current)
     return ret;
   }
 
-  ret = recv_mgmt_response(reply.ptr, reply.len, EVENT_ACTIVE, &err, &bval);
+  ret = recv_mgmt_response(reply.ptr, reply.len, OpType::EVENT_ACTIVE, &err, &bval);
   ats_free(reply.ptr);
 
   if (ret != TS_ERR_OKAY) {
@@ -1022,10 +1022,10 @@ EventSignalCbRegister(const char *event_name, TSEventSignalFunc func, void *data
 
   // if we need to notify traffic manager of the event then send msg
   if (first_time) {
-    MgmtMarshallInt optype  = EVENT_REG_CALLBACK;
+    OpType optype           = OpType::EVENT_REG_CALLBACK;
     MgmtMarshallString name = const_cast<MgmtMarshallString>(event_name);
 
-    ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, EVENT_REG_CALLBACK, &optype, &name);
+    ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::EVENT_REG_CALLBACK, &optype, &name);
     if (ret != TS_ERR_OKAY) {
       return ret;
     }
@@ -1080,7 +1080,7 @@ static TSMgmtError
 snapshot_message(OpType op, const char *snapshot_name)
 {
   TSMgmtError ret;
-  MgmtMarshallInt optype  = op;
+  OpType optype           = op;
   MgmtMarshallString name = const_cast<MgmtMarshallString>(snapshot_name);
 
   if (!snapshot_name) {
@@ -1094,19 +1094,19 @@ snapshot_message(OpType op, const char *snapshot_name)
 TSMgmtError
 SnapshotTake(const char *snapshot_name)
 {
-  return snapshot_message(SNAPSHOT_TAKE, snapshot_name);
+  return snapshot_message(OpType::SNAPSHOT_TAKE, snapshot_name);
 }
 
 TSMgmtError
 SnapshotRestore(const char *snapshot_name)
 {
-  return snapshot_message(SNAPSHOT_RESTORE, snapshot_name);
+  return snapshot_message(OpType::SNAPSHOT_RESTORE, snapshot_name);
 }
 
 TSMgmtError
 SnapshotRemove(const char *snapshot_name)
 {
-  return snapshot_message(SNAPSHOT_REMOVE, snapshot_name);
+  return snapshot_message(OpType::SNAPSHOT_REMOVE, snapshot_name);
 }
 
 TSMgmtError
@@ -1116,15 +1116,15 @@ SnapshotGetMlt(LLQ *snapshots)
     return TS_ERR_PARAMS;
   }
 
-  return send_and_parse_list(SNAPSHOT_GET_MLT, snapshots);
+  return send_and_parse_list(OpType::SNAPSHOT_GET_MLT, snapshots);
 }
 
 TSMgmtError
 StatsReset(bool cluster, const char *stat_name)
 {
   TSMgmtError ret;
-  OpType op               = cluster ? STATS_RESET_CLUSTER : STATS_RESET_NODE;
-  MgmtMarshallInt optype  = op;
+  OpType op               = cluster ? OpType::STATS_RESET_CLUSTER : OpType::STATS_RESET_NODE;
+  OpType optype           = op;
   MgmtMarshallString name = const_cast<MgmtMarshallString>(stat_name);
 
   ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, op, &optype, &name);

--- a/mgmt/api/EventControlMain.cc
+++ b/mgmt/api/EventControlMain.cc
@@ -391,11 +391,11 @@ event_callback_main(void *arg)
       while (con_entry) {
         client_entry = (EventClientT *)ink_hash_table_entry_value(accepted_clients, con_entry);
         if (client_entry->events_registered[event->id]) {
-          MgmtMarshallInt optype  = EVENT_NOTIFY;
+          OpType optype           = OpType::EVENT_NOTIFY;
           MgmtMarshallString name = event->name;
           MgmtMarshallString desc = event->description;
 
-          ret = send_mgmt_request(client_entry->fd, EVENT_NOTIFY, &optype, &name, &desc);
+          ret = send_mgmt_request(client_entry->fd, OpType::EVENT_NOTIFY, &optype, &name, &desc);
           if (ret != TS_ERR_OKAY) {
             Debug("event", "sending even notification to fd [%d] failed.", client_entry->fd);
           }
@@ -452,7 +452,7 @@ handle_event_reg_callback(EventClientT *client, void *req, size_t reqlen)
   MgmtMarshallString name = nullptr;
   TSMgmtError ret;
 
-  ret = recv_mgmt_request(req, reqlen, EVENT_REG_CALLBACK, &optype, &name);
+  ret = recv_mgmt_request(req, reqlen, OpType::EVENT_REG_CALLBACK, &optype, &name);
   if (ret != TS_ERR_OKAY) {
     goto done;
   }
@@ -495,7 +495,7 @@ handle_event_unreg_callback(EventClientT *client, void *req, size_t reqlen)
   MgmtMarshallString name = nullptr;
   TSMgmtError ret;
 
-  ret = recv_mgmt_request(req, reqlen, EVENT_UNREG_CALLBACK, &optype, &name);
+  ret = recv_mgmt_request(req, reqlen, OpType::EVENT_UNREG_CALLBACK, &optype, &name);
   if (ret != TS_ERR_OKAY) {
     goto done;
   }
@@ -557,11 +557,11 @@ handle_event_message(EventClientT *client, void *req, size_t reqlen)
 {
   OpType optype = extract_mgmt_request_optype(req, reqlen);
 
-  if (optype < 0 || static_cast<unsigned>(optype) >= countof(handlers)) {
+  if (static_cast<unsigned>(optype) >= countof(handlers)) {
     goto fail;
   }
 
-  if (handlers[optype] == nullptr) {
+  if (handlers[static_cast<unsigned>(optype)] == nullptr) {
     goto fail;
   }
 
@@ -576,7 +576,7 @@ handle_event_message(EventClientT *client, void *req, size_t reqlen)
     }
   }
 
-  return handlers[optype](client, req, reqlen);
+  return handlers[static_cast<unsigned>(optype)](client, req, reqlen);
 
 fail:
   mgmt_elog(0, "%s: missing handler for type %d event message\n", __func__, (int)optype);

--- a/mgmt/api/NetworkMessage.cc
+++ b/mgmt/api/NetworkMessage.cc
@@ -107,15 +107,15 @@ static const struct NetCmdOperation responses[] = {
   /* LIFECYCLE_MESSAGE          */ {1, {MGMT_MARSHALL_INT}},
 };
 
-#define GETCMD(ops, optype, cmd)                                       \
-  do {                                                                 \
-    if (optype < 0 || static_cast<unsigned>(optype) >= countof(ops)) { \
-      return TS_ERR_PARAMS;                                            \
-    }                                                                  \
-    if (ops[optype].nfields == 0) {                                    \
-      return TS_ERR_PARAMS;                                            \
-    }                                                                  \
-    cmd = &ops[optype];                                                \
+#define GETCMD(ops, optype, cmd)                           \
+  do {                                                     \
+    if (static_cast<unsigned>(optype) >= countof(ops)) {   \
+      return TS_ERR_PARAMS;                                \
+    }                                                      \
+    if (ops[static_cast<unsigned>(optype)].nfields == 0) { \
+      return TS_ERR_PARAMS;                                \
+    }                                                      \
+    cmd = &ops[static_cast<unsigned>(optype)];             \
   } while (0);
 
 TSMgmtError
@@ -200,59 +200,59 @@ send_mgmt_error(int fd, OpType optype, TSMgmtError error)
 
   // Switch on operations, grouped by response format.
   switch (optype) {
-  case BOUNCE:
-  case EVENT_RESOLVE:
-  case FILE_WRITE:
-  case LIFECYCLE_MESSAGE:
-  case PROXY_STATE_SET:
-  case RECONFIGURE:
-  case RESTART:
-  case SNAPSHOT_REMOVE:
-  case SNAPSHOT_RESTORE:
-  case SNAPSHOT_TAKE:
-  case STATS_RESET_CLUSTER:
-  case STATS_RESET_NODE:
-  case STORAGE_DEVICE_CMD_OFFLINE:
-    ink_release_assert(responses[optype].nfields == 1);
+  case OpType::BOUNCE:
+  case OpType::EVENT_RESOLVE:
+  case OpType::FILE_WRITE:
+  case OpType::LIFECYCLE_MESSAGE:
+  case OpType::PROXY_STATE_SET:
+  case OpType::RECONFIGURE:
+  case OpType::RESTART:
+  case OpType::SNAPSHOT_REMOVE:
+  case OpType::SNAPSHOT_RESTORE:
+  case OpType::SNAPSHOT_TAKE:
+  case OpType::STATS_RESET_CLUSTER:
+  case OpType::STATS_RESET_NODE:
+  case OpType::STORAGE_DEVICE_CMD_OFFLINE:
+    ink_release_assert(responses[static_cast<unsigned>(optype)].nfields == 1);
     return send_mgmt_response(fd, optype, &ecode);
 
-  case RECORD_SET:
-  case PROXY_STATE_GET:
-  case EVENT_ACTIVE:
-    ink_release_assert(responses[optype].nfields == 2);
+  case OpType::RECORD_SET:
+  case OpType::PROXY_STATE_GET:
+  case OpType::EVENT_ACTIVE:
+    ink_release_assert(responses[static_cast<unsigned>(optype)].nfields == 2);
     return send_mgmt_response(fd, optype, &ecode, &intval);
 
-  case EVENT_GET_MLT:
-  case SNAPSHOT_GET_MLT:
-  case SERVER_BACKTRACE:
-    ink_release_assert(responses[optype].nfields == 2);
+  case OpType::EVENT_GET_MLT:
+  case OpType::SNAPSHOT_GET_MLT:
+  case OpType::SERVER_BACKTRACE:
+    ink_release_assert(responses[static_cast<unsigned>(optype)].nfields == 2);
     return send_mgmt_response(fd, optype, &ecode, &strval);
 
-  case FILE_READ:
-    ink_release_assert(responses[optype].nfields == 3);
+  case OpType::FILE_READ:
+    ink_release_assert(responses[static_cast<unsigned>(optype)].nfields == 3);
     return send_mgmt_response(fd, optype, &ecode, &intval, &dataval);
 
-  case RECORD_GET:
-  case RECORD_MATCH_GET:
-    ink_release_assert(responses[optype].nfields == 5);
+  case OpType::RECORD_GET:
+  case OpType::RECORD_MATCH_GET:
+    ink_release_assert(responses[static_cast<unsigned>(optype)].nfields == 5);
     return send_mgmt_response(fd, optype, &ecode, &intval, &intval, &strval, &dataval);
 
-  case RECORD_DESCRIBE_CONFIG:
-    ink_release_assert(responses[optype].nfields == 15);
+  case OpType::RECORD_DESCRIBE_CONFIG:
+    ink_release_assert(responses[static_cast<unsigned>(optype)].nfields == 15);
     return send_mgmt_response(fd, optype, &ecode, &strval /* name */, &dataval /* value */, &dataval /* default */,
                               &intval /* type */, &intval /* class */, &intval /* version */, &intval /* rsb */,
                               &intval /* order */, &intval /* access */, &intval /* update */, &intval /* updatetype */,
                               &intval /* checktype */, &intval /* source */, &strval /* checkexpr */);
 
-  case EVENT_REG_CALLBACK:
-  case EVENT_UNREG_CALLBACK:
-  case EVENT_NOTIFY:
-  case API_PING:
+  case OpType::EVENT_REG_CALLBACK:
+  case OpType::EVENT_UNREG_CALLBACK:
+  case OpType::EVENT_NOTIFY:
+  case OpType::API_PING:
     /* no response for these */
-    ink_release_assert(responses[optype].nfields == 0);
+    ink_release_assert(responses[static_cast<unsigned>(optype)].nfields == 0);
     return TS_ERR_OKAY;
 
-  case UNDEFINED_OP:
+  case OpType::UNDEFINED_OP:
     return TS_ERR_OKAY;
   }
 
@@ -260,7 +260,7 @@ send_mgmt_error(int fd, OpType optype, TSMgmtError error)
   // updating the switch statement above. Don't do that; this
   // code must be able to handle every OpType.
 
-  ink_fatal("missing generic error support for type %d management message", optype);
+  ink_fatal("missing generic error support for type %d management message", static_cast<int>(optype));
   return TS_ERR_FAIL;
 }
 
@@ -364,7 +364,7 @@ extract_mgmt_request_optype(void *msg, size_t msglen)
   MgmtMarshallInt optype;
 
   if (mgmt_message_parse(msg, msglen, fields, countof(fields), &optype) == -1) {
-    return UNDEFINED_OP;
+    return OpType::UNDEFINED_OP;
   }
 
   return (OpType)optype;

--- a/mgmt/api/NetworkMessage.h
+++ b/mgmt/api/NetworkMessage.h
@@ -32,7 +32,7 @@
 #define MAX_CONN_TRIES 10 // maximum number of attemps to reconnect to TM
 
 // the possible operations or msg types sent from remote client to TM
-typedef enum {
+enum class OpType : MgmtMarshallInt {
   FILE_READ,
   FILE_WRITE,
   RECORD_SET,
@@ -61,9 +61,7 @@ typedef enum {
   RECORD_DESCRIBE_CONFIG,
   LIFECYCLE_MESSAGE,
   UNDEFINED_OP /* This must be last */
-} OpType;
-
-#define MGMT_OPERATION_TYPE_MAX (UNDEFINED_OP)
+};
 
 enum {
   RECORD_DESCRIBE_FLAGS_MATCH = 0x0001,

--- a/mgmt/api/NetworkUtilsRemote.cc
+++ b/mgmt/api/NetworkUtilsRemote.cc
@@ -79,10 +79,10 @@ set_socket_paths(const char *path)
 static bool
 socket_test(int fd)
 {
-  MgmtMarshallInt optype = API_PING;
-  MgmtMarshallInt now    = time(nullptr);
+  OpType optype       = OpType::API_PING;
+  MgmtMarshallInt now = time(nullptr);
 
-  if (MGMTAPI_SEND_MESSAGE(fd, API_PING, &optype, &now) == TS_ERR_OKAY) {
+  if (MGMTAPI_SEND_MESSAGE(fd, OpType::API_PING, &optype, &now) == TS_ERR_OKAY) {
     return true; // write was successful; connection still open
   }
 
@@ -450,10 +450,10 @@ send_register_all_callbacks(int fd, CallbackTable *cb_table)
   events_with_cb = get_events_with_callbacks(cb_table);
   // need to check that the list has all the events registered
   if (!events_with_cb) { // all events have registered callback
-    MgmtMarshallInt optype        = EVENT_REG_CALLBACK;
+    OpType optype                 = OpType::EVENT_REG_CALLBACK;
     MgmtMarshallString event_name = nullptr;
 
-    err = MGMTAPI_SEND_MESSAGE(fd, EVENT_REG_CALLBACK, &optype, &event_name);
+    err = MGMTAPI_SEND_MESSAGE(fd, OpType::EVENT_REG_CALLBACK, &optype, &event_name);
     if (err != TS_ERR_OKAY) {
       return err;
     }
@@ -461,12 +461,12 @@ send_register_all_callbacks(int fd, CallbackTable *cb_table)
     int num_events = queue_len(events_with_cb);
     // iterate through the LLQ and send request for each event
     for (int i = 0; i < num_events; i++) {
-      MgmtMarshallInt optype        = EVENT_REG_CALLBACK;
+      OpType optype                 = OpType::EVENT_REG_CALLBACK;
       MgmtMarshallInt event_id      = *(int *)dequeue(events_with_cb);
       MgmtMarshallString event_name = (char *)get_event_name(event_id);
 
       if (event_name) {
-        err = MGMTAPI_SEND_MESSAGE(fd, EVENT_REG_CALLBACK, &optype, &event_name);
+        err = MGMTAPI_SEND_MESSAGE(fd, OpType::EVENT_REG_CALLBACK, &optype, &event_name);
         ats_free(event_name); // free memory
         if (err != TS_ERR_OKAY) {
           send_err  = err; // save the type of send error
@@ -527,10 +527,10 @@ send_unregister_all_callbacks(int fd, CallbackTable *cb_table)
   // send message to TM to mark unregister
   for (int k = 0; k < NUM_EVENTS; k++) {
     if (reg_callback[k] == 0) { // event has no registered callbacks
-      MgmtMarshallInt optype        = EVENT_UNREG_CALLBACK;
+      OpType optype                 = OpType::EVENT_UNREG_CALLBACK;
       MgmtMarshallString event_name = get_event_name(k);
 
-      err = MGMTAPI_SEND_MESSAGE(fd, EVENT_UNREG_CALLBACK, &optype, &event_name);
+      err = MGMTAPI_SEND_MESSAGE(fd, OpType::EVENT_UNREG_CALLBACK, &optype, &event_name);
       ats_free(event_name);
       if (err != TS_ERR_OKAY) {
         send_err  = err; // save the type of the sending error
@@ -607,7 +607,7 @@ event_poll_thread_main(void *arg)
     TSMgmtEvent *event = nullptr;
 
     MgmtMarshallData reply = {nullptr, 0};
-    MgmtMarshallInt optype;
+    OpType optype;
     MgmtMarshallString name = nullptr;
     MgmtMarshallString desc = nullptr;
 
@@ -627,7 +627,7 @@ event_poll_thread_main(void *arg)
       break;
     }
 
-    ret = recv_mgmt_request(reply.ptr, reply.len, EVENT_NOTIFY, &optype, &name, &desc);
+    ret = recv_mgmt_request(reply.ptr, reply.len, OpType::EVENT_NOTIFY, &optype, &name, &desc);
     ats_free(reply.ptr);
 
     if (ret != TS_ERR_OKAY) {
@@ -636,7 +636,7 @@ event_poll_thread_main(void *arg)
       break;
     }
 
-    ink_assert(optype == EVENT_NOTIFY);
+    ink_assert(optype == OpType::EVENT_NOTIFY);
 
     // The new event takes ownership of the message strings.
     event              = TSEventCreate();

--- a/mgmt/api/TSControlMain.cc
+++ b/mgmt/api/TSControlMain.cc
@@ -352,7 +352,7 @@ send_record_get_response(int fd, const RecRecord *rec)
     break; // skip it
   }
 
-  return send_mgmt_response(fd, RECORD_GET, &err, &rclass, &type, &name, &value);
+  return send_mgmt_response(fd, OpType::RECORD_GET, &err, &rclass, &type, &name, &value);
 }
 
 /**************************************************************************
@@ -381,7 +381,7 @@ handle_record_get(int fd, void *req, size_t reqlen)
 
   int fderr = fd; // [in,out] variable for the fd and error
 
-  ret = recv_mgmt_request(req, reqlen, RECORD_GET, &optype, &name);
+  ret = recv_mgmt_request(req, reqlen, OpType::RECORD_GET, &optype, &name);
   if (ret != TS_ERR_OKAY) {
     return ret;
   }
@@ -432,7 +432,7 @@ handle_record_match(int fd, void *req, size_t reqlen)
   MgmtMarshallInt optype;
   MgmtMarshallString name;
 
-  ret = recv_mgmt_request(req, reqlen, RECORD_MATCH_GET, &optype, &name);
+  ret = recv_mgmt_request(req, reqlen, OpType::RECORD_MATCH_GET, &optype, &name);
   if (ret != TS_ERR_OKAY) {
     return ret;
   }
@@ -476,7 +476,7 @@ handle_record_set(int fd, void *req, size_t reqlen)
   MgmtMarshallString name  = nullptr;
   MgmtMarshallString value = nullptr;
 
-  ret = recv_mgmt_request(req, reqlen, RECORD_SET, &optype, &name, &value);
+  ret = recv_mgmt_request(req, reqlen, OpType::RECORD_SET, &optype, &name, &value);
   if (ret != TS_ERR_OKAY) {
     ret = TS_ERR_FAIL;
     goto fail;
@@ -496,7 +496,7 @@ fail:
 
   MgmtMarshallInt err = ret;
   MgmtMarshallInt act = action;
-  return send_mgmt_response(fd, RECORD_SET, &err, &act);
+  return send_mgmt_response(fd, OpType::RECORD_SET, &err, &act);
 }
 
 /**************************************************************************
@@ -519,7 +519,7 @@ handle_file_read(int fd, void *req, size_t reqlen)
   MgmtMarshallInt vers  = 0;
   MgmtMarshallData data = {nullptr, 0};
 
-  err = recv_mgmt_request(req, reqlen, FILE_READ, &optype, &fid);
+  err = recv_mgmt_request(req, reqlen, OpType::FILE_READ, &optype, &fid);
   if (err != TS_ERR_OKAY) {
     return (TSMgmtError)err;
   }
@@ -532,7 +532,7 @@ handle_file_read(int fd, void *req, size_t reqlen)
     data.len = size;
   }
 
-  err = send_mgmt_response(fd, FILE_READ, &err, &vers, &data);
+  err = send_mgmt_response(fd, OpType::FILE_READ, &err, &vers, &data);
 
   ats_free(text); // free memory allocated by ReadFile
   return (TSMgmtError)err;
@@ -555,7 +555,7 @@ handle_file_write(int fd, void *req, size_t reqlen)
 
   MgmtMarshallInt err;
 
-  err = recv_mgmt_request(req, reqlen, FILE_WRITE, &optype, &fid, &vers, &data);
+  err = recv_mgmt_request(req, reqlen, OpType::FILE_WRITE, &optype, &fid, &vers, &data);
   if (err != TS_ERR_OKAY) {
     goto done;
   }
@@ -570,7 +570,7 @@ handle_file_write(int fd, void *req, size_t reqlen)
 
 done:
   ats_free(data.ptr);
-  return send_mgmt_response(fd, FILE_WRITE, &err);
+  return send_mgmt_response(fd, OpType::FILE_WRITE, &err);
 }
 
 /**************************************************************************
@@ -587,12 +587,12 @@ handle_proxy_state_get(int fd, void *req, size_t reqlen)
   MgmtMarshallInt err;
   MgmtMarshallInt state = TS_PROXY_UNDEFINED;
 
-  err = recv_mgmt_request(req, reqlen, PROXY_STATE_GET, &optype);
+  err = recv_mgmt_request(req, reqlen, OpType::PROXY_STATE_GET, &optype);
   if (err == TS_ERR_OKAY) {
     state = ProxyStateGet();
   }
 
-  return send_mgmt_response(fd, PROXY_STATE_GET, &err, &state);
+  return send_mgmt_response(fd, OpType::PROXY_STATE_GET, &err, &state);
 }
 
 /**************************************************************************
@@ -611,13 +611,13 @@ handle_proxy_state_set(int fd, void *req, size_t reqlen)
 
   MgmtMarshallInt err;
 
-  err = recv_mgmt_request(req, reqlen, PROXY_STATE_SET, &optype, &state, &clear);
+  err = recv_mgmt_request(req, reqlen, OpType::PROXY_STATE_SET, &optype, &state, &clear);
   if (err != TS_ERR_OKAY) {
-    return send_mgmt_response(fd, PROXY_STATE_SET, &err);
+    return send_mgmt_response(fd, OpType::PROXY_STATE_SET, &err);
   }
 
   err = ProxyStateSet((TSProxyStateT)state, (TSCacheClearT)clear);
-  return send_mgmt_response(fd, PROXY_STATE_SET, &err);
+  return send_mgmt_response(fd, OpType::PROXY_STATE_SET, &err);
 }
 
 /**************************************************************************
@@ -633,12 +633,12 @@ handle_reconfigure(int fd, void *req, size_t reqlen)
   MgmtMarshallInt err;
   MgmtMarshallInt optype;
 
-  err = recv_mgmt_request(req, reqlen, RECONFIGURE, &optype);
+  err = recv_mgmt_request(req, reqlen, OpType::RECONFIGURE, &optype);
   if (err == TS_ERR_OKAY) {
     err = Reconfigure();
   }
 
-  return send_mgmt_response(fd, RECONFIGURE, &err);
+  return send_mgmt_response(fd, OpType::RECONFIGURE, &err);
 }
 
 /**************************************************************************
@@ -651,17 +651,17 @@ handle_reconfigure(int fd, void *req, size_t reqlen)
 static TSMgmtError
 handle_restart(int fd, void *req, size_t reqlen)
 {
-  MgmtMarshallInt optype;
+  OpType optype;
   MgmtMarshallInt options;
   MgmtMarshallInt err;
 
-  err = recv_mgmt_request(req, reqlen, RESTART, &optype, &options);
+  err = recv_mgmt_request(req, reqlen, OpType::RESTART, &optype, &options);
   if (err == TS_ERR_OKAY) {
     switch (optype) {
-    case BOUNCE:
+    case OpType::BOUNCE:
       err = Bounce(options);
       break;
-    case RESTART:
+    case OpType::RESTART:
       err = Restart(options);
       break;
     default:
@@ -670,7 +670,7 @@ handle_restart(int fd, void *req, size_t reqlen)
     }
   }
 
-  return send_mgmt_response(fd, RESTART, &err);
+  return send_mgmt_response(fd, OpType::RESTART, &err);
 }
 
 /**************************************************************************
@@ -687,13 +687,13 @@ handle_storage_device_cmd_offline(int fd, void *req, size_t reqlen)
   MgmtMarshallString name = nullptr;
   MgmtMarshallInt err;
 
-  err = recv_mgmt_request(req, reqlen, STORAGE_DEVICE_CMD_OFFLINE, &optype, &name);
+  err = recv_mgmt_request(req, reqlen, OpType::STORAGE_DEVICE_CMD_OFFLINE, &optype, &name);
   if (err == TS_ERR_OKAY) {
     // forward to server
     lmgmt->signalEvent(MGMT_EVENT_STORAGE_DEVICE_CMD_OFFLINE, name);
   }
 
-  return send_mgmt_response(fd, STORAGE_DEVICE_CMD_OFFLINE, &err);
+  return send_mgmt_response(fd, OpType::STORAGE_DEVICE_CMD_OFFLINE, &err);
 }
 
 /**************************************************************************
@@ -710,13 +710,13 @@ handle_event_resolve(int fd, void *req, size_t reqlen)
   MgmtMarshallString name = nullptr;
   MgmtMarshallInt err;
 
-  err = recv_mgmt_request(req, reqlen, EVENT_RESOLVE, &optype, &name);
+  err = recv_mgmt_request(req, reqlen, OpType::EVENT_RESOLVE, &optype, &name);
   if (err == TS_ERR_OKAY) {
     err = EventResolve(name);
   }
 
   ats_free(name);
-  return send_mgmt_response(fd, EVENT_RESOLVE, &err);
+  return send_mgmt_response(fd, OpType::EVENT_RESOLVE, &err);
 }
 
 /**************************************************************************
@@ -738,7 +738,7 @@ handle_event_get_mlt(int fd, void *req, size_t reqlen)
   MgmtMarshallInt err;
   MgmtMarshallString list = nullptr;
 
-  err = recv_mgmt_request(req, reqlen, EVENT_GET_MLT, &optype);
+  err = recv_mgmt_request(req, reqlen, OpType::EVENT_GET_MLT, &optype);
   if (err != TS_ERR_OKAY) {
     goto done;
   }
@@ -766,7 +766,7 @@ handle_event_get_mlt(int fd, void *req, size_t reqlen)
 
 done:
   delete_queue(event_list);
-  return send_mgmt_response(fd, EVENT_GET_MLT, &err, &list);
+  return send_mgmt_response(fd, OpType::EVENT_GET_MLT, &err, &list);
 }
 
 /**************************************************************************
@@ -786,7 +786,7 @@ handle_event_active(int fd, void *req, size_t reqlen)
   MgmtMarshallInt err;
   MgmtMarshallInt bval = 0;
 
-  err = recv_mgmt_request(req, reqlen, EVENT_ACTIVE, &optype, &name);
+  err = recv_mgmt_request(req, reqlen, OpType::EVENT_ACTIVE, &optype, &name);
   if (err != TS_ERR_OKAY) {
     goto done;
   }
@@ -803,7 +803,7 @@ handle_event_active(int fd, void *req, size_t reqlen)
 
 done:
   ats_free(name);
-  return send_mgmt_response(fd, EVENT_ACTIVE, &err, &bval);
+  return send_mgmt_response(fd, OpType::EVENT_ACTIVE, &err, &bval);
 }
 
 /**************************************************************************
@@ -815,12 +815,12 @@ done:
 static TSMgmtError
 handle_snapshot(int fd, void *req, size_t reqlen)
 {
-  MgmtMarshallInt optype;
+  OpType optype;
   MgmtMarshallString name = nullptr;
 
   MgmtMarshallInt err;
 
-  err = recv_mgmt_request(req, reqlen, SNAPSHOT_TAKE, &optype, &name);
+  err = recv_mgmt_request(req, reqlen, OpType::SNAPSHOT_TAKE, &optype, &name);
   if (err != TS_ERR_OKAY) {
     goto done;
   }
@@ -832,13 +832,13 @@ handle_snapshot(int fd, void *req, size_t reqlen)
 
   // call CoreAPI call on Traffic Manager side
   switch (optype) {
-  case SNAPSHOT_TAKE:
+  case OpType::SNAPSHOT_TAKE:
     err = SnapshotTake(name);
     break;
-  case SNAPSHOT_RESTORE:
+  case OpType::SNAPSHOT_RESTORE:
     err = SnapshotRestore(name);
     break;
-  case SNAPSHOT_REMOVE:
+  case OpType::SNAPSHOT_REMOVE:
     err = SnapshotRemove(name);
     break;
   default:
@@ -870,7 +870,7 @@ handle_snapshot_get_mlt(int fd, void *req, size_t reqlen)
   MgmtMarshallInt err;
   MgmtMarshallString list = nullptr;
 
-  err = recv_mgmt_request(req, reqlen, SNAPSHOT_GET_MLT, &optype);
+  err = recv_mgmt_request(req, reqlen, OpType::SNAPSHOT_GET_MLT, &optype);
   if (err != TS_ERR_OKAY) {
     goto done;
   }
@@ -898,7 +898,7 @@ handle_snapshot_get_mlt(int fd, void *req, size_t reqlen)
 
 done:
   delete_queue(snap_list);
-  return send_mgmt_response(fd, SNAPSHOT_GET_MLT, &err, &list);
+  return send_mgmt_response(fd, OpType::SNAPSHOT_GET_MLT, &err, &list);
 }
 
 /**************************************************************************
@@ -910,13 +910,13 @@ done:
 static TSMgmtError
 handle_stats_reset(int fd, void *req, size_t reqlen)
 {
-  MgmtMarshallInt optype;
+  OpType optype;
   MgmtMarshallString name = nullptr;
   MgmtMarshallInt err;
 
-  err = recv_mgmt_request(req, reqlen, STATS_RESET_NODE, &optype, &name);
+  err = recv_mgmt_request(req, reqlen, OpType::STATS_RESET_NODE, &optype, &name);
   if (err == TS_ERR_OKAY) {
-    err = StatsReset(optype == STATS_RESET_CLUSTER, name);
+    err = StatsReset(optype == OpType::STATS_RESET_CLUSTER, name);
   }
 
   ats_free(name);
@@ -936,7 +936,7 @@ handle_api_ping(int /* fd */, void *req, size_t reqlen)
   MgmtMarshallInt optype;
   MgmtMarshallInt stamp;
 
-  return recv_mgmt_request(req, reqlen, API_PING, &optype, &stamp);
+  return recv_mgmt_request(req, reqlen, OpType::API_PING, &optype, &stamp);
 }
 
 static TSMgmtError
@@ -947,12 +947,12 @@ handle_server_backtrace(int fd, void *req, size_t reqlen)
   MgmtMarshallString trace = nullptr;
   MgmtMarshallInt err;
 
-  err = recv_mgmt_request(req, reqlen, SERVER_BACKTRACE, &optype, &options);
+  err = recv_mgmt_request(req, reqlen, OpType::SERVER_BACKTRACE, &optype, &options);
   if (err == TS_ERR_OKAY) {
     err = ServerBacktrace(options, &trace);
   }
 
-  err = send_mgmt_response(fd, SERVER_BACKTRACE, &err, &trace);
+  err = send_mgmt_response(fd, OpType::SERVER_BACKTRACE, &err, &trace);
   ats_free(trace);
 
   return (TSMgmtError)err;
@@ -1032,9 +1032,9 @@ send_record_describe(const RecRecord *rec, void *edata)
     }
   }
 
-  err = send_mgmt_response(match->fd, RECORD_DESCRIBE_CONFIG, &err, &rec_name, &rec_value, &rec_default, &rec_type, &rec_class,
-                           &rec_version, &rec_rsb, &rec_order, &rec_access, &rec_update, &rec_updatetype, &rec_checktype,
-                           &rec_source, &rec_checkexpr);
+  err = send_mgmt_response(match->fd, OpType::RECORD_DESCRIBE_CONFIG, &err, &rec_name, &rec_value, &rec_default, &rec_type,
+                           &rec_class, &rec_version, &rec_rsb, &rec_order, &rec_access, &rec_update, &rec_updatetype,
+                           &rec_checktype, &rec_source, &rec_checkexpr);
 
 done:
   match->err = err;
@@ -1049,7 +1049,7 @@ handle_record_describe(int fd, void *req, size_t reqlen)
   MgmtMarshallInt options;
   MgmtMarshallString name;
 
-  ret = recv_mgmt_request(req, reqlen, RECORD_DESCRIBE_CONFIG, &optype, &name, &options);
+  ret = recv_mgmt_request(req, reqlen, OpType::RECORD_DESCRIBE_CONFIG, &optype, &name, &options);
   if (ret != TS_ERR_OKAY) {
     return ret;
   }
@@ -1103,12 +1103,12 @@ handle_lifecycle_message(int fd, void *req, size_t reqlen)
   MgmtMarshallString tag;
   MgmtMarshallData data;
 
-  err = recv_mgmt_request(req, reqlen, LIFECYCLE_MESSAGE, &optype, &tag, &data);
+  err = recv_mgmt_request(req, reqlen, OpType::LIFECYCLE_MESSAGE, &optype, &tag, &data);
   if (err == TS_ERR_OKAY) {
     lmgmt->signalEvent(MGMT_EVENT_LIFECYCLE_MESSAGE, static_cast<char *>(req), reqlen);
   }
 
-  return send_mgmt_response(fd, LIFECYCLE_MESSAGE, &err);
+  return send_mgmt_response(fd, OpType::LIFECYCLE_MESSAGE, &err);
 }
 /**************************************************************************/
 
@@ -1148,8 +1148,8 @@ static const control_message_handler handlers[] = {
 };
 
 // This should use countof(), but we need a constexpr :-/
-#define NUM_OP_HANDLERS (sizeof(handlers) / sizeof(handlers[0]))
-extern char __msg_handler_static_assert[NUM_OP_HANDLERS == MGMT_OPERATION_TYPE_MAX ? 0 : -1];
+static_assert((sizeof(handlers) / sizeof(handlers[0])) == static_cast<unsigned>(OpType::UNDEFINED_OP),
+              "handlers array is not of correct size");
 
 static TSMgmtError
 handle_control_message(int fd, void *req, size_t reqlen)
@@ -1157,11 +1157,11 @@ handle_control_message(int fd, void *req, size_t reqlen)
   OpType optype = extract_mgmt_request_optype(req, reqlen);
   TSMgmtError error;
 
-  if (optype < 0 || static_cast<unsigned>(optype) >= countof(handlers)) {
+  if (static_cast<unsigned>(optype) >= countof(handlers)) {
     goto fail;
   }
 
-  if (handlers[optype].handler == nullptr) {
+  if (handlers[static_cast<unsigned>(optype)].handler == nullptr) {
     goto fail;
   }
 
@@ -1170,7 +1170,7 @@ handle_control_message(int fd, void *req, size_t reqlen)
     gid_t egid = -1;
 
     // For privileged calls, ensure we have caller credentials and that the caller is privileged.
-    if (handlers[optype].flags & MGMT_API_PRIVILEGED) {
+    if (handlers[static_cast<unsigned>(optype)].flags & MGMT_API_PRIVILEGED) {
       if (mgmt_get_peereid(fd, &euid, &egid) == -1 || (euid != 0 && euid != geteuid())) {
         Debug("ts_main", "denied privileged API access on fd=%d for uid=%d gid=%d", fd, euid, egid);
         return send_mgmt_error(fd, optype, TS_ERR_PERMISSION_DENIED);
@@ -1178,9 +1178,9 @@ handle_control_message(int fd, void *req, size_t reqlen)
     }
   }
 
-  Debug("ts_main", "handling message type=%d ptr=%p len=%zu on fd=%d", optype, req, reqlen, fd);
+  Debug("ts_main", "handling message type=%d ptr=%p len=%zu on fd=%d", static_cast<int>(optype), req, reqlen, fd);
 
-  error = handlers[optype].handler(fd, req, reqlen);
+  error = handlers[static_cast<unsigned>(optype)].handler(fd, req, reqlen);
   if (error != TS_ERR_OKAY) {
     // NOTE: if the error was produced by the handler sending a response, this could attempt to
     // send a response again. However, this would only happen if sending the response failed, so


### PR DESCRIPTION
This fixes an issue where the behavior of va_start is undefined when using
the enum as the <n>'th argument (before the ...). Switching to the enum class
fixes this issue, and is also nicer (as per previous enum class changes).