### PR TITLE
Remove extraneous '*'

### DIFF
--- a/doc/developer-guide/plugins/http-transformations/index.en.rst
+++ b/doc/developer-guide/plugins/http-transformations/index.en.rst
@@ -122,7 +122,7 @@ Transformations
 VIOs
 ----
 
-A ``VIO``*or virtual IO is a description of an in progress IO
+A ``VIO`` or virtual IO is a description of an in progress IO
 operation. The ``VIO`` data structure is used by ``VConnection`` users
 to determine how much progress has been made on a particular IO
 operation, and to reenable an IO operation when it stalls due to buffer


### PR DESCRIPTION
This caused a bunch of text to be incorrectly highlighted.

Also, I have no idea why git decided that I changed two lines. I only removed the '*', I promise.