### PR TITLE
Using MT_hashtable for VC lookup.

### DIFF
--- a/iocore/net/P_QUICPacketHandler.h
+++ b/iocore/net/P_QUICPacketHandler.h
@@ -74,7 +74,7 @@ public:
 private:
   void _recv_packet(int event, UDPPacket *udp_packet) override;
 
-  QUICConnectionTable _ctable;
+  QUICConnectionTable *_ctable = nullptr;
   SSL_CTX *_ssl_ctx;
 };
 

--- a/iocore/net/quic/QUICConfig.cc
+++ b/iocore/net/quic/QUICConfig.cc
@@ -25,7 +25,8 @@
 
 #include <records/I_RecHttp.h>
 
-int QUICConfig::_config_id = 0;
+int QUICConfig::_config_id                   = 0;
+int QUICConfigParams::_connection_table_size = 65521;
 
 //
 // QUICConfigParams
@@ -38,6 +39,7 @@ QUICConfigParams::initialize()
   REC_EstablishStaticConfigInt32U(this->_initial_max_data, "proxy.config.quic.initial_max_data");
   REC_EstablishStaticConfigInt32U(this->_initial_max_stream_data, "proxy.config.quic.initial_max_stream_data");
   REC_EstablishStaticConfigInt32U(this->_server_id, "proxy.config.quic.server_id");
+  REC_EstablishStaticConfigInt32(_connection_table_size, "proxy.config.quic.connection_table.size");
 }
 
 uint32_t
@@ -56,6 +58,12 @@ uint32_t
 QUICConfigParams::server_id() const
 {
   return this->_server_id;
+}
+
+int
+QUICConfigParams::connection_table_size()
+{
+  return _connection_table_size;
 }
 
 uint32_t

--- a/iocore/net/quic/QUICConfig.h
+++ b/iocore/net/quic/QUICConfig.h
@@ -24,7 +24,6 @@
 #pragma once
 
 #include "ProxyConfig.h"
-
 class QUICConfigParams : public ConfigInfo
 {
 public:
@@ -39,6 +38,7 @@ public:
   uint32_t initial_max_stream_id_uni_in() const;
   uint32_t initial_max_stream_id_uni_out() const;
   uint32_t server_id() const;
+  static int connection_table_size();
 
 private:
   // FIXME Fill appropriate default values in RecordsConfig.cc
@@ -47,6 +47,7 @@ private:
   uint32_t _initial_max_data        = 0;
   uint32_t _initial_max_stream_data = 0;
   uint32_t _server_id               = 0;
+  static int _connection_table_size;
 
   uint32_t _initial_max_stream_id_bidi_in  = 100;
   uint32_t _initial_max_stream_id_bidi_out = 101;

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1326,6 +1326,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.quic.server_id", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_STR, "^-?[0-9]+$", RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.quic.connection_table.size", RECD_INT, "65521", RECU_RESTART_TS, RR_NULL, RECC_INT, "[1-536870909]", RECA_NULL}
+  ,
 
   //# Add LOCAL Records Here
   {RECT_LOCAL, "proxy.local.incoming_ip_to_bind", RECD_STRING, nullptr, RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL}


### PR DESCRIPTION
Bring back MT_hashtable to lib/ts. The MT_hashtable have 64 locks, each lock protects 65535 buckets, so ideally, the table was accessed by 64 threads concurrently.
Using MT_hashtable as data structures of QUICConnectionTable.