### PR TITLE
Add flag to ignore out of bounds compile error for test

### DIFF
--- a/lib/ts/Makefile.am
+++ b/lib/ts/Makefile.am
@@ -250,6 +250,7 @@ test_tslib_CPPFLAGS = $(AM_CPPFLAGS)\
 	-I$(abs_top_srcdir)/tests/include
 
 # add you catch based test file here for tslib
+test_tslib_CXXFLAGS = -Wno-array-bounds $(AM_CXXFLAGS)
 test_tslib_LDADD = libtsutil.la
 test_tslib_SOURCES = \
 	unit-tests/unit_test_main.cc \


### PR DESCRIPTION
Seeing this error with gcc7 when running make check:
```
./string_view.h: In function ‘void ____C_A_T_C_H____T_E_S_T____23()’:
./string_view.h:96:7: error: array subscript is below array bounds [-Werror=array-bounds]
       --m_ptr;
       ^~
./string_view.h:96:7: error: array subscript is below array bounds [-Werror=array-bounds]
       --m_ptr;
       ^~
```