### PR TITLE
Removes the limit on the number of remap plugins per rule

### DIFF
--- a/proxy/http/remap/RemapPlugins.cc
+++ b/proxy/http/remap/RemapPlugins.cc
@@ -118,12 +118,7 @@ RemapPlugins::run_single_remap()
     return 1;
   }
 
-  if (_cur > MAX_REMAP_PLUGIN_CHAIN) {
-    Error("called %s more than %u times; stopping this remap insanity now", __func__, MAX_REMAP_PLUGIN_CHAIN);
-    return 1;
-  }
-
-  if (_cur >= map->_plugin_count) {
+  if (_cur >= map->plugin_count()) {
     // Normally, we would callback into this function but we dont have anything more to do!
     Debug("url_rewrite", "completed all remap plugins for rule id %d", map->map_id);
     return 1;

--- a/proxy/http/remap/UrlMapping.h
+++ b/proxy/http/remap/UrlMapping.h
@@ -24,6 +24,8 @@
 #ifndef _URL_MAPPING_H_
 #define _URL_MAPPING_H_
 
+#include <vector>
+
 #include "ts/ink_config.h"
 #include "AclFiltering.h"
 #include "Main.h"
@@ -31,8 +33,6 @@
 #include "RemapPluginInfo.h"
 #include "ts/Regex.h"
 #include "ts/List.h"
-
-static const unsigned int MAX_REMAP_PLUGIN_CHAIN = 10;
 
 /**
  * Used to store http referer strings (and/or regexp)
@@ -79,17 +79,18 @@ public:
 class url_mapping
 {
 public:
-  url_mapping();
   ~url_mapping();
 
   bool add_plugin(remap_plugin_info *i, void *ih);
-  remap_plugin_info *get_plugin(unsigned int) const;
+  remap_plugin_info *get_plugin(std::size_t) const;
+  void *get_instance(std::size_t) const;
 
-  void *
-  get_instance(unsigned int index) const
+  std::size_t
+  plugin_count() const
   {
-    return _instance_data[index];
-  };
+    return _plugin_list.size();
+  }
+
   void delete_instance(unsigned int index);
   void Print();
 
@@ -109,8 +110,7 @@ public:
   redirect_tag_str *redir_chunk_list = nullptr;
   bool ip_allow_check_enabled_p      = false;
   acl_filter_rule *filter            = nullptr; // acl filtering (list of rules)
-  unsigned int _plugin_count         = 0;
-  LINK(url_mapping, link); // For use with the main Queue linked list holding all the mapping
+  LINK(url_mapping, link);                      // For use with the main Queue linked list holding all the mapping
 
   int
   getRank() const
@@ -124,8 +124,8 @@ public:
   };
 
 private:
-  remap_plugin_info *_plugin_list[MAX_REMAP_PLUGIN_CHAIN];
-  void *_instance_data[MAX_REMAP_PLUGIN_CHAIN];
+  std::vector<remap_plugin_info *> _plugin_list;
+  std::vector<void *> _instance_data;
   int _rank = 0;
 };
 


### PR DESCRIPTION
Note: This retains as much as possible of the old code, such that we
can cherry pick this reasonably safely to 7.x. Long term, we should change
this to be something like

     using PluginInstance = std::pair<remap_plugin_info *, void *>;

and iterate over those instead of the indices.