### PR TITLE
Removes the delay when sending traffic_ctl msgs

### DIFF
--- a/mgmt/BaseManager.cc
+++ b/mgmt/BaseManager.cc
@@ -113,44 +113,6 @@ BaseManager::registerMgmtCallback(int msg_id, MgmtCallback cb, void *opaque_cb_d
   return msg_id;
 } /* End BaseManager::registerMgmtCallback */
 
-/*
- * signalMgmtEntity(...)
- */
-int
-BaseManager::signalMgmtEntity(int msg_id, char *data_str)
-{
-  if (data_str) {
-    return signalMgmtEntity(msg_id, data_str, strlen(data_str) + 1);
-  } else {
-    return signalMgmtEntity(msg_id, nullptr, 0);
-  }
-
-} /* End BaseManager::signalMgmtEntity */
-
-/*
- * signalMgmtEntity(...)
- */
-int
-BaseManager::signalMgmtEntity(int msg_id, char *data_raw, int data_len)
-{
-  MgmtMessageHdr *mh;
-
-  if (data_raw) {
-    mh           = (MgmtMessageHdr *)ats_malloc(sizeof(MgmtMessageHdr) + data_len);
-    mh->msg_id   = msg_id;
-    mh->data_len = data_len;
-    memcpy((char *)mh + sizeof(MgmtMessageHdr), data_raw, data_len);
-  } else {
-    mh           = (MgmtMessageHdr *)ats_malloc(sizeof(MgmtMessageHdr));
-    mh->msg_id   = msg_id;
-    mh->data_len = 0;
-  }
-
-  ink_release_assert(enqueue(mgmt_event_queue, mh));
-  return msg_id;
-
-} /* End BaseManager::signalMgmtEntity */
-
 void
 BaseManager::executeMgmtCallback(int msg_id, char *data_raw, int data_len)
 {

--- a/mgmt/BaseManager.h
+++ b/mgmt/BaseManager.h
@@ -124,9 +124,6 @@ public:
 
   int registerMgmtCallback(int msg_id, MgmtCallback func, void *opaque_callback_data = NULL);
 
-  int signalMgmtEntity(int msg_id, char *data_str = NULL);
-  int signalMgmtEntity(int msg_id, char *data_raw, int data_len);
-
   LLQ *mgmt_event_queue;
   InkHashTable *mgmt_callback_table;
 

--- a/mgmt/LocalManager.h
+++ b/mgmt/LocalManager.h
@@ -37,10 +37,13 @@
 #include "Alarms.h"
 #include "BaseManager.h"
 #include <records/I_RecHttp.h>
+#include <syslog.h>
 #if TS_HAS_WCCP
 #include <wccp/Wccp.h>
 #endif
-#include <syslog.h>
+#if HAVE_EVENTFD
+#include <sys/eventfd.h>
+#endif
 
 class FileManager;
 
@@ -120,7 +123,10 @@ public:
 
   int process_server_sockfd = ts::NO_FD;
   int watched_process_fd    = ts::NO_FD;
-  pid_t proxy_launch_pid    = -1;
+#if HAVE_EVENTFD
+  int wakeup_fd = ts::NO_FD; // external trigger to stop polling
+#endif
+  pid_t proxy_launch_pid = -1;
 
   Alarms *alarm_keeper     = nullptr;
   FileManager *configFiles = nullptr;

--- a/mgmt/ProcessManager.h
+++ b/mgmt/ProcessManager.h
@@ -43,6 +43,10 @@
 #include "ts/ink_apidefs.h"
 #include <functional>
 
+#if HAVE_EVENTFD
+#include <sys/eventfd.h>
+#endif
+
 class ConfigUpdateCbTable;
 
 class ProcessManager : public BaseManager
@@ -91,6 +95,9 @@ private:
   std::function<void()> init;
 
   int local_manager_sockfd;
+#if HAVE_EVENTFD
+  int wakeup_fd; // external trigger to stop polling
+#endif
   ConfigUpdateCbTable *cbtable;
   int max_msgs_in_a_row;
 


### PR DESCRIPTION
New PR, couldn't reopen because force pushed.

The RPC code used for traffic_ctl to communicate with traffic_server has a long delay associated. There's a situation (which happens often) where both LocalManager and ProcessManager are polling for messages over the socket. Both can't write so there's nothing to read. Currently, they rely on a timeout to stop polling and start sending messages. This fix:

1. allows for external events (ie. adding to a write queue) to trigger and eventfd to wakeup the manager
2. removes static wait, previously in ProcessManager.cc:175
3. makes `ProcessManager` handle messages as they arrive, similar to what `LocalManager` does

Effectively, it actively stops polling rather than passively relying on timeouts. This causes msgs sent from traffic_ctl to be quickly received by traffic_server.