### PR TITLE
Enable ProxyAllocator for the IOBufferData::_data

### DIFF
--- a/iocore/eventsystem/I_Thread.h
+++ b/iocore/eventsystem/I_Thread.h
@@ -143,6 +143,7 @@ public:
   ProxyAllocator ioDataAllocator;
   ProxyAllocator ioAllocator;
   ProxyAllocator ioBlockAllocator;
+  ProxyAllocator ioBufAllocator[DEFAULT_BUFFER_SIZES];
 
 public:
   /** Start the underlying thread.

--- a/iocore/eventsystem/P_IOBuffer.h
+++ b/iocore/eventsystem/P_IOBuffer.h
@@ -282,7 +282,7 @@ IOBufferData::alloc(int64_t size_index, AllocType type)
   switch (type) {
   case MEMALIGNED:
     if (BUFFER_SIZE_INDEX_IS_FAST_ALLOCATED(size_index))
-      _data = (char *)ioBufAllocator[size_index].alloc_void();
+      _data = (char *)THREAD_ALLOC(ioBufAllocator[size_index], this_thread());
     // coverity[dead_error_condition]
     else if (BUFFER_SIZE_INDEX_IS_XMALLOCED(size_index))
       _data = (char *)ats_memalign(ats_pagesize(), index_to_buffer_size(size_index));
@@ -290,7 +290,7 @@ IOBufferData::alloc(int64_t size_index, AllocType type)
   default:
   case DEFAULT_ALLOC:
     if (BUFFER_SIZE_INDEX_IS_FAST_ALLOCATED(size_index))
-      _data = (char *)ioBufAllocator[size_index].alloc_void();
+      _data = (char *)THREAD_ALLOC(ioBufAllocator[size_index], this_thread());
     else if (BUFFER_SIZE_INDEX_IS_XMALLOCED(size_index))
       _data = (char *)ats_malloc(BUFFER_SIZE_FOR_XMALLOC(size_index));
     break;
@@ -308,14 +308,14 @@ IOBufferData::dealloc()
   switch (_mem_type) {
   case MEMALIGNED:
     if (BUFFER_SIZE_INDEX_IS_FAST_ALLOCATED(_size_index))
-      ioBufAllocator[_size_index].free_void(_data);
+      THREAD_FREE(_data, ioBufAllocator[_size_index], this_thread());
     else if (BUFFER_SIZE_INDEX_IS_XMALLOCED(_size_index))
       ::free((void *)_data);
     break;
   default:
   case DEFAULT_ALLOC:
     if (BUFFER_SIZE_INDEX_IS_FAST_ALLOCATED(_size_index))
-      ioBufAllocator[_size_index].free_void(_data);
+      THREAD_FREE(_data, ioBufAllocator[_size_index], this_thread());
     else if (BUFFER_SIZE_INDEX_IS_XMALLOCED(_size_index))
       ats_free(_data);
     break;

--- a/proxy/http/unit-tests/test_ForwardedConfig_mocks.cc
+++ b/proxy/http/unit-tests/test_ForwardedConfig_mocks.cc
@@ -84,3 +84,8 @@ void
 IOBufferData::free()
 {
 }
+
+void
+thread_freeup(Allocator &a, ProxyAllocator &l)
+{
+}


### PR DESCRIPTION
My Lab:

1 x Client on a PC1
1 x ATS on a VM (PC2)
1 x Nginx on a VM (PC2)

The OS is Debian Linux. PC1 and PC2 are connected to a 1000Mbps Ethernet switch. 

I have finished some tests, please check the report below:

1. without the patch and configure --prefix=/usr/local/ats --enable-debug

```
CONFIG proxy.config.diags.debug.enabled INT 0

# for i in `seq 1 5`; do http_proxy=http://172.20.21.120:8081 wget -O /dev/null http://172.20.21.123/500MB.rar; done

93.3M/s 44.5M/s 74.0M/s 78.4M/s 94.5M/s
62.1M/s 72.7M/s 85.4M/s 65.9M/s 81.9M/s
87.9M/s 70.9M/s 82.4M/s 52.4M/s 84.2M/s 

# perf top `pidof traffic_server

  60.95%  libtsutil.so.6.0.0  [.] ink_freelist_free
   7.46%  [kernel]            [k] copy_user_enhanced_fast_string

# ab -c 1 -n 5 -X 172.20.21.120:8081 http://172.20.21.123/500MB.rar

Server Software:        nginx
Server Hostname:        172.20.21.123
Server Port:            80

Document Path:          /500MB.rar
Document Length:        524288000 bytes

Concurrency Level:      1
Time taken for tests:   32.955 seconds
Complete requests:      5
Failed requests:        0
Write errors:           0
Total transferred:      2621441340 bytes
HTML transferred:       2621440000 bytes
Requests per second:    0.15 [#/sec] (mean)
Time per request:       6591.092 [ms] (mean)
Time per request:       6591.092 [ms] (mean, across all concurrent requests)
Transfer rate:          77680.65 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.3      0       1
Processing:  4992 6591 1818.8   6434    9610
Waiting:        1   24  32.8     20      75
Total:       4993 6591 1818.8   6435    9611

Percentage of the requests served within a certain time (ms)
  50%   6060
  66%   6810
  75%   6810
  80%   9611
  90%   9611
  95%   9611
  98%   9611
  99%   9611
 100%   9611 (longest request)
```

2. with the patch and configure --prefix=/usr/local/ats --enable-debug

```
CONFIG proxy.config.diags.debug.enabled INT 0

# for i in `seq 1 5`; do http_proxy=http://172.20.21.120:8081 wget -O /dev/null http://172.20.21.123/500MB.rar; done

97.8M/s 88.6M/s 109M/s 105M/s  107M/s
 102M/s 99.2M/s 111M/s 103M/s 98.1M/s
89.9M/s 96.9M/s 111M/s 111M/s  102M/s

# perf top `pidof traffic_server

  36.32%  traffic_server      [.] IOBufferBlock::read_avail()
   8.76%  libtsutil.so.6.0.0  [.] ink_freelist_free_bulk
   7.56%  [kernel]            [k] copy_user_enhanced_fast_string
   5.95%  traffic_server      [.] Ptr<IOBufferBlock>::operator IOBufferBlock*() const
   5.55%  traffic_server      [.] IOBufferReader::read_avail()

# ab -c 1 -n 5 -X 172.20.21.120:8081 http://172.20.21.123/500MB.rar

Server Software:        nginx
Server Hostname:        172.20.21.123
Server Port:            80

Document Path:          /500MB.rar
Document Length:        524288000 bytes

Concurrency Level:      1
Time taken for tests:   26.046 seconds
Complete requests:      5
Failed requests:        0
Write errors:           0
Total transferred:      2621441340 bytes
HTML transferred:       2621440000 bytes
Requests per second:    0.19 [#/sec] (mean)
Time per request:       5209.114 [ms] (mean)
Time per request:       5209.114 [ms] (mean, across all concurrent requests)
Transfer rate:          98289.32 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    1   0.6      1       2
Processing:  5089 5208  84.1   5218    5323
Waiting:        1    9  10.2      8      26
Total:       5089 5209  84.3   5220    5323

Percentage of the requests served within a certain time (ms)
  50%   5202
  66%   5237
  75%   5237
  80%   5323
  90%   5323
  95%   5323
  98%   5323
  99%   5323
 100%   5323 (longest request)
```