### PR TITLE
Add function name to the HttpSM history.

### DIFF
--- a/lib/ts/SourceLocation.h
+++ b/lib/ts/SourceLocation.h
@@ -33,9 +33,14 @@
 class SourceLocation
 {
 public:
-  const char *file;
-  const char *func;
-  int line;
+  const char *file = nullptr;
+  const char *func = nullptr;
+  int line         = 0;
+
+  SourceLocation()                          = default;
+  SourceLocation(const SourceLocation &rhs) = default;
+
+  SourceLocation(const char *_file, const char *_func, int _line) : file(_file), func(_func), line(_line) {}
 
   bool
   valid() const
@@ -43,8 +48,6 @@ public:
     return file && line;
   }
 
-  SourceLocation(const SourceLocation &rhs) : file(rhs.file), func(rhs.func), line(rhs.line) {}
-  SourceLocation(const char *_file, const char *_func, int _line) : file(_file), func(_func), line(_line) {}
   SourceLocation &
   operator=(const SourceLocation &rhs)
   {

--- a/proxy/CoreUtils.cc
+++ b/proxy/CoreUtils.cc
@@ -697,9 +697,10 @@ CoreUtils::dump_history(HttpSM *hsm)
 
   // Loop through the history and dump it
   for (int i = 0; i < hsm->history_pos; i++) {
+    char loc[256];
     int r          = (int)hsm->history[i].reentrancy;
     int e          = (int)hsm->history[i].event;
-    char *fileline = load_string(hsm->history[i].fileline);
+    char *fileline = load_string(hsm->history[i].location.str(loc, sizeof(loc)));
 
     fileline = (fileline != nullptr) ? fileline : ats_strdup("UNKNOWN");
 

--- a/proxy/http/HttpCacheSM.cc
+++ b/proxy/http/HttpCacheSM.cc
@@ -40,10 +40,7 @@
     Debug("http_cache", "[%" PRId64 "] [%s, %s]", master_sm->sm_id, #state_name, HttpDebugNames::get_event_name(event)); \
   }
 
-#define __REMEMBER(x) #x
-#define _REMEMBER(x) __REMEMBER(x)
-
-#define REMEMBER(e, r) master_sm->add_history_entry(__FILE__ ":" _REMEMBER(__LINE__), e, r);
+#define REMEMBER(e, r) master_sm->add_history_entry(MakeSourceLocation(), e, r);
 
 HttpCacheAction::HttpCacheAction() : sm(nullptr)
 {

--- a/proxy/http/HttpPages.cc
+++ b/proxy/http/HttpPages.cc
@@ -222,10 +222,11 @@ HttpPagesHandler::dump_history(HttpSM *sm)
   }
 
   for (int i = 0; i < size; i++) {
+    char buf[256];
     resp_begin_row();
 
     resp_begin_column();
-    resp_add("%s", sm->history[i].fileline);
+    resp_add("%s", sm->history[i].location.str(buf, sizeof(buf)));
     resp_end_column();
 
     resp_begin_column();

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -236,16 +236,13 @@ HttpVCTable::cleanup_all()
 
 #define REMEMBER_EVENT_FILTER(e) 1
 
-#define __REMEMBER(x) #x
-#define _REMEMBER(x) __REMEMBER(x)
+#define RECORD_FILE_LINE() history[pos].location = MakeSourceLocation();
 
-#define RECORD_FILE_LINE() history[pos].fileline = __FILE__ ":" _REMEMBER(__LINE__);
-
-#define REMEMBER(e, r)                                           \
-  {                                                              \
-    if (REMEMBER_EVENT_FILTER(e)) {                              \
-      add_history_entry(__FILE__ ":" _REMEMBER(__LINE__), e, r); \
-    }                                                            \
+#define REMEMBER(e, r)                               \
+  {                                                  \
+    if (REMEMBER_EVENT_FILTER(e)) {                  \
+      add_history_entry(MakeSourceLocation(), e, r); \
+    }                                                \
   }
 
 #define DebugSM(tag, ...) DebugSpecific(debug_on, tag, __VA_ARGS__)
@@ -6979,9 +6976,10 @@ HttpSM::dump_state_on_assert()
   }
   // Loop through the history and dump it
   for (int i = 0; i < hist_size; i++) {
+    char buf[256];
     int r = history[i].reentrancy;
     int e = history[i].event;
-    Error("%d   %d   %s", e, r, history[i].fileline);
+    Error("%d   %d   %s", e, r, history[i].location.str(buf, sizeof(buf)));
   }
 
   // Dump the via string

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -259,7 +259,7 @@ public:
   void txn_hook_prepend(TSHttpHookID id, INKContInternal *cont);
   APIHook *txn_hook_get(TSHttpHookID id);
 
-  void add_history_entry(const char *fileline, int event, int reentrant);
+  void add_history_entry(const SourceLocation &location, int event, int reentrant);
   void add_cache_sm();
   bool is_private();
   bool is_redirect_required();
@@ -293,12 +293,11 @@ protected:
   int reentrancy_count = 0;
 
   struct History {
-    const char *fileline;
-    unsigned short event;
-    short reentrancy;
+    SourceLocation location;
+    unsigned short event = 0;
+    short reentrancy     = 0;
   };
-  History history[HISTORY_SIZE] = {{nullptr, 0, 0}};
-  ;
+  History history[HISTORY_SIZE];
   int history_pos = 0;
 
   HttpTunnel tunnel;
@@ -611,10 +610,10 @@ HttpSM::write_response_header_into_buffer(HTTPHdr *h, MIOBuffer *b)
 }
 
 inline void
-HttpSM::add_history_entry(const char *fileline, int event, int reentrant)
+HttpSM::add_history_entry(const SourceLocation &location, int event, int reentrant)
 {
   int pos                 = history_pos++ % HISTORY_SIZE;
-  history[pos].fileline   = fileline;
+  history[pos].location   = location;
   history[pos].event      = (unsigned short)event;
   history[pos].reentrancy = (short)reentrant;
 }


### PR DESCRIPTION
Capture the state machine source location with SourceLocation so that
we now have the function in the history.

