### PR TITLE
Include cstring to make the compiler stop complaining about strlen

### DIFF
--- a/plugins/experimental/cachekey/configs.cc
+++ b/plugins/experimental/cachekey/configs.cc
@@ -25,6 +25,7 @@
 #include <sstream>   /* std::istringstream */
 #include <getopt.h>  /* getopt_long() */
 #include <strings.h> /* strncasecmp() */
+#include <cstring>   /* strlen() */
 
 #include "configs.h"
 


### PR DESCRIPTION
bug fix for cachekey, issue #2715