### PR TITLE
Add null pointer check to server response set status in Lua plugin

### DIFF
--- a/plugins/experimental/ts_lua/ts_lua_server_response.c
+++ b/plugins/experimental/ts_lua/ts_lua_server_response.c
@@ -291,7 +291,7 @@ ts_lua_server_response_set_status(lua_State *L)
 {
   int status;
   const char *reason;
-  int reason_len;
+  int reason_len = 0;
 
   ts_lua_http_ctx *http_ctx;
 
@@ -302,7 +302,9 @@ ts_lua_server_response_set_status(lua_State *L)
   status = luaL_checkint(L, 1);
 
   reason     = TSHttpHdrReasonLookup(status);
-  reason_len = strlen(reason);
+  if (reason) {
+      reason_len = strlen(reason);
+  }
 
   TSHttpHdrStatusSet(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, status);
   TSHttpHdrReasonSet(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, reason, reason_len);

--- a/plugins/experimental/ts_lua/ts_lua_server_response.c
+++ b/plugins/experimental/ts_lua/ts_lua_server_response.c
@@ -301,9 +301,9 @@ ts_lua_server_response_set_status(lua_State *L)
 
   status = luaL_checkint(L, 1);
 
-  reason     = TSHttpHdrReasonLookup(status);
+  reason = TSHttpHdrReasonLookup(status);
   if (reason) {
-      reason_len = strlen(reason);
+    reason_len = strlen(reason);
   }
 
   TSHttpHdrStatusSet(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, status);


### PR DESCRIPTION
Lua code to reproduce this crash:
```
function do_hook_server_response()
	ts.server_response.set_status(418)
end


function do_remap()
	ts.hook(TS_LUA_HOOK_READ_RESPONSE_HDR, do_hook_server_response)

	return 0
end
```