### PR TITLE
Add SINK_TRANSFORM option to CPPAPI

### DIFF
--- a/lib/cppapi/TransformationPlugin.cc
+++ b/lib/cppapi/TransformationPlugin.cc
@@ -321,6 +321,10 @@ TransformationPlugin::produce(const std::string &data)
   if (state_->type_ == REQUEST_TRANSFORMATION) {
     state_->request_xform_output_.append(data);
     return data.size();
+  } else if (state_->type_ == SINK_TRANSFORMATION) {
+    LOG_DEBUG("produce TransformationPlugin=%p tshttptxn=%p : This is a sink transform. Not producing any output", this,
+              state_->txn_);
+    return 0;
   } else {
     return doProduce(data);
   }
@@ -329,7 +333,13 @@ TransformationPlugin::produce(const std::string &data)
 size_t
 TransformationPlugin::setOutputComplete()
 {
-  if (state_->type_ == REQUEST_TRANSFORMATION) {
+  if (state_->type_ == SINK_TRANSFORMATION) {
+    // There's no output stream for a sink transform, so we do nothing
+    //
+    // Warning: don't try to shutdown the VConn, since the default implementation (DummyVConnection)
+    // has a stubbed out shutdown/close implementation
+    return 0;
+  } else if (state_->type_ == REQUEST_TRANSFORMATION) {
     doProduce(state_->request_xform_output_);
   }
 

--- a/lib/cppapi/include/atscppapi/TransformationPlugin.h
+++ b/lib/cppapi/include/atscppapi/TransformationPlugin.h
@@ -86,7 +86,9 @@ public:
    */
   enum Type {
     REQUEST_TRANSFORMATION = 0, /**< Transform the Request body content */
-    RESPONSE_TRANSFORMATION     /**< Transform the Response body content */
+    RESPONSE_TRANSFORMATION,    /**< Transform the Response body content */
+    SINK_TRANSFORMATION         /**< Sink transformation, meaning you get a separate stream of the Response
+                                     body content that does not get hooked up to a downstream input */
   };
 
   /**

--- a/lib/cppapi/utils_internal.cc
+++ b/lib/cppapi/utils_internal.cc
@@ -210,6 +210,8 @@ utils::internal::convertInternalTransformationTypeToTsHook(TransformationPlugin:
     return TS_HTTP_RESPONSE_TRANSFORM_HOOK;
   case TransformationPlugin::REQUEST_TRANSFORMATION:
     return TS_HTTP_REQUEST_TRANSFORM_HOOK;
+  case TransformationPlugin::SINK_TRANSFORMATION:
+    return TS_HTTP_RESPONSE_CLIENT_HOOK;
   default:
     assert(false); // shouldn't happen, let's catch it early
     break;


### PR DESCRIPTION
This adds support for the TS_HTTP_RESPONSE_CLIENT_HOOK into the CPPAPI
TransformationPlugin. TS_HTTP_RESPONSE_CLIENT_HOOK is a unique
transformation hook in that there is an input channel but no output
channel.

To the best of my knowledge, this patch is correct. I tested it with a custom plugin and all seems well. One thing to note is that we can never actually *close* the output end of the VConn. That's because the output connection is a stubbed out class.

This is a redo of #1713 