### PR TITLE
Fix assertion with 100-continue --- 7.1.x

### DIFF
--- a/proxy/hdrs/HTTP.h
+++ b/proxy/hdrs/HTTP.h
@@ -495,6 +495,7 @@ public:
   mutable int m_port;           ///< Target port.
   mutable bool m_target_cached; ///< Whether host name and port are cached.
   mutable bool m_target_in_url; ///< Whether host name and port are in the URL.
+  mutable bool m_100_continue_required;
   /// Set if the port was effectively specified in the header.
   /// @c true if the target (in the URL or the HOST field) also specified
   /// a port. That is, @c true if whatever source had the target host
@@ -760,7 +761,7 @@ HTTPVersion::operator<=(const HTTPVersion &hv) const
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-inline HTTPHdr::HTTPHdr() : MIMEHdr(), m_http(NULL), m_url_cached(), m_target_cached(false)
+inline HTTPHdr::HTTPHdr() : MIMEHdr(), m_http(NULL), m_url_cached(), m_target_cached(false), m_100_continue_required(false)
 {
 }
 

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -795,9 +795,11 @@ HttpSM::state_read_client_request_header(int event, void *data)
         ua_entry->write_buffer    = new_MIOBuffer(alloc_index);
         IOBufferReader *buf_start = ua_entry->write_buffer->alloc_reader();
 
+        t_state.hdr_info.client_request.m_100_continue_required = true;
+
         DebugSM("http_seq", "send 100 Continue response to client");
-        int64_t nbytes = ua_entry->write_buffer->write(str_100_continue_response, len_100_continue_response);
-        ua_session->do_io_write(netvc, nbytes, buf_start);
+        int64_t nbytes      = ua_entry->write_buffer->write(str_100_continue_response, len_100_continue_response);
+        ua_entry->write_vio = ua_session->do_io_write(this, nbytes, buf_start);
       }
     }
 
@@ -891,7 +893,7 @@ HttpSM::state_watch_for_client_abort(int event, void *data)
 {
   STATE_ENTER(&HttpSM::state_watch_for_client_abort, event);
 
-  ink_assert(ua_entry->read_vio == (VIO *)data);
+  ink_assert(ua_entry->read_vio == (VIO *)data || ua_entry->write_vio == (VIO *)data);
   ink_assert(ua_entry->vc == ua_session);
 
   switch (event) {
@@ -953,6 +955,20 @@ HttpSM::state_watch_for_client_abort(int event, void *data)
   case VC_EVENT_READ_READY:
     //  Ignore.  Could be a pipelined request.  We'll get to  it
     //    when we finish the current transaction
+    break;
+  case VC_EVENT_WRITE_READY:
+    // 100-continue handler
+    ink_assert(t_state.hdr_info.client_request.m_100_continue_required);
+    ua_entry->write_vio->reenable();
+    break;
+  case VC_EVENT_WRITE_COMPLETE:
+    // 100-continue handler
+    ink_assert(t_state.hdr_info.client_request.m_100_continue_required);
+    if (ua_entry->write_buffer) {
+      ink_assert(ua_entry->write_vio && !ua_entry->write_vio->ntodo());
+      free_MIOBuffer(ua_entry->write_buffer);
+      ua_entry->write_buffer = nullptr;
+    }
     break;
   default:
     ink_release_assert(0);
@@ -3504,6 +3520,9 @@ HttpSM::tunnel_handler_post_ua(int event, HttpTunnelProducer *p)
       // send back 408 request timeout
       alloc_index = buffer_size_to_index(len_408_request_timeout_response + t_state.internal_msg_buffer_size);
       if (ua_entry->write_buffer) {
+        if (t_state.hdr_info.client_request.m_100_continue_required) {
+          ink_assert(ua_entry->write_vio && !ua_entry->write_vio->ntodo());
+        }
         free_MIOBuffer(ua_entry->write_buffer);
         ua_entry->write_buffer = nullptr;
       }


### PR DESCRIPTION
#1923 

Discussed the #1777 issue with @oknet. We could reuse HttpSM::state_watch_for_client_abort as 100-continue handler.

please review!