### PR TITLE
Fix over reporting of aborted chunked responses

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1357,6 +1357,8 @@ Http2ConnectionState::send_a_data_frame(Http2Stream *stream, size_t &payload_len
   this->ua_session->handleEvent(HTTP2_SESSION_EVENT_XMIT, &data);
 
   if (flags & HTTP2_FLAGS_DATA_END_STREAM) {
+    // Update write_vio nbytes in the chunked case
+    stream->finalize_chunked_sent_bytes();
     Http2StreamDebug(ua_session, stream->get_id(), "End of DATA frame");
     stream->send_end_stream = true;
     // Setting to the same state shouldn't be erroneous

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -89,6 +89,14 @@ public:
     this->write_vio.ndone += num_bytes;
   }
 
+  void
+  finalize_chunked_sent_bytes()
+  {
+    if (chunked) {
+      write_vio.nbytes = write_vio.ndone;
+    }
+  }
+
   Http2StreamId
   get_id() const
   {


### PR DESCRIPTION
Adjust nbytes when the last frame of the response that was chunked is delivered.  The nbytes was originally set to the size of the response including the chunked encoding.  When delivered over H2
the chunked encoding bytes are not included.  When the EOS was delivered to the state machine this was being logged as an ERR_CLIENT_ABORT even though all real bytes were delivered.

When we deployed 7.1.2 widely the ops team noted that our error client abort rate increase multiple times which caused them great distress.  With this fix, our rate dropped back down to the 7.1.1 rate.