### PR TITLE
Limit HPACK indexing table size correctly

### DIFF
--- a/proxy/http2/HPACK.h
+++ b/proxy/http2/HPACK.h
@@ -169,12 +169,13 @@ int64_t decode_indexed_header_field(MIMEFieldWrapper &header, const uint8_t *buf
                                     HpackIndexingTable &indexing_table);
 int64_t decode_literal_header_field(MIMEFieldWrapper &header, const uint8_t *buf_start, const uint8_t *buf_end,
                                     HpackIndexingTable &indexing_table);
-int64_t update_dynamic_table_size(const uint8_t *buf_start, const uint8_t *buf_end, HpackIndexingTable &indexing_table);
+int64_t update_dynamic_table_size(const uint8_t *buf_start, const uint8_t *buf_end, HpackIndexingTable &indexing_table,
+                                  uint32_t maximum_table_size);
 
 // High level interfaces
 typedef HpackIndexingTable HpackHandle;
 int64_t hpack_decode_header_block(HpackHandle &handle, HTTPHdr *hdr, const uint8_t *in_buf, const size_t in_buf_len,
-                                  uint32_t max_header_size);
+                                  uint32_t max_header_size, uint32_t maximum_table_size);
 int64_t hpack_encode_header_block(HpackHandle &handle, uint8_t *out_buf, const size_t out_buf_len, HTTPHdr *hdr,
                                   int32_t maximum_table_size = -1);
 int32_t hpack_get_maximum_table_size(HpackHandle &handle);

--- a/proxy/http2/HTTP2.cc
+++ b/proxy/http2/HTTP2.cc
@@ -609,13 +609,13 @@ http2_encode_header_blocks(HTTPHdr *in, uint8_t *out, uint32_t out_len, uint32_t
  */
 Http2ErrorCode
 http2_decode_header_blocks(HTTPHdr *hdr, const uint8_t *buf_start, const uint32_t buf_len, uint32_t *len_read, HpackHandle &handle,
-                           bool &trailing_header)
+                           bool &trailing_header, uint32_t maximum_table_size)
 {
   const MIMEField *field;
   const char *value;
   int len;
   bool is_trailing_header = trailing_header;
-  int64_t result          = hpack_decode_header_block(handle, hdr, buf_start, buf_len, Http2::max_request_header_size);
+  int64_t result = hpack_decode_header_block(handle, hdr, buf_start, buf_len, Http2::max_request_header_size, maximum_table_size);
 
   if (result < 0) {
     if (result == HPACK_ERROR_COMPRESSION_ERROR) {

--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -350,7 +350,7 @@ bool http2_parse_goaway(IOVec, Http2Goaway &);
 
 bool http2_parse_window_update(IOVec, uint32_t &);
 
-Http2ErrorCode http2_decode_header_blocks(HTTPHdr *, const uint8_t *, const uint32_t, uint32_t *, HpackHandle &, bool &);
+Http2ErrorCode http2_decode_header_blocks(HTTPHdr *, const uint8_t *, const uint32_t, uint32_t *, HpackHandle &, bool &, uint32_t);
 
 Http2ErrorCode http2_encode_header_blocks(HTTPHdr *, uint8_t *, uint32_t, uint32_t *, HpackHandle &, int32_t);
 

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -318,7 +318,8 @@ rcv_headers_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
       empty_request = true;
     }
 
-    Http2ErrorCode result = stream->decode_header_blocks(*cstate.local_hpack_handle);
+    Http2ErrorCode result =
+      stream->decode_header_blocks(*cstate.local_hpack_handle, cstate.server_settings.get(HTTP2_SETTINGS_HEADER_TABLE_SIZE));
 
     if (result != Http2ErrorCode::HTTP2_ERROR_NO_ERROR) {
       if (result == Http2ErrorCode::HTTP2_ERROR_COMPRESSION_ERROR) {
@@ -791,7 +792,8 @@ rcv_continuation_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
                         "continuation no state change");
     }
 
-    Http2ErrorCode result = stream->decode_header_blocks(*cstate.local_hpack_handle);
+    Http2ErrorCode result =
+      stream->decode_header_blocks(*cstate.local_hpack_handle, cstate.server_settings.get(HTTP2_SETTINGS_HEADER_TABLE_SIZE));
 
     if (result != Http2ErrorCode::HTTP2_ERROR_NO_ERROR) {
       if (result == Http2ErrorCode::HTTP2_ERROR_COMPRESSION_ERROR) {

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -138,10 +138,10 @@ Http2Stream::main_event_handler(int event, void *edata)
 }
 
 Http2ErrorCode
-Http2Stream::decode_header_blocks(HpackHandle &hpack_handle)
+Http2Stream::decode_header_blocks(HpackHandle &hpack_handle, uint32_t maximum_table_size)
 {
   return http2_decode_header_blocks(&_req_header, (const uint8_t *)header_blocks, header_blocks_length, nullptr, hpack_handle,
-                                    trailing_header);
+                                    trailing_header, maximum_table_size);
 }
 
 void

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -135,7 +135,7 @@ public:
     return content_length == 0 || content_length == data_length;
   }
 
-  Http2ErrorCode decode_header_blocks(HpackHandle &hpack_handle);
+  Http2ErrorCode decode_header_blocks(HpackHandle &hpack_handle, uint32_t maximum_table_size);
   void send_request(Http2ConnectionState &cstate);
   VIO *do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf) override;
   VIO *do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *abuffer, bool owner = false) override;

--- a/proxy/http2/RegressionHPACK.cc
+++ b/proxy/http2/RegressionHPACK.cc
@@ -30,6 +30,7 @@ const static int DYNAMIC_TABLE_SIZE_FOR_REGRESSION_TEST = 256;
 const static int BUFSIZE_FOR_REGRESSION_TEST            = 128;
 const static int MAX_TEST_FIELD_NUM                     = 8;
 const static int MAX_REQUEST_HEADER_SIZE                = 131072;
+const static int MAX_TABLE_SIZE                         = 4096;
 
 /***********************************************************************************
  *                                                                                 *
@@ -549,7 +550,7 @@ REGRESSION_TEST(HPACK_Decode)(RegressionTest *t, int, int *pstatus)
     headers->create(HTTP_TYPE_REQUEST);
 
     hpack_decode_header_block(indexing_table, headers, encoded_field_request_test_case[i].encoded_field,
-                              encoded_field_request_test_case[i].encoded_field_len, MAX_REQUEST_HEADER_SIZE);
+                              encoded_field_request_test_case[i].encoded_field_len, MAX_REQUEST_HEADER_SIZE, MAX_TABLE_SIZE);
 
     for (unsigned int j = 0; j < sizeof(raw_field_request_test_case[i]) / sizeof(raw_field_request_test_case[i][0]); j++) {
       const char *expected_name  = raw_field_request_test_case[i][j].raw_name;

--- a/proxy/http2/test_HPACK.cc
+++ b/proxy/http2/test_HPACK.cc
@@ -33,6 +33,7 @@
 #include "ts/TestBox.h"
 
 const static int MAX_REQUEST_HEADER_SIZE = 131072;
+const static int MAX_TABLE_SIZE          = 4096;
 
 using namespace std;
 
@@ -197,7 +198,7 @@ test_decoding(const string &filename)
       case 'w':
         parse_line(line, 6, name, value);
         unpacked_len = unpack(value, unpacked);
-        hpack_decode_header_block(indexing_table, &decoded, unpacked, unpacked_len, MAX_REQUEST_HEADER_SIZE);
+        hpack_decode_header_block(indexing_table, &decoded, unpacked, unpacked_len, MAX_REQUEST_HEADER_SIZE, MAX_TABLE_SIZE);
         break;
       }
       break;
@@ -252,7 +253,8 @@ test_encoding(const string &filename_in, const string &filename_out)
             result = seqnum;
             break;
           }
-          hpack_decode_header_block(indexing_table_for_decoding, &decoded, encoded, written, MAX_REQUEST_HEADER_SIZE);
+          hpack_decode_header_block(indexing_table_for_decoding, &decoded, encoded, written, MAX_REQUEST_HEADER_SIZE,
+                                    MAX_TABLE_SIZE);
           if (compare_header_fields(&decoded, &original) != 0) {
             result = seqnum;
             break;
@@ -297,7 +299,7 @@ test_encoding(const string &filename_in, const string &filename_out)
     result = seqnum;
     return result;
   }
-  hpack_decode_header_block(indexing_table_for_decoding, &decoded, encoded, written, MAX_REQUEST_HEADER_SIZE);
+  hpack_decode_header_block(indexing_table_for_decoding, &decoded, encoded, written, MAX_REQUEST_HEADER_SIZE, MAX_TABLE_SIZE);
   if (compare_header_fields(&decoded, &original) != 0) {
     result = seqnum;
     return result;


### PR DESCRIPTION
ATS advertises the maximum table size but it allowed clients to update the table size larger than the advertised value.
This fixes h2spec test 6.3.1: Sends a dynamic table size update larger than the value of SETTINGS_HEADER_TABLE_SIZE