### PR TITLE
Backport PR 2338 to 7.1.x - Add null pointer check to server response set status in Lua plugin

### DIFF
--- a/plugins/experimental/ts_lua/ts_lua_server_response.c
+++ b/plugins/experimental/ts_lua/ts_lua_server_response.c
@@ -291,7 +291,7 @@ ts_lua_server_response_set_status(lua_State *L)
 {
   int status;
   const char *reason;
-  int reason_len;
+  int reason_len = 0;
 
   ts_lua_http_ctx *http_ctx;
 
@@ -302,7 +302,9 @@ ts_lua_server_response_set_status(lua_State *L)
   status = luaL_checkint(L, 1);
 
   reason     = TSHttpHdrReasonLookup(status);
-  reason_len = strlen(reason);
+  if (reason) {
+      reason_len = strlen(reason);
+  }
 
   TSHttpHdrStatusSet(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, status);
   TSHttpHdrReasonSet(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, reason, reason_len);

--- a/plugins/experimental/ts_lua/ts_lua_server_response.c
+++ b/plugins/experimental/ts_lua/ts_lua_server_response.c
@@ -301,9 +301,9 @@ ts_lua_server_response_set_status(lua_State *L)
 
   status = luaL_checkint(L, 1);
 
-  reason     = TSHttpHdrReasonLookup(status);
+  reason = TSHttpHdrReasonLookup(status);
   if (reason) {
-      reason_len = strlen(reason);
+    reason_len = strlen(reason);
   }
 
   TSHttpHdrStatusSet(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, status);


### PR DESCRIPTION
This is a backport of #2338 to 7.1.x

(cherry picked from 84bc7ab86a020c1ff418014ac65da9f0483deafc  and a0aca6f911445ed3492177cbb24b5ee50bfa39e1)