### PR TITLE
Add SO_MARK functionality to header_rewrite plugin.

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -682,6 +682,16 @@ When invoked, sets the client side `DSCP
 <https://en.wikipedia.org/wiki/Differentiated_services>`_ value for the current
 transaction.  The ``<value>`` should be specified as a decimal integer.
 
+set-conn-mark
+~~~~~~~~~~~~~
+::
+
+  set-conn-mark <value>
+
+When invoked, sets the client side MARK value for the current
+transaction.  The ``<value>`` should be specified as a decimal integer.
+Requires at least Linux 2.6.25.
+
 set-debug
 ~~~~~~~~~
 ::

--- a/plugins/header_rewrite/factory.cc
+++ b/plugins/header_rewrite/factory.cc
@@ -64,6 +64,8 @@ operator_factory(const std::string &op)
     o = new OperatorAddCookie();
   } else if (op == "set-conn-dscp") {
     o = new OperatorSetConnDSCP();
+  } else if (op == "set-conn-mark") {
+    o = new OperatorSetConnMark();
   } else if (op == "set-debug") {
     o = new OperatorSetDebug();
   } else {

--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -925,6 +925,32 @@ OperatorSetConnDSCP::exec(const Resources &res) const
   }
 }
 
+// OperatorSetConnMark
+void
+OperatorSetConnMark::initialize(Parser &p)
+{
+  Operator::initialize(p);
+
+  _ds_value.set_value(p.get_arg());
+}
+
+void
+OperatorSetConnMark::initialize_hooks()
+{
+  add_allowed_hook(TS_HTTP_READ_REQUEST_HDR_HOOK);
+  add_allowed_hook(TS_HTTP_SEND_RESPONSE_HDR_HOOK);
+  add_allowed_hook(TS_REMAP_PSEUDO_HOOK);
+}
+
+void
+OperatorSetConnMark::exec(const Resources &res) const
+{
+  if (res.txnp) {
+    TSHttpTxnClientPacketMarkSet(res.txnp, _ds_value.get_int_value());
+    TSDebug(PLUGIN_NAME, "   Setting MARK to %d", _ds_value.get_int_value());
+  }
+}
+
 // OperatorSetDebug
 void
 OperatorSetDebug::initialize(Parser &p)

--- a/plugins/header_rewrite/operators.h
+++ b/plugins/header_rewrite/operators.h
@@ -312,6 +312,22 @@ private:
   Value _ds_value;
 };
 
+class OperatorSetConnMark : public Operator
+{
+public:
+  OperatorSetConnMark() { TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for OperatorSetConnMark"); }
+  void initialize(Parser &p);
+
+protected:
+  void initialize_hooks();
+  void exec(const Resources &res) const;
+
+private:
+  DISALLOW_COPY_AND_ASSIGN(OperatorSetConnMark);
+
+  Value _ds_value;
+};
+
 class OperatorSetDebug : public Operator
 {
 public:


### PR DESCRIPTION
This adds setting a packet mark to a socket on Linux. It's nearly identical to DSCP support.