### PR TITLE
malformed chunked responses will be cached under some terrible network circumstances

### DIFF
--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1520,11 +1520,15 @@ HttpTunnel::finish_all_internal(HttpTunnelProducer *p, bool chain)
       if (chain == true && c->self_producer) {
         chain_finish_all(c->self_producer);
       }
+      // add fixed code for caching incompleted chunked response case under some terrible network circumstances
+      if (c->vc_type == HT_HTTP_CLIENT && p->chunked_handler.truncation == true) {
+        consumer_handler(VC_EVENT_EOS, c);
+      }
       // The IO Core will not call us back if there
       //   is nothing to do.  Check to see if there is
       //   nothing to do and take the appripriate
       //   action
-      if (c->write_vio && c->write_vio->nbytes == c->write_vio->ndone) {
+      else if (c->write_vio && c->write_vio->nbytes == c->write_vio->ndone) {
         consumer_handler(VC_EVENT_WRITE_COMPLETE, c);
       }
     }


### PR DESCRIPTION
Recently we found some uncompleted chunked responses were cached and served on production ATS 5.3.2 and 6.2.1 which complained by our customers, we consider this also is a possible reason for such warnings "Document 6E175543E1C4B188B8DDD553EEF9862F truncated"  in diags.log.

If the original servers(OS) sent chunked response back to ATS under some terrible network circumstances, ATS couldn't receive a complete chunked data but it surprisedly cached the malformed response and then served from cache. 

I reviewed some source codes related to http tunnel and chunked in ATS, and later combined the following diags.log，I concluded that this is a bug which ATS couldn't handle VC_EVENT_EOS from original server correctly.
 
[Sep 27 19:06:44.734] Server {0x2acf89a19700} DEBUG: <HttpTunnel.cc:1106 (producer_handler)> (http_tunnel) [9698] producer_handler [http server VC_EVENT_EOS]
[Sep 27 19:06:44.734] Server {0x2acf89a19700} DEBUG: <HttpTunnel.cc:1041 (producer_handler_chunked)> (http_tunnel) [9698] producer_handler_chunked [http server VC_EVENT_EOS]
[Sep 27 19:06:44.734] Server {0x2acf89a19700} DEBUG: <HttpTunnel.cc:1146 (producer_handler)> (http_redirect) [HttpTunnel::producer_handler] enable_redirection: [1 0 0] event: 104
[Sep 27 19:06:44.734] Server {0x2acf89a19700} DEBUG: <HttpSM.cc:2846 (tunnel_handler_server)> (http) [9698] [&HttpSM::tunnel_handler_server, VC_EVENT_EOS]
[Sep 27 19:06:44.734] Server {0x2acf89a19700} DEBUG: <HttpSM.cc:2897 (tunnel_handler_server)> (http) [9698] [HttpSM::tunnel_handler_server] finishing HTTP tunnel
[Sep 27 19:06:44.734] Server {0x2acf89a19700} DEBUG: <HttpTunnel.cc:1306 (consumer_handler)> (http_tunnel) [9698] consumer_handler [cache write VC_EVENT_WRITE_COMPLETE]
[Sep 27 19:06:44.734] Server {0x2acf89a19700} DEBUG: <HttpSM.cc:3293 (tunnel_handler_cache_write)> (http) [9698] [&HttpSM::tunnel_handler_cache_write, VC_EVENT_WRITE_COMPLETE]
[Sep 27 19:06:44.734] Server {0x2acf89a19700} DEBUG: <HttpTunnel.cc:1306 (consumer_handler)> (http_tunnel) [9698] consumer_handler [user agent VC_EVENT_WRITE_COMPLETE]
[Sep 27 19:06:44.734] Server {0x2acf89a19700} DEBUG: <HttpSM.cc:3086 (tunnel_handler_ua)> (http) [9698] [&HttpSM::tunnel_handler_ua, VC_EVENT_WRITE_COMPLETE]
[Sep 27 19:06:44.734] Server {0x2acf89a19700} DEBUG: <HttpClientSession.cc:478 (release)> (http_cs) [9666] session released by sm [9698]
[Sep 27 19:06:44.734] Server {0x2acf89a19700} DEBUG: <HttpClientSession.cc:222 (do_io_write)> (http_cs) tcp_init_cwnd_set 1
[Sep 27 19:06:44.734] Server {0x2acf89a19700} DEBUG: <HttpClientSession.cc:507 (release)> (http_cs) [9666] initiating io for next header
[Sep 27 19:06:44.734] Server {0x2acf89a19700} DEBUG: <HttpServerSession.cc:121 (do_io_close)> (http_ss) [9436] session closing, netvc 0x2ad138012f00
[Sep 27 19:06:44.734] Server {0x2acf89a19700} DEBUG: <HttpSM.cc:2532 (main_handler)> (http) [9698] [HttpSM::main_handler, HTTP_TUNNEL_EVENT_DONE]
[Sep 27 19:06:44.734] Server {0x2acf89a19700} DEBUG: <HttpSM.cc:2785 (tunnel_handler)> (http) [9698] [&HttpSM::tunnel_handler, HTTP_TUNNEL_EVENT_DONE]
[Sep 27 19:06:44.734] Server {0x2acf89a19700} DEBUG: <HttpTunnel.cc:1669 (deallocate_redirect_postdata_buffers)> (http_redirect) [HttpTunnel::deallocate_postdata_copy_buffers]
[Sep 27 19:06:44.734] Server {0x2acf89a19700} DEBUG: <HttpTunnel.cc:1669 (deallocate_redirect_postdata_buffers)> (http_redirect) [HttpTunnel::deallocate_postdata_copy_buffers]
[Sep 27 19:06:44.734] Server {0x2acf89a19700} DEBUG: <HttpSM.cc:1376 (state_api_callout)> (http) [9698] calling plugin on hook TS_HTTP_TXN_CLOSE_HOOK at hook 0x2a99e30
[Sep 27 19:06:44.734] Server {0x2acf89a19700} DEBUG: <HttpSM.cc:1273 (state_api_callback)> (http) [9698] [&HttpSM::state_api_callback, HTTP_API_CONTINUE]
[Sep 27 19:06:44.734] Server {0x2acf89a19700} DEBUG: <HttpSM.cc:1313 (state_api_callout)> (http) [9698] [&HttpSM::state_api_callout, HTTP_API_CONTINUE]
[Sep 27 19:06:44.734] Server {0x2acf89a19700} DEBUG: <HttpSM.cc:482 (state_remove_from_list)> (http) [9698] [&HttpSM::state_remove_from_list, VC_EVENT_NONE]
[Sep 27 19:06:44.734] Server {0x2acf89a19700} DEBUG: <HttpSM.cc:6568 (kill_this)> (http_seq) [HttpSM::update_stats] Logging transaction
[Sep 27 19:06:44.734] Server {0x2acf89a19700} DEBUG: <HttpSM.cc:6595 (kill_this)> (http) [9698] deallocating sm

you can simulate this issue using limit speed and forced chunked response under a nginx source server with nginx.conf include the location block:

server {
	listen      80;
	server_name localhost;

	location ~ ^/test/ {
	 	expires 10d;
	 	root html;
	 	limit_rate 50K;
	 	more_set_headers "Content-Length:";
	}

	location / {
		root   html;
		index  index.html index.htm;
	}
	......
}

ATS listen on 18980 and nginx listen on 80 on the same machine, then you make a request for the following url:
curl -vx 127.0.0.1:18980 -o 1 'http://127.0.0.1/test/1.m3u8'
during the response process, you suddenly stop nginx and the response is interrupted, retry several times you can found the truncated chunked response was cached and served from cache by ATS.
