### PR TITLE
doc/admin-guide: minor fixes

### DIFF
--- a/doc/admin-guide/files/index.en.rst
+++ b/doc/admin-guide/files/index.en.rst
@@ -78,7 +78,7 @@ Configuration Files
    Defines mapping rules used by |TS| to properly route all incoming requests.
 
 :doc:`splitdns.config.en`
-   Configures DNS servers to use under specific conditios.
+   Configures DNS servers to use under specific conditions.
 
 :doc:`ssl_multicert.config.en`
    Configures |TS| to use different server certificates for SSL termination

--- a/doc/admin-guide/monitoring/statistics/core/http-connection.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/http-connection.en.rst
@@ -150,4 +150,4 @@ HTTP Connection
 .. ts:stat:: global proxy.process.http.origin_connections_throttled_out integer
    :type: counter
 
-This tracks the number of origin connections denied due to being over the :ts:cv`proxy.config.http.origin_max_connections` limit.
+This tracks the number of origin connections denied due to being over the :ts:cv:`proxy.config.http.origin_max_connections` limit.


### PR DESCRIPTION
Fix a typo and a syntax error in the ATS Administrator's Guide.