### PR TITLE
Remove spurious max_connection warning

### DIFF
--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -1206,7 +1206,7 @@ HttpConfig::reconfigure()
   params->oride.origin_max_connections       = m_master.oride.origin_max_connections;
   params->oride.origin_max_connections_queue = m_master.oride.origin_max_connections_queue;
   // if origin_max_connections_queue is set without max_connections, it is meaningless, so we'll warn
-  if (params->oride.origin_max_connections_queue >= 0 &&
+  if (params->oride.origin_max_connections_queue > 0 &&
       !(params->oride.origin_max_connections || params->origin_min_keep_alive_connections)) {
     Warning("origin_max_connections_queue is set, but neither origin_max_connections nor origin_min_keep_alive_connections are "
             "set, please correct your records.config");


### PR DESCRIPTION
In our environment we always see the following warning on server setup.

```
WARNING: origin_max_connections_queue is set, but neither origin_max_connections nor origin_min_keep_alive_connections are set, please correct your records.config
```
However, we have all three of the referenced values explicitly set to 0, which seems like a reasonable combination of values.  If you are thinking that you are queueing (retrying) connections over the maximum perhaps the warning is reasonable.