### PR TITLE
Adds 206 and 304 to the default status codes to be compressible

### DIFF
--- a/plugins/gzip/configuration.cc
+++ b/plugins/gzip/configuration.cc
@@ -196,12 +196,8 @@ HostConfiguration::is_url_allowed(const char *url, int url_len)
 bool
 HostConfiguration::is_status_code_compressible(const TSHttpStatus status_code) const
 {
-  // maintain backwards compatibility/usability out of the box
-  if (compressible_status_codes_.empty()) {
-    return status_code == 200;
-  }
-
   std::set<TSHttpStatus>::const_iterator it = compressible_status_codes_.find(status_code);
+
   return it != compressible_status_codes_.end();
 }
 

--- a/plugins/gzip/configuration.h
+++ b/plugins/gzip/configuration.h
@@ -149,7 +149,9 @@ private:
   StringContainer compressible_content_types_;
   StringContainer disallows_;
   StringContainer allows_;
-  std::set<TSHttpStatus> compressible_status_codes_;
+  // maintain backwards compatibility/usability out of the box
+  std::set<TSHttpStatus> compressible_status_codes_ = {TS_HTTP_STATUS_OK, TS_HTTP_STATUS_PARTIAL_CONTENT,
+                                                       TS_HTTP_STATUS_NOT_MODIFIED};
 
   DISALLOW_COPY_AND_ASSIGN(HostConfiguration);
 };


### PR DESCRIPTION
Miles ran into an issue where something is stale in cache, and we end
up returning a 304, we don't send proper Vary headers, and this causes
things to be bad.