### PR TITLE
PR-1794 - Cache tweaks.

### DIFF
--- a/iocore/cache/CacheRead.cc
+++ b/iocore/cache/CacheRead.cc
@@ -161,9 +161,10 @@ uint32_t
 CacheVC::load_http_info(CacheHTTPInfoVector *info, Doc *doc, RefCountObj *block_ptr)
 {
   uint32_t zret = info->get_handles(doc->hdr(), doc->hlen, block_ptr);
-  if (cache_config_compatibility_4_2_0_fixup && // manual override not engaged
-      !this->f.doc_from_ram_cache &&            // it's already been done for ram cache fragments
-      vol->header->version.ink_major == 23 && vol->header->version.ink_minor == 0) {
+  if (!this->f.doc_from_ram_cache && // ram cache is always already fixed up.
+      // If this is an old object, the object version will be old or 0, in either case this is correct.
+      // Forget the 4.2 compatibility, always update older versioned objects.
+      VersionNumber(doc->v_major, doc->v_minor) < CACHE_DB_VERSION) {
     for (int i = info->xcount - 1; i >= 0; --i) {
       info->data(i).alternate.m_alt->m_response_hdr.m_mime->recompute_accelerators_and_presence_bits();
       info->data(i).alternate.m_alt->m_request_hdr.m_mime->recompute_accelerators_and_presence_bits();

--- a/iocore/cache/I_CacheDefs.h
+++ b/iocore/cache/I_CacheDefs.h
@@ -33,11 +33,15 @@
 #define CACHE_ALT_INDEX_DEFAULT -1
 #define CACHE_ALT_REMOVED -2
 
-#define CACHE_DB_MAJOR_VERSION 24
-#define CACHE_DB_MINOR_VERSION 1
+static const uint8_t CACHE_DB_MAJOR_VERSION = 24;
+static const uint8_t CACHE_DB_MINOR_VERSION = 1;
+// This is used in various comparisons because otherwise if the minor version is 0,
+// the compile fails because the condition is always true or false. Running it through
+// VersionNumber prevents that.
+extern const VersionNumber CACHE_DB_VERSION;
 
-#define CACHE_DIR_MAJOR_VERSION 18
-#define CACHE_DIR_MINOR_VERSION 0
+static const uint8_t CACHE_DIR_MAJOR_VERSION = 18;
+static const uint8_t CACHE_DIR_MINOR_VERSION = 0;
 
 #define CACHE_DB_FDS 128
 

--- a/lib/ts/I_Version.h
+++ b/lib/ts/I_Version.h
@@ -46,6 +46,12 @@ operator<(VersionNumber const &lhs, VersionNumber const &rhs)
 }
 
 inline bool
+operator>(VersionNumber const &lhs, VersionNumber const &rhs)
+{
+  return rhs < lhs;
+}
+
+inline bool
 operator==(VersionNumber const &lhs, VersionNumber const &rhs)
 {
   return lhs.ink_major == rhs.ink_major && lhs.ink_minor == rhs.ink_minor;


### PR DESCRIPTION
Two changes:

* If an object is older than the current version reset all the WKS indices. This means that changes in the WKS index table can be handled by incrementing the cache DB minor version.
* If an object has a more recent version, it is presumed from the future and treated as if it were corrupt and not used.