### PR TITLE
Update initialization to activate openssl async_job properly

### DIFF
--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -124,6 +124,9 @@ SSL_CTX *SSLCreateServerContext(const SSLConfigParams *params);
 // Initialize the SSL library.
 void SSLInitializeLibrary();
 
+// Initialize SSL library based on configuration settings
+void SSLPostConfigInitialize();
+
 // Initialize SSL statistics.
 void SSLInitializeStatistics();
 

--- a/iocore/net/SSLNetProcessor.cc
+++ b/iocore/net/SSLNetProcessor.cc
@@ -60,6 +60,7 @@ SSLNetProcessor::start(int, size_t stacksize)
   // This initialization order matters ...
   SSLInitializeLibrary();
   SSLConfig::startup();
+  SSLPostConfigInitialize();
   SNIConfig::startup();
 
   if (!SSLCertificateConfig::startup()) {

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -880,6 +880,24 @@ ssl_track_free(void *ptr, const char * /*filename*/, int /*lineno*/)
   ats_track_free(ptr, &ssl_memory_freed);
 }
 
+/*
+ * Some items are only initialized if certain config values are set
+ * Must have a second pass that initializes after loading the SSL config
+ */
+void
+SSLPostConfigInitialize()
+{
+  if (SSLConfigParams::engine_conf_file) {
+    ENGINE_load_dynamic();
+
+    OPENSSL_load_builtin_modules();
+    if (CONF_modules_load_file(SSLConfigParams::engine_conf_file, nullptr, 0) <= 0) {
+      Error("FATAL: error loading engine configuration file %s", SSLConfigParams::engine_conf_file);
+      // ERR_print_errors_fp(stderr);
+    }
+  }
+}
+
 void
 SSLInitializeLibrary()
 {
@@ -895,22 +913,6 @@ SSLInitializeLibrary()
 
     SSL_load_error_strings();
     SSL_library_init();
-
-#if TS_USE_TLS_ASYNC
-    if (SSLConfigParams::async_handshake_enabled) {
-      ASYNC_init_thread(0, 0);
-    }
-#endif
-
-    if (SSLConfigParams::engine_conf_file) {
-      ENGINE_load_dynamic();
-
-      OPENSSL_load_builtin_modules();
-      if (CONF_modules_load_file(SSLConfigParams::engine_conf_file, nullptr, 0) <= 0) {
-        Error("FATAL: error loading engine configuration file %s", SSLConfigParams::engine_conf_file);
-        // ERR_print_errors_fp(stderr);
-      }
-    }
 
 #ifdef OPENSSL_FIPS
     // calling FIPS_mode_set() will force FIPS to POST (Power On Self Test)


### PR DESCRIPTION
Initial commit of the ASYNC_JOBS was not correctly initializing the ASYNC_JOB features.  Need to read some configs before attempting to initialize.