### PR TITLE
Add verify functionality for runroot of traffic_layout

### DIFF
--- a/cmd/traffic_layout/engine.h
+++ b/cmd/traffic_layout/engine.h
@@ -43,12 +43,15 @@ struct RunrootEngine {
   // the function of creating runroot
   void create_runroot();
 
+  // the function of verifying runroot
+  void verify_runroot();
+
   // copy the stuff from original_root to ts_runroot
   // fill in the global map for yaml file emitting later
   void copy_runroot(const std::string &original_root, const std::string &ts_runroot);
 
   // the help message for runroot
-  void runroot_help_message(const bool runflag, const bool cleanflag);
+  void runroot_help_message(const bool runflag, const bool cleanflag, const bool verifyflag, const bool fixflag);
 
   // the pass in arguments
   std::vector<std::string> _argv;
@@ -59,6 +62,11 @@ struct RunrootEngine {
   bool clean_flag   = false;
   bool force_flag   = false;
   bool abs_flag     = false;
+  bool verify_flag  = false;
+  bool fix_flag     = false;
+  // for parsing
+  int command_num = 0;
+
   // the path for create & remove
   std::string path;
 

--- a/cmd/traffic_layout/file_system.h
+++ b/cmd/traffic_layout/file_system.h
@@ -38,9 +38,9 @@ void append_slash(std::string &path);
 void remove_slash(std::string &path);
 
 // some checks for directory exist or is it a directory
-bool exists(std::string const &dir);
+bool exists(const std::string &dir);
 
-bool is_directory(std::string const &directory);
+bool is_directory(const std::string &directory);
 
 // for file system
 bool create_directory(const std::string &dir);

--- a/cmd/traffic_layout/traffic_layout.cc
+++ b/cmd/traffic_layout/traffic_layout.cc
@@ -66,6 +66,7 @@ help_usage()
                "init         Initialize the ts_runroot sandbox\n"
                "remove       Remove the ts_runroot sandbox\n"
                "info         Show the layout as default\n"
+               "verify:      Verify the ts_runroot paths\n"
             << std::endl;
   std::cout << "Switches of runroot:\n"
                "--path       Specify the path of the runroot\n"
@@ -73,7 +74,7 @@ help_usage()
                "--absolute:  Produce absolute path in the yaml file\n"
                "--run-root(=/path):  Using specified TS_RUNROOT as sandbox\n"
             << std::endl;
-
+  printf("Detailed usage and description in traffic_layout.en.rst\n");
   printf("General Usage:\n");
   usage(argument_descriptions, countof(argument_descriptions), nullptr);
 }
@@ -128,7 +129,7 @@ traffic_runroot(int argc, const char **argv)
   }
   // parse the command line & put into global variable
   if (!engine.runroot_parse()) {
-    engine.runroot_help_message(true, true);
+    engine.runroot_help_message(true, true, true, true);
     return 0;
   }
   // check sanity of the command about the runroot program
@@ -138,13 +139,15 @@ traffic_runroot(int argc, const char **argv)
   runroot_handler(argv);
   Layout::create();
 
-  // check to clean the runroot or not
-  if (engine.clean_flag) {
-    engine.clean_runroot();
-    std::cout << "runroot removed" << std::endl;
-  } else {
+  // check the command to execute
+  if (engine.run_flag) {
     engine.create_runroot();
+  } else if (engine.clean_flag) {
+    engine.clean_runroot();
+  } else if (engine.verify_flag) {
+    engine.verify_runroot();
   }
+
   return 0;
 }
 
@@ -155,6 +158,8 @@ main(int argc, const char **argv)
     {info, "info", "Show the layout"},
     {traffic_runroot, "init", "Initialize the ts_runroot sandbox"},
     {traffic_runroot, "remove", "Remove the ts_runroot sandbox"},
+    {traffic_runroot, "verify", "verify the ts_runroot paths"},
+    {traffic_runroot, "fix", "fix permmision issue of the ts_runroot"},
   };
 
   // with command (info, init, remove)

--- a/lib/ts/runroot.cc
+++ b/lib/ts/runroot.cc
@@ -177,30 +177,31 @@ runroot_handler(const char **argv, bool json)
 
 // return a map of all path in runroot_path.yml
 std::unordered_map<std::string, std::string>
-runroot_map(std::string &yaml_path, std::string &prefix)
+runroot_map(const std::string &prefix)
 {
+  std::string yaml_path = Layout::relative_to(prefix, "runroot_path.yml");
   std::ifstream file;
   file.open(yaml_path);
   if (!file.good()) {
-    ink_warning("Bad path, continue with default value");
+    ink_warning("Bad path '%s', continue with default value", prefix.c_str());
     return std::unordered_map<std::string, std::string>{};
   }
 
   std::ifstream yamlfile(yaml_path);
-  std::unordered_map<std::string, std::string> runroot_map;
+  std::unordered_map<std::string, std::string> map;
   std::string str;
   while (std::getline(yamlfile, str)) {
     int pos = str.find(':');
-    runroot_map[str.substr(0, pos)] = str.substr(pos + 2);
+    map[str.substr(0, pos)] = str.substr(pos + 2);
   }
 
   // change it to absolute path in the map
-  for (auto it : runroot_map) {
+  for (auto it : map) {
     if (it.second[0] != '/') {
-      runroot_map[it.first] = Layout::relative_to(prefix, it.second);
+      map[it.first] = Layout::relative_to(prefix, it.second);
     }
   }
-  return runroot_map;
+  return map;
 }
 
 // check for the using of runroot
@@ -217,6 +218,5 @@ check_runroot()
   if ((len + 1) > PATH_NAME_MAX) {
     ink_fatal("runroot path is too big: %d, max %d\n", len, PATH_NAME_MAX - 1);
   }
-  std::string yaml_path = Layout::relative_to(using_runroot, "runroot_path.yml");
-  return runroot_map(yaml_path, using_runroot);
+  return runroot_map(using_runroot);
 }

--- a/lib/ts/runroot.h
+++ b/lib/ts/runroot.h
@@ -29,12 +29,14 @@
 #include <string>
 #include <unordered_map>
 
+std::string check_path(const std::string &path);
+
 std::string check_parent_path(const std::string &path);
 
 void runroot_handler(const char **argv, bool json = false);
 
 // get runroot map from yaml path and prefix
-std::unordered_map<std::string, std::string> runroot_map(std::string &yaml_path, std::string &prefix);
+std::unordered_map<std::string, std::string> runroot_map(const std::string &prefix);
 
 // help check runroot for layout
 std::unordered_map<std::string, std::string> check_runroot();


### PR DESCRIPTION
1. Add a new verify command to runroot.
This command will find the user and group trafficserver is set to and check the permission of each directory inside runroot with the specified user and group.
This command requires root privilege.
Example Usage: ``sudo traffic_layout verify (--path /dir)``

2. Some code clean up of runroot
Clean up some code for the engine and ts/runroot.  
Help messages are updated accordingly