### PR TITLE
Fix memory issue with intercept context in lua plugin

### DIFF
--- a/plugins/experimental/ts_lua/ts_lua_http_intercept.c
+++ b/plugins/experimental/ts_lua/ts_lua_http_intercept.c
@@ -291,6 +291,7 @@ ts_lua_http_intercept_process_read(TSEvent event, ts_lua_http_intercept_ctx *ict
   switch (event) {
   case TS_EVENT_VCONN_READ_READY:
     TSVConnShutdown(ictx->net_vc, 1, 0);
+    ictx->recv_complete = 1;
     break; // READ_READY_READY is not equal to EOS break statement is probably missing?
   case TS_EVENT_VCONN_READ_COMPLETE:
   case TS_EVENT_VCONN_EOS:


### PR DESCRIPTION
After coverity fix #1867, i find that we are leaking some memory. 
Doing this change will preserve the original mechanics before the coverity fix in #1867 
and it showed the leak is stopped