### PR TITLE
cachekey: ability to base the key on pristine URI.

### DIFF
--- a/doc/admin-guide/plugins/cachekey.en.rst
+++ b/doc/admin-guide/plugins/cachekey.en.rst
@@ -39,6 +39,13 @@ This plugin allows some common cache key manipulations based on various HTTP req
 * capture and replace strings from the URI and include them in the cache key
 * do more - please find more examples below.
 
+URI type
+========
+
+The plugin manipulates the ``remap`` URI (value set during URI remap) by default. If manipulation needs to be based on the ``pristine`` URI (the value before URI remapping takes place) one could use the following option:
+
+* ``--uri-type=[remap|pristine]`` (default: ``remap``)
+
 Cache key structure and related plugin parameters
 =================================================
 

--- a/plugins/experimental/cachekey/configs.cc
+++ b/plugins/experimental/cachekey/configs.cc
@@ -344,6 +344,7 @@ Configs::init(int argc, char *argv[])
     {const_cast<char *>("remove-prefix"), optional_argument, nullptr, 'q'},
     {const_cast<char *>("remove-path"), optional_argument, nullptr, 'r'},
     {const_cast<char *>("separator"), optional_argument, nullptr, 's'},
+    {const_cast<char *>("uri-type"), optional_argument, nullptr, 't'},
     {nullptr, 0, nullptr, 0},
   };
 
@@ -442,6 +443,9 @@ Configs::init(int argc, char *argv[])
     case 's': /* separator */
       setSeparator(optarg);
       break;
+    case 't': /* uri-type */
+      setUriType(optarg);
+      break;
     }
   }
 
@@ -485,4 +489,28 @@ const String &
 Configs::getSeparator()
 {
   return _separator;
+}
+
+void
+Configs::setUriType(const char *arg)
+{
+  if (nullptr != arg) {
+    if (5 == strlen(arg) && 0 == strncasecmp(arg, "remap", 5)) {
+      _uriType = CacheKeyUriType::REMAP;
+      CacheKeyDebug("using remap URI type");
+    } else if (8 == strlen(arg) && 0 == strncasecmp(arg, "pristine", 8)) {
+      _uriType = CacheKeyUriType::PRISTINE;
+      CacheKeyDebug("using pristine URI type");
+    } else {
+      CacheKeyError("unrecognized URI type '%s', using default 'remap'", arg);
+    }
+  } else {
+    CacheKeyError("found an empty URI type, using default 'remap'");
+  }
+}
+
+CacheKeyUriType
+Configs::getUriType()
+{
+  return _uriType;
 }

--- a/plugins/experimental/cachekey/configs.h
+++ b/plugins/experimental/cachekey/configs.h
@@ -27,6 +27,11 @@
 #include "pattern.h"
 #include "common.h"
 
+enum CacheKeyUriType {
+  REMAP,
+  PRISTINE,
+};
+
 /**
  * @brief Plug-in configuration elements (query / headers / cookies).
  *
@@ -122,7 +127,7 @@ private:
 class Configs
 {
 public:
-  Configs() : _prefixToBeRemoved(false), _pathToBeRemoved(false), _separator("/") {}
+  Configs() {}
   /**
    * @brief initializes plugin configuration.
    * @param argc number of plugin parameters
@@ -157,6 +162,16 @@ public:
    */
   const String &getSeparator();
 
+  /**
+   * @brief sets the URI Type.
+   */
+  void setUriType(const char *arg);
+
+  /**
+   * @brief get URI type.
+   */
+  CacheKeyUriType getUriType();
+
   /* Make the following members public to avoid unnecessary accessors */
   ConfigQuery _query;        /**< @brief query parameter related configuration */
   ConfigHeaders _headers;    /**< @brief headers related configuration */
@@ -178,9 +193,10 @@ private:
    */
   bool loadClassifiers(const String &args, bool blacklist = true);
 
-  bool _prefixToBeRemoved; /**< @brief instructs the prefix (i.e. host:port) not to added to the cache key */
-  bool _pathToBeRemoved;   /**< @brief instructs the path not to added to the cache key */
-  String _separator;       /**< @brief a separator used to separate the cache key elements extracted from the URI */
+  bool _prefixToBeRemoved  = false; /**< @brief instructs the prefix (i.e. host:port) not to added to the cache key */
+  bool _pathToBeRemoved    = false; /**< @brief instructs the path not to added to the cache key */
+  String _separator        = "/";   /**< @brief a separator used to separate the cache key elements extracted from the URI */
+  CacheKeyUriType _uriType = REMAP; /**< @brief shows which URI the cache key will be based on */
 };
 
 #endif // PLUGINS_EXPERIMENTAL_CACHEKEY_CONFIGS_H_


### PR DESCRIPTION
Added ability to base the cache key on the pristine URI rather then on the URI set during remap.

New option added (see plugin doc):
`--uri-type=[remap|pristine]` (default:`remap`)

In addition changed the `CacheKey` constructor to use in-class member initialization.