### PR TITLE
Quic pollcont, Reuse the NetHandler for UDP packet

### DIFF
--- a/cmd/traffic_quic/quic_client.cc
+++ b/cmd/traffic_quic/quic_client.cc
@@ -51,6 +51,7 @@ QUICClient::start()
     NetVCOptions opt;
     opt.ip_proto            = NetVCOptions::USE_UDP;
     opt.ip_family           = info->ai_family;
+    opt.etype               = ET_NET;
     opt.socket_recv_bufsize = 1048576;
     opt.socket_send_bufsize = 1048576;
 

--- a/cmd/traffic_quic/quic_client.h
+++ b/cmd/traffic_quic/quic_client.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include "P_Net.h"
 #include "I_EventSystem.h"
 #include "I_NetVConnection.h"
 #include "P_QUICNetProcessor.h"

--- a/cmd/traffic_quic/traffic_quic.cc
+++ b/cmd/traffic_quic/traffic_quic.cc
@@ -74,10 +74,12 @@ main(int argc, const char **argv)
   Thread *main_thread = new EThread;
   main_thread->set_specific();
   net_config_poll_timeout = 10;
+  ink_net_init(makeModuleVersion(1, 0, PRIVATE_MODULE_HEADER));
 
   SSLInitializeLibrary();
   SSLConfig::startup();
 
+  netProcessor.init();
   quic_NetProcessor.init();
 
   ink_event_system_init(EVENT_SYSTEM_MODULE_VERSION);
@@ -120,7 +122,7 @@ DNSConnection::trigger()
 void
 StatPagesManager::register_http(char const *, Action *(*)(Continuation *, HTTPHdr *))
 {
-  ink_assert(false);
+  //  ink_assert(false);
 }
 
 #include "ParentSelection.h"

--- a/cmd/traffic_quic/traffic_quic.cc
+++ b/cmd/traffic_quic/traffic_quic.cc
@@ -78,6 +78,8 @@ main(int argc, const char **argv)
   SSLInitializeLibrary();
   SSLConfig::startup();
 
+  quic_NetProcessor.init();
+
   ink_event_system_init(EVENT_SYSTEM_MODULE_VERSION);
   eventProcessor.start(THREADS);
   udpNet.start(1, stacksize);

--- a/cmd/traffic_quic/traffic_quic.cc
+++ b/cmd/traffic_quic/traffic_quic.cc
@@ -88,7 +88,7 @@ main(int argc, const char **argv)
   quic_NetProcessor.start(-1, stacksize);
 
   QUICClient client(addr, port);
-  eventProcessor.schedule_in(&client, 1, ET_UDP);
+  eventProcessor.schedule_in(&client, 1, ET_NET);
 
   this_thread()->execute();
 }

--- a/iocore/net/I_UDPPacket.h
+++ b/iocore/net/I_UDPPacket.h
@@ -62,12 +62,6 @@ public:
   IpEndpoint to;   // what address to send to
 
   int from_size;
-  typedef union udppacket_data {
-    void *ptr;
-    uint32_t u32;
-    uint64_t u64;
-  } udppacket_data_t;
-  udppacket_data_t data;
 
   LINK(UDPPacket, link);
 };

--- a/iocore/net/I_UDPPacket.h
+++ b/iocore/net/I_UDPPacket.h
@@ -63,7 +63,7 @@ public:
 
   int from_size;
   typedef union udppacket_data {
-    void    *ptr;
+    void *ptr;
     uint32_t u32;
     uint64_t u64;
   } udppacket_data_t;

--- a/iocore/net/I_UDPPacket.h
+++ b/iocore/net/I_UDPPacket.h
@@ -62,6 +62,12 @@ public:
   IpEndpoint to;   // what address to send to
 
   int from_size;
+  typedef union udppacket_data {
+    void    *ptr;
+    uint32_t u32;
+    uint64_t u64;
+  } udppacket_data_t;
+  udppacket_data_t data;
 
   LINK(UDPPacket, link);
 };

--- a/iocore/net/Makefile.am
+++ b/iocore/net/Makefile.am
@@ -162,10 +162,12 @@ libinknet_a_SOURCES = \
 if ENABLE_QUIC
 libinknet_a_SOURCES += \
   P_QUICPacketHandler.h \
+  P_QUICNet.h \
   P_QUICNetProcessor.h \
   P_QUICNetVConnection.h \
   P_QUICNextProtocolAccept.h \
   QUICPacketHandler.cc \
+  QUICNet.cc \
   QUICNetProcessor.cc \
   QUICNetVConnection.cc \
   QUICNextProtocolAccept.cc

--- a/iocore/net/P_Net.h
+++ b/iocore/net/P_Net.h
@@ -113,6 +113,7 @@ extern RecRawStatBlock *net_rsb;
 #include "P_QUICNetVConnection.h"
 #include "P_QUICNetProcessor.h"
 #include "P_QUICPacketHandler.h"
+#include "P_QUICNet.h"
 #endif
 // #include "P_QUICCertLookup.h"
 

--- a/iocore/net/P_QUICNet.h
+++ b/iocore/net/P_QUICNet.h
@@ -32,6 +32,8 @@
 class NetHandler;
 typedef int (NetHandler::*NetContHandler)(int, void *);
 
+void initialize_thread_for_quic_net(EThread *thread);
+
 struct QUICPollCont : public Continuation {
   NetHandler *net_handler;
   PollDescriptor *pollDescriptor;
@@ -49,6 +51,10 @@ public:
   Que(UDPPacket, link) longInQueue;
   // Internal Queue to save Short Header Packet
   Que(UDPPacket, link) shortInQueue;
+
+private:
+  void _process_short_header_packet(UDPPacketInternal *p, NetHandler *nh);
+  void _process_long_header_packet(UDPPacketInternal *p, NetHandler *nh);
 };
 
 static inline QUICPollCont *

--- a/iocore/net/P_QUICNet.h
+++ b/iocore/net/P_QUICNet.h
@@ -1,0 +1,60 @@
+/** @file
+
+  A brief file description
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#ifndef __P_QUICNET_H__
+#define __P_QUICNET_H__
+
+#include <bitset>
+
+#include "ts/ink_platform.h"
+
+#include "P_Net.h"
+class NetHandler;
+typedef int (NetHandler::*NetContHandler)(int, void *);
+
+struct QUICPollCont : public Continuation {
+  NetHandler *net_handler;
+  PollDescriptor *pollDescriptor;
+
+  QUICPollCont(Ptr<ProxyMutex> &m);
+  QUICPollCont(Ptr<ProxyMutex> &m, NetHandler *nh);
+  ~QUICPollCont();
+  int pollEvent(int, Event *);
+
+public:
+  // Atomic Queue to save incoming packets
+  ASLL(UDPPacketInternal, alink) inQueue;
+
+  // Internal Queue to save Long Header Packet
+  Que(UDPPacket, link) longInQueue;
+  // Internal Queue to save Short Header Packet
+  Que(UDPPacket, link) shortInQueue;
+};
+
+static inline QUICPollCont *
+get_QUICPollCont(EThread *t)
+{
+  return (QUICPollCont *)ETHREAD_GET_PTR(t, quic_NetProcessor.quicPollCont_offset);
+}
+
+#endif

--- a/iocore/net/P_QUICNetProcessor.h
+++ b/iocore/net/P_QUICNetProcessor.h
@@ -67,6 +67,8 @@ public:
 
   Action *main_accept(Continuation *cont, SOCKET fd, AcceptOptions const &opt) override;
 
+  off_t quicPollCont_offset;
+
 private:
   QUICNetProcessor(const QUICNetProcessor &);
   QUICNetProcessor &operator=(const QUICNetProcessor &);

--- a/iocore/net/P_QUICNetProcessor.h
+++ b/iocore/net/P_QUICNetProcessor.h
@@ -56,6 +56,7 @@ public:
   QUICNetProcessor();
   virtual ~QUICNetProcessor();
 
+  void init() override;
   virtual int start(int, size_t stacksize) override;
   void cleanup();
   // TODO: refactoring NetProcessor::connect_re and UnixNetProcessor::connect_re_internal

--- a/iocore/net/P_QUICNetVConnection.h
+++ b/iocore/net/P_QUICNetVConnection.h
@@ -145,6 +145,9 @@ public:
   QUICNetVConnection() {}
   void init(QUICConnectionId original_cid, UDPConnection *, QUICPacketHandler *, QUICConnectionTable *ctable = nullptr);
 
+  // accept new conn_id
+  int acceptEvent(int event, Event *e);
+
   // UnixNetVConnection
   void reenable(VIO *vio) override;
   VIO *do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf) override;

--- a/iocore/net/P_QUICNetVConnection.h
+++ b/iocore/net/P_QUICNetVConnection.h
@@ -302,4 +302,6 @@ private:
   QUICStatelessResetToken _reset_token;
 };
 
+typedef int (QUICNetVConnection::*QUICNetVConnHandler)(int, void *);
+
 extern ClassAllocator<QUICNetVConnection> quicNetVCAllocator;

--- a/iocore/net/P_UDPNet.h
+++ b/iocore/net/P_UDPNet.h
@@ -59,6 +59,8 @@ extern UDPNetProcessorInternal udpNetInternal;
 #define SLOT_TIME HRTIME_MSECONDS(SLOT_TIME_MSEC)
 #define N_SLOTS 2048
 
+constexpr int UDP_PERIOD = 9;
+
 class PacketQueue
 {
 public:

--- a/iocore/net/QUICNet.cc
+++ b/iocore/net/QUICNet.cc
@@ -1,0 +1,125 @@
+/** @file
+
+  A brief file description
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "P_Net.h"
+
+QUICPollCont::QUICPollCont(Ptr<ProxyMutex> &m)
+  : Continuation(m.get()), net_handler(nullptr)
+{
+  SET_HANDLER(&PollCont::pollEvent);
+}
+
+QUICPollCont::QUICPollCont(Ptr<ProxyMutex> &m, NetHandler *nh)
+  : Continuation(m.get()), net_handler(nh)
+{
+  SET_HANDLER(&QUICPollCont::pollEvent);
+}
+
+QUICPollCont::~QUICPollCont()
+{
+}
+
+//
+// QUICPollCont continuation which traverse the inQueue(ASLL)
+// and create new QUICNetVC for Initial Packet,
+// and push the triggered QUICNetVC into enable list.
+//
+int
+QUICPollCont::pollEvent(int, Event *)
+{
+  UnixUDPConnection *uc;
+  QUICPacketHandler *ph;
+  QUICNetVConnection *vc;
+  QUICConnectionId cid;
+  uint8_t *buf;
+  uint8_t ptype;
+  UDPPacket *packet_r;
+  UDPPacketInternal *p = nullptr;
+  NetHandler *nh       = get_NetHandler(t);
+
+  // Process the ASLL
+  SList(UDPPacketInternal, alink) aq(inQueue.popall());
+  Queue<UDPPacketInternal> result;
+  while ((p = aq.pop())) {
+    result.push(p);
+  }
+
+  while ((p = result.pop())) {
+    uc  = static_cast<UnixUDPConnection *>(p->getConnection());
+    ph  = static_cast<QUICPacketHandler *>(uc->continuation);
+    vc  = static_cast<QUICNetVConnection *>(p->data.ptr);
+    buf = (uint8_t *)p->getIOBlockChain()->buf();
+    cid = QUICPacket::connection_id(buf)
+    if (buf[0] & 0x80) { // Long Header Packet with Connection ID, has a valid type value.
+      ptype = buf[0] & 0x7f;
+      if (ptype == QUICPacketType::INITIAL) { // Initial Packet
+        vc->read.triggered = 1;
+        vc->push_packet(p);
+        // reschedule the vc and callback vc->acceptEvent
+        this_ethread()->schedule_imm(vc);
+      } elseif (ptype == QUICPacketType::ZERO_RTT_PROTECTED) { // 0-RTT Packet
+        // TODO:
+      } elseif (ptype == QUICPacketType::HANDSHAKE) { // Handshake Packet
+        if (vc) {
+          vc->read.triggered = 1;
+          vc->push_packet(p);
+        } else {
+          longInQueue.push(p);
+        }
+      } else {
+        ink_assert(!"not reached!");
+      }
+    } elseif (buf[0] & 0x40) { // Short Header Packet with Connection ID, has a valid type value.
+      if (vc) {
+        vc->read.triggered = 1;
+        vc->push_packet(p);
+      } else {
+        shortInQueue.push(p);
+      }
+    } else {
+      ink_assert(!"not reached!");
+    }
+
+    // Push QUICNetVC into nethandler's enabled list
+    if (vc != nullptr) {
+      int isin = ink_atomic_swap(&vc->read.in_enabled_list, 1);
+      if (!isin) {
+        nh->read_enable_list.push(vc);
+      }
+    }
+  }
+  
+  return EVENT_CONT;
+}
+
+void
+initialize_thread_for_quic_net(EThread *thread)
+{
+  NetHandler *nh       = get_NetHandler(thread);
+  QUICPollCont *quicpc = get_QUICPollCont(thread);
+
+  new ((ink_dummy_for_new *)quicpc) QUICPollCont(thread->mutex, nh);
+
+  thread->schedule_every(quicpc, -9);
+}
+

--- a/iocore/net/QUICNet.cc
+++ b/iocore/net/QUICNet.cc
@@ -154,5 +154,5 @@ initialize_thread_for_quic_net(EThread *thread)
 
   new ((ink_dummy_for_new *)quicpc) QUICPollCont(thread->mutex, nh);
 
-  thread->schedule_every(quicpc, -9);
+  thread->schedule_every(quicpc, -UDP_PERIOD);
 }

--- a/iocore/net/QUICNetProcessor.cc
+++ b/iocore/net/QUICNetProcessor.cc
@@ -50,6 +50,16 @@ QUICNetProcessor::cleanup()
   SSL_CTX_free(this->_ssl_ctx);
 }
 
+void
+QUICNetProcessor::init()
+{
+  // first we allocate a QUICPollCont.
+  this->quicPollCont_offset = eventProcessor.allocate(sizeof(QUICPollCont));
+
+  // schedule event
+  eventProcessor.schedule_spawn(&initialize_thread_for_quic_net, ET_NET);
+}
+
 int
 QUICNetProcessor::start(int, size_t stacksize)
 {

--- a/iocore/net/QUICNetProcessor.cc
+++ b/iocore/net/QUICNetProcessor.cc
@@ -181,6 +181,8 @@ QUICNetProcessor::connect_re(Continuation *cont, sockaddr const *remote_addr, Ne
   vc->mutex       = cont->mutex;
   vc->action_     = cont;
 
+  SET_CONTINUATION_HANDLER(vc, &QUICNetVConnection::state_pre_handshake);
+
   vc->start(this->_ssl_ctx);
   vc->connectUp(t, NO_FD);
 

--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -70,6 +70,7 @@ QUICNetVConnection::init(QUICConnectionId original_cid, UDPConnection *udp_con, 
   this->_packet_handler              = packet_handler;
   this->_original_quic_connection_id = original_cid;
   this->_quic_connection_id.randomize();
+  this->ep.syscall = false;
   // PacketHandler for out going connection doesn't have connection table
   if (ctable) {
     this->_ctable = ctable;

--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -117,6 +117,7 @@ QUICNetVConnection::acceptEvent(int event, Event *e)
     free(t);
     return EVENT_DONE;
   }
+  this->read.enabled = 1;
 
   // Handshake callback handler.
   SET_HANDLER((NetVConnHandler)&QUICNetVConnection::state_pre_handshake);

--- a/iocore/net/QUICPacketHandler.cc
+++ b/iocore/net/QUICPacketHandler.cc
@@ -124,7 +124,8 @@ QUICPacketHandlerIn::init_accept(EThread *t = nullptr)
 void
 QUICPacketHandlerIn::_recv_packet(int event, UDPPacket *udp_packet)
 {
-  EThread *eth;
+  EThread *eth           = nullptr;
+  QUICPollEvent *qe      = nullptr;
   QUICNetVConnection *vc = nullptr;
   IOBufferBlock *block   = udp_packet->getIOBlockChain();
 
@@ -185,10 +186,13 @@ QUICPacketHandlerIn::_recv_packet(int event, UDPPacket *udp_packet)
     eth = vc->thread;
   }
 
-  // Push the packet into QUICPollCont
-  udp_packet->data.ptr = vc;
+  qe = quicPollEventAllocator.alloc();
+
+  qe->data.ptr = vc;
   // should we use dynamic_cast ??
-  get_QUICPollCont(eth)->inQueue.push(static_cast<UDPPacketInternal *>(udp_packet));
+  qe->packet = static_cast<UDPPacketInternal *>(udp_packet);
+  // Push the packet into QUICPollCont
+  get_QUICPollCont(eth)->inQueue.push(qe);
 }
 
 // TODO: Should be called via eventProcessor?

--- a/iocore/net/UnixUDPNet.cc
+++ b/iocore/net/UnixUDPNet.cc
@@ -86,7 +86,7 @@ initialize_thread_for_udp_net(EThread *thread)
   REC_ReadConfigInt32(g_udp_numSendRetries, "proxy.config.udp.send_retries");
   g_udp_numSendRetries = g_udp_numSendRetries < 0 ? 0 : g_udp_numSendRetries;
 
-  thread->schedule_every(get_UDPPollCont(thread), -9);
+  thread->schedule_every(get_UDPPollCont(thread), -UDP_PERIOD);
   thread->schedule_imm(get_UDPNetHandler(thread));
 }
 
@@ -923,7 +923,7 @@ UDPNetHandler::startNetEvent(int event, Event *e)
   (void)event;
   SET_HANDLER((UDPNetContHandler)&UDPNetHandler::mainNetEvent);
   trigger_event = e;
-  e->schedule_every(-HRTIME_MSECONDS(9));
+  e->schedule_every(-HRTIME_MSECONDS(UDP_PERIOD));
   return EVENT_CONT;
 }
 

--- a/iocore/net/UnixUDPNet.cc
+++ b/iocore/net/UnixUDPNet.cc
@@ -86,7 +86,7 @@ initialize_thread_for_udp_net(EThread *thread)
   REC_ReadConfigInt32(g_udp_numSendRetries, "proxy.config.udp.send_retries");
   g_udp_numSendRetries = g_udp_numSendRetries < 0 ? 0 : g_udp_numSendRetries;
 
-  thread->schedule_every(get_UDPPollCont(thread), -UDP_PERIOD);
+  thread->schedule_every(get_UDPPollCont(thread), -HRTIME_MSECONDS(UDP_PERIOD));
   thread->schedule_imm(get_UDPNetHandler(thread));
 }
 

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -1800,6 +1800,10 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   // Do the inits for NetProcessors that use ET_NET threads. MUST be before starting those threads.
   netProcessor.init();
   init_HttpProxyServer();
+#if TS_USE_QUIC == 1
+  // OK, pushing a spawn scheduling here
+  quic_NetProcessor.init();
+#endif
 
   // !! ET_NET threads start here !!
   // This means any spawn scheduling must be done before this point.


### PR DESCRIPTION
Base on @oknet design.

We create QUICPollCont to dispatch UDPacket to different qvc. And NetHandler will callback to qvc handler to process packet.