### PR TITLE
Call initiating_close and delay delete_stream

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1128,7 +1128,7 @@ Http2ConnectionState::cleanup_streams()
     if (this->tx_error_code.cls != ProxyErrorClass::NONE) {
       s->set_tx_error_code(this->tx_error_code);
     }
-    this->delete_stream(s);
+    s->initiating_close();
     ink_assert(s != next);
     s = next;
   }
@@ -1182,8 +1182,8 @@ Http2ConnectionState::delete_stream(Http2Stream *stream)
     ink_assert(client_streams_out_count > 0);
     --client_streams_out_count;
   }
-  // total_client_streams_count will be decremented in release_stream(), because it's a counter include streams in the process of
-  // shutting down.
+  // total_client_streams_count will be decremented in release_stream(), because that counter is used to determine
+  // whether it is safe to destroy the Session
 
   stream->initiating_close();
 

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -438,7 +438,7 @@ Http2Stream::initiating_close()
     } else if (!sent_write_complete) {
       // Transaction is already gone or not started. Kill yourself
       do_io_close();
-      destroy();
+      transaction_done(); // Mark that it is safe to kill the stream
     }
   }
 }


### PR DESCRIPTION
Another issue found while tracking down leaked Http2ClientSessions using the zombie event (PR #3713).

Some cases the stream would be removed from the stream_list but then never deleted.   Replacing the calls to delete_stream with a call to stream->initiating_close solved the problem.  The delete_stream gets called from the stream destroys.