### PR TITLE
Test: fix body factory gold files to ignore irrelevant headers.

### DIFF
--- a/tests/gold_tests/body_factory/gold/http-get-200.gold
+++ b/tests/gold_tests/body_factory/gold/http-get-200.gold
@@ -1,6 +1,6 @@
 HTTP/1.1 200 OK
+``
 Content-Length: 47
-Age: 0
-Connection: keep-alive
+``
 
 This body should be returned for a GET request.

--- a/tests/gold_tests/body_factory/gold/http-get-304.gold
+++ b/tests/gold_tests/body_factory/gold/http-get-304.gold
@@ -1,5 +1,4 @@
 HTTP/1.1 304 Not Modified
-Age: 0
-Connection: keep-alive
+``
 Warning: 199 VERSION Proxy received unexpected 304 response; content may be stale
-
+``

--- a/tests/gold_tests/body_factory/gold/http-head-200.gold
+++ b/tests/gold_tests/body_factory/gold/http-head-200.gold
@@ -1,4 +1,2 @@
 HTTP/1.1 200 OK
-Age: 0
-Connection: keep-alive
-
+``


### PR DESCRIPTION
These tests don't need to verify connection keep alive nor the age in the cache of the response. More than one developer has gotten a PR hung up on false failures related to this.