### PR TITLE
Fix Last-Stream-ID of GOAWAY frame

### DIFF
--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -495,7 +495,7 @@ Http2ClientSession::state_process_frame_read(int event, VIO *vio, bool inside_fr
       if (err > Http2ErrorCode::HTTP2_ERROR_NO_ERROR) {
         SCOPED_MUTEX_LOCK(lock, this->connection_state.mutex, this_ethread());
         if (!this->connection_state.is_state_closed()) {
-          this->connection_state.send_goaway_frame(this->current_hdr.streamid, err);
+          this->connection_state.send_goaway_frame(this->connection_state.get_latest_stream_id_in(), err);
         }
       }
       return 0;

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -897,7 +897,7 @@ Http2ConnectionState::main_event_handler(int event, void *edata)
           Error("HTTP/2 connection error client_ip=%s session_id=%" PRId64 " %s", client_ip, ua_session->connection_id(),
                 error.msg);
         }
-        this->send_goaway_frame(stream_id, error.code);
+        this->send_goaway_frame(this->latest_streamid_in, error.code);
         // The streams will be cleaned up by the HTTP2_SESSION_EVENT_FINI event
         // The Http2ClientSession will shutdown because connection_state.is_state_closed() will be true
 
@@ -1350,7 +1350,7 @@ Http2ConnectionState::send_headers_frame(Http2Stream *stream)
 
   // Change stream state
   if (!stream->change_state(HTTP2_FRAME_TYPE_HEADERS, flags)) {
-    this->send_goaway_frame(stream->get_id(), Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR);
+    this->send_goaway_frame(this->latest_streamid_in, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR);
     h2_hdr.destroy();
     ats_free(buf);
     return;
@@ -1508,7 +1508,7 @@ Http2ConnectionState::send_rst_stream_frame(Http2StreamId id, Http2ErrorCode ec)
   Http2Stream *stream = find_stream(id);
   if (stream != nullptr) {
     if (!stream->change_state(HTTP2_FRAME_TYPE_RST_STREAM, 0)) {
-      this->send_goaway_frame(stream->get_id(), Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR);
+      this->send_goaway_frame(this->latest_streamid_in, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR);
       return;
     }
   }
@@ -1541,7 +1541,7 @@ Http2ConnectionState::send_settings_frame(const Http2ConnectionSettings &new_set
 
       // Write settings to send buffer
       if (!http2_write_settings(param, iov)) {
-        send_goaway_frame(0, Http2ErrorCode::HTTP2_ERROR_INTERNAL_ERROR);
+        send_goaway_frame(this->latest_streamid_in, Http2ErrorCode::HTTP2_ERROR_INTERNAL_ERROR);
         return;
       }
       iov.iov_base = reinterpret_cast<uint8_t *>(iov.iov_base) + HTTP2_SETTINGS_PARAMETER_LEN;


### PR DESCRIPTION
[RFC-7540](http://httpwg.org/specs/rfc7540.html#GOAWAY) says below

> The last stream identifier in the GOAWAY frame contains the highest-numbered stream identifier for which the sender of the GOAWAY frame might have taken some action on or might yet take action on. 

So, basically TS should indicate `latest_streamid_in` of `Http2ConnectionState` to client.