### PR TITLE
Makes the CI work again with ClangAnalyzer v6.x

### DIFF
--- a/ci/jenkins/bin/clang-analyzer.sh
+++ b/ci/jenkins/bin/clang-analyzer.sh
@@ -77,7 +77,9 @@ export CCC_CXX=${LLVM_BASE}/bin/clang++
 # Start the build / scan
 [ "$output" != "/tmp" ] && echo "Results (if any) can be found at ${results_url}"
 autoreconf -fi
-${LLVM_BASE}/bin/scan-build ./configure ${configure}
+${LLVM_BASE}/bin/scan-build ./configure ${configure} \
+    CXXFLAGS="-stdlib=libc++ -I/opt/llvm/include/c++/v1 -std=c++17" \
+    LDFLAGS="-L/opt/llvm/lib64 -Wl,-rpath=/opt/llvm/lib64"
 
 # Since we don't want the analyzer to look at LuaJIT, build it first
 # without scan-build. The subsequent make will then skip it.


### PR DESCRIPTION
There are a few issues with clang and how we do things:

      1) The autoconf module we use for C++ version detection
      puts the -std=c++17 in the CXX variable, but not CXXFLAGS.
      This fails when you wrap the compilers like we do with scan.

      2) The STL includes on CentOS7 are much too old, and clang
      seems to prefer those over its own for some odd reason. So,
      enforce the use of the LLVM/clang include files.

      3) We must also link with an appropriate C++ standard library.
      Similar to 2), we therefore specifically use libc++.