### PR TITLE
Clean up of error logging in regex_remap.cc

### DIFF
--- a/plugins/regex_remap/regex_remap.cc
+++ b/plugins/regex_remap/regex_remap.cc
@@ -35,6 +35,8 @@
 #include <fstream>
 #include <string>
 #include <cctype>
+#include <memory>
+#include <sstream>
 
 // Get some specific stuff from libts, yes, we can do that now that we build inside the core.
 #include "ts/ink_platform.h"
@@ -152,7 +154,7 @@ public:
     fprintf(stderr, "[%s]:    Regex %d ( %s ): %.2f%%\n", now, ix, _rex_string, 100.0 * _hits / max);
   }
 
-  int compile(const char **error, int *erroffset);
+  int compile(const char *&error, int &erroffset);
 
   // Perform the regular expression matching against a string.
   int
@@ -202,6 +204,11 @@ public:
   regex() const
   {
     return _rex_string;
+  }
+  inline bool
+  regex_empty() const
+  {
+    return !_rex_string || !*_rex_string;
   }
   inline const char *
   substitution() const
@@ -347,9 +354,9 @@ RemapRegex::initialize(const std::string &reg, const std::string &sub, const std
       std::string opt_name = opt.substr(start, pos1 - start - 1);
 
       if (TS_SUCCESS == TSHttpTxnConfigFind(opt_name.c_str(), opt_name.length(), &key, &type)) {
-        Override *cur = new Override;
+        std::unique_ptr<Override> cur(new Override);
 
-        TSReleaseAssert(cur);
+        TSReleaseAssert(cur.get());
         switch (type) {
         case TS_RECORDDATATYPE_INT:
           cur->data.rec_int = strtoll(opt_val.c_str(), nullptr, 10);
@@ -363,19 +370,19 @@ RemapRegex::initialize(const std::string &reg, const std::string &sub, const std
           break;
         default:
           TSError("[%s] configuration variable '%s' is of an unsupported type", PLUGIN_NAME, opt_name.c_str());
-          delete cur;
           return false;
         }
         TSDebug(PLUGIN_NAME, "Overridable config %s=%s", opt_name.c_str(), opt_val.c_str());
         cur->key  = key;
         cur->type = type;
         cur->next = nullptr;
+        auto tmp  = cur.get();
         if (nullptr == last_override) {
-          _first_override = cur;
+          _first_override = cur.release();
         } else {
-          last_override->next = cur;
+          last_override->next = cur.release();
         }
-        last_override = cur;
+        last_override = tmp;
       } else {
         TSError("[%s] Unknown options: %s", PLUGIN_NAME, opt.c_str());
       }
@@ -388,27 +395,32 @@ RemapRegex::initialize(const std::string &reg, const std::string &sub, const std
 
 // Compile and study the regular expression.
 int
-RemapRegex::compile(const char **error, int *erroffset)
+RemapRegex::compile(const char *&error, int &erroffset)
 {
   char *str;
   int ccount;
 
+  // Initialize these in case they are not set.
+  error     = "unknown error";
+  erroffset = -1;
+
   _rex = pcre_compile(_rex_string, // the pattern
                       _options,    // options
-                      error,       // for error message
-                      erroffset,   // for error offset
+                      &error,      // for error message
+                      &erroffset,  // for error offset
                       nullptr);    // use default character tables
 
   if (nullptr == _rex) {
     return -1;
   }
 
-  _extra = pcre_study(_rex, 0, error);
-  if ((_extra == nullptr) && error && (*error != nullptr)) {
+  _extra = pcre_study(_rex, 0, &error);
+  if ((_extra == nullptr) && (error != nullptr)) {
     return -1;
   }
 
   if (pcre_fullinfo(_rex, _extra, PCRE_INFO_CAPTURECOUNT, &ccount) != 0) {
+    error = "call to pcre_fullinfo() failed";
     return -1;
   }
 
@@ -461,8 +473,8 @@ RemapRegex::compile(const char **error, int *erroffset)
 
       if (ix > -1) {
         if ((ix < 10) && (ix > ccount)) {
-          TSDebug(PLUGIN_NAME, "Trying to use unavailable substitution, check the regex!");
-          return -1; // No substitutions available other than $0
+          error = "using unavailable captured substring ($n) in substitution";
+          return -1;
         }
 
         _sub_ix[_num_subs]  = ix;
@@ -707,8 +719,6 @@ TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 TSReturnCode
 TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSED */, int /* errbuf_sizeATS_UNUSED */)
 {
-  const char *error;
-  int erroffset;
   RemapInstance *ri = new RemapInstance();
 
   std::ifstream f;
@@ -825,26 +835,38 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
     }
 
     // Got a regex and substitution string
-    RemapRegex *cur = new RemapRegex();
+    std::unique_ptr<RemapRegex> cur(new RemapRegex);
 
     if (!cur->initialize(regex, subst, options)) {
       TSError("[%s] can't create a new regex remap rule", PLUGIN_NAME);
-      delete cur;
       continue;
     }
 
-    if (cur->compile(&error, &erroffset) < 0) {
-      TSError("[%s] PCRE failed in %s (line %d) at offset %d: %s", PLUGIN_NAME, (ri->filename).c_str(), lineno, erroffset, error);
-      delete (cur);
+    const char *error;
+    int erroffset;
+    if (cur->compile(error, erroffset) < 0) {
+      std::ostringstream oss;
+      oss << '[' << PLUGIN_NAME << "] PCRE failed in " << (ri->filename).c_str() << " (line " << lineno << ')';
+      if (erroffset > 0) {
+        oss << " at offset " << erroffset;
+      }
+      oss << ": " << error;
+      if (cur->regex_empty()) {
+        oss << "  (no regular expression)";
+      } else {
+        oss << "  regex: \"" << cur->regex() << '"';
+      }
+      TSError("%s", oss.str().c_str());
     } else {
       TSDebug(PLUGIN_NAME, "Added regex=%s with subs=%s and options `%s'", regex.c_str(), subst.c_str(), options.c_str());
       cur->set_order(++count);
+      auto tmp = cur.get();
       if (ri->first == nullptr) {
-        ri->first = cur;
+        ri->first = cur.release();
       } else {
-        ri->last->set_next(cur);
+        ri->last->set_next(cur.release());
       }
-      ri->last = cur;
+      ri->last = tmp;
     }
   }
 


### PR DESCRIPTION
Provide clearer message when $n used in substitution string in remap configuration file, and n is too large.  Don't output bogus line offset.  Clean up changes to conform better to RAII.