### PR TITLE
Remove custom memory barriers from header_rewrite and replace with std::atomic

### DIFF
--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -25,6 +25,7 @@
 #include <cctype>
 #include <sstream>
 #include <array>
+#include <atomic>
 
 #include "ts/ts.h"
 
@@ -175,7 +176,7 @@ ConditionAccess::eval(const Resources & /* res ATS_UNUSED */)
     bool check = !access(_qualifier.c_str(), R_OK);
 
     tv.tv_sec += 2;
-    mb();
+    std::atomic_thread_fence(std::memory_order_seq_cst);
     _next = tv.tv_sec; // I hope this is an atomic "set"...
     _last = check;     // This sure ought to be
   }

--- a/plugins/header_rewrite/lulu.h
+++ b/plugins/header_rewrite/lulu.h
@@ -34,39 +34,6 @@ std::string getIP(sockaddr const *s_sockaddr);
 char *getIP(sockaddr const *s_sockaddr, char res[INET6_ADDRSTRLEN]);
 uint16_t getPort(sockaddr const *s_sockaddr);
 
-// Memory barriers
-#if defined(__i386__)
-#define mb() __asm__ __volatile__("lock; addl $0,0(%%esp)" : : : "memory")
-#define rmb() __asm__ __volatile__("lock; addl $0,0(%%esp)" : : : "memory")
-#define wmb() __asm__ __volatile__("" : : : "memory")
-#elif defined(__x86_64__)
-#define mb() __asm__ __volatile__("mfence" : : : "memory")
-#define rmb() __asm__ __volatile__("lfence" : : : "memory")
-#define wmb() __asm__ __volatile__("" : : : "memory")
-#elif defined(__mips__)
-#define mb() __asm__ __volatile__("sync" : : : "memory")
-#define rmb() __asm__ __volatile__("sync" : : : "memory")
-#define wmb() __asm__ __volatile__("" : : : "memory")
-#elif defined(__arm__)
-#define mb() __asm__ __volatile__("dmb" : : : "memory")
-#define rmb() __asm__ __volatile__("dmb" : : : "memory")
-#define wmb() __asm__ __volatile__("" : : : "memory")
-#elif defined(__mips__)
-#define mb() __asm__ __volatile__("sync" : : : "memory")
-#define rmb() __asm__ __volatile__("sync" : : : "memory")
-#define wmb() __asm__ __volatile__("" : : : "memory")
-#elif defined(__powerpc64__)
-#define mb() __asm__ __volatile__("sync" : : : "memory")
-#define rmb() __asm__ __volatile__("sync" : : : "memory")
-#define wmb() __asm__ __volatile__("sync" : : : "memory")
-#elif defined(__aarch64__)
-#define mb() __asm__ __volatile__("dsb sy" : : : "memory")
-#define rmb() __asm__ __volatile__("dsb ld" : : : "memory")
-#define wmb() __asm__ __volatile__("dsb st" : : : "memory")
-#else
-#error "Define barriers"
-#endif
-
 extern const char PLUGIN_NAME[];
 extern const char PLUGIN_NAME_DBG[];
 


### PR DESCRIPTION
I'm not exactly sure why this barrier is here, but this change produces the same assembly so I think we should at least make this change. If someone feels that the barrier is unneeded we can remove it altogether.