### PR TITLE
Use std::min and std::max globally

### DIFF
--- a/example/thread_pool/psi.c
+++ b/example/thread_pool/psi.c
@@ -35,6 +35,7 @@
 #include <stdlib.h>
 #include <limits.h>
 #include <string.h>
+#include <sys/param.h>
 
 #include "ts/ts.h"
 #include "thread.h"

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -3366,7 +3366,7 @@ HTTPInfo_v21::copy_and_upgrade_unmarshalled_to_v23(char *&dst, char *&src, size_
   // Extra data is fragment table - set that if we have it.
   if (n_frags) {
     static size_t const IFT_SIZE = HTTPCacheAlt_v23::N_INTEGRAL_FRAG_OFFSETS * sizeof(FragOffset);
-    size_t ift_actual            = min(n_frags, HTTPCacheAlt_v23::N_INTEGRAL_FRAG_OFFSETS) * sizeof(FragOffset);
+    size_t ift_actual            = std::min(n_frags, HTTPCacheAlt_v23::N_INTEGRAL_FRAG_OFFSETS) * sizeof(FragOffset);
 
     if (length < (HTTP_ALT_MARSHAL_SIZE + n_frags * sizeof(FragOffset) - IFT_SIZE)) {
       return false; // can't place fragment table.

--- a/iocore/cache/Store.cc
+++ b/iocore/cache/Store.cc
@@ -573,7 +573,7 @@ Span::init(const char *path, int64_t size)
 
   // The actual size of a span always trumps the configured size.
   if (size > 0 && this->size() != size) {
-    int64_t newsz = MIN(size, this->size());
+    int64_t newsz = std::min(size, this->size());
 
     Note("cache %s '%s' is %" PRId64 " bytes, but the configured size is %" PRId64 " bytes, using the minimum",
          span_file_typename(sbuf.st_mode), path, this->size(), size);

--- a/iocore/eventsystem/P_UnixSocketManager.h
+++ b/iocore/eventsystem/P_UnixSocketManager.h
@@ -118,7 +118,7 @@ SocketManager::vector_io(int fd, struct iovec *vector, size_t count, int read_re
   int64_t current_request_bytes;
 
   for (n_vec = 0; n_vec < (int)count; n_vec += max_iovecs_per_request) {
-    current_count = min(max_iovecs_per_request, ((int)(count - n_vec)));
+    current_count = std::min(max_iovecs_per_request, ((int)(count - n_vec)));
     do {
       // coverity[tainted_data_argument]
       r = read_request ? ::readv(fd, &vector[n_vec], current_count) : ::writev(fd, &vector[n_vec], current_count);

--- a/iocore/net/NetVCTest.cc
+++ b/iocore/net/NetVCTest.cc
@@ -308,7 +308,7 @@ NetVCTest::write_handler(int event)
     if (write_vio->ndone < bytes_to_send) {
       int left_to_send = bytes_to_send - actual_bytes_sent;
       ink_assert(left_to_send >= 0);
-      int to_fill = MIN(left_to_send, write_bytes_to_add_per);
+      int to_fill = std::min(left_to_send, write_bytes_to_add_per);
       actual_bytes_sent += fill_buffer(write_buffer, &write_seed, to_fill);
       write_vio->reenable();
     }

--- a/iocore/net/P_InkBulkIO.h
+++ b/iocore/net/P_InkBulkIO.h
@@ -141,7 +141,7 @@ struct InkBulkIORequest {
  */
 #define INKBIO_MAX_PKTS_PER_REQ_BLOCK                                                              \
   ((INKBIO_PKT_SIZE_WO_UDPHDR - (sizeof(struct InkBulkIORequest) + sizeof(struct InkBulkIOPkt))) / \
-   MAX((sizeof(struct InkBulkIORequest)), (sizeof(struct InkBulkIOPkt))))
+   std::max((sizeof(struct InkBulkIORequest)), (sizeof(struct InkBulkIOPkt))))
 
 /*
  * Requests are just block-ids---the block id points to the inkbio-block

--- a/iocore/net/UnixUDPNet.cc
+++ b/iocore/net/UnixUDPNet.cc
@@ -676,10 +676,10 @@ UDPQueue::service(UDPNetHandler *nh)
       // insert into our queue.
       Debug("udp-send", "Adding %p", p);
       if (p->conn->lastPktStartTime == 0) {
-        pktSendStartTime = MAX(now, p->delivery_time);
+        pktSendStartTime = std::max(now, p->delivery_time);
       } else {
         pktSendTime      = p->delivery_time;
-        pktSendStartTime = MAX(MAX(now, pktSendTime), p->delivery_time);
+        pktSendStartTime = std::max(std::max(now, pktSendTime), p->delivery_time);
       }
       p->conn->lastPktStartTime = pktSendStartTime;
       p->delivery_time          = pktSendStartTime;

--- a/lib/records/RecHttp.cc
+++ b/lib/records/RecHttp.cc
@@ -602,7 +602,7 @@ HttpProxyPort::print(char *out, size_t n)
     }
   }
 
-  return min(zret, n);
+  return std::min(zret, n);
 }
 
 void

--- a/lib/ts/ink_defs.h
+++ b/lib/ts/ink_defs.h
@@ -88,33 +88,6 @@ countof(const T (&)[N])
 #define ABS(x) (((x) < 0) ? (-(x)) : (x))
 #endif
 
-#ifndef MAX
-#define MAX(x, y) (((x) >= (y)) ? (x) : (y))
-#endif
-
-#ifndef MIN
-#define MIN(x, y) (((x) <= (y)) ? (x) : (y))
-#endif
-
-#ifdef __cplusplus
-// We can't use #define for min and max because it will conflict with
-// other declarations of min and max functions.  This conflict
-// occurs with STL
-template <class T>
-T
-min(const T a, const T b)
-{
-  return a < b ? a : b;
-}
-
-template <class T>
-T
-max(const T a, const T b)
-{
-  return a > b ? a : b;
-}
-#endif
-
 #define ATS_UNUSED __attribute__((unused))
 #define ATS_WARN_IF_UNUSED __attribute__((warn_unused_result))
 #define ATS_UNUSED_RETURN(x) \

--- a/proxy/InkAPITestTool.cc
+++ b/proxy/InkAPITestTool.cc
@@ -667,7 +667,7 @@ synclient_txn_write_request(TSCont contp)
   while (ntodo > 0) {
     block     = TSIOBufferStart(txn->req_buffer);
     ptr_block = TSIOBufferBlockWriteStart(block, &avail);
-    towrite   = MIN(ntodo, avail);
+    towrite   = std::min(ntodo, avail);
     memcpy(ptr_block, txn->request + ndone, towrite);
     TSIOBufferProduce(txn->req_buffer, towrite);
     ntodo -= towrite;
@@ -962,7 +962,7 @@ synserver_txn_write_response(TSCont contp)
   while (ntodo > 0) {
     block     = TSIOBufferStart(txn->resp_buffer);
     ptr_block = TSIOBufferBlockWriteStart(block, &avail);
-    towrite   = MIN(ntodo, avail);
+    towrite   = std::min(ntodo, avail);
     memcpy(ptr_block, response + ndone, towrite);
     TSIOBufferProduce(txn->resp_buffer, towrite);
     ntodo -= towrite;

--- a/proxy/PluginVC.cc
+++ b/proxy/PluginVC.cc
@@ -432,7 +432,7 @@ PluginVC::transfer_bytes(MIOBuffer *transfer_to, IOBufferReader *transfer_from, 
 
   while (act_on > 0) {
     int64_t block_read_avail = transfer_from->block_read_avail();
-    int64_t to_move          = MIN(act_on, block_read_avail);
+    int64_t to_move          = std::min(act_on, block_read_avail);
     int64_t moved            = 0;
 
     if (to_move <= 0) {
@@ -507,7 +507,7 @@ PluginVC::process_write_side(bool other_side_call)
 
   IOBufferReader *reader = write_state.vio.get_reader();
   int64_t bytes_avail    = reader->read_avail();
-  int64_t act_on         = MIN(bytes_avail, ntodo);
+  int64_t act_on         = std::min(bytes_avail, ntodo);
 
   Debug("pvc", "[%u] %s: process_write_side; act_on %" PRId64 "", core_obj->id, PVC_TYPE, act_on);
 
@@ -532,7 +532,7 @@ PluginVC::process_write_side(bool other_side_call)
     Debug("pvc", "[%u] %s: process_write_side no buffer space", core_obj->id, PVC_TYPE);
     return;
   }
-  act_on = MIN(act_on, buf_space);
+  act_on = std::min(act_on, buf_space);
 
   int64_t added = transfer_bytes(core_buffer, reader, act_on);
   if (added < 0) {
@@ -625,7 +625,7 @@ PluginVC::process_read_side(bool other_side_call)
   }
 
   int64_t bytes_avail = core_reader->read_avail();
-  int64_t act_on      = MIN(bytes_avail, ntodo);
+  int64_t act_on      = std::min(bytes_avail, ntodo);
 
   Debug("pvc", "[%u] %s: process_read_side; act_on %" PRId64 "", core_obj->id, PVC_TYPE, act_on);
 
@@ -641,13 +641,13 @@ PluginVC::process_read_side(bool other_side_call)
   MIOBuffer *output_buffer = read_state.vio.get_writer();
 
   int64_t water_mark = output_buffer->water_mark;
-  water_mark         = MAX(water_mark, PVC_DEFAULT_MAX_BYTES);
+  water_mark         = std::max(water_mark, static_cast<int64_t>(PVC_DEFAULT_MAX_BYTES));
   int64_t buf_space  = water_mark - output_buffer->max_read_avail();
   if (buf_space <= 0) {
     Debug("pvc", "[%u] %s: process_read_side no buffer space", core_obj->id, PVC_TYPE);
     return;
   }
-  act_on = MIN(act_on, buf_space);
+  act_on = std::min(act_on, buf_space);
 
   int64_t added = transfer_bytes(output_buffer, core_reader, act_on);
   if (added <= 0) {

--- a/proxy/hdrs/HTTP.cc
+++ b/proxy/hdrs/HTTP.cc
@@ -1809,6 +1809,8 @@ ClassAllocator<HTTPCacheAlt> httpCacheAltAllocator("httpCacheAltAllocator");
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
+int constexpr HTTPCacheAlt::N_INTEGRAL_FRAG_OFFSETS;
+
 HTTPCacheAlt::HTTPCacheAlt()
   : m_magic(CACHE_ALT_MAGIC_ALIVE),
     m_writeable(1),

--- a/proxy/hdrs/HTTP.h
+++ b/proxy/hdrs/HTTP.h
@@ -1338,7 +1338,7 @@ struct HTTPCacheAlt {
   /// for the last fragment.
   FragOffset *m_frag_offsets;
   /// # of fragment offsets built in to object.
-  static int const N_INTEGRAL_FRAG_OFFSETS = 4;
+  static int constexpr N_INTEGRAL_FRAG_OFFSETS = 4;
   /// Integral fragment offset table.
   FragOffset m_integral_frag_offsets[N_INTEGRAL_FRAG_OFFSETS];
 

--- a/proxy/hdrs/HttpCompat.cc
+++ b/proxy/hdrs/HttpCompat.cc
@@ -851,7 +851,7 @@ HttpCompat::determine_set_by_language(RawHashTable *table_of_sets, StrList *acpt
       // index, preferring values earlier in Accept-Language list.   //
       /////////////////////////////////////////////////////////////////
 
-      Q = min(Ql, Qc);
+      Q = std::min(Ql, Qc);
 
       //////////////////////////////////////////////////////////
       // normally the Q for default pages should be slightly  //

--- a/proxy/hdrs/MIME.cc
+++ b/proxy/hdrs/MIME.cc
@@ -2802,7 +2802,7 @@ mime_mem_print(const char *src_d, int src_l, char *buf_start, int buf_length, in
     }
   }
 
-  copy_l = min(buf_length - *buf_index_inout, src_l);
+  copy_l = std::min(buf_length - *buf_index_inout, src_l);
   if (copy_l > 0) {
     memcpy(buf_start + *buf_index_inout, src_d, copy_l);
     *buf_index_inout += copy_l;

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -1284,7 +1284,7 @@ HttpConfig::reconfigure()
 
   params->oride.cache_heuristic_min_lifetime = m_master.oride.cache_heuristic_min_lifetime;
   params->oride.cache_heuristic_max_lifetime = m_master.oride.cache_heuristic_max_lifetime;
-  params->oride.cache_heuristic_lm_factor    = min(max(m_master.oride.cache_heuristic_lm_factor, 0.0f), 1.0f);
+  params->oride.cache_heuristic_lm_factor    = std::min(std::max(m_master.oride.cache_heuristic_lm_factor, 0.0f), 1.0f);
 
   params->oride.cache_guaranteed_min_lifetime = m_master.oride.cache_guaranteed_min_lifetime;
   params->oride.cache_guaranteed_max_lifetime = m_master.oride.cache_guaranteed_max_lifetime;

--- a/proxy/http/HttpTransactHeaders.cc
+++ b/proxy/http/HttpTransactHeaders.cc
@@ -409,7 +409,7 @@ HttpTransactHeaders::calculate_document_age(ink_time_t request_time, ink_time_t 
   // Deal with clock skew. Sigh.
   //
   // TODO solve this global clock problem
-  now_value = max(now, response_time);
+  now_value = std::max(now, response_time);
 
   ink_assert(response_time >= 0);
   ink_assert(request_time >= 0);
@@ -417,12 +417,12 @@ HttpTransactHeaders::calculate_document_age(ink_time_t request_time, ink_time_t 
   ink_assert(now_value >= response_time);
 
   if (date_value > 0) {
-    apparent_age = max((time_t)0, (response_time - date_value));
+    apparent_age = std::max((time_t)0, (response_time - date_value));
   }
   if (age_value < 0) {
     current_age = -1; // Overflow from Age: header
   } else {
-    corrected_received_age = max(apparent_age, age_value);
+    corrected_received_age = std::max(apparent_age, age_value);
     response_delay         = response_time - request_time;
     corrected_initial_age  = corrected_received_age + response_delay;
     resident_time          = now_value - response_time;

--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -207,7 +207,7 @@ ChunkedHandler::transfer_bytes()
 
   // Handle the case where we are doing chunked passthrough.
   if (!dechunked_buffer) {
-    moved = MIN(bytes_left, chunked_reader->read_avail());
+    moved = std::min(bytes_left, chunked_reader->read_avail());
     chunked_reader->consume(moved);
     bytes_left = bytes_left - moved;
     return moved;
@@ -216,7 +216,7 @@ ChunkedHandler::transfer_bytes()
   while (bytes_left > 0) {
     block_read_avail = chunked_reader->block_read_avail();
 
-    to_move = MIN(bytes_left, block_read_avail);
+    to_move = std::min(bytes_left, block_read_avail);
     if (to_move <= 0) {
       break;
     }
@@ -348,7 +348,7 @@ ChunkedHandler::generate_chunked_content()
   }
 
   while ((r_avail = dechunked_reader->read_avail()) > 0 && state != CHUNK_WRITE_DONE) {
-    int64_t write_val = MIN(max_chunk_size, r_avail);
+    int64_t write_val = std::min(max_chunk_size, r_avail);
 
     state = CHUNK_WRITE_CHUNK;
     Debug("http_chunk", "creating a chunk of size %" PRId64 " bytes", write_val);

--- a/proxy/http2/HTTP2.cc
+++ b/proxy/http2/HTTP2.cc
@@ -588,7 +588,7 @@ http2_encode_header_blocks(HTTPHdr *in, uint8_t *out, uint32_t out_len, uint32_t
                            int32_t maximum_table_size)
 {
   // Limit the maximum table size to 64kB, which is the size advertised by major clients
-  maximum_table_size = min(maximum_table_size, HTTP2_MAX_TABLE_SIZE_LIMIT);
+  maximum_table_size = std::min(maximum_table_size, HTTP2_MAX_TABLE_SIZE_LIMIT);
   // Set maximum table size only if it is different from current maximum size
   if (maximum_table_size == hpack_get_maximum_table_size(handle)) {
     maximum_table_size = -1;

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -167,7 +167,7 @@ rcv_data_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
   myreader->writer()->dealloc_reader(myreader);
 
   uint32_t initial_rwnd = cstate.server_settings.get(HTTP2_SETTINGS_INITIAL_WINDOW_SIZE);
-  uint32_t min_rwnd     = min(initial_rwnd, cstate.server_settings.get(HTTP2_SETTINGS_MAX_FRAME_SIZE));
+  uint32_t min_rwnd     = std::min(initial_rwnd, cstate.server_settings.get(HTTP2_SETTINGS_MAX_FRAME_SIZE));
   // Connection level WINDOW UPDATE
   if (cstate.server_rwnd <= min_rwnd) {
     Http2WindowSize diff_size = initial_rwnd - cstate.server_rwnd;
@@ -713,7 +713,7 @@ rcv_window_update_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
     }
 
     stream->client_rwnd += size;
-    ssize_t wnd = min(cstate.client_rwnd, stream->client_rwnd);
+    ssize_t wnd = std::min(cstate.client_rwnd, stream->client_rwnd);
 
     if (!stream->is_closed() && stream->get_state() == Http2StreamState::HTTP2_STREAM_STATE_HALF_CLOSED_REMOTE && wnd > 0) {
       stream->send_response_body();
@@ -1072,7 +1072,7 @@ Http2ConnectionState::restart_streams()
   while (s) {
     Http2Stream *next = static_cast<Http2Stream *>(s->link.next);
     if (!s->is_closed() && s->get_state() == Http2StreamState::HTTP2_STREAM_STATE_HALF_CLOSED_REMOTE &&
-        min(this->client_rwnd, s->client_rwnd) > 0) {
+        std::min(this->client_rwnd, s->client_rwnd) > 0) {
       s->send_response_body();
     }
     ink_assert(s != next);
@@ -1246,9 +1246,9 @@ Http2ConnectionState::send_data_frames_depends_on_priority()
 Http2SendADataFrameResult
 Http2ConnectionState::send_a_data_frame(Http2Stream *stream, size_t &payload_length)
 {
-  const ssize_t window_size         = min(this->client_rwnd, stream->client_rwnd);
+  const ssize_t window_size         = std::min(this->client_rwnd, stream->client_rwnd);
   const size_t buf_len              = BUFFER_SIZE_FOR_INDEX(buffer_size_index[HTTP2_FRAME_TYPE_DATA]);
-  const size_t write_available_size = min(buf_len, static_cast<size_t>(window_size));
+  const size_t write_available_size = std::min(buf_len, static_cast<size_t>(window_size));
   size_t read_available_size        = 0;
 
   uint8_t flags = 0x00;
@@ -1414,8 +1414,8 @@ Http2ConnectionState::send_headers_frame(Http2Stream *stream)
   flags = 0;
   while (sent < header_blocks_size) {
     DebugHttp2Stream(ua_session, stream->get_id(), "Send CONTINUATION frame");
-    payload_length = MIN(static_cast<uint32_t>(BUFFER_SIZE_FOR_INDEX(buffer_size_index[HTTP2_FRAME_TYPE_CONTINUATION])),
-                         header_blocks_size - sent);
+    payload_length = std::min(static_cast<uint32_t>(BUFFER_SIZE_FOR_INDEX(buffer_size_index[HTTP2_FRAME_TYPE_CONTINUATION])),
+                              static_cast<uint32_t>(header_blocks_size - sent));
     if (sent + payload_length == header_blocks_size) {
       flags |= HTTP2_FLAGS_CONTINUATION_END_HEADERS;
     }
@@ -1496,8 +1496,8 @@ Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url)
   flags = 0;
   while (sent < header_blocks_size) {
     DebugHttp2Stream(ua_session, stream->get_id(), "Send CONTINUATION frame");
-    payload_length = MIN(static_cast<uint32_t>(BUFFER_SIZE_FOR_INDEX(buffer_size_index[HTTP2_FRAME_TYPE_CONTINUATION])),
-                         header_blocks_size - sent);
+    payload_length = std::min(static_cast<uint32_t>(BUFFER_SIZE_FOR_INDEX(buffer_size_index[HTTP2_FRAME_TYPE_CONTINUATION])),
+                              static_cast<uint32_t>(header_blocks_size - sent));
     if (sent + payload_length == header_blocks_size) {
       flags |= HTTP2_FLAGS_CONTINUATION_END_HEADERS;
     }

--- a/tools/jtest/jtest.cc
+++ b/tools/jtest/jtest.cc
@@ -548,7 +548,7 @@ max_limit_fd()
   if (getrlimit(RLIMIT_NOFILE, &rl) >= 0) {
 #ifdef OPEN_MAX
     // Darwin
-    rl.rlim_cur = MIN(OPEN_MAX, rl.rlim_max);
+    rl.rlim_cur = std::min(static_cast<rlim_t>(OPEN_MAX), rl.rlim_max);
 #else
     rl.rlim_cur = rl.rlim_max;
 #endif
@@ -2140,7 +2140,7 @@ compose_all_urls(const char *tag, char *buf, char *start, char *end, int buflen,
   char old;
   while ((start = find_href_start(tag, end, buflen - (end - buf)))) {
     char newurl[512];
-    end = (char *)find_href_end(start, MIN(buflen - (start - buf), 512 - 10));
+    end = (char *)find_href_end(start, std::min(static_cast<int>(buflen - (start - buf)), 512 - 10));
     if (!end) {
       end = start + strlen(tag);
       continue;


### PR DESCRIPTION
Get rid of custom macros and templates around min/max and just use STL ones.