### PR TITLE
Add check on continuation before dereferencing, issue #3310

### DIFF
--- a/proxy/PluginVC.cc
+++ b/proxy/PluginVC.cc
@@ -262,7 +262,7 @@ PluginVC::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
 
   // Note: we set vio.op last because process_read_side looks at it to
   //  tell if the VConnection is active.
-  read_state.vio.mutex     = c->mutex;
+  read_state.vio.mutex     = c ? c->mutex : this->mutex;
   read_state.vio._cont     = c;
   read_state.vio.nbytes    = nbytes;
   read_state.vio.ndone     = 0;


### PR DESCRIPTION
We saw this crash twice in a short time span. The do_io_read function can be called from HttpTunnel::producer_handler and in the case of this crash will call do_io_read(nullptr, 0, 0). So without a check it will always crash here in those few event instances in producer_handler.