### PR TITLE
Coverity 1379933:  Control flow issues  (DEADCODE)

### DIFF
--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -479,9 +479,6 @@ Ldone:
 Lerror:
   server.close();
   e->cancel();
-  if (vc) {
-    vc->free(e->ethread);
-  }
   NET_DECREMENT_DYN_STAT(net_accepts_currently_open_stat);
   delete this;
   return EVENT_DONE;


### PR DESCRIPTION
```
** CID 1379933:  Control flow issues  (DEADCODE)
/iocore/net/UnixNetAccept.cc: 483 in NetAccept::acceptFastEvent(int, void *)()


________________________________________________________________________________________________________
*** CID 1379933:  Control flow issues  (DEADCODE)
/iocore/net/UnixNetAccept.cc: 483 in NetAccept::acceptFastEvent(int, void *)()
477       return EVENT_CONT;
478
479     Lerror:
480       server.close();
481       e->cancel();
482       if (vc) {
>>>     CID 1379933:  Control flow issues  (DEADCODE)
>>>     Execution cannot reach this statement: "vc->free(e->ethread);".
483         vc->free(e->ethread);
484       }
485       NET_DECREMENT_DYN_STAT(net_accepts_currently_open_stat);
486       delete this;
487       return EVENT_DONE;
488     }
```

Caused by PR #2408 
