### PR TITLE
TS-4375: Fix PCRE link issues on Darwin.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1169,12 +1169,9 @@ if test "x${TCL_INCLUDE_SPEC}" != "x-I/usr/include"; then
 fi
 
 #
-# Check for XML parser
+# Check for XML parser. Required.
 #
 TS_CHECK_XML
-if test "x${enable_xml}" != "xyes"; then
-  AC_MSG_ERROR([Need at least one XML library, --with-expat is supported])
-fi
 
 AC_CHECK_FUNCS([clock_gettime kqueue epoll_ctl posix_memalign posix_fadvise posix_madvise posix_fallocate inotify_init])
 AC_CHECK_FUNCS([lrand48_r srand48_r port_create strlcpy strlcat sysconf sysctlbyname getpagesize])


### PR DESCRIPTION
Darwin has a copy of PCRE in the SDK, but it has JIT disabled. When
we use pkg-config to find the PCRE version, we find the Homebrew
version in /usr/local which does have JIT enabled. Now, we end up
searching for Expat in the SDK so the SDK ends up in our library
search path causing us to find the wrong version of libpcre. Link
failures ensue.

Since it is so trivial to just use expat from Homebrew, remove the
SDK path search and tidy up the XML m4 macros to be a bit more
informative.

(cherry picked from commit cbf10fd45fa8429dc9b700252fff1a749d252bfa)