### PR TITLE
Add --enable-sanity-check option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -167,6 +167,14 @@ AC_ARG_ENABLE([debug],
 )
 AC_MSG_RESULT([$enable_debug])
 
+AC_MSG_CHECKING([whether to enable mime sanity check])
+AC_ARG_ENABLE([mime-sanity-check],
+  [AS_HELP_STRING([--enable-mime-sanity-check],[turn on mime sanity check])],
+  [],
+  [enable_mime_sanity_check=no]
+)
+AC_MSG_RESULT([$enable_mime_sanity_check])
+
 # Enable code coverage instrumentation only if requested by the user.
 AC_MSG_CHECKING([whether to code coverage])
 AC_ARG_ENABLE([coverage],
@@ -939,6 +947,9 @@ if test "x${enable_debug}" = "xyes"; then
   TS_ADDTO(AM_CFLAGS, [${cc_oflag_dbg}])
   TS_ADDTO(AM_CXXFLAGS, [${cxx_oflag_dbg}])
   TS_ADDTO(AM_CPPFLAGS, [-DDEBUG -D_DEBUG])
+  if test "x${enable_mime_sanity_check}" = "xyes"; then
+    TS_ADDTO(AM_CPPFLAGS, [-DENABLE_MIME_SANITY_CHECK])
+  fi
 else
   TS_ADDTO(AM_CFLAGS, [${cc_oflag_opt}])
   TS_ADDTO(AM_CXXFLAGS, [${cxx_oflag_opt}])

--- a/proxy/hdrs/MIME.h
+++ b/proxy/hdrs/MIME.h
@@ -67,7 +67,7 @@ enum MimeParseState {
  *                                                                     *
  ***********************************************************************/
 
-#ifdef DEBUG
+#ifdef ENABLE_MIME_SANITY_CHECK
 #define MIME_HDR_SANITY_CHECK mime_hdr_sanity_check
 #else
 #define MIME_HDR_SANITY_CHECK (void)


### PR DESCRIPTION
I'd like to introduce --enable-sanity-check option to disable sanity check for MIME headers.

The sanity check is a heavy check. It haven't been a problem because we didn't store so many headers, but now it is. Our HPACK implementation uses MIMEHdr internally, and it handles lots of headers and frequently append and delete them.

I ran test_HPACK with and without debug flag, and it took about 100x more time with the flag. Also, I tried appending 2000 headers into a MIMEHdr (not HPACK), then it took over 900 seconds just for 2000 headers if debug is on.

Sometimes we have to run ATS built with debug flag under certain load, but the check is now too heavy to run on a test box. So I added a configure option to disable only the sanity check.

To make --enable-debug option the master switch, the sanity check will be enabled if both --enable-debug and --enable-sanity-check was specified.

I'm not 100% sure but I think this mitigate the CPU usage problem on #1593.