### PR TITLE
Rename HttpSM::ua_session HttpSM::ua_txn

### DIFF
--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -331,8 +331,8 @@ protected:
   void remove_ua_entry();
 
 public:
-  ProxyClientTransaction *ua_session = nullptr;
-  BackgroundFill_t background_fill   = BACKGROUND_FILL_NONE;
+  ProxyClientTransaction *ua_txn   = nullptr;
+  BackgroundFill_t background_fill = BACKGROUND_FILL_NONE;
   // AuthHttpAdapter authAdapter;
   void set_http_schedule(Continuation *);
   int get_http_schedule(int event, void *data);
@@ -682,8 +682,7 @@ HttpSM::add_cache_sm()
 inline bool
 HttpSM::is_transparent_passthrough_allowed()
 {
-  return (t_state.client_info.is_transparent && ua_session->is_transparent_passthrough_allowed() &&
-          ua_session->get_transact_count() == 1);
+  return (t_state.client_info.is_transparent && ua_txn->is_transparent_passthrough_allowed() && ua_txn->get_transact_count() == 1);
 }
 
 inline int64_t

--- a/proxy/http/HttpSessionManager.cc
+++ b/proxy/http/HttpSessionManager.cc
@@ -264,7 +264,7 @@ HttpSessionManager::purge_keepalives()
 
 HSMresult_t
 HttpSessionManager::acquire_session(Continuation * /* cont ATS_UNUSED */, sockaddr const *ip, const char *hostname,
-                                    ProxyClientTransaction *ua_session, HttpSM *sm)
+                                    ProxyClientTransaction *ua_txn, HttpSM *sm)
 {
   HttpServerSession *to_return = nullptr;
   TSServerSessionSharingMatchType match_style =
@@ -276,9 +276,9 @@ HttpSessionManager::acquire_session(Continuation * /* cont ATS_UNUSED */, sockad
 
   // First check to see if there is a server session bound
   //   to the user agent session
-  to_return = ua_session->get_server_session();
+  to_return = ua_txn->get_server_session();
   if (to_return != nullptr) {
-    ua_session->attach_server_session(nullptr);
+    ua_txn->attach_server_session(nullptr);
 
     // Since the client session is reusing the same server session, it seems that the SNI should match
     // Will the client make requests to different hosts over the same SSL session? Though checking

--- a/proxy/http/HttpSessionManager.h
+++ b/proxy/http/HttpSessionManager.h
@@ -152,7 +152,7 @@ class HttpSessionManager
 public:
   HttpSessionManager() : m_g_pool(NULL) {}
   ~HttpSessionManager() {}
-  HSMresult_t acquire_session(Continuation *cont, sockaddr const *addr, const char *hostname, ProxyClientTransaction *ua_session,
+  HSMresult_t acquire_session(Continuation *cont, sockaddr const *addr, const char *hostname, ProxyClientTransaction *ua_txn,
                               HttpSM *sm);
   HSMresult_t release_session(HttpServerSession *to_release);
   void purge_keepalives();

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -805,12 +805,12 @@ HttpTransact::EndRemapRequest(State *s)
     }
   }
   s->reverse_proxy              = true;
-  s->server_info.is_transparent = s->state_machine->ua_session ? s->state_machine->ua_session->is_outbound_transparent() : false;
+  s->server_info.is_transparent = s->state_machine->ua_txn ? s->state_machine->ua_txn->is_outbound_transparent() : false;
 
 done:
   // We now set the active-timeout again, since it might have been changed as part of the remap rules.
-  if (s->state_machine->ua_session) {
-    s->state_machine->ua_session->set_active_timeout(HRTIME_SECONDS(s->txn_conf->transaction_active_timeout_in));
+  if (s->state_machine->ua_txn) {
+    s->state_machine->ua_txn->set_active_timeout(HRTIME_SECONDS(s->txn_conf->transaction_active_timeout_in));
   }
 
   if (is_debug_tag_set("http_chdr_describe") || is_debug_tag_set("http_trans") || is_debug_tag_set("url_rewrite")) {
@@ -1744,10 +1744,10 @@ HttpTransact::StartAccessControl(State *s)
   HandleRequestAuthorized(s);
   //  return;
   // }
-  // ua_session is NULL for scheduled updates.
+  // ua_txn is NULL for scheduled updates.
   // Don't use req_flavor to do the test because if updated
   // urls are remapped, the req_flavor is changed to REV_PROXY.
-  // if (s->state_machine->ua_session == NULL) {
+  // if (s->state_machine->ua_txn == NULL) {
   // Scheduled updates should always be allowed
   // return;
   //}
@@ -3513,7 +3513,7 @@ HttpTransact::handle_response_from_server(State *s)
         // Force host resolution to have the same family as the client.
         // Because this is a transparent connection, we can't switch address
         // families - that is locked in by the client source address.
-        s->state_machine->ua_session->set_host_res_style(ats_host_res_match(&s->current.server->dst_addr.sa));
+        s->state_machine->ua_txn->set_host_res_style(ats_host_res_match(&s->current.server->dst_addr.sa));
         TRANSACT_RETURN(SM_ACTION_DNS_LOOKUP, OSDNSLookup);
       } else if ((s->dns_info.srv_lookup_success || s->host_db_info.is_rr_elt()) &&
                  (s->txn_conf->connect_attempts_rr_retries > 0) &&
@@ -5425,8 +5425,8 @@ HttpTransact::initialize_state_variables_from_request(State *s, HTTPHdr *obsolet
   }
 
   NetVConnection *vc = nullptr;
-  if (s->state_machine->ua_session) {
-    vc = s->state_machine->ua_session->get_netvc();
+  if (s->state_machine->ua_txn) {
+    vc = s->state_machine->ua_txn->get_netvc();
   }
 
   if (vc) {
@@ -5435,7 +5435,7 @@ HttpTransact::initialize_state_variables_from_request(State *s, HTTPHdr *obsolet
   }
 
   // If this is an internal request, never keep alive
-  if (!s->txn_conf->keep_alive_enabled_in || (s->state_machine->ua_session && s->state_machine->ua_session->ignore_keep_alive())) {
+  if (!s->txn_conf->keep_alive_enabled_in || (s->state_machine->ua_txn && s->state_machine->ua_txn->ignore_keep_alive())) {
     s->client_info.keep_alive = HTTP_NO_KEEPALIVE;
   } else if (vc && vc->get_is_internal_request()) {
     // Following the trail of JIRAs back from TS-4960, there can be issues with
@@ -5565,7 +5565,7 @@ HttpTransact::initialize_state_variables_from_response(State *s, HTTPHdr *incomi
       TxnDebug("http_hdrs", "[initialize_state_variables_from_response]"
                             "Server is keep-alive.");
     }
-  } else if (s->state_machine->ua_session && s->state_machine->ua_session->is_outbound_transparent() &&
+  } else if (s->state_machine->ua_txn && s->state_machine->ua_txn->is_outbound_transparent() &&
              s->state_machine->t_state.http_config_param->use_client_source_port) {
     /* If we are reusing the client<->ATS 4-tuple for ATS<->server then if the server side is closed, we can't
        re-open it because the 4-tuple may still be in the processing of shutting down. So if the server isn't
@@ -6397,8 +6397,8 @@ HttpTransact::process_quick_http_filter(State *s, int method)
     return;
   }
 
-  if (s->state_machine->ua_session) {
-    const AclRecord *acl_record = s->state_machine->ua_session->get_acl_record();
+  if (s->state_machine->ua_txn) {
+    const AclRecord *acl_record = s->state_machine->ua_txn->get_acl_record();
     bool deny_request           = (acl_record == nullptr);
     if (acl_record && (acl_record->_method_mask != AclRecord::ALL_METHOD_MASK)) {
       if (method != -1) {
@@ -7839,7 +7839,7 @@ HttpTransact::build_error_response(State *s, HTTPStatus status_code, const char 
   }
   // If transparent and the forward server connection looks unhappy don't
   // keep alive the ua connection.
-  if ((s->state_machine->ua_session && s->state_machine->ua_session->is_outbound_transparent()) &&
+  if ((s->state_machine->ua_txn && s->state_machine->ua_txn->is_outbound_transparent()) &&
       (status_code == HTTP_STATUS_INTERNAL_SERVER_ERROR || status_code == HTTP_STATUS_GATEWAY_TIMEOUT ||
        status_code == HTTP_STATUS_BAD_GATEWAY || status_code == HTTP_STATUS_SERVICE_UNAVAILABLE)) {
     s->client_info.keep_alive = HTTP_NO_KEEPALIVE;

--- a/proxy/http/remap/UrlRewrite.cc
+++ b/proxy/http/remap/UrlRewrite.cc
@@ -437,7 +437,7 @@ UrlRewrite::PerformACLFiltering(HttpTransact::State *s, url_mapping *map)
         match = false;
         for (int j = 0; j < rp->in_ip_cnt && !match; j++) {
           IpEndpoint incoming_addr;
-          incoming_addr.assign(s->state_machine->ua_session->get_netvc()->get_local_addr());
+          incoming_addr.assign(s->state_machine->ua_txn->get_netvc()->get_local_addr());
           if (is_debug_tag_set("url_rewrite")) {
             char buf1[128], buf2[128], buf3[128];
             ats_ip_ntop(incoming_addr, buf1, sizeof(buf1));
@@ -459,7 +459,7 @@ UrlRewrite::PerformACLFiltering(HttpTransact::State *s, url_mapping *map)
       }
 
       if (rp->internal) {
-        match = s->state_machine->ua_session->get_netvc()->get_is_internal_request();
+        match = s->state_machine->ua_txn->get_netvc()->get_is_internal_request();
         Debug("url_rewrite", "%s an internal request", match ? "matched" : "didn't match");
       }
 

--- a/proxy/logging/LogAccessHttp.cc
+++ b/proxy/logging/LogAccessHttp.cc
@@ -1473,7 +1473,7 @@ LogAccessHttp::marshal_client_http_connection_id(char *buf)
   if (buf) {
     int64_t id = 0;
     if (m_http_sm) {
-      auto p = m_http_sm->ua_session;
+      auto p = m_http_sm->ua_txn;
       if (p) {
         auto p2 = p->get_parent();
         if (p2) {
@@ -1495,7 +1495,7 @@ LogAccessHttp::marshal_client_http_transaction_id(char *buf)
   if (buf) {
     int64_t id = 0;
     if (m_http_sm) {
-      auto p = m_http_sm->ua_session;
+      auto p = m_http_sm->ua_txn;
       if (p) {
         id = p->get_transaction_id();
       }


### PR DESCRIPTION
Rename `HttpSM::ua_session` `HttpSM::ua_txn`.

- Basically changes are made by clang-rename (
http://releases.llvm.org/5.0.0/tools/clang/tools/extra/docs/clang-rename.html )
- Some `ua_session` in comments are changed by hand.

Changes for #2810. 