### PR TITLE
Fix cache_read_busy_success_stat

### DIFF
--- a/iocore/cache/CacheRead.cc
+++ b/iocore/cache/CacheRead.cc
@@ -953,8 +953,9 @@ CacheVC::openReadStartEarliest(int /* event ATS_UNUSED */, Event * /* e ATS_UNUS
 Lcallreturn:
   return handleEvent(AIO_EVENT_DONE, nullptr); // hopefully a tail call
 Lsuccess:
-  if (write_vc)
+  if (write_vc) {
     CACHE_INCREMENT_DYN_STAT(cache_read_busy_success_stat);
+  }
   SET_HANDLER(&CacheVC::openReadMain);
   return callcont(CACHE_EVENT_OPEN_READ);
 }

--- a/iocore/cache/P_CacheInternal.h
+++ b/iocore/cache/P_CacheInternal.h
@@ -165,23 +165,31 @@ extern RecRawStatBlock *cache_rsb;
 #define CACHE_SET_DYN_STAT(x, y) \
   RecSetGlobalRawStatSum(cache_rsb, (x), (y)) RecSetGlobalRawStatSum(vol->cache_vol->vol_rsb, (x), (y))
 
-#define CACHE_INCREMENT_DYN_STAT(x)                              \
-  RecIncrRawStat(cache_rsb, mutex->thread_holding, (int)(x), 1); \
-  RecIncrRawStat(vol->cache_vol->vol_rsb, mutex->thread_holding, (int)(x), 1);
+#define CACHE_INCREMENT_DYN_STAT(x)                                              \
+  do {                                                                           \
+    RecIncrRawStat(cache_rsb, mutex->thread_holding, (int)(x), 1);               \
+    RecIncrRawStat(vol->cache_vol->vol_rsb, mutex->thread_holding, (int)(x), 1); \
+  } while (0);
 
-#define CACHE_DECREMENT_DYN_STAT(x)                               \
-  RecIncrRawStat(cache_rsb, mutex->thread_holding, (int)(x), -1); \
-  RecIncrRawStat(vol->cache_vol->vol_rsb, mutex->thread_holding, (int)(x), -1);
+#define CACHE_DECREMENT_DYN_STAT(x)                                               \
+  do {                                                                            \
+    RecIncrRawStat(cache_rsb, mutex->thread_holding, (int)(x), -1);               \
+    RecIncrRawStat(vol->cache_vol->vol_rsb, mutex->thread_holding, (int)(x), -1); \
+  } while (0);
 
 #define CACHE_VOL_SUM_DYN_STAT(x, y) RecIncrRawStat(vol->cache_vol->vol_rsb, mutex->thread_holding, (int)(x), (int64_t)y);
 
-#define CACHE_SUM_DYN_STAT(x, y)                                            \
-  RecIncrRawStat(cache_rsb, mutex->thread_holding, (int)(x), (int64_t)(y)); \
-  RecIncrRawStat(vol->cache_vol->vol_rsb, mutex->thread_holding, (int)(x), (int64_t)(y));
+#define CACHE_SUM_DYN_STAT(x, y)                                                            \
+  do {                                                                                      \
+    RecIncrRawStat(cache_rsb, mutex->thread_holding, (int)(x), (int64_t)(y));               \
+    RecIncrRawStat(vol->cache_vol->vol_rsb, mutex->thread_holding, (int)(x), (int64_t)(y)); \
+  } while (0);
 
-#define CACHE_SUM_DYN_STAT_THREAD(x, y)                              \
-  RecIncrRawStat(cache_rsb, this_ethread(), (int)(x), (int64_t)(y)); \
-  RecIncrRawStat(vol->cache_vol->vol_rsb, this_ethread(), (int)(x), (int64_t)(y));
+#define CACHE_SUM_DYN_STAT_THREAD(x, y)                                              \
+  do {                                                                               \
+    RecIncrRawStat(cache_rsb, this_ethread(), (int)(x), (int64_t)(y));               \
+    RecIncrRawStat(vol->cache_vol->vol_rsb, this_ethread(), (int)(x), (int64_t)(y)); \
+  } while (0);
 
 #define GLOBAL_CACHE_SUM_GLOBAL_DYN_STAT(x, y) RecIncrGlobalRawStatSum(cache_rsb, (x), (y))
 


### PR DESCRIPTION
The stat was incremented unintentionally in a certain case due to a combination of multiple statement macro and a `if` statement without braces.

Now the macro is in a loop so the statements can't be called separately, but I added braces to the `if` statement for consistency.

This fixes #3458.