### PR TITLE
request_content_length is used without initializing in state_read_client_request_header

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -724,7 +724,8 @@ HttpSM::state_read_client_request_header(int event, void *data)
     }
 
     if (t_state.hdr_info.client_request.method_get_wksidx() == HTTP_WKSIDX_TRACE ||
-        (t_state.hdr_info.request_content_length <= 0 && t_state.client_info.transfer_encoding != HttpTransact::CHUNKED_ENCODING)) {
+        (t_state.hdr_info.client_request.get_content_length() == 0 &&
+         t_state.client_info.transfer_encoding != HttpTransact::CHUNKED_ENCODING)) {
       // Enable further IO to watch for client aborts
       ua_entry->read_vio->reenable();
     } else {


### PR DESCRIPTION
request_content_length is unintialized in HttpSM::state_read_client_request_header.
So we need to get cl from client_request header.