### PR TITLE
BufferWriter formatting for sockaddr and IpEndpoint

### DIFF
--- a/doc/developer-guide/api/types/CoreTypes.en.rst
+++ b/doc/developer-guide/api/types/CoreTypes.en.rst
@@ -34,3 +34,7 @@ Description
 These types are provided by the compiler ("built-in") or from a required operating system, POSIX, or package header.
 
 .. cpp:type:: uint24_t
+
+.. cpp:class:: IpEndpoint
+
+   A wrapper for :code:`sockaddr` types.

--- a/doc/developer-guide/internal-libraries/buffer-writer.en.rst
+++ b/doc/developer-guide/internal-libraries/buffer-writer.en.rst
@@ -30,7 +30,8 @@ Synopsis
 
 .. code-block:: cpp
 
-   #include <ts/BufferWriter.h>
+   #include <ts/BufferWriterForward.h> // Forward declarations
+   #include <ts/BufferWriter.h> // Full
 
 Description
 +++++++++++
@@ -42,9 +43,10 @@ past the end, while tracking the theoretical output to enable buffer resizing af
 also lets a :class:`BufferWriter` instance write into the middle of a larger buffer, making nested
 output logic easy to build.
 
-The header files are divided in to two variants. ``BufferWriter.h`` provides the basic capabilities
-of buffer output control. ``BufferWriterFormat.h`` provides formatted output mechanisms, primarily
-the implementation and ancillary classes for :func:`BufferWriter::print`.
+The header files are divided in to two variants. :ts:git:`lib/ts/BufferWriter.h` provides the basic
+capabilities of buffer output control. :ts:git:`lib/ts/BufferWriterFormat.h` provides the basic
+formatted output mechanisms, primarily the implementation and ancillary classes for
+:class:`BWFSpec` which is used to build formatters.
 
 :class:`BufferWriter` is an abstract base class, in the style of :code:`std::ostream`. There are
 several subclasses for various use cases. When passing around this is the common type.
@@ -68,9 +70,11 @@ can be more compactly and robustly done as:
 
    ts::LocalBufferWriter<1024> w;
 
-In many cases using :class:`LocalBufferWriter` this is the only place the size of the buffer needs
-to be specified, and therefore can simply be a constant without the overhead of defining a size to
-maintain consistency.
+In many cases, when using :class:`LocalBufferWriter` this is the only place the size of the buffer
+needs to be specified and therefore can simply be a constant without the overhead of defining a size
+to maintain consistency. The choice between :class:`LocalBufferWriter` and :class:`FixedBufferWriter`
+comes down to the owner of the buffer - the former has its own buffer while the latter operates on
+a buffer owned by some other object.
 
 Writing
 -------
@@ -86,19 +90,15 @@ There are also stream operators in the style of C++ stream I/O. The basic templa
 
    template < typename T > ts::BufferWriter& operator << (ts::BufferWriter& w, T const& t);
 
-Several basic types are overloaded and it is easy to extend to additional types. For instance, to make :code:`ts::TextView` work with :class:`BufferWriter`, the code would be
-
-.. code-block:: cpp
-
-   ts::BufferWriter & operator << (ts::BufferWriter & w, TextView const & sv) {
-      w.write(sv.data(), sv.size());
-      return w;
-   }
+The stream operators are provided as a convenience, the primary mechanism for formatted output is
+via overloading the :func:`bwformat` function. Except for a limited set of cases the stream operators
+are implemented by calling :func:`bwformat` with the Buffer Writer, the argument, and a default
+format specification.
 
 Reading
 -------
 
-The data in the buffer can be extracted using :func:`BufferWriter::data`. This and
+Data in the buffer can be extracted using :func:`BufferWriter::data`. This and
 :func:`BufferWriter::size` return a pointer to the start of the buffer and the amount of data
 written to the buffer. This is very similar to :func:`BufferWriter::view` which returns a
 :class:`string_view` which covers the output data. Calling :func:`BufferWriter::error` will indicate
@@ -304,6 +304,17 @@ Reference
 
       Construct an instance with a capacity of :arg:`N`.
 
+.. class:: BWFSpec
+
+   This holds a format specifier. It has the parsing logic for a specifier and if the constructor is
+   passed a :class:`string_view` of a specifier, that will parse it and loaded into the class
+   members. This is useful to specialized implementations of :func:`bwformat`.
+
+.. function:: template<typename V> BufferWriter& bwformat(BufferWriter & w, BWFSpec const & spec, V const & v)
+
+   A family of overloads that perform formatted output on a :class:`BufferWriter`. The set of types
+   supported can be extended by defining an overload of this function for the types.
+
 .. _bw-formatting:
 
 Formatted Output
@@ -353,7 +364,7 @@ arguments in generating out in the buffer. The basic format is divided in to thr
       min: integer
       precision: integer
       max: integer
-      type: "x" | "o" | "b"
+      type: "g" | "s" | "x" | "X" | "d" | "o" | "b" | "B" | "p" | "P"
 
    The output is placed in a field that is at least :token:`min` wide and no more than :token:`max` wide. If
    the output is less than :token:`min` then
@@ -375,19 +386,29 @@ arguments in generating out in the buffer. The basic format is divided in to thr
             Numerically align, putting the fill between the output and the sign character.
 
    The output is clipped by :token:`max` width characters or the end of the buffer. :token:`precision` is used by
-   floating point values to specify the number of places of precision. The precense of the ``#`` character is used for
-   integer values and causes a radix indicator to be used (one of ``0xb``, ``0``, ``0x``).
+   floating point values to specify the number of places of precision.
 
-   :token:`type` is used to indicate type specific formatting. For integers it indicates the output
-   radix. If ``#`` is present the radix is prefix is generated with case matching that of the type
-   (e.g. type ``x`` causes ``0x`` and type ``X`` causes ``0X``).
+   :token:`type` is used to indicate type specific formatting. For integers it indicates the output radix and
+   if ``#`` is present the radix is prefix is generated (one of ``0xb``, ``0``, ``0x``). Format types of the same
+   letter are  equivalent, varying only in the character case used for output. Most common, 'x' prints values in
+   lower cased hexadecimal (:code:`0x1337beef`) while 'X' prints in upper case hexadecimal (:code:`0X1337BEEF`).
 
       = ===============
       b binary
+      B Binary
+      d decimal
       o octal
       x hexadecimal
+      X Hexadecimal
+      p pointer (hexadecimal address)
+      P Pointer (Hexidecimal address)
+      s string
       = ===============
 
+   For several specializations the hexadecimal format is taken to indicate printing the value as if
+   it were a hexidecimal value, in effect providing a hex dump of the value. This is the case for
+   :class:`string_view` and therefore a hex dump of an object can be done by creating a
+   :class:`string_view` covering the data and then printing it with :code:`{:x}`.
 
 :arg:`extension`
    Text (excluding braces) that is passed to the formatting function. This can be used to provide
@@ -407,10 +428,49 @@ When an value needs to be formatted an overloaded function for type :code:`V` is
 This can (and should be) overloaded for user defined types. This makes it easier and cheaper to
 build one overload on another by tweaking the :arg:`spec` as it passed through. The calling
 framework will handle basic alignment, the overload does not need to unless the alignment
-requirements are more detailed (e.g. integer alignment operations).
+requirements are more detailed (e.g. integer alignment operations) or performance is critical.
 
 The output stream operator :code:`operator<<` is defined to call this function with a default
 constructed :code:`BWFSpec` instance.
+
+Specialized Types
++++++++++++++++++
+
+:class:`string_view`
+   Generally the contents of the view.
+
+   'x' or 'X'
+      A hexadecimal dump of the contents of the view in lower ('x') or upper ('X') case.
+
+   'p' or 'P'
+      The pointer and length value of the view in lower ('p') or upper ('P') case.
+
+:code:`sockaddr const*`
+   The IP address is printed. Fill is used to fill in address segments if provided, not to the
+   minimum width if specified.
+
+   'p' or 'P'
+      The pointer address is printed as a hexadecimal pointer lower ('p') or upper ('P') case
+
+   The extension can be used to control which parts of the address are printed. These can be in any order,
+   the output is always address, port, family. The default is the equivalent of "ap".
+
+   'a'
+      The address.
+
+   'p'
+      The port (host order).
+
+   'f'
+      The IP address family.
+
+   E.g.
+
+   .. code-block: cpp
+
+      sockaddr const* addr;
+      bw.print("Connecting to {0::a} on port {0::p}", addr); // no need to pass the argument twice.
+      bw.print("Using address family {::f}", addr);
 
 Futures
 +++++++

--- a/doc/developer-guide/internal-libraries/buffer-writer.en.rst
+++ b/doc/developer-guide/internal-libraries/buffer-writer.en.rst
@@ -187,8 +187,13 @@ becomes
    }
    w << ']';
 
-Note that in addition there will be no overrun on the memory buffer in :arg:`w`, in strong contrast
+In addition there will be no overrun on the memory buffer in :arg:`w`, in strong contrast
 to the original code.
+
+.. note::
+
+   Work is ongoing to provide formatted output for increased ease of use, particulary with types that
+   are commonly printed but hard to format well, such as IP addresses.
 
 Reference
 +++++++++
@@ -447,13 +452,14 @@ Specialized Types
 
 :code:`sockaddr const*`
    The IP address is printed. Fill is used to fill in address segments if provided, not to the
-   minimum width if specified.
+   minimum width if specified. :class:`IpEndpoint` is also supported with the same formatting.
 
    'p' or 'P'
       The pointer address is printed as a hexadecimal pointer lower ('p') or upper ('P') case
 
    The extension can be used to control which parts of the address are printed. These can be in any order,
-   the output is always address, port, family. The default is the equivalent of "ap".
+   the output is always address, port, family. The default is the equivalent of "ap". In addition, the
+   character '^' ("numeric align") can be used to internally right justify the elements.
 
    'a'
       The address.
@@ -464,13 +470,25 @@ Specialized Types
    'f'
       The IP address family.
 
+   '^'
+      Internally justify the numeric values. This must be the first or second character. If it is the second
+      the first character is treated as the internal fill character. If omitted '0' (zero) is used.
+
    E.g.
 
-   .. code-block: cpp
+   .. code-block:: cpp
 
       sockaddr const* addr;
+      bw.print("Connecting to {}", addr); // -> "Connecting to 172.19.3.105:49951"
       bw.print("Connecting to {0::a} on port {0::p}", addr); // no need to pass the argument twice.
       bw.print("Using address family {::f}", addr);
+      bw.print("{::a}",addr);      // -> "172.19.3.105"
+      bw.print("{::^a}",addr);     // -> "172.019.003.105"
+      bw.print("{::0^a}",addr);    // -> "172.019.003.105"
+      bw.print("{:: ^a}",addr);    // -> "172. 19.  3.105"
+      bw.print("{:>20:a}",addr);   // -> "        172.19.3.105"
+      bw.print("{:>20:^a}",addr);  // -> "     172.019.003.105"
+      bw.print("{:>20: ^a}",addr); // -> "     172. 19.  3.105"
 
 Futures
 +++++++

--- a/lib/ts/BufferWriter.h
+++ b/lib/ts/BufferWriter.h
@@ -197,6 +197,7 @@ public:
 class FixedBufferWriter : public BufferWriter
 {
   using super_type = BufferWriter;
+  using self_type  = FixedBufferWriter;
 
 public:
   /** Construct a buffer writer on a fixed @a buffer of size @a capacity.
@@ -318,13 +319,28 @@ public:
 
   /// Reduce extent to @a n.
   /// If @a n is less than the capacity the error condition, if any, is cleared.
-  /// This can be used to clear the output by calling @c reduce(0)
-  void
+  /// This can be used to clear the output by calling @c reduce(0). In contrast
+  /// to @c clip this reduces the data in the buffer, rather than the capacity.
+  self_type &
   reduce(size_t n)
   {
     ink_assert(n <= _attempted);
 
     _attempted = n;
+    return *this;
+  }
+
+  /// Clear the buffer, reset to empty (no data).
+  /// This is a convenience for reusing a buffer. For instance
+  /// @code
+  ///   bw.reset().print("....."); // clear old data and print new data.
+  /// @endcode
+  /// This is equivalent to @c reduce(0) but clearer for that case.
+  self_type &
+  reset()
+  {
+    _attempted = 0;
+    return *this;
   }
 
   /// Provide a string_view of all successfully written characters.
@@ -446,10 +462,14 @@ protected:
         // generate output on @a w
       }
     @endcode
+
+    The argument can be passed by value if that would be more efficient.
   */
 
 namespace bw_fmt
 {
+  /// Internal signature for template generated formatting.
+  /// @a args is a forwarded tuple of arguments to be processed.
   template <typename TUPLE> using ArgFormatterSignature = BufferWriter &(*)(BufferWriter &w, BWFSpec const &, TUPLE const &args);
 
   /// Internal error / reporting message generators
@@ -460,7 +480,7 @@ namespace bw_fmt
   /// This selects the @a I th argument in the @a TUPLE arg pack and calls the formatter on it. This
   /// (or the equivalent lambda) is needed because the array of formatters must have a homogenous
   /// signature, not vary per argument. Effectively this indirection erases the type of the specific
-  /// argument being formatter.
+  /// argument being formatted. Instances of this have the signature @c ArgFormatterSignature.
   template <typename TUPLE, size_t I>
   BufferWriter &
   Arg_Formatter(BufferWriter &w, BWFSpec const &spec, TUPLE const &args)
@@ -470,7 +490,7 @@ namespace bw_fmt
 
   /// This exists only to expand the index sequence into an array of formatters for the tuple type
   /// @a TUPLE.  Due to langauge limitations it cannot be done directly. The formatters can be
-  /// access via standard array access in constrast to templated tuple access. The actual array is
+  /// accessed via standard array access in constrast to templated tuple access. The actual array is
   /// static and therefore at run time the only operation is loading the address of the array.
   template <typename TUPLE, size_t... N>
   ArgFormatterSignature<TUPLE> *
@@ -481,6 +501,8 @@ namespace bw_fmt
   }
 
   /// Perform alignment adjustments / fill on @a w of the content in @a lw.
+  /// This is the normal mechanism, but a number of the builtin types handle this internally
+  /// for performance reasons.
   void Do_Alignment(BWFSpec const &spec, BufferWriter &w, BufferWriter &lw);
 
   /// Global named argument table.
@@ -497,7 +519,10 @@ namespace bw_fmt
 
 } // bw_fmt
 
-/** Compiled BufferWriter format
+/** Compiled BufferWriter format.
+
+    @note This is not as useful as hoped, the performance is not much better using this than parsing
+    on the fly (about 30% better, which is fine for tight loops but not for general use).
  */
 class BWFormat
 {
@@ -545,12 +570,14 @@ template <typename... Rest>
 BufferWriter &
 BufferWriter::print(TextView fmt, Rest... rest)
 {
-  static constexpr int N = sizeof...(Rest);
-  auto args(std::forward_as_tuple(rest...));
-  auto fa     = bw_fmt::Get_Arg_Formatter_Array<decltype(args)>(std::index_sequence_for<Rest...>{});
-  int arg_idx = 0;
+  static constexpr int N = sizeof...(Rest);  // used as loop limit
+  auto args(std::forward_as_tuple(rest...)); // gather the arguments for easy access.
+  static const auto fa = bw_fmt::Get_Arg_Formatter_Array<decltype(args)>(std::index_sequence_for<Rest...>{});
+  int arg_idx          = 0; // the next argument index to be processed.
 
   while (fmt.size()) {
+    // Next string piece of interest is an (optional) literal and then an (optinal) format specifier.
+    // There will always be a specifier except for the possible trailing literal.
     string_view lit_v;
     string_view spec_v;
     bool spec_p = BWFormat::parse(fmt, lit_v, spec_v);
@@ -558,8 +585,9 @@ BufferWriter::print(TextView fmt, Rest... rest)
     if (lit_v.size()) {
       this->write(lit_v);
     }
+
     if (spec_p) {
-      BWFSpec spec{spec_v};
+      BWFSpec spec{spec_v}; // parse the specifier.
       size_t width = this->remaining();
       if (spec._max < width) {
         width = spec._max;
@@ -630,7 +658,7 @@ operator<<(BufferWriter &w, V &&v)
   return bwformat(w, BWFSpec::DEFAULT, std::forward<V>(v));
 }
 
-// Pointers
+// Pointers that are not specialized.
 inline BufferWriter &
 bwformat(BufferWriter &w, BWFSpec const &spec, const void *ptr)
 {

--- a/lib/ts/BufferWriterFormat.cc
+++ b/lib/ts/BufferWriterFormat.cc
@@ -60,12 +60,40 @@ tv_to_positive_decimal(ts::TextView src, ts::TextView *out)
 
 namespace ts
 {
-const ts::BWFSpec ts::BWFSpec::DEFAULT;
+const BWFSpec BWFSpec::DEFAULT;
+
+const BWFSpec::Property BWFSpec::_prop;
+
+#pragma GCC diagnostic ignored "-Wchar-subscripts"
+BWFSpec::Property::Property()
+{
+  memset(_data, 0, sizeof(_data));
+  _data['b'] = TYPE_CHAR | NUMERIC_TYPE_CHAR;
+  _data['B'] = TYPE_CHAR | NUMERIC_TYPE_CHAR | UPPER_TYPE_CHAR;
+  _data['d'] = TYPE_CHAR | NUMERIC_TYPE_CHAR;
+  _data['g'] = TYPE_CHAR;
+  _data['o'] = TYPE_CHAR | NUMERIC_TYPE_CHAR;
+  _data['p'] = TYPE_CHAR;
+  _data['P'] = TYPE_CHAR | UPPER_TYPE_CHAR;
+  _data['s'] = TYPE_CHAR;
+  _data['S'] = TYPE_CHAR | UPPER_TYPE_CHAR;
+  _data['x'] = TYPE_CHAR | NUMERIC_TYPE_CHAR;
+  _data['X'] = TYPE_CHAR | NUMERIC_TYPE_CHAR | UPPER_TYPE_CHAR;
+
+  _data[' '] = SIGN_CHAR;
+  _data['-'] = SIGN_CHAR;
+  _data['+'] = SIGN_CHAR;
+
+  _data['<'] = static_cast<uint8_t>(BWFSpec::Align::LEFT);
+  _data['>'] = static_cast<uint8_t>(BWFSpec::Align::RIGHT);
+  _data['^'] = static_cast<uint8_t>(BWFSpec::Align::SIGN);
+  _data['='] = static_cast<uint8_t>(BWFSpec::Align::CENTER);
+}
 
 /// Parse a format specification.
 BWFSpec::BWFSpec(TextView fmt)
 {
-  TextView num;
+  TextView num; // temporary for number parsing.
   intmax_t n;
 
   _name = fmt.take_prefix_at(':');

--- a/lib/ts/BufferWriterForward.h
+++ b/lib/ts/BufferWriterForward.h
@@ -68,6 +68,17 @@ struct BWFSpec {
 
   static const self_type DEFAULT;
 
+  /// Validate @a c is a specifier type indicator.
+  static bool is_type(char c);
+  /// Check if the type flag is numeric.
+  static bool is_numeric_type(char c);
+  /// Check if the type is an upper case variant.
+  static bool is_upper_case_type(char c);
+  /// Check if the type @a in @a this is numeric.
+  bool has_numeric_type() const;
+  /// Check if the type in @a this is an upper case variant.
+  bool has_upper_case_type() const;
+
 protected:
   /// Validate character is alignment character and return the appropriate enum value.
   Align align_of(char c);
@@ -75,26 +86,54 @@ protected:
   /// Validate is sign indicator.
   bool is_sign(char c);
 
-  /// Validate @a c is a specifier type indicator.
-  bool is_type(char c);
+  /// Handrolled initialization the character syntactic property data.
+  static const struct Property {
+    Property(); ///< Default constructor, creates initialized flag set.
+    /// Flag storage, indexed by character value.
+    uint8_t _data[0x100];
+    /// Flag mask values.
+    static constexpr uint8_t ALIGN_MASK        = 0x0F; ///< Alignment type.
+    static constexpr uint8_t TYPE_CHAR         = 0x10; ///< A valid type character.
+    static constexpr uint8_t UPPER_TYPE_CHAR   = 0x20; ///< Upper case flag.
+    static constexpr uint8_t NUMERIC_TYPE_CHAR = 0x40; ///< Numeric output.
+    static constexpr uint8_t SIGN_CHAR         = 0x80; ///< Is sign character.
+  } _prop;
 };
 
 inline BWFSpec::Align
 BWFSpec::align_of(char c)
 {
-  return '<' == c ? Align::LEFT : '>' == c ? Align::RIGHT : '=' == c ? Align::CENTER : '^' == c ? Align::SIGN : Align::NONE;
+  return static_cast<Align>(_prop._data[static_cast<unsigned>(c)] & Property::ALIGN_MASK);
 }
 
 inline bool
 BWFSpec::is_sign(char c)
 {
-  return '+' == c || '-' == c || ' ' == c;
+  return _prop._data[static_cast<unsigned>(c)] & Property::SIGN_CHAR;
 }
 
 inline bool
 BWFSpec::is_type(char c)
 {
-  return 'x' == c || 'X' == c || 'o' == c || 'b' == c || 'B' == c || 'd' == c || 's' == c || 'S' == c;
+  return _prop._data[static_cast<unsigned>(c)] & Property::TYPE_CHAR;
+}
+
+inline bool
+BWFSpec::is_upper_case_type(char c)
+{
+  return _prop._data[static_cast<unsigned>(c)] & Property::UPPER_TYPE_CHAR;
+}
+
+inline bool
+BWFSpec::has_numeric_type() const
+{
+  return _prop._data[static_cast<unsigned>(_type)] & Property::NUMERIC_TYPE_CHAR;
+}
+
+inline bool
+BWFSpec::has_upper_case_type() const
+{
+  return _prop._data[static_cast<unsigned>(_type)] & Property::UPPER_TYPE_CHAR;
 }
 
 class BWFormat;

--- a/lib/ts/Makefile.am
+++ b/lib/ts/Makefile.am
@@ -212,6 +212,8 @@ libtsutil_la_SOURCES = \
   X509HostnameValidator.cc \
   X509HostnameValidator.h
 
+BufferWriterFormat.o : AM_CPPFLAGS += -Wno-char-subscripts
+
 #test_UNUSED_SOURCES = \
 #  load_http_hdr.cc \
 #  IntrusivePtrTest.cc \

--- a/lib/ts/ink_inet.h
+++ b/lib/ts/ink_inet.h
@@ -30,6 +30,7 @@
 #include <ts/ink_memory.h>
 #include <ts/ink_apidefs.h>
 #include <ts/string_view.h>
+#include <ts/BufferWriterForward.h>
 
 #if !TS_HAS_IN6_IS_ADDR_UNSPECIFIED
 #if defined(IN6_IS_ADDR_UNSPECIFIED)
@@ -1542,3 +1543,14 @@ IpEndpoint::setToLoopback(int family)
   }
   return *this;
 }
+
+// BufferWriter formatting support.
+namespace ts
+{
+BufferWriter &bwformat(BufferWriter &w, BWFSpec const &spec, sockaddr const *addr);
+inline BufferWriter &
+bwformat(BufferWriter &w, BWFSpec const &spec, IpEndpoint const &addr)
+{
+  return bwformat(w, spec, &addr.sa);
+}
+} // ts

--- a/lib/ts/unit-tests/test_ink_inet.cc
+++ b/lib/ts/unit-tests/test_ink_inet.cc
@@ -144,3 +144,92 @@ TEST_CASE("ats_ip_pton", "[libts][inet][ink_inet]")
   addr.load("c000::ffff:ffff:ffff:ffff:ffff:ffff");
   REQUIRE(addr == upper);
 }
+
+TEST_CASE("inet formatting", "[libts][ink_inet][bwformat]")
+{
+  IpEndpoint ep;
+  ts::string_view addr_1{"[ffee::24c3:3349:3cee:143]:8080"};
+  ts::string_view addr_2{"172.17.99.231:23995"};
+  ts::string_view addr_3{"[1337:ded:BEEF::]:53874"};
+  ts::string_view addr_4{"[1337::ded:BEEF]:53874"};
+  ts::string_view addr_5{"[1337:0:0:ded:BEEF:0:0:956]:53874"};
+  ts::string_view addr_6{"[1337:0:0:ded:BEEF:0:0:0]:53874"};
+  ts::string_view addr_7{"172.19.3.105:49951"};
+  ts::string_view addr_null{"[::]:53874"};
+  ts::LocalBufferWriter<1024> w;
+
+  REQUIRE(0 == ats_ip_pton(addr_1, &ep.sa));
+  w.print("{}", ep);
+  REQUIRE(w.view() == addr_1);
+  w.reset().print("{::p}", ep);
+  REQUIRE(w.view() == "8080");
+  w.reset().print("{::a}", ep);
+  REQUIRE(w.view() == addr_1.substr(1, 24)); // check the brackets are dropped.
+  w.reset().print("[{::a}]", ep);
+  REQUIRE(w.view() == addr_1.substr(0, 26)); // check the brackets are dropped.
+  w.reset().print("[{0::a}]:{0::p}", ep);
+  REQUIRE(w.view() == addr_1); // check the brackets are dropped.
+  w.reset().print("{::^a}", ep);
+  REQUIRE(w.view() == "ffee:0000:0000:0000:24c3:3349:3cee:0143");
+  w.reset().print("{:: ^a}", ep);
+  REQUIRE(w.view() == "ffee:   0:   0:   0:24c3:3349:3cee: 143");
+  ep.setToLoopback(AF_INET6);
+  w.reset().print("{::a}", ep);
+  REQUIRE(w.view() == "::1");
+  REQUIRE(0 == ats_ip_pton(addr_3, &ep.sa));
+  w.reset().print("{::a}", ep);
+  REQUIRE(w.view() == "1337:ded:beef::");
+  REQUIRE(0 == ats_ip_pton(addr_4, &ep.sa));
+  w.reset().print("{::a}", ep);
+  REQUIRE(w.view() == "1337::ded:beef");
+
+  REQUIRE(0 == ats_ip_pton(addr_5, &ep.sa));
+  w.reset().print("{:X:a}", ep);
+  REQUIRE(w.view() == "1337::DED:BEEF:0:0:956");
+
+  REQUIRE(0 == ats_ip_pton(addr_6, &ep.sa));
+  w.reset().print("{::a}", ep);
+  REQUIRE(w.view() == "1337:0:0:ded:beef::");
+
+  REQUIRE(0 == ats_ip_pton(addr_null, &ep.sa));
+  w.reset().print("{::a}", ep);
+  REQUIRE(w.view() == "::");
+
+  REQUIRE(0 == ats_ip_pton(addr_2, &ep.sa));
+  w.reset().print("{::a}", ep);
+  REQUIRE(w.view() == addr_2.substr(0, 13));
+  w.reset().print("{::ap}", ep);
+  REQUIRE(w.view() == addr_2);
+  w.reset().print("{::f}", ep);
+  REQUIRE(w.view() == IP_PROTO_TAG_IPV4);
+  w.reset().print("{::fpa}", ep);
+  REQUIRE(w.view() == "172.17.99.231:23995 ipv4");
+  w.reset().print("{:: ^a}", ep);
+  REQUIRE(w.view() == "172. 17. 99.231");
+  w.reset().print("{::^a}", ep);
+  REQUIRE(w.view() == "172.017.099.231");
+
+  // Documentation examples
+  REQUIRE(0 == ats_ip_pton(addr_7, &ep.sa));
+  w.reset().print("Connecting to {}", ep);
+  REQUIRE(w.view() == "Connecting to 172.19.3.105:49951");
+  w.reset().print("{::a}", ep);
+  REQUIRE(w.view() == "172.19.3.105");
+  w.reset().print("{::^a}", ep);
+  REQUIRE(w.view() == "172.019.003.105");
+  w.reset().print("{::0^a}", ep);
+  REQUIRE(w.view() == "172.019.003.105");
+  w.reset().print("{:: ^a}", ep);
+  REQUIRE(w.view() == "172. 19.  3.105");
+  w.reset().print("{:>20:a}", ep);
+  REQUIRE(w.view() == "        172.19.3.105");
+  w.reset().print("{:>20:^a}", ep);
+  REQUIRE(w.view() == "     172.019.003.105");
+  w.reset().print("{:>20: ^a}", ep);
+  REQUIRE(w.view() == "     172. 19.  3.105");
+  w.reset().print("{:<20:a}", ep);
+  REQUIRE(w.view() == "172.19.3.105        ");
+
+  w.reset().print("{:p}", reinterpret_cast<sockaddr const *>(0x1337beef));
+  REQUIRE(w.view() == "0x1337beef");
+}


### PR DESCRIPTION
This depends on #3408 which is encapsulated in the first commit. It also depends on #3419, which corresponds to the second commit. Once those are merged, this PR will be reduced to a single commit (which is currently the third commit).

Should be merged after ~#3340~, #3408, #3419.

This provides formatting for `sockaddr const*` and `IpEndpoint` with a good amount of flexibility in the formatting. One goal of this is to avoid having to declare the local text buffers to log / debug IP addresses. Instead a `LocalBufferWriter` can be declare and a single formatted string written to that for later logging. The formatting allows extract of the address, port, family, or any subset so none of that has to be done in separate code.

Examples from `HttpSM::do_http_server_open`.
```
int ip_family = t_state.current.server->dst_addr.sa.sa_family;	
auto fam_name = ats_ip_family_name(ip_family);	
SMDebug("http_track", "entered inside do_http_server_open ][%.*s]", static_cast<int>(fam_name.size()), fam_name.data());
```
to
```
ts::LocalBufferWriter<256> w;
w.print("entered inside do_http_server_open [{::f}]", t_state.current.server->dst_addr);
SMDebug("http_track", "%.*s", static_cast<int>(w.size()), w.data());
```

Later on in that function
```
char addrbuf[INET6_ADDRPORTSTRLEN];
SMDebug("http", "[%" PRId64 "] open connection to %s: %s", sm_id, t_state.current.server->name,
    ats_ip_nptop(&t_state.current.server->dst_addr.sa, addrbuf, sizeof(addrbuf)));
```
to (because `w` was already declared)
```
w.reset().print("[{}] open connection to {} : {}", sm_id, t_state.current.server->name, 
    t_state.current.server->dst_addr);
SMDebug("http", "%.*s", static_cast<int>(w.size()), w.data();
```

Note that if the length for `w` is too short, all that happens is the log message is truncated, which is easily fixed by bumping up the length.