### PR TITLE
Enhance background_fetch plugin for better squid logging

### DIFF
--- a/plugins/background_fetch/background_fetch.cc
+++ b/plugins/background_fetch/background_fetch.cc
@@ -382,7 +382,7 @@ cont_bg_fetch(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
 
     // Setup the NetVC for background fetch
     TSAssert(nullptr == data->vc);
-    if ((data->vc = TSHttpConnect((sockaddr *)&data->client_ip)) != nullptr) {
+    if ((data->vc = TSHttpConnectWithPluginId((sockaddr *)&data->client_ip, PLUGIN_NAME, 0)) != nullptr) {
       TSHttpHdrPrint(data->mbuf, data->hdr_loc, data->req_io_buf);
       // We never send a body with the request. ToDo: Do we ever need to support that ?
       TSIOBufferWrite(data->req_io_buf, "\r\n", 2);


### PR DESCRIPTION
Right now it is hard to tell from squid log which requests are from background_fetch. By replacing `TSHttpConnect` with `TSHttpConnectWithPluginId` and adding `%<pitag>` to squid log format, we can easily differentiate requests from the plugin, which makes it easier to locate issues related to connections.

Example format:
%\<pitag> %\<cqtq> %\<ttms> %\<chi> %\<crc>/%\<pssc> %\<psql> %\<cqhm> %\<cquc> %\<caun> %\<phr>/%\<pqsn> %\<psct>
Example output:
\* 1526398333.599 537 127.0.0.1 TCP_MISS/206 1654 GET http://i.imgur.com/z4d4kWk.jpg - DIRECT/i.imgur.com image/jpeg
background_fetch 1526398334.144 62 127.0.0.1 TCP_MISS/200 147068 GET http://i.imgur.com/z4d4kWk.jpg - DIRECT/i.imgur.com image/jpeg