### PR TITLE
Better initialization in Thread.cc.

### DIFF
--- a/iocore/eventsystem/Thread.cc
+++ b/iocore/eventsystem/Thread.cc
@@ -35,10 +35,17 @@
 // Common Interface impl                     //
 ///////////////////////////////////////////////
 
-static ink_thread_key init_thread_key();
+ink_hrtime Thread::cur_time = ink_get_hrtime_internal();
+inkcoreapi ink_thread_key Thread::thread_data_key;
 
-ink_hrtime Thread::cur_time                       = ink_get_hrtime_internal();
-inkcoreapi ink_thread_key Thread::thread_data_key = init_thread_key();
+namespace
+{
+static bool initialized = ([]() -> bool {
+  // File scope initialization goes here.
+  ink_thread_key_create(&Thread::thread_data_key, nullptr);
+  return true;
+})();
+}
 
 Thread::Thread()
 {
@@ -52,13 +59,6 @@ Thread::~Thread()
   ink_release_assert(mutex->thread_holding == (EThread *)this);
   mutex->nthread_holding -= THREAD_MUTEX_THREAD_HOLDING;
   MUTEX_UNTAKE_LOCK(mutex, (EThread *)this);
-}
-
-ink_thread_key
-init_thread_key()
-{
-  ink_thread_key_create(&Thread::thread_data_key, nullptr);
-  return Thread::thread_data_key;
 }
 
 ///////////////////////////////////////////////


### PR DESCRIPTION
Currently `thread_data_key` is initialized by calling a local function that initializes and then hands it back so it can be assigned again even though it's already initialized. This changes the file scope initialization to be lambda based which simply does the initialization logic without the extra assignment complexity. Any additional initialization is simply placed inside the lambda as well.