### PR TITLE
Add missing checks for request url to fix crash in TS_Lua plugin

### DIFF
--- a/plugins/experimental/ts_lua/ts_lua_server_request.c
+++ b/plugins/experimental/ts_lua/ts_lua_server_request.c
@@ -569,6 +569,8 @@ ts_lua_server_request_get_url_host(lua_State *L)
 
   GET_HTTP_CONTEXT(http_ctx, L);
 
+  TS_LUA_CHECK_SERVER_REQUEST_URL(http_ctx);
+
   host = TSUrlHostGet(http_ctx->server_request_bufp, http_ctx->server_request_url, &len);
 
   if (len == 0) {
@@ -624,6 +626,7 @@ ts_lua_server_request_get_url_scheme(lua_State *L)
   ts_lua_http_ctx *http_ctx;
 
   GET_HTTP_CONTEXT(http_ctx, L);
+  TS_LUA_CHECK_SERVER_REQUEST_URL(http_ctx);
 
   scheme = TSUrlSchemeGet(http_ctx->server_request_bufp, http_ctx->server_request_url, &len);
 
@@ -641,6 +644,7 @@ ts_lua_server_request_set_url_scheme(lua_State *L)
   ts_lua_http_ctx *http_ctx;
 
   GET_HTTP_CONTEXT(http_ctx, L);
+  TS_LUA_CHECK_SERVER_REQUEST_URL(http_ctx);
 
   scheme = luaL_checklstring(L, 1, &len);
 


### PR DESCRIPTION
Lua to reproduce these crashes:
```
function do_hook_server_request()
        --ts.server_request.set_url_scheme('https')
        ts.debug(ts.server_request.get_url_host())
        --ts.debug(ts.server_request.get_url_scheme())
end


function do_remap()
        ts.hook(TS_LUA_HOOK_SEND_REQUEST_HDR, do_hook_server_request)

        return 0
end
```
