### PR TITLE
SEGV in Diags when we try to use Fatal macro

### DIFF
--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -1644,17 +1644,19 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   main_thread->set_specific();
 
   // Re-initialize diagsConfig based on records.config configuration
-  if (diagsConfig) {
-    RecDebugOff();
-    delete (diagsConfig);
-  }
-  diagsConfig = new DiagsConfig("Server", DIAGS_LOG_FILENAME, error_tags, action_tags, true);
-  diags       = diagsConfig->diags;
+  DiagsConfig *old_log = diagsConfig;
+  diagsConfig          = new DiagsConfig("Server", DIAGS_LOG_FILENAME, error_tags, action_tags, true);
+  diags                = diagsConfig->diags;
   RecSetDiags(diags);
   diags->set_stdout_output(bind_stdout);
   diags->set_stderr_output(bind_stderr);
   if (is_debug_tag_set("diags")) {
     diags->dump();
+  }
+
+  if (old_log) {
+    delete (old_log);
+    old_log = nullptr;
   }
 
   DebugCapabilities("privileges"); // Can do this now, logging is up.


### PR DESCRIPTION
#2148 

we use diags in DiagsConfig::DiagsConfig(like fatal, error or debug macro) but we free it in 1657.  

This case may happen when we set group failed.

```
1655   if (diagsConfig) {
1656     RecDebugOff();
1657     delete (diagsConfig);
1658   }
1659   diagsConfig = new DiagsConfig("Server", DIAGS_LOG_FILENAME, error_tags, action_tags, true);
1660   diags       = diagsConfig->diags;
1661   RecSetDiags(diags);
1662   diags->set_stdout_output(bind_stdout);
1663   diags->set_stderr_output(bind_stderr);
1664   if (is_debug_tag_set("diags")) {
1665     diags->dump();
1666   }
```

```
[Jun 16 10:07:43.788] Server {0x7ffff7fe5780} FATAL: switching to user root, failed to set group ID 0
[Jun 16 10:07:43.788] Server {0x7ffff7fe5780} FATAL: switching to user root, failed to set group ID 0
Fatal: switching to user root, failed to set group ID 0
```