### PR TITLE
Make string_view available in plugin cppapi.

### DIFF
--- a/lib/ts/Makefile.am
+++ b/lib/ts/Makefile.am
@@ -20,7 +20,7 @@ include $(top_srcdir)/build/tidy.mk
 
 library_includedir=$(includedir)/ts
 
-library_include_HEADERS = apidefs.h
+library_include_HEADERS = apidefs.h string_view.h
 
 noinst_PROGRAMS = mkdfa CompileParseRules
 check_PROGRAMS = test_tsutil test_arena test_atomic test_freelist test_geometry test_List test_Map test_Vec test_X509HostnameValidator test_Scalar test_tslib


### PR DESCRIPTION
The diff that git/github displays is misleading.  The change is simply to move string_view.h to lib/cppapi/include/atscppapi and create a symbolic link to it from it's old location in lib/ts .