### PR TITLE
Prevent memcpy overlapping buffers when assigning a CryptoHash to itself

### DIFF
--- a/lib/ts/CryptoHash.h
+++ b/lib/ts/CryptoHash.h
@@ -52,7 +52,9 @@ union CryptoHash {
   CryptoHash &
   operator=(CryptoHash const &that)
   {
-    memcpy(this, &that, sizeof(*this));
+    if (this != &that) {
+      memcpy(this, &that, sizeof(*this));
+    }
     return *this;
   }
 


### PR DESCRIPTION
This happens in open_write when assigning the cacheKey to itself
clang-analyzer line:
Improper arguments | Unix API | proxy/http/HttpCacheSM.cc | operator= | 55 | 7
memcpy  copying to overlapping memory (itself)


 