### PR TITLE
Fix default include path ordering.

### DIFF
--- a/cmd/traffic_cop/Makefile.am
+++ b/cmd/traffic_cop/Makefile.am
@@ -17,11 +17,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-AM_CPPFLAGS += $(iocore_include_dirs) \
+AM_CPPFLAGS += \
+  $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/lib/records \
   -I$(abs_top_srcdir)/mgmt \
-  -I$(abs_top_srcdir)/mgmt/api/include
+  -I$(abs_top_srcdir)/mgmt/api/include \
+  $(TS_INCLUDES)
 
 AM_LDFLAGS += \
   @OPENSSL_LDFLAGS@

--- a/cmd/traffic_crashlog/Makefile.am
+++ b/cmd/traffic_crashlog/Makefile.am
@@ -23,7 +23,8 @@ AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/lib/records \
   -I$(abs_top_srcdir)/mgmt \
   -I$(abs_top_srcdir)/mgmt/utils \
-  -I$(abs_top_srcdir)/mgmt/api/include
+  -I$(abs_top_srcdir)/mgmt/api/include \
+  $(TS_INCLUDES)
 
 AM_LDFLAGS += \
   @OPENSSL_LDFLAGS@

--- a/cmd/traffic_ctl/Makefile.am
+++ b/cmd/traffic_ctl/Makefile.am
@@ -22,7 +22,8 @@ AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/lib/records \
   -I$(abs_top_srcdir)/mgmt \
-  -I$(abs_top_srcdir)/mgmt/api/include
+  -I$(abs_top_srcdir)/mgmt/api/include \
+  $(TS_INCLUDES)
 
 bin_PROGRAMS = traffic_ctl
 

--- a/cmd/traffic_layout/Makefile.am
+++ b/cmd/traffic_layout/Makefile.am
@@ -22,7 +22,8 @@ AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/lib/records \
   -I$(abs_top_srcdir)/mgmt \
-  -I$(abs_top_srcdir)/mgmt/utils
+  -I$(abs_top_srcdir)/mgmt/utils \
+  $(TS_INCLUDES)
 
 AM_LDFLAGS += \
   @OPENSSL_LDFLAGS@

--- a/cmd/traffic_manager/Makefile.am
+++ b/cmd/traffic_manager/Makefile.am
@@ -30,7 +30,8 @@ AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/mgmt/api \
   -I$(abs_top_srcdir)/mgmt/api/include \
   -I$(abs_top_srcdir)/mgmt/utils \
-  -I$(abs_top_srcdir)/lib
+  -I$(abs_top_srcdir)/lib \
+  $(TS_INCLUDES)
 
 if BUILD_LUAJIT
 AM_CPPFLAGS += \

--- a/cmd/traffic_top/Makefile.am
+++ b/cmd/traffic_top/Makefile.am
@@ -24,6 +24,7 @@ AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/lib/records \
   -I$(abs_top_srcdir)/mgmt \
   -I$(abs_top_srcdir)/mgmt/api/include \
+  $(TS_INCLUDES) \
   @CURL_CFLAGS@ \
   @CURSES_CFLAGS@
 

--- a/cmd/traffic_via/Makefile.am
+++ b/cmd/traffic_via/Makefile.am
@@ -20,7 +20,8 @@
 AM_CPPFLAGS += \
   $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib \
-  -I$(abs_top_srcdir)/mgmt/api/include
+  -I$(abs_top_srcdir)/mgmt/api/include \
+  $(TS_INCLUDES)
 
 AM_LDFLAGS += \
   @OPENSSL_LDFLAGS@

--- a/cmd/traffic_wccp/Makefile.am
+++ b/cmd/traffic_wccp/Makefile.am
@@ -17,10 +17,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-AM_CPPFLAGS += $(iocore_include_dirs) \
+AM_CPPFLAGS += \
+  $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/lib/records \
   -I$(abs_top_srcdir)/lib/wccp \
+  $(TS_INCLUDES) \
   @OPENSSL_INCLUDES@
 
 AM_LDFLAGS += \

--- a/configure.ac
+++ b/configure.ac
@@ -655,7 +655,7 @@ case $host_os in
   freebsd*)
     host_os_def="freebsd"
     AM_LDFLAGS="-rdynamic"
-    TS_ADDTO(AM_CPPFLAGS, [-I/usr/local/include])
+    TS_ADDTO(TS_INCLUDES, [-I/usr/local/include])
     TS_ADDTO(AM_CPPFLAGS, [-D_GLIBCXX_USE_C99])
     TS_ADDTO(AM_CPPFLAGS, [-D_GLIBCXX_USE_C99_MATH])
     TS_ADDTO(AM_CPPFLAGS, [-D_GLIBCXX_USE_C99_MATH_TR1])
@@ -663,7 +663,7 @@ case $host_os in
   kfreebsd*)
     host_os_def="freebsd"
     AM_LDFLAGS="-rdynamic"
-    TS_ADDTO(AM_CPPFLAGS, [-I/usr/local/include])
+    TS_ADDTO(TS_INCLUDES, [-I/usr/local/include])
     TS_ADDTO(AM_CPPFLAGS, [-Dkfreebsd])
     ;;
   openbsd*)
@@ -872,7 +872,7 @@ case $host_os_def in
 
     # NOTE: This seems semi-kludgy, but useful for MacPorts I think.
     AS_IF([test -d /opt/local/include], [
-      TS_ADDTO(AM_CPPFLAGS, [-I/opt/local/include])
+      TS_ADDTO(TS_INCLUDES, [-I/opt/local/include])
     ])
     AS_IF([test -d /opt/local/lib], [
       TS_ADDTO(AM_LDFLAGS, [-L/opt/local/lib])
@@ -1247,7 +1247,7 @@ AC_SUBST([LIBTCL],[$TCL_LIB_SPEC])
 
 
 if test "x${TCL_INCLUDE_SPEC}" != "x-I/usr/include"; then
-   TS_ADDTO(AM_CPPFLAGS, [$TCL_INCLUDE_SPEC])
+   TS_ADDTO(TS_INCLUDES, [$TCL_INCLUDE_SPEC])
 fi
 
 AC_CHECK_FUNCS([clock_gettime kqueue epoll_ctl posix_memalign posix_fadvise posix_madvise posix_fallocate inotify_init])
@@ -1989,6 +1989,13 @@ AC_SUBST([AM_CXXFLAGS])
 AC_SUBST([AM_LDFLAGS])
 AC_SUBST([iocore_include_dirs])
 
+# NOTE: All additions to the default include path must be added to
+# TS_INCLUDES *not* to AM_CPPFLAGS. If you add then to AM_CPPFLAGS
+# then they are always prepended to the local AM_CPPFLAGS which risks
+# name collisions with in-tree files. We always want the in-tree files
+# to have precendence.
+AC_SUBST([TS_INCLUDES])
+
 AS_IF([test "x$RPATH" != "x"], [
        TS_ADDTO_RPATH([$RPATH])
 ])
@@ -2073,9 +2080,10 @@ AC_MSG_NOTICE([Build option summary:
     AM@&t@_CXXFLAGS:        $AM_CXXFLAGS
     AM@&t@_CPPFLAGS:        $AM_CPPFLAGS
     AM@&t@_LDFLAGS:         $AM_LDFLAGS
+    TS_INCLUDES:        $TS_INCLUDES
     OPENSSL_LDFLAGS:    $OPENSSL_LDFLAGS
     OPENSSL_INCLUDES:   $OPENSSL_INCLUDES
     LUAJIT_CFLAGS:      $LUAJIT_CFLAGS
-    LUAJIT_CPPFLAGS:	$LUAJIT_CPPFLAGS
+    LUAJIT_CPPFLAGS:	  $LUAJIT_CPPFLAGS
     LUAJIT_LDFLAGS:     $LUAJIT_LDFLAGS
 ])

--- a/iocore/aio/Makefile.am
+++ b/iocore/aio/Makefile.am
@@ -19,7 +19,8 @@
 AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/iocore/eventsystem \
   -I$(abs_top_srcdir)/lib \
-  -I$(abs_top_srcdir)/lib/records
+  -I$(abs_top_srcdir)/lib/records \
+  $(TS_INCLUDES)
 
 TESTS = test_AIO.sample
 

--- a/iocore/cache/Makefile.am
+++ b/iocore/cache/Makefile.am
@@ -26,12 +26,8 @@ AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/proxy/shared \
   -I$(abs_top_srcdir)/proxy/http/remap \
   -I$(abs_top_srcdir)/mgmt \
-  -I$(abs_top_srcdir)/mgmt/utils
-
-ADD_SRC =
-if BUILD_TESTS
-  ADD_SRC += CacheTest.cc P_CacheTest.h
-endif
+  -I$(abs_top_srcdir)/mgmt/utils \
+  $(TS_INCLUDES)
 
 noinst_LIBRARIES = libinkcache.a
 
@@ -62,8 +58,13 @@ libinkcache_a_SOURCES = \
   P_RamCache.h \
   RamCacheCLFUS.cc \
   RamCacheLRU.cc \
-  Store.cc \
-  $(ADD_SRC)
+  Store.cc
+
+if BUILD_TESTS
+libinkcache_a_SOURCES += \
+  CacheTest.cc \
+  P_CacheTest.h
+endif
 
 include $(top_srcdir)/build/tidy.mk
 

--- a/iocore/dns/Makefile.am
+++ b/iocore/dns/Makefile.am
@@ -24,7 +24,8 @@ AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/proxy/http \
   -I$(abs_top_srcdir)/proxy/hdrs \
   -I$(abs_top_srcdir)/mgmt \
-  -I$(abs_top_srcdir)/mgmt/utils
+  -I$(abs_top_srcdir)/mgmt/utils \
+  $(TS_INCLUDES)
 
 noinst_LIBRARIES = libinkdns.a
 

--- a/iocore/eventsystem/Makefile.am
+++ b/iocore/eventsystem/Makefile.am
@@ -18,7 +18,8 @@
 
 AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/lib \
-  -I$(abs_top_srcdir)/lib/records
+  -I$(abs_top_srcdir)/lib/records \
+  $(TS_INCLUDES)
 
 TESTS = $(check_PROGRAMS)
 

--- a/iocore/hostdb/Makefile.am
+++ b/iocore/hostdb/Makefile.am
@@ -24,7 +24,8 @@ AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/proxy/hdrs \
   -I$(abs_top_srcdir)/proxy/http \
   -I$(abs_top_srcdir)/mgmt \
-  -I$(abs_top_srcdir)/mgmt/utils
+  -I$(abs_top_srcdir)/mgmt/utils \
+  $(TS_INCLUDES)
 
 EXTRA_DIST = I_HostDB.h
 

--- a/iocore/net/Makefile.am
+++ b/iocore/net/Makefile.am
@@ -27,6 +27,7 @@ AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/mgmt \
   -I$(abs_top_srcdir)/mgmt/utils \
   -I$(abs_top_srcdir)/proxy/http \
+  $(TS_INCLUDES) \
   @OPENSSL_INCLUDES@
 
 TESTS = $(check_PROGRAMS)

--- a/iocore/utils/Makefile.am
+++ b/iocore/utils/Makefile.am
@@ -19,7 +19,8 @@
 AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/lib \
   -I$(abs_top_srcdir)/lib/records \
-  -I$(abs_top_srcdir)/iocore/eventsystem
+  -I$(abs_top_srcdir)/iocore/eventsystem \
+  $(TS_INCLUDES)
 
 noinst_LIBRARIES = libinkutils.a
 

--- a/lib/bindings/Makefile.am
+++ b/lib/bindings/Makefile.am
@@ -21,7 +21,8 @@ include $(top_srcdir)/build/tidy.mk
 AM_CPPFLAGS += \
   $(LUAJIT_CPPFLAGS) \
   -I$(abs_top_srcdir)/lib \
-  -I$(abs_top_srcdir)/lib/records
+  -I$(abs_top_srcdir)/lib/records \
+  $(TS_INCLUDES)
 
 noinst_LTLIBRARIES = libbindings.la
 

--- a/lib/records/Makefile.am
+++ b/lib/records/Makefile.am
@@ -24,7 +24,8 @@ AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/mgmt \
   -I$(abs_top_srcdir)/mgmt/api/include \
   -I$(abs_top_srcdir)/mgmt/utils \
-  -I$(abs_top_srcdir)/lib
+  -I$(abs_top_srcdir)/lib \
+  $(TS_INCLUDES)
 
 noinst_LIBRARIES = librecords_lm.a librecords_p.a librecords_cop.a
 

--- a/lib/ts/Makefile.am
+++ b/lib/ts/Makefile.am
@@ -32,9 +32,10 @@ TESTS = $(check_PROGRAMS)
 lib_LTLIBRARIES = libtsutil.la
 
 AM_CPPFLAGS += \
-               $(iocore_include_dirs) \
-               -I$(abs_top_srcdir)/lib \
-               -I$(abs_top_srcdir)/lib/records
+  $(iocore_include_dirs) \
+  -I$(abs_top_srcdir)/lib \
+  -I$(abs_top_srcdir)/lib/records \
+  $(TS_INCLUDES)
 
 libtsutil_la_LDFLAGS = -no-undefined -version-info @TS_LIBTOOL_VERSION@
 libtsutil_la_LIBADD = \

--- a/lib/tsconfig/Makefile.am
+++ b/lib/tsconfig/Makefile.am
@@ -24,7 +24,8 @@ AM_CFLAGS += @FLEX_CFLAGS@
 AM_YFLAGS = --yacc -d -p tsconfig
 
 AM_CPPFLAGS += \
-  -I$(abs_top_srcdir)/lib
+  -I$(abs_top_srcdir)/lib \
+  $(TS_INCLUDES)
 
 BUILT_SOURCES = \
   TsConfigGrammar.hpp

--- a/lib/wccp/Makefile.am
+++ b/lib/wccp/Makefile.am
@@ -21,7 +21,8 @@ include $(top_srcdir)/build/tidy.mk
 
 AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/lib \
-  -I$(abs_top_srcdir)/proxy
+  -I$(abs_top_srcdir)/proxy \
+  $(TS_INCLUDES)
 
 #WCCP_DEFS = @WCCP_DEFS@
 #DEFS += $(WCCP_DEFS)

--- a/mgmt/Makefile.am
+++ b/mgmt/Makefile.am
@@ -33,7 +33,8 @@ AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/proxy/http \
   -I$(abs_top_srcdir)/proxy/hdrs \
   -I$(abs_top_srcdir)/lib/records \
-  -I$(abs_top_srcdir)/lib
+  -I$(abs_top_srcdir)/lib \
+  $(TS_INCLUDES)
 
 libmgmt_c_la_SOURCES = \
   RecordsConfig.cc \

--- a/mgmt/api/Makefile.am
+++ b/mgmt/api/Makefile.am
@@ -28,6 +28,7 @@ AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/mgmt/utils \
   -I$(abs_top_srcdir)/mgmt/api/include \
   -I$(abs_top_srcdir)/lib \
+  $(TS_INCLUDES) \
   $(LIBUNWIND_CFLAGS)
 
 noinst_LTLIBRARIES = libmgmtapilocal.la libmgmtapi.la

--- a/mgmt/utils/Makefile.am
+++ b/mgmt/utils/Makefile.am
@@ -26,6 +26,7 @@ AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/proxy \
   -I$(abs_top_srcdir)/lib/records \
   -I$(abs_top_srcdir)/lib \
+  $(TS_INCLUDES) \
   @OPENSSL_INCLUDES@
 
 # header files used by other libraries

--- a/proxy/Makefile.am
+++ b/proxy/Makefile.am
@@ -42,6 +42,7 @@ AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/mgmt \
   -I$(abs_top_srcdir)/mgmt/utils \
   -I$(abs_top_srcdir)/lib \
+  $(TS_INCLUDES) \
   @OPENSSL_INCLUDES@
 
 # NOTE: it is safe to use AM_LDFLAGS here because we are only building executables. If we start

--- a/proxy/congest/Makefile.am
+++ b/proxy/congest/Makefile.am
@@ -25,7 +25,8 @@ AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/mgmt \
   -I$(abs_top_srcdir)/mgmt/utils \
   -I$(abs_top_srcdir)/proxy/shared \
-  -I$(abs_top_srcdir)/proxy/hdrs
+  -I$(abs_top_srcdir)/proxy/hdrs \
+  $(TS_INCLUDES)
 
 noinst_LIBRARIES = libCongestionControl.a
 

--- a/proxy/hdrs/Makefile.am
+++ b/proxy/hdrs/Makefile.am
@@ -21,7 +21,8 @@ include $(top_srcdir)/build/tidy.mk
 AM_CPPFLAGS += \
   $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib \
-  -I$(abs_top_srcdir)/lib/records
+  -I$(abs_top_srcdir)/lib/records \
+  $(TS_INCLUDES)
 
 noinst_LIBRARIES = libhdrs.a
 EXTRA_PROGRAMS = load_http_hdr

--- a/proxy/http/Makefile.am
+++ b/proxy/http/Makefile.am
@@ -31,7 +31,8 @@ AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/proxy/shared \
   -I$(abs_top_srcdir)/proxy/http/remap \
   -I$(abs_top_srcdir)/proxy/logging \
-  -I$(abs_top_srcdir)/proxy/http2
+  -I$(abs_top_srcdir)/proxy/http2 \
+  $(TS_INCLUDES)
 
 noinst_HEADERS = HttpProxyServerMain.h
 noinst_LIBRARIES = libhttp.a

--- a/proxy/http/remap/Makefile.am
+++ b/proxy/http/remap/Makefile.am
@@ -27,7 +27,8 @@ AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/mgmt/utils \
   -I$(abs_top_srcdir)/proxy/hdrs \
   -I$(abs_top_srcdir)/proxy/shared \
-  -I$(abs_top_srcdir)/proxy/http
+  -I$(abs_top_srcdir)/proxy/http \
+  $(TS_INCLUDES)
 
 noinst_LIBRARIES = libhttp_remap.a
 

--- a/proxy/http2/Makefile.am
+++ b/proxy/http2/Makefile.am
@@ -28,7 +28,8 @@ AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/proxy/http \
   -I$(abs_top_srcdir)/proxy/hdrs \
   -I$(abs_top_srcdir)/proxy/shared \
-  -I$(abs_top_srcdir)/proxy/http/remap
+  -I$(abs_top_srcdir)/proxy/http/remap \
+  $(TS_INCLUDES)
 
 noinst_LIBRARIES = libhttp2.a
 

--- a/proxy/logging/Makefile.am
+++ b/proxy/logging/Makefile.am
@@ -28,7 +28,8 @@ AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/proxy/hdrs \
   -I$(abs_top_srcdir)/proxy/shared \
   -I$(abs_top_srcdir)/mgmt \
-  -I$(abs_top_srcdir)/mgmt/utils
+  -I$(abs_top_srcdir)/mgmt/utils \
+  $(TS_INCLUDES)
 
 if BUILD_LUAJIT
 AM_CPPFLAGS += \

--- a/proxy/shared/Makefile.am
+++ b/proxy/shared/Makefile.am
@@ -35,9 +35,8 @@ AM_CPPFLAGS += \
   -I$(abs_top_srcdir)/proxy/http \
   -I$(abs_top_srcdir)/proxy/hdrs \
   -I$(abs_top_srcdir)/proxy/logging \
-  -I$(abs_top_srcdir)/lib
-
-
+  -I$(abs_top_srcdir)/lib \
+  $(TS_INCLUDES)
 
 libdiagsconfig_a_SOURCES = \
   DiagsConfig.cc

--- a/rc/Makefile.am
+++ b/rc/Makefile.am
@@ -16,13 +16,5 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-AM_CPPFLAGS += \
-  -I$(abs_top_srcdir)/lib/records \
-  -I$(abs_top_srcdir)/proxy \
-  -I$(abs_top_srcdir)/mgmt \
-  -I$(abs_top_srcdir)/mgmt/utils \
-  -I$(abs_top_srcdir)/proxy/cache \
-  -I$(abs_top_srcdir)/proxy/logging
-
 dist_bin_SCRIPTS = \
   trafficserver

--- a/tests/unit_tests/Makefile.am
+++ b/tests/unit_tests/Makefile.am
@@ -16,7 +16,8 @@
 #  limitations under the License.
 
 AM_CPPFLAGS += \
-  -I$(abs_top_srcdir)
+  -I$(abs_top_srcdir) \
+  $(TS_INCLUDES)
 
 bin_PROGRAMS = unit_tests
 

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -22,9 +22,11 @@ bin_SCRIPTS = tsxs tspush
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = trafficserver.pc
 
-AM_CPPFLAGS += $(iocore_include_dirs) \
+AM_CPPFLAGS += \
+  $(iocore_include_dirs) \
   -I$(abs_top_srcdir)/lib \
-  -I$(abs_top_srcdir)/lib/wccp
+  -I$(abs_top_srcdir)/lib/wccp \
+  $(TS_INCLUDES)
 
 if BUILD_TEST_TOOLS
 bin_PROGRAMS = jtest/jtest


### PR DESCRIPTION
Originally, prior to commit c7c9d0f7a, the configure phase
appended any include paths to `CPPFLAGS`. After c7c9d0f7a, they
were appended to `AM_CPPFLAGS`. Since automake always specifies
`AM_CPPFLAGS` before `CPPFLAGS` when it generated the compilation
commands, this had the effect of always including system (or
library) headers before any in-tree headers. However, we actually
want the reverse (i.e. the original semantics) because in the
case of a name collision we will always want to resolve the
in-tree name.

This problem caused the build to break on macOS 10.13 (with a
case-insensitive filesystem) because the in-tree `Transform.h`
was being resolved to the Tcl `transform.h`. Hijinks ensued.

The fix is simple but slightly ugly. We keep using `AM_CPPFLAGS`
for global defines, but create a `TS_INCLUDES` build variable for
the include path. This lets us control the include ordering and
ensure that the autoconfigured include paths are included last.