### PR TITLE
Allow for spaces in list of algorithms in configuration file for gzip plugin.

### DIFF
--- a/plugins/gzip/configuration.h
+++ b/plugins/gzip/configuration.h
@@ -116,7 +116,7 @@ public:
   void add_compressible_content_type(const std::string &content_type);
   bool is_url_allowed(const char *url, int url_len);
   bool is_content_type_compressible(const char *content_type, int content_type_length);
-  void add_compression_algorithms(const std::string &algorithms);
+  void add_compression_algorithms(std::string &algorithms);
   int compression_algorithms();
 
   // Ref-counting these host configuration objects

--- a/tests/gold_tests/pluginTest/gzip/gzip.test.py
+++ b/tests/gold_tests/pluginTest/gzip/gzip.test.py
@@ -80,7 +80,7 @@ def oneTs(name, AeHdr1='gzip, deflate, sdch, br'):
     ts.Disk.remap_config.AddLine(
         'map http://ae-2/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
         ' @plugin=conf_remap.so @pparam=proxy.config.http.normalize_ae=2' +
-        ' @plugin=gzip.so @pparam={}/gzip.config'.format(Test.TestDirectory)
+        ' @plugin=gzip.so @pparam={}/gzip2.config'.format(Test.TestDirectory)
     )
 
     def curl(idx, encodingList):

--- a/tests/gold_tests/pluginTest/gzip/gzip2.config
+++ b/tests/gold_tests/pluginTest/gzip/gzip2.config
@@ -1,0 +1,7 @@
+cache true
+remove-accept-encoding true
+compressible-content-type text/*
+compressible-content-type application/x-javascript*
+compressible-content-type application/javascript*
+compressible-content-type application/json*
+supported-algorithms gzip, br

--- a/tests/gold_tests/pluginTest/url_sig/url_sig.test.py
+++ b/tests/gold_tests/pluginTest/url_sig/url_sig.test.py
@@ -24,6 +24,7 @@ Test url_sig plugin
 
 Test.SkipUnless(
     Condition.HasATSFeature('TS_USE_TLS_ALPN'),
+    Condition.HasProgram("netstat", "netstat needs to be installed on system for this test to work")
 )
 
 # Skip if plugins not present.


### PR DESCRIPTION
In the "supported-algorithm" line in the plugin's config file, allow any string of commas and space characters to be used as separators in the list of algorithms.