### PR TITLE
Save errno ASAP within SSLNetVConnection methods

### DIFF
--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -135,8 +135,8 @@ void SSLReleaseContext(SSL_CTX *ctx);
 // Wrapper functions to SSL I/O routines
 ssl_error_t SSLWriteBuffer(SSL *ssl, const void *buf, int64_t nbytes, int64_t &nwritten);
 ssl_error_t SSLReadBuffer(SSL *ssl, void *buf, int64_t nbytes, int64_t &nread);
-ssl_error_t SSLAccept(SSL *ssl);
-ssl_error_t SSLConnect(SSL *ssl);
+ssl_error_t SSLAccept(SSL *ssl, int &err);
+ssl_error_t SSLConnect(SSL *ssl, int &err);
 
 // Log an SSL error.
 #define SSLError(fmt, ...) SSLDiagnostic(MakeSourceLocation(), false, nullptr, fmt, ##__VA_ARGS__)

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -2223,6 +2223,7 @@ SSLWriteBuffer(SSL *ssl, const void *buf, int64_t nbytes, int64_t &nwritten)
     }
     return SSL_ERROR_NONE;
   }
+  nwritten      = -errno;
   int ssl_error = SSL_get_error(ssl, ret);
   if (ssl_error == SSL_ERROR_SSL && is_debug_tag_set("ssl.error.write")) {
     char buf[512];
@@ -2247,6 +2248,11 @@ SSLReadBuffer(SSL *ssl, void *buf, int64_t nbytes, int64_t &nread)
     nread = ret;
     return SSL_ERROR_NONE;
   }
+  if (ret == 0) { // EOS or shutdown
+    nread = 0;
+    return SSL_ERROR_ZERO_RETURN;
+  }
+  nread         = -errno;
   int ssl_error = SSL_get_error(ssl, ret);
   if (ssl_error == SSL_ERROR_SSL && is_debug_tag_set("ssl.error.read")) {
     char buf[512];
@@ -2259,10 +2265,11 @@ SSLReadBuffer(SSL *ssl, void *buf, int64_t nbytes, int64_t &nread)
 }
 
 ssl_error_t
-SSLAccept(SSL *ssl)
+SSLAccept(SSL *ssl, int &err)
 {
   ERR_clear_error();
   int ret = SSL_accept(ssl);
+  err     = errno;
   if (ret > 0) {
     return SSL_ERROR_NONE;
   }
@@ -2278,10 +2285,11 @@ SSLAccept(SSL *ssl)
 }
 
 ssl_error_t
-SSLConnect(SSL *ssl)
+SSLConnect(SSL *ssl, int &err)
 {
   ERR_clear_error();
   int ret = SSL_connect(ssl);
+  err     = errno;
   if (ret > 0) {
     return SSL_ERROR_NONE;
   }


### PR DESCRIPTION
    The `errno' may be overwritted within the wrapper function: SSLAccept,
    SSLConnect, SSLReadBuffer and SSLWriteBuffer.
    
    And also occurred within ssl_read_from_net and load_buffer_and_write.