### PR TITLE
Update H2 priority tree node with a created stream

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -282,6 +282,7 @@ rcv_headers_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
     DependencyTree::Node *node = cstate.dependency_tree->find(stream_id);
     if (node != nullptr) {
       stream->priority_node = node;
+      node->t               = stream;
     } else {
       DebugHttp2Stream(cstate.ua_session, stream_id, "PRIORITY - dep: %d, weight: %d, excl: %d, tree size: %d",
                        params.priority.stream_dependency, params.priority.weight, params.priority.exclusive_flag,


### PR DESCRIPTION
Priority tree node was not updated if the node was created with a PRIORITY frame.
This fixes h2spec:3.3.2 Sends a PRIORITY frame with priority 256