### PR TITLE
Combine mutex of Http2ClientSession and Http2ConnectionState

### DIFF
--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -175,7 +175,7 @@ Http2ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOB
   this->mutex          = new_vc->mutex;
   this->in_destroy     = false;
 
-  this->connection_state.mutex = new_ProxyMutex();
+  this->connection_state.mutex = this->mutex;
 
   Http2SsnDebug("session born, netvc %p", this->client_vc);
 


### PR DESCRIPTION
Request for Comments.

This came up my mind while tracking recent annoying issues of HTTP/2 component. Is there're any advantages of using independent mutex of Http2ClientSession and Http2ConnectionState? In other words, is there any cases to run Http2ClientSession and Http2ConnectionState simultaneously?
It looks like this starts race of Http2ClientSession and Http2ConnectionState and it making complexity of event scheduling and mutex lock in HTTP/2 component.
