### PR TITLE
Rename "ink_mutex_lock" to "ink_scoped_mutex_lock" for better consistency.

### DIFF
--- a/lib/ts/ink_mutex.h
+++ b/lib/ts/ink_mutex.h
@@ -74,21 +74,21 @@ ink_mutex_try_acquire(ink_mutex *m)
     ink_mutex m;
     // ...
     {
-       ink_mutex_lock lock(m);
+       ink_mutex_scoped_lock lock(m);
        // code under lock.
     }
     // code not under lock
     @endcode
  */
-class ink_mutex_lock
+class ink_scoped_mutex_lock
 {
 private:
   ink_mutex &_m;
 
 public:
-  ink_mutex_lock(ink_mutex *m) : _m(*m) { ink_mutex_acquire(&_m); }
-  ink_mutex_lock(ink_mutex &m) : _m(m) { ink_mutex_acquire(&_m); }
-  ~ink_mutex_lock() { ink_mutex_release(&_m); }
+  ink_scoped_mutex_lock(ink_mutex *m) : _m(*m) { ink_mutex_acquire(&_m); }
+  ink_scoped_mutex_lock(ink_mutex &m) : _m(m) { ink_mutex_acquire(&_m); }
+  ~ink_scoped_mutex_lock() { ink_mutex_release(&_m); }
 };
 
 #endif /* _ink_mutex_h_ */


### PR DESCRIPTION
Follow up to #2014 - after pondering I think @jpeach is correct and the class could be named better. Not great, but closer to similar classes in ATS.