### PR TITLE
Remove useless icp enabled flags from HttpSM and hopefully fix a clang analyzer bug.

### DIFF
--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -4535,21 +4535,6 @@ TSLifecycleHookAdd(TSLifecycleHookID id, TSCont contp)
   lifecycle_hooks->append(id, (INKContInternal *)contp);
 }
 
-void
-TSHttpIcpDynamicSet(int value)
-{
-  int32_t old_value, new_value;
-
-  new_value = (value == 0) ? 0 : 1;
-  old_value = icp_dynamic_enabled;
-  while (old_value != new_value) {
-    if (ink_atomic_cas(&icp_dynamic_enabled, old_value, new_value)) {
-      break;
-    }
-    old_value = icp_dynamic_enabled;
-  }
-}
-
 /* HTTP sessions */
 void
 TSHttpSsnHookAdd(TSHttpSsn ssnp, TSHttpHookID id, TSCont contp)

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -1004,9 +1004,6 @@ HttpConfig::startup()
   HttpEstablishStaticConfigByte(c.enable_http_stats, "proxy.config.http.enable_http_stats");
   HttpEstablishStaticConfigByte(c.oride.normalize_ae_gzip, "proxy.config.http.normalize_ae_gzip");
 
-  HttpEstablishStaticConfigByte(c.icp_enabled, "proxy.config.icp.enabled");
-  HttpEstablishStaticConfigByte(c.stale_icp_enabled, "proxy.config.icp.stale_icp_enabled");
-
   HttpEstablishStaticConfigLongLong(c.oride.cache_heuristic_min_lifetime, "proxy.config.http.cache.heuristic_min_lifetime");
   HttpEstablishStaticConfigLongLong(c.oride.cache_heuristic_max_lifetime, "proxy.config.http.cache.heuristic_max_lifetime");
   HttpEstablishStaticConfigFloat(c.oride.cache_heuristic_lm_factor, "proxy.config.http.cache.heuristic_lm_factor");
@@ -1293,9 +1290,6 @@ HttpConfig::reconfigure()
   params->oride.insert_age_in_response       = INT_TO_BOOL(m_master.oride.insert_age_in_response);
   params->enable_http_stats                  = INT_TO_BOOL(m_master.enable_http_stats);
   params->oride.normalize_ae_gzip            = INT_TO_BOOL(m_master.oride.normalize_ae_gzip);
-
-  params->icp_enabled       = (m_master.icp_enabled == ICP_MODE_SEND_RECEIVE ? 1 : 0); // INT_TO_BOOL
-  params->stale_icp_enabled = INT_TO_BOOL(m_master.stale_icp_enabled);
 
   params->oride.cache_heuristic_min_lifetime = m_master.oride.cache_heuristic_min_lifetime;
   params->oride.cache_heuristic_max_lifetime = m_master.oride.cache_heuristic_max_lifetime;

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -800,9 +800,6 @@ public:
 
   MgmtByte enable_http_stats; // Can be "slow"
 
-  MgmtByte icp_enabled;
-  MgmtByte stale_icp_enabled;
-
   MgmtByte cache_post_method;
 
   MgmtByte push_method_enabled;
@@ -872,9 +869,6 @@ public:
   static HttpConfigParams m_master;
 };
 
-// DI's request to disable ICP on the fly
-extern volatile int32_t icp_dynamic_enabled;
-
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 //
@@ -911,8 +905,6 @@ inline HttpConfigParams::HttpConfigParams()
     use_client_target_addr(0),
     use_client_source_port(0),
     enable_http_stats(1),
-    icp_enabled(0),
-    stale_icp_enabled(0),
     cache_post_method(0),
     push_method_enabled(0),
     referer_filter_enabled(0),

--- a/proxy/http/HttpProxyServerMain.cc
+++ b/proxy/http/HttpProxyServerMain.cc
@@ -238,9 +238,6 @@ init_HttpProxyServer(int n_accept_threads)
   ink_mutex_init(&debug_cs_list_mutex, "HttpCS Debug List");
 #endif
 
-  // DI's request to disable/reenable ICP on the fly
-  icp_dynamic_enabled = 1;
-
   // Used to give plugins the ability to create http requests
   //   The equivalent of the connecting to localhost on the  proxy
   //   port but without going through the operating system

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -949,7 +949,6 @@ public:
     bool api_req_cacheable;
     bool api_resp_cacheable;
     bool api_server_addr_set;
-    bool stale_icp_lookup;
     UpdateCachedObject_t api_update_cached_object;
     LockUrl_t api_lock_url;
     StateMachineAction_t saved_update_next_action;
@@ -1063,7 +1062,6 @@ public:
         api_req_cacheable(false),
         api_resp_cacheable(false),
         api_server_addr_set(false),
-        stale_icp_lookup(false),
         api_update_cached_object(UPDATE_CACHED_OBJECT_NONE),
         api_lock_url(LOCK_URL_FIRST),
         saved_update_next_action(SM_ACTION_UNDEFINED),


### PR DESCRIPTION
The bug seems related to `icp_enabled` which isn't used, so let's KIWF and see if that's bettter.