### PR TITLE
Issue #2883: Split TXN and SSN user arg allocation.

### DIFF
--- a/doc/developer-guide/api/functions/TSHttpArgs.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpArgs.en.rst
@@ -18,16 +18,19 @@
 .. default-domain:: c
 
 TSHttpArgs
-************
+**********
 
 Synopsis
 ========
 
 `#include <ts/ts.h>`
 
-.. function:: TSReturnCode TSHttpArgIndexReserve(const char * name, const char * description, int * arg_idx)
-.. function:: TSReturnCode TSHttpArgIndexNameLookup(const char * name, int * arg__idx, const char ** description)
-.. function:: TSReturnCode TSHttpArgIndexLookup(int arg_idx, const char ** name, const char ** description)
+.. function:: TSReturnCode TSHttpTxnArgIndexReserve(const char * name, const char * description, int * arg_idx)
+.. function:: TSReturnCode TSHttpTxnArgIndexNameLookup(const char * name, int * arg__idx, const char ** description)
+.. function:: TSReturnCode TSHttpTxnArgIndexLookup(int arg_idx, const char ** name, const char ** description)
+.. function:: TSReturnCode TSHttpSsnArgIndexReserve(const char * name, const char * description, int * arg_idx)
+.. function:: TSReturnCode TSHttpSsnArgIndexNameLookup(const char * name, int * arg__idx, const char ** description)
+.. function:: TSReturnCode TSHttpSsnArgIndexLookup(int arg_idx, const char ** name, const char ** description)
 .. function:: void TSHttpTxnArgSet(TSHttpTxn txnp, int arg_idx, void * arg)
 .. function:: void * TSHttpTxnArgGet(TSHttpTxn txnp, int arg_idx)
 .. function:: void TSHttpSsnArgSet(TSHttpTxn txnp, int arg_idx, void * arg)
@@ -40,30 +43,44 @@ Description
 store information. This can be used to avoid creating a per session or transaction continuations to
 hold data, or to communicate between plugins as the values in the array are visible to any plugin
 which can access the session or transaction. The array values are opaque to |TS| and it will not
-dereference or release them. Plugins are responsible for cleaning up any resources pointed to by the
-values or, if the values are simply values there is no need for the plugin to remove them after the
+dereference nor release them. Plugins are responsible for cleaning up any resources pointed to by the
+values or, if the values are simply values, there is no need for the plugin to remove them after the
 session or transaction has completed.
 
-To avoid collisions between plugins a plugin should first *reserve* an index in the array by calling
-:func:`TSHttpArgIndexReserve` passing it an identifying name, a description, and a pointer to an
-integer which will get the reserved index. The function returns :code:`TS_SUCCESS` if an index was
-reserved, :code:`TS_ERROR` if not (most likely because all of the indices have already been
-reserved). Generally this will be a file or library scope global which is set at plugin
-initialization. This function is used in the example remap plugin :ts:git:`example/remap/remap.cc`.
-The index is stored in the global :code:`arg_index`. When an index is reserved it is reserved for
-both sessions and transactions.
+To avoid collisions between plugins a plugin should first *reserve* an index in the array. A
+transaction based plugin argument is reserved by calling :func:`TSHttpTxnArgIndexReserve`. A session
+base plugin argument is reserved by calling :func:`TSHttpSsnArgIndexReserve`. Both functions have the arguments
 
-To look up the owner of a reserved index use :func:`TSHttpArgIndexNameLookup`. If the :arg:`name` is
-found as an owner, the function returns :code:`TS_SUCCESS` and :arg:`arg_index` is updated with the
-index reserved under that name. If :arg:`description` is not :code:`NULL` then it will be updated
-with the description for that reserved index. This enables communication between plugins where
-plugin "A" reserves an index under a well known name and plugin "B" locates the index by looking it
-up under that name.
+:arg:`name`
+   An identifying name for the plugin that reserved the index. Required.
 
-The owner of a reserved index can be found with :func:`TSHttpArgIndexLookup`. If :arg:`arg_index` is
-reserved then the function returns :code:`TS_SUCCESS` and :arg:`name` and :arg:`description` are
-updated. :arg:`name` must point at a valid character pointer but :arg:`description` can be
-:code:`NULL`.
+:arg:`description`
+   An optional description of the use of the arg. This can be :code:`nullptr`.
+
+:arg:`arg_idx`
+   A pointer to an :code:`int`. If an index is successfully reserved, the :code:`int` pointed at by this is
+   set to the reserved index. It is not modified if the call is unsuccessful.
+
+The functions return :code:`TS_SUCCESS` if an index was reserved,
+:code:`TS_ERROR` if not (most likely because all of the indices have already been reserved).
+Generally this will be a file or library scope global which is set at plugin initialization. This
+function is used in the example remap plugin :ts:git:`example/remap/remap.cc`. The index is stored
+in the plugin global :code:`arg_index`. Transaction and session plugin argument indices are reserved
+independently.
+
+To look up the owner of a reserved index use :func:`TSHttpTxnArgIndexNameLookup` or
+:func:`TSHttpSsnArgIndexNameLookup` for transaction and session plugin argument respectively. If
+:arg:`name` is found as an owner, the function returns :code:`TS_SUCCESS` and :arg:`arg_index` is
+updated with the index reserved under that name. If :arg:`description` is not :code:`NULL` then
+the character pointer to which it points will be updated to point at the description for that
+reserved index. This enables communication between plugins where plugin "A" reserves an index under
+a well known name and plugin "B" locates the index by looking it up under that name.
+
+The owner of a reserved index can be found with :func:`TSHttpTxnArgIndexLookup` or
+:func:`TSHttpSsnArgIndexLookup` for transaction and session plugin arguments respectively. If
+:arg:`arg_index` is reserved then the function returns :code:`TS_SUCCESS` and the pointers referred
+to by :arg:`name` and :arg:`description` are updated. :arg:`name` must point at a valid character
+pointer but :arg:`description` can be :code:`NULL` in which case it is ignored.
 
 Manipulating the array is simple. :func:`TSHttpTxnArgSet` sets the array slot at :arg:`arg_idx` for
 the transaction :arg:`txnp` to the value :arg:`arg`. Note this sets the value only for the specific

--- a/example/remap/remap.cc
+++ b/example/remap/remap.cc
@@ -271,7 +271,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
   }
 
   // How to store plugin private arguments inside Traffic Server request processing block.
-  if (TSHttpArgIndexReserve("remap_example", "Example remap plugin", &arg_index) == TS_SUCCESS) {
+  if (TSHttpTxnArgIndexReserve("remap_example", "Example remap plugin", &arg_index) == TS_SUCCESS) {
     TSDebug(PLUGIN_NAME, "Save processing counter %" PRIu64 " inside request processing block\n", _processing_counter);
     TSHttpTxnArgSet((TSHttpTxn)rh, arg_index, (void *)_processing_counter); // save counter
   }

--- a/lib/cppapi/utils_internal.cc
+++ b/lib/cppapi/utils_internal.cc
@@ -98,7 +98,7 @@ void
 setupTransactionManagement()
 {
   // Reserve a transaction slot
-  TSAssert(TS_SUCCESS == TSHttpArgIndexReserve("atscppapi", "ATS CPP API", &TRANSACTION_STORAGE_INDEX));
+  TSAssert(TS_SUCCESS == TSHttpTxnArgIndexReserve("atscppapi", "ATS CPP API", &TRANSACTION_STORAGE_INDEX));
   // We must always have a cleanup handler available
   TSMutex mutex = nullptr;
   TSCont cont   = TSContCreate(handleTransactionEvents, mutex);

--- a/plugins/authproxy/authproxy.cc
+++ b/plugins/authproxy/authproxy.cc
@@ -748,7 +748,7 @@ TSPluginInit(int argc, const char *argv[])
     AuthLogError("plugin registration failed");
   }
 
-  TSReleaseAssert(TSHttpArgIndexReserve("AuthProxy", "AuthProxy authorization tag", &AuthTaggedRequestArg) == TS_SUCCESS);
+  TSReleaseAssert(TSHttpTxnArgIndexReserve("AuthProxy", "AuthProxy authorization tag", &AuthTaggedRequestArg) == TS_SUCCESS);
 
   AuthOsDnsContinuation = TSContCreate(AuthProxyGlobalHook, nullptr);
   AuthGlobalOptions     = AuthParseOptions(argc, argv);
@@ -761,7 +761,7 @@ TSPluginInit(int argc, const char *argv[])
 TSReturnCode
 TSRemapInit(TSRemapInterface * /* api ATS_UNUSED */, char * /* err ATS_UNUSED */, int /* errsz ATS_UNUSED */)
 {
-  TSReleaseAssert(TSHttpArgIndexReserve("AuthProxy", "AuthProxy authorization tag", &AuthTaggedRequestArg) == TS_SUCCESS);
+  TSReleaseAssert(TSHttpTxnArgIndexReserve("AuthProxy", "AuthProxy authorization tag", &AuthTaggedRequestArg) == TS_SUCCESS);
 
   AuthOsDnsContinuation = TSContCreate(AuthProxyGlobalHook, nullptr);
   return TS_SUCCESS;

--- a/plugins/esi/combo_handler.cc
+++ b/plugins/esi/combo_handler.cc
@@ -406,7 +406,7 @@ TSPluginInit(int argc, const char *argv[])
 
   TSHttpHookAdd(TS_HTTP_OS_DNS_HOOK, rrh_contp);
 
-  if (TSHttpArgIndexReserve(DEBUG_TAG, "will save plugin-enable flag here", &arg_idx) != TS_SUCCESS) {
+  if (TSHttpTxnArgIndexReserve(DEBUG_TAG, "will save plugin-enable flag here", &arg_idx) != TS_SUCCESS) {
     LOG_ERROR("failed to reserve private data slot");
     return;
   } else {

--- a/plugins/experimental/collapsed_connection/collapsed_connection.cc
+++ b/plugins/experimental/collapsed_connection/collapsed_connection.cc
@@ -993,7 +993,7 @@ getCcPlugin()
     data->keep_pass_list        = new UsecList();
     data->seq_id                = 0;
     data->global_config         = nullptr;
-    TSHttpArgIndexReserve(PLUGIN_NAME, "reserve txn_data slot", &(data->txn_slot));
+    TSHttpTxnArgIndexReserve(PLUGIN_NAME, "reserve txn_data slot", &(data->txn_slot));
 
     if (TS_SUCCESS == TSMgmtIntGet("proxy.config.cache.enable_read_while_writer", &read_while_writer) && read_while_writer > 0) {
       data->read_while_writer = true;

--- a/plugins/experimental/remap_stats/remap_stats.c
+++ b/plugins/experimental/remap_stats/remap_stats.c
@@ -282,7 +282,7 @@ TSPluginInit(int argc, const char *argv[])
     }
   }
 
-  TSHttpArgIndexReserve(PLUGIN_NAME, "txn data", &(config->txn_slot));
+  TSHttpTxnArgIndexReserve(PLUGIN_NAME, "txn data", &(config->txn_slot));
 
   if (!config->post_remap_host) {
     pre_remap_cont = TSContCreate(handle_read_req_hdr, NULL);

--- a/plugins/experimental/stale_while_revalidate/stale_while_revalidate.c
+++ b/plugins/experimental/stale_while_revalidate/stale_while_revalidate.c
@@ -758,7 +758,7 @@ TSPluginInit(int argc, const char *argv[])
     }
 
     // proxy.config.http.insert_age_in_response
-    TSHttpArgIndexReserve(PLUGIN_NAME, "txn state info", &(plugin_config->txn_slot));
+    TSHttpTxnArgIndexReserve(PLUGIN_NAME, "txn state info", &(plugin_config->txn_slot));
     main_cont = TSContCreate(main_plugin, NULL);
     TSContDataSet(main_cont, (void *)plugin_config);
     TSHttpHookAdd(TS_HTTP_READ_REQUEST_HDR_HOOK, main_cont);

--- a/plugins/xdebug/xdebug.cc
+++ b/plugins/xdebug/xdebug.cc
@@ -414,7 +414,7 @@ TSPluginInit(int argc, const char *argv[])
   xDebugHeader.len = strlen(xDebugHeader.str);
 
   // Setup the global hook
-  TSReleaseAssert(TSHttpArgIndexReserve("xdebug", "xdebug header requests", &XArgIndex) == TS_SUCCESS);
+  TSReleaseAssert(TSHttpTxnArgIndexReserve("xdebug", "xdebug header requests", &XArgIndex) == TS_SUCCESS);
   TSReleaseAssert(XInjectHeadersCont = TSContCreate(XInjectResponseHeaders, nullptr));
   TSHttpHookAdd(TS_HTTP_READ_REQUEST_HDR_HOOK, TSContCreate(XScanRequestHeaders, nullptr));
 }

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -22,6 +22,7 @@
  */
 
 #include <cstdio>
+#include <atomic>
 
 #include "ts/ink_platform.h"
 #include "ts/ink_base64.h"
@@ -87,18 +88,28 @@
 static int api_rsb_index;
 static RecRawStatBlock *api_rsb;
 
-// Globals for the Sessions/Transaction index registry
-static int next_argv_index;
-
 static std::type_info const &TYPE_INFO_MGMT_INT   = typeid(MgmtInt);
 static std::type_info const &TYPE_INFO_MGMT_BYTE  = typeid(MgmtByte);
 static std::type_info const &TYPE_INFO_MGMT_FLOAT = typeid(MgmtFloat);
 
-static struct _STATE_ARG_TABLE {
-  char *name;
-  size_t name_len;
-  char *description;
-} state_arg_table[HTTP_SSN_TXN_MAX_USER_ARG];
+/** Reservation for a user arg.
+ */
+struct UserArg {
+  /// Types of user args.
+  enum Type {
+    TXN,  ///< Transaction based.
+    SSN,  ///< Session based
+    COUNT ///< Fake enum, # of valid entries.
+  };
+
+  std::string name;        ///< Name of reserving plugin.
+  std::string description; ///< Description of use for this arg.
+};
+
+/// Table of reservations, indexed by type and then index.
+UserArg UserArgTable[UserArg::Type::COUNT][TS_HTTP_MAX_USER_ARG];
+/// Table of next reserved index.
+std::atomic<int> UserArgIdx[UserArg::Type::COUNT];
 
 /* URL schemes */
 tsapi const char *TS_URL_SCHEME_FILE;
@@ -1660,8 +1671,6 @@ api_init()
     } else {
       api_rsb = nullptr;
     }
-
-    memset(state_arg_table, 0, sizeof(state_arg_table));
 
     // Setup the version string for returning to plugins
     ink_strlcpy(traffic_server_version, appVersionInfo.VersionStr, sizeof(traffic_server_version));
@@ -5911,19 +5920,20 @@ TSHttpTxnReenable(TSHttpTxn txnp, TSEvent event)
 }
 
 TSReturnCode
-TSHttpArgIndexReserve(const char *name, const char *description, int *arg_idx)
+TSHttpArgIndexReserve(UserArg::Type type, const char *name, const char *description, int *ptr_idx)
 {
-  sdk_assert(sdk_sanity_check_null_ptr(arg_idx) == TS_SUCCESS);
+  sdk_assert(sdk_sanity_check_null_ptr(ptr_idx) == TS_SUCCESS);
+  sdk_assert(sdk_sanity_check_null_ptr(name) == TS_SUCCESS);
+  sdk_assert(0 <= type && type < UserArg::Type::COUNT);
 
-  int ix = ink_atomic_increment(&next_argv_index, 1);
+  int idx = UserArgIdx[type]++;
 
-  if (ix < HTTP_SSN_TXN_MAX_USER_ARG) {
-    state_arg_table[ix].name     = ats_strdup(name);
-    state_arg_table[ix].name_len = strlen(state_arg_table[ix].name);
-    if (description) {
-      state_arg_table[ix].description = ats_strdup(description);
-    }
-    *arg_idx = ix;
+  if (idx < TS_HTTP_MAX_USER_ARG) {
+    UserArg &arg(UserArgTable[type][idx]);
+    arg.name = name;
+    if (description)
+      arg.description = description;
+    *ptr_idx          = idx;
 
     return TS_SUCCESS;
   }
@@ -5931,13 +5941,15 @@ TSHttpArgIndexReserve(const char *name, const char *description, int *arg_idx)
 }
 
 TSReturnCode
-TSHttpArgIndexLookup(int arg_idx, const char **name, const char **description)
+TSHttpArgIndexLookup(UserArg::Type type, int idx, const char **name, const char **description)
 {
+  sdk_assert(0 <= type && type < UserArg::Type::COUNT);
   if (sdk_sanity_check_null_ptr(name) == TS_SUCCESS) {
-    if (state_arg_table[arg_idx].name) {
-      *name = state_arg_table[arg_idx].name;
+    if (idx < UserArgIdx[type]) {
+      UserArg &arg(UserArgTable[type][idx]);
+      *name = arg.name.c_str();
       if (description) {
-        *description = state_arg_table[arg_idx].description;
+        *description = arg.description.c_str();
       }
       return TS_SUCCESS;
     }
@@ -5947,31 +5959,69 @@ TSHttpArgIndexLookup(int arg_idx, const char **name, const char **description)
 
 // Not particularly efficient, but good enough for now.
 TSReturnCode
-TSHttpArgIndexNameLookup(const char *name, int *arg_idx, const char **description)
+TSHttpArgIndexNameLookup(UserArg::Type type, const char *name, int *arg_idx, const char **description)
 {
   sdk_assert(sdk_sanity_check_null_ptr(arg_idx) == TS_SUCCESS);
+  sdk_assert(0 <= type && type < UserArg::Type::COUNT);
 
-  size_t len = strlen(name);
+  ts::string_view n{name};
 
-  for (int ix = 0; ix < next_argv_index; ++ix) {
-    if ((len == state_arg_table[ix].name_len) && (0 == strcmp(name, state_arg_table[ix].name))) {
+  for (UserArg *arg = UserArgTable[type], *limit = arg + UserArgIdx[type]; arg < limit; ++arg) {
+    if (arg->name == n) {
       if (description) {
-        *description = state_arg_table[ix].description;
+        *description = arg->description.c_str();
       }
-      *arg_idx = ix;
+      *arg_idx = arg - UserArgTable[type];
       return TS_SUCCESS;
     }
   }
   return TS_ERROR;
 }
 
+// -------------
+TSReturnCode
+TSHttpTxnArgIndexReserve(const char *name, const char *description, int *arg_idx)
+{
+  return TSHttpArgIndexReserve(UserArg::TXN, name, description, arg_idx);
+}
+
+TSReturnCode
+TSHttpTxnArgIndexLookup(int arg_idx, const char **name, const char **description)
+{
+  return TSHttpArgIndexLookup(UserArg::TXN, arg_idx, name, description);
+}
+
+TSReturnCode
+TSHttpTxnArgIndexNameLookup(const char *name, int *arg_idx, const char **description)
+{
+  return TSHttpArgIndexNameLookup(UserArg::TXN, name, arg_idx, description);
+}
+
+TSReturnCode
+TSHttpSsnArgIndexReserve(const char *name, const char *description, int *arg_idx)
+{
+  return TSHttpArgIndexReserve(UserArg::SSN, name, description, arg_idx);
+}
+
+TSReturnCode
+TSHttpSsnArgIndexLookup(int arg_idx, const char **name, const char **description)
+{
+  return TSHttpArgIndexLookup(UserArg::SSN, arg_idx, name, description);
+}
+
+TSReturnCode
+TSHttpSsnArgIndexNameLookup(const char *name, int *arg_idx, const char **description)
+{
+  return TSHttpArgIndexNameLookup(UserArg::SSN, name, arg_idx, description);
+}
+
 void
 TSHttpTxnArgSet(TSHttpTxn txnp, int arg_idx, void *arg)
 {
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
-  sdk_assert(arg_idx >= 0 && arg_idx < HTTP_SSN_TXN_MAX_USER_ARG);
+  sdk_assert(arg_idx >= 0 && arg_idx < TS_HTTP_MAX_USER_ARG);
 
-  HttpSM *sm                     = (HttpSM *)txnp;
+  HttpSM *sm                     = reinterpret_cast<HttpSM *>(txnp);
   sm->t_state.user_args[arg_idx] = arg;
 }
 
@@ -5979,9 +6029,9 @@ void *
 TSHttpTxnArgGet(TSHttpTxn txnp, int arg_idx)
 {
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
-  sdk_assert(arg_idx >= 0 && arg_idx < HTTP_SSN_TXN_MAX_USER_ARG);
+  sdk_assert(arg_idx >= 0 && arg_idx < TS_HTTP_MAX_USER_ARG);
 
-  HttpSM *sm = (HttpSM *)txnp;
+  HttpSM *sm = reinterpret_cast<HttpSM *>(txnp);
   return sm->t_state.user_args[arg_idx];
 }
 
@@ -5989,7 +6039,7 @@ void
 TSHttpSsnArgSet(TSHttpSsn ssnp, int arg_idx, void *arg)
 {
   sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
-  sdk_assert(arg_idx >= 0 && arg_idx < HTTP_SSN_TXN_MAX_USER_ARG);
+  sdk_assert(arg_idx >= 0 && arg_idx < TS_HTTP_MAX_USER_ARG);
 
   ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
 
@@ -6000,7 +6050,7 @@ void *
 TSHttpSsnArgGet(TSHttpSsn ssnp, int arg_idx)
 {
   sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
-  sdk_assert(arg_idx >= 0 && arg_idx < HTTP_SSN_TXN_MAX_USER_ARG);
+  sdk_assert(arg_idx >= 0 && arg_idx < TS_HTTP_MAX_USER_ARG);
 
   ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
   return cs->get_user_arg(arg_idx);

--- a/proxy/InkAPIInternal.h
+++ b/proxy/InkAPIInternal.h
@@ -40,7 +40,7 @@
 
 /* Some defines that might be candidates for configurable settings later.
  */
-#define HTTP_SSN_TXN_MAX_USER_ARG 16 /* max number of user arguments for Transactions and Sessions */
+#define TS_HTTP_MAX_USER_ARG 16 /* max number of user arguments for Transactions and Sessions */
 
 typedef int8_t TSMgmtByte; // Not for external use
 

--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -262,7 +262,7 @@ private:
   TSHttpHookID api_hookid = TS_HTTP_READ_REQUEST_HDR_HOOK;
   APIHook *api_current    = nullptr;
   HttpAPIHooks api_hooks;
-  void *user_args[HTTP_SSN_TXN_MAX_USER_ARG];
+  void *user_args[TS_HTTP_MAX_USER_ARG];
 
   // for DI. An active connection is one that a request has
   // been successfully parsed (PARSE_DONE) and it remains to

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -1533,9 +1533,12 @@ tsapi void *TSHttpSsnArgGet(TSHttpSsn ssnp, int arg_idx);
 /* The reserve API should only be use in TSAPI plugins, during plugin initialization! */
 /* The lookup methods can be used anytime, but are best used during initialization as well,
    or at least "cache" the results for best performance. */
-tsapi TSReturnCode TSHttpArgIndexReserve(const char *name, const char *description, int *arg_idx);
-tsapi TSReturnCode TSHttpArgIndexNameLookup(const char *name, int *arg_idx, const char **description);
-tsapi TSReturnCode TSHttpArgIndexLookup(int arg_idx, const char **name, const char **description);
+tsapi TSReturnCode TSHttpTxnArgIndexReserve(const char *name, const char *description, int *arg_idx);
+tsapi TSReturnCode TSHttpTxnArgIndexNameLookup(const char *name, int *arg_idx, const char **description);
+tsapi TSReturnCode TSHttpTxnArgIndexLookup(int arg_idx, const char **name, const char **description);
+tsapi TSReturnCode TSHttpSsnArgIndexReserve(const char *name, const char *description, int *arg_idx);
+tsapi TSReturnCode TSHttpSsnArgIndexNameLookup(const char *name, int *arg_idx, const char **description);
+tsapi TSReturnCode TSHttpSsnArgIndexLookup(int arg_idx, const char **name, const char **description);
 
 /* ToDo: This is a leftover from olden days, can we eliminate? */
 tsapi void TSHttpTxnSetHttpRetStatus(TSHttpTxn txnp, TSHttpStatus http_retstatus);

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -798,7 +798,7 @@ public:
 
     // INK API/Remap API plugin interface
     void *remap_plugin_instance = nullptr;
-    void *user_args[HTTP_SSN_TXN_MAX_USER_ARG];
+    void *user_args[TS_HTTP_MAX_USER_ARG];
     remap_plugin_info::_tsremap_os_response *fp_tsremap_os_response = nullptr;
     HTTPStatus http_return_code                                     = HTTP_STATUS_NONE;
 


### PR DESCRIPTION
As discussed on the mailing list, this splits reservation of TXN and SSN args, along with updated documentation.

Related to #2783 #2380 #2388

**This is an API breaking change. Do not backport.**