### PR TITLE
Multiplexer plugin causing unnecessary ASAN alert

### DIFF
--- a/plugins/experimental/multiplexer/original-request.cc
+++ b/plugins/experimental/multiplexer/original-request.cc
@@ -34,7 +34,6 @@ get(const TSMBuffer &b, const TSMLoc &l, const T &t)
 
   assert(buffer != nullptr);
   assert(length > 0);
-  assert(strlen(buffer) >= static_cast<unsigned int>(length));
 
   return std::string(buffer, length);
 }
@@ -47,7 +46,6 @@ get(const TSMBuffer &b, const TSMLoc &l, const TSMLoc &f, const int i = 0)
 
   assert(buffer != nullptr);
   assert(length > 0);
-  assert(strlen(buffer) >= static_cast<unsigned int>(length));
 
   return std::string(buffer, length);
 }


### PR DESCRIPTION
This is causing ASAN to freak out, and it is actually not useful.