### PR TITLE
Race condition when starting accept threads

### DIFF
--- a/iocore/net/P_NetAccept.h
+++ b/iocore/net/P_NetAccept.h
@@ -39,6 +39,7 @@
 #ifndef __P_NETACCEPT_H__
 #define __P_NETACCEPT_H__
 
+#include <vector>
 #include "ts/ink_platform.h"
 #include "P_Connection.h"
 
@@ -113,5 +114,8 @@ struct NetAccept : public Continuation {
   explicit NetAccept(const NetProcessor::AcceptOptions &);
   virtual ~NetAccept() { action_ = nullptr; }
 };
+
+extern Ptr<ProxyMutex> naVecMutex;
+extern std::vector<NetAccept *> naVec;
 
 #endif

--- a/iocore/net/SSLSNIConfig.cc
+++ b/iocore/net/SSLSNIConfig.cc
@@ -42,7 +42,6 @@
 
 static ConfigUpdateHandler<SNIConfig> *sniConfigUpdate;
 struct NetAccept;
-extern std::vector<NetAccept *> naVec;
 Map<int, SSLNextProtocolSet *> snpsMap;
 extern TunnelHashMap TunnelMap;
 NextHopProperty::NextHopProperty()
@@ -226,6 +225,7 @@ SNIConfig::startup()
 void
 SNIConfig::cloneProtoSet()
 {
+  SCOPED_MUTEX_LOCK(lock, naVecMutex, this_ethread());
   for (auto na : naVec) {
     if (na->snpa) {
       auto snps = na->snpa->cloneProtoSet();

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -31,6 +31,9 @@
 using NetAcceptHandler = int (NetAccept::*)(int, void *);
 int accept_till_done   = 1;
 
+// we need to protect naVec since it might be accessed
+// in different threads at the same time
+Ptr<ProxyMutex> naVecMutex;
 std::vector<NetAccept *> naVec;
 static void
 safe_delay(int msec)
@@ -139,6 +142,7 @@ Ldone:
 NetAccept *
 getNetAccept(int ID)
 {
+  SCOPED_MUTEX_LOCK(lock, naVecMutex, this_ethread());
   return naVec.at(ID);
 }
 

--- a/iocore/net/UnixNetProcessor.cc
+++ b/iocore/net/UnixNetProcessor.cc
@@ -30,7 +30,6 @@
 #include "StatPages.h"
 
 int net_accept_number = 0;
-extern std::vector<NetAccept *> naVec;
 NetProcessor::AcceptOptions const NetProcessor::DEFAULT_ACCEPT_OPTIONS;
 
 NetProcessor::AcceptOptions &
@@ -174,7 +173,12 @@ UnixNetProcessor::accept_internal(Continuation *cont, int fd, AcceptOptions cons
   } else {
     na->init_accept(nullptr);
   }
-  naVec.push_back(na);
+
+  {
+    SCOPED_MUTEX_LOCK(lock, naVecMutex, this_ethread());
+    naVec.push_back(na);
+  }
+
 #ifdef TCP_DEFER_ACCEPT
   // set tcp defer accept timeout if it is configured, this will not trigger an accept until there is
   // data on the socket ready to be read

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -9289,12 +9289,13 @@ TSAcceptorGet(TSVConn sslp)
   return ssl_vc ? reinterpret_cast<TSAcceptor>(ssl_vc->accept_object) : nullptr;
 }
 
-extern std::vector<NetAccept *> naVec;
 TSAcceptor
 TSAcceptorGetbyID(int ID)
 {
-  Debug("ssl", "getNetAccept in INK API.cc %p", naVec.at(ID));
-  return reinterpret_cast<TSAcceptor>(naVec.at(ID));
+  SCOPED_MUTEX_LOCK(lock, naVecMutex, this_ethread());
+  auto ret = naVec.at(ID);
+  Debug("ssl", "getNetAccept in INK API.cc %p", ret);
+  return reinterpret_cast<TSAcceptor>(ret);
 }
 
 int
@@ -9307,6 +9308,7 @@ TSAcceptorIDGet(TSAcceptor acceptor)
 int
 TSAcceptorCount()
 {
+  SCOPED_MUTEX_LOCK(lock, naVecMutex, this_ethread());
   return naVec.size();
 }
 

--- a/proxy/http/HttpProxyServerMain.cc
+++ b/proxy/http/HttpProxyServerMain.cc
@@ -39,6 +39,7 @@
 #include "ProtocolProbeSessionAccept.h"
 #include "http2/Http2SessionAccept.h"
 #include "HttpConnectionCount.h"
+#include "HttpProxyServerMain.h"
 
 #include <vector>
 
@@ -47,6 +48,15 @@ HttpSessionAccept *plugin_http_transparent_accept = nullptr;
 
 static SLL<SSLNextProtocolAccept> ssl_plugin_acceptors;
 static Ptr<ProxyMutex> ssl_plugin_mutex;
+
+// used to keep count of how many et_net threads we have started
+std::atomic<int> started_et_net_threads;
+std::mutex proxyServerMutex;
+std::condition_variable proxyServerCheck;
+bool et_net_threads_ready = false;
+
+extern int num_of_net_threads;
+extern int num_accept_threads;
 
 bool
 ssl_register_protocol(const char *protocol, Continuation *contp)
@@ -227,7 +237,7 @@ MakeHttpProxyAcceptor(HttpProxyAcceptor &acceptor, HttpProxyPort &port, unsigned
 
 /// Do all pre-thread initialization / setup.
 void
-init_HttpProxyServer()
+prep_HttpProxyServer()
 {
   httpSessionManager.init();
 }
@@ -274,6 +284,25 @@ init_accept_HttpProxyServer(int n_accept_threads)
   }
 }
 
+/** Increment the counter to keep track of how many et_net threads
+ *  we have started. This function is scheduled at the start of each
+ *  et_net thread using schedule_spawn(). We also check immediately
+ *  after incrementing the counter to see whether all of the et_net
+ *  threads have started such that we can notify main() to call
+ *  start_HttpProxyServer().
+ */
+void
+init_HttpProxyServer(EThread *)
+{
+  auto check_et_net_num = ++started_et_net_threads;
+  if (check_et_net_num == num_of_net_threads) {
+    std::unique_lock<std::mutex> lock(proxyServerMutex);
+    et_net_threads_ready = true;
+    lock.unlock();
+    proxyServerCheck.notify_one();
+  }
+}
+
 void
 start_HttpProxyServer()
 {
@@ -317,6 +346,14 @@ start_HttpProxyServer()
   while (hook) {
     hook->invoke(TS_EVENT_LIFECYCLE_PORTS_READY, nullptr);
     hook = hook->next();
+  }
+
+  // Start the back door, since it's just a special HttpProxyServer,
+  // the requirements to start it has been met if we got here.
+  int back_door_port = NO_FD;
+  REC_ReadConfigInteger(back_door_port, "proxy.config.process_manager.mgmt_port");
+  if (back_door_port != NO_FD) {
+    start_HttpProxyServerBackDoor(back_door_port, !!num_accept_threads); // One accept thread is enough
   }
 }
 

--- a/proxy/http/HttpProxyServerMain.h
+++ b/proxy/http/HttpProxyServerMain.h
@@ -21,17 +21,25 @@
   limitations under the License.
  */
 
+#include <atomic>
+#include <mutex>
+#include <condition_variable>
+
 struct HttpProxyPort;
 
 /// Perform any pre-thread start initialization.
-void init_HttpProxyServer();
+void prep_HttpProxyServer();
 
 /** Initialize all HTTP proxy port data structures needed to accept connections.
  */
 void init_accept_HttpProxyServer(int n_accept_threads = 0);
 
+/** Checkes whether we can call start_HttpProxyServer().
+ */
+void init_HttpProxyServer(EThread *);
+
 /** Start the proxy server.
-    The port data should have been created by @c init_HttpProxyServer().
+    The port data should have been created by @c prep_HttpProxyServer().
 */
 void start_HttpProxyServer();
 
@@ -40,3 +48,8 @@ void stop_HttpProxyServer();
 void start_HttpProxyServerBackDoor(int port, int accept_threads = 0);
 
 NetProcessor::AcceptOptions make_net_accept_options(const HttpProxyPort *port, unsigned nthreads);
+
+extern std::atomic<int> started_et_net_threads;
+extern std::mutex proxyServerMutex;
+extern std::condition_variable proxyServerCheck;
+extern bool et_net_threads_ready;


### PR DESCRIPTION
Fixing a race condition when starting accept threads. This race condition only happens when setting accept threads to 0 in the config, so it doesn't show up quite frequently. The problem was caused by in some rare cases, start_HttpProxyServer() is being called before et_net threads are initialized.