### PR TITLE
Multiplexer plugin: Fix bug with chunk decoding, add some comments.

### DIFF
--- a/plugins/experimental/multiplexer/chunk-decoder.cc
+++ b/plugins/experimental/multiplexer/chunk-decoder.cc
@@ -1,6 +1,6 @@
 /** @file
 
-  Multiplexes request to other origins.
+  Chunk decoding.
 
   @section license License
 
@@ -51,7 +51,6 @@ ChunkDecoder::parseSize(const char *p, const int64_t s)
   while (state_ != State::kData && *p != '\0' && length < s) {
     assert(state_ < State::kUpperBound); // VALID RANGE
     switch (state_) {
-    case State::kUnknown:
     case State::kData:
     case State::kInvalid:
     case State::kEnd:
@@ -117,6 +116,7 @@ ChunkDecoder::decode(const TSIOBufferReader &r)
   int64_t size;
   TSIOBufferBlock block = TSIOBufferReaderStart(r);
 
+  // Trying to parse a size.
   if (isSizeState()) {
     while (block != nullptr && size_ == 0) {
       const char *p = TSIOBufferBlockReadStart(block, r, &size);
@@ -141,7 +141,7 @@ ChunkDecoder::decode(const TSIOBufferReader &r)
     assert(size_ > 0);
     const char *p = TSIOBufferBlockReadStart(block, r, &size);
     if (p != nullptr) {
-      if (size > size_) {
+      if (size >= size_) {
         length += size_;
         size_  = 0;
         state_ = State::kSizeR;

--- a/plugins/experimental/multiplexer/chunk-decoder.h
+++ b/plugins/experimental/multiplexer/chunk-decoder.h
@@ -26,31 +26,32 @@
 #include <ts/ts.h>
 #include <inttypes.h>
 
+/** Class to handle state for decoding chunked data.
+ */
 class ChunkDecoder
 {
-  struct State {
-    enum STATES {
-      kUnknown,
+  /// Parse states.
+  enum State {
+    kInvalid, ///< Invalid state.
 
-      kInvalid,
+    kData,  ///< Expecting data.
+    kDataN, ///< Expecting LF after size.
+    kEnd,
+    kEndN,
+    kSize,  ///< Expecting chunk size.
+    kSizeN, ///< Expecting LF after data.
+    kSizeR, ///< Expecting CR after data.
 
-      kData,
-      kDataN,
-      kEnd,
-      kEndN,
-      kSize,
-      kSizeN,
-      kSizeR,
-
-      kUpperBound,
-    };
+    kUpperBound,
   };
 
-  State::STATES state_;
-  int64_t size_;
+  State state_  = kSize;
+  int64_t size_ = 0;
 
 public:
-  ChunkDecoder(void) : state_(State::kSize), size_(0) {}
+  /// Default Constructor. Construct to empty state of expected size 0.
+  ChunkDecoder() {}
+
   void parseSizeCharacter(const char);
   int parseSize(const char *, const int64_t);
   int decode(const TSIOBufferReader &);


### PR DESCRIPTION
The chunk decoding issue was discovered in production and this was verified to fix the problem.