### PR TITLE
Add a configuration parameter  to the regex_revalidate plugin.

### DIFF
--- a/doc/admin-guide/plugins/regex_revalidate.en.rst
+++ b/doc/admin-guide/plugins/regex_revalidate.en.rst
@@ -58,11 +58,18 @@ two required arguments: the path to a rules file, and the path to a log file::
 
 The rule configuration file format is described below in `Revalidation Rules`_.
 
-The plugin regularly (every 60 seconds) checks its rules configuration file for
-changes. If the file has been modified since its last scan, the contents are
-read and the in-memory rules list is updated. Thus, new rules may be added and
-existing ones modified without requiring a service restart every time (as long
-as the delay of up to 60 seconds is acceptable).
+By default The plugin regularly (every 60 seconds) checks its rules configuration
+file for changes and it will also check for changes when ``traffic_ctl config reload``
+is run. If the file has been modified since its last scan, the contents 
+are read and the in-memory rules list is updated. Thus, new rules may be added and
+existing ones modified without requiring a service restart.
+
+The configuration parameter `--disable-timed-updates` or `-d` may be used to configure
+the plugin to disable timed config file change checks.  With timed checks disabled,
+config file changes are checked are only when ``traffic_ctl config reload`` is run.::
+
+    regex_revalidate.so -d -c <path to rules> -l <path to log>
+
 
 Revalidation Rules
 ==================

--- a/plugins/regex_revalidate/regex_revalidate.c
+++ b/plugins/regex_revalidate/regex_revalidate.c
@@ -349,6 +349,10 @@ config_handler(TSCont cont, TSEvent event ATS_UNUSED, void *edata ATS_UNUSED)
   invalidate_t *i, *iptr;
   TSCont free_cont;
   bool updated;
+  TSMutex mutex;
+
+  mutex = TSContMutexGet(cont);
+  TSMutexLock(mutex);
 
   TSDebug(LOG_PREFIX, "In config Handler");
   pstate = (plugin_state_t *)TSContDataGet(cont);
@@ -372,6 +376,8 @@ config_handler(TSCont cont, TSEvent event ATS_UNUSED, void *edata ATS_UNUSED)
       free_invalidate_t_list(i);
     }
   }
+
+  TSMutexUnlock(mutex);
 
   TSContSchedule(cont, CONFIG_TMOUT, TS_THREAD_POOL_TASK);
   return 0;
@@ -476,7 +482,8 @@ TSPluginInit(int argc, const char *argv[])
   TSPluginRegistrationInfo info;
   TSCont main_cont, config_cont;
   plugin_state_t *pstate;
-  invalidate_t *iptr = NULL;
+  invalidate_t *iptr        = NULL;
+  bool disable_timed_reload = false;
 
   TSDebug(LOG_PREFIX, "Starting plugin init");
 
@@ -484,8 +491,10 @@ TSPluginInit(int argc, const char *argv[])
   init_plugin_state_t(pstate);
 
   int c;
-  static const struct option longopts[] = {
-    {"config", required_argument, NULL, 'c'}, {"log", required_argument, NULL, 'l'}, {NULL, 0, NULL, 0}};
+  static const struct option longopts[] = {{"config", required_argument, NULL, 'c'},
+                                           {"log", required_argument, NULL, 'l'},
+                                           {"disable-timed-reload", no_argument, NULL, 'd'},
+                                           {NULL, 0, NULL, 0}};
 
   while ((c = getopt_long(argc, (char *const *)argv, "c:l:", longopts, NULL)) != -1) {
     switch (c) {
@@ -498,6 +507,9 @@ TSPluginInit(int argc, const char *argv[])
         TSTextLogObjectRollingIntervalSecSet(pstate->log, LOG_ROLL_INTERVAL);
         TSTextLogObjectRollingOffsetHrSet(pstate->log, LOG_ROLL_OFFSET);
       }
+      break;
+    case 'd':
+      disable_timed_reload = true;
       break;
     default:
       break;
@@ -545,7 +557,12 @@ TSPluginInit(int argc, const char *argv[])
 
   config_cont = TSContCreate(config_handler, TSMutexCreate());
   TSContDataSet(config_cont, (void *)pstate);
-  TSContSchedule(config_cont, CONFIG_TMOUT, TS_THREAD_POOL_TASK);
+
+  TSMgmtUpdateRegister(config_cont, LOG_PREFIX);
+
+  if (!disable_timed_reload) {
+    TSContSchedule(config_cont, CONFIG_TMOUT, TS_THREAD_POOL_TASK);
+  }
 
   TSDebug(LOG_PREFIX, "Plugin Init Complete");
 }


### PR DESCRIPTION
Currently the regex_revalidate plugin re-reads it's rules every 60 seonds if the config file has changed since the last scan.  I'm adding an optional configuration parameter that allows the operator to override this so that the config file is re-read if the file has changed and only when 'traffic_ctl config reload' is run.