### PR TITLE
Avoid closing the last netvc if accept_till_done is set

### DIFF
--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -470,6 +470,7 @@ NetAccept::acceptFastEvent(int event, void *ep)
     } else {
       close_UnixNetVConnection(vc, e->ethread);
     }
+    vc = nullptr;
   } while (loop);
 
 Ldone:


### PR DESCRIPTION
if the `accept_till_done` is set and we have got a netvc in the last loop, 
and the `accept4()` failed (`res < 0`),
and the `NetAccept` is cancelled.

It is goto Lerror, it will close the last netvc.