### PR TITLE
Return 408 response with specified header

### DIFF
--- a/tests/gold_tests/headers/http408.gold
+++ b/tests/gold_tests/headers/http408.gold
@@ -1,0 +1,22 @@
+HTTP/1.1 408`` 
+Date:``
+Connection: close
+Server:``
+Cache-Control: no-store
+Content-Type: text/html; charset=utf-8
+Content-Language: en
+
+<HTML>
+<HEAD>
+<TITLE>Inactivity Timeout</TITLE>
+</HEAD>
+
+<BODY BGCOLOR="white" FGCOLOR="black">
+<H1>Inactivity Timeout</H1>
+<HR>
+
+<FONT FACE="Helvetica,Arial"><B>
+Description: Too much time has passed without sending any data for document.
+</B></FONT>
+<HR>
+</BODY>

--- a/tests/gold_tests/headers/http408.test.py
+++ b/tests/gold_tests/headers/http408.test.py
@@ -1,0 +1,58 @@
+'''
+Test the 408 reponse header. 
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import subprocess
+
+Test.Summary = '''
+Check 408 response header for protocol stack data.
+'''
+
+Test.SkipUnless(
+)
+Test.ContinueOnFail = True
+
+# Define default ATS
+ts = Test.MakeATSProcess("ts")
+server = Test.MakeOriginServer("server")
+
+testName = "408 test"
+
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+server.addResponse("sessionlog.json", request_header, response_header)
+
+ts.Disk.remap_config.AddLine(
+    'map http://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port)
+    )
+
+ts.Disk.records_config.update({
+    'proxy.config.http.transaction_no_activity_timeout_in' : 2,
+    })
+
+Test.Setup.Copy(os.path.join(os.pardir, os.pardir, 'tools', 'tcp_408_client.py'))
+
+tr = Test.AddTestRun()
+tr.Processes.Default.StartBefore(server)
+tr.Processes.Default.StartBefore(Test.Processes.ts)
+tr.Processes.Default.Command = 'python tcp_408_client.py 127.0.0.1 {0} 4'.format(
+    ts.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.TimeOut = 10
+tr.Processes.Default.Streams.stdout = "http408.gold"

--- a/tests/tools/tcp_408_client.py
+++ b/tests/tools/tcp_408_client.py
@@ -1,0 +1,63 @@
+'''
+A simple command line interface to send/receive bytes over TCP.
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import argparse
+import socket
+import sys
+import time
+
+def tcp_client(host, port, sleep, header, data):
+    pass
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.connect((host, port))
+    s.sendall(header.encode())
+    s.sendall(data[0].encode())
+    time.sleep(sleep)
+    s.shutdown(socket.SHUT_WR)
+    while True:
+        output = s.recv(4096)  # suggested bufsize from docs.python.org
+        if len(output) <= 0:
+            break
+        else:
+            sys.stdout.write(output.decode())
+    s.close()
+
+
+DESCRIPTION =\
+    """A simple command line interface to send/receive bytes over TCP.
+
+The full contents of the given file are sent via a TCP connection to the given
+host and port. Then data is read from the connection and printed to standard
+output. Streaming is not supported."""
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.add_argument('host', help='the target host')
+    parser.add_argument('port', type=int, help='the target port')
+    parser.add_argument('sleep', type=int, help='timeout')
+    args = parser.parse_args()
+
+    header = 'POST / HTTP/1.1\r\nHost: www.example.com\r\nContent-Length: 2\r\n\r\n'
+    data = "aa"
+    tcp_client(args.host, args.port, args.sleep, header, data)
+
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
Fixed #1607 

We prefer to return the header which builded in build_error_response rather than static 408 header.

By the way, there is a problem in my first fix. I want to use call_transact_and_set_next_state() to get into the Transaction, and send response data just like HttpTransact::BadRequest. So we can hack the response in SEND_RESPONSE_HOOK.
We usually takes over control of the vc with do_io_xxx . And we should not call transaction directly. Because, in HttpSM::tunnel_handler_post_ua, the tunnel is still running before we return to HttpTunnel::main_handler.

So rescheduling the event again may be a good choice , but not smoothly. So I throw it out !
```
void
HttpTransact::BadRequest(State *s)
{
  DebugTxn("http_trans", "[BadRequest]"
                         "parser marked request bad");
  bootstrap_state_variables_from_request(s, &s->hdr_info.client_request);
  build_error_response(s, HTTP_STATUS_BAD_REQUEST, "Invalid HTTP Request", "request#syntax_error");
  TRANSACT_RETURN(SM_ACTION_SEND_ERROR_CACHE_NOOP, nullptr);
}
``` 

