### PR TITLE
x-debug log-headers propagation and documentation

### DIFF
--- a/doc/admin-guide/plugins/xdebug.en.rst
+++ b/doc/admin-guide/plugins/xdebug.en.rst
@@ -54,6 +54,12 @@ Diags
     transaction specific diagnostics for the transaction. This also requires
     that :ts:cv:`proxy.config.diags.debug.enabled` is set to ``1``.
 
+log-headers
+    If the ``log-headers`` is requested while :ts:cv:`proxy.config.diags.debug.tags` 
+    is set to ``xdebug.headers`` and :ts:cv:`proxy.config.diags.debug.enabled` is set to ``1``, 
+    then all client and server, request and response headers are logged. 
+    Also, the ``X-Debug: log-headers`` header is always added to the upstream request.
+
 X-Cache-Key
     The ``X-Cache-Key`` header contains the URL that identifies the HTTP object in the
     Traffic Server cache. This header is particularly useful if a custom cache

--- a/plugins/xdebug/xdebug.cc
+++ b/plugins/xdebug/xdebug.cc
@@ -262,6 +262,10 @@ InjectTxnUuidHeader(TSHttpTxn txn, TSMBuffer buffer, TSMLoc hdr)
 void
 log_headers(TSHttpTxn txn, TSMBuffer bufp, TSMLoc hdr_loc, const char *msg_type)
 {
+  if (!TSIsDebugTagSet(DEBUG_TAG_LOG_HEADERS)) {
+    return;
+  }
+
   TSIOBuffer output_buffer;
   TSIOBufferReader reader;
   TSIOBufferBlock block;
@@ -394,7 +398,7 @@ XScanRequestHeaders(TSCont /* contp */, TSEvent event, void *edata)
       } else if (header_field_eq("diags", value, vsize)) {
         // Enable diagnostics for DebugTxn()'s only
         TSHttpTxnDebugSet(txn, 1);
-      } else if (header_field_eq("log-headers", value, vsize) && TSIsDebugTagSet(DEBUG_TAG_LOG_HEADERS)) {
+      } else if (header_field_eq("log-headers", value, vsize)) {
         xheaders |= XHEADER_X_DUMP_HEADERS;
         log_headers(txn, buffer, hdr, "ClientRequest");
 


### PR DESCRIPTION
Now the log-headers request will propagate upstream even when logging is not enabled on the local box. This makes it easier to use on higher tier caches. 

Also added documentation.