### PR TITLE
#2220 use parsed_hosts_file_ptr only if it has valid value

### DIFF
--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -2306,7 +2306,8 @@ ParseHostFile(const char *path, unsigned int hostdb_hostfile_check_interval)
   }
 
   // Swap the pointer
-  hostDB.hosts_file_ptr = parsed_hosts_file_ptr;
+  if (parsed_hosts_file_ptr != nullptr)
+    hostDB.hosts_file_ptr = parsed_hosts_file_ptr;
   // Mark this one as completed, so we can allow another update to happen
   HostDBFileUpdateActive = 0;
 }


### PR DESCRIPTION
https://github.com/apache/trafficserver/issues/2220

When ATS is configured to use a hosts file (via proxy.config.hostdb.host_file.path) and fails to open it, there's a crash:
#0 0x00000000006e4ccc in std::_Rb_tree<ts::ConstBuffer, std::pair<ts::ConstBuffer const, IpAddr>, std::_Select1st<std::pair<ts::ConstBuffer const, IpAddr> >, CmpConstBuffferCaseInsensitive, std::allocator<std::pair<ts::ConstBuffer const, IpAddr> > >::_M_begin (this=0x10) at /usr/include/c++/4.9/bits/stl_tree.h:518
#1 0x00000000006e4f05 in std::_Rb_tree<ts::ConstBuffer, std::pair<ts::ConstBuffer const, IpAddr>, std::_Select1st<std::pair<ts::ConstBuffer const, IpAddr> >, CmpConstBuffferCaseInsensitive, std::allocator<std::pair<ts::ConstBuffer const, IpAddr> > >::find (this=0x10, __k=...) at /usr/include/c++/4.9/bits/stl_tree.h:1913
#2 0x00000000006e48a9 in std::map<ts::ConstBuffer, IpAddr, CmpConstBuffferCaseInsensitive, std::allocator<std::pair<ts::ConstBuffer const, IpAddr> > >::find (this=0x10, __x=...)
at /usr/include/c++/4.9/bits/stl_map.h:860
#3 0x00000000006dd237 in HostDBContinuation::do_dns (this=0x7f8e1a9d65e0) at HostDB.cc:1993
#4 0x00000000006dcd91 in HostDBContinuation::probeEvent (this=0x7f8e1a9d65e0, e=0x7f8df0252b00) at HostDB.cc:1932
#5 0x000000000050ce28 in Continuation::handleEvent (this=0x7f8e1a9d65e0, event=2, data=0x7f8df0252b00) at ../iocore/eventsystem/I_Continuation.h:153
#6 0x00000000007b7d11 in EThread::process_event (this=0x7f8e16c0a010, e=0x7f8df0252b00, calling_code=2) at UnixEThread.cc:148
#7 0x00000000007b8120 in EThread::execute (this=0x7f8e16c0a010) at UnixEThread.cc:230
#8 0x00000000007b72bb in spawn_thread_internal (a=0x1612870) at Thread.cc:86
#9 0x00007f8e193eb6ba in start_thread (arg=0x7f8e161ff700) at pthread_create.c:333
#10 0x00007f8e1867582d in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:109

Found on ATS 6.2.1 but looks applicable to current master.