### PR TITLE
CID 1196423: Error handling issues  (CHECKED_RETURN)

### DIFF
--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -323,7 +323,10 @@ TS_INLINE void
 UnixNetVConnection::set_local_addr()
 {
   int local_sa_size = sizeof(local_addr);
-  safe_getsockname(con.fd, &local_addr.sa, &local_sa_size);
+  // This call will fail if fd is closed already. That is ok, because the
+  // `local_addr` is checked within get_local_addr() and the `got_local_addr`
+  // is set only with a valid `local_addr`.
+  ATS_UNUSED_RETURN(safe_getsockname(con.fd, &local_addr.sa, &local_sa_size));
 }
 
 TS_INLINE ink_hrtime


### PR DESCRIPTION
```
** CID 1196423:  Error handling issues  (CHECKED_RETURN)
/iocore/net/P_UnixNetVConnection.h: 326 in UnixNetVConnection::set_local_addr()()


________________________________________________________________________________________________________
*** CID 1196423:  Error handling issues  (CHECKED_RETURN)
/iocore/net/P_UnixNetVConnection.h: 326 in UnixNetVConnection::set_local_addr()()
320     }
321
322     TS_INLINE void
323     UnixNetVConnection::set_local_addr()
324     {
325       int local_sa_size = sizeof(local_addr);
>>>     CID 1196423:  Error handling issues  (CHECKED_RETURN)
>>>     Calling "safe_getsockname" without checking return value (as is done elsewhere 7 out of 8 times).
326       safe_getsockname(con.fd, &local_addr.sa, &local_sa_size);
327     }
328
329     TS_INLINE ink_hrtime
330     UnixNetVConnection::get_active_timeout()
331     {
```