### PR TITLE
Build: Fix WCCP link error for 'make check' in traffic_manager.

### DIFF
--- a/cmd/traffic_manager/Makefile.am
+++ b/cmd/traffic_manager/Makefile.am
@@ -50,9 +50,9 @@ traffic_manager_LDADD = \
   $(top_builddir)/mgmt/api/libmgmtapilocal.la \
   $(top_builddir)/mgmt/libmgmt_lm.la \
   $(top_builddir)/proxy/hdrs/libhdrs.a \
-  $(top_builddir)/lib/records/librecords_lm.a \
   $(top_builddir)/lib/ts/libtsutil.la \
   $(top_builddir)/iocore/eventsystem/libinkevent.a \
+  $(top_builddir)/lib/records/librecords_lm.a \
   $(top_builddir)/proxy/shared/libdiagsconfig.a
 
 AM_LDFLAGS += \
@@ -70,14 +70,6 @@ traffic_manager_LDADD +=\
   @LIBRESOLV@ @LIBPCRE@ @LIBTCL@ @LIBCAP@ @HWLOC_LIBS@ \
   -lm
 
-# Must do it this way or the dependencies aren't detected.
-if BUILD_WCCP
-traffic_manager_LDADD += \
-  $(top_builddir)/lib/wccp/libwccp.a \
-  $(top_builddir)/lib/tsconfig/libtsconfig.la \
-  @OPENSSL_LIBS@
-endif
-
 test_metrics_SOURCES = test_metrics.cc metrics.cc WebOverview.cc
 test_metrics_LDADD = \
   $(top_builddir)/mgmt/libmgmt_lm.la \
@@ -87,6 +79,20 @@ test_metrics_LDADD = \
   $(top_builddir)/lib/ts/libtsutil.la \
   $(top_builddir)/iocore/eventsystem/libinkevent.a \
   @LIBTCL@ @LIBPCRE@
+
+# Must do it this way or the dependencies aren't detected.
+if BUILD_WCCP
+traffic_manager_LDADD += \
+  $(top_builddir)/lib/wccp/libwccp.a \
+  $(top_builddir)/lib/tsconfig/libtsconfig.la \
+  @OPENSSL_LIBS@
+
+test_metrics_LDADD += \
+  $(top_builddir)/lib/wccp/libwccp.a \
+  $(top_builddir)/lib/tsconfig/libtsconfig.la \
+  @OPENSSL_LIBS@
+
+endif
 
 include $(top_srcdir)/build/tidy.mk
 


### PR DESCRIPTION
This is a backport of changes to linking for `traffic_manager` from master. This should resolve build issues with #2936.