### PR TITLE
TS-4265: Restructure thread initialization

### DIFF
--- a/doc/developer-guide/api/types/CoreTypes.en.rst
+++ b/doc/developer-guide/api/types/CoreTypes.en.rst
@@ -36,13 +36,5 @@ These types are provided by the compiler ("built-in") or from a required operati
 
 
 .. cpp:type:: uint24_t
-
-
-
-.. cpp:type:: Event
-
-
 .. cpp:type:: DLL
-
-
 .. cpp:type:: INK_MD5

--- a/doc/developer-guide/index.en.rst
+++ b/doc/developer-guide/index.en.rst
@@ -43,6 +43,7 @@ duplicate bugs is encouraged, but not required.
    contributing/index.en
    testing-with-vagrant/index.en
    debugging/index.en
+   threads-and-events.en
    cache-architecture/index.en
    logging-architecture/index.en
    internal-libraries/index.en
@@ -52,4 +53,3 @@ duplicate bugs is encouraged, but not required.
    continuous-integration/index.en
    documentation/index.en
    host-resolution-proposal.en
-

--- a/doc/developer-guide/threads-and-events.en.rst
+++ b/doc/developer-guide/threads-and-events.en.rst
@@ -1,0 +1,203 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+
+.. include:: ../common.defs
+
+.. default-domain:: cpp
+
+.. highlight:: cpp
+
+.. _threads-and-events:
+
+Threads and Event Processing
+****************************
+
+Internally |TS| is a cooperative multi-threaded environment. There are a fixed number of threads for core operations, determined at process start time. All core operations take place on one of these existing threads. Plugins may spawn additional threads but these are outside the scope of this document.
+
+Threads
+=======
+
+|TS| has a taxonomy of thread types which are layered to create the threading infrastructure. At the
+most basic are threads as the operating system provides. Classes provide additional data and
+operations on these threads to make them operate properly for |TS|.
+
+Thread
+------
+
+The abstract :class:`Thread` is the base class for thread operations. It contains a mutex and a
+thread identifier. The logic for starting the thread at the system level is embedded in this class.
+All threads started by |TS| have an instance of this class (or subclass). Plugins can directly start
+their own threads via system calls and those are not tracked. :class:`Thread` sets up thread local
+storage via :code:`pthread_setspecific`. Threads can be started via an explicit function provided to
+:func:`Thread::start` or by subclassing :class:`Thread` and overriding :func:`Thread::execute`.
+
+:class:`Thread` also performs the basic time keeping for |TS|. The class contains a global static value which is treated as the current time for |TS|. Usually this class is accessed as a static but it can also be accessed in a way to update the current time. Because of the large number of threads the static use is generally sufficiently accurate because it contains the last time any thread updated.
+
+EThread
+-------
+
+:class:`EThread` is a subclass of :class:`Thread` which provides support for |TS| core operations.
+It is this class that provides support for using :class:`Continuation` instances. :class:`EThread`
+overrides the :func:`Thread::execute` method to gain control after the underlying thread is started.
+This method executes a single continuation at thread start. If the thread is :enumerator:
+
+`ThreadType::DEDICATED` it returns after invoking the start continuation. No join is exectuted, the
+presumption is the start continuation will run until process termination. This mechanism is used
+because it is, from the |TS| point of view, the easiest to use because of the common support of
+continuations.
+
+A :enumerator:`ThreadType::REGULAR` thread will first execute its start continuation and then process its event queue until explicitly stopped after executing the start continuation.
+
+Despite the name :class:`EventProcessor` is primarily a thread management class. It enables the
+creation and management of thread groups which are then used by the |TS| core for different types of
+computation. The set of groups is determined at run time via subsystems making calls to the
+:func:`EventProcessor::register_event_type`. Threads managed by :class:`EventProcessor` have the
+:class:`EThread` start continuation controlled by :class:`EventProcessor`. Each thread group (event
+type) has a list of continuations to run when a thread of that type starts. Continuations are added
+to the list with :func:`EventProcessor::schedule_spawn`. There are two variants of this method, one
+for continuations and one for just a function. The latter creates a continuation to call the
+function and then schedules that using the former. The :class:`EventProcessor` internal start
+continuation for the :class:`EThread` executes the continuations on this list for the appropriate
+thread group and then returns, after which :func:`EThread::execute` loops on processing its event
+queue.
+
+:class:`EventProcessor` is intended to be a singleton and the global instance is :var:`eventProcessor`.
+
+In general if a subsystem in the |TS| core is setting up a thread group, it should use code of the
+form
+
+.. code-block:: cpp
+
+   int ET_GROUP; // global variable, where "GROUP" is repalced by the actual group / type name.
+   int n_group_threads = 3; // Want 3 of these threads by default, possibly changed by configuration options.
+   constexpr size_t GROUP_STACK_SIZE = DEFAULT_STACK_SIZE; // stack size for each thread.
+   void Group_Thread_Init(EThread*); // function to perform per thread local initialization.
+
+   ET_GROUP = eventProcessor::registerEventType("Group");
+   eventProcessor.schedule_spawn(&Group_Per_Thread_Init, ET_GROUP);
+   eventProcessor.spawn_event_threads(ET_GROUP, n_group_threads, GROUP_STACK_SIZE);
+
+
+The function :code:`Group_Thread_Init` can be replaced with a continuation if that's more
+convenient. One advantage of a continuation is additional data (via :arg:`cookie`) can be provide
+during thread initialization.
+
+If there is no thread initializatoin needed, this can be compressed in to a single call
+
+.. code-block:: cpp
+
+   ET_GROUP = eventProcessor.spawn_event_threads("Group", n_group_threads, GROUP_STACK_SIZE);
+
+This registers the group name and type, starts the threads, and returns the event type.
+
+Types
+=====
+
+.. type:: EventType
+
+   A thread classification value that represents the type of events the thread is expected to process.
+
+.. var:: EventType ET_CALL
+
+   A predefined :type:`EventType` which always exists. This is deprecated, use :var:`ET_NET` instead.
+
+.. var:: EventType ET_NET
+
+   A synonymn for :var:`ET_CALL`.
+
+.. var:: EventProcessor eventProcessor
+
+   The global single instance of :class:`EventProcessor`.
+
+.. type:: ThreadFunction
+
+   The type of function invoked by :func:`Thread::start`. It is a function returning :code:`void*` and taking no arguments.
+
+.. class:: Thread
+
+   Wrapper for system level thread.
+
+   .. function:: start(const char * name, void * stack, size_t stacksize, ThreadFunction const &f)
+
+      Start the underyling thread. It is given the name :arg:`name`. If :arg:`stack` is
+      :code:`nullptr` then a stack is allocated for it of size :arg:`stacksize`. Once the thread is
+      started, :arg:`f` is invoked in the context of the thread if non :code:`nullptr`, otherwise
+      the method :func:`Thread::execute` is called. The thread execution returns immediately after
+      either of these, leaving a zombie thread. It is presumed both will execute until process
+      termination.
+
+   .. function:: void execute()
+
+      A pure virtual method that must be overridden in a subclass.
+
+.. class:: EThread
+
+   Event processing thread.
+
+   .. function:: EventType registerEventType(const char* name)
+
+      Register an event type by name. This reserves an event type index which is returned as :type:`EventType`.
+
+   .. function:: void execute()
+
+      Call the start continuation, if any. If a regular (not dedicated) thread, continuously process the event queue.
+
+.. enum:: ThreadType
+
+   .. enumerator:: DEDICATED
+
+      A thread which executes only the start contiuation and then exits.
+
+   .. enumerator:: REGULAR
+
+      A thread which executes the start continuation and then processes its event queue.
+
+.. class:: Continuation
+
+   A future computation. A continuation has a handler which is a class method with a
+   specific signature. A continuation is invoked by calling its handler. A future computation can be
+   referenced by an :class:`Action` instance. This is used primarily to allow the future work to be
+   canceled.
+
+.. class:: Action
+
+   Reference to a future computation for a :class:`Continuation`.
+
+.. class:: Event : public Action
+
+   Reference to code to dispatch. Note that an :class:`Event` is a type of :class:`Action`. This class combines the future computational reference of :class:`Action`
+
+.. type:: ThreadSpawnFunction
+
+   A function that takes a single argument of pointer to :class:`EThread` and returns :code:`void`. The argument will be the :class:`EThread` in which the function is executing.
+
+.. class:: EventProcessor
+
+   .. function:: EventType register_event_type(char const * name)
+
+      Register an event type with the name :arg:`name`. The unique type index is returned.
+
+   .. function:: Event * schedule_spawn(Continuation * c, EventType ev_type, int event = EVENT_IMMEDIATE, void * cookie = NULL)
+
+      When the :class:`EventProcessor` starts a thread of type :arg:`ev_type`, :arg:`c` will be
+      called before any events are dispatched by the thread. The handler for :arg:`c` will be called
+      with an event code of :arg:`event` and data pointer of :arg:`cookie`.
+
+   .. function:: Event * schedule_spawn(void ( * f) (EThread * ), EventType ev_type)
+
+      When the :class:`EventProcessor` starts a thread of type :arg:`ev_type` the function :arg:`f`
+      will be called with a pointer to the :class:`EThread` instance which is starting.

--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -202,13 +202,14 @@ DNSProcessor::start(int, size_t stacksize)
 
   if (dns_thread > 0) {
     // TODO: Hmmm, should we just get a single thread some other way?
-    ET_DNS = eventProcessor.spawn_event_threads(1, "ET_DNS", stacksize);
-    initialize_thread_for_net(eventProcessor.eventthread[ET_DNS][0]);
+    ET_DNS = eventProcessor.register_event_type("ET_DNS");
+    eventProcessor.schedule_spawn(&initialize_thread_for_net, ET_DNS);
+    eventProcessor.spawn_event_threads(ET_DNS, 1, stacksize);
   } else {
     // Initialize the first event thread for DNS.
     ET_DNS = ET_CALL;
   }
-  thread = eventProcessor.eventthread[ET_DNS][0];
+  thread = eventProcessor.thread_group[ET_DNS]._thread[0];
 
   dns_failover_try_period = dns_timeout + 1; // Modify the "default" accordingly
 

--- a/iocore/dns/SplitDNS.cc
+++ b/iocore/dns/SplitDNS.cc
@@ -502,7 +502,7 @@ SplitDNSRecord::Init(matcher_line *line_info)
   m_servers.x_dnsH = dnsH;
 
   SET_CONTINUATION_HANDLER(dnsH, &DNSHandler::startEvent_sdns);
-  (eventProcessor.eventthread[ET_DNS][0])->schedule_imm(dnsH);
+  eventProcessor.thread_group[ET_DNS]._thread[0]->schedule_imm(dnsH);
 
   /* -----------------------------------------------------
      Process any modifiers to the directive, if they exist

--- a/iocore/eventsystem/P_UnixEventProcessor.h
+++ b/iocore/eventsystem/P_UnixEventProcessor.h
@@ -29,16 +29,6 @@
 
 const int LOAD_BALANCE_INTERVAL = 1;
 
-TS_INLINE
-EventProcessor::EventProcessor()
-{
-  ink_zero(all_ethreads);
-  ink_zero(all_dthreads);
-  ink_zero(n_threads_for_type);
-  ink_zero(next_thread_for_type);
-  ink_mutex_init(&dedicated_spawn_thread_mutex);
-}
-
 TS_INLINE off_t
 EventProcessor::allocate(int size)
 {
@@ -60,13 +50,14 @@ TS_INLINE EThread *
 EventProcessor::assign_thread(EventType etype)
 {
   int next;
+  ThreadGroupDescriptor *tg = &thread_group[etype];
 
   ink_assert(etype < MAX_EVENT_TYPES);
-  if (n_threads_for_type[etype] > 1)
-    next = next_thread_for_type[etype]++ % n_threads_for_type[etype];
+  if (tg->_count > 1)
+    next = tg->_next_round_robin++ % tg->_count;
   else
     next = 0;
-  return (eventthread[etype][next]);
+  return tg->_thread[next];
 }
 
 TS_INLINE Event *

--- a/iocore/eventsystem/Tasks.cc
+++ b/iocore/eventsystem/Tasks.cc
@@ -32,6 +32,6 @@ TasksProcessor tasksProcessor;
 int
 TasksProcessor::start(int task_threads, size_t stacksize)
 {
-  ET_TASK = eventProcessor.spawn_event_threads(task_threads > 0 ? task_threads : 1, "ET_TASK", stacksize);
+  ET_TASK = eventProcessor.spawn_event_threads("ET_TASK", std::max(1, task_threads), stacksize);
   return 0;
 }

--- a/iocore/eventsystem/UnixEventProcessor.cc
+++ b/iocore/eventsystem/UnixEventProcessor.cc
@@ -32,226 +32,252 @@
 #include "ts/ink_defs.h"
 #include "ts/hugepages.h"
 
-EventType
-EventProcessor::spawn_event_threads(int n_threads, const char *et_name, size_t stacksize)
-{
-  char thr_name[MAX_THREAD_NAME_LENGTH];
-  EventType new_thread_group_id;
-  int i;
-
-  ink_release_assert(n_threads > 0);
-  ink_release_assert((n_ethreads + n_threads) <= MAX_EVENT_THREADS);
-  ink_release_assert(n_thread_groups < MAX_EVENT_TYPES);
-
-  new_thread_group_id = (EventType)n_thread_groups;
-
-  for (i = 0; i < n_threads; i++) {
-    EThread *t                          = new EThread(REGULAR, n_ethreads + i);
-    all_ethreads[n_ethreads + i]        = t;
-    eventthread[new_thread_group_id][i] = t;
-    t->set_event_type(new_thread_group_id);
-  }
-
-  n_threads_for_type[new_thread_group_id] = n_threads;
-  for (i = 0; i < n_threads; i++) {
-    snprintf(thr_name, MAX_THREAD_NAME_LENGTH, "[%s %d]", et_name, i);
-    eventthread[new_thread_group_id][i]->start(thr_name, nullptr, stacksize);
-  }
-
-  n_thread_groups++;
-  n_ethreads += n_threads;
-  Debug("iocore_thread", "Created thread group '%s' id %d with %d threads", et_name, new_thread_group_id, n_threads);
-
-  return new_thread_group_id;
-}
-
-static void *
-alloc_stack(size_t stacksize)
-{
-  void *stack = nullptr;
-
-  if (ats_hugepage_enabled()) {
-    stack = ats_alloc_hugepage(stacksize);
-  }
-
-  if (stack == nullptr) {
-    stack = ats_memalign(ats_pagesize(), stacksize);
-  }
-
-  return stack;
-}
-
-#if TS_USE_HWLOC
-static void *
-alloc_numa_stack(hwloc_cpuset_t cpuset, size_t stacksize)
-{
-  hwloc_membind_policy_t mem_policy = HWLOC_MEMBIND_DEFAULT;
-  hwloc_nodeset_t nodeset           = hwloc_bitmap_alloc();
-  int num_nodes                     = 0;
-  void *stack                       = nullptr;
-
-  // Find the NUMA node set that correlates to our next thread CPU set
-  hwloc_cpuset_to_nodeset(ink_get_topology(), cpuset, nodeset);
-  // How many NUMA nodes will we be needing to allocate across?
-  num_nodes = hwloc_get_nbobjs_inside_cpuset_by_type(ink_get_topology(), cpuset, HWLOC_OBJ_NODE);
-
-  if (num_nodes == 1) {
-    // The preferred memory policy. The thread lives in one NUMA node.
-    mem_policy = HWLOC_MEMBIND_BIND;
-  } else if (num_nodes > 1) {
-    // If we have mode than one NUMA node we should interleave over them.
-    mem_policy = HWLOC_MEMBIND_INTERLEAVE;
-  }
-
-  if (mem_policy != HWLOC_MEMBIND_DEFAULT) {
-    // Let's temporarily set the memory binding to our destination NUMA node
-    hwloc_set_membind_nodeset(ink_get_topology(), nodeset, mem_policy, HWLOC_MEMBIND_THREAD);
-  }
-
-  // Alloc our stack
-  stack = alloc_stack(stacksize);
-
-  if (mem_policy != HWLOC_MEMBIND_DEFAULT) {
-    // Now let's set it back to default for this thread.
-    hwloc_set_membind_nodeset(ink_get_topology(), hwloc_topology_get_topology_nodeset(ink_get_topology()), HWLOC_MEMBIND_DEFAULT,
-                              HWLOC_MEMBIND_THREAD);
-  }
-
-  hwloc_bitmap_free(nodeset);
-
-  return stack;
-}
-#endif // TS_USE_HWLOC
-
+/// Global singleton.
 class EventProcessor eventProcessor;
 
-int
-EventProcessor::start(int n_event_threads, size_t stacksize)
+class ThreadAffinityInitializer : public Continuation
 {
-  char thr_name[MAX_THREAD_NAME_LENGTH];
-  int i;
-  void *stack = nullptr;
+  typedef ThreadAffinityInitializer self;
 
-  // do some sanity checking.
-  static int started = 0;
-  ink_release_assert(!started);
-  ink_release_assert(n_event_threads > 0 && n_event_threads <= MAX_EVENT_THREADS);
-  started = 1;
+public:
+  /// Default construct.
+  ThreadAffinityInitializer() { SET_HANDLER(&self::set_affinity); }
+  /// Load up basic affinity data.
+  void init();
+  /// Set the affinity for the current thread.
+  int set_affinity(int, Event *);
 
-  n_ethreads      = n_event_threads;
-  n_thread_groups = 1;
+#if TS_USE_HWLOC
+private:
+  hwloc_obj_t _type;
+  hwloc_obj_type_t obj_type;
+  int obj_count;
+  char const *obj_name;
+#endif
+};
 
-  // Make sure that our thread stack size is at least the minimum size
-  stacksize = MAX(stacksize, INK_THREAD_STACK_MIN);
+ThreadAffinityInitializer Thread_Affinity_Initializer;
 
-  // Make sure it is a multiple of our page size
-  if (ats_hugepage_enabled()) {
-    stacksize = INK_ALIGN(stacksize, ats_hugepage_size());
-  } else {
-    stacksize = INK_ALIGN(stacksize, ats_pagesize());
+namespace
+{
+class ThreadInitByFunc : public Continuation
+{
+public:
+  ThreadInitByFunc() { SET_HANDLER(&ThreadInitByFunc::invoke); }
+  int
+  invoke(int, Event *ev)
+  {
+    void (*f)(EThread *) = reinterpret_cast<void (*)(EThread *)>(ev->cookie);
+    f(ev->ethread);
+    return 0;
   }
+} Thread_Init_Func;
+}
 
-  Debug("iocore_thread", "Thread stack size set to %zu", stacksize);
-
-  for (i = 0; i < n_event_threads; i++) {
-    EThread *t      = new EThread(REGULAR, i);
-    all_ethreads[i] = t;
-
-    eventthread[ET_CALL][i] = t;
-    t->set_event_type((EventType)ET_CALL);
-  }
-  n_threads_for_type[ET_CALL] = n_event_threads;
-
+void
+ThreadAffinityInitializer::init()
+{
 #if TS_USE_HWLOC
   int affinity = 1;
   REC_ReadConfigInteger(affinity, "proxy.config.exec_thread.affinity");
-  hwloc_obj_t obj;
-  hwloc_obj_type_t obj_type;
-  int obj_count = 0;
-  char *obj_name;
 
   switch (affinity) {
   case 4: // assign threads to logical processing units
 // Older versions of libhwloc (eg. Ubuntu 10.04) don't have HWLOC_OBJ_PU.
 #if HAVE_HWLOC_OBJ_PU
     obj_type = HWLOC_OBJ_PU;
-    obj_name = (char *)"Logical Processor";
+    obj_name = "Logical Processor";
     break;
 #endif
   case 3: // assign threads to real cores
     obj_type = HWLOC_OBJ_CORE;
-    obj_name = (char *)"Core";
+    obj_name = "Core";
     break;
   case 1: // assign threads to NUMA nodes (often 1:1 with sockets)
     obj_type = HWLOC_OBJ_NODE;
-    obj_name = (char *)"NUMA Node";
+    obj_name = "NUMA Node";
     if (hwloc_get_nbobjs_by_type(ink_get_topology(), obj_type) > 0) {
       break;
     }
   case 2: // assign threads to sockets
     obj_type = HWLOC_OBJ_SOCKET;
-    obj_name = (char *)"Socket";
+    obj_name = "Socket";
     break;
   default: // assign threads to the machine as a whole (a level below SYSTEM)
     obj_type = HWLOC_OBJ_MACHINE;
-    obj_name = (char *)"Machine";
+    obj_name = "Machine";
   }
 
-  // How many of the above `obj_type` do we have in our topology?
   obj_count = hwloc_get_nbobjs_by_type(ink_get_topology(), obj_type);
   Debug("iocore_thread", "Affinity: %d %ss: %d PU: %d", affinity, obj_name, obj_count, ink_number_of_processors());
-
 #endif
-  for (i = 0; i < n_ethreads; i++) {
-    ink_thread tid;
+}
 
+int
+ThreadAffinityInitializer::set_affinity(int, Event *)
+{
 #if TS_USE_HWLOC
-    if (obj_count > 0) {
-      // Get our `obj` instance with index based on the thread number we are on.
-      obj = hwloc_get_obj_by_type(ink_get_topology(), obj_type, i % obj_count);
+  hwloc_obj_t obj;
+  EThread *t = this_ethread();
+
+  if (obj_count > 0) {
+    obj = hwloc_get_obj_by_type(ink_get_topology(), obj_type, t->id % obj_count);
 #if HWLOC_API_VERSION >= 0x00010100
-      // Pretty print our CPU set
-      int cpu_mask_len = hwloc_bitmap_snprintf(nullptr, 0, obj->cpuset) + 1;
-      char *cpu_mask   = (char *)alloca(cpu_mask_len);
-      hwloc_bitmap_snprintf(cpu_mask, cpu_mask_len, obj->cpuset);
-      Debug("iocore_thread", "EThread: %d %s: %d CPU Mask: %s", i, obj_name, obj->logical_index, cpu_mask);
+    int cpu_mask_len = hwloc_bitmap_snprintf(NULL, 0, obj->cpuset) + 1;
+    char *cpu_mask   = (char *)alloca(cpu_mask_len);
+    hwloc_bitmap_snprintf(cpu_mask, cpu_mask_len, obj->cpuset);
+    Debug("iocore_thread", "EThread: %p %s: %d CPU Mask: %s\n", t, obj_name, obj->logical_index, cpu_mask);
 #else
-      Debug("iocore_thread", "EThread: %d %s: %d", i, obj_name, obj->logical_index);
+    Debug("iocore_thread", "EThread: %d %s: %d", _name, obj->logical_index);
 #endif // HWLOC_API_VERSION
-    }
-#endif // TS_USE_HWLOC
-
-    // Name our thread
-    snprintf(thr_name, MAX_THREAD_NAME_LENGTH, "[ET_NET %d]", i);
-#if TS_USE_HWLOC
-    // Lets create a NUMA local stack if we can
-    if (obj_count > 0) {
-      stack = alloc_numa_stack(obj->cpuset, stacksize);
-    } else {
-      // Lets just alloc a stack even with no NUMA knowledge
-      stack = alloc_stack(stacksize);
-    }
-#else
-    // Lets just alloc a stack even with no NUMA knowledge
-    stack = alloc_stack(stacksize);
-#endif // TS_USE_HWLOC
-
-    // Start our new thread with our new stack.
-    tid   = all_ethreads[i]->start(thr_name, stack, stacksize);
-    stack = nullptr;
-
-#if TS_USE_HWLOC
-    if (obj_count > 0) {
-      // Lets bind our new thread to it's CPU set
-      hwloc_set_thread_cpubind(ink_get_topology(), tid, obj->cpuset, HWLOC_CPUBIND_STRICT);
-    } else {
-      Warning("hwloc returned an unexpected value -- CPU affinity disabled");
-    }
-#else
-    // Lets ignore tid if we don't link with HWLOC
-    (void)tid;
-#endif // TS_USE_HWLOC
+    hwloc_set_thread_cpubind(ink_get_topology(), t->tid, obj->cpuset, HWLOC_CPUBIND_STRICT);
+  } else {
+    Warning("hwloc returned an unexpected number of objects -- CPU affinity disabled");
   }
+#endif // TS_USE_HWLOC
+  return 0;
+}
+
+EventProcessor::EventProcessor() : thread_initializer(this)
+{
+  ink_zero(all_ethreads);
+  ink_zero(all_dthreads);
+  ink_zero(thread_group);
+  ink_mutex_init(&dedicated_thread_spawn_mutex);
+  // Because ET_NET is compile time set to 0 it *must* be the first type registered.
+  this->register_event_type("ET_NET");
+}
+
+EventProcessor::~EventProcessor()
+{
+  ink_mutex_destroy(&dedicated_thread_spawn_mutex);
+}
+
+namespace
+{
+Event *
+make_event_for_scheduling(Continuation *c, int event_code, void *cookie)
+{
+  Event *e = eventAllocator.alloc();
+
+  e->init(c);
+  e->mutex          = c->mutex;
+  e->callback_event = event_code;
+  e->cookie         = cookie;
+
+  return e;
+}
+}
+
+Event *
+EventProcessor::schedule_spawn(Continuation *c, EventType ev_type, int event_code, void *cookie)
+{
+  Event *e = make_event_for_scheduling(c, event_code, cookie);
+  ink_assert(ev_type < MAX_EVENT_TYPES);
+  thread_group[ev_type]._spawnQueue.enqueue(e);
+  return e;
+}
+
+Event *
+EventProcessor::schedule_spawn(void (*f)(EThread *), EventType ev_type)
+{
+  Event *e = make_event_for_scheduling(&Thread_Init_Func, EVENT_IMMEDIATE, reinterpret_cast<void *>(f));
+  ink_assert(ev_type < MAX_EVENT_TYPES);
+  thread_group[ev_type]._spawnQueue.enqueue(e);
+  return e;
+}
+
+EventType
+EventProcessor::register_event_type(char const *name)
+{
+  ThreadGroupDescriptor *tg = &(thread_group[n_thread_groups++]);
+  ink_release_assert(n_thread_groups <= MAX_EVENT_TYPES); // check for overflow
+
+  tg->_name = ats_strdup(name);
+  return n_thread_groups - 1;
+}
+
+EventType
+EventProcessor::spawn_event_threads(char const *name, int n_threads, size_t stacksize)
+{
+  int ev_type = this->register_event_type(name);
+  this->spawn_event_threads(ev_type, n_threads, stacksize);
+  return ev_type;
+}
+
+EventType
+EventProcessor::spawn_event_threads(EventType ev_type, int n_threads, size_t stacksize)
+{
+  char thr_name[MAX_THREAD_NAME_LENGTH];
+  int i;
+  ThreadGroupDescriptor *tg = &(thread_group[ev_type]);
+
+  ink_release_assert(n_threads > 0);
+  ink_release_assert((n_ethreads + n_threads) <= MAX_EVENT_THREADS);
+  ink_release_assert(ev_type < MAX_EVENT_TYPES);
+
+  for (i = 0; i < n_threads; ++i) {
+    EThread *t                   = new EThread(REGULAR, n_ethreads + i);
+    all_ethreads[n_ethreads + i] = t;
+    tg->_thread[i]               = t;
+    t->set_event_type(ev_type);
+    t->schedule_spawn(&thread_initializer);
+  }
+  tg->_count = n_threads;
+
+  for (i = 0; i < n_threads; i++) {
+    snprintf(thr_name, MAX_THREAD_NAME_LENGTH, "[%s %d]", tg->_name.get(), i);
+    tg->_thread[i]->start(thr_name, nullptr, stacksize);
+  }
+
+  n_ethreads += n_threads;
+  Debug("iocore_thread", "Created thread group '%s' id %d with %d threads", tg->_name.get(), ev_type, n_threads);
+
+  return ev_type; // useless but not sure what would be better.
+}
+
+// This is called from inside a thread as the @a start_event for that thread.  It chains to the
+// startup events for the appropriate thread group start events.
+void
+EventProcessor::initThreadState(EThread *t)
+{
+  // Run all thread type initialization continuations that match the event types for this thread.
+  for (int i = 0; i < MAX_EVENT_TYPES; ++i) {
+    if (t->is_event_type(i)) { // that event type done here, roll thread start events of that type.
+      // To avoid race conditions on the event in the spawn queue, create a local one to actually send.
+      // Use the spawn queue event as a read only model.
+      Event *nev = eventAllocator.alloc();
+      for (Event *ev = thread_group[i]._spawnQueue.head; NULL != ev; ev = ev->link.next) {
+        nev->init(ev->continuation, 0, 0);
+        nev->ethread        = t;
+        nev->callback_event = ev->callback_event;
+        nev->mutex          = ev->continuation->mutex;
+        nev->cookie         = ev->cookie;
+        ev->continuation->handleEvent(ev->callback_event, nev);
+      }
+      nev->free();
+    }
+  }
+}
+
+int
+EventProcessor::start(int n_event_threads, size_t stacksize)
+{
+  // do some sanity checking.
+  static bool started = false;
+  ink_release_assert(!started);
+  ink_release_assert(n_event_threads > 0 && n_event_threads <= MAX_EVENT_THREADS);
+  started = true;
+
+  Thread_Affinity_Initializer.init();
+  // Least ugly thing - this needs to be the first callback from the thread but by the time this
+  // method is called other spawn callbacks have been registered. This forces thread affinity
+  // first. The other alternative would be to require a call to an @c init method which I like even
+  // less because this cannot be done in the constructor - that depends on too much other
+  // infrastructure being in place (e.g. the proxy allocators).
+  thread_group[ET_CALL]._spawnQueue.push(make_event_for_scheduling(&Thread_Affinity_Initializer, EVENT_IMMEDIATE, nullptr));
+
+  this->spawn_event_threads(ET_CALL, n_event_threads, stacksize);
 
   Debug("iocore_thread", "Created event thread group id %d with %d threads", ET_CALL, n_event_threads);
   return 0;
@@ -282,13 +308,12 @@ EventProcessor::spawn_thread(Continuation *cont, const char *thr_name, size_t st
   // Do as much as possible outside the lock. Until the array element and count is changed
   // this is thread safe.
   Event *e = eventAllocator.alloc();
-
   e->init(cont, 0, 0);
   e->ethread  = new EThread(DEDICATED, e);
   e->mutex    = e->ethread->mutex;
   cont->mutex = e->ethread->mutex;
   {
-    ink_scoped_mutex_lock lock(dedicated_spawn_thread_mutex);
+    ink_scoped_mutex_lock lock(dedicated_thread_spawn_mutex);
     ink_release_assert(n_dthreads < MAX_EVENT_THREADS);
     all_dthreads[n_dthreads] = e->ethread;
     ++n_dthreads; // Be very sure this is after the array element update.

--- a/iocore/net/I_NetProcessor.h
+++ b/iocore/net/I_NetProcessor.h
@@ -198,14 +198,10 @@ public:
   Action *connect_s(Continuation *cont, sockaddr const *addr, int timeout = NET_CONNECT_TIMEOUT, NetVCOptions *opts = nullptr);
 
   /**
-    Starts the Netprocessor. This has to be called before doing any
-    other net call.
-
-    @param number_of_net_threads is not used. The net processor
-      uses the Event Processor threads for its activity.
+    Initializes the net processor. This must be called before the event threads are started.
 
   */
-  virtual int start(int number_of_net_threads, size_t stacksize) = 0;
+  virtual void init() = 0;
 
   inkcoreapi virtual NetVConnection *allocate_vc(EThread *) = 0;
 

--- a/iocore/net/P_UnixNetProcessor.h
+++ b/iocore/net/P_UnixNetProcessor.h
@@ -41,9 +41,9 @@ public:
   Action *connect(Continuation *cont, UnixNetVConnection **vc, sockaddr const *target, NetVCOptions *opt = nullptr);
 
   virtual NetAccept *createNetAccept(const NetProcessor::AcceptOptions &opt);
-  virtual NetVConnection *allocate_vc(EThread *t);
+  NetVConnection *allocate_vc(EThread *t) override;
 
-  virtual int start(int number_of_net_threads, size_t stacksize);
+  void init() override;
 
   Event *accept_thread_event;
 

--- a/iocore/net/SSLNetProcessor.cc
+++ b/iocore/net/SSLNetProcessor.cc
@@ -72,7 +72,7 @@ SSLNetProcessor::start(int, size_t stacksize)
 
 #ifdef HAVE_OPENSSL_OCSP_STAPLING
   if (SSLConfigParams::ssl_ocsp_enabled) {
-    EventType ET_OCSP = eventProcessor.spawn_event_threads(1, "ET_OCSP", stacksize);
+    EventType ET_OCSP = eventProcessor.spawn_event_threads("ET_OCSP", 1, stacksize);
     eventProcessor.schedule_every(new OCSPContinuation(), HRTIME_SECONDS(SSLConfigParams::ssl_ocsp_update_period), ET_OCSP);
   }
 #endif /* HAVE_OPENSSL_OCSP_STAPLING */

--- a/iocore/net/UnixNet.cc
+++ b/iocore/net/UnixNet.cc
@@ -591,7 +591,7 @@ void
 NetHandler::configure_per_thread()
 {
   // figure out the number of threads and calculate the number of connections per thread
-  int threads                          = eventProcessor.n_threads_for_type[ET_NET];
+  int threads                          = eventProcessor.thread_group[ET_NET]._count;
   max_connections_per_thread_in        = max_connections_in / threads;
   max_connections_active_per_thread_in = max_connections_active_in / threads;
   Debug("net_queue", "max_connections_per_thread_in updated to %d threads: %d", max_connections_per_thread_in, threads);

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -174,7 +174,7 @@ NetAccept::init_accept_per_thread()
   }
 
   period = -HRTIME_MSECONDS(net_accept_period);
-  n      = eventProcessor.n_threads_for_type[opt.etype];
+  n      = eventProcessor.thread_group[opt.etype]._count;
 
   for (i = 0; i < n; i++) {
     NetAccept *a;
@@ -185,7 +185,7 @@ NetAccept::init_accept_per_thread()
       a = this;
     }
 
-    EThread *t         = eventProcessor.eventthread[opt.etype][i];
+    EThread *t         = eventProcessor.thread_group[opt.etype]._thread[i];
     PollDescriptor *pd = get_PollDescriptor(t);
 
     if (a->ep.start(pd, a, EVENTIO_READ) < 0) {

--- a/iocore/net/UnixNetPages.cc
+++ b/iocore/net/UnixNetPages.cc
@@ -104,8 +104,8 @@ struct ShowNet : public ShowCont {
                       vc->f.shutdown, vc->closed ? "closed " : ""));
     }
     ithread++;
-    if (ithread < eventProcessor.n_threads_for_type[ET_NET]) {
-      eventProcessor.eventthread[ET_NET][ithread]->schedule_imm(this);
+    if (ithread < eventProcessor.thread_group[ET_NET]._count) {
+      eventProcessor.thread_group[ET_NET]._thread[ithread]->schedule_imm(this);
     } else {
       CHECK_SHOW(show("</table>\n"));
       return complete(event, e);
@@ -139,7 +139,7 @@ struct ShowNet : public ShowCont {
                     "<th>Comments</th>"
                     "</tr>\n"));
     SET_HANDLER(&ShowNet::showConnectionsOnThread);
-    eventProcessor.eventthread[ET_NET][0]->schedule_imm(this); // This can not use ET_TASK.
+    eventProcessor.thread_group[ET_NET]._thread[0]->schedule_imm(this); // This can not use ET_TASK.
     return EVENT_CONT;
   }
 
@@ -167,8 +167,8 @@ struct ShowNet : public ShowCont {
     CHECK_SHOW(show("<tr><th>#</th><th>Read Priority</th><th>Read Bucket</th><th>Write Priority</th><th>Write Bucket</th></tr>\n"));
     CHECK_SHOW(show("</table>\n"));
     ithread++;
-    if (ithread < eventProcessor.n_threads_for_type[ET_NET]) {
-      eventProcessor.eventthread[ET_NET][ithread]->schedule_imm(this);
+    if (ithread < eventProcessor.thread_group[ET_NET]._count) {
+      eventProcessor.thread_group[ET_NET]._thread[ithread]->schedule_imm(this);
     } else {
       return complete(event, e);
     }
@@ -180,7 +180,7 @@ struct ShowNet : public ShowCont {
   {
     CHECK_SHOW(begin("Net Threads"));
     SET_HANDLER(&ShowNet::showSingleThread);
-    eventProcessor.eventthread[ET_NET][0]->schedule_imm(this); // This can not use ET_TASK
+    eventProcessor.thread_group[ET_NET]._thread[0]->schedule_imm(this); // This can not use ET_TASK
     return EVENT_CONT;
   }
   int

--- a/iocore/net/UnixUDPNet.cc
+++ b/iocore/net/UnixUDPNet.cc
@@ -92,17 +92,12 @@ UDPNetProcessorInternal::start(int n_upd_threads, size_t stacksize)
     return -1;
   }
 
-  ET_UDP = eventProcessor.spawn_event_threads(n_upd_threads, "ET_UDP", stacksize);
-  if (ET_UDP < 0) { // Probably can't happen, maybe at some point EventType should be unsigned ?
-    return -1;
-  }
+  ET_UDP = eventProcessor.register_event_type("ET_UDP");
+  eventProcessor.schedule_spawn(&initialize_thread_for_udp_net, ET_UDP);
+  eventProcessor.spawn_event_threads(ET_UDP, n_upd_threads, stacksize);
 
   pollCont_offset      = eventProcessor.allocate(sizeof(PollCont));
   udpNetHandler_offset = eventProcessor.allocate(sizeof(UDPNetHandler));
-
-  for (int i = 0; i < eventProcessor.n_threads_for_type[ET_UDP]; i++) {
-    initialize_thread_for_udp_net(eventProcessor.eventthread[ET_UDP][i]);
-  }
 
   return 0;
 }

--- a/proxy/http/HttpProxyServerMain.cc
+++ b/proxy/http/HttpProxyServerMain.cc
@@ -222,15 +222,21 @@ MakeHttpProxyAcceptor(HttpProxyAcceptor &acceptor, HttpProxyPort &port, unsigned
   }
 }
 
+/// Do all pre-thread initialization / setup.
+void
+init_HttpProxyServer()
+{
+  httpSessionManager.init();
+}
+
 /** Set up all the accepts and sockets.
  */
 void
-init_HttpProxyServer(int n_accept_threads)
+init_accept_HttpProxyServer(int n_accept_threads)
 {
   HttpProxyPort::Group &proxy_ports = HttpProxyPort::global();
 
   init_reverse_proxy();
-  httpSessionManager.init();
   http_pages_init();
 
 #ifdef USE_HTTP_DEBUG_LISTS

--- a/proxy/http/HttpProxyServerMain.h
+++ b/proxy/http/HttpProxyServerMain.h
@@ -23,9 +23,12 @@
 
 struct HttpProxyPort;
 
-/** Initialize all HTTP proxy port data structures needed to run.
+/// Perform any pre-thread start initialization.
+void init_HttpProxyServer();
+
+/** Initialize all HTTP proxy port data structures needed to accept connections.
  */
-void init_HttpProxyServer(int n_accept_threads = 0);
+void init_accept_HttpProxyServer(int n_accept_threads = 0);
 
 /** Start the proxy server.
     The port data should have been created by @c init_HttpProxyServer().

--- a/proxy/http/HttpSessionManager.cc
+++ b/proxy/http/HttpSessionManager.cc
@@ -38,7 +38,7 @@
 
 // Initialize a thread to handle HTTP session management
 void
-initialize_thread_for_http_sessions(EThread *thread, int /* thread_index ATS_UNUSED */)
+initialize_thread_for_http_sessions(EThread *thread)
 {
   thread->server_session_pool = new ServerSessionPool;
 }
@@ -246,6 +246,7 @@ void
 HttpSessionManager::init()
 {
   m_g_pool = new ServerSessionPool;
+  eventProcessor.schedule_spawn(&initialize_thread_for_http_sessions, ET_NET);
 }
 
 // TODO: Should this really purge all keep-alive sessions?

--- a/proxy/http/remap/RemapProcessor.cc
+++ b/proxy/http/remap/RemapProcessor.cc
@@ -30,7 +30,7 @@ int
 RemapProcessor::start(int num_threads, size_t stacksize)
 {
   if (_use_separate_remap_thread) {
-    ET_REMAP = eventProcessor.spawn_event_threads(num_threads, "ET_REMAP", stacksize); // ET_REMAP is a class member
+    ET_REMAP = eventProcessor.spawn_event_threads("ET_REMAP", num_threads, stacksize); // ET_REMAP is a class member
   }
 
   return 0;

--- a/proxy/shared/UglyLogStubs.cc
+++ b/proxy/shared/UglyLogStubs.cc
@@ -122,6 +122,12 @@ UnixNetProcessor::createNetAccept(const NetProcessor::AcceptOptions &opt)
   return nullptr;
 }
 
+void
+UnixNetProcessor::init()
+{
+  ink_release_assert(false);
+}
+
 // TODO: The following was necessary only for Solaris, should examine more.
 NetVCOptions const Connection::DEFAULT_OPTIONS;
 NetProcessor::AcceptOptions const NetProcessor::DEFAULT_ACCEPT_OPTIONS;
@@ -155,13 +161,6 @@ CacheVC::handleWrite(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
 
 UnixNetProcessor unix_netProcessor;
 NetProcessor &netProcessor = unix_netProcessor;
-
-int
-UnixNetProcessor::start(int, size_t)
-{
-  ink_release_assert(false);
-  return 0;
-}
 
 Action *
 NetProcessor::accept(Continuation * /* cont ATS_UNUSED */, AcceptOptions const & /* opt ATS_UNUSED */)


### PR DESCRIPTION
This is primarily a precursor to other changes which are too large for a single PR. It does have some (IMHO) significant benefits of itself.

* Thread initialization is no longer subject to race conditions or "getting lucky" on the timing, where the current code starts the threads *and then initializes them*. Seriously. This changes that to allow thread startup continuations to be registered and executed *in the target thread* while the thread is starting up.
* This also enables decoupling and a reduction of circular dependencies. The thread start up logic no longer needs to be aware of how a client module needs to have a thread initialized. The client module registers a start up continuation which the event system simply executes at thread start just like any other continuation.
* The event system logic is now at least partially documented both in code comments and the official documentation.
* Information about threads and thread groups is in a structure instead of being parallel arrays.
* A fix for thread start up race conditions is present which IMHO is better than #1989.

P.S. @PSUdaemon pre-reviewed this. I integrated all of his requested changes except one because that change causes a compilation failure.