### PR TITLE
logging: fix incorrect use of LogAccess::strlen()

### DIFF
--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -1044,7 +1044,7 @@ LogAccess::unmarshal_int_to_date_str(char **buf, char *dest, int len)
 
   int64_t value = unmarshal_int(buf);
   char *strval  = LogUtils::timestamp_to_date_str(value);
-  int strlen    = LogAccess::strlen(strval);
+  int strlen    = (int)::strlen(strval);
 
   memcpy(dest, strval, strlen);
   return strlen;
@@ -1059,7 +1059,7 @@ LogAccess::unmarshal_int_to_time_str(char **buf, char *dest, int len)
 
   int64_t value = unmarshal_int(buf);
   char *strval  = LogUtils::timestamp_to_time_str(value);
-  int strlen    = LogAccess::strlen(strval);
+  int strlen    = (int)::strlen(strval);
 
   memcpy(dest, strval, strlen);
   return strlen;
@@ -1074,7 +1074,7 @@ LogAccess::unmarshal_int_to_netscape_str(char **buf, char *dest, int len)
 
   int64_t value = unmarshal_int(buf);
   char *strval  = LogUtils::timestamp_to_netscape_str(value);
-  int strlen    = LogAccess::strlen(strval);
+  int strlen    = (int)::strlen(strval);
 
   memcpy(dest, strval, strlen);
   return strlen;


### PR DESCRIPTION
```
several unmarshal functions in proxy/logging/LogAccess.cc incorrectly
use LogAccess::strlen() instead of std::strlen() to determine the length
of the result.  LogAccess::strlen() rounds its return value to multiples
of 8, meaning an incorrect length would be returned (longer than the
actual string) and data past the end of the string would be written to
the logfile.

this manifested as NUL characters in logfiles using %<cqtn>, %<cqtt> and
%<cqtd>:

::1 phptest.local [15/Dec/2017:15:03:28 -0000^@^@^@^@^@^@] "GET / HTTP/1.1" 503

this closes #2940 (%<cqtn> is full of NULs)
```