### PR TITLE
FD leaks when ep.start() failed or cancelled in acceptEvent or con.connect() failed

### DIFF
--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -892,7 +892,6 @@ SSLNetVConnection::free(EThread *t)
 
   closed = 0;
   options.reset();
-  con.close();
 
   ink_assert(con.fd == NO_FD);
 

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -94,7 +94,6 @@ close_UnixNetVConnection(UnixNetVConnection *vc, EThread *t)
   NetHandler *nh = vc->nh;
   vc->cancel_OOB();
   vc->ep.stop();
-  vc->con.close();
 
   ink_release_assert(vc->thread == t);
 
@@ -1152,14 +1151,14 @@ UnixNetVConnection::acceptEvent(int event, Event *e)
 
   SET_HANDLER((NetVConnHandler)&UnixNetVConnection::mainEvent);
 
-  nh                 = get_NetHandler(thread);
   PollDescriptor *pd = get_PollDescriptor(thread);
   if (ep.start(pd, this, EVENTIO_READ | EVENTIO_WRITE) < 0) {
     Debug("iocore_net", "acceptEvent : failed EventIO::start");
-    close_UnixNetVConnection(this, e->ethread);
+    free(e->ethread);
     return EVENT_DONE;
   }
 
+  nh = get_NetHandler(thread);
   set_inactivity_timeout(0);
   nh->open_list.enqueue(this);
 
@@ -1394,6 +1393,9 @@ void
 UnixNetVConnection::free(EThread *t)
 {
   ink_release_assert(t == this_ethread());
+
+  // close socket fd
+  con.close();
   // clear variables for reuse
   this->mutex.clear();
   action_.mutex.clear();


### PR DESCRIPTION
(cherry-pick from commit 9ded874c82de732d2c2d42c2b633d7e94adcb2e7)

Conflicts:
  iocore/net/UnixNetVConnection.cc