### PR TITLE
Fix the declaration of the stub function for Forward check

### DIFF
--- a/proxy/http/unit-tests/test_ForwardedConfig_mocks.cc
+++ b/proxy/http/unit-tests/test_ForwardedConfig_mocks.cc
@@ -61,7 +61,7 @@ ink_freelist_free(InkFreeList *f, void *item){STUB} inkcoreapi
 void ink_mutex_destroy(pthread_mutex_t *){STUB} inkcoreapi ClassAllocator<ProxyMutex> mutexAllocator("ARGH");
 inkcoreapi ink_thread_key Thread::thread_data_key;
 int res_track_memory;
-void ResourceTracker::increment(const char *, long){STUB} inkcoreapi Allocator ioBufAllocator[DEFAULT_BUFFER_SIZES];
+void ResourceTracker::increment(const char *, const int64_t){STUB} inkcoreapi Allocator ioBufAllocator[DEFAULT_BUFFER_SIZES];
 void
 ats_free(void *)
 {


### PR DESCRIPTION
This restores the prototype that this test tries to mock.