### PR TITLE
1962: Reload keyblock from key file on every config reload

### DIFF
--- a/cmd/traffic_manager/traffic_manager.cc
+++ b/cmd/traffic_manager/traffic_manager.cc
@@ -949,6 +949,8 @@ fileUpdated(char *fname, bool incVersion)
     mgmt_log("[fileUpdated] metrics.config file has been modified\n");
   } else if (strcmp(fname, "congestion.config") == 0) {
     lmgmt->signalFileChange("proxy.config.http.congestion_control.filename");
+  } else if (strcmp(fname, "proxy.config.ssl.server.ticket_key.filename") == 0) {
+    lmgmt->signalFileChange("proxy.config.ssl.server.ticket_key.filename");
   } else {
     mgmt_log("[fileUpdated] Unknown config file updated '%s'\n", fname);
   }

--- a/iocore/net/P_SSLConfig.h
+++ b/iocore/net/P_SSLConfig.h
@@ -70,7 +70,6 @@ struct SSLConfigParams : public ConfigInfo {
   char *cipherSuite;
   char *client_cipherSuite;
   char *ticket_key_filename;
-  ssl_ticket_key_block *default_global_keyblock;
   int configExitOnLoadError;
   int clientCertLevel;
   int verify_depth;
@@ -142,7 +141,6 @@ struct SSLConfig {
   static void reconfigure();
   static SSLConfigParams *acquire();
   static void release(SSLConfigParams *params);
-
   typedef ConfigProcessor::scoped_config<SSLConfig, SSLConfigParams> scoped_config;
 
 private:
@@ -156,6 +154,37 @@ struct SSLCertificateConfig {
   static void release(SSLCertLookup *params);
 
   typedef ConfigProcessor::scoped_config<SSLCertificateConfig, SSLCertLookup> scoped_config;
+
+private:
+  static int configid;
+};
+
+struct SSLTicketParams : public ConfigInfo {
+  ssl_ticket_key_block *default_global_keyblock;
+  char *ticket_key_filename;
+  void LoadTicket();
+  void cleanup();
+
+  ~SSLTicketParams() { cleanup(); }
+};
+
+struct SSLTicketKeyConfig {
+  static void startup();
+  static bool reconfigure();
+
+  static SSLTicketParams *
+  acquire()
+  {
+    return static_cast<SSLTicketParams *>(configProcessor.get(configid));
+  }
+
+  static void
+  release(SSLTicketParams *params)
+  {
+    configProcessor.release(configid, params);
+  }
+
+  typedef ConfigProcessor::scoped_config<SSLTicketKeyConfig, SSLTicketParams> scoped_config;
 
 private:
   static int configid;

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -43,6 +43,7 @@
 
 int SSLConfig::configid                                     = 0;
 int SSLCertificateConfig::configid                          = 0;
+int SSLTicketKeyConfig::configid                            = 0;
 int SSLConfigParams::ssl_maxrecord                          = 0;
 bool SSLConfigParams::ssl_allow_client_renegotiation        = false;
 bool SSLConfigParams::ssl_ocsp_enabled                      = false;
@@ -90,7 +91,6 @@ SSLConfigParams::reset()
   serverCertPathOnly = serverCertChainFilename = configFilePath = serverCACertFilename = serverCACertPath = clientCertPath =
     clientKeyPath = clientCACertFilename = clientCACertPath = cipherSuite = client_cipherSuite = dhparamsFile = serverKeyPathOnly =
       ticket_key_filename                                                                                     = nullptr;
-  default_global_keyblock                                                                                     = nullptr;
   client_ctx                                                                                                  = nullptr;
   clientCertLevel = client_verify_depth = verify_depth = clientVerify = 0;
   ssl_ctx_options                                                     = SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3;
@@ -122,7 +122,7 @@ SSLConfigParams::cleanup()
   dhparamsFile            = (char *)ats_free_null(dhparamsFile);
   ssl_wire_trace_ip       = (IpAddr *)ats_free_null(ssl_wire_trace_ip);
   ticket_key_filename     = (char *)ats_free_null(ticket_key_filename);
-  ticket_block_free(default_global_keyblock);
+
   freeCTXmap();
   SSLReleaseContext(client_ctx);
   reset();
@@ -268,17 +268,6 @@ SSLConfigParams::initialize()
   set_paths_helper(CACertRelativePath, ssl_server_ca_cert_filename, &serverCACertPath, &serverCACertFilename);
   ats_free(ssl_server_ca_cert_filename);
   ats_free(CACertRelativePath);
-
-#if HAVE_OPENSSL_SESSION_TICKETS
-
-  if (REC_ReadConfigStringAlloc(ticket_key_filename, "proxy.config.ssl.server.ticket_key.filename") == REC_ERR_OKAY &&
-      this->ticket_key_filename != nullptr) {
-    ats_scoped_str ticket_key_path(Layout::relative_to(this->serverCertPathOnly, this->ticket_key_filename));
-    default_global_keyblock = ssl_create_ticket_keyblock(ticket_key_path);
-  } else {
-    default_global_keyblock = ssl_create_ticket_keyblock(nullptr);
-  }
-#endif
 
   // SSL session cache configurations
   REC_ReadConfigInteger(ssl_session_cache, "proxy.config.ssl.session_cache");
@@ -477,12 +466,10 @@ SSLCertificateConfig::startup()
 {
   sslCertUpdate = new ConfigUpdateHandler<SSLCertificateConfig>();
   sslCertUpdate->attach("proxy.config.ssl.server.multicert.filename");
-  sslCertUpdate->attach("proxy.config.ssl.server.ticket_key.filename");
   sslCertUpdate->attach("proxy.config.ssl.server.cert.path");
   sslCertUpdate->attach("proxy.config.ssl.server.private_key.path");
   sslCertUpdate->attach("proxy.config.ssl.server.cert_chain.filename");
   sslCertUpdate->attach("proxy.config.ssl.server.session_ticket.enable");
-
   // Exit if there are problems on the certificate loading and the
   // proxy.config.ssl.server.multicert.exit_on_load_fail is true
   SSLConfig::scoped_config params;
@@ -534,4 +521,57 @@ void
 SSLCertificateConfig::release(SSLCertLookup *lookup)
 {
   configProcessor.release(configid, lookup);
+}
+
+void
+SSLTicketParams::LoadTicket()
+{
+  cleanup();
+
+#if HAVE_OPENSSL_SESSION_TICKETS
+
+  SSLConfig::scoped_config params;
+
+  if (REC_ReadConfigStringAlloc(ticket_key_filename, "proxy.config.ssl.server.ticket_key.filename") == REC_ERR_OKAY &&
+      ticket_key_filename != nullptr) {
+    ats_scoped_str ticket_key_path(Layout::relative_to(params->serverCertPathOnly, ticket_key_filename));
+    default_global_keyblock = ssl_create_ticket_keyblock(ticket_key_path);
+  } else {
+    default_global_keyblock = ssl_create_ticket_keyblock(nullptr);
+  }
+  if (!default_global_keyblock) {
+    Fatal("Could not load Ticket Key from %s", ticket_key_filename);
+    return;
+  }
+  Debug("ssl", "ticket key reloaded from %s", ticket_key_filename);
+
+#endif
+}
+
+void
+SSLTicketKeyConfig::startup()
+{
+  auto sslTicketKey = new ConfigUpdateHandler<SSLTicketKeyConfig>();
+
+  sslTicketKey->attach("proxy.config.ssl.server.ticket_key.filename");
+  reconfigure();
+}
+
+bool
+SSLTicketKeyConfig::reconfigure()
+{
+  SSLTicketParams *ticketKey = new SSLTicketParams();
+
+  if (ticketKey)
+    ticketKey->LoadTicket();
+
+  configid = configProcessor.set(configid, ticketKey);
+  return true;
+}
+
+void
+SSLTicketParams::cleanup()
+{
+  ticket_block_free(default_global_keyblock);
+  ticket_key_filename = (char *)ats_free_null(ticket_key_filename);
 }

--- a/iocore/net/SSLNetProcessor.cc
+++ b/iocore/net/SSLNetProcessor.cc
@@ -63,6 +63,7 @@ SSLNetProcessor::start(int, size_t stacksize)
   if (!SSLCertificateConfig::startup()) {
     return -1;
   }
+  SSLTicketKeyConfig::startup();
 
   // Acquire a SSLConfigParams instance *after* we start SSL up.
   // SSLConfig::scoped_config params;

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -2055,7 +2055,7 @@ ssl_callback_session_ticket(SSL *ssl, unsigned char *keyname, unsigned char *iv,
                             int enc)
 {
   SSLCertificateConfig::scoped_config lookup;
-  SSLConfig::scoped_config params;
+  SSLTicketKeyConfig::scoped_config params;
   SSLNetVConnection *netvc = SSLNetVCAccess(ssl);
 
   // Get the IP address to look up the keyblock

--- a/mgmt/FileManager.cc
+++ b/mgmt/FileManager.cc
@@ -180,7 +180,7 @@ FileManager::fileChanged(const char *fileName, bool incVersion)
 {
   callbackListable *cb;
   char *filenameCopy;
-
+  Debug("lm", "filename changed %s", fileName);
   ink_mutex_acquire(&cbListLock);
 
   for (cb = cblist.head; cb != nullptr; cb = cb->link.next) {
@@ -667,6 +667,7 @@ FileManager::rereadConfig()
   if (found && enabled) {
     fileChanged("proxy.config.body_factory.template_sets_dir", true);
   }
+  fileChanged("proxy.config.ssl.server.ticket_key.filename", true);
 }
 
 bool

--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -595,7 +595,8 @@ LocalManager::sendMgmtMsgToProcesses(MgmtMessageHdr *mh)
     }
     ink_assert(found);
     if (!(configFiles && configFiles->getRollbackObj(fname, &rb)) &&
-        (strcmp(data_raw, "proxy.config.body_factory.template_sets_dir") != 0)) {
+        (strcmp(data_raw, "proxy.config.body_factory.template_sets_dir") != 0) &&
+        (strcmp(data_raw, "proxy.config.ssl.server.ticket_key.filename") != 0)) {
       mgmt_fatal(0, "[LocalManager::sendMgmtMsgToProcesses] "
                     "Invalid 'data_raw' for MGMT_EVENT_CONFIG_FILE_UPDATE\n");
     }
@@ -733,7 +734,7 @@ LocalManager::processEventQueue()
         ink_assert(enqueue(mgmt_event_queue, mh));
         return;
       }
-      Debug("lm", "[TrafficManager] ==> Sending signal event '%d' payload=%d", mh->msg_id, mh->data_len);
+      Debug("lm", "[TrafficManager] ==> Sending signal event '%d' %s payload=%d", mh->msg_id, data_raw, mh->data_len);
       lmgmt->sendMgmtMsgToProcesses(mh);
     }
     ats_free(mh);


### PR DESCRIPTION
This patch is for letting the ticket keyblock get updated each time config reload is called. The config 'proxy.config.ssl.server.ticket_key.filename' is attached to sslcertupdate,  but the callback function for this update is different to avoid reloading of stack of ssl certificates unnecessarily. Hence if there is a change in the content of ticket key file only, then a call to `config reload` should load the ticket keyblock only not the entire certificate stack from ssl_multicert.config  