### PR TITLE
Fix a nullptr dereference

### DIFF
--- a/proxy/hdrs/HttpCompat.cc
+++ b/proxy/hdrs/HttpCompat.cc
@@ -454,7 +454,8 @@ HttpCompat::do_header_values_rfc2068_14_43_match(MIMEField *hdr1, MIMEField *hdr
   const char *hdr2_val = iter2.get_first(hdr2, &hdr2_val_len);
 
   while (hdr1_val || hdr2_val) {
-    if (hdr1_val_len != hdr2_val_len || ParseRules::strncasecmp_eow(hdr1_val, hdr2_val, hdr1_val_len) == false) {
+    if (!hdr1_val || !hdr2_val || hdr1_val_len != hdr2_val_len ||
+        ParseRules::strncasecmp_eow(hdr1_val, hdr2_val, hdr1_val_len) == false) {
       return false;
     }
 


### PR DESCRIPTION
clang-analyzer found that `hdr1_val ` can be null and be dereferenced in `strncasecmp_eow`.