### PR TITLE
Log the full ATS version to traffic.out on startup.

### DIFF
--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -1572,6 +1572,8 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   runroot_handler(argv);
   // Before accessing file system initialize Layout engine
   Layout::create();
+  // Let's be clear on what exactly is starting up.
+  printf("Traffic Server " PACKAGE_VERSION BUILD_NUMBER " " __DATE__ " " __TIME__ " " BUILD_MACHINE "\n");
   chdir_root(); // change directory to the install root of traffic server.
 
   std::sort(argument_descriptions, argument_descriptions + countof(argument_descriptions),


### PR DESCRIPTION
When supporting a number of groups upgrading it would be very useful to have the exact version of Traffic Server logged to `traffic.out`.