### PR TITLE
Use variadic templates for rpc serialization

### DIFF
--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -578,11 +578,10 @@ LocalManager::handleMgmtMsgFromProcesses(MgmtMessageHdr *mh)
     break;
   // Congestion Control - end
   case MGMT_SIGNAL_CONFIG_FILE_CHILD: {
-    static const MgmtMarshallType fields[] = {MGMT_MARSHALL_STRING, MGMT_MARSHALL_STRING, MGMT_MARSHALL_INT};
-    char *parent                           = nullptr;
-    char *child                            = nullptr;
-    MgmtMarshallInt options                = 0;
-    if (mgmt_message_parse(data_raw, mh->data_len, fields, countof(fields), &parent, &child, &options) != -1) {
+    char *parent            = nullptr;
+    char *child             = nullptr;
+    MgmtMarshallInt options = 0;
+    if (mgmt_message_parse(data_raw, mh->data_len, &parent, &child, &options) != -1) {
       configFiles->configFileChild(parent, child, (unsigned int)options);
     } else {
       mgmt_log("[LocalManager::handleMgmtMsgFromProcesses] "

--- a/mgmt/ProcessManager.cc
+++ b/mgmt/ProcessManager.cc
@@ -218,14 +218,12 @@ ProcessManager::reconfigure()
 void
 ProcessManager::signalConfigFileChild(const char *parent, const char *child, unsigned int options)
 {
-  static const MgmtMarshallType fields[] = {MGMT_MARSHALL_STRING, MGMT_MARSHALL_STRING, MGMT_MARSHALL_INT};
-
   MgmtMarshallInt mgmtopt = options;
 
-  size_t len   = mgmt_message_length(fields, countof(fields), &parent, &child, &mgmtopt);
+  size_t len   = mgmt_message_length(&parent, &child, &mgmtopt);
   void *buffer = ats_malloc(len);
 
-  mgmt_message_marshall(buffer, len, fields, countof(fields), &parent, &child, &mgmtopt);
+  mgmt_message_marshall(buffer, len, &parent, &child, &mgmtopt);
   signalManager(MGMT_SIGNAL_CONFIG_FILE_CHILD, (const char *)buffer, len);
 
   ats_free(buffer);

--- a/mgmt/api/CoreAPIRemote.cc
+++ b/mgmt/api/CoreAPIRemote.cc
@@ -101,7 +101,7 @@ send_and_parse_list(OpType op, LLQ *list)
     goto done;
   }
 
-  ret = recv_mgmt_response(reply.ptr, reply.len, op, &err, &strval);
+  ret = parse_mgmt_message(reply.ptr, reply.len, op, &err, &strval);
   if (ret != TS_ERR_OKAY) {
     goto done;
   }
@@ -168,7 +168,7 @@ mgmt_record_set(const char *rec_name, const char *rec_val, TSActionNeedT *action
     return ret;
   }
 
-  ret = recv_mgmt_response(reply.ptr, reply.len, OpType::RECORD_SET, &err, &action);
+  ret = parse_mgmt_message(reply.ptr, reply.len, OpType::RECORD_SET, &err, &action);
   ats_free(reply.ptr);
 
   if (ret != TS_ERR_OKAY) {
@@ -314,7 +314,7 @@ ProxyStateGet()
     return TS_PROXY_UNDEFINED;
   }
 
-  ret = recv_mgmt_response(reply.ptr, reply.len, OpType::PROXY_STATE_GET, &err, &state);
+  ret = parse_mgmt_message(reply.ptr, reply.len, OpType::PROXY_STATE_GET, &err, &state);
   ats_free(reply.ptr);
 
   if (ret != TS_ERR_OKAY || err != TS_ERR_OKAY) {
@@ -357,7 +357,7 @@ ServerBacktrace(unsigned options, char **trace)
     goto fail;
   }
 
-  ret = recv_mgmt_response(reply.ptr, reply.len, OpType::SERVER_BACKTRACE, &err, &strval);
+  ret = parse_mgmt_message(reply.ptr, reply.len, OpType::SERVER_BACKTRACE, &err, &strval);
   if (ret != TS_ERR_OKAY) {
     goto fail;
   }
@@ -552,7 +552,7 @@ mgmt_record_get_reply(OpType op, TSRecordEle *rec_ele)
     return ret;
   }
 
-  ret = recv_mgmt_response(reply.ptr, reply.len, op, &err, &rclass, &type, &name, &value);
+  ret = parse_mgmt_message(reply.ptr, reply.len, op, &err, &rclass, &type, &name, &value);
   ats_free(reply.ptr);
   if (ret != TS_ERR_OKAY) {
     goto done;
@@ -602,7 +602,7 @@ mgmt_record_describe_reply(TSConfigRecordDescription *val)
   MgmtMarshallInt checktype;
   MgmtMarshallInt source;
 
-  ret = recv_mgmt_response(reply.ptr, reply.len, OpType::RECORD_DESCRIBE_CONFIG, &err, &name, &value, &deflt, &rtype, &rclass,
+  ret = parse_mgmt_message(reply.ptr, reply.len, OpType::RECORD_DESCRIBE_CONFIG, &err, &name, &value, &deflt, &rtype, &rclass,
                            &version, &rsb, &order, &access, &update, &updatetype, &checktype, &source, &expr);
 
   ats_free(reply.ptr);
@@ -941,7 +941,7 @@ EventIsActive(const char *event_name, bool *is_current)
     return ret;
   }
 
-  ret = recv_mgmt_response(reply.ptr, reply.len, OpType::EVENT_ACTIVE, &err, &bval);
+  ret = parse_mgmt_message(reply.ptr, reply.len, OpType::EVENT_ACTIVE, &err, &bval);
   ats_free(reply.ptr);
 
   if (ret != TS_ERR_OKAY) {

--- a/mgmt/api/EventControlMain.cc
+++ b/mgmt/api/EventControlMain.cc
@@ -446,7 +446,7 @@ handle_event_reg_callback(EventClientT *client, void *req, size_t reqlen)
   MgmtMarshallString name = nullptr;
   TSMgmtError ret;
 
-  ret = recv_mgmt_request(req, reqlen, OpType::EVENT_REG_CALLBACK, &optype, &name);
+  ret = parse_mgmt_message(req, reqlen, OpType::EVENT_REG_CALLBACK, &optype, &name);
   if (ret != TS_ERR_OKAY) {
     goto done;
   }
@@ -489,7 +489,7 @@ handle_event_unreg_callback(EventClientT *client, void *req, size_t reqlen)
   MgmtMarshallString name = nullptr;
   TSMgmtError ret;
 
-  ret = recv_mgmt_request(req, reqlen, OpType::EVENT_UNREG_CALLBACK, &optype, &name);
+  ret = parse_mgmt_message(req, reqlen, OpType::EVENT_UNREG_CALLBACK, &optype, &name);
   if (ret != TS_ERR_OKAY) {
     goto done;
   }

--- a/mgmt/api/NetworkMessage.cc
+++ b/mgmt/api/NetworkMessage.cc
@@ -31,163 +31,6 @@
 #define MAX_OPERATION_BUFSZ 1024
 #define MAX_OPERATION_FIELDS 16
 
-struct NetCmdOperation {
-  unsigned nfields;
-  const MgmtMarshallType fields[MAX_OPERATION_FIELDS];
-};
-
-// Requests always begin with a OpType, followed by aditional fields.
-static const struct NetCmdOperation requests[] = {
-  /* RECORD_SET                 */ {3, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING, MGMT_MARSHALL_STRING}},
-  /* RECORD_GET                 */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-  /* PROXY_STATE_GET            */ {1, {MGMT_MARSHALL_INT}},
-  /* PROXY_STATE_SET            */ {3, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
-  /* RECONFIGURE                */ {1, {MGMT_MARSHALL_INT}},
-  /* RESTART                    */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
-  /* BOUNCE                     */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
-  /* STOP                       */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
-  /* DRAIN                      */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
-  /* EVENT_RESOLVE              */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-  /* EVENT_GET_MLT              */ {1, {MGMT_MARSHALL_INT}},
-  /* EVENT_ACTIVE               */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-  /* EVENT_REG_CALLBACK         */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-  /* EVENT_UNREG_CALLBACK       */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-  /* EVENT_NOTIFY               */ {3, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING, MGMT_MARSHALL_STRING}}, // only msg sent from TM to
-                                                                                                         // client
-  /* STATS_RESET_NODE           */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-  /* STORAGE_DEVICE_CMD_OFFLINE */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-  /* RECORD_MATCH_GET           */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-  /* API_PING                   */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
-  /* SERVER_BACKTRACE           */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
-  /* RECORD_DESCRIBE_CONFIG     */ {3, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING, MGMT_MARSHALL_INT}},
-  /* LIFECYCLE_MESSAGE          */ {3, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING, MGMT_MARSHALL_DATA}},
-  /* HOST_STATUS_HOST_UP        */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-  /* HOST_STATUS_HOST_DOWN      */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-};
-
-// Responses always begin with a TSMgmtError code, followed by additional fields.
-static const struct NetCmdOperation responses[] = {
-  /* RECORD_SET                 */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
-  /* RECORD_GET                 */
-  {5, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT, MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING, MGMT_MARSHALL_DATA}},
-  /* PROXY_STATE_GET            */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
-  /* PROXY_STATE_SET            */ {1, {MGMT_MARSHALL_INT}},
-  /* RECONFIGURE                */ {1, {MGMT_MARSHALL_INT}},
-  /* RESTART                    */ {1, {MGMT_MARSHALL_INT}},
-  /* BOUNCE                     */ {1, {MGMT_MARSHALL_INT}},
-  /* STOP                       */ {1, {MGMT_MARSHALL_INT}},
-  /* DRAIN                      */ {1, {MGMT_MARSHALL_INT}},
-  /* EVENT_RESOLVE              */ {1, {MGMT_MARSHALL_INT}},
-  /* EVENT_GET_MLT              */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-  /* EVENT_ACTIVE               */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
-  /* EVENT_REG_CALLBACK         */ {0, {}}, // no reply
-  /* EVENT_UNREG_CALLBACK       */ {0, {}}, // no reply
-  /* EVENT_NOTIFY               */ {0, {}}, // no reply
-  /* STATS_RESET_NODE           */ {1, {MGMT_MARSHALL_INT}},
-  /* STORAGE_DEVICE_CMD_OFFLINE */ {1, {MGMT_MARSHALL_INT}},
-  /* RECORD_MATCH_GET           */
-  {5, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT, MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING, MGMT_MARSHALL_DATA}},
-  /* API_PING                   */ {0, {}}, // no reply
-  /* SERVER_BACKTRACE           */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-  /* RECORD_DESCRIBE_CONFIG     */
-  {15,
-   {MGMT_MARSHALL_INT /* status */, MGMT_MARSHALL_STRING /* name */, MGMT_MARSHALL_DATA /* value */,
-    MGMT_MARSHALL_DATA /* default */, MGMT_MARSHALL_INT /* type */, MGMT_MARSHALL_INT /* class */, MGMT_MARSHALL_INT /* version */,
-    MGMT_MARSHALL_INT /* rsb */, MGMT_MARSHALL_INT /* order */, MGMT_MARSHALL_INT /* access */, MGMT_MARSHALL_INT /* update */,
-    MGMT_MARSHALL_INT /* updatetype */, MGMT_MARSHALL_INT /* checktype */, MGMT_MARSHALL_INT /* source */,
-    MGMT_MARSHALL_STRING /* checkexpr */}},
-  /* LIFECYCLE_MESSAGE          */ {1, {MGMT_MARSHALL_INT}},
-  /* HOST_STATUS_UP             */ {1, {MGMT_MARSHALL_INT}},
-  /* HOST_STATUS_DOWN           */ {1, {MGMT_MARSHALL_INT}},
-};
-
-#define GETCMD(ops, optype, cmd)                           \
-  do {                                                     \
-    if (static_cast<unsigned>(optype) >= countof(ops)) {   \
-      return TS_ERR_PARAMS;                                \
-    }                                                      \
-    if (ops[static_cast<unsigned>(optype)].nfields == 0) { \
-      return TS_ERR_PARAMS;                                \
-    }                                                      \
-    cmd = &ops[static_cast<unsigned>(optype)];             \
-  } while (0);
-
-TSMgmtError
-send_mgmt_request(const mgmt_message_sender &snd, OpType optype, ...)
-{
-  va_list ap;
-  ats_scoped_mem<char> msgbuf;
-  MgmtMarshallInt msglen;
-  const MgmtMarshallType lenfield[] = {MGMT_MARSHALL_INT};
-  const NetCmdOperation *cmd;
-
-  if (!snd.is_connected()) {
-    return TS_ERR_NET_ESTABLISH; // no connection.
-  }
-
-  GETCMD(requests, optype, cmd);
-
-  va_start(ap, optype);
-  msglen = mgmt_message_length_v(cmd->fields, cmd->nfields, ap);
-  va_end(ap);
-
-  msgbuf = (char *)ats_malloc(msglen + 4);
-
-  // First marshall the total message length.
-  mgmt_message_marshall((char *)msgbuf, msglen, lenfield, countof(lenfield), &msglen);
-
-  // Now marshall the message itself.
-  va_start(ap, optype);
-  if (mgmt_message_marshall_v((char *)msgbuf + 4, msglen, cmd->fields, cmd->nfields, ap) == -1) {
-    va_end(ap);
-    return TS_ERR_PARAMS;
-  }
-
-  va_end(ap);
-  return snd.send(msgbuf, msglen + 4);
-}
-
-TSMgmtError
-send_mgmt_request(int fd, OpType optype, ...)
-{
-  va_list ap;
-  MgmtMarshallInt msglen;
-  MgmtMarshallData req            = {nullptr, 0};
-  const MgmtMarshallType fields[] = {MGMT_MARSHALL_DATA};
-  const NetCmdOperation *cmd;
-
-  GETCMD(requests, optype, cmd);
-
-  // Figure out the payload length.
-  va_start(ap, optype);
-  msglen = mgmt_message_length_v(cmd->fields, cmd->nfields, ap);
-  va_end(ap);
-
-  ink_assert(msglen >= 0);
-
-  req.ptr = (char *)ats_malloc(msglen);
-  req.len = msglen;
-
-  // Marshall the message itself.
-  va_start(ap, optype);
-  if (mgmt_message_marshall_v(req.ptr, req.len, cmd->fields, cmd->nfields, ap) == -1) {
-    ats_free(req.ptr);
-    va_end(ap);
-    return TS_ERR_PARAMS;
-  }
-
-  va_end(ap);
-
-  // Send the response as the payload of a data object.
-  if (mgmt_message_write(fd, fields, countof(fields), &req) == -1) {
-    ats_free(req.ptr);
-    return TS_ERR_NET_WRITE;
-  }
-
-  ats_free(req.ptr);
-  return TS_ERR_OKAY;
-}
-
 TSMgmtError
 send_mgmt_error(int fd, OpType optype, TSMgmtError error)
 {
@@ -210,27 +53,22 @@ send_mgmt_error(int fd, OpType optype, TSMgmtError error)
   case OpType::HOST_STATUS_UP:
   case OpType::HOST_STATUS_DOWN:
   case OpType::STORAGE_DEVICE_CMD_OFFLINE:
-    ink_release_assert(responses[static_cast<unsigned>(optype)].nfields == 1);
     return send_mgmt_response(fd, optype, &ecode);
 
   case OpType::RECORD_SET:
   case OpType::PROXY_STATE_GET:
   case OpType::EVENT_ACTIVE:
-    ink_release_assert(responses[static_cast<unsigned>(optype)].nfields == 2);
     return send_mgmt_response(fd, optype, &ecode, &intval);
 
   case OpType::EVENT_GET_MLT:
   case OpType::SERVER_BACKTRACE:
-    ink_release_assert(responses[static_cast<unsigned>(optype)].nfields == 2);
     return send_mgmt_response(fd, optype, &ecode, &strval);
 
   case OpType::RECORD_GET:
   case OpType::RECORD_MATCH_GET:
-    ink_release_assert(responses[static_cast<unsigned>(optype)].nfields == 5);
     return send_mgmt_response(fd, optype, &ecode, &intval, &intval, &strval, &dataval);
 
   case OpType::RECORD_DESCRIBE_CONFIG:
-    ink_release_assert(responses[static_cast<unsigned>(optype)].nfields == 15);
     return send_mgmt_response(fd, optype, &ecode, &strval /* name */, &dataval /* value */, &dataval /* default */,
                               &intval /* type */, &intval /* class */, &intval /* version */, &intval /* rsb */,
                               &intval /* order */, &intval /* access */, &intval /* update */, &intval /* updatetype */,
@@ -241,7 +79,6 @@ send_mgmt_error(int fd, OpType optype, TSMgmtError error)
   case OpType::EVENT_NOTIFY:
   case OpType::API_PING:
     /* no response for these */
-    ink_release_assert(responses[static_cast<unsigned>(optype)].nfields == 0);
     return TS_ERR_OKAY;
 
   case OpType::UNDEFINED_OP:
@@ -256,93 +93,10 @@ send_mgmt_error(int fd, OpType optype, TSMgmtError error)
   return TS_ERR_FAIL;
 }
 
-// Send a management message response. We don't need to worry about retransmitting the message if we get
-// disconnected, so this is much simpler. We can directly marshall the response as a data object.
-TSMgmtError
-send_mgmt_response(int fd, OpType optype, ...)
-{
-  va_list ap;
-  MgmtMarshallInt msglen;
-  MgmtMarshallData reply          = {nullptr, 0};
-  const MgmtMarshallType fields[] = {MGMT_MARSHALL_DATA};
-  const NetCmdOperation *cmd;
-
-  GETCMD(responses, optype, cmd);
-
-  va_start(ap, optype);
-  msglen = mgmt_message_length_v(cmd->fields, cmd->nfields, ap);
-  va_end(ap);
-
-  ink_assert(msglen >= 0);
-
-  reply.ptr = (char *)ats_malloc(msglen);
-  reply.len = msglen;
-
-  // Marshall the message itself.
-  va_start(ap, optype);
-  if (mgmt_message_marshall_v(reply.ptr, reply.len, cmd->fields, cmd->nfields, ap) == -1) {
-    ats_free(reply.ptr);
-    va_end(ap);
-    return TS_ERR_PARAMS;
-  }
-
-  va_end(ap);
-
-  // Send the response as the payload of a data object.
-  if (mgmt_message_write(fd, fields, countof(fields), &reply) == -1) {
-    ats_free(reply.ptr);
-    return TS_ERR_NET_WRITE;
-  }
-
-  ats_free(reply.ptr);
-  return TS_ERR_OKAY;
-}
-
-template <unsigned N>
-static TSMgmtError
-recv_x(const struct NetCmdOperation (&ops)[N], void *buf, size_t buflen, OpType optype, va_list ap)
-{
-  ssize_t msglen;
-  const NetCmdOperation *cmd;
-
-  GETCMD(ops, optype, cmd);
-
-  msglen = mgmt_message_parse_v(buf, buflen, cmd->fields, cmd->nfields, ap);
-  return (msglen == -1) ? TS_ERR_PARAMS : TS_ERR_OKAY;
-}
-
-TSMgmtError
-recv_mgmt_request(void *buf, size_t buflen, OpType optype, ...)
-{
-  TSMgmtError err;
-  va_list ap;
-
-  va_start(ap, optype);
-  err = recv_x(requests, buf, buflen, optype, ap);
-  va_end(ap);
-
-  return err;
-}
-
-TSMgmtError
-recv_mgmt_response(void *buf, size_t buflen, OpType optype, ...)
-{
-  TSMgmtError err;
-  va_list ap;
-
-  va_start(ap, optype);
-  err = recv_x(responses, buf, buflen, optype, ap);
-  va_end(ap);
-
-  return err;
-}
-
 TSMgmtError
 recv_mgmt_message(int fd, MgmtMarshallData &msg)
 {
-  const MgmtMarshallType fields[] = {MGMT_MARSHALL_DATA};
-
-  if (mgmt_message_read(fd, fields, countof(fields), &msg) == -1) {
+  if (mgmt_message_read(fd, &msg) == -1) {
     return TS_ERR_NET_READ;
   }
 
@@ -352,10 +106,9 @@ recv_mgmt_message(int fd, MgmtMarshallData &msg)
 OpType
 extract_mgmt_request_optype(void *msg, size_t msglen)
 {
-  const MgmtMarshallType fields[] = {MGMT_MARSHALL_INT};
   MgmtMarshallInt optype;
 
-  if (mgmt_message_parse(msg, msglen, fields, countof(fields), &optype) == -1) {
+  if (mgmt_message_parse(msg, msglen, &optype) == -1) {
     return OpType::UNDEFINED_OP;
   }
 

--- a/mgmt/api/NetworkMessage.h
+++ b/mgmt/api/NetworkMessage.h
@@ -72,23 +72,110 @@ struct mgmt_message_sender {
 };
 
 // Marshall and send a request, prefixing the message length as a MGMT_MARSHALL_INT.
-TSMgmtError send_mgmt_request(const mgmt_message_sender &snd, OpType optype, ...);
-TSMgmtError send_mgmt_request(int fd, OpType optype, ...);
+template <typename... Params>
+TSMgmtError
+send_mgmt_request(const mgmt_message_sender &snd, OpType optype, Params... params)
+{
+  ats_scoped_mem<char> msgbuf;
+  MgmtMarshallInt msglen;
 
-// Marshall and send an error respose for this operation type.
-TSMgmtError send_mgmt_error(int fd, OpType op, TSMgmtError error);
+  if (!snd.is_connected()) {
+    return TS_ERR_NET_ESTABLISH; // no connection.
+  }
 
-// Parse a request message from a buffer.
-TSMgmtError recv_mgmt_request(void *buf, size_t buflen, OpType optype, ...);
+  msglen = mgmt_message_length(params...);
+  msgbuf = (char *)ats_malloc(msglen + 4);
 
-// Marshall and send a response, prefixing the message length as a MGMT_MARSHALL_INT.
-TSMgmtError send_mgmt_response(int fd, OpType optype, ...);
+  // First marshall the total message length.
+  mgmt_message_marshall((char *)msgbuf, 4, &msglen);
 
-// Parse a response message from a buffer.
-TSMgmtError recv_mgmt_response(void *buf, size_t buflen, OpType optype, ...);
+  // Now marshall the message itself.
+  if (mgmt_message_marshall((char *)msgbuf + 4, msglen, params...) == -1) {
+    return TS_ERR_PARAMS;
+  }
+  return snd.send(msgbuf, msglen + 4);
+}
+
+template <typename... Params>
+TSMgmtError
+send_mgmt_request(int fd, OpType optype, Params... params)
+{
+  MgmtMarshallInt msglen;
+  MgmtMarshallData req = {nullptr, 0};
+
+  // Figure out the payload length.
+  msglen = mgmt_message_length(params...);
+
+  ink_assert(msglen >= 0);
+
+  req.ptr = (char *)ats_malloc(msglen);
+  req.len = msglen;
+
+  // Marshall the message itself.
+  if (mgmt_message_marshall(req.ptr, req.len, params...) == -1) {
+    ats_free(req.ptr);
+    return TS_ERR_PARAMS;
+  }
+
+  // Send the response as the payload of a data object.
+  if (mgmt_message_write(fd, &req) == -1) {
+    ats_free(req.ptr);
+    return TS_ERR_NET_WRITE;
+  }
+
+  ats_free(req.ptr);
+  return TS_ERR_OKAY;
+}
+
+// Parse a request or response message from a buffer.
+template <typename... Params>
+TSMgmtError
+parse_mgmt_message(void *buf, size_t buflen, OpType optype, Params... params)
+{
+  ssize_t err;
+
+  err = mgmt_message_parse(buf, buflen, params...);
+  return (err == -1) ? TS_ERR_PARAMS : TS_ERR_OKAY;
+}
 
 // Pull a management message (either request or response) off the wire.
 TSMgmtError recv_mgmt_message(int fd, MgmtMarshallData &msg);
+
+// Marshall and send a response, prefixing the message length as a MGMT_MARSHALL_INT.
+// Send a management message response. We don't need to worry about retransmitting the message if we get
+// disconnected, so this is much simpler. We can directly marshall the response as a data object.
+// Note, there is no need to send the optype as this is a response not a request.
+template <typename... Params>
+TSMgmtError
+send_mgmt_response(int fd, OpType optype, Params... params)
+{
+  MgmtMarshallInt msglen;
+  MgmtMarshallData reply = {nullptr, 0};
+
+  msglen = mgmt_message_length(params...);
+
+  ink_assert(msglen >= 0);
+
+  reply.ptr = (char *)ats_malloc(msglen);
+  reply.len = msglen;
+
+  // Marshall the message itself.
+  if (mgmt_message_marshall(reply.ptr, reply.len, params...) == -1) {
+    return TS_ERR_PARAMS;
+  }
+
+  // Send the response as the payload of a data object.
+  if (mgmt_message_write(fd, &reply) == -1) {
+    ats_free(reply.ptr);
+    return TS_ERR_NET_WRITE;
+  }
+
+  ats_free(reply.ptr);
+  return TS_ERR_OKAY;
+}
+
+// Marshall and send an error respose for this operation type.
+TSMgmtError send_mgmt_error(int fd, OpType op, TSMgmtError error);
 
 // Extract the first MGMT_MARSHALL_INT from the buffered message. This is the OpType.
 OpType extract_mgmt_request_optype(void *msg, size_t msglen);

--- a/mgmt/api/NetworkUtilsRemote.cc
+++ b/mgmt/api/NetworkUtilsRemote.cc
@@ -572,7 +572,7 @@ parse_generic_response(OpType optype, int fd)
     return err;
   }
 
-  err = recv_mgmt_response(data.ptr, data.len, optype, &ival);
+  err = parse_mgmt_message(data.ptr, data.len, optype, &ival);
   ats_free(data.ptr);
 
   if (err != TS_ERR_OKAY) {
@@ -634,7 +634,7 @@ event_poll_thread_main(void *arg)
       break;
     }
 
-    ret = recv_mgmt_request(reply.ptr, reply.len, OpType::EVENT_NOTIFY, &optype, &name, &desc);
+    ret = parse_mgmt_message(reply.ptr, reply.len, OpType::EVENT_NOTIFY, &optype, &name, &desc);
     ats_free(reply.ptr);
 
     if (ret != TS_ERR_OKAY) {

--- a/mgmt/api/TSControlMain.cc
+++ b/mgmt/api/TSControlMain.cc
@@ -381,7 +381,7 @@ handle_record_get(int fd, void *req, size_t reqlen)
 
   int fderr = fd; // [in,out] variable for the fd and error
 
-  ret = recv_mgmt_request(req, reqlen, OpType::RECORD_GET, &optype, &name);
+  ret = parse_mgmt_message(req, reqlen, OpType::RECORD_GET, &optype, &name);
   if (ret != TS_ERR_OKAY) {
     return ret;
   }
@@ -432,7 +432,7 @@ handle_record_match(int fd, void *req, size_t reqlen)
   MgmtMarshallInt optype;
   MgmtMarshallString name;
 
-  ret = recv_mgmt_request(req, reqlen, OpType::RECORD_MATCH_GET, &optype, &name);
+  ret = parse_mgmt_message(req, reqlen, OpType::RECORD_MATCH_GET, &optype, &name);
   if (ret != TS_ERR_OKAY) {
     return ret;
   }
@@ -476,7 +476,7 @@ handle_record_set(int fd, void *req, size_t reqlen)
   MgmtMarshallString name  = nullptr;
   MgmtMarshallString value = nullptr;
 
-  ret = recv_mgmt_request(req, reqlen, OpType::RECORD_SET, &optype, &name, &value);
+  ret = parse_mgmt_message(req, reqlen, OpType::RECORD_SET, &optype, &name, &value);
   if (ret != TS_ERR_OKAY) {
     ret = TS_ERR_FAIL;
     goto fail;
@@ -513,7 +513,7 @@ handle_proxy_state_get(int fd, void *req, size_t reqlen)
   MgmtMarshallInt err;
   MgmtMarshallInt state = TS_PROXY_UNDEFINED;
 
-  err = recv_mgmt_request(req, reqlen, OpType::PROXY_STATE_GET, &optype);
+  err = parse_mgmt_message(req, reqlen, OpType::PROXY_STATE_GET, &optype);
   if (err == TS_ERR_OKAY) {
     state = ProxyStateGet();
   }
@@ -537,7 +537,7 @@ handle_proxy_state_set(int fd, void *req, size_t reqlen)
 
   MgmtMarshallInt err;
 
-  err = recv_mgmt_request(req, reqlen, OpType::PROXY_STATE_SET, &optype, &state, &clear);
+  err = parse_mgmt_message(req, reqlen, OpType::PROXY_STATE_SET, &optype, &state, &clear);
   if (err != TS_ERR_OKAY) {
     return send_mgmt_response(fd, OpType::PROXY_STATE_SET, &err);
   }
@@ -559,7 +559,7 @@ handle_reconfigure(int fd, void *req, size_t reqlen)
   MgmtMarshallInt err;
   MgmtMarshallInt optype;
 
-  err = recv_mgmt_request(req, reqlen, OpType::RECONFIGURE, &optype);
+  err = parse_mgmt_message(req, reqlen, OpType::RECONFIGURE, &optype);
   if (err == TS_ERR_OKAY) {
     err = Reconfigure();
   }
@@ -581,7 +581,7 @@ handle_restart(int fd, void *req, size_t reqlen)
   MgmtMarshallInt options;
   MgmtMarshallInt err;
 
-  err = recv_mgmt_request(req, reqlen, OpType::RESTART, &optype, &options);
+  err = parse_mgmt_message(req, reqlen, OpType::RESTART, &optype, &options);
   if (err == TS_ERR_OKAY) {
     switch (optype) {
     case OpType::BOUNCE:
@@ -613,7 +613,7 @@ handle_stop(int fd, void *req, size_t reqlen)
   MgmtMarshallInt options;
   MgmtMarshallInt err;
 
-  err = recv_mgmt_request(req, reqlen, OpType::STOP, &optype, &options);
+  err = parse_mgmt_message(req, reqlen, OpType::STOP, &optype, &options);
   if (err == TS_ERR_OKAY) {
     err = Stop(options);
   }
@@ -635,7 +635,7 @@ handle_drain(int fd, void *req, size_t reqlen)
   MgmtMarshallInt options;
   MgmtMarshallInt err;
 
-  err = recv_mgmt_request(req, reqlen, OpType::DRAIN, &optype, &options);
+  err = parse_mgmt_message(req, reqlen, OpType::DRAIN, &optype, &options);
   if (err == TS_ERR_OKAY) {
     err = Drain(options);
   }
@@ -657,7 +657,7 @@ handle_storage_device_cmd_offline(int fd, void *req, size_t reqlen)
   MgmtMarshallString name = nullptr;
   MgmtMarshallInt err;
 
-  err = recv_mgmt_request(req, reqlen, OpType::STORAGE_DEVICE_CMD_OFFLINE, &optype, &name);
+  err = parse_mgmt_message(req, reqlen, OpType::STORAGE_DEVICE_CMD_OFFLINE, &optype, &name);
   if (err == TS_ERR_OKAY) {
     // forward to server
     lmgmt->signalEvent(MGMT_EVENT_STORAGE_DEVICE_CMD_OFFLINE, name);
@@ -680,7 +680,7 @@ handle_event_resolve(int fd, void *req, size_t reqlen)
   MgmtMarshallString name = nullptr;
   MgmtMarshallInt err;
 
-  err = recv_mgmt_request(req, reqlen, OpType::EVENT_RESOLVE, &optype, &name);
+  err = parse_mgmt_message(req, reqlen, OpType::EVENT_RESOLVE, &optype, &name);
   if (err == TS_ERR_OKAY) {
     err = EventResolve(name);
   }
@@ -708,7 +708,7 @@ handle_event_get_mlt(int fd, void *req, size_t reqlen)
   MgmtMarshallInt err;
   MgmtMarshallString list = nullptr;
 
-  err = recv_mgmt_request(req, reqlen, OpType::EVENT_GET_MLT, &optype);
+  err = parse_mgmt_message(req, reqlen, OpType::EVENT_GET_MLT, &optype);
   if (err != TS_ERR_OKAY) {
     goto done;
   }
@@ -756,7 +756,7 @@ handle_event_active(int fd, void *req, size_t reqlen)
   MgmtMarshallInt err;
   MgmtMarshallInt bval = 0;
 
-  err = recv_mgmt_request(req, reqlen, OpType::EVENT_ACTIVE, &optype, &name);
+  err = parse_mgmt_message(req, reqlen, OpType::EVENT_ACTIVE, &optype, &name);
   if (err != TS_ERR_OKAY) {
     goto done;
   }
@@ -789,7 +789,7 @@ handle_stats_reset(int fd, void *req, size_t reqlen)
   MgmtMarshallString name = nullptr;
   MgmtMarshallInt err;
 
-  err = recv_mgmt_request(req, reqlen, OpType::STATS_RESET_NODE, &optype, &name);
+  err = parse_mgmt_message(req, reqlen, OpType::STATS_RESET_NODE, &optype, &name);
   if (err == TS_ERR_OKAY) {
     err = StatsReset(name);
   }
@@ -811,7 +811,7 @@ handle_host_status_up(int fd, void *req, size_t reqlen)
   MgmtMarshallString name = nullptr;
   MgmtMarshallInt err;
 
-  err = recv_mgmt_request(req, reqlen, OpType::HOST_STATUS_UP, &optype, &name);
+  err = parse_mgmt_message(req, reqlen, OpType::HOST_STATUS_UP, &optype, &name);
   if (err == TS_ERR_OKAY) {
     err = HostStatusSetUp(name);
   }
@@ -833,7 +833,7 @@ handle_host_status_down(int fd, void *req, size_t reqlen)
   MgmtMarshallString name = nullptr;
   MgmtMarshallInt err;
 
-  err = recv_mgmt_request(req, reqlen, OpType::HOST_STATUS_DOWN, &optype, &name);
+  err = parse_mgmt_message(req, reqlen, OpType::HOST_STATUS_DOWN, &optype, &name);
   if (err == TS_ERR_OKAY) {
     err = HostStatusSetDown(name);
   }
@@ -854,7 +854,7 @@ handle_api_ping(int /* fd */, void *req, size_t reqlen)
   MgmtMarshallInt optype;
   MgmtMarshallInt stamp;
 
-  return recv_mgmt_request(req, reqlen, OpType::API_PING, &optype, &stamp);
+  return parse_mgmt_message(req, reqlen, OpType::API_PING, &optype, &stamp);
 }
 
 static TSMgmtError
@@ -865,7 +865,7 @@ handle_server_backtrace(int fd, void *req, size_t reqlen)
   MgmtMarshallString trace = nullptr;
   MgmtMarshallInt err;
 
-  err = recv_mgmt_request(req, reqlen, OpType::SERVER_BACKTRACE, &optype, &options);
+  err = parse_mgmt_message(req, reqlen, OpType::SERVER_BACKTRACE, &optype, &options);
   if (err == TS_ERR_OKAY) {
     err = ServerBacktrace(options, &trace);
   }
@@ -967,7 +967,7 @@ handle_record_describe(int fd, void *req, size_t reqlen)
   MgmtMarshallInt options;
   MgmtMarshallString name;
 
-  ret = recv_mgmt_request(req, reqlen, OpType::RECORD_DESCRIBE_CONFIG, &optype, &name, &options);
+  ret = parse_mgmt_message(req, reqlen, OpType::RECORD_DESCRIBE_CONFIG, &optype, &name, &options);
   if (ret != TS_ERR_OKAY) {
     return ret;
   }
@@ -1021,7 +1021,7 @@ handle_lifecycle_message(int fd, void *req, size_t reqlen)
   MgmtMarshallString tag;
   MgmtMarshallData data;
 
-  err = recv_mgmt_request(req, reqlen, OpType::LIFECYCLE_MESSAGE, &optype, &tag, &data);
+  err = parse_mgmt_message(req, reqlen, OpType::LIFECYCLE_MESSAGE, &optype, &tag, &data);
   if (err == TS_ERR_OKAY) {
     lmgmt->signalEvent(MGMT_EVENT_LIFECYCLE_MESSAGE, static_cast<char *>(req), reqlen);
   }

--- a/mgmt/utils/MgmtMarshall.cc
+++ b/mgmt/utils/MgmtMarshall.cc
@@ -54,6 +54,19 @@ data_is_nul_terminated(const MgmtMarshallData *data)
 }
 
 static ssize_t
+nospace()
+{
+  errno = EMSGSIZE;
+  return -1;
+}
+
+static bool
+empty_buf(const void *buf, size_t len)
+{
+  return (buf == nullptr || len == 0) ? true : false;
+}
+
+static ssize_t
 socket_read_bytes(int fd, void *buf, size_t needed)
 {
   size_t nread = 0;
@@ -195,337 +208,221 @@ fail:
   return -1;
 }
 
+//-----------------------------------------------------------------------
+// mgmt_message_length
+//-----------------------------------------------------------------------
 MgmtMarshallInt
-mgmt_message_length(const MgmtMarshallType *fields, unsigned count, ...)
+mgmt_message_length(MgmtMarshallInt *field)
 {
-  MgmtMarshallInt length;
-  va_list ap;
-
-  va_start(ap, count);
-  length = mgmt_message_length_v(fields, count, ap);
-  va_end(ap);
-
-  return length;
+  return 4;
 }
 
 MgmtMarshallInt
-mgmt_message_length_v(const MgmtMarshallType *fields, unsigned count, va_list ap)
+mgmt_message_length(MgmtMarshallLong *field)
 {
-  MgmtMarshallAnyPtr ptr;
-  MgmtMarshallInt nbytes = 0;
+  return 8;
+}
 
-  for (unsigned n = 0; n < count; ++n) {
-    switch (fields[n]) {
-    case MGMT_MARSHALL_INT:
-      ptr.m_int = va_arg(ap, MgmtMarshallInt *);
-      nbytes += 4;
-      break;
-    case MGMT_MARSHALL_LONG:
-      ptr.m_long = va_arg(ap, MgmtMarshallLong *);
-      nbytes += 8;
-      break;
-    case MGMT_MARSHALL_STRING:
-      nbytes += 4;
-      ptr.m_string = va_arg(ap, MgmtMarshallString *);
-      if (*ptr.m_string == nullptr) {
-        ptr.m_string = &empty;
-      }
-      nbytes += strlen(*ptr.m_string) + 1;
-      break;
-    case MGMT_MARSHALL_DATA:
-      nbytes += 4;
-      ptr.m_data = va_arg(ap, MgmtMarshallData *);
-      nbytes += ptr.m_data->len;
-      break;
-    default:
-      errno = EINVAL;
-      return -1;
-    }
+MgmtMarshallInt
+mgmt_message_length(MgmtMarshallString *field)
+{
+  if (*field == nullptr) {
+    field = &empty;
+  }
+  return 4 + strlen(*field) + 1;
+}
+
+MgmtMarshallInt
+mgmt_message_length(MgmtMarshallData *field)
+{
+  return 4 + field->len;
+}
+
+//-----------------------------------------------------------------------
+// mgmt_message_write
+//-----------------------------------------------------------------------
+ssize_t
+mgmt_message_write(int fd, MgmtMarshallInt *field)
+{
+  return socket_write_bytes(fd, field, 4);
+}
+
+ssize_t
+mgmt_message_write(int fd, MgmtMarshallLong *field)
+{
+  return socket_write_bytes(fd, field, 8);
+}
+
+ssize_t
+mgmt_message_write(int fd, MgmtMarshallString *field)
+{
+  MgmtMarshallData data;
+  if (*field == nullptr) {
+    field = &empty;
+  }
+  data.ptr = *field;
+  data.len = strlen(*field) + 1;
+  return socket_write_buffer(fd, &data);
+}
+
+ssize_t
+mgmt_message_write(int fd, MgmtMarshallData *field)
+{
+  return socket_write_buffer(fd, field);
+}
+
+//-----------------------------------------------------------------------
+// mgmgt_message_marshall
+//-----------------------------------------------------------------------
+ssize_t
+mgmt_message_marshall(void *buf, size_t remain, MgmtMarshallInt *field)
+{
+  if (empty_buf(buf, remain)) {
+    return 0;
+  }
+  if (remain < 4) {
+    return nospace();
+  }
+  memcpy(buf, field, 4);
+  return 4;
+}
+
+ssize_t
+mgmt_message_marshall(void *buf, size_t remain, MgmtMarshallLong *field)
+{
+  if (empty_buf(buf, remain)) {
+    return 0;
+  }
+  if (remain < 8) {
+    return nospace();
+  }
+  memcpy(buf, field, 8);
+  return 8;
+}
+
+ssize_t
+mgmt_message_marshall(void *buf, size_t remain, MgmtMarshallString *field)
+{
+  if (empty_buf(buf, remain)) {
+    return 0;
+  }
+  MgmtMarshallData data;
+  if (*field == nullptr) {
+    field = &empty;
   }
 
-  return nbytes;
-}
+  data.ptr = field;
+  data.len = strlen(*field) + 1;
 
-ssize_t
-mgmt_message_write(int fd, const MgmtMarshallType *fields, unsigned count, ...)
-{
-  ssize_t nbytes;
-  va_list ap;
-
-  va_start(ap, count);
-  nbytes = mgmt_message_write_v(fd, fields, count, ap);
-  va_end(ap);
-
-  return nbytes;
-}
-
-ssize_t
-mgmt_message_write_v(int fd, const MgmtMarshallType *fields, unsigned count, va_list ap)
-{
-  MgmtMarshallAnyPtr ptr;
-  ssize_t nbytes = 0;
-
-  for (unsigned n = 0; n < count; ++n) {
-    ssize_t nwritten = 0;
-
-    switch (fields[n]) {
-    case MGMT_MARSHALL_INT:
-      ptr.m_int = va_arg(ap, MgmtMarshallInt *);
-      nwritten  = socket_write_bytes(fd, ptr.m_void, 4);
-      break;
-    case MGMT_MARSHALL_LONG:
-      ptr.m_long = va_arg(ap, MgmtMarshallLong *);
-      nwritten   = socket_write_bytes(fd, ptr.m_void, 8);
-      break;
-    case MGMT_MARSHALL_STRING: {
-      MgmtMarshallData data;
-      ptr.m_string = va_arg(ap, MgmtMarshallString *);
-      if (*ptr.m_string == nullptr) {
-        ptr.m_string = &empty;
-      }
-      data.ptr = *ptr.m_string;
-      data.len = strlen(*ptr.m_string) + 1;
-      nwritten = socket_write_buffer(fd, &data);
-      break;
-    }
-    case MGMT_MARSHALL_DATA:
-      ptr.m_data = va_arg(ap, MgmtMarshallData *);
-      nwritten   = socket_write_buffer(fd, ptr.m_data);
-      break;
-    default:
-      errno = EINVAL;
-      return -1;
-    }
-
-    if (nwritten == -1) {
-      return -1;
-    }
-
-    nbytes += nwritten;
+  if (remain < (4 + data.len)) {
+    return nospace();
   }
 
-  return nbytes;
+  memcpy(buf, &data.len, 4);
+  memcpy((uint8_t *)buf + 4, data.ptr, data.len);
+  return 4 + data.len;
 }
 
 ssize_t
-mgmt_message_read(int fd, const MgmtMarshallType *fields, unsigned count, ...)
+mgmt_message_marshall(void *buf, size_t remain, MgmtMarshallData *field)
 {
-  ssize_t nbytes;
-  va_list ap;
+  if (empty_buf(buf, remain)) {
+    return 0;
+  }
+  if (remain < (4 + field->len)) {
+    return nospace();
+  }
+  memcpy(buf, &(field->len), 4);
+  memcpy((uint8_t *)buf + 4, field->ptr, field->len);
+  return 4 + field->len;
+}
 
-  va_start(ap, count);
-  nbytes = mgmt_message_read_v(fd, fields, count, ap);
-  va_end(ap);
-
-  return nbytes;
+//-----------------------------------------------------------------------
+// mgmt_message_read
+//-----------------------------------------------------------------------
+ssize_t
+mgmt_message_read(int fd, MgmtMarshallInt *field)
+{
+  return socket_read_bytes(fd, field, 4);
 }
 
 ssize_t
-mgmt_message_read_v(int fd, const MgmtMarshallType *fields, unsigned count, va_list ap)
+mgmt_message_read(int fd, MgmtMarshallLong *field)
 {
-  MgmtMarshallAnyPtr ptr;
-  ssize_t nbytes = 0;
+  return socket_read_bytes(fd, field, 8);
+}
 
-  for (unsigned n = 0; n < count; ++n) {
-    ssize_t nread;
+ssize_t
+mgmt_message_read(int fd, MgmtMarshallString *field)
+{
+  MgmtMarshallData data;
 
-    switch (fields[n]) {
-    case MGMT_MARSHALL_INT:
-      ptr.m_int = va_arg(ap, MgmtMarshallInt *);
-      nread     = socket_read_bytes(fd, ptr.m_void, 4);
-      break;
-    case MGMT_MARSHALL_LONG:
-      ptr.m_long = va_arg(ap, MgmtMarshallLong *);
-      nread      = socket_read_bytes(fd, ptr.m_void, 8);
-      break;
-    case MGMT_MARSHALL_STRING: {
-      MgmtMarshallData data;
-
-      nread = socket_read_buffer(fd, &data);
-      if (nread == -1) {
-        break;
-      }
-
-      ink_assert(data_is_nul_terminated(&data));
-      ptr.m_string  = va_arg(ap, MgmtMarshallString *);
-      *ptr.m_string = (char *)data.ptr;
-      break;
-    }
-    case MGMT_MARSHALL_DATA:
-      ptr.m_data = va_arg(ap, MgmtMarshallData *);
-      nread      = socket_read_buffer(fd, ptr.m_data);
-      break;
-    default:
-      errno = EINVAL;
-      return -1;
-    }
-
-    if (nread == -1) {
-      return -1;
-    }
-
-    nbytes += nread;
+  ssize_t nread = socket_read_buffer(fd, &data);
+  if (nread == -1) {
+    return -1;
   }
 
-  return nbytes;
+  ink_assert(data_is_nul_terminated(&data));
+  *field = (char *)data.ptr;
+  return nread;
 }
 
 ssize_t
-mgmt_message_marshall(void *buf, size_t remain, const MgmtMarshallType *fields, unsigned count, ...)
+mgmt_message_read(int fd, MgmtMarshallData *field)
 {
-  ssize_t nbytes = 0;
-  va_list ap;
-
-  va_start(ap, count);
-  nbytes = mgmt_message_marshall_v(buf, remain, fields, count, ap);
-  va_end(ap);
-
-  return nbytes;
+  return socket_read_buffer(fd, field);
 }
 
+//-----------------------------------------------------------------------
+// mgmt_message_parse
+//-----------------------------------------------------------------------
 ssize_t
-mgmt_message_marshall_v(void *buf, size_t remain, const MgmtMarshallType *fields, unsigned count, va_list ap)
+mgmt_message_parse(const void *buf, size_t len, MgmtMarshallInt *field)
 {
-  MgmtMarshallAnyPtr ptr;
-  ssize_t nbytes = 0;
-
-  for (unsigned n = 0; n < count; ++n) {
-    ssize_t nwritten = 0;
-
-    switch (fields[n]) {
-    case MGMT_MARSHALL_INT:
-      if (remain < 4) {
-        goto nospace;
-      }
-      ptr.m_int = va_arg(ap, MgmtMarshallInt *);
-      memcpy(buf, ptr.m_int, 4);
-      nwritten = 4;
-      break;
-    case MGMT_MARSHALL_LONG:
-      if (remain < 8) {
-        goto nospace;
-      }
-      ptr.m_long = va_arg(ap, MgmtMarshallLong *);
-      memcpy(buf, ptr.m_long, 8);
-      nwritten = 8;
-      break;
-    case MGMT_MARSHALL_STRING: {
-      MgmtMarshallData data;
-      ptr.m_string = va_arg(ap, MgmtMarshallString *);
-      if (*ptr.m_string == nullptr) {
-        ptr.m_string = &empty;
-      }
-
-      data.ptr = *ptr.m_string;
-      data.len = strlen(*ptr.m_string) + 1;
-
-      if (remain < (4 + data.len)) {
-        goto nospace;
-      }
-
-      memcpy(buf, &data.len, 4);
-      memcpy((uint8_t *)buf + 4, data.ptr, data.len);
-      nwritten = 4 + data.len;
-      break;
-    }
-    case MGMT_MARSHALL_DATA:
-      ptr.m_data = va_arg(ap, MgmtMarshallData *);
-      if (remain < (4 + ptr.m_data->len)) {
-        goto nospace;
-      }
-      memcpy(buf, &(ptr.m_data->len), 4);
-      memcpy((uint8_t *)buf + 4, ptr.m_data->ptr, ptr.m_data->len);
-      nwritten = 4 + ptr.m_data->len;
-      break;
-    default:
-      errno = EINVAL;
-      return -1;
-    }
-
-    nbytes += nwritten;
-    buf = (uint8_t *)buf + nwritten;
-    remain -= nwritten;
+  if (empty_buf(buf, len)) {
+    return 0;
+  }
+  if (len < 4) {
+    return nospace();
+  }
+  memcpy(field, buf, 4);
+  return 4;
+}
+ssize_t
+mgmt_message_parse(const void *buf, size_t len, MgmtMarshallLong *field)
+{
+  if (empty_buf(buf, len)) {
+    return 0;
+  }
+  if (len < 8) {
+    return nospace();
+  }
+  memcpy(field, buf, 8);
+  return 8;
+}
+ssize_t
+mgmt_message_parse(const void *buf, size_t len, MgmtMarshallString *field)
+{
+  if (empty_buf(buf, len)) {
+    return 0;
+  }
+  MgmtMarshallData data;
+  ssize_t nread = buffer_read_buffer((const uint8_t *)buf, len, &data);
+  if (nread == -1) {
+    return nospace();
   }
 
-  return nbytes;
+  ink_assert(data_is_nul_terminated(&data));
 
-nospace:
-  errno = EMSGSIZE;
-  return -1;
+  *field = (char *)data.ptr;
+  return nread;
 }
-
 ssize_t
-mgmt_message_parse(const void *buf, size_t len, const MgmtMarshallType *fields, unsigned count, ...)
+mgmt_message_parse(const void *buf, size_t len, MgmtMarshallData *field)
 {
-  MgmtMarshallInt nbytes = 0;
-  va_list ap;
-
-  va_start(ap, count);
-  nbytes = mgmt_message_parse_v(buf, len, fields, count, ap);
-  va_end(ap);
-
-  return nbytes;
-}
-
-ssize_t
-mgmt_message_parse_v(const void *buf, size_t len, const MgmtMarshallType *fields, unsigned count, va_list ap)
-{
-  MgmtMarshallAnyPtr ptr;
-  ssize_t nbytes = 0;
-
-  for (unsigned n = 0; n < count; ++n) {
-    ssize_t nread;
-
-    switch (fields[n]) {
-    case MGMT_MARSHALL_INT:
-      if (len < 4) {
-        goto nospace;
-      }
-      ptr.m_int = va_arg(ap, MgmtMarshallInt *);
-      memcpy(ptr.m_int, buf, 4);
-      nread = 4;
-      break;
-    case MGMT_MARSHALL_LONG:
-      if (len < 8) {
-        goto nospace;
-      }
-      ptr.m_long = va_arg(ap, MgmtMarshallLong *);
-      memcpy(ptr.m_int, buf, 8);
-      nread = 8;
-      break;
-    case MGMT_MARSHALL_STRING: {
-      MgmtMarshallData data;
-      nread = buffer_read_buffer((const uint8_t *)buf, len, &data);
-      if (nread == -1) {
-        goto nospace;
-      }
-
-      ink_assert(data_is_nul_terminated(&data));
-
-      ptr.m_string  = va_arg(ap, MgmtMarshallString *);
-      *ptr.m_string = (char *)data.ptr;
-      break;
-    }
-    case MGMT_MARSHALL_DATA:
-      ptr.m_data = va_arg(ap, MgmtMarshallData *);
-      nread      = buffer_read_buffer((const uint8_t *)buf, len, ptr.m_data);
-      if (nread == -1) {
-        goto nospace;
-      }
-      break;
-    default:
-      errno = EINVAL;
-      return -1;
-    }
-
-    nbytes += nread;
-    buf = (uint8_t *)buf + nread;
-    len -= nread;
+  if (empty_buf(buf, len)) {
+    return 0;
   }
-
-  return nbytes;
-
-nospace:
-  errno = EMSGSIZE;
-  return -1;
+  ssize_t nread = buffer_read_buffer((const uint8_t *)buf, len, field);
+  return (nread == -1) ? nospace() : nread;
 }

--- a/mgmt/utils/MgmtMarshall.h
+++ b/mgmt/utils/MgmtMarshall.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <stdarg.h>
+#include <iostream>
 
 #define MAX_TIME_WAIT 60 // num secs for a timeout on a select call (remote only)
 
@@ -61,17 +62,126 @@ struct MgmtMarshallData {
   size_t len;
 };
 
-MgmtMarshallInt mgmt_message_length(const MgmtMarshallType *fields, unsigned count, ...);
-MgmtMarshallInt mgmt_message_length_v(const MgmtMarshallType *fields, unsigned count, va_list ap);
+/// mgmt_message_length -------------------------------------------------------
+template <typename T>
+MgmtMarshallInt
+mgmt_message_length(T field)
+{
+  // We should always have a template specialization
+  // If we get here, it means we are marshalling an object of an invalid type.
+  errno = EINVAL;
+  return -1;
+}
+MgmtMarshallInt mgmt_message_length(MgmtMarshallInt *field);
+MgmtMarshallInt mgmt_message_length(MgmtMarshallLong *field);
+MgmtMarshallInt mgmt_message_length(MgmtMarshallString *field);
+MgmtMarshallInt mgmt_message_length(MgmtMarshallData *field);
 
-ssize_t mgmt_message_read(int fd, const MgmtMarshallType *fields, unsigned count, ...);
-ssize_t mgmt_message_read_v(int fd, const MgmtMarshallType *fields, unsigned count, va_list ap);
+template <typename T, typename... Rest>
+MgmtMarshallInt
+mgmt_message_length(T first, Rest... rest)
+{
+  MgmtMarshallInt len = mgmt_message_length(first);
+  return (len == -1) ? len + mgmt_message_length(rest...) : len;
+}
+/// end mgmt_message_length ---------------------------------------------------
 
-ssize_t mgmt_message_write(int fd, const MgmtMarshallType *fields, unsigned count, ...);
-ssize_t mgmt_message_write_v(int fd, const MgmtMarshallType *fields, unsigned count, va_list ap);
+/// mgmt_message_read ---------------------------------------------------------
+template <typename T>
+ssize_t
+mgmt_message_read(int fd, T field)
+{
+  // We should always have a template specialization
+  // If we get here, it means we are marshalling an object of an invalid type.
+  errno = EINVAL;
+  return -1;
+}
+ssize_t mgmt_message_read(int fd, MgmtMarshallInt *field);
+ssize_t mgmt_message_read(int fd, MgmtMarshallLong *field);
+ssize_t mgmt_message_read(int fd, MgmtMarshallString *field);
+ssize_t mgmt_message_read(int fd, MgmtMarshallData *field);
 
-ssize_t mgmt_message_parse(const void *ptr, size_t len, const MgmtMarshallType *fields, unsigned count, ...);
-ssize_t mgmt_message_parse_v(const void *ptr, size_t len, const MgmtMarshallType *fields, unsigned count, va_list ap);
+template <typename T, typename... Rest>
+ssize_t
+mgmt_message_read(int fd, T first, Rest... rest)
+{
+  ssize_t nbytes = mgmt_message_read(fd, first);
+  return (nbytes == -1) ? nbytes + mgmt_message_read(fd, rest...) : nbytes;
+}
+/// mgmt_message_read ---------------------------------------------------------
 
-ssize_t mgmt_message_marshall(void *ptr, size_t len, const MgmtMarshallType *fields, unsigned count, ...);
-ssize_t mgmt_message_marshall_v(void *ptr, size_t len, const MgmtMarshallType *fields, unsigned count, va_list ap);
+/// mgmt_message_write --------------------------------------------------------
+template <typename T>
+ssize_t
+mgmt_message_write(int fd, T field)
+{
+  // We should always have a template specialization
+  // If we get here, it means we are marshalling an object of an invalid type.
+  errno = EINVAL;
+  return -1;
+}
+ssize_t mgmt_message_write(int fd, MgmtMarshallInt *field);
+ssize_t mgmt_message_write(int fd, MgmtMarshallLong *field);
+ssize_t mgmt_message_write(int fd, MgmtMarshallString *field);
+ssize_t mgmt_message_write(int fd, MgmtMarshallData *field);
+
+template <typename T, typename... Rest>
+ssize_t
+mgmt_message_write(int fd, T first, Rest... rest)
+{
+  ssize_t nbytes = mgmt_message_write(fd, first);
+  return (nbytes != -1) ? nbytes + mgmt_message_write(fd, rest...) : nbytes;
+}
+/// end mgmt_message_write ----------------------------------------------------
+
+/// mgmt_message_marshall -----------------------------------------------------
+template <typename T>
+ssize_t
+mgmt_message_marshall(void *buf, size_t remain, T field)
+{
+  // We should always have a template specialization
+  // If we get here, it means we are marshalling an object of an invalid type.
+  errno = EINVAL;
+  return -1;
+}
+
+ssize_t mgmt_message_marshall(void *buf, size_t remain, MgmtMarshallInt *field);
+ssize_t mgmt_message_marshall(void *buf, size_t remain, MgmtMarshallLong *field);
+ssize_t mgmt_message_marshall(void *buf, size_t remain, MgmtMarshallString *field);
+ssize_t mgmt_message_marshall(void *buf, size_t remain, MgmtMarshallData *field);
+
+template <typename T, typename... Rest>
+ssize_t
+mgmt_message_marshall(void *buf, size_t remain, T first, Rest... rest)
+{
+  ssize_t nbytes = mgmt_message_marshall(buf, remain, first);
+  return (nbytes != -1) ? nbytes + mgmt_message_marshall(static_cast<uint8_t *>(buf) + nbytes, remain - nbytes, rest...) : nbytes;
+}
+/// end mgmt_message_marshall ---------------------------------------------------
+
+/// mgmt_message_parse ----------------------------------------------------------
+template <typename T>
+ssize_t
+mgmt_message_parse(const void *buf, size_t len, T field)
+{
+  // We should always have a template specialization
+  // If we get here, it means we are marshalling an object of an invalid type.
+  errno = EINVAL;
+  return -1;
+}
+ssize_t mgmt_message_parse(const void *buf, size_t len, MgmtMarshallInt *field);
+ssize_t mgmt_message_parse(const void *buf, size_t len, MgmtMarshallLong *field);
+ssize_t mgmt_message_parse(const void *buf, size_t len, MgmtMarshallString *field);
+ssize_t mgmt_message_parse(const void *buf, size_t len, MgmtMarshallData *field);
+
+template <typename T, typename... Rest>
+ssize_t
+mgmt_message_parse(const void *buf, size_t len, T first, Rest... rest)
+{
+  if (buf == nullptr || len == 0) {
+    return 0;
+  }
+  ssize_t nbytes = mgmt_message_parse(buf, len, first);
+  return (nbytes != -1) ? nbytes + mgmt_message_parse(static_cast<const uint8_t *>(buf) + nbytes, len - nbytes, rest...) : nbytes;
+}
+/// end mgmt_message_parse ------------------------------------------------------

--- a/mgmt/utils/test_marshall.cc
+++ b/mgmt/utils/test_marshall.cc
@@ -46,22 +46,6 @@
     }                                                                                                                \
   } while (0)
 
-const MgmtMarshallType inval[] = {(MgmtMarshallType)1568};
-
-const MgmtMarshallType ifields[] = {MGMT_MARSHALL_INT, MGMT_MARSHALL_LONG};
-
-const MgmtMarshallType sfields[] = {
-  MGMT_MARSHALL_STRING,
-};
-
-const MgmtMarshallType dfields[] = {
-  MGMT_MARSHALL_DATA,
-};
-
-const MgmtMarshallType afields[] = {
-  MGMT_MARSHALL_DATA, MGMT_MARSHALL_INT, MGMT_MARSHALL_LONG, MGMT_MARSHALL_STRING, MGMT_MARSHALL_LONG, MGMT_MARSHALL_LONG,
-};
-
 const char alpha[]       = "abcdefghijklmnopqrstuvwxyz0123456789";
 const char *stringvals[] = {nullptr, "", "randomstring"};
 
@@ -166,11 +150,11 @@ REGRESSION_TEST(MessageReadWriteA)(RegressionTest *t, int /* atype ATS_UNUSED */
   // Check invalid Fd write. ToDo: Commented out, see TS-3052.
   // CHECK_EQ(mgmt_message_write(FD_SETSIZE - 1, ifields, countof(ifields), &mint, &mlong), -1);
 
-  CHECK_EQ(mgmt_message_write(clientfd, ifields, countof(ifields), &mint, &mlong), 12);
+  CHECK_EQ(mgmt_message_write(clientfd, &mint, &mlong), 12);
 
   mint  = 0;
   mlong = 0;
-  CHECK_EQ(mgmt_message_read(serverfd, ifields, countof(ifields), &mint, &mlong), 12);
+  CHECK_EQ(mgmt_message_read(serverfd, &mint, &mlong), 12);
   CHECK_VALUE(mint, 99, "%" PRId32);
   CHECK_VALUE(mlong, (MgmtMarshallLong)(&listenfd), "%" PRId64);
 
@@ -180,11 +164,11 @@ REGRESSION_TEST(MessageReadWriteA)(RegressionTest *t, int /* atype ATS_UNUSED */
     size_t len    = 4 /* length */ + (s ? strlen(s) : 0) /* bytes */ + 1 /* NULL */;
 
     mstring = s ? ats_strdup(s) : nullptr;
-    CHECK_EQ(mgmt_message_write(clientfd, sfields, countof(sfields), &mstring), len);
+    CHECK_EQ(mgmt_message_write(clientfd, &mstring), len);
     ats_free(mstring);
     mstring = nullptr;
 
-    CHECK_EQ(mgmt_message_read(serverfd, sfields, countof(sfields), &mstring), len);
+    CHECK_EQ(mgmt_message_read(serverfd, &mstring), len);
     CHECK_STRING(s, mstring);
     ats_free(mstring);
     mstring = nullptr;
@@ -193,11 +177,11 @@ REGRESSION_TEST(MessageReadWriteA)(RegressionTest *t, int /* atype ATS_UNUSED */
   // Marshall data.
   mdata.ptr = ats_strdup(alpha);
   mdata.len = strlen(alpha);
-  CHECK_EQ(mgmt_message_write(clientfd, dfields, countof(dfields), &mdata), 4 + strlen(alpha));
+  CHECK_EQ(mgmt_message_write(clientfd, &mdata), 4 + strlen(alpha));
   ats_free(mdata.ptr);
   ink_zero(mdata);
 
-  CHECK_EQ(mgmt_message_read(serverfd, dfields, countof(dfields), &mdata), 4 + strlen(alpha));
+  CHECK_EQ(mgmt_message_read(serverfd, &mdata), 4 + strlen(alpha));
   CHECK_VALUE(mdata.len, strlen(alpha), "%zu");
   box.check(memcmp(mdata.ptr, alpha, strlen(alpha)) == 0, "unexpected mdata contents");
   ats_free(mdata.ptr);
@@ -220,7 +204,7 @@ REGRESSION_TEST(MessageMarshall)(RegressionTest *t, int /* atype ATS_UNUSED */, 
   MgmtMarshallData mdata     = {nullptr, 0};
 
   // Parse empty message.
-  CHECK_EQ(mgmt_message_parse(nullptr, 0, nullptr, 0), 0);
+  CHECK_EQ(mgmt_message_parse(nullptr, 0, 0), 0);
 
   // Marshall empty message.
   CHECK_EQ(mgmt_message_marshall(nullptr, 0, nullptr, 0), 0);
@@ -228,10 +212,10 @@ REGRESSION_TEST(MessageMarshall)(RegressionTest *t, int /* atype ATS_UNUSED */, 
   // Marshall some integral types.
   mint  = -156;
   mlong = UINT32_MAX;
-  CHECK_EQ(mgmt_message_marshall(msgbuf, 1, ifields, countof(ifields), &mint, &mlong), -1);
-  CHECK_EQ(mgmt_message_marshall(msgbuf, sizeof(msgbuf), ifields, countof(ifields), &mint, &mlong), 12);
-  CHECK_EQ(mgmt_message_parse(msgbuf, 1, ifields, countof(ifields), &mint, &mlong), -1);
-  CHECK_EQ(mgmt_message_parse(msgbuf, sizeof(msgbuf), ifields, countof(ifields), &mint, &mlong), 12);
+  CHECK_EQ(mgmt_message_marshall(msgbuf, 1, &mint, &mlong), -1);
+  CHECK_EQ(mgmt_message_marshall(msgbuf, sizeof(msgbuf), &mint, &mlong), 12);
+  CHECK_EQ(mgmt_message_parse(msgbuf, 1, &mint, &mlong), -1);
+  CHECK_EQ(mgmt_message_parse(msgbuf, sizeof(msgbuf), &mint, &mlong), 12);
   CHECK_VALUE(mint, -156, "%" PRId32);
   CHECK_VALUE(mlong, static_cast<MgmtMarshallLong>(UINT32_MAX), "%" PRId64);
 
@@ -241,13 +225,13 @@ REGRESSION_TEST(MessageMarshall)(RegressionTest *t, int /* atype ATS_UNUSED */, 
     size_t len    = 4 /* length */ + (s ? strlen(s) : 0) /* bytes */ + 1 /* NULL */;
 
     mstring = s ? ats_strdup(s) : nullptr;
-    CHECK_EQ(mgmt_message_marshall(msgbuf, 1, sfields, countof(sfields), &mstring), -1);
-    CHECK_EQ(mgmt_message_marshall(msgbuf, sizeof(msgbuf), sfields, countof(sfields), &mstring), len);
+    CHECK_EQ(mgmt_message_marshall(msgbuf, 1, &mstring), -1);
+    CHECK_EQ(mgmt_message_marshall(msgbuf, sizeof(msgbuf), &mstring), len);
     ats_free(mstring);
     mstring = nullptr;
 
-    CHECK_EQ(mgmt_message_parse(msgbuf, 1, sfields, countof(sfields), &mstring), -1);
-    CHECK_EQ(mgmt_message_parse(msgbuf, sizeof(msgbuf), sfields, countof(sfields), &mstring), len);
+    CHECK_EQ(mgmt_message_parse(msgbuf, 1, &mstring), -1);
+    CHECK_EQ(mgmt_message_parse(msgbuf, sizeof(msgbuf), &mstring), len);
     CHECK_STRING(s, mstring);
     ats_free(mstring);
     mstring = nullptr;
@@ -256,24 +240,24 @@ REGRESSION_TEST(MessageMarshall)(RegressionTest *t, int /* atype ATS_UNUSED */, 
   // Marshall data.
   mdata.ptr = ats_strdup(alpha);
   mdata.len = strlen(alpha);
-  CHECK_EQ(mgmt_message_marshall(msgbuf, 10, dfields, countof(dfields), &mdata), -1);
-  CHECK_EQ(mgmt_message_marshall(msgbuf, sizeof(msgbuf), dfields, countof(dfields), &mdata), 4 + strlen(alpha));
+  CHECK_EQ(mgmt_message_marshall(msgbuf, 10, &mdata), -1);
+  CHECK_EQ(mgmt_message_marshall(msgbuf, sizeof(msgbuf), &mdata), 4 + strlen(alpha));
   ats_free(mdata.ptr);
   ink_zero(mdata);
 
-  CHECK_EQ(mgmt_message_parse(msgbuf, strlen(alpha), dfields, countof(dfields), &mdata), -1);
-  CHECK_EQ(mgmt_message_parse(msgbuf, strlen(alpha) + 4, dfields, countof(dfields), &mdata), 4 + strlen(alpha));
+  CHECK_EQ(mgmt_message_parse(msgbuf, strlen(alpha), &mdata), -1);
+  CHECK_EQ(mgmt_message_parse(msgbuf, strlen(alpha) + 4, &mdata), 4 + strlen(alpha));
   CHECK_VALUE(mdata.len, strlen(alpha), "%zu");
   box.check(memcmp(mdata.ptr, alpha, strlen(alpha)) == 0, "unexpected mdata contents");
   ats_free(mdata.ptr);
   ink_zero(mdata);
 
   // Marshall empty data.
-  CHECK_EQ(mgmt_message_marshall(msgbuf, sizeof(msgbuf), dfields, countof(dfields), &mdata), 4);
+  CHECK_EQ(mgmt_message_marshall(msgbuf, sizeof(msgbuf), &mdata), 4);
 
   mdata.ptr = (void *)99;
   mdata.len = 1000;
-  CHECK_EQ(mgmt_message_parse(msgbuf, sizeof(msgbuf), dfields, countof(dfields), &mdata), 4);
+  CHECK_EQ(mgmt_message_parse(msgbuf, sizeof(msgbuf), &mdata), 4);
   CHECK_VALUE(mdata.ptr, (void *)nullptr, "%p");
   CHECK_VALUE(mdata.len, (size_t)0, "%zu");
 }
@@ -288,36 +272,32 @@ REGRESSION_TEST(MessageLength)(RegressionTest *t, int /* atype ATS_UNUSED */, in
   MgmtMarshallData mdata     = {nullptr, 0};
 
   // Check invalid marshall type.
-  CHECK_EQ(mgmt_message_length(inval, countof(inval), NULL), -1);
+  CHECK_EQ(mgmt_message_length(NULL), -1);
 
-  // Check empty types array.
-  CHECK_EQ(mgmt_message_length(nullptr, 0), 0);
-
-  CHECK_EQ(mgmt_message_length(ifields, countof(ifields), &mint, &mlong), 12);
+  CHECK_EQ(mgmt_message_length(&mint, &mlong), 12);
 
   // string messages include a 4-byte length and the NULL
   mstring = (char *)"foo";
-  CHECK_EQ(mgmt_message_length(sfields, countof(sfields), &mstring), sizeof("foo") + 4);
+  CHECK_EQ(mgmt_message_length(&mstring), sizeof("foo") + 4);
 
   // NULL strings are the same as empty strings ...
   mstring = nullptr;
-  CHECK_EQ(mgmt_message_length(sfields, countof(sfields), &mstring), 4 + 1);
+  CHECK_EQ(mgmt_message_length(&mstring), 4 + 1);
   mstring = (char *)"";
-  CHECK_EQ(mgmt_message_length(sfields, countof(sfields), &mstring), 4 + 1);
+  CHECK_EQ(mgmt_message_length(&mstring), 4 + 1);
 
   // data fields include a 4-byte length. We don't go looking at the data in this case.
   mdata.len = 99;
   mdata.ptr = nullptr;
-  CHECK_EQ(mgmt_message_length(dfields, countof(dfields), &mdata), 99 + 4);
+  CHECK_EQ(mgmt_message_length(&mdata), 99 + 4);
 
   mstring   = (char *)"all fields";
   mdata.len = 31;
-  CHECK_EQ(mgmt_message_length(afields, countof(afields), &mdata, &mint, &mlong, &mstring, &mlong, &mlong),
-           31 + 4 + 4 + 8 + sizeof("all fields") + 4 + 8 + 8);
+  CHECK_EQ(mgmt_message_length(&mdata, &mint, &mlong, &mstring, &mlong, &mlong), 31 + 4 + 4 + 8 + sizeof("all fields") + 4 + 8 + 8);
 
   mdata.ptr = nullptr;
   mdata.len = 0;
-  CHECK_EQ(mgmt_message_length(dfields, countof(dfields), &mdata), 4);
+  CHECK_EQ(mgmt_message_length(&mdata), 4);
 }
 
 int

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -2079,9 +2079,8 @@ mgmt_lifecycle_msg_callback(void *, char *data, int len)
   MgmtInt op;
   MgmtMarshallString tag;
   MgmtMarshallData payload;
-  static const MgmtMarshallType fields[] = {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING, MGMT_MARSHALL_DATA};
 
-  if (mgmt_message_parse(data, len, fields, countof(fields), &op, &tag, &payload) == -1) {
+  if (mgmt_message_parse(data, len, &op, &tag, &payload) == -1) {
     Error("Plugin message - RPC parsing error - message discarded.");
   } else {
     msg.tag       = tag;


### PR DESCRIPTION
Replaces variable argument lists in serialization with variadic templates. 

- The main benefit of doing this is that the hard coded schema for `requests` and `responses` in `NetworkMessage.cc` is no longer needed. 
- requests/responses are now parsed in the same manner. 