### PR TITLE
Negative caching shouldn't happen on 400 response (#396)

### DIFF
--- a/lib/ts/Vec.h
+++ b/lib/ts/Vec.h
@@ -151,6 +151,9 @@ public:
   void qsort(bool (*lt)(const C &, const C &));
   void swap(C *p1, C *p2);
 
+  bool bin_search(int start, int end, bool (*lt)(C, C), bool (*eq)(C, C), C item);
+  bool binary_search(bool (*lt)(C, C), bool (*eq)(C, C), C item);
+
 private:
   void move_internal(Vec<C, A, S> &v);
   void copy_internal(const Vec<C, A, S> &v);
@@ -1109,6 +1112,35 @@ Vec<C, A, S>::qsort(bool (*lt)(const C &, const C &))
     qsort_VecRef<C>(&v[0], end(), lt, &ctr);
   Debug("qsort", "took %u iterations to sort %ld elements", ctr, n);
 }
+
+template <class C, class A, int S>
+inline bool
+Vec<C, A, S>::binary_search(bool (*lt)(C, C), bool (*eq)(C, C), C item)
+{
+  return bin_search(0, n - 1, lt, eq, item);
+}
+
+template <class C, class A, int S>
+inline bool
+Vec<C, A, S>::bin_search(int start, int end, bool (*lt)(C, C), bool (*eq)(C, C), C item)
+{
+  int s   = start;
+  int e   = end;
+  int mid = (s + e) / 2;
+  if (s > e)
+    return false;
+
+  if (eq(v[mid], item))
+    return true;
+
+  if (lt(v[mid], item))
+    return bin_search(mid + 1, e, lt, eq, item);
+  else
+    return bin_search(s, mid - 1, lt, eq, item);
+
+  return false;
+}
+
 void test_vec();
 
 #endif

--- a/lib/ts/test_Vec.cc
+++ b/lib/ts/test_Vec.cc
@@ -52,11 +52,22 @@ test_append()
 
   ink_assert(str.length() == 1000 * len);
 }
+bool
+lt(int x, int y)
+{
+  return x < y;
+}
 
+bool
+eq(int x, int y)
+{
+  return x == y;
+}
 static void
 test_basic()
 {
   Vec<void *> v, vv, vvv;
+  Vec<int> intVec;
   int tt = 99 * 50, t = 0;
 
   for (size_t i = 0; i < 100; i++) {
@@ -130,6 +141,22 @@ test_basic()
   uf.unify(1, 2);
   ink_assert(uf.find(0) == uf.find(3));
   ink_assert(uf.find(1) == uf.find(3));
+
+  intVec.add(9);
+  intVec.add(5);
+  intVec.add(4);
+  intVec.add(12);
+  intVec.add(1);
+  intVec.add(21);
+  intVec.add(13);
+  intVec.add(18);
+  intVec.add(142);
+  intVec.add(721);
+  intVec.add(173);
+  intVec.add(188);
+  intVec.qsort(lt);
+  ink_assert(false == intVec.binary_search(lt, eq, 56));
+  ink_assert(true == intVec.binary_search(lt, eq, 1));
 }
 
 static bool

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -864,6 +864,11 @@ register_stat_callbacks()
                      (int)http_sm_finish_time_stat, RecRawStatSyncSum);
 }
 
+bool
+lt_sort(int x, int y)
+{
+  return x < y;
+}
 ////////////////////////////////////////////////////////////////
 //
 //  HttpConfig::startup()
@@ -1119,6 +1124,20 @@ HttpConfig::startup()
 
   // Local Manager
   HttpEstablishStaticConfigLongLong(c.synthetic_port, "proxy.config.admin.synthetic_port");
+
+  // The responses with the following status code WILL BE cached with negative caching enabled.
+  c.codeNegCache.add(HTTP_STATUS_NO_CONTENT);
+  c.codeNegCache.add(HTTP_STATUS_USE_PROXY);
+  c.codeNegCache.add(HTTP_STATUS_FORBIDDEN);
+  c.codeNegCache.add(HTTP_STATUS_NOT_FOUND);
+  c.codeNegCache.add(HTTP_STATUS_METHOD_NOT_ALLOWED);
+  c.codeNegCache.add(HTTP_STATUS_REQUEST_URI_TOO_LONG);
+  c.codeNegCache.add(HTTP_STATUS_INTERNAL_SERVER_ERROR);
+  c.codeNegCache.add(HTTP_STATUS_NOT_IMPLEMENTED);
+  c.codeNegCache.add(HTTP_STATUS_BAD_GATEWAY);
+  c.codeNegCache.add(HTTP_STATUS_SERVICE_UNAVAILABLE);
+  c.codeNegCache.add(HTTP_STATUS_GATEWAY_TIMEOUT);
+  c.codeNegCache.qsort(lt_sort);
 
   http_config_cont->handleEvent(EVENT_NONE, nullptr);
 
@@ -1394,8 +1413,8 @@ HttpConfig::reconfigure()
 
   // Local Manager
   params->synthetic_port = m_master.synthetic_port;
-
-  m_id = configProcessor.set(m_id, params);
+  params->codeNegCache   = m_master.codeNegCache;
+  m_id                   = configProcessor.set(m_id, params);
 
 #undef INT_TO_BOOL
 }

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -47,6 +47,7 @@
 #include "HttpProxyAPIEnums.h"
 #include "ProxyConfig.h"
 #include "P_RecProcess.h"
+#include "ts/Vec.h"
 
 /* Instead of enumerating the stats in DynamicStats.h, each module needs
    to enumerate its stats separately and register them with librecords
@@ -814,6 +815,9 @@ public:
 
   MgmtByte server_session_sharing_pool = TS_SERVER_SESSION_SHARING_POOL_THREAD;
 
+  // Vector to hold the status codes that will BE cached with negative caching enabled
+  Vec<int> codeNegCache;
+
   // All the overridable configurations goes into this class member, but they
   // are not copied over until needed ("lazy").
   OverridableHttpConfigParams oride;
@@ -883,6 +887,12 @@ inline HttpConfigParams::~HttpConfigParams()
   ats_free(oride.cache_vary_default_other);
   ats_free(connect_ports_string);
   ats_free(reverse_proxy_no_host_redirect);
+
+  int len = codeNegCache.n - 1;
+  for (int i = len; i >= 0; i--) {
+    codeNegCache.remove_index(i);
+  }
+  codeNegCache.clear();
 
   if (connect_ports) {
     delete connect_ports;

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -217,33 +217,32 @@ find_appropriate_cached_resp(HttpTransact::State *s)
 }
 
 int response_cacheable_indicated_by_cc(HTTPHdr *response);
+bool
+lt(int x, int y)
+{
+  return x < y;
+}
 
+bool
+eq(int x, int y)
+{
+  return x == y;
+}
 inline static bool
 is_negative_caching_appropriate(HttpTransact::State *s)
 {
   if (!s->txn_conf->negative_caching_enabled || !s->hdr_info.server_response.valid()) {
     return false;
   }
-
-  switch (s->hdr_info.server_response.status_get()) {
-  case HTTP_STATUS_NO_CONTENT:
-  case HTTP_STATUS_USE_PROXY:
-  case HTTP_STATUS_BAD_REQUEST:
-  case HTTP_STATUS_FORBIDDEN:
-  case HTTP_STATUS_NOT_FOUND:
-  case HTTP_STATUS_METHOD_NOT_ALLOWED:
-  case HTTP_STATUS_REQUEST_URI_TOO_LONG:
-  case HTTP_STATUS_INTERNAL_SERVER_ERROR:
-  case HTTP_STATUS_NOT_IMPLEMENTED:
-  case HTTP_STATUS_BAD_GATEWAY:
-  case HTTP_STATUS_SERVICE_UNAVAILABLE:
-  case HTTP_STATUS_GATEWAY_TIMEOUT:
+  int status  = s->hdr_info.server_response.status_get();
+  auto params = HttpConfig::acquire();
+  if (params->codeNegCache.binary_search(lt, eq, status)) {
+    DebugTxn("http_trans", "%d is eligible for negative caching", status);
     return true;
-  default:
-    break;
+  } else {
+    DebugTxn("http_trans", "%d is NOT eligible for negative caching", status);
+    return false;
   }
-
-  return false;
 }
 
 inline static HttpTransact::LookingUp_t


### PR DESCRIPTION
- adds a vector containing the status code for which the response will be cached with negative caching enabled.
- binary search added for ts/Vec
- test program to test the binary search