### PR TITLE
Coverity 1022122, 1022123, 1022125: Dereference before null check

### DIFF
--- a/example/protocol/TxnSM.c
+++ b/example/protocol/TxnSM.c
@@ -160,10 +160,12 @@ state_start(TSCont contp, TSEvent event ATS_UNUSED, void *data ATS_UNUSED)
     return prepare_to_die(contp);
   }
 
-  txn_sm->q_client_request_buffer        = TSIOBufferCreate();
+  txn_sm->q_client_request_buffer = TSIOBufferCreate();
+  if (!txn_sm->q_client_request_buffer) {
+    return prepare_to_die(contp);
+  }
   txn_sm->q_client_request_buffer_reader = TSIOBufferReaderAlloc(txn_sm->q_client_request_buffer);
-
-  if (!txn_sm->q_client_request_buffer || !txn_sm->q_client_request_buffer_reader) {
+  if (!txn_sm->q_client_request_buffer_reader) {
     return prepare_to_die(contp);
   }
 
@@ -286,13 +288,20 @@ state_handle_cache_lookup(TSCont contp, TSEvent event, TSVConn vc)
     response_size = TSVConnCacheObjectSizeGet(txn_sm->q_cache_vc);
 
     /* Allocate IOBuffer to store data from the cache. */
-    txn_sm->q_client_response_buffer        = TSIOBufferCreate();
+    txn_sm->q_client_response_buffer = TSIOBufferCreate();
+    if (!txn_sm->q_client_response_buffer) {
+      return prepare_to_die(contp);
+    }
     txn_sm->q_client_response_buffer_reader = TSIOBufferReaderAlloc(txn_sm->q_client_response_buffer);
-    txn_sm->q_cache_read_buffer             = TSIOBufferCreate();
-    txn_sm->q_cache_read_buffer_reader      = TSIOBufferReaderAlloc(txn_sm->q_cache_read_buffer);
-
-    if (!txn_sm->q_client_response_buffer || !txn_sm->q_client_response_buffer_reader || !txn_sm->q_cache_read_buffer ||
-        !txn_sm->q_cache_read_buffer_reader) {
+    if (!txn_sm->q_client_response_buffer_reader) {
+      return prepare_to_die(contp);
+    }
+    txn_sm->q_cache_read_buffer = TSIOBufferCreate();
+    if (!txn_sm->q_cache_read_buffer) {
+      return prepare_to_die(contp);
+    }
+    txn_sm->q_cache_read_buffer_reader = TSIOBufferReaderAlloc(txn_sm->q_cache_read_buffer);
+    if (!txn_sm->q_cache_read_buffer_reader) {
       return prepare_to_die(contp);
     }
 


### PR DESCRIPTION
Problem:
CID 1022122 (#1 of 1): Dereference before null check (REVERSE_INULL)
check_after_deref: Null-checking txn_sm->q_client_request_buffer suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
CID 1022123 (#1 of 1): Dereference before null check (REVERSE_INULL)
check_after_deref: Null-checking txn_sm->q_client_response_buffer suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
CID 1022125 (#1 of 1): Dereference before null check (REVERSE_INULL)
check_after_deref: Null-checking txn_sm->q_cache_read_buffer suggests that it may be null, but it has already been dereferenced on all paths leading to the check

Fix:
Checked the return values on each step instead of all at the end.