### PR TITLE
Ran clang-tidy with modernize-redundant-void-arg

### DIFF
--- a/cmd/traffic_cop/traffic_cop.cc
+++ b/cmd/traffic_cop/traffic_cop.cc
@@ -146,7 +146,7 @@ static const char localhost[] = "127.0.0.1";
 
 static void cop_log(int priority, const char *format, ...) TS_PRINTFLIKE(2, 3);
 
-static void get_admin_user(void);
+static void get_admin_user();
 
 struct ConfigValue {
   ConfigValue() : config_type(RECT_NULL), data_type(RECD_NULL) {}
@@ -375,7 +375,7 @@ set_alarm_warn()
 }
 
 static void
-process_syslog_config(void)
+process_syslog_config()
 {
   int new_fac;
 
@@ -421,7 +421,7 @@ safe_kill(const char *lockfile_name, const char *pname, bool group)
 // one 64bit int
 //
 static ink_hrtime
-milliseconds(void)
+milliseconds()
 {
   struct timeval now;
 

--- a/iocore/aio/AIO.cc
+++ b/iocore/aio/AIO.cc
@@ -131,7 +131,7 @@ AIOTestData::ink_aio_stats(int event, void *d)
  * Common
  */
 AIOCallback *
-new_AIOCallback(void)
+new_AIOCallback()
 {
   return new AIOCallbackInternal;
 }

--- a/iocore/aio/test_AIO.cc
+++ b/iocore/aio/test_AIO.cc
@@ -149,7 +149,7 @@ struct AIO_Device : public Continuation {
 };
 
 void
-dump_summary(void)
+dump_summary()
 {
   /* dump timing info */
   printf("Writing summary info\n");

--- a/iocore/cache/CacheDir.cc
+++ b/iocore/cache/CacheDir.cc
@@ -890,7 +890,7 @@ dir_entries_used(Vol *d)
  */
 
 void
-sync_cache_dir_on_shutdown(void)
+sync_cache_dir_on_shutdown()
 {
   Debug("cache_dir_sync", "sync started");
   char *buf     = nullptr;

--- a/iocore/cluster/ClusterProcessor.cc
+++ b/iocore/cluster/ClusterProcessor.cc
@@ -645,7 +645,7 @@ ClusterProcessor::init()
 
 // function added to adhere to the name calling convention of init functions
 int
-init_clusterprocessor(void)
+init_clusterprocessor()
 {
   return clusterProcessor.init();
 }

--- a/iocore/net/Connection.cc
+++ b/iocore/net/Connection.cc
@@ -40,7 +40,7 @@
 #define ROUNDUP(x, y) ((((x) + ((y)-1)) / (y)) * (y))
 
 int
-get_listen_backlog(void)
+get_listen_backlog()
 {
   int listen_backlog;
 

--- a/iocore/net/Net.cc
+++ b/iocore/net/Net.cc
@@ -41,7 +41,7 @@ int net_retry_delay         = 10;
 int net_throttle_delay      = 50; /* milliseconds */
 
 static inline void
-configure_net(void)
+configure_net()
 {
   REC_RegisterConfigUpdateFunc("proxy.config.net.connections_throttle", change_net_connections_throttle, nullptr);
   REC_ReadConfigInteger(fds_throttle, "proxy.config.net.connections_throttle");

--- a/iocore/net/OCSPStapling.cc
+++ b/iocore/net/OCSPStapling.cc
@@ -63,7 +63,7 @@ certinfo_free(void * /*parent*/, void *ptr, CRYPTO_EX_DATA * /*ad*/, int /*idx*/
 static int ssl_stapling_index = -1;
 
 void
-ssl_stapling_ex_init(void)
+ssl_stapling_ex_init()
 {
   if (ssl_stapling_index != -1)
     return;

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -432,7 +432,7 @@ SSLConfigParams::deleteKey(cchar *key) const
 }
 
 SSL_CTX *
-SSLConfigParams::getClientSSL_CTX(void) const
+SSLConfigParams::getClientSSL_CTX() const
 {
   return client_ctx;
 }

--- a/iocore/net/SSLNetProcessor.cc
+++ b/iocore/net/SSLNetProcessor.cc
@@ -49,7 +49,7 @@ struct OCSPContinuation : public Continuation {
 #endif /* HAVE_OPENSSL_OCSP_STAPLING */
 
 void
-SSLNetProcessor::cleanup(void)
+SSLNetProcessor::cleanup()
 {
 }
 

--- a/iocore/net/UnixUDPNet.cc
+++ b/iocore/net/UnixUDPNet.cc
@@ -177,7 +177,7 @@ public:
   UDPReadContinuation(Event *completionToken);
   UDPReadContinuation();
   ~UDPReadContinuation();
-  inline void free(void);
+  inline void free();
   inline void init_token(Event *completionToken);
   inline void init_read(int fd, IOBufferBlock *buf, int len, struct sockaddr *fromaddr, socklen_t *fromaddrlen);
 
@@ -249,7 +249,7 @@ UDPReadContinuation::UDPReadContinuation()
 }
 
 inline void
-UDPReadContinuation::free(void)
+UDPReadContinuation::free()
 {
   ink_assert(event != nullptr);
   completionUtil::destroy(event);

--- a/lib/records/RecConfigParse.cc
+++ b/lib/records/RecConfigParse.cc
@@ -44,7 +44,7 @@ ink_mutex g_rec_config_lock;
 // RecConfigFileInit
 //-------------------------------------------------------------------------
 void
-RecConfigFileInit(void)
+RecConfigFileInit()
 {
   ink_mutex_init(&g_rec_config_lock, nullptr);
   g_rec_config_contents_llq = create_queue();

--- a/lib/records/RecProcess.cc
+++ b/lib/records/RecProcess.cc
@@ -289,7 +289,7 @@ RecProcessInitMessage(RecModeT mode_type)
 // RecProcessStart
 //-------------------------------------------------------------------------
 int
-RecProcessStart(void)
+RecProcessStart()
 {
   if (g_started) {
     return REC_ERR_OKAY;

--- a/lib/ts/EventNotify.cc
+++ b/lib/ts/EventNotify.cc
@@ -61,7 +61,7 @@ EventNotify::EventNotify()
 }
 
 void
-EventNotify::signal(void)
+EventNotify::signal()
 {
 #ifdef HAVE_EVENTFD
   uint64_t value = 1;
@@ -77,7 +77,7 @@ EventNotify::signal(void)
 }
 
 int
-EventNotify::wait(void)
+EventNotify::wait()
 {
 #ifdef HAVE_EVENTFD
   ssize_t nr, nr_fd;
@@ -140,7 +140,7 @@ int EventNotify::timedwait(int timeout) // milliseconds
 }
 
 void
-EventNotify::lock(void)
+EventNotify::lock()
 {
 #ifdef HAVE_EVENTFD
 // do nothing
@@ -150,7 +150,7 @@ EventNotify::lock(void)
 }
 
 bool
-EventNotify::trylock(void)
+EventNotify::trylock()
 {
 #ifdef HAVE_EVENTFD
   return true;
@@ -160,7 +160,7 @@ EventNotify::trylock(void)
 }
 
 void
-EventNotify::unlock(void)
+EventNotify::unlock()
 {
 #ifdef HAVE_EVENTFD
 // do nothing

--- a/lib/ts/HashFNV.cc
+++ b/lib/ts/HashFNV.cc
@@ -13,46 +13,46 @@ static const uint32_t FNV_INIT_32 = 0x811c9dc5u;
 static const uint64_t FNV_INIT_64 = 0xcbf29ce484222325ull;
 
 // FNV-1a 64bit
-ATSHash32FNV1a::ATSHash32FNV1a(void)
+ATSHash32FNV1a::ATSHash32FNV1a()
 {
   this->clear();
 }
 
 void
-ATSHash32FNV1a::final(void)
+ATSHash32FNV1a::final()
 {
 }
 
 uint32_t
-ATSHash32FNV1a::get(void) const
+ATSHash32FNV1a::get() const
 {
   return hval;
 }
 
 void
-ATSHash32FNV1a::clear(void)
+ATSHash32FNV1a::clear()
 {
   hval = FNV_INIT_32;
 }
 
 // FNV-1a 64bit
-ATSHash64FNV1a::ATSHash64FNV1a(void)
+ATSHash64FNV1a::ATSHash64FNV1a()
 {
   this->clear();
 }
 void
-ATSHash64FNV1a::final(void)
+ATSHash64FNV1a::final()
 {
 }
 
 uint64_t
-ATSHash64FNV1a::get(void) const
+ATSHash64FNV1a::get() const
 {
   return hval;
 }
 
 void
-ATSHash64FNV1a::clear(void)
+ATSHash64FNV1a::clear()
 {
   hval = FNV_INIT_64;
 }

--- a/lib/ts/HashMD5.cc
+++ b/lib/ts/HashMD5.cc
@@ -22,7 +22,7 @@
 #include "ts/HashMD5.h"
 #include "ts/ink_assert.h"
 
-ATSHashMD5::ATSHashMD5(void) : md_len(0), finalized(false)
+ATSHashMD5::ATSHashMD5() : md_len(0), finalized(false)
 {
   ctx     = EVP_MD_CTX_new();
   int ret = EVP_DigestInit_ex(ctx, EVP_md5(), nullptr);
@@ -39,7 +39,7 @@ ATSHashMD5::update(const void *data, size_t len)
 }
 
 void
-ATSHashMD5::final(void)
+ATSHashMD5::final()
 {
   if (!finalized) {
     int ret = EVP_DigestFinal_ex(ctx, md_value, &md_len);
@@ -49,7 +49,7 @@ ATSHashMD5::final(void)
 }
 
 const void *
-ATSHashMD5::get(void) const
+ATSHashMD5::get() const
 {
   if (finalized) {
     return (void *)md_value;
@@ -59,13 +59,13 @@ ATSHashMD5::get(void) const
 }
 
 size_t
-ATSHashMD5::size(void) const
+ATSHashMD5::size() const
 {
   return EVP_MD_CTX_size(ctx);
 }
 
 void
-ATSHashMD5::clear(void)
+ATSHashMD5::clear()
 {
   int ret = EVP_MD_CTX_reset(ctx);
   ink_assert(ret == 1);

--- a/lib/ts/HashSip.cc
+++ b/lib/ts/HashSip.cc
@@ -33,7 +33,7 @@ https://github.com/floodyberry/siphash
   x3 ^= x0;                         \
   x2 = ROTL64(x2, 32);
 
-ATSHash64Sip24::ATSHash64Sip24(void)
+ATSHash64Sip24::ATSHash64Sip24()
 {
   k0 = 0;
   k1 = 0;
@@ -96,7 +96,7 @@ ATSHash64Sip24::update(const void *data, size_t len)
 }
 
 void
-ATSHash64Sip24::final(void)
+ATSHash64Sip24::final()
 {
   uint64_t last7;
   int i;
@@ -123,7 +123,7 @@ ATSHash64Sip24::final(void)
 }
 
 uint64_t
-ATSHash64Sip24::get(void) const
+ATSHash64Sip24::get() const
 {
   if (finalized) {
     return hfinal;
@@ -133,7 +133,7 @@ ATSHash64Sip24::get(void) const
 }
 
 void
-ATSHash64Sip24::clear(void)
+ATSHash64Sip24::clear()
 {
   v0               = k0 ^ 0x736f6d6570736575ull;
   v1               = k1 ^ 0x646f72616e646f6dull;

--- a/lib/ts/hugepages.cc
+++ b/lib/ts/hugepages.cc
@@ -37,7 +37,7 @@ static bool hugepage_enabled;
 #endif
 
 size_t
-ats_hugepage_size(void)
+ats_hugepage_size()
 {
 #ifdef MAP_HUGETLB
   return hugepage_size;
@@ -48,7 +48,7 @@ ats_hugepage_size(void)
 }
 
 bool
-ats_hugepage_enabled(void)
+ats_hugepage_enabled()
 {
 #ifdef MAP_HUGETLB
   return hugepage_enabled;

--- a/lib/ts/ink_res_init.cc
+++ b/lib/ts/ink_res_init.cc
@@ -256,7 +256,7 @@ ink_res_setoptions(ink_res_state statp, const char *options, const char *source 
 }
 
 static unsigned
-ink_res_randomid(void)
+ink_res_randomid()
 {
   struct timeval now;
 

--- a/lib/ts/lockfile.cc
+++ b/lib/ts/lockfile.cc
@@ -166,7 +166,7 @@ Lockfile::Get(pid_t *holding_pid)
 }
 
 void
-Lockfile::Close(void)
+Lockfile::Close()
 {
   if (fd != -1) {
     close(fd);

--- a/mgmt/ProxyConfig.cc
+++ b/mgmt/ProxyConfig.cc
@@ -281,7 +281,7 @@ volatile int RegressionConfig::nobjects = 0;
 struct ProxyConfig_Set_Completion {
   ProxyConfig_Set_Completion(int _id, RegressionConfig *_c) : configid(_id), config(_c) {}
   void
-  operator()(void) const
+  operator()() const
   {
     // Push one more RegressionConfig to force the LAST-tagged one to get destroyed.
     rprintf(config->test, "setting LAST config object %p\n", config);
@@ -315,7 +315,7 @@ EXCLUSIVE_REGRESSION_TEST(ProxyConfig_Set)(RegressionTest *test, int /* atype AT
 struct ProxyConfig_Release_Completion {
   ProxyConfig_Release_Completion(int _id, RegressionConfig *_c) : configid(_id), config(_c) {}
   void
-  operator()(void) const
+  operator()() const
   {
     // Release the reference count. Since we were keeping this alive, it should be the last to die.
     configProcessor.release(configid, config);

--- a/mgmt/api/APITestCliRemote.cc
+++ b/mgmt/api/APITestCliRemote.cc
@@ -939,7 +939,7 @@ reconfigure()
  * tests if correct action need is returned when requested record is set
  */
 void
-test_action_need(void)
+test_action_need()
 {
   TSActionNeedT action;
 
@@ -1235,7 +1235,7 @@ test_rec_get(char *rec_name)
  * get list of records
  */
 void
-test_record_get_mlt(void)
+test_record_get_mlt()
 {
   TSRecordEle *rec_ele;
   TSStringList name_list;
@@ -1323,7 +1323,7 @@ test_record_get_mlt(void)
  * Also checks to make sure correct action_need type is set.
  */
 void
-test_record_set_mlt(void)
+test_record_set_mlt()
 {
   TSList list;
   TSRecordEle *ele1, *ele2, *ele3, *ele4, *ele5;
@@ -2025,7 +2025,7 @@ eventCallbackFn(char *name, char *msg, int /* pri ATS_UNUSED */, void * /* data 
  * that for any event that's signalled, the callback fn will also be called
  */
 void
-register_event_callback(void)
+register_event_callback()
 {
   TSMgmtError err;
 
@@ -2042,7 +2042,7 @@ register_event_callback(void)
  * event called, the eventCallbackFn will NOT be called
  */
 void
-unregister_event_callback(void)
+unregister_event_callback()
 {
   TSMgmtError err;
 

--- a/mgmt/cluster/ClusterCom.cc
+++ b/mgmt/cluster/ClusterCom.cc
@@ -641,7 +641,7 @@ ClusterCom::checkPeers(time_t *ticker)
 } /* End ClusterCom::checkPeers */
 
 void
-ClusterCom::generateClusterDelta(void)
+ClusterCom::generateClusterDelta()
 {
   long highest_delta = 0L;
   InkHashTableEntry *entry;
@@ -1636,7 +1636,7 @@ ClusterCom::establishChannels()
  *   Setup our multicast channel for broadcasting.
  */
 void
-ClusterCom::establishBroadcastChannel(void)
+ClusterCom::establishBroadcastChannel()
 {
   if ((broadcast_fd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
     mgmt_fatal(errno, "[ClusterCom::establishBroadcastChannel] Unable to open socket.\n");

--- a/mgmt/utils/MgmtSocket.cc
+++ b/mgmt/utils/MgmtSocket.cc
@@ -295,7 +295,7 @@ mgmt_read_timeout(int fd, int sec, int usec)
 }
 
 bool
-mgmt_has_peereid(void)
+mgmt_has_peereid()
 {
 #if HAVE_GETPEEREID
   return true;

--- a/plugins/experimental/inliner/chunk-decoder.cc
+++ b/plugins/experimental/inliner/chunk-decoder.cc
@@ -111,7 +111,7 @@ ChunkDecoder::parseSize(const char *p, const int64_t s)
 }
 
 bool
-ChunkDecoder::isSizeState(void) const
+ChunkDecoder::isSizeState() const
 {
   return state_ == State::kDataN || state_ == State::kEndN || state_ == State::kSize || state_ == State::kSizeN ||
          state_ == State::kSizeR;

--- a/plugins/experimental/inliner/fetcher.cc
+++ b/plugins/experimental/inliner/fetcher.cc
@@ -45,7 +45,7 @@
 namespace ats
 {
 void
-HttpParser::destroyParser(void)
+HttpParser::destroyParser()
 {
   if (parser_ != nullptr) {
     TSHttpParserClear(parser_);

--- a/plugins/experimental/inliner/html-parser.cc
+++ b/plugins/experimental/inliner/html-parser.cc
@@ -31,7 +31,7 @@ namespace ats
 {
 namespace inliner
 {
-  Attributes::operator std::string(void) const
+  Attributes::operator std::string() const
   {
     std::string result;
     for (Attributes::const_iterator item = begin(); item != end(); ++item) {

--- a/plugins/experimental/inliner/inliner-handler.cc
+++ b/plugins/experimental/inliner/inliner-handler.cc
@@ -67,7 +67,7 @@ namespace inliner
   }
 
   void
-  Handler::parse(void)
+  Handler::parse()
   {
     assert(reader_ != nullptr);
     TSIOBufferBlock block = TSIOBufferReaderStart(reader_);
@@ -130,7 +130,7 @@ namespace inliner
   }
 
   std::string
-  Handler::generateId(void)
+  Handler::generateId()
   {
     std::stringstream ss;
     // TODO(dmorilha): stop using memory address here.
@@ -139,7 +139,7 @@ namespace inliner
   }
 
   void
-  Handler::abort(void)
+  Handler::abort()
   {
     abort_ = true;
     assert(ioSink_);

--- a/plugins/experimental/inliner/ts.cc
+++ b/plugins/experimental/inliner/ts.cc
@@ -58,7 +58,7 @@ namespace io
   }
 
   int64_t
-  IO::consume(void) const
+  IO::consume() const
   {
     assert(reader != nullptr);
     const int64_t available = TSIOBufferReaderAvail(reader);
@@ -69,7 +69,7 @@ namespace io
   }
 
   int64_t
-  IO::done(void) const
+  IO::done() const
   {
     assert(vio != nullptr);
     assert(reader != nullptr);
@@ -257,7 +257,7 @@ namespace io
   }
 
   void
-  WriteOperation::close(void)
+  WriteOperation::close()
   {
     assert(mutex_ != nullptr);
     const Lock lock(mutex_);
@@ -269,7 +269,7 @@ namespace io
   }
 
   void
-  WriteOperation::abort(void)
+  WriteOperation::abort()
   {
     assert(mutex_ != nullptr);
     const Lock lock(mutex_);
@@ -287,7 +287,7 @@ namespace io
   }
 
   void
-  IOSink::process(void)
+  IOSink::process()
   {
     const WriteOperationPointer operation = operation_.lock();
 
@@ -308,7 +308,7 @@ namespace io
   }
 
   Lock
-  IOSink::lock(void)
+  IOSink::lock()
   {
     const WriteOperationPointer operation = operation_.lock();
 
@@ -323,7 +323,7 @@ namespace io
   }
 
   void
-  IOSink::abort(void)
+  IOSink::abort()
   {
     const WriteOperationPointer operation = operation_.lock();
     if (operation) {
@@ -394,7 +394,7 @@ namespace io
   }
 
   SinkPointer
-  IOSink::branch(void)
+  IOSink::branch()
   {
     if (!data_) {
       data_.reset(new Data(shared_from_this()));
@@ -406,7 +406,7 @@ namespace io
   }
 
   SinkPointer
-  Sink::branch(void)
+  Sink::branch()
   {
     DataPointer data;
     if (data_) {

--- a/plugins/experimental/multiplexer/chunk-decoder.cc
+++ b/plugins/experimental/multiplexer/chunk-decoder.cc
@@ -91,7 +91,7 @@ ChunkDecoder::parseSize(const char *p, const int64_t s)
 }
 
 bool
-ChunkDecoder::isSizeState(void) const
+ChunkDecoder::isSizeState() const
 {
   return state_ == State::kDataN || state_ == State::kEndN || state_ == State::kSize || state_ == State::kSizeN ||
          state_ == State::kSizeR;

--- a/plugins/experimental/multiplexer/dispatch.cc
+++ b/plugins/experimental/multiplexer/dispatch.cc
@@ -150,14 +150,14 @@ public:
   }
 
   void
-  error(void)
+  error()
   {
     TSError("[" PLUGIN_TAG "] error when communicating with \"%s\"\n", url.c_str());
     TSStatIntIncrement(statistics.failures, 1);
   }
 
   void
-  timeout(void)
+  timeout()
   {
     TSError("[" PLUGIN_TAG "] timeout when communicating with \"%s\"\n", url.c_str());
     TSStatIntIncrement(statistics.timeouts, 1);
@@ -189,7 +189,7 @@ public:
   }
 
   void
-  done(void)
+  done()
   {
     struct timeval end;
 

--- a/plugins/experimental/multiplexer/fetcher.cc
+++ b/plugins/experimental/multiplexer/fetcher.cc
@@ -25,7 +25,7 @@
 namespace ats
 {
 void
-HttpParser::destroyParser(void)
+HttpParser::destroyParser()
 {
   if (parser_ != nullptr) {
     TSHttpParserClear(parser_);

--- a/plugins/experimental/multiplexer/original-request.cc
+++ b/plugins/experimental/multiplexer/original-request.cc
@@ -77,7 +77,7 @@ OriginalRequest::OriginalRequest(const TSMBuffer b, const TSMLoc l) : buffer_(b)
   }
 }
 
-OriginalRequest::~OriginalRequest(void)
+OriginalRequest::~OriginalRequest()
 {
   urlScheme(original.urlScheme);
   urlHost(original.urlHost);

--- a/plugins/generator/generator.cc
+++ b/plugins/generator/generator.cc
@@ -626,7 +626,7 @@ GeneratorTxnHook(TSCont contp, TSEvent event, void *edata)
 }
 
 static void
-GeneratorInitialize(void)
+GeneratorInitialize()
 {
   TxnHook = TSContCreate(GeneratorTxnHook, nullptr);
   memset(GeneratorData, 'x', sizeof(GeneratorData));

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -510,7 +510,7 @@ check_lockfile()
 }
 
 static void
-check_config_directories(void)
+check_config_directories()
 {
   ats_scoped_str rundir(RecConfigReadRuntimeDir());
   ats_scoped_str sysconfdir(RecConfigReadConfigDir());
@@ -1053,7 +1053,7 @@ init_core_size()
 }
 
 static void
-adjust_sys_settings(void)
+adjust_sys_settings()
 {
   struct rlimit lim;
   int fds_throttle = -1;

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -8370,7 +8370,7 @@ HttpTransact::get_error_string(int erno)
 }
 
 ink_time_t
-ink_cluster_time(void)
+ink_cluster_time()
 {
   int highest_delta;
   ink_time_t local_time;

--- a/proxy/http/remap/AclFiltering.cc
+++ b/proxy/http/remap/AclFiltering.cc
@@ -30,7 +30,7 @@
 // ===============================================================================
 
 void
-acl_filter_rule::reset(void)
+acl_filter_rule::reset()
 {
   int i;
   for (i = (argc = 0); i < ACL_FILTER_MAX_ARGV; i++) {
@@ -91,7 +91,7 @@ acl_filter_rule::name(const char *_name)
 }
 
 void
-acl_filter_rule::print(void)
+acl_filter_rule::print()
 {
   int i;
   printf("-----------------------------------------------------------------------------------------\n");

--- a/proxy/logging/LogAccessHttp.cc
+++ b/proxy/logging/LogAccessHttp.cc
@@ -324,7 +324,7 @@ LogAccessHttp::marshal_client_auth_user_name(char *buf)
   -------------------------------------------------------------------------*/
 
 void
-LogAccessHttp::validate_unmapped_url(void)
+LogAccessHttp::validate_unmapped_url()
 {
   if (m_client_req_unmapped_url_canon_len < 0) {
     if (m_http_sm->t_state.unmapped_url.valid()) {
@@ -347,7 +347,7 @@ LogAccessHttp::validate_unmapped_url(void)
   -------------------------------------------------------------------------*/
 
 void
-LogAccessHttp::validate_unmapped_url_path(void)
+LogAccessHttp::validate_unmapped_url_path()
 {
   int len;
   char *c;
@@ -383,7 +383,7 @@ LogAccessHttp::validate_unmapped_url_path(void)
   m_cache_lookup__url_canon_len fields.
   -------------------------------------------------------------------------*/
 void
-LogAccessHttp::validate_lookup_url(void)
+LogAccessHttp::validate_lookup_url()
 {
   if (m_cache_lookup_url_canon_len < 0) {
     if (m_http_sm->t_state.cache_info.lookup_url_storage.valid()) {

--- a/proxy/logging/LogField.cc
+++ b/proxy/logging/LogField.cc
@@ -204,7 +204,7 @@ static const milestone milestones[] = {
 };
 
 void
-LogField::init_milestone_container(void)
+LogField::init_milestone_container()
 {
   if (m_milestone_map.empty()) {
     for (unsigned i = 0; i < countof(milestones); ++i) {


### PR DESCRIPTION
Running clang-tidy over the 7.1.x branch to make things easier to backport
