### PR TITLE
Selects version 1.4.2 of autest

### DIFF
--- a/tests/bootstrap.py
+++ b/tests/bootstrap.py
@@ -26,7 +26,7 @@ import platform
 import sys
 
 pip_packages = [
-    "autest",
+    "autest==1.4.2",
     "hyper",
     "requests",
     "dnslib",


### PR DESCRIPTION
As a developer, I would like to limit the version of autest that is installed, so that breaking changes do not break my automation that builds ATS.