### PR TITLE
print url when document truncated warning occurs

### DIFF
--- a/iocore/cache/CacheRead.cc
+++ b/iocore/cache/CacheRead.cc
@@ -585,10 +585,17 @@ CacheVC::openReadReadDone(int event, Event *e)
     }
     // fall through for truncated documents
   }
-Lerror:
+Lerror : {
   char tmpstring[100];
-  Warning("Document %s truncated", earliest_key.toHexStr(tmpstring));
+  if (request.valid()) {
+    int url_length;
+    const char *url_text = request.url_get()->string_get_ref(&url_length);
+    Warning("Document %s truncated, url[%.*s]", earliest_key.toHexStr(tmpstring), url_length, url_text);
+  } else {
+    Warning("Document %s truncated", earliest_key.toHexStr(tmpstring));
+  }
   return calluser(VC_EVENT_ERROR);
+}
 Ldone:
   return calluser(VC_EVENT_EOS);
 Lcallreturn:


### PR DESCRIPTION
print url when document truncated warning occurs, so it is convenient to find out this Object and delete  it from ATS.