### PR TITLE
HostDB - removing infinite ttl=0

### DIFF
--- a/iocore/hostdb/I_HostDBProcessor.h
+++ b/iocore/hostdb/I_HostDBProcessor.h
@@ -242,7 +242,7 @@ struct HostDBInfo : public RefCountObj {
   bool
   is_ip_timeout() const
   {
-    return ip_timeout_interval && ip_interval() >= ip_timeout_interval;
+    return ip_interval() >= ip_timeout_interval;
   }
 
   bool
@@ -337,9 +337,8 @@ struct HostDBInfo : public RefCountObj {
   unsigned int hostname_offset; // always maintain a permanent copy of the hostname for non-rev dns records.
 
   unsigned int ip_timestamp;
-  // limited to HOST_DB_MAX_TTL (0x1FFFFF, 24 days)
-  // if this is 0 then no timeout.
-  unsigned int ip_timeout_interval;
+
+  unsigned int ip_timeout_interval; // bounded between 1 and HOST_DB_MAX_TTL (0x1FFFFF, 24 days)
 
   unsigned int is_srv : 1;
   unsigned int reverse_dns : 1;

--- a/iocore/hostdb/P_HostDBProcessor.h
+++ b/iocore/hostdb/P_HostDBProcessor.h
@@ -120,7 +120,7 @@ HOSTDB_CLIENT_IP_HASH(sockaddr const *lhs, sockaddr const *rhs)
 #define HOST_DB_IP_FAIL_TIMEOUT (60 * 60)
 
 //#define HOST_DB_MAX_INTERVAL                 (0x7FFFFFFF)
-#define HOST_DB_MAX_TTL (0x1FFFFF) // 24 days
+const unsigned int HOST_DB_MAX_TTL = (0x1FFFFF); // 24 days
 
 //
 // Constants

--- a/lib/ts/ink_std_compat.h
+++ b/lib/ts/ink_std_compat.h
@@ -23,7 +23,12 @@
 
 #pragma once
 
+#ifdef __cplusplus
+//
 #if __cplusplus < 201402L
+//
+// C++ 14 compatibility
+//
 #include <memory>
 namespace std
 {
@@ -33,5 +38,25 @@ make_unique(Args &&... args)
 {
   return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
+} // namespace std
+#endif // C++ 14 compatibility
+
+//
+#if __cplusplus < 201700L
+//
+// C++ 17 compatibility
+//
+#include <cassert>
+namespace std
+{
+template <typename T>
+inline const T &
+clamp(const T &v, const T &lo, const T &hi)
+{
+  assert(lo <= hi);
+  return (v < lo) ? lo : ((hi < v) ? hi : v);
 }
-#endif
+
+} // namespace std
+#endif // C++ 17 compatibility
+#endif // __cplusplus


### PR DESCRIPTION
Persistent Host are now stored in HostsFileMap. HostDb ttl's are now restricted to be between 1 and Host_db_max_ttl. Any host stored with ttl==0 will expire.  
