### PR TITLE
Send HPACK dynamic table size update at the beginning of header block

### DIFF
--- a/proxy/http2/HPACK.h
+++ b/proxy/http2/HPACK.h
@@ -122,6 +122,7 @@ public:
   const MIMEField *get_header_field(uint32_t index) const;
   void add_header_field(const MIMEField *field);
 
+  uint32_t maximum_size() const;
   uint32_t size() const;
   bool update_maximum_size(uint32_t new_size);
 
@@ -146,6 +147,7 @@ public:
   int get_header_field(uint32_t index, MIMEFieldWrapper &header_field) const;
 
   void add_header_field(const MIMEField *field);
+  uint32_t maximum_size() const;
   uint32_t size() const;
   bool update_maximum_size(uint32_t new_size);
 
@@ -173,6 +175,8 @@ int64_t update_dynamic_table_size(const uint8_t *buf_start, const uint8_t *buf_e
 typedef HpackIndexingTable HpackHandle;
 int64_t hpack_decode_header_block(HpackHandle &handle, HTTPHdr *hdr, const uint8_t *in_buf, const size_t in_buf_len,
                                   uint32_t max_header_size);
-int64_t hpack_encode_header_block(HpackHandle &handle, uint8_t *out_buf, const size_t out_buf_len, HTTPHdr *hdr);
+int64_t hpack_encode_header_block(HpackHandle &handle, uint8_t *out_buf, const size_t out_buf_len, HTTPHdr *hdr,
+                                  int32_t maximum_table_size = -1);
+int32_t hpack_get_maximum_table_size(HpackHandle &handle);
 
 #endif /* __HPACK_H__ */

--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -356,7 +356,7 @@ bool http2_parse_window_update(IOVec, uint32_t &);
 
 Http2ErrorCode http2_decode_header_blocks(HTTPHdr *, const uint8_t *, const uint32_t, uint32_t *, HpackHandle &, bool &);
 
-Http2ErrorCode http2_encode_header_blocks(HTTPHdr *, uint8_t *, uint32_t, uint32_t *, HpackHandle &);
+Http2ErrorCode http2_encode_header_blocks(HTTPHdr *, uint8_t *, uint32_t, uint32_t *, HpackHandle &, int32_t);
 
 ParseResult http2_convert_header_from_2_to_1_1(HTTPHdr *);
 void http2_generate_h2_header_from_1_1(HTTPHdr *headers, HTTPHdr *h2_headers);

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1324,7 +1324,8 @@ Http2ConnectionState::send_headers_frame(Http2Stream *stream)
     h2_hdr.destroy();
     return;
   }
-  Http2ErrorCode result = http2_encode_header_blocks(&h2_hdr, buf, buf_len, &header_blocks_size, *(this->remote_hpack_handle));
+  Http2ErrorCode result = http2_encode_header_blocks(&h2_hdr, buf, buf_len, &header_blocks_size, *(this->remote_hpack_handle),
+                                                     client_settings.get(HTTP2_SETTINGS_HEADER_TABLE_SIZE));
   if (result != Http2ErrorCode::HTTP2_ERROR_NO_ERROR) {
     h2_hdr.destroy();
     ats_free(buf);
@@ -1413,7 +1414,8 @@ Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url)
     h2_hdr.destroy();
     return;
   }
-  Http2ErrorCode result = http2_encode_header_blocks(&h2_hdr, buf, buf_len, &header_blocks_size, *(this->remote_hpack_handle));
+  Http2ErrorCode result = http2_encode_header_blocks(&h2_hdr, buf, buf_len, &header_blocks_size, *(this->remote_hpack_handle),
+                                                     client_settings.get(HTTP2_SETTINGS_HEADER_TABLE_SIZE));
   if (result != Http2ErrorCode::HTTP2_ERROR_NO_ERROR) {
     h2_hdr.destroy();
     ats_free(buf);


### PR DESCRIPTION
This closes #1591.

There are two commits. The first one is a bug fix for the table size update issue. The second commit adds an implementation limit to avoid abusing. The maximum table size is advertised by clients, but we can use any value lower than the value. The value 64k is came from major client implementations.
https://bugzilla.mozilla.org/show_bug.cgi?id=1296280
https://bugs.chromium.org/p/chromium/issues/detail?id=642784

 I will squash the commits before merging.