### PR TITLE
gzip plugin new config option for allow urls.

### DIFF
--- a/doc/admin-guide/plugins/gzip.en.rst
+++ b/doc/admin-guide/plugins/gzip.en.rst
@@ -117,6 +117,15 @@ of the objects will be cached and returned to clients. This may be useful for
 objects which already have their own compression built-in, to avoid the expense
 of multiple rounds of compression for trivial gains.
 
+allow
+--------
+
+Provides a wildcard pattern which will be applied to request URLs. Any which
+match the pattern will be considered compressible, and only deflated versions
+of the objects will be cached and returned to clients. This may be useful for
+objects which already have their own compression built-in, to avoid the expense
+of multiple rounds of compression for trivial gains.
+
 enabled
 -------
 
@@ -168,6 +177,7 @@ might create a configuration with the following options::
     cache false
     remove-accept-encoding true
     disallow /notthis/*.js
+    allow /this/*.js
     flush true
 
     # Allows brotli encoded response from origin but is not capable of brotli compression

--- a/plugins/gzip/README
+++ b/plugins/gzip/README
@@ -43,7 +43,9 @@ a sample configuration (sample.gzip.config):
 #
 # compressible-content-type: wildcard pattern for matching compressible content types
 #
-# disallow: wildcard pattern for disablign compression on urls
+# disallow: wildcard pattern for disabling compression on urls
+#
+# allow: wildcard pattern for enabling compression on urls
 #
 # supported-algorithms: compression algorithms supported. comma separated algorithms. Default is gzip
 #
@@ -63,6 +65,10 @@ disallow /notthis/*.js
 disallow /notthat*
 disallow */bla*
 
+allow */here/*
+#disabling is possible too. trying to deprecate disallow
+allow !*/nothere/*
+
 #supported algorithms
 supported-algorithms br,gzip
 
@@ -76,3 +82,6 @@ compressible-content-type text/*
 cache false
 disallow /notthis/*.js
 disallow /notthat*
+
+allow /this/*.js
+allow !/notthat/*.css

--- a/plugins/gzip/configuration.cc
+++ b/plugins/gzip/configuration.cc
@@ -95,7 +95,8 @@ enum ParserState {
   kParseCache,
   kParseDisallow,
   kParseFlush,
-  kParseAlgorithms
+  kParseAlgorithms,
+  kParseAllow
 };
 
 void
@@ -109,6 +110,12 @@ void
 HostConfiguration::add_disallow(const std::string &disallow)
 {
   disallows_.push_back(disallow);
+}
+
+void
+HostConfiguration::add_allow(const std::string &allow)
+{
+  allows_.push_back(allow);
 }
 
 void
@@ -150,14 +157,31 @@ bool
 HostConfiguration::is_url_allowed(const char *url, int url_len)
 {
   string surl(url, url_len);
-
-  for (StringContainer::iterator it = disallows_.begin(); it != disallows_.end(); ++it) {
-    if (fnmatch(it->c_str(), surl.c_str(), 0) == 0) {
-      info("url [%s] disabled for compression, matched on pattern [%s]", surl.c_str(), it->c_str());
-      return false;
+  if (has_disallows()) {
+    for (StringContainer::iterator it = disallows_.begin(); it != disallows_.end(); ++it) {
+      if (fnmatch(it->c_str(), surl.c_str(), 0) == 0) {
+        info("url [%s] disabled for compression, matched disallow pattern [%s]", surl.c_str(), it->c_str());
+        return false;
+      }
     }
   }
-
+  if (has_allows()) {
+    for (StringContainer::iterator allow_it = allows_.begin(); allow_it != allows_.end(); ++allow_it) {
+      const char *match_string = allow_it->c_str();
+      bool exclude             = match_string[0] == '!';
+      if (exclude) {
+        ++match_string; // skip !
+      }
+      if (fnmatch(match_string, surl.c_str(), 0) == 0) {
+        info("url [%s] %s for compression, matched allow pattern [%s]", surl.c_str(), exclude ? "disabled" : "enabled",
+             allow_it->c_str());
+        return !exclude;
+      }
+    }
+    info("url [%s] disabled for compression, did not match any allows pattern", surl.c_str());
+    return false;
+  }
+  info("url [%s] enabled for compression, did not match and disallow pattern ", surl.c_str());
   return true;
 }
 
@@ -295,6 +319,8 @@ Configuration::Parse(const char *path)
           state = kParseFlush;
         } else if (token == "supported-algorithms") {
           state = kParseAlgorithms;
+        } else if (token == "allow") {
+          state = kParseAllow;
         } else {
           warning("failed to interpret \"%s\" at line %zu", token.c_str(), lineno);
         }
@@ -325,6 +351,10 @@ Configuration::Parse(const char *path)
         break;
       case kParseAlgorithms:
         current_host_configuration->add_compression_algorithms(token);
+        state = kParseStart;
+        break;
+      case kParseAllow:
+        current_host_configuration->add_allow(token);
         state = kParseStart;
         break;
       }

--- a/plugins/gzip/configuration.h
+++ b/plugins/gzip/configuration.h
@@ -105,7 +105,14 @@ public:
     return !disallows_.empty();
   }
 
+  bool
+  has_allows() const
+  {
+    return !allows_.empty();
+  }
+
   void add_disallow(const std::string &disallow);
+  void add_allow(const std::string &allow);
   void add_compressible_content_type(const std::string &content_type);
   bool is_url_allowed(const char *url, int url_len);
   bool is_content_type_compressible(const char *content_type, int content_type_length);
@@ -138,6 +145,7 @@ private:
 
   StringContainer compressible_content_types_;
   StringContainer disallows_;
+  StringContainer allows_;
 
   DISALLOW_COPY_AND_ASSIGN(HostConfiguration);
 };

--- a/plugins/gzip/gzip.cc
+++ b/plugins/gzip/gzip.cc
@@ -519,7 +519,7 @@ compress_transform_finish(Data *data)
 {
   if (data->compression_type & COMPRESSION_TYPE_BROTLI && data->compression_algorithms & ALGORITHM_BROTLI) {
     brotli_transform_finish(data);
-    debug("brotli-transform: Brolti compression finish.");
+    debug("brotli-transform: Brotli compression finish.");
   } else if ((data->compression_type & (COMPRESSION_TYPE_GZIP | COMPRESSION_TYPE_DEFLATE)) &&
              (data->compression_algorithms & (ALGORITHM_GZIP | ALGORITHM_DEFLATE))) {
     gzip_transform_finish(data);
@@ -908,7 +908,7 @@ handle_request(TSHttpTxn txnp, Configuration *config)
     bool allowed = false;
 
     if (hc->enabled()) {
-      if (hc->has_disallows()) {
+      if (hc->has_disallows() || hc->has_allows()) {
         int url_len;
         char *url = TSHttpTxnEffectiveUrlStringGet(txnp, &url_len);
         allowed   = hc->is_url_allowed(url, url_len);


### PR DESCRIPTION
@bryancall @shukitchan added a new option for gzip plugin to enable compression based on allowed urls.
Added a ! exclude option to exclude certain urls from compression. This can be replacement to disallow which can be deprecated in the next major release.

