### PR TITLE
Add time option to traffic_ctl host down.  

### DIFF
--- a/cmd/traffic_ctl/host.cc
+++ b/cmd/traffic_ctl/host.cc
@@ -52,12 +52,19 @@ status_get(unsigned argc, const char **argv)
 static int
 status_down(unsigned argc, const char **argv)
 {
-  if (!CtrlProcessArguments(argc, argv, nullptr, 0) || n_file_arguments < 1) {
-    return CtrlCommandUsage("host down HOST  value", nullptr, 0);
+  int down_time     = 0;
+  const char *usage = "host down HOST [OPTIONS]";
+
+  const ArgumentDescription opts[] = {
+    {"time", 'I', "number of seconds that a host is marked down", "I", &down_time, nullptr, nullptr}};
+
+  if (!CtrlProcessArguments(argc, argv, opts, countof(opts)) || n_file_arguments < 1) {
+    return CtrlCommandUsage(usage, opts, countof(opts));
   }
+
   TSMgmtError error = TS_ERR_OKAY;
   for (unsigned i = 0; i < n_file_arguments; ++i) {
-    error = TSHostStatusSetDown(file_arguments[i]);
+    error = TSHostStatusSetDown(file_arguments[i], down_time);
     if (error != TS_ERR_OKAY) {
       CtrlMgmtError(error, "failed to set %s", file_arguments[i]);
       return CTRL_EX_ERROR;

--- a/doc/appendices/command-line/traffic_ctl.en.rst
+++ b/doc/appendices/command-line/traffic_ctl.en.rst
@@ -258,9 +258,12 @@ traffic_ctl host
     Get the current status of the hosts used in parent.config as a next hop in a multi-tiered cache heirarchy.  The value 0 or 1 is returned indicating that the host is marked as down '0' or marked as up '1'.  If a host is marked as down, it will not be used as the next hop parent, another host marked as up will be chosen.
 
 .. program:: traffic_ctl host
-.. option:: down HOSTNAME [HOSTNAME ...]
+.. option:: down --time seconds HOSTNAME [HOSTNAME ...]
 
     Marks the listed hosts as down so that they will not be chosen as a next hop parent.
+    If the --time option is included, the host is marked down for the specified number of 
+    seconds after which the host will automatically be marked up.  0 seconds marks the host 
+    down indefinately until marked up manually and is the default.
 
 .. program:: traffic_ctl host
 .. option:: up HOSTNAME [HOSTNAME ...]

--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -122,16 +122,16 @@ LocalManager::rollLogFiles()
 }
 
 void
-LocalManager::hostStatusSetDown(const char *name)
+LocalManager::hostStatusSetDown(const char *marshalled_req, int len)
 {
-  signalEvent(MGMT_EVENT_HOST_STATUS_DOWN, name);
+  signalEvent(MGMT_EVENT_HOST_STATUS_DOWN, marshalled_req, len);
   return;
 }
 
 void
-LocalManager::hostStatusSetUp(const char *name)
+LocalManager::hostStatusSetUp(const char *marshalled_req)
 {
-  signalEvent(MGMT_EVENT_HOST_STATUS_UP, name);
+  signalEvent(MGMT_EVENT_HOST_STATUS_UP, marshalled_req);
   return;
 }
 

--- a/mgmt/LocalManager.h
+++ b/mgmt/LocalManager.h
@@ -94,8 +94,8 @@ public:
   void processDrain(int to_drain = 1);
   void rollLogFiles();
   void clearStats(const char *name = nullptr);
-  void hostStatusSetDown(const char *name);
-  void hostStatusSetUp(const char *name);
+  void hostStatusSetDown(const char *marshalled_req, int len);
+  void hostStatusSetUp(const char *marshalled_req);
 
   bool processRunning();
 

--- a/mgmt/api/CoreAPI.cc
+++ b/mgmt/api/CoreAPI.cc
@@ -884,11 +884,14 @@ EventSignalCbUnregister(const char *event_name, TSEventSignalFunc func)
  * HostStatusSetDown
  *-------------------------------------------------------------------------
  * Sets the HOST status to Down
+ *
+ * 'marshalled_req' is marshalled here, (host_name and down_time).
+ * 'len' is the length of the 'req' marshaled data.
  */
 TSMgmtError
-HostStatusSetDown(const char *name)
+HostStatusSetDown(const char *marshalled_req, int len)
 {
-  lmgmt->hostStatusSetDown(name);
+  lmgmt->hostStatusSetDown(marshalled_req, len);
   return TS_ERR_OKAY;
 }
 
@@ -896,11 +899,13 @@ HostStatusSetDown(const char *name)
  * HostStatusSetUp
  *-------------------------------------------------------------------------
  * Sets the HOST status to Up
+ *
+ * 'marshalled_req' is marshalled here, host_name.
  */
 TSMgmtError
-HostStatusSetUp(const char *name)
+HostStatusSetUp(const char *marshalled_req)
 {
-  lmgmt->hostStatusSetUp(name);
+  lmgmt->hostStatusSetUp(marshalled_req);
   return TS_ERR_OKAY;
 }
 

--- a/mgmt/api/CoreAPI.h
+++ b/mgmt/api/CoreAPI.h
@@ -82,6 +82,6 @@ TSMgmtError EventIsActive(const char *event_name, bool *is_current);
 TSMgmtError EventSignalCbRegister(const char *event_name, TSEventSignalFunc func, void *data);
 TSMgmtError EventSignalCbUnregister(const char *event_name, TSEventSignalFunc func);
 
-TSMgmtError HostStatusSetDown(const char *name);
-TSMgmtError HostStatusSetUp(const char *name);
+TSMgmtError HostStatusSetDown(const char *host_name, int down_time);
+TSMgmtError HostStatusSetUp(const char *host_name);
 TSMgmtError StatsReset(const char *name = nullptr);

--- a/mgmt/api/CoreAPIRemote.cc
+++ b/mgmt/api/CoreAPIRemote.cc
@@ -1033,13 +1033,15 @@ EventSignalCbUnregister(const char *event_name, TSEventSignalFunc func)
 }
 
 TSMgmtError
-HostStatusSetDown(const char *host_name)
+HostStatusSetDown(const char *host_name, int down_time)
 {
+  fprintf(stderr, "%s:%s:%d - host_name: %s, down_time: %d\n", __FILE__, __func__, __LINE__, host_name, down_time);
   TSMgmtError ret         = TS_ERR_PARAMS;
   OpType op               = OpType::HOST_STATUS_DOWN;
   MgmtMarshallString name = const_cast<MgmtMarshallString>(host_name);
+  MgmtMarshallInt dtime   = down_time;
 
-  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, op, &op, &name);
+  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, op, &op, &name, &dtime);
   return (ret == TS_ERR_OKAY) ? parse_generic_response(op, main_socket_fd) : ret;
 }
 

--- a/mgmt/api/INKMgmtAPI.cc
+++ b/mgmt/api/INKMgmtAPI.cc
@@ -416,15 +416,15 @@ TSRecordEleDestroy(TSRecordEle *ele)
 
 /*--- host status operations ----------------------------------------------- */
 tsapi TSMgmtError
-TSHostStatusSetUp(const char *name)
+TSHostStatusSetUp(const char *host_name)
 {
-  return HostStatusSetUp(name);
+  return HostStatusSetUp(host_name);
 }
 
 tsapi TSMgmtError
-TSHostStatusSetDown(const char *name)
+TSHostStatusSetDown(const char *host_name, int down_time)
 {
-  return HostStatusSetDown(name);
+  return HostStatusSetDown(host_name, down_time);
 }
 
 /*--- statistics operations ----------------------------------------------- */

--- a/mgmt/api/NetworkMessage.cc
+++ b/mgmt/api/NetworkMessage.cc
@@ -63,7 +63,7 @@ static const struct NetCmdOperation requests[] = {
   /* RECORD_DESCRIBE_CONFIG     */ {3, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING, MGMT_MARSHALL_INT}},
   /* LIFECYCLE_MESSAGE          */ {3, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING, MGMT_MARSHALL_DATA}},
   /* HOST_STATUS_HOST_UP        */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
-  /* HOST_STATUS_HOST_DOWN      */ {2, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING}},
+  /* HOST_STATUS_HOST_DOWN      */ {3, {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING, MGMT_MARSHALL_INT}},
 };
 
 // Responses always begin with a TSMgmtError code, followed by additional fields.
@@ -178,6 +178,15 @@ send_mgmt_request(int fd, OpType optype, ...)
   }
 
   va_end(ap);
+
+  MgmtMarshallInt op;
+  MgmtMarshallString name;
+  int down_time;
+  static const MgmtMarshallType fieldso[] = {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING, MGMT_MARSHALL_INT};
+
+  if (mgmt_message_parse(static_cast<void *>(req.ptr), msglen, fieldso, countof(fieldso), &op, &name, &down_time) == -1) {
+    printf("Plugin message - RPC parsing error - message discarded.\n");
+  }
 
   // Send the response as the payload of a data object.
   if (mgmt_message_write(fd, fields, countof(fields), &req) == -1) {

--- a/mgmt/api/TSControlMain.cc
+++ b/mgmt/api/TSControlMain.cc
@@ -832,10 +832,11 @@ handle_host_status_down(int fd, void *req, size_t reqlen)
   OpType optype;
   MgmtMarshallString name = nullptr;
   MgmtMarshallInt err;
+  MgmtMarshallInt down_time;
 
-  err = recv_mgmt_request(req, reqlen, OpType::HOST_STATUS_DOWN, &optype, &name);
+  err = recv_mgmt_request(req, reqlen, OpType::HOST_STATUS_DOWN, &optype, &name, &down_time);
   if (err == TS_ERR_OKAY) {
-    err = HostStatusSetDown(name);
+    lmgmt->signalEvent(MGMT_EVENT_HOST_STATUS_DOWN, static_cast<char *>(req), reqlen);
   }
 
   ats_free(name);

--- a/mgmt/api/include/mgmtapi.h
+++ b/mgmt/api/include/mgmtapi.h
@@ -428,8 +428,8 @@ tsapi TSMgmtError TSReadFromUrl(char *url, char **header, int *headerSize, char 
  * NOTE: header and headerSize can be NULL
  */
 tsapi TSMgmtError TSReadFromUrlEx(const char *url, char **header, int *headerSize, char **body, int *bodySize, int timeout);
-tsapi TSMgmtError TSHostStatusSetUp(const char *name);
-tsapi TSMgmtError TSHostStatusSetDown(const char *name);
+tsapi TSMgmtError TSHostStatusSetUp(const char *host_name);
+tsapi TSMgmtError TSHostStatusSetDown(const char *host_name, int down_time);
 /*--- statistics operations -----------------------------------------------*/
 /* TSStatsReset: sets all the statistics variables to their default values
  * Outpue: TSErrr

--- a/proxy/HostStatus.h
+++ b/proxy/HostStatus.h
@@ -40,6 +40,12 @@ enum HostStatus_t {
   HOST_STATUS_UP,
 };
 
+struct HostStatRec_t {
+  HostStatus_t status;
+  time_t marked_down;     // the time that this host was marked down.
+  unsigned int down_time; // number of seconds that the host should be down, 0 is indefinately
+};
+
 const std::string stat_prefix = "host_status.";
 
 /**
@@ -54,7 +60,7 @@ struct HostStatus {
     static HostStatus instance;
     return instance;
   }
-  void setHostStatus(const char *name, const HostStatus_t status);
+  void setHostStatus(const char *name, const HostStatus_t status, const unsigned int down_time);
   HostStatus_t getHostStatus(const char *name);
   void createHostStat(const char *name);
 

--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -370,7 +370,7 @@ ParentRecord::PreProcessParents(const char *val, const int line_num, char *buf, 
         } else {
           Debug("parent_select", "token: %s, matches this machine.  Marking down self from parent list at line %d", fqdn, line_num);
           hs.createHostStat(fqdn);
-          hs.setHostStatus(fqdn, HostStatus_t::HOST_STATUS_DOWN);
+          hs.setHostStatus(fqdn, HostStatus_t::HOST_STATUS_DOWN, 0);
         }
       }
     } else {
@@ -383,7 +383,7 @@ ParentRecord::PreProcessParents(const char *val, const int line_num, char *buf, 
           Debug("parent_select", "token: %s, matches this machine.  Marking down self from parent list at line %d", token,
                 line_num);
           hs.createHostStat(token);
-          hs.setHostStatus(token, HostStatus_t::HOST_STATUS_DOWN);
+          hs.setHostStatus(token, HostStatus_t::HOST_STATUS_DOWN, 0);
         }
       }
     }
@@ -1429,7 +1429,7 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
   // Test 184
   // mark fuzzy down with HostStatus API.
   HostStatus &_st = HostStatus::instance();
-  _st.setHostStatus("fuzzy", HOST_STATUS_DOWN);
+  _st.setHostStatus("fuzzy", HOST_STATUS_DOWN, 0);
 
   ST(184);
   REINIT;
@@ -1440,7 +1440,7 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
 
   // Test 185
   // mark fluffy down and expect furry to be chosen
-  _st.setHostStatus("fluffy", HOST_STATUS_DOWN);
+  _st.setHostStatus("fluffy", HOST_STATUS_DOWN, 0);
 
   ST(185);
   REINIT;
@@ -1451,9 +1451,9 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
 
   // Test 186
   // mark furry and frisky down, fuzzy up and expect fuzzy to be chosen
-  _st.setHostStatus("furry", HOST_STATUS_DOWN);
-  _st.setHostStatus("frisky", HOST_STATUS_DOWN);
-  _st.setHostStatus("fuzzy", HOST_STATUS_UP);
+  _st.setHostStatus("furry", HOST_STATUS_DOWN, 0);
+  _st.setHostStatus("frisky", HOST_STATUS_DOWN, 0);
+  _st.setHostStatus("fuzzy", HOST_STATUS_UP, 0);
 
   ST(186);
   REINIT;
@@ -1471,10 +1471,10 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
   REBUILD;
 
   // mark all up.
-  _st.setHostStatus("furry", HOST_STATUS_UP);
-  _st.setHostStatus("fluffy", HOST_STATUS_UP);
-  _st.setHostStatus("frisky", HOST_STATUS_UP);
-  _st.setHostStatus("fuzzy", HOST_STATUS_UP);
+  _st.setHostStatus("furry", HOST_STATUS_UP, 0);
+  _st.setHostStatus("fluffy", HOST_STATUS_UP, 0);
+  _st.setHostStatus("frisky", HOST_STATUS_UP, 0);
+  _st.setHostStatus("fuzzy", HOST_STATUS_UP, 0);
 
   REINIT;
   br(request, "i.am.rabbit.net");
@@ -1484,7 +1484,7 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
 
   // Test 188
   // mark fuzzy down and expect fluffy.
-  _st.setHostStatus("fuzzy", HOST_STATUS_DOWN);
+  _st.setHostStatus("fuzzy", HOST_STATUS_DOWN, 0);
 
   ST(188);
   REINIT;
@@ -1495,7 +1495,7 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
 
   // Test 189
   // mark fuzzy back up and expect fuzzy.
-  _st.setHostStatus("fuzzy", HOST_STATUS_UP);
+  _st.setHostStatus("fuzzy", HOST_STATUS_UP, 0);
 
   ST(189);
   REINIT;
@@ -1511,7 +1511,7 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
   // because the host status is set to down.
   params->markParentDown(result, fail_threshold, retry_time);
   // set host status down
-  _st.setHostStatus("fuzzy", HOST_STATUS_DOWN);
+  _st.setHostStatus("fuzzy", HOST_STATUS_DOWN, 0);
   // sleep long enough so that fuzzy is retryable
   sleep(params->policy.ParentRetryTime + 1);
   ST(190);
@@ -1522,7 +1522,7 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
 
   // now set the host staus on fuzzy to up and it should now
   // be retried.
-  _st.setHostStatus("fuzzy", HOST_STATUS_UP);
+  _st.setHostStatus("fuzzy", HOST_STATUS_UP, 0);
   ST(191);
   REINIT;
   br(request, "i.am.rabbit.net");
@@ -1535,10 +1535,10 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
   T("dest_domain=rabbit.net parent=fuzzy:80,fluffy:80,furry:80,frisky:80 round_robin=false go_direct=true\n");
   REBUILD;
   // mark all up.
-  _st.setHostStatus("fuzzy", HOST_STATUS_UP);
-  _st.setHostStatus("fluffy", HOST_STATUS_UP);
-  _st.setHostStatus("furry", HOST_STATUS_UP);
-  _st.setHostStatus("frisky", HOST_STATUS_UP);
+  _st.setHostStatus("fuzzy", HOST_STATUS_UP, 0);
+  _st.setHostStatus("fluffy", HOST_STATUS_UP, 0);
+  _st.setHostStatus("furry", HOST_STATUS_UP, 0);
+  _st.setHostStatus("frisky", HOST_STATUS_UP, 0);
   // fuzzy should be chosen.
   sleep(1);
   REINIT;
@@ -1553,7 +1553,7 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
   sleep(params->policy.ParentRetryTime + 1);
   // since the host status is down even though fuzzy is
   // retryable, fluffy should be chosen
-  _st.setHostStatus("fuzzy", HOST_STATUS_DOWN);
+  _st.setHostStatus("fuzzy", HOST_STATUS_DOWN, 0);
   REINIT;
   br(request, "i.am.rabbit.net");
   FP;
@@ -1563,7 +1563,7 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
   // set the host status for fuzzy  back up and since its
   // retryable fuzzy should be chosen
   ST(194);
-  _st.setHostStatus("fuzzy", HOST_STATUS_UP);
+  _st.setHostStatus("fuzzy", HOST_STATUS_UP, 0);
   REINIT;
   br(request, "i.am.rabbit.net");
   FP;
@@ -1684,7 +1684,7 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
   T("dest_domain=rabbit.net parent=fuzzy:80|1.0;fluffy:80|1.0 secondary_parent=furry:80|1.0;frisky:80|1.0 "
     "round_robin=consistent_hash go_direct=false secondary_mode=3\n");
   REBUILD;
-  _st.setHostStatus("fuzzy", HOST_STATUS_DOWN);
+  _st.setHostStatus("fuzzy", HOST_STATUS_DOWN, 0);
   REINIT;
   br(request, "i.am.rabbit.net");
   FP;


### PR DESCRIPTION
Add time option to traffic_ctl host down.  The --time option allows the user to mark a host down for a
specific amount of time in seconds after which the host will be marked back up.  A time of '0', the default, marks the host down indefinitely and requires manual restoration using 'traffic_ctl host up'.