### PR TITLE
Add next-hop self detection (Issue #2269)

### DIFF
--- a/iocore/utils/I_Machine.h
+++ b/iocore/utils/I_Machine.h
@@ -33,6 +33,7 @@
 
 #include "ts/ink_inet.h"
 #include "ts/ink_uuid.h"
+#include "ts/ink_hash_table.h"
 
 /**
   The Machine is a simple place holder for the hostname and the ip
@@ -79,11 +80,18 @@ struct Machine {
                     );
   /// @return The global instance of this class.
   static self *instance();
+  bool is_self(const char *name);
+  bool is_self(const IpAddr *ipaddr);
+  void insert_id(char *id);
+  void insert_id(IpAddr *ipaddr);
 
 protected:
   Machine(char const *hostname, sockaddr const *addr);
 
   static self *_instance; ///< Singleton for the class.
+
+  InkHashTable *machine_id_strings;
+  InkHashTable *machine_id_ipaddrs;
 };
 
 #endif

--- a/proxy/ParentSelection.h
+++ b/proxy/ParentSelection.h
@@ -134,6 +134,7 @@ public:
 
   const char *scheme = nullptr;
   // private:
+  void PreProcessParents(const char *val, const int line_num, char *buf, size_t len);
   const char *ProcessParents(char *val, bool isPrimary);
   bool ignore_query                                                  = false;
   volatile uint32_t rr_next                                          = 0;


### PR DESCRIPTION
Please have a look at this PR.  I chose to remove any references to self in the parent list when creating the parent_record at the time parent.config is read.  Uses information known to traffic server at startup, Machine.hostname and Machine.ip_string.

This fixes Issue #2269.