### PR TITLE
Fix #2372: Preserve Accept-Encoding header for H2 Server Push promise.

### DIFF
--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -7644,12 +7644,19 @@ TSHttpTxnServerPush(TSHttpTxn txnp, const char *url, int url_len)
     url_obj.destroy();
     return;
   }
+
   HttpSM *sm          = reinterpret_cast<HttpSM *>(txnp);
   Http2Stream *stream = dynamic_cast<Http2Stream *>(sm->ua_session);
   if (stream) {
     Http2ClientSession *parent = static_cast<Http2ClientSession *>(stream->get_parent());
     if (!parent->is_url_pushed(url, url_len)) {
-      stream->push_promise(url_obj);
+      HTTPHdr *hptr = &(sm->t_state.hdr_info.client_request);
+      TSMLoc obj    = reinterpret_cast<TSMLoc>(hptr->m_http);
+
+      MIMEHdrImpl *mh = _hdr_mloc_to_mime_hdr_impl(obj);
+      MIMEField *f    = mime_hdr_field_find(mh, MIME_FIELD_ACCEPT_ENCODING, MIME_LEN_ACCEPT_ENCODING);
+      stream->push_promise(url_obj, f);
+
       parent->add_url_to_pushed_table(url, url_len);
     }
   }

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1435,7 +1435,7 @@ Http2ConnectionState::send_headers_frame(Http2Stream *stream)
 }
 
 void
-Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url)
+Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url, const MIMEField *accept_encoding)
 {
   HTTPHdr h1_hdr, h2_hdr;
   uint8_t *buf                = nullptr;
@@ -1454,6 +1454,21 @@ Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url)
   h1_hdr.create(HTTP_TYPE_REQUEST);
   h1_hdr.url_set(&url);
   h1_hdr.method_set("GET", 3);
+  if (accept_encoding != nullptr) {
+    MIMEField *f;
+    const char *name;
+    int name_len;
+    const char *value;
+    int value_len;
+
+    name  = accept_encoding->name_get(&name_len);
+    f     = h1_hdr.field_create(name, name_len);
+    value = accept_encoding->value_get(&value_len);
+    f->value_set(h1_hdr.m_heap, h1_hdr.m_mime, value, value_len);
+
+    h1_hdr.field_attach(f);
+  }
+
   http2_generate_h2_header_from_1_1(&h1_hdr, &h2_hdr);
 
   buf_len = h1_hdr.length_get() * 2; // Make it double just in case

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -220,7 +220,7 @@ public:
   void send_data_frames(Http2Stream *stream);
   Http2SendADataFrameResult send_a_data_frame(Http2Stream *stream, size_t &payload_length);
   void send_headers_frame(Http2Stream *stream);
-  void send_push_promise_frame(Http2Stream *stream, URL &url);
+  void send_push_promise_frame(Http2Stream *stream, URL &url, const MIMEField *accept_encoding);
   void send_rst_stream_frame(Http2StreamId id, Http2ErrorCode ec);
   void send_settings_frame(const Http2ConnectionSettings &new_settings);
   void send_ping_frame(Http2StreamId id, uint8_t flag, const uint8_t *opaque_data);

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -619,10 +619,10 @@ Http2Stream::update_write_request(IOBufferReader *buf_reader, int64_t write_len,
 }
 
 void
-Http2Stream::push_promise(URL &url)
+Http2Stream::push_promise(URL &url, const MIMEField *accept_encoding)
 {
   Http2ClientSession *parent = static_cast<Http2ClientSession *>(this->get_parent());
-  parent->connection_state.send_push_promise_frame(this, url);
+  parent->connection_state.send_push_promise_frame(this, url, accept_encoding);
 }
 
 void

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -153,7 +153,7 @@ public:
   void reenable(VIO *vio) override;
   virtual void transaction_done() override;
   void send_response_body();
-  void push_promise(URL &url);
+  void push_promise(URL &url, const MIMEField *accept_encoding);
 
   // Stream level window size
   ssize_t client_rwnd;


### PR DESCRIPTION
I'm not sure if this is the right change. The intention here is to be able to use the GZIP plugin to compress responses initiated by a server push promise by preserving the Accept-Encoding header, but I'm in doubt if this will actually work.

@maskit I'd really appreciate your input about this problem.

This change maintains API compatibility with H2 server push.

See #2372

Signed-off-by: David Calavera <david.calavera@gmail.com>