### PR TITLE
Optimize: rename close_UnixNetVConnection to NetHandler::free_netvc.

### DIFF
--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -430,7 +430,6 @@ UnixNetVConnection::set_action(Continuation *c)
 
 // declarations for local use (within the net module)
 
-void close_UnixNetVConnection(UnixNetVConnection *vc, EThread *t);
 void write_to_net(NetHandler *nh, UnixNetVConnection *vc, EThread *thread);
 void write_to_net_io(NetHandler *nh, UnixNetVConnection *vc, EThread *thread);
 

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -876,7 +876,12 @@ SSLNetVConnection::free(EThread *t)
 {
   ink_release_assert(t == this_ethread());
 
+  // cancel OOB
+  cancel_OOB();
   // close socket fd
+  if (con.fd != NO_FD) {
+    NET_SUM_GLOBAL_DYN_STAT(net_connections_currently_open_stat, -1);
+  }
   con.close();
 
   clear();


### PR DESCRIPTION
EThread is processor of Event, it is the event processor's responsibility to deallocate Event object. (refer to the comments in I_EventProcessor.h, "Event allocation policy" section.)

Due to NetHandler is processor of NetVC, it is the NetHandler's responsibility to free NetVC object.

Take EThread::free_event() as reference to create NetHandler::free_netvc() from close_UnixNetVConnection().