### PR TITLE
Replaces the old metrics.config with a simple C++ class

### DIFF
--- a/cmd/traffic_manager/traffic_manager.cc
+++ b/cmd/traffic_manager/traffic_manager.cc
@@ -49,6 +49,7 @@
 #include "RecordsConfig.h"
 
 #include "P_RecLocal.h"
+#include "DerivativeMetrics.h"
 
 #if TS_USE_POSIX_CAP
 #include <sys/capability.h>
@@ -89,8 +90,6 @@ static const char *mgmt_path = nullptr;
 static const char *recs_conf = "records.config";
 
 static int fds_limit;
-
-// ToDo: Any globals for calculated metrics
 
 // TODO: Use positive instead negative selection
 //       This should just be #if defined(solaris)
@@ -714,7 +713,7 @@ main(int argc, const char **argv)
   int sleep_time             = 0;  // sleep_time given in sec
   uint64_t last_start_epoc_s = 0;  // latest start attempt in seconds since epoc
 
-  // ToDo: Initialize whatever is needed for calculated metrics
+  DerivativeMetrics derived; // This is simple class to calculate some useful derived metrics
 
   for (;;) {
     lmgmt->processEventQueue();
@@ -731,7 +730,9 @@ main(int argc, const char **argv)
       mgmt_log("[main] Reading Configuration Files Reread\n");
     }
 
-    // ToDo: Here we should update the calculated metrics
+    // Update the derived metrics. ToDo: this runs once a second, that might be excessive, maybe it should be
+    // done more like every config_update_interval_ms (proxy.config.config_update_interval_ms) ?
+    derived.Update();
 
     if (lmgmt->mgmt_shutdown_outstanding != MGMT_PENDING_NONE) {
       Debug("lm", "pending shutdown %d", lmgmt->mgmt_shutdown_outstanding);

--- a/mgmt/DerivativeMetrics.cc
+++ b/mgmt/DerivativeMetrics.cc
@@ -1,0 +1,148 @@
+/** @file
+
+  Calculate some derivative metrics (for convenience).
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+#include <vector>
+
+#include "DerivativeMetrics.h"
+
+// ToDo: It's a little bizarre that we include this here, but it's the only way to get to RecSetRecord(). We should
+// move that elsewhere... But other places in our core does the same thing.
+#include "P_RecCore.h"
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// This currently only supports one type of derivative metrics: Sums() of other, existing metrics. It's ok to add
+// additional metrics here, and we prefer to call them proxy.process (since, hopefully in the future, traffic_manager dies).
+//
+static const std::vector<DerivativeSum> sum_metrics = {
+  // Total bytes of client request body + headers
+  {"proxy.process.http.user_agent_total_request_bytes",
+   RECD_INT,
+   {"proxy.process.http.user_agent_request_document_total_size", "proxy.process.http.user_agent_request_header_total_size"}},
+  // Total bytes of client response body + headers
+  {"proxy.process.http.user_agent_total_response_bytes",
+   RECD_INT,
+   {"proxy.process.http.user_agent_response_document_total_size", "proxy.process.http.user_agent_response_header_total_size"}},
+  // Total bytes of origin server request body + headers
+  {"proxy.process.http.origin_server_total_request_bytes",
+   RECD_INT,
+   {"proxy.process.http.origin_server_request_document_total_size", "proxy.process.http.origin_server_request_header_total_size"}},
+  // Total bytes of origin server response body + headers
+  {"proxy.process.http.origin_server_total_response_bytes",
+   RECD_INT,
+   {"proxy.process.http.origin_server_response_document_total_size",
+    "proxy.process.http.origin_server_response_header_total_size"}},
+  // Total byates of client request and response (total traffic to and from clients)
+  {"proxy.process.user_agent_total_bytes",
+   RECD_INT,
+   {"proxy.process.http.user_agent_total_request_bytes", "proxy.process.http.user_agent_total_response_bytes"}},
+  // Total bytes of origin/parent request and response
+  {"proxy.process.origin_server_total_bytes",
+   RECD_INT,
+   {"proxy.process.http.origin_server_total_request_bytes", "proxy.process.http.origin_server_total_response_bytes",
+    "proxy.process.http.parent_proxy_request_total_bytes", "proxy.process.http.parent_proxy_response_total_bytes"}},
+  // Total requests which are cache hits
+  {"proxy.process.cache_total_hits",
+   RECD_COUNTER,
+   {"proxy.process.http.cache_hit_fresh", "proxy.process.http.cache_hit_mem_fresh", "proxy.process.http.cache_hit_revalidated",
+    "proxy.process.http.cache_hit_ims", "proxy.process.http.cache_hit_stale_served"}},
+  // Total requests which are cache misses
+  {"proxy.process.cache_total_misses",
+   RECD_COUNTER,
+   {"proxy.process.http.cache_miss_cold", "proxy.process.http.cache_miss_changed", "proxy.process.http.cache_miss_client_no_cache",
+    "proxy.process.http.cache_miss_ims", "proxy.process.http.cache_miss_client_not_cacheable"}},
+  // Total requests, both hits and misses (this is slightly superflous, but assures correct percentage calculations)
+  {"proxy.process.cache_total_requests", RECD_COUNTER, {"proxy.process.cache_total_hits", "proxy.process.cache_total_misses"}},
+  // Total cache requests bytes which are cache hits
+  {"proxy.process.cache_total_hits_bytes",
+   RECD_INT,
+   {"proxy.process.http.tcp_hit_user_agent_bytes_stat", "proxy.process.http.tcp_refresh_hit_user_agent_bytes_stat",
+    "proxy.process.http.tcp_ims_hit_user_agent_bytes_stat"}},
+  // Total cache requests bytes which are cache misses
+  {"proxy.process.cache_total_misses_bytes",
+   RECD_INT,
+   {"proxy.process.http.tcp_miss_user_agent_bytes_stat", "proxy.process.http.tcp_expired_miss_user_agent_bytes_stat",
+    "proxy.process.http.tcp_refresh_miss_user_agent_bytes_stat", "proxy.process.http.tcp_ims_miss_user_agent_bytes_stat"}},
+  // Total request bytes, both hits and misses
+  {"proxy.process.cache_total_bytes", RECD_INT, {"proxy.process.cache_total_hits_bytes", "proxy.process.cache_total_misses_bytes"}},
+  // Total of all server connections (sum of origins and parent connections)
+  {"proxy.process.current_server_connections",
+   RECD_INT,
+   {"proxy.process.http.current_server_connections", "proxy.process.http.current_parent_proxy_connections"}}};
+
+// The constructor is responsible for registering the new metrics. ToDo: At some point we could
+// in theory expand this to support some sort of configuration, and then replace the hardcoded metrics
+// here with parameters to an Add() method.
+DerivativeMetrics::DerivativeMetrics()
+{
+  // Add all the sum derived metrics to LibRecords
+  for (auto &&[derived_metric, type, metric_parts] : sum_metrics) {
+    (void)metric_parts;
+
+    switch (type) {
+    case RECD_INT:
+      RecRegisterStatInt(RECT_PROCESS, derived_metric, static_cast<RecInt>(0), RECP_NON_PERSISTENT);
+      break;
+    case RECD_COUNTER:
+      RecRegisterStatCounter(RECT_PROCESS, derived_metric, static_cast<RecCounter>(0), RECP_NON_PERSISTENT);
+      break;
+    default:
+      ink_release_assert(!"Unsupported metric type");
+      break;
+    }
+  }
+}
+
+// Updates all the derived metrics
+void
+DerivativeMetrics::Update()
+{
+  int error = REC_ERR_FAIL;
+  RecData sum;
+  RecInt int_val;
+  RecCounter counter_val;
+
+  for (auto &&[derived_metric, type, metric_parts] : sum_metrics) {
+    ink_zero(sum);
+    for (auto &&metric : metric_parts) {
+      switch (type) {
+      case RECD_INT:
+        error = RecGetRecordInt(metric, &int_val);
+        sum.rec_int += int_val;
+        break;
+      case RECD_COUNTER:
+        error = RecGetRecordCounter(metric, &counter_val);
+        sum.rec_counter += counter_val;
+        break;
+      default:
+        ink_release_assert(!"Unsupported metric type");
+        break;
+      }
+      if (error) { // No point in continuing here, since the metric is failing for odd reasons
+        break;
+      }
+    }
+
+    if (!error) {
+      RecSetRecord(RECT_NULL, derived_metric, type, &sum, nullptr, REC_SOURCE_EXPLICIT);
+    }
+  }
+}

--- a/mgmt/DerivativeMetrics.h
+++ b/mgmt/DerivativeMetrics.h
@@ -1,0 +1,41 @@
+/** @file
+
+  Calculate some derivative metrics (for convenience).
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include <tuple>
+
+#include "I_RecLocal.h"
+
+using DerivativeSum = std::tuple<const char *, RecDataT, std::vector<const char *>>;
+
+class DerivativeMetrics
+{
+public:
+  DerivativeMetrics();
+  void Update();
+
+  // Don't allow copy and assign
+  DerivativeMetrics(DerivativeMetrics const &) = delete;
+  DerivativeMetrics &operator=(DerivativeMetrics const &) = delete;
+};

--- a/mgmt/Makefile.am
+++ b/mgmt/Makefile.am
@@ -38,7 +38,7 @@ AM_CPPFLAGS += \
 
 libmgmt_c_la_SOURCES = \
 	RecordsConfig.cc \
-	RecordsConfig.h
+	RecordsConfig.h 
 
 libmgmt_COMMON = \
 	BaseManager.cc \
@@ -57,12 +57,16 @@ libmgmt_lm_la_SOURCES = \
 	$(libmgmt_COMMON) \
 	Alarms.cc \
 	Alarms.h \
+	DerivativeMetrics.cc \
+	DerivativeMetrics.h \
 	FileManager.cc \
 	FileManager.h \
 	LocalManager.cc \
 	LocalManager.h \
 	Rollback.cc \
 	Rollback.h \
+	DerivativeMetrics.cc \
+	DerivativeMetrics.h \
 	WebMgmtUtils.cc \
 	WebMgmtUtils.h
 


### PR DESCRIPTION
This retains the ~10 metrics that were calculated before in Lua (and XML
before that), which are actually useful. I've not examined what other
derivative metrics be useful to add, but this is a good start. Adding new
metrics to this "system" is easy, but for now it only supports sum() of
process metrics into a new derivative metric.

Eventually I imagine this will be part of traffic_server itself, which is
why I put this in mgmt/ rather than in cmd/traffic_manager, where the old
Lua code resided.