### PR TITLE
S3_auth:uri(En|De)code() pass by ref,not val(master)

### DIFF
--- a/plugins/s3_auth/aws_auth_v4.cc
+++ b/plugins/s3_auth/aws_auth_v4.cc
@@ -78,7 +78,7 @@ base16Encode(const char *in, size_t inLen)
  * @return encoded string.
  */
 String
-uriEncode(const String in, bool isObjectName)
+uriEncode(const String &in, bool isObjectName)
 {
   std::stringstream result;
 
@@ -114,7 +114,7 @@ uriEncode(const String in, bool isObjectName)
  * @return encoded string.
  */
 String
-uriDecode(const String in)
+uriDecode(const String &in)
 {
   std::string result;
   result.reserve(in.length());

--- a/plugins/s3_auth/unit-tests/test_aws_auth_v4.h
+++ b/plugins/s3_auth/unit-tests/test_aws_auth_v4.h
@@ -119,8 +119,8 @@ public:
 
 /* Expose the following methods only to the unit tests */
 String base16Encode(const char *in, size_t inLen);
-String uriEncode(const String in, bool isObjectName = false);
-String uriDecode(const String in);
+String uriEncode(const String &in, bool isObjectName = false);
+String uriDecode(const String &in);
 String lowercase(const char *in, size_t inLen);
 const char *trimWhiteSpaces(const char *in, size_t inLen, size_t &newLen);
 


### PR DESCRIPTION
Changed to pass the input const String by ref instead of value.