### PR TITLE
Issue_1943: get rid of ticket_key_name tag from ssl_multicert

### DIFF
--- a/doc/admin-guide/files/ssl_multicert.config.en.rst
+++ b/doc/admin-guide/files/ssl_multicert.config.en.rst
@@ -98,20 +98,8 @@ ssl_ticket_enabled=1|0 (optional)
   OpenSSL should be upgraded to version 0.9.8f or higher. This
   option must be set to `0` to disable session ticket support.
 
-ticket_key_name=FILENAME (optional)
-  The name of session ticket key file which contains a secret for
-  encrypting and decrypting TLS session tickets. If *FILENAME* is
-  not an absolute path, it is resolved relative to the
-  :ts:cv:`proxy.config.ssl.server.cert.path` configuration variable.
-  This option has no effect if session tickets are disabled by the
-  ``ssl_ticket_enabled`` option.  The contents of the key file should
-  be 48 random (ASCII) bytes. One way to generate this would be to run
-  ``head -c48 /dev/urandom | openssl enc -base64 | head -c48 > file.ticket``.
-
-  Session ticket support is enabled by default. If neither of the
-  ``ssl_ticket_enabled`` and ``ticket_key_name`` options are
-  specified, and internal session ticket key is generated. This
-  key will be different each time Traffic Server is started.
+ticket_key_name=FILENAME (optional) [**REMOVED in 7.1.x and 8.0**]
+   Ticket key should be set in records.config via :ts:cv:`proxy.config.ssl.server.ticket_key.filename`
 
 ssl_key_dialog=builtin|"exec:/path/to/program [args]" (optional)
   Method used to provide a pass phrase for encrypted private keys.  If the

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -100,8 +100,6 @@ struct ssl_user_config {
   ssl_user_config() : opt(SSLCertContext::OPT_NONE)
   {
     REC_ReadConfigInt32(session_ticket_enabled, "proxy.config.ssl.server.session_ticket.enable");
-    REC_ReadConfigStringAlloc(ticket_key_filename, "proxy.config.ssl.server.ticket_key.filename");
-    Debug("ssl", "ticket  key filename %s", (const char *)ticket_key_filename);
   }
 
   int session_ticket_enabled;
@@ -110,7 +108,6 @@ struct ssl_user_config {
   ats_scoped_str first_cert;
   ats_scoped_str ca;
   ats_scoped_str key;
-  ats_scoped_str ticket_key_filename;
   ats_scoped_str dialog;
   SSLCertContext::Option opt;
 };
@@ -1813,11 +1810,8 @@ ssl_store_ssl_context(const SSLConfigParams *params, SSLCertLookup *lookup, cons
     }
   }
 
-  // Load the session ticket key if session tickets are not disabled and we have key name.
-  if (sslMultCertSettings->session_ticket_enabled != 0 && sslMultCertSettings->ticket_key_filename) {
-    ats_scoped_str ticket_key_path(Layout::relative_to(params->serverCertPathOnly, sslMultCertSettings->ticket_key_filename));
-    keyblock = ssl_context_enable_tickets(ctx, ticket_key_path);
-  } else if (sslMultCertSettings->session_ticket_enabled != 0) {
+  // Load the session ticket key if session tickets are not disabled
+  if (sslMultCertSettings->session_ticket_enabled != 0) {
     keyblock = ssl_context_enable_tickets(ctx, nullptr);
   }
 
@@ -1937,10 +1931,6 @@ ssl_extract_certificate(const matcher_line *line_info, ssl_user_config &sslMultC
 
     if (strcasecmp(label, SSL_SESSION_TICKET_ENABLED) == 0) {
       sslMultCertSettings.session_ticket_enabled = atoi(value);
-    }
-
-    if (strcasecmp(label, SSL_SESSION_TICKET_KEY_FILE_TAG) == 0) {
-      sslMultCertSettings.ticket_key_filename = ats_strdup(value);
     }
 
     if (strcasecmp(label, SSL_KEY_DIALOG) == 0) {

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -67,7 +67,6 @@
 #define SSL_ACTION_TAG "action"
 #define SSL_ACTION_TUNNEL_TAG "tunnel"
 #define SSL_SESSION_TICKET_ENABLED "ssl_ticket_enabled"
-#define SSL_SESSION_TICKET_KEY_FILE_TAG "ticket_key_name"
 #define SSL_KEY_DIALOG "ssl_key_dialog"
 #define SSL_CERT_SEPARATE_DELIM ','
 


### PR DESCRIPTION
ticket_key_name is removed. 
Ticket key should be set in records.config like 
CONFIG proxy.config.ssl.server.ticket_key.filename STRING ssl_ticket.key 