### PR TITLE
The content-type of TRACE response should be message/http.

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -5416,6 +5416,7 @@ HttpTransact::handle_trace_and_options_requests(State *s, HTTPHdr *incoming_hdr)
       done = incoming_hdr->print(s->internal_msg_buffer, s->internal_msg_buffer_size, &used, &offset);
       HTTP_RELEASE_ASSERT(done);
       s->internal_msg_buffer_size = used;
+      s->internal_msg_buffer_type = ats_strdup("message/http");
 
       s->hdr_info.client_response.set_content_length(used);
     } else {


### PR DESCRIPTION
https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html

```
9.8 TRACE

The TRACE method is used to invoke a remote, application-layer loop- back of the request message. The final recipient of the request SHOULD reflect the message received back to the client as the entity-body of a 200 (OK) response. The final recipient is either the

origin server or the first proxy or gateway to receive a Max-Forwards value of zero (0) in the request (see section 14.31). A TRACE request MUST NOT include an entity.

TRACE allows the client to see what is being received at the other end of the request chain and use that data for testing or diagnostic information. The value of the Via header field (section 14.45) is of particular interest, since it acts as a trace of the request chain. Use of the Max-Forwards header field allows the client to limit the length of the request chain, which is useful for testing a chain of proxies forwarding messages in an infinite loop.

If the request is valid, the response SHOULD contain the entire request message in the entity-body, with a Content-Type of "message/http". Responses to this method MUST NOT be cached.
```

To reproduce:
```
root@xuc:~# telnet <ATS IP> 8080
Trying x.x.x.x...
Connected to x.x.x.x.
Escape character is '^]'.
TRACE / HTTP/1.1
Host: www.test.com
Max-Forwards: 0

HTTP/1.1 200 OK
Date: Fri, 23 Jun 2017 11:53:26 GMT
Connection: close
Content-Length: 82
Content-Type: text/html

TRACE http://www.test.com/ HTTP/1.1
Host: www.test.com
Max-Forwards: 0

Connection closed by foreign host.
```