### PR TITLE
appends missing dot to udns domain

### DIFF
--- a/tests/gold_tests/autest-site/microDNS.test.ext
+++ b/tests/gold_tests/autest-site/microDNS.test.ext
@@ -44,7 +44,11 @@ def addRecords(self, records=None, jsonFile=None):
 
     if records:
         for domain in records:
-            record = AddRecord(domain, records[domain])
+            # Let's do this for the test writer's convenience.
+            normalized_domain = domain
+            if normalized_domain[-1] != '.':
+                normalized_domain += '.'
+            record = AddRecord(normalized_domain, records[domain])
 
             jsondata["mappings"].append(record)
 

--- a/tests/gold_tests/redirect/redirect.test.py
+++ b/tests/gold_tests/redirect/redirect.test.py
@@ -51,7 +51,7 @@ dest_request_header = {"headers": "GET /redirectDest HTTP/1.1\r\nHost: *\r\n\r\n
 dest_response_header = {"headers": "HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n", "timestamp": "22", "body": ""}
 dest_serv.addResponse("sessionfile.log", dest_request_header, dest_response_header)
 
-dns.addRecords(records={"iwillredirect.test.": ["127.0.0.1"]})
+dns.addRecords(records={"iwillredirect.test": ["127.0.0.1"]})
 
 data_dirname = 'generated_test_data'
 data_path = os.path.join(Test.TestDirectory, data_dirname)


### PR DESCRIPTION
In the past I have forgotten that uDNS expects domains to be formatted like `www.example.test.`—with a trailing dot `.`—and not like `www.example.test`. However, as a test writer I think of the domain as it might appear in a URL.

This is a small enhancement to make uDNS handle both kinds of syntax.

---
Milestone: 8.0.0
Labels: Tests
Project: 7.x releases