### PR TITLE
Add nullptr check before jump in HttpTunnel::consumer_handler()

### DIFF
--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1356,6 +1356,9 @@ HttpTunnel::consumer_handler(int event, HttpTunnelConsumer *c)
 
     c->bytes_written = c->write_vio ? c->write_vio->ndone : 0;
 
+    if (c->vc_handler == nullptr) {
+      break;
+    }
     // Interesting tunnel event, call SM
     jump_point = c->vc_handler;
     (sm->*jump_point)(event, c);


### PR DESCRIPTION
Fix for #3234