### PR TITLE
Unify H2 log format

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -30,7 +30,7 @@
 #define DebugHttp2Con(ua_session, fmt, ...) \
   DebugSsn(ua_session, "http2_con", "[%" PRId64 "] " fmt, ua_session->connection_id(), ##__VA_ARGS__);
 
-#define DebugHttp2Stream(ua_session, stream_id, fmt, ...) \
+#define Http2StreamDebug(ua_session, stream_id, fmt, ...) \
   DebugSsn(ua_session, "http2_con", "[%" PRId64 "] [%u] " fmt, ua_session->connection_id(), stream_id, ##__VA_ARGS__);
 
 using http2_frame_dispatch = Http2Error (*)(Http2ConnectionState &, const Http2Frame &);
@@ -71,7 +71,7 @@ rcv_data_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
   uint8_t pad_length            = 0;
   const uint32_t payload_length = frame.header().length;
 
-  DebugHttp2Stream(cstate.ua_session, id, "Received DATA frame");
+  Http2StreamDebug(cstate.ua_session, id, "Received DATA frame");
 
   // If a DATA frame is received whose stream identifier field is 0x0, the
   // recipient MUST
@@ -199,7 +199,7 @@ rcv_headers_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
   const Http2StreamId stream_id = frame.header().streamid;
   const uint32_t payload_length = frame.header().length;
 
-  DebugHttp2Stream(cstate.ua_session, stream_id, "Received HEADERS frame");
+  Http2StreamDebug(cstate.ua_session, stream_id, "Received HEADERS frame");
 
   if (!http2_is_client_streamid(stream_id)) {
     return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR,
@@ -284,7 +284,7 @@ rcv_headers_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
       stream->priority_node = node;
       node->t               = stream;
     } else {
-      DebugHttp2Stream(cstate.ua_session, stream_id, "HEADER PRIORITY - dep: %d, weight: %d, excl: %d, tree size: %d",
+      Http2StreamDebug(cstate.ua_session, stream_id, "HEADER PRIORITY - dep: %d, weight: %d, excl: %d, tree size: %d",
                        params.priority.stream_dependency, params.priority.weight, params.priority.exclusive_flag,
                        cstate.dependency_tree->size());
 
@@ -343,7 +343,7 @@ rcv_headers_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
   } else {
     // NOTE: Expect CONTINUATION Frame. Do NOT change state of stream or decode
     // Header Blocks.
-    DebugHttp2Stream(cstate.ua_session, stream_id, "No END_HEADERS flag, expecting CONTINUATION frame");
+    Http2StreamDebug(cstate.ua_session, stream_id, "No END_HEADERS flag, expecting CONTINUATION frame");
     cstate.set_continued_stream_id(stream_id);
   }
 
@@ -360,7 +360,7 @@ rcv_priority_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
   const Http2StreamId stream_id = frame.header().streamid;
   const uint32_t payload_length = frame.header().length;
 
-  DebugHttp2Stream(cstate.ua_session, stream_id, "Received PRIORITY frame");
+  Http2StreamDebug(cstate.ua_session, stream_id, "Received PRIORITY frame");
 
   // If a PRIORITY frame is received with a stream identifier of 0x0, the
   // recipient MUST respond with a connection error of type PROTOCOL_ERROR.
@@ -395,14 +395,14 @@ rcv_priority_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
                       "PRIORITY frame depends on itself");
   }
 
-  DebugHttp2Stream(cstate.ua_session, stream_id, "PRIORITY - dep: %d, weight: %d, excl: %d, tree size: %d",
+  Http2StreamDebug(cstate.ua_session, stream_id, "PRIORITY - dep: %d, weight: %d, excl: %d, tree size: %d",
                    priority.stream_dependency, priority.weight, priority.exclusive_flag, cstate.dependency_tree->size());
 
   Http2DependencyTree::Node *node = cstate.dependency_tree->find(stream_id);
 
   if (node != nullptr) {
     // [RFC 7540] 5.3.3 Reprioritization
-    DebugHttp2Stream(cstate.ua_session, stream_id, "Reprioritize");
+    Http2StreamDebug(cstate.ua_session, stream_id, "Reprioritize");
     cstate.dependency_tree->reprioritize(node, priority.stream_dependency, priority.exclusive_flag);
   } else {
     // PRIORITY frame is received before HEADERS frame.
@@ -425,7 +425,7 @@ rcv_rst_stream_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
   char *end;
   const Http2StreamId stream_id = frame.header().streamid;
 
-  DebugHttp2Stream(cstate.ua_session, frame.header().streamid, "Received RST_STREAM frame");
+  Http2StreamDebug(cstate.ua_session, frame.header().streamid, "Received RST_STREAM frame");
 
   // RST_STREAM frames MUST be associated with a stream.  If a RST_STREAM
   // frame is received with a stream identifier of 0x0, the recipient MUST
@@ -468,7 +468,7 @@ rcv_rst_stream_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
   }
 
   if (stream != nullptr) {
-    DebugHttp2Stream(cstate.ua_session, stream_id, "RST_STREAM: Error Code: %u", rst_stream.error_code);
+    Http2StreamDebug(cstate.ua_session, stream_id, "RST_STREAM: Error Code: %u", rst_stream.error_code);
 
     cstate.delete_stream(stream);
   }
@@ -484,7 +484,7 @@ rcv_settings_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
   unsigned nbytes               = 0;
   const Http2StreamId stream_id = frame.header().streamid;
 
-  DebugHttp2Stream(cstate.ua_session, stream_id, "Received SETTINGS frame");
+  Http2StreamDebug(cstate.ua_session, stream_id, "Received SETTINGS frame");
 
   // [RFC 7540] 6.5. The stream identifier for a SETTINGS frame MUST be zero.
   // If an endpoint receives a SETTINGS frame whose stream identifier field is
@@ -533,7 +533,7 @@ rcv_settings_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
       }
     }
 
-    DebugHttp2Stream(cstate.ua_session, stream_id, "   %s : %u", Http2DebugNames::get_settings_param_name(param.id), param.value);
+    Http2StreamDebug(cstate.ua_session, stream_id, "   %s : %u", Http2DebugNames::get_settings_param_name(param.id), param.value);
 
     // [RFC 7540] 6.9.2. When the value of SETTINGS_INITIAL_WINDOW_SIZE
     // changes, a receiver MUST adjust the size of all stream flow control
@@ -557,7 +557,7 @@ rcv_settings_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
 static Http2Error
 rcv_push_promise_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
 {
-  DebugHttp2Stream(cstate.ua_session, frame.header().streamid, "Received PUSH_PROMISE frame");
+  Http2StreamDebug(cstate.ua_session, frame.header().streamid, "Received PUSH_PROMISE frame");
 
   // [RFC 7540] 8.2. A client cannot push. Thus, servers MUST treat the receipt of a
   // PUSH_PROMISE frame as a connection error of type PROTOCOL_ERROR.
@@ -571,7 +571,7 @@ rcv_ping_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
   uint8_t opaque_data[HTTP2_PING_LEN];
   const Http2StreamId stream_id = frame.header().streamid;
 
-  DebugHttp2Stream(cstate.ua_session, stream_id, "Received PING frame");
+  Http2StreamDebug(cstate.ua_session, stream_id, "Received PING frame");
 
   //  If a PING frame is received with a stream identifier field value other
   //  than 0x0, the recipient MUST respond with a connection error of type
@@ -608,7 +608,7 @@ rcv_goaway_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
   unsigned nbytes               = 0;
   const Http2StreamId stream_id = frame.header().streamid;
 
-  DebugHttp2Stream(cstate.ua_session, stream_id, "Received GOAWAY frame");
+  Http2StreamDebug(cstate.ua_session, stream_id, "Received GOAWAY frame");
 
   // An endpoint MUST treat a GOAWAY frame with a stream identifier other
   // than 0x0 as a connection error of type PROTOCOL_ERROR.
@@ -626,7 +626,7 @@ rcv_goaway_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
     }
   }
 
-  DebugHttp2Stream(cstate.ua_session, stream_id, "GOAWAY: last stream id=%d, error code=%d", goaway.last_streamid,
+  Http2StreamDebug(cstate.ua_session, stream_id, "GOAWAY: last stream id=%d, error code=%d", goaway.last_streamid,
                    static_cast<int>(goaway.error_code));
 
   cstate.handleEvent(HTTP2_SESSION_EVENT_FINI, nullptr);
@@ -645,7 +645,7 @@ rcv_window_update_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
   //  A WINDOW_UPDATE frame with a length other than 4 octets MUST be
   //  treated as a connection error of type FRAME_SIZE_ERROR.
   if (frame.header().length != HTTP2_WINDOW_UPDATE_LEN) {
-    DebugHttp2Stream(cstate.ua_session, stream_id, "Received WINDOW_UPDATE frame - length incorrect");
+    Http2StreamDebug(cstate.ua_session, stream_id, "Received WINDOW_UPDATE frame - length incorrect");
     return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, Http2ErrorCode::HTTP2_ERROR_FRAME_SIZE_ERROR,
                       "window update bad length");
   }
@@ -667,7 +667,7 @@ rcv_window_update_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
 
   if (stream_id == 0) {
     // Connection level window update
-    DebugHttp2Stream(cstate.ua_session, stream_id, "Received WINDOW_UPDATE frame - updated to: %zd delta: %u",
+    Http2StreamDebug(cstate.ua_session, stream_id, "Received WINDOW_UPDATE frame - updated to: %zd delta: %u",
                      (cstate.client_rwnd + size), size);
 
     // A sender MUST NOT allow a flow-control window to exceed 2^31-1
@@ -697,7 +697,7 @@ rcv_window_update_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
       }
     }
 
-    DebugHttp2Stream(cstate.ua_session, stream_id, "Received WINDOW_UPDATE frame - updated to: %zd delta: %u",
+    Http2StreamDebug(cstate.ua_session, stream_id, "Received WINDOW_UPDATE frame - updated to: %zd delta: %u",
                      (stream->client_rwnd + size), size);
 
     // A sender MUST NOT allow a flow-control window to exceed 2^31-1
@@ -736,7 +736,7 @@ rcv_continuation_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
   const Http2StreamId stream_id = frame.header().streamid;
   const uint32_t payload_length = frame.header().length;
 
-  DebugHttp2Stream(cstate.ua_session, stream_id, "Received CONTINUATION frame");
+  Http2StreamDebug(cstate.ua_session, stream_id, "Received CONTINUATION frame");
 
   if (!http2_is_client_streamid(stream_id)) {
     return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR,
@@ -814,7 +814,7 @@ rcv_continuation_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
     stream->send_request(cstate);
   } else {
     // NOTE: Expect another CONTINUATION Frame. Do nothing.
-    DebugHttp2Stream(cstate.ua_session, stream_id, "No END_HEADERS flag, expecting CONTINUATION frame");
+    Http2StreamDebug(cstate.ua_session, stream_id, "No END_HEADERS flag, expecting CONTINUATION frame");
   }
 
   return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_NONE);
@@ -890,7 +890,7 @@ Http2ConnectionState::main_event_handler(int event, void *edata)
     // [RFC 7540] 5.5. Extending HTTP/2
     //   Implementations MUST discard frames that have unknown or unsupported types.
     if (frame->header().type >= HTTP2_FRAME_TYPE_MAX) {
-      DebugHttp2Stream(ua_session, stream_id, "Discard a frame which has unknown type, type=%x", frame->header().type);
+      Http2StreamDebug(ua_session, stream_id, "Discard a frame which has unknown type, type=%x", frame->header().type);
       break;
     }
 
@@ -1132,7 +1132,7 @@ Http2ConnectionState::delete_stream(Http2Stream *stream)
     return false;
   }
 
-  DebugHttp2Stream(ua_session, stream->get_id(), "Delete stream");
+  Http2StreamDebug(ua_session, stream->get_id(), "Delete stream");
 
   if (Http2::stream_priority_enabled) {
     Http2DependencyTree::Node *node = stream->priority_node;
@@ -1206,7 +1206,7 @@ Http2ConnectionState::update_initial_rwnd(Http2WindowSize new_size)
 void
 Http2ConnectionState::schedule_stream(Http2Stream *stream)
 {
-  DebugHttp2Stream(ua_session, stream->get_id(), "Scheduled");
+  Http2StreamDebug(ua_session, stream->get_id(), "Scheduled");
 
   Http2DependencyTree::Node *node = stream->priority_node;
   ink_release_assert(node != nullptr);
@@ -1234,7 +1234,7 @@ Http2ConnectionState::send_data_frames_depends_on_priority()
 
   Http2Stream *stream = static_cast<Http2Stream *>(node->t);
   ink_release_assert(stream != nullptr);
-  DebugHttp2Stream(ua_session, stream->get_id(), "top node, point=%d", node->point);
+  Http2StreamDebug(ua_session, stream->get_id(), "top node, point=%d", node->point);
 
   size_t len                       = 0;
   Http2SendADataFrameResult result = send_a_data_frame(stream, len);
@@ -1310,7 +1310,7 @@ Http2ConnectionState::send_a_data_frame(Http2Stream *stream, size_t &payload_len
   stream->client_rwnd -= payload_length;
 
   // Create frame
-  DebugHttp2Stream(ua_session, stream->get_id(), "Send a DATA frame - client window con: %zd stream: %zd payload: %zd", client_rwnd,
+  Http2StreamDebug(ua_session, stream->get_id(), "Send a DATA frame - client window con: %zd stream: %zd payload: %zd", client_rwnd,
                    stream->client_rwnd, payload_length);
 
   Http2Frame data(HTTP2_FRAME_TYPE_DATA, stream->get_id(), flags);
@@ -1325,7 +1325,7 @@ Http2ConnectionState::send_a_data_frame(Http2Stream *stream, size_t &payload_len
   this->ua_session->handleEvent(HTTP2_SESSION_EVENT_XMIT, &data);
 
   if (flags & HTTP2_FLAGS_DATA_END_STREAM) {
-    DebugHttp2Stream(ua_session, stream->get_id(), "End of DATA frame");
+    Http2StreamDebug(ua_session, stream->get_id(), "End of DATA frame");
     stream->send_end_stream = true;
     // Setting to the same state shouldn't be erroneous
     stream->change_state(data.header().type, data.header().flags);
@@ -1343,7 +1343,7 @@ Http2ConnectionState::send_data_frames(Http2Stream *stream)
   // a closed stream.  So we return without sending
   if (stream->get_state() == Http2StreamState::HTTP2_STREAM_STATE_HALF_CLOSED_LOCAL ||
       stream->get_state() == Http2StreamState::HTTP2_STREAM_STATE_CLOSED) {
-    DebugSsn(this->ua_session, "http2_cs", "Shutdown half closed local stream %d", stream->get_id());
+    Http2StreamDebug(this->ua_session, stream->get_id(), "Shutdown half closed local stream");
     this->delete_stream(stream);
     return;
   }
@@ -1357,7 +1357,7 @@ Http2ConnectionState::send_data_frames(Http2Stream *stream)
       // TODO its should not be deleted for a several time to handling
       // RST_STREAM and WINDOW_UPDATE.
       // See 'closed' state written at [RFC 7540] 5.1.
-      DebugSsn(this->ua_session, "http2_cs", "Shutdown stream %d", stream->get_id());
+      Http2StreamDebug(this->ua_session, stream->get_id(), "Shutdown stream");
       this->delete_stream(stream);
       break;
     } else if (result == HTTP2_SEND_A_DATA_FRAME_NO_ERROR) {
@@ -1380,7 +1380,7 @@ Http2ConnectionState::send_headers_frame(Http2Stream *stream)
 
   HTTPHdr *resp_header = &stream->response_header;
 
-  DebugHttp2Stream(ua_session, stream->get_id(), "Send HEADERS frame");
+  Http2StreamDebug(ua_session, stream->get_id(), "Send HEADERS frame");
 
   HTTPHdr h2_hdr;
   http2_generate_h2_header_from_1_1(resp_header, &h2_hdr);
@@ -1434,7 +1434,7 @@ Http2ConnectionState::send_headers_frame(Http2Stream *stream)
   // Send CONTINUATION frames
   flags = 0;
   while (sent < header_blocks_size) {
-    DebugHttp2Stream(ua_session, stream->get_id(), "Send CONTINUATION frame");
+    Http2StreamDebug(ua_session, stream->get_id(), "Send CONTINUATION frame");
     payload_length = std::min(static_cast<uint32_t>(BUFFER_SIZE_FOR_INDEX(buffer_size_index[HTTP2_FRAME_TYPE_CONTINUATION])),
                               static_cast<uint32_t>(header_blocks_size - sent));
     if (sent + payload_length == header_blocks_size) {
@@ -1470,7 +1470,7 @@ Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url, con
     return;
   }
 
-  DebugHttp2Stream(ua_session, stream->get_id(), "Send PUSH_PROMISE frame");
+  Http2StreamDebug(ua_session, stream->get_id(), "Send PUSH_PROMISE frame");
 
   h1_hdr.create(HTTP_TYPE_REQUEST);
   h1_hdr.url_set(&url);
@@ -1531,7 +1531,7 @@ Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url, con
   // Send CONTINUATION frames
   flags = 0;
   while (sent < header_blocks_size) {
-    DebugHttp2Stream(ua_session, stream->get_id(), "Send CONTINUATION frame");
+    Http2StreamDebug(ua_session, stream->get_id(), "Send CONTINUATION frame");
     payload_length = std::min(static_cast<uint32_t>(BUFFER_SIZE_FOR_INDEX(buffer_size_index[HTTP2_FRAME_TYPE_CONTINUATION])),
                               static_cast<uint32_t>(header_blocks_size - sent));
     if (sent + payload_length == header_blocks_size) {
@@ -1559,7 +1559,7 @@ Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url, con
     if (node != nullptr) {
       stream->priority_node = node;
     } else {
-      DebugHttp2Stream(this->ua_session, id, "PRIORITY - dep: %d, weight: %d, excl: %d, tree size: %d",
+      Http2StreamDebug(this->ua_session, id, "PRIORITY - dep: %d, weight: %d, excl: %d, tree size: %d",
                        HTTP2_PRIORITY_DEFAULT_STREAM_DEPENDENCY, HTTP2_PRIORITY_DEFAULT_WEIGHT, false,
                        this->dependency_tree->size());
 
@@ -1578,7 +1578,7 @@ Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url, con
 void
 Http2ConnectionState::send_rst_stream_frame(Http2StreamId id, Http2ErrorCode ec)
 {
-  DebugHttp2Stream(ua_session, id, "Send RST_STREAM frame");
+  Http2StreamDebug(ua_session, id, "Send RST_STREAM frame");
 
   if (ec != Http2ErrorCode::HTTP2_ERROR_NO_ERROR) {
     HTTP2_INCREMENT_THREAD_DYN_STAT(HTTP2_STAT_STREAM_ERRORS_COUNT, this_ethread());
@@ -1612,7 +1612,7 @@ Http2ConnectionState::send_settings_frame(const Http2ConnectionSettings &new_set
 {
   const Http2StreamId stream_id = 0;
 
-  DebugHttp2Stream(ua_session, stream_id, "Send SETTINGS frame");
+  Http2StreamDebug(ua_session, stream_id, "Send SETTINGS frame");
 
   Http2Frame settings(HTTP2_FRAME_TYPE_SETTINGS, stream_id, 0);
   settings.alloc(buffer_size_index[HTTP2_FRAME_TYPE_SETTINGS]);
@@ -1643,7 +1643,7 @@ Http2ConnectionState::send_settings_frame(const Http2ConnectionSettings &new_set
       // Update current settings
       server_settings.set(id, new_settings.get(id));
 
-      DebugHttp2Stream(ua_session, stream_id, "  %s : %u", Http2DebugNames::get_settings_param_name(param.id), param.value);
+      Http2StreamDebug(ua_session, stream_id, "  %s : %u", Http2DebugNames::get_settings_param_name(param.id), param.value);
     }
   }
 
@@ -1655,7 +1655,7 @@ Http2ConnectionState::send_settings_frame(const Http2ConnectionSettings &new_set
 void
 Http2ConnectionState::send_ping_frame(Http2StreamId id, uint8_t flag, const uint8_t *opaque_data)
 {
-  DebugHttp2Stream(ua_session, id, "Send PING frame");
+  Http2StreamDebug(ua_session, id, "Send PING frame");
 
   Http2Frame ping(HTTP2_FRAME_TYPE_PING, id, flag);
 
@@ -1699,7 +1699,7 @@ Http2ConnectionState::send_goaway_frame(Http2StreamId id, Http2ErrorCode ec)
 void
 Http2ConnectionState::send_window_update_frame(Http2StreamId id, uint32_t size)
 {
-  DebugHttp2Stream(ua_session, id, "Send WINDOW_UPDATE frame");
+  Http2StreamDebug(ua_session, id, "Send WINDOW_UPDATE frame");
 
   // Create WINDOW_UPDATE frame
   Http2Frame window_update(HTTP2_FRAME_TYPE_WINDOW_UPDATE, id, 0x0);

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -26,6 +26,9 @@
 #include "Http2ClientSession.h"
 #include "../http/HttpSM.h"
 
+#define Http2StreamDebug(fmt, ...) \
+  DebugSsn(parent, "http2_stream", "[%" PRId64 "] [%u] " fmt, parent->connection_id(), this->get_id(), ##__VA_ARGS__);
+
 ClassAllocator<Http2Stream> http2StreamAllocator("http2StreamAllocator");
 
 int
@@ -261,7 +264,7 @@ Http2Stream::change_state(uint8_t type, uint8_t flags)
     return false;
   }
 
-  Debug("http2_stream", "%s", Http2DebugNames::get_state_name(_state));
+  Http2StreamDebug("%s", Http2DebugNames::get_state_name(_state));
 
   return true;
 }
@@ -314,7 +317,7 @@ Http2Stream::do_io_close(int /* flags */)
   SCOPED_MUTEX_LOCK(lock, this->mutex, this_ethread());
   super::release(nullptr);
   if (!closed) {
-    Debug("http2_stream", "do_io_close stream %d", this->get_id());
+    Http2StreamDebug("do_io_close");
 
     // When we get here, the SM has initiated the shutdown.  Either it received a WRITE_COMPLETE, or it is shutting down.  Any
     // remaining IO operations back to client should be abandoned.  The SM-side buffers backing these operations will be deleted
@@ -378,7 +381,7 @@ Http2Stream::initiating_close()
 {
   if (!closed) {
     SCOPED_MUTEX_LOCK(lock, this->mutex, this_ethread());
-    Debug("http2_stream", "initiating_close stream %d", this->get_id());
+    Http2StreamDebug("initiating_close");
 
     // Set the state of the connection to closed
     // TODO - these states should be combined
@@ -406,11 +409,11 @@ Http2Stream::initiating_close()
         SCOPED_MUTEX_LOCK(lock, write_vio.mutex, this_ethread());
         // Are we done?
         if (write_vio.nbytes == write_vio.ndone) {
-          Debug("http2_stream", "handle write from destroy stream=%d event=%d", this->_id, VC_EVENT_WRITE_COMPLETE);
+          Http2StreamDebug("handle write from destroy (event=%d)", VC_EVENT_WRITE_COMPLETE);
           write_event = send_tracked_event(write_event, VC_EVENT_WRITE_COMPLETE, &write_vio);
         } else {
           write_event = send_tracked_event(write_event, VC_EVENT_EOS, &write_vio);
-          Debug("http2_stream", "handle write from destroy stream=%d event=%d", this->_id, VC_EVENT_EOS);
+          Http2StreamDebug("handle write from destroy (event=%d)", VC_EVENT_EOS);
         }
         sent_write_complete = true;
       }
@@ -420,7 +423,7 @@ Http2Stream::initiating_close()
       // Only bother with the EOS if we haven't sent the write complete
       if (!sent_write_complete) {
         SCOPED_MUTEX_LOCK(lock, read_vio.mutex, this_ethread());
-        Debug("http2_stream", "send EOS to read cont stream=%d", this->_id);
+        Http2StreamDebug("send EOS to read cont");
         read_event = send_tracked_event(read_event, VC_EVENT_EOS, &read_vio);
       }
     } else if (current_reader) {
@@ -619,7 +622,7 @@ Http2Stream::update_write_request(IOBufferReader *buf_reader, int64_t write_len,
       }
     }
 
-    Debug("http2_stream", "write update stream_id=%d event=%d", this->get_id(), send_event);
+    Http2StreamDebug("write update (event=%d)", send_event);
   }
 
   return retval;
@@ -663,7 +666,7 @@ Http2Stream::reenable(VIO *vio)
 void
 Http2Stream::destroy()
 {
-  Debug("http2_stream", "Destroy stream %d, sent %" PRIu64 " bytes", this->_id, this->bytes_sent);
+  Http2StreamDebug("Destroy stream, sent %" PRIu64 " bytes", this->bytes_sent);
   SCOPED_MUTEX_LOCK(lock, this->mutex, this_ethread());
   // Clean up after yourself if this was an EOS
   ink_release_assert(this->closed);
@@ -736,7 +739,7 @@ Http2Stream::response_initialize_data_handling(bool &is_done)
   int chunked_index = response_header.value_get_index(name, strlen(name), value, strlen(value));
   // -1 means this value was not found for this field
   if (chunked_index >= 0) {
-    Debug("http2_stream", "Response is chunked");
+    Http2StreamDebug("Response is chunked");
     chunked = true;
     this->chunked_handler.init_by_action(this->response_reader, ChunkedHandler::ACTION_DECHUNK);
     this->chunked_handler.state            = ChunkedHandler::CHUNK_READ_SIZE;


### PR DESCRIPTION
All H2 log will contain connection id, and also stream id if available, with unified format.