### PR TITLE
FD leaks when ep.start() failed or cancelled in acceptEvent or con.connect() failed

### DIFF
--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -878,7 +878,6 @@ SSLNetVConnection::free(EThread *t)
 
   closed = 0;
   options.reset();
-  con.close();
 
   ink_assert(con.fd == NO_FD);
 


### PR DESCRIPTION
Currently, we have ```con.close()``` inside the ```SSLNetVConnection::free()``` but ```UnixNetVConnection::free()``` doesn't.

It makes socket fd leaks when:

- ep.start() failed inside UnixNetVConnection::connectUp
- action.cancelled inside UnixNetVConnection::acceptEvent
- con.connect() failed inside UnixNetVConnection::connectUp

The ```Connection::~Connection()``` is not called since the NetVC is deallocated by freelist.