### PR TITLE
VIA changes for 7.1.x

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -820,18 +820,19 @@ ip-resolve
 
    Set how the ``Via`` field is handled on a request to the origin server.
 
-   ===== ============================================
+   ===== ====================================================================
    Value Effect
-   ===== ============================================
+   ===== ====================================================================
    ``0`` Do not modify or set this Via header.
-   ``1`` Update the Via, with normal verbosity.
-   ``2`` Update the Via, with higher verbosity.
-   ``3`` Update the Via, with highest verbosity.
-   ===== ============================================
+   ``1`` Add the basic protocol and proxy identifier.
+   ``2`` And basic transaction codes.
+   ``3`` And detailed transaction codes.
+   ``4`` And full user agent connection :ref:`protocol tags <protocol_tags>`.
+   ===== ====================================================================
 
 .. note::
 
-   The ``Via`` header string can be decoded with the `Via Decoder Ring <http://trafficserver.apache.org/tools/via>`_.
+   The ``Via`` transaction codes can be decoded with the `Via Decoder Ring <http://trafficserver.apache.org/tools/via>`_.
 
 .. ts:cv:: CONFIG proxy.config.http.request_via_str STRING ApacheTrafficServer/${PACKAGE_VERSION}
    :reloadable:
@@ -845,18 +846,19 @@ ip-resolve
 
    Set how the ``Via`` field is handled on the response to the client.
 
-   ===== ============================================
+   ===== ==================================================================
    Value Effect
-   ===== ============================================
-   ``0`` Do not modify or set this via header.
-   ``1`` Update the via, with normal verbosity.
-   ``2`` Update the via, with higher verbosity.
-   ``3`` Update the via, with highest verbosity.
-   ===== ============================================
+   ===== ==================================================================
+   ``0`` Do not modify or set this Via header.
+   ``1`` Add the basic protocol and proxy identifier.
+   ``2`` And basic transaction codes.
+   ``3`` And detailed transaction codes.
+   ``4`` And full upstream connection :ref:`protocol tags <protocol_tags>`.
+   ===== ==================================================================
 
 .. note::
 
-   The ``Via`` header string can be decoded with the `Via Decoder Ring <http://trafficserver.apache.org/tools/via>`_.
+   The ``Via`` transaction codes can be decoded with the `Via Decoder Ring <http://trafficserver.apache.org/tools/via>`_.
 
 .. ts:cv:: CONFIG proxy.config.http.response_via_str STRING ApacheTrafficServer/${PACKAGE_VERSION}
    :reloadable:

--- a/doc/developer-guide/api/functions/TSClientProtocolStack.en.rst
+++ b/doc/developer-guide/api/functions/TSClientProtocolStack.en.rst
@@ -42,40 +42,42 @@ Synopsis
 Description
 ===========
 
-These functions are used to explore the protocol stack of the client (user agent) connection to 
-|TS|. The functions :func:`TSHttpTxnClientProtocolStackGet` and 
-:func:`TSHttpSsnClientProtocolStackGet` can be used to retrieve the entire protocol stack for the 
-user agent connection. :func:`TSHttpTxnClientProtocolStackContains` and 
-:func:`TSHttpSsnClientProtocolStackContains` will check for a specific protocol :arg:`tag` being 
+These functions are used to explore the protocol stack of the client (user agent) connection to
+|TS|. The functions :func:`TSHttpTxnClientProtocolStackGet` and
+:func:`TSHttpSsnClientProtocolStackGet` can be used to retrieve the entire protocol stack for the
+user agent connection. :func:`TSHttpTxnClientProtocolStackContains` and
+:func:`TSHttpSsnClientProtocolStackContains` will check for a specific protocol :arg:`tag` being
 present in the stack.
 
-Each protocol is represented by tag which is a null terminated string. A particular tag will always 
-be returned as the same character pointer and so protocols can be reliably checked with pointer 
-comparisons. :func:`TSNormalizedProtocolTag` will return this character pointer for a specific 
-:arg:`tag`. A return value of :const:`NULL` indicates the provided :arg:`tag` is not registered as 
-a known protocol tag. :func:`TSRegisterProtocolTag` registers the :arg:`tag` and then returns its 
+Each protocol is represented by tag which is a null terminated string. A particular tag will always
+be returned as the same character pointer and so protocols can be reliably checked with pointer
+comparisons. :func:`TSNormalizedProtocolTag` will return this character pointer for a specific
+:arg:`tag`. A return value of :const:`NULL` indicates the provided :arg:`tag` is not registered as
+a known protocol tag. :func:`TSRegisterProtocolTag` registers the :arg:`tag` and then returns its
 normalized value. This is useful for plugins that provide custom protocols for user agents.
 
-The protocols are ordered from higher level protocols to the lower level ones on which the higher 
-operate. For instance a stack might look like "http/1.1,tls/1.2,tcp,ipv4". For 
-:func:`TSHttpTxnClientProtocolStackGet` and :func:`TSHttpSsnClientProtocolStackGet` these values 
-are placed in the array :arg:`result`. :arg:`count` is the maximum number of elements of 
-:arg:`result` that may be modified by the function call. If :arg:`actual` is not :const:`NULL` then 
-the actual number of elements in the protocol stack will be returned. If this is equal or less than 
-:arg:`count` then all elements were returned. If it is larger then some layers were omitted from 
-:arg:`result`. If the full stack is required :arg:`actual` can be used to resize :arg:`result` to 
-be sufficient to hold all of the elements and the function called again with updated :arg:`count` 
-and :arg:`result`. In practice the maximum number of elements will is almost certain to be less 
-than 10 which therefore should suffice. These functions return :const:`TS_SUCCESS` on success and 
+The protocols are ordered from higher level protocols to the lower level ones on which the higher
+operate. For instance a stack might look like "http/1.1,tls/1.2,tcp,ipv4". For
+:func:`TSHttpTxnClientProtocolStackGet` and :func:`TSHttpSsnClientProtocolStackGet` these values
+are placed in the array :arg:`result`. :arg:`count` is the maximum number of elements of
+:arg:`result` that may be modified by the function call. If :arg:`actual` is not :const:`NULL` then
+the actual number of elements in the protocol stack will be returned. If this is equal or less than
+:arg:`count` then all elements were returned. If it is larger then some layers were omitted from
+:arg:`result`. If the full stack is required :arg:`actual` can be used to resize :arg:`result` to
+be sufficient to hold all of the elements and the function called again with updated :arg:`count`
+and :arg:`result`. In practice the maximum number of elements will is almost certain to be less
+than 10 which therefore should suffice. These functions return :const:`TS_SUCCESS` on success and
 :const:`TS_ERROR` on failure which should only occurr if :arg:`txnp` or :arg:`ssnp` are invalid.
 
-The :func:`TSHttpTxnClientProtocolStackContains` and :func:`TSHttpSsnClientProtocolStackContains` 
-functions are provided for the convenience when only the presence of a protocol is of interest, not 
-its location or the presence of other protocols. These functions return NULL if the protocol 
+The :func:`TSHttpTxnClientProtocolStackContains` and :func:`TSHttpSsnClientProtocolStackContains`
+functions are provided for the convenience when only the presence of a protocol is of interest, not
+its location or the presence of other protocols. These functions return NULL if the protocol
 :arg:`tag` is not present, and a pointer to the normalized tag if it is present. The strings are
 matched with an anchor prefix search, as with debug tags. For instance if :arg:`tag` is "tls" then it
 will match "tls/1.2" or "tls/1.3". This makes checking for TLS or IP more convenient. If more precision
 is required the entire protocol stack can be retrieved and processed more thoroughly.
+
+.. _protocol_tags:
 
 The protocol tags defined by |TS|.
 
@@ -107,4 +109,3 @@ use :func:`TSHttpTxnClientProtocolStackGet` and :func:`TSHttpTxnClientProtocolSt
 .. literalinclude:: ../../../../example/protocol-stack/protocol-stack.cc
   :language: c
   :lines: 31-46
-

--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -33,6 +33,7 @@
 #include "I_IOBuffer.h"
 #include "I_Socks.h"
 #include <ts/apidefs.h>
+#include <ts/MemView.h>
 
 #define CONNECT_SUCCESS 1
 #define CONNECT_FAILURE 0
@@ -233,9 +234,9 @@ struct NetVCOptions {
     return *this;
   }
 
-  const char *get_family_string() const;
+  ts::StringView get_family_string() const;
 
-  const char *get_proto_string() const;
+  ts::StringView get_proto_string() const;
 
   /// @name Debugging
   //@{
@@ -626,13 +627,13 @@ public:
   }
 
   virtual int
-  populate_protocol(const char **results, int n) const
+  populate_protocol(ts::StringView *results, int n) const
   {
     return 0;
   }
 
   virtual const char *
-  protocol_contains(const char *tag) const
+  protocol_contains(ts::StringView prefix) const
   {
     return nullptr;
   }

--- a/iocore/net/NetVConnection.cc
+++ b/iocore/net/NetVConnection.cc
@@ -45,33 +45,30 @@ NetVConnection::cancel_OOB()
   return;
 }
 
-const char *
+ts::StringView
 NetVCOptions::get_proto_string() const
 {
   switch (ip_proto) {
   case USE_TCP:
-    return TS_PROTO_TAG_TCP;
+    return IP_PROTO_TAG_TCP;
   case USE_UDP:
-    return TS_PROTO_TAG_UDP;
+    return IP_PROTO_TAG_UDP;
   default:
-    return nullptr;
+    break;
   }
+  return nullptr;
 }
 
-const char *
+ts::StringView
 NetVCOptions::get_family_string() const
 {
-  const char *retval;
   switch (ip_family) {
   case AF_INET:
-    retval = TS_PROTO_TAG_IPV4;
-    break;
+    return IP_PROTO_TAG_IPV4;
   case AF_INET6:
-    retval = TS_PROTO_TAG_IPV6;
-    break;
+    return IP_PROTO_TAG_IPV6;
   default:
-    retval = nullptr;
     break;
   }
-  return retval;
+  return nullptr;
 }

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -37,6 +37,7 @@
 #include "P_UnixNetVConnection.h"
 #include "P_UnixNet.h"
 #include "ts/apidefs.h"
+#include <ts/MemView.h>
 
 #include <openssl/ssl.h>
 #include <openssl/err.h>
@@ -241,15 +242,15 @@ public:
     return ssl ? SSL_get_cipher_name(ssl) : nullptr;
   }
 
-  int populate_protocol(const char **results, int n) const override;
-  const char *protocol_contains(const char *tag) const override;
+  int populate_protocol(ts::StringView *results, int n) const override;
+  const char *protocol_contains(ts::StringView tag) const override;
 
   /**
    * Populate the current object based on the socket information in in the
    * con parameter and the ssl object in the arg parameter
    * This is logic is invoked when the NetVC object is created in a new thread context
    */
-  virtual int populate(Connection &con, Continuation *c, void *arg) override;
+  int populate(Connection &con, Continuation *c, void *arg) override;
 
   SSL *ssl;
   ink_hrtime sslHandshakeBeginTime;
@@ -263,7 +264,7 @@ private:
   SSLNetVConnection(const SSLNetVConnection &);
   SSLNetVConnection &operator=(const SSLNetVConnection &);
 
-  const char *map_tls_protocol_to_tag(const char *proto_string) const;
+  ts::StringView map_tls_protocol_to_tag(const char *proto_string) const;
 
   bool sslHandShakeComplete;
   bool sslClientRenegotiationAbort;

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -104,14 +104,14 @@ enum tcp_congestion_control_t { CLIENT_SIDE, SERVER_SIDE };
 class UnixNetVConnection : public NetVConnection
 {
 public:
-  virtual int64_t outstanding();
-  virtual VIO *do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf);
-  virtual VIO *do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool owner = false);
+  int64_t outstanding() override;
+  VIO *do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf) override;
+  VIO *do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool owner = false) override;
 
-  virtual bool get_data(int id, void *data);
+  bool get_data(int id, void *data) override;
 
-  virtual Action *send_OOB(Continuation *cont, char *buf, int len);
-  virtual void cancel_OOB();
+  Action *send_OOB(Continuation *cont, char *buf, int len) override;
+  void cancel_OOB() override;
 
   virtual void
   setSSLHandshakeWantsRead(bool /* flag */)
@@ -135,8 +135,8 @@ public:
     return false;
   }
 
-  virtual void do_io_close(int lerrno = -1);
-  virtual void do_io_shutdown(ShutdownHowTo_t howto);
+  void do_io_close(int lerrno = -1) override;
+  void do_io_shutdown(ShutdownHowTo_t howto) override;
 
   ////////////////////////////////////////////////////////////
   // Set the timeouts associated with this connection.      //
@@ -150,21 +150,21 @@ public:
   // called when handing an  event from this NetVConnection,//
   // or the NetVConnection creation callback.               //
   ////////////////////////////////////////////////////////////
-  virtual void set_active_timeout(ink_hrtime timeout_in);
-  virtual void set_inactivity_timeout(ink_hrtime timeout_in);
-  virtual void cancel_active_timeout();
-  virtual void cancel_inactivity_timeout();
-  virtual void set_action(Continuation *c);
-  virtual void add_to_keep_alive_queue();
-  virtual void remove_from_keep_alive_queue();
-  virtual bool add_to_active_queue();
+  void set_active_timeout(ink_hrtime timeout_in) override;
+  void set_inactivity_timeout(ink_hrtime timeout_in) override;
+  void cancel_active_timeout() override;
+  void cancel_inactivity_timeout() override;
+  void set_action(Continuation *c) override;
+  void add_to_keep_alive_queue() override;
+  void remove_from_keep_alive_queue() override;
+  bool add_to_active_queue() override;
   virtual void remove_from_active_queue();
 
   // The public interface is VIO::reenable()
-  virtual void reenable(VIO *vio);
-  virtual void reenable_re(VIO *vio);
+  void reenable(VIO *vio) override;
+  void reenable_re(VIO *vio) override;
 
-  virtual SOCKET get_socket();
+  SOCKET get_socket() override;
 
   virtual ~UnixNetVConnection();
 
@@ -176,33 +176,31 @@ public:
   UnixNetVConnection();
 
   int
-  populate_protocol(const char **results, int n) const
+  populate_protocol(ts::StringView *results, int n) const override
   {
     int retval = 0;
-    if (n > 0) {
-      results[retval++] = options.get_proto_string();
-      if (n > 1) {
-        results[retval++] = options.get_family_string();
+    if (n > retval) {
+      if (!(results[retval] = options.get_proto_string()).isEmpty())
+        ++retval;
+      if (n > retval) {
+        if (!(results[retval] = options.get_family_string()).isEmpty())
+          ++retval;
       }
     }
     return retval;
   }
 
   const char *
-  protocol_contains(const char *tag) const
+  protocol_contains(ts::StringView tag) const override
   {
-    const char *retval   = nullptr;
-    unsigned int tag_len = strlen(tag);
-    const char *test_tag = options.get_proto_string();
-    if (strncmp(tag, test_tag, tag_len) == 0) {
-      retval = test_tag;
-    } else {
-      test_tag = options.get_family_string();
-      if (strncmp(tag, test_tag, tag_len) == 0) {
-        retval = test_tag;
+    ts::StringView retval = options.get_proto_string();
+    if (strncmp(tag.ptr(), retval.ptr(), tag.size()) != 0) {
+      retval = options.get_family_string();
+      if (strncmp(tag.ptr(), retval.ptr(), tag.size()) != 0) {
+        retval.clear();
       }
     }
-    return retval;
+    return retval.ptr();
   }
 
 private:
@@ -311,14 +309,14 @@ public:
   virtual int populate(Connection &con, Continuation *c, void *arg);
   virtual void free(EThread *t);
 
-  virtual ink_hrtime get_inactivity_timeout();
-  virtual ink_hrtime get_active_timeout();
+  ink_hrtime get_inactivity_timeout() override;
+  ink_hrtime get_active_timeout() override;
 
-  virtual void set_local_addr();
-  virtual void set_remote_addr();
-  virtual int set_tcp_init_cwnd(int init_cwnd);
-  virtual int set_tcp_congestion_control(int side);
-  virtual void apply_options();
+  void set_local_addr() override;
+  void set_remote_addr() override;
+  int set_tcp_init_cwnd(int init_cwnd) override;
+  int set_tcp_congestion_control(int side) override;
+  void apply_options() override;
 
   friend void write_to_net_io(NetHandler *, UnixNetVConnection *, EThread *);
 

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -1545,21 +1545,28 @@ SSLNetVConnection::populate(Connection &con, Continuation *c, void *arg)
   return EVENT_DONE;
 }
 
-const char *
+ts::StringView
 SSLNetVConnection::map_tls_protocol_to_tag(const char *proto_string) const
 {
-  const char *retval    = nullptr;
-  const char *ssl_proto = getSSLProtocol();
-  if (ssl_proto && strncmp(ssl_proto, "TLSv1", 5) == 0) {
-    if (ssl_proto[5] == '\0') {
-      retval = TS_PROTO_TAG_TLS_1_0;
-    } else if (ssl_proto[5] == '.') {
-      if (ssl_proto[6] == '1' && ssl_proto[7] == '\0') {
-        retval = TS_PROTO_TAG_TLS_1_1;
-      } else if (ssl_proto[6] == '2' && ssl_proto[7] == '\0') {
-        retval = TS_PROTO_TAG_TLS_1_2;
-      } else if (ssl_proto[6] == '3' && ssl_proto[7] == '\0') {
-        retval = TS_PROTO_TAG_TLS_1_3;
+  // Prefix for the string the SSL library hands back.
+  static const ts::StringView PREFIX("TLSv1");
+
+  ts::StringView retval;
+  ts::StringView proto(proto_string);
+
+  if (proto.size() >= PREFIX.size() && strncmp(proto.ptr(), PREFIX.ptr(), PREFIX.size()) == 0) {
+    proto += PREFIX.size();
+    if (proto.size() <= 0) {
+      retval = IP_PROTO_TAG_TLS_1_0;
+    } else if (*proto == '.') {
+      ++proto; // skip .
+      if (proto.size() == 1) {
+        if (*proto == '1')
+          retval = IP_PROTO_TAG_TLS_1_1;
+        else if (*proto == '2')
+          retval = IP_PROTO_TAG_TLS_1_2;
+        else if (*proto == '3')
+          retval = IP_PROTO_TAG_TLS_1_3;
       }
     }
   }
@@ -1567,14 +1574,13 @@ SSLNetVConnection::map_tls_protocol_to_tag(const char *proto_string) const
 }
 
 int
-SSLNetVConnection::populate_protocol(const char **results, int n) const
+SSLNetVConnection::populate_protocol(ts::StringView *results, int n) const
 {
   int retval = 0;
-  if (n > 0) {
-    results[0] = map_tls_protocol_to_tag(getSSLProtocol());
-    if (results[0] != nullptr) {
-      retval++;
-    }
+  if (n > retval) {
+    results[retval] = map_tls_protocol_to_tag(getSSLProtocol());
+    if (results[retval])
+      ++retval;
     if (n > retval) {
       retval += super::populate_protocol(results + retval, n - retval);
     }
@@ -1583,15 +1589,14 @@ SSLNetVConnection::populate_protocol(const char **results, int n) const
 }
 
 const char *
-SSLNetVConnection::protocol_contains(const char *tag) const
+SSLNetVConnection::protocol_contains(ts::StringView prefix) const
 {
-  const char *retval   = nullptr;
-  const char *tls_tag  = map_tls_protocol_to_tag(getSSLProtocol());
-  unsigned int tag_len = strlen(tag);
-  if (tag_len <= strlen(tls_tag) && strncmp(tag, tls_tag, tag_len) == 0) {
-    retval = tls_tag;
+  const char *retval = nullptr;
+  ts::StringView tag = map_tls_protocol_to_tag(getSSLProtocol());
+  if (prefix.size() <= tag.size() && strncmp(tag.ptr(), prefix.ptr(), prefix.size()) == 0) {
+    retval = tag.ptr();
   } else {
-    retval = super::protocol_contains(tag);
+    retval = super::protocol_contains(prefix);
   }
   return retval;
 }

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -277,6 +277,7 @@ NetAccept::do_blocking_accept(EThread *t)
     vc->set_is_transparent(opt.f_inbound_transparent);
     vc->options.packet_mark = opt.packet_mark;
     vc->options.packet_tos  = opt.packet_tos;
+    vc->options.ip_family   = opt.ip_family;
     vc->apply_options();
     vc->set_context(NET_VCONNECTION_IN);
     vc->accept_object = this;
@@ -421,6 +422,7 @@ NetAccept::acceptFastEvent(int event, void *ep)
     vc->set_is_transparent(opt.f_inbound_transparent);
     vc->options.packet_mark = opt.packet_mark;
     vc->options.packet_tos  = opt.packet_tos;
+    vc->options.ip_family   = opt.ip_family;
     vc->apply_options();
     vc->set_context(NET_VCONNECTION_IN);
     SET_CONTINUATION_HANDLER(vc, (NetVConnHandler)&UnixNetVConnection::mainEvent);

--- a/lib/records/RecHttp.cc
+++ b/lib/records/RecHttp.cc
@@ -26,7 +26,9 @@
 #include <ts/ink_defs.h>
 #include <ts/ink_hash_table.h>
 #include <ts/Tokenizer.h>
+#include <ts/MemView.h>
 #include <strings.h>
+#include <ts/ink_inet.h>
 
 SessionProtocolNameRegistry globalSessionProtocolNameRegistry;
 
@@ -34,10 +36,10 @@ SessionProtocolNameRegistry globalSessionProtocolNameRegistry;
    These are also used for NPN setup.
 */
 
-const char *const TS_ALPN_PROTOCOL_HTTP_0_9 = "http/0.9";
-const char *const TS_ALPN_PROTOCOL_HTTP_1_0 = "http/1.0";
-const char *const TS_ALPN_PROTOCOL_HTTP_1_1 = "http/1.1";
-const char *const TS_ALPN_PROTOCOL_HTTP_2_0 = "h2"; // HTTP/2 over TLS
+const char *const TS_ALPN_PROTOCOL_HTTP_0_9 = IP_PROTO_TAG_HTTP_0_9.ptr();
+const char *const TS_ALPN_PROTOCOL_HTTP_1_0 = IP_PROTO_TAG_HTTP_1_0.ptr();
+const char *const TS_ALPN_PROTOCOL_HTTP_1_1 = IP_PROTO_TAG_HTTP_1_1.ptr();
+const char *const TS_ALPN_PROTOCOL_HTTP_2_0 = IP_PROTO_TAG_HTTP_2_0.ptr();
 
 const char *const TS_ALPN_PROTOCOL_GROUP_HTTP  = "http";
 const char *const TS_ALPN_PROTOCOL_GROUP_HTTP2 = "http2";
@@ -45,14 +47,14 @@ const char *const TS_ALPN_PROTOCOL_GROUP_HTTP2 = "http2";
 const char *const TS_PROTO_TAG_HTTP_1_0 = TS_ALPN_PROTOCOL_HTTP_1_0;
 const char *const TS_PROTO_TAG_HTTP_1_1 = TS_ALPN_PROTOCOL_HTTP_1_1;
 const char *const TS_PROTO_TAG_HTTP_2_0 = TS_ALPN_PROTOCOL_HTTP_2_0;
-const char *const TS_PROTO_TAG_TLS_1_3  = "tls/1.3";
-const char *const TS_PROTO_TAG_TLS_1_2  = "tls/1.2";
-const char *const TS_PROTO_TAG_TLS_1_1  = "tls/1.1";
-const char *const TS_PROTO_TAG_TLS_1_0  = "tls/1.0";
-const char *const TS_PROTO_TAG_TCP      = "tcp";
-const char *const TS_PROTO_TAG_UDP      = "udp";
-const char *const TS_PROTO_TAG_IPV4     = "ipv4";
-const char *const TS_PROTO_TAG_IPV6     = "ipv6";
+const char *const TS_PROTO_TAG_TLS_1_3  = IP_PROTO_TAG_TLS_1_3.ptr();
+const char *const TS_PROTO_TAG_TLS_1_2  = IP_PROTO_TAG_TLS_1_2.ptr();
+const char *const TS_PROTO_TAG_TLS_1_1  = IP_PROTO_TAG_TLS_1_1.ptr();
+const char *const TS_PROTO_TAG_TLS_1_0  = IP_PROTO_TAG_TLS_1_0.ptr();
+const char *const TS_PROTO_TAG_TCP      = IP_PROTO_TAG_TCP.ptr();
+const char *const TS_PROTO_TAG_UDP      = IP_PROTO_TAG_UDP.ptr();
+const char *const TS_PROTO_TAG_IPV4     = IP_PROTO_TAG_IPV4.ptr();
+const char *const TS_PROTO_TAG_IPV6     = IP_PROTO_TAG_IPV6.ptr();
 
 InkHashTable *TSProtoTags;
 
@@ -386,7 +388,7 @@ HttpProxyPort::processOptions(const char *opts)
     if (in_ip_set_p && m_family != m_inbound_ip.family()) {
       Warning(
         "Invalid port descriptor '%s' - the inbound adddress family [%s] is not the same type as the explicit family value [%s]",
-        opts, ats_ip_family_name(m_inbound_ip.family()), ats_ip_family_name(m_family));
+        opts, ats_ip_family_name(m_inbound_ip.family()).ptr(), ats_ip_family_name(m_family).ptr());
       zret = false;
     }
   } else if (in_ip_set_p) {

--- a/lib/ts/Makefile.am
+++ b/lib/ts/Makefile.am
@@ -23,7 +23,7 @@ library_includedir=$(includedir)/ts
 library_include_HEADERS = apidefs.h
 
 noinst_PROGRAMS = mkdfa CompileParseRules
-check_PROGRAMS = test_tsutil test_arena test_atomic test_freelist test_geometry test_List test_Map test_Vec test_X509HostnameValidator
+check_PROGRAMS = test_tsutil test_arena test_atomic test_freelist test_geometry test_List test_Map test_Vec test_X509HostnameValidator test_MemView
 
 TESTS_ENVIRONMENT = LSAN_OPTIONS=suppressions=suppression.txt
 
@@ -85,6 +85,7 @@ libtsutil_la_SOURCES = \
   IpMapConf.h \
   Layout.cc \
   List.h \
+  MemView.h MemView.cc \
   MMH.cc \
   MMH.h \
   Map.h \
@@ -235,6 +236,9 @@ test_X509HostnameValidator_SOURCES = test_X509HostnameValidator.cc
 test_X509HostnameValidator_LDADD = libtsutil.la @LIBTCL@ @LIBPCRE@ @OPENSSL_LIBS@
 test_X509HostnameValidator_LDFLAGS = @EXTRA_CXX_LDFLAGS@ @LIBTOOL_LINK_FLAGS@
 
+test_MemView_SOURCES = test_MemView.cc
+test_MemView_LDADD = libtsutil.la
+
 test_tsutil_LDADD = libtsutil.la @LIBTCL@ @LIBPCRE@
 test_tsutil_LDFLAGS = @EXTRA_CXX_LDFLAGS@ @LIBTOOL_LINK_FLAGS@
 test_tsutil_SOURCES = \
@@ -250,4 +254,3 @@ clean-local:
 
 tidy-local: $(DIST_SOURCES)
 	$(CXX_Clang_Tidy)
-

--- a/lib/ts/MemView.cc
+++ b/lib/ts/MemView.cc
@@ -1,0 +1,158 @@
+/** @file
+
+    Class for handling "views" of a buffer. Views presume the memory for the buffer is managed
+    elsewhere and allow efficient access to segments of the buffer without copies. Views are read
+    only as the view doesn't own the memory. Along with generic buffer methods are specialized
+    methods to support better string parsing, particularly token based parsing.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+#include <ts/MemView.h>
+#include <sstream>
+#include <cctype>
+#include <ts/ink_platform.h>
+
+namespace ts
+{
+StringView::StringView(const char *s) : _ptr(s), _size(strlen(s))
+{
+}
+
+int
+memcmp(MemView const &lhs, MemView const &rhs)
+{
+  int zret;
+  size_t n;
+
+  // Seems a bit ugly but size comparisons must be done anyway to get the memcmp args.
+  if (lhs.size() < rhs.size()) {
+    zret = 1, n = lhs.size();
+  } else {
+    n    = rhs.size();
+    zret = rhs.size() < lhs.size() ? -1 : 0;
+  }
+
+  int r = ::memcmp(lhs.ptr(), rhs.ptr(), n);
+  if (0 != r) { // If we got a not-equal, override the size based result.
+    zret = r;
+  }
+
+  return zret;
+}
+
+int
+strcasecmp(StringView lhs, StringView rhs)
+{
+  while (lhs && rhs) {
+    char l = tolower(*lhs);
+    char r = tolower(*rhs);
+    if (l < r) {
+      return -1;
+    } else if (r < l) {
+      return 1;
+    }
+    ++lhs, ++rhs;
+  }
+  return lhs ? 1 : rhs ? -1 : 0;
+}
+
+intmax_t
+svtoi(StringView src, StringView *out, int base)
+{
+  static const int8_t convert[256] = {
+    /* [can't do this nicely because clang format won't allow exdented comments]
+     0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+    */
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 00
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 10
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 20
+    0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  -1, -1, -1, -1, -1, -1, // 30
+    -1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, // 40
+    25, 26, 27, 28, 20, 30, 31, 32, 33, 34, 35, -1, -1, -1, -1, -1, // 50
+    -1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, // 60
+    25, 26, 27, 28, 20, 30, 31, 32, 33, 34, 35, -1, -1, -1, -1, -1, // 70
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 80
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 90
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // A0
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // B0
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // C0
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // D0
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // E0
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // F0
+  };
+
+  intmax_t zret = 0;
+
+  if (out) {
+    out->clear();
+  }
+  if (!(1 < base && base <= 36)) {
+    return 0;
+  }
+  if (src.ltrim(&isspace)) {
+    const char *start = src.ptr();
+    int8_t v;
+    bool neg = false;
+    if ('-' == *src) {
+      ++src;
+      neg = true;
+    }
+    while (src.size() && (-1 != (v = convert[static_cast<unsigned char>(*src)]))) {
+      zret = zret * base + v;
+      ++src;
+    }
+    if (out && (src.ptr() > (neg ? start + 1 : start))) {
+      out->setView(start, src.ptr());
+    }
+
+    if (neg) {
+      zret = -zret;
+    }
+  }
+  return zret;
+}
+
+// Do the template instantions.
+template void detail::stream_fill(std::ostream &, std::size_t);
+template std::ostream &StringView::stream_write(std::ostream &, const StringView &) const;
+}
+
+namespace std
+{
+ostream &
+operator<<(ostream &os, const ts::MemView &b)
+{
+  if (os.good()) {
+    ostringstream out;
+    out << b.size() << '@' << hex << b.ptr();
+    os << out.str();
+  }
+  return os;
+}
+
+ostream &
+operator<<(ostream &os, const ts::StringView &b)
+{
+  if (os.good()) {
+    b.stream_write<ostream>(os, b);
+    os.width(0);
+  }
+  return os;
+}
+}

--- a/lib/ts/MemView.h
+++ b/lib/ts/MemView.h
@@ -1,0 +1,1392 @@
+#if !defined TS_MEM_VIEW
+#define TS_MEM_VIEW
+
+/** @file
+
+   Class for handling "views" of a buffer. Views presume the memory for the buffer is managed
+   elsewhere and allow efficient access to segments of the buffer without copies. Views are read
+   only as the view doesn't own the memory. Along with generic buffer methods are specialized
+   methods to support better string parsing, particularly token based parsing.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#include <bitset>
+#include <functional>
+#include <iosfwd>
+#include <memory.h>
+#include <algorithm>
+#include <string>
+
+/// Apache Traffic Server commons.
+namespace ts
+{
+class MemView;
+class StringView;
+
+/// Compare the memory in two views.
+/// Return based on the first different byte. If one argument is a prefix of the other, the prefix
+/// is considered the "smaller" value.
+/// @return
+/// - -1 if @a lhs byte is less than @a rhs byte.
+/// -  1 if @a lhs byte is greater than @a rhs byte.
+/// -  0 if the views contain identical memory.
+int memcmp(MemView const &lhs, MemView const &rhs);
+using ::memcmp; // Make this an overload, not an override.
+/// Compare the strings in two views.
+/// Return based on the first different character. If one argument is a prefix of the other, the prefix
+/// is considered the "smaller" value.
+/// @return
+/// - -1 if @a lhs char is less than @a rhs char.
+/// -  1 if @a lhs char is greater than @a rhs char.
+/// -  0 if the views contain identical strings.
+int strcmp(StringView const &lhs, StringView const &rhs);
+using ::strcmp; // Make this an overload, not an override.
+/// Compare the strings in two views.
+/// Return based on the first different character. If one argument is a prefix of the other, the prefix
+/// is considered the "smaller" value. The values are compared ignoring case.
+/// @return
+/// - -1 if @a lhs char is less than @a rhs char.
+/// -  1 if @a lhs char is greater than @a rhs char.
+/// -  0 if the views contain identical strings.
+///
+/// @internal Why not <const&>? Because the implementation would make copies anyway, might as well save
+/// the cost of passing the pointers.
+int strcasecmp(StringView lhs, StringView rhs);
+using ::strcasecmp; // Make this an overload, not an override.
+
+/** Convert the text in @c StringView @a src to a numeric value.
+
+    If @a parsed is non-null then the part of the string actually parsed is placed there.
+    @a base sets the conversion base. This defaults to 10 with two special cases:
+
+    - If the number starts with a literal '0' then it is treated as base 8.
+    - If the number starts with the literal characters '0x' or '0X' then it is treated as base 16.
+*/
+intmax_t svtoi(StringView src, StringView *parsed = nullptr, int base = 10);
+
+/** A read only view of contiguous piece of memory.
+
+    A @c MemView does not own the memory to which it refers, it is simply a view of part of some
+    (presumably) larger memory object. The purpose is to allow working in a read only way a specific
+    part of the memory. This can avoid copying or allocation by allocating all needed memory at once
+    and then working with it via instances of this class.
+
+    MemView is based on an earlier class ConstBuffer and influenced by Boost.string_ref. Neither
+    of these were adequate for how use of @c ConstBuffer evolved and so @c MemView is @c
+    ConstBuffer with some additional stylistic changes based on Boost.string_ref.
+
+    This class is closely integrated with @c StringView. These classes have the same underlying
+    implementation and are differentiated only because of the return types and a few string oriented
+    methods.
+ */
+class MemView
+{
+  typedef MemView self; ///< Self reference type.
+
+protected:
+  const void *_ptr = nullptr; ///< Pointer to base of memory chunk.
+  size_t _size     = 0;       ///< Size of memory chunk.
+
+public:
+  /// Default constructor (empty buffer).
+  constexpr MemView();
+
+  /** Construct explicitly with a pointer and size.
+   */
+  constexpr MemView(const void *ptr, ///< Pointer to buffer.
+                    size_t n         ///< Size of buffer.
+                    );
+
+  /** Construct from a half open range of two pointers.
+      @note The instance at @start is in the view but the instance at @a end is not.
+  */
+  template <typename T>
+  constexpr MemView(T const *start, ///< First byte in the view.
+                    T const *end    ///< First byte not in the view.
+                    );
+
+  /** Construct from a half open range of two pointers.
+      @note The instance at @start is in the view but the instance at @a end is not.
+  */
+  MemView(void const *start, ///< First byte in the view.
+          void const *end    ///< First byte not in the view.
+          );
+
+  /** Construct from nullptr.
+      This implicitly makes the length 0.
+  */
+  constexpr MemView(std::nullptr_t);
+
+  /// Convert from StringView.
+  constexpr MemView(StringView const &that);
+
+  /** Equality.
+
+      This is effectively a pointer comparison, buffer contents are not compared.
+
+      @return @c true if @a that refers to the same view as @a this,
+      @c false otherwise.
+   */
+  bool operator==(self const &that) const;
+
+  /** Inequality.
+      @return @c true if @a that does not refer to the same view as @a this,
+      @c false otherwise.
+   */
+  bool operator!=(self const &that) const;
+
+  /// Assignment - the view is copied, not the content.
+  self &operator=(self const &that);
+
+  /** Shift the view to discard the first byte.
+      @return @a this.
+  */
+  self &operator++();
+
+  /** Shift the view to discard the leading @a n bytes.
+      @return @a this
+  */
+  self &operator+=(size_t n);
+
+  /// Check for empty view.
+  /// @return @c true if the view has a zero pointer @b or size.
+  bool operator!() const;
+
+  /// Check for non-empty view.
+  /// @return @c true if the view refers to a non-empty range of bytes.
+  explicit operator bool() const;
+
+  /// Check for empty view (no content).
+  /// @see operator bool
+  bool isEmpty() const;
+
+  /// @name Accessors.
+  //@{
+  /// Pointer to the first byte in the view.
+  const void *begin() const;
+  /// Pointer to first byte not in the view.
+  const void *end() const;
+  /// Number of bytes in the view.
+  constexpr size_t size() const;
+  /// Memory pointer.
+  /// @note This is equivalent to @c begin currently but it's probably good to have separation.
+  constexpr const void *ptr() const;
+  /// @return the @a V value at index @a n.
+  template <typename V> V at(ssize_t n) const;
+  /// @return a pointer to the @a V value at index @a n.
+  template <typename V> V const *at_ptr(ssize_t n) const;
+  //@}
+
+  /// Set the view.
+  /// This is faster but equivalent to constructing a new view with the same
+  /// arguments and assigning it.
+  /// @return @c this.
+  self &setView(const void *ptr, ///< Buffer address.
+                size_t n = 0     ///< Buffer size.
+                );
+
+  /// Set the view.
+  /// This is faster but equivalent to constructing a new view with the same
+  /// arguments and assigning it.
+  /// @return @c this.
+  self &setView(const void *start, ///< First valid character.
+                const void *end    ///< First invalid character.
+                );
+
+  /// Clear the view (become an empty view).
+  self &clear();
+
+  /// @return @c true if the byte at @a *p is in the view.
+  bool contains(const void *p) const;
+
+  /** Find a value.
+      The memory is searched as if it were an array of the value type @a T.
+
+      @return A pointer to the first occurrence of @a v in @a this
+      or @c nullptr if @a v is not found.
+  */
+  template <typename V> const V *find(V v) const;
+
+  /** Find a value.
+      The memory is searched as if it were an array of the value type @a V.
+
+      @return A pointer to the first value for which @a pred is @c true otherwise
+      @c nullptr.
+  */
+  template <typename V> const V *find(std::function<bool(V)> const &pred);
+
+  /** Get the initial segment of the view before @a p.
+
+      The byte at @a p is not included. If @a p is not in the view an empty view
+      is returned.
+
+      @return A buffer that contains all data before @a p.
+  */
+  self prefix(const void *p) const;
+
+  /** Split the view at @a p.
+
+      The view is split in to two parts at @a p and the prefix is returned. The view is updated to
+     contain the bytes not returned in the prefix. The prefix will not contain @a p.
+
+      @note If @a *p refers to a byte that is not in @a this then @a this is not changed and an empty
+      buffer is returned. Therefore this method can be safely called with the return value of
+      calling @c find.
+
+      @return A buffer containing data up to but not including @a p.
+
+      @see extractPrefix
+  */
+  self splitPrefix(const void *p);
+
+  /** Extract a prefix delimited by @a p.
+
+      A prefix of @a this is removed from the view and returned. If @a p is not in the view then the
+      entire view is extracted and returned.
+
+      If @a p points at a byte in the view this is identical to @c splitPrefix.  If not then the
+      entire view in @a this will be returned and @a this will become an empty view.
+
+      @return The prefix bounded at @a p or the entire view if @a p is not a byte in the view.
+
+      @see splitPrefix
+  */
+  self extractPrefix(const void *p);
+
+  /** Get the trailing segment of the view after @a p.
+
+      The byte at @a p is not included. If @a p is not in the view an empty view is returned.
+
+      @return A buffer that contains all data after @a p.
+  */
+  self suffix(const void *p) const;
+
+  /** Split the view at @a p.
+
+      The view is split in to two parts and the suffix is returned. The view is updated to contain
+      the bytes not returned in the suffix. The suffix will not contain @a p.
+
+      @note If @a p does not refer to a byte in the view, an empty view is returned and @a this is
+      unchanged.
+
+      @return @a this.
+  */
+  self splitSuffix(const void *p);
+};
+
+/** A read only view of contiguous piece of memory.
+
+    A @c StringView does not own the memory to which it refers, it is simply a view of part of some
+    (presumably) larger memory object. The purpose is to allow working in a read only way a specific
+    part of the memory. A classic example for ATS is working with HTTP header fields and values
+    which need to be accessed independently but preferably without copying. A @c StringView supports this style.
+
+    MemView is based on an earlier class ConstBuffer and influenced by Boost.string_ref. Neither
+    of these were adequate for how use of @c ConstBuffer evolved and so @c MemView is @c
+    ConstBuffer with some additional stylistic changes based on Boost.string_ref.
+
+    In particular @c MemView is designed both to support passing via API (to replace the need to
+    pass two parameters for one real argument) and to aid in parsing input without copying.
+
+ */
+class StringView
+{
+  typedef StringView self; ///< Self reference type.
+
+protected:
+  const char *_ptr = nullptr; ///< Pointer to base of memory chunk.
+  size_t _size     = 0;       ///< Size of memory chunk.
+
+  struct literal_t {
+  };
+  struct array_t {
+  };
+
+public:
+  /// Default constructor (empty buffer).
+  constexpr StringView();
+
+  /** Construct explicitly with a pointer and size.
+   */
+  constexpr StringView(const char *ptr, ///< Pointer to buffer.
+                       size_t n         ///< Size of buffer.
+                       );
+
+  /** Construct explicitly with a pointer and size.
+      If @a n is negative it is treated as 0.
+      @internal Overload for convience, otherwise get "narrow conversion" errors.
+   */
+  constexpr StringView(const char *ptr, ///< Pointer to buffer.
+                       int n            ///< Size of buffer.
+                       );
+
+  /** Construct from a half open range of two pointers.
+      @note The byte at @start is in the view but the byte at @a end is not.
+  */
+  constexpr StringView(const char *start, ///< First byte in the view.
+                       const char *end    ///< First byte not in the view.
+                       );
+
+  /** Constructor from literal string.
+
+      Construct directly from a literal string. This avoids a call to :c strlen and therefore is
+      faster and can be @c constexpr. The terminal nul character is excluded. Internal nul
+      characters are included.
+
+      @code
+        StringView a("literal", StringView::literal);
+      @endcode
+   */
+  template <size_t N> constexpr StringView(const char (&s)[N], literal_t);
+
+  /** Constructor from character array.
+
+      Construct directly from an array of characters. All elements of the array are
+      included in the view.
+
+      @code
+        char buff[SIZE];
+        StringView a(buff, StringView::array);
+      @endcode
+
+      @note If this is used on a literal string, the terminal nul character is included.
+   */
+  template <size_t N> constexpr StringView(const char (&s)[N], array_t);
+
+  /** Construct from nullptr.
+      This implicitly makes the length 0.
+  */
+  constexpr StringView(std::nullptr_t);
+
+  /// Construct from @c MemView to reference the same view.
+  /// @internal Can't be @c constexpr because @c static_cast of @c <void*> is not permitted.
+  StringView(MemView const &that);
+
+  /** Construct from null terminated string.
+      @note The terminating null is not included. @c strlen is used to determine the length.
+  */
+  explicit StringView(const char *s);
+
+  /// Construct from @c std::string, referencing the entire string contents.
+  /// @internal Not all compilers make @c std::string methods called @c constexpr
+  StringView(std::string const &str);
+
+  /** Equality.
+
+      This is effectively a pointer comparison, buffer contents are not compared.
+
+      @return @c true if @a that refers to the same view as @a this,
+      @c false otherwise.
+   */
+  bool operator==(self const &that) const;
+
+  /** Inequality.
+      @return @c true if @a that does not refer to the same view as @a this,
+      @c false otherwise.
+   */
+  bool operator!=(self const &that) const;
+
+  /** Prefix check.
+      @return @c true if @a this is a prefix of @a that.
+  */
+  bool isPrefixOf(self const &that) const;
+
+  /** Case ignoring prefix check.
+      @return @c true if @a this is a prefix of @a that, ignoring case.
+  */
+  bool isNoCasePrefixOf(self const &that) const;
+
+  /// Assignment - the view is copied, not the content.
+  self &operator=(self const &that);
+
+  /// @return The first byte in the view.
+  char operator*() const;
+
+  /// @return the byte at offset @a n.
+  char operator[](size_t n) const;
+
+  /// @return the byte at offset @a n.
+  char operator[](int n) const;
+
+  /** Shift the view to discard the first byte.
+      @return @a this.
+  */
+  self &operator++();
+
+  /** Shift the view to discard the leading @a n bytes.
+      @return @a this
+  */
+  self &operator+=(size_t n);
+
+  /// Check for empty view.
+  /// @return @c true if the view has a zero pointer @b or size.
+  bool operator!() const;
+
+  /// Check for non-empty view.
+  /// @return @c true if the view refers to a non-empty range of bytes.
+  explicit operator bool() const;
+
+  /// Check for empty view (no content).
+  /// @see operator bool
+  bool isEmpty() const;
+
+  /// @name Accessors.
+  //@{
+  /// Pointer to the first byte in the view.
+  const char *begin() const;
+  /// Pointer to first byte not in the view.
+  const char *end() const;
+  /// Number of bytes in the view.
+  constexpr size_t size() const;
+  /// Memory pointer.
+  /// @note This is equivalent to @c begin currently but it's probably good to have separation.
+  constexpr const char *ptr() const;
+  //@}
+
+  /// Set the view.
+  /// This is faster but equivalent to constructing a new view with the same
+  /// arguments and assigning it.
+  /// @return @c this.
+  self &setView(const char *ptr, ///< Buffer address.
+                size_t n = 0     ///< Buffer size.
+                );
+
+  /// Set the view.
+  /// This is faster but equivalent to constructing a new view with the same
+  /// arguments and assigning it.
+  /// @return @c this.
+  self &setView(const char *start, ///< First valid character.
+                const char *end    ///< First invalid character.
+                );
+
+  /// Clear the view (become an empty view).
+  self &clear();
+
+  /// @return @c true if the byte at @a *p is in the view.
+  bool contains(const char *p) const;
+
+  /** Find a byte.
+      @return A pointer to the first occurrence of @a c in @a this
+      or @c nullptr if @a c is not found.
+  */
+  const char *find(char c) const;
+
+  /** Find a byte.
+      @return A pointer to the first occurence of any of @a delimiters in @a
+      this or @c nullptr if not found.
+  */
+  const char *find(self delimiters) const;
+
+  /** Find a byte.
+      @return A pointer to the first byte for which @a pred is @c true otherwise
+      @c nullptr.
+  */
+  const char *find(std::function<bool(char)> const &pred) const;
+
+  /** Remove bytes that match @a c from the start of the view.
+  */
+  self &ltrim(char c);
+  /** Remove bytes from the start of the view that are in @a delimiters.
+  */
+  self &ltrim(self delimiters);
+  /** Remove bytes from the start of the view for which @a pred is @c true.
+  */
+  self &ltrim(std::function<bool(char)> const &pred);
+
+  /** Remove bytes that match @a c from the end of the view.
+  */
+  self &rtrim(char c);
+  /** Remove bytes from the end of the view that are in @a delimiters.
+  */
+  self &rtrim(self delimiters);
+  /** Remove bytes from the start and end of the view for which @a pred is @c true.
+  */
+  self &rtrim(std::function<bool(char)> const &pred);
+
+  /** Remove bytes that match @a c from the end of the view.
+  */
+  self &trim(char c);
+  /** Remove bytes from the start and end of the view that are in @a delimiters.
+  */
+  self &trim(self delimiters);
+  /** Remove bytes from the start and end of the view for which @a pred is @c true.
+  */
+  self &trim(std::function<bool(char)> const &pred);
+
+  /** Get the initial segment of the view before @a p.
+
+      The byte at @a p is not included. If @a p is not in the view an empty view
+      is returned.
+
+      @return A buffer that contains all data before @a p.
+  */
+  self prefix(const char *p) const;
+
+  /// Convenience overload for character.
+  self prefix(char c);
+  /// Convenience overload, split on delimiter set.
+  self prefix(self delimiters) const;
+  /// Convenience overload, split on predicate.
+  self prefix(std::function<bool(char)> const &pred) const;
+
+  /** Split the view on the character at @a p.
+
+      The view is split in to two parts and the byte at @a p is discarded. @a this retains all data
+      @b after @a p (equivalent to <tt>MemView(p+1, this->end()</tt>). A new view containing the
+      initial bytes up to but not including @a p is returned, (equivalent to
+      <tt>MemView(this->begin(), p)</tt>).
+
+      This is convenient when tokenizing and @a p points at a delimiter.
+
+      @note If @a *p refers toa byte that is not in @a this then @a this is not changed and an empty
+      buffer is returned. Therefore this method can be safely called with the return value of
+      calling @c find.
+
+      @code
+        void f(MemView& text) {
+          MemView token = text.splitPrefix(text.find(delimiter));
+          if (token) { // ... process token }
+      @endcode
+
+      @return A buffer containing data up to but not including @a p.
+
+      @see extractPrefix
+  */
+  self splitPrefix(const char *p);
+
+  /// Convenience overload, split on character.
+  self splitPrefix(char c);
+  /// Convenience overload, split on delimiter set.
+  self splitPrefix(self delimiters);
+  /// Convenience overload, split on predicate.
+  self splitPrefix(std::function<bool(char)> const &pred);
+
+  /** Extract a prefix delimited by @a p.
+
+      A prefix of @a this is removed from the view and returned. If @a p is not in the view then the
+      entire view is extracted and returned.
+
+      If @a p points at a byte in the view this is identical to @c splitPrefix.  If not then the
+      entire view in @a this will be returned and @a this will become an empty view. This is easier
+      to use when repeated extracting tokens. The source view will become empty after extracting the
+      last token.
+
+      @code
+      MemView text;
+      while (text) {
+        MemView token = text.extractPrefix(text.find(delimiter));
+        // .. process token which will always be non-empty because text was not empty.
+      }
+      @endcode
+
+      @return The prefix bounded at @a p or the entire view if @a p is not a byte in the view.
+
+      @see splitPrefix
+  */
+  self extractPrefix(const char *p);
+
+  /// Convenience overload, extract on delimiter set.
+  self extractPrefix(char c);
+  /// Convenience overload, extract on delimiter set.
+  self extractPrefix(self delimiters);
+  /// Convenience overload, extract on predicate.
+  self extractPrefix(std::function<bool(char)> const &pred);
+
+  /** Get the trailing segment of the view after @a p.
+
+      The byte at @a p is not included. If @a p is not in the view an empty view is returned.
+
+      @return A buffer that contains all data after @a p.
+  */
+  self suffix(const char *p) const;
+
+  /// Convenience overload for character.
+  self suffix(char c);
+  /// Convenience overload for delimiter set.
+  self suffix(self delimiters);
+  /// Convenience overload for predicate.
+  self suffix(std::function<bool(char)> const &pred);
+
+  /** Split the view on the character at @a p.
+
+      The view is split in to two parts and the byte at @a p is discarded. @a this retains all data
+      @b before @a p (equivalent to <tt>MemView(this->begin(), p)</tt>). A new view containing
+      the trailing bytes after @a p is returned, (equivalent to <tt>MemView(p+1,
+      this->end())</tt>).
+
+      @note If @a p does not refer to a byte in the view, an empty view is returned and @a this is
+      unchanged.
+
+      @return @a this.
+  */
+  self splitSuffix(const char *p);
+
+  /// Convenience overload for character.
+  self splitSuffix(char c);
+  /// Convenience overload for delimiter set.
+  self splitSuffix(self delimiters);
+  /// Convenience overload for predicate.
+  self splitSuffix(std::function<bool(char)> const &pred);
+
+  // Functors for using this class in STL containers.
+  /// Ordering functor, lexicographic comparison.
+  struct LessThan {
+    bool
+    operator()(MemView const &lhs, MemView const &rhs)
+    {
+      return -1 == strcmp(lhs, rhs);
+    }
+  };
+  /// Ordering functor, case ignoring lexicographic comparison.
+  struct LessThanNoCase {
+    bool
+    operator()(MemView const &lhs, MemView const &rhs)
+    {
+      return -1 == strcasecmp(lhs, rhs);
+    }
+  };
+
+  /// Specialized stream operator implementation.
+  /// @note Use the standard stream operator unless there is a specific need for this, which is unlikely.
+  /// @return The stream @a os.
+  /// @internal Needed because @c std::ostream::write must be used and
+  /// so alignment / fill have to be explicitly handled.
+  template <typename Stream> Stream &stream_write(Stream &os, const StringView &b) const;
+
+  static constexpr literal_t literal{};
+  static constexpr array_t array{};
+
+protected:
+  /// Initialize a bit mask to mark which characters are in this view.
+  void initDelimiterSet(std::bitset<256> &set);
+};
+// ----------------------------------------------------------
+// Inline implementations.
+
+inline constexpr MemView::MemView()
+{
+}
+inline constexpr MemView::MemView(void const *ptr, size_t n) : _ptr(ptr), _size(n)
+{
+}
+template <typename T> constexpr MemView::MemView(const T *start, const T *end) : _ptr(start), _size((end - start) * sizeof(T))
+{
+}
+// <void*> is magic, handle that specially.
+// No constexpr because the spec specifically forbids casting from <void*> to a typed pointer.
+inline MemView::MemView(void const *start, void const *end)
+  : _ptr(start), _size(static_cast<const char *>(end) - static_cast<char const *>(start))
+{
+}
+inline constexpr MemView::MemView(std::nullptr_t) : _ptr(nullptr), _size(0)
+{
+}
+inline constexpr MemView::MemView(StringView const &that) : _ptr(that.ptr()), _size(that.size())
+{
+}
+
+inline MemView &
+MemView::setView(const void *ptr, size_t n)
+{
+  _ptr  = ptr;
+  _size = n;
+  return *this;
+}
+
+inline MemView &
+MemView::setView(const void *ptr, const void *limit)
+{
+  _ptr  = ptr;
+  _size = static_cast<const char *>(limit) - static_cast<const char *>(ptr);
+  return *this;
+}
+
+inline MemView &
+MemView::clear()
+{
+  _ptr  = 0;
+  _size = 0;
+  return *this;
+}
+
+inline bool
+MemView::operator==(self const &that) const
+{
+  return _size == that._size && _ptr == that._ptr;
+}
+
+inline bool
+MemView::operator!=(self const &that) const
+{
+  return !(*this == that);
+}
+
+inline bool MemView::operator!() const
+{
+  return !(_ptr && _size);
+}
+
+inline MemView::operator bool() const
+{
+  return _ptr && _size;
+}
+
+inline bool
+MemView::isEmpty() const
+{
+  return !(_ptr && _size);
+}
+
+inline MemView &MemView::operator++()
+{
+  _ptr = static_cast<const char *>(_ptr) + 1;
+  --_size;
+  return *this;
+}
+
+inline MemView &
+MemView::operator+=(size_t n)
+{
+  if (n > _size) {
+    _ptr  = nullptr;
+    _size = 0;
+  } else {
+    _ptr = static_cast<const char *>(_ptr) + n;
+    _size -= n;
+  }
+  return *this;
+}
+
+inline const void *
+MemView::begin() const
+{
+  return _ptr;
+}
+inline constexpr const void *
+MemView::ptr() const
+{
+  return _ptr;
+}
+
+inline const void *
+MemView::end() const
+{
+  return static_cast<const char *>(_ptr) + _size;
+}
+
+inline constexpr size_t
+MemView::size() const
+{
+  return _size;
+}
+
+inline MemView &
+MemView::operator=(MemView const &that)
+{
+  _ptr  = that._ptr;
+  _size = that._size;
+  return *this;
+}
+
+inline bool
+MemView::contains(const void *p) const
+{
+  return _ptr <= this->begin() && p < this->end();
+}
+
+inline MemView
+MemView::prefix(const void *p) const
+{
+  self zret;
+  if (this->contains(p))
+    zret.setView(_ptr, p);
+  return zret;
+}
+
+inline MemView
+MemView::splitPrefix(const void *p)
+{
+  self zret; // default to empty return.
+  if (this->contains(p)) {
+    zret.setView(_ptr, p);
+    this->setView(p, this->end());
+  }
+  return zret;
+}
+
+inline MemView
+MemView::extractPrefix(const void *p)
+{
+  self zret{this->splitPrefix(p)};
+
+  // For extraction if zret is empty, use up all of @a this
+  if (!zret) {
+    zret = *this;
+    this->clear();
+  }
+
+  return zret;
+}
+
+inline MemView
+MemView::suffix(const void *p) const
+{
+  self zret;
+  if (this->contains(p))
+    zret.setView(p, this->end());
+  return zret;
+}
+
+inline MemView
+MemView::splitSuffix(const void *p)
+{
+  self zret;
+  if (this->contains(p)) {
+    zret.setView(p, this->end());
+    this->setView(_ptr, p);
+  }
+  return zret;
+}
+
+template <typename V>
+inline V
+MemView::at(ssize_t n) const
+{
+  return static_cast<V const *>(_ptr)[n];
+}
+
+template <typename V>
+inline V const *
+MemView::at_ptr(ssize_t n) const
+{
+  return static_cast<V const *>(_ptr) + n;
+}
+
+template <typename V>
+inline const V *
+MemView::find(V v) const
+{
+  for (const V *spot = static_cast<const V *>(_ptr), limit = spot + (_size / sizeof(V)); spot < limit; ++spot)
+    if (v == *spot)
+      return spot;
+  return nullptr;
+}
+
+// Specialize char for performance.
+template <>
+inline const char *
+MemView::find(char v) const
+{
+  return static_cast<const char *>(memchr(_ptr, v, _size));
+}
+
+template <typename V>
+inline const V *
+MemView::find(std::function<bool(V)> const &pred)
+{
+  for (const V *p = static_cast<const V *>(_ptr), *limit = p + (_size / sizeof(V)); p < limit; ++p)
+    if (pred(*p))
+      return p;
+  return nullptr;
+}
+
+// === StringView Implementation ===
+inline constexpr StringView::StringView()
+{
+}
+inline constexpr StringView::StringView(const char *ptr, size_t n) : _ptr(ptr), _size(n)
+{
+}
+inline constexpr StringView::StringView(const char *ptr, int n) : _ptr(ptr), _size(n < 0 ? 0 : n)
+{
+}
+inline constexpr StringView::StringView(const char *start, const char *end) : _ptr(start), _size(end - start)
+{
+}
+inline constexpr StringView::StringView(std::nullptr_t) : _ptr(nullptr), _size(0)
+{
+}
+inline StringView::StringView(MemView const &that) : _ptr(static_cast<const char *>(that.ptr())), _size(that.size())
+{
+}
+inline StringView::StringView(std::string const &str) : _ptr(str.data()), _size(str.size())
+{
+}
+template <size_t N> constexpr StringView::StringView(const char (&s)[N], literal_t) : _ptr(s), _size(N - 1)
+{
+}
+
+template <size_t N> constexpr StringView::StringView(const char (&s)[N], array_t) : _ptr(s), _size(N)
+{
+}
+
+inline void StringView::initDelimiterSet(std::bitset<256> &set)
+{
+  set.reset();
+  for (char c : *this)
+    set[static_cast<uint8_t>(c)] = true;
+}
+
+inline StringView &
+StringView::setView(const char *ptr, size_t n)
+{
+  _ptr  = ptr;
+  _size = n;
+  return *this;
+}
+
+inline StringView &
+StringView::setView(const char *ptr, const char *limit)
+{
+  _ptr  = ptr;
+  _size = limit - ptr;
+  return *this;
+}
+
+inline StringView &
+StringView::clear()
+{
+  _ptr  = 0;
+  _size = 0;
+  return *this;
+}
+
+inline bool
+StringView::operator==(self const &that) const
+{
+  return _size == that._size && _ptr == that._ptr;
+}
+
+inline bool
+StringView::operator!=(self const &that) const
+{
+  return !(*this == that);
+}
+
+inline bool StringView::operator!() const
+{
+  return !(_ptr && _size);
+}
+
+inline StringView::operator bool() const
+{
+  return _ptr && _size;
+}
+
+inline bool
+StringView::isEmpty() const
+{
+  return !(_ptr && _size);
+}
+
+inline char StringView::operator*() const
+{
+  return *_ptr;
+}
+
+inline StringView &StringView::operator++()
+{
+  ++_ptr;
+  --_size;
+  return *this;
+}
+
+inline StringView &
+StringView::operator+=(size_t n)
+{
+  if (n > _size) {
+    _ptr  = nullptr;
+    _size = 0;
+  } else {
+    _ptr += n;
+    _size -= n;
+  }
+  return *this;
+}
+
+inline const char *
+StringView::begin() const
+{
+  return _ptr;
+}
+inline constexpr const char *
+StringView::ptr() const
+{
+  return _ptr;
+}
+
+inline const char *
+StringView::end() const
+{
+  return _ptr + _size;
+}
+
+inline constexpr size_t
+StringView::size() const
+{
+  return _size;
+}
+
+inline StringView &
+StringView::operator=(StringView const &that)
+{
+  _ptr  = that._ptr;
+  _size = that._size;
+  return *this;
+}
+
+inline char StringView::operator[](size_t n) const
+{
+  return _ptr[n];
+}
+
+inline char StringView::operator[](int n) const
+{
+  return _ptr[n];
+}
+
+inline bool
+StringView::contains(const char *p) const
+{
+  return _ptr <= p && p < _ptr + _size;
+}
+
+inline StringView
+StringView::prefix(const char *p) const
+{
+  self zret;
+  if (this->contains(p))
+    zret.setView(_ptr, p);
+  return zret;
+}
+
+inline StringView
+StringView::prefix(char c)
+{
+  return this->prefix(this->find(c));
+}
+
+inline StringView
+StringView::prefix(self delimiters) const
+{
+  return this->prefix(this->find(delimiters));
+}
+
+inline StringView
+StringView::prefix(std::function<bool(char)> const &pred) const
+{
+  return this->prefix(this->find(pred));
+}
+
+inline StringView
+StringView::splitPrefix(const char *p)
+{
+  self zret; // default to empty return.
+  if (this->contains(p)) {
+    zret.setView(_ptr, p);
+    this->setView(p + 1, this->end());
+  }
+  return zret;
+}
+
+inline StringView
+StringView::splitPrefix(char c)
+{
+  return this->splitPrefix(this->find(c));
+}
+
+inline StringView
+StringView::splitPrefix(self delimiters)
+{
+  return this->splitPrefix(this->find(delimiters));
+}
+
+inline StringView
+StringView::splitPrefix(std::function<bool(char)> const &pred)
+{
+  return this->splitPrefix(this->find(pred));
+}
+
+inline StringView
+StringView::extractPrefix(const char *p)
+{
+  self zret{this->splitPrefix(p)};
+
+  // For extraction if zret is empty, use up all of @a this
+  if (!zret) {
+    zret = *this;
+    this->clear();
+  }
+
+  return zret;
+}
+
+inline StringView
+StringView::extractPrefix(char c)
+{
+  return this->extractPrefix(this->find(c));
+}
+
+inline StringView
+StringView::extractPrefix(self delimiters)
+{
+  return this->extractPrefix(this->find(delimiters));
+}
+
+inline StringView
+StringView::extractPrefix(std::function<bool(char)> const &pred)
+{
+  return this->extractPrefix(this->find(pred));
+}
+
+inline StringView
+StringView::suffix(const char *p) const
+{
+  self zret;
+  if (this->contains(p))
+    zret.setView(p + 1, _ptr + _size);
+  return zret;
+}
+
+inline StringView
+StringView::suffix(char c)
+{
+  return this->suffix(this->find(c));
+}
+
+inline StringView
+StringView::suffix(self delimiters)
+{
+  return this->suffix(this->find(delimiters));
+}
+
+inline StringView
+StringView::suffix(std::function<bool(char)> const &pred)
+{
+  return this->suffix(this->find(pred));
+}
+
+inline StringView
+StringView::splitSuffix(const char *p)
+{
+  self zret;
+  if (this->contains(p)) {
+    zret.setView(p + 1, this->end());
+    this->setView(_ptr, p);
+  }
+  return zret;
+}
+
+inline StringView
+StringView::splitSuffix(char c)
+{
+  return this->splitSuffix(this->find(c));
+}
+
+inline StringView
+StringView::splitSuffix(self delimiters)
+{
+  return this->splitSuffix(this->find(delimiters));
+}
+
+inline StringView
+StringView::splitSuffix(std::function<bool(char)> const &pred)
+{
+  return this->splitSuffix(this->find(pred));
+}
+
+inline const char *
+StringView::find(char c) const
+{
+  return static_cast<const char *>(memchr(_ptr, c, _size));
+}
+
+inline const char *
+StringView::find(self delimiters) const
+{
+  std::bitset<256> valid;
+  delimiters.initDelimiterSet(valid);
+
+  for (const char *p = this->begin(), *limit = this->end(); p < limit; ++p)
+    if (valid[static_cast<uint8_t>(*p)])
+      return p;
+
+  return nullptr;
+}
+
+inline const char *
+StringView::find(std::function<bool(char)> const &pred) const
+{
+  const char *p = std::find_if(this->begin(), this->end(), pred);
+  return p == this->end() ? nullptr : p;
+}
+
+inline StringView &
+StringView::ltrim(char c)
+{
+  while (_size && *_ptr == c)
+    ++*this;
+  return *this;
+}
+
+inline StringView &
+StringView::rtrim(char c)
+{
+  while (_size && _ptr[_size - 1] == c)
+    --_size;
+  return *this;
+}
+inline StringView &
+StringView::trim(char c)
+{
+  this->ltrim(c);
+  return this->rtrim(c);
+}
+
+inline StringView &
+StringView::ltrim(self delimiters)
+{
+  std::bitset<256> valid;
+  delimiters.initDelimiterSet(valid);
+
+  while (_size && valid[static_cast<uint8_t>(*_ptr)])
+    ++*this;
+
+  return *this;
+}
+
+inline StringView &
+StringView::rtrim(self delimiters)
+{
+  std::bitset<256> valid;
+  delimiters.initDelimiterSet(valid);
+
+  while (_size && valid[static_cast<uint8_t>(_ptr[_size - 1])])
+    --_size;
+
+  return *this;
+}
+
+inline StringView &
+StringView::trim(self delimiters)
+{
+  std::bitset<256> valid;
+  delimiters.initDelimiterSet(valid);
+  // Do this explicitly, so we don't have to initialize the character set twice.
+  while (_size && valid[static_cast<uint8_t>(_ptr[_size - 1])])
+    --_size;
+  while (_size && valid[static_cast<uint8_t>(_ptr[0])])
+    ++*this;
+  return *this;
+}
+
+inline StringView &
+StringView::ltrim(std::function<bool(char)> const &pred)
+{
+  while (_size && pred(_ptr[0]))
+    ++*this;
+  return *this;
+}
+
+inline StringView &
+StringView::rtrim(std::function<bool(char)> const &pred)
+{
+  while (_size && pred(_ptr[_size - 1]))
+    --_size;
+  return *this;
+}
+
+inline StringView &
+StringView::trim(std::function<bool(char)> const &pred)
+{
+  this->ltrim(pred);
+  return this->rtrim(pred);
+}
+
+inline bool
+StringView::isPrefixOf(self const &that) const
+{
+  return _size <= that._size && 0 == memcmp(_ptr, that._ptr, _size);
+}
+
+inline bool
+StringView::isNoCasePrefixOf(self const &that) const
+{
+  return _size <= that._size && 0 == strncasecmp(_ptr, that._ptr, _size);
+}
+
+inline int
+strcmp(StringView const &lhs, StringView const &rhs)
+{
+  return ts::memcmp(lhs, rhs);
+}
+
+namespace detail
+{
+  /// Write padding to the stream, using the current stream fill character.
+  template <typename Stream>
+  void
+  stream_fill(Stream &os, std::size_t n)
+  {
+    static constexpr size_t pad_size = 8;
+    typename Stream::char_type padding[pad_size];
+
+    std::fill_n(padding, pad_size, os.fill());
+    for (; n >= pad_size && os.good(); n -= pad_size)
+      os.write(padding, pad_size);
+    if (n > 0 && os.good())
+      os.write(padding, n);
+  }
+
+  extern template void stream_fill(std::ostream &, std::size_t);
+} // detail
+
+template <typename Stream>
+Stream &
+StringView::stream_write(Stream &os, const StringView &b) const
+{
+  const std::size_t w = os.width();
+  if (w <= b.size()) {
+    os.write(b.ptr(), b.size());
+  } else {
+    const std::size_t pad_size = w - b.size();
+    const bool align_left      = (os.flags() & Stream::adjustfield) == Stream::left;
+    if (!align_left && os.good())
+      detail::stream_fill(os, pad_size);
+    if (os.good())
+      os.write(b.ptr(), b.size());
+    if (align_left && os.good())
+      detail::stream_fill(os, pad_size);
+  }
+  return os;
+}
+
+// Provide an instantiation for @c std::ostream as it's likely this is the only one ever used.
+extern template std::ostream &StringView::stream_write(std::ostream &, const StringView &) const;
+
+} // end namespace ApacheTrafficServer
+
+namespace std
+{
+ostream &operator<<(ostream &os, const ts::MemView &b);
+ostream &operator<<(ostream &os, const ts::StringView &b);
+}
+
+#endif // TS_BUFFER_HEADER

--- a/lib/ts/ink_inet.cc
+++ b/lib/ts/ink_inet.cc
@@ -40,6 +40,19 @@ struct hostent *gethostbyaddr_r(const char *name, size_t size, int type, struct 
 
 IpAddr const IpAddr::INVALID;
 
+const ts::StringView IP_PROTO_TAG_IPV4("ipv4", ts::StringView::literal);
+const ts::StringView IP_PROTO_TAG_IPV6("ipv6", ts::StringView::literal);
+const ts::StringView IP_PROTO_TAG_UDP("udp", ts::StringView::literal);
+const ts::StringView IP_PROTO_TAG_TCP("tcp", ts::StringView::literal);
+const ts::StringView IP_PROTO_TAG_TLS_1_0("tls/1.0", ts::StringView::literal);
+const ts::StringView IP_PROTO_TAG_TLS_1_1("tls/1.1", ts::StringView::literal);
+const ts::StringView IP_PROTO_TAG_TLS_1_2("tls/1.2", ts::StringView::literal);
+const ts::StringView IP_PROTO_TAG_TLS_1_3("tls/1.3", ts::StringView::literal);
+const ts::StringView IP_PROTO_TAG_HTTP_0_9("http/0.9", ts::StringView::literal);
+const ts::StringView IP_PROTO_TAG_HTTP_1_0("http/1.0", ts::StringView::literal);
+const ts::StringView IP_PROTO_TAG_HTTP_1_1("http/1.1", ts::StringView::literal);
+const ts::StringView IP_PROTO_TAG_HTTP_2_0("h2", ts::StringView::literal); // HTTP/2 over TLS
+
 struct hostent *
 ink_gethostbyname_r(char *hostname, ink_gethostbyname_r_data *data)
 {
@@ -172,10 +185,11 @@ ats_ip_ntop(const struct sockaddr *addr, char *dst, size_t size)
   return zret;
 }
 
-const char *
+ts::StringView
 ats_ip_family_name(int family)
 {
-  return AF_INET == family ? "IPv4" : AF_INET6 == family ? "IPv6" : "Unspec";
+  static const ts::StringView UNSPEC("Unspec", ts::StringView::literal);
+  return AF_INET == family ? IP_PROTO_TAG_IPV4 : AF_INET6 == family ? IP_PROTO_TAG_IPV6 : UNSPEC;
 }
 
 const char *

--- a/lib/ts/ink_inet.h
+++ b/lib/ts/ink_inet.h
@@ -31,6 +31,7 @@
 #include "ts/ink_memory.h"
 #include "ts/ink_apidefs.h"
 #include "ts/TsBuffer.h"
+#include <ts/MemView.h>
 
 #define INK_GETHOSTBYNAME_R_DATA_SIZE 1024
 #define INK_GETHOSTBYADDR_R_DATA_SIZE 1024
@@ -46,6 +47,20 @@ IN6_IS_ADDR_UNSPECIFIED(in6_addr const *addr)
   return 0 == w[0] && 0 == w[1];
 }
 #endif
+
+// IP protocol stack tags.
+extern const ts::StringView IP_PROTO_TAG_IPV4;
+extern const ts::StringView IP_PROTO_TAG_IPV6;
+extern const ts::StringView IP_PROTO_TAG_UDP;
+extern const ts::StringView IP_PROTO_TAG_TCP;
+extern const ts::StringView IP_PROTO_TAG_TLS_1_0;
+extern const ts::StringView IP_PROTO_TAG_TLS_1_1;
+extern const ts::StringView IP_PROTO_TAG_TLS_1_2;
+extern const ts::StringView IP_PROTO_TAG_TLS_1_3;
+extern const ts::StringView IP_PROTO_TAG_HTTP_0_9;
+extern const ts::StringView IP_PROTO_TAG_HTTP_1_0;
+extern const ts::StringView IP_PROTO_TAG_HTTP_1_1;
+extern const ts::StringView IP_PROTO_TAG_HTTP_2_0;
 
 struct IpAddr; // forward declare.
 
@@ -213,7 +228,7 @@ ats_ip_invalidate(IpEndpoint *ip)
 /** Get a string name for an IP address family.
     @return The string name (never @c nullptr).
 */
-const char *ats_ip_family_name(int family);
+ts::StringView ats_ip_family_name(int family);
 
 /// Test for IP protocol.
 /// @return @c true if the address is IP, @c false otherwise.

--- a/lib/ts/test_MemView.cc
+++ b/lib/ts/test_MemView.cc
@@ -1,0 +1,96 @@
+/** @file
+
+   MemView testing.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#include <ts/MemView.h>
+#include <algorithm>
+#include <iomanip>
+#include <ios>
+#include <iostream>
+#include <string>
+
+using namespace ts;
+
+template <typename T, typename S>
+bool
+CheckEqual(T const &lhs, S const &rhs, std::string const &prefix)
+{
+  bool zret = lhs == rhs;
+  if (!zret) {
+    std::cout << "FAIL: " << prefix << ": Expected " << lhs << " to be " << rhs << std::endl;
+  }
+  return zret;
+}
+
+bool
+Test_1()
+{
+  std::string text = "01234567";
+  StringView a(text);
+
+  std::cout << "Text = |" << a << '|' << std::endl;
+  std::cout << "     = |" << std::setw(5) << a << '|' << std::endl;
+  std::cout << "     = |" << std::setw(12) << a << '|' << std::endl;
+  std::cout << "     = |" << std::setw(12) << std::right << a << '|' << std::endl;
+  std::cout << "     = |" << std::setw(12) << std::left << a << '|' << std::endl;
+  std::cout << "     = |" << std::setw(12) << std::right << std::setfill('_') << a << '|' << std::endl;
+  std::cout << "     = |" << std::setw(12) << std::left << std::setfill('_') << a << '|' << std::endl;
+  return true;
+}
+
+bool
+Test_2()
+{
+  bool zret = true;
+  StringView sva("litt\0ral");
+  StringView svb("litt\0ral", StringView::literal);
+  StringView svc("litt\0ral", StringView::array);
+
+  zret = zret && CheckEqual(sva.size(), 4U, "strlen constructor");
+  zret = zret && CheckEqual(svb.size(), 8U, "literal constructor");
+  zret = zret && CheckEqual(svc.size(), 9U, "array constructor");
+
+  return zret;
+}
+
+// These tests are purely compile time.
+void
+Test_Compile()
+{
+  int i[12];
+  char c[29];
+  void *x = i, *y = i + 12;
+  MemView mvi(i, i + 12);
+  MemView mci(c, c + 29);
+  MemView mcv(x, y);
+}
+
+int
+main(int, char *argv[])
+{
+  bool zret = true;
+
+  zret = zret && Test_1();
+  zret = zret && Test_2();
+
+  return zret ? 0 : 1;
+}

--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -1035,9 +1035,9 @@ LocalManager::listenForProxy()
 
     if ((listen(p.m_fd, backlog)) < 0) {
       mgmt_fatal(errno, "[LocalManager::listenForProxy] Unable to listen on port: %d (%s)\n", p.m_port,
-                 ats_ip_family_name(p.m_family));
+                 ats_ip_family_name(p.m_family).ptr());
     }
-    mgmt_log("[LocalManager::listenForProxy] Listening on port: %d (%s)\n", p.m_port, ats_ip_family_name(p.m_family));
+    mgmt_log("[LocalManager::listenForProxy] Listening on port: %d (%s)\n", p.m_port, ats_ip_family_name(p.m_family).ptr());
   }
   return;
 }

--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -183,27 +183,17 @@ public:
   }
 
   virtual int
-  populate_protocol(const char **result, int size) const
+  populate_protocol(ts::StringView *result, int size) const
   {
-    int retval = 0;
-
-    if (get_netvc()) {
-      retval += this->get_netvc()->populate_protocol(result, size);
-    }
-
-    return retval;
+    auto vc = this->get_netvc();
+    return vc ? vc->populate_protocol(result, size) : 0;
   }
 
   virtual const char *
-  protocol_contains(const char *tag_prefix) const
+  protocol_contains(ts::StringView tag_prefix) const
   {
-    const char *retval = NULL;
-
-    if (get_netvc()) {
-      retval = this->get_netvc()->protocol_contains(tag_prefix);
-    }
-
-    return retval;
+    auto vc = this->get_netvc();
+    return vc ? vc->protocol_contains(tag_prefix) : nullptr;
   }
 
   void set_session_active();

--- a/proxy/ProxyClientTransaction.h
+++ b/proxy/ProxyClientTransaction.h
@@ -25,6 +25,7 @@
 #define __PROXY_CLIENT_TRANSACTION_H__
 
 #include "ProxyClientSession.h"
+#include <ts/MemView.h>
 
 class HttpSM;
 class HttpServerSession;
@@ -243,22 +244,15 @@ public:
   }
 
   virtual int
-  populate_protocol(const char **result, int size) const
+  populate_protocol(ts::StringView *result, int size) const
   {
-    int retval = 0;
-    if (parent) {
-      retval = parent->populate_protocol(result, size);
-    }
-    return retval;
+    return parent ? parent->populate_protocol(result, size) : 0;
   }
+
   virtual const char *
-  protocol_contains(const char *tag_prefix) const
+  protocol_contains(ts::StringView tag_prefix) const
   {
-    const char *retval = NULL;
-    if (parent) {
-      retval = parent->protocol_contains(tag_prefix);
-    }
-    return retval;
+    return parent ? parent->protocol_contains(tag_prefix) : nullptr;
   }
 
 protected:

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -50,6 +50,8 @@
 #include "congest/Congestion.h"
 #include "ts/I_Layout.h"
 
+using ts::StringView;
+
 #define DEFAULT_RESPONSE_BUFFER_SIZE_INDEX 6 // 8K
 #define DEFAULT_REQUEST_BUFFER_SIZE_INDEX 6  // 8K
 #define MIN_CONFIG_BUFFER_SIZE_INDEX 5       // 4K
@@ -4737,7 +4739,7 @@ void
 HttpSM::do_http_server_open(bool raw)
 {
   int ip_family = t_state.current.server->dst_addr.sa.sa_family;
-  DebugSM("http_track", "entered inside do_http_server_open ][%s]", ats_ip_family_name(ip_family));
+  DebugSM("http_track", "entered inside do_http_server_open ][%s]", ats_ip_family_name(ip_family).ptr());
 
   // Make sure we are on the "right" thread
   if (ua_session) {
@@ -8102,14 +8104,13 @@ HttpSM::is_redirect_required()
 
 // Fill in the client protocols used.  Return the number of entries returned
 int
-HttpSM::populate_client_protocol(const char **result, int n) const
+HttpSM::populate_client_protocol(ts::StringView *result, int n) const
 {
   int retval = 0;
   if (n > 0) {
-    const char *proto = HttpSM::find_proto_string(t_state.hdr_info.client_request.version_get());
+    StringView proto = HttpSM::find_proto_string(t_state.hdr_info.client_request.version_get());
     if (proto) {
-      result[0] = proto;
-      retval    = 1;
+      result[retval++] = proto;
       if (n > retval && ua_session) {
         retval += ua_session->populate_protocol(result + retval, n - retval);
       }
@@ -8120,29 +8121,28 @@ HttpSM::populate_client_protocol(const char **result, int n) const
 
 // Look for a specific protocol
 const char *
-HttpSM::client_protocol_contains(const char *tag_prefix) const
+HttpSM::client_protocol_contains(StringView tag_prefix) const
 {
   const char *retval = nullptr;
-  const char *proto  = HttpSM::find_proto_string(t_state.hdr_info.client_request.version_get());
+  StringView proto   = HttpSM::find_proto_string(t_state.hdr_info.client_request.version_get());
   if (proto) {
-    unsigned int tag_prefix_len = strlen(tag_prefix);
-    if (tag_prefix_len <= strlen(proto) && strncmp(tag_prefix, proto, tag_prefix_len) == 0) {
-      retval = proto;
+    StringView prefix(tag_prefix);
+    if (prefix.size() <= proto.size() && 0 == strncmp(proto.ptr(), prefix.ptr(), prefix.size())) {
+      retval = proto.ptr();
     } else if (ua_session) {
-      retval = ua_session->protocol_contains(tag_prefix);
+      retval = ua_session->protocol_contains(prefix);
     }
   }
   return retval;
 }
 
-const char *
+StringView
 HttpSM::find_proto_string(HTTPVersion version) const
 {
   if (version == HTTPVersion(1, 1)) {
-    return TS_PROTO_TAG_HTTP_1_1;
+    return IP_PROTO_TAG_HTTP_1_1;
   } else if (version == HTTPVersion(1, 0)) {
-    return TS_PROTO_TAG_HTTP_1_0;
-  } else {
-    return nullptr;
+    return IP_PROTO_TAG_HTTP_1_0;
   }
+  return nullptr;
 }

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -41,6 +41,7 @@
 #include "InkAPIInternal.h"
 #include "../ProxyClientTransaction.h"
 #include "HdrUtils.h"
+#include <ts/MemView.h>
 //#include "AuthHttpAdapter.h"
 
 /* Enable LAZY_BUF_ALLOC to delay allocation of buffers until they
@@ -263,9 +264,12 @@ public:
   bool is_private();
   bool is_redirect_required();
 
-  int populate_client_protocol(const char **result, int n) const;
-  const char *client_protocol_contains(const char *tag_prefix) const;
-  const char *find_proto_string(HTTPVersion version) const;
+  /// Get the protocol stack for the inbound (client, user agent) connection.
+  /// @arg result [out] Array to store the results
+  /// @arg n [in] Size of the array @a result.
+  int populate_client_protocol(ts::StringView *result, int n) const;
+  const char *client_protocol_contains(ts::StringView tag_prefix) const;
+  ts::StringView find_proto_string(HTTPVersion version) const;
 
   int64_t sm_id;
   unsigned int magic;

--- a/proxy/http/HttpServerSession.h
+++ b/proxy/http/HttpServerSession.h
@@ -180,6 +180,20 @@ public:
   //   an asyncronous cancel on NT
   MIOBuffer *read_buffer;
 
+  virtual int
+  populate_protocol(ts::StringView *result, int size) const
+  {
+    auto vc = this->get_netvc();
+    return vc ? vc->populate_protocol(result, size) : 0;
+  }
+
+  virtual const char *
+  protocol_contains(ts::StringView tag_prefix) const
+  {
+    auto vc = this->get_netvc();
+    return vc ? vc->protocol_contains(tag_prefix) : nullptr;
+  }
+
 private:
   HttpServerSession(HttpServerSession &);
 

--- a/proxy/http/HttpTransactHeaders.cc
+++ b/proxy/http/HttpTransactHeaders.cc
@@ -31,6 +31,9 @@
 
 #include "I_Machine.h"
 
+#include <array>
+#include <ts/MemView.h>
+
 bool
 HttpTransactHeaders::is_method_cacheable(const HttpConfigParams *http_config_param, const int method)
 {
@@ -685,6 +688,54 @@ HttpTransactHeaders::insert_server_header_in_response(const char *server_tag, in
   }
 }
 
+/// write the protocol stack to the @a via_string.
+/// If @a detailed then do the full stack, otherwise just the "top level" protocol.
+size_t
+write_via_protocol_stack(char *via_string, size_t len, bool detailed, ts::StringView *proto_buf, int n_proto)
+{
+  char *via   = via_string; // keep original pointer for size computation later.
+  char *limit = via_string + len;
+  static constexpr ts::StringView tls_prefix{"tls/", ts::StringView::literal};
+
+  if (n_proto <= 0 || via == nullptr || len <= 0) {
+    // nothing
+  } else if (detailed) {
+    for (ts::StringView *v = proto_buf, *v_limit = proto_buf + n_proto; v < v_limit && (via + v->size() + 1) < limit; ++v) {
+      if (v != proto_buf) {
+        *via++ = ' ';
+      }
+      memcpy(via, v->ptr(), v->size());
+      via += v->size();
+    }
+  } else {
+    ts::StringView *proto_end = proto_buf + n_proto;
+    bool http_1_0_p           = std::find(proto_buf, proto_end, IP_PROTO_TAG_HTTP_1_0) != proto_end;
+    bool http_1_1_p           = std::find(proto_buf, proto_end, IP_PROTO_TAG_HTTP_1_1) != proto_end;
+
+    if ((http_1_0_p || http_1_1_p) && via + 10 < limit) {
+      bool tls_p = std::find_if(proto_buf, proto_end, [](ts::StringView tag) { return tls_prefix.isPrefixOf(tag); }) != proto_end;
+      bool http_2_p = std::find(proto_buf, proto_end, IP_PROTO_TAG_HTTP_2_0) != proto_end;
+
+      memcpy(via, "http", 4);
+      via += 4;
+      if (tls_p)
+        *via++ = 's';
+      *via++   = '/';
+      if (http_2_p) {
+        *via++ = '2';
+      } else if (http_1_0_p) {
+        memcpy(via, "1.0", 3);
+        via += 3;
+      } else if (http_1_1_p) {
+        memcpy(via, "1.1", 3);
+        via += 3;
+      }
+      *via++ = ' ';
+    }
+  }
+  return via - via_string;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Name       : insert_via_header_in_request
 // Description: takes in existing via_string and inserts it in header
@@ -734,6 +785,7 @@ HttpTransactHeaders::insert_via_header_in_request(HttpTransact::State *s, HTTPHd
 {
   char new_via_string[1024]; // 512-bytes for hostname+via string, 512-bytes for the debug info
   char *via_string = new_via_string;
+  char *via_limit  = via_string + sizeof(new_via_string);
 
   if ((s->http_config_param->proxy_hostname_len + s->http_config_param->proxy_request_via_string_len) > 512) {
     header->value_append(MIME_FIELD_VIA, MIME_LEN_VIA, "TrafficServer", 13, true);
@@ -741,26 +793,10 @@ HttpTransactHeaders::insert_via_header_in_request(HttpTransact::State *s, HTTPHd
   }
 
   char *incoming_via = s->via_string;
-  int scheme         = s->orig_scheme;
-  ink_assert(scheme >= 0);
+  std::array<ts::StringView, 10> proto_buf; // 10 seems like a reasonable number of protos to print
+  int n_proto = s->state_machine->populate_client_protocol(proto_buf.data(), proto_buf.size());
 
-  int scheme_len   = hdrtoken_index_to_length(scheme);
-  int32_t hversion = header->version_get().m_version;
-
-  memcpy(via_string, hdrtoken_index_to_wks(scheme), scheme_len);
-  via_string += scheme_len;
-
-  // Common case (I hope?)
-  if ((HTTP_MAJOR(hversion) == 1) && HTTP_MINOR(hversion) == 1) {
-    memcpy(via_string, "/1.1 ", 5);
-    via_string += 5;
-  } else {
-    *via_string++ = '/';
-    *via_string++ = '0' + HTTP_MAJOR(hversion);
-    *via_string++ = '.';
-    *via_string++ = '0' + HTTP_MINOR(hversion);
-    *via_string++ = ' ';
-  }
+  via_string += write_via_protocol_stack(via_string, via_limit - via_string, false, proto_buf.data(), n_proto);
   via_string += nstrcpy(via_string, s->http_config_param->proxy_hostname);
 
   *via_string++ = '[';
@@ -785,6 +821,14 @@ HttpTransactHeaders::insert_via_header_in_request(HttpTransact::State *s, HTTPHd
       via_string += VIA_SERVER - VIA_CLIENT;
     }
     *via_string++ = ']';
+
+    // reserve 4 for " []" and 3 for "])".
+    if (via_limit - via_string > 4 && s->txn_conf->insert_request_via_string > 3) { // Ultra highest verbosity
+      *via_string++ = ' ';
+      *via_string++ = '[';
+      via_string += write_via_protocol_stack(via_string, via_limit - via_string - 3, true, proto_buf.data(), n_proto);
+      *via_string++ = ']';
+    }
   }
 
   *via_string++ = ')';
@@ -819,6 +863,7 @@ HttpTransactHeaders::insert_via_header_in_response(HttpTransact::State *s, HTTPH
 {
   char new_via_string[1024]; // 512-bytes for hostname+via string, 512-bytes for the debug info
   char *via_string = new_via_string;
+  char *via_limit  = via_string + sizeof(new_via_string);
 
   if ((s->http_config_param->proxy_hostname_len + s->http_config_param->proxy_response_via_string_len) > 512) {
     header->value_append(MIME_FIELD_VIA, MIME_LEN_VIA, "TrafficServer", 13, true);
@@ -826,14 +871,17 @@ HttpTransactHeaders::insert_via_header_in_response(HttpTransact::State *s, HTTPH
   }
 
   char *incoming_via = s->via_string;
+  std::array<ts::StringView, 10> proto_buf; // 10 seems like a reasonable number of protos to print
+  int n_proto = 0;
 
-  const char *proto_buf[10]; // 10 seems like a reasonable number of protos to print
-  int retval = s->state_machine->populate_client_protocol(proto_buf, countof(proto_buf));
-  for (int i = 0; i < retval; i++) {
-    memcpy(via_string, proto_buf[i], strlen(proto_buf[i]));
-    via_string += strlen(proto_buf[i]);
-    *via_string++ = ' ';
+  // Should suffice - if we're adding a response VIA, the connection is HTTP and only 1.0 and 1.1 are supported outbound.
+  proto_buf[n_proto++] = HTTP_MINOR(header->version_get().m_version) == 0 ? IP_PROTO_TAG_HTTP_1_0 : IP_PROTO_TAG_HTTP_1_1;
+
+  auto ss = s->state_machine->get_server_session();
+  if (ss) {
+    n_proto += ss->populate_protocol(proto_buf.data() + n_proto, proto_buf.size() - n_proto);
   }
+  via_string += write_via_protocol_stack(via_string, via_limit - via_string, false, proto_buf.data(), n_proto);
 
   via_string += nstrcpy(via_string, s->http_config_param->proxy_hostname);
   *via_string++ = ' ';
@@ -854,6 +902,13 @@ HttpTransactHeaders::insert_via_header_in_response(HttpTransact::State *s, HTTPH
       via_string += VIA_PROXY - VIA_CACHE;
     }
     *via_string++ = ']';
+
+    if (via_limit - via_string > 4 && s->txn_conf->insert_response_via_string > 3) { // Ultra highest verbosity
+      *via_string++ = ' ';
+      *via_string++ = '[';
+      via_string += write_via_protocol_stack(via_string, via_limit - via_string - 3, true, proto_buf.data(), n_proto);
+      *via_string++ = ']';
+    }
   }
 
   *via_string++ = ')';

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -28,6 +28,8 @@
 #include "Plugin.h"
 #include "ProxyClientSession.h"
 #include "Http2ConnectionState.h"
+#include <ts/MemView.h>
+#include <ts/ink_inet.h>
 
 // Name                       Edata                 Description
 // HTTP2_SESSION_EVENT_INIT   Http2ClientSession *  HTTP/2 session is born
@@ -152,15 +154,15 @@ class Http2ClientSession : public ProxyClientSession
 {
 public:
   typedef ProxyClientSession super; ///< Parent type.
-  Http2ClientSession();
-
   typedef int (Http2ClientSession::*SessionHandler)(int, void *);
 
+  Http2ClientSession();
+
   // Implement ProxyClientSession interface.
-  void start();
-  virtual void destroy();
-  virtual void free();
-  virtual void new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader, bool backdoor);
+  void start() override;
+  void destroy() override;
+  void free() override;
+  void new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader, bool backdoor) override;
 
   bool
   ready_to_free() const
@@ -169,20 +171,20 @@ public:
   }
 
   // Implement VConnection interface.
-  VIO *do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = 0);
-  VIO *do_io_write(Continuation *c = NULL, int64_t nbytes = INT64_MAX, IOBufferReader *buf = 0, bool owner = false);
-  void do_io_close(int lerrno = -1);
-  void do_io_shutdown(ShutdownHowTo_t howto);
-  void reenable(VIO *vio);
+  VIO *do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = 0) override;
+  VIO *do_io_write(Continuation *c = NULL, int64_t nbytes = INT64_MAX, IOBufferReader *buf = 0, bool owner = false) override;
+  void do_io_close(int lerrno = -1) override;
+  void do_io_shutdown(ShutdownHowTo_t howto) override;
+  void reenable(VIO *vio) override;
 
-  virtual NetVConnection *
-  get_netvc() const
+  NetVConnection *
+  get_netvc() const override
   {
     return client_vc;
   }
 
-  virtual void
-  release_netvc()
+  void
+  release_netvc() override
   {
     // Make sure the vio's are also released to avoid later surprises in inactivity timeout
     if (client_vc) {
@@ -212,14 +214,14 @@ public:
     return upgrade_context;
   }
 
-  virtual int
-  get_transact_count() const
+  int
+  get_transact_count() const override
   {
     return connection_state.get_stream_requests();
   }
 
-  virtual void
-  release(ProxyClientTransaction *trans)
+  void
+  release(ProxyClientTransaction *trans) override
   {
   }
 
@@ -242,35 +244,34 @@ public:
     return recursion > 0;
   }
 
-  virtual const char *
-  get_protocol_string() const
+  const char *
+  get_protocol_string() const override
   {
     return "http/2";
   }
 
   virtual int
-  populate_protocol(const char **result, int size) const
+  populate_protocol(ts::StringView *result, int size) const override
   {
     int retval = 0;
-    if (size > 0) {
-      result[0] = TS_PROTO_TAG_HTTP_2_0;
-      retval    = 1;
-      if (size > 1) {
-        retval += super::populate_protocol(result + 1, size - 1);
+    if (size > retval) {
+      result[retval++] = IP_PROTO_TAG_HTTP_2_0;
+      if (size > retval) {
+        retval += super::populate_protocol(result + retval, size - retval);
       }
     }
     return retval;
   }
 
   virtual const char *
-  protocol_contains(const char *tag_prefix) const
+  protocol_contains(ts::StringView prefix) const override
   {
-    const char *retval   = NULL;
-    unsigned int tag_len = strlen(tag_prefix);
-    if (tag_len <= strlen(TS_PROTO_TAG_HTTP_2_0) && strncmp(tag_prefix, TS_PROTO_TAG_HTTP_2_0, tag_len) == 0) {
-      retval = TS_PROTO_TAG_HTTP_2_0;
+    const char *retval = nullptr;
+
+    if (prefix.size() <= IP_PROTO_TAG_HTTP_2_0.size() && strncmp(IP_PROTO_TAG_HTTP_2_0.ptr(), prefix.ptr(), prefix.size()) == 0) {
+      retval = IP_PROTO_TAG_HTTP_2_0.ptr();
     } else {
-      retval = super::protocol_contains(tag_prefix);
+      retval = super::protocol_contains(prefix);
     }
     return retval;
   }


### PR DESCRIPTION
This implements the VIA protocol stack support currently in master along with the necessary infrastructure changes. It is split in to 3 commits

* Add `MemView` / `StringView`.
* Change the infrastructure of the protocol stack logic to use `StringView`.
* Changes the VIA header logic and add documentation.

The VIA tests unfortunately were not backported because they depend on significant changes to the testing infrastructure.