### PR TITLE
Removed path-reading codes from records.config in RecCore

### DIFF
--- a/cmd/traffic_cop/traffic_cop.cc
+++ b/cmd/traffic_cop/traffic_cop.cc
@@ -547,12 +547,8 @@ ConfigIntFatalError:
 static std::string
 config_read_runtime_dir()
 {
-  char state_dir[PATH_NAME_MAX];
-
-  state_dir[0] = '\0';
-  config_read_string("proxy.config.local_state_dir", state_dir, sizeof(state_dir), true);
-  if (strlen(state_dir) > 0) {
-    return Layout::get()->relative(state_dir);
+  if (const char *env = getenv("PROXY_CONFIG_LOCAL_STATE_DIR")) {
+    return Layout::get()->relative(env);
   } else {
     return Layout::get()->runtimedir;
   }
@@ -561,12 +557,8 @@ config_read_runtime_dir()
 static std::string
 config_read_sysconfig_dir()
 {
-  char sysconfig_dir[PATH_NAME_MAX];
-
-  sysconfig_dir[0] = '\0';
-  config_read_string("proxy.config.config_dir", sysconfig_dir, sizeof(sysconfig_dir), true);
-  if (strlen(sysconfig_dir) > 0) {
-    return Layout::get()->relative(sysconfig_dir);
+  if (const char *env = getenv("PROXY_CONFIG_CONFIG_DIR")) {
+    return Layout::get()->relative(env);
   } else {
     return Layout::get()->sysconfdir;
   }
@@ -575,13 +567,8 @@ config_read_sysconfig_dir()
 static std::string
 config_read_bin_dir()
 {
-  char bindir[PATH_NAME_MAX];
-
-  bindir[0] = '\0';
-  config_read_string("proxy.config.bin_path", bindir, sizeof(bindir), true);
-  cop_log(COP_DEBUG, "binpath is %s\n", bindir);
-  if (strlen(bindir) > 0) {
-    return Layout::get()->relative(bindir);
+  if (const char *env = getenv("PROXY_CONFIG_BIN_PATH")) {
+    return Layout::get()->relative(env);
   } else {
     return Layout::get()->bindir;
   }
@@ -590,12 +577,8 @@ config_read_bin_dir()
 static std::string
 config_read_log_dir()
 {
-  char logdir[PATH_NAME_MAX];
-
-  logdir[0] = '\0';
-  config_read_string("proxy.config.log.logfile_dir", logdir, sizeof(logdir), true);
-  if (strlen(logdir) > 0) {
-    return Layout::get()->relative(logdir);
+  if (const char *env = getenv("PROXY_CONFIG_LOG_LOGFILE_DIR")) {
+    return Layout::get()->relative(env);
   } else {
     return Layout::get()->logdir;
   }

--- a/lib/records/I_RecCore.h
+++ b/lib/records/I_RecCore.h
@@ -48,19 +48,19 @@ typedef void (*RecConfigEntryCallback)(RecT rec_type, RecDataT data_type, const 
 void RecConfigFileInit(void);
 int RecConfigFileParse(const char *path, RecConfigEntryCallback handler, bool inc_version);
 
-// Return a copy of the system's configuration directory, taking proxy.config.config_dir into account. The
+// Return a copy of the system's configuration directory with Env variable overwrite.
 std::string RecConfigReadConfigDir();
 
-// Return a copy of the system's local state directory, taking proxy.config.local_state_dir into account. The
+// Return a copy of the system's local state directory with Env variable overwrite.
 std::string RecConfigReadRuntimeDir();
 
-// Return a copy of the system's log directory, taking proxy.config.log.logfile_dir into account. The caller
+// Return a copy of the system's log directory with Env variable overwrite.
 std::string RecConfigReadLogDir();
 
-// Return a copy of the system's bin directory, taking proxy.config.bin_path into account. The caller MUST
+// Return a copy of the system's bin directory with Env variable overwrite.
 std::string RecConfigReadBinDir();
 
-// Return a copy of the system's plugin directory, taking proxy.config.plugin.plugin_dir into account. The caller MUST
+// Return a copy of the system's plugin directory with Env variable overwrite.
 std::string RecConfigReadPluginDir();
 
 // Return a copy of a configuration file that is relative to sysconfdir. The relative path to the configuration

--- a/lib/records/RecCore.cc
+++ b/lib/records/RecCore.cc
@@ -1120,23 +1120,14 @@ REC_readString(const char *name, bool *found, bool lock)
   return _tmp;
 }
 
-// RecConfigReadConfigDir. Note that we handle environmental configuration
-// overrides specially here. Normally we would override the configuration
-// variable when we read records.config but to avoid the bootstrapping
-// problem, we make an explicit check here.
+//-------------------------------------------------------------------------
+// RecConfigReadConfigDir
+//-------------------------------------------------------------------------
 std::string
 RecConfigReadConfigDir()
 {
-  char buf[PATH_NAME_MAX] = {0};
-
   if (const char *env = getenv("PROXY_CONFIG_CONFIG_DIR")) {
-    ink_strlcpy(buf, env, sizeof(buf));
-  } else {
-    RecGetRecordString("proxy.config.config_dir", buf, sizeof(buf));
-  }
-
-  if (strlen(buf) > 0) {
-    return Layout::get()->relative(buf);
+    return Layout::get()->relative(env);
   } else {
     return Layout::get()->sysconfdir;
   }
@@ -1148,12 +1139,8 @@ RecConfigReadConfigDir()
 std::string
 RecConfigReadRuntimeDir()
 {
-  char buf[PATH_NAME_MAX];
-
-  buf[0] = '\0';
-  RecGetRecordString("proxy.config.local_state_dir", buf, PATH_NAME_MAX);
-  if (strlen(buf) > 0) {
-    return Layout::get()->relative(buf);
+  if (const char *env = getenv("PROXY_CONFIG_LOCAL_STATE_DIR")) {
+    return Layout::get()->relative(env);
   } else {
     return Layout::get()->runtimedir;
   }
@@ -1165,12 +1152,8 @@ RecConfigReadRuntimeDir()
 std::string
 RecConfigReadLogDir()
 {
-  char buf[PATH_NAME_MAX];
-
-  buf[0] = '\0';
-  RecGetRecordString("proxy.config.log.logfile_dir", buf, PATH_NAME_MAX);
-  if (strlen(buf) > 0) {
-    return Layout::get()->relative(buf);
+  if (const char *env = getenv("PROXY_CONFIG_LOG_LOGFILE_DIR")) {
+    return Layout::get()->relative(env);
   } else {
     return Layout::get()->logdir;
   }
@@ -1182,12 +1165,8 @@ RecConfigReadLogDir()
 std::string
 RecConfigReadBinDir()
 {
-  char buf[PATH_NAME_MAX];
-
-  buf[0] = '\0';
-  RecGetRecordString("proxy.config.bin_path", buf, PATH_NAME_MAX);
-  if (strlen(buf) > 0) {
-    return Layout::get()->relative(buf);
+  if (const char *env = getenv("PROXY_CONFIG_BIN_PATH")) {
+    return Layout::get()->relative(env);
   } else {
     return Layout::get()->bindir;
   }
@@ -1199,7 +1178,11 @@ RecConfigReadBinDir()
 std::string
 RecConfigReadPluginDir()
 {
-  return RecConfigReadPrefixPath("proxy.config.plugin.plugin_dir");
+  if (const char *env = getenv("PROXY_CONFIG_PLUGIN_PLUGIN_DIR")) {
+    return Layout::get()->relative(env);
+  } else {
+    return Layout::get()->libexecdir;
+  }
 }
 
 //-------------------------------------------------------------------------

--- a/mgmt/api/APITestCliRemote.cc
+++ b/mgmt/api/APITestCliRemote.cc
@@ -512,7 +512,7 @@ test_record_get_mlt()
   TSStringList name_list;
   TSList rec_list;
   int i, num;
-  char *v1, *v2, *v3, *v6, *v7;
+  char *v1, *v3, *v6, *v7;
   TSMgmtError ret;
 
   name_list = TSStringListCreate();
@@ -521,9 +521,6 @@ test_record_get_mlt()
   const size_t v1_size = (sizeof(char) * (strlen("proxy.config.proxy_name") + 1));
   v1                   = (char *)TSmalloc(v1_size);
   ink_strlcpy(v1, "proxy.config.proxy_name", v1_size);
-  const size_t v2_size = (sizeof(char) * (strlen("proxy.config.bin_path") + 1));
-  v2                   = (char *)TSmalloc(v2_size);
-  ink_strlcpy(v2, "proxy.config.bin_path", v2_size);
   const size_t v3_size = (sizeof(char) * (strlen("proxy.config.manager_binary") + 1));
   v3                   = (char *)TSmalloc(v3_size);
   ink_strlcpy(v3, "proxy.config.manager_binary", v3_size);
@@ -536,7 +533,6 @@ test_record_get_mlt()
 
   // add the names to the get_list
   TSStringListEnqueue(name_list, v1);
-  TSStringListEnqueue(name_list, v2);
   TSStringListEnqueue(name_list, v3);
   TSStringListEnqueue(name_list, v6);
   TSStringListEnqueue(name_list, v7);


### PR DESCRIPTION
We should not read any path values from records.config. An example problem will occur by reading the records.config (in config directory) to find the config directory, a contradiction.

There is no need for: 
``proxy.config.config_dir``
``proxy.config.local_state_dir``
``proxy.config.bin_path``
``proxy.config.log.logfile_dir``
``proxy.config.plugin.plugin_dir``

These values overwrite all the path which are already nicely built in the layout code. We can overwrite these value using ENVIRONMENT variables.

Documents will be updated later.

@SolidWallOfCode @dragon512 