### PR TITLE
Coverity CID #1375003 Structurally dead code

### DIFF
--- a/example/passthru/passthru.cc
+++ b/example/passthru/passthru.cc
@@ -215,15 +215,15 @@ PassthruSessionEvent(TSCont cont, TSEvent event, void *edata)
       TSVIOReenable(sp->server.readio.vio);
       TSVIOReenable(sp->client.writeio.vio);
     }
-  }
 
-  if (PassthruSessionIsFinished(sp)) {
-    delete sp;
+    if (PassthruSessionIsFinished(sp)) {
+      delete sp;
+      return TS_EVENT_NONE;
+    }
+
+    TSVIOReenable(arg.vio);
     return TS_EVENT_NONE;
   }
-
-  TSVIOReenable(arg.vio);
-  return TS_EVENT_NONE;
 
   if (event == TS_EVENT_VCONN_WRITE_READY) {
     if (PassthruSessionIsFinished(sp)) {


### PR DESCRIPTION
I think this was due to the wrong `}` being removed in #1883. @gtenev can you confirm this?