### PR TITLE
Parent Selection -- Add option to mark down self specified as a parent.

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -1317,10 +1317,20 @@ Parent Proxy Configuration
 
 .. ts:cv:: CONFIG proxy.local.http.parent_proxy.disable_connect_tunneling INT 0
 
-.. ts:cv:: CONFIG proxy.config.http.parent_proxy.self_detect INT 1
+.. ts:cv:: CONFIG proxy.config.http.parent_proxy.self_detect INT 2
 
-   Filter out hosts that are determined to be the same as the current host, e.g., localhost,
-   that have been specified in any parent and secondary_parent lists in the parent.config file.
+   For each host that has been specified in a ``parent`` or ``secondary_parent`` list in the
+   :file:`parent.config` file, determine if the host is the same as the current host.
+   Obvious examples include ``localhost`` and ``127.0.0.1``. If a match is found,
+   take an action depending upon the value below.
+
+   ===== ======================================================================
+   Value Description
+   ===== ======================================================================
+   ``0`` Disables the feature by not checking for matches.
+   ``1`` Remove the matching host from the list.
+   ``2`` Mark the host down. This is the default.
+   ===== ======================================================================
 
 HTTP Connection Timeouts
 ========================

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -446,7 +446,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.http.parent_proxy.mark_down_hostdb", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.http.parent_proxy.self_detect", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  {RECT_CONFIG, "proxy.config.http.parent_proxy.self_detect", RECD_INT, "2", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.http.forward.proxy_auth_to_parent", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,

--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -40,7 +40,7 @@ typedef ControlMatcher<ParentRecord, ParentResult> P_table;
 // Global Vars for Parent Selection
 static const char modulePrefix[]                             = "[ParentSelection]";
 static ConfigUpdateHandler<ParentConfig> *parentConfigUpdate = nullptr;
-static int self_detect                                       = 1;
+static int self_detect                                       = 2;
 
 // Config var names
 static const char *file_var      = "proxy.config.http.parent_proxy.file";
@@ -353,6 +353,7 @@ ParentRecord::PreProcessParents(const char *val, const int line_num, char *buf, 
   std::string str;
   Machine *machine                   = Machine::instance();
   constexpr char PARENT_DELIMITERS[] = ";, ";
+  HostStatus &hs                     = HostStatus::instance();
 
   strncpy(_val, val, strlen(val));
 
@@ -364,15 +365,28 @@ ParentRecord::PreProcessParents(const char *val, const int line_num, char *buf, 
       memset(fqdn, 0, sizeof(fqdn));
       strncpy(fqdn, token, len);
       if (self_detect && machine->is_self(fqdn)) {
-        Debug("parent_select", "token: %s, matches this machine.  Removing self from parent list at line %d", fqdn, line_num);
-        token = strtok_r(nullptr, PARENT_DELIMITERS, &savePtr);
-        continue;
+        if (self_detect == 1) {
+          Debug("parent_select", "token: %s, matches this machine.  Removing self from parent list at line %d", fqdn, line_num);
+          token = strtok_r(nullptr, PARENT_DELIMITERS, &savePtr);
+          continue;
+        } else {
+          Debug("parent_select", "token: %s, matches this machine.  Marking down self from parent list at line %d", fqdn, line_num);
+          hs.createHostStat(fqdn);
+          hs.setHostStatus(fqdn, HostStatus_t::HOST_STATUS_DOWN);
+        }
       }
     } else {
       if (self_detect && machine->is_self(token)) {
-        Debug("parent_select", "token: %s, matches this machine.  Removing self from parent list at line %d", token, line_num);
-        token = strtok_r(nullptr, PARENT_DELIMITERS, &savePtr);
-        continue;
+        if (self_detect == 1) {
+          Debug("parent_select", "token: %s, matches this machine.  Removing self from parent list at line %d", token, line_num);
+          token = strtok_r(nullptr, PARENT_DELIMITERS, &savePtr);
+          continue;
+        } else {
+          Debug("parent_select", "token: %s, matches this machine.  Marking down self from parent list at line %d", token,
+                line_num);
+          hs.createHostStat(token);
+          hs.setHostStatus(token, HostStatus_t::HOST_STATUS_DOWN);
+        }
       }
     }
 
@@ -587,7 +601,7 @@ ParentRecord::Init(matcher_line *line_info)
   bool used              = false;
   ParentRR_t round_robin = P_NO_ROUND_ROBIN;
   char buf[128];
-  RecInt rec_self_detect = 1;
+  RecInt rec_self_detect = 2;
 
   this->line_num = line_info->line_num;
   this->scheme   = nullptr;


### PR DESCRIPTION
Extends the proxy.config.http.parent_proxy.self_detect configuration
option so that a specified parent that has been detected as self may be
marked down instead of removed from the parent list.

This may be useful in some Parent Selection Consistent Hashing configurations
where we want the self-parent to remain in the hash ring but never be selected.
Simply removing the self-parent would change the distribution of parent
selection URLs across the remaining parents.