### PR TITLE
Fix #2700 - single nameserver failover in DNSHandler failover

### DIFF
--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -645,6 +645,8 @@ DNSHandler::failover()
     switch_named(name_server);
   } else {
     ip_text_buffer buff;
+    con[name_server].eio.stop();
+    con[name_server].close();
     Warning("failover: connection to DNS server %s lost, retrying", ats_ip_ntop(&ip.sa, buff, sizeof(buff)));
   }
 }


### PR DESCRIPTION
Added stop and close to else in failover to cleanup a single configured connection on failover.

This is a simple bug fix that really needs to go into 7.1.2, if at all possible.