### PR TITLE
Disables the support for multi-range request by default

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -1739,7 +1739,7 @@ Security
    post body larger than this limit the response will be terminated with
    413 - Request Entity Too Large and logged accordingly.
 
-.. ts:cv:: CONFIG proxy.config.http.allow_multi_range INT 1
+.. ts:cv:: CONFIG proxy.config.http.allow_multi_range INT 0
    :reloadable:
    :overridable:
 

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -534,7 +534,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.http.enable_http_stats", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.http.allow_multi_range", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-2]", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.http.allow_multi_range", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-2]", RECA_NULL}
   ,
   // This defaults to a special invalid value so the HTTP transaction handling code can tell that it was not explicitly set.
   {RECT_CONFIG, "proxy.config.http.normalize_ae", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-2]", RECA_NULL}

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -435,7 +435,7 @@ struct OverridableHttpConfigParams {
       cache_required_headers(2),
       cache_range_lookup(1),
       cache_range_write(0),
-      allow_multi_range(1),
+      allow_multi_range(0),
       cache_enable_default_vary_headers(0),
       ignore_accept_mismatch(0),
       ignore_accept_language_mismatch(0),


### PR DESCRIPTION
Deliberately left the default on the original patch, such that it can be cherry-picked to LTS branches without breaking backwards compatibility. This should not be back ported to v6 or v7 IMO.