### PR TITLE
Fix parsing of runroot from ink_args of 7.1.x

### DIFF
--- a/lib/ts/ink_args.cc
+++ b/lib/ts/ink_args.cc
@@ -219,9 +219,12 @@ process_args_ex(const AppVersionInfo *appinfo, const ArgumentDescription *argume
     if ((*argv)[1] == '-') {
       // Deal with long options ...
       for (i = 0; i < n_argument_descriptions; i++) {
-        if (!strcmp(argument_descriptions[i].name, "run-root")) {
+        // handle the runroot arg
+        std::string cur_argv = *argv + 2;
+        if (cur_argv.size() >= 8 && cur_argv.substr(0, 8) == "run-root") {
           break;
         }
+        // handle the args
         if (!strcmp(argument_descriptions[i].name, (*argv) + 2)) {
           *argv += strlen(*argv) - 1;
           if (!process_arg(appinfo, argument_descriptions, n_argument_descriptions, i, &argv)) {


### PR DESCRIPTION
This is for branch 7.1.x

The previous change to ink_args.cc cherry picked from commit 30c2c35e5ed1daadcf8a8db5e46760e3d7ae5325 caused issue with the command line using.

It was fixed in commit 8bc227945e0e13dfb553b63d3ea6822d2c90d879 of master.