### PR TITLE
Fix remap to use ats_ip_range_parse for better range parsing.

### DIFF
--- a/proxy/http/remap/AclFiltering.cc
+++ b/proxy/http/remap/AclFiltering.cc
@@ -112,13 +112,13 @@ acl_filter_rule::print()
   printf("src_ip_cnt=%d\n", src_ip_cnt);
   for (i = 0; i < src_ip_cnt; i++) {
     ip_text_buffer b1, b2;
-    printf("%s - %s", ats_ip_ntop(&src_ip_array[i].start.sa, b1, sizeof(b1)), ats_ip_ntop(&src_ip_array[i].end.sa, b2, sizeof(b2)));
+    printf("%s - %s", src_ip_array[i].start.toString(b1, sizeof(b1)), src_ip_array[i].end.toString(b2, sizeof(b2)));
   }
   printf("\n");
   printf("in_ip_cnt=%d\n", in_ip_cnt);
   for (i = 0; i < in_ip_cnt; i++) {
     ip_text_buffer b1, b2;
-    printf("%s - %s", ats_ip_ntop(&in_ip_array[i].start.sa, b1, sizeof(b1)), ats_ip_ntop(&in_ip_array[i].end.sa, b2, sizeof(b2)));
+    printf("%s - %s", in_ip_array[i].start.toString(b1, sizeof(b1)), in_ip_array[i].end.toString(b2, sizeof(b2)));
   }
   printf("\n");
   for (i = 0; i < argc; i++) {

--- a/proxy/http/remap/AclFiltering.h
+++ b/proxy/http/remap/AclFiltering.h
@@ -38,15 +38,15 @@ static int const ACL_FILTER_MAX_IN_IP  = 8;
 static int const ACL_FILTER_MAX_ARGV   = 512;
 
 struct src_ip_info_t {
-  IpEndpoint start; ///< Minimum value in range.
-  IpEndpoint end;   ///< Maximum value in range.
-  bool invert;      ///< Should we "invert" the meaning of this IP range ("not in range")
+  IpAddr start; ///< Minimum value in range.
+  IpAddr end;   ///< Maximum value in range.
+  bool invert;  ///< Should we "invert" the meaning of this IP range ("not in range")
 
   void
   reset()
   {
-    ink_zero(start);
-    ink_zero(end);
+    start.invalidate();
+    end.invalidate();
     invert = false;
   }
 
@@ -54,7 +54,8 @@ struct src_ip_info_t {
   bool
   contains(IpEndpoint const &ip)
   {
-    return ats_ip_addr_cmp(&start, &ip) <= 0 && ats_ip_addr_cmp(&ip, &end) <= 0;
+    IpAddr addr{ip};
+    return addr.cmp(start) >= 0 && addr.cmp(end) <= 0;
   }
 };
 

--- a/proxy/http/remap/RemapConfig.cc
+++ b/proxy/http/remap/RemapConfig.cc
@@ -420,7 +420,6 @@ remap_validate_filter_args(acl_filter_rule **rule_pp, const char **argv, int arg
   acl_filter_rule *rule;
   unsigned long ul;
   const char *argptr;
-  char tmpbuf[1024];
   src_ip_info_t *ipi;
   int i, j;
   bool new_rule_flg = false;
@@ -505,9 +504,7 @@ remap_validate_filter_args(acl_filter_rule **rule_pp, const char **argv, int arg
       if (ul & REMAP_OPTFLG_INVERT) {
         ipi->invert = true;
       }
-      ink_strlcpy(tmpbuf, argptr, sizeof(tmpbuf));
-      // important! use copy of argument
-      if (ExtractIpRange(tmpbuf, &ipi->start.sa, &ipi->end.sa) != nullptr) {
+      if (ats_ip_range_parse(argptr, ipi->start, ipi->end) != 0) {
         Debug("url_rewrite", "[validate_filter_args] Unable to parse IP value in %s", argv[i]);
         snprintf(errStrBuf, errStrBufSize, "Unable to parse IP value in %s", argv[i]);
         errStrBuf[errStrBufSize - 1] = 0;
@@ -545,9 +542,8 @@ remap_validate_filter_args(acl_filter_rule **rule_pp, const char **argv, int arg
       if (ul & REMAP_OPTFLG_INVERT) {
         ipi->invert = true;
       }
-      ink_strlcpy(tmpbuf, argptr, sizeof(tmpbuf));
       // important! use copy of argument
-      if (ExtractIpRange(tmpbuf, &ipi->start.sa, &ipi->end.sa) != nullptr) {
+      if (ats_ip_range_parse(argptr, ipi->start, ipi->end) != 0) {
         Debug("url_rewrite", "[validate_filter_args] Unable to parse IP value in %s", argv[i]);
         snprintf(errStrBuf, errStrBufSize, "Unable to parse IP value in %s", argv[i]);
         errStrBuf[errStrBufSize - 1] = 0;

--- a/proxy/http/remap/UrlRewrite.cc
+++ b/proxy/http/remap/UrlRewrite.cc
@@ -441,8 +441,8 @@ UrlRewrite::PerformACLFiltering(HttpTransact::State *s, url_mapping *map)
           if (is_debug_tag_set("url_rewrite")) {
             char buf1[128], buf2[128], buf3[128];
             ats_ip_ntop(incoming_addr, buf1, sizeof(buf1));
-            ats_ip_ntop(rp->in_ip_array[j].start, buf2, sizeof(buf2));
-            ats_ip_ntop(rp->in_ip_array[j].end, buf3, sizeof(buf3));
+            rp->in_ip_array[j].start.toString(buf2, sizeof(buf2));
+            rp->in_ip_array[j].end.toString(buf3, sizeof(buf3));
             Debug("url_rewrite", "Trying to match incoming address %s in range %s - %s.", buf1, buf2, buf3);
           }
           bool in_range = rp->in_ip_array[j].contains(incoming_addr);


### PR DESCRIPTION
As with #3448, `ExtractIpRange` is replaced by `ats_ip_range_parse` to avoid copies and support ranges and networks for IPv4 and IPv6.