### PR TITLE
Fix crash from HttpSM::setup_100_continue_transfer

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -6149,6 +6149,10 @@ HttpSM::setup_100_continue_transfer()
 
   HTTP_SM_SET_DEFAULT_HANDLER(&HttpSM::tunnel_handler_100_continue);
 
+  // Clear the decks before we set up new producers.  As things stand, we cannot have two static operators
+  // at once
+  tunnel.reset();
+
   // Setup the tunnel to the client
   HttpTunnelProducer *p = tunnel.add_producer(HTTP_TUNNEL_STATIC_PRODUCER, client_response_hdr_bytes, buf_start,
                                               (HttpProducerHandler) nullptr, HT_STATIC, "internal msg - 100 continue");


### PR DESCRIPTION
We have been seeing quite a few crashes in production with our version of 7.1.  It looks like the issue is due to confusion of setting up a static producer that already has another static producer set.

```
[ 0  ] libc-2.12.so        raise                                                        ( :undefined                ) 
[ 1  ] libc-2.12.so        __GI_abort                                                   ( :undefined                ) 
[ 2  ] libtsutil.so.7      ink_abort                                                    ( ink_error.cc:99           ) 
[ 3  ] libtsutil.so.7      _ink_assert                                                  ( ink_assert.cc:37          ) 
[ 4  ] traffic_server      HttpTunnel::producer_run(HttpTunnelProducer*)                ( HttpTunnel.cc:917         ) 
[ 5  ] traffic_server      HttpTunnel::tunnel_run(HttpTunnelProducer*)                  ( HttpTunnel.cc:800         ) 
[ 6  ] traffic_server      HttpSM::setup_100_continue_transfer()                        ( HttpSM.cc:6317            ) 
[ 7  ] traffic_server      HttpSM::set_next_state()                                     ( HttpSM.cc:7537            ) 
[ 8  ] traffic_server      HttpSM::call_transact_and_set_next_state(void (*)(HttpTra... ( HttpSM.cc:7306            ) 
[ 9  ] traffic_server      HttpSM::handle_api_return()                                  ( HttpSM.cc:1633            ) 
[ 10 ] traffic_server      HttpSM::state_api_callout(int, void*)                        ( HttpSM.cc:1582            ) 
[ 11 ] traffic_server      HttpSM::state_api_callback(int, void*)                       ( HttpSM.cc:1381            ) 
[ 12 ] traffic_server      TSHttpTxnReenable                                            ( InkAPI.cc:5891            ) 
[ 13 ] custom_redirect.so  handle_response                                              ( custom_redirect.cc:87     ) 
[ 14 ] custom_redirect.so  plugin_main_handler                                          ( custom_redirect.cc:97     ) 
[ 15 ] traffic_server      INKContInternal::handle_event(int, void*)                    ( InkAPI.cc:1052            ) 
[ 16 ] traffic_server      Continuation::handleEvent(int, void*)                        ( I_Continuation.h:153      ) 
[ 17 ] traffic_server      APIHook::invoke(int, void*)                                  ( InkAPI.cc:1271            ) 
[ 18 ] traffic_server      HttpSM::state_api_callout(int, void*)                        ( HttpSM.cc:1503            ) 
[ 19 ] traffic_server      HttpSM::state_api_callback(int, void*)                       ( HttpSM.cc:1381            ) 
[ 20 ] traffic_server      TSHttpTxnReenable                                            ( InkAPI.cc:5891            ) 
[ 21 ] yahoo_connection.so http_hook                                                    ( INKPluginInit.cc:405      ) 
[ 22 ] traffic_server      INKContInternal::handle_event(int, void*)                    ( InkAPI.cc:1052            ) 
[ 23 ] traffic_server      Continuation::handleEvent(int, void*)                        ( I_Continuation.h:153      ) 
[ 24 ] traffic_server      APIHook::invoke(int, void*)                                  ( InkAPI.cc:1271            ) 
[ 25 ] traffic_server      HttpSM::state_api_callout(int, void*)                        ( HttpSM.cc:1503            ) 
[ 26 ] traffic_server      HttpSM::do_api_callout_internal()                            ( HttpSM.cc:5270            ) 
[ 27 ] traffic_server      HttpSM::do_api_callout()                                     ( HttpSM.cc:441             ) 
[ 28 ] traffic_server      HttpSM::state_read_server_response_header(int, void*)        ( HttpSM.cc:2015            ) 
[ 29 ] traffic_server      HttpSM::main_handler(int, void*)                             ( HttpSM.cc:2717            ) 
[ 30 ] traffic_server      Continuation::handleEvent(int, void*)                        ( I_Continuation.h:153      ) 
[ 31 ] traffic_server      read_signal_and_update                                       ( UnixNetVConnection.cc:144 ) 
[ 32 ] traffic_server      read_from_net                                                ( UnixNetVConnection.cc:384 ) 
[ 33 ] traffic_server      UnixNetVConnection::net_read_io(NetHandler*, EThread*)       ( UnixNetVConnection.cc:961 ) 
[ 34 ] traffic_server      NetHandler::mainNetEvent(int, Event*)                        ( UnixNet.cc:499            ) 
[ 35 ] traffic_server      Continuation::handleEvent(int, void*)                        ( I_Continuation.h:153      ) 
[ 36 ] traffic_server      EThread::process_event(Event*, int)                          ( UnixEThread.cc:122        ) 
[ 37 ] traffic_server      EThread::execute()                                           ( UnixEThread.cc:266        ) 
[ 38 ] traffic_server      spawn_thread_internal                                        ( Thread.cc:85              ) 
[ 39 ] libpthread-2.12.so  start_thread                                                 ( :undefined                )
```