### PR TITLE
Doc: various fixes

### DIFF
--- a/doc/admin-guide/files/hosting.config.en.rst
+++ b/doc/admin-guide/files/hosting.config.en.rst
@@ -22,7 +22,7 @@ hosting.config
 .. configfile:: hosting.config
 
 The :file:`hosting.config` file (by default, located in
-``/usr/local/etc/trafficserver/``) you to assign cache volumes to
+``/usr/local/etc/trafficserver/``) allows you to assign cache volumes to
 specific origin servers and/or domains so that you can manage cache
 space efficiently and restrict disk usage. For step-by-step instructions
 on partitioning the cache according to origin servers and/or domains,
@@ -39,10 +39,6 @@ directory and run :option:`traffic_ctl config reload` to apply your changes.
 When you apply the changes to a node in a cluster, Traffic Server
 automatically applies the changes to all other nodes in the cluster.
 
-.. important::
-
-    The :file:`volume.config` configuration must be the same on all nodes in a cluster.
-
 Format
 ======
 
@@ -55,16 +51,16 @@ formats::
 where ``HOST`` is the fully-qualified hostname of the origin server
 whose content you want to store on a particular volume (for example,
 ``www.myhost.com``); ``DOMAIN`` is the domain whose content you
-want to store on a particular partition(for example, ``mydomain.com``);
+want to store on a particular partition (for example, ``mydomain.com``);
 and ``NUMBERS`` is a comma-separated list of the partitions on
 which you want to store the content that belongs to the origin server or
 domain listed. The partition numbers must be valid numbers listed in the
-file:`volume.config`.
+:file:`volume.config`.
 
 **Note:** To allocate more than one partition to an origin server or
 domain, you must enter the partitions in a comma-separated list on one
 line, as shown in the example below. The
-:file:`hosting.config`  file cannot contain multiple entries
+:file:`hosting.config` file cannot contain multiple entries
 for the same origin server or domain.
 
 Generic Partition

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3389,6 +3389,7 @@ Client-Related Configuration
 :2: The provided certificate will be verified and the connection will be established irrespective of the verification result. If verification fails the name of the server will be logged.
 
 .. ts:cv:: CONFIG proxy.config.ssl.client.cert.filename STRING NULL
+   :overridable:
 
    The filename of SSL client certificate installed on Traffic Server.
 

--- a/doc/admin-guide/files/volume.config.en.rst
+++ b/doc/admin-guide/files/volume.config.en.rst
@@ -23,16 +23,10 @@ volume.config
 
 The :file:`volume.config` file enables you to manage your cache space more
 efficiently and restrict disk usage by creating cache volumes of
-different sizes for specific protocols. You can further configure these
-volumes to store data from certain origin servers and/or domains in the
-:file:`hosting.config` file.
-
-.. important::
-
-    The volume configuration must be the same on all nodes in
-    a cluster. You must stop Traffic Server before you change the cache
-    volume size and protocol assignment. For step-by-step instructions about
-    partitioning the cache, refer to :ref:`partitioning-the-cache`.
+different sizes. By distributing the cache across multiple volumes,
+you can help decrease single-lock pressure when there are not many hard drives
+present. You can further configure these volumes to store data from certain
+origin servers and/or domains in the :file:`hosting.config` file.
 
 Format
 ======
@@ -61,8 +55,11 @@ volumes without deleting and clearing the existing volumes.
 Examples
 ========
 
-The following example partitions the cache evenly between HTTP and HTTPS
-requests::
+The following example partitions the cache across 5 volumes to decreasing
+single-lock pressure for a machine with few drives.::
 
-    volume=1 scheme=http size=50%
-    volume=2 scheme=http size=50%
+    volume=1 scheme=http size=20%
+    volume=2 scheme=http size=20%
+    volume=3 scheme=http size=20%
+    volume=4 scheme=http size=20%
+    volume=5 scheme=http size=20%

--- a/doc/admin-guide/plugins/tcpinfo.en.rst
+++ b/doc/admin-guide/plugins/tcpinfo.en.rst
@@ -70,7 +70,7 @@ The following options may be specified in :file:`plugin.config`:
   event         Event name (one of the names listed above)
   client        Client IP address
   server        Server IP address
-  rtt           Estimated round trip time
+  rtt           Estimated round trip time in microseconds
   ==========    ==================================================
 
   The following fields are logged when the log level is ``2``:
@@ -82,7 +82,7 @@ The following options may be specified in :file:`plugin.config`:
   event             Event name (one of the names listed above)
   client            Client IP address
   server            Server IP address
-  rtt               Estimated round trip time
+  rtt               Estimated round trip time in microseconds
   rttvar
   last_sent
   last_recv
@@ -106,12 +106,12 @@ The following options may be specified in :file:`plugin.config`:
 --rolling-enabled=VALUE
   This logfile option allows you to set logfile rolling behaviour of
   the output log file  without making any changes to the global
-  logging configurations.  This option overrides the 
-  :ts:cv:`proxy.config.output.logfile.rolling_enabled` setting in records.config
+  logging configurations.  This option overrides the
+  :ts:cv:`proxy.config.output.logfile.rolling_enabled` setting in :file:`records.config`
   for the ``tcpinfo`` plugin.  The setting may range from ``0`` to ``3``.
   ``0`` disables logfile rolling.  ``1`` is the ``default`` and enables logfile
   rolling at specfic intervals set by ``--rolling-interval-sec`` discussed
-  below.  ``2`` enables logfile rolling by logfile size, see 
+  below.  ``2`` enables logfile rolling by logfile size, see
   ``--rolling-size-mb`` below.  Finally a value of ``3`` enables logfile rolling
   at specfic intervals or size, whichever occurs first using the interval or size
   settings discussed below.
@@ -121,11 +121,11 @@ The following options may be specified in :file:`plugin.config`:
   using interval rolling. Default value is ``0``.
 
 --rolling-interval-sec=VALUE
-  Set the rolling interval in seconds for the output log file. May be set 
+  Set the rolling interval in seconds for the output log file. May be set
   from ``60`` to ``86400`` seconds, Defaults to ``86400``.
 
 --rolling-size=VALUE
-  Set the size in MB at which the output log file  will roll when using log size 
+  Set the size in MB at which the output log file  will roll when using log size
   rolling.  Minimum value is ``10``, defaults to ``1024``. In your config file,
   you may use the K, M, or G suffix as in::
 
@@ -140,12 +140,12 @@ transaction thereafter::
 
   tcpinfo.so --log-file=tcp-metrics --log-level=1 --hooks=ssn_start,txn_start
 
-The file ``tcp-metrics.log`` will contain the following log format::
+The file ``tcp-metrics.log`` will contain the following log format (with client and server both on 127.0.0.1)::
 
   timestamp event client server rtt
-  20140414.17h40m14s ssn_start 127.0.0.1 127.0.0.1 4000
-  20140414.17h40m14s txn_start 127.0.0.1 127.0.0.1 4000
-  20140414.17h40m16s ssn_start 127.0.0.1 127.0.0.1 4000
-  20140414.17h40m16s txn_start 127.0.0.1 127.0.0.1 4000
-  20140414.17h40m16s ssn_start 127.0.0.1 127.0.0.1 4000
-  20140414.17h40m16s txn_start 127.0.0.1 127.0.0.1 4000
+  20140414.17h40m14s ssn_start 127.0.0.1 127.0.0.1 153859
+  20140414.17h40m14s txn_start 127.0.0.1 127.0.0.1 181018
+  20140414.17h40m16s ssn_start 127.0.0.1 127.0.0.1 86869
+  20140414.17h40m16s txn_start 127.0.0.1 127.0.0.1 19088
+  20140414.17h40m16s ssn_start 127.0.0.1 127.0.0.1 85718
+  20140414.17h40m16s txn_start 127.0.0.1 127.0.0.1 38059

--- a/doc/admin-guide/storage/index.en.rst
+++ b/doc/admin-guide/storage/index.en.rst
@@ -182,63 +182,16 @@ existing disk, or to remove disks from a Traffic Server node:
 Partitioning the Cache
 ======================
 
-You can manage your cache space more efficiently and restrict disk usage
-by creating :term:`cache volumes <cache volume>` with different sizes for
-specific protocols. You can further configure these volumes to store data from
-specific :term:`origin servers <origin server>` and/or domains.
-
-Creating Cache Partitions for Specific Protocols
-------------------------------------------------
-
-You can create separate :term:`volumes <cache volume>` for your cache that vary
-in size to store content according to protocol. This ensures that a certain
-amount of disk space is always available for a particular protocol. Traffic
-Server currently supports only the ``http`` partition type.
-
-To partition the cache according to protocol:
-
-#. Enter a line in :file:`volume.config` for each volume you want to create. ::
-
-    volume=1 scheme=http size=50%
-    volume=2 scheme=http size=50%
-
-#. Restart Traffic Server.
-
-.. important::
-
-    Volume definitions must be the same across all nodes in a cluster.
-
-Making Changes to Partition Sizes and Protocols
------------------------------------------------
-
-After you've configured your cache volumes based on protocol, you can
-make changes to the configuration at any time. Before making changes,
-note the following:
-
--  You must stop Traffic Server before you change the cache volume size
-   and protocol assignment.
-
--  When you increase the size of a volume, the contents of the volume
-   are *not* deleted. However, when you reduce the size of a volume, the
-   contents of the volume *are* deleted.
-
--  When you change the volume number, the volume is deleted and then
-   recreated, even if the size and protocol type remain the same.
-
--  When you add new disks to your Traffic Server node, volume sizes
-   specified in percentages will increase proportionately.
-
--  Substantial changes to volume sizes can result in disk fragmentation,
-   which affects performance and cache hit rate. You should clear the cache
-   before making many changes to cache volume sizes (refer to `Clearing the Cache`_).
+You can manage your cache space and restrict disk usage from specific
+:term:`origin servers <origin server>` and/or domains by creating
+:term:`cache volumes <cache volume>`.
 
 Partitioning the Cache According to Origin Server or Domain
 -----------------------------------------------------------
 
 .. XXX: rewrite to remove repetitious single-v-multiple points; break out global partition note for clarify; fix up plurality
 
-After you have partitioned the cache according to size and protocol, you
-can assign the volumes you created to specific origin servers and/or
+You can assign the volumes you create to specific origin servers and/or
 domains. You can assign a volume to a single origin server or to
 multiple origin servers. However, if a volume is assigned to multiple
 origin servers, then there is no guarantee on the space available in the
@@ -248,7 +201,8 @@ origin servers and domains, you must assign a generic volume to store
 content from all origin servers and domains that are not listed. This
 generic volume is also used if the partitions for a particular origin
 server or domain become corrupt. If you do not assign a generic volume,
-then Traffic Server will run in proxy-only mode.
+then Traffic Server will run in proxy-only mode. The volumes do
+not need to be the same size.
 
 .. note::
 
@@ -260,12 +214,6 @@ then Traffic Server will run in proxy-only mode.
 
 To partition the cache according to hostname and domain:
 
-#. Configure the cache volumes according to size and protocol, as
-   described in `Creating Cache Partitions for Specific Protocols`_.
-#. Create a separate volume based on protocol for each host and domain,
-   as well as an additional generic partition to use for content that
-   does not belong to these origin servers or domains. The volumes do
-   not need to be the same size.
 #. Enter a line in the :file:`hosting.config` file to
    allocate the volume(s) used for each origin server and/or domain.
 #. Assign a generic volume to use for content that does not belong to


### PR DESCRIPTION
- remove some more references to clustering
- cert for ATS acting as client setting is overridable
- tcpinfo rtt is in microseconds
- the volume.config only has 1 scheme nowadays, so, that makes
partitioning based on it useless -- so removed those sections.