### PR TITLE
Use a strongly typed enum for VC shutdown.

### DIFF
--- a/iocore/cache/I_Cache.h
+++ b/iocore/cache/I_Cache.h
@@ -180,7 +180,7 @@ struct CacheVConnection : public VConnection {
   void reenable(VIO *avio)          = 0;
   void reenable_re(VIO *avio)       = 0;
   void
-  do_io_shutdown(ShutdownHowTo_t howto)
+  do_io_shutdown(IOShutdown howto)
   {
     (void)howto;
     ink_assert(!"CacheVConnection::do_io_shutdown unsupported");

--- a/iocore/eventsystem/I_SocketManager.h
+++ b/iocore/eventsystem/I_SocketManager.h
@@ -121,7 +121,7 @@ struct SocketManager {
   int port_getn(int port, port_event_t *list, uint_t max, uint_t *nget, timespec_t *timeout);
 #endif
 
-  int shutdown(int s, int how);
+  int shutdown(int s, IOShutdown how);
   int dup(int s);
 
   // result is the fd or -errno

--- a/iocore/eventsystem/I_VConnection.h
+++ b/iocore/eventsystem/I_VConnection.h
@@ -116,12 +116,15 @@
 //
 //////////////////////////////////////////////////////////////////////////////
 
-/** Used in VConnection::shutdown(). */
-enum ShutdownHowTo_t {
-  IO_SHUTDOWN_READ = 0,
-  IO_SHUTDOWN_WRITE,
-  IO_SHUTDOWN_READWRITE,
+enum class IOShutdown {
+  READ      = SHUT_RD,
+  WRITE     = SHUT_WR,
+  READWRITE = SHUT_RDWR,
 };
+
+constexpr IOShutdown IO_SHUTDOWN_READ      = IOShutdown::READ;
+constexpr IOShutdown IO_SHUTDOWN_WRITE     = IOShutdown::WRITE;
+constexpr IOShutdown IO_SHUTDOWN_READWRITE = IOShutdown::READWRITE;
 
 /** Used in VConnection::get_data(). */
 enum TSApiDataType {
@@ -307,7 +310,7 @@ public:
       shutdown.
 
   */
-  virtual void do_io_shutdown(ShutdownHowTo_t howto) = 0;
+  virtual void do_io_shutdown(IOShutdown howto) = 0;
 
   VConnection(ProxyMutex *aMutex);
   VConnection(Ptr<ProxyMutex> &aMutex);
@@ -399,7 +402,7 @@ struct DummyVConnection : public VConnection {
                 "cannot use default implementation");
   }
 
-  virtual void do_io_shutdown(ShutdownHowTo_t /* howto ATS_UNUSED */)
+  virtual void do_io_shutdown(IOShutdown /* howto ATS_UNUSED */)
   {
     ink_assert(!"VConnection::do_io_shutdown -- "
                 "cannot use default implementation");

--- a/iocore/eventsystem/P_UnixSocketManager.h
+++ b/iocore/eventsystem/P_UnixSocketManager.h
@@ -484,13 +484,16 @@ SocketManager::socket(int domain, int type, int protocol)
 }
 
 TS_INLINE int
-SocketManager::shutdown(int s, int how)
+SocketManager::shutdown(int s, IOShutdown how)
 {
   int res;
+
   do {
-    if (unlikely((res = ::shutdown(s, how)) < 0))
+    if (unlikely((res = ::shutdown(s, static_cast<int>(how))) < 0)) {
       res = -errno;
-  } while (res == -EINTR);
+    }
+  } while (transient_error());
+
   return res;
 }
 

--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -365,7 +365,7 @@ public:
     @param howto IO_SHUTDOWN_READ, IO_SHUTDOWN_WRITE, IO_SHUTDOWN_READWRITE
 
   */
-  virtual void do_io_shutdown(ShutdownHowTo_t howto) = 0;
+  virtual void do_io_shutdown(IOShutdown howto) = 0;
 
   /**
     Sends out of band messages over the connection. This function

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -136,7 +136,7 @@ public:
   }
 
   void do_io_close(int lerrno = -1) override;
-  void do_io_shutdown(ShutdownHowTo_t howto) override;
+  void do_io_shutdown(IOShutdown howto) override;
 
   ////////////////////////////////////////////////////////////
   // Set the timeouts associated with this connection.      //

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -709,11 +709,11 @@ UnixNetVConnection::do_io_close(int alerrno /* = -1 */)
 }
 
 void
-UnixNetVConnection::do_io_shutdown(ShutdownHowTo_t howto)
+UnixNetVConnection::do_io_shutdown(IOShutdown howto)
 {
   switch (howto) {
   case IO_SHUTDOWN_READ:
-    socketManager.shutdown(((UnixNetVConnection *)this)->con.fd, 0);
+    socketManager.shutdown(((UnixNetVConnection *)this)->con.fd, IO_SHUTDOWN_READ);
     read.enabled = 0;
     read.vio.buffer.clear();
     read.vio.nbytes = 0;
@@ -721,7 +721,7 @@ UnixNetVConnection::do_io_shutdown(ShutdownHowTo_t howto)
     f.shutdown      = NET_VC_SHUTDOWN_READ;
     break;
   case IO_SHUTDOWN_WRITE:
-    socketManager.shutdown(((UnixNetVConnection *)this)->con.fd, 1);
+    socketManager.shutdown(((UnixNetVConnection *)this)->con.fd, IO_SHUTDOWN_WRITE);
     write.enabled = 0;
     write.vio.buffer.clear();
     write.vio.nbytes = 0;
@@ -729,7 +729,7 @@ UnixNetVConnection::do_io_shutdown(ShutdownHowTo_t howto)
     f.shutdown       = NET_VC_SHUTDOWN_WRITE;
     break;
   case IO_SHUTDOWN_READWRITE:
-    socketManager.shutdown(((UnixNetVConnection *)this)->con.fd, 2);
+    socketManager.shutdown(((UnixNetVConnection *)this)->con.fd, IO_SHUTDOWN_READWRITE);
     read.enabled  = 0;
     write.enabled = 0;
     read.vio.buffer.clear();

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -1190,7 +1190,7 @@ INKVConnInternal::do_io_close(int error)
 }
 
 void
-INKVConnInternal::do_io_shutdown(ShutdownHowTo_t howto)
+INKVConnInternal::do_io_shutdown(IOShutdown howto)
 {
   if ((howto == IO_SHUTDOWN_READ) || (howto == IO_SHUTDOWN_READWRITE)) {
     m_read_vio.op = VIO::NONE;

--- a/proxy/PluginVC.cc
+++ b/proxy/PluginVC.cc
@@ -388,7 +388,7 @@ PluginVC::do_io_close(int /* flag ATS_UNUSED */)
 }
 
 void
-PluginVC::do_io_shutdown(ShutdownHowTo_t howto)
+PluginVC::do_io_shutdown(IOShutdown howto)
 {
   ink_assert(!closed);
   ink_assert(magic == PLUGIN_VC_MAGIC_ALIVE);

--- a/proxy/PluginVC.h
+++ b/proxy/PluginVC.h
@@ -82,7 +82,7 @@ public:
   virtual VIO *do_io_write(Continuation *c = NULL, int64_t nbytes = INT64_MAX, IOBufferReader *buf = 0, bool owner = false);
 
   virtual void do_io_close(int lerrno = -1);
-  virtual void do_io_shutdown(ShutdownHowTo_t howto);
+  virtual void do_io_shutdown(IOShutdown howto);
 
   // Reenable a given vio.  The public interface is through VIO::reenable
   virtual void reenable(VIO *vio);

--- a/proxy/Transform.cc
+++ b/proxy/Transform.cc
@@ -348,7 +348,7 @@ TransformTerminus::do_io_close(int error)
   -------------------------------------------------------------------------*/
 
 void
-TransformTerminus::do_io_shutdown(ShutdownHowTo_t howto)
+TransformTerminus::do_io_shutdown(IOShutdown howto)
 {
   if ((howto == IO_SHUTDOWN_READ) || (howto == IO_SHUTDOWN_READWRITE)) {
     m_read_vio.op = VIO::NONE;
@@ -471,11 +471,11 @@ TransformVConnection::do_io_close(int error)
   -------------------------------------------------------------------------*/
 
 void
-TransformVConnection::do_io_shutdown(ShutdownHowTo_t howto)
+TransformVConnection::do_io_shutdown(IOShutdown howto)
 {
   ink_assert(howto == IO_SHUTDOWN_WRITE);
 
-  Debug("transform", "TransformVConnection do_io_shutdown: %d [0x%lx]", howto, (long)this);
+  Debug("transform", "TransformVConnection do_io_shutdown: %d [%p]", static_cast<int>(howto), this);
 
   m_transform->do_io_shutdown(howto);
 }

--- a/proxy/TransformInternal.h
+++ b/proxy/TransformInternal.h
@@ -41,7 +41,7 @@ public:
   VIO *do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf);
   VIO *do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool owner = false);
   void do_io_close(int lerrno = -1);
-  void do_io_shutdown(ShutdownHowTo_t howto);
+  void do_io_shutdown(IOShutdown howto);
 
   void reenable(VIO *vio);
 
@@ -66,7 +66,7 @@ public:
   VIO *do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf);
   VIO *do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool owner = false);
   void do_io_close(int lerrno = -1);
-  void do_io_shutdown(ShutdownHowTo_t howto);
+  void do_io_shutdown(IOShutdown howto);
 
   void reenable(VIO *vio);
 

--- a/proxy/api/ts/InkAPIPrivateIOCore.h
+++ b/proxy/api/ts/InkAPIPrivateIOCore.h
@@ -81,7 +81,7 @@ public:
 
   void do_io_close(int lerrno = -1);
 
-  void do_io_shutdown(ShutdownHowTo_t howto);
+  void do_io_shutdown(IOShutdown howto);
 
   void reenable(VIO *vio);
 

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -256,7 +256,7 @@ Http1ClientSession::set_tcp_init_cwnd()
 }
 
 void
-Http1ClientSession::do_io_shutdown(ShutdownHowTo_t howto)
+Http1ClientSession::do_io_shutdown(IOShutdown howto)
 {
   client_vc->do_io_shutdown(howto);
 }

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -73,7 +73,7 @@ public:
   virtual VIO *do_io_write(Continuation *c = NULL, int64_t nbytes = INT64_MAX, IOBufferReader *buf = 0, bool owner = false);
 
   virtual void do_io_close(int lerrno = -1);
-  virtual void do_io_shutdown(ShutdownHowTo_t howto);
+  virtual void do_io_shutdown(IOShutdown howto);
   virtual void reenable(VIO *vio);
 
   void

--- a/proxy/http/Http1ClientTransaction.h
+++ b/proxy/http/Http1ClientTransaction.h
@@ -63,7 +63,7 @@ public:
   }
 
   void
-  do_io_shutdown(ShutdownHowTo_t howto) override
+  do_io_shutdown(IOShutdown howto) override
   {
     parent->do_io_shutdown(howto);
   }

--- a/proxy/http/HttpServerSession.cc
+++ b/proxy/http/HttpServerSession.cc
@@ -109,7 +109,7 @@ HttpServerSession::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *
 }
 
 void
-HttpServerSession::do_io_shutdown(ShutdownHowTo_t howto)
+HttpServerSession::do_io_shutdown(IOShutdown howto)
 {
   server_vc->do_io_shutdown(howto);
 }

--- a/proxy/http/HttpServerSession.h
+++ b/proxy/http/HttpServerSession.h
@@ -112,7 +112,7 @@ public:
   virtual VIO *do_io_write(Continuation *c = NULL, int64_t nbytes = INT64_MAX, IOBufferReader *buf = 0, bool owner = false);
 
   virtual void do_io_close(int lerrno = -1);
-  virtual void do_io_shutdown(ShutdownHowTo_t howto);
+  virtual void do_io_shutdown(IOShutdown howto);
 
   virtual void reenable(VIO *vio);
 

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -239,7 +239,7 @@ Http2ClientSession::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader 
 }
 
 void
-Http2ClientSession::do_io_shutdown(ShutdownHowTo_t howto)
+Http2ClientSession::do_io_shutdown(IOShutdown howto)
 {
   this->client_vc->do_io_shutdown(howto);
 }

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -177,7 +177,7 @@ public:
   VIO *do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = 0) override;
   VIO *do_io_write(Continuation *c = NULL, int64_t nbytes = INT64_MAX, IOBufferReader *buf = 0, bool owner = false) override;
   void do_io_close(int lerrno = -1) override;
-  void do_io_shutdown(ShutdownHowTo_t howto) override;
+  void do_io_shutdown(IOShutdown howto) override;
   void reenable(VIO *vio) override;
 
   NetVConnection *

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -141,7 +141,7 @@ public:
   VIO *do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *abuffer, bool owner = false) override;
   void do_io_close(int lerrno = -1) override;
   void initiating_close();
-  void do_io_shutdown(ShutdownHowTo_t) override {}
+  void do_io_shutdown(IOShutdown) override {}
   void update_read_request(int64_t read_len, bool send_update);
   bool update_write_request(IOBufferReader *buf_reader, int64_t write_len, bool send_update);
   void reenable(VIO *vio) override;


### PR DESCRIPTION
- Rename ShutdownHowTo_t to IOShutdown to be more consistent with
  other IOCore nomenclature.
- Use a strongly typed enum for improved type safety.
- Use the same set of constants for both VC shutdown arguments and
  socket manager shutdown arguments.