### PR TITLE
Add TS_HTTP_RESPONSE_CLIENT_HOOK into cppapi

### DIFF
--- a/lib/cppapi/Plugin.cc
+++ b/lib/cppapi/Plugin.cc
@@ -21,12 +21,17 @@
  */
 #include "atscppapi/Plugin.h"
 #include <ts/ts.h>
-const std::string atscppapi::HOOK_TYPE_STRINGS[] = {
-  std::string("HOOK_READ_REQUEST_HEADERS_PRE_REMAP"), std::string("HOOK_READ_REQUEST_HEADERS_POST_REMAP"),
-  std::string("HOOK_SEND_REQUEST_HEADERS"),           std::string("HOOK_READ_RESPONSE_HEADERS"),
-  std::string("HOOK_SEND_RESPONSE_HEADERS"),          std::string("HOOK_OS_DNS"),
-  std::string("HOOK_READ_REQUEST_HEADERS"),           std::string("HOOK_READ_CACHE_HEADERS"),
-  std::string("HOOK_CACHE_LOOKUP_COMPLETE"),          std::string("HOOK_SELECT_ALT")};
+const std::string atscppapi::HOOK_TYPE_STRINGS[] = {std::string("HOOK_READ_REQUEST_HEADERS_PRE_REMAP"),
+                                                    std::string("HOOK_READ_REQUEST_HEADERS_POST_REMAP"),
+                                                    std::string("HOOK_SEND_REQUEST_HEADERS"),
+                                                    std::string("HOOK_READ_RESPONSE_HEADERS"),
+                                                    std::string("HOOK_SEND_RESPONSE_HEADERS"),
+                                                    std::string("HOOK_OS_DNS"),
+                                                    std::string("HOOK_READ_REQUEST_HEADERS"),
+                                                    std::string("HOOK_READ_CACHE_HEADERS"),
+                                                    std::string("HOOK_CACHE_LOOKUP_COMPLETE"),
+                                                    std::string("HOOK_SELECT_ALT"),
+                                                    std::string("HOOK_RESPONSE_CLIENT")};
 
 void
 atscppapi::RegisterGlobalPlugin(const char *name, const char *vendor, const char *email)

--- a/lib/cppapi/include/atscppapi/Plugin.h
+++ b/lib/cppapi/include/atscppapi/Plugin.h
@@ -59,7 +59,8 @@ public:
     HOOK_READ_REQUEST_HEADERS,  /**< This hook will be fired after the request is read. */
     HOOK_READ_CACHE_HEADERS,    /**< This hook will be fired after the CACHE hdrs. */
     HOOK_CACHE_LOOKUP_COMPLETE, /**< This hook will be fired after caceh lookup complete. */
-    HOOK_SELECT_ALT             /**< This hook will be fired after select alt. */
+    HOOK_SELECT_ALT,            /**< This hook will be fired after select alt. */
+    HOOK_RESPONSE_CLIENT /**< This is a special hook that supports a special type of transformation -- input with no output */
   };
 
   /**
@@ -148,6 +149,15 @@ public:
    */
   virtual void
   handleSelectAlt(Transaction &transaction)
+  {
+    transaction.resume();
+  };
+
+  /**
+   * This method must be implemented when you hook HOOK_RESPONSE_CLIENT
+   */
+  virtual void
+  handleResponseClient(Transaction &transaction)
   {
     transaction.resume();
   };

--- a/lib/cppapi/utils_internal.cc
+++ b/lib/cppapi/utils_internal.cc
@@ -144,6 +144,8 @@ void inline invokePluginForEvent(Plugin *plugin, TSHttpTxn ats_txn_handle, TSEve
   case TS_EVENT_HTTP_SELECT_ALT:
     plugin->handleSelectAlt(transaction);
     break;
+  case TS_HTTP_RESPONSE_CLIENT_HOOK:
+    plugin->handleResponseClient(transaction);
 
   default:
     assert(false); /* we should never get here */
@@ -195,6 +197,8 @@ utils::internal::convertInternalHookToTsHook(Plugin::HookType hooktype)
     return TS_HTTP_CACHE_LOOKUP_COMPLETE_HOOK;
   case Plugin::HOOK_SELECT_ALT:
     return TS_HTTP_SELECT_ALT_HOOK;
+  case Plugin::HOOK_RESPONSE_CLIENT:
+    return TS_HTTP_RESPONSE_CLIENT_HOOK;
   default:
     assert(false); // shouldn't happen, let's catch it early
     break;


### PR DESCRIPTION
The hook was not present before.

Side note: it seems like touching the `HOOK_TYPE_STRINGS` array woke clang-format up.