### PR TITLE
TS-4976: Regularize plugins - redirect_1

### DIFF
--- a/doc/developer-guide/plugins/adding-statistics.en.rst
+++ b/doc/developer-guide/plugins/adding-statistics.en.rst
@@ -40,4 +40,14 @@ with :c:func:`TSStatIntSet`, and increment it with :c:func:`TSStatIntIncrement` 
    :language: c
    :lines: 30-
 
-:c:func:`TSStatFindName` can be used to check if the statistic already exists or to provide a generic interface to statistics. In the example above you can see the code first verifies the statistic does not already exist before creating it. In general, though, this should be handled by not executing the registration code twice. If done only from plugin initialization then this will be the case. It can be the case however that statistics are based on configuration data which may be reloaded and the check must be done.
+If this plugin is loaded, then the statistic can be accessed with ::
+
+   traffic_ctl metric show plugin.statistics.now
+
+The name of the statistic can be any string but it is best to use the convention of starting it with the literal tag "plugin" followed the plugin name followed by statistic specific tags. This avoids any name collisions and also makes finding all statistics for a plugin simple. For instance, the "redirect_1" example plugin creates a number of statistics. These can be listed with the command ::
+
+   traffic_ctl metric match plugin.redirect_1..*
+
+The "redirect_1" example plugin has a more realistic handling of statistics with regard to updating and is worth examining.
+
+:c:func:`TSStatFindName` can be used to check if the statistic already exists or to provide a generic interface to statistics. In the example above you can see the code first verifies the statistic does not already exist before creating it. In general, though, this should be handled by not executing the registration code twice. If done only from plugin initialization then this will be the case. It can be the case however that statistics are based on configuration data which may be reloaded and the check must be done. This is more likely with remap plugins.

--- a/doc/developer-guide/plugins/introduction.en.rst
+++ b/doc/developer-guide/plugins/introduction.en.rst
@@ -173,7 +173,7 @@ them into activity.
 
 A plugin may consist of just one static continuation that is called
 whenever certain events happen. Examples of such plugins include
-``blacklist_1.c``, ``basic_auth.c``, and ``redirect-1.c``.
+``blacklist_1.c``, ``basic_auth.c``, and ``redirect_1.c``.
 Alternatively, a plugin might dynamically create other continuations as
 needed. Transform plugins are built in this manner: a static parent
 continuation checks all transactions to see if any are transformable;

--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -41,6 +41,7 @@ example_Plugins = \
 	protocol.la \
 	psi.la \
 	query_remap.la \
+	redirect_1.la \
 	remap.la \
 	remap_header_add.la \
 	replace-header.la \
@@ -121,10 +122,10 @@ statistic_la_SOURCES = statistic/statistic.cc
 thread_1_la_SOURCES = thread-1/thread-1.c
 txn_data_sink_la_SOURCES = txn-data-sink/txn-data-sink.c
 version_la_SOURCES = version/version.c
+redirect_1_la_SOURCES = redirect_1/redirect_1.c
 
 # The following examples do not build:
 #
-# redirect_1_la_SOURCES = redirect-1/redirect-1.c
 # session_1_la_SOURCES = session-1/session-1.c
 
 cppapi_AsyncHttpFetchStreaming_la_SOURCES = cppapi/async_http_fetch_streaming/AsyncHttpFetchStreaming.cc

--- a/example/redirect_1/readme.txt
+++ b/example/redirect_1/readme.txt
@@ -1,4 +1,4 @@
-About redirect-1.c
+About redirect_1.c
 
 This plugin redirects requests from a specified IP address ("block_ip")
 to a specified URL ("url_redirect").
@@ -6,4 +6,4 @@ to a specified URL ("url_redirect").
 Specify block_ip and url_redirect int the plugin.config file; for
 example, enter the following line in plugin.config
 
-	redirect-1.so block_ip url_redirect
+	redirect_1.so block_ip url_redirect

--- a/example/statistic/statistic.cc
+++ b/example/statistic/statistic.cc
@@ -38,22 +38,22 @@ TSPluginInit(int /* argc */, const char * /* argv */ [])
 {
   TSPluginRegistrationInfo info;
 
-  info.plugin_name   = (char *)PLUGIN_NAME;
-  info.vendor_name   = (char *)"Apache Software Foundation";
-  info.support_email = (char *)"dev@trafficserver.apache.org";
+  info.plugin_name   = PLUGIN_NAME;
+  info.vendor_name   = "Apache Software Foundation";
+  info.support_email = "dev@trafficserver.apache.org";
 
   int id;
-  const char name[] = "example.statistic.now";
+  const char name[] = "plugin." PLUGIN_NAME ".now";
 
   if (TSStatFindName(name, &id) == TS_ERROR) {
     id = TSStatCreate(name, TS_RECORDDATATYPE_INT, TS_STAT_NON_PERSISTENT, TS_STAT_SYNC_SUM);
     if (id == TS_ERROR) {
-      TSError("%s: failed to register '%s'", PLUGIN_NAME, name);
+      TSError("[%s] failed to register '%s'", PLUGIN_NAME, name);
       return;
     }
   }
 
-  TSError("%s: %s registered with id %d", PLUGIN_NAME, name, id);
+  TSError("[%s] %s registered with id %d", PLUGIN_NAME, name, id);
 
 #if DEBUG
   TSReleaseAssert(id != TS_ERROR);


### PR DESCRIPTION
This actually needs a serious review. This hasn't been built for a long time, it used a stat API so old I had a hard time finding any reference to it, so I'm not confident I've extracted the relevant features. In addition there is the question if any of this should be used in the statistics documentation section.

The statistics example was added to this PR, along with documentation updates for statistics involving both the statistics example plugin and the redirect example plugin.