### PR TITLE
overload ats_stringdup for string_view

### DIFF
--- a/lib/ts/ink_memory.h
+++ b/lib/ts/ink_memory.h
@@ -138,15 +138,6 @@ char *_xstrdup(const char *str, int length, const char *path);
 
 #define ats_strdup(p) _xstrdup((p), -1, nullptr)
 
-// this is to help with migration to a std::string issue with older code that
-// expects char* being copied. As more code moves to std::string, this can be
-// removed to avoid these extra copies.
-inline char *
-ats_stringdup(std::string const &p)
-{
-  return p.empty() ? nullptr : _xstrdup(p.c_str(), p.size(), nullptr);
-}
-
 #define ats_strndup(p, n) _xstrdup((p), n, nullptr)
 
 #ifdef __cplusplus
@@ -154,6 +145,21 @@ ats_stringdup(std::string const &p)
 #endif
 
 #ifdef __cplusplus
+
+// this is to help with migration to a std::string issue with older code that
+// expects char* being copied. As more code moves to std::string, this can be
+// removed to avoid these extra copies.
+inline char *
+ats_stringdup(std::string const &p)
+{
+  return p.empty() ? nullptr : _xstrdup(p.data(), p.size(), nullptr);
+}
+
+inline char *
+ats_stringdup(ts::string_view const &p)
+{
+  return p.empty() ? nullptr : _xstrdup(p.data(), p.size(), nullptr);
+}
 
 template <typename PtrType, typename SizeType>
 static inline IOVec


### PR DESCRIPTION
This commit 
- moves ats_stringdup out of the extern C block
- Overloads ats_stringdup to take ts::string_view to make a copy of the data 
