### PR TITLE
Better github PR support, and per-branch rules

### DIFF
--- a/.clang-analyzer
+++ b/.clang-analyzer
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+# Additional checkers
+checkers="-enable-checker alpha.unix.cstring.BufferOverlap \
+          -enable-checker alpha.unix.PthreadLock\
+          -enable-checker alpha.core.BoolAssignment \
+          -enable-checker alpha.core.CastSize \
+          -enable-checker alpha.core.SizeofPtr"

--- a/ci/jenkins/bin/clang-analyzer.sh
+++ b/ci/jenkins/bin/clang-analyzer.sh
@@ -25,6 +25,7 @@
 LLVM_BASE=${LLVM:-/opt/llvm}
 NPROCS=${NPROCS:-$(getconf _NPROCESSORS_ONLN)}
 NOCLEAN=${NOCLEAN:-}
+OUTPUT_BASE=${OUTPUT_BASE:-/home/jenkins/clang-analyzer}
 
 # Options
 options="--status-bugs --keep-empty"
@@ -45,13 +46,33 @@ test ! -z "${WORKSPACE}" && cd "${WORKSPACE}/src"
 
 # Where to store the results, special case for the CI
 output="/tmp"
-test -w "/home/jenkins/clang-analyzer/${ATS_BRANCH}" && output="/home/jenkins/clang-analyzer/${ATS_BRANCH}"
+
+# Find a Jenkins output tree if possible
+if [ "${JOB_NAME#*-github}" != "${JOB_NAME}" ]; then
+    # This is a Github PR build, override the branch name accordingly
+    ATS_BRANCH="github"
+    if [ -w "${OUTPUT_BASE}/${ATS_BRANCH}" ]; then
+	output="${OUTPUT_BASE}/${ATS_BRANCH}/${ghprbPullId}"
+	[ ! -d "${output}}"] && mkdir "${output}"
+    fi
+    github_pr=" PR #${ghprbPullId}"
+    results_url="https://ci.trafficserver.apache.org/files/clang-analyzer/${ATS_BRANCH}/${ghprbPullId}/"
+else
+    test -w "${OUTPUT_BASE}/${ATS_BRANCH}" && output="${OUTPUT_BASE}/${ATS_BRANCH}"
+    github_pr=""
+    results_url="https://ci.trafficserver.apache.org/files/clang-analyzer/${ATS_BRANCH}/"
+fi
 
 # Tell scan-build to use clang as the underlying compiler to actually build
 # source. If you don't do this, it will default to GCC.
 export CCC_CC=${LLVM_BASE}/bin/clang
 export CCC_CXX=${LLVM_BASE}/bin/clang++
 
+# This can be used to override any of those settings above
+[ -f .clang-analyzer ] && source .clang-analyzer
+
+# Start the build / scan
+[ "$output" != "/tmp" ] && echo "Results (if any) can be found at ${results_url}"
 autoreconf -fi
 ${LLVM_BASE}/bin/scan-build ./configure ${configure}
 
@@ -59,7 +80,9 @@ ${LLVM_BASE}/bin/scan-build ./configure ${configure}
 # without scan-build. The subsequent make will then skip it.
 ${ATS_MAKE} -j $NPROCS -C lib all-local V=1 Q=
 
-${LLVM_BASE}/bin/scan-build ${checkers} ${options} -o ${output} --html-title="clang-analyzer: ${ATS_BRANCH}" ${ATS_MAKE} -j $NPROCS V=1 Q=
+${LLVM_BASE}/bin/scan-build ${checkers} ${options} -o ${output} \
+	    --html-title="clang-analyzer: ${ATS_BRANCH}${github_pr}"\
+	    ${ATS_MAKE} -j $NPROCS V=1 Q=
 status=$?
 
 # Clean the work area unless NOCLEAN is set. This is jsut for debugging when you
@@ -67,6 +90,7 @@ status=$?
 if [ ! -z "$NOCLEAN" ]; then
   ${ATS_MAKE} distclean
 fi
+[ "$output" != "/tmp" ] && echo "Results (if any) can be found at ${results_url}"
 
 # Cleanup old reports, for main clang and github as well (if the local helper script is available)
 if [ -x "/admin/bin/clean-clang.sh" ]; then


### PR DESCRIPTION
In addition to making the Github Reports sub-treed by the PR number, this also makes it possible
to override the set of rules (or other configs) per branch. Similar to how we have e.g. a ._clang-format_ file, we now have a ._clang-analyzer_ file.