### PR TITLE
Limit the amount of memory that a HTTP/2 stream will allocate

### DIFF
--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -62,6 +62,7 @@ const uint32_t HTTP2_INITIAL_WINDOW_SIZE    = 65535;
 const uint32_t HTTP2_MAX_FRAME_SIZE         = 16384;
 const uint32_t HTTP2_HEADER_TABLE_SIZE      = 4096;
 const uint32_t HTTP2_MAX_HEADER_LIST_SIZE   = UINT_MAX;
+const uint32_t HTTP2_MAX_BUFFER_USAGE       = 524288;
 
 // [RFC 7540] 5.3.5 Default Priorities
 // The RFC says weight value is 1 to 256, but the value in TS is between 0 to 255

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -312,6 +312,12 @@ public:
     }
   }
 
+  int64_t
+  write_buffer_size()
+  {
+    return write_buffer->max_read_avail();
+  }
+
   // noncopyable
   Http2ClientSession(Http2ClientSession &) = delete;
   Http2ClientSession &operator=(const Http2ClientSession &) = delete;

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -274,7 +274,8 @@ private:
   uint64_t bytes_sent  = 0;
 
   ChunkedHandler chunked_handler;
-  Event *cross_thread_event = nullptr;
+  Event *cross_thread_event      = nullptr;
+  Event *buffer_full_write_event = nullptr;
 
   // Support stream-specific timeouts
   ink_hrtime active_timeout = 0;


### PR DESCRIPTION
This is a fix for issue: #2530 