### PR TITLE
Fix #2761. NetHandler needs to be initialized

### DIFF
--- a/iocore/net/UnixNet.cc
+++ b/iocore/net/UnixNet.cc
@@ -212,6 +212,9 @@ initialize_thread_for_net(EThread *thread)
   nh->mutex  = new_ProxyMutex();
   nh->thread = thread;
 
+  // This is needed to initialize NetHandler
+  thread->schedule_imm(nh);
+
   PollCont *pc       = get_PollCont(thread);
   PollDescriptor *pd = pc->pollDescriptor;
 


### PR DESCRIPTION
This is to fix #2761.
In https://github.com/apache/trafficserver/pull/2541, `thread->schedule_imm(get_NetHandler(thread));` is removed but this statement is needed to initialize NetHandler.

@bryancall @maskit @SolidWallOfCode 