### PR TITLE
Update TSContSchedule.en.rst

### DIFF
--- a/doc/developer-guide/api/functions/TSContSchedule.en.rst
+++ b/doc/developer-guide/api/functions/TSContSchedule.en.rst
@@ -31,7 +31,7 @@ Synopsis
 Description
 ===========
 
-Schedules :arg:`contp` to run :arg:`delay` nanoseconds in the future. This is approximate. The delay
+Schedules :arg:`contp` to run :arg:`delay` milliseconds in the future. This is approximate. The delay
 will be at least :arg:`delay` but possibly more. Resultions finer than roughly 5 milliseconds will
 not be effective. :arg:`contp` is required to have a mutex, which is provided to
 :func:`TSContCreate`.


### PR DESCRIPTION
Fix Documentation bug: the function takes its argument in milliseconds instead of nanoseconds.