### PR TITLE
Fix in cache truncate when read_while_write #3503

### DIFF
--- a/iocore/cache/CachePages.cc
+++ b/iocore/cache/CachePages.cc
@@ -337,6 +337,13 @@ ShowCache::handleCacheEvent(int event, Event *e)
     CacheHTTPInfoVector *vec = &(cache_vc->vector);
     int alt_count            = vec->count();
     if (alt_count) {
+      // check cache_vc->first_buf is NULL, response cache lookup busy.
+      if (!cache_vc->first_buf.m_ptr) {
+        cache_vc->do_io_close(-1);
+        CHECK_SHOW(show("<H3>Cache Lookup Busy, please try again</H3>\n"));
+        return complete(event, e);
+      }
+
       Doc *d = (Doc *)(cache_vc->first_buf->data());
       time_t t;
       char tmpstr[4096];


### PR DESCRIPTION
Chunked transmission when read_while_write, if Cache Write multi fragments, read while write will be truncated.

Chunked transmission process, the Content-Length is non-existent. The writer finished one fragment at a time, the reader user dir_proble find it. if not find, there may be three case.
1. the writer not write fragment. (next fragment) -- schedule reader
2. the writer error  -- this case, the writer will delete earliest_dir.
3. the write complete -- should call user read_complete.