### PR TITLE
Fix double do_io_close in HttpTunnel::chain_abort_all()

### DIFF
--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1480,12 +1480,12 @@ HttpTunnel::chain_abort_all(HttpTunnelProducer *p)
     if (p->read_vio) {
       p->bytes_read = p->read_vio->ndone;
     }
-    if (p->self_consumer) {
-      p->self_consumer->alive = false;
-    }
     p->read_vio = nullptr;
-    p->vc->do_io_close(EHTTP_ERROR);
-    update_stats_after_abort(p->vc_type);
+    if (p->self_consumer && p->self_consumer->alive) {
+      p->self_consumer->alive = false;
+      p->vc->do_io_close(EHTTP_ERROR);
+      update_stats_after_abort(p->vc_type);
+    }
   }
 }
 


### PR DESCRIPTION
A state machine can not access the VConnectuion or any returned
VIOs after calling do_io_close().

The TVC maybe already destroyed while the 2nd close on TransformVC,
this bug may cause TransformVC crash.