### PR TITLE
Doc: Tweak makefiles to not build man pages for install if doc building is disabled.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -96,7 +96,9 @@ install-examples: examples
 	@cd example && $(MAKE) $(AM_MAKEFLAGS) install pkglibdir=$(pkglibexecdir)
 
 install-data-hook:
+if BUILD_DOCS
 	@cd doc && $(MAKE) $(AM_MAKEFLAGS) install-man
+endif
 
 TESTS = tools/check-unused-dependencies
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -28,7 +28,9 @@ $(man1_MANS) $(man3_MANS) $(man5_MANS) $(man8_MANS): man
 # Hook the 'all' target so that the man pages get generated in the "all" target, prior
 # to "make install". If we leave it to "make install" time, then the man pages are likely
 # to me generated as root.
+if BUILD_DOCS
 all-am: $(man1_MANS) $(man3_MANS) $(man5_MANS) $(man8_MANS)
+endif
 
 endif
 


### PR DESCRIPTION
If documentation building is not enabled, the man pages should not be built and installed during `make install`.