### PR TITLE
CacheTool: Fix Scalar / bwformat issues for MacOS.

### DIFF
--- a/cmd/traffic_cache_tool/CacheTool.cc
+++ b/cmd/traffic_cache_tool/CacheTool.cc
@@ -26,24 +26,26 @@
 #include <memory>
 #include <vector>
 #include <map>
-#include <ts/ink_memory.h>
-#include <ts/ink_file.h>
 #include <getopt.h>
 #include <system_error>
 #include <string.h>
 #include <fcntl.h>
 #include <ctype.h>
-#include "File.h"
-#include "CacheDefs.h"
-#include "Command.h"
-#include "ts/ink_code.h"
 #include <cstring>
-#include <openssl/md5.h>
 #include <vector>
 #include <unordered_set>
 #include <time.h>
 #include <bitset>
 #include <inttypes.h>
+
+#include <ts/ink_memory.h>
+#include <ts/ink_file.h>
+#include <ts/BufferWriter.h>
+#include <ts/CryptoHash.h>
+
+#include "File.h"
+#include "CacheDefs.h"
+#include "Command.h"
 
 using ts::Bytes;
 using ts::Megabytes;

--- a/lib/ts/BufferWriterFormat.cc
+++ b/lib/ts/BufferWriterFormat.cc
@@ -589,7 +589,7 @@ BWF_Now(ts::BufferWriter &w, ts::BWFSpec const &spec)
   w.fill(std::strftime(w.auxBuffer(), w.remaining(), "%Y%b%d:%H%M%S", std::localtime(&t)));
 }
 
-static bool BW_INITIALIZED = []() -> bool {
+static bool BW_INITIALIZED __attribute__((unused)) = []() -> bool {
   ts::bw_fmt::BWF_GLOBAL_TABLE.emplace("now", &BWF_Now);
   return true;
 }();

--- a/lib/ts/Scalar.h
+++ b/lib/ts/Scalar.h
@@ -25,13 +25,13 @@
   limitations under the License.
  */
 
-#if !defined(TS_SCALAR_H)
-#define TS_SCALAR_H
+#pragma once
 
 #include <cstdint>
 #include <ratio>
 #include <ostream>
 #include <type_traits>
+#include <ts/BufferWriter.h>
 
 namespace tag
 {
@@ -911,14 +911,35 @@ namespace detail
     return s;
   }
   template <typename T>
+  inline BufferWriter &
+  tag_label(BufferWriter &w, BWFSpec const &, tag_label_A const &)
+  {
+    return w;
+  }
+  template <typename T>
   inline auto
   tag_label(std::ostream &s, tag_label_B const &) -> decltype(s << T::label, s)
   {
     return s << T::label;
   }
+  template <typename T>
+  inline auto
+  tag_label(BufferWriter &w, BWFSpec const &spec, tag_label_B const &) -> decltype(bwformat(w, spec, T::label), w)
+  {
+    return bwformat(w, spec, T::label);
+  }
 } // detail
 
-} // namespace
+template <intmax_t N, typename C, typename T>
+BufferWriter &
+bwformat(BufferWriter &w, BWFSpec const &spec, Scalar<N, C, T> const &x)
+{
+  static constexpr ts::detail::tag_label_B b{};
+  bwformat(w, spec, x.value());
+  return ts::detail::tag_label<T>(w, spec, b);
+}
+
+} // ts
 
 namespace std
 {
@@ -938,5 +959,4 @@ template <intmax_t N, typename C, intmax_t S, typename I, typename T> struct com
   typedef std::ratio<N, S> R;
   typedef ts::Scalar<N / R::num, typename common_type<C, I>::type, T> type;
 };
-}
-#endif // TS_SCALAR_H
+} // std


### PR DESCRIPTION
This is intended to solve an overload resolution problem that occurs in MacOS due to the interaction of `bwformat` and `Scalar`. Essentially a `Scalar` specific overload is provided to simplify template argument deduction. This also provides the labeling feature for `bwformat` which is useful.

Also added a tweak for Ubuntu 16.04 complaining about an unused static that serves the purpose of file scope initialization.