### PR TITLE
Drain all of udp packets and make sure PollCont run before UDPNetHandler

### DIFF
--- a/iocore/net/P_UDPNet.h
+++ b/iocore/net/P_UDPNet.h
@@ -59,7 +59,8 @@ extern UDPNetProcessorInternal udpNetInternal;
 #define SLOT_TIME HRTIME_MSECONDS(SLOT_TIME_MSEC)
 #define N_SLOTS 2048
 
-constexpr int UDP_PERIOD = 9;
+constexpr int UDP_PERIOD    = 9;
+constexpr int UDP_NH_PERIOD = UDP_PERIOD + 1;
 
 class PacketQueue
 {

--- a/iocore/net/UnixUDPNet.cc
+++ b/iocore/net/UnixUDPNet.cc
@@ -923,7 +923,7 @@ UDPNetHandler::startNetEvent(int event, Event *e)
   (void)event;
   SET_HANDLER((UDPNetContHandler)&UDPNetHandler::mainNetEvent);
   trigger_event = e;
-  e->schedule_every(-HRTIME_MSECONDS(UDP_PERIOD));
+  e->schedule_every(-HRTIME_MSECONDS(UDP_NH_PERIOD));
   return EVENT_CONT;
 }
 


### PR DESCRIPTION
Since we don't schedule the recv event anymore (callback by nethandler), we should walk through the recv queue and handle every udp packet.