### PR TITLE
Set ua_session of Http2ConnectionState nullptr when ua_session is freed

### DIFF
--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -147,6 +147,7 @@ public:
     ats_free(continued_buffer.iov_base);
 
     delete dependency_tree;
+    this->ua_session = nullptr;
   }
 
   // Event handlers


### PR DESCRIPTION
There're some race of freeing Http2ClientSession vs  freeing Http2ConnectionState.
`Http2ConnectionState::destroy()` is called from `Http2ClientSession::free()` and when it called, `ua_session` should be set `nullptr`.
This could be fix #2711 