### PR TITLE
Remove use of netstat in tests

### DIFF
--- a/cmd/traffic_layout/info.cc
+++ b/cmd/traffic_layout/info.cc
@@ -68,6 +68,11 @@ produce_features(bool json)
 #else
   print_feature("TS_HAS_LZMA", 0, json);
 #endif
+#ifdef HAVE_BROTLI_ENCODE_H
+  print_feature("TS_HAS_BROTLI", 1, json);
+#else
+  print_feature("TS_HAS_BROTLI", 0, json);
+#endif
   print_feature("TS_HAS_JEMALLOC", TS_HAS_JEMALLOC, json);
   print_feature("TS_HAS_TCMALLOC", TS_HAS_TCMALLOC, json);
   print_feature("TS_HAS_IN6_IS_ADDR_UNSPECIFIED", TS_HAS_IN6_IS_ADDR_UNSPECIFIED, json);

--- a/tests/gold_tests/autest-site/init.cli.ext
+++ b/tests/gold_tests/autest-site/init.cli.ext
@@ -23,7 +23,7 @@ if sys.version_info < (3, 5, 0):
     host.WriteError(
         "You need python 3.5 or later to run these tests\n", show_stack=False)
 
-autest_version ="1.4.1"
+autest_version ="1.4.2"
 if AuTestVersion() < autest_version:
     host.WriteError(
         "Tests need AuTest version {ver} or better\n Please update AuTest:\n  pip install --upgrade autest\n".format(ver=autest_version), show_stack=False)

--- a/tests/gold_tests/logging/ccid_ctid.test.py
+++ b/tests/gold_tests/logging/ccid_ctid.test.py
@@ -28,8 +28,7 @@ Test.SkipUnless(
         "curl", "Curl need to be installed on system for this test to work"),
     # Condition.IsPlatform("linux"), Don't see the need for this.
     Condition.HasATSFeature('TS_USE_TLS_ALPN'),
-    Condition.HasCurlFeature('http2'),
-    Condition.HasProgram("netstat", "netstat need to be installed on system for this test to work")
+    Condition.HasCurlFeature('http2')
 )
 
 # Define default ATS.  "select_ports=False" needed because SSL port used.
@@ -70,17 +69,9 @@ log.ascii {
 }'''.split("\n")
 )
 
-# Ask the OS if the port is ready for connect()
-#
-
-
-def CheckPort(Port):
-    return lambda: 0 == subprocess.call('netstat --listen --tcp -n | grep -q :{}'.format(Port), shell=True)
-
-
 tr = Test.AddTestRun()
 # Delay on readiness of ssl port
-tr.Processes.Default.StartBefore(Test.Processes.ts, ready=CheckPort(ts.Variables.ssl_port))
+tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.ssl_port))
 #
 tr.Processes.Default.Command = 'curl "http://127.0.0.1:{0}" --verbose'.format(
     ts.Variables.port)

--- a/tests/gold_tests/pluginTest/gzip/gzip.test.py
+++ b/tests/gold_tests/pluginTest/gzip/gzip.test.py
@@ -26,9 +26,12 @@ Test gzip plugin
 
 # Skip if plugins not present.
 #
-Test.SkipUnless(Condition.PluginExists('gzip.so'))
-Test.SkipUnless(Condition.PluginExists('conf_remap.so'))
-Test.SkipUnless(Condition.HasProgram("netstat", "netstat need to be installed on system for this test to work"))
+Test.SkipUnless(
+    Condition.PluginExists('gzip.so'),
+    Condition.PluginExists('conf_remap.so'),
+    Condition.HasATSFeature('TS_HAS_BROTLI')
+)
+
 
 server = Test.MakeOriginServer("server", options={'--load': '{}/gzip_observer.py'.format(Test.TestDirectory)})
 
@@ -50,10 +53,6 @@ for i in range(3):
     }
     server.addResponse("sessionfile.log", request_header, response_header)
 
-# Ask the OS if the port is ready for connect()
-#
-def CheckPort(Port):
-    return lambda: 0 == subprocess.call('netstat --listen --tcp -n | grep -q :{}'.format(Port), shell=True)
 
 def oneTs(name, AeHdr1='gzip, deflate, sdch, br'):
     global waitForServer
@@ -95,10 +94,10 @@ def oneTs(name, AeHdr1='gzip, deflate, sdch, br'):
 
         tr = Test.AddTestRun()
         if (waitForTs):
-            tr.Processes.Default.StartBefore(ts, ready=CheckPort(ts.Variables.port))
+            tr.Processes.Default.StartBefore(ts, ready=When.PortOpen(ts.Variables.port))
         waitForTs = False
         if (waitForServer):
-            tr.Processes.Default.StartBefore(server, ready=CheckPort(server.Variables.Port))
+            tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Port))
         waitForServer = False
         tr.Processes.Default.ReturnCode = 0
         tr.Processes.Default.Command = curl(i, AeHdr1)
@@ -114,6 +113,7 @@ def oneTs(name, AeHdr1='gzip, deflate, sdch, br'):
         tr = Test.AddTestRun()
         tr.Processes.Default.ReturnCode = 0
         tr.Processes.Default.Command = curl(i, "deflate")
+
 
 waitForServer = True
 

--- a/tests/gold_tests/pluginTest/url_sig/url_sig.test.py
+++ b/tests/gold_tests/pluginTest/url_sig/url_sig.test.py
@@ -24,7 +24,6 @@ Test url_sig plugin
 
 Test.SkipUnless(
     Condition.HasATSFeature('TS_USE_TLS_ALPN'),
-    Condition.HasProgram("netstat", "netstat needs to be installed on system for this test to work")
 )
 
 # Skip if plugins not present.
@@ -57,8 +56,8 @@ ts.Variables.ssl_port = 4443
 ts.Disk.records_config.update({
     # 'proxy.config.diags.debug.enabled': 1,
     # 'proxy.config.diags.debug.tags': 'http|url_sig',
-    'proxy.config.http.cache.http': 0, # Make sure each request is forwarded to the origin server.
-    'proxy.config.proxy_name': 'Poxy_Proxy', # This will be the server name.
+    'proxy.config.http.cache.http': 0,  # Make sure each request is forwarded to the origin server.
+    'proxy.config.proxy_name': 'Poxy_Proxy',  # This will be the server name.
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.http.server_ports': (
@@ -98,11 +97,6 @@ ts.Disk.remap_config.AddLine(
     ' @plugin=url_sig.so @pparam={}/url_sig.config @pparam=PristineUrl'.format(Test.TestDirectory)
 )
 
-# Ask the OS if the port is ready for connect()
-#
-def CheckPort(Port):
-    return lambda: 0 == subprocess.call('netstat --listen --tcp -n | grep -q :{}'.format(Port), shell=True)
-
 # Validation failure tests.
 
 LogTee = " 2>&1 | tee -a {}/url_sig_long.log".format(Test.RunDirectory)
@@ -110,8 +104,8 @@ LogTee = " 2>&1 | tee -a {}/url_sig_long.log".format(Test.RunDirectory)
 # Bad client / MD5 / P=101 / URL pristine / URL altered.
 #
 tr = Test.AddTestRun()
-tr.Processes.Default.StartBefore(ts, ready=CheckPort(ts.Variables.ssl_port))
-tr.Processes.Default.StartBefore(server, ready=CheckPort(server.Variables.Port))
+tr.Processes.Default.StartBefore(ts, ready=When.PortOpen(ts.Variables.ssl_port))
+tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Port))
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Command = (
     "curl --verbose --proxy http://127.0.0.1:{} 'http://seven.eight.nine/".format(ts.Variables.port) +


### PR DESCRIPTION
update autest to 1.4.2 as this has fix for portopen to be like netstat, but portable