### PR TITLE
 Upgrade API I/O functions to consistently use s/size_t.

### DIFF
--- a/doc/developer-guide/api/functions/TSfread.en.rst
+++ b/doc/developer-guide/api/functions/TSfread.en.rst
@@ -26,11 +26,16 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. function:: size_t TSfread(TSFile filep, void * buf, size_t length)
+.. function:: ssize_t TSfread(TSFile filep, void * buf, size_t length)
 
 Description
 ===========
 
 Attempts to read :arg:`length` bytes of data from the file pointed to by
-:arg:`filep` into the buffer :arg:`buf`.
+:arg:`filep` into the buffer :arg:`buf`. The behavior is undefined if
+:arg:`length` is greater than SSIZE_MAX.
 
+Return Value
+============
+
+Returns the number of bytes read on success, or -1 on failure.

--- a/doc/developer-guide/api/functions/TSfwrite.en.rst
+++ b/doc/developer-guide/api/functions/TSfwrite.en.rst
@@ -26,7 +26,7 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. function:: size_t TSfwrite(TSFile filep, const void * buf, size_t length)
+.. function:: ssize_t TSfwrite(TSFile filep, const void * buf, size_t length)
 
 Description
 ===========
@@ -39,3 +39,9 @@ number of bytes written (:c:func:`TSfwrite` returns this value) against the
 value of :arg:`length`.  If it is less, there might be insufficient space on
 disk, for example.
 
+The behavior is undefined if length is greater than SSIZE_MAX.
+
+Return Value
+============
+
+Returns the number of bytes actually written, or -1 if an error occured.

--- a/plugins/experimental/fq_pacing/fq_pacing.c
+++ b/plugins/experimental/fq_pacing/fq_pacing.c
@@ -54,8 +54,8 @@ static int
 fq_is_default_qdisc()
 {
   TSFile f       = 0;
-  size_t s       = 0;
-  char buffer[4] = {};
+  ssize_t s      = 0;
+  char buffer[5] = {};
   int rc         = 0;
 
   f = TSfopen("/proc/sys/net/core/default_qdisc", "r");

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -802,11 +802,11 @@ FileImpl::fclose()
   }
 }
 
-int
-FileImpl::fread(void *buf, int length)
+ssize_t
+FileImpl::fread(void *buf, size_t length)
 {
-  int64_t amount;
-  int64_t err;
+  size_t amount;
+  ssize_t err;
 
   if ((m_mode != READ) || (m_fd == -1)) {
     return -1;
@@ -855,11 +855,11 @@ FileImpl::fread(void *buf, int length)
   }
 }
 
-int
-FileImpl::fwrite(const void *buf, int length)
+ssize_t
+FileImpl::fwrite(const void *buf, size_t length)
 {
   const char *p, *e;
-  int64_t avail;
+  size_t avail;
 
   if ((m_mode != WRITE) || (m_fd == -1)) {
     return -1;
@@ -895,11 +895,11 @@ FileImpl::fwrite(const void *buf, int length)
   return (p - (const char *)buf);
 }
 
-int
+ssize_t
 FileImpl::fflush()
 {
   char *p, *e;
-  int err = 0;
+  ssize_t err = 0;
 
   if ((m_mode != WRITE) || (m_fd == -1)) {
     return -1;
@@ -930,10 +930,10 @@ FileImpl::fflush()
 }
 
 char *
-FileImpl::fgets(char *buf, int length)
+FileImpl::fgets(char *buf, size_t length)
 {
   char *e;
-  int pos;
+  size_t pos;
 
   if (length == 0) {
     return nullptr;
@@ -954,13 +954,15 @@ FileImpl::fgets(char *buf, int length)
   e = (char *)memchr(m_buf, '\n', m_bufpos);
   if (e) {
     e += 1;
-    if (length > (e - m_buf + 1)) {
+    if (length > (size_t)(e - m_buf + 1)) {
       length = e - m_buf + 1;
     }
   }
 
-  pos      = fread(buf, length - 1);
-  buf[pos] = '\0';
+  ssize_t rlen = fread(buf, length - 1);
+  if (rlen >= 0) {
+    buf[rlen] = '\0';
+  }
 
   return buf;
 }
@@ -1888,14 +1890,14 @@ TSfclose(TSFile filep)
   delete file;
 }
 
-size_t
+ssize_t
 TSfread(TSFile filep, void *buf, size_t length)
 {
   FileImpl *file = (FileImpl *)filep;
   return file->fread(buf, length);
 }
 
-size_t
+ssize_t
 TSfwrite(TSFile filep, const void *buf, size_t length)
 {
   FileImpl *file = (FileImpl *)filep;

--- a/proxy/InkAPIInternal.h
+++ b/proxy/InkAPIInternal.h
@@ -83,17 +83,17 @@ public:
 
   int fopen(const char *filename, const char *mode);
   void fclose();
-  int fread(void *buf, int length);
-  int fwrite(const void *buf, int length);
-  int fflush();
-  char *fgets(char *buf, int length);
+  ssize_t fread(void *buf, size_t length);
+  ssize_t fwrite(const void *buf, size_t length);
+  ssize_t fflush();
+  char *fgets(char *buf, size_t length);
 
 public:
   int m_fd;
   int m_mode;
   char *m_buf;
-  int m_bufsize;
-  int m_bufpos;
+  size_t m_bufsize;
+  size_t m_bufpos;
 };
 
 struct INKConfigImpl : public ConfigInfo {

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -203,7 +203,7 @@ tsapi void TSfclose(TSFile filep);
       while reading the file, it returns -1.
 
  */
-tsapi size_t TSfread(TSFile filep, void *buf, size_t length);
+tsapi ssize_t TSfread(TSFile filep, void *buf, size_t length);
 
 /**
     Attempts to write length bytes of data from the buffer buf
@@ -220,7 +220,7 @@ tsapi size_t TSfread(TSFile filep, void *buf, size_t length);
       writing, it returns the number of bytes successfully written.
 
  */
-tsapi size_t TSfwrite(TSFile filep, const void *buf, size_t length);
+tsapi ssize_t TSfwrite(TSFile filep, const void *buf, size_t length);
 
 /**
     Flushes pending data that has been buffered up in memory from


### PR DESCRIPTION
These functions were returning -1 on error, but in an unsigned type.
Internally, ints were being used inconsistently. This cleans it up.

Coverity 1390800
Coverity 1390807