### PR TITLE
spawn_thread with atomic operation

### DIFF
--- a/iocore/eventsystem/I_EventProcessor.h
+++ b/iocore/eventsystem/I_EventProcessor.h
@@ -307,7 +307,7 @@ public:
   EThread *assign_thread(EventType etype);
 
   EThread *all_dthreads[MAX_EVENT_THREADS];
-  int n_dthreads; // No. of dedicated threads
+  volatile int n_dthreads; // No. of dedicated threads
   volatile int thread_data_used;
 };
 


### PR DESCRIPTION
We met a coredump:
```
#0  0x00002b5e5c553b4c in EventProcessor::spawn_thread (this=0x2b5e5ce6b9c0, cont=0x2b5e911683a0, thr_name=0x7ffe9f9436b0 "[ACCEPT 0:8084]", 
    stacksize=1048576) at UnixEventProcessor.cc:274
274     UnixEventProcessor.cc: No such file or directory.
(gdb) bt
#0  0x00002b5e5c553b4c in EventProcessor::spawn_thread (this=0x2b5e5ce6b9c0, cont=0x2b5e911683a0, thr_name=0x7ffe9f9436b0 "[ACCEPT 0:8084]", 
    stacksize=1048576) at UnixEventProcessor.cc:274
#1  0x00002b5e5c51f54d in NetAccept::init_accept_loop (this=0x2b5e911683a0, thr_name=0x7ffe9f9436b0 "[ACCEPT 0:8084]") at UnixNetAccept.cc:171
#2  0x00002b5e5c52147b in UnixNetProcessor::accept_internal (this=<optimized out>, cont=<optimized out>, fd=<optimized out>, opt=...)
    at UnixNetProcessor.cc:166
#3  0x00002b5e5c2eb34c in main_accept (opt=..., listen_socket_in=-1, cont=0x2b5e91069e60, this=<optimized out>)
    at ../../proxy/ProtocolProcessor.h:64
#4  start_HttpProxyServerBackDoor (port=<optimized out>, accept_threads=1) at HttpProxyServerMain.cc:549
#5  0x00002b5e5c201f61 in main (argv=<optimized out>) at Main.cc:1993
(gdb) f 0
#0  0x00002b5e5c553b4c in EventProcessor::spawn_thread (this=0x2b5e5ce6b9c0, cont=0x2b5e911683a0, thr_name=0x7ffe9f9436b0 "[ACCEPT 0:8084]", 
    stacksize=1048576) at UnixEventProcessor.cc:274
274     in UnixEventProcessor.cc
(gdb) p all_dthreads
$15 = {0x2b5e8ad045b0, 0x2b5e8ad25510, 0x2b5e8ad7e010, 0x2b5e8e458020, 0x2b5e8e478f80, 0x2b5e8e499ee0, 0x2b5e8e4bae40, 0x2b5e8e4dbda0, 
  0x2b5e8e4fcd00, 0x2b5e8ec37010, 0x2b5e91138c20, 0x2b5e910dd270, 0x2b5e9140b050, 0x2b5e9142bfb0, 0x2b5e915b0020, 0x2b5e68051830, 0x2b5e68072790, 
  0x2b5e68095f00, 0x2b5e680b7010, 0x2b5e680d8210, 0x2b5e9206e010, 0x2b5e920aef80, 0x2b5e68150010, 0x2b5e68170f70, 0x2b5e68191ed0, 0x2b5e681b2e30, 
  0x2b5e92111da0, 0x2b5e681f4cf0, 0x2b5e68225be0, 0x0 <repeats 4067 times>}
(gdb) p n_dthreads
$16 = 29
(gdb) p e->ethread
$17 = (EThread *) 0x2b5e92111da0
(gdb) p ((EThread *) 0x2b5e681f4cf0)->oneevent
$18 = (Event *) 0x2b5e64046910
(gdb) p *((EThread *) 0x2b5e681f4cf0)->oneevent->continuation
$19 = {<force_VFPT_to_top> = {_vptr.force_VFPT_to_top = 0x2b5e5c8a7c70}, handler = (int (Continuation::*)(Continuation * const, int, 
    void *)) 0x2b5e5c4fbff0 <AIOThreadInfo::start(int, Event*)>, mutex = {m_ptr = 0x2b5e680956d0}, link = {<SLink<Continuation>> = {next = 0x0}, 
    prev = 0x0}}
(gdb) p *((EThread *) 0x2b5e68225be0)->oneevent->continuation
$20 = {<force_VFPT_to_top> = {_vptr.force_VFPT_to_top = 0x2b5e5c8a7c70}, handler = (int (Continuation::*)(Continuation * const, int, 
    void *)) 0x2b5e5c4fbff0 <AIOThreadInfo::start(int, Event*)>, mutex = {m_ptr = 0x2b5e68095720}, link = {<SLink<Continuation>> = {next = 0x0}, 
    prev = 0x0}}
(gdb) 
```