### PR TITLE
Remove redundant common definitions

### DIFF
--- a/doc/common.defs
+++ b/doc/common.defs
@@ -26,30 +26,3 @@
 .. |TS| replace:: Traffic Server
 
 .. |RST| replace:: reStructuredText
-
-.. Files in github.
-.. TODO: Should write a custom domain so we can do :ts:git:`iocore/cache/P_CacheDir.h`
-
-.. |HTTP.h| replace:: ``HTTP.h``
-
-.. _HTTP.h: https://github.com/apache/trafficserver/blob/master/proxy/hdrs/HTTP.h
-
-.. |HttpCacheSM.h| replace:: ``HttpCacheSM.h``
-
-.. _HttpCacheSM.h: https://github.com/apache/trafficserver/blob/master/proxy/http/HttpCacheSM.h
-
-.. |HttpCacheSM.cc| replace:: ``HttpCacheSM.cc``
-
-.. _HttpCacheSM.cc: https://github.com/apache/trafficserver/blob/master/proxy/http/HttpCacheSM.cc
-
-.. |P-CacheDir.h| replace:: ``P_CacheDir.h``
-
-.. _P-CacheDir.h: https://github.com/apache/trafficserver/blob/master/iocore/cache/P_CacheDir.h
-
-.. |P-CacheHttp.h| replace:: ``P_CacheHttp.h``
-
-.. _P-CacheHttp.h: https://github.com/apache/trafficserver/blob/master/iocore/cache/P_CacheHttp.h
-
-.. |P-CacheVol.h| replace:: ``P_CacheVol.h``
-
-.. _P-CacheVol.h: https://github.com/apache/trafficserver/blob/master/iocore/cache/P_CacheVol.h

--- a/doc/developer-guide/architecture/architecture.en.rst
+++ b/doc/developer-guide/architecture/architecture.en.rst
@@ -499,7 +499,7 @@ The in memory volume directory entries are described below.
 
 .. cpp:class:: Dir
 
-   Defined in |P-CacheDir.h|_.
+   Defined in :ts:git:`iocore/cache/P_CacheDir.h`.
 
    =========== =================== ===================================================
    Name        Type                Use

--- a/doc/developer-guide/architecture/data-structures.en.rst
+++ b/doc/developer-guide/architecture/data-structures.en.rst
@@ -54,13 +54,13 @@ Data Structures
 
 .. cpp:class:: CacheHTTPInfoVector
 
-   Defined in |P-CacheHttp.h|_. This is an array of :cpp:class:`HTTPInfo`
+   Defined in :ts:git:`iocore/cache/P_CacheHttp.h`. This is an array of :cpp:class:`HTTPInfo`
    objects and serves as the respository of information about alternates of an
    object. It is marshaled as part of the metadata for an object in the cache.
 
 .. cpp:class:: HTTPInfo
 
-   Defined in |HTTP.h|_.
+   Defined in :ts:git:`proxy/hdrs/HTTP.h`.
 
    This class is a wrapper for :cpp:class:`HTTPCacheAlt`. It provides the
    external API for accessing data in the wrapped class. It contains only a
@@ -72,7 +72,7 @@ Data Structures
 
 .. cpp:class:: HTTPCacheAlt
 
-   Defined in |HTTP.h|_.
+   Defined in :ts:git:`proxy/hdrs/HTTP.h`.
 
    This is the metadata for a single :term:`alternate` for a cached object. It
    contains, among other data, the following:
@@ -127,7 +127,7 @@ Data Structures
 
 .. cpp:class:: Doc
 
-   Defined in |P-CacheVol.h|_.
+   Defined in :ts:git:`iocore/cache/P_CacheVol.h`.
 
    .. cpp:member:: uint32_t Doc::magic
 


### PR DESCRIPTION
Since we just landed the `:ts:git:` markup, these defines are no longer
necessary. This patch moves all previous uses of the hard coded defines
to the new `:ts:git:` markup.