### PR TITLE
Doc: Unify ":unit:" to ":units".

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -433,7 +433,7 @@ Thread Variables
    `traffic_server` a signal either by `bin/trafficserver stop` or `kill`.
 
 .. ts:cv:: CONFIG proxy.config.thread.max_heartbeat_mseconds INT 60
-   :unit: milliseconds
+   :units: milliseconds
 
    Set the maximum heartbeat in milliseconds for threads, ranges from 0 to 1000.
 

--- a/doc/admin-guide/monitoring/statistics/core/bandwidth.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/bandwidth.en.rst
@@ -24,7 +24,7 @@ Bandwidth and Transfer
 
 .. ts:stat:: global proxy.node.bandwidth_hit_ratio_avg_10s float
    :type: derivative
-   :unit: ratio
+   :units: ratio
 
    The difference of :ts:stat:`proxy.node.user_agent_total_bytes_avg_10s` and
    :ts:stat:`proxy.node.origin_server_total_bytes_avg_10s`, divided by
@@ -35,7 +35,7 @@ Bandwidth and Transfer
 
 .. ts:stat:: global proxy.node.bandwidth_hit_ratio float
    :type: derivative
-   :unit: ratio
+   :units: ratio
 
    The difference of :ts:stat:`proxy.node.user_agent_total_bytes` and
    :ts:stat:`proxy.node.origin_server_total_bytes`, divided by
@@ -46,19 +46,19 @@ Bandwidth and Transfer
 
 .. ts:stat:: global proxy.node.client_throughput_out float
    :type: gauge
-   :unit: mbits
+   :units: mbits
 
    The value of :ts:stat:`proxy.node.http.throughput` represented in megabits.
 
 .. ts:stat:: global proxy.node.client_throughput_out_kbit integer
    :type: gauge
-   :unit: kbits
+   :units: kbits
 
    The value of :ts:stat:`proxy.node.http.throughput` represented in kilobits.
 
 .. ts:stat:: global proxy.node.http.throughput integer
    :type: gauge
-   :unit: bytes
+   :units: bytes
 
    The throughput of responses to user agents over the previous 10 seconds, in
    bytes.
@@ -66,53 +66,53 @@ Bandwidth and Transfer
 .. ts:stat:: global proxy.process.http.throttled_proxy_only integer
 .. ts:stat:: global proxy.process.http.user_agent_request_document_total_size integer
    :type: counter
-   :unit: bytes
+   :units: bytes
    :ungathered:
 
 .. ts:stat:: global proxy.process.http.user_agent_request_header_total_size integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.http.user_agent_response_document_total_size integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.http.user_agent_response_header_total_size integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.http.user_agent_speed_bytes_per_sec_100 integer
    :type: derivative
-   :unit: bytes
+   :units: bytes
    :ungathered:
 
 .. ts:stat:: global proxy.process.http.user_agent_speed_bytes_per_sec_100K integer
    :type: derivative
-   :unit: bytes
+   :units: bytes
    :ungathered:
 
 .. ts:stat:: global proxy.process.http.user_agent_speed_bytes_per_sec_100M integer
    :type: derivative
-   :unit: bytes
+   :units: bytes
    :ungathered:
 
 .. ts:stat:: global proxy.process.http.user_agent_speed_bytes_per_sec_10K integer
    :type: derivative
-   :unit: bytes
+   :units: bytes
    :ungathered:
 
 .. ts:stat:: global proxy.process.http.user_agent_speed_bytes_per_sec_10M integer
    :type: derivative
-   :unit: bytes
+   :units: bytes
    :ungathered:
 
 .. ts:stat:: global proxy.process.http.user_agent_speed_bytes_per_sec_1K integer
    :type: derivative
-   :unit: bytes
+   :units: bytes
    :ungathered:
 
 .. ts:stat:: global proxy.process.http.user_agent_speed_bytes_per_sec_1M integer
    :type: derivative
-   :unit: bytes
+   :units: bytes
    :ungathered:
 

--- a/doc/admin-guide/monitoring/statistics/core/cache-volume.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/cache-volume.en.rst
@@ -32,13 +32,13 @@ a configuration with only one cache volume: :literal:`0`.
 
 .. ts:stat:: global proxy.process.cache.volume_0.bytes_total integer
    :type: gauge
-   :unit: bytes
+   :units: bytes
 
    Represents the total number of bytes allocated for the cache volume.
 
 .. ts:stat:: global proxy.process.cache.volume_0.bytes_used integer
    :type: gauge
-   :unit: bytes
+   :units: bytes
 
    Represents the number of bytes in this cache volume which are occupied by
    cache objects.
@@ -112,7 +112,7 @@ a configuration with only one cache volume: :literal:`0`.
 
 .. ts:stat:: global proxy.process.cache.volume_0.percent_full integer
    :type: gauge
-   :unit: percent
+   :units: percent
 
 .. ts:stat:: global proxy.process.cache.volume_0.pread_count integer
    :type: counter
@@ -120,7 +120,7 @@ a configuration with only one cache volume: :literal:`0`.
 
 .. ts:stat:: global proxy.process.cache.volume_0.ram_cache.bytes_used integer
    :type: gauge
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.cache.volume_0.ram_cache.hits integer
    :type: counter
@@ -130,7 +130,7 @@ a configuration with only one cache volume: :literal:`0`.
 
 .. ts:stat:: global proxy.process.cache.volume_0.ram_cache.total_bytes integer
    :type: gauge
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.cache.volume_0.read.active integer
    :type: gauge
@@ -195,7 +195,7 @@ a configuration with only one cache volume: :literal:`0`.
 
 .. ts:stat:: global proxy.process.cache.volume_0.write_bytes_stat integer
    :type: counter
-   :unit: bytes
+   :units: bytes
    :ungathered:
 
 .. ts:stat:: global proxy.process.cache.volume_0.write.failure integer

--- a/doc/admin-guide/monitoring/statistics/core/dns.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/dns.en.rst
@@ -24,7 +24,7 @@ DNS
 
 .. ts:stat:: global proxy.node.dns.lookup_avg_time_ms integer
    :type: derivative
-   :unit: milliseconds
+   :units: milliseconds
    :ungathered:
 
    Average number of milliseconds spent performing DNS lookups per host.
@@ -43,7 +43,7 @@ DNS
 
 .. ts:stat:: global proxy.process.dns.fail_avg_time integer
    :type: derivative
-   :unit: milliseconds
+   :units: milliseconds
    :ungathered:
 
    The average time per DNS lookup, in milliseconds, which ultimately failed.
@@ -56,7 +56,7 @@ DNS
 
 .. ts:stat:: global proxy.process.dns.lookup_avg_time integer
    :type: derivative
-   :unit: milliseconds
+   :units: milliseconds
    :ungathered:
 
    The average time spent performaning DNS lookups per host.
@@ -88,7 +88,7 @@ DNS
 
 .. ts:stat:: global proxy.process.dns.success_avg_time integer
    :type: derivative
-   :unit: milliseconds
+   :units: milliseconds
    :ungathered:
 
    The average time per DNS lookup, in milliseconds, which have succeeded.

--- a/doc/admin-guide/monitoring/statistics/core/general.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/general.en.rst
@@ -56,14 +56,14 @@ General
 
 .. ts:stat:: global proxy.node.restarts.manager.start_time integer
    :type: gauge
-   :unit: seconds
+   :units: seconds
 
    Unix epoch-time value indicating the time at which the currently-running
    :program:`traffic_manager` process was started.
 
 .. ts:stat:: global proxy.node.restarts.proxy.cache_ready_time integer
    :type: gauge
-   :unit: seconds
+   :units: seconds
 
 .. ts:stat:: global proxy.node.restarts.proxy.restart_count integer
 .. ts:stat:: global proxy.node.restarts.proxy.start_time integer
@@ -118,7 +118,7 @@ General
    |TS|.
 
 .. ts:stat:: global proxy.process.traffic_server.memory.rss integer
-   :unit: bytes
+   :units: bytes
 
    The resident set size (RSS) of the ``traffic_server`` process. This is
    basically the amount of memory this process is consuming.

--- a/doc/admin-guide/monitoring/statistics/core/hierarchical.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/hierarchical.en.rst
@@ -27,26 +27,26 @@ Hierarchical Cache
 
 .. ts:stat:: global proxy.node.http.parent_proxy_total_request_bytes integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.node.http.parent_proxy_total_response_bytes integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.http.current_parent_proxy_connections integer
    :type: counter
 
 .. ts:stat:: global proxy.process.http.parent_proxy_request_total_bytes integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.http.parent_proxy_response_total_bytes integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.http.parent_proxy_transaction_time integer
    :type: counter
-   :unit: seconds
+   :units: seconds
 
 .. ts:stat:: global proxy.process.http.total_parent_proxy_connections integer
    :type: counter

--- a/doc/admin-guide/monitoring/statistics/core/hostdb.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/hostdb.en.rst
@@ -29,14 +29,14 @@ origin servers' hostnames prior to object revalidation or retrieval.
 
 .. ts:stat:: global proxy.node.hostdb.hit_ratio_avg_10s float
    :type: derivative
-   :unit: ratio
+   :units: ratio
 
    Represents the ratio of origin server name resolutions which were satisfied
    by the HostDB lookup cache over the last 10 seconds.
 
 .. ts:stat:: global proxy.node.hostdb.hit_ratio float
    :type: derivative
-   :unit: ratio
+   :units: ratio
 
    Represents the ratio of origin server name resolutions which were satisfied
    by the HostDB lookup cache since statistics collection began.
@@ -70,7 +70,7 @@ origin servers' hostnames prior to object revalidation or retrieval.
 
 .. ts:stat:: global proxy.process.hostdb.bytes integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
    Represents the number of bytes allocated to the HostDB lookup cache.
 
@@ -99,11 +99,11 @@ origin servers' hostnames prior to object revalidation or retrieval.
 
 .. ts:stat:: global proxy.process.hostdb.ttl_expires integer
    :type: gauge
-   :unit: seconds
+   :units: seconds
 
 .. ts:stat:: global proxy.process.hostdb.ttl float
    :type: gauge
-   :unit: seconds
+   :units: seconds
 
 .. ts:stat:: global proxy.process.hostdb.cache.current_items integer
    :type: gauge
@@ -112,7 +112,7 @@ origin servers' hostnames prior to object revalidation or retrieval.
 
 .. ts:stat:: global proxy.process.hostdb.cache.current_size integer
    :type: gauge
-   :unit: bytes
+   :units: bytes
 
    The total size of all host records in the HostDB cache.
 
@@ -128,7 +128,7 @@ origin servers' hostnames prior to object revalidation or retrieval.
 
 .. ts:stat:: global proxy.process.hostdb.cache.last_sync.total_size integer
    :type: gauge
-   :unit: bytes
+   :units: bytes
 
    The total size of all host records in the HostDB cache that where synced to disk.
 

--- a/doc/admin-guide/monitoring/statistics/core/http-connection.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/http-connection.en.rst
@@ -43,11 +43,11 @@ HTTP Connection
 
 .. ts:stat:: global proxy.node.http.user_agent_total_request_bytes integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.node.http.user_agent_total_response_bytes integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.node.http.user_agent_xacts_per_second float
    :type: derivative
@@ -85,22 +85,22 @@ HTTP Connection
 
 .. ts:stat:: global proxy.process.http.err_client_abort_origin_server_bytes_stat integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.http.err_client_abort_user_agent_bytes_stat integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.http.err_client_read_error_count_stat integer
    :type: counter
 
 .. ts:stat:: global proxy.process.http.err_client_read_error_origin_server_bytes_stat integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.http.err_client_read_error_user_agent_bytes_stat integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.http.err_connect_fail_count_stat integer
    :type: counter
@@ -108,17 +108,17 @@ HTTP Connection
 
 .. ts:stat:: global proxy.process.http.err_connect_fail_origin_server_bytes_stat integer
    :type: counter
-   :unit: bytes
+   :units: bytes
    :ungathered:
 
 .. ts:stat:: global proxy.process.http.err_connect_fail_user_agent_bytes_stat integer
    :type: counter
-   :unit: bytes
+   :units: bytes
    :ungathered:
 
 .. ts:stat:: global proxy.process.http.http_misc_origin_server_bytes_stat integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.http.incoming_requests integer
    :type: counter

--- a/doc/admin-guide/monitoring/statistics/core/http-document-size.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/http-document-size.en.rst
@@ -24,7 +24,7 @@ HTTP Document Size
 
 .. ts:stat:: global proxy.process.http.pushed_document_total_size integer
    :type: counter
-   :unit: bytes
+   :units: bytes
    :ungathered:
 
 .. ts:stat:: global proxy.process.http.request_document_size_100 integer

--- a/doc/admin-guide/monitoring/statistics/core/http-transaction.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/http-transaction.en.rst
@@ -108,59 +108,59 @@ HTTP Transaction
 
 .. ts:stat:: global proxy.node.http.transaction_msec_avg_10s.errors.aborts integer
    :type: derivative
-   :unit: milliseconds
+   :units: milliseconds
 
 .. ts:stat:: global proxy.node.http.transaction_msec_avg_10s.errors.connect_failed integer
    :type: derivative
-   :unit: milliseconds
+   :units: milliseconds
 
 .. ts:stat:: global proxy.node.http.transaction_msec_avg_10s.errors.early_hangups integer
    :type: derivative
-   :unit: milliseconds
+   :units: milliseconds
 
 .. ts:stat:: global proxy.node.http.transaction_msec_avg_10s.errors.empty_hangups integer
    :type: derivative
-   :unit: milliseconds
+   :units: milliseconds
 
 .. ts:stat:: global proxy.node.http.transaction_msec_avg_10s.errors.other integer
    :type: derivative
-   :unit: milliseconds
+   :units: milliseconds
 
 .. ts:stat:: global proxy.node.http.transaction_msec_avg_10s.errors.possible_aborts integer
    :type: derivative
-   :unit: milliseconds
+   :units: milliseconds
 
 .. ts:stat:: global proxy.node.http.transaction_msec_avg_10s.errors.pre_accept_hangups integer
    :type: derivative
-   :unit: milliseconds
+   :units: milliseconds
 
 .. ts:stat:: global proxy.node.http.transaction_msec_avg_10s.hit_fresh integer
    :type: derivative
-   :unit: milliseconds
+   :units: milliseconds
 
 .. ts:stat:: global proxy.node.http.transaction_msec_avg_10s.hit_revalidated integer
    :type: derivative
-   :unit: milliseconds
+   :units: milliseconds
 
 .. ts:stat:: global proxy.node.http.transaction_msec_avg_10s.miss_changed integer
    :type: derivative
-   :unit: milliseconds
+   :units: milliseconds
 
 .. ts:stat:: global proxy.node.http.transaction_msec_avg_10s.miss_client_no_cache integer
    :type: derivative
-   :unit: milliseconds
+   :units: milliseconds
 
 .. ts:stat:: global proxy.node.http.transaction_msec_avg_10s.miss_cold integer
    :type: derivative
-   :unit: milliseconds
+   :units: milliseconds
 
 .. ts:stat:: global proxy.node.http.transaction_msec_avg_10s.miss_not_cacheable integer
    :type: derivative
-   :unit: milliseconds
+   :units: milliseconds
 
 .. ts:stat:: global proxy.node.http.transaction_msec_avg_10s.other.unclassified integer
    :type: derivative
-   :unit: milliseconds
+   :units: milliseconds
 
 .. ts:stat:: global proxy.process.http.avg_transactions_per_client_connection float
    :type: derivative
@@ -170,7 +170,7 @@ HTTP Transaction
 
 .. ts:stat:: global proxy.process.http.total_transactions_time integer
    :type: counter
-   :unit: seconds
+   :units: seconds
 
 .. ts:stat:: global proxy.process.http.transaction_counts.errors.aborts integer
    :type: counter
@@ -226,66 +226,66 @@ HTTP Transaction
 
 .. ts:stat:: global proxy.process.http.transaction_totaltime.errors.aborts float
    :type: counter
-   :unit: seconds
+   :units: seconds
    :ungathered:
 
 .. ts:stat:: global proxy.process.http.transaction_totaltime.errors.connect_failed float
    :type: counter
-   :unit: seconds
+   :units: seconds
    :ungathered:
 
 .. ts:stat:: global proxy.process.http.transaction_totaltime.errors.other float
    :type: counter
-   :unit: seconds
+   :units: seconds
    :ungathered:
 
 .. ts:stat:: global proxy.process.http.transaction_totaltime.errors.possible_aborts float
    :type: counter
-   :unit: seconds
+   :units: seconds
    :ungathered:
 
 .. ts:stat:: global proxy.process.http.transaction_totaltime.errors.pre_accept_hangups float
    :type: counter
-   :unit: seconds
+   :units: seconds
    :ungathered:
 
 .. ts:stat:: global proxy.process.http.transaction_totaltime.hit_fresh float
    :type: counter
-   :unit: seconds
+   :units: seconds
    :ungathered:
 
 .. ts:stat:: global proxy.process.http.transaction_totaltime.hit_fresh.process float
    :type: counter
-   :unit: seconds
+   :units: seconds
    :ungathered:
 
 .. ts:stat:: global proxy.process.http.transaction_totaltime.hit_revalidated float
    :type: counter
-   :unit: seconds
+   :units: seconds
    :ungathered:
 
 .. ts:stat:: global proxy.process.http.transaction_totaltime.miss_changed float
    :type: counter
-   :unit: seconds
+   :units: seconds
    :ungathered:
 
 .. ts:stat:: global proxy.process.http.transaction_totaltime.miss_client_no_cache float
    :type: counter
-   :unit: seconds
+   :units: seconds
    :ungathered:
 
 .. ts:stat:: global proxy.process.http.transaction_totaltime.miss_cold float
    :type: counter
-   :unit: seconds
+   :units: seconds
    :ungathered:
 
 .. ts:stat:: global proxy.process.http.transaction_totaltime.miss_not_cacheable float
    :type: counter
-   :unit: seconds
+   :units: seconds
    :ungathered:
 
 .. ts:stat:: global proxy.process.http.transaction_totaltime.other.unclassified float
    :type: counter
-   :unit: seconds
+   :units: seconds
    :ungathered:
 

--- a/doc/admin-guide/monitoring/statistics/core/log.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/log.en.rst
@@ -24,52 +24,52 @@ Logging
 
 .. ts:stat:: global proxy.node.log.bytes_flush_to_disk integer
    :type: counter
-   :unit: bytes
+   :units: bytes
    :ungathered:
 
 .. ts:stat:: global proxy.node.log.bytes_lost_before_flush_to_disk integer
    :type: counter
-   :unit: bytes
+   :units: bytes
    :ungathered:
 
 .. ts:stat:: global proxy.node.log.bytes_lost_before_preproc integer
    :type: counter
-   :unit: bytes
+   :units: bytes
    :ungathered:
 
 .. ts:stat:: global proxy.node.log.bytes_lost_before_sent_to_network integer
    :type: counter
-   :unit: bytes
+   :units: bytes
    :ungathered:
 
 .. ts:stat:: global proxy.node.log.bytes_lost_before_written_to_disk integer
    :type: counter
-   :unit: bytes
+   :units: bytes
    :ungathered:
 
 .. ts:stat:: global proxy.node.log.bytes_received_from_network_avg_10s integer
    :type: derivative
-   :unit: bytes
+   :units: bytes
    :ungathered:
 
 .. ts:stat:: global proxy.node.log.bytes_received_from_network integer
    :type: counter
-   :unit: bytes
+   :units: bytes
    :ungathered:
 
 .. ts:stat:: global proxy.node.log.bytes_sent_to_network_avg_10s integer
    :type: derivative
-   :unit: bytes
+   :units: bytes
    :ungathered:
 
 .. ts:stat:: global proxy.node.log.bytes_sent_to_network integer
    :type: counter
-   :unit: bytes
+   :units: bytes
    :ungathered:
 
 .. ts:stat:: global proxy.node.log.bytes_written_to_disk integer
    :type: counter
-   :unit: bytes
+   :units: bytes
    :ungathered:
 
 .. ts:stat:: global proxy.node.log.event_log_access_aggr integer
@@ -134,35 +134,35 @@ Logging
 
 .. ts:stat:: global proxy.process.log.bytes_flush_to_disk integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.log.bytes_lost_before_flush_to_disk integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.log.bytes_lost_before_preproc integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.log.bytes_lost_before_sent_to_network integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.log.bytes_lost_before_written_to_disk integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.log.bytes_received_from_network integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.log.bytes_sent_to_network integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.log.bytes_written_to_disk integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.log.event_log_access_aggr integer
    :type: counter
@@ -225,7 +225,7 @@ Logging
 
 .. ts:stat:: global proxy.process.log.log_files_space_used integer
    :type: gauge
-   :unit: bytes
+   :units: bytes
 
    Indicates the number of bytes currently in use by |TS| log files.
 

--- a/doc/admin-guide/monitoring/statistics/core/misc.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/misc.en.rst
@@ -46,11 +46,11 @@ Miscellaneous
     Number of loops that did a conditional wait.
 
 .. ts:stat:: global proxy.process.eventloop.time.min integer
-    :unit: nanoseconds
+    :units: nanoseconds
 
     Shortest time spent in a loop.
 
 .. ts:stat:: global proxy.process.eventloop.time.max integer
-    :unit: nanoseconds
+    :units: nanoseconds
 
     Longest time spent in a loop.

--- a/doc/admin-guide/monitoring/statistics/core/network-io.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/network-io.en.rst
@@ -69,11 +69,11 @@ Network I/O
 
 .. ts:stat:: global proxy.process.net.read_bytes integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.net.write_bytes integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.tcp.total_accepts integer
    :type: counter

--- a/doc/admin-guide/monitoring/statistics/core/origin.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/origin.en.rst
@@ -27,65 +27,65 @@ Origin Server
 
 .. ts:stat:: global proxy.node.http.origin_server_total_request_bytes integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.node.http.origin_server_total_response_bytes integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.node.http.origin_server_total_transactions_count integer
    :type: counter
 
 .. ts:stat:: global proxy.node.origin_server_total_bytes_avg_10s float
    :type: derivative
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.node.origin_server_total_bytes integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.http.origin_server_request_document_total_size integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.http.origin_server_request_header_total_size integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.http.origin_server_response_document_total_size integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.http.origin_server_response_header_total_size integer
    :type: counter
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.http.origin_server_speed_bytes_per_sec_100 integer
    :type: derivative
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.http.origin_server_speed_bytes_per_sec_100K integer
    :type: derivative
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.http.origin_server_speed_bytes_per_sec_100M integer
    :type: derivative
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.http.origin_server_speed_bytes_per_sec_10K integer
    :type: derivative
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.http.origin_server_speed_bytes_per_sec_10M integer
    :type: derivative
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.http.origin_server_speed_bytes_per_sec_1K integer
    :type: derivative
-   :unit: bytes
+   :units: bytes
 
 .. ts:stat:: global proxy.process.http.origin_server_speed_bytes_per_sec_1M integer
    :type: derivative
-   :unit: bytes
+   :units: bytes
 
 

--- a/doc/admin-guide/monitoring/statistics/core/ssl.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/ssl.en.rst
@@ -115,7 +115,7 @@ SSL/TLS
 
 .. ts:stat:: global proxy.process.ssl.total_handshake_time integer
    :type: counter
-   :unit: milliseconds
+   :units: milliseconds
 
    The total amount of time spent performing SSL/TLS handshakes for new sessions
    since statistics collection began.

--- a/doc/developer-guide/api/functions/TSVConnArgs.en.rst
+++ b/doc/developer-guide/api/functions/TSVConnArgs.en.rst
@@ -14,7 +14,7 @@
    implied.  See the License for the specific language governing
    permissions and limitations under the License.
 
-.. include:: ../common.defs
+.. include:: ../../../common.defs
 .. default-domain:: c
 
 .. _TSVConnArgs:

--- a/doc/ext/traffic-server.py
+++ b/doc/ext/traffic-server.py
@@ -188,7 +188,7 @@ class TSStat(std.Target):
 
     option_spec = {
         'type': metrictypes,
-        'unit': metricunits,
+        'units': metricunits,
         'introduced': rst.directives.unchanged,
         'deprecated': rst.directives.unchanged,
         'ungathered': rst.directives.flag


### PR DESCRIPTION
For unknown reason `:ts:stat:` used `:unit:` as the unit option while `:ts:cv:` used `:units:`. This changes both to use `:units:` to avoid annoyingly wrong uses in the future.

Fix TSVConnArg error.