### PR TITLE
Disable freelist in ProxyAllocator

### DIFF
--- a/lib/ts/ink_args.cc
+++ b/lib/ts/ink_args.cc
@@ -41,6 +41,7 @@ Process arguments
 const char *file_arguments[MAX_FILE_ARGUMENTS] = {nullptr};
 const char *program_name                       = (char *)"Traffic Server";
 unsigned n_file_arguments                      = 0;
+int cmd_disable_freelist                       = 0;
 
 //
 //  Local variables

--- a/lib/ts/ink_args.h
+++ b/lib/ts/ink_args.h
@@ -84,6 +84,7 @@ struct ArgumentDescription {
 extern const char *file_arguments[]; // exported by process_args()
 extern unsigned n_file_arguments;    // exported by process_args()
 extern const char *program_name;     // exported by process_args()
+extern int cmd_disable_freelist;
 
 /* Print out arguments and values
 */

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -169,7 +169,6 @@ HttpBodyFactory *body_factory              = nullptr;
 static int accept_mss             = 0;
 static int cmd_line_dprintf_level = 0;  // default debug output level from ink_dprintf function
 static int poll_timeout           = -1; // No value set.
-static int cmd_disable_freelist   = 0;
 
 static bool signal_received[NSIG];
 
@@ -1571,7 +1570,7 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   command_index = find_cmd_index(command_string);
   command_valid = command_flag && command_index >= 0;
 
-  if (cmd_disable_freelist) {
+  if (likely(cmd_disable_freelist)) {
     ink_freelist_init_ops(ink_freelist_malloc_ops());
   }
 

--- a/proxy/http2/test_HPACK.cc
+++ b/proxy/http2/test_HPACK.cc
@@ -39,7 +39,6 @@ using namespace std;
 
 AppVersionInfo appVersionInfo;
 
-static int cmd_disable_freelist = 0;
 static char cmd_input_dir[512]  = "";
 static char cmd_output_dir[512] = "";
 
@@ -397,7 +396,7 @@ main(int argc, const char **argv)
   appVersionInfo.setup(PACKAGE_NAME, "test_HPACK", PACKAGE_VERSION, __DATE__, __TIME__, BUILD_MACHINE, BUILD_PERSON, "");
   process_args(&appVersionInfo, argument_descriptions, countof(argument_descriptions), argv);
 
-  if (cmd_disable_freelist) {
+  if (likely(cmd_disable_freelist)) {
     ink_freelist_init_ops(ink_freelist_malloc_ops());
   }
   if (*cmd_input_dir) {


### PR DESCRIPTION
~~Created a new command line argument `-F` or `--disable_fl_more` to disable freelist in ProxyAllocator.~~

This has now been combined with the `-f` option.