### PR TITLE
ua_buffer_reader should be released in deallocate_redirect_postdata

### DIFF
--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -589,8 +589,8 @@ HttpTunnel::kill_tunnel()
     ink_assert(producer.alive == false);
   }
   active = false;
-  this->deallocate_buffers();
   this->deallocate_redirect_postdata_buffers();
+  this->deallocate_buffers();
   this->reset();
 }
 
@@ -630,6 +630,9 @@ HttpTunnel::deallocate_buffers()
   for (auto &producer : producers) {
     if (producer.read_buffer != nullptr) {
       ink_assert(producer.vc != nullptr);
+      if (postbuf && postbuf->ua_buffer_reader && postbuf->ua_buffer_reader->mbuf == producer.read_buffer) {
+        postbuf->ua_buffer_reader = nullptr;
+      }
       free_MIOBuffer(producer.read_buffer);
       producer.read_buffer  = nullptr;
       producer.buffer_start = nullptr;
@@ -1761,6 +1764,12 @@ HttpTunnel::deallocate_redirect_postdata_buffers()
       postbuf->postdata_copy_buffer       = nullptr;
       postbuf->postdata_copy_buffer_start = nullptr; // deallocated by the buffer
     }
+
+    if (postbuf->ua_buffer_reader != nullptr) {
+      postbuf->ua_buffer_reader->mbuf->dealloc_reader(postbuf->ua_buffer_reader);
+      postbuf->ua_buffer_reader = nullptr;
+    }
+
     delete postbuf;
     postbuf = nullptr;
   }


### PR DESCRIPTION
ua_buffer_reader should be released in deallocate_redirect_postdata_buffers

Otherwise, we will never append block in mbuf.  The max_read_avail (in read_from net) will check every readers in this mbuf and find out this reader. But we've not consumed data in this reader. 

So if the buffer is full, the request will be blocked until timeout. 