### PR TITLE
Select the current cert when looking for issuer

### DIFF
--- a/iocore/net/OCSPStapling.cc
+++ b/iocore/net/OCSPStapling.cc
@@ -86,6 +86,13 @@ stapling_get_issuer(SSL_CTX *ssl_ctx, X509 *x)
   if (inctx == nullptr) {
     return nullptr;
   }
+
+#ifdef SSL_CTX_select_current_cert
+  if (!SSL_CTX_select_current_cert(ssl_ctx, x)) {
+    Warning("OCSP: could not select current certifcate chain %p", x);
+  }
+#endif
+
   if (X509_STORE_CTX_init(inctx, st, nullptr, nullptr) == 0) {
     goto end;
   }


### PR DESCRIPTION
This is needed when working with multiple cert chains

Fixes issue #3032