### PR TITLE
Delay creation of transaction until user agent sends request.

### DIFF
--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -451,7 +451,7 @@ Http1ClientSession::reenable(VIO *vio)
 void
 Http1ClientSession::release(ProxyClientTransaction *trans)
 {
-  ink_assert(read_state == HCS_ACTIVE_READER);
+  ink_assert(read_state == HCS_ACTIVE_READER || read_state == HCS_INIT);
 
   // Clean up the write VIO in case of inactivity timeout
   this->do_io_write(nullptr, 0, nullptr);

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -62,8 +62,8 @@ public:
   virtual void
   start()
   {
-    // Create a new transaction object and kick it off
-    this->new_transaction();
+    // Troll for data to get a new transaction
+    this->release(&trans);
   }
 
   void new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader, bool backdoor);


### PR DESCRIPTION
One of groups saw an increase in ttms latencies reported in the logs when moving from openssl 1.0.1 to openssl 1.0.2.  We eventually tracked it down to the fact that the original code would report that the 0 length write would be reported as complete immediately after the TLS handshake completed.  This would exercise the NextProtocol trampoline which would create a Http1ClientSession object and call start() on it.  This would create a HttpSM which would start the clock on the transaction.

Changed the logic so the first transaction on a Http1ClientSession is treated the same as all the other transactions on the client session.  The session goes into keep_alive mode and only creates a transaction once data has been read (i.e. the user agent has sent data above and beyond the handshake).  

Since there is additional frame data processed to get a client request over HTTP/2, no change is needed there.

Still not clear why this isn't always a problem or why changing openssl versions affects anything.  But the underlying change seems good in any case.