### PR TITLE
fixing memory leak when ATS serves stale records

### DIFF
--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -1364,8 +1364,8 @@ HostDBContinuation::dnsEvent(int event, HostEnt *e)
 
     int allocSize = s_size + rrsize; // The extra space we need for the rest of the things
 
-    Debug("hostdb", "allocating %d bytes for %s with %d RR records", allocSize, aname, valid_records);
     HostDBInfo *r = HostDBInfo::alloc(allocSize);
+    Debug("hostdb", "allocating %d bytes for %s with %d RR records at [%p]", allocSize, aname, valid_records, r);
     // set up the record
     r->key = md5.hash.fold(); // always set the key
 
@@ -1377,6 +1377,7 @@ HostDBContinuation::dnsEvent(int event, HostEnt *e)
     // which is okay with being served stale-- lets continue to serve the stale record as long as
     // the record is willing to be served.
     if (failed && old_r && old_r->serve_stale_but_revalidate()) {
+      r->free();
       r = old_r.get();
     } else if (is_byname()) {
       if (first_record) {

--- a/iocore/hostdb/I_HostDBProcessor.h
+++ b/iocore/hostdb/I_HostDBProcessor.h
@@ -159,6 +159,7 @@ struct HostDBInfo : public RefCountObj {
   void
   free()
   {
+    Debug("hostdb", "freeing %d bytes at [%p]", (1 << (7 + iobuffer_index)), this);
     ioBufAllocator[iobuffer_index].free_void((void *)(this));
   }
 


### PR DESCRIPTION
freeing allocated memory before assign it to a new raw ptr value.