### PR TITLE
TS-5057: Add 103 Early Hints support

### DIFF
--- a/doc/developer-guide/api/types/TSHttpStatus.en.rst
+++ b/doc/developer-guide/api/types/TSHttpStatus.en.rst
@@ -47,6 +47,8 @@ Enumeration Members
 
 .. c:member:: TSHttpStatus TS_HTTP_STATUS_SWITCHING_PROTOCOL
 
+.. c:member:: TSHttpStatus TS_HTTP_STATUS_EARLY_HINTS
+
 .. c:member:: TSHttpStatus TS_HTTP_STATUS_OK
 
 .. c:member:: TSHttpStatus TS_HTTP_STATUS_CREATED

--- a/lib/cppapi/include/atscppapi/HttpStatus.h
+++ b/lib/cppapi/include/atscppapi/HttpStatus.h
@@ -37,6 +37,7 @@ enum HttpStatus {
 
   HTTP_STATUS_CONTINUE           = 100,
   HTTP_STATUS_SWITCHING_PROTOCOL = 101,
+  HTTP_STATUS_EARLY_HINTS        = 103,
 
   HTTP_STATUS_OK                            = 200,
   HTTP_STATUS_CREATED                       = 201,

--- a/lib/ts/apidefs.h.in
+++ b/lib/ts/apidefs.h.in
@@ -155,6 +155,7 @@ typedef enum {
   TS_HTTP_STATUS_NONE                            = 0,
   TS_HTTP_STATUS_CONTINUE                        = 100,
   TS_HTTP_STATUS_SWITCHING_PROTOCOL              = 101,
+  TS_HTTP_STATUS_EARLY_HINTS                     = 103,
   TS_HTTP_STATUS_OK                              = 200,
   TS_HTTP_STATUS_CREATED                         = 201,
   TS_HTTP_STATUS_ACCEPTED                        = 202,

--- a/lib/ts/mkdfa.c
+++ b/lib/ts/mkdfa.c
@@ -138,6 +138,7 @@ info_t methods[] = {
 info_t statuses[] = {
   {"100", "HTTP_STATUS_CONTINUE", -1},
   {"101", "HTTP_STATUS_SWITCHING_PROTOCOL", -1},
+  {"103", "HTTP_STATUS_EARLY_HINTS", -1},
   {"200", "HTTP_STATUS_OK", -1},
   {"201", "HTTP_STATUS_CREATED", -1},
   {"202", "HTTP_STATUS_ACCEPTED", -1},

--- a/proxy/InkAPITest.cc
+++ b/proxy/InkAPITest.cc
@@ -3278,12 +3278,21 @@ REGRESSION_TEST(SDK_API_TSHttpHdr)(RegressionTest *test, int /* atype ATS_UNUSED
   }
 
   if (strcmp("Not Modified", TSHttpHdrReasonLookup(TS_HTTP_STATUS_NOT_MODIFIED)) != 0) {
-    SDK_RPRINT(test, "TSHttpHdrReasonLookup", "TestCase2", TC_FAIL, "TSHttpHdrReasonLookup returns Value's mismatch");
+    SDK_RPRINT(test, "TSHttpHdrReasonLookup", "TestCase4", TC_FAIL, "TSHttpHdrReasonLookup returns Value's mismatch");
     if (test_passed_Http_Hdr_Reason_Lookup == true) {
       test_passed_Http_Hdr_Reason_Lookup = false;
     }
   } else {
     SDK_RPRINT(test, "TSHttpHdrReasonLookup", "TestCase4", TC_PASS, "ok");
+  }
+
+  if (strcmp("Early Hints", TSHttpHdrReasonLookup(TS_HTTP_STATUS_EARLY_HINTS)) != 0) {
+    SDK_RPRINT(test, "TSHttpHdrReasonLookup", "TestCase5", TC_FAIL, "TSHttpHdrReasonLookup returns Value's mismatch");
+    if (test_passed_Http_Hdr_Reason_Lookup == true) {
+      test_passed_Http_Hdr_Reason_Lookup = false;
+    }
+  } else {
+    SDK_RPRINT(test, "TSHttpHdrReasonLookup", "TestCase5", TC_PASS, "ok");
   }
 
   // Copy
@@ -5470,6 +5479,7 @@ typedef enum {
 
   ORIG_TS_HTTP_STATUS_CONTINUE           = 100,
   ORIG_TS_HTTP_STATUS_SWITCHING_PROTOCOL = 101,
+  ORIG_TS_HTTP_STATUS_EARLY_HINTS        = 103,
 
   ORIG_TS_HTTP_STATUS_OK                            = 200,
   ORIG_TS_HTTP_STATUS_CREATED                       = 201,
@@ -5640,6 +5650,8 @@ REGRESSION_TEST(SDK_API_TSConstant)(RegressionTest *test, int /* atype ATS_UNUSE
   PRINT_DIFF(TS_HTTP_STATUS_NONE);
   PRINT_DIFF(TS_HTTP_STATUS_CONTINUE);
   PRINT_DIFF(TS_HTTP_STATUS_SWITCHING_PROTOCOL);
+  PRINT_DIFF(TS_HTTP_STATUS_EARLY_HINTS);
+
   PRINT_DIFF(TS_HTTP_STATUS_OK);
   PRINT_DIFF(TS_HTTP_STATUS_CREATED);
 

--- a/proxy/hdrs/HTTP.cc
+++ b/proxy/hdrs/HTTP.cc
@@ -749,6 +749,7 @@ http_hdr_reason_lookup(unsigned status)
     HTTP_STATUS_ENTRY(100, Continue);            // [RFC2616]
     HTTP_STATUS_ENTRY(101, Switching Protocols); // [RFC2616]
     HTTP_STATUS_ENTRY(102, Processing);          // [RFC2518]
+    HTTP_STATUS_ENTRY(103, Early Hints);         // TODO: add RFC number
     // 103-199 Unassigned
     HTTP_STATUS_ENTRY(200, OK);                              // [RFC2616]
     HTTP_STATUS_ENTRY(201, Created);                         // [RFC2616]

--- a/proxy/hdrs/HTTP.h
+++ b/proxy/hdrs/HTTP.h
@@ -43,6 +43,7 @@ enum HTTPStatus {
 
   HTTP_STATUS_CONTINUE           = 100,
   HTTP_STATUS_SWITCHING_PROTOCOL = 101,
+  HTTP_STATUS_EARLY_HINTS        = 103,
 
   HTTP_STATUS_OK                            = 200,
   HTTP_STATUS_CREATED                       = 201,

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -3798,7 +3798,8 @@ HttpTransact::handle_forward_server_connection_open(State *s)
     // dont update the hostdb. let us try again with what we currently think.
   }
 
-  if (s->hdr_info.server_response.status_get() == HTTP_STATUS_CONTINUE) {
+  if (s->hdr_info.server_response.status_get() == HTTP_STATUS_CONTINUE ||
+      s->hdr_info.server_response.status_get() == HTTP_STATUS_EARLY_HINTS) {
     handle_100_continue_response(s);
     return;
   }


### PR DESCRIPTION
Add ["An HTTP Status Code for Indicating Hints"](https://datatracker.ietf.org/doc/draft-ietf-httpbis-early-hints/) Support. Changes of this PR are basically to pass through the 103 Early Hints response from origin server to client.

Out of scope:
- Trigger HTTP/2 Server Push by Link headers of 103 Early Hints Response.
- AUTest