### PR TITLE
QUIC: Rename local params and remote params

### DIFF
--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -1376,8 +1376,8 @@ QUICNetVConnection::_complete_handshake_if_possible()
     return -1;
   }
 
-  this->_init_flow_control_params(this->_handshake_handler->local_transport_parameters(),
-                                  this->_handshake_handler->remote_transport_parameters());
+  this->_init_flow_control_params(this->_handshake_handler->local_transport_encrypted_extensions_parameters(),
+                                  this->_handshake_handler->remote_transport_encrypted_extensions_parameters());
 
   this->_start_application();
 

--- a/iocore/net/quic/QUICHandshake.cc
+++ b/iocore/net/quic/QUICHandshake.cc
@@ -207,7 +207,7 @@ QUICHandshake::set_transport_parameters(std::shared_ptr<QUICTransportParametersI
     return;
   }
 
-  this->_remote_transport_parameters = tp;
+  this->_remote_transport_encrypted_extensions_parameters = tp;
 
   // Version revalidation
   if (this->_version_negotiator->validate(tp.get()) != QUICVersionNegotiationStatus::VALIDATED) {
@@ -230,7 +230,7 @@ QUICHandshake::set_transport_parameters(std::shared_ptr<QUICTransportParametersI
     return;
   }
 
-  this->_remote_transport_parameters = tp;
+  this->_remote_transport_encrypted_extensions_parameters = tp;
 
   // TODO Add client side implementation
 
@@ -247,22 +247,22 @@ QUICHandshake::set_transport_parameters(std::shared_ptr<QUICTransportParametersI
     return;
   }
 
-  this->_remote_transport_parameters = tp;
+  this->_remote_transport_encrypted_extensions_parameters = tp;
 
   // TODO Add client side implementation
   ink_assert(false);
 }
 
 std::shared_ptr<const QUICTransportParameters>
-QUICHandshake::local_transport_parameters()
+QUICHandshake::local_transport_encrypted_extensions_parameters()
 {
-  return this->_local_transport_parameters;
+  return this->_local_transport_encrypted_extensions_parameters;
 }
 
 std::shared_ptr<const QUICTransportParameters>
-QUICHandshake::remote_transport_parameters()
+QUICHandshake::remote_transport_encrypted_extensions_parameters()
 {
-  return this->_remote_transport_parameters;
+  return this->_remote_transport_encrypted_extensions_parameters;
 }
 
 int
@@ -427,10 +427,10 @@ QUICHandshake::_load_local_server_transport_parameters(QUICVersion negotiated_ve
   // MAYs
   tp->set(QUICTransportParameterId::INITIAL_MAX_STREAM_ID_BIDI, params->initial_max_stream_id_bidi_in());
   tp->set(QUICTransportParameterId::INITIAL_MAX_STREAM_ID_UNI, params->initial_max_stream_id_uni_in());
-  // this->_local_transport_parameters.add(QUICTransportParameterId::OMIT_CONNECTION_ID, {});
-  // this->_local_transport_parameters.add(QUICTransportParameterId::MAX_PACKET_SIZE, {{0x00, 0x00}, 2});
+  // this->_local_transport_encrypted_extensions_parameters.add(QUICTransportParameterId::OMIT_CONNECTION_ID, {});
+  // this->_local_transport_encrypted_extensions_parameters.add(QUICTransportParameterId::MAX_PACKET_SIZE, {{0x00, 0x00}, 2});
 
-  this->_local_transport_parameters = std::unique_ptr<QUICTransportParameters>(tp);
+  this->_local_transport_encrypted_extensions_parameters = std::unique_ptr<QUICTransportParameters>(tp);
 }
 
 void
@@ -449,7 +449,7 @@ QUICHandshake::_load_local_client_transport_parameters(QUICVersion initial_versi
   tp->set(QUICTransportParameterId::INITIAL_MAX_STREAM_ID_BIDI, params->initial_max_stream_id_bidi_out());
   tp->set(QUICTransportParameterId::INITIAL_MAX_STREAM_ID_UNI, params->initial_max_stream_id_uni_out());
 
-  this->_local_transport_parameters = std::unique_ptr<QUICTransportParameters>(tp);
+  this->_local_transport_encrypted_extensions_parameters = std::unique_ptr<QUICTransportParameters>(tp);
 }
 
 int

--- a/iocore/net/quic/QUICHandshake.h
+++ b/iocore/net/quic/QUICHandshake.h
@@ -76,8 +76,8 @@ public:
   QUICVersion negotiated_version();
   const char *negotiated_cipher_suite();
   void negotiated_application_name(const uint8_t **name, unsigned int *len);
-  std::shared_ptr<const QUICTransportParameters> local_transport_parameters();
-  std::shared_ptr<const QUICTransportParameters> remote_transport_parameters();
+  std::shared_ptr<const QUICTransportParameters> local_transport_encrypted_extensions_parameters();
+  std::shared_ptr<const QUICTransportParameters> remote_transport_encrypted_extensions_parameters();
 
   bool is_version_negotiated() const;
   bool is_completed() const;
@@ -91,10 +91,10 @@ public:
   QUICHandshakeMsgType msg_type() const;
 
 private:
-  SSL *_ssl                                                             = nullptr;
-  QUICHandshakeProtocol *_hs_protocol                                   = nullptr;
-  std::shared_ptr<QUICTransportParameters> _local_transport_parameters  = nullptr;
-  std::shared_ptr<QUICTransportParameters> _remote_transport_parameters = nullptr;
+  SSL *_ssl                                                                                  = nullptr;
+  QUICHandshakeProtocol *_hs_protocol                                                        = nullptr;
+  std::shared_ptr<QUICTransportParameters> _local_transport_encrypted_extensions_parameters  = nullptr;
+  std::shared_ptr<QUICTransportParameters> _remote_transport_encrypted_extensions_parameters = nullptr;
 
   QUICVersionNegotiator *_version_negotiator = nullptr;
   NetVConnectionContext_t _netvc_context     = NET_VCONNECTION_UNSET;

--- a/iocore/net/quic/QUICTransportParameters.cc
+++ b/iocore/net/quic/QUICTransportParameters.cc
@@ -564,7 +564,7 @@ QUICTransportParametersHandler::add(SSL *s, unsigned int ext_type, unsigned int 
 {
   QUICHandshake *hs = static_cast<QUICHandshake *>(SSL_get_ex_data(s, QUIC::ssl_quic_hs_index));
   *out              = reinterpret_cast<const unsigned char *>(ats_malloc(TRANSPORT_PARAMETERS_MAXIMUM_SIZE));
-  hs->local_transport_parameters()->store(const_cast<uint8_t *>(*out), reinterpret_cast<uint16_t *>(outlen));
+  hs->local_transport_encrypted_extensions_parameters()->store(const_cast<uint8_t *>(*out), reinterpret_cast<uint16_t *>(outlen));
 
   return 1;
 }


### PR DESCRIPTION

>5.2. Enabling 0-RTT
>In order to be usable for 0-RTT, TLS MUST provide a NewSessionTicket message that contains the “max_early_data” extension with the value 0xffffffff; the amount of data which the client can send in >0-RTT is controlled by the “initial_max_data” transport parameter supplied by the server. A client >MUST treat receipt of a NewSessionTicket that contains a “max_early_data” extension with any other >value as a connection error of type PROTOCOL_VIOLATION.


To support session ticket params, we may need to invoke a new member to save session ticket params.