### PR TITLE
Coverity 1021705: Uninitialized pointer field

### DIFF
--- a/iocore/cache/CacheHosting.cc
+++ b/iocore/cache/CacheHosting.cc
@@ -29,8 +29,6 @@
 
 extern int gndisks;
 
-matcher_tags CacheHosting_tags = {"hostname", "domain", nullptr, nullptr, nullptr, nullptr, false};
-
 /*************************************************************
  *   Begin class HostMatcher
  *************************************************************/
@@ -184,14 +182,9 @@ CacheHostTable::CacheHostTable(Cache *c, CacheType typ)
 {
   ats_scoped_str config_path;
 
-  config_tags = &CacheHosting_tags;
-  ink_assert(config_tags != nullptr);
-
   type         = typ;
   cache        = c;
   matcher_name = "[CacheHosting]";
-  ;
-  hostMatch = nullptr;
 
   config_path = RecConfigReadConfigPath("proxy.config.cache.hosting_filename");
   ink_release_assert(config_path);
@@ -284,7 +277,7 @@ CacheHostTable::BuildTableFromString(const char *config_file_path, char *file_bu
 
     if (*tmp != '#' && *tmp != '\0') {
       current = (matcher_line *)ats_malloc(sizeof(matcher_line));
-      errPtr  = parseConfigLine((char *)tmp, current, config_tags);
+      errPtr  = parseConfigLine((char *)tmp, current, &config_tags);
 
       if (errPtr != nullptr) {
         RecSignalWarning(REC_SIGNAL_CONFIG_ERROR, "%s discarding %s entry at line %d : %s", matcher_name, config_file_path,

--- a/iocore/cache/P_CacheHosting.h
+++ b/iocore/cache/P_CacheHosting.h
@@ -144,15 +144,15 @@ public:
     REC_RegisterConfigUpdateFunc("proxy.config.cache.hosting_filename", CacheHostTable::config_callback, (void *)p);
   }
 
-  CacheType type;
-  Cache *cache;
-  int m_numEntries;
+  CacheType type   = CACHE_HTTP_TYPE;
+  Cache *cache     = nullptr;
+  int m_numEntries = 0;
   CacheHostRecord gen_host_rec;
 
 private:
-  CacheHostMatcher *hostMatch;
-  const matcher_tags *config_tags;
-  const char *matcher_name; // Used for Debug/Warning/Error messages
+  CacheHostMatcher *hostMatch    = nullptr;
+  const matcher_tags config_tags = {"hostname", "domain", nullptr, nullptr, nullptr, nullptr, false};
+  const char *matcher_name       = "unknown"; // Used for Debug/Warning/Error messages
 };
 
 struct CacheHostTableConfig;

--- a/proxy/ControlMatcher.cc
+++ b/proxy/ControlMatcher.cc
@@ -88,8 +88,7 @@ HttpRequestData::get_client_ip()
  *************************************************************/
 
 template <class Data, class MatchResult>
-HostMatcher<Data, MatchResult>::HostMatcher(const char *name, const char *filename)
-  : data_array(nullptr), array_len(-1), num_el(-1), matcher_name(name), file_name(filename)
+HostMatcher<Data, MatchResult>::HostMatcher(const char *name, const char *filename) : BaseMatcher<Data>(name, filename)
 {
   host_lookup = new HostLookup(name);
 }
@@ -97,7 +96,6 @@ HostMatcher<Data, MatchResult>::HostMatcher(const char *name, const char *filena
 template <class Data, class MatchResult> HostMatcher<Data, MatchResult>::~HostMatcher()
 {
   delete host_lookup;
-  delete[] data_array;
 }
 
 //
@@ -142,9 +140,8 @@ HostMatcher<Data, MatchResult>::AllocateSpace(int num_entries)
   host_lookup->AllocateSpace(num_entries);
 
   data_array = new Data[num_entries];
-
-  array_len = num_entries;
-  num_el    = 0;
+  array_len  = num_entries;
+  num_el     = 0;
 }
 
 // void HostMatcher<Data,MatchResult>::Match(RequestData* rdata, MatchResult* result)
@@ -237,15 +234,7 @@ HostMatcher<Data, MatchResult>::NewEntry(matcher_line *line_info)
 // UrlMatcher<Data,MatchResult>::UrlMatcher()
 //
 template <class Data, class MatchResult>
-UrlMatcher<Data, MatchResult>::UrlMatcher(const char *name, const char *filename)
-  : url_ht(nullptr),
-    url_str(nullptr),
-    url_value(nullptr),
-    data_array(nullptr),
-    array_len(0),
-    num_el(-1),
-    matcher_name(name),
-    file_name(filename)
+UrlMatcher<Data, MatchResult>::UrlMatcher(const char *name, const char *filename) : BaseMatcher<Data>(name, filename)
 {
   url_ht = ink_hash_table_create(InkHashTableKeyType_String);
 }
@@ -261,7 +250,6 @@ template <class Data, class MatchResult> UrlMatcher<Data, MatchResult>::~UrlMatc
   }
   delete[] url_str;
   delete[] url_value;
-  delete[] data_array;
 }
 
 //
@@ -382,8 +370,7 @@ UrlMatcher<Data, MatchResult>::Match(RequestData *rdata, MatchResult *result)
 // RegexMatcher<Data,MatchResult>::RegexMatcher()
 //
 template <class Data, class MatchResult>
-RegexMatcher<Data, MatchResult>::RegexMatcher(const char *name, const char *filename)
-  : re_array(nullptr), re_str(nullptr), data_array(nullptr), array_len(-1), num_el(-1), matcher_name(name), file_name(filename)
+RegexMatcher<Data, MatchResult>::RegexMatcher(const char *name, const char *filename) : BaseMatcher<Data>(name, filename)
 {
 }
 
@@ -398,7 +385,6 @@ template <class Data, class MatchResult> RegexMatcher<Data, MatchResult>::~Regex
   }
   delete[] re_str;
   ats_free(re_array);
-  delete[] data_array;
 }
 
 //
@@ -589,17 +575,8 @@ HostRegexMatcher<Data, MatchResult>::Match(RequestData *rdata, MatchResult *resu
 // IpMatcher<Data,MatchResult>::IpMatcher()
 //
 template <class Data, class MatchResult>
-IpMatcher<Data, MatchResult>::IpMatcher(const char *name, const char *filename)
-  : data_array(nullptr), array_len(-1), num_el(-1), matcher_name(name), file_name(filename)
+IpMatcher<Data, MatchResult>::IpMatcher(const char *name, const char *filename) : BaseMatcher<Data>(name, filename)
 {
-}
-
-//
-// IpMatcher<Data,MatchResult>::~IpMatcher()
-//
-template <class Data, class MatchResult> IpMatcher<Data, MatchResult>::~IpMatcher()
-{
-  delete[] data_array;
 }
 
 //


### PR DESCRIPTION
This also cleans up the Matcher class layout, such that we
cleanly initialize everything in one place.