### PR TITLE
Fix origin requests to default to HTTP 1.1

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -3022,6 +3022,14 @@ HttpTransact::HandleCacheOpenReadMiss(State *s)
   HTTPHdr *h = &s->hdr_info.client_request;
 
   if (!h->is_cache_control_set(HTTP_VALUE_ONLY_IF_CACHED)) {
+    // Initialize the server_info structure if we haven't been through DNS
+    // Otherwise, the http_version will not be initialized
+    if (!s->current.server || !s->current.server->dst_addr.isValid()) {
+      // Short term hack.  get_ka_info_from_config assumes if http_version is > 0,9 it has already been
+      // set and skips the rest of the function.  The default functor sets it to 1,0
+      s->server_info.http_version = HTTPVersion(0, 9);
+      get_ka_info_from_config(s, &s->server_info);
+    }
     find_server_and_update_current_info(s);
     // a parent lookup could come back as PARENT_FAIL if in parent.config go_direct == false and
     // there are no available parents (all down).


### PR DESCRIPTION
To follow proxy.config.http.send_http11_requests setting.  Aaron Canary tracked down our reduction in connection reuse to origin to an increase in HTTP 1.0 requests from ATS to origin.

This regression was caused by commit 762aa98710412ec6fa30878fbbda6890bab1a903 which delayed the DNS look up when opening the cache.  The DNS path was initializing s->server_info.http_version.  Without going down the DNS path the s->server_info.http_version defaulted to HTTP 1.0 which very negatively affected our origin connection reuse going from around 10 requests per connection to 2 or 3 requests per connection.

This code change adds back in the initialization logic in the cache miss case. 

This significantly affects performance and resource utilization so I think it should be considered for 7.1.1