### PR TITLE
Optimize: Add startIO & stopIO for NetHandler

### DIFF
--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -90,6 +90,7 @@ class SSLNetVConnection : public UnixNetVConnection
 
 public:
   int sslStartHandShake(int event, int &err) override;
+  void clear() override;
   void free(EThread *t) override;
 
   virtual void

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -276,6 +276,7 @@ public:
    * This is logic is invoked when the NetVC object is created in a new thread context
    */
   virtual int populate(Connection &con, Continuation *c, void *arg);
+  virtual void clear();
   virtual void free(EThread *t);
 
   ink_hrtime get_inactivity_timeout() override;

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -83,10 +83,10 @@ close_UnixNetVConnection(UnixNetVConnection *vc, EThread *t)
   }
   NetHandler *nh = vc->nh;
   vc->cancel_OOB();
-  vc->ep.stop();
 
   ink_release_assert(vc->thread == t);
 
+  // 1. Cancel timeout
   vc->next_inactivity_timeout_at = 0;
   vc->next_activity_timeout_at   = 0;
 
@@ -94,21 +94,15 @@ close_UnixNetVConnection(UnixNetVConnection *vc, EThread *t)
   vc->active_timeout_in     = 0;
 
   if (nh) {
+    // 2. Release vc from InactivityCop.
     nh->open_list.remove(vc);
     nh->cop_list.remove(vc);
-    nh->read_ready_list.remove(vc);
-    nh->write_ready_list.remove(vc);
-    if (vc->read.in_enabled_list) {
-      nh->read_enable_list.remove(vc);
-      vc->read.in_enabled_list = 0;
-    }
-    if (vc->write.in_enabled_list) {
-      nh->write_enable_list.remove(vc);
-      vc->write.in_enabled_list = 0;
-    }
     vc->remove_from_keep_alive_queue();
     vc->remove_from_active_queue();
+    // 3. Release vc from NetHandler.
+    nh->stopIO(vc);
   }
+  // 4. Clear then deallocate vc.
   vc->free(t);
 }
 
@@ -1118,9 +1112,10 @@ UnixNetVConnection::startEvent(int /* event ATS_UNUSED */, Event *e)
 int
 UnixNetVConnection::acceptEvent(int event, Event *e)
 {
-  EThread *t = (e == nullptr) ? this_ethread() : e->ethread;
+  EThread *t    = (e == nullptr) ? this_ethread() : e->ethread;
+  NetHandler *h = get_NetHandler(t);
 
-  MUTEX_TRY_LOCK(lock, get_NetHandler(t)->mutex, t);
+  MUTEX_TRY_LOCK(lock, h->mutex, t);
   if (!lock.is_locked()) {
     if (event == EVENT_NONE) {
       t->schedule_in(this, HRTIME_MSECONDS(net_retry_delay));
@@ -1138,28 +1133,22 @@ UnixNetVConnection::acceptEvent(int event, Event *e)
     return EVENT_DONE;
   }
 
-  SET_HANDLER((NetVConnHandler)&UnixNetVConnection::mainEvent);
-
-  PollDescriptor *pd = get_PollDescriptor(thread);
-  if (ep.start(pd, this, EVENTIO_READ | EVENTIO_WRITE) < 0) {
-    Debug("iocore_net", "acceptEvent : failed EventIO::start");
+  // Send this NetVC to NetHandler and start to polling read & write event.
+  if (h->startIO(this) < 0) {
     free(t);
     return EVENT_DONE;
   }
 
-  nh = get_NetHandler(thread);
-  set_inactivity_timeout(0);
-  nh->open_list.enqueue(this);
+  // Setup a timeout callback handler.
+  SET_HANDLER((NetVConnHandler)&UnixNetVConnection::mainEvent);
 
-#ifdef USE_EDGE_TRIGGER
-  // Set the vc as triggered and place it in the read ready queue in case there is already data on the socket.
-  Debug("iocore_net", "acceptEvent : Setting triggered and adding to the read ready queue");
-  read.triggered = 1;
-  nh->read_ready_list.enqueue(this);
-#endif
+  // All NetVCs in the open_list is checked for timeout by InactivityCop.
+  nh->open_list.enqueue(this);
 
   if (inactivity_timeout_in) {
     UnixNetVConnection::set_inactivity_timeout(inactivity_timeout_in);
+  } else {
+    set_inactivity_timeout(0);
   }
 
   if (active_timeout_in) {
@@ -1248,25 +1237,22 @@ UnixNetVConnection::populate(Connection &con_in, Continuation *c, void *arg)
   this->mutex  = c->mutex;
   this->thread = this_ethread();
 
-  EThread *t = this_ethread();
-  if (ep.start(get_PollDescriptor(t), this, EVENTIO_READ | EVENTIO_WRITE) < 0) {
-    // EEXIST should be ok, though it should have been cleared before we got back here
-    if (errno != EEXIST) {
-      Debug("iocore_net", "populate : Failed to add to epoll list");
-      return EVENT_ERROR;
-    }
-  }
+  EThread *t    = this_ethread();
+  NetHandler *h = get_NetHandler(t);
 
-  SET_HANDLER(&UnixNetVConnection::mainEvent);
-
-  this->nh = get_NetHandler(t);
-  ink_assert(this->nh != nullptr);
-  MUTEX_TRY_LOCK(lock, this->nh->mutex, t);
+  MUTEX_TRY_LOCK(lock, h->mutex, t);
   if (!lock.is_locked()) {
     // Clean up and go home
     return EVENT_ERROR;
   }
-  ink_assert(nh->mutex->thread_holding == this_ethread());
+
+  if (h->startIO(this) < 0) {
+    Debug("iocore_net", "populate : Failed to add to epoll list");
+    return EVENT_ERROR;
+  }
+
+  ink_assert(this->nh != nullptr);
+  SET_HANDLER(&UnixNetVConnection::mainEvent);
   ink_assert(!nh->open_list.in(this));
   this->nh->open_list.enqueue(this);
   ink_assert(this->con.fd != NO_FD);
@@ -1276,14 +1262,14 @@ UnixNetVConnection::populate(Connection &con_in, Continuation *c, void *arg)
 int
 UnixNetVConnection::connectUp(EThread *t, int fd)
 {
+  ink_assert(get_NetHandler(t)->mutex->thread_holding == this_ethread());
   int res;
 
   thread = t;
   if (check_net_throttle(CONNECT, submit_time)) {
     check_throttle_warning();
-    action_.continuation->handleEvent(NET_EVENT_OPEN_FAILED, (void *)-ENET_THROTTLING);
-    free(t);
-    return CONNECT_FAILURE;
+    res = -ENET_THROTTLING;
+    goto fail;
   }
 
   // Force family to agree with remote (server) address.
@@ -1334,46 +1320,40 @@ UnixNetVConnection::connectUp(EThread *t, int fd)
 
   // Must connect after EventIO::Start() to avoid a race condition
   // when edge triggering is used.
-  if (ep.start(get_PollDescriptor(t), this, EVENTIO_READ | EVENTIO_WRITE) < 0) {
-    res = -errno;
-    Debug("iocore_net", "connectUp : Failed to add to epoll list : %s", strerror(errno));
+  if ((res = get_NetHandler(t)->startIO(this)) < 0) {
     goto fail;
   }
 
   if (fd == NO_FD) {
     res = con.connect(nullptr, options);
     if (res != 0) {
+      // fast stopIO
+      nh = nullptr;
       goto fail;
     }
   }
 
-  // start up next round immediately
-
+  // Setup a timeout callback handler.
   SET_HANDLER(&UnixNetVConnection::mainEvent);
-
-  nh = get_NetHandler(t);
-  set_inactivity_timeout(0);
+  // All NetVCs in the open_list is checked for timeout by InactivityCop.
   nh->open_list.enqueue(this);
 
+  set_inactivity_timeout(0);
   ink_assert(!active_timeout_in);
   this->set_local_addr();
   action_.continuation->handleEvent(NET_EVENT_OPEN, this);
   return CONNECT_SUCCESS;
 
 fail:
-  lerrno = errno;
+  lerrno = -res;
   action_.continuation->handleEvent(NET_EVENT_OPEN_FAILED, (void *)(intptr_t)res);
   free(t);
   return CONNECT_FAILURE;
 }
 
 void
-UnixNetVConnection::free(EThread *t)
+UnixNetVConnection::clear()
 {
-  ink_release_assert(t == this_ethread());
-
-  // close socket fd
-  con.close();
   // clear variables for reuse
   this->mutex.clear();
   action_.mutex.clear();
@@ -1382,8 +1362,7 @@ UnixNetVConnection::free(EThread *t)
   attributes      = 0;
   read.vio.mutex.clear();
   write.vio.mutex.clear();
-  flags = 0;
-  SET_CONTINUATION_HANDLER(this, (NetVConnHandler)&UnixNetVConnection::startEvent);
+  flags               = 0;
   nh                  = nullptr;
   read.triggered      = 0;
   write.triggered     = 0;
@@ -1401,6 +1380,18 @@ UnixNetVConnection::free(EThread *t)
   ink_assert(!write.ready_link.prev && !write.ready_link.next);
   ink_assert(!write.enable_link.next);
   ink_assert(!link.next && !link.prev);
+}
+
+void
+UnixNetVConnection::free(EThread *t)
+{
+  ink_release_assert(t == this_ethread());
+
+  // close socket fd
+  con.close();
+
+  clear();
+  SET_CONTINUATION_HANDLER(this, (NetVConnHandler)&UnixNetVConnection::startEvent);
   ink_assert(con.fd == NO_FD);
   ink_assert(t == this_ethread());
 


### PR DESCRIPTION
startIO: put a netvc into NetHandler and start to polling read & write
event.

stopIO: stop polling read & write event and release a netvc from
NetHandler.