### PR TITLE
Make it Python 3 compatible

### DIFF
--- a/tools/check-unused-dependencies
+++ b/tools/check-unused-dependencies
@@ -92,9 +92,9 @@ for filename in config_files.split():
                         dependencies = list(get_dependencies(program))
                         if len(dependencies) > 1:
                             success = False
-                            print program
+                            print (program)
                             for dependency in dependencies:
-                                print dependency
+                                print (dependency)
 
 if not success:
     sys.exit(1)


### PR DESCRIPTION
Fix the issue where `check-unused-dependencies` gives error when running `make test` if python3 is the default python.