### PR TITLE
QUIC: Fix complier error

### DIFF
--- a/proxy/hq/HQFrame.cc
+++ b/proxy/hq/HQFrame.cc
@@ -251,7 +251,7 @@ HQFrameFactory::create(const uint8_t *buf, size_t len)
     return HQFrameUPtr(frame, &HQFrameDeleter::delete_data_frame);
   default:
     // Unknown frame
-    Debug("hq_frame_factory", "Unknown frame type %hhx", type);
+    Debug("hq_frame_factory", "Unknown frame type %hhx", static_cast<uint8_t>(type));
     frame = hqFrameAllocator.alloc();
     new (frame) HQFrame(buf, len);
     return HQFrameUPtr(frame, &HQFrameDeleter::delete_frame);

--- a/proxy/hq/HQTypes.h
+++ b/proxy/hq/HQTypes.h
@@ -23,6 +23,10 @@
 
 #pragma once
 
+#include "ts/ink_platform.h"
+
+#include <memory>
+
 // Update HQFrame::type(const uint8_t *) too when you modify this list
 enum class HQFrameType : uint8_t {
   DATA          = 0x00,


### PR DESCRIPTION
```
g++ -v
Using built-in specs.
COLLECT_GCC=g++
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/5/lto-wrapper

ubuntu 16.04
```