### PR TITLE
Call mark_body_done() when response body is empty

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -608,8 +608,9 @@ Http2Stream::update_write_request(IOBufferReader *buf_reader, int64_t write_len,
 
       // If there is additional data, send it along in a data frame.  Or if this was header only
       // make sure to send the end of stream
+      is_done |= (write_vio.ntodo() + this->response_header.length_get()) == bytes_avail;
       if (this->response_is_data_available() || is_done) {
-        if ((write_vio.ntodo() + this->response_header.length_get()) == bytes_avail || is_done) {
+        if (is_done) {
           this->mark_body_done();
         }
 


### PR DESCRIPTION
a98021cb21ea2e180ba2664a80d9c154893b97af broke logic of calling mark_body_done()
when response body is empty like 304 Not Modified.

----
- 7.1.3 backport candidate