### PR TITLE
Revert PR #947 - merge to 7.1.x

### DIFF
--- a/iocore/net/P_UnixNetState.h
+++ b/iocore/net/P_UnixNetState.h
@@ -48,14 +48,13 @@ class UnixNetVConnection;
 
 struct NetState {
   volatile int enabled;
-  volatile int error;
   VIO vio;
   Link<UnixNetVConnection> ready_link;
   SLink<UnixNetVConnection> enable_link;
   int in_enabled_list;
   int triggered;
 
-  NetState() : enabled(0), error(0), vio(VIO::NONE), in_enabled_list(0), triggered(0) {}
+  NetState() : enabled(0), vio(VIO::NONE), in_enabled_list(0), triggered(0) {}
 };
 
 #endif

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -237,7 +237,6 @@ public:
   virtual int64_t load_buffer_and_write(int64_t towrite, MIOBufferAccessor &buf, int64_t &total_written, int &needs);
   void readDisable(NetHandler *nh);
   void readSignalError(NetHandler *nh, int err);
-  void writeSignalError(NetHandler *nh, int err);
   int readSignalDone(int event, NetHandler *nh);
   int readSignalAndUpdate(int event);
   void readReschedule(NetHandler *nh);


### PR DESCRIPTION
This reverts PRs #1559, #1522 and #947

PR #947 made the HTTP state machine unstable and lead to crashes in production like #1930 #1559 #1522 #1531 #1629

This reverts commit c1ac5f8bf87fd4bc3a8e06507219970d83965acd.