### PR TITLE
Coredump with server_session

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -3026,8 +3026,7 @@ HttpSM::tunnel_handler_server(int event, HttpTunnelProducer *p)
 
   if (close_connection) {
     p->vc->do_io_close();
-    server_session = nullptr; // Because p->vc == server_session
-    p->read_vio    = nullptr;
+    p->read_vio = nullptr;
     /* TS-1424: if we're outbound transparent and using the client
        source port for the outbound connection we must effectively
        propagate server closes back to the client. Part of that is
@@ -3055,6 +3054,12 @@ HttpSM::tunnel_handler_server(int event, HttpTunnelProducer *p)
       server_session->release();
     }
   }
+
+  // The server session has been released. Clean all pointer
+  server_entry->in_tunnel = true; // to avid cleaning in clenup_entry
+  vc_table.cleanup_entry(server_entry);
+  server_session = nullptr; // Because p->vc == server_session
+  server_entry   = nullptr;
 
   return 0;
 }


### PR DESCRIPTION
Fixed the #1924 .

The server has already recieved all data before TRANSFORM_READ_READY event sometimes(in tunnel). We will call the HttpSM::tunnel_handler_server function to release(or close) server session . **we should not access to server session after released if that happend**. 

But we reenter the server session after TRANSFORM_READ_READY in HttpSM::tunnel_handler_ua . It may cause coredump, because the netvc may be released by session pool.

As the comment above. we set the nullptr to server session to avoid the wrong accessing.