### PR TITLE
Removing inert code: LogFile::do_filesystem_checks()

### DIFF
--- a/proxy/logging/LogFile.cc
+++ b/proxy/logging/LogFile.cc
@@ -193,14 +193,6 @@ LogFile::open_file()
     }
   }
 
-  int e = do_filesystem_checks();
-  if (e != 0) {
-    m_fd = -1; // reset to error condition
-    delete m_log;
-    m_log = nullptr;
-    return LOG_FILE_FILESYSTEM_CHECKS_FAILED;
-  }
-
   //
   // If we've opened the file and it didn't already exist, then this is a
   // "new" file and we need to make some initializations.  This is the

--- a/proxy/logging/LogFile.h
+++ b/proxy/logging/LogFile.h
@@ -102,13 +102,6 @@ public:
       return 0;
   }
 
-  // TODO: this need to be tidy up when to redo the file checking
-  int
-  do_filesystem_checks()
-  {
-    return 0;
-  }
-
 public:
   bool is_open();
   void close_file();

--- a/proxy/logging/LogHost.cc
+++ b/proxy/logging/LogHost.cc
@@ -464,14 +464,3 @@ LogHostList::operator==(LogHostList &rhs)
   }
   return true;
 }
-
-int
-LogHostList::do_filesystem_checks()
-{
-  for (LogHost *host = first(); host; host = next(host)) {
-    if (host->do_filesystem_checks() < 0) {
-      return -1;
-    }
-  }
-  return 0;
-}

--- a/proxy/logging/LogHost.h
+++ b/proxy/logging/LogHost.h
@@ -99,13 +99,6 @@ public:
     return m_orphan_file.get();
   }
 
-  // check if we will be able to write orphan file
-  int
-  do_filesystem_checks()
-  {
-    return m_orphan_file->do_filesystem_checks();
-  }
-
 private:
   void clear();
   bool authenticated();
@@ -163,7 +156,6 @@ public:
 
   void display(FILE *fd = stdout);
   bool operator==(LogHostList &rhs);
-  int do_filesystem_checks();
 
   // -- member functions not allowed --
   LogHostList(const LogHostList &) = delete;

--- a/proxy/logging/LogObject.cc
+++ b/proxy/logging/LogObject.cc
@@ -791,18 +791,6 @@ LogObject::check_buffer_expiration(long time_now)
   }
 }
 
-// make sure that we will be able to write the logs to the disk
-//
-int
-LogObject::do_filesystem_checks()
-{
-  if (m_logFile) {
-    return m_logFile->do_filesystem_checks();
-  } else {
-    return m_host_list.do_filesystem_checks();
-  }
-}
-
 /*-------------------------------------------------------------------------
   TextLogObject::TextLogObject
   -------------------------------------------------------------------------*/
@@ -901,14 +889,7 @@ LogObjectManager::_manage_object(LogObject *log_object, bool is_api_object, int 
     if (col_client || (retVal = _solve_filename_conflicts(log_object, maxConflicts), retVal == NO_FILENAME_CONFLICTS)) {
       // do filesystem checks
       //
-      if (log_object->do_filesystem_checks() < 0) {
-        const char *msg = "The log file %s did not pass filesystem checks. "
-                          "No output will be produced for this log";
-        Error(msg, log_object->get_full_filename());
-        LogUtils::manager_alarm(LogUtils::LOG_ALARM_ERROR, msg, log_object->get_full_filename());
-        retVal = ERROR_DOING_FILESYSTEM_CHECKS;
-
-      } else {
+      {
         // no conflicts, add object to the list of managed objects
         //
         REF_COUNT_OBJ_REFCOUNT_INC(log_object);

--- a/proxy/logging/LogObject.h
+++ b/proxy/logging/LogObject.h
@@ -263,7 +263,6 @@ public:
   }
 
   bool operator==(LogObject &rhs);
-  int do_filesystem_checks();
 
 public:
   bool m_auto_created;


### PR DESCRIPTION
This code has been disabled since 
   65477944 - Leif Hedstrom        2015-03-21
Now I kill it with fire.
I think it has been replaced with LogFile::check_fd().