### PR TITLE
Fix a bug that chunked resopnses aren't logged properly if the client side is H2

### DIFF
--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -75,6 +75,11 @@ public:
   mark_body_done()
   {
     body_done = true;
+    if (response_is_chunked()) {
+      ink_assert(chunked_handler.state == ChunkedHandler::CHUNK_READ_DONE ||
+                 chunked_handler.state == ChunkedHandler::CHUNK_READ_ERROR);
+      this->write_vio.nbytes = response_header.length_get() + chunked_handler.dechunked_size;
+    }
   }
 
   void


### PR DESCRIPTION
If a response from an origin server is chunked, `write_vio.ndone` won't reach `write_vio.nbytes` because `nbytes` include chunk sizes but `ndone` doesn't. It confuses closing process and the transaction will be logged as aborted (ERR_CLIENT_ABORT).