### PR TITLE
Adjust ssl read loops for POST timeouts

### DIFF
--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -994,14 +994,6 @@ SSLNetVConnection::sslStartHandShake(int event, int &err)
       } else {
         clientCTX = params->client_ctx;
       }
-
-      if (this->options.clientVerificationFlag && params->clientCACertFilename != nullptr && params->clientCACertPath != nullptr) {
-        if (!SSL_CTX_load_verify_locations(clientCTX, params->clientCACertFilename, params->clientCACertPath)) {
-          SSLError("invalid client CA Certificate file (%s) or CA Certificate path (%s)", params->clientCACertFilename,
-                   params->clientCACertPath);
-          return EVENT_ERROR;
-        }
-      }
       this->ssl = make_ssl_connection(clientCTX, this);
 
       if (this->ssl == nullptr) {

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1234,6 +1234,7 @@ UnixNetVConnection::mainEvent(int event, Event *e)
     // ink_assert(next_inactivity_timeout_at < Thread::get_hrtime());
     if (!inactivity_timeout_in || next_inactivity_timeout_at > Thread::get_hrtime())
       return EVENT_CONT;
+    Warning("next_inactivity %" PRId64 " current time %" PRId64, next_inactivity_timeout_at, Thread::get_hrtime());
     signal_event      = VC_EVENT_INACTIVITY_TIMEOUT;
     signal_timeout_at = &next_inactivity_timeout_at;
   } else {

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -3611,7 +3611,7 @@ HttpSM::tunnel_handler_post_ua(int event, HttpTunnelProducer *p)
     //   timeouts
     ua_entry->vc_handler = &HttpSM::state_watch_for_client_abort;
     ua_entry->read_vio   = p->vc->do_io_read(this, INT64_MAX, ua_buffer_reader->mbuf);
-    ua_session->set_inactivity_timeout(0);
+    //ua_session->set_inactivity_timeout(0);
     break;
   default:
     ink_release_assert(0);
@@ -3698,7 +3698,7 @@ HttpSM::tunnel_handler_post_server(int event, HttpTunnelConsumer *c)
     //  on the user agent in order to get timeouts
     //  coming to the state machine and not the tunnel
     ua_entry->vc_handler = &HttpSM::state_watch_for_client_abort;
-    ua_session->set_inactivity_timeout(0);
+    //ua_session->set_inactivity_timeout(0);
 
     // YTS Team, yamsat Plugin
     // When event is VC_EVENT_ERROR,and when redirection is enabled

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -3611,6 +3611,7 @@ HttpSM::tunnel_handler_post_ua(int event, HttpTunnelProducer *p)
     //   timeouts
     ua_entry->vc_handler = &HttpSM::state_watch_for_client_abort;
     ua_entry->read_vio   = p->vc->do_io_read(this, INT64_MAX, ua_buffer_reader->mbuf);
+    ua_session->set_inactivity_timeout(0);
     break;
   default:
     ink_release_assert(0);
@@ -3697,6 +3698,7 @@ HttpSM::tunnel_handler_post_server(int event, HttpTunnelConsumer *c)
     //  on the user agent in order to get timeouts
     //  coming to the state machine and not the tunnel
     ua_entry->vc_handler = &HttpSM::state_watch_for_client_abort;
+    ua_session->set_inactivity_timeout(0);
 
     // YTS Team, yamsat Plugin
     // When event is VC_EVENT_ERROR,and when redirection is enabled


### PR DESCRIPTION
Taking over from PR #2242.  Taking @maskit  and @oknet  comments to break up the read loop to fill at most one buffer block before giving control back to event loop.  Keeping read triggered if there is more to be read, so hopefully there will not be needless waiting (probably the cause of my original slow upload problems).

Also added logic to set inactivity timeout to 0 on UA side after the user agent has sent all of its data.  Not 100% sure this is what we want to do.  It did solve my reproduction case, but I think pdm's case is different.  Threw it in to help debugging.

Also backed up one commit temporarily to push along debugging.  That commit is not part of the final solution.