### PR TITLE
Increase write_vio.ndone only if sending DATA frame is succeeded

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1236,11 +1236,11 @@ Http2ConnectionState::send_data_frames_depends_on_priority()
   ink_release_assert(stream != nullptr);
   Http2StreamDebug(ua_session, stream->get_id(), "top node, point=%d", node->point);
 
-  size_t len                       = 0;
-  Http2SendADataFrameResult result = send_a_data_frame(stream, len);
+  size_t len                      = 0;
+  Http2SendDataFrameResult result = send_a_data_frame(stream, len);
 
   switch (result) {
-  case HTTP2_SEND_A_DATA_FRAME_NO_ERROR: {
+  case Http2SendDataFrameResult::NO_ERROR: {
     // No response body to send
     if (len == 0 && !stream->is_body_done()) {
       dependency_tree->deactivate(node, len);
@@ -1249,7 +1249,7 @@ Http2ConnectionState::send_data_frames_depends_on_priority()
     }
     break;
   }
-  case HTTP2_SEND_A_DATA_FRAME_DONE: {
+  case Http2SendDataFrameResult::DONE: {
     dependency_tree->deactivate(node, len);
     delete_stream(stream);
     break;
@@ -1264,13 +1264,14 @@ Http2ConnectionState::send_data_frames_depends_on_priority()
   return;
 }
 
-Http2SendADataFrameResult
+Http2SendDataFrameResult
 Http2ConnectionState::send_a_data_frame(Http2Stream *stream, size_t &payload_length)
 {
   const ssize_t window_size         = std::min(this->client_rwnd, stream->client_rwnd);
   const size_t buf_len              = BUFFER_SIZE_FOR_INDEX(buffer_size_index[HTTP2_FRAME_TYPE_DATA]);
   const size_t write_available_size = std::min(buf_len, static_cast<size_t>(window_size));
   size_t read_available_size        = 0;
+  payload_length                    = 0;
 
   uint8_t flags = 0x00;
   uint8_t payload_buffer[buf_len];
@@ -1280,16 +1281,21 @@ Http2ConnectionState::send_a_data_frame(Http2Stream *stream, size_t &payload_len
 
   if (current_reader) {
     read_available_size = static_cast<size_t>(current_reader->read_avail());
+  } else {
+    Http2StreamDebug(this->ua_session, stream->get_id(), "couldn't get data reader");
+    return Http2SendDataFrameResult::ERROR;
   }
 
   // Select appropriate payload length
   if (read_available_size > 0) {
     // We only need to check for window size when there is a payload
     if (window_size <= 0) {
-      return HTTP2_SEND_A_DATA_FRAME_NO_WINDOW;
+      Http2StreamDebug(this->ua_session, stream->get_id(), "No window");
+      return Http2SendDataFrameResult::NO_WINDOW;
     }
     // Copy into the payload buffer. Seems like we should be able to skip this copy step
-    payload_length = current_reader->read(payload_buffer, write_available_size);
+    payload_length = std::min(read_available_size, write_available_size);
+    current_reader->memcpy(payload_buffer, static_cast<int64_t>(payload_length));
   } else {
     payload_length = 0;
   }
@@ -1298,7 +1304,8 @@ Http2ConnectionState::send_a_data_frame(Http2Stream *stream, size_t &payload_len
   // If we return here, we never send the END_STREAM in the case of a early terminating OS.
   // OK if there is no body yet. Otherwise continue on to send a DATA frame and delete the stream
   if (!stream->is_body_done() && payload_length == 0) {
-    return HTTP2_SEND_A_DATA_FRAME_NO_PAYLOAD;
+    Http2StreamDebug(this->ua_session, stream->get_id(), "No payload");
+    return Http2SendDataFrameResult::NO_PAYLOAD;
   }
 
   if (stream->is_body_done() && read_available_size <= write_available_size) {
@@ -1310,8 +1317,8 @@ Http2ConnectionState::send_a_data_frame(Http2Stream *stream, size_t &payload_len
   stream->client_rwnd -= payload_length;
 
   // Create frame
-  Http2StreamDebug(ua_session, stream->get_id(), "Send a DATA frame - client window con: %zd stream: %zd payload: %zd", client_rwnd,
-                   stream->client_rwnd, payload_length);
+  Http2StreamDebug(ua_session, stream->get_id(), "Send a DATA frame - client window con: %5zd stream: %5zd payload: %5zd",
+                   client_rwnd, stream->client_rwnd, payload_length);
 
   Http2Frame data(HTTP2_FRAME_TYPE_DATA, stream->get_id(), flags);
   data.alloc(buffer_size_index[HTTP2_FRAME_TYPE_DATA]);
@@ -1319,6 +1326,7 @@ Http2ConnectionState::send_a_data_frame(Http2Stream *stream, size_t &payload_len
   data.finalize(payload_length);
 
   stream->update_sent_count(payload_length);
+  current_reader->consume(payload_length);
 
   // xmit event
   SCOPED_MUTEX_LOCK(lock, this->ua_session->mutex, this_ethread());
@@ -1330,10 +1338,10 @@ Http2ConnectionState::send_a_data_frame(Http2Stream *stream, size_t &payload_len
     // Setting to the same state shouldn't be erroneous
     stream->change_state(data.header().type, data.header().flags);
 
-    return HTTP2_SEND_A_DATA_FRAME_DONE;
+    return Http2SendDataFrameResult::DONE;
   }
 
-  return HTTP2_SEND_A_DATA_FRAME_NO_ERROR;
+  return Http2SendDataFrameResult::NO_ERROR;
 }
 
 void
@@ -1348,24 +1356,22 @@ Http2ConnectionState::send_data_frames(Http2Stream *stream)
     return;
   }
 
-  size_t len = 0;
-  while (true) {
-    Http2SendADataFrameResult result = send_a_data_frame(stream, len);
+  size_t len                      = 0;
+  Http2SendDataFrameResult result = Http2SendDataFrameResult::NO_ERROR;
+  while (result == Http2SendDataFrameResult::NO_ERROR) {
+    result = send_a_data_frame(stream, len);
 
-    if (result == HTTP2_SEND_A_DATA_FRAME_DONE) {
+    if (result == Http2SendDataFrameResult::DONE) {
       // Delete a stream immediately
       // TODO its should not be deleted for a several time to handling
       // RST_STREAM and WINDOW_UPDATE.
       // See 'closed' state written at [RFC 7540] 5.1.
       Http2StreamDebug(this->ua_session, stream->get_id(), "Shutdown stream");
       this->delete_stream(stream);
-      break;
-    } else if (result == HTTP2_SEND_A_DATA_FRAME_NO_ERROR) {
-      continue;
-    } else {
-      break;
     }
   }
+
+  return;
 }
 
 void

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1236,11 +1236,11 @@ Http2ConnectionState::send_data_frames_depends_on_priority()
   ink_release_assert(stream != nullptr);
   Http2StreamDebug(ua_session, stream->get_id(), "top node, point=%d", node->point);
 
-  size_t len                      = 0;
-  Http2SendDataFrameResult result = send_a_data_frame(stream, len);
+  size_t len                       = 0;
+  Http2SendADataFrameResult result = send_a_data_frame(stream, len);
 
   switch (result) {
-  case Http2SendDataFrameResult::NO_ERROR: {
+  case HTTP2_SEND_A_DATA_FRAME_NO_ERROR: {
     // No response body to send
     if (len == 0 && !stream->is_body_done()) {
       dependency_tree->deactivate(node, len);
@@ -1249,7 +1249,7 @@ Http2ConnectionState::send_data_frames_depends_on_priority()
     }
     break;
   }
-  case Http2SendDataFrameResult::DONE: {
+  case HTTP2_SEND_A_DATA_FRAME_DONE: {
     dependency_tree->deactivate(node, len);
     delete_stream(stream);
     break;
@@ -1264,7 +1264,7 @@ Http2ConnectionState::send_data_frames_depends_on_priority()
   return;
 }
 
-Http2SendDataFrameResult
+Http2SendADataFrameResult
 Http2ConnectionState::send_a_data_frame(Http2Stream *stream, size_t &payload_length)
 {
   const ssize_t window_size         = std::min(this->client_rwnd, stream->client_rwnd);
@@ -1286,7 +1286,7 @@ Http2ConnectionState::send_a_data_frame(Http2Stream *stream, size_t &payload_len
   if (read_available_size > 0) {
     // We only need to check for window size when there is a payload
     if (window_size <= 0) {
-      return Http2SendDataFrameResult::NO_WINDOW;
+      return HTTP2_SEND_A_DATA_FRAME_NO_WINDOW;
     }
     // Copy into the payload buffer. Seems like we should be able to skip this copy step
     payload_length = current_reader->read(payload_buffer, write_available_size);
@@ -1298,7 +1298,7 @@ Http2ConnectionState::send_a_data_frame(Http2Stream *stream, size_t &payload_len
   // If we return here, we never send the END_STREAM in the case of a early terminating OS.
   // OK if there is no body yet. Otherwise continue on to send a DATA frame and delete the stream
   if (!stream->is_body_done() && payload_length == 0) {
-    return Http2SendDataFrameResult::NO_PAYLOAD;
+    return HTTP2_SEND_A_DATA_FRAME_NO_PAYLOAD;
   }
 
   if (stream->is_body_done() && read_available_size <= write_available_size) {
@@ -1330,13 +1330,13 @@ Http2ConnectionState::send_a_data_frame(Http2Stream *stream, size_t &payload_len
     // Setting to the same state shouldn't be erroneous
     stream->change_state(data.header().type, data.header().flags);
 
-    return Http2SendDataFrameResult::DONE;
+    return HTTP2_SEND_A_DATA_FRAME_DONE;
   }
 
-  return Http2SendDataFrameResult::NO_ERROR;
+  return HTTP2_SEND_A_DATA_FRAME_NO_ERROR;
 }
 
-Http2SendDataFrameResult
+void
 Http2ConnectionState::send_data_frames(Http2Stream *stream)
 {
   // To follow RFC 7540 must not send more frames other than priority on
@@ -1345,25 +1345,27 @@ Http2ConnectionState::send_data_frames(Http2Stream *stream)
       stream->get_state() == Http2StreamState::HTTP2_STREAM_STATE_CLOSED) {
     Http2StreamDebug(this->ua_session, stream->get_id(), "Shutdown half closed local stream");
     this->delete_stream(stream);
-    return Http2SendDataFrameResult::NO_ERROR;
+    return;
   }
 
-  size_t len                      = 0;
-  Http2SendDataFrameResult result = Http2SendDataFrameResult::NO_ERROR;
-  while (result == Http2SendDataFrameResult::NO_ERROR) {
-    result = send_a_data_frame(stream, len);
+  size_t len = 0;
+  while (true) {
+    Http2SendADataFrameResult result = send_a_data_frame(stream, len);
 
-    if (result == Http2SendDataFrameResult::DONE) {
+    if (result == HTTP2_SEND_A_DATA_FRAME_DONE) {
       // Delete a stream immediately
       // TODO its should not be deleted for a several time to handling
       // RST_STREAM and WINDOW_UPDATE.
       // See 'closed' state written at [RFC 7540] 5.1.
       Http2StreamDebug(this->ua_session, stream->get_id(), "Shutdown stream");
       this->delete_stream(stream);
+      break;
+    } else if (result == HTTP2_SEND_A_DATA_FRAME_NO_ERROR) {
+      continue;
+    } else {
+      break;
     }
   }
-
-  return result;
 }
 
 void

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -31,11 +31,12 @@
 
 class Http2ClientSession;
 
-enum Http2SendADataFrameResult {
-  HTTP2_SEND_A_DATA_FRAME_NO_ERROR   = 0,
-  HTTP2_SEND_A_DATA_FRAME_NO_WINDOW  = 1,
-  HTTP2_SEND_A_DATA_FRAME_NO_PAYLOAD = 2,
-  HTTP2_SEND_A_DATA_FRAME_DONE       = 3,
+enum class Http2SendDataFrameResult {
+  NO_ERROR = 0,
+  NO_WINDOW,
+  NO_PAYLOAD,
+  ERROR,
+  DONE,
 };
 
 enum Http2ShutdownState { NOT_INITIATED, INITIATED, IN_PROGRESS };
@@ -219,7 +220,7 @@ public:
   void schedule_stream(Http2Stream *stream);
   void send_data_frames_depends_on_priority();
   void send_data_frames(Http2Stream *stream);
-  Http2SendADataFrameResult send_a_data_frame(Http2Stream *stream, size_t &payload_length);
+  Http2SendDataFrameResult send_a_data_frame(Http2Stream *stream, size_t &payload_length);
   void send_headers_frame(Http2Stream *stream);
   void send_push_promise_frame(Http2Stream *stream, URL &url, const MIMEField *accept_encoding);
   void send_rst_stream_frame(Http2StreamId id, Http2ErrorCode ec);

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -31,11 +31,11 @@
 
 class Http2ClientSession;
 
-enum class Http2SendDataFrameResult {
-  NO_ERROR   = 0,
-  NO_WINDOW  = 1,
-  NO_PAYLOAD = 2,
-  DONE       = 3,
+enum Http2SendADataFrameResult {
+  HTTP2_SEND_A_DATA_FRAME_NO_ERROR   = 0,
+  HTTP2_SEND_A_DATA_FRAME_NO_WINDOW  = 1,
+  HTTP2_SEND_A_DATA_FRAME_NO_PAYLOAD = 2,
+  HTTP2_SEND_A_DATA_FRAME_DONE       = 3,
 };
 
 enum Http2ShutdownState { NOT_INITIATED, INITIATED, IN_PROGRESS };
@@ -218,8 +218,8 @@ public:
   // HTTP/2 frame sender
   void schedule_stream(Http2Stream *stream);
   void send_data_frames_depends_on_priority();
-  Http2SendDataFrameResult send_data_frames(Http2Stream *stream);
-  Http2SendDataFrameResult send_a_data_frame(Http2Stream *stream, size_t &payload_length);
+  void send_data_frames(Http2Stream *stream);
+  Http2SendADataFrameResult send_a_data_frame(Http2Stream *stream, size_t &payload_length);
   void send_headers_frame(Http2Stream *stream);
   void send_push_promise_frame(Http2Stream *stream, URL &url, const MIMEField *accept_encoding);
   void send_rst_stream_frame(Http2StreamId id, Http2ErrorCode ec);

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -315,32 +315,26 @@ void
 Http2Stream::do_io_close(int /* flags */)
 {
   SCOPED_MUTEX_LOCK(lock, this->mutex, this_ethread());
-
+  super::release(nullptr);
   if (!closed) {
-    if (parent && this->is_client_state_writeable()) {
-      // Make sure any trailing end of stream frames are sent
-      // Wee will be removed at send_data_frames or closing connection phase
-      Http2SendDataFrameResult result = static_cast<Http2ClientSession *>(parent)->connection_state.send_data_frames(this);
-      if (result == Http2SendDataFrameResult::NO_WINDOW) {
-        Http2StreamDebug("cancel closing");
-        return;
-      } else {
-        Http2StreamDebug("continue closing");
-      }
-    }
+    Http2StreamDebug("do_io_close");
 
     // When we get here, the SM has initiated the shutdown.  Either it received a WRITE_COMPLETE, or it is shutting down.  Any
     // remaining IO operations back to client should be abandoned.  The SM-side buffers backing these operations will be deleted
     // by the time this is called from transaction_done.
     closed = true;
 
+    if (parent && this->is_client_state_writeable()) {
+      // Make sure any trailing end of stream frames are sent
+      // Wee will be removed at send_data_frames or closing connection phase
+      static_cast<Http2ClientSession *>(parent)->connection_state.send_data_frames(this);
+    }
+
     clear_timers();
     clear_io_events();
 
     // Wait until transaction_done is called from HttpSM to signal that the TXN_CLOSE hook has been executed
   }
-
-  super::release(nullptr);
 }
 
 /*

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -81,6 +81,7 @@ public:
   update_sent_count(unsigned num_bytes)
   {
     bytes_sent += num_bytes;
+    this->write_vio.ndone += num_bytes;
   }
 
   Http2StreamId

--- a/tests/gold_tests/h2/http2.test.py
+++ b/tests/gold_tests/h2/http2.test.py
@@ -65,11 +65,12 @@ ts.Disk.ssl_multicert_config.AddLine(
 )
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http|socket',
+    'proxy.config.diags.debug.tags': 'http2',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     # enable ssl port
     'proxy.config.http.server_ports': '{0} {1}:proto=http2;http:ssl'.format(ts.Variables.port, ts.Variables.ssl_port),
+    'proxy.config.http.cache.http': 0,
     'proxy.config.ssl.client.verify.server':  0,
     'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
     'proxy.config.http2.active_timeout_in': 3,


### PR DESCRIPTION
This is alternate approach of #2805 (fix for ~~#2759~~ #2795). As we concerned, "cancel closing on `Http2Stream::do_io_close()`" was bad idea.  It led connection leaks (#2834).
And I couldn't find reasons of connection leaks. So I revisited ~~#2759~~ #2795.

## Root cause of ~~#2759~~ #2795
1) The `write_vio.ndone` is increased regardless the stream could send data frame or not. 
https://github.com/apache/trafficserver/blob/e2bccd5384a4a3e769f994ee794888f3efacb335/proxy/http2/Http2Stream.cc#L561

2) This leads `VC_EVENT_WRITE_COMPLETE` event on `HttpTunnel` even if the response is not proceed (especially `ChunkHandler` is used). 
https://github.com/apache/trafficserver/blob/e2bccd5384a4a3e769f994ee794888f3efacb335/proxy/http/HttpTunnel.cc#L1510-L1512

3) Finally `Http2Stream::do_io_close()` is called from `HttpSM`.
https://github.com/apache/trafficserver/blob/e2bccd5384a4a3e769f994ee794888f3efacb335/proxy/http/HttpSM.cc#L3297

## Approach
Fix 1) in above by undo `write_vio.ndone` increase when actual sent length is different from expected.

## Concerns
- This patch doesn't support stream priority. Ideally `write_vio.ndone` should be increased in  `Http2ConnectionState::send_a_data_frame()`. But I'm not confident about removing the logic from `Http2Stream::update_write_request()`. 
- It looks like when ATS receive WINDOW_UPDATE frame and restart sending, `write_vio.ndone` is not increased. Could this be problem in some cases?