### PR TITLE
tsxs generation uses AM_C*FLAGS instead of C*FLAGS

### DIFF
--- a/tools/tsxs.in
+++ b/tools/tsxs.in
@@ -25,8 +25,8 @@ localstatedir="@localstatedir@"
 INSTALLDIR=`eval echo "@libexecdir@"`
 INCLUDEDIR=`eval echo "@includedir@"`
 CPPFLAGS="$CPPFLAGS -I$INCLUDEDIR"
-CFLAGS="$CFLAGS @CFLAGS@"
-CXXFLAGS="$CXXFLAGS @CXXFLAGS@"
+CFLAGS="$CFLAGS @AM_CFLAGS@"
+CXXFLAGS="$CXXFLAGS @AM_CXXFLAGS@"
 BUILD=
 DEBUGECHO=
 
@@ -77,8 +77,8 @@ query() {
   case $1 in
     CC) echo @CC@ ;;
     CXX) echo @CXX@ ;;
-    CFLAGS) echo @CFLAGS@ ;;
-    CXXFLAGS) echo @CXXFLAGS@ ;;
+    CFLAGS) echo @AM_CFLAGS@ ;;
+    CXXFLAGS) echo @AM_CXXFLAGS@ ;;
     PREFIX) echo @prefix@ ;;
     SYSCONFDIR) echo @sysconfdir@ ;;
     INCLUDEDIR) echo @includedir@ ;;


### PR DESCRIPTION
The change to prefer `AM_C*FLAGS` over `C*FLAGS` [moved](https://github.com/apache/trafficserver/commit/c7c9d0f7af1f1771945213e0197f15cce6a68b63#diff-67e997bcfdac55191033d57a16d1408aL586) `-std=c++11` from `CPPFLAGS` to `AM_CPPFLAGS`, but the `tsxs` template had no [corresponding change](https://github.com/apache/trafficserver/blob/45765558208b3fb39c54d145a79b25f43c04160e/tools/tsxs.in#L29).

As a result, gcc does not build with c++11 compatibility when building plugins via the generated `tsxs` tool.