### PR TITLE
Doc: Remove man page reference to congestion.config which no longer exists.

### DIFF
--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -36,7 +36,6 @@ man_pages = [
     ('appendices/command-line/traffic_via.en', 'traffic_via', u'Traffic Server Via header decoder', None, '1'),
 
     ('admin-guide/files/cache.config.en', 'cache.config', u'Traffic Server cache configuration file', None, '5'),
-    ('admin-guide/files/congestion.config.en', 'congestion.config', u'Traffic Server congestion control configuration file', None, '5'),
     ('admin-guide/files/hosting.config.en', 'hosting.config', u'Traffic Server domain hosting configuration file', None, '5'),
     ('admin-guide/files/ip_allow.config.en', 'ip_allow.config', u'Traffic Server IP access control configuration file', None, '5'),
     ('admin-guide/files/log_hosts.config.en', 'log_hosts.config', u'Traffic Server log host configuration file', None, '5'),


### PR DESCRIPTION
The man page generation logic is a bit obscure, and so this was missed when congestion control was removed.