### PR TITLE
The return of TSHttpTxnIsInternal changed.

### DIFF
--- a/plugins/experimental/inliner/ats-inliner.cc
+++ b/plugins/experimental/inliner/ats-inliner.cc
@@ -157,7 +157,7 @@ transformable(TSHttpTxn txnp)
 
   CHECK(TSHandleMLocRelease(buffer, TS_NULL_MLOC, location));
 
-  returnValue &= TSHttpTxnIsInternal(txnp) != TS_SUCCESS;
+  returnValue &= !TSHttpTxnIsInternal(txnp);
   return returnValue;
 }
 


### PR DESCRIPTION
When the name changed in the move to 7.0.  The original version had a return
value of TS_SUCCESS(0) if the transaction is internal.  The new version has a
return value of True(1) if the transaction is internal.  This plugin changed
the name but not the return value test.