### PR TITLE
Ran clang-tidy with modernize-loop-convert

### DIFF
--- a/cmd/traffic_cache_tool/CacheDefs.cc
+++ b/cmd/traffic_cache_tool/CacheDefs.cc
@@ -229,15 +229,15 @@ Stripe::InitializeMeta()
 {
   Errata zret;
   // memset(this->raw_dir, 0, dir_len);
-  for (int i = 0; i < 2; i++) {
-    for (int j = 0; j < 2; j++) {
-      _meta[i][j].magic             = StripeMeta::MAGIC;
-      _meta[i][j].version.ink_major = ts::CACHE_DB_MAJOR_VERSION;
-      _meta[i][j].version.ink_minor = ts::CACHE_DB_MINOR_VERSION;
-      _meta[i][j].agg_pos = _meta[i][j].last_write_pos = _meta[i][j].write_pos = this->_content;
-      _meta[i][j].phase = _meta[i][j].cycle = _meta[i][j].sync_serial = _meta[i][j].write_serial = _meta[i][j].dirty = 0;
-      _meta[i][j].create_time = time(nullptr);
-      _meta[i][j].sector_size = DEFAULT_HW_SECTOR_SIZE;
+  for (auto &i : _meta) {
+    for (auto &j : i) {
+      j.magic             = StripeMeta::MAGIC;
+      j.version.ink_major = ts::CACHE_DB_MAJOR_VERSION;
+      j.version.ink_minor = ts::CACHE_DB_MINOR_VERSION;
+      j.agg_pos = j.last_write_pos = j.write_pos = this->_content;
+      j.phase = j.cycle = j.sync_serial = j.write_serial = j.dirty = 0;
+      j.create_time                                                = time(nullptr);
+      j.sector_size                                                = DEFAULT_HW_SECTOR_SIZE;
     }
   }
   if (!freelist) // freelist is not allocated yet

--- a/example/cppapi/serverresponse/ServerResponse.cc
+++ b/example/cppapi/serverresponse/ServerResponse.cc
@@ -106,8 +106,8 @@ private:
     for (auto &&header : headers) {
       cout << "Header " << header.name() << ": " << endl;
 
-      for (HeaderField::iterator value_iter = header.begin(), values_end = header.end(); value_iter != values_end; ++value_iter) {
-        cout << "\t" << *value_iter << endl;
+      for (auto &&value_iter : header) {
+        cout << "\t" << value_iter << endl;
       }
     }
 

--- a/iocore/dns/P_DNSProcessor.h
+++ b/iocore/dns/P_DNSProcessor.h
@@ -165,8 +165,8 @@ struct DNSEntry : public Continuation {
 
   DNSEntry()
   {
-    for (int i = 0; i < MAX_DNS_RETRIES; i++)
-      id[i]    = -1;
+    for (int &i : id)
+      i = -1;
     memset(qname, 0, MAXDNAME);
   }
 };

--- a/iocore/eventsystem/I_IOBuffer.h
+++ b/iocore/eventsystem/I_IOBuffer.h
@@ -1100,18 +1100,18 @@ public:
     if (_writer) {
       _writer->reset();
     }
-    for (int j = 0; j < MAX_MIOBUFFER_READERS; j++)
-      if (readers[j].allocated()) {
-        readers[j].reset();
+    for (auto &reader : readers)
+      if (reader.allocated()) {
+        reader.reset();
       }
   }
 
   void
   init_readers()
   {
-    for (int j = 0; j < MAX_MIOBUFFER_READERS; j++)
-      if (readers[j].allocated() && !readers[j].block)
-        readers[j].block = _writer;
+    for (auto &reader : readers)
+      if (reader.allocated() && !reader.block)
+        reader.block = _writer;
   }
 
   void

--- a/iocore/eventsystem/P_IOBuffer.h
+++ b/iocore/eventsystem/P_IOBuffer.h
@@ -1036,9 +1036,9 @@ TS_INLINE int
 MIOBuffer::max_block_count()
 {
   int maxb = 0;
-  for (int i = 0; i < MAX_MIOBUFFER_READERS; i++) {
-    if (readers[i].allocated()) {
-      int c = readers[i].block_count();
+  for (auto &reader : readers) {
+    if (reader.allocated()) {
+      int c = reader.block_count();
       if (c > maxb) {
         maxb = c;
       }
@@ -1052,9 +1052,9 @@ MIOBuffer::max_read_avail()
 {
   int64_t s = 0;
   int found = 0;
-  for (int i = 0; i < MAX_MIOBUFFER_READERS; i++) {
-    if (readers[i].allocated()) {
-      int64_t ss = readers[i].read_avail();
+  for (auto &reader : readers) {
+    if (reader.allocated()) {
+      int64_t ss = reader.read_avail();
       if (ss > s) {
         s = ss;
       }
@@ -1160,9 +1160,9 @@ IOBufferReader::dealloc()
 TS_INLINE void
 MIOBuffer::dealloc_all_readers()
 {
-  for (int i = 0; i < MAX_MIOBUFFER_READERS; i++)
-    if (readers[i].allocated())
-      dealloc_reader(&readers[i]);
+  for (auto &reader : readers)
+    if (reader.allocated())
+      dealloc_reader(&reader);
 }
 
 TS_INLINE void

--- a/plugins/esi/lib/Variables.h
+++ b/plugins/esi/lib/Variables.h
@@ -55,8 +55,8 @@ public:
   void
   populate(const HttpHeaderList &headers)
   {
-    for (HttpHeaderList::const_iterator iter = headers.begin(); iter != headers.end(); ++iter) {
-      populate(*iter);
+    for (const auto &header : headers) {
+      populate(header);
     }
   };
 

--- a/proxy/hdrs/HdrHeap.h
+++ b/proxy/hdrs/HdrHeap.h
@@ -279,9 +279,9 @@ public:
       if (heap->m_read_write_heap && heap->m_read_write_heap->contains(str)) {
         m_ptr = heap->m_read_write_heap.get();
       } else {
-        for (int i = 0; i < HDR_BUF_RONLY_HEAPS; ++i) {
-          if (heap->m_ronly_heap[i].contains(str)) {
-            m_ptr = heap->m_ronly_heap[i].m_ref_count_ptr;
+        for (auto &i : heap->m_ronly_heap) {
+          if (i.contains(str)) {
+            m_ptr = i.m_ref_count_ptr;
             break;
           }
         }

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -128,8 +128,8 @@ private:
 inline bool
 HttpVCTable::is_table_clear() const
 {
-  for (int i = 0; i < vc_table_max_entries; i++) {
-    if (vc_table[i].vc != nullptr) {
+  for (const auto &i : vc_table) {
+    if (i.vc != nullptr) {
       return false;
     }
   }

--- a/proxy/http/HttpTunnel.h
+++ b/proxy/http/HttpTunnel.h
@@ -395,15 +395,15 @@ HttpTunnel::is_tunnel_alive() const
 {
   bool tunnel_alive = false;
 
-  for (int i = 0; i < MAX_PRODUCERS; i++) {
-    if (producers[i].alive == true) {
+  for (const auto &producer : producers) {
+    if (producer.alive == true) {
       tunnel_alive = true;
       break;
     }
   }
   if (!tunnel_alive) {
-    for (int i = 0; i < MAX_CONSUMERS; i++) {
-      if (consumers[i].alive == true) {
+    for (const auto &consumer : consumers) {
+      if (consumer.alive == true) {
         tunnel_alive = true;
         break;
       }
@@ -504,8 +504,8 @@ HttpTunnel::append_message_to_producer_buffer(HttpTunnelProducer *p, const char 
 inline bool
 HttpTunnel::has_cache_writer() const
 {
-  for (int i = 0; i < MAX_CONSUMERS; i++) {
-    if (consumers[i].vc_type == HT_CACHE_WRITE && consumers[i].vc != nullptr) {
+  for (const auto &consumer : consumers) {
+    if (consumer.vc_type == HT_CACHE_WRITE && consumer.vc != nullptr) {
       return true;
     }
   }


### PR DESCRIPTION
Ran clang-tidy 6.0.0 over the code base to get ready for branching for the 8.0.0 release.

Included headers this time.