### PR TITLE
TextView: Change 'set_view' to 'assign'.

### DIFF
--- a/lib/ts/BufferWriterFormat.cc
+++ b/lib/ts/BufferWriterFormat.cc
@@ -51,7 +51,7 @@ tv_to_positive_decimal(ts::TextView src, ts::TextView *out)
       ++start;
     }
     if (out && (start > src.data())) {
-      out->set_view(src.data(), start);
+      out->assign(src.data(), start);
     }
   }
   return zret;

--- a/lib/ts/TextView.cc
+++ b/lib/ts/TextView.cc
@@ -123,7 +123,7 @@ ts::svtoi(TextView src, TextView *out, int base)
       ++src;
     }
     if (out && (src.data() > (neg ? start + 1 : start))) {
-      out->set_view(start, src.data());
+      out->assign(start, src.data());
     }
 
     if (neg) {

--- a/lib/ts/TextView.h
+++ b/lib/ts/TextView.h
@@ -160,10 +160,10 @@ public:
   template <size_t N> self_type &operator=(const char (&s)[N]);
 
   /// Explicitly set the view.
-  self_type &set_view(char const *ptr, size_t n);
+  self_type &assign(char const *ptr, size_t n);
 
   /// Explicitly set the view to the range [ @a b , @a e )
-  self_type &set_view(char const *b, char const *e);
+  self_type &assign(char const *b, char const *e);
 
   /// @return The first byte in the view.
   char operator*() const;
@@ -589,14 +589,14 @@ TextView::operator=(super_type const &that)
 }
 
 inline TextView &
-TextView::set_view(char const *ptr, size_t n)
+TextView::assign(char const *ptr, size_t n)
 {
   *this = super_type(ptr, n);
   return *this;
 }
 
 inline TextView &
-TextView::set_view(char const *b, char const *e)
+TextView::assign(char const *b, char const *e)
 {
   *this = super_type(b, e - b);
   return *this;

--- a/lib/ts/ink_inet.cc
+++ b/lib/ts/ink_inet.cc
@@ -214,8 +214,8 @@ ats_ip_parse(ts::string_view str, ts::string_view *addr, ts::string_view *port, 
       ts::TextView tmp{src};
       src.ltrim_if(&ParseRules::is_digit);
 
-      if (tmp.data() == src.data()) {                 // no digits at all
-        src.set_view(tmp.data() - 1, tmp.size() + 1); // back up to include colon
+      if (tmp.data() == src.data()) {               // no digits at all
+        src.assign(tmp.data() - 1, tmp.size() + 1); // back up to include colon
       } else {
         *port = ts::string_view(tmp.data(), src.data() - tmp.data());
       }


### PR DESCRIPTION
Why I ever used `set_view` instead of the more STL compliant `assign`, I can't explain. Better to fix it now before it's more widely used.