### PR TITLE
Use #pragma once

### DIFF
--- a/cmd/traffic_crashlog/traffic_crashlog.h
+++ b/cmd/traffic_crashlog/traffic_crashlog.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __TRAFFIC_CRASHLOG_H__
-#define __TRAFFIC_CRASHLOG_H__
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "ts/ink_memory.h"
@@ -75,5 +74,3 @@ bool crashlog_write_regions(FILE *, const crashlog_target &);
 bool crashlog_write_registers(FILE *, const crashlog_target &);
 bool crashlog_write_siginfo(FILE *, const crashlog_target &);
 bool crashlog_write_uname(FILE *, const crashlog_target &);
-
-#endif /* __TRAFFIC_CRASHLOG_H__ */

--- a/cmd/traffic_ctl/traffic_ctl.h
+++ b/cmd/traffic_ctl/traffic_ctl.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _TRAFFIC_CTRL_H_
-#define _TRAFFIC_CTRL_H_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "ts/Diags.h"
@@ -209,5 +208,3 @@ int subcommand_plugin(unsigned argc, const char **argv);
 #define CTRL_EX_UNIMPLEMENTED 3
 #define CTRL_EX_USAGE EX_USAGE
 #define CTRL_EX_UNAVAILABLE 69
-
-#endif /* _TRAFFIC_CTRL_H_ */

--- a/cmd/traffic_manager/MgmtHandlers.h
+++ b/cmd/traffic_manager/MgmtHandlers.h
@@ -21,12 +21,9 @@
     limitations under the License.
 */
 
-#ifndef _MGMT_HANDLERS_H_
-#define _MGMT_HANDLERS_H_
+#pragma once
 
 extern int aconf_port_arg;
 
 void *mgmt_synthetic_main(void *);
 bool api_socket_is_restricted();
-
-#endif

--- a/cmd/traffic_manager/metrics.h
+++ b/cmd/traffic_manager/metrics.h
@@ -21,8 +21,7 @@
  *  limitations under the License.
  */
 
-#ifndef METRICS_H_D289E71B_AAC5_4CF3_9954_D54EDED60D1B
-#define METRICS_H_D289E71B_AAC5_4CF3_9954_D54EDED60D1B
+#pragma once
 
 #include "bindings/bindings.h"
 #include "bindings/metrics.h"
@@ -35,5 +34,3 @@ bool metrics_binding_configure(BindingInstance &binding);
 
 // Evaluate the metrics in this binding instance.
 void metrics_binding_evaluate(BindingInstance &binding);
-
-#endif /* METRICS_H_D289E71B_AAC5_4CF3_9954_D54EDED60D1B */

--- a/example/cppapi/websocket/WSBuffer.h
+++ b/example/cppapi/websocket/WSBuffer.h
@@ -22,8 +22,6 @@
  */
 
 #pragma once
-#ifndef WSBUFFER_H_20F6C829_0736_47D3_A5D2_7130D4D99CC0
-#define WSBUFFER_H_20F6C829_0736_47D3_A5D2_7130D4D99CC0
 
 #include <string>
 
@@ -89,5 +87,3 @@ private:
   int frame_;           // frame type of current message
   std::string msg_buf_; // decoded message data
 };
-
-#endif /* WSBUFFER_H_20F6C829_0736_47D3_A5D2_7130D4D99CC0 */

--- a/example/cppapi/websocket/WebSocket.h
+++ b/example/cppapi/websocket/WebSocket.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef WEBSOCKET_H_3AE11C09_90DC_4BC6_A297_B38C3B8AEFBF
-#define WEBSOCKET_H_3AE11C09_90DC_4BC6_A297_B38C3B8AEFBF
+#pragma once
 
 #include <atscppapi/GlobalPlugin.h>
 #include <atscppapi/InterceptPlugin.h>
@@ -65,5 +64,3 @@ public:
 
   void handleReadRequestHeadersPreRemap(Transaction &transaction);
 };
-
-#endif /* WEBSOCKET_H_3AE11C09_90DC_4BC6_A297_B38C3B8AEFBF */

--- a/example/thread-pool/thread.h
+++ b/example/thread-pool/thread.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _THREAD_H_
-#define _THREAD_H_
+#pragma once
 
 #define MAGIC_ALIVE 0xfeedbabe
 #define MAGIC_DEAD 0xdeadbeef
@@ -77,5 +76,3 @@ void thread_signal_job();
 void thread_init();
 
 void thread_loop(void *arg);
-
-#endif

--- a/iocore/aio/I_AIO.h
+++ b/iocore/aio/I_AIO.h
@@ -28,8 +28,7 @@
 
 
  ****************************************************************************/
-#if !defined(_I_AIO_h_)
-#define _I_AIO_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "I_EventSystem.h"
@@ -153,4 +152,3 @@ int ink_aio_readv(AIOCallback *op,
                   int fromAPI = 0); // fromAPI is a boolean to indicate if this is from a API call such as upload proxy feature
 int ink_aio_writev(AIOCallback *op, int fromAPI = 0);
 AIOCallback *new_AIOCallback(void);
-#endif

--- a/iocore/aio/P_AIO.h
+++ b/iocore/aio/P_AIO.h
@@ -28,8 +28,7 @@
 
 
  ****************************************************************************/
-#ifndef _P_AIO_h_
-#define _P_AIO_h_
+#pragma once
 
 #include "P_EventSystem.h"
 #include "I_AIO.h"
@@ -161,5 +160,3 @@ enum aio_stat_enum {
   AIO_STAT_COUNT
 };
 extern RecRawStatBlock *aio_rsb;
-
-#endif

--- a/iocore/cache/I_Cache.h
+++ b/iocore/cache/I_Cache.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _I_CACHE_H__
-#define _I_CACHE_H__
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "I_EventSystem.h"
@@ -231,5 +230,3 @@ struct CacheVConnection : public VConnection {
 void ink_cache_init(ModuleVersion version);
 extern inkcoreapi CacheProcessor cacheProcessor;
 extern Continuation *cacheRegexDeleteCont;
-
-#endif /* _I_CACHE_H__ */

--- a/iocore/cache/I_CacheDefs.h
+++ b/iocore/cache/I_CacheDefs.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _I_CACHE_DEFS_H__
-#define _I_CACHE_DEFS_H__
+#pragma once
 
 #include "ts/CryptoHash.h"
 
@@ -145,4 +144,3 @@ struct HttpCacheKey {
    word(2) - tag (lower bits), hosttable hash (upper bits)
    word(3) - ram cache hash, lookaside cache
  */
-#endif // __CACHE_DEFS_H__

--- a/iocore/cache/I_Store.h
+++ b/iocore/cache/I_Store.h
@@ -28,8 +28,7 @@
 
  ****************************************************************************/
 
-#ifndef _Store_h_
-#define _Store_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 
@@ -273,5 +272,3 @@ struct Store {
 
 // store either free or in the cache, can be stolen for reconfiguration
 void stealStore(Store &s, int blocks);
-
-#endif

--- a/iocore/cache/P_Cache.h
+++ b/iocore/cache/P_Cache.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _P_CACHE_H__
-#define _P_CACHE_H__
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "P_EventSystem.h"
@@ -43,4 +42,3 @@
 #include "P_CacheInternal.h"
 #include "P_CacheHosting.h"
 #include "P_CacheHttp.h"
-#endif /* _P_CACHE_H */

--- a/iocore/cache/P_CacheArray.h
+++ b/iocore/cache/P_CacheArray.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __CACHE_ARRAY_H__
-#define __CACHE_ARRAY_H__
+#pragma once
 
 #define FAST_DATA_SIZE 4
 
@@ -183,5 +182,3 @@ CacheArray<T>::resize(int new_size)
     size = new_size;
   }
 }
-
-#endif /* __CACHE_ARRAY_H__ */

--- a/iocore/cache/P_CacheBC.h
+++ b/iocore/cache/P_CacheBC.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _P_CACHE_BC_H__
-#define _P_CACHE_BC_H__
+#pragma once
 
 namespace cache_bc
 {
@@ -137,5 +136,3 @@ Doc_v23::hdr()
 }
 
 } // namespace cache_bc
-
-#endif /* _P_CACHE_BC_H__ */

--- a/iocore/cache/P_CacheDir.h
+++ b/iocore/cache/P_CacheDir.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _P_CACHE_DIR_H__
-#define _P_CACHE_DIR_H__
+#pragma once
 
 #include "P_CacheHttp.h"
 
@@ -354,5 +353,3 @@ dir_bucket_row(Dir *b, int64_t i)
 {
   return dir_in_seg(b, i);
 }
-
-#endif /* _P_CACHE_DIR_H__ */

--- a/iocore/cache/P_CacheDisk.h
+++ b/iocore/cache/P_CacheDisk.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _P_CACHE_DISK_H__
-#define _P_CACHE_DISK_H__
+#pragma once
 
 #include "I_Cache.h"
 
@@ -142,5 +141,3 @@ struct CacheDisk : public Continuation {
   DiskVol *get_diskvol(int vol_number);
   void incrErrors(const AIOCallback *io);
 };
-
-#endif

--- a/iocore/cache/P_CacheHosting.h
+++ b/iocore/cache/P_CacheHosting.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __P_CACHE_HOSTING_H__
-#define __P_CACHE_HOSTING_H__
+#pragma once
 #include "P_Cache.h"
 
 #define CACHE_MEM_FREE_TIMEOUT HRTIME_SECONDS(1)
@@ -206,5 +205,3 @@ struct ConfigVolumes {
     num_stream_volumes = 0;
   }
 };
-
-#endif

--- a/iocore/cache/P_CacheHttp.h
+++ b/iocore/cache/P_CacheHttp.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __CACHE_HTTP_H__
-#define __CACHE_HTTP_H__
+#pragma once
 
 #include "P_CacheArray.h"
 #ifdef HTTP_CACHE
@@ -91,5 +90,3 @@ CacheHTTPInfoVector::get(int idx)
   ink_assert(idx < xcount);
   return &data[idx].alternate;
 }
-
-#endif /* __CACHE_HTTP_H__ */

--- a/iocore/cache/P_CacheInternal.h
+++ b/iocore/cache/P_CacheInternal.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _P_CACHE_INTERNAL_H__
-#define _P_CACHE_INTERNAL_H__
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "ts/InkErrno.h"
@@ -1070,5 +1069,3 @@ cache_hash(const INK_MD5 &md5)
 #endif
 
 LINK_DEFINITION(CacheVC, opendir_link)
-
-#endif /* _P_CACHE_INTERNAL_H__ */

--- a/iocore/cache/P_CacheTest.h
+++ b/iocore/cache/P_CacheTest.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __P_CACHE_TEST_H__
-#define __P_CACHE_TEST_H__
+#pragma once
 
 #include "P_Cache.h"
 #include "RegressionSM.h"
@@ -150,5 +149,3 @@ struct CacheTestSM : public RegressionSM {
   } _sm(_t);
 
 void force_link_CacheTest();
-
-#endif /* __P_CACHE_TEST_H__ */

--- a/iocore/cache/P_CacheVol.h
+++ b/iocore/cache/P_CacheVol.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _P_CACHE_VOL_H__
-#define _P_CACHE_VOL_H__
+#pragma once
 
 #define CACHE_BLOCK_SHIFT 9
 #define CACHE_BLOCK_SIZE (1 << CACHE_BLOCK_SHIFT) // 512, smallest sector size
@@ -517,5 +516,3 @@ Vol::round_to_approx_size(uint32_t l)
   uint32_t ll = round_to_approx_dir_size(l);
   return ROUND_TO_SECTOR(this, ll);
 }
-
-#endif /* _P_CACHE_VOL_H__ */

--- a/iocore/cache/P_RamCache.h
+++ b/iocore/cache/P_RamCache.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _P_RAM_CACHE_H__
-#define _P_RAM_CACHE_H__
+#pragma once
 
 #include "I_Cache.h"
 
@@ -42,5 +41,3 @@ struct RamCache {
 
 RamCache *new_RamCacheLRU();
 RamCache *new_RamCacheCLFUS();
-
-#endif /* _P_RAM_CACHE_H__ */

--- a/iocore/dns/I_DNS.h
+++ b/iocore/dns/I_DNS.h
@@ -28,12 +28,9 @@
 
  ****************************************************************************/
 
-#ifndef _I_DNS_h_
-#define _I_DNS_h_
+#pragma once
 
 #include "I_EventSystem.h"
 #include "I_HostDB.h"
 #include "I_Net.h"
 #include "I_DNSProcessor.h"
-
-#endif //_I_DNS_h_

--- a/iocore/dns/I_DNSProcessor.h
+++ b/iocore/dns/I_DNSProcessor.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _I_DNSProcessor_h_
-#define _I_DNSProcessor_h_
+#pragma once
 
 #include "SRV.h"
 
@@ -210,5 +209,3 @@ DNSProcessor::Options::reset()
 }
 
 void ink_dns_init(ModuleVersion version);
-
-#endif

--- a/iocore/dns/I_SplitDNS.h
+++ b/iocore/dns/I_SplitDNS.h
@@ -28,8 +28,7 @@
  *
  ****************************************************************************/
 
-#ifndef _I_SPLIT_DNS_H_
-#define _I_SPLIT_DNS_H_
+#pragma once
 
 #include "I_SplitDNSProcessor.h"
 
@@ -37,5 +36,3 @@
 #define SPLITDNS_MODULE_MINOR_VERSION 0
 #define SPLITDNS_MODULE_VERSION \
   makeModuleVersion(SPLITDNS_MODULE_MAJOR_VERSION, SPLITDNS_MODULE_MINOR_VERSION, PUBLIC_MODULE_HEADER)
-
-#endif //_I_SPLIT_DNS_H_

--- a/iocore/dns/I_SplitDNSProcessor.h
+++ b/iocore/dns/I_SplitDNSProcessor.h
@@ -28,8 +28,7 @@
  *
  ****************************************************************************/
 
-#ifndef _I_SPLIT_DNSProcessor_H_
-#define _I_SPLIT_DNSProcessor_H_
+#pragma once
 
 struct SplitDNS;
 
@@ -53,5 +52,3 @@ struct SplitDNSConfig {
 
   static int gsplit_dns_enabled;
 };
-
-#endif

--- a/iocore/dns/P_DNS.h
+++ b/iocore/dns/P_DNS.h
@@ -27,8 +27,7 @@
 
 
  ****************************************************************************/
-#if !defined(_P_DNS_h_)
-#define _P_DNS_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "I_DNS.h"
@@ -38,5 +37,3 @@
 #include "P_DNSConnection.h"
 #include "P_DNSProcessor.h"
 #include "SRV.h"
-
-#endif // _P_DNS_h_

--- a/iocore/dns/P_DNSConnection.h
+++ b/iocore/dns/P_DNSConnection.h
@@ -28,8 +28,7 @@
   struct DNSConnection
   **************************************************************************/
 
-#ifndef __P_DNSCONNECTION_H__
-#define __P_DNSCONNECTION_H__
+#pragma once
 
 #include "I_EventSystem.h"
 
@@ -135,5 +134,3 @@ DNSConnection::Options::setLocalIpv6(sockaddr const *ip)
   _local_ipv6 = ip;
   return *this;
 }
-
-#endif /*_P_DNSConnection_h*/

--- a/iocore/dns/P_DNSProcessor.h
+++ b/iocore/dns/P_DNSProcessor.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#if !defined(_P_DNSProcessor_h_)
-#define _P_DNSProcessor_h_
+#pragma once
 
 /*
   #include "I_DNS.h"
@@ -354,5 +353,3 @@ DNSHandler::DNSHandler()
 
 #define DOT_SEPARATED(_x) \
   ((unsigned char *)&(_x))[0], ((unsigned char *)&(_x))[1], ((unsigned char *)&(_x))[2], ((unsigned char *)&(_x))[3]
-
-#endif

--- a/iocore/dns/P_SplitDNS.h
+++ b/iocore/dns/P_SplitDNS.h
@@ -28,8 +28,7 @@
  *
  ****************************************************************************/
 
-#ifndef _P_SPLIT_DNS_H_
-#define _P_SPLIT_DNS_H_
+#pragma once
 
 #include "P_DNS.h"
 #include "I_SplitDNS.h"
@@ -41,5 +40,3 @@
 #undef SPLITDNS_MODULE_VERSION
 #define SPLITDNS_MODULE_VERSION \
   makeModuleVersion(SPLITDNS_MODULE_MAJOR_VERSION, SPLITDNS_MODULE_MINOR_VERSION, PRIVATE_MODULE_HEADER)
-
-#endif /* _P_SPLIT_DNS_H_ */

--- a/iocore/dns/P_SplitDNSProcessor.h
+++ b/iocore/dns/P_SplitDNSProcessor.h
@@ -28,8 +28,7 @@
  *
  ****************************************************************************/
 
-#ifndef _P_SPLIT_DNSProcessor_H_
-#define _P_SPLIT_DNSProcessor_H_
+#pragma once
 
 /*
 #include "P_DNS.h"
@@ -232,5 +231,3 @@ TS_INLINE SplitDNSRecord::~SplitDNSRecord()
 SplitDNSRecord *createDefaultServer();
 void reloadDefaultParent(char *val);
 void reloadParentFile();
-
-#endif

--- a/iocore/dns/SRV.h
+++ b/iocore/dns/SRV.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _SRV_h_
-#define _SRV_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "I_HostDBProcessor.h"
@@ -59,5 +58,3 @@ struct SRVHosts {
   ~SRVHosts() {}
   SRVHosts() : srv_host_count(0), srv_hosts_length(0) {}
 };
-
-#endif

--- a/iocore/eventsystem/I_Action.h
+++ b/iocore/eventsystem/I_Action.h
@@ -22,8 +22,7 @@
 
  */
 
-#ifndef _I_Action_h_
-#define _I_Action_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "I_Thread.h"
@@ -203,5 +202,3 @@ public:
 //   MAKE_ACTION_RESULT(ACTION_RESULT_HOST_DB_BASE + 0)
 
 #define MAKE_ACTION_RESULT(_x) (Action *)(((uintptr_t)((_x << 1) + 1)))
-
-#endif /*_Action_h_*/

--- a/iocore/eventsystem/I_Continuation.h
+++ b/iocore/eventsystem/I_Continuation.h
@@ -33,8 +33,7 @@
 
  */
 
-#ifndef _I_Continuation_h_
-#define _I_Continuation_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "ts/List.h"
@@ -213,5 +212,3 @@ inline Continuation::Continuation(ProxyMutex *amutex)
   // Pick up the control flags from the creating thread
   this->control_flags.set_flags(get_cont_flags().get_flags());
 }
-
-#endif /*_Continuation_h_*/

--- a/iocore/eventsystem/I_EThread.h
+++ b/iocore/eventsystem/I_EThread.h
@@ -22,8 +22,7 @@
 
  */
 
-#ifndef _EThread_h_
-#define _EThread_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "ts/ink_rand.h"
@@ -402,4 +401,3 @@ operator new(size_t, ink_dummy_for_new *p)
 #define ETHREAD_GET_PTR(thread, offset) ((void *)((char *)(thread) + (offset)))
 
 extern EThread *this_ethread();
-#endif /*_EThread_h_*/

--- a/iocore/eventsystem/I_Event.h
+++ b/iocore/eventsystem/I_Event.h
@@ -22,8 +22,7 @@
 
  */
 
-#ifndef _Event_h_
-#define _Event_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "I_Action.h"
@@ -281,5 +280,3 @@ extern ClassAllocator<Event> eventAllocator;
     ::_a.free(_p);             \
   else                         \
   THREAD_FREE(_p, _a, _t)
-
-#endif /*_Event_h_*/

--- a/iocore/eventsystem/I_EventProcessor.h
+++ b/iocore/eventsystem/I_EventProcessor.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _I_EventProcessor_h_
-#define _I_EventProcessor_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "I_Continuation.h"
@@ -312,5 +311,3 @@ public:
 };
 
 extern inkcoreapi class EventProcessor eventProcessor;
-
-#endif /*_EventProcessor_h_*/

--- a/iocore/eventsystem/I_EventSystem.h
+++ b/iocore/eventsystem/I_EventSystem.h
@@ -22,7 +22,7 @@
 
  */
 
-#ifndef _I_EventSystem_h
+#pragma once
 #define _I_EventSystem_h
 
 #include "ts/ink_platform.h"
@@ -50,5 +50,3 @@
   makeModuleVersion(EVENT_SYSTEM_MODULE_MAJOR_VERSION, EVENT_SYSTEM_MODULE_MINOR_VERSION, PUBLIC_MODULE_HEADER)
 
 void ink_event_system_init(ModuleVersion version);
-
-#endif

--- a/iocore/eventsystem/I_IOBuffer.h
+++ b/iocore/eventsystem/I_IOBuffer.h
@@ -36,7 +36,7 @@
 
  */
 
-#if !defined(I_IOBuffer_h)
+#pragma once
 #define I_IOBuffer_h
 
 #include "ts/ink_platform.h"
@@ -1401,4 +1401,3 @@ extern IOBufferBlock *iobufferblock_clone(IOBufferBlock *b, int64_t offset, int6
 
 */
 extern IOBufferBlock *iobufferblock_skip(IOBufferBlock *b, int64_t *poffset, int64_t *plen, int64_t write);
-#endif

--- a/iocore/eventsystem/I_Lock.h
+++ b/iocore/eventsystem/I_Lock.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _I_Lock_h_
-#define _I_Lock_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "ts/Diags.h"
@@ -656,5 +655,3 @@ new_ProxyMutex()
   m->init();
   return m;
 }
-
-#endif // _Lock_h_

--- a/iocore/eventsystem/I_PriorityEventQueue.h
+++ b/iocore/eventsystem/I_PriorityEventQueue.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _I_PriorityEventQueue_h_
-#define _I_PriorityEventQueue_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "I_Event.h"
@@ -120,5 +119,3 @@ struct PriorityEventQueue {
 
   PriorityEventQueue();
 };
-
-#endif

--- a/iocore/eventsystem/I_Processor.h
+++ b/iocore/eventsystem/I_Processor.h
@@ -22,8 +22,7 @@
 
  */
 
-#ifndef _I_Processor_h_
-#define _I_Processor_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 
@@ -115,5 +114,3 @@ private:
   Processor(const Processor &);
   Processor &operator=(const Processor &);
 };
-
-#endif //_I_Processor_h_

--- a/iocore/eventsystem/I_ProtectedQueue.h
+++ b/iocore/eventsystem/I_ProtectedQueue.h
@@ -32,8 +32,7 @@
 
 
  ****************************************************************************/
-#ifndef _I_ProtectedQueue_h_
-#define _I_ProtectedQueue_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "I_Event.h"
@@ -79,5 +78,3 @@ struct ProtectedQueue {
 };
 
 void flush_signals(EThread *t);
-
-#endif

--- a/iocore/eventsystem/I_ProxyAllocator.h
+++ b/iocore/eventsystem/I_ProxyAllocator.h
@@ -28,8 +28,7 @@
 
 
 *****************************************************************************/
-#ifndef _I_ProxyAllocator_h_
-#define _I_ProxyAllocator_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 
@@ -122,5 +121,3 @@ void thread_freeup(Allocator &a, ProxyAllocator &l);
     if (_t->_a.allocated > thread_freelist_high_watermark) \
       thread_freeup(::_a, _t->_a);                         \
   } while (0)
-
-#endif /* _ProxyAllocator_h_ */

--- a/iocore/eventsystem/I_SocketManager.h
+++ b/iocore/eventsystem/I_SocketManager.h
@@ -30,8 +30,7 @@
 
  ****************************************************************************/
 
-#ifndef _I_SocketManager_h_
-#define _I_SocketManager_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "I_EventSystem.h"
@@ -152,5 +151,3 @@ private:
 };
 
 extern SocketManager socketManager;
-
-#endif /*_SocketManager_h_*/

--- a/iocore/eventsystem/I_Tasks.h
+++ b/iocore/eventsystem/I_Tasks.h
@@ -22,8 +22,7 @@
 
  */
 
-#if !defined(I_Tasks_h)
-#define I_Tasks_h
+#pragma once
 
 #include "I_EventSystem.h"
 
@@ -36,5 +35,3 @@ public:
 };
 
 extern TasksProcessor tasksProcessor;
-
-#endif

--- a/iocore/eventsystem/I_Thread.h
+++ b/iocore/eventsystem/I_Thread.h
@@ -56,8 +56,7 @@
 
  */
 
-#ifndef _I_Thread_h
-#define _I_Thread_h
+#pragma once
 
 #if !defined(_I_EventSystem_h) && !defined(_P_EventSystem_h)
 #error "include I_EventSystem.h or P_EventSystem.h"
@@ -184,5 +183,3 @@ Thread::get_hrtime_updated()
 {
   return cur_time = ink_get_hrtime_internal();
 }
-
-#endif /*_I_Thread_h*/

--- a/iocore/eventsystem/I_VConnection.h
+++ b/iocore/eventsystem/I_VConnection.h
@@ -22,8 +22,7 @@
 
  */
 
-#if !defined(_I_VConnection_h_)
-#define _I_VConnection_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "I_EventSystem.h"
@@ -407,5 +406,3 @@ struct DummyVConnection : public VConnection {
   }
   DummyVConnection(ProxyMutex *m) : VConnection(m) {}
 };
-
-#endif /*_I_VConnection_h_*/

--- a/iocore/eventsystem/I_VIO.h
+++ b/iocore/eventsystem/I_VIO.h
@@ -22,7 +22,7 @@
 
  */
 
-#if !defined(I_VIO_h)
+#pragma once
 #define I_VIO_h
 
 #include "ts/ink_platform.h"
@@ -222,4 +222,3 @@ public:
 };
 
 #include "I_VConnection.h"
-#endif

--- a/iocore/eventsystem/P_EventSystem.h
+++ b/iocore/eventsystem/P_EventSystem.h
@@ -28,7 +28,7 @@
 
 
 **************************************************************************/
-#ifndef _P_EventSystem_h
+#pragma once
 #define _P_EventSystem_h
 
 #include "ts/ink_platform.h"
@@ -48,5 +48,3 @@
 #undef EVENT_SYSTEM_MODULE_VERSION
 #define EVENT_SYSTEM_MODULE_VERSION \
   makeModuleVersion(EVENT_SYSTEM_MODULE_MAJOR_VERSION, EVENT_SYSTEM_MODULE_MINOR_VERSION, PRIVATE_MODULE_HEADER)
-
-#endif

--- a/iocore/eventsystem/P_Freer.h
+++ b/iocore/eventsystem/P_Freer.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#if !defined(_P_Freer_h_)
-#define _P_Freer_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "I_Tasks.h"
@@ -125,5 +124,3 @@ new_Derefer(C *ap, ink_hrtime t)
 {
   eventProcessor.schedule_in(new DereferContinuation<C>(ap), t, ET_TASK);
 }
-
-#endif /* _Freer_h_ */

--- a/iocore/eventsystem/P_IOBuffer.h
+++ b/iocore/eventsystem/P_IOBuffer.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#if !defined(_P_IOBuffer_h)
-#define _P_IOBuffer_h
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "ts/ink_resource.h"
@@ -1202,5 +1201,3 @@ TS_INLINE
 MIOBufferAccessor::~MIOBufferAccessor()
 {
 }
-
-#endif

--- a/iocore/eventsystem/P_ProtectedQueue.h
+++ b/iocore/eventsystem/P_ProtectedQueue.h
@@ -27,8 +27,7 @@
 
 
  ****************************************************************************/
-#ifndef _P_ProtectedQueue_h_
-#define _P_ProtectedQueue_h_
+#pragma once
 
 #include "I_EventSystem.h"
 
@@ -91,5 +90,3 @@ ProtectedQueue::dequeue_local()
   }
   return e;
 }
-
-#endif

--- a/iocore/eventsystem/P_Thread.h
+++ b/iocore/eventsystem/P_Thread.h
@@ -28,8 +28,7 @@
 
 
 ****************************************************************************/
-#ifndef _P_Thread_h_
-#define _P_Thread_h_
+#pragma once
 
 #include "I_Thread.h"
 
@@ -52,5 +51,3 @@ this_thread()
 {
   return (Thread *)ink_thread_getspecific(Thread::thread_data_key);
 }
-
-#endif //_P_Thread_h_

--- a/iocore/eventsystem/P_UnixEThread.h
+++ b/iocore/eventsystem/P_UnixEThread.h
@@ -28,8 +28,7 @@
 
 
 *****************************************************************************/
-#ifndef _P_UnixEThread_h_
-#define _P_UnixEThread_h_
+#pragma once
 
 #include "I_EThread.h"
 #include "I_EventProcessor.h"
@@ -183,5 +182,3 @@ EThread::set_tail_handler(LoopTailHandler *handler)
 {
   ink_atomic_swap(&tail_cb, handler);
 }
-
-#endif /*_EThread_h_*/

--- a/iocore/eventsystem/P_UnixEvent.h
+++ b/iocore/eventsystem/P_UnixEvent.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _P_UnixEvent_h_
-#define _P_UnixEvent_h_
+#pragma once
 
 TS_INLINE Event *
 Event::init(Continuation *c, ink_hrtime atimeout_at, ink_hrtime aperiod)
@@ -54,5 +53,3 @@ Event::Event()
     period(0)
 {
 }
-
-#endif /*_UnixEvent_h_*/

--- a/iocore/eventsystem/P_UnixEventProcessor.h
+++ b/iocore/eventsystem/P_UnixEventProcessor.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _P_UnixEventProcessor_h_
-#define _P_UnixEventProcessor_h_
+#pragma once
 
 #include "ts/ink_align.h"
 #include "I_EventProcessor.h"
@@ -146,5 +145,3 @@ EventProcessor::schedule_every(Continuation *cont, ink_hrtime t, EventType et, i
   else
     return schedule(e->init(cont, Thread::get_hrtime() + t, t), et);
 }
-
-#endif

--- a/iocore/eventsystem/P_UnixSocketManager.h
+++ b/iocore/eventsystem/P_UnixSocketManager.h
@@ -29,8 +29,7 @@
 
 
 ****************************************************************************/
-#ifndef _P_UnixSocketManager_h_
-#define _P_UnixSocketManager_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "ts/ink_sock.h"
@@ -516,5 +515,3 @@ SocketManager::dup(int s)
   } while (res == -EINTR);
   return res;
 }
-
-#endif /*P_UnixSocketManager_h_ */

--- a/iocore/eventsystem/P_VConnection.h
+++ b/iocore/eventsystem/P_VConnection.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#if !defined(P_VConnection_h)
-#define P_VConnection_h
+#pragma once
 #include "I_EventSystem.h"
 
 TS_INLINE const char *
@@ -135,4 +134,3 @@ VConnection::reenable_re(VIO *vio)
 {
   reenable(vio);
 }
-#endif

--- a/iocore/eventsystem/P_VIO.h
+++ b/iocore/eventsystem/P_VIO.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#if !defined(P_VIO_h)
-#define P_VIO_h
+#pragma once
 #include "I_VIO.h"
 
 TS_INLINE
@@ -122,5 +121,3 @@ VIO::reenable_re()
   if (vc_server)
     vc_server->reenable_re(this);
 }
-
-#endif /* #if !defined ( P_VIO_h) */

--- a/iocore/hostdb/I_HostDB.h
+++ b/iocore/hostdb/I_HostDB.h
@@ -28,8 +28,7 @@
 
  ****************************************************************************/
 
-#ifndef _I_HostDB_h_
-#define _I_HostDB_h_
+#pragma once
 
 #include "I_EventSystem.h"
 #include "I_Net.h"
@@ -43,5 +42,3 @@
 #define HOSTDB_MODULE_MINOR_VERSION 1
 
 #define HOSTDB_MODULE_VERSION makeModuleVersion(HOSTDB_MODULE_MAJOR_VERSION, HOSTDB_MODULE_MINOR_VERSION, PUBLIC_MODULE_HEADER)
-
-#endif /* _I_HostDB_h_ */

--- a/iocore/hostdb/I_HostDBProcessor.h
+++ b/iocore/hostdb/I_HostDBProcessor.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _I_HostDBProcessor_h_
-#define _I_HostDBProcessor_h_
+#pragma once
 
 #include "ts/HashFNV.h"
 #include "ts/ink_time.h"
@@ -525,5 +524,3 @@ void run_HostDBTest();
 extern inkcoreapi HostDBProcessor hostDBProcessor;
 
 void ink_hostdb_init(ModuleVersion version);
-
-#endif

--- a/iocore/hostdb/P_HostDB.h
+++ b/iocore/hostdb/P_HostDB.h
@@ -28,8 +28,7 @@
 
  ****************************************************************************/
 
-#ifndef _P_HostDB_h_
-#define _P_HostDB_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 
@@ -52,4 +51,3 @@
 Ptr<HostDBInfo> probe(ProxyMutex *mutex, HostDBMD5 const &md5, bool ignore_timeout);
 
 void make_md5(INK_MD5 &md5, const char *hostname, int len, int port, const char *pDNSServers, HostDBMark mark);
-#endif

--- a/iocore/hostdb/P_HostDBProcessor.h
+++ b/iocore/hostdb/P_HostDBProcessor.h
@@ -25,8 +25,7 @@
   P_HostDBProcessor.h
  ****************************************************************************/
 
-#ifndef _P_HostDBProcessor_h_
-#define _P_HostDBProcessor_h_
+#pragma once
 
 #include "I_HostDBProcessor.h"
 
@@ -555,5 +554,3 @@ HostDBContinuation::key_partition()
 {
   return hostDB.refcountcache->partition_for_key(md5.hash.fold());
 }
-
-#endif /* _P_HostDBProcessor_h_ */

--- a/iocore/hostdb/P_RefCountCache.h
+++ b/iocore/hostdb/P_RefCountCache.h
@@ -20,8 +20,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-#ifndef _P_RefCountCache_h_
-#define _P_RefCountCache_h_
+#pragma once
 
 #include <I_EventSystem.h>
 #include <P_EventSystem.h> // TODO: less? just need ET_TASK
@@ -618,5 +617,3 @@ LoadRefCountCacheFromPath(RefCountCache<CacheEntryType> &cache, std::string dirn
   socketManager.close(fd);
   return 0;
 }
-
-#endif /* _P_RefCountCache_h_ */

--- a/iocore/hostdb/P_RefCountCacheSerializer.h
+++ b/iocore/hostdb/P_RefCountCacheSerializer.h
@@ -21,8 +21,7 @@
  *  limitations under the License.
  */
 
-#ifndef P_REFCOUNTCACHESERIALIZER_H_07545391_276D_4BD3_B0DD_EF6B0007071D
-#define P_REFCOUNTCACHESERIALIZER_H_07545391_276D_4BD3_B0DD_EF6B0007071D
+#pragma once
 
 #include "P_RefCountCache.h"
 
@@ -320,5 +319,3 @@ RefCountCacheSerializer<C>::write_to_disk(const void *ptr, size_t n_bytes)
   }
   return 0;
 }
-
-#endif /* P_REFCOUNTCACHESERIALIZER_H_07545391_276D_4BD3_B0DD_EF6B0007071D */

--- a/iocore/net/BIO_fastopen.h
+++ b/iocore/net/BIO_fastopen.h
@@ -21,8 +21,7 @@
  *  limitations under the License.
  */
 
-#ifndef BIO_FASTOPEN_H_DA87E080_DB75_4C9C_959A_40243592D454
-#define BIO_FASTOPEN_H_DA87E080_DB75_4C9C_959A_40243592D454
+#pragma once
 
 #include <openssl/bio.h>
 
@@ -34,5 +33,3 @@ const BIO_METHOD *BIO_s_fastopen();
 #if !defined(BIO_set_conn_address)
 #define BIO_set_conn_address(b, addr) BIO_ctrl(b, BIO_C_SET_CONNECT, 2, (char *)addr)
 #endif
-
-#endif /* BIO_FASTOPEN_H_DA87E080_DB75_4C9C_959A_40243592D454 */

--- a/iocore/net/I_Net.h
+++ b/iocore/net/I_Net.h
@@ -38,8 +38,7 @@
   has socks and ssl support.
 
  */
-#ifndef __I_NET_H_
-#define __I_NET_H_
+#pragma once
 
 #include "ts/I_Version.h"
 #include "I_EventSystem.h"
@@ -95,4 +94,3 @@ extern int net_throttle_delay;
 #include "I_SessionAccept.h"
 
 void ink_net_init(ModuleVersion version);
-#endif

--- a/iocore/net/I_NetProcessor.h
+++ b/iocore/net/I_NetProcessor.h
@@ -22,8 +22,7 @@
 
  */
 
-#ifndef __I_NETPROCESSOR_H__
-#define __I_NETPROCESSOR_H__
+#pragma once
 
 #include "I_EventSystem.h"
 #include "I_Socks.h"
@@ -271,5 +270,3 @@ extern inkcoreapi NetProcessor &netProcessor;
 
 */
 extern inkcoreapi NetProcessor &sslNetProcessor;
-
-#endif

--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -22,8 +22,7 @@
 
  */
 
-#ifndef __NETVCONNECTION_H__
-#define __NETVCONNECTION_H__
+#pragma once
 
 #include "ts/ink_inet.h"
 #include "I_Action.h"
@@ -680,5 +679,3 @@ NetVConnection::trapWriteBufferEmpty(int event)
 {
   write_buffer_empty_event = event;
 }
-
-#endif

--- a/iocore/net/I_SessionAccept.h
+++ b/iocore/net/I_SessionAccept.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef I_SessionAccept_H_
-#define I_SessionAccept_H_
+#pragma once
 
 #include "I_Net.h"
 #include "I_VConnection.h"
@@ -79,5 +78,3 @@ public:
 private:
   virtual int mainEvent(int event, void *netvc) = 0;
 };
-
-#endif /* I_SessionAccept_H_ */

--- a/iocore/net/I_Socks.h
+++ b/iocore/net/I_Socks.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __I_SOCKS_H__
-#define __I_SOCKS_H__
+#pragma once
 
 /*When this is being compiled with TS, we enable more features the use
   non modularized stuff. namely:
@@ -68,5 +67,3 @@ struct SocksAddrType {
   SocksAddrType() : type(SOCKS_ATYPE_NONE) { addr.buf = 0; }
   ~SocksAddrType() { reset(); }
 };
-
-#endif

--- a/iocore/net/I_UDPConnection.h
+++ b/iocore/net/I_UDPConnection.h
@@ -29,8 +29,7 @@
 
  ****************************************************************************/
 
-#ifndef __I_UDPCONNECTION_H_
-#define __I_UDPCONNECTION_H_
+#pragma once
 
 #include "I_EventSystem.h"
 #define INK_ETHERNET_MTU_SIZE 1472
@@ -105,4 +104,3 @@ public:
 };
 
 extern UDPConnection *new_UDPConnection(int fd);
-#endif //__I_UDPCONNECTION_H_

--- a/iocore/net/I_UDPNet.h
+++ b/iocore/net/I_UDPNet.h
@@ -29,8 +29,7 @@
 
  ****************************************************************************/
 
-#ifndef __UDPNET_H_
-#define __UDPNET_H_
+#pragma once
 
 #include "ts/I_Version.h"
 #include "I_EventSystem.h"
@@ -107,5 +106,3 @@ inkcoreapi extern UDPNetProcessor &udpNet;
 
 #include "I_UDPPacket.h"
 #include "I_UDPConnection.h"
-
-#endif //__UDPNET_H_

--- a/iocore/net/I_UDPPacket.h
+++ b/iocore/net/I_UDPPacket.h
@@ -29,8 +29,7 @@
 
  ****************************************************************************/
 
-#ifndef __I_UDPPACKET_H_
-#define __I_UDPPACKET_H_
+#pragma once
 
 #include "I_UDPConnection.h"
 /** @name UDPPacket
@@ -103,4 +102,3 @@ extern UDPPacket *new_UDPPacket();
 extern UDPPacket *new_incoming_UDPPacket(struct sockaddr *from, char *buf, int len);
 
 //@}
-#endif //__I_UDPPACKET_H_

--- a/iocore/net/P_CompletionUtil.h
+++ b/iocore/net/P_CompletionUtil.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _COMPLETION_UTIL_H_
-#define _COMPLETION_UTIL_H_
+#pragma once
 // interface
 class completionUtil
 {
@@ -43,5 +42,3 @@ public:
 };
 
 #include "P_UnixCompletionUtil.h"
-
-#endif

--- a/iocore/net/P_Connection.h
+++ b/iocore/net/P_Connection.h
@@ -47,8 +47,7 @@
 
   **************************************************************************/
 
-#ifndef __CONNECTION_H__
-#define __CONNECTION_H__
+#pragma once
 
 #include "ts/ink_platform.h"
 
@@ -177,5 +176,3 @@ struct Server : public Connection {
 
   Server() : Connection(), http_accept_filter(false) { ink_zero(accept_addr); }
 };
-
-#endif /*_Connection_h*/

--- a/iocore/net/P_Net.h
+++ b/iocore/net/P_Net.h
@@ -27,8 +27,7 @@
 
 
 **************************************************************************/
-#ifndef __P_NET_H__
-#define __P_NET_H__
+#pragma once
 
 // Net Stats
 
@@ -124,5 +123,3 @@ extern RecRawStatBlock *net_rsb;
 /// Default amount of buffer space to use for the initial read on an incoming connection.
 /// This is an IOBufferBlock index, not the size in bytes.
 static size_t const CLIENT_CONNECTION_FIRST_READ_BUFFER_SIZE_INDEX = BUFFER_SIZE_INDEX_4K;
-
-#endif

--- a/iocore/net/P_NetAccept.h
+++ b/iocore/net/P_NetAccept.h
@@ -36,8 +36,7 @@
 
 
  ****************************************************************************/
-#ifndef __P_NETACCEPT_H__
-#define __P_NETACCEPT_H__
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "P_Connection.h"
@@ -112,5 +111,3 @@ struct NetAccept : public Continuation {
   explicit NetAccept(const NetProcessor::AcceptOptions &);
   virtual ~NetAccept() { action_ = nullptr; }
 };
-
-#endif

--- a/iocore/net/P_NetVCTest.h
+++ b/iocore/net/P_NetVCTest.h
@@ -34,8 +34,7 @@
 
  ****************************************************************************/
 
-#ifndef _P_NET_VC_TEST_H_
-#define _P_NET_VC_TEST_H_
+#pragma once
 
 #include "ts/ink_platform.h"
 
@@ -141,5 +140,3 @@ public:
   const char *module_name;
   const char *debug_tag;
 };
-
-#endif

--- a/iocore/net/P_OCSPStapling.h
+++ b/iocore/net/P_OCSPStapling.h
@@ -19,8 +19,7 @@
   limitations under the License.
  */
 
-#ifndef __P_OCSPSTAPLING_H__
-#define __P_OCSPSTAPLING_H__
+#pragma once
 
 #include <openssl/ssl.h>
 
@@ -29,5 +28,3 @@ void ssl_stapling_ex_init();
 bool ssl_stapling_init_cert(SSL_CTX *ctx, X509 *cert, const char *certname);
 void ocsp_update();
 int ssl_callback_ocsp_stapling(SSL *);
-
-#endif /* __P_OCSPSTAPLING_H__ */

--- a/iocore/net/P_SSLCertLookup.h
+++ b/iocore/net/P_SSLCertLookup.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __P_SSLCERTLOOKUP_H__
-#define __P_SSLCERTLOOKUP_H__
+#pragma once
 
 #include "ProxyConfig.h"
 #include "P_SSLUtils.h"
@@ -111,4 +110,3 @@ void ticket_block_free(void *ptr);
 ssl_ticket_key_block *ticket_block_alloc(unsigned count);
 ssl_ticket_key_block *ticket_block_create(char *ticket_key_data, int ticket_key_len);
 ssl_ticket_key_block *ssl_create_ticket_keyblock(const char *ticket_key_path);
-#endif /* __P_SSLCERTLOOKUP_H__ */

--- a/iocore/net/P_SSLClientUtils.h
+++ b/iocore/net/P_SSLClientUtils.h
@@ -19,8 +19,7 @@
   limitations under the License.
  */
 
-#ifndef IOCORE_NET_P_SSLCLIENTUTILS_H_
-#define IOCORE_NET_P_SSLCLIENTUTILS_H_
+#pragma once
 
 #include "ts/ink_config.h"
 #include "ts/Diags.h"
@@ -38,5 +37,3 @@
 SSL_CTX *SSLInitClientContext(const struct SSLConfigParams *param);
 
 int verify_callback(int preverify_ok, X509_STORE_CTX *ctx);
-
-#endif /* IOCORE_NET_P_SSLCLIENTUTILS_H_ */

--- a/iocore/net/P_SSLConfig.h
+++ b/iocore/net/P_SSLConfig.h
@@ -28,8 +28,7 @@
    Description:
    SSL Configurations
  ****************************************************************************/
-#ifndef __P_SSLCONFIG_H__
-#define __P_SSLCONFIG_H__
+#pragma once
 
 #include "ProxyConfig.h"
 #include "SSLSessionCache.h"
@@ -191,5 +190,3 @@ private:
 };
 
 extern SSLSessionCache *session_cache;
-
-#endif

--- a/iocore/net/P_SSLNetAccept.h
+++ b/iocore/net/P_SSLNetAccept.h
@@ -36,8 +36,7 @@
 
 
  ****************************************************************************/
-#if !defined(_SSLNetAccept_h_)
-#define _SSLNetAccept_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "P_Connection.h"
@@ -54,4 +53,3 @@ struct SSLNetAccept : public NetAccept {
   SSLNetAccept(const NetProcessor::AcceptOptions &opt);
   virtual ~SSLNetAccept();
 };
-#endif

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -29,8 +29,7 @@
 
 
  ****************************************************************************/
-#if !defined(_SSLNetVConnection_h_)
-#define _SSLNetVConnection_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "P_EventSystem.h"
@@ -336,5 +335,3 @@ private:
 typedef int (SSLNetVConnection::*SSLNetVConnHandler)(int, void *);
 
 extern ClassAllocator<SSLNetVConnection> sslNetVCAllocator;
-
-#endif /* _SSLNetVConnection_h_ */

--- a/iocore/net/P_SSLNextProtocolAccept.h
+++ b/iocore/net/P_SSLNextProtocolAccept.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef P_SSLNextProtocolAccept_H_
-#define P_SSLNextProtocolAccept_H_
+#pragma once
 
 #include "P_Net.h"
 #include "P_EventSystem.h"
@@ -64,5 +63,3 @@ private:
 
   friend struct SSLNextProtocolTrampoline;
 };
-
-#endif /* P_SSLNextProtocolAccept_H_ */

--- a/iocore/net/P_SSLNextProtocolSet.h
+++ b/iocore/net/P_SSLNextProtocolSet.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef P_SSLNextProtocolSet_H_
-#define P_SSLNextProtocolSet_H_
+#pragma once
 
 #include "ts/List.h"
 #include "I_Net.h"
@@ -65,5 +64,3 @@ private:
 
   NextProtocolEndpoint::list_type endpoints;
 };
-
-#endif /* P_SSLNextProtocolSet_H_ */

--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -19,8 +19,7 @@
   limitations under the License.
  */
 
-#ifndef __P_SSLUTILS_H__
-#define __P_SSLUTILS_H__
+#pragma once
 
 #include "ts/ink_config.h"
 #include "ts/Diags.h"
@@ -217,5 +216,3 @@ namespace detail
 
 typedef ats_scoped_resource<ssl::detail::SCOPED_X509_TRAITS> scoped_X509;
 typedef ats_scoped_resource<ssl::detail::SCOPED_BIO_TRAITS> scoped_BIO;
-
-#endif /* __P_SSLUTILS_H__ */

--- a/iocore/net/P_Socks.h
+++ b/iocore/net/P_Socks.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __P_SOCKS_H__
-#define __P_SOCKS_H__
+#pragma once
 #include "P_EventSystem.h"
 #include "I_Socks.h"
 
@@ -173,5 +172,3 @@ SocksAddrType::reset()
   addr.buf = 0;
   type     = SOCKS_ATYPE_NONE;
 }
-
-#endif

--- a/iocore/net/P_UDPConnection.h
+++ b/iocore/net/P_UDPConnection.h
@@ -28,8 +28,7 @@
 
 
  ****************************************************************************/
-#ifndef __P_UDPCONNECTION_H_
-#define __P_UDPCONNECTION_H_
+#pragma once
 
 #include "I_UDPNet.h"
 
@@ -160,5 +159,3 @@ UDPConnection::setContinuation(Continuation *c)
   mutex                                         = c->mutex;
   ((UDPConnectionInternal *)this)->continuation = c;
 }
-
-#endif //__P_UDPCONNECTION_H_

--- a/iocore/net/P_UDPIOEvent.h
+++ b/iocore/net/P_UDPIOEvent.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _UDP_IO_EVENT_H_
-#define _UDP_IO_EVENT_H_
+#pragma once
 // ugly -- just encapsulate the I/O result so that it can be passed
 // back to the caller via continuation handler.
 
@@ -107,4 +106,3 @@ UDPIOEvent::free(UDPIOEvent *e)
   e->mutex = nullptr;
   UDPIOEventAllocator.free(e);
 }
-#endif

--- a/iocore/net/P_UDPNet.h
+++ b/iocore/net/P_UDPNet.h
@@ -28,8 +28,7 @@
 
  ****************************************************************************/
 
-#ifndef __P_UDPNET_H_
-#define __P_UDPNET_H_
+#pragma once
 
 extern EventType ET_UDP;
 
@@ -340,5 +339,3 @@ get_UDPNetHandler(EThread *t)
 {
   return (UDPNetHandler *)ETHREAD_GET_PTR(t, udpNetInternal.udpNetHandler_offset);
 }
-
-#endif //__P_UDPNET_H_

--- a/iocore/net/P_UDPPacket.h
+++ b/iocore/net/P_UDPPacket.h
@@ -28,8 +28,7 @@
 
  ****************************************************************************/
 
-#ifndef __P_UDPPPACKET_H_
-#define __P_UDPPPACKET_H_
+#pragma once
 
 #include "I_UDPNet.h"
 
@@ -251,5 +250,3 @@ new_UDPPacket()
   UDPPacketInternal *p = udpPacketAllocator.alloc();
   return p;
 }
-
-#endif //__P_UDPPPACKET_H_

--- a/iocore/net/P_UnixCompletionUtil.h
+++ b/iocore/net/P_UnixCompletionUtil.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _UNIX_COMPLETION_UTIL_H_
-#define _UNIX_COMPLETION_UTIL_H_
+#pragma once
 
 // platform specific wrappers for dealing with I/O completion events
 // passed into and back from the I/O core.
@@ -101,4 +100,3 @@ completionUtil::getError(Event *e)
   UDPIOEvent *u = (UDPIOEvent *)e;
   return u->getError();
 }
-#endif

--- a/iocore/net/P_UnixNet.h
+++ b/iocore/net/P_UnixNet.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __P_UNIXNET_H__
-#define __P_UNIXNET_H__
+#pragma once
 
 #include "ts/ink_platform.h"
 
@@ -633,5 +632,3 @@ EventIO::stop()
   }
   return 0;
 }
-
-#endif

--- a/iocore/net/P_UnixNetProcessor.h
+++ b/iocore/net/P_UnixNetProcessor.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __UNIXNETPROCESSOR_H__
-#define __UNIXNETPROCESSOR_H__
+#pragma once
 #include "I_Net.h"
 #include "P_NetAccept.h"
 
@@ -72,4 +71,3 @@ extern UnixNetProcessor unix_netProcessor;
 extern void initialize_thread_for_net(EThread *thread);
 
 //#include "UnixNet.h"
-#endif

--- a/iocore/net/P_UnixNetState.h
+++ b/iocore/net/P_UnixNetState.h
@@ -37,8 +37,7 @@
 
 
  ****************************************************************************/
-#if !defined(_UnixNetState_h_)
-#define _UnixNetState_h_
+#pragma once
 
 #include "ts/List.h"
 #include "I_VIO.h"
@@ -56,5 +55,3 @@ struct NetState {
 
   NetState() : enabled(0), vio(VIO::NONE), in_enabled_list(0), triggered(0) {}
 };
-
-#endif

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -29,8 +29,7 @@
 
  ****************************************************************************/
 
-#ifndef __P_UNIXNETVCONNECTION_H__
-#define __P_UNIXNETVCONNECTION_H__
+#pragma once
 
 #include "ts/ink_sock.h"
 #include "I_NetVConnection.h"
@@ -504,5 +503,3 @@ UnixNetVConnection::set_action(Continuation *c)
 void close_UnixNetVConnection(UnixNetVConnection *vc, EThread *t);
 void write_to_net(NetHandler *nh, UnixNetVConnection *vc, EThread *thread);
 void write_to_net_io(NetHandler *nh, UnixNetVConnection *vc, EThread *thread);
-
-#endif

--- a/iocore/net/P_UnixPollDescriptor.h
+++ b/iocore/net/P_UnixPollDescriptor.h
@@ -27,8 +27,7 @@
 
 
 *****************************************************************************/
-#ifndef __P_UNIXPOLLDESCRIPTOR_H__
-#define __P_UNIXPOLLDESCRIPTOR_H__
+#pragma once
 
 #include "ts/ink_platform.h"
 
@@ -138,5 +137,3 @@ private:
 #endif
   }
 };
-
-#endif

--- a/iocore/net/P_UnixUDPConnection.h
+++ b/iocore/net/P_UnixUDPConnection.h
@@ -28,8 +28,7 @@
 
 
  ****************************************************************************/
-#ifndef __UNIXUDPCONNECTION_H_
-#define __UNIXUDPCONNECTION_H_
+#pragma once
 
 #include "P_UDPConnection.h"
 #include "P_UDPPacket.h"
@@ -112,5 +111,3 @@ new_UDPConnection(int fd)
 {
   return (fd >= 0) ? new UnixUDPConnection(fd) : 0;
 }
-
-#endif //__UNIXUDPCONNECTION_H_

--- a/iocore/net/SSLDynlock.h
+++ b/iocore/net/SSLDynlock.h
@@ -21,11 +21,8 @@
   limitations under the License.
  */
 
-#ifndef __SSLDYNLOCK_H__
-#define __SSLDYNLOCK_H__
+#pragma once
 
 extern struct CRYPTO_dynlock_value *ssl_dyn_create_callback(const char *file, int line);
 extern void ssl_dyn_lock_callback(int mode, struct CRYPTO_dynlock_value *value, const char *file, int line);
 extern void ssl_dyn_destroy_callback(struct CRYPTO_dynlock_value *value, const char *file, int line);
-
-#endif

--- a/iocore/net/SSLSessionCache.h
+++ b/iocore/net/SSLSessionCache.h
@@ -19,8 +19,7 @@
   limitations under the License.
  */
 
-#ifndef __SSLSESSIONCACHE_H__
-#define __SSLSESSIONCACHE_H__
+#pragma once
 
 #include "ts/Map.h"
 #include "ts/List.h"
@@ -158,5 +157,3 @@ private:
   SSLSessionBucket *session_bucket;
   size_t nbuckets;
 };
-
-#endif /* __SSLSESSIONCACHE_H__ */

--- a/iocore/utils/I_OneWayMultiTunnel.h
+++ b/iocore/utils/I_OneWayMultiTunnel.h
@@ -28,8 +28,7 @@
 
  */
 
-#if !defined(_I_OneWayMultiTunnel_h_)
-#define _I_OneWayMultiTunnel_h_
+#pragma once
 
 #include "I_OneWayTunnel.h"
 
@@ -149,4 +148,3 @@ struct OneWayMultiTunnel : public OneWayTunnel {
 };
 
 extern ClassAllocator<OneWayMultiTunnel> OneWayMultiTunnelAllocator;
-#endif

--- a/iocore/utils/I_OneWayTunnel.h
+++ b/iocore/utils/I_OneWayTunnel.h
@@ -28,8 +28,7 @@
 
  */
 
-#if !defined(_I_OneWayTunnel_h_)
-#define _I_OneWayTunnel_h_
+#pragma once
 
 #include "I_EventSystem.h"
 
@@ -210,5 +209,3 @@ private:
   OneWayTunnel(const OneWayTunnel &);
   OneWayTunnel &operator=(const OneWayTunnel &);
 };
-
-#endif

--- a/lib/bindings/bindings.h
+++ b/lib/bindings/bindings.h
@@ -21,8 +21,7 @@
  *  limitations under the License.
  */
 
-#ifndef BINDINGS_H_02DF784C_94BD_4A5C_B57A_F986F5493C6A
-#define BINDINGS_H_02DF784C_94BD_4A5C_B57A_F986F5493C6A
+#pragma once
 
 #include <string>
 #include <map>
@@ -71,5 +70,3 @@ private:
   BindingInstance(const BindingInstance &);            // noncopyable
   BindingInstance &operator=(const BindingInstance &); // noncopyable
 };
-
-#endif /* BINDINGS_H_02DF784C_94BD_4A5C_B57A_F986F5493C6A */

--- a/lib/bindings/lua.h
+++ b/lib/bindings/lua.h
@@ -21,8 +21,7 @@
  *  limitations under the License.
  */
 
-#ifndef LUA_H_7A9F5CCE_01C6_45C3_987A_FDCC1F437AA2
-#define LUA_H_7A9F5CCE_01C6_45C3_987A_FDCC1F437AA2
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -99,5 +98,3 @@ private:
   lua_State *L;
   unsigned nvals;
 };
-
-#endif /* LUA_H_7A9F5CCE_01C6_45C3_987A_FDCC1F437AA2 */

--- a/lib/bindings/metrics.h
+++ b/lib/bindings/metrics.h
@@ -21,8 +21,7 @@
  *  limitations under the License.
  */
 
-#ifndef METRICS_H_FED1F5EA_9EDE_48E6_B05A_5DCAFD8DC319
-#define METRICS_H_FED1F5EA_9EDE_48E6_B05A_5DCAFD8DC319
+#pragma once
 
 // Create a new metrics binding userdata object.
 int lua_metrics_new(const char *prefix, lua_State *L);
@@ -36,5 +35,3 @@ void lua_metrics_register(lua_State *L);
 // if the metric is named "proxy.my.great.counter", it would install
 // a metrics object at the global name "proxy.my.great".
 int lua_metrics_install(lua_State *L);
-
-#endif /* METRICS_H_FED1F5EA_9EDE_48E6_B05A_5DCAFD8DC319 */

--- a/lib/bindings/repl.h
+++ b/lib/bindings/repl.h
@@ -21,10 +21,7 @@
  *  limitations under the License.
  */
 
-#ifndef REPL_H_DB690467_F8FE_4797_8B08_7FD1F090DBA2
-#define REPL_H_DB690467_F8FE_4797_8B08_7FD1F090DBA2
+#pragma once
 
 // Drop this binding instance into a Lua REPL (and never come out).
 void repl(BindingInstance &binding) TS_NORETURN;
-
-#endif /* REPL_H_DB690467_F8FE_4797_8B08_7FD1F090DBA2 */

--- a/lib/cppapi/include/atscppapi/AsyncHttpFetch.h
+++ b/lib/cppapi/include/atscppapi/AsyncHttpFetch.h
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef ATSCPPAPI_ASYNCHTTPFETCH_H_
-#define ATSCPPAPI_ASYNCHTTPFETCH_H_
 
 #include <string>
 #include <memory>
@@ -135,5 +133,3 @@ private:
 };
 
 } /* atscppapi */
-
-#endif /* ATSCPPAPI_ASYNCHTTPFETCH_H_ */

--- a/lib/cppapi/include/atscppapi/AsyncTimer.h
+++ b/lib/cppapi/include/atscppapi/AsyncTimer.h
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef ATSCPPAPI_ASYNCTIMER_H_
-#define ATSCPPAPI_ASYNCTIMER_H_
 
 #include <string>
 #include <memory>
@@ -79,5 +77,3 @@ private:
 };
 
 } /* atscppapi */
-
-#endif /* ATSCPPAPI_ASYNCTIMER_H_ */

--- a/lib/cppapi/include/atscppapi/CaseInsensitiveStringComparator.h
+++ b/lib/cppapi/include/atscppapi/CaseInsensitiveStringComparator.h
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef ATSCPPAPI_CASE_INSENSITIVE_STRING_COMPARATOR_H_
-#define ATSCPPAPI_CASE_INSENSITIVE_STRING_COMPARATOR_H_
 
 #include <string>
 
@@ -47,5 +45,3 @@ public:
   int compare(const std::string &lhs, const std::string &rhs) const;
 };
 }
-
-#endif

--- a/lib/cppapi/include/atscppapi/ClientRequest.h
+++ b/lib/cppapi/include/atscppapi/ClientRequest.h
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef ATSCPPAPI_CLIENTREQUEST_H_
-#define ATSCPPAPI_CLIENTREQUEST_H_
 
 #include <atscppapi/Request.h>
 
@@ -56,5 +54,3 @@ private:
   ClientRequestState *state_;
 };
 }
-
-#endif /* ATSCPPAPI_CLIENTREQUEST_H_ */

--- a/lib/cppapi/include/atscppapi/GlobalPlugin.h
+++ b/lib/cppapi/include/atscppapi/GlobalPlugin.h
@@ -22,8 +22,6 @@
  */
 
 #pragma once
-#ifndef ATSCPPAPI_GLOBALPLUGIN_H_
-#define ATSCPPAPI_GLOBALPLUGIN_H_
 
 #include <atscppapi/Plugin.h>
 
@@ -88,5 +86,3 @@ private:
 };
 
 } /* atscppapi */
-
-#endif /* ATSCPPAPI_GLOBALPLUGIN_H_ */

--- a/lib/cppapi/include/atscppapi/Headers.h
+++ b/lib/cppapi/include/atscppapi/Headers.h
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef ATSCPPAPI_HEADERS_H_
-#define ATSCPPAPI_HEADERS_H_
 
 #include <atscppapi/noncopyable.h>
 #include <string>
@@ -602,5 +600,3 @@ private:
   friend class Response;
 };
 }
-
-#endif

--- a/lib/cppapi/include/atscppapi/HttpMethod.h
+++ b/lib/cppapi/include/atscppapi/HttpMethod.h
@@ -21,8 +21,6 @@
  * @brief Contains an enumeration and printable strings for Http Methods.
  */
 #pragma once
-#ifndef ATSCPPAPI_HTTP_METHOD_H_
-#define ATSCPPAPI_HTTP_METHOD_H_
 
 #include <string>
 
@@ -54,5 +52,3 @@ enum HttpMethod {
  */
 extern const std::string HTTP_METHOD_STRINGS[];
 }
-
-#endif

--- a/lib/cppapi/include/atscppapi/HttpStatus.h
+++ b/lib/cppapi/include/atscppapi/HttpStatus.h
@@ -22,8 +22,6 @@
  */
 
 #pragma once
-#ifndef ATSCPPAPI_HTTP_STATUS_H_
-#define ATSCPPAPI_HTTP_STATUS_H_
 
 #include <string>
 
@@ -99,5 +97,3 @@ enum HttpStatus {
 
 };
 }
-
-#endif

--- a/lib/cppapi/include/atscppapi/HttpVersion.h
+++ b/lib/cppapi/include/atscppapi/HttpVersion.h
@@ -22,8 +22,6 @@
  */
 
 #pragma once
-#ifndef ATSCPPAPI_HTTP_VERSION_H_
-#define ATSCPPAPI_HTTP_VERSION_H_
 
 #include <string>
 
@@ -47,5 +45,3 @@ enum HttpVersion {
  */
 extern const std::string HTTP_VERSION_STRINGS[];
 }
-
-#endif

--- a/lib/cppapi/include/atscppapi/InterceptPlugin.h
+++ b/lib/cppapi/include/atscppapi/InterceptPlugin.h
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef ATSCPPAPI_INTERCEPT_PLUGIN_H_
-#define ATSCPPAPI_INTERCEPT_PLUGIN_H_
 
 #include <string>
 #include <atscppapi/Transaction.h>
@@ -99,5 +97,3 @@ private:
 };
 
 } /* atscppapi */
-
-#endif /* ATSCPPAPI_INTERCEPT_PLUGIN_H_ */

--- a/lib/cppapi/include/atscppapi/Logger.h
+++ b/lib/cppapi/include/atscppapi/Logger.h
@@ -27,8 +27,6 @@
  */
 
 #pragma once
-#ifndef ATSCPPAPI_LOGGER_H_
-#define ATSCPPAPI_LOGGER_H_
 
 #include <string>
 #include <atscppapi/noncopyable.h>
@@ -263,5 +261,3 @@ private:
 };
 
 } /* atscppapi */
-
-#endif /* ATSCPPAPI_LOGGER_H_ */

--- a/lib/cppapi/include/atscppapi/Plugin.h
+++ b/lib/cppapi/include/atscppapi/Plugin.h
@@ -24,8 +24,6 @@
  */
 
 #pragma once
-#ifndef ATSCPPAPI_PLUGIN_H_
-#define ATSCPPAPI_PLUGIN_H_
 
 #include <atscppapi/Transaction.h>
 #include <atscppapi/noncopyable.h>
@@ -169,5 +167,3 @@ extern const std::string HOOK_TYPE_STRINGS[];
 void RegisterGlobalPlugin(const std::string &name, const std::string &vendor, const std::string &email);
 
 } /* atscppapi */
-
-#endif /* ATSCPPAPI_GLOBALPLUGIN_H_ */

--- a/lib/cppapi/include/atscppapi/PluginInit.h
+++ b/lib/cppapi/include/atscppapi/PluginInit.h
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef ATSCPPAPI_PLUGININIT_H_
-#define ATSCPPAPI_PLUGININIT_H_
 #include <ts/apidefs.h>
 #include <atscppapi/utils.h>
 extern "C" {
@@ -47,5 +45,3 @@ void TSPluginInit(int argc, const char *argv[]);
  */
 TSReturnCode TSRemapNewInstance(int argc, char *argv[], void **instance_handle, char *errbuf, int errbuf_size);
 }
-
-#endif /* ATSCPPAPI_PLUGININIT_H_ */

--- a/lib/cppapi/include/atscppapi/RemapPlugin.h
+++ b/lib/cppapi/include/atscppapi/RemapPlugin.h
@@ -21,8 +21,6 @@
  */
 
 #pragma once
-#ifndef ATSCPPAPI_REMAP_PLUGIN_H_
-#define ATSCPPAPI_REMAP_PLUGIN_H_
 
 #include "atscppapi/Transaction.h"
 #include "atscppapi/Url.h"
@@ -73,5 +71,3 @@ public:
   virtual ~RemapPlugin() {}
 };
 }
-
-#endif

--- a/lib/cppapi/include/atscppapi/Request.h
+++ b/lib/cppapi/include/atscppapi/Request.h
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef ATSCPPAPI_REQUEST_H_
-#define ATSCPPAPI_REQUEST_H_
 
 #include <atscppapi/Headers.h>
 #include <atscppapi/HttpVersion.h>
@@ -82,5 +80,3 @@ private:
   friend class ClientRequest;
 };
 }
-
-#endif

--- a/lib/cppapi/include/atscppapi/Response.h
+++ b/lib/cppapi/include/atscppapi/Response.h
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef ATSCPPAPI_RESPONSE_H_
-#define ATSCPPAPI_RESPONSE_H_
 
 #include <atscppapi/Headers.h>
 #include <atscppapi/HttpVersion.h>
@@ -72,5 +70,3 @@ private:
   friend class utils::internal;
 };
 }
-
-#endif

--- a/lib/cppapi/include/atscppapi/Stat.h
+++ b/lib/cppapi/include/atscppapi/Stat.h
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef ATSCPPAPI_STAT_H_
-#define ATSCPPAPI_STAT_H_
 
 #include <atscppapi/noncopyable.h>
 #include <stdint.h>
@@ -103,5 +101,3 @@ private:
 };
 
 } /* atscppapi */
-
-#endif /* ATSCPPAPI_STAT_H_ */

--- a/lib/cppapi/include/atscppapi/Transaction.h
+++ b/lib/cppapi/include/atscppapi/Transaction.h
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef ATSCPPAPI_TRANSACTION_H_
-#define ATSCPPAPI_TRANSACTION_H_
 
 #include <sys/socket.h>
 #include <stdint.h>
@@ -413,5 +411,3 @@ private:
 };
 
 } /* atscppapi */
-
-#endif /* ATSCPPAPI_TRANSACTION_H_ */

--- a/lib/cppapi/include/atscppapi/Url.h
+++ b/lib/cppapi/include/atscppapi/Url.h
@@ -20,8 +20,6 @@
  */
 
 #pragma once
-#ifndef ATSCPPAPI_URL_H_
-#define ATSCPPAPI_URL_H_
 
 #include <string>
 #include <stdint.h>
@@ -146,5 +144,3 @@ private:
   friend class RemapPlugin;
 };
 }
-
-#endif /* ATSCPPAPI_URL_H_ */

--- a/lib/cppapi/include/atscppapi/noncopyable.h
+++ b/lib/cppapi/include/atscppapi/noncopyable.h
@@ -23,8 +23,6 @@
  */
 
 #pragma once
-#ifndef ATSCPPAPI_NONCOPYABLE_H_
-#define ATSCPPAPI_NONCOPYABLE_H_
 
 namespace atscppapi
 {
@@ -59,5 +57,3 @@ private:
 };
 
 } /* atscppapi */
-
-#endif /* ATSCPPAPI_NONCOPYABLE_H_ */

--- a/lib/cppapi/include/atscppapi/utils.h
+++ b/lib/cppapi/include/atscppapi/utils.h
@@ -23,8 +23,6 @@
  */
 
 #pragma once
-#ifndef ATSCPPAPI_UTILS_H_
-#define ATSCPPAPI_UTILS_H_
 
 #include <string>
 #include <netinet/in.h>
@@ -68,5 +66,3 @@ namespace utils
   std::string getIpPortString(const sockaddr *);
 }
 }
-
-#endif /* ATSCPPAPI_UTILS_H_ */

--- a/lib/cppapi/include/logging_internal.h
+++ b/lib/cppapi/include/logging_internal.h
@@ -24,8 +24,6 @@
  */
 
 #pragma once
-#ifndef ATSCPPAPI_LOGGING_INTERNAL_H_
-#define ATSCPPAPI_LOGGING_INTERNAL_H_
 
 #include "atscppapi/Logger.h"
 
@@ -40,5 +38,3 @@
 
 #define LOG_DEBUG(fmt, ...) TS_DEBUG("atscppapi", fmt, ##__VA_ARGS__)
 #define LOG_ERROR(fmt, ...) TS_ERROR("atscppapi", fmt, ##__VA_ARGS__)
-
-#endif /* ATSCPPAPI_LOGGING_INTERNAL_H_ */

--- a/lib/cppapi/include/utils_internal.h
+++ b/lib/cppapi/include/utils_internal.h
@@ -24,8 +24,6 @@
  */
 
 #pragma once
-#ifndef ATSCPPAPI_ATSUTILS_H_
-#define ATSCPPAPI_ATSUTILS_H_
 
 #include <ts/ts.h>
 #include <string>
@@ -105,5 +103,3 @@ namespace utils
 
 } /* utils */
 }
-
-#endif /* ATSCPPAPI_ATSUTILS_H_ */

--- a/lib/raft/raft.h
+++ b/lib/raft/raft.h
@@ -20,8 +20,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-#ifndef RAFT_H_
-#define RAFT_H_
+#pragma once
 // An implementation of the RAFT consensus algorithm:
 //   https://ramcloud.stanford.edu/raft.pdf
 //
@@ -132,4 +131,3 @@ public:
   void ConfigChange(RaftClass *raft, const Config &config);
 };
 } // namespace raft
-#endif // RAFT_H_

--- a/lib/raft/raft_impl.h
+++ b/lib/raft/raft_impl.h
@@ -20,8 +20,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-#ifndef CONSENSUS_IMPL_H_
-#define CONSENSUS_IMPL_H_
+#pragma once
 #include <stdlib.h>
 #include <algorithm>
 #include <deque>
@@ -617,4 +616,3 @@ NewRaft(Server *server, const ::std::string &node)
   return new RaftImpl<Server>(server, node);
 }
 } // namespace raft
-#endif // CONSENSUS_IMPL_H_

--- a/lib/records/I_RecAlarms.h
+++ b/lib/records/I_RecAlarms.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _I_REC_ALARMS_H_
-#define _I_REC_ALARMS_H_
+#pragma once
 
 // copy from mgmt/Alarms.h
 #define REC_ALARM_PROXY_PROCESS_DIED 1
@@ -46,5 +45,3 @@
 #define REC_ALARM_PROXY_LOG_SPACE_ROLLED 19
 #define REC_ALARM_PROXY_HTTP_CONGESTED_SERVER 20
 #define REC_ALARM_PROXY_HTTP_ALLEVIATED_SERVER 21
-
-#endif

--- a/lib/records/I_RecCore.h
+++ b/lib/records/I_RecCore.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _I_REC_CORE_H_
-#define _I_REC_CORE_H_
+#pragma once
 
 #include "ts/Diags.h"
 
@@ -315,5 +314,3 @@ RecErrT RecSetSyncRequired(char *name, bool lock = true);
 //------------------------------------------------------------------------
 typedef void *(*RecManagerCb)(void *opaque_cb_data, char *data_raw, int data_len);
 int RecRegisterManagerCb(int _signal, RecManagerCb _fn, void *_data = nullptr);
-
-#endif

--- a/lib/records/I_RecDefs.h
+++ b/lib/records/I_RecDefs.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _I_REC_DEFS_H_
-#define _I_REC_DEFS_H_
+#pragma once
 
 #include "ts/ink_mutex.h"
 #include "ts/ink_rwlock.h"
@@ -183,5 +182,3 @@ struct RecRawStatBlock {
 typedef int (*RecConfigUpdateCb)(const char *name, RecDataT data_type, RecData data, void *cookie);
 typedef int (*RecStatUpdateFunc)(const char *name, RecDataT data_type, RecData *data, RecRawStatBlock *rsb, int id, void *cookie);
 typedef int (*RecRawStatSyncCb)(const char *name, RecDataT data_type, RecData *data, RecRawStatBlock *rsb, int id);
-
-#endif

--- a/lib/records/I_RecEvents.h
+++ b/lib/records/I_RecEvents.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _I_REC_EVENTS_H_
-#define _I_REC_EVENTS_H_
+#pragma once
 
 // copy from mgmt/BaseManager.h
 #define REC_EVENT_SYNC_KEY 10000
@@ -38,5 +37,3 @@
 #define REC_EVENT_CONFIG_FILE_UPDATE_NO_INC_VERSION 10010
 
 #define REC_EVENT_CACHE_DISK_CONTROL 10011
-
-#endif

--- a/lib/records/I_RecHttp.h
+++ b/lib/records/I_RecHttp.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _I_REC_HTTP_H
-#define _I_REC_HTTP_H
+#pragma once
 
 #include <ts/ink_inet.h>
 #include <ts/ink_resolver.h>
@@ -473,5 +472,3 @@ HttpProxyPort::findHttp(uint16_t family)
     This must be called before any proxy port parsing is done.
 */
 extern void ts_session_protocol_well_known_name_indices_init();
-
-#endif // I_REC_HTTP_H

--- a/lib/records/I_RecLocal.h
+++ b/lib/records/I_RecLocal.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _I_REC_LOCAL_H_
-#define _I_REC_LOCAL_H_
+#pragma once
 
 #include "I_RecCore.h"
 
@@ -35,5 +34,3 @@ class FileManager;
 int RecLocalInit(Diags *diags = nullptr);
 int RecLocalInitMessage();
 int RecLocalStart(FileManager *);
-
-#endif

--- a/lib/records/I_RecMutex.h
+++ b/lib/records/I_RecMutex.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _I_REC_MUTEX_H_
-#define _I_REC_MUTEX_H_
+#pragma once
 
 #include "ts/ink_mutex.h"
 #include "ts/ink_thread.h"
@@ -42,5 +41,3 @@ int rec_mutex_init(RecMutex *m, const char *name = nullptr);
 int rec_mutex_destroy(RecMutex *m);
 int rec_mutex_acquire(RecMutex *m);
 int rec_mutex_release(RecMutex *m);
-
-#endif

--- a/lib/records/I_RecProcess.h
+++ b/lib/records/I_RecProcess.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _I_REC_PROCESS_H_
-#define _I_REC_PROCESS_H_
+#pragma once
 
 #include "I_RecCore.h"
 #include "I_EventSystem.h"
@@ -156,5 +155,3 @@ RecIncrRawStatCount(RecRawStatBlock *rsb, EThread *ethread, int id, int64_t incr
   tlp->count += incr;
   return REC_ERR_OKAY;
 }
-
-#endif /* !_I_REC_PROCESS_H_ */

--- a/lib/records/I_RecSignals.h
+++ b/lib/records/I_RecSignals.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _I_REC_SIGNALS_H_
-#define _I_REC_SIGNALS_H_
+#pragma once
 
 // copy from mgmt/BaseManager.h
 #define REC_SIGNAL_PID 0
@@ -44,5 +43,3 @@
 #define REC_SIGNAL_LIBRECORDS 16
 #define REC_SIGNAL_HTTP_CONGESTED_SERVER 20
 #define REC_SIGNAL_HTTP_ALLEVIATED_SERVER 21
-
-#endif

--- a/lib/records/P_RecCore.h
+++ b/lib/records/P_RecCore.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _P_REC_CORE_H_
-#define _P_REC_CORE_H_
+#pragma once
 
 #include "ts/ink_thread.h"
 #include "ts/ink_hash_table.h"
@@ -97,5 +96,3 @@ RecUpdateT RecExecConfigUpdateCbs(unsigned int update_required_type);
 void RecDumpRecordsHt(RecT rec_type = RECT_NULL);
 
 void RecDumpRecords(RecT rec_type, RecDumpEntryCb callback, void *edata);
-
-#endif

--- a/lib/records/P_RecDefs.h
+++ b/lib/records/P_RecDefs.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _P_REC_DEFS_H_
-#define _P_REC_DEFS_H_
+#pragma once
 
 #include "I_RecDefs.h"
 
@@ -162,5 +161,3 @@ typedef RecMessageHdr RecMessage;
 typedef void (*RecDumpEntryCb)(RecT rec_type, void *edata, int registered, const char *name, int data_type, RecData *datum);
 
 typedef RecErrT (*RecMessageRecvCb)(RecMessage *msg, RecMessageT msg_type, void *cookie);
-
-#endif

--- a/lib/records/P_RecFile.h
+++ b/lib/records/P_RecFile.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _P_REC_FILE_H_
-#define _P_REC_FILE_H_
+#pragma once
 
 //-------------------------------------------------------------------------
 // types/defines
@@ -53,5 +52,3 @@ RecHandle RecPipeConnect(const char *base_path, const char *name);
 int RecPipeClose(RecHandle h_pipe);
 int RecPipeRead(RecHandle h_pipe, char *buf, int size);
 int RecPipeWrite(RecHandle h_pipe, char *buf, int size);
-
-#endif

--- a/lib/records/P_RecLocal.h
+++ b/lib/records/P_RecLocal.h
@@ -21,9 +21,6 @@
   limitations under the License.
  */
 
-#ifndef _P_REC_LOCAL_H_
-#define _P_REC_LOCAL_H_
+#pragma once
 
 #include "I_RecLocal.h"
-
-#endif

--- a/lib/records/P_RecMessage.h
+++ b/lib/records/P_RecMessage.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _P_REC_MESSAGE_H_
-#define _P_REC_MESSAGE_H_
+#pragma once
 
 #include "P_RecDefs.h"
 
@@ -50,5 +49,3 @@ void *RecMessageRecvThis(void *cookie, char *data_raw, int data_len);
 
 RecMessage *RecMessageReadFromDisk(const char *fpath);
 int RecMessageWriteToDisk(RecMessage *msg, const char *fpath);
-
-#endif

--- a/lib/records/P_RecProcess.h
+++ b/lib/records/P_RecProcess.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _P_REC_PROCESS_H_
-#define _P_REC_PROCESS_H_
+#pragma once
 
 // Must include 'P_EventSystem.h' before 'I_EventSystem.h' (which is
 // included in 'I_RecProcess.h') to prevent multiple-symbol-definition
@@ -38,5 +37,3 @@
 //-------------------------------------------------------------------------
 
 int RecExecRawStatSyncCbs();
-
-#endif

--- a/lib/records/P_RecUtils.h
+++ b/lib/records/P_RecUtils.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _P_REC_UTILS_H_
-#define _P_REC_UTILS_H_
+#pragma once
 
 #include "ts/Diags.h"
 #include "ts/ink_atomic.h"
@@ -78,5 +77,3 @@ void RecDebugOff();
 
 #define RecLog(level, fmt, ...) _RecLog(level, MakeSourceLocation(), fmt, ##__VA_ARGS__)
 #define RecDebug(level, fmt, ...) _RecDebug(level, MakeSourceLocation(), fmt, ##__VA_ARGS__)
-
-#endif

--- a/lib/ts/Allocator.h
+++ b/lib/ts/Allocator.h
@@ -37,8 +37,7 @@
 
  */
 
-#ifndef _Allocator_h_
-#define _Allocator_h_
+#pragma once
 
 #include <new>
 #include <stdlib.h>
@@ -251,5 +250,3 @@ private:
   uint64_t allocations;
   ink_mutex trackerLock;
 };
-
-#endif // _Allocator_h_

--- a/lib/ts/Arena.h
+++ b/lib/ts/Arena.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __ARENA_H__
-#define __ARENA_H__
+#pragma once
 
 #include <sys/types.h>
 #include <memory.h>
@@ -165,5 +164,3 @@ Arena::str_store(const char *str, size_t len)
 
   return mem;
 }
-
-#endif /* __ARENA_H__ */

--- a/lib/ts/BaseLogFile.h
+++ b/lib/ts/BaseLogFile.h
@@ -22,8 +22,7 @@
 
  */
 
-#ifndef BASE_LOG_FILE_H
-#define BASE_LOG_FILE_H
+#pragma once
 
 #include <stdarg.h>
 #include <stdio.h>
@@ -240,4 +239,3 @@ private:
   bool m_is_init;
   BaseMetaInfo *m_meta_info;
 };
-#endif

--- a/lib/ts/Bitops.h
+++ b/lib/ts/Bitops.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __BITOPS_H__
-#define __BITOPS_H__
+#pragma once
 
 #include <strings.h>
 
@@ -271,5 +270,3 @@ bitops_isset(unsigned char *val, int bit)
   int idx = bit % 8;
   return ((val[pos] & (1 << idx)) != 0);
 }
-
-#endif /* __BITOPS_H__ */

--- a/lib/ts/ConsistentHash.h
+++ b/lib/ts/ConsistentHash.h
@@ -19,8 +19,7 @@
   limitations under the License.
  */
 
-#ifndef __CONSISTENT_HASH_H__
-#define __CONSISTENT_HASH_H__
+#pragma once
 
 #include "Hash.h"
 #include <stdint.h>
@@ -60,5 +59,3 @@ private:
   ATSHash64 *hash;
   std::map<uint64_t, ATSConsistentHashNode *> NodeMap;
 };
-
-#endif

--- a/lib/ts/ContFlags.h
+++ b/lib/ts/ContFlags.h
@@ -32,8 +32,7 @@
  at least a 32 bit architecture, so the rawflags size is 32 bits.
  ****************************************************************************/
 
-#ifndef _CONT_FLAGS_H
-#define _CONT_FLAGS_H
+#pragma once
 
 #include "ink_thread.h"
 
@@ -90,5 +89,3 @@ void set_cont_flags(const ContFlags &flags);
 void set_cont_flag(ContFlags::flags flag_bit, bool value);
 ContFlags get_cont_flags();
 bool get_cont_flag(ContFlags::flags flag_bit);
-
-#endif // _CONT_FLAGS_H

--- a/lib/ts/CryptoHash.h
+++ b/lib/ts/CryptoHash.h
@@ -20,8 +20,7 @@
     limitations under the License.
  */
 
-#if !defined CRYPTO_HASH_HEADER
-#define CRYPTO_HASH_HEADER
+#pragma once
 
 /// Apache Traffic Server commons.
 
@@ -141,5 +140,3 @@ CryptoContext::finalize(CryptoHash *hash)
 using ats::CryptoHash;
 using ats::CryptoContext;
 using ats::CRYPTO_HASH_ZERO;
-
-#endif // CRYPTO_HASH_HEADER

--- a/lib/ts/Diags.h
+++ b/lib/ts/Diags.h
@@ -31,8 +31,7 @@
 
  ****************************************************************************/
 
-#ifndef __DIAGS_H___
-#define __DIAGS_H___
+#pragma once
 
 #include <stdarg.h>
 #include "ink_mutex.h"
@@ -353,4 +352,3 @@ extern inkcoreapi Diags *diags;
 #define is_diags_on(_t) 0
 
 #endif // TS_USE_DIAGS
-#endif /*_Diags_h_*/

--- a/lib/ts/DynArray.h
+++ b/lib/ts/DynArray.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __DYN_ARRAY_H__
-#define __DYN_ARRAY_H__
+#pragma once
 
 template <class T> class DynArray
 {
@@ -188,5 +187,3 @@ DynArray<T>::resize(intptr_t new_size)
     size = new_size;
   }
 }
-
-#endif /* __DYN_ARRAY_H__ */

--- a/lib/ts/EventNotify.h
+++ b/lib/ts/EventNotify.h
@@ -28,8 +28,7 @@
 
 **************************************************************************/
 
-#ifndef EVENT_NOTIFY_H
-#define EVENT_NOTIFY_H
+#pragma once
 
 #include "ts/ink_thread.h"
 
@@ -54,6 +53,4 @@ private:
   ink_mutex m_mutex;
 #endif
 };
-
-#endif /* EVENT_NOTIFY_H */
 /* vim: set sw=4 ts=4 tw=79 et : */

--- a/lib/ts/Hash.h
+++ b/lib/ts/Hash.h
@@ -19,8 +19,7 @@
   limitations under the License.
  */
 
-#ifndef __HASH_H__
-#define __HASH_H__
+#pragma once
 
 #include <cstddef>
 #include <stdint.h>
@@ -64,5 +63,3 @@ struct ATSHash64 : ATSHashBase {
   virtual uint64_t get(void) const = 0;
   virtual bool operator==(const ATSHash64 &) const;
 };
-
-#endif

--- a/lib/ts/HashFNV.h
+++ b/lib/ts/HashFNV.h
@@ -25,8 +25,7 @@
   Currently implemented FNV-1a 32bit and FNV-1a 64bit
  */
 
-#ifndef __HASH_FNV_H__
-#define __HASH_FNV_H__
+#pragma once
 
 #include "ts/Hash.h"
 #include <stdint.h>
@@ -92,5 +91,3 @@ ATSHash64FNV1a::update(const void *data, size_t len, Transform xfrm)
     hval += (hval << 1) + (hval << 4) + (hval << 5) + (hval << 7) + (hval << 8) + (hval << 40);
   }
 }
-
-#endif

--- a/lib/ts/HashMD5.h
+++ b/lib/ts/HashMD5.h
@@ -19,8 +19,7 @@
   limitations under the License.
  */
 
-#ifndef __HASH_MD5_H__
-#define __HASH_MD5_H__
+#pragma once
 
 #include "ts/Hash.h"
 #include <openssl/evp.h>
@@ -40,5 +39,3 @@ private:
   unsigned int md_len;
   bool finalized;
 };
-
-#endif

--- a/lib/ts/HashSip.h
+++ b/lib/ts/HashSip.h
@@ -19,8 +19,7 @@
   limitations under the License.
  */
 
-#ifndef __HASH_SIP_H__
-#define __HASH_SIP_H__
+#pragma once
 
 #include "ts/Hash.h"
 #include <stdint.h>
@@ -48,5 +47,3 @@ private:
   size_t total_len;
   bool finalized;
 };
-
-#endif

--- a/lib/ts/HostLookup.h
+++ b/lib/ts/HostLookup.h
@@ -28,8 +28,8 @@
  *
  ****************************************************************************/
 
-#ifndef _HOST_LOOKUP_H_
-#define _HOST_LOOKUP_H_
+#pragma once
+
 // HostLookup  constantss
 const int HOST_TABLE_DEPTH = 3; // Controls the max number of levels in the logical tree
 const int HOST_ARRAY_MAX   = 8; // Sets the fixed array size
@@ -125,5 +125,3 @@ private:
   int num_el;               // the numbe of itmems in the tree
   const char *matcher_name; // Used for Debug/Warning/Error messages
 };
-
-#endif

--- a/lib/ts/INK_MD5.h
+++ b/lib/ts/INK_MD5.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _INK_MD5_h_
-#define _INK_MD5_h_
+#pragma once
 
 #include "ts/ink_code.h"
 #include "ts/ink_defs.h"
@@ -42,5 +41,3 @@ public:
 };
 
 typedef CryptoHash INK_MD5;
-
-#endif

--- a/lib/ts/I_Layout.h
+++ b/lib/ts/I_Layout.h
@@ -28,8 +28,7 @@
 
  */
 
-#ifndef _I_Layout_h
-#define _I_Layout_h
+#pragma once
 
 // use std string and string view for layout
 #include <string>
@@ -106,5 +105,3 @@ struct Layout {
   std::string infodir;
   std::string cachedir;
 };
-
-#endif

--- a/lib/ts/I_Version.h
+++ b/lib/ts/I_Version.h
@@ -28,8 +28,7 @@
 
   **************************************************************************/
 
-#ifndef _Version_h
-#define _Version_h
+#pragma once
 
 struct VersionNumber {
   short int ink_major; // incompatible change
@@ -110,5 +109,3 @@ public:
   void setup(const char *pkg_name, const char *app_name, const char *app_version, const char *build_date, const char *build_time,
              const char *build_machine, const char *build_person, const char *build_cflags);
 };
-
-#endif /*_Version_h*/

--- a/lib/ts/InkErrno.h
+++ b/lib/ts/InkErrno.h
@@ -27,8 +27,7 @@
 
 */
 
-#if !defined(_Errno_h_)
-#define _Errno_h_
+#pragma once
 #include <errno.h>
 
 #define INK_START_ERRNO 20000
@@ -70,5 +69,3 @@
 #define EHTTP_ERROR (HTTP_ERRNO + 0)
 
 const char *InkStrerror(int ink_errno);
-
-#endif

--- a/lib/ts/IntrusiveDList.h
+++ b/lib/ts/IntrusiveDList.h
@@ -1,6 +1,3 @@
-#if !defined(TS_INTRUSIVE_DOUBLE_LIST_HEADER)
-#define TS_INTRUSIVE_DOUBLE_LIST_HEADER
-
 /** @file
 
     Intrusive double linked list container.
@@ -41,6 +38,8 @@
     limitations under the License.
 
  */
+
+#pragma once
 
 /// FreeBSD doesn't like just declaring the tag struct we need so we have to include the file.
 #include <iterator>
@@ -375,5 +374,3 @@ protected:
   T *_tail;      ///< Last element in list.
   size_t _count; ///< # of elements in list.
 };
-
-#endif // TS_INTRUSIVE_DOUBLE_LIST_HEADER

--- a/lib/ts/IpMap.h
+++ b/lib/ts/IpMap.h
@@ -1,13 +1,3 @@
-#if !defined(TS_IP_MAP_HEADER)
-#define TS_IP_MAP_HEADER
-
-#include "ts/ink_platform.h"
-#include "ts/ink_defs.h"
-#include "ts/RbTree.h"
-#include "ts/ink_inet.h"
-#include "ts/IntrusiveDList.h"
-#include "ts/ink_assert.h"
-
 /** @file
 
     Map of IP addresses to client data.
@@ -30,6 +20,15 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
+
+#pragma once
+
+#include "ts/ink_platform.h"
+#include "ts/ink_defs.h"
+#include "ts/RbTree.h"
+#include "ts/ink_inet.h"
+#include "ts/IntrusiveDList.h"
+#include "ts/ink_assert.h"
 
 namespace ts
 {
@@ -449,5 +448,3 @@ inline IpMap::iterator::pointer IpMap::iterator::operator->() const
 inline IpMap::IpMap() : _m4(0), _m6(0)
 {
 }
-
-#endif // TS_IP_MAP_HEADER

--- a/lib/ts/IpMapConf.h
+++ b/lib/ts/IpMapConf.h
@@ -23,6 +23,8 @@
 
 // Copied from IPRange.cc for backwards compatibility.
 
+#pragma once
+
 class IpMap; // declare in name only.
 
 // Returns 0 if successful, error string otherwise

--- a/lib/ts/List.h
+++ b/lib/ts/List.h
@@ -51,8 +51,7 @@
 
  ****************************************************************************/
 
-#ifndef _List_h_
-#define _List_h_
+#pragma once
 
 #include <stdint.h>
 
@@ -742,5 +741,3 @@ template <class C, class L> inline AtomicSLL<C, L>::AtomicSLL()
 {
   ink_atomiclist_init(&al, "AtomicSLL", (uint32_t)(uintptr_t)&L::next_link((C *)0));
 }
-
-#endif /*_List_h_*/

--- a/lib/ts/MMH.h
+++ b/lib/ts/MMH.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _MMH_h_
-#define _MMH_h_
+#pragma once
 
 #include "ts/ink_code.h"
 #include "ts/ink_defs.h"
@@ -115,5 +114,3 @@ public:
   }
 #endif
 };
-
-#endif

--- a/lib/ts/MatcherUtils.h
+++ b/lib/ts/MatcherUtils.h
@@ -29,8 +29,7 @@
  *
  ****************************************************************************/
 
-#ifndef _MATCHER_UTILS_H_
-#define _MATCHER_UTILS_H_
+#pragma once
 
 #include "ts/ParseRules.h"
 #include "ts/ink_inet.h"
@@ -171,5 +170,3 @@ LowerCaseStr(char *str)
     str++;
   }
 }
-
-#endif

--- a/lib/ts/ParseRules.h
+++ b/lib/ts/ParseRules.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#if !defined(_ParseRules_h_)
-#define _ParseRules_h_
+#pragma once
 
 #include <string.h>
 
@@ -866,5 +865,3 @@ ink_atoui(const char *str)
   else
     return static_cast<int>(val);
 }
-
-#endif /* #if !defined (_ParseRules_h_) */

--- a/lib/ts/PriorityQueue.h
+++ b/lib/ts/PriorityQueue.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __PRIORITY_QUEUE_H__
-#define __PRIORITY_QUEUE_H__
+#pragma once
 
 #include "ts/ink_assert.h"
 #include "ts/Vec.h"
@@ -252,5 +251,3 @@ PriorityQueue<T, Comp>::_bubble_down(uint32_t index)
     break;
   }
 }
-
-#endif // __PRIORITY_QUEUE_H__

--- a/lib/ts/Ptr.h
+++ b/lib/ts/Ptr.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef PTR_H_FBBD7DC3_CA5D_4715_9162_5E4DDA93353F
-#define PTR_H_FBBD7DC3_CA5D_4715_9162_5E4DDA93353F
+#pragma once
 
 #include "ts/ink_atomic.h"
 
@@ -250,5 +249,3 @@ Ptr<T>::operator=(const Ptr<T> &src)
 {
   return (operator=(src.m_ptr));
 }
-
-#endif /* PTR_H_FBBD7DC3_CA5D_4715_9162_5E4DDA93353F */

--- a/lib/ts/RawHashTable.h
+++ b/lib/ts/RawHashTable.h
@@ -28,8 +28,7 @@
 
 */
 
-#ifndef _RawHashTable_h_
-#define _RawHashTable_h_
+#pragma once
 
 #include "ts/ink_apidefs.h"
 #include "ts/ink_hash_table.h"
@@ -379,5 +378,3 @@ inline RawHashTableIter::~RawHashTableIter()
 {
   return;
 }
-
-#endif /*_RawHashTable_h_*/

--- a/lib/ts/RbTree.h
+++ b/lib/ts/RbTree.h
@@ -19,8 +19,7 @@
   limitations under the License.
  */
 
-#ifndef RBTREE_H_
-#define RBTREE_H_
+#pragma once
 
 namespace ts
 {
@@ -218,5 +217,3 @@ namespace detail
 } /* namespace detail */
 
 } /* namespace ts */
-
-#endif /* RBTREE_H_ */

--- a/lib/ts/Regex.h
+++ b/lib/ts/Regex.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __TS_REGEX_H__
-#define __TS_REGEX_H__
+#pragma once
 
 #include "ts/ink_config.h"
 
@@ -79,5 +78,3 @@ private:
 
   dfa_pattern *_my_patterns;
 };
-
-#endif /* __TS_REGEX_H__ */

--- a/lib/ts/Regression.h
+++ b/lib/ts/Regression.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _Regression_h
-#define _Regression_h
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "ts/Regex.h"
@@ -104,5 +103,3 @@ struct RegressionTest {
 int rprintf(RegressionTest *t, const char *format, ...);
 int rperf(RegressionTest *t, const char *tag, double val);
 char *regression_status_string(int status);
-
-#endif /* _Regression_h */

--- a/lib/ts/SimpleTokenizer.h
+++ b/lib/ts/SimpleTokenizer.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _SIMPLE_TOKENIZER_H_
-#define _SIMPLE_TOKENIZER_H_
+#pragma once
 
 #include <stdlib.h>
 #include <string.h>
@@ -295,5 +294,3 @@ private:
     return count;
   };
 };
-
-#endif

--- a/lib/ts/SourceLocation.h
+++ b/lib/ts/SourceLocation.h
@@ -21,8 +21,7 @@
  *  limitations under the License.
  */
 
-#ifndef SOURCELOCATION_H_88F6E38C_ACBB_4EFE_8819_71FCB162AE9B
-#define SOURCELOCATION_H_88F6E38C_ACBB_4EFE_8819_71FCB162AE9B
+#pragma once
 
 // The SourceLocation class wraps up a source code location, including
 // file name, function name, and line number, and contains a method to
@@ -56,5 +55,3 @@ public:
 
   char *str(char *buf, int buflen) const;
 };
-
-#endif /* SOURCELOCATION_H_88F6E38C_ACBB_4EFE_8819_71FCB162AE9B */

--- a/lib/ts/TestBox.h
+++ b/lib/ts/TestBox.h
@@ -1,6 +1,3 @@
-#if !defined(TS_TEST_BOX_HEADER)
-#define TS_TEST_BOX_HEADER
-
 /** @file
 
     Regression testing support class.
@@ -23,6 +20,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
+
+#pragma once
 
 #include <stdarg.h>
 #include "ts/ink_apidefs.h"
@@ -71,4 +70,3 @@ TestBox::check(bool result, char const *fmt, ...)
   return result;
 }
 }
-#endif // TS_TEST_BOX_HEADER

--- a/lib/ts/TextBuffer.h
+++ b/lib/ts/TextBuffer.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _TEXT_BUFFER
-#define _TEXT_BUFFER
+#pragma once
 
 /****************************************************************************
  *
@@ -82,5 +81,3 @@ private:
   char *bufferStart;
   char *nextAdd;
 };
-
-#endif

--- a/lib/ts/Tokenizer.h
+++ b/lib/ts/Tokenizer.h
@@ -23,8 +23,7 @@
 
 /***************************************/
 
-#ifndef _TOKENIZER_H_
-#define _TOKENIZER_H_
+#pragma once
 
 /****************************************************************************
  *
@@ -166,5 +165,3 @@ private:
   tok_node *add_node;
   int add_index;
 };
-
-#endif

--- a/lib/ts/Trie.h
+++ b/lib/ts/Trie.h
@@ -20,8 +20,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-#ifndef _TRIE_H
-#define _TRIE_H
+#pragma once
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -250,5 +249,3 @@ Trie<T>::Node::Print(const char *debug_tag) const
     }
   }
 }
-
-#endif // _TRIE_H

--- a/lib/ts/TsBuffer.h
+++ b/lib/ts/TsBuffer.h
@@ -1,6 +1,3 @@
-#if !defined TS_BUFFER_HEADER
-#define TS_BUFFER_HEADER
-
 /** @file
     Definitions for a buffer type, to carry a reference to a chunk of memory.
 
@@ -25,6 +22,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
  */
+
+#pragma once
 
 #if defined _MSC_VER
 #include <stddef.h>
@@ -514,5 +513,3 @@ ConstBuffer::clip(char const *p)
 
 typedef ts::Buffer TsBuffer;
 typedef ts::ConstBuffer TsConstBuffer;
-
-#endif // TS_BUFFER_HEADER

--- a/lib/ts/X509HostnameValidator.h
+++ b/lib/ts/X509HostnameValidator.h
@@ -21,8 +21,7 @@
     limitations under the License.
 */
 
-#ifndef LIB_TS_X509HOSTNAMEVALIDATOR_H_
-#define LIB_TS_X509HOSTNAMEVALIDATOR_H_
+#pragma once
 
 #include <openssl/x509.h>
 
@@ -36,5 +35,3 @@
  */
 
 bool validate_hostname(X509 *cert, const unsigned char *hostname, bool is_ip, char **peername);
-
-#endif /* LIB_TS_X509HOSTNAMEVALIDATOR_H_ */

--- a/lib/ts/apidefs.h.in
+++ b/lib/ts/apidefs.h.in
@@ -28,8 +28,7 @@
 
  */
 
-#ifndef __TS_APIDEFS_H__
-#define __TS_APIDEFS_H__
+#pragma once
 
 /*
  * ATS Plugin just needs to include <ts/ts.h>,
@@ -1211,5 +1210,3 @@ typedef struct tsapi_uuid *TSUuid;
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
-
-#endif /* __TS_APIDEFS_H__ */

--- a/lib/ts/defalloc.h
+++ b/lib/ts/defalloc.h
@@ -20,8 +20,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-#ifndef _defalloc_H_
-#define _defalloc_H_
+#pragma once
 
 #include "ts/ink_memory.h"
 
@@ -39,5 +38,3 @@ public:
     ats_free(p);
   }
 };
-
-#endif

--- a/lib/ts/fastlz.h
+++ b/lib/ts/fastlz.h
@@ -24,8 +24,7 @@
   THE SOFTWARE.
 */
 
-#ifndef FASTLZ_H
-#define FASTLZ_H
+#pragma once
 
 #define FASTLZ_VERSION 0x000100
 
@@ -96,5 +95,3 @@ int fastlz_compress_level(int level, const void *input, int length, void *output
 #if defined(__cplusplus)
 }
 #endif
-
-#endif /* FASTLZ_H */

--- a/lib/ts/hugepages.h
+++ b/lib/ts/hugepages.h
@@ -18,8 +18,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-#ifndef _hugepages_h_
-#define _hugepages_h_
+#pragma once
 
 #include <cstring>
 
@@ -28,5 +27,3 @@ bool ats_hugepage_enabled(void);
 void ats_hugepage_init(int);
 void *ats_alloc_hugepage(size_t);
 bool ats_free_hugepage(void *, size_t);
-
-#endif

--- a/lib/ts/ink_aiocb.h
+++ b/lib/ts/ink_aiocb.h
@@ -29,8 +29,7 @@
 
  ****************************************************************************/
 
-#ifndef _ink_aiocb_h_
-#define _ink_aiocb_h_
+#pragma once
 
 #include "ts/ink_defs.h"
 
@@ -58,5 +57,3 @@ struct ink_aiocb {
   int aio_state;   /* state flag for List I/O */
   int aio__pad[1]; /* extension padding */
 };
-
-#endif

--- a/lib/ts/ink_align.h
+++ b/lib/ts/ink_align.h
@@ -22,8 +22,7 @@
  */
 
 //-*-c++-*-
-#ifndef _ink_align_h_
-#define _ink_align_h_
+#pragma once
 
 #include "ts/ink_time.h"
 
@@ -94,5 +93,3 @@ align_pointer_forward_and_zero(const void *pointer_, size_t alignment)
 // We could handle this using casts, but that's more prone to
 // errors during porting.
 //
-
-#endif

--- a/lib/ts/ink_apidefs.h
+++ b/lib/ts/ink_apidefs.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _ink_apidefs_h_
-#define _ink_apidefs_h_
+#pragma once
 
 #define inkliapi
 #define inkcoreapi
@@ -73,6 +72,4 @@
 
 #if !defined(TS_INLINE)
 #define TS_INLINE inline
-#endif
-
 #endif

--- a/lib/ts/ink_args.h
+++ b/lib/ts/ink_args.h
@@ -26,8 +26,7 @@ Process arguments
 
 ****************************************************************************/
 
-#ifndef _INK_ARGS_H
-#define _INK_ARGS_H
+#pragma once
 #include "ts/ink_defs.h"
 #include "ts/ink_apidefs.h"
 
@@ -99,5 +98,3 @@ void process_args(const AppVersionInfo *appinfo, const ArgumentDescription *argu
 
 bool process_args_ex(const AppVersionInfo *appinfo, const ArgumentDescription *argument_descriptions,
                      unsigned n_argument_descriptions, const char **argv);
-
-#endif /*_INK_ARGS_H*/

--- a/lib/ts/ink_assert.h
+++ b/lib/ts/ink_assert.h
@@ -25,8 +25,7 @@
 Assertions
 
 ***************************************************************************/
-#ifndef _INK_ASSERT_H
-#define _INK_ASSERT_H
+#pragma once
 
 #include "ts/ink_apidefs.h"
 #include "ts/ink_error.h"
@@ -56,8 +55,6 @@ inkcoreapi void _ink_assert(const char *a, const char *f, int l) TS_NORETURN;
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
-
-#endif /*_INK_ASSERT_H*/
 
 /* workaround a bug in the  stupid Sun preprocessor
 

--- a/lib/ts/ink_atomic.h
+++ b/lib/ts/ink_atomic.h
@@ -34,8 +34,7 @@
 
  ****************************************************************************/
 
-#ifndef _ink_atomic_h_
-#define _ink_atomic_h_
+#pragma once
 
 #include <stdio.h>
 #include <string.h>
@@ -192,5 +191,3 @@ ink_atomic_decrement(pvuint64 mem, Amount value)
 #else /* not gcc > v4.1.2 */
 #error Need a compiler / libc that supports atomic operations, e.g. gcc v4.1.2 or later
 #endif
-
-#endif /* _ink_atomic_h_ */

--- a/lib/ts/ink_base64.h
+++ b/lib/ts/ink_base64.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _ink_base64_h_
-#define _ink_base64_h_
+#pragma once
 
 /*
  * Base64 encoding and decoding as according to RFC1521.  Similar to uudecode.
@@ -45,5 +44,3 @@ bool ats_base64_decode(const char *inBuffer, size_t inBufferSize, unsigned char 
 // Little helper functions to calculate minimum required output buffer for encoding/decoding.
 #define ATS_BASE64_ENCODE_DSTLEN(_length) ((_length * 8) / 6 + 4)
 #define ATS_BASE64_DECODE_DSTLEN(_length) (((_length + 3) / 4) * 3)
-
-#endif

--- a/lib/ts/ink_cap.h
+++ b/lib/ts/ink_cap.h
@@ -21,8 +21,7 @@
   limitations under the License.
 
  */
-#if !defined(_ink_cap_h_)
-#define _ink_cap_h_
+#pragma once
 
 #include <unistd.h>
 #include <sys/types.h>
@@ -98,5 +97,3 @@ private:
   void *cap_state; ///< Original capabilities state to restore.
 #endif
 };
-
-#endif

--- a/lib/ts/ink_code.h
+++ b/lib/ts/ink_code.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _ink_code_h_
-#define _ink_code_h_
+#pragma once
 
 #include "ts/ink_apidefs.h"
 #include "ts/ink_defs.h"
@@ -41,4 +40,3 @@ inkcoreapi char *ink_code_to_hex_str(char *dest33, uint8_t const *md5);
 inkcoreapi int ink_code_incr_md5_init(INK_DIGEST_CTX *context);
 inkcoreapi int ink_code_incr_md5_update(INK_DIGEST_CTX *context, const char *input, int input_length);
 inkcoreapi int ink_code_incr_md5_final(char *sixteen_byte_hash_pointer, INK_DIGEST_CTX *context);
-#endif

--- a/lib/ts/ink_defs.h
+++ b/lib/ts/ink_defs.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _ink_defs_h
-#define _ink_defs_h
+#pragma once
 
 #include "ts/ink_config.h"
 #include <stddef.h>
@@ -140,5 +139,3 @@ namespace ts
 static const int NO_FD = -1; ///< No or invalid file descriptor.
 }
 #endif
-
-#endif /*__ink_defs_h*/

--- a/lib/ts/ink_error.h
+++ b/lib/ts/ink_error.h
@@ -29,8 +29,7 @@
 
  ****************************************************************************/
 
-#ifndef _ink_error_h_
-#define _ink_error_h_
+#pragma once
 
 #include <stdarg.h>
 #include "ts/ink_platform.h"
@@ -56,5 +55,3 @@ void ink_eprintf(const char *message_format, ...) TS_PRINTFLIKE(1, 2);
 void ink_error(const char *message_format, ...) TS_PRINTFLIKE(1, 2);
 
 int ink_set_dprintf_level(int debug_level);
-
-#endif

--- a/lib/ts/ink_exception.h
+++ b/lib/ts/ink_exception.h
@@ -31,6 +31,8 @@
  *
  */
 
+#pragma once
+
 class Exception
 {
 };

--- a/lib/ts/ink_file.h
+++ b/lib/ts/ink_file.h
@@ -29,8 +29,7 @@
 
  ****************************************************************************/
 
-#ifndef _ink_file_h_
-#define _ink_file_h_
+#pragma once
 
 #include "ts/ink_config.h"
 
@@ -139,5 +138,3 @@ isdotdot(const char *path)
 {
   return path[0] == '.' && path[1] == '.' && path[2] == '\0';
 }
-
-#endif // _ink_file_h_

--- a/lib/ts/ink_hash_table.h
+++ b/lib/ts/ink_hash_table.h
@@ -30,8 +30,7 @@
 
  ****************************************************************************/
 
-#ifndef _ink_hash_table_h_
-#define _ink_hash_table_h_
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -144,4 +143,3 @@ ink_hash_table_iterator_next(InkHashTable *ht_ptr, InkHashTableIteratorState *st
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
-#endif /* #ifndef _ink_hash_table_h_ */

--- a/lib/ts/ink_hrtime.h
+++ b/lib/ts/ink_hrtime.h
@@ -28,8 +28,7 @@
   This file contains code supporting the Inktomi high-resolution timer.
 **************************************************************************/
 
-#if !defined(_ink_hrtime_h_)
-#define _ink_hrtime_h_
+#pragma once
 
 #include "ts/ink_config.h"
 #include "ts/ink_assert.h"
@@ -274,5 +273,3 @@ ink_hrtime_sleep(ink_hrtime delay)
   struct timespec ts = ink_hrtime_to_timespec(delay);
   nanosleep(&ts, nullptr);
 }
-
-#endif /* _ink_hrtime_h_ */

--- a/lib/ts/ink_inet.h
+++ b/lib/ts/ink_inet.h
@@ -22,8 +22,7 @@
 
  */
 
-#if !defined(_ink_inet_h_)
-#define _ink_inet_h_
+#pragma once
 
 #include <netinet/in.h>
 #include <netdb.h>
@@ -1581,5 +1580,3 @@ IpEndpoint::setToLoopback(int family)
   }
   return *this;
 }
-
-#endif // _ink_inet.h

--- a/lib/ts/ink_inout.h
+++ b/lib/ts/ink_inout.h
@@ -26,8 +26,7 @@
 
 **************************************************************************/
 
-#ifndef _INOUT_H
-#define _INOUT_H
+#pragma once
 
 // source of good macros..
 #ifdef __cplusplus
@@ -81,5 +80,3 @@ extern "C" {
     (cp)[0] = l >> 8;      \
     (cp) += 8;             \
   }
-
-#endif /* #ifndef _INOUT_H */

--- a/lib/ts/ink_llqueue.h
+++ b/lib/ts/ink_llqueue.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _INK_LLQUEUE_H
-#define _INK_LLQUEUE_H
+#pragma once
 
 /****************************************************************************
 
@@ -52,5 +51,3 @@ uint64_t queue_len(LLQ *Q);
 uint64_t queue_highwater(LLQ *Q);
 void delete_queue(LLQ *Q); /* only deletes an empty queue but
                               provides symmetry. */
-
-#endif

--- a/lib/ts/ink_lockfile.h
+++ b/lib/ts/ink_lockfile.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __INK_LOCKFILE_H__
-#define __INK_LOCKFILE_H__
+#pragma once
 
 #include "ts/ink_defs.h"
 #include "ts/ink_string.h"
@@ -89,5 +88,3 @@ private:
   char fname[PATH_NAME_MAX];
   int fd;
 };
-
-#endif // __LOCK_FILE_H__

--- a/lib/ts/ink_memory.h
+++ b/lib/ts/ink_memory.h
@@ -20,8 +20,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-#ifndef _ink_memory_h_
-#define _ink_memory_h_
+#pragma once
 
 #include <ctype.h>
 #include <string.h>
@@ -570,5 +569,3 @@ path_join(ats_scoped_str const &lhs, ats_scoped_str const &rhs)
   return x.release();
 }
 #endif /* __cplusplus */
-
-#endif

--- a/lib/ts/ink_mutex.h
+++ b/lib/ts/ink_mutex.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _ink_mutex_h_
-#define _ink_mutex_h_
+#pragma once
 
 /***********************************************************************
 
@@ -109,4 +108,3 @@ ink_mutex_try_acquire(ink_mutex *m)
 }
 
 #endif /* #if defined(POSIX_THREAD) */
-#endif /* _ink_mutex_h_ */

--- a/lib/ts/ink_platform.h
+++ b/lib/ts/ink_platform.h
@@ -22,8 +22,7 @@
   limitations under the License.
  */
 
-#ifndef _ink_platform_h
-#define _ink_platform_h
+#pragma once
 
 #include "ts/ink_config.h"
 
@@ -204,5 +203,3 @@ typedef unsigned int in_addr_t;
                            // on various OSs (linux-4096,osx/bsd-1024,
                            //                 windows-260,etc)
 #endif
-
-#endif /* _ink_platform_h */

--- a/lib/ts/ink_queue.h
+++ b/lib/ts/ink_queue.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _ink_queue_h_
-#define _ink_queue_h_
+#pragma once
 
 /***********************************************************************
 
@@ -202,5 +201,3 @@ void *ink_atomiclist_remove(InkAtomicList *l, void *item);
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
-
-#endif /* _ink_queue_h_ */

--- a/lib/ts/ink_rand.h
+++ b/lib/ts/ink_rand.h
@@ -58,8 +58,7 @@
    email: m-mat @ math.sci.hiroshima-u.ac.jp (remove spaces)
 */
 
-#ifndef __INK_RAND_H__
-#define __INK_RAND_H__
+#pragma once
 
 #include "ts/ink_defs.h"
 #include "ts/ink_apidefs.h"
@@ -83,5 +82,3 @@ ink_rand_r(uint32_t *p)
 {
   return (((*p) = (*p) * 1103515245 + 12345) % ((uint32_t)0x7fffffff + 1));
 }
-
-#endif /* __INK_RAND_H__ */

--- a/lib/ts/ink_resolver.h
+++ b/lib/ts/ink_resolver.h
@@ -66,8 +66,7 @@
   limitations under the License.
 */
 
-#ifndef _ink_resolver_h_
-#define _ink_resolver_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "ts/ink_inet.h"
@@ -286,5 +285,3 @@ int ts_host_res_order_to_string(HostResPreferenceOrder const &order, ///< order 
                                 char *out,                           ///< Target buffer for string.
                                 int size                             ///< Size of buffer.
                                 );
-
-#endif /* _ink_resolver_h_ */

--- a/lib/ts/ink_resource.h
+++ b/lib/ts/ink_resource.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __INK_RESOURCE_H__
-#define __INK_RESOURCE_H__
+#pragma once
 
 #include "ts/ink_mutex.h"
 #include <map>
@@ -55,5 +54,3 @@ private:
   static std::map<const char *, Resource *> _resourceMap;
   static ink_mutex resourceLock;
 };
-
-#endif /* __INK_RESOURCE_H__ */

--- a/lib/ts/ink_rwlock.h
+++ b/lib/ts/ink_rwlock.h
@@ -27,8 +27,7 @@
 // will not work if used in conjunction with ink_thread_cancel().
 //-------------------------------------------------------------------------
 
-#ifndef _INK_RWLOCK_H_
-#define _INK_RWLOCK_H_
+#pragma once
 
 #include "ts/ink_mutex.h"
 #include "ts/ink_thread.h"
@@ -50,5 +49,3 @@ int ink_rwlock_destroy(ink_rwlock *rw);
 int ink_rwlock_rdlock(ink_rwlock *rw);
 int ink_rwlock_wrlock(ink_rwlock *rw);
 int ink_rwlock_unlock(ink_rwlock *rw);
-
-#endif

--- a/lib/ts/ink_sock.h
+++ b/lib/ts/ink_sock.h
@@ -27,8 +27,7 @@
 
 
 ***************************************************************************/
-#if !defined(_ink_sock_h_)
-#define _ink_sock_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "ts/ink_defs.h"
@@ -64,5 +63,3 @@ int read_socket(int s, char *buffer, int length);
 inkcoreapi uint32_t ink_inet_addr(const char *s);
 
 int bind_unix_domain_socket(const char *path, mode_t mode);
-
-#endif /* _ink_sock_h_ */

--- a/lib/ts/ink_sprintf.h
+++ b/lib/ts/ink_sprintf.h
@@ -31,8 +31,7 @@
 
   ****************************************************************************/
 
-#ifndef _ink_sprintf_h_
-#define _ink_sprintf_h_
+#pragma once
 
 #include <stdio.h>
 #include <stdarg.h>
@@ -41,5 +40,3 @@
 
 int ink_bsprintf(char *buffer, const char *format, ...) TS_PRINTFLIKE(2, 3);
 int ink_bvsprintf(char *buffer, const char *format, va_list ap);
-
-#endif

--- a/lib/ts/ink_stack_trace.h
+++ b/lib/ts/ink_stack_trace.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef ink_stack_trace_h
-#define ink_stack_trace_h
+#pragma once
 
 // The max number of levels in the stack trace
 #define INK_STACK_TRACE_MAX_LEVELS 100
@@ -35,5 +34,3 @@ void ink_stack_trace_dump();
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* ink_stack_trace_h */

--- a/lib/ts/ink_string++.h
+++ b/lib/ts/ink_string++.h
@@ -30,8 +30,7 @@
 
  ****************************************************************************/
 
-#if !defined(_ink_string_pp_h_)
-#define _ink_string_pp_h_
+#pragma once
 #include <stdio.h>
 #include <strings.h>
 
@@ -298,5 +297,3 @@ StrList::append_string(const char *s, int len_not_counting_nul)
   append(cell);
   return (cell);
 }
-
-#endif

--- a/lib/ts/ink_string.h
+++ b/lib/ts/ink_string.h
@@ -29,8 +29,7 @@
 
  ****************************************************************************/
 
-#ifndef _ink_string_h_
-#define _ink_string_h_
+#pragma once
 
 #include <stdio.h>
 #include <memory.h>
@@ -384,5 +383,3 @@ ink_fast_ltoa(int64_t val, char *buf, int buf_len)
 
   return ink_small_itoa((int)val, buf, buf_len);
 }
-
-#endif

--- a/lib/ts/ink_sys_control.h
+++ b/lib/ts/ink_sys_control.h
@@ -21,12 +21,9 @@
   limitations under the License.
  */
 
-#ifndef _INK_SYS_CONTROL_H
-#define _INK_SYS_CONTROL_H
+#pragma once
 
 #include <sys/resource.h>
 
 rlim_t ink_max_out_rlimit(int which, bool max_it = true, bool unlim_it = true);
 rlim_t ink_get_max_files();
-
-#endif /*_INK_SYS_CONTROL_H*/

--- a/lib/ts/ink_syslog.h
+++ b/lib/ts/ink_syslog.h
@@ -29,9 +29,6 @@
  *
  ****************************************************************************/
 
-#ifndef _INK_SYSLOG_H_
-#define _INK_SYSLOG_H_
+#pragma once
 
 int facility_string_to_int(const char *str);
-
-#endif

--- a/lib/ts/ink_thread.h
+++ b/lib/ts/ink_thread.h
@@ -26,8 +26,7 @@
 
 **************************************************************************/
 
-#ifndef _INK_THREAD_H
-#define _INK_THREAD_H
+#pragma once
 
 #include "ts/ink_hrtime.h"
 #include "ts/ink_defs.h"
@@ -300,5 +299,3 @@ ink_set_thread_name(const char *name ATS_UNUSED)
 }
 
 #endif /* #if defined(POSIX_THREAD) */
-
-#endif /*_INK_THREAD_H*/

--- a/lib/ts/ink_time.h
+++ b/lib/ts/ink_time.h
@@ -31,8 +31,7 @@
 
  ****************************************************************************/
 
-#ifndef _ink_time_h_
-#define _ink_time_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "ts/ink_defs.h"
@@ -91,5 +90,3 @@ ink_timezone()
 }
 
 #endif /* #if defined(freebsd) || defined(openbsd) */
-
-#endif /* #ifndef _ink_time_h_ */

--- a/lib/ts/ink_uuid.h
+++ b/lib/ts/ink_uuid.h
@@ -21,6 +21,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+#pragma once
+
 #include <stdio.h>
 
 #include "ts/apidefs.h"

--- a/lib/ts/signals.h
+++ b/lib/ts/signals.h
@@ -26,8 +26,7 @@
 
 **************************************************************************/
 
-#ifndef __SIGNALS_H__
-#define __SIGNALS_H__
+#pragma once
 
 typedef void (*signal_handler_t)(int signo, siginfo_t *info, void *ctx);
 
@@ -54,5 +53,3 @@ bool signal_check_handler(int signo, signal_handler_t handler);
 // Start a thread to test whether signals have the expected handler. Apparantly useful for
 // finding pthread bugs in some version of DEC Unix.
 void signal_start_check_thread(signal_handler_t handler);
-
-#endif /* __SIGNALS_H__ */

--- a/lib/tsconfig/TsConfigGrammar.h
+++ b/lib/tsconfig/TsConfigGrammar.h
@@ -30,8 +30,7 @@
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
-#ifndef YY_TSCONFIG_TSCONFIGGRAMMAR_H_INCLUDED
-# define YY_TSCONFIG_TSCONFIGGRAMMAR_H_INCLUDED
+#pragma once
 /* Enabling traces.  */
 #ifndef YYDEBUG
 # define YYDEBUG 0
@@ -127,5 +126,3 @@ int tsconfigparse (yyscan_t lexer, struct TsConfigHandlers* handlers);
 int tsconfigparse ();
 #endif
 #endif /* ! YYPARSE_PARAM */
-
-#endif /* !YY_TSCONFIG_TSCONFIGGRAMMAR_H_INCLUDED  */

--- a/lib/wccp/Wccp.h
+++ b/lib/wccp/Wccp.h
@@ -1,6 +1,3 @@
-#if !defined(ATS_WCCP_API_HEADER)
-#define ATS_WCCP_API_HEADER
-
 /** @file
     WCCP (v2) support API.
 
@@ -22,6 +19,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
  */
+
+#pragma once
 
 #include <ts/TsBuffer.h>
 #include <tsconfig/Errata.h>
@@ -516,4 +515,3 @@ EndPoint::useMD5Security(char const *key)
 // ------------------------------------------------------
 
 } // namespace Wccp
-#endif // include guard.

--- a/lib/wccp/WccpLocal.h
+++ b/lib/wccp/WccpLocal.h
@@ -1,6 +1,3 @@
-#if !defined(TS_WCCP_LOCAL_HEADER)
-#define TS_WCCP_LOCAL_HEADER
-
 /** @file
     WCCP (v2) support for Apache Traffic Server.
 
@@ -22,6 +19,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
  */
+
+#pragma once
 
 #include "Wccp.h"
 #include "WccpUtil.h"
@@ -3740,5 +3739,3 @@ RouterImpl::RouterData::resize(size_t n)
 // ------------------------------------------------------
 
 } // namespace wccp
-
-#endif // TS_WCCP_LOCAL_HEADER

--- a/lib/wccp/WccpMeta.h
+++ b/lib/wccp/WccpMeta.h
@@ -1,6 +1,3 @@
-#if !defined(TS_WCCP_META_HEADER)
-#define TS_WCCP_META_HEADER
-
 /** @file
     Meta programming support for WCCP.
 
@@ -22,6 +19,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
  */
+
+#pragma once
 
 #include <algorithm>
 

--- a/lib/wccp/WccpUtil.h
+++ b/lib/wccp/WccpUtil.h
@@ -20,8 +20,7 @@
     limitations under the License.
  */
 
-#if !defined(ATS_WCCP_UTIL_HEADER)
-#define ATS_WCCP_UTIL_HEADER
+#pragma once
 
 #include <vector>
 
@@ -221,5 +220,3 @@ char const *ip_addr_to_str(uint32_t addr ///< Address to convert.
 // ------------------------------------------------------
 
 } // namespace Wccp
-
-#endif // define ATS_WCCP_UTIL_HEADER

--- a/mgmt/FileManager.h
+++ b/mgmt/FileManager.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _FILE_MANAGER_H_
-#define _FILE_MANAGER_H_
+#pragma once
 
 /****************************************************************************
  *
@@ -155,5 +154,3 @@ private:
 int snapEntryCmpFunc(const void *e1, const void *e2);
 
 void initializeRegistry(); // implemented in AddConfigFilesHere.cc
-
-#endif

--- a/mgmt/RecordsConfig.h
+++ b/mgmt/RecordsConfig.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#if !defined(_RECORDS_CONFIG_H_)
-#define _RECORDS_CONFIG_H_
+#pragma once
 
 //#include "MgmtDefs.h"
 #include "P_RecCore.h"
@@ -51,5 +50,3 @@ void RecordsConfigIterate(RecordElementCallback, void *);
 void LibRecordsConfigInit();                 // initializes RecordsConfigIndex
 void RecordsConfigOverrideFromEnvironment(); // Override records from the environment
 void test_librecords();
-
-#endif

--- a/mgmt/Rollback.h
+++ b/mgmt/Rollback.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _ROLLBACK_H_
-#define _ROLLBACK_H_
+#pragma once
 
 /****************************************************************************
  *
@@ -260,4 +259,3 @@ private:
 // qSort comptable function to sort versionInfo*
 //   based on version number
 int versionCmp(const void *i1, const void *i2);
-#endif

--- a/mgmt/api/CoreAPI.h
+++ b/mgmt/api/CoreAPI.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _CORE_API_H
-#define _CORE_API_H
+#pragma once
 
 #include <stdarg.h> // for va_list
 
@@ -92,5 +91,3 @@ TSMgmtError SnapshotRemove(const char *snapshot_name);
 TSMgmtError SnapshotGetMlt(LLQ *snapshots);
 
 TSMgmtError StatsReset(bool cluster, const char *name = NULL);
-
-#endif

--- a/mgmt/api/CoreAPIShared.h
+++ b/mgmt/api/CoreAPIShared.h
@@ -30,8 +30,7 @@
  *
  ***************************************************************************/
 
-#ifndef _CORE_API_SHARED_H_
-#define _CORE_API_SHARED_H_
+#pragma once
 
 #include "mgmtapi.h"
 
@@ -83,5 +82,3 @@ int connectDirect(const char *host, int port, uint64_t timeout);
 // used for Events
 int get_event_id(const char *event_name);
 char *get_event_name(int id);
-
-#endif

--- a/mgmt/api/EventCallback.h
+++ b/mgmt/api/EventCallback.h
@@ -35,8 +35,7 @@
  * specific events. Used by both local api and remote api.
  */
 
-#ifndef _EVENT_CALLBACK_H_
-#define _EVENT_CALLBACK_H_
+#pragma once
 
 #include "ts/ink_llqueue.h"
 
@@ -77,5 +76,3 @@ TSMgmtError cb_table_unregister(CallbackTable *cb_table, const char *event_name,
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
-
-#endif

--- a/mgmt/api/EventControlMain.h
+++ b/mgmt/api/EventControlMain.h
@@ -29,8 +29,7 @@
  *
  ***************************************************************************/
 
-#ifndef EVENT_CONTROL_MAIN_H
-#define EVENT_CONTROL_MAIN_H
+#pragma once
 
 #include "mgmtapi.h"       //add the include path b/c included in web dir
 #include "CoreAPIShared.h" // for NUM_EVENTS
@@ -52,5 +51,3 @@ void delete_event_queue(LLQ *q);
 
 void apiAlarmCallback(alarm_t newAlarm, char *ip, char *desc);
 void *event_callback_main(void *arg);
-
-#endif

--- a/mgmt/api/GenericParser.h
+++ b/mgmt/api/GenericParser.h
@@ -26,8 +26,7 @@
 
 
  ***************************************************************************/
-#ifndef _GENERIC_PARSER_H_
-#define _GENERIC_PARSER_H_
+#pragma once
 
 #include <string.h>
 #include "ts/ink_assert.h"
@@ -322,5 +321,3 @@ private:
  *****************************************************************************************/
 // char *strtrim(char *);
 const char *strtrim(const char *, char chr = ' ');
-
-#endif /* _GENERIC_PARSER_H_ */

--- a/mgmt/api/NetworkMessage.h
+++ b/mgmt/api/NetworkMessage.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _NETWORK_MESSAGE_H_
-#define _NETWORK_MESSAGE_H_
+#pragma once
 
 #include "MgmtMarshall.h"
 
@@ -93,5 +92,3 @@ TSMgmtError recv_mgmt_message(int fd, MgmtMarshallData &msg);
 
 // Extract the first MGMT_MARSHALL_INT from the buffered message. This is the OpType.
 OpType extract_mgmt_request_optype(void *msg, size_t msglen);
-
-#endif /* _NETWORK_MESSAGE_H_ */

--- a/mgmt/api/NetworkUtilsLocal.h
+++ b/mgmt/api/NetworkUtilsLocal.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _NETWORK_UTILS_LOCAL_H_
-#define _NETWORK_UTILS_LOCAL_H_
+#pragma once
 
 #include "ts/ink_defs.h"
 #include "mgmtapi.h"
@@ -31,5 +30,3 @@
  * Unmarshalling/marshalling
  *****************************************************************************/
 TSMgmtError preprocess_msg(int fd, void **req, size_t *reqlen);
-
-#endif /* _NETWORK_UTILS_LOCAL_H_ */

--- a/mgmt/api/NetworkUtilsRemote.h
+++ b/mgmt/api/NetworkUtilsRemote.h
@@ -32,8 +32,7 @@
  *
  ***************************************************************************/
 
-#ifndef _NETWORK_UTILS_REMOTE_H_
-#define _NETWORK_UTILS_REMOTE_H_
+#pragma once
 
 #include "mgmtapi.h"
 #include "NetworkMessage.h"
@@ -87,5 +86,3 @@ TSMgmtError send_unregister_all_callbacks(int fd, CallbackTable *cb_table);
  * Un-marshalling (parse responses)
  *****************************************************************************/
 TSMgmtError parse_generic_response(OpType optype, int fd);
-
-#endif /* _NETWORK_UTILS_REMOTE_H_ */

--- a/mgmt/api/include/mgmtapi.h
+++ b/mgmt/api/include/mgmtapi.h
@@ -25,8 +25,7 @@
   limitations under the License.
  */
 
-#ifndef __TS_MGMT_API_H__
-#define __TS_MGMT_API_H__
+#pragma once
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -1261,5 +1260,3 @@ tsapi TSMgmtError TSInvalidateFromCacheUrlRegex(TSString url_regex, TSString *li
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
-
-#endif /* __TS_MGMT_API_H__ */

--- a/mgmt/utils/ExpandingArray.h
+++ b/mgmt/utils/ExpandingArray.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _EXPANDING_ARRAY_H_
-#define _EXPANDING_ARRAY_H_
+#pragma once
 
 /****************************************************************************
  *
@@ -61,5 +60,3 @@ private:
   int numValidValues;
   bool freeContentsOnDestruct;
 };
-
-#endif

--- a/mgmt/utils/MgmtHashTable.h
+++ b/mgmt/utils/MgmtHashTable.h
@@ -30,8 +30,7 @@
  *
  */
 
-#ifndef _MGMT_HASH_TABLE_H
-#define _MGMT_HASH_TABLE_H
+#pragma once
 
 #include "ts/ink_memory.h"
 #include "ts/ink_hash_table.h"
@@ -188,5 +187,3 @@ private:
   ink_mutex mutex;
 
 }; /* End class MgmtHashTable */
-
-#endif /* _MGMT_HASH_TABLE_H */

--- a/mgmt/utils/MgmtMarshall.h
+++ b/mgmt/utils/MgmtMarshall.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _MGMT_MARSHALL_H
-#define _MGMT_MARSHALL_H
+#pragma once
 
 #include <stdarg.h>
 
@@ -76,5 +75,3 @@ ssize_t mgmt_message_parse_v(const void *ptr, size_t len, const MgmtMarshallType
 
 ssize_t mgmt_message_marshall(void *ptr, size_t len, const MgmtMarshallType *fields, unsigned count, ...);
 ssize_t mgmt_message_marshall_v(void *ptr, size_t len, const MgmtMarshallType *fields, unsigned count, va_list ap);
-
-#endif /* _MGMT_MARSHALL_H */

--- a/mgmt/utils/MgmtSocket.h
+++ b/mgmt/utils/MgmtSocket.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _MGMT_SOCKET_H_
-#define _MGMT_SOCKET_H_
+#pragma once
 
 #include "ts/ink_platform.h"
 
@@ -93,5 +92,3 @@ bool mgmt_has_peereid(void);
 
 // Get the Unix domain peer credentials.
 int mgmt_get_peereid(int fd, uid_t *euid, gid_t *egid);
-
-#endif // _MGMT_SOCKET_H_

--- a/plugins/background_fetch/configs.h
+++ b/plugins/background_fetch/configs.h
@@ -22,8 +22,7 @@
     limitations under the License.
 */
 
-#ifndef CONFIGS_H_DEBFCE23_D6E9_40C2_AAA5_32B32586A3DA
-#define CONFIGS_H_DEBFCE23_D6E9_40C2_AAA5_32B32586A3DA
+#pragma once
 
 #include <stdlib.h>
 
@@ -84,5 +83,3 @@ private:
   BgFetchRule *_rules;
   volatile int _ref_count;
 };
-
-#endif /* CONFIGS_H_DEBFCE23_D6E9_40C2_AAA5_32B32586A3DA */

--- a/plugins/background_fetch/headers.h
+++ b/plugins/background_fetch/headers.h
@@ -22,11 +22,8 @@
     limitations under the License.
 */
 
-#ifndef HEADERS_H_9E78B01C_90CA_4E2D_9346_B17740751B9F
-#define HEADERS_H_9E78B01C_90CA_4E2D_9346_B17740751B9F
+#pragma once
 
 int remove_header(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len);
 bool set_header(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len, const char *val, int val_len);
 void dump_headers(TSMBuffer bufp, TSMLoc hdr_loc);
-
-#endif /* HEADERS_H_9E78B01C_90CA_4E2D_9346_B17740751B9F */

--- a/plugins/background_fetch/rules.h
+++ b/plugins/background_fetch/rules.h
@@ -22,8 +22,7 @@
     limitations under the License.
 */
 
-#ifndef RULES_H_E39522EE_1258_49B4_8FA4_7DAB7A6FC4DA
-#define RULES_H_E39522EE_1258_49B4_8FA4_7DAB7A6FC4DA
+#pragma once
 
 #include <stdlib.h>
 #include <netinet/in.h>
@@ -66,5 +65,3 @@ private:
   const char *_value;
   BgFetchRule *_next; // For the linked list
 };
-
-#endif /* RULES_H_E39522EE_1258_49B4_8FA4_7DAB7A6FC4DA */

--- a/plugins/experimental/balancer/balancer.h
+++ b/plugins/experimental/balancer/balancer.h
@@ -21,8 +21,7 @@
  *  limitations under the License.
  */
 
-#ifndef BALANCER_H_29177589_32F1_4D93_AE4F_1E140EDCC273
-#define BALANCER_H_29177589_32F1_4D93_AE4F_1E140EDCC273
+#pragma once
 
 #include <ts/ts.h>
 #include <ts/remap.h>
@@ -49,5 +48,3 @@ struct BalancerInstance {
 
 BalancerInstance *MakeHashBalancer(const char *);
 BalancerInstance *MakeRoundRobinBalancer(const char *);
-
-#endif /* BALANCER_H_29177589_32F1_4D93_AE4F_1E140EDCC273 */

--- a/plugins/experimental/cachekey/cachekey.h
+++ b/plugins/experimental/cachekey/cachekey.h
@@ -21,8 +21,7 @@
  * @brief Cache key manipulation (header file).
  */
 
-#ifndef PLUGINS_EXPERIMENTAL_CACHEKEY_CACHEKEY_H_
-#define PLUGINS_EXPERIMENTAL_CACHEKEY_CACHEKEY_H_
+#pragma once
 
 #include "common.h"
 #include "configs.h"
@@ -78,5 +77,3 @@ private:
   String _key;       /**< @brief cache key */
   String _separator; /**< @brief a separator used to separate the cache key elements extracted from the URI */
 };
-
-#endif /* PLUGINS_EXPERIMENTAL_CACHEKEY_CACHEKEY_H_ */

--- a/plugins/experimental/cachekey/common.h
+++ b/plugins/experimental/cachekey/common.h
@@ -21,8 +21,7 @@
  * @brief Common declarations and definitions (header file).
  */
 
-#ifndef PLUGINS_EXPERIMENTAL_CACHEKEY_COMMON_H_
-#define PLUGINS_EXPERIMENTAL_CACHEKEY_COMMON_H_
+#pragma once
 
 #define PLUGIN_NAME "cachekey"
 
@@ -58,5 +57,3 @@ void PrintToStdErr(const char *fmt, ...);
     TSDebug(PLUGIN_NAME, "%s:%d:%s() " fmt, __FILE__, __LINE__, __func__, ##__VA_ARGS__); \
   } while (0)
 #endif /* CACHEKEY_UNIT_TEST */
-
-#endif /* PLUGINS_EXPERIMENTAL_CACHEKEY_COMMON_H_ */

--- a/plugins/experimental/cachekey/configs.h
+++ b/plugins/experimental/cachekey/configs.h
@@ -21,8 +21,7 @@
  * @brief Plugin configuration (header file).
  */
 
-#ifndef PLUGINS_EXPERIMENTAL_CACHEKEY_CONFIGS_H_
-#define PLUGINS_EXPERIMENTAL_CACHEKEY_CONFIGS_H_
+#pragma once
 
 #include "pattern.h"
 #include "common.h"
@@ -198,5 +197,3 @@ private:
   String _separator        = "/";   /**< @brief a separator used to separate the cache key elements extracted from the URI */
   CacheKeyUriType _uriType = REMAP; /**< @brief shows which URI the cache key will be based on */
 };
-
-#endif // PLUGINS_EXPERIMENTAL_CACHEKEY_CONFIGS_H_

--- a/plugins/experimental/cachekey/pattern.h
+++ b/plugins/experimental/cachekey/pattern.h
@@ -21,8 +21,7 @@
  * @brief PRCE related classes (header file).
  */
 
-#ifndef PLUGINS_EXPERIMENTAL_CACHEKEY_PATTERN_H_
-#define PLUGINS_EXPERIMENTAL_CACHEKEY_PATTERN_H_
+#pragma once
 
 #include "ts/ink_defs.h"
 
@@ -138,5 +137,3 @@ private:
   Classifier(const Classifier &);            // disallow
   Classifier &operator=(const Classifier &); // disallow
 };
-
-#endif /* PLUGINS_EXPERIMENTAL_CACHEKEY_PATTERN_H_ */

--- a/plugins/experimental/collapsed_connection/P_collapsed_connection.h
+++ b/plugins/experimental/collapsed_connection/P_collapsed_connection.h
@@ -26,8 +26,7 @@
 #include <list>
 #include <utility>
 
-#ifndef ATS_COLLAPSED_CONNECTION_PLUGIN_H_
-#define ATS_COLLAPSED_CONNECTION_PLUGIN_H_
+#pragma once
 
 #define PLUGIN_NAME "collapsed_connection"
 #define PLUGIN_VENDOR "Apache Software Foundation"
@@ -112,5 +111,3 @@ const unsigned int c_hashSeed = 27240313;
 
 static CcPluginData *getCcPlugin();
 static int collapsedConnectionMainHandler(TSCont contp, TSEvent event, void *edata);
-
-#endif // ATS_COLLAPSED_CONNECTION_PLUGIN_H_

--- a/plugins/experimental/geoip_acl/lulu.h
+++ b/plugins/experimental/geoip_acl/lulu.h
@@ -20,8 +20,7 @@
 //
 // Implement the classes for the various types of hash keys we support.
 //
-#ifndef __LULU_H__
-#define __LULU_H__ 1
+#pragma once
 
 #include <sys/types.h>
 
@@ -30,5 +29,3 @@
 
 // Used for Debug etc.
 static const char *PLUGIN_NAME = "geoip_acl";
-
-#endif // __LULU_H__

--- a/plugins/experimental/mysql_remap/default.h
+++ b/plugins/experimental/mysql_remap/default.h
@@ -16,10 +16,7 @@
   limitations under the License.
 */
 
-#ifndef __DEFAULT_H__
-#define __DEFAULT_H__ 1
+#pragma once
 
 static const char *PLUGIN_NAME = "mysql_remap";
 #define QSIZE 2048
-
-#endif // __DEFAULT_H__

--- a/plugins/experimental/mysql_remap/lib/dictionary.h
+++ b/plugins/experimental/mysql_remap/lib/dictionary.h
@@ -42,8 +42,7 @@
         $Revision: 1.12 $
 */
 
-#ifndef _DICTIONARY_H_
-#define _DICTIONARY_H_
+#pragma once
 
 /*---------------------------------------------------------------------------
                                                                 Includes
@@ -188,5 +187,3 @@ void dictionary_unset(dictionary *d, char *key);
  */
 /*--------------------------------------------------------------------------*/
 void dictionary_dump(dictionary *d, FILE *out);
-
-#endif

--- a/plugins/experimental/mysql_remap/lib/iniparser.h
+++ b/plugins/experimental/mysql_remap/lib/iniparser.h
@@ -36,8 +36,7 @@
         $Revision: 1.24 $
 */
 
-#ifndef _INIPARSER_H_
-#define _INIPARSER_H_
+#pragma once
 
 /*---------------------------------------------------------------------------
                                                                 Includes
@@ -294,5 +293,3 @@ dictionary *iniparser_load(const char *ininame);
  */
 /*--------------------------------------------------------------------------*/
 void iniparser_freedict(dictionary *d);
-
-#endif

--- a/plugins/experimental/ssl_cert_loader/ats-util.h
+++ b/plugins/experimental/ssl_cert_loader/ats-util.h
@@ -22,8 +22,7 @@
 
 */
 
-#if !defined(_ats_util_h)
-#define _ats_util_h
+#pragma once
 
 #if defined(__cplusplus)
 /** Set data to zero.
@@ -61,5 +60,3 @@ ink_zero(T &t ///< Object to zero.
   memset(&t, 0, sizeof(t));
 }
 #endif /* __cplusplus */
-
-#endif // ats-util.h

--- a/plugins/experimental/url_sig/url_sig.h
+++ b/plugins/experimental/url_sig/url_sig.h
@@ -16,8 +16,7 @@
   limitations under the License.
  */
 
-#ifndef URL_SIG_H_
-#define URL_SIG_H_
+#pragma once
 
 /* in the query string that we add to sign the url: */
 #define CIP_QSTRING "C" /* C=24.0.33.12 designates the client IP address */
@@ -50,5 +49,3 @@
 
 #define USIG_HMAC_SHA1 1
 #define USIG_HMAC_MD5 2
-
-#endif /* URL_SIG_H_ */

--- a/plugins/gzip/configuration.h
+++ b/plugins/gzip/configuration.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef GZIP_CONFIGURATION_H_
-#define GZIP_CONFIGURATION_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -171,5 +170,3 @@ private:
 }; // class Configuration
 
 } // namespace
-
-#endif

--- a/plugins/gzip/misc.h
+++ b/plugins/gzip/misc.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _GZIP_MISC_H_
-#define _GZIP_MISC_H_
+#pragma once
 
 #include <zlib.h>
 #include <ts/ts.h>
@@ -98,5 +97,3 @@ const char *init_hidden_header_name();
 int check_ts_version();
 int register_plugin();
 void gzip_log_ratio(int64_t in, int64_t out);
-
-#endif

--- a/plugins/header_rewrite/condition.h
+++ b/plugins/header_rewrite/condition.h
@@ -19,8 +19,7 @@
 //
 // Implement the classes for the various types of hash keys we support.
 //
-#ifndef __CONDITION_H__
-#define __CONDITION_H__ 1
+#pragma once
 
 #include <string>
 
@@ -130,5 +129,3 @@ private:
 
   CondModifiers _mods;
 };
-
-#endif // __CONDITION_H

--- a/plugins/header_rewrite/conditions.h
+++ b/plugins/header_rewrite/conditions.h
@@ -19,8 +19,7 @@
 //
 // Declarations for all conditionals / conditional values we support.
 //
-#ifndef __CONDITIONS_H__
-#define __CONDITIONS_H__ 1
+#pragma once
 
 #include <string>
 #include <cstring>
@@ -479,5 +478,3 @@ private:
   DISALLOW_COPY_AND_ASSIGN(ConditionId);
   IdQualifiers _id_qual;
 };
-
-#endif // __CONDITIONS_H

--- a/plugins/header_rewrite/expander.h
+++ b/plugins/header_rewrite/expander.h
@@ -19,8 +19,7 @@
 //////////////////////////////////////////////////////////////////////////////////////////////
 // Public interface for the Variable Expander
 //
-#ifndef __EXPANDER_H__
-#define __EXPANDER_H__ 1
+#pragma once
 
 #include <string>
 
@@ -36,5 +35,3 @@ public:
 private:
   std::string _source;
 };
-
-#endif // __EXPANDER_H

--- a/plugins/header_rewrite/factory.h
+++ b/plugins/header_rewrite/factory.h
@@ -19,8 +19,7 @@
 //
 // Implement the classes for the various types of hash keys we support.
 //
-#ifndef __FACTORY_H__
-#define __FACTORY_H__ 1
+#pragma once
 
 #include <string>
 
@@ -29,5 +28,3 @@
 
 Operator *operator_factory(const std::string &op);
 Condition *condition_factory(const std::string &cond);
-
-#endif

--- a/plugins/header_rewrite/lulu.h
+++ b/plugins/header_rewrite/lulu.h
@@ -20,8 +20,7 @@
 //
 // Implement the classes for the various types of hash keys we support.
 //
-#ifndef __LULU_H__
-#define __LULU_H__ 1
+#pragma once
 
 #include <string>
 
@@ -74,5 +73,3 @@ extern const char PLUGIN_NAME_DBG[];
 #define DISALLOW_COPY_AND_ASSIGN(TypeName) \
   TypeName(const TypeName &);              \
   void operator=(const TypeName &)
-
-#endif // __LULU_H__

--- a/plugins/header_rewrite/matcher.h
+++ b/plugins/header_rewrite/matcher.h
@@ -19,8 +19,7 @@
 //
 // Implement the classes for the various types of hash keys we support.
 //
-#ifndef __MATCHER_H__
-#define __MATCHER_H__ 1
+#pragma once
 
 #include <string>
 #include <sstream>
@@ -218,5 +217,3 @@ private:
   T _data;
   regexHelper helper;
 };
-
-#endif // __MATCHER_H

--- a/plugins/header_rewrite/operator.h
+++ b/plugins/header_rewrite/operator.h
@@ -19,8 +19,7 @@
 // Public interface for creating all operators. Don't user the operator.h interface
 // directly!
 //
-#ifndef __OPERATOR_H__
-#define __OPERATOR_H__ 1
+#pragma once
 
 #include <string>
 
@@ -99,5 +98,3 @@ protected:
 private:
   DISALLOW_COPY_AND_ASSIGN(OperatorCookies);
 };
-
-#endif // __OPERATOR_H

--- a/plugins/header_rewrite/operators.h
+++ b/plugins/header_rewrite/operators.h
@@ -19,8 +19,7 @@
 //
 // Implement the classes for the various types of hash keys we support.
 //
-#ifndef __OPERATORS_H__
-#define __OPERATORS_H__ 1
+#pragma once
 
 #include <string>
 
@@ -313,5 +312,3 @@ private:
 
   Value _ds_value;
 };
-
-#endif // __OPERATORS_H

--- a/plugins/header_rewrite/parser.h
+++ b/plugins/header_rewrite/parser.h
@@ -19,8 +19,7 @@
 //
 // Interface for the config line parser
 //
-#ifndef __PARSER_H__
-#define __PARSER_H__ 1
+#pragma once
 
 #include <string>
 #include <vector>
@@ -88,5 +87,3 @@ private:
 protected:
   std::vector<std::string> _tokens;
 };
-
-#endif // __PARSER_H

--- a/plugins/header_rewrite/regex_helper.h
+++ b/plugins/header_rewrite/regex_helper.h
@@ -15,8 +15,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-#ifndef REGEX_HELPER_H
-#define REGEX_HELPER_H
+#pragma once
 
 #include "ts/ink_defs.h"
 
@@ -51,5 +50,3 @@ private:
   std::string regexString;
   int regexCcount;
 };
-
-#endif

--- a/plugins/header_rewrite/resources.h
+++ b/plugins/header_rewrite/resources.h
@@ -19,8 +19,7 @@
 //
 // Implement the classes for the various types of hash keys we support.
 //
-#ifndef __RESOURCES_H__
-#define __RESOURCES_H__ 1
+#pragma once
 
 #include <string>
 
@@ -103,5 +102,3 @@ private:
 
   bool _ready;
 };
-
-#endif // __RESOURCES_H

--- a/plugins/header_rewrite/ruleset.h
+++ b/plugins/header_rewrite/ruleset.h
@@ -19,8 +19,7 @@
 //
 // Implement the classes for the various types of hash keys we support.
 //
-#ifndef __RULESET_H__
-#define __RULESET_H__ 1
+#pragma once
 
 #include <string>
 
@@ -118,5 +117,3 @@ private:
   OperModifiers _opermods;
   bool _last;
 };
-
-#endif // __RULESET_H

--- a/plugins/header_rewrite/statement.h
+++ b/plugins/header_rewrite/statement.h
@@ -20,8 +20,7 @@
 // Base class for all Conditions and Operations. We share the "linked" list, and the
 // resource management / requirements.
 //
-#ifndef __STATEMENT_H__
-#define __STATEMENT_H__ 1
+#pragma once
 
 #include <string>
 #include <time.h>
@@ -162,5 +161,3 @@ private:
   std::vector<TSHttpHookID> _allowed_hooks;
   TSHttpHookID _hook;
 };
-
-#endif // __STATEMENT_H

--- a/plugins/header_rewrite/value.h
+++ b/plugins/header_rewrite/value.h
@@ -19,8 +19,7 @@
 // Public interface for creating all values.
 //
 //
-#ifndef __VALUE_H__
-#define __VALUE_H__ 1
+#pragma once
 
 #include <string>
 
@@ -122,5 +121,3 @@ private:
   double _float_value;
   Condition *_cond_val;
 };
-
-#endif // __VALUE_H

--- a/plugins/s3_auth/aws_auth_v4.h
+++ b/plugins/s3_auth/aws_auth_v4.h
@@ -22,8 +22,7 @@
  * @see aws_auth_v4.cc
  */
 
-#ifndef PLUGINS_S3_AUTH_AWS_AUTH_V4_CC_
-#define PLUGINS_S3_AUTH_AWS_AUTH_V4_CC_
+#pragma once
 
 #include <algorithm> /* transform() */
 #include <cstddef>   /* soze_t */
@@ -109,4 +108,3 @@ private:
   const StringSet &_excludedHeaders;
   const StringMap &_regionMap;
 };
-#endif /* PLUGINS_S3_AUTH_AWS_AUTH_V4_CC_ */

--- a/plugins/s3_auth/aws_auth_v4_wrap.h
+++ b/plugins/s3_auth/aws_auth_v4_wrap.h
@@ -22,8 +22,7 @@
  * @see aws_auth_v4.h
  */
 
-#ifndef PLUGINS_S3_AUTH_AWS_AUTH_V4_WRAP_H_
-#define PLUGINS_S3_AUTH_AWS_AUTH_V4_WRAP_H_
+#pragma once
 
 /* Define a header iterator to be used in the plugin using ATS API */
 class HeaderIterator
@@ -125,5 +124,3 @@ public:
   TSMLoc _hdrs;
   TSMLoc _url;
 };
-
-#endif /* PLUGINS_S3_AUTH_AWS_AUTH_V4_WRAP_H_ */

--- a/plugins/s3_auth/unit-tests/test_aws_auth_v4.h
+++ b/plugins/s3_auth/unit-tests/test_aws_auth_v4.h
@@ -22,8 +22,7 @@
  * @see test_aws_auth_v4.cc
  */
 
-#ifndef PLUGINS_S3_AUTH_UNIT_TESTS_TEST_AWS_AUTH_V4_H_
-#define PLUGINS_S3_AUTH_UNIT_TESTS_TEST_AWS_AUTH_V4_H_
+#pragma once
 
 #include <string> /* std::string */
 
@@ -142,5 +141,3 @@ size_t getIso8601Time(time_t *now, char *dateTime, size_t dateTimeLen);
 extern const StringMap defaultDefaultRegionMap;
 extern const StringSet defaultExcludeHeaders;
 extern const StringSet defaultIncludeHeaders;
-
-#endif /* PLUGINS_S3_AUTH_UNIT_TESTS_TEST_AWS_AUTH_V4_H_ */

--- a/proxy/CacheControl.h
+++ b/proxy/CacheControl.h
@@ -28,8 +28,7 @@
  *
  ****************************************************************************/
 
-#ifndef _CACHE_CONTROL_H_
-#define _CACHE_CONTROL_H_
+#pragma once
 
 #include "Main.h"
 #include "P_EventSystem.h"
@@ -150,5 +149,3 @@ inkcoreapi bool ip_rule_in_CacheControlTable();
 
 void initCacheControl();
 void reloadCacheControl();
-
-#endif /* _CACHE_CONTROL_H_ */

--- a/proxy/CompletionUtil.h
+++ b/proxy/CompletionUtil.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _COMPLETION_UTIL_H_
-#define _COMPLETION_UTIL_H_
+#pragma once
 // interface
 class completionUtil
 {
@@ -43,5 +42,3 @@ public:
 };
 
 #include "UnixCompletionUtil.h"
-
-#endif

--- a/proxy/ControlBase.h
+++ b/proxy/ControlBase.h
@@ -29,8 +29,7 @@
  *
  ****************************************************************************/
 
-#ifndef _CONTROL_BASE_H_
-#define _CONTROL_BASE_H_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "ts/Vec.h"
@@ -107,5 +106,3 @@ ControlBase::CheckForMatch(HttpRequestData *request_data, int last_number)
 {
   return (last_number < 0 || last_number > this->line_num) && this->CheckModifiers(request_data);
 }
-
-#endif

--- a/proxy/ControlMatcher.h
+++ b/proxy/ControlMatcher.h
@@ -84,8 +84,7 @@
 //     ControlMatcher.cc
 //
 
-#ifndef _CONTROL_MATCHER_H_
-#define _CONTROL_MATCHER_H_
+#pragma once
 
 #include "ts/DynArray.h"
 #include "ts/ink_hash_table.h"
@@ -364,5 +363,3 @@ public:
   int m_numEntries;
   const char *matcher_name; // Used for Debug/Warning/Error messages
 };
-
-#endif /* _CONTROL_MATCHER_H_ */

--- a/proxy/CoreUtils.h
+++ b/proxy/CoreUtils.h
@@ -28,8 +28,7 @@
    Description:  Automated processing of core files on Sparc & Linux
  ****************************************************************************/
 
-#ifndef _CORE_UTILS_H_
-#define _CORE_UTILS_H_
+#pragma once
 
 #if defined(linux)
 #include <stdio.h>
@@ -198,5 +197,3 @@ public:
 
 // parses the core file
 void process_core(char *fname);
-
-#endif /* _core_utils_h_ */

--- a/proxy/EventName.h
+++ b/proxy/EventName.h
@@ -28,11 +28,8 @@
    Description:  Stringifying Events
  ****************************************************************************/
 
-#ifndef _EVENT_NAME_H_
-#define _EVENT_NAME_H_
+#pragma once
 
 #include <unistd.h>
 
 const char *event_int_to_string(int event, int blen = 0, char *buffer = NULL);
-
-#endif /* _event_name_h_ */

--- a/proxy/FetchSM.h
+++ b/proxy/FetchSM.h
@@ -27,8 +27,7 @@
  *
  ****************************************************************************/
 
-#ifndef _FETCH_SM_H
-#define _FETCH_SM_H
+#pragma once
 
 #include "P_Net.h"
 #include "ts.h"
@@ -187,5 +186,3 @@ private:
   int64_t resp_content_length;
   int64_t resp_received_body_len;
 };
-
-#endif

--- a/proxy/ICPevents.h
+++ b/proxy/ICPevents.h
@@ -21,9 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _ICPEvents_h_
-#define _ICPEvents_h_
-
+#pragma once
 #include "I_EventSystem.h"
 
 /** Events specific to ICP. */
@@ -38,5 +36,3 @@ typedef enum {
   ICP_STALE_OBJECT = ICP_EVENT_EVENTS_START + 10,
   ICP_FRESH_OBJECT = ICP_EVENT_EVENTS_START + 11
 } ICPreturn_t;
-
-#endif // _ICPevents_h_

--- a/proxy/IPAllow.h
+++ b/proxy/IPAllow.h
@@ -28,8 +28,7 @@
  *
  ****************************************************************************/
 
-#ifndef _IP_ALLOW_H_
-#define _IP_ALLOW_H_
+#pragma once
 
 #include "Main.h"
 #include "hdrs/HTTP.h"
@@ -186,5 +185,3 @@ IpAllow::match(sockaddr const *ip, match_key_t key) const
   map.contains(ip, &raw);
   return static_cast<AclRecord *>(raw);
 }
-
-#endif

--- a/proxy/InkAPIInternal.h
+++ b/proxy/InkAPIInternal.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __INK_API_INTERNAL_H__
-#define __INK_API_INTERNAL_H__
+#pragma once
 
 #include "P_EventSystem.h"
 #include "URL.h"
@@ -348,5 +347,3 @@ extern HttpAPIHooks *http_global_hooks;
 extern LifecycleAPIHooks *lifecycle_hooks;
 extern SslAPIHooks *ssl_hooks;
 extern ConfigUpdateCbTable *global_config_cbs;
-
-#endif /* __INK_API_INTERNAL_H__ */

--- a/proxy/Main.h
+++ b/proxy/Main.h
@@ -20,8 +20,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-#ifndef _Main_h_
-#define _Main_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "ts/ink_apidefs.h"
@@ -82,5 +81,3 @@ extern AppVersionInfo appVersionInfo;
 
 void crash_logger_init();
 void crash_logger_invoke(int signo, siginfo_t *info, void *ctx);
-
-#endif /* _Main_h_ */

--- a/proxy/Milestones.h
+++ b/proxy/Milestones.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#if !defined(_Milestones_h_)
-#define _Milestones_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "ts/ink_hrtime.h"
@@ -76,5 +75,3 @@ public:
 private:
   ink_hrtime milestones[TS_MILESTONE_LAST_ENTRY];
 };
-
-#endif /* _Milestones_h_ */

--- a/proxy/ParentConsistentHash.h
+++ b/proxy/ParentConsistentHash.h
@@ -27,8 +27,7 @@
  *
  ****************************************************************************/
 
-#ifndef _PARENT_CONSISTENT_HASH_H
-#define _PARENT_CONSISTENT_HASH_H
+#pragma once
 
 #include "ts/HashSip.h"
 #include "ParentSelection.h"
@@ -58,5 +57,3 @@ public:
   uint32_t numParents(ParentResult *result) const;
   void markParentUp(ParentResult *result);
 };
-
-#endif

--- a/proxy/ParentRoundRobin.h
+++ b/proxy/ParentRoundRobin.h
@@ -27,8 +27,7 @@
  *
  *****************************************************************************/
 
-#ifndef _PARENT_ROUND_ROBIN_H
-#define _PARENT_ROUND_ROBIN_H
+#pragma once
 
 #include "ParentSelection.h"
 
@@ -45,5 +44,3 @@ public:
   uint32_t numParents(ParentResult *result) const;
   void markParentUp(ParentResult *result);
 };
-
-#endif

--- a/proxy/ParentSelection.h
+++ b/proxy/ParentSelection.h
@@ -28,8 +28,7 @@
  *
  ****************************************************************************/
 
-#ifndef _PARENT_SELECTION_H_
-#define _PARENT_SELECTION_H_
+#pragma once
 
 #include "Main.h"
 #include "ProxyConfig.h"
@@ -439,5 +438,3 @@ struct SocksServerConfig {
 
   static int m_id;
 };
-
-#endif

--- a/proxy/Plugin.h
+++ b/proxy/Plugin.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __PLUGIN_H__
-#define __PLUGIN_H__
+#pragma once
 
 #include "ts/List.h"
 
@@ -86,5 +85,3 @@ public:
     return 0;
   }
 };
-
-#endif /* __PLUGIN_H__ */

--- a/proxy/PluginVC.h
+++ b/proxy/PluginVC.h
@@ -33,8 +33,7 @@
 
  ****************************************************************************/
 
-#ifndef _PLUGIN_VC_H_
-#define _PLUGIN_VC_H_
+#pragma once
 
 #include "Plugin.h"
 #include "P_Net.h"
@@ -281,5 +280,3 @@ inline PluginVCCore::PluginVCCore()
 
   id = ink_atomic_increment(&nextid, 1);
 }
-
-#endif

--- a/proxy/Prefetch.h
+++ b/proxy/Prefetch.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _PREFETCH_H_
-#define _PREFETCH_H_
+#pragma once
 
 #include <ts/IpMap.h>
 #include "TransformInternal.h"
@@ -429,5 +428,3 @@ public:
 #define PREFETCH_CONFIG_UPDATE_TIMEOUT (HRTIME_SECOND * 60)
 
 #endif // PREFETCH
-
-#endif // _PREFETCH_H_

--- a/proxy/ProtocolProbeSessionAccept.h
+++ b/proxy/ProtocolProbeSessionAccept.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef ProtocolProbeSessionAccept_H_
-#define ProtocolProbeSessionAccept_H_
+#pragma once
 
 #include "I_SessionAccept.h"
 
@@ -65,5 +64,3 @@ private:
 
   friend struct ProtocolProbeTrampoline;
 };
-
-#endif /* ProtocolProbeSessionAccept_H_ */

--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __PROXY_CLIENT_SESSION_H__
-#define __PROXY_CLIENT_SESSION_H__
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "ts/ink_resolver.h"
@@ -243,5 +242,3 @@ private:
 
   friend void TSHttpSsnDebugSet(TSHttpSsn, int);
 };
-
-#endif // __PROXY_CLIENT_SESSION_H__

--- a/proxy/ProxyClientTransaction.h
+++ b/proxy/ProxyClientTransaction.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __PROXY_CLIENT_TRANSACTION_H__
-#define __PROXY_CLIENT_TRANSACTION_H__
+#pragma once
 
 #include "ProxyClientSession.h"
 #include <ts/MemView.h>
@@ -269,5 +268,3 @@ protected:
 
 private:
 };
-
-#endif /* __PROXY_CLIENT_TRANSACTION_H__ */

--- a/proxy/RegressionSM.h
+++ b/proxy/RegressionSM.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _RegressionSM_h
-#define _RegressionSM_h
+#pragma once
 
 #include "I_EventSystem.h"
 #include "ts/Regression.h"
@@ -91,5 +90,3 @@ RegressionSM *r_sequential(RegressionTest *t, int n, RegressionSM *sm);
 RegressionSM *r_sequential(RegressionTest *t, RegressionSM *sm, ...); // terminate list in NULL
 RegressionSM *r_parallel(RegressionTest *t, int n, RegressionSM *sm);
 RegressionSM *r_parallel(RegressionTest *t, RegressionSM *sm, ...); // terminate list in NULL
-
-#endif

--- a/proxy/ReverseProxy.h
+++ b/proxy/ReverseProxy.h
@@ -30,8 +30,7 @@
  *
  ****************************************************************************/
 
-#ifndef _REVERSE_PROXY_H_
-#define _REVERSE_PROXY_H_
+#pragma once
 
 #include "P_RecProcess.h"
 
@@ -68,5 +67,3 @@ bool response_url_remap(HTTPHdr *response_header);
 bool reloadUrlRewrite();
 
 int url_rewrite_CB(const char *name, RecDataT data_type, RecData data, void *cookie);
-
-#endif

--- a/proxy/Show.h
+++ b/proxy/Show.h
@@ -28,8 +28,7 @@
 
  ****************************************************************************/
 
-#ifndef _Show_h_
-#define _Show_h_
+#pragma once
 
 #include "StatPages.h"
 
@@ -162,5 +161,3 @@ public:
     ats_free(start);
   }
 };
-
-#endif

--- a/proxy/StatPages.h
+++ b/proxy/StatPages.h
@@ -28,8 +28,7 @@
 
  ****************************************************************************/
 
-#ifndef _StatPages_h_
-#define _StatPages_h_
+#pragma once
 #include "P_EventSystem.h"
 
 #include "HTTP.h"
@@ -118,5 +117,3 @@ protected:
   int response_size;
   int response_length;
 };
-
-#endif

--- a/proxy/TestPreProc.h
+++ b/proxy/TestPreProc.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#if !defined(_TestPreProc_h_)
-#define _TestPreProc_h_
+#pragma once
 
 class IOBuffer;
 
@@ -47,5 +46,3 @@ private:
   unsigned m_len;
   IOBuffer *m_cb;
 };
-
-#endif

--- a/proxy/TimeTrace.h
+++ b/proxy/TimeTrace.h
@@ -28,8 +28,7 @@
 
  ****************************************************************************/
 
-#ifndef _TimeTrace_h_
-#define _TimeTrace_h_
+#pragma once
 
 // #define ENABLE_TIME_TRACE
 
@@ -79,7 +78,3 @@ extern int cluster_send_events;
 #else // !ENABLE_TIME_TRACE
 #define LOG_EVENT_TIME(_start_time, _time_dist, _time_cnt)
 #endif // !ENABLE_TIME_TRACE
-
-#endif // _TimeTrace_h_
-
-// End of TimeTrace.h

--- a/proxy/Transform.h
+++ b/proxy/Transform.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __TRANSFORM_H__
-#define __TRANSFORM_H__
+#pragma once
 
 #include "P_EventSystem.h"
 #include "HTTP.h"
@@ -106,5 +105,3 @@ num_chars_for_int(int64_t i)
 }
 
 extern TransformProcessor transformProcessor;
-
-#endif /* __TRANSFORM_H__ */

--- a/proxy/TransformInternal.h
+++ b/proxy/TransformInternal.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __TRANSFORM_INTERNAL_H__
-#define __TRANSFORM_INTERNAL_H__
+#pragma once
 
 #include "HttpSM.h"
 #include "MIME.h"
@@ -153,5 +152,3 @@ public:
 
 extern PrefetchProcessor prefetchProcessor;
 #endif // PREFETCH
-
-#endif /* __TRANSFORM_INTERNAL_H__ */

--- a/proxy/UDPAPIClientTest.h
+++ b/proxy/UDPAPIClientTest.h
@@ -21,6 +21,7 @@
   limitations under the License.
  */
 
+#pragma once
 #include "api/include/experimental.h"
 
 void UDPClientTestInit();

--- a/proxy/UDPAPITest.h
+++ b/proxy/UDPAPITest.h
@@ -21,6 +21,7 @@
   limitations under the License.
  */
 
+#pragma once
 #include "api/include/experimental.h"
 
 void UDPTestInit();

--- a/proxy/UnixCompletionUtil.h
+++ b/proxy/UnixCompletionUtil.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _UNIX_COMPLETION_UTIL_H_
-#define _UNIX_COMPLETION_UTIL_H_
+#pragma once
 
 // platform specific wrappers for dealing with I/O completion events
 // passed into and back from the I/O core.
@@ -101,4 +100,3 @@ completionUtil::getError(Event *e)
   UDPIOEvent *u = (UDPIOEvent *)e;
   return u->getError();
 }
-#endif

--- a/proxy/api/ts/InkAPIPrivateIOCore.h
+++ b/proxy/api/ts/InkAPIPrivateIOCore.h
@@ -21,9 +21,9 @@
   limitations under the License.
  */
 
-#ifndef __INK_API_PRIVATE_IOCORE_H__
-#define __INK_API_PRIVATE_IOCORE_H__
+#pragma once
 #include "ts.h"
+
 #if !defined(__GNUC__)
 #include "I_EventSystem.h"
 #include "I_Cache.h"
@@ -202,5 +202,3 @@ tsapi INKUDPPacket INKUDPPacketGet(INKUDPacketQueue queuep);
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
-
-#endif /* __INK_API_PRIVATE_IOCORE_H__ */

--- a/proxy/api/ts/TsException.h
+++ b/proxy/api/ts/TsException.h
@@ -21,8 +21,7 @@
     limitations under the License.
 */
 
-#if !defined(TS_EXCEPTION_HEADER)
-#define TS_EXCEPTION_HEADER
+#pragma once
 
 /** @file
     Apache Traffic Server Exceptions.
@@ -63,5 +62,3 @@ inline Exception::Exception(const char *text) : m_text(text)
 {
 }
 }
-
-#endif // TS_EXCEPTION_HEADER

--- a/proxy/api/ts/experimental.h
+++ b/proxy/api/ts/experimental.h
@@ -29,8 +29,7 @@
  *   Traffic Server, DO NOT USE anything in this file.
  */
 
-#ifndef __TS_API_EXPERIMENTAL_H__
-#define __TS_API_EXPERIMENTAL_H__
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -574,4 +573,3 @@ tsapi TSMLoc TSFetchRespHdrMLocGet(TSFetchSM fetch_sm);
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
-#endif /* __TS_API_EXPERIMENTAL_H__ */

--- a/proxy/api/ts/remap.h
+++ b/proxy/api/ts/remap.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __TS_REMAP_H__
-#define __TS_REMAP_H__
+#pragma once
 
 #ifndef tsapi
 #define tsapi
@@ -122,4 +121,3 @@ tsapi void TSRemapOSResponse(void *ih, TSHttpTxn rh, int os_response_type);
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
-#endif /* #ifndef __TS_REMAP_H__ */

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -27,8 +27,7 @@
 
  */
 
-#ifndef __TS_API_H__
-#define __TS_API_H__
+#pragma once
 
 #include <ts/apidefs.h>
 
@@ -2438,5 +2437,3 @@ tsapi const char *TSRegisterProtocolTag(char const *tag);
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
-
-#endif /* __TS_API_H__ */

--- a/proxy/congest/MT_hashtable.h
+++ b/proxy/congest/MT_hashtable.h
@@ -29,8 +29,7 @@
 
 
  ****************************************************************************/
-#ifndef MT_HASHTABLE_H_
-#define MT_HASHTABLE_H_
+#pragma once
 //#include "Lock.h"
 
 #define MT_HASHTABLE_PARTITION_BITS 6
@@ -429,5 +428,3 @@ private:
   // int last_GC_time[MT_HASHTABLE_PARTITIONS];
   // int32_t cur_items;
 };
-
-#endif /* MT_HASHTABLE_H_ */

--- a/proxy/hdrs/HTTP.h
+++ b/proxy/hdrs/HTTP.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __HTTP_H__
-#define __HTTP_H__
+#pragma once
 
 #include <assert.h>
 #include "ts/Arena.h"
@@ -1607,5 +1606,3 @@ HTTPInfo::get_frag_offset_count()
 {
   return m_alt ? m_alt->m_frag_offset_count : 0;
 }
-
-#endif /* __HTTP_H__ */

--- a/proxy/hdrs/HdrHeap.h
+++ b/proxy/hdrs/HdrHeap.h
@@ -30,8 +30,7 @@
 
  ****************************************************************************/
 
-#ifndef _HDR_HEAP_H_
-#define _HDR_HEAP_H_
+#pragma once
 
 #include "ts/Ptr.h"
 #include "ts/ink_defs.h"
@@ -481,4 +480,3 @@ HdrHeapSDKHandle::set(const HdrHeapSDKHandle *from)
 inkcoreapi HdrHeap *new_HdrHeap(int size = HDR_HEAP_DEFAULT_SIZE);
 
 void hdr_heap_test();
-#endif

--- a/proxy/hdrs/HdrTest.h
+++ b/proxy/hdrs/HdrTest.h
@@ -32,8 +32,7 @@
 
  ****************************************************************************/
 
-#ifndef _HdrTest_H_
-#define _HdrTest_H_
+#pragma once
 
 #include "ts/Regression.h"
 
@@ -77,5 +76,3 @@ private:
   void bri_box(const char *s);
   int failures_to_status(const char *testname, int nfail);
 };
-
-#endif

--- a/proxy/hdrs/HdrToken.h
+++ b/proxy/hdrs/HdrToken.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __HDRTOKEN_H__
-#define __HDRTOKEN_H__
+#pragma once
 
 #include <assert.h>
 #include <sys/types.h>
@@ -384,5 +383,3 @@ hdrtoken_wks_to_flags(const char *wks)
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
-
-#endif /* __HDRTOKEN_H__ */

--- a/proxy/hdrs/HdrUtils.h
+++ b/proxy/hdrs/HdrUtils.h
@@ -31,8 +31,7 @@
 
  ****************************************************************************/
 
-#ifndef _HDR_UTILS_H_
-#define _HDR_UTILS_H_
+#pragma once
 
 #include "ts/ParseRules.h"
 #include "MIME.h"
@@ -182,5 +181,3 @@ HdrCsvIter::get_next_int(int *valid)
     return 0;
   }
 }
-
-#endif

--- a/proxy/hdrs/HttpCompat.h
+++ b/proxy/hdrs/HttpCompat.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __HTTP_COMPAT_H__
-#define __HTTP_COMPAT_H__
+#pragma once
 
 #include "ts/ink_string++.h"
 #include "MIME.h"
@@ -91,5 +90,3 @@ public:
     parse_tok_list(list, 1, comma_list_str, comma_list_len, ';');
   }
 };
-
-#endif /* __HTTP_COMPAT_H__ */

--- a/proxy/hdrs/MIME.h
+++ b/proxy/hdrs/MIME.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __MIME_H__
-#define __MIME_H__
+#pragma once
 
 #include <sys/time.h>
 
@@ -1737,5 +1736,3 @@ MIMEHdr::set_server(const char *server_id_tag, int server_id_tag_size)
 {
   value_set(MIME_FIELD_SERVER, MIME_LEN_SERVER, server_id_tag, server_id_tag_size);
 }
-
-#endif /* __MIME_H__ */

--- a/proxy/hdrs/URL.h
+++ b/proxy/hdrs/URL.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __URL_H__
-#define __URL_H__
+#pragma once
 
 #include "ts/Arena.h"
 #include "HdrToken.h"
@@ -763,5 +762,3 @@ URL::unescapify(Arena *arena, const char *str, int length)
 {
   return url_unescapify(arena, str, length);
 }
-
-#endif /* __URL_H__ */

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -29,8 +29,7 @@
 
  ****************************************************************************/
 
-#ifndef _HTTP1_CLIENT_SESSION_H_
-#define _HTTP1_CLIENT_SESSION_H_
+#pragma once
 
 //#include "libts.h"
 #include "P_Net.h"
@@ -235,5 +234,3 @@ public:
 };
 
 extern ClassAllocator<Http1ClientSession> http1ClientSessionAllocator;
-
-#endif

--- a/proxy/http/Http1ClientTransaction.h
+++ b/proxy/http/Http1ClientTransaction.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __HTTP_CLIENT_TRANSACTION_H_
-#define __HTTP_CLIENT_TRANSACTION_H_
+#pragma once
 
 #include "../ProxyClientTransaction.h"
 
@@ -185,5 +184,3 @@ protected:
   IpAddr outbound_ip6;
   bool outbound_transparent;
 };
-
-#endif

--- a/proxy/http/HttpBodyFactory.h
+++ b/proxy/http/HttpBodyFactory.h
@@ -52,8 +52,7 @@
 
  ****************************************************************************/
 
-#ifndef _HttpBodyFactory_h_
-#define _HttpBodyFactory_h_
+#pragma once
 
 #include <strings.h>
 #include <sys/types.h>
@@ -234,5 +233,3 @@ private:
   bool callbacks_established;  // all config variables present
   RawHashTable *table_of_sets; // sets of template hash tables
 };
-
-#endif

--- a/proxy/http/HttpCacheSM.h
+++ b/proxy/http/HttpCacheSM.h
@@ -30,8 +30,7 @@
 
  ****************************************************************************/
 
-#ifndef _HTTP_CACHE_SM_H_
-#define _HTTP_CACHE_SM_H_
+#pragma once
 
 #include "P_Cache.h"
 #include "ProxyConfig.h"
@@ -213,5 +212,3 @@ private:
   int lookup_max_recursive;
   int current_lookup_level;
 };
-
-#endif

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -31,8 +31,7 @@
 
 
  ****************************************************************************/
-#ifndef _HttpConfig_h_
-#define _HttpConfig_h_
+#pragma once
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -958,4 +957,3 @@ inline HttpConfigParams::~HttpConfigParams()
     delete connect_ports;
   }
 }
-#endif /* #ifndef _HttpConfig_h_ */

--- a/proxy/http/HttpConnectionCount.h
+++ b/proxy/http/HttpConnectionCount.h
@@ -31,8 +31,7 @@
 #include "ts/ink_config.h"
 #include "HttpProxyAPIEnums.h"
 
-#ifndef _HTTP_CONNECTION_COUNT_H_
-#define _HTTP_CONNECTION_COUNT_H_
+#pragma once
 
 /**
  * Singleton class to keep track of the number of connections per host
@@ -215,5 +214,3 @@ public:
 private:
   static ConnectionCountQueue _connectionCount;
 };
-
-#endif

--- a/proxy/http/HttpDebugNames.h
+++ b/proxy/http/HttpDebugNames.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#if !defined(_HttpDebugNames_h_)
-#define _HttpDebugNames_h_
+#pragma once
 
 #include "HttpTransact.h"
 #include "api/ts/ts.h"
@@ -37,5 +36,3 @@ public:
   static const char *get_api_hook_name(TSHttpHookID t);
   static const char *get_server_state_name(HttpTransact::ServerState_t state);
 };
-
-#endif

--- a/proxy/http/HttpPages.h
+++ b/proxy/http/HttpPages.h
@@ -31,8 +31,7 @@
 
  ****************************************************************************/
 
-#ifndef _HTTP_PAGES_H_
-#define _HTTP_PAGES_H_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "P_EventSystem.h"
@@ -86,5 +85,3 @@ private:
 };
 
 void http_pages_init();
-
-#endif

--- a/proxy/http/HttpProxyAPIEnums.h
+++ b/proxy/http/HttpProxyAPIEnums.h
@@ -27,6 +27,8 @@
 
  */
 
+#pragma once
+
 #ifndef _HTTP_PROXY_API_ENUMS_H_
 #define _HTTP_PROXY_API_ENUMS_H_
 
@@ -43,5 +45,4 @@ typedef enum {
   TS_SERVER_SESSION_SHARING_POOL_GLOBAL,
   TS_SERVER_SESSION_SHARING_POOL_THREAD,
 } TSServerSessionSharingPoolType;
-
-#endif // _HTTP_PROXY_API_ENUMS_H_
+#endif

--- a/proxy/http/HttpProxyServerMain.h
+++ b/proxy/http/HttpProxyServerMain.h
@@ -21,6 +21,8 @@
   limitations under the License.
  */
 
+#pragma once
+
 struct HttpProxyPort;
 
 /** Initialize all HTTP proxy port data structures needed to run.

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -30,8 +30,7 @@
 
  ****************************************************************************/
 
-#ifndef _HTTP_SM_H_
-#define _HTTP_SM_H_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "P_EventSystem.h"
@@ -725,5 +724,3 @@ HttpSM::postbuf_init(IOBufferReader *ua_reader)
 {
   this->_postbuf.init(ua_reader);
 }
-
-#endif

--- a/proxy/http/HttpServerSession.h
+++ b/proxy/http/HttpServerSession.h
@@ -30,8 +30,7 @@
 
  ****************************************************************************/
 
-#ifndef _HTTP_SERVER_SESSION_H_
-#define _HTTP_SERVER_SESSION_H_
+#pragma once
 /* Enable LAZY_BUF_ALLOC to delay allocation of buffers until they
 * are actually required.
 * Enabling LAZY_BUF_ALLOC, stop Http code from allocation space
@@ -212,4 +211,3 @@ HttpServerSession::attach_hostname(const char *hostname)
     ink_code_md5((unsigned char *)hostname, strlen(hostname), (unsigned char *)&hostname_hash);
   }
 }
-#endif

--- a/proxy/http/HttpSessionAccept.h
+++ b/proxy/http/HttpSessionAccept.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#if !defined(_HttpSessionAccept_h_)
-#define _HttpSessionAccept_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "records/I_RecHttp.h"
@@ -212,5 +211,3 @@ private:
   HttpSessionAccept(const HttpSessionAccept &);
   HttpSessionAccept &operator=(const HttpSessionAccept &);
 };
-
-#endif

--- a/proxy/http/HttpSessionManager.h
+++ b/proxy/http/HttpSessionManager.h
@@ -30,8 +30,7 @@
 
  ****************************************************************************/
 
-#ifndef _HTTP_SESSION_MANAGER_H_
-#define _HTTP_SESSION_MANAGER_H_
+#pragma once
 
 #include "P_EventSystem.h"
 #include "HttpServerSession.h"
@@ -166,5 +165,3 @@ private:
 };
 
 extern HttpSessionManager httpSessionManager;
-
-#endif

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#if !defined(_HttpTransact_h_)
-#define _HttpTransact_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "P_HostDB.h"
@@ -1378,5 +1377,3 @@ is_response_body_precluded(HTTPStatus status_code, int method)
 }
 
 inkcoreapi extern ink_time_t ink_cluster_time(void);
-
-#endif

--- a/proxy/http/HttpTransactCache.h
+++ b/proxy/http/HttpTransactCache.h
@@ -28,8 +28,7 @@
 
 
  ****************************************************************************/
-#if !defined(_HttpTransactCache_h_)
-#define _HttpTransactCache_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 
@@ -139,5 +138,3 @@ public:
   static HTTPStatus match_response_to_request_conditionals(HTTPHdr *ua_request, HTTPHdr *c_response,
                                                            ink_time_t response_received_time);
 };
-
-#endif

--- a/proxy/http/HttpTransactHeaders.h
+++ b/proxy/http/HttpTransactHeaders.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#if !defined(_HttpTransactHeaders_h_)
-#define _HttpTransactHeaders_h_
+#pragma once
 
 #define ink_time_t time_t
 
@@ -131,5 +130,3 @@ HttpTransactHeaders::is_request_proxy_authorized(HTTPHdr *incoming_hdr)
   // TODO: What do we need to do here?
   return true;
 }
-
-#endif

--- a/proxy/http/HttpTunnel.h
+++ b/proxy/http/HttpTunnel.h
@@ -30,8 +30,7 @@
 
 ****************************************************************************/
 
-#ifndef _HTTP_TUNNEL_H_
-#define _HTTP_TUNNEL_H_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "P_EventSystem.h"
@@ -582,5 +581,3 @@ HttpTunnelProducer::unthrottle()
 inline HttpTunnel::FlowControl::FlowControl() : high_water(DEFAULT_WATER_MARK), low_water(DEFAULT_WATER_MARK), enabled_p(false)
 {
 }
-
-#endif

--- a/proxy/http/HttpUpdateSM.h
+++ b/proxy/http/HttpUpdateSM.h
@@ -32,8 +32,7 @@
 
  ****************************************************************************/
 
-#ifndef _HTTP_SM_UPDATE_H_
-#define _HTTP_SM_UPDATE_H_
+#pragma once
 
 #include "P_EventSystem.h"
 #include "HttpSM.h"
@@ -76,5 +75,3 @@ HttpUpdateSM::allocate()
 
 // Regression/Testing Routing
 void init_http_update_test();
-
-#endif

--- a/proxy/http/remap/AclFiltering.h
+++ b/proxy/http/remap/AclFiltering.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _ACL_FILTERING_H_
-#define _ACL_FILTERING_H_
+#pragma once
 
 #include "Main.h"
 #include "ts/ink_inet.h"
@@ -106,5 +105,3 @@ public:
   static void requeue_in_active_list(acl_filter_rule **list, acl_filter_rule *rp);
   static void requeue_in_passive_list(acl_filter_rule **list, acl_filter_rule *rp);
 };
-
-#endif

--- a/proxy/http/remap/RemapConfig.h
+++ b/proxy/http/remap/RemapConfig.h
@@ -21,8 +21,7 @@
  *  limitations under the License.
  */
 
-#ifndef REMAPCONFIG_H_E862FB4C_EFFC_4F2A_8BF2_9AB6E1E5E9CF
-#define REMAPCONFIG_H_E862FB4C_EFFC_4F2A_8BF2_9AB6E1E5E9CF
+#pragma once
 
 #include "AclFiltering.h"
 
@@ -75,5 +74,3 @@ unsigned long remap_check_option(const char **argv, int argc, unsigned long find
                                  const char **argptr = NULL);
 
 bool remap_parse_config(const char *path, UrlRewrite *rewrite);
-
-#endif /* REMAPCONFIG_H_E862FB4C_EFFC_4F2A_8BF2_9AB6E1E5E9CF */

--- a/proxy/http/remap/RemapPluginInfo.h
+++ b/proxy/http/remap/RemapPluginInfo.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#if !defined(_REMAPPLUGININFO_h_)
-#define _REMAPPLUGININFO_h_
+#pragma once
 #include "ts/ink_platform.h"
 #include "api/ts/ts.h"
 #include "api/ts/remap.h"
@@ -77,5 +76,3 @@ struct host_hdr_info {
   int host_len;
   int request_port;
 };
-
-#endif

--- a/proxy/http/remap/RemapPlugins.h
+++ b/proxy/http/remap/RemapPlugins.h
@@ -25,8 +25,7 @@
  * Remap plugins class
 **/
 
-#if !defined(_REMAPPLUGINS_h_)
-#define _REMAPPLUGINS_h_
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "I_EventSystem.h"
@@ -83,5 +82,3 @@ private:
   HTTPHdr *_request_header;
   host_hdr_info *_hh_ptr;
 };
-
-#endif

--- a/proxy/http/remap/RemapProcessor.h
+++ b/proxy/http/remap/RemapProcessor.h
@@ -24,8 +24,7 @@
 /**
  * Remap plugin processor
 **/
-#if !defined(_REMAPPROCESSOR_h_)
-#define _REMAPPROCESSOR_h_
+#pragma once
 
 #include "I_EventSystem.h"
 #include "RemapPlugins.h"
@@ -71,5 +70,3 @@ private:
  * the global remapProcessor that everyone uses
 **/
 extern RemapProcessor remapProcessor;
-
-#endif

--- a/proxy/http/remap/UrlMapping.h
+++ b/proxy/http/remap/UrlMapping.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _URL_MAPPING_H_
-#define _URL_MAPPING_H_
+#pragma once
 
 #include <vector>
 
@@ -207,5 +206,3 @@ private:
   UrlMappingContainer(const UrlMappingContainer &orig);
   UrlMappingContainer &operator=(const UrlMappingContainer &rhs);
 };
-
-#endif

--- a/proxy/http/remap/UrlMappingPathIndex.h
+++ b/proxy/http/remap/UrlMappingPathIndex.h
@@ -20,8 +20,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-#ifndef _URL_MAPPING_PATH_INDEX_H
-#define _URL_MAPPING_PATH_INDEX_H
+#pragma once
 
 #include "ts/ink_platform.h"
 #undef std // FIXME: remove dependancy on the STL
@@ -96,5 +95,3 @@ private:
     return 0;
   }
 };
-
-#endif // _URL_MAPPING_PATH_INDEX_H

--- a/proxy/http/remap/UrlRewrite.h
+++ b/proxy/http/remap/UrlRewrite.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef _URL_REWRITE_H_
-#define _URL_REWRITE_H_
+#pragma once
 
 #include "ts/ink_config.h"
 #include "UrlMapping.h"
@@ -192,5 +191,3 @@ private:
 };
 
 void url_rewrite_remap_request(const UrlMappingContainer &mapping_container, URL *request_url, int scheme = -1);
-
-#endif

--- a/proxy/http2/HPACK.h
+++ b/proxy/http2/HPACK.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __HPACK_H__
-#define __HPACK_H__
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "ts/Vec.h"
@@ -179,5 +178,3 @@ int64_t hpack_decode_header_block(HpackHandle &handle, HTTPHdr *hdr, const uint8
 int64_t hpack_encode_header_block(HpackHandle &handle, uint8_t *out_buf, const size_t out_buf_len, HTTPHdr *hdr,
                                   int32_t maximum_table_size = -1);
 int32_t hpack_get_maximum_table_size(HpackHandle &handle);
-
-#endif /* __HPACK_H__ */

--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -21,8 +21,7 @@
  *  limitations under the License.
  */
 
-#ifndef __HTTP2_H__
-#define __HTTP2_H__
+#pragma once
 
 #include "ts/ink_defs.h"
 #include "ts/ink_memory.h"
@@ -381,5 +380,3 @@ public:
 
   static void init();
 };
-
-#endif /* __HTTP2_H__ */

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __HTTP2_CLIENT_SESSION_H__
-#define __HTTP2_CLIENT_SESSION_H__
+#pragma once
 
 #include "HTTP2.h"
 #include "Plugin.h"
@@ -348,5 +347,3 @@ private:
 };
 
 extern ClassAllocator<Http2ClientSession> http2ClientSessionAllocator;
-
-#endif // __HTTP2_CLIENT_SESSION_H__

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __HTTP2_CONNECTION_STATE_H__
-#define __HTTP2_CONNECTION_STATE_H__
+#pragma once
 
 #include "HTTP2.h"
 #include "HPACK.h"
@@ -312,5 +311,3 @@ private:
   int recursion;
   Event *fini_event;
 };
-
-#endif // __HTTP2_CONNECTION_STATE_H__

--- a/proxy/http2/Http2DebugNames.h
+++ b/proxy/http2/Http2DebugNames.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __HTTP2_DEBUG_NAMES_H__
-#define __HTTP2_DEBUG_NAMES_H__
+#pragma once
 
 #include "ts/ink_defs.h"
 
@@ -34,5 +33,3 @@ public:
   static const char *get_settings_param_name(uint16_t id);
   static const char *get_state_name(Http2StreamState id);
 };
-
-#endif // __HTTP2_DEBUG_NAMES_H__

--- a/proxy/http2/Http2DependencyTree.h
+++ b/proxy/http2/Http2DependencyTree.h
@@ -24,8 +24,7 @@
   limitations under the License.
  */
 
-#ifndef __HTTP2_DEP_TREE_H__
-#define __HTTP2_DEP_TREE_H__
+#pragma once
 
 #include "ts/List.h"
 #include "ts/Diags.h"
@@ -436,4 +435,3 @@ Tree<T>::size() const
   return _node_count;
 }
 } // namespce Http2DependencyTree
-#endif // __HTTP2_DEP_TREE_H__

--- a/proxy/http2/Http2SessionAccept.h
+++ b/proxy/http2/Http2SessionAccept.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __HTTP2_SESSION_ACCEPT_H__
-#define __HTTP2_SESSION_ACCEPT_H__
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "I_Net.h"
@@ -52,5 +51,3 @@ private:
 
   HttpSessionAccept::Options options;
 };
-
-#endif // __HTTP2_SESSION_ACCEPT_H__

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __HTTP2_STREAM_H__
-#define __HTTP2_STREAM_H__
+#pragma once
 
 #include "HTTP2.h"
 #include "../ProxyClientTransaction.h"
@@ -328,5 +327,3 @@ extern ClassAllocator<Http2Stream> http2StreamAllocator;
 
 extern bool check_continuation(Continuation *cont);
 extern bool check_stream_thread(Continuation *cont);
-
-#endif

--- a/proxy/http2/HuffmanCodec.h
+++ b/proxy/http2/HuffmanCodec.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef __HPACK_HUFFMAN_H__
-#define __HPACK_HUFFMAN_H__
+#pragma once
 
 #include <stddef.h>
 #include <stdint.h>
@@ -32,5 +31,3 @@ void hpack_huffman_fin();
 int64_t huffman_decode(char *dst_start, const uint8_t *src, uint32_t src_len);
 uint8_t *huffman_encode_append(uint8_t *dst, uint32_t src, int n);
 int64_t huffman_encode(uint8_t *dst_start, const uint8_t *src, uint32_t src_len);
-
-#endif /* __HPACK_Huffman_H__ */

--- a/proxy/logging/Log.h
+++ b/proxy/logging/Log.h
@@ -290,8 +290,7 @@
 
 */
 
-#ifndef LOG_H
-#define LOG_H
+#pragma once
 
 #include <stdarg.h>
 #include "ts/ink_platform.h"
@@ -496,5 +495,3 @@ LogRollingEnabledIsValid(int enabled)
     if (unlikely(flag))            \
       Log::trace_out(__VA_ARGS__); \
   } while (0)
-
-#endif

--- a/proxy/logging/LogAccess.h
+++ b/proxy/logging/LogAccess.h
@@ -26,8 +26,7 @@
 
 
  ***************************************************************************/
-#ifndef LOG_ACCESS_H
-#define LOG_ACCESS_H
+#pragma once
 #include "ts/ink_platform.h"
 #include "ts/ink_inet.h"
 #include "ts/ink_align.h"
@@ -405,5 +404,3 @@ LogAccess::marshal_int(char *dest, int64_t source)
   -------------------------------------------------------------------------*/
 
 char *resolve_logfield_string(LogAccess *context, const char *format_str);
-
-#endif

--- a/proxy/logging/LogAccessHttp.h
+++ b/proxy/logging/LogAccessHttp.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef LOG_ACCESS_HTTP_H
-#define LOG_ACCESS_HTTP_H
+#pragma once
 
 #include "ts/Arena.h"
 #include "HTTP.h"
@@ -213,5 +212,3 @@ private:
   LogAccessHttp(const LogAccessHttp &rhs);
   LogAccessHttp &operator=(LogAccessHttp &rhs);
 };
-
-#endif

--- a/proxy/logging/LogAccessTest.h
+++ b/proxy/logging/LogAccessTest.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef LOG_ACCESS_TEST_H
-#define LOG_ACCESS_TEST_H
+#pragma once
 
 #include "LogAccess.h"
 
@@ -101,5 +100,3 @@ private:
   LogAccessTest(const LogAccessTest &rhs);
   LogAccessTest &operator=(LogAccessTest &rhs);
 };
-
-#endif

--- a/proxy/logging/LogBindings.h
+++ b/proxy/logging/LogBindings.h
@@ -21,13 +21,10 @@
  *  limitations under the License.
  */
 
-#ifndef LOGBINDINGS_H_B54572F3_71A3_4665_A66C_4EEA311CCE15
-#define LOGBINDINGS_H_B54572F3_71A3_4665_A66C_4EEA311CCE15
+#pragma once
 
 #include "bindings/bindings.h"
 
 class LogConfig;
 
 bool MakeLogBindings(BindingInstance &binding, LogConfig *conf);
-
-#endif /* LOGBINDINGS_H_B54572F3_71A3_4665_A66C_4EEA311CCE15 */

--- a/proxy/logging/LogBuffer.h
+++ b/proxy/logging/LogBuffer.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef LOG_BUFFER_H
-#define LOG_BUFFER_H
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "ts/Diags.h"
@@ -324,4 +323,3 @@ inline LogBufferIterator::LogBufferIterator(LogBufferHeader *header, bool in_net
 inline LogBufferIterator::~LogBufferIterator()
 {
 }
-#endif

--- a/proxy/logging/LogBufferSink.h
+++ b/proxy/logging/LogBufferSink.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef LOG_BUFFER_SINK
-#define LOG_BUFFER_SINK
+#pragma once
 
 #include "LogBuffer.h"
 
@@ -47,5 +46,3 @@ public:
   virtual int preproc_and_try_delete(LogBuffer *buffer) = 0;
   virtual ~LogBufferSink(){};
 };
-
-#endif

--- a/proxy/logging/LogCollationAccept.h
+++ b/proxy/logging/LogCollationAccept.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef LOG_COLLATION_ACCEPT_H
-#define LOG_COLLATION_ACCEPT_H
+#pragma once
 
 #include "P_EventSystem.h"
 #include "P_Net.h"
@@ -41,5 +40,3 @@ private:
 };
 
 typedef int (LogCollationAccept::*LogCollationAcceptHandler)(int, void *);
-
-#endif /* LOG_COLLATION_ACCEPT_H */

--- a/proxy/logging/LogCollationBase.h
+++ b/proxy/logging/LogCollationBase.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef LOG_COLLATION_BASE_H
-#define LOG_COLLATION_BASE_H
+#pragma once
 
 //-------------------------------------------------------------------------
 // LogCollationBase
@@ -44,5 +43,3 @@ protected:
     LOG_COLL_EVENT_ERROR
   };
 };
-
-#endif // LOG_COLLATION_BASE_H

--- a/proxy/logging/LogCollationClientSM.h
+++ b/proxy/logging/LogCollationClientSM.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef LOG_COLLATION_CLIENT_SM_H
-#define LOG_COLLATION_CLIENT_SM_H
+#pragma once
 
 //-------------------------------------------------------------------------
 // includes
@@ -114,5 +113,3 @@ private:
 };
 
 typedef int (LogCollationClientSM::*LogCollationClientSMHandler)(int, void *);
-
-#endif // LOG_COLLATION_CLIENT_SM_H

--- a/proxy/logging/LogCollationHostSM.h
+++ b/proxy/logging/LogCollationHostSM.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef LOG_COLLATION_HOST_SM_H
-#define LOG_COLLATION_HOST_SM_H
+#pragma once
 
 //-------------------------------------------------------------------------
 // includes
@@ -108,5 +107,3 @@ private:
 };
 
 typedef int (LogCollationHostSM::*LogCollationHostSMHandler)(int, void *);
-
-#endif // LOG_COLLATION_HOST_SM_H

--- a/proxy/logging/LogConfig.h
+++ b/proxy/logging/LogConfig.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef LOG_CONFIG_H
-#define LOG_CONFIG_H
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "P_RecProcess.h"
@@ -236,5 +235,3 @@ struct LogDeleteCandidate {
   char *name;
   int64_t size;
 };
-
-#endif

--- a/proxy/logging/LogField.h
+++ b/proxy/logging/LogField.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef LOG_FIELD_H
-#define LOG_FIELD_H
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "ts/List.h"
@@ -277,5 +276,3 @@ union LogFieldIpStorage {
   LogFieldIp4 _ip4;
   LogFieldIp6 _ip6;
 };
-
-#endif

--- a/proxy/logging/LogFieldAliasMap.h
+++ b/proxy/logging/LogFieldAliasMap.h
@@ -26,8 +26,7 @@
   easily remembered names can be used to refer to log fields of integer type.
  */
 
-#ifndef LOG_FIELD_ALIAS_MAP_H
-#define LOG_FIELD_ALIAS_MAP_H
+#pragma once
 
 #include <stdarg.h>
 #include <string.h>
@@ -215,4 +214,3 @@ public:
 };
 
 // LOG_FIELD_ALIAS_MAP_H
-#endif

--- a/proxy/logging/LogFile.h
+++ b/proxy/logging/LogFile.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef LOG_FILE_H
-#define LOG_FILE_H
+#pragma once
 
 #include <stdarg.h>
 #include <stdio.h>
@@ -142,5 +141,3 @@ private:
 /***************************************************************************
  LogFileList IS NOT USED
 ****************************************************************************/
-
-#endif

--- a/proxy/logging/LogFilter.h
+++ b/proxy/logging/LogFilter.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef LOG_FILTER_H
-#define LOG_FILTER_H
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "ts/IpMap.h"
@@ -498,5 +497,3 @@ LogFilterString::_checkConditionAndWipe(OperatorFunction f, char **field_value, 
   }
   return retVal;
 }
-
-#endif

--- a/proxy/logging/LogFormat.h
+++ b/proxy/logging/LogFormat.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef LOG_FORMAT_H
-#define LOG_FORMAT_H
+#pragma once
 
 #define LOG_FIELD_MARKER '\377'
 
@@ -213,5 +212,3 @@ private:
   LogFormatList(const LogFormatList &rhs);
   LogFormatList &operator=(const LogFormatList &rhs);
 };
-
-#endif

--- a/proxy/logging/LogHost.h
+++ b/proxy/logging/LogHost.h
@@ -20,8 +20,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-#ifndef LOG_HOST_H
-#define LOG_HOST_H
+#pragma once
 
 class LogSock;
 class LogBuffer;
@@ -170,5 +169,3 @@ private:
   LogHostList(const LogHostList &);
   LogHostList &operator=(const LogHostList &);
 };
-
-#endif

--- a/proxy/logging/LogLimits.h
+++ b/proxy/logging/LogLimits.h
@@ -26,8 +26,7 @@
  module.
  ***************************************************************************/
 
-#ifndef LOG_LIMITS_H
-#define LOG_LIMITS_H
+#pragma once
 
 enum {
   LOG_MAX_FORMAT_LINE      = 2048, /* "format:enable:..." */
@@ -37,5 +36,3 @@ enum {
 
 #define LOG_KILOBYTE ((int64_t)1024)
 #define LOG_MEGABYTE ((int64_t)1048576)
-
-#endif

--- a/proxy/logging/LogObject.h
+++ b/proxy/logging/LogObject.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef LOG_OBJECT_H
-#define LOG_OBJECT_H
+#pragma once
 
 #include "ts/ink_platform.h"
 #include "Log.h"
@@ -450,5 +449,3 @@ LogObject::get_file_size_bytes()
     return max_size;
   }
 }
-
-#endif

--- a/proxy/logging/LogSock.h
+++ b/proxy/logging/LogSock.h
@@ -21,8 +21,7 @@
   limitations under the License.
  */
 
-#ifndef LOG_SOCK_H
-#define LOG_SOCK_H
+#pragma once
 
 #include "ts/ink_platform.h"
 
@@ -130,5 +129,3 @@ private:
   LogSock(const LogSock &);
   LogSock &operator=(const LogSock &);
 };
-
-#endif

--- a/proxy/logging/LogUtils.h
+++ b/proxy/logging/LogUtils.h
@@ -20,8 +20,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-#ifndef LOG_UTILS_H
-#define LOG_UTILS_H
+#pragma once
 
 #include "time.h"
 
@@ -61,4 +60,3 @@ int seconds_to_next_roll(time_t time_now, int rolling_offset, int rolling_interv
 int file_is_writeable(const char *full_filename, off_t *size_bytes = 0, bool *has_size_limit = 0,
                       uint64_t *current_size_limit_bytes = 0);
 };
-#endif

--- a/proxy/shared/DiagsConfig.h
+++ b/proxy/shared/DiagsConfig.h
@@ -21,8 +21,8 @@
   limitations under the License.
  */
 
-#ifndef __DIAGSCONFIG_H__
-#define __DIAGSCONFIG_H__
+#pragma once
+
 #include "ts/Diags.h"
 #include "ts/BaseLogFile.h"
 
@@ -43,5 +43,3 @@ private:
 public:
   Diags *diags;
 };
-
-#endif

--- a/tools/http_load/timers.h
+++ b/tools/http_load/timers.h
@@ -25,8 +25,7 @@
 ** SUCH DAMAGE.
 */
 
-#ifndef _TIMERS_H_
-#define _TIMERS_H_
+#pragma once
 
 #include <sys/time.h>
 
@@ -100,5 +99,3 @@ extern void tmr_cleanup(void);
 
 /* Cancel all timers and free storage, usually in preparation for exitting. */
 extern void tmr_destroy(void);
-
-#endif /* _TIMERS_H_ */


### PR DESCRIPTION
Since @zwoop cherry-picked a part of `#pragma once` changes (61c7caa7efef05167c45c63b65c593e4abeb7213), I assume we are going to use it on 7.1.x too. If we are not, we need to revert the commit. Otherwise we can't enable WCCP due to a compile error.

(cherry picked from commit b82d0aaf8fe7a56e68c397757980790e9306c7e0)

 Conflicts:
	cmd/traffic_cache_tool/Command.h
	cmd/traffic_cache_tool/File.h
	iocore/cluster/test_I_Cluster.cc
	iocore/eventsystem/I_Event.h
	iocore/eventsystem/I_MIOBufferWriter.h
	iocore/hostdb/P_HostDB.h
	iocore/net/P_NetAccept.h
	iocore/net/P_SNIActionPerformer.h
	iocore/net/P_SSLSNI.h
	iocore/net/P_UnixNet.h
	lib/records/I_RecMutex.h
	lib/records/P_RecFile.h
	lib/ts/BufferWriter.h
	lib/ts/History.h
	lib/ts/HostLookup.h
	lib/ts/JeAllocator.h
	lib/ts/MemArena.h
	lib/ts/Result.h
	lib/ts/ink_mutex.h
	mgmt/api/CoreAPI.h
	plugins/experimental/tls_bridge/regex.h
	plugins/header_rewrite/conditions.h
	plugins/header_rewrite/lulu.h
	proxy/HostStatus.h
	proxy/ICPevents.h
	proxy/api/ts/InkAPIPrivateIOCore.h
	proxy/congest/MT_hashtable.h
	proxy/http/HttpConnectionCount.h
	proxy/http/HttpProxyServerMain.h
	proxy/http/HttpSM.h
	proxy/http/HttpTransact.h