### PR TITLE
Replace uses of deprecated Lua APIs

### DIFF
--- a/lib/bindings/bindings.cc
+++ b/lib/bindings/bindings.cc
@@ -327,7 +327,7 @@ BindingInstance::typecheck(lua_State *lua, const char *name, ...)
 }
 
 void
-BindingInstance::register_metatable(lua_State *lua, const char *name, const luaL_reg *metatable)
+BindingInstance::register_metatable(lua_State *lua, const char *name, const luaL_Reg *metatable)
 {
   // Create a metatable, adding it to the Lua registry.
   luaL_newmetatable(lua, name);

--- a/lib/bindings/bindings.h
+++ b/lib/bindings/bindings.h
@@ -62,7 +62,7 @@ struct BindingInstance {
   static BindingInstance *self(lua_State *);
 
   // Register a Lua metatable for a custom type.
-  static void register_metatable(lua_State *, const char *, const luaL_reg *);
+  static void register_metatable(lua_State *, const char *, const luaL_Reg *);
 
   lua_State *lua;
 

--- a/lib/bindings/metrics.cc
+++ b/lib/bindings/metrics.cc
@@ -196,7 +196,7 @@ lua_metrics_new(const char *prefix, lua_State *L)
 void
 lua_metrics_register(lua_State *L)
 {
-  static const luaL_reg metatable[] = {
+  static const luaL_Reg metatable[] = {
     {"__gc", metrics_gc}, {"__index", metrics_index}, {"__newindex", metrics_newindex}, {nullptr, nullptr},
   };
 

--- a/proxy/logging/LogBindings.cc
+++ b/proxy/logging/LogBindings.cc
@@ -179,7 +179,7 @@ log_object_add_hosts(lua_State *L, LogObject *log, int value, bool top)
   if (lua_istable(L, value)) {
     lua_scoped_stack saved(L);
 
-    int count   = luaL_getn(L, value);
+    int count   = lua_objlen(L, value);
     LogHost *lh = nullptr;
 
     saved.push_value(value); // Push the table to -1.
@@ -257,7 +257,7 @@ log_object_add_filters(lua_State *L, LogObject *log, int value)
   if (lua_istable(L, value)) {
     lua_scoped_stack saved(L);
     LogFilter *filter;
-    int count = luaL_getn(L, value);
+    int count = lua_objlen(L, value);
 
     saved.push_value(value); // Push the table to -1.
 
@@ -391,7 +391,7 @@ create_pipe_log_object(lua_State *L)
 bool
 MakeLogBindings(BindingInstance &binding, LogConfig *conf)
 {
-  static const luaL_reg metatable[] = {
+  static const luaL_Reg metatable[] = {
     {"__gc", refcount_object_gc}, {nullptr, nullptr},
   };
 


### PR DESCRIPTION
`luaL_reg` and `luaL_getn` aren't in LuaJIT 2.1 beta3. This patch just does one part of what will eventually be needed to get TS running on ARM64.

`luaL_reg` isn't even mentioned in Lua 5.1 docs, and `luaL_getn` is marked deprecated and should be replaced with `lua_objlen`.