### PR TITLE
Optimize: update ink_thread_create with thread-safe support

### DIFF
--- a/cmd/traffic_manager/MgmtHandlers.cc
+++ b/cmd/traffic_manager/MgmtHandlers.cc
@@ -266,7 +266,7 @@ mgmt_synthetic_main(void *)
       mgmt_log("[SyntheticHealthServer] Connect by disallowed client %s, closing\n", inet_ntoa(clientInfo.sin_addr));
       close_socket(clientFD);
     } else {
-      ink_thread_create(synthetic_thread, (void *)&clientFD, 1, 0, nullptr);
+      ink_thread_create(nullptr, synthetic_thread, (void *)&clientFD, 1, 0, nullptr);
     }
   }
 

--- a/cmd/traffic_manager/traffic_manager.cc
+++ b/cmd/traffic_manager/traffic_manager.cc
@@ -642,7 +642,7 @@ main(int argc, const char **argv)
   // can keep a consistent euid when create mgmtapi/eventapi unix
   // sockets in mgmt_synthetic_main thread.
   //
-  synthThrId = ink_thread_create(mgmt_synthetic_main, nullptr, 0, 0, nullptr); /* Spin web agent thread */
+  ink_thread_create(&synthThrId, mgmt_synthetic_main, nullptr, 0, 0, nullptr); /* Spin web agent thread */
   Debug("lm", "Created Web Agent thread (%" PRId64 ")", (int64_t)synthThrId);
 
   // Setup the API and event sockets
@@ -670,8 +670,8 @@ main(int argc, const char **argv)
   }
 
   umask(oldmask);
-  ink_thread_create(ts_ctrl_main, &mgmtapiFD, 0, 0, nullptr);
-  ink_thread_create(event_callback_main, &eventapiFD, 0, 0, nullptr);
+  ink_thread_create(nullptr, ts_ctrl_main, &mgmtapiFD, 0, 0, nullptr);
+  ink_thread_create(nullptr, event_callback_main, &eventapiFD, 0, 0, nullptr);
 
   mgmt_log("[TrafficManager] Setup complete\n");
 

--- a/iocore/eventsystem/I_Thread.h
+++ b/iocore/eventsystem/I_Thread.h
@@ -151,7 +151,7 @@ public:
       @c nullptr a stack of size @a stacksize is allocated and used. If @a f is present and valid it
       is called in the thread context. Otherwise the method @c execute is invoked.
   */
-  ink_thread start(const char *name, void *stack, size_t stacksize, ThreadFunction const &f = ThreadFunction());
+  void start(const char *name, void *stack, size_t stacksize, ThreadFunction const &f = ThreadFunction());
 
   virtual void execute() = 0;
 

--- a/lib/records/RecLocal.cc
+++ b/lib/records/RecLocal.cc
@@ -215,8 +215,8 @@ RecLocalInitMessage()
 int
 RecLocalStart(FileManager *configFiles)
 {
-  ink_thread_create(sync_thr, configFiles, 0, 0, nullptr);
-  ink_thread_create(config_update_thr, nullptr, 0, 0, nullptr);
+  ink_thread_create(nullptr, sync_thr, configFiles, 0, 0, nullptr);
+  ink_thread_create(nullptr, config_update_thr, nullptr, 0, 0, nullptr);
   return REC_ERR_OKAY;
 }
 

--- a/lib/ts/ink_thread.h
+++ b/lib/ts/ink_thread.h
@@ -127,12 +127,16 @@ ink_thread_key_delete(ink_thread_key key)
   ink_assert(!pthread_key_delete(key));
 }
 
-static inline ink_thread
-ink_thread_create(void *(*f)(void *), void *a, int detached, size_t stacksize, void *stack)
+static inline void
+ink_thread_create(ink_thread *tid, void *(*f)(void *), void *a, int detached, size_t stacksize, void *stack)
 {
   ink_thread t;
   int ret;
   pthread_attr_t attr;
+
+  if (tid == nullptr) {
+    tid = &t;
+  }
 
   pthread_attr_init(&attr);
   pthread_attr_setscope(&attr, PTHREAD_SCOPE_SYSTEM);
@@ -149,13 +153,11 @@ ink_thread_create(void *(*f)(void *), void *a, int detached, size_t stacksize, v
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
   }
 
-  ret = pthread_create(&t, &attr, f, a);
+  ret = pthread_create(tid, &attr, f, a);
   if (ret != 0) {
     ink_abort("pthread_create() failed: %s (%d)", strerror(ret), ret);
   }
   pthread_attr_destroy(&attr);
-
-  return t;
 }
 
 static inline void

--- a/lib/ts/signals.cc
+++ b/lib/ts/signals.cc
@@ -116,7 +116,7 @@ check_signal_thread(void *ptr)
 void
 signal_start_check_thread(signal_handler_t handler)
 {
-  ink_thread_create(check_signal_thread, (void *)handler, 0, 0, nullptr);
+  ink_thread_create(nullptr, check_signal_thread, (void *)handler, 0, 0, nullptr);
 }
 
 bool

--- a/lib/ts/test_freelist.cc
+++ b/lib/ts/test_freelist.cc
@@ -74,7 +74,7 @@ main(int /* argc ATS_UNUSED */, char * /*argv ATS_UNUSED */ [])
 
   for (i = 0; i < NTHREADS; i++) {
     fprintf(stderr, "Create thread %d\n", i);
-    ink_thread_create(test, (void *)((intptr_t)i), 0, 0, nullptr);
+    ink_thread_create(nullptr, test, (void *)((intptr_t)i), 0, 0, nullptr);
   }
 
   test((void *)NTHREADS);

--- a/mgmt/ProcessManager.cc
+++ b/mgmt/ProcessManager.cc
@@ -100,7 +100,7 @@ ProcessManager::start(std::function<void()> const &cb)
 
   ink_release_assert(running == 0);
   ink_atomic_increment(&running, 1);
-  poll_thread = ink_thread_create(processManagerThread, nullptr, 0, 0, nullptr);
+  ink_thread_create(&poll_thread, processManagerThread, nullptr, 0, 0, nullptr);
 }
 
 void

--- a/mgmt/api/CoreAPIRemote.cc
+++ b/mgmt/api/CoreAPIRemote.cc
@@ -227,7 +227,7 @@ Init(const char *socket_path, TSInitOptionT options)
 
   // if connected, create event thread that listens for events from TM
   if (0 == (ts_init_options & TS_MGMT_OPT_NO_EVENTS)) {
-    ts_event_thread = ink_thread_create(event_poll_thread_main, &event_socket_fd, 0, 0, nullptr);
+    ink_thread_create(&ts_event_thread, event_poll_thread_main, &event_socket_fd, 0, 0, nullptr);
   } else {
     ts_event_thread = ink_thread_null();
   }
@@ -237,7 +237,7 @@ END:
   // create thread that periodically checks the socket connection
   // with TM alive - reconnects if not alive
   if (0 == (ts_init_options & TS_MGMT_OPT_NO_SOCK_TESTS)) {
-    ts_test_thread = ink_thread_create(socket_test_thread, nullptr, 0, 0, nullptr);
+    ink_thread_create(&ts_test_thread, socket_test_thread, nullptr, 0, 0, nullptr);
   } else {
     ts_test_thread = ink_thread_null();
   }

--- a/mgmt/api/NetworkUtilsRemote.cc
+++ b/mgmt/api/NetworkUtilsRemote.cc
@@ -238,7 +238,7 @@ reconnect()
 
   // relaunch a new event thread since socket_fd changed
   if (0 == (ts_init_options & TS_MGMT_OPT_NO_EVENTS)) {
-    ts_event_thread = ink_thread_create(event_poll_thread_main, &event_socket_fd, 0, 0, nullptr);
+    ink_thread_create(&ts_event_thread, event_poll_thread_main, &event_socket_fd, 0, 0, nullptr);
     // reregister the callbacks on the TM side for this new client connection
     if (remote_event_callbacks) {
       err = send_register_all_callbacks(event_socket_fd, remote_event_callbacks);
@@ -652,7 +652,7 @@ event_poll_thread_main(void *arg)
     event->description = desc;
 
     // got event notice; spawn new thread to handle the event's callback functions
-    ink_thread_create(event_callback_thread, (void *)event, 0, 0, nullptr);
+    ink_thread_create(nullptr, event_callback_thread, (void *)event, 0, 0, nullptr);
   }
 
   ink_thread_exit(nullptr);

--- a/proxy/InkIOCoreAPI.cc
+++ b/proxy/InkIOCoreAPI.cc
@@ -143,6 +143,7 @@ TSThread
 TSThreadCreate(TSThreadFunc func, void *data)
 {
   INKThreadInternal *thread;
+  ink_thread tid = 0;
 
   thread = new INKThreadInternal;
 
@@ -152,7 +153,8 @@ TSThreadCreate(TSThreadFunc func, void *data)
   thread->func = func;
   thread->data = data;
 
-  if (!(ink_thread_create(ink_thread_trampoline, (void *)thread, 1, 0, nullptr))) {
+  ink_thread_create(&tid, ink_thread_trampoline, (void *)thread, 1, 0, nullptr);
+  if (!tid) {
     return (TSThread) nullptr;
   }
 


### PR DESCRIPTION
This is a alternative solution for #2195 .
The `ink_thread_create` changes the way to return thread id and the new way is not thread-safe.

This PR makes `ink_thread_create` follow the way of `pthread_create` to return thread id.