### PR TITLE
Isolate client ctx options from server options

### DIFF
--- a/iocore/net/P_SSLConfig.h
+++ b/iocore/net/P_SSLConfig.h
@@ -86,7 +86,7 @@ struct SSLConfigParams : public ConfigInfo {
   int8_t clientVerify;
   int client_verify_depth;
   long ssl_ctx_options;
-  long ssl_client_ctx_protocols;
+  long ssl_client_ctx_options;
 
   static int ssl_maxrecord;
   static bool ssl_allow_client_renegotiation;

--- a/iocore/net/SSLClientUtils.cc
+++ b/iocore/net/SSLClientUtils.cc
@@ -124,16 +124,12 @@ SSLInitClientContext(const SSLConfigParams *params)
   meth       = SSLv23_client_method();
   client_ctx = SSL_CTX_new(meth);
 
-  // disable selected protocols
-  SSL_CTX_set_options(client_ctx, params->ssl_ctx_options);
   if (!client_ctx) {
     SSLError("cannot create new client context");
     ::exit(1);
   }
 
-  if (params->ssl_client_ctx_protocols) {
-    SSL_CTX_set_options(client_ctx, params->ssl_client_ctx_protocols);
-  }
+  SSL_CTX_set_options(client_ctx, params->ssl_client_ctx_options);
   if (params->client_cipherSuite != nullptr) {
     if (!SSL_CTX_set_cipher_list(client_ctx, params->client_cipherSuite)) {
       SSLError("invalid client cipher suite in records.config");


### PR DESCRIPTION
This allows configuring ATS to have completely different TLS versions on each side