### PR TITLE
Fixing 404 on redirects

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -1123,7 +1123,7 @@ HttpTransact::HandleRequest(State *s)
 {
   TxnDebug("http_trans", "START HttpTransact::HandleRequest");
 
-  if (!s->request_data.hdr) {
+  if (!s->state_machine->is_waiting_for_full_body) {
     ink_assert(!s->hdr_info.server_request.valid());
 
     HTTP_INCREMENT_DYN_STAT(http_incoming_requests_stat);


### PR DESCRIPTION
This is a bug introduced with PR #2335. The `if` is to avoid unnecessary
works when buffering the post body, but since redirects also need to
execute the logic flow and the request info may be changed during the
process of redirects. We need to extract the request info every time redirects
happen.