### PR TITLE
Make sure we only capture merged PRs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,7 +57,7 @@ doxygen:
 	@cd doc && $(MAKE) $(AM_MAKEFLAGS) $@
 
 changelog:
-	./tools/changelog.pl apache trafficserver $(VERSION) > CHANGELOG-$(VERSION)
+	./tools/changelog.pl apache trafficserver $(VERSION) $(AUTHTOKEN) > CHANGELOG-$(VERSION)
 
 asf-dist: asf-distdir
 	tardir=$(distdir) && $(am__tar) --mtime=./configure.ac | bzip2 -9 -c >$(distdir).tar.bz2


### PR DESCRIPTION
This seems more complete. Will only capture merged and closed PRs on closed Milestones. You will also likely have to pass an auth token like:

`make changelog AUTHTOKEN=<username:tokenhash>`

You can run without the auth token, but it will likely hit the default rate limit of 60/hour.

You can create a new token here: https://github.com/settings/tokens/new