### PR TITLE
TransformVC may be double closed because there is a issue within HttpTunnel::chain_abort_all

### DIFF
--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -1187,6 +1187,7 @@ INKVConnInternal::do_io_close(int error)
 
   if (m_output_vc) {
     m_output_vc->do_io_close(error);
+    m_output_vc = nullptr;
   }
 
   eventProcessor.schedule_imm(this, ET_NET);

--- a/proxy/Transform.cc
+++ b/proxy/Transform.cc
@@ -458,6 +458,10 @@ TransformVConnection::do_io_close(int error)
 {
   Debug("transform", "TransformVConnection do_io_close: %d [0x%lx]", error, (long)this);
 
+  if (m_closed != 0) {
+    return;
+  }
+
   if (error != -1) {
     m_closed = TS_VC_CLOSE_ABORT;
   } else {
@@ -465,6 +469,7 @@ TransformVConnection::do_io_close(int error)
   }
 
   m_transform->do_io_close(error);
+  m_transform = nullptr;
 }
 
 /*-------------------------------------------------------------------------


### PR DESCRIPTION
This is a hack way to avoid double close on TVC.
The double close issue within HttpTunnel::chain_abort_all is not
resolved.