### PR TITLE
Add fix option for traffic_layout verify subcommand

### DIFF
--- a/cmd/traffic_layout/engine.h
+++ b/cmd/traffic_layout/engine.h
@@ -29,6 +29,8 @@
 
 #define RUNROOT_WORD_LENGTH 10
 
+typedef std::unordered_map<std::string, std::string> RunrootMapType;
+
 // structure for informaiton of the runroot passing around
 struct RunrootEngine {
   // the parsing function for traffic runroot program
@@ -43,7 +45,7 @@ struct RunrootEngine {
   // the function of creating runroot
   void create_runroot();
 
-  // the function of verifying runroot
+  // the function of verifying runroot (including fix)
   void verify_runroot();
 
   // copy the stuff from original_root to ts_runroot
@@ -51,7 +53,7 @@ struct RunrootEngine {
   void copy_runroot(const std::string &original_root, const std::string &ts_runroot);
 
   // the help message for runroot
-  void runroot_help_message(const bool runflag, const bool cleanflag, const bool verifyflag, const bool fixflag);
+  void runroot_help_message(const bool runflag, const bool cleanflag, const bool verifyflag);
 
   // the pass in arguments
   std::vector<std::string> _argv;
@@ -69,6 +71,11 @@ struct RunrootEngine {
 
   // the path for create & remove
   std::string path;
+
+  // vector containing all directory names
+  std::vector<std::string> dir_vector = {"prefix",     "exec_prefix", "bindir", "sbindir",    "sysconfdir",
+                                         "datadir",    "includedir",  "libdir", "libexecdir", "localstatedir",
+                                         "runtimedir", "logdir",      "mandir", "cachedir"};
 
   // map for yaml file emit
   std::unordered_map<std::string, std::string> path_map;

--- a/cmd/traffic_layout/file_system.cc
+++ b/cmd/traffic_layout/file_system.cc
@@ -204,7 +204,7 @@ copy_function(const char *src_path, const struct stat *sb, int flag)
       }
     }
     // hardlink bin executable
-    if (sb->st_mode == BIN_MODE) {
+    if (sb->st_mode & S_IEXEC) {
       if (link(src_path, dst_path.c_str()) != 0) {
         if (errno != EEXIST) {
           ink_warning("failed to create hard link - %s", strerror(errno));

--- a/cmd/traffic_layout/file_system.h
+++ b/cmd/traffic_layout/file_system.h
@@ -25,9 +25,6 @@
 
 #include <string>
 
-// binary executable mode (for symlink)
-#define BIN_MODE 33261
-
 // some system does not have OPEN_MAX defined
 // size can be changed accordingly
 #define OPEN_MAX_FILE 256

--- a/cmd/traffic_layout/traffic_layout.cc
+++ b/cmd/traffic_layout/traffic_layout.cc
@@ -63,19 +63,20 @@ static void
 help_usage()
 {
   std::cout << "\nSubcommands:\n"
+               "info         Show the layout as default\n"
                "init         Initialize the ts_runroot sandbox\n"
                "remove       Remove the ts_runroot sandbox\n"
-               "info         Show the layout as default\n"
-               "verify:      Verify the ts_runroot paths\n"
+               "verify       Verify the ts_runroot paths\n"
             << std::endl;
   std::cout << "Switches of runroot:\n"
-               "--path       Specify the path of the runroot\n"
-               "--force:     Force to create ts_runroot, only works with init\n"
-               "--absolute:  Produce absolute path in the yaml file\n"
+               "--path:      Specify the path of the runroot\n"
+               "--force:     Force to create or remove ts_runroot\n"
+               "--absolute:  Produce absolute path in the yaml file during init\n"
                "--run-root(=/path):  Using specified TS_RUNROOT as sandbox\n"
+               "--fix:       fix the premission issues that verify found"
             << std::endl;
   printf("Detailed usage and description in traffic_layout.en.rst\n");
-  printf("General Usage:\n");
+  printf("\nGeneral Usage:\n");
   usage(argument_descriptions, countof(argument_descriptions), nullptr);
 }
 
@@ -129,7 +130,7 @@ traffic_runroot(int argc, const char **argv)
   }
   // parse the command line & put into global variable
   if (!engine.runroot_parse()) {
-    engine.runroot_help_message(true, true, true, true);
+    engine.runroot_help_message(true, true, true);
     return 0;
   }
   // check sanity of the command about the runroot program

--- a/doc/appendices/command-line/traffic_layout.en.rst
+++ b/doc/appendices/command-line/traffic_layout.en.rst
@@ -20,73 +20,97 @@
 traffic_layout
 *****************
 
+Synopsis
+========
+:program:`traffic_layout` SUBCOMMAND [OPTIONS]
+
+Options
+=============
 .. program:: traffic_layout
 
-.. option:: --run-root [<path>]
+.. option:: --run-root=[<path>]
 
    Use the run root file at :arg:`path`.
 
+.. option:: -V, --version
+
+    Print version information and exit.
+
 Description
 =============
-Document for the special functionality of ``runroot`` inside :program:`traffic_layout` This feature
+Document for the special functionality of ``runroot`` inside :program:`traffic_layout`. This feature
 is for the setup of traffic server runroot. It will create a runtime sandbox for any program of
 traffic server to run under.
 
-#. Use :program:`traffic_layout` to create sandbox.
-#. Run any program using the sandbox with ``--run-root=/path/to/file`` or ``--run-root``.
+Use :program:`traffic_layout` to create sandbox.
+Run any program using the sandbox with ``--run-root=/path/to/file`` or ``--run-root``.
 
-How it works:
+How it works
 --------------
 
 #. Create a sandbox directory for programs to run under.
 #. Copy and symlink build time directories and files to the sandbox, allowing users to modify freely.
 #. Emit a yaml file that defines layout structure for other programs to use (relative path).
+#. Users are able to remove runroot and verify permission of the runroot.
 
-Options:
+Subcommands
 =============
 
-#. Initialize the runroot: ::
+- Initialize the runroot: ::
 
       traffic_layout init (--path /path/to/sandbox/)
 
-   Use the current working directory or specific path to create runroot.
+      Use the current working directory or the specific path to create runroot.
+      The path can be relative or set up in :envvar:`TS_RUNROOT`.
 
-#. Remove the runroot: ::
 
-      traffic_layout remove --path /path/to/sandbox/
+- Remove the runroot: ::
 
-   Remove the sandbox we created(check yaml file).
-   If no path provided, it will check bin executing path and current working directory to clean.
+      traffic_layout remove (--path /path/to/sandbox/)
 
-#. Use Force flag for creating: ::
+      Find the sandbox to remove in following order: 
+
+            1. specified in --path as absolute or relative.
+            2. :envvar:`TS_RUNROOT`
+            3. current working directory
+            4. installed directory.
+
+- Verify the runroot: ::
+
+      traffic_layout verify (--path /path/to/sandbox/)
+
+      Verify the permission of the sandbox.
+
+Subcommands options
+--------------
+- Force option: ::
 
       traffic_layout init --force (--path /path/to/sandbox)
-      traffic_layout remove --force --path /path/to/sandbox
+      traffic_layout remove --force (--path /path/to/sandbox)
 
-   Force create sandbox and overwrite existing directory when directory is not empty or has a yaml file in it.
-   Force removing a directory when directory has no yaml file.
+      Force init will create sandbox even if the directory is not empty.
+      Force remove will remove a directory even if directory has no yaml file.
 
-#. Use absolute flag for creating: ::
+- Absolute option: ::
 
       traffic_layout init --absolute (--path /path/to/sandbox)
 
-   create sandbox and put directories in the yaml file with absolute path form.
+      create the sandbox and put directories in the yaml file in the form of absolute path.
+
+- Fix option: ::
+
+      traffic_layout verify --fix (--path /path/to/sandbox)
+
+      Fix the permission issues verify found. ``--fix`` requires root privilege (sudo).
 
 Usage for other programs:
 ==============================================
 
-Use command line path or use :envvar:`TS_RUNROOT`.
-If command line path and envvar are not found, program will try to find the current executing program bin path or current working directory to use as runroot if the yaml file is found. 
-For bin path and cwd, it can go one level up to the parent directory to find the yaml file. ::
+All programs can find the runroot to use in the following order
 
-   trafficserver --run-root=/path/to/runroot (use /path/to/runroot as runroot)
-   trafficserver --run-root                  (use $TS_RUNROOT as runroot)
+      #. specified in --run-root=/path/to/runroot (path needs to be absolute)
+      #. :envvar:`TS_RUNROOT`
+      #. current working directory
+      #. installed directory
 
-.. envvar:: TS_RUNROOT
-
-   The path to run root directory.
-
-Notes
-==========
-
-.. note:: Path to sandbox must be an absolute path.
+if none of the above is found as runroot, runroot will not be used


### PR DESCRIPTION
1. The ``--fix`` option is added to the verify subcommand of traffic_layout.
2. ``--fix`` is able to fix the permission issues verify found (require root privilege).
3. ``verify`` subcommand is updated and does not require root privilege.
4. Small update on the file system about the determination of executable file type.
5. The document is updated accordingly.