### PR TITLE
Changed TSfread and TSfwrite to return int.

### DIFF
--- a/plugins/experimental/fq_pacing/fq_pacing.c
+++ b/plugins/experimental/fq_pacing/fq_pacing.c
@@ -54,8 +54,8 @@ static int
 fq_is_default_qdisc()
 {
   TSFile f       = 0;
-  size_t s       = 0;
-  char buffer[4] = {};
+  int s          = 0;
+  char buffer[5] = {};
   int rc         = 0;
 
   f = TSfopen("/proc/sys/net/core/default_qdisc", "r");

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -1888,14 +1888,14 @@ TSfclose(TSFile filep)
   delete file;
 }
 
-size_t
+int
 TSfread(TSFile filep, void *buf, size_t length)
 {
   FileImpl *file = (FileImpl *)filep;
   return file->fread(buf, length);
 }
 
-size_t
+int
 TSfwrite(TSFile filep, const void *buf, size_t length)
 {
   FileImpl *file = (FileImpl *)filep;

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -203,7 +203,7 @@ tsapi void TSfclose(TSFile filep);
       while reading the file, it returns -1.
 
  */
-tsapi size_t TSfread(TSFile filep, void *buf, size_t length);
+tsapi int TSfread(TSFile filep, void *buf, size_t length);
 
 /**
     Attempts to write length bytes of data from the buffer buf
@@ -220,7 +220,7 @@ tsapi size_t TSfread(TSFile filep, void *buf, size_t length);
       writing, it returns the number of bytes successfully written.
 
  */
-tsapi size_t TSfwrite(TSFile filep, const void *buf, size_t length);
+tsapi int TSfwrite(TSFile filep, const void *buf, size_t length);
 
 /**
     Flushes pending data that has been buffered up in memory from


### PR DESCRIPTION
These functions return -1 on error, so having a signed return type
was leading to incorrect usage. This also fixes a related error in
the fq_pacing plugin.

Coverity 1390800
Coverity 1390807