### PR TITLE
Handle unexpected events as errors in HttpSM::state_http_server_open().

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -1711,6 +1711,10 @@ HttpSM::state_http_server_open(int event, void *data)
       do_http_server_open();
     }
     break;
+  default:
+    // log unexpected event and handle it as an error in production. debug builds will drop a core and call abort.
+    Error("[HttpSM::state_http_server_open] Unknown event: %d", event);
+    ink_assert(!"Unexpected event");
   case VC_EVENT_ERROR:
   case NET_EVENT_OPEN_FAILED:
     t_state.current.state = HttpTransact::CONNECTION_ERROR;
@@ -1744,11 +1748,6 @@ HttpSM::state_http_server_open(int event, void *data)
   case CONGESTION_EVENT_CONGESTED_ON_M:
     t_state.current.state = HttpTransact::CONGEST_CONTROL_CONGESTED_ON_M;
     call_transact_and_set_next_state(HttpTransact::HandleResponse);
-    return 0;
-
-  default:
-    Error("[HttpSM::state_http_server_open] Unknown event: %d", event);
-    ink_release_assert(0);
     return 0;
   }
 


### PR DESCRIPTION
On our production caches we see very intermittent crashes when HttpSM::state_http_server_open() receives unexpected events.  In our case, I see a VC_EVENT_WRITE_COMPLETE event while that state machine is processing a POST request to an origin server.  I've tried duplicating this in order to find the bug but am unable to do so.  In any event, I thought it would be better to log and handle the unexpected events as errors in production rather than dropping a core and crashing traffic server.  As suggested by B. Call, i added an ink_assert() so that debug builds will drop a core and terminate when an unexpected event comes to this handler.