### PR TITLE
Support more redirect status codes - 303, 305.

### DIFF
--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -26,6 +26,7 @@
 
 #include "operators.h"
 #include "expander.h"
+#include "../../lib/ts/apidefs.h"
 
 // OperatorConfig
 void
@@ -279,10 +280,9 @@ OperatorSetRedirect::initialize(Parser &p)
 
   _status.set_value(p.get_arg());
   _location.set_value(p.get_value());
-
-  if ((_status.get_int_value() != (int)TS_HTTP_STATUS_MOVED_PERMANENTLY) &&
-      (_status.get_int_value() != (int)TS_HTTP_STATUS_MOVED_TEMPORARILY)) {
-    TSError("[%s] unsupported redirect status %d", PLUGIN_NAME, _status.get_int_value());
+  auto status = _status.get_int_value();
+  if (status < 300 || status > 399 || status == TS_HTTP_STATUS_NOT_MODIFIED) {
+    TSError("[%s] unsupported redirect status %d", PLUGIN_NAME, status);
   }
 
   require_resources(RSRC_SERVER_RESPONSE_HEADERS);

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -693,6 +693,8 @@ HttpTransact::EndRemapRequest(State *s)
     switch (s->http_return_code) {
     case HTTP_STATUS_MOVED_PERMANENTLY:
     case HTTP_STATUS_PERMANENT_REDIRECT:
+    case HTTP_STATUS_SEE_OTHER:
+    case HTTP_STATUS_USE_PROXY:
       error_body_type = "redirect#moved_permanently";
       break;
     case HTTP_STATUS_MOVED_TEMPORARILY:


### PR DESCRIPTION
This changes `header_rewrite` to not complain about status codes in the 300 range for `set-redirect`. The core also needed a tweak to support status codes 303 `See Other` and 305 `Use Proxy`.