### PR TITLE
Fix in cache truncate when read_while_write #3503

### DIFF
--- a/iocore/cache/CacheRead.cc
+++ b/iocore/cache/CacheRead.cc
@@ -784,7 +784,7 @@ Lread : {
         if (dir_offset(&dir) == dir_offset(&earliest_dir)) {
           DDebug("cache_read_agg", "%p: key: %X ReadMain complete: %d", this, first_key.slice32(1), (int)vio.ndone);
           doc_len = vio.ndone;
-          goto Leos;
+          goto Lcomplete;
         }
       }
       DDebug("cache_read_agg", "%p: key: %X ReadMain writer aborted: %d", this, first_key.slice32(1), (int)vio.ndone);
@@ -802,6 +802,8 @@ Lread : {
   // remove the directory entry
   dir_delete(&earliest_key, vol, &earliest_dir);
 }
+Lcomplete:
+  return calluser(VC_EVENT_READ_COMPLETE);
 Lerror:
   return calluser(VC_EVENT_ERROR);
 Leos:


### PR DESCRIPTION
Chunked transmission when read_while_write, if Cache Write multi fragments, read while write will be truncated.

Chunked transmission process, the Content-Length is non-existent. The writer finished one fragment at a time, the reader user dir_proble find it. if not find, there may be three case.
1. the writer not write fragment. (next fragment) -- schedule reader
2. the writer error  -- this case, the writer will delete earliest_dir.
3. the write complete -- should call user read_complete.