### PR TITLE
TS-4976: Regularize plugins - replace-protoset changed to disable_http2

### DIFF
--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -56,7 +56,7 @@ example_Plugins = \
 	thread-1.la \
 	txn-data-sink.la \
 	version.la \
-	replace-protoset.la
+	disable_http2.la
 
 example_Plugins += \
 	cppapi/AsyncHttpFetch.la \
@@ -117,7 +117,7 @@ server_transform_la_SOURCES = server-transform/server-transform.c
 ssl_preaccept_la_SOURCES = ssl-preaccept/ssl-preaccept.cc
 ssl_sni_la_SOURCES = ssl-sni/ssl-sni.cc
 ssl_sni_whitelist_la_SOURCES = ssl-sni-whitelist/ssl-sni-whitelist.cc
-replace_protoset_la_SOURCES = replace-protoset/replace-protoset.cc
+disable_http2_la_SOURCES = disable_http2/disable_http2.cc
 statistic_la_SOURCES = statistic/statistic.cc
 thread_1_la_SOURCES = thread-1/thread-1.c
 txn_data_sink_la_SOURCES = txn-data-sink/txn-data-sink.c

--- a/example/disable_http2/readme.txt
+++ b/example/disable_http2/readme.txt
@@ -1,0 +1,7 @@
+Usage:
+
+In plugins.config,
+
+disable_http2 sni_a sni_b [...]
+
+For connections with any of these SNI values, HTTP/2 will be removed (disabled) from the list of valid next protocols.


### PR DESCRIPTION
A fairly simple fixup. I changed the name to `disable_http2` because that's much more indicative of what the plugin does. I added a `readme.txt` for further clarification.