### PR TITLE
corrects truncation of timestamp string

### DIFF
--- a/lib/ts/Diags.cc
+++ b/lib/ts/Diags.cc
@@ -235,7 +235,7 @@ Diags::print_va(const char *debug_tag, DiagsLevel diags_level, const SourceLocat
 
     if (num_bytes_written > 0) {
       format_writer.write('[');
-      format_writer.write(buffer + 4, num_bytes_written);
+      format_writer.write(buffer + 4, strlen(buffer + 4));
       format_writer.write("] ", 2);
     }
   }


### PR DESCRIPTION
This fixes one issue raised in https://github.com/apache/trafficserver/pull/3081#issuecomment-368095761.

Milestone: 8.0.0
Labels: Backports, Logging
Project: 7.x releases

Backport:

    This depends on #3081 .
    Backport requested for potential 7.2 release, not 7.x branch (to avoid needing to backport BufferWriter as well)
