### PR TITLE
prevent serving from INADDR_ANY hosts

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -1569,6 +1569,14 @@ HttpTransact::OSDNSLookup(State *s)
   TxnDebug("http_trans", "[HttpTransact::OSDNSLookup] This was attempt %d", s->dns_info.attempts);
   ++s->dns_info.attempts;
 
+  // It's never valid to connect *to* INADDR_ANY, so let's reject the request now.
+  if (ats_is_ip_any(s->host_db_info.ip())) {
+    TxnDebug("http_trans", "[OSDNSLookup] Invalid request IP: INADDR_ANY");
+    build_error_response(s, HTTP_STATUS_BAD_REQUEST, "Bad Destination Address", "request#syntax_error");
+    SET_VIA_STRING(VIA_DETAIL_TUNNEL, VIA_DETAIL_TUNNEL_NO_FORWARD);
+    TRANSACT_RETURN(SM_ACTION_SEND_ERROR_CACHE_NOOP, nullptr);
+  }
+
   // detect whether we are about to self loop. the client may have
   // specified the proxy as the origin server (badness).
   // Check if this procedure is already done - YTS Team, yamsat

--- a/tests/gold_tests/basic/.gitignore
+++ b/tests/gold_tests/basic/.gitignore
@@ -1,0 +1,1 @@
+generated_test_data

--- a/tests/gold_tests/basic/deny0.test.py
+++ b/tests/gold_tests/basic/deny0.test.py
@@ -1,0 +1,103 @@
+'''
+Test that Trafficserver rejects requests for host 0
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import socket
+Test.Summary = '''
+Test that Trafficserver rejects requests for host 0
+'''
+
+Test.ContinueOnFail = True
+
+HOST1='redirect.test'
+
+redirect_serv = Test.MakeOriginServer("redirect_serv", ip='0.0.0.0')
+
+dns = Test.MakeDNServer("dns")
+dns.addRecords(records={HOST1: ['127.0.0.1']})
+
+ts = Test.MakeATSProcess("ts")
+ts.Disk.records_config.update({
+     'proxy.config.diags.debug.enabled': 1
+    ,'proxy.config.diags.debug.tags': 'http|dns|redirect'
+    ,'proxy.config.http.redirection_enabled': 1
+    ,'proxy.config.http.number_of_redirections': 1
+    ,'proxy.config.http.cache.http': 0
+    ,'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port)
+    ,'proxy.config.dns.resolv_conf': 'NULL'
+    ,'proxy.config.url_remap.remap_required': 0  # need this so the domain gets a chance to be evaluated through DNS
+})
+
+Test.Setup.Copy(os.path.join(Test.Variables.AtsTestToolsDir,'tcp_client.py'))
+
+data_dirname = 'generated_test_data'
+data_path = os.path.join(Test.TestDirectory, data_dirname)
+os.makedirs(data_path, exist_ok=True)
+gold_filepath = os.path.join(data_path, 'deny0.gold')
+with open(os.path.join(data_path, 'deny0.gold'), 'w') as f:
+    f.write('HTTP/1.1 400 Bad Destination Address\r\n')
+
+isFirstTest = True
+def buildMetaTest(testName, requestString):
+  tr = Test.AddTestRun(testName)
+  global isFirstTest
+  if isFirstTest:
+    isFirstTest = False
+    tr.Processes.Default.StartBefore(ts, ready=When.PortOpen(ts.Variables.port))
+    tr.Processes.Default.StartBefore(redirect_serv, ready=When.PortOpen(redirect_serv.Variables.Port))
+    tr.Processes.Default.StartBefore(dns)
+  with open(os.path.join(data_path, tr.Name), 'w') as f:
+      f.write(requestString)
+  tr.Processes.Default.Command = "python tcp_client.py 127.0.0.1 {0} {1} | head -1".format(ts.Variables.port, os.path.join(data_dirname, tr.Name))
+  tr.ReturnCode = 0
+  tr.Processes.Default.Streams.stdout = gold_filepath
+  tr.StillRunningAfter = ts
+  tr.StillRunningAfter = redirect_serv
+  tr.StillRunningAfter = dns
+
+
+buildMetaTest('RejectInterfaceAnyIpv4',
+    'GET / HTTP/1.1\r\nHost: 0:{port}\r\nConnection: close\r\n\r\n'.format(port=ts.Variables.port))
+
+
+buildMetaTest('RejectInterfaceAnyIpv6',
+    'GET / HTTP/1.1\r\nHost: [::]:{port}\r\nConnection: close\r\n\r\n'.format(port=ts.Variables.portv6))
+
+
+# Sets up redirect to IPv4 ANY address
+redirect_request_header = {"headers": "GET /redirect-0 HTTP/1.1\r\nHost: *\r\n\r\n", "timestamp": "5678", "body": ""}
+redirect_response_header = {"headers": "HTTP/1.1 302 Found\r\nLocation: http://0:{0}/\r\nConnection: close\r\n\r\n".format(
+    ts.Variables.port), "timestamp": "5678", "body": ""}
+redirect_serv.addResponse("sessionfile.log", redirect_request_header, redirect_response_header)
+
+buildMetaTest('RejectRedirectToInterfaceAnyIpv4',
+    'GET /redirect-0 HTTP/1.1\r\nHost: {host}:{port}\r\n\r\n'.format(host=HOST1, port=redirect_serv.Variables.Port))
+
+
+# Sets up redirect to IPv6 ANY address
+redirect_request_header = {"headers": "GET /redirect-0v6 HTTP/1.1\r\nHost: *\r\n\r\n", "timestamp": "5678", "body": ""}
+redirect_response_header = {"headers": "HTTP/1.1 302 Found\r\nLocation: http://[::]:{0}/\r\nConnection: close\r\n\r\n".format(
+    ts.Variables.port), "timestamp": "5678", "body": ""}
+redirect_serv.addResponse("sessionfile.log", redirect_request_header, redirect_response_header)
+
+buildMetaTest('RejectRedirectToInterfaceAnyIpv6',
+    'GET /redirect-0v6 HTTP/1.1\r\nHost: {host}:{port}\r\n\r\n'.format(host=HOST1, port=redirect_serv.Variables.Port))
+
+
+Test.Setup.Copy(data_path)


### PR DESCRIPTION
Milestone: 8.0.0
Labels: Backports, Core, DNS, HTTP
Project: 7.x releases

Backport rationale:

Hosts that resolve to addresses matching `INADDR_ANY` should not be used in valid origin requests, whether from the original client request or from following a redirect.