### PR TITLE
Fixed error message about no-noexcept-type when compiling C

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -849,10 +849,10 @@ case $host_os_def in
     AS_IF([test "x$ax_cv_c_compiler_vendor" = "xgnu"], [
       # This is useful for finding odd conversions
       #    common_opt="-pipe -Wall -Wconversion -Wno-sign-conversion -Wno-format-truncation"
-      common_opt="-pipe -Wall -Wextra -Wno-ignored-qualifiers -Wno-unused-parameter -Wno-format-truncation -Wno-noexcept-type"
+      common_opt="-pipe -Wall -Wextra -Wno-ignored-qualifiers -Wno-unused-parameter -Wno-format-truncation"
       debug_opt="-ggdb3 $common_opt"
       release_opt="-g $common_opt $optimizing_flags -feliminate-unused-debug-symbols -fno-strict-aliasing"
-      cxx_opt="-Wno-invalid-offsetof"
+      cxx_opt="-Wno-invalid-offsetof -Wno-noexcept-type"
       # Special options for flex generated .c files
       flex_cflags="-Wno-unused-parameter"
     ])


### PR DESCRIPTION
Fixed these errors:
cc1: warning: command line option ‘-Wno-noexcept-type’ is valid for C++/ObjC++ but not for C