### PR TITLE
Fix LIBTCL and HWLOC_LIBS linking for traffic_top for Ubuntu.

### DIFF
--- a/cmd/traffic_top/Makefile.am
+++ b/cmd/traffic_top/Makefile.am
@@ -42,7 +42,8 @@ traffic_top_LDADD = \
   $(top_builddir)/mgmt/api/libtsmgmt.la \
   $(top_builddir)/lib/ts/libtsutil.la \
   @CURL_LIBS@ \
-  @CURSES_LIBS@
+  @CURSES_LIBS@ \
+  @LIBTCL@ @HWLOC_LIBS@
 
 endif
 


### PR DESCRIPTION
Based on prior patch TS-3109.