### PR TITLE
Rework the new udp connection

### DIFF
--- a/iocore/net/P_UDPNet.h
+++ b/iocore/net/P_UDPNet.h
@@ -31,6 +31,7 @@
 #ifndef __P_UDPNET_H_
 #define __P_UDPNET_H_
 
+#include "ts/ink_platform.h"
 #include "I_UDPNet.h"
 #include "P_UDPPacket.h"
 
@@ -40,7 +41,7 @@ static inline PollCont *get_UDPPollCont(EThread *);
 #include "P_UnixUDPConnection.h"
 #include "P_UDPIOEvent.h"
 
-struct UDPNetHandler;
+class UDPNetHandler;
 
 struct UDPNetProcessorInternal : public UDPNetProcessor {
   virtual int start(int n_udp_threads, size_t stacksize);
@@ -303,19 +304,21 @@ public:
 
 void initialize_thread_for_udp_net(EThread *thread);
 
-struct UDPNetHandler : public Continuation {
+class UDPNetHandler : public Continuation
+{
 public:
-  // to be polled for read
-  Que(UnixUDPConnection, polling_link) udp_polling;
+  // engine for outgoing packets
+  UDPQueue udpOutQueue{};
+
+  // New UDPConnections
+  // to hold the newly created descriptors before scheduling them on the servicing buckets.
+  // atomically added to by a thread creating a new connection with UDPBind
+  ASLL(UnixUDPConnection, newconn_alink) newconn_list;
+  // All opened UDPConnections
+  Que(UnixUDPConnection, link) open_list;
   // to be called back with data
   Que(UnixUDPConnection, callback_link) udp_callbacks;
-  // outgoing packets
-  UDPQueue udpOutQueue{};
-  // to hold the newly created descriptors before scheduling them on
-  // the servicing buckets.
-  // atomically added to by a thread creating a new connection with
-  // UDPBind
-  InkAtomicList udpNewConnections;
+
   Event *trigger_event = nullptr;
   ink_hrtime nextCheck;
   ink_hrtime lastCheck;

--- a/iocore/net/P_UnixUDPConnection.h
+++ b/iocore/net/P_UnixUDPConnection.h
@@ -42,9 +42,8 @@ public:
   void errorAndDie(int e);
   int callbackHandler(int event, void *data);
 
-  LINK(UnixUDPConnection, polling_link);
-  LINK(UnixUDPConnection, callback_link);
   SLINK(UnixUDPConnection, newconn_alink);
+  LINK(UnixUDPConnection, callback_link);
 
   // Incoming UDP Packet Queue
   ASLL(UDPPacketInternal, alink) inQueue;

--- a/iocore/net/UnixUDPConnection.cc
+++ b/iocore/net/UnixUDPConnection.cc
@@ -109,7 +109,7 @@ UDPConnection::bindToThread(Continuation *c)
   AddRef();
   uc->continuation = c;
   mutex            = c->mutex;
-  ink_atomiclist_push(&get_UDPNetHandler(t)->udpNewConnections, uc);
+  get_UDPNetHandler(t)->newconn_list.push(uc);
 }
 
 Action *
@@ -145,8 +145,8 @@ UDPConnection::Release()
   if (ink_atomic_increment(&p->refcount, -1) == 1) {
     ink_assert(p->callback_link.next == nullptr);
     ink_assert(p->callback_link.prev == nullptr);
-    ink_assert(p->polling_link.next == nullptr);
-    ink_assert(p->polling_link.prev == nullptr);
+    ink_assert(p->link.next == nullptr);
+    ink_assert(p->link.prev == nullptr);
     ink_assert(p->newconn_alink.next == nullptr);
 
     delete this;


### PR DESCRIPTION
The UDPNetHandler works like the NetHandler. But it is free lock to
push a UDPConnection into UDPNetHandler.
The UDPNetHandler gets new UDPConnection from newconn_list (an atomic
list) and push into open_list that saved all opend udp connections.

There is no InactivityCop for UDPConnection. The open_list is traversal
within UDPNetHandler::mainNetEvent() every second.