### PR TITLE
Add TSAPI functions TSRemapFrom/ToUrlGet().  Allow TSMBuffer pointer passed to TSUrlStringGet() to be null.

### DIFF
--- a/doc/developer-guide/api/functions/TSRemapFromToUrlGet.en.rst
+++ b/doc/developer-guide/api/functions/TSRemapFromToUrlGet.en.rst
@@ -1,0 +1,40 @@
+.. Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed
+   with this work for additional information regarding copyright
+   ownership.  The ASF licenses this file to you under the Apache
+   License, Version 2.0 (the "License"); you may not use this file
+   except in compliance with the License.  You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied.  See the License for the specific language governing
+   permissions and limitations under the License.
+
+.. include:: ../../../common.defs
+
+.. default-domain:: c
+
+TSRemapFrom/ToUrlGet
+********************
+
+Synopsis
+========
+
+`#include <ts/ts.h>`
+
+.. function:: TSReturnCode TSRemapFromUrlGet(TSHttpTxn txnp, TSMLoc * urlLocp)
+.. function:: TSReturnCode TSRemapToUrlGet(TSHttpTxn txnp, TSMLoc * urlLocp)
+
+Description
+===========
+
+These functions are useful for transactions where the URL is remapped, due to matching a line in :file:`remap.config`.
+:func:`TSRemapFromUrlGet` returns the *from* URL in the matching line in :file:`remap.config`.
+:func:`TSRemapToUrlGet` returns the *to* URL in the matching line in :file:`remap.config`.
+This info is available at or after the :c:data:`TS_HTTP_POST_REMAP_HOOK` hook.  If the function returns
+:data:`TS_SUCCESS`, the location of the URL is put into the variable pointed to by :arg:`urlLocp`.  On error, the function
+returns :data:`TS_ERROR`.

--- a/doc/developer-guide/api/functions/TSUrlStringGet.en.rst
+++ b/doc/developer-guide/api/functions/TSUrlStringGet.en.rst
@@ -44,7 +44,7 @@ and retrieve or modify parts of URLs, such as their host, port or scheme
 information.
 
 :func:`TSUrlStringGet` constructs a string representation of the URL located
-at :arg:`offset` within the marshal buffer :arg:`bufp`.
+at :arg:`offset` within the marshal buffer :arg:`bufp`.  (However :arg:`bufp` is actually superfluous and may be null.)
 :func:`TSUrlStringGet` stores the length of the allocated string in the
 parameter :arg:`length`. This is the same length that :func:`TSUrlLengthGet`
 returns. The returned string is allocated by a call to :func:`TSmalloc` and

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -2448,6 +2448,18 @@ tsapi const char *TSHttpSsnClientProtocolStackContains(TSHttpSsn ssnp, char cons
 tsapi const char *TSNormalizedProtocolTag(char const *tag);
 tsapi const char *TSRegisterProtocolTag(char const *tag);
 
+// If, for the given transaction, the URL has been remapped, this function puts the memory location of the "from" URL object in the
+// variable pointed to by urlLocp, and returns TS_SUCCESS.  (The URL object will be within memory allocated to the transaction
+// object.)  Otherwise, the function returns TS_ERROR.
+//
+tsapi TSReturnCode TSRemapFromUrlGet(TSHttpTxn txnp, TSMLoc *urlLocp);
+
+// If, for the given transaction, the URL has been remapped, this function puts the memory location of the "to" URL object in the
+// variable pointed to by urlLocp, and returns TS_SUCCESS.  (The URL object will be within memory allocated to the transaction
+// object.)  Otherwise, the function returns TS_ERROR.
+//
+tsapi TSReturnCode TSRemapToUrlGet(TSHttpTxn txnp, TSMLoc *urlLocp);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */


### PR DESCRIPTION
These new TS API functions report the to and from URLs from the line in remap.config for remapped URLs, in the post-remap hook and those following.