### PR TITLE
Fix race condition during testing rc2.

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -5480,6 +5480,12 @@ HttpSM::handle_server_setup_error(int event, void *data)
     // if (vio->op == VIO::WRITE && vio->ndone == 0) {
     if (server_entry->write_vio && server_entry->write_vio->nbytes > 0 && server_entry->write_vio->ndone == 0) {
       t_state.current.state = HttpTransact::CONNECTION_ERROR;
+      if (server_entry) {
+        ink_assert(server_entry->vc_type == HTTP_SERVER_VC);
+        vc_table.cleanup_entry(server_entry);
+        server_entry   = nullptr;
+        server_session = nullptr;
+      }
     } else {
       t_state.current.state = HttpTransact::INACTIVE_TIMEOUT;
     }
@@ -5489,7 +5495,7 @@ HttpSM::handle_server_setup_error(int event, void *data)
   }
 
   // Closedown server connection and deallocate buffers
-  ink_assert(server_entry->in_tunnel == false);
+  ink_assert(!server_entry || server_entry->in_tunnel == false);
 
   // if we are waiting on a plugin callout for
   //   HTTP_API_SEND_REQUEST_HDR defer calling transact until


### PR DESCRIPTION
A race condition in connect timeout is found when testing rc2 with traffic replay. 

Each traffic-replay test consists of ~5k transactions, 10 processors and 10 threads. rc2 failed 3 out of 10 such tests.

With the fix applied, it succeeds 10/10.

@SolidWallOfCode 