### PR TITLE
std::vector usage transition

### DIFF
--- a/cmd/traffic_manager/metrics.cc
+++ b/cmd/traffic_manager/metrics.cc
@@ -22,11 +22,11 @@
  */
 
 #include <cmath>
+#include <vector>
 
 #include "ts/ink_config.h"
 #include "ts/ink_memory.h"
 #include "ts/Ptr.h"
-#include "ts/Vec.h"
 #include "ts/I_Layout.h"
 #include "bindings/bindings.h"
 #include "bindings/metrics.h"
@@ -146,7 +146,7 @@ struct EvaluatorList {
   EvaluatorList() : update(true), passes(0) {}
   ~EvaluatorList()
   {
-    forv_Vec (Evaluator, e, this->evaluators) {
+    for (auto &e : this->evaluators) {
       delete e;
     }
   }
@@ -163,7 +163,7 @@ struct EvaluatorList {
   void
   unbind(lua_State *L) const
   {
-    forv_Vec (Evaluator, e, this->evaluators) {
+    for (auto &e : this->evaluators) {
       e->unbind(L);
     }
   }
@@ -174,17 +174,17 @@ struct EvaluatorList {
     ink_hrtime start = ink_get_hrtime_internal();
     ink_hrtime elapsed;
 
-    forv_Vec (Evaluator, e, this->evaluators) {
+    for (auto &e : this->evaluators) {
       e->eval(L);
     }
 
     elapsed = ink_hrtime_diff(ink_get_hrtime_internal(), start);
-    Debug("lua", "evaluated %u metrics in %fmsec", evaluators.length(), ink_hrtime_to_usec(elapsed) / 1000.0);
+    Debug("lua", "evaluated %lu metrics in %fmsec", evaluators.size(), ink_hrtime_to_usec(elapsed) / 1000.0);
   }
 
   bool update;
   int64_t passes;
-  Vec<Evaluator *> evaluators;
+  std::vector<Evaluator *> evaluators;
 };
 
 static int

--- a/configure.ac
+++ b/configure.ac
@@ -639,6 +639,9 @@ case $host_os in
     host_os_def="freebsd"
     AM_LDFLAGS="-rdynamic"
     TS_ADDTO(AM_CPPFLAGS, [-I/usr/local/include])
+    TS_ADDTO(AM_CPPFLAGS, [-D_GLIBCXX_USE_C99])
+    TS_ADDTO(AM_CPPFLAGS, [-D_GLIBCXX_USE_C99_MATH])
+    TS_ADDTO(AM_CPPFLAGS, [-D_GLIBCXX_USE_C99_MATH_TR1])
     ;;
   kfreebsd*)
     host_os_def="freebsd"

--- a/iocore/hostdb/P_RefCountCache.h
+++ b/iocore/hostdb/P_RefCountCache.h
@@ -32,7 +32,6 @@
 #include <ts/List.h>
 #include <ts/ink_hrtime.h>
 
-#include <ts/Vec.h>
 #include <ts/I_Version.h>
 #include <unistd.h>
 
@@ -154,7 +153,7 @@ public:
   template <class Iterator> void dealloc_entry(Iterator ptr);
 
   size_t count() const;
-  void copy(Vec<RefCountCacheHashEntry *> &items);
+  void copy(std::vector<RefCountCacheHashEntry *> &items);
 
   typedef typename TSHashTable<RefCountCacheHashing>::iterator iterator_type;
   typedef typename TSHashTable<RefCountCacheHashing>::self hash_type;
@@ -339,7 +338,7 @@ RefCountCachePartition<C>::count() const
 
 template <class C>
 void
-RefCountCachePartition<C>::copy(Vec<RefCountCacheHashEntry *> &items)
+RefCountCachePartition<C>::copy(std::vector<RefCountCacheHashEntry *> &items)
 {
   for (RefCountCachePartition<C>::iterator_type i = this->item_map.begin(); i != this->item_map.end(); ++i) {
     RefCountCacheHashEntry *val = RefCountCacheHashEntry::alloc();
@@ -419,7 +418,7 @@ private:
   int max_size;  // Total size
   int max_items; // Total number of items allowed
   unsigned int num_partitions;
-  Vec<RefCountCachePartition<C> *> partitions;
+  std::vector<RefCountCachePartition<C> *> partitions;
   // Header
   RefCountCacheHeader header; // Our header
   RecRawStatBlock *rsb;

--- a/iocore/hostdb/P_RefCountCacheSerializer.h
+++ b/iocore/hostdb/P_RefCountCacheSerializer.h
@@ -26,6 +26,8 @@
 
 #include "P_RefCountCache.h"
 
+#include <vector>
+
 // This continuation is responsible for persisting RefCountCache to disk
 // To avoid locking the partitions for a long time we'll do the following per-partition:
 //    - lock
@@ -59,7 +61,7 @@ public:
   ~RefCountCacheSerializer();
 
 private:
-  Vec<RefCountCacheHashEntry *> partition_items;
+  std::vector<RefCountCacheHashEntry *> partition_items;
 
   int fd; // fd for the file we are writing to
 
@@ -107,7 +109,7 @@ template <class C> RefCountCacheSerializer<C>::~RefCountCacheSerializer()
     socketManager.close(fd);
   }
 
-  forv_Vec (RefCountCacheHashEntry, entry, this->partition_items) {
+  for (auto &entry : this->partition_items) {
     RefCountCacheHashEntry::free<C>(entry);
   }
   this->partition_items.clear();
@@ -157,7 +159,7 @@ RefCountCacheSerializer<C>::write_partition(int /* event */, Event *e)
   // for item in this->partitionItems
   // write to disk with headers per item
 
-  for (unsigned int i = 0; i < this->partition_items.length(); i++) {
+  for (unsigned int i = 0; i < this->partition_items.size(); i++) {
     RefCountCacheHashEntry *entry = this->partition_items[i];
 
     // check if the item has expired, if so don't persist it to disk
@@ -186,7 +188,7 @@ RefCountCacheSerializer<C>::write_partition(int /* event */, Event *e)
   }
 
   // Clear the copied partition for the next round.
-  forv_Vec (RefCountCacheHashEntry, entry, this->partition_items) {
+  for (auto &entry : this->partition_items) {
     RefCountCacheHashEntry::free<C>(entry);
   }
   this->partition_items.clear();

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -41,7 +41,7 @@
 #include <openssl/bn.h>
 #include <unistd.h>
 #include <termios.h>
-#include "ts/Vec.h"
+#include <vector>
 
 #if HAVE_OPENSSL_EVP_H
 #include <openssl/evp.h>
@@ -1472,7 +1472,7 @@ ssl_set_handshake_callbacks(SSL_CTX *ctx)
 }
 
 SSL_CTX *
-SSLInitServerContext(const SSLConfigParams *params, const ssl_user_config *sslMultCertSettings, Vec<X509 *> &certList)
+SSLInitServerContext(const SSLConfigParams *params, const ssl_user_config *sslMultCertSettings, std::vector<X509 *> &certList)
 {
   int server_verify_client;
   ats_scoped_str completeServerCertPath;
@@ -1781,9 +1781,8 @@ fail:
     EVP_MD_CTX_free(digest);
   SSL_CLEAR_PW_REFERENCES(ctx)
   SSLReleaseContext(ctx);
-  for (unsigned int i = 0; i < certList.length(); i++) {
-    X509_free(certList[i]);
-  }
+  for (auto cert : certList)
+    X509_free(cert);
 
   return nullptr;
 }
@@ -1791,16 +1790,16 @@ fail:
 SSL_CTX *
 SSLCreateServerContext(const SSLConfigParams *params)
 {
-  Vec<X509 *> cert_list;
+  std::vector<X509 *> cert_list;
   SSL_CTX *ctx = SSLInitServerContext(params, nullptr, cert_list);
-  ink_assert(cert_list.length() == 0);
+  ink_assert(cert_list.empty());
   return ctx;
 }
 
 static SSL_CTX *
 ssl_store_ssl_context(const SSLConfigParams *params, SSLCertLookup *lookup, const ssl_user_config *sslMultCertSettings)
 {
-  Vec<X509 *> cert_list;
+  std::vector<X509 *> cert_list;
   SSL_CTX *ctx                   = SSLInitServerContext(params, sslMultCertSettings, cert_list);
   ssl_ticket_key_block *keyblock = nullptr;
   bool inserted                  = false;
@@ -1811,8 +1810,8 @@ ssl_store_ssl_context(const SSLConfigParams *params, SSLCertLookup *lookup, cons
   }
 
   const char *certname = sslMultCertSettings->cert.get();
-  for (unsigned i = 0; i < cert_list.length(); ++i) {
-    if (0 > SSLCheckServerCertNow(cert_list[i], certname)) {
+  for (auto cert : cert_list) {
+    if (0 > SSLCheckServerCertNow(cert, certname)) {
       /* At this point, we know cert is bad, and we've already printed a
          descriptive reason as to why cert is bad to the log file */
       Debug("ssl", "Marking certificate as NOT VALID: %s", certname);
@@ -1867,8 +1866,8 @@ ssl_store_ssl_context(const SSLConfigParams *params, SSLCertLookup *lookup, cons
   if (SSLConfigParams::ssl_ocsp_enabled) {
     Debug("ssl", "ssl ocsp stapling is enabled");
     SSL_CTX_set_tlsext_status_cb(ctx, ssl_callback_ocsp_stapling);
-    for (unsigned i = 0; i < cert_list.length(); ++i) {
-      if (!ssl_stapling_init_cert(ctx, cert_list[i], certname)) {
+    for (auto cert : cert_list) {
+      if (!ssl_stapling_init_cert(ctx, cert, certname)) {
         Warning("fail to configure SSL_CTX for OCSP Stapling info for certificate at %s", (const char *)certname);
       }
     }
@@ -1885,8 +1884,8 @@ ssl_store_ssl_context(const SSLConfigParams *params, SSLCertLookup *lookup, cons
   // this code is updated to reconfigure the SSL certificates, it will need some sort of
   // refcounting or alternate way of avoiding double frees.
   Debug("ssl", "importing SNI names from %s", (const char *)certname);
-  for (unsigned i = 0; i < cert_list.length(); ++i) {
-    if (ssl_index_certificate(lookup, SSLCertContext(ctx, sslMultCertSettings->opt), cert_list[i], certname)) {
+  for (auto cert : cert_list) {
+    if (ssl_index_certificate(lookup, SSLCertContext(ctx, sslMultCertSettings->opt), cert, certname)) {
       inserted = true;
     }
   }
@@ -1902,7 +1901,7 @@ ssl_store_ssl_context(const SSLConfigParams *params, SSLCertLookup *lookup, cons
     ctx = nullptr;
   }
 
-  for (unsigned int i = 0; i < cert_list.length(); i++) {
+  for (unsigned int i = 0; i < cert_list.size(); i++) {
     X509_free(cert_list[i]);
   }
 

--- a/lib/records/I_RecHttp.h
+++ b/lib/records/I_RecHttp.h
@@ -27,8 +27,10 @@
 #include <ts/ink_inet.h>
 #include <ts/ink_resolver.h>
 #include <ts/apidefs.h>
-#include <ts/Vec.h>
 #include <ts/apidefs.h>
+#include <ts/ink_assert.h>
+#include <algorithm>
+#include <vector>
 
 /// Load default inbound IP addresses from the configuration file.
 void RecHttpLoadIp(const char *name, ///< Name of value in configuration file.
@@ -222,7 +224,7 @@ private:
   typedef HttpProxyPort self; ///< Self reference type.
 public:
   /// Explicitly supported collection of proxy ports.
-  typedef Vec<self> Group;
+  typedef std::vector<self> Group;
 
   /// Type of transport on the connection.
   enum TransportType {
@@ -287,7 +289,7 @@ public:
       This is provided because most of the work with this data is used as a singleton
       and it's handy to encapsulate it here.
   */
-  static Vec<self> &global();
+  static std::vector<self> &global();
 
   /// Check for SSL ports.
   /// @return @c true if any port in @a ports is an SSL port.
@@ -307,7 +309,7 @@ public:
       @return @c true if at least one valid port description was
       found, @c false if none.
   */
-  static bool loadConfig(Vec<self> &ports ///< Destination for found port data.
+  static bool loadConfig(std::vector<self> &ports ///< Destination for found port data.
                          );
 
   /** Load all relevant configuration data into the global ports.
@@ -325,8 +327,8 @@ public:
       @note This is used primarily internally but is available if needed.
       @return @c true if a valid port was found, @c false if none.
   */
-  static bool loadValue(Vec<self> &ports, ///< Destination for found port data.
-                        const char *value ///< Source port data.
+  static bool loadValue(std::vector<self> &ports, ///< Destination for found port data.
+                        const char *value         ///< Source port data.
                         );
 
   /** Load ports from a value string into the global ports.
@@ -341,7 +343,7 @@ public:
 
   /// Load default value if @a ports is empty.
   /// @return @c true if the default was needed / loaded.
-  static bool loadDefaultIfEmpty(Vec<self> &ports ///< Load target.
+  static bool loadDefaultIfEmpty(std::vector<self> &ports ///< Load target.
                                  );
 
   /// Load default value into the global set if it is empty.
@@ -353,16 +355,16 @@ public:
       are checked.
       @return The port if found, @c nullptr if not.
   */
-  static self *findHttp(Group const &ports,         ///< Group to search.
-                        uint16_t family = AF_UNSPEC ///< Desired address family.
-                        );
+  static const self *findHttp(Group const &ports,         ///< Group to search.
+                              uint16_t family = AF_UNSPEC ///< Desired address family.
+                              );
 
   /** Find an HTTP port in the global ports.
       If @a family is specified then only ports for that family
       are checked.
       @return The port if found, @c nullptr if not.
   */
-  static self *findHttp(uint16_t family = AF_UNSPEC);
+  static const self *findHttp(uint16_t family = AF_UNSPEC);
 
   /** Create text description to be used for inter-process access.
       Prints the file descriptor and then any options.
@@ -395,7 +397,7 @@ public:
   static const char *const OPT_HOST_RES_PREFIX;         ///< Set DNS family preference.
   static const char *const OPT_PROTO_PREFIX;            ///< Transport layer protocols.
 
-  static Vec<self> &m_global; ///< Global ("default") data.
+  static std::vector<self> &m_global; ///< Global ("default") data.
 
 protected:
   /// Process @a value for DNS resolution family preferences.
@@ -453,7 +455,7 @@ HttpProxyPort::loadDefaultIfEmpty()
 {
   return self::loadDefaultIfEmpty(m_global);
 }
-inline Vec<HttpProxyPort> &
+inline std::vector<HttpProxyPort> &
 HttpProxyPort::global()
 {
   return m_global;
@@ -463,7 +465,7 @@ HttpProxyPort::hasSSL()
 {
   return self::hasSSL(m_global);
 }
-inline HttpProxyPort *
+inline const HttpProxyPort *
 HttpProxyPort::findHttp(uint16_t family)
 {
   return self::findHttp(m_global, family);

--- a/lib/records/RecHttp.cc
+++ b/lib/records/RecHttp.cc
@@ -168,22 +168,16 @@ HttpProxyPort::HttpProxyPort()
 bool
 HttpProxyPort::hasSSL(Group const &ports)
 {
-  bool zret = false;
-  for (int i = 0, n = ports.length(); i < n && !zret; ++i) {
-    if (ports[i].isSSL()) {
-      zret = true;
-    }
-  }
-  return zret;
+  return std::any_of(ports.begin(), ports.end(), [](HttpProxyPort const &port) { return port.isSSL(); });
 }
 
-HttpProxyPort *
+const HttpProxyPort *
 HttpProxyPort::findHttp(Group const &ports, uint16_t family)
 {
   bool check_family_p = ats_is_ip(family);
-  self *zret          = nullptr;
-  for (int i = 0, n = ports.length(); i < n && !zret; ++i) {
-    HttpProxyPort &p = ports[i];
+  const self *zret    = nullptr;
+  for (int i = 0, n = ports.size(); i < n && !zret; ++i) {
+    const self &p = ports[i];
     if (p.m_port &&                               // has a valid port
         TRANSPORT_DEFAULT == p.m_type &&          // is normal HTTP
         (!check_family_p || p.m_family == family) // right address family
@@ -209,7 +203,7 @@ HttpProxyPort::checkPrefix(const char *src, char const *prefix, size_t prefix_le
 }
 
 bool
-HttpProxyPort::loadConfig(Vec<self> &entries)
+HttpProxyPort::loadConfig(std::vector<self> &entries)
 {
   char *text;
   bool found_p;
@@ -220,23 +214,23 @@ HttpProxyPort::loadConfig(Vec<self> &entries)
   }
   ats_free(text);
 
-  return 0 < entries.length();
+  return 0 < entries.size();
 }
 
 bool
 HttpProxyPort::loadDefaultIfEmpty(Group &ports)
 {
-  if (0 == ports.length()) {
+  if (0 == ports.size()) {
     self::loadValue(ports, DEFAULT_VALUE);
   }
 
-  return 0 < ports.length();
+  return 0 < ports.size();
 }
 
 bool
-HttpProxyPort::loadValue(Vec<self> &ports, const char *text)
+HttpProxyPort::loadValue(std::vector<self> &ports, const char *text)
 {
-  unsigned old_port_length = ports.length(); // remember this.
+  unsigned old_port_length = ports.size(); // remember this.
   if (text && *text) {
     Tokenizer tokens(", ");
     int n_ports = tokens.Initialize(text);
@@ -252,7 +246,7 @@ HttpProxyPort::loadValue(Vec<self> &ports, const char *text)
       }
     }
   }
-  return ports.length() > old_port_length; // we added at least one port.
+  return ports.size() > old_port_length; // we added at least one port.
 }
 
 bool
@@ -265,7 +259,7 @@ HttpProxyPort::processOptions(const char *opts)
   bool bracket_p      = false; // found an open bracket in the input?
   const char *value;           // Temp holder for value of a prefix option.
   IpAddr ip;                   // temp for loading IP addresses.
-  Vec<char *> values;          // Pointers to single option values.
+  std::vector<char *> values;  // Pointers to single option values.
 
   // Make a copy we can modify safely.
   size_t opts_len = strlen(opts) + 1;
@@ -297,7 +291,7 @@ HttpProxyPort::processOptions(const char *opts)
     return zret;
   }
 
-  for (int i = 0, n_items = values.length(); i < n_items; ++i) {
+  for (int i = 0, n_items = values.size(); i < n_items; ++i) {
     const char *item = values[i];
     if (isdigit(item[0])) { // leading digit -> port value
       char *ptr;

--- a/lib/ts/test_PriorityQueue.cc
+++ b/lib/ts/test_PriorityQueue.cc
@@ -52,9 +52,9 @@ using PQ    = PriorityQueue<N *>;
 void
 dump(PQ *pq)
 {
-  Vec<Entry *> v = pq->dump();
+  std::vector<Entry *> v = pq->dump();
 
-  for (uint32_t i = 0; i < v.length(); i++) {
+  for (uint32_t i = 0; i < v.size(); i++) {
     cout << v[i]->index << "," << v[i]->node->weight << "," << v[i]->node->content << endl;
   }
   cout << "--------" << endl;

--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -834,7 +834,7 @@ LocalManager::startProxy(const char *onetime_options)
 
     // Check if we need to pass down port/fd information to
     // traffic_server by seeing if there are any open ports.
-    for (int i = 0, limit = m_proxy_ports.length(); !open_ports_p && i < limit; ++i) {
+    for (int i = 0, limit = m_proxy_ports.size(); !open_ports_p && i < limit; ++i) {
       if (ts::NO_FD != m_proxy_ports[i].m_fd) {
         open_ports_p = true;
       }
@@ -845,7 +845,7 @@ LocalManager::startProxy(const char *onetime_options)
       bool need_comma_p = false;
 
       ink_strlcat(real_proxy_options, " --httpport ", OPTIONS_SIZE);
-      for (int i = 0, limit = m_proxy_ports.length(); i < limit; ++i) {
+      for (int i = 0, limit = m_proxy_ports.size(); i < limit; ++i) {
         HttpProxyPort &p = m_proxy_ports[i];
         if (ts::NO_FD != p.m_fd) {
           if (need_comma_p) {
@@ -883,7 +883,7 @@ LocalManager::startProxy(const char *onetime_options)
 void
 LocalManager::closeProxyPorts()
 {
-  for (int i = 0, n = lmgmt->m_proxy_ports.length(); i < n; ++i) {
+  for (int i = 0, n = lmgmt->m_proxy_ports.size(); i < n; ++i) {
     HttpProxyPort &p = lmgmt->m_proxy_ports[i];
     if (ts::NO_FD != p.m_fd) {
       close_socket(p.m_fd);
@@ -903,7 +903,7 @@ LocalManager::listenForProxy()
   }
 
   // We are not already bound, bind the port
-  for (int i = 0, n = lmgmt->m_proxy_ports.length(); i < n; ++i) {
+  for (int i = 0, n = lmgmt->m_proxy_ports.size(); i < n; ++i) {
     HttpProxyPort &p = lmgmt->m_proxy_ports[i];
     if (ts::NO_FD == p.m_fd) {
       this->bindProxyPort(p);

--- a/mgmt/api/CoreAPI.cc
+++ b/mgmt/api/CoreAPI.cc
@@ -49,6 +49,8 @@
 #include "ts/I_Layout.h"
 #include "ts/ink_cap.h"
 
+#include <vector>
+
 // global variable
 static CallbackTable *local_event_callbacks;
 
@@ -209,7 +211,7 @@ Lerror:
 #include <sys/ptrace.h>
 #include <cxxabi.h>
 
-typedef Vec<pid_t> threadlist;
+typedef std::vector<pid_t> threadlist;
 
 static threadlist
 threads_for_process(pid_t proc)
@@ -338,9 +340,9 @@ ServerBacktrace(unsigned /* options */, char **trace)
   threadlist threads(threads_for_process(lmgmt->watched_process_pid));
   TextBuffer text(0);
 
-  Debug("backtrace", "tracing %zd threads for traffic_server PID %ld", threads.count(), (long)lmgmt->watched_process_pid);
+  Debug("backtrace", "tracing %zd threads for traffic_server PID %ld", threads.size(), (long)lmgmt->watched_process_pid);
 
-  for_Vec (pid_t, threadid, threads) {
+  for (auto threadid : threads) {
     Debug("backtrace", "tracing thread %ld", (long)threadid);
     // Get the thread name using /proc/PID/comm
     ats_scoped_fd fd;

--- a/proxy/ControlBase.cc
+++ b/proxy/ControlBase.cc
@@ -40,9 +40,10 @@
 #include "HTTP.h"
 #include "ControlMatcher.h"
 #include "HdrUtils.h"
-#include "ts/Vec.h"
 
 #include <ts/TsBuffer.h>
+
+#include <vector>
 
 /** Used for printing IP address.
     @code
@@ -436,7 +437,7 @@ TextMod::set(const char *value)
 }
 
 struct MultiTextMod : public ControlBase::Modifier {
-  Vec<ts::Buffer> text_vec;
+  std::vector<ts::Buffer> text_vec;
   MultiTextMod();
   ~MultiTextMod() override;
 
@@ -458,7 +459,7 @@ MultiTextMod::~MultiTextMod()
 void
 MultiTextMod::print(FILE *f) const
 {
-  for_Vec (ts::Buffer, text_iter, this->text_vec) {
+  for (auto text_iter : this->text_vec) {
     fprintf(f, "%s=%*s ", this->name(), static_cast<int>(text_iter.size()), text_iter.data());
   }
 }
@@ -585,12 +586,12 @@ SuffixMod::check(HttpRequestData *req) const
   int path_len;
   const char *path = req->hdr->url_get()->path_get(&path_len);
 
-  if (1 == static_cast<int>(this->text_vec.count()) && 1 == static_cast<int>(this->text_vec[0].size()) &&
+  if (1 == static_cast<int>(this->text_vec.size()) && 1 == static_cast<int>(this->text_vec[0].size()) &&
       0 == strcmp(this->text_vec[0].data(), "*")) {
     return true;
   }
 
-  for_Vec (ts::Buffer, text_iter, this->text_vec) {
+  for (auto text_iter : this->text_vec) {
     if (path_len >= static_cast<int>(text_iter.size()) &&
         0 == strncasecmp(path + path_len - text_iter.size(), text_iter.data(), text_iter.size())) {
       return true;
@@ -701,7 +702,7 @@ ControlBase::~ControlBase()
 void
 ControlBase::clear()
 {
-  _mods.delete_and_clear();
+  _mods.clear();
 }
 
 // static const modifier_el default_el = { MOD_INVALID, NULL };
@@ -709,7 +710,7 @@ ControlBase::clear()
 void
 ControlBase::Print()
 {
-  int n = _mods.length();
+  int n = _mods.size();
 
   if (0 >= n) {
     return;
@@ -754,7 +755,7 @@ ControlBase::CheckModifiers(HttpRequestData *request_data)
     return false;
   }
 
-  forv_Vec (Modifier, cur_mod, _mods) {
+  for (auto &cur_mod : _mods) {
     if (cur_mod && !cur_mod->check(request_data)) {
       return false;
     }
@@ -777,7 +778,7 @@ static const char *errorFormats[] = {
 ControlBase::Modifier *
 ControlBase::findModOfType(Modifier::Type t) const
 {
-  forv_Vec (Modifier, m, _mods) {
+  for (auto &m : _mods) {
     if (m && t == m->type()) {
       return m;
     }

--- a/proxy/ControlBase.h
+++ b/proxy/ControlBase.h
@@ -33,7 +33,7 @@
 #define _CONTROL_BASE_H_
 
 #include "ts/ink_platform.h"
-#include "ts/Vec.h"
+#include "vector"
 
 class HttpRequestData;
 class Tokenizer;
@@ -88,7 +88,7 @@ protected:
   const char *getSchemeModText() const;
 
 private:
-  typedef Vec<Modifier *> Array;
+  typedef std::vector<Modifier *> Array;
   Array _mods;
   const char *ProcessSrcIp(char *val, void **opaque_ptr);
   const char *ProcessTimeOfDay(char *val, void **opaque_ptr);

--- a/proxy/IPAllow.cc
+++ b/proxy/IPAllow.cc
@@ -284,11 +284,11 @@ IpAllow::BuildTable()
           }
 
           if (method_found) {
-            Vec<AclRecord> &acls = is_dest_ip ? _dest_acls : _src_acls;
-            IpMap &map           = is_dest_ip ? _dest_map : _src_map;
+            std::vector<AclRecord> &acls = is_dest_ip ? _dest_acls : _src_acls;
+            IpMap &map                   = is_dest_ip ? _dest_map : _src_map;
             acls.push_back(AclRecord(acl_method_mask, line_num, nonstandard_methods, deny_nonstandard_methods));
             // Color with index in acls because at this point the address is volatile.
-            map.fill(&addr1, &addr2, reinterpret_cast<void *>(acls.length() - 1));
+            map.fill(&addr1, &addr2, reinterpret_cast<void *>(acls.size() - 1));
           } else {
             snprintf(errBuf, sizeof(errBuf), "%s discarding %s entry at line %d : %s", module_name, config_file_path, line_num,
                      "Invalid action/method specified"); // changed by YTS Team, yamsat bug id -59022

--- a/proxy/IPAllow.h
+++ b/proxy/IPAllow.h
@@ -34,11 +34,11 @@
 #include "Main.h"
 #include "hdrs/HTTP.h"
 #include "ts/IpMap.h"
-#include "ts/Vec.h"
 #include "ProxyConfig.h"
 
 #include <string>
 #include <set>
+#include <vector>
 
 // forward declare in name only so it can be a friend.
 struct IpAllowUpdate;
@@ -168,8 +168,8 @@ private:
   const char *action;
   IpMap _src_map;
   IpMap _dest_map;
-  Vec<AclRecord> _src_acls;
-  Vec<AclRecord> _dest_acls;
+  std::vector<AclRecord> _src_acls;
+  std::vector<AclRecord> _dest_acls;
 };
 
 inline AclRecord *

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -9002,7 +9002,7 @@ TSPluginDescriptorAccept(TSCont contp)
   Action *action = nullptr;
 
   HttpProxyPort::Group &proxy_ports = HttpProxyPort::global();
-  for (int i = 0, n = proxy_ports.length(); i < n; ++i) {
+  for (int i = 0, n = proxy_ports.size(); i < n; ++i) {
     HttpProxyPort &port = proxy_ports[i];
     if (port.isPlugin()) {
       NetProcessor::AcceptOptions net(make_net_accept_options(&port, -1 /* nthreads */));

--- a/proxy/InkAPITest.cc
+++ b/proxy/InkAPITest.cc
@@ -2155,9 +2155,9 @@ static int
 checkHttpTxnIncomingAddrGet(SocketTest *test, void *data)
 {
   uint16_t port;
-  HttpProxyPort *proxy_port = HttpProxyPort::findHttp(AF_INET);
-  TSHttpTxn txnp            = (TSHttpTxn)data;
-  sockaddr const *ptr       = TSHttpTxnIncomingAddrGet(txnp);
+  const HttpProxyPort *proxy_port = HttpProxyPort::findHttp(AF_INET);
+  TSHttpTxn txnp                  = (TSHttpTxn)data;
+  sockaddr const *ptr             = TSHttpTxnIncomingAddrGet(txnp);
 
   if (nullptr == proxy_port) {
     SDK_RPRINT(test->regtest, "TSHttpTxnIncomingPortGet", "TestCase1", TC_FAIL,

--- a/proxy/InkAPITestTool.cc
+++ b/proxy/InkAPITestTool.cc
@@ -482,7 +482,7 @@ get_response_id(TSHttpTxn txnp)
 static ClientTxn *
 synclient_txn_create(void)
 {
-  HttpProxyPort *proxy_port;
+  const HttpProxyPort *proxy_port;
 
   ClientTxn *txn = (ClientTxn *)TSmalloc(sizeof(ClientTxn));
 

--- a/proxy/http/HttpProxyServerMain.cc
+++ b/proxy/http/HttpProxyServerMain.cc
@@ -40,6 +40,8 @@
 #include "http2/Http2SessionAccept.h"
 #include "HttpConnectionCount.h"
 
+#include <vector>
+
 HttpSessionAccept *plugin_http_accept             = nullptr;
 HttpSessionAccept *plugin_http_transparent_accept = nullptr;
 
@@ -105,7 +107,7 @@ struct HttpProxyAcceptor {
     @c SSLNextProtocolAccept is a subclass of @c Cont instead of @c
     HttpAccept.
 */
-Vec<HttpProxyAcceptor> HttpProxyAcceptors;
+std::vector<HttpProxyAcceptor> HttpProxyAcceptors;
 
 // Called from InkAPI.cc
 NetProcessor::AcceptOptions
@@ -265,8 +267,10 @@ init_accept_HttpProxyServer(int n_accept_threads)
   }
 
   // Do the configuration defined ports.
-  for (int i = 0, n = proxy_ports.length(); i < n; ++i) {
-    MakeHttpProxyAcceptor(HttpProxyAcceptors.add(), proxy_ports[i], n_accept_threads);
+  // Assign temporary empty objects of proxy ports size
+  HttpProxyAcceptors.assign(proxy_ports.size(), HttpProxyAcceptor());
+  for (int i = 0, n = proxy_ports.size(); i < n; ++i) {
+    MakeHttpProxyAcceptor(HttpProxyAcceptors.at(i), proxy_ports[i], n_accept_threads);
   }
 }
 
@@ -281,9 +285,9 @@ start_HttpProxyServer()
   ///////////////////////////////////
 
   ink_assert(!called_once);
-  ink_assert(proxy_ports.length() == HttpProxyAcceptors.length());
+  ink_assert(proxy_ports.size() == HttpProxyAcceptors.size());
 
-  for (int i = 0, n = proxy_ports.length(); i < n; ++i) {
+  for (int i = 0, n = proxy_ports.size(); i < n; ++i) {
     HttpProxyAcceptor &acceptor = HttpProxyAcceptors[i];
     HttpProxyPort &port         = proxy_ports[i];
     if (port.isSSL()) {

--- a/proxy/http2/HPACK.cc
+++ b/proxy/http2/HPACK.cc
@@ -219,9 +219,9 @@ HpackLookupResult
 HpackIndexingTable::lookup(const char *name, int name_len, const char *value, int value_len) const
 {
   HpackLookupResult result;
-  const int entry_num = TS_HPACK_STATIC_TABLE_ENTRY_NUM + _dynamic_table->length();
+  const unsigned int entry_num = TS_HPACK_STATIC_TABLE_ENTRY_NUM + _dynamic_table->length();
 
-  for (int index = 1; index < entry_num; ++index) {
+  for (unsigned int index = 1; index < entry_num; ++index) {
     const char *table_name, *table_value;
     int table_name_len = 0, table_value_len = 0;
 
@@ -321,7 +321,7 @@ HpackIndexingTable::update_maximum_size(uint32_t new_size)
 const MIMEField *
 HpackDynamicTable::get_header_field(uint32_t index) const
 {
-  return _headers.get(index);
+  return _headers.at(index);
 }
 
 void
@@ -344,13 +344,13 @@ HpackDynamicTable::add_header_field(const MIMEField *field)
     _current_size += header_size;
     while (_current_size > _maximum_size) {
       int last_name_len, last_value_len;
-      MIMEField *last_field = _headers.last();
+      MIMEField *last_field = _headers.back();
 
       last_field->name_get(&last_name_len);
       last_field->value_get(&last_value_len);
       _current_size -= ADDITIONAL_OCTETS + last_name_len + last_value_len;
 
-      _headers.remove_index(_headers.length() - 1);
+      _headers.erase(_headers.begin() + _headers.size() - 1);
       _mhdr->field_delete(last_field, false);
     }
 
@@ -358,7 +358,7 @@ HpackDynamicTable::add_header_field(const MIMEField *field)
     new_field->value_set(_mhdr->m_heap, _mhdr->m_mime, value, value_len);
     _mhdr->field_attach(new_field);
     // XXX Because entire Vec instance is copied, Its too expensive!
-    _headers.insert(0, new_field);
+    _headers.insert(_headers.begin(), new_field);
   }
 }
 
@@ -385,17 +385,17 @@ bool
 HpackDynamicTable::update_maximum_size(uint32_t new_size)
 {
   while (_current_size > new_size) {
-    if (_headers.n <= 0) {
+    if (_headers.size() <= 0) {
       return false;
     }
     int last_name_len, last_value_len;
-    MIMEField *last_field = _headers.last();
+    MIMEField *last_field = _headers.back();
 
     last_field->name_get(&last_name_len);
     last_field->value_get(&last_value_len);
     _current_size -= ADDITIONAL_OCTETS + last_name_len + last_value_len;
 
-    _headers.remove_index(_headers.length() - 1);
+    _headers.erase(_headers.begin() + _headers.size() - 1);
     _mhdr->field_delete(last_field, false);
   }
 
@@ -406,7 +406,7 @@ HpackDynamicTable::update_maximum_size(uint32_t new_size)
 uint32_t
 HpackDynamicTable::length() const
 {
-  return _headers.length();
+  return _headers.size();
 }
 
 //

--- a/proxy/http2/HPACK.h
+++ b/proxy/http2/HPACK.h
@@ -25,9 +25,10 @@
 #define __HPACK_H__
 
 #include "ts/ink_platform.h"
-#include "ts/Vec.h"
 #include "ts/Diags.h"
 #include "HTTP.h"
+
+#include <vector>
 
 // It means that any header field can be compressed/decompressed by ATS
 const static int HPACK_ERROR_COMPRESSION_ERROR   = -1;
@@ -133,7 +134,7 @@ private:
   uint32_t _maximum_size;
 
   MIMEHdr *_mhdr;
-  Vec<MIMEField *> _headers;
+  std::vector<MIMEField *> _headers;
 };
 
 // [RFC 7541] 2.3. Indexing Table

--- a/proxy/logging/LogObject.h
+++ b/proxy/logging/LogObject.h
@@ -33,7 +33,7 @@
 #include "LogBuffer.h"
 #include "LogAccess.h"
 #include "LogFilter.h"
-#include "ts/Vec.h"
+#include <vector>
 
 /*-------------------------------------------------------------------------
   LogObject
@@ -352,7 +352,7 @@ public:
   };
 
 private:
-  typedef Vec<LogObject *> LogObjectList;
+  typedef std::vector<LogObject *> LogObjectList;
 
   LogObjectList _objects;    // array of configured objects
   LogObjectList _APIobjects; // array of API objects
@@ -408,12 +408,12 @@ public:
   bool
   has_api_objects() const
   {
-    return _APIobjects.length() > 0;
+    return _APIobjects.size() > 0;
   }
   unsigned
   get_num_objects() const
   {
-    return _objects.length();
+    return _objects.size();
   }
   unsigned get_num_collation_clients() const;
 };


### PR DESCRIPTION
This PR #1560 is regarding code refactoring and refusal of use of custom vector container (against std::vector) implementation that still can be found in ATS core functionality.

Tested using next test case:
- forward proxy
- http2 support
- overall stability

The rest of test cases were out of scope since above covers pretty much.

For now some of ATS core functionality like Map container implementation still uses Vec: it inherits some key functionality of latter one thus some of sources still haven't been refactored - discussion in regards is required.