### PR TITLE
Add diagram for header_rewrite Hooks

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -881,6 +881,24 @@ them take any operands::
 Because hook conditions must be the first condition in a ruleset, the use of
 one forces the beginning of a new ruleset.
 
+.. graphviz::
+   :alt: header rewrite hooks
+
+   digraph header_rewrite_hooks {
+     graph [rankdir = LR];
+     node[shape=record];
+
+     Client[height=4, label="{ Client|{<p1>|<p2>} }"];
+     ATS[height=4, fontsize=10,label="{ {{<clientside0>Global:\nREAD_REQUEST_PRE_REMAP_HOOK|<clientside01>Global:\nREAD_REQUEST_HDR_HOOK\nRemap rule:\nREMAP_PSEUDO_HOOK}|<clientside1>SEND_RESPONSE_HDR_HOOK}|ATS |{<originside0>SEND_REQUEST_HDR_HOOK|<originside1>READ_RESPONSE_HDR_HOOK} }",xlabel="ATS"];
+     Origin[height=4, label="{ {<request>|<response>}|Origin }"];
+
+     Client:p1 -> ATS:clientside0 [ label = "Request" ];
+     ATS:originside0 -> Origin:request [ label="proxied request" ];
+
+     Origin:response -> ATS:originside1 [ label="origin response" ];
+     ATS:clientside1 -> Client:p2 [ label = "Response" ];
+   }
+
 READ_REQUEST_HDR_HOOK
 ~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The header_rewrite hooks are confusing. Perhaps a diagram will help people grok them?
![webgraphviz](https://user-images.githubusercontent.com/387053/28145450-3a9ad326-6727-11e7-96d0-09edbe40b595.jpg)
