### PR TITLE
Adding DNS over TCP support 

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -2422,6 +2422,20 @@ DNS
    in DNS Injection attacks), particularly in forward or transparent proxies, but
    requires that the resolver populates the queries section of the response properly.
 
+.. ts:cv:: CONFIG proxy.config.dns.connection_mode INT 0
+
+   Three connection modes between |TS| and nameservers can be set -- UDP_ONLY,
+   TCP_RETRY, TCP_ONLY.
+
+
+   ===== ======================================================================
+   Value Description
+   ===== ======================================================================
+   ``0`` UDP_ONLY:  |TS| always talks to nameservers over UDP.
+   ``1`` TCP_RETRY: |TS| first UDP, retries with TCP if UDP response is truncated.
+   ``2`` TCP_ONLY:  |TS| always talks to nameservers over TCP.
+   ===== ======================================================================
+
 HostDB
 ======
 

--- a/iocore/dns/DNSConnection.cc
+++ b/iocore/dns/DNSConnection.cc
@@ -33,6 +33,7 @@
 
 #define SET_TCP_NO_DELAY
 #define SET_NO_LINGER
+#define SET_SO_KEEPALIVE
 // set in the OS
 // #define RECV_BUF_SIZE            (1024*64)
 // #define SEND_BUF_SIZE            (1024*64)
@@ -84,6 +85,8 @@ DNSConnection::connect(sockaddr const *addr, Options const &opt)
 {
   ink_assert(fd == NO_FD);
   ink_assert(ats_is_ip(addr));
+  this->opt = opt;
+  this->tcp_data.reset();
 
   int res = 0;
   short Proto;

--- a/iocore/dns/P_DNSConnection.h
+++ b/iocore/dns/P_DNSConnection.h
@@ -32,11 +32,13 @@
 #define __P_DNSCONNECTION_H__
 
 #include "I_EventSystem.h"
+#include "I_DNSProcessor.h"
 
 //
 // Connection
 //
 struct DNSHandler;
+enum class DNS_CONN_MODE { UDP_ONLY, TCP_RETRY, TCP_ONLY };
 
 struct DNSConnection {
   /// Options for connecting.
@@ -75,10 +77,25 @@ struct DNSConnection {
   int fd;
   IpEndpoint ip;
   int num;
+  Options opt;
   LINK(DNSConnection, link);
   EventIO eio;
   InkRand generator;
   DNSHandler *handler;
+
+  /// TCPData structure is to track the reading progress of a TCP connection
+  struct TCPData {
+    Ptr<HostEnt> buf_ptr;
+    unsigned short total_length = 0;
+    unsigned short done_reading = 0;
+    void
+    reset()
+    {
+      buf_ptr.clear();
+      total_length = 0;
+      done_reading = 0;
+    }
+  } tcp_data;
 
   int connect(sockaddr const *addr, Options const &opt = DEFAULT_OPTIONS);
   /*

--- a/iocore/dns/P_DNSProcessor.h
+++ b/iocore/dns/P_DNSProcessor.h
@@ -188,7 +188,8 @@ struct DNSHandler : public Continuation {
   IpEndpoint local_ipv4; ///< Local V4 address if set.
   int ifd[MAX_NAMED];
   int n_con;
-  DNSConnection con[MAX_NAMED];
+  DNSConnection tcpcon[MAX_NAMED];
+  DNSConnection udpcon[MAX_NAMED];
   Queue<DNSEntry> entries;
   Queue<DNSConnection> triggered;
   int in_flight;
@@ -250,7 +251,8 @@ struct DNSHandler : public Continuation {
   int startEvent_sdns(int event, Event *e);
   int mainEvent(int event, Event *e);
 
-  void open_con(sockaddr const *addr, bool failed = false, int icon = 0);
+  void open_cons(sockaddr const *addr, bool failed = false, int icon = 0);
+  void open_con(sockaddr const *addr, bool failed = false, int icon = 0, bool over_tcp = false);
   void failover();
   void rr_failure(int ndx);
   void recover();
@@ -329,7 +331,8 @@ DNSHandler::DNSHandler()
     failover_soon_number[i]    = 0;
     crossed_failover_number[i] = 0;
     ns_down[i]                 = 1;
-    con[i].handler             = this;
+    tcpcon[i].handler          = this;
+    udpcon[i].handler          = this;
   }
   memset(&qid_in_flight, 0, sizeof(qid_in_flight));
   SET_HANDLER(&DNSHandler::startEvent);

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -931,6 +931,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.dns.dedicated_thread", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_NULL, "[0-1]", RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.dns.connection.mode", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_NULL, "[0-2]", RECA_NULL}
+  ,
   {RECT_CONFIG, "proxy.config.hostdb.ip_resolve", RECD_STRING, nullptr, RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
 


### PR DESCRIPTION
In so many scenarios, a 512 byte UDP package is far from enough for DNS responses in modern productions. Our peer Nginx also started to enable DNS over TCP about one year and a half ago.

The PR introduces the TCP support and defines three different connection modes:
- UDP_ONLY
- TCP_RETRY
- TCP_ONLY

When the mode is set to TCP_RETRY, ATS will retry a DNS query if the response has the `Truncated`  flag set, which is a similar behavior that can be observed when using `dig` and `bind DNS`. 

I understand there will be a lot to improve in this PR. Please feel free to leave your comments here. Thanks!