### PR TITLE
Prevent infinite loop in ssl handshake for unknown names.

### DIFF
--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -1437,8 +1437,7 @@ SSLNetVConnection::callHooks(TSEvent eventId)
   Debug("ssl", "callHooks sslHandshakeHookState=%d", this->sslHandshakeHookState);
 
   // First time through, set the type of the hook that is currently being invoked
-  if ((this->sslHandshakeHookState == HANDSHAKE_HOOKS_PRE || this->sslHandshakeHookState == HANDSHAKE_HOOKS_DONE) &&
-      eventId == TS_EVENT_SSL_CERT) {
+  if (this->sslHandshakeHookState == HANDSHAKE_HOOKS_PRE && eventId == TS_EVENT_SSL_CERT) {
     // the previous hook should be DONE and set curHook to nullptr before trigger the sni hook.
     ink_assert(curHook == nullptr);
     // set to HOOKS_CERT means CERT/SNI hooks has called by SSL_accept()


### PR DESCRIPTION
This fixes a problem where ATS enters an infinite loop trying
to lookup certificates for domains that don't exist when you have
a plugin hook that lazy loads certificates.

This change needs to be backported to 7.1.x since it was
introduced in https://github.com/apache/trafficserver/commit/712eedb1dbd52cbb941625db807ab778852a7ef4

@shinrich can you please review this change?

Signed-off-by: David Calavera <david.calavera@gmail.com>