### PR TITLE
Fix parent.config memory leak.

### DIFF
--- a/proxy/ParentConsistentHash.cc
+++ b/proxy/ParentConsistentHash.cc
@@ -55,6 +55,7 @@ ParentConsistentHash::ParentConsistentHash(ParentRecord *parent_record)
 
 ParentConsistentHash::~ParentConsistentHash()
 {
+  Debug("parent_select", "~ParentConsistentHash(): releasing hashes");
   delete chash[PRIMARY];
   delete chash[SECONDARY];
 }

--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -91,6 +91,15 @@ ParentConfigParams::ParentConfigParams(P_table *_parent_table) : parent_table(_p
   ats_free(default_val);
 }
 
+ParentConfigParams::~ParentConfigParams()
+{
+  if (parent_table) {
+    Debug("parent_select", "~ParentConfigParams(): releasing parent_table %p", parent_table);
+  }
+  delete parent_table;
+  delete DefaultParent;
+}
+
 bool
 ParentConfigParams::apiParentExists(HttpRequestData *rdata)
 {
@@ -956,7 +965,6 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
 
 #define REBUILD                                                                                                            \
   do {                                                                                                                     \
-    delete ParentTable;                                                                                                    \
     delete params;                                                                                                         \
     ParentTable = new P_table("", "ParentSelection Unit Test Table", &http_dest_tags,                                      \
                               ALLOW_HOST_TABLE | ALLOW_REGEX_TABLE | ALLOW_URL_TABLE | ALLOW_IP_TABLE | DONT_BUILD_TABLE); \

--- a/proxy/ParentSelection.h
+++ b/proxy/ParentSelection.h
@@ -302,7 +302,7 @@ class ParentConfigParams : public ConfigInfo
 {
 public:
   explicit ParentConfigParams(P_table *_parent_table);
-  ~ParentConfigParams(){};
+  ~ParentConfigParams();
 
   bool apiParentExists(HttpRequestData *rdata);
   void findParent(HttpRequestData *rdata, ParentResult *result, unsigned int fail_threshold, unsigned int retry_time);


### PR DESCRIPTION
When loading a new parent.config with traffic_ctl, the old parent_table is not freed resulting in a memory leak.  This  patch fixes this problem.  This bug fix should be back ported to ats 7 and ats 6.