### PR TITLE
Adds a new header_rewrite condition %{CIDR}

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -288,6 +288,39 @@ arguments to another operator. For example::
 
     set-header ATS-Req-UUID %{ID:UNIQUE}
 
+CIDR
+~~
+::
+
+   set-header @Client-CIDR %{CIDR:24,48}
+
+This condition takes the client IP, and applies the provided CIDR style masks
+to the IP, before producing a string. The typical use of this conditions is as
+above, producing a header that contains a IP representation which has some
+privacy properties. It can of course also be used as a regular condition, and
+the output is a string that can be compared against. The two optional
+arguments are as follows:
+
+    IPv4-Mask    Length, in bits, of the IPv4 address to preserve. Default: 24
+    IPv6-Mask    Length, in bits, of the IPv6 address to preserve. Default: 48
+
+The two arguments, if provided, are comma separated. Valid syntax includes
+
+    %{CIDR}         Defaults to 24,48 (as above)
+    %{CIDR:16}      IPv4 CIDR mask is 16 bits, IPv6 mask is 48
+    %{CIDR:18,42}   IPv4 CIDR mask is 18 bits, IPv6 mask is 42 bits
+
+A typical use case is to insert the @-prefixed header as above, and then use
+this header in a custom log format, rather than logging the full client
+IP. Another use case could be to make a special condition on a sub-net,
+e.g. ::
+
+    cond %{CIDR:8} ="8.0.0.0"
+        set-header X-Is-Eight "Yes"
+
+This condition has no requirements other than access to the Client IP, hence,
+it should work in any and all hooks.
+
 INBOUND
 ~~~~~~~
 ::

--- a/plugins/header_rewrite/conditions.h
+++ b/plugins/header_rewrite/conditions.h
@@ -498,6 +498,38 @@ private:
   IdQualifiers _id_qual;
 };
 
+// cidr: A CIDR masked string representation of the Client's IP.
+class ConditionCidr : public Condition
+{
+  using MatcherType = Matchers<std::string>;
+  using self        = ConditionCidr;
+
+public:
+  explicit ConditionCidr()
+  {
+    _create_masks(); // This must be called here, because we might not have parameters specified
+    TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for ConditionCidr");
+  };
+
+  ConditionCidr(self &) = delete;
+  self &operator=(self &) = delete;
+
+  void initialize(Parser &p);
+  void set_qualifier(const std::string &q);
+  void append_value(std::string &s, const Resources &res);
+
+protected:
+  bool eval(const Resources &res);
+
+private:
+  void _create_masks();
+  int _v4_cidr = 24;
+  int _v6_cidr = 48;
+  struct in_addr _v4_mask; // We do a 32-bit & using this mask, for efficiency
+  unsigned char _v6_mask;  // Only need one byte here, since we memset the rest (see next)
+  int _v6_zero_bytes;      // How many initial bytes to memset to 0
+};
+
 /// Information about the inbound (client) session.
 class ConditionInbound : public Condition
 {

--- a/plugins/header_rewrite/factory.cc
+++ b/plugins/header_rewrite/factory.cc
@@ -141,6 +141,8 @@ condition_factory(const std::string &cond)
     c = new ConditionGeo();
   } else if (c_name == "ID") {
     c = new ConditionId();
+  } else if (c_name == "CIDR") {
+    c = new ConditionCidr();
   } else if (c_name == "INBOUND") {
     c = new ConditionInbound();
   } else {


### PR DESCRIPTION
This can be used to produced a header (typically an @ header) which
can then be used in a custom log format to anonymize the client IP
address. But, one could for example put this into a header that gets
sent to the Origin server as well, again anonymized.