### PR TITLE
Doc: Fix LaTex paper size options to work and not generate a warning.

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -46,8 +46,11 @@ PAPER         = letter
 BUILDDIR      = docbuild
 
 # Internal variables.
-PAPEROPT_a4     = -D latex_paper_size=a4
-PAPEROPT_letter = -D latex_paper_size=letter
+# [amc] LaTex apparently doesn't work as of Sphinx 1.6.1
+# see https://media.readthedocs.org/pdf/sphinx/1.6.3/sphinx.pdf
+# section 24.3.2 around page 247, third item for 'NotImplementedError', so this is kind of useless.
+PAPEROPT_a4     = -t latex_a4
+PAPEROPT_letter = -t latex_letter
 ALLSPHINXOPTS   = $(SPHINXOPTS)
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(SPHINXOPTS)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -335,6 +335,11 @@ latex_elements = {
     #'preamble': '',
 }
 
+if tags.has('latex_a4') :
+    latex_elements['papersize'] = 'a4paper'
+elif tags.has('latex_paper') :
+    latex_elements['papersiize'] = 'letterpaper'
+
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [


### PR DESCRIPTION
This was changed at the same time the conf.py was changed to have `latex_elements` so we should be consistent.

Extracted from #2320.