### PR TITLE
Compile trafficserver with the musl libc

### DIFF
--- a/lib/ts/ink_defs.cc
+++ b/lib/ts/ink_defs.cc
@@ -33,7 +33,6 @@
 #if defined(linux) || defined(freebsd) || defined(darwin)
 #include <sys/types.h>
 #include <sys/param.h>
-#include <sys/sysctl.h>
 #endif
 #if defined(linux)
 #include <sys/utsname.h>

--- a/lib/ts/ink_error.h
+++ b/lib/ts/ink_error.h
@@ -36,6 +36,11 @@
 #include "ts/ink_platform.h"
 #include "ts/ink_apidefs.h"
 
+// throw isn't available in every libc (musl, ..)
+#ifndef __THROW
+#define __THROW
+#endif
+
 // This magic exit code is used to signal that the crashing process cannot
 // be recovered from a restart of said process
 //

--- a/lib/ts/ink_error.h
+++ b/lib/ts/ink_error.h
@@ -33,6 +33,7 @@
 #define _ink_error_h_
 
 #include <stdarg.h>
+#include <stdio.h>
 #include "ts/ink_platform.h"
 #include "ts/ink_apidefs.h"
 

--- a/lib/ts/ink_sys_control.cc
+++ b/lib/ts/ink_sys_control.cc
@@ -32,7 +32,7 @@ ink_max_out_rlimit(int which, bool max_it, bool unlim_it)
 {
   struct rlimit rl;
 
-#if defined(linux)
+#if defined(__GLIBC__)
 #define MAGIC_CAST(x) (enum __rlimit_resource)(x)
 #else
 #define MAGIC_CAST(x) x


### PR DESCRIPTION
With these commits, trafficserver now compiles fully on musl, opening the door to very convenient and small containers (as well as being packaged in alpine linux - ping @ncopa 😄). I'm yet to look into experimental plugins and other variants; this is stock `./configure`.

The ifdef workaround (https://github.com/apache/trafficserver/issues/2760) is unfortunate since its generally bad practice to target specific functionality in libc's. I leave the decision to the more experienced trafficserver developers to suggest a better path (perhaps just drop it?).

Oh, and here's the output of the test suite (one failed test, need to look into it):
```console
FAIL: test_traffic_via
======================

--- /tmp/via.fOiBNb
+++ /trafficserver/cmd/traffic_via/tests/long rubbish via code 2
@@ -1,4 +1,3 @@
-Via header is long rubbish via code 2, Length is 23
 traffic_via: Invalid VIA header character: l
 traffic_via: Invalid VIA header character: o
 traffic_via: Invalid VIA header character: n
@@ -13,5 +12,6 @@
 traffic_via: Invalid VIA header character: a
 traffic_via: Invalid VIA header character: o
 traffic_via: Invalid VIA header character: d
+Via header is long rubbish via code 2, Length is 23
 Via Header Details:
 Error codes (if any)                                   :unknown
FAIL test_traffic_via (exit status: 1)
```