### PR TITLE
Framework for CPPAPI regression test plugin run by a gold test

### DIFF
--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -42,6 +42,7 @@ include s3_auth/Makefile.inc
 include stats_over_http/Makefile.inc
 include tcpinfo/Makefile.inc
 include xdebug/Makefile.inc
+include test_cppapi/Makefile.inc
 
 if BUILD_EXPERIMENTAL_PLUGINS
 

--- a/plugins/test_cppapi/Makefile.inc
+++ b/plugins/test_cppapi/Makefile.inc
@@ -1,0 +1,18 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+pkglib_LTLIBRARIES += test_cppapi/test_cppapi.la
+test_cppapi_test_cppapi_la_SOURCES = test_cppapi/test_cppapi.cc

--- a/plugins/test_cppapi/test_cppapi.cc
+++ b/plugins/test_cppapi/test_cppapi.cc
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ts/ts.h"
+
+// Placeholder test.
+//
+namespace Test1
+{
+void
+x()
+{
+  TSReleaseAssert(true);
+}
+
+} // end namespace Test1;
+
+void
+TSPluginInit(int, const char **)
+{
+  TSPluginRegistrationInfo info;
+
+  info.plugin_name   = "test_cppapi";
+  info.vendor_name   = "Apache Software Foundation";
+  info.support_email = "dev@trafficserver.apache.org";
+
+  TSReleaseAssert(TSPluginRegister(&info) == TS_SUCCESS);
+
+  Test1::x();
+}

--- a/tests/gold_tests/pluginTest/cppapi/cppapi.test.py
+++ b/tests/gold_tests/pluginTest/cppapi/cppapi.test.py
@@ -1,0 +1,29 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = '''
+Execute plugin with cppapi tests.
+'''
+
+ts = Test.MakeATSProcess("ts")
+
+ts.Disk.plugin_config.AddLine('test_cppapi.so')
+
+tr = Test.AddTestRun()
+tr.Processes.Default.StartBefore(Test.Processes.ts)
+tr.Processes.Default.Command = "echo run test_cppapi plugin"
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.StillRunningAfter = ts


### PR DESCRIPTION
Tests for CPPAPI can be added to plugins/test_cppapi/test_cppapi.cc .