### PR TITLE
corrects calls to TSContSchedule in documentation examples

### DIFF
--- a/doc/developer-guide/plugins/actions/index.en.rst
+++ b/doc/developer-guide/plugins/actions/index.en.rst
@@ -97,7 +97,7 @@ Below is an example of typical usage for an action:
                system is initialized. We'll simply schedule an event
                on the continuation to occur as soon as the rest of
                the system is started up. */
-            TSContSchedule (contp, 0);
+            TSContSchedule (contp, 0, TS_THREAD_POOL_DEFAULT);
         }
 
 The example above shows a simple plugin that creates a continuation and
@@ -127,7 +127,7 @@ cancel the action. The following sample code implements this:
         {
             switch (event) {
                 case (TS_EVENT_IMMEDIATE):
-                    TSContSchedule (contp, 30000);
+                    TSContSchedule (contp, 30000, TS_THREAD_POOL_DEFAULT);
                     TSAction actionp = TSNetConnect(contp, 127.0.0.1, 9999);
                     if (!TSActionDone (actionp)) {
                         TSContDataSet (contp, actionp);


### PR DESCRIPTION
Milestone: v8.0.0
Labels: Backport, Documentation
Projects: 7.x releases

Backport Reason: Same error is present in 7.x