### PR TITLE
Search cache for urls matching the regex input

### DIFF
--- a/cmd/traffic_cache_tool/CacheDefs.h
+++ b/cmd/traffic_cache_tool/CacheDefs.h
@@ -279,14 +279,45 @@ public:
 
 class DFA;
 // this class matches url of the format : scheme://hostname:port/path;params?query
+
 struct url_matcher {
-  // R"(^https?\:\/\/^[a-z A-Z 0-9]\.[a-z A-Z 0-9 \.]+)"
+  url_matcher(ts::FilePath const &path) // file contains a list of regex
+  {
+    ts::BulkFile cfile(path);
+    if (cfile.load() == 0) {
+      ts::TextView fileContent = cfile.content();
+      const char **patterns;
+      std::vector<std::string> str_vec;
+      int count = 0;
+      while (fileContent) {
+        ts::TextView line = fileContent.take_prefix_at('\n');
+        std::string reg_str(line.data(), line.size());
+        str_vec.push_back(reg_str);
+        count++;
+      }
+      patterns = (const char **)ats_malloc(count * sizeof(char *));
+      int i    = 0;
+      for (auto str : str_vec) {
+        patterns[i++] = ats_strdup(str.data());
+
+        std::cout << "regex input\n" << patterns[i - 1] << std::endl;
+      }
+      for (i = 0; i < count; i++) {
+        std::cout << "regex " << patterns[i] << std::endl;
+      }
+      if (regex.compile(patterns, count) != 0) {
+        std::cout << "Check your regular expression" << std::endl;
+      }
+
+      if (port.compile(R"([0-9]+$)") != 0) {
+        std::cout << "Check your regular expression" << std::endl;
+        return;
+      }
+    }
+  }
+
   url_matcher()
   {
-    /*if (regex.compile(R"(^https?\:\/\/^[a-z A-Z 0-9][\. a-z A-Z 0-9 ]+(\:[0-9]\/)?.*))") != 0) {
-        std::cout<<"Check your regular expression"<<std::endl;
-    }*/
-    //  (\w+\:[\w\W]+\@)? (:[0-9]+)?(\/.*)
     if (regex.compile(R"(^(https?\:\/\/)") != 0) {
       std::cout << "Check your regular expression" << std::endl;
       return;
@@ -298,14 +329,14 @@ struct url_matcher {
   }
 
   ~url_matcher() {}
+
   uint8_t
   match(const char *hostname) const
   {
     if (regex.match(hostname) != -1) {
       return 1;
     }
-    //   if(url_with_user.match(hostname) != -1)
-    //       return 2;
+
     return 0;
   }
   uint8_t
@@ -314,8 +345,6 @@ struct url_matcher {
     if (port.match(hostname, length) != -1) {
       return 1;
     }
-    //   if(url_with_user.match(hostname) != -1)
-    //       return 2;
     return 0;
   }
 

--- a/cmd/traffic_cache_tool/CacheScan.h
+++ b/cmd/traffic_cache_tool/CacheScan.h
@@ -40,11 +40,18 @@ namespace ct
 class CacheScan
 {
   Stripe *stripe;
+  url_matcher *u_matcher;
 
 public:
-  CacheScan(Stripe *str) : stripe(str){};
-  Errata Scan();
-  Errata get_alternates(const char *buf, int length);
+  CacheScan(Stripe *str, ts::FilePath const &path) : stripe(str)
+  {
+    if (path.has_path()) {
+      u_matcher = new url_matcher(path);
+    }
+  };
+  CacheScan(Stripe *str) : stripe(str) {}
+  Errata Scan(bool search = false);
+  Errata get_alternates(const char *buf, int length, bool search);
   Errata unmarshal(char *buf, int len, RefCountObj *block_ref);
   Errata unmarshal(HdrHeap *hh, int buf_length, int obj_type, HdrHeapObjImpl **found_obj, RefCountObj *block_ref);
   Errata unmarshal(HTTPHdrImpl *obj, intptr_t offset);

--- a/cmd/traffic_cache_tool/CacheTool.cc
+++ b/cmd/traffic_cache_tool/CacheTool.cc
@@ -749,6 +749,7 @@ Span::loadDevice()
           }
           _len = _header->num_blocks;
         } else {
+          zret = Errata::Message(0, 0, _path, " header is uninitialized or invalid");
           std::cout << "Span: " << _path << " header is uninitialized or invalid" << std::endl;
           _len = round_down(_geometry.totalsz) - _base;
         }
@@ -1350,30 +1351,36 @@ Get_Response(FilePath const &input_file_path)
   return zret;
 }
 
-void static scan_span(Span *span)
+void static scan_span(Span *span, ts::FilePath const &regex_path)
 {
   for (auto strp : span->_stripes) {
     strp->loadMeta();
     strp->loadDir();
-    strp->walk_all_buckets();
-    CacheScan cs(strp);
-    cs.Scan();
 
+    if (regex_path.has_path()) {
+      CacheScan cs(strp, regex_path);
+      cs.Scan(true);
+    } else {
+      CacheScan cs(strp);
+      cs.Scan(false);
+    }
     // break; // to be removed
   }
 }
 
 Errata
-Scan_Cache()
+Scan_Cache(ts::FilePath const &regex_path)
 {
   Errata zret;
   Cache cache;
   std::vector<std::thread> threadPool;
   if ((zret = cache.loadSpan(SpanFile))) {
+    if (zret.size()) {
+      return zret;
+    }
     cache.dumpSpans(Cache::SpanDumpDepth::SPAN);
     for (auto sp : cache._spans) {
-      threadPool.emplace_back(scan_span, sp); // move constructor is necessary since std::thread is non copyable
-      // break; // to be removed
+      threadPool.emplace_back(scan_span, sp);
     }
     for (auto &th : threadPool)
       th.join();
@@ -1446,7 +1453,7 @@ main(int argc, char *argv[])
   Commands.add(std::string("init"), std::string(" Initializes uninitialized span"),
                [&](int, char *argv[]) { return Init_disk(input_url_file); });
   Commands.add(std::string("scan"), std::string(" Scans the whole cache and lists the urls of the cached contents"),
-               [&](int, char *argv[]) { return Scan_Cache(); });
+               [&](int, char *argv[]) { return Scan_Cache(input_url_file); });
   Commands.setArgIndex(optind);
 
   if (help) {


### PR DESCRIPTION
Scans disk cache for urls matching the provided list of regular expression of urls.

Example command:

`sudo cmd/traffic_cache_tool/traffic_cache_tool --span /opt/ats_master/etc/trafficserver/storage.config --volume /opt/ats_master/etc/trafficserver/volume.config scan --input ~/regex_doc.txt `

Example input:
```^(http://whatever.com:[0-9]+/file1)
^(http://whatever.com:[0-9]+/file4)
^(http://whatever.com:[0-9]+/file7)
```