### PR TITLE
HTTP/2 transaction thought it was being aborted by the client

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -397,7 +397,7 @@ Http2Stream::initiating_close()
     // We are sending signals rather than calling the handlers directly to avoid the case where
     // the HttpTunnel handler causes the HttpSM to be deleted on the stack.
     bool sent_write_complete = false;
-    if (current_reader && this->is_client_state_writeable()) {
+    if (current_reader) {
       // Push out any last IO events
       if (write_vio._cont) {
         SCOPED_MUTEX_LOCK(lock, write_vio.mutex, this_ethread());


### PR DESCRIPTION
Fixed an issue where io events were based on the state of the stream.
This showed up after a bug in is_client_state_writeable() was fixed in:
b2bddd32e555326fd4231881bde6c8d4da380965

(cherry picked from commit 78414357112f8947eb0d5843823ae37374a5fcf3)