### PR TITLE
Fixed some code for runroot of traffic_layout and lib/ts/layout

### DIFF
--- a/cmd/traffic_layout/traffic_layout.cc
+++ b/cmd/traffic_layout/traffic_layout.cc
@@ -202,7 +202,6 @@ traffic_runroot(int argc, const char **argv)
 
   // start the runroot creating stuff
   std::string original_root = TS_BUILD_PREFIX;
-  append_slash(original_root);
 
   // setting up ts_runroot
   // Use passed in parameter, else use ENV variable
@@ -220,8 +219,7 @@ traffic_runroot(int argc, const char **argv)
 
   // handle the ts_runroot
   // ts runroot must be an accessible path
-  append_slash(ts_runroot);
-  std::ifstream check_file(ts_runroot + "runroot_path.yaml");
+  std::ifstream check_file(Layout::relative_to(ts_runroot, "runroot_path.yml"));
   if (check_file.good()) {
     // if the path already ts_runroot, use it
     ink_notice("Using existing TS_RUNROOT...");
@@ -236,14 +234,14 @@ traffic_runroot(int argc, const char **argv)
 
   // create and emit to yaml file the key value pairs of path
   std::ofstream yamlfile;
-  std::string yaml_path = ts_runroot + "runroot_path.yaml";
+  std::string yaml_path = Layout::relative_to(ts_runroot, "runroot_path.yml");
   yamlfile.open(yaml_path);
 
   for (auto it : engine.path_map) {
     // out put key value pairs of path
     yamlfile << it.first << ": " << it.second << std::endl;
   }
-  ink_notice("\nTS runroot initialized");
+  ink_notice("TS runroot initialized");
 
   return;
 }

--- a/lib/ts/Layout.cc
+++ b/lib/ts/Layout.cc
@@ -114,28 +114,24 @@ Layout::relative_to(char *buf, size_t bufsz, ts::string_view dir, ts::string_vie
 bool
 Layout::check_runroot()
 {
-  std::string yaml_path = {};
-
   if (getenv("USING_RUNROOT") == nullptr) {
     return false;
-  } else {
-    std::string env_path = getenv("USING_RUNROOT");
-    int len              = env_path.size();
-    if ((len + 1) > PATH_NAME_MAX) {
-      ink_fatal("TS_RUNROOT environment variable is too big: %d, max %d\n", len, PATH_NAME_MAX - 1);
-    }
-    std::ifstream file;
-    if (env_path.back() != '/') {
-      env_path.append("/");
-    }
-    yaml_path = env_path + "runroot_path.yaml";
-
-    file.open(yaml_path);
-    if (!file.good()) {
-      ink_warning("Bad env path, continue with default value");
-      return false;
-    }
   }
+
+  std::string env_path = getenv("USING_RUNROOT");
+  int len              = env_path.size();
+  if ((len + 1) > PATH_NAME_MAX) {
+    ink_fatal("TS_RUNROOT environment variable is too big: %d, max %d\n", len, PATH_NAME_MAX - 1);
+  }
+  std::ifstream file;
+  std::string yaml_path = layout_relative(env_path, "runroot_path.yml");
+
+  file.open(yaml_path);
+  if (!file.good()) {
+    ink_warning("Bad env path, continue with default value");
+    return false;
+  }
+
   std::ifstream yamlfile(yaml_path);
   std::unordered_map<std::string, std::string> runroot_map;
   std::string str;
@@ -143,23 +139,22 @@ Layout::check_runroot()
     int pos = str.find(':');
     runroot_map[str.substr(0, pos)] = str.substr(pos + 2);
   }
-  for (auto it : runroot_map) {
-    prefix        = runroot_map["prefix"];
-    exec_prefix   = runroot_map["exec_prefix"];
-    bindir        = runroot_map["bindir"];
-    sbindir       = runroot_map["sbindir"];
-    sysconfdir    = runroot_map["sysconfdir"];
-    datadir       = runroot_map["datadir"];
-    includedir    = runroot_map["includedir"];
-    libdir        = runroot_map["libdir"];
-    libexecdir    = runroot_map["libexecdir"];
-    localstatedir = runroot_map["localstatedir"];
-    runtimedir    = runroot_map["runtimedir"];
-    logdir        = runroot_map["logdir"];
-    mandir        = runroot_map["mandir"];
-    infodir       = runroot_map["infodir"];
-    cachedir      = runroot_map["cachedir"];
-  }
+
+  prefix        = runroot_map["prefix"];
+  exec_prefix   = runroot_map["exec_prefix"];
+  bindir        = runroot_map["bindir"];
+  sbindir       = runroot_map["sbindir"];
+  sysconfdir    = runroot_map["sysconfdir"];
+  datadir       = runroot_map["datadir"];
+  includedir    = runroot_map["includedir"];
+  libdir        = runroot_map["libdir"];
+  libexecdir    = runroot_map["libexecdir"];
+  localstatedir = runroot_map["localstatedir"];
+  runtimedir    = runroot_map["runtimedir"];
+  logdir        = runroot_map["logdir"];
+  mandir        = runroot_map["mandir"];
+  infodir       = runroot_map["infodir"];
+  cachedir      = runroot_map["cachedir"];
 
   // // for yaml lib operations
   // YAML::Node yamlfile = YAML::LoadFile(yaml_path);

--- a/lib/ts/runroot.cc
+++ b/lib/ts/runroot.cc
@@ -38,6 +38,7 @@ datadir, libexecdir, libdir, runtimedir, infodir, cachedir.
 */
 
 #include "ts/ink_error.h"
+#include "ts/I_Layout.h"
 #include "runroot.h"
 
 #include <vector>
@@ -54,16 +55,14 @@ check_parent_path(const std::string &path, bool json)
   if (whole_path.back() == '/')
     whole_path.pop_back();
 
-  while (whole_path != "") {
-    whole_path                   = whole_path.substr(0, whole_path.find_last_of("/"));
-    std::string parent_yaml_path = whole_path + "/runroot_path.yaml";
-    std::ifstream parent_check_file;
-    parent_check_file.open(parent_yaml_path);
-    if (parent_check_file.good()) {
-      if (!json)
-        ink_notice("using parent of bin/current working dir");
-      return whole_path;
-    }
+  whole_path                   = whole_path.substr(0, whole_path.find_last_of("/"));
+  std::string parent_yaml_path = Layout::relative_to(whole_path, "runroot_path.yml");
+  std::ifstream parent_check_file;
+  parent_check_file.open(parent_yaml_path);
+  if (parent_check_file.good()) {
+    if (!json)
+      ink_notice("using parent of bin/current working dir");
+    return whole_path;
   }
   return {};
 }
@@ -101,12 +100,8 @@ runroot_handler(const char **argv, bool json)
   prefix += "=";
   if (arg.substr(0, prefix.size()) == prefix) {
     std::ifstream yaml_checkfile;
-    std::string path = arg.substr(prefix.size(), arg.size() - 1);
-
-    if (path.back() != '/')
-      path.append("/");
-
-    std::string yaml_path = path + "runroot_path.yaml";
+    std::string path      = arg.substr(prefix.size(), arg.size() - 1);
+    std::string yaml_path = Layout::relative_to(path, "runroot_path.yml");
     yaml_checkfile.open(yaml_path);
     if (yaml_checkfile.good()) {
       if (!json)

--- a/tests/gold_tests/basic/runroot-layout.test.py
+++ b/tests/gold_tests/basic/runroot-layout.test.py
@@ -34,7 +34,7 @@ tr.Processes.Default.Command = "$ATS_BIN/traffic_layout --init " + path
 tr.Processes.Default.ReturnCode = 0
 d = tr.Disk.Directory(path)
 d.Exists = True
-f = tr.Disk.File(os.path.join(path, "runroot_path.yaml"))
+f = tr.Disk.File(os.path.join(path, "runroot_path.yml"))
 f.Exists = True
 
 # remove from pass in path
@@ -43,7 +43,7 @@ tr.Processes.Default.Command = "$ATS_BIN/traffic_layout --remove " + path
 tr.Processes.Default.ReturnCode = 0
 d = tr.Disk.Directory(path)
 d.Exists = False
-f = tr.Disk.File(os.path.join(path, "runroot_path.yaml"))
+f = tr.Disk.File(os.path.join(path, "runroot_path.yml"))
 f.Exists = False
 
 path += '/'
@@ -55,7 +55,7 @@ tr.Processes.Default.Command = "$ATS_BIN/traffic_layout --init"
 tr.Processes.Default.ReturnCode = 0
 d = tr.Disk.Directory(path)
 d.Exists = True
-f = tr.Disk.File(os.path.join(path, "runroot_path.yaml"))
+f = tr.Disk.File(os.path.join(path, "runroot_path.yml"))
 f.Exists = True
 
 #use env variable to remove
@@ -65,5 +65,5 @@ tr.Processes.Default.Command = "$ATS_BIN/traffic_layout --remove"
 tr.Processes.Default.ReturnCode = 0
 d = tr.Disk.Directory(path)
 d.Exists = False
-f = tr.Disk.File(os.path.join(path, "runroot_path.yaml"))
+f = tr.Disk.File(os.path.join(path, "runroot_path.yml"))
 f.Exists = False


### PR DESCRIPTION
1. Some code fix for runroot part of traffic_layout and lib/ts/layout.
This fix include some path join problem and some code structure.
.yaml extension are all changed to .yml for consistency.

2. Now check parent only check one level of parent path, not all the way down to root (``check_parent_path`` inside ``runroot.cc``)

@dragon512 