### PR TITLE
TS-4976: Regularize plugins - session_hooks (nee session-1).

### DIFF
--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -50,6 +50,7 @@ example_Plugins = \
 	secure_link.la \
 	server_push.la \
 	server_transform.la \
+	session_hooks.la \
 	ssl-preaccept.la \
 	ssl-sni-whitelist.la \
 	ssl-sni.la \
@@ -127,10 +128,7 @@ thread_1_la_SOURCES = thread-1/thread-1.c
 txn_data_sink_la_SOURCES = txn-data-sink/txn-data-sink.c
 version_la_SOURCES = version/version.c
 redirect_1_la_SOURCES = redirect_1/redirect_1.c
-
-# The following examples do not build:
-#
-# session_1_la_SOURCES = session-1/session-1.c
+session_hooks_la_SOURCES = session_hooks/session_hooks.c
 
 cppapi_AsyncHttpFetchStreaming_la_SOURCES = cppapi/async_http_fetch_streaming/AsyncHttpFetchStreaming.cc
 cppapi_AsyncHttpFetch_la_SOURCES = cppapi/async_http_fetch/AsyncHttpFetch.cc

--- a/example/session_hooks/session_hooks.c
+++ b/example/session_hooks/session_hooks.c
@@ -1,6 +1,6 @@
 /** @file
 
-  A brief file description
+  An example plugin that demonstrates session hook usage.
 
   @section license License
 
@@ -21,40 +21,33 @@
   limitations under the License.
  */
 
-/* session-1.c: a plugin that illustrates how to use
- *                session hooks
- *
- *
- *  Usage: session-1.so
- *
- */
-
 #include <stdio.h>
 #include "ts/ts.h"
 #include "ts/ink_defs.h"
 
-static INKStat transaction_count;
-static INKStat session_count;
-static INKStat av_transaction;
+#define PLUGIN_NAME "session_hooks"
+
+static int transaction_count_stat;
+static int session_count_stat;
 
 static void
 txn_handler(TSHttpTxn txnp, TSCont contp)
 {
-  int64_t num_txns = 0;
+  TSMgmtInt num_txns = 0;
 
-  INKStatIncrement(transaction_count);
-  num_txns = INKStatIntGet(transaction_count);
-  TSDebug("tag_session", "The number of transactions is %" PRId64, num_txns);
+  TSStatIntIncrement(transaction_count_stat, 1);
+  num_txns = TSStatIntGet(transaction_count_stat);
+  TSDebug(PLUGIN_NAME, "The number of transactions is %" PRId64, num_txns);
 }
 
 static void
 handle_session(TSHttpSsn ssnp, TSCont contp)
 {
-  int64_t num_ssn = 0;
+  TSMgmtInt num_ssn = 0;
 
-  INKStatIncrement(session_count);
-  num_ssn = INKStatIntGet(session_count);
-  TSDebug("tag_session", "The number of sessions is %" PRId64, num_ssn);
+  TSStatIntIncrement(session_count_stat, 1);
+  num_ssn = TSStatIntGet(session_count_stat);
+  TSDebug(PLUGIN_NAME, "The number of sessions is %" PRId64, num_ssn);
   TSHttpSsnHookAdd(ssnp, TS_HTTP_TXN_START_HOOK, contp);
 }
 
@@ -79,7 +72,7 @@ ssn_handler(TSCont contp, TSEvent event, void *edata)
     return 0;
 
   default:
-    TSDebug("tag_session", "In the default case: event = %d", event);
+    TSDebug(PLUGIN_NAME, "In the default case: event = %d", event);
     break;
   }
   return 0;
@@ -91,23 +84,22 @@ TSPluginInit(int argc, const char *argv[])
   TSCont contp;
   TSPluginRegistrationInfo info;
 
-  info.plugin_name   = "session-1";
-  info.vendor_name   = "MyCompany";
-  info.support_email = "ts-api-support@MyCompany.com";
+  info.plugin_name   = PLUGIN_NAME;
+  info.vendor_name   = "Apache Software Foundation";
+  info.support_email = "dev@trafficserver.apache.org";
 
   if (TSPluginRegister(&info) != TS_SUCCESS) {
-    TSError("[session-1] Plugin registration failed.\n");
+    TSError("[%s] Plugin registration failed.\n", PLUGIN_NAME);
 
     goto error;
   }
 
-  transaction_count = INKStatCreate("transaction.count", INKSTAT_TYPE_INT64);
-  session_count     = INKStatCreate("session.count", INKSTAT_TYPE_INT64);
-  av_transaction    = INKStatCreate("avg.transactions", INKSTAT_TYPE_FLOAT);
+  transaction_count_stat = TSStatCreate("transaction.count", TS_RECORDDATATYPE_INT, TS_STAT_NON_PERSISTENT, TS_STAT_SYNC_SUM);
+  session_count_stat     = TSStatCreate("session.count", TS_RECORDDATATYPE_INT, TS_STAT_NON_PERSISTENT, TS_STAT_SYNC_SUM);
 
   contp = TSContCreate(ssn_handler, NULL);
   TSHttpHookAdd(TS_HTTP_SSN_START_HOOK, contp);
 
 error:
-  TSError("[session-1] Plugin not initialized");
+  TSError("[%s] Plugin not initialized", PLUGIN_NAME);
 }


### PR DESCRIPTION
A bit more involved. This plugin was disable from the build because it used the very old style plugin stat calls  and was never updated. This change renames it from 'session-1' to the IMHO more informative 'session_hooks' because it is an example of using session hooks and updated the stat calls to the current API.