### PR TITLE
the global SELECT_ALT C++ hook badly needs fixing

### DIFF
--- a/lib/cppapi/GlobalPlugin.cc
+++ b/lib/cppapi/GlobalPlugin.cc
@@ -48,8 +48,15 @@ namespace
 static int
 handleGlobalPluginEvents(TSCont cont, TSEvent event, void *edata)
 {
-  TSHttpTxn txn            = static_cast<TSHttpTxn>(edata);
   GlobalPluginState *state = static_cast<GlobalPluginState *>(TSContDataGet(cont));
+
+  if (event == TS_EVENT_HTTP_SELECT_ALT) {
+    TSHttpAltInfo alt = static_cast<TSHttpAltInfo>(edata);
+    utils::internal::invokePluginForEvent(state->global_plugin_, alt, event);
+    return 0;
+  }
+
+  TSHttpTxn txn = static_cast<TSHttpTxn>(edata);
   if (state->ignore_internal_transactions_ && TSHttpTxnIsInternal(txn)) {
     LOG_DEBUG("Ignoring event %d on internal transaction %p for global plugin %p", event, txn, state->global_plugin_);
     TSHttpTxnReenable(txn, TS_EVENT_HTTP_CONTINUE);

--- a/lib/cppapi/include/atscppapi/Plugin.h
+++ b/lib/cppapi/include/atscppapi/Plugin.h
@@ -27,6 +27,7 @@
 #ifndef ATSCPPAPI_PLUGIN_H_
 #define ATSCPPAPI_PLUGIN_H_
 
+#include <atscppapi/Request.h>
 #include <atscppapi/Transaction.h>
 #include <atscppapi/noncopyable.h>
 
@@ -146,11 +147,7 @@ public:
   /**
    * This method must be implemented when you hook HOOK_SELECT_ALT
    */
-  virtual void
-  handleSelectAlt(Transaction &transaction)
-  {
-    transaction.resume();
-  };
+  virtual void handleSelectAlt(const Request &clientReq, const Request &cachedReq, const Response &cachedResp){};
 
   virtual ~Plugin(){};
 

--- a/lib/cppapi/include/atscppapi/Request.h
+++ b/lib/cppapi/include/atscppapi/Request.h
@@ -31,6 +31,11 @@
 
 namespace atscppapi
 {
+namespace utils
+{
+  class internal;
+}
+
 class Transaction;
 struct RequestState;
 
@@ -80,6 +85,7 @@ private:
   void reset();
   friend class Transaction;
   friend class ClientRequest;
+  friend class utils::internal;
 };
 }
 

--- a/lib/cppapi/include/utils_internal.h
+++ b/lib/cppapi/include/utils_internal.h
@@ -53,6 +53,7 @@ namespace utils
     static TSHttpHookID convertInternalTransformationTypeToTsHook(TransformationPlugin::Type type);
     static void invokePluginForEvent(TransactionPlugin *, TSHttpTxn, TSEvent);
     static void invokePluginForEvent(GlobalPlugin *, TSHttpTxn, TSEvent);
+    static void invokePluginForEvent(GlobalPlugin *, TSHttpAltInfo, TSEvent);
     static HttpVersion getHttpVersion(TSMBuffer hdr_buf, TSMLoc hdr_loc);
     static void initTransactionManagement();
     static std::string consumeFromTSIOBufferReader(TSIOBufferReader);

--- a/lib/cppapi/utils_internal.cc
+++ b/lib/cppapi/utils_internal.cc
@@ -141,10 +141,6 @@ void inline invokePluginForEvent(Plugin *plugin, TSHttpTxn ats_txn_handle, TSEve
   case TS_EVENT_HTTP_CACHE_LOOKUP_COMPLETE:
     plugin->handleReadCacheLookupComplete(transaction);
     break;
-  case TS_EVENT_HTTP_SELECT_ALT:
-    plugin->handleSelectAlt(transaction);
-    break;
-
   default:
     assert(false); /* we should never get here */
     break;
@@ -230,6 +226,27 @@ void
 utils::internal::invokePluginForEvent(GlobalPlugin *plugin, TSHttpTxn ats_txn_handle, TSEvent event)
 {
   ::invokePluginForEvent(static_cast<Plugin *>(plugin), ats_txn_handle, event);
+}
+
+void
+utils::internal::invokePluginForEvent(GlobalPlugin *plugin, TSHttpAltInfo altinfo_handle, TSEvent event)
+{
+  TSMBuffer hdr_buf;
+  TSMLoc hdr_loc;
+
+  assert(event == TS_EVENT_HTTP_SELECT_ALT);
+
+  TSHttpAltInfoClientReqGet(altinfo_handle, &hdr_buf, &hdr_loc);
+  const Request clientReq(hdr_buf, hdr_loc); // no MLocRelease needed
+
+  TSHttpAltInfoCachedReqGet(altinfo_handle, &hdr_buf, &hdr_loc);
+  const Request cachedReq(hdr_buf, hdr_loc); // no MLocRelease needed
+
+  TSHttpAltInfoCachedRespGet(altinfo_handle, &hdr_buf, &hdr_loc);
+  Response cachedResp;
+  cachedResp.init(hdr_buf, hdr_loc); // no MLocRelease needed
+
+  plugin->handleSelectAlt(clientReq, cachedReq, cachedResp);
 }
 
 std::string


### PR DESCRIPTION
The global event TS_EVENT_HTTP_SELECT_ALT is sent without a TSHttpTxn edata.   

Instead it is sent TSHttpAltInfo. The default virtual function work if it gets these args.