### PR TITLE
Doc: Add documentation for MIME header plugin API functions.

### DIFF
--- a/doc/developer-guide/api/functions/TSMimeHdrFieldAppend.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldAppend.en.rst
@@ -31,17 +31,10 @@ Synopsis
 Description
 ===========
 
-Returns the :c:type:`TSMLoc` location of a specified MIME field from
-within the MIME header located at :arg:`hdr`.
+Attaches a MIME :arg:`field` to a header. The header is represented by the :arg:`bufp` and :arg:`hdr`
+arguments which should have been obtained by a call to :func:`TSHttpTxnClientReqGet` or similar. If
+the field in :arg:`field` was created by calling :func:`TSMimeHdrFieldCreateNamed` the same
+:arg:`bufp` and :arg:`hdr` passed to that should be passed to this function.
 
-The retrieved_str parameter specifies which field to retrieve.  For
-each MIME field in the MIME header, a pointer comparison is done
-between the field name and retrieved_str.  This is a much quicker
-retrieval function than :c:func:`TSMimeHdrFieldFind` since it obviates
-the need for a string comparison.  However, retrieved_str must be one
-of the predefined field names of the form ``TS_MIME_FIELD_XXX``
-for the call to succeed.  Release the returned :c:type:`TSMLoc` handle
-with a call to :c:func:`TSHandleMLocRelease`.
-
-.. XXX The above is surely from the documentation of another function. Confirm
-       and remove from here (or relocate to the appropriate function's doc).
+Returns :code:`TS_SUCCESS` if the :arg:`field` was attached to the header, :code:`TS_ERROR` if it
+was not. Fields cannot be attached to read only headers.

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldCreate.en.rst
@@ -26,7 +26,23 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. function:: TSReturnCode TSMimeHdrFieldCreate(TSMBuffer bufp, TSMLoc hdr, TSMLoc * locp)
+.. function:: TSReturnCode TSMimeHdrFieldCreate(TSMBuffer bufp, TSMLoc hdr, TSMLoc * out)
+.. function:: TSReturnCode TSMimeHdrFieldCreateNamed(TSMBuffer bufp, TSMLoc hdr, const char * name, int name_len, TSMLoc * out)
 
 Description
 ===========
+
+These functions create MIME fields in a MIME header. The header is specified by the combination of
+the buffer :arg:`bufp` and a location :arg:`hdr`. The header must be either created such as by
+:func:`TSMimeHdrCreate` or be an existing header found via a function such as :func:`TSHttpTxnClientReqGet`.
+
+:func:`TSMimeHdrFieldCreate` creates a completely empty field which must be named before being used
+in a header, usually via :func:`TSMimeHdrFieldNameSet`. It is almost always more convenient to use
+:func:`TSMimeHdrFieldCreateNamed` which combines these two steps, creating the field and then
+setting the name to :arg:`name`.
+
+For both functions a reference to the new field is returned via arg:`out`.
+
+The field created is not in a header even though it is in the same buffer. It can be added to a
+header with :func:`TSMimeHdrFieldAppend`. The field also has no value, only a name. If a value is
+needed it must be added explicitly with a function such as :func:`TSMimeHdrFieldValueIntSet`.


### PR DESCRIPTION
Add documentation for a couple of MIME header plugin API functions.

Extracted from #2320.