### PR TITLE
Ran clang-tidy with modernize-loop-convert

### DIFF
--- a/example/cppapi/async_http_fetch_streaming/AsyncHttpFetchStreaming.cc
+++ b/example/cppapi/async_http_fetch_streaming/AsyncHttpFetchStreaming.cc
@@ -122,10 +122,10 @@ Intercept::handleAsyncComplete(AsyncHttpFetch &async_http_fetch)
     oss << HTTP_VERSION_STRINGS[response.getVersion()] << ' ' << response.getStatusCode() << ' ' << response.getReasonPhrase()
         << "\r\n";
     Headers &response_headers = response.getHeaders();
-    for (Headers::iterator iter = response_headers.begin(), end = response_headers.end(); iter != end; ++iter) {
-      HeaderFieldName header_name = (*iter).name();
+    for (auto &&response_header : response_headers) {
+      HeaderFieldName header_name = response_header.name();
       if (header_name != "Transfer-Encoding") {
-        oss << header_name.str() << ": " << (*iter).values() << "\r\n";
+        oss << header_name.str() << ": " << response_header.values() << "\r\n";
       }
     }
     oss << "\r\n";

--- a/example/cppapi/clientrequest/ClientRequest.cc
+++ b/example/cppapi/clientrequest/ClientRequest.cc
@@ -101,9 +101,8 @@ public:
     cout << "Adding a new accept type accept header" << endl;
     client_request_headers.append("accept", "text/blah");
 
-    for (Headers::iterator header_iter = client_request_headers.begin(), header_end = client_request_headers.end();
-         header_iter != header_end; ++header_iter) {
-      cout << (*header_iter).str() << endl;
+    for (auto &&client_request_header : client_request_headers) {
+      cout << client_request_header.str() << endl;
     }
 
     /*

--- a/example/cppapi/serverresponse/ServerResponse.cc
+++ b/example/cppapi/serverresponse/ServerResponse.cc
@@ -103,11 +103,10 @@ private:
   void
   printHeadersManual(Headers &headers)
   {
-    for (Headers::iterator header_iter = headers.begin(), header_end = headers.end(); header_iter != header_end; ++header_iter) {
-      cout << "Header " << (*header_iter).name() << ": " << endl;
+    for (auto &&header : headers) {
+      cout << "Header " << header.name() << ": " << endl;
 
-      for (HeaderField::iterator value_iter = (*header_iter).begin(), values_end = (*header_iter).end(); value_iter != values_end;
-           ++value_iter) {
+      for (HeaderField::iterator value_iter = header.begin(), values_end = header.end(); value_iter != values_end; ++value_iter) {
         cout << "\t" << *value_iter << endl;
       }
     }

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1975,8 +1975,8 @@ ssl_store_ssl_context(const SSLConfigParams *params, SSLCertLookup *lookup, cons
     ctx = nullptr;
   }
 
-  for (unsigned int i = 0; i < cert_list.size(); i++) {
-    X509_free(cert_list[i]);
+  for (auto &i : cert_list) {
+    X509_free(i);
   }
 
   return ctx;

--- a/iocore/net/UnixNetProcessor.cc
+++ b/iocore/net/UnixNetProcessor.cc
@@ -204,8 +204,8 @@ UnixNetProcessor::accept_internal(Continuation *cont, int fd, AcceptOptions cons
 void
 NetProcessor::stop_accept()
 {
-  for (auto na = naVec.begin(); na != naVec.end(); ++na) {
-    (*na)->stop_accept();
+  for (auto &na : naVec) {
+    na->stop_accept();
   }
 }
 

--- a/lib/cppapi/AsyncHttpFetch.cc
+++ b/lib/cppapi/AsyncHttpFetch.cc
@@ -231,9 +231,9 @@ AsyncHttpFetch::run()
                     state_->request_->getUrl().getUrlString().c_str(), HTTP_VERSION_STRINGS[state_->request_->getVersion()].c_str(),
                     reinterpret_cast<struct sockaddr const *>(&addr), TS_FETCH_FLAGS_STREAM | TS_FETCH_FLAGS_DECHUNK);
     string header_value;
-    for (Headers::iterator iter = headers.begin(), end = headers.end(); iter != end; ++iter) {
-      HeaderFieldName header_name = (*iter).name();
-      header_value                = (*iter).values();
+    for (auto &&header : headers) {
+      HeaderFieldName header_name = header.name();
+      header_value                = header.values();
       TSFetchHeaderAdd(state_->fetch_sm_, header_name.c_str(), header_name.length(), header_value.data(), header_value.size());
     }
     LOG_DEBUG("Launching streaming fetch");

--- a/lib/cppapi/Headers.cc
+++ b/lib/cppapi/Headers.cc
@@ -693,8 +693,8 @@ std::string
 Headers::wireStr()
 {
   string retval;
-  for (iterator iter = begin(), last = end(); iter != last; ++iter) {
-    HeaderField hf = *iter;
+  for (auto &&iter : *this) {
+    HeaderField hf = iter;
     retval += hf.name().str();
     retval += ": ";
     retval += hf.values(", ");

--- a/lib/records/RecHttp.cc
+++ b/lib/records/RecHttp.cc
@@ -291,8 +291,7 @@ HttpProxyPort::processOptions(const char *opts)
     return zret;
   }
 
-  for (int i = 0, n_items = values.size(); i < n_items; ++i) {
-    const char *item = values[i];
+  for (auto item : values) {
     if (isdigit(item[0])) { // leading digit -> port value
       char *ptr;
       int port = strtoul(item, &ptr, 10);

--- a/lib/ts/test_PriorityQueue.cc
+++ b/lib/ts/test_PriorityQueue.cc
@@ -54,8 +54,8 @@ dump(PQ *pq)
 {
   std::vector<Entry *> v = pq->dump();
 
-  for (uint32_t i = 0; i < v.size(); i++) {
-    cout << v[i]->index << "," << v[i]->node->weight << "," << v[i]->node->content << endl;
+  for (auto &i : v) {
+    cout << i->index << "," << i->node->weight << "," << i->node->content << endl;
   }
   cout << "--------" << endl;
 }

--- a/lib/ts/unit-tests/test_IpMap.cc
+++ b/lib/ts/unit-tests/test_IpMap.cc
@@ -37,11 +37,10 @@ void
 IpMapTestPrint(IpMap &map)
 {
   printf("IpMap Dump\n");
-  for (IpMap::iterator spot(map.begin()), limit(map.end()); spot != limit; ++spot) {
+  for (auto &spot : map) {
     ip_text_buffer ipb1, ipb2;
 
-    printf("%s - %s : %p\n", ats_ip_ntop(spot->min(), ipb1, sizeof ipb1), ats_ip_ntop(spot->max(), ipb2, sizeof(ipb2)),
-           spot->data());
+    printf("%s - %s : %p\n", ats_ip_ntop(spot.min(), ipb1, sizeof ipb1), ats_ip_ntop(spot.max(), ipb2, sizeof(ipb2)), spot.data());
   }
   printf("\n");
 }

--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -919,8 +919,7 @@ LocalManager::startProxy(const char *onetime_options)
       bool need_comma_p = false;
 
       ink_strlcat(real_proxy_options, " --httpport ", OPTIONS_SIZE);
-      for (int i = 0, limit = m_proxy_ports.size(); i < limit; ++i) {
-        HttpProxyPort &p = m_proxy_ports[i];
+      for (auto &p : m_proxy_ports) {
         if (ts::NO_FD != p.m_fd) {
           if (need_comma_p) {
             ink_strlcat(real_proxy_options, ",", OPTIONS_SIZE);
@@ -957,8 +956,7 @@ LocalManager::startProxy(const char *onetime_options)
 void
 LocalManager::closeProxyPorts()
 {
-  for (int i = 0, n = lmgmt->m_proxy_ports.size(); i < n; ++i) {
-    HttpProxyPort &p = lmgmt->m_proxy_ports[i];
+  for (auto &p : lmgmt->m_proxy_ports) {
     if (ts::NO_FD != p.m_fd) {
       close_socket(p.m_fd);
       p.m_fd = ts::NO_FD;
@@ -977,8 +975,7 @@ LocalManager::listenForProxy()
   }
 
   // We are not already bound, bind the port
-  for (int i = 0, n = lmgmt->m_proxy_ports.size(); i < n; ++i) {
-    HttpProxyPort &p = lmgmt->m_proxy_ports[i];
+  for (auto &p : lmgmt->m_proxy_ports) {
     if (ts::NO_FD == p.m_fd) {
       this->bindProxyPort(p);
     }

--- a/plugins/s3_auth/aws_auth_v4.cc
+++ b/plugins/s3_auth/aws_auth_v4.cc
@@ -82,20 +82,20 @@ uriEncode(const String &in, bool isObjectName)
 {
   std::stringstream result;
 
-  for (std::string::size_type i = 0; i < in.length(); i++) {
-    if (isalnum(in[i]) || in[i] == '-' || in[i] == '_' || in[i] == '.' || in[i] == '~') {
+  for (char i : in) {
+    if (isalnum(i) || i == '-' || i == '_' || i == '.' || i == '~') {
       /* URI encode every byte except the unreserved characters:
        * 'A'-'Z', 'a'-'z', '0'-'9', '-', '.', '_', and '~'. */
-      result << in[i];
-    } else if (in[i] == ' ') {
+      result << i;
+    } else if (i == ' ') {
       /* The space character is a reserved character and must be encoded as "%20" (and not as "+"). */
       result << "%20";
-    } else if (isObjectName && in[i] == '/') {
+    } else if (isObjectName && i == '/') {
       /* Encode the forward slash character, '/', everywhere except in the object key name. */
       result << "/";
     } else {
       /* Letters in the hexadecimal value must be upper-case, for example "%1A". */
-      result << "%" << std::uppercase << std::setfill('0') << std::setw(2) << std::hex << (int)in[i];
+      result << "%" << std::uppercase << std::setfill('0') << std::setw(2) << std::hex << (int)i;
     }
   }
 
@@ -304,12 +304,12 @@ getCanonicalRequestSha256Hash(TsInterface &api, bool signPayload, const StringSe
   }
 
   String queryStr;
-  for (StringSet::iterator it = paramNames.begin(); it != paramNames.end(); it++) {
+  for (const auto &paramName : paramNames) {
     if (!queryStr.empty()) {
       queryStr.append("&");
     }
-    queryStr.append(*it);
-    queryStr.append("=").append(paramsMap[*it]);
+    queryStr.append(paramName);
+    queryStr.append("=").append(paramsMap[paramName]);
   }
   sha256Update(&canonicalRequestSha256Ctx, queryStr);
   sha256Update(&canonicalRequestSha256Ctx, "\n");
@@ -364,19 +364,19 @@ getCanonicalRequestSha256Hash(TsInterface &api, bool signPayload, const StringSe
     headersMap[lowercaseName] = String(trimValue, trimValueLen);
   }
 
-  for (StringSet::iterator it = signedHeadersSet.begin(); it != signedHeadersSet.end(); it++) {
-    sha256Update(&canonicalRequestSha256Ctx, *it);
+  for (const auto &it : signedHeadersSet) {
+    sha256Update(&canonicalRequestSha256Ctx, it);
     sha256Update(&canonicalRequestSha256Ctx, ":");
-    sha256Update(&canonicalRequestSha256Ctx, headersMap[*it]);
+    sha256Update(&canonicalRequestSha256Ctx, headersMap[it]);
     sha256Update(&canonicalRequestSha256Ctx, "\n");
   }
   sha256Update(&canonicalRequestSha256Ctx, "\n");
 
-  for (StringSet::iterator it = signedHeadersSet.begin(); it != signedHeadersSet.end(); ++it) {
+  for (const auto &it : signedHeadersSet) {
     if (!signedHeaders.empty()) {
       signedHeaders.append(";");
     }
-    signedHeaders.append(*it);
+    signedHeaders.append(it);
   }
 
   sha256Update(&canonicalRequestSha256Ctx, signedHeaders);

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -9147,8 +9147,7 @@ TSPluginDescriptorAccept(TSCont contp)
   Action *action = nullptr;
 
   HttpProxyPort::Group &proxy_ports = HttpProxyPort::global();
-  for (int i = 0, n = proxy_ports.size(); i < n; ++i) {
-    HttpProxyPort &port = proxy_ports[i];
+  for (auto &port : proxy_ports) {
     if (port.isPlugin()) {
       NetProcessor::AcceptOptions net(make_net_accept_options(&port, -1 /* nthreads */));
       action = netProcessor.main_accept((INKContInternal *)contp, port.m_fd, net);


### PR DESCRIPTION
Ran clang-tidy 6.0.0 over the code base to get ready for branching for the 8.0.0 release.