### PR TITLE
Corrects boolean argument validation/error message

### DIFF
--- a/tests/tools/microServer/uWServer.py
+++ b/tests/tools/microServer/uWServer.py
@@ -594,13 +594,13 @@ def _bool(arg):
     elif tmp in opt_false_values:
         return False
     else:
-        msg = 'Invalid value Boolean value : "{0}"\n Valid options are {0}'.format(arg,
+        msg = 'Invalid value Boolean value : "{0}"\n Valid options are {1}'.format(arg,
                                                                                    opt_true_values | opt_false_values)
         raise ValueError(msg)
 
-def _argparse_bool():
+def _argparse_bool(arg):
     try:
-        _bool
+        _bool(arg)
     except ValueError as ve:
         raise argparse.ArgumentTypeError(ve)
 


### PR DESCRIPTION
```
(container:rhel7-gcc6_2)[~/trafficserver/tests/tools/microServer]
linuxkit-025000000001 ∴ mkdir emptydir
(container:rhel7-gcc6_2)[~/trafficserver/tests/tools/microServer]
linuxkit-025000000001 ∴ python3 ./uWServer.py -d emptydir/ --clientverify 1
size 0
Dropped 0 sessions for being malformed
^C
=== ^C received, shutting down httpserver ===
Traceback (most recent call last):
  File "./uWServer.py", line 696, in main
    server = ThreadingServer((options.ip_address, options.port), MyHandler, options)
  File "./uWServer.py", line 121, in __init__
    HTTPServer.__init__(self, local_addr, handler_class)
  File "/opt/rh/rh-python35/root/usr/lib64/python3.5/socketserver.py", line 443, in __init__
    self.server_bind()
  File "/opt/rh/rh-python35/root/usr/lib64/python3.5/http/server.py", line 140, in server_bind
    self.server_name = socket.getfqdn(host)
  File "/opt/rh/rh-python35/root/usr/lib64/python3.5/socket.py", line 662, in getfqdn
    hostname, aliases, ipaddrs = gethostbyaddr(name)
KeyboardInterrupt

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./uWServer.py", line 711, in <module>
    main()
  File "./uWServer.py", line 705, in main
    server.socket.close()
UnboundLocalError: local variable 'server' referenced before assignment
☞  (1)
(container:rhel7-gcc6_2)[~/trafficserver/tests/tools/microServer]
linuxkit-025000000001 ∴ python3 ./uWServer.py -d emptydir/ --clientverify foobar
usage: uWServer.py [-h] --data-dir DATA_DIR [--ip_address IP_ADDRESS]
                   [--port PORT] [--delay DELAY] [--timeout TIMEOUT] [-V]
                   [--mode MODE] [--ssl SSL] [--key KEY] [--cert CERT]
                   [--clientverify CLIENTVERIFY] [--load LOAD]
                   [--lookupkey LOOKUPKEY]
uWServer.py: error: argument --clientverify/-cverify: Invalid value Boolean value : "foobar"
 Valid options are {'y', 'off', 'all', 'true', 'no', '0', 'on', 'false', 'yes', None, 'n', '1', 'f', 'none', 't'}
```

If we want unit tests for this in addition, I can add those.