### PR TITLE
Proper support for the %{URL:<qual>} conditions

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -179,7 +179,7 @@ CLIENT-IP
 Remote IP address, as a string, of the client connection for the current
 transaction.
 
-This condition is *deprecated* as of ATS v7.2.x, please use %{IP:CLIENT} instead.
+This condition is *deprecated* as of ATS v7.1.x, please use %{IP:CLIENT} instead.
 
 CLIENT-URL
 ~~~~~~~~~~
@@ -376,6 +376,10 @@ first).
 Refer to `Requests vs. Responses`_ for more information on determining the
 context in which the transaction's URL is evaluated.
 
+This condition is *deprecated* as of ATS v7.1.x, please use e.g. %{URL:PATH}
+or %{CLIENT-URL:PATH} instead.
+
+
 QUERY
 ~~~~~
 ::
@@ -385,6 +389,10 @@ QUERY
 The query parameters, if any, of the transaction.  Refer to `Requests vs.
 Responses`_ for more information on determining the context in which the
 transaction's URL is evaluated.
+
+This condition is *deprecated* as of ATS v7.1.x, please use e.g. %{URL:QUERY}
+or %{CLIENT-URL:QUERY} instead.
+
 
 RANDOM
 ~~~~~~
@@ -444,14 +452,15 @@ URL
 ~~~
 ::
 
-    cond %{URL:option} <operand>
+    cond %{URL:<part>} <operand>
 
 The complete URL of the current transaction. This will automatically choose the
 most relevant URL depending upon the hook context in which the condition is
 being evaluated.
 
 Refer to `Requests vs. Responses`_ for more information on determining the
-context in which the transaction's URL is evaluated.
+context in which the transaction's URL is evaluated.  The ``<part>`` may be
+specified according to the options documented in `URL Parts`_.
 
 Condition Operands
 ------------------


### PR DESCRIPTION
This was never properly, or completely, implemented. This makes sure that
the URL conditions works as both conditions and values. Supported qualifiers
are e.g.

```
cond %{SEND_RESPONSE_HDR_HOOK} [AND]
cond %{CLIENT-URL:SCHEME} =http
     set-header X-Url %{CLIENT-URL}
     set-header X-Url-Scheme %{CLIENT-URL:SCHEME}
     set-header X-Url-Host %{CLIENT-URL:HOST}
     set-header X-Url-Port %{CLIENT-URL:PORT}
     set-header X-Url-Path %{CLIENT-URL:PATH}
     set-header X-Url-Query %{CLIENT-URL:QUERY}
     set-header X-Url-Matrix %{CLIENT-URL:MATRIX}
```