### PR TITLE
Fix missing header

### DIFF
--- a/example/disable_http2/disable_http2.cc
+++ b/example/disable_http2/disable_http2.cc
@@ -30,6 +30,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <string>
+#include <string.h>
 #include <openssl/ssl.h>
 
 #define PLUGIN_NAME "disable_http2"


### PR DESCRIPTION
Compile was failing on example plugin b/c of a `strlen` call without an included <string.h> header.