### PR TITLE
Fix http2 big client test

### DIFF
--- a/tests/gold_tests/h2/http2.test.py
+++ b/tests/gold_tests/h2/http2.test.py
@@ -70,7 +70,7 @@ tr=Test.AddTestRun()
 tr.Processes.Default.Command='python3 h2client.py -p {0}'.format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode=0
 # time delay as proxy.config.http.wait_for_cache could be broken
-tr.Processes.Default.StartBefore(server,ready=When.PortOpen(server.Variables.Port))
+tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.ssl_port))
 tr.Processes.Default.Streams.stdout="gold/remap-200.gold"
 tr.StillRunningAfter=server
@@ -79,9 +79,6 @@ tr.StillRunningAfter=server
 tr=Test.AddTestRun()
 tr.Processes.Default.Command='python3 h2bigclient.py -p {0}'.format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode=0
-# time delay as proxy.config.http.wait_for_cache could be broken
-tr.Processes.Default.StartBefore(server,ready=When.PortOpen(server.Variables.Port))
-tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.ssl_port))
 tr.Processes.Default.Streams.stdout="gold/bigfile.gold"
 tr.StillRunningAfter=server
 


### PR DESCRIPTION
This will fix the following problem we are seeing in AUcheck

Test: http2: Failed
    File: http2.test.py
    Directory: /var/jenkins/workspace/autest-github/src/tests/gold_tests/h2
   Starting Test http2 : No issues found - Passed
      Reason: Started!
   Process: server: Passed
     Setting up : MakeDir - Passed
   Process: Default: Skipped
      Reason: Was not started
   Process: ts: Failed
     Setting up : MakeDir - Passed
     Setting up : Copy - Failed
        Reason: Cannot copy /var/jenkins/workspace/autest-github/167/install/bin to /tmp/ausb-29544/http2/ts/bin because:
          Cannot copy /var/jenkins/workspace/autest-github/167/install/bin because '/var/jenkins/workspace/autest-github/167/install/bin/traffic_logstats' and '/tmp/ausb-29544/http2/ts/bin/traffic_logstats' are the same file