### PR TITLE
Remove usage of volatile keyword

### DIFF
--- a/iocore/aio/AIO.cc
+++ b/iocore/aio/AIO.cc
@@ -39,7 +39,7 @@ int ts_config_with_inkdiskio = 0;
 /* structure to hold information about each file descriptor */
 AIO_Reqs *aio_reqs[MAX_DISKS_POSSIBLE];
 /* number of unique file descriptors in the aio_reqs array */
-volatile int num_filedes = 1;
+int num_filedes = 1;
 
 // acquire this mutex before inserting a new entry in the aio_reqs array.
 // Don't need to acquire this for searching the array

--- a/iocore/aio/I_AIO.h
+++ b/iocore/aio/I_AIO.h
@@ -70,10 +70,10 @@ typedef struct io_event ink_io_event_t;
 #else
 
 struct ink_aiocb {
-  int aio_fildes         = 0;
-  volatile void *aio_buf = nullptr; /* buffer location */
-  size_t aio_nbytes      = 0;       /* length of transfer */
-  off_t aio_offset       = 0;       /* file offset */
+  int aio_fildes    = 0;
+  void *aio_buf     = nullptr; /* buffer location */
+  size_t aio_nbytes = 0;       /* length of transfer */
+  off_t aio_offset  = 0;       /* file offset */
 
   int aio_reqprio    = 0; /* request priority offset */
   int aio_lio_opcode = 0; /* listio operation */

--- a/iocore/aio/P_AIO.h
+++ b/iocore/aio/P_AIO.h
@@ -122,11 +122,11 @@ struct AIO_Reqs {
   InkAtomicList aio_temp_list;
   ink_mutex aio_mutex;
   ink_cond aio_cond;
-  int index;            /* position of this struct in the aio_reqs array */
-  volatile int pending; /* number of outstanding requests on the disk */
-  volatile int queued;  /* total number of aio_todo and http_todo requests */
-  volatile int filedes; /* the file descriptor for the requests */
-  volatile int requests_queued;
+  int index;   /* position of this struct in the aio_reqs array */
+  int pending; /* number of outstanding requests on the disk */
+  int queued;  /* total number of aio_todo and http_todo requests */
+  int filedes; /* the file descriptor for the requests */
+  int requests_queued;
 };
 
 #endif // AIO_MODE == AIO_MODE_NATIVE

--- a/iocore/aio/test_AIO.cc
+++ b/iocore/aio/test_AIO.cc
@@ -52,7 +52,7 @@ enum {
 };
 
 struct AIO_Device;
-volatile int n_accessors = 0;
+int n_accessors = 0;
 int orig_n_accessors;
 AIO_Device *dev[MAX_DISK_THREADS];
 

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -87,26 +87,26 @@ int cache_config_compatibility_4_2_0_fixup = 1;
 
 // Globals
 
-RecRawStatBlock *cache_rsb          = nullptr;
-Cache *theStreamCache               = nullptr;
-Cache *theCache                     = nullptr;
-CacheDisk **gdisks                  = nullptr;
-int gndisks                         = 0;
-static volatile int initialize_disk = 0;
+RecRawStatBlock *cache_rsb = nullptr;
+Cache *theStreamCache      = nullptr;
+Cache *theCache            = nullptr;
+CacheDisk **gdisks         = nullptr;
+int gndisks                = 0;
+static int initialize_disk;
 Cache *caches[NUM_CACHE_FRAG_TYPES] = {nullptr};
 CacheSync *cacheDirSync             = nullptr;
 Store theCacheStore;
-volatile int CacheProcessor::initialized      = CACHE_INITIALIZING;
-volatile uint32_t CacheProcessor::cache_ready = 0;
-volatile int CacheProcessor::start_done       = 0;
-bool CacheProcessor::clear                    = false;
-bool CacheProcessor::fix                      = false;
-bool CacheProcessor::check                    = false;
-int CacheProcessor::start_internal_flags      = 0;
-int CacheProcessor::auto_clear_flag           = 0;
+int CacheProcessor::initialized          = CACHE_INITIALIZING;
+uint32_t CacheProcessor::cache_ready     = 0;
+int CacheProcessor::start_done           = 0;
+bool CacheProcessor::clear               = false;
+bool CacheProcessor::fix                 = false;
+bool CacheProcessor::check               = false;
+int CacheProcessor::start_internal_flags = 0;
+int CacheProcessor::auto_clear_flag      = 0;
 CacheProcessor cacheProcessor;
-Vol **gvol         = nullptr;
-volatile int gnvol = 0;
+Vol **gvol = nullptr;
+int gnvol  = 0;
 ClassAllocator<CacheVC> cacheVConnectionAllocator("cacheVConnection");
 ClassAllocator<EvacuationBlock> evacuationBlockAllocator("evacuationBlock");
 ClassAllocator<CacheRemoveCont> cacheRemoveContAllocator("cacheRemoveCont");
@@ -277,7 +277,7 @@ static int
 update_cache_config(const char * /* name ATS_UNUSED */, RecDataT /* data_type ATS_UNUSED */, RecData data,
                     void * /* cookie ATS_UNUSED */)
 {
-  volatile int new_value         = validate_rww(data.rec_int);
+  int new_value                  = validate_rww(data.rec_int);
   cache_config_read_while_writer = new_value;
 
   return 0;

--- a/iocore/cache/CacheHosting.cc
+++ b/iocore/cache/CacheHosting.cc
@@ -770,7 +770,7 @@ extern CacheDisk **gdisks;
 extern Queue<CacheVol> cp_list;
 extern int cp_list_len;
 extern ConfigVolumes config_volumes;
-extern volatile int gnvol;
+extern int gnvol;
 
 extern void cplist_init();
 extern int cplist_reconfigure();

--- a/iocore/cache/CachePagesInternal.cc
+++ b/iocore/cache/CachePagesInternal.cc
@@ -52,7 +52,7 @@ extern ShowCacheInternal *theshowcacheInternal;
 Action *register_ShowCacheInternal(Continuation *c, HTTPHdr *h);
 
 extern Vol **gvol;
-extern volatile int gnvol;
+extern int gnvol;
 
 // Stat Pages
 ShowCacheInternal *theshowcacheInternal = nullptr;

--- a/iocore/cache/I_Cache.h
+++ b/iocore/cache/I_Cache.h
@@ -150,9 +150,9 @@ struct CacheProcessor : public Processor {
     return wait_for_cache;
   }
 
-  static volatile uint32_t cache_ready;
-  static volatile int initialized;
-  static volatile int start_done;
+  static uint32_t cache_ready;
+  static int initialized;
+  static int start_done;
   static bool clear;
   static bool fix;
   static bool check;

--- a/iocore/cache/P_CacheDir.h
+++ b/iocore/cache/P_CacheDir.h
@@ -233,8 +233,8 @@ struct OpenDirEntry {
   uint16_t max_writers;                            // max number of simultaneous writers allowed
   bool dont_update_directory;                      // if set, the first_dir is not updated.
   bool move_resident_alt;                          // if set, single_doc_dir is inserted.
-  volatile bool reading_vec;                       // somebody is currently reading the vector
-  volatile bool writing_vec;                       // somebody is currently writing the vector
+  bool reading_vec;                                // somebody is currently reading the vector
+  bool writing_vec;                                // somebody is currently writing the vector
 
   LINK(OpenDirEntry, link);
 

--- a/iocore/cache/P_CacheHosting.h
+++ b/iocore/cache/P_CacheHosting.h
@@ -49,8 +49,8 @@ struct CacheHostRecord {
 
   CacheType type;
   Vol **vols;
-  volatile int good_num_vols;
-  volatile int num_vols;
+  int good_num_vols;
+  int num_vols;
   int num_initialized;
   unsigned short *vol_hash_table;
   CacheVol **cp;

--- a/iocore/cache/P_CacheInternal.h
+++ b/iocore/cache/P_CacheInternal.h
@@ -944,13 +944,13 @@ struct Vol;
 class CacheHostTable;
 
 struct Cache {
-  volatile int cache_read_done;
-  volatile int total_good_nvol;
-  volatile int total_nvol;
-  volatile int ready;
+  int cache_read_done;
+  int total_good_nvol;
+  int total_nvol;
+  int ready;
   int64_t cache_size; // in store block size
   CacheHostTable *hosttable;
-  volatile int total_initialized_vol;
+  int total_initialized_vol;
   CacheType scheme;
 
   int open(bool reconfigure, bool fix);

--- a/iocore/cache/P_CacheTest.h
+++ b/iocore/cache/P_CacheTest.h
@@ -50,7 +50,7 @@ struct PinnedDocTable : public Continuation {
 
 struct CacheTestHost {
   char *name;
-  volatile unsigned int xlast_cachable_id;
+  unsigned int xlast_cachable_id;
   double xprev_host_prob;
   double xnext_host_prob;
 

--- a/iocore/cache/P_CacheVol.h
+++ b/iocore/cache/P_CacheVol.h
@@ -302,7 +302,7 @@ struct Doc {
 // Global Data
 
 extern Vol **gvol;
-extern volatile int gnvol;
+extern int gnvol;
 extern ClassAllocator<OpenDirEntry> openDirEntryAllocator;
 extern ClassAllocator<EvacuationBlock> evacuationBlockAllocator;
 extern ClassAllocator<EvacuationKey> evacuationKeyAllocator;

--- a/iocore/eventsystem/I_Action.h
+++ b/iocore/eventsystem/I_Action.h
@@ -119,7 +119,7 @@ public:
     machine.
 
   */
-  volatile int cancelled = false;
+  int cancelled = false;
 
   /**
     Cancels the asynchronous operation represented by this action.

--- a/iocore/eventsystem/I_EThread.h
+++ b/iocore/eventsystem/I_EThread.h
@@ -52,7 +52,7 @@ enum ThreadType {
   DEDICATED,
 };
 
-extern volatile bool shutdown_event_system;
+extern bool shutdown_event_system;
 
 /**
   Event System specific type of thread.

--- a/iocore/eventsystem/I_EventProcessor.h
+++ b/iocore/eventsystem/I_EventProcessor.h
@@ -332,8 +332,8 @@ public:
   EThread *assign_thread(EventType etype);
 
   EThread *all_dthreads[MAX_EVENT_THREADS];
-  volatile int n_dthreads       = 0; // No. of dedicated threads
-  volatile int thread_data_used = 0;
+  int n_dthreads       = 0; // No. of dedicated threads
+  int thread_data_used = 0;
 
   /// Provide container style access to just the active threads, not the entire array.
   class active_threads_type

--- a/iocore/eventsystem/I_Lock.h
+++ b/iocore/eventsystem/I_Lock.h
@@ -149,7 +149,6 @@
 
 class EThread;
 typedef EThread *EThreadPtr;
-typedef volatile EThreadPtr VolatileEThreadPtr;
 
 #if DEBUG
 inkcoreapi extern void lock_waiting(const SourceLocation &, const char *handler);
@@ -203,7 +202,7 @@ public:
     lock.  You must not modify or set this value directly.
 
   */
-  volatile EThreadPtr thread_holding;
+  EThreadPtr thread_holding;
 
   int nthread_holding;
 

--- a/iocore/eventsystem/UnixEThread.cc
+++ b/iocore/eventsystem/UnixEThread.cc
@@ -38,7 +38,7 @@ struct AIOCallback;
 #define NO_HEARTBEAT -1
 #define THREAD_MAX_HEARTBEAT_MSECONDS 60
 
-volatile bool shutdown_event_system = false;
+bool shutdown_event_system = false;
 
 EThread::EThread()
 {

--- a/iocore/net/P_UnixNetState.h
+++ b/iocore/net/P_UnixNetState.h
@@ -44,7 +44,7 @@ class Event;
 class UnixNetVConnection;
 
 struct NetState {
-  volatile int enabled;
+  int enabled;
   VIO vio;
   Link<UnixNetVConnection> ready_link;
   SLink<UnixNetVConnection> enable_link;

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -223,7 +223,7 @@ public:
   UnixNetVConnection *migrateToCurrentThread(Continuation *c, EThread *t);
 
   Action action_;
-  volatile int closed;
+  int closed;
   NetState read;
   NetState write;
 

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -28,9 +28,8 @@
 #endif
 #define ROUNDUP(x, y) ((((x) + ((y)-1)) / (y)) * (y))
 
-using NetAcceptHandler      = int (NetAccept::*)(int, void *);
-volatile int dummy_volatile = 0;
-int accept_till_done        = 1;
+using NetAcceptHandler = int (NetAccept::*)(int, void *);
+int accept_till_done   = 1;
 
 std::vector<NetAccept *> naVec;
 static void

--- a/iocore/net/UnixNetProcessor.cc
+++ b/iocore/net/UnixNetProcessor.cc
@@ -29,7 +29,7 @@
 // For Stat Pages
 #include "StatPages.h"
 
-volatile int net_accept_number = 0;
+int net_accept_number = 0;
 extern std::vector<NetAccept *> naVec;
 NetProcessor::AcceptOptions const NetProcessor::DEFAULT_ACCEPT_OPTIONS;
 

--- a/lib/cppapi/Logger.cc
+++ b/lib/cppapi/Logger.cc
@@ -44,7 +44,7 @@ struct atscppapi::LoggerState : noncopyable {
   std::string filename_;
   bool add_timestamp_;
   bool rename_file_;
-  volatile Logger::LogLevel level_;
+  Logger::LogLevel level_;
   bool rolling_enabled_;
   int rolling_interval_seconds_;
   TSTextLogObject text_log_obj_;

--- a/lib/ts/BaseLogFile.h
+++ b/lib/ts/BaseLogFile.h
@@ -219,10 +219,10 @@ public:
     LOG_FILE_COULD_NOT_OPEN_FILE,
   };
 
-  FILE *m_fp                        = nullptr;
-  long m_start_time                 = time(nullptr);
-  long m_end_time                   = 0L;
-  volatile uint64_t m_bytes_written = 0;
+  FILE *m_fp               = nullptr;
+  long m_start_time        = time(nullptr);
+  long m_end_time          = 0L;
+  uint64_t m_bytes_written = 0;
 
 private:
   // member functions

--- a/lib/ts/Diags.h
+++ b/lib/ts/Diags.h
@@ -121,7 +121,7 @@ public:
   BaseLogFile *stderr_log;
 
   const unsigned int magic;
-  volatile DiagsConfigState config;
+  DiagsConfigState config;
   DiagsShowLocation show_location;
   DiagsCleanupFunc cleanup_func;
 

--- a/lib/ts/Ptr.h
+++ b/lib/ts/Ptr.h
@@ -87,7 +87,7 @@ public:
   }
 
 private:
-  volatile int m_refcount;
+  int m_refcount;
 };
 
 #define REF_COUNT_OBJ_REFCOUNT_INC(_x) (_x)->refcount_inc()

--- a/lib/ts/ink_aiocb.h
+++ b/lib/ts/ink_aiocb.h
@@ -42,7 +42,7 @@
 struct ink_aiocb {
   int aio_fildes;
 #if defined(__STDC__)
-  volatile void *aio_buf; /* buffer location */
+  void *aio_buf; /* buffer location */
 #else
   void *aio_buf; /* buffer location */
 #endif

--- a/lib/ts/ink_atomic.h
+++ b/lib/ts/ink_atomic.h
@@ -46,22 +46,6 @@
 #include "ts/ink_apidefs.h"
 #include "ts/ink_mutex.h"
 
-typedef volatile int8_t vint8;
-typedef volatile int16_t vint16;
-typedef volatile int32_t vint32;
-typedef volatile int64_t vint64;
-typedef volatile uint64_t vuint64;
-typedef volatile long vlong;
-typedef volatile void *vvoidp;
-
-typedef vint8 *pvint8;
-typedef vint16 *pvint16;
-typedef vint32 *pvint32;
-typedef vint64 *pvint64;
-typedef vuint64 *pvuint64;
-typedef vlong *pvlong;
-typedef vvoidp *pvvoidp;
-
 /* GCC compiler >= 4.1 */
 #if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 1)) || (__GNUC__ >= 5))
 
@@ -71,7 +55,7 @@ typedef vvoidp *pvvoidp;
 // Writes @value into @ptr, returning the previous value.
 template <typename T>
 static inline T
-ink_atomic_swap(volatile T *mem, T value)
+ink_atomic_swap(T *mem, T value)
 {
   return __sync_lock_test_and_set(mem, value);
 }
@@ -81,7 +65,7 @@ ink_atomic_swap(volatile T *mem, T value)
 // Returns true if @next was successfully stored.
 template <typename T>
 static inline bool
-ink_atomic_cas(volatile T *mem, T prev, T next)
+ink_atomic_cas(T *mem, T prev, T next)
 {
   return __sync_bool_compare_and_swap(mem, prev, next);
 }
@@ -90,7 +74,7 @@ ink_atomic_cas(volatile T *mem, T prev, T next)
 // Increment @ptr by @count, returning the previous value.
 template <typename Type, typename Amount>
 static inline Type
-ink_atomic_increment(volatile Type *mem, Amount count)
+ink_atomic_increment(Type *mem, Amount count)
 {
   return __sync_fetch_and_add(mem, (Type)count);
 }
@@ -99,7 +83,7 @@ ink_atomic_increment(volatile Type *mem, Amount count)
 // Decrement @ptr by @count, returning the previous value.
 template <typename Type, typename Amount>
 static inline Type
-ink_atomic_decrement(volatile Type *mem, Amount count)
+ink_atomic_decrement(Type *mem, Amount count)
 {
   return __sync_fetch_and_sub(mem, (Type)count);
 }

--- a/lib/ts/ink_queue.cc
+++ b/lib/ts/ink_queue.cc
@@ -282,7 +282,7 @@ ink_freelist_free(InkFreeList *f, void *item)
 static void
 freelist_free(InkFreeList *f, void *item)
 {
-  volatile void **adr_of_next = (volatile void **)ADDRESS_OF_NEXT(item, 0);
+  void **adr_of_next = (void **)ADDRESS_OF_NEXT(item, 0);
   head_p h;
   head_p item_pair;
   int result = 0;
@@ -338,7 +338,7 @@ ink_freelist_free_bulk(InkFreeList *f, void *head, void *tail, size_t num_item)
 static void
 freelist_bulkfree(InkFreeList *f, void *head, void *tail, size_t num_item)
 {
-  volatile void **adr_of_next = (volatile void **)ADDRESS_OF_NEXT(tail, 0);
+  void **adr_of_next = (void **)ADDRESS_OF_NEXT(tail, 0);
   head_p h;
   head_p item_pair;
   int result = 0;
@@ -522,11 +522,11 @@ ink_atomiclist_popall(InkAtomicList *l)
 void *
 ink_atomiclist_push(InkAtomicList *l, void *item)
 {
-  volatile void **adr_of_next = (volatile void **)ADDRESS_OF_NEXT(item, l->offset);
+  void **adr_of_next = (void **)ADDRESS_OF_NEXT(item, l->offset);
   head_p head;
   head_p item_pair;
-  int result       = 0;
-  volatile void *h = nullptr;
+  int result = 0;
+  void *h    = nullptr;
   do {
     INK_QUEUE_LD(head, l->head);
     h            = FREELIST_POINTER(head);

--- a/lib/ts/ink_queue.h
+++ b/lib/ts/ink_queue.h
@@ -147,7 +147,7 @@ union head_p {
 #endif
 
 struct _InkFreeList {
-  volatile head_p head;
+  head_p head;
   const char *name;
   uint32_t type_size, chunk_size, used, allocated, alignment;
   uint32_t allocated_base, used_base;
@@ -178,7 +178,7 @@ void ink_freelists_snap_baseline();
 
 struct InkAtomicList {
   InkAtomicList() {}
-  volatile head_p head{};
+  head_p head{};
   const char *name = nullptr;
   uint32_t offset  = 0;
 };

--- a/lib/ts/ink_queue_utils.cc
+++ b/lib/ts/ink_queue_utils.cc
@@ -69,8 +69,8 @@ void
 ink_queue_load_64(void *dst, void *src)
 {
 #if (defined(__i386__) || defined(__arm__) || defined(__mips__)) && (SIZEOF_VOIDP == 4)
-  volatile int32_t src_version = (*(head_p *)src).s.version;
-  void *src_pointer            = (*(head_p *)src).s.pointer;
+  int32_t src_version = (*(head_p *)src).s.version;
+  void *src_pointer   = (*(head_p *)src).s.pointer;
 
   (*(head_p *)dst).s.version = src_version;
   (*(head_p *)dst).s.pointer = src_pointer;

--- a/lib/ts/ink_resource.cc
+++ b/lib/ts/ink_resource.cc
@@ -26,7 +26,7 @@
 #include "ts/ink_resource.h"
 #include <execinfo.h>
 
-volatile int res_track_memory = 0; // Disabled by default
+int res_track_memory          = 0; // Disabled by default
 uint64_t ssl_memory_allocated = 0;
 uint64_t ssl_memory_freed     = 0;
 

--- a/lib/ts/ink_resource.h
+++ b/lib/ts/ink_resource.h
@@ -28,7 +28,7 @@
 #include <map>
 #include <string>
 
-extern volatile int res_track_memory; /* set this to zero to disable resource tracking */
+extern int res_track_memory; /* set this to zero to disable resource tracking */
 extern uint64_t ssl_memory_allocated;
 extern uint64_t ssl_memory_freed;
 

--- a/lib/ts/test_atomic.cc
+++ b/lib/ts/test_atomic.cc
@@ -37,7 +37,7 @@
 #define MAX_ALIST_ARRAY 100000
 InkAtomicList al[MAX_ALIST_TEST];
 void *al_test[MAX_ALIST_TEST][MAX_ALIST_ARRAY];
-volatile int al_done = 0;
+int al_done = 0;
 
 void *
 testalist(void *ame)
@@ -171,7 +171,7 @@ main(int /* argc ATS_UNUSED */, const char * /* argv ATS_UNUSED */ [])
   printf("changed to: %d,  result=%d\n", n, m);
 
   printf("Atomic Fetch-and-Add 2 to pointer to '%s'\n", m2);
-  n2 = (char *)ink_atomic_increment((pvvoidp)&m2, (void *)2);
+  n2 = (char *)ink_atomic_increment((void **)&m2, (void *)2);
   printf("changed to: %s,  result=%s\n", m2, n2);
 
   printf("Testing atomic lists\n");

--- a/mgmt/LocalManager.h
+++ b/mgmt/LocalManager.h
@@ -88,14 +88,14 @@ public:
 
   bool processRunning();
 
-  volatile bool run_proxy;
-  volatile bool proxy_recoverable = true; // false if traffic_server cannot recover with a reboot
-  volatile time_t manager_started_at;
-  volatile time_t proxy_started_at                              = -1;
-  volatile int proxy_launch_count                               = 0;
-  volatile bool proxy_launch_outstanding                        = false;
-  volatile ManagementPendingOperation mgmt_shutdown_outstanding = MGMT_PENDING_NONE;
-  volatile int proxy_running                                    = 0;
+  bool run_proxy;
+  bool proxy_recoverable = true; // false if traffic_server cannot recover with a reboot
+  time_t manager_started_at;
+  time_t proxy_started_at                              = -1;
+  int proxy_launch_count                               = 0;
+  bool proxy_launch_outstanding                        = false;
+  ManagementPendingOperation mgmt_shutdown_outstanding = MGMT_PENDING_NONE;
+  int proxy_running                                    = 0;
   HttpProxyPort::Group m_proxy_ports;
   // Local inbound addresses to bind, if set.
   IpAddr m_inbound_ip4;
@@ -110,14 +110,14 @@ public:
   char *proxy_options = nullptr; // These options should persist across proxy reboots
   char *env_prep;
 
-  int process_server_sockfd       = ts::NO_FD;
-  volatile int watched_process_fd = ts::NO_FD;
-  volatile pid_t proxy_launch_pid = -1;
+  int process_server_sockfd = ts::NO_FD;
+  int watched_process_fd    = ts::NO_FD;
+  pid_t proxy_launch_pid    = -1;
 
   Alarms *alarm_keeper     = nullptr;
   FileManager *configFiles = nullptr;
 
-  volatile pid_t watched_process_pid = -1;
+  pid_t watched_process_pid = -1;
 
   int syslog_facility = LOG_DAEMON;
 

--- a/mgmt/ProcessManager.h
+++ b/mgmt/ProcessManager.h
@@ -84,7 +84,7 @@ private:
   pid_t pid;
 
   ink_thread poll_thread = ink_thread_null();
-  volatile int running   = 0;
+  int running            = 0;
 
   /// Thread initialization callback.
   /// This allows @c traffic_server and @c traffic_manager to perform different initialization in the thread.

--- a/mgmt/ProxyConfig.cc
+++ b/mgmt/ProxyConfig.cc
@@ -214,7 +214,7 @@ enum {
 };
 
 struct RegressionConfig : public ConfigInfo {
-  static volatile int nobjects; // count of outstanding RegressionConfig objects (not-reentrant)
+  static int nobjects; // count of outstanding RegressionConfig objects (not-reentrant)
 
   // DeferredCall is a simple function call wrapper that defers itself until the RegressionConfig
   // object count drops below the specified count.
@@ -276,7 +276,7 @@ struct RegressionConfig : public ConfigInfo {
   unsigned flags;
 };
 
-volatile int RegressionConfig::nobjects = 0;
+int RegressionConfig::nobjects = 0;
 
 struct ProxyConfig_Set_Completion {
   ProxyConfig_Set_Completion(int _id, RegressionConfig *_c) : configid(_id), config(_c) {}

--- a/plugins/background_fetch/configs.h
+++ b/plugins/background_fetch/configs.h
@@ -82,7 +82,7 @@ private:
 
   TSCont _cont;
   BgFetchRule *_rules;
-  volatile int _ref_count;
+  int _ref_count;
 };
 
 #endif /* CONFIGS_H_DEBFCE23_D6E9_40C2_AAA5_32B32586A3DA */

--- a/plugins/experimental/memcache/tsmemcache.cc
+++ b/plugins/experimental/memcache/tsmemcache.cc
@@ -39,9 +39,9 @@ ClassAllocator<MC> theMCAllocator("MC");
 static time_t base_day_time;
 
 // These should be persistent.
-volatile int32_t MC::verbosity     = 0;
-volatile ink_hrtime MC::last_flush = 0;
-volatile int64_t MC::next_cas      = 1;
+int32_t MC::verbosity     = 0;
+ink_hrtime MC::last_flush = 0;
+int64_t MC::next_cas      = 1;
 
 static void
 tsmemcache_constants()

--- a/plugins/experimental/memcache/tsmemcache.h
+++ b/plugins/experimental/memcache/tsmemcache.h
@@ -154,9 +154,9 @@ struct MC : Continuation {
   uint64_t nbytes;
   uint64_t delta;
 
-  static volatile int32_t verbosity;
-  static volatile ink_hrtime last_flush;
-  static volatile int64_t next_cas;
+  static int32_t verbosity;
+  static ink_hrtime last_flush;
+  static int64_t next_cas;
 
   int write_to_client(int64_t ntowrite = -1);
   int write_then_read_from_client(int64_t ntowrite = -1);

--- a/plugins/gzip/configuration.h
+++ b/plugins/gzip/configuration.h
@@ -141,7 +141,7 @@ private:
   bool remove_accept_encoding_;
   bool flush_;
   int compression_algorithms_;
-  volatile int ref_count_;
+  int ref_count_;
 
   StringContainer compressible_content_types_;
   StringContainer disallows_;

--- a/plugins/header_rewrite/header_rewrite.cc
+++ b/plugins/header_rewrite/header_rewrite.cc
@@ -120,7 +120,7 @@ private:
   bool add_rule(RuleSet *rule);
 
   TSCont _cont;
-  volatile int _ref_count;
+  int _ref_count;
   RuleSet *_rules[TS_HTTP_LAST_HOOK + 1];
   ResourceIDs _resids[TS_HTTP_LAST_HOOK + 1];
 };

--- a/plugins/healthchecks/healthchecks.c
+++ b/plugins/healthchecks/healthchecks.c
@@ -43,11 +43,8 @@ static const char SEPARATORS[]  = " \t\n";
 #define MAX_BODY_LEN 16384
 #define FREELIST_TIMEOUT 300
 
-/* Some atomic stuff, from ATS core */
-typedef volatile void *vvoidp;
-
 static inline void *
-ink_atomic_swap_ptr(vvoidp mem, void *value)
+ink_atomic_swap_ptr(void *mem, void *value)
 {
   return __sync_lock_test_and_set((void **)mem, value);
 }

--- a/plugins/regex_revalidate/regex_revalidate.c
+++ b/plugins/regex_revalidate/regex_revalidate.c
@@ -69,9 +69,9 @@ typedef struct invalidate_t {
 } invalidate_t;
 
 typedef struct {
-  invalidate_t *volatile invalidate_list;
+  invalidate_t *invalidate_list;
   char *config_file;
-  volatile time_t last_load;
+  time_t last_load;
   TSTextLogObject log;
 } plugin_state_t;
 

--- a/plugins/s3_auth/s3_auth.cc
+++ b/plugins/s3_auth/s3_auth.cc
@@ -397,7 +397,7 @@ private:
   bool _version_modified   = false;
   bool _virt_host_modified = false;
   TSCont _cont             = nullptr;
-  volatile int _ref_count  = 1;
+  int _ref_count           = 1;
   StringSet _v4includeHeaders;
   bool _v4includeHeaders_modified = false;
   StringSet _v4excludeHeaders;

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -83,11 +83,11 @@
   _HDR.m_mime = _HDR.m_http->m_fields_impl;
 
 // Globals for new librecords stats
-static volatile int api_rsb_index = 0;
+static int api_rsb_index;
 static RecRawStatBlock *api_rsb;
 
 // Globals for the Sessions/Transaction index registry
-static volatile int next_argv_index = 0;
+static int next_argv_index;
 
 static std::type_info const &TYPE_INFO_MGMT_INT   = typeid(MgmtInt);
 static std::type_info const &TYPE_INFO_MGMT_BYTE  = typeid(MgmtByte);

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -165,12 +165,12 @@ static int cmd_line_dprintf_level = 0;  // default debug output level from ink_d
 static int poll_timeout           = -1; // No value set.
 static int cmd_disable_freelist   = 0;
 
-static volatile bool signal_received[NSIG];
+static bool signal_received[NSIG];
 
 // 1: delay listen, wait for cache.
 // 0: Do not delay, start listen ASAP.
 // -1: cache is already initialized, don't delay.
-static volatile int delay_listen_for_cache_p = 0;
+static int delay_listen_for_cache_p;
 
 AppVersionInfo appVersionInfo; // Build info for this application
 

--- a/proxy/ParentSelection.h
+++ b/proxy/ParentSelection.h
@@ -137,7 +137,7 @@ public:
   void PreProcessParents(const char *val, const int line_num, char *buf, size_t len);
   const char *ProcessParents(char *val, bool isPrimary);
   bool ignore_query                                                  = false;
-  volatile uint32_t rr_next                                          = 0;
+  uint32_t rr_next                                                   = 0;
   bool go_direct                                                     = true;
   bool parent_is_proxy                                               = true;
   ParentSelectionStrategy *selection_strategy                        = nullptr;

--- a/proxy/PluginVC.cc
+++ b/proxy/PluginVC.cc
@@ -1003,7 +1003,7 @@ PluginVC::set_data(int id, void *data)
 
 // PluginVCCore
 
-vint32 PluginVCCore::nextid = 0;
+int32_t PluginVCCore::nextid;
 
 PluginVCCore::~PluginVCCore()
 {

--- a/proxy/PluginVC.h
+++ b/proxy/PluginVC.h
@@ -170,7 +170,7 @@ private:
   bool need_read_process;
   bool need_write_process;
 
-  volatile bool closed;
+  bool closed;
   Event *sm_lock_retry_event;
   Event *core_lock_retry_event;
 
@@ -259,7 +259,7 @@ private:
   void *passive_data;
   void *active_data;
 
-  static vint32 nextid;
+  static int32_t nextid;
   unsigned id;
 };
 

--- a/proxy/StatPages.cc
+++ b/proxy/StatPages.cc
@@ -44,7 +44,7 @@ static struct {
   StatPagesFunc func;
 } stat_pages[MAX_STAT_PAGES];
 
-static volatile int n_stat_pages = 0;
+static int n_stat_pages;
 
 void
 StatPagesManager::init()

--- a/proxy/TransformInternal.h
+++ b/proxy/TransformInternal.h
@@ -49,9 +49,9 @@ public:
   TransformVConnection *m_tvc;
   VIO m_read_vio;
   VIO m_write_vio;
-  volatile int m_event_count;
-  volatile int m_deletable;
-  volatile int m_closed;
+  int m_event_count;
+  int m_deletable;
+  int m_closed;
   int m_called_user;
 };
 
@@ -79,7 +79,7 @@ public:
   VConnection *m_transform;
   Continuation *m_cont;
   TransformTerminus m_terminus;
-  volatile int m_closed;
+  int m_closed;
 };
 
 class TransformControl : public Continuation

--- a/proxy/api/ts/InkAPIPrivateIOCore.h
+++ b/proxy/api/ts/InkAPIPrivateIOCore.h
@@ -57,8 +57,8 @@ protected:
 public:
   void *mdata;
   TSEventFunc m_event_func;
-  volatile int m_event_count;
-  volatile int m_closed;
+  int m_event_count;
+  int m_closed;
   int m_deletable;
   int m_deleted;
   // INKqa07670: Nokia memory leak bug fix

--- a/proxy/congest/Congestion.h
+++ b/proxy/congest/Congestion.h
@@ -202,10 +202,10 @@ struct CongestionEntry : public RequestData {
   FailHistory m_history;
   Ptr<ProxyMutex> m_hist_lock;
   ink_hrtime m_last_congested;
-  volatile int m_congested; // 0 | 1
+  int m_congested; // 0 | 1
   int m_stat_congested_conn_failures;
 
-  volatile int m_M_congested;
+  int m_M_congested;
   ink_hrtime m_last_M_congested;
 
   // State -- concorrent connections

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -209,11 +209,7 @@ private:
   MIOBuffer *read_buffer;
   IOBufferReader *sm_reader;
 
-  /*
-   * Volatile should not be necessary, but there appears to be a bug in the 4.9 rhel gcc
-   * compiler that was using an old version of read_state to make decisions in really_destroy
-   */
-  volatile C_Read_State read_state;
+  C_Read_State read_state;
 
   VIO *ka_vio;
   VIO *slave_ka_vio;

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -120,7 +120,7 @@ static const ConfigEnumPair<TSServerSessionSharingPoolType> SessionSharingPoolSt
 int HttpConfig::m_id = 0;
 HttpConfigParams HttpConfig::m_master;
 
-static volatile int http_config_changes = 1;
+static int http_config_changes          = 1;
 static HttpConfigCont *http_config_cont = nullptr;
 
 HttpConfigCont::HttpConfigCont() : Continuation(new_ProxyMutex())

--- a/proxy/http/unit-tests/test_ForwardedConfig_mocks.cc
+++ b/proxy/http/unit-tests/test_ForwardedConfig_mocks.cc
@@ -60,7 +60,7 @@ ink_freelist_free(InkFreeList *f, void *item){STUB} inkcoreapi
 }
 void ink_mutex_destroy(pthread_mutex_t *){STUB} inkcoreapi ClassAllocator<ProxyMutex> mutexAllocator("ARGH");
 inkcoreapi ink_thread_key Thread::thread_data_key;
-volatile int res_track_memory;
+int res_track_memory;
 void ResourceTracker::increment(const char *, long){STUB} inkcoreapi Allocator ioBufAllocator[DEFAULT_BUFFER_SIZES];
 void
 ats_free(void *)

--- a/proxy/http2/HTTP2.cc
+++ b/proxy/http2/HTTP2.cc
@@ -28,7 +28,7 @@
 #include "P_RecCore.h"
 #include "P_RecProcess.h"
 
-volatile bool http2_drain = false;
+bool http2_drain = false;
 
 const char *const HTTP2_CONNECTION_PREFACE = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 

--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -38,7 +38,7 @@ typedef unsigned Http2StreamId;
 // the flow control window can be come negative so we need to track it with a signed type.
 typedef int32_t Http2WindowSize;
 
-extern volatile bool http2_drain;
+extern bool http2_drain;
 
 extern const char *const HTTP2_CONNECTION_PREFACE;
 const size_t HTTP2_CONNECTION_PREFACE_LEN = 24;

--- a/proxy/logging/LogBuffer.cc
+++ b/proxy/logging/LogBuffer.cc
@@ -55,7 +55,7 @@ enum {
 
 FieldListCacheElement fieldlist_cache[FIELDLIST_CACHE_SIZE];
 int fieldlist_cache_entries = 0;
-vint32 LogBuffer::M_ID      = 0;
+int32_t LogBuffer::M_ID;
 
 /*-------------------------------------------------------------------------
   The following LogBufferHeader routines are used to grab strings out from
@@ -137,7 +137,7 @@ LogBuffer::LogBuffer(LogObject *owner, size_t size, size_t buf_align, size_t wri
   m_state.s.offset = hdr_size;
 
   // update the buffer id (m_id gets the old value)
-  m_id = (uint32_t)ink_atomic_increment((pvint32)&M_ID, 1);
+  m_id = (uint32_t)ink_atomic_increment((int32_t *)&M_ID, 1);
 
   m_expiration_time = LogUtils::timestamp() + Log::config->max_secs_per_buffer;
 
@@ -164,7 +164,7 @@ LogBuffer::LogBuffer(LogObject *owner, LogBufferHeader *header)
 
   // update the buffer id (m_id gets the old value)
   //
-  m_id = (uint32_t)ink_atomic_increment((pvint32)&M_ID, 1);
+  m_id = (uint32_t)ink_atomic_increment((int32_t *)&M_ID, 1);
 
   Debug("log-logbuffer", "[%p] Created repurposed buffer %u for %s at address %p", this_ethread(), m_id,
         m_owner->get_base_filename(), m_buffer);

--- a/proxy/logging/LogBuffer.h
+++ b/proxy/logging/LogBuffer.h
@@ -97,9 +97,9 @@ struct LogBufferHeader {
 
 union LB_State {
   LB_State() : ival(0) {}
-  LB_State(volatile LB_State &vs) { ival = vs.ival; }
+  LB_State(LB_State &vs) { ival = vs.ival; }
   LB_State &
-  operator=(volatile LB_State &vs)
+  operator=(LB_State &vs)
   {
     ival = vs.ival;
     return *this;
@@ -183,7 +183,7 @@ public:
   LINK(LogBuffer, link);
 
   // static variables
-  static vint32 M_ID;
+  static int32_t M_ID;
 
   // static functions
   static size_t max_entry_bytes();
@@ -222,8 +222,8 @@ private:
 
   uint32_t m_id; // unique buffer id (for debugging)
 public:
-  volatile LB_State m_state; // buffer state
-  volatile int m_references; // oustanding checkout_write references.
+  LB_State m_state; // buffer state
+  int m_references; // oustanding checkout_write references.
 
   // noncopyable
   // -- member functions that are not allowed --

--- a/proxy/logging/LogObject.cc
+++ b/proxy/logging/LogObject.cc
@@ -361,7 +361,7 @@ LogObject::display(FILE *fd)
 }
 
 static head_p
-increment_pointer_version(volatile head_p *dst)
+increment_pointer_version(head_p *dst)
 {
   head_p h;
   head_p new_h;
@@ -375,7 +375,7 @@ increment_pointer_version(volatile head_p *dst)
 }
 
 static bool
-write_pointer_version(volatile head_p *dst, head_p old_h, void *ptr, head_p::version_type vers)
+write_pointer_version(head_p *dst, head_p old_h, void *ptr, head_p::version_type vers)
 {
   head_p tmp_h;
 

--- a/proxy/logging/LogObject.h
+++ b/proxy/logging/LogObject.h
@@ -294,7 +294,7 @@ private:
   long m_last_roll_time;   // the last time this object rolled
   // its files
 
-  volatile head_p m_log_buffer; // current work buffer
+  head_p m_log_buffer; // current work buffer
   unsigned m_buffer_manager_idx;
   LogBufferManager *m_buffer_manager;
 


### PR DESCRIPTION
I think we should remove `volatile` from our code. [Here is an article](https://software.intel.com/en-us/blogs/2007/11/30/volatile-almost-useless-for-multi-threaded-programming/) describing it's correct usage. It's entirely likely that this will mostly replace `ink_atomic` with `std::atomic` as most of the incorrect usage of `volatile` is around thread safety. I have marked this as WIP and plan to add commits over time. Please feel free to review the current progress or debate the issue entirely.