### PR TITLE
Test: Fix timing issues with txn and double tests.

### DIFF
--- a/iocore/net/test_I_UDPNet.cc
+++ b/iocore/net/test_I_UDPNet.cc
@@ -36,7 +36,7 @@
 
 #include "diags.i"
 
-static const int port       = 4443;
+static const int port       = 56912;
 static const char payload[] = "hello";
 
 /*This implements a standard Unix echo server: just send every udp packet you
@@ -98,7 +98,7 @@ EchoServer::handle_packet(int event, void *data)
   }
 
   default:
-    std::cout << "got unknown event" << std::endl;
+    std::cout << "got unknown event [" << event << "]" << std::endl;
     std::exit(EXIT_FAILURE);
   }
 

--- a/tests/gold_tests/continuations/double.test.py
+++ b/tests/gold_tests/continuations/double.test.py
@@ -42,7 +42,8 @@ server.addResponse("sessionfile.log", request_header, response_header)
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 1,
     'proxy.config.diags.debug.tags': 'continuations_verify.*',
-
+    'proxy.config.http.cache.http' : 0, #disable cache to simply the test.
+    'proxy.config.cache.enable_read_while_writer' : 0
 })
 ts.Disk.remap_config.AddLine(
     'map http://127.0.0.1:{0} http://127.0.0.1:{1}'.format(ts.Variables.port, server.Variables.Port)
@@ -52,7 +53,7 @@ numberOfRequests = randint(1000, 1500)
 
 # Make a *ton* of calls to the proxy!
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'ab -n {0} -c 10 http://127.0.0.1:{1}/'.format(numberOfRequests, ts.Variables.port)
+tr.Processes.Default.Command = 'ab -n {0} -c 10 http://127.0.0.1:{1}/;sleep 5'.format(numberOfRequests, ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 # time delay as proxy.config.http.wait_for_cache could be broken
 tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Port))

--- a/tests/gold_tests/transaction/txn.test.py
+++ b/tests/gold_tests/transaction/txn.test.py
@@ -42,7 +42,8 @@ server.addResponse("sessionfile.log", request_header, response_header)
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 1,
     'proxy.config.diags.debug.tags': 'ssntxnorder_verify.*',
-
+    'proxy.config.http.cache.http' : 0, #disable cache to simply the test.
+    'proxy.config.cache.enable_read_while_writer' : 0
 })
 
 ts.Disk.remap_config.AddLine(
@@ -53,7 +54,7 @@ numberOfRequests = randint(1000, 1500)
 
 # Make a *ton* of calls to the proxy!
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'ab -n {0} -c 10 http://127.0.0.1:{1}/'.format(numberOfRequests, ts.Variables.port)
+tr.Processes.Default.Command = 'ab -n {0} -c 10 http://127.0.0.1:{1}/;sleep 5'.format(numberOfRequests, ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 # time delay as proxy.config.http.wait_for_cache could be broken
 tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Port))


### PR DESCRIPTION
This disables caching and read-while-write which are currently problematic under stress. Many of the failures are due to crashing ATS in that way. The other issue seems to be the log file is sometimes not completely written out before ATS is shut down so I added a 5 second delay after the stress test which seems to clear that up. That's a hack, though - we need to do much better about log flushing when needed or on shutdown.