### PR TITLE
Add doxygen + sphinx integration

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -33,9 +33,10 @@ all-am: $(man1_MANS) $(man3_MANS) $(man5_MANS) $(man8_MANS)
 endif
 
 clean-local:
-	-rm -rf $(BUILDDIR)/* _build/html/* xml
+	-rm -rf $(BUILDDIR)/* _build/html/* xml ext/breathe
 
 doxygen: Doxyfile
+	pip install breathe --target ext/breathe
 	$(DOXYGEN)
 
 # Makefile for Sphinx documentation
@@ -71,27 +72,27 @@ help:
 	@echo "  changes    to make an overview of all changed/added/deprecated items"
 	@echo "  linkcheck  to check all external links for integrity"
 
-html-local:
+html-local: doxygen
 	$(SBUILD) -d $(BUILDDIR)/doctrees -b html $(srcdir) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-dirhtml:
+dirhtml: doxygen
 	$(SBUILD) -d $(BUILDDIR)/doctrees -b dirhtml $(srcdir) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
-singlehtml:
+singlehtml: doxygen
 	$(SBUILD) -d $(BUILDDIR)/doctrees -b singlehtml $(srcdir) $(BUILDDIR)/singlehtml
 	@echo
 	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
 
-epub:
+epub: doxygen
 	$(SBUILD) -d $(BUILDDIR)/doctrees -b epub $(srcdir) $(BUILDDIR)/epub
 	@echo
 	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
 
-latex:
+latex: doxygen
 	$(SBUILD) -d $(BUILDDIR)/doctrees -b latex $(srcdir) $(BUILDDIR)/latex
 	@echo
 	@echo "Build finished. The epub file is in $(BUILDDIR)/latex."

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -33,9 +33,9 @@ from sphinx import version_info
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
-sys.path.insert(0, os.path.abspath('ext'))
 sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('ext'))
+sys.path.insert(0, os.path.abspath('ext/breathe'))
 
 from manpages import man_pages
 
@@ -66,6 +66,13 @@ else :
 # extensions += [
 #   'doxygen',
 # ]
+
+# Doxygen + Sphinx integration config
+breathe_projects = { "Apache Traffic Server" : "xml/"}
+breathe_default_project = "Apache Traffic Server"
+if os.path.isdir('ext/breathe'):
+    # if ext/breathe/ was created, then it means we want to generate doxygen
+    extensions.append('breathe')
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/developer-guide/doxygen/index.en.rst
+++ b/doc/developer-guide/doxygen/index.en.rst
@@ -1,0 +1,25 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+
+.. include:: ../../common.defs
+
+.. _developer-doxygen:
+
+Doxygen Reference (warning: big page)
+*************************************
+
+.. doxygenindex::

--- a/doc/developer-guide/index.en.rst
+++ b/doc/developer-guide/index.en.rst
@@ -46,6 +46,7 @@ duplicate bugs is encouraged, but not required.
    architecture/index.en
    plugins/index.en
    config-vars.en
+   doxygen/index.en
    api/index.en
    continuous-integration/index.en
    documentation/index.en


### PR DESCRIPTION
This patch adds doxygen integration into sphinx. Two things happened:

  1. Developer's Guide gained a doxygen index page in the documentation

  2. We can use the built in C++ domain in sphinx. For example, to
     cross-reference a class from another documentation page:

       Reference this class here: :cpp:class:\`PluginIdentity\`!

     See http://www.sphinx-doc.org/en/stable/domains.html#id2 for more
     info.