### PR TITLE
removes TCL dependency from RecHttp

### DIFF
--- a/lib/records/.gitignore
+++ b/lib/records/.gitignore
@@ -1,0 +1,1 @@
+test_librecords_p

--- a/lib/records/Makefile.am
+++ b/lib/records/Makefile.am
@@ -27,6 +27,15 @@ AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/lib
 
 noinst_LIBRARIES = librecords_lm.a librecords_p.a librecords_cop.a
+check_PROGRAMS = test_librecords_p
+
+TESTS = $(check_PROGRAMS)
+test_librecords_p_CPPFLAGS = $(AM_CPPFLAGS) \
+	-I$(abs_top_srcdir)/tests/include
+test_librecords_p_LDADD = RecProtoTags.o -L$(top_builddir)/lib/ts -ltsutil
+test_librecords_p_SOURCES = \
+	unit-tests/main.cc \
+	unit-tests/RecProtoTagsTest.cc
 
 librecords_COMMON = \
   I_RecAlarms.h \
@@ -50,6 +59,7 @@ librecords_COMMON = \
   RecHttp.cc \
   RecMessage.cc \
   RecMutex.cc \
+  RecProtoTags.cc \
   RecRawStats.cc \
   RecUtils.cc
 

--- a/lib/records/RecHttp.cc
+++ b/lib/records/RecHttp.cc
@@ -23,8 +23,8 @@
 
 #include <records/I_RecCore.h>
 #include <records/I_RecHttp.h>
+#include <records/RecProtoTags.h>
 #include <ts/ink_defs.h>
-#include <ts/ink_hash_table.h>
 #include <ts/Tokenizer.h>
 #include <ts/MemView.h>
 #include <strings.h>
@@ -32,31 +32,8 @@
 
 SessionProtocolNameRegistry globalSessionProtocolNameRegistry;
 
-/* Protocol session well-known protocol names.
-   These are also used for NPN setup.
-*/
-
-const char *const TS_ALPN_PROTOCOL_HTTP_0_9 = IP_PROTO_TAG_HTTP_0_9.ptr();
-const char *const TS_ALPN_PROTOCOL_HTTP_1_0 = IP_PROTO_TAG_HTTP_1_0.ptr();
-const char *const TS_ALPN_PROTOCOL_HTTP_1_1 = IP_PROTO_TAG_HTTP_1_1.ptr();
-const char *const TS_ALPN_PROTOCOL_HTTP_2_0 = IP_PROTO_TAG_HTTP_2_0.ptr();
-
 const char *const TS_ALPN_PROTOCOL_GROUP_HTTP  = "http";
 const char *const TS_ALPN_PROTOCOL_GROUP_HTTP2 = "http2";
-
-const char *const TS_PROTO_TAG_HTTP_1_0 = TS_ALPN_PROTOCOL_HTTP_1_0;
-const char *const TS_PROTO_TAG_HTTP_1_1 = TS_ALPN_PROTOCOL_HTTP_1_1;
-const char *const TS_PROTO_TAG_HTTP_2_0 = TS_ALPN_PROTOCOL_HTTP_2_0;
-const char *const TS_PROTO_TAG_TLS_1_3  = IP_PROTO_TAG_TLS_1_3.ptr();
-const char *const TS_PROTO_TAG_TLS_1_2  = IP_PROTO_TAG_TLS_1_2.ptr();
-const char *const TS_PROTO_TAG_TLS_1_1  = IP_PROTO_TAG_TLS_1_1.ptr();
-const char *const TS_PROTO_TAG_TLS_1_0  = IP_PROTO_TAG_TLS_1_0.ptr();
-const char *const TS_PROTO_TAG_TCP      = IP_PROTO_TAG_TCP.ptr();
-const char *const TS_PROTO_TAG_UDP      = IP_PROTO_TAG_UDP.ptr();
-const char *const TS_PROTO_TAG_IPV4     = IP_PROTO_TAG_IPV4.ptr();
-const char *const TS_PROTO_TAG_IPV6     = IP_PROTO_TAG_IPV6.ptr();
-
-InkHashTable *TSProtoTags;
 
 // Precomputed indices for ease of use.
 int TS_ALPN_PROTOCOL_INDEX_HTTP_0_9 = SessionProtocolNameRegistry::INVALID;
@@ -638,30 +615,7 @@ ts_session_protocol_well_known_name_indices_init()
 
   DEFAULT_NON_TLS_SESSION_PROTOCOL_SET = HTTP_PROTOCOL_SET;
 
-  TSProtoTags = ink_hash_table_create(InkHashTableKeyType_String);
-  ink_hash_table_insert(TSProtoTags, TS_PROTO_TAG_HTTP_1_0, reinterpret_cast<void *>(const_cast<char *>(TS_PROTO_TAG_HTTP_1_0)));
-  ink_hash_table_insert(TSProtoTags, TS_PROTO_TAG_HTTP_1_1, reinterpret_cast<void *>(const_cast<char *>(TS_PROTO_TAG_HTTP_1_1)));
-  ink_hash_table_insert(TSProtoTags, TS_PROTO_TAG_HTTP_2_0, reinterpret_cast<void *>(const_cast<char *>(TS_PROTO_TAG_HTTP_2_0)));
-  ink_hash_table_insert(TSProtoTags, TS_PROTO_TAG_TLS_1_3, reinterpret_cast<void *>(const_cast<char *>(TS_PROTO_TAG_TLS_1_3)));
-  ink_hash_table_insert(TSProtoTags, TS_PROTO_TAG_TLS_1_2, reinterpret_cast<void *>(const_cast<char *>(TS_PROTO_TAG_TLS_1_2)));
-  ink_hash_table_insert(TSProtoTags, TS_PROTO_TAG_TLS_1_1, reinterpret_cast<void *>(const_cast<char *>(TS_PROTO_TAG_TLS_1_1)));
-  ink_hash_table_insert(TSProtoTags, TS_PROTO_TAG_TLS_1_0, reinterpret_cast<void *>(const_cast<char *>(TS_PROTO_TAG_TLS_1_0)));
-  ink_hash_table_insert(TSProtoTags, TS_PROTO_TAG_TCP, reinterpret_cast<void *>(const_cast<char *>(TS_PROTO_TAG_TCP)));
-  ink_hash_table_insert(TSProtoTags, TS_PROTO_TAG_UDP, reinterpret_cast<void *>(const_cast<char *>(TS_PROTO_TAG_UDP)));
-  ink_hash_table_insert(TSProtoTags, TS_PROTO_TAG_IPV4, reinterpret_cast<void *>(const_cast<char *>(TS_PROTO_TAG_IPV4)));
-  ink_hash_table_insert(TSProtoTags, TS_PROTO_TAG_IPV6, reinterpret_cast<void *>(const_cast<char *>(TS_PROTO_TAG_IPV6)));
-}
-
-const char *
-RecNormalizeProtoTag(const char *tag)
-{
-  InkHashTableValue value;
-
-  if (ink_hash_table_lookup(TSProtoTags, tag, &value)) {
-    return reinterpret_cast<const char *>(value);
-  }
-
-  return nullptr;
+  ts_session_protocol_well_known_name_tags_init();
 }
 
 SessionProtocolNameRegistry::SessionProtocolNameRegistry() : m_n(0)

--- a/lib/records/RecProtoTags.cc
+++ b/lib/records/RecProtoTags.cc
@@ -1,0 +1,46 @@
+/** @file
+
+  Protocol Tags
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include "RecProtoTags.h"
+
+void
+ts_session_protocol_well_known_name_tags_init()
+{
+  TSProtoTags.put(TS_PROTO_TAG_HTTP_1_0);
+  TSProtoTags.put(TS_PROTO_TAG_HTTP_1_1);
+  TSProtoTags.put(TS_PROTO_TAG_HTTP_2_0);
+  TSProtoTags.put(TS_PROTO_TAG_TLS_1_3);
+  TSProtoTags.put(TS_PROTO_TAG_TLS_1_2);
+  TSProtoTags.put(TS_PROTO_TAG_TLS_1_1);
+  TSProtoTags.put(TS_PROTO_TAG_TLS_1_0);
+  TSProtoTags.put(TS_PROTO_TAG_TCP);
+  TSProtoTags.put(TS_PROTO_TAG_UDP);
+  TSProtoTags.put(TS_PROTO_TAG_IPV4);
+  TSProtoTags.put(TS_PROTO_TAG_IPV6);
+}
+
+const char *
+RecNormalizeProtoTag(const char *tag)
+{
+  return TSProtoTags.get(tag);
+}

--- a/lib/records/RecProtoTags.h
+++ b/lib/records/RecProtoTags.h
@@ -1,0 +1,58 @@
+/** @file
+
+  Protocol Tags
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#ifndef _REC_PROTO_TAGS_H_
+#define _REC_PROTO_TAGS_H_
+
+#include "ts/ink_inet.h"
+#include "ts/Map.h"
+
+/* Protocol session well-known protocol names.
+   These are also used for NPN setup.
+*/
+
+const char *const TS_ALPN_PROTOCOL_HTTP_0_9 = IP_PROTO_TAG_HTTP_0_9.ptr();
+const char *const TS_ALPN_PROTOCOL_HTTP_1_0 = IP_PROTO_TAG_HTTP_1_0.ptr();
+const char *const TS_ALPN_PROTOCOL_HTTP_1_1 = IP_PROTO_TAG_HTTP_1_1.ptr();
+const char *const TS_ALPN_PROTOCOL_HTTP_2_0 = IP_PROTO_TAG_HTTP_2_0.ptr();
+
+const char *const TS_PROTO_TAG_HTTP_1_0 = TS_ALPN_PROTOCOL_HTTP_1_0;
+const char *const TS_PROTO_TAG_HTTP_1_1 = TS_ALPN_PROTOCOL_HTTP_1_1;
+const char *const TS_PROTO_TAG_HTTP_2_0 = TS_ALPN_PROTOCOL_HTTP_2_0;
+const char *const TS_PROTO_TAG_TLS_1_3  = IP_PROTO_TAG_TLS_1_3.ptr();
+const char *const TS_PROTO_TAG_TLS_1_2  = IP_PROTO_TAG_TLS_1_2.ptr();
+const char *const TS_PROTO_TAG_TLS_1_1  = IP_PROTO_TAG_TLS_1_1.ptr();
+const char *const TS_PROTO_TAG_TLS_1_0  = IP_PROTO_TAG_TLS_1_0.ptr();
+const char *const TS_PROTO_TAG_TCP      = IP_PROTO_TAG_TCP.ptr();
+const char *const TS_PROTO_TAG_UDP      = IP_PROTO_TAG_UDP.ptr();
+const char *const TS_PROTO_TAG_IPV4     = IP_PROTO_TAG_IPV4.ptr();
+const char *const TS_PROTO_TAG_IPV6     = IP_PROTO_TAG_IPV6.ptr();
+
+typedef HashSet<const char *, StringHashFns, const char *> TSProtoTagsSet;
+static TSProtoTagsSet TSProtoTags;
+
+void ts_session_protocol_well_known_name_tags_init();
+
+const char *RecNormalizeProtoTag(const char *tag);
+
+#endif

--- a/lib/records/unit-tests/RecProtoTagsTest.cc
+++ b/lib/records/unit-tests/RecProtoTagsTest.cc
@@ -1,0 +1,116 @@
+/** @file
+  Test file for basic_string_view class
+  @section license License
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include <string>
+#include <ts/ink_inet.h>
+#include "catch.hpp"
+#include "records/RecProtoTags.h"
+
+SCENARIO("RecNormalizeProtoTag returns static pointers to the matching string")
+{
+  GIVEN("tags for well-known names have been initialized")
+  {
+    ts_session_protocol_well_known_name_tags_init();
+
+    WHEN("stack-allocated pointer for ipv4 is normalized")
+    {
+      THEN("the static pointer for IP_PROTO_TAG_IPV4 is returned")
+      {
+        REQUIRE(RecNormalizeProtoTag("ipv4") == IP_PROTO_TAG_IPV4.ptr());
+      }
+    }
+    WHEN("stack-allocated pointer for ipv6 is normalized")
+    {
+      THEN("the static pointer for IP_PROTO_TAG_IPV6 is returned")
+      {
+        REQUIRE(RecNormalizeProtoTag("ipv6") == IP_PROTO_TAG_IPV6.ptr());
+      }
+    }
+    WHEN("stack-allocated pointer for udp is normalized")
+    {
+      THEN("the static pointer for IP_PROTO_TAG_UDP is returned")
+      {
+        REQUIRE(RecNormalizeProtoTag("udp") == IP_PROTO_TAG_UDP.ptr());
+      }
+    }
+    WHEN("stack-allocated pointer for tcp is normalized")
+    {
+      THEN("the static pointer for IP_PROTO_TAG_TCP is returned")
+      {
+        REQUIRE(RecNormalizeProtoTag("tcp") == IP_PROTO_TAG_TCP.ptr());
+      }
+    }
+    WHEN("stack-allocated pointer for tls/1.0 is normalized")
+    {
+      THEN("the static pointer for IP_PROTO_TAG_TLS_1_0 is returned")
+      {
+        REQUIRE(RecNormalizeProtoTag("tls/1.0") == IP_PROTO_TAG_TLS_1_0.ptr());
+      }
+    }
+    WHEN("stack-allocated pointer for tls/1.1 is normalized")
+    {
+      THEN("the static pointer for IP_PROTO_TAG_TLS_1_1 is returned")
+      {
+        REQUIRE(RecNormalizeProtoTag("tls/1.1") == IP_PROTO_TAG_TLS_1_1.ptr());
+      }
+    }
+    WHEN("stack-allocated pointer for tls/1.2 is normalized")
+    {
+      THEN("the static pointer for IP_PROTO_TAG_TLS_1_2 is returned")
+      {
+        REQUIRE(RecNormalizeProtoTag("tls/1.2") == IP_PROTO_TAG_TLS_1_2.ptr());
+      }
+    }
+    WHEN("stack-allocated pointer for tls/1.3 is normalized")
+    {
+      THEN("the static pointer for IP_PROTO_TAG_TLS_1_3 is returned")
+      {
+        REQUIRE(RecNormalizeProtoTag("tls/1.3") == IP_PROTO_TAG_TLS_1_3.ptr());
+      }
+    }
+    WHEN("stack-allocated pointer for http/1.0 is normalized")
+    {
+      THEN("the static pointer for IP_PROTO_TAG_HTTP_1_0 is returned")
+      {
+        REQUIRE(RecNormalizeProtoTag("http/1.0") == IP_PROTO_TAG_HTTP_1_0.ptr());
+      }
+    }
+    WHEN("stack-allocated pointer for http/1.1 is normalized")
+    {
+      THEN("the static pointer for IP_PROTO_TAG_HTTP_1_1 is returned")
+      {
+        REQUIRE(RecNormalizeProtoTag("http/1.1") == IP_PROTO_TAG_HTTP_1_1.ptr());
+      }
+    }
+    WHEN("stack-allocated pointer for h2 is normalized")
+    {
+      THEN("the static pointer for IP_PROTO_TAG_HTTP_2_0 is returned")
+      {
+        REQUIRE(RecNormalizeProtoTag("h2") == IP_PROTO_TAG_HTTP_2_0.ptr());
+      }
+    }
+    WHEN("stack-allocated pointer for a bogus string is normalized")
+    {
+      THEN("null is returned")
+      {
+        std::string arbitraryString = "a8e9b0d9-28ce-4b78-882f-5d813d882f4d";
+        REQUIRE(RecNormalizeProtoTag(arbitraryString.c_str()) == nullptr);
+      }
+    }
+  }
+}

--- a/lib/records/unit-tests/main.cc
+++ b/lib/records/unit-tests/main.cc
@@ -1,0 +1,25 @@
+/** @file
+
+  This file used for catch based tests. It is the main() stub.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/lib/ts/Map.h
+++ b/lib/ts/Map.h
@@ -438,7 +438,7 @@ HashSet<K, AHashFns, C, A>::get(K akey)
   }
   uintptr_t h = AHashFns::hash(akey);
   h           = h % n;
-  for (int k = h, j = 0; j < i + 3; j++) {
+  for (size_t k = h, j = 0; j < i + 3; j++) {
     if (!v[k])
       return 0;
     else if (AHashFns::equal(akey, v[k]))
@@ -455,7 +455,7 @@ HashSet<K, AHashFns, C, A>::put(C avalue)
   if (n < MAP_INTEGRAL_SIZE) {
     if (!v)
       v = e;
-    for (int i = 0; i < n; i++)
+    for (size_t i = 0; i < n; i++)
       if (AHashFns::equal(avalue, v[i]))
         return &v[i];
     v[n] = avalue;
@@ -465,7 +465,7 @@ HashSet<K, AHashFns, C, A>::put(C avalue)
   if (n > MAP_INTEGRAL_SIZE) {
     uintptr_t h = AHashFns::hash(avalue);
     h           = h % n;
-    for (int k = h, j = 0; j < i + 3; j++) {
+    for (size_t k = h, j = 0; j < i + 3; j++) {
       if (!v[k]) {
         v[k] = avalue;
         return &v[k];
@@ -476,7 +476,7 @@ HashSet<K, AHashFns, C, A>::put(C avalue)
     i = SET_INITIAL_INDEX - 1; // will be incremented in set_expand
   HashSet<K, AHashFns, C, A> vv(*this);
   Vec<C, A>::set_expand();
-  for (int i = 0; i < vv.n; i++)
+  for (size_t i = 0; i < vv.n; i++)
     if (vv.v[i])
       put(vv.v[i]);
   return put(avalue);


### PR DESCRIPTION
Purpose: This is a tiny step toward removing dependencies we have on the TCL programming language, which is used for certain data structures.

* I wanted to write some unit test cases to cover the functionality of the code that needs to be changed, I have attempted to pull out this code in order to make it more testable.
* While attempting to use our own [HashMap](https://github.com/apache/trafficserver/blob/2c26e5aaedf7d34e0678c139f2efabc46f152a98/lib/ts/Map.h#L104), I encountered some difficulties in isolating the code for testing due to some coupling with the `tsutil` library. Stubbing a large number of symbols did not seem readable nor maintainable.
* The intention is to preserve functionality and performance of the current implementation.

This is a small change, and I am open to suggestions, especially if others have put some thought into whether a step-by-step approach like this will successfully lead to more testable code and to better test coverage.

Fields I don't have permission to edit:

    Milestone: v8.0.0
    Labels: Core?
    Projects: 8.x releases
