### PR TITLE
ATS doesn't respond to HEAD request if the origin server is down

### DIFF
--- a/proxy/http/HttpBodyFactory.cc
+++ b/proxy/http/HttpBodyFactory.cc
@@ -138,11 +138,6 @@ HttpBodyFactory::fabricate_with_old_api(const char *type, HttpTransact::State *c
   // if failed, try to fabricate the default custom response //
   /////////////////////////////////////////////////////////////
   if (buffer == nullptr) {
-    if (is_response_body_precluded(context->http_return_code, context->method)) {
-      *resulting_buffer_length = 0;
-      unlock();
-      return nullptr;
-    }
     buffer = fabricate(&acpt_language_list, &acpt_charset_list, "default", context, resulting_buffer_length, &lang_ptr,
                        &charset_ptr, &set);
   }
@@ -411,8 +406,6 @@ HttpBodyFactory::fabricate(StrList *acpt_language_list, StrList *acpt_charset_li
     set = determine_set_by_language(acpt_language_list, acpt_charset_list);
   } else if (enable_customizations == 3) {
     set = determine_set_by_host(context);
-  } else if (is_response_body_precluded(context->http_return_code, context->method)) {
-    return nullptr;
   } else {
     set = "default";
   }
@@ -431,9 +424,6 @@ HttpBodyFactory::fabricate(StrList *acpt_language_list, StrList *acpt_charset_li
 
   // Check for base customizations if specializations didn't work.
   if (t == nullptr) {
-    if (is_response_body_precluded(context->http_return_code, context->method)) {
-      return nullptr;
-    }
     t = find_template(set, type, &body_set); // this executes if the template_base is wrong and doesn't exist
   }
 

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -6119,10 +6119,10 @@ HttpSM::setup_100_continue_transfer()
 void
 HttpSM::setup_error_transfer()
 {
-  if (t_state.internal_msg_buffer || t_state.http_return_code == HTTP_STATUS_NO_CONTENT) {
+  if (t_state.internal_msg_buffer) {
     // Since we need to send the error message, call the API
     //   function
-    ink_assert(t_state.internal_msg_buffer_size > 0 || t_state.http_return_code == HTTP_STATUS_NO_CONTENT);
+    ink_assert(t_state.internal_msg_buffer_size > 0);
     t_state.api_next_action = HttpTransact::SM_ACTION_API_SEND_RESPONSE_HDR;
     do_api_callout();
   } else {
@@ -6196,7 +6196,8 @@ HttpSM::setup_internal_transfer(HttpSMHandler handler_arg)
   // --> do not append the message onto the MIOBuffer and keep our pointer
   // to it so that it can be freed.
 
-  if (is_msg_buf_present && t_state.method != HTTP_WKSIDX_HEAD) {
+  if (is_msg_buf_present && t_state.method != HTTP_WKSIDX_HEAD &&
+      t_state.hdr_info.client_response.status_get() != HTTP_STATUS_NO_CONTENT) {
     nbytes += t_state.internal_msg_buffer_size;
 
     if (t_state.internal_msg_buffer_fast_allocator_size < 0) {


### PR DESCRIPTION
#2173 
It simply revert some code from #2042 .

I don't think we need to use is_response_body_precluded in fabricate_with_old_api, because the head request may be ignored and set length with 0 in fabricate_with_old_api or fabricate. Then ats close vc directly.

Checking response's status in setup_error_transfer is a better choice if we want to ignore the body .