### PR TITLE
Remove prepended "_" from public member of VIO

### DIFF
--- a/iocore/cache/CacheWrite.cc
+++ b/iocore/cache/CacheWrite.cc
@@ -1149,7 +1149,7 @@ CacheVC::openWriteCloseDir(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED *
   if (f.close_complete) {
     recursive++;
     ink_assert(!vol || this_ethread() != vol->mutex->thread_holding);
-    vio._cont->handleEvent(VC_EVENT_WRITE_COMPLETE, (void *)&vio);
+    vio.cont->handleEvent(VC_EVENT_WRITE_COMPLETE, (void *)&vio);
     recursive--;
   }
   return free_CacheVC(this);

--- a/iocore/cache/P_CacheInternal.h
+++ b/iocore/cache/P_CacheInternal.h
@@ -625,7 +625,7 @@ CacheVC::calluser(int event)
 {
   recursive++;
   ink_assert(!vol || this_ethread() != vol->mutex->thread_holding);
-  vio._cont->handleEvent(event, (void *)&vio);
+  vio.cont->handleEvent(event, (void *)&vio);
   recursive--;
   if (closed) {
     die();

--- a/iocore/eventsystem/I_VIO.h
+++ b/iocore/eventsystem/I_VIO.h
@@ -165,7 +165,7 @@ public:
     call with events for this operation.
 
   */
-  Continuation *_cont;
+  Continuation *cont;
 
   /**
     Number of bytes to be done for this operation.

--- a/iocore/eventsystem/P_VIO.h
+++ b/iocore/eventsystem/P_VIO.h
@@ -25,7 +25,7 @@
 #include "I_VIO.h"
 
 TS_INLINE
-VIO::VIO(int aop) : _cont(nullptr), nbytes(0), ndone(0), op(aop), buffer(), vc_server(nullptr), mutex(nullptr) {}
+VIO::VIO(int aop) : cont(nullptr), nbytes(0), ndone(0), op(aop), buffer(), vc_server(nullptr), mutex(nullptr) {}
 
 /////////////////////////////////////////////////////////////
 //
@@ -33,12 +33,12 @@ VIO::VIO(int aop) : _cont(nullptr), nbytes(0), ndone(0), op(aop), buffer(), vc_s
 //
 /////////////////////////////////////////////////////////////
 TS_INLINE
-VIO::VIO() : _cont(nullptr), nbytes(0), ndone(0), op(VIO::NONE), buffer(), vc_server(nullptr), mutex(nullptr) {}
+VIO::VIO() : cont(nullptr), nbytes(0), ndone(0), op(VIO::NONE), buffer(), vc_server(nullptr), mutex(nullptr) {}
 
 TS_INLINE Continuation *
 VIO::get_continuation()
 {
-  return _cont;
+  return cont;
 }
 TS_INLINE void
 VIO::set_writer(MIOBuffer *writer)
@@ -88,10 +88,10 @@ VIO::set_continuation(Continuation *acont)
   }
   if (acont) {
     mutex = acont->mutex;
-    _cont = acont;
+    cont  = acont;
   } else {
     mutex = nullptr;
-    _cont = nullptr;
+    cont  = nullptr;
   }
   return;
 }

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -460,7 +460,7 @@ SSLNetVConnection::net_read_io(NetHandler *nh, EThread *lthread)
     return;
   }
 
-  MUTEX_TRY_LOCK_FOR(lock, s->vio.mutex, lthread, s->vio._cont);
+  MUTEX_TRY_LOCK_FOR(lock, s->vio.mutex, lthread, s->vio.cont);
   if (!lock.is_locked()) {
     readReschedule(nh);
     return;

--- a/proxy/CoreUtils.cc
+++ b/proxy/CoreUtils.cc
@@ -740,7 +740,7 @@ void
 CoreUtils::print_netstate(NetState *n)
 {
   printf("      enabled: %d\n", n->enabled);
-  printf("      op: %d  _cont: 0x%p\n", n->vio.op, n->vio._cont);
+  printf("      op: %d  cont: 0x%p\n", n->vio.op, n->vio.cont);
   printf("      nbytes: %d  done: %d\n", (int)n->vio.nbytes, (int)n->vio.ndone);
   printf("      vc_server: 0x%p   mutex: 0x%p\n\n", n->vio.vc_server, n->vio.mutex.m_ptr);
 }

--- a/proxy/InkIOCoreAPI.cc
+++ b/proxy/InkIOCoreAPI.cc
@@ -385,7 +385,7 @@ TSVIOContGet(TSVIO viop)
   sdk_assert(sdk_sanity_check_iocore_structure(viop) == TS_SUCCESS);
 
   VIO *vio = (VIO *)viop;
-  return (TSCont)vio->_cont;
+  return (TSCont)vio->cont;
 }
 
 TSVConn

--- a/proxy/Prefetch.cc
+++ b/proxy/Prefetch.cc
@@ -435,7 +435,7 @@ PrefetchTransform::handle_event(int event, void *edata)
   } else {
     switch (event) {
     case VC_EVENT_ERROR:
-      m_write_vio._cont->handleEvent(VC_EVENT_ERROR, &m_write_vio);
+      m_write_vio.cont->handleEvent(VC_EVENT_ERROR, &m_write_vio);
       break;
 
     case VC_EVENT_WRITE_COMPLETE:
@@ -506,12 +506,12 @@ PrefetchTransform::handle_event(int event, void *edata)
       if (m_write_vio.ntodo() > 0) {
         if (towrite > 0) {
           m_output_vio->reenable();
-          m_write_vio._cont->handleEvent(VC_EVENT_WRITE_READY, &m_write_vio);
+          m_write_vio.cont->handleEvent(VC_EVENT_WRITE_READY, &m_write_vio);
         }
       } else {
         m_output_vio->nbytes = m_write_vio.ndone;
         m_output_vio->reenable();
-        m_write_vio._cont->handleEvent(VC_EVENT_WRITE_COMPLETE, &m_write_vio);
+        m_write_vio.cont->handleEvent(VC_EVENT_WRITE_COMPLETE, &m_write_vio);
       }
 
       break;

--- a/proxy/Transform.cc
+++ b/proxy/Transform.cc
@@ -213,10 +213,10 @@ TransformTerminus::handle_event(int event, void * /* edata ATS_UNUSED */)
 
       if (m_write_vio.ntodo() > 0) {
         if (towrite > 0) {
-          m_write_vio._cont->handleEvent(VC_EVENT_WRITE_READY, &m_write_vio);
+          m_write_vio.cont->handleEvent(VC_EVENT_WRITE_READY, &m_write_vio);
         }
       } else {
-        m_write_vio._cont->handleEvent(VC_EVENT_WRITE_COMPLETE, &m_write_vio);
+        m_write_vio.cont->handleEvent(VC_EVENT_WRITE_COMPLETE, &m_write_vio);
       }
 
       // We could have closed on the write callback
@@ -226,12 +226,12 @@ TransformTerminus::handle_event(int event, void * /* edata ATS_UNUSED */)
 
       if (m_read_vio.ntodo() > 0) {
         if (m_write_vio.ntodo() <= 0) {
-          m_read_vio._cont->handleEvent(VC_EVENT_EOS, &m_read_vio);
+          m_read_vio.cont->handleEvent(VC_EVENT_EOS, &m_read_vio);
         } else if (towrite > 0) {
-          m_read_vio._cont->handleEvent(VC_EVENT_READ_READY, &m_read_vio);
+          m_read_vio.cont->handleEvent(VC_EVENT_READ_READY, &m_read_vio);
         }
       } else {
-        m_read_vio._cont->handleEvent(VC_EVENT_READ_COMPLETE, &m_read_vio);
+        m_read_vio.cont->handleEvent(VC_EVENT_READ_COMPLETE, &m_read_vio);
       }
     }
   } else {
@@ -256,8 +256,8 @@ TransformTerminus::handle_event(int event, void * /* edata ATS_UNUSED */)
           m_called_user = 1;
           m_tvc->m_cont->handleEvent(ev, &m_read_vio);
         } else {
-          ink_assert(m_read_vio._cont != nullptr);
-          m_read_vio._cont->handleEvent(ev, &m_read_vio);
+          ink_assert(m_read_vio.cont != nullptr);
+          m_read_vio.cont->handleEvent(ev, &m_read_vio);
         }
       }
 
@@ -639,7 +639,7 @@ NullTransform::handle_event(int event, void *edata)
   } else {
     switch (event) {
     case VC_EVENT_ERROR:
-      m_write_vio._cont->handleEvent(VC_EVENT_ERROR, &m_write_vio);
+      m_write_vio.cont->handleEvent(VC_EVENT_ERROR, &m_write_vio);
       break;
     case VC_EVENT_WRITE_COMPLETE:
       ink_assert(m_output_vio == (VIO *)edata);
@@ -702,12 +702,12 @@ NullTransform::handle_event(int event, void *edata)
       if (m_write_vio.ntodo() > 0) {
         if (towrite > 0) {
           m_output_vio->reenable();
-          m_write_vio._cont->handleEvent(VC_EVENT_WRITE_READY, &m_write_vio);
+          m_write_vio.cont->handleEvent(VC_EVENT_WRITE_READY, &m_write_vio);
         }
       } else {
         m_output_vio->nbytes = m_write_vio.ndone;
         m_output_vio->reenable();
-        m_write_vio._cont->handleEvent(VC_EVENT_WRITE_COMPLETE, &m_write_vio);
+        m_write_vio.cont->handleEvent(VC_EVENT_WRITE_COMPLETE, &m_write_vio);
       }
 
       break;
@@ -794,7 +794,7 @@ RangeTransform::handle_event(int event, void *edata)
   } else {
     switch (event) {
     case VC_EVENT_ERROR:
-      m_write_vio._cont->handleEvent(VC_EVENT_ERROR, &m_write_vio);
+      m_write_vio.cont->handleEvent(VC_EVENT_ERROR, &m_write_vio);
       break;
     case VC_EVENT_WRITE_COMPLETE:
       ink_assert(m_output_vio == (VIO *)edata);
@@ -910,7 +910,7 @@ RangeTransform::transform_to_range()
         //   input data, send VC_EVENT_EOS to let the upstream know
         //   that it can rely on us consuming any more data
         int cb_event = (m_write_vio.ntodo() > 0) ? VC_EVENT_EOS : VC_EVENT_WRITE_COMPLETE;
-        m_write_vio._cont->handleEvent(cb_event, &m_write_vio);
+        m_write_vio.cont->handleEvent(cb_event, &m_write_vio);
         return;
       }
 
@@ -946,7 +946,7 @@ RangeTransform::transform_to_range()
   }
 
   m_output_vio->reenable();
-  m_write_vio._cont->handleEvent(VC_EVENT_WRITE_READY, &m_write_vio);
+  m_write_vio.cont->handleEvent(VC_EVENT_WRITE_READY, &m_write_vio);
 }
 
 /*-------------------------------------------------------------------------


### PR DESCRIPTION
For consistency of naming convention. `_cont` of VIO is public member, this name should not begin with "_".

> Member Variables
Prepend '_' to the beginning of the private or protected member variable to distinguish it from other variable

https://cwiki.apache.org/confluence/display/TS/Coding+Style#CodingStyle-MemberVariables

This has only name changes.