### PR TITLE
Change ip_allow.config to support network masks.

### DIFF
--- a/doc/admin-guide/files/ip_allow.config.en.rst
+++ b/doc/admin-guide/files/ip_allow.config.en.rst
@@ -15,81 +15,120 @@
   specific language governing permissions and limitations
   under the License.
 
+.. include:: ../../common.defs
+.. highlight:: none
+
 ===============
 ip_allow.config
 ===============
 
 .. configfile:: ip_allow.config
 
-The :file:`ip_allow.config` file controls client access to the Traffic
-Server proxy cache and Traffic Server connections to the servers. You
-can specify ranges of IP addresses that are allowed to use the Traffic
-Server as a web proxy cache or that are allowed to be remapped by
-Traffic Server. After you modify the :file:`ip_allow.config` file,
-navigate to the Traffic Server bin directory and run the
-:option:`traffic_ctl config reload` command to apply changes. When
-you apply the changes to a node in a cluster, Traffic Server
-automatically applies the changes to all other nodes in the cluster.
+The :file:`ip_allow.config` file controls client access to |TS| and |TS| connections to the servers.
+You can specify ranges of IP addresses that are allowed to connect to |TS| or that are allowed to be
+remapped by Traffic Server. After you modify the :file:`ip_allow.config` file, navigate to the |TS|
+bin directory and run the :option:`traffic_ctl config reload` command to apply changes.
 
 Format
 ======
 
-Each line in the :file:`ip_allow.config` file must have the following
+Each line in :file:`ip_allow.config` file must have on of the following formats
 format::
 
     src_ip=<range of IP addresses> action=<action> [method=<list of methods separated by '|'>]
     dest_ip=<range of IP addresses> action=<action> [method=<list of methods separated by '|'>]
 
-where src_ip is the IP address or range of IP addresses of the
-client(s) and dest_ip is the IP address or range of IP addresses of the
-server(s). When src_ip is indicated, the action ``ip_allow`` enables
-the specified client(s) to access the Traffic Server proxy cache,
-and ``ip_deny`` denies the specified client(s) to access the Traffic
-Server proxy cache. When dest_ip is indicated, the action ``ip_allow``
-enables the Traffic Server to access the specified server(s), and
-``ip_deny`` denies the Traffic Server to access the specified server(s).
-Multiple method keywords can be specified (method=GET method=HEAD), or
-multiple methods can be separated by an '\|' (method=GET\|HEAD). The method
-keyword is optional and it is defaulted to ALL. This supports ANY string
-as the HTTP method, meaning no validation is done to check whether it
-is a valid HTTP method. This allows you to create filters for any method
-that your origin may require, this is especially useful if you use newer
-methods that aren't know to trafficserver (such as PROPFIND) or if your
-origin uses an http-ish protocol.
+For ``src_ip`` the remote inbound connection address, i.e. the IP address of the client, is checked
+against the specified range of IP addresses. For ``dst_ip`` the outbound remote address (i.e. the IP
+address to which |TS| connects) is checked against the specified IP address range.
 
-By default, the :file:`ip_allow.config` file contains the following lines,
-which allows all methods to localhost to access the Traffic Server proxy
-cache and denies PUSH, PURGE and DELETE to all IPs (note this allows all
-other methods to all IPs)::
+Range specifications can be IPv4 or IPv6, but any single range must be one or the other. Ranges can
+be specified by two addresses, the lower address and the upper address, separated by a dash, ``-``.
+Such a range inclusive and contains the lower, upper addresses and all addresses inbetween. A range
+can also be specified by an address and a CIDR mask, separated by a slash, ``/``. This case is
+converted to a range of the previous case by retaining only the left most ``mask`` bits, clearing
+the rest for the lower address and setting them for the upper address. For instance, a mask of
+``23`` would mean the left most 23 bits are kept and all bits to the right are cleared or set.
+Finally, a range can be a single IP address which matches exactly that address (the equivalent of a
+range with the lower and upper values equal to that IP address).
+
+The value of ``method`` is a string which must consist of either HTTP method names separated by the
+character '|' or the keyword literal ``ALL``. This keyword may omitted in which case it is treated
+as if it were ``method=ALL``. Methods can also be specified by having multiple instances of the
+``method`` keyword, each specifiying a single method. E.g., ``method=GET|HEAD`` is the same as
+``method=GET method=HEAD``. The method names are not validated which means non-standard method names
+can be specified.
+
+The ``action`` must be either ``ip_allow`` or ``ip_deny``. This controls what |TS| does if the
+address is in the range and the method matches. If there is a match, |TS| allows the connection (for
+``ip_allow``) or denies it (``ip_deny``).
+
+For each inbound or outbound connection the applicable rule is selectd by first match on the IP
+address. The rule is then applied (if the method matches) or its opposite is applied (if the method
+doesn't match). If no rule is matched access is allowed. This makes each rule both an accept and
+deny, one explicit and the other implicit. The ``src_ip`` rules are checked when a host connects
+to |TS|. The ``dst_ip`` rules are checked when |TS| connects to another host.
+
+By default the :file:`ip_allow.config` file contains the following lines, which allows all methods
+to connections from localhost and denies the ``PUSH``, ``PURGE`` and ``DELETE`` methods to all other
+IP addresses (note this allows all other methods to all IP addresses)::
 
     src_ip=127.0.0.1                                  action=ip_allow method=ALL
     src_ip=::1                                        action=ip_allow method=ALL
     src_ip=0.0.0.0-255.255.255.255                    action=ip_deny  method=PUSH|PURGE|DELETE
     src_ip=::-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff action=ip_deny  method=PUSH|PURGE|DELETE
 
+This could also be specified as::
+
+    src_ip=127.0.0.1   action=ip_allow method=ALL
+    src_ip=::1         action=ip_allow method=ALL
+    src_ip=0/0         action=ip_deny  method=PUSH|PURGE|DELETE
+    src_ip=::/0        action=ip_deny  method=PUSH|PURGE|DELETE
+
 Examples
 ========
 
-The following example enables all clients to access the Traffic Server
-proxy cache::
+The following example enables all clients access.::
 
-    src_ip=0.0.0.0-255.255.255.255 action=ip_allow
+   src_ip=0.0.0.0-255.255.255.255 action=ip_allow
 
-The following example allows all clients on a specific subnet to access
-the Traffic Server proxy cache::
+The following example allows access to all clients on addresses in a subnet::
 
-    src_ip=123.12.3.000-123.12.3.123 action=ip_allow
+   src_ip=123.12.3.000-123.12.3.123 action=ip_allow
 
-The following example denies all clients on a specific subnet to access
-the Traffic Server proxy cache::
+The following example denies access all clients on addresses in a subnet::
 
-    src_ip=123.45.6.0-123.45.6.123 action=ip_deny
+   src_ip=123.45.6.0-123.45.6.123 action=ip_deny
 
-The following example enables the Traffic Server to access all servers::
+If the entire subnet were to be denied, that would be::
 
-    dest_ip=0.0.0.0-255.255.255.255 action=ip_allow
+   src_ip=123.45.6.0/24 action=ip_deny
 
-The following example denies the Traffic Server to access all servers
-on a specific subnet::
+The following example allows to any upstream servers::
 
-    dest_ip=10.0.0.0-10.0.0.255 action=ip_deny
+   dest_ip=0.0.0.0-255.255.255.255 action=ip_allow
+
+Alternatively this can be done with::
+
+   dest_ip=0/0 action=ip_allow
+
+The following example denies to access all servers on a specific subnet::
+
+   dest_ip=10.0.0.0-10.0.255.255 action=ip_deny
+
+Alternatively::
+
+   dest_ip=10.0.0.0/16 action=ip_deny
+
+If the goal is to allow only ``GET`` and ``HEAD`` requests to those servers, it would be::
+
+   dest_ip=10.0.0.0/16 action=ip_allow method=GET method=HEAD
+
+or::
+
+   dest_ip=10.0.0.0/16 action=ip_allow method=GET|HEAD
+
+This will match the IP address for the targer servers on the outbound connection. Then, if the
+method is ``GET`` or ``HEAD`` the connection will be allowed, otherwise the connection will be
+denied.
+

--- a/lib/ts/IpMap.cc
+++ b/lib/ts/IpMap.cc
@@ -1,4 +1,5 @@
 #include "ts/IpMap.h"
+#include "ink_inet.h"
 
 /** @file
     IP address map support.

--- a/lib/ts/IpMap.h
+++ b/lib/ts/IpMap.h
@@ -273,6 +273,8 @@ public:
   /// Fill addresses (overload).
   self &fill(IpEndpoint const *min, IpEndpoint const *max, void *data = nullptr);
   /// Fill addresses (overload).
+  self &fill(IpAddr const &min, IpAddr const &max, void *data = nullptr);
+  /// Fill addresses (overload).
   self &fill(in_addr_t min, in_addr_t max, void *data = nullptr);
 
   /** Test for membership.
@@ -393,6 +395,15 @@ inline IpMap &
 IpMap::fill(IpEndpoint const *min, IpEndpoint const *max, void *data)
 {
   return this->fill(&min->sa, &max->sa, data);
+}
+
+inline IpMap &
+IpMap::fill(IpAddr const &min, IpAddr const &max, void *data)
+{
+  IpEndpoint x, y;
+  x.assign(min);
+  y.assign(max);
+  return this->fill(&x.sa, &y.sa, data);
 }
 
 inline bool

--- a/proxy/IPAllow.cc
+++ b/proxy/IPAllow.cc
@@ -174,8 +174,8 @@ IpAllow::BuildTable()
   char errBuf[1024];
   char *file_buf = nullptr;
   int line_num   = 0;
-  IpEndpoint addr1;
-  IpEndpoint addr2;
+  IpAddr addr1;
+  IpAddr addr2;
   matcher_line line_info;
   bool alarmAlready = false;
 
@@ -209,13 +209,7 @@ IpAllow::BuildTable()
       } else {
         ink_assert(line_info.type == MATCH_IP);
 
-        errPtr = ExtractIpRange(line_info.line[1][line_info.dest_entry], &addr1.sa, &addr2.sa);
-
-        if (errPtr != nullptr) {
-          snprintf(errBuf, sizeof(errBuf), "%s discarding %s entry at line %d : %s", module_name, config_file_path, line_num,
-                   errPtr);
-          SignalError(errBuf, alarmAlready);
-        } else {
+        if (0 == ats_ip_range_parse(line_info.line[1][line_info.dest_entry], addr1, addr2)) {
           // INKqa05845
           // Search for "action=ip_allow method=PURGE method=GET ..." or "action=ip_deny method=PURGE method=GET ...".
           char *label, *val;
@@ -288,12 +282,16 @@ IpAllow::BuildTable()
             IpMap &map                   = is_dest_ip ? _dest_map : _src_map;
             acls.push_back(AclRecord(acl_method_mask, line_num, nonstandard_methods, deny_nonstandard_methods));
             // Color with index in acls because at this point the address is volatile.
-            map.fill(&addr1, &addr2, reinterpret_cast<void *>(acls.size() - 1));
+            map.fill(addr1, addr2, reinterpret_cast<void *>(acls.size() - 1));
           } else {
             snprintf(errBuf, sizeof(errBuf), "%s discarding %s entry at line %d : %s", module_name, config_file_path, line_num,
                      "Invalid action/method specified"); // changed by YTS Team, yamsat bug id -59022
             SignalError(errBuf, alarmAlready);
           }
+        } else {
+          snprintf(errBuf, sizeof(errBuf), "%s discarding %s entry at line %d : %s", module_name, config_file_path, line_num,
+                   "invalid IP range");
+          SignalError(errBuf, alarmAlready);
         }
       }
     }


### PR DESCRIPTION
This makes use of the change in #3448. Using `ats_ip_range_parse` instead of `ExtractIpRange` enables masks and singletons for the ranges.

This does require a minor tweak to `IpMap`.