### PR TITLE
Syntax check should ignore age

### DIFF
--- a/tests/gold_tests/headers/syntax.200.gold
+++ b/tests/gold_tests/headers/syntax.200.gold
@@ -1,6 +1,6 @@
 HTTP/1.1 200 OK
 Date: ``
-Age: 0
+Age: ``
 Transfer-Encoding: chunked
 Connection: keep-alive
 Server: ``


### PR DESCRIPTION
The same element is fetched in test one and 5.  On a loaded system it
could be in cache for a second and report age:1 instead of age:0

Saw this failure in another PR.