### PR TITLE
Remove the default tab size in editorconfig, and create C/C++ section

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,9 +26,11 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 indent_style = space
-indent_size = 2
 trim_trailing_whitespace = true
 max_line_length = 132
+# C and C++
+[{*.c, *.h, *.cc, *.cpp}]
+indent_size = 2
 # Python
 [*.py]
 indent_size = 4
@@ -37,6 +39,7 @@ charset = utf-8
 [{*.pm,*.pl}]
 indent_size = 4
 charset = utf-8
+# Makefile's
 [*.am]
 trim_trailing_whitespace = false
 indent_style = tab


### PR DESCRIPTION
The default of two for a tab stop makes it really easy to make dumb mistakes in the Makefile's.