### PR TITLE
Fixed issue with clean/distclean

### DIFF
--- a/proxy/http/Makefile.am
+++ b/proxy/http/Makefile.am
@@ -91,8 +91,10 @@ test_ForwardedConfig_CPPFLAGS = $(AM_CPPFLAGS)\
 test_ForwardedConfig_SOURCES = \
   unit-tests/test_ForwardedConfig.cc \
   ForwardedConfig.cc \
-  unit-tests/test_ForwardedConfig_mocks.cc \
-  ../../lib/ts/TextView.cc
+  unit-tests/test_ForwardedConfig_mocks.cc
+
+test_ForwardedConfig_LDADD = \
+  $(top_builddir)/lib/ts/libtsutil.la
 
 tidy-local: $(libhttp_a_SOURCES) $(noinst_HEADERS)
 	$(CXX_Clang_Tidy)


### PR DESCRIPTION
```
make[2]: Leaving directory '/home/bcall/dev/apache/trafficserver/proxy/congest'
Making distclean in http
make[2]: Entering directory '/home/bcall/dev/apache/trafficserver/proxy/http'
Makefile:979: ../../lib/ts/.deps/test_ForwardedConfig-TextView.Po: No such file or directory
make[2]: *** No rule to make target '../../lib/ts/.deps/test_ForwardedConfig-TextView.Po'.  Stop.
make[2]: Leaving directory '/home/bcall/dev/apache/trafficserver/proxy/http'
make[1]: *** [Makefile:1213: distclean-recursive] Error 1
make[1]: Leaving directory '/home/bcall/dev/apache/trafficserver/proxy'
make: *** [Makefile:840: distclean-recursive] Error 1
```