### PR TITLE
In adjust_sys_settings(), if we try to adjust the NOFILE limit due to

### DIFF
--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -1107,7 +1107,7 @@ adjust_sys_settings()
 
   if (getrlimit(RLIMIT_NOFILE, &lim) == 0) {
     if (fds_throttle > (int)(lim.rlim_cur - THROTTLE_FD_HEADROOM)) {
-      lim.rlim_cur = (lim.rlim_max = (rlim_t)fds_throttle);
+      lim.rlim_cur = (lim.rlim_max = (rlim_t)(fds_throttle + THROTTLE_FD_HEADROOM));
       if (setrlimit(RLIMIT_NOFILE, &lim) == 0 && getrlimit(RLIMIT_NOFILE, &lim) == 0) {
         fds_limit = (int)lim.rlim_cur;
         syslog(LOG_NOTICE, "NOTE: RLIMIT_NOFILE(%d):cur(%d),max(%d)", RLIMIT_NOFILE, (int)lim.rlim_cur, (int)lim.rlim_max);


### PR DESCRIPTION
(fds_throttle > limit - THROTTLE_FD_HEADROOM), then try to set
the new limit to (fds_throttle + THROTTLE_FD_HEADROOM) instead of
just (fds_throttle) since the latter will always result in
fds_throttle being reduced in check_fd_limit() later.

This issue is under discussion with @oknet in the dev mailing list.