### PR TITLE
Coverity 1200007 : missing break statement

### DIFF
--- a/plugins/experimental/ts_lua/ts_lua_http_intercept.c
+++ b/plugins/experimental/ts_lua/ts_lua_http_intercept.c
@@ -291,7 +291,7 @@ ts_lua_http_intercept_process_read(TSEvent event, ts_lua_http_intercept_ctx *ict
   switch (event) {
   case TS_EVENT_VCONN_READ_READY:
     TSVConnShutdown(ictx->net_vc, 1, 0);
-
+    break; // READ_READY_READY is not equal to EOS break statement is probably missing?
   case TS_EVENT_VCONN_READ_COMPLETE:
   case TS_EVENT_VCONN_EOS:
     ictx->recv_complete = 1;


### PR DESCRIPTION
CID 1200007 (#1 of 1): Missing break in switch (MISSING_BREAK)