### PR TITLE
Fix the default storage config for the tests so the storage config

### DIFF
--- a/tests/gold_tests/autest-site/min_cfg/storage.config
+++ b/tests/gold_tests/autest-site/min_cfg/storage.config
@@ -1,4 +1,4 @@
 # seems good enought for doing something for playing with. 
 # not good for production
 # File must exist and must have this value in it
-var 256M
+var/run/trafficserver 256MB

--- a/tests/gold_tests/autest-site/trafficserver.test.ext
+++ b/tests/gold_tests/autest-site/trafficserver.test.ext
@@ -111,6 +111,7 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True):
     p.Env['PROXY_CONFIG_HOSTDB_STORAGE_PATH']=runtime_dir
     #p.Variables.RUNTIMEDIR=runtime_dir
     p.Setup.MakeDir(runtime_dir)
+    p.Setup.Chown(runtime_dir, "nobody", "nobody",ignore=True) 
     # will need this for traffic_manager is it runs
     p.Setup.MakeDir(os.path.join(config_dir, 'snapshots'))
 


### PR DESCRIPTION
file is openable by nobody.  Otherwise, the cachedb is not accessible
by the traffic_server user.