### PR TITLE
Fix map_with_referer to work and add tests for it.

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -660,6 +660,12 @@ HttpTransact::StartRemapRequest(State *s)
     obj_describe(s->hdr_info.client_request.m_http, true);
   }
 
+  if (s->http_config_param->referer_filter_enabled) {
+    s->filter_mask = URL_REMAP_FILTER_REFERER;
+    if (s->http_config_param->referer_format_redirect)
+      s->filter_mask |= URL_REMAP_FILTER_REDIRECT_FMT;
+  }
+
   DebugTxn("http_trans", "END HttpTransact::StartRemapRequest");
   TRANSACT_RETURN(SM_ACTION_API_PRE_REMAP, HttpTransact::PerformRemap);
 }

--- a/proxy/http/remap/RemapProcessor.cc
+++ b/proxy/http/remap/RemapProcessor.cc
@@ -227,7 +227,8 @@ RemapProcessor::finish_remap(HttpTransact::State *s)
       if (*redirect_url == nullptr) {
         *redirect_url = ats_strdup(map->filter_redirect_url ? map->filter_redirect_url : rewrite_table->http_default_redirect_url);
       }
-
+      if (HTTP_STATUS_NONE == s->http_return_code)
+        s->http_return_code = HTTP_STATUS_MOVED_TEMPORARILY;
       return false;
     }
   }

--- a/tests/gold_tests/remap/gold/remap-redirect.gold
+++ b/tests/gold_tests/remap/gold/remap-redirect.gold
@@ -1,0 +1,15 @@
+``
+> GET http://test3.com``
+> Host: test3.com``
+> User-Agent: curl/``
+> Accept: */*
+``
+< HTTP/1.1 301 Redirect
+< Date: ``
+< Proxy-Connection: ``
+< Server: ATS/``
+< Cache-Control: ``
+< Location: http://httpbin.org/
+``
+< Content-Length: ``
+``

--- a/tests/gold_tests/remap/gold/remap-referer-hit.gold
+++ b/tests/gold_tests/remap/gold/remap-referer-hit.gold
@@ -1,0 +1,14 @@
+``
+> GET http://test4.com``
+> Host: test4.com``
+> User-Agent: curl/``
+> Accept: */*
+``
+< HTTP/1.1 200 OK
+< Date: ``
+< Age: ``
+< Transfer-Encoding: chunked
+< Proxy-Connection: keep-alive
+< Server: ATS/``
+< 
+``

--- a/tests/gold_tests/remap/gold/remap-referer-miss.gold
+++ b/tests/gold_tests/remap/gold/remap-referer-miss.gold
@@ -1,0 +1,15 @@
+``
+> GET http://test4.com``
+> Host: test4.com``
+> User-Agent: curl/``
+> Accept: */*
+``
+< HTTP/1.1 302 Redirect
+< Date: ``
+< Proxy-Connection: ``
+< Server: ATS/``
+< Cache-Control: ``
+< Location: http://httpbin.org
+``
+< Content-Length: ``
+``


### PR DESCRIPTION
Changes for TS-3692 (commit 17342dbab5579c8f9c04afc6b1201ca18f6dcf78) broke `map_with_referer` in effect disabling the configuration setting that enabled it. This restores that functionality and adds tests to verify it.