### PR TITLE
Address session/transaction close errors.

### DIFF
--- a/proxy/ProxyClientTransaction.cc
+++ b/proxy/ProxyClientTransaction.cc
@@ -81,10 +81,7 @@ ProxyClientTransaction::attach_server_session(HttpServerSession *ssession, bool 
 void
 ProxyClientTransaction::destroy()
 {
-  if (current_reader) {
-    current_reader->ua_session = nullptr;
-    current_reader             = nullptr;
-  }
+  current_reader = nullptr;
   this->mutex.clear();
 }
 

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -75,6 +75,7 @@ Http1ClientSession::Http1ClientSession()
     ka_vio(nullptr),
     slave_ka_vio(nullptr),
     bound_ss(nullptr),
+    released_transactions(0),
     outbound_port(0),
     f_outbound_transparent(false),
     f_transparent_passthrough(false)
@@ -89,12 +90,23 @@ Http1ClientSession::destroy()
   }
   if (!in_destroy) {
     in_destroy = true;
-    DebugHttpSsn("[%" PRId64 "] session destroy", con_id);
 
+    DebugHttpSsn("[%" PRId64 "] session destroy", con_id);
     ink_release_assert(!client_vc);
     ink_assert(read_buffer);
-
+    ink_release_assert(transact_count == released_transactions);
     do_api_callout(TS_HTTP_SSN_CLOSE_HOOK);
+  } else {
+    Warning("http1: Attempt to double ssn close");
+  }
+}
+
+void
+Http1ClientSession::release_transaction()
+{
+  released_transactions++;
+  if (transact_count == released_transactions) {
+    destroy();
   }
 }
 
@@ -269,7 +281,10 @@ Http1ClientSession::do_io_close(int alerrno)
     bound_ss     = nullptr;
     slave_ka_vio = nullptr;
   }
-
+  // Completed the last transaction.  Just shutdown already
+  if (transact_count == released_transactions) {
+    half_close = false;
+  }
   if (half_close && this->trans.get_sm()) {
     read_state = HCS_HALF_CLOSED;
     SET_HANDLER(&Http1ClientSession::state_wait_for_close);
@@ -308,7 +323,7 @@ Http1ClientSession::do_io_close(int alerrno)
       client_vc = nullptr;
     }
   }
-  if (trans.get_sm() == nullptr) { // Destroying from keep_alive state
+  if (transact_count == released_transactions) {
     this->destroy();
   }
 }
@@ -408,16 +423,7 @@ Http1ClientSession::state_keep_alive(int event, void *data)
     break;
 
   case VC_EVENT_EOS:
-    // If there is data in the buffer, start a new
-    //  transaction, otherwise the client gave up
-    //  SKH - A bit odd starting a transaction when the client has closed
-    //  already.  At a minimum, should have to do some half open connection
-    //  tracking
-    // if (sm_reader->read_avail() > 0) {
-    //  new_transaction();
-    //} else {
     this->do_io_close();
-    //}
     break;
 
   case VC_EVENT_READ_COMPLETE:

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -57,6 +57,7 @@ public:
   // Implement ProxyClientSession interface.
   virtual void destroy();
   virtual void free();
+  void release_transaction();
 
   virtual void
   start()
@@ -218,6 +219,8 @@ private:
   VIO *slave_ka_vio;
 
   HttpServerSession *bound_ss;
+
+  int released_transactions;
 
 public:
   // Link<Http1ClientSession> debug_link;

--- a/proxy/http/Http1ClientTransaction.cc
+++ b/proxy/http/Http1ClientTransaction.cc
@@ -63,11 +63,9 @@ Http1ClientTransaction::set_parent(ProxyClientSession *new_parent)
 void
 Http1ClientTransaction::transaction_done()
 {
-  current_reader = nullptr;
   // If the parent session is not in the closed state, the destroy will not occur.
   if (parent) {
-    parent->destroy();
-    parent = nullptr;
+    static_cast<Http1ClientSession *>(parent)->release_transaction();
   }
 }
 

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -125,7 +125,9 @@ Http2Stream::main_event_handler(int event, void *edata)
       ink_release_assert(this->closed);
 
       // Safe to initiate SSN_CLOSE if this is the last stream
-      static_cast<Http2ClientSession *>(parent)->connection_state.release_stream(this);
+      if (parent) {
+        static_cast<Http2ClientSession *>(parent)->connection_state.release_stream(this);
+      }
       this->destroy();
     }
     break;


### PR DESCRIPTION
We had problems with double session closes and misorders between transaction and session close hooks on heavily loaded systems.  These changes ensure that session closes are called only once and session close hooks are called after the last transaction close for the session.