### PR TITLE
fixed: if a request is range and icp hit,it might response Multi-Hop …

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -3176,7 +3176,7 @@ HttpTransact::HandleICPLookup(State *s)
     // Since the ICPDNSLookup is not called, these two
     //   values are not initialized.
     // Force them to be initialized
-    s->icp_info.http_version.set(1, 0);
+    s->icp_info.http_version.set(1, 1);
     if (!s->txn_conf->keep_alive_enabled_out) {
       s->icp_info.keep_alive = HTTP_NO_KEEPALIVE;
     } else {

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -3176,7 +3176,11 @@ HttpTransact::HandleICPLookup(State *s)
     // Since the ICPDNSLookup is not called, these two
     //   values are not initialized.
     // Force them to be initialized
-    s->icp_info.http_version.set(1, 1);
+    if (s->request_data.hdr){
+        s->icp_info.http_version = s->request_data.hdr->version_get();
+    } else {
+        s->icp_info.http_version.set(1, 0);
+    }
     if (!s->txn_conf->keep_alive_enabled_out) {
       s->icp_info.keep_alive = HTTP_NO_KEEPALIVE;
     } else {


### PR DESCRIPTION
If a request is range and icp hit,it might response Multi-Hop Cycle Detected。

When serverA receive one range request，it send icp request, and  serverB response icp hit，then serverA send http1.0 request with range；serverB find the HTTPVersion  which is 1.0 in do_range_setup_if_necessary function,so cache miss，then it send icp request too. Then this action might Multi-Hop Cycle Detected。
