### PR TITLE
Upgrades target autest version to 1.5.3

### DIFF
--- a/tests/bootstrap.py
+++ b/tests/bootstrap.py
@@ -26,7 +26,7 @@ import platform
 import sys
 
 pip_packages = [
-    "autest==1.5.0",
+    "autest==1.5.3",
     "hyper",
     "requests",
     "dnslib",


### PR DESCRIPTION
See https://github.com/apache/trafficserver/pull/3666#issuecomment-389241318

There was a bug in 1.5.0 in which an unnecessary operation required privilege on macOS (and possibly other systems). This was fixed by a later unrelated change as of 1.5.3.