### PR TITLE
Changes the default for proxy.config.ssl.server.multicert.exit_on_loa…

### DIFF
--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -101,7 +101,7 @@ SSLConfigParams::reset()
   ssl_session_cache_skip_on_contention = 0;
   ssl_session_cache_timeout            = 0;
   ssl_session_cache_auto_clear         = 1;
-  configExitOnLoadError                = 0;
+  configExitOnLoadError                = 1;
 }
 
 void

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1148,7 +1148,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.ssl.server.multicert.filename", RECD_STRING, "ssl_multicert.config", RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.ssl.server.multicert.exit_on_load_fail", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_NULL, "[0-1]", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.ssl.server.multicert.exit_on_load_fail", RECD_INT, "1", RECU_RESTART_TS, RR_NULL, RECC_NULL, "[0-1]", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.ssl.server.ticket_key.filename", RECD_STRING, nullptr, RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,


### PR DESCRIPTION
…d_fail

This restores the old (and IMO expected) behavior of how we don't allow
bad configurations to be reloaded / replaced. We've had a case where
all certificates were lost for a small period of time, and an unrelated
config reload happening at the same time caused us to lose all certificates.