### PR TITLE
Fixed off-by-one error in select_best_srv.

### DIFF
--- a/iocore/hostdb/P_HostDBProcessor.h
+++ b/iocore/hostdb/P_HostDBProcessor.h
@@ -373,7 +373,7 @@ HostDBRoundRobin::select_best_srv(char *target, InkRand *rand, ink_time_t now, i
     result = &info(current++ % len);
   } else {
     uint32_t xx = rand->random() % weight;
-    for (i = 0; i < len && xx >= infos[i]->data.srv.srv_weight; ++i)
+    for (i = 0; i < len - 1 && xx >= infos[i]->data.srv.srv_weight; ++i)
       xx -= infos[i]->data.srv.srv_weight;
 
     result = infos[i];


### PR DESCRIPTION
This error may never actually occur, it was reported by clang-analyzer. This
just ensures that in no case does the loop run one past the end of the array.

(cherry picked from commit ad99a3f49be7f9e9779c55cc6d344df5805fe23d)