### PR TITLE
TSThreadFunc should return a pointer

### DIFF
--- a/example/thread_pool/psi.c
+++ b/example/thread_pool/psi.c
@@ -987,7 +987,7 @@ TSPluginInit(int argc ATS_UNUSED, const char *argv[] ATS_UNUSED)
   for (i = 0; i < NB_THREADS; i++) {
     char *thread_name = (char *)TSmalloc(64);
     sprintf(thread_name, "Thread[%d]", i);
-    if (!TSThreadCreate((TSThreadFunc)thread_loop, thread_name)) {
+    if (!TSThreadCreate(thread_loop, thread_name)) {
       TSError("[%s] Failed creating threads", PLUGIN_NAME);
       return;
     }

--- a/example/thread_pool/thread.c
+++ b/example/thread_pool/thread.c
@@ -154,7 +154,7 @@ thread_init()
   pthread_cond_init(&cond, NULL);
 }
 
-void
+void *
 thread_loop(void *arg ATS_UNUSED)
 {
   Job *job_todo;
@@ -179,4 +179,5 @@ thread_loop(void *arg ATS_UNUSED)
       pthread_mutex_unlock(&cond_mutex);
     }
   }
+  return NULL;
 }

--- a/example/thread_pool/thread.h
+++ b/example/thread_pool/thread.h
@@ -77,4 +77,4 @@ void thread_signal_job();
 
 void thread_init();
 
-void thread_loop(void *arg);
+void *thread_loop(void *arg);


### PR DESCRIPTION
With gcc8:
```
CC       thread_pool/psi.lo
thread_pool/psi.c: In function 'TSPluginInit':
thread_pool/psi.c:990:25: error: cast between incompatible function types from 'void (*)(void *)' to 'void * (*)(void *)' [-Werror=cast-function-type]
   if (!TSThreadCreate((TSThreadFunc)thread_loop, thread_name)) {
                       ^
```

I'm not sure what pointer is expected to be return but it shouldn't be used right now.