### PR TITLE
Ran clang-tidy with modernize-deprecated-headers

### DIFF
--- a/cmd/traffic_ctl/config.cc
+++ b/cmd/traffic_ctl/config.cc
@@ -22,7 +22,7 @@
  */
 
 #include "traffic_ctl.h"
-#include <time.h>
+#include <ctime>
 #include <I_RecDefs.h>
 #include <P_RecUtils.h>
 

--- a/cmd/traffic_top/traffic_top.cc
+++ b/cmd/traffic_top/traffic_top.cc
@@ -25,10 +25,10 @@
 #include <map>
 #include <list>
 #include <string>
-#include <string.h>
+#include <cstring>
 #include <iostream>
-#include <assert.h>
-#include <stdlib.h>
+#include <cassert>
+#include <cstdlib>
 #include <unistd.h>
 #include <getopt.h>
 

--- a/cmd/traffic_via/traffic_via.cc
+++ b/cmd/traffic_via/traffic_via.cc
@@ -27,8 +27,8 @@
 #include "ts/Tokenizer.h"
 #include "ts/TextBuffer.h"
 #include "mgmtapi.h"
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include "ts/Regex.h"
 
 /// XXX Use DFA or Regex wrappers?

--- a/example/cache-scan/cache-scan.cc
+++ b/example/cache-scan/cache-scan.cc
@@ -25,10 +25,10 @@
  * cache_scan.cc:  use TSCacheScan to print URLs and headers for objects in
  *                 the cache when endpoint /show-cache is requested
  */
-#include <stdio.h>
-#include <string.h>
-#include <limits.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstring>
+#include <climits>
+#include <cstdlib>
 
 #include "ts/ts.h"
 #include "ts/experimental.h"

--- a/example/intercept/intercept.cc
+++ b/example/intercept/intercept.cc
@@ -22,10 +22,10 @@
  */
 
 #include <ts/ts.h>
-#include <stdlib.h>
-#include <errno.h>
-#include <inttypes.h>
-#include <string.h>
+#include <cstdlib>
+#include <cerrno>
+#include <cinttypes>
+#include <cstring>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <unistd.h>

--- a/example/passthru/passthru.cc
+++ b/example/passthru/passthru.cc
@@ -32,8 +32,8 @@
  */
 
 #include <ts/ts.h>
-#include <inttypes.h>
-#include <string.h>
+#include <cinttypes>
+#include <cstring>
 
 #define PLUGIN_NAME "passthru"
 

--- a/example/protocol-stack/protocol-stack.cc
+++ b/example/protocol-stack/protocol-stack.cc
@@ -21,7 +21,7 @@
   limitations under the License.
  */
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "ts/ts.h"
 #include "ts/ink_defs.h"

--- a/example/remap/remap.cc
+++ b/example/remap/remap.cc
@@ -29,11 +29,11 @@
     # tsxs -i -o remap.so
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdarg.h>
-#include <errno.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cstdarg>
+#include <cerrno>
 #include <pwd.h>
 #include <pthread.h>
 #include <unistd.h>

--- a/example/remap_header_add/remap_header_add.cc
+++ b/example/remap_header_add/remap_header_add.cc
@@ -27,9 +27,9 @@
     map /foo http://127.0.0.1/ @plugin=remap_header_add.so @pparam=foo:"x" @pparam=@test:"c" @pparam=a:"b"
 
  */
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #include "ts/ts.h"
 #include "ts/remap.h"

--- a/example/ssl-preaccept/ssl-preaccept.cc
+++ b/example/ssl-preaccept/ssl-preaccept.cc
@@ -25,9 +25,9 @@
   limitations under the License.
  */
 
-#include <stdio.h>
+#include <cstdio>
 #include <memory.h>
-#include <inttypes.h>
+#include <cinttypes>
 #include <ts/ts.h>
 #include <tsconfig/TsValue.h>
 #include <ts/ink_inet.h>

--- a/example/ssl-sni-whitelist/ssl-sni-whitelist.cc
+++ b/example/ssl-sni-whitelist/ssl-sni-whitelist.cc
@@ -23,9 +23,9 @@
   limitations under the License.
  */
 
-#include <stdio.h>
+#include <cstdio>
 #include <memory.h>
-#include <inttypes.h>
+#include <cinttypes>
 #include <ts/ts.h>
 #include "ts/ink_config.h"
 #include <tsconfig/TsValue.h>

--- a/example/ssl-sni/ssl-sni.cc
+++ b/example/ssl-sni/ssl-sni.cc
@@ -25,9 +25,9 @@
   limitations under the License.
  */
 
-#include <stdio.h>
+#include <cstdio>
 #include <memory.h>
-#include <inttypes.h>
+#include <cinttypes>
 #include <ts/ts.h>
 #include "ts/ink_config.h"
 #include <tsconfig/TsValue.h>

--- a/example/statistic/statistic.cc
+++ b/example/statistic/statistic.cc
@@ -28,8 +28,8 @@
 // doc/developer-guide/plugins/adding-statistics.en.rst
 
 #include <ts/ts.h>
-#include <inttypes.h>
-#include <time.h>
+#include <cinttypes>
+#include <ctime>
 
 #define PLUGIN_NAME "statistics"
 

--- a/iocore/cache/CacheHttp.cc
+++ b/iocore/cache/CacheHttp.cc
@@ -22,7 +22,7 @@
  */
 
 #include "ts/ink_config.h"
-#include <string.h>
+#include <cstring>
 #include "P_Cache.h"
 
 /*-------------------------------------------------------------------------

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -32,7 +32,7 @@
 #include "ts/ink_platform.h"
 #include "ts/I_Layout.h"
 
-#include <string.h>
+#include <cstring>
 #include "P_Net.h"
 #include "P_SSLConfig.h"
 #include "P_SSLUtils.h"

--- a/lib/bindings/repl.cc
+++ b/lib/bindings/repl.cc
@@ -23,7 +23,7 @@
 
 #include "ink_autoconf.h"
 #include "bindings.h"
-#include <stdlib.h>
+#include <cstdlib>
 
 #if HAVE_READLINE_H
 #include <readline.h>

--- a/lib/cppapi/RemapPlugin.cc
+++ b/lib/cppapi/RemapPlugin.cc
@@ -22,7 +22,7 @@
 #include "atscppapi/RemapPlugin.h"
 #include "logging_internal.h"
 #include "utils_internal.h"
-#include <assert.h>
+#include <cassert>
 #include <ts/remap.h>
 
 using namespace atscppapi;

--- a/lib/cppapi/Stat.cc
+++ b/lib/cppapi/Stat.cc
@@ -21,7 +21,7 @@
 
 #include "atscppapi/Stat.h"
 #include <string>
-#include <stdint.h>
+#include <cstdint>
 #include <ts/ts.h>
 #include "logging_internal.h"
 

--- a/lib/ts/Arena.cc
+++ b/lib/ts/Arena.cc
@@ -25,8 +25,8 @@
 #include "ts/ink_memory.h"
 #include "ts/Allocator.h"
 #include "ts/Arena.h"
-#include <assert.h>
-#include <string.h>
+#include <cassert>
+#include <cstring>
 
 #define DEFAULT_ALLOC_SIZE 1024
 #define DEFAULT_BLOCK_SIZE (DEFAULT_ALLOC_SIZE - (sizeof(ArenaBlock) - 8))

--- a/lib/ts/CompileParseRules.cc
+++ b/lib/ts/CompileParseRules.cc
@@ -33,8 +33,8 @@ unsigned int tparseRulesCType[256];
 char tparseRulesCTypeToUpper[256];
 char tparseRulesCTypeToLower[256];
 
-#include <stdio.h>
-#include <ctype.h>
+#include <cstdio>
+#include <cctype>
 #include "ts/ink_string.h"
 
 static char *

--- a/lib/ts/InkErrno.cc
+++ b/lib/ts/InkErrno.cc
@@ -23,7 +23,7 @@
 
 #include "InkErrno.h"
 #include "ink_assert.h"
-#include <string.h>
+#include <cstring>
 
 const char *
 InkStrerror(int ink_errno)

--- a/lib/ts/MMH.cc
+++ b/lib/ts/MMH.cc
@@ -21,8 +21,8 @@
   limitations under the License.
  */
 
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 #include "ts/ink_assert.h"
 #include "ts/ink_platform.h"
 #include "ts/MMH.h"

--- a/lib/ts/SourceLocation.cc
+++ b/lib/ts/SourceLocation.cc
@@ -23,8 +23,8 @@
 
 #include "SourceLocation.h"
 #include "ink_defs.h"
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 // This method takes a SourceLocation source location data structure and
 // converts it to a human-readable representation, in the buffer <buf>

--- a/lib/ts/TextBuffer.cc
+++ b/lib/ts/TextBuffer.cc
@@ -21,7 +21,7 @@
   limitations under the License.
  */
 
-#include <stdarg.h>
+#include <cstdarg>
 #include "ts/ink_platform.h"
 #include "ts/ink_memory.h"
 #include "ts/TextBuffer.h"

--- a/lib/ts/Vec.cc
+++ b/lib/ts/Vec.cc
@@ -22,7 +22,7 @@
 
 /* UnionFind after Tarjan */
 
-#include <stdint.h>
+#include <cstdint>
 #include "ts/Vec.h"
 
 const uintptr_t prime2[] = {1,       3,       7,       13,       31,       61,       127,       251,       509,      1021,

--- a/lib/ts/ink_code.cc
+++ b/lib/ts/ink_code.cc
@@ -21,8 +21,8 @@
   limitations under the License.
  */
 
-#include <string.h>
-#include <stdio.h>
+#include <cstring>
+#include <cstdio>
 #include "ts/ink_code.h"
 #include "ts/INK_MD5.h"
 #include "ts/ink_assert.h"

--- a/lib/ts/ink_error.cc
+++ b/lib/ts/ink_error.cc
@@ -27,7 +27,7 @@
 #include "ts/ink_stack_trace.h"
 
 #include <syslog.h>
-#include <signal.h> /* MAGIC_EDITING_TAG */
+#include <csignal> /* MAGIC_EDITING_TAG */
 
 /**
   This routine prints/logs an error message given the printf format

--- a/lib/ts/ink_file.cc
+++ b/lib/ts/ink_file.cc
@@ -22,7 +22,7 @@
  */
 
 #include <unistd.h>
-#include <limits.h>
+#include <climits>
 #include "ts/ink_platform.h"
 #include "ts/ink_file.h"
 #include "ts/ink_string.h"

--- a/lib/ts/ink_memory.cc
+++ b/lib/ts/ink_memory.cc
@@ -31,15 +31,15 @@
 #include <malloc_np.h> // for malloc_usable_size
 #endif
 
-#include <assert.h>
+#include <cassert>
 #if defined(linux)
 // XXX: SHouldn't that be part of CPPFLAGS?
 #ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 600
 #endif
 #endif
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 
 void *
 ats_malloc(size_t size)

--- a/lib/ts/ink_mutex.cc
+++ b/lib/ts/ink_mutex.cc
@@ -23,8 +23,8 @@
 
 #include "ts/ink_error.h"
 #include "ts/ink_defs.h"
-#include <assert.h>
-#include "stdio.h"
+#include <cassert>
+#include <cstdio>
 #include "ts/ink_mutex.h"
 
 // Define the _g_mattr first to avoid static initialization order fiasco.

--- a/lib/ts/ink_queue.cc
+++ b/lib/ts/ink_queue.cc
@@ -37,9 +37,9 @@
   ****************************************************************************/
 
 #include "ts/ink_config.h"
-#include <assert.h>
+#include <cassert>
 #include <memory.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/mman.h>

--- a/lib/ts/ink_queue_utils.cc
+++ b/lib/ts/ink_queue_utils.cc
@@ -22,7 +22,7 @@
  */
 
 #include "ts/ink_config.h"
-#include <assert.h>
+#include <cassert>
 
 #include "ts/ink_atomic.h"
 #include "ts/ink_queue.h"

--- a/lib/ts/ink_res_init.cc
+++ b/lib/ts/ink_res_init.cc
@@ -77,12 +77,12 @@
 #ifdef HAVE_ARPA_NAMESER_COMPAT_H
 #include <arpa/nameser_compat.h>
 #endif
-#include <stdio.h>
-#include <ctype.h>
+#include <cstdio>
+#include <cctype>
 #include <resolv.h>
 #include <unistd.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 
 #include "ts/ink_string.h"
 #include "ts/ink_resolver.h"

--- a/lib/ts/ink_res_mkquery.cc
+++ b/lib/ts/ink_res_mkquery.cc
@@ -76,8 +76,8 @@
 #endif
 #include <netdb.h>
 #include <resolv.h>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #include "ts/ink_error.h"
 #include "ts/ink_resolver.h"

--- a/lib/ts/ink_stack_trace.cc
+++ b/lib/ts/ink_stack_trace.cc
@@ -26,8 +26,8 @@
 #include "ts/ink_args.h"
 
 #include <strings.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <unistd.h>
 
 #ifndef STDERR_FILENO
@@ -37,7 +37,7 @@
 #if TS_HAS_BACKTRACE
 
 #include <execinfo.h> /* for backtrace_symbols, etc. */
-#include <signal.h>
+#include <csignal>
 
 void
 ink_stack_trace_dump()

--- a/lib/ts/ink_string.cc
+++ b/lib/ts/ink_string.cc
@@ -24,10 +24,10 @@
 #include "ts/ink_platform.h"
 #include "ts/ink_assert.h"
 
-#include <assert.h>
-#include <stdarg.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cassert>
+#include <cstdarg>
+#include <cstdlib>
+#include <cstring>
 
 #define INK_MAX_STRING_ARRAY_SIZE 128
 

--- a/lib/ts/ink_time.cc
+++ b/lib/ts/ink_time.cc
@@ -34,7 +34,7 @@
 #include "ts/ink_assert.h"
 #include "ts/ink_string.h"
 
-#include <locale.h>
+#include <clocale>
 #include <sys/resource.h>
 
 /*===========================================================================*

--- a/lib/ts/llqueue.cc
+++ b/lib/ts/llqueue.cc
@@ -24,13 +24,13 @@
 #include "ts/ink_config.h"
 #include "ts/ink_memory.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <assert.h>
-#include <limits.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cassert>
+#include <climits>
 
 #include "ts/ink_llqueue.h"
-#include "errno.h"
+#include <cerrno>
 
 #define RECORD_CHUNK 1024
 

--- a/lib/ts/test_Map.cc
+++ b/lib/ts/test_Map.cc
@@ -20,7 +20,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-#include <stdint.h>
+#include <cstdint>
 #include "ts/Map.h"
 #include <list>
 

--- a/lib/ts/test_PriorityQueue.cc
+++ b/lib/ts/test_PriorityQueue.cc
@@ -22,7 +22,7 @@
 */
 
 #include <iostream>
-#include <string.h>
+#include <cstring>
 
 #include <ts/TestBox.h>
 

--- a/lib/ts/test_Vec.cc
+++ b/lib/ts/test_Vec.cc
@@ -22,8 +22,8 @@
 
 /* UnionFind after Tarjan */
 
-#include <stdint.h>
-#include <stdio.h>
+#include <cstdint>
+#include <cstdio>
 #include "ts/ink_assert.h"
 #include "ts/Vec.h"
 

--- a/lib/ts/test_arena.cc
+++ b/lib/ts/test_arena.cc
@@ -34,7 +34,7 @@
  ****************************************************************************/
 
 #include "ts/Arena.h"
-#include <stdio.h>
+#include <cstdio>
 
 void
 fill_test_data(char *ptr, int size, int seed)

--- a/lib/ts/test_atomic.cc
+++ b/lib/ts/test_atomic.cc
@@ -22,8 +22,8 @@
  */
 
 #include <unistd.h>
-#include <stdlib.h>
-#include <time.h>
+#include <cstdlib>
+#include <ctime>
 #include <poll.h>
 #include <pthread.h>
 

--- a/lib/ts/test_freelist.cc
+++ b/lib/ts/test_freelist.cc
@@ -21,8 +21,8 @@
   limitations under the License.
  */
 
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 #include "ts/ink_thread.h"
 #include "ts/ink_queue.h"
 

--- a/lib/tsconfig/TsBuilder.cc
+++ b/lib/tsconfig/TsBuilder.cc
@@ -25,7 +25,7 @@
 # include "TsErrataUtil.h"
 # include "TsConfigLexer.h"
 # include "TsConfigGrammar.hpp"
-# include <stdlib.h>
+# include <cstdlib>
 
 // Prefix for text of our messages.
 # define PRE "Configuration Parser: "

--- a/lib/tsconfig/TsErrataUtil.cc
+++ b/lib/tsconfig/TsErrataUtil.cc
@@ -22,11 +22,11 @@
  */
 
 # if !defined(_MSC_VER)
-# include <stdio.h>
-# include <string.h>
+# include <cstdio>
+# include <cstring>
 # endif
-# include <stdarg.h>
-# include <errno.h>
+# include <cstdarg>
+# include <cerrno>
 # include <TsErrataUtil.h>
 # include "ts/ink_string.h"
 # include "ts/ink_defs.h"

--- a/lib/tsconfig/TsValue.cc
+++ b/lib/tsconfig/TsValue.cc
@@ -27,8 +27,8 @@
 
 # include <TsErrataUtil.h>
 # include <sys/stat.h>
-# include <stdio.h>
-# include <stdlib.h>
+# include <cstdio>
+# include <cstdlib>
 
 # if !defined(_MSC_VER)
 # define _fileno fileno

--- a/lib/tsconfig/test-tsconfig.cc
+++ b/lib/tsconfig/test-tsconfig.cc
@@ -19,7 +19,7 @@
 */
 
 # include "tsconfig/TsValue.h"
-# include <stdio.h>
+# include <cstdio>
 # include <iostream>
 
 using ts::config::Configuration;

--- a/mgmt/api/APITestCliRemote.cc
+++ b/mgmt/api/APITestCliRemote.cc
@@ -95,9 +95,9 @@
 
 #include "ts/ink_config.h"
 #include "ts/ink_defs.h"
-#include <stdlib.h>
-#include <string.h>
-#include <stdio.h>
+#include <cstdlib>
+#include <cstring>
+#include <cstdio>
 #include <strings.h>
 #include "ts/ink_string.h"
 

--- a/mgmt/api/INKMgmtAPI.cc
+++ b/mgmt/api/INKMgmtAPI.cc
@@ -32,7 +32,7 @@
 #include "ts/ink_platform.h"
 #include "ts/ink_code.h"
 #include "ts/ParseRules.h"
-#include <limits.h>
+#include <climits>
 #include "ts/I_Layout.h"
 
 #include "mgmtapi.h"

--- a/plugins/background_fetch/background_fetch.cc
+++ b/plugins/background_fetch/background_fetch.cc
@@ -21,10 +21,10 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdarg.h>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+#include <cstdarg>
 #include <getopt.h>
 
 #include <string>

--- a/plugins/background_fetch/headers.cc
+++ b/plugins/background_fetch/headers.cc
@@ -21,7 +21,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-#include <stdlib.h>
+#include <cstdlib>
 
 #include "configs.h"
 #include "headers.h"

--- a/plugins/background_fetch/rules.cc
+++ b/plugins/background_fetch/rules.cc
@@ -22,7 +22,7 @@
     limitations under the License.
 */
 
-#include <stdlib.h>
+#include <cstdlib>
 
 #include "configs.h"
 #include "rules.h"

--- a/plugins/conf_remap/conf_remap.cc
+++ b/plugins/conf_remap/conf_remap.cc
@@ -20,10 +20,10 @@
 #include "ts/remap.h"
 #include "ts/ink_defs.h"
 
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstring>
+#include <cctype>
+#include <cstdlib>
 #include <string>
 
 static const char PLUGIN_NAME[] = "conf_remap";

--- a/plugins/esi/combo_handler.cc
+++ b/plugins/esi/combo_handler.cc
@@ -26,7 +26,7 @@
 #include <sstream>
 #include <vector>
 #include <algorithm>
-#include <time.h>
+#include <ctime>
 #include <pthread.h>
 #include <arpa/inet.h>
 

--- a/plugins/esi/esi.cc
+++ b/plugins/esi/esi.cc
@@ -23,10 +23,10 @@
 
 #include "ts/ink_defs.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <limits.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <climits>
+#include <cstring>
 #include <string>
 #include <list>
 #include <arpa/inet.h>

--- a/plugins/esi/fetcher/HttpDataFetcherImpl.cc
+++ b/plugins/esi/fetcher/HttpDataFetcherImpl.cc
@@ -26,7 +26,7 @@
 #include "lib/gzip.h"
 
 #include <arpa/inet.h>
-#include <stdlib.h>
+#include <cstdlib>
 
 using std::string;
 using namespace EsiLib;

--- a/plugins/esi/lib/EsiGunzip.cc
+++ b/plugins/esi/lib/EsiGunzip.cc
@@ -23,8 +23,8 @@
 
 #include "EsiGunzip.h"
 #include "gzip.h"
-#include <ctype.h>
-#include <stdint.h>
+#include <cctype>
+#include <cstdint>
 
 using std::string;
 using namespace EsiLib;

--- a/plugins/esi/lib/EsiGzip.cc
+++ b/plugins/esi/lib/EsiGzip.cc
@@ -23,8 +23,8 @@
 
 #include "EsiGzip.h"
 #include "gzip.h"
-#include <ctype.h>
-#include <stdint.h>
+#include <cctype>
+#include <cstdint>
 
 using std::string;
 using namespace EsiLib;

--- a/plugins/esi/lib/EsiParser.cc
+++ b/plugins/esi/lib/EsiParser.cc
@@ -24,7 +24,7 @@
 #include "EsiParser.h"
 #include "Utils.h"
 
-#include <ctype.h>
+#include <cctype>
 
 using std::string;
 using namespace EsiLib;

--- a/plugins/esi/lib/EsiProcessor.cc
+++ b/plugins/esi/lib/EsiProcessor.cc
@@ -24,7 +24,7 @@
 #include "EsiProcessor.h"
 #include "Stats.h"
 #include "FailureInfo.h"
-#include <ctype.h>
+#include <cctype>
 
 using std::string;
 using namespace EsiLib;

--- a/plugins/esi/lib/Variables.cc
+++ b/plugins/esi/lib/Variables.cc
@@ -25,7 +25,7 @@
 #include "Attribute.h"
 #include "Utils.h"
 
-#include <errno.h>
+#include <cerrno>
 
 using std::list;
 using std::pair;

--- a/plugins/esi/lib/gzip.cc
+++ b/plugins/esi/lib/gzip.cc
@@ -21,7 +21,7 @@
   limitations under the License.
  */
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "gzip.h"
 #include <zlib.h>

--- a/plugins/esi/serverIntercept.cc
+++ b/plugins/esi/serverIntercept.cc
@@ -25,9 +25,9 @@
 #include "serverIntercept.h"
 
 #include <string>
-#include <limits.h>
+#include <climits>
 #include <strings.h>
-#include <stdio.h>
+#include <cstdio>
 
 const char *ECHO_HEADER_PREFIX        = "Echo-";
 const int ECHO_HEADER_PREFIX_LEN      = 5;

--- a/plugins/esi/test/StubIncludeHandler.cc
+++ b/plugins/esi/test/StubIncludeHandler.cc
@@ -20,7 +20,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-#include <stdio.h>
+#include <cstdio>
 #include "StubIncludeHandler.h"
 #include "TestHttpDataFetcher.h"
 

--- a/plugins/esi/test/docnode_test.cc
+++ b/plugins/esi/test/docnode_test.cc
@@ -22,7 +22,7 @@
  */
 
 #include <iostream>
-#include <assert.h>
+#include <cassert>
 #include <string>
 
 #include "EsiParser.h"

--- a/plugins/esi/test/gzip_test.cc
+++ b/plugins/esi/test/gzip_test.cc
@@ -22,9 +22,9 @@
  */
 
 #include <iostream>
-#include <assert.h>
+#include <cassert>
 #include <string>
-#include <string.h>
+#include <cstring>
 
 #include "print_funcs.h"
 #include "Utils.h"

--- a/plugins/esi/test/parser_test.cc
+++ b/plugins/esi/test/parser_test.cc
@@ -22,7 +22,7 @@
  */
 
 #include <iostream>
-#include <assert.h>
+#include <cassert>
 #include <string>
 
 #include "EsiParser.h"

--- a/plugins/esi/test/print_funcs.cc
+++ b/plugins/esi/test/print_funcs.cc
@@ -21,8 +21,8 @@
   limitations under the License.
  */
 
-#include <stdio.h>
-#include <stdarg.h>
+#include <cstdio>
+#include <cstdarg>
 
 #include "print_funcs.h"
 

--- a/plugins/esi/test/processor_test.cc
+++ b/plugins/esi/test/processor_test.cc
@@ -22,7 +22,7 @@
  */
 
 #include <iostream>
-#include <assert.h>
+#include <cassert>
 #include <string>
 
 #include "EsiProcessor.h"

--- a/plugins/esi/test/utils_test.cc
+++ b/plugins/esi/test/utils_test.cc
@@ -22,7 +22,7 @@
  */
 
 #include <iostream>
-#include <assert.h>
+#include <cassert>
 #include <string>
 
 #include "print_funcs.h"

--- a/plugins/esi/test/vars_test.cc
+++ b/plugins/esi/test/vars_test.cc
@@ -20,11 +20,11 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
-#include <assert.h>
+#include <cassert>
 #include <string>
-#include <stdarg.h>
+#include <cstdarg>
 
 #include "print_funcs.h"
 #include "Variables.h"

--- a/plugins/experimental/balancer/balancer.cc
+++ b/plugins/experimental/balancer/balancer.cc
@@ -23,10 +23,10 @@
 
 #include "balancer.h"
 #include <ts/remap.h>
-#include <stdio.h>
+#include <cstdio>
 #include <getopt.h>
-#include <string.h>
-#include <stdlib.h>
+#include <cstring>
+#include <cstdlib>
 #include <iterator>
 
 // Using ink_inet API is cheating, but I was too lazy to write new IPv6 address parsing routines ;)

--- a/plugins/experimental/balancer/hash.cc
+++ b/plugins/experimental/balancer/hash.cc
@@ -22,10 +22,10 @@
  */
 
 #include "balancer.h"
-#include <stdlib.h>
+#include <cstdlib>
 #include <openssl/md5.h>
 #include <netinet/in.h>
-#include <string.h>
+#include <cstring>
 #include <map>
 #include <string>
 #include <vector>

--- a/plugins/experimental/balancer/roundrobin.cc
+++ b/plugins/experimental/balancer/roundrobin.cc
@@ -22,8 +22,8 @@
  */
 
 #include "balancer.h"
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 #include <map>
 #include <string>
 #include <vector>

--- a/plugins/experimental/buffer_upload/buffer_upload.cc
+++ b/plugins/experimental/buffer_upload/buffer_upload.cc
@@ -27,19 +27,19 @@
  *
  */
 
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-#include <limits.h>
+#include <cstdio>
+#include <cstring>
+#include <cctype>
+#include <climits>
 #include <ts/ts.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <errno.h>
+#include <cerrno>
 #include <dirent.h>
 #include <unistd.h>
-#include <stdlib.h>
-#include <inttypes.h>
+#include <cstdlib>
+#include <cinttypes>
 
 /* #define DEBUG 1 */
 #define DEBUG_TAG "buffer_upload-dbg"

--- a/plugins/experimental/cache_promote/cache_promote.cc
+++ b/plugins/experimental/cache_promote/cache_promote.cc
@@ -16,12 +16,12 @@
   limitations under the License.
 */
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include <unistd.h>
 #include <getopt.h>
-#include <stdlib.h>
-#include <time.h>
+#include <cstdlib>
+#include <ctime>
 #include <openssl/sha.h>
 
 #include <string>

--- a/plugins/experimental/cache_range_requests/cache_range_requests.cc
+++ b/plugins/experimental/cache_range_requests/cache_range_requests.cc
@@ -26,8 +26,8 @@
  * requests.
  */
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include "ts/ts.h"
 #include "ts/remap.h"
 

--- a/plugins/experimental/cachekey/cachekey.cc
+++ b/plugins/experimental/cachekey/cachekey.cc
@@ -21,8 +21,8 @@
  * @brief Cache key manipulation.
  */
 
-#include <string.h> /* strlen() */
-#include <sstream>  /* istringstream */
+#include <cstring> /* strlen() */
+#include <sstream> /* istringstream */
 #include "cachekey.h"
 
 static void

--- a/plugins/experimental/collapsed_connection/collapsed_connection.cc
+++ b/plugins/experimental/collapsed_connection/collapsed_connection.cc
@@ -21,16 +21,16 @@
   limitations under the License.
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <ctype.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cctype>
 
 #include <ts/ts.h>
 #include <ts/remap.h>
 #include <ts/experimental.h>
 #include "MurmurHash3.h"
-#include <inttypes.h>
+#include <cinttypes>
 
 #include "P_collapsed_connection.h"
 

--- a/plugins/experimental/collapsed_forwarding/collapsed_forwarding.cc
+++ b/plugins/experimental/collapsed_forwarding/collapsed_forwarding.cc
@@ -56,11 +56,11 @@
 #include <ts/remap.h>
 #include <set>
 #include <string>
-#include <string.h>
-#include <stdlib.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdarg.h>
+#include <cstring>
+#include <cstdlib>
+#include <cstdint>
+#include <cstdio>
+#include <cstdarg>
 #include <getopt.h>
 #include <netdb.h>
 #include <map>

--- a/plugins/experimental/custom_redirect/custom_redirect.cc
+++ b/plugins/experimental/custom_redirect/custom_redirect.cc
@@ -24,15 +24,15 @@
 /* custom_redirect.cc: Allows read header set by origin for internal redirects
  */
 
-#include <stdio.h>
+#include <cstdio>
 #include <string>
 #include <iostream>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <ts/ts.h>
-#include <string.h>
-#include <stdlib.h>
+#include <cstring>
+#include <cstdlib>
 
 static char *redirect_url_header   = nullptr;
 static int redirect_url_header_len = 0;

--- a/plugins/experimental/epic/epic.cc
+++ b/plugins/experimental/epic/epic.cc
@@ -17,16 +17,16 @@
  */
 
 #include <ts/ts.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <limits.h>
-#include <time.h>
+#include <cstdio>
+#include <cstdlib>
+#include <climits>
+#include <ctime>
 #include <getopt.h>
-#include <errno.h>
-#include <string.h>
+#include <cerrno>
+#include <cstring>
 #include <unistd.h>
 #include <sys/param.h>
-#include <inttypes.h>
+#include <cinttypes>
 #include <set>
 #include <string>
 

--- a/plugins/experimental/escalate/escalate.cc
+++ b/plugins/experimental/escalate/escalate.cc
@@ -23,10 +23,10 @@
 #include <ts/ts.h>
 #include <ts/remap.h>
 #include <ts/experimental.h>
-#include <stdlib.h>
-#include <stdio.h>
+#include <cstdlib>
+#include <cstdio>
 #include <getopt.h>
-#include <string.h>
+#include <cstring>
 #include <string>
 #include <iterator>
 #include <map>

--- a/plugins/experimental/geoip_acl/geoip_acl.cc
+++ b/plugins/experimental/geoip_acl/geoip_acl.cc
@@ -22,8 +22,8 @@
 //
 #include <ts/ts.h>
 #include <ts/remap.h>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #include "lulu.h"
 #include "acl.h"

--- a/plugins/experimental/header_freq/header_freq.cc
+++ b/plugins/experimental/header_freq/header_freq.cc
@@ -25,8 +25,8 @@
 #include <iostream>
 #include <map>
 #include <fstream>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 #include <string>
 #include <ts/ts.h>
 

--- a/plugins/experimental/header_normalize/header_normalize.cc
+++ b/plugins/experimental/header_normalize/header_normalize.cc
@@ -45,10 +45,10 @@ static char UNUSED rcsId__header_normalize_cc[] =
 #include <ts/remap.h>
 #include <set>
 #include <string>
-#include <string.h>
-#include <stdlib.h>
-#include <stdint.h>
-#include <stdio.h>
+#include <cstring>
+#include <cstdlib>
+#include <cstdint>
+#include <cstdio>
 #include <netdb.h>
 #include <map>
 

--- a/plugins/experimental/hipes/hipes.cc
+++ b/plugins/experimental/hipes/hipes.cc
@@ -18,10 +18,10 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-#include <stdio.h>
+#include <cstdio>
 #include <sys/time.h>
-#include <string.h>
-#include <stdlib.h>
+#include <cstring>
+#include <cstdlib>
 #include <string>
 
 #include <ts/ts.h>

--- a/plugins/experimental/inliner/ats-inliner.cc
+++ b/plugins/experimental/inliner/ats-inliner.cc
@@ -20,12 +20,12 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-#include <assert.h>
+#include <cassert>
 #include <cstring>
 #include <dlfcn.h>
-#include <inttypes.h>
+#include <cinttypes>
 #include <limits>
-#include <stdio.h>
+#include <cstdio>
 #include <unistd.h>
 
 #include "inliner-handler.h"

--- a/plugins/experimental/inliner/chunk-decoder.cc
+++ b/plugins/experimental/inliner/chunk-decoder.cc
@@ -41,7 +41,7 @@
   limitations under the License.
  */
 #include <algorithm>
-#include <assert.h>
+#include <cassert>
 #include <cstring>
 
 #include "chunk-decoder.h"

--- a/plugins/experimental/inliner/html-parser.cc
+++ b/plugins/experimental/inliner/html-parser.cc
@@ -21,7 +21,7 @@
   limitations under the License.
  */
 
-#include <assert.h>
+#include <cassert>
 #include <locale>
 #include <string>
 

--- a/plugins/experimental/inliner/inliner-handler.cc
+++ b/plugins/experimental/inliner/inliner-handler.cc
@@ -20,7 +20,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-#include <assert.h>
+#include <cassert>
 #include <iostream>
 #include <sstream>
 

--- a/plugins/experimental/memcached_remap/memcached_remap.cc
+++ b/plugins/experimental/memcached_remap/memcached_remap.cc
@@ -18,8 +18,8 @@
 
 #include <ts/ts.h>
 #include <ts/remap.h>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include <unistd.h>
 
 // change this on your box

--- a/plugins/experimental/money_trace/money_trace.cc
+++ b/plugins/experimental/money_trace/money_trace.cc
@@ -19,8 +19,8 @@
 
 #include <iostream>
 #include <sstream>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include "ts/ts.h"
 #include "ts/remap.h"
 

--- a/plugins/experimental/multiplexer/ats-multiplexer.cc
+++ b/plugins/experimental/multiplexer/ats-multiplexer.cc
@@ -24,7 +24,7 @@
 #include <ts/ts.h>
 #include <ts/remap.h>
 
-#include <inttypes.h>
+#include <cinttypes>
 
 #include "dispatch.h"
 #include "fetcher.h"

--- a/plugins/experimental/multiplexer/chunk-decoder.cc
+++ b/plugins/experimental/multiplexer/chunk-decoder.cc
@@ -21,7 +21,7 @@
   limitations under the License.
  */
 #include <algorithm>
-#include <assert.h>
+#include <cassert>
 
 #include "chunk-decoder.h"
 

--- a/plugins/experimental/multiplexer/dispatch.cc
+++ b/plugins/experimental/multiplexer/dispatch.cc
@@ -20,7 +20,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-#include <inttypes.h>
+#include <cinttypes>
 #include <sys/time.h>
 
 #include "dispatch.h"

--- a/plugins/experimental/multiplexer/post.cc
+++ b/plugins/experimental/multiplexer/post.cc
@@ -20,7 +20,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-#include <assert.h>
+#include <cassert>
 #include <limits>
 
 #include "post.h"

--- a/plugins/experimental/mysql_remap/mysql_remap.cc
+++ b/plugins/experimental/mysql_remap/mysql_remap.cc
@@ -18,7 +18,7 @@
 
 #include <ts/ts.h>
 #include <ts/remap.h>
-#include <stdio.h>
+#include <cstdio>
 #include <unistd.h>
 
 #include "mysql/mysql.h"

--- a/plugins/experimental/ssl_cert_loader/domain-tree.cc
+++ b/plugins/experimental/ssl_cert_loader/domain-tree.cc
@@ -20,9 +20,9 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-#include <stdio.h>
+#include <cstdio>
 #include <memory.h>
-#include <inttypes.h>
+#include <cinttypes>
 #include "domain-tree.h"
 
 // return true if comparable.  Return type of compare in relative parameter

--- a/plugins/experimental/ssl_cert_loader/ssl-cert-loader.cc
+++ b/plugins/experimental/ssl_cert_loader/ssl-cert-loader.cc
@@ -22,9 +22,9 @@
     limitations under the License.
 */
 
-#include <stdio.h>
+#include <cstdio>
 #include <memory.h>
-#include <inttypes.h>
+#include <cinttypes>
 #include <ts/ts.h>
 #include <tsconfig/TsValue.h>
 #include <openssl/ssl.h>

--- a/plugins/experimental/sslheaders/test_sslheaders.cc
+++ b/plugins/experimental/sslheaders/test_sslheaders.cc
@@ -18,8 +18,8 @@
 
 #include "sslheaders.h"
 #include <ts/TestBox.h>
-#include <stdio.h>
-#include <stdarg.h>
+#include <cstdio>
+#include <cstdarg>
 #include <openssl/ssl.h>
 #include <openssl/bio.h>
 #include <openssl/pem.h>

--- a/plugins/experimental/stream_editor/stream_editor.cc
+++ b/plugins/experimental/stream_editor/stream_editor.cc
@@ -88,16 +88,16 @@
 #define MAX_RX_MATCH 10
 #define WHITESPACE " \t\r\n"
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <vector>
 #include <set>
 #include <regex.h>
-#include <ctype.h>
-#include <assert.h>
-#include <string.h>
+#include <cctype>
+#include <cassert>
+#include <cstring>
 #include <string>
-#include <stdio.h>
+#include <cstdio>
 #include "ts/ts.h"
 
 struct edit_t;

--- a/plugins/generator/generator.cc
+++ b/plugins/generator/generator.cc
@@ -23,13 +23,13 @@
 
 #include <ts/ts.h>
 #include <ts/remap.h>
-#include <errno.h>
-#include <inttypes.h>
+#include <cerrno>
+#include <cinttypes>
 #include <iterator>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <time.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
 #include <unistd.h>
 
 // Generator plugin

--- a/plugins/gzip/gzip.cc
+++ b/plugins/gzip/gzip.cc
@@ -21,7 +21,7 @@
   limitations under the License.
  */
 
-#include <string.h>
+#include <cstring>
 #include <zlib.h>
 
 #if HAVE_BROTLI_ENCODE_H

--- a/plugins/gzip/misc.cc
+++ b/plugins/gzip/misc.cc
@@ -25,8 +25,8 @@
 #include "ts/ink_defs.h"
 
 #include "misc.h"
-#include <string.h>
-#include <inttypes.h>
+#include <cstring>
+#include <cinttypes>
 #include "debug_macros.h"
 
 voidpf

--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -22,7 +22,7 @@
 #include <sys/time.h>
 #include <unistd.h>
 #include <arpa/inet.h>
-#include <ctype.h>
+#include <cctype>
 #include <sstream>
 
 #include "ts/ts.h"

--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -20,7 +20,7 @@
 //
 //
 #include <arpa/inet.h>
-#include <string.h>
+#include <cstring>
 
 #include "ts/ts.h"
 

--- a/plugins/regex_remap/regex_remap.cc
+++ b/plugins/regex_remap/regex_remap.cc
@@ -24,17 +24,17 @@
 #include "ts/remap.h"
 
 #include <sys/types.h>
-#include <stdio.h>
-#include <time.h>
-#include <string.h>
+#include <cstdio>
+#include <ctime>
+#include <cstring>
 
-#include <ctype.h>
+#include <cctype>
 #include <unistd.h>
 
 #include <iostream>
 #include <fstream>
 #include <string>
-#include <ctype.h>
+#include <cctype>
 
 // Get some specific stuff from libts, yes, we can do that now that we build inside the core.
 #include "ts/ink_platform.h"

--- a/plugins/s3_auth/s3_auth.cc
+++ b/plugins/s3_auth/s3_auth.cc
@@ -20,13 +20,13 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-#include <time.h>
-#include <string.h>
+#include <ctime>
+#include <cstring>
 #include <getopt.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <limits.h>
-#include <ctype.h>
+#include <cstdio>
+#include <cstdlib>
+#include <climits>
+#include <cctype>
 #include <sys/time.h>
 
 #include <fstream> /* std::ifstream */

--- a/plugins/tcpinfo/tcpinfo.cc
+++ b/plugins/tcpinfo/tcpinfo.cc
@@ -21,8 +21,8 @@
   limitations under the License.
  */
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <ts/ts.h>
 #include <unistd.h>
 #include <netinet/in.h>
@@ -31,9 +31,9 @@
 #include <sys/stat.h>
 #include <getopt.h>
 #include <fcntl.h>
-#include <limits.h>
-#include <string.h>
-#include <errno.h>
+#include <climits>
+#include <cstring>
+#include <cerrno>
 #include <sys/time.h>
 #include <arpa/inet.h>
 

--- a/plugins/xdebug/xdebug.cc
+++ b/plugins/xdebug/xdebug.cc
@@ -16,10 +16,10 @@
  * limitations under the License.
  */
 
-#include <stdlib.h>
-#include <stdio.h>
+#include <cstdlib>
+#include <cstdio>
 #include <strings.h>
-#include <string.h>
+#include <cstring>
 #include <getopt.h>
 
 #include "ts/ts.h"

--- a/proxy/AbstractBuffer.cc
+++ b/proxy/AbstractBuffer.cc
@@ -22,8 +22,8 @@
  */
 
 #include "ts/ink_config.h"
-#include <assert.h>
-#include <string.h>
+#include <cassert>
+#include <cstring>
 #include "AbstractBuffer.h"
 /* #include "CacheAtomic.h" */
 #include "ts/ink_align.h"

--- a/proxy/EventName.cc
+++ b/proxy/EventName.cc
@@ -22,8 +22,8 @@
  */
 
 #include "ts/ink_config.h"
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #include "P_EventSystem.h"
 // #include "I_Disk.h" unused

--- a/proxy/FetchSM.cc
+++ b/proxy/FetchSM.cc
@@ -23,7 +23,7 @@
 
 #include "ts/ink_config.h"
 #include "FetchSM.h"
-#include <stdio.h>
+#include <cstdio>
 #include "HTTP.h"
 #include "PluginVC.h"
 

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -21,7 +21,7 @@
   limitations under the License.
  */
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "ts/ink_platform.h"
 #include "ts/ink_base64.h"

--- a/proxy/InkAPITest.cc
+++ b/proxy/InkAPITest.cc
@@ -32,13 +32,13 @@
 #include "ts/ink_file.h"
 #include <sys/types.h>
 
-#include <errno.h>
+#include <cerrno>
 // extern int errno;
 
 #include <pthread.h>
 #include <unistd.h>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #include "ts/Regression.h"
 #include "api/ts/ts.h"

--- a/proxy/Plugin.cc
+++ b/proxy/Plugin.cc
@@ -21,7 +21,7 @@
   limitations under the License.
  */
 
-#include <stdio.h>
+#include <cstdio>
 #include "ts/ink_platform.h"
 #include "ts/ink_file.h"
 #include "ts/ParseRules.h"

--- a/proxy/hdrs/HTTP.cc
+++ b/proxy/hdrs/HTTP.cc
@@ -24,9 +24,9 @@
 #include "ts/ink_defs.h"
 #include "ts/ink_platform.h"
 #include "ts/ink_inet.h"
-#include <assert.h>
-#include <stdio.h>
-#include <string.h>
+#include <cassert>
+#include <cstdio>
+#include <cstring>
 #include "HTTP.h"
 #include "HdrToken.h"
 #include "ts/Diags.h"

--- a/proxy/hdrs/HdrToken.cc
+++ b/proxy/hdrs/HdrToken.cc
@@ -25,7 +25,7 @@
 #include "ts/HashFNV.h"
 #include "ts/Diags.h"
 #include "ts/ink_memory.h"
-#include <stdio.h>
+#include <cstdio>
 #include "ts/Allocator.h"
 #include "HTTP.h"
 #include "HdrToken.h"

--- a/proxy/hdrs/MIME.cc
+++ b/proxy/hdrs/MIME.cc
@@ -25,9 +25,9 @@
 #include "ts/ink_platform.h"
 #include "ts/ink_memory.h"
 #include "ts/TsBuffer.h"
-#include <assert.h>
-#include <stdio.h>
-#include <string.h>
+#include <cassert>
+#include <cstdio>
+#include <cstring>
 #include "MIME.h"
 #include "HdrHeap.h"
 #include "HdrToken.h"

--- a/proxy/hdrs/URL.cc
+++ b/proxy/hdrs/URL.cc
@@ -21,7 +21,7 @@
   limitations under the License.
  */
 
-#include <assert.h>
+#include <cassert>
 #include <new>
 #include "ts/ink_platform.h"
 #include "ts/ink_memory.h"

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -22,8 +22,8 @@
  */
 
 #include "ts/ink_config.h"
-#include <ctype.h>
-#include <string.h>
+#include <cctype>
+#include <cstring>
 #include "HttpConfig.h"
 #include "HTTP.h"
 #include "ProcessManager.h"

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -24,14 +24,14 @@
 #include "ts/ink_platform.h"
 
 #include <strings.h>
-#include <math.h>
+#include <cmath>
 
 #include "HttpTransact.h"
 #include "HttpTransactHeaders.h"
 #include "HttpSM.h"
 #include "HttpCacheSM.h" //Added to get the scope of HttpCacheSM object - YTS Team, yamsat
 #include "HttpDebugNames.h"
-#include "time.h"
+#include <ctime>
 #include "ts/ParseRules.h"
 #include "HTTP.h"
 #include "HdrUtils.h"

--- a/proxy/http/HttpTransactCache.cc
+++ b/proxy/http/HttpTransactCache.cc
@@ -26,7 +26,7 @@
 #include "HttpTransact.h"
 #include "HttpTransactHeaders.h"
 #include "HttpTransactCache.h"
-#include "time.h"
+#include <ctime>
 #include "HTTP.h"
 #include "HttpCompat.h"
 #include "ts/InkErrno.h"

--- a/proxy/http2/test_Http2DependencyTree.cc
+++ b/proxy/http2/test_Http2DependencyTree.cc
@@ -22,7 +22,7 @@
 */
 
 #include <iostream>
-#include <string.h>
+#include <cstring>
 #include <sstream>
 
 #include "ts/TestBox.h"

--- a/proxy/http2/test_Huffmancode.cc
+++ b/proxy/http2/test_Huffmancode.cc
@@ -22,10 +22,10 @@
 */
 
 #include "HuffmanCodec.h"
-#include <stdlib.h>
+#include <cstdlib>
 #include <iostream>
-#include <assert.h>
-#include <string.h>
+#include <cassert>
+#include <cstring>
 
 using namespace std;
 

--- a/proxy/logging/LogBuffer.cc
+++ b/proxy/logging/LogBuffer.cc
@@ -27,9 +27,9 @@
  */
 #include "ts/ink_platform.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #include "P_EventSystem.h"
 #include "LogField.h"

--- a/proxy/logging/LogCollationClientSM.cc
+++ b/proxy/logging/LogCollationClientSM.cc
@@ -27,10 +27,10 @@
 
 #include "ts/ink_platform.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <limits.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <climits>
+#include <cstring>
 #include <sys/types.h>
 
 #include "P_EventSystem.h"

--- a/proxy/logging/LogCollationHostSM.cc
+++ b/proxy/logging/LogCollationHostSM.cc
@@ -27,10 +27,10 @@
 
 #include "ts/ink_config.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <limits.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <climits>
+#include <cstring>
 #include <sys/types.h>
 
 #include "P_EventSystem.h"

--- a/proxy/logging/LogFile.cc
+++ b/proxy/logging/LogFile.cc
@@ -31,7 +31,7 @@
 #include "ts/SimpleTokenizer.h"
 #include "ts/ink_file.h"
 
-#include <errno.h>
+#include <cerrno>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>

--- a/proxy/logging/LogFormat.cc
+++ b/proxy/logging/LogFormat.cc
@@ -28,9 +28,9 @@
  ***************************************************************************/
 #include "ts/ink_config.h"
 
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
 
 #include "ts/INK_MD5.h"
 

--- a/proxy/logging/LogUtils.cc
+++ b/proxy/logging/LogUtils.cc
@@ -24,12 +24,12 @@
 #include "ts/ink_config.h"
 #include "ts/ink_string.h"
 
-#include <assert.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <time.h>
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstdarg>
+#include <cstring>
+#include <ctime>
 
 #include <sys/time.h>
 #include <sys/types.h>


### PR DESCRIPTION
Running clang-tidy against the 7.1.x branch