### PR TITLE
Push triggered DNSConnections into an atomic queue to prevent DNSConnection lost.

### DIFF
--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -753,7 +753,9 @@ DNSHandler::recv_dns(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   DNSConnection *dnsc = nullptr;
   ip_text_buffer ipbuff1, ipbuff2;
 
-  while ((dnsc = (DNSConnection *)triggered.dequeue())) {
+  SList(DNSConnection, triggered_link) cq(triggered.popall());
+
+  while ((dnsc = (DNSConnection *)cq.pop())) {
     while (true) {
       IpEndpoint from_ip;
       socklen_t from_length = sizeof(from_ip);

--- a/iocore/dns/DNSConnection.cc
+++ b/iocore/dns/DNSConnection.cc
@@ -75,7 +75,7 @@ DNSConnection::close()
 void
 DNSConnection::trigger()
 {
-  handler->triggered.enqueue(this);
+  handler->triggered.push(this);
 }
 
 int

--- a/iocore/dns/P_DNSConnection.h
+++ b/iocore/dns/P_DNSConnection.h
@@ -92,6 +92,7 @@ struct DNSConnection {
   DNSConnection();
 
   static Options const DEFAULT_OPTIONS;
+  SLINK(DNSConnection, triggered_link);
 };
 
 inline DNSConnection::Options::Options()

--- a/iocore/dns/P_DNSProcessor.h
+++ b/iocore/dns/P_DNSProcessor.h
@@ -190,7 +190,7 @@ struct DNSHandler : public Continuation {
   int n_con;
   DNSConnection con[MAX_NAMED];
   Queue<DNSEntry> entries;
-  Queue<DNSConnection> triggered;
+  ASLL(DNSConnection, triggered_link) triggered;
   int in_flight;
   int name_server;
   int in_write_dns;


### PR DESCRIPTION
The `DNSConnection` is put into `NetHandler` to wait for `READ` event.
`NetHandler` will call `DNSConnection::triggered()` to put it into `DNSHandler::triggered` queue when it is readable.

There are some issues if `CONFIG proxy.config.dns.dedicated_thread INT 1`:
1. The `DNSHandler::triggered` queue is not atomic queue
2. The `DNSConnection::triggered()` calls `triggered.enqueue()` directly without mutex locked.
3. The `DNSHandler::recv_dns()` calls `triggered.dequeue()` directly without mutex locked.

otherwise ET_NET == ET_DNS and only the `NetHandler` inside the `[ET_NET 0]` would get the DNSConnection event.