### PR TITLE
Do not try to load empty client_cert path.

### DIFF
--- a/iocore/net/SSLClientUtils.cc
+++ b/iocore/net/SSLClientUtils.cc
@@ -148,7 +148,7 @@ SSLInitClientContext(const SSLConfigParams *params)
     clientKeyPtr = params->clientCertPath;
   }
 
-  if (params->clientCertPath != nullptr) {
+  if (params->clientCertPath != nullptr && params->clientCertPath[0] != '\0') {
     if (!SSL_CTX_use_certificate_chain_file(client_ctx, params->clientCertPath)) {
       SSLError("failed to load client certificate from %s", params->clientCertPath);
       goto fail;

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -415,7 +415,7 @@ SSLConfigParams::getNewCTX(cchar *client_cert) const
     SSLError("Can't initialize the SSL client, HTTPS in remap rules will not function");
     return nullptr;
   }
-  if (nclient_ctx && client_cert != nullptr) {
+  if (nclient_ctx && client_cert != nullptr && client_cert[0] != '\0') {
     if (!SSL_CTX_use_certificate_chain_file(nclient_ctx, (const char *)client_cert)) {
       SSLError("failed to load client certificate from %s", this->clientCertPath);
       SSLReleaseContext(nclient_ctx);


### PR DESCRIPTION
Without the change will generate spurious error messages in diags.log if you have a sni rule without a client certificate specified.