### PR TITLE
Update doc building instructions

### DIFF
--- a/doc/developer-guide/documentation/building.en.rst
+++ b/doc/developer-guide/documentation/building.en.rst
@@ -24,11 +24,8 @@ Building the Documentation
 
 All documentation and related files are located in the source tree under the
 ``doc/`` directory. Makefiles are generated automatically by the main configure
-script. For simplicity's sake, it is recommended that contributors new to the
-documentation make use of the included Vagrant configurations, as these will
-take care of providing all dependencies. Please refer to the
-:ref:`developer-testing-with-vagrant` chapter for complete details on using
-Vagrant to build and test the |TS| source tree.
+script. The current configure script switch for enabling documentation builds is
+``--enable-docs``. Also make sure you have run ``pip install sphinx`` at some point.
 
 With a configured source tree, building the documentation requires only the
 invocation ``make html`` from within ``doc/``. For repeated builds while working


### PR DESCRIPTION
Few reasons why this change is needed:
  - the `--enable-docs` switch is easy to forget.
  - the Vagrant config doesn't even set up sphinx
  - not having the python sphinx package installed generates
    very ambiguous error messages