### PR TITLE
Port some of autests to OS X

### DIFF
--- a/tests/gold_tests/autest-site/ports.py
+++ b/tests/gold_tests/autest-site/ports.py
@@ -19,6 +19,7 @@
 import socket
 import subprocess
 import os
+import platform
 
 import hosts.output as host
 
@@ -61,10 +62,20 @@ def setup_port_queue(amount=1000):
         # some docker setups don't have sbin setup correctly
         new_env = os.environ.copy()
         new_env['PATH'] = "/sbin:/usr/sbin:" + new_env['PATH']
-        dmin, dmax = subprocess.check_output(
-            ["sysctl", "net.ipv4.ip_local_port_range"],
-            env=new_env
-        ).decode().split("=")[1].split()
+        if 'Darwin' == platform.system():
+            dmin = subprocess.check_output(
+                ["sysctl", "net.inet.ip.portrange.first"],
+                env=new_env
+            ).decode().split(":")[1].split()[0]
+            dmax = subprocess.check_output(
+                ["sysctl", "net.inet.ip.portrange.last"],
+                env=new_env
+            ).decode().split(":")[1].split()[0]
+        else:
+            dmin, dmax = subprocess.check_output(
+                ["sysctl", "net.ipv4.ip_local_port_range"],
+                env=new_env
+            ).decode().split("=")[1].split()
         dmin = int(dmin)
         dmax = int(dmax)
     except:

--- a/tests/gold_tests/headers/forwarded.test.py
+++ b/tests/gold_tests/headers/forwarded.test.py
@@ -159,11 +159,8 @@ ts.Disk.remap_config.AddLine(
 
 # Ask the OS if the port is ready for connect()
 #
-
-
-def CheckPort(Port):
-    return lambda: 0 == subprocess.call('netstat --listen --tcp -n | grep -q :{}'.format(Port), shell=True)
-
+def CheckPort(port):
+    return lambda: 0 == subprocess.call('lsof -iTCP:{} -sTCP:LISTEN'.format(port), shell=True, stdout=open(os.devnull, 'wb'), stderr=open(os.devnull, 'wb'))
 
 # Basic HTTP 1.1 -- No Forwarded by default
 tr = Test.AddTestRun()

--- a/tests/gold_tests/headers/normalize_ae.test.py
+++ b/tests/gold_tests/headers/normalize_ae.test.py
@@ -82,12 +82,10 @@ baselineTsSetup(ts)
 normalize_ae_log_id = Test.Disk.File("normalize_ae.log")
 normalize_ae_log_id.Content = "normalize_ae.gold"
 
-# ask the os if the port is ready for connect()
+# Ask the os if the port is ready for connect()
 #
-
-
 def CheckPort(port):
-    return lambda: 0 == subprocess.call('netstat --listen --tcp -n | grep -q :{}'.format(port), shell=True)
+    return lambda: 0 == subprocess.call('lsof -iTCP:{} -sTCP:LISTEN'.format(port), shell=True, stdout=open(os.devnull, 'wb'), stderr=open(os.devnull, 'wb'))
 
 # Try various Accept-Encoding header fields for a particular traffic server and host.
 

--- a/tests/gold_tests/headers/via.test.py
+++ b/tests/gold_tests/headers/via.test.py
@@ -73,11 +73,9 @@ via_log_id = Test.Disk.File("via.log")
 via_log_id.Content = "via.gold"
 
 # Ask the OS if the port is ready for connect()
-
-
-def CheckPort(Port):
-    return lambda: 0 == subprocess.call('netstat --listen --tcp -n | grep -q :{}'.format(Port), shell=True)
-
+#
+def CheckPort(port):
+    return lambda: 0 == subprocess.call('lsof -iTCP:{} -sTCP:LISTEN'.format(port), shell=True, stdout=open(os.devnull, 'wb'), stderr=open(os.devnull, 'wb'))
 
 # Basic HTTP 1.1
 tr = Test.AddTestRun()

--- a/tests/gold_tests/logging/ccid_ctid.test.py
+++ b/tests/gold_tests/logging/ccid_ctid.test.py
@@ -72,11 +72,8 @@ log.ascii {
 
 # Ask the OS if the port is ready for connect()
 #
-
-
-def CheckPort(Port):
-    return lambda: 0 == subprocess.call('netstat --listen --tcp -n | grep -q :{}'.format(Port), shell=True)
-
+def CheckPort(port):
+    return lambda: 0 == subprocess.call('lsof -iTCP:{} -sTCP:LISTEN'.format(port), shell=True, stdout=open(os.devnull, 'wb'), stderr=open(os.devnull, 'wb'))
 
 tr = Test.AddTestRun()
 # Delay on readiness of ssl port

--- a/tests/gold_tests/tls/ssl-post.c
+++ b/tests/gold_tests/tls/ssl-post.c
@@ -85,7 +85,7 @@ spawn_same_session_send(void *arg)
   fcntl(sfd, F_SETFL, O_NONBLOCK);
   // Make sure we are nagling
   int one = 0;
-  setsockopt(sfd, SOL_TCP, TCP_NODELAY, &one, sizeof(one));
+  setsockopt(sfd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
 
   SSL_CTX *client_ctx = SSL_CTX_new(SSLv23_client_method());
   SSL *ssl            = SSL_new(client_ctx);
@@ -220,7 +220,7 @@ main(int argc, char *argv[])
   }
   char *host       = argv[1];
   int header_count = atoi(argv[3]);
-  snprintf(req_buf, sizeof(req_buf), "POST /post HTTP/1.1\r\nHost: %s\r\nConnection: close\r\nContent-length:%d\r\n", host,
+  snprintf(req_buf, sizeof(req_buf), "POST /post HTTP/1.1\r\nHost: %s\r\nConnection: close\r\nContent-length:%ld\r\n", host,
            sizeof(post_buf));
   int i;
   for (i = 0; i < header_count; i++) {
@@ -318,7 +318,7 @@ main(int argc, char *argv[])
     retval = NULL;
     pthread_join(threads[i], &retval);
     if (retval != NULL) {
-      printf("Thread %d failed 0x%x\n", i, retval);
+      printf("Thread %d failed %p\n", i, retval);
     }
   }
 


### PR DESCRIPTION
* changed `netstat` usage to `lsof`
* added OS X specific `sysctl` usage for getting port range
* changed less portable `SOL_TCP` to `IPPROTO_TCP`