### PR TITLE
BufferRewrite: Add support for MemSpan, string_view hex dump, and std::string

### DIFF
--- a/lib/ts/BufferWriterForward.h
+++ b/lib/ts/BufferWriterForward.h
@@ -38,7 +38,9 @@ namespace ts
 /** A parsed version of a format specifier.
  */
 struct BWFSpec {
-  using self_type = BWFSpec; ///< Self reference type.
+  using self_type                    = BWFSpec; ///< Self reference type.
+  static constexpr char DEFAULT_TYPE = 'g';     ///< Default format type.
+
   /// Constructor a default instance.
   constexpr BWFSpec() {}
 
@@ -48,21 +50,21 @@ struct BWFSpec {
   char _fill = ' '; ///< Fill character.
   char _sign = '-'; ///< Numeric sign style, space + -
   enum class Align : char {
-    NONE,                           ///< No alignment.
-    LEFT,                           ///< Left alignment '<'.
-    RIGHT,                          ///< Right alignment '>'.
-    CENTER,                         ///< Center alignment '='.
-    SIGN                            ///< Align plus/minus sign before numeric fill. '^'
-  } _align           = Align::NONE; ///< Output field alignment.
-  char _type         = 'g';         ///< Type / radix indicator.
-  bool _radix_lead_p = false;       ///< Print leading radix indication.
+    NONE,                            ///< No alignment.
+    LEFT,                            ///< Left alignment '<'.
+    RIGHT,                           ///< Right alignment '>'.
+    CENTER,                          ///< Center alignment '='.
+    SIGN                             ///< Align plus/minus sign before numeric fill. '^'
+  } _align           = Align::NONE;  ///< Output field alignment.
+  char _type         = DEFAULT_TYPE; ///< Type / radix indicator.
+  bool _radix_lead_p = false;        ///< Print leading radix indication.
   // @a _min is unsigned because there's no point in an invalid default, 0 works fine.
-  unsigned int _min = 0;  ///< Minimum width.
-  int _prec         = -1; ///< Precision
-  unsigned int _max = 0;  ///< Maxium width
-  int _idx          = -1; ///< Positional "name" of the specification.
-  string_view _name;      ///< Name of the specification.
-  string_view _ext;       ///< Extension if provided.
+  unsigned int _min = 0;                                        ///< Minimum width.
+  int _prec         = -1;                                       ///< Precision
+  unsigned int _max = std::numeric_limits<unsigned int>::max(); ///< Maxium width
+  int _idx          = -1;                                       ///< Positional "name" of the specification.
+  string_view _name;                                            ///< Name of the specification.
+  string_view _ext;                                             ///< Extension if provided.
 
   static const self_type DEFAULT;
 

--- a/lib/ts/CryptoHash.h
+++ b/lib/ts/CryptoHash.h
@@ -23,6 +23,9 @@
 #if !defined CRYPTO_HASH_HEADER
 #define CRYPTO_HASH_HEADER
 
+#include <ts/BufferWriter.h>
+#include <ts/string_view.h>
+
 /// Apache Traffic Server commons.
 
 #if TS_ENABLE_FIPS == 1
@@ -177,6 +180,18 @@ CryptoContext::finalize(CryptoHash &hash)
 }
 
 } // end namespace
+
+namespace ts
+{
+inline BufferWriter &
+bwformat(BufferWriter &w, BWFSpec const &spec, ats::CryptoHash const &hash)
+{
+  BWFSpec local_spec{spec};
+  if ('X' != local_spec._type)
+    local_spec._type = 'x';
+  return bwformat(w, local_spec, ts::string_view(reinterpret_cast<const char *>(hash.u8), CRYPTO_HASH_SIZE));
+}
+} // ts
 
 using ats::CryptoHash;
 using ats::CryptoContext;

--- a/lib/ts/MemSpan.h
+++ b/lib/ts/MemSpan.h
@@ -141,6 +141,8 @@ public:
 
   /// Number of bytes in the span.
   constexpr ptrdiff_t size() const;
+  /// Number of bytes in the span (unsigned).
+  constexpr size_t usize() const;
 
   /// Memory pointer.
   /// @note This is equivalent to @c begin currently but it's probably good to have separation.
@@ -426,6 +428,12 @@ MemSpan::size() const
   return _size;
 }
 
+inline constexpr size_t
+MemSpan::usize() const
+{
+  return _size;
+}
+
 inline MemSpan &
 MemSpan::operator=(MemSpan const &that)
 {
@@ -559,13 +567,11 @@ MemSpan::find_if(F const &pred)
 
 namespace std
 {
-ostream &
+inline ostream &
 operator<<(ostream &os, const ts::MemSpan &b)
 {
   if (os.good()) {
-    ostringstream out;
-    out << b.size() << '@' << hex << b.data();
-    os << out.str();
+    os << b.size() << '@' << hex << b.data();
   }
   return os;
 }


### PR DESCRIPTION
This adds a number of formatting features.

*  Setting the type to 'x' or 'X' for a `string_view` will cause it to do a hex dump of the contents.
*  The extent is computed correctly now.
*  `bwformat` will write to a ` std::string`, adjusting the size as needed (may require printing twice).
*  A small increase in performance.
*  Support for printing `MemSpan`.
*  Support for pointers.