### PR TITLE
Ran clang-tidy with modernize-use-override

### DIFF
--- a/example/cppapi/async_http_fetch/AsyncHttpFetch.cc
+++ b/example/cppapi/async_http_fetch/AsyncHttpFetch.cc
@@ -56,13 +56,13 @@ public:
   DelayedAsyncHttpFetch(string request, HttpMethod method, std::shared_ptr<Mutex> mutex)
     : AsyncHttpFetch(request, method), mutex_(mutex), timer_(nullptr){};
   void
-  run()
+  run() override
   {
     timer_ = new AsyncTimer(AsyncTimer::TYPE_ONE_OFF, 1000 /* 1s */);
     Async::execute(this, timer_, mutex_);
   }
   void
-  handleAsyncComplete(AsyncTimer & /*timer ATS_UNUSED */)
+  handleAsyncComplete(AsyncTimer & /*timer ATS_UNUSED */) override
   {
     TS_DEBUG(TAG, "Receiver should not be reachable");
     assert(!getDispatchController()->dispatch());
@@ -73,7 +73,7 @@ public:
   {
     return getDispatchController()->isEnabled();
   }
-  ~DelayedAsyncHttpFetch() { delete timer_; }
+  ~DelayedAsyncHttpFetch() override { delete timer_; }
 private:
   std::shared_ptr<Mutex> mutex_;
   AsyncTimer *timer_;
@@ -94,7 +94,7 @@ public:
   }
 
   void
-  handleSendRequestHeaders(Transaction & /*transaction ATS_UNUSED */)
+  handleSendRequestHeaders(Transaction & /*transaction ATS_UNUSED */) override
   {
     Async::execute<AsyncHttpFetch>(this, new AsyncHttpFetch("http://127.0.0.1/"), getMutex());
     ++num_fetches_pending_;
@@ -122,7 +122,7 @@ public:
   }
 
   void
-  handleAsyncComplete(AsyncHttpFetch &async_http_fetch)
+  handleAsyncComplete(AsyncHttpFetch &async_http_fetch) override
   {
     // This will be called when our async event is complete.
     TS_DEBUG(TAG, "AsyncHttpFetch completed");
@@ -130,14 +130,14 @@ public:
   }
 
   void
-  handleAsyncComplete(AsyncHttpFetch2 &async_http_fetch)
+  handleAsyncComplete(AsyncHttpFetch2 &async_http_fetch) override
   {
     // This will be called when our async event is complete.
     TS_DEBUG(TAG, "AsyncHttpFetch2 completed");
     handleAnyAsyncComplete(async_http_fetch);
   }
 
-  virtual ~TransactionHookPlugin()
+  ~TransactionHookPlugin() override
   {
     TS_DEBUG(TAG, "Destroyed TransactionHookPlugin!");
     // since we die right away, we should not receive the callback for this (using POST request this time)
@@ -145,13 +145,13 @@ public:
   }
 
   void
-  handleAsyncComplete(AsyncHttpFetch3 & /* async_http_fetch ATS_UNUSED */)
+  handleAsyncComplete(AsyncHttpFetch3 & /* async_http_fetch ATS_UNUSED */) override
   {
     assert(!"AsyncHttpFetch3 shouldn't have completed!");
   }
 
   void
-  handleAsyncComplete(DelayedAsyncHttpFetch & /*async_http_fetch ATS_UNUSED */)
+  handleAsyncComplete(DelayedAsyncHttpFetch & /*async_http_fetch ATS_UNUSED */) override
   {
     assert(!"Should've been canceled!");
   }
@@ -197,8 +197,8 @@ public:
     registerHook(HOOK_READ_REQUEST_HEADERS_POST_REMAP);
   }
 
-  virtual void
-  handleReadRequestHeadersPostRemap(Transaction &transaction)
+  void
+  handleReadRequestHeadersPostRemap(Transaction &transaction) override
   {
     TS_DEBUG(TAG, "Received a request in handleReadRequestHeadersPostRemap.");
 

--- a/example/cppapi/async_http_fetch_streaming/AsyncHttpFetchStreaming.cc
+++ b/example/cppapi/async_http_fetch_streaming/AsyncHttpFetchStreaming.cc
@@ -47,10 +47,10 @@ public:
   {
     main_url_ = transaction.getClientRequest().getUrl().getUrlString();
   }
-  void consume(const string &data, InterceptPlugin::RequestDataType type);
-  void handleInputComplete();
-  void handleAsyncComplete(AsyncHttpFetch &async_http_fetch);
-  ~Intercept();
+  void consume(const string &data, InterceptPlugin::RequestDataType type) override;
+  void handleInputComplete() override;
+  void handleAsyncComplete(AsyncHttpFetch &async_http_fetch) override;
+  ~Intercept() override;
 
 private:
   Transaction &transaction_;
@@ -68,7 +68,7 @@ public:
     GlobalPlugin::registerHook(Plugin::HOOK_READ_REQUEST_HEADERS_PRE_REMAP);
   }
   void
-  handleReadRequestHeadersPreRemap(Transaction &transaction)
+  handleReadRequestHeadersPreRemap(Transaction &transaction) override
   {
     transaction.addPlugin(new Intercept(transaction));
     TS_DEBUG(TAG, "Added intercept");

--- a/example/cppapi/async_timer/AsyncTimer.cc
+++ b/example/cppapi/async_timer/AsyncTimer.cc
@@ -38,7 +38,7 @@ public:
   }
 
   void
-  handleAsyncComplete(AsyncTimer &timer ATSCPPAPI_UNUSED)
+  handleAsyncComplete(AsyncTimer &timer ATSCPPAPI_UNUSED) override
   {
     TS_DEBUG(TAG, "Got timer event in object %p!", this);
     if ((type_ == AsyncTimer::TYPE_ONE_OFF) || (max_instances_ && (++instance_count_ == max_instances_))) {
@@ -47,7 +47,7 @@ public:
     }
   }
 
-  ~TimerEventReceiver() { delete timer_; }
+  ~TimerEventReceiver() override { delete timer_; }
 private:
   int max_instances_;
   int instance_count_;

--- a/example/cppapi/boom/boom.cc
+++ b/example/cppapi/boom/boom.cc
@@ -312,7 +312,7 @@ public:
   }
 
   void
-  handleSendResponseHeaders(Transaction &transaction)
+  handleSendResponseHeaders(Transaction &transaction) override
   {
     transaction.getClientResponse().setStatusCode(status_);
     transaction.getClientResponse().setReasonPhrase(reason_);
@@ -376,7 +376,7 @@ public:
   }
 
   // Upcall method that is called for every transaction.
-  void handleReadResponseHeaders(Transaction &transaction);
+  void handleReadResponseHeaders(Transaction &transaction) override;
 
 private:
   BoomGlobalPlugin();

--- a/example/cppapi/clientredirect/ClientRedirect.cc
+++ b/example/cppapi/clientredirect/ClientRedirect.cc
@@ -48,7 +48,7 @@ public:
   }
 
   void
-  handleSendResponseHeaders(Transaction &transaction)
+  handleSendResponseHeaders(Transaction &transaction) override
   {
     transaction.getClientResponse().setStatusCode(HTTP_STATUS_MOVED_TEMPORARILY);
     transaction.getClientResponse().setReasonPhrase("Moved Temporarily");
@@ -56,7 +56,7 @@ public:
     transaction.resume();
   }
 
-  virtual ~ClientRedirectTransactionPlugin() {}
+  ~ClientRedirectTransactionPlugin() override {}
 private:
   string location_;
 };
@@ -66,7 +66,7 @@ class ClientRedirectGlobalPlugin : public GlobalPlugin
 public:
   ClientRedirectGlobalPlugin() { registerHook(HOOK_SEND_REQUEST_HEADERS); }
   void
-  handleSendRequestHeaders(Transaction &transaction)
+  handleSendRequestHeaders(Transaction &transaction) override
   {
     if (transaction.getClientRequest().getUrl().getQuery().find("redirect=1") != string::npos) {
       transaction.addPlugin(new ClientRedirectTransactionPlugin(transaction, "http://www.linkedin.com/"));

--- a/example/cppapi/clientrequest/ClientRequest.cc
+++ b/example/cppapi/clientrequest/ClientRequest.cc
@@ -44,7 +44,7 @@ public:
   }
 
   void
-  handleReadRequestHeadersPreRemap(Transaction &transaction)
+  handleReadRequestHeadersPreRemap(Transaction &transaction) override
   {
     cout << "Hello from handleReadRequesHeadersPreRemap!" << endl;
 
@@ -69,7 +69,7 @@ public:
   }
 
   void
-  handleReadRequestHeadersPostRemap(Transaction &transaction)
+  handleReadRequestHeadersPostRemap(Transaction &transaction) override
   {
     cout << "Hello from handleReadRequesHeadersPostRemap!" << endl;
 
@@ -123,7 +123,7 @@ public:
   }
 
   void
-  handleSendRequestHeaders(Transaction &transaction)
+  handleSendRequestHeaders(Transaction &transaction) override
   {
     cout << "Hello from handleSendRequestHeaders!" << endl;
     cout << "---------------------IP INFORMATION-----------------" << endl;

--- a/example/cppapi/custom_error_remap_plugin/CustomErrorRemapPlugin.cc
+++ b/example/cppapi/custom_error_remap_plugin/CustomErrorRemapPlugin.cc
@@ -33,7 +33,7 @@ class MyRemapPlugin : public RemapPlugin
 public:
   MyRemapPlugin(void **instance_handle) : RemapPlugin(instance_handle) {}
   Result
-  doRemap(const Url &map_from_url, const Url &map_to_url, Transaction &transaction, bool &redirect)
+  doRemap(const Url &map_from_url, const Url &map_to_url, Transaction &transaction, bool &redirect) override
   {
     if (transaction.getClientRequest().getUrl().getQuery().find("custom=1") != string::npos) {
       transaction.setStatusCode(HTTP_STATUS_FORBIDDEN);

--- a/example/cppapi/customresponse/CustomResponse.cc
+++ b/example/cppapi/customresponse/CustomResponse.cc
@@ -53,14 +53,14 @@ public:
   }
 
   void
-  handleSendResponseHeaders(Transaction &transaction)
+  handleSendResponseHeaders(Transaction &transaction) override
   {
     transaction.getClientResponse().setStatusCode(status_);
     transaction.getClientResponse().setReasonPhrase(reason_);
     transaction.resume();
   }
 
-  virtual ~CustomResponseTransactionPlugin() {}
+  ~CustomResponseTransactionPlugin() override {}
 private:
   HttpStatus status_;
   string reason_;
@@ -72,7 +72,7 @@ class ClientRedirectGlobalPlugin : public GlobalPlugin
 public:
   ClientRedirectGlobalPlugin() { registerHook(HOOK_SEND_REQUEST_HEADERS); }
   void
-  handleSendRequestHeaders(Transaction &transaction)
+  handleSendRequestHeaders(Transaction &transaction) override
   {
     if (transaction.getClientRequest().getUrl().getQuery().find("custom=1") != string::npos) {
       transaction.addPlugin(new CustomResponseTransactionPlugin(transaction, HTTP_STATUS_OK, "Ok",

--- a/example/cppapi/globalhook/GlobalHookPlugin.cc
+++ b/example/cppapi/globalhook/GlobalHookPlugin.cc
@@ -33,8 +33,8 @@ class GlobalHookPlugin : public GlobalPlugin
 {
 public:
   GlobalHookPlugin() { registerHook(HOOK_READ_REQUEST_HEADERS_PRE_REMAP); }
-  virtual void
-  handleReadRequestHeadersPreRemap(Transaction &transaction)
+  void
+  handleReadRequestHeadersPreRemap(Transaction &transaction) override
   {
     std::cout << "Hello from handleReadRequesHeadersPreRemap!" << std::endl;
     transaction.resume();

--- a/example/cppapi/gzip_transformation/GzipTransformationPlugin.cc
+++ b/example/cppapi/gzip_transformation/GzipTransformationPlugin.cc
@@ -95,7 +95,7 @@ public:
   }
 
   void
-  handleSendResponseHeaders(Transaction &transaction)
+  handleSendResponseHeaders(Transaction &transaction) override
   {
     TS_DEBUG(TAG, "Added X-Content-Transformed header");
     transaction.getClientResponse().getHeaders()["X-Content-Transformed"] = "1";
@@ -103,13 +103,13 @@ public:
   }
 
   void
-  consume(const string &data)
+  consume(const string &data) override
   {
     produce(data);
   }
 
   void
-  handleInputComplete()
+  handleInputComplete() override
   {
     Helpers::ContentType content_type = Helpers::getContentType(transaction_);
     if (content_type == Helpers::TEXT_HTML) {
@@ -124,7 +124,7 @@ public:
     setOutputComplete();
   }
 
-  virtual ~SomeTransformationPlugin() {}
+  ~SomeTransformationPlugin() override {}
 private:
   Transaction &transaction_;
 };
@@ -139,8 +139,8 @@ public:
     registerHook(HOOK_SEND_RESPONSE_HEADERS);
   }
 
-  virtual void
-  handleSendRequestHeaders(Transaction &transaction)
+  void
+  handleSendRequestHeaders(Transaction &transaction) override
   {
     // Since we can only decompress gzip we will change the accept encoding header
     // to gzip, even if the user cannot accept gziped content we will return to them
@@ -154,8 +154,8 @@ public:
     transaction.resume();
   }
 
-  virtual void
-  handleReadResponseHeaders(Transaction &transaction)
+  void
+  handleReadResponseHeaders(Transaction &transaction) override
   {
     TS_DEBUG(TAG, "Determining if we need to add an inflate transformation or a deflate transformation..");
     // We're guaranteed to have been returned either gzipped content or Identity.
@@ -176,8 +176,8 @@ public:
     transaction.resume();
   }
 
-  virtual void
-  handleSendResponseHeaders(Transaction &transaction)
+  void
+  handleSendResponseHeaders(Transaction &transaction) override
   {
     // If the client supported gzip then we can guarantee they are receiving gzip since regardless of the
     // origins content-encoding we returned gzip, so let's make sure the content-encoding header is correctly

--- a/example/cppapi/intercept/intercept.cc
+++ b/example/cppapi/intercept/intercept.cc
@@ -36,9 +36,9 @@ class Intercept : public InterceptPlugin
 {
 public:
   Intercept(Transaction &transaction) : InterceptPlugin(transaction, InterceptPlugin::SERVER_INTERCEPT) {}
-  void consume(const string &data, InterceptPlugin::RequestDataType type);
-  void handleInputComplete();
-  ~Intercept() { cout << "Shutting down" << endl; }
+  void consume(const string &data, InterceptPlugin::RequestDataType type) override;
+  void handleInputComplete() override;
+  ~Intercept() override { cout << "Shutting down" << endl; }
 };
 
 class InterceptInstaller : public GlobalPlugin
@@ -49,7 +49,7 @@ public:
     GlobalPlugin::registerHook(Plugin::HOOK_READ_REQUEST_HEADERS_PRE_REMAP);
   }
   void
-  handleReadRequestHeadersPreRemap(Transaction &transaction)
+  handleReadRequestHeadersPreRemap(Transaction &transaction) override
   {
     transaction.addPlugin(new Intercept(transaction));
     cout << "Added intercept" << endl;

--- a/example/cppapi/internal_transaction_handling/InternalTransactionHandling.cc
+++ b/example/cppapi/internal_transaction_handling/InternalTransactionHandling.cc
@@ -41,8 +41,8 @@ public:
     registerHook(HOOK_READ_REQUEST_HEADERS_POST_REMAP);
   }
 
-  virtual void
-  handleReadRequestHeadersPostRemap(Transaction &transaction)
+  void
+  handleReadRequestHeadersPostRemap(Transaction &transaction) override
   {
     TS_DEBUG(TAG, "Received a request in handleReadRequestHeadersPostRemap.");
     transaction.resume();
@@ -58,8 +58,8 @@ public:
     registerHook(HOOK_READ_REQUEST_HEADERS_POST_REMAP);
   }
 
-  virtual void
-  handleReadRequestHeadersPostRemap(Transaction &transaction)
+  void
+  handleReadRequestHeadersPostRemap(Transaction &transaction) override
   {
     TS_DEBUG(TAG, "Received a request in handleReadRequestHeadersPostRemap.");
     std::shared_ptr<Mutex> mutex(new Mutex());                                            // required for async operation
@@ -68,7 +68,7 @@ public:
   }
 
   void
-  handleAsyncComplete(AsyncHttpFetch &provider ATSCPPAPI_UNUSED)
+  handleAsyncComplete(AsyncHttpFetch &provider ATSCPPAPI_UNUSED) override
   {
   }
 };

--- a/example/cppapi/logger_example/LoggerExample.cc
+++ b/example/cppapi/logger_example/LoggerExample.cc
@@ -58,8 +58,8 @@ public:
     registerHook(HOOK_READ_REQUEST_HEADERS_POST_REMAP);
   }
 
-  virtual void
-  handleReadRequestHeadersPostRemap(Transaction &transaction)
+  void
+  handleReadRequestHeadersPostRemap(Transaction &transaction) override
   {
     LOG_DEBUG(log, "handleReadRequestHeadersPostRemap.\n"
                    "\tRequest URL: %s\n"

--- a/example/cppapi/multiple_transaction_hooks/MultipleTransactionHookPlugins.cc
+++ b/example/cppapi/multiple_transaction_hooks/MultipleTransactionHookPlugins.cc
@@ -37,9 +37,9 @@ public:
     std::cout << "Constructed MultipleTransactionHookPluginsOne!" << std::endl;
   }
 
-  virtual ~MultipleTransactionHookPluginsOne() { std::cout << "Destroyed MultipleTransactionHookPluginsOne!" << std::endl; }
+  ~MultipleTransactionHookPluginsOne() override { std::cout << "Destroyed MultipleTransactionHookPluginsOne!" << std::endl; }
   void
-  handleSendResponseHeaders(Transaction &transaction)
+  handleSendResponseHeaders(Transaction &transaction) override
   {
     std::cerr << "MultipleTransactionHookPluginsOne -- Send response headers!" << std::endl;
     transaction.resume();
@@ -56,9 +56,9 @@ public:
     std::cout << "Constructed MultipleTransactionHookPluginsTwo!" << std::endl;
   }
 
-  virtual ~MultipleTransactionHookPluginsTwo() { std::cout << "Destroyed MultipleTransactionHookPluginsTwo!" << std::endl; }
+  ~MultipleTransactionHookPluginsTwo() override { std::cout << "Destroyed MultipleTransactionHookPluginsTwo!" << std::endl; }
   void
-  handleSendRequestHeaders(Transaction &transaction)
+  handleSendRequestHeaders(Transaction &transaction) override
   {
     std::cout << "MultipleTransactionHookPluginsTwo -- Send request headers!" << std::endl;
     some_container_.push_back("We have transaction scoped storage in Transaction Hooks!");
@@ -66,7 +66,7 @@ public:
   }
 
   void
-  handleSendResponseHeaders(Transaction &transaction)
+  handleSendResponseHeaders(Transaction &transaction) override
   {
     std::cout << "MultipleTransactionHookPluginsTwo -- Send response headers!" << std::endl;
 
@@ -86,8 +86,8 @@ class GlobalHookPlugin : public atscppapi::GlobalPlugin
 {
 public:
   GlobalHookPlugin() { GlobalPlugin::registerHook(HOOK_READ_REQUEST_HEADERS_PRE_REMAP); }
-  virtual void
-  handleReadRequestHeadersPreRemap(Transaction &transaction)
+  void
+  handleReadRequestHeadersPreRemap(Transaction &transaction) override
   {
     std::cout << "Hello from handleReadRequesHeadersPreRemap!" << std::endl;
 

--- a/example/cppapi/null_transformation_plugin/NullTransformationPlugin.cc
+++ b/example/cppapi/null_transformation_plugin/NullTransformationPlugin.cc
@@ -43,32 +43,32 @@ public:
   }
 
   void
-  handleSendRequestHeaders(Transaction &transaction)
+  handleSendRequestHeaders(Transaction &transaction) override
   {
     transaction.getServerRequest().getHeaders()["X-Content-Transformed"] = "1";
     transaction.resume();
   }
 
   void
-  handleSendResponseHeaders(Transaction &transaction)
+  handleSendResponseHeaders(Transaction &transaction) override
   {
     transaction.getClientResponse().getHeaders()["X-Content-Transformed"] = "1";
     transaction.resume();
   }
 
   void
-  consume(const string &data)
+  consume(const string &data) override
   {
     produce(data);
   }
 
   void
-  handleInputComplete()
+  handleInputComplete() override
   {
     setOutputComplete();
   }
 
-  virtual ~NullTransformationPlugin() {}
+  ~NullTransformationPlugin() override {}
 private:
 };
 
@@ -81,15 +81,15 @@ public:
     registerHook(HOOK_READ_RESPONSE_HEADERS);
   }
 
-  virtual void
-  handleReadRequestHeadersPostRemap(Transaction &transaction)
+  void
+  handleReadRequestHeadersPostRemap(Transaction &transaction) override
   {
     transaction.addPlugin(new NullTransformationPlugin(transaction, TransformationPlugin::REQUEST_TRANSFORMATION));
     transaction.resume();
   }
 
-  virtual void
-  handleReadResponseHeaders(Transaction &transaction)
+  void
+  handleReadResponseHeaders(Transaction &transaction) override
   {
     transaction.addPlugin(new NullTransformationPlugin(transaction, TransformationPlugin::RESPONSE_TRANSFORMATION));
     transaction.resume();

--- a/example/cppapi/post_buffer/PostBuffer.cc
+++ b/example/cppapi/post_buffer/PostBuffer.cc
@@ -43,19 +43,19 @@ public:
   }
 
   void
-  consume(const string &data)
+  consume(const string &data) override
   {
     buffer_.append(data);
   }
 
   void
-  handleInputComplete()
+  handleInputComplete() override
   {
     produce(buffer_);
     setOutputComplete();
   }
 
-  virtual ~PostBufferTransformationPlugin() {}
+  ~PostBufferTransformationPlugin() override {}
 private:
   Transaction &transaction_;
   string buffer_;
@@ -65,8 +65,8 @@ class GlobalHookPlugin : public GlobalPlugin
 {
 public:
   GlobalHookPlugin() { registerHook(HOOK_READ_REQUEST_HEADERS_POST_REMAP); }
-  virtual void
-  handleReadRequestHeadersPostRemap(Transaction &transaction)
+  void
+  handleReadRequestHeadersPostRemap(Transaction &transaction) override
   {
     cerr << "Read Request Headers Post Remap" << endl;
     cerr << "Path: " << transaction.getClientRequest().getUrl().getPath() << endl;

--- a/example/cppapi/remap_plugin/RemapPlugin.cc
+++ b/example/cppapi/remap_plugin/RemapPlugin.cc
@@ -38,7 +38,7 @@ class MyRemapPlugin : public RemapPlugin
 public:
   MyRemapPlugin(void **instance_handle) : RemapPlugin(instance_handle) {}
   Result
-  doRemap(const Url &map_from_url, const Url &map_to_url, Transaction &transaction, bool &redirect)
+  doRemap(const Url &map_from_url, const Url &map_to_url, Transaction &transaction, bool &redirect) override
   {
     Url &request_url = transaction.getClientRequest().getUrl();
     TS_DEBUG(LOG_TAG, "from URL is [%s], to URL is [%s], request URL is [%s]", map_from_url.getUrlString().c_str(),

--- a/example/cppapi/serverresponse/ServerResponse.cc
+++ b/example/cppapi/serverresponse/ServerResponse.cc
@@ -44,7 +44,7 @@ public:
   }
 
   void
-  handleSendRequestHeaders(Transaction &transaction)
+  handleSendRequestHeaders(Transaction &transaction) override
   {
     // Here we can decide to abort the request to the origin (we can do this earlier too)
     // and just send the user an error page.
@@ -62,7 +62,7 @@ public:
   }
 
   void
-  handleReadResponseHeaders(Transaction &transaction)
+  handleReadResponseHeaders(Transaction &transaction) override
   {
     cout << "Hello from handleReadResponseHeaders!" << endl;
     cout << "Server response headers are" << endl;
@@ -73,7 +73,7 @@ public:
   }
 
   void
-  handleSendResponseHeaders(Transaction &transaction)
+  handleSendResponseHeaders(Transaction &transaction) override
   {
     cout << "Hello from handleSendResponseHeaders!" << endl;
     cout << "Client response headers are" << endl;

--- a/example/cppapi/stat_example/StatExample.cc
+++ b/example/cppapi/stat_example/StatExample.cc
@@ -55,8 +55,8 @@ public:
     registerHook(HOOK_READ_REQUEST_HEADERS_POST_REMAP);
   }
 
-  virtual void
-  handleReadRequestHeadersPostRemap(Transaction &transaction)
+  void
+  handleReadRequestHeadersPostRemap(Transaction &transaction) override
   {
     TS_DEBUG(TAG, "Received a request, incrementing the counter.");
     stat.increment();

--- a/example/cppapi/timeout_example/TimeoutExamplePlugin.cc
+++ b/example/cppapi/timeout_example/TimeoutExamplePlugin.cc
@@ -39,15 +39,15 @@ public:
     registerHook(HOOK_SEND_RESPONSE_HEADERS);
   }
 
-  virtual void
-  handleSendResponseHeaders(Transaction &transaction)
+  void
+  handleSendResponseHeaders(Transaction &transaction) override
   {
     TS_DEBUG(TAG, "Sending response headers to the client, status=%d", transaction.getClientResponse().getStatusCode());
     transaction.resume();
   }
 
-  virtual void
-  handleReadRequestHeadersPreRemap(Transaction &transaction)
+  void
+  handleReadRequestHeadersPreRemap(Transaction &transaction) override
   {
     TS_DEBUG(TAG, "Setting all timeouts to 1ms, this will likely cause the transaction to receive a 504.");
     transaction.setTimeout(Transaction::TIMEOUT_CONNECT, 1);

--- a/example/cppapi/transactionhook/TransactionHookPlugin.cc
+++ b/example/cppapi/transactionhook/TransactionHookPlugin.cc
@@ -37,13 +37,13 @@ public:
     TransactionPlugin::registerHook(HOOK_SEND_RESPONSE_HEADERS);
     std::cout << "Constructed!" << std::endl;
   }
-  virtual ~TransactionHookPlugin()
+  ~TransactionHookPlugin() override
   {
     delete[] char_ptr_; // cleanup
     std::cout << "Destroyed!" << std::endl;
   }
   void
-  handleSendResponseHeaders(Transaction &transaction)
+  handleSendResponseHeaders(Transaction &transaction) override
   {
     std::cout << "Send response headers!" << std::endl;
     transaction.resume();
@@ -57,8 +57,8 @@ class GlobalHookPlugin : public atscppapi::GlobalPlugin
 {
 public:
   GlobalHookPlugin() { GlobalPlugin::registerHook(HOOK_READ_REQUEST_HEADERS_PRE_REMAP); }
-  virtual void
-  handleReadRequestHeadersPreRemap(Transaction &transaction)
+  void
+  handleReadRequestHeadersPreRemap(Transaction &transaction) override
   {
     std::cout << "Hello from handleReadRequesHeadersPreRemap!" << std::endl;
     transaction.addPlugin(new TransactionHookPlugin(transaction));

--- a/iocore/cache/CachePages.cc
+++ b/iocore/cache/CachePages.cc
@@ -153,7 +153,7 @@ struct ShowCache : public ShowCont {
     SET_HANDLER(&ShowCache::showMain);
   }
 
-  ~ShowCache()
+  ~ShowCache() override
   {
     if (show_cache_urlstrs)
       delete[] show_cache_urlstrs;

--- a/iocore/cache/CachePagesInternal.cc
+++ b/iocore/cache/CachePagesInternal.cc
@@ -49,7 +49,7 @@ struct ShowCacheInternal : public ShowCont {
     SET_HANDLER(&ShowCacheInternal::showMain);
   }
 
-  ~ShowCacheInternal() {}
+  ~ShowCacheInternal() override {}
 };
 extern ShowCacheInternal *theshowcacheInternal;
 Action *register_ShowCacheInternal(Continuation *c, HTTPHdr *h);

--- a/iocore/cache/RamCacheCLFUS.cc
+++ b/iocore/cache/RamCacheCLFUS.cc
@@ -76,12 +76,12 @@ struct RamCacheCLFUS : public RamCache {
   int64_t objects;
 
   // returns 1 on found/stored, 0 on not found/stored, if provided auxkey1 and auxkey2 must match
-  int get(INK_MD5 *key, Ptr<IOBufferData> *ret_data, uint32_t auxkey1 = 0, uint32_t auxkey2 = 0);
-  int put(INK_MD5 *key, IOBufferData *data, uint32_t len, bool copy = false, uint32_t auxkey1 = 0, uint32_t auxkey2 = 0);
-  int fixup(const INK_MD5 *key, uint32_t old_auxkey1, uint32_t old_auxkey2, uint32_t new_auxkey1, uint32_t new_auxkey2);
-  int64_t size() const;
+  int get(INK_MD5 *key, Ptr<IOBufferData> *ret_data, uint32_t auxkey1 = 0, uint32_t auxkey2 = 0) override;
+  int put(INK_MD5 *key, IOBufferData *data, uint32_t len, bool copy = false, uint32_t auxkey1 = 0, uint32_t auxkey2 = 0) override;
+  int fixup(const INK_MD5 *key, uint32_t old_auxkey1, uint32_t old_auxkey2, uint32_t new_auxkey1, uint32_t new_auxkey2) override;
+  int64_t size() const override;
 
-  void init(int64_t max_bytes, Vol *vol);
+  void init(int64_t max_bytes, Vol *vol) override;
 
   // private
   Vol *vol; // for stats

--- a/iocore/cache/RamCacheLRU.cc
+++ b/iocore/cache/RamCacheLRU.cc
@@ -40,12 +40,12 @@ struct RamCacheLRU : public RamCache {
   int64_t objects;
 
   // returns 1 on found/stored, 0 on not found/stored, if provided auxkey1 and auxkey2 must match
-  int get(INK_MD5 *key, Ptr<IOBufferData> *ret_data, uint32_t auxkey1 = 0, uint32_t auxkey2 = 0);
-  int put(INK_MD5 *key, IOBufferData *data, uint32_t len, bool copy = false, uint32_t auxkey1 = 0, uint32_t auxkey2 = 0);
-  int fixup(const INK_MD5 *key, uint32_t old_auxkey1, uint32_t old_auxkey2, uint32_t new_auxkey1, uint32_t new_auxkey2);
-  int64_t size() const;
+  int get(INK_MD5 *key, Ptr<IOBufferData> *ret_data, uint32_t auxkey1 = 0, uint32_t auxkey2 = 0) override;
+  int put(INK_MD5 *key, IOBufferData *data, uint32_t len, bool copy = false, uint32_t auxkey1 = 0, uint32_t auxkey2 = 0) override;
+  int fixup(const INK_MD5 *key, uint32_t old_auxkey1, uint32_t old_auxkey2, uint32_t new_auxkey1, uint32_t new_auxkey2) override;
+  int64_t size() const override;
 
-  void init(int64_t max_bytes, Vol *vol);
+  void init(int64_t max_bytes, Vol *vol) override;
 
   // private
   uint16_t *seen;

--- a/iocore/cluster/ClusterAPI.cc
+++ b/iocore/cluster/ClusterAPI.cc
@@ -94,7 +94,7 @@ public:
   {
     SET_HANDLER((MachineStatusSMHandler)&MachineStatusSM::MachineStatusSMEvent);
   }
-  ~MachineStatusSM() {}
+  ~MachineStatusSM() override {}
   int MachineStatusSMEvent(Event *e, void *d);
 
 private:
@@ -197,7 +197,7 @@ public:
   {
     SET_HANDLER((ClusterAPIPeriodicSMHandler)&ClusterAPIPeriodicSM::ClusterAPIPeriodicSMEvent);
   }
-  ~ClusterAPIPeriodicSM() {}
+  ~ClusterAPIPeriodicSM() override {}
   int ClusterAPIPeriodicSMEvent(int, void *);
   MachineStatusSM *GetNextSM();
 

--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -271,7 +271,7 @@ struct HostDBSync : public HostDBBackgroundTask {
   HostDBSync(int frequency, std::string storage_path, std::string full_path)
     : HostDBBackgroundTask(frequency), storage_path(storage_path), full_path(full_path){};
   int
-  sync_event(int, void *)
+  sync_event(int, void *) override
   {
     SET_HANDLER(&HostDBSync::wait_event);
     start_time = Thread::get_hrtime();

--- a/iocore/hostdb/test_RefCountCache.cc
+++ b/iocore/hostdb/test_RefCountCache.cc
@@ -59,7 +59,7 @@ public:
 
   // Really free the memory, we can use asan leak detection to verify it was freed
   void
-  free()
+  free() override
   {
     this->idx = -1;
     items_freed.insert(this);

--- a/iocore/net/UnixNetProcessor.cc
+++ b/iocore/net/UnixNetProcessor.cc
@@ -371,7 +371,7 @@ struct CheckConnect : public Continuation {
     reader = buf->alloc_reader();
   }
 
-  ~CheckConnect()
+  ~CheckConnect() override
   {
     buf->dealloc_all_readers();
     buf->clear();

--- a/iocore/net/UnixUDPNet.cc
+++ b/iocore/net/UnixUDPNet.cc
@@ -176,7 +176,7 @@ class UDPReadContinuation : public Continuation
 public:
   UDPReadContinuation(Event *completionToken);
   UDPReadContinuation();
-  ~UDPReadContinuation();
+  ~UDPReadContinuation() override;
   inline void free();
   inline void init_token(Event *completionToken);
   inline void init_read(int fd, IOBufferBlock *buf, int len, struct sockaddr *fromaddr, socklen_t *fromaddrlen);

--- a/lib/records/RecProcess.cc
+++ b/lib/records/RecProcess.cc
@@ -179,7 +179,7 @@ struct sync_cont : public Continuation {
     m_tb = new textBuffer(65536);
   }
 
-  ~sync_cont()
+  ~sync_cont() override
   {
     if (m_tb != nullptr) {
       delete m_tb;

--- a/lib/ts/IpMap.cc
+++ b/lib/ts/IpMap.cc
@@ -748,21 +748,21 @@ namespace detail
       ats_ip4_set(ats_ip_sa_cast(&_sa._max), htonl(max));
     }
     /// @return The minimum value of the interval.
-    virtual sockaddr const *
-    min() const
+    sockaddr const *
+    min() const override
     {
       return ats_ip_sa_cast(&_sa._min);
     }
     /// @return The maximum value of the interval.
-    virtual sockaddr const *
-    max() const
+    sockaddr const *
+    max() const override
     {
       return ats_ip_sa_cast(&_sa._max);
     }
     /// Set the client data.
     self &
     setData(void *data ///< Client data.
-            )
+            ) override
     {
       _data = data;
       return *this;
@@ -902,21 +902,21 @@ namespace detail
     {
     }
     /// @return The minimum value of the interval.
-    virtual sockaddr const *
-    min() const
+    sockaddr const *
+    min() const override
     {
       return ats_ip_sa_cast(&_min);
     }
     /// @return The maximum value of the interval.
-    virtual sockaddr const *
-    max() const
+    sockaddr const *
+    max() const override
     {
       return ats_ip_sa_cast(&_max);
     }
     /// Set the client data.
     self &
     setData(void *data ///< Client data.
-            )
+            ) override
     {
       _data = data;
       return *this;

--- a/lib/ts/test_Ptr.cc
+++ b/lib/ts/test_Ptr.cc
@@ -24,7 +24,7 @@
 
 struct PtrObject : RefCountObj {
   PtrObject(unsigned *_c) : count(_c) { ++(*count); }
-  ~PtrObject() { --(*count); }
+  ~PtrObject() override { --(*count); }
   unsigned *count;
 };
 

--- a/mgmt/ProxyConfig.cc
+++ b/mgmt/ProxyConfig.cc
@@ -254,7 +254,7 @@ struct RegressionConfig : public ConfigInfo {
     ink_atomic_increment(&nobjects, 1);
   }
 
-  ~RegressionConfig()
+  ~RegressionConfig() override
   {
     TestBox box(this->test, this->pstatus);
 

--- a/plugins/experimental/balancer/hash.cc
+++ b/plugins/experimental/balancer/hash.cc
@@ -154,7 +154,7 @@ struct HashBalancer : public BalancerInstance {
 
   HashBalancer() { this->hash_parts.push_back(HashTxnUrl); }
   void
-  push_target(const BalancerTarget &target)
+  push_target(const BalancerTarget &target) override
   {
     for (unsigned i = 0; i < iterations; ++i) {
       this->hash_ring.insert(std::make_pair(md5_key(target, i), target));
@@ -162,7 +162,7 @@ struct HashBalancer : public BalancerInstance {
   }
 
   const BalancerTarget &
-  balance(TSHttpTxn txn, TSRemapRequestInfo *rri)
+  balance(TSHttpTxn txn, TSRemapRequestInfo *rri) override
   {
     md5_key key;
     MD5_CTX ctx;

--- a/plugins/experimental/balancer/roundrobin.cc
+++ b/plugins/experimental/balancer/roundrobin.cc
@@ -33,13 +33,13 @@ namespace
 struct RoundRobinBalancer : public BalancerInstance {
   RoundRobinBalancer() : targets(), next(0) {}
   void
-  push_target(const BalancerTarget &target)
+  push_target(const BalancerTarget &target) override
   {
     this->targets.push_back(target);
   }
 
   const BalancerTarget &
-  balance(TSHttpTxn, TSRemapRequestInfo *)
+  balance(TSHttpTxn, TSRemapRequestInfo *) override
   {
     return this->targets[++next % this->targets.size()];
   }

--- a/plugins/experimental/cache_promote/cache_promote.cc
+++ b/plugins/experimental/cache_promote/cache_promote.cc
@@ -117,20 +117,20 @@ private:
 class ChancePolicy : public PromotionPolicy
 {
 public:
-  bool doPromote(TSHttpTxn /* txnp ATS_UNUSED */)
+  bool doPromote(TSHttpTxn /* txnp ATS_UNUSED */) override
   {
     TSDebug(PLUGIN_NAME, "ChancePolicy::doPromote(%f)", getSample());
     return true;
   }
 
   void
-  usage() const
+  usage() const override
   {
     TSError("[%s] Usage: @plugin=%s.so @pparam=--policy=chance @pparam=--sample=<x>%%", PLUGIN_NAME, PLUGIN_NAME);
   }
 
   const char *
-  policyName() const
+  policyName() const override
   {
     return "chance";
   }
@@ -197,7 +197,7 @@ class LRUPolicy : public PromotionPolicy
 {
 public:
   LRUPolicy() : PromotionPolicy(), _buckets(1000), _hits(10), _lock(TSMutexCreate()), _list_size(0), _freelist_size(0) {}
-  ~LRUPolicy()
+  ~LRUPolicy() override
   {
     TSDebug(PLUGIN_NAME, "deleting LRUPolicy object");
     TSMutexLock(_lock);
@@ -213,7 +213,7 @@ public:
   }
 
   bool
-  parseOption(int opt, char *optarg)
+  parseOption(int opt, char *optarg) override
   {
     switch (opt) {
     case 'b':
@@ -240,7 +240,7 @@ public:
   }
 
   bool
-  doPromote(TSHttpTxn txnp)
+  doPromote(TSHttpTxn txnp) override
   {
     LRUHash hash;
     LRUMap::iterator map_it;
@@ -321,14 +321,14 @@ public:
   }
 
   void
-  usage() const
+  usage() const override
   {
     TSError("[%s] Usage: @plugin=%s.so @pparam=--policy=lru @pparam=--buckets=<n> --hits=<m> --sample=<x>", PLUGIN_NAME,
             PLUGIN_NAME);
   }
 
   const char *
-  policyName() const
+  policyName() const override
   {
     return "LRU";
   }

--- a/plugins/experimental/stream_editor/stream_editor.cc
+++ b/plugins/experimental/stream_editor/stream_editor.cc
@@ -207,9 +207,9 @@ class rxscope : public scope_t
 {
 private:
   regex_t rx;
-  virtual bool
+  bool
 
-  match(const char *str) const
+  match(const char *str) const override
   {
     return (regexec(&rx, str, 0, nullptr, 0) == 0) ? true : false;
   }
@@ -228,7 +228,7 @@ public:
     TSfree(str);
   }
 
-  virtual ~rxscope() { regfree(&rx); }
+  ~rxscope() override { regfree(&rx); }
 };
 
 class strscope : public scope_t
@@ -236,16 +236,16 @@ class strscope : public scope_t
 private:
   const bool icase;
   char *str;
-  virtual bool
+  bool
 
-  match(const char *p) const
+  match(const char *p) const override
   {
     return ((icase ? strncasecmp : strncmp)(str, p, strlen(str)) == 0) ? true : false;
   }
 
 public:
   strscope(const bool u, const bool i, const char *pattern, int len) : scope_t(u), icase(i) { str = TSstrndup(pattern, len); }
-  virtual ~strscope()
+  ~strscope() override
   {
     if (str) {
       TSfree(str);
@@ -268,8 +268,8 @@ class strmatch : public match_t
   const size_t slen;
 
 public:
-  virtual bool
-  find(const char *buf, size_t len, size_t &found, size_t &found_len, const char *to, std::string &repl) const
+  bool
+  find(const char *buf, size_t len, size_t &found, size_t &found_len, const char *to, std::string &repl) const override
   {
     const char *match = icase ? strcasestr(buf, str) : strstr(buf, str);
     if (match) {
@@ -283,15 +283,15 @@ public:
   }
 
   strmatch(const bool i, const char *pattern, int len) : icase(i), slen(len) { str = TSstrndup(pattern, len); }
-  virtual ~strmatch()
+  ~strmatch() override
   {
     if (str) {
       TSfree(str);
     }
   }
 
-  virtual size_t
-  cont_size() const
+  size_t
+  cont_size() const override
   {
     return slen;
   }
@@ -303,8 +303,8 @@ class rxmatch : public match_t
   regex_t rx;
 
 public:
-  virtual bool
-  find(const char *buf, size_t len, size_t &found, size_t &found_len, const char *tmpl, std::string &repl) const
+  bool
+  find(const char *buf, size_t len, size_t &found, size_t &found_len, const char *tmpl, std::string &repl) const override
   {
     regmatch_t pmatch[MAX_RX_MATCH];
     if (regexec(&rx, buf, MAX_RX_MATCH, pmatch, REG_NOTEOL) == 0) {
@@ -343,8 +343,8 @@ public:
     }
   }
 
-  virtual size_t
-  cont_size() const
+  size_t
+  cont_size() const override
   {
     return match_len;
   }
@@ -362,7 +362,7 @@ public:
     TSfree(str);
   }
 
-  virtual ~rxmatch() { regfree(&rx); }
+  ~rxmatch() override { regfree(&rx); }
 };
 
 #define PARSE_VERIFY(line, x, str) \

--- a/plugins/experimental/webp_transform/ImageTransform.cc
+++ b/plugins/experimental/webp_transform/ImageTransform.cc
@@ -43,7 +43,7 @@ public:
   }
 
   void
-  handleReadResponseHeaders(Transaction &transaction)
+  handleReadResponseHeaders(Transaction &transaction) override
   {
     transaction.getServerResponse().getHeaders()["Content-Type"] = "image/webp";
     transaction.getServerResponse().getHeaders()["Vary"]         = "Content-Type"; // to have a separate cache entry.
@@ -53,13 +53,13 @@ public:
   }
 
   void
-  consume(const string &data)
+  consume(const string &data) override
   {
     _img.write(data.data(), data.size());
   }
 
   void
-  handleInputComplete()
+  handleInputComplete() override
   {
     string input_data = _img.str();
     Blob input_blob(input_data.data(), input_data.length());
@@ -75,7 +75,7 @@ public:
     setOutputComplete();
   }
 
-  virtual ~ImageTransform() {}
+  ~ImageTransform() override {}
 private:
   std::stringstream _img;
 };
@@ -84,8 +84,8 @@ class GlobalHookPlugin : public GlobalPlugin
 {
 public:
   GlobalHookPlugin() { registerHook(HOOK_READ_RESPONSE_HEADERS); }
-  virtual void
-  handleReadResponseHeaders(Transaction &transaction)
+  void
+  handleReadResponseHeaders(Transaction &transaction) override
   {
     string ctype      = transaction.getServerResponse().getHeaders().values("Content-Type");
     string user_agent = transaction.getServerRequest().getHeaders().values("User-Agent");

--- a/proxy/ControlBase.cc
+++ b/proxy/ControlBase.cc
@@ -74,10 +74,10 @@ struct TimeMod : public ControlBase::Modifier {
 
   static const char *const NAME;
 
-  virtual Type type() const;
-  virtual const char *name() const;
-  virtual bool check(HttpRequestData *req) const;
-  virtual void print(FILE *f) const;
+  Type type() const override;
+  const char *name() const override;
+  bool check(HttpRequestData *req) const override;
+  void print(FILE *f) const override;
   static TimeMod *make(char *value, const char **error);
   static const char *timeOfDayToSeconds(const char *time_str, time_t *seconds);
 };
@@ -180,9 +180,9 @@ struct PortMod : public ControlBase::Modifier {
 
   static const char *const NAME;
 
-  virtual const char *name() const;
-  virtual bool check(HttpRequestData *req) const;
-  virtual void print(FILE *f) const;
+  const char *name() const override;
+  bool check(HttpRequestData *req) const override;
+  void print(FILE *f) const override;
 
   static PortMod *make(char *value, const char **error);
 };
@@ -244,9 +244,9 @@ struct IPortMod : public ControlBase::Modifier {
 
   IPortMod(int port);
 
-  virtual const char *name() const;
-  virtual bool check(HttpRequestData *req) const;
-  virtual void print(FILE *f) const;
+  const char *name() const override;
+  bool check(HttpRequestData *req) const override;
+  void print(FILE *f) const override;
   static IPortMod *make(char *value, const char **error);
 };
 
@@ -292,10 +292,10 @@ struct SrcIPMod : public ControlBase::Modifier {
 
   static const char *const NAME;
 
-  virtual Type type() const;
-  virtual const char *name() const;
-  virtual bool check(HttpRequestData *req) const;
-  virtual void print(FILE *f) const;
+  Type type() const override;
+  const char *name() const override;
+  bool check(HttpRequestData *req) const override;
+  void print(FILE *f) const override;
   static SrcIPMod *make(char *value, const char **error);
 };
 
@@ -343,10 +343,10 @@ struct SchemeMod : public ControlBase::Modifier {
 
   SchemeMod(int scheme);
 
-  virtual Type type() const;
-  virtual const char *name() const;
-  virtual bool check(HttpRequestData *req) const;
-  virtual void print(FILE *f) const;
+  Type type() const override;
+  const char *name() const override;
+  bool check(HttpRequestData *req) const override;
+  void print(FILE *f) const override;
 
   const char *getWksText() const;
 
@@ -405,10 +405,10 @@ struct TextMod : public ControlBase::Modifier {
   ts::Buffer text;
 
   TextMod();
-  ~TextMod();
+  ~TextMod() override;
 
   // Calls name() which the subclass must provide.
-  virtual void print(FILE *f) const;
+  void print(FILE *f) const override;
 
   // Copy the given NUL-terminated string to the text buffer.
   void set(const char *value);
@@ -438,13 +438,13 @@ TextMod::set(const char *value)
 struct MultiTextMod : public ControlBase::Modifier {
   Vec<ts::Buffer> text_vec;
   MultiTextMod();
-  ~MultiTextMod();
+  ~MultiTextMod() override;
 
   // Copy the value to the MultiTextMod buffer.
   void set(char *value);
 
   // Calls name() which the subclass must provide.
-  virtual void print(FILE *f) const;
+  void print(FILE *f) const override;
 };
 
 MultiTextMod::MultiTextMod()
@@ -479,9 +479,9 @@ MultiTextMod::set(char *value)
 struct MethodMod : public TextMod {
   static const char *const NAME;
 
-  virtual Type type() const;
-  virtual const char *name() const;
-  virtual bool check(HttpRequestData *req) const;
+  Type type() const override;
+  const char *name() const override;
+  bool check(HttpRequestData *req) const override;
 
   static MethodMod *make(char *value, const char **error);
 };
@@ -515,9 +515,9 @@ MethodMod::make(char *value, const char **)
 struct PrefixMod : public TextMod {
   static const char *const NAME;
 
-  virtual Type type() const;
-  virtual const char *name() const;
-  virtual bool check(HttpRequestData *req) const;
+  Type type() const override;
+  const char *name() const override;
+  bool check(HttpRequestData *req) const override;
   static PrefixMod *make(char *value, const char **error);
 };
 
@@ -563,9 +563,9 @@ PrefixMod::make(char *value, const char ** /* error ATS_UNUSED */)
 struct SuffixMod : public MultiTextMod {
   static const char *const NAME;
 
-  virtual Type type() const;
-  virtual const char *name() const;
-  virtual bool check(HttpRequestData *req) const;
+  Type type() const override;
+  const char *name() const override;
+  bool check(HttpRequestData *req) const override;
   static SuffixMod *make(char *value, const char **error);
 };
 const char *const SuffixMod::NAME = "Suffix";
@@ -611,9 +611,9 @@ SuffixMod::make(char *value, const char ** /* error ATS_UNUSED */)
 struct TagMod : public TextMod {
   static const char *const NAME;
 
-  virtual Type type() const;
-  virtual const char *name() const;
-  virtual bool check(HttpRequestData *req) const;
+  Type type() const override;
+  const char *name() const override;
+  bool check(HttpRequestData *req) const override;
   static TagMod *make(char *value, const char **error);
 };
 const char *const TagMod::NAME = "Tag";
@@ -645,23 +645,23 @@ struct InternalMod : public ControlBase::Modifier {
   bool flag;
   static const char *const NAME;
 
-  virtual Type
-  type() const
+  Type
+  type() const override
   {
     return MOD_INTERNAL;
   }
-  virtual const char *
-  name() const
+  const char *
+  name() const override
   {
     return NAME;
   }
-  virtual bool
-  check(HttpRequestData *req) const
+  bool
+  check(HttpRequestData *req) const override
   {
     return req->internal_txn == flag;
   }
-  virtual void
-  print(FILE *f) const
+  void
+  print(FILE *f) const override
   {
     fprintf(f, "%s=%s  ", this->name(), flag ? "true" : "false");
   }

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -289,7 +289,7 @@ public:
     baseline_taken = 0;
   }
 
-  ~TrackerContinuation() { mutex = nullptr; }
+  ~TrackerContinuation() override { mutex = nullptr; }
   int
   periodic(int event, Event * /* e ATS_UNUSED */)
   {
@@ -354,7 +354,7 @@ public:
     memset(&_usage, 0, sizeof(_usage));
     SET_HANDLER(&MemoryLimit::periodic);
   }
-  ~MemoryLimit() { mutex = nullptr; }
+  ~MemoryLimit() override { mutex = nullptr; }
   int
   periodic(int event, Event *e)
   {

--- a/proxy/PluginVC.cc
+++ b/proxy/PluginVC.cc
@@ -1243,7 +1243,7 @@ class PVCTestDriver : public NetTestDriver
 {
 public:
   PVCTestDriver();
-  ~PVCTestDriver();
+  ~PVCTestDriver() override;
 
   void start_tests(RegressionTest *r_arg, int *pstatus_arg);
   void run_next_test();

--- a/proxy/RegressionSM.cc
+++ b/proxy/RegressionSM.cc
@@ -252,8 +252,8 @@ RegressionSM::RegressionSM(const RegressionSM &ao) : Continuation(ao)
 }
 
 struct ReRegressionSM : public RegressionSM {
-  virtual void
-  run()
+  void
+  run() override
   {
     if (time(nullptr) < 1) { // example test
       rprintf(t, "impossible");
@@ -263,8 +263,8 @@ struct ReRegressionSM : public RegressionSM {
     }
   }
   ReRegressionSM(RegressionTest *at) : RegressionSM(at) {}
-  virtual RegressionSM *
-  clone()
+  RegressionSM *
+  clone() override
   {
     return new ReRegressionSM(*this);
   }

--- a/proxy/SocksProxy.cc
+++ b/proxy/SocksProxy.cc
@@ -69,7 +69,7 @@ struct SocksProxy : public Continuation {
       pending_action(nullptr)
   {
   }
-  ~SocksProxy() {}
+  ~SocksProxy() override {}
   // int startEvent(int event, void * data);
   int mainEvent(int event, void *data);
   int setupHttpRequest(unsigned char *p);

--- a/proxy/shared/UglyLogStubs.cc
+++ b/proxy/shared/UglyLogStubs.cc
@@ -38,8 +38,8 @@ int fds_limit = 8000;
 
 class FakeUDPNetProcessor : public UDPNetProcessor
 {
-  virtual int
-  start(int, size_t)
+  int
+  start(int, size_t) override
   {
     ink_release_assert(false);
     return 0;


### PR DESCRIPTION
Running clang-tidy over the 7.1.x branch to make things easier to backport
