### PR TITLE
Fix handling read errors in TLS Handshake

### DIFF
--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -351,10 +351,12 @@ SSLNetVConnection::read_raw_data()
   // If we have already moved some bytes successfully, adjust total_read to reflect reality
   // If any read succeeded, we should return success
   if (r != rattempted) {
-    if (r <= 0)
+    // If the first read failds, we should return error
+    if (r <= 0 && total_read > rattempted) {
       r = total_read - rattempted;
-    else
+    } else {
       r = total_read - rattempted + r;
+    }
   }
   NET_SUM_DYN_STAT(net_read_bytes_stat, r);
 


### PR DESCRIPTION
After c128363e2ce3ad435769221466627f7fbff86cb8, I sometime saw TLS Handshake error in my local box. It looks like `SSLNetVConnection::read_raw_data()` returns `0` even if result of ` SocketManager::read()` is some error like `EAGAIN`.