### PR TITLE
Ran clang-tidy with modernize-use-nullptr

### DIFF
--- a/cmd/traffic_cop/traffic_cop.cc
+++ b/cmd/traffic_cop/traffic_cop.cc
@@ -935,7 +935,7 @@ getaddrinfo_error:
 }
 
 static int
-test_port(int port, const char *request, char *buffer, int bufsize, int64_t test_timeout, const char *ip = NULL,
+test_port(int port, const char *request, char *buffer, int bufsize, int64_t test_timeout, const char *ip = nullptr,
           const char *ip_to_bind = nullptr)
 {
   int64_t start_time, timeout;
@@ -1520,11 +1520,11 @@ check_memory()
     if ((fp = fopen("/proc/meminfo", "r"))) {
       while (fgets(buf, sizeof buf, fp)) {
         if (strncmp(buf, "MemFree:", sizeof "MemFree:" - 1) == 0)
-          memfree = strtoll(buf + sizeof "MemFree:" - 1, 0, 10);
+          memfree = strtoll(buf + sizeof "MemFree:" - 1, nullptr, 10);
         else if (strncmp(buf, "SwapFree:", sizeof "SwapFree:" - 1) == 0)
-          swapfree = strtoll(buf + sizeof "SwapFree:" - 1, 0, 10);
+          swapfree = strtoll(buf + sizeof "SwapFree:" - 1, nullptr, 10);
         else if (strncmp(buf, "SwapTotal:", sizeof "SwapTotal:" - 1) == 0)
-          swapsize = strtoll(buf + sizeof "SwapTotal:" - 1, 0, 10);
+          swapsize = strtoll(buf + sizeof "SwapTotal:" - 1, nullptr, 10);
       }
       fclose(fp);
       // simple heuristic for linux

--- a/iocore/net/UnixNet.cc
+++ b/iocore/net/UnixNet.cc
@@ -243,7 +243,7 @@ initialize_thread_for_net(EThread *thread)
   thread->ep          = (EventIO *)ats_malloc(sizeof(EventIO));
   thread->ep->type    = EVENTIO_ASYNC_SIGNAL;
 #if HAVE_EVENTFD
-  thread->ep->start(pd, thread->evfd, 0, EVENTIO_READ);
+  thread->ep->start(pd, thread->evfd, nullptr, EVENTIO_READ);
 #else
   thread->ep->start(pd, thread->evpipe[0], nullptr, EVENTIO_READ);
 #endif

--- a/lib/bindings/bindings.cc
+++ b/lib/bindings/bindings.cc
@@ -265,7 +265,7 @@ BindingInstance::require(const char *path)
 bool
 BindingInstance::eval(const char *chunk)
 {
-  ink_release_assert(this->lua != NULL);
+  ink_release_assert(this->lua != nullptr);
 
   if (luaL_dostring(this->lua, chunk) != 0) {
     const char *w = lua_tostring(this->lua, -1);

--- a/lib/ts/ink_cap.cc
+++ b/lib/ts/ink_cap.cc
@@ -408,7 +408,7 @@ ElevateAccess::ElevateAccess(unsigned lvl)
     level(lvl)
 #if TS_USE_POSIX_CAP
     ,
-    cap_state(0)
+    cap_state(nullptr)
 #endif
 {
   elevate(level);

--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -244,7 +244,7 @@ LocalManager::LocalManager(bool proxy_on) : BaseManager(), run_proxy(proxy_on), 
   proxy_name                   = REC_readString("proxy.config.proxy_name", &found);
   proxy_binary                 = REC_readString("proxy.config.proxy_binary", &found);
   env_prep                     = REC_readString("proxy.config.env_prep", &found);
-  proxy_options                = NULL;
+  proxy_options                = nullptr;
 
   // Calculate proxy_binary from the absolute bin_path
   absolute_proxy_binary = Layout::relative_to(bindir, proxy_binary);
@@ -946,7 +946,7 @@ LocalManager::startProxy(const char *onetime_options)
     }
 
     // Make sure we're starting the proxy in mgmt mode
-    if (strstr(real_proxy_options, MGMT_OPT) == 0) {
+    if (strstr(real_proxy_options, MGMT_OPT) == nullptr) {
       ink_strlcat(real_proxy_options, " ", OPTIONS_SIZE);
       ink_strlcat(real_proxy_options, MGMT_OPT, OPTIONS_SIZE);
     }

--- a/plugins/experimental/buffer_upload/buffer_upload.cc
+++ b/plugins/experimental/buffer_upload/buffer_upload.cc
@@ -427,7 +427,7 @@ pvc_process_n_write(TSCont contp, TSEvent event, pvc_state *my_state)
   /* FALL THROUGH */
   case TS_EVENT_VCONN_WRITE_COMPLETE:
     /* We should have already shutdown read pvc side */
-    TSAssert(my_state->p_read_vio == NULL);
+    TSAssert(my_state->p_read_vio == nullptr);
     TSVConnShutdown(my_state->net_vc, 0, 1);
     my_state->req_finished = 1;
 
@@ -512,7 +512,7 @@ pvc_process_p_write(TSCont contp, TSEvent event, pvc_state *my_state)
   /* FALL THROUGH */
   case TS_EVENT_VCONN_WRITE_COMPLETE:
     /* We should have already shutdown read net side */
-    TSAssert(my_state->n_read_vio == NULL);
+    TSAssert(my_state->n_read_vio == nullptr);
     TSVConnShutdown(my_state->p_vc, 0, 1);
     my_state->resp_finished = 1;
     pvc_check_done(contp, my_state);

--- a/plugins/experimental/mysql_remap/mysql_remap.cc
+++ b/plugins/experimental/mysql_remap/mysql_remap.cc
@@ -208,8 +208,8 @@ TSPluginInit(int argc, const char *argv[])
 
   host     = iniparser_getstring(ini, "mysql_remap:mysql_host", (char *)"localhost");
   port     = iniparser_getint(ini, "mysql_remap:mysql_port", 3306);
-  username = iniparser_getstring(ini, "mysql_remap:mysql_username", NULL);
-  password = iniparser_getstring(ini, "mysql_remap:mysql_password", NULL);
+  username = iniparser_getstring(ini, "mysql_remap:mysql_username", nullptr);
+  password = iniparser_getstring(ini, "mysql_remap:mysql_password", nullptr);
   db       = iniparser_getstring(ini, "mysql_remap:mysql_database", (char *)"mysql_remap");
 
   if (mysql_library_init(0, NULL, NULL)) {

--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -903,7 +903,7 @@ const char *
 ConditionGeo::get_geo_string(const sockaddr *addr) const
 {
   TSError("[%s] No Geo library available!", PLUGIN_NAME);
-  return NULL;
+  return nullptr;
 }
 
 int64_t

--- a/plugins/s3_auth/s3_auth.cc
+++ b/plugins/s3_auth/s3_auth.cc
@@ -645,7 +645,7 @@ TSHttpStatus
 S3Request::authorizeV4(S3Config *s3)
 {
   TsApi api(_bufp, _hdr_loc, _url_loc);
-  time_t now = time(0);
+  time_t now = time(nullptr);
 
   AwsAuthV4 util(api, &now, /* signPayload */ false, s3->keyid(), s3->keyid_len(), s3->secret(), s3->secret_len(), "s3", 2,
                  s3->v4includeHeaders(), s3->v4excludeHeaders(), s3->v4RegionMap());

--- a/plugins/tcpinfo/tcpinfo.cc
+++ b/plugins/tcpinfo/tcpinfo.cc
@@ -104,13 +104,13 @@ log_tcp_info(Config *config, const char *event_name, TSHttpSsn ssnp)
   socklen_t tcp_info_len = sizeof(info);
   int fd;
 
-  TSReleaseAssert(config->log != NULL);
+  TSReleaseAssert(config->log != nullptr);
 
-  if (ssnp != NULL && (TSHttpSsnClientFdGet(ssnp, &fd) != TS_SUCCESS || fd <= 0)) {
+  if (ssnp != nullptr && (TSHttpSsnClientFdGet(ssnp, &fd) != TS_SUCCESS || fd <= 0)) {
     TSDebug("tcpinfo", "error getting the client socket fd from ssn");
     return;
   }
-  if (ssnp == NULL) {
+  if (ssnp == nullptr) {
     TSDebug("tcpinfo", "ssn is not specified");
     return;
   }
@@ -123,7 +123,7 @@ log_tcp_info(Config *config, const char *event_name, TSHttpSsn ssnp)
   client_addr.sa = TSHttpSsnClientAddrGet(ssnp);
   server_addr.sa = TSHttpSsnIncomingAddrGet(ssnp);
 
-  if (client_addr.sa == NULL || server_addr.sa == NULL) {
+  if (client_addr.sa == nullptr || server_addr.sa == nullptr) {
     return;
   }
 

--- a/proxy/CoreUtils.cc
+++ b/proxy/CoreUtils.cc
@@ -307,7 +307,7 @@ CoreUtils::get_next_frame(core_stack_state *coress)
     if ((frameoff = (void **)ats_malloc(sizeof(long)))) {
       if (fread(frameoff, 4, 1, fp) == 1) {
         coress->framep = (intptr_t)*frameoff;
-        if (*frameoff == NULL) {
+        if (*frameoff == nullptr) {
           ats_free(frameoff);
           return 0;
         }

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -4619,7 +4619,7 @@ TSHttpTxnHookAdd(TSHttpTxn txnp, TSHttpHookID id, TSCont contp)
   APIHook *hook = sm->txn_hook_get(id);
 
   // Traverse list of hooks and add a particular hook only once
-  while (hook != NULL) {
+  while (hook != nullptr) {
     if (hook->m_cont == (INKContInternal *)contp) {
       return;
     }

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -213,7 +213,7 @@ static const ArgumentDescription argument_descriptions[] = {
   {"bind_stdout", '-', "Regular file to bind stdout to", "S512", &bind_stdout, "PROXY_BIND_STDOUT", nullptr},
   {"bind_stderr", '-', "Regular file to bind stderr to", "S512", &bind_stderr, "PROXY_BIND_STDERR", nullptr},
 #if defined(linux)
-  {"read_core", 'c', "Read Core file", "S255", &core_file, NULL, NULL},
+  {"read_core", 'c', "Read Core file", "S255", &core_file, nullptr, nullptr},
 #endif
 
   {"accept_mss", '-', "MSS for client connections", "I", &accept_mss, nullptr, nullptr},
@@ -354,7 +354,7 @@ public:
     memset(&_usage, 0, sizeof(_usage));
     SET_HANDLER(&MemoryLimit::periodic);
   }
-  ~MemoryLimit() { mutex = NULL; }
+  ~MemoryLimit() { mutex = nullptr; }
   int
   periodic(int event, Event *e)
   {
@@ -1783,7 +1783,7 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   eventProcessor.schedule_every(new DiagsLogContinuation, HRTIME_SECOND, ET_TASK);
   eventProcessor.schedule_every(new MemoryLimit, HRTIME_SECOND, ET_TASK);
   REC_RegisterConfigUpdateFunc("proxy.config.dump_mem_info_frequency", init_memory_tracker, nullptr);
-  init_memory_tracker(NULL, RECD_NULL, RecData(), nullptr);
+  init_memory_tracker(nullptr, RECD_NULL, RecData(), nullptr);
 
   // log initialization moved down
 

--- a/proxy/ParentConsistentHash.cc
+++ b/proxy/ParentConsistentHash.cc
@@ -292,7 +292,7 @@ ParentConsistentHash::markParentDown(const ParentSelectionPolicy *policy, Parent
 
   } else {
     int old_count = 0;
-    now           = time(NULL);
+    now           = time(nullptr);
 
     // if the last failure was outside the retry window, set the failcount to 1
     // and failedAt to now.

--- a/proxy/ParentRoundRobin.cc
+++ b/proxy/ParentRoundRobin.cc
@@ -233,7 +233,7 @@ ParentRoundRobin::markParentDown(const ParentSelectionPolicy *policy, ParentResu
 
   } else {
     int old_count = 0;
-    now           = time(NULL);
+    now           = time(nullptr);
 
     // if the last failure was outside the retry window, set the failcount to 1
     // and failedAt to now.

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -2764,7 +2764,7 @@ HttpSM::tunnel_handler_post(int event, void *data)
     if (ua_entry->write_buffer) {
       free_MIOBuffer(ua_entry->write_buffer);
       ua_entry->write_buffer = nullptr;
-      ua_entry->vc->do_io_write(this, 0, NULL);
+      ua_entry->vc->do_io_write(this, 0, nullptr);
     }
     // The if statement will always true since these codes are all for HTTP 408 response sending. - by oknet xu
     if (p->handler_state == HTTP_SM_POST_UA_FAIL) {
@@ -4806,7 +4806,7 @@ HttpSM::do_http_server_open(bool raw)
   }
 
   // Congestion Check
-  if (t_state.pCongestionEntry != NULL) {
+  if (t_state.pCongestionEntry != nullptr) {
     if (t_state.pCongestionEntry->F_congested() &&
         (!t_state.pCongestionEntry->proxy_retry(milestones[TS_MILESTONE_SERVER_CONNECT]))) {
       t_state.congestion_congested_or_failed = 1;
@@ -7298,7 +7298,7 @@ HttpSM::set_next_state()
       DebugSM("dns", "[HttpTransact::HandleRequest] Skipping DNS lookup for %s because it's loopback",
               t_state.dns_info.lookup_name);
       t_state.dns_info.lookup_success = true;
-      call_transact_and_set_next_state(NULL);
+      call_transact_and_set_next_state(nullptr);
       break;
     } else if (url_remap_mode == HttpTransact::URL_REMAP_FOR_OS && t_state.first_dns_lookup) {
       DebugSM("cdn", "Skipping DNS Lookup");

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -577,8 +577,8 @@ HttpTransact::Forbidden(State *s)
   DebugTxn("http_trans", "[Forbidden]"
                          "IpAllow marked request forbidden");
   bootstrap_state_variables_from_request(s, &s->hdr_info.client_request);
-  build_error_response(s, HTTP_STATUS_FORBIDDEN, "Access Denied", "access#denied", NULL);
-  TRANSACT_RETURN(SM_ACTION_SEND_ERROR_CACHE_NOOP, NULL);
+  build_error_response(s, HTTP_STATUS_FORBIDDEN, "Access Denied", "access#denied", nullptr);
+  TRANSACT_RETURN(SM_ACTION_SEND_ERROR_CACHE_NOOP, nullptr);
 }
 
 void

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -85,7 +85,7 @@ rcv_data_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
   if (stream == nullptr) {
     if (cstate.is_valid_streamid(id)) {
       // This error occurs fairly often, and is probably innocuous (SM initiates the shutdown)
-      return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_STREAM, Http2ErrorCode::HTTP2_ERROR_STREAM_CLOSED, NULL);
+      return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_STREAM, Http2ErrorCode::HTTP2_ERROR_STREAM_CLOSED, nullptr);
     } else {
       return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR,
                         "recv data stream freed with invalid id");
@@ -998,7 +998,7 @@ Http2ConnectionState::create_stream(Http2StreamId new_id, Http2Error &error)
   Http2Stream *new_stream = THREAD_ALLOC_INIT(http2StreamAllocator, this_ethread());
   new_stream->init(new_id, client_settings.get(HTTP2_SETTINGS_INITIAL_WINDOW_SIZE));
 
-  ink_assert(NULL != new_stream);
+  ink_assert(nullptr != new_stream);
   ink_assert(!stream_list.in(new_stream));
 
   stream_list.push(new_stream);
@@ -1076,7 +1076,7 @@ Http2ConnectionState::cleanup_streams()
 bool
 Http2ConnectionState::delete_stream(Http2Stream *stream)
 {
-  ink_assert(NULL != stream);
+  ink_assert(nullptr != stream);
 
   // If stream has already been removed from the list, just go on
   if (!stream_list.in(stream)) {

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -138,7 +138,7 @@ Http2Stream::main_event_handler(int event, void *edata)
 Http2ErrorCode
 Http2Stream::decode_header_blocks(HpackHandle &hpack_handle)
 {
-  return http2_decode_header_blocks(&_req_header, (const uint8_t *)header_blocks, header_blocks_length, NULL, hpack_handle,
+  return http2_decode_header_blocks(&_req_header, (const uint8_t *)header_blocks, header_blocks_length, nullptr, hpack_handle,
                                     trailing_header);
 }
 

--- a/proxy/logging/LogHost.cc
+++ b/proxy/logging/LogHost.cc
@@ -312,7 +312,7 @@ LogHost::display(FILE *fd)
   fprintf(fd, "LogHost: %s:%u, %s\n", name(), port(), (connected(NOPING)) ? "connected" : "not connected");
 
   LogHost *host = this;
-  while (host->failover_link.next != NULL) {
+  while (host->failover_link.next != nullptr) {
     fprintf(fd, "Failover: %s:%u, %s\n", host->name(), host->port(), (host->connected(NOPING)) ? "connected" : "not connected");
     host = host->failover_link.next;
   }


### PR DESCRIPTION
Running clang-tidy over the 7.1.x branch to make things easier to backport
