### PR TITLE
H2 Assertsion at Http2DependencyTree::deactivate

### DIFF
--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -274,7 +274,7 @@ private:
   //   is CLOSED.
   //   If given Stream Identifier is not found in stream_list and it is greater
   //   than latest_streamid_in, the state of Stream is IDLE.
-  DLL<Http2Stream> stream_list;
+  Queue<Http2Stream> stream_list;
   Http2StreamId latest_streamid_in  = 0;
   Http2StreamId latest_streamid_out = 0;
   int stream_requests               = 0;

--- a/proxy/http2/Http2DependencyTree.h
+++ b/proxy/http2/Http2DependencyTree.h
@@ -316,8 +316,6 @@ Http2DependencyTree<T>::deactivate(Node *node, uint32_t sent)
   node->active = false;
 
   while (node->queue->empty() && node->parent != NULL) {
-    ink_assert(node->parent->queue->top() == node->entry);
-
     node->parent->queue->pop();
     node->queued = false;
 

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -153,8 +153,6 @@ public:
   ssize_t client_rwnd;
   ssize_t server_rwnd = Http2::initial_window_size;
 
-  LINK(Http2Stream, link);
-
   uint8_t *header_blocks        = nullptr;
   uint32_t header_blocks_length = 0;  // total length of header blocks (not include
                                       // Padding or other fields)


### PR DESCRIPTION
Fixed #2208 

H2 Assert fails sometimes at Http2DependencyTree::deactivate.

There is a problem, when we received the reprioritize frame. The priority queue will be changed.
This event will happen again, when client abort.

<b>This pr only fixes the trigger by h2load</b>.

By the way,  @masaori335 why do we use this assertion? :-)