### PR TITLE
Assertion with add_header plugin

### DIFF
--- a/example/add_header/add_header.c
+++ b/example/add_header/add_header.c
@@ -154,12 +154,6 @@ TSPluginInit(int argc, const char *argv[])
       goto error;
     }
 
-    retval = TSMimeHdrFieldAppend(hdr_bufp, hdr_loc, field_loc);
-    if (retval != TS_SUCCESS) {
-      TSError("[%s] Unable to add field", PLUGIN_NAME);
-      goto error;
-    }
-
     p = strchr(argv[i], ':');
     if (p) {
       retval = TSMimeHdrFieldNameSet(hdr_bufp, hdr_loc, field_loc, argv[i], p - argv[i]);
@@ -183,6 +177,13 @@ TSPluginInit(int argc, const char *argv[])
         TSError("[%s] Unable to set field name", PLUGIN_NAME);
         goto error;
       }
+    }
+
+    // TSMimeHdrFieldAppend is used only after successfully inserting field names and values
+    retval = TSMimeHdrFieldAppend(hdr_bufp, hdr_loc, field_loc);
+    if (retval != TS_SUCCESS) {
+      TSError("[%s] Unable to add field", PLUGIN_NAME);
+      goto error;
     }
   }
 


### PR DESCRIPTION
TSMimeHdrFieldAppend is used only after successfully inserting field names and values. 

```
(gdb) bt
#0  0x00007ffff2be1c37 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
#1  0x00007ffff2be5028 in __GI_abort () at abort.c:89
#2  0x00007ffff4bd5943 in ink_abort (message_format=0x7ffff4c1b140 "%s:%d: failed assertion `%s`") at ink_error.cc:99
#3  0x00007ffff4bd003d in _ink_assert (expression=0xa39920 "field_handle->field_ptr->m_ptr_name", file=0xa383e0 "InkAPI.cc", 
    line=2810) at ink_assert.cc:37
#4  0x0000000000534514 in TSMimeHdrFieldAppend (bufp=0x600400002d30, mh_mloc=0x7ffff0d7d888, field_mloc=0x607200001fe0)
    at InkAPI.cc:2810
#5  0x00007ffff0d8011f in TSPluginInit (argc=2, argv=0x7fffffffd9c0) at add_header.c:157
#6  0x0000000000584a1e in plugin_load (argc=2, argv=0x7fffffffd9c0, validateOnly=false) at Plugin.cc:139
#7  0x0000000000585796 in plugin_init (validateOnly=false) at Plugin.cc:304
#8  0x0000000000562e67 in main (argv=0x7fffffffe528) at Main.cc:1824
```