### PR TITLE
cqtq,cqtn,cqtd,cqtt timestamp blog format to be INT again

### DIFF
--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -388,23 +388,23 @@ Log::init_fields()
   global_field_list.add(field, false);
   ink_hash_table_insert(field_symbol_hash, "cqth", field);
 
-  field = new LogField("client_req_timestamp_squid", "cqtq", LogField::STRING, &LogAccess::marshal_client_req_timestamp_squid,
-                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
+  field = new LogField("client_req_timestamp_squid", "cqtq", LogField::sINT, &LogAccess::marshal_client_req_timestamp_ms,
+                       &LogAccess::unmarshal_ttmsf);
   global_field_list.add(field, false);
   ink_hash_table_insert(field_symbol_hash, "cqtq", field);
 
-  field = new LogField("client_req_timestamp_netscape", "cqtn", LogField::STRING, &LogAccess::marshal_client_req_timestamp_netscape,
-                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
+  field = new LogField("client_req_timestamp_netscape", "cqtn", LogField::sINT, &LogAccess::marshal_client_req_timestamp_sec,
+                       &LogAccess::unmarshal_int_to_netscape_str);
   global_field_list.add(field, false);
   ink_hash_table_insert(field_symbol_hash, "cqtn", field);
 
-  field = new LogField("client_req_timestamp_date", "cqtd", LogField::STRING, &LogAccess::marshal_client_req_timestamp_date,
-                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
+  field = new LogField("client_req_timestamp_date", "cqtd", LogField::sINT, &LogAccess::marshal_client_req_timestamp_sec,
+                       &LogAccess::unmarshal_int_to_date_str);
   global_field_list.add(field, false);
   ink_hash_table_insert(field_symbol_hash, "cqtd", field);
 
-  field = new LogField("client_req_timestamp_time", "cqtt", LogField::STRING, &LogAccess::marshal_client_req_timestamp_time,
-                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
+  field = new LogField("client_req_timestamp_time", "cqtt", LogField::sINT, &LogAccess::marshal_client_req_timestamp_sec,
+                       &LogAccess::unmarshal_int_to_time_str);
   global_field_list.add(field, false);
   ink_hash_table_insert(field_symbol_hash, "cqtt", field);
 

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -216,10 +216,7 @@ LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_uuid, DEFAULT_STR_FIELD)
   -------------------------------------------------------------------------*/
 
 LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_timestamp_sec, DEFAULT_INT_FIELD)
-LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_timestamp_squid, DEFAULT_STR_FIELD)
-LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_timestamp_netscape, DEFAULT_STR_FIELD)
-LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_timestamp_date, DEFAULT_STR_FIELD)
-LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_timestamp_time, DEFAULT_STR_FIELD)
+LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_timestamp_ms, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
@@ -1023,9 +1020,54 @@ LogAccess::unmarshal_ttmsf(char **buf, char *dest, int len)
   ink_assert(dest != nullptr);
 
   int64_t val = unmarshal_int(buf);
-  float secs  = (float)val / 1000;
+  double secs = (double)val / 1000;
   int val_len = snprintf(dest, len, "%.3f", secs);
   return val_len;
+}
+
+int
+LogAccess::unmarshal_int_to_date_str(char **buf, char *dest, int len)
+{
+  ink_assert(buf != nullptr);
+  ink_assert(*buf != nullptr);
+  ink_assert(dest != nullptr);
+
+  int64_t value = unmarshal_int(buf);
+  char *strval  = LogUtils::timestamp_to_date_str(value);
+  int strlen    = LogAccess::strlen(strval);
+
+  memcpy(dest, strval, strlen);
+  return strlen;
+}
+
+int
+LogAccess::unmarshal_int_to_time_str(char **buf, char *dest, int len)
+{
+  ink_assert(buf != nullptr);
+  ink_assert(*buf != nullptr);
+  ink_assert(dest != nullptr);
+
+  int64_t value = unmarshal_int(buf);
+  char *strval  = LogUtils::timestamp_to_time_str(value);
+  int strlen    = LogAccess::strlen(strval);
+
+  memcpy(dest, strval, strlen);
+  return strlen;
+}
+
+int
+LogAccess::unmarshal_int_to_netscape_str(char **buf, char *dest, int len)
+{
+  ink_assert(buf != nullptr);
+  ink_assert(*buf != nullptr);
+  ink_assert(dest != nullptr);
+
+  int64_t value = unmarshal_int(buf);
+  char *strval  = LogUtils::timestamp_to_netscape_str(value);
+  int strlen    = LogAccess::strlen(strval);
+
+  memcpy(dest, strval, strlen);
+  return strlen;
 }
 
 /*-------------------------------------------------------------------------

--- a/proxy/logging/LogAccess.h
+++ b/proxy/logging/LogAccess.h
@@ -174,10 +174,7 @@ public:
   inkcoreapi virtual int marshal_client_host_port(char *);              // INT
   inkcoreapi virtual int marshal_client_auth_user_name(char *);         // STR
   inkcoreapi virtual int marshal_client_req_timestamp_sec(char *);      // INT
-  inkcoreapi virtual int marshal_client_req_timestamp_squid(char *);    // STR
-  inkcoreapi virtual int marshal_client_req_timestamp_netscape(char *); // STR
-  inkcoreapi virtual int marshal_client_req_timestamp_date(char *);     // STR
-  inkcoreapi virtual int marshal_client_req_timestamp_time(char *);     // STR
+  inkcoreapi virtual int marshal_client_req_timestamp_ms(char *);       // INT
   inkcoreapi virtual int marshal_client_req_text(char *);               // STR
   inkcoreapi virtual int marshal_client_req_http_method(char *);        // STR
   inkcoreapi virtual int marshal_client_req_url(char *);                // STR
@@ -327,6 +324,9 @@ public:
   static int unmarshal_int_to_str_hex(char **buf, char *dest, int len);
   static int unmarshal_str(char **buf, char *dest, int len, LogSlice *slice = NULL);
   static int unmarshal_ttmsf(char **buf, char *dest, int len);
+  static int unmarshal_int_to_date_str(char **buf, char *dest, int len);
+  static int unmarshal_int_to_time_str(char **buf, char *dest, int len);
+  static int unmarshal_int_to_netscape_str(char **buf, char *dest, int len);
   static int unmarshal_http_version(char **buf, char *dest, int len);
   static int unmarshal_http_text(char **buf, char *dest, int len, LogSlice *slice = NULL);
   static int unmarshal_http_status(char **buf, char *dest, int len);

--- a/proxy/logging/LogAccessHttp.cc
+++ b/proxy/logging/LogAccessHttp.cc
@@ -436,33 +436,9 @@ LogAccessHttp::marshal_client_req_timestamp_sec(char *buf)
   -------------------------------------------------------------------------*/
 
 int
-LogAccessHttp::marshal_client_req_timestamp_squid(char *buf)
+LogAccessHttp::marshal_client_req_timestamp_ms(char *buf)
 {
-  return marshal_milestone_fmt_squid(TS_MILESTONE_UA_BEGIN, buf);
-}
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-
-int
-LogAccessHttp::marshal_client_req_timestamp_netscape(char *buf)
-{
-  return marshal_milestone_fmt_netscape(TS_MILESTONE_UA_BEGIN, buf);
-}
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-
-int
-LogAccessHttp::marshal_client_req_timestamp_date(char *buf)
-{
-  return marshal_milestone_fmt_date(TS_MILESTONE_UA_BEGIN, buf);
-}
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-
-int
-LogAccessHttp::marshal_client_req_timestamp_time(char *buf)
-{
-  return marshal_milestone_fmt_time(TS_MILESTONE_UA_BEGIN, buf);
+  return marshal_milestone_fmt_ms(TS_MILESTONE_UA_BEGIN, buf);
 }
 
 /*-------------------------------------------------------------------------
@@ -1710,70 +1686,20 @@ int
 LogAccessHttp::marshal_milestone_fmt_sec(TSMilestonesType type, char *buf)
 {
   if (buf) {
-    struct timeval tp = ink_hrtime_to_timeval(m_http_sm->milestones[type]);
-    marshal_int(buf, tp.tv_sec);
+    ink_hrtime tsec = ink_hrtime_to_sec(m_http_sm->milestones[type]);
+    marshal_int(buf, tsec);
   }
   return INK_MIN_ALIGN;
 }
 
 int
-LogAccessHttp::marshal_milestone_fmt_squid(TSMilestonesType type, char *buf)
+LogAccessHttp::marshal_milestone_fmt_ms(TSMilestonesType type, char *buf)
 {
-  struct timeval tp          = ink_hrtime_to_timeval(m_http_sm->milestones[type]);
-  const unsigned int val_len = 32;
-  char val[val_len]          = {0};
-
-  squid_timestamp_to_buf(val, val_len, tp.tv_sec, tp.tv_usec);
-
-  int len = LogAccess::strlen(val);
-
   if (buf) {
-    marshal_str(buf, val, len);
+    ink_hrtime tmsec = ink_hrtime_to_msec(m_http_sm->milestones[type]);
+    marshal_int(buf, tmsec);
   }
-
-  return len;
-}
-
-int
-LogAccessHttp::marshal_milestone_fmt_netscape(TSMilestonesType type, char *buf)
-{
-  struct timeval tp = ink_hrtime_to_timeval(m_http_sm->milestones[type]);
-  char *val         = LogUtils::timestamp_to_netscape_str(tp.tv_sec);
-  int len           = LogAccess::strlen(val);
-
-  if (buf) {
-    marshal_str(buf, val, len);
-  }
-
-  return len;
-}
-
-int
-LogAccessHttp::marshal_milestone_fmt_date(TSMilestonesType type, char *buf)
-{
-  struct timeval tp = ink_hrtime_to_timeval(m_http_sm->milestones[type]);
-  char *val         = LogUtils::timestamp_to_date_str(tp.tv_sec);
-  int len           = LogAccess::strlen(val);
-
-  if (buf) {
-    marshal_str(buf, val, len);
-  }
-
-  return len;
-}
-
-int
-LogAccessHttp::marshal_milestone_fmt_time(TSMilestonesType type, char *buf)
-{
-  struct timeval tp = ink_hrtime_to_timeval(m_http_sm->milestones[type]);
-  char *val         = LogUtils::timestamp_to_time_str(tp.tv_sec);
-  int len           = LogAccess::strlen(val);
-
-  if (buf) {
-    marshal_str(buf, val, len);
-  }
-
-  return len;
+  return INK_MIN_ALIGN;
 }
 
 int

--- a/proxy/logging/LogAccessHttp.h
+++ b/proxy/logging/LogAccessHttp.h
@@ -77,10 +77,7 @@ public:
   virtual int marshal_client_req_is_ssl(char *);             // INT
   virtual int marshal_client_req_ssl_reused(char *);         // INT
   virtual int marshal_client_req_timestamp_sec(char *);      // INT
-  virtual int marshal_client_req_timestamp_squid(char *);    // STR
-  virtual int marshal_client_req_timestamp_netscape(char *); // STR
-  virtual int marshal_client_req_timestamp_date(char *);     // STR
-  virtual int marshal_client_req_timestamp_time(char *);     // STR
+  virtual int marshal_client_req_timestamp_ms(char *);       // INT
   virtual int marshal_client_security_protocol(char *);      // STR
   virtual int marshal_client_security_cipher_suite(char *);  // STR
   virtual int marshal_client_finish_status_code(char *);     // INT
@@ -165,10 +162,7 @@ public:
 
   virtual int marshal_milestone(TSMilestonesType ms, char *buf);
   virtual int marshal_milestone_fmt_sec(TSMilestonesType ms, char *buf);
-  virtual int marshal_milestone_fmt_squid(TSMilestonesType ms, char *buf);
-  virtual int marshal_milestone_fmt_netscape(TSMilestonesType ms, char *buf);
-  virtual int marshal_milestone_fmt_date(TSMilestonesType ms, char *buf);
-  virtual int marshal_milestone_fmt_time(TSMilestonesType ms, char *buf);
+  virtual int marshal_milestone_fmt_ms(TSMilestonesType ms, char *buf);
   virtual int marshal_milestone_diff(TSMilestonesType ms1, TSMilestonesType ms2, char *buf);
 
   virtual void set_client_req_url(char *, int);                // STR


### PR DESCRIPTION
logstats which parses a squid binary log format no longer worked
since the 'cqtq' field binary representation changed to string
(from integer) in the latest traffic server.