### PR TITLE
Add range check of Http2SettingsIdentifier

### DIFF
--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -69,7 +69,7 @@ public:
   unsigned
   get(Http2SettingsIdentifier id) const
   {
-    if (id < HTTP2_SETTINGS_MAX) {
+    if (0 < id && id < HTTP2_SETTINGS_MAX) {
       return this->settings[indexof(id)];
     } else {
       ink_assert(!"Bad Settings Identifier");
@@ -95,7 +95,7 @@ private:
   static unsigned
   indexof(Http2SettingsIdentifier id)
   {
-    ink_assert(id < HTTP2_SETTINGS_MAX);
+    ink_assert(0 < id && id < HTTP2_SETTINGS_MAX);
 
     return id - 1;
   }


### PR DESCRIPTION
Add same check of #2002 in `get()` and `indexof()`