### PR TITLE
Optimize: force to process negative event if period less than -99.

### DIFF
--- a/iocore/dns/P_DNSProcessor.h
+++ b/iocore/dns/P_DNSProcessor.h
@@ -62,7 +62,9 @@ extern unsigned int dns_sequence_number;
 // Constants
 //
 
-#define DNS_PERIOD HRTIME_MSECONDS(-100)
+// In order to guarantee DNSHandler running after NetHandler,
+// DNS_PERIOD should less than proxy.config.net.event_period.
+#define DNS_PERIOD HRTIME_MSECONDS(-101)
 #define DNS_DELAY_PERIOD HRTIME_MSECONDS(10)
 #define DNS_SEQUENCE_NUMBER_RESTART_OFFSET 4000
 #define DNS_PRIMARY_RETRY_PERIOD HRTIME_SECONDS(5)

--- a/iocore/net/Net.cc
+++ b/iocore/net/Net.cc
@@ -35,7 +35,7 @@ RecRawStatBlock *net_rsb = nullptr;
 
 // All in milli-seconds
 int net_config_poll_timeout = -1; // This will get set via either command line or records.config.
-int net_event_period        = 10;
+int net_event_period        = 100;
 int net_accept_period       = 10;
 int net_retry_delay         = 10;
 int net_throttle_delay      = 50; /* milliseconds */

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -804,7 +804,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.net.inactivity_check_frequency", RECD_INT, "1", RECU_RESTART_TC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.net.event_period", RECD_INT, "10", RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  {RECT_CONFIG, "proxy.config.net.event_period", RECD_INT, "100", RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.net.accept_period", RECD_INT, "10", RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,


### PR DESCRIPTION
In the EThread::process_event(), ATS will take the mutex lock again if
the period of an event less than -99.

It is mandatory to call back HetHandler and/or UDPReadContinuation in
each event loop and will reduce the latencies of Net Sub-system.