### PR TITLE
Converity 1373288: Dereference after null check

### DIFF
--- a/example/secure-link/secure-link.c
+++ b/example/secure-link/secure-link.c
@@ -114,7 +114,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
     sprintf(&hash[i * 2], "%02x", md[i]);
   }
   time(&t);
-  e = strtol(expire, NULL, 16);
+  e = (NULL == expire ? 0 : strtol(expire, NULL, 16));
   i = TSREMAP_DID_REMAP;
   if (e < t || strcmp(hash, token) != 0) {
     if (e < t) {


### PR DESCRIPTION
Problem:
  CID 1373288 (#1 of 1): Dereference after null check (FORWARD_NULL)
  20. var_deref_model: Passing null pointer expire to strtol, which dereferences it.

Fix:
  Missing expiration query parameter and missing expiration query parameter value
  should be treated the same (expire=0).