### PR TITLE
Change textwidth option in .vimrc to 132

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -4,4 +4,4 @@ set tabstop=2
 set softtabstop=2
 set shiftwidth=2
 set expandtab
-set textwidth=120
+set textwidth=132


### PR DESCRIPTION
Change textwidth option in .vimrc to 128 so that it corresponds to the line length used by 'make clang-format'.