### PR TITLE
Server information should be cleared when following redirect

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -7694,6 +7694,8 @@ HttpSM::redirect_request(const char *redirect_url, const int redirect_len)
   // we have a new OS and need to have DNS lookup the new OS
   t_state.dns_info.lookup_success = false;
   t_state.force_dns               = false;
+  t_state.server_info.clear();
+  t_state.parent_info.clear();
 
   if (t_state.txn_conf->cache_http) {
     t_state.cache_info.object_read = nullptr;

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -637,10 +637,14 @@ public:
       connect_result = e;
     }
 
-    ConnectionAttributes()
+    ConnectionAttributes() { clear(); }
+
+    void
+    clear()
     {
-      memset(&src_addr, 0, sizeof(src_addr));
-      memset(&dst_addr, 0, sizeof(dst_addr));
+      ink_zero(src_addr);
+      ink_zero(dst_addr);
+      connect_result = 0;
     }
   };
 


### PR DESCRIPTION
Prior to  #1756, clearing the server information was not required while following a redirect as DNS was always done under all circumstances. Now, ATS does DNS only it is required so, server information should be cleared while following the redirect.