### PR TITLE
Define htobe64 for macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1638,6 +1638,7 @@ AC_CHECK_HEADERS([sys/types.h \
                   sys/pset.h \
                   sched.h \
                   pthread.h \
+                  sys/endian.h \
                   machine/endian.h \
                   endian.h \
                   sys/sysinfo.h \

--- a/lib/ts/ink_endian.h
+++ b/lib/ts/ink_endian.h
@@ -1,0 +1,51 @@
+/** @file
+ *
+ *  Endian convertion routines
+ *
+ *  @section license License
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#ifdef HAVE_SYS_ENDIAN_H
+#include <sys/endian.h>
+#endif
+#ifdef HAVE_MACHINE_ENDIAN_H
+#include <machine/endian.h>
+#endif
+#ifdef HAVE_ENDIAN_H
+#include <endian.h>
+#endif
+#ifdef HAVE_SYS_BYTEORDER_H
+#include <sys/byteorder.h>
+#endif
+
+#if defined(darwin)
+#include <libkern/OSByteOrder.h>
+inline uint64_t
+be64toh(uint64_t x)
+{
+  return OSSwapBigToHostInt64(x);
+}
+inline uint64_t
+htobe64(uint64_t x)
+{
+  return OSSwapHostToBigInt64(x);
+}
+#endif

--- a/lib/ts/ink_platform.h
+++ b/lib/ts/ink_platform.h
@@ -137,15 +137,7 @@ struct ifafilt;
 #include <stropts.h>
 #endif
 
-#ifdef HAVE_MACHINE_ENDIAN_H
-#include <machine/endian.h>
-#endif
-#ifdef HAVE_ENDIAN_H
-#include <endian.h>
-#endif
-#ifdef HAVE_SYS_BYTEORDER_H
-#include <sys/byteorder.h>
-#endif
+#include "ink_endian.h"
 
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>


### PR DESCRIPTION
After #3448, master is not compilable on macOS.

```
CXX      ink_inet.lo
ink_inet.cc:315:31: error: use of undeclared identifier 'htobe64'
            mask          = htobe64(~static_cast<uint64_t>(0) << (64 - cidr));
                            ^
ink_inet.cc:329:24: error: use of undeclared identifier 'htobe64'
              mask = htobe64(~static_cast<uint64_t>(0) << (128 - cidr));
                     ^
2 errors generated.
```

macOS provides platform specific functions, but their signatures are actually the same as htobe64 and htobe64. So we can simply define aliases.

```
#define be64toh(x) OSSwapBigToHostInt64(x)
#define htobe64(x) OSSwapHostToBigInt64(x)
```

The macros have been working perfectly on quic-latest branch.