### PR TITLE
Need to call signalActivity() to wake up epoll_wait()

### DIFF
--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -817,7 +817,9 @@ UnixNetVConnection::reenable(VIO *vio)
           nh->write_enable_list.push(this);
         }
       }
-      if (nh->trigger_event) {
+      if (likely(nh->thread)) {
+        nh->thread->tail_cb->signalActivity();
+      } else if (nh->trigger_event) {
         nh->trigger_event->ethread->tail_cb->signalActivity();
       }
     } else {


### PR DESCRIPTION
 `trigger_event` isn't set in certain situations, but we still need to wake up `epoll_wait`, otherwise the thread might be stuck in there till the timeout.