### PR TITLE
QUIC: Fix compiler warning

### DIFF
--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -774,7 +774,7 @@ QUICNetVConnection::_state_handshake_process_packet(QUICPacketUPtr packet)
     break;
   case QUICPacketType::PROTECTED:
   default:
-    QUICConDebug("Ignore %s(%" PRIu8 ") packet", QUICDebugNames::packet_type(packet->type()), packet->type());
+    QUICConDebug("Ignore %s(%" PRIu8 ") packet", QUICDebugNames::packet_type(packet->type()), static_cast<uint8_t>(packet->type()));
 
     error = QUICErrorUPtr(new QUICConnectionError(QUICTransErrorCode::INTERNAL_ERROR));
     break;
@@ -878,7 +878,7 @@ QUICNetVConnection::_state_common_receive_packet()
       error = this->_recv_and_ack(std::move(p));
       break;
     default:
-      QUICConDebug("Unknown packet type: %s(%" PRIu8 ")", QUICDebugNames::packet_type(p->type()), p->type());
+      QUICConDebug("Unknown packet type: %s(%" PRIu8 ")", QUICDebugNames::packet_type(p->type()), static_cast<uint8_t>(p->type()));
 
       error = QUICErrorUPtr(new QUICConnectionError(QUICTransErrorCode::INTERNAL_ERROR));
       break;


### PR DESCRIPTION
```
QUICNetVConnection.cc: In member function ‘QUICErrorUPtr QUICNetVConnection::_state_handshake_process_packet(QUICPacketUPtr)’:
../../lib/ts/Diags.h:330:50: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 8 has type ‘QUICPacketType’ [-Wformat=]
       diags->log(tag, DL_Debug, &loc, __VA_ARGS__);    \
                                                  ^
QUICNetVConnection.cc:47:3: note: in expansion of macro ‘Debug’
   Debug("quic_net", "[%" PRIx64 "] " fmt, static_cast<uint64_t>(this->_quic_connection_id), ##__VA_ARGS__)
   ^
QUICNetVConnection.cc:790:5: note: in expansion of macro ‘QUICConDebug’
     QUICConDebug("Ignore %s(%" PRIu8 ") packet", QUICDebugNames::packet_type(packet->type()), packet->type());
     ^
QUICNetVConnection.cc: In member function ‘QUICErrorUPtr QUICNetVConnection::_state_common_receive_packet()’:
../../lib/ts/Diags.h:330:50: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 8 has type ‘QUICPacketType’ [-Wformat=]
       diags->log(tag, DL_Debug, &loc, __VA_ARGS__);    \
                                                  ^
QUICNetVConnection.cc:47:3: note: in expansion of macro ‘Debug’
   Debug("quic_net", "[%" PRIx64 "] " fmt, static_cast<uint64_t>(this->_quic_connection_id), ##__VA_ARGS__)
   ^
QUICNetVConnection.cc:894:7: note: in expansion of macro ‘QUICConDebug’
       QUICConDebug("Unknown packet type: %s(%" PRIu8 ")", QUICDebugNames::packet_type(p->type()), p->type());
       ^
At global scope:

```

Ubuntu 16.04