### PR TITLE
Accurately parse path-params in URLs

### DIFF
--- a/proxy/hdrs/URL.cc
+++ b/proxy/hdrs/URL.cc
@@ -1409,6 +1409,11 @@ parse_params1:
   params_start = cur + 1;
   GETNEXT(done);
 parse_params2:
+  if (*cur == '/') {
+    params_end = cur;
+    path_end = NULL;
+    goto parse_path2;
+  }
   if (*cur == '?') {
     params_end = cur;
     goto parse_query1;

--- a/proxy/hdrs/URL.cc
+++ b/proxy/hdrs/URL.cc
@@ -1411,7 +1411,7 @@ parse_params1:
 parse_params2:
   if (*cur == '/') {
     params_end = cur;
-    path_end = NULL;
+    path_end   = NULL;
     goto parse_path2;
   }
   if (*cur == '?') {


### PR DESCRIPTION
Currently path-params like this .....

http://pink.floyd.machine.gov/dreams/guitar;type=mean/bar/steak.json

get returned with a truncated path ...

PATH: dreams/guitar
PARAMS: type=mean/bar/steak.json

Which would be better parsed as ...

PATH:  dreams/guitar;type=mean/bar/steak.json
PARAMS: type=mean

Most params don't show up in multiple locations and URL signatures need only one location.