### PR TITLE
ESI:combo_handler: Make maximum file count runtime configurable.

### DIFF
--- a/plugins/esi/README.combo
+++ b/plugins/esi/README.combo
@@ -18,6 +18,13 @@ The arguments in the plugin.config line in order represent
 A "-" can be supplied as a value for any of these arguments to request
 default value be applied.
 
+Optional arguments:
+
+  --max-files N
+
+    If present in the plugin.config args, this sets the maximum number of
+    files to process in a request to N. This cannot be changed per remap.
+
 Also, just like the original combohandler, this plugin generates URLs
 of the form 'http://localhost/<dir>/<file-path>'. <dir> here defaults
 to "Host" header unless specified by the file path in the query parameter using


### PR DESCRIPTION
Oath has been running with a local patch to bump the max file count up. Rather than hand patch every release, the plugin should take an optional argument to set the number.

As requested by @djcarlin I've bumped up the default file and query size values.