### PR TITLE
Update traffic_layout runroot commands and switches

### DIFF
--- a/tests/gold_tests/runroot/runroot_init.test.py
+++ b/tests/gold_tests/runroot/runroot_init.test.py
@@ -39,7 +39,7 @@ f.Exists = True
 # init to relative directory
 path2 = os.path.join(ts_root, "runroot2")
 tr = Test.AddTestRun("Test traffic_layout init #2")
-tr.Processes.Default.Command = "cd " + ts_root + "; " + "$ATS_BIN/traffic_layout init --path runroot2"
+tr.Processes.Default.Command = "cd " + ts_root + ";$ATS_BIN/traffic_layout init --path runroot2"
 tr.Processes.Default.ReturnCode = 0
 f = tr.Disk.File(os.path.join(path2, "runroot_path.yml"))
 f.Exists = True
@@ -47,7 +47,17 @@ f.Exists = True
 # init to cwd
 path3 = os.path.join(ts_root, "runroot3")
 tr = Test.AddTestRun("Test traffic_layout init #3")
-tr.Processes.Default.Command = "mkdir " + path3 + "; cd " + path3 + "; " + "$ATS_BIN/traffic_layout init"
+tr.Processes.Default.Command = "mkdir " + path3 + ";cd " + path3 + ";$ATS_BIN/traffic_layout init"
 tr.Processes.Default.ReturnCode = 0
 f = tr.Disk.File(os.path.join(path3, "runroot_path.yml"))
 f.Exists = True
+
+# --force init to an non-empty directory
+path4 = os.path.join(ts_root, "runroot4")
+tr = Test.AddTestRun("Test traffic_layout init #4")
+randomfile = os.path.join(path4, "foo")
+tr.Processes.Default.Command = "mkdir " + path4 + ";touch " + randomfile + ";$ATS_BIN/traffic_layout init --force --path " + path4
+tr.Processes.Default.ReturnCode = 0
+f = tr.Disk.File(os.path.join(path4, "runroot_path.yml"))
+f.Exists = True
+tr.Processes.Default.Streams.All = Testers.ContainsExpression("Forcing creating runroot", "force message")

--- a/tests/gold_tests/runroot/runroot_remove.test.py
+++ b/tests/gold_tests/runroot/runroot_remove.test.py
@@ -59,7 +59,7 @@ d.Exists = False
 
 # remove of relative path
 tr = Test.AddTestRun("Test traffic_layout remove #2")
-tr.Processes.Default.Command = "cd " + ts_root + "; " + "$ATS_BIN/traffic_layout remove --path runroot2"
+tr.Processes.Default.Command = "cd " + ts_root + ";$ATS_BIN/traffic_layout remove --path runroot2"
 tr.Processes.Default.ReturnCode = 0
 f = tr.Disk.File(os.path.join(path2, "runroot_path.yml"))
 f.Exists = False
@@ -68,9 +68,9 @@ d.Exists = False
 
 # remove cwd
 tr = Test.AddTestRun("Test traffic_layout remove #3")
-tr.Processes.Default.Command = "mkdir " + path3 + "; cd " + path3 + "; " + "$ATS_BIN/traffic_layout remove"
+tr.Processes.Default.Command = "mkdir " + path3 + ";cd " + path3 + ";$ATS_BIN/traffic_layout remove"
 tr.Processes.Default.ReturnCode = 0
 f = tr.Disk.File(os.path.join(path3, "runroot_path.yml"))
 f.Exists = False
-d = tr.Disk.Directory(path2)
-d.Exists = False
+d = tr.Disk.Directory(path3)
+d.Exists = True


### PR DESCRIPTION
``remove`` and ``init`` command of runroot is updated. 

- if the user is in some directory of the runroot and tries to remove itself, remove will not delete the directory that user is currently in.
- init will not be allowed if we are creating another runroot inside an existing runroot. 
- init will ask for user input Y/N if the destination directory is not empty.
- init with ``--force`` option will create runroot automatically even if the destination directory is not empty.

Tests are updated accordingly.