### PR TITLE
Fix potential crash from returning string_view.

### DIFF
--- a/iocore/net/NetVConnection.cc
+++ b/iocore/net/NetVConnection.cc
@@ -56,7 +56,7 @@ NetVCOptions::get_proto_string() const
   default:
     break;
   }
-  return nullptr;
+  return {};
 }
 
 ts::string_view
@@ -70,5 +70,5 @@ NetVCOptions::get_family_string() const
   default:
     break;
   }
-  return nullptr;
+  return {};
 }

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -8049,7 +8049,7 @@ HttpSM::find_proto_string(HTTPVersion version) const
   } else if (version == HTTPVersion(0, 9)) {
     return IP_PROTO_TAG_HTTP_0_9;
   }
-  return nullptr;
+  return {};
 }
 
 // YTS Team, yamsat Plugin


### PR DESCRIPTION
Due to poor design of `std::string_view`, it does not handle `nullptr` correctly in its constructor.