### PR TITLE
TS-4044: The server_vc should be established (writeable) before request transform start.

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -4959,21 +4959,27 @@ HttpSM::do_http_server_open(bool raw)
     connect_action_handle = sslNetProcessor.connect_re(this,                                 // state machine
                                                        &t_state.current.server->dst_addr.sa, // addr + port
                                                        &opt);
-  } else if (t_state.method != HTTP_WKSIDX_CONNECT) {
+  } else if (t_state.method != HTTP_WKSIDX_CONNECT && t_state.method != HTTP_WKSIDX_POST && t_state.method != HTTP_WKSIDX_PUT) {
     DebugSM("http", "calling netProcessor.connect_re");
     connect_action_handle = netProcessor.connect_re(this,                                 // state machine
                                                     &t_state.current.server->dst_addr.sa, // addr + port
                                                     &opt);
   } else {
-    // CONNECT method
+    // The request transform would be applied to POST and/or PUT request.
+    // The server_vc should be established (writeable) before request transform start.
+    // The CheckConnect is created by connect_s,
+    //   It will callback NET_EVENT_OPEN to HttpSM if server_vc is WRITE_READY,
+    //   Otherwise NET_EVENT_OPEN_FAILED is callbacked.
     MgmtInt connect_timeout;
 
-    ink_assert(t_state.method == HTTP_WKSIDX_CONNECT);
+    ink_assert(t_state.method == HTTP_WKSIDX_CONNECT || t_state.method == HTTP_WKSIDX_POST || t_state.method == HTTP_WKSIDX_PUT);
 
     // Set the inactivity timeout to the connect timeout so that we
     // we fail this server if it doesn't start sending the response
     // header
-    if (t_state.current.server == &t_state.parent_info) {
+    if (t_state.method == HTTP_WKSIDX_POST || t_state.method == HTTP_WKSIDX_PUT) {
+      connect_timeout = t_state.txn_conf->post_connect_attempts_timeout;
+    } else if (t_state.current.server == &t_state.parent_info) {
       connect_timeout = t_state.txn_conf->parent_connect_timeout;
     } else if (t_state.pCongestionEntry != nullptr) {
       connect_timeout = t_state.pCongestionEntry->connect_timeout();


### PR DESCRIPTION
The request transform would be applied to POST and/or PUT request.
The server_vc should be established (writeable) before request transform start.
The CheckConnect is created by connect_s,
  It will callback NET_EVENT_OPEN to HttpSM if server_vc is WRITE_READY,
  Otherwise NET_EVENT_OPEN_FAILED is callbacked.