### PR TITLE
Permissive mode for server certificate verification (#433)

### DIFF
--- a/iocore/net/SSLClientUtils.cc
+++ b/iocore/net/SSLClientUtils.cc
@@ -42,30 +42,37 @@ verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
   int depth;
   int err;
   SSL *ssl;
-  SSLNetVConnection *netvc;
 
   SSLDebug("Entered verify cb");
   depth = X509_STORE_CTX_get_error_depth(ctx);
   cert  = X509_STORE_CTX_get_current_cert(ctx);
   err   = X509_STORE_CTX_get_error(ctx);
 
+  /*
+   * Retrieve the pointer to the SSL of the connection currently treated
+   * and the application specific data stored into the SSL object.
+   */
+  ssl                      = static_cast<SSL *>(X509_STORE_CTX_get_ex_data(ctx, SSL_get_ex_data_X509_STORE_CTX_idx()));
+  SSLNetVConnection *netvc = SSLNetVCAccess(ssl);
   if (!preverify_ok) {
     // Don't bother to check the hostname if we failed openssl's verification
     SSLDebug("verify error:num=%d:%s:depth=%d", err, X509_verify_cert_error_string(err), depth);
+    if (netvc && netvc->options.clientVerificationFlag == 2) {
+      if (netvc->options.sni_servername)
+        Warning("Hostname verification failed for (%s) but still continuing with the connection establishment",
+                netvc->options.sni_servername.get());
+      else
+        Warning("Server certificate verification failed but still continuing with the connection establishment");
+      return 1;
+    }
     return preverify_ok;
   }
-
   if (depth != 0) {
     // Not server cert....
     return preverify_ok;
   }
 
-  // Retrieve the pointer to the SSL of the connection currently treated
-  // and the application specific data stored into the SSL object.
-  ssl   = static_cast<SSL *>(X509_STORE_CTX_get_ex_data(ctx, SSL_get_ex_data_X509_STORE_CTX_idx()));
-  netvc = SSLNetVCAccess(ssl);
-
-  if (netvc != nullptr) {
+  if (netvc) {
     // Match SNI if present
     if (netvc->options.sni_servername) {
       char *matched_name = nullptr;
@@ -74,7 +81,7 @@ verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
         ats_free(matched_name);
         return preverify_ok;
       }
-      SSLDebug("Hostname verification failed for (%s)", netvc->options.sni_servername.get());
+      Warning("Hostname verification failed for (%s)", netvc->options.sni_servername.get());
     }
     // Otherwise match by IP
     else {
@@ -84,7 +91,12 @@ verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
         SSLDebug("IP %s verified OK", buff);
         return preverify_ok;
       }
-      SSLDebug("IP verification failed for (%s)", buff);
+      Warning("IP verification failed for (%s)", buff);
+    }
+    if (netvc->options.clientVerificationFlag == 2) {
+      Warning("Server certificate verification failed but continuing with the connection establishment:%s",
+              netvc->options.sni_servername.get());
+      return preverify_ok;
     }
     return 0;
   }

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1158,7 +1158,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.ssl.CA.cert.path", RECD_STRING, TS_BUILD_SYSCONFDIR, RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.ssl.client.verify.server", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.ssl.client.verify.server", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-2]", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.ssl.client.cert.filename", RECD_STRING, nullptr, RECU_RESTART_TS, RR_NULL, RECC_STR, "^[^[:space:]]*$", RECA_NULL}
   ,

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -5279,11 +5279,6 @@ HttpSM::handle_http_server_open()
   //          server session's first transaction.
   if (nullptr != server_session) {
     NetVConnection *vc = server_session->get_netvc();
-
-    //    SSLNetVConnection *ssl_vc = dynamic_cast<SSLNetVConnection *>(vc);
-    //    if (ssl_vc) {
-    //      ssl_vc->setClientVerifyEnable(t_state.txn_conf->ssl_client_verify_server);
-    //    }
     if (vc != NULL && (vc->options.sockopt_flags != t_state.txn_conf->sock_option_flag_out ||
                        vc->options.packet_mark != t_state.txn_conf->sock_packet_mark_out ||
                        vc->options.packet_tos != t_state.txn_conf->sock_packet_tos_out ||


### PR DESCRIPTION
proxy.config.ssl.client.verify.server accepts third value (=2) which 

- allows ATS to conitnue with the SSL connection with the next server even if cert verification fails
- ATS logs the verification failure