### PR TITLE
Changes to allow for possible stale ua_session pointer in HttpSM object.

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -437,6 +437,17 @@ HttpSM::attach_client_session(ProxyClientTransaction *client_vc, IOBufferReader 
   }
   ua_txn = client_vc;
 
+  // It seems to be possible that the ua_txn pointer will go stale before log entries for this HTTP transaction are
+  // generated.  Therefore, collect information that may be needed for logging from the ua_txn object at this point.
+  //
+  _client_transaction_id = ua_txn->get_transaction_id();
+  {
+    auto p = ua_txn->get_parent();
+    if (p) {
+      _client_connection_id = p->connection_id();
+    }
+  }
+
   // Collect log & stats information
   client_tcp_reused         = !(ua_txn->is_first_transaction());
   SSLNetVConnection *ssl_vc = dynamic_cast<SSLNetVConnection *>(netvc);

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -583,8 +583,21 @@ public:
     return terminate_sm;
   }
 
+  int
+  client_connection_id() const
+  {
+    return _client_connection_id;
+  }
+
+  int
+  client_transaction_id() const
+  {
+    return _client_transaction_id;
+  }
+
 private:
   PostDataBuffers _postbuf;
+  int _client_connection_id = -1, _client_transaction_id = -1;
 };
 
 // Function to get the cache_sm object - YTS Team, yamsat

--- a/proxy/logging/LogAccessHttp.cc
+++ b/proxy/logging/LogAccessHttp.cc
@@ -1473,13 +1473,7 @@ LogAccessHttp::marshal_client_http_connection_id(char *buf)
   if (buf) {
     int64_t id = 0;
     if (m_http_sm) {
-      auto p = m_http_sm->ua_txn;
-      if (p) {
-        auto p2 = p->get_parent();
-        if (p2) {
-          id = p2->connection_id();
-        }
-      }
+      id = m_http_sm->client_connection_id();
     }
     marshal_int(buf, id);
   }
@@ -1495,10 +1489,7 @@ LogAccessHttp::marshal_client_http_transaction_id(char *buf)
   if (buf) {
     int64_t id = 0;
     if (m_http_sm) {
-      auto p = m_http_sm->ua_txn;
-      if (p) {
-        id = p->get_transaction_id();
-      }
+      id = m_http_sm->client_transaction_id();
     }
     marshal_int(buf, id);
   }


### PR DESCRIPTION
(cherry picked from Oath-internal commit 6d79b71950e14b13167fdf6422bf0e68bad6fccc)

This is a fix for a problem in commit ff2c84732d96963c01d35d78892edc623a1b92d1 .  (Log fields for Connection ID and HTTP/2 Stream ID.)  It avoids terminations due to segment violations that were seen to occur on Oath field proxies.