### PR TITLE
Ran clang-tidy with modernize-use-using

### DIFF
--- a/cmd/traffic_ctl/alarm.cc
+++ b/cmd/traffic_ctl/alarm.cc
@@ -24,7 +24,7 @@
 #include "traffic_ctl.h"
 
 struct AlarmListPolicy {
-  typedef char *entry_type;
+  using entry_type = char *;
 
   static void
   free(entry_type e)
@@ -39,7 +39,7 @@ struct AlarmListPolicy {
   }
 };
 
-typedef CtrlMgmtList<AlarmListPolicy> CtrlAlarmList;
+using CtrlAlarmList = CtrlMgmtList<AlarmListPolicy>;
 
 static int
 alarm_list(unsigned argc, const char **argv)

--- a/cmd/traffic_ctl/config.cc
+++ b/cmd/traffic_ctl/config.cc
@@ -27,7 +27,7 @@
 #include <P_RecUtils.h>
 
 struct RecordDescriptionPolicy {
-  typedef TSConfigRecordDescription *entry_type;
+  using entry_type = TSConfigRecordDescription *;
 
   static void
   free(entry_type e)

--- a/example/cache-scan/cache-scan.cc
+++ b/example/cache-scan/cache-scan.cc
@@ -57,7 +57,7 @@ struct cache_scan_state_t {
   bool write_pending;
 };
 
-typedef struct cache_scan_state_t cache_scan_state;
+using cache_scan_state = struct cache_scan_state_t;
 
 //----------------------------------------------------------------------------
 static int

--- a/example/ssl-preaccept/ssl-preaccept.cc
+++ b/example/ssl-preaccept/ssl-preaccept.cc
@@ -43,7 +43,7 @@ namespace
 {
 std::string ConfigPath;
 typedef std::pair<IpAddr, IpAddr> IpRange;
-typedef std::deque<IpRange> IpRangeQueue;
+using IpRangeQueue = std::deque<IpRange>;
 IpRangeQueue ClientBlindTunnelIp;
 
 Configuration Config; // global configuration

--- a/iocore/cluster/ClusterAPI.cc
+++ b/iocore/cluster/ClusterAPI.cc
@@ -72,7 +72,7 @@ typedef struct RPCHandle {
 #define RPC_HANDLE_MAGIC 0x12345678
 
 class MachineStatusSM;
-typedef int (MachineStatusSM::*MachineStatusSMHandler)(int, void *);
+using MachineStatusSMHandler = int (MachineStatusSM::*)(int, void *);
 class MachineStatusSM : public Continuation
 {
 public:
@@ -189,7 +189,7 @@ MachineStatusSM::MachineStatusSMEvent(Event * /* e ATS_UNUSED */, void * /* d AT
 }
 
 class ClusterAPIPeriodicSM;
-typedef int (ClusterAPIPeriodicSM::*ClusterAPIPeriodicSMHandler)(int, void *);
+using ClusterAPIPeriodicSMHandler = int (ClusterAPIPeriodicSM::*)(int, void *);
 class ClusterAPIPeriodicSM : public Continuation
 {
 public:

--- a/iocore/cluster/ClusterCache.cc
+++ b/iocore/cluster/ClusterCache.cc
@@ -1775,7 +1775,7 @@ CacheContinuation::tunnelClosedEvent(int /* event ATS_UNUSED */, void *c)
 // Retry DisposeOfDataBuffer continuation
 ////////////////////////////////////////////////////////////
 struct retryDisposeOfDataBuffer;
-typedef int (retryDisposeOfDataBuffer::*rtryDisOfDBufHandler)(int, void *);
+using rtryDisOfDBufHandler = int (retryDisposeOfDataBuffer::*)(int, void *);
 struct retryDisposeOfDataBuffer : public Continuation {
   CacheContinuation *c;
 

--- a/iocore/cluster/ClusterConfig.cc
+++ b/iocore/cluster/ClusterConfig.cc
@@ -233,7 +233,7 @@ ClusterConfiguration::ClusterConfiguration() : n_machines(0), changed(0)
 // ConfigurationContinuation member functions (Internal Class)
 /*************************************************************************/
 struct ConfigurationContinuation;
-typedef int (ConfigurationContinuation::*CfgContHandler)(int, void *);
+using CfgContHandler = int (ConfigurationContinuation::*)(int, void *);
 struct ConfigurationContinuation : public Continuation {
   ClusterConfiguration *c;
   ClusterConfiguration *prev;

--- a/iocore/cluster/ClusterMachine.cc
+++ b/iocore/cluster/ClusterMachine.cc
@@ -168,7 +168,7 @@ ClusterMachine::~ClusterMachine()
 }
 
 struct MachineTimeoutContinuation;
-typedef int (MachineTimeoutContinuation::*McTimeoutContHandler)(int, void *);
+using McTimeoutContHandler = int (MachineTimeoutContinuation::*)(int, void *);
 struct MachineTimeoutContinuation : public Continuation {
   ClusterMachine *m;
   int

--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -1654,7 +1654,7 @@ ink_dns_init(ModuleVersion v)
 
 #ifdef TS_HAS_TESTS
 struct DNSRegressionContinuation;
-typedef int (DNSRegressionContinuation::*DNSRegContHandler)(int, void *);
+using DNSRegContHandler = int (DNSRegressionContinuation::*)(int, void *);
 
 struct DNSRegressionContinuation : public Continuation {
   int hosts;

--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -2100,7 +2100,7 @@ HostDBContinuation::master_machine(ClusterConfiguration *cc)
 }
 
 struct ShowHostDB;
-typedef int (ShowHostDB::*ShowHostDBEventHandler)(int event, Event *data);
+using ShowHostDBEventHandler = int (ShowHostDB::*)(int, Event *);
 struct ShowHostDB : public ShowCont {
   char *name;
   uint16_t port;
@@ -2386,7 +2386,7 @@ register_ShowHostDB(Continuation *c, HTTPHdr *h)
 #define HOSTDB_TEST_LENGTH 100000
 
 struct HostDBTestReverse;
-typedef int (HostDBTestReverse::*HostDBTestReverseHandler)(int, void *);
+using HostDBTestReverseHandler = int (HostDBTestReverse::*)(int, void *);
 struct HostDBTestReverse : public Continuation {
   RegressionTest *test;
   int type;
@@ -2490,18 +2490,18 @@ ink_hostdb_init(ModuleVersion v)
 
 /// Pair of IP address and host name from a host file.
 struct HostFilePair {
-  typedef HostFilePair self;
+  using self = HostFilePair;
   IpAddr ip;
   const char *name;
 };
 
 struct HostDBFileContinuation : public Continuation {
-  typedef HostDBFileContinuation self;
+  using self = HostDBFileContinuation;
 
   int idx;          ///< Working index.
   const char *name; ///< Host name (just for debugging)
   INK_MD5 md5;      ///< Key for entry.
-  typedef std::vector<INK_MD5> Keys;
+  using Keys = std::vector<INK_MD5>;
   Keys *keys;          ///< Entries from file.
   ats_scoped_str path; ///< Used to keep the host file name around.
 

--- a/iocore/net/SSLClientUtils.cc
+++ b/iocore/net/SSLClientUtils.cc
@@ -30,7 +30,7 @@
 #include <openssl/pem.h>
 
 #if (OPENSSL_VERSION_NUMBER >= 0x10000000L) // openssl returns a const SSL_METHOD
-typedef const SSL_METHOD *ink_ssl_method_t;
+using ink_ssl_method_t = const SSL_METHOD *;
 #else
 typedef SSL_METHOD *ink_ssl_method_t;
 #endif

--- a/iocore/net/UnixConnection.cc
+++ b/iocore/net/UnixConnection.cc
@@ -177,8 +177,8 @@ namespace
     @endcode
  */
 template <typename T> struct cleaner {
-  T *obj;                      ///< Object instance.
-  typedef void (T::*method)(); ///< Method signature.
+  T *obj;                       ///< Object instance.
+  using method = void (T::*)(); ///< Method signature.
   method m;
 
   cleaner(T *_obj, method _method) : obj(_obj), m(_method) {}

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -28,7 +28,7 @@
 #endif
 #define ROUNDUP(x, y) ((((x) + ((y)-1)) / (y)) * (y))
 
-typedef int (NetAccept::*NetAcceptHandler)(int, void *);
+using NetAcceptHandler      = int (NetAccept::*)(int, void *);
 volatile int dummy_volatile = 0;
 int accept_till_done        = 1;
 

--- a/iocore/net/UnixNetPages.cc
+++ b/iocore/net/UnixNetPages.cc
@@ -27,7 +27,7 @@
 #include "I_Tasks.h"
 
 struct ShowNet;
-typedef int (ShowNet::*ShowNetEventHandler)(int event, Event *data);
+using ShowNetEventHandler = int (ShowNet::*)(int, Event *);
 struct ShowNet : public ShowCont {
   int ithread;
   IpEndpoint addr;

--- a/iocore/net/UnixUDPNet.cc
+++ b/iocore/net/UnixUDPNet.cc
@@ -32,7 +32,7 @@
 #include "P_Net.h"
 #include "P_UDPNet.h"
 
-typedef int (UDPNetHandler::*UDPNetContHandler)(int, void *);
+using UDPNetContHandler = int (UDPNetHandler::*)(int, void *);
 
 inkcoreapi ClassAllocator<UDPPacketInternal> udpPacketAllocator("udpPacketAllocator");
 EventType ET_UDP;

--- a/lib/cppapi/Transaction.cc
+++ b/lib/cppapi/Transaction.cc
@@ -415,7 +415,7 @@ namespace
 class initializeHandles
 {
 public:
-  typedef TSReturnCode (*GetterFunction)(TSHttpTxn, TSMBuffer *, TSMLoc *);
+  using GetterFunction = TSReturnCode (*)(TSHttpTxn, TSMBuffer *, TSMLoc *);
   initializeHandles(GetterFunction getter) : getter_(getter) {}
   bool
   operator()(TSHttpTxn txn, TSMBuffer &hdr_buf, TSMLoc &hdr_loc, const char *handles_name)

--- a/lib/ts/HostLookup.cc
+++ b/lib/ts/HostLookup.cc
@@ -554,7 +554,7 @@ charIndex::iter_next(charIndexIterState *s)
 
 // Since the only iter state is an index into the
 //   array typedef it
-typedef int hostArrayIterState;
+using hostArrayIterState = int;
 
 class hostArray
 {

--- a/lib/ts/IpMap.cc
+++ b/lib/ts/IpMap.cc
@@ -134,9 +134,9 @@ namespace detail
   struct IpMapBase {
     friend class ::IpMap;
 
-    typedef IpMapBase self;              ///< Self reference type.
-    typedef typename N::ArgType ArgType; ///< Import type.
-    typedef typename N::Metric Metric;   ///< Import type.g482
+    using self    = IpMapBase<N>;        ///< Self reference type.
+    using ArgType = typename N::ArgType; ///< Import type.
+    using Metric  = typename N::Metric;  ///< Import type.g482
 
     IpMapBase() : _root(nullptr) {}
     ~IpMapBase() { this->clear(); }
@@ -735,7 +735,7 @@ namespace detail
     friend struct IpMapBase<Ip4Node>;
 
   public:
-    typedef Ip4Node self; ///< Self reference type.
+    using self = ts::detail::Ip4Node; ///< Self reference type.
 
     /// Construct with values.
     Ip4Node(ArgType min, ///< Minimum address (host order).
@@ -871,7 +871,7 @@ namespace detail
   };
 
   //----------------------------------------------------------------------------
-  typedef Interval<sockaddr_in6> Ip6Span;
+  using Ip6Span = Interval<sockaddr_in6>;
 
   /** Node for IPv6 map.
   */
@@ -880,10 +880,10 @@ namespace detail
     friend struct IpMapBase<Ip6Node>;
 
   public:
-    typedef Ip6Node self; ///< Self reference type.
+    using self = ts::detail::Ip6Node; ///< Self reference type.
     /// Override @c ArgType from @c Interval because the convention
     /// is to use a pointer, not a reference.
-    typedef Metric const *ArgType;
+    using ArgType = const ts::detail::Interval<sockaddr_in6, const sockaddr_in6 &>::Metric *;
 
     /// Construct from pointers.
     Ip6Node(ArgType min, ///< Minimum address (network order).

--- a/lib/ts/X509HostnameValidator.cc
+++ b/lib/ts/X509HostnameValidator.cc
@@ -29,7 +29,7 @@
 
 #include "ts/ink_memory.h"
 
-typedef bool (*equal_fn)(const unsigned char *prefix, size_t prefix_len, const unsigned char *suffix, size_t suffix_len);
+using equal_fn = bool (*)(const unsigned char *, size_t, const unsigned char *, size_t);
 
 /* Return a ptr to a valid wildcard or NULL if not found
  *

--- a/lib/ts/test_Map.cc
+++ b/lib/ts/test_Map.cc
@@ -24,15 +24,15 @@
 #include "ts/Map.h"
 #include <list>
 
-typedef const char cchar;
+using cchar = const char;
 
 struct Item {
   LINK(Item, m_link);
   struct Hash {
-    typedef uint32_t ID;
-    typedef uint32_t Key;
-    typedef Item Value;
-    typedef DList(Item, m_link) ListHead;
+    using ID       = uint32_t;
+    using Key      = uint32_t;
+    using Value    = Item;
+    using ListHead = DLL<Item, Item::Link_m_link>;
 
     static ID
     hash(Key key)
@@ -61,7 +61,7 @@ Item::Hash::equal(Key lhs, Key rhs)
   return lhs == rhs;
 }
 
-typedef TSHashTable<Item::Hash> Table;
+using Table = TSHashTable<Item::Hash>;
 
 void
 test_TSHashTable()

--- a/lib/ts/test_PriorityQueue.cc
+++ b/lib/ts/test_PriorityQueue.cc
@@ -45,8 +45,8 @@ public:
   string content;
 };
 
-typedef PriorityQueueEntry<N *> Entry;
-typedef PriorityQueue<N *> PQ;
+using Entry = PriorityQueueEntry<N *>;
+using PQ    = PriorityQueue<N *>;
 
 // For debug
 void

--- a/mgmt/FileManager.cc
+++ b/mgmt/FileManager.cc
@@ -36,7 +36,7 @@
 #define DIR_MODE S_IRWXU
 #define FILE_MODE S_IRWXU
 
-typedef fileEntry snapshot;
+using snapshot = fileEntry;
 
 FileManager::FileManager()
 {

--- a/mgmt/api/EventControlMain.cc
+++ b/mgmt/api/EventControlMain.cc
@@ -522,7 +522,7 @@ done:
   return ret;
 }
 
-typedef TSMgmtError (*event_message_handler)(EventClientT *, void *, size_t);
+using event_message_handler = TSMgmtError (*)(EventClientT *, void *, size_t);
 
 static const event_message_handler handlers[] = {
   nullptr,                     // FILE_READ

--- a/plugins/authproxy/authproxy.cc
+++ b/plugins/authproxy/authproxy.cc
@@ -44,7 +44,7 @@ using std::strlen;
 
 struct AuthRequestContext;
 
-typedef bool (*AuthRequestTransform)(AuthRequestContext *auth);
+using AuthRequestTransform = bool (*)(AuthRequestContext *);
 
 const static int MAX_HOST_LENGTH = 4096;
 
@@ -73,7 +73,7 @@ static AuthOptions *AuthGlobalOptions;
 //      TS_EVENT_CONTINUE   Continue the state machine, returning to the ATS event loop
 //      TS_EVENT_NONE       Stop processing (because a nested dispatch occurred)
 //      Anything else       Continue the state machine with this event
-typedef TSEvent (*StateHandler)(struct AuthRequestContext *, void *edata);
+using StateHandler = TSEvent (*)(struct AuthRequestContext *, void *);
 
 struct StateTransition {
   TSEvent event;

--- a/plugins/esi/combo_handler.cc
+++ b/plugins/esi/combo_handler.cc
@@ -66,7 +66,7 @@ static int COMBO_HANDLER_PATH_SIZE;
     TSDebug(DEBUG_TAG, "[%s:%d] [%s] DEBUG: " fmt, __FILE__, __LINE__, __FUNCTION__, ##args); \
   } while (0)
 
-typedef list<string> StringList;
+using StringList = list<string>;
 
 struct ClientRequest {
   TSHttpStatus status;

--- a/plugins/experimental/balancer/hash.cc
+++ b/plugins/experimental/balancer/hash.cc
@@ -69,7 +69,7 @@ struct md5_key {
   unsigned char key[MD5_DIGEST_LENGTH];
 };
 
-typedef void (*HashComponent)(TSHttpTxn txn, TSRemapRequestInfo *, MD5_CTX *);
+using HashComponent = void (*)(TSHttpTxn, TSRemapRequestInfo *, MD5_CTX *);
 
 // Hash on the source (client) IP address.
 void
@@ -146,7 +146,7 @@ done:
 
 struct HashBalancer : public BalancerInstance {
   typedef std::map<md5_key, BalancerTarget> hash_ring_type;
-  typedef std::vector<HashComponent> hash_part_type;
+  using hash_part_type = std::vector<HashComponent>;
 
   enum {
     iterations = 10,

--- a/plugins/experimental/buffer_upload/buffer_upload.cc
+++ b/plugins/experimental/buffer_upload/buffer_upload.cc
@@ -76,7 +76,7 @@ struct upload_config_t {
   int thread_num;
 };
 
-typedef struct upload_config_t upload_config;
+using upload_config = struct upload_config_t;
 
 enum config_type {
   TYPE_INT,
@@ -135,7 +135,7 @@ struct pvc_state_t {
   TSHttpTxn http_txnp;
 };
 
-typedef struct pvc_state_t pvc_state;
+using pvc_state = struct pvc_state_t;
 
 // print IOBuffer for test purpose
 /*

--- a/plugins/experimental/cache_promote/cache_promote.cc
+++ b/plugins/experimental/cache_promote/cache_promote.cc
@@ -188,7 +188,7 @@ struct LRUHashHasher {
 };
 
 typedef std::pair<LRUHash, unsigned> LRUEntry;
-typedef std::list<LRUEntry> LRUList;
+using LRUList = std::list<LRUEntry>;
 typedef std::unordered_map<const LRUHash *, LRUList::iterator, LRUHashHasher, LRUHashHasher> LRUMap;
 
 static LRUEntry NULL_LRU_ENTRY; // Used to create an "empty" new LRUEntry

--- a/plugins/experimental/ssl_cert_loader/ssl-cert-loader.cc
+++ b/plugins/experimental/ssl_cert_loader/ssl-cert-loader.cc
@@ -78,7 +78,7 @@ public:
 
 std::string ConfigPath;
 typedef std::pair<IpAddr, IpAddr> IpRange;
-typedef std::deque<IpRange> IpRangeQueue;
+using IpRangeQueue = std::deque<IpRange>;
 
 Configuration Config; // global configuration
 

--- a/plugins/experimental/sslheaders/expand.cc
+++ b/plugins/experimental/sslheaders/expand.cc
@@ -22,7 +22,7 @@
 #include <openssl/x509.h>
 #include <openssl/pem.h>
 
-typedef void (*x509_expansion)(X509 *, BIO *);
+using x509_expansion = void (*)(X509 *, BIO *);
 
 static void
 x509_expand_none(X509 *, BIO *)

--- a/plugins/experimental/stream_editor/stream_editor.cc
+++ b/plugins/experimental/stream_editor/stream_editor.cc
@@ -101,8 +101,8 @@
 #include "ts/ts.h"
 
 struct edit_t;
-typedef std::set<edit_t> editset_t;
-typedef editset_t::const_iterator edit_p;
+using editset_t = std::set<edit_t>;
+using edit_p    = editset_t::const_iterator;
 
 struct edit_t {
   const size_t start;
@@ -547,8 +547,8 @@ public:
     }
   }
 };
-typedef std::vector<rule_t> ruleset_t;
-typedef ruleset_t::const_iterator rule_p;
+using ruleset_t = std::vector<rule_t>;
+using rule_p    = ruleset_t::const_iterator;
 
 typedef struct contdata_t {
   TSCont cont;

--- a/proxy/CacheControl.cc
+++ b/proxy/CacheControl.cc
@@ -68,7 +68,7 @@ CC_delete_table()
 //  a timeout
 //
 struct CC_FreerContinuation;
-typedef int (CC_FreerContinuation::*CC_FreerContHandler)(int, void *);
+using CC_FreerContHandler = int (CC_FreerContinuation::*)(int, void *);
 struct CC_FreerContinuation : public Continuation {
   CC_table *p;
   int

--- a/proxy/ICP.cc
+++ b/proxy/ICP.cc
@@ -144,10 +144,10 @@ HTTPHdr gclient_request;
 //****************************************************************************
 
 // VC++ 5.0 is rather picky
-typedef int (ICPPeerReadCont::*ICPPeerReadContHandler)(int, void *);
-typedef int (ICPPeriodicCont::*ICPPeriodicContHandler)(int, void *);
-typedef int (ICPHandlerCont::*ICPHandlerContHandler)(int, void *);
-typedef int (ICPRequestCont::*ICPRequestContHandler)(int, void *);
+using ICPPeerReadContHandler = int (ICPPeerReadCont::*)(int, void *);
+using ICPPeriodicContHandler = int (ICPPeriodicCont::*)(int, void *);
+using ICPHandlerContHandler  = int (ICPHandlerCont::*)(int, void *);
+using ICPRequestContHandler  = int (ICPRequestCont::*)(int, void *);
 
 // Plugin freshness function
 PluginFreshnessCalcFunc pluginFreshnessCalcFunc = (PluginFreshnessCalcFunc) nullptr;

--- a/proxy/ICPConfig.cc
+++ b/proxy/ICPConfig.cc
@@ -397,7 +397,7 @@ ICPConfigUpdateCont::RetryICPconfigUpdate(int /* event ATS_UNUSED */, Event * /*
 // Class ICPConfiguration member functions
 //      Overall manager of ICP configuration data from TS configuration.
 //--------------------------------------------------------------------------
-typedef int (ICPConfigUpdateCont::*ICPCfgContHandler)(int, void *);
+using ICPCfgContHandler = int (ICPConfigUpdateCont::*)(int, void *);
 ICPConfiguration::ICPConfiguration() : _icp_config_callouts(0)
 {
   //*********************************************************
@@ -1188,7 +1188,7 @@ MultiCastPeer::FindMultiCastChild(IpAddr const &addr, uint16_t port)
 // Class PeriodicCont member functions (abstract base class)
 //      Look for TS ICP configuration changes by periodically looking.
 //-------------------------------------------------------------------------
-typedef int (ICPPeriodicCont::*ICPPeriodicContHandler)(int, void *);
+using ICPPeriodicContHandler = int (ICPPeriodicCont::*)(int, void *);
 PeriodicCont::PeriodicCont(ICPProcessor *icpP) : Continuation(nullptr), _ICPpr(icpP)
 {
   mutex = new_ProxyMutex();

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -2123,8 +2123,8 @@ TSUrlStringGet(TSMBuffer bufp, TSMLoc obj, int *length)
   return url_string_get(url_impl, nullptr, length, nullptr);
 }
 
-typedef const char *(URL::*URLPartGetF)(int *length);
-typedef void (URL::*URLPartSetF)(const char *value, int length);
+using URLPartGetF = const char *(URL::*)(int *);
+using URLPartSetF = void (URL::*)(const char *, int);
 
 static const char *
 URLPartGet(TSMBuffer bufp, TSMLoc obj, int *length, URLPartGetF url_f)

--- a/proxy/Plugin.cc
+++ b/proxy/Plugin.cc
@@ -36,7 +36,7 @@
 
 static const char *plugin_dir = ".";
 
-typedef void (*init_func_t)(int argc, char *argv[]);
+using init_func_t = void (*)(int, char **);
 
 // Plugin registration vars
 //

--- a/proxy/ReverseProxy.cc
+++ b/proxy/ReverseProxy.cc
@@ -119,7 +119,7 @@ response_url_remap(HTTPHdr *response_header)
 
 /** Used to read the remap.config file after the manager signals a change. */
 struct UR_UpdateContinuation;
-typedef int (UR_UpdateContinuation::*UR_UpdContHandler)(int, void *);
+using UR_UpdContHandler = int (UR_UpdateContinuation::*)(int, void *);
 struct UR_UpdateContinuation : public Continuation {
   int
   file_update_handler(int /* etype ATS_UNUSED */, void * /* data ATS_UNUSED */)

--- a/proxy/SocksProxy.cc
+++ b/proxy/SocksProxy.cc
@@ -43,7 +43,7 @@ static RecRawStatBlock *socksproxy_stat_block;
 #define SOCKSPROXY_INC_STAT(x) RecIncrRawStat(socksproxy_stat_block, mutex->thread_holding, x)
 
 struct SocksProxy : public Continuation {
-  typedef int (SocksProxy::*EventHandler)(int event, void *data);
+  using EventHandler = int (SocksProxy::*)(int, void *);
 
   enum {
     SOCKS_INIT = 1,
@@ -494,7 +494,7 @@ new_SocksProxy(NetVConnection *netVC)
 }
 
 struct SocksAccepter : public Continuation {
-  typedef int (SocksAccepter::*SocksAccepterHandler)(int, void *);
+  using SocksAccepterHandler = int (SocksAccepter::*)(int, void *);
 
   int
   mainEvent(int event, NetVConnection *netVC)

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -33,7 +33,7 @@
 #define DebugHttp2Stream(ua_session, stream_id, fmt, ...) \
   DebugSsn(ua_session, "http2_con", "[%" PRId64 "] [%u] " fmt, ua_session->connection_id(), stream_id, ##__VA_ARGS__);
 
-typedef Http2Error (*http2_frame_dispatch)(Http2ConnectionState &, const Http2Frame &);
+using http2_frame_dispatch = Http2Error (*)(Http2ConnectionState &, const Http2Frame &);
 
 static const int buffer_size_index[HTTP2_FRAME_TYPE_MAX] = {
   BUFFER_SIZE_INDEX_16K, // HTTP2_FRAME_TYPE_DATA

--- a/proxy/http2/test_Http2DependencyTree.cc
+++ b/proxy/http2/test_Http2DependencyTree.cc
@@ -31,7 +31,7 @@
 
 using namespace std;
 
-typedef Http2DependencyTree<string *> Tree;
+using Tree = Http2DependencyTree<string *>;
 
 /**
  * Exclusive Dependency Creation

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -171,7 +171,7 @@ Log::change_configuration()
   -------------------------------------------------------------------------*/
 
 struct PeriodicWakeup;
-typedef int (PeriodicWakeup::*PeriodicWakeupHandler)(int, void *);
+using PeriodicWakeupHandler = int (PeriodicWakeup::*)(int, void *);
 struct PeriodicWakeup : Continuation {
   int m_preproc_threads;
   int m_flush_threads;


### PR DESCRIPTION
Ran clang-tidy on the 7.1.x branch to make changes easier to backport.