### PR TITLE
Drain stop and drain improve

### DIFF
--- a/mgmt/BaseManager.h
+++ b/mgmt/BaseManager.h
@@ -70,6 +70,7 @@
 // case statement.
 #define MGMT_EVENT_STORAGE_DEVICE_CMD_OFFLINE 10011
 #define MGMT_EVENT_LIFECYCLE_MESSAGE 10012
+#define MGMT_EVENT_DRAIN 10013
 
 /***********************************************************************
  *

--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -99,6 +99,14 @@ LocalManager::processBounce()
 }
 
 void
+LocalManager::processDrain(int to_drain)
+{
+  mgmt_log("[LocalManager::processDrain] Executing process drain request.\n");
+  signalEvent(MGMT_EVENT_DRAIN, to_drain ? "1" : "0");
+  return;
+}
+
+void
 LocalManager::rollLogFiles()
 {
   mgmt_log("[LocalManager::rollLogFiles] Log files are being rolled.\n");

--- a/mgmt/LocalManager.h
+++ b/mgmt/LocalManager.h
@@ -48,8 +48,13 @@ enum ManagementPendingOperation {
   MGMT_PENDING_NONE,         // Do nothing
   MGMT_PENDING_RESTART,      // Restart TS and TM
   MGMT_PENDING_BOUNCE,       // Restart TS
+  MGMT_PENDING_STOP,         // Stop TS
+  MGMT_PENDING_DRAIN,        // Drain TS
   MGMT_PENDING_IDLE_RESTART, // Restart TS and TM when TS is idle
-  MGMT_PENDING_IDLE_BOUNCE   // Restart TS when TS is idle
+  MGMT_PENDING_IDLE_BOUNCE,  // Restart TS when TS is idle
+  MGMT_PENDING_IDLE_STOP,    // Stop TS when TS is idle
+  MGMT_PENDING_IDLE_DRAIN,   // Drain TS when TS is idle from new connections
+  MGMT_PENDING_UNDO_DRAIN,   // Recover TS from drain
 };
 
 class LocalManager : public BaseManager
@@ -83,6 +88,7 @@ public:
   void processShutdown(bool mainThread = false);
   void processRestart();
   void processBounce();
+  void processDrain(int to_drain = 1);
   void rollLogFiles();
   void clearStats(const char *name = NULL);
 
@@ -95,7 +101,9 @@ public:
   int proxy_launch_count                               = 0;
   bool proxy_launch_outstanding                        = false;
   ManagementPendingOperation mgmt_shutdown_outstanding = MGMT_PENDING_NONE;
-  int proxy_running                                    = 0;
+  time_t mgmt_shutdown_triggered_at;
+  time_t mgmt_drain_triggered_at;
+  int proxy_running = 0;
   HttpProxyPort::Group m_proxy_ports;
   // Local inbound addresses to bind, if set.
   IpAddr m_inbound_ip4;

--- a/mgmt/ProcessManager.cc
+++ b/mgmt/ProcessManager.cc
@@ -381,6 +381,9 @@ ProcessManager::handleMgmtMsgFromLM(MgmtMessageHdr *mh)
   case MGMT_EVENT_RESTART:
     signalMgmtEntity(MGMT_EVENT_RESTART);
     break;
+  case MGMT_EVENT_DRAIN:
+    signalMgmtEntity(MGMT_EVENT_DRAIN, data_raw, mh->data_len);
+    break;
   case MGMT_EVENT_CLEAR_STATS:
     signalMgmtEntity(MGMT_EVENT_CLEAR_STATS);
     break;

--- a/mgmt/api/CoreAPI.cc
+++ b/mgmt/api/CoreAPI.cc
@@ -403,7 +403,8 @@ Reconfigure()
 TSMgmtError
 Restart(unsigned options)
 {
-  lmgmt->mgmt_shutdown_outstanding = (options & TS_RESTART_OPT_DRAIN) ? MGMT_PENDING_IDLE_RESTART : MGMT_PENDING_RESTART;
+  lmgmt->mgmt_shutdown_triggered_at = time(nullptr);
+  lmgmt->mgmt_shutdown_outstanding  = (options & TS_RESTART_OPT_DRAIN) ? MGMT_PENDING_IDLE_RESTART : MGMT_PENDING_RESTART;
 
   return TS_ERR_OKAY;
 }
@@ -416,8 +417,47 @@ Restart(unsigned options)
 TSMgmtError
 Bounce(unsigned options)
 {
-  lmgmt->mgmt_shutdown_outstanding = (options & TS_RESTART_OPT_DRAIN) ? MGMT_PENDING_IDLE_BOUNCE : MGMT_PENDING_BOUNCE;
+  lmgmt->mgmt_shutdown_triggered_at = time(nullptr);
+  lmgmt->mgmt_shutdown_outstanding  = (options & TS_RESTART_OPT_DRAIN) ? MGMT_PENDING_IDLE_BOUNCE : MGMT_PENDING_BOUNCE;
 
+  return TS_ERR_OKAY;
+}
+
+/*-------------------------------------------------------------------------
+ * Stop
+ *-------------------------------------------------------------------------
+ * Stops traffic_server process(es).
+ */
+TSMgmtError
+Stop(unsigned options)
+{
+  lmgmt->mgmt_shutdown_triggered_at = time(nullptr);
+  lmgmt->mgmt_shutdown_outstanding  = (options & TS_STOP_OPT_DRAIN) ? MGMT_PENDING_IDLE_STOP : MGMT_PENDING_STOP;
+
+  return TS_ERR_OKAY;
+}
+
+/*-------------------------------------------------------------------------
+ * Drain
+ *-------------------------------------------------------------------------
+ * Drain requests of traffic_server
+ */
+TSMgmtError
+Drain(unsigned options)
+{
+  switch (options) {
+  case TS_DRAIN_OPT_NONE:
+    lmgmt->mgmt_shutdown_outstanding = MGMT_PENDING_DRAIN;
+    break;
+  case TS_DRAIN_OPT_IDLE:
+    lmgmt->mgmt_shutdown_outstanding = MGMT_PENDING_IDLE_DRAIN;
+    break;
+  case TS_DRAIN_OPT_UNDO:
+    lmgmt->mgmt_shutdown_outstanding = MGMT_PENDING_UNDO_DRAIN;
+    break;
+  default:
+    ink_release_assert(!"Not expected to reach here");
+  }
   return TS_ERR_OKAY;
 }
 

--- a/mgmt/api/CoreAPI.h
+++ b/mgmt/api/CoreAPI.h
@@ -50,6 +50,8 @@ TSMgmtError ServerBacktrace(unsigned options, char **trace);
 TSMgmtError Reconfigure();                                                         // TS reread config files
 TSMgmtError Restart(unsigned options);                                             // restart TM
 TSMgmtError Bounce(unsigned options);                                              // restart traffic_server
+TSMgmtError Stop(unsigned options);                                                // stop traffic_server
+TSMgmtError Drain(unsigned options);                                               // drain requests of traffic_server
 TSMgmtError StorageDeviceCmdOffline(const char *dev);                              // Storage device operation.
 TSMgmtError LifecycleMessage(const char *tag, void const *data, size_t data_size); // Lifecycle alert to plugins.
 

--- a/mgmt/api/CoreAPIRemote.cc
+++ b/mgmt/api/CoreAPIRemote.cc
@@ -434,6 +434,40 @@ Bounce(unsigned options)
 }
 
 /*-------------------------------------------------------------------------
+ * Stop
+ *-------------------------------------------------------------------------
+ * Restart the traffic_server process(es) only.
+ */
+TSMgmtError
+Stop(unsigned options)
+{
+  TSMgmtError ret;
+  OpType optype        = OpType::STOP;
+  MgmtMarshallInt oval = options;
+
+  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::STOP, &optype, &oval);
+
+  return (ret == TS_ERR_OKAY) ? parse_generic_response(OpType::STOP, main_socket_fd) : ret;
+}
+
+/*-------------------------------------------------------------------------
+ * Drain
+ *-------------------------------------------------------------------------
+ * Drain requests of the traffic_server process(es) only.
+ */
+TSMgmtError
+Drain(unsigned options)
+{
+  TSMgmtError ret;
+  OpType optype        = OpType::DRAIN;
+  MgmtMarshallInt oval = options;
+
+  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::DRAIN, &optype, &oval);
+
+  return (ret == TS_ERR_OKAY) ? parse_generic_response(OpType::DRAIN, main_socket_fd) : ret;
+}
+
+/*-------------------------------------------------------------------------
  * StorageDeviceCmdOffline
  *-------------------------------------------------------------------------
  * Disable a storage device.

--- a/mgmt/api/INKMgmtAPI.cc
+++ b/mgmt/api/INKMgmtAPI.cc
@@ -813,6 +813,18 @@ TSBounce(unsigned options)
 }
 
 tsapi TSMgmtError
+TSStop(unsigned options)
+{
+  return Stop(options);
+}
+
+tsapi TSMgmtError
+TSDrain(unsigned options)
+{
+  return Drain(options);
+}
+
+tsapi TSMgmtError
 TSStorageDeviceCmdOffline(const char *dev)
 {
   return StorageDeviceCmdOffline(dev);

--- a/mgmt/api/NetworkMessage.cc
+++ b/mgmt/api/NetworkMessage.cc
@@ -45,6 +45,8 @@ static const struct NetCmdOperation requests[] = {
   /* RECONFIGURE                */ {1, {MGMT_MARSHALL_INT}},
   /* RESTART                    */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
   /* BOUNCE                     */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
+  /* STOP                       */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
+  /* DRAIN                      */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
   /* EVENT_RESOLVE              */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
   /* EVENT_GET_MLT              */ {1, {MGMT_MARSHALL_INT}},
   /* EVENT_ACTIVE               */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
@@ -71,6 +73,8 @@ static const struct NetCmdOperation responses[] = {
   /* RECONFIGURE                */ {1, {MGMT_MARSHALL_INT}},
   /* RESTART                    */ {1, {MGMT_MARSHALL_INT}},
   /* BOUNCE                     */ {1, {MGMT_MARSHALL_INT}},
+  /* STOP                       */ {1, {MGMT_MARSHALL_INT}},
+  /* DRAIN                      */ {1, {MGMT_MARSHALL_INT}},
   /* EVENT_RESOLVE              */ {1, {MGMT_MARSHALL_INT}},
   /* EVENT_GET_MLT              */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
   /* EVENT_ACTIVE               */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
@@ -190,6 +194,8 @@ send_mgmt_error(int fd, OpType optype, TSMgmtError error)
   // Switch on operations, grouped by response format.
   switch (optype) {
   case OpType::BOUNCE:
+  case OpType::STOP:
+  case OpType::DRAIN:
   case OpType::EVENT_RESOLVE:
   case OpType::LIFECYCLE_MESSAGE:
   case OpType::PROXY_STATE_SET:

--- a/mgmt/api/NetworkMessage.h
+++ b/mgmt/api/NetworkMessage.h
@@ -40,6 +40,8 @@ enum class OpType : MgmtMarshallInt {
   RECONFIGURE,
   RESTART,
   BOUNCE,
+  STOP,
+  DRAIN,
   EVENT_RESOLVE,
   EVENT_GET_MLT,
   EVENT_ACTIVE,

--- a/mgmt/api/TSControlMain.cc
+++ b/mgmt/api/TSControlMain.cc
@@ -600,6 +600,50 @@ handle_restart(int fd, void *req, size_t reqlen)
 }
 
 /**************************************************************************
+ * handle_stop
+ *
+ * purpose: handles request to stop TS
+ * output: TS_ERR_xx
+ * note: None
+ *************************************************************************/
+static TSMgmtError
+handle_stop(int fd, void *req, size_t reqlen)
+{
+  OpType optype;
+  MgmtMarshallInt options;
+  MgmtMarshallInt err;
+
+  err = recv_mgmt_request(req, reqlen, OpType::STOP, &optype, &options);
+  if (err == TS_ERR_OKAY) {
+    err = Stop(options);
+  }
+
+  return send_mgmt_response(fd, OpType::STOP, &err);
+}
+
+/**************************************************************************
+ * handle_drain
+ *
+ * purpose: handles request to drain TS
+ * output: TS_ERR_xx
+ * note: None
+ *************************************************************************/
+static TSMgmtError
+handle_drain(int fd, void *req, size_t reqlen)
+{
+  OpType optype;
+  MgmtMarshallInt options;
+  MgmtMarshallInt err;
+
+  err = recv_mgmt_request(req, reqlen, OpType::DRAIN, &optype, &options);
+  if (err == TS_ERR_OKAY) {
+    err = Drain(options);
+  }
+
+  return send_mgmt_response(fd, OpType::DRAIN, &err);
+}
+
+/**************************************************************************
  * handle_storage_device_cmd_offline
  *
  * purpose: handle storage offline command.
@@ -956,6 +1000,8 @@ static const control_message_handler handlers[] = {
   /* RECONFIGURE                */ {MGMT_API_PRIVILEGED, handle_reconfigure},
   /* RESTART                    */ {MGMT_API_PRIVILEGED, handle_restart},
   /* BOUNCE                     */ {MGMT_API_PRIVILEGED, handle_restart},
+  /* STOP                       */ {MGMT_API_PRIVILEGED, handle_stop},
+  /* DRAIN                      */ {MGMT_API_PRIVILEGED, handle_drain},
   /* EVENT_RESOLVE              */ {MGMT_API_PRIVILEGED, handle_event_resolve},
   /* EVENT_GET_MLT              */ {0, handle_event_get_mlt},
   /* EVENT_ACTIVE               */ {0, handle_event_active},

--- a/mgmt/api/include/mgmtapi.h
+++ b/mgmt/api/include/mgmtapi.h
@@ -201,6 +201,17 @@ typedef enum {
   TS_RESTART_OPT_DRAIN = 0x02, /* Wait for traffic to drain before restarting. */
 } TSRestartOptionT;
 
+typedef enum {
+  TS_STOP_OPT_NONE = 0x0,
+  TS_STOP_OPT_DRAIN, /* Wait for traffic to drain before stopping. */
+} TSStopOptionT;
+
+typedef enum {
+  TS_DRAIN_OPT_NONE = 0x0,
+  TS_DRAIN_OPT_IDLE, /* Wait for idle from new connections before draining. */
+  TS_DRAIN_OPT_UNDO, /* Recover TS from drain mode */
+} TSDrainOptionT;
+
 /***************************************************************************
  * Structures
  ***************************************************************************/
@@ -411,6 +422,18 @@ tsapi TSMgmtError TSActionDo(TSActionNeedT action);
  * Output TSMgmtError
  */
 tsapi TSMgmtError TSBounce(unsigned options);
+
+/* TSStop: stop the traffic_server process(es).
+ * Input: options - bitmask of TSRestartOptionT
+ * Output TSMgmtError
+ */
+tsapi TSMgmtError TSStop(unsigned options);
+
+/* TSDrain: drain requests of the traffic_server process.
+ * Input: options - TSDrainOptionT
+ * Output TSMgmtError
+ */
+tsapi TSMgmtError TSDrain(unsigned options);
 
 /* TSStorageDeviceCmdOffline: Request to make a cache storage device offline.
  * @arg dev Target device, specified by path to device.

--- a/proxy/ProxyClientSession.cc
+++ b/proxy/ProxyClientSession.cc
@@ -25,8 +25,6 @@
 #include "HttpDebugNames.h"
 #include "ProxyClientSession.h"
 
-bool http_client_session_draining = false;
-
 static int64_t next_cs_id = 0;
 
 ProxyClientSession::ProxyClientSession() : VConnection(nullptr)

--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -31,8 +31,6 @@
 #include "InkAPIInternal.h"
 #include "http/HttpServerSession.h"
 
-extern bool http_client_session_draining;
-
 // Emit a debug message conditional on whether this particular client session
 // has debugging enabled. This should only be called from within a client session
 // member function.
@@ -125,7 +123,11 @@ public:
   bool
   is_draining() const
   {
-    return http_client_session_draining;
+    RecInt draining;
+    if (RecGetRecordInt("proxy.node.config.draining", &draining) != REC_ERR_OKAY) {
+      return false;
+    }
+    return draining != 0;
   }
 
   // Initiate an API hook invocation.

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -347,6 +347,10 @@ Http2ClientSession::main_event_handler(int event, void *edata)
     break;
   }
 
+  if (!this->is_draining()) {
+    this->connection_state.set_shutdown_state(HTTP2_SHUTDOWN_NONE);
+  }
+
   // For a case we already checked Connection header and it didn't exist
   if (this->is_draining() && this->connection_state.get_shutdown_state() == HTTP2_SHUTDOWN_NONE) {
     this->connection_state.set_shutdown_state(HTTP2_SHUTDOWN_NOT_INITIATED);


### PR DESCRIPTION
This PR includes 

1. `Add maximum time limit for draining` from @maskit, 
2. `Add traffic_ctl server stop --drain` from @maskit and 
3. `Fixing #2906: improve draining` from me.



For the `Fixing #2906: improve draining`,

1. Adding `traffic server drain` subcommand
2. Adding default option, --no-new-connection option and --undo option

TODO:
1. implement `is_server_idle_from_new_connection()`
2. update docs
3. adding tests


@maskit @bryancall @zwoop @oknet @scw00 @masaori335 can you guys review it when you got time? Any ideas would be much appreciated!