### PR TITLE
Stop looping refreshing stale hostDB records

### DIFF
--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -110,6 +110,24 @@ ink_get16(const uint8_t *src)
   return dst;
 }
 
+static inline unsigned int
+get_rcode(char *buff)
+{
+  return reinterpret_cast<HEADER *>(buff)->rcode;
+}
+
+static inline unsigned int
+get_rcode(HostEnt *ent)
+{
+  return get_rcode(reinterpret_cast<char *>(ent->buf));
+}
+
+bool
+HostEnt::isNameError()
+{
+  return get_rcode(this) == NXDOMAIN;
+}
+
 void
 HostEnt::free()
 {
@@ -702,18 +720,6 @@ DNSHandler::rr_failure(int ndx)
   }
 }
 
-static inline unsigned int
-get_rcode(char *buff)
-{
-  return reinterpret_cast<HEADER *>(buff)->rcode;
-}
-
-static inline unsigned int
-get_rcode(HostEnt *ent)
-{
-  return get_rcode(reinterpret_cast<char *>(ent));
-}
-
 static bool
 good_rcode(char *buff)
 {
@@ -1114,7 +1120,7 @@ dns_result(DNSHandler *h, DNSEntry *e, HostEnt *ent, bool retry)
   ProxyMutex *mutex = h->mutex.get();
   bool cancelled    = (e->action.cancelled ? true : false);
 
-  if (!ent && !cancelled) {
+  if ((!ent || !ent->good) && !cancelled) {
     // try to retry operation
     if (retry && e->retries) {
       Debug("dns", "doing retry for %s", e->qname);
@@ -1161,7 +1167,7 @@ dns_result(DNSHandler *h, DNSEntry *e, HostEnt *ent, bool retry)
   if (ent == BAD_DNS_RESULT)
     ent = nullptr;
   if (!cancelled) {
-    if (!ent) {
+    if (!ent || !ent->good) {
       DNS_SUM_DYN_STAT(dns_fail_time_stat, Thread::get_hrtime() - e->submit_time);
     } else {
       DNS_SUM_DYN_STAT(dns_success_time_stat, Thread::get_hrtime() - e->submit_time);
@@ -1174,13 +1180,13 @@ dns_result(DNSHandler *h, DNSEntry *e, HostEnt *ent, bool retry)
       ip_text_buffer buff;
       const char *ptr    = "<none>";
       const char *result = "FAIL";
-      if (ent) {
+      if (ent && ent->good) {
         result = "SUCCESS";
         ptr    = inet_ntop(e->qtype == T_AAAA ? AF_INET6 : AF_INET, ent->ent.h_addr_list[0], buff, sizeof(buff));
       }
       Debug("dns", "%s result for %s = %s retry %d", result, e->qname, ptr, retry);
     } else {
-      if (ent) {
+      if (ent && ent->good) {
         Debug("dns", "SUCCESS result for %s = %s af=%d retry %d", e->qname, ent->ent.h_name, ent->ent.h_addrtype, retry);
       } else {
         Debug("dns", "FAIL result for %s = <not found> retry %d", e->qname, retry);
@@ -1188,7 +1194,7 @@ dns_result(DNSHandler *h, DNSEntry *e, HostEnt *ent, bool retry)
     }
   }
 
-  if (ent) {
+  if (ent || !ent->good) {
     DNS_INCREMENT_DYN_STAT(dns_lookup_success_stat);
   } else {
     DNS_INCREMENT_DYN_STAT(dns_lookup_fail_stat);
@@ -1600,7 +1606,8 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
   }
 Lerror:;
   DNS_INCREMENT_DYN_STAT(dns_lookup_fail_stat);
-  dns_result(handler, e, nullptr, retry);
+  buf->good = false;
+  dns_result(handler, e, buf, retry);
   return server_ok;
 }
 

--- a/iocore/dns/I_DNSProcessor.h
+++ b/iocore/dns/I_DNSProcessor.h
@@ -48,7 +48,8 @@ struct HostEnt : RefCountObj {
   u_char *h_addr_ptrs[DNS_MAX_ADDRS + 1] = {nullptr};
   u_char hostbuf[DNS_HOSTBUF_SIZE]       = {0};
   SRVHosts srv_hosts;
-
+  bool good = true;
+  bool isNameError();
   virtual void free();
 };
 

--- a/iocore/hostdb/P_HostDBProcessor.h
+++ b/iocore/hostdb/P_HostDBProcessor.h
@@ -198,9 +198,10 @@ struct HostDBCache {
 
   // TODO configurable number of items in the cache
   Queue<HostDBContinuation, Continuation::Link_link> *pending_dns;
-  Queue<HostDBContinuation, Continuation::Link_link> &pending_dns_for_hash(INK_MD5 &md5);
+  Queue<HostDBContinuation, Continuation::Link_link> &pending_dns_for_hash(const INK_MD5 &md5);
   Queue<HostDBContinuation, Continuation::Link_link> *remoteHostDBQueue;
   HostDBCache();
+  bool is_pending_dns_for_hash(const INK_MD5 &md5);
 };
 
 inline int
@@ -519,7 +520,7 @@ is_dotted_form_hostname(const char *c)
 }
 
 inline Queue<HostDBContinuation> &
-HostDBCache::pending_dns_for_hash(INK_MD5 &md5)
+HostDBCache::pending_dns_for_hash(const INK_MD5 &md5)
 {
   return pending_dns[this->refcountcache->partition_for_key(md5.fold())];
 }


### PR DESCRIPTION
This is an issue happened in production in LNKD.
When a DNS record doesn't exist anymore but it's still in hostDB. ATS will refresh this stale record. Since it can't get new DNS resolution, ATS will continue to refresh the same record forever.