### PR TITLE
Coverity: 1381603 1381604 fix to traffic_layout on engine and file_system

### DIFF
--- a/README
+++ b/README
@@ -78,7 +78,7 @@ plugins to build large scale web applications.
     openssl-devel
     tcl-devel
     pcre-devel
-    ncurses-devel and libcurl-devl(optional, needed for traffic_top)
+    ncurses-devel and libcurl-devel(optional, needed for traffic_top)
     libcap-devel (optional, highly recommended)
     hwloc-devel (optional, highly recommended)
     flex (optional, needed for e.g. WCCP)

--- a/cmd/traffic_layout/engine.cc
+++ b/cmd/traffic_layout/engine.cc
@@ -200,7 +200,10 @@ clean_parent(const std::string &bin_path)
 {
   char cwd[MAX_CWD_LEN];
   getcwd(cwd, sizeof(cwd));
-  std::string RealBinPath = realpath(bin_path.c_str(), nullptr); // bin path
+
+  char resolved_binpath[MAX_CWD_LEN];
+  realpath(bin_path.c_str(), resolved_binpath); // bin path
+  std::string RealBinPath = resolved_binpath;
 
   std::vector<std::string> TwoPath = {RealBinPath, cwd};
   for (auto it : TwoPath) {

--- a/cmd/traffic_layout/file_system.cc
+++ b/cmd/traffic_layout/file_system.cc
@@ -164,7 +164,9 @@ copy_function(const char *src_path, const struct stat *sb, int flag)
       std::ifstream src(src_path, std::ios::binary);
       std::ofstream dst(dst_path, std::ios::binary);
       dst << src.rdbuf();
-      chmod(dst_path.c_str(), sb->st_mode);
+      if (chmod(dst_path.c_str(), sb->st_mode) == -1) {
+        ink_warning("failed chomd the destination path: %s", strerror(errno));
+      }
     }
   }
   return 0;


### PR DESCRIPTION
A coverity fix to the errors reported in the runroot functionality in traffic_layout. 
Modification in ``engine.cc`` and ``file_system.cc``.
And a small README document fix.
