### PR TITLE
Fixed length calculation for url_sig excl regexes.

### DIFF
--- a/plugins/experimental/url_sig/url_sig.c
+++ b/plugins/experimental/url_sig/url_sig.c
@@ -509,17 +509,15 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
   const char *query = strchr(url, '?');
 
   if (cfg->regex) {
-    int offset = 0, options = 0;
+    const int offset = 0, options = 0;
     int ovector[30];
-    int len            = url_len;
-    const char *anchor = strchr(url, '#');
-    if (query && !anchor) {
-      len -= (query - url);
-    } else if (anchor && !query) {
-      len -= (anchor - url);
-    } else if (anchor && query) {
-      len -= ((query < anchor ? query : anchor) - url);
-    }
+
+    /* Only search up to the first ? or # */
+    const char *base_url_end = url;
+    while (*base_url_end && !(*base_url_end == '?' || *base_url_end == '#'))
+      ++base_url_end;
+    const int len = base_url_end - url;
+
     if (pcre_exec(cfg->regex, cfg->regex_extra, url, len, offset, options, ovector, 30) >= 0) {
       goto allow;
     }


### PR DESCRIPTION
The old calculation was incorrectly calculating the length to be
searched. Fortunately, it was not possible for the length to be
overlong, so there is no security concern, simply a bug that caused some
requests that should have been whitelisted via the excl regex to be
validated (and therefore to fail) incorrectly.

This change corrects the calculation.