### PR TITLE
Fix mem leak related to do_os_response() function in ts_lua plugin

### DIFF
--- a/plugins/experimental/ts_lua/ts_lua.c
+++ b/plugins/experimental/ts_lua/ts_lua.c
@@ -194,6 +194,8 @@ ts_lua_remap_plugin_init(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
 
   lua_getglobal(L, (remap ? TS_LUA_FUNCTION_REMAP : TS_LUA_FUNCTION_OS_RESPONSE));
   if (lua_type(L, -1) != LUA_TFUNCTION) {
+    lua_pop(L, 1);
+    ts_lua_destroy_http_ctx(http_ctx);
     TSMutexUnlock(main_ctx->mutexp);
     return TSREMAP_NO_REMAP;
   }


### PR DESCRIPTION
The exit for this block is missing a few things needed to release the resources 
Those are things we are already doing when exiting the function in other execution path