### PR TITLE
move state change to _write_to_read_vio

### DIFF
--- a/iocore/net/quic/QUICStream.cc
+++ b/iocore/net/quic/QUICStream.cc
@@ -260,6 +260,8 @@ QUICStream::_write_to_read_vio(const std::shared_ptr<const QUICStreamFrame> &fra
   Debug("quic_flow_ctrl", "Stream [%" PRIx32 "] [%s] [LOCAL] %" PRIu64 "/%" PRIu64, this->_id,
         QUICDebugNames::stream_state(this->_state), this->_local_flow_controller->current_offset(),
         this->_local_flow_controller->current_limit());
+
+  this->_state.update_with_received_frame(*frame);
 }
 
 void
@@ -290,7 +292,6 @@ QUICStream::recv(const std::shared_ptr<const QUICStreamFrame> frame)
     this->reset();
     return QUICError(QUICErrorClass::QUIC_TRANSPORT, QUICErrorCode::INTERNAL_ERROR);
   }
-  this->_state.update_with_received_frame(*frame);
 
   // Flow Control - Even if it's allowed to receive on the state, it may exceed the limit
   QUICError error = this->_local_flow_controller->update(frame->offset() + frame->data_length());


### PR DESCRIPTION
From 10.2.2. open
>>When an endpoint receives all stream data and a FIN flag the stream state becomes “half-closed >>(remote)”. An endpoint MUST NOT consider the stream state to have changed until all data has >>been sent or received.