### PR TITLE
Add move operator and constructor to Result and TextBuffer

### DIFF
--- a/lib/ts/Result.h
+++ b/lib/ts/Result.h
@@ -32,7 +32,21 @@
 // the success case. Arguably it ought to just be Error(), but Diags.h
 // already owns that name.
 
+#include <utility>
 struct Result {
+  Result() {}
+
+  Result &
+  operator=(Result &&other)
+  {
+    if (this != &other) {
+      buf = std::move(other.buf);
+    }
+    return *this;
+  }
+
+  Result(Result &&other) { *this = std::move(other); }
+
   bool
   failed() const
   {

--- a/lib/ts/TextBuffer.h
+++ b/lib/ts/TextBuffer.h
@@ -33,6 +33,7 @@
  ****************************************************************************/
 
 #include "ts/ink_platform.h"
+#include "ts/ink_memory.h"
 #include "ts/ink_apidefs.h"
 
 #include <stdarg.h>
@@ -46,6 +47,16 @@ public:
     if (!rhs.empty()) {
       copyFrom(rhs.bufPtr(), rhs.spaceUsed());
     }
+  }
+  TextBuffer &
+  operator=(TextBuffer &&other)
+  {
+    if (this != &other) {
+      ats_free(bufferStart);
+      bufferStart       = other.bufferStart;
+      other.bufferStart = nullptr;
+    }
+    return *this;
   }
 
   TextBuffer(int size);


### PR DESCRIPTION
TextBuffer has a copy constructor but it's not used on some paths, and it causes a double free (#3101). It seems like "move" is used on the path.

I'm really not sure this is an appropriate approach. Please take a look carefully.