### PR TITLE
Use variadic templates for rpc serialization

### DIFF
--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -578,19 +578,18 @@ LocalManager::handleMgmtMsgFromProcesses(MgmtMessageHdr *mh)
     break;
   // Congestion Control - end
   case MGMT_SIGNAL_CONFIG_FILE_CHILD: {
-    static const MgmtMarshallType fields[] = {MGMT_MARSHALL_STRING, MGMT_MARSHALL_STRING, MGMT_MARSHALL_INT};
-    char *parent                           = nullptr;
-    char *child                            = nullptr;
-    MgmtMarshallInt options                = 0;
-    if (mgmt_message_parse(data_raw, mh->data_len, fields, countof(fields), &parent, &child, &options) != -1) {
-      configFiles->configFileChild(parent, child, (unsigned int)options);
+    MgmtMarshallInt options    = 0;
+    MgmtMarshallString mparent = nullptr;
+    MgmtMarshallString mchild  = nullptr;
+    if (mgmt_message_parse(data_raw, mh->data_len, &mparent, &mchild, &options) != -1) {
+      configFiles->configFileChild(mparent, mchild, static_cast<unsigned int>(options));
     } else {
       mgmt_log("[LocalManager::handleMgmtMsgFromProcesses] "
                "MGMT_SIGNAL_CONFIG_FILE_CHILD mgmt_message_parse error\n");
     }
     // Output pointers are guaranteed to be NULL or valid.
-    ats_free_null(parent);
-    ats_free_null(child);
+    ats_free_null(mparent);
+    ats_free_null(mchild);
   } break;
   case MGMT_SIGNAL_SAC_SERVER_DOWN:
     alarm_keeper->signalAlarm(MGMT_ALARM_SAC_SERVER_DOWN, data_raw);

--- a/mgmt/ProcessManager.cc
+++ b/mgmt/ProcessManager.cc
@@ -218,14 +218,14 @@ ProcessManager::reconfigure()
 void
 ProcessManager::signalConfigFileChild(const char *parent, const char *child, unsigned int options)
 {
-  static const MgmtMarshallType fields[] = {MGMT_MARSHALL_STRING, MGMT_MARSHALL_STRING, MGMT_MARSHALL_INT};
+  MgmtMarshallInt mgmtopt    = options;
+  MgmtMarshallString mparent = const_cast<MgmtMarshallString>(parent);
+  MgmtMarshallString mchild  = const_cast<MgmtMarshallString>(child);
 
-  MgmtMarshallInt mgmtopt = options;
-
-  size_t len   = mgmt_message_length(fields, countof(fields), &parent, &child, &mgmtopt);
+  size_t len   = mgmt_message_length(&mparent, &mchild, &mgmtopt);
   void *buffer = ats_malloc(len);
 
-  mgmt_message_marshall(buffer, len, fields, countof(fields), &parent, &child, &mgmtopt);
+  mgmt_message_marshall(buffer, len, &mparent, &mchild, &mgmtopt);
   signalManager(MGMT_SIGNAL_CONFIG_FILE_CHILD, (const char *)buffer, len);
 
   ats_free(buffer);

--- a/mgmt/api/CoreAPIRemote.cc
+++ b/mgmt/api/CoreAPIRemote.cc
@@ -81,7 +81,7 @@ send_and_parse_list(OpType op, LLQ *list)
   Tokenizer tokens(REMOTE_DELIM_STR);
   tok_iter_state i_state;
 
-  OpType optype = op;
+  MgmtMarshallInt optype = static_cast<MgmtMarshallInt>(op);
   MgmtMarshallInt err;
   MgmtMarshallData reply    = {nullptr, 0};
   MgmtMarshallString strval = nullptr;
@@ -101,7 +101,7 @@ send_and_parse_list(OpType op, LLQ *list)
     goto done;
   }
 
-  ret = recv_mgmt_response(reply.ptr, reply.len, op, &err, &strval);
+  ret = parse_mgmt_message(reply.ptr, reply.len, op, &err, &strval);
   if (ret != TS_ERR_OKAY) {
     goto done;
   }
@@ -143,7 +143,7 @@ mgmt_record_set(const char *rec_name, const char *rec_val, TSActionNeedT *action
 {
   TSMgmtError ret;
 
-  OpType optype            = OpType::RECORD_SET;
+  MgmtMarshallInt optype   = static_cast<MgmtMarshallInt>(OpType::RECORD_SET);
   MgmtMarshallString name  = const_cast<MgmtMarshallString>(rec_name);
   MgmtMarshallString value = const_cast<MgmtMarshallString>(rec_val);
 
@@ -168,7 +168,7 @@ mgmt_record_set(const char *rec_name, const char *rec_val, TSActionNeedT *action
     return ret;
   }
 
-  ret = recv_mgmt_response(reply.ptr, reply.len, OpType::RECORD_SET, &err, &action);
+  ret = parse_mgmt_message(reply.ptr, reply.len, OpType::RECORD_SET, &err, &action);
   ats_free(reply.ptr);
 
   if (ret != TS_ERR_OKAY) {
@@ -299,7 +299,7 @@ TSProxyStateT
 ProxyStateGet()
 {
   TSMgmtError ret;
-  OpType optype          = OpType::PROXY_STATE_GET;
+  MgmtMarshallInt optype = static_cast<MgmtMarshallInt>(OpType::PROXY_STATE_GET);
   MgmtMarshallData reply = {nullptr, 0};
   MgmtMarshallInt err;
   MgmtMarshallInt state;
@@ -314,7 +314,7 @@ ProxyStateGet()
     return TS_PROXY_UNDEFINED;
   }
 
-  ret = recv_mgmt_response(reply.ptr, reply.len, OpType::PROXY_STATE_GET, &err, &state);
+  ret = parse_mgmt_message(reply.ptr, reply.len, OpType::PROXY_STATE_GET, &err, &state);
   ats_free(reply.ptr);
 
   if (ret != TS_ERR_OKAY || err != TS_ERR_OKAY) {
@@ -328,7 +328,7 @@ TSMgmtError
 ProxyStateSet(TSProxyStateT state, TSCacheClearT clear)
 {
   TSMgmtError ret;
-  OpType optype          = OpType::PROXY_STATE_SET;
+  MgmtMarshallInt optype = static_cast<MgmtMarshallInt>(OpType::PROXY_STATE_SET);
   MgmtMarshallInt pstate = state;
   MgmtMarshallInt pclear = clear;
 
@@ -342,7 +342,7 @@ ServerBacktrace(unsigned options, char **trace)
   ink_release_assert(trace != nullptr);
   TSMgmtError ret;
   MgmtMarshallInt err;
-  OpType optype             = OpType::SERVER_BACKTRACE;
+  MgmtMarshallInt optype    = static_cast<MgmtMarshallInt>(OpType::SERVER_BACKTRACE);
   MgmtMarshallInt flags     = options;
   MgmtMarshallData reply    = {nullptr, 0};
   MgmtMarshallString strval = nullptr;
@@ -357,7 +357,7 @@ ServerBacktrace(unsigned options, char **trace)
     goto fail;
   }
 
-  ret = recv_mgmt_response(reply.ptr, reply.len, OpType::SERVER_BACKTRACE, &err, &strval);
+  ret = parse_mgmt_message(reply.ptr, reply.len, OpType::SERVER_BACKTRACE, &err, &strval);
   if (ret != TS_ERR_OKAY) {
     goto fail;
   }
@@ -381,7 +381,7 @@ TSMgmtError
 Reconfigure()
 {
   TSMgmtError ret;
-  OpType optype = OpType::RECONFIGURE;
+  MgmtMarshallInt optype = static_cast<MgmtMarshallInt>(OpType::RECONFIGURE);
 
   ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::RECONFIGURE, &optype);
   return (ret == TS_ERR_OKAY) ? parse_generic_response(OpType::RECONFIGURE, main_socket_fd) : ret;
@@ -400,8 +400,8 @@ TSMgmtError
 Restart(unsigned options)
 {
   TSMgmtError ret;
-  OpType optype        = OpType::RESTART;
-  MgmtMarshallInt oval = options;
+  MgmtMarshallInt optype = static_cast<MgmtMarshallInt>(OpType::RESTART);
+  MgmtMarshallInt oval   = options;
 
   ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::RESTART, &optype, &oval);
   if (ret != TS_ERR_OKAY) {
@@ -425,8 +425,8 @@ TSMgmtError
 Bounce(unsigned options)
 {
   TSMgmtError ret;
-  OpType optype        = OpType::BOUNCE;
-  MgmtMarshallInt oval = options;
+  MgmtMarshallInt optype = static_cast<MgmtMarshallInt>(OpType::BOUNCE);
+  MgmtMarshallInt oval   = options;
 
   ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::BOUNCE, &optype, &oval);
 
@@ -442,8 +442,8 @@ TSMgmtError
 Stop(unsigned options)
 {
   TSMgmtError ret;
-  OpType optype        = OpType::STOP;
-  MgmtMarshallInt oval = options;
+  MgmtMarshallInt optype = static_cast<MgmtMarshallInt>(OpType::STOP);
+  MgmtMarshallInt oval   = options;
 
   ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::STOP, &optype, &oval);
 
@@ -459,8 +459,8 @@ TSMgmtError
 Drain(unsigned options)
 {
   TSMgmtError ret;
-  OpType optype        = OpType::DRAIN;
-  MgmtMarshallInt oval = options;
+  MgmtMarshallInt optype = static_cast<MgmtMarshallInt>(OpType::DRAIN);
+  MgmtMarshallInt oval   = options;
 
   ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::DRAIN, &optype, &oval);
 
@@ -476,7 +476,7 @@ TSMgmtError
 StorageDeviceCmdOffline(const char *dev)
 {
   TSMgmtError ret;
-  OpType optype           = OpType::STORAGE_DEVICE_CMD_OFFLINE;
+  MgmtMarshallInt optype  = static_cast<MgmtMarshallInt>(OpType::STORAGE_DEVICE_CMD_OFFLINE);
   MgmtMarshallString name = const_cast<MgmtMarshallString>(dev);
 
   ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::STORAGE_DEVICE_CMD_OFFLINE, &optype, &name);
@@ -492,7 +492,7 @@ TSMgmtError
 LifecycleMessage(const char *tag, void const *data, size_t data_size)
 {
   TSMgmtError ret;
-  OpType optype           = OpType::LIFECYCLE_MESSAGE;
+  MgmtMarshallInt optype  = static_cast<MgmtMarshallInt>(OpType::LIFECYCLE_MESSAGE);
   MgmtMarshallString mtag = const_cast<MgmtMarshallString>(tag);
   MgmtMarshallData mdata  = {const_cast<void *>(data), data_size};
 
@@ -552,7 +552,7 @@ mgmt_record_get_reply(OpType op, TSRecordEle *rec_ele)
     return ret;
   }
 
-  ret = recv_mgmt_response(reply.ptr, reply.len, op, &err, &rclass, &type, &name, &value);
+  ret = parse_mgmt_message(reply.ptr, reply.len, op, &err, &rclass, &type, &name, &value);
   ats_free(reply.ptr);
   if (ret != TS_ERR_OKAY) {
     goto done;
@@ -602,7 +602,7 @@ mgmt_record_describe_reply(TSConfigRecordDescription *val)
   MgmtMarshallInt checktype;
   MgmtMarshallInt source;
 
-  ret = recv_mgmt_response(reply.ptr, reply.len, OpType::RECORD_DESCRIBE_CONFIG, &err, &name, &value, &deflt, &rtype, &rclass,
+  ret = parse_mgmt_message(reply.ptr, reply.len, OpType::RECORD_DESCRIBE_CONFIG, &err, &name, &value, &deflt, &rtype, &rclass,
                            &version, &rsb, &order, &access, &update, &updatetype, &checktype, &source, &expr);
 
   ats_free(reply.ptr);
@@ -646,7 +646,7 @@ TSMgmtError
 MgmtRecordGet(const char *rec_name, TSRecordEle *rec_ele)
 {
   TSMgmtError ret;
-  OpType optype             = OpType::RECORD_GET;
+  MgmtMarshallInt optype    = static_cast<MgmtMarshallInt>(OpType::RECORD_GET);
   MgmtMarshallString record = const_cast<MgmtMarshallString>(rec_name);
 
   if (!rec_name || !rec_ele) {
@@ -672,7 +672,7 @@ TSMgmtError
 MgmtConfigRecordDescribeMatching(const char *rec_name, unsigned options, TSList rec_vals)
 {
   TSMgmtError ret;
-  OpType optype             = OpType::RECORD_DESCRIBE_CONFIG;
+  MgmtMarshallInt optype    = static_cast<MgmtMarshallInt>(OpType::RECORD_DESCRIBE_CONFIG);
   MgmtMarshallInt flags     = options | RECORD_DESCRIBE_FLAGS_MATCH;
   MgmtMarshallString record = const_cast<MgmtMarshallString>(rec_name);
 
@@ -718,7 +718,7 @@ TSMgmtError
 MgmtConfigRecordDescribe(const char *rec_name, unsigned options, TSConfigRecordDescription *val)
 {
   TSMgmtError ret;
-  OpType optype             = OpType::RECORD_DESCRIBE_CONFIG;
+  MgmtMarshallInt optype    = static_cast<MgmtMarshallInt>(OpType::RECORD_DESCRIBE_CONFIG);
   MgmtMarshallInt flags     = options & ~RECORD_DESCRIBE_FLAGS_MATCH;
   MgmtMarshallString record = const_cast<MgmtMarshallString>(rec_name);
 
@@ -737,7 +737,7 @@ MgmtRecordGetMatching(const char *regex, TSList rec_vals)
   TSMgmtError ret;
   TSRecordEle *rec_ele;
 
-  OpType optype             = OpType::RECORD_MATCH_GET;
+  MgmtMarshallInt optype    = static_cast<MgmtMarshallInt>(OpType::RECORD_MATCH_GET);
   MgmtMarshallString record = const_cast<MgmtMarshallString>(regex);
 
   if (!regex || !rec_vals) {
@@ -883,7 +883,7 @@ TSMgmtError
 EventResolve(const char *event_name)
 {
   TSMgmtError ret;
-  OpType optype           = OpType::EVENT_RESOLVE;
+  MgmtMarshallInt optype  = static_cast<MgmtMarshallInt>(OpType::EVENT_RESOLVE);
   MgmtMarshallString name = const_cast<MgmtMarshallString>(event_name);
 
   if (!event_name) {
@@ -919,7 +919,7 @@ TSMgmtError
 EventIsActive(const char *event_name, bool *is_current)
 {
   TSMgmtError ret;
-  OpType optype           = OpType::EVENT_ACTIVE;
+  MgmtMarshallInt optype  = static_cast<MgmtMarshallInt>(OpType::EVENT_ACTIVE);
   MgmtMarshallString name = const_cast<MgmtMarshallString>(event_name);
 
   MgmtMarshallData reply = {nullptr, 0};
@@ -941,7 +941,7 @@ EventIsActive(const char *event_name, bool *is_current)
     return ret;
   }
 
-  ret = recv_mgmt_response(reply.ptr, reply.len, OpType::EVENT_ACTIVE, &err, &bval);
+  ret = parse_mgmt_message(reply.ptr, reply.len, OpType::EVENT_ACTIVE, &err, &bval);
   ats_free(reply.ptr);
 
   if (ret != TS_ERR_OKAY) {
@@ -981,7 +981,7 @@ EventSignalCbRegister(const char *event_name, TSEventSignalFunc func, void *data
 
   // if we need to notify traffic manager of the event then send msg
   if (first_time) {
-    OpType optype           = OpType::EVENT_REG_CALLBACK;
+    MgmtMarshallInt optype  = static_cast<MgmtMarshallInt>(OpType::EVENT_REG_CALLBACK);
     MgmtMarshallString name = const_cast<MgmtMarshallString>(event_name);
 
     ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::EVENT_REG_CALLBACK, &optype, &name);
@@ -1036,22 +1036,22 @@ TSMgmtError
 HostStatusSetDown(const char *host_name)
 {
   TSMgmtError ret         = TS_ERR_PARAMS;
-  OpType op               = OpType::HOST_STATUS_DOWN;
+  MgmtMarshallInt op      = static_cast<MgmtMarshallInt>(OpType::HOST_STATUS_DOWN);
   MgmtMarshallString name = const_cast<MgmtMarshallString>(host_name);
 
-  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, op, &op, &name);
-  return (ret == TS_ERR_OKAY) ? parse_generic_response(op, main_socket_fd) : ret;
+  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::HOST_STATUS_DOWN, &op, &name);
+  return (ret == TS_ERR_OKAY) ? parse_generic_response(OpType::HOST_STATUS_DOWN, main_socket_fd) : ret;
 }
 
 TSMgmtError
 HostStatusSetUp(const char *host_name)
 {
   TSMgmtError ret         = TS_ERR_PARAMS;
-  OpType op               = OpType::HOST_STATUS_UP;
+  MgmtMarshallInt op      = static_cast<MgmtMarshallInt>(OpType::HOST_STATUS_UP);
   MgmtMarshallString name = const_cast<MgmtMarshallString>(host_name);
 
-  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, op, &op, &name);
-  return (ret == TS_ERR_OKAY) ? parse_generic_response(op, main_socket_fd) : ret;
+  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::HOST_STATUS_UP, &op, &name);
+  return (ret == TS_ERR_OKAY) ? parse_generic_response(OpType::HOST_STATUS_UP, main_socket_fd) : ret;
 }
 
 TSMgmtError
@@ -1059,7 +1059,7 @@ StatsReset(const char *stat_name)
 {
   TSMgmtError ret;
   OpType op               = OpType::STATS_RESET_NODE;
-  OpType optype           = op;
+  MgmtMarshallInt optype  = static_cast<MgmtMarshallInt>(OpType::STATS_RESET_NODE);
   MgmtMarshallString name = const_cast<MgmtMarshallString>(stat_name);
 
   ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, op, &optype, &name);

--- a/mgmt/api/EventControlMain.cc
+++ b/mgmt/api/EventControlMain.cc
@@ -385,7 +385,7 @@ event_callback_main(void *arg)
       while (con_entry) {
         client_entry = (EventClientT *)ink_hash_table_entry_value(accepted_clients, con_entry);
         if (client_entry->events_registered[event->id]) {
-          OpType optype           = OpType::EVENT_NOTIFY;
+          MgmtMarshallInt optype  = static_cast<MgmtMarshallInt>(OpType::EVENT_NOTIFY);
           MgmtMarshallString name = event->name;
           MgmtMarshallString desc = event->description;
 
@@ -446,7 +446,7 @@ handle_event_reg_callback(EventClientT *client, void *req, size_t reqlen)
   MgmtMarshallString name = nullptr;
   TSMgmtError ret;
 
-  ret = recv_mgmt_request(req, reqlen, OpType::EVENT_REG_CALLBACK, &optype, &name);
+  ret = parse_mgmt_message(req, reqlen, OpType::EVENT_REG_CALLBACK, &optype, &name);
   if (ret != TS_ERR_OKAY) {
     goto done;
   }
@@ -489,7 +489,7 @@ handle_event_unreg_callback(EventClientT *client, void *req, size_t reqlen)
   MgmtMarshallString name = nullptr;
   TSMgmtError ret;
 
-  ret = recv_mgmt_request(req, reqlen, OpType::EVENT_UNREG_CALLBACK, &optype, &name);
+  ret = parse_mgmt_message(req, reqlen, OpType::EVENT_UNREG_CALLBACK, &optype, &name);
   if (ret != TS_ERR_OKAY) {
     goto done;
   }

--- a/mgmt/api/NetworkMessage.cc
+++ b/mgmt/api/NetworkMessage.cc
@@ -31,163 +31,6 @@
 #define MAX_OPERATION_BUFSZ 1024
 #define MAX_OPERATION_FIELDS 16
 
-struct NetCmdOperation {
-  unsigned nfields;
-  const MgmtMarshallType fields[MAX_OPERATION_FIELDS];
-};
-
-// Requests always begin with a OpType, followed by aditional fields.
-static const struct NetCmdOperation requests[] = {
-  /* RECORD_SET                 */ {3, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING, MGMT_MARSHALL_STRING}},
-  /* RECORD_GET                 */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-  /* PROXY_STATE_GET            */ {1, {MGMT_MARSHALL_INT}},
-  /* PROXY_STATE_SET            */ {3, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
-  /* RECONFIGURE                */ {1, {MGMT_MARSHALL_INT}},
-  /* RESTART                    */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
-  /* BOUNCE                     */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
-  /* STOP                       */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
-  /* DRAIN                      */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
-  /* EVENT_RESOLVE              */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-  /* EVENT_GET_MLT              */ {1, {MGMT_MARSHALL_INT}},
-  /* EVENT_ACTIVE               */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-  /* EVENT_REG_CALLBACK         */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-  /* EVENT_UNREG_CALLBACK       */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-  /* EVENT_NOTIFY               */ {3, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING, MGMT_MARSHALL_STRING}}, // only msg sent from TM to
-                                                                                                         // client
-  /* STATS_RESET_NODE           */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-  /* STORAGE_DEVICE_CMD_OFFLINE */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-  /* RECORD_MATCH_GET           */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-  /* API_PING                   */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
-  /* SERVER_BACKTRACE           */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
-  /* RECORD_DESCRIBE_CONFIG     */ {3, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING, MGMT_MARSHALL_INT}},
-  /* LIFECYCLE_MESSAGE          */ {3, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING, MGMT_MARSHALL_DATA}},
-  /* HOST_STATUS_HOST_UP        */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-  /* HOST_STATUS_HOST_DOWN      */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-};
-
-// Responses always begin with a TSMgmtError code, followed by additional fields.
-static const struct NetCmdOperation responses[] = {
-  /* RECORD_SET                 */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
-  /* RECORD_GET                 */
-  {5, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT, MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING, MGMT_MARSHALL_DATA}},
-  /* PROXY_STATE_GET            */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
-  /* PROXY_STATE_SET            */ {1, {MGMT_MARSHALL_INT}},
-  /* RECONFIGURE                */ {1, {MGMT_MARSHALL_INT}},
-  /* RESTART                    */ {1, {MGMT_MARSHALL_INT}},
-  /* BOUNCE                     */ {1, {MGMT_MARSHALL_INT}},
-  /* STOP                       */ {1, {MGMT_MARSHALL_INT}},
-  /* DRAIN                      */ {1, {MGMT_MARSHALL_INT}},
-  /* EVENT_RESOLVE              */ {1, {MGMT_MARSHALL_INT}},
-  /* EVENT_GET_MLT              */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-  /* EVENT_ACTIVE               */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT}},
-  /* EVENT_REG_CALLBACK         */ {0, {}}, // no reply
-  /* EVENT_UNREG_CALLBACK       */ {0, {}}, // no reply
-  /* EVENT_NOTIFY               */ {0, {}}, // no reply
-  /* STATS_RESET_NODE           */ {1, {MGMT_MARSHALL_INT}},
-  /* STORAGE_DEVICE_CMD_OFFLINE */ {1, {MGMT_MARSHALL_INT}},
-  /* RECORD_MATCH_GET           */
-  {5, {MGMT_MARSHALL_INT, MGMT_MARSHALL_INT, MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING, MGMT_MARSHALL_DATA}},
-  /* API_PING                   */ {0, {}}, // no reply
-  /* SERVER_BACKTRACE           */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-  /* RECORD_DESCRIBE_CONFIG     */
-  {15,
-   {MGMT_MARSHALL_INT /* status */, MGMT_MARSHALL_STRING /* name */, MGMT_MARSHALL_DATA /* value */,
-    MGMT_MARSHALL_DATA /* default */, MGMT_MARSHALL_INT /* type */, MGMT_MARSHALL_INT /* class */, MGMT_MARSHALL_INT /* version */,
-    MGMT_MARSHALL_INT /* rsb */, MGMT_MARSHALL_INT /* order */, MGMT_MARSHALL_INT /* access */, MGMT_MARSHALL_INT /* update */,
-    MGMT_MARSHALL_INT /* updatetype */, MGMT_MARSHALL_INT /* checktype */, MGMT_MARSHALL_INT /* source */,
-    MGMT_MARSHALL_STRING /* checkexpr */}},
-  /* LIFECYCLE_MESSAGE          */ {1, {MGMT_MARSHALL_INT}},
-  /* HOST_STATUS_UP             */ {1, {MGMT_MARSHALL_INT}},
-  /* HOST_STATUS_DOWN           */ {1, {MGMT_MARSHALL_INT}},
-};
-
-#define GETCMD(ops, optype, cmd)                           \
-  do {                                                     \
-    if (static_cast<unsigned>(optype) >= countof(ops)) {   \
-      return TS_ERR_PARAMS;                                \
-    }                                                      \
-    if (ops[static_cast<unsigned>(optype)].nfields == 0) { \
-      return TS_ERR_PARAMS;                                \
-    }                                                      \
-    cmd = &ops[static_cast<unsigned>(optype)];             \
-  } while (0);
-
-TSMgmtError
-send_mgmt_request(const mgmt_message_sender &snd, OpType optype, ...)
-{
-  va_list ap;
-  ats_scoped_mem<char> msgbuf;
-  MgmtMarshallInt msglen;
-  const MgmtMarshallType lenfield[] = {MGMT_MARSHALL_INT};
-  const NetCmdOperation *cmd;
-
-  if (!snd.is_connected()) {
-    return TS_ERR_NET_ESTABLISH; // no connection.
-  }
-
-  GETCMD(requests, optype, cmd);
-
-  va_start(ap, optype);
-  msglen = mgmt_message_length_v(cmd->fields, cmd->nfields, ap);
-  va_end(ap);
-
-  msgbuf = (char *)ats_malloc(msglen + 4);
-
-  // First marshall the total message length.
-  mgmt_message_marshall((char *)msgbuf, msglen, lenfield, countof(lenfield), &msglen);
-
-  // Now marshall the message itself.
-  va_start(ap, optype);
-  if (mgmt_message_marshall_v((char *)msgbuf + 4, msglen, cmd->fields, cmd->nfields, ap) == -1) {
-    va_end(ap);
-    return TS_ERR_PARAMS;
-  }
-
-  va_end(ap);
-  return snd.send(msgbuf, msglen + 4);
-}
-
-TSMgmtError
-send_mgmt_request(int fd, OpType optype, ...)
-{
-  va_list ap;
-  MgmtMarshallInt msglen;
-  MgmtMarshallData req            = {nullptr, 0};
-  const MgmtMarshallType fields[] = {MGMT_MARSHALL_DATA};
-  const NetCmdOperation *cmd;
-
-  GETCMD(requests, optype, cmd);
-
-  // Figure out the payload length.
-  va_start(ap, optype);
-  msglen = mgmt_message_length_v(cmd->fields, cmd->nfields, ap);
-  va_end(ap);
-
-  ink_assert(msglen >= 0);
-
-  req.ptr = (char *)ats_malloc(msglen);
-  req.len = msglen;
-
-  // Marshall the message itself.
-  va_start(ap, optype);
-  if (mgmt_message_marshall_v(req.ptr, req.len, cmd->fields, cmd->nfields, ap) == -1) {
-    ats_free(req.ptr);
-    va_end(ap);
-    return TS_ERR_PARAMS;
-  }
-
-  va_end(ap);
-
-  // Send the response as the payload of a data object.
-  if (mgmt_message_write(fd, fields, countof(fields), &req) == -1) {
-    ats_free(req.ptr);
-    return TS_ERR_NET_WRITE;
-  }
-
-  ats_free(req.ptr);
-  return TS_ERR_OKAY;
-}
-
 TSMgmtError
 send_mgmt_error(int fd, OpType optype, TSMgmtError error)
 {
@@ -210,27 +53,22 @@ send_mgmt_error(int fd, OpType optype, TSMgmtError error)
   case OpType::HOST_STATUS_UP:
   case OpType::HOST_STATUS_DOWN:
   case OpType::STORAGE_DEVICE_CMD_OFFLINE:
-    ink_release_assert(responses[static_cast<unsigned>(optype)].nfields == 1);
     return send_mgmt_response(fd, optype, &ecode);
 
   case OpType::RECORD_SET:
   case OpType::PROXY_STATE_GET:
   case OpType::EVENT_ACTIVE:
-    ink_release_assert(responses[static_cast<unsigned>(optype)].nfields == 2);
     return send_mgmt_response(fd, optype, &ecode, &intval);
 
   case OpType::EVENT_GET_MLT:
   case OpType::SERVER_BACKTRACE:
-    ink_release_assert(responses[static_cast<unsigned>(optype)].nfields == 2);
     return send_mgmt_response(fd, optype, &ecode, &strval);
 
   case OpType::RECORD_GET:
   case OpType::RECORD_MATCH_GET:
-    ink_release_assert(responses[static_cast<unsigned>(optype)].nfields == 5);
     return send_mgmt_response(fd, optype, &ecode, &intval, &intval, &strval, &dataval);
 
   case OpType::RECORD_DESCRIBE_CONFIG:
-    ink_release_assert(responses[static_cast<unsigned>(optype)].nfields == 15);
     return send_mgmt_response(fd, optype, &ecode, &strval /* name */, &dataval /* value */, &dataval /* default */,
                               &intval /* type */, &intval /* class */, &intval /* version */, &intval /* rsb */,
                               &intval /* order */, &intval /* access */, &intval /* update */, &intval /* updatetype */,
@@ -241,7 +79,6 @@ send_mgmt_error(int fd, OpType optype, TSMgmtError error)
   case OpType::EVENT_NOTIFY:
   case OpType::API_PING:
     /* no response for these */
-    ink_release_assert(responses[static_cast<unsigned>(optype)].nfields == 0);
     return TS_ERR_OKAY;
 
   case OpType::UNDEFINED_OP:
@@ -256,93 +93,10 @@ send_mgmt_error(int fd, OpType optype, TSMgmtError error)
   return TS_ERR_FAIL;
 }
 
-// Send a management message response. We don't need to worry about retransmitting the message if we get
-// disconnected, so this is much simpler. We can directly marshall the response as a data object.
-TSMgmtError
-send_mgmt_response(int fd, OpType optype, ...)
-{
-  va_list ap;
-  MgmtMarshallInt msglen;
-  MgmtMarshallData reply          = {nullptr, 0};
-  const MgmtMarshallType fields[] = {MGMT_MARSHALL_DATA};
-  const NetCmdOperation *cmd;
-
-  GETCMD(responses, optype, cmd);
-
-  va_start(ap, optype);
-  msglen = mgmt_message_length_v(cmd->fields, cmd->nfields, ap);
-  va_end(ap);
-
-  ink_assert(msglen >= 0);
-
-  reply.ptr = (char *)ats_malloc(msglen);
-  reply.len = msglen;
-
-  // Marshall the message itself.
-  va_start(ap, optype);
-  if (mgmt_message_marshall_v(reply.ptr, reply.len, cmd->fields, cmd->nfields, ap) == -1) {
-    ats_free(reply.ptr);
-    va_end(ap);
-    return TS_ERR_PARAMS;
-  }
-
-  va_end(ap);
-
-  // Send the response as the payload of a data object.
-  if (mgmt_message_write(fd, fields, countof(fields), &reply) == -1) {
-    ats_free(reply.ptr);
-    return TS_ERR_NET_WRITE;
-  }
-
-  ats_free(reply.ptr);
-  return TS_ERR_OKAY;
-}
-
-template <unsigned N>
-static TSMgmtError
-recv_x(const struct NetCmdOperation (&ops)[N], void *buf, size_t buflen, OpType optype, va_list ap)
-{
-  ssize_t msglen;
-  const NetCmdOperation *cmd;
-
-  GETCMD(ops, optype, cmd);
-
-  msglen = mgmt_message_parse_v(buf, buflen, cmd->fields, cmd->nfields, ap);
-  return (msglen == -1) ? TS_ERR_PARAMS : TS_ERR_OKAY;
-}
-
-TSMgmtError
-recv_mgmt_request(void *buf, size_t buflen, OpType optype, ...)
-{
-  TSMgmtError err;
-  va_list ap;
-
-  va_start(ap, optype);
-  err = recv_x(requests, buf, buflen, optype, ap);
-  va_end(ap);
-
-  return err;
-}
-
-TSMgmtError
-recv_mgmt_response(void *buf, size_t buflen, OpType optype, ...)
-{
-  TSMgmtError err;
-  va_list ap;
-
-  va_start(ap, optype);
-  err = recv_x(responses, buf, buflen, optype, ap);
-  va_end(ap);
-
-  return err;
-}
-
 TSMgmtError
 recv_mgmt_message(int fd, MgmtMarshallData &msg)
 {
-  const MgmtMarshallType fields[] = {MGMT_MARSHALL_DATA};
-
-  if (mgmt_message_read(fd, fields, countof(fields), &msg) == -1) {
+  if (mgmt_message_read(fd, &msg) == -1) {
     return TS_ERR_NET_READ;
   }
 
@@ -352,10 +106,9 @@ recv_mgmt_message(int fd, MgmtMarshallData &msg)
 OpType
 extract_mgmt_request_optype(void *msg, size_t msglen)
 {
-  const MgmtMarshallType fields[] = {MGMT_MARSHALL_INT};
   MgmtMarshallInt optype;
 
-  if (mgmt_message_parse(msg, msglen, fields, countof(fields), &optype) == -1) {
+  if (mgmt_message_parse(msg, msglen, &optype) == -1) {
     return OpType::UNDEFINED_OP;
   }
 

--- a/mgmt/api/NetworkMessage.h
+++ b/mgmt/api/NetworkMessage.h
@@ -72,23 +72,111 @@ struct mgmt_message_sender {
 };
 
 // Marshall and send a request, prefixing the message length as a MGMT_MARSHALL_INT.
-TSMgmtError send_mgmt_request(const mgmt_message_sender &snd, OpType optype, ...);
-TSMgmtError send_mgmt_request(int fd, OpType optype, ...);
+template <typename... Params>
+TSMgmtError
+send_mgmt_request(const mgmt_message_sender &snd, OpType optype, Params &&... params)
+{
+  ats_scoped_mem<char> msgbuf;
+  MgmtMarshallInt msglen;
 
-// Marshall and send an error respose for this operation type.
-TSMgmtError send_mgmt_error(int fd, OpType op, TSMgmtError error);
+  if (!snd.is_connected()) {
+    return TS_ERR_NET_ESTABLISH; // no connection.
+  }
 
-// Parse a request message from a buffer.
-TSMgmtError recv_mgmt_request(void *buf, size_t buflen, OpType optype, ...);
+  msglen = mgmt_message_length(std::forward<Params>(params)...);
+  msgbuf = static_cast<char *>(ats_malloc(msglen + MGMT_HDR_LENGTH));
 
-// Marshall and send a response, prefixing the message length as a MGMT_MARSHALL_INT.
-TSMgmtError send_mgmt_response(int fd, OpType optype, ...);
+  // Add data header
+  uint32_t hdr = mgmt_message_build_hdr(MGMT_DATA_TYPE, msglen);
+  memcpy(static_cast<char *>(msgbuf), &hdr, MGMT_HDR_LENGTH);
 
-// Parse a response message from a buffer.
-TSMgmtError recv_mgmt_response(void *buf, size_t buflen, OpType optype, ...);
+  // Now marshall the message itself.
+  if (mgmt_message_marshall(static_cast<char *>(msgbuf) + MGMT_HDR_LENGTH, msglen, std::forward<Params>(params)...) == -1) {
+    return TS_ERR_PARAMS;
+  }
+  return snd.send(msgbuf, msglen + MGMT_HDR_LENGTH);
+}
+
+template <typename... Params>
+TSMgmtError
+send_mgmt_request(int fd, OpType optype, Params &&... params)
+{
+  MgmtMarshallInt msglen;
+  MgmtMarshallData req{nullptr, 0};
+
+  // Figure out the payload length.
+  msglen = mgmt_message_length(std::forward<Params>(params)...);
+
+  ink_assert(msglen >= 0);
+
+  req.ptr = static_cast<char *>(ats_malloc(msglen));
+  req.len = msglen;
+
+  // Marshall the message itself.
+  if (mgmt_message_marshall(req.ptr, req.len, std::forward<Params>(params)...) == -1) {
+    ats_free(req.ptr);
+    return TS_ERR_PARAMS;
+  }
+
+  // Send the response as the payload of a data object.
+  if (mgmt_message_write(fd, &req) == -1) {
+    ats_free(req.ptr);
+    return TS_ERR_NET_WRITE;
+  }
+
+  ats_free(req.ptr);
+  return TS_ERR_OKAY;
+}
+
+// Parse a request or response message from a buffer.
+template <typename... Params>
+TSMgmtError
+parse_mgmt_message(void *buf, size_t buflen, OpType optype, Params &&... params)
+{
+  ssize_t err;
+
+  err = mgmt_message_parse(buf, buflen, std::forward<Params>(params)...);
+  return (err == -1) ? TS_ERR_PARAMS : TS_ERR_OKAY;
+}
 
 // Pull a management message (either request or response) off the wire.
 TSMgmtError recv_mgmt_message(int fd, MgmtMarshallData &msg);
+
+// Marshall and send a response, prefixing the message length as a MGMT_MARSHALL_INT.
+// Send a management message response. We don't need to worry about retransmitting the message if we get
+// disconnected, so this is much simpler. We can directly marshall the response as a data object.
+// Note, there is no need to send the optype as this is a response not a request.
+template <typename... Params>
+TSMgmtError
+send_mgmt_response(int fd, OpType optype, Params &&... params)
+{
+  MgmtMarshallInt msglen;
+  MgmtMarshallData reply{nullptr, 0};
+
+  msglen = mgmt_message_length(std::forward<Params>(params)...);
+
+  ink_assert(msglen >= 0);
+
+  reply.ptr = static_cast<char *>(ats_malloc(msglen));
+  reply.len = msglen;
+
+  // Marshall the message itself.
+  if (mgmt_message_marshall(reply.ptr, reply.len, std::forward<Params>(params)...) == -1) {
+    return TS_ERR_PARAMS;
+  }
+
+  // Send the response as the payload of a data object.
+  if (mgmt_message_write(fd, &reply) == -1) {
+    ats_free(reply.ptr);
+    return TS_ERR_NET_WRITE;
+  }
+
+  ats_free(reply.ptr);
+  return TS_ERR_OKAY;
+}
+
+// Marshall and send an error respose for this operation type.
+TSMgmtError send_mgmt_error(int fd, OpType op, TSMgmtError error);
 
 // Extract the first MGMT_MARSHALL_INT from the buffered message. This is the OpType.
 OpType extract_mgmt_request_optype(void *msg, size_t msglen);

--- a/mgmt/utils/test_marshall.cc
+++ b/mgmt/utils/test_marshall.cc
@@ -46,22 +46,6 @@
     }                                                                                                                \
   } while (0)
 
-const MgmtMarshallType inval[] = {(MgmtMarshallType)1568};
-
-const MgmtMarshallType ifields[] = {MGMT_MARSHALL_INT, MGMT_MARSHALL_LONG};
-
-const MgmtMarshallType sfields[] = {
-  MGMT_MARSHALL_STRING,
-};
-
-const MgmtMarshallType dfields[] = {
-  MGMT_MARSHALL_DATA,
-};
-
-const MgmtMarshallType afields[] = {
-  MGMT_MARSHALL_DATA, MGMT_MARSHALL_INT, MGMT_MARSHALL_LONG, MGMT_MARSHALL_STRING, MGMT_MARSHALL_LONG, MGMT_MARSHALL_LONG,
-};
-
 const char alpha[]       = "abcdefghijklmnopqrstuvwxyz0123456789";
 const char *stringvals[] = {nullptr, "", "randomstring"};
 
@@ -166,25 +150,26 @@ REGRESSION_TEST(MessageReadWriteA)(RegressionTest *t, int /* atype ATS_UNUSED */
   // Check invalid Fd write. ToDo: Commented out, see TS-3052.
   // CHECK_EQ(mgmt_message_write(FD_SETSIZE - 1, ifields, countof(ifields), &mint, &mlong), -1);
 
-  CHECK_EQ(mgmt_message_write(clientfd, ifields, countof(ifields), &mint, &mlong), 12);
+  ssize_t len = mgmt_message_length(&mint, &mlong);
+  CHECK_EQ(mgmt_message_write(clientfd, &mint, &mlong), len);
 
   mint  = 0;
   mlong = 0;
-  CHECK_EQ(mgmt_message_read(serverfd, ifields, countof(ifields), &mint, &mlong), 12);
+  CHECK_EQ(mgmt_message_read(serverfd, &mint, &mlong), len);
   CHECK_VALUE(mint, 99, "%" PRId32);
   CHECK_VALUE(mlong, (MgmtMarshallLong)(&listenfd), "%" PRId64);
 
   // Marshall a string.
   for (unsigned i = 0; i < countof(stringvals); ++i) {
     const char *s = stringvals[i];
-    size_t len    = 4 /* length */ + (s ? strlen(s) : 0) /* bytes */ + 1 /* NULL */;
+    len           = MGMT_HDR_LENGTH /* length */ + (s ? strlen(s) : 0) /* bytes */ + 1 /* NULL */;
 
     mstring = s ? ats_strdup(s) : nullptr;
-    CHECK_EQ(mgmt_message_write(clientfd, sfields, countof(sfields), &mstring), len);
+    CHECK_EQ(mgmt_message_write(clientfd, &mstring), len);
     ats_free(mstring);
     mstring = nullptr;
 
-    CHECK_EQ(mgmt_message_read(serverfd, sfields, countof(sfields), &mstring), len);
+    CHECK_EQ(mgmt_message_read(serverfd, &mstring), len);
     CHECK_STRING(s, mstring);
     ats_free(mstring);
     mstring = nullptr;
@@ -193,11 +178,13 @@ REGRESSION_TEST(MessageReadWriteA)(RegressionTest *t, int /* atype ATS_UNUSED */
   // Marshall data.
   mdata.ptr = ats_strdup(alpha);
   mdata.len = strlen(alpha);
-  CHECK_EQ(mgmt_message_write(clientfd, dfields, countof(dfields), &mdata), 4 + strlen(alpha));
+
+  len = mgmt_message_length(&mdata);
+  CHECK_EQ(mgmt_message_write(clientfd, &mdata), len);
   ats_free(mdata.ptr);
   ink_zero(mdata);
 
-  CHECK_EQ(mgmt_message_read(serverfd, dfields, countof(dfields), &mdata), 4 + strlen(alpha));
+  CHECK_EQ(mgmt_message_read(serverfd, &mdata), len);
   CHECK_VALUE(mdata.len, strlen(alpha), "%zu");
   box.check(memcmp(mdata.ptr, alpha, strlen(alpha)) == 0, "unexpected mdata contents");
   ats_free(mdata.ptr);
@@ -219,35 +206,32 @@ REGRESSION_TEST(MessageMarshall)(RegressionTest *t, int /* atype ATS_UNUSED */, 
   MgmtMarshallString mstring = nullptr;
   MgmtMarshallData mdata     = {nullptr, 0};
 
-  // Parse empty message.
-  CHECK_EQ(mgmt_message_parse(nullptr, 0, nullptr, 0), 0);
-
-  // Marshall empty message.
-  CHECK_EQ(mgmt_message_marshall(nullptr, 0, nullptr, 0), 0);
-
   // Marshall some integral types.
   mint  = -156;
   mlong = UINT32_MAX;
-  CHECK_EQ(mgmt_message_marshall(msgbuf, 1, ifields, countof(ifields), &mint, &mlong), -1);
-  CHECK_EQ(mgmt_message_marshall(msgbuf, sizeof(msgbuf), ifields, countof(ifields), &mint, &mlong), 12);
-  CHECK_EQ(mgmt_message_parse(msgbuf, 1, ifields, countof(ifields), &mint, &mlong), -1);
-  CHECK_EQ(mgmt_message_parse(msgbuf, sizeof(msgbuf), ifields, countof(ifields), &mint, &mlong), 12);
+
+  ssize_t len = mgmt_message_length(&mint, &mlong);
+  CHECK_EQ(mgmt_message_marshall(msgbuf, 1, &mint, &mlong), -1);
+  CHECK_EQ(mgmt_message_marshall(msgbuf, sizeof(msgbuf), &mint, &mlong), len);
+  CHECK_EQ(mgmt_message_parse(msgbuf, 1, &mint, &mlong), -1);
+  CHECK_EQ(mgmt_message_parse(msgbuf, sizeof(msgbuf), &mint, &mlong), len);
   CHECK_VALUE(mint, -156, "%" PRId32);
   CHECK_VALUE(mlong, static_cast<MgmtMarshallLong>(UINT32_MAX), "%" PRId64);
 
   // Marshall a string.
   for (unsigned i = 0; i < countof(stringvals); ++i) {
     const char *s = stringvals[i];
-    size_t len    = 4 /* length */ + (s ? strlen(s) : 0) /* bytes */ + 1 /* NULL */;
+    len           = MGMT_HDR_LENGTH /* length */ + (s ? strlen(s) : 0) /* bytes */ + 1 /* NULL */;
 
     mstring = s ? ats_strdup(s) : nullptr;
-    CHECK_EQ(mgmt_message_marshall(msgbuf, 1, sfields, countof(sfields), &mstring), -1);
-    CHECK_EQ(mgmt_message_marshall(msgbuf, sizeof(msgbuf), sfields, countof(sfields), &mstring), len);
+    CHECK_EQ(mgmt_message_marshall(msgbuf, 1, &mstring), -1);
+    CHECK_EQ(mgmt_message_marshall(msgbuf, sizeof(msgbuf), &mstring), len);
     ats_free(mstring);
     mstring = nullptr;
 
-    CHECK_EQ(mgmt_message_parse(msgbuf, 1, sfields, countof(sfields), &mstring), -1);
-    CHECK_EQ(mgmt_message_parse(msgbuf, sizeof(msgbuf), sfields, countof(sfields), &mstring), len);
+    CHECK_EQ(mgmt_message_parse(msgbuf, 1, &mstring), -1);
+    CHECK_EQ(mgmt_message_parse(msgbuf, sizeof(msgbuf), &mstring), len);
+
     CHECK_STRING(s, mstring);
     ats_free(mstring);
     mstring = nullptr;
@@ -256,24 +240,27 @@ REGRESSION_TEST(MessageMarshall)(RegressionTest *t, int /* atype ATS_UNUSED */, 
   // Marshall data.
   mdata.ptr = ats_strdup(alpha);
   mdata.len = strlen(alpha);
-  CHECK_EQ(mgmt_message_marshall(msgbuf, 10, dfields, countof(dfields), &mdata), -1);
-  CHECK_EQ(mgmt_message_marshall(msgbuf, sizeof(msgbuf), dfields, countof(dfields), &mdata), 4 + strlen(alpha));
+
+  len = mgmt_message_length(&mdata);
+  CHECK_EQ(mgmt_message_marshall(msgbuf, 10, &mdata), -1);
+  CHECK_EQ(mgmt_message_marshall(msgbuf, sizeof(msgbuf), &mdata), len);
   ats_free(mdata.ptr);
   ink_zero(mdata);
 
-  CHECK_EQ(mgmt_message_parse(msgbuf, strlen(alpha), dfields, countof(dfields), &mdata), -1);
-  CHECK_EQ(mgmt_message_parse(msgbuf, strlen(alpha) + 4, dfields, countof(dfields), &mdata), 4 + strlen(alpha));
+  CHECK_EQ(mgmt_message_parse(msgbuf, strlen(alpha), &mdata), -1);
+  CHECK_EQ(mgmt_message_parse(msgbuf, len, &mdata), len);
   CHECK_VALUE(mdata.len, strlen(alpha), "%zu");
   box.check(memcmp(mdata.ptr, alpha, strlen(alpha)) == 0, "unexpected mdata contents");
   ats_free(mdata.ptr);
   ink_zero(mdata);
 
   // Marshall empty data.
-  CHECK_EQ(mgmt_message_marshall(msgbuf, sizeof(msgbuf), dfields, countof(dfields), &mdata), 4);
+  len = mgmt_message_length(&mdata);
+  CHECK_EQ(mgmt_message_marshall(msgbuf, sizeof(msgbuf), &mdata), len);
 
   mdata.ptr = (void *)99;
   mdata.len = 1000;
-  CHECK_EQ(mgmt_message_parse(msgbuf, sizeof(msgbuf), dfields, countof(dfields), &mdata), 4);
+  CHECK_EQ(mgmt_message_parse(msgbuf, sizeof(msgbuf), &mdata), len);
   CHECK_VALUE(mdata.ptr, (void *)nullptr, "%p");
   CHECK_VALUE(mdata.len, (size_t)0, "%zu");
 }
@@ -287,37 +274,31 @@ REGRESSION_TEST(MessageLength)(RegressionTest *t, int /* atype ATS_UNUSED */, in
   MgmtMarshallString mstring = nullptr;
   MgmtMarshallData mdata     = {nullptr, 0};
 
-  // Check invalid marshall type.
-  CHECK_EQ(mgmt_message_length(inval, countof(inval), NULL), -1);
-
-  // Check empty types array.
-  CHECK_EQ(mgmt_message_length(nullptr, 0), 0);
-
-  CHECK_EQ(mgmt_message_length(ifields, countof(ifields), &mint, &mlong), 12);
+  CHECK_EQ(mgmt_message_length(&mint, &mlong), MGMT_INT_LENGTH + MGMT_HDR_LENGTH + MGMT_LONG_LENGTH + MGMT_HDR_LENGTH);
 
   // string messages include a 4-byte length and the NULL
   mstring = (char *)"foo";
-  CHECK_EQ(mgmt_message_length(sfields, countof(sfields), &mstring), sizeof("foo") + 4);
+  CHECK_EQ(mgmt_message_length(&mstring), sizeof("foo") + MGMT_HDR_LENGTH);
 
   // NULL strings are the same as empty strings ...
   mstring = nullptr;
-  CHECK_EQ(mgmt_message_length(sfields, countof(sfields), &mstring), 4 + 1);
+  CHECK_EQ(mgmt_message_length(&mstring), 1 + MGMT_HDR_LENGTH);
   mstring = (char *)"";
-  CHECK_EQ(mgmt_message_length(sfields, countof(sfields), &mstring), 4 + 1);
+  CHECK_EQ(mgmt_message_length(&mstring), 1 + MGMT_HDR_LENGTH);
 
   // data fields include a 4-byte length. We don't go looking at the data in this case.
   mdata.len = 99;
   mdata.ptr = nullptr;
-  CHECK_EQ(mgmt_message_length(dfields, countof(dfields), &mdata), 99 + 4);
+  CHECK_EQ(mgmt_message_length(&mdata), 99 + MGMT_HDR_LENGTH);
 
   mstring   = (char *)"all fields";
   mdata.len = 31;
-  CHECK_EQ(mgmt_message_length(afields, countof(afields), &mdata, &mint, &mlong, &mstring, &mlong, &mlong),
-           31 + 4 + 4 + 8 + sizeof("all fields") + 4 + 8 + 8);
+  CHECK_EQ(mgmt_message_length(&mdata, &mint, &mlong, &mstring, &mlong, &mlong),
+           31 + 4 + 8 + sizeof("all fields") + 8 + 8 + 6 * MGMT_HDR_LENGTH);
 
   mdata.ptr = nullptr;
   mdata.len = 0;
-  CHECK_EQ(mgmt_message_length(dfields, countof(dfields), &mdata), 4);
+  CHECK_EQ(mgmt_message_length(&mdata), MGMT_HDR_LENGTH);
 }
 
 int

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -2079,9 +2079,8 @@ mgmt_lifecycle_msg_callback(void *, char *data, int len)
   MgmtInt op;
   MgmtMarshallString tag;
   MgmtMarshallData payload;
-  static const MgmtMarshallType fields[] = {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING, MGMT_MARSHALL_DATA};
 
-  if (mgmt_message_parse(data, len, fields, countof(fields), &op, &tag, &payload) == -1) {
+  if (mgmt_message_parse(data, len, &op, &tag, &payload) == -1) {
     Error("Plugin message - RPC parsing error - message discarded.");
   } else {
     msg.tag       = tag;


### PR DESCRIPTION
Replaces variable argument lists in serialization with variadic templates. Since we no longer need to predefine a schema for rpc messages sent, we can change from hard coded callbacks to a registration system. RPC protocol has been modified such that a 32-bit header is always sent before any parameters. The leading 8 bits indicate the type (ie int, string ...) and the last 24 bits indicate the length in bytes. 

Needed by #3505.

- serialization functions are type-safe at compile time. 
- The main benefit of doing this is that the hard coded schema for `requests` and `responses` in `NetworkMessage.cc` is no longer needed. 
- requests/responses are now parsed in the same manner. 