### PR TITLE
QUIC: Add refcount to protect qvc

### DIFF
--- a/iocore/net/P_QUICNetVConnection.h
+++ b/iocore/net/P_QUICNetVConnection.h
@@ -142,7 +142,7 @@ class SSLNextProtocolSet;
  *    WRITE:
  *      Do nothing
  **/
-class QUICNetVConnection : public UnixNetVConnection, public QUICConnection
+class QUICNetVConnection : public UnixNetVConnection, public QUICConnection, public RefCountObj
 {
   using super = UnixNetVConnection; ///< Parent type.
 
@@ -168,6 +168,7 @@ public:
   int state_connection_draining(int event, Event *data);
   int state_connection_closed(int event, Event *data);
   void start();
+  void remove_connection_ids();
   void free(EThread *t) override;
   void destroy(EThread *t);
 

--- a/iocore/net/QUICClosedConCollector.cc
+++ b/iocore/net/QUICClosedConCollector.cc
@@ -43,7 +43,7 @@ QUICClosedConCollector::_process_closed_connection(EThread *t)
 
   while ((qvc = this->_localClosedQueue.pop())) {
     if (qvc->shouldDestroy()) {
-      qvc->free(t);
+      qvc->destroy(t);
     } else {
       local_queue.push(qvc);
     }
@@ -51,8 +51,9 @@ QUICClosedConCollector::_process_closed_connection(EThread *t)
 
   SList(QUICNetVConnection, closed_alink) aq(this->closedQueue.popall());
   while ((qvc = aq.pop())) {
+    qvc->remove_connection_ids();
     if (qvc->shouldDestroy()) {
-      qvc->free(t);
+      qvc->destroy(t);
     } else {
       local_queue.push(qvc);
     }


### PR DESCRIPTION
Splits free function into 3 parts:
 - cleanup the sub components like stream manager, packet handler and so on. (ET_NET)
 - cleanup connection ids from ctable (ET_UDP)
 - destroy connection (ET_UDP)
