### PR TITLE
Test: autest for traffic_layout verify runroot and expected error

### DIFF
--- a/tests/gold_tests/runroot/runroot_error.test.py
+++ b/tests/gold_tests/runroot/runroot_error.test.py
@@ -1,0 +1,70 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import sys
+import time
+
+Test.Summary = '''
+Test for expected error and failure of runroot from traffic_layout.
+'''
+Test.ContinueOnFail = True
+
+p = Test.MakeATSProcess("ts")
+ts_root = p.Env['TS_ROOT']
+
+# create runroot
+path = os.path.join(ts_root, "runroot")
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = "$ATS_BIN/traffic_layout init --path " + path
+f = tr.Disk.File(os.path.join(path, "runroot_path.yml"))
+f.Exists = True
+
+# bad command line args
+tr = Test.AddTestRun("wrong usage")
+tr.Processes.Default.Command = "$ATS_BIN/traffic_layout init --path"
+tr.Processes.Default.Streams.All = Testers.ContainsExpression("init Usage", "init incorrect usage")
+tr.Processes.Default.Streams.All = Testers.ContainsExpression("remove Usage", "init incorrect usage")
+tr.Processes.Default.Streams.All = Testers.ContainsExpression("verify Usage", "init incorrect usage")
+
+# use existing runroot
+tr = Test.AddTestRun("using existing runroot")
+tr.Processes.Default.Command = "$ATS_BIN/traffic_layout init --path " + path
+tr.Processes.Default.Streams.All = Testers.ContainsExpression("Using existing runroot", "init incorrect usage")
+f = tr.Disk.File(os.path.join(path, "runroot_path.yml"))
+f.Exists = True
+
+# create runroot inside another
+path_inside = os.path.join(path, "runroot")
+tr = Test.AddTestRun("create runroot inside runroot")
+tr.Processes.Default.Command = "$ATS_BIN/traffic_layout init --path " + path_inside
+tr.Processes.Default.Streams.All = Testers.ContainsExpression(
+    "Cannot create runroot inside another runroot", "init incorrect usage")
+f = tr.Disk.File(os.path.join(path_inside, "runroot_path.yml"))
+f.Exists = False
+
+# remove invalid runroot
+path_invalid = os.path.join(ts_root, "tmp")
+tr = Test.AddTestRun("remove invalid runroot")
+tr.Processes.Default.Command = "$ATS_BIN/traffic_layout remove --path " + path_invalid
+tr.Processes.Default.Streams.All = Testers.ContainsExpression("Bad path", "init incorrect usage")
+
+# verify invalid runroot
+tr = Test.AddTestRun("verify invalid runroot")
+tr.Processes.Default.Command = "$ATS_BIN/traffic_layout verify --path " + path_invalid
+tr.Processes.Default.Streams.All = Testers.ContainsExpression("Bad path", "init incorrect usage")

--- a/tests/gold_tests/runroot/runroot_use.test.py
+++ b/tests/gold_tests/runroot/runroot_use.test.py
@@ -43,13 +43,13 @@ f.Exists = True
 
 # 1. --run-root use path cmd
 tr = Test.AddTestRun("use runroot via commandline")
-tr.Processes.Default.Command = os.path.join("$ATS_BIN/traffic_layout info --run-root=" + path)
+tr.Processes.Default.Command = "$ATS_BIN/traffic_layout info --run-root=" + path
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("PREFIX: " + path, "commandline runroot path")
 
 # 2. use cwd as runroot
 tr = Test.AddTestRun("use runroot via cwd")
-tr.Processes.Default.Command = "cd " + path + ";" + os.path.join("$ATS_BIN/traffic_layout info")
+tr.Processes.Default.Command = "cd " + path + ";" + "$ATS_BIN/traffic_layout info"
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("PREFIX: " + path, "cwd runroot path")
 
@@ -62,6 +62,6 @@ tr.Processes.Default.Streams.All = Testers.ContainsExpression("PREFIX: " + path,
 # 3. TS_RUNROOT ENV variable
 tr = Test.AddTestRun("use runroot via TS_RUNROOT")
 tr.Processes.Default.Env["TS_RUNROOT"] = path2
-tr.Processes.Default.Command = os.path.join("$ATS_BIN/traffic_layout info")
+tr.Processes.Default.Command = "$ATS_BIN/traffic_layout info"
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("PREFIX: " + path2, "$TS_RUNROOT Env path")

--- a/tests/gold_tests/runroot/runroot_verify.test.py
+++ b/tests/gold_tests/runroot/runroot_verify.test.py
@@ -1,0 +1,67 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import sys
+import time
+
+Test.Summary = '''
+Test for verify of runroot from traffic_layout.
+'''
+Test.ContinueOnFail = True
+
+p = Test.MakeATSProcess("ts")
+ts_root = p.Env['TS_ROOT']
+
+# create runroot
+path = os.path.join(ts_root, "runroot")
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = "$ATS_BIN/traffic_layout init --path " + path
+f = tr.Disk.File(os.path.join(path, "runroot_path.yml"))
+f.Exists = True
+
+# verify test #1
+tr = Test.AddTestRun("verify runroot test1")
+tr.Processes.Default.Command = "$ATS_BIN/traffic_layout verify --path " + path
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.All = Testers.ContainsExpression(
+    os.path.join(path, "bin"), "example bindir output")
+tr.Processes.Default.Streams.All = Testers.ContainsExpression(
+    os.path.join(path, "var/log/trafficserver"), "example logdir output")
+tr.Processes.Default.Streams.All = Testers.ContainsExpression(
+    "Read Permission: ", "read permission output")
+tr.Processes.Default.Streams.All = Testers.ContainsExpression(
+    "Execute Permission: ", "execute permission output")
+tr.Processes.Default.Streams.All = Testers.ContainsExpression(
+    "Write Permission: ", "write permission output")
+
+# verify test #2
+tr = Test.AddTestRun("verify runroot test2")
+tr.Processes.Default.Command = "cd " + path + \
+    ";" + "bin/traffic_layout verify --path " + path
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.All = Testers.ContainsExpression(
+    os.path.join(path, "bin"), "example bindir output")
+tr.Processes.Default.Streams.All = Testers.ContainsExpression(
+    os.path.join(path, "var/log/trafficserver"), "example logdir output")
+tr.Processes.Default.Streams.All = Testers.ContainsExpression(
+    "Read Permission: ", "read permission output")
+tr.Processes.Default.Streams.All = Testers.ContainsExpression(
+    "Execute Permission: ", "execute permission output")
+tr.Processes.Default.Streams.All = Testers.ContainsExpression(
+    "Write Permission: ", "write permission output")


### PR DESCRIPTION
- Update the original test of traffic_layout runroot (test for init)
- Add two new tests:
1. runroot_verify.test.py: test for verify functionality of traffic_layout runroot.
2. runroot_error.test.py: test for expected errors and failure of traffic_layout runroot.