### PR TITLE
Support set-redirect with READ_REQUEST_PRE_REMAP_HOOK

### DIFF
--- a/plugins/header_rewrite/operators.h
+++ b/plugins/header_rewrite/operators.h
@@ -110,6 +110,17 @@ class OperatorSetRedirect : public Operator
 public:
   OperatorSetRedirect() { TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for OperatorSetRedirect"); }
   void initialize(Parser &p);
+  TSHttpStatus
+  get_status()
+  {
+    return static_cast<TSHttpStatus>(_status.get_int_value());
+  }
+  std::string
+  get_location(int &size)
+  {
+    size = (int)_location.size();
+    return static_cast<std::string>(_location.get_value());
+  }
 
 protected:
   void exec(const Resources &res) const;


### PR DESCRIPTION
works with the following rule now.
`cond %{READ_REQUEST_PRE_REMAP_HOOK} [AND]
cond %{CLIENT-HEADER:Bla-Bla} "/^Bla$/"
set-redirect 301 "https://127.0.0.boo1:4443" [QSA,L]`