### PR TITLE
Add 'Printer' class for constructing strings/sequences of characters.

### DIFF
--- a/lib/ts/Makefile.am
+++ b/lib/ts/Makefile.am
@@ -23,7 +23,7 @@ library_includedir=$(includedir)/ts
 library_include_HEADERS = apidefs.h
 
 noinst_PROGRAMS = mkdfa CompileParseRules
-check_PROGRAMS = test_tsutil test_arena test_atomic test_freelist test_geometry test_List test_Map test_Vec test_X509HostnameValidator test_MemView test_Scalar
+check_PROGRAMS = test_tsutil test_arena test_atomic test_freelist test_geometry test_List test_Map test_Vec test_X509HostnameValidator test_MemView test_Scalar test_Printer
 
 TESTS_ENVIRONMENT = LSAN_OPTIONS=suppressions=suppression.txt
 
@@ -239,6 +239,8 @@ test_tsutil_SOURCES = \
 
 test_MemView_SOURCES = test_MemView.cc
 test_MemView_LDADD = libtsutil.la
+
+test_Printer_SOURCES = test_Printer.cc
 
 test_Scalar_SOURCES = test_Scalar.cc Scalar.h
 

--- a/lib/ts/Printer.h
+++ b/lib/ts/Printer.h
@@ -1,0 +1,258 @@
+#if !defined TS_PRINTER_H_
+#define TS_PRINTER_H_
+
+/** @file
+
+    Utilities for generating character sequences.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#include <utility>
+#include <cstring>
+
+#include <ts/MemView.h>
+#include <ts/ink_assert.h>
+
+namespace ts
+{
+// Abstract class.
+//
+class BasePrinterIface
+{
+protected:
+  // The _pushBack() functions "add" characters at the end.  If these functions discard any characters, this must put the instance
+  // in an error state (indicated by the override of error() ).  Derived classes must not assume the _pushBack() functions will
+  // not be called when the instance is in an error state.
+
+  virtual void _pushBack(char c) = 0;
+
+  virtual void
+  _pushBack(ts::StringView sV)
+  {
+    for (size_t i = 0; i < sV.size(); ++i) {
+      _pushBack(sV[i]);
+    }
+  }
+
+public:
+  virtual bool error() const = 0;
+
+  template <typename... Args>
+  BasePrinterIface &
+  operator()(const char &c, Args &&... args)
+  {
+    _pushBack(c);
+
+    (*this)(std::forward<Args>(args)...);
+
+    return *this;
+  }
+
+  template <typename... Args>
+  BasePrinterIface &
+  operator()(const ts::StringView &sv, Args &&... args)
+  {
+    _pushBack(sv);
+
+    (*this)(std::forward<Args>(args)...);
+
+    return *this;
+  }
+
+  // Use this member function as a less verbose way to convert a string literal to a StringView and add the contents to the
+  // printed sequence.
+  //
+  template <size_t N, typename... Args>
+  BasePrinterIface &
+  l(const char (&s)[N], Args &&... args)
+  {
+    _pushBack(StringView(s, N - 1)); // Don't print terminal nul at the end of the string literal.
+
+    (*this)(std::forward<Args>(args)...);
+
+    return *this;
+  }
+
+  // Make destructor virtual.
+  //
+  ~BasePrinterIface() {}
+
+private:
+  void
+  operator()()
+  {
+  }
+};
+
+// Abstract class.
+//
+class PrinterIface : public BasePrinterIface
+{
+public:
+  // Returns pointer to an auxiliary buffer.  Succeeding calls to non-const member functions, other than auxBuf(), must be presumed
+  // to invalidate the current auxiliary buffer (contents and address).
+  //
+  virtual char *auxBuf() = 0;
+
+  // Size of auxiliary buffer (number of chars).
+  //
+  virtual size_t auxBufCapacity() const = 0;
+
+  // Print the first n characters that have been placed in the auxiliary buffer.  (This call invalidates the auxiliary buffer.)
+  //
+  virtual void auxPrint(size_t n) = 0;
+};
+
+// A concrete printer that prints into a char array.
+//
+class Printer : public PrinterIface
+{
+public:
+  // Construct an instance, and provide it with a buffer with the given capacity (number of chars) to store the results of printing.
+  //
+  Printer(char *buf, size_t capacity) : _buf(buf), _capacity(capacity), _size(0) {}
+
+  // No copying. (No move constructor/assignment because none for base class.)
+  Printer(const Printer &) = delete;
+  Printer &operator=(const Printer &) = delete;
+
+  StringView
+  sV() const
+  {
+    return StringView(_buf, _size);
+  }
+
+  operator StringView() const { return sV(); }
+
+  size_t
+  capacity() const
+  {
+    return _capacity;
+  }
+
+  size_t
+  size() const
+  {
+    return _size;
+  }
+
+  // Discard characters currently at the end of the buffer.
+  //
+  void
+  resize(size_t smaller_size)
+  {
+    ink_assert(smaller_size <= _size);
+    _size = smaller_size;
+  }
+
+  size_t
+  remain() const
+  {
+    return error() ? 0 : _capacity - _size;
+  }
+
+  char *
+  auxBuf() override
+  {
+    return _buf + _size;
+  }
+
+  size_t
+  auxBufCapacity() const override
+  {
+    return remain();
+  }
+
+  void
+  auxPrint(size_t n) override
+  {
+    ink_assert(n <= auxBufCapacity());
+    _size += n;
+  }
+
+  bool
+  error() const override
+  {
+    return _size > _capacity;
+  }
+
+protected:
+  void
+  _pushBack(char c) override
+  {
+    if (_size >= _capacity) {
+      // Overflow error.
+      //
+      _size = _capacity + 1;
+
+    } else {
+      _buf[_size++] = c;
+    }
+  }
+
+  void
+  _pushBack(ts::StringView sV) override
+  {
+    if ((_size + sV.size()) > _capacity) {
+      // Overflow error.
+      //
+      _size = _capacity + 1;
+
+    } else {
+      std::memcpy(_buf + _size, sV.begin(), sV.size());
+      _size += sV.size();
+    }
+  }
+
+  char *const _buf; // Pointer to buffer that is printed into.
+  const size_t _capacity;
+  size_t _size;
+};
+
+// An encapsulated array of N chars, with a Printer interface.
+//
+template <size_t N> class BuffPrinter : public Printer
+{
+public:
+  BuffPrinter() : Printer(_arr, N) {}
+
+  BuffPrinter(const BuffPrinter &that) : Printer(_arr, N) { *this = that; }
+
+  BuffPrinter &
+  operator=(const BuffPrinter &that)
+  {
+    if (this != &that) {
+      _size = that._size;
+
+      std::memcpy(_arr, that._arr, _size);
+    }
+
+    return (*this);
+  }
+
+  // Move construction/assignment intentionally defaulted to copying.
+
+protected:
+  char _arr[N];
+};
+
+} // end namespace ts
+
+#endif // include once

--- a/lib/ts/test_Printer.cc
+++ b/lib/ts/test_Printer.cc
@@ -1,0 +1,205 @@
+/** @file
+
+    Unit tests for Printer.h.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#include <ts/Printer.h>
+
+#include <ts/test_Simple.h>
+
+#include <ts/MemView.h>
+
+#include <cstring>
+
+using SV = ts::StringView;
+
+bool
+eqSV(SV sV1, SV sV2)
+{
+  return (sV1.size() == sV2.size()) and (memcmp(sV1.ptr(), sV2.ptr(), sV1.size()) == 0);
+}
+
+SV three[] = {SV("a", SV::literal), SV("", SV::literal), SV("bcd", SV::literal)};
+
+TEST("BasePrinterIface::_pushBack(StringView)")
+{
+  class X : public ts::BasePrinterIface
+  {
+    size_t i, j;
+
+  public:
+    bool good;
+
+    X() : i(0), j(0), good(true) {}
+
+    void
+    _pushBack(char c) override
+    {
+      while (j == three[i].size()) {
+        ++i;
+        j = 0;
+      }
+
+      if ((i >= 3) or (c != three[i][j])) {
+        good = false;
+      }
+
+      ++j;
+    }
+
+    bool
+    error() const override
+    {
+      return (false);
+    }
+  };
+
+  X x;
+
+  x(three[0], three[1], three[2]);
+
+  return (x.good);
+}
+
+template <size_t N> using BP = ts::BuffPrinter<N>;
+
+ATEST
+{
+  BP<1> bp;
+
+  if ((bp.capacity() != 1) or (bp.size() != 0) or bp.error() or (bp.auxBufCapacity() != 1)) {
+    return false;
+  }
+
+  bp('#');
+
+  if ((bp.capacity() != 1) or (bp.size() != 1) or bp.error() or (bp.auxBufCapacity() != 0)) {
+    return false;
+  }
+
+  if (!eqSV(bp, SV("#", SV::literal))) {
+    return false;
+  }
+
+  bp('#');
+
+  if (!bp.error()) {
+    return (false);
+  }
+
+  bp.resize(1);
+
+  if ((bp.capacity() != 1) or (bp.size() != 1) or bp.error() or (bp.auxBufCapacity() != 0)) {
+    return false;
+  }
+
+  if (!eqSV(bp, SV("#", SV::literal))) {
+    return false;
+  }
+
+  return true;
+}
+
+ATEST
+{
+  BP<20> bp;
+
+  if ((bp.capacity() != 20) or (bp.size() != 0) or bp.error() or (bp.auxBufCapacity() != 20)) {
+    return false;
+  }
+
+  bp('T');
+
+  if ((bp.capacity() != 20) or (bp.size() != 1) or bp.error() or (bp.auxBufCapacity() != 19)) {
+    return false;
+  }
+
+  if (!eqSV(bp, SV("T", SV::literal))) {
+    return false;
+  }
+
+  bp.l("he")(' ', SV("quick", SV::literal), ' ').l("brown");
+
+  SV tQB("The quick brown", SV::literal);
+
+  if ((bp.capacity() != 20) or bp.error() or (bp.auxBufCapacity() != (20 - tQB.size()))) {
+    return false;
+  }
+
+  if (!eqSV(bp, tQB)) {
+    return false;
+  }
+
+  strcpy(bp.auxBuf(), " fox");
+  bp.auxPrint(sizeof(" fox") - 1);
+
+  if (bp.error()) {
+    return false;
+  }
+
+  SV tQBF("The quick brown fox", SV::literal);
+
+  if (!eqSV(bp, tQBF)) {
+    return false;
+  }
+
+  bp('x');
+
+  if (bp.error()) {
+    return false;
+  }
+
+  bp('x');
+
+  if (!bp.error()) {
+    return false;
+  }
+
+  bp('x');
+
+  if (!bp.error()) {
+    return false;
+  }
+
+  bp.resize(tQBF.size());
+
+  if (bp.error()) {
+    return false;
+  }
+
+  if (!eqSV(bp, tQBF)) {
+    return false;
+  }
+
+  ts::BuffPrinter<20> bp2(bp), bp3;
+
+  bp3 = bp2;
+
+  if (!eqSV(bp2, tQBF)) {
+    return false;
+  }
+
+  if (!eqSV(bp3, tQBF)) {
+    return false;
+  }
+
+  return true;
+}

--- a/lib/ts/test_Simple.h
+++ b/lib/ts/test_Simple.h
@@ -1,0 +1,184 @@
+#if defined TS_TEST_SIMPLE_H_
+
+#error only include once
+
+#else
+
+#define TS_TEST_SIMPLE_H_
+
+#endif
+
+/** @file
+
+    A bare-bones framework for unit testing.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+/*
+Copyright (c) 2016 Walter William Karas
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+struct Test_base;
+
+std::vector<Test_base *> test_list;
+
+// Function to set breakpoints on for debugging
+//
+void
+pre_break()
+{
+}
+
+// Base class for all tests.
+//
+class Test_base
+{
+public:
+  Test_base() : _name(nullptr) { test_list.push_back(this); }
+
+  bool
+  operator()()
+  {
+    pre_break();
+    return test();
+  }
+
+  const char *
+  name() const
+  {
+    return _name;
+  }
+
+protected:
+  // Set optional test name, to be displayed if the test fails.
+  //
+  const void
+  name(const char *optional_name)
+  {
+    _name = optional_name;
+  }
+
+private:
+  virtual bool
+  test()
+  {
+    return false;
+  }
+
+  const char *_name;
+};
+
+// Simple named test, the parameter is the name as a string literal.  The body of the test function should follow the
+// invocation of this macro.  It should return true if the test succeeds, false if it fails.
+//
+#define TEST(NAME) TEST_(name(NAME);, __LINE__)
+
+// Simple annonynous test.  The body of the test function should follow the invocation of this macro.  It should return true if the
+// test succeeds, false if it fails.
+//
+#define ATEST TEST_(, __LINE__)
+
+// The definitions/declarations from here down should not be used outside this file.
+
+#define TEST_(CONS_STATEMENT, SUFFIX) TEST2_(CONS_STATEMENT, SUFFIX)
+
+#define TEST2_(CONS_STATEMENT, SUFFIX)     \
+  class GenTest##SUFFIX : public Test_base \
+  {                                        \
+  public:                                  \
+    GenTest##SUFFIX() { CONS_STATEMENT }   \
+    bool test() override;                  \
+  };                                       \
+  GenTest##SUFFIX genTest##SUFFIX;         \
+  bool GenTest##SUFFIX::test()
+
+namespace SimpleTest
+{
+unsigned currTestNumber;
+}
+
+void
+_ink_assert(const char *bool_expr, const char *file_spec, int line)
+{
+  std::cout << "ink_assert() failed: expression: " << bool_expr << " file: " << file_spec << " line: " << line
+            << " test number: " << SimpleTest::currTestNumber << std::endl;
+
+  exit(1);
+}
+
+bool
+one_test(unsigned tno)
+{
+  SimpleTest::currTestNumber = tno;
+
+  Test_base *t = test_list[tno];
+
+  if (!((*t)())) {
+    std::cout << "Test " << tno;
+
+    if (t->name())
+      std::cout << " (" << t->name() << ')';
+
+    std::cout << " failed\n";
+
+    return false;
+  }
+  return true;
+}
+
+int
+main(int n_arg, const char *const *arg)
+{
+  bool success = true;
+  if (n_arg < 3) {
+    if (n_arg == 2) { // Run the single test whose (zero-base) number was specified on the command line.
+      unsigned tno = static_cast<unsigned>(atoi(arg[1]));
+
+      if (tno < test_list.size()) {
+        success = one_test(static_cast<unsigned>(tno)) and success;
+      } else {
+        std::cout << "test number must be less than " << test_list.size() << '\n';
+      }
+    } else { // Run all the tests.
+      for (unsigned tno = 0; tno < test_list.size(); ++tno) {
+        success = one_test(static_cast<unsigned>(tno)) and success;
+      }
+    }
+  }
+
+  return success ? 0 : 1;
+}


### PR DESCRIPTION
This is a utility I think will be useful in the implementation of the "Forwarded" header.  It makes concatenation of character and string literals compact and safe.  It can interact with existing ATS functions, needed to generate Forwarded components, in a less error-prone manner.  It hopefully will have future uses in header editing and log formatting.