### PR TITLE
Add a --enable-fips flag which will eliminate MD5 and MMH and

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -255,6 +255,19 @@ AC_MSG_RESULT([$enable_diags])
 TS_ARG_ENABLE_VAR([use], [diags])
 
 #
+# FIPS
+#
+
+AC_MSG_CHECKING([whether to enable fips])
+AC_ARG_ENABLE([fips],
+  [AS_HELP_STRING([--enable-fips],[turn on FIPS compliance])],
+  [],
+  [enable_fips=no]
+)
+AC_MSG_RESULT([$enable_fips])
+TS_ARG_ENABLE_VAR([enable], [fips])
+
+#
 # Build regression tests?
 #
 

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -1276,7 +1276,7 @@ Vol::init(char *s, off_t blocks, off_t dir_skip, bool clear)
   ink_strlcpy(hash_text, seed_str, hash_text_size);
   snprintf(hash_text + hash_seed_size, (hash_text_size - hash_seed_size), " %" PRIu64 ":%" PRIu64 "", (uint64_t)dir_skip,
            (uint64_t)blocks);
-  MD5Context().hash_immediate(hash_id, hash_text, strlen(hash_text));
+  CryptoContext().hash_immediate(hash_id, hash_text, strlen(hash_text));
 
   dir_skip = ROUND_TO_STORE_BLOCK((dir_skip < START_POS ? START_POS : dir_skip));
   path     = ats_strdup(s);

--- a/iocore/cache/I_CacheDefs.h
+++ b/iocore/cache/I_CacheDefs.h
@@ -124,20 +124,10 @@ enum CacheFragType {
 typedef CryptoHash CacheKey;
 
 struct HttpCacheKey {
-  uint64_t
-  slice64(int i) const
-  {
-    return hash.slice64(i);
-  }
-  uint32_t
-  slice32(int i) const
-  {
-    return hash.slice32(i);
-  }
-
   int hostlen;
   const char *hostname;
   CacheKey hash;
+  CacheKey hash2;
 };
 
 #define CACHE_ALLOW_MULTIPLE_WRITES 1

--- a/iocore/cache/P_CacheInternal.h
+++ b/iocore/cache/P_CacheInternal.h
@@ -799,7 +799,7 @@ Vol::open_write_lock(CacheVC *cont, int allow_if_writers, int max_writers)
 }
 
 TS_INLINE OpenDirEntry *
-Vol::open_read_lock(INK_MD5 *key, EThread *t)
+Vol::open_read_lock(CryptoHash *key, EThread *t)
 {
   CACHE_TRY_LOCK(lock, mutex, t);
   if (!lock.is_locked())
@@ -969,8 +969,8 @@ struct Cache {
   Action *open_write(Continuation *cont, const CacheKey *key, CacheHTTPInfo *old_info, time_t pin_in_cache = (time_t)0,
                      const CacheKey *key1 = nullptr, CacheFragType type = CACHE_FRAG_TYPE_HTTP, const char *hostname = 0,
                      int host_len = 0);
-  static void generate_key(INK_MD5 *md5, CacheURL *url);
-  static void generate_key(HttpCacheKey *md5, CacheURL *url, cache_generation_t generation = -1);
+  static void generate_key(CryptoHash *hash, CacheURL *url);
+  static void generate_key(HttpCacheKey *hash, CacheURL *url, cache_generation_t generation = -1);
 
   Action *link(Continuation *cont, const CacheKey *from, const CacheKey *to, CacheFragType type, const char *hostname,
                int host_len);
@@ -1000,9 +1000,9 @@ extern Cache *theStreamCache;
 inkcoreapi extern Cache *caches[NUM_CACHE_FRAG_TYPES];
 
 TS_INLINE void
-Cache::generate_key(INK_MD5 *md5, CacheURL *url)
+Cache::generate_key(CryptoHash *hash, CacheURL *url)
 {
-  url->hash_get(md5);
+  url->hash_get(hash);
 }
 
 TS_INLINE void
@@ -1013,9 +1013,9 @@ Cache::generate_key(HttpCacheKey *key, CacheURL *url, cache_generation_t generat
 }
 
 TS_INLINE unsigned int
-cache_hash(const INK_MD5 &md5)
+cache_hash(const CryptoHash &hash)
 {
-  uint64_t f         = md5.fold();
+  uint64_t f         = hash.fold();
   unsigned int mhash = (unsigned int)(f >> 32);
   return mhash;
 }

--- a/iocore/cache/P_CacheVol.h
+++ b/iocore/cache/P_CacheVol.h
@@ -276,11 +276,18 @@ struct CacheVol {
 
 // Note : hdr() needs to be 8 byte aligned.
 struct Doc {
-  uint32_t magic;        // DOC_MAGIC
-  uint32_t len;          // length of this fragment (including hlen & sizeof(Doc), unrounded)
-  uint64_t total_len;    // total length of document
-  CryptoHash first_key;  ///< first key in object.
-  CryptoHash key;        ///< Key for this doc.
+  uint32_t magic;     // DOC_MAGIC
+  uint32_t len;       // length of this fragment (including hlen & sizeof(Doc), unrounded)
+  uint64_t total_len; // total length of document
+#ifndef TS_ENABLE_FIPS
+  CryptoHash first_key; ///< first key in object.
+  CryptoHash key;       ///< Key for this doc.
+#else
+  // For FIPS CryptoHash is 256 bits vs. 128, and the 'first_key' must be checked first, so
+  // ensure that the new 'first_key' overlaps the old 'first_key' and that the rest of the data layout
+  // is the same by putting 'key' at the ned.
+  CryptoHash first_key; ///< first key in object.
+#endif
   uint32_t hlen;         ///< Length of this header.
   uint32_t doc_type : 8; ///< Doc type - indicates the format of this structure and its content.
   uint32_t v_major : 8;  ///< Major version number.
@@ -290,6 +297,9 @@ struct Doc {
   uint32_t write_serial;
   uint32_t pinned; // pinned until
   uint32_t checksum;
+#ifdef TS_ENABLE_FIPS
+  CryptoHash key; ///< Key for this doc.
+#endif
 
   uint32_t data_len();
   uint32_t prefix_len();

--- a/iocore/cache/P_RamCache.h
+++ b/iocore/cache/P_RamCache.h
@@ -30,11 +30,12 @@
 
 struct RamCache {
   // returns 1 on found/stored, 0 on not found/stored, if provided auxkey1 and auxkey2 must match
-  virtual int get(INK_MD5 *key, Ptr<IOBufferData> *ret_data, uint32_t auxkey1 = 0, uint32_t auxkey2 = 0) = 0;
-  virtual int put(INK_MD5 *key, IOBufferData *data, uint32_t len, bool copy = false, uint32_t auxkey1 = 0,
+  virtual int get(CryptoHash *key, Ptr<IOBufferData> *ret_data, uint32_t auxkey1 = 0, uint32_t auxkey2 = 0) = 0;
+  virtual int put(CryptoHash *key, IOBufferData *data, uint32_t len, bool copy = false, uint32_t auxkey1 = 0,
                   uint32_t auxkey2 = 0) = 0;
-  virtual int fixup(const INK_MD5 *key, uint32_t old_auxkey1, uint32_t old_auxkey2, uint32_t new_auxkey1, uint32_t new_auxkey2) = 0;
-  virtual int64_t size() const = 0;
+  virtual int fixup(const CryptoHash *key, uint32_t old_auxkey1, uint32_t old_auxkey2, uint32_t new_auxkey1,
+                    uint32_t new_auxkey2) = 0;
+  virtual int64_t size() const            = 0;
 
   virtual void init(int64_t max_bytes, Vol *vol) = 0;
   virtual ~RamCache(){};

--- a/iocore/cache/RamCacheLRU.cc
+++ b/iocore/cache/RamCacheLRU.cc
@@ -24,7 +24,7 @@
 #include "P_Cache.h"
 
 struct RamCacheLRUEntry {
-  INK_MD5 key;
+  CryptoHash key;
   uint32_t auxkey1;
   uint32_t auxkey2;
   LINK(RamCacheLRUEntry, lru_link);
@@ -40,9 +40,10 @@ struct RamCacheLRU : public RamCache {
   int64_t objects   = 0;
 
   // returns 1 on found/stored, 0 on not found/stored, if provided auxkey1 and auxkey2 must match
-  int get(INK_MD5 *key, Ptr<IOBufferData> *ret_data, uint32_t auxkey1 = 0, uint32_t auxkey2 = 0) override;
-  int put(INK_MD5 *key, IOBufferData *data, uint32_t len, bool copy = false, uint32_t auxkey1 = 0, uint32_t auxkey2 = 0) override;
-  int fixup(const INK_MD5 *key, uint32_t old_auxkey1, uint32_t old_auxkey2, uint32_t new_auxkey1, uint32_t new_auxkey2) override;
+  int get(CryptoHash *key, Ptr<IOBufferData> *ret_data, uint32_t auxkey1 = 0, uint32_t auxkey2 = 0) override;
+  int put(CryptoHash *key, IOBufferData *data, uint32_t len, bool copy = false, uint32_t auxkey1 = 0,
+          uint32_t auxkey2 = 0) override;
+  int fixup(const CryptoHash *key, uint32_t old_auxkey1, uint32_t old_auxkey2, uint32_t new_auxkey1, uint32_t new_auxkey2) override;
   int64_t size() const override;
 
   void init(int64_t max_bytes, Vol *vol) override;
@@ -118,7 +119,7 @@ RamCacheLRU::init(int64_t abytes, Vol *avol)
 }
 
 int
-RamCacheLRU::get(INK_MD5 *key, Ptr<IOBufferData> *ret_data, uint32_t auxkey1, uint32_t auxkey2)
+RamCacheLRU::get(CryptoHash *key, Ptr<IOBufferData> *ret_data, uint32_t auxkey1, uint32_t auxkey2)
 {
   if (!max_bytes) {
     return 0;
@@ -159,7 +160,7 @@ RamCacheLRU::remove(RamCacheLRUEntry *e)
 
 // ignore 'copy' since we don't touch the data
 int
-RamCacheLRU::put(INK_MD5 *key, IOBufferData *data, uint32_t len, bool, uint32_t auxkey1, uint32_t auxkey2)
+RamCacheLRU::put(CryptoHash *key, IOBufferData *data, uint32_t len, bool, uint32_t auxkey1, uint32_t auxkey2)
 {
   if (!max_bytes) {
     return 0;
@@ -215,7 +216,7 @@ RamCacheLRU::put(INK_MD5 *key, IOBufferData *data, uint32_t len, bool, uint32_t 
 }
 
 int
-RamCacheLRU::fixup(const INK_MD5 *key, uint32_t old_auxkey1, uint32_t old_auxkey2, uint32_t new_auxkey1, uint32_t new_auxkey2)
+RamCacheLRU::fixup(const CryptoHash *key, uint32_t old_auxkey1, uint32_t old_auxkey2, uint32_t new_auxkey1, uint32_t new_auxkey2)
 {
   if (!max_bytes) {
     return 0;

--- a/iocore/hostdb/I_HostDB.h
+++ b/iocore/hostdb/I_HostDB.h
@@ -38,8 +38,9 @@
 #include "I_HostDBProcessor.h"
 
 // TS-1925: switch from MMH to MD5 hash; bumped to version 2
+// switch from MD5 to SHA256 hash; bumped to version 3
 // 2.1: Switched to mark RR elements.
-#define HOSTDB_MODULE_MAJOR_VERSION 2
+#define HOSTDB_MODULE_MAJOR_VERSION 3
 #define HOSTDB_MODULE_MINOR_VERSION 1
 
 #define HOSTDB_MODULE_VERSION makeModuleVersion(HOSTDB_MODULE_MAJOR_VERSION, HOSTDB_MODULE_MINOR_VERSION, PUBLIC_MODULE_HEADER)

--- a/iocore/hostdb/I_HostDBProcessor.h
+++ b/iocore/hostdb/I_HostDBProcessor.h
@@ -26,7 +26,7 @@
 
 #include "ts/HashFNV.h"
 #include "ts/ink_time.h"
-#include "ts/INK_MD5.h"
+#include "ts/CryptoHash.h"
 #include "ts/ink_align.h"
 #include "ts/ink_resolver.h"
 #include "I_EventSystem.h"

--- a/iocore/hostdb/P_HostDB.h
+++ b/iocore/hostdb/P_HostDB.h
@@ -48,7 +48,7 @@
 
 #undef HOSTDB_MODULE_VERSION
 #define HOSTDB_MODULE_VERSION makeModuleVersion(HOSTDB_MODULE_MAJOR_VERSION, HOSTDB_MODULE_MINOR_VERSION, PRIVATE_MODULE_HEADER)
-Ptr<HostDBInfo> probe(ProxyMutex *mutex, HostDBMD5 const &md5, bool ignore_timeout);
+Ptr<HostDBInfo> probe(ProxyMutex *mutex, CryptoHash const &hash, bool ignore_timeout);
 
-void make_md5(INK_MD5 &md5, const char *hostname, int len, int port, const char *pDNSServers, HostDBMark mark);
+void make_crypto_hash(CryptoHash &hash, const char *hostname, int len, int port, const char *pDNSServers, HostDBMark mark);
 #endif

--- a/lib/ts/CryptoHash.cc
+++ b/lib/ts/CryptoHash.cc
@@ -1,0 +1,105 @@
+/** @file
+
+  Generic wrapper for cryptographic hashes.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include <cstdlib>
+#include <cstring>
+#include <new>
+#include "ts/ink_assert.h"
+#include "ts/ink_platform.h"
+#include "ts/ink_code.h"
+#include "ts/CryptoHash.h"
+#include "ts/SHA256.h"
+
+#ifndef TS_ENABLE_FIPS
+CryptoContext::HashType CryptoContext::Setting = CryptoContext::MD5;
+#else
+CryptoContext::HashType CryptoContext::Setting = CryptoContext::SHA256;
+#endif
+
+CryptoContext::CryptoContext()
+{
+  switch (Setting) {
+  case UNSPECIFIED:
+#ifndef TS_ENABLE_FIPS
+  case MD5:
+    new (_obj) MD5Context;
+    break;
+  case MMH:
+    new (_obj) MMHContext;
+    break;
+#endif
+  case SHA256:
+    new (_obj) SHA256Context;
+    break;
+  default:
+    ink_release_assert("Invalid global URL hash context");
+  };
+#ifndef TS_ENABLE_FIPS
+  static_assert(CryptoContext::OBJ_SIZE >= sizeof(MD5Context), "bad OBJ_SIZE");
+  static_assert(CryptoContext::OBJ_SIZE >= sizeof(MMHContext), "bad OBJ_SIZE");
+#endif
+  static_assert(CryptoContext::OBJ_SIZE >= sizeof(SHA256Context), "bad OBJ_SIZE");
+}
+
+/**
+  @brief Converts a hash to a null-terminated string
+
+  Externalizes an hash as a null-terminated string into the first argument.
+  Does so without intenal procedure calls.
+  Side Effects: none.
+  Reentrancy:     n/a.
+  Thread Safety:  safe.
+  Mem Management: stomps the passed dest char*.
+
+  @return returns the passed destination string ptr.
+*/
+/* reentrant version */
+static char *
+ink_code_to_hex_str(char *dest, uint8_t const *hash)
+{
+  int i;
+  char *d;
+
+  static char hex_digits[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+
+  d = dest;
+  for (i = 0; i < CRYPTO_HASH_SIZE; i += 4) {
+    *(d + 0) = hex_digits[hash[i + 0] >> 4];
+    *(d + 1) = hex_digits[hash[i + 0] & 15];
+    *(d + 2) = hex_digits[hash[i + 1] >> 4];
+    *(d + 3) = hex_digits[hash[i + 1] & 15];
+    *(d + 4) = hex_digits[hash[i + 2] >> 4];
+    *(d + 5) = hex_digits[hash[i + 2] & 15];
+    *(d + 6) = hex_digits[hash[i + 3] >> 4];
+    *(d + 7) = hex_digits[hash[i + 3] & 15];
+    d += 8;
+  }
+  *d = '\0';
+  return (dest);
+}
+
+char *
+CryptoHash::toHexStr(char buffer[(CRYPTO_HASH_SIZE * 2) + 1])
+{
+  return ink_code_to_hex_str(buffer, u8);
+}

--- a/lib/ts/CryptoHash.h
+++ b/lib/ts/CryptoHash.h
@@ -1,5 +1,5 @@
 /** @file
-    Protocol class for crypto hashes.
+    Wrapper class for crypto hashes.
 
     @section license License
 
@@ -25,30 +25,32 @@
 
 /// Apache Traffic Server commons.
 
-#include "ts/ink_code.h"
+#ifdef TS_ENABLE_FIPS
+// #include "ts/SHA256.h"
+#define CRYPTO_HASH_SIZE (256 / 8)
+#else
+// #include "ts/ink_code.h"
+#define CRYPTO_HASH_SIZE (128 / 8)
+#endif
+#define CRYPTO_HEX_SIZE ((CRYPTO_HASH_SIZE * 2) + 1)
 
 namespace ats
 {
 /// Crypto hash output.
 union CryptoHash {
-  uint64_t b[2]; // Legacy placeholder
-  uint64_t u64[2];
-  uint32_t u32[4];
-  uint8_t u8[16];
+  uint64_t b[CRYPTO_HASH_SIZE / sizeof(uint64_t)]; // Legacy placeholder
+  uint64_t u64[CRYPTO_HASH_SIZE / sizeof(uint64_t)];
+  uint32_t u32[CRYPTO_HASH_SIZE / sizeof(uint32_t)];
+  uint8_t u8[CRYPTO_HASH_SIZE / sizeof(uint8_t)];
 
   /// Default constructor - init to zero.
-  CryptoHash()
-  {
-    u64[0] = 0;
-    u64[1] = 0;
-  }
+  CryptoHash() { memset(this, 0, sizeof(*this)); }
 
   /// Assignment - bitwise copy.
   CryptoHash &
   operator=(CryptoHash const &that)
   {
-    u64[0] = that.u64[0];
-    u64[1] = that.u64[1];
+    memcpy(this, &that, sizeof(*this));
     return *this;
   }
 
@@ -56,7 +58,7 @@ union CryptoHash {
   bool
   operator==(CryptoHash const &that) const
   {
-    return u64[0] == that.u64[0] && u64[1] == that.u64[1];
+    return memcmp(this, &that, sizeof(*this)) == 0;
   }
 
   /// Equality - bitwise identical.
@@ -70,7 +72,11 @@ union CryptoHash {
   uint64_t
   fold() const
   {
+#if CRYPTO_HASH_SIZE == 16
     return u64[0] ^ u64[1];
+#elif CRYPTO_HASH_SIZE == 32
+    return u64[0] ^ u64[1] ^ u64[2] ^ u64[3];
+#endif
   }
 
   /// Access 64 bit slice.
@@ -91,11 +97,7 @@ union CryptoHash {
   }
 
   /// Fast conversion to hex in fixed sized string.
-  char *
-  toHexStr(char buffer[33])
-  {
-    return ink_code_to_hex_str(buffer, u8);
-  }
+  char *toHexStr(char buffer[(CRYPTO_HASH_SIZE * 2) + 1]);
 };
 
 extern CryptoHash const CRYPTO_HASH_ZERO;
@@ -104,12 +106,12 @@ extern CryptoHash const CRYPTO_HASH_ZERO;
 
     A hash of this type is used for strong hashing, such as for URLs.
 */
-class CryptoContext
+class CryptoContextBase
 {
-  typedef CryptoContext self; ///< Self reference type.
+  typedef CryptoContextBase self; ///< Self reference type.
 public:
   /// Destructor (force virtual)
-  virtual ~CryptoContext() {}
+  virtual ~CryptoContextBase() {}
   /// Update the hash with @a data of @a length bytes.
   virtual bool update(void const *data, int length) = 0;
   /// Finalize and extract the @a hash.
@@ -121,23 +123,61 @@ public:
   /// Convenience - compute final @a hash for @a data.
   /// @note This is just as fast as the previous style, as a new context must be initialized
   /// everytime this is done.
-  virtual bool hash_immediate(CryptoHash &hash, void const *data, int length);
+  bool hash_immediate(CryptoHash &hash, void const *data, int length);
 };
 
 inline bool
-CryptoContext::hash_immediate(CryptoHash &hash, void const *data, int length)
+CryptoContextBase::hash_immediate(CryptoHash &hash, void const *data, int length)
 {
   return this->update(data, length) && this->finalize(hash);
 }
+
 inline bool
-CryptoContext::finalize(CryptoHash *hash)
+CryptoContextBase::finalize(CryptoHash *hash)
 {
   return this->finalize(*hash);
 }
 
+class CryptoContext : public CryptoContextBase
+{
+public:
+  CryptoContext();
+  /// Update the hash with @a data of @a length bytes.
+  virtual bool update(void const *data, int length);
+  /// Finalize and extract the @a hash.
+  virtual bool finalize(CryptoHash &hash);
+
+  enum HashType {
+    UNSPECIFIED,
+#ifndef TS_ENABLE_FIPS
+    MD5,
+    MMH,
+#endif
+    SHA256,
+  }; ///< What type of hash we really are.
+  static HashType Setting;
+
+  /// Size of storage for placement @c new of hashing context.
+  static size_t const OBJ_SIZE = 256;
+
+protected:
+  char _obj[OBJ_SIZE]; ///< Raw storage for instantiated context.
+};
+
+inline bool
+CryptoContext::update(void const *data, int length)
+{
+  return reinterpret_cast<CryptoContextBase *>(_obj)->update(data, length);
+}
+
+inline bool
+CryptoContext::finalize(CryptoHash &hash)
+{
+  return reinterpret_cast<CryptoContextBase *>(_obj)->finalize(hash);
+}
+
 } // end namespace
 
-// Promote for the primitives who don't use namespaces...
 using ats::CryptoHash;
 using ats::CryptoContext;
 using ats::CRYPTO_HASH_ZERO;

--- a/lib/ts/MMH.h
+++ b/lib/ts/MMH.h
@@ -49,7 +49,7 @@ int inkcoreapi ink_code_MMH(unsigned char *input, int len, unsigned char *sixtee
   cost.
 
 */
-class MMHContext : public CryptoContext
+class MMHContext : public ats::CryptoContextBase
 {
 protected:
   MMH_CTX _ctx;

--- a/lib/ts/Makefile.am
+++ b/lib/ts/Makefile.am
@@ -56,6 +56,8 @@ libtsutil_la_SOURCES = \
   ConsistentHash.h \
   ContFlags.cc \
   ContFlags.h \
+  CryptoHash.cc \
+  CryptoHash.h \
   defalloc.h \
   Diags.cc \
   Diags.h \

--- a/lib/ts/SHA256.h
+++ b/lib/ts/SHA256.h
@@ -1,6 +1,6 @@
 /** @file
 
-  MD5 support class.
+  SHA256 support class.
 
   @section license License
 
@@ -27,23 +27,30 @@
 #include "ts/ink_code.h"
 #include "ts/ink_defs.h"
 #include "ts/CryptoHash.h"
+#include <openssl/sha.h>
 
-#ifndef TS_ENABLE_FIPS
+#ifdef TS_ENABLE_FIPS
 
-class MD5Context : public ats::CryptoContextBase
+class SHA256Context : public ats::CryptoContextBase
 {
 protected:
-  MD5_CTX _ctx;
+  SHA256_CTX _ctx;
 
 public:
-  MD5Context();
+  SHA256Context() { SHA256_Init(&_ctx); }
   /// Update the hash with @a data of @a length bytes.
-  virtual bool update(void const *data, int length);
+  virtual bool
+  update(void const *data, int length)
+  {
+    return SHA256_Update(&_ctx, data, length);
+  }
   /// Finalize and extract the @a hash.
-  virtual bool finalize(CryptoHash &hash);
+  virtual bool
+  finalize(CryptoHash &hash)
+  {
+    return SHA256_Final(hash.u8, &_ctx);
+  }
 };
 
-typedef CryptoHash INK_MD5;
 #endif
-
 #endif

--- a/lib/ts/ink_code.cc
+++ b/lib/ts/ink_code.cc
@@ -28,6 +28,7 @@
 #include "ts/ink_assert.h"
 
 ats::CryptoHash const ats::CRYPTO_HASH_ZERO; // default constructed is correct.
+#ifndef TS_ENABLE_FIPS
 
 MD5Context::MD5Context()
 {
@@ -89,40 +90,4 @@ ink_code_md5(unsigned const char *input, int input_length, unsigned char *sixtee
 
   return (0);
 }
-
-/**
-  @brief Converts a MD5 to a null-terminated string
-
-  Externalizes an INK_MD5 as a null-terminated string into the first argument.
-  Does so without intenal procedure calls.
-  Side Effects: none.
-  Reentrancy:     n/a.
-  Thread Safety:  safe.
-  Mem Management: stomps the passed dest char*.
-
-  @return returns the passed destination string ptr.
-*/
-/* reentrant version */
-char *
-ink_code_to_hex_str(char *dest33, uint8_t const *hash)
-{
-  int i;
-  char *d;
-
-  static char hex_digits[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
-
-  d = dest33;
-  for (i = 0; i < 16; i += 4) {
-    *(d + 0) = hex_digits[hash[i + 0] >> 4];
-    *(d + 1) = hex_digits[hash[i + 0] & 15];
-    *(d + 2) = hex_digits[hash[i + 1] >> 4];
-    *(d + 3) = hex_digits[hash[i + 1] & 15];
-    *(d + 4) = hex_digits[hash[i + 2] >> 4];
-    *(d + 5) = hex_digits[hash[i + 2] & 15];
-    *(d + 6) = hex_digits[hash[i + 3] >> 4];
-    *(d + 7) = hex_digits[hash[i + 3] & 15];
-    d += 8;
-  }
-  *d = '\0';
-  return (dest33);
-}
+#endif

--- a/lib/ts/ink_code.h
+++ b/lib/ts/ink_code.h
@@ -26,6 +26,7 @@
 
 #include "ts/ink_apidefs.h"
 #include "ts/ink_defs.h"
+#ifndef TS_ENABLE_FIPS
 #include <openssl/md5.h>
 
 /* INK_MD5 context. */
@@ -36,9 +37,8 @@ typedef MD5_CTX INK_DIGEST_CTX;
 */
 
 inkcoreapi int ink_code_md5(unsigned const char *input, int input_length, unsigned char *sixteen_byte_hash_pointer);
-inkcoreapi char *ink_code_to_hex_str(char *dest33, uint8_t const *md5);
-
 inkcoreapi int ink_code_incr_md5_init(INK_DIGEST_CTX *context);
 inkcoreapi int ink_code_incr_md5_update(INK_DIGEST_CTX *context, const char *input, int input_length);
 inkcoreapi int ink_code_incr_md5_final(char *sixteen_byte_hash_pointer, INK_DIGEST_CTX *context);
+#endif
 #endif

--- a/lib/ts/ink_config.h.in
+++ b/lib/ts/ink_config.h.in
@@ -59,6 +59,7 @@
 #define TS_HAS_BACKTRACE @has_backtrace@
 #define TS_HAS_PROFILER @has_profiler@
 #define TS_USE_FAST_SDK @use_fast_sdk@
+#define TS_ENABLE_FIPS @enable_fips@
 #define TS_USE_DIAGS @use_diags@
 #define TS_USE_EPOLL @use_epoll@
 #define TS_USE_KQUEUE @use_kqueue@

--- a/plugins/experimental/memcache/tsmemcache.cc
+++ b/plugins/experimental/memcache/tsmemcache.cc
@@ -471,7 +471,7 @@ int
 MC::get_item()
 {
   TS_PUSH_HANDLER(&MC::cache_read_event);
-  MD5Context().hash_immediate(cache_key, (void *)key, (int)header.nkey);
+  CryptoContext().hash_immediate(cache_key, (void *)key, (int)header.nkey);
   pending_action = cacheProcessor.open_read(this, &cache_key);
   return EVENT_CONT;
 }
@@ -479,7 +479,7 @@ MC::get_item()
 int
 MC::set_item()
 {
-  MD5Context().hash_immediate(cache_key, (void *)key, (int)header.nkey);
+  CryptoContext().hash_immediate(cache_key, (void *)key, (int)header.nkey);
   pending_action = cacheProcessor.open_write(this, &cache_key, CACHE_FRAG_TYPE_NONE, header.nbytes,
                                              CACHE_WRITE_OPT_OVERWRITE | TSMEMCACHE_WRITE_SYNC);
   return EVENT_CONT;
@@ -488,7 +488,7 @@ MC::set_item()
 int
 MC::delete_item()
 {
-  MD5Context().hash_immediate(cache_key, (void *)key, (int)header.nkey);
+  CryptoContext().hash_immediate(cache_key, (void *)key, (int)header.nkey);
   pending_action = cacheProcessor.remove(this, &cache_key, CACHE_FRAG_TYPE_NONE);
   return EVENT_CONT;
 }

--- a/plugins/experimental/memcache/tsmemcache.h
+++ b/plugins/experimental/memcache/tsmemcache.h
@@ -33,7 +33,7 @@
 #include "protocol_binary.h"
 #include "ink_memory.h"
 #include "ink_hrtime.h"
-#include "INK_MD5.h"
+#include "CryptoHash.h"
 
 #define TSMEMCACHE_VERSION "1.0.0"
 #define TSMEMCACHE_MAX_CMD_SIZE (128 * 1024 * 1024) // silly large

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -4064,7 +4064,7 @@ TSCacheKeyDigestSet(TSCacheKey key, const char *input, int length)
     return TS_ERROR;
   }
 
-  MD5Context().hash_immediate(ci->cache_key, input, length);
+  CryptoContext().hash_immediate(ci->cache_key, input, length);
   return TS_SUCCESS;
 }
 
@@ -4077,7 +4077,7 @@ TSCacheKeyDigestFromUrlSet(TSCacheKey key, TSMLoc url)
     return TS_ERROR;
   }
 
-  url_MD5_get((URLImpl *)url, &((CacheInfo *)key)->cache_key);
+  url_CryptoHash_get((URLImpl *)url, &((CacheInfo *)key)->cache_key);
   return TS_SUCCESS;
 }
 
@@ -5122,7 +5122,7 @@ TSHttpTxnNewCacheLookupDo(TSHttpTxn txnp, TSMBuffer bufp, TSMLoc url_loc)
   sdk_assert(sdk_sanity_check_url_handle(url_loc) == TS_SUCCESS);
 
   URL new_url, *client_url, *l_url, *o_url;
-  INK_MD5 md51, md52;
+  CryptoHash crypto_hash1, crypto_hash2;
 
   new_url.m_heap     = ((HdrHeapSDKHandle *)bufp)->m_heap;
   new_url.m_url_impl = (URLImpl *)url_loc;
@@ -5146,9 +5146,9 @@ TSHttpTxnNewCacheLookupDo(TSHttpTxn txnp, TSMBuffer bufp, TSMLoc url_loc)
     s->cache_info.lookup_url = &(s->cache_info.lookup_url_storage);
     l_url                    = s->cache_info.lookup_url;
   } else {
-    l_url->hash_get(&md51);
-    new_url.hash_get(&md52);
-    if (md51 == md52) {
+    l_url->hash_get(&crypto_hash1);
+    new_url.hash_get(&crypto_hash2);
+    if (crypto_hash1 == crypto_hash2) {
       return TS_ERROR;
     }
     o_url = &(s->cache_info.original_url);
@@ -7465,7 +7465,7 @@ TSCacheHttpInfoKeySet(TSCacheHttpInfo infop, TSCacheKey keyp)
 {
   // TODO: Check input ?
   CacheHTTPInfo *info = (CacheHTTPInfo *)infop;
-  INK_MD5 *key        = (INK_MD5 *)keyp;
+  CryptoHash *key     = (CryptoHash *)keyp;
 
   info->object_key_set(*key);
 }

--- a/proxy/InkAPIInternal.h
+++ b/proxy/InkAPIInternal.h
@@ -53,7 +53,7 @@ enum CacheInfoMagic {
 };
 
 struct CacheInfo {
-  INK_MD5 cache_key;
+  CryptoHash cache_key;
   CacheFragType frag_type;
   char *hostname;
   int len;

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -691,6 +691,7 @@ CB_After_Cache_Init()
 
   start = ink_atomic_swap(&delay_listen_for_cache_p, -1);
 
+#ifndef TS_ENABLE_FIPS
   // Check for cache BC after the cache is initialized and before listen, if possible.
   if (cacheProcessor.min_stripe_version.ink_major < CACHE_DB_MAJOR_VERSION) {
     // Versions before 23 need the MMH hash.
@@ -700,6 +701,7 @@ CB_After_Cache_Init()
       URLHashContext::Setting = URLHashContext::MMH;
     }
   }
+#endif
 
   if (1 == start) {
     Debug("http_listen", "Delayed listen enable, cache initialization finished");

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -4838,10 +4838,9 @@ HttpSM::do_http_server_open(bool raw)
   if (t_state.txn_conf->origin_max_connections > 0) {
     ConnectionCount *connections = ConnectionCount::getInstance();
 
-    INK_MD5 hostname_hash;
-    MD5Context md5_ctx;
-    md5_ctx.hash_immediate(hostname_hash, static_cast<const void *>(t_state.current.server->name),
-                           strlen(t_state.current.server->name));
+    CryptoHash hostname_hash;
+    CryptoContext().hash_immediate(hostname_hash, static_cast<const void *>(t_state.current.server->name),
+                                   strlen(t_state.current.server->name));
 
     if (connections->getCount(t_state.current.server->dst_addr, hostname_hash,
                               (TSServerSessionSharingMatchType)t_state.txn_conf->server_session_sharing_match) >=
@@ -5299,10 +5298,9 @@ HttpSM::handle_http_server_open()
 {
   // if we were a queued request, we need to decrement the queue size-- as we got a connection
   if (t_state.origin_request_queued) {
-    INK_MD5 hostname_hash;
-    MD5Context md5_ctx;
-    md5_ctx.hash_immediate(hostname_hash, static_cast<const void *>(t_state.current.server->name),
-                           strlen(t_state.current.server->name));
+    CryptoHash hostname_hash;
+    CryptoContext().hash_immediate(hostname_hash, static_cast<const void *>(t_state.current.server->name),
+                                   strlen(t_state.current.server->name));
 
     ConnectionCountQueue *waiting_connections = ConnectionCountQueue::getInstance();
     waiting_connections->incrementCount(t_state.current.server->dst_addr, hostname_hash,

--- a/proxy/http/HttpServerSession.h
+++ b/proxy/http/HttpServerSession.h
@@ -137,7 +137,7 @@ public:
     return server_vc->get_remote_endpoint();
   }
 
-  INK_MD5 hostname_hash;
+  CryptoHash hostname_hash;
 
   int64_t con_id;
   int transact_count;
@@ -209,7 +209,7 @@ inline void
 HttpServerSession::attach_hostname(const char *hostname)
 {
   if (CRYPTO_HASH_ZERO == hostname_hash) {
-    ink_code_md5((unsigned char *)hostname, strlen(hostname), (unsigned char *)&hostname_hash);
+    CryptoContext().hash_immediate(hostname_hash, (unsigned char *)hostname, strlen(hostname));
   }
 }
 #endif

--- a/proxy/http/HttpSessionManager.cc
+++ b/proxy/http/HttpSessionManager.cc
@@ -64,7 +64,7 @@ ServerSessionPool::purge()
 }
 
 bool
-ServerSessionPool::match(HttpServerSession *ss, sockaddr const *addr, INK_MD5 const &hostname_hash,
+ServerSessionPool::match(HttpServerSession *ss, sockaddr const *addr, CryptoHash const &hostname_hash,
                          TSServerSessionSharingMatchType match_style)
 {
   return TS_SERVER_SESSION_SHARING_MATCH_NONE != match_style && // if no matching allowed, fail immediately.
@@ -92,8 +92,8 @@ ServerSessionPool::validate_sni(HttpSM *sm, NetVConnection *netvc)
 }
 
 HSMresult_t
-ServerSessionPool::acquireSession(sockaddr const *addr, INK_MD5 const &hostname_hash, TSServerSessionSharingMatchType match_style,
-                                  HttpSM *sm, HttpServerSession *&to_return)
+ServerSessionPool::acquireSession(sockaddr const *addr, CryptoHash const &hostname_hash,
+                                  TSServerSessionSharingMatchType match_style, HttpSM *sm, HttpServerSession *&to_return)
 {
   HSMresult_t zret = HSM_NOT_FOUND;
   if (TS_SERVER_SESSION_SHARING_MATCH_HOST == match_style) {
@@ -269,10 +269,10 @@ HttpSessionManager::acquire_session(Continuation * /* cont ATS_UNUSED */, sockad
   HttpServerSession *to_return = nullptr;
   TSServerSessionSharingMatchType match_style =
     static_cast<TSServerSessionSharingMatchType>(sm->t_state.txn_conf->server_session_sharing_match);
-  INK_MD5 hostname_hash;
+  CryptoHash hostname_hash;
   HSMresult_t retval = HSM_NOT_FOUND;
 
-  ink_code_md5((unsigned char *)hostname, strlen(hostname), (unsigned char *)&hostname_hash);
+  CryptoContext().hash_immediate(hostname_hash, (unsigned char *)hostname, strlen(hostname));
 
   // First check to see if there is a server session bound
   //   to the user agent session

--- a/proxy/http/HttpSessionManager.h
+++ b/proxy/http/HttpSessionManager.h
@@ -95,7 +95,7 @@ protected:
   /// Interface class for FQDN map.
   struct HostHashing {
     typedef uint64_t ID;
-    typedef INK_MD5 const &Key;
+    typedef CryptoHash const &Key;
     typedef HttpServerSession Value;
     typedef DList(HttpServerSession, host_hash_link) ListHead;
 
@@ -122,7 +122,7 @@ protected:
 public:
   /** Check if a session matches address and host name.
    */
-  static bool match(HttpServerSession *ss, sockaddr const *addr, INK_MD5 const &host_hash,
+  static bool match(HttpServerSession *ss, sockaddr const *addr, CryptoHash const &host_hash,
                     TSServerSessionSharingMatchType match_style);
 
   /** Get a session from the pool.
@@ -132,7 +132,7 @@ public:
 
       @return A pointer to the session or @c NULL if not matching session was found.
   */
-  HSMresult_t acquireSession(sockaddr const *addr, INK_MD5 const &host_hash, TSServerSessionSharingMatchType match_style,
+  HSMresult_t acquireSession(sockaddr const *addr, CryptoHash const &host_hash, TSServerSessionSharingMatchType match_style,
                              HttpSM *sm, HttpServerSession *&server_session);
   /** Release a session to to pool.
    */

--- a/proxy/logging/LogFormat.cc
+++ b/proxy/logging/LogFormat.cc
@@ -32,9 +32,8 @@
 #include <cstring>
 #include <cstdlib>
 
-#include "ts/INK_MD5.h"
-
 #include "ts/SimpleTokenizer.h"
+#include "ts/CryptoHash.h"
 
 #include "LogUtils.h"
 #include "LogFile.h"
@@ -109,7 +108,7 @@ LogFormat::id_from_name(const char *name)
   int32_t id = 0;
   if (name) {
     CryptoHash hash;
-    MD5Context().hash_immediate(hash, name, static_cast<int>(strlen(name)));
+    CryptoContext().hash_immediate(hash, name, static_cast<int>(strlen(name)));
 #if defined(linux)
     /* Mask most signficant bit so that return value of this function
      * is not sign extended to be a negative number.

--- a/proxy/logging/LogObject.cc
+++ b/proxy/logging/LogObject.cc
@@ -28,7 +28,6 @@
  ***************************************************************************/
 #include "ts/ink_platform.h"
 #include "ts/CryptoHash.h"
-#include "ts/INK_MD5.h"
 #include "P_EventSystem.h"
 #include "LogUtils.h"
 #include "LogField.h"
@@ -338,7 +337,7 @@ LogObject::compute_signature(LogFormat *format, char *filename, unsigned int fla
                                    flags & LogObject::BINARY ? "B" : (flags & LogObject::WRITES_TO_PIPE ? "P" : "A"), NULL);
 
     CryptoHash hash;
-    MD5Context().hash_immediate(hash, buffer, buf_size - 1);
+    CryptoContext().hash_immediate(hash, buffer, buf_size - 1);
     signature = hash.fold();
 
     ats_free(buffer);

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -33,7 +33,7 @@ noinst_PROGRAMS = jtest/jtest
 endif
 
 jtest_jtest_SOURCES = jtest/jtest.cc
-jtest_jtest_LDADD = $(top_builddir)/lib/ts/libtsutil.la
+jtest_jtest_LDADD = $(top_builddir)/lib/ts/libtsutil.la -lssl -lcrypto
 
 if BUILD_HTTP_LOAD
 

--- a/tools/jtest/jtest.cc
+++ b/tools/jtest/jtest.cc
@@ -44,6 +44,7 @@
 #include <limits.h>
 #include <sys/mman.h>
 #include <cmath>
+#include <openssl/md5.h>
 
 #include <inttypes.h>
 
@@ -3435,6 +3436,18 @@ UrlHashTable::~UrlHashTable()
     close(fd);
   }
 } // UrlHashTable::~UrlHashTable
+
+static int
+ink_code_md5(unsigned const char *input, int input_length, unsigned char *sixteen_byte_hash_pointer)
+{
+  MD5_CTX context;
+
+  MD5_Init(&context);
+  MD5_Update(&context, input, input_length);
+  MD5_Final(sixteen_byte_hash_pointer, &context);
+
+  return (0);
+}
 
 static int
 seen_it(char *url)


### PR DESCRIPTION
replace them with SHA256.  This will effectively clear the cache
because existing documents will not be found.