### PR TITLE
Ran clang-tidy with performance-faster-string-find

### DIFF
--- a/example/ssl-preaccept/ssl-preaccept.cc
+++ b/example/ssl-preaccept/ssl-preaccept.cc
@@ -54,7 +54,7 @@ Parse_Addr_String(ts::ConstBuffer const &text, IpRange &range)
   IpAddr newAddr;
   std::string textstr(text._ptr, text._size);
   // Is there a hyphen?
-  size_t hyphen_pos = textstr.find("-");
+  size_t hyphen_pos = textstr.find('-');
   if (hyphen_pos != std::string::npos) {
     std::string addr1 = textstr.substr(0, hyphen_pos);
     std::string addr2 = textstr.substr(hyphen_pos + 1);

--- a/plugins/esi/lib/Variables.cc
+++ b/plugins/esi/lib/Variables.cc
@@ -358,7 +358,7 @@ Variables::_parseCookieString(const char *str, int str_len)
   Utils::parseAttributes(str, str_len, cookies, ";,");
   for (auto &iter : cookies) {
     std::string cookie = iter.name;
-    size_t pos         = cookie.find("=");
+    size_t pos         = cookie.find('=');
 
     if (pos != std::string::npos) {
       cookie = cookie.substr(0, pos);

--- a/plugins/experimental/cachekey/cachekey.cc
+++ b/plugins/experimental/cachekey/cachekey.cc
@@ -108,7 +108,7 @@ getKeyQuery(const char *query, int length, const ConfigQuery &config)
   T container;
 
   while (std::getline(istr, token, '&')) {
-    String::size_type pos(token.find_first_of("="));
+    String::size_type pos(token.find_first_of('='));
     String param(token.substr(0, pos == String::npos ? token.size() : pos));
 
     if (config.toBeAdded(param)) {
@@ -458,7 +458,7 @@ CacheKey::appendCookies(const ConfigCookies &config)
       while (std::getline(istr, cookie, ';')) {
         ::ltrim(cookie); // Trim leading spaces.
 
-        String::size_type pos(cookie.find_first_of("="));
+        String::size_type pos(cookie.find_first_of('='));
         String name(cookie.substr(0, pos == String::npos ? cookie.size() : pos));
 
         /* We only add it to the cache key it is in the cookie set. */

--- a/plugins/experimental/cachekey/pattern.cc
+++ b/plugins/experimental/cachekey/pattern.cc
@@ -86,7 +86,7 @@ Pattern::init(const String &config)
     size_t next    = 1;
     do {
       current = next + 1;
-      next    = config.find_first_of("/", current);
+      next    = config.find_first_of('/', current);
     } while (next != String::npos && '\\' == config[next - 1]);
 
     if (next != String::npos) {
@@ -100,7 +100,7 @@ Pattern::init(const String &config)
     start = next + 1;
     do {
       current = next + 1;
-      next    = config.find_first_of("/", current);
+      next    = config.find_first_of('/', current);
     } while (next != String::npos && '\\' == config[next - 1]);
 
     if (next != String::npos) {

--- a/plugins/experimental/hipes/hipes.cc
+++ b/plugins/experimental/hipes/hipes.cc
@@ -193,7 +193,7 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
 
   for (int ix = 2; ix < argc; ++ix) {
     std::string arg            = argv[ix];
-    std::string::size_type sep = arg.find_first_of(":");
+    std::string::size_type sep = arg.find_first_of(':');
 
     if (sep == std::string::npos) {
       TSError("[hipes] Malformed options in url_remap: %s", argv[ix]);
@@ -212,7 +212,7 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
       } else if (arg.compare(0, 3, "ssl") == 0) {
         ri->ssl = true;
       } else if (arg.compare(0, 7, "service") == 0) {
-        std::string::size_type port = arg_val.find_first_of(":");
+        std::string::size_type port = arg_val.find_first_of(':');
 
         if (port == std::string::npos) {
           ri->svc_server = arg_val;
@@ -221,7 +221,7 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
           ri->svc_port   = atoi(arg_val.substr(port + 1).c_str());
         }
       } else if (arg.compare(0, 6, "server") == 0) {
-        std::string::size_type port = arg_val.find_first_of(":");
+        std::string::size_type port = arg_val.find_first_of(':');
 
         if (port == std::string::npos) {
           ri->hipes_server = arg_val;

--- a/plugins/experimental/inliner/inliner-handler.cc
+++ b/plugins/experimental/inliner/inliner-handler.cc
@@ -101,7 +101,7 @@ namespace inliner
     }
 
     const bool isTagged =
-      (src.find("http://") == 0 || src.find("https://") == 0) && src.find("inline", src.find("#")) != std::string::npos;
+      (src.find("http://") == 0 || src.find("https://") == 0) && src.find("inline", src.find('#')) != std::string::npos;
 
     if (isTagged) {
       std::string classes, original = " ";

--- a/plugins/experimental/ssl_cert_loader/domain-tree.cc
+++ b/plugins/experimental/ssl_cert_loader/domain-tree.cc
@@ -30,7 +30,7 @@
 bool
 DomainNameTree::DomainNameNode::compare(std::string key, int &relative)
 {
-  size_t star_loc = key.find("*");
+  size_t star_loc = key.find('*');
   bool is_wild    = false;
 
   if (star_loc != std::string::npos) {
@@ -89,7 +89,7 @@ DomainNameTree::find(std::string key, bool best_match)
 {
   DomainNameNode *retval = nullptr;
   DomainNameNode *first  = nullptr;
-  size_t star_loc        = key.find("*");
+  size_t star_loc        = key.find('*');
   bool is_wild           = false;
 
   if (star_loc != std::string::npos) {
@@ -152,7 +152,7 @@ DomainNameTree::insert(std::string key, void *payload, int order)
   int relative;
 
   if (node->compare(key, relative)) {
-    size_t star_loc = key.find("*");
+    size_t star_loc = key.find('*');
     bool is_wild    = false;
 
     if (star_loc != std::string::npos) {

--- a/plugins/experimental/ssl_cert_loader/ssl-cert-loader.cc
+++ b/plugins/experimental/ssl_cert_loader/ssl-cert-loader.cc
@@ -88,7 +88,7 @@ Parse_Addr_String(ts::ConstBuffer const &text, IpRange &range)
   IpAddr newAddr;
   std::string textstr(text._ptr, text._size);
   // Is there a hyphen?
-  size_t hyphen_pos = textstr.find("-");
+  size_t hyphen_pos = textstr.find('-');
 
   if (hyphen_pos != std::string::npos) {
     std::string addr1 = textstr.substr(0, hyphen_pos);

--- a/plugins/header_rewrite/expander.cc
+++ b/plugins/header_rewrite/expander.cc
@@ -44,7 +44,7 @@ VariableExpander::expand(const Resources &res)
       break;
     }
 
-    std::string::size_type end = result.find(">", start);
+    std::string::size_type end = result.find('>', start);
     if (end == std::string::npos) {
       break;
     }

--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -345,7 +345,7 @@ OperatorSetRedirect::exec(const Resources &res) const
     query             = TSUrlHttpQueryGet(bufp, url_loc, &query_len);
     if ((get_oper_modifiers() & OPER_QSA) && (query_len > 0)) {
       TSDebug(PLUGIN_NAME, "QSA mode, append original query string: %.*s", query_len, query);
-      std::string connector = (value.find("?") == std::string::npos) ? "?" : "&";
+      std::string connector = (value.find('?') == std::string::npos) ? "?" : "&";
       value.append(connector);
       value.append(query, query_len);
     }

--- a/plugins/regex_remap/regex_remap.cc
+++ b/plugins/regex_remap/regex_remap.cc
@@ -326,7 +326,7 @@ RemapRegex::initialize(const std::string &reg, const std::string &sub, const std
   _next = nullptr;
 
   // Parse options
-  std::string::size_type start = opt.find_first_of("@");
+  std::string::size_type start = opt.find_first_of('@');
   std::string::size_type pos1, pos2;
   Override *last_override = nullptr;
 
@@ -334,7 +334,7 @@ RemapRegex::initialize(const std::string &reg, const std::string &sub, const std
     std::string opt_val;
 
     ++start;
-    pos1 = opt.find_first_of("=", start);
+    pos1 = opt.find_first_of('=', start);
     pos2 = opt.find_first_of(" \t\n", pos1);
     if (pos2 == std::string::npos) {
       pos2 = opt.length();
@@ -406,7 +406,7 @@ RemapRegex::initialize(const std::string &reg, const std::string &sub, const std
         TSError("[%s] Unknown options: %s", PLUGIN_NAME, opt.c_str());
       }
     }
-    start = opt.find_first_of("@", pos2);
+    start = opt.find_first_of('@', pos2);
   }
 
   return true;


### PR DESCRIPTION
Running clang-tidy over the 7.1.x branch to make things easier to backport
