### PR TITLE
BufferWriterFormat: add handling for 'p'/'P' pointer type override.

### DIFF
--- a/lib/ts/BufferWriter.h
+++ b/lib/ts/BufferWriter.h
@@ -637,8 +637,11 @@ bwformat(BufferWriter &w, BWFSpec const &spec, const void *ptr)
 {
   BWFSpec ptr_spec{spec};
   ptr_spec._radix_lead_p = true;
-  if (ptr_spec._type == BWFSpec::DEFAULT_TYPE)
-    ptr_spec._type = 'x'; // if default, switch to hex.
+  if (ptr_spec._type == BWFSpec::DEFAULT_TYPE || ptr_spec._type == 'p') {
+    ptr_spec._type = 'x'; // if default or 'p;, switch to lower hex.
+  } else if (ptr_spec._type == 'P') {
+    ptr_spec._type = 'X'; // P means upper hex, overriding other specializations.
+  }
   return bw_fmt::Format_Integer(w, ptr_spec, reinterpret_cast<intptr_t>(ptr), false);
 }
 


### PR DESCRIPTION
This sets up other formatters to use 'p' or 'P' to mean "print as a pointer, not the referenced type".

Should be merged after #3340, #3408.