### PR TITLE
Fix inactivity_timeout canceling

### DIFF
--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1514,9 +1514,10 @@ UnixNetVConnection::set_inactivity_timeout(ink_hrtime timeout_in)
 #else
   if (timeout_in == 0) {
     // set default inactivity timeout
-    inactivity_timeout_in = timeout_in = HRTIME_SECONDS(nh->default_inactivity_timeout);
+    timeout_in = HRTIME_SECONDS(nh->default_inactivity_timeout);
   }
-  next_inactivity_timeout_at = Thread::get_hrtime() + timeout_in;
+  inactivity_timeout_in      = timeout_in;
+  next_inactivity_timeout_at = Thread::get_hrtime() + inactivity_timeout_in;
 #endif
 }
 


### PR DESCRIPTION
Last few years, we're seeing inactivity_timeout doesn't work as expected in some cases.
Below is some debug logs when `proxy.config.http2.no_activity_timeout_in` is set `3`.

```
# 1. connection initialized
[Apr 21 09:42:27.994] Server {0xb0012000} DEBUG: <UnixNetVConnection.cc:1492 (set_inactivity_timeout)> (socket) Set inactive timeout=0, for NetVC=0xaabb70
[Apr 21 09:42:27.994] Server {0xb0012000} DEBUG: <UnixNetVConnection.cc:1492 (set_inactivity_timeout)> (socket) Set inactive timeout=86400000000000, for NetVC=0xaabb70
[Apr 21 09:42:27.994] Server {0xb0012000} DEBUG: <UnixNetVConnection.cc:1492 (set_inactivity_timeout)> (socket) Set inactive timeout=0, for NetVC=0xaabb70

# 2. accept connection and set proxy.config.http2.accept_no_activity_timeout
[Apr 21 09:42:28.002] Server {0xb0012000} DEBUG: <Http2SessionAccept.cc:54 (accept)> (http2_seq) [HttpSessionAccept2:mainEvent 0xaabb70] accepted connection from 127.0.0.1:57528 transport type = 4
[Apr 21 09:42:28.003] Server {0xb0012000} DEBUG: <UnixNetVConnection.cc:1492 (set_inactivity_timeout)> (socket) Set inactive timeout=120000000000, for NetVC=0xaabb70
[Apr 21 09:42:28.003] Server {0xb0012000} DEBUG: <Http2ClientSession.cc:185 (new_connection)> (http2_cs) [0] session born, netvc 0xaabb70

# 3. read and update inactivity timeout
[Apr 21 09:42:28.004] Server {0xb0012000} DEBUG: <Http2ClientSession.cc:351 (state_read_connection_preface)> (http2_cs) [0] [&Http2ClientSession::state_read_connection_preface, VC_EVENT_READ_READY]
[Apr 21 09:42:28.004] Server {0xb0012000} DEBUG: <UnixNetVConnection.cc:64 (net_activity)> (socket) net_activity updating inactivity 86400000000000, NetVC=0xaabb70    <---- !!!!!!

# 4. set proxy.config.http2.no_activity_timeout_in
[Apr 21 09:42:28.004] Server {0xb0012000} DEBUG: <Http2ClientSession.cc:367 (state_read_connection_preface)> (http2_cs) [0] received connection preface
[Apr 21 09:42:28.004] Server {0xb0012000} DEBUG: <UnixNetVConnection.cc:1492 (set_inactivity_timeout)> (socket) Set inactive timeout=3000000000, for NetVC=0xaabb70

# 5. read and update inactivity timeout
[Apr 21 09:42:28.004] Server {0xb0012000} DEBUG: <Http2ClientSession.cc:396 (state_start_frame_read)> (http2_cs) [0] [&Http2ClientSession::state_start_frame_read, VC_EVENT_READ_READY]
[Apr 21 09:42:28.018] Server {0xb0012000} DEBUG: <UnixNetVConnection.cc:64 (net_activity)> (socket) net_activity updating inactivity 86400000000000, NetVC=0xaabb70    <---- !!!!!!
[Apr 21 09:42:28.018] Server {0xb0012000} DEBUG: <UnixNetVConnection.cc:64 (net_activity)> (socket) net_activity updating inactivity 86400000000000, NetVC=0xaabb70    <---- !!!!!!
```

It looks like when some read or write is happened, inactivity timeout is updated by a value of `proxy.config.net.default_inactivity_timeout` (86400000000000). Is this expected behavior?
IMO, a value should be used which is passed by `UnixNetVConnection::set_inactivity_timeout(ink_hrtime timeout_in)`.

With this patch, it works as expected.
```
# connection initialized
[Apr 21 09:35:36.564] Server {0xb0012000} DEBUG: <UnixNetVConnection.cc:1492 (set_inactivity_timeout)> (socket) Set inactive timeout=0, for NetVC=0x2d50b70
[Apr 21 09:35:36.564] Server {0xb0012000} DEBUG: <UnixNetVConnection.cc:1492 (set_inactivity_timeout)> (socket) Set inactive timeout=86400000000000, for NetVC=0x2d50b70
[Apr 21 09:35:36.564] Server {0xb0012000} DEBUG: <UnixNetVConnection.cc:1492 (set_inactivity_timeout)> (socket) Set inactive timeout=0, for NetVC=0x2d50b70

# accept connection and set proxy.config.http2.accept_no_activity_timeout
[Apr 21 09:35:36.572] Server {0xb0012000} DEBUG: <Http2SessionAccept.cc:54 (accept)> (http2_seq) [HttpSessionAccept2:mainEvent 0x2d50b70] accepted connection from 127.0.0.1:57512 transport type = 4
[Apr 21 09:35:36.573] Server {0xb0012000} DEBUG: <UnixNetVConnection.cc:1492 (set_inactivity_timeout)> (socket) Set inactive timeout=120000000000, for NetVC=0x2d50b70
[Apr 21 09:35:36.573] Server {0xb0012000} DEBUG: <Http2ClientSession.cc:185 (new_connection)> (http2_cs) [0] session born, netvc 0x2d50b70

# read and update inactivity timeout
[Apr 21 09:35:36.573] Server {0xb0012000} DEBUG: <Http2ClientSession.cc:351 (state_read_connection_preface)> (http2_cs) [0] [&Http2ClientSession::state_read_connection_preface, VC_EVENT_READ_READY]
[Apr 21 09:35:36.573] Server {0xb0012000} DEBUG: <UnixNetVConnection.cc:64 (net_activity)> (socket) net_activity updating inactivity 120000000000, NetVC=0x2d50b70

#  set proxy.config.http2.no_activity_timeout_in
[Apr 21 09:35:36.573] Server {0xb0012000} DEBUG: <Http2ClientSession.cc:367 (state_read_connection_preface)> (http2_cs) [0] received connection preface
[Apr 21 09:35:36.573] Server {0xb0012000} DEBUG: <UnixNetVConnection.cc:1492 (set_inactivity_timeout)> (socket) Set inactive timeout=3000000000, for NetVC=0x2d50b70

# read and update inactivity timeout
[Apr 21 09:35:36.573] Server {0xb0012000} DEBUG: <Http2ClientSession.cc:396 (state_start_frame_read)> (http2_cs) [0] [&Http2ClientSession::state_start_frame_read, VC_EVENT_READ_READY]
[Apr 21 09:35:36.588] Server {0xb0012000} DEBUG: <UnixNetVConnection.cc:64 (net_activity)> (socket) net_activity updating inactivity 3000000000, NetVC=0x2d50b70
[Apr 21 09:35:36.588] Server {0xb0012000} DEBUG: <UnixNetVConnection.cc:64 (net_activity)> (socket) net_activity updating inactivity 3000000000, NetVC=0x2d50b70
```