### PR TITLE
Fix linkage of traffic_manager with WCCP due to removal of metric library.

### DIFF
--- a/cmd/traffic_manager/Makefile.am
+++ b/cmd/traffic_manager/Makefile.am
@@ -54,14 +54,6 @@ traffic_manager_LDADD = \
 AM_LDFLAGS += \
 	$(LUAJIT_LDFLAGS)
 
-traffic_manager_LDADD += \
-	$(top_builddir)/lib/bindings/libbindings.la
-
-if BUILD_LUAJIT
-traffic_manager_LDADD += \
-	$(top_builddir)/lib/luajit/src/libluajit.a
-endif
-
 if SYSTEM_LUAJIT
 traffic_manager_LDADD +=\
 	@LIBLUAJIT@
@@ -80,6 +72,14 @@ traffic_manager_LDADD += \
 	$(top_builddir)/lib/tsconfig/libtsconfig.la \
 	@OPENSSL_LIBS@
 
+endif
+
+traffic_manager_LDADD += \
+	$(top_builddir)/lib/bindings/libbindings.la
+
+if BUILD_LUAJIT
+traffic_manager_LDADD += \
+	$(top_builddir)/lib/luajit/src/libluajit.a
 endif
 
 include $(top_srcdir)/build/tidy.mk


### PR DESCRIPTION
I think the problem is that due to the metrics, the LuaJIT dependences would get pulled in before the `tsconfig` library was loaded for WCCP. Without that, the LuaJIT library, being before `libtsconfig`, goes by and then `libtsconfig` can't find its Lua functions. This moves the LuaJIT library after WCCP in the link line so the dependencies are detected correcly.