### PR TITLE
Do not try to open the resolv_conf file if it's nullptr.

### DIFF
--- a/lib/ts/ink_res_init.cc
+++ b/lib/ts/ink_res_init.cc
@@ -441,7 +441,7 @@ ink_res_init(ink_res_state statp,         ///< State object to update.
 #define MATCH(line, name) \
   (!strncmp(line, name, sizeof(name) - 1) && (line[sizeof(name) - 1] == ' ' || line[sizeof(name) - 1] == '\t'))
 
-  if ((fp = fopen(pResolvConf, "r")) != nullptr) {
+  if (pResolvConf && ((fp = fopen(pResolvConf, "r")) != nullptr)) {
     /* read the config file */
     while (fgets(buf, sizeof(buf), fp) != nullptr) {
       /* skip comments */


### PR DESCRIPTION
@persiaAziz found this doing ASAN related testing. It is unclear why this doesn't break without ASAN but having run it through the debugger, `fopen` happily accepts a `nullptr` path and just returns `nullptr`. I suspect it's catching exceptions internally but when running ASAN that doesn't work. In any case, it's reasonable to do our own check and not try to open a non-existent resolver configuration file.