### PR TITLE
Clang6: Fix nullptr use in AtomicList.

### DIFF
--- a/lib/ts/List.h
+++ b/lib/ts/List.h
@@ -739,5 +739,7 @@ template <class C, class L = typename C::Link_link> struct AtomicSLL {
 
 template <class C, class L> inline AtomicSLL<C, L>::AtomicSLL()
 {
-  ink_atomiclist_init(&al, "AtomicSLL", (uint32_t)(uintptr_t)&L::next_link((C *)nullptr));
+  // need @c offsetof but that's not reliable until C++17, and we can't use the nullptr trick directly because
+  // clang-analyzer gets upset, so we use 0x10 as the base and subtract it back afterwards.
+  ink_atomiclist_init(&al, "AtomicSLL", reinterpret_cast<uintptr_t>(&L::next_link(reinterpret_cast<C *>(0x10))) - 0x10);
 }


### PR DESCRIPTION
This should cover 3 different issues. The underlying issue is `AtomicList` is passing `nullptr` in order to compute member offsets. If we move to C++17 we can do this cleanly, but for now I've hacked it to do basically the same thing in a way that doesn't upset clang analyzer.