### PR TITLE
register stats in traffic_server if running in standalone mode

### DIFF
--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -1613,6 +1613,15 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   // Restart syslog now that we have configuration info
   syslog_log_configure();
 
+  // Register stats if standalone
+  if (DEFAULT_REMOTE_MANAGEMENT_FLAG == remote_management_flag) {
+    RecRegisterStatInt(RECT_NODE, "proxy.node.config.reconfigure_time", time(nullptr), RECP_NON_PERSISTENT);
+    RecRegisterStatInt(RECT_NODE, "proxy.node.config.reconfigure_required", 0, RECP_NON_PERSISTENT);
+    RecRegisterStatInt(RECT_NODE, "proxy.node.config.restart_required.proxy", 0, RECP_NON_PERSISTENT);
+    RecRegisterStatInt(RECT_NODE, "proxy.node.config.restart_required.manager", 0, RECP_NON_PERSISTENT);
+    RecRegisterStatInt(RECT_NODE, "proxy.node.config.draining", 0, RECP_NON_PERSISTENT);
+  }
+
   // init huge pages
   int enabled;
   REC_ReadConfigInteger(enabled, "proxy.config.allocator.hugepages");


### PR DESCRIPTION
Without this the
`RecSetRecordInt("proxy.node.config.draining", 1, REC_SOURCE_DEFAULT);` on Main.cc:288 will fail,
because
```
    // Add the record but do not set the 'registered' flag, as this
    // record really hasn't been registered yet.  Also, in order to
    // add the record, we need to have a rec_type, so if the user
    // calls RecSetRecord on a record we haven't registered yet, we
    // should fail out here.
    if ((rec_type == RECT_NULL) || (data_type == RECD_NULL)) {
      err = REC_ERR_FAIL;
      goto Ldone;
    }
``` 

from P_RecCore.cc:422.

This bug is breaking the drain feature and it's needed for https://github.com/apache/trafficserver/pull/2918.