### PR TITLE
Add logic to flush gcov data from traffic_server on interrupt.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -176,13 +176,15 @@ AC_ARG_ENABLE([mime-sanity-check],
 AC_MSG_RESULT([$enable_mime_sanity_check])
 
 # Enable code coverage instrumentation only if requested by the user.
+use_gcov=0
 AC_MSG_CHECKING([whether to code coverage])
 AC_ARG_ENABLE([coverage],
   [AS_HELP_STRING([--enable-coverage],[generate code coverage instrumentation])],
-  [],
+  [use_gcov=1],
   [enable_coverage=no]
 )
 AC_MSG_RESULT([$enable_coverage])
+AC_SUBST(use_gcov)
 
 #
 # Enable -Werror. We want this enabled by default for developers, but disabled by default

--- a/lib/ts/ink_config.h.in
+++ b/lib/ts/ink_config.h.in
@@ -58,6 +58,7 @@
 #define TS_HAS_IN6_IS_ADDR_UNSPECIFIED @has_in6_is_addr_unspecified@
 #define TS_HAS_BACKTRACE @has_backtrace@
 #define TS_HAS_PROFILER @has_profiler@
+#define TS_USE_GCOV @use_gcov@
 #define TS_USE_FAST_SDK @use_fast_sdk@
 #define TS_USE_DIAGS @use_diags@
 #define TS_USE_EPOLL @use_epoll@

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -91,12 +91,17 @@ extern "C" int plock(int);
 #include "I_Tasks.h"
 #include "InkAPIInternal.h"
 #include "HTTP2.h"
+#include "ts/ink_config.h"
 
 #include <ts/ink_cap.h>
 
 #if TS_HAS_PROFILER
 #include <gperftools/profiler.h>
 #include <gperftools/heap-profiler.h>
+#endif
+
+#if TS_USE_GCOV
+extern "C" void __gcov_flush();
 #endif
 
 //
@@ -443,6 +448,10 @@ proxy_signal_handler(int signo, siginfo_t *info, void *ctx)
   HeapProfilerDump("/tmp/ts_end.hprof");
   HeapProfilerStop();
   ProfilerStop();
+#endif
+
+#if TS_USE_GCOV
+  __gcov_flush();
 #endif
 
   // We don't expect any crashing signals here because, but


### PR DESCRIPTION
Without this change code coverage data from traffic_server won't get pushed unless traffic_server shuts down cleanly.  With this change, the data will be flushed out on interrupt.