### PR TITLE
Remove useless name from ink_mutex_init.

### DIFF
--- a/iocore/aio/AIO.cc
+++ b/iocore/aio/AIO.cc
@@ -158,7 +158,7 @@ ink_aio_init(ModuleVersion v)
                      (int)AIO_STAT_KB_WRITE_PER_SEC, aio_stats_cb);
 #if AIO_MODE != AIO_MODE_NATIVE
   memset(&aio_reqs, 0, MAX_DISKS_POSSIBLE * sizeof(AIO_Reqs *));
-  ink_mutex_init(&insert_mutex, nullptr);
+  ink_mutex_init(&insert_mutex);
 #endif
   REC_ReadConfigInteger(cache_config_threads_per_disk, "proxy.config.cache.threads_per_disk");
 #if TS_USE_LINUX_NATIVE_AIO
@@ -228,7 +228,7 @@ aio_init_fildes(int fildes, int fromAPI = 0)
   INK_WRITE_MEMORY_BARRIER;
 
   ink_cond_init(&request->aio_cond);
-  ink_mutex_init(&request->aio_mutex, nullptr);
+  ink_mutex_init(&request->aio_mutex);
   ink_atomiclist_init(&request->aio_temp_list, "temp_list", (uintptr_t) & ((AIOCallback *)nullptr)->link);
 
   RecInt thread_num;

--- a/iocore/eventsystem/I_Lock.h
+++ b/iocore/eventsystem/I_Lock.h
@@ -270,7 +270,7 @@ public:
   void
   init(const char *name = "UnnamedMutex")
   {
-    ink_mutex_init(&the_mutex, name);
+    ink_mutex_init(&the_mutex);
   }
 };
 

--- a/iocore/eventsystem/P_ProtectedQueue.h
+++ b/iocore/eventsystem/P_ProtectedQueue.h
@@ -36,7 +36,7 @@ TS_INLINE
 ProtectedQueue::ProtectedQueue()
 {
   Event e;
-  ink_mutex_init(&lock, "ProtectedQueue");
+  ink_mutex_init(&lock);
   ink_atomiclist_init(&al, "ProtectedQueue", (char *)&e.link.next - (char *)&e);
   ink_cond_init(&might_have_data);
 }

--- a/iocore/eventsystem/P_UnixEventProcessor.h
+++ b/iocore/eventsystem/P_UnixEventProcessor.h
@@ -36,7 +36,7 @@ EventProcessor::EventProcessor() : n_ethreads(0), n_thread_groups(0), n_dthreads
   memset(all_dthreads, 0, sizeof(all_dthreads));
   memset(n_threads_for_type, 0, sizeof(n_threads_for_type));
   memset(next_thread_for_type, 0, sizeof(next_thread_for_type));
-  ink_mutex_init(&dedicated_spawn_thread_mutex, "EventProcessorDedicatedThreadSpawn");
+  ink_mutex_init(&dedicated_spawn_thread_mutex);
 }
 
 TS_INLINE off_t

--- a/iocore/net/OCSPStapling.cc
+++ b/iocore/net/OCSPStapling.cc
@@ -134,7 +134,7 @@ ssl_stapling_init_cert(SSL_CTX *ctx, X509 *cert, const char *certname)
   cinf->uri         = nullptr;
   cinf->certname    = ats_strdup(certname);
   cinf->resp_derlen = 0;
-  ink_mutex_init(&cinf->stapling_mutex, "stapling_mutex");
+  ink_mutex_init(&cinf->stapling_mutex);
   cinf->is_expire   = true;
   cinf->expire_time = 0;
 

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -74,7 +74,7 @@ static ConfigUpdateHandler<SSLCertificateConfig> *sslCertUpdate;
 
 SSLConfigParams::SSLConfigParams()
 {
-  ink_mutex_init(&ctxMapLock, "Context List Lock");
+  ink_mutex_init(&ctxMapLock);
   reset();
 }
 

--- a/iocore/net/SSLDynlock.cc
+++ b/iocore/net/SSLDynlock.cc
@@ -27,7 +27,7 @@
 #include "ts/Diags.h"
 
 struct CRYPTO_dynlock_value {
-  CRYPTO_dynlock_value(const char *f, int l) : file(f), line(l) { ink_mutex_init(&mutex, nullptr); }
+  CRYPTO_dynlock_value(const char *f, int l) : file(f), line(l) { ink_mutex_init(&mutex); }
   ~CRYPTO_dynlock_value() { ink_mutex_destroy(&mutex); }
   const char *file;
   int line;

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -859,7 +859,7 @@ SSLInitializeLibrary()
     mutex_buf = (ink_mutex *)OPENSSL_malloc(CRYPTO_num_locks() * sizeof(ink_mutex));
 
     for (int i = 0; i < CRYPTO_num_locks(); i++) {
-      ink_mutex_init(&mutex_buf[i], nullptr);
+      ink_mutex_init(&mutex_buf[i]);
     }
 
     CRYPTO_set_locking_callback(SSL_locking_callback);

--- a/lib/records/RecConfigParse.cc
+++ b/lib/records/RecConfigParse.cc
@@ -46,7 +46,7 @@ ink_mutex g_rec_config_lock;
 void
 RecConfigFileInit()
 {
-  ink_mutex_init(&g_rec_config_lock, nullptr);
+  ink_mutex_init(&g_rec_config_lock);
   g_rec_config_contents_llq = create_queue();
   g_rec_config_contents_ht  = ink_hash_table_create(InkHashTableKeyType_String);
 }

--- a/lib/records/RecCore.cc
+++ b/lib/records/RecCore.cc
@@ -214,7 +214,7 @@ RecCoreInit(RecModeT mode_type, Diags *_diags)
   if ((mode_type == RECM_SERVER) || (mode_type == RECM_STAND_ALONE)) {
     bool file_exists = true;
 
-    ink_mutex_init(&g_rec_config_lock, nullptr);
+    ink_mutex_init(&g_rec_config_lock);
 
     g_rec_config_fpath = RecConfigReadConfigPath(nullptr, REC_CONFIG_FILE REC_SHADOW_EXT);
     if (RecFileExists(g_rec_config_fpath) == REC_ERR_FAIL) {

--- a/lib/records/RecMutex.cc
+++ b/lib/records/RecMutex.cc
@@ -25,11 +25,11 @@
 #include "I_RecMutex.h"
 
 void
-rec_mutex_init(RecMutex *m, const char *name)
+rec_mutex_init(RecMutex *m, const char *)
 {
   m->nthread_holding = 0;
   m->thread_holding  = ink_thread_null();
-  ink_mutex_init(&(m->the_mutex), name);
+  ink_mutex_init(&(m->the_mutex));
 }
 
 void

--- a/lib/records/RecProcess.cc
+++ b/lib/records/RecProcess.cc
@@ -233,7 +233,7 @@ RecProcessInit(RecModeT mode_type, Diags *_diags)
    }
 
    ink_cond_init(&g_force_req_cond);
-   ink_mutex_init(&g_force_req_mutex, nullptr);
+   ink_mutex_init(&g_force_req_mutex);
    if (mode_type == RECM_CLIENT) {
    send_pull_message(RECG_PULL_REQ);
    ink_cond_wait(&g_force_req_cond, &g_force_req_mutex);

--- a/lib/records/RecRawStats.cc
+++ b/lib/records/RecRawStats.cc
@@ -235,7 +235,7 @@ RecAllocateRawStatBlock(int num_stats)
   rsb->max_stats        = num_stats;
   rsb->ethr_stat_offset = ethr_stat_offset;
 
-  ink_mutex_init(&(rsb->mutex), "net stat mutex");
+  ink_mutex_init(&(rsb->mutex));
   return rsb;
 }
 

--- a/lib/ts/Diags.cc
+++ b/lib/ts/Diags.cc
@@ -110,7 +110,7 @@ Diags::Diags(const char *prefix_string, const char *bdt, const char *bat, BaseLo
   int i;
 
   cleanup_func = nullptr;
-  ink_mutex_init(&tag_table_lock, "Diags::tag_table_lock");
+  ink_mutex_init(&tag_table_lock);
 
   ////////////////////////////////////////////////////////
   // initialize the default, base debugging/action tags //

--- a/lib/ts/EventNotify.cc
+++ b/lib/ts/EventNotify.cc
@@ -56,7 +56,7 @@ EventNotify::EventNotify()
   ink_release_assert(ret != -1);
 #else
   ink_cond_init(&m_cond);
-  ink_mutex_init(&m_mutex, nullptr);
+  ink_mutex_init(&m_mutex);
 #endif
 }
 

--- a/lib/ts/ink_mutex.cc
+++ b/lib/ts/ink_mutex.cc
@@ -52,7 +52,7 @@ public:
 static x_pthread_mutexattr_t attr;
 
 void
-ink_mutex_init(ink_mutex *m, const char * /* name */)
+ink_mutex_init(ink_mutex *m)
 {
   int error;
 

--- a/lib/ts/ink_mutex.h
+++ b/lib/ts/ink_mutex.h
@@ -41,7 +41,7 @@
 
 typedef pthread_mutex_t ink_mutex;
 
-void ink_mutex_init(ink_mutex *m, const char * /* name */);
+void ink_mutex_init(ink_mutex *m);
 void ink_mutex_destroy(ink_mutex *m);
 
 static inline void

--- a/lib/ts/ink_rwlock.cc
+++ b/lib/ts/ink_rwlock.cc
@@ -32,7 +32,7 @@
 int
 ink_rwlock_init(ink_rwlock *rw)
 {
-  ink_mutex_init(&rw->rw_mutex, nullptr);
+  ink_mutex_init(&rw->rw_mutex);
 
   ink_cond_init(&rw->rw_condreaders);
   ink_cond_init(&rw->rw_condwriters);

--- a/lib/ts/llqueue.cc
+++ b/lib/ts/llqueue.cc
@@ -76,7 +76,7 @@ create_queue()
   LLQ *new_val = (LLQ *)ats_malloc(sizeof(LLQ));
 
   ink_sem_init(&(new_val->sema), 0);
-  ink_mutex_init(&(new_val->mux), "LLQ::create_queue");
+  ink_mutex_init(&(new_val->mux));
 
   new_val->head = new_val->tail = new_val->free = nullptr;
   new_val->len = new_val->highwater = 0;

--- a/mgmt/Alarms.cc
+++ b/mgmt/Alarms.cc
@@ -81,7 +81,7 @@ Alarms::Alarms()
   cblist        = ink_hash_table_create(InkHashTableKeyType_String);
   local_alarms  = ink_hash_table_create(InkHashTableKeyType_String);
   remote_alarms = ink_hash_table_create(InkHashTableKeyType_String);
-  ink_mutex_init(&mutex, "alarms-mutex");
+  ink_mutex_init(&mutex);
   alarmOEMcount = minOEMkey;
 } /* End Alarms::Alarms */
 

--- a/mgmt/FileManager.cc
+++ b/mgmt/FileManager.cc
@@ -43,8 +43,8 @@ FileManager::FileManager()
   bindings = ink_hash_table_create(InkHashTableKeyType_String);
   ink_assert(bindings != nullptr);
 
-  ink_mutex_init(&accessLock, "File Manager Mutex");
-  ink_mutex_init(&cbListLock, "File Changed Callback Mutex");
+  ink_mutex_init(&accessLock);
+  ink_mutex_init(&cbListLock);
 
   ats_scoped_str snapshotDir(RecConfigReadSnapshotDir());
 

--- a/mgmt/Rollback.cc
+++ b/mgmt/Rollback.cc
@@ -87,7 +87,7 @@ Rollback::Rollback(const char *fileName_, bool root_access_needed_, Rollback *pa
     fileBaseName = fileName;
   }
 
-  ink_mutex_init(&fileAccessLock, "RollBack Mutex");
+  ink_mutex_init(&fileAccessLock);
 
   if (varIntFromName("proxy.config.admin.number_config_bak", &numBak) == true) {
     if (numBak > 1) {

--- a/mgmt/api/EventCallback.cc
+++ b/mgmt/api/EventCallback.cc
@@ -79,7 +79,7 @@ delete_event_callback(EventCallbackT *event_cb)
  * notes: None
  **********************************************************************/
 CallbackTable *
-create_callback_table(const char *lock_name)
+create_callback_table(const char *)
 {
   CallbackTable *cb_table = (CallbackTable *)ats_malloc(sizeof(CallbackTable));
 
@@ -88,7 +88,7 @@ create_callback_table(const char *lock_name)
   }
 
   // initialize the mutex
-  ink_mutex_init(&cb_table->event_callback_lock, lock_name);
+  ink_mutex_init(&cb_table->event_callback_lock);
   return cb_table;
 }
 

--- a/mgmt/api/EventControlMain.cc
+++ b/mgmt/api/EventControlMain.cc
@@ -122,7 +122,7 @@ remove_event_client(EventClientT *client, InkHashTable *table)
 TSMgmtError
 init_mgmt_events()
 {
-  ink_mutex_init(&mgmt_events_lock, "mgmt_event_notice");
+  ink_mutex_init(&mgmt_events_lock);
 
   // initialize queue
   mgmt_events = create_queue();

--- a/mgmt/utils/MgmtHashTable.h
+++ b/mgmt/utils/MgmtHashTable.h
@@ -40,9 +40,9 @@
 class MgmtHashTable
 {
 public:
-  MgmtHashTable(const char *name, bool free_on_delete, InkHashTableKeyType type)
+  MgmtHashTable(const char *, bool free_on_delete, InkHashTableKeyType type)
   {
-    ink_mutex_init(&mutex, name);
+    ink_mutex_init(&mutex);
     destroy_and_free = free_on_delete;
     ht               = ink_hash_table_create(type);
   }

--- a/proxy/InkIOCoreAPI.cc
+++ b/proxy/InkIOCoreAPI.cc
@@ -98,7 +98,7 @@ TSReturnCode sdk_sanity_check_null_ptr(void *ptr);
 struct INKThreadInternal : public EThread {
   INKThreadInternal() : EThread(DEDICATED, -1)
   {
-    ink_mutex_init(&completion.lock, nullptr);
+    ink_mutex_init(&completion.lock);
     ink_cond_init(&completion.signal);
   }
 

--- a/proxy/http/HttpBodyFactory.cc
+++ b/proxy/http/HttpBodyFactory.cc
@@ -334,7 +334,7 @@ HttpBodyFactory::HttpBodyFactory()
   ////////////////////////////////////
   // initialize first-time defaults //
   ////////////////////////////////////
-  ink_mutex_init(&mutex, "HttpBodyFactory::lock");
+  ink_mutex_init(&mutex);
 
   //////////////////////////////////////////////////////
   // set up management configuration-change callbacks //

--- a/proxy/http/HttpConnectionCount.h
+++ b/proxy/http/HttpConnectionCount.h
@@ -192,7 +192,7 @@ public:
 
 protected:
   // Hide the constructor and copy constructor
-  ConnectionCount() { ink_mutex_init(&_mutex, "ConnectionCountMutex"); }
+  ConnectionCount() { ink_mutex_init(&_mutex); }
   ConnectionCount(const ConnectionCount & /* x ATS_UNUSED */) {}
   static ConnectionCount _connectionCount;
   HashMap<ConnAddr, ConnAddrHashFns, int> _hostCount;

--- a/proxy/http/HttpProxyServerMain.cc
+++ b/proxy/http/HttpProxyServerMain.cc
@@ -234,8 +234,8 @@ init_HttpProxyServer(int n_accept_threads)
   http_pages_init();
 
 #ifdef USE_HTTP_DEBUG_LISTS
-  ink_mutex_init(&debug_sm_list_mutex, "HttpSM Debug List");
-  ink_mutex_init(&debug_cs_list_mutex, "HttpCS Debug List");
+  ink_mutex_init(&debug_sm_list_mutex);
+  ink_mutex_init(&debug_cs_list_mutex);
 #endif
 
   // Used to give plugins the ability to create http requests

--- a/proxy/logging/LogBuffer.cc
+++ b/proxy/logging/LogBuffer.cc
@@ -771,7 +771,7 @@ LogBuffer::to_ascii(LogEntryHeader *entry, LogFormatType type, char *buf, int bu
 LogBufferList::LogBufferList()
 {
   m_size = 0;
-  ink_mutex_init(&m_mutex, "LogBufferList");
+  ink_mutex_init(&m_mutex);
 }
 
 /*-------------------------------------------------------------------------

--- a/proxy/logging/LogObject.cc
+++ b/proxy/logging/LogObject.cc
@@ -864,7 +864,7 @@ TextLogObject::va_write(const char *format, va_list ap)
 LogObjectManager::LogObjectManager()
 {
   _APImutex = new ink_mutex;
-  ink_mutex_init(_APImutex, "_APImutex");
+  ink_mutex_init(_APImutex);
 }
 
 LogObjectManager::~LogObjectManager()


### PR DESCRIPTION
The name isn't stored anywhere, the argument is actually ignored. Why bother with it?