### PR TITLE
This adds a new callback to remap APIs: TSRemapConfigReload

### DIFF
--- a/doc/developer-guide/api/functions/TSRemap.en.rst
+++ b/doc/developer-guide/api/functions/TSRemap.en.rst
@@ -30,6 +30,7 @@ Synopsis
 `#include <ts/remap.h>`
 
 .. function:: TSReturnCode TSRemapInit(TSRemapInterface * api_info, char * errbuf, int errbuf_size)
+.. function:: void TSRemapConfigReload(void)
 .. function:: void TSRemapDone(void)
 .. function:: TSRemapStatus TSRemapDoRemap(void * ih, TSHttpTxn rh, TSRemapRequestInfo * rri)
 .. function:: TSReturnCode TSRemapNewInstance(int argc, char * argv[], void ** ih, char * errbuf, int errbuf_size)
@@ -57,11 +58,16 @@ the remap plugin.
 A remap plugin may be invoked for different remap rules. Traffic Server
 will call the entry point each time a plugin is specified in a remap
 rule. When a remap plugin instance is no longer required, Traffic Server
-will call :func:`TSRemapDeleteInstance`.
+will call :func:`TSRemapDeleteInstance`. At that point, it's safe to remove
+any data or continuations associated with that instance.
 
 :func:`TSRemapDoRemap` is called for each HTTP transaction. This is a mandatory
 entry point. In this function, the remap plugin may examine and modify
 the HTTP transaction.
+
+:func:`TSRemapConfigReload` is called once for every remap plugin just before the
+remap configuration file (:file:`remap.config`) is reloaded. This is an optional
+entry point, which takes no arguments and has no return value.
 
 Types
 =====

--- a/proxy/ReverseProxy.cc
+++ b/proxy/ReverseProxy.cc
@@ -44,8 +44,8 @@
 
 // Global Ptrs
 static Ptr<ProxyMutex> reconfig_mutex;
-UrlRewrite *rewrite_table = nullptr;
-remap_plugin_info *remap_pi_list; // We never reload the remap plugins, just append to 'em.
+UrlRewrite *rewrite_table        = nullptr;
+remap_plugin_info *remap_pi_list = nullptr; // We never reload the remap plugins, just append to 'em.
 
 // Tokens for the Callback function
 #define FILE_CHANGED 0
@@ -58,7 +58,6 @@ remap_plugin_info *remap_pi_list; // We never reload the remap plugins, just app
 //
 // Begin API Functions
 //
-
 int
 init_reverse_proxy()
 {

--- a/proxy/api/ts/remap.h
+++ b/proxy/api/ts/remap.h
@@ -88,6 +88,14 @@ typedef enum {
 */
 tsapi TSReturnCode TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size);
 
+/* This gets called everytime remap.config is reloaded. This is complementary
+   to TSRemapInit() which gets called when the plugin is first loaded. You can
+   not fail, or cause reload to stop here, it's merely a notification.
+   Optional function.
+   Return: none
+*/
+tsapi void TSRemapConfigReload(void);
+
 /* Remap new request
    Mandatory interface function.
    Remap API plugin can/should use SDK API function calls inside this function!

--- a/proxy/http/remap/RemapPluginInfo.cc
+++ b/proxy/http/remap/RemapPluginInfo.cc
@@ -31,6 +31,7 @@ remap_plugin_info::remap_plugin_info(char *_path)
     path_size(0),
     dlh(nullptr),
     fp_tsremap_init(nullptr),
+    fp_tsremap_config_reload(nullptr),
     fp_tsremap_done(nullptr),
     fp_tsremap_new_instance(nullptr),
     fp_tsremap_delete_instance(nullptr),
@@ -106,4 +107,20 @@ remap_plugin_info::delete_my_list()
   }
 
   delete this;
+}
+
+//
+// Tell all plugins (that so wish) that remap.config is being reloaded
+//
+void
+remap_plugin_info::indicate_reload()
+{
+  remap_plugin_info *p = this;
+
+  while (p) {
+    if (p->fp_tsremap_config_reload) {
+      p->fp_tsremap_config_reload();
+    }
+    p = p->next;
+  }
 }

--- a/proxy/http/remap/RemapPluginInfo.h
+++ b/proxy/http/remap/RemapPluginInfo.h
@@ -28,6 +28,7 @@
 #include "api/ts/remap.h"
 
 #define TSREMAP_FUNCNAME_INIT "TSRemapInit"
+#define TSREMAP_FUNCNAME_CONFIG_RELOAD "TSRemapConfigReload"
 #define TSREMAP_FUNCNAME_DONE "TSRemapDone"
 #define TSREMAP_FUNCNAME_NEW_INSTANCE "TSRemapNewInstance"
 #define TSREMAP_FUNCNAME_DELETE_INSTANCE "TSRemapDeleteInstance"
@@ -43,6 +44,7 @@ class remap_plugin_info
 {
 public:
   typedef TSReturnCode _tsremap_init(TSRemapInterface *api_info, char *errbuf, int errbuf_size);
+  typedef void _tsremap_config_reload();
   typedef void _tsremap_done(void);
   typedef TSReturnCode _tsremap_new_instance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_size);
   typedef void _tsremap_delete_instance(void *);
@@ -54,6 +56,7 @@ public:
   int path_size;
   void *dlh; /* "handle" for the dynamic library */
   _tsremap_init *fp_tsremap_init;
+  _tsremap_config_reload *fp_tsremap_config_reload;
   _tsremap_done *fp_tsremap_done;
   _tsremap_new_instance *fp_tsremap_new_instance;
   _tsremap_delete_instance *fp_tsremap_delete_instance;
@@ -66,6 +69,7 @@ public:
   remap_plugin_info *find_by_path(char *_path);
   void add_to_list(remap_plugin_info *pi);
   void delete_my_list();
+  void indicate_reload();
 };
 
 /**


### PR DESCRIPTION
The purpose of this is to send a notification to every remap plugin
(if they implement this callback) that a remap.config is about to
be reloaded. This can be useful for some plugin that needs to know
that it's about to get instantiated one or numerous times.

This new callback is optional, so this should be a compatible
change. It takes no arguments, and has no return value.

Once this has landed, I'll update the s3_auth plugin with an example
how this new callback can be useful. But tldr; this plugin has a
little config state cache, which has to be reset whenever the remap
rules are reloaded.