### PR TITLE
Stop ATS from crashing on kernel 4.14

### DIFF
--- a/lib/ts/ink_sys_control.cc
+++ b/lib/ts/ink_sys_control.cc
@@ -26,6 +26,7 @@
 #include "ts/ink_defs.h"
 #include "ts/ink_assert.h"
 #include "ts/ink_sys_control.h"
+#include "ts/Diags.h"
 
 rlim_t
 ink_max_out_rlimit(int which, bool max_it, bool unlim_it)
@@ -49,7 +50,9 @@ ink_max_out_rlimit(int which, bool max_it, bool unlim_it)
 #else
       rl.rlim_cur = rl.rlim_max;
 #endif
-      ink_release_assert(setrlimit(MAGIC_CAST(which), &rl) >= 0);
+      if (setrlimit(MAGIC_CAST(which), &rl) != 0) {
+        Warning("Failed to set Limit : %s", strerror(errno));
+      }
     }
   }
 
@@ -58,7 +61,9 @@ ink_max_out_rlimit(int which, bool max_it, bool unlim_it)
     ink_release_assert(getrlimit(MAGIC_CAST(which), &rl) >= 0);
     if (rl.rlim_cur != (rlim_t)RLIM_INFINITY) {
       rl.rlim_cur = (rl.rlim_max = RLIM_INFINITY);
-      ink_release_assert(setrlimit(MAGIC_CAST(which), &rl) >= 0);
+      if (setrlimit(MAGIC_CAST(which), &rl) != 0) {
+        Warning("Failed to set Limit : %s", strerror(errno));
+      }
     }
   }
 #endif


### PR DESCRIPTION
Use warning instead of assert for `setrlimit()` in `ink_sys_control.cc`