### PR TITLE
fix the compiler error with gcc 4.9

### DIFF
--- a/iocore/net/quic/QUICFrame.h
+++ b/iocore/net/quic/QUICFrame.h
@@ -429,6 +429,7 @@ private:
 };
 
 using QUICFrameDeleterFunc = void (*)(QUICFrame *p);
+using QUICFramePtr         = std::unique_ptr<QUICFrame, QUICFrameDeleterFunc>;
 
 //
 // Retransmission Frame
@@ -444,7 +445,7 @@ public:
   QUICPacketType packet_type() const;
 
 private:
-  std::unique_ptr<QUICFrame, QUICFrameDeleterFunc> _frame = std::unique_ptr<QUICFrame, QUICFrameDeleterFunc>(nullptr, nullptr);
+  std::unique_ptr<QUICFrame, QUICFrameDeleterFunc> _frame = QUICFramePtr(nullptr, nullptr);
   ats_unique_buf _data = ats_unique_buf(nullptr, [](void *p) { ats_free(p); });
   size_t _size;
   QUICPacketType _packet_type;


### PR DESCRIPTION
fix the compiler error with gcc 4.9

error message:

```
make[1]: Entering directory `/root/trafficserver/iocore/net/quic'
  CXX      QUICGlobals.o
In file included from QUICFrameTransmitter.h:26:0,
                 from QUICConnection.h:27,
                 from QUICGlobals.cc:26:
QUICFrame.h:447:88: error: expected ‘;’ at end of member declaration
   std::unique_ptr<QUICFrame, QUICFrameDeleterFunc> _frame = std::unique_ptr<QUICFrame, QUICFrameDeleterFunc>(nullptr, nullptr);
                                                                                        ^
QUICFrame.h:447:88: error: declaration of ‘std::unique_ptr<QUICFrame, void (*)(QUICFrame*)> QUICRetransmissionFrame::QUICFrameDeleterFunc’ [-fpermissive]
QUICFrame.h:431:52: error: changes meaning of ‘QUICFrameDeleterFunc’ from ‘using QUICFrameDeleterFunc = void (*)(class QUICFrame*)’ [-fpermissive]
 using QUICFrameDeleterFunc = void (*)(QUICFrame *p);
                                                    ^
QUICFrame.h:447:108: error: expected unqualified-id before ‘>’ token
   std::unique_ptr<QUICFrame, QUICFrameDeleterFunc> _frame = std::unique_ptr<QUICFrame, QUICFrameDeleterFunc>(nullptr, nullptr);
                                                                                                            ^
QUICFrame.h:447:77: error: template argument 1 is invalid
   std::unique_ptr<QUICFrame, QUICFrameDeleterFunc> _frame = std::unique_ptr<QUICFrame, QUICFrameDeleterFunc>(nullptr, nullptr);
                                                                             ^
QUICFrame.h:447:77: error: template argument 2 is invalid
In file included from /usr/include/c++/4.9/memory:81:0,
                 from QUICPacket.h:26,
                 from QUICPacketTransmitter.h:26,
                 from QUICConnection.h:26,
                 from QUICGlobals.cc:26:
/usr/include/c++/4.9/bits/unique_ptr.h: In instantiation of ‘constexpr std::unique_ptr<_Tp, _Dp>::unique_ptr() [with _Tp = QUICFrame; _Dp = void (*)(QUICFrame*)]’:
QUICFrame.h:440:41:   required from here
/usr/include/c++/4.9/bits/unique_ptr.h:159:9: error: static assertion failed: constructed with null function pointer deleter
       { static_assert(!is_pointer<deleter_type>::value,
         ^

```