### PR TITLE
Coverity: CID 1380037:  Resource leaks  (RESOURCE_LEAK)

### DIFF
--- a/lib/ts/ink_sock.cc
+++ b/lib/ts/ink_sock.cc
@@ -292,7 +292,7 @@ bind_unix_domain_socket(const char *path, mode_t mode)
 
   if (strlen(path) > sizeof(sockaddr.sun_path) - 1) {
     errno = ENAMETOOLONG;
-    return -1;
+    goto fail;
   }
 
   ink_zero(sockaddr);


### PR DESCRIPTION
```
** CID 1380037:  Resource leaks  (RESOURCE_LEAK)
/lib/ts/ink_sock.cc: 295 in bind_unix_domain_socket(const char *, unsigned int)()


________________________________________________________________________________________________________
*** CID 1380037:  Resource leaks  (RESOURCE_LEAK)
/lib/ts/ink_sock.cc: 295 in bind_unix_domain_socket(const char *, unsigned int)()
289       if (sockfd < 0) {
290         return sockfd;
291       }
292
293       if (strlen(path) > sizeof(sockaddr.sun_path) - 1) {
294         errno = ENAMETOOLONG;
>>>     CID 1380037:  Resource leaks  (RESOURCE_LEAK)
>>>     Handle variable "sockfd" going out of scope leaks the handle.
295         return -1;
296       }
297
298       ink_zero(sockaddr);
299       sockaddr.sun_family = AF_UNIX;
300       ink_strlcpy(sockaddr.sun_path, path, sizeof(sockaddr.sun_path));
```

Caused by PR #2425 