### PR TITLE
Fix compiling with a custom OpenSSL 1.1.0f library.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1140,6 +1140,15 @@ TS_CHECK_CRYPTO_SET_RBIO
 # Check for DH_get_2048_256
 TS_CHECK_CRYPTO_DH_GET_2048_256
 
+saved_LIBS="$LIBS"
+TS_ADDTO([LIBS], ["$OPENSSL_LIBS"])
+
+AC_CHECK_FUNCS([ \
+  X509_get0_signature \
+])
+
+LIBS="$saved_LIBS"
+
 #
 # Check for zlib presence and usability
 TS_CHECK_ZLIB

--- a/lib/ts/Makefile.am
+++ b/lib/ts/Makefile.am
@@ -28,7 +28,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/lib
 
 lib_LTLIBRARIES = libtsutil.la
 
-libtsutil_la_LDFLAGS = -no-undefined -version-info @TS_LIBTOOL_VERSION@
+libtsutil_la_LDFLAGS = -no-undefined -version-info @TS_LIBTOOL_VERSION@ @LIBTOOL_LINK_FLAGS@
 libtsutil_la_LIBADD = \
   @HWLOC_LIBS@ \
   @LIBOBJS@ \

--- a/plugins/experimental/sslheaders/expand.cc
+++ b/plugins/experimental/sslheaders/expand.cc
@@ -70,9 +70,17 @@ x509_expand_serial(X509 *x509, BIO *bio)
 static void
 x509_expand_signature(X509 *x509, BIO *bio)
 {
-  ASN1_BIT_STRING *sig = x509->signature;
-  const char *ptr      = (const char *)sig->data;
-  const char *end      = ptr + sig->length;
+#ifndef HAVE_X509_GET0_SIGNATURE
+  const ASN1_BIT_STRING *sig = x509->signature;
+#else
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#define X509_get0_signature(psig, palg, x) (X509_get0_signature(const_cast<ASN1_BIT_STRING **>(psig), (palg), (x)))
+#endif
+  const ASN1_BIT_STRING *sig;
+  X509_get0_signature(&sig, nullptr, x509);
+#endif
+  const char *ptr = (const char *)sig->data;
+  const char *end = ptr + sig->length;
 
   // The canonical OpenSSL way to format the signature seems to be
   // X509_signature_dump(). However that separates each byte with a ':', which is


### PR DESCRIPTION
1. Fixed linker error with libtsutil.so when compiling with a
   custom OpenSSL library, i.e., configure --with-openssl.
   This may be a problem specific with Ubuntu Linux (14.04 LTS
   Server 64-bit) since others reported no issues with Red Hat.

2. Manually back-ported 22994b0dc3ad5827a26a6fed2ee525cc16b476d8
   due to a compile failure with the sslheaders plugin due to
   X509 being made opaque in OpenSSL 1.1.