### PR TITLE
Remove multiprocessing.Queue.qsize() from traffic_replay

### DIFF
--- a/tests/tools/traffic-replay/Scheduler.py
+++ b/tests/tools/traffic-replay/Scheduler.py
@@ -47,7 +47,6 @@ def LaunchWorkers(path, nProcess, proxy, replay_type, nThread):
         # if QList[0].qsize() > 10 :
         #    break
     #=============================================== Launch Processes
-    print("size", QList[0].qsize())
     for i in range(nProcess):
         QList[i].put('STOP')
     for i in range(nProcess):


### PR DESCRIPTION
Because this raise NotImplementedError on Unix platforms like Mac OS X.
Details in below.
http://python.readthedocs.io/en/stable/library/multiprocessing.html#multiprocessing.Queue.qsize