### PR TITLE
Make throttling feature more useful.

### DIFF
--- a/iocore/net/Net.cc
+++ b/iocore/net/Net.cc
@@ -112,6 +112,11 @@ register_net_stats()
   RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.tcp.total_accepts", RECD_INT, RECP_NON_PERSISTENT,
                      static_cast<int>(net_tcp_accept_stat), RecRawStatSyncSum);
   NET_CLEAR_DYN_STAT(net_tcp_accept_stat);
+
+  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.connections_throttled_in", RECD_INT, RECP_PERSISTENT,
+                     (int)net_connections_throttled_in_stat, RecRawStatSyncSum);
+  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.connections_throttled_out", RECD_INT, RECP_PERSISTENT,
+                     (int)net_connections_throttled_out_stat, RecRawStatSyncSum);
 }
 
 void

--- a/iocore/net/P_Net.h
+++ b/iocore/net/P_Net.h
@@ -56,6 +56,8 @@ enum Net_Stats {
   net_fastopen_attempts_stat,
   net_fastopen_successes_stat,
   net_tcp_accept_stat,
+  net_connections_throttled_in_stat,
+  net_connections_throttled_out_stat,
   Net_Stat_Count
 };
 

--- a/iocore/net/UnixNet.cc
+++ b/iocore/net/UnixNet.cc
@@ -25,7 +25,6 @@
 
 ink_hrtime last_throttle_warning;
 ink_hrtime last_shedding_warning;
-ink_hrtime emergency_throttle_time;
 int net_connections_throttle;
 bool net_memory_throttle = false;
 int fds_throttle;

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -38,6 +38,29 @@ safe_delay(int msec)
   socketManager.poll(nullptr, 0, msec);
 }
 
+static int
+drain_throttled_accepts(NetAccept *na)
+{
+  struct pollfd afd;
+  Connection con[THROTTLE_AT_ONCE];
+
+  afd.fd     = na->server.fd;
+  afd.events = POLLIN;
+
+  // Try to close at most THROTTLE_AT_ONCE accept requests
+  // Stop if there is nothing waiting
+  int n = 0;
+  for (; n < THROTTLE_AT_ONCE && socketManager.poll(&afd, 1, 0) > 0; n++) {
+    int res = 0;
+    if ((res = na->server.accept(&con[n])) < 0) {
+      return res;
+    }
+    con[n].close();
+  }
+  // Return the number of accept cases we closed
+  return n;
+}
+
 //
 // General case network connection accept code
 //
@@ -253,7 +276,19 @@ NetAccept::do_blocking_accept(EThread *t)
   do {
     ink_hrtime now = Thread::get_hrtime();
 
+    // Throttle accepts
+    while (!opt.backdoor && check_net_throttle(ACCEPT)) {
+      check_throttle_warning(ACCEPT);
+      int num_throttled = drain_throttled_accepts(this);
+      if (num_throttled < 0) {
+        goto Lerror;
+      }
+      NET_SUM_DYN_STAT(net_connections_throttled_in_stat, num_throttled);
+      now = Thread::get_hrtime();
+    }
+
     if ((res = server.accept(&con)) < 0) {
+    Lerror:
       int seriousness = accept_error_seriousness(res);
       if (seriousness >= 0) { // not so bad
         if (!seriousness) {   // bad enough to warn about
@@ -268,20 +303,6 @@ NetAccept::do_blocking_accept(EThread *t)
         Warning("accept thread received fatal error: errno = %d", errno);
       }
       return -1;
-    }
-
-    // Throttle accepts
-    if (!opt.backdoor && (check_net_throttle(ACCEPT, now) || net_memory_throttle)) {
-      Debug("net_accept", "Too many connections or too much memory used, throttling");
-      check_throttle_warning();
-      con.close();
-      continue;
-    }
-
-    // The con.fd may exceed the limitation of check_net_throttle() because we do blocking accept here.
-    if (check_emergency_throttle(con)) {
-      con.close();
-      return 0;
     }
 
     // Use 'nullptr' to Bypass thread allocator
@@ -374,7 +395,7 @@ NetAccept::acceptFastEvent(int event, void *ep)
   int loop               = accept_till_done;
 
   do {
-    if (!opt.backdoor && check_net_throttle(ACCEPT, Thread::get_hrtime())) {
+    if (!opt.backdoor && check_net_throttle(ACCEPT)) {
       ifd = NO_FD;
       return EVENT_CONT;
     }

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1234,9 +1234,10 @@ UnixNetVConnection::connectUp(EThread *t, int fd)
   int res;
 
   thread = t;
-  if (check_net_throttle(CONNECT, submit_time)) {
-    check_throttle_warning();
+  if (check_net_throttle(CONNECT)) {
+    check_throttle_warning(CONNECT);
     res = -ENET_THROTTLING;
+    NET_INCREMENT_DYN_STAT(net_connections_throttled_out_stat);
     goto fail;
   }
 
@@ -1272,13 +1273,6 @@ UnixNetVConnection::connectUp(EThread *t, int fd)
     con.fd           = fd;
     con.is_connected = true;
     con.is_bound     = true;
-  }
-
-  if (check_emergency_throttle(con)) {
-    // Set errno force to EMFILE (reached limit for open file descriptors)
-    errno = EMFILE;
-    res   = -errno;
-    goto fail;
   }
 
   // Must connect after EventIO::Start() to avoid a race condition

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -1795,6 +1795,9 @@ HttpSM::state_http_server_open(int event, void *data)
       }
       t_state.client_info.keep_alive = HTTP_NO_KEEPALIVE; // part of the problem, clear it.
       terminate_sm                   = true;
+    } else if (ENET_THROTTLING == t_state.current.server->connect_result) {
+      HTTP_INCREMENT_DYN_STAT(http_origin_connections_throttled_stat);
+      send_origin_throttled_response();
     } else {
       call_transact_and_set_next_state(HttpTransact::HandleResponse);
     }

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -181,7 +181,6 @@ class PostDataBuffers
 {
 public:
   PostDataBuffers() { Debug("http_redirect", "[PostDataBuffers::PostDataBuffers]"); }
-
   MIOBuffer *postdata_copy_buffer            = nullptr;
   IOBufferReader *postdata_copy_buffer_start = nullptr;
   IOBufferReader *ua_buffer_reader           = nullptr;


### PR DESCRIPTION
The existing throttling feature "queues" and reattempts the throttled connection later.  In our experience this causes an already over-loaded system to fall over.  This PR replaces the delay and retry with an immediate failure return to the client.  This makes it more likely that the system will survive.

This approach still isn't great because the the throttle limit is a global metric, and the per thread values are only gathered once every couple seconds, so there is a lag.  But that can be a later fix.