### PR TITLE
Coverity 1022124: Dereference before null check

### DIFF
--- a/example/protocol/TxnSM.c
+++ b/example/protocol/TxnSM.c
@@ -873,10 +873,9 @@ state_done(TSCont contp, TSEvent event ATS_UNUSED, TSVIO vio ATS_UNUSED)
     txn_sm->q_server_response = NULL;
   }
 
-  if (txn_sm) {
-    txn_sm->q_magic = TXN_SM_DEAD;
-    TSfree(txn_sm);
-  }
+  txn_sm->q_magic = TXN_SM_DEAD;
+  TSfree(txn_sm);
+
   TSContDestroy(contp);
   return TS_EVENT_NONE;
 }


### PR DESCRIPTION
Problem:
  CID 1022124 (#1 of 1): Dereference before null check (REVERSE_INULL)
  check_after_deref: Null-checking txn_sm suggests that it may be null, but it has already been dereferenced on all paths leading to the check.

Fix:
  Removed the check for NULL.