### PR TITLE
Rename half_close_flag to half_close_local_flag in Http2ClientSession

### DIFF
--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -276,12 +276,12 @@ Http2ClientSession::reenable(VIO *vio)
 }
 
 void
-Http2ClientSession::set_half_close_flag(bool flag)
+Http2ClientSession::set_half_close_local_flag(bool flag)
 {
-  if (!half_close && flag) {
-    DebugHttp2Ssn("session half-close");
+  if (!half_close_local && flag) {
+    DebugHttp2Ssn("session half-close local");
   }
-  half_close = flag;
+  half_close_local = flag;
 }
 
 int
@@ -500,7 +500,7 @@ Http2ClientSession::state_process_frame_read(int event, VIO *vio, bool inside_fr
         SCOPED_MUTEX_LOCK(lock, this->connection_state.mutex, this_ethread());
         if (!this->connection_state.is_state_closed()) {
           this->connection_state.send_goaway_frame(this->connection_state.get_latest_stream_id_in(), err);
-          this->set_half_close_flag(true);
+          this->set_half_close_local_flag(true);
           this->do_io_close();
         }
       }

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -284,11 +284,11 @@ public:
     return retval;
   }
 
-  void set_half_close_flag(bool flag) override;
+  void set_half_close_local_flag(bool flag);
   bool
-  get_half_close_flag() const override
+  get_half_close_local_flag() const
   {
-    return half_close;
+    return half_close_local;
   }
 
 private:
@@ -322,11 +322,11 @@ private:
   // For Upgrade: h2c
   Http2UpgradeContext upgrade_context;
 
-  VIO *write_vio  = nullptr;
-  int dying_event = 0;
-  bool kill_me    = false;
-  bool half_close = false;
-  int recursion   = 0;
+  VIO *write_vio        = nullptr;
+  int dying_event       = 0;
+  bool kill_me          = false;
+  bool half_close_local = false;
+  int recursion         = 0;
 };
 
 extern ClassAllocator<Http2ClientSession> http2ClientSessionAllocator;


### PR DESCRIPTION
Fix #1861. Stop using `half_close_flag` of ProxyClientSession and add `half_close_local_flag` in Http2ClientSession.