### PR TITLE
Be less aggressive in calling SSL_shutdown.

### DIFF
--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -824,7 +824,11 @@ SSLNetVConnection::do_io_close(int lerrno)
     char c;
     ssize_t x = recv(this->con.fd, &c, 1, MSG_PEEK);
     // x < 0 means error.  x == 0 means fin sent
-    if (x != 0) {
+    bool do_shutdown = (x > 0);
+    if (x < 0) {
+      do_shutdown = (errno == EAGAIN || errno == EWOULDBLOCK);
+    }
+    if (do_shutdown) {
       // Send the close-notify
       int ret = SSL_shutdown(ssl);
       Debug("ssl-shutdown", "SSL_shutdown %s", (ret) ? "success" : "failed");


### PR DESCRIPTION
Maybe helps avoid the crash described in issue #2212 