### PR TITLE
Free Http2Stream directly when HttpSM is already gone or not allocated

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -436,8 +436,9 @@ Http2Stream::initiating_close()
       SCOPED_MUTEX_LOCK(lock, current_reader->mutex, this_ethread());
       current_reader->handleEvent(VC_EVENT_ERROR);
     } else if (!sent_write_complete) {
-      // Transaction is already gone.  Kill yourself
+      // Transaction is already gone or not started. Kill yourself
       do_io_close();
+      destroy();
     }
   }
 }


### PR DESCRIPTION
When Http2Stream get error before start transaction, Http2Stream::transaction_done() is never called.
Because HttpSM is not allocated. In regular cases, Http2Stream::initiating_close() signal some events
to HttpSM, but in above cases it should free itself directly.

----

- Fix #3193 
- 7.1.x Backport Candidate 