### PR TITLE
Remove unnecessary assertion

### DIFF
--- a/iocore/cache/CacheRead.cc
+++ b/iocore/cache/CacheRead.cc
@@ -254,7 +254,6 @@ CacheVC::openReadChooseWriter(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSE
           continue;
         }
       }
-      ink_assert(w->alternate.valid());
       if (w->alternate.valid()) {
         vector.insert(&w->alternate, alt_ndx);
       }


### PR DESCRIPTION
There is an if statement check for the same thing as the ink_assert, and the ink_assert is causing crashes (sends abort signal), so there might be something else that's wrong. This fix is just to remove the unnecessary assertion such that the server doesn't crash during testing.