### PR TITLE
ISSUE 2996, clean up the server_session before marking server as down

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -7446,6 +7446,30 @@ HttpSM::set_next_state()
     HTTP_SM_SET_DEFAULT_HANDLER(&HttpSM::state_mark_os_down);
 
     ink_assert(t_state.dns_info.looking_up == HttpTransact::ORIGIN_SERVER);
+    // We need to close the previous attempt
+    if (server_entry) {
+      ink_assert(server_entry->vc_type == HTTP_SERVER_VC);
+      vc_table.cleanup_entry(server_entry);
+      server_entry   = nullptr;
+      server_session = nullptr;
+    } else {
+      // Now that we have gotten the user agent request, we can cancel
+      // the inactivity timeout associated with it.  Note, however, that
+      // we must not cancel the inactivity timeout if the message
+      // contains a body (as indicated by the non-zero request_content_length
+      // field).  This indicates that a POST operation is taking place and
+      // that the client is still sending data to the origin server.  The
+      // origin server cannot reply until the entire request is received.  In
+      // light of this dependency, TS must ensure that the client finishes
+      // sending its request and for this reason, the inactivity timeout
+      // cannot be cancelled.
+      if (ua_txn && !t_state.hdr_info.request_content_length) {
+        ua_txn->cancel_inactivity_timeout();
+      } else if (!ua_txn) {
+        terminate_sm = true;
+        return; // Give up if there is no session
+      }
+    }
 
     // TODO: This might not be optimal (or perhaps even correct), but it will
     // effectively mark the host as down. What's odd is that state_mark_os_down


### PR DESCRIPTION
Sometime, we need to retry the server due to timeout or connection error. Then we mark OS as down, and get a new IP from dns.   **we need clean up the server session before do dns lookup**

link to #2996