### PR TITLE
uDNS no longer returns localhost addresses in cases of NXDOMAIN

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -195,10 +195,11 @@ ts.Disk.remap_config.AddLine(
 ```
 
 ## Setting up DNS
-### Test.MakeDNServer(name)
+### Test.MakeDNServer(name, default=None)
  * name - A name for this instance of the DNS.
+ * default - if a list argument is provided, uDNS will reply with the list contents instead of NXDOMAIN if a DNS can't be found for a partcular entry
 
- This function returns a AuTest process object that launches the python-based microDNS (uDNS). uDNS is a mock DNS which responds to DNS queries. uDNS needs to be setup for the tests that require made-up domains. The server reads a JSON-formatted data file that contains mappings of domain to IP addresses. uDNS responds with the approriate IP addresses if the requested domain is in uDNS' mappings, otherwise responds with default IP address 127.0.0.1.  
+ This function returns a AuTest process object that launches the python-based microDNS (uDNS). uDNS is a mock DNS which responds to DNS queries. uDNS needs to be setup for the tests that require made-up domains. The server reads a JSON-formatted data file that contains mappings of domain to IP addresses. uDNS responds with the approriate IP addresses if the requested domain is in uDNS' mappings.
 
  * addRecords(records=None, jsonFile=None)
  
@@ -219,16 +220,17 @@ ts.Disk.remap_config.AddLine(
  ### Examples
  There are 3 ways to utilize uDNS -
 
- Easy way if everything is done on localhost:  
- *uDNS by default returns 127.0.0.1 for any unknown mappings*
+ Easy way if everything is done on localhost - by adding default option to Test.MakeDNServer:  
+ *uDNS by default returns NXDOMAIN for any unknown mappings*
 
  ```python
     # create TrafficServer and uDNS processes
     ts = Test.MakeATSProcess("ts")
-    dns = Test.MakeDNServer("dns")
+    dns = Test.MakeDNServer("dns", default=['127.0.0.1'])
 
     ts.Disk.records_config.update({
         'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port), # let TrafficServer know where the DNS is located
+        'proxy.config.dns.resolv_conf': 'NULL',
         'proxy.config.url_remap.remap_required': 0  # need this so TrafficServer won't return error upon not finding the domain in its remap file
     })
  ```
@@ -241,10 +243,11 @@ ts.Disk.remap_config.AddLine(
 
     ts.Disk.records_config.update({
         'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port), # let TrafficServer know where the DNS is located
+        'proxy.config.dns.resolv_conf': 'NULL',
         'proxy.config.url_remap.remap_required': 0  # need this so TrafficServer won't return error upon not finding the domain in its remap file
     })
 
-    dns.addRecords(records={"foo.com":["127.0.0.1", "127.0.1.1"]})
+    dns.addRecords(records={"foo.com.":["127.0.0.1", "127.0.1.1"]})
     # AND/OR
     dns.addRecords(jsonFile="zone.json") # where zone.json is in the format described above
  ```
@@ -256,6 +259,7 @@ ts.Disk.remap_config.AddLine(
     dns = Test.MakeDNServer("dns")
 
     ts.Disk.records_config.update({
+        'proxy.config.dns.resolv_conf': 'NULL',
         'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port) # let TrafficServer know where the DNS is located
     })
 
@@ -264,7 +268,7 @@ ts.Disk.remap_config.AddLine(
         'map http://example.com http://foo.com'
     )
 
-    dns.addRecords(records={"foo.com":["127.0.0.1", "127.0.1.1"]})
+    dns.addRecords(records={"foo.com.":["127.0.0.1", "127.0.1.1"]})
  ```
 
 ## Condition Testing

--- a/tests/gold_tests/autest-site/microDNS.test.ext
+++ b/tests/gold_tests/autest-site/microDNS.test.ext
@@ -64,7 +64,7 @@ def addRecords(self, records=None, jsonFile=None):
         f.write(json.dumps(jsondata))
 
 
-def MakeDNServer(obj, name, filename="dns_file.json", port=False, IP='127.0.0.1', rr=False, options={}):
+def MakeDNServer(obj, name, filename="dns_file.json", port=False, IP='127.0.0.1', rr=False, default=None, options={}):
     server_path = os.path.join(obj.Variables.AtsTestToolsDir, 'microDNS/uDNS.py')
     data_dir = os.path.join(obj.RunDirectory, name)
     filepath = os.path.join(data_dir, filename)
@@ -74,7 +74,10 @@ def MakeDNServer(obj, name, filename="dns_file.json", port=False, IP='127.0.0.1'
     if not os.path.exists(os.path.dirname(filepath)):
         os.makedirs(os.path.dirname(filepath))
 
-        jsondata = {'otherwise': ['127.0.0.1'], 'mappings': []}
+        jsondata = {'mappings': []}
+
+        if default:
+            jsondata['otherwise'] = default
 
         with open(filepath, 'w') as f:
             f.write(json.dumps(jsondata))

--- a/tests/gold_tests/redirect/redirect.test.py
+++ b/tests/gold_tests/redirect/redirect.test.py
@@ -52,8 +52,8 @@ dest_response_header = {"headers": "HTTP/1.1 204 No Content\r\n\r\n", "timestamp
 redirect_serv.addResponse("sessionfile.log", redirect_request_header, redirect_response_header)
 dest_serv.addResponse("sessionfile.log", dest_request_header, dest_response_header)
 
-# we don't really need these two lines, since DNS by default will redirect any unknown domains back to 127.0.0.1
-# dns.addRecords(records={"iwillredirect.com":["127.0.0.1"]})
+
+dns.addRecords(records={"iwillredirect.com.": ["127.0.0.1"]})
 # dns.addRecords(jsonFile="zone.json")
 
 # if we don't disable remap_required, we can also just remap a domain to the domain recognized by DNS

--- a/tests/gold_tests/remap/remap_http.test.py
+++ b/tests/gold_tests/remap/remap_http.test.py
@@ -61,6 +61,8 @@ ts.Disk.remap_config.AddLine(
     'map http://testDNS.com http://audrey.hepburn.com:{0}'.format(server.Variables.Port)
 )
 
+dns.addRecords(records={"audrey.hepburn.com.": ["127.0.0.1"]})
+
 # call localhost straight
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = 'curl "http://127.0.0.1:{0}/" --verbose'.format(ts.Variables.port)

--- a/tests/tools/microDNS/uDNS.py
+++ b/tests/tools/microDNS/uDNS.py
@@ -91,7 +91,8 @@ def build_domain_mappings(path):
             records[domain_name] = [A(x) for x in domain[domain_name]]
             print(records[domain_name])
 
-    default_records.extend([A(d) for d in zone_file['otherwise']])
+    if 'otherwise' in zone_file:
+        default_records.extend([A(d) for d in zone_file['otherwise']])
 
 
 def add_authoritative_records(reply, domain):
@@ -135,10 +136,15 @@ def dns_response(data):
     # else if a specific mapping is not found, return default A-records
     if not found_specific:
         for a in default_records:
+            found_specific = True
             reply.add_answer(RR(rname=qname, rtype=QTYPE.A, rclass=1, ttl=TTL, rdata=a))
 
         if round_robin:
             default_records = default_records[1:] + default_records[:1]
+
+    if not found_specific:
+        reply.header.set_rcode(3)
+
     print("---- Reply: ----\n", reply)
     return reply.pack()
 


### PR DESCRIPTION
uDNS now returns NXDOMAIN as expected if a domain can't be found and there is no 'otherwise' field supplied to provide a default IP, whereas originally uDNS would automatically return 127.0.0.1 and 127.0.1.1. 