### PR TITLE
Uses next_hop_scheme when connecting to parent proxies

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -4959,7 +4959,9 @@ HttpSM::do_http_server_open(bool raw)
 
   int scheme_to_use = t_state.scheme; // get initial scheme
 
-  if (!t_state.is_websocket) { // if not websocket, then get scheme from server request
+  if (t_state.current.request_to == HttpTransact::PARENT_PROXY) {
+    scheme_to_use = t_state.next_hop_scheme;
+  } else if (!t_state.is_websocket) { // if not websocket, then get scheme from server request
     int new_scheme_to_use = t_state.hdr_info.server_request.url_get()->scheme_get_wksidx();
     // if the server_request url scheme was never set, try the client_request
     if (new_scheme_to_use < 0) {


### PR DESCRIPTION
I have Apache Traffic Server 7.1.1 configured with defaults, except for:

```
# records.config
CONFIG proxy.config.http.parent_proxy_routing_enable INT 1
CONFIG proxy.config.http.uncacheable_requests_bypass_parent INT 0
```

```
# parent.config
dest_domain=. parent="parent.example:3128" go_direct=false
```

```
# remap.config
map / https://origin.example
```

The origin server is `https://`, but the parent proxy `parent.example` proxy uses unencrypted `http://`.

What I expect to happen is a request to ATS for `http://foo.example` (or `https://foo.example`) is mapped to `https://origin.example`, then routed through the parent proxy at `http://parent.example:3128`

What actually happens currently is that ATS attempts to connect to `parent.example` over SSL/TLS because ATS seems to use the scheme of the mapped URL, rather than [`next_hop_scheme` set during parent selection](https://github.com/apache/trafficserver/blob/f14df9e431099d415b243af94d692133c0b1b4d7/proxy/http/HttpTransact.cc#L342).

I am a first-time contributor and don't know the codebase too well, so while I think this fixes my issue, I'm open to feedback for implementing it in a better way, if there is a better way.

Thank you for maintaining Apache Traffic Server!