### PR TITLE
Fix the expression for checking file descriptor

### DIFF
--- a/iocore/hostdb/P_RefCountCacheSerializer.h
+++ b/iocore/hostdb/P_RefCountCacheSerializer.h
@@ -230,7 +230,7 @@ int
 RefCountCacheSerializer<C>::initialize_storage(int /* event */, Event *e)
 {
   this->fd = socketManager.open(this->tmp_filename.c_str(), O_TRUNC | O_RDWR | O_CREAT, 0644); // TODO: configurable perms
-  if (this->fd == -1) {
+  if (this->fd < 0) {
     Warning("Unable to create temporary file %s, unable to persist hostdb: %s", this->tmp_filename.c_str(), strerror(errno));
     delete this;
     return EVENT_DONE;


### PR DESCRIPTION
socketManager.open returns -errno in case the open fails. So the file descriptor should be checked for any negative value so that useful diagnostic message can be  logged in diags