### PR TITLE
Make the default thread stack size global and configurable.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1857,6 +1857,17 @@ AS_IF([test "x$enable_experimental_plugins" = "xyes"],
 AM_CONDITIONAL([BUILD_REMAP_STATS_PLUGIN],
   [ test "x$enable_experimental_plugins" = "xyes" -a "x$ac_cv_header_search_h" = "xyes" -a "x$ac_cv_type_struct_hsearch_data" = "xyes" -a "x$ac_cv_func_hcreate_r" = "xyes" -a "x$ac_cv_func_hsearch_r" = "xyes" ])
 
+AC_ARG_WITH([default-stack-size],
+  [AS_HELP_STRING([--with-default-stack-size],[specify the default stack size in bytes [default=1048576]])],
+  [
+  with_default_stack_size="$withval"
+  ],[
+  with_default_stack_size="1048576"
+  ]
+)
+
+AC_SUBST([default_stack_size], [$with_default_stack_size])
+
 #
 # use modular IOCORE
 #

--- a/iocore/eventsystem/I_Thread.h
+++ b/iocore/eventsystem/I_Thread.h
@@ -72,7 +72,6 @@ class ProxyMutex;
 typedef void *(*ThreadFunction)(void *arg);
 
 static const int MAX_THREAD_NAME_LENGTH = 16;
-static const int DEFAULT_STACKSIZE      = 1048576; // 1MB
 
 /**
   Base class for the threads in the Event System. Thread is the base

--- a/lib/ts/ink_config.h.in
+++ b/lib/ts/ink_config.h.in
@@ -124,4 +124,6 @@
 #define TS_BUILD_DEFAULT_LOOPBACK_IFACE "@default_loopback_iface@"
 /* clang-format on */
 
+static const int DEFAULT_STACKSIZE = @default_stack_size@;
+
 #endif /* _ink_config_h */


### PR DESCRIPTION
Sub-PR for #1997.

Make the default thread stack size more global (not just in `I_Thread.h`) and make it build time configurable via autotools.