### PR TITLE
Add ats_ip_range_parse to ink_net.h to improve/replace ExtractIpRange.

### DIFF
--- a/lib/ts/ink_inet.h
+++ b/lib/ts/ink_inet.h
@@ -1448,6 +1448,8 @@ ats_ip_pton(const char *text, ///< [in] text.
   return addr.load(text) ? 0 : -1;
 }
 
+int ats_ip_range_parse(ts::string_view src, IpAddr &lower, IpAddr &upper);
+
 inline IpEndpoint &
 IpEndpoint::assign(IpAddr const &addr, in_port_t port)
 {


### PR DESCRIPTION
The `ExtractIpRanges` in `MatcherUtils.cc` is mediocre and doesn't handle all the expected cases (e.g., IPv6 masks, bad input, etc.). In addition, because `ExtractIpRanges` uses `strtok` internally it requires `ats_strdup` in most cases to protect the original string. It also seems reasonable to move that kind of IP address parsing support to `ink_inet.h`. This function is intended to replace `ExtractIpRange`. It also comes with unit tests.