### PR TITLE
Refine and clean up runroot

### DIFF
--- a/cmd/traffic_layout/engine.h
+++ b/cmd/traffic_layout/engine.h
@@ -51,7 +51,6 @@ struct RunrootEngine {
   void runroot_help_message(const bool runflag, const bool cleanflag);
 
   // the pass in arguments
-  int _argc;
   std::vector<std::string> _argv;
   // flags for command line parsing
   bool help_flag    = false;

--- a/cmd/traffic_layout/file_system.cc
+++ b/cmd/traffic_layout/file_system.cc
@@ -22,7 +22,8 @@
 */
 
 // funciton for file system management
-// including: make directory (with parents), copy directory (recursively), remove directory (recursively)
+// including: make directory (with parents), copy directory (recursively), remove directory (recursively), remove all directories
+// inside
 
 #include "ts/ink_error.h"
 #include "ts/I_Layout.h"
@@ -194,11 +195,11 @@ copy_function(const char *src_path, const struct stat *sb, int flag)
         ink_error("overwrite file falied during copy");
       }
     }
-    // for files if bin executable mode, symlink
+    // hardlink bin executable
     if (sb->st_mode == BIN_MODE) {
-      if (symlink(src_path, dst_path.c_str()) != 0) {
+      if (link(src_path, dst_path.c_str()) != 0) {
         if (errno != EEXIST)
-          ink_warning("failed to create symbolic link - %s", strerror(errno));
+          ink_warning("failed to create hard link - %s", strerror(errno));
       }
     } else {
       // for normal other files

--- a/cmd/traffic_layout/traffic_layout.cc
+++ b/cmd/traffic_layout/traffic_layout.cc
@@ -42,7 +42,7 @@ struct subcommand {
   const std::string help;
 };
 
-// // Command line arguments (parsing)
+// Command line arguments (parsing)
 struct CommandLineArgs {
   int layout;
   int features;
@@ -120,7 +120,6 @@ traffic_runroot(int argc, const char **argv)
 {
   // runroot engine for operations
   RunrootEngine engine;
-  engine._argc = argc;
 
   int i = 0;
   while (argv[i]) {

--- a/lib/ts/ink_args.cc
+++ b/lib/ts/ink_args.cc
@@ -221,9 +221,12 @@ process_args_ex(const AppVersionInfo *appinfo, const ArgumentDescription *argume
     if ((*argv)[1] == '-') {
       // Deal with long options ...
       for (i = 0; i < n_argument_descriptions; i++) {
-        if (!strcmp(argument_descriptions[i].name, "run-root")) {
+        // handle the runroot arg
+        std::string cur_argv = *argv + 2;
+        if (cur_argv.size() >= 8 && cur_argv.substr(0, 8) == "run-root") {
           break;
         }
+        // handle the args
         if (!strcmp(argument_descriptions[i].name, (*argv) + 2)) {
           *argv += strlen(*argv) - 1;
           if (!process_arg(appinfo, argument_descriptions, n_argument_descriptions, i, &argv)) {

--- a/lib/ts/runroot.cc
+++ b/lib/ts/runroot.cc
@@ -48,23 +48,39 @@ datadir, libexecdir, libdir, runtimedir, cachedir.
 
 static std::string using_runroot = {};
 
-// the function for the checking of the yaml file in parent path
+// the function for the checking of the yaml file in the passed in path
+// if found return the path, if not return empty string
+std::string
+check_path(const std::string &path)
+{
+  std::string whole_path = path;
+  std::string yaml_path  = Layout::relative_to(whole_path, "runroot_path.yml");
+  std::ifstream check_file;
+  check_file.open(yaml_path);
+  if (check_file.good()) {
+    return whole_path;
+  }
+  return {};
+}
+
+// the function for the checking of the yaml file in passed in directory or parent directory
 // if found return the parent path containing the yaml file
 std::string
-check_parent_path(const std::string &path, bool json)
+check_parent_path(const std::string &path)
 {
   std::string whole_path = path;
   if (whole_path.back() == '/')
     whole_path.pop_back();
 
-  whole_path                   = whole_path.substr(0, whole_path.find_last_of("/"));
-  std::string parent_yaml_path = Layout::relative_to(whole_path, "runroot_path.yml");
-  std::ifstream parent_check_file;
-  parent_check_file.open(parent_yaml_path);
-  if (parent_check_file.good()) {
-    if (!json)
-      ink_notice("using parent of bin/current working dir");
-    return whole_path;
+  // go up to 4 level of parent directories
+  for (int i = 0; i < 4; i++) {
+    if (whole_path.empty()) {
+      return {};
+    }
+    if (!check_path(whole_path).empty()) {
+      return whole_path;
+    }
+    whole_path = whole_path.substr(0, whole_path.find_last_of("/"));
   }
   return {};
 }
@@ -79,63 +95,84 @@ is_directory(const char *directory)
 }
 
 // handler for ts runroot
+// this function set up using_runroot
 void
 runroot_handler(const char **argv, bool json)
 {
-  std::string command = {};
-  std::string arg     = {};
-  std::string prefix  = "--run-root";
+  std::string prefix = "--run-root";
+  std::string path;
+
+  // check if we have --run-root...
+  std::string arg = {};
 
   int i = 0;
   while (argv[i]) {
-    command = argv[i];
+    std::string command = argv[i];
     if (command.substr(0, prefix.size()) == prefix) {
       arg = command;
       break;
     }
     i++;
   }
-  if (arg.empty())
-    return;
 
-  // 1. check pass in path
-  prefix += "=";
-  if (arg.substr(0, prefix.size()) == prefix) {
-    std::ifstream yaml_checkfile;
-    std::string path      = arg.substr(prefix.size(), arg.size() - 1);
-    std::string yaml_path = Layout::relative_to(path, "runroot_path.yml");
-    yaml_checkfile.open(yaml_path);
-    if (yaml_checkfile.good()) {
+  // if --run-root is provided arg is not just --run-root
+  if (!arg.empty() && arg != prefix) {
+    // 1. pass in path
+    prefix += "=";
+    path = check_path(arg.substr(prefix.size(), arg.size() - 1));
+    if (!path.empty()) {
       if (!json)
         ink_notice("using command line path as RUNROOT");
       using_runroot = path;
       return;
     } else {
       if (!json)
-        ink_warning("bad RUNROOT");
+        ink_warning("bad RUNROOT passed in");
     }
   }
-  // 2. argv provided invalid/no yaml file, then check env variable
+
+  // 2. check Environment variable
   char *env_val = getenv("TS_RUNROOT");
   if ((env_val != nullptr) && is_directory(env_val)) {
-    using_runroot = env_val;
-    if (!json)
-      ink_notice("using the environment variable TS_RUNROOT");
-    return;
-  }
-  // 3. find parent path of bin/pwd to check
-  char cwd[PATH_MAX]         = {0};
-  char RealBinPath[PATH_MAX] = {0};
-  if ((argv[0] != nullptr) && (getcwd(cwd, sizeof(cwd)) != nullptr) && (realpath(argv[0], RealBinPath) != nullptr)) {
-    std::vector<std::string> TwoPath = {RealBinPath, cwd};
-    for (auto it : TwoPath) {
-      std::string path = check_parent_path(it);
-      if (!path.empty()) {
-        using_runroot = path;
-        return;
-      }
+    path = check_path(env_val);
+    if (!path.empty()) {
+      using_runroot = env_val;
+      if (!json)
+        ink_notice("using the environment variable TS_RUNROOT");
+      return;
+    } else {
+      if (!json)
+        ink_warning("bad Environment var: $TS_RUNROOT");
     }
   }
+
+  // 3. find cwd or parent path of cwd to check
+  char cwd[PATH_MAX] = {0};
+  if (getcwd(cwd, sizeof(cwd)) != nullptr) {
+    path = check_parent_path(cwd);
+    if (!path.empty()) {
+      using_runroot = path;
+      if (!json)
+        ink_notice("using cwd as TS_RUNROOT");
+      return;
+    }
+  }
+
+  // 4. installed executable
+  char RealBinPath[PATH_MAX] = {0};
+  if ((argv[0] != nullptr) && realpath(argv[0], RealBinPath) != nullptr) {
+    std::string bindir = RealBinPath;
+    bindir             = bindir.substr(0, bindir.find_last_of("/")); // getting the bin dir not executable path
+    path               = check_parent_path(bindir);
+    if (!path.empty()) {
+      using_runroot = path;
+      if (!json)
+        ink_notice("using the installed dir as TS_RUNROOT");
+      return;
+    }
+  }
+  // 5. if no runroot use, using default build
+  return;
 }
 
 // return a map of all path in runroot_path.yml
@@ -145,7 +182,7 @@ runroot_map(std::string &yaml_path, std::string &prefix)
   std::ifstream file;
   file.open(yaml_path);
   if (!file.good()) {
-    ink_warning("Bad env path, continue with default value");
+    ink_warning("Bad path, continue with default value");
     return std::unordered_map<std::string, std::string>{};
   }
 
@@ -176,12 +213,10 @@ check_runroot()
     return std::unordered_map<std::string, std::string>{};
   }
 
-  std::string env_path = using_runroot;
-  int len              = env_path.size();
+  int len = using_runroot.size();
   if ((len + 1) > PATH_NAME_MAX) {
-    ink_fatal("TS_RUNROOT environment variable is too big: %d, max %d\n", len, PATH_NAME_MAX - 1);
+    ink_fatal("runroot path is too big: %d, max %d\n", len, PATH_NAME_MAX - 1);
   }
-  std::string yaml_path = Layout::relative_to(env_path, "runroot_path.yml");
-
-  return runroot_map(yaml_path, env_path);
+  std::string yaml_path = Layout::relative_to(using_runroot, "runroot_path.yml");
+  return runroot_map(yaml_path, using_runroot);
 }

--- a/lib/ts/runroot.h
+++ b/lib/ts/runroot.h
@@ -29,7 +29,7 @@
 #include <string>
 #include <unordered_map>
 
-std::string check_parent_path(const std::string &path, bool json = false);
+std::string check_parent_path(const std::string &path);
 
 void runroot_handler(const char **argv, bool json = false);
 

--- a/tests/gold_tests/basic/runroot.test.py
+++ b/tests/gold_tests/basic/runroot.test.py
@@ -38,32 +38,10 @@ f = tr.Disk.File(os.path.join(path, "runroot_path.yml"))
 f.Exists = True
 
 # remove from pass in path
-tr = Test.AddTestRun("Test traffoc_layout remove")
+tr = Test.AddTestRun("Test traffic_layout remove")
 tr.Processes.Default.Command = "$ATS_BIN/traffic_layout remove --path " + path
 tr.Processes.Default.ReturnCode = 0
 d = tr.Disk.Directory(path)
 d.Exists = False
 f = tr.Disk.File(os.path.join(path, "runroot_path.yml"))
 f.Exists = False
-
-# path += '/'
-
-# #use env variable to init
-# tr = Test.AddTestRun("Test traffic_layout ENV init")
-# tr.Processes.Default.Env["TS_RUNROOT"] = path
-# tr.Processes.Default.Command = "$ATS_BIN/traffic_layout init"
-# tr.Processes.Default.ReturnCode = 0
-# d = tr.Disk.Directory(path)
-# d.Exists = True
-# f = tr.Disk.File(os.path.join(path, "runroot_path.yml"))
-# f.Exists = True
-
-# #use env variable to remove
-# tr = Test.AddTestRun("Test traffic_layout ENV remove")
-# tr.Processes.Default.Env["TS_RUNROOT"] = path
-# tr.Processes.Default.Command = "$ATS_BIN/traffic_layout remove"
-# tr.Processes.Default.ReturnCode = 0
-# d = tr.Disk.Directory(path)
-# d.Exists = False
-# f = tr.Disk.File(os.path.join(path, "runroot_path.yml"))
-# f.Exists = False


### PR DESCRIPTION
1. Some code cleaning up of runroot engine and test.
2. Improved functionality of runroot_handler with executables using runroot directly by finding the current working directory or executable path.

@dragon512 