### PR TITLE
Coverity CID #1021966 Dereference after null check

### DIFF
--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -931,7 +931,9 @@ FileImpl::fgets(char *buf, int length)
   if (!m_buf || (m_bufpos < (length - 1))) {
     pos = m_bufpos;
 
-    fread(nullptr, length - 1);
+    if (fread(nullptr, length - 1) < 0) {
+      return nullptr;
+    }
 
     if (!m_bufpos && (pos == m_bufpos)) {
       return nullptr;


### PR DESCRIPTION
We need to handle an error condition from `fread` better so that we don't do a null deref of `m_buf`.