### PR TITLE
h2spec: GOAWAY is needed for receiving frames after a stream closed.

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -85,7 +85,7 @@ rcv_data_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
   if (stream == nullptr) {
     if (cstate.is_valid_streamid(id)) {
       // This error occurs fairly often, and is probably innocuous (SM initiates the shutdown)
-      return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_STREAM, Http2ErrorCode::HTTP2_ERROR_STREAM_CLOSED, nullptr);
+      return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, Http2ErrorCode::HTTP2_ERROR_STREAM_CLOSED, nullptr);
     } else {
       return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR,
                         "recv data stream freed with invalid id");


### PR DESCRIPTION
@masaori335 @maskit With https://github.com/apache/trafficserver/pull/1704, https://github.com/apache/trafficserver/pull/1747, https://github.com/apache/trafficserver/pull/1752, and this fix, all test cases of `h2spec` passed!
```
Hypertext Transfer Protocol Version 2 (HTTP/2)
  3. Starting HTTP/2
    3.5. HTTP/2 Connection Preface
      ✔ 1: Sends client connection preface
      ✔ 2: Sends invalid connection preface
...
...
...
    8.2. Server Push
      ✔ 1: Sends a PUSH_PROMISE frame

Finished in 1.3408 seconds
94 tests, 94 passed, 0 skipped, 0 fail
```

