### PR TITLE
Test: Fix TLS test plugin compile error for Fedora 26.

### DIFF
--- a/tests/tools/plugins/ssl_hook_test.cc
+++ b/tests/tools/plugins/ssl_hook_test.cc
@@ -29,6 +29,7 @@
 #include <ts/remap.h>
 #include <getopt.h>
 #include <openssl/ssl.h>
+#include <strings.h>
 
 #define PN "ssl_hook_test"
 #define PCP "[" PN " Plugin] "


### PR DESCRIPTION
For some reason `strings.h` is needed for `index` on Fedora 26 but not elsewhere. It doesn't hurt so just add it.