### PR TITLE
Clang: fix CacheTool null parameter reference.

### DIFF
--- a/cmd/traffic_cache_tool/CacheDefs.h
+++ b/cmd/traffic_cache_tool/CacheDefs.h
@@ -36,10 +36,6 @@
 #include "Command.h"
 #include "File.h"
 
-#if defined(MAGIC)
-#undef MAGIC
-#endif
-
 namespace tag
 {
 struct bytes {

--- a/cmd/traffic_cache_tool/CacheTool.cc
+++ b/cmd/traffic_cache_tool/CacheTool.cc
@@ -45,8 +45,8 @@
 #include <thread>
 
 #include "File.h"
-#include "CacheDefs.h"
 #include "Command.h"
+#include "CacheDefs.h"
 #include "CacheScan.h"
 
 using ts::Bytes;

--- a/cmd/traffic_cache_tool/File.h
+++ b/cmd/traffic_cache_tool/File.h
@@ -23,9 +23,11 @@
 
 #pragma once
 
-#include <ts/ink_memory.h>
+#include <sys/types.h>
 #include <sys/stat.h>
-#include <ts/TextView.h>
+#include <fcntl.h>
+#include "ts/ink_memory.h"
+#include "ts/TextView.h"
 
 namespace ts
 {

--- a/lib/ts/HashMD5.cc
+++ b/lib/ts/HashMD5.cc
@@ -19,8 +19,9 @@
   limitations under the License.
  */
 
-#include "ts/HashMD5.h"
 #include "ts/ink_assert.h"
+#include "ts/ink_config.h"
+#include "ts/HashMD5.h"
 
 ATSHashMD5::ATSHashMD5() : md_len(0), finalized(false)
 {

--- a/lib/ts/ink_assert.h
+++ b/lib/ts/ink_assert.h
@@ -28,7 +28,6 @@ Assertions
 #pragma once
 
 #include "ts/ink_apidefs.h"
-#include "ts/ink_error.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -45,12 +44,12 @@ extern "C" {
 inkcoreapi void _ink_assert(const char *a, const char *f, int l) TS_NORETURN;
 
 #if defined(DEBUG) || defined(__clang_analyzer__) || defined(__COVERITY__)
-#define ink_assert(EX) ((void)(likely(EX) ? (void)0 : _ink_assert(#EX, __FILE__, __LINE__)))
+#define ink_assert(EX) ((void)(__builtin_expect(!!(EX), 1) ? (void)0 : _ink_assert(#EX, __FILE__, __LINE__)))
 #else
 #define ink_assert(EX) (void)(EX)
 #endif
 
-#define ink_release_assert(EX) ((void)(likely(EX) ? (void)0 : _ink_assert(#EX, __FILE__, __LINE__)))
+#define ink_release_assert(EX) ((void)(__builtin_expect(!!(EX), 0) ? (void)0 : _ink_assert(#EX, __FILE__, __LINE__)))
 
 #ifdef __cplusplus
 }

--- a/lib/ts/ink_hrtime.cc
+++ b/lib/ts/ink_hrtime.cc
@@ -37,6 +37,7 @@
 #include <sys/param.h>
 #include <sys/sysctl.h>
 #endif
+#include <string.h>
 #include <sys/time.h>
 
 char *

--- a/lib/ts/ink_platform.h
+++ b/lib/ts/ink_platform.h
@@ -131,6 +131,9 @@ struct ifafilt;
 
 #ifdef HAVE_CPIO_H
 #include <cpio.h>
+#if defined(MAGIC)
+#undef MAGIC
+#endif
 #endif
 
 #ifdef HAVE_STROPTS_H

--- a/mgmt/api/NetworkMessage.cc
+++ b/mgmt/api/NetworkMessage.cc
@@ -23,6 +23,7 @@
 
 #include "ts/ink_config.h"
 #include "ts/ink_defs.h"
+#include "ts/ink_error.h"
 #include "ts/ink_assert.h"
 #include "ts/ink_memory.h"
 #include "mgmtapi.h"

--- a/tools/jtest/jtest.cc
+++ b/tools/jtest/jtest.cc
@@ -53,6 +53,7 @@
 #include <stdlib.h>
 
 #include "ts/ink_defs.h"
+#include "ts/ink_error.h"
 #include "ts/ink_memory.h"
 #include "ts/ink_assert.h"
 #include "ts/INK_MD5.h"


### PR DESCRIPTION
I think clang is confused, but I will try this approach.