### PR TITLE
Stale-while-revalidate plugin cleanup for memory leak and high latency

### DIFF
--- a/doc/admin-guide/plugins/stale_while_revalidate.en.rst
+++ b/doc/admin-guide/plugins/stale_while_revalidate.en.rst
@@ -1,10 +1,3 @@
-.. _admin-plugins-tale-while-revalidate:
-
-Stale While Revalidate Plugin
-*****************************
-
-  :deprecated:
-
 .. Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
   distributed with this work for additional information
@@ -22,4 +15,45 @@ Stale While Revalidate Plugin
   specific language governing permissions and limitations
   under the License.
 
+.. _admin-plugins-stale-while-revalidate:
+
+  :deprecated:
+
+Stale While Revalidate Plugin
+=============================
+
+The `Stale While Revalidate` plugin implements two extensions to the
+`Cache-Control` header from `RFC 5861`_.
+
+Both of these extensions give a window of time whereby stale assets
+are allowed to be served with a Warning header line given that attempts
+are being made to refresh the content.  With a correct implementation
+a refresh can be successfully completed without a client request being
+slowed for its delay.
+
+From a client's perspective the plugin simply allows stale URLs to
+be delivered as cache-stored fresh URLs for a correctly determined amount
+of time.  Ideally a low-latency hit for any new URL content will quickly
+appear if those windows of time have passed.
+
+How it Works
+------------
+
+The plugin uses a global hook to detect client cache lookups that
+result in `TS_CACHE_LOOKUP_HIT_STALE`.  From there the plugin uses both
+configuration settings and the cached `Cache-Control` field to apply
+the policy to the cache.  The main task at first is to determine if the lookup
+can be changed to `TS_CACHE_LOOKUP_HIT_FRESH` under the rules of the
+current cached doc.
+
+1) stale-while-revalidate_
+
+
+
+2) stale-if-error_
+
 refresh content asynchronously while serving stale data
+
+.. _RFC 5861: https://tools.ietf.org/html/rfc5861
+.. _stale-while-revalidate: https://tools.ietf.org/html/rfc5861#section-3
+.. _stale-if-error: https://tools.ietf.org/html/rfc5861#section-4


### PR DESCRIPTION
Main changes are (1) to remove TSHttpTxnNewCacheLookupDo and repeated/counted lookups that result in races and a memory leak, (2) add an IMS header to detect (in plugin) a valid stale asset so the NewCacheLookupDo isn't needed and (3) use HEAD instead of GET to more quickly test for revalidation.

Some streamlining and removal of lots of old mallocs and more complex deps.