### PR TITLE
Fix README typo of OSX

### DIFF
--- a/README
+++ b/README
@@ -113,9 +113,9 @@ plugins to build large scale web applications.
   OSX (we recommend HomeBrew):
     autoconf
     automake
-    pkgconfig
+    pkg-config
     libtool
-    tcl
+    tcl-tk (or tcl from Homebrew-Cask)
     openssl
     pcre
 


### PR DESCRIPTION
- pkgconfig should be pkg-config.
- tcl should be installed by homebrew-cask.