### PR TITLE
CacheTool:Set exit code in case of error

### DIFF
--- a/cmd/traffic_cache_tool/CacheTool.cc
+++ b/cmd/traffic_cache_tool/CacheTool.cc
@@ -2503,6 +2503,7 @@ main(int argc, char *argv[])
 
   if (result.size()) {
     std::cerr << result;
+    exit(1);
   }
   if (inp)
     free(inp);


### PR DESCRIPTION
Required for users who check the exit code to see if an operation failed or not