### PR TITLE
Revert PR #947

### DIFF
--- a/iocore/net/P_UnixNetState.h
+++ b/iocore/net/P_UnixNetState.h
@@ -45,14 +45,13 @@ class UnixNetVConnection;
 
 struct NetState {
   volatile int enabled;
-  volatile int error;
   VIO vio;
   Link<UnixNetVConnection> ready_link;
   SLink<UnixNetVConnection> enable_link;
   int in_enabled_list;
   int triggered;
 
-  NetState() : enabled(0), error(0), vio(VIO::NONE), in_enabled_list(0), triggered(0) {}
+  NetState() : enabled(0), vio(VIO::NONE), in_enabled_list(0), triggered(0) {}
 };
 
 #endif

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -211,7 +211,6 @@ public:
   virtual int64_t load_buffer_and_write(int64_t towrite, MIOBufferAccessor &buf, int64_t &total_written, int &needs);
   void readDisable(NetHandler *nh);
   void readSignalError(NetHandler *nh, int err);
-  void writeSignalError(NetHandler *nh, int err);
   int readSignalDone(int event, NetHandler *nh);
   int readSignalAndUpdate(int event);
   void readReschedule(NetHandler *nh);

--- a/iocore/net/UnixNet.cc
+++ b/iocore/net/UnixNet.cc
@@ -453,13 +453,8 @@ NetHandler::mainNetEvent(int event, Event *e)
       if (cop_list.in(vc)) {
         cop_list.remove(vc);
       }
-      if (get_ev_events(pd, x) & EVENTIO_READ) {
+      if (get_ev_events(pd, x) & (EVENTIO_READ | EVENTIO_ERROR)) {
         vc->read.triggered = 1;
-        if (get_ev_events(pd, x) & EVENTIO_ERROR) {
-          vc->read.error = 1;
-        } else {
-          vc->read.error = 0;
-        }
         if (!read_ready_list.in(vc)) {
           read_ready_list.enqueue(vc);
         } else if (get_ev_events(pd, x) & EVENTIO_ERROR) {
@@ -469,13 +464,8 @@ NetHandler::mainNetEvent(int event, Event *e)
         }
       }
       vc = epd->data.vc;
-      if (get_ev_events(pd, x) & EVENTIO_WRITE) {
+      if (get_ev_events(pd, x) & (EVENTIO_WRITE | EVENTIO_ERROR)) {
         vc->write.triggered = 1;
-        if (get_ev_events(pd, x) & EVENTIO_ERROR) {
-          vc->write.error = 1;
-        } else {
-          vc->write.error = 0;
-        }
         if (!write_ready_list.in(vc)) {
           write_ready_list.enqueue(vc);
         } else if (get_ev_events(pd, x) & EVENTIO_ERROR) {
@@ -506,11 +496,11 @@ NetHandler::mainNetEvent(int event, Event *e)
   while ((vc = read_ready_list.dequeue())) {
     // Initialize the thread-local continuation flags
     set_cont_flags(vc->control_flags);
-    if (vc->closed) {
+    if (vc->closed)
       close_UnixNetVConnection(vc, trigger_event->ethread);
-    } else if (vc->read.triggered && (vc->read.enabled || (vc->read.error && vc->read.vio._cont != nullptr))) {
+    else if (vc->read.enabled && vc->read.triggered)
       vc->net_read_io(this, trigger_event->ethread);
-    } else if (!vc->read.enabled) {
+    else if (!vc->read.enabled) {
       read_ready_list.remove(vc);
 #if defined(solaris)
       if (vc->read.triggered && vc->write.enabled) {
@@ -523,11 +513,11 @@ NetHandler::mainNetEvent(int event, Event *e)
   }
   while ((vc = write_ready_list.dequeue())) {
     set_cont_flags(vc->control_flags);
-    if (vc->closed) {
+    if (vc->closed)
       close_UnixNetVConnection(vc, trigger_event->ethread);
-    } else if (vc->write.triggered && (vc->write.enabled || (vc->write.error && vc->write.vio._cont != nullptr))) {
+    else if (vc->write.enabled && vc->write.triggered)
       write_to_net(this, vc, trigger_event->ethread);
-    } else if (!vc->write.enabled) {
+    else if (!vc->write.enabled) {
       write_ready_list.remove(vc);
 #if defined(solaris)
       if (vc->write.triggered && vc->read.enabled) {
@@ -543,7 +533,7 @@ NetHandler::mainNetEvent(int event, Event *e)
     diags->set_override(vc->control.debug_override);
     if (vc->closed)
       close_UnixNetVConnection(vc, trigger_event->ethread);
-    else if (vc->read.triggered && (vc->read.enabled || (vc->read.error && vc->read.vio._cont != nullptr)))
+    else if (vc->read.enabled && vc->read.triggered)
       vc->net_read_io(this, trigger_event->ethread);
     else if (!vc->read.enabled)
       vc->ep.modify(-EVENTIO_READ);
@@ -552,7 +542,7 @@ NetHandler::mainNetEvent(int event, Event *e)
     diags->set_override(vc->control.debug_override);
     if (vc->closed)
       close_UnixNetVConnection(vc, trigger_event->ethread);
-    else if (vc->write.triggered && (vc->write.enabled || (vc->write.error && vc->write.vio._cont != nullptr)))
+    else if (vc->write.enabled && vc->write.triggered)
       write_to_net(this, vc, trigger_event->ethread);
     else if (!vc->write.enabled)
       vc->ep.modify(-EVENTIO_WRITE);

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -265,33 +265,6 @@ read_from_net(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
     close_UnixNetVConnection(vc, thread);
     return;
   }
-
-  if (!s->enabled && vc->read.error) {
-    int err = 0, errlen = sizeof(int);
-    if (getsockopt(vc->con.fd, SOL_SOCKET, SO_ERROR, &err, (socklen_t *)&errlen) == -1) {
-      err = errno;
-    }
-
-    // if it is a non-temporary error, we should die appropriately
-    if (err && err != EAGAIN && err != EINTR) {
-      Continuation *reader_cont = vc->read.vio._cont;
-
-      if (read_signal_error(nh, vc, err) == EVENT_DONE) {
-        return;
-      }
-      // If vc is closed or shutdown(WRITE) in last read_signal_error callback,
-      //   or reader_cont is same as write.vio._cont.
-      // Then we must clear the write.error to avoid callback EVENT_ERROR to SM by write_ready_list.
-      if (vc->closed || (vc->f.shutdown & NET_VC_SHUTDOWN_WRITE) || reader_cont == vc->write.vio._cont) {
-        vc->write.error = 0;
-      }
-      return;
-    }
-
-    // clear read.error if it is non-fatal error
-    vc->read.error = 0;
-  }
-
   // if it is not enabled.
   if (!s->enabled || s->vio.op != VIO::READ) {
     read_disable(nh, vc);
@@ -462,23 +435,6 @@ write_to_net_io(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
   if (!lock.is_locked() || lock.get_mutex() != s->vio.mutex.get()) {
     write_reschedule(nh, vc);
     return;
-  }
-
-  if (!s->enabled && vc->write.error) {
-    int err = 0, errlen = sizeof(int);
-    if (getsockopt(vc->con.fd, SOL_SOCKET, SO_ERROR, &err, (socklen_t *)&errlen) == -1) {
-      err = errno;
-    }
-
-    if (err && err != EAGAIN && err != EINTR) {
-      // Here is differ to net_read_io since read_signal_error always callback first.
-      // NetHandler::mainNetEvent() is always handle read_ready_list first and then write_ready_list.
-      write_signal_error(nh, vc, err);
-      return;
-    }
-
-    // clear write.error if it is non-fatal error.
-    vc->write.error = 0;
   }
 
   // This function will always return true unless
@@ -1148,12 +1104,6 @@ void
 UnixNetVConnection::readSignalError(NetHandler *nh, int err)
 {
   read_signal_error(nh, this, err);
-}
-
-void
-UnixNetVConnection::writeSignalError(NetHandler *nh, int err)
-{
-  write_signal_error(nh, this, err);
 }
 
 int


### PR DESCRIPTION
This reverts PRs #1559, #1522 and #947

PR #947  made the HTTP state machine unstable and lead to crashes in production like #1930 #1559 #1522 #1531 #1629 

