### PR TITLE
clarifies traffic_ctl dependency on traffic_manager

### DIFF
--- a/doc/appendices/command-line/traffic_ctl.en.rst
+++ b/doc/appendices/command-line/traffic_ctl.en.rst
@@ -51,6 +51,8 @@ of subcommands that control different aspects of Traffic Server:
 :program:`traffic_ctl plugin`
     Interact with plugins.
 
+To use :program:`traffic_ctl`, :ref:`traffic_manager` needs to be running.
+
 Options
 =======
 


### PR DESCRIPTION
I did not update the Japanese [localized text](https://github.com/apache/trafficserver/blob/a7be6ec083dc3d7aafd6f392b7dc841957d3a26a/doc/locale/ja/LC_MESSAGES/admin-guide/introduction.en.po#L435-L440) because it seems out of date, and also because I don't know Japanese.