### PR TITLE
QUIC: Ensure only first initial packet could enter QVC::acceptEvent

### DIFF
--- a/iocore/net/QUICNet.cc
+++ b/iocore/net/QUICNet.cc
@@ -73,10 +73,12 @@ QUICPollCont::_process_long_header_packet(QUICPollEvent *e, NetHandler *nh)
   ptype = static_cast<QUICPacketType>(buf[0] & 0x7f);
   switch (ptype) {
   case QUICPacketType::INITIAL:
-    vc->read.triggered = 1;
-    vc->handle_received_packet(p);
-    this->mutex->thread_holding->schedule_imm(vc, QUIC_EVENT_PACKET_READ_READY);
-    return;
+    if (!vc->read.triggered) {
+      vc->read.triggered = 1;
+      vc->handle_received_packet(p);
+      vc->handleEvent(QUIC_EVENT_PACKET_READ_READY, nullptr);
+      return;
+    }
   case QUICPacketType::ZERO_RTT_PROTECTED:
   // TODO:: do something ?
   // break;

--- a/iocore/net/QUICPacketHandler.cc
+++ b/iocore/net/QUICPacketHandler.cc
@@ -213,7 +213,6 @@ QUICPacketHandlerIn::_recv_packet(int event, UDPPacket *udp_packet)
     vc->action_     = *this->action_;
     vc->set_is_transparent(this->opt.f_inbound_transparent);
     vc->set_context(NET_VCONNECTION_IN);
-    vc->read.triggered = 1;
     vc->start(this->_ssl_ctx);
     vc->options.ip_proto  = NetVCOptions::USE_UDP;
     vc->options.ip_family = udp_packet->from.sa.sa_family;


### PR DESCRIPTION
Client may send several initial packets by retransmission. Server should only call the QVC::acceptEvent once. 