### PR TITLE
fix ts_lua core dump issue after config reload

### DIFF
--- a/plugins/experimental/ts_lua/ts_lua.c
+++ b/plugins/experimental/ts_lua/ts_lua.c
@@ -166,7 +166,9 @@ TSRemapDeleteInstance(void *ih)
   int states = ((ts_lua_instance_conf *)ih)->states;
   ts_lua_del_module((ts_lua_instance_conf *)ih, ts_lua_main_ctx_array, states);
   ts_lua_del_instance(ih);
-  TSfree(ih);
+  // because we now reuse ts_lua_instance_conf / ih for remap rules sharing the same lua script
+  // we cannot safely free it in this function during the configuration reloads
+  // we therefore are leaking memory on configuration reloads
   return;
 }
 

--- a/plugins/experimental/ts_lua/ts_lua_util.c
+++ b/plugins/experimental/ts_lua/ts_lua_util.c
@@ -297,8 +297,8 @@ ts_lua_del_module(ts_lua_instance_conf *conf, ts_lua_main_ctx *arr, int n)
     }
 
     lua_pushlightuserdata(L, conf);
-    lua_pushnil(L);
-    lua_rawset(L, LUA_REGISTRYINDEX); /* L[REG][conf] = nil */
+    lua_pushvalue(L, LUA_GLOBALSINDEX);
+    lua_rawset(L, LUA_REGISTRYINDEX); /* L[REG][conf] = L[GLOBAL] */
 
     lua_newtable(L);
     lua_replace(L, LUA_GLOBALSINDEX); /* L[GLOBAL] = EMPTY  */


### PR DESCRIPTION
After #2696, the ts_lua plugin will core dump after doing a traffic_ctl config reload.

The reason is that, after #2696, the ts_lua_instance_conf is shared among remap rules that used the same script for the ts_lua plugin. And therefore we can't possibly release the object at cleanup. And also we cannot cleanup the reference using the instance object as key inside the lua state machine. 