### PR TITLE
Issue #2963 - Remove TS.pm.in from copy

### DIFF
--- a/lib/perl/Makefile.PL
+++ b/lib/perl/Makefile.PL
@@ -18,6 +18,13 @@ require 5.006;
 use ExtUtils::MakeMaker;
 # See lib/ExtUtils/MakeMaker.pm for details of how to influence
 # the contents of the Makefile that is written.
+
+sub MY::libscan {
+    my( $mm, $file ) = @_;
+    return if $file =~  /\.in$/; # SKIP
+    return $file;
+}
+
 WriteMakefile(
     NAME              => 'Apache::TS',
     VERSION_FROM      => 'lib/Apache/TS.pm', # finds $VERSION


### PR DESCRIPTION
Added sub to skip .in extension in the Makefile.PL. This way when it generates the Makefile-pl it does not copy TS.pm.in to the blib dir