### PR TITLE
updates pre-commit hook to use specific clang-format

### DIFF
--- a/tools/git/pre-commit
+++ b/tools/git/pre-commit
@@ -18,7 +18,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-ROOT=$(git rev-parse --show-toplevel)/.git/fmt
+GIT_TOP="$(git rev-parse --show-toplevel)"
+source "$GIT_TOP/tools/clang-format.sh"
+
 case $(uname -s) in
 Darwin)
     FORMAT=${FORMAT:-${ROOT}/clang-format/clang-format.osx}


### PR DESCRIPTION
From IRC
```
16:21	d2r	zwoop, I have.git/fmt/20170404/clang-format/clang-format.linux
16:21	d2r	but the pre-commit hook is looking in .git/fmt/clang-format/clang-format.linux
16:21	d2r	(no datestamp dir)
```

Fields I don't have permission to edit:

Milestone: v8.0.0
Labels: Tools
Projects: 8.x releases
