### PR TITLE
Docs: Fix warning for statistic.cc include.

### DIFF
--- a/doc/developer-guide/plugins/adding-statistics.en.rst
+++ b/doc/developer-guide/plugins/adding-statistics.en.rst
@@ -37,8 +37,8 @@ with :c:func:`TSStatIntSet`, and increment it with :c:func:`TSStatIntIncrement` 
 :c:func:`TSStatIntDecrement`.
 
 .. literalinclude:: ../../../example/statistic/statistic.cc
-   :language: c
-   :lines: 30-
+   :language: cpp
+   :lines: 32-
 
 If this plugin is loaded, then the statistic can be accessed with ::
 


### PR DESCRIPTION
Warning from a change in the `statistics.cc` file and also formatting for the actual language.