### PR TITLE
Changing all *Debug* macros to *Debug

### DIFF
--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -143,11 +143,11 @@ ssl_error_t SSLConnect(SSL *ssl);
 #define SSLErrorVC(vc, fmt, ...) SSLDiagnostic(MakeSourceLocation(), false, (vc), fmt, ##__VA_ARGS__)
 // Log a SSL diagnostic using the "ssl" diagnostic tag.
 #define SSLDebug(fmt, ...) SSLDiagnostic(MakeSourceLocation(), true, nullptr, fmt, ##__VA_ARGS__)
-#define SSLDebugVC(vc, fmt, ...) SSLDiagnostic(MakeSourceLocation(), true, (vc), fmt, ##__VA_ARGS__)
+#define SSLVCDebug(vc, fmt, ...) SSLDiagnostic(MakeSourceLocation(), true, (vc), fmt, ##__VA_ARGS__)
 
 #define SSL_CLR_ERR_INCR_DYN_STAT(vc, x, fmt, ...) \
   do {                                             \
-    SSLDebugVC((vc), fmt, ##__VA_ARGS__);          \
+    SSLVCDebug((vc), fmt, ##__VA_ARGS__);          \
     RecIncrRawStat(ssl_rsb, nullptr, (int)x, 1);   \
   } while (0)
 

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -1096,16 +1096,16 @@ SSLNetVConnection::sslServerHandShakeEvent(int &err)
         if (retval < 0) {
           if (retval == -EAGAIN) {
             // No data at the moment, hang tight
-            SSLDebugVC(this, "SSL handshake: EAGAIN");
+            SSLVCDebug(this, "SSL handshake: EAGAIN");
             return SSL_HANDSHAKE_WANT_READ;
           } else {
             // An error, make us go away
-            SSLDebugVC(this, "SSL handshake error: read_retval=%d", retval);
+            SSLVCDebug(this, "SSL handshake error: read_retval=%d", retval);
             return EVENT_ERROR;
           }
         } else if (retval == 0) {
           // EOF, go away, we stopped in the handshake
-          SSLDebugVC(this, "SSL handshake error: EOF");
+          SSLVCDebug(this, "SSL handshake error: EOF");
           return EVENT_ERROR;
         }
       } else {
@@ -1119,12 +1119,12 @@ SSLNetVConnection::sslServerHandShakeEvent(int &err)
 
   if (ssl_error != SSL_ERROR_NONE) {
     err = errno;
-    SSLDebugVC(this, "SSL handshake error: %s (%d), errno=%d", SSLErrorName(ssl_error), ssl_error, err);
+    SSLVCDebug(this, "SSL handshake error: %s (%d), errno=%d", SSLErrorName(ssl_error), ssl_error, err);
 
     // start a blind tunnel if tr-pass is set and data does not look like ClientHello
     char *buf = handShakeBuffer ? handShakeBuffer->buf() : nullptr;
     if (getTransparentPassThrough() && buf && *buf != SSL_OP_HANDSHAKE) {
-      SSLDebugVC(this, "Data does not look like SSL handshake, starting blind tunnel");
+      SSLVCDebug(this, "Data does not look like SSL handshake, starting blind tunnel");
       this->attributes     = HttpProxyPort::TRANSPORT_BLIND_TUNNEL;
       sslHandShakeComplete = false;
       return EVENT_CONT;

--- a/lib/ts/Diags.h
+++ b/lib/ts/Diags.h
@@ -339,7 +339,7 @@ extern inkcoreapi Diags *diags;
     }                                                                                                     \
   } while (0)
 
-#define DebugSpecific(flag, tag, ...)                                                                       \
+#define SpecificDebug(flag, tag, ...)                                                                       \
   do {                                                                                                      \
     if (unlikely(diags->on())) {                                                                            \
       const SourceLocation loc = MakeSourceLocation();                                                      \
@@ -358,7 +358,7 @@ extern inkcoreapi Diags *diags;
 #define Diag(tag, fmt, ...)
 #define Debug(tag, fmt, ...)
 #define DiagSpecific(flag, tag, ...)
-#define DebugSpecific(flag, tag, ...)
+#define SpecificDebug(flag, tag, ...)
 
 #define is_debug_tag_set(_t) 0
 #define is_action_tag_set(_t) 0

--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -34,7 +34,7 @@
 // Emit a debug message conditional on whether this particular client session
 // has debugging enabled. This should only be called from within a client session
 // member function.
-#define DebugSsn(ssn, tag, ...) DebugSpecific((ssn)->debug(), tag, __VA_ARGS__)
+#define SsnDebug(ssn, tag, ...) SpecificDebug((ssn)->debug(), tag, __VA_ARGS__)
 
 class ProxyClientTransaction;
 struct AclRecord;

--- a/proxy/ProxyClientTransaction.cc
+++ b/proxy/ProxyClientTransaction.cc
@@ -25,7 +25,7 @@
 #include "http/HttpServerSession.h"
 #include "Plugin.h"
 
-#define DebugHttpTxn(fmt, ...) DebugSsn(this, "http_txn", fmt, __VA_ARGS__)
+#define HttpTxnDebug(fmt, ...) SsnDebug(this, "http_txn", fmt, __VA_ARGS__)
 
 ProxyClientTransaction::ProxyClientTransaction()
   : VConnection(nullptr),
@@ -48,7 +48,7 @@ ProxyClientTransaction::new_transaction()
   ink_release_assert(parent != nullptr);
   current_reader = HttpSM::allocate();
   current_reader->init();
-  DebugHttpTxn("[%" PRId64 "] Starting transaction %d using sm [%" PRId64 "]", parent->connection_id(),
+  HttpTxnDebug("[%" PRId64 "] Starting transaction %d using sm [%" PRId64 "]", parent->connection_id(),
                parent->get_transact_count(), current_reader->sm_id);
 
   PluginIdentity *pi = dynamic_cast<PluginIdentity *>(this->get_netvc());
@@ -63,7 +63,7 @@ ProxyClientTransaction::new_transaction()
 void
 ProxyClientTransaction::release(IOBufferReader *r)
 {
-  DebugHttpTxn("[%" PRId64 "] session released by sm [%" PRId64 "]", parent ? parent->connection_id() : 0,
+  HttpTxnDebug("[%" PRId64 "] session released by sm [%" PRId64 "]", parent ? parent->connection_id() : 0,
                current_reader ? current_reader->sm_id : 0);
 
   // Pass along the release to the session

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -27,11 +27,11 @@
 #include "Http2Stream.h"
 #include "Http2DebugNames.h"
 
-#define DebugHttp2Con(ua_session, fmt, ...) \
-  DebugSsn(ua_session, "http2_con", "[%" PRId64 "] " fmt, ua_session->connection_id(), ##__VA_ARGS__);
+#define Http2ConDebug(ua_session, fmt, ...) \
+  SsnDebug(ua_session, "http2_con", "[%" PRId64 "] " fmt, ua_session->connection_id(), ##__VA_ARGS__);
 
 #define Http2StreamDebug(ua_session, stream_id, fmt, ...) \
-  DebugSsn(ua_session, "http2_con", "[%" PRId64 "] [%u] " fmt, ua_session->connection_id(), stream_id, ##__VA_ARGS__);
+  SsnDebug(ua_session, "http2_con", "[%" PRId64 "] [%u] " fmt, ua_session->connection_id(), stream_id, ##__VA_ARGS__);
 
 using http2_frame_dispatch = Http2Error (*)(Http2ConnectionState &, const Http2Frame &);
 
@@ -951,7 +951,7 @@ Http2ConnectionState::main_event_handler(int event, void *edata)
   } break;
 
   default:
-    DebugHttp2Con(ua_session, "unexpected event=%d edata=%p", event, edata);
+    Http2ConDebug(ua_session, "unexpected event=%d edata=%p", event, edata);
     ink_release_assert(0);
     break;
   }
@@ -1671,7 +1671,7 @@ Http2ConnectionState::send_ping_frame(Http2StreamId id, uint8_t flag, const uint
 void
 Http2ConnectionState::send_goaway_frame(Http2StreamId id, Http2ErrorCode ec)
 {
-  DebugHttp2Con(ua_session, "Send GOAWAY frame, last_stream_id: %d", id);
+  Http2ConDebug(ua_session, "Send GOAWAY frame, last_stream_id: %d", id);
 
   if (ec != Http2ErrorCode::HTTP2_ERROR_NO_ERROR) {
     HTTP2_INCREMENT_THREAD_DYN_STAT(HTTP2_STAT_CONNECTION_ERRORS_COUNT, this_ethread());
@@ -1723,7 +1723,7 @@ Http2ConnectionState::_adjust_concurrent_stream()
   int64_t current_client_streams = 0;
   RecGetRawStatSum(http2_rsb, HTTP2_STAT_CURRENT_CLIENT_STREAM_COUNT, &current_client_streams);
 
-  DebugHttp2Con(ua_session, "current client streams: %" PRId64, current_client_streams);
+  Http2ConDebug(ua_session, "current client streams: %" PRId64, current_client_streams);
 
   if (current_client_streams >= Http2::max_active_streams_in) {
     if (!Http2::throttling) {

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -27,7 +27,7 @@
 #include "../http/HttpSM.h"
 
 #define Http2StreamDebug(fmt, ...) \
-  DebugSsn(parent, "http2_stream", "[%" PRId64 "] [%u] " fmt, parent->connection_id(), this->get_id(), ##__VA_ARGS__);
+  SsnDebug(parent, "http2_stream", "[%" PRId64 "] [%u] " fmt, parent->connection_id(), this->get_id(), ##__VA_ARGS__);
 
 ClassAllocator<Http2Stream> http2StreamAllocator("http2StreamAllocator");
 


### PR DESCRIPTION
Changing all *Debug* Macros to *Debug( according to #2802. Haven't touched the APIs, as they will break plugins. Changed `DebugSpecific(` to `SpecificDebug(` as well. Let me know if this is undesirable.