### PR TITLE
Remove the logic of retrying all the in-flight DNS queries when nameservers are all down

### DIFF
--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -940,7 +940,7 @@ write_dns(DNSHandler *h)
             h->name_server = (h->name_server + 1) % max_nscount;
           } while (h->ns_down[h->name_server] && h->name_server != ns_start);
         }
-        if (!write_dns_event(h, e)) {
+        if (h->ns_down[h->name_server] || !write_dns_event(h, e)) {
           break;
         }
       }


### PR DESCRIPTION
It makes no sense that ATS is using a negative period to schedule events.
When DNS servers are down, ATS will send tremendous requests to DNS servers, at a ratio basically as fast as it can. 