### PR TITLE
uses backoff to launch ts if crash was recent

### DIFF
--- a/cmd/traffic_manager/traffic_manager.cc
+++ b/cmd/traffic_manager/traffic_manager.cc
@@ -681,7 +681,9 @@ main(int argc, const char **argv)
   metrics_binding_initialize(*binding);
   metrics_binding_configure(*binding);
 
-  int sleep_time = 0; // sleep_time given in sec
+  const int MAX_SLEEP_S      = 60; // Max sleep duration
+  int sleep_time             = 0;  // sleep_time given in sec
+  uint64_t last_start_epoc_s = 0;  // latest start attempt in seconds since epoc
 
   for (;;) {
     lmgmt->processEventQueue();
@@ -740,16 +742,17 @@ main(int argc, const char **argv)
     }
 
     if (lmgmt->run_proxy && !lmgmt->processRunning() && lmgmt->proxy_recoverable) { /* Make sure we still have a proxy up */
-      if (sleep_time) {
+      const uint64_t now = static_cast<uint64_t>(time(nullptr));
+      if (sleep_time && now - last_start_epoc_s < MAX_SLEEP_S) {
         mgmt_log("Relaunching proxy after %d sec...", sleep_time);
         millisleep(1000 * sleep_time); // we use millisleep instead of sleep because it doesnt interfere with signals
-        sleep_time = (sleep_time > 30) ? 60 : sleep_time * 2;
+        sleep_time = MIN(sleep_time * 2, MAX_SLEEP_S);
       } else {
         sleep_time = 1;
       }
       if (ProxyStateSet(TS_PROXY_ON, TS_CACHE_CLEAR_NONE) == TS_ERR_OKAY) {
-        just_started = 0;
-        sleep_time   = 0;
+        just_started      = 0;
+        last_start_epoc_s = static_cast<uint64_t>(time(nullptr));
       } else {
         just_started++;
       }

--- a/cmd/traffic_manager/traffic_manager.cc
+++ b/cmd/traffic_manager/traffic_manager.cc
@@ -746,7 +746,7 @@ main(int argc, const char **argv)
       if (sleep_time && ((now - last_start_epoc_s) < MAX_SLEEP_S)) {
         mgmt_log("Relaunching proxy after %d sec...", sleep_time);
         millisleep(1000 * sleep_time); // we use millisleep instead of sleep because it doesnt interfere with signals
-        sleep_time = MIN(sleep_time * 2, MAX_SLEEP_S);
+        sleep_time = std::min(sleep_time * 2, MAX_SLEEP_S);
       } else {
         sleep_time = 1;
       }

--- a/cmd/traffic_manager/traffic_manager.cc
+++ b/cmd/traffic_manager/traffic_manager.cc
@@ -743,7 +743,7 @@ main(int argc, const char **argv)
 
     if (lmgmt->run_proxy && !lmgmt->processRunning() && lmgmt->proxy_recoverable) { /* Make sure we still have a proxy up */
       const uint64_t now = static_cast<uint64_t>(time(nullptr));
-      if (sleep_time && now - last_start_epoc_s < MAX_SLEEP_S) {
+      if (sleep_time && ((now - last_start_epoc_s) < MAX_SLEEP_S)) {
         mgmt_log("Relaunching proxy after %d sec...", sleep_time);
         millisleep(1000 * sleep_time); // we use millisleep instead of sleep because it doesnt interfere with signals
         sleep_time = MIN(sleep_time * 2, MAX_SLEEP_S);


### PR DESCRIPTION
Fields I don't have permission to edit:
* Milestone: v8.0.0
* Labels: Backport, Manager
* Projects: 7.x releases

Backport notes:
* Not an emergency.
* This reduce the rate of accumulation of core files in cases where the traffic server has issues shortly after communicating with the traffic manager on launch.
* Depends on #154
