### PR TITLE
Corrects marshaling of source ip and port

### DIFF
--- a/proxy/logging/LogAccessHttp.cc
+++ b/proxy/logging/LogAccessHttp.cc
@@ -1056,14 +1056,14 @@ LogAccessHttp::marshal_proxy_req_server_name(char *buf)
 int
 LogAccessHttp::marshal_proxy_req_server_ip(char *buf)
 {
-  return marshal_ip(buf, m_http_sm->t_state.current.server != nullptr ? &m_http_sm->t_state.current.server->dst_addr.sa : nullptr);
+  return marshal_ip(buf, m_http_sm->t_state.current.server != nullptr ? &m_http_sm->t_state.current.server->src_addr.sa : nullptr);
 }
 
 int
 LogAccessHttp::marshal_proxy_req_server_port(char *buf)
 {
   if (buf) {
-    uint16_t port = ntohs(m_http_sm->t_state.current.server != nullptr ? m_http_sm->t_state.current.server->dst_addr.port() : 0);
+    uint16_t port = ntohs(m_http_sm->t_state.current.server != nullptr ? m_http_sm->t_state.current.server->src_addr.port() : 0);
     marshal_int(buf, port);
   }
   return INK_MIN_ALIGN;


### PR DESCRIPTION
Found this while trying to use [pqsi and pqsp](https://docs.trafficserver.apache.org/en/7.1.x/admin-guide/logging/formatting.en.html?highlight=formatting#admin-logging-fields-network).