### PR TITLE
Update inactivity if total_written is more than 0

### DIFF
--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -506,6 +506,7 @@ write_to_net_io(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
   if (total_written > 0) {
     NET_SUM_DYN_STAT(net_write_bytes_stat, total_written);
     s->vio.ndone += total_written;
+    net_activity(vc, thread);
   }
 
   // A write of 0 makes no sense since we tried to write more than 0.
@@ -540,8 +541,6 @@ write_to_net_io(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
     if (!(buf.reader()->is_read_avail_more_than(0))) {
       vc->write_buffer_empty_event = 0;
     }
-
-    net_activity(vc, thread);
 
     // If there are no more bytes to write, signal write complete,
     ink_assert(ntodo >= 0);


### PR DESCRIPTION
In `UnixNetVConnection:: write_to_net_io()`, when `load_buffer_and_write()` returns error, `net_activity()` is never called and inactivity is not updated.
But inactivity should be updated if `load_buffer_and_write()` write some data regardless return value.

Fix #2232
