### PR TITLE
Remove unused SHARED_* build variables.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -601,9 +601,8 @@ TS_SUBST([pkgdocdir])
 # Implementation note (toc)
 # 1) Get default compiler settings (case statement.)
 # 2) Check for over-rides of default compiler.
-# 3) Set standard CFLAGS, SHARED_CFLAGS, etc.
-# 4) (in first kludge mode block...) obtain any further CFLAG-type additions.
-# 5) Test compilers with all flags set.
+# 3) (in first kludge mode block...) obtain any further CFLAG-type additions.
+# 4) Test compilers with all flags set.
 
 # AC_PROG can sometimes mangle CFLAGS etc.
 # in particular, on Linux they insert -g -O2, here we preserve any user CFLAGS
@@ -955,11 +954,6 @@ cxx_oflag_dbg="$debug_opt $cxx_opt $cxx_dbg"
 
 # Special compiler flag hacks for various pieces of the code
 AC_SUBST([FLEX_CFLAGS], $flex_cflags)
-
-SHARED_CFLAGS=-fPIC
-SHARED_LDFLAGS=-shared
-SHARED_CXXFLAGS=-fPIC
-SHARED_CXXLINKFLAGS=-shared
 
 #
 # _Here_ is where we go ahead and add the _optimizations_ to already
@@ -1994,10 +1988,6 @@ AC_SUBST([AM_CFLAGS])
 AC_SUBST([AM_CXXFLAGS])
 AC_SUBST([AM_LDFLAGS])
 AC_SUBST([iocore_include_dirs])
-AC_SUBST([SHARED_CFLAGS])
-AC_SUBST([SHARED_CXXFLAGS])
-AC_SUBST([SHARED_CXXLINKFLAGS])
-AC_SUBST([SHARED_LDFLAGS])
 
 AS_IF([test "x$RPATH" != "x"], [
        TS_ADDTO_RPATH([$RPATH])
@@ -2083,10 +2073,6 @@ AC_MSG_NOTICE([Build option summary:
     AM@&t@_CXXFLAGS:        $AM_CXXFLAGS
     AM@&t@_CPPFLAGS:        $AM_CPPFLAGS
     AM@&t@_LDFLAGS:         $AM_LDFLAGS
-    SHARED_CFLAGS:      $SHARED_CFLAGS
-    SHARED_CXXFLAGS:    $SHARED_CXXFLAGS
-    SHARED_CXXLINKFLAGS:$SHARED_LINKCXXFLAGS
-    SHARED_LDFLAGS:     $SHARED_LDFLAGS
     OPENSSL_LDFLAGS:    $OPENSSL_LDFLAGS
     OPENSSL_INCLUDES:   $OPENSSL_INCLUDES
     LUAJIT_CFLAGS:      $LUAJIT_CFLAGS


### PR DESCRIPTION
Remove the SHARED_* build variables from configure, since they
are not used.