### PR TITLE
TS-4128: select alternate hook not working for ts_lua plugin

### DIFF
--- a/doc/admin-guide/plugins/ts_lua.en.rst
+++ b/doc/admin-guide/plugins/ts_lua.en.rst
@@ -107,7 +107,6 @@ each lua script:
 - **'do_global_send_response'**
 - **'do_global_cache_lookup_complete'**
 - **'do_global_read_cache'**
-- **'do_global_select_alt'**
 
 We can write this in plugin.config:
 
@@ -391,7 +390,6 @@ Hook point constants
     TS_LUA_HOOK_OS_DNS
     TS_LUA_HOOK_PRE_REMAP
     TS_LUA_HOOK_READ_CACHE_HDR
-    TS_LUA_HOOK_SELECT_ALT
     TS_LUA_HOOK_TXN_CLOSE
     TS_LUA_HOOK_POST_REMAP
     TS_LUA_HOOK_CACHE_LOOKUP_COMPLETE
@@ -423,9 +421,6 @@ Additional Information:
 +-----------------------+---------------------------+----------------------+--------------------+----------------------+
 | TS_HTTP_POST          | TS_LUA_HOOK               |     YES              |    NO              |    YES               |
 | _REMAP_HOOK           | _POST_REMAP               |                      |                    |                      |
-+-----------------------+---------------------------+----------------------+--------------------+----------------------+
-| TS_HTTP_SELECT        | TS_LUA_HOOK               |     NO               |    NO              |    NO                |
-| _ALT_HOOK             | _SELECT_ALT               |                      |                    |                      |
 +-----------------------+---------------------------+----------------------+--------------------+----------------------+
 | TS_HTTP_READ          | TS_LUA_HOOK               |     YES              |    NO              |    YES               |
 | _CACHE_HDR_HOOK       | _READ_CACHE_HDR           |                      |                    |                      |

--- a/plugins/experimental/ts_lua/ts_lua.c
+++ b/plugins/experimental/ts_lua/ts_lua.c
@@ -337,10 +337,6 @@ globalHookHandler(TSCont contp, TSEvent event ATS_UNUSED, void *edata)
     lua_getglobal(l, TS_LUA_FUNCTION_G_POST_REMAP);
     break;
 
-  case TS_EVENT_HTTP_SELECT_ALT:
-    lua_getglobal(l, TS_LUA_FUNCTION_G_SELECT_ALT);
-    break;
-
   case TS_EVENT_HTTP_OS_DNS:
     lua_getglobal(l, TS_LUA_FUNCTION_G_OS_DNS);
     break;
@@ -547,13 +543,6 @@ TSPluginInit(int argc, const char *argv[])
   if (lua_type(l, -1) == LUA_TFUNCTION) {
     TSHttpHookAdd(TS_HTTP_POST_REMAP_HOOK, global_contp);
     TSDebug(TS_LUA_DEBUG_TAG, "post_remap_hook added");
-  }
-  lua_pop(l, 1);
-
-  lua_getglobal(l, TS_LUA_FUNCTION_G_SELECT_ALT);
-  if (lua_type(l, -1) == LUA_TFUNCTION) {
-    TSHttpHookAdd(TS_HTTP_SELECT_ALT_HOOK, global_contp);
-    TSDebug(TS_LUA_DEBUG_TAG, "select_alt_hook added");
   }
   lua_pop(l, 1);
 

--- a/plugins/experimental/ts_lua/ts_lua_common.h
+++ b/plugins/experimental/ts_lua/ts_lua_common.h
@@ -44,7 +44,6 @@
 #define TS_LUA_FUNCTION_PRE_REMAP "do_pre_remap"
 #define TS_LUA_FUNCTION_POST_REMAP "do_post_remap"
 #define TS_LUA_FUNCTION_OS_DNS "do_os_dns"
-#define TS_LUA_FUNCTION_SELECT_ALT "do_select_alt"
 #define TS_LUA_FUNCTION_READ_CACHE "do_read_cache"
 #define TS_LUA_FUNCTION_TXN_CLOSE "do_txn_close"
 
@@ -57,7 +56,6 @@
 #define TS_LUA_FUNCTION_G_PRE_REMAP "do_global_pre_remap"
 #define TS_LUA_FUNCTION_G_POST_REMAP "do_global_post_remap"
 #define TS_LUA_FUNCTION_G_OS_DNS "do_global_os_dns"
-#define TS_LUA_FUNCTION_G_SELECT_ALT "do_global_select_alt"
 #define TS_LUA_FUNCTION_G_READ_CACHE "do_global_read_cache"
 #define TS_LUA_FUNCTION_G_TXN_CLOSE "do_global_txn_close"
 

--- a/plugins/experimental/ts_lua/ts_lua_hook.c
+++ b/plugins/experimental/ts_lua/ts_lua_hook.c
@@ -31,7 +31,6 @@ typedef enum {
   TS_LUA_HOOK_PRE_REMAP,
   TS_LUA_HOOK_POST_REMAP,
   TS_LUA_HOOK_OS_DNS,
-  TS_LUA_HOOK_SELECT_ALT,
   TS_LUA_HOOK_READ_CACHE_HDR,
   TS_LUA_HOOK_TXN_CLOSE,
   TS_LUA_REQUEST_TRANSFORM,
@@ -49,7 +48,6 @@ char *ts_lua_hook_id_string[] = {"TS_LUA_HOOK_DUMMY",
                                  "TS_LUA_HOOK_PRE_REMAP",
                                  "TS_LUA_HOOK_POST_REMAP",
                                  "TS_LUA_HOOK_OS_DNS",
-                                 "TS_LUA_HOOK_SELECT_ALT",
                                  "TS_LUA_HOOK_READ_CACHE_HDR",
                                  "TS_LUA_HOOK_TXN_CLOSE",
                                  "TS_LUA_REQUEST_TRANSFORM",
@@ -202,18 +200,6 @@ ts_lua_add_hook(lua_State *L)
     } else {
       lua_pushvalue(L, 2);
       lua_setglobal(L, TS_LUA_FUNCTION_G_OS_DNS);
-    }
-    break;
-
-  case TS_LUA_HOOK_SELECT_ALT:
-    if (http_ctx) {
-      TSHttpTxnHookAdd(http_ctx->txnp, TS_HTTP_SELECT_ALT_HOOK, http_ctx->cinfo.contp);
-      http_ctx->has_hook = 1;
-      lua_pushvalue(L, 2);
-      lua_setglobal(L, TS_LUA_FUNCTION_SELECT_ALT);
-    } else {
-      lua_pushvalue(L, 2);
-      lua_setglobal(L, TS_LUA_FUNCTION_G_SELECT_ALT);
     }
     break;
 

--- a/plugins/experimental/ts_lua/ts_lua_util.c
+++ b/plugins/experimental/ts_lua/ts_lua_util.c
@@ -762,15 +762,6 @@ ts_lua_http_cont_handler(TSCont contp, TSEvent ev, void *edata)
 
     break;
 
-  case TS_EVENT_HTTP_SELECT_ALT:
-
-    lua_getglobal(L, TS_LUA_FUNCTION_SELECT_ALT);
-    if (lua_type(L, -1) == LUA_TFUNCTION) {
-      ret = lua_resume(L, 0);
-    }
-
-    break;
-
   case TS_EVENT_HTTP_READ_CACHE_HDR:
 
     lua_getglobal(L, TS_LUA_FUNCTION_READ_CACHE);


### PR DESCRIPTION
Now the select alternate hook is not really working for ts_lua plugin. This PR is to remove this from plugin and we should re-introduce this again later on. 