### PR TITLE
Avoid copying over data in the write_vio into response_buffer

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -716,7 +716,7 @@ rcv_window_update_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
     ssize_t wnd = std::min(cstate.client_rwnd, stream->client_rwnd);
 
     if (!stream->is_closed() && stream->get_state() == Http2StreamState::HTTP2_STREAM_STATE_HALF_CLOSED_REMOTE && wnd > 0) {
-      stream->send_response_body();
+      stream->restart_sending();
     }
   }
 
@@ -1085,14 +1085,14 @@ Http2ConnectionState::restart_streams()
       Http2Stream *next = static_cast<Http2Stream *>(s->link.next ? s->link.next : stream_list.head);
       if (!s->is_closed() && s->get_state() == Http2StreamState::HTTP2_STREAM_STATE_HALF_CLOSED_REMOTE &&
           std::min(this->client_rwnd, s->client_rwnd) > 0) {
-        s->send_response_body();
+        s->restart_sending();
       }
       ink_assert(s != next);
       s = next;
     }
     if (!s->is_closed() && s->get_state() == Http2StreamState::HTTP2_STREAM_STATE_HALF_CLOSED_REMOTE &&
         std::min(this->client_rwnd, s->client_rwnd) > 0) {
-      s->send_response_body();
+      s->restart_sending();
     }
 
     ++starting_point;

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -162,6 +162,7 @@ public:
     return false;
   }
 
+  void restart_sending();
   void send_response_body();
   void push_promise(URL &url, const MIMEField *accept_encoding);
 
@@ -248,7 +249,6 @@ private:
   Http2StreamId _id;
   Http2StreamState _state = Http2StreamState::HTTP2_STREAM_STATE_IDLE;
 
-  MIOBuffer response_buffer;
   HTTPHdr _req_header;
   VIO read_vio;
   VIO write_vio;


### PR DESCRIPTION
At `Http2Stream::update_write_request()`, data in the `write_vio` is copied to `response_buffer` and consumed immediately . But we don't need it.
Also, this could be fix of #2530. Because the `response_buffer` is removed.

----

Notes: This PR includes commits of #2837. Please look at last commit. I'll rebase after #2837 is merged.

