### PR TITLE
fixes parse of redirect uris missing leading /

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -7737,14 +7737,14 @@ HttpSM::redirect_request(const char *redirect_url, const int redirect_len)
 
     if (tmpOrigHost) {
       memcpy(origHost, tmpOrigHost, origHost_len);
-      origHost[origHost_len] = '\0';
+      origHost[std::min(origHost_len, MAXDNAME - 1)] = '\0';
     } else {
       valid_origHost = false;
     }
 
     char *tmpOrigMethod = (char *)t_state.hdr_info.server_request.method_get(&origMethod_len);
     if (tmpOrigMethod) {
-      memcpy(origMethod, tmpOrigMethod, origMethod_len);
+      memcpy(origMethod, tmpOrigMethod, std::min(origMethod_len, static_cast<int>(sizeof(origMethod))));
     } else {
       valid_origHost = false;
     }
@@ -7766,6 +7766,22 @@ HttpSM::redirect_request(const char *redirect_url, const int redirect_len)
 
   // redirectUrl.user_set(redirect_url, redirect_len);
   redirectUrl.parse(redirect_url, redirect_len);
+  {
+    int _scheme_len = -1;
+    int _host_len   = -1;
+    if (redirectUrl.scheme_get(&_scheme_len) == nullptr && redirectUrl.host_get(&_host_len) != nullptr && redirect_url[0] != '/') {
+      // RFC7230 § 5.5
+      // The redirect URL lacked a scheme and so it is a relative URL.
+      // The redirect URL did not begin with a slash, so we parsed some or all
+      // of the the relative URI path as the host.
+      // Prepend a slash and parse again.
+      char redirect_url_leading_slash[redirect_len + 1];
+      redirect_url_leading_slash[0] = '/';
+      memcpy(redirect_url_leading_slash + 1, redirect_url, redirect_len + 1);
+      url_nuke_proxy_stuff(redirectUrl.m_url_impl);
+      redirectUrl.parse(redirect_url_leading_slash, redirect_len + 1);
+    }
+  }
 
   // copy the client url to the original url
   URL &origUrl = t_state.redirect_info.original_url;
@@ -7814,6 +7830,10 @@ HttpSM::redirect_request(const char *redirect_url, const int redirect_len)
   }
 
   bool noPortInHost = HttpConfig::m_master.redirection_host_no_port;
+
+  bool isRedirectUrlOriginForm = clientUrl.m_url_impl->m_len_scheme <= 0 && clientUrl.m_url_impl->m_len_user <= 0 &&
+                                 clientUrl.m_url_impl->m_len_password <= 0 && clientUrl.m_url_impl->m_len_host <= 0 &&
+                                 clientUrl.m_url_impl->m_len_port <= 0;
 
   // check to see if the client request passed a host header, if so copy the host and port from the redirect url and
   // make a new host header
@@ -7887,10 +7907,17 @@ HttpSM::redirect_request(const char *redirect_url, const int redirect_len)
         // Cleanup of state etc.
         url_nuke_proxy_stuff(clientUrl.m_url_impl);
         url_nuke_proxy_stuff(t_state.hdr_info.client_request.m_url_cached.m_url_impl);
-        t_state.hdr_info.client_request.method_set(origMethod, origMethod_len);
+        t_state.hdr_info.client_request.method_set(origMethod, std::min(origMethod_len, static_cast<int>(sizeof(origMethod))));
         t_state.hdr_info.client_request.m_target_cached = false;
         t_state.hdr_info.server_request.m_target_cached = false;
         clientUrl.scheme_set(scheme_str, scheme_len);
+        if (isRedirectUrlOriginForm) {
+          // build the rest of the effictive URL: the authority part
+          clientUrl.user_set(origUrl.m_url_impl->m_ptr_user, origUrl.m_url_impl->m_len_user);
+          clientUrl.password_set(origUrl.m_url_impl->m_ptr_password, origUrl.m_url_impl->m_len_password);
+          clientUrl.host_set(origUrl.m_url_impl->m_ptr_host, origUrl.m_url_impl->m_len_host);
+          clientUrl.port_set(origUrl.port_get());
+        }
       } else {
       LhostError:
         // the server request didn't have a host, so remove it from the headers

--- a/tests/gold_tests/redirect/.gitignore
+++ b/tests/gold_tests/redirect/.gitignore
@@ -1,0 +1,1 @@
+generated_test_data/

--- a/tests/gold_tests/redirect/gold/redirect.gold
+++ b/tests/gold_tests/redirect/gold/redirect.gold
@@ -1,5 +1,4 @@
 HTTP/1.1 204 No Content
-Date: ``
 Age: ``
 Connection: keep-alive
-Server: ATS/``
+

--- a/tests/gold_tests/redirect/gold/redirect_post.gold
+++ b/tests/gold_tests/redirect/gold/redirect_post.gold
@@ -1,0 +1,5 @@
+HTTP/1.1 204 No Content
+Date: ``
+Age: ``
+Connection: keep-alive
+Server: ATS/``

--- a/tests/gold_tests/redirect/redirect.test.py
+++ b/tests/gold_tests/redirect/redirect.test.py
@@ -1,4 +1,5 @@
 '''
+Test redirection
 '''
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
@@ -18,14 +19,8 @@
 
 import os
 Test.Summary = '''
-Test basic redirection
+Test redirection
 '''
-
-MAX_REDIRECT = 99
-
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
 
 Test.ContinueOnFail = True
 
@@ -35,37 +30,82 @@ dest_serv = Test.MakeOriginServer("dest_server")
 dns = Test.MakeDNServer("dns")
 
 ts.Disk.records_config.update({
-    'proxy.config.http.number_of_redirections': MAX_REDIRECT,
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'http|dns|redirect',
+    'proxy.config.http.redirection_enabled': 1,
+    'proxy.config.http.number_of_redirections': 1,
     'proxy.config.http.cache.http': 0,
     'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
     'proxy.config.dns.resolv_conf': 'NULL',
     'proxy.config.url_remap.remap_required': 0  # need this so the domain gets a chance to be evaluated through DNS
 })
 
+Test.Setup.Copy(os.path.join(Test.Variables.AtsTestToolsDir,'tcp_client.py'))
+
 redirect_request_header = {"headers": "GET /redirect HTTP/1.1\r\nHost: *\r\n\r\n", "timestamp": "5678", "body": ""}
 redirect_response_header = {"headers": "HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:{0}/redirectDest\r\n\r\n".format(
     dest_serv.Variables.Port), "timestamp": "5678", "body": ""}
-dest_request_header = {"headers": "GET /redirectDest HTTP/1.1\r\nHost: *\r\n\r\n", "timestamp": "11", "body": ""}
-dest_response_header = {"headers": "HTTP/1.1 204 No Content\r\n\r\n", "timestamp": "22", "body": ""}
-
 redirect_serv.addResponse("sessionfile.log", redirect_request_header, redirect_response_header)
+
+dest_request_header = {"headers": "GET /redirectDest HTTP/1.1\r\nHost: *\r\n\r\n", "timestamp": "11", "body": ""}
+dest_response_header = {"headers": "HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n", "timestamp": "22", "body": ""}
 dest_serv.addResponse("sessionfile.log", dest_request_header, dest_response_header)
 
+dns.addRecords(records={"iwillredirect.test.": ["127.0.0.1"]})
 
-dns.addRecords(records={"iwillredirect.com.": ["127.0.0.1"]})
-# dns.addRecords(jsonFile="zone.json")
+data_dirname = 'generated_test_data'
+data_path = os.path.join(Test.TestDirectory, data_dirname)
+os.makedirs(data_path, exist_ok=True)
 
-# if we don't disable remap_required, we can also just remap a domain to the domain recognized by DNS
-# ts.Disk.remap_config.AddLine(
-#     'map http://example.com http://iwillredirect.com:{1}/redirect'.format(redirect_serv.Variables.Port)
-# )
-
-tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'curl -i --proxy 127.0.0.1:{0} "http://iwillredirect.com:{1}/redirect"'.format(
-    ts.Variables.port, redirect_serv.Variables.Port)
+# Here and below: spaces are deliberately omitted from the test run names because autest creates directories using these names.
+tr = Test.AddTestRun("FollowsRedirectWithAbsoluteLocationURI")
+# Here and below: because autest's Copy does not behave like standard cp, it's easiest to write all of our files out and copy last.
+with open(os.path.join(data_path, tr.Name), 'w') as f:
+    f.write('GET /redirect HTTP/1.1\r\nHost: iwillredirect.test:{port}\r\n\r\n'.format(port=redirect_serv.Variables.Port))
+tr.Processes.Default.Command = "python tcp_client.py 127.0.0.1 {0} {1} | egrep -v '^(Date: |Server: ATS/)'".format(ts.Variables.port, os.path.join(data_dirname, tr.Name))
 tr.Processes.Default.StartBefore(ts)
 tr.Processes.Default.StartBefore(redirect_serv)
 tr.Processes.Default.StartBefore(dest_serv)
 tr.Processes.Default.StartBefore(dns)
 tr.Processes.Default.Streams.stdout = "gold/redirect.gold"
 tr.Processes.Default.ReturnCode = 0
+
+
+
+redirect_request_header = {"headers": "GET /redirect-relative-path HTTP/1.1\r\nHost: *\r\n\r\n", "timestamp": "5678", "body": ""}
+redirect_response_header = {"headers": "HTTP/1.1 302 Found\r\nLocation: /redirect\r\n\r\n", "timestamp": "5678", "body": ""}
+redirect_serv.addResponse("sessionfile.log", redirect_request_header, redirect_response_header)
+
+redirect_request_header = {"headers": "GET /redirect HTTP/1.1\r\nHost: *\r\n\r\n", "timestamp": "5678", "body": ""}
+redirect_response_header = {"headers": "HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n", "timestamp": "22", "body": ""}
+redirect_serv.addResponse("sessionfile.log", redirect_request_header, redirect_response_header)
+
+tr = Test.AddTestRun("FollowsRedirectWithRelativeLocationURI")
+with open(os.path.join(data_path, tr.Name), 'w') as f:
+    f.write('GET /redirect-relative-path HTTP/1.1\r\nHost: iwillredirect.test:{port}\r\n\r\n'.format(port=redirect_serv.Variables.Port))
+tr.Processes.Default.Command = "python tcp_client.py 127.0.0.1 {0} {1} | egrep -v '^(Date: |Server: ATS/)'".format(ts.Variables.port, os.path.join(data_dirname, tr.Name))
+tr.StillRunningAfter = ts
+tr.StillRunningAfter = redirect_serv
+tr.StillRunningAfter = dest_serv
+tr.StillRunningAfter = dns
+tr.Processes.Default.Streams.stdout = "gold/redirect.gold"
+tr.Processes.Default.ReturnCode = 0
+
+
+
+redirect_request_header = {"headers": "GET /redirect-relative-path-no-leading-slash HTTP/1.1\r\nHost: *\r\n\r\n", "timestamp": "5678", "body": ""}
+redirect_response_header = {"headers": "HTTP/1.1 302 Found\r\nLocation: redirect\r\n\r\n", "timestamp": "5678", "body": ""}
+redirect_serv.addResponse("sessionfile.log", redirect_request_header, redirect_response_header)
+
+tr = Test.AddTestRun("FollowsRedirectWithRelativeLocationURIMissingLeadingSlash")
+with open(os.path.join(data_path, tr.Name), 'w') as f:
+    f.write('GET /redirect-relative-path-no-leading-slash HTTP/1.1\r\nHost: iwillredirect.test:{port}\r\n\r\n'.format(port=redirect_serv.Variables.Port))
+tr.Processes.Default.Command = "python tcp_client.py 127.0.0.1 {0} {1} | egrep -v '^(Date: |Server: ATS/)'".format(ts.Variables.port, os.path.join(data_dirname, tr.Name))
+tr.StillRunningAfter = ts
+tr.StillRunningAfter = redirect_serv
+tr.StillRunningAfter = dest_serv
+tr.StillRunningAfter = dns
+tr.Processes.Default.Streams.stdout = "gold/redirect.gold"
+tr.Processes.Default.ReturnCode = 0
+
+Test.Setup.Copy(data_path)

--- a/tests/gold_tests/redirect/redirect_post.test.py
+++ b/tests/gold_tests/redirect/redirect_post.test.py
@@ -68,5 +68,5 @@ tr.Processes.Default.StartBefore(ts)
 tr.Processes.Default.StartBefore(redirect_serv1)
 tr.Processes.Default.StartBefore(redirect_serv2)
 tr.Processes.Default.StartBefore(dest_serv)
-tr.Processes.Default.Streams.stdout = "gold/redirect.gold"
+tr.Processes.Default.Streams.stdout = "gold/redirect_post.gold"
 tr.Processes.Default.ReturnCode = 0


### PR DESCRIPTION
RFC7230 § 5.5

These are a variant of origin-form URIs where the origin neglected to begin the path with a / character.

Milestone: v8.0.0
Labels: Core, HTTP, Backports
Project: 7.x releases

Requesting a backport because browsers handle this case, but when following redirects, ATS currently does not.