### PR TITLE
Add 7.0.x to the doc version list

### DIFF
--- a/doc/static/languages.json
+++ b/doc/static/languages.json
@@ -1,4 +1,4 @@
 {
-  "en": { "name": "English", "versions": ["latest","6.2.x","5.3.x"] },
-  "ja": { "name": "日本語", "versions": ["latest","6.2.x","5.3.x"] }
+  "en": { "name": "English", "versions": ["latest","7.0.x","6.2.x","5.3.x"] },
+  "ja": { "name": "日本語", "versions": ["latest","7.0.x","6.2.x","5.3.x"] }
 }


### PR DESCRIPTION
7.0.x isn't shown on the version list but the latest is 8.0.
<img width="300" alt="screen shot 2017-06-15 at 10 47 02" src="https://user-images.githubusercontent.com/153144/27161683-014982ea-51b8-11e7-886c-1af5e3efa7c0.png">
