### PR TITLE
Add H2 session level inactivity timer

### DIFF
--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -322,6 +322,10 @@ public:
   Http2ClientSession(Http2ClientSession &) = delete;
   Http2ClientSession &operator=(const Http2ClientSession &) = delete;
 
+  void set_inactivity_timeout(ink_hrtime timeout_in) override;
+  void clear_inactive_timer();
+  void reset_inactivity_timeout();
+
 private:
   int main_event_handler(int, void *);
 
@@ -355,6 +359,10 @@ private:
   bool kill_me          = false;
   bool half_close_local = false;
   int recursion         = 0;
+
+  ink_hrtime inactive_timeout    = 0;
+  ink_hrtime inactive_timeout_at = 0;
+  Event *inactive_event          = nullptr;
 
   InkHashTable *h2_pushed_urls = nullptr;
   uint32_t h2_pushed_urls_size = 0;


### PR DESCRIPTION
The current implementation relies on TCP/TLS level netvc inactivity timer.  However, the HTTP/2 protocol allows for many frame types and we may not want all of the possible frame times sent by the client to reset the inactivity timer.

For example, while debugging a Http2ClientSession leak (using PR #3713), I saw cases of clients sending Ping frames and pushing the life of the Http2Client session far beyond the inactivity time beyond the last seen HTTP/2 stream.

This PR adds Http2ClientSession inactivity support much like the Http2Stream inactivity logic.  It does not reset the inactivity timer when receiving a Ping frame, so a pinging client cannot pin open a Http2ClientSession.

I think it is reasonable to not include Ping's with extending the activity of a session.  But I'd like to hear other peoples opinions on this.