### PR TITLE
Gracefully shut down traffic_server on SIGINT.

### DIFF
--- a/doc/appendices/command-line/traffic_manager.en.rst
+++ b/doc/appendices/command-line/traffic_manager.en.rst
@@ -57,7 +57,11 @@ Signals
 SIGHUP
   This signal causes a reconfiguration event, equivalent to running :program:`traffic_ctl config reload`.
 
+SIGINT, SIGTERM
+  These signals cause :program:`traffic_manager` to exit after also shutting down :program:`traffic_server`.
+
 See also
 ========
 
-:manpage:`traffic_ctl(8)`
+:manpage:`traffic_ctl(8)`,
+:manpage:`traffic_server(8)`

--- a/doc/appendices/command-line/traffic_server.en.rst
+++ b/doc/appendices/command-line/traffic_server.en.rst
@@ -109,11 +109,14 @@ startup. This is primarily useful for testing.
 Signals
 =======
 
-On `SIGTERM`, :program:`traffic_server` exits.
+SIGINT, SIGTERM
+  On `SIGINT` and `SIGTERM`, :program:`traffic_server` exits.
 
-On `SIGUSR1`, :program:`traffic_server` logs its current memory usage.
+SIGUSR1
+  On `SIGUSR1`, :program:`traffic_server` logs its current memory usage.
 
-On `SIGUSR2`, :program:`traffic_server` re-opens its standard error and standard out file descriptors.
+SIGUSR2
+  On `SIGUSR2`, :program:`traffic_server` re-opens its standard error and standard out file descriptors.
 
 See also
 ========

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -269,8 +269,9 @@ public:
       diags->set_stderr_output(bind_stderr);
     }
 
-    if (signal_received[SIGTERM]) {
+    if (signal_received[SIGTERM] || signal_received[SIGINT]) {
       signal_received[SIGTERM] = false;
+      signal_received[SIGINT]  = false;
 
       RecInt timeout = 0;
       REC_ReadConfigInteger(timeout, "proxy.config.stop.shutdown_timeout");
@@ -279,7 +280,7 @@ public:
         http2_drain = true;
       }
 
-      Debug("server", "received SIGTERM, shutting down in %" PRId64 "secs", timeout);
+      Debug("server", "received exit signal, shutting down in %" PRId64 "secs", timeout);
 
       // Shutdown in `timeout` seconds (or now if that is 0).
       eventProcessor.schedule_in(new AutoStopCont(), HRTIME_SECONDS(timeout));
@@ -463,10 +464,11 @@ proxy_signal_handler(int signo, siginfo_t *info, void *ctx)
 
   // These signals are all handled by SignalContinuation.
   switch (signo) {
+  case SIGHUP:
+  case SIGINT:
+  case SIGTERM:
   case SIGUSR1:
   case SIGUSR2:
-  case SIGHUP:
-  case SIGTERM:
     return;
   }
 


### PR DESCRIPTION
traffic_manager forwards SIGTERM and SIGINT to traffic_server in the
expectation that traffic_server will exit. Add support for this to the
traffic_server signal handler so that SIGTERM and SIGINT are handled in
the same way. Document the usage of these signals.