### PR TITLE
corrects HTTP status 0 to 302 on redirect

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -704,7 +704,12 @@ HttpTransact::EndRemapRequest(State *s)
       error_body_type = "redirect#moved_temporarily";
       break;
     default:
-      Warning("Invalid status code for redirect '%d'. Building a response for a temporary redirect.", s->http_return_code);
+      if (HTTP_STATUS_NONE == s->http_return_code) {
+        s->http_return_code = HTTP_STATUS_MOVED_TEMPORARILY;
+        Warning("Changed status code from '0' to '%d'.", s->http_return_code);
+      } else {
+        Warning("Using invalid status code for redirect '%d'. Building a response for a temporary redirect.", s->http_return_code);
+      }
       error_body_type = "redirect#moved_temporarily";
     }
     build_error_response(s, s->http_return_code, "Redirect", error_body_type);

--- a/tests/gold_tests/headers/data/www.redirect0.test_get.txt
+++ b/tests/gold_tests/headers/data/www.redirect0.test_get.txt
@@ -1,0 +1,2 @@
+GET http://www.redirect0.test/ HTTP/1.1
+

--- a/tests/gold_tests/headers/redirect0_get.gold
+++ b/tests/gold_tests/headers/redirect0_get.gold
@@ -1,0 +1,22 @@
+HTTP/1.1 302 Redirect
+Connection: keep-alive
+Cache-Control: no-store
+Location: http://www.redirect0.test/
+Content-Type: text/html
+Content-Language: en
+Content-Length: 308
+
+<HTML>
+<HEAD>
+<TITLE>Document Has Moved</TITLE>
+</HEAD>
+
+<BODY BGCOLOR="white" FGCOLOR="black">
+<H1>Document Has Moved</H1>
+<HR>
+
+<FONT FACE="Helvetica,Arial"><B>
+Description: The document you requested has moved to a new location.  The new location is "http://www.redirect0.test/".
+</B></FONT>
+<HR>
+</BODY>


### PR DESCRIPTION
Fields I don't have permission to edit:
* Milestone: v8.0.0
* Labels: Backport, HTTP
* Projects: 7.x releases

Backport notes:
* Not an emergency.
* This can fix potential issues in remap plugins when a redirect is requested but the plugin does not set a status code. Formerly in this case a bug led ATS to set 302, and this restores the old behavior for the status 0 case.
* Depends on #2168.