### PR TITLE
Acquire lock before calling Http2ClientSession::free() from Http2ConnectionState

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -965,9 +965,12 @@ Http2ConnectionState::main_event_handler(int event, void *edata)
   --recursion;
   if (recursion == 0 && ua_session && !ua_session->is_recursing()) {
     if (this->ua_session->ready_to_free()) {
-      this->ua_session->free();
-      // After the free, the Http2ConnectionState object is also freed.
-      // The Http2ConnectionState object is allocted within the Http2ClientSession object
+      MUTEX_TRY_LOCK(lock, this->ua_session->mutex, this_ethread());
+      if (lock.is_locked()) {
+        this->ua_session->free();
+        // After the free, the Http2ConnectionState object is also freed.
+        // The Http2ConnectionState object is allocted within the Http2ClientSession object
+      }
     }
   }
 


### PR DESCRIPTION
This is possible fix of GitHub#3176.

I couldn't reproduce the crash of #3176, but there is a path to call `ua_session->free()` without locking mutex of Http2ClientSession. So the crash could be happened when inactivity timeout and a event which go to the path are happened in same time.