### PR TITLE
Go into timeout state regardless of whether server response data was sent

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -2653,7 +2653,7 @@ HttpSM::tunnel_handler_post(int event, void *data)
 
   switch (event) {
   case HTTP_TUNNEL_EVENT_DONE: // Tunnel done.
-    if (p->handler_state == HTTP_SM_POST_UA_FAIL && client_response_hdr_bytes == 0) {
+    if (p->handler_state == HTTP_SM_POST_UA_FAIL) {
       // post failed
       switch (t_state.client_info.state) {
       case HttpTransact::ACTIVE_TIMEOUT:


### PR DESCRIPTION
We had issue where client timed out in the POST tunnel state but client_response_hdr_bytes
was non-zero, so the original post tunnel was not shutdown.  Causing an assert in consumer_handler later.

client_response_hdr_bytes may be set in the setup_100_continue logic, cache logic, and probably a few other paths in addition to the receive response header logic.

This is logic that was updated by @scw00 last November.

Our crash stack.
```
#0  0x00002b731d9751d7 in raise () from /lib64/libc.so.6
#1  0x00002b731d976a08 in abort () from /lib64/libc.so.6
#2  0x00002b731b19b575 in ink_abort (message_format=0x2b731b1b731c "%s:%d: failed assertion `%s`") at ../../../../trafficserver/lib/ts/ink_error.cc:99
#3  0x00002b731b1986ed in _ink_assert (expression=0x82c712 "0", file=0x82c662 "HttpTunnel.cc", line=1427) at ../../../../trafficserver/lib/ts/ink_assert.cc:37
#4  0x000000000067036e in HttpTunnel::consumer_handler (this=0x2b73500310b8, event=100, c=0x2b73500310f8) at HttpTunnel.cc:1427
#5  0x0000000000670969 in HttpTunnel::main_handler (this=0x2b73500310b8, event=100, data=0x2b8300da4170) at HttpTunnel.cc:1633
#6  0x000000000053f308 in Continuation::handleEvent (this=0x2b73500310b8, event=100, data=0x2b8300da4170) at /Users/acanary/ats7/iocore/eventsystem/I_Continuation.h:153
#7  0x0000000000678e54 in Http2Stream::update_read_request (this=0x2b8300da3e40, read_len=9223372036854775807, call_update=true) at Http2Stream.cc:495
#8  0x0000000000684511 in rcv_data_frame (cstate=..., frame=...) at Http2ConnectionState.cc:174
#9  0x0000000000687a66 in Http2ConnectionState::main_event_handler (this=0x2b80175e50e0, event=2253, edata=0x2b7327e85970) at Http2ConnectionState.cc:910
#10 0x000000000053f308 in Continuation::handleEvent (this=0x2b80175e50e0, event=2253, data=0x2b7327e85970) at /Users/acanary/ats7/iocore/eventsystem/I_Continuation.h:153
#11 0x00000000006802fd in send_connection_event (cont=0x2b80175e50e0, event=2253, edata=0x2b7327e85970) at Http2ClientSession.cc:58
#12 0x000000000068269d in Http2ClientSession::do_complete_frame_read (this=0x2b80175e4e80) at Http2ClientSession.cc:488
#13 0x000000000068288d in Http2ClientSession::state_process_frame_read (this=0x2b80175e4e80, event=100, vio=0x2b75b00b9020, inside_frame=false) at Http2ClientSession.cc:525
#14 0x0000000000681e52 in Http2ClientSession::state_start_frame_read (this=0x2b80175e4e80, event=100, edata=0x2b75b00b9020) at Http2ClientSession.cc:418
#15 0x0000000000681645 in Http2ClientSession::main_event_handler (this=0x2b80175e4e80, event=100, edata=0x2b75b00b9020) at Http2ClientSession.cc:323
#16 0x000000000053f308 in Continuation::handleEvent (this=0x2b80175e4e80, event=100, data=0x2b75b00b9020) at /Users/acanary/ats7/iocore/eventsystem/I_Continuation.h:153
#17 0x00000000007c8058 in read_signal_and_update (event=100, vc=0x2b75b00b8ef0) at UnixNetVConnection.cc:144
#18 0x00000000007caff8 in UnixNetVConnection::readSignalAndUpdate (this=0x2b75b00b8ef0, event=100) at UnixNetVConnection.cc:1092
#19 0x00000000007a321e in SSLNetVConnection::net_read_io (this=0x2b75b00b8ef0, nh=0x2b7324b0ecf0, lthread=0x2b7324b0b010) at SSLNetVConnection.cc:599
#20 0x00000000007bf9a5 in NetHandler::waitForActivity (this=0x2b7324b0ecf0, timeout=60000000) at UnixNet.cc:497
#21 0x00000000007ec385 in EThread::execute_regular (this=0x2b7324b0b010) at UnixEThread.cc:232
#22 0x00000000007ec45b in EThread::execute (this=0x2b7324b0b010) at UnixEThread.cc:262
#23 0x00000000007eb3fe in spawn_thread_internal (a=0x2bc9f60) at Thread.cc:85
#24 0x00002b731cd08dc5 in start_thread () from /lib64/libpthread.so.0
#25 0x00002b731da3776d in clone () from /lib64/libc.so.6
```

The read event is being fed to the tunnel consumer.  The state machine had a post tunnel but now has a static tunnel to send a message back to the client.  Looking at the history, we see that write complete happens before the inactivity timeout.  The write complete is on the server side from sending the request header to the server.  The inactivity timeout happens on the client side while waiting for the client to send the POST data.

```
(gdb) print sm->history
$2 = {{fileline = 0x81f463 "HttpSM.cc:1418", event = 60000, reentrancy = 2}, {fileline = 0x81f48e "HttpSM.cc:1458", event = 60000, reentrancy = 2}, {fileline = 0x81efab "HttpSM.cc:676", event = 100, reentrancy = 3}, {
    fileline = 0x81efab "HttpSM.cc:676", event = 100, reentrancy = 1}, {fileline = 0x81f463 "HttpSM.cc:1418", event = 60000, reentrancy = 2}, {fileline = 0x81f48e "HttpSM.cc:1458", event = 60000, reentrancy = 2}, {
    fileline = 0x81f463 "HttpSM.cc:1418", event = 60000, reentrancy = 3}, {fileline = 0x81f48e "HttpSM.cc:1458", event = 60000, reentrancy = 3}, {fileline = 0x81f463 "HttpSM.cc:1418", event = 60000, reentrancy = 4}, {
    fileline = 0x81f48e "HttpSM.cc:1458", event = 60000, reentrancy = 4}, {fileline = 0x81f463 "HttpSM.cc:1418", event = 60000, reentrancy = 5}, {fileline = 0x81f48e "HttpSM.cc:1458", event = 60000, reentrancy = 5}, {
    fileline = 0x81f463 "HttpSM.cc:1418", event = 60000, reentrancy = 6}, {fileline = 0x81f48e "HttpSM.cc:1458", event = 60000, reentrancy = 6}, {fileline = 0x81f463 "HttpSM.cc:1418", event = 60000, reentrancy = 7}, {
    fileline = 0x81f48e "HttpSM.cc:1458", event = 60000, reentrancy = 7}, {fileline = 0x81f463 "HttpSM.cc:1418", event = 60000, reentrancy = 8}, {fileline = 0x81f48e "HttpSM.cc:1458", event = 60000, reentrancy = 8}, {
    fileline = 0x81f463 "HttpSM.cc:1418", event = 60000, reentrancy = 9}, {fileline = 0x81f48e "HttpSM.cc:1458", event = 60000, reentrancy = 9}, {fileline = 0x81f463 "HttpSM.cc:1418", event = 60000, reentrancy = 10}, {
    fileline = 0x81f48e "HttpSM.cc:1458", event = 60000, reentrancy = 10}, {fileline = 0x81f463 "HttpSM.cc:1418", event = 60000, reentrancy = 11}, {fileline = 0x81f48e "HttpSM.cc:1458", event = 60000, reentrancy = 11}, {
    fileline = 0x821dac "HttpSM.cc:7543", event = 65535, reentrancy = 11}, {fileline = 0x817a20 "HttpCacheSM.cc:118", event = 1103, reentrancy = -1}, {fileline = 0x81fd74 "HttpSM.cc:2705", event = 1103, reentrancy = 12}, {
    fileline = 0x81f463 "HttpSM.cc:1418", event = 60000, reentrancy = 13}, {fileline = 0x81f48e "HttpSM.cc:1458", event = 60000, reentrancy = 13}, {fileline = 0x81f463 "HttpSM.cc:1418", event = 60000, reentrancy = 14}, {
    fileline = 0x81f48e "HttpSM.cc:1458", event = 60000, reentrancy = 14}, {fileline = 0x821d8e "HttpSM.cc:7503", event = 65535, reentrancy = 14}, {fileline = 0x81f463 "HttpSM.cc:1418", event = 60000, reentrancy = 15}, {
    fileline = 0x81f48e "HttpSM.cc:1458", event = 60000, reentrancy = 15}, {fileline = 0x821dca "HttpSM.cc:7556", event = 65535, reentrancy = 15}, {fileline = 0x81f463 "HttpSM.cc:1418", event = 60000, reentrancy = 16}, {
    fileline = 0x81f48e "HttpSM.cc:1458", event = 60000, reentrancy = 16}, {fileline = 0x81f463 "HttpSM.cc:1418", event = 60000, reentrancy = 17}, {fileline = 0x81f48e "HttpSM.cc:1458", event = 60000, reentrancy = 17}, {
    fileline = 0x820a39 "HttpSM.cc:4683", event = 0, reentrancy = 11}, {fileline = 0x81f8d4 "HttpSM.cc:2106", event = 103, reentrancy = 1}, {fileline = 0x821057 "HttpSM.cc:5860", event = 65535, reentrancy = 1}, {
    fileline = 0x8202c3 "HttpSM.cc:3609", event = 105, reentrancy = 0}, {fileline = 0x81fe8e "HttpSM.cc:2875", event = 2301, reentrancy = 1}, {fileline = 0x81f463 "HttpSM.cc:1418", event = 60000, reentrancy = 2}, {
    fileline = 0x81f48e "HttpSM.cc:1458", event = 60000, reentrancy = 2}, {fileline = 0x81f463 "HttpSM.cc:1418", event = 60000, reentrancy = 3}, {fileline = 0x81f48e "HttpSM.cc:1458", event = 60000, reentrancy = 3}, {
    fileline = 0x8213e7 "HttpSM.cc:6489", event = 65535, reentrancy = 3}, {fileline = 0x0, event = 0, reentrancy = 0} <repeats 15 times>}
```