### PR TITLE
Fix sdk_sanity_check_null_ptr to take a <const void *>

### DIFF
--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -670,12 +670,9 @@ sdk_sanity_check_ssl_hook_id(TSHttpHookID id)
 }
 
 TSReturnCode
-sdk_sanity_check_null_ptr(void *ptr)
+sdk_sanity_check_null_ptr(void const *ptr)
 {
-  if (ptr == nullptr) {
-    return TS_ERROR;
-  }
-  return TS_SUCCESS;
+  return ptr == nullptr ? TS_ERROR : TS_SUCCESS;
 }
 
 // Plugin metric IDs index the plugin RSB, so bounds check against that.

--- a/proxy/InkIOCoreAPI.cc
+++ b/proxy/InkIOCoreAPI.cc
@@ -88,7 +88,7 @@ sdk_sanity_check_iocore_structure(void *data)
 
 // From InkAPI.cc
 TSReturnCode sdk_sanity_check_continuation(TSCont cont);
-TSReturnCode sdk_sanity_check_null_ptr(void *ptr);
+TSReturnCode sdk_sanity_check_null_ptr(void const *ptr);
 
 ////////////////////////////////////////////////////////////////////
 //


### PR DESCRIPTION
`sdk_sanity_check_null_ptr` should take a `void const *`. This is both reasonable and required for #2883.