### PR TITLE
Correct the listen_backlog

### DIFF
--- a/iocore/net/Connection.cc
+++ b/iocore/net/Connection.cc
@@ -45,7 +45,7 @@ get_listen_backlog()
   int listen_backlog;
 
   REC_ReadConfigInteger(listen_backlog, "proxy.config.net.listen_backlog");
-  return listen_backlog >= 0 ? listen_backlog : ats_tcp_somaxconn();
+  return (0 < listen_backlog && listen_backlog <= 65535) ? listen_backlog : ats_tcp_somaxconn();
 }
 
 //

--- a/lib/ts/ink_inet.cc
+++ b/lib/ts/ink_inet.cc
@@ -571,19 +571,19 @@ ats_tcp_somaxconn()
 /* Darwin version ... */
 #if HAVE_SYSCTLBYNAME
   size_t value_size = sizeof(value);
-  if (sysctlbyname("kern.ipc.somaxconn", &value, &value_size, nullptr, 0) == 0) {
-    return value;
+  if (sysctlbyname("kern.ipc.somaxconn", &value, &value_size, nullptr, 0) < 0) {
+    value = 0;
   }
-#endif
-
-  std::ifstream f("/proc/sys/net/ipv4/tcp_max_syn_backlog", std::ifstream::in);
+#else
+  std::ifstream f("/proc/sys/net/core/somaxconn", std::ifstream::in);
   if (f.good()) {
     f >> value;
   }
+#endif
 
   // Default to the compatible value we used before detection. SOMAXCONN is the right
   // macro to use, but most systems set this to 128, which is just too small.
-  if (value <= 0) {
+  if (value <= 0 || value > 65535) {
     value = 1024;
   }
 


### PR DESCRIPTION
The valid range of `backlog` for `listen(int socket, int backlog)` is 1 to 65535.

According to the `man 2 listen` in linux:

```
       The behavior of the backlog argument on TCP sockets changed with Linux 2.2.  Now it specifies the queue length  for  com‐
       pletely established sockets waiting to be accepted, instead of the number of incomplete connection requests.  The maximum
       length of the queue for incomplete sockets can be set using /proc/sys/net/ipv4/tcp_max_syn_backlog.  When syncookies  are
       enabled there is no logical maximum length and this setting is ignored.  See tcp(7) for more information.

       If  the backlog argument is greater than the value in /proc/sys/net/core/somaxconn, then it is silently truncated to that
       value; the default value in this file is 128.  In kernels before 2.4.25, this limit was a hard  coded  value,  SOMAXCONN,
       with the value 128.
```

But there was a bug in old kernel and reported by : 

- http://patchwork.ozlabs.org/patch/255460/
- https://serverfault.com/questions/518862/will-increasing-net-core-somaxconn-make-a-difference


We should confirm the backlog has a valid value.

The correct path and file name for `SOMAXCONN` is `/proc/sys/net/core/somaxconn`.