### PR TITLE
Handle MIME hdr parsing edge case

### DIFF
--- a/proxy/hdrs/MIME.cc
+++ b/proxy/hdrs/MIME.cc
@@ -2485,9 +2485,15 @@ mime_scanner_get(MIMEScanner *S, const char **raw_input_s, const char *raw_input
         zret = PARSE_RESULT_ERROR; // Unterminated field.
       }
     } else if (data_size) {
-      // Inside a field but more data is expected. Save what we've got.
-      mime_scanner_append(S, *raw_input_s, data_size);
-      data_size = 0; // Don't append again.
+      if (MIME_PARSE_INSIDE == S->m_state) {
+        // Inside a field but more data is expected. Save what we've got.
+        mime_scanner_append(S, *raw_input_s, data_size);
+        data_size = 0; // Don't append again.
+      } else if (MIME_PARSE_AFTER == S->m_state) {
+        // After a field but we still have data. Need to parse it too.
+        S->m_state = MIME_PARSE_BEFORE;
+        zret       = PARSE_RESULT_OK;
+      }
     }
   }
 


### PR DESCRIPTION
Change to handle edge case: FIN and Data sent in a single TCP packet, also only a single line feed at the end of the header. This causes the last MIME field to be missed in the parsing of the header.

Cause: because single CR LF, in MIME.cc:2427(case MIME_PARSE_INSIDE) raw_input_c = raw_input_e and zret = PARSE_RESULT_CONT (default) and S->m_state = MIME_PARSE_AFTER. This causes to it exit the loop rather than iterating once more and setting zret = PARSE_RESULT_OK to parse the field. When it goes to MIME.cc:2487 it thinks there is more data coming and appends it. When the SM re-enters, to MIME.cc:2461 raw_input_eof = true and data_size = 0, and thus returns PARSE_RESULT_DONE. So it gets a signal that parsing is finished even though there was data appended that hadn't been parsed.

Fix: If we have data and are in MIME_PARSE_AFTER, force it to parse at this point (PARSE_RESULT_OK) rather than appending and sending PARSE_RESULT_CONT. Thus, when the SM re-enters and sends PARSE_RESULT_DONE, all field will have actually been parsed.