### PR TITLE
Prevent releasing streams simultaneously

### DIFF
--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -272,7 +272,11 @@ Http2ClientSession::do_io_close(int alerrno)
     client_vc->do_io_close();
     client_vc = nullptr;
   }
-  this->connection_state.release_stream(nullptr);
+
+  {
+    SCOPED_MUTEX_LOCK(lock, this->connection_state.mutex, this_ethread());
+    this->connection_state.release_stream(nullptr);
+  }
 }
 
 void

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -667,6 +667,7 @@ Http2Stream::destroy()
     // release_stream and delete_stream indirectly call each other and seem to have a lot of commonality
     // Should get resolved at somepoint.
     Http2ClientSession *h2_parent = static_cast<Http2ClientSession *>(parent);
+    SCOPED_MUTEX_LOCK(lock, h2_parent->connection_state.mutex, this_ethread());
     h2_parent->connection_state.release_stream(this);
 
     // Current Http2ConnectionState implementation uses a memory pool for instantiating streams and DLL<> stream_list for storing


### PR DESCRIPTION
I couldn't reproduce #2711 but `release_stream()` can be ran simultaneously due to lack of acquiring a lock for a connection state, and it should cause the BAD_ACCESS after a null check.

~This is the only place~ These are the only places calling `release_stream()` without the lock.

I think this should be back ported to 7.1.x.