### PR TITLE
Fix coverity issues 1379739 - 1379741

### DIFF
--- a/iocore/utils/Machine.cc
+++ b/iocore/utils/Machine.cc
@@ -293,21 +293,19 @@ Machine::insert_id(char *id)
 {
   char lower_case_name[TS_MAX_HOST_NAME_LEN + 1] = {0};
   char *value                                    = nullptr;
-  size_t len                                     = strlen(id);
 
-  value = static_cast<char *>(ats_malloc(len + 1));
   make_to_lower_case(id, lower_case_name, sizeof(lower_case_name));
-  strncpy(value, lower_case_name, strlen(lower_case_name));
+  value = ats_strndup(lower_case_name, strlen(lower_case_name));
   ink_hash_table_insert(machine_id_strings, lower_case_name, value);
 }
 
 void
 Machine::insert_id(IpAddr *ipaddr)
 {
-  int length         = INET6_ADDRSTRLEN + 1;
-  char *string_value = static_cast<char *>(ats_calloc(length, 1));
+  int length = INET6_ADDRSTRLEN + 1;
 
   if (ipaddr != nullptr) {
+    char *string_value = static_cast<char *>(ats_calloc(length, 1));
     ipaddr->toString(string_value, length);
     ink_hash_table_insert(machine_id_strings, string_value, string_value);
     ink_hash_table_insert(machine_id_ipaddrs, string_value, ipaddr);

--- a/iocore/utils/Machine.cc
+++ b/iocore/utils/Machine.cc
@@ -295,12 +295,10 @@ Machine::insert_id(char *id)
   char *value                                    = nullptr;
   size_t len                                     = strlen(id);
 
-  if (id != nullptr) {
-    value = static_cast<char *>(ats_malloc(len));
-    make_to_lower_case(id, lower_case_name, sizeof(lower_case_name));
-    strncpy(value, lower_case_name, strlen(lower_case_name));
-    ink_hash_table_insert(machine_id_strings, lower_case_name, value);
-  }
+  value = static_cast<char *>(ats_malloc(len + 1));
+  make_to_lower_case(id, lower_case_name, sizeof(lower_case_name));
+  strncpy(value, lower_case_name, strlen(lower_case_name));
+  ink_hash_table_insert(machine_id_strings, lower_case_name, value);
 }
 
 void


### PR DESCRIPTION
This fixes coverity issues 1379740 and 1379741 introduced by commit 7530f775f603e055eb8cfab2a4d6fdcf8685d3b4.  The resource leak reported by 1379739 does not exist as the memory is released in the ~Machine DTOR.