### PR TITLE
Modernize literal 0 to nullptr

### DIFF
--- a/iocore/eventsystem/I_Continuation.h
+++ b/iocore/eventsystem/I_Continuation.h
@@ -148,7 +148,7 @@ public:
 
   */
   int
-  handleEvent(int event = CONTINUATION_EVENT_NONE, void *data = 0)
+  handleEvent(int event = CONTINUATION_EVENT_NONE, void *data = nullptr)
   {
     return (this->*handler)(event, data);
   }

--- a/iocore/eventsystem/I_SocketManager.h
+++ b/iocore/eventsystem/I_SocketManager.h
@@ -77,9 +77,9 @@ struct SocketManager {
 
   // result is the number of bytes or -errno
   int64_t read(int fd, void *buf, int len, void *pOLP = nullptr);
-  int64_t vector_io(int fd, struct iovec *vector, size_t count, int read_request, void *pOLP = 0);
+  int64_t vector_io(int fd, struct iovec *vector, size_t count, int read_request, void *pOLP = nullptr);
   int64_t readv(int fd, struct iovec *vector, size_t count);
-  int64_t read_vector(int fd, struct iovec *vector, size_t count, void *pOLP = 0);
+  int64_t read_vector(int fd, struct iovec *vector, size_t count, void *pOLP = nullptr);
   int64_t pread(int fd, void *buf, int len, off_t offset, char *tag = nullptr);
 
   int recv(int s, void *buf, int len, int flags);
@@ -87,12 +87,12 @@ struct SocketManager {
 
   int64_t write(int fd, void *buf, int len, void *pOLP = nullptr);
   int64_t writev(int fd, struct iovec *vector, size_t count);
-  int64_t write_vector(int fd, struct iovec *vector, size_t count, void *pOLP = 0);
+  int64_t write_vector(int fd, struct iovec *vector, size_t count, void *pOLP = nullptr);
   int64_t pwrite(int fd, void *buf, int len, off_t offset, char *tag = nullptr);
 
   int send(int fd, void *buf, int len, int flags);
   int sendto(int fd, void *buf, int len, int flags, struct sockaddr const *to, int tolen);
-  int sendmsg(int fd, struct msghdr *m, int flags, void *pOLP = 0);
+  int sendmsg(int fd, struct msghdr *m, int flags, void *pOLP = nullptr);
   int64_t lseek(int fd, off_t offset, int whence);
   int fstat(int fd, struct stat *);
   int unlink(char *buf);

--- a/lib/ts/IpMap.h
+++ b/lib/ts/IpMap.h
@@ -191,7 +191,7 @@ public:
   */
   self &mark(sockaddr const *min, ///< Minimum value in range.
              sockaddr const *max, ///< Maximum value in range.
-             void *data = 0       ///< Client data payload.
+             void *data = nullptr ///< Client data payload.
              );
 
   /** Mark a range.
@@ -199,9 +199,9 @@ public:
       @note Convenience overload for IPv4 addresses.
       @return This object.
   */
-  self &mark(in_addr_t min, ///< Minimum address (network order).
-             in_addr_t max, ///< Maximum address (network order).
-             void *data = 0 ///< Client data.
+  self &mark(in_addr_t min,       ///< Minimum address (network order).
+             in_addr_t max,       ///< Maximum address (network order).
+             void *data = nullptr ///< Client data.
              );
 
   /** Mark a range.
@@ -209,9 +209,9 @@ public:
       @note Convenience overload for IPv4 addresses.
       @return This object.
   */
-  self &mark(IpAddr const &min, ///< Minimum address (network order).
-             IpAddr const &max, ///< Maximum address (network order).
-             void *data = 0     ///< Client data.
+  self &mark(IpAddr const &min,   ///< Minimum address (network order).
+             IpAddr const &max,   ///< Maximum address (network order).
+             void *data = nullptr ///< Client data.
              );
 
   /** Mark an IPv4 address @a addr with @a data.
@@ -219,8 +219,8 @@ public:
       @note Convenience overload for IPv4 addresses.
       @return This object.
   */
-  self &mark(in_addr_t addr, ///< Address (network order).
-             void *data = 0  ///< Client data.
+  self &mark(in_addr_t addr,      ///< Address (network order).
+             void *data = nullptr ///< Client data.
              );
 
   /** Mark a range.
@@ -230,7 +230,7 @@ public:
   */
   self &mark(IpEndpoint const *min, ///< Minimum address (network order).
              IpEndpoint const *max, ///< Maximum address (network order).
-             void *data = 0         ///< Client data.
+             void *data = nullptr   ///< Client data.
              );
 
   /** Mark an address @a addr with @a data.
@@ -239,7 +239,7 @@ public:
       @return This object.
   */
   self &mark(IpEndpoint const *addr, ///< Address (network order).
-             void *data = 0          ///< Client data.
+             void *data = nullptr    ///< Client data.
              );
 
   /** Unmark addresses.
@@ -270,11 +270,11 @@ public:
 
       @return This object.
   */
-  self &fill(sockaddr const *min, sockaddr const *max, void *data = 0);
+  self &fill(sockaddr const *min, sockaddr const *max, void *data = nullptr);
   /// Fill addresses (overload).
-  self &fill(IpEndpoint const *min, IpEndpoint const *max, void *data = 0);
+  self &fill(IpEndpoint const *min, IpEndpoint const *max, void *data = nullptr);
   /// Fill addresses (overload).
-  self &fill(in_addr_t min, in_addr_t max, void *data = 0);
+  self &fill(in_addr_t min, in_addr_t max, void *data = nullptr);
 
   /** Test for membership.
 
@@ -283,7 +283,7 @@ public:
       is set to the client data for the address.
   */
   bool contains(sockaddr const *target, ///< Search target (network order).
-                void **ptr = 0          ///< Client data return.
+                void **ptr = nullptr    ///< Client data return.
                 ) const;
 
   /** Test for membership.
@@ -294,8 +294,8 @@ public:
       If the address is in the map and @a ptr is not @c nullptr, @c *ptr
       is set to the client data for the address.
   */
-  bool contains(in_addr_t target, ///< Search target (network order).
-                void **ptr = 0    ///< Client data return.
+  bool contains(in_addr_t target,    ///< Search target (network order).
+                void **ptr = nullptr ///< Client data return.
                 ) const;
 
   /** Test for membership.
@@ -307,7 +307,7 @@ public:
       is set to the client data for the address.
   */
   bool contains(IpEndpoint const *target, ///< Search target (network order).
-                void **ptr = 0            ///< Client data return.
+                void **ptr = nullptr      ///< Client data return.
                 ) const;
 
   /** Test for membership.
@@ -319,7 +319,7 @@ public:
       is set to the client data for the address.
   */
   bool contains(IpAddr const &target, ///< Search target (network order).
-                void **ptr = 0        ///< Client data return.
+                void **ptr = nullptr  ///< Client data return.
                 ) const;
 
   /** Remove all addresses from the map.

--- a/plugins/esi/lib/HandlerManager.h
+++ b/plugins/esi/lib/HandlerManager.h
@@ -55,7 +55,7 @@ private:
   struct ModuleHandles {
     void *object;
     SpecialIncludeHandlerCreator function;
-    ModuleHandles(void *o = 0, SpecialIncludeHandlerCreator f = 0) : object(o), function(f){};
+    ModuleHandles(void *o = nullptr, SpecialIncludeHandlerCreator f = 0) : object(o), function(f){};
   };
 
   typedef std::map<std::string, ModuleHandles> ModuleHandleMap;

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -821,7 +821,7 @@ public:
     CacheAuth_t www_auth_content = CACHE_AUTH_NONE;
 
     // INK API/Remap API plugin interface
-    void *remap_plugin_instance = 0;
+    void *remap_plugin_instance = nullptr;
     void *user_args[HTTP_SSN_TXN_MAX_USER_ARG];
     remap_plugin_info::_tsremap_os_response *fp_tsremap_os_response = nullptr;
     HTTPStatus http_return_code                                     = HTTP_STATUS_NONE;


### PR DESCRIPTION
Replace literal 0 with nullptr if it is matched `void \*\S* = 0`.