### PR TITLE
Via: Change separator character to '-' instead of ' '.

### DIFF
--- a/proxy/http/HttpTransactHeaders.cc
+++ b/proxy/http/HttpTransactHeaders.cc
@@ -693,10 +693,12 @@ write_client_protocol_stack(HttpTransact::State *s, char *via_string, size_t len
   char *limit       = via_string + len;
   ts::StringView *v = proto_buf.data();
   for (int i = 0; i < retval && (via + v->size() + 1) < limit; ++i, ++v) {
+    if (i)
+      *via++ = '-';
     memcpy(via, v->ptr(), v->size());
     via += v->size();
-    *via++ = ' ';
   }
+  *via++ = ' ';
   return via - via_string;
 }
 

--- a/tests/gold_tests/headers/via.gold
+++ b/tests/gold_tests/headers/via.gold
@@ -1,4 +1,4 @@
-Via: http/1.1 tcp ipv4
-Via: http/1.0 tcp ipv4
-Via: http/1.1 h2 tls/1.2 tcp ipv4
-Via: http/1.1 tls/1.2 tcp ipv4
+Via: http/1.1-tcp-ipv4
+Via: http/1.0-tcp-ipv4
+Via: http/1.1-h2-tls/1.2-tcp-ipv4
+Via: http/1.1-tls/1.2-tcp-ipv4


### PR DESCRIPTION
To avoid future compatibility issues with plugins and origins that parse the VIA header, the protocol stack should be a single space delimited value rather than a variable number.