### PR TITLE
header_rewrite - Delete space after semi colon when deleting cookies from a list

### DIFF
--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -842,6 +842,11 @@ CookieHelper::cookieModifyHelper(const char *cookies, const size_t cookies_len, 
         for (; idx < cookies_len && cookies[idx] != ';'; idx++) {
           ;
         }
+        // If we have not reached the end and there is a space after the
+        // semi-colon, advance one char
+        if (idx < cookies_len && std::isspace(cookies[idx + 1])) {
+          idx++;
+        }
         // cookie value is found
         size_t value_end_idx = idx;
         if (CookieHelper::COOKIE_OP_SET == cookie_op) {

--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -844,7 +844,7 @@ CookieHelper::cookieModifyHelper(const char *cookies, const size_t cookies_len, 
         }
         // If we have not reached the end and there is a space after the
         // semi-colon, advance one char
-        if (idx < cookies_len && std::isspace(cookies[idx + 1])) {
+        if (idx + 1 < cookies_len && std::isspace(cookies[idx + 1])) {
           idx++;
         }
         // cookie value is found


### PR DESCRIPTION
This is an addendum to #2857.  

Per RFC6265, multiple cookies in the Cookies: header are separated by a semi-colon and a space.  This patch detects a space after the semi-colon and advances the idx if the space was present. This, essentially, deletes the entire cookie 'key=value; ' when cookies are deleted from within a list of cookies.  If all cookies are deleted, cookies is zero length and the header is removed properly.  Without this check, a space is left in the cookie string and fails the .empty() check to remove the cookie.

If possible, would be nice to backport to 7.1.2, if not too late.