### PR TITLE
Ran clang-tidy with performance-unnecessary-value-param

### DIFF
--- a/example/cppapi/async_http_fetch/AsyncHttpFetch.cc
+++ b/example/cppapi/async_http_fetch/AsyncHttpFetch.cc
@@ -25,6 +25,7 @@
 #include <atscppapi/PluginInit.h>
 #include <cstring>
 #include <cassert>
+#include <utility>
 
 using namespace atscppapi;
 using std::string;
@@ -41,20 +42,20 @@ GlobalPlugin *plugin;
 class AsyncHttpFetch2 : public AsyncHttpFetch
 {
 public:
-  AsyncHttpFetch2(string request) : AsyncHttpFetch(request){};
+  AsyncHttpFetch2(const string &request) : AsyncHttpFetch(request){};
 };
 
 class AsyncHttpFetch3 : public AsyncHttpFetch
 {
 public:
-  AsyncHttpFetch3(string request, HttpMethod method) : AsyncHttpFetch(request, method){};
+  AsyncHttpFetch3(const string &request, HttpMethod method) : AsyncHttpFetch(request, method){};
 };
 
 class DelayedAsyncHttpFetch : public AsyncHttpFetch, public AsyncReceiver<AsyncTimer>
 {
 public:
-  DelayedAsyncHttpFetch(string request, HttpMethod method, std::shared_ptr<Mutex> mutex)
-    : AsyncHttpFetch(request, method), mutex_(mutex), timer_(nullptr){};
+  DelayedAsyncHttpFetch(const string &request, HttpMethod method, std::shared_ptr<Mutex> mutex)
+    : AsyncHttpFetch(request, method), mutex_(std::move(mutex)), timer_(nullptr){};
   void
   run()
   {

--- a/example/cppapi/boom/boom.cc
+++ b/example/cppapi/boom/boom.cc
@@ -194,7 +194,7 @@ BoomResponseRegistry::register_error_codes(const std::vector<std::string> &error
   }
 }
 // forward declaration
-bool get_file_contents(std::string fileName, std::string &contents);
+bool get_file_contents(const std::string &fileName, std::string &contents);
 
 // Examine the error file directory and populate the error_response
 // map with the file contents.
@@ -339,7 +339,7 @@ stringSplit(const std::string &in, char delim, std::vector<std::string> &res)
 // Utility routine to read file contents into a string
 // @returns true if the file exists and has been successfully read
 bool
-get_file_contents(std::string fileName, std::string &contents)
+get_file_contents(const std::string &fileName, std::string &contents)
 {
   if (fileName.empty()) {
     return false;

--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -29,6 +29,7 @@
 #include "Show.h"
 #include "ts/Tokenizer.h"
 
+#include <utility>
 #include <vector>
 #include <algorithm>
 
@@ -269,7 +270,7 @@ struct HostDBSync : public HostDBBackgroundTask {
   std::string storage_path;
   std::string full_path;
   HostDBSync(int frequency, std::string storage_path, std::string full_path)
-    : HostDBBackgroundTask(frequency), storage_path(storage_path), full_path(full_path){};
+    : HostDBBackgroundTask(frequency), storage_path(std::move(storage_path)), full_path(std::move(full_path)){};
   int
   sync_event(int, void *)
   {

--- a/lib/cppapi/AsyncHttpFetch.cc
+++ b/lib/cppapi/AsyncHttpFetch.cc
@@ -30,6 +30,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <utility>
 
 using namespace atscppapi;
 using std::string;
@@ -54,7 +55,7 @@ struct atscppapi::AsyncHttpFetchState : noncopyable {
 
   AsyncHttpFetchState(const string &url_str, HttpMethod http_method, string request_body,
                       AsyncHttpFetch::StreamingFlag streaming_flag)
-    : request_body_(request_body),
+    : request_body_(std::move(request_body)),
       result_(AsyncHttpFetch::RESULT_FAILURE),
       body_(nullptr),
       body_size_(0),

--- a/lib/cppapi/Headers.cc
+++ b/lib/cppapi/Headers.cc
@@ -261,7 +261,7 @@ HeaderField::values(const char join)
 }
 
 std::string
-Headers::value(const std::string key, size_type index /* = 0 */)
+Headers::value(const std::string &key, size_type index /* = 0 */)
 {
   header_field_iterator iter = find(key);
   if (iter == end()) {

--- a/lib/cppapi/Plugin.cc
+++ b/lib/cppapi/Plugin.cc
@@ -29,7 +29,7 @@ const std::string atscppapi::HOOK_TYPE_STRINGS[] = {
   std::string("HOOK_CACHE_LOOKUP_COMPLETE"),          std::string("HOOK_SELECT_ALT")};
 
 void
-atscppapi::RegisterGlobalPlugin(std::string name, std::string vendor, std::string email)
+atscppapi::RegisterGlobalPlugin(const std::string &name, const std::string &vendor, const std::string &email)
 {
   TSPluginRegistrationInfo info;
   info.plugin_name   = const_cast<char *>(name.c_str());

--- a/lib/cppapi/Stat.cc
+++ b/lib/cppapi/Stat.cc
@@ -40,7 +40,7 @@ Stat::~Stat()
 }
 
 bool
-Stat::init(string name, Stat::SyncType type, bool persistent)
+Stat::init(const string &name, Stat::SyncType type, bool persistent)
 {
   if (TSStatFindName(name.c_str(), &stat_id_) == TS_SUCCESS) {
     LOG_DEBUG("Attached to stat '%s' with stat_id = %d", name.c_str(), stat_id_);

--- a/lib/cppapi/Transaction.cc
+++ b/lib/cppapi/Transaction.cc
@@ -25,6 +25,7 @@
 #include <cstring>
 #include <map>
 #include <string>
+#include <utility>
 
 #include "atscppapi/Transaction.h"
 #include "ts/ink_memory.h"
@@ -241,7 +242,7 @@ Transaction::getContextValue(const std::string &key)
 void
 Transaction::setContextValue(const std::string &key, std::shared_ptr<Transaction::ContextValue> value)
 {
-  state_->context_values_[key] = value;
+  state_->context_values_[key] = std::move(value);
 }
 
 ClientRequest &

--- a/lib/cppapi/include/atscppapi/Headers.h
+++ b/lib/cppapi/include/atscppapi/Headers.h
@@ -536,7 +536,7 @@ public:
     * @param position of value
     * @return value
     */
-  std::string value(const std::string key, size_type index = 0);
+  std::string value(const std::string &key, size_type index = 0);
 
   /**
     * Returns an iterator to the first HeaderField with the name key.

--- a/lib/cppapi/include/atscppapi/Plugin.h
+++ b/lib/cppapi/include/atscppapi/Plugin.h
@@ -166,7 +166,7 @@ protected:
 
 /**< Human readable strings for each HookType, you can access them as HOOK_TYPE_STRINGS[HOOK_OS_DNS] for example. */
 extern const std::string HOOK_TYPE_STRINGS[];
-void RegisterGlobalPlugin(std::string name, std::string vendor, std::string email);
+void RegisterGlobalPlugin(const std::string &name, const std::string &vendor, const std::string &email);
 
 } /* atscppapi */
 

--- a/lib/cppapi/include/atscppapi/Stat.h
+++ b/lib/cppapi/include/atscppapi/Stat.h
@@ -73,7 +73,7 @@ public:
    *
    * @see SyncType
    */
-  bool init(std::string name, Stat::SyncType type = SYNC_COUNT, bool persistent = false);
+  bool init(const std::string &name, Stat::SyncType type = SYNC_COUNT, bool persistent = false);
 
   /**
    * This method allows you to increment a stat by a certain amount.

--- a/lib/ts/test_PriorityQueue.cc
+++ b/lib/ts/test_PriorityQueue.cc
@@ -22,6 +22,7 @@
 */
 
 #include <iostream>
+#include <utility>
 #include <cstring>
 
 #include <ts/TestBox.h>
@@ -33,7 +34,7 @@ using namespace std;
 class N
 {
 public:
-  N(uint32_t w, string c) : weight(w), content(c) {}
+  N(uint32_t w, string c) : weight(w), content(std::move(c)) {}
   bool
   operator<(const N &n) const
   {

--- a/plugins/experimental/ssl_cert_loader/domain-tree.cc
+++ b/plugins/experimental/ssl_cert_loader/domain-tree.cc
@@ -43,7 +43,7 @@ DomainNameTree::DomainNameNode::compare(std::string key, int &relative)
 }
 
 bool
-DomainNameTree::DomainNameNode::prunedCompare(std::string key, int &relative, bool is_wild)
+DomainNameTree::DomainNameNode::prunedCompare(const std::string &key, int &relative, bool is_wild)
 {
   if (key == this->key) {
     relative = 0;

--- a/plugins/experimental/ssl_cert_loader/domain-tree.h
+++ b/plugins/experimental/ssl_cert_loader/domain-tree.h
@@ -52,7 +52,7 @@ public:
     // 0 if eq.  < 0 if node key is broader.  > 0 if parameter key is broader
     bool compare(std::string key, int &relative);
     // The wildcard is pruned out of the key
-    bool prunedCompare(std::string key, int &relative, bool is_wild);
+    bool prunedCompare(const std::string &key, int &relative, bool is_wild);
     std::string key; // The string trailing the * (if any)
     int order;       // Track insert order for conflict resolution
     void *payload;

--- a/plugins/header_rewrite/header_rewrite.cc
+++ b/plugins/header_rewrite/header_rewrite.cc
@@ -93,7 +93,7 @@ public:
     return _rules[hook];
   }
 
-  bool parse_config(const std::string fname, TSHttpHookID default_hook);
+  bool parse_config(const std::string &fname, TSHttpHookID default_hook);
 
   void
   hold()
@@ -149,7 +149,7 @@ RulesConfig::add_rule(RuleSet *rule)
 // anyways (or reload for remap.config), so not really in the critical path.
 //
 bool
-RulesConfig::parse_config(const std::string fname, TSHttpHookID default_hook)
+RulesConfig::parse_config(const std::string &fname, TSHttpHookID default_hook)
 {
   RuleSet *rule = nullptr;
   std::string filename;

--- a/plugins/header_rewrite/header_rewrite_test.cc
+++ b/plugins/header_rewrite/header_rewrite_test.cc
@@ -38,7 +38,7 @@ TSError(const char *fmt, ...)
 class ParserTest : public Parser
 {
 public:
-  ParserTest(std::string line) : Parser(line), res(true) { std::cout << "Finished parser test: " << line << std::endl; }
+  ParserTest(const std::string &line) : Parser(line), res(true) { std::cout << "Finished parser test: " << line << std::endl; }
   std::vector<std::string>
   getTokens()
   {

--- a/plugins/s3_auth/aws_auth_v4.cc
+++ b/plugins/s3_auth/aws_auth_v4.cc
@@ -74,7 +74,7 @@ base16Encode(const char *in, size_t inLen)
  * @return encoded string.
  */
 String
-uriEncode(const String in, bool isObjectName)
+uriEncode(const String &in, bool isObjectName)
 {
   std::stringstream result;
 

--- a/proxy/http2/test_HPACK.cc
+++ b/proxy/http2/test_HPACK.cc
@@ -163,7 +163,7 @@ compare_header_fields(HTTPHdr *a, HTTPHdr *b)
 
 // Returns -1 if test passes, or returns the failed sequence number
 int
-test_decoding(const string filename)
+test_decoding(const string &filename)
 {
   HpackIndexingTable indexing_table(INITIAL_TABLE_SIZE);
   string line, name, value;
@@ -216,7 +216,7 @@ test_decoding(const string filename)
 }
 
 int
-test_encoding(const string filename_in, const string filename_out)
+test_encoding(const string &filename_in, const string &filename_out)
 {
   HpackIndexingTable indexing_table_for_encoding(INITIAL_TABLE_SIZE), indexing_table_for_decoding(INITIAL_TABLE_SIZE);
   string line, name, value;

--- a/proxy/logging/LogField.cc
+++ b/proxy/logging/LogField.cc
@@ -242,7 +242,7 @@ LogField::LogField(const char *name, const char *symbol, Type type, MarshalFunc 
 }
 
 LogField::LogField(const char *name, const char *symbol, Type type, MarshalFunc marshal, UnmarshalFuncWithMap unmarshal,
-                   Ptr<LogFieldAliasMap> map, SetFunc _setfunc)
+                   const Ptr<LogFieldAliasMap> &map, SetFunc _setfunc)
   : m_name(ats_strdup(name)),
     m_symbol(ats_strdup(symbol)),
     m_type(type),

--- a/proxy/logging/LogField.h
+++ b/proxy/logging/LogField.h
@@ -120,7 +120,7 @@ public:
   LogField(const char *name, const char *symbol, Type type, MarshalFunc marshal, UnmarshalFunc unmarshal, SetFunc _setFunc = NULL);
 
   LogField(const char *name, const char *symbol, Type type, MarshalFunc marshal, UnmarshalFuncWithMap unmarshal,
-           Ptr<LogFieldAliasMap> map, SetFunc _setFunc = NULL);
+           const Ptr<LogFieldAliasMap> &map, SetFunc _setFunc = NULL);
 
   LogField(const char *field, Container container, SetFunc _setFunc = NULL);
   LogField(const LogField &rhs);


### PR DESCRIPTION
Running clang-tidy over the 7.1.x branch to make things easier to backport
