### PR TITLE
Adds log field for "reason" returned with status error codes

### DIFF
--- a/doc/admin-guide/logging/formatting.en.rst
+++ b/doc/admin-guide/logging/formatting.en.rst
@@ -585,6 +585,7 @@ Status Codes
 .. _pfsc:
 .. _pssc:
 .. _sssc:
+.. _prrp:
 
 These log fields provide a variety of status codes, some numeric and some as
 strings, relating to client, proxy, and origin transactions.
@@ -601,6 +602,8 @@ pfsc  Proxy Request         Finish status code specifying whether the proxy
                             request from |TS| to the origin server was
                             successfully completed (``FIN``), interrupted
                             (``INTR``), or timed out (``TIMEOUT``).
+prrp  Proxy Response        HTTP response reason phrase sent by |TS| proxy to the
+                            client.
 pssc  Proxy Response        HTTP response status code sent by |TS| proxy to the
                             client.
 sssc  Origin Response       HTTP response status code sent by the origin server

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -554,6 +554,11 @@ Log::init_fields()
   global_field_list.add(field, false);
   ink_hash_table_insert(field_symbol_hash, "psct", field);
 
+  field = new LogField("proxy_resp_reason_phrase", "prrp", LogField::STRING, &LogAccess::marshal_proxy_resp_reason_phrase,
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
+  global_field_list.add(field, false);
+  ink_hash_table_insert(field_symbol_hash, "prrp", field);
+
   field = new LogField("proxy_resp_squid_len", "psql", LogField::sINT, &LogAccess::marshal_proxy_resp_squid_len,
                        &LogAccess::unmarshal_int_to_str);
   global_field_list.add(field, false);

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -232,6 +232,11 @@ LOG_ACCESS_DEFAULT_FIELD(marshal_proxy_resp_content_type, DEFAULT_STR_FIELD)
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
+LOG_ACCESS_DEFAULT_FIELD(marshal_proxy_resp_reason_phrase, DEFAULT_STR_FIELD)
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
 LOG_ACCESS_DEFAULT_FIELD(marshal_proxy_resp_squid_len, DEFAULT_INT_FIELD)
 LOG_ACCESS_DEFAULT_FIELD(marshal_client_req_squid_len, DEFAULT_INT_FIELD)
 LOG_ACCESS_DEFAULT_FIELD(marshal_proxy_req_squid_len, DEFAULT_INT_FIELD)

--- a/proxy/logging/LogAccess.h
+++ b/proxy/logging/LogAccess.h
@@ -203,6 +203,7 @@ public:
   // proxy -> client fields
   //
   inkcoreapi virtual int marshal_proxy_resp_content_type(char *);  // STR
+  inkcoreapi virtual int marshal_proxy_resp_reason_phrase(char *); // STR
   inkcoreapi virtual int marshal_proxy_resp_squid_len(char *);     // INT
   inkcoreapi virtual int marshal_proxy_resp_content_len(char *);   // INT
   inkcoreapi virtual int marshal_proxy_resp_status_code(char *);   // INT

--- a/proxy/logging/LogAccessHttp.cc
+++ b/proxy/logging/LogAccessHttp.cc
@@ -70,6 +70,8 @@ LogAccessHttp::LogAccessHttp(HttpSM *sm)
     m_client_req_url_path_len(0),
     m_proxy_resp_content_type_str(nullptr),
     m_proxy_resp_content_type_len(0),
+    m_proxy_resp_reason_phrase_str(nullptr),
+    m_proxy_resp_reason_phrase_len(0),
     m_cache_lookup_url_canon_str(nullptr),
     m_cache_lookup_url_canon_len(0)
 {
@@ -135,6 +137,7 @@ LogAccessHttp::init()
         LogUtils::remove_content_type_attributes(m_proxy_resp_content_type_str, &m_proxy_resp_content_type_len);
       }
     }
+    m_proxy_resp_reason_phrase_str = (char *)m_proxy_response->reason_get(&m_proxy_resp_reason_phrase_len);
   }
   if (hdr->server_request.valid()) {
     m_proxy_request = &(hdr->server_request);
@@ -870,6 +873,19 @@ LogAccessHttp::marshal_proxy_resp_content_type(char *buf)
   int len = round_strlen(m_proxy_resp_content_type_len + 1);
   if (buf) {
     marshal_mem(buf, m_proxy_resp_content_type_str, m_proxy_resp_content_type_len, len);
+  }
+  return len;
+}
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+int
+LogAccessHttp::marshal_proxy_resp_reason_phrase(char *buf)
+{
+  int len = round_strlen(m_proxy_resp_reason_phrase_len + 1);
+  if (buf) {
+    marshal_mem(buf, m_proxy_resp_reason_phrase_str, m_proxy_resp_reason_phrase_len, len);
   }
   return len;
 }

--- a/proxy/logging/LogAccessHttp.h
+++ b/proxy/logging/LogAccessHttp.h
@@ -89,6 +89,7 @@ public:
   // proxy -> client fields
   //
   int marshal_proxy_resp_content_type(char *) override;  // STR
+  int marshal_proxy_resp_reason_phrase(char *) override; // STR
   int marshal_proxy_resp_header_len(char *) override;    // INT
   int marshal_proxy_resp_content_len(char *) override;   // INT
   int marshal_proxy_resp_squid_len(char *) override;     // INT
@@ -208,6 +209,8 @@ private:
   int m_client_req_url_path_len;
   char *m_proxy_resp_content_type_str;
   int m_proxy_resp_content_type_len;
+  char *m_proxy_resp_reason_phrase_str;
+  int m_proxy_resp_reason_phrase_len;
   char *m_cache_lookup_url_canon_str;
   int m_cache_lookup_url_canon_len;
 

--- a/proxy/logging/LogAccessTest.cc
+++ b/proxy/logging/LogAccessTest.cc
@@ -192,6 +192,20 @@ LogAccessTest::marshal_proxy_resp_content_type(char *buf)
   -------------------------------------------------------------------------*/
 
 int
+LogAccessTest::marshal_proxy_resp_reason_phrase(char *buf)
+{
+  static char const *str = "Unknown reason";
+  int len                = LogAccess::strlen(str);
+  if (buf) {
+    marshal_str(buf, str, len);
+  }
+  return len;
+}
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+int
 LogAccessTest::marshal_proxy_resp_squid_len(char *buf)
 {
   if (buf) {

--- a/proxy/logging/LogAccessTest.h
+++ b/proxy/logging/LogAccessTest.h
@@ -61,6 +61,7 @@ public:
   // proxy -> client fields
   //
   virtual int marshal_proxy_resp_content_type(char *);  // STR
+  virtual int marshal_proxy_resp_reason_phrase(char *); // STR
   virtual int marshal_proxy_resp_squid_len(char *);     // INT
   virtual int marshal_proxy_resp_content_len(char *);   // INT
   virtual int marshal_proxy_resp_status_code(char *);   // INT


### PR DESCRIPTION
reason sometimes has more detail about why a request failed than the
status code or the result code (crc)

`prrr`: Proxy Response Result Reason