### PR TITLE
Add string literal support to ts::string_view.

### DIFF
--- a/lib/ts/Makefile.am
+++ b/lib/ts/Makefile.am
@@ -255,6 +255,7 @@ test_tslib_SOURCES = \
 	unit-tests/main.cpp \
 	unit-tests/test_IpMap.cc \
 	unit-tests/test_layout.cpp \
+	unit-tests/string_view.cpp \
 	unit-tests/BufferWriter.cpp
 
 CompileParseRules_SOURCES = CompileParseRules.cc

--- a/lib/ts/string_view.h
+++ b/lib/ts/string_view.h
@@ -1210,3 +1210,12 @@ operator<<(std::basic_ostream<_Type, _Traits> &os, const basic_string_view<_Type
 using string_view = basic_string_view<char>;
 
 } // namespace ts
+
+/// Literal suffix for string_view.
+/// @note This enables @c string_view literals from C++ string literals in @c constexpr contexts, which
+/// is not the case for the character pointer constructor.
+/// @internal This must be in the global namespace to be found.
+constexpr ts::string_view operator"" _sv(const char *str, size_t len) noexcept
+{
+  return ts::string_view(str, len);
+}

--- a/lib/ts/unit-tests/string_view.cpp
+++ b/lib/ts/unit-tests/string_view.cpp
@@ -27,6 +27,7 @@
 #include <string>
 #include <vector>
 
+
 using namespace std;
 
 constexpr auto npos = ts::string_view::npos;
@@ -44,6 +45,19 @@ TEST_CASE("constructor calls", "[string_view] [constructor]")
     REQUIRE(sv.length() == 5);
     REQUIRE(sv.empty() == false);
     REQUIRE(sv == "hello");
+
+    constexpr ts::string_view a{"evil dave"_sv};
+    REQUIRE(a.size() == 9);
+    REQUIRE(a.length() == 9);
+    REQUIRE(a.empty() == false);
+    REQUIRE(a == "evil dave");
+
+    auto b = "grigor rulz"_sv;
+    REQUIRE((std::is_same<decltype(b), ts::string_view>::value) == true);
+    REQUIRE(b.size() == 11);
+    REQUIRE(b.length() ==11);
+    REQUIRE(b.empty() == false);
+    REQUIRE(b == "grigor rulz");
   }
 
   SECTION("operator =")
@@ -131,7 +145,7 @@ TEST_CASE("operators", "[string_view] [operator]")
 
     REQUIRE(str2 == str3);
     REQUIRE(str1 == str3);
-    
+
     REQUIRE(sv == "hello");
     REQUIRE(sv == str1);
     REQUIRE(sv == str2);


### PR DESCRIPTION
Expand the `string_view` tests and _actually run them_.