### PR TITLE
Clean up Diags

### DIFF
--- a/cmd/traffic_manager/traffic_manager.cc
+++ b/cmd/traffic_manager/traffic_manager.cc
@@ -488,8 +488,8 @@ main(int argc, const char **argv)
   //  up the manager
   diagsConfig = new DiagsConfig("Manager", DIAGS_LOG_FILENAME, debug_tags, action_tags, false);
   diags       = diagsConfig->diags;
-  diags->set_stdout_output(bind_stdout);
-  diags->set_stderr_output(bind_stderr);
+  diags->set_std_output(StdStream::STDOUT, bind_stdout);
+  diags->set_std_output(StdStream::STDERR, bind_stderr);
 
   RecLocalInit();
   LibRecordsConfigInit();
@@ -534,8 +534,8 @@ main(int argc, const char **argv)
   diagsConfig = new DiagsConfig("Manager", DIAGS_LOG_FILENAME, debug_tags, action_tags, true);
   diags       = diagsConfig->diags;
   RecSetDiags(diags);
-  diags->set_stdout_output(bind_stdout);
-  diags->set_stderr_output(bind_stderr);
+  diags->set_std_output(StdStream::STDOUT, bind_stdout);
+  diags->set_std_output(StdStream::STDERR, bind_stderr);
 
   if (is_debug_tag_set("diags")) {
     diags->dump();

--- a/lib/ts/Diags.h
+++ b/lib/ts/Diags.h
@@ -49,10 +49,10 @@
 class Diags;
 
 // extern int diags_on_for_plugins;
-typedef enum {
+enum DiagsTagType {
   DiagsTagType_Debug  = 0, // do not renumber --- used as array index
   DiagsTagType_Action = 1
-} DiagsTagType;
+};
 
 struct DiagsModeOutput {
   bool to_stdout;
@@ -61,18 +61,20 @@ struct DiagsModeOutput {
   bool to_diagslog;
 };
 
-typedef enum {  // do not renumber --- used as array index
-  DL_Diag = 0,  // process does not die
-  DL_Debug,     // process does not die
-  DL_Status,    // process does not die
-  DL_Note,      // process does not die
-  DL_Warning,   // process does not die
-  DL_Error,     // process does not die
-  DL_Fatal,     // causes process termination
-  DL_Alert,     // causes process termination
-  DL_Emergency, // causes process termination
-  DL_Undefined  // must be last, used for size!
-} DiagsLevel;
+enum DiagsLevel { // do not renumber --- used as array index
+  DL_Diag = 0,    // process does not die
+  DL_Debug,       // process does not die
+  DL_Status,      // process does not die
+  DL_Note,        // process does not die
+  DL_Warning,     // process does not die
+  DL_Error,       // process does not die
+  DL_Fatal,       // causes process termination
+  DL_Alert,       // causes process termination
+  DL_Emergency,   // causes process termination
+  DL_Undefined    // must be last, used for size!
+};
+
+enum StdStream { STDOUT = 0, STDERR };
 
 enum RollingEnabledValues { NO_ROLLING = 0, ROLL_ON_TIME, ROLL_ON_SIZE, ROLL_ON_TIME_OR_SIZE, INVALID_ROLLING_VALUE };
 
@@ -215,8 +217,7 @@ public:
   bool should_roll_diagslog();
   bool should_roll_outputlog();
 
-  bool set_stdout_output(const char *_bind_stdout);
-  bool set_stderr_output(const char *_bind_stderr);
+  bool set_std_output(StdStream stream, const char *file);
 
   const char *base_debug_tags;  // internal copy of default debug tags
   const char *base_action_tags; // internal copy of default action tags
@@ -240,8 +241,7 @@ private:
   time_t outputlog_time_last_roll;
   time_t diagslog_time_last_roll;
 
-  bool rebind_stdout(int new_fd);
-  bool rebind_stderr(int new_fd);
+  bool rebind_std_stream(StdStream stream, int new_fd);
 
   void
   lock() const

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -265,8 +265,8 @@ public:
       Debug("log", "received SIGUSR2, reloading traffic.out");
 
       // reload output logfile (file is usually called traffic.out)
-      diags->set_stdout_output(bind_stdout);
-      diags->set_stderr_output(bind_stderr);
+      diags->set_std_output(StdStream::STDOUT, bind_stdout);
+      diags->set_std_output(StdStream::STDERR, bind_stderr);
     }
 
     if (signal_received[SIGTERM] || signal_received[SIGINT]) {
@@ -1561,8 +1561,8 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   // related errors and if diagsConfig isn't get up yet that will crash on a NULL pointer.
   diagsConfig = new DiagsConfig("Server", DIAGS_LOG_FILENAME, error_tags, action_tags, false);
   diags       = diagsConfig->diags;
-  diags->set_stdout_output(bind_stdout);
-  diags->set_stderr_output(bind_stderr);
+  diags->set_std_output(StdStream::STDOUT, bind_stdout);
+  diags->set_std_output(StdStream::STDERR, bind_stderr);
   if (is_debug_tag_set("diags")) {
     diags->dump();
   }
@@ -1651,8 +1651,8 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   diagsConfig = new DiagsConfig("Server", DIAGS_LOG_FILENAME, error_tags, action_tags, true);
   diags       = diagsConfig->diags;
   RecSetDiags(diags);
-  diags->set_stdout_output(bind_stdout);
-  diags->set_stderr_output(bind_stderr);
+  diags->set_std_output(StdStream::STDOUT, bind_stdout);
+  diags->set_std_output(StdStream::STDERR, bind_stderr);
   if (is_debug_tag_set("diags")) {
     diags->dump();
   }


### PR DESCRIPTION
Few cleanups:

1) Remove typedefs from some enums. typedef'ing enums stopped being
   useful when C++ came to town.

2) De-duplicate the separate stdout and stderr fiddling functions. These
   functions do the exact same thing except on different objects. We
   should not repeat code.