### PR TITLE
No dump allocator using jemalloc

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -98,6 +98,11 @@ Copyright (c) <2008>, Sun Microsystems, Inc.  All rights reserved.
 
 ~~
 
-Reusable Gold Testing System  
+Reusable Gold Testing System
 https://bitbucket.org/dragon512/reusable-gold-testing-system
 Copyright (c) 2015-2016 Jason Kenny All Rights Reserved.
+
+~~
+
+Folly: Facebook Open-source Library
+https://github.com/facebook/folly

--- a/lib/ts/JeAllocator.cc
+++ b/lib/ts/JeAllocator.cc
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2016-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unistd.h>
+#include <sys/types.h>
+#include <cstring>
+#include <cstdlib>
+#include <iostream>
+#include "ts/ink_memory.h"
+#include "ts/ink_error.h"
+#include "ts/ink_assert.h"
+#include "ts/ink_align.h"
+#include "ts/JeAllocator.h"
+
+namespace jearena
+{
+JemallocNodumpAllocator::JemallocNodumpAllocator()
+{
+  extend_and_setup_arena();
+}
+
+#ifdef JEMALLOC_NODUMP_ALLOCATOR_SUPPORTED
+
+extent_hooks_t JemallocNodumpAllocator::extent_hooks_;
+extent_alloc_t *JemallocNodumpAllocator::original_alloc_ = nullptr;
+
+void *
+JemallocNodumpAllocator::alloc(extent_hooks_t *extent, void *new_addr, size_t size, size_t alignment, bool *zero, bool *commit,
+                               unsigned arena_ind)
+{
+  void *result = original_alloc_(extent, new_addr, size, alignment, zero, commit, arena_ind);
+
+  if (result != nullptr) {
+    // Seems like we don't really care if the advice went through
+    // in the original code, so just keeping it the same here.
+    ats_madvise((caddr_t)result, size, MADV_DONTDUMP);
+  }
+
+  return result;
+}
+
+#endif /* JEMALLOC_NODUMP_ALLOCATOR_SUPPORTED */
+
+bool
+JemallocNodumpAllocator::extend_and_setup_arena()
+{
+#ifdef JEMALLOC_NODUMP_ALLOCATOR_SUPPORTED
+  size_t arena_index_len_ = sizeof(arena_index_);
+  if (auto ret = mallctl("arenas.create", &arena_index_, &arena_index_len_, nullptr, 0)) {
+    ink_abort("Unable to extend arena: %s", std::strerror(ret));
+  }
+  flags_ = MALLOCX_ARENA(arena_index_) | MALLOCX_TCACHE_NONE;
+
+  // Read the existing hooks
+  const auto key = "arena." + std::to_string(arena_index_) + ".extent_hooks";
+  extent_hooks_t *hooks;
+  size_t hooks_len = sizeof(hooks);
+  if (auto ret = mallctl(key.c_str(), &hooks, &hooks_len, nullptr, 0)) {
+    ink_abort("Unable to get the hooks: %s", std::strerror(ret));
+  }
+  if (original_alloc_ == nullptr) {
+    original_alloc_ = hooks->alloc;
+  } else {
+    ink_release_assert(original_alloc_ == hooks->alloc);
+  }
+
+  // Set the custom hook
+  extent_hooks_             = *hooks;
+  extent_hooks_.alloc       = &JemallocNodumpAllocator::alloc;
+  extent_hooks_t *new_hooks = &extent_hooks_;
+  if (auto ret = mallctl(key.c_str(), nullptr, nullptr, &new_hooks, sizeof(new_hooks))) {
+    ink_abort("Unable to set the hooks: %s", std::strerror(ret));
+  }
+
+  return true;
+#else  /* JEMALLOC_NODUMP_ALLOCATOR_SUPPORTED */
+  return false;
+#endif /* JEMALLOC_NODUMP_ALLOCATOR_SUPPORTED */
+}
+
+/**
+ * This will retain the orignal functionality if
+ * !defined(JEMALLOC_NODUMP_ALLOCATOR_SUPPORTED)
+ */
+void *
+JemallocNodumpAllocator::allocate(InkFreeList *f)
+{
+  void *newp = nullptr;
+
+  if (f->advice) {
+#ifdef JEMALLOC_NODUMP_ALLOCATOR_SUPPORTED
+    if (likely(f->type_size > 0)) {
+      int flags = flags_ | MALLOCX_ALIGN(f->alignment);
+      if (unlikely((newp = mallocx(f->type_size, flags)) == nullptr)) {
+        ink_abort("couldn't allocate %u bytes", f->type_size);
+      }
+    }
+#else
+    newp = ats_memalign(f->alignment, f->type_size);
+    if (INK_ALIGN((uint64_t)newp, ats_pagesize()) == (uint64_t)newp) {
+      ats_madvise((caddr_t)newp, INK_ALIGN(f->type_size, f->alignment), f->advice);
+    }
+#endif
+  } else {
+    newp = ats_memalign(f->alignment, f->type_size);
+  }
+  return newp;
+}
+
+/**
+ * This will retain the orignal functionality if
+ * !defined(JEMALLOC_NODUMP_ALLOCATOR_SUPPORTED)
+ */
+void
+JemallocNodumpAllocator::deallocate(InkFreeList *f, void *ptr)
+{
+  if (f->advice) {
+#ifdef JEMALLOC_NODUMP_ALLOCATOR_SUPPORTED
+    if (likely(ptr)) {
+      dallocx(ptr, flags_);
+    }
+#else
+    ats_memalign_free(ptr);
+#endif
+  } else {
+    ats_memalign_free(ptr);
+  }
+}
+
+JemallocNodumpAllocator &
+globalJemallocNodumpAllocator()
+{
+  static auto instance = new JemallocNodumpAllocator();
+  return *instance;
+}
+}

--- a/lib/ts/JeAllocator.h
+++ b/lib/ts/JeAllocator.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2016-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// https://github.com/jemalloc/jemalloc/releases
+// Requires jemalloc 5.0.0 or above.
+
+#ifndef _jeallocator_h_
+#define _jeallocator_h_
+
+#include "ts/ink_config.h"
+#include "ts/ink_queue.h"
+#include <sys/mman.h>
+#include <cstddef>
+
+#if TS_HAS_JEMALLOC
+#include <jemalloc/jemalloc.h>
+#if (JEMALLOC_VERSION_MAJOR == 5) && defined(MADV_DONTDUMP)
+#define JEMALLOC_NODUMP_ALLOCATOR_SUPPORTED 1
+#endif /* MADV_DONTDUMP */
+#endif /* TS_HAS_JEMALLOC */
+
+namespace jearena
+{
+/**
+ * An allocator which uses Jemalloc to create an dedicated arena to allocate
+ * memory from. The only special property set on the allocated memory is that
+ * the memory is not dump-able.
+ *
+ * This is done by setting MADV_DONTDUMP using the `madvise` system call. A
+ * custom hook installed which is called when allocating a new chunk / extent of
+ * memory.  All it does is call the original jemalloc hook to allocate the
+ * memory and then set the advise on it before returning the pointer to the
+ * allocated memory. Jemalloc does not use allocated chunks / extents across
+ * different arenas, without `munmap`-ing them first, and the advises are not
+ * sticky i.e. they are unset if `munmap` is done. Also this arena can't be used
+ * by any other part of the code by just calling `malloc`.
+ *
+ * If target system doesn't support MADV_DONTDUMP or jemalloc doesn't support
+ * custom arena hook, JemallocNodumpAllocator would fall back to using malloc /
+ * free. Such behavior can be identified by using
+ * !defined(JEMALLOC_NODUMP_ALLOCATOR_SUPPORTED).
+ *
+ * Similarly, if binary isn't linked with jemalloc, the logic would fall back to
+ * malloc / free.
+ */
+class JemallocNodumpAllocator
+{
+public:
+  explicit JemallocNodumpAllocator();
+
+  void *allocate(InkFreeList *f);
+  void deallocate(InkFreeList *f, void *ptr);
+
+private:
+#if JEMALLOC_NODUMP_ALLOCATOR_SUPPORTED
+  static extent_hooks_t extent_hooks_;
+  static extent_alloc_t *original_alloc_;
+  static void *alloc(extent_hooks_t *extent, void *new_addr, size_t size, size_t alignment, bool *zero, bool *commit,
+                     unsigned arena_ind);
+
+  unsigned arena_index_{0};
+  int flags_{0};
+#endif /* JEMALLOC_NODUMP_ALLOCATOR_SUPPORTED */
+
+  bool extend_and_setup_arena();
+};
+
+/**
+ * JemallocNodumpAllocator singleton.
+ */
+JemallocNodumpAllocator &globalJemallocNodumpAllocator();
+
+} /* namespace jearena */
+
+#endif /* _jeallocator_h_ */

--- a/lib/ts/Makefile.am
+++ b/lib/ts/Makefile.am
@@ -161,6 +161,8 @@ libtsutil_la_SOURCES = \
   IpMapConf.h \
   IpMap.h \
   I_Version.h \
+  JeAllocator.h \
+  JeAllocator.cc \
   Layout.cc \
   List.h \
   llqueue.cc \


### PR DESCRIPTION
This allocator requires jemalloc 5.0.0 or above, else it falls back to the original memory allocator. 