### PR TITLE
Fix build errors for glibc 2.25

### DIFF
--- a/lib/ts/ink_res_init.cc
+++ b/lib/ts/ink_res_init.cc
@@ -320,8 +320,6 @@ ink_res_init(ink_res_state statp,         ///< State object to update.
   statp->pfcode  = 0;
   statp->_vcsock = -1;
   statp->_flags  = 0;
-  statp->qhook   = nullptr;
-  statp->rhook   = nullptr;
 
 #ifdef SOLARIS2
   /*

--- a/lib/ts/ink_resolver.h
+++ b/lib/ts/ink_resolver.h
@@ -259,8 +259,6 @@ struct ts_imp_res_state {
   unsigned ndots : 4; /*%< threshold for initial abs. query */
   unsigned nsort : 4; /*%< number of elements in sort_list[] */
   char unused[3];
-  res_send_qhook qhook;         /*%< query hook */
-  res_send_rhook rhook;         /*%< response hook */
   int res_h_errno;              /*%< last one set for this context */
   int _vcsock;                  /*%< PRIVATE: for res_send VC i/o */
   unsigned _flags;              /*%< PRIVATE: see below */


### PR DESCRIPTION
glibc 2.25 removes a few symbols for resolving related stuff. ATS never
even used those symbols anyways so let's just delete them.

This fixes issue #1589.