### PR TITLE
MADV_DODUMP causing instability and performance overhead

### DIFF
--- a/lib/ts/ink_queue.cc
+++ b/lib/ts/ink_queue.cc
@@ -320,11 +320,6 @@ static void
 malloc_free(InkFreeList *f, void *item)
 {
   if (f->alignment) {
-#ifdef MADV_DODUMP
-    if (f->advice && (INK_ALIGN((uint64_t)item, ats_pagesize()) == (uint64_t)item)) {
-      ats_madvise((caddr_t)item, INK_ALIGN(f->type_size, f->alignment), MADV_DODUMP);
-    }
-#endif
     ats_memalign_free(item);
   } else {
     ats_free(item);
@@ -394,11 +389,6 @@ malloc_bulkfree(InkFreeList *f, void *head, void *tail, size_t num_item)
   if (f->alignment) {
     for (size_t i = 0; i < num_item && item; ++i, item = next) {
       next = *(void **)item; // find next item before freeing current item
-#ifdef MADV_DODUMP
-      if (f->advice && (INK_ALIGN((uint64_t)item, ats_pagesize()) == (uint64_t)item)) {
-        ats_madvise((caddr_t)item, INK_ALIGN(f->type_size, f->alignment), MADV_DODUMP);
-      }
-#endif
       ats_memalign_free(item);
     }
   } else {


### PR DESCRIPTION
This is to reverse PR #2967. We've seen an increase in instability when using the MADV_DODUMP flag combined with NOT using freelist, as well as increase load, both are observed in production. The memory seems to not like being advised right before being freed. And after playing around with the location of putting the MADV_DODUMP flag, it seems to be stable if used right after allocation (so the code will always use madvise, default flag value to MADV_DODUMP). But due to some unknown issue with how `madvise` works, the overhead increased dramatically, observing 10x compared to not having to advise MADV_DODUMP. So reversing this change seems to be the only way to go for now, we will be working on using jemalloc arena to fix this problem.