### PR TITLE
Alloc PollCont and UDPNetHandler before call initialize_thread_for_udp_net

### DIFF
--- a/iocore/net/UnixUDPNet.cc
+++ b/iocore/net/UnixUDPNet.cc
@@ -92,12 +92,12 @@ UDPNetProcessorInternal::start(int n_upd_threads, size_t stacksize)
     return -1;
   }
 
+  pollCont_offset      = eventProcessor.allocate(sizeof(PollCont));
+  udpNetHandler_offset = eventProcessor.allocate(sizeof(UDPNetHandler));
+
   ET_UDP = eventProcessor.register_event_type("ET_UDP");
   eventProcessor.schedule_spawn(&initialize_thread_for_udp_net, ET_UDP);
   eventProcessor.spawn_event_threads(ET_UDP, n_upd_threads, stacksize);
-
-  pollCont_offset      = eventProcessor.allocate(sizeof(PollCont));
-  udpNetHandler_offset = eventProcessor.allocate(sizeof(UDPNetHandler));
 
   return 0;
 }


### PR DESCRIPTION
To avoid race of `eventProcessor.allocate(sizeof(PollCont))` vs `new ((ink_dummy_for_new *)get_UDPPollCont(thread)) PollCont(thread->mutex)`

Fix #2226
