### PR TITLE
Coverity 1021989

### DIFF
--- a/lib/ts/RbTree.cc
+++ b/lib/ts/RbTree.cc
@@ -272,7 +272,7 @@ namespace detail
 
       while (parent) { // @a n is not the root
         // If the current node is RED, we can just recolor and be done
-        if (n == RED) {
+        if (n && n == RED) {
           n->_color = BLACK;
           break;
         } else {


### PR DESCRIPTION
The non-null check isn't strictly speaking necessary because the == operator does the null check, but
the compiler should get rid of the duplicate check and it should make coverity happy.