### PR TITLE
Issue 3350: traffic_server using 100% CPU

### DIFF
--- a/mgmt/ProcessManager.cc
+++ b/mgmt/ProcessManager.cc
@@ -148,6 +148,8 @@ ProcessManager::processManagerThread(void *arg)
 
   if (pmgmt->require_lm) { /* Allow p. process to run w/o a lm */
     pmgmt->initLMConnection();
+  } else {
+    return ret;
   }
 
   if (pmgmt->init) {


### PR DESCRIPTION
Fixes issue #3350. When `traffic_manager` is not present `processManagerThread` spins as it sees an empty queue, skips the polling step (which causes the thread to wait), sees the `ProcessManager` is running and does the whole process again. Causes the CPU to run at 100%. 
```
 %CPU %MEM CMD
 101  3.0 /tmp/trafficservertest/bin/traffic_server
```

Contrast this to when `traffic_manager` is also running.

```
%CPU %MEM CMD
 3.2  3.0 /tmp/trafficservertest/bin/traffic_server -M --httpport 8080:fd=7,8080:fd=8:ipv6
```

If there is no `LocalManager` there is nothing for `ProcessManager` to even talk to so just exit the thread. 
``` 
%CPU %MEM CMD
 3.6  3.0 /tmp/trafficservertest/bin/traffic_server
```

@masaori335 can you verify this fix?