### PR TITLE
Fix for URL obj leak in HTTP2 server push upon calling TSHttpTxnServerPush #2275

### DIFF
--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -7641,6 +7641,7 @@ TSHttpTxnServerPush(TSHttpTxn txnp, const char *url, int url_len)
   URL url_obj;
   url_obj.create(nullptr);
   if (url_obj.parse(url, url_len) == PARSE_RESULT_ERROR) {
+    url_obj.destroy();
     return;
   }
   HttpSM *sm          = reinterpret_cast<HttpSM *>(txnp);
@@ -7648,6 +7649,7 @@ TSHttpTxnServerPush(TSHttpTxn txnp, const char *url, int url_len)
   if (stream) {
     stream->push_promise(url_obj);
   }
+  url_obj.destroy();
 }
 
 TSReturnCode

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1515,6 +1515,7 @@ Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url)
   Http2Error error(Http2ErrorClass::HTTP2_ERROR_CLASS_NONE);
   stream = this->create_stream(id, error);
   if (!stream) {
+    h2_hdr.destroy();
     return;
   }
   if (Http2::stream_priority_enabled) {


### PR DESCRIPTION
Fix for URL obj leak in HTTP2 server push upon calling TSHttpTxnServerPush
https://github.com/apache/trafficserver/issues/2275