### PR TITLE
Build: Change --enable-example-plugins to control both build and install.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -498,13 +498,13 @@ PKG_CHECK_MODULES([LIBMAGICKCPP],[Magick++], [
 AM_CONDITIONAL([BUILD_WEBP_TRANSFORM_PLUGIN], [test "x${enable_webp_transform_plugin}" = "xyes"])
 
 #
-# Example plugins. The example plugins are always built, but not always installed. Installing
+# Example plugins. The example plugins are only built and installed if this is enabled. Installing
 # them is useful for QA, but not useful for most users, so we default this to disabled.
 #
 
 AC_MSG_CHECKING([whether to install example plugins])
 AC_ARG_ENABLE([example-plugins],
-  [AS_HELP_STRING([--enable-example-plugins],[install example plugins])],
+  [AS_HELP_STRING([--enable-example-plugins],[build and install example plugins])],
   [],
   [enable_example_plugins=no]
 )

--- a/doc/developer-guide/plugins/example-plugins/index.en.rst
+++ b/doc/developer-guide/plugins/example-plugins/index.en.rst
@@ -47,7 +47,11 @@ understand the following topics:
 -  Working with HTTP header functions
 
 The two sample plugins discussed in this chapter are ``blacklist_1.c``
-and ``basic_auth.c``.
+and ``basic_auth.c``. To build and install the example plugins use ::
+
+   ./configure --enable-example-plugins
+
+when :ref:`setting the build configuration <admin-configuration-options>` for |TS|.
 
 Overview
 --------

--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -23,6 +23,8 @@ AM_LDFLAGS = $(TS_PLUGIN_LD_FLAGS)
 libatscppapi = $(top_builddir)/lib/cppapi/libatscppapi.la
 libtsconfig = $(top_builddir)/lib/tsconfig/libtsconfig.la
 
+if BUILD_EXAMPLE_PLUGINS
+
 example_Plugins = \
 	add_header.la \
 	append_transform.la \
@@ -86,10 +88,8 @@ example_Plugins += \
 	cppapi/boom.la \
 	cppapi/intercept.la
 
-if BUILD_EXAMPLE_PLUGINS
 pkglib_LTLIBRARIES = $(example_Plugins)
-else
-noinst_LTLIBRARIES = $(example_Plugins)
+
 endif
 
 add_header_la_SOURCES = add_header/add_header.c


### PR DESCRIPTION
It seems odd to me that `--enable-example-plugins` controls only the install of the examples, not whether they are built. This changes means the examples are either built and installed, or neither, with neither being the default.