### PR TITLE
Coverity 1373289: Explicit null dereferenced

### DIFF
--- a/example/secure_link/secure_link.c
+++ b/example/secure_link/secure_link.c
@@ -118,7 +118,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
   time(&t);
   e = (NULL == expire ? 0 : strtol(expire, NULL, 16));
   i = TSREMAP_DID_REMAP;
-  if (e < t || strcmp(hash, token) != 0) {
+  if (e < t || (NULL == token || 0 != strcmp(hash, token))) {
     if (e < t) {
       TSDebug(PLUGIN_NAME, "link expired: [%lu] vs [%lu]", t, e);
     } else {


### PR DESCRIPTION
Problem:
  CID 1373289 (#1 of 1): Explicit null dereferenced (FORWARD_NULL)
  21. var_deref_model: Passing null pointer token to strcmp, which dereferences it.

Fix:
  Check if token is NULL and if yes it cannot be equal to what is in hash
  (also hash is never NULL)