### PR TITLE
Isolate client ctx options from server options

### DIFF
--- a/iocore/net/P_SSLConfig.h
+++ b/iocore/net/P_SSLConfig.h
@@ -87,7 +87,7 @@ struct SSLConfigParams : public ConfigInfo {
   int clientVerify;
   int client_verify_depth;
   long ssl_ctx_options;
-  long ssl_client_ctx_protocols;
+  long ssl_client_ctx_options;
 
   static int ssl_maxrecord;
   static bool ssl_allow_client_renegotiation;

--- a/iocore/net/SSLClientUtils.cc
+++ b/iocore/net/SSLClientUtils.cc
@@ -105,16 +105,12 @@ SSLInitClientContext(const SSLConfigParams *params)
   meth       = SSLv23_client_method();
   client_ctx = SSL_CTX_new(meth);
 
-  // disable selected protocols
-  SSL_CTX_set_options(client_ctx, params->ssl_ctx_options);
   if (!client_ctx) {
     SSLError("cannot create new client context");
     ::exit(1);
   }
 
-  if (params->ssl_client_ctx_protocols) {
-    SSL_CTX_set_options(client_ctx, params->ssl_client_ctx_protocols);
-  }
+  SSL_CTX_set_options(client_ctx, params->ssl_client_ctx_options);
   if (params->client_cipherSuite != nullptr) {
     if (!SSL_CTX_set_cipher_list(client_ctx, params->client_cipherSuite)) {
       SSLError("invalid client cipher suite in records.config");

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -94,7 +94,7 @@ SSLConfigParams::reset()
   client_ctx                                                                                                  = nullptr;
   clientCertLevel = client_verify_depth = verify_depth = clientVerify = 0;
   ssl_ctx_options                                                     = SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3;
-  ssl_client_ctx_protocols                                            = SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3;
+  ssl_client_ctx_options                                              = SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3;
   ssl_session_cache                                                   = SSL_SESSION_CACHE_MODE_SERVER_ATS_IMPL;
   ssl_session_cache_size                                              = 1024 * 100;
   ssl_session_cache_num_buckets = 1024; // Sessions per bucket is ceil(ssl_session_cache_size / ssl_session_cache_num_buckets)
@@ -187,11 +187,13 @@ SSLConfigParams::initialize()
 #if TS_USE_SSLV3_CLIENT
   REC_ReadConfigInteger(client_ssl_options, "proxy.config.ssl.client.SSLv3");
   if (client_ssl_options)
-    ssl_client_ctx_protocols &= ~SSL_OP_NO_SSLv3;
+    ssl_client_ctx_options &= ~SSL_OP_NO_SSLv3;
 #endif
+
   REC_ReadConfigInteger(client_ssl_options, "proxy.config.ssl.client.TLSv1");
-  if (!client_ssl_options)
-    ssl_client_ctx_protocols |= SSL_OP_NO_TLSv1;
+  if (!client_ssl_options) {
+    ssl_client_ctx_options |= SSL_OP_NO_TLSv1;
+  }
 
 // These are not available in all versions of OpenSSL (e.g. CentOS6). Also see http://s.apache.org/TS-2355.
 #ifdef SSL_OP_NO_TLSv1_1
@@ -200,8 +202,9 @@ SSLConfigParams::initialize()
     ssl_ctx_options |= SSL_OP_NO_TLSv1_1;
 
   REC_ReadConfigInteger(client_ssl_options, "proxy.config.ssl.client.TLSv1_1");
-  if (!client_ssl_options)
-    ssl_client_ctx_protocols |= SSL_OP_NO_TLSv1_1;
+  if (!client_ssl_options) {
+    ssl_client_ctx_options |= SSL_OP_NO_TLSv1_1;
+  }
 #endif
 #ifdef SSL_OP_NO_TLSv1_2
   REC_ReadConfigInteger(options, "proxy.config.ssl.TLSv1_2");
@@ -209,8 +212,10 @@ SSLConfigParams::initialize()
     ssl_ctx_options |= SSL_OP_NO_TLSv1_2;
 
   REC_ReadConfigInteger(client_ssl_options, "proxy.config.ssl.client.TLSv1_2");
-  if (!client_ssl_options)
-    ssl_client_ctx_protocols |= SSL_OP_NO_TLSv1_2;
+
+  if (!client_ssl_options) {
+    ssl_client_ctx_options |= SSL_OP_NO_TLSv1_2;
+  }
 #endif
 
 #ifdef SSL_OP_CIPHER_SERVER_PREFERENCE
@@ -222,6 +227,7 @@ SSLConfigParams::initialize()
 #ifdef SSL_OP_NO_COMPRESSION
   /* OpenSSL >= 1.0 only */
   ssl_ctx_options |= SSL_OP_NO_COMPRESSION;
+  ssl_client_ctx_options |= SSL_OP_NO_COMPRESSION;
 #elif OPENSSL_VERSION_NUMBER >= 0x00908000L
   sk_SSL_COMP_zero(SSL_COMP_get_compression_methods());
 #endif
@@ -229,19 +235,23 @@ SSLConfigParams::initialize()
 // Enable ephemeral DH parameters for the case where we use a cipher with DH forward security.
 #ifdef SSL_OP_SINGLE_DH_USE
   ssl_ctx_options |= SSL_OP_SINGLE_DH_USE;
+  ssl_client_ctx_options |= SSL_OP_SINGLE_DH_USE;
 #endif
 
 #ifdef SSL_OP_SINGLE_ECDH_USE
   ssl_ctx_options |= SSL_OP_SINGLE_ECDH_USE;
+  ssl_client_ctx_options |= SSL_OP_SINGLE_ECDH_USE;
 #endif
 
   // Enable all SSL compatibility workarounds.
   ssl_ctx_options |= SSL_OP_ALL;
+  ssl_client_ctx_options |= SSL_OP_ALL;
 
 // According to OpenSSL source, applications must enable this if they support the Server Name extension. Since
 // we do, then we ought to enable this. Httpd also enables this unconditionally.
 #ifdef SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION
   ssl_ctx_options |= SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION;
+  ssl_client_ctx_options |= SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION;
 #endif
 
   REC_ReadConfigStringAlloc(serverCertChainFilename, "proxy.config.ssl.server.cert_chain.filename");


### PR DESCRIPTION
(cherry picked from commit 2075a921ec27d2bb3f6310fa0a427429d0d15893)


-- This patch allows to have different options and tls versions on the outbound and inbound context. Even though we had separate config variables before, those were useless as the code would set the client ctx with server options and then with client specific options. We had a scenario where the outbound and inbound needed to have completely different tls version which was not working