### PR TITLE
Backport of #2015, setup HttpSM for redirect

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -695,6 +695,11 @@ HttpTransact::StartRemapRequest(State *s)
 
     s->hdr_info.client_request.set_url_target_from_host_field();
 
+    // Since we're not doing remap, we still have to allow for these overridable
+    // configurations to modify follow-redirect behavior. Someone could for example
+    // have set them in a plugin other than conf_remap running in a prior hook.
+    s->state_machine->enable_redirection = (s->txn_conf->redirection_enabled && (s->txn_conf->number_of_redirections > 0));
+
     if (s->is_upgrade_request && s->post_remap_upgrade_return_point) {
       TRANSACT_RETURN(SM_ACTION_POST_REMAP_SKIP, s->post_remap_upgrade_return_point);
     }
@@ -776,6 +781,12 @@ HttpTransact::EndRemapRequest(State *s)
   int host_len;
   const char *host = incoming_request->host_get(&host_len);
   DebugTxn("http_trans", "EndRemapRequest host is %.*s", host_len, host);
+
+  // Setting enable_redirection according to HttpConfig (master or overridable). We
+  // defer this as late as possible, to allow plugins to modify the overridable
+  // configurations (e.g. conf_remap.so). We intentionally only modify this if
+  // the configuration says so.
+  s->state_machine->enable_redirection = (s->txn_conf->redirection_enabled && (s->txn_conf->number_of_redirections > 0));
 
   ////////////////////////////////////////////////////////////////
   // if we got back a URL to redirect to, vector the user there //


### PR DESCRIPTION
This was fixed on master, in a6c14f0. However, that change was an
incompatible change, and should not be backported to 7.x. However,
I think we can "cheat" here a little bit, and just pick the portion
that makes sure the internal state is properly mirroring the
overridable settings. This is a little ugly, but does seem to work.

This closes #2765.