### PR TITLE
Handle rescheduled transaction close event via tunnel.

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -1340,8 +1340,13 @@ HttpSM::state_api_callout(int event, void *data)
   }
 
   switch (event) {
+  case HTTP_TUNNEL_EVENT_DONE:
+  // This is a reschedule via the tunnel.  Just fall through
+  //
   case EVENT_INTERVAL:
-    ink_assert(pending_action == data);
+    if (data != pending_action) {
+      pending_action->cancel();
+    }
     pending_action = nullptr;
   // FALLTHROUGH
   case EVENT_NONE:
@@ -1505,12 +1510,6 @@ plugins required to work with sni_routing.
       api_next = API_RETURN_ERROR_JUMP;
     }
     break;
-
-  // We may receive an event from the tunnel
-  // if it took a long time to call the SEND_RESPONSE_HDR hook
-  case HTTP_TUNNEL_EVENT_DONE:
-    state_common_wait_for_transform_read(&transform_info, &HttpSM::tunnel_handler, event, data);
-    return 0;
 
   default:
     ink_assert(false);
@@ -2357,6 +2356,9 @@ HttpSM::state_cache_open_write(int event, void *data)
 
   // Make sure we are on the "right" thread
   if (ua_txn) {
+    if (pending_action) {
+      pending_action->cancel();
+    }
     if ((pending_action = ua_txn->adjust_thread(this, event, data))) {
       return 0; // Go away if we reschedule
     }
@@ -2829,7 +2831,6 @@ HttpSM::tunnel_handler(int event, void *data)
   STATE_ENTER(&HttpSM::tunnel_handler, event);
 
   ink_assert(event == HTTP_TUNNEL_EVENT_DONE);
-  ink_assert(data == &tunnel);
   // The tunnel calls this when it is done
   terminate_sm = true;
 
@@ -6783,6 +6784,8 @@ HttpSM::kill_this()
     if (callout_state == HTTP_API_NO_CALLOUT && pending_action) {
       pending_action->cancel();
       pending_action = nullptr;
+    } else if (pending_action) {
+      ink_assert(pending_action == nullptr);
     }
 
     cache_sm.end_both();
@@ -6842,6 +6845,7 @@ HttpSM::kill_this()
   //   then the value of kill_this_async_done has changed so
   //   we must check it again
   if (kill_this_async_done == true) {
+    ink_assert(pending_action == nullptr);
     if (t_state.http_config_param->enable_http_stats) {
       update_stats();
     }
@@ -7499,6 +7503,7 @@ HttpSM::set_next_state()
     Action *action_handle = statPagesManager.handle_http(this, &t_state.hdr_info.client_request);
 
     if (action_handle != ACTION_RESULT_DONE) {
+      ink_assert(pending_action == nullptr);
       pending_action = action_handle;
     }
 


### PR DESCRIPTION
Addresses issue #3143.  Should unblock PR #3047.

@xf6wang found this issue while creating additional session/transaction open/close tests.  If the plugin lock cannot be obtained in the state_api_callout function the event is rescheduled.  The EVENT_INTERVAL will be sent to the tunnel handler which will then call the HttpSM handler with the HTTP_TUNNEL_EVENT_DONE event.  On the retry the HttpSM handler will have changed to state_api_callout.

State_api_callout already had the HTTP_TUNNEL_EVENT_DONE event, but it was assuming it was a transform tunnel (calling state_common_wait_for_transform_read).  Actually that logic seems to be scattered through HttpSM,  some with a check to see if we are in a transform but most like this do not.   Based on a look at git blame this logic has been there quite a while,  but I think it was added erroneously 

What should be happening is that the HTTP_TUNNEL_EVENT_DONE event should be handled as a EVENT_INTERVAL (event retry).

The other thing we had to be careful of was canceling pending_actions that weren't used.  While testing, I'd see 103 events come through before the pending event.  That is fine, but we would need to cancel the pending event so it would not be dangling.

I added asserts to check for pending_action == null before reassign and caught a similar problem in HttpSM::state_cache_open_write that was exercised by the thread tests.