### PR TITLE
Script load speedup for ts_lua remap plugin 

### DIFF
--- a/plugins/experimental/ts_lua/ts_lua_util.h
+++ b/plugins/experimental/ts_lua/ts_lua_util.h
@@ -24,6 +24,9 @@
 int ts_lua_create_vm(ts_lua_main_ctx *arr, int n);
 void ts_lua_destroy_vm(ts_lua_main_ctx *arr, int n);
 
+ts_lua_instance_conf *ts_lua_script_registered(lua_State *L, char *script);
+void ts_lua_script_register(lua_State *L, char *script, ts_lua_instance_conf *conf);
+
 int ts_lua_add_module(ts_lua_instance_conf *conf, ts_lua_main_ctx *arr, int n, int argc, char *argv[], char *errbuf,
                       int errbuf_len);
 


### PR DESCRIPTION
Currently when there are over 1000 remap rules using the same lua script, it can take over 1 min for ATS to finish the start up. This patch is trying to do things a bit smarter and avoid loading the same script again on the lua VM for different remap rules. 

@pbchou can you please also review this? I think this is the feature you have been asking for.