### PR TITLE
MemArena: overhaul and cleanup.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1347,6 +1347,7 @@ add_executable(test_tslib
 	lib/ts/unit-tests/test_ink_inet.cc
 	lib/ts/unit-tests/test_IpMap.cc
 	lib/ts/unit-tests/test_layout.cc
+	lib/ts/unit-tests/test_MemSpan.cc
 	lib/ts/unit-tests/test_MT_hashtable.cc
 	lib/ts/unit-tests/test_Scalar.cc
 	lib/ts/unit-tests/test_string_view.cc

--- a/cmd/traffic_cache_tool/CacheDefs.cc
+++ b/cmd/traffic_cache_tool/CacheDefs.cc
@@ -270,7 +270,7 @@ Stripe::validateMeta(StripeMeta const *meta)
 bool
 Stripe::probeMeta(MemSpan &mem, StripeMeta const *base_meta)
 {
-  while (mem.usize() >= sizeof(StripeMeta)) {
+  while (mem.size() >= sizeof(StripeMeta)) {
     StripeMeta const *meta = mem.ptr<StripeMeta>(0);
     if (this->validateMeta(meta) && (base_meta == nullptr ||               // no base version to check against.
                                      (meta->version == base_meta->version) // need more checks here I think.

--- a/lib/ts/BufferWriterFormat.cc
+++ b/lib/ts/BufferWriterFormat.cc
@@ -591,14 +591,14 @@ bwformat(BufferWriter &w, BWFSpec const &spec, string_view sv)
 BufferWriter &
 bwformat(BufferWriter &w, BWFSpec const &spec, MemSpan const &span)
 {
-  static const BWFormat default_fmt{"{:#x}@{}"};
+  static const BWFormat default_fmt{"{:#x}@{:p}"};
   if (spec._ext.size() && 'd' == spec._ext.front()) {
     const char *digits = 'X' == spec._type ? bw_fmt::UPPER_DIGITS : bw_fmt::LOWER_DIGITS;
     if (spec._radix_lead_p) {
       w.write('0');
       w.write(digits[33]);
     }
-    bw_fmt::Hex_Dump(w, string_view{static_cast<char *>(span.data()), span.usize()}, digits);
+    bw_fmt::Hex_Dump(w, span.view(), digits);
   } else {
     w.print(default_fmt, span.size(), span.data());
   }


### PR DESCRIPTION
I made `size` return `size_t` because it was just too annoying to have it be signed. I also added easier conversion to `string_view` on the basis that the writable version should easily convert to the const / read only version and not the other way.