### PR TITLE
fixes parse of redirect uris missing leading /

### DIFF
--- a/tests/gold_tests/redirect/.gitignore
+++ b/tests/gold_tests/redirect/.gitignore
@@ -1,0 +1,1 @@
+generated_test_data/

--- a/tests/gold_tests/redirect/gold/redirect.gold
+++ b/tests/gold_tests/redirect/gold/redirect.gold
@@ -1,5 +1,4 @@
 HTTP/1.1 204 No Content
-Date: ``
 Age: ``
 Connection: keep-alive
-Server: ATS/``
+

--- a/tests/gold_tests/redirect/redirect.test.py
+++ b/tests/gold_tests/redirect/redirect.test.py
@@ -1,4 +1,5 @@
 '''
+Test redirection
 '''
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
@@ -18,14 +19,8 @@
 
 import os
 Test.Summary = '''
-Test basic redirection
+Test redirection
 '''
-
-MAX_REDIRECT = 99
-
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
 
 Test.ContinueOnFail = True
 
@@ -35,37 +30,82 @@ dest_serv = Test.MakeOriginServer("dest_server")
 dns = Test.MakeDNServer("dns")
 
 ts.Disk.records_config.update({
-    'proxy.config.http.number_of_redirections': MAX_REDIRECT,
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'http|dns|redirect',
+    'proxy.config.http.redirection_enabled': 1,
+    'proxy.config.http.number_of_redirections': 1,
     'proxy.config.http.cache.http': 0,
     'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
     'proxy.config.dns.resolv_conf': 'NULL',
     'proxy.config.url_remap.remap_required': 0  # need this so the domain gets a chance to be evaluated through DNS
 })
 
+Test.Setup.Copy(os.path.join(Test.Variables.AtsTestToolsDir,'tcp_client.py'))
+
 redirect_request_header = {"headers": "GET /redirect HTTP/1.1\r\nHost: *\r\n\r\n", "timestamp": "5678", "body": ""}
 redirect_response_header = {"headers": "HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:{0}/redirectDest\r\n\r\n".format(
     dest_serv.Variables.Port), "timestamp": "5678", "body": ""}
-dest_request_header = {"headers": "GET /redirectDest HTTP/1.1\r\nHost: *\r\n\r\n", "timestamp": "11", "body": ""}
-dest_response_header = {"headers": "HTTP/1.1 204 No Content\r\n\r\n", "timestamp": "22", "body": ""}
-
 redirect_serv.addResponse("sessionfile.log", redirect_request_header, redirect_response_header)
+
+dest_request_header = {"headers": "GET /redirectDest HTTP/1.1\r\nHost: *\r\n\r\n", "timestamp": "11", "body": ""}
+dest_response_header = {"headers": "HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n", "timestamp": "22", "body": ""}
 dest_serv.addResponse("sessionfile.log", dest_request_header, dest_response_header)
 
+dns.addRecords(records={"iwillredirect.test.": ["127.0.0.1"]})
 
-dns.addRecords(records={"iwillredirect.com.": ["127.0.0.1"]})
-# dns.addRecords(jsonFile="zone.json")
+data_dirname = 'generated_test_data'
+data_path = os.path.join(Test.TestDirectory, data_dirname)
+os.makedirs(data_path, exist_ok=True)
 
-# if we don't disable remap_required, we can also just remap a domain to the domain recognized by DNS
-# ts.Disk.remap_config.AddLine(
-#     'map http://example.com http://iwillredirect.com:{1}/redirect'.format(redirect_serv.Variables.Port)
-# )
-
-tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'curl -i --proxy 127.0.0.1:{0} "http://iwillredirect.com:{1}/redirect"'.format(
-    ts.Variables.port, redirect_serv.Variables.Port)
+# Here and below: spaces are deliberately omitted from the test run names because autest creates directories using these names.
+tr = Test.AddTestRun("FollowsRedirectWithAbsoluteLocationURI")
+# Here and below: because autest's Copy does not behave like standard cp, it's easiest to write all of our files out and copy last.
+with open(os.path.join(data_path, tr.Name), 'w') as f:
+    f.write('GET /redirect HTTP/1.1\r\nHost: iwillredirect.test:{port}\r\n\r\n'.format(port=redirect_serv.Variables.Port))
+tr.Processes.Default.Command = "python tcp_client.py 127.0.0.1 {0} {1} | egrep -v '^(Date: |Server: ATS/)'".format(ts.Variables.port, os.path.join(data_dirname, tr.Name))
 tr.Processes.Default.StartBefore(ts)
 tr.Processes.Default.StartBefore(redirect_serv)
 tr.Processes.Default.StartBefore(dest_serv)
 tr.Processes.Default.StartBefore(dns)
 tr.Processes.Default.Streams.stdout = "gold/redirect.gold"
 tr.Processes.Default.ReturnCode = 0
+
+
+
+redirect_request_header = {"headers": "GET /redirect-relative-path HTTP/1.1\r\nHost: *\r\n\r\n", "timestamp": "5678", "body": ""}
+redirect_response_header = {"headers": "HTTP/1.1 302 Found\r\nLocation: /redirect\r\n\r\n", "timestamp": "5678", "body": ""}
+redirect_serv.addResponse("sessionfile.log", redirect_request_header, redirect_response_header)
+
+redirect_request_header = {"headers": "GET /redirect HTTP/1.1\r\nHost: *\r\n\r\n", "timestamp": "5678", "body": ""}
+redirect_response_header = {"headers": "HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n", "timestamp": "22", "body": ""}
+redirect_serv.addResponse("sessionfile.log", redirect_request_header, redirect_response_header)
+
+tr = Test.AddTestRun("FollowsRedirectWithRelativeLocationURI")
+with open(os.path.join(data_path, tr.Name), 'w') as f:
+    f.write('GET /redirect-relative-path HTTP/1.1\r\nHost: iwillredirect.test:{port}\r\n\r\n'.format(port=redirect_serv.Variables.Port))
+tr.Processes.Default.Command = "python tcp_client.py 127.0.0.1 {0} {1} | egrep -v '^(Date: |Server: ATS/)'".format(ts.Variables.port, os.path.join(data_dirname, tr.Name))
+tr.StillRunningAfter = ts
+tr.StillRunningAfter = redirect_serv
+tr.StillRunningAfter = dest_serv
+tr.StillRunningAfter = dns
+tr.Processes.Default.Streams.stdout = "gold/redirect.gold"
+tr.Processes.Default.ReturnCode = 0
+
+
+
+redirect_request_header = {"headers": "GET /redirect-relative-path-no-leading-slash HTTP/1.1\r\nHost: *\r\n\r\n", "timestamp": "5678", "body": ""}
+redirect_response_header = {"headers": "HTTP/1.1 302 Found\r\nLocation: redirect\r\n\r\n", "timestamp": "5678", "body": ""}
+redirect_serv.addResponse("sessionfile.log", redirect_request_header, redirect_response_header)
+
+tr = Test.AddTestRun("FollowsRedirectWithRelativeLocationURIMissingLeadingSlash")
+with open(os.path.join(data_path, tr.Name), 'w') as f:
+    f.write('GET /redirect-relative-path-no-leading-slash HTTP/1.1\r\nHost: iwillredirect.test:{port}\r\n\r\n'.format(port=redirect_serv.Variables.Port))
+tr.Processes.Default.Command = "python tcp_client.py 127.0.0.1 {0} {1} | egrep -v '^(Date: |Server: ATS/)'".format(ts.Variables.port, os.path.join(data_dirname, tr.Name))
+tr.StillRunningAfter = ts
+tr.StillRunningAfter = redirect_serv
+tr.StillRunningAfter = dest_serv
+tr.StillRunningAfter = dns
+tr.Processes.Default.Streams.stdout = "gold/redirect.gold"
+tr.Processes.Default.ReturnCode = 0
+
+Test.Setup.Copy(data_path)


### PR DESCRIPTION
RFC7230 § 5.5

These are a variant of origin-form URIs where the origin neglected to begin the path with a / character.

Milestone: v8.0.0
Labels: Core, HTTP, Backports
Project: 7.x releases

Requesting a backport because browsers handle this case, but when following redirects, ATS currently does not.