### PR TITLE
Do not propagate origin Connection:close to client http/2 session.

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -586,19 +586,6 @@ Http2Stream::update_write_request(IOBufferReader *buf_reader, int64_t write_len,
       case PARSE_RESULT_DONE: {
         this->response_header_done = true;
 
-        // Schedule session shutdown if response header has "Connection: close"
-        MIMEField *field = this->response_header.field_find(MIME_FIELD_CONNECTION, MIME_LEN_CONNECTION);
-        if (field) {
-          int len;
-          const char *value = field->value_get(&len);
-          if (memcmp(HTTP_VALUE_CLOSE, value, HTTP_LEN_CLOSE) == 0) {
-            SCOPED_MUTEX_LOCK(lock, this->mutex, this_ethread());
-            if (parent->connection_state.get_shutdown_state() == HTTP2_SHUTDOWN_NONE) {
-              parent->connection_state.set_shutdown_state(HTTP2_SHUTDOWN_NOT_INITIATED);
-            }
-          }
-        }
-
         // Send the response header back
         parent->connection_state.send_headers_frame(this);
 


### PR DESCRIPTION
This is a concern about the commit created from PR #2106.  I like the commit in general, but this bit that closes the HTTP2 session if the origin response comes back with Connection: close seems wrong.

In the HTTP/1.1 case we do not propagate connection close from origin to client.  According the HTTP standard the connection header is a hop-by-hop header and should not be propagated in any case.  The HttpTransactHeaders::copy_header_fields() will drop the hop-by-hop headers when moving between client and origin (or origin and client).

I noticed this while testing a build.  The http2 test would fail due to errors about not being able to start new streams due to a half open session.  Track it down to the fact that the shutdown timer was being initiated after the first response (which had the connection: close header).