### PR TITLE
Coverity 1022126 and 1022127: Dereference before null check

### DIFF
--- a/example/protocol/TxnSM.c
+++ b/example/protocol/TxnSM.c
@@ -432,14 +432,20 @@ state_build_and_send_request(TSCont contp, TSEvent event ATS_UNUSED, void *data 
 
   txn_sm->q_pending_action = NULL;
 
-  txn_sm->q_server_request_buffer        = TSIOBufferCreate();
+  txn_sm->q_server_request_buffer = TSIOBufferCreate();
+  if (!txn_sm->q_server_request_buffer) {
+    return prepare_to_die(contp);
+  }
   txn_sm->q_server_request_buffer_reader = TSIOBufferReaderAlloc(txn_sm->q_server_request_buffer);
-
-  txn_sm->q_server_response_buffer       = TSIOBufferCreate();
+  if (!txn_sm->q_server_request_buffer_reader) {
+    return prepare_to_die(contp);
+  }
+  txn_sm->q_server_response_buffer = TSIOBufferCreate();
+  if (!txn_sm->q_server_response_buffer) {
+    return prepare_to_die(contp);
+  }
   txn_sm->q_cache_response_buffer_reader = TSIOBufferReaderAlloc(txn_sm->q_server_response_buffer);
-
-  if (!txn_sm->q_server_request_buffer || !txn_sm->q_server_request_buffer_reader || !txn_sm->q_server_response_buffer ||
-      !txn_sm->q_cache_response_buffer_reader) {
+  if (!txn_sm->q_cache_response_buffer_reader) {
     return prepare_to_die(contp);
   }
 


### PR DESCRIPTION
Problem:
  CID 1022126 (#1 of 1): Dereference before null check (REVERSE_INULL)
  check_after_deref: Null-checking txn_sm->q_server_response_buffer suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
  CID 1022127 (#1 of 1): Dereference before null check (REVERSE_INULL)
  check_after_deref: Null-checking txn_sm->q_server_request_buffer suggests that it may be null, but it has already been dereferenced on all paths leading to the check.

Fix:
  Checked the return values on each step instead of all at the end.
