### PR TITLE
Explicit std:: name space, seems to make compiler happy

### DIFF
--- a/cmd/traffic_manager/metrics.cc
+++ b/cmd/traffic_manager/metrics.cc
@@ -21,6 +21,8 @@
  *  limitations under the License.
  */
 
+#include <cmath>
+
 #include "ts/ink_config.h"
 #include "ts/ink_memory.h"
 #include "ts/Ptr.h"
@@ -102,7 +104,7 @@ struct Evaluator {
       case RECD_FLOAT:
         // Lua will eval 0/0 to NaN rather than 0.
         rec_value.rec_float = lua_tonumber(L, -1);
-        if (isnan(rec_value.rec_float)) {
+        if (std::isnan(rec_value.rec_float)) {
           rec_value.rec_float = 0.0;
         }
         break;

--- a/configure.ac
+++ b/configure.ac
@@ -1553,7 +1553,6 @@ AC_CHECK_HEADERS([sys/types.h \
                   stropts.h \
                   sys/param.h \
                   sys/sysmacros.h \
-                  math.h \
                   stdint.h \
                   stdbool.h \
                   sysexits.h \

--- a/iocore/cache/CacheTest.cc
+++ b/iocore/cache/CacheTest.cc
@@ -26,6 +26,7 @@
 #include "P_CacheTest.h"
 #include "api/ts/ts.h"
 #include <vector>
+#include <cmath>
 
 using namespace std;
 

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -33,6 +33,7 @@
 #include "ts/I_Layout.h"
 
 #include <cstring>
+#include <cmath>
 #include "P_Net.h"
 #include "P_SSLConfig.h"
 #include "P_SSLUtils.h"

--- a/lib/ts/ink_platform.h
+++ b/lib/ts/ink_platform.h
@@ -186,9 +186,7 @@ typedef unsigned int in_addr_t;
 #ifdef HAVE_DLFCN_H
 #include <dlfcn.h>
 #endif
-#ifdef HAVE_MATH_H
-#include <math.h>
-#endif
+
 #ifdef HAVE_FLOAT_H
 #include <float.h>
 #endif

--- a/proxy/CoreUtils.cc
+++ b/proxy/CoreUtils.cc
@@ -103,7 +103,6 @@ int program_counter = 0;
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <math.h>
 #include "ts/ink_platform.h"
 #include "CoreUtils.h"
 #endif /* darwin || freebsd || solaris */
@@ -112,6 +111,7 @@ int program_counter = 0;
 #include "http/HttpSM.h"
 
 #include <cstdlib>
+#include <cmath>
 
 bool inTable;
 FILE *fp;

--- a/proxy/CoreUtils.h
+++ b/proxy/CoreUtils.h
@@ -37,7 +37,6 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
-#include <math.h>
 #include <assert.h>
 #include <elf.h>
 #include "ts/DynArray.h"
@@ -62,7 +61,6 @@ struct core_stack_state {
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
-#include <math.h>
 #include <assert.h>
 
 #define NO_OF_ARGS                                             \

--- a/proxy/congest/CongestionTest.cc
+++ b/proxy/congest/CongestionTest.cc
@@ -28,7 +28,6 @@
  *
  ****************************************************************************/
 #include "ts/ink_platform.h"
-#include <math.h>
 #include "Main.h"
 #include "CongestionDB.h"
 #include "Congestion.h"

--- a/proxy/logstats.cc
+++ b/proxy/logstats.cc
@@ -36,7 +36,6 @@
 #include "LogObject.h"
 #include "hdrs/HTTP.h"
 
-#include <math.h>
 #include <sys/utsname.h>
 #if defined(solaris)
 #include <sys/types.h>
@@ -51,6 +50,7 @@
 #include <algorithm>
 #include <vector>
 #include <list>
+#include <cmath>
 #include <functional>
 #include <fcntl.h>
 #include <unordered_map>

--- a/tools/jtest/jtest.cc
+++ b/tools/jtest/jtest.cc
@@ -41,9 +41,9 @@
 #include <poll.h>
 #include <netinet/tcp.h>
 #include <sys/resource.h>
-#include <math.h>
 #include <limits.h>
 #include <sys/mman.h>
+#include <cmath>
 
 #include <inttypes.h>
 


### PR DESCRIPTION
This also cleans up the mess around math.h vs cmath on the includes,
this was necessary to make all platforms and compilers happy.