### PR TITLE
Server information should be cleared when following redirect

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -7701,6 +7701,8 @@ HttpSM::redirect_request(const char *redirect_url, const int redirect_len)
   // we have a new OS and need to have DNS lookup the new OS
   t_state.dns_info.lookup_success = false;
   t_state.force_dns               = false;
+  t_state.server_info.clear();
+  t_state.parent_info.clear();
 
   if (t_state.txn_conf->cache_http) {
     t_state.cache_info.object_read = NULL;

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -686,22 +686,14 @@ public:
       connect_result = e;
     }
 
-    ConnectionAttributes()
-      : http_version(),
-        keep_alive(HTTP_KEEPALIVE_UNDEFINED),
-        receive_chunked_response(false),
-        pipeline_possible(false),
-        proxy_connect_hdr(false),
-        connect_result(0),
-        name(NULL),
-        transfer_encoding(NO_TRANSFER_ENCODING),
-        state(STATE_UNDEFINED),
-        abort(ABORT_UNDEFINED),
-        port_attribute(HttpProxyPort::TRANSPORT_DEFAULT),
-        is_transparent(false)
+    ConnectionAttributes() { clear(); }
+
+    void
+    clear()
     {
-      memset(&src_addr, 0, sizeof(src_addr));
-      memset(&dst_addr, 0, sizeof(dst_addr));
+      ink_zero(src_addr);
+      ink_zero(dst_addr);
+      connect_result = 0;
     }
   };
 


### PR DESCRIPTION
See backport PR 1900, this is required along wth 1900.

(cherry picked from commit e01f7ff372293da71724ced0815d02048c8b96dc)

Conflicts:
	proxy/http/HttpTransact.h