### PR TITLE
Make HTTP2 Windows Update with invalid stream id a stream error

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -690,7 +690,7 @@ rcv_window_update_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
       if (cstate.is_valid_streamid(stream_id)) {
         return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_NONE);
       } else {
-        return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR,
+        return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_STREAM, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR,
                           "window update stream invalid id");
       }
     }


### PR DESCRIPTION
Trying to debug bad behavior loading a page with many small images from Firefox, we noticed the following pairs of messages in diags.log

```
[Jun 15 21:59:26.334] Server {0x2aeb79a31700} ERROR: HTTP/2 stream error client_ip=98.139.254.60 session_id=1968 recv headers creating stream beyond max_concurrent limit
[Jun 15 21:59:26.334] Server {0x2aeb79a31700} ERROR: HTTP/2 connection error client_ip=98.139.254.60 session_id=1968 window update stream invalid id
```

The max_concurrent stream error is not surprising. The browser is probably asking for 100's of streams at once and ATS is sending the max_concurrent error back to throttle, but the "windows update stream invalid id" connection error is surprising. I assume that the client already had a window update frame in flight before learning that the new stream request had been updated due to being of the max concurrent limit. ATS is treating this as a connection error which takes down the whole session. The probably is causing in part the performance problems in Firefox.

I looked over the spec again, and it isn't clear to me that we are required to treat a such a stream-based windows update failure as a connection failure.  Seems harmless enough to cut the client some slack.