### PR TITLE
Fixes compile errors introduced by backport of "prevents connecting t…

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -1680,8 +1680,8 @@ HttpTransact::OSDNSLookup(State *s)
 
   // It's never valid to connect *to* INADDR_ANY, so let's reject the request now.
   if (ats_is_ip_any(s->host_db_info.ip())) {
-    TxnDebug("http_trans", "[OSDNSLookup] Invalid request IP: INADDR_ANY");
-    build_error_response(s, HTTP_STATUS_BAD_REQUEST, "Bad Destination Address", "request#syntax_error");
+    DebugTxn("http_trans", "[OSDNSLookup] Invalid request IP: INADDR_ANY");
+    build_error_response(s, HTTP_STATUS_BAD_REQUEST, "Bad Destination Address", "request#syntax_error", nullptr);
     SET_VIA_STRING(VIA_DETAIL_TUNNEL, VIA_DETAIL_TUNNEL_NO_FORWARD);
     TRANSACT_RETURN(SM_ACTION_SEND_ERROR_CACHE_NOOP, nullptr);
   }


### PR DESCRIPTION
…o INADDR_ANY hosts".

The errors were introduced in 0fd63fd6c8a148f827e198cc8cc6ecd268cf7518
which was backported to 7.1 from 582a6731f9701acdc2739ee60676180227050d51.
The names and number of arguments in the function changed, so there
was a semantic conflict that caused compile errors. This corrects the
usage to be correct fot 7.1.