### PR TITLE
The Brotli buffer pointer is was not being set to a default value

### DIFF
--- a/plugins/gzip/gzip.cc
+++ b/plugins/gzip/gzip.cc
@@ -109,6 +109,7 @@ data_alloc(int compression_type, int compression_algorithms)
     }
   }
 #if HAVE_BROTLI_ENCODE_H
+  data->bstrm.br = nullptr;
   if (compression_type & COMPRESSION_TYPE_BROTLI) {
     debug("gzip-transform: brotli compression. Create Brotli Encoder Instance.");
     data->bstrm.br = BrotliEncoderCreateInstance(0, 0, 0);


### PR DESCRIPTION
without this change I was getting coredumps in the plugin:

```
(gdb) bt full
#0 0x00007fff3feeba1e in BrotliEncoderDestroyInstance (state=0x83c0098490120) at encode.c:676
m = 0x83c0098490150
free_func = 0x7ffff021bc80
opaque = 0x904e1d0
#1 0x00007fff401717a8 in data_destroy (data=0x7ffd780087c0) at gzip.cc:146
(gdb) p data->bstrm.br
$13 = (BrotliEncoderState *) 0x54375f75554b3934
(gdb) p *data->bstrm.br
Cannot access memory at address 0x54375f75554b3934
```
