### PR TITLE
cid 1375841: Replace strncpy with memcpy

### DIFF
--- a/plugins/s3_auth/aws_auth_v4.cc
+++ b/plugins/s3_auth/aws_auth_v4.cc
@@ -29,7 +29,6 @@
 #include <openssl/sha.h>  /* SHA(), sha256_Update(), SHA256_Final, etc. */
 #include <openssl/hmac.h> /* HMAC() */
 
-#undef AWS_AUTH_V4_DETAILED_DEBUG_OUTPUT
 #ifdef AWS_AUTH_V4_DETAILED_DEBUG_OUTPUT
 #include <iostream>
 #endif
@@ -565,8 +564,8 @@ getSignature(const char *awsSecret, size_t awsSecretLen, const char *awsRegion, 
 
   size_t keyLen = 4 + awsSecretLen;
   char key[keyLen];
-  strncpy(key, "AWS4", 4);
-  strncpy(key + 4, awsSecret, awsSecretLen);
+  memcpy(key, "AWS4", 4);
+  memcpy(key + 4, awsSecret, awsSecretLen);
 
   unsigned int len = signatureLen;
   if (HMAC(EVP_sha256(), key, keyLen, (unsigned char *)dateTime, dateTimeLen, dateKey, &dateKeyLen) &&


### PR DESCRIPTION
Issue:
  CID 1375841 (#1 of 1): Buffer not null terminated (BUFFER_SIZE)
  1. buffer_size: Calling strncpy with a source string whose length
  (4 chars) is greater than or equal to the size argument (4) will
  fail to null-terminate key.

Fix:
  The code is correct. The buffer is not meant to be NULL-terminated.
  It seems Coverity thinks that since strncpy is used NULL-terminated
  buffer is expected.  Changing strncpy to memcpy.

Also removing unnecessary #undef