### PR TITLE
Add <ts/debug.h> with debug / Test Mode types, constants, and use in ink_assert.h .

### DIFF
--- a/lib/ts/debug.h
+++ b/lib/ts/debug.h
@@ -1,0 +1,54 @@
+/** @file
+
+  Define ts::Debug and ts::DebugType
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include <type_traits>
+
+namespace ts
+{
+#if defined(DEBUG)
+
+using DebugType = std::true_type;
+
+#else
+
+using DebugType = std::false_type;
+
+#endif
+
+const bool Debug = DebugType::value;
+
+#if defined(DEBUG) or defined(__clang_analyzer__) or defined(__COVERITY__)
+
+using TestModeType = std::true_type;
+
+#else
+
+using TestModeType = std::false_type;
+
+#endif
+
+const bool TestMode = TestModeType::value;
+
+} // end namespace ts


### PR DESCRIPTION
Done at the behest of @SolidWallOfCode to annoy @zwoop with plausible deniability.