### PR TITLE
Acquire mutex lock of Http2Stream before starting new transaction

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -336,6 +336,7 @@ rcv_headers_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
 
     // Set up the State Machine
     if (!empty_request) {
+      SCOPED_MUTEX_LOCK(stream_lock, stream->mutex, this_ethread());
       stream->new_transaction();
       // Send request header to SM
       stream->send_request(cstate);
@@ -810,6 +811,7 @@ rcv_continuation_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
     }
 
     // Set up the State Machine
+    SCOPED_MUTEX_LOCK(stream_lock, stream->mutex, this_ethread());
     stream->new_transaction();
     // Send request header to SM
     stream->send_request(cstate);
@@ -1590,6 +1592,8 @@ Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url, con
     h2_hdr.destroy();
     return;
   }
+
+  SCOPED_MUTEX_LOCK(stream_lock, stream->mutex, this_ethread());
   if (Http2::stream_priority_enabled) {
     Http2DependencyTree::Node *node = this->dependency_tree->find(id);
     if (node != nullptr) {


### PR DESCRIPTION
After #3141, there're no guarantee of mutex of HttpSM is held by some thread.

- Fix #3497 
- 7.x backport candidate