### PR TITLE
Clear vio so lingering IO is not confused when error message is returned

### DIFF
--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -306,9 +306,9 @@ CacheVC::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *abuf)
   vio.nbytes    = nbytes;
   vio.vc_server = this;
 #ifdef DEBUG
-  ink_assert(c->mutex->thread_holding);
+  ink_assert(!c || c->mutex->thread_holding);
 #endif
-  if (!trigger && !recursive) {
+  if (c && !trigger && !recursive) {
     trigger = c->mutex->thread_holding->schedule_imm_local(this);
   }
   return &vio;
@@ -344,9 +344,9 @@ CacheVC::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *abuf, bool
   vio.nbytes    = nbytes;
   vio.vc_server = this;
 #ifdef DEBUG
-  ink_assert(c->mutex->thread_holding);
+  ink_assert(!c || c->mutex->thread_holding);
 #endif
-  if (!trigger && !recursive) {
+  if (c && !trigger && !recursive) {
     trigger = c->mutex->thread_holding->schedule_imm_local(this);
   }
   return &vio;

--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1245,6 +1245,9 @@ HttpTunnel::producer_handler(int event, HttpTunnelProducer *p)
     if (p->alive) {
       p->alive      = false;
       p->bytes_read = p->read_vio->ndone;
+      // Clear any outstanding reads so they don't
+      // collide with future tunnel IO's
+      p->vc->do_io_read(nullptr, 0, 0);
       // Interesting tunnel event, call SM
       jump_point = p->vc_handler;
       (sm->*jump_point)(event, p);


### PR DESCRIPTION
Addresses issue #3239 

When a user agent timeout occurs, ATS sets up a tunnel to send a 408 response to the client.  The original post body tunnel is cleared but the read_vio on the client remains.  If the client awaken the read ready request gets delivered to the consumer_handler which is expecting only write operations.

If we clear the read_vio before setting up the error tunnel, any additional read operations from the timed out client will be ignored.