### PR TITLE
Fix include issue in example null transform plugin and test

### DIFF
--- a/example/null_transform/null_transform.c
+++ b/example/null_transform/null_transform.c
@@ -23,9 +23,9 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include <inttypes.h>
 
 #include "ts/ts.h"
-#include "ts/ink_defs.h"
 
 #define PLUGIN_NAME "null_transform"
 
@@ -183,7 +183,7 @@ handle_transform(TSCont contp)
 }
 
 static int
-null_transform(TSCont contp, TSEvent event, void *edata ATS_UNUSED)
+null_transform(TSCont contp, TSEvent event, void *edata)
 {
   /* Check to see if the transformation has been closed by a call to
    * TSVConnClose.
@@ -275,7 +275,7 @@ transform_add(TSHttpTxn txnp)
 }
 
 static int
-transform_plugin(TSCont contp ATS_UNUSED, TSEvent event, void *edata)
+transform_plugin(TSCont contp, TSEvent event, void *edata)
 {
   TSHttpTxn txnp = (TSHttpTxn)edata;
 
@@ -297,7 +297,7 @@ transform_plugin(TSCont contp ATS_UNUSED, TSEvent event, void *edata)
 }
 
 void
-TSPluginInit(int argc ATS_UNUSED, const char *argv[] ATS_UNUSED)
+TSPluginInit(int argc, const char *argv[])
 {
   TSPluginRegistrationInfo info;
 

--- a/tests/gold_tests/null_transform/gold/null_transform-200.gold
+++ b/tests/gold_tests/null_transform/gold/null_transform-200.gold
@@ -1,14 +1,11 @@
 ``
 > GET http://www.example.com/ HTTP/1.1
+``
 > Host: www.example.com``
-> User-Agent: curl/``
-> Accept: */*
-> Proxy-Connection:``
 ``
 < HTTP/1.1 200 OK
-< Date:``
+``
 < Content-Length: 26
-< Age: ``
-< Proxy-Connection: keep-alive
+``
 < Server: ATS/``
 ``

--- a/tests/gold_tests/null_transform/null_transform.test.py
+++ b/tests/gold_tests/null_transform/null_transform.test.py
@@ -55,20 +55,7 @@ ts.Disk.remap_config.AddLine(
 )
 
 # Load plugin
-plugin_args = ""
-lib_dir = os.path.join(Test.Variables.AtsTestToolsDir, '../../lib')
-plugin_dir = ts.Env['PROXY_CONFIG_PLUGIN_PLUGIN_DIR']
-plugin_dir_src = os.path.join(Test.Variables.AtsTestToolsDir, 'plugins', 'null_transform.c')
-ts.Setup.Copy(plugin_dir_src, plugin_dir)
-
-in_basename = os.path.basename(plugin_dir_src)
-in_path = os.path.join(plugin_dir, in_basename)
-out_basename = os.path.splitext(in_basename)[0] + '.so'
-out_path = os.path.join(plugin_dir, out_basename)
-
-ts.Setup.RunCommand('tsxs -c {0} -o {1} -I {2}'.format(in_path, out_path, lib_dir))
-ts.Disk.plugin_config.AddLine("{0} {1}".format(out_basename, plugin_args))
-
+Test.prepare_plugin(os.path.join(Test.Variables.AtsTestToolsDir, 'plugins', 'null_transform.c'), ts)
 
 # www.example.com Host
 tr = Test.AddTestRun()

--- a/tests/tools/plugins/null_transform.c
+++ b/tests/tools/plugins/null_transform.c
@@ -1,6 +1,6 @@
 /** @file
 
-  A brief file description
+  An example program that does a null transform of response body content.
 
   @section license License
 
@@ -21,22 +21,11 @@
   limitations under the License.
  */
 
-/* null_transform.c:  an example program that does a null transform
- *                    of response body content
- *
- *
- *
- *	Usage:
- *	  null_transform.so
- *
- *
- */
-
 #include <stdio.h>
 #include <unistd.h>
+#include <inttypes.h>
 
 #include "ts/ts.h"
-#include "ts/ink_defs.h"
 
 #define PLUGIN_NAME "null_transform"
 
@@ -194,7 +183,7 @@ handle_transform(TSCont contp)
 }
 
 static int
-null_transform(TSCont contp, TSEvent event, void *edata ATS_UNUSED)
+null_transform(TSCont contp, TSEvent event, void *edata)
 {
   /* Check to see if the transformation has been closed by a call to
    * TSVConnClose.
@@ -286,7 +275,7 @@ transform_add(TSHttpTxn txnp)
 }
 
 static int
-transform_plugin(TSCont contp ATS_UNUSED, TSEvent event, void *edata)
+transform_plugin(TSCont contp, TSEvent event, void *edata)
 {
   TSHttpTxn txnp = (TSHttpTxn)edata;
 
@@ -308,7 +297,7 @@ transform_plugin(TSCont contp ATS_UNUSED, TSEvent event, void *edata)
 }
 
 void
-TSPluginInit(int argc ATS_UNUSED, const char *argv[] ATS_UNUSED)
+TSPluginInit(int argc, const char *argv[])
 {
   TSPluginRegistrationInfo info;
 


### PR DESCRIPTION
Fix null_transform.test.py on how to load plugin
Minor changes on gold file

Removed all `ATS_UNUSED`. This fix deals with the `#include "ts/ink_defs.h"`, which is internal and requires additional include argument to compile with tsxs. This causes problem in autest.
