### PR TITLE
Autest for ATS test support all configuration layout

### DIFF
--- a/tests/gold_tests/autest-site/copy_config.test.ext
+++ b/tests/gold_tests/autest-site/copy_config.test.ext
@@ -15,16 +15,13 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
 import os
 from future.utils import native_str
 
 
 class CopyATSConfig(SetupItem):
     def __init__(self, file, targetname=None, process=None):
-        super(CopyATSConfig, self).__init__(
-            itemname="CopyATSConfig"
-        )
+        super(CopyATSConfig, self).__init__(itemname="CopyATSConfig")
         self.file = file
         # some protection
         if process is None and not isinstance(targetname, native_str):
@@ -34,21 +31,24 @@ class CopyATSConfig(SetupItem):
         self.targetname = targetname
 
     def setup(self):
-
         process = self.process if self.process else self
         try:
             ts_dir = process.Env['TS_ROOT']
         except:
             if self.process:
                 raise SetupError(
-                    'TS_ROOT is not defined. Cannot copy ats config file without location to copy to.')
+                    'TS_ROOT is not defined. Cannot copy ats config file without location to copy to.'
+                )
             else:
                 raise SetupError(
-                    'TS_ROOT is not defined. Cannot copy ats config file without location to copy to. Please pass in an ATS process object')
-        config_dir = os.path.join(ts_dir, process.ComposeVariables(
-        ).SYSCONFDIR.replace(process.ComposeVariables().PREFIX + "/", ""))
-        host.WriteVerbose(
-            "CopyATSConfig", "Copying {0} to {1}".format(self.file, config_dir))
+                    'TS_ROOT is not defined. Cannot copy ats config file without location to copy to. Please pass in an ATS process object'
+                )
+
+        # set up the config path for test manually
+        config_dir = os.path.join(ts_dir, "config")
+        
+        host.WriteVerbose("CopyATSConfig", "Copying {0} to {1}".format(
+            self.file, config_dir))
         self.CopyAs(self.file, config_dir, self.targetname)
 
 

--- a/tests/gold_tests/autest-site/trafficserver.test.ext
+++ b/tests/gold_tests/autest-site/trafficserver.test.ext
@@ -25,6 +25,7 @@ from ports import get_port
 def make_id(s):
     return s.replace(".", "_").replace('-', '_')
 
+
 # this forms is for the global process define
 
 
@@ -36,31 +37,31 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True):
     ts_dir = os.path.join(obj.RunDirectory, name)
     # common bin directory
     bin_dir = 'bin'
-    # ideally we would use a value like config.. but there is a bug
-    # in which records.conf values are not loaded correctly from this location,
-    # so we use the expecetd "build" layout to correct the issue for the time
-    # being
-    config_dir = os.path.join(
-        ts_dir,
-        obj.Variables.SYSCONFDIR.replace(
-            obj.Variables.PREFIX + "/",
-            ""
-        )
-    )
+
+    # manually set up all directory for the test
+
+    # configuration directory
+    config_dir = os.path.join(ts_dir, 'config')
+    
     # directory contains the html response templates
-    template_dir = os.path.join(config_dir, "body_factory")
+    template_dir = os.path.join(config_dir, 'body_factory')
+    
     # contains plugins
-    plugin_dir = os.path.join(
-        ts_dir, obj.Variables.PLUGINDIR.replace(obj.Variables.PREFIX + "/", ""))
+    plugin_dir = os.path.join(ts_dir, 'plugin')
+    
     # the log directory
     log_dir = os.path.join(ts_dir, 'log')
-    runtime_dir = os.path.join(
-        ts_dir, obj.Variables.RUNTIMEDIR.replace(obj.Variables.PREFIX + "/", ""))
+    
+    # runtime dir
+    runtime_dir = os.path.join(ts_dir, 'runtime')
+    
+    #ssl, storage & cache
     ssl_dir = os.path.join(ts_dir, 'ssl')
     storage_dir = os.path.join(ts_dir, 'storage')
+    cache_dir = os.path.join(ts_dir, 'cache')
+
     # create process
     p = obj.Processes.Process(name, command)
-
     # we want to have a few directories more fixed
     # this helps with debugging as location are common
     # we do this by overiding locations from the "layout"
@@ -80,22 +81,32 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True):
     p.Env['PATH'] = bin_path + os.pathsep + p.ComposeEnv()['PATH']
     p.Setup.Copy(p.Variables.BINDIR, bin_path, True)
 
-    #########################################################
     # setup config directory
 
     # copy all basic config files we need to get this to work
     cfg_dir = os.path.join(AUTEST_SITE_PATH, "min_cfg")
+
     for f in os.listdir(cfg_dir):
         p.Setup.CopyAs(os.path.join(cfg_dir, f), config_dir)
 
+    #########################################################
+    # setup config directory
+    p.Env['PROXY_CONFIG_CONFIG_DIR'] = config_dir
+    p.Variables.CONFIGDIR = config_dir
     #########################################################
     # setup read-only data directory in config. Needed for response body
     # reponses
 
     p.Env['PROXY_CONFIG_BODY_FACTORY_TEMPLATE_SETS_DIR'] = template_dir
-    p.Variables.body_factory_template_dir = template_dir
-    p.Setup.Copy(os.path.join(p.Variables.SYSCONFDIR,
-                              'body_factory'), template_dir)
+    p.Variables.BODY_FACTORY_TEMPLATE_DIR = template_dir
+    p.Setup.Copy(
+        os.path.join(p.Variables.SYSCONFDIR, 'body_factory'), template_dir)
+
+    #########################################################
+    # setup cache directory
+    p.Setup.MakeDir(cache_dir)
+    p.Env['PROXY_CONFIG_CACHE_DIR'] = cache_dir
+    p.Variables.CACHEDIR = cache_dir
 
     #########################################################
     # setup read-only data directory for plugins
@@ -115,14 +126,16 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True):
 
     # this is needed for cache and communication sockets
     # Below was to make shorter paths but the code in
-    # traffic_ctl is broken and ignores this.
-    # p.Env['PROXY_CONFIG_LOCAL_STATE_DIR']=runtime_dir
+    # set runtime directory(local state dir)
+    p.Env['PROXY_CONFIG_LOCAL_STATE_DIR'] = runtime_dir
     p.Env['PROXY_CONFIG_HOSTDB_STORAGE_PATH'] = runtime_dir
-    # p.Variables.RUNTIMEDIR=runtime_dir
+    p.Variables.RUNTIMEDIR = runtime_dir
+    p.Variables.LOCALSTATEDIR = runtime_dir
+
     p.Setup.MakeDir(runtime_dir)
     # will need this for traffic_manager is it runs
     p.Setup.MakeDir(os.path.join(config_dir, 'snapshots'))
-
+    p.Env['PROXY_CONFIG_SNAPSHOT_DIR'] = os.path.join(config_dir, 'snapshots')
     ##########################################################
     # create subdirectories that need to exist (but are empty)
     # ssl directory has to be created for keeping certs and keys
@@ -137,7 +150,6 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True):
     # cache.db directory
     p.Setup.MakeDir(storage_dir)
     p.Setup.Chown(storage_dir, "nobody", "nobody", ignore=True)
-
     # set env so traffic server uses correct locations
     p.Env['PROXY_CONFIG_STORAGE_DIR'] = storage_dir
     p.Variables.STORAGEDIR = storage_dir
@@ -258,11 +270,11 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True):
     p.Env['PROXY_CONFIG_ADMIN_SYNTHETIC_PORT'] = str(p.Variables.admin_port)
     p.Env['PROXY_CONFIG_ADMIN_AUTOCONF_PORT'] = str(
         p.Variables.admin_port)  # support pre ATS 6.x
-
     # since we always kill this
     p.ReturnCode = None
 
     return p
+
 
 ##################################
 # added to ats process object to help deal with config files
@@ -273,10 +285,23 @@ class Config(File):
     Class to represent a config file
     '''
 
-    def __init__(self, runable, name, exists=None, size=None, content_tester=None, execute=False, runtime=True, content=None):
+    def __init__(self,
+                 runable,
+                 name,
+                 exists=None,
+                 size=None,
+                 content_tester=None,
+                 execute=False,
+                 runtime=True,
+                 content=None):
         super(Config, self).__init__(
-            runable, name, exists=None, size=None, content_tester=None, execute=False, runtime=True
-        )
+            runable,
+            name,
+            exists=None,
+            size=None,
+            content_tester=None,
+            execute=False,
+            runtime=True)
 
         self.content = content
         self._added = False
@@ -289,8 +314,8 @@ class Config(File):
         '''
         Write contents to disk
         '''
-        host.WriteVerbosef('ats-config-file',
-                           "Writting out file {0}", self.Name)
+        host.WriteVerbosef('ats-config-file', "Writting out file {0}",
+                           self.Name)
         if self.content is not None:
             with open(name, 'w') as f:
                 f.write(self.content)
@@ -317,17 +342,30 @@ class RecordsConfig(Config, dict):
     rc['CONFIG']['proxy.config.log.hostname']
     '''
 
-    reverse_kind_map = {str: 'STRING',
-                        int: 'INT',
-                        float: 'FLOAT',
-                        }
+    reverse_kind_map = {
+        str: 'STRING',
+        int: 'INT',
+        float: 'FLOAT',
+    }
 
     line_template = 'CONFIG {name} {kind} {val}\n'
 
-    def __init__(self, runable, name, exists=None, size=None, content_tester=None, execute=False, runtime=True):
+    def __init__(self,
+                 runable,
+                 name,
+                 exists=None,
+                 size=None,
+                 content_tester=None,
+                 execute=False,
+                 runtime=True):
         super(RecordsConfig, self).__init__(
-            runable, name, exists=None, size=None, content_tester=None, execute=False, runtime=True
-        )
+            runable,
+            name,
+            exists=None,
+            size=None,
+            content_tester=None,
+            execute=False,
+            runtime=True)
         self.WriteCustomOn(self._do_write)
 
     def _do_write(self, name):
@@ -335,16 +373,23 @@ class RecordsConfig(Config, dict):
         if len(self) > 0:
             with open(name, 'w') as f:
                 for name, val in self.items():
-                    f.write(self.line_template.format(name=name,
-                                                      kind=self.reverse_kind_map[
-                                                          type(val)],
-                                                      val=val))
-        return (False, "Writing config file {0}".format(os.path.split(self.Name)[-1]), "Success")
+                    f.write(
+                        self.line_template.format(
+                            name=name,
+                            kind=self.reverse_kind_map[type(val)],
+                            val=val)
+                    )
+        return (False,
+                "Writing config file {0}".format(os.path.split(self.Name)[-1]),
+                "Success")
+
+
 ##########################################################################
 
 
 def addSSLfile(self, filename):
     self.Setup.CopyAs(filename, self.Variables.SSLDir)
+
 
 RegisterFileType(Config, "ats:config")
 RegisterFileType(RecordsConfig, "ats:config:records")

--- a/tests/gold_tests/body_factory/custom_response.test.py
+++ b/tests/gold_tests/body_factory/custom_response.test.py
@@ -36,7 +36,7 @@ ts.Disk.remap_config.AddLine(
 
 
 domain_directory = ['www.linkedin.com', '127.0.0.1', 'www.foobar.net']
-body_factory_dir = ts.Variables.body_factory_template_dir
+body_factory_dir=ts.Variables.BODY_FACTORY_TEMPLATE_DIR
 # for each domain
 set = False
 for directory_item in domain_directory:

--- a/tests/gold_tests/body_factory/http204_response.test.py
+++ b/tests/gold_tests/body_factory/http204_response.test.py
@@ -37,8 +37,8 @@ ts.Disk.records_config.update({
 })
 
 # Create a template body for a 204.
-body_factory_dir = ts.Variables.body_factory_template_dir
-ts.Disk.File(os.path.join(body_factory_dir, 'default', CUSTOM_TEMPLATE_204_HOST + '_default')).\
+body_factory_dir=ts.Variables.BODY_FACTORY_TEMPLATE_DIR
+ts.Disk.File(os.path.join(body_factory_dir, 'default', CUSTOM_TEMPLATE_204_HOST+'_default')).\
     WriteOn(
     """<HTML>
 <HEAD>


### PR DESCRIPTION
Fixed the extension file for autest of ATS. Changed variables and directories in trafficserver.test.ext and copy_config.test.ext. Support all kinds of config.layout during build to guarantee the test run in the sandbox without side effects.