### PR TITLE
removes usages of deleted http.redirection_enabled

### DIFF
--- a/tests/gold_tests/redirect/redirect.test.py
+++ b/tests/gold_tests/redirect/redirect.test.py
@@ -35,7 +35,6 @@ dest_serv = Test.MakeOriginServer("dest_server")
 dns = Test.MakeDNServer("dns")
 
 ts.Disk.records_config.update({
-    'proxy.config.http.redirection_enabled': 1,
     'proxy.config.http.number_of_redirections': MAX_REDIRECT,
     'proxy.config.http.cache.http': 0,
     'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),

--- a/tests/gold_tests/redirect/redirect_post.test.py
+++ b/tests/gold_tests/redirect/redirect_post.test.py
@@ -37,7 +37,6 @@ redirect_serv2 = Test.MakeOriginServer("re_server2")
 dest_serv = Test.MakeOriginServer("dest_server")
 
 ts.Disk.records_config.update({
-    'proxy.config.http.redirection_enabled': 1,
     'proxy.config.http.number_of_redirections': MAX_REDIRECT,
     'proxy.config.http.post_copy_size' : 919430601,
     'proxy.config.http.cache.http': 0  # ,


### PR DESCRIPTION
These will cause a `WARNING: Unrecognized configuration value 'proxy.config.http.redirection_enabled'` if used.

The config has been removed. It is my understanding that setting `proxy.config.http.number_of_redirections` to `0` disables redirects.

Milestone: 8.0.0
Labels: Tests