### PR TITLE
Fix documentation for transaction_active_timeout_in default value.

### DIFF
--- a/doc/admin-guide/performance/index.en.rst
+++ b/doc/admin-guide/performance/index.en.rst
@@ -425,7 +425,8 @@ in seconds, which |TS| will spend sending/receiving data with a client or
 origin server, respectively. If the data transfer has not completed within the
 time specified then the connection will be closed automatically. This may
 result in the lack of a cache update, or partial data transmitted to a client.
-Both timeouts are disabled (set to ``0``) by default.
+:ts:cv:`proxy.config.http.transaction_active_timeout_out` is disabled (set to ``0``) by default.
+:ts:cv:`proxy.config.http.transaction_active_timeout_in` is set to 900 seconds by default.
 
 In general, it's unlikely you will want to enable either of these timeouts
 globally, especially if your cache contains objects of varying sizes and deals
@@ -445,7 +446,7 @@ values prove somewhat more generally applicable.
 
 ::
 
-    CONFIG proxy.config.http.transaction_active_timeout_in INT 0
+    CONFIG proxy.config.http.transaction_active_timeout_in INT 900
     CONFIG proxy.config.http.transaction_active_timeout_out INT 0
     CONFIG proxy.config.http.transaction_no_activity_timeout_in INT 30
     CONFIG proxy.config.http.transaction_no_activity_timeout_out INT 30


### PR DESCRIPTION
Fixing discrepancy in reporting the default value.