### PR TITLE
Clang6: Fix garbage return value in CacheTool.cc.

### DIFF
--- a/cmd/traffic_cache_tool/CacheTool.cc
+++ b/cmd/traffic_cache_tool/CacheTool.cc
@@ -723,7 +723,7 @@ Span::loadDevice()
 
   ats_scoped_fd fd{_path.open(flags)};
 
-  if (fd) {
+  if (fd != ts::NO_FD) {
     if (ink_file_get_geometry(fd, _geometry)) {
       off_t offset = ts::CacheSpan::OFFSET;
       CacheStoreBlocks span_hdr_size(1);                        // default.


### PR DESCRIPTION
I think it's a bool vs. int return conversion. Change to compare explicitly to `NO_FD` which is more correct.