### PR TITLE
Ran clang-tidy with modernize-use-nullptr

### DIFF
--- a/cmd/traffic_cache_tool/CacheDefs.cc
+++ b/cmd/traffic_cache_tool/CacheDefs.cc
@@ -465,7 +465,7 @@ dir_from_offset(int64_t i, CacheDirEntry *seg)
 {
 #if DIR_DEPTH < 5
   if (!i)
-    return 0;
+    return nullptr;
   return dir_in_seg(seg, i);
 #else
   i = i + ((i - 1) / (DIR_DEPTH - 1));

--- a/example/verify_cert/verify_cert.cc
+++ b/example/verify_cert/verify_cert.cc
@@ -47,12 +47,12 @@ debug_certificate(const char *msg, X509_NAME *name)
 {
   BIO *bio;
 
-  if (name == NULL) {
+  if (name == nullptr) {
     return;
   }
 
   bio = BIO_new(BIO_s_mem());
-  if (bio == NULL) {
+  if (bio == nullptr) {
     return;
   }
 

--- a/iocore/cache/I_Cache.h
+++ b/iocore/cache/I_Cache.h
@@ -65,7 +65,7 @@ struct CacheProcessor : public Processor {
   CacheProcessor()
     : min_stripe_version(CACHE_DB_MAJOR_VERSION, CACHE_DB_MINOR_VERSION),
       max_stripe_version(CACHE_DB_MAJOR_VERSION, CACHE_DB_MINOR_VERSION),
-      cb_after_init(0),
+      cb_after_init(nullptr),
       wait_for_cache(0)
   {
   }
@@ -78,15 +78,15 @@ struct CacheProcessor : public Processor {
   int db_check(bool fix);
 
   inkcoreapi Action *lookup(Continuation *cont, const CacheKey *key, CacheFragType frag_type = CACHE_FRAG_TYPE_NONE,
-                            const char *hostname = 0, int host_len = 0);
+                            const char *hostname = nullptr, int host_len = 0);
   inkcoreapi Action *open_read(Continuation *cont, const CacheKey *key, CacheFragType frag_type = CACHE_FRAG_TYPE_NONE,
-                               const char *hostname = 0, int host_len = 0);
+                               const char *hostname = nullptr, int host_len = 0);
   inkcoreapi Action *open_write(Continuation *cont, CacheKey *key, CacheFragType frag_type = CACHE_FRAG_TYPE_NONE,
                                 int expected_size = CACHE_EXPECTED_SIZE, int options = 0, time_t pin_in_cache = (time_t)0,
-                                char *hostname = 0, int host_len = 0);
+                                char *hostname = nullptr, int host_len = 0);
   inkcoreapi Action *remove(Continuation *cont, const CacheKey *key, CacheFragType frag_type = CACHE_FRAG_TYPE_NONE,
-                            const char *hostname = 0, int host_len = 0);
-  Action *scan(Continuation *cont, char *hostname = 0, int host_len = 0, int KB_per_second = SCAN_KB_PER_SECOND);
+                            const char *hostname = nullptr, int host_len = 0);
+  Action *scan(Continuation *cont, char *hostname = nullptr, int host_len = 0, int KB_per_second = SCAN_KB_PER_SECOND);
   Action *lookup(Continuation *cont, const HttpCacheKey *key, CacheFragType frag_type = CACHE_FRAG_TYPE_HTTP);
   inkcoreapi Action *open_read(Continuation *cont, const HttpCacheKey *key, CacheHTTPHdr *request,
                                OverridableHttpConfigParams *params, time_t pin_in_cache = (time_t)0,
@@ -94,10 +94,10 @@ struct CacheProcessor : public Processor {
   Action *open_write(Continuation *cont, int expected_size, const HttpCacheKey *key, CacheHTTPHdr *request, CacheHTTPInfo *old_info,
                      time_t pin_in_cache = (time_t)0, CacheFragType frag_type = CACHE_FRAG_TYPE_HTTP);
   Action *remove(Continuation *cont, const HttpCacheKey *key, CacheFragType frag_type = CACHE_FRAG_TYPE_HTTP);
-  Action *link(Continuation *cont, CacheKey *from, CacheKey *to, CacheFragType frag_type = CACHE_FRAG_TYPE_HTTP, char *hostname = 0,
-               int host_len = 0);
+  Action *link(Continuation *cont, CacheKey *from, CacheKey *to, CacheFragType frag_type = CACHE_FRAG_TYPE_HTTP,
+               char *hostname = nullptr, int host_len = 0);
 
-  Action *deref(Continuation *cont, CacheKey *key, CacheFragType frag_type = CACHE_FRAG_TYPE_HTTP, char *hostname = 0,
+  Action *deref(Continuation *cont, CacheKey *key, CacheFragType frag_type = CACHE_FRAG_TYPE_HTTP, char *hostname = nullptr,
                 int host_len = 0);
 
   /** Mark physical disk/device/file as offline.

--- a/iocore/cache/I_Store.h
+++ b/iocore/cache/I_Store.h
@@ -171,7 +171,7 @@ public:
   /// at every call site. We also need this because we have ats_scoped_str members.
   Span(Span const &that)
   {
-    memcpy(this, &that, reinterpret_cast<intptr_t>(&(static_cast<Span *>(0)->pathname)));
+    memcpy(this, &that, reinterpret_cast<intptr_t>(&(static_cast<Span *>(nullptr)->pathname)));
     if (that.pathname)
       pathname = ats_strdup(that.pathname);
     if (that.hash_base_string)

--- a/iocore/cache/P_CacheDir.h
+++ b/iocore/cache/P_CacheDir.h
@@ -270,7 +270,14 @@ struct CacheSync : public Continuation {
   void aio_write(int fd, char *b, int n, off_t o);
 
   CacheSync()
-    : Continuation(new_ProxyMutex()), vol_idx(0), buf(0), buflen(0), buf_huge(false), writepos(0), trigger(0), start_time(0)
+    : Continuation(new_ProxyMutex()),
+      vol_idx(0),
+      buf(nullptr),
+      buflen(0),
+      buf_huge(false),
+      writepos(0),
+      trigger(nullptr),
+      start_time(0)
   {
     SET_HANDLER(&CacheSync::mainEvent);
   }
@@ -294,8 +301,8 @@ void dir_sync_init();
 int check_dir(Vol *d);
 void dir_clean_vol(Vol *d);
 void dir_clear_range(off_t start, off_t end, Vol *d);
-int dir_segment_accounted(int s, Vol *d, int offby = 0, int *free = 0, int *used = 0, int *empty = 0, int *valid = 0,
-                          int *agg_valid = 0, int *avg_size = 0);
+int dir_segment_accounted(int s, Vol *d, int offby = 0, int *free = nullptr, int *used = nullptr, int *empty = nullptr,
+                          int *valid = nullptr, int *agg_valid = nullptr, int *avg_size = nullptr);
 uint64_t dir_entries_used(Vol *d);
 void sync_cache_dir_on_shutdown();
 
@@ -318,7 +325,7 @@ dir_from_offset(int64_t i, Dir *seg)
 {
 #if DIR_DEPTH < 5
   if (!i)
-    return 0;
+    return nullptr;
   return dir_in_seg(seg, i);
 #else
   i = i + ((i - 1) / (DIR_DEPTH - 1));

--- a/iocore/cache/P_CacheHosting.h
+++ b/iocore/cache/P_CacheHosting.h
@@ -61,7 +61,7 @@ struct CacheHostRecord {
       good_num_vols(0),
       num_vols(0),
       num_initialized(0),
-      vol_hash_table(0),
+      vol_hash_table(nullptr),
       cp(nullptr),
       num_cachevols(0)
   {

--- a/iocore/cache/P_CacheInternal.h
+++ b/iocore/cache/P_CacheInternal.h
@@ -633,7 +633,7 @@ CacheVC::callcont(int event)
   if (closed)
     die();
   else if (vio.vc_server)
-    handleEvent(EVENT_IMMEDIATE, 0);
+    handleEvent(EVENT_IMMEDIATE, nullptr);
   return EVENT_DONE;
 }
 
@@ -644,14 +644,14 @@ CacheVC::do_read_call(CacheKey *akey)
   read_key            = akey;
   io.aiocb.aio_nbytes = dir_approx_size(&dir);
   PUSH_HANDLER(&CacheVC::handleRead);
-  return handleRead(EVENT_CALL, 0);
+  return handleRead(EVENT_CALL, nullptr);
 }
 
 TS_INLINE int
 CacheVC::do_write_call()
 {
   PUSH_HANDLER(&CacheVC::handleWrite);
-  return handleWrite(EVENT_CALL, 0);
+  return handleWrite(EVENT_CALL, nullptr);
 }
 
 TS_INLINE void
@@ -703,7 +703,7 @@ CacheVC::handleWriteLock(int /* event ATS_UNUSED */, Event *e)
     ret = handleWrite(EVENT_CALL, e);
   }
   if (ret == EVENT_RETURN)
-    return handleEvent(AIO_EVENT_DONE, 0);
+    return handleEvent(AIO_EVENT_DONE, nullptr);
   return EVENT_CONT;
 }
 
@@ -711,14 +711,14 @@ TS_INLINE int
 CacheVC::do_write_lock()
 {
   PUSH_HANDLER(&CacheVC::handleWriteLock);
-  return handleWriteLock(EVENT_NONE, 0);
+  return handleWriteLock(EVENT_NONE, nullptr);
 }
 
 TS_INLINE int
 CacheVC::do_write_lock_call()
 {
   PUSH_HANDLER(&CacheVC::handleWriteLock);
-  return handleWriteLock(EVENT_CALL, 0);
+  return handleWriteLock(EVENT_CALL, nullptr);
 }
 
 TS_INLINE bool
@@ -958,15 +958,15 @@ struct Cache {
   Action *lookup(Continuation *cont, const CacheKey *key, CacheFragType type, const char *hostname, int host_len);
   inkcoreapi Action *open_read(Continuation *cont, const CacheKey *key, CacheFragType type, const char *hostname, int len);
   inkcoreapi Action *open_write(Continuation *cont, const CacheKey *key, CacheFragType frag_type, int options = 0,
-                                time_t pin_in_cache = (time_t)0, const char *hostname = 0, int host_len = 0);
+                                time_t pin_in_cache = (time_t)0, const char *hostname = nullptr, int host_len = 0);
   inkcoreapi Action *remove(Continuation *cont, const CacheKey *key, CacheFragType type = CACHE_FRAG_TYPE_HTTP,
-                            const char *hostname = 0, int host_len = 0);
-  Action *scan(Continuation *cont, const char *hostname = 0, int host_len = 0, int KB_per_second = 2500);
+                            const char *hostname = nullptr, int host_len = 0);
+  Action *scan(Continuation *cont, const char *hostname = nullptr, int host_len = 0, int KB_per_second = 2500);
 
   Action *open_read(Continuation *cont, const CacheKey *key, CacheHTTPHdr *request, OverridableHttpConfigParams *params,
                     CacheFragType type, const char *hostname, int host_len);
   Action *open_write(Continuation *cont, const CacheKey *key, CacheHTTPInfo *old_info, time_t pin_in_cache = (time_t)0,
-                     const CacheKey *key1 = nullptr, CacheFragType type = CACHE_FRAG_TYPE_HTTP, const char *hostname = 0,
+                     const CacheKey *key1 = nullptr, CacheFragType type = CACHE_FRAG_TYPE_HTTP, const char *hostname = nullptr,
                      int host_len = 0);
   static void generate_key(CryptoHash *hash, CacheURL *url);
   static void generate_key(HttpCacheKey *hash, CacheURL *url, cache_generation_t generation = -1);

--- a/iocore/cache/P_CacheTest.h
+++ b/iocore/cache/P_CacheTest.h
@@ -107,7 +107,7 @@ struct CacheTestSM : public RegressionSM {
   {
     if (timeout)
       timeout->cancel();
-    timeout = 0;
+    timeout = nullptr;
   }
 
   // RegressionSM API

--- a/iocore/cache/P_CacheVol.h
+++ b/iocore/cache/P_CacheVol.h
@@ -276,7 +276,7 @@ struct CacheVol {
   // per volume stats
   RecRawStatBlock *vol_rsb;
 
-  CacheVol() : vol_number(-1), scheme(0), size(0), num_vols(0), vols(nullptr), disk_vols(0), vol_rsb(0) {}
+  CacheVol() : vol_number(-1), scheme(0), size(0), num_vols(0), vols(nullptr), disk_vols(nullptr), vol_rsb(nullptr) {}
 };
 
 // Note : hdr() needs to be 8 byte aligned.
@@ -446,7 +446,7 @@ evacuation_block_exists(Dir *dir, Vol *p)
   for (; b; b = b->link.next)
     if (dir_offset(&b->dir) == dir_offset(dir))
       return b;
-  return 0;
+  return nullptr;
 }
 
 TS_INLINE void
@@ -464,8 +464,8 @@ new_EvacuationBlock(EThread *t)
   EvacuationBlock *b      = THREAD_ALLOC(evacuationBlockAllocator, t);
   b->init                 = 0;
   b->readers              = 0;
-  b->earliest_evacuator   = 0;
-  b->evac_frags.link.next = 0;
+  b->earliest_evacuator   = nullptr;
+  b->evac_frags.link.next = nullptr;
   return b;
 }
 

--- a/iocore/dns/I_DNSProcessor.h
+++ b/iocore/dns/I_DNSProcessor.h
@@ -115,7 +115,7 @@ struct DNSProcessor : public Processor {
 
   // Open/close a link to a 'named' (done in start())
   //
-  void open(sockaddr const *ns = 0);
+  void open(sockaddr const *ns = nullptr);
 
   DNSProcessor();
 
@@ -172,7 +172,7 @@ DNSProcessor::gethostbyaddr(Continuation *cont, IpAddr const *addr, Options cons
   return getby(reinterpret_cast<const char *>(addr), 0, T_PTR, cont, opt);
 }
 
-inline DNSProcessor::Options::Options() : handler(0), timeout(0), host_res_style(HOST_RES_IPV4)
+inline DNSProcessor::Options::Options() : handler(nullptr), timeout(0), host_res_style(HOST_RES_IPV4)
 {
 }
 

--- a/iocore/dns/P_DNSConnection.h
+++ b/iocore/dns/P_DNSConnection.h
@@ -111,7 +111,12 @@ struct DNSConnection {
 };
 
 inline DNSConnection::Options::Options()
-  : _non_blocking_connect(true), _non_blocking_io(true), _use_tcp(false), _bind_random_port(true), _local_ipv6(0), _local_ipv4(0)
+  : _non_blocking_connect(true),
+    _non_blocking_io(true),
+    _use_tcp(false),
+    _bind_random_port(true),
+    _local_ipv6(nullptr),
+    _local_ipv4(nullptr)
 {
 }
 

--- a/iocore/dns/P_DNSProcessor.h
+++ b/iocore/dns/P_DNSProcessor.h
@@ -316,10 +316,10 @@ DNSHandler::DNSHandler()
     in_flight(0),
     name_server(0),
     in_write_dns(0),
-    hostent_cache(0),
+    hostent_cache(nullptr),
     last_primary_retry(0),
     last_primary_reopen(0),
-    m_res(0),
+    m_res(nullptr),
     txn_lookup_timeout(0),
     generator((uint32_t)((uintptr_t)time(nullptr) ^ (uintptr_t)this))
 {

--- a/iocore/dns/P_SplitDNSProcessor.h
+++ b/iocore/dns/P_SplitDNSProcessor.h
@@ -144,7 +144,7 @@ public:
    DNSRequestData::get_string()
    -------------------------------------------------------------- */
 TS_INLINE
-DNSRequestData::DNSRequestData() : m_pHost(0)
+DNSRequestData::DNSRequestData() : m_pHost(nullptr)
 {
 }
 

--- a/iocore/eventsystem/I_Action.h
+++ b/iocore/eventsystem/I_Action.h
@@ -176,7 +176,7 @@ public:
     if (acont)
       mutex = acont->mutex;
     else
-      mutex = 0;
+      mutex = nullptr;
     return acont;
   }
 

--- a/iocore/eventsystem/I_EventProcessor.h
+++ b/iocore/eventsystem/I_EventProcessor.h
@@ -238,7 +238,7 @@ public:
   /// Schedule an @a event on continuation @a c when a thread of type @a ev_type is spawned.
   /// The @a cookie is attached to the event instance passed to the continuation.
   /// @return The scheduled event.
-  Event *schedule_spawn(Continuation *c, EventType ev_type, int event = EVENT_IMMEDIATE, void *cookie = NULL);
+  Event *schedule_spawn(Continuation *c, EventType ev_type, int event = EVENT_IMMEDIATE, void *cookie = nullptr);
 
   /// Schedule the function @a f to be called in a thread of type @a ev_type when it is spawned.
   Event *schedule_spawn(void (*f)(EThread *), EventType ev_type);

--- a/iocore/eventsystem/I_IOBuffer.h
+++ b/iocore/eventsystem/I_IOBuffer.h
@@ -935,7 +935,7 @@ public:
   buf()
   {
     IOBufferBlock *b = first_write_block();
-    return b ? b->buf() : 0;
+    return b ? b->buf() : nullptr;
   }
 
   char *

--- a/iocore/eventsystem/I_Lock.h
+++ b/iocore/eventsystem/I_Lock.h
@@ -282,7 +282,7 @@ Mutex_trylock(
 #endif
   ProxyMutex *m, EThread *t)
 {
-  ink_assert(t != 0);
+  ink_assert(t != nullptr);
   ink_assert(t == (EThread *)this_thread());
   if (m->thread_holding != t) {
     if (!ink_mutex_try_acquire(&m->the_mutex)) {
@@ -340,7 +340,7 @@ Mutex_trylock_spin(
 #endif
   ProxyMutex *m, EThread *t, int spincnt = 1)
 {
-  ink_assert(t != 0);
+  ink_assert(t != nullptr);
   if (m->thread_holding != t) {
     int locked;
     do {
@@ -403,7 +403,7 @@ Mutex_lock(
 #endif
   ProxyMutex *m, EThread *t)
 {
-  ink_assert(t != 0);
+  ink_assert(t != nullptr);
   if (m->thread_holding != t) {
     ink_mutex_acquire(&m->the_mutex);
     m->thread_holding = t;
@@ -460,7 +460,7 @@ Mutex_unlock(ProxyMutex *m, EThread *t)
       m->handler = nullptr;
 #endif // DEBUG
       ink_assert(m->thread_holding);
-      m->thread_holding = 0;
+      m->thread_holding = nullptr;
       ink_mutex_release(&m->the_mutex);
     }
   }

--- a/iocore/eventsystem/I_ProxyAllocator.h
+++ b/iocore/eventsystem/I_ProxyAllocator.h
@@ -41,7 +41,7 @@ struct ProxyAllocator {
   int allocated;
   void *freelist;
 
-  ProxyAllocator() : allocated(0), freelist(0) {}
+  ProxyAllocator() : allocated(0), freelist(nullptr) {}
 };
 
 template <class C>

--- a/iocore/eventsystem/I_VConnection.h
+++ b/iocore/eventsystem/I_VConnection.h
@@ -200,7 +200,7 @@ public:
     @return VIO representing the scheduled IO operation.
 
   */
-  virtual VIO *do_io_read(Continuation *c = nullptr, int64_t nbytes = INT64_MAX, MIOBuffer *buf = 0) = 0;
+  virtual VIO *do_io_read(Continuation *c = nullptr, int64_t nbytes = INT64_MAX, MIOBuffer *buf = nullptr) = 0;
 
   /**
     Write data to the VConnection.
@@ -250,7 +250,8 @@ public:
     @return VIO representing the scheduled IO operation.
 
   */
-  virtual VIO *do_io_write(Continuation *c = nullptr, int64_t nbytes = INT64_MAX, IOBufferReader *buf = 0, bool owner = false) = 0;
+  virtual VIO *do_io_write(Continuation *c = nullptr, int64_t nbytes = INT64_MAX, IOBufferReader *buf = nullptr,
+                           bool owner = false) = 0;
 
   /**
     Indicate that the VConnection is no longer needed.

--- a/iocore/eventsystem/P_IOBuffer.h
+++ b/iocore/eventsystem/P_IOBuffer.h
@@ -319,7 +319,7 @@ IOBufferData::dealloc()
       ats_free(_data);
     break;
   }
-  _data       = 0;
+  _data       = nullptr;
   _size_index = BUFFER_SIZE_NOT_ALLOCATED;
   _mem_type   = NO_ALLOC;
 }
@@ -368,12 +368,12 @@ new_IOBufferBlock_internal(
 
 TS_INLINE
 IOBufferBlock::IOBufferBlock()
-  : _start(0),
-    _end(0),
-    _buf_end(0)
+  : _start(nullptr),
+    _end(nullptr),
+    _buf_end(nullptr)
 #ifdef TRACK_BUFFER_USER
     ,
-    _location(0)
+    _location(nullptr)
 #endif
 {
   return;
@@ -578,7 +578,7 @@ TS_INLINE char *
 IOBufferReader::start()
 {
   if (!block) {
-    return 0;
+    return nullptr;
   }
 
   skip_empty_blocks();
@@ -589,7 +589,7 @@ TS_INLINE char *
 IOBufferReader::end()
 {
   if (!block) {
-    return 0;
+    return nullptr;
   }
 
   skip_empty_blocks();

--- a/iocore/eventsystem/P_VConnection.h
+++ b/iocore/eventsystem/P_VConnection.h
@@ -56,13 +56,13 @@ get_vc_event_name(int event)
 TS_INLINE
 VConnection::VConnection(ProxyMutex *aMutex) : Continuation(aMutex), lerrno(0)
 {
-  SET_HANDLER(0);
+  SET_HANDLER(nullptr);
 }
 
 TS_INLINE
 VConnection::VConnection(Ptr<ProxyMutex> &aMutex) : Continuation(aMutex), lerrno(0)
 {
-  SET_HANDLER(0);
+  SET_HANDLER(nullptr);
 }
 
 TS_INLINE

--- a/iocore/eventsystem/P_VIO.h
+++ b/iocore/eventsystem/P_VIO.h
@@ -25,7 +25,7 @@
 #include "I_VIO.h"
 
 TS_INLINE
-VIO::VIO(int aop) : _cont(nullptr), nbytes(0), ndone(0), op(aop), buffer(), vc_server(0), mutex(0)
+VIO::VIO(int aop) : _cont(nullptr), nbytes(0), ndone(0), op(aop), buffer(), vc_server(nullptr), mutex(nullptr)
 {
 }
 
@@ -35,7 +35,7 @@ VIO::VIO(int aop) : _cont(nullptr), nbytes(0), ndone(0), op(aop), buffer(), vc_s
 //
 /////////////////////////////////////////////////////////////
 TS_INLINE
-VIO::VIO() : _cont(0), nbytes(0), ndone(0), op(VIO::NONE), buffer(), vc_server(0), mutex(0)
+VIO::VIO() : _cont(nullptr), nbytes(0), ndone(0), op(VIO::NONE), buffer(), vc_server(nullptr), mutex(nullptr)
 {
 }
 

--- a/iocore/eventsystem/UnixEventProcessor.cc
+++ b/iocore/eventsystem/UnixEventProcessor.cc
@@ -192,7 +192,7 @@ ThreadAffinityInitializer::set_affinity(int, Event *)
     // Get our `obj` instance with index based on the thread number we are on.
     hwloc_obj_t obj = hwloc_get_obj_by_type(ink_get_topology(), obj_type, t->id % obj_count);
 #if HWLOC_API_VERSION >= 0x00010100
-    int cpu_mask_len = hwloc_bitmap_snprintf(NULL, 0, obj->cpuset) + 1;
+    int cpu_mask_len = hwloc_bitmap_snprintf(nullptr, 0, obj->cpuset) + 1;
     char *cpu_mask   = (char *)alloca(cpu_mask_len);
     hwloc_bitmap_snprintf(cpu_mask, cpu_mask_len, obj->cpuset);
     Debug("iocore_thread", "EThread: %p %s: %d CPU Mask: %s\n", t, obj_name, obj->logical_index, cpu_mask);

--- a/iocore/hostdb/I_HostDBProcessor.h
+++ b/iocore/hostdb/I_HostDBProcessor.h
@@ -474,7 +474,7 @@ struct HostDBProcessor : public Processor {
   void
   setbyaddr_appinfo(sockaddr const *addr, HostDBApplicationInfo *app)
   {
-    this->setby(0, 0, addr, app);
+    this->setby(nullptr, 0, addr, app);
   }
 
   void
@@ -482,7 +482,7 @@ struct HostDBProcessor : public Processor {
   {
     sockaddr_in addr;
     ats_ip4_set(&addr, ip);
-    this->setby(0, 0, ats_ip_sa_cast(&addr), app);
+    this->setby(nullptr, 0, ats_ip_sa_cast(&addr), app);
   }
 
   /** Configuration. */

--- a/iocore/hostdb/P_HostDBProcessor.h
+++ b/iocore/hostdb/P_HostDBProcessor.h
@@ -233,7 +233,7 @@ HostDBRoundRobin::find_ip(sockaddr const *ip)
 inline HostDBInfo *
 HostDBRoundRobin::select_next(sockaddr const *ip)
 {
-  HostDBInfo *zret = 0;
+  HostDBInfo *zret = nullptr;
   if (good > 1) {
     int idx = this->index_of(ip);
     if (idx >= 0) {
@@ -495,7 +495,7 @@ struct HostDBContinuation : public Continuation {
     bool force_dns;              ///< Force DNS lookup. Default @c false
     Continuation *cont;          ///< Continuation / action. Default @c nullptr (none)
 
-    Options() : timeout(0), host_res_style(HOST_RES_NONE), force_dns(false), cont(0) {}
+    Options() : timeout(0), host_res_style(HOST_RES_NONE), force_dns(false), cont(nullptr) {}
   };
   static const Options DEFAULT_OPTIONS; ///< Default defaults.
   void init(HostDBHash const &hash, Options const &opt = DEFAULT_OPTIONS);

--- a/iocore/hostdb/P_RefCountCacheSerializer.h
+++ b/iocore/hostdb/P_RefCountCacheSerializer.h
@@ -117,7 +117,7 @@ template <class C> RefCountCacheSerializer<C>::~RefCountCacheSerializer()
 
   // Note that we have to do the unlink before we send the completion event, otherwise
   // we could unlink the sync file out from under another serializer.
-  cont->handleEvent(REFCOUNT_CACHE_EVENT_SYNC, 0);
+  cont->handleEvent(REFCOUNT_CACHE_EVENT_SYNC, nullptr);
 }
 
 template <class C>

--- a/iocore/net/I_Socks.h
+++ b/iocore/net/I_Socks.h
@@ -64,6 +64,6 @@ struct SocksAddrType {
   } addr;
 
   void reset();
-  SocksAddrType() : type(SOCKS_ATYPE_NONE) { addr.buf = 0; }
+  SocksAddrType() : type(SOCKS_ATYPE_NONE) { addr.buf = nullptr; }
   ~SocksAddrType() { reset(); }
 };

--- a/iocore/net/P_SSLCertLookup.h
+++ b/iocore/net/P_SSLCertLookup.h
@@ -60,7 +60,7 @@ struct SSLCertContext {
     OPT_TUNNEL ///< Just tunnel, don't terminate.
   };
 
-  SSLCertContext() : ctx(0), opt(OPT_NONE), keyblock(nullptr) {}
+  SSLCertContext() : ctx(nullptr), opt(OPT_NONE), keyblock(nullptr) {}
   explicit SSLCertContext(SSL_CTX *c) : ctx(c), opt(OPT_NONE), keyblock(nullptr) {}
   SSLCertContext(SSL_CTX *c, Option o) : ctx(c), opt(o), keyblock(nullptr) {}
   SSLCertContext(SSL_CTX *c, Option o, ssl_ticket_key_block *kb) : ctx(c), opt(o), keyblock(kb) {}

--- a/iocore/net/P_Socks.h
+++ b/iocore/net/P_Socks.h
@@ -160,6 +160,6 @@ SocksAddrType::reset()
     ats_free(addr.buf);
   }
 
-  addr.buf = 0;
+  addr.buf = nullptr;
   type     = SOCKS_ATYPE_NONE;
 }

--- a/iocore/net/P_UDPIOEvent.h
+++ b/iocore/net/P_UDPIOEvent.h
@@ -28,7 +28,7 @@
 class UDPIOEvent : public Event
 {
 public:
-  UDPIOEvent() : fd(-1), err(0), m(0), handle(0), b(0), bytesTransferred(0){};
+  UDPIOEvent() : fd(-1), err(0), m(nullptr), handle(nullptr), b(nullptr), bytesTransferred(0){};
   ~UDPIOEvent(){};
 
   void

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -90,7 +90,7 @@ struct OOB_callback : public Continuation {
   int retry_OOB_send(int, Event *);
 
   OOB_callback(Ptr<ProxyMutex> &m, NetVConnection *vc, Continuation *cont, char *buf, int len)
-    : Continuation(m), data(buf), length(len), trigger(0)
+    : Continuation(m), data(buf), length(len), trigger(nullptr)
   {
     server_vc   = (UnixNetVConnection *)vc;
     server_cont = cont;

--- a/iocore/net/P_UnixUDPConnection.h
+++ b/iocore/net/P_UnixUDPConnection.h
@@ -105,5 +105,5 @@ UDPConnection::recv(Continuation *c)
 TS_INLINE UDPConnection *
 new_UDPConnection(int fd)
 {
-  return (fd >= 0) ? new UnixUDPConnection(fd) : 0;
+  return (fd >= 0) ? new UnixUDPConnection(fd) : nullptr;
 }

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -953,7 +953,7 @@ SSLNetVConnection::sslStartHandShake(int event, int &err)
           this->attributes     = HttpProxyPort::TRANSPORT_BLIND_TUNNEL;
           sslHandShakeComplete = 1;
           SSL_free(this->ssl);
-          this->ssl = NULL;
+          this->ssl = nullptr;
           return EVENT_DONE;
         } else {
           SSLConfig::scoped_config params;

--- a/iocore/utils/I_Machine.h
+++ b/iocore/utils/I_Machine.h
@@ -75,8 +75,8 @@ struct Machine {
       @note This must be called before called @c instance so that the
       singleton is not @em inadvertently default initialized.
   */
-  static self *init(char const *name     = 0, ///< Host name of the machine.
-                    sockaddr const *addr = 0  ///< Primary IP address of the machine.
+  static self *init(char const *name     = nullptr, ///< Host name of the machine.
+                    sockaddr const *addr = nullptr  ///< Primary IP address of the machine.
                     );
   /// @return The global instance of this class.
   static self *instance();

--- a/lib/ts/ConsistentHash.h
+++ b/lib/ts/ConsistentHash.h
@@ -48,10 +48,11 @@ typedef std::map<uint64_t, ATSConsistentHashNode *>::iterator ATSConsistentHashI
 struct ATSConsistentHash {
   ATSConsistentHash(int r = 1024, ATSHash64 *h = nullptr);
   void insert(ATSConsistentHashNode *node, float weight = 1.0, ATSHash64 *h = nullptr);
-  ATSConsistentHashNode *lookup(const char *url = nullptr, ATSConsistentHashIter *i = NULL, bool *w = NULL, ATSHash64 *h = NULL);
-  ATSConsistentHashNode *lookup_available(const char *url = nullptr, ATSConsistentHashIter *i = NULL, bool *w = NULL,
+  ATSConsistentHashNode *lookup(const char *url = nullptr, ATSConsistentHashIter *i = nullptr, bool *w = nullptr,
+                                ATSHash64 *h = nullptr);
+  ATSConsistentHashNode *lookup_available(const char *url = nullptr, ATSConsistentHashIter *i = nullptr, bool *w = nullptr,
                                           ATSHash64 *h = nullptr);
-  ATSConsistentHashNode *lookup_by_hashval(uint64_t hashval, ATSConsistentHashIter *i = nullptr, bool *w = NULL);
+  ATSConsistentHashNode *lookup_by_hashval(uint64_t hashval, ATSConsistentHashIter *i = nullptr, bool *w = nullptr);
   ~ATSConsistentHash();
 
 private:

--- a/lib/ts/HostLookup.h
+++ b/lib/ts/HostLookup.h
@@ -85,7 +85,9 @@ typedef void (*HostLookupPrintFunc)(void *opaque_data);
 //
 
 struct HostLookupState {
-  HostLookupState() : cur(nullptr), table_level(0), array_index(0), hostname(NULL), host_copy(NULL), host_copy_next(NULL) {}
+  HostLookupState() : cur(nullptr), table_level(0), array_index(0), hostname(nullptr), host_copy(nullptr), host_copy_next(nullptr)
+  {
+  }
   ~HostLookupState() { ats_free(host_copy); }
   HostBranch *cur;
   int table_level;

--- a/lib/ts/IntrusiveDList.h
+++ b/lib/ts/IntrusiveDList.h
@@ -192,7 +192,7 @@ public:
   };
 
   /// Default constructor (empty list).
-  IntrusiveDList() : _head(0), _tail(0), _count(0) {}
+  IntrusiveDList() : _head(nullptr), _tail(nullptr), _count(0) {}
   /// Empty check.
   /// @return @c true if the list is empty.
   bool
@@ -207,7 +207,7 @@ public:
           )
   {
     elt->*N = _head;
-    elt->*P = 0;
+    elt->*P = nullptr;
     if (_head)
       _head->*P = elt;
     _head       = elt;
@@ -222,7 +222,7 @@ public:
   append(T *elt ///< Element to add.
          )
   {
-    elt->*N = 0;
+    elt->*N = nullptr;
     elt->*P = _tail;
     if (_tail)
       _tail->*N = elt;
@@ -324,7 +324,7 @@ public:
       _head = elt->*N;
     if (elt == _tail)
       _tail = elt->*P;
-    elt->*P = elt->*N = 0;
+    elt->*P = elt->*N = nullptr;
     --_count;
     return *this;
   }
@@ -334,7 +334,7 @@ public:
   self &
   clear()
   {
-    _head = _tail = 0;
+    _head = _tail = nullptr;
     _count        = 0;
     return *this;
   }

--- a/lib/ts/IpMap.h
+++ b/lib/ts/IpMap.h
@@ -109,7 +109,7 @@ public:
   public:
     typedef Node self; ///< Self reference type.
     /// Default constructor.
-    Node() : _data(0) {}
+    Node() : _data(nullptr) {}
     /// Construct with @a data.
     Node(void *data) : _data(data) {}
     /// @return Client data for the node.
@@ -153,7 +153,7 @@ public:
     typedef Node &reference;     ///< Reference to referent.
     typedef std::bidirectional_iterator_tag iterator_category;
     /// Default constructor.
-    iterator() : _tree(0), _node(0) {}
+    iterator() : _tree(nullptr), _node(nullptr) {}
     reference operator*() const; //!< value operator
     pointer operator->() const;  //!< dereference operator
     self &operator++();          //!< next node (prefix)
@@ -412,7 +412,7 @@ IpMap::contains(IpAddr const &addr, void **ptr) const
 inline IpMap::iterator
 IpMap::end() const
 {
-  return iterator(this, 0);
+  return iterator(this, nullptr);
 }
 
 inline IpMap::iterator IpMap::iterator::operator++(int)
@@ -445,6 +445,6 @@ inline IpMap::iterator::pointer IpMap::iterator::operator->() const
   return _node;
 }
 
-inline IpMap::IpMap() : _m4(0), _m6(0)
+inline IpMap::IpMap() : _m4(nullptr), _m6(nullptr)
 {
 }

--- a/lib/ts/List.h
+++ b/lib/ts/List.h
@@ -739,5 +739,5 @@ template <class C, class L = typename C::Link_link> struct AtomicSLL {
 
 template <class C, class L> inline AtomicSLL<C, L>::AtomicSLL()
 {
-  ink_atomiclist_init(&al, "AtomicSLL", (uint32_t)(uintptr_t)&L::next_link((C *)0));
+  ink_atomiclist_init(&al, "AtomicSLL", (uint32_t)(uintptr_t)&L::next_link((C *)nullptr));
 }

--- a/lib/ts/MT_hashtable.h
+++ b/lib/ts/MT_hashtable.h
@@ -77,7 +77,7 @@ public:
 template <class key_t, class data_t> class IMTHashTable
 {
 public:
-  IMTHashTable(int size, bool (*gc_func)(data_t) = NULL, void (*pre_gc_func)(void) = NULL)
+  IMTHashTable(int size, bool (*gc_func)(data_t) = NULL, void (*pre_gc_func)(void) = nullptr)
   {
     m_gc_func     = gc_func;
     m_pre_gc_func = pre_gc_func;
@@ -328,7 +328,7 @@ IMTHashTable<key_t, data_t>::remove_entry(HashTableIteratorState<key_t, data_t> 
 template <class key_t, class data_t> class MTHashTable
 {
 public:
-  MTHashTable(int size, bool (*gc_func)(data_t) = NULL, void (*pre_gc_func)(void) = NULL)
+  MTHashTable(int size, bool (*gc_func)(data_t) = NULL, void (*pre_gc_func)(void) = nullptr)
   {
     for (int i = 0; i < MT_HASHTABLE_PARTITIONS; i++) {
       locks[i]      = new_ProxyMutex();

--- a/lib/ts/Map.h
+++ b/lib/ts/Map.h
@@ -242,7 +242,7 @@ const uintptr_t open_hash_primes[256] = {
 
 /* IMPLEMENTATION */
 
-template <class C, class A, int S> inline Vec<C, A, S>::Vec() : n(0), i(0), v(0)
+template <class C, class A, int S> inline Vec<C, A, S>::Vec() : n(0), i(0), v(nullptr)
 {
   memset(&e[0], 0, sizeof(e));
 }
@@ -332,7 +332,7 @@ Vec<C, A, S>::set_add(C a)
   if (n < SET_LINEAR_SIZE) {
     for (C *c = v; c < v + n; c++)
       if (*c == a)
-        return 0;
+        return nullptr;
     add(a);
     return &v[n - 1];
   }
@@ -375,7 +375,7 @@ Vec<C, A, S>::in(C a)
   for (C *c = v; c < v + n; c++)
     if (*c == a)
       return c;
-  return NULL;
+  return nullptr;
 }
 
 template <class C, class A, int S>
@@ -438,7 +438,7 @@ inline void
 Vec<C, A, S>::move(Vec<C, A, S> &vv)
 {
   move_internal(vv);
-  vv.v = 0;
+  vv.v = nullptr;
   vv.clear();
 }
 
@@ -455,7 +455,7 @@ Vec<C, A, S>::copy(const Vec<C, A, S> &vv)
     if (vv.v)
       copy_internal(vv);
     else
-      v = 0;
+      v = nullptr;
   }
 }
 
@@ -529,7 +529,7 @@ Vec<C, A, S>::set_add_internal(C c)
         v[k] = c;
         return &v[k];
       } else if (v[k] == c) {
-        return 0;
+        return nullptr;
       }
       k = (k + open_hash_primes[j]) % n;
     }
@@ -553,13 +553,13 @@ Vec<C, A, S>::set_in_internal(C c)
     h           = h % n;
     for (k = h, j = 0; j < i + 3; j++) {
       if (!v[k])
-        return 0;
+        return nullptr;
       else if (v[k] == c)
         return &v[k];
       k = (k + open_hash_primes[j]) % n;
     }
   }
-  return 0;
+  return nullptr;
 }
 
 template <class C, class A, int S>
@@ -846,7 +846,7 @@ template <class C, class A, int S>
 inline void
 Vec<C, A, S>::reset()
 {
-  v = NULL;
+  v = nullptr;
   n = 0;
   i = 0;
 }
@@ -1125,7 +1125,7 @@ typedef const char cchar;
 
 template <class A>
 static inline char *
-_dupstr(cchar *s, cchar *e = 0)
+_dupstr(cchar *s, cchar *e = nullptr)
 {
   int l    = e ? e - s : strlen(s);
   char *ss = (char *)A::alloc(l + 1);
@@ -1573,24 +1573,24 @@ inline MapElem<K, C> *
 HashMap<K, AHashFns, C, A>::get_internal(K akey) const
 {
   if (!n)
-    return 0;
+    return nullptr;
   if (n <= MAP_INTEGRAL_SIZE) {
     for (MapElem<K, C> *c = v; c < v + n; c++)
       if (c->key)
         if (AHashFns::equal(akey, c->key))
           return c;
-    return 0;
+    return nullptr;
   }
   uintptr_t h = AHashFns::hash(akey);
   h           = h % n;
   for (size_t k = h, j = 0; j < i + 3; j++) {
     if (!v[k].key)
-      return 0;
+      return nullptr;
     else if (AHashFns::equal(akey, v[k].key))
       return &v[k];
     k = (k + open_hash_primes[j]) % n;
   }
-  return 0;
+  return nullptr;
 }
 
 template <class K, class AHashFns, class C, class A>
@@ -1813,7 +1813,7 @@ public:
     size_t m_distance; ///< How many values in the chain we've gone past to get here.
 
     /// Default constructor - empty location.
-    Location() : m_value(nullptr), m_bucket(NULL), m_id(0), m_distance(0) {}
+    Location() : m_value(nullptr), m_bucket(nullptr), m_id(0), m_distance(0) {}
     /// Check for location being valid (referencing a value).
     bool
     isValid() const
@@ -2028,7 +2028,7 @@ template <typename H>
 typename TSHashTable<H>::iterator
 TSHashTable<H>::end()
 {
-  return iterator(0, 0);
+  return iterator(nullptr, nullptr);
 }
 
 template <typename H> typename TSHashTable<H>::iterator &TSHashTable<H>::iterator::operator++()
@@ -2094,7 +2094,7 @@ TSHashTable<H>::find(Key key)
   this->findBucket(key, zret); // zret gets updated to match the bucket.
   v = zret.m_bucket->m_chain.head;
   // Search for first matching key.
-  while (0 != v && !Hasher::equal(key, Hasher::key(v)))
+  while (nullptr != v && !Hasher::equal(key, Hasher::key(v)))
     v          = ListHead::next(v);
   zret.m_value = v;
   return zret;

--- a/lib/ts/MatcherUtils.h
+++ b/lib/ts/MatcherUtils.h
@@ -102,8 +102,8 @@ struct matcher_tags {
   bool
   empty() const
   {
-    return this->match_host == nullptr && this->match_domain == NULL && this->match_ip == NULL && this->match_regex == NULL &&
-           this->match_url == nullptr && this->match_host_regex == NULL;
+    return this->match_host == nullptr && this->match_domain == nullptr && this->match_ip == nullptr &&
+           this->match_regex == nullptr && this->match_url == nullptr && this->match_host_regex == nullptr;
   }
 };
 

--- a/lib/ts/MemSpan.h
+++ b/lib/ts/MemSpan.h
@@ -342,7 +342,7 @@ MemSpan::assign(void *ptr, void const *limit)
 inline MemSpan &
 MemSpan::clear()
 {
-  _data = 0;
+  _data = nullptr;
   _size = 0;
   return *this;
 }

--- a/lib/ts/ParseRules.h
+++ b/lib/ts/ParseRules.h
@@ -780,7 +780,7 @@ ParseRules::strstr_eow(const char *s1, const char *s2)
       if (strncasecmp_eow(&s1[i1], &s2[0], s2_len))
         return (&s1[i1]);
 
-  return (0);
+  return (nullptr);
 }
 
 inline const char *
@@ -795,7 +795,7 @@ ParseRules::strcasestr(const char *s1, const char *s2)
       if (strncasecmp_eow(&s1[i1], &s2[0], (int)s2_len))
         return (&s1[i1]);
 
-  return (0);
+  return (nullptr);
 }
 
 inline const char *
@@ -804,7 +804,7 @@ ParseRules::memchr(const char *s, char c, int max_length)
   for (int i = 0; i < max_length; i++)
     if (s[i] == c)
       return (&s[i]);
-  return (0);
+  return (nullptr);
 }
 
 inline const char *
@@ -813,7 +813,7 @@ ParseRules::strchr(const char *s, char c)
   for (int i = 0; s[i] != '\0'; i++)
     if (s[i] == c)
       return (&s[i]);
-  return (0);
+  return (nullptr);
 }
 
 static inline int

--- a/lib/ts/PriorityQueue.h
+++ b/lib/ts/PriorityQueue.h
@@ -76,7 +76,7 @@ template <typename T, typename Comp>
 bool
 PriorityQueue<T, Comp>::in(PriorityQueueEntry<T> *entry)
 {
-  ink_release_assert(entry != NULL);
+  ink_release_assert(entry != nullptr);
 
   if (std::find(_v.begin(), _v.end(), entry) != _v.end()) {
     return true;
@@ -96,7 +96,7 @@ template <typename T, typename Comp>
 void
 PriorityQueue<T, Comp>::push(PriorityQueueEntry<T> *entry)
 {
-  ink_release_assert(entry != NULL);
+  ink_release_assert(entry != nullptr);
 
   int len = _v.size();
   _v.push_back(entry);
@@ -110,7 +110,7 @@ PriorityQueueEntry<T> *
 PriorityQueue<T, Comp>::top()
 {
   if (empty()) {
-    return NULL;
+    return nullptr;
   } else {
     return _v[0];
   }
@@ -164,7 +164,7 @@ template <typename T, typename Comp>
 void
 PriorityQueue<T, Comp>::update(PriorityQueueEntry<T> *entry)
 {
-  ink_release_assert(entry != NULL);
+  ink_release_assert(entry != nullptr);
 
   if (empty()) {
     return;
@@ -179,7 +179,7 @@ template <typename T, typename Comp>
 void
 PriorityQueue<T, Comp>::update(PriorityQueueEntry<T> *entry, bool increased)
 {
-  ink_release_assert(entry != NULL);
+  ink_release_assert(entry != nullptr);
 
   if (empty()) {
     return;

--- a/lib/ts/Ptr.h
+++ b/lib/ts/Ptr.h
@@ -97,7 +97,7 @@ private:
 template <class T> class Ptr
 {
 public:
-  explicit Ptr(T *p = 0);
+  explicit Ptr(T *p = nullptr);
   Ptr(const Ptr<T> &);
   ~Ptr();
 
@@ -156,7 +156,7 @@ public:
   detach()
   {
     T *tmp = m_ptr;
-    m_ptr  = NULL;
+    m_ptr  = nullptr;
     return tmp;
   }
 
@@ -238,7 +238,7 @@ Ptr<T>::clear()
   if (m_ptr) {
     if (!m_ptr->refcount_dec())
       m_ptr->free();
-    m_ptr = NULL;
+    m_ptr = nullptr;
   }
 }
 

--- a/lib/ts/RawHashTable.h
+++ b/lib/ts/RawHashTable.h
@@ -81,7 +81,7 @@ public:
   //
 
   RawHashTable_Binding *getCurrentBinding(RawHashTable_Key key);
-  RawHashTable_Binding *getOrCreateBinding(RawHashTable_Key key, bool *was_new = NULL);
+  RawHashTable_Binding *getOrCreateBinding(RawHashTable_Key key, bool *was_new = nullptr);
 
   void setBindingValue(RawHashTable_Binding *binding, RawHashTable_Value value);
   RawHashTable_Key getKeyFromBinding(RawHashTable_Binding *binding);
@@ -353,7 +353,7 @@ inline RawHashTable_Value &RawHashTableIter::operator++()
 
 inline RawHashTableIter::operator const void *() const
 {
-  return ((m_currentBinding != 0) ? this : 0);
+  return ((m_currentBinding != nullptr) ? this : nullptr);
 }
 
 inline RawHashTable_Value &
@@ -368,7 +368,7 @@ RawHashTableIter::key() const
   return (m_currentBinding->key.string);
 }
 
-inline RawHashTableIter::RawHashTableIter(RawHashTable &ht) : m_ht(ht), m_currentBinding(0)
+inline RawHashTableIter::RawHashTableIter(RawHashTable &ht) : m_ht(ht), m_currentBinding(nullptr)
 {
   m_currentBinding = m_ht.firstBinding(&m_hashIterState);
   return;

--- a/lib/ts/RbTree.h
+++ b/lib/ts/RbTree.h
@@ -108,7 +108,7 @@ namespace detail
     int validate();
 
     /// Default constructor.
-    RBNode() : _color(RED), _parent(0), _left(0), _right(0), _next(0), _prev(0) {}
+    RBNode() : _color(RED), _parent(nullptr), _left(nullptr), _right(nullptr), _next(nullptr), _prev(nullptr) {}
     /// Destructor (force virtual).
     virtual ~RBNode() {}
     /** Rotate the subtree rooted at this node.
@@ -149,9 +149,9 @@ namespace detail
     clearChild(Direction dir)
     {
       if (LEFT == dir)
-        _left = 0;
+        _left = nullptr;
       else if (RIGHT == dir)
-        _right = 0;
+        _right = nullptr;
     }
 
     /** @name Subclass hook methods */

--- a/lib/ts/Regex.h
+++ b/lib/ts/Regex.h
@@ -40,7 +40,7 @@ enum REFlags {
 class Regex
 {
 public:
-  Regex() : regex(NULL), regex_extra(NULL) {}
+  Regex() : regex(nullptr), regex_extra(nullptr) {}
   bool compile(const char *pattern, const unsigned flags = 0);
   // It is safe to call exec() concurrently on the same object instance
   bool exec(const char *str);
@@ -64,7 +64,7 @@ typedef struct __pat {
 class DFA
 {
 public:
-  DFA() : _my_patterns(0) {}
+  DFA() : _my_patterns(nullptr) {}
   ~DFA();
 
   int compile(const char *pattern, unsigned flags = 0);

--- a/lib/ts/SimpleTokenizer.h
+++ b/lib/ts/SimpleTokenizer.h
@@ -124,13 +124,13 @@ public:
   };
 
   SimpleTokenizer(char delimiter = ' ', unsigned mode = 0, char escape = '\\')
-    : _data(0), _delimiter(delimiter), _mode(mode), _escape(escape), _start(0), _length(0)
+    : _data(nullptr), _delimiter(delimiter), _mode(mode), _escape(escape), _start(0), _length(0)
   {
   }
 
   // NOTE: The input strring 's' is overwritten for mode OVERWRITE_INPUT_STRING.
   SimpleTokenizer(const char *s, char delimiter = ' ', unsigned mode = 0, char escape = '\\')
-    : _data(0), _delimiter(delimiter), _mode(mode), _escape(escape)
+    : _data(nullptr), _delimiter(delimiter), _mode(mode), _escape(escape)
   {
     setString(s);
   }
@@ -209,7 +209,7 @@ private:
   char *
   _getNext(char delimiter, bool countOnly = false, int numTokens = 1)
   {
-    char *next = NULL;
+    char *next = nullptr;
 
     if (_start < _length) {
       // set start

--- a/lib/ts/Trie.h
+++ b/lib/ts/Trie.h
@@ -169,7 +169,7 @@ Trie<T>::Search(const char *key, int key_len /* = -1 */) const
 {
   _CheckArgs(key, key_len);
 
-  const Node *found_node = 0;
+  const Node *found_node = nullptr;
   const Node *curr_node  = &m_root;
   int i                  = 0;
 

--- a/lib/ts/TsBuffer.h
+++ b/lib/ts/TsBuffer.h
@@ -305,7 +305,7 @@ inline Buffer::Buffer(char *start, char *end) : _ptr(start), _size(end - start)
 inline Buffer &
 Buffer::reset()
 {
-  _ptr  = 0;
+  _ptr  = nullptr;
   _size = 0;
   return *this;
 }
@@ -335,7 +335,7 @@ inline bool Buffer::operator!() const
 }
 inline Buffer::operator pseudo_bool() const
 {
-  return _ptr && _size ? &self::operator! : 0;
+  return _ptr && _size ? &self::operator! : nullptr;
 }
 inline char Buffer::operator*() const
 {
@@ -389,7 +389,7 @@ ConstBuffer::set(char const *start, char const *end)
 inline ConstBuffer &
 ConstBuffer::reset()
 {
-  _ptr  = 0;
+  _ptr  = nullptr;
   _size = 0;
   return *this;
 }
@@ -426,7 +426,7 @@ inline bool ConstBuffer::operator!() const
 }
 inline ConstBuffer::operator pseudo_bool() const
 {
-  return _ptr && _size ? &self::operator! : 0;
+  return _ptr && _size ? &self::operator! : nullptr;
 }
 inline char ConstBuffer::operator*() const
 {

--- a/lib/ts/ink_args.h
+++ b/lib/ts/ink_args.h
@@ -94,7 +94,7 @@ void usage(const ArgumentDescription *argument_descriptions, unsigned n_argument
 /* Process all arguments
 */
 void process_args(const AppVersionInfo *appinfo, const ArgumentDescription *argument_descriptions, unsigned n_argument_descriptions,
-                  const char **argv, const char *usage_string = 0);
+                  const char **argv, const char *usage_string = nullptr);
 
 bool process_args_ex(const AppVersionInfo *appinfo, const ArgumentDescription *argument_descriptions,
                      unsigned n_argument_descriptions, const char **argv);

--- a/lib/ts/ink_inet.h
+++ b/lib/ts/ink_inet.h
@@ -138,10 +138,10 @@ int ats_tcp_somaxconn();
 
     @return 0 if an address was found, non-zero otherwise.
 */
-int ats_ip_parse(ts::string_view src,      ///< [in] String to search.
-                 ts::string_view *addr,    ///< [out] Range containing IP address.
-                 ts::string_view *port,    ///< [out] Range containing port.
-                 ts::string_view *rest = 0 ///< [out] Remnant past the addr/port if any.
+int ats_ip_parse(ts::string_view src,            ///< [in] String to search.
+                 ts::string_view *addr,          ///< [out] Range containing IP address.
+                 ts::string_view *port,          ///< [out] Range containing port.
+                 ts::string_view *rest = nullptr ///< [out] Remnant past the addr/port if any.
                  );
 
 /**  Check to see if a buffer contains only IP address characters.
@@ -542,7 +542,7 @@ ats_ip6_addr_cast(IpEndpoint const *ip)
 inline uint32_t *
 ats_ip_addr32_cast(sockaddr *addr)
 {
-  uint32_t *zret = 0;
+  uint32_t *zret = nullptr;
   switch (addr->sa_family) {
   case AF_INET:
     zret = reinterpret_cast<uint32_t *>(&ats_ip4_addr_cast(addr));
@@ -569,7 +569,7 @@ ats_ip_addr32_cast(sockaddr const *addr)
 inline uint8_t *
 ats_ip_addr8_cast(sockaddr *addr)
 {
-  uint8_t *zret = 0;
+  uint8_t *zret = nullptr;
   switch (addr->sa_family) {
   case AF_INET:
     zret = reinterpret_cast<uint8_t *>(&ats_ip4_addr_cast(addr));

--- a/lib/ts/ink_memory.h
+++ b/lib/ts/ink_memory.h
@@ -439,7 +439,7 @@ struct SCOPED_MALLOC_TRAITS {
   static bool
   isValid(T *t)
   {
-    return 0 != t;
+    return nullptr != t;
   }
   static void
   destroy(T *t)
@@ -461,7 +461,7 @@ struct SCOPED_OBJECT_TRAITS {
   static bool
   isValid(T *t)
   {
-    return 0 != t;
+    return nullptr != t;
   }
   static void
   destroy(T *t)

--- a/lib/ts/ink_resolver.h
+++ b/lib/ts/ink_resolver.h
@@ -267,7 +267,7 @@ struct ts_imp_res_state {
 typedef ts_imp_res_state *ink_res_state;
 
 int ink_res_init(ink_res_state, IpEndpoint const *pHostList, size_t pHostListSize, int dnsSearch, const char *pDefDomain = nullptr,
-                 const char *pSearchList = nullptr, const char *pResolvConf = NULL);
+                 const char *pSearchList = nullptr, const char *pResolvConf = nullptr);
 
 int ink_res_mkquery(ink_res_state, int, const char *, int, int, const unsigned char *, int, const unsigned char *, unsigned char *,
                     int);

--- a/lib/ts/ink_string++.h
+++ b/lib/ts/ink_string++.h
@@ -46,7 +46,7 @@ struct Str {
   struct Str *next; // next in list
   struct Str *prev; // prev in list
 
-  Str() : str(nullptr), len(0), next(NULL), prev(NULL) {}
+  Str() : str(nullptr), len(0), next(nullptr), prev(nullptr) {}
   Str(char *s)
   {
     str  = s;
@@ -261,7 +261,7 @@ StrList::prepend(Str *str)
 inline void
 StrList::add_after(Str *prev, Str *str)
 {
-  if (str == nullptr || prev == NULL)
+  if (str == nullptr || prev == nullptr)
     return;
   ++count;
   str->next  = prev->next;

--- a/lib/ts/ink_uuid.h
+++ b/lib/ts/ink_uuid.h
@@ -47,7 +47,7 @@ public:
   const char *
   getString() const
   {
-    return valid() ? _string : NULL;
+    return valid() ? _string : nullptr;
   }
 
   const char *

--- a/lib/tsconfig/IntrusivePtr.h
+++ b/lib/tsconfig/IntrusivePtr.h
@@ -399,7 +399,7 @@ IntrusivePtrPolicy<T>::Order::operator()(IntrusivePtr<T> const &lhs, IntrusivePt
 }
 /* ----------------------------------------------------------------------- */
 /* ----------------------------------------------------------------------- */
-template <typename T> IntrusivePtr<T>::IntrusivePtr() : m_obj(0)
+template <typename T> IntrusivePtr<T>::IntrusivePtr() : m_obj(nullptr)
 {
 }
 
@@ -500,7 +500,7 @@ template <typename T>
 void
 IntrusivePtr<T>::unset()
 {
-  if (0 != m_obj) {
+  if (nullptr != m_obj) {
     /* magic: our target is required to inherit from IntrusivePtrCounter,
      * which provides a protected counter variable and access via our
      * super class. We call the super class method to get a raw pointer
@@ -518,7 +518,7 @@ IntrusivePtr<T>::unset()
     if (0 == --*cp) {
       IntrusivePtrPolicy<T>::finalize(m_obj);
     }
-    m_obj = 0;
+    m_obj = nullptr;
   }
 }
 
@@ -527,7 +527,7 @@ void
 IntrusivePtr<T>::set(T *obj)
 {
   m_obj = obj;    /* update to new object */
-  if (0 != m_obj) /* if a real object, bump the ref count */
+  if (nullptr != m_obj) /* if a real object, bump the ref count */
     ++(*(this->getCounter()));
 }
 
@@ -553,7 +553,7 @@ IntrusivePtr<T>::release()
     // so be extra careful with the reference count.
     if (*cp > 0)
       --*cp;
-    m_obj = 0;
+    m_obj = nullptr;
   }
   return zret;
 }
@@ -601,7 +601,7 @@ bool
 operator==(int lhs, IntrusivePtr<T> const &rhs)
 {
   assert(0 == lhs);
-  return rhs.get() == 0;
+  return rhs.get() == nullptr;
 }
 
 template <typename T>

--- a/lib/tsconfig/TsBuilder.h
+++ b/lib/tsconfig/TsBuilder.h
@@ -92,7 +92,7 @@ public:
   self& init();
 };
 
-inline Builder::Handler::Handler() : _ptr(0), _method(0) { }
+inline Builder::Handler::Handler() : _ptr(nullptr), _method(nullptr) { }
 inline Builder::Builder() { this->init(); }
 inline Builder::Builder(Configuration const& config) : _config(config) { this->init(); }
 

--- a/lib/tsconfig/TsValue.h
+++ b/lib/tsconfig/TsValue.h
@@ -158,7 +158,7 @@ public:
         - ERROR: A syntax error was encountered. See the errata for detail. Do not continue parsing.
     */
     Rv<Result> parse(
-      ConstBuffer* cbuff = 0 ///< [out] Parsed path element.
+      ConstBuffer* cbuff = nullptr ///< [out] Parsed path element.
     );
 
     /// Check if input is available.
@@ -642,7 +642,7 @@ namespace detail {
   inline size_t ValueTable::size() const { return _ptr ? _ptr->_values.size() : 0; }
   inline Generation ValueTable::generation() const { return _ptr ? _ptr->_generation : Generation(0); }
   inline ValueItem const& ValueTable::operator [] (ValueIndex idx) const { return const_cast<self*>(this)->operator [] (idx); }
-  inline ValueTable& ValueTable::reset() { _ptr = 0; return *this; }
+  inline ValueTable& ValueTable::reset() { _ptr = nullptr; return *this; }
 
   inline ValueItem::ValueItem() : _type(VoidValue), _local_index(0), _srcLine(0), _srcColumn(0) {}
   inline ValueItem::ValueItem(ValueType type) : _type(type), _local_index(0), _srcLine(0), _srcColumn(0) {}
@@ -678,7 +678,7 @@ inline bool Value::isContainer() const { return 0 != (detail::IS_CONTAINER & det
 inline Value Value::getParent() const { return this->hasValue() ? Value(_config, _config._table[_vidx]._parent) : Value(); }
 inline bool Value::isRoot() const { return this->hasValue() && _vidx == 0; }
 inline Value& Value::reset() { _config = Configuration(); _vidx = detail::NULL_VALUE_INDEX; return *this; }
-inline detail::ValueItem* Value::item() { return this->hasValue() ? &(_config._table[_vidx]) : 0; }
+inline detail::ValueItem* Value::item() { return this->hasValue() ? &(_config._table[_vidx]) : nullptr; }
 inline detail::ValueItem const* Value::item() const { return const_cast<self*>(this)->item(); }
 inline Value Value::operator [] (char const* name) const { return (*this)[ConstBuffer(name, strlen(name))]; }
 inline size_t Value::childCount() const {
@@ -718,7 +718,7 @@ inline Path::ImplType::ImplType() { }
 inline Path::Path() { }
 inline Path::ImplType* Path::instance() { if (!_ptr) _ptr = new ImplType; return _ptr.get(); }
 inline Path& Path::append(ConstBuffer const& tag) { this->instance()->_elements.push_back(tag); return *this; }
-inline Path& Path::append(size_t index) { this->instance()->_elements.push_back(ConstBuffer(0, index)); return *this; }
+inline Path& Path::append(size_t index) { this->instance()->_elements.push_back(ConstBuffer(nullptr, index)); return *this; }
 inline size_t Path::count() const { return _ptr ? _ptr->_elements.size() : 0; }
 inline ConstBuffer const& Path::operator [] (size_t idx) const { return _ptr ? _ptr->_elements[idx] : detail::NULL_CONST_BUFFER; }
 

--- a/mgmt/Alarms.h
+++ b/mgmt/Alarms.h
@@ -107,10 +107,10 @@ public:
   ~Alarms();
 
   void registerCallback(AlarmCallbackFunc func);
-  bool isCurrentAlarm(alarm_t a, char *ip = NULL);
+  bool isCurrentAlarm(alarm_t a, char *ip = nullptr);
 
-  void signalAlarm(alarm_t t, const char *desc, const char *ip = NULL);
-  void resolveAlarm(alarm_t a, char *ip = NULL);
+  void signalAlarm(alarm_t t, const char *desc, const char *ip = nullptr);
+  void resolveAlarm(alarm_t a, char *ip = nullptr);
 
   void constructAlarmMessage(const AppVersionInfo &version, char *ip, char *message, int max);
   void resetSeenFlag(char *ip);

--- a/mgmt/BaseManager.h
+++ b/mgmt/BaseManager.h
@@ -124,7 +124,7 @@ public:
   BaseManager();
   ~BaseManager();
 
-  int registerMgmtCallback(int msg_id, MgmtCallback func, void *opaque_callback_data = NULL);
+  int registerMgmtCallback(int msg_id, MgmtCallback func, void *opaque_callback_data = nullptr);
 
   LLQ *mgmt_event_queue;
   InkHashTable *mgmt_callback_table;

--- a/mgmt/FileManager.h
+++ b/mgmt/FileManager.h
@@ -88,7 +88,7 @@ class FileManager
 public:
   FileManager();
   ~FileManager();
-  void addFile(const char *fileName, bool root_access_needed, Rollback *parentRollback = NULL, unsigned flags = 0);
+  void addFile(const char *fileName, bool root_access_needed, Rollback *parentRollback = nullptr, unsigned flags = 0);
   bool getRollbackObj(const char *fileName, Rollback **rbPtr);
   void registerCallback(FileCallbackFunc func);
   void fileChanged(const char *fileName, bool incVersion);

--- a/mgmt/LocalManager.h
+++ b/mgmt/LocalManager.h
@@ -78,7 +78,7 @@ public:
   void signalFileChange(const char *var_name, bool incVersion = true);
   void signalEvent(int msg_id, const char *data_str);
   void signalEvent(int msg_id, const char *data_raw, int data_len);
-  void signalAlarm(int alarm_id, const char *desc = NULL, const char *ip = NULL);
+  void signalAlarm(int alarm_id, const char *desc = nullptr, const char *ip = nullptr);
 
   void processEventQueue();
   bool startProxy(const char *onetime_options);
@@ -93,7 +93,7 @@ public:
   void processBounce();
   void processDrain(int to_drain = 1);
   void rollLogFiles();
-  void clearStats(const char *name = NULL);
+  void clearStats(const char *name = nullptr);
   void hostStatusSetDown(const char *name);
   void hostStatusSetUp(const char *name);
 

--- a/mgmt/ProxyConfig.h
+++ b/mgmt/ProxyConfig.h
@@ -79,7 +79,7 @@ public:
   template <typename ClassType, typename ConfigType> struct scoped_config {
     scoped_config() : ptr(ClassType::acquire()) {}
     ~scoped_config() { ClassType::release(ptr); }
-    operator bool() const { return ptr != 0; }
+    operator bool() const { return ptr != nullptr; }
     operator const ConfigType *() const { return ptr; }
     const ConfigType *operator->() const { return ptr; }
 

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -201,7 +201,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.diags.debug.tags", RECD_STRING, "http|dns", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.diags.debug.client_ip", RECD_STRING, NULL, RECU_DYNAMIC, RR_NULL, RECC_NULL, NULL, RECA_NULL} 
+  {RECT_CONFIG, "proxy.config.diags.debug.client_ip", RECD_STRING, nullptr, RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL} 
   ,
   {RECT_CONFIG, "proxy.config.diags.action.enabled", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,

--- a/mgmt/Rollback.h
+++ b/mgmt/Rollback.h
@@ -156,7 +156,7 @@ class Rollback
 {
 public:
   // fileName_ should be rooted or a base file name.
-  Rollback(const char *fileName_, bool root_access_needed, Rollback *parentRollback = NULL, unsigned flags = 0);
+  Rollback(const char *fileName_, bool root_access_needed, Rollback *parentRollback = nullptr, unsigned flags = 0);
   ~Rollback();
 
   // Manual take out of lock required
@@ -221,7 +221,7 @@ public:
   bool
   isChildRollback() const
   {
-    return parentRollback != NULL;
+    return parentRollback != nullptr;
   }
   Rollback *
   getParentRollback() const
@@ -241,7 +241,7 @@ public:
   Rollback &operator=(const Rollback &) = delete;
 
 private:
-  int openFile(version_t version, int oflags, int *errnoPtr = NULL);
+  int openFile(version_t version, int oflags, int *errnoPtr = nullptr);
   int closeFile(int fd, bool callSync);
   int statFile(version_t version, struct stat *buf);
   char *createPathStr(version_t version);

--- a/mgmt/api/CoreAPI.cc
+++ b/mgmt/api/CoreAPI.cc
@@ -215,8 +215,8 @@ typedef std::vector<pid_t> threadlist;
 static threadlist
 threads_for_process(pid_t proc)
 {
-  DIR *dir             = NULL;
-  struct dirent *entry = NULL;
+  DIR *dir             = nullptr;
+  struct dirent *entry = nullptr;
 
   char path[64];
   threadlist threads;
@@ -226,7 +226,7 @@ threads_for_process(pid_t proc)
   }
 
   dir = opendir(path);
-  if (dir == NULL) {
+  if (dir == nullptr) {
     goto done;
   }
 
@@ -237,7 +237,7 @@ threads_for_process(pid_t proc)
       continue;
     }
 
-    threadid = strtol(entry->d_name, NULL, 10);
+    threadid = strtol(entry->d_name, nullptr, 10);
     if (threadid > 0) {
       threads.push_back(threadid);
       Debug("backtrace", "found thread %ld", (long)threadid);
@@ -256,9 +256,9 @@ static void
 backtrace_for_thread(pid_t threadid, TextBuffer &text)
 {
   int status;
-  unw_addr_space_t addr_space = NULL;
+  unw_addr_space_t addr_space = nullptr;
   unw_cursor_t cursor;
-  void *ap       = NULL;
+  void *ap       = nullptr;
   pid_t target   = -1;
   unsigned level = 0;
 
@@ -279,13 +279,13 @@ backtrace_for_thread(pid_t threadid, TextBuffer &text)
 
   ap = _UPT_create(threadid);
   Debug("backtrace", "created UPT %p", ap);
-  if (ap == NULL) {
+  if (ap == nullptr) {
     goto done;
   }
 
   addr_space = unw_create_addr_space(&_UPT_accessors, 0 /* byteorder */);
   Debug("backtrace", "created address space %p", addr_space);
-  if (addr_space == NULL) {
+  if (addr_space == nullptr) {
     goto done;
   }
 
@@ -304,7 +304,7 @@ backtrace_for_thread(pid_t threadid, TextBuffer &text)
 
     if (unw_get_proc_name(&cursor, buf, sizeof(buf), &offset) == 0) {
       int status;
-      char *name = abi::__cxa_demangle(buf, NULL, NULL, &status);
+      char *name = abi::__cxa_demangle(buf, nullptr, nullptr, &status);
       text.format("%-4u 0x%016llx %s + %p\n", level, (unsigned long long)ip, name ? name : buf, (void *)offset);
       free(name);
     } else {
@@ -330,7 +330,7 @@ done:
 TSMgmtError
 ServerBacktrace(unsigned /* options */, char **trace)
 {
-  *trace = NULL;
+  *trace = nullptr;
 
   // Unfortunately, we need to be privileged here. We either need to be root or to be holding
   // the CAP_SYS_PTRACE capability. Even though we are the parent traffic_manager, it is not

--- a/mgmt/api/CoreAPI.h
+++ b/mgmt/api/CoreAPI.h
@@ -36,7 +36,7 @@
 #define MAX_BUF_SIZE 4098
 #endif
 
-TSMgmtError Init(const char *socket_path = NULL, TSInitOptionT options = TS_MGMT_OPT_DEFAULTS);
+TSMgmtError Init(const char *socket_path = nullptr, TSInitOptionT options = TS_MGMT_OPT_DEFAULTS);
 TSMgmtError Terminate();
 
 /***************************************************************************
@@ -84,4 +84,4 @@ TSMgmtError EventSignalCbUnregister(const char *event_name, TSEventSignalFunc fu
 
 TSMgmtError HostStatusSetDown(const char *name);
 TSMgmtError HostStatusSetUp(const char *name);
-TSMgmtError StatsReset(const char *name = NULL);
+TSMgmtError StatsReset(const char *name = nullptr);

--- a/mgmt/utils/MgmtUtils.h
+++ b/mgmt/utils/MgmtUtils.h
@@ -51,7 +51,7 @@ void mgmt_use_syslog();
 void mgmt_cleanup();
 
 struct in_addr *mgmt_sortipaddrs(int num, struct in_addr **list);
-bool mgmt_getAddrForIntr(char *intrName, sockaddr *addr, int *mtu = 0);
+bool mgmt_getAddrForIntr(char *intrName, sockaddr *addr, int *mtu = nullptr);
 
 /* the following functions are all DEPRECATED.  The Diags
    interface should be used exclusively in the future */

--- a/plugins/background_fetch/configs.h
+++ b/plugins/background_fetch/configs.h
@@ -38,7 +38,7 @@ const char PLUGIN_NAME[] = "background_fetch";
 class BgFetchConfig
 {
 public:
-  BgFetchConfig(TSCont cont) : _cont(cont), _rules(NULL), _ref_count(0) { TSContDataSet(cont, static_cast<void *>(this)); }
+  BgFetchConfig(TSCont cont) : _cont(cont), _rules(nullptr), _ref_count(0) { TSContDataSet(cont, static_cast<void *>(this)); }
   void
   acquire()
   {

--- a/plugins/background_fetch/rules.h
+++ b/plugins/background_fetch/rules.h
@@ -38,7 +38,7 @@ class BgFetchRule
 {
 public:
   BgFetchRule(bool exc, const char *field, const char *value)
-    : _exclude(exc), _field(TSstrdup(field)), _value(TSstrdup(value)), _next(NULL)
+    : _exclude(exc), _field(TSstrdup(field)), _value(TSstrdup(value)), _next(nullptr)
   {
   }
 

--- a/plugins/esi/fetcher/HttpDataFetcher.h
+++ b/plugins/esi/fetcher/HttpDataFetcher.h
@@ -38,18 +38,18 @@ class HttpDataFetcher
 {
 public:
   virtual bool
-  addFetchRequest(const char *url, int url_len, FetchedDataProcessor *callback_obj = 0)
+  addFetchRequest(const char *url, int url_len, FetchedDataProcessor *callback_obj = nullptr)
   {
     return addFetchRequest(std::string(url, url_len), callback_obj);
   }
 
   virtual bool
-  addFetchRequest(const char *url, FetchedDataProcessor *callback_obj = 0)
+  addFetchRequest(const char *url, FetchedDataProcessor *callback_obj = nullptr)
   {
     return addFetchRequest(std::string(url), callback_obj);
   }
 
-  virtual bool addFetchRequest(const std::string &url, FetchedDataProcessor *callback_obj = 0) = 0;
+  virtual bool addFetchRequest(const std::string &url, FetchedDataProcessor *callback_obj = nullptr) = 0;
 
   virtual DataStatus
   getRequestStatus(const char *url, int url_len) const

--- a/plugins/esi/fetcher/HttpDataFetcherImpl.h
+++ b/plugins/esi/fetcher/HttpDataFetcherImpl.h
@@ -42,7 +42,7 @@ public:
 
   void useHeaders(const EsiLib::HttpHeaderList &headers);
 
-  bool addFetchRequest(const std::string &url, FetchedDataProcessor *callback_obj = 0);
+  bool addFetchRequest(const std::string &url, FetchedDataProcessor *callback_obj = nullptr);
 
   bool handleFetchEvent(TSEvent event, void *edata);
 
@@ -74,12 +74,12 @@ public:
     TSMBuffer bufp;
     TSMLoc hdr_loc;
     TSHttpStatus status;
-    ResponseData() { set(0, 0, 0, 0, TS_HTTP_STATUS_NONE); }
+    ResponseData() { set(nullptr, 0, nullptr, nullptr, TS_HTTP_STATUS_NONE); }
     inline void set(const char *c, int clen, TSMBuffer b, TSMLoc loc, TSHttpStatus s);
     void
     clear()
     {
-      set(0, 0, 0, 0, TS_HTTP_STATUS_NONE);
+      set(nullptr, 0, nullptr, nullptr, TS_HTTP_STATUS_NONE);
     }
   };
 
@@ -119,7 +119,9 @@ private:
     TSMBuffer bufp;
     TSMLoc hdr_loc;
 
-    RequestData() : body(0), body_len(0), resp_status(TS_HTTP_STATUS_NONE), complete(false), bufp(0), hdr_loc(0) {}
+    RequestData() : body(nullptr), body_len(0), resp_status(TS_HTTP_STATUS_NONE), complete(false), bufp(nullptr), hdr_loc(nullptr)
+    {
+    }
   };
 
   typedef __gnu_cxx::hash_map<std::string, RequestData, EsiLib::StringHasher> UrlToContentMap;

--- a/plugins/esi/lib/Attribute.h
+++ b/plugins/esi/lib/Attribute.h
@@ -33,7 +33,7 @@ struct Attribute {
   int32_t name_len;
   const char *value;
   int32_t value_len;
-  Attribute(const char *n = 0, int32_t n_len = 0, const char *v = 0, int32_t v_len = 0)
+  Attribute(const char *n = nullptr, int32_t n_len = 0, const char *v = nullptr, int32_t v_len = 0)
     : name(n), name_len(n_len), value(v), value_len(v_len){};
 };
 

--- a/plugins/esi/lib/DocNode.h
+++ b/plugins/esi/lib/DocNode.h
@@ -99,7 +99,7 @@ public:
 
   DocNodeList child_nodes;
 
-  DocNode(TYPE _type = TYPE_UNKNOWN, const char *_data = 0, int32_t _data_len = 0)
+  DocNode(TYPE _type = TYPE_UNKNOWN, const char *_data = nullptr, int32_t _data_len = 0)
     : type(_type), data(_data), data_len(_data_len){};
 
   void pack(std::string &buffer) const;

--- a/plugins/esi/lib/EsiParser.h
+++ b/plugins/esi/lib/EsiParser.h
@@ -56,7 +56,7 @@ public:
    *
    * Output nodes contain pointers to internal data; use with care. */
   bool
-  completeParse(EsiLib::DocNodeList &node_list, const char *data = 0, int data_len = -1)
+  completeParse(EsiLib::DocNodeList &node_list, const char *data = nullptr, int data_len = -1)
   {
     return _completeParse(_data, _parse_start_pos, _orig_output_list_size, node_list, data, data_len);
   }
@@ -141,7 +141,7 @@ private:
               const char *data_ptr, int &data_len) const;
 
   bool _completeParse(std::string &data, int &parse_start_pos, size_t &orig_output_list_size, EsiLib::DocNodeList &node_list,
-                      const char *data_ptr = 0, int data_len = -1) const;
+                      const char *data_ptr = nullptr, int data_len = -1) const;
 
   inline void _adjustPointers(EsiLib::DocNodeList::iterator node_iter, EsiLib::DocNodeList::iterator end, const char *ext_data_ptr,
                               const char *int_data_start) const;

--- a/plugins/esi/lib/EsiProcessor.h
+++ b/plugins/esi/lib/EsiProcessor.h
@@ -67,7 +67,7 @@ public:
 
   /** Tells processor to wrap-up parsing; a final or the only piece of
    * data can be optionally provided */
-  bool completeParse(const char *data = 0, int data_len = -1);
+  bool completeParse(const char *data = nullptr, int data_len = -1);
 
   /** convenient alternative to method above */
   bool
@@ -147,7 +147,7 @@ private:
 
   bool _processEsiNode(const EsiLib::DocNodeList::iterator &iter);
   bool _handleParseComplete();
-  bool _getIncludeData(const EsiLib::DocNode &node, const char **content_ptr = 0, int *content_len_ptr = 0);
+  bool _getIncludeData(const EsiLib::DocNode &node, const char **content_ptr = nullptr, int *content_len_ptr = nullptr);
   DataStatus _getIncludeStatus(const EsiLib::DocNode &node);
   bool _handleVars(const char *str, int str_len);
   bool _handleChoose(EsiLib::DocNodeList::iterator &curr_node);

--- a/plugins/esi/lib/Expression.h
+++ b/plugins/esi/lib/Expression.h
@@ -84,7 +84,7 @@ private:
   struct OperatorString {
     const char *str;
     int str_len;
-    OperatorString(const char *s = 0, int s_len = -1) : str(s), str_len(s_len){};
+    OperatorString(const char *s = nullptr, int s_len = -1) : str(s), str_len(s_len){};
   };
 
   static const OperatorString OPERATOR_STRINGS[N_OPERATORS];

--- a/plugins/esi/lib/HandlerManager.h
+++ b/plugins/esi/lib/HandlerManager.h
@@ -55,7 +55,7 @@ private:
   struct ModuleHandles {
     void *object;
     SpecialIncludeHandlerCreator function;
-    ModuleHandles(void *o = nullptr, SpecialIncludeHandlerCreator f = 0) : object(o), function(f){};
+    ModuleHandles(void *o = nullptr, SpecialIncludeHandlerCreator f = nullptr) : object(o), function(f){};
   };
 
   typedef std::map<std::string, ModuleHandles> ModuleHandleMap;

--- a/plugins/esi/lib/HttpHeader.h
+++ b/plugins/esi/lib/HttpHeader.h
@@ -34,7 +34,7 @@ struct HttpHeader {
   int name_len;
   const char *value;
   int value_len;
-  HttpHeader(const char *n = 0, int n_len = -1, const char *v = 0, int v_len = -1)
+  HttpHeader(const char *n = nullptr, int n_len = -1, const char *v = nullptr, int v_len = -1)
     : name(n), name_len(n_len), value(v), value_len(v_len){};
 };
 

--- a/plugins/esi/lib/SpecialIncludeHandler.h
+++ b/plugins/esi/lib/SpecialIncludeHandler.h
@@ -57,7 +57,7 @@ public:
   virtual void
   getFooter(const char *&footer, int &footer_len)
   {
-    footer     = NULL;
+    footer     = nullptr;
     footer_len = 0;
   }
 

--- a/plugins/esi/lib/Utils.h
+++ b/plugins/esi/lib/Utils.h
@@ -48,7 +48,7 @@ namespace Utils
   // also be specified apart from the end_pos; attr_info will point
   // to data inside data string
   bool getAttribute(const std::string &data, const std::string &attr, size_t curr_pos, size_t end_pos, Attribute &attr_info,
-                    size_t *term_pos = 0, char terminator = 0);
+                    size_t *term_pos = nullptr, char terminator = 0);
 
   // less specialized version of method above
   inline bool

--- a/plugins/esi/lib/gzip.h
+++ b/plugins/esi/lib/gzip.h
@@ -46,7 +46,7 @@ namespace EsiLib
 struct ByteBlock {
   const char *data;
   int data_len;
-  ByteBlock(const char *d = 0, int d_len = 0) : data(d), data_len(d_len){};
+  ByteBlock(const char *d = nullptr, int d_len = 0) : data(d), data_len(d_len){};
 };
 
 typedef std::list<ByteBlock> ByteBlockList;

--- a/plugins/esi/test/TestHttpDataFetcher.h
+++ b/plugins/esi/test/TestHttpDataFetcher.h
@@ -33,7 +33,7 @@ class TestHttpDataFetcher : public HttpDataFetcher
 public:
   TestHttpDataFetcher() : _n_pending_requests(0), _return_data(true) {}
   bool
-  addFetchRequest(const std::string &url, FetchedDataProcessor *callback_obj = 0)
+  addFetchRequest(const std::string &url, FetchedDataProcessor *callback_obj = nullptr)
   {
     ++_n_pending_requests;
     return true;

--- a/plugins/experimental/geoip_acl/acl.h
+++ b/plugins/experimental/geoip_acl/acl.h
@@ -68,7 +68,7 @@ public:
     if (_html.size() > 0) {
       char *msg = TSstrdup(_html.c_str());
 
-      TSHttpTxnErrorBodySet(txnp, msg, _html.size(), NULL); // Defaults to text/html
+      TSHttpTxnErrorBodySet(txnp, msg, _html.size(), nullptr); // Defaults to text/html
     }
   }
 
@@ -93,7 +93,7 @@ protected:
 class RegexAcl
 {
 public:
-  RegexAcl(Acl *acl) : _rex(NULL), _extra(NULL), _next(NULL), _acl(acl) {}
+  RegexAcl(Acl *acl) : _rex(nullptr), _extra(nullptr), _next(nullptr), _acl(acl) {}
   const std::string &
   get_regex() const
   {
@@ -117,7 +117,7 @@ public:
       return false;
     }
 
-    return (pcre_exec(_rex, _extra, str, len, 0, PCRE_NOTEMPTY, NULL, 0) != -1);
+    return (pcre_exec(_rex, _extra, str, len, 0, PCRE_NOTEMPTY, nullptr, 0) != -1);
   }
 
   void append(RegexAcl *ra);
@@ -136,7 +136,7 @@ private:
 class CountryAcl : public Acl
 {
 public:
-  CountryAcl() : _regexes(NULL) { memset(_iso_country_codes, 0, sizeof(_iso_country_codes)); }
+  CountryAcl() : _regexes(nullptr) { memset(_iso_country_codes, 0, sizeof(_iso_country_codes)); }
   void read_regex(const char *fn, int &tokens);
   int process_args(int argc, char *argv[]);
   bool eval(TSRemapRequestInfo *rri, TSHttpTxn txnp) const;

--- a/plugins/experimental/inliner/cache-handler.h
+++ b/plugins/experimental/inliner/cache-handler.h
@@ -52,10 +52,10 @@ getHeader(TSMBuffer buffer, TSMLoc location, const std::string &name, std::strin
 {
   bool result        = false;
   const TSMLoc field = TSMimeHdrFieldFind(buffer, location, name.c_str(), name.size());
-  if (field != NULL) {
+  if (field != nullptr) {
     int length                = 0;
     const char *const content = TSMimeHdrFieldValueStringGet(buffer, location, field, -1, &length);
-    if (content != NULL && length > 0) {
+    if (content != nullptr && length > 0) {
       value  = std::string(content, length);
       result = true;
     }
@@ -75,7 +75,7 @@ namespace inliner
     int64_t
     data(const TSIOBufferReader r, int64_t l)
     {
-      assert(r != NULL);
+      assert(r != nullptr);
       TSIOBufferBlock block = TSIOBufferReaderStart(r);
 
       assert(l >= 0);
@@ -89,7 +89,7 @@ namespace inliner
       for (; block && l > 0; block = TSIOBufferBlockNext(block)) {
         int64_t size              = 0;
         const char *const pointer = TSIOBufferBlockReadStart(block, r, &size);
-        if (pointer != NULL && size > 0) {
+        if (pointer != nullptr && size > 0) {
           size = std::min(size, l);
           std::copy(pointer, pointer + size, std::back_inserter(content_));
           length += size;
@@ -180,7 +180,7 @@ namespace inliner
   uint64_t
   read(const TSIOBufferReader &r, std::string &o, int64_t l = 0)
   {
-    assert(r != NULL);
+    assert(r != nullptr);
     TSIOBufferBlock block = TSIOBufferReaderStart(r);
 
     assert(l >= 0);
@@ -194,7 +194,7 @@ namespace inliner
     for (; block && l > 0; block = TSIOBufferBlockNext(block)) {
       int64_t size              = 0;
       const char *const pointer = TSIOBufferBlockReadStart(block, r, &size);
-      if (pointer != NULL && size > 0) {
+      if (pointer != nullptr && size > 0) {
         size = std::min(size, l);
         o.append(pointer, size);
         length += size;
@@ -216,20 +216,20 @@ namespace inliner
 
     ~CacheHandler()
     {
-      if (reader_ != NULL) {
+      if (reader_ != nullptr) {
         TSIOBufferReaderConsume(reader_, TSIOBufferReaderAvail(reader_));
         assert(TSIOBufferReaderAvail(reader_) == 0);
         TSIOBufferReaderFree(reader_);
-        reader_ = NULL;
+        reader_ = nullptr;
       }
     }
 
     template <class T1, class T2>
     CacheHandler(const std::string &s, const std::string &o, const std::string c, const std::string &i, T1 &&si, T2 &&si2)
-      : src_(s), original_(o), classes_(c), id_(i), sink_(std::forward<T1>(si)), sink2_(std::forward<T2>(si2)), reader_(NULL)
+      : src_(s), original_(o), classes_(c), id_(i), sink_(std::forward<T1>(si)), sink2_(std::forward<T2>(si2)), reader_(nullptr)
     {
-      assert(sink_ != NULL);
-      assert(sink2_ != NULL);
+      assert(sink_ != nullptr);
+      assert(sink2_ != nullptr);
     }
 
     CacheHandler(CacheHandler &&h)
@@ -241,7 +241,7 @@ namespace inliner
         sink2_(std::move(h.sink2_)),
         reader_(h.reader_)
     {
-      h.reader_ = NULL;
+      h.reader_ = nullptr;
     }
 
     CacheHandler(const CacheHandler &) = delete;
@@ -250,8 +250,8 @@ namespace inliner
     void
     done(void)
     {
-      assert(reader_ != NULL);
-      assert(sink2_ != NULL);
+      assert(reader_ != nullptr);
+      assert(sink2_ != nullptr);
       std::string o;
       read(reader_, o);
       o = "<script>h(\"" + id_ + "\",\"" + o + "\");</script>";
@@ -262,7 +262,7 @@ namespace inliner
     data(TSIOBufferReader r)
     {
       // TODO(dmorilha): API maybe address as a different single event?
-      if (reader_ == NULL) {
+      if (reader_ == nullptr) {
         reader_ = TSIOBufferReaderClone(r);
       }
     }
@@ -270,7 +270,7 @@ namespace inliner
     void
     hit(TSVConn v)
     {
-      assert(v != NULL);
+      assert(v != nullptr);
 
       TSDebug(PLUGIN_TAG, "cache hit for %s (%" PRId64 " bytes)", src_.c_str(), TSVConnCacheObjectSizeGet(v));
 
@@ -293,7 +293,7 @@ namespace inliner
     void
     miss(void)
     {
-      assert(sink_ != NULL);
+      assert(sink_ != nullptr);
       *sink_ << original_;
       if (!src_.empty()) {
         *sink_ << "src=\"" << src_ << "\" ";
@@ -303,7 +303,7 @@ namespace inliner
       }
       sink_.reset();
 
-      assert(sink2_ != NULL);
+      assert(sink2_ != nullptr);
       sink2_.reset();
 
       const std::string b;

--- a/plugins/experimental/inliner/cache.h
+++ b/plugins/experimental/inliner/cache.h
@@ -36,17 +36,17 @@ namespace cache
   struct Key {
     ~Key()
     {
-      assert(key_ != NULL);
+      assert(key_ != nullptr);
       TSCacheKeyDestroy(key_);
     }
 
-    Key(void) : key_(TSCacheKeyCreate()) { assert(key_ != NULL); }
+    Key(void) : key_(TSCacheKeyCreate()) { assert(key_ != nullptr); }
     Key(const Key &) = delete;
     Key &operator=(const Key &) = delete;
 
     explicit Key(const std::string &s) : key_(TSCacheKeyCreate())
     {
-      assert(key_ != NULL);
+      assert(key_ != nullptr);
       CHECK(TSCacheKeyDigestSet(key_, s.c_str(), s.size()));
     }
 
@@ -69,10 +69,10 @@ namespace cache
     handle(TSCont c, TSEvent e, void *d)
     {
       Self *const self = static_cast<Self *const>(TSContDataGet(c));
-      assert(self != NULL);
+      assert(self != nullptr);
       switch (e) {
       case TS_EVENT_CACHE_OPEN_READ:
-        assert(d != NULL);
+        assert(d != nullptr);
         self->t_.hit(static_cast<TSVConn>(d));
         break;
       case TS_EVENT_CACHE_OPEN_READ_FAILED:
@@ -83,7 +83,7 @@ namespace cache
         break;
       }
       delete self;
-      TSContDataSet(c, NULL);
+      TSContDataSet(c, nullptr);
       TSContDestroy(c);
       return TS_SUCCESS;
     }
@@ -95,7 +95,7 @@ namespace cache
   {
     const Key key(k);
     const TSCont continuation = TSContCreate(Read<T>::handle, TSMutexCreate());
-    assert(continuation != NULL);
+    assert(continuation != nullptr);
     TSContDataSet(continuation, new Read<T>(std::forward<A>(a)...));
     TSCacheRead(continuation, key.key());
   }
@@ -107,12 +107,12 @@ namespace cache
 
     ~Write()
     {
-      if (out_ != NULL) {
+      if (out_ != nullptr) {
         delete out_;
       }
     }
 
-    Write(std::string &&s) : content_(std::move(s)), out_(NULL), vconnection_(NULL) {}
+    Write(std::string &&s) : content_(std::move(s)), out_(nullptr), vconnection_(nullptr) {}
     static int handle(TSCont, TSEvent, void *);
   };
 

--- a/plugins/experimental/inliner/inliner-handler.h
+++ b/plugins/experimental/inliner/inliner-handler.h
@@ -42,7 +42,7 @@ namespace inliner
 
     ~Handler()
     {
-      assert(reader_ != NULL);
+      assert(reader_ != nullptr);
       if (!abort_) {
         const int64_t available = TSIOBufferReaderAvail(reader_);
         if (available > 0) {

--- a/plugins/experimental/inliner/ts.h
+++ b/plugins/experimental/inliner/ts.h
@@ -52,14 +52,14 @@ namespace io
     ~IO()
     {
       consume();
-      assert(reader != NULL);
+      assert(reader != nullptr);
       TSIOBufferReaderFree(reader);
-      assert(buffer != NULL);
+      assert(buffer != nullptr);
       TSIOBufferDestroy(buffer);
     }
 
-    IO(void) : buffer(TSIOBufferCreate()), reader(TSIOBufferReaderAlloc(buffer)), vio(NULL) {}
-    IO(const TSIOBuffer &b) : buffer(b), reader(TSIOBufferReaderAlloc(buffer)), vio(NULL) { assert(buffer != NULL); }
+    IO(void) : buffer(TSIOBufferCreate()), reader(TSIOBufferReaderAlloc(buffer)), vio(nullptr) {}
+    IO(const TSIOBuffer &b) : buffer(b), reader(TSIOBufferReaderAlloc(buffer)), vio(nullptr) { assert(buffer != nullptr); }
     static IO *read(TSVConn, TSCont, const int64_t);
 
     static IO *
@@ -90,7 +90,7 @@ namespace io
 
     ReaderSize(const TSIOBufferReader r, const size_t s, const size_t o = 0) : reader(r), offset(o), size(s)
     {
-      assert(reader != NULL);
+      assert(reader != nullptr);
     }
 
     ReaderSize(const ReaderSize &) = delete;
@@ -102,7 +102,7 @@ namespace io
     const TSIOBufferReader reader;
     const size_t offset;
 
-    ReaderOffset(const TSIOBufferReader r, const size_t o) : reader(r), offset(o) { assert(reader != NULL); }
+    ReaderOffset(const TSIOBufferReader r, const size_t o) : reader(r), offset(o) { assert(reader != nullptr); }
     ReaderOffset(const ReaderOffset &) = delete;
     ReaderOffset &operator=(const ReaderOffset &) = delete;
     void *operator new(const std::size_t)         = delete;
@@ -118,23 +118,23 @@ namespace io
 
     ~Lock()
     {
-      if (mutex_ != NULL) {
+      if (mutex_ != nullptr) {
         TSMutexUnlock(mutex_);
       }
     }
 
     Lock(const TSMutex m) : mutex_(m)
     {
-      if (mutex_ != NULL) {
+      if (mutex_ != nullptr) {
         TSMutexLock(mutex_);
       }
     }
 
     // noncopyable
-    Lock(void) : mutex_(NULL) {}
+    Lock(void) : mutex_(nullptr) {}
     Lock(const Lock &) = delete;
 
-    Lock(Lock &&l) : mutex_(l.mutex_) { const_cast<TSMutex &>(l.mutex_) = NULL; }
+    Lock(Lock &&l) : mutex_(l.mutex_) { const_cast<TSMutex &>(l.mutex_) = nullptr; }
     Lock &operator=(const Lock &) = delete;
   };
 
@@ -151,7 +151,7 @@ namespace io
     bool reenable_;
 
     static int Handle(TSCont, TSEvent, void *);
-    static WriteOperationWeakPointer Create(const TSVConn, const TSMutex mutex = NULL, const size_t timeout = 0);
+    static WriteOperationWeakPointer Create(const TSVConn, const TSMutex mutex = nullptr, const size_t timeout = 0);
 
     ~WriteOperation();
 
@@ -243,16 +243,16 @@ namespace io
 
     ~BufferNode()
     {
-      assert(reader_ != NULL);
+      assert(reader_ != nullptr);
       TSIOBufferReaderFree(reader_);
-      assert(buffer_ != NULL);
+      assert(buffer_ != nullptr);
       TSIOBufferDestroy(buffer_);
     }
 
     BufferNode(void) : buffer_(TSIOBufferCreate()), reader_(TSIOBufferReaderAlloc(buffer_))
     {
-      assert(buffer_ != NULL);
-      assert(reader_ != NULL);
+      assert(buffer_ != nullptr);
+      assert(reader_ != nullptr);
     }
 
     // noncopyable
@@ -299,7 +299,7 @@ namespace io
     {
       if (data_) {
         const Lock lock = data_->root_->lock();
-        assert(data_->root_ != NULL);
+        assert(data_->root_ != nullptr);
         const bool empty = data_->nodes_.empty();
         if (data_->first_ && empty) {
           // TSDebug(PLUGIN_TAG, "flushing");
@@ -307,15 +307,15 @@ namespace io
           *data_->root_ << std::forward<T>(t);
         } else {
           // TSDebug(PLUGIN_TAG, "buffering");
-          BufferNode *buffer = NULL;
+          BufferNode *buffer = nullptr;
           if (!empty) {
             buffer = dynamic_cast<BufferNode *>(data_->nodes_.back().get());
           }
-          if (buffer == NULL) {
+          if (buffer == nullptr) {
             data_->nodes_.emplace_back(new BufferNode());
             buffer = reinterpret_cast<BufferNode *>(data_->nodes_.back().get());
           }
-          assert(buffer != NULL);
+          assert(buffer != nullptr);
           *buffer << std::forward<T>(t);
         }
       }

--- a/plugins/experimental/inliner/vconnection.h
+++ b/plugins/experimental/inliner/vconnection.h
@@ -42,9 +42,9 @@ namespace io
 
       Read(TSVConn v, T &&t, const int64_t s) : vconnection_(v), t_(std::forward<T>(t))
       {
-        assert(vconnection_ != NULL);
-        TSCont continuation = TSContCreate(Self::handleRead, NULL);
-        assert(continuation != NULL);
+        assert(vconnection_ != nullptr);
+        TSCont continuation = TSContCreate(Self::handleRead, nullptr);
+        assert(continuation != nullptr);
         TSContDataSet(continuation, this);
         in_.vio = TSVConnRead(vconnection_, continuation, in_.buffer, s);
       }
@@ -52,9 +52,9 @@ namespace io
       static void
       close(Self *const s)
       {
-        assert(s != NULL);
+        assert(s != nullptr);
         TSIOBufferReaderConsume(s->in_.reader, TSIOBufferReaderAvail(s->in_.reader));
-        assert(s->vconnection_ != NULL);
+        assert(s->vconnection_ != nullptr);
         TSVConnShutdown(s->vconnection_, 1, 1);
         TSVConnClose(s->vconnection_);
         delete s;
@@ -64,7 +64,7 @@ namespace io
       handleRead(TSCont c, TSEvent e, void *)
       {
         Self *const self = static_cast<Self *const>(TSContDataGet(c));
-        assert(self != NULL);
+        assert(self != nullptr);
         switch (e) {
         case TS_EVENT_VCONN_EOS:
         case TS_EVENT_VCONN_READ_COMPLETE:
@@ -77,7 +77,7 @@ namespace io
           if (e == TS_EVENT_VCONN_READ_COMPLETE || e == TS_EVENT_VCONN_EOS) {
             self->t_.done();
             close(self);
-            TSContDataSet(c, NULL);
+            TSContDataSet(c, nullptr);
             TSContDestroy(c);
           }
         } break;

--- a/plugins/experimental/money_trace/money_trace.h
+++ b/plugins/experimental/money_trace/money_trace.h
@@ -43,7 +43,7 @@
 struct MT {
   std::minstd_rand0 generator;
 
-  MT() { generator.seed(time(0)); }
+  MT() { generator.seed(time(nullptr)); }
   long
   spanId()
   {

--- a/plugins/experimental/mp4/mp4_common.h
+++ b/plugins/experimental/mp4/mp4_common.h
@@ -33,18 +33,18 @@
 class IOHandle
 {
 public:
-  IOHandle() : vio(NULL), buffer(NULL), reader(NULL){};
+  IOHandle() : vio(nullptr), buffer(nullptr), reader(nullptr){};
 
   ~IOHandle()
   {
     if (reader) {
       TSIOBufferReaderFree(reader);
-      reader = NULL;
+      reader = nullptr;
     }
 
     if (buffer) {
       TSIOBufferDestroy(buffer);
-      buffer = NULL;
+      buffer = nullptr;
     }
   }
 
@@ -103,13 +103,13 @@ public:
 class Mp4Context
 {
 public:
-  Mp4Context(float s) : start(s), cl(0), mtc(NULL), transform_added(false){};
+  Mp4Context(float s) : start(s), cl(0), mtc(nullptr), transform_added(false){};
 
   ~Mp4Context()
   {
     if (mtc) {
       delete mtc;
-      mtc = NULL;
+      mtc = nullptr;
     }
   }
 

--- a/plugins/experimental/mp4/mp4_meta.h
+++ b/plugins/experimental/mp4/mp4_meta.h
@@ -311,18 +311,18 @@ typedef struct {
 class BufferHandle
 {
 public:
-  BufferHandle() : buffer(NULL), reader(NULL){};
+  BufferHandle() : buffer(nullptr), reader(nullptr){};
 
   ~BufferHandle()
   {
     if (reader) {
       TSIOBufferReaderFree(reader);
-      reader = NULL;
+      reader = nullptr;
     }
 
     if (buffer) {
       TSIOBufferDestroy(buffer);
-      buffer = NULL;
+      buffer = nullptr;
     }
   }
 
@@ -426,12 +426,12 @@ public:
 
     if (meta_reader) {
       TSIOBufferReaderFree(meta_reader);
-      meta_reader = NULL;
+      meta_reader = nullptr;
     }
 
     if (meta_buffer) {
       TSIOBufferDestroy(meta_buffer);
-      meta_buffer = NULL;
+      meta_buffer = nullptr;
     }
   }
 

--- a/plugins/experimental/multiplexer/fetcher.h
+++ b/plugins/experimental/multiplexer/fetcher.h
@@ -112,12 +112,12 @@ template <class T> struct HttpTransaction {
     : parsingHeaders_(false),
       abort_(false),
       timeout_(false),
-      in_(NULL),
+      in_(nullptr),
       out_(i),
       vconnection_(v),
       continuation_(c),
       t_(t),
-      chunkDecoder_(NULL)
+      chunkDecoder_(nullptr)
   {
     assert(vconnection_ != NULL);
     assert(continuation_ != NULL);
@@ -157,14 +157,14 @@ template <class T> struct HttpTransaction {
   static bool
   isChunkEncoding(const TSMBuffer b, const TSMLoc l)
   {
-    assert(b != NULL);
-    assert(l != NULL);
+    assert(b != nullptr);
+    assert(l != nullptr);
     bool result        = false;
     const TSMLoc field = TSMimeHdrFieldFind(b, l, TS_MIME_FIELD_TRANSFER_ENCODING, TS_MIME_LEN_TRANSFER_ENCODING);
-    if (field != NULL) {
+    if (field != nullptr) {
       int length;
       const char *const value = TSMimeHdrFieldValueStringGet(b, l, field, -1, &length);
-      if (value != NULL && length == TS_HTTP_LEN_CHUNKED) {
+      if (value != nullptr && length == TS_HTTP_LEN_CHUNKED) {
         result = strncasecmp(value, TS_HTTP_VALUE_CHUNKED, TS_HTTP_LEN_CHUNKED) == 0;
       }
       TSHandleMLocRelease(b, l, field);
@@ -183,7 +183,7 @@ template <class T> struct HttpTransaction {
       self->t_.error();
       self->abort();
       close(self);
-      TSContDataSet(c, NULL);
+      TSContDataSet(c, nullptr);
       break;
     case TS_EVENT_VCONN_EOS:
       TSDebug(PLUGIN_TAG, "HttpTransaction: EOS");
@@ -229,14 +229,14 @@ template <class T> struct HttpTransaction {
       if (e == TS_EVENT_VCONN_READ_COMPLETE || e == TS_EVENT_VCONN_EOS) {
         self->t_.done();
         close(self);
-        TSContDataSet(c, NULL);
+        TSContDataSet(c, nullptr);
       } else if (self->chunkDecoder_ != NULL && self->chunkDecoder_->isEnd()) {
         assert(self->parsingHeaders_ == false);
         assert(isChunkEncoding(self->parser_.buffer_, self->parser_.location_));
         self->abort();
         self->t_.done();
         close(self);
-        TSContDataSet(c, NULL);
+        TSContDataSet(c, nullptr);
       } else {
         TSVIOReenable(self->in_->vio);
       }
@@ -265,7 +265,7 @@ template <class T> struct HttpTransaction {
       self->t_.timeout();
       self->abort();
       close(self);
-      TSContDataSet(c, NULL);
+      TSContDataSet(c, nullptr);
       break;
 
     default:
@@ -288,9 +288,9 @@ get(const std::string &a, io::IO *const i, const int64_t l, const T &t, const in
     return false;
   }
   TSVConn vconn = TSHttpConnect(reinterpret_cast<sockaddr *>(&socket));
-  assert(vconn != NULL);
+  assert(vconn != nullptr);
   TSCont contp = TSContCreate(Transaction::handle, TSMutexCreate());
-  assert(contp != NULL);
+  assert(contp != nullptr);
   Transaction *transaction = new Transaction(vconn, contp, i, l, t);
   TSContDataSet(contp, transaction);
   if (ti > 0) {

--- a/plugins/experimental/multiplexer/ts.h
+++ b/plugins/experimental/multiplexer/ts.h
@@ -41,8 +41,8 @@ namespace io
 
     ~IO()
     {
-      assert(buffer != NULL);
-      assert(reader != NULL);
+      assert(buffer != nullptr);
+      assert(reader != nullptr);
       const int64_t available = TSIOBufferReaderAvail(reader);
       if (available > 0) {
         TSIOBufferReaderConsume(reader, available);
@@ -51,8 +51,8 @@ namespace io
       TSIOBufferDestroy(buffer);
     }
 
-    IO(void) : buffer(TSIOBufferCreate()), reader(TSIOBufferReaderAlloc(buffer)), vio(NULL) {}
-    IO(const TSIOBuffer &b) : buffer(b), reader(TSIOBufferReaderAlloc(buffer)), vio(NULL) { assert(buffer != NULL); }
+    IO(void) : buffer(TSIOBufferCreate()), reader(TSIOBufferReaderAlloc(buffer)), vio(nullptr) {}
+    IO(const TSIOBuffer &b) : buffer(b), reader(TSIOBufferReaderAlloc(buffer)), vio(nullptr) { assert(buffer != nullptr); }
     static IO *read(TSVConn, TSCont, const int64_t);
 
     static IO *

--- a/plugins/experimental/ssl_cert_loader/domain-tree.h
+++ b/plugins/experimental/ssl_cert_loader/domain-tree.h
@@ -31,9 +31,9 @@ public:
   class DomainNameNode
   {
   public:
-    DomainNameNode() : order(-1), payload(NULL), parent(NULL), is_wild(false) {}
+    DomainNameNode() : order(-1), payload(nullptr), parent(nullptr), is_wild(false) {}
     DomainNameNode(std::string key, void *payload, int order, bool is_wild)
-      : key(key), order(order), payload(payload), parent(NULL), is_wild(is_wild)
+      : key(key), order(order), payload(payload), parent(nullptr), is_wild(is_wild)
     {
     }
 

--- a/plugins/header_rewrite/condition.h
+++ b/plugins/header_rewrite/condition.h
@@ -47,7 +47,7 @@ enum CondModifiers {
 class Condition : public Statement
 {
 public:
-  Condition() : _qualifier(""), _cond_op(MATCH_EQUAL), _matcher(NULL), _mods(COND_NONE)
+  Condition() : _qualifier(""), _cond_op(MATCH_EQUAL), _matcher(nullptr), _mods(COND_NONE)
   {
     TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for Condition");
   }

--- a/plugins/header_rewrite/conditions.h
+++ b/plugins/header_rewrite/conditions.h
@@ -180,7 +180,7 @@ private:
     const char *start, *last, *end;
 
     // Sanity
-    if (buf == NULL || name == NULL || value == NULL || value_len == NULL) {
+    if (buf == nullptr || name == nullptr || value == nullptr || value_len == nullptr) {
       return TS_ERROR;
     }
 

--- a/plugins/header_rewrite/matcher.h
+++ b/plugins/header_rewrite/matcher.h
@@ -43,7 +43,7 @@ enum MatcherOps {
 class Matcher
 {
 public:
-  explicit Matcher(const MatcherOps op) : _pdata(NULL), _op(op) { TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for Matcher"); }
+  explicit Matcher(const MatcherOps op) : _pdata(nullptr), _op(op) { TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for Matcher"); }
   virtual ~Matcher()
   {
     TSDebug(PLUGIN_NAME_DBG, "Calling DTOR for Matcher");
@@ -64,7 +64,7 @@ public:
   free_pdata()
   {
     TSfree(_pdata);
-    _pdata = NULL;
+    _pdata = nullptr;
   }
 
 protected:

--- a/plugins/header_rewrite/operator.h
+++ b/plugins/header_rewrite/operator.h
@@ -51,7 +51,7 @@ public:
   do_exec(const Resources &res) const
   {
     exec(res);
-    if (NULL != _next) {
+    if (nullptr != _next) {
       static_cast<Operator *>(_next)->do_exec(res);
     }
   }

--- a/plugins/header_rewrite/operators.h
+++ b/plugins/header_rewrite/operators.h
@@ -57,7 +57,7 @@ private:
 class OperatorSetStatus : public Operator
 {
 public:
-  OperatorSetStatus() : _reason(NULL), _reason_len(0) { TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for OperatorSetStatus"); }
+  OperatorSetStatus() : _reason(nullptr), _reason_len(0) { TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for OperatorSetStatus"); }
   void initialize(Parser &p);
 
 protected:

--- a/plugins/header_rewrite/regex_helper.h
+++ b/plugins/header_rewrite/regex_helper.h
@@ -32,7 +32,7 @@ const int OVECCOUNT = 30; // We support $1 - $9 only, and this needs to be 3x th
 class regexHelper
 {
 public:
-  regexHelper() : regex(NULL), regexExtra(NULL), regexCcount(0) {}
+  regexHelper() : regex(nullptr), regexExtra(nullptr), regexCcount(0) {}
   ~regexHelper()
   {
     pcre_free(regex);

--- a/plugins/header_rewrite/resources.h
+++ b/plugins/header_rewrite/resources.h
@@ -51,12 +51,12 @@ public:
   explicit Resources(TSHttpTxn txnptr, TSCont contptr)
     : txnp(txnptr),
       contp(contptr),
-      bufp(NULL),
-      hdr_loc(NULL),
-      client_bufp(NULL),
-      client_hdr_loc(NULL),
+      bufp(nullptr),
+      hdr_loc(nullptr),
+      client_bufp(nullptr),
+      client_hdr_loc(nullptr),
       resp_status(TS_HTTP_STATUS_NONE),
-      _rri(NULL),
+      _rri(nullptr),
       changed_url(false),
       _ready(false)
   {
@@ -65,11 +65,11 @@ public:
 
   Resources(TSHttpTxn txnptr, TSRemapRequestInfo *rri)
     : txnp(txnptr),
-      contp(NULL),
-      bufp(NULL),
-      hdr_loc(NULL),
-      client_bufp(NULL),
-      client_hdr_loc(NULL),
+      contp(nullptr),
+      bufp(nullptr),
+      hdr_loc(nullptr),
+      client_bufp(nullptr),
+      client_hdr_loc(nullptr),
       resp_status(TS_HTTP_STATUS_NONE),
       _rri(rri),
       changed_url(false),

--- a/plugins/header_rewrite/ruleset.h
+++ b/plugins/header_rewrite/ruleset.h
@@ -36,9 +36,9 @@ class RuleSet
 {
 public:
   RuleSet()
-    : next(NULL),
-      _cond(NULL),
-      _oper(NULL),
+    : next(nullptr),
+      _cond(nullptr),
+      _oper(nullptr),
       _hook(TS_HTTP_READ_RESPONSE_HDR_HOOK),
       _ids(RSRC_NONE),
       _opermods(OPER_NONE),
@@ -53,13 +53,13 @@ public:
   bool
   has_operator() const
   {
-    return NULL != _oper;
+    return nullptr != _oper;
   }
 
   bool
   has_condition() const
   {
-    return NULL != _cond;
+    return nullptr != _cond;
   }
 
   void
@@ -83,7 +83,7 @@ public:
   bool
   eval(const Resources &res) const
   {
-    if (NULL == _cond) {
+    if (nullptr == _cond) {
       return true;
     } else {
       return _cond->do_eval(res);

--- a/plugins/header_rewrite/statement.h
+++ b/plugins/header_rewrite/statement.h
@@ -96,7 +96,7 @@ enum NetworkSessionQualifiers {
 class Statement
 {
 public:
-  Statement() : _next(NULL), _pdata(NULL), _rsrc(RSRC_NONE), _initialized(false), _hook(TS_HTTP_READ_RESPONSE_HDR_HOOK)
+  Statement() : _next(nullptr), _pdata(nullptr), _rsrc(RSRC_NONE), _initialized(false), _hook(TS_HTTP_READ_RESPONSE_HDR_HOOK)
   {
     TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for Statement");
   }
@@ -124,7 +124,7 @@ public:
   free_pdata()
   {
     TSfree(_pdata);
-    _pdata = NULL;
+    _pdata = nullptr;
   }
 
   // Which hook are we adding this statement to?

--- a/plugins/header_rewrite/value.h
+++ b/plugins/header_rewrite/value.h
@@ -40,7 +40,7 @@
 class Value : Statement
 {
 public:
-  Value() : _need_expander(false), _value(""), _int_value(0), _float_value(0.0), _cond_val(NULL)
+  Value() : _need_expander(false), _value(""), _int_value(0), _float_value(0.0), _cond_val(nullptr)
   {
     TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for Value");
   }
@@ -61,8 +61,8 @@ public:
       // TODO: This is still not optimal, we should pre-parse the _value string here,
       // and perhaps populate a per-Value VariableExpander that holds state.
     } else {
-      _int_value   = strtol(_value.c_str(), NULL, 10);
-      _float_value = strtod(_value.c_str(), NULL);
+      _int_value   = strtol(_value.c_str(), nullptr, 10);
+      _float_value = strtod(_value.c_str(), nullptr);
     }
   }
 

--- a/proxy/CacheControl.h
+++ b/proxy/CacheControl.h
@@ -137,7 +137,7 @@ struct HttpConfigParams;
 struct OverridableHttpConfigParams;
 
 inkcoreapi void getCacheControl(CacheControlResult *result, HttpRequestData *rdata, OverridableHttpConfigParams *h_txn_conf,
-                                char *tag = NULL);
+                                char *tag = nullptr);
 inkcoreapi bool host_rule_in_CacheControlTable();
 inkcoreapi bool ip_rule_in_CacheControlTable();
 

--- a/proxy/ControlMatcher.h
+++ b/proxy/ControlMatcher.h
@@ -138,15 +138,15 @@ public:
   inkcoreapi sockaddr const *get_client_ip();
 
   HttpRequestData()
-    : hdr(NULL),
-      hostname_str(NULL),
-      api_info(NULL),
+    : hdr(nullptr),
+      hostname_str(nullptr),
+      api_info(nullptr),
       xact_start(0),
       incoming_port(0),
-      tag(NULL),
+      tag(nullptr),
       internal_txn(false),
-      cache_info_lookup_url(NULL),
-      cache_info_parent_selection_url(NULL)
+      cache_info_lookup_url(nullptr),
+      cache_info_parent_selection_url(nullptr)
   {
     ink_zero(src_ip);
     ink_zero(dest_ip);

--- a/proxy/EventName.h
+++ b/proxy/EventName.h
@@ -32,4 +32,4 @@
 
 #include <unistd.h>
 
-const char *event_int_to_string(int event, int blen = 0, char *buffer = NULL);
+const char *event_int_to_string(int event, int blen = 0, char *buffer = nullptr);

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -9404,7 +9404,7 @@ extern SSLSessionCache *session_cache; // declared extern in P_SSLConfig.h
 TSSslSession
 TSSslSessionGet(const TSSslSessionID *session_id)
 {
-  SSL_SESSION *session = NULL;
+  SSL_SESSION *session = nullptr;
   if (session_id && session_cache) {
     session_cache->getSession(reinterpret_cast<const SSLSessionID &>(*session_id), &session);
   }

--- a/proxy/InkAPIInternal.h
+++ b/proxy/InkAPIInternal.h
@@ -62,7 +62,7 @@ struct CacheInfo {
   CacheInfo()
   {
     frag_type    = CACHE_FRAG_TYPE_NONE;
-    hostname     = NULL;
+    hostname     = nullptr;
     len          = 0;
     pin_in_cache = 0;
     magic        = CACHE_INFO_MAGIC_ALIVE;
@@ -144,13 +144,13 @@ private:
 inline bool
 APIHooks::is_empty() const
 {
-  return NULL == m_hooks.head;
+  return nullptr == m_hooks.head;
 }
 
 inline void
 APIHooks::invoke(int event, void *data)
 {
-  for (APIHook *hook = m_hooks.head; NULL != hook; hook = hook->next())
+  for (APIHook *hook = m_hooks.head; nullptr != hook; hook = hook->next())
     hook->invoke(event, data);
 }
 
@@ -245,7 +245,7 @@ template <typename ID, ID N>
 APIHook *
 FeatureAPIHooks<ID, N>::get(ID id) const
 {
-  return likely(is_valid(id)) ? m_hooks[id].get() : NULL;
+  return likely(is_valid(id)) ? m_hooks[id].get() : nullptr;
 }
 
 template <typename ID, ID N>
@@ -311,11 +311,11 @@ public:
       if (!trylock.is_locked()) {
         eventProcessor.schedule_in(this, HRTIME_MSECONDS(10), ET_TASK);
       } else {
-        m_cont->handleEvent(TS_EVENT_MGMT_UPDATE, NULL);
+        m_cont->handleEvent(TS_EVENT_MGMT_UPDATE, nullptr);
         delete this;
       }
     } else {
-      m_cont->handleEvent(TS_EVENT_MGMT_UPDATE, NULL);
+      m_cont->handleEvent(TS_EVENT_MGMT_UPDATE, nullptr);
       delete this;
     }
 

--- a/proxy/InkAPITestTool.cc
+++ b/proxy/InkAPITestTool.cc
@@ -171,7 +171,7 @@ static char *
 get_body_ptr(const char *request)
 {
   char *ptr = (char *)strstr((const char *)request, (const char *)"\r\n\r\n");
-  return (ptr != NULL) ? (ptr + 4) : NULL;
+  return (ptr != nullptr) ? (ptr + 4) : nullptr;
 }
 
 /* Caller must free returned request */
@@ -488,7 +488,7 @@ synclient_txn_create(void)
 
   ink_zero(*txn);
 
-  if (0 == (proxy_port = HttpProxyPort::findHttp(AF_INET)))
+  if (nullptr == (proxy_port = HttpProxyPort::findHttp(AF_INET)))
     txn->connect_port = PROXY_HTTP_DEFAULT_PORT;
   else
     txn->connect_port = proxy_port->m_port;
@@ -507,7 +507,7 @@ synclient_txn_delete(ClientTxn *txn)
   TSAssert(txn->magic == MAGIC_ALIVE);
   if (txn->connect_action && !TSActionDone(txn->connect_action)) {
     TSActionCancel(txn->connect_action);
-    txn->connect_action = NULL;
+    txn->connect_action = nullptr;
   }
 
   ats_free(txn->request);
@@ -520,19 +520,19 @@ static void
 synclient_txn_close(ClientTxn *txn)
 {
   if (txn) {
-    if (txn->vconn != NULL) {
+    if (txn->vconn != nullptr) {
       TSVConnClose(txn->vconn);
-      txn->vconn = NULL;
+      txn->vconn = nullptr;
     }
 
-    if (txn->req_buffer != NULL) {
+    if (txn->req_buffer != nullptr) {
       TSIOBufferDestroy(txn->req_buffer);
-      txn->req_buffer = NULL;
+      txn->req_buffer = nullptr;
     }
 
-    if (txn->resp_buffer != NULL) {
+    if (txn->resp_buffer != nullptr) {
       TSIOBufferDestroy(txn->resp_buffer);
-      txn->resp_buffer = NULL;
+      txn->resp_buffer = nullptr;
     }
 
     TSDebug(CDBG_TAG, "Client Txn destroyed");
@@ -580,7 +580,7 @@ synclient_txn_read_response(TSCont contp)
   TSAssert(txn->magic == MAGIC_ALIVE);
 
   TSIOBufferBlock block = TSIOBufferReaderStart(txn->resp_reader);
-  while (block != NULL) {
+  while (block != nullptr) {
     int64_t blocklen;
     const char *blockptr = TSIOBufferBlockReadStart(block, txn->resp_reader, &blocklen);
 
@@ -746,8 +746,8 @@ synclient_txn_connect_handler(TSCont contp, TSEvent event, void *data)
     txn->vconn      = (TSVConn)data;
     txn->local_port = (int)((NetVConnection *)data)->get_local_port();
 
-    txn->write_vio = NULL;
-    txn->read_vio  = NULL;
+    txn->write_vio = nullptr;
+    txn->read_vio  = nullptr;
 
     /* start writing */
     SET_TEST_HANDLER(txn->current_handler, synclient_txn_write_request_handler);
@@ -789,7 +789,7 @@ synserver_create(int port, TSCont cont)
   SocketServer *s  = (SocketServer *)TSmalloc(sizeof(SocketServer));
   s->magic         = MAGIC_ALIVE;
   s->accept_port   = port;
-  s->accept_action = NULL;
+  s->accept_action = nullptr;
   s->accept_cont   = cont;
   TSContDataSet(s->accept_cont, s);
   return s;
@@ -805,7 +805,7 @@ static int
 synserver_start(SocketServer *s)
 {
   TSAssert(s->magic == MAGIC_ALIVE);
-  TSAssert(s->accept_action == NULL);
+  TSAssert(s->accept_action == nullptr);
 
   if (s->accept_port != SYNSERVER_DUMMY_PORT) {
     TSAssert(s->accept_port > 0);
@@ -823,7 +823,7 @@ synserver_stop(SocketServer *s)
   TSAssert(s->magic == MAGIC_ALIVE);
   if (s->accept_action && !TSActionDone(s->accept_action)) {
     TSActionCancel(s->accept_action);
-    s->accept_action = NULL;
+    s->accept_action = nullptr;
     TSDebug(SDBG_TAG, "Had to cancel action");
   }
   TSDebug(SDBG_TAG, "stopped");
@@ -833,13 +833,13 @@ synserver_stop(SocketServer *s)
 static int
 synserver_delete(SocketServer *s)
 {
-  if (s != NULL) {
+  if (s != nullptr) {
     TSAssert(s->magic == MAGIC_ALIVE);
     synserver_stop(s);
 
     if (s->accept_cont) {
       TSContDestroy(s->accept_cont);
-      s->accept_cont = NULL;
+      s->accept_cont = nullptr;
       TSDebug(SDBG_TAG, "destroyed accept cont");
     }
 
@@ -909,7 +909,7 @@ synserver_vc_accept(TSCont contp, TSEvent event, void *data)
 
   txn->vconn = (TSVConn)data;
 
-  txn->write_vio = NULL;
+  txn->write_vio = nullptr;
 
   /* start reading */
   txn->read_vio = TSVConnRead(txn->vconn, txn_cont, txn->req_buffer, INT64_MAX);
@@ -923,7 +923,7 @@ synserver_txn_close(TSCont contp)
   ServerTxn *txn = (ServerTxn *)TSContDataGet(contp);
   TSAssert(txn->magic == MAGIC_ALIVE);
 
-  if (txn->vconn != NULL) {
+  if (txn->vconn != nullptr) {
     TSVConnClose(txn->vconn);
   }
   if (txn->req_buffer) {
@@ -1023,7 +1023,7 @@ synserver_txn_read_request(TSCont contp)
   int end;
   TSIOBufferBlock block = TSIOBufferReaderStart(txn->req_reader);
 
-  while (block != NULL) {
+  while (block != nullptr) {
     int64_t blocklen;
     const char *blockptr = TSIOBufferBlockReadStart(block, txn->req_reader, &blocklen);
 
@@ -1040,7 +1040,7 @@ synserver_txn_read_request(TSCont contp)
   txn->request[txn->request_len] = '\0';
   TSDebug(SDBG_TAG, "Request = |%s|, req len = %d", txn->request, txn->request_len);
 
-  end = (strstr(txn->request, HTTP_REQUEST_END) != NULL);
+  end = (strstr(txn->request, HTTP_REQUEST_END) != nullptr);
   TSDebug(SDBG_TAG, "End of request = %d", end);
 
   return end;

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -1841,7 +1841,7 @@ main(int /* argc ATS_UNUSED */, const char **argv)
     // Translate string to IpAddr
     set_debug_ip(p);
   }
-  REC_RegisterConfigUpdateFunc("proxy.config.diags.debug.client_ip", update_debug_client_ip, NULL);
+  REC_RegisterConfigUpdateFunc("proxy.config.diags.debug.client_ip", update_debug_client_ip, nullptr);
 
   // log initialization moved down
 

--- a/proxy/ParentSelection.h
+++ b/proxy/ParentSelection.h
@@ -178,7 +178,7 @@ struct ParentResult {
   bool
   is_some() const
   {
-    if (rec == NULL) {
+    if (rec == nullptr) {
       // If we don't have a result, we either haven't done a parent
       // lookup yet (PARENT_UNDEFINED), or the lookup didn't match
       // anything (PARENT_DIRECT).
@@ -313,7 +313,7 @@ public:
   selectParent(bool firstCall, ParentResult *result, RequestData *rdata, unsigned int fail_threshold, unsigned int retry_time)
   {
     if (!result->is_api_result()) {
-      ink_release_assert(result->rec->selection_strategy != NULL);
+      ink_release_assert(result->rec->selection_strategy != nullptr);
       return result->rec->selection_strategy->selectParent(firstCall, result, rdata, fail_threshold, retry_time);
     }
   }
@@ -322,7 +322,7 @@ public:
   markParentDown(ParentResult *result, unsigned int fail_threshold, unsigned int retry_time)
   {
     if (!result->is_api_result()) {
-      ink_release_assert(result->rec->selection_strategy != NULL);
+      ink_release_assert(result->rec->selection_strategy != nullptr);
       result->rec->selection_strategy->markParentDown(result, fail_threshold, retry_time);
     }
   }
@@ -331,7 +331,7 @@ public:
   markParentUp(ParentResult *result)
   {
     if (!result->is_api_result()) {
-      ink_release_assert(result != NULL);
+      ink_release_assert(result != nullptr);
       result->rec->selection_strategy->markParentUp(result);
     }
   }
@@ -342,7 +342,7 @@ public:
     if (result->is_api_result()) {
       return 1;
     } else {
-      ink_release_assert(result->rec->selection_strategy != NULL);
+      ink_release_assert(result->rec->selection_strategy != nullptr);
       return result->rec->selection_strategy->numParents(result);
     }
   }
@@ -384,7 +384,7 @@ int parentSelection_CB(const char *name, RecDataT data_type, RecData data, void 
 
 // Unit Test Functions
 void show_result(ParentResult *aParentResult);
-void br(HttpRequestData *h, const char *os_hostname, sockaddr const *dest_ip = NULL); // short for build request
+void br(HttpRequestData *h, const char *os_hostname, sockaddr const *dest_ip = nullptr); // short for build request
 int verify(ParentResult *r, ParentResultType e, const char *h, int p);
 
 /*

--- a/proxy/Plugin.h
+++ b/proxy/Plugin.h
@@ -73,7 +73,7 @@ public:
   virtual char const *
   getPluginTag() const
   {
-    return NULL;
+    return nullptr;
   }
   /** Get the plugin instance ID.
       A plugin can create multiple subsidiary instances. This is used as the

--- a/proxy/PluginVC.h
+++ b/proxy/PluginVC.h
@@ -76,9 +76,10 @@ public:
   PluginVC(PluginVCCore *core_obj);
   ~PluginVC();
 
-  virtual VIO *do_io_read(Continuation *c = NULL, int64_t nbytes = INT64_MAX, MIOBuffer *buf = 0);
+  virtual VIO *do_io_read(Continuation *c = nullptr, int64_t nbytes = INT64_MAX, MIOBuffer *buf = nullptr);
 
-  virtual VIO *do_io_write(Continuation *c = NULL, int64_t nbytes = INT64_MAX, IOBufferReader *buf = 0, bool owner = false);
+  virtual VIO *do_io_write(Continuation *c = nullptr, int64_t nbytes = INT64_MAX, IOBufferReader *buf = nullptr,
+                           bool owner = false);
 
   virtual void do_io_close(int lerrno = -1);
   virtual void do_io_shutdown(ShutdownHowTo_t howto);
@@ -265,14 +266,14 @@ private:
 inline PluginVCCore::PluginVCCore()
   : active_vc(this),
     passive_vc(this),
-    connect_to(NULL),
+    connect_to(nullptr),
     connected(false),
-    p_to_a_buffer(NULL),
-    p_to_a_reader(NULL),
-    a_to_p_buffer(NULL),
-    a_to_p_reader(NULL),
-    passive_data(NULL),
-    active_data(NULL),
+    p_to_a_buffer(nullptr),
+    p_to_a_reader(nullptr),
+    a_to_p_buffer(nullptr),
+    a_to_p_reader(nullptr),
+    passive_data(nullptr),
+    active_data(nullptr),
     id(0)
 {
   memset(&active_addr_struct, 0, sizeof active_addr_struct);

--- a/proxy/ProtocolProbeSessionAccept.h
+++ b/proxy/ProtocolProbeSessionAccept.h
@@ -39,7 +39,7 @@ struct ProtocolProbeSessionAcceptEnums {
 class ProtocolProbeSessionAccept : public SessionAccept, public ProtocolProbeSessionAcceptEnums
 {
 public:
-  ProtocolProbeSessionAccept() : SessionAccept(NULL)
+  ProtocolProbeSessionAccept() : SessionAccept(nullptr)
   {
     memset(endpoint, 0, sizeof(endpoint));
     SET_HANDLER(&ProtocolProbeSessionAccept::mainEvent);

--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -192,7 +192,7 @@ public:
   virtual HttpServerSession *
   get_server_session() const
   {
-    return NULL;
+    return nullptr;
   }
 
   TSHttpHookID
@@ -219,7 +219,7 @@ public:
   bool
   is_client_closed() const
   {
-    return get_netvc() == NULL;
+    return get_netvc() == nullptr;
   }
 
   virtual int

--- a/proxy/ProxyClientTransaction.h
+++ b/proxy/ProxyClientTransaction.h
@@ -40,7 +40,7 @@ public:
   virtual NetVConnection *
   get_netvc() const
   {
-    return (parent) ? parent->get_netvc() : NULL;
+    return (parent) ? parent->get_netvc() : nullptr;
   }
 
   virtual void set_active_timeout(ink_hrtime timeout_in)     = 0;
@@ -106,7 +106,7 @@ public:
   APIHook *
   ssn_hook_get(TSHttpHookID id) const
   {
-    return parent ? parent->ssn_hook_get(id) : NULL;
+    return parent ? parent->ssn_hook_get(id) : nullptr;
   }
 
   bool
@@ -146,7 +146,7 @@ public:
   const AclRecord *
   get_acl_record() const
   {
-    return parent ? parent->acl_record : NULL;
+    return parent ? parent->acl_record : nullptr;
   }
 
   // Indicate we are done with this transaction
@@ -225,7 +225,7 @@ public:
   HttpServerSession *
   get_server_session() const
   {
-    return parent ? parent->get_server_session() : NULL;
+    return parent ? parent->get_server_session() : nullptr;
   }
 
   HttpSM *
@@ -239,7 +239,7 @@ public:
   virtual const char *
   get_protocol_string()
   {
-    return parent ? parent->get_protocol_string() : NULL;
+    return parent ? parent->get_protocol_string() : nullptr;
   }
 
   void

--- a/proxy/RegressionSM.h
+++ b/proxy/RegressionSM.h
@@ -68,7 +68,7 @@ struct RegressionSM : public Continuation {
   void child_done(int status);
   void xrun(RegressionSM *parent);
 
-  RegressionSM(RegressionTest *at = NULL) : t(at) { mutex = new_ProxyMutex(); }
+  RegressionSM(RegressionTest *at = nullptr) : t(at) { mutex = new_ProxyMutex(); }
 
   RegressionSM(const RegressionSM &);
 };

--- a/proxy/Show.h
+++ b/proxy/Show.h
@@ -91,10 +91,10 @@ public:
     if (!action.cancelled) {
       StatPageData data(start, buf - start);
       action.continuation->handleEvent(STAT_PAGE_SUCCESS, &data);
-      start = 0;
+      start = nullptr;
     } else {
       ats_free(start);
-      start = NULL;
+      start = nullptr;
     }
     return done(VIO::CLOSE, event, e);
   }
@@ -116,9 +116,9 @@ public:
   complete_error(int event, Event *e)
   {
     ats_free(start);
-    start = NULL;
+    start = nullptr;
     if (!action.cancelled)
-      action.continuation->handleEvent(STAT_PAGE_FAILURE, NULL);
+      action.continuation->handleEvent(STAT_PAGE_FAILURE, nullptr);
     return done(VIO::ABORT, event, e);
   }
 
@@ -144,7 +144,7 @@ public:
     return EVENT_DONE;
   }
 
-  ShowCont(Continuation *c, HTTPHdr * /* h ATS_UNUSED */) : Continuation(NULL), sarg(0)
+  ShowCont(Continuation *c, HTTPHdr * /* h ATS_UNUSED */) : Continuation(nullptr), sarg(nullptr)
   {
     size_t sz = ats_pagesize();
 

--- a/proxy/StatPages.h
+++ b/proxy/StatPages.h
@@ -68,9 +68,9 @@ struct StatPageData {
   char *type;
   int length;
 
-  StatPageData() : data(NULL), type(NULL), length(0) {}
-  StatPageData(char *adata) : data(adata), type(NULL) { length = strlen(adata); }
-  StatPageData(char *adata, int alength) : data(adata), type(NULL), length(alength) {}
+  StatPageData() : data(nullptr), type(nullptr), length(0) {}
+  StatPageData(char *adata) : data(adata), type(nullptr) { length = strlen(adata); }
+  StatPageData(char *adata, int alength) : data(adata), type(nullptr), length(alength) {}
 };
 
 struct StatPagesManager {
@@ -93,7 +93,7 @@ inkcoreapi extern StatPagesManager statPagesManager;
 class BaseStatPagesHandler : public Continuation
 {
 public:
-  BaseStatPagesHandler(ProxyMutex *amutex) : Continuation(amutex), response(NULL), response_size(0), response_length(0){};
+  BaseStatPagesHandler(ProxyMutex *amutex) : Continuation(amutex), response(nullptr), response_size(0), response_length(0){};
   ~BaseStatPagesHandler() { resp_clear(); };
 
 protected:
@@ -112,7 +112,7 @@ protected:
   inkcoreapi void resp_end_table();
   inkcoreapi void resp_begin_row();
   inkcoreapi void resp_end_row();
-  inkcoreapi void resp_begin_column(int percent = -1, const char *align = NULL);
+  inkcoreapi void resp_begin_column(int percent = -1, const char *align = nullptr);
   inkcoreapi void resp_end_column();
 
   char *response;

--- a/proxy/hdrs/HTTP.h
+++ b/proxy/hdrs/HTTP.h
@@ -538,15 +538,15 @@ public:
       and invoking @c URL::string_get if the host is in a header
       field and not explicitly in the URL.
    */
-  char *url_string_get(Arena *arena = 0, ///< Arena to use, or @c malloc if NULL.
-                       int *length  = 0  ///< Store string length here.
+  char *url_string_get(Arena *arena = nullptr, ///< Arena to use, or @c malloc if NULL.
+                       int *length  = nullptr  ///< Store string length here.
                        );
   /** Get a string with the effective URL in it.
       This is automatically allocated if needed in the request heap.
 
       @see url_string_get
    */
-  char *url_string_get_ref(int *length = 0 ///< Store string length here.
+  char *url_string_get_ref(int *length = nullptr ///< Store string length here.
                            );
 
   /** Print the URL.
@@ -571,7 +571,7 @@ public:
       @note The results are cached so this is fast after the first call.
       @return A pointer to the host name.
   */
-  const char *host_get(int *length = 0);
+  const char *host_get(int *length = nullptr);
 
   /** Get the target port.
       If the target port is not found then it is adjusted to the
@@ -604,7 +604,7 @@ public:
   /// If @a url is @c NULL the cached URL in this header is used.
   /// @note In the default case the copy is avoided if the cached URL already
   /// has the target. If @a url is non @c NULL the copy is always performed.
-  void set_url_target_from_host_field(URL *url = 0);
+  void set_url_target_from_host_field(URL *url = nullptr);
 
   /// Mark the target cache as invalid.
   /// @internal Ugly but too many places currently that touch the
@@ -1280,14 +1280,14 @@ inline const char *
 HTTPHdr::path_get(int *length)
 {
   URL *url = this->url_get();
-  return url ? url->path_get(length) : 0;
+  return url ? url->path_get(length) : nullptr;
 }
 
 inline const char *
 HTTPHdr::scheme_get(int *length)
 {
   URL *url = this->url_get();
-  return url ? url->scheme_get(length) : 0;
+  return url ? url->scheme_get(length) : nullptr;
 }
 
 /*-------------------------------------------------------------------------
@@ -1575,7 +1575,7 @@ HTTPInfo::object_size_set(int64_t size)
 inline HTTPInfo::FragOffset *
 HTTPInfo::get_frag_table()
 {
-  return m_alt ? m_alt->m_frag_offsets : 0;
+  return m_alt ? m_alt->m_frag_offsets : nullptr;
 }
 
 inline int

--- a/proxy/hdrs/HdrHeap.h
+++ b/proxy/hdrs/HdrHeap.h
@@ -220,14 +220,14 @@ public:
     // The move is necessary because the rest of the code assumes
     // heaps are always allocated in order.
     for (int j = 0; j < i; j++) {
-      if (m_ronly_heap[j].m_heap_start == NULL) {
+      if (m_ronly_heap[j].m_heap_start == nullptr) {
         // move slot i to slot j
         m_ronly_heap[j].m_ref_count_ptr = m_ronly_heap[i].m_ref_count_ptr;
         m_ronly_heap[j].m_heap_start    = m_ronly_heap[i].m_heap_start;
         m_ronly_heap[j].m_heap_len      = m_ronly_heap[i].m_heap_len;
         m_ronly_heap[j].m_locked        = m_ronly_heap[i].m_locked;
-        m_ronly_heap[i].m_ref_count_ptr = NULL;
-        m_ronly_heap[i].m_heap_start    = NULL;
+        m_ronly_heap[i].m_ref_count_ptr = nullptr;
+        m_ronly_heap[i].m_heap_start    = nullptr;
         m_ronly_heap[i].m_heap_len      = 0;
         m_ronly_heap[i].m_locked        = false;
       }
@@ -433,7 +433,7 @@ struct HeapCheck {
 //
 struct HdrHeapSDKHandle {
 public:
-  HdrHeapSDKHandle() : m_heap(NULL) {}
+  HdrHeapSDKHandle() : m_heap(nullptr) {}
   ~HdrHeapSDKHandle() { clear(); }
   // clear() only deallocates chained SDK return values
   //   The underlying MBuffer is left untouched
@@ -466,7 +466,7 @@ HdrHeapSDKHandle::destroy()
 inline void
 HdrHeapSDKHandle::clear()
 {
-  m_heap = NULL;
+  m_heap = nullptr;
 }
 
 inline void

--- a/proxy/hdrs/HdrTest.h
+++ b/proxy/hdrs/HdrTest.h
@@ -41,7 +41,7 @@ class HdrTest
 public:
   RegressionTest *rtest;
 
-  HdrTest() : rtest(NULL){};
+  HdrTest() : rtest(nullptr){};
   ~HdrTest(){};
 
   int go(RegressionTest *t, int atype);

--- a/proxy/hdrs/HdrToken.h
+++ b/proxy/hdrs/HdrToken.h
@@ -108,8 +108,8 @@ extern uint32_t hdrtoken_str_flags[];
 ////////////////////////////////////////////////////////////////////////////
 
 extern void hdrtoken_init();
-extern int hdrtoken_tokenize_dfa(const char *string, int string_len, const char **wks_string_out = NULL);
-inkcoreapi extern int hdrtoken_tokenize(const char *string, int string_len, const char **wks_string_out = NULL);
+extern int hdrtoken_tokenize_dfa(const char *string, int string_len, const char **wks_string_out = nullptr);
+inkcoreapi extern int hdrtoken_tokenize(const char *string, int string_len, const char **wks_string_out = nullptr);
 extern const char *hdrtoken_string_to_wks(const char *string);
 extern const char *hdrtoken_string_to_wks(const char *string, int length);
 

--- a/proxy/hdrs/HdrUtils.h
+++ b/proxy/hdrs/HdrUtils.h
@@ -43,15 +43,15 @@ public:
   // MIME standard separator ',' is used as the default value
   // Set-cookie/Cookie uses ';'
   HdrCsvIter(const char s = ',')
-    : m_value_start(NULL),
+    : m_value_start(nullptr),
       m_value_len(0),
       m_bytes_consumed(0),
       m_follow_dups(false),
-      m_csv_start(NULL),
+      m_csv_start(nullptr),
       m_csv_len(0),
-      m_csv_end(NULL),
+      m_csv_end(nullptr),
       m_csv_index(0),
-      m_cur_field(NULL),
+      m_cur_field(nullptr),
       m_separator(s)
   {
   }
@@ -64,8 +64,8 @@ public:
 
   int get_index();
 
-  int get_first_int(MIMEField *m, int *valid = NULL);
-  int get_next_int(int *valid = NULL);
+  int get_first_int(MIMEField *m, int *valid = nullptr);
+  int get_next_int(int *valid = nullptr);
 
 private:
   void find_csv();

--- a/proxy/hdrs/MIME.h
+++ b/proxy/hdrs/MIME.h
@@ -267,7 +267,7 @@ struct MIMEHdrImpl : public HdrHeapObjImpl {
   void check_strings(HeapCheck *heaps, int num_heaps);
 
   // Cooked values
-  void recompute_cooked_stuff(MIMEField *changing_field_or_null = NULL);
+  void recompute_cooked_stuff(MIMEField *changing_field_or_null = nullptr);
   void recompute_accelerators_and_presence_bits();
 };
 
@@ -621,7 +621,7 @@ void mime_init_date_format_table();
 
 MIMEHdrImpl *mime_hdr_create(HdrHeap *heap);
 void _mime_hdr_field_block_init(MIMEFieldBlockImpl *fblock);
-void mime_hdr_cooked_stuff_init(MIMEHdrImpl *mh, MIMEField *changing_field_or_null = NULL);
+void mime_hdr_cooked_stuff_init(MIMEHdrImpl *mh, MIMEField *changing_field_or_null = nullptr);
 void mime_hdr_init(MIMEHdrImpl *mh);
 MIMEFieldBlockImpl *_mime_field_block_copy(MIMEFieldBlockImpl *s_fblock, HdrHeap *s_heap, HdrHeap *d_heap);
 void _mime_field_block_destroy(HdrHeap *heap, MIMEFieldBlockImpl *fblock);
@@ -721,11 +721,11 @@ void mime_days_since_epoch_to_mdy_slowcase(unsigned int days_since_jan_1_1970, i
 void mime_days_since_epoch_to_mdy(unsigned int days_since_jan_1_1970, int *m_return, int *d_return, int *y_return);
 int mime_format_date(char *buffer, time_t value);
 
-int32_t mime_parse_int(const char *buf, const char *end = NULL);
-uint32_t mime_parse_uint(const char *buf, const char *end = NULL);
-int64_t mime_parse_int64(const char *buf, const char *end = NULL);
+int32_t mime_parse_int(const char *buf, const char *end = nullptr);
+uint32_t mime_parse_uint(const char *buf, const char *end = nullptr);
+int64_t mime_parse_int64(const char *buf, const char *end = nullptr);
 int mime_parse_rfc822_date_fastcase(const char *buf, int length, struct tm *tp);
-time_t mime_parse_date(const char *buf, const char *end = NULL);
+time_t mime_parse_date(const char *buf, const char *end = nullptr);
 int mime_parse_day(const char *&buf, const char *end, int *day);
 int mime_parse_month(const char *&buf, const char *end, int *month);
 int mime_parse_mday(const char *&buf, const char *end, int *mday);
@@ -893,7 +893,7 @@ MIMEField::value_is_valid() const
 inline int
 MIMEField::has_dups() const
 {
-  return (m_next_dup != NULL);
+  return (m_next_dup != nullptr);
 }
 
 /***********************************************************************
@@ -903,7 +903,7 @@ MIMEField::has_dups() const
  ***********************************************************************/
 
 struct MIMEFieldIter {
-  MIMEFieldIter() : m_slot(0), m_block(NULL) {}
+  MIMEFieldIter() : m_slot(0), m_block(nullptr) {}
   uint32_t m_slot;
   MIMEFieldBlockImpl *m_block;
 };
@@ -926,7 +926,7 @@ public:
 
   int valid() const;
 
-  void create(HdrHeap *heap = NULL);
+  void create(HdrHeap *heap = nullptr);
   void copy(const MIMEHdr *hdr);
 
   int length_get();
@@ -934,7 +934,7 @@ public:
   void fields_clear();
   int fields_count();
 
-  MIMEField *field_create(const char *name = NULL, int length = -1);
+  MIMEField *field_create(const char *name = nullptr, int length = -1);
   MIMEField *field_find(const char *name, int length);
   const MIMEField *field_find(const char *name, int length) const;
   void field_attach(MIMEField *field);
@@ -1133,7 +1133,7 @@ MIMEHdr::field_find(const char *name, int length) const
 inline void
 MIMEHdr::field_attach(MIMEField *field)
 {
-  mime_hdr_field_attach(m_mime, field, 1, NULL);
+  mime_hdr_field_attach(m_mime, field, 1, nullptr);
 }
 
 /*-------------------------------------------------------------------------
@@ -1191,8 +1191,8 @@ MIMEHdr::iter_get(MIMEFieldIter *iter)
     slot = 0;
   }
 
-  iter->m_block = NULL;
-  return NULL;
+  iter->m_block = nullptr;
+  return nullptr;
 }
 
 inline MIMEField *
@@ -1259,7 +1259,7 @@ MIMEHdr::value_get(const char *name, int name_length, int *value_length_return) 
   if (field)
     return (mime_field_value_get(field, value_length_return));
   else
-    return (NULL);
+    return (nullptr);
 }
 
 inline int32_t

--- a/proxy/hdrs/URL.h
+++ b/proxy/hdrs/URL.h
@@ -245,9 +245,9 @@ public:
 
   int length_get();
   void clear_string_ref();
-  char *string_get(Arena *arena, int *length = NULL);
-  char *string_get_ref(int *length = NULL);
-  char *string_get_buf(char *dstbuf, int dsbuf_size, int *length = NULL);
+  char *string_get(Arena *arena, int *length = nullptr);
+  char *string_get_ref(int *length = nullptr);
+  char *string_get_buf(char *dstbuf, int dsbuf_size, int *length = nullptr);
   void hash_get(CryptoHash *hash, cache_generation_t generation = -1) const;
   void host_hash_get(CryptoHash *hash);
 
@@ -354,14 +354,14 @@ URL::copy_shallow(const URL *url)
 inline void
 URL::clear()
 {
-  m_url_impl = NULL;
+  m_url_impl = nullptr;
   HdrHeapSDKHandle::clear();
 }
 
 inline void
 URL::reset()
 {
-  m_url_impl = NULL;
+  m_url_impl = nullptr;
 }
 
 /*-------------------------------------------------------------------------

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -68,8 +68,9 @@ public:
   void new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader, bool backdoor) override;
 
   // Implement VConnection interface.
-  VIO *do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = 0) override;
-  VIO *do_io_write(Continuation *c = NULL, int64_t nbytes = INT64_MAX, IOBufferReader *buf = 0, bool owner = false) override;
+  VIO *do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = nullptr) override;
+  VIO *do_io_write(Continuation *c = nullptr, int64_t nbytes = INT64_MAX, IOBufferReader *buf = nullptr,
+                   bool owner = false) override;
 
   void do_io_close(int lerrno = -1) override;
   void do_io_shutdown(ShutdownHowTo_t howto) override;
@@ -105,10 +106,10 @@ public:
     // Make sure the vio's are also released to avoid
     // later surprises in inactivity timeout
     if (client_vc) {
-      client_vc->do_io_read(NULL, 0, NULL);
-      client_vc->do_io_write(NULL, 0, NULL);
-      client_vc->set_action(NULL);
-      client_vc = NULL;
+      client_vc->do_io_read(nullptr, 0, nullptr);
+      client_vc->do_io_write(nullptr, 0, nullptr);
+      client_vc->set_action(nullptr);
+      client_vc = nullptr;
     }
   }
 

--- a/proxy/http/Http1ClientTransaction.h
+++ b/proxy/http/Http1ClientTransaction.h
@@ -35,12 +35,12 @@ public:
   Http1ClientTransaction() {}
   // Implement VConnection interface.
   VIO *
-  do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = 0) override
+  do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = nullptr) override
   {
     return parent->do_io_read(c, nbytes, buf);
   }
   VIO *
-  do_io_write(Continuation *c = NULL, int64_t nbytes = INT64_MAX, IOBufferReader *buf = 0, bool owner = false) override
+  do_io_write(Continuation *c = nullptr, int64_t nbytes = INT64_MAX, IOBufferReader *buf = nullptr, bool owner = false) override
   {
     return parent->do_io_write(c, nbytes, buf, owner);
   }

--- a/proxy/http/HttpBodyFactory.h
+++ b/proxy/http/HttpBodyFactory.h
@@ -181,7 +181,7 @@ public:
 private:
   char *fabricate(StrList *acpt_language_list, StrList *acpt_charset_list, const char *type, HttpTransact::State *context,
                   int64_t *resulting_buffer_length, const char **content_language_return, const char **content_charset_return,
-                  const char **set_return = NULL);
+                  const char **set_return = nullptr);
 
   const char *determine_set_by_language(StrList *acpt_language_list, StrList *acpt_charset_list);
   const char *determine_set_by_host(HttpTransact::State *context);

--- a/proxy/http/HttpCacheSM.h
+++ b/proxy/http/HttpCacheSM.h
@@ -43,7 +43,7 @@ class HttpCacheSM;
 
 struct HttpCacheAction : public Action {
   HttpCacheAction();
-  virtual void cancel(Continuation *c = NULL);
+  virtual void cancel(Continuation *c = nullptr);
   void
   init(HttpCacheSM *sm_arg)
   {
@@ -143,7 +143,7 @@ public:
     if (cache_read_vc) {
       HTTP_DECREMENT_DYN_STAT(http_current_cache_connections_stat);
       cache_read_vc->do_io_close(); // abort
-      cache_read_vc = NULL;
+      cache_read_vc = nullptr;
     }
   }
   inline void
@@ -152,7 +152,7 @@ public:
     if (cache_write_vc) {
       HTTP_DECREMENT_DYN_STAT(http_current_cache_connections_stat);
       cache_write_vc->do_io_close(); // abort
-      cache_write_vc = NULL;
+      cache_write_vc = nullptr;
     }
   }
   inline void
@@ -161,7 +161,7 @@ public:
     if (cache_write_vc) {
       HTTP_DECREMENT_DYN_STAT(http_current_cache_connections_stat);
       cache_write_vc->do_io_close();
-      cache_write_vc = NULL;
+      cache_write_vc = nullptr;
     }
   }
   inline void
@@ -170,7 +170,7 @@ public:
     if (cache_read_vc) {
       HTTP_DECREMENT_DYN_STAT(http_current_cache_connections_stat);
       cache_read_vc->do_io_close();
-      cache_read_vc = NULL;
+      cache_read_vc = nullptr;
     }
   }
   inline void

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -355,7 +355,7 @@ struct HttpConfigPortRange {
   int high;
   HttpConfigPortRange *next;
 
-  HttpConfigPortRange() : low(0), high(0), next(0) {}
+  HttpConfigPortRange() : low(0), high(0), next(nullptr) {}
   ~HttpConfigPortRange()
   {
     if (next)
@@ -502,19 +502,19 @@ struct OverridableHttpConfigParams {
       default_buffer_size_index(8),
       default_buffer_water_mark(32768),
       slow_log_threshold(0),
-      body_factory_template_base(NULL),
+      body_factory_template_base(nullptr),
       body_factory_template_base_len(0),
-      proxy_response_server_string(NULL),
+      proxy_response_server_string(nullptr),
       proxy_response_server_string_len(0),
-      global_user_agent_header(NULL),
+      global_user_agent_header(nullptr),
       global_user_agent_header_size(0),
       cache_heuristic_lm_factor(0.10),
       background_fill_threshold(0.5),
-      client_cert_filename(NULL),
-      client_cert_filepath(NULL),
-      cache_vary_default_text(NULL),
-      cache_vary_default_images(NULL),
-      cache_vary_default_other(NULL)
+      client_cert_filename(nullptr),
+      client_cert_filepath(nullptr),
+      cache_vary_default_text(nullptr),
+      cache_vary_default_images(nullptr),
+      cache_vary_default_other(nullptr)
   {
   }
 

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -140,7 +140,7 @@ struct HttpTransformInfo {
   HttpVCTableEntry *entry;
   VConnection *vc;
 
-  HttpTransformInfo() : entry(NULL), vc(NULL) {}
+  HttpTransformInfo() : entry(nullptr), vc(nullptr) {}
 };
 
 enum {
@@ -648,7 +648,7 @@ inline void
 HttpSM::remove_ua_entry()
 {
   vc_table.remove_entry(ua_entry);
-  ua_entry = NULL;
+  ua_entry = nullptr;
 }
 
 inline void
@@ -656,7 +656,7 @@ HttpSM::remove_server_entry()
 {
   if (server_entry) {
     vc_table.remove_entry(server_entry);
-    server_entry = NULL;
+    server_entry = nullptr;
   }
 }
 
@@ -699,15 +699,15 @@ HttpSM::txn_hook_get(TSHttpHookID id)
 inline void
 HttpSM::add_cache_sm()
 {
-  if (second_cache_sm == NULL) {
+  if (second_cache_sm == nullptr) {
     second_cache_sm = new HttpCacheSM;
     second_cache_sm->init(this, mutex);
-    if (t_state.cache_info.object_read != NULL) {
+    if (t_state.cache_info.object_read != nullptr) {
       second_cache_sm->cache_read_vc        = cache_sm.cache_read_vc;
-      cache_sm.cache_read_vc                = NULL;
+      cache_sm.cache_read_vc                = nullptr;
       second_cache_sm->read_locked          = cache_sm.read_locked;
       t_state.cache_info.second_object_read = t_state.cache_info.object_read;
-      t_state.cache_info.object_read        = NULL;
+      t_state.cache_info.object_read        = nullptr;
     }
   }
 }

--- a/proxy/http/HttpServerSession.h
+++ b/proxy/http/HttpServerSession.h
@@ -68,7 +68,7 @@ class HttpServerSession : public VConnection
 {
 public:
   HttpServerSession()
-    : VConnection(NULL),
+    : VConnection(nullptr),
       hostname_hash(),
       con_id(0),
       transact_count(0),
@@ -79,11 +79,11 @@ public:
       sharing_match(TS_SERVER_SESSION_SHARING_MATCH_BOTH),
       sharing_pool(TS_SERVER_SESSION_SHARING_POOL_GLOBAL),
       enable_origin_connection_limiting(false),
-      connection_count(NULL),
-      read_buffer(NULL),
-      server_vc(NULL),
+      connection_count(nullptr),
+      read_buffer(nullptr),
+      server_vc(nullptr),
       magic(HTTP_SS_MAGIC_DEAD),
-      buf_reader(NULL)
+      buf_reader(nullptr)
   {
   }
 
@@ -94,9 +94,9 @@ public:
   reset_read_buffer(void)
   {
     ink_assert(read_buffer->_writer);
-    ink_assert(buf_reader != NULL);
+    ink_assert(buf_reader != nullptr);
     read_buffer->dealloc_all_readers();
-    read_buffer->_writer = NULL;
+    read_buffer->_writer = nullptr;
     buf_reader           = read_buffer->alloc_reader();
   }
 
@@ -106,9 +106,10 @@ public:
     return buf_reader;
   };
 
-  virtual VIO *do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = 0);
+  virtual VIO *do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = nullptr);
 
-  virtual VIO *do_io_write(Continuation *c = NULL, int64_t nbytes = INT64_MAX, IOBufferReader *buf = 0, bool owner = false);
+  virtual VIO *do_io_write(Continuation *c = nullptr, int64_t nbytes = INT64_MAX, IOBufferReader *buf = nullptr,
+                           bool owner = false);
 
   virtual void do_io_close(int lerrno = -1);
   virtual void do_io_shutdown(ShutdownHowTo_t howto);

--- a/proxy/http/HttpSessionAccept.h
+++ b/proxy/http/HttpSessionAccept.h
@@ -197,7 +197,7 @@ public:
       initialization order issues. It is important to pick up data that is read
       from the config file and a static is initialized long before that point.
   */
-  HttpSessionAccept(Options const &opt = Options()) : SessionAccept(NULL), detail::HttpSessionAcceptOptions(opt) // copy these.
+  HttpSessionAccept(Options const &opt = Options()) : SessionAccept(nullptr), detail::HttpSessionAcceptOptions(opt) // copy these.
   {
     SET_HANDLER(&HttpSessionAccept::mainEvent);
     return;

--- a/proxy/http/HttpSessionManager.h
+++ b/proxy/http/HttpSessionManager.h
@@ -149,7 +149,7 @@ public:
 class HttpSessionManager
 {
 public:
-  HttpSessionManager() : m_g_pool(NULL) {}
+  HttpSessionManager() : m_g_pool(nullptr) {}
   ~HttpSessionManager() {}
   HSMresult_t acquire_session(Continuation *cont, sockaddr const *addr, const char *hostname, ProxyClientTransaction *ua_txn,
                               HttpSM *sm);

--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1247,7 +1247,7 @@ HttpTunnel::producer_handler(int event, HttpTunnelProducer *p)
       p->bytes_read = p->read_vio->ndone;
       // Clear any outstanding reads so they don't
       // collide with future tunnel IO's
-      p->vc->do_io_read(nullptr, 0, 0);
+      p->vc->do_io_read(nullptr, 0, nullptr);
       // Interesting tunnel event, call SM
       jump_point = p->vc_handler;
       (sm->*jump_point)(event, p);

--- a/proxy/http/HttpTunnel.h
+++ b/proxy/http/HttpTunnel.h
@@ -298,7 +298,7 @@ public:
   HttpTunnelProducer *get_producer(VConnection *vc);
   HttpTunnelConsumer *get_consumer(VConnection *vc);
   HttpTunnelProducer *get_producer(HttpTunnelType_t type);
-  void tunnel_run(HttpTunnelProducer *p = NULL);
+  void tunnel_run(HttpTunnelProducer *p = nullptr);
 
   int main_handler(int event, void *data);
   void consumer_reenable(HttpTunnelConsumer *c);
@@ -421,7 +421,7 @@ HttpTunnel::get_producer(VConnection *vc)
       return producers + i;
     }
   }
-  return NULL;
+  return nullptr;
 }
 
 inline HttpTunnelProducer *
@@ -432,7 +432,7 @@ HttpTunnel::get_producer(HttpTunnelType_t type)
       return producers + i;
     }
   }
-  return NULL;
+  return nullptr;
 }
 
 inline HttpTunnelConsumer *
@@ -474,7 +474,7 @@ HttpTunnel::get_producer(VIO *vio)
       return producers + i;
     }
   }
-  return NULL;
+  return nullptr;
 }
 
 inline HttpTunnelConsumer *
@@ -487,13 +487,13 @@ HttpTunnel::get_consumer(VIO *vio)
       }
     }
   }
-  return NULL;
+  return nullptr;
 }
 
 inline void
 HttpTunnel::append_message_to_producer_buffer(HttpTunnelProducer *p, const char *msg, int64_t msg_len)
 {
-  if (p == NULL || p->read_buffer == NULL)
+  if (p == nullptr || p->read_buffer == nullptr)
     return;
 
   p->read_buffer->write(msg, msg_len);
@@ -524,7 +524,7 @@ HttpTunnelConsumer::is_downstream_from(VConnection *vc)
     // of a blind tunnel so give up if we find ourself (the original
     // consumer).
     c = p->self_consumer;
-    p = (c && c != this) ? c->producer : 0;
+    p = (c && c != this) ? c->producer : nullptr;
   }
   return false;
 }
@@ -554,7 +554,7 @@ HttpTunnelProducer::update_state_if_not_set(int new_handler_state)
 inline bool
 HttpTunnelProducer::is_throttled() const
 {
-  return 0 != flow_control_source;
+  return nullptr != flow_control_source;
 }
 
 inline void
@@ -568,7 +568,7 @@ inline void
 HttpTunnelProducer::unthrottle()
 {
   if (this->is_throttled())
-    this->set_throttle_src(0);
+    this->set_throttle_src(nullptr);
 }
 
 inline HttpTunnel::FlowControl::FlowControl() : high_water(DEFAULT_WATER_MARK), low_water(DEFAULT_WATER_MARK), enabled_p(false)

--- a/proxy/http/remap/AclFiltering.h
+++ b/proxy/http/remap/AclFiltering.h
@@ -96,7 +96,7 @@ public:
 
   acl_filter_rule();
   ~acl_filter_rule();
-  void name(const char *_name = NULL);
+  void name(const char *_name = nullptr);
   int add_argv(int _argc, char *_argv[]);
   void print(void);
 

--- a/proxy/http/remap/RemapConfig.h
+++ b/proxy/http/remap/RemapConfig.h
@@ -70,7 +70,7 @@ const char *remap_parse_directive(BUILD_TABLE_INFO *bti, char *errbuf, size_t er
 const char *remap_validate_filter_args(acl_filter_rule **rule_pp, const char **argv, int argc, char *errStrBuf,
                                        size_t errStrBufSize);
 
-unsigned long remap_check_option(const char **argv, int argc, unsigned long findmode = 0, int *_ret_idx = NULL,
-                                 const char **argptr = NULL);
+unsigned long remap_check_option(const char **argv, int argc, unsigned long findmode = 0, int *_ret_idx = nullptr,
+                                 const char **argptr = nullptr);
 
 bool remap_parse_config(const char *path, UrlRewrite *rewrite);

--- a/proxy/http/remap/UrlMapping.h
+++ b/proxy/http/remap/UrlMapping.h
@@ -39,7 +39,7 @@
 class referer_info
 {
 public:
-  referer_info(char *_ref, bool *error_flag = NULL, char *errmsgbuf = NULL, int errmsgbuf_size = 0);
+  referer_info(char *_ref, bool *error_flag = nullptr, char *errmsgbuf = nullptr, int errmsgbuf_size = 0);
   ~referer_info();
   referer_info *next;
   char *referer;
@@ -56,13 +56,13 @@ public:
 class redirect_tag_str
 {
 public:
-  redirect_tag_str() : next(0), chunk_str(NULL), type(0) {}
+  redirect_tag_str() : next(nullptr), chunk_str(nullptr), type(0) {}
   ~redirect_tag_str()
   {
     type = 0;
     if (chunk_str) {
       ats_free(chunk_str);
-      chunk_str = NULL;
+      chunk_str = nullptr;
     }
   }
 
@@ -135,8 +135,8 @@ private:
 class UrlMappingContainer
 {
 public:
-  UrlMappingContainer() : _mapping(NULL), _toURLPtr(NULL), _heap(NULL) {}
-  explicit UrlMappingContainer(HdrHeap *heap) : _mapping(NULL), _toURLPtr(NULL), _heap(heap) {}
+  UrlMappingContainer() : _mapping(nullptr), _toURLPtr(nullptr), _heap(nullptr) {}
+  explicit UrlMappingContainer(HdrHeap *heap) : _mapping(nullptr), _toURLPtr(nullptr), _heap(heap) {}
   ~UrlMappingContainer() { deleteToURL(); }
   URL *
   getToURL() const
@@ -146,7 +146,7 @@ public:
   URL *
   getFromURL() const
   {
-    return _mapping ? &(_mapping->fromURL) : NULL;
+    return _mapping ? &(_mapping->fromURL) : nullptr;
   };
 
   url_mapping *
@@ -160,7 +160,7 @@ public:
   {
     deleteToURL();
     _mapping  = m;
-    _toURLPtr = m ? &(m->toUrl) : NULL;
+    _toURLPtr = m ? &(m->toUrl) : nullptr;
   }
 
   void
@@ -172,7 +172,7 @@ public:
   URL *
   createNewToURL()
   {
-    ink_assert(_heap != NULL);
+    ink_assert(_heap != nullptr);
     deleteToURL();
     _toURL.create(_heap);
     _toURLPtr = &_toURL;
@@ -191,9 +191,9 @@ public:
   clear()
   {
     deleteToURL();
-    _mapping  = NULL;
-    _toURLPtr = NULL;
-    _heap     = NULL;
+    _mapping  = nullptr;
+    _toURLPtr = nullptr;
+    _heap     = nullptr;
   }
 
   // noncopyable, non-assignable

--- a/proxy/http/remap/UrlMappingPathIndex.h
+++ b/proxy/http/remap/UrlMappingPathIndex.h
@@ -92,6 +92,6 @@ private:
     if (group_iter != m_tries.end()) {
       return group_iter->second;
     }
-    return 0;
+    return nullptr;
   }
 };

--- a/proxy/http/remap/UrlRewrite.h
+++ b/proxy/http/remap/UrlRewrite.h
@@ -119,7 +119,7 @@ public:
     bool
     empty()
     {
-      return ((hash_lookup == NULL) && regex_list.empty());
+      return ((hash_lookup == nullptr) && regex_list.empty());
     }
   };
 

--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -238,7 +238,7 @@ struct Http2FrameHeader {
 // [RFC 7540] 5.4. Error Handling
 struct Http2Error {
   Http2Error(const Http2ErrorClass error_class = Http2ErrorClass::HTTP2_ERROR_CLASS_NONE,
-             const Http2ErrorCode error_code = Http2ErrorCode::HTTP2_ERROR_NO_ERROR, const char *err_msg = NULL)
+             const Http2ErrorCode error_code = Http2ErrorCode::HTTP2_ERROR_NO_ERROR, const char *err_msg = nullptr)
   {
     cls  = error_class;
     code = error_code;

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -47,7 +47,7 @@ size_t const HTTP2_HEADER_BUFFER_SIZE_INDEX = CLIENT_CONNECTION_FIRST_READ_BUFFE
 
 // To support Upgrade: h2c
 struct Http2UpgradeContext {
-  Http2UpgradeContext() : req_header(NULL) {}
+  Http2UpgradeContext() : req_header(nullptr) {}
   ~Http2UpgradeContext()
   {
     if (req_header) {
@@ -75,7 +75,7 @@ public:
   Http2Frame(Http2FrameType type, Http2StreamId streamid, uint8_t flags)
   {
     this->hdr      = {0, (uint8_t)type, flags, streamid};
-    this->ioreader = NULL;
+    this->ioreader = nullptr;
   }
 
   IOBufferReader *
@@ -173,8 +173,9 @@ public:
   }
 
   // Implement VConnection interface.
-  VIO *do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = 0) override;
-  VIO *do_io_write(Continuation *c = NULL, int64_t nbytes = INT64_MAX, IOBufferReader *buf = 0, bool owner = false) override;
+  VIO *do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = nullptr) override;
+  VIO *do_io_write(Continuation *c = nullptr, int64_t nbytes = INT64_MAX, IOBufferReader *buf = nullptr,
+                   bool owner = false) override;
   void do_io_close(int lerrno = -1) override;
   void do_io_shutdown(ShutdownHowTo_t howto) override;
   void reenable(VIO *vio) override;
@@ -190,9 +191,9 @@ public:
   {
     // Make sure the vio's are also released to avoid later surprises in inactivity timeout
     if (client_vc) {
-      client_vc->do_io_read(NULL, 0, NULL);
-      client_vc->do_io_write(NULL, 0, NULL);
-      client_vc->set_action(NULL);
+      client_vc->do_io_read(nullptr, 0, nullptr);
+      client_vc->do_io_write(nullptr, 0, nullptr);
+      client_vc->set_action(nullptr);
     }
   }
 

--- a/proxy/logging/LogAccess.h
+++ b/proxy/logging/LogAccess.h
@@ -323,13 +323,13 @@ public:
   static int unmarshal_itox(int64_t val, char *dest, int field_width = 0, char leading_char = ' ');
   static int unmarshal_int_to_str(char **buf, char *dest, int len);
   static int unmarshal_int_to_str_hex(char **buf, char *dest, int len);
-  static int unmarshal_str(char **buf, char *dest, int len, LogSlice *slice = NULL);
+  static int unmarshal_str(char **buf, char *dest, int len, LogSlice *slice = nullptr);
   static int unmarshal_ttmsf(char **buf, char *dest, int len);
   static int unmarshal_int_to_date_str(char **buf, char *dest, int len);
   static int unmarshal_int_to_time_str(char **buf, char *dest, int len);
   static int unmarshal_int_to_netscape_str(char **buf, char *dest, int len);
   static int unmarshal_http_version(char **buf, char *dest, int len);
-  static int unmarshal_http_text(char **buf, char *dest, int len, LogSlice *slice = NULL);
+  static int unmarshal_http_text(char **buf, char *dest, int len, LogSlice *slice = nullptr);
   static int unmarshal_http_status(char **buf, char *dest, int len);
   static int unmarshal_ip(char **buf, IpEndpoint *dest);
   static int unmarshal_ip_to_str(char **buf, char *dest, int len);
@@ -342,7 +342,7 @@ public:
   static int unmarshal_cache_write_code(char **buf, char *dest, int len, Ptr<LogFieldAliasMap> map);
   static int unmarshal_client_protocol_stack(char **buf, char *dest, int len, Ptr<LogFieldAliasMap> map);
 
-  static int unmarshal_with_map(int64_t code, char *dest, int len, Ptr<LogFieldAliasMap> map, const char *msg = 0);
+  static int unmarshal_with_map(int64_t code, char *dest, int len, Ptr<LogFieldAliasMap> map, const char *msg = nullptr);
 
   static int unmarshal_record(char **buf, char *dest, int len);
 
@@ -385,7 +385,7 @@ LogAccess::round_strlen(int len)
 inline int
 LogAccess::strlen(const char *str)
 {
-  if (str == NULL || str[0] == 0) {
+  if (str == nullptr || str[0] == 0) {
     return round_strlen(sizeof(DEFAULT_STR));
   } else {
     return (int)(round_strlen(((int)::strlen(str) + 1))); // actual bytes for string

--- a/proxy/logging/LogBuffer.h
+++ b/proxy/logging/LogBuffer.h
@@ -306,7 +306,7 @@ private:
   -------------------------------------------------------------------------*/
 
 inline LogBufferIterator::LogBufferIterator(LogBufferHeader *header, bool in_network_order)
-  : m_in_network_order(in_network_order), m_next(0), m_iter_entry_count(0), m_buffer_entry_count(0)
+  : m_in_network_order(in_network_order), m_next(nullptr), m_iter_entry_count(0), m_buffer_entry_count(0)
 {
   ink_assert(header);
 

--- a/proxy/logging/LogConfig.h
+++ b/proxy/logging/LogConfig.h
@@ -103,7 +103,7 @@ public:
   LogConfig();
   ~LogConfig();
 
-  void init(LogConfig *previous_config = 0);
+  void init(LogConfig *previous_config = nullptr);
   void display(FILE *fd = stdout);
   void setup_log_objects();
 

--- a/proxy/logging/LogFieldAliasMap.h
+++ b/proxy/logging/LogFieldAliasMap.h
@@ -87,7 +87,7 @@ public:
   };
 
   virtual int asInt(char *key, IntType *val, bool case_sensitive = 0) const = 0;
-  virtual int asString(IntType key, char *buf, size_t bufLen, size_t *numChars = 0) const = 0;
+  virtual int asString(IntType key, char *buf, size_t bufLen, size_t *numChars = nullptr) const = 0;
 };
 
 /*****************************************************************************
@@ -107,7 +107,7 @@ struct LogFieldAliasTableEntry {
   char *name;    // the string equivalent
   size_t length; // the length of the string
 
-  LogFieldAliasTableEntry() : valid(false), name(NULL), length(0) {}
+  LogFieldAliasTableEntry() : valid(false), name(nullptr), length(0) {}
   ~LogFieldAliasTableEntry()
   {
     if (name) {
@@ -125,7 +125,7 @@ private:
   LogFieldAliasTableEntry *m_table; // array of table entries
 
 public:
-  LogFieldAliasTable() : m_min(0), m_max(0), m_entries(0), m_table(0) {}
+  LogFieldAliasTable() : m_min(0), m_max(0), m_entries(0), m_table(nullptr) {}
   ~LogFieldAliasTable() { delete[] m_table; }
   void init(size_t numPairs, ...);
 
@@ -156,7 +156,7 @@ public:
   }
 
   int
-  asString(IntType key, char *buf, size_t bufLen, size_t *numCharsPtr = 0) const
+  asString(IntType key, char *buf, size_t bufLen, size_t *numCharsPtr = nullptr) const
   {
     int retVal;
     size_t numChars;
@@ -207,7 +207,7 @@ public:
   }
 
   int
-  asString(IntType time, char *buf, size_t bufLen, size_t *numCharsPtr = 0) const
+  asString(IntType time, char *buf, size_t bufLen, size_t *numCharsPtr = nullptr) const
   {
     return (LogUtils::timestamp_to_hex_str(time, buf, bufLen, numCharsPtr) ? BUFFER_TOO_SMALL : ALL_OK);
   }

--- a/proxy/logging/LogFilter.h
+++ b/proxy/logging/LogFilter.h
@@ -159,7 +159,7 @@ private:
     // return 0 if s1 is substring of s0 and 1 otherwise
     // this reverse behavior is to conform to the behavior of strcmp
     // which returns 0 if strings match
-    return (strstr(s0, s1) == NULL ? 1 : 0);
+    return (strstr(s0, s1) == nullptr ? 1 : 0);
   }
 
   enum LengthCondition {

--- a/proxy/logging/LogUtils.h
+++ b/proxy/logging/LogUtils.h
@@ -38,7 +38,7 @@ enum AlarmType {
 static inline long
 timestamp()
 {
-  return (long)time(0);
+  return (long)time(nullptr);
 }
 
 int timestamp_to_str(long timestamp, char *buf, int size);
@@ -55,8 +55,8 @@ char *pure_escapify_url(Arena *arena, char *url, size_t len_in, int *len_out, ch
 char *int64_to_str(char *buf, unsigned int buf_size, int64_t val, unsigned int *total_chars, unsigned int req_width = 0,
                    char pad_char = '0');
 void remove_content_type_attributes(char *type_str, int *type_len);
-int timestamp_to_hex_str(unsigned timestamp, char *str, size_t len, size_t *n_chars = 0);
+int timestamp_to_hex_str(unsigned timestamp, char *str, size_t len, size_t *n_chars = nullptr);
 int seconds_to_next_roll(time_t time_now, int rolling_offset, int rolling_interval);
-int file_is_writeable(const char *full_filename, off_t *size_bytes = 0, bool *has_size_limit = 0,
-                      uint64_t *current_size_limit_bytes = 0);
+int file_is_writeable(const char *full_filename, off_t *size_bytes = nullptr, bool *has_size_limit = nullptr,
+                      uint64_t *current_size_limit_bytes = nullptr);
 };


### PR DESCRIPTION
Ran clang-tidy 6.0.0 over the code base to get ready for branching for the 8.0.0 release.