### PR TITLE
Fix logging of connection error when unable to refresh stale content due to DNS down.

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -2359,10 +2359,8 @@ HttpTransact::HandleCacheOpenReadHitFreshness(State *s)
   }
 
   ink_assert(s->cache_lookup_result != HttpTransact::CACHE_LOOKUP_MISS);
-  if (s->cache_lookup_result == HttpTransact::CACHE_LOOKUP_HIT_STALE) {
+  if (s->cache_lookup_result == HttpTransact::CACHE_LOOKUP_HIT_STALE)
     SET_VIA_STRING(VIA_DETAIL_CACHE_LOOKUP, VIA_DETAIL_MISS_EXPIRED);
-    SET_VIA_STRING(VIA_CACHE_RESULT, VIA_IN_CACHE_STALE);
-  }
 
   if (!s->force_dns) { // If DNS is not performed before
     if (need_to_revalidate(s)) {

--- a/proxy/http/HttpTransactHeaders.cc
+++ b/proxy/http/HttpTransactHeaders.cc
@@ -596,7 +596,7 @@ HttpTransactHeaders::generate_and_set_squid_codes(HTTPHdr *header, char *via_str
     log_code = SQUID_LOG_ERR_PROXY_DENIED;
     break;
   case VIA_ERROR_CONNECTION:
-    if (log_code == SQUID_LOG_TCP_MISS || log_code == SQUID_LOG_TCP_REFRESH_MISS) {
+    if (log_code == SQUID_LOG_TCP_MISS) {
       log_code = SQUID_LOG_ERR_CONNECT_FAIL;
     }
     break;

--- a/proxy/http/HttpTransactHeaders.cc
+++ b/proxy/http/HttpTransactHeaders.cc
@@ -596,6 +596,14 @@ HttpTransactHeaders::generate_and_set_squid_codes(HTTPHdr *header, char *via_str
     log_code = SQUID_LOG_ERR_PROXY_DENIED;
     break;
   case VIA_ERROR_CONNECTION:
+    // When the content is expired in the cache but ATS is unable to
+    // refresh from the origin due to the DNS server being down, then
+    // (1) the error is 'C' here instead of 'D' below and (2) the
+    // log_code is TCP hit. This overrides the TCP hit with
+    // error-connect-fail based on the error and miss-expired results.
+    if (hit_miss_code == SQUID_MISS_PRE_EXPIRED) {
+      log_code = SQUID_LOG_ERR_CONNECT_FAIL;
+    }
     if (log_code == SQUID_LOG_TCP_MISS) {
       log_code = SQUID_LOG_ERR_CONNECT_FAIL;
     }


### PR DESCRIPTION
Reverts #2461 and replaces with a new patch. This patch does not attempt to fix any via_string result inconsistencies since this appears to have caused side effects in the previous PR. Instead, we just override the squid log result code based on the existing via_string results (so changes are confined to generation of logging codes).