### PR TITLE
Send RST_STREAM frame when deleting a stream if it is not CLOSED state

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1143,7 +1143,7 @@ Http2ConnectionState::delete_stream(Http2Stream *stream)
     }
   }
 
-  if (stream->get_state() == Http2StreamState::HTTP2_STREAM_STATE_HALF_CLOSED_LOCAL) {
+  if (stream->get_state() != Http2StreamState::HTTP2_STREAM_STATE_CLOSED) {
     send_rst_stream_frame(stream->get_id(), Http2ErrorCode::HTTP2_ERROR_NO_ERROR);
   }
 


### PR DESCRIPTION
ATS doesn't send any frame when deleting H2 streams even if their states are not closed (except half-closed-local state). This makes a client wait data from the streams forever since the client doesn't know that the server closed the streams.

I don't remember why I made ATS sends RST_STREAM only if the stream state is on half-closed-local state, but the frame should be sent if the stream is not on closed state.

This fixes #2749.