### PR TITLE
Cleanup: remove ts::ConstBuffer from ink_inet.

### DIFF
--- a/example/ssl_preaccept/ssl_preaccept.cc
+++ b/example/ssl_preaccept/ssl_preaccept.cc
@@ -51,17 +51,16 @@ IpRangeQueue ClientBlindTunnelIp;
 Configuration Config; // global configuration
 
 void
-Parse_Addr_String(ts::ConstBuffer const &text, IpRange &range)
+Parse_Addr_String(ts::string_view const &text, IpRange &range)
 {
   IpAddr newAddr;
-  std::string textstr(text._ptr, text._size);
   // Is there a hyphen?
-  size_t hyphen_pos = textstr.find('-');
-  if (hyphen_pos != std::string::npos) {
-    std::string addr1 = textstr.substr(0, hyphen_pos);
-    std::string addr2 = textstr.substr(hyphen_pos + 1);
-    range.first.load(ts::ConstBuffer(addr1.c_str(), addr1.length()));
-    range.second.load(ts::ConstBuffer(addr2.c_str(), addr2.length()));
+  size_t hyphen_pos = text.find('-');
+  if (hyphen_pos != ts::string_view::npos) {
+    ts::string_view addr1 = text.substr(0, hyphen_pos);
+    ts::string_view addr2 = text.substr(hyphen_pos + 1);
+    range.first.load(addr1);
+    range.second.load(addr2);
   } else { // Assume it is a single address
     newAddr.load(text);
     range.first  = newAddr;
@@ -77,13 +76,14 @@ Load_Config_Value(Value const &parent, const char *name, IpRangeQueue &addrs)
   std::string zret;
   IpRange ipRange;
   if (v.isLiteral()) {
-    Parse_Addr_String(v.getText(), ipRange);
+    auto txt = v.getText();
+    Parse_Addr_String(ts::string_view(txt._ptr, txt._size), ipRange);
     addrs.push_back(ipRange);
   } else if (v.isContainer()) {
     size_t i;
     for (i = 0; i < v.childCount(); i++) {
-      std::string val_str(v[i].getText()._ptr, v[i].getText()._size);
-      Parse_Addr_String(v[i].getText(), ipRange);
+      auto txt = v[i].getText();
+      Parse_Addr_String(ts::string_view(txt._ptr, txt._size), ipRange);
       addrs.push_back(ipRange);
     }
   }

--- a/iocore/hostdb/P_HostDBProcessor.h
+++ b/iocore/hostdb/P_HostDBProcessor.h
@@ -29,6 +29,7 @@
 #define _P_HostDBProcessor_h_
 
 #include "I_HostDBProcessor.h"
+#include <ts/TsBuffer.h>
 
 //
 // Data

--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -33,7 +33,7 @@
 #include "I_IOBuffer.h"
 #include "I_Socks.h"
 #include <ts/apidefs.h>
-#include <ts/MemView.h>
+#include <ts/string_view.h>
 
 #define CONNECT_SUCCESS 1
 #define CONNECT_FAILURE 0
@@ -202,7 +202,7 @@ struct NetVCOptions {
     IpEndpoint ip;
 
     // Literal IPv4 and IPv6 addresses are not permitted in "HostName".(rfc6066#section-3)
-    if (name && len && ats_ip_pton(ts::ConstBuffer(name, len), &ip) != 0) {
+    if (name && len && ats_ip_pton(ts::string_view(name, len), &ip) != 0) {
       sni_servername = ats_strndup(name, len);
     } else {
       sni_servername = nullptr;
@@ -236,9 +236,9 @@ struct NetVCOptions {
     return *this;
   }
 
-  ts::StringView get_family_string() const;
+  ts::string_view get_family_string() const;
 
-  ts::StringView get_proto_string() const;
+  ts::string_view get_proto_string() const;
 
   /// @name Debugging
   //@{
@@ -629,13 +629,13 @@ public:
   }
 
   virtual int
-  populate_protocol(ts::StringView *results, int n) const
+  populate_protocol(ts::string_view *results, int n) const
   {
     return 0;
   }
 
   virtual const char *
-  protocol_contains(ts::StringView prefix) const
+  protocol_contains(ts::string_view prefix) const
   {
     return nullptr;
   }

--- a/iocore/net/NetVConnection.cc
+++ b/iocore/net/NetVConnection.cc
@@ -45,7 +45,7 @@ NetVConnection::cancel_OOB()
   return;
 }
 
-ts::StringView
+ts::string_view
 NetVCOptions::get_proto_string() const
 {
   switch (ip_proto) {
@@ -59,7 +59,7 @@ NetVCOptions::get_proto_string() const
   return nullptr;
 }
 
-ts::StringView
+ts::string_view
 NetVCOptions::get_family_string() const
 {
   switch (ip_family) {

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -280,8 +280,8 @@ public:
     return ssl ? SSL_get_cipher_name(ssl) : nullptr;
   }
 
-  int populate_protocol(ts::StringView *results, int n) const override;
-  const char *protocol_contains(ts::StringView tag) const override;
+  int populate_protocol(ts::string_view *results, int n) const override;
+  const char *protocol_contains(ts::string_view tag) const override;
 
   /**
    * Populate the current object based on the socket information in in the
@@ -304,7 +304,7 @@ public:
   SSLNetVConnection &operator=(const SSLNetVConnection &) = delete;
 
 private:
-  ts::StringView map_tls_protocol_to_tag(const char *proto_string) const;
+  ts::string_view map_tls_protocol_to_tag(const char *proto_string) const;
   bool update_rbio(bool move_to_socket);
 
   bool sslHandShakeComplete        = false;

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -175,8 +175,8 @@ public:
   /////////////////////////////////////////////////////////////////
   UnixNetVConnection();
 
-  int populate_protocol(ts::StringView *results, int n) const override;
-  const char *protocol_contains(ts::StringView tag) const override;
+  int populate_protocol(ts::string_view *results, int n) const override;
+  const char *protocol_contains(ts::string_view tag) const override;
 
   // noncopyable
   UnixNetVConnection(const NetVConnection &) = delete;

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -1597,13 +1597,10 @@ SSLNetVConnection::populate(Connection &con, Continuation *c, void *arg)
   return EVENT_DONE;
 }
 
-ts::StringView
+ts::string_view
 SSLNetVConnection::map_tls_protocol_to_tag(const char *proto_string) const
 {
-  // tag to use if something goes wrong with fetching the TLS protocol string.
-  static constexpr ts::StringView UNKNOWN("tls/?.?", ts::StringView::literal);
-
-  ts::StringView retval{UNKNOWN}; // return this if the protocol lookup doesn't work.
+  ts::string_view retval{"tls/?.?"_sv}; // return this if the protocol lookup doesn't work.
 
   if (proto_string) {
     // openSSL guarantees the case of the protocol string.
@@ -1632,12 +1629,12 @@ SSLNetVConnection::map_tls_protocol_to_tag(const char *proto_string) const
 }
 
 int
-SSLNetVConnection::populate_protocol(ts::StringView *results, int n) const
+SSLNetVConnection::populate_protocol(ts::string_view *results, int n) const
 {
   int retval = 0;
   if (n > retval) {
     results[retval] = map_tls_protocol_to_tag(getSSLProtocol());
-    if (results[retval]) {
+    if (!results[retval].empty()) {
       ++retval;
     }
     if (n > retval) {
@@ -1648,12 +1645,12 @@ SSLNetVConnection::populate_protocol(ts::StringView *results, int n) const
 }
 
 const char *
-SSLNetVConnection::protocol_contains(ts::StringView prefix) const
+SSLNetVConnection::protocol_contains(ts::string_view prefix) const
 {
-  const char *retval = nullptr;
-  ts::StringView tag = map_tls_protocol_to_tag(getSSLProtocol());
-  if (prefix.size() <= tag.size() && strncmp(tag.ptr(), prefix.ptr(), prefix.size()) == 0) {
-    retval = tag.ptr();
+  const char *retval  = nullptr;
+  ts::string_view tag = map_tls_protocol_to_tag(getSSLProtocol());
+  if (prefix.size() <= tag.size() && strncmp(tag.data(), prefix.data(), prefix.size()) == 0) {
+    retval = tag.data();
   } else {
     retval = super::protocol_contains(prefix);
   }

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1495,15 +1495,15 @@ UnixNetVConnection::remove_from_active_queue()
 }
 
 int
-UnixNetVConnection::populate_protocol(ts::StringView *results, int n) const
+UnixNetVConnection::populate_protocol(ts::string_view *results, int n) const
 {
   int retval = 0;
   if (n > retval) {
-    if (!(results[retval] = options.get_proto_string()).isEmpty()) {
+    if (!(results[retval] = options.get_proto_string()).empty()) {
       ++retval;
     }
     if (n > retval) {
-      if (!(results[retval] = options.get_family_string()).isEmpty()) {
+      if (!(results[retval] = options.get_family_string()).empty()) {
         ++retval;
       }
     }
@@ -1512,14 +1512,14 @@ UnixNetVConnection::populate_protocol(ts::StringView *results, int n) const
 }
 
 const char *
-UnixNetVConnection::protocol_contains(ts::StringView tag) const
+UnixNetVConnection::protocol_contains(ts::string_view tag) const
 {
-  ts::StringView retval = options.get_proto_string();
-  if (!tag.isNoCasePrefixOf(retval)) { // didn't match IP level, check TCP level
+  ts::string_view retval = options.get_proto_string();
+  if (!IsNoCasePrefixOf(tag, retval)) { // didn't match IP level, check TCP level
     retval = options.get_family_string();
-    if (!tag.isNoCasePrefixOf(retval)) { // no match here either, return empty.
-      retval.clear();
+    if (!IsNoCasePrefixOf(tag, retval)) { // no match here either, return empty.
+      ink_zero(retval);
     }
   }
-  return retval.ptr();
+  return retval.data();
 }

--- a/lib/records/RecHttp.cc
+++ b/lib/records/RecHttp.cc
@@ -36,10 +36,10 @@ SessionProtocolNameRegistry globalSessionProtocolNameRegistry;
    These are also used for NPN setup.
 */
 
-const char *const TS_ALPN_PROTOCOL_HTTP_0_9 = IP_PROTO_TAG_HTTP_0_9.ptr();
-const char *const TS_ALPN_PROTOCOL_HTTP_1_0 = IP_PROTO_TAG_HTTP_1_0.ptr();
-const char *const TS_ALPN_PROTOCOL_HTTP_1_1 = IP_PROTO_TAG_HTTP_1_1.ptr();
-const char *const TS_ALPN_PROTOCOL_HTTP_2_0 = IP_PROTO_TAG_HTTP_2_0.ptr();
+const char *const TS_ALPN_PROTOCOL_HTTP_0_9 = IP_PROTO_TAG_HTTP_0_9.data();
+const char *const TS_ALPN_PROTOCOL_HTTP_1_0 = IP_PROTO_TAG_HTTP_1_0.data();
+const char *const TS_ALPN_PROTOCOL_HTTP_1_1 = IP_PROTO_TAG_HTTP_1_1.data();
+const char *const TS_ALPN_PROTOCOL_HTTP_2_0 = IP_PROTO_TAG_HTTP_2_0.data();
 
 const char *const TS_ALPN_PROTOCOL_GROUP_HTTP  = "http";
 const char *const TS_ALPN_PROTOCOL_GROUP_HTTP2 = "http2";
@@ -47,14 +47,14 @@ const char *const TS_ALPN_PROTOCOL_GROUP_HTTP2 = "http2";
 const char *const TS_PROTO_TAG_HTTP_1_0 = TS_ALPN_PROTOCOL_HTTP_1_0;
 const char *const TS_PROTO_TAG_HTTP_1_1 = TS_ALPN_PROTOCOL_HTTP_1_1;
 const char *const TS_PROTO_TAG_HTTP_2_0 = TS_ALPN_PROTOCOL_HTTP_2_0;
-const char *const TS_PROTO_TAG_TLS_1_3  = IP_PROTO_TAG_TLS_1_3.ptr();
-const char *const TS_PROTO_TAG_TLS_1_2  = IP_PROTO_TAG_TLS_1_2.ptr();
-const char *const TS_PROTO_TAG_TLS_1_1  = IP_PROTO_TAG_TLS_1_1.ptr();
-const char *const TS_PROTO_TAG_TLS_1_0  = IP_PROTO_TAG_TLS_1_0.ptr();
-const char *const TS_PROTO_TAG_TCP      = IP_PROTO_TAG_TCP.ptr();
-const char *const TS_PROTO_TAG_UDP      = IP_PROTO_TAG_UDP.ptr();
-const char *const TS_PROTO_TAG_IPV4     = IP_PROTO_TAG_IPV4.ptr();
-const char *const TS_PROTO_TAG_IPV6     = IP_PROTO_TAG_IPV6.ptr();
+const char *const TS_PROTO_TAG_TLS_1_3  = IP_PROTO_TAG_TLS_1_3.data();
+const char *const TS_PROTO_TAG_TLS_1_2  = IP_PROTO_TAG_TLS_1_2.data();
+const char *const TS_PROTO_TAG_TLS_1_1  = IP_PROTO_TAG_TLS_1_1.data();
+const char *const TS_PROTO_TAG_TLS_1_0  = IP_PROTO_TAG_TLS_1_0.data();
+const char *const TS_PROTO_TAG_TCP      = IP_PROTO_TAG_TCP.data();
+const char *const TS_PROTO_TAG_UDP      = IP_PROTO_TAG_UDP.data();
+const char *const TS_PROTO_TAG_IPV4     = IP_PROTO_TAG_IPV4.data();
+const char *const TS_PROTO_TAG_IPV6     = IP_PROTO_TAG_IPV6.data();
 
 InkHashTable *TSProtoTags;
 
@@ -386,11 +386,11 @@ HttpProxyPort::processOptions(const char *opts)
 
   if (af_set_p) {
     if (in_ip_set_p && m_family != m_inbound_ip.family()) {
-      ts::StringView iname{ats_ip_family_name(m_inbound_ip.family())};
-      ts::StringView fname{ats_ip_family_name(m_family)};
+      ts::string_view iname{ats_ip_family_name(m_inbound_ip.family())};
+      ts::string_view fname{ats_ip_family_name(m_family)};
       Warning("Invalid port descriptor '%s' - the inbound adddress family [%.*s] is not the same type as the explicit family value "
               "[%.*s]",
-              opts, static_cast<int>(iname.size()), iname.ptr(), static_cast<int>(fname.size()), fname.ptr());
+              opts, static_cast<int>(iname.size()), iname.data(), static_cast<int>(fname.size()), fname.data());
       zret = false;
     }
   } else if (in_ip_set_p) {

--- a/lib/ts/MemView.h
+++ b/lib/ts/MemView.h
@@ -33,6 +33,7 @@
 #include <memory.h>
 #include <algorithm>
 #include <string>
+#include <ts/string_view.h>
 
 /// Apache Traffic Server commons.
 namespace ts
@@ -344,6 +345,10 @@ public:
                        const char *end    ///< First byte not in the view.
                        );
 
+  /** Construct from standard string view.
+   */
+  constexpr StringView(ts::string_view const &that);
+
   /** Constructor from literal string.
 
       Construct directly from a literal string. This avoids a call to :c strlen and therefore is
@@ -387,6 +392,9 @@ public:
   /// Construct from @c std::string, referencing the entire string contents.
   /// @internal Not all compilers make @c std::string methods called @c constexpr
   StringView(std::string const &str);
+
+  /// Convert to standard string view.
+  operator ts::string_view() const;
 
   /** Equality.
 
@@ -935,6 +943,15 @@ template <size_t N> constexpr StringView::StringView(const char (&s)[N], literal
 
 template <size_t N> constexpr StringView::StringView(const char (&s)[N], array_t) : _ptr(s), _size(N)
 {
+}
+
+inline constexpr StringView::StringView(ts::string_view const &that) : _ptr(that.data()), _size(that.size())
+{
+}
+
+inline StringView::operator ts::string_view() const
+{
+  return {_ptr, _size};
 }
 
 inline void StringView::initDelimiterSet(std::bitset<256> &set)

--- a/lib/ts/ink_inet.h
+++ b/lib/ts/ink_inet.h
@@ -30,8 +30,7 @@
 #include <sys/socket.h>
 #include "ts/ink_memory.h"
 #include "ts/ink_apidefs.h"
-#include "ts/TsBuffer.h"
-#include <ts/MemView.h>
+#include <ts/string_view.h>
 
 #if !TS_HAS_IN6_IS_ADDR_UNSPECIFIED
 #if defined(IN6_IS_ADDR_UNSPECIFIED)
@@ -46,18 +45,18 @@ IN6_IS_ADDR_UNSPECIFIED(in6_addr const *addr)
 #endif
 
 // IP protocol stack tags.
-extern const ts::StringView IP_PROTO_TAG_IPV4;
-extern const ts::StringView IP_PROTO_TAG_IPV6;
-extern const ts::StringView IP_PROTO_TAG_UDP;
-extern const ts::StringView IP_PROTO_TAG_TCP;
-extern const ts::StringView IP_PROTO_TAG_TLS_1_0;
-extern const ts::StringView IP_PROTO_TAG_TLS_1_1;
-extern const ts::StringView IP_PROTO_TAG_TLS_1_2;
-extern const ts::StringView IP_PROTO_TAG_TLS_1_3;
-extern const ts::StringView IP_PROTO_TAG_HTTP_0_9;
-extern const ts::StringView IP_PROTO_TAG_HTTP_1_0;
-extern const ts::StringView IP_PROTO_TAG_HTTP_1_1;
-extern const ts::StringView IP_PROTO_TAG_HTTP_2_0;
+extern const ts::string_view IP_PROTO_TAG_IPV4;
+extern const ts::string_view IP_PROTO_TAG_IPV6;
+extern const ts::string_view IP_PROTO_TAG_UDP;
+extern const ts::string_view IP_PROTO_TAG_TCP;
+extern const ts::string_view IP_PROTO_TAG_TLS_1_0;
+extern const ts::string_view IP_PROTO_TAG_TLS_1_1;
+extern const ts::string_view IP_PROTO_TAG_TLS_1_2;
+extern const ts::string_view IP_PROTO_TAG_TLS_1_3;
+extern const ts::string_view IP_PROTO_TAG_HTTP_0_9;
+extern const ts::string_view IP_PROTO_TAG_HTTP_1_0;
+extern const ts::string_view IP_PROTO_TAG_HTTP_1_1;
+extern const ts::string_view IP_PROTO_TAG_HTTP_2_0;
 
 struct IpAddr; // forward declare.
 
@@ -140,10 +139,10 @@ int ats_tcp_somaxconn();
 
     @return 0 if an address was found, non-zero otherwise.
 */
-int ats_ip_parse(ts::ConstBuffer src,      ///< [in] String to search.
-                 ts::ConstBuffer *addr,    ///< [out] Range containing IP address.
-                 ts::ConstBuffer *port,    ///< [out] Range containing port.
-                 ts::ConstBuffer *rest = 0 ///< [out] Remnant past the addr/port if any.
+int ats_ip_parse(ts::string_view src,      ///< [in] String to search.
+                 ts::string_view *addr,    ///< [out] Range containing IP address.
+                 ts::string_view *port,    ///< [out] Range containing port.
+                 ts::string_view *rest = 0 ///< [out] Remnant past the addr/port if any.
                  );
 
 /**  Check to see if a buffer contains only IP address characters.
@@ -152,7 +151,7 @@ int ats_ip_parse(ts::ConstBuffer src,      ///< [in] String to search.
     - AF_INET - only digits and dots.
     - AF_INET6 - colons found.
 */
-int ats_ip_check_characters(ts::ConstBuffer text);
+int ats_ip_check_characters(ts::string_view text);
 
 /**
   Wrapper for inet_addr().
@@ -189,7 +188,7 @@ ats_ip_invalidate(IpEndpoint *ip)
 /** Get a string name for an IP address family.
     @return The string name (never @c nullptr).
 */
-ts::StringView ats_ip_family_name(int family);
+ts::string_view ats_ip_family_name(int family);
 
 /// Test for IP protocol.
 /// @return @c true if the address is IP, @c false otherwise.
@@ -1045,7 +1044,7 @@ ats_ip_nptop(IpEndpoint const *addr, ///< Address.
 
     @return 0 on success, non-zero on failure.
 */
-int ats_ip_pton(const ts::ConstBuffer &text, ///< [in] text.
+int ats_ip_pton(const ts::string_view &text, ///< [in] text.
                 sockaddr *addr               ///< [out] address
                 );
 
@@ -1065,11 +1064,11 @@ ats_ip_pton(const char *text,  ///< [in] text.
             sockaddr_in6 *addr ///< [out] address
             )
 {
-  return ats_ip_pton(ts::ConstBuffer(text, strlen(text)), ats_ip_sa_cast(addr));
+  return ats_ip_pton(ts::string_view(text, strlen(text)), ats_ip_sa_cast(addr));
 }
 
 inline int
-ats_ip_pton(const ts::ConstBuffer &text, ///< [in] text.
+ats_ip_pton(const ts::string_view &text, ///< [in] text.
             IpEndpoint *addr             ///< [out] address
             )
 {
@@ -1081,7 +1080,7 @@ ats_ip_pton(const char *text, ///< [in] text.
             IpEndpoint *addr  ///< [out] address
             )
 {
-  return ats_ip_pton(ts::ConstBuffer(text, strlen(text)), &addr->sa);
+  return ats_ip_pton(ts::string_view(text, strlen(text)), &addr->sa);
 }
 
 inline int
@@ -1089,7 +1088,7 @@ ats_ip_pton(const char *text, ///< [in] text.
             sockaddr *addr    ///< [out] address
             )
 {
-  return ats_ip_pton(ts::ConstBuffer(text, strlen(text)), addr);
+  return ats_ip_pton(ts::string_view(text, strlen(text)), addr);
 }
 
 /** Get the best address info for @a name.
@@ -1201,7 +1200,7 @@ struct IpAddr {
       otherwise this object is invalidated.
       @return 0 on success, non-zero on failure.
   */
-  int load(ts::ConstBuffer const &str ///< Text of IP address.
+  int load(ts::string_view const &str ///< Text of IP address.
            );
 
   /** Output to a string.

--- a/lib/ts/ink_res_init.cc
+++ b/lib/ts/ink_res_init.cc
@@ -515,7 +515,7 @@ ink_res_init(ink_res_state statp,         ///< State object to update.
           cp++;
         }
         if ((*cp != '\0') && (*cp != '\n')) {
-          ts::ConstBuffer host(cp, strcspn(cp, ";# \t\n"));
+          ts::string_view host(cp, strcspn(cp, ";# \t\n"));
           if (0 == ats_ip_pton(host, &statp->nsaddr_list[nserv].sa)) {
             // If there was no port in the config, lets use NAMESERVER_PORT
             if (ats_ip_port_host_order(&statp->nsaddr_list[nserv].sa) == 0) {

--- a/lib/ts/string_view.h
+++ b/lib/ts/string_view.h
@@ -33,6 +33,7 @@
 #include <utility>
 #include <string>
 #include <ostream>
+#include <cstring>
 
 #if __cplusplus < 201402
 #define CONSTEXPR14 inline
@@ -1218,4 +1219,21 @@ using string_view = basic_string_view<char>;
 constexpr ts::string_view operator"" _sv(const char *str, size_t len) noexcept
 {
   return ts::string_view(str, len);
+}
+
+// TS local extensions, not dependent on our local implementation of std::string_view.
+
+/// Check for prefix.
+/// @return @c true if @a lhs is a prefix (ignoring case) of @a rhs.
+inline bool
+IsNoCasePrefixOf(ts::string_view const &lhs, ts::string_view const &rhs)
+{
+  return lhs.size() <= rhs.size() && 0 == strncasecmp(lhs.data(), rhs.data(), lhs.size());
+}
+/// Check for prefix.
+/// @return @c true if @a lhs is a prefix of @a rhs.
+inline bool
+IsPrefixOf(ts::string_view const &lhs, ts::string_view const &rhs)
+{
+  return lhs.size() <= rhs.size() && 0 == memcmp(lhs.data(), rhs.data(), lhs.size());
 }

--- a/lib/ts/unit-tests/test_layout.cc
+++ b/lib/ts/unit-tests/test_layout.cc
@@ -1,6 +1,9 @@
 /** @file
+
   Test file for layout structure
+
   @section license License
+
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
   distributed with this work for additional information

--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -31,6 +31,7 @@
 #include "MgmtSocket.h"
 #include "ts/ink_cap.h"
 #include "FileManager.h"
+#include <ts/MemView.h>
 
 #if TS_USE_POSIX_CAP
 #include <sys/capability.h>

--- a/plugins/experimental/ssl_cert_loader/ssl-cert-loader.cc
+++ b/plugins/experimental/ssl_cert_loader/ssl-cert-loader.cc
@@ -83,18 +83,17 @@ using IpRangeQueue = std::deque<IpRange>;
 Configuration Config; // global configuration
 
 void
-Parse_Addr_String(ts::ConstBuffer const &text, IpRange &range)
+Parse_Addr_String(ts::string_view const &text, IpRange &range)
 {
   IpAddr newAddr;
-  std::string textstr(text._ptr, text._size);
   // Is there a hyphen?
-  size_t hyphen_pos = textstr.find('-');
+  size_t hyphen_pos = text.find('-');
 
-  if (hyphen_pos != std::string::npos) {
-    std::string addr1 = textstr.substr(0, hyphen_pos);
-    std::string addr2 = textstr.substr(hyphen_pos + 1);
-    range.first.load(ts::ConstBuffer(addr1.c_str(), addr1.length()));
-    range.second.load(ts::ConstBuffer(addr2.c_str(), addr2.length()));
+  if (hyphen_pos != ts::string_view::npos) {
+    ts::string_view addr1 = text.substr(0, hyphen_pos);
+    ts::string_view addr2 = text.substr(hyphen_pos + 1);
+    range.first.load(addr1);
+    range.second.load(addr2);
   } else { // Assume it is a single address
     newAddr.load(text);
     range.first  = newAddr;
@@ -269,8 +268,9 @@ Parse_Config(Value &parent, ParsedSslValues &orig_values)
   val = parent.find("server-ip");
   if (val) {
     IpRange ipRange;
+    auto txt = val.getText();
 
-    Parse_Addr_String(val.getText(), ipRange);
+    Parse_Addr_String(ts::string_view(txt._ptr, txt._size), ipRange);
     cur_values.server_ips.push_back(ipRange);
   }
   val = parent.find("server-name");

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -60,7 +60,7 @@
 #include "I_RecCore.h"
 #include "I_Machine.h"
 #include "HttpProxyServerMain.h"
-#include <ts/MemView.h>
+#include <ts/string_view.h>
 
 #include "api/ts/ts.h"
 
@@ -9366,10 +9366,10 @@ TSHttpTxnClientProtocolStackGet(TSHttpTxn txnp, int n, const char **result, int 
   HttpSM *sm = reinterpret_cast<HttpSM *>(txnp);
   int count  = 0;
   if (sm && n > 0) {
-    auto mem = static_cast<ts::StringView *>(alloca(sizeof(ts::StringView) * n));
+    auto mem = static_cast<ts::string_view *>(alloca(sizeof(ts::string_view) * n));
     count    = sm->populate_client_protocol(mem, n);
     for (int i = 0; i < count; ++i) {
-      result[i] = mem[i].ptr();
+      result[i] = mem[i].data();
     }
   }
   if (actual) {
@@ -9386,10 +9386,10 @@ TSHttpSsnClientProtocolStackGet(TSHttpSsn ssnp, int n, const char **result, int 
   ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
   int count              = 0;
   if (cs && n > 0) {
-    auto mem = static_cast<ts::StringView *>(alloca(sizeof(ts::StringView) * n));
+    auto mem = static_cast<ts::string_view *>(alloca(sizeof(ts::string_view) * n));
     count    = cs->populate_protocol(mem, n);
     for (int i = 0; i < count; ++i) {
-      result[i] = mem[i].ptr();
+      result[i] = mem[i].data();
     }
   }
   if (actual) {
@@ -9409,7 +9409,7 @@ TSHttpTxnClientProtocolStackContains(TSHttpTxn txnp, const char *tag)
 {
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
   HttpSM *sm = (HttpSM *)txnp;
-  return sm->client_protocol_contains(ts::StringView(tag));
+  return sm->client_protocol_contains(ts::string_view{tag});
 }
 
 const char *
@@ -9417,7 +9417,7 @@ TSHttpSsnClientProtocolStackContains(TSHttpSsn ssnp, const char *tag)
 {
   sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
   ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
-  return cs->protocol_contains(ts::StringView(tag));
+  return cs->protocol_contains(ts::string_view{tag});
 }
 
 const char *

--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -189,14 +189,14 @@ public:
   }
 
   virtual int
-  populate_protocol(ts::StringView *result, int size) const
+  populate_protocol(ts::string_view *result, int size) const
   {
     auto vc = this->get_netvc();
     return vc ? vc->populate_protocol(result, size) : 0;
   }
 
   virtual const char *
-  protocol_contains(ts::StringView tag_prefix) const
+  protocol_contains(ts::string_view tag_prefix) const
   {
     auto vc = this->get_netvc();
     return vc ? vc->protocol_contains(tag_prefix) : nullptr;

--- a/proxy/ProxyClientTransaction.h
+++ b/proxy/ProxyClientTransaction.h
@@ -240,13 +240,13 @@ public:
   }
 
   virtual int
-  populate_protocol(ts::StringView *result, int size) const
+  populate_protocol(ts::string_view *result, int size) const
   {
     return parent ? parent->populate_protocol(result, size) : 0;
   }
 
   virtual const char *
-  protocol_contains(ts::StringView tag_prefix) const
+  protocol_contains(ts::string_view tag_prefix) const
   {
     return parent ? parent->protocol_contains(tag_prefix) : nullptr;
   }

--- a/proxy/hdrs/HTTP.cc
+++ b/proxy/hdrs/HTTP.cc
@@ -1130,9 +1130,9 @@ validate_hdr_host(HTTPHdrImpl *hh)
     } else {
       int host_len         = 0;
       const char *host_val = host_field->value_get(&host_len);
-      ts::ConstBuffer addr, port, rest, host(host_val, host_len);
+      ts::string_view addr, port, rest, host(host_val, host_len);
       if (0 == ats_ip_parse(host, &addr, &port, &rest)) {
-        if (port) {
+        if (!port.empty()) {
           if (port.size() > 5) {
             return PARSE_RESULT_ERROR;
           }
@@ -1144,11 +1144,8 @@ validate_hdr_host(HTTPHdrImpl *hh)
         if (!validate_host_name(addr)) {
           return PARSE_RESULT_ERROR;
         }
-        while (rest && PARSE_RESULT_DONE == ret) {
-          if (!ParseRules::is_ws(*rest)) {
-            return PARSE_RESULT_ERROR;
-          }
-          ++rest;
+        if (PARSE_RESULT_DONE == ret && !std::all_of(rest.begin(), rest.end(), &ParseRules::is_ws)) {
+          return PARSE_RESULT_ERROR;
         }
       } else {
         ret = PARSE_RESULT_ERROR;

--- a/proxy/hdrs/URL.h
+++ b/proxy/hdrs/URL.h
@@ -30,7 +30,7 @@
 #include "ts/INK_MD5.h"
 #include "ts/MMH.h"
 #include "MIME.h"
-#include "ts/TsBuffer.h"
+#include <ts/string_view.h>
 
 #include "ts/ink_apidefs.h"
 
@@ -194,7 +194,7 @@ extern int URL_LEN_MMST;
 void url_adjust(MarshalXlate *str_xlate, int num_xlate);
 
 /* Public */
-bool validate_host_name(ts::ConstBuffer addr);
+bool validate_host_name(ts::string_view addr);
 void url_init();
 
 URLImpl *url_create(HdrHeap *heap);

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -274,9 +274,9 @@ public:
   /// Get the protocol stack for the inbound (client, user agent) connection.
   /// @arg result [out] Array to store the results
   /// @arg n [in] Size of the array @a result.
-  int populate_client_protocol(ts::StringView *result, int n) const;
-  const char *client_protocol_contains(ts::StringView tag_prefix) const;
-  ts::StringView find_proto_string(HTTPVersion version) const;
+  int populate_client_protocol(ts::string_view *result, int n) const;
+  const char *client_protocol_contains(ts::string_view tag_prefix) const;
+  ts::string_view find_proto_string(HTTPVersion version) const;
 
   int64_t sm_id      = -1;
   unsigned int magic = HTTP_SM_MAGIC_DEAD;

--- a/proxy/http/HttpServerSession.h
+++ b/proxy/http/HttpServerSession.h
@@ -181,14 +181,14 @@ public:
   MIOBuffer *read_buffer;
 
   virtual int
-  populate_protocol(ts::StringView *result, int size) const
+  populate_protocol(ts::string_view *result, int size) const
   {
     auto vc = this->get_netvc();
     return vc ? vc->populate_protocol(result, size) : 0;
   }
 
   virtual const char *
-  protocol_contains(ts::StringView tag_prefix) const
+  protocol_contains(ts::string_view tag_prefix) const
   {
     auto vc = this->get_netvc();
     return vc ? vc->protocol_contains(tag_prefix) : nullptr;

--- a/proxy/http/HttpTransactHeaders.h
+++ b/proxy/http/HttpTransactHeaders.h
@@ -64,7 +64,7 @@ public:
 
   enum class ProtocolStackDetail { Compact, Standard, Full };
 
-  static int write_hdr_protocol_stack(char *hdr_string, size_t len, ProtocolStackDetail pSDetail, ts::StringView *proto_buf,
+  static int write_hdr_protocol_stack(char *hdr_string, size_t len, ProtocolStackDetail pSDetail, ts::string_view *proto_buf,
                                       int n_proto, char separator = ' ');
 
   // Removing handle_conditional_headers.  Functionality appears to be elsewhere (issue_revalidate)

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -260,7 +260,7 @@ public:
   }
 
   virtual int
-  populate_protocol(ts::StringView *result, int size) const override
+  populate_protocol(ts::string_view *result, int size) const override
   {
     int retval = 0;
     if (size > retval) {
@@ -273,12 +273,12 @@ public:
   }
 
   virtual const char *
-  protocol_contains(ts::StringView prefix) const override
+  protocol_contains(ts::string_view prefix) const override
   {
     const char *retval = nullptr;
 
-    if (prefix.size() <= IP_PROTO_TAG_HTTP_2_0.size() && strncmp(IP_PROTO_TAG_HTTP_2_0.ptr(), prefix.ptr(), prefix.size()) == 0) {
-      retval = IP_PROTO_TAG_HTTP_2_0.ptr();
+    if (prefix.size() <= IP_PROTO_TAG_HTTP_2_0.size() && strncmp(IP_PROTO_TAG_HTTP_2_0.data(), prefix.data(), prefix.size()) == 0) {
+      retval = IP_PROTO_TAG_HTTP_2_0.data();
     } else {
       retval = super::protocol_contains(prefix);
     }

--- a/proxy/logging/LogField.h
+++ b/proxy/logging/LogField.h
@@ -26,6 +26,7 @@
 
 #include "ts/ink_platform.h"
 #include "ts/List.h"
+#include <ts/TsBuffer.h>
 #include "LogFieldAliasMap.h"
 #include "Milestones.h"
 

--- a/proxy/logging/LogHost.cc
+++ b/proxy/logging/LogHost.cc
@@ -158,9 +158,9 @@ bool
 LogHost::set_name_or_ipstr(const char *name_or_ip)
 {
   if (name_or_ip && name_or_ip[0] != '\0') {
-    ts::ConstBuffer addr, port;
-    if (ats_ip_parse(ts::ConstBuffer(name_or_ip, strlen(name_or_ip)), &addr, &port) == 0) {
-      uint16_t p = port ? atoi(port.data()) : Log::config->collation_port;
+    ts::string_view addr, port;
+    if (ats_ip_parse(ts::string_view(name_or_ip), &addr, &port) == 0) {
+      uint16_t p = port.empty() ? Log::config->collation_port : atoi(port.data());
       char *n    = const_cast<char *>(addr.data());
       // Force termination. We know we can do this because the address
       // string is followed by either a nul or a colon.


### PR DESCRIPTION
This turns out to have a lot of tentacles all over so I may have removed `ConstBuffer` from places that aren't strictly required. It is certainly not the case that all uses of `ConstBuffer` were removed, the remnants can go in other PRs. This is all driven by cleaning up `ink_inet` and then dealing with the fall out.

Also, `ts::string_view` constants! That definitely cleans up some ugly @bryancall and @zwoop were whining about. AFAICT this is eleventy compliant.

I've got another branch I haven't pushed yet that has `ts::TextView` which is a reworking of `StringView` based on `ts::string_view`. Once that is it place we'll cull all of `ConstBuffer` and `StringView`. I'm still exploring how much pain it's worth to use `string_view` over `TextView`. You can see places here where noticeably more awkward, but we have no control over the `string_view` API.