### PR TITLE
Introduce an API in 'ts.h' to reload remap.config, if the config file…

### DIFF
--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -56,6 +56,7 @@
 #include "HttpDebugNames.h"
 #include "I_AIO.h"
 #include "I_Tasks.h"
+#include "ReverseProxy.h"
 
 #include "I_RecDefs.h"
 #include "I_RecCore.h"
@@ -4126,6 +4127,12 @@ TSConfigDataGet(TSConfig configp)
 {
   INKConfigImpl *config = (INKConfigImpl *)configp;
   return config->mdata;
+}
+
+bool
+TSRemapConfigReload()
+{
+  return reloadUrlRewrite();
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -1179,6 +1179,11 @@ tsapi TSConfig TSConfigGet(unsigned int id);
 tsapi void TSConfigRelease(unsigned int id, TSConfig configp);
 tsapi void *TSConfigDataGet(TSConfig configp);
 
+/**
+ * Should be called when the remap.config file has changed on the disk to reload it.
+ */
+bool TSRemapConfigReload();
+
 /* --------------------------------------------------------------------------
    Management */
 tsapi void TSMgmtUpdateRegister(TSCont contp, const char *plugin_name);


### PR DESCRIPTION
This change is regarding introducing a new API to ts.h so that remap.config can be reloaded by `traffic_server` itself without restarting or without using `traffic_ctl`.

Our use case is that we have a thread (running as a part of plugin) which keeps on polling a git mirror at regular interval. Once it identifies that there is a change in remap.config file in that git mirror, it pulls the new file and replaces the the old config file with the new one on disk (with creating a backup of the previous one). After doing that it will call `TSRemapConfigReload()` to reload the new remap.config.