### PR TITLE
Don't skip TLS marker on protocol string error.

### DIFF
--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -1551,25 +1551,30 @@ SSLNetVConnection::populate(Connection &con, Continuation *c, void *arg)
 ts::StringView
 SSLNetVConnection::map_tls_protocol_to_tag(const char *proto_string) const
 {
-  // Prefix for the string the SSL library hands back.
-  static const ts::StringView PREFIX("TLSv1", ts::StringView::literal);
+  // tag to use if something goes wrong with fetching the TLS protocol string.
+  static constexpr ts::StringView UNKNOWN("tls/?.?", ts::StringView::literal);
 
-  ts::StringView retval;
-  ts::StringView proto(proto_string);
+  ts::StringView retval{UNKNOWN}; // return this if the protocol lookup doesn't work.
 
-  if (PREFIX.isNoCasePrefixOf(proto)) {
-    proto += PREFIX.size(); // skip the prefix part.
-    if (proto.size() <= 0) {
-      retval = IP_PROTO_TAG_TLS_1_0;
-    } else if (*proto == '.') {
-      ++proto; // skip .
-      if (proto.size() == 1) {
-        if (*proto == '1') {
+  if (proto_string) {
+    // openSSL guarantees the case of the protocol string.
+    if (proto_string[0] == 'T' && proto_string[1] == 'L' && proto_string[2] == 'S' && proto_string[3] == 'v' &&
+        proto_string[4] == '1') {
+      if (proto_string[5] == 0) {
+        retval = IP_PROTO_TAG_TLS_1_0;
+      } else if (proto_string[5] == '.' && proto_string[7] == 0) {
+        switch (proto_string[6]) {
+        case '1':
           retval = IP_PROTO_TAG_TLS_1_1;
-        } else if (*proto == '2') {
+          break;
+        case '2':
           retval = IP_PROTO_TAG_TLS_1_2;
-        } else if (*proto == '3') {
+          break;
+        case '3':
           retval = IP_PROTO_TAG_TLS_1_3;
+          break;
+        default:
+          break;
         }
       }
     }


### PR DESCRIPTION
Fix protocol stack to return unknown TLS string instead of eliding it in case of error. It is better to have a bogus tag in the protocol stack than to elide the fact that the connection negotiated TLS.