### PR TITLE
H2 test with traffic -replay

### DIFF
--- a/tests/bootstrap.py
+++ b/tests/bootstrap.py
@@ -27,7 +27,8 @@ import sys
 
 pip_packages = [
     "autest",
-    "hyper"
+    "hyper",
+    "requests"
 ]
 
 

--- a/tests/gold_tests/h2/gold/replay.gold
+++ b/tests/gold_tests/h2/gold/replay.gold
@@ -1,0 +1,5 @@
+``
+PASS
+PASS
+PASS
+``

--- a/tests/gold_tests/h2/http2.test.py
+++ b/tests/gold_tests/h2/http2.test.py
@@ -100,3 +100,11 @@ tr.Processes.Default.Command = 'python3 h2chunked.py -p {0}  -u /{1}'.format(ts.
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/chunked.gold"
 tr.StillRunningAfter = server
+
+# Test Case 4: Multiple request
+client_path= os.path.join(Test.Variables.AtsTestToolsDir,'traffic-replay/')
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = "python3 {0} -type {1} -log_dir {2} -port {3} -host '127.0.0.1' -s_port {4} -v -colorize False".format(client_path, 'h2', server.Variables.DataDir, ts.Variables.port,ts.Variables.ssl_port)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = "gold/replay.gold"
+tr.StillRunningAfter = server

--- a/tests/tools/traffic-replay/Config.py
+++ b/tests/tools/traffic-replay/Config.py
@@ -18,8 +18,8 @@
 #  limitations under the License.
 
 # SSL config
-ca_certs = "/path/to/certfile"
-keyfile = "/path/to/keyfile"
+ca_certs = None
+keyfile = None
 
 # Proxy config
 proxy_host = "127.0.0.1"
@@ -29,3 +29,6 @@ proxy_nonssl_port = 8080
 # process and thread config
 nProcess = 4
 nThread = 4
+
+#colorize output
+colorize = True

--- a/tests/tools/traffic-replay/NonSSL.py
+++ b/tests/tools/traffic-replay/NonSSL.py
@@ -17,7 +17,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import gevent
 import socket
 import requests
 import os

--- a/tests/tools/traffic-replay/RandomReplay.py
+++ b/tests/tools/traffic-replay/RandomReplay.py
@@ -17,7 +17,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import gevent
 import socket
 import requests
 import os

--- a/tests/tools/traffic-replay/SSLReplay.py
+++ b/tests/tools/traffic-replay/SSLReplay.py
@@ -21,7 +21,6 @@ import http.client
 import socket
 import ssl
 import pprint
-import gevent
 import requests
 import os
 #import threading
@@ -30,7 +29,6 @@ from multiprocessing import current_process
 import sessionvalidation.sessionvalidation as sv
 import lib.result as result
 import extractHeader
-from gevent import monkey, sleep
 from threading import Thread
 import mainProcess
 import json
@@ -197,7 +195,8 @@ def session_replay(input, proxy, result_queue):
             txn_req_headers = req.getHeaders()
             txn_req_headers_dict = extractHeader.header_to_dict(txn_req_headers)
             sc = ssl.SSLContext(protocol=ssl.PROTOCOL_SSLv23)
-            sc.load_cert_chain(Config.ca_certs, keyfile=Config.keyfile)
+            if Config.ca_certs != None and Config.keyfile != None:
+                sc.load_cert_chain(Config.ca_certs, keyfile=Config.keyfile)
             conn = ProxyHTTPSConnection(Config.proxy_host, Config.proxy_ssl_port, cert_file=Config.ca_certs,
                                         key_file=Config.keyfile, context=sc, server_name=txn_req_headers_dict['Host'])
             for txn in session.getTransactionIter():

--- a/tests/tools/traffic-replay/Scheduler.py
+++ b/tests/tools/traffic-replay/Scheduler.py
@@ -21,7 +21,6 @@ import time
 import random
 import json
 from multiprocessing import Process, Queue, current_process
-from progress.bar import Bar
 import sessionvalidation.sessionvalidation as sv
 import WorkerTask
 import time

--- a/tests/tools/traffic-replay/WorkerTask.py
+++ b/tests/tools/traffic-replay/WorkerTask.py
@@ -25,7 +25,6 @@ import sys
 from multiprocessing import current_process
 import sessionvalidation.sessionvalidation as sv
 import lib.result as result
-from progress.bar import Bar
 import extractHeader
 import NonSSL
 import SSLReplay

--- a/tests/tools/traffic-replay/__main__.py
+++ b/tests/tools/traffic-replay/__main__.py
@@ -20,16 +20,23 @@
 from __future__ import absolute_import, division, print_function
 import mainProcess
 import argparse
+import Config
 
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-type", action='store', dest='replay_type', help="Replay type: ssl/random/h2")
+    parser.add_argument("-type", action='store', dest='replay_type', help="Replay type: ssl/random/h2/nossl")
     parser.add_argument("-log_dir", type=str, help="directory of JSON replay files")
     parser.add_argument("-v", dest="verbose", help="verify response status code", action="store_true")
+    parser.add_argument("-host", help="proxy/host to send the requests to",default=Config.proxy_host)
+    parser.add_argument("-port",type=int,help=" The non secure port of ATS to send the request to",default=Config.proxy_nonssl_port)
+    parser.add_argument("-s_port",type=int,help="secure port",default=Config.proxy_ssl_port)
+    parser.add_argument("-ca_cert",help="Certificate to present",default=Config.ca_certs)
+    parser.add_argument("-colorize",type=str,help="specify whether to use colorize the output",default='True')
 
     args = parser.parse_args()
 
     # Let 'er loose
     #main(args.log_dir, args.hostname, int(args.port), args.threads, args.timing, args.verbose)
-    mainProcess.main(args.log_dir, args.replay_type, args.verbose)
+    Config.colorize = True if args.colorize == 'True' else False
+    mainProcess.main(args.log_dir, args.replay_type, args.verbose, pHost = args.host, pNSSLport = args.port, pSSL = args.s_port)

--- a/tests/tools/traffic-replay/h2Replay.py
+++ b/tests/tools/traffic-replay/h2Replay.py
@@ -17,7 +17,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import gevent
 import os
 from threading import Thread
 import sys
@@ -318,7 +317,7 @@ def session_replay(input, proxy, result_queue):
                         expected_output = (int(expected_output_split[1]), str(expected_output_split[2]))
                         r = result.Result("", expected_output[0], response.status)
                         expected_Dict = extractHeader.responseHeader_to_dict(expectedH.getHeaders())
-                        print(r.getResultString(response_dict, expected_Dict, colorize=True))
+                        print(r.getResultString(response_dict, expected_Dict, colorize=Config.colorize))
                         # r.Compare(response_dict,expected_Dict)
 
         bSTOP = True

--- a/tests/tools/traffic-replay/mainProcess.py
+++ b/tests/tools/traffic-replay/mainProcess.py
@@ -29,7 +29,17 @@ import subprocess
 import shlex
 from multiprocessing import Pool, Process
 from collections import deque
-from progress.bar import Bar
+#from progress.bar import Bar
+
+sys.path.append(
+    os.path.normpath(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            '..'
+        )
+    )
+)
+
 import sessionvalidation.sessionvalidation as sv
 import lib.result as result
 import WorkerTask
@@ -55,9 +65,12 @@ def check_for_ats(hostname, port):
 # Hopefully this isn't an issue because multi-line headers are deprecated now
 
 
-def main(path, replay_type, Bverbose):
+def main(path, replay_type, Bverbose, pHost = Config.proxy_host, pNSSLport = Config.proxy_nonssl_port, pSSL = Config.proxy_ssl_port):
     global verbose
     verbose = Bverbose
-    check_for_ats(Config.proxy_host, Config.proxy_nonssl_port)
+    check_for_ats(pHost, pNSSLport)
+    Config.proxy_host = pHost
+    Config.proxy_nonssl_port = pNSSLport
+    Config.proxy_ssl_port = pSSL
     proxy = {"http": "http://{0}:{1}".format(Config.proxy_host, Config.proxy_nonssl_port)}
     Scheduler.LaunchWorkers(path, Config.nProcess, proxy, replay_type, Config.nThread)


### PR DESCRIPTION
This patch : 
- Uses traffic replay as h2 client for sending multiple requests
- removes unnecessary imports
- fixes config to make it usable with autest