### PR TITLE
add function name to the history of sm

### DIFF
--- a/lib/ts/SourceLocation.h
+++ b/lib/ts/SourceLocation.h
@@ -44,7 +44,7 @@ public:
   }
 
   SourceLocation(const SourceLocation &rhs) : file(rhs.file), func(rhs.func), line(rhs.line) {}
-  SourceLocation(const char *_file, const char *_func, int _line) : file(_file), func(_func), line(_line) {}
+  SourceLocation(const char *_file = nullptr, const char *_func = nullptr, int _line = 0) : file(_file), func(_func), line(_line) {}
   SourceLocation &
   operator=(const SourceLocation &rhs)
   {

--- a/proxy/CoreUtils.cc
+++ b/proxy/CoreUtils.cc
@@ -697,9 +697,10 @@ CoreUtils::dump_history(HttpSM *hsm)
 
   // Loop through the history and dump it
   for (int i = 0; i < hsm->history_pos; i++) {
+    char loc[256];
     int r          = (int)hsm->history[i].reentrancy;
     int e          = (int)hsm->history[i].event;
-    char *fileline = load_string(hsm->history[i].fileline);
+    char *fileline = load_string(hsm->history[i].location.str(loc, sizeof(loc)));
 
     fileline = (fileline != nullptr) ? fileline : ats_strdup("UNKNOWN");
 

--- a/proxy/http/HttpCacheSM.cc
+++ b/proxy/http/HttpCacheSM.cc
@@ -43,7 +43,7 @@
 #define __REMEMBER(x) #x
 #define _REMEMBER(x) __REMEMBER(x)
 
-#define REMEMBER(e, r) master_sm->add_history_entry(__FILE__ ":" _REMEMBER(__LINE__), e, r);
+#define REMEMBER(e, r) master_sm->add_history_entry(MakeSourceLocation(), e, r);
 
 HttpCacheAction::HttpCacheAction() : sm(nullptr)
 {

--- a/proxy/http/HttpPages.cc
+++ b/proxy/http/HttpPages.cc
@@ -222,10 +222,11 @@ HttpPagesHandler::dump_history(HttpSM *sm)
   }
 
   for (int i = 0; i < size; i++) {
+    char buf[256];
     resp_begin_row();
 
     resp_begin_column();
-    resp_add("%s", sm->history[i].fileline);
+    resp_add("%s", sm->history[i].location.str(buf, sizeof(buf)));
     resp_end_column();
 
     resp_begin_column();

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -239,13 +239,13 @@ HttpVCTable::cleanup_all()
 #define __REMEMBER(x) #x
 #define _REMEMBER(x) __REMEMBER(x)
 
-#define RECORD_FILE_LINE() history[pos].fileline = __FILE__ ":" _REMEMBER(__LINE__);
+#define RECORD_FILE_LINE() history[pos].location = MakeSourceLocation();
 
-#define REMEMBER(e, r)                                           \
-  {                                                              \
-    if (REMEMBER_EVENT_FILTER(e)) {                              \
-      add_history_entry(__FILE__ ":" _REMEMBER(__LINE__), e, r); \
-    }                                                            \
+#define REMEMBER(e, r)                               \
+  {                                                  \
+    if (REMEMBER_EVENT_FILTER(e)) {                  \
+      add_history_entry(MakeSourceLocation(), e, r); \
+    }                                                \
   }
 
 #define DebugSM(tag, ...) DebugSpecific(debug_on, tag, __VA_ARGS__)
@@ -6979,9 +6979,10 @@ HttpSM::dump_state_on_assert()
   }
   // Loop through the history and dump it
   for (int i = 0; i < hist_size; i++) {
+    char buf[256];
     int r = history[i].reentrancy;
     int e = history[i].event;
-    Error("%d   %d   %s", e, r, history[i].fileline);
+    Error("%d   %d   %s", e, r, history[i].location.str(buf, sizeof(buf)));
   }
 
   // Dump the via string

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -259,7 +259,7 @@ public:
   void txn_hook_prepend(TSHttpHookID id, INKContInternal *cont);
   APIHook *txn_hook_get(TSHttpHookID id);
 
-  void add_history_entry(const char *fileline, int event, int reentrant);
+  void add_history_entry(const SourceLocation &location, int event, int reentrant);
   void add_cache_sm();
   bool is_private();
   bool is_redirect_required();
@@ -293,12 +293,12 @@ protected:
   int reentrancy_count = 0;
 
   struct History {
-    const char *fileline;
-    unsigned short event;
-    short reentrancy;
+    SourceLocation location;
+    unsigned short event = 0;
+    short reentrancy = 0;
+
   };
-  History history[HISTORY_SIZE] = {{nullptr, 0, 0}};
-  ;
+  History history[HISTORY_SIZE];
   int history_pos = 0;
 
   HttpTunnel tunnel;
@@ -611,10 +611,10 @@ HttpSM::write_response_header_into_buffer(HTTPHdr *h, MIOBuffer *b)
 }
 
 inline void
-HttpSM::add_history_entry(const char *fileline, int event, int reentrant)
+HttpSM::add_history_entry(const SourceLocation &location, int event, int reentrant)
 {
   int pos                 = history_pos++ % HISTORY_SIZE;
-  history[pos].fileline   = fileline;
+  history[pos].location   = location;
   history[pos].event      = (unsigned short)event;
   history[pos].reentrancy = (short)reentrant;
 }


### PR DESCRIPTION
Hmm,  Function name is more useful than file's line sometimes

```
$2 = {{
    fileline = 0xab5c60 "HttpSM.cc:553", 
    function = 0xac16c0 <HttpSM::state_read_client_request_header(int, void*)::__FUNCTION__> "state_read_client_request_header", 
    event = 100, 
    reentrancy = 2
  }, {
    fileline = 0xabfc80 "HttpSM.cc:7214", 
    function = 0xac2da0 <HttpSM::set_next_state()::__FUNCTION__> "set_next_state", 
    event = 65535, 
    reentrancy = 2
  }, {
    fileline = 0xabbb80 "HttpSM.cc:4434", 
    function = 0xac2480 <HttpSM::do_cache_lookup_and_read()::__FUNCTION__> "do_cache_lookup_and_read", 
    event = 29352, 
    reentrancy = 2
  }, {
    fileline = 0xab6240 "HttpSM.cc:815", 
    function = 0xac1720 <HttpSM::state_watch_for_client_abort(int, void*)::__FUNCTION__> "state_watch_for_client_abort", 
    event = 100, 
    reentrancy = 1
  }, {
    fileline = 0xa9b2c0 "HttpCacheSM.cc:118", 
    function = 0xa9c3e0 <HttpCacheSM::state_cache_open_read(int, void*)::__FUNCTION__> "state_cache_open_read", 
    event = 1102, 
    reentrancy = -1
  }, {
    fileline = 0xab8900 "HttpSM.cc:2429", 
    function = 0xac1c80 <HttpSM::state_cache_open_read(int, void*)::__FUNCTION__> "state_cache_open_read", 
    event = 1102, 
    reentrancy = 1
  }, {
    fileline = 0xac0080 "HttpSM.cc:7329", 
    function = 0xac2da0 <HttpSM::set_next_state()::__FUNCTION__> "set_next_state", 
    event = 65535, 
    reentrancy = 1
  }, {
---Type <return> to continue, or q <return> to quit---
    fileline = 0xa9b620 "HttpCacheSM.cc:177", 
    function = 0xa9c420 <HttpCacheSM::state_cache_open_write(int, void*)::__FUNCTION__> "state_cache_open_write", 
    event = 1108, 
    reentrancy = -1
  }, {
    fileline = 0xab86c0 "HttpSM.cc:2310", 
    function = 0xac1c40 <HttpSM::state_cache_open_write(int, void*)::__FUNCTION__> "state_cache_open_write", 
    event = 1108, 
    reentrancy = 2
  }, {
    fileline = 0xabfd00 "HttpSM.cc:7227", 
    function = 0xac2da0 <HttpSM::set_next_state()::__FUNCTION__> "set_next_state", 
    event = 65535, 
    reentrancy = 2
  }, {
    fileline = 0xabd1e0 "HttpSM.cc:5545", 
    function = 0xac2760 <HttpSM::do_setup_post_tunnel(HttpVC_t)::__FUNCTION__> "do_setup_post_tunnel", 
    event = 65535, 
    reentrancy = 2
  }, {
    fileline = 0xaba160 "HttpSM.cc:3339", 
    function = 0xac2040 <HttpSM::tunnel_handler_post_ua(int, HttpTunnelProducer*)::__FUNCTION__> "tunnel_handler_post_ua", 
    event = 2302, 
    reentrancy = 2
  }, {
    fileline = 0xaba8e0 "HttpSM.cc:3685", 
    function = 0xac2180 <HttpSM::tunnel_handler_transform_write(int, HttpTunnelConsumer*)::__FUNCTION__> "tunnel_handler_transform_write", 
    event = 103, 
    reentrancy = 0
  }, {
    fileline = 0xab6860 "HttpSM.cc:1111", 
    function = 0xac17e0 <HttpSM::state_request_wait_for_transform_read(int, void*)::__FUNCTION__> "state_request_wait_for_transform_read", 
    event = 2301, 
    reentrancy = 1
---Type <return> to continue, or q <return> to quit---
  }, {
    fileline = 0xab6a80 "HttpSM.cc:1181", 
    function = 0xac18a0 <HttpSM::state_common_wait_for_transform_read(HttpTransformInfo*, int (HttpSM::*)(int, void*), int, void*)::__FUNCTION__> "state_common_wait_for_transform_read", 
    event = 2301, 
    reentrancy = 1
  }, {
    fileline = 0xab6860 "HttpSM.cc:1111", 
    function = 0xac17e0 <HttpSM::state_request_wait_for_transform_read(int, void*)::__FUNCTION__> "state_request_wait_for_transform_read", 
    event = 2000, 
    reentrancy = 1
  }, {
    fileline = 0xab6240 "HttpSM.cc:815", 
    function = 0xac1720 <HttpSM::state_watch_for_client_abort(int, void*)::__FUNCTION__> "state_watch_for_client_abort", 
    event = 104, 
    reentrancy = 1
  }, {
    fileline = 0xab7a80 "HttpSM.cc:1920", 
    function = 0xac1a60 <HttpSM::state_send_server_request_header(int, void*)::__FUNCTION__> "state_send_server_request_header", 
    event = 103, 
    reentrancy = 1
  }, {
    fileline = 0xabd060 "HttpSM.cc:5451", 
    function = 0xac2700 <HttpSM::setup_transform_to_server_transfer()::__FUNCTION__> "setup_transform_to_server_transfer", 
    event = 65535, 
    reentrancy = 1
  }, {
    fileline = 0xabaa40 "HttpSM.cc:3771", 
    function = 0xac21c0 <HttpSM::tunnel_handler_transform_read(int, HttpTunnelProducer*)::__FUNCTION__> "tunnel_handler_transform_read", 
    event = 102, 
    reentrancy = 0
  }, {
    fileline = 0xab7a80 "HttpSM.cc:1920", 
    function = 0xac1a60 <HttpSM::state_send_server_request_header(int, void*)::__FUNCTION__> "state_send_server_request_header", 
---Type <return> to continue, or q <return> to quit---
    event = 3, 
    reentrancy = 1
  }, {
    fileline = 0xabcd20 "HttpSM.cc:5326", 
    function = 0xac26c0 <HttpSM::handle_server_setup_error(int, void*)::__FUNCTION__> "handle_server_setup_error", 
    event = 3, 
    reentrancy = 1
  }, {
    fileline = 0xaba4a0 "HttpSM.cc:3463", 
    function = 0xac20c0 <HttpSM::tunnel_handler_post_server(int, HttpTunnelConsumer*)::__FUNCTION__> "tunnel_handler_post_server", 
    event = 3, 
    reentrancy = 1
  }, {
    fileline = 0xab9000 "HttpSM.cc:2599", 
    function = 0xac1d00 <HttpSM::tunnel_handler_post(int, void*)::__FUNCTION__> "tunnel_handler_post", 
    event = 2301, 
    reentrancy = 2
  }, {
    fileline = 0xabcba0 "HttpSM.cc:5217", 
    function = 0xac2680 <HttpSM::handle_post_failure()::__FUNCTION__> "handle_post_failure", 
    event = 0, 
    reentrancy = 2
  }, {
    fileline = 0xabfd00 "HttpSM.cc:7227", 
    function = 0xac2da0 <HttpSM::set_next_state()::__FUNCTION__> "set_next_state", 
    event = 65535, 
    reentrancy = 2
  }, {
    fileline = 0xab74e0 "HttpSM.cc:1656", 
    function = 0xac19c0 <HttpSM::state_http_server_open(int, void*)::__FUNCTION__> "state_http_server_open", 
    event = 200, 
    reentrancy = 3
  }, {
    fileline = 0x0, 
    function = 0x0, 
---Type <return> to continue, or q <return> to quit---
    event = 0, 
    reentrancy = 0
  } <repeats 37 times>}

```