### PR TITLE
Add a HostStatus container used to mark  parents down or up.

### DIFF
--- a/proxy/HostStatus.cc
+++ b/proxy/HostStatus.cc
@@ -1,0 +1,59 @@
+/** @file
+
+  Implementation of Host Proxy routing
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+#include "HostStatus.h"
+
+HostStatus::HostStatus() : hosts_statuses(ink_hash_table_create(InkHashTableKeyType_String))
+{
+  ink_mutex_init(&hosts_statuses_mutex);
+}
+
+HostStatus::~HostStatus()
+{
+  ink_hash_table_destroy(hosts_statuses);
+
+  ink_mutex_destroy(&hosts_statuses_mutex);
+}
+
+void
+HostStatus::setHostStatus(const char *key, HostStatus_t status)
+{
+  Debug("host_statuses", "HostStatus::setHostStatus():  key: %s, status: %d", key, status);
+  ink_mutex_acquire(&hosts_statuses_mutex);
+  // update / insert status.
+  // using the hash table pointer to store the HostStatus_t value.
+  ink_hash_table_insert(hosts_statuses, key, reinterpret_cast<void *>(status));
+
+  ink_mutex_release(&hosts_statuses_mutex);
+}
+
+HostStatus_t
+HostStatus::getHostStatus(const char *key)
+{
+  intptr_t _status = HostStatus_t::HOST_STATUS_INIT;
+
+  // the hash table value pointer has the HostStatus_t value.
+  ink_hash_table_lookup(hosts_statuses, key, reinterpret_cast<void **>(&_status));
+  Debug("host_statuses", "HostStatus::getHostStatus():  key: %s, status: %d", key, static_cast<int>(_status));
+
+  return static_cast<HostStatus_t>(_status);
+}

--- a/proxy/HostStatus.h
+++ b/proxy/HostStatus.h
@@ -1,0 +1,68 @@
+/** @file
+
+  A brief file description
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+/*****************************************************************************
+ *
+ *  HostSelection.h - Interface to Host Selection System
+ *
+ *
+ ****************************************************************************/
+
+#ifndef _HOST_SELECTION_H_
+#define _HOST_SELECTION_H_
+
+#include "ControlBase.h"
+#include "ControlMatcher.h"
+#include "P_RecProcess.h"
+
+enum HostStatus_t {
+  HOST_STATUS_INIT,
+  HOST_STATUS_UP,
+  HOST_STATUS_DOWN,
+};
+
+/**
+ * Singleton placeholder for next hop status.
+ */
+struct HostStatus {
+  ~HostStatus();
+
+  static HostStatus &
+  instance()
+  {
+    static HostStatus instance;
+    return instance;
+  } // return the signleton pointer.
+  void setHostStatus(const char *key, const HostStatus_t status);
+  HostStatus_t getHostStatus(const char *key);
+
+private:
+  HostStatus();
+  HostStatus(const HostStatus &obj) = delete;
+  HostStatus &operator=(HostStatus const &) = delete;
+
+  InkHashTable *hosts_statuses; // next hop status, key is hostname or ip string, data is bool (available).
+  ink_mutex hosts_statuses_mutex;
+};
+
+#endif

--- a/proxy/Makefile.am
+++ b/proxy/Makefile.am
@@ -136,6 +136,8 @@ traffic_server_SOURCES = \
   Crash.cc \
   EventName.cc \
   FetchSM.cc \
+  HostStatus.cc \
+  HostStatus.h \
   IPAllow.cc \
   IPAllow.h \
   InkAPI.cc \
@@ -148,7 +150,7 @@ traffic_server_SOURCES = \
   ParentConsistentHash.h \
   ParentRoundRobin.cc \
   ParentRoundRobin.h \
-	ParentSelectionStrategy.cc \
+  ParentSelectionStrategy.cc \
   ParentSelection.cc \
   ParentSelection.h \
   Plugin.cc \

--- a/proxy/ParentConsistentHash.cc
+++ b/proxy/ParentConsistentHash.cc
@@ -20,6 +20,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
+#include "HostStatus.h"
 #include "ParentConsistentHash.h"
 
 ParentConsistentHash::ParentConsistentHash(ParentRecord *parent_record)
@@ -115,6 +116,7 @@ ParentConsistentHash::selectParent(bool first_call, ParentResult *result, Reques
   uint64_t path_hash            = 0;
   uint32_t last_lookup;
   pRecord *prtmp = nullptr, *pRec = nullptr;
+  HostStatus &pStatus = HostStatus::instance();
 
   Debug("parent_select", "ParentConsistentHash::%s(): Using a consistent hash parent selection strategy.", __func__);
   ink_assert(numParents(result) > 0 || result->rec->go_direct == true);
@@ -165,9 +167,8 @@ ParentConsistentHash::selectParent(bool first_call, ParentResult *result, Reques
       } while (prtmp && strcmp(prtmp->hostname, result->hostname) == 0);
     }
   }
-
   // didn't find a parent or the parent is marked unavailable.
-  if (!pRec || (pRec && !pRec->available)) {
+  if ((pRec && !pRec->available) || pStatus.getHostStatus(pRec->hostname) == HOST_STATUS_DOWN) {
     do {
       if (pRec && !pRec->available) {
         Debug("parent_select", "Parent.failedAt = %u, retry = %u, xact_start = %u", (unsigned int)pRec->failedAt,
@@ -215,7 +216,7 @@ ParentConsistentHash::selectParent(bool first_call, ParentResult *result, Reques
         Debug("parent_select", "No available parents.");
         break;
       }
-    } while (!prtmp || !pRec->available);
+    } while (!prtmp || !pRec->available || pStatus.getHostStatus(pRec->hostname) == HOST_STATUS_DOWN);
   }
 
   // use the available or marked for retry parent.


### PR DESCRIPTION
Added HostStatus to provide ability to control host status manually( for example using traffic_ctl).
This PR only controls Parents.