### PR TITLE
make autest use the new port selection method

### DIFF
--- a/tests/bootstrap.py
+++ b/tests/bootstrap.py
@@ -175,7 +175,8 @@ def venv_cmds(path):
     return [
         # first command only needed for rhel and centos systems at this time
         extra + " virtualenv --python=python3 {0}".format(path),
-        extra + " {0}/bin/pip install pip --upgrade".format(path)
+        extra + " {0}/bin/pip install pip --upgrade".format(path),
+        extra + "export PATH=$PATH:/usr/sbin"
     ]
 
 

--- a/tests/gold_tests/autest-site/ports.py
+++ b/tests/gold_tests/autest-site/ports.py
@@ -20,6 +20,7 @@ import socket
 import subprocess
 import sys
 import hosts.output as host
+import os
 
 try:
     import queue as Queue
@@ -57,6 +58,8 @@ def setup_port_queue(amount=1000):
     else:
         return
     try:
+        thisEnv = os.environ;
+        thisEnv["PATH"] = "/usr/sbin:/sbin:"+thisEnv["PATH"]
         comm = subprocess.check_output(["which","sysctl"]).decode()[:-1]
         dmin, dmax = subprocess.check_output(
             [comm, "net.ipv4.ip_local_port_range"]).decode().split("=")[1].split()

--- a/tests/gold_tests/autest-site/ports.py
+++ b/tests/gold_tests/autest-site/ports.py
@@ -18,6 +18,8 @@
 
 import socket
 import subprocess
+import sys
+import hosts.output as host
 
 try:
     import queue as Queue
@@ -55,11 +57,13 @@ def setup_port_queue(amount=1000):
     else:
         return
     try:
+        comm = subprocess.check_output(["which","sysctl"]).decode()[:-1]
         dmin, dmax = subprocess.check_output(
-            ["sysctl", "net.ipv4.ip_local_port_range"]).decode().split("=")[1].split()
+            [comm, "net.ipv4.ip_local_port_range"]).decode().split("=")[1].split()
         dmin = int(dmin)
         dmax = int(dmax)
     except:
+        host.WriteMessagef("Exception{0}:{1}".format(sys.exc_info()[0],sys.exc_info()[1]))
         return
 
     rmin = dmin - 2000


### PR DESCRIPTION
The random port binding failure is happening due to Autest not using the new port selection method at all because it can not find sysctl. The exception in the setup_port_queue returns without printing any information, which made it difficult to debug. Again, this problem does not show up on any of my local machines, so I have to make trial and error commits to see what makes it work in the CI. 

@dragon512 probably can help me on how to correctly add /usr/sbin (which is where sysctl might be in the CI) to the PATH variable. 