### PR TITLE
QUIC: Push closed conn into closed queue

### DIFF
--- a/iocore/net/Makefile.am
+++ b/iocore/net/Makefile.am
@@ -161,11 +161,13 @@ libinknet_a_SOURCES = \
 
 if ENABLE_QUIC
 libinknet_a_SOURCES += \
+  P_QUICClosedConCollector.h \
   P_QUICPacketHandler.h \
   P_QUICNet.h \
   P_QUICNetProcessor.h \
   P_QUICNetVConnection.h \
   P_QUICNextProtocolAccept.h \
+  QUICClosedConCollector.cc \
   QUICPacketHandler.cc \
   QUICNet.cc \
   QUICNetProcessor.cc \

--- a/iocore/net/P_QUICClosedConCollector.h
+++ b/iocore/net/P_QUICClosedConCollector.h
@@ -1,0 +1,39 @@
+/** @file
+  This file implements an I/O Processor for network I/O
+  @section license License
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#ifndef _QUIC_CLOSED_CON_COLLECTOR_H_
+#define _QUIC_CLOSED_CON_COLLECTOR_H_
+
+#include "P_QUICNetVConnection.h"
+
+class QUICClosedConCollector : public Continuation
+{
+public:
+  QUICClosedConCollector();
+
+  int mainEvent(int event, Event *e);
+
+  ASLL(QUICNetVConnection, closed_alink) closedQueue;
+
+private:
+  Que(QUICNetVConnection, closed_link) _localClosedQueue;
+
+  void _process_closed_connection(EThread *t);
+};
+
+#endif

--- a/iocore/net/P_QUICNetVConnection.h
+++ b/iocore/net/P_QUICNetVConnection.h
@@ -164,6 +164,7 @@ public:
   int state_connection_closed(int event, Event *data);
   void start(SSL_CTX *);
   void free(EThread *t) override;
+  void destroy(EThread *t);
 
   UDPConnection *get_udp_con();
   virtual void net_read_io(NetHandler *nh, EThread *lthread) override;
@@ -202,6 +203,13 @@ public:
   // QUICConnection (QUICFrameHandler)
   std::vector<QUICFrameType> interests() override;
   QUICErrorUPtr handle_frame(std::shared_ptr<const QUICFrame> frame) override;
+
+  int in_closed_queue = 0;
+
+  bool shouldDestroy();
+
+  LINK(QUICNetVConnection, closed_link);
+  SLINK(QUICNetVConnection, closed_alink);
 
 private:
   class AltConnectionInfo

--- a/iocore/net/P_QUICPacketHandler.h
+++ b/iocore/net/P_QUICPacketHandler.h
@@ -29,17 +29,25 @@
 #include "quic/QUICTypes.h"
 #include "quic/QUICConnectionTable.h"
 
+class QUICClosedConCollector;
 class QUICNetVConnection;
 class QUICPacket;
 
 class QUICPacketHandler
 {
 public:
+  QUICPacketHandler();
+  ~QUICPacketHandler();
+
   virtual void send_packet(const QUICPacket &packet, QUICNetVConnection *vc) = 0;
+  virtual void close_conenction(QUICNetVConnection *conn);
 
 protected:
   static void _send_packet(Continuation *c, const QUICPacket &packet, UDPConnection *udp_con, IpEndpoint &addr, uint32_t pmtu);
   static QUICConnectionId _read_connection_id(IOBufferBlock *block);
+
+  Event *_collector_event                       = nullptr;
+  QUICClosedConCollector *_closed_con_collector = nullptr;
 
   virtual void _recv_packet(int event, UDPPacket *udpPacket) = 0;
 };

--- a/iocore/net/QUICClosedConCollector.cc
+++ b/iocore/net/QUICClosedConCollector.cc
@@ -1,0 +1,62 @@
+/** @file
+  This file implements an I/O Processor for network I/O
+  @section license License
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "P_QUICClosedConCollector.h"
+
+QUICClosedConCollector::QUICClosedConCollector()
+{
+  SET_HANDLER(&QUICClosedConCollector::mainEvent);
+}
+
+int
+QUICClosedConCollector::mainEvent(int event, Event *e)
+{
+  EThread *t = this->mutex->thread_holding;
+  ink_assert(t == this_thread());
+
+  this->_process_closed_connection(t);
+  return 0;
+}
+
+void
+QUICClosedConCollector::_process_closed_connection(EThread *t)
+{
+  ink_release_assert(t != nullptr);
+
+  QUICNetVConnection *qvc;
+  Que(QUICNetVConnection, closed_link) local_queue;
+
+  while ((qvc = this->_localClosedQueue.pop())) {
+    if (qvc->shouldDestroy()) {
+      qvc->free(t);
+    } else {
+      local_queue.push(qvc);
+    }
+  }
+
+  SList(QUICNetVConnection, closed_alink) aq(this->closedQueue.popall());
+  while ((qvc = aq.pop())) {
+    if (qvc->shouldDestroy()) {
+      qvc->free(t);
+    } else {
+      local_queue.push(qvc);
+    }
+  }
+
+  this->_localClosedQueue.append(local_queue);
+}

--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -79,6 +79,13 @@ QUICNetVConnection::init(QUICConnectionId original_cid, UDPConnection *udp_con, 
                static_cast<uint64_t>(this->_quic_connection_id));
 }
 
+bool
+QUICNetVConnection::shouldDestroy()
+{
+  // TODO: return this->refcount == 0;
+  return true;
+}
+
 VIO *
 QUICNetVConnection::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
 {
@@ -654,6 +661,12 @@ QUICNetVConnection::state_connection_closed(int event, Event *data)
     // Shutdown loss detector
     this->_loss_detector->handleEvent(QUIC_EVENT_LD_SHUTDOWN, nullptr);
 
+    if (this->nh) {
+      this->nh->stopCop(this);
+      this->nh->stopIO(this);
+    }
+
+    this->_packet_handler->close_conenction(this);
     break;
   }
   case QUIC_EVENT_PACKET_WRITE_READY: {

--- a/iocore/net/quic/QUICConnectionTable.cc
+++ b/iocore/net/quic/QUICConnectionTable.cc
@@ -36,7 +36,12 @@ QUICConnectionTable::insert(QUICConnectionId cid, QUICConnection *connection)
 void
 QUICConnectionTable::erase(QUICConnectionId cid, QUICConnection *connection)
 {
-  ink_assert(this->_connections.get(cid) == connection);
+  QUICConnection *qc = this->_connections.get(cid);
+  if (qc == nullptr) {
+    return;
+  }
+  ink_assert(qc == connection);
+  Debug("quic_ctable", "ctable erase cid: [%" PRIx64 "] ", static_cast<uint64_t>(cid));
   // if (this->_cids.get(connection->endpoint(), connection->connection_id()) == cid) {
   //   this->_cids.put(connection->endpoint(), nullptr);
   // }


### PR DESCRIPTION
Push closed conn into closed queue. 

This change will call qvc::free in ET_UDP, so we don't need to grab the lock when we erase the cid from ctable.