### PR TITLE
Eliminate symbolic link from proxy/http unit tests.

### DIFF
--- a/proxy/http/Makefile.am
+++ b/proxy/http/Makefile.am
@@ -92,7 +92,7 @@ test_ForwardedConfig_SOURCES = \
   unit-tests/test_ForwardedConfig.cc \
   ForwardedConfig.cc \
   unit-tests/test_ForwardedConfig_mocks.cc \
-  unit-tests/sym-links/MemView.cc
+  unit-tests/test_MemView.cc
 
 tidy-local: $(libhttp_a_SOURCES) $(noinst_HEADERS)
 	$(CXX_Clang_Tidy)

--- a/proxy/http/unit-tests/sym-links/MemView.cc
+++ b/proxy/http/unit-tests/sym-links/MemView.cc
@@ -1,1 +1,0 @@
-../../../../lib/ts/MemView.cc

--- a/proxy/http/unit-tests/test_MemView.cc
+++ b/proxy/http/unit-tests/test_MemView.cc
@@ -1,0 +1,24 @@
+/** @file
+
+  Include a needed TS lib source file to avoid mocking.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include <ts/MemView.cc>


### PR DESCRIPTION
This should have been in the Forwarded PR ( https://github.com/apache/trafficserver/pull/2446 ).