### PR TITLE
BufferWriter: Add data() method for access to the internal buffer

### DIFF
--- a/lib/ts/BufferWriter.h
+++ b/lib/ts/BufferWriter.h
@@ -60,6 +60,9 @@ public:
     return write(sV.data(), sV.size());
   }
 
+  /// Return the written buffer.
+  virtual const char *data() const = 0;
+
   // Returns true if the instance is in an error state.
   //
   virtual bool error() const = 0;
@@ -169,6 +172,13 @@ public:
   // resolving calls to a 'write' member ( wkaras@oath.com ).
   //
   using BufferWriter::write;
+
+  /// Return the written buffer.
+  const char *
+  data() const override
+  {
+    return _buf;
+  }
 
   bool
   error() const override

--- a/lib/ts/unit-tests/test_BufferWriter.cc
+++ b/lib/ts/unit-tests/test_BufferWriter.cc
@@ -69,6 +69,11 @@ TEST_CASE("BufferWriter::write(StringView)", "[BWWSV]")
     }
 
     // Dummies.
+    const char *
+    data() const override
+    {
+      return nullptr;
+    }
     size_t
     capacity() const override
     {


### PR DESCRIPTION
This is not strictly needed, as there is a conversion to `ts::string_view` to extract the written buffer contents. However, for the purposes of API consistency with `std:string` and `ts::string_view` this is handy because then it has `data()` and `size()` methods with the same semantics. A primary use case is for `printf` with the `%.*s` specifier - then this can be printed using exactly the same technique as for the string classes.