### PR TITLE
Fix post and post transform retry

### DIFF
--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -407,6 +407,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.http.strict_uri_parsing", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.http.tunnel_faker_enabled", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
   //       # Send http11 requests
   //       #
   //       #   0 - Never

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -1045,6 +1045,7 @@ HttpConfig::startup()
   HttpEstablishStaticConfigLongLong(c.oride.flow_low_water_mark, "proxy.config.http.flow_control.low_water");
   HttpEstablishStaticConfigByte(c.oride.post_check_content_length_enabled, "proxy.config.http.post.check.content_length.enabled");
   HttpEstablishStaticConfigByte(c.strict_uri_parsing, "proxy.config.http.strict_uri_parsing");
+  HttpEstablishStaticConfigByte(c.tunnel_faker_enabled, "proxy.config.http.tunnel_faker_enabled");
 
   // [amc] This is a bit of a mess, need to figure out to make this cleaner.
   RecRegisterConfigUpdateCb("proxy.config.http.server_session_sharing.match", &http_server_session_sharing_cb, &c);
@@ -1482,6 +1483,8 @@ HttpConfig::reconfigure()
   params->referer_format_redirect = INT_TO_BOOL(m_master.referer_format_redirect);
 
   params->strict_uri_parsing = INT_TO_BOOL(m_master.strict_uri_parsing);
+
+  params->tunnel_faker_enabled = INT_TO_BOOL(m_master.tunnel_faker_enabled);
 
   params->oride.down_server_timeout    = m_master.oride.down_server_timeout;
   params->oride.client_abort_threshold = m_master.oride.client_abort_threshold;

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -792,6 +792,8 @@ public:
 
   MgmtByte strict_uri_parsing = 0;
 
+  MgmtByte tunnel_faker_enabled = 0;
+
   MgmtByte reverse_proxy_enabled = 0;
   MgmtByte url_remap_required    = 1;
 

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -360,6 +360,7 @@ protected:
   int tunnel_handler(int event, void *data);
   int tunnel_handler_push(int event, void *data);
   int tunnel_handler_post(int event, void *data);
+  int tunnel_handler_fake(int event, void *data);
 
   // YTS Team, yamsat Plugin
   int tunnel_handler_for_partial_post(int event, void *data);
@@ -405,6 +406,8 @@ protected:
   int state_common_wait_for_transform_read(HttpTransformInfo *t_info, HttpSMHandler tunnel_handler, int event, void *data);
 
   // Tunnel event handlers
+  int tunnel_handler_fake_downstream(int event, HttpTunnelProducer *c);
+  int tunnel_handler_fake_upstream(int event, HttpTunnelConsumer *p);
   int tunnel_handler_server(int event, HttpTunnelProducer *p);
   int tunnel_handler_ua(int event, HttpTunnelConsumer *c);
   int tunnel_handler_ua_push(int event, HttpTunnelProducer *p);
@@ -419,12 +422,17 @@ protected:
   int tunnel_handler_transform_read(int event, HttpTunnelProducer *p);
   int tunnel_handler_plugin_agent(int event, HttpTunnelConsumer *c);
 
+  int fake_server_setup_error(int event, void *data);
+  int fake_handle_post_failure(int event, void *data);
+
   void do_hostdb_lookup();
   void do_hostdb_reverse_lookup();
   void do_cache_lookup_and_read();
   void do_http_server_open(bool raw = false);
   void send_origin_throttled_response();
   void do_setup_post_tunnel(HttpVC_t to_vc_type);
+  void do_setup_ua_to_fake_tunnel(int event, void *data);
+  void do_setup_fake_tunnel();
   void do_cache_prepare_write();
   void do_cache_prepare_write_transform();
   void do_cache_prepare_update();
@@ -467,6 +475,7 @@ protected:
   void setup_100_continue_transfer();
   HttpTunnelProducer *setup_push_transfer_to_cache();
   void setup_transform_to_server_transfer();
+  void setup_transform_to_fake_transfer(int event, void *data);
   void setup_cache_write_transfer(HttpCacheSM *c_sm, VConnection *source_vc, HTTPInfo *store_info, int64_t skip_bytes,
                                   const char *name);
   void issue_cache_update();


### PR DESCRIPTION
Currently, the post and put request can not work together with server connection retry mechanism.
Because ATS can not replay the post content.