### PR TITLE
Require at least one ET_TASK thread

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3646,7 +3646,8 @@ Sockets
 .. ts:cv:: CONFIG proxy.config.task_threads INT 2
 
    Specifies the number of task threads to run. These threads are used for
-   various tasks that should be off-loaded from the normal network threads.
+   various tasks that should be off-loaded from the normal network
+   threads. You must have at least one task thread available.
 
 .. ts:cv:: CONFIG proxy.config.allocator.thread_freelist_size INT 512
 

--- a/iocore/eventsystem/Tasks.cc
+++ b/iocore/eventsystem/Tasks.cc
@@ -32,8 +32,6 @@ TasksProcessor tasksProcessor;
 int
 TasksProcessor::start(int task_threads, size_t stacksize)
 {
-  if (task_threads > 0) {
-    ET_TASK = eventProcessor.spawn_event_threads(task_threads, "ET_TASK", stacksize);
-  }
+  ET_TASK = eventProcessor.spawn_event_threads(task_threads > 0 ? task_threads : 1, "ET_TASK", stacksize);
   return 0;
 }

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -132,7 +132,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.accept_threads", RECD_INT, "1", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-" TS_STR(TS_MAX_NUMBER_EVENT_THREADS) "]", RECA_READ_ONLY}
   ,
-  {RECT_CONFIG, "proxy.config.task_threads", RECD_INT, "2", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-" TS_STR(TS_MAX_NUMBER_EVENT_THREADS) "]", RECA_READ_ONLY}
+  {RECT_CONFIG, "proxy.config.task_threads", RECD_INT, "2", RECU_RESTART_TS, RR_NULL, RECC_INT, "[1-" TS_STR(TS_MAX_NUMBER_EVENT_THREADS) "]", RECA_READ_ONLY}
   ,
   {RECT_CONFIG, "proxy.config.thread.default.stacksize", RECD_INT, "1048576", RECU_RESTART_TS, RR_NULL, RECC_INT, "[131072-104857600]", RECA_READ_ONLY}
   ,


### PR DESCRIPTION
This also (rightfully) makes us require at least one ET_TASK thread.
There are already things depending on ET_TASK, so this is nothing new.