### PR TITLE
Processing DNS reponses with CNAME & SRV records

### DIFF
--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -1600,7 +1600,7 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
       //
       // Decode cname
       //
-      if (is_addr_query(e->qtype) && (type == T_CNAME || type == T_DNAME)) {
+      if ((is_addr_query(e->qtype) || e->qtype == T_SRV) && (type == T_CNAME || type == T_DNAME)) {
         if (ap >= &buf->host_aliases[DNS_MAX_ALIASES - 1]) {
           continue;
         }


### PR DESCRIPTION
When DNS responded to SRV query with a CNAME code breaking and not prase SRV records.
Now this processes the same as if it were an A or AAAA query.