### PR TITLE
Fixed problem with url_len sometimes not being initialized

### DIFF
--- a/tools/jtest/jtest.cc
+++ b/tools/jtest/jtest.cc
@@ -749,7 +749,7 @@ send_response(int sock)
   char *url_start = nullptr;
   char *url_end   = nullptr;
   int err         = 0, towrite;
-  int url_len;
+  int url_len     = 0;
 
   if (fd[sock].req_pos >= 0) {
     char header[1024];


### PR DESCRIPTION
jtest/jtest.cc: In function ‘int send_response(int)’:
jtest/jtest.cc:789:53: error: ‘url_len’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     total_server_response_header_bytes += print_len - url_len;
                                           ~~~~~~~~~~^~~~~~~~~