### PR TITLE
TS-4265: Fix NUMA stack support.

### DIFF
--- a/iocore/eventsystem/UnixEventProcessor.cc
+++ b/iocore/eventsystem/UnixEventProcessor.cc
@@ -46,12 +46,24 @@ public:
   void init();
   /// Set the affinity for the current thread.
   int set_affinity(int, Event *);
+  /// Allocate a stack.
+  /// @internal This is the external entry point and is different depending on
+  /// whether HWLOC is enabled.
+  void *alloc_stack(EThread *t, size_t stacksize);
+
+protected:
+  /// Allocate a hugepage stack.
+  /// If huge pages are not enable, allocate a basic stack.
+  void *alloc_hugepage_stack(size_t stacksize);
 
 #if TS_USE_HWLOC
+
+  /// Allocate a stack based on NUMA information, if possible.
+  void *alloc_numa_stack(EThread *t, size_t stacksize);
+
 private:
-  hwloc_obj_t _type;
   hwloc_obj_type_t obj_type;
-  int obj_count;
+  int obj_count = 0;
   char const *obj_name;
 #endif
 };
@@ -60,6 +72,9 @@ ThreadAffinityInitializer Thread_Affinity_Initializer;
 
 namespace
 {
+/// This is a wrapper used to convert a static function into a continuation. The function pointer is
+/// passed in the cookie. For this reason the class is used as a singleton.
+/// @internal This is the implementation for @c schedule_spawn... overloads.
 class ThreadInitByFunc : public Continuation
 {
 public:
@@ -74,10 +89,16 @@ public:
 } Thread_Init_Func;
 }
 
+void *
+ThreadAffinityInitializer::alloc_hugepage_stack(size_t stacksize)
+{
+  return ats_hugepage_enabled() ? ats_alloc_hugepage(stacksize) : ats_memalign(ats_pagesize(), stacksize);
+}
+
+#if TS_USE_HWLOC
 void
 ThreadAffinityInitializer::init()
 {
-#if TS_USE_HWLOC
   int affinity = 1;
   REC_ReadConfigInteger(affinity, "proxy.config.exec_thread.affinity");
 
@@ -110,18 +131,16 @@ ThreadAffinityInitializer::init()
 
   obj_count = hwloc_get_nbobjs_by_type(ink_get_topology(), obj_type);
   Debug("iocore_thread", "Affinity: %d %ss: %d PU: %d", affinity, obj_name, obj_count, ink_number_of_processors());
-#endif
 }
 
 int
 ThreadAffinityInitializer::set_affinity(int, Event *)
 {
-#if TS_USE_HWLOC
-  hwloc_obj_t obj;
   EThread *t = this_ethread();
 
   if (obj_count > 0) {
-    obj = hwloc_get_obj_by_type(ink_get_topology(), obj_type, t->id % obj_count);
+    // Get our `obj` instance with index based on the thread number we are on.
+    hwloc_obj_t obj = hwloc_get_obj_by_type(ink_get_topology(), obj_type, t->id % obj_count);
 #if HWLOC_API_VERSION >= 0x00010100
     int cpu_mask_len = hwloc_bitmap_snprintf(NULL, 0, obj->cpuset) + 1;
     char *cpu_mask   = (char *)alloca(cpu_mask_len);
@@ -134,9 +153,76 @@ ThreadAffinityInitializer::set_affinity(int, Event *)
   } else {
     Warning("hwloc returned an unexpected number of objects -- CPU affinity disabled");
   }
-#endif // TS_USE_HWLOC
   return 0;
 }
+
+void *
+ThreadAffinityInitializer::alloc_numa_stack(EThread *t, size_t stacksize)
+{
+  hwloc_membind_policy_t mem_policy = HWLOC_MEMBIND_DEFAULT;
+  hwloc_nodeset_t nodeset           = hwloc_bitmap_alloc();
+  int num_nodes                     = 0;
+  void *stack                       = nullptr;
+  hwloc_obj_t obj                   = hwloc_get_obj_by_type(ink_get_topology(), obj_type, t->id % obj_count);
+
+  // Find the NUMA node set that correlates to our next thread CPU set
+  hwloc_cpuset_to_nodeset(ink_get_topology(), obj->cpuset, nodeset);
+  // How many NUMA nodes will we be needing to allocate across?
+  num_nodes = hwloc_get_nbobjs_inside_cpuset_by_type(ink_get_topology(), obj->cpuset, HWLOC_OBJ_NODE);
+
+  if (num_nodes == 1) {
+    // The preferred memory policy. The thread lives in one NUMA node.
+    mem_policy = HWLOC_MEMBIND_BIND;
+  } else if (num_nodes > 1) {
+    // If we have mode than one NUMA node we should interleave over them.
+    mem_policy = HWLOC_MEMBIND_INTERLEAVE;
+  }
+
+  if (mem_policy != HWLOC_MEMBIND_DEFAULT) {
+    // Let's temporarily set the memory binding to our destination NUMA node
+    hwloc_set_membind_nodeset(ink_get_topology(), nodeset, mem_policy, HWLOC_MEMBIND_THREAD);
+  }
+
+  // Alloc our stack
+  stack = this->alloc_hugepage_stack(stacksize);
+
+  if (mem_policy != HWLOC_MEMBIND_DEFAULT) {
+    // Now let's set it back to default for this thread.
+    hwloc_set_membind_nodeset(ink_get_topology(), hwloc_topology_get_topology_nodeset(ink_get_topology()), HWLOC_MEMBIND_DEFAULT,
+                              HWLOC_MEMBIND_THREAD);
+  }
+
+  hwloc_bitmap_free(nodeset);
+
+  return stack;
+}
+
+void *
+ThreadAffinityInitializer::alloc_stack(EThread *t, size_t stacksize)
+{
+  return this->obj_count > 0 ? this->alloc_numa_stack(t, stacksize) : this->alloc_hugepage_stack(stacksize);
+}
+
+#else
+
+void
+ThreadAffinityInitializer::init()
+{
+}
+
+int
+ThreadAffinityInitializer::set_affinity(int, Event *)
+{
+  return 0;
+}
+
+void *
+ThreadAffinityInitializer::alloc_stack(EThread *, size_t stacksize)
+{
+  return this->alloc_hugepage_stack(stacksize);
+}
+
+#endif // TS_USE_HWLOC
 
 EventProcessor::EventProcessor() : thread_initializer(this)
 {
@@ -216,21 +302,36 @@ EventProcessor::spawn_event_threads(EventType ev_type, int n_threads, size_t sta
   ink_release_assert((n_ethreads + n_threads) <= MAX_EVENT_THREADS);
   ink_release_assert(ev_type < MAX_EVENT_TYPES);
 
+  stacksize = std::max(stacksize, static_cast<decltype(stacksize)>(INK_THREAD_STACK_MIN));
+  // Make sure it is a multiple of our page size
+  if (ats_hugepage_enabled()) {
+    stacksize = INK_ALIGN(stacksize, ats_hugepage_size());
+  } else {
+    stacksize = INK_ALIGN(stacksize, ats_pagesize());
+  }
+
+  Debug("iocore_thread", "Thread stack size set to %zu", stacksize);
+
   for (i = 0; i < n_threads; ++i) {
     EThread *t                   = new EThread(REGULAR, n_ethreads + i);
     all_ethreads[n_ethreads + i] = t;
     tg->_thread[i]               = t;
+    t->id                        = i; // unfortunately needed to support affinity and NUMA logic.
     t->set_event_type(ev_type);
     t->schedule_spawn(&thread_initializer);
+    snprintf(thr_name, MAX_THREAD_NAME_LENGTH, "[%s %d]", tg->_name.get(), i);
   }
   tg->_count = n_threads;
+  n_ethreads += n_threads;
 
-  for (i = 0; i < n_threads; i++) {
-    snprintf(thr_name, MAX_THREAD_NAME_LENGTH, "[%s %d]", tg->_name.get(), i);
-    tg->_thread[i]->start(thr_name, nullptr, stacksize);
+  // Separate loop to avoid race conditions between spawn events and updating the thread table for
+  // the group. Some thread set up depends on knowing the total number of threads but that can't be
+  // safely updated until all the EThread instances are created and stored in the table.
+  for (i = 0; i < n_threads; ++i) {
+    void *stack = Thread_Affinity_Initializer.alloc_stack(tg->_thread[i], stacksize);
+    tg->_thread[i]->start(thr_name, stack, stacksize);
   }
 
-  n_ethreads += n_threads;
   Debug("iocore_thread", "Created thread group '%s' id %d with %d threads", tg->_name.get(), ev_type, n_threads);
 
   return ev_type; // useless but not sure what would be better.


### PR DESCRIPTION
The support for NUMA based stacks was lost in the #1997 PR due to the length of time of the work - it was added after work started and I didn't notice it until too late. This adds that back and also provides additional comments on the logic.