### PR TITLE
Remove TSHttpSsnSSLConnectionGet which seems redundant.

### DIFF
--- a/plugins/experimental/sslheaders/sslheaders.cc
+++ b/plugins/experimental/sslheaders/sslheaders.cc
@@ -32,11 +32,11 @@ SslHdrExpandRequestHook(TSCont cont, TSEvent event, void *edata)
   TSHttpTxn txn;
   TSMBuffer mbuf;
   TSMLoc mhdr;
-  SSL *ssl;
 
-  txn = (TSHttpTxn)edata;
-  hdr = (const SslHdrInstance *)TSContDataGet(cont);
-  ssl = (SSL *)TSHttpSsnSSLConnectionGet(TSHttpTxnSsnGet(txn));
+  txn                 = (TSHttpTxn)edata;
+  hdr                 = (const SslHdrInstance *)TSContDataGet(cont);
+  TSVConn vconn       = TSHttpSsnClientVConnGet(TSHttpTxnSsnGet(txn));
+  TSSslConnection ssl = TSVConnSSLConnectionGet(vconn);
 
   switch (event) {
   case TS_EVENT_HTTP_READ_REQUEST_HDR:
@@ -61,7 +61,7 @@ SslHdrExpandRequestHook(TSCont cont, TSEvent event, void *edata)
     goto done;
   }
 
-  SslHdrExpand(ssl, hdr->expansions, mbuf, mhdr);
+  SslHdrExpand((SSL *)ssl, hdr->expansions, mbuf, mhdr);
   TSHandleMLocRelease(mbuf, TS_NULL_MLOC, mhdr);
 
 done:

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -5446,24 +5446,6 @@ TSHttpTxnTransformRespGet(TSHttpTxn txnp, TSMBuffer *bufp, TSMLoc *obj)
   return TS_ERROR;
 }
 
-void *
-TSHttpSsnSSLConnectionGet(TSHttpSsn ssnp)
-{
-  sdk_assert(sdk_sanity_check_null_ptr((void *)ssnp) == TS_SUCCESS);
-
-  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
-  if (cs == nullptr) {
-    return nullptr;
-  }
-
-  SSLNetVConnection *ssl_vc = dynamic_cast<SSLNetVConnection *>(cs->get_netvc());
-  if (ssl_vc == nullptr) {
-    return nullptr;
-  }
-
-  return (void *)ssl_vc->ssl;
-}
-
 sockaddr const *
 TSHttpSsnClientAddrGet(TSHttpSsn ssnp)
 {

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -1316,13 +1316,6 @@ tsapi TSReturnCode TSHttpTxnTransformRespGet(TSHttpTxn txnp, TSMBuffer *bufp, TS
 */
 tsapi void TSHttpTxnClientIncomingPortSet(TSHttpTxn txnp, int port);
 
-/** Get SSL object of this session.
-    Retrieves the SSL object of the SSL connection.
-
-    @return SSL object of this session
- */
-tsapi void *TSHttpSsnSSLConnectionGet(TSHttpSsn ssnp); /* returns SSL * */
-
 /** Get client address for transaction @a txnp.
     Retrieves the socket address of the remote client that has
     connected to Traffic Server for transaction @a txnp. The


### PR DESCRIPTION
I just discovered the TS API

void *TSHttpSsnConnectionGet(TSHttpSsn ssnp)

This seems redundant with the TSVConnSSLConnectionGet and TSHttpSsnClientVConnGet functions.

I propose removing it.  

If we need to keep this, we should document the API and change the signature to return TSSslConnection instead of void *