### PR TITLE
Change locking for spawning dedicated threads to avoid race conditions.

### DIFF
--- a/iocore/eventsystem/I_EventProcessor.h
+++ b/iocore/eventsystem/I_EventProcessor.h
@@ -309,6 +309,7 @@ public:
   EThread *all_dthreads[MAX_EVENT_THREADS];
   volatile int n_dthreads; // No. of dedicated threads
   volatile int thread_data_used;
+  ink_mutex dedicated_spawn_thread_mutex;
 };
 
 extern inkcoreapi class EventProcessor eventProcessor;

--- a/iocore/eventsystem/P_UnixEventProcessor.h
+++ b/iocore/eventsystem/P_UnixEventProcessor.h
@@ -36,6 +36,7 @@ EventProcessor::EventProcessor() : n_ethreads(0), n_thread_groups(0), n_dthreads
   memset(all_dthreads, 0, sizeof(all_dthreads));
   memset(n_threads_for_type, 0, sizeof(n_threads_for_type));
   memset(next_thread_for_type, 0, sizeof(next_thread_for_type));
+  ink_mutex_init(&dedicated_spawn_thread_mutex, "EventProcessorDedicatedThreadSpawn");
 }
 
 TS_INLINE off_t


### PR DESCRIPTION
Sub task of PR #1997. This is a fix for #1969 in place of #1984 and #1989 which was incorporated in #1997. See the code comments for details.