### PR TITLE
[QUIC] Fixs the compiler error with c++17

### DIFF
--- a/iocore/net/quic/QUICAckFrameCreator.cc
+++ b/iocore/net/quic/QUICAckFrameCreator.cc
@@ -113,6 +113,7 @@ QUICAckFrameCreator::_create_ack_frame()
     uint64_t delay = this->_calculate_delay();
     ack_frame      = QUICFrameFactory::create_ack_frame(largest_ack_number, delay, length - 1, protection);
   }
+
   return ack_frame;
 }
 

--- a/iocore/net/quic/QUICCongestionController.cc
+++ b/iocore/net/quic/QUICCongestionController.cc
@@ -87,11 +87,11 @@ QUICCongestionController::on_packet_acked(QUICPacketNumber acked_packet_number, 
 }
 
 void
-QUICCongestionController::on_packets_lost(std::map<QUICPacketNumber, PacketInfo &> lost_packets)
+QUICCongestionController::on_packets_lost(std::map<QUICPacketNumber, PacketInfo *> &lost_packets)
 {
   // Remove lost packets from bytes_in_flight.
   for (auto &lost_packet : lost_packets) {
-    this->_bytes_in_flight -= lost_packet.second.bytes;
+    this->_bytes_in_flight -= lost_packet.second->bytes;
   }
   QUICPacketNumber largest_lost_packet = lost_packets.rbegin()->first;
   // Start a new recovery epoch if the lost packet is larger

--- a/iocore/net/quic/QUICLossDetector.h
+++ b/iocore/net/quic/QUICLossDetector.h
@@ -62,7 +62,7 @@ public:
   virtual ~QUICCongestionController() {}
   void on_packet_sent(size_t bytes_sent);
   void on_packet_acked(QUICPacketNumber acked_packet_number, size_t acked_packet_size);
-  virtual void on_packets_lost(std::map<QUICPacketNumber, PacketInfo &> packets);
+  virtual void on_packets_lost(std::map<QUICPacketNumber, PacketInfo *> &packets);
   void on_retransmission_timeout_verified();
   bool check_credit() const;
 


### PR DESCRIPTION
```
/usr/bin/../lib/gcc/x86_64-linux-gnu/7.1.0/../../../../include/c++/7.1.0/bits/ptr_traits.h:133:9: error: 'rebind' declared as a pointer to a reference of type 'PacketInfo &'
        using rebind = _Up*;
        ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/7.1.0/../../../../include/c++/7.1.0/bits/ptr_traits.h:147:5: note: in instantiation of template type alias 'rebind' requested here
    using __ptr_rebind = typename pointer_traits<_Ptr>::template rebind<_Tp>;
    ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/7.1.0/../../../../include/c++/7.1.0/bits/node_handle.h:203:2: note: in instantiation of template type alias '__ptr_rebind' requested here
        using __pointer = __ptr_rebind<typename _AllocTraits::pointer, _Tp>;
        ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/7.1.0/../../../../include/c++/7.1.0/bits/node_handle.h:206:7: note: in instantiation of template type alias '__pointer' requested here
      __pointer<typename _Value::second_type>   _M_pmapped = nullptr;
      ^
QUICLossDetector.cc:392:27: note: in instantiation of template class 'std::_Node_handle<unsigned long, std::pair<const unsigned long, PacketInfo &>, std::allocator<std::_Rb_tree_node<std::pair<const
      unsigned long, PacketInfo &> > > >' requested here
      lost_packets.insert({unacked.first, *unacked.second});

```

```
clang version 5.0.0-3~16.04.1 (tags/RELEASE_500/final)
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/5
Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0
Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/6
Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/6.0.0
Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/7
Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/7.1.0
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/5
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/5.4.0
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/6
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/6.0.0
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/7
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/7.1.0
Selected GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/7.1.0
Candidate multilib: .;@m64
Selected multilib: .;@m64
```