### PR TITLE
Docs: Add macro to link to Github

### DIFF
--- a/doc/developer-guide/documentation/ts-markup.en.rst
+++ b/doc/developer-guide/documentation/ts-markup.en.rst
@@ -216,3 +216,22 @@ domain reference markup should be used::
 
 References should not include the collection name, data type, or any other
 components aside from the statistic name.
+
+Referencing source code
+-----------------------
+
+To reference source code from the documentation, use the following markup::
+
+    :ts:git:`path/to/source/file`
+
+This creates a link to Github. Sphinx does its best to pin the reference to the
+current release version of |ATS|.
+
+Avoid using hard links to Github as Github may be replaced with another host
+in the future.
+
+.. note::
+
+    Although adding the ability to point to a specific line number would not be
+    difficult, code shifts around too much and this feature would only cause
+    confusion to a downstream reader. This feature was deliberately omitted.


### PR DESCRIPTION
This patch adds in a quality of life macro to link to Github from
reStructuredText documentation.

For example, to add a link to the logging header:
    ``:ts:git:`proxy/logging/Log.h` ``