### PR TITLE
Documentation build improvements

### DIFF
--- a/doc/checkvers.py
+++ b/doc/checkvers.py
@@ -29,39 +29,39 @@ if __name__ == '__main__':
     # Check whether we have a recent version of sphinx. EPEL and CentOS are completely crazy and I don't understand their
     # packaging at all. The test below works on Ubuntu and places where sphinx is installed sanely AFAICT.
     if options.checkvers:
-        print 'checking for sphinx version >= 1.5.1... ',
+        print('checking for sphinx version >= 1.5.1... '),
         # Need at least 1.5.1 to use svg
         # version >= 1.2 guarantees sphinx.version_info is available.
         try:
             import sphinx
 
             if 'version_info' in dir(sphinx):
-                print 'Found Sphinx version {0}'.format(sphinx.version_info)
+                print('Found Sphinx version {0}'.format(sphinx.version_info))
             else:
                 version = sphinx.__version__
-                print 'Found Sphinx version (old) {0}'.format(sphinx.__version__)
+                print('Found Sphinx version (old) {0}'.format(sphinx.__version__))
                 sphinx.version_info = version.split('.')
 
             if sphinx.version_info < (1, 5, 1):
-                print 'sphinx version is older than 1.5.1'
+                print('sphinx version is older than 1.5.1')
                 sys.exit(1)
 
         except Exception as e:
-            print e
+            print(e)
             sys.exit(1)
 
-        print 'checking for sphinx.writers.manpage... ',
+        print('checking for sphinx.writers.manpage... '),
         try:
             from sphinx.writers import manpage
-            print 'yes'
+            print('yes')
         except Exception as e:
-            print e
+            print(e)
             sys.exit(1)
 
-        print 'checking for sphinxcontrib.plantuml...',
+        print('checking for sphinxcontrib.plantuml...'),
         try:
             import sphinxcontrib.plantuml
-            print 'yes'
+            print('yes')
         except Exception as e:
-            print e;
+            print(e);
             sys.exit(1)

--- a/doc/ext/traffic-server.py
+++ b/doc/ext/traffic-server.py
@@ -47,7 +47,6 @@ except NameError:
     def is_string_type(s):
         return isinstance(s, str)
 
-
 class TSConfVar(std.Target):
     """
     Description of a traffic server configuration variable.

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -20,7 +20,7 @@ import os
 man_pages = [
     # Add all files in the reference/api directory to the list of manual
     # pages
-    ('developer-guide/api/functions/' + filename[:-4], filename.split('.', 1)[0], '', None, '3ts') for filename in os.listdir('developer-guide/api/functions/') if filename != 'index.en.rst' and filename.endswith('.rst')] + [
+    ('developer-guide/api/functions/' + filename[:-4], filename.split('.', 1)[0], filename.split('.', 1)[0] + ' API function', None, '3ts') for filename in os.listdir('developer-guide/api/functions/') if filename != 'index.en.rst' and filename.endswith('.rst')] + [
 
     ('appendices/command-line/traffic_cop.en', 'traffic_cop', u'Traffic Server watchdog', None, '8'),
     ('appendices/command-line/traffic_ctl.en', 'traffic_ctl', u'Traffic Server command line tool', None, '8'),


### PR DESCRIPTION
Current documentation build only works with Python < 3:
* because of print syntax not using parenthesis
* because of `basestring` type usage, which doesn't exists anymore in Python 3

Second improvement is related to developer's api functions' manpages. They're missing proper "whatis" entry. It's not mandatory strictly speaking, but Debian package quality tool (ie. lintian) complains about it.
This PR adds a generic entry.