### PR TITLE
Cache_tool: replace MD5CTX with CryptoContext

### DIFF
--- a/cmd/traffic_cache_tool/CacheDefs.cc
+++ b/cmd/traffic_cache_tool/CacheDefs.cc
@@ -214,6 +214,7 @@ Stripe::Chunk::clear()
 Stripe::Stripe(Span *span, Bytes start, CacheStoreBlocks len) : _span(span), _start(start), _len(len)
 {
   ts::bwprint(hashText, "{} {}:{}", span->_path.path(), _start.count(), _len.count());
+  CryptoContext().hash_immediate(hash_id, hashText.data(), static_cast<int>(hashText.size()));
   printf("hash id of stripe is hash of %.*s\n", static_cast<int>(hashText.size()), hashText.data());
 }
 
@@ -525,7 +526,7 @@ Stripe::stripe_offset(CacheDirEntry *e)
 }
 
 int
-Stripe::dir_probe(INK_MD5 *key, CacheDirEntry *result, CacheDirEntry **last_collision)
+Stripe::dir_probe(CryptoHash *key, CacheDirEntry *result, CacheDirEntry **last_collision)
 {
   int segment = key->slice32(0) % this->_segments;
   int bucket  = key->slice32(1) % this->_buckets;

--- a/cmd/traffic_cache_tool/CacheDefs.h
+++ b/cmd/traffic_cache_tool/CacheDefs.h
@@ -32,6 +32,7 @@
 #include <ts/TextView.h>
 #include <ts/ink_file.h>
 #include <list>
+#include <ts/CryptoHash.h>
 
 #include "Command.h"
 #include "File.h"
@@ -573,7 +574,7 @@ struct Stripe {
   void updateLiveData(enum Copy c);
 
   Span *_span;           ///< Hosting span.
-  INK_MD5 hash_id;       /// hash_id
+  CryptoHash hash_id;    /// hash_id
   Bytes _start;          ///< Offset of first byte of stripe metadata.
   Bytes _content;        ///< Start of content.
   CacheStoreBlocks _len; ///< Length of stripe.
@@ -609,7 +610,7 @@ struct Stripe {
   void dir_free_entry(CacheDirEntry *e, int s);
   CacheDirEntry *dir_delete_entry(CacheDirEntry *e, CacheDirEntry *p, int s);
   //  int dir_bucket_length(CacheDirEntry *b, int s);
-  int dir_probe(INK_MD5 *key, CacheDirEntry *result, CacheDirEntry **last_collision);
+  int dir_probe(CryptoHash *key, CacheDirEntry *result, CacheDirEntry **last_collision);
   bool dir_valid(CacheDirEntry *e);
   bool validate_sync_serial();
   Errata updateHeaderFooter();

--- a/cmd/traffic_cache_tool/CacheTool.cc
+++ b/cmd/traffic_cache_tool/CacheTool.cc
@@ -199,7 +199,7 @@ struct Cache {
   void dumpSpans(SpanDumpDepth depth);
   void dumpVolumes();
   void build_stripe_hash_table();
-  Stripe *key_to_stripe(INK_MD5 *key, const char *hostname, int host_len);
+  Stripe *key_to_stripe(CryptoHash *key, const char *hostname, int host_len);
   //  ts::CacheStripeBlocks calcTotalSpanPhysicalSize();
   ts::CacheStripeBlocks calcTotalSpanConfiguredSize();
 
@@ -992,7 +992,7 @@ Cache::build_stripe_hash_table()
 }
 
 Stripe *
-Cache::key_to_stripe(INK_MD5 *key, const char *hostname, int host_len)
+Cache::key_to_stripe(CryptoHash *key, const char *hostname, int host_len)
 {
   uint32_t h = (key->slice32(2) >> DIR_TAG_WIDTH) % VOL_HASH_TABLE_SIZE;
   return globalVec_stripe[stripes_hash_table[h]];
@@ -1174,8 +1174,8 @@ Find_Stripe(FilePath const &input_file_path)
     cache.dumpSpans(Cache::SpanDumpDepth::SPAN);
     cache.build_stripe_hash_table();
     for (auto host : cache.URLset) {
-      MD5Context ctx;
-      INK_MD5 hashT;
+      CryptoContext ctx;
+      CryptoHash hashT;
       ts::LocalBufferWriter<33> w;
       ctx.update(host->url.data(), host->url.size());
       ctx.update(&host->port, sizeof(host->port));
@@ -1302,8 +1302,8 @@ Get_Response(FilePath const &input_file_path)
     cache.dumpSpans(Cache::SpanDumpDepth::SPAN);
     cache.build_stripe_hash_table();
     for (auto host : cache.URLset) {
-      MD5Context ctx;
-      INK_MD5 hashT;
+      CryptoContext ctx;
+      CryptoHash hashT;
       ts::LocalBufferWriter<33> w;
       ctx.update(host->url.data(), host->url.size());
       ctx.update(&host->port, sizeof(host->port));

--- a/cmd/traffic_cache_tool/Makefile.am
+++ b/cmd/traffic_cache_tool/Makefile.am
@@ -35,6 +35,8 @@ traffic_cache_tool_LDADD = \
 	$(top_builddir)/lib/ts/.libs/TextView.o \
 	$(top_builddir)/lib/tsconfig/.libs/Errata.o \
 	$(top_builddir)/lib/ts/.libs/Regex.o \
+	$(top_builddir)/lib/ts/.libs/CryptoHash.o \
+	$(top_builddir)/lib/ts/.libs/MMH.o \
 	@OPENSSL_LIBS@ @LIBPCRE@
 
 all-am: Makefile $(PROGRAMS)


### PR DESCRIPTION
replacing md5_cts with cryptocontext since that is what ATS uses