### PR TITLE
Explicitly cast to void * when initializing a memory with a pointer for a class object

### DIFF
--- a/cmd/traffic_cache_tool/CacheTool.cc
+++ b/cmd/traffic_cache_tool/CacheTool.cc
@@ -721,7 +721,7 @@ Span::loadDevice()
           span_hdr_size = round_up(sizeof(ts::SpanHeader) + (nspb - 1) * sizeof(ts::CacheStripeDescriptor));
           _header.reset(new (malloc(span_hdr_size)) ts::SpanHeader);
           if (span_hdr_size <= BUFF_SIZE) {
-            memcpy(_header.get(), buff, span_hdr_size);
+            memcpy(static_cast<void *>(_header.get()), buff, span_hdr_size);
           } else {
             // TODO - check the pread return
             ssize_t n = pread(fd, _header.get(), span_hdr_size, offset);

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -1305,7 +1305,7 @@ Vol::init(char *s, off_t blocks, off_t dir_skip, bool clear)
   evacuate_size = (int)(len / EVACUATION_BUCKET_SIZE) + 2;
   int evac_len  = (int)evacuate_size * sizeof(DLL<EvacuationBlock>);
   evacuate      = (DLL<EvacuationBlock> *)ats_malloc(evac_len);
-  memset(evacuate, 0, evac_len);
+  memset(static_cast<void *>(evacuate), 0, evac_len);
 
   Debug("cache_init", "Vol %s: allocating %zu directory bytes for a %lld byte volume (%lf%%)", hash_text.get(), dirlen(),
         (long long)this->len, (double)dirlen() / (double)this->len * 100.0);
@@ -3418,7 +3418,7 @@ HTTPInfo_v21::copy_and_upgrade_unmarshalled_to_v23(char *&dst, char *&src, size_
   if (hdr_size > length) {
     return false;
   }
-  memcpy(d_hdr, s_hdr, hdr_size);
+  memcpy(static_cast<void *>(d_hdr), s_hdr, hdr_size);
   d_alt->m_request_hdr.m_heap = reinterpret_cast<HdrHeap_v23 *>(reinterpret_cast<char *>(d_hdr) - reinterpret_cast<char *>(d_alt));
   dst += hdr_size;
   length -= hdr_size;
@@ -3430,7 +3430,7 @@ HTTPInfo_v21::copy_and_upgrade_unmarshalled_to_v23(char *&dst, char *&src, size_
   if (hdr_size > length) {
     return false;
   }
-  memcpy(d_hdr, s_hdr, hdr_size);
+  memcpy(static_cast<void *>(d_hdr), s_hdr, hdr_size);
   d_alt->m_response_hdr.m_heap = reinterpret_cast<HdrHeap_v23 *>(reinterpret_cast<char *>(d_hdr) - reinterpret_cast<char *>(d_alt));
   dst += hdr_size;
   length -= hdr_size;

--- a/iocore/cache/CacheDir.cc
+++ b/iocore/cache/CacheDir.cc
@@ -217,7 +217,7 @@ dir_init_segment(int s, Vol *d)
   d->header->freelist[s] = 0;
   Dir *seg               = d->dir_segment(s);
   int l, b;
-  memset(seg, 0, SIZEOF_DIR * DIR_DEPTH * d->buckets);
+  memset(static_cast<void *>(seg), 0, SIZEOF_DIR * DIR_DEPTH * d->buckets);
   for (l = 1; l < DIR_DEPTH; l++) {
     for (b = 0; b < d->buckets; b++) {
       Dir *bucket = dir_bucket(b, seg);
@@ -1514,7 +1514,7 @@ EXCLUSIVE_REGRESSION_TEST(Cache_dir)(RegressionTest *t, int /* atype ATS_UNUSED 
   }
 
   Dir dir1;
-  memset(&dir1, 0, sizeof(dir1));
+  memset(static_cast<void *>(&dir1), 0, sizeof(dir1));
   int s1, b1;
 
   rprintf(t, "corrupt_bucket test\n");

--- a/iocore/cache/CacheHosting.cc
+++ b/iocore/cache/CacheHosting.cc
@@ -165,7 +165,7 @@ CacheHostMatcher::NewEntry(matcher_line *line_info)
 
   if (errNo) {
     // There was a problem so undo the effects this function
-    memset(cur_d, 0, sizeof(CacheHostRecord));
+    memset(static_cast<void *>(cur_d), 0, sizeof(CacheHostRecord));
     return;
   }
   Debug("cache_hosting", "hostname: %s, host record: %p", match_data, cur_d);
@@ -1079,8 +1079,8 @@ save_state()
   saved_cp_list_len = cp_list_len;
   memcpy(&saved_config_volumes, &config_volumes, sizeof(ConfigVolumes));
   saved_gnvol = gnvol;
-  memset(&cp_list, 0, sizeof(Queue<CacheVol>));
-  memset(&config_volumes, 0, sizeof(ConfigVolumes));
+  memset(static_cast<void *>(&cp_list), 0, sizeof(Queue<CacheVol>));
+  memset(static_cast<void *>(&config_volumes), 0, sizeof(ConfigVolumes));
   gnvol = 0;
 }
 

--- a/iocore/cache/CacheWrite.cc
+++ b/iocore/cache/CacheWrite.cc
@@ -1058,7 +1058,7 @@ Lagain:
     int l       = round_to_approx_size(sizeof(Doc));
     agg_buf_pos = l;
     Doc *d      = (Doc *)agg_buffer;
-    memset(d, 0, sizeof(Doc));
+    memset(static_cast<void *>(d), 0, sizeof(Doc));
     d->magic        = DOC_MAGIC;
     d->len          = l;
     d->sync_serial  = header->sync_serial;

--- a/iocore/cache/RamCacheCLFUS.cc
+++ b/iocore/cache/RamCacheCLFUS.cc
@@ -184,7 +184,7 @@ RamCacheCLFUS::resize_hashtable()
   DDebug("ram_cache", "resize hashtable %d", anbuckets);
   int64_t s = anbuckets * sizeof(DList(RamCacheCLFUSEntry, hash_link));
   DList(RamCacheCLFUSEntry, hash_link) *new_bucket = (DList(RamCacheCLFUSEntry, hash_link) *)ats_malloc(s);
-  memset(new_bucket, 0, s);
+  memset(static_cast<void *>(new_bucket), 0, s);
   if (bucket) {
     for (int64_t i = 0; i < nbuckets; i++) {
       RamCacheCLFUSEntry *e = nullptr;

--- a/iocore/cache/RamCacheLRU.cc
+++ b/iocore/cache/RamCacheLRU.cc
@@ -86,7 +86,7 @@ RamCacheLRU::resize_hashtable()
   DDebug("ram_cache", "resize hashtable %d", anbuckets);
   int64_t s = anbuckets * sizeof(DList(RamCacheLRUEntry, hash_link));
   DList(RamCacheLRUEntry, hash_link) *new_bucket = (DList(RamCacheLRUEntry, hash_link) *)ats_malloc(s);
-  memset(new_bucket, 0, s);
+  memset(static_cast<void *>(new_bucket), 0, s);
   if (bucket) {
     for (int64_t i = 0; i < nbuckets; i++) {
       RamCacheLRUEntry *e = nullptr;

--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -222,7 +222,7 @@ struct NetVCOptions {
     if (&that != this) {
       sni_servername    = nullptr; // release any current name.
       clientCertificate = nullptr;
-      memcpy(this, &that, sizeof(self));
+      memcpy(static_cast<void *>(this), &that, sizeof(self));
       if (that.sni_servername) {
         sni_servername.release(); // otherwise we'll free the source string.
         this->sni_servername = ats_strdup(that.sni_servername);

--- a/lib/ts/Map.h
+++ b/lib/ts/Map.h
@@ -244,7 +244,7 @@ const uintptr_t open_hash_primes[256] = {
 
 template <class C, class A, int S> inline Vec<C, A, S>::Vec() : n(0), i(0), v(0)
 {
-  memset(&e[0], 0, sizeof(e));
+  memset(static_cast<void *>(&e[0]), 0, sizeof(e));
 }
 
 template <class C, class A, int S> inline Vec<C, A, S>::Vec(const Vec<C, A, S> &vv)
@@ -774,8 +774,8 @@ Vec<C, A, S>::copy_internal(const Vec<C, A, S> &vv)
   }
   nl = 1 << nl;
   v  = (C *)A::alloc(nl * sizeof(C));
-  memcpy(v, vv.v, n * sizeof(C));
-  memset(v + n, 0, (nl - n) * sizeof(C));
+  memcpy(static_cast<void *>(v), vv.v, n * sizeof(C));
+  memset(static_cast<void *>(v + n), 0, (nl - n) * sizeof(C));
   if (i > n) // reset reserve
     i = 0;
 }
@@ -790,7 +790,7 @@ Vec<C, A, S>::set_expand()
     i = i + 1;
   n   = prime2[i];
   v   = (C *)A::alloc(n * sizeof(C));
-  memset(v, 0, n * sizeof(C));
+  memset(static_cast<void *>(v), 0, n * sizeof(C));
 }
 
 template <class C, class A, int S>
@@ -822,9 +822,9 @@ Vec<C, A, S>::addx()
   }
   if (v == e) {
     v = (C *)A::alloc(VEC_INITIAL_SIZE * sizeof(C));
-    memcpy(v, &e[0], n * sizeof(C));
+    memcpy(static_cast<void *>(v), &e[0], n * sizeof(C));
     ink_assert(n < VEC_INITIAL_SIZE);
-    memset(&v[n], 0, (VEC_INITIAL_SIZE - n) * sizeof(C));
+    memset(static_cast<void *>(&v[n]), 0, (VEC_INITIAL_SIZE - n) * sizeof(C));
   } else {
     if ((n & (n - 1)) == 0) {
       size_t nl = n * 2;
@@ -835,8 +835,8 @@ Vec<C, A, S>::addx()
       }
       void *vv = (void *)v;
       v        = (C *)A::alloc(nl * sizeof(C));
-      memcpy(v, vv, n * sizeof(C));
-      memset(&v[n], 0, n * sizeof(C));
+      memcpy(static_cast<void *>(v), vv, n * sizeof(C));
+      memset(static_cast<void *>(&v[n]), 0, n * sizeof(C));
       A::free(vv);
     }
   }

--- a/lib/ts/ink_memory.h
+++ b/lib/ts/ink_memory.h
@@ -205,7 +205,7 @@ template <typename T>
 inline void
 ink_zero(T &t)
 {
-  memset(&t, 0, sizeof(t));
+  memset(static_cast<void *>(&t), 0, sizeof(t));
 }
 
 /** Scoped resources.

--- a/tools/jtest/jtest.cc
+++ b/tools/jtest/jtest.cc
@@ -3641,7 +3641,7 @@ main(int argc __attribute__((unused)), const char *argv[])
   setvbuf(stdout, (char *)nullptr, _IOLBF, 0);
 
   fd = (FD *)malloc(MAXFDS * sizeof(FD));
-  memset(fd, 0, MAXFDS * sizeof(FD));
+  memset(static_cast<void *>(fd), 0, MAXFDS * sizeof(FD));
   process_args(&appVersionInfo, argument_descriptions, n_argument_descriptions, argv);
 
   if (!drand_seed) {


### PR DESCRIPTION
gcc 8 is more picky.

```
In file included from ink_queue.cc:48:
../../lib/ts/ink_memory.h: In instantiation of 'void ink_zero(T&) [with T = _InkFreeList]':
ink_queue.cc:128:14:   required from here
../../lib/ts/ink_memory.h:208:9: error: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'struct _InkFreeList'; use assignment or value-initialization instead [-Werror=class-memaccess]
   memset(&t, 0, sizeof(t));
   ~~~~~~^~~~~~~~~~~~~~~~~~
In file included from ink_queue.cc:47:
../../lib/ts/ink_queue.h:148:8: note: 'struct _InkFreeList' declared here
 struct _InkFreeList {
        ^~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[3]: *** [Makefile:1438: ink_queue.lo] Error 1
make[3]: *** Waiting for unfinished jobs....
In file included from ../../lib/ts/ink_inet.h:30,
                 from ink_inet.cc:26:
../../lib/ts/ink_memory.h: In instantiation of 'void ink_zero(T&) [with T = std::basic_string_view<char>]':
ink_inet.cc:172:17:   required from here
../../lib/ts/ink_memory.h:208:9: error: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'class std::basic_string_view<char>'; use assignment or value-initialization instead [-Werror=class-memaccess]
   memset(&t, 0, sizeof(t));
   ~~~~~~^~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/8/bits/basic_string.h:48,
                 from /usr/include/c++/8/string:52,
                 from ../../lib/ts/ink_memory.h:29,
                 from ../../lib/ts/ink_inet.h:30,
                 from ink_inet.cc:26:
/usr/include/c++/8/string_view:71:11: note: 'class std::basic_string_view<char>' declared here
     class basic_string_view
           ^~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```