### PR TITLE
Cleanup: fix rollback to use elevating file operations.

### DIFF
--- a/lib/ts/ink_cap.cc
+++ b/lib/ts/ink_cap.cc
@@ -351,6 +351,17 @@ elevating_chmod(const char *path, int perm)
   return ret;
 }
 
+int
+elevating_stat(const char *path, struct stat *buff)
+{
+  int ret = stat(path, buff);
+  if (ret != 0 && (EPERM == errno || EACCES == errno)) {
+    ElevateAccess access(ElevateAccess::FILE_PRIVILEGE);
+    return stat(path, buff);
+  }
+  return ret;
+}
+
 #if TS_USE_POSIX_CAP
 /** Acquire file access privileges to bypass DAC.
     @a level is a mask of the specific file access capabilities to acquire.

--- a/lib/ts/ink_cap.h
+++ b/lib/ts/ink_cap.h
@@ -53,6 +53,8 @@ extern FILE *elevating_fopen(const char *path, const char *mode);
 
 // chmod a file, elevating if necessary
 extern int elevating_chmod(const char *path, int perm);
+/// @c stat a file, evelating only if needed.
+extern int elevating_stat(const char *path, struct stat *buff);
 
 /** Control generate of core file on crash.
     @a flag sets whether core files are enabled on crash.

--- a/mgmt/Rollback.cc
+++ b/mgmt/Rollback.cc
@@ -261,9 +261,8 @@ Rollback::statFile(version_t version, struct stat *buf)
   }
 
   ats_scoped_str filePath(createPathStr(version));
-  ElevateAccess access(root_access_needed ? ElevateAccess::FILE_PRIVILEGE : 0);
 
-  statResult = stat(filePath, buf);
+  statResult = root_access_needed ? elevating_stat(filePath, buf) : stat(filePath, buf);
 
   return statResult;
 }
@@ -279,12 +278,10 @@ Rollback::openFile(version_t version, int oflags, int *errnoPtr)
   int fd;
 
   ats_scoped_str filePath(createPathStr(version));
-  ElevateAccess access(root_access_needed ? ElevateAccess::FILE_PRIVILEGE : 0);
-
   // TODO: Use the original permissions
   //       Anyhow the _1 files should not be created inside Syconfdir.
   //
-  fd = mgmt_open_mode(filePath, oflags, 0644);
+  fd = mgmt_open_mode_elevate(filePath, oflags, 0644, root_access_needed);
 
   if (fd < 0) {
     if (errnoPtr != nullptr) {

--- a/mgmt/utils/MgmtSocket.cc
+++ b/mgmt/utils/MgmtSocket.cc
@@ -23,6 +23,7 @@
 
 #include "ts/ink_platform.h"
 #include "ts/ink_assert.h"
+#include <ts/ink_cap.cc>
 #include "MgmtSocket.h"
 
 #if HAVE_UCRED_H
@@ -153,6 +154,25 @@ mgmt_open_mode(const char *path, int oflag, mode_t mode)
   return r;
 }
 
+//-------------------------------------------------------------------------
+// mgmt_open_mode_elevate
+//-------------------------------------------------------------------------
+
+int
+mgmt_open_mode_elevate(const char *path, int oflag, mode_t mode, bool elevate_p)
+{
+  int r, retries;
+  for (retries = 0; retries < MGMT_MAX_TRANSIENT_ERRORS; retries++) {
+    r = elevate_p ? elevating_open(path, oflag, mode) : ::open(path, oflag, mode);
+    if (r >= 0) {
+      return r;
+    }
+    if (!mgmt_transient_error()) {
+      break;
+    }
+  }
+  return r;
+}
 //-------------------------------------------------------------------------
 // mgmt_select
 //-------------------------------------------------------------------------

--- a/mgmt/utils/MgmtSocket.h
+++ b/mgmt/utils/MgmtSocket.h
@@ -61,6 +61,12 @@ int mgmt_open(const char *path, int oflag);
 int mgmt_open_mode(const char *path, int oflag, mode_t mode);
 
 //-------------------------------------------------------------------------
+// mgmt_open_mode_elevate
+//-------------------------------------------------------------------------
+
+int mgmt_open_mode_elevate(const char *path, int oflag, mode_t mode, bool elevate_p = false);
+
+//-------------------------------------------------------------------------
 // mgmt_select
 //-------------------------------------------------------------------------
 

--- a/proxy/hdrs/Makefile.am
+++ b/proxy/hdrs/Makefile.am
@@ -71,7 +71,7 @@ test_mime_LDADD = -L. -lhdrs \
   $(top_builddir)/mgmt/libmgmt_p.la \
   $(top_builddir)/proxy/shared/libUglyLogStubs.a \
   @HWLOC_LIBS@ \
-  @LIBTCL@
+  @LIBTCL@ @LIBCAP@
 
 test_mime_SOURCES = test_mime.cc
 

--- a/proxy/http2/Makefile.am
+++ b/proxy/http2/Makefile.am
@@ -89,7 +89,7 @@ test_HPACK_LDADD = \
   $(top_builddir)/mgmt/libmgmt_p.la \
   $(top_builddir)/proxy/shared/libUglyLogStubs.a \
   @LIBTCL@ \
-  @HWLOC_LIBS@
+  @HWLOC_LIBS@ @LIBCAP@
 
 test_HPACK_SOURCES = \
   test_HPACK.cc \


### PR DESCRIPTION
This fixes an issue where if you try to run Traffic Server unprivileged it breaks due to the rollback / configuration file snapshot logic generating a fatal error because it always elevates before file access, even though it could perform its operations without privilege. This changes that to use the elevating file operations which try the operation first and only elevate if the operation fails due to permission problems.

This has been showing up with autest + CI where the tests run non-privileged. We can run them as root, or do this fix.