### PR TITLE
Coverity 1200018 & 1200017

### DIFF
--- a/example/secure-link/secure-link.c
+++ b/example/secure-link/secure-link.c
@@ -50,7 +50,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
   const char *qh, *ph, *ip;
   unsigned char md[MD5_DIGEST_LENGTH];
   secure_link_info *sli = (secure_link_info *)ih;
-  char *token = NULL, *expire = NULL, *path = NULL;
+  char *token = NULL, *tokenptr = NULL, *expire = NULL, *expireptr = NULL, *path = NULL;
   char *s, *ptr, *saveptr = NULL, *val, hash[32] = "";
 
   in = (struct sockaddr_in *)TSHttpTxnClientAddrGet(rh);
@@ -67,15 +67,17 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
         if ((val = strchr(ptr, '=')) != NULL) {
           *val++ = '\0';
           if (strcmp(ptr, "st") == 0) {
-            token = TSstrdup(val);
+            tokenptr = val;
           } else if (strcmp(ptr, "ex") == 0) {
-            expire = TSstrdup(val);
+            expireptr = val;
           }
         } else {
           TSError("[secure_link] Invalid parameter [%s]", ptr);
           break;
         }
       } while ((ptr = strtok_r(NULL, "&", &saveptr)) != NULL);
+      token  = (NULL == tokenptr ? NULL : TSstrdup(tokenptr));
+      expire = (NULL == expireptr ? NULL : TSstrdup(expireptr));
     } else {
       TSError("[secure_link] strtok didn't find a & in the query string");
       /* this is just example, so set fake params to prevent plugin crash */


### PR DESCRIPTION
Problem:
  CID 1200018 (#1 of 1): Resource leak (RESOURCE_LEAK)
  13. overwrite_var: Overwriting token in token = _TSstrdup(val, -1L, "memory/secure-link/secure-link.c:70") leaks the storage that token points to.

  CID 1200017 (#1 of 1): Resource leak (RESOURCE_LEAK)
  19. overwrite_var: Overwriting expire in expire = _TSstrdup(val, -1L, "memory/secure-link/secure-link.c:72") leaks the storage that expire points to

Fix:
  Took the TSstrdup() for expire and token outside the loop to avoid the leak.