### PR TITLE
Support dynamic registration to StatPages.

### DIFF
--- a/proxy/StatPages.cc
+++ b/proxy/StatPages.cc
@@ -49,17 +49,20 @@ static volatile int n_stat_pages = 0;
 void
 StatPagesManager::init()
 {
+  ink_mutex_init(&stat_pages_mutex);
   REC_EstablishStaticConfigInt32(m_enabled, "proxy.config.http_ui_enabled");
 }
 
 void
 StatPagesManager::register_http(const char *module, StatPagesFunc func)
 {
+  ink_mutex_acquire(&stat_pages_mutex);
   ink_release_assert(n_stat_pages < MAX_STAT_PAGES);
 
   stat_pages[n_stat_pages].module = (char *)ats_malloc(strlen(module) + 3);
   snprintf(stat_pages[n_stat_pages].module, strlen(module) + 3, "{%s}", module);
   stat_pages[n_stat_pages++].func = func;
+  ink_mutex_release(&stat_pages_mutex);
 }
 
 Action *

--- a/proxy/StatPages.h
+++ b/proxy/StatPages.h
@@ -84,6 +84,7 @@ struct StatPagesManager {
   bool is_stat_page(URL *url);
   bool is_cache_inspector_page(URL *url);
   int m_enabled;
+  ink_mutex stat_pages_mutex;
 };
 
 inkcoreapi extern StatPagesManager statPagesManager;


### PR DESCRIPTION
The cache stat module will register to StatPages after cache system
initialized. But there is not a mutex to protect the stat_pages[] array.
It will leads a rare crash when proxy.config.http.wait_for_cache is
false.