### PR TITLE
new_MIOBuffer: uninitialized water_mark fix.

### DIFF
--- a/iocore/eventsystem/P_IOBuffer.h
+++ b/iocore/eventsystem/P_IOBuffer.h
@@ -1123,6 +1123,7 @@ MIOBuffer::alloc(int64_t i)
 #endif
   _writer->alloc(i);
   size_index = i;
+  water_mark = 0;
   init_readers();
 }
 

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -625,7 +625,7 @@ SSLNetVConnection::net_read_io(NetHandler *nh, EThread *lthread)
     read.triggered = 0;
     nh->read_ready_list.remove(this);
     Debug("ssl", "read_from_net, read finished - would block");
-#ifdef TS_USE_PORT
+#if TS_USE_PORT
     if (ret == SSL_READ_WOULD_BLOCK) {
       readReschedule(nh);
     } else {


### PR DESCRIPTION
While calling `new_MIOBuffer()` the `water_mark` is not initialized,
water_mark could end up with a very high (random) value to be used
during the network reads. This always results in overly aggressive
uninterrupted reading from the connection, severe buffer size increase
and CPU saturation of one or more `ET_NET` threads which renders the
traffic server unresponsive. Initializing the water_mark fixes the issue.

The problem can be easily reproduced by a series of very large TLS POST
requests in combination with a stalling origin server and periodic use
of `FetchSM` which internally allocates a buffer using `new_MIOBuffer()`
and sets `water_mark` to `INT64_MAX`.
While serving the POST requests a buffer previously used by `FetchSM`
would be reused and its `water_mark` would end up being equal to `IN64_MAX`
since the `water_mark` is not initialized when calling `new_MIOBuffer()`.
This always results in aggressive uninterrupted network reads, the
buffer size would keep growing progressively and the constant block iteration
in `IOBufferReader::read_avail()` at some point would saturate the `ET_NET`
thread CPU.

This patch should fix issue #2144

Additionally fixed erroneous `#ifdef TS_USE_PORT` directive in
`SSLNetVConnection::net_read_io()`.