### PR TITLE
Potential traffic_cop crash due to leftover data in socket

### DIFF
--- a/mgmt/api/CoreAPIRemote.cc
+++ b/mgmt/api/CoreAPIRemote.cc
@@ -654,8 +654,18 @@ MgmtRecordGet(const char *rec_name, TSRecordEle *rec_ele)
   }
 
   // create and send request
-  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::RECORD_GET, &optype, &record);
-  return (ret == TS_ERR_OKAY) ? mgmt_record_get_reply(OpType::RECORD_GET, rec_ele) : ret;
+  if ((ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::RECORD_GET, &optype, &record)) != TS_ERR_OKAY) {
+    return ret;
+  }
+
+  // drop the response if the record name doesn't match
+  // we need to do this because there might be left over data on the socket
+  // when restarting traffic_server, even though it can't be recreated in a
+  // test environment, it has been observed in production the names doesn't
+  // match and caused traffic_cop to crash due to type mismatch.
+  while ((ret = mgmt_record_get_reply(OpType::RECORD_GET, rec_ele)) == TS_ERR_OKAY && strcmp(rec_name, rec_ele->rec_name) != 0) {
+  }
+  return ret;
 }
 
 TSMgmtError


### PR DESCRIPTION
This has been observed in production environment a couple of times during the testing for other things (freelist and jemalloc related stuff). The problem is when traffic_server crashed, traffic_cop will try to restart the process and request `proxy.config.manager_binary` using `TSRecordGetString()`. But for some unknown reason the response to that request returns values for `proxy.node.proxy_running`. And since the value type for `proxy.node.proxy_running` is `int`, but `TSRecordGetString()` wants to interpret it as a `str`, the integer value gets dereferenced and traffic_cop segfaults.