### PR TITLE
Coverity CID 1380022: FORWARD_NULL

### DIFF
--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1145,7 +1145,7 @@ UnixNetVConnection::acceptEvent(int event, Event *e)
   PollDescriptor *pd = get_PollDescriptor(thread);
   if (ep.start(pd, this, EVENTIO_READ | EVENTIO_WRITE) < 0) {
     Debug("iocore_net", "acceptEvent : failed EventIO::start");
-    close_UnixNetVConnection(this, e->ethread);
+    close_UnixNetVConnection(this, t);
     return EVENT_DONE;
   }
 


### PR DESCRIPTION
```
*** CID 1380022:    (FORWARD_NULL)
/iocore/net/UnixNetVConnection.cc: 1148 in UnixNetVConnection::acceptEvent(int, Event *)()
1142       SET_HANDLER((NetVConnHandler)&UnixNetVConnection::mainEvent);
1143
1144       nh                 = get_NetHandler(thread);
1145       PollDescriptor *pd = get_PollDescriptor(thread);
1146       if (ep.start(pd, this, EVENTIO_READ | EVENTIO_WRITE) < 0) {
1147         Debug("iocore_net", "acceptEvent : failed EventIO::start");
>>>     CID 1380022:    (FORWARD_NULL)
>>>     Dereferencing null pointer "e".
1148         close_UnixNetVConnection(this, e->ethread);
1149         return EVENT_DONE;
1150       }
1151
1152       set_inactivity_timeout(0);
1153       nh->open_list.enqueue(this);
/iocore/net/UnixNetVConnection.cc: 1122 in UnixNetVConnection::acceptEvent(int, Event *)()
1116       return EVENT_DONE;
1117     }
1118
1119     int
1120     UnixNetVConnection::acceptEvent(int event, Event *e)
1121     {
>>>     CID 1380022:    (FORWARD_NULL)
>>>     Comparing "e" to null implies that "e" might be null.
1122       EThread *t = (e == nullptr) ? this_ethread() : e->ethread;
1123
1124       MUTEX_TRY_LOCK(lock, get_NetHandler(t)->mutex, t);
1125       if (!lock.is_locked()) {
1126         if (event == EVENT_NONE) {
1127           t->schedule_in(this, HRTIME_MSECONDS(net_retry_delay));
```