### PR TITLE
Traffic-replay updated

### DIFF
--- a/tests/gold_tests/autest-site/microserver.test.ext
+++ b/tests/gold_tests/autest-site/microserver.test.ext
@@ -49,54 +49,57 @@ def addResponse(self, filename, testName, request_header, response_header):
     self.Setup.CopyAs(absFilepath, self.Variables.DataDir)
     return
 
+
 def getHeaderFieldVal(request_header, field):
     requestline = request_header["headers"].split("\r\n")[0]
     requestline = requestline.split(" ")[1]
-    field = field+':'
-    valField = request_header["headers"].split(field,1);
-    val=""
-    if len(valField)>1:
-            field_v = valField[1].split("\r\n",1)
-            if len(field_v)>0:
-                val = field_v[0].strip()
+    field = field + ':'
+    valField = request_header["headers"].split(field, 1)
+    val = ""
+    if len(valField) > 1:
+        field_v = valField[1].split("\r\n", 1)
+        if len(field_v) > 0:
+            val = field_v[0].strip()
     return val
 
 # addResponse adds customized response with respect to request_header. request_header and response_header are both dictionaries
+
+
 def addResponse(self, filename, request_header, response_header):
     requestline = request_header["headers"].split("\r\n")[0]
     host_ = ""
     path_ = ""
     if requestline:
         url_part = requestline.split(" ")
-        if len(url_part)>1:
+        if len(url_part) > 1:
             if url_part[1].startswith("http"):
-                path_ = url_part[1].split("/",2)[2]
-                host_,path_ = path_.split("/",1)
+                path_ = url_part[1].split("/", 2)[2]
+                host_, path_ = path_.split("/", 1)
             else:
-                path_ = url_part[1].split("/",1)[1]
+                path_ = url_part[1].split("/", 1)[1]
 
     kpath = ""
     #print("Format of lookup key",self.Variables.lookup_key)
-    
+
     argsList = []
     keyslist = self.Variables.lookup_key.split("}")
     for keystr in keyslist:
         if keystr == '{PATH':
-            kpath = kpath+path_
+            kpath = kpath + path_
             continue
         if keystr == '{HOST':
             kpath = kpath + host_
             continue
-        if keystr == '': #empty
+        if keystr == '':  # empty
             continue
-        stringk = keystr.replace("{%","")
+        stringk = keystr.replace("{%", "")
         argsList.append(stringk)
     KeyList = []
     for argsL in argsList:
-        field_val = getHeaderFieldVal(request_header,argsL)
-        if field_val!=None:
+        field_val = getHeaderFieldVal(request_header, argsL)
+        if field_val != None:
             KeyList.append(field_val)
-    rl = "".join(KeyList)+kpath
+    rl = "".join(KeyList) + kpath
     txn = dict()
     txn["timestamp"] = ""
     txn["uuid"] = rl
@@ -141,7 +144,7 @@ def makeHeader(self, requestString, **kwargs):
     return headerStr
 
 
-def MakeOriginServer(obj, name, port=False, ip=False, delay=False, ssl=False, lookup_key='{PATH}', options={}):
+def MakeOriginServer(obj, name, port=False, ip=False, delay=False, ssl=False, lookup_key='{PATH}', mode='test', options={}):
     server_path = os.path.join(obj.Variables.AtsTestToolsDir, 'microServer/uWServer.py')
     data_dir = os.path.join(obj.RunDirectory, name)
     # create Process
@@ -152,8 +155,8 @@ def MakeOriginServer(obj, name, port=False, ip=False, delay=False, ssl=False, lo
         ip = '127.0.0.1'
     if (delay == False):
         delay = 0
-    command = "python3 {0} --data-dir {1} --port {2} --ip_address {3} --delay {4} -m test --ssl {5} --lookupkey '{6}'".format(
-        server_path, data_dir, port, ip, delay, ssl,lookup_key)
+    command = "python3 {0} --data-dir {1} --port {2} --ip_address {3} --delay {4} -m test --ssl {5} --lookupkey '{6}' -m {7}".format(
+        server_path, data_dir, port, ip, delay, ssl, lookup_key, mode)
     for flag, value in options.items():
         command += " {} {}".format(flag, value)
 
@@ -163,7 +166,7 @@ def MakeOriginServer(obj, name, port=False, ip=False, delay=False, ssl=False, lo
     p.Variables.DataDir = data_dir
     p.Variables.lookup_key = lookup_key
     p.Ready = When.PortOpen(port, ip)
-    p.ReturnCode = Any(None,0)
+    p.ReturnCode = Any(None, 0)
     AddMethodToInstance(p, addResponse)
     AddMethodToInstance(p, addTransactionToSession)
 
@@ -172,4 +175,3 @@ def MakeOriginServer(obj, name, port=False, ip=False, delay=False, ssl=False, lo
 
 ExtendTest(MakeOriginServer, name="MakeOriginServer")
 ExtendTest(MakeOriginServer, name="MakeOrigin")
-

--- a/tests/tools/microServer/uWServer.py
+++ b/tests/tools/microServer/uWServer.py
@@ -52,7 +52,7 @@ import sessionvalidation.sessionvalidation as sv
 
 
 SERVER_PORT = 5005  # default port
-SERVER_DELAY = 0 # default delay
+SERVER_DELAY = 0  # default delay
 HTTP_VERSION = 'HTTP/1.1'
 G_replay_dict = {}
 
@@ -171,40 +171,39 @@ class MyHandler(BaseHTTPRequestHandler):
 
     def getLookupKey(self, requestline):
         global lookup_key_
-        kpath= ""
+        kpath = ""
         path = ""
         url_part = requestline.split(" ")
         if url_part:
             if url_part[1].startswith("http"):
-                path = url_part[1].split("/",2)[2]
-                host_, path = path.split("/",1)
+                path = url_part[1].split("/", 2)[2]
+                host_, path = path.split("/", 1)
             else:
-                path = url_part[1].split("/",1)[1]
+                path = url_part[1].split("/", 1)[1]
         argsList = []
         keyslist = lookup_key_.split("}")
-        for keystr in keyslist:            
+        for keystr in keyslist:
             if keystr == '{PATH':
-                kpath = kpath+path
-                continue # do not include path in the list of header fields
+                kpath = kpath + path
+                continue  # do not include path in the list of header fields
             if keystr == '{HOST':
-                kpath = kpath+host_
+                kpath = kpath + host_
                 continue
-            stringk = keystr.replace("{%","")
+            stringk = keystr.replace("{%", "")
             argsList.append(stringk)
         KeyList = []
         for argsL in argsList:
-            print("args",argsL,len(argsL))
-            if len(argsL)>0:
+            print("args", argsL, len(argsL))
+            if len(argsL) > 0:
                 val = self.headers.get(argsL)
                 if val:
-                    field_val,__ = cgi.parse_header(val)
+                    field_val, __ = cgi.parse_header(val)
                 else:
-                    field_val=None
-                if field_val!=None:
+                    field_val = None
+                if field_val != None:
                     KeyList.append(field_val)
-        key = "".join(KeyList)+kpath
-        print("lookup key",key, len(key))
-
+        key = "".join(KeyList) + kpath
+        print("lookup key", key, len(key))
 
         return key
 
@@ -447,7 +446,7 @@ class MyHandler(BaseHTTPRequestHandler):
                     header_parts = header.split(':', 1)
                     header_field = str(header_parts[0].strip())
                     header_field_val = str(header_parts[1].strip())
-                    #print("{0} === >{1}".format(header_field, header_field_val))
+                    # print("{0} === >{1}".format(header_field, header_field_val))
                     self.send_header(header_field, header_field_val)
                 # End for
                 if test_mode_enabled:
@@ -712,7 +711,7 @@ def main():
         else:
             server = ThreadingServer((options.ip_address, options.port), MyHandler, options)
         server.timeout = 5
-        print("started server")
+        print("started server on port {0}".format(options.port))
         server_thread = threading.Thread(target=server.serve_forever())
         server_thread.daemon = True
         server_thread.start()

--- a/tests/tools/traffic-replay/__main__.py
+++ b/tests/tools/traffic-replay/__main__.py
@@ -25,7 +25,8 @@ import Config
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-type", action='store', dest='replay_type', help="Replay type: ssl/random/h2/nossl")
+    parser.add_argument("-type", action='store', dest='replay_type',
+                        help="Replay type: ssl/random/h2/nossl/mixed (at least 2 processes needed for mixed)")
     parser.add_argument("-log_dir", type=str, help="directory of JSON replay files")
     parser.add_argument("-v", dest="verbose", help="verify response status code", action="store_true")
     parser.add_argument("-host", help="proxy/host to send the requests to", default=Config.proxy_host)

--- a/tests/tools/traffic-replay/extractHeader.py
+++ b/tests/tools/traffic-replay/extractHeader.py
@@ -42,7 +42,11 @@ def responseHeader_to_dict(header):
     headers = {}
     for line in header:
         split_here = line.find(":")
-        headers[line[:split_here].lower()] = line[(split_here + 1):].strip()
+        # append multiple headers into a single string
+        if line[:split_here].lower() in headers:
+            headers[line[:split_here].lower()] += ", {0}".format(line[(split_here + 1):].strip())
+        else:
+            headers[line[:split_here].lower()] = line[(split_here + 1):].strip()
 
     return headers
 

--- a/tests/tools/traffic-replay/h2Replay.py
+++ b/tests/tools/traffic-replay/h2Replay.py
@@ -230,7 +230,7 @@ def txn_replay(session_filename, txn, proxy, result_queue, h2conn, request_IDs):
         if method == 'GET':
             responseID = h2conn.request('GET', url=extractHeader.extract_GET_path(
                 txn_req_headers), headers=txn_req_headers_dict, body=mbody)
-            #print("get response", responseID)
+            # print("get response", responseID)
             return responseID
             # request_IDs.append(responseID)
             #response = h2conn.get_response(id)
@@ -249,18 +249,6 @@ def txn_replay(session_filename, txn, proxy, result_queue, h2conn, request_IDs):
             responseID = h2conn.request('HEAD', url=extractHeader.extract_GET_path(txn_req_headers), headers=txn_req_headers_dict)
             print("get response", responseID)
             return responseID
-
-        # print(response.headers)
-        #print("logged respose")
-        expected = extractHeader.responseHeader_to_dict(resp.getHeaders())
-        # print(expected)
-        if mainProcess.verbose:
-            expected_output_split = resp.getHeaders().split('\r\n')[0].split(' ', 2)
-            expected_output = (int(expected_output_split[1]), str(expected_output_split[2]))
-            r = result.Result(session_filename, expected_output[0], response.status_code)
-            print(r.getResultString(response.headers, expected, colorize=True))
-
-        # return responseID
 
     except UnicodeEncodeError as e:
         # these unicode errors are due to the interaction between Requests and our wiretrace data.
@@ -315,10 +303,16 @@ def session_replay(input, proxy, result_queue):
 
                         expected_output_split = expectedH.getHeaders().split('\r\n')[0].split(' ', 2)
                         expected_output = (int(expected_output_split[1]), str(expected_output_split[2]))
-                        r = result.Result("", expected_output[0], response.status)
+                        r = result.Result("", expected_output[0], response.status, response.read())
                         expected_Dict = extractHeader.responseHeader_to_dict(expectedH.getHeaders())
-                        print(r.getResultString(response_dict, expected_Dict, colorize=Config.colorize))
-                        # r.Compare(response_dict,expected_Dict)
+                        b_res, res = r.getResult(response_dict, expected_Dict, colorize=Config.colorize)
+                        print(res)
+
+                        if not b_res:
+                            print("Received response")
+                            print(response_dict)
+                            print("Expected response")
+                            print(expected_Dict)
 
         bSTOP = True
         #print("Queue is empty")


### PR DESCRIPTION
- Changed SSL and nonSSL replays to use full paths
- Ignoring connection header since ATS modifies it
- allows custom http methods
- Cleaned up traffic-replay verification logic; prints more useful information if a session fails
- Added in content-length vs actual body length verification #2817 
- SSLReplay and NonSSLReplay now uses the same logic for sending out requests
- Removed unnecessary functions
- Updated h2replay