### PR TITLE
Coverity CID #1241990 Resource leak

### DIFF
--- a/plugins/experimental/ssl_cert_loader/ssl-cert-loader.cc
+++ b/plugins/experimental/ssl_cert_loader/ssl-cert-loader.cc
@@ -315,7 +315,7 @@ Parse_Config(Value &parent, ParsedSslValues &orig_values)
       }
     }
     if (entry != nullptr) {
-      if (!cert_names.empty()) {
+      if (cert_names.size() > 0) {
         for (const auto &cert_name : cert_names) {
           Lookup.tree.insert(cert_name, entry, Parse_order++);
         }


### PR DESCRIPTION
This is a bit of a guess, but trying to see if switching from `empty()` to `size()`, which is used elsewhere, will make Coverity realize that it can't bail on the for loop that soon.

![screen shot 2017-05-16 at 15 44 55](https://cloud.githubusercontent.com/assets/1149361/26129760/d1d43f8a-3a4e-11e7-83cd-23bbd07e69f2.png)
