### PR TITLE
header_rewrite: Allow set-debug in READ_RESPONSE_HDR_HOOK.

### DIFF
--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -926,6 +926,7 @@ void
 OperatorSetDebug::initialize_hooks()
 {
   add_allowed_hook(TS_HTTP_READ_REQUEST_HDR_HOOK);
+  add_allowed_hook(TS_HTTP_READ_RESPONSE_HDR_HOOK);
   add_allowed_hook(TS_REMAP_PSEUDO_HOOK);
 }
 


### PR DESCRIPTION
This doesn't work currently:
```
cond %{READ_RESPONSE_HDR_HOOK}
cond %{STATUS} =302
set-debug
```
I see no reason it shouldn't. I tweaked the code to enable it and it worked fine both globally and remap.