### PR TITLE
Allow receiving H2 frames on server initiated streams

### DIFF
--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -436,12 +436,6 @@ Http2ClientSession::do_start_frame_read(Http2ErrorCode &ret_error)
     return -1;
   }
 
-  // Allow only stream id = 0 or streams started by client.
-  if (this->current_hdr.streamid != 0 && !http2_is_client_streamid(this->current_hdr.streamid)) {
-    ret_error = Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR;
-    return -1;
-  }
-
   // CONTINUATIONs MUST follow behind HEADERS which doesn't have END_HEADERS
   Http2StreamId continued_stream_id = this->connection_state.get_continued_stream_id();
 

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -429,7 +429,7 @@ rcv_rst_stream_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
   // frame is received with a stream identifier of 0x0, the recipient MUST
   // treat this as a connection error (Section 5.4.1) of type
   // PROTOCOL_ERROR.
-  if (!http2_is_client_streamid(stream_id)) {
+  if (stream_id == 0) {
     return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR,
                       "reset access stream with invalid id");
   }


### PR DESCRIPTION
After supporting H2 server push, server can initiate streams.
We haven't taken account of them in some checks.