### PR TITLE
removes unused public ip option from microserver code

### DIFF
--- a/tests/gold_tests/autest-site/microserver.test.ext
+++ b/tests/gold_tests/autest-site/microserver.test.ext
@@ -103,7 +103,7 @@ def makeHeader(self, requestString, **kwargs):
     return headerStr
 
 
-def MakeOriginServer(obj, name, port=False, ip=False, delay=False, public_ip=False, ssl=False, options={}):
+def MakeOriginServer(obj, name, port=False, ip=False, delay=False, ssl=False, options={}):
     server_path = os.path.join(obj.Variables.AtsTestToolsDir, 'microServer/uWServer.py')
     data_dir = os.path.join(obj.RunDirectory, name)
     # create Process
@@ -114,8 +114,8 @@ def MakeOriginServer(obj, name, port=False, ip=False, delay=False, public_ip=Fal
         ip = '127.0.0.1'
     if (delay == False):
         delay = 0
-    command = "python3 {0} --data-dir {1} --port {2} --ip_address {3} --delay {4} --public {5} -m test --ssl {6}".format(
-        server_path, data_dir, port, ip, delay, public_ip, ssl)
+    command = "python3 {0} --data-dir {1} --port {2} --ip_address {3} --delay {4} -m test --ssl {5}".format(
+        server_path, data_dir, port, ip, delay, ssl)
     for flag, value in options.items():
         command += " {} {}".format(flag, value)
 

--- a/tests/tools/microServer/uWServer.py
+++ b/tests/tools/microServer/uWServer.py
@@ -605,12 +605,6 @@ def main():
                         help="Directory with data file"
                         )
 
-    parser.add_argument("--public", "-P",
-                        type=_bool,
-                        default=False,
-                        help="Bind server to public IP 0.0.0.0 vs private IP of 127.0.0.1"
-                        )
-
     parser.add_argument("--ip_address", "-ip",
                         type=str,
                         default='',


### PR DESCRIPTION
Milestone:  8.0.0
Labels: Tests, Tools

I attempted to use this, but found that it does not appear to do anything.
From what I can tell in the git history, it never did anything.
It does not appear it was being used by any tests either.

The same functionality can be achieved right now by using an IP of `0.0.0.0`, which is what the help text said the missing functionality would do.