### PR TITLE
Coverity: CID 1380282:  Error handling issues  (CHECKED_RETURN)

### DIFF
--- a/proxy/InkAPITest.cc
+++ b/proxy/InkAPITest.cc
@@ -1622,12 +1622,13 @@ REGRESSION_TEST(SDK_API_TSMutexCreate)(RegressionTest *test, int /* atype ATS_UN
   TSMutexLock(mutexp);
 
   /* This is normal because all locking is from the same thread */
-  TSReturnCode lock = TS_ERROR;
+  TSReturnCode lock1 = TS_ERROR;
+  TSReturnCode lock2 = TS_ERROR;
 
-  TSMutexLockTry(mutexp);
-  lock = TSMutexLockTry(mutexp);
+  lock1 = TSMutexLockTry(mutexp);
+  lock2 = TSMutexLockTry(mutexp);
 
-  if (TS_SUCCESS == lock) {
+  if (TS_SUCCESS == lock1 && TS_SUCCESS == lock2) {
     SDK_RPRINT(test, "TSMutexCreate", "TestCase1", TC_PASS, "ok");
     SDK_RPRINT(test, "TSMutexLock", "TestCase1", TC_PASS, "ok");
     SDK_RPRINT(test, "TSMutexLockTry", "TestCase1", TC_PASS, "ok");


### PR DESCRIPTION
```
** CID 1380282:  Error handling issues  (CHECKED_RETURN)
/proxy/InkAPITest.cc: 1627 in RegressionTest_SDK_API_TSMutexCreate(RegressionTest *, int, int *)()


________________________________________________________________________________________________________
*** CID 1380282:  Error handling issues  (CHECKED_RETURN)
/proxy/InkAPITest.cc: 1627 in RegressionTest_SDK_API_TSMutexCreate(RegressionTest *, int, int *)()
1621
1622       TSMutexLock(mutexp);
1623
1624       /* This is normal because all locking is from the same thread */
1625       TSReturnCode lock = TS_ERROR;
1626
>>>     CID 1380282:  Error handling issues  (CHECKED_RETURN)
>>>     Calling "TSMutexLockTry" without checking return value (as is done elsewhere 4 out of 5 times).
1627       TSMutexLockTry(mutexp);
1628       lock = TSMutexLockTry(mutexp);
1629
1630       if (TS_SUCCESS == lock) {
1631         SDK_RPRINT(test, "TSMutexCreate", "TestCase1", TC_PASS, "ok");
1632         SDK_RPRINT(test, "TSMutexLock", "TestCase1", TC_PASS, "ok");
```

Caused by

```
TS-1475: fix clang warning.

commit 63d601814bd7d1724f4c7156622f1dc9f6ac37db
Author: Phil Sorber <sorber@apache.org>
Date:   Mon Jul 21 23:35:47 2014 -0600

    TS-1475: fix clang warning

diff --git a/proxy/InkAPITest.cc b/proxy/InkAPITest.cc
index a8abd3e..73dd100 100644
--- a/proxy/InkAPITest.cc
+++ b/proxy/InkAPITest.cc
@@ -1567,7 +1567,7 @@ REGRESSION_TEST(SDK_API_TSMutexCreate) (RegressionTest * test, int /* atype ATS_
   /* This is normal because all locking is from the same thread */
   TSReturnCode lock = TS_ERROR;
 
-  lock = TSMutexLockTry(mutexp);
+  TSMutexLockTry(mutexp);
   lock = TSMutexLockTry(mutexp);
 
   if (TS_SUCCESS == lock) {
```

Try to fix it, It will be compatible with clang-analyzer and coverity scan.