### PR TITLE
gitignore .vscode/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ rc/trafficserver.service
 .libs/
 
 .svn/
+.vscode/
 
 tsxs
 


### PR DESCRIPTION
Telling git to ignore workspace setting files generated by visual studio code.