### PR TITLE
QUIC: Set packet_info's bytes to zero if it is the ack-only packet

### DIFF
--- a/iocore/net/quic/QUICLossDetector.cc
+++ b/iocore/net/quic/QUICLossDetector.cc
@@ -135,7 +135,7 @@ QUICLossDetector::on_packet_sent(QUICPacketUPtr packet)
 
   QUICPacketNumber packet_number = packet->packet_number();
   bool is_ack_only               = !packet->is_retransmittable();
-  size_t sent_bytes              = packet->size();
+  size_t sent_bytes              = is_ack_only ? 0 : packet->size();
   this->_on_packet_sent(packet_number, is_ack_only, is_handshake, sent_bytes, std::move(packet));
 }
 


### PR DESCRIPTION
```
    OnPacketSent(packet_number, is_ack_only, sent_bytes):
      time_of_last_sent_packet = now
      largest_sent_packet = packet_number
      sent_packets[packet_number].packet_number = packet_number
      sent_packets[packet_number].time = now
      sent_packets[packet_number].ack_only = is_ack_only
      if !is_ack_only:
        OnPacketSentCC(sent_bytes)
        sent_packets[packet_number].bytes = sent_bytes
        SetLossDetectionAlarm()
```

ATS may receive a ack for ack-only packet (or includes this packet number), and decrease the bytes_in_flights to negative value.