### PR TITLE
Back port event loop changes from PR #2541

### DIFF
--- a/iocore/cluster/ClusterHandler.cc
+++ b/iocore/cluster/ClusterHandler.cc
@@ -2473,8 +2473,9 @@ ClusterHandler::mainClusterEvent(int event, Event *e)
     // Process deferred open_local requests
     /////////////////////////////////////////
     if (!on_stolen_thread) {
-      if (do_open_local_requests())
-        thread->signal_hook(thread);
+      if (do_open_local_requests()) {
+        thread->tail_cb->signalActivity();
+      }
     }
   }
 

--- a/iocore/cluster/ClusterProcessor.cc
+++ b/iocore/cluster/ClusterProcessor.cc
@@ -129,8 +129,9 @@ ClusterProcessor::internal_invoke_remote(ClusterHandler *ch, int cluster_fn, voi
 
       MUTEX_TRY_LOCK(lock, ch->mutex, tt);
       if (!lock.is_locked()) {
-        if (ch->thread && ch->thread->signal_hook)
-          ch->thread->signal_hook(ch->thread);
+        if (ch->thread) {
+          ch->thread->tail_cb->signalActivity();
+        }
         return 1;
       }
       if (steal)
@@ -259,8 +260,9 @@ ClusterProcessor::open_local(Continuation *cont, ClusterMachine * /* m ATS_UNUSE
     }
     vc->action_ = cont;
     ink_atomiclist_push(&ch->external_incoming_open_local, (void *)vc);
-    if (ch->thread && ch->thread->signal_hook)
-      ch->thread->signal_hook(ch->thread);
+    if (ch->thread) {
+      ch->thread->tail_cb->signalActivity();
+    }
     return CLUSTER_DELAYED_OPEN;
 
 #ifdef CLUSTER_THREAD_STEALING

--- a/iocore/eventsystem/P_UnixEThread.h
+++ b/iocore/eventsystem/P_UnixEThread.h
@@ -37,13 +37,6 @@
 const int DELAY_FOR_RETRY = HRTIME_MSECONDS(10);
 
 TS_INLINE Event *
-EThread::schedule_spawn(Continuation *cont)
-{
-  Event *e = EVENT_ALLOC(eventAllocator, this);
-  return schedule(e->init(cont, 0, 0));
-}
-
-TS_INLINE Event *
 EThread::schedule_imm(Continuation *cont, int callback_event, void *cookie)
 {
   Event *e          = ::eventAllocator.alloc();
@@ -156,6 +149,21 @@ EThread::schedule_local(Event *e)
   return e;
 }
 
+TS_INLINE Event *
+EThread::schedule_spawn(Continuation *c, int ev, void *cookie)
+{
+  ink_assert(this != this_ethread()); // really broken to call this from the same thread.
+  if (start_event)
+    free_event(start_event);
+  start_event          = EVENT_ALLOC(eventAllocator, this);
+  start_event->ethread = this;
+  start_event->mutex   = this->mutex;
+  start_event->init(c);
+  start_event->callback_event = ev;
+  start_event->cookie         = cookie;
+  return start_event;
+}
+
 TS_INLINE EThread *
 this_ethread()
 {
@@ -168,6 +176,12 @@ EThread::free_event(Event *e)
   ink_assert(!e->in_the_priority_queue && !e->in_the_prot_queue);
   e->mutex = nullptr;
   EVENT_FREE(e, eventAllocator, this);
+}
+
+TS_INLINE void
+EThread::set_tail_handler(LoopTailHandler *handler)
+{
+  ink_atomic_swap(&tail_cb, handler);
 }
 
 #endif /*_EThread_h_*/

--- a/iocore/eventsystem/ProtectedQueue.cc
+++ b/iocore/eventsystem/ProtectedQueue.cc
@@ -53,53 +53,9 @@ ProtectedQueue::enqueue(Event *e, bool fast_signal)
 
   if (was_empty) {
     EThread *inserting_thread = this_ethread();
-    // queue e->ethread in the list of threads to be signalled
     // inserting_thread == 0 means it is not a regular EThread
     if (inserting_thread != e_ethread) {
-      if (!inserting_thread || !inserting_thread->ethreads_to_be_signalled) {
-        signal();
-        if (fast_signal) {
-          if (e_ethread->signal_hook)
-            e_ethread->signal_hook(e_ethread);
-        }
-      } else {
-#ifdef EAGER_SIGNALLING
-        // Try to signal now and avoid deferred posting.
-        if (e_ethread->EventQueueExternal.try_signal())
-          return;
-#endif
-        if (fast_signal) {
-          if (e_ethread->signal_hook)
-            e_ethread->signal_hook(e_ethread);
-        }
-        int &t          = inserting_thread->n_ethreads_to_be_signalled;
-        EThread **sig_e = inserting_thread->ethreads_to_be_signalled;
-        if ((t + 1) >= eventProcessor.n_ethreads) {
-          // we have run out of room
-          if ((t + 1) == eventProcessor.n_ethreads) {
-            // convert to direct map, put each ethread (sig_e[i]) into
-            // the direct map loation: sig_e[sig_e[i]->id]
-            for (int i = 0; i < t; i++) {
-              EThread *cur = sig_e[i]; // put this ethread
-              while (cur) {
-                EThread *next = sig_e[cur->id]; // into this location
-                if (next == cur)
-                  break;
-                sig_e[cur->id] = cur;
-                cur            = next;
-              }
-              // if not overwritten
-              if (sig_e[i] && sig_e[i]->id != i)
-                sig_e[i] = nullptr;
-            }
-            t++;
-          }
-          // we have a direct map, insert this EThread
-          sig_e[e_ethread->id] = e_ethread;
-        } else
-          // insert into vector
-          sig_e[t++] = e_ethread;
-      }
+      e_ethread->tail_cb->signalActivity();
     }
   }
 }
@@ -113,23 +69,9 @@ flush_signals(EThread *thr)
     n = eventProcessor.n_ethreads; // MAX
   int i;
 
-// Since the lock is only there to prevent a race in ink_cond_timedwait
-// the lock is taken only for a short time, thus it is unlikely that
-// this code has any effect.
-#ifdef EAGER_SIGNALLING
-  for (i = 0; i < n; i++) {
-    // Try to signal as many threads as possible without blocking.
-    if (thr->ethreads_to_be_signalled[i]) {
-      if (thr->ethreads_to_be_signalled[i]->EventQueueExternal.try_signal())
-        thr->ethreads_to_be_signalled[i] = 0;
-    }
-  }
-#endif
   for (i = 0; i < n; i++) {
     if (thr->ethreads_to_be_signalled[i]) {
-      thr->ethreads_to_be_signalled[i]->EventQueueExternal.signal();
-      if (thr->ethreads_to_be_signalled[i]->signal_hook)
-        thr->ethreads_to_be_signalled[i]->signal_hook(thr->ethreads_to_be_signalled[i]);
+      thr->ethreads_to_be_signalled[i]->tail_cb->signalActivity();
       thr->ethreads_to_be_signalled[i] = nullptr;
     }
   }
@@ -140,17 +82,16 @@ void
 ProtectedQueue::dequeue_timed(ink_hrtime cur_time, ink_hrtime timeout, bool sleep)
 {
   (void)cur_time;
-  Event *e;
   if (sleep) {
-    ink_mutex_acquire(&lock);
-    if (INK_ATOMICLIST_EMPTY(al)) {
-      timespec ts = ink_hrtime_to_timespec(timeout);
-      ink_cond_timedwait(&might_have_data, &lock, &ts);
-    }
-    ink_mutex_release(&lock);
+    this->wait(timeout);
   }
+  this->dequeue_external();
+}
 
-  e = (Event *)ink_atomiclist_popall(&al);
+void
+ProtectedQueue::dequeue_external()
+{
+  Event *e = (Event *)ink_atomiclist_popall(&al);
   // invert the list, to preserve order
   SLL<Event, Event::Link_link> l, t;
   t.head = e;
@@ -165,4 +106,15 @@ ProtectedQueue::dequeue_timed(ink_hrtime cur_time, ink_hrtime timeout, bool slee
       eventAllocator.free(e);
     }
   }
+}
+
+void
+ProtectedQueue::wait(ink_hrtime timeout)
+{
+  ink_mutex_acquire(&lock);
+  if (INK_ATOMICLIST_EMPTY(al)) {
+    timespec ts = ink_hrtime_to_timespec(timeout);
+    ink_cond_timedwait(&might_have_data, &lock, &ts);
+  }
+  ink_mutex_release(&lock);
 }

--- a/iocore/eventsystem/UnixEThread.cc
+++ b/iocore/eventsystem/UnixEThread.cc
@@ -47,7 +47,6 @@ EThread::EThread()
     n_ethreads_to_be_signalled(0),
     id(NO_ETHREAD_ID),
     event_types(0),
-    signal_hook(nullptr),
     tt(REGULAR)
 {
   memset(thread_private, 0, PER_THREAD_DATA);
@@ -59,7 +58,6 @@ EThread::EThread(ThreadType att, int anid)
     n_ethreads_to_be_signalled(0),
     id(anid),
     event_types(0),
-    signal_hook(nullptr),
     tt(att),
     server_session_pool(nullptr)
 {
@@ -95,7 +93,6 @@ EThread::EThread(ThreadType att, Event *e)
     n_ethreads_to_be_signalled(0),
     id(NO_ETHREAD_ID),
     event_types(0),
-    signal_hook(nullptr),
     tt(att),
     oneevent(e)
 {
@@ -161,6 +158,97 @@ EThread::process_event(Event *e, int calling_code)
   }
 }
 
+void EThread::process_queue(Que(Event, link) * NegativeQueue)
+{
+  Event *e;
+
+  // Move events from the external thread safe queues to the local queue.
+  EventQueueExternal.dequeue_external();
+
+  // execute all the available external events that have
+  // already been dequeued
+  while ((e = EventQueueExternal.dequeue_local())) {
+    if (e->cancelled) {
+      free_event(e);
+    } else if (!e->timeout_at) { // IMMEDIATE
+      ink_assert(e->period == 0);
+      process_event(e, e->callback_event);
+    } else if (e->timeout_at > 0) { // INTERVAL
+      EventQueue.enqueue(e, cur_time);
+    } else { // NEGATIVE
+      Event *p = nullptr;
+      Event *a = NegativeQueue->head;
+      while (a && a->timeout_at > e->timeout_at) {
+        p = a;
+        a = a->link.next;
+      }
+      if (!a) {
+        NegativeQueue->enqueue(e);
+      } else {
+        NegativeQueue->insert(e, p);
+      }
+    }
+  }
+}
+
+void
+EThread::execute_regular()
+{
+  Event *e;
+  Que(Event, link) NegativeQueue;
+  ink_hrtime next_time = 0;
+
+  // give priority to immediate events
+  for (;;) {
+    if (unlikely(shutdown_event_system == true)) {
+      return;
+    }
+
+    process_queue(&NegativeQueue);
+
+    bool done_one;
+    do {
+      done_one = false;
+      // execute all the eligible internal events
+      EventQueue.check_ready(cur_time, this);
+      while ((e = EventQueue.dequeue_ready(cur_time))) {
+        ink_assert(e);
+        ink_assert(e->timeout_at > 0);
+        if (e->cancelled)
+          free_event(e);
+        else {
+          done_one = true;
+          process_event(e, e->callback_event);
+        }
+      }
+    } while (done_one);
+
+    // execute any negative (poll) events
+    if (NegativeQueue.head) {
+      process_queue(&NegativeQueue);
+
+      // execute poll events
+      while ((e = NegativeQueue.dequeue())) {
+        process_event(e, EVENT_POLL);
+      }
+    }
+
+    next_time             = EventQueue.earliest_timeout();
+    ink_hrtime sleep_time = next_time - Thread::get_hrtime_updated();
+    if (sleep_time > 0) {
+      sleep_time = std::min(sleep_time, HRTIME_MSECONDS(THREAD_MAX_HEARTBEAT_MSECONDS));
+    } else {
+      sleep_time = 0;
+    }
+
+    if (n_ethreads_to_be_signalled) {
+      flush_signals(this);
+    }
+
+    tail_cb->waitForActivity(sleep_time);
+  }
+}
+
 //
 // void  EThread::execute()
 //
@@ -175,116 +263,20 @@ EThread::process_event(Event *e, int calling_code)
 void
 EThread::execute()
 {
+  // Do the start event first.
+  // coverity[lock]
+  if (start_event) {
+    MUTEX_TAKE_LOCK_FOR(start_event->mutex, this, start_event->continuation);
+    start_event->continuation->handleEvent(EVENT_IMMEDIATE, start_event);
+    MUTEX_UNTAKE_LOCK(start_event->mutex, this);
+    free_event(start_event);
+    start_event = nullptr;
+  }
+
   switch (tt) {
   case REGULAR: {
-    Event *e;
-    Que(Event, link) NegativeQueue;
-    ink_hrtime next_time = 0;
-
-    // give priority to immediate events
-    for (;;) {
-      if (unlikely(shutdown_event_system == true)) {
-        return;
-      }
-      // execute all the available external events that have
-      // already been dequeued
-      cur_time = Thread::get_hrtime_updated();
-      while ((e = EventQueueExternal.dequeue_local())) {
-        if (e->cancelled)
-          free_event(e);
-        else if (!e->timeout_at) { // IMMEDIATE
-          ink_assert(e->period == 0);
-          process_event(e, e->callback_event);
-        } else if (e->timeout_at > 0) // INTERVAL
-          EventQueue.enqueue(e, cur_time);
-        else { // NEGATIVE
-          Event *p = nullptr;
-          Event *a = NegativeQueue.head;
-          while (a && a->timeout_at > e->timeout_at) {
-            p = a;
-            a = a->link.next;
-          }
-          if (!a)
-            NegativeQueue.enqueue(e);
-          else
-            NegativeQueue.insert(e, p);
-        }
-      }
-      bool done_one;
-      do {
-        done_one = false;
-        // execute all the eligible internal events
-        EventQueue.check_ready(cur_time, this);
-        while ((e = EventQueue.dequeue_ready(cur_time))) {
-          ink_assert(e);
-          ink_assert(e->timeout_at > 0);
-          if (e->cancelled)
-            free_event(e);
-          else {
-            done_one = true;
-            process_event(e, e->callback_event);
-          }
-        }
-      } while (done_one);
-      // execute any negative (poll) events
-      if (NegativeQueue.head) {
-        if (n_ethreads_to_be_signalled)
-          flush_signals(this);
-        // dequeue all the external events and put them in a local
-        // queue. If there are no external events available, don't
-        // do a cond_timedwait.
-        if (!INK_ATOMICLIST_EMPTY(EventQueueExternal.al))
-          EventQueueExternal.dequeue_timed(cur_time, next_time, false);
-        while ((e = EventQueueExternal.dequeue_local())) {
-          if (!e->timeout_at)
-            process_event(e, e->callback_event);
-          else {
-            if (e->cancelled)
-              free_event(e);
-            else {
-              // If its a negative event, it must be a result of
-              // a negative event, which has been turned into a
-              // timed-event (because of a missed lock), executed
-              // before the poll. So, it must
-              // be executed in this round (because you can't have
-              // more than one poll between two executions of a
-              // negative event)
-              if (e->timeout_at < 0) {
-                Event *p = nullptr;
-                Event *a = NegativeQueue.head;
-                while (a && a->timeout_at > e->timeout_at) {
-                  p = a;
-                  a = a->link.next;
-                }
-                if (!a)
-                  NegativeQueue.enqueue(e);
-                else
-                  NegativeQueue.insert(e, p);
-              } else
-                EventQueue.enqueue(e, cur_time);
-            }
-          }
-        }
-        // execute poll events
-        while ((e = NegativeQueue.dequeue()))
-          process_event(e, EVENT_POLL);
-        if (!INK_ATOMICLIST_EMPTY(EventQueueExternal.al))
-          EventQueueExternal.dequeue_timed(cur_time, next_time, false);
-      } else { // Means there are no negative events
-        next_time             = EventQueue.earliest_timeout();
-        ink_hrtime sleep_time = next_time - cur_time;
-
-        if (sleep_time > THREAD_MAX_HEARTBEAT_MSECONDS * HRTIME_MSECOND) {
-          next_time = cur_time + THREAD_MAX_HEARTBEAT_MSECONDS * HRTIME_MSECOND;
-        }
-        // dequeue all the external events and put them in a local
-        // queue. If there are no external events available, do a
-        // cond_timedwait.
-        if (n_ethreads_to_be_signalled)
-          flush_signals(this);
-        EventQueueExternal.dequeue_timed(cur_time, next_time, true);
-      }
-    }
+    this->execute_regular();
+    break;
   }
 
   case DEDICATED: {

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -858,8 +858,8 @@ UnixNetVConnection::reenable(VIO *vio)
           nh->write_enable_list.push(this);
         }
       }
-      if (nh->trigger_event && nh->trigger_event->ethread->signal_hook)
-        nh->trigger_event->ethread->signal_hook(nh->trigger_event->ethread);
+      if (nh->trigger_event)
+        nh->trigger_event->ethread->tail_cb->signalActivity();
     } else {
       if (vio == &read.vio) {
         ep.modify(EVENTIO_READ);


### PR DESCRIPTION
removed unnecessary defines

moved to class initializer

removed metrics collection

extracted externel queue processing code into new method

use std::min instead of just min

bug fix

remove unnecessary arg

(cherry picked from commit c7fa901358ac2b70930dbdd415fbfb1c2e34a238)