### PR TITLE
Add and update autest of runroot

### DIFF
--- a/tests/gold_tests/runroot/runroot_init.test.py
+++ b/tests/gold_tests/runroot/runroot_init.test.py
@@ -21,27 +21,33 @@ import sys
 import time
 
 Test.Summary = '''
-Test that use for runroot from traffic_layout is all functional.
+Test for init of runroot from traffic_layout.
 '''
 Test.ContinueOnFail = True
 
 p = Test.MakeATSProcess("ts")
-path = os.path.join(p.Env['TS_ROOT'], "runroot")
+ts_root = p.Env['TS_ROOT']
 
-# normal init from pass in path
-tr = Test.AddTestRun("Test traffic_layout init")
-tr.Processes.Default.Command = "$ATS_BIN/traffic_layout init --path " + path
+# init from pass in path
+path1 = os.path.join(ts_root, "runroot1")
+tr = Test.AddTestRun("Test traffic_layout init #1")
+tr.Processes.Default.Command = "$ATS_BIN/traffic_layout init --path " + path1
 tr.Processes.Default.ReturnCode = 0
-d = tr.Disk.Directory(path)
-d.Exists = True
-f = tr.Disk.File(os.path.join(path, "runroot_path.yml"))
+f = tr.Disk.File(os.path.join(path1, "runroot_path.yml"))
 f.Exists = True
 
-# remove from pass in path
-tr = Test.AddTestRun("Test traffic_layout remove")
-tr.Processes.Default.Command = "$ATS_BIN/traffic_layout remove --path " + path
+# init to relative directory
+path2 = os.path.join(ts_root, "runroot2")
+tr = Test.AddTestRun("Test traffic_layout init #2")
+tr.Processes.Default.Command = "cd " + ts_root + "; " + "$ATS_BIN/traffic_layout init --path runroot2"
 tr.Processes.Default.ReturnCode = 0
-d = tr.Disk.Directory(path)
-d.Exists = False
-f = tr.Disk.File(os.path.join(path, "runroot_path.yml"))
-f.Exists = False
+f = tr.Disk.File(os.path.join(path2, "runroot_path.yml"))
+f.Exists = True
+
+# init to cwd
+path3 = os.path.join(ts_root, "runroot3")
+tr = Test.AddTestRun("Test traffic_layout init #3")
+tr.Processes.Default.Command = "mkdir " + path3 + "; cd " + path3 + "; " + "$ATS_BIN/traffic_layout init"
+tr.Processes.Default.ReturnCode = 0
+f = tr.Disk.File(os.path.join(path3, "runroot_path.yml"))
+f.Exists = True

--- a/tests/gold_tests/runroot/runroot_remove.test.py
+++ b/tests/gold_tests/runroot/runroot_remove.test.py
@@ -1,0 +1,76 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import sys
+import time
+
+Test.Summary = '''
+Test for remove of runroot from traffic_layout.
+'''
+Test.ContinueOnFail = True
+
+p = Test.MakeATSProcess("ts")
+ts_root = p.Env['TS_ROOT']
+
+
+# create three runroot for removing testing
+path1 = os.path.join(ts_root, "runroot1")
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = "$ATS_BIN/traffic_layout init --path " + path1
+f = tr.Disk.File(os.path.join(path1, "runroot_path.yml"))
+f.Exists = True
+
+path2 = os.path.join(ts_root, "runroot2")
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = "$ATS_BIN/traffic_layout init --path " + path2
+f = tr.Disk.File(os.path.join(path2, "runroot_path.yml"))
+f.Exists = True
+
+path3 = os.path.join(ts_root, "runroot3")
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = "$ATS_BIN/traffic_layout init --path " + path3
+f = tr.Disk.File(os.path.join(path3, "runroot_path.yml"))
+f.Exists = True
+
+# normal remove from pass in path
+tr = Test.AddTestRun("Test traffic_layout remove #1")
+tr.Processes.Default.Command = "$ATS_BIN/traffic_layout remove --path " + path1
+tr.Processes.Default.ReturnCode = 0
+f = tr.Disk.File(os.path.join(path1, "runroot_path.yml"))
+f.Exists = False
+d = tr.Disk.Directory(path1)
+d.Exists = False
+
+# remove of relative path
+tr = Test.AddTestRun("Test traffic_layout remove #2")
+tr.Processes.Default.Command = "cd " + ts_root + "; " + "$ATS_BIN/traffic_layout remove --path runroot2"
+tr.Processes.Default.ReturnCode = 0
+f = tr.Disk.File(os.path.join(path2, "runroot_path.yml"))
+f.Exists = False
+d = tr.Disk.Directory(path2)
+d.Exists = False
+
+# remove cwd
+tr = Test.AddTestRun("Test traffic_layout remove #3")
+tr.Processes.Default.Command = "mkdir " + path3 + "; cd " + path3 + "; " + "$ATS_BIN/traffic_layout remove"
+tr.Processes.Default.ReturnCode = 0
+f = tr.Disk.File(os.path.join(path3, "runroot_path.yml"))
+f.Exists = False
+d = tr.Disk.Directory(path2)
+d.Exists = False

--- a/tests/gold_tests/runroot/runroot_use.test.py
+++ b/tests/gold_tests/runroot/runroot_use.test.py
@@ -1,0 +1,67 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import sys
+import time
+
+Test.Summary = '''
+Test for using of runroot from traffic_layout.
+'''
+Test.ContinueOnFail = True
+
+p = Test.MakeATSProcess("ts")
+ts_root = p.Env['TS_ROOT']
+
+# create two runroot for testing
+path = os.path.join(ts_root, "runroot")
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = "$ATS_BIN/traffic_layout init --path " + path
+f = tr.Disk.File(os.path.join(path, "runroot_path.yml"))
+f.Exists = True
+
+path2 = os.path.join(ts_root, "runroot2")
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = "$ATS_BIN/traffic_layout init --path " + path2
+f = tr.Disk.File(os.path.join(path2, "runroot_path.yml"))
+f.Exists = True
+
+# 1. --run-root use path cmd
+tr = Test.AddTestRun("use runroot via commandline")
+tr.Processes.Default.Command = os.path.join("$ATS_BIN/traffic_layout info --run-root=" + path)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.All = Testers.ContainsExpression("PREFIX: " + path, "commandline runroot path")
+
+# 2. use cwd as runroot
+tr = Test.AddTestRun("use runroot via cwd")
+tr.Processes.Default.Command = "cd " + path + ";" + os.path.join("$ATS_BIN/traffic_layout info")
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.All = Testers.ContainsExpression("PREFIX: " + path, "cwd runroot path")
+
+# 4. use path directly bin
+tr = Test.AddTestRun("use runroot via bin executable")
+tr.Processes.Default.Command = os.path.join(path, "bin/traffic_layout info")
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.All = Testers.ContainsExpression("PREFIX: " + path, "bin path")
+
+# 3. TS_RUNROOT ENV variable
+tr = Test.AddTestRun("use runroot via TS_RUNROOT")
+tr.Processes.Default.Env["TS_RUNROOT"] = path2
+tr.Processes.Default.Command = os.path.join("$ATS_BIN/traffic_layout info")
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.All = Testers.ContainsExpression("PREFIX: " + path2, "$TS_RUNROOT Env path")


### PR DESCRIPTION
Updated the original test and added some new tests. Now the tests of runroot are put in a folder named runroot.

Three test files updated:
__runroot_init.test.py__:  3 cases of creating runroot
__runroot_use.test.py__: 4 cases of using runroot (including 2 testruns of creating)
__runroot_remove.test.py__: 3 cases of removing runroot (including 3 testruns of creating)

The 4 cases of using runroot tests include:
1. Using runroot by a program with passed in path argument.
2. Using runroot by a program with the current working directory.
3. Using runroot by a program with the installed directory.
4. Using runroot by a program with ``$TS_RUNROOT`` Environment variable.

test of expected failure will be updated later