### PR TITLE
Support stateless retry token in transport parameters

### DIFF
--- a/iocore/net/P_QUICNetVConnection.h
+++ b/iocore/net/P_QUICNetVConnection.h
@@ -240,6 +240,8 @@ private:
   QUICApplication *_create_application();
   void _init_flow_control_params(const std::shared_ptr<const QUICTransportParameters> &local_tp,
                                  const std::shared_ptr<const QUICTransportParameters> &remote_tp);
+
+  QUICStatelessToken _token;
 };
 
 extern ClassAllocator<QUICNetVConnection> quicNetVCAllocator;

--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -49,6 +49,7 @@
 static constexpr uint32_t MINIMUM_MTU               = 1280;
 static constexpr uint32_t MAX_PACKET_OVERHEAD       = 25; // Max long header len(17) + FNV-1a hash len(8)
 static constexpr uint32_t MAX_STREAM_FRAME_OVERHEAD = 15;
+static constexpr char STATELESS_RETRY_TOKEN_KEY[]   = "stateless_token_retry_key";
 
 ClassAllocator<QUICNetVConnection> quicNetVCAllocator("quicNetVCAllocator");
 
@@ -95,7 +96,9 @@ void
 QUICNetVConnection::start(SSL_CTX *ssl_ctx)
 {
   // Version 0x00000001 uses stream 0 for cryptographic handshake with TLS 1.3, but newer version may not
-  this->_handshake_handler = new QUICHandshake(this, ssl_ctx);
+  this->_token.gen_token(STATELESS_RETRY_TOKEN_KEY, _quic_connection_id ^ id);
+
+  this->_handshake_handler = new QUICHandshake(this, ssl_ctx, this->_token.get());
   this->_application_map   = new QUICApplicationMap();
   this->_application_map->set(STREAM_ID_FOR_HANDSHAKE, this->_handshake_handler);
 

--- a/iocore/net/quic/QUICHandshake.cc
+++ b/iocore/net/quic/QUICHandshake.cc
@@ -54,7 +54,7 @@ static constexpr int UDP_MAXIMUM_PAYLOAD_SIZE = 65527;
 // TODO: fix size
 static constexpr int MAX_HANDSHAKE_MSG_LEN = 65527;
 
-QUICHandshake::QUICHandshake(QUICConnection *qc, SSL_CTX *ssl_ctx) : QUICApplication(qc)
+QUICHandshake::QUICHandshake(QUICConnection *qc, SSL_CTX *ssl_ctx, INK_MD5 token) : QUICApplication(qc), _token(token)
 {
   this->_ssl = SSL_new(ssl_ctx);
   SSL_set_ex_data(this->_ssl, QUIC::ssl_quic_qc_index, qc);
@@ -256,6 +256,9 @@ QUICHandshake::_load_local_transport_parameters()
 
   tp->add(QUICTransportParameterId::IDLE_TIMEOUT, std::unique_ptr<QUICTransportParameterValue>(new QUICTransportParameterValue(
                                                     params->no_activity_timeout_in(), sizeof(uint16_t))));
+
+  tp->add(QUICTransportParameterId::STATELESS_RETRY_TOKEN,
+          std::unique_ptr<QUICTransportParameterValue>(new QUICTransportParameterValue(this->_token.u64, 16)));
 
   tp->add_version(QUIC_SUPPORTED_VERSIONS[0]);
   // MAYs

--- a/iocore/net/quic/QUICHandshake.h
+++ b/iocore/net/quic/QUICHandshake.h
@@ -50,7 +50,7 @@ class SSLNextProtocolSet;
 class QUICHandshake : public QUICApplication
 {
 public:
-  QUICHandshake(QUICConnection *qc, SSL_CTX *ssl_ctx);
+  QUICHandshake(QUICConnection *qc, SSL_CTX *ssl_ctx, INK_MD5 token);
   ~QUICHandshake();
 
   QUICError start(const QUICPacket *initial_packet, QUICPacketFactory *packet_factory);
@@ -87,4 +87,6 @@ private:
   QUICError _process_client_hello();
   QUICError _process_client_finished();
   QUICError _process_handshake_complete();
+
+  INK_MD5 _token;
 };

--- a/iocore/net/quic/QUICTransportParameters.cc
+++ b/iocore/net/quic/QUICTransportParameters.cc
@@ -44,6 +44,21 @@ QUICTransportParameterValue::QUICTransportParameterValue(uint64_t raw_data, uint
   this->_len = len;
 };
 
+QUICTransportParameterValue::QUICTransportParameterValue(uint64_t raw_data[2], uint16_t l)
+{
+  this->_data = ats_unique_malloc(l);
+  size_t len  = 0;
+  if (l > 8) {
+    QUICTypeUtil::write_uint_as_nbytes(raw_data[0], 8, this->_data.get(), &len);
+    this->_len += len;
+    QUICTypeUtil::write_uint_as_nbytes(raw_data[1], l - 8, this->_data.get() + 8, &len);
+    this->_len += len;
+  } else {
+    QUICTypeUtil::write_uint_as_nbytes(raw_data[0], l, this->_data.get(), &len);
+    this->_len += len;
+  }
+}
+
 const uint8_t *
 QUICTransportParameterValue::data() const
 {

--- a/iocore/net/quic/QUICTransportParameters.h
+++ b/iocore/net/quic/QUICTransportParameters.h
@@ -40,6 +40,7 @@ public:
     IDLE_TIMEOUT,
     TRUNCATE_CONNECTION_ID,
     MAX_PACKET_SIZE,
+    STATELESS_RETRY_TOKEN,
   };
 
   explicit operator bool() const { return true; }
@@ -68,6 +69,7 @@ class QUICTransportParameterValue
 public:
   QUICTransportParameterValue(ats_unique_buf d, uint16_t l);
   QUICTransportParameterValue(uint64_t raw_data, uint16_t l);
+  QUICTransportParameterValue(uint64_t raw_data[2], uint16_t l);
 
   const uint8_t *data() const;
   uint16_t len() const;

--- a/iocore/net/quic/QUICTypes.h
+++ b/iocore/net/quic/QUICTypes.h
@@ -37,6 +37,7 @@
 #include <memory>
 #include <random>
 #include <cstdint>
+#include "ts/INK_MD5.h"
 #include "ts/ink_memory.h"
 
 // These magical defines should be removed when we implement seriously
@@ -147,6 +148,28 @@ struct QUICError {
   QUICErrorClass cls;
   QUICErrorCode code;
   const char *msg;
+};
+
+class QUICStatelessToken
+{
+public:
+  void
+  gen_token(const char *key, uint64_t data)
+  {
+    MD5Context ctx;
+    ctx.update(key, strlen(key));
+    ctx.update(reinterpret_cast<void *>(&data), 8);
+    ctx.finalize(_md5);
+  }
+
+  const INK_MD5
+  get() const
+  {
+    return _md5;
+  }
+
+private:
+  INK_MD5 _md5;
 };
 
 class QUICConnectionId

--- a/iocore/net/quic/test/test_QUICTransportParameters.cc
+++ b/iocore/net/quic/test/test_QUICTransportParameters.cc
@@ -79,15 +79,19 @@ TEST_CASE("QUICTransportParametersInClientHello_write", "[quic]")
   uint16_t len;
 
   uint8_t expected[] = {
-    0x01, 0x02, 0x03, 0x04, // negotiated version
-    0x05, 0x06, 0x07, 0x08, // iinitial version
-    0x00, 0x0e,             // size of parameters
-    0x00, 0x00,             // parameter id
-    0x00, 0x04,             // length of value
-    0x11, 0x22, 0x33, 0x44, // value
-    0x00, 0x05,             // parameter id
-    0x00, 0x02,             // length of value
-    0xab, 0xcd,             // value
+    0x01, 0x02, 0x03, 0x04,                         // negotiated version
+    0x05, 0x06, 0x07, 0x08,                         // iinitial version
+    0x00, 0x22,                                     // size of parameters
+    0x00, 0x00,                                     // parameter id
+    0x00, 0x04,                                     // length of value
+    0x11, 0x22, 0x33, 0x44,                         // value
+    0x00, 0x05,                                     // parameter id
+    0x00, 0x02,                                     // length of value
+    0xab, 0xcd,                                     // value
+    0x00, 0x06,                                     // parameter id
+    0x00, 0x10,                                     // length of value
+    0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, // value
+    0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, // value
   };
 
   QUICTransportParametersInClientHello params_in_ch(0x01020304, 0x05060708);
@@ -102,8 +106,12 @@ TEST_CASE("QUICTransportParametersInClientHello_write", "[quic]")
     QUICTransportParameterId::MAX_PACKET_SIZE,
     std::unique_ptr<QUICTransportParameterValue>(new QUICTransportParameterValue(max_packet_size, sizeof(max_packet_size))));
 
+  uint64_t stateless_retry_token[2] = {0x0011223344556677, 0x0011223344556677};
+  params_in_ch.add(QUICTransportParameterId::STATELESS_RETRY_TOKEN,
+                   std::unique_ptr<QUICTransportParameterValue>(new QUICTransportParameterValue(stateless_retry_token, 16)));
+
   params_in_ch.store(buf, &len);
-  CHECK(len == 24);
+  CHECK(len == 44);
   CHECK(memcmp(buf, expected, len) == 0);
 }
 


### PR DESCRIPTION
Support stateless retry token in transport parameters #2481 

```
root@ubuntu-linux:~/ngtcp2# ./examples/client 127.0.0.1 8081
t=0.000398 TX Client Initial(0x02) CID=0xd957fddfba594004 PKN=957878627 V=0xff000005
           STREAM(0xc1) F=0x00 SS=0x00 OO=0x00 D=0x01
           stream_id=0x00000000 fin=0 offset=0 data_length=274
           PADDING(0x00)
           length=949
t=0.066805 RX Server Cleartext(0x04) CID=0x5a7f603fdc29e638 PKN=147683377 V=0xff000005
           STREAM(0xdf) F=0x00 SS=0x03 OO=0x03 D=0x01
           stream_id=0x00000000 fin=0 offset=0 data_length=1181
           ; TransportParameter received in EncryptedExtensions
           ; supported_version[0]=0xff000005
           ; initial_max_stream_data=2048
           ; initial_max_data=100
           ; initial_max_stream_id=100
           ; idle_timeout=30
           ; omit_connection_id=0
           ; max_packet_size=65527
           ; stateless_reset_token=246a37b97de517aea333261d2a40270c
           ; Negotiated cipher suite is TLS13-AES-128-GCM-SHA256
           ; Negotiated ALPN is hq-05
           PADDING(0x00)
           length=56
t=0.069428 QUIC handshake has completed
t=0.069533 TX Client Cleartext(0x05) CID=0x5a7f603fdc29e638 PKN=957878628 V=0xff000005
           ACK(0xa8) N=0x00 LL=0x02 MM=0x00
           num_blks=0 num_ts=0 largest_ack=147683377 ack_delay=2731
           first_ack_block_length=0; [147683377..147683377]
           STREAM(0xc3) F=0x00 SS=0x00 OO=0x01 D=0x01
           stream_id=0x00000000 fin=0 offset=274 data_length=58
t=0.081378 RX Short 01(0x01) CID=0x5a7f603fdc29e638 PKN=147683378
           ACK(0xaa) N=0x00 LL=0x02 MM=0x02
           num_blks=0 num_ts=0 largest_ack=957878628 ack_delay=0
           first_ack_block_length=1; [957878628..957878627]
           PADDING(0x00)
           length=1240
t=0.091959 RX Short 01(0x01) CID=0x5a7f603fdc29e638 PKN=147683379
           STREAM(0xdf) F=0x00 SS=0x03 OO=0x03 D=0x01
           stream_id=0x00000000 fin=0 offset=1181 data_length=224
           PADDING(0x00)
           length=1013
t=0.117316 TX Short 01(0x01) CID=0x5a7f603fdc29e638 PKN=957878629
           ACK(0xa8) N=0x00 LL=0x02 MM=0x00
           num_blks=0 num_ts=0 largest_ack=147683379 ack_delay=25348
           first_ack_block_length=1; [147683379..147683378]
```