### PR TITLE
Fix slow leak in traffic_manager caused by un-freed capabilities.

### DIFF
--- a/lib/ts/ink_cap.cc
+++ b/lib/ts/ink_cap.cc
@@ -396,6 +396,7 @@ ElevateAccess::releasePrivilege()
     if (cap_set_proc(static_cast<cap_t>(cap_state)) != 0) {
       Fatal("failed to restore privileged capabilities: %s", strerror(errno));
     }
+    cap_free(this->cap_state);
     cap_state = NULL;
   }
 }


### PR DESCRIPTION
(cherry picked from commit 5c3d091a6e75827a873f2568de004a2880e5c966)

Conflicts:
	lib/ts/ink_cap.cc