### PR TITLE
Session ticket resumption needs consistent CA-certificate version

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3133,7 +3133,8 @@ SSL Termination
 
    The filename of the default and global ticket key for SSL sessions. The location is relative to the
    :ts:cv:`proxy.config.ssl.server.cert.path` directory. One way to generate this would be to run
-   ``head -c48 /dev/urandom | openssl enc -base64 | head -c48 > file.ticket``.
+   ``head -c48 /dev/urandom | openssl enc -base64 | head -c48 > file.ticket``. Also
+   note that OpenSSL session tickets are sensitive to the version of the ca-certificates.
 
 .. ts:cv:: CONFIG proxy.config.ssl.max_record_size INT 0
 


### PR DESCRIPTION
OpenSSL session tickets are sensitive to the version of the
ca-certificates OEL/RHEL package.

We had ~200 machines with 1 version of ca-certificates-... , and the
rest with another version. Sessions generated with the “old”
ca-cerficates do not resume with the newer CAs (and vice versa). Hoping
other can avoid this confusion with this note.