### PR TITLE
adds autest gitignore enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,6 @@ tools/trafficserver.pc
 BUILDS
 DEBUG
 RELEASE
+
+# autest
+tests/env-test/

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+_sandbox/


### PR DESCRIPTION
By default, autest generates artifacts within the working tree that should be ignored by git.