### PR TITLE
Explicitly set enable_doc_build to yes if --enable-docs is provided to allow documentation and manpages build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -275,7 +275,7 @@ AM_CONDITIONAL([BUILD_TESTS], [test 0 -ne $has_tests])
 AC_MSG_CHECKING([whether to build documentation])
 AC_ARG_ENABLE([docs],
   [AS_HELP_STRING([--enable-docs],[enable documentation building])],
-  [],
+  [enable_doc_build=yes],
   [enable_doc_build=no]
 )
 AC_MSG_RESULT([$enable_doc_build])


### PR DESCRIPTION
Hello,
As far as I can see, and understand, the option `--enable-docs` doesn't work as expected in 7.1.2.
Please note that I might be wrong. If so, I apologize and am likely to learn how it works :)

In `configure.ac`:

```AC_MSG_CHECKING([whether to build documentation])
AC_ARG_ENABLE([docs],
  [AS_HELP_STRING([--enable-docs],[enable documentation building])],
  [],
  [enable_doc_build=no]
)
AC_MSG_RESULT([$enable_doc_build])
AM_CONDITIONAL([BUILD_DOCS], [test "xyes" = "x$enable_doc_build"])
```

`enable_doc_build` is set to `no` if option is missing. If option is provided, nothing is done.
Then, `BUILD_DOCS` is set to true only if `enable_doc_build` is set to `yes` which seems to be unlikely to happen.

In `configure`:

```{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to build documentation" >&5
$as_echo_n "checking whether to build documentation... " >&6; }
# Check whether --enable-docs was given.
if test "${enable_docs+set}" = set; then :
  enableval=$enable_docs;
else
  enable_doc_build=no

fi

{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $enable_doc_build" >&5
$as_echo "$enable_doc_build" >&6; }
 if test "xyes" = "x$enable_doc_build"; then
  BUILD_DOCS_TRUE=
  BUILD_DOCS_FALSE='#'
else
  BUILD_DOCS_TRUE='#'
  BUILD_DOCS_FALSE=
fi
```

If `--enable-docs` option isn't provided, `enable_doc_build` is set to `no` and never set to `yes` if option is provided.
When testing `enable_doc_build` to set `BUILD_DOCS_TRUE` and `BUILD_DOCS_FALSE`, first case is never triggered, leading to `enable_doc_build` to be always empty.
This means BUILD_DOCS_TRUE will be always equal to '#', thus leading man pages generation to be disabled in `doc/Makefile.in`:

```@BUILD_MANPAGES_TRUE@$(man1_MANS) $(man3_MANS) $(man5_MANS) $(man8_MANS): man

# Hook the 'all' target so that the man pages get generated in the "all" target, prior
# to "make install". If we leave it to "make install" time, then the man pages are likely
# to me generated as root.
@BUILD_DOCS_TRUE@@BUILD_MANPAGES_TRUE@all-am: $(man1_MANS) $(man3_MANS) $(man5_MANS) $(man8_MANS)
```
