### PR TITLE
Delete H2 stream before destroy

### DIFF
--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -147,6 +147,7 @@ public:
   VIO *do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *abuffer, bool owner = false) override;
   void do_io_close(int lerrno = -1) override;
   void initiating_close();
+  void terminate_if_possible();
   void do_io_shutdown(ShutdownHowTo_t) override {}
   void update_read_request(int64_t read_len, bool send_update);
   bool update_write_request(IOBufferReader *buf_reader, int64_t write_len, bool send_update);


### PR DESCRIPTION
`delete_stream()` removes a stream from `priority_tree`, but here, the stream destroy itself without calling `delete_stream()`. The stream can be used during processing `HTTP2_SESSION_EVENT_XMIT`.

I think this fixes #2207.