### PR TITLE
remove delay from sending traffic_ctl msgs

### DIFF
--- a/mgmt/LocalManager.h
+++ b/mgmt/LocalManager.h
@@ -36,6 +36,7 @@
 
 #include "Alarms.h"
 #include "BaseManager.h"
+#include "MgmtSocket.h"
 #include <records/I_RecHttp.h>
 #if TS_HAS_WCCP
 #include <wccp/Wccp.h>
@@ -120,6 +121,8 @@ public:
   pid_t watched_process_pid = -1;
 
   int syslog_facility = LOG_DAEMON;
+
+  SocketPoller* data_sock;
 
 #if TS_HAS_WCCP
   wccp::Cache wccp_cache;

--- a/mgmt/ProcessManager.h
+++ b/mgmt/ProcessManager.h
@@ -37,6 +37,7 @@
 #define _PROCESS_MANAGER_H
 
 #include "MgmtUtils.h"
+#include "MgmtSocket.h"
 #include "BaseManager.h"
 #include "ts/ink_sock.h"
 
@@ -91,11 +92,18 @@ private:
   std::function<void()> init;
 
   int local_manager_sockfd;
-  ConfigUpdateCbTable *cbtable;
-  int max_msgs_in_a_row;
 
+  SocketPoller *ctrl_sock; //TODO: add special socket for control messages
+  SocketPoller *data_sock;
+
+  ConfigUpdateCbTable *cbtable;
+
+  int max_msgs_in_a_row;
   static const int MAX_MSGS_IN_A_ROW = 10000;
+
   static void *processManagerThread(void *arg);
+
+  int readManagementMsg(int sockfd, ink_hrtime timeout, MgmtMessageHdr **msg);
 };
 
 inkcoreapi extern ProcessManager *pmgmt;

--- a/mgmt/utils/MgmtSocket.h
+++ b/mgmt/utils/MgmtSocket.h
@@ -25,16 +25,133 @@
 #define _MGMT_SOCKET_H_
 
 #include "ts/ink_platform.h"
+#include "ts/ink_apidefs.h"
+
+#include <vector>
+#include <unordered_set>
+
+/**
+ *  An epoll instance to monitor socket fds. epoll_wait can be woken up with
+ *   a poke(). This prevents situations where both the client and server are
+ *   both trying to read messages and unable to write messages themselves. 
+ *   SocketPoller allows for active wakeup rather than a passive timeout. 
+ * 
+ *  SocketPoller only maintains fds for wakeupfd and epoll_fd. Any fd registered
+ *   should be removed or you will continue to recieve events for it. Calling 
+ *   cleanup is important because it will unregister any fds that the
+ *   caller forgot to remove.
+ *
+ *  If system doesn't have eventfd, poke does nothing and timeouts are relied on.
+ */
+class SocketPoller
+{
+    typedef struct epoll_event PollEvent;
+
+public:
+    SocketPoller(int fds = 10);
+    ~SocketPoller();
+
+    /**
+     * readSocketTimeout. 
+     * 
+     * polls fd registered to epoll instance 
+     *
+     * input: timeout in ms
+     * output: returns 0 if there is a timeout or an external trigger. basically, stop polling 
+     *            socket, go do something else.
+     *         returns < 0 if error. check system errno
+     *         returns > 0 for the number of ready fds. This should be used with getReadyFileDescriptors() 
+     *            and getReadyFileDescriptorAt() to avoid going out of bounds.
+     */ 
+    int readSocketTimeout(unsigned int timeout_ms);
+
+    /**
+     * getReadyFileDescriptorAt.
+     * readSocketTimeout returns the number of ready fds. In order to see which fd was triggered 
+     *
+     * input: index: event index, num_ready: total number of ready events
+     * output: return > 0 for the fd at index. if index correct, should not error here. 
+     */
+    int getReadyFileDescriptorAt(int index, int num_ready) const;
+
+    /**
+     * getReadyFileDescriptors. Get all the fds that are ready. 
+     */
+    std::vector<int> getReadyFileDescriptors(int num_ready) const;
+
+    /**
+     * poke.
+     *
+     * To avoid relying on timeouts when both sides are polling for messages, we can poke the epoll_wait 
+     *    to force it to stop polling and to go do something else. An external event, such as adding to 
+     *    the write queue, should poke to get things moving quicker.
+     *
+     * poke() maintains an internal mutex and is thread safe.
+     */
+    void poke();
+
+    /**
+     * cleanup.
+     *
+     * purpose: deallocates memory, closes internally managed fds and unregisters all fds
+     */
+    void cleanup();
+
+    /**
+     * registerFileDescriptor. adds a fd to the epoll_fd to watch. 
+     *
+     * input: fd to add
+     * output: return 0 if successful or already registered. 
+     *         return < 0 if there is an error. check errno. 
+     *             Note: some places use ret = -1 and errno == EEXIST to check if fd already registered. In SocketPoller,
+     *             fds are internally managed so this should never happen. if return < 0, there is a epoll_ctl error. 
+     */ 
+    int registerFileDescriptor(int fd);
+
+    /**
+     * removeFileDescriptor. removes fd. does not close file descriptor.
+     */
+    int removeFileDescriptor(int fd);
+
+    /**
+     * purgeDescriptors. remove all fds, including the wakeup_event.
+     */
+    void purgeDescriptors();
+
+    /** 
+     * isRegistered. checks if fd is being monitored. 
+     */
+    bool isRegistered(int fd) const;
+
+    /**
+     * wakeupDescriptor. get the fd for the wakeup_event.
+     */
+    int wakeupDescriptor() const;
+
+private:
+
+    int epfd;             // epoll_fd
+
+    PollEvent* events;    // internal buffer for ready fd events
+    std::unordered_set<int> registered_fds; // track all fds. helps to prevent the case where the caller forgets to remove fds.
+
+    bool setup;
+#if HAVE_EVENTFD
+    int wakeup_event;     // eventfd used to wakeup epoll_wait
+#endif
+
+};
+
+
+//-------------------------------------------------------------------------
+// system calls (based on implementation from UnixSocketManager);
+//-------------------------------------------------------------------------
 
 //-------------------------------------------------------------------------
 // transient_error
 //-------------------------------------------------------------------------
 
 bool mgmt_transient_error();
-
-//-------------------------------------------------------------------------
-// system calls (based on implementation from UnixSocketManager);
-//-------------------------------------------------------------------------
 
 //-------------------------------------------------------------------------
 // mgmt_accept


### PR DESCRIPTION
The RPC code used for traffic_ctl to communicate with traffic_server has a long delay associated. There's a situation (which happens often) where both LocalManager and ProcessManager are polling for messages over the socket. Both can't write so there's nothing to read. Currently, they rely on a timeout to stop polling and start sending messages. This fix does three things:

1. changes socket fd monitoring to use epoll_wait instead of select
2. allows for external events (ie. adding to a write queue) to trigger and eventfd to wakeup epoll_wait
3. removes static wait, previously in ProcessManager.cc:175

Effectively, it actively stops polling rather than passively relying on timeouts. This causes msgs sent from traffic_ctl to be quickly received by traffic_server.