### PR TITLE
Test: fix string_view unit test.

### DIFF
--- a/lib/ts/unit-tests/test_string_view.cc
+++ b/lib/ts/unit-tests/test_string_view.cc
@@ -255,12 +255,12 @@ TEST_CASE("Access & iterators", "[string_view] [access]")
 
     REQUIRE(*sv.begin() == 'a');
     REQUIRE(*sv.cbegin() == 'a');
-    REQUIRE(*sv.end() == '\0');
-    REQUIRE(*sv.cend() == '\0');
+    REQUIRE(*(--sv.end()) == 'e');
+    REQUIRE(*(--sv.cend()) == 'e');
     REQUIRE(*sv.rbegin() == 'e');
     REQUIRE(*sv.crbegin() == 'e');
-    REQUIRE(*sv.rend() == '\0');
-    REQUIRE(*sv.crend() == '\0');
+    REQUIRE(*(--sv.rend()) == 'a');
+    REQUIRE(*(--sv.crend()) == 'a');
 
     int n = 0;
     for (auto it : sv) {


### PR DESCRIPTION
The  test was dereferencing `end()` and the like, which is always wrong. Tweaked it a bit to still use those methods to test them, but making the dereference valid.