### PR TITLE
Only allow the gzip/brotli transformation on 200 OK responses

### DIFF
--- a/plugins/gzip/gzip.cc
+++ b/plugins/gzip/gzip.cc
@@ -663,8 +663,9 @@ transformable(TSHttpTxn txnp, bool server, HostConfiguration *host_configuration
 
   resp_status = TSHttpHdrStatusGet(bufp, hdr_loc);
 
-  // conservatively pick some statusses to compress
-  if (!(resp_status == 200 || resp_status == 404 || resp_status == 500)) {
+  // For now, only do gzip / brotli on 200 responses, dealing with error responses can mess up plugins
+  // like the escalate.so plugin, and possibly the escalation feature of parent.config. See #2913.
+  if (resp_status != 200) {
     info("http response status [%d] is not compressible", resp_status);
     TSHandleMLocRelease(bufp, TS_NULL_MLOC, hdr_loc);
     return 0;


### PR DESCRIPTION
This is per suggestion from Oknet and scw00, to avoid inompcatilibities
between the transforms and the follow redirect APIs.

This closes #2913.