### PR TITLE
QUIC: Memory pollution in building packet

### DIFF
--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -1006,6 +1006,7 @@ QUICNetVConnection::_store_frame(ats_unique_buf &buf, size_t &len, bool &retrans
     this->_transmit_packet(this->_build_packet(std::move(buf), len, retransmittable, previous_packet_type));
     retransmittable = false;
     len             = 0;
+    buf             = nullptr;
   }
 
   retransmittable = retransmittable || (frame->type() != QUICFrameType::ACK && frame->type() != QUICFrameType::PADDING);


### PR DESCRIPTION
We got a very large packet in last _store_frame and decide  transmitting in this chance. Due to different packet type , we may create another packet and transmit the last packet without clearing the buffer memory .

That means if the last packet is smaller than the previous packet, we will get wrong frame.