### PR TITLE
Protect against LRUHash x = x

### DIFF
--- a/plugins/experimental/cache_promote/cache_promote.cc
+++ b/plugins/experimental/cache_promote/cache_promote.cc
@@ -152,7 +152,9 @@ public:
   operator=(const LRUHash &h)
   {
     TSDebug(PLUGIN_NAME, "copying an LRUHash object");
-    memcpy(_hash, h._hash, sizeof(_hash));
+    if (this != &h) {
+      memcpy(_hash, h._hash, sizeof(_hash));
+    }
     return *this;
   }
 


### PR DESCRIPTION
This address clang-analyzer issue reported on master, after we upgraded to
v4.0.1. Technically this is a "false positive" in our code, since it can't happen,
but this seems right to me.