### PR TITLE
Cleanup / correct buffer sizes for UUIDs

### DIFF
--- a/doc/developer-guide/api/functions/TSUuidCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSUuidCreate.en.rst
@@ -88,8 +88,9 @@ object, but it does not need to be previously initialized.
 
 Finally, :func:`TSClientRequestUuidGet` can be used to extract
 the client request uuid from a transaction. The output buffer must be of
-sufficient length, minimum of ``TS_CRUUID_STRING_LEN``. This produces the same
-string as the log tag %<cruuid> generates.
+sufficient length, minimum of ``TS_CRUUID_STRING_LEN`` + 1 bytes. This
+produces the same string as the log tag %<cruuid> generates, and it will
+be NULL terminated.
 
 Return Values
 =============

--- a/lib/ts/apidefs.h.in
+++ b/lib/ts/apidefs.h.in
@@ -1204,7 +1204,7 @@ typedef enum {
 } TSUuidVersion;
 
 #define TS_UUID_STRING_LEN 36
-#define TS_CRUUID_STRING_LEN (TS_UUID_STRING_LEN + 20 + 1) /* UUID-len + len(int64_t) + '-' */
+#define TS_CRUUID_STRING_LEN (TS_UUID_STRING_LEN + 19 + 1) /* UUID-len + len(uint64_t) + '-' */
 typedef struct tsapi_uuid *TSUuid;
 
 #ifdef __cplusplus

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -9287,7 +9287,7 @@ TSClientRequestUuidGet(TSHttpTxn txnp, char *uuid_str)
   const char *machine = (char *)Machine::instance()->uuid.getString();
   int len;
 
-  len = snprintf(uuid_str, TS_CRUUID_STRING_LEN, "%s-%" PRId64 "", machine, sm->sm_id);
+  len = snprintf(uuid_str, TS_CRUUID_STRING_LEN + 1, "%s-%" PRId64 "", machine, sm->sm_id);
   if (len > TS_CRUUID_STRING_LEN) {
     return TS_ERROR;
   }

--- a/proxy/logging/LogAccessHttp.cc
+++ b/proxy/logging/LogAccessHttp.cc
@@ -812,20 +812,18 @@ LogAccessHttp::marshal_client_req_id(char *buf)
 int
 LogAccessHttp::marshal_client_req_uuid(char *buf)
 {
+  char str[TS_CRUUID_STRING_LEN + 1];
+  const char *uuid = Machine::instance()->uuid.getString();
+  int len          = snprintf(str, sizeof(str), "%s-%" PRId64 "", uuid, m_http_sm->sm_id);
+
+  ink_assert(len <= TS_CRUUID_STRING_LEN);
+  len = round_strlen(len + 1);
+
   if (buf) {
-    char str[TS_CRUUID_STRING_LEN + 1];
-    const char *uuid = (char *)Machine::instance()->uuid.getString();
-    int len;
-
-    len = snprintf(str, sizeof(str), "%s-%" PRId64 "", uuid, m_http_sm->sm_id);
-    ink_assert(len < (int)sizeof(str));
-
-    len = round_strlen(len + 1);
-    marshal_str(buf, str, len);
-    return len;
+    marshal_str(buf, str, len); // This will pad the remaning bytes properly ...
   }
 
-  return round_strlen(TS_CRUUID_STRING_LEN + 1);
+  return len;
 }
 
 /*-------------------------------------------------------------------------


### PR DESCRIPTION
I don't think this is particular critical, but it feels more correct.