### PR TITLE
Allow the tool to apply multiple PRs

### DIFF
--- a/tools/apply-pr.sh
+++ b/tools/apply-pr.sh
@@ -20,13 +20,13 @@
 
 set -e # exit on error
 
-PR="$1"
-URI="https://patch-diff.githubusercontent.com/raw/apache/trafficserver/pull/${PR}.diff"
 
-if [[ "$PR" =~ ^[0-9]+$ ]];  then
-    echo "Applying changes from $URI ..."
-    curl -s $URI | patch -p1
-else
-    echo "$PR is not a valid pull request"
-    exit -1
-fi
+for pr in $@; do
+    if [[ "$pr" =~ ^[0-9]+$ ]];  then
+	URI="https://patch-diff.githubusercontent.com/raw/apache/trafficserver/pull/${pr}.diff"
+	echo "Applying changes from $URI ..."
+	curl -s $URI | patch -p1
+    else
+	echo "$PR is not a valid pull request, skipping"
+    fi
+done


### PR DESCRIPTION
This makes it easier to manage a larger set of PRs to test on e.g. docs.trafficserver.apache.org.