### PR TITLE
Parent Selection -- Balance treatment of primary and secondary parent…

### DIFF
--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -519,8 +519,13 @@ ParentRecord::ProcessParents(char *val, bool isPrimary)
   return nullptr;
 
 MERROR:
-  ats_free(parents);
-  parents = nullptr;
+  if (isPrimary) {
+    ats_free(parents);
+    parents = nullptr;
+  } else {
+    ats_free(secondary_parents);
+    secondary_parents = nullptr;
+  }
 
   return errPtr;
 }


### PR DESCRIPTION
…s in ProcessParents().

If an error is detected in ParentRecord::ProcessParents(), then the interim parent
memory is freed. This was being done only for primary parents but not for secondary
parents.

Not certain this is a memory leak, but certainly the init vs freed of parent vs secondary-parent was not balanced in this function. I added a debug tag (for testing) to the class destruct method (which was the only place the secondary-parent was freed previously), and I did not see it called.