### PR TITLE
Parent Selection -- Make self-detection configurable.

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -1306,6 +1306,11 @@ Parent Proxy Configuration
 
 .. ts:cv:: CONFIG proxy.local.http.parent_proxy.disable_connect_tunneling INT 0
 
+.. ts:cv:: CONFIG proxy.config.http.parent_proxy.self_detect INT 1
+
+   Filter out hosts that are determined to be the same as the current host, e.g., localhost,
+   that have been specified in any parent and secondary_parent lists in the parent.config file.
+
 HTTP Connection Timeouts
 ========================
 

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -444,6 +444,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.http.parent_proxy.mark_down_hostdb", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.http.parent_proxy.self_detect", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
   {RECT_CONFIG, "proxy.config.http.forward.proxy_auth_to_parent", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
 


### PR DESCRIPTION
* Adds a new configuration option "proxy.config.http.parent_proxy.self_detect" that
  enables "1" or disables "0" the self detection filtering of parent lists
  specified in parent.config. The default is "1".

* The self detect filtering only filters on the host rather than the host:port so this
  filtering can interfere with certain configurations such as test/dev hosts
  that have multiple instances of ATS running on different ports.

* Also, modified the string-tokenizer delimiter in PreProcessParents() to include
  ";, " rather than just ";" since the ProcessParents() delimiter includes these characters.