### PR TITLE
Corrects off-by-one error, adds test

### DIFF
--- a/lib/ts/BufferWriter.h
+++ b/lib/ts/BufferWriter.h
@@ -308,7 +308,7 @@ public:
 
     _capacity += n;
 
-    ink_assert(_capacity < N);
+    ink_assert(_capacity <= N);
 
     return *this;
   }

--- a/lib/ts/unit-tests/test_BufferWriter.cc
+++ b/lib/ts/unit-tests/test_BufferWriter.cc
@@ -320,3 +320,20 @@ TEST_CASE("Buffer Writer << operator", "[BW<<]")
 
   REQUIRE(bw.view() == "The quick brown fox");
 }
+
+TEST_CASE("LocalBufferWriter clip and extend")
+{
+  ts::LocalBufferWriter<10> bw;
+
+  bw.clip(7);
+  bw << "aaaaaa";
+  REQUIRE(bw.view() == "aaa");
+
+  bw.extend(3);
+  bw << "bbbbbb";
+  REQUIRE(bw.view() == "aaabbb");
+
+  bw.extend(4);
+  bw.write(static_cast<size_t>(snprintf(bw.auxBuffer(), bw.remaining(), "ccc")));
+  REQUIRE(bw.view() == "aaabbbccc");
+}


### PR DESCRIPTION
Milestone: 8.0.0
Labels: Backports, Core
Project: 7.x releases

Backport Rationale: This fix is needed for another PR that we wish to backport: #3081 