### PR TITLE
Disable cache volume size check for already configured volumes.

### DIFF
--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -2686,8 +2686,7 @@ cplist_update()
   while (cp) {
     for (config_vol = config_volumes.cp_queue.head; config_vol; config_vol = config_vol->link.next) {
       if (config_vol->number == cp->vol_number) {
-        off_t size_in_blocks = config_vol->size << (20 - STORE_BLOCK_SHIFT);
-        if ((cp->size <= size_in_blocks) && (cp->scheme == config_vol->scheme)) {
+        if (cp->scheme == config_vol->scheme) {
           config_vol->cachep = cp;
         } else {
           /* delete this volume from all the disks */


### PR DESCRIPTION
I spent a long time pondering this code and was never able to figure why this check was done, particularly since it only checks for the actual volume on the caches disks being larger than the computed configuration size. On the other hand, having this check makes any sort of external tool for fiddling volume / cache sizes almost impossible to write because the result is so constrained.