### PR TITLE
Remove all references to TS_USE_TLS_SNI.

### DIFF
--- a/build/crypto.m4
+++ b/build/crypto.m4
@@ -119,14 +119,13 @@ AC_DEFUN([TS_CHECK_CRYPTO_SNI], [
     enable_tls_sni=no
   ])
 
-  AC_CHECK_FUNCS(SSL_get_servername, [], [enable_tls_sni=no])
+  AC_CHECK_FUNCS(SSL_get_servername, [], [enable_tls_sni])
 
   LIBS=$_sni_saved_LIBS
 
   AC_MSG_CHECKING(whether to enable ServerNameIndication TLS extension support)
   AC_MSG_RESULT([$enable_tls_sni])
   TS_ARG_ENABLE_VAR([use], [tls-sni])
-  AC_SUBST(use_tls_sni)
 ])
 
 AC_DEFUN([TS_CHECK_CRYPTO_CERT_CB], [

--- a/cmd/traffic_layout/info.cc
+++ b/cmd/traffic_layout/info.cc
@@ -85,7 +85,6 @@ produce_features(bool json)
   print_feature("TS_USE_HWLOC", TS_USE_HWLOC, json);
   print_feature("TS_USE_TLS_NPN", TS_USE_TLS_NPN, json);
   print_feature("TS_USE_TLS_ALPN", TS_USE_TLS_ALPN, json);
-  print_feature("TS_USE_TLS_SNI", TS_USE_TLS_SNI, json);
   print_feature("TS_USE_CERT_CB", TS_USE_CERT_CB, json);
   print_feature("TS_USE_SET_RBIO", TS_USE_SET_RBIO, json);
   print_feature("TS_USE_TLS_ECKEY", TS_USE_TLS_ECKEY, json);

--- a/configure.ac
+++ b/configure.ac
@@ -1135,10 +1135,6 @@ TS_CHECK_CRYPTO_ALPN
 TS_CHECK_CRYPTO_EC_KEYS
 
 #
-# Check for ServerNameIndication TLS extension support.
-TS_CHECK_CRYPTO_SNI
-
-#
 # Check for the presense of the certificate callback in the ssl library
 TS_CHECK_CRYPTO_CERT_CB
 

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3339,9 +3339,7 @@ SSL Termination
 
 .. ts:cv:: CONFIG proxy.config.ssl.wire_trace_server_name STRING NULL
 
-   This specifies the server name for which wire_traces should be
-   printed. This only works if traffic_server is built with
-   TS_USE_TLS_SNI flag set to true.
+   This specifies the server name for which wire_traces should be printed.
 
 Client-Related Configuration
 ----------------------------

--- a/doc/locale/ja/LC_MESSAGES/admin-guide/files/records.config.en.po
+++ b/doc/locale/ja/LC_MESSAGES/admin-guide/files/records.config.en.po
@@ -4830,9 +4830,7 @@ msgstr ""
 
 #: ../../../admin-guide/files/records.config.en.rst:3117
 msgid ""
-"This specifies the server name for which wire_traces should be printed. "
-"This only works if traffic_server is built with TS_USE_TLS_SNI flag set to "
-"true."
+"This specifies the server name for which wire_traces should be printed."
 msgstr ""
 
 #: ../../../admin-guide/files/records.config.en.rst:3122

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -317,7 +317,6 @@ ssl_rm_cached_session(SSL_CTX *ctx, SSL_SESSION *sess)
   session_cache->removeSession(sid);
 }
 
-#if TS_USE_TLS_SNI
 int
 set_context_cert(SSL *ssl)
 {
@@ -330,7 +329,6 @@ set_context_cert(SSL *ssl)
   int retval               = 1;
 
   Debug("ssl", "set_context_cert ssl=%p server=%s handshake_complete=%d", ssl, servername, netvc->getSSLHandShakeComplete());
-  // set SSL trace (we do this a little later in the USE_TLS_SNI case so we can get the servername
   if (SSLConfigParams::ssl_wire_trace_enabled) {
     bool trace = netvc->computeSSLTrace();
     Debug("ssl", "sslnetvc. setting trace to=%s", trace ? "true" : "false");
@@ -495,7 +493,6 @@ done:
   return retval;
 }
 #endif
-#endif /* TS_USE_TLS_SNI */
 
 #if TS_USE_GET_DH_2048_256 == 0
 /* Build 2048-bit MODP Group with 256-bit Prime Order Subgroup from RFC 5114 */
@@ -1492,14 +1489,12 @@ ssl_callback_info(const SSL *ssl, int where, int ret)
 static void
 ssl_set_handshake_callbacks(SSL_CTX *ctx)
 {
-#if TS_USE_TLS_SNI
 // Make sure the callbacks are set
 #if TS_USE_CERT_CB
   SSL_CTX_set_cert_cb(ctx, ssl_cert_callback, nullptr);
   SSL_CTX_set_tlsext_servername_callback(ctx, ssl_servername_only_callback);
 #else
   SSL_CTX_set_tlsext_servername_callback(ctx, ssl_servername_and_cert_callback);
-#endif
 #endif
 }
 

--- a/lib/ts/ink_config.h.in
+++ b/lib/ts/ink_config.h.in
@@ -70,7 +70,6 @@
 #define TS_USE_HWLOC @use_hwloc@
 #define TS_USE_TLS_NPN @use_tls_npn@
 #define TS_USE_TLS_ALPN @use_tls_alpn@
-#define TS_USE_TLS_SNI @use_tls_sni@
 #define TS_USE_CERT_CB @use_cert_cb@
 #define TS_USE_SET_RBIO @use_set_rbio@
 #define TS_USE_GET_DH_2048_256 @use_dh_get_2048_256@

--- a/plugins/experimental/ssl_cert_loader/ssl-cert-loader.cc
+++ b/plugins/experimental/ssl_cert_loader/ssl-cert-loader.cc
@@ -43,8 +43,6 @@ using ts::config::Value;
 #define PN "ssl-cert-loader"
 #define PCP "[" PN " Plugin] "
 
-#if TS_USE_TLS_SNI
-
 namespace
 {
 class CertLookup
@@ -547,13 +545,3 @@ TSPluginInit(int argc, const char *argv[])
 
   return;
 }
-
-#else // ! TS_USE_TLS_SNI
-
-void
-TSPluginInit(int, const char *[])
-{
-  TSError(PCP "requires TLS SNI which is not available");
-}
-
-#endif // TS_USE_TLS_SNI

--- a/tests/README.md
+++ b/tests/README.md
@@ -295,7 +295,6 @@ ts.Disk.remap_config.AddLine(
  * TS_USE_HWLOC
  * TS_USE_TLS_NPN
  * TS_USE_TLS_ALPN
- * TS_USE_TLS_SNI
  * TS_USE_CERT_CB
  * TS_USE_SET_RBIO
  * TS_USE_TLS_ECKEY


### PR DESCRIPTION
ATS 7.X and on don't support versions of openSSL that don't have SNI.

Fixes #2431

Signed-off-by: David Calavera <david.calavera@gmail.com>