### PR TITLE
Disable the post_transform retry due to coredump

### DIFF
--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -238,6 +238,14 @@ public:
   VConnection *do_transform_open();
   VConnection *do_post_transform_open();
 
+  // Called by transact(HttpTransact::is_request_retryable), temperarily.
+  // This function should be remove after #1994 fixed.
+  bool
+  is_post_transform_request()
+  {
+    return t_state.method == HTTP_WKSIDX_POST && post_transform_info.vc;
+  }
+
   // Called from InkAPI.cc which acquires the state machine lock
   //  before calling
   int state_api_callback(int event, void *data);

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -6326,6 +6326,11 @@ HttpTransact::is_request_retryable(State *s)
     return false;
   }
 
+  // FIXME: disable the post transform retry currently.
+  if (s->state_machine->is_post_transform_request()) {
+    return false;
+  }
+
   if (s->state_machine->plugin_tunnel_type != HTTP_NO_PLUGIN_TUNNEL) {
     // API can override
     if (s->state_machine->plugin_tunnel_type == HTTP_PLUGIN_AS_SERVER && s->api_info.retry_intercept_failures == true) {


### PR DESCRIPTION
#1994 

Disable post transform retry because of the coredump when tvc has been closed.