### PR TITLE
Ran clang-tidy with modernize-loop-convert

### DIFF
--- a/cmd/traffic_top/traffic_top.cc
+++ b/cmd/traffic_top/traffic_top.cc
@@ -130,12 +130,12 @@ makeTable(const int x, const int y, const list<string> &items, Stats &stats)
 {
   int my_y = y;
 
-  for (list<string>::const_iterator it = items.begin(); it != items.end(); ++it) {
+  for (const auto &item : items) {
     string prettyName;
     double value = 0;
     int type;
 
-    stats.getStat(*it, value, prettyName, type);
+    stats.getStat(item, value, prettyName, type);
     mvprintw(my_y, x, prettyName.c_str());
     prettyPrint(x + 10, my_y++, value, type);
   }

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -130,9 +130,9 @@ struct VolInitInfo {
 
   ~VolInitInfo()
   {
-    for (int i = 0; i < 4; i++) {
-      vol_aio[i].action = nullptr;
-      vol_aio[i].mutex.clear();
+    for (auto &i : vol_aio) {
+      i.action = nullptr;
+      i.mutex.clear();
     }
     free(vol_h_f);
   }
@@ -1799,9 +1799,9 @@ Vol::handle_header_read(int event, void *data)
   switch (event) {
   case AIO_EVENT_DONE:
     op = (AIOCallback *)data;
-    for (int i = 0; i < 4; i++) {
+    for (auto &i : hf) {
       ink_assert(op != nullptr);
-      hf[i] = (VolHeaderFooter *)(op->aiocb.aio_buf);
+      i = (VolHeaderFooter *)(op->aiocb.aio_buf);
       if ((size_t)op->aio_result != (size_t)op->aiocb.aio_nbytes) {
         clear_dir();
         return EVENT_DONE;

--- a/iocore/cache/CacheDir.cc
+++ b/iocore/cache/CacheDir.cc
@@ -796,14 +796,14 @@ void
 dir_lookaside_cleanup(Vol *d)
 {
   ink_assert(d->mutex->thread_holding == this_ethread());
-  for (int i = 0; i < LOOKASIDE_SIZE; i++) {
-    EvacuationBlock *b = d->lookaside[i].head;
+  for (auto &i : d->lookaside) {
+    EvacuationBlock *b = i.head;
     while (b) {
       if (!dir_valid(d, &b->new_dir)) {
         EvacuationBlock *nb = b->link.next;
         DDebug("dir_lookaside", "cleanup %X %X cleaned up", b->evac_frags.earliest_key.slice32(0),
                b->evac_frags.earliest_key.slice32(1));
-        d->lookaside[i].remove(b);
+        i.remove(b);
         free_CacheVC(b->earliest_evacuator);
         free_EvacuationBlock(b, d->mutex->thread_holding);
         b = nb;

--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -841,10 +841,10 @@ get_dns(DNSHandler *h, uint16_t id)
 {
   for (DNSEntry *e = h->entries.head; e; e = (DNSEntry *)e->link.next) {
     if (e->once_written_flag) {
-      for (int j = 0; j < MAX_DNS_RETRIES; j++) {
-        if (e->id[j] == id) {
+      for (int j : e->id) {
+        if (j == id) {
           return e;
-        } else if (e->id[j] < 0) {
+        } else if (j < 0) {
           goto Lnext;
         }
       }
@@ -1213,17 +1213,17 @@ dns_result(DNSHandler *h, DNSEntry *e, HostEnt *ent, bool retry)
       Debug("dns", "failed lock for result %s", e->qname);
       goto Lretry;
     }
-    for (int i = 0; i < MAX_DNS_RETRIES; i++) {
-      if (e->id[i] < 0)
+    for (int i : e->id) {
+      if (i < 0)
         break;
-      h->release_query_id(e->id[i]);
+      h->release_query_id(i);
     }
     e->postEvent(0, nullptr);
   } else {
-    for (int i = 0; i < MAX_DNS_RETRIES; i++) {
-      if (e->id[i] < 0)
+    for (int i : e->id) {
+      if (i < 0)
         break;
-      h->release_query_id(e->id[i]);
+      h->release_query_id(i);
     }
     e->mutex = e->action.mutex;
     SET_CONTINUATION_HANDLER(e, &DNSEntry::postEvent);

--- a/lib/bindings/metrics.cc
+++ b/lib/bindings/metrics.cc
@@ -169,8 +169,8 @@ metrics_gc(lua_State *L)
   metrics_binding *m = metrics_binding::check(L, 1);
 
   // Clean up any references we stashed.
-  for (metrics_binding::ref_map::iterator ptr = m->refs.begin(); ptr != m->refs.end(); ++ptr) {
-    luaL_unref(L, LUA_REGISTRYINDEX, ptr->second);
+  for (auto &ref : m->refs) {
+    luaL_unref(L, LUA_REGISTRYINDEX, ref.second);
   }
 
   m->~metrics_binding();

--- a/lib/cppapi/utils_internal.cc
+++ b/lib/cppapi/utils_internal.cc
@@ -76,12 +76,12 @@ handleTransactionEvents(TSCont cont, TSEvent event, void *edata)
   case TS_EVENT_HTTP_TXN_CLOSE: { // opening scope to declare plugins variable below
     resetTransactionHandles(transaction, event);
     const std::list<TransactionPlugin *> &plugins = utils::internal::getTransactionPlugins(transaction);
-    for (std::list<TransactionPlugin *>::const_iterator iter = plugins.begin(), end = plugins.end(); iter != end; ++iter) {
-      std::shared_ptr<Mutex> trans_mutex = utils::internal::getTransactionPluginMutex(**iter);
-      LOG_DEBUG("Locking TransacitonPlugin mutex to delete transaction plugin at %p", *iter);
+    for (auto plugin : plugins) {
+      std::shared_ptr<Mutex> trans_mutex = utils::internal::getTransactionPluginMutex(*plugin);
+      LOG_DEBUG("Locking TransacitonPlugin mutex to delete transaction plugin at %p", plugin);
       trans_mutex->lock();
-      LOG_DEBUG("Locked Mutex...Deleting transaction plugin at %p", *iter);
-      delete *iter;
+      LOG_DEBUG("Locked Mutex...Deleting transaction plugin at %p", plugin);
+      delete plugin;
       trans_mutex->unlock();
     }
     delete &transaction;

--- a/lib/ts/Tokenizer.cc
+++ b/lib/ts/Tokenizer.cc
@@ -71,8 +71,8 @@ Tokenizer::~Tokenizer()
 
   while (cur != nullptr) {
     if (options & COPY_TOKS) {
-      for (int i = 0; i < TOK_NODE_ELEMENTS; i++)
-        ats_free(cur->el[i]);
+      for (auto &i : cur->el)
+        ats_free(i);
     }
 
     next = cur->next;
@@ -356,8 +356,8 @@ Tokenizer::ReUse()
 
   while (cur_node != nullptr) {
     if (options & COPY_TOKS) {
-      for (int i = 0; i < TOK_NODE_ELEMENTS; i++)
-        ats_free(cur_node->el[i]);
+      for (auto &i : cur_node->el)
+        ats_free(i);
     }
     memset(cur_node->el, 0, sizeof(char *) * TOK_NODE_ELEMENTS);
     cur_node = cur_node->next;

--- a/lib/ts/ink_res_init.cc
+++ b/lib/ts/ink_res_init.cc
@@ -614,14 +614,14 @@ ts_host_res_order_to_string(HostResPreferenceOrder const &order, char *out, int 
 {
   int zret   = 0;
   bool first = true;
-  for (int i = 0; i < N_HOST_RES_PREFERENCE_ORDER; ++i) {
+  for (auto i : order) {
     /* Note we use a semi-colon here because this must be compatible
      * with the -httpport command line option which uses comma to
      * separate port descriptors so we cannot use that to separate
      * resolution key words.
      */
-    zret += snprintf(out + zret, size - zret, "%s%s", !first ? ";" : "", HOST_RES_PREFERENCE_STRING[order[i]]);
-    if (HOST_RES_PREFER_NONE == order[i])
+    zret += snprintf(out + zret, size - zret, "%s%s", !first ? ";" : "", HOST_RES_PREFERENCE_STRING[i]);
+    if (HOST_RES_PREFER_NONE == i)
       break;
     first = false;
   }

--- a/lib/tsconfig/TsValue.cc
+++ b/lib/tsconfig/TsValue.cc
@@ -55,8 +55,8 @@ unsigned int const detail::Type_Property[N_VALUE_TYPES] = {
 // ---------------------------------------------------------------------------
 detail::ValueTableImpl::ValueTableImpl() : _generation(0) { }
 detail::ValueTableImpl::~ValueTableImpl() {
-  for ( BufferGroup::iterator spot(_buffers.begin()), limit(_buffers.end()) ; spot != limit ; ++spot)
-    free(spot->_ptr);
+  for (auto & _buffer : _buffers)
+    free(_buffer._ptr);
 }
 // ---------------------------------------------------------------------------
 detail::ValueTable::ImplType*
@@ -135,9 +135,9 @@ Value::operator [] (ConstBuffer const& name) const {
   Value zret;
   detail::ValueItem const* item = this->item();
   if (item) {
-    for ( detail::ValueItem::ChildGroup::const_iterator spot = item->_children.begin(), limit = item->_children.end(); spot != limit; ++spot ) {
-      if (_config._table[*spot]._name == name) {
-        zret = Value(_config, *spot);
+    for (const auto & spot : item->_children) {
+      if (_config._table[spot]._name == name) {
+        zret = Value(_config, spot);
         if (PathValue == zret.getType()) zret = _config.getRoot().find(_config._table[zret._vidx]._path);
         break;
       }

--- a/mgmt/api/EventCallback.cc
+++ b/mgmt/api/EventCallback.cc
@@ -83,8 +83,8 @@ create_callback_table(const char *lock_name)
 {
   CallbackTable *cb_table = (CallbackTable *)ats_malloc(sizeof(CallbackTable));
 
-  for (int i = 0; i < NUM_EVENTS; i++) {
-    cb_table->event_callback_l[i] = nullptr;
+  for (auto &i : cb_table->event_callback_l) {
+    i = nullptr;
   }
 
   // initialize the mutex
@@ -110,15 +110,15 @@ delete_callback_table(CallbackTable *cb_table)
   ink_mutex_acquire(&cb_table->event_callback_lock);
 
   // for each event
-  for (int i = 0; i < NUM_EVENTS; i++) {
-    if (cb_table->event_callback_l[i]) {
+  for (auto &i : cb_table->event_callback_l) {
+    if (i) {
       // remove and delete each EventCallbackT for that event
-      while (!queue_is_empty(cb_table->event_callback_l[i])) {
-        event_cb = (EventCallbackT *)dequeue(cb_table->event_callback_l[i]);
+      while (!queue_is_empty(i)) {
+        event_cb = (EventCallbackT *)dequeue(i);
         delete_event_callback(event_cb);
       }
 
-      delete_queue(cb_table->event_callback_l[i]);
+      delete_queue(i);
     }
   }
 
@@ -196,19 +196,19 @@ cb_table_register(CallbackTable *cb_table, const char *event_name, TSEventSignal
   // got lock, add it
   if (event_name == nullptr) { // register for all alarms
     // printf("[EventSignalCbRegister] Register callback for all alarms\n");
-    for (int i = 0; i < NUM_EVENTS; i++) {
-      if (!cb_table->event_callback_l[i]) {
-        cb_table->event_callback_l[i] = create_queue();
-        first_time                    = 1;
+    for (auto &i : cb_table->event_callback_l) {
+      if (!i) {
+        i          = create_queue();
+        first_time = 1;
       }
 
-      if (!cb_table->event_callback_l[i]) {
+      if (!i) {
         ink_mutex_release(&cb_table->event_callback_lock);
         return TS_ERR_SYS_CALL;
       }
 
       event_cb = create_event_callback(func, data);
-      enqueue(cb_table->event_callback_l[i], event_cb);
+      enqueue(i, event_cb);
     }
   } else { // register callback for specific alarm
     // printf("[EventSignalCbRegister] Register callback for %s\n", event_name);
@@ -262,27 +262,27 @@ cb_table_unregister(CallbackTable *cb_table, const char *event_name, TSEventSign
   // got lock, add it
   if (event_name == nullptr) { // unregister the callback for ALL EVENTS
     // for each event
-    for (int i = 0; i < NUM_EVENTS; i++) {
-      if (!cb_table->event_callback_l[i]) { // this event has no callbacks
+    for (auto &i : cb_table->event_callback_l) {
+      if (!i) { // this event has no callbacks
         continue;
       }
 
       // func == NULL means unregister all functions associated with alarm
       if (func == nullptr) {
-        while (!queue_is_empty(cb_table->event_callback_l[i])) {
-          event_cb = (EventCallbackT *)dequeue(cb_table->event_callback_l[i]);
+        while (!queue_is_empty(i)) {
+          event_cb = (EventCallbackT *)dequeue(i);
           delete_event_callback(event_cb);
         }
         // clean up queue and set to NULL
-        delete_queue(cb_table->event_callback_l[i]);
-        cb_table->event_callback_l[i] = nullptr;
+        delete_queue(i);
+        i = nullptr;
       } else { // only remove the func passed in
         int queue_depth;
 
-        queue_depth = queue_len(cb_table->event_callback_l[i]);
+        queue_depth = queue_len(i);
         // remove this function
         for (int j = 0; j < queue_depth; j++) {
-          event_cb = (EventCallbackT *)dequeue(cb_table->event_callback_l[i]);
+          event_cb = (EventCallbackT *)dequeue(i);
           cb_fun   = event_cb->func;
 
           // the pointers are the same so don't enqueue the fn back on
@@ -291,13 +291,13 @@ cb_table_unregister(CallbackTable *cb_table, const char *event_name, TSEventSign
             continue;
           }
 
-          enqueue(cb_table->event_callback_l[i], event_cb);
+          enqueue(i, event_cb);
         }
 
         // is queue empty now? then clean up
-        if (queue_is_empty(cb_table->event_callback_l[i])) {
-          delete_queue(cb_table->event_callback_l[i]);
-          cb_table->event_callback_l[i] = nullptr;
+        if (queue_is_empty(i)) {
+          delete_queue(i);
+          i = nullptr;
         }
       }
     } // end for (int i = 0; i < NUM_EVENTS; i++) {

--- a/mgmt/api/EventControlMain.cc
+++ b/mgmt/api/EventControlMain.cc
@@ -61,8 +61,8 @@ new_event_client()
   EventClientT *ele = (EventClientT *)ats_malloc(sizeof(EventClientT));
 
   // now set the alarms registered section
-  for (int i = 0; i < NUM_EVENTS; i++) {
-    ele->events_registered[i] = 0;
+  for (bool &i : ele->events_registered) {
+    i = 0;
   }
 
   ele->adr = (struct sockaddr *)ats_malloc(sizeof(struct sockaddr));
@@ -459,8 +459,8 @@ handle_event_reg_callback(EventClientT *client, void *req, size_t reqlen)
 
   // mark the specified alarm as "wanting to be notified" in the client's alarm_registered list
   if (strlen(name) == 0) { // mark all alarms
-    for (int i = 0; i < NUM_EVENTS; i++) {
-      client->events_registered[i] = true;
+    for (bool &i : client->events_registered) {
+      i = true;
     }
   } else {
     int id = get_event_id(name);
@@ -502,8 +502,8 @@ handle_event_unreg_callback(EventClientT *client, void *req, size_t reqlen)
 
   // mark the specified alarm as "wanting to be notified" in the client's alarm_registered list
   if (strlen(name) == 0) { // mark all alarms
-    for (int i = 0; i < NUM_EVENTS; i++) {
-      client->events_registered[i] = false;
+    for (bool &i : client->events_registered) {
+      i = false;
     }
   } else {
     int id = get_event_id(name);

--- a/mgmt/api/NetworkUtilsRemote.cc
+++ b/mgmt/api/NetworkUtilsRemote.cc
@@ -507,8 +507,8 @@ send_unregister_all_callbacks(int fd, CallbackTable *cb_table)
   bool no_errors = true; // set to false if at least one send fails
 
   // init array so that all events don't have any callbacks
-  for (int i = 0; i < NUM_EVENTS; i++) {
-    reg_callback[i] = 0;
+  for (int &i : reg_callback) {
+    i = 0;
   }
 
   events_with_cb = get_events_with_callbacks(cb_table);

--- a/plugins/esi/lib/DocNode.cc
+++ b/plugins/esi/lib/DocNode.cc
@@ -68,9 +68,9 @@ DocNode::pack(string &buffer) const
   packString(data, data_len, buffer);
   int32_t n_elements = attr_list.size();
   buffer.append(reinterpret_cast<const char *>(&n_elements), sizeof(n_elements));
-  for (AttributeList::const_iterator iter = attr_list.begin(); iter != attr_list.end(); ++iter) {
-    packString(iter->name, iter->name_len, buffer);
-    packString(iter->value, iter->value_len, buffer);
+  for (const auto &iter : attr_list) {
+    packString(iter.name, iter.name_len, buffer);
+    packString(iter.value, iter.value_len, buffer);
   }
   child_nodes.packToBuffer(buffer);
   *(reinterpret_cast<int32_t *>(&buffer[orig_buf_size + 1])) = buffer.size() - orig_buf_size;
@@ -126,8 +126,8 @@ DocNodeList::packToBuffer(string &buffer) const
 {
   int32_t n_elements = size();
   buffer.append(reinterpret_cast<const char *>(&n_elements), sizeof(n_elements));
-  for (DocNodeList::const_iterator iter = begin(); iter != end(); ++iter) {
-    iter->pack(buffer);
+  for (const auto &iter : *this) {
+    iter.pack(buffer);
   }
 }
 

--- a/plugins/esi/lib/EsiGunzip.cc
+++ b/plugins/esi/lib/EsiGunzip.cc
@@ -112,8 +112,8 @@ EsiGunzip::stream_decode(const char *data, int data_len, std::string &udata)
     _total_data_length += data_len;
   }
 
-  for (BufferList::iterator iter = buf_list.begin(); iter != buf_list.end(); ++iter) {
-    udata.append(iter->data(), iter->size());
+  for (auto &iter : buf_list) {
+    udata.append(iter.data(), iter.size());
   }
 
   return true;

--- a/plugins/esi/lib/Utils.cc
+++ b/plugins/esi/lib/Utils.cc
@@ -115,8 +115,8 @@ Utils::parseKeyValueConfig(const std::list<string> &lines, KeyValueMap &kvMap, H
 {
   string key, value;
   std::istringstream iss;
-  for (std::list<string>::const_iterator list_iter = lines.begin(); list_iter != lines.end(); ++list_iter) {
-    const string &conf_line = *list_iter; // handy reference
+  for (const auto &conf_line : lines) {
+    // handy reference
     if (!conf_line.size() || (conf_line[0] == '#')) {
       continue;
     }

--- a/plugins/esi/lib/Variables.cc
+++ b/plugins/esi/lib/Variables.cc
@@ -50,9 +50,9 @@ const string Variables::NORM_SPECIAL_HEADERS[] = {string("HTTP_ACCEPT_LANGUAGE")
 inline string &
 Variables::_toUpperCase(string &str) const
 {
-  for (size_t i = 0; i < str.size(); ++i) {
-    if ((str[i] >= 'a') && (str[i] <= 'z')) {
-      str[i] = 'A' + (str[i] - 'a');
+  for (char &i : str) {
+    if ((i >= 'a') && (i <= 'z')) {
+      i = 'A' + (i - 'a');
     }
   }
   return str;
@@ -167,10 +167,10 @@ Variables::_parseQueryString(const char *query_string, int query_string_len)
   _insert(_simple_data, string("QUERY_STRING"), string(query_string, query_string_len));
   AttributeList attr_list;
   Utils::parseAttributes(query_string, query_string_len, attr_list, "&");
-  for (AttributeList::iterator iter = attr_list.begin(); iter != attr_list.end(); ++iter) {
-    _debugLog(_debug_tag, "[%s] Inserting query string variable [%.*s] with value [%.*s]", __FUNCTION__, iter->name_len, iter->name,
-              iter->value_len, iter->value);
-    _insert(_dict_data[QUERY_STRING], string(iter->name, iter->name_len), string(iter->value, iter->value_len));
+  for (auto &iter : attr_list) {
+    _debugLog(_debug_tag, "[%s] Inserting query string variable [%.*s] with value [%.*s]", __FUNCTION__, iter.name_len, iter.name,
+              iter.value_len, iter.value);
+    _insert(_dict_data[QUERY_STRING], string(iter.name, iter.name_len), string(iter.value, iter.value_len));
   }
 }
 
@@ -276,10 +276,10 @@ Variables::_parseSubCookies()
     StringHash &subcookies = _sub_cookies[name];
     AttributeList attr_list;
     Utils::parseAttributes(value.c_str(), value.length(), attr_list, "&");
-    for (AttributeList::iterator iter = attr_list.begin(); iter != attr_list.end(); ++iter) {
-      _debugLog(_debug_tag, "[%s] Inserting query string variable [%.*s] with value [%.*s]", __FUNCTION__, iter->name_len,
-                iter->name, iter->value_len, iter->value);
-      _insert(subcookies, string(iter->name, iter->name_len), string(iter->value, iter->value_len));
+    for (auto &iter : attr_list) {
+      _debugLog(_debug_tag, "[%s] Inserting query string variable [%.*s] with value [%.*s]", __FUNCTION__, iter.name_len, iter.name,
+                iter.value_len, iter.value);
+      _insert(subcookies, string(iter.name, iter.name_len), string(iter.value, iter.value_len));
     }
   }
 }
@@ -342,8 +342,8 @@ Variables::clear()
     _dict_data[i].clear();
     _cached_special_headers[i].clear();
   }
-  for (int i = 0; i < N_SIMPLE_HEADERS; ++i) {
-    _cached_simple_headers[i].clear();
+  for (auto &_cached_simple_header : _cached_simple_headers) {
+    _cached_simple_header.clear();
   }
   _query_string.clear();
   _headers_parsed = _query_string_parsed = false;
@@ -356,8 +356,8 @@ Variables::_parseCookieString(const char *str, int str_len)
 {
   AttributeList cookies;
   Utils::parseAttributes(str, str_len, cookies, ";,");
-  for (AttributeList::iterator iter = cookies.begin(); iter != cookies.end(); ++iter) {
-    std::string cookie = iter->name;
+  for (auto &iter : cookies) {
+    std::string cookie = iter.name;
     size_t pos         = cookie.find("=");
 
     if (pos != std::string::npos) {
@@ -365,16 +365,16 @@ Variables::_parseCookieString(const char *str, int str_len)
     }
 
     bool found = false;
-    for (Utils::HeaderValueList::iterator approved = _whitelistCookies.begin(); approved != _whitelistCookies.end(); ++approved) {
-      if ((*approved == "*") || (*approved == cookie)) {
+    for (auto &_whitelistCookie : _whitelistCookies) {
+      if ((_whitelistCookie == "*") || (_whitelistCookie == cookie)) {
         found = true;
       }
     }
 
     if (found == true) {
-      _insert(_dict_data[HTTP_COOKIE], string(iter->name, iter->name_len), string(iter->value, iter->value_len));
-      _debugLog(_debug_tag, "[%s] Inserted cookie with name [%.*s] and value [%.*s]", __FUNCTION__, iter->name_len, iter->name,
-                iter->value_len, iter->value);
+      _insert(_dict_data[HTTP_COOKIE], string(iter.name, iter.name_len), string(iter.value, iter.value_len));
+      _debugLog(_debug_tag, "[%s] Inserted cookie with name [%.*s] and value [%.*s]", __FUNCTION__, iter.name_len, iter.name,
+                iter.value_len, iter.value);
     }
   }
 }

--- a/plugins/esi/lib/gzip.cc
+++ b/plugins/esi/lib/gzip.cc
@@ -90,17 +90,17 @@ EsiLib::gzip(const ByteBlockList &blocks, std::string &cdata)
   uLong crc          = crc32(0, Z_NULL, 0);
   int deflate_result = Z_OK;
   int in_data_size   = 0;
-  for (ByteBlockList::const_iterator iter = blocks.begin(); iter != blocks.end(); ++iter) {
-    if (iter->data && (iter->data_len > 0)) {
-      zstrm.next_in  = reinterpret_cast<Bytef *>(const_cast<char *>(iter->data));
-      zstrm.avail_in = iter->data_len;
-      in_data_size += iter->data_len;
+  for (auto block : blocks) {
+    if (block.data && (block.data_len > 0)) {
+      zstrm.next_in  = reinterpret_cast<Bytef *>(const_cast<char *>(block.data));
+      zstrm.avail_in = block.data_len;
+      in_data_size += block.data_len;
       deflate_result = runDeflateLoop(zstrm, 0, cdata);
       if (deflate_result != Z_OK) {
         break; // break out of the blocks iteration
       }
-      crc = crc32(crc, reinterpret_cast<const Bytef *>(iter->data), iter->data_len);
-      total_data_len += iter->data_len;
+      crc = crc32(crc, reinterpret_cast<const Bytef *>(block.data), block.data_len);
+      total_data_len += block.data_len;
     }
   }
   if (!in_data_size) {

--- a/plugins/experimental/cachekey/cachekey.cc
+++ b/plugins/experimental/cachekey/cachekey.cc
@@ -284,8 +284,8 @@ CacheKey::appendPrefix(const String &prefix, Pattern &prefixCapture, Pattern &pr
 
     StringVector captures;
     if (prefixCapture.process(hostAndPort, captures)) {
-      for (StringVector::iterator it = captures.begin(); it != captures.end(); it++) {
-        append(*it);
+      for (auto &capture : captures) {
+        append(capture);
       }
       CacheKeyDebug("added host:port capture prefix, key: '%s'", _key.c_str());
     }
@@ -298,8 +298,8 @@ CacheKey::appendPrefix(const String &prefix, Pattern &prefixCapture, Pattern &pr
     if (!uri.empty()) {
       StringVector captures;
       if (prefixCaptureUri.process(uri, captures)) {
-        for (StringVector::iterator it = captures.begin(); it != captures.end(); it++) {
-          append(*it);
+        for (auto &capture : captures) {
+          append(capture);
         }
         CacheKeyDebug("added URI capture prefix, key: '%s'", _key.c_str());
       }
@@ -341,8 +341,8 @@ CacheKey::appendPath(Pattern &pathCapture, Pattern &pathCaptureUri)
     if (!uri.empty()) {
       StringVector captures;
       if (pathCaptureUri.process(uri, captures)) {
-        for (StringVector::iterator it = captures.begin(); it != captures.end(); it++) {
-          append(*it);
+        for (auto &capture : captures) {
+          append(capture);
         }
         CacheKeyDebug("added URI capture (path), key: '%s'", _key.c_str());
       }
@@ -356,8 +356,8 @@ CacheKey::appendPath(Pattern &pathCapture, Pattern &pathCaptureUri)
     if (!path.empty()) {
       StringVector captures;
       if (pathCapture.process(path, captures)) {
-        for (StringVector::iterator it = captures.begin(); it != captures.end(); it++) {
-          append(*it);
+        for (auto &capture : captures) {
+          append(capture);
         }
         CacheKeyDebug("added path capture, key: '%s'", _key.c_str());
       }
@@ -554,8 +554,8 @@ CacheKey::appendUaCaptures(Pattern &config)
     StringVector captures;
 
     if (config.process(val, captures)) {
-      for (StringVector::iterator it = captures.begin(); it != captures.end(); it++) {
-        append(*it);
+      for (auto &capture : captures) {
+        append(capture);
       }
     }
   }

--- a/plugins/experimental/cachekey/pattern.cc
+++ b/plugins/experimental/cachekey/pattern.cc
@@ -395,8 +395,8 @@ Pattern::compile()
  */
 MultiPattern::~MultiPattern()
 {
-  for (std::vector<Pattern *>::iterator p = this->_list.begin(); p != this->_list.end(); ++p) {
-    delete (*p);
+  for (auto &p : this->_list) {
+    delete p;
   }
 }
 
@@ -430,8 +430,8 @@ MultiPattern::add(Pattern *pattern)
 bool
 MultiPattern::match(const String &subject) const
 {
-  for (std::vector<Pattern *>::const_iterator p = this->_list.begin(); p != this->_list.end(); ++p) {
-    if (nullptr != (*p) && (*p)->match(subject)) {
+  for (auto p : this->_list) {
+    if (nullptr != p && p->match(subject)) {
       return true;
     }
   }
@@ -452,8 +452,8 @@ MultiPattern::name() const
  */
 Classifier::~Classifier()
 {
-  for (std::vector<MultiPattern *>::iterator p = _list.begin(); p != _list.end(); ++p) {
-    delete (*p);
+  for (auto &p : _list) {
+    delete p;
   }
 }
 
@@ -468,11 +468,11 @@ bool
 Classifier::classify(const String &subject, String &name) const
 {
   bool matched = false;
-  for (std::vector<MultiPattern *>::const_iterator p = _list.begin(); p != _list.end(); ++p) {
-    if ((*p)->empty()) {
+  for (auto p : _list) {
+    if (p->empty()) {
       continue;
-    } else if ((*p)->match(subject)) {
-      name    = (*p)->name();
+    } else if (p->match(subject)) {
+      name    = p->name();
       matched = true;
       break;
     }

--- a/plugins/experimental/inliner/html-parser.cc
+++ b/plugins/experimental/inliner/html-parser.cc
@@ -34,12 +34,12 @@ namespace inliner
   Attributes::operator std::string(void) const
   {
     std::string result;
-    for (Attributes::const_iterator item = begin(); item != end(); ++item) {
-      if (!item->first.empty()) {
-        if (!item->second.empty()) {
-          result += item->first + "=\"" + item->second += "\" ";
+    for (const auto &item : *this) {
+      if (!item.first.empty()) {
+        if (!item.second.empty()) {
+          result += item.first + "=\"" + item.second += "\" ";
         } else {
-          result += item->first;
+          result += item.first;
         }
       }
     }

--- a/plugins/experimental/inliner/inliner-handler.cc
+++ b/plugins/experimental/inliner/inliner-handler.cc
@@ -94,9 +94,9 @@ namespace inliner
   {
     std::string src;
 
-    for (Attributes::const_iterator item = a.begin(); item != a.end(); ++item) {
-      if (!item->first.empty()) {
-        src = item->second;
+    for (const auto &item : a) {
+      if (!item.first.empty()) {
+        src = item.second;
       }
     }
 
@@ -105,17 +105,17 @@ namespace inliner
 
     if (isTagged) {
       std::string classes, original = " ";
-      for (Attributes::const_iterator item = a.begin(); item != a.end(); ++item) {
-        if (!item->first.empty()) {
-          if (!item->second.empty()) {
-            if (item->first == "class") {
-              classes = item->second;
-            } else if (item->first.find("src") == std::string::npos) {
-              original += item->first + "=\"" + item->second += "\" ";
+      for (const auto &item : a) {
+        if (!item.first.empty()) {
+          if (!item.second.empty()) {
+            if (item.first == "class") {
+              classes = item.second;
+            } else if (item.first.find("src") == std::string::npos) {
+              original += item.first + "=\"" + item.second += "\" ";
             }
           }
         } else {
-          original += item->first + " ";
+          original += item.first + " ";
         }
       }
 

--- a/plugins/experimental/ssl_cert_loader/ssl-cert-loader.cc
+++ b/plugins/experimental/ssl_cert_loader/ssl-cert-loader.cc
@@ -301,19 +301,19 @@ Parse_Config(Value &parent, ParsedSslValues &orig_values)
       Lookup.tree.insert(cur_values.server_name, entry, Parse_order++);
     }
     if (cur_values.server_ips.size() > 0) {
-      for (size_t i = 0; i < cur_values.server_ips.size(); i++) {
+      for (auto &server_ip : cur_values.server_ips) {
         IpEndpoint first, second;
-        first.assign(cur_values.server_ips[i].first);
-        second.assign(cur_values.server_ips[i].second);
+        first.assign(server_ip.first);
+        second.assign(server_ip.second);
         Lookup.ipmap.fill(&first, &second, entry);
         char val1[256], val2[256];
-        cur_values.server_ips[i].first.toString(val1, sizeof(val1));
-        cur_values.server_ips[i].second.toString(val2, sizeof(val2));
+        server_ip.first.toString(val1, sizeof(val1));
+        server_ip.second.toString(val2, sizeof(val2));
       }
     }
     if (entry != nullptr) {
-      for (size_t i = 0; i < cert_names.size(); i++) {
-        Lookup.tree.insert(cert_names[i], entry, Parse_order++);
+      for (const auto &cert_name : cert_names) {
+        Lookup.tree.insert(cert_name, entry, Parse_order++);
       }
     }
   }
@@ -348,8 +348,8 @@ Load_Certificate_Thread(void *arg)
       TSVConnReenable(vc);
     }
     TSMutexUnlock(entry->mutex);
-    for (size_t i = 0; i < cert_names.size(); i++) {
-      Lookup.tree.insert(cert_names[i], entry, Parse_order++);
+    for (const auto &cert_name : cert_names) {
+      Lookup.tree.insert(cert_name, entry, Parse_order++);
     }
   } else {
     TSMutexUnlock(entry->mutex);

--- a/plugins/experimental/sslheaders/sslheaders.cc
+++ b/plugins/experimental/sslheaders/sslheaders.cc
@@ -123,15 +123,15 @@ static void
 SslHdrExpand(SSL *ssl, const SslHdrInstance::expansion_list &expansions, TSMBuffer mbuf, TSMLoc mhdr)
 {
   if (ssl == nullptr) {
-    for (SslHdrInstance::expansion_list::const_iterator e = expansions.begin(); e != expansions.end(); ++e) {
-      SslHdrRemoveHeader(mbuf, mhdr, e->name);
+    for (const auto &expansion : expansions) {
+      SslHdrRemoveHeader(mbuf, mhdr, expansion.name);
     }
   } else {
     X509 *x509;
     BIO *exp = BIO_new(BIO_s_mem());
 
-    for (SslHdrInstance::expansion_list::const_iterator e = expansions.begin(); e != expansions.end(); ++e) {
-      switch (e->scope) {
+    for (const auto &expansion : expansions) {
+      switch (expansion.scope) {
       case SSL_HEADERS_SCOPE_CLIENT:
         x509 = SSL_get_peer_certificate(ssl);
         break;
@@ -146,15 +146,15 @@ SslHdrExpand(SSL *ssl, const SslHdrInstance::expansion_list &expansions, TSMBuff
         continue;
       }
 
-      SslHdrExpandX509Field(exp, x509, e->field);
+      SslHdrExpandX509Field(exp, x509, expansion.field);
       if (BIO_pending(exp)) {
-        SslHdrSetHeader(mbuf, mhdr, e->name, exp);
+        SslHdrSetHeader(mbuf, mhdr, expansion.name, exp);
       } else {
-        SslHdrRemoveHeader(mbuf, mhdr, e->name);
+        SslHdrRemoveHeader(mbuf, mhdr, expansion.name);
       }
 
       // Getting the peer certificate takes a reference count, but the server certificate doesn't.
-      if (x509 && e->scope == SSL_HEADERS_SCOPE_CLIENT) {
+      if (x509 && expansion.scope == SSL_HEADERS_SCOPE_CLIENT) {
         X509_free(x509);
       }
     }

--- a/plugins/gzip/configuration.cc
+++ b/plugins/gzip/configuration.cc
@@ -69,14 +69,14 @@ tokenize(const string &s, int (*fp)(int))
   vector<string> r;
   string tmp;
 
-  for (size_t i = 0; i < s.size(); i++) {
-    if (fp(s[i])) {
+  for (char i : s) {
+    if (fp(i)) {
       if (tmp.size()) {
         r.push_back(tmp);
         tmp = "";
       }
     } else {
-      tmp += s[i];
+      tmp += i;
     }
   }
 
@@ -148,8 +148,8 @@ Configuration::find(const char *host, int host_length)
 void
 Configuration::release_all()
 {
-  for (HostContainer::iterator it = host_configurations_.begin(); it != host_configurations_.end(); ++it) {
-    (*it)->release();
+  for (auto &host_configuration : host_configurations_) {
+    host_configuration->release();
   }
 }
 
@@ -285,8 +285,7 @@ Configuration::Parse(const char *path)
 
     vector<string> v = tokenize(line, isspace);
 
-    for (size_t i = 0; i < v.size(); i++) {
-      string token = v[i];
+    for (auto token : v) {
       trim_if(token, isspace);
 
       // should not happen

--- a/plugins/s3_auth/aws_auth_v4.cc
+++ b/plugins/s3_auth/aws_auth_v4.cc
@@ -78,20 +78,20 @@ uriEncode(const String in, bool isObjectName)
 {
   std::stringstream result;
 
-  for (std::string::size_type i = 0; i < in.length(); i++) {
-    if (isalnum(in[i]) || in[i] == '-' || in[i] == '_' || in[i] == '.' || in[i] == '~') {
+  for (char i : in) {
+    if (isalnum(i) || i == '-' || i == '_' || i == '.' || i == '~') {
       /* URI encode every byte except the unreserved characters:
        * 'A'-'Z', 'a'-'z', '0'-'9', '-', '.', '_', and '~'. */
-      result << in[i];
-    } else if (in[i] == ' ') {
+      result << i;
+    } else if (i == ' ') {
       /* The space character is a reserved character and must be encoded as "%20" (and not as "+"). */
       result << "%20";
-    } else if (isObjectName && in[i] == '/') {
+    } else if (isObjectName && i == '/') {
       /* Encode the forward slash character, '/', everywhere except in the object key name. */
       result << "/";
     } else {
       /* Letters in the hexadecimal value must be upper-case, for example "%1A". */
-      result << "%" << std::uppercase << std::setfill('0') << std::setw(2) << std::hex << (int)in[i];
+      result << "%" << std::uppercase << std::setfill('0') << std::setw(2) << std::hex << (int)i;
     }
   }
 
@@ -260,12 +260,12 @@ getCanonicalRequestSha256Hash(TsInterface &api, bool signPayload, const StringSe
   }
 
   String queryStr;
-  for (StringSet::iterator it = paramNames.begin(); it != paramNames.end(); it++) {
+  for (const auto &paramName : paramNames) {
     if (!queryStr.empty()) {
       queryStr.append("&");
     }
-    queryStr.append(*it);
-    queryStr.append("=").append(paramsMap[*it]);
+    queryStr.append(paramName);
+    queryStr.append("=").append(paramsMap[paramName]);
   }
   sha256Update(&canonicalRequestSha256Ctx, queryStr);
   sha256Update(&canonicalRequestSha256Ctx, "\n");
@@ -320,19 +320,19 @@ getCanonicalRequestSha256Hash(TsInterface &api, bool signPayload, const StringSe
     headersMap[lowercaseName] = String(trimValue, trimValueLen);
   }
 
-  for (StringSet::iterator it = signedHeadersSet.begin(); it != signedHeadersSet.end(); it++) {
-    sha256Update(&canonicalRequestSha256Ctx, *it);
+  for (const auto &it : signedHeadersSet) {
+    sha256Update(&canonicalRequestSha256Ctx, it);
     sha256Update(&canonicalRequestSha256Ctx, ":");
-    sha256Update(&canonicalRequestSha256Ctx, headersMap[*it]);
+    sha256Update(&canonicalRequestSha256Ctx, headersMap[it]);
     sha256Update(&canonicalRequestSha256Ctx, "\n");
   }
   sha256Update(&canonicalRequestSha256Ctx, "\n");
 
-  for (StringSet::iterator it = signedHeadersSet.begin(); it != signedHeadersSet.end(); ++it) {
+  for (const auto &it : signedHeadersSet) {
     if (!signedHeaders.empty()) {
       signedHeaders.append(";");
     }
-    signedHeaders.append(*it);
+    signedHeaders.append(it);
   }
 
   sha256Update(&canonicalRequestSha256Ctx, signedHeaders);

--- a/proxy/IPAllow.cc
+++ b/proxy/IPAllow.cc
@@ -113,13 +113,13 @@ IpAllow::PrintMap(IpMap *map)
 {
   std::ostringstream s;
   s << map->getCount() << " ACL entries.";
-  for (IpMap::iterator spot(map->begin()), limit(map->end()); spot != limit; ++spot) {
+  for (auto &spot : *map) {
     char text[INET6_ADDRSTRLEN];
-    AclRecord const *ar = static_cast<AclRecord const *>(spot->data());
+    AclRecord const *ar = static_cast<AclRecord const *>(spot.data());
 
-    s << std::endl << "  Line " << ar->_src_line << ": " << ats_ip_ntop(spot->min(), text, sizeof text);
-    if (0 != ats_ip_addr_cmp(spot->min(), spot->max())) {
-      s << " - " << ats_ip_ntop(spot->max(), text, sizeof text);
+    s << std::endl << "  Line " << ar->_src_line << ": " << ats_ip_ntop(spot.min(), text, sizeof text);
+    if (0 != ats_ip_addr_cmp(spot.min(), spot.max())) {
+      s << " - " << ats_ip_ntop(spot.max(), text, sizeof text);
     }
     s << " method=";
     uint32_t mask = AclRecord::ALL_METHOD_MASK & ar->_method_mask;
@@ -143,12 +143,11 @@ IpAllow::PrintMap(IpMap *map)
     if (!ar->_nonstandard_methods.empty()) {
       s << " nonstandard method=";
       bool leader = false; // need leading vbar?
-      for (AclRecord::MethodSet::iterator iter = ar->_nonstandard_methods.begin(), end = ar->_nonstandard_methods.end();
-           iter != end; ++iter) {
+      for (const auto &_nonstandard_method : ar->_nonstandard_methods) {
         if (leader) {
           s << '|';
         }
-        s << *iter;
+        s << _nonstandard_method;
         leader = true;
       }
     }

--- a/proxy/hdrs/URL.cc
+++ b/proxy/hdrs/URL.cc
@@ -1854,12 +1854,11 @@ REGRESSION_TEST(VALIDATE_HDR_FIELD)(RegressionTest *t, int /* level ATS_UNUSED *
   TestBox box(t, pstatus);
   box = REGRESSION_TEST_PASSED;
 
-  for (unsigned int i = 0; i < sizeof(http_validate_hdr_field_test_case) / sizeof(http_validate_hdr_field_test_case[0]); ++i) {
-    const char *const txt = http_validate_hdr_field_test_case[i].text;
+  for (auto i : http_validate_hdr_field_test_case) {
+    const char *const txt = i.text;
     ts::ConstBuffer tmp   = ts::ConstBuffer(txt, strlen(txt));
-    box.check(validate_host_name(tmp) == http_validate_hdr_field_test_case[i].valid,
-              "Validation of FQDN (host) header: \"%s\", expected %s, but not", txt,
-              (http_validate_hdr_field_test_case[i].valid ? "true" : "false"));
+    box.check(validate_host_name(tmp) == i.valid, "Validation of FQDN (host) header: \"%s\", expected %s, but not", txt,
+              (i.valid ? "true" : "false"));
   }
 }
 
@@ -1892,11 +1891,10 @@ REGRESSION_TEST(ParseRules_strict_URI)(RegressionTest *t, int /* level ATS_UNUSE
   TestBox box(t, pstatus);
   box = REGRESSION_TEST_PASSED;
 
-  for (unsigned int i = 0; i < sizeof(http_strict_uri_parsing_test_case) / sizeof(http_strict_uri_parsing_test_case[0]); ++i) {
-    const char *const uri = http_strict_uri_parsing_test_case[i].uri;
-    box.check(url_is_strictly_compliant(uri, uri + strlen(uri)) == http_strict_uri_parsing_test_case[i].valid,
-              "Strictly parse URI: \"%s\", expected %s, but not", uri,
-              (http_strict_uri_parsing_test_case[i].valid ? "true" : "false"));
+  for (auto i : http_strict_uri_parsing_test_case) {
+    const char *const uri = i.uri;
+    box.check(url_is_strictly_compliant(uri, uri + strlen(uri)) == i.valid, "Strictly parse URI: \"%s\", expected %s, but not", uri,
+              (i.valid ? "true" : "false"));
   }
 }
 

--- a/proxy/http/HttpPages.cc
+++ b/proxy/http/HttpPages.cc
@@ -119,33 +119,33 @@ HttpPagesHandler::dump_tunnel_info(HttpSM *sm)
 
   resp_add("<p> Producers </p>");
   resp_begin_table(1, 4, 60);
-  for (int i = 0; i < MAX_PRODUCERS; i++) {
-    if (t->producers[i].vc != nullptr) {
+  for (auto &producer : t->producers) {
+    if (producer.vc != nullptr) {
       resp_begin_row();
 
       // Col 1 - name
       resp_begin_column();
-      resp_add(t->producers[i].name);
+      resp_add(producer.name);
       resp_end_column();
 
       // Col 2 - alive
       resp_begin_column();
-      resp_add("%d", t->producers[i].alive);
+      resp_add("%d", producer.alive);
       resp_end_column();
 
       // Col 3 - ndone
       resp_begin_column();
-      if (t->producers[i].alive && t->producers[i].read_vio) {
-        resp_add("%d", t->producers[i].read_vio->ndone);
+      if (producer.alive && producer.read_vio) {
+        resp_add("%d", producer.read_vio->ndone);
       } else {
-        resp_add("%d", t->producers[i].bytes_read);
+        resp_add("%d", producer.bytes_read);
       }
       resp_end_column();
 
       // Col 4 - nbytes
       resp_begin_column();
-      if (t->producers[i].alive && t->producers[i].read_vio) {
-        resp_add("%d", t->producers[i].read_vio->nbytes);
+      if (producer.alive && producer.read_vio) {
+        resp_add("%d", producer.read_vio->nbytes);
       } else {
         resp_add("-");
       }
@@ -158,33 +158,33 @@ HttpPagesHandler::dump_tunnel_info(HttpSM *sm)
 
   resp_add("<p> Consumers </p>");
   resp_begin_table(1, 5, 60);
-  for (int j = 0; j < MAX_CONSUMERS; j++) {
-    if (t->consumers[j].vc != nullptr) {
+  for (auto &consumer : t->consumers) {
+    if (consumer.vc != nullptr) {
       resp_begin_row();
 
       // Col 1 - name
       resp_begin_column();
-      resp_add(t->consumers[j].name);
+      resp_add(consumer.name);
       resp_end_column();
 
       // Col 2 - alive
       resp_begin_column();
-      resp_add("%d", t->consumers[j].alive);
+      resp_add("%d", consumer.alive);
       resp_end_column();
 
       // Col 3 - ndone
       resp_begin_column();
-      if (t->consumers[j].alive && t->consumers[j].write_vio) {
-        resp_add("%d", t->consumers[j].write_vio->ndone);
+      if (consumer.alive && consumer.write_vio) {
+        resp_add("%d", consumer.write_vio->ndone);
       } else {
-        resp_add("%d", t->consumers[j].bytes_written);
+        resp_add("%d", consumer.bytes_written);
       }
       resp_end_column();
 
       // Col 4 - nbytes
       resp_begin_column();
-      if (t->consumers[j].alive && t->consumers[j].write_vio) {
-        resp_add("%d", t->consumers[j].write_vio->nbytes);
+      if (consumer.alive && consumer.write_vio) {
+        resp_add("%d", consumer.write_vio->nbytes);
       } else {
         resp_add("-");
       }
@@ -192,8 +192,8 @@ HttpPagesHandler::dump_tunnel_info(HttpSM *sm)
 
       // Col 5 - read avail
       resp_begin_column();
-      if (t->consumers[j].alive && t->consumers[j].buffer_reader) {
-        resp_add("%d", t->consumers[j].buffer_reader->read_avail());
+      if (consumer.alive && consumer.buffer_reader) {
+        resp_add("%d", consumer.buffer_reader->read_avail());
       } else {
         resp_add("-");
       }
@@ -462,7 +462,7 @@ http_pages_init()
   statPagesManager.register_http("http", http_pages_callback);
 
   // Create the mutexes for http list protection
-  for (int i = 0; i < HTTP_LIST_BUCKETS; i++) {
-    HttpSMList[i].mutex = new_ProxyMutex();
+  for (auto &i : HttpSMList) {
+    i.mutex = new_ProxyMutex();
   }
 }

--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -582,11 +582,11 @@ HttpTunnel::reset()
 void
 HttpTunnel::kill_tunnel()
 {
-  for (int i = 0; i < MAX_PRODUCERS; ++i) {
-    if (producers[i].vc != nullptr) {
-      chain_abort_all(&producers[i]);
+  for (auto &producer : producers) {
+    if (producer.vc != nullptr) {
+      chain_abort_all(&producer);
     }
-    ink_assert(producers[i].alive == false);
+    ink_assert(producer.alive == false);
   }
   active = false;
   this->deallocate_buffers();
@@ -627,29 +627,29 @@ HttpTunnel::deallocate_buffers()
 {
   int num = 0;
   ink_release_assert(active == false);
-  for (int i = 0; i < MAX_PRODUCERS; ++i) {
-    if (producers[i].read_buffer != nullptr) {
-      ink_assert(producers[i].vc != nullptr);
-      free_MIOBuffer(producers[i].read_buffer);
-      producers[i].read_buffer  = nullptr;
-      producers[i].buffer_start = nullptr;
+  for (auto &producer : producers) {
+    if (producer.read_buffer != nullptr) {
+      ink_assert(producer.vc != nullptr);
+      free_MIOBuffer(producer.read_buffer);
+      producer.read_buffer  = nullptr;
+      producer.buffer_start = nullptr;
       num++;
     }
 
-    if (producers[i].chunked_handler.dechunked_buffer != nullptr) {
-      ink_assert(producers[i].vc != nullptr);
-      free_MIOBuffer(producers[i].chunked_handler.dechunked_buffer);
-      producers[i].chunked_handler.dechunked_buffer = nullptr;
+    if (producer.chunked_handler.dechunked_buffer != nullptr) {
+      ink_assert(producer.vc != nullptr);
+      free_MIOBuffer(producer.chunked_handler.dechunked_buffer);
+      producer.chunked_handler.dechunked_buffer = nullptr;
       num++;
     }
 
-    if (producers[i].chunked_handler.chunked_buffer != nullptr) {
-      ink_assert(producers[i].vc != nullptr);
-      free_MIOBuffer(producers[i].chunked_handler.chunked_buffer);
-      producers[i].chunked_handler.chunked_buffer = nullptr;
+    if (producer.chunked_handler.chunked_buffer != nullptr) {
+      ink_assert(producer.vc != nullptr);
+      free_MIOBuffer(producer.chunked_handler.chunked_buffer);
+      producer.chunked_handler.chunked_buffer = nullptr;
       num++;
     }
-    producers[i].chunked_handler.max_chunk_header_len = 0;
+    producer.chunked_handler.max_chunk_header_len = 0;
   }
   return num;
 }

--- a/proxy/http/remap/AclFiltering.cc
+++ b/proxy/http/remap/AclFiltering.cc
@@ -105,8 +105,8 @@ acl_filter_rule::print(void)
     }
   }
   printf("nonstandard methods=");
-  for (MethodMap::iterator iter = nonstandard_methods.begin(), end = nonstandard_methods.end(); iter != end; ++iter) {
-    printf("%s ", iter->c_str());
+  for (const auto &nonstandard_method : nonstandard_methods) {
+    printf("%s ", nonstandard_method.c_str());
   }
   printf("\n");
   printf("src_ip_cnt=%d\n", src_ip_cnt);

--- a/proxy/http/remap/UrlMappingPathIndex.cc
+++ b/proxy/http/remap/UrlMappingPathIndex.cc
@@ -24,8 +24,8 @@
 
 UrlMappingPathIndex::~UrlMappingPathIndex()
 {
-  for (UrlMappingGroup::iterator group_iter = m_tries.begin(); group_iter != m_tries.end(); ++group_iter) {
-    delete group_iter->second; // Delete the Trie
+  for (auto &m_trie : m_tries) {
+    delete m_trie.second; // Delete the Trie
   }
   m_tries.clear();
 }
@@ -86,7 +86,7 @@ lFail:
 void
 UrlMappingPathIndex::Print()
 {
-  for (UrlMappingGroup::iterator group_iter = m_tries.begin(); group_iter != m_tries.end(); ++group_iter) {
-    group_iter->second->Print();
+  for (auto &m_trie : m_tries) {
+    m_trie.second->Print();
   }
 }

--- a/proxy/http2/test_Huffmancode.cc
+++ b/proxy/http2/test_Huffmancode.cc
@@ -70,10 +70,10 @@ random_test()
   const int size  = 1024;
   char *dst_start = (char *)malloc(size * 2);
   char string[size];
-  for (int i = 0; i < size; i++) {
+  for (char &i : string) {
     // coverity[dont_call]
-    long num  = lrand48();
-    string[i] = (char)num;
+    long num = lrand48();
+    i        = (char)num;
   }
   const uint8_t *src = (const uint8_t *)string;
   uint32_t src_len   = sizeof(string);
@@ -160,12 +160,12 @@ const static struct {
 void
 encode_test()
 {
-  for (uint64_t i = 0; i < sizeof(huffman_encode_test_data) / sizeof(huffman_encode_test_data[0]); ++i) {
-    uint8_t *dst        = static_cast<uint8_t *>(malloc(huffman_encode_test_data[i].expect_len));
-    int64_t encoded_len = huffman_encode(dst, huffman_encode_test_data[i].src, huffman_encode_test_data[i].src_len);
+  for (const auto &i : huffman_encode_test_data) {
+    uint8_t *dst        = static_cast<uint8_t *>(malloc(i.expect_len));
+    int64_t encoded_len = huffman_encode(dst, i.src, i.src_len);
 
-    assert(encoded_len == huffman_encode_test_data[i].expect_len);
-    assert(memcmp(huffman_encode_test_data[i].expect, dst, encoded_len) == 0);
+    assert(encoded_len == i.expect_len);
+    assert(memcmp(i.expect, dst, encoded_len) == 0);
 
     free(dst);
   }

--- a/proxy/logging/LogFilter.cc
+++ b/proxy/logging/LogFilter.cc
@@ -757,8 +757,8 @@ LogFilterIP::LogFilterIP(const char *name, LogField *field, LogFilter::Action ac
 
 LogFilterIP::LogFilterIP(const LogFilterIP &rhs) : LogFilter(rhs.m_name, rhs.m_field, rhs.m_action, rhs.m_operator)
 {
-  for (IpMap::iterator spot(rhs.m_map.begin()), limit(rhs.m_map.end()); spot != limit; ++spot) {
-    m_map.mark(spot->min(), spot->max(), spot->data());
+  for (auto &spot : rhs.m_map) {
+    m_map.mark(spot.min(), spot.max(), spot.data());
   }
   this->init();
 }


### PR DESCRIPTION
Running clang-tidy over the 7.1.x branch to make things easier to backport
