### PR TITLE
 Added auth_directives to uri_signing.

### DIFF
--- a/plugins/experimental/uri_signing/README.md
+++ b/plugins/experimental/uri_signing/README.md
@@ -46,6 +46,35 @@ If there is not precisely one renewal key, the plugin will not load.
 Although the `kid` and `alg` parameters are optional in JWKs generally, both
 members must be present in keys used for URI signing.
 
+### Auth Directives
+
+It's occasionally useful to allow un-signed access to specific paths. To
+that end, the `auth_directives` parameter is supported. It can be used
+like this:
+
+    {
+      "Kabletown URI Authority": {
+        "renewal_kid": "Second Key",
+        "auth_directives": [
+          { auth: "allow", uri: "uri-regex:.*crossdomain.xml" },
+          { auth: "deny",  uri: "uri-regex:https?://[^/]*/public/secret.xml.*" },
+          { auth: "allow", uri: "uri-regex:https?://[^/]*/public/.*" },
+          { auth: "allow", uri: "uri-regex:.*favicon.ico" }
+        ]
+        "keys": [
+          ⋮
+        ]
+    }
+
+Each of the `auth_directives` will be evaluated in order for each url
+that does not have a valid token. If it matches an allowed path before
+it matches a denied one, it will be served anyway. If it matches no
+`auth_directives`, it will not be served.
+
+It's worth noting that multiple issuers can provide `auth_directives`.
+Each issuer will be processed in order and any issuer can provide access to
+a path.
+
 Usage
 -----
 

--- a/plugins/experimental/uri_signing/config.h
+++ b/plugins/experimental/uri_signing/config.h
@@ -16,6 +16,9 @@
  * limitations under the License.
  */
 
+#include <stdbool.h>
+#include <stdlib.h>
+
 struct config;
 struct _cjose_jwk_int;
 struct signer {
@@ -29,3 +32,4 @@ void config_delete(struct config *g);
 struct signer *config_signer(struct config *);
 struct _cjose_jwk_int **find_keys(struct config *cfg, const char *issuer);
 struct _cjose_jwk_int *find_key_by_kid(struct config *cfg, const char *issuer, const char *kid);
+bool uri_matches_auth_directive(struct config *cfg, const char *uri, size_t uri_ct);

--- a/plugins/experimental/uri_signing/jwt.c
+++ b/plugins/experimental/uri_signing/jwt.c
@@ -145,17 +145,17 @@ jwt_validate(struct jwt *jwt)
 }
 
 bool
-jwt_check_uri(struct jwt *jwt, const char *uri)
+jwt_check_uri(const char *sub, const char *uri)
 {
   static const char CONT_URI_STR[]         = "uri";
   static const char CONT_URI_PATTERN_STR[] = "uri-pattern";
   static const char CONT_URI_REGEX_STR[]   = "uri-regex";
 
-  if (!jwt || !uri) {
+  if (!sub || !*sub || !uri) {
     return false;
   }
 
-  const char *kind = jwt->sub, *container = jwt->sub;
+  const char *kind = sub, *container = sub;
   while (*container && *container != ':') {
     ++container;
   }

--- a/plugins/experimental/uri_signing/jwt.h
+++ b/plugins/experimental/uri_signing/jwt.h
@@ -35,7 +35,7 @@ struct jwt {
 struct jwt *parse_jwt(json_t *raw);
 void jwt_delete(struct jwt *jwt);
 bool jwt_validate(struct jwt *jwt);
-bool jwt_check_uri(struct jwt *jwt, const char *uri);
+bool jwt_check_uri(const char *sub, const char *uri);
 
 struct _cjose_jwk_int;
 char *renew(struct jwt *jwt, const char *iss, struct _cjose_jwk_int *jwk, const char *alg, const char *package);

--- a/plugins/experimental/uri_signing/parse.c
+++ b/plugins/experimental/uri_signing/parse.c
@@ -184,7 +184,7 @@ validate_jws(cjose_jws_t *jws, struct config *cfg, const char *uri, size_t uri_c
     }
   }
 
-  if (!jwt_check_uri(jwt, uri)) {
+  if (!jwt_check_uri(jwt->sub, uri)) {
     PluginDebug("Valid key for %16p that does not match uri.", jws);
     goto jwt_fail;
   }

--- a/plugins/experimental/uri_signing/uri_signing.c
+++ b/plugins/experimental/uri_signing/uri_signing.c
@@ -153,10 +153,10 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
   const int max_cpi       = 20;
   int64_t checkpoints[20] = {0};
   int cpi                 = 0;
+  int url_ct              = 0;
+  const char *url         = NULL;
 
   const char *package = "URISigningPackage";
-  int url_ct          = 0;
-  const char *url     = NULL;
 
   TSMBuffer mbuf;
   TSMLoc ul;
@@ -246,6 +246,9 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
   PluginDebug("Spent %" PRId64 " ns uri_signing verification of %.*s.", mark_timer(&t), url_ct, url);
   return TSREMAP_NO_REMAP;
 fail:
+  if (uri_matches_auth_directive((struct config *)ih, url, url_ct)) {
+    return TSREMAP_NO_REMAP;
+  }
   PluginDebug("Invalid JWT for %.*s", url_ct, url);
   TSHttpTxnSetHttpRetStatus(txnp, TS_HTTP_STATUS_FORBIDDEN);
   PluginDebug("Spent %" PRId64 " ns uri_signing verification of %.*s.", mark_timer(&t), url_ct, url);


### PR DESCRIPTION
These directives exist to indicate that specific paths should be considered "pre-authenticated". This allows users to override specific paths where signing should not or cannot be used.