### PR TITLE
Fix instability caused by HTTP2_SESSION_EVENT_FINI

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -836,6 +836,9 @@ static const http2_frame_dispatch frame_handlers[HTTP2_FRAME_TYPE_MAX] = {
 int
 Http2ConnectionState::main_event_handler(int event, void *edata)
 {
+  if (edata == fini_event) {
+    fini_event = nullptr;
+  }
   ++recursion;
   switch (event) {
   // Initialize HTTP/2 Connection
@@ -910,7 +913,9 @@ Http2ConnectionState::main_event_handler(int event, void *edata)
         }
         this->send_goaway_frame(this->latest_streamid_in, error.code);
         this->ua_session->set_half_close_local_flag(true);
-        this_ethread()->schedule_imm_local((Continuation *)this, HTTP2_SESSION_EVENT_FINI);
+        if (fini_event == nullptr) {
+          fini_event = this_ethread()->schedule_imm_local((Continuation *)this, HTTP2_SESSION_EVENT_FINI);
+        }
 
         // The streams will be cleaned up by the HTTP2_SESSION_EVENT_FINI event
         // The Http2ClientSession will shutdown because connection_state.is_state_closed() will be true
@@ -970,8 +975,11 @@ Http2ConnectionState::main_event_handler(int event, void *edata)
 }
 
 int
-Http2ConnectionState::state_closed(int /* event */, void * /* edata */)
+Http2ConnectionState::state_closed(int /* event */, void *edata)
 {
+  if (edata == fini_event) {
+    fini_event = nullptr;
+  }
   return 0;
 }
 
@@ -1197,8 +1205,8 @@ Http2ConnectionState::release_stream(Http2Stream *stream)
         // Can't do this because we just destroyed right here ^,
         // or we can use a local variable to do it.
         // ua_session = nullptr;
-      } else if (shutdown_state == HTTP2_SHUTDOWN_IN_PROGRESS) {
-        this_ethread()->schedule_imm_local((Continuation *)this, HTTP2_SESSION_EVENT_FINI);
+      } else if (shutdown_state == HTTP2_SHUTDOWN_IN_PROGRESS && fini_event == nullptr) {
+        fini_event = this_ethread()->schedule_imm_local((Continuation *)this, HTTP2_SESSION_EVENT_FINI);
       }
     }
   }
@@ -1438,7 +1446,9 @@ Http2ConnectionState::send_headers_frame(Http2Stream *stream)
   if (!stream->change_state(HTTP2_FRAME_TYPE_HEADERS, flags)) {
     this->send_goaway_frame(this->latest_streamid_in, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR);
     this->ua_session->set_half_close_local_flag(true);
-    this_ethread()->schedule_imm_local((Continuation *)this, HTTP2_SESSION_EVENT_FINI);
+    if (fini_event == nullptr) {
+      fini_event = this_ethread()->schedule_imm_local((Continuation *)this, HTTP2_SESSION_EVENT_FINI);
+    }
 
     h2_hdr.destroy();
     ats_free(buf);
@@ -1615,7 +1625,9 @@ Http2ConnectionState::send_rst_stream_frame(Http2StreamId id, Http2ErrorCode ec)
     if (!stream->change_state(HTTP2_FRAME_TYPE_RST_STREAM, 0)) {
       this->send_goaway_frame(this->latest_streamid_in, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR);
       this->ua_session->set_half_close_local_flag(true);
-      this_ethread()->schedule_imm_local((Continuation *)this, HTTP2_SESSION_EVENT_FINI);
+      if (fini_event == nullptr) {
+        fini_event = this_ethread()->schedule_imm_local((Continuation *)this, HTTP2_SESSION_EVENT_FINI);
+      }
 
       return;
     }
@@ -1651,7 +1663,9 @@ Http2ConnectionState::send_settings_frame(const Http2ConnectionSettings &new_set
       if (!http2_write_settings(param, iov)) {
         this->send_goaway_frame(this->latest_streamid_in, Http2ErrorCode::HTTP2_ERROR_INTERNAL_ERROR);
         this->ua_session->set_half_close_local_flag(true);
-        this_ethread()->schedule_imm_local((Continuation *)this, HTTP2_SESSION_EVENT_FINI);
+        if (fini_event == nullptr) {
+          fini_event = this_ethread()->schedule_imm_local((Continuation *)this, HTTP2_SESSION_EVENT_FINI);
+        }
 
         return;
       }

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -152,6 +152,10 @@ public:
 
     delete dependency_tree;
     this->ua_session = nullptr;
+
+    if (fini_event) {
+      fini_event->cancel();
+    }
   }
 
   // Event handlers
@@ -307,6 +311,7 @@ private:
   int recursion                     = 0;
   Http2ShutdownState shutdown_state = HTTP2_SHUTDOWN_NONE;
   Event *shutdown_cont_event        = nullptr;
+  Event *fini_event                 = nullptr;
 };
 
 #endif // __HTTP2_CONNECTION_STATE_H__


### PR DESCRIPTION
```
[ 0 ] traffic_server     Continuation::handleEvent(int, void*)                   ( I_Continuation.h:153 ) 
[ 1 ] traffic_server     EThread::process_event(Event*, int)                     ( UnixEThread.cc:122   ) 
[ 2 ] traffic_server     EThread::process_queue(Queue<Event, Event::Link_link>*) ( UnixEThread.cc:159   ) 
[ 3 ] traffic_server     EThread::execute_regular()                              ( UnixEThread.cc:191   ) 
[ 4 ] traffic_server     EThread::execute()                                      ( UnixEThread.cc:262   ) 
[ 5 ] traffic_server     spawn_thread_internal                                   ( Thread.cc:85         ) 
[ 6 ] libpthread-2.12.so start_thread                                            ( :undefined           )
```

This happens quite frequently after disabling freelist and using jemalloc, and the event is always HTTP2_SESSION_EVENT_FINI.