### PR TITLE
Coverity 1373301: Untrusted loop bound

### DIFF
--- a/example/cppapi/websocket/WSBuffer.cc
+++ b/example/cppapi/websocket/WSBuffer.cc
@@ -135,7 +135,7 @@ WSBuffer::read_buffered_message(std::string &message, int &code)
 
   // Apply any mask.
   if (mask_len) {
-    for (size_t i = 0, p = pos; i < msg_len; ++i, ++p) {
+    for (size_t i = 0, p = pos; i < msg_len && p < ws_buf_.size(); ++i, ++p) {
       ws_buf_[p] ^= mask[i & 3];
     }
   }


### PR DESCRIPTION
Problem:
CID 1373301 (#1 of 1): Untrusted loop bound (TAINTED_SCALAR)
17. tainted_data: Using tainted variable msg_len as a loop boundary.

Fix:
Added check for p < ws_buf_.size() to make sure improper msg_len
(user input) would not lead to out of scope write.