### PR TITLE
remove bad check for configuration directory override (kill it with fire)

### DIFF
--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -1542,12 +1542,6 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   }
 #endif
 
-  // Specific validity checks.
-  if (*conf_dir && command_index != find_cmd_index(CMD_VERIFY_CONFIG)) {
-    fprintf(stderr, "-D option can only be used with the %s command\n", CMD_VERIFY_CONFIG);
-    ::exit(1);
-  }
-
   // Bootstrap syslog.  Since we haven't read records.config
   //   yet we do not know where
   openlog("traffic_server", LOG_PID | LOG_NDELAY | LOG_NOWAIT, LOG_DAEMON);


### PR DESCRIPTION
This code was checking to see if we had a custom config directory being used ( that was not based on TS_ROOT) that we had set a --D options set to validate the config files. In the case of testing ( as well as other use cases) this is the wrong assumption. Removing this code allows us to test more custom layouts build of ATS in which the configuration directory is set as an absolute path. Without this fix we cannot run ats in a sandbox like environment correctly for testing purposes  

I think this needs to be backported to 7.1