### PR TITLE
Tests wait until microserver is ready

### DIFF
--- a/tests/gold_tests/autest-site/microserver.test.ext
+++ b/tests/gold_tests/autest-site/microserver.test.ext
@@ -16,8 +16,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from autest.api import AddWhenFunction
 from ports import get_port
 import json
+import socket
+import ssl
+import time
 
 
 def addMethod(self, testName, request_header, functionName):
@@ -32,22 +36,6 @@ def httpObject(self, header, data):
     r["headers"] = header
     r["body"] = data
     return r
-
-# addResponse adds customized response with respect to request_header. request_header and response_header are both dictionaries
-
-
-def addResponse(self, filename, testName, request_header, response_header):
-
-    txn = dict()
-    txn["timestamp"] = ""
-    txn["uuid"] = testName
-    txn["request"] = request_header
-    txn["response"] = response_header
-
-    addTransactionToSession(txn, filename)
-    absFilepath = os.path.abspath(filename)
-    self.Setup.CopyAs(absFilepath, self.Variables.DataDir)
-    return
 
 
 def getHeaderFieldVal(request_header, field):
@@ -79,7 +67,6 @@ def addResponse(self, filename, request_header, response_header):
                 path_ = url_part[1].split("/", 1)[1]
 
     kpath = ""
-    #print("Format of lookup key",self.Variables.lookup_key)
 
     argsList = []
     keyslist = self.Variables.lookup_key.split("}")
@@ -124,7 +111,7 @@ def addTransactionToSession(txn, JFile):
 
     if jsondata == None:
         jsondata = dict()
-        jsondata["version"] = '0.1'
+        jsondata["version"] = '0.2'
         jsondata["timestamp"] = "1234567890.098"
         jsondata["encoding"] = "url_encoded"
         jsondata["txns"] = list()
@@ -144,6 +131,36 @@ def makeHeader(self, requestString, **kwargs):
     return headerStr
 
 
+def uServerUpAndRunning(host, port, isSsl):
+    plain_sock = socket.socket(socket.AF_INET)
+    sock = ssl.wrap_socket(plain_sock) if isSsl else plain_sock
+    try:
+        sock.connect((host, port))
+    except ConnectionRefusedError:
+        return False
+
+    sock.sendall("GET /ruok HTTP/1.1\r\nHost: {}\r\n\r\n".format(host).encode())
+    decoded_output=''
+    while True:
+        output = sock.recv(4096)  # suggested bufsize from docs.python.org
+        if len(output) <= 0:
+            break
+        else:
+            decoded_output+=output.decode()
+    sock.close()
+    sock = None
+
+    expected_response="HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 4\r\n\r\nimok"
+    if decoded_output == expected_response:
+        return True
+    raise RuntimeError('\n'.join([
+            'Got invalid response from microserver:',
+            '----',
+            decoded_output,
+            '----']))
+AddWhenFunction(uServerUpAndRunning)
+
+
 def MakeOriginServer(obj, name, port=False, ip=False, delay=False, ssl=False, lookup_key='{PATH}', mode='test', options={}):
     server_path = os.path.join(obj.Variables.AtsTestToolsDir, 'microServer/uWServer.py')
     data_dir = os.path.join(obj.RunDirectory, name)
@@ -160,15 +177,27 @@ def MakeOriginServer(obj, name, port=False, ip=False, delay=False, ssl=False, lo
     for flag, value in options.items():
         command += " {} {}".format(flag, value)
 
-    # create process
     p.Command = command
     p.Setup.MakeDir(data_dir)
     p.Variables.DataDir = data_dir
     p.Variables.lookup_key = lookup_key
-    p.Ready = When.PortOpen(port, ip)
-    p.ReturnCode = Any(None, 0)
     AddMethodToInstance(p, addResponse)
     AddMethodToInstance(p, addTransactionToSession)
+
+    # Set up health check.
+    addResponse(p, "healthcheck.json", {
+        "headers": "GET /ruok HTTP/1.1\r\nHost: {}\r\n\r\n".format(ip),
+        "timestamp": "1469733493.993",
+        "body": ""
+    }, {
+        "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
+        "timestamp": "1469733493.993",
+        "body": "imok",
+        "options": "skipHooks"
+    })
+
+    p.Ready = When.uServerUpAndRunning(ip, port, ssl)
+    p.ReturnCode = Any(None, 0)
 
     return p
 

--- a/tests/gold_tests/continuations/double.test.py
+++ b/tests/gold_tests/continuations/double.test.py
@@ -32,7 +32,7 @@ ts = Test.MakeATSProcess("ts", command="traffic_manager")
 server = Test.MakeOriginServer("server")
 
 Test.testName = ""
-request_header = {"headers": "GET / HTTP/1.1\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: double.test\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 # expected response from the origin server
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
@@ -47,7 +47,7 @@ ts.Disk.records_config.update({
     'proxy.config.cache.enable_read_while_writer' : 0
 })
 ts.Disk.remap_config.AddLine(
-    'map http://127.0.0.1:{0} http://127.0.0.1:{1}'.format(ts.Variables.port, server.Variables.Port)
+    'map http://double.test:{0} http://127.0.0.1:{1}'.format(ts.Variables.port, server.Variables.Port)
 )
 
 numberOfRequests = randint(1000, 1500)

--- a/tests/gold_tests/transaction/txn.test.py
+++ b/tests/gold_tests/transaction/txn.test.py
@@ -33,7 +33,7 @@ ts = Test.MakeATSProcess("ts", command="traffic_manager")
 server = Test.MakeOriginServer("server")
 
 Test.testName = ""
-request_header = {"headers": "GET / HTTP/1.1\r\n\r\n",
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: txn.test\r\n\r\n",
                   "timestamp": "1469733493.993", "body": ""}
 # expected response from the origin server
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
@@ -52,7 +52,7 @@ ts.Disk.records_config.update({
 })
 
 ts.Disk.remap_config.AddLine(
-    'map http://127.0.0.1:{0} http://127.0.0.1:{1}'.format(
+    'map http://txn.test:{0} http://127.0.0.1:{1}'.format(
         ts.Variables.port, server.Variables.Port)
 )
 
@@ -60,7 +60,7 @@ numberOfRequests = randint(1000, 1500)
 
 # Make a *ton* of calls to the proxy!
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'ab -n {0} -c 10 http://127.0.0.1:{1}/;sleep 5'.format(
+tr.Processes.Default.Command = 'ab -n {0} -c 10 -X 127.0.0.1:{1} http://txn.test/;sleep 5'.format(
     numberOfRequests, ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 # time delay as proxy.config.http.wait_for_cache could be broken

--- a/tests/tools/microServer/README.md
+++ b/tests/tools/microServer/README.md
@@ -4,20 +4,7 @@ uWServer
 uWServer is a mock HTTP server that takes predefined set of sessions for serving response to HTTP requests. Each session includes one or more transactions. A transaction is composed of an HTTP request and an HTTP response. 
 uWServer accepts session data in JSON fromat only.
 
-Example session :
-```
- {"version": "0.1",  
-  "txns": [  
-        {"request": {"headers": "GET /path1\r\n Host: example.com \r\n\r\n", "timestamp": "1522783378", "body": "Apache Traffic Server"},     
-        "response": {"headers": "HTTP/1.1\r\n Server: microserver\r\nContent-Length:100 \r\n\r\n", "timestamp": "1522783378", "body": ""},  
-         "uuid": "1"},   
-        {"request": {"headers": "GET /path2\r\n\r\n", "timestamp": "1522783378", "body": "Apache Traffic Server"},   
-        "response": {"headers": "HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n", "timestamp": "1522783378", "body": "Apache Traffic Server"},   
-        "uuid": "2"}  
-  ],   
-  "timestamp": "1522783378",   
-  "encoding": ""}  
-```
+
 Command:
 ----------------
 
@@ -26,6 +13,37 @@ Command:
 Options:
 -----------
 
-To see the options please run `python3.5 uWServer.py -h`
+To see the options please run `python3.5 uWServer.py --help`
 
+Session Definitions:
+--------------------
 
+Example session:
+
+```
+{
+  "encoding": "url_encoded",
+  "version": "0.2",
+  "txns": [
+    {
+      "response": {
+        "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
+        "body": "",
+        "timestamp": "1469733493.993"
+      },
+      "request": {
+        "headers": "GET / HTTP/1.1\r\nHost: www.example.test\r\n\r\n",
+        "body": "",
+        "timestamp": "1469733493.993"
+      },
+      "uuid": "",
+      "timestamp": ""
+    }
+  ],
+  "timestamp": "1234567890.098"
+}
+```
+
+Each session should be in its own file, and any number of files may be created to define sessions.
+
+The `response` map may include an `options` string, which is a comma-delimited list of options to be enabled. Currently the only option supported is `skipHooks`, which will ignore any hooks created for the matching request/response pair. See **Options**.

--- a/tests/tools/sessionvalidation/response.py
+++ b/tests/tools/sessionvalidation/response.py
@@ -16,6 +16,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import re
+
 
 class Response(object):
     ''' Response encapsulates a single request from the UA '''
@@ -29,12 +31,19 @@ class Response(object):
     def getBody(self):
         return self._body
 
+    def getOptions(self):
+        return self._options
+
     def __repr__(self):
-        return "<Response: {{'timestamp': {0}, 'headers': {1}, 'body': {2}}}>".format(
-            self._timestamp, self._headers, self._body
+        return "<Response: {{'timestamp': {0}, 'headers': {1}, 'body': {2}, 'options': {3}}}>".format(
+            self._timestamp, self._headers, self._body, self._options
         )
 
-    def __init__(self, timestamp, headers, body):
+    def __init__(self, timestamp, headers, body, options_string):
         self._timestamp = timestamp
         self._headers = headers
         self._body = body
+        if options_string:
+            self._options = re.compile(r'\s*,\s*').split(options_string)
+        else:
+            self._options = list()

--- a/tests/tools/sessionvalidation/sessionvalidation.py
+++ b/tests/tools/sessionvalidation/sessionvalidation.py
@@ -75,7 +75,6 @@ class SessionValidator(object):
                     session_version = sesh['version']
                     session_txns = list()
                     for txn in sesh['txns']:
-                        # print("PERSIA____________________________________________________________",txn)
                         # create transaction Request object
                         txn_request = txn['request']
 
@@ -88,12 +87,12 @@ class SessionValidator(object):
                         txn_response_body = ''
                         if 'body' in txn_response:
                             txn_response_body = txn_response['body']
-                        txn_response_obj = response.Response(txn_response['timestamp'], txn_response['headers'], txn_response_body)
+                        txn_response_obj = response.Response(txn_response['timestamp'], txn_response['headers'], txn_response_body,
+                                txn_response.get('options'))
 
                         # create Transaction object
                         txn_obj = transaction.Transaction(txn_request_obj, txn_response_obj, txn['uuid'])
                         session_txns.append(txn_obj)
-                        # print(txn_request['timestamp'])
                     session_obj = session.Session(fname, session_version, session_timestamp, session_txns)
 
                 except KeyError as e:
@@ -195,11 +194,6 @@ class SessionValidator(object):
             if not found_host:
                 print("missing host", txn_req)
                 _verbose_print("transaction request Host header doesn't have specified host")
-                retval = False
-
-            # reject if the host is localhost (since ATS seems to ignore remap rules for localhost requests)
-            if "127.0.0.1" in txn_req.getHeaders() or "localhost" in txn_req.getHeaders():
-                _verbose_print("transaction request Host is localhost, we must reject because ATS ignores remap rules for localhost requests")
                 retval = False
 
             # now validate response


### PR DESCRIPTION
This change also updates some tests that use "observers" to account for the
extra request served by the microserver before actual tests run.

The purpose of this patch is to help eliminate a race condition when running tests, between the time a port is bound and the time a microserver is able to serve requests.

The cause was traced down from a transient test error in #3360 pointed out by @zwoop 