### PR TITLE
TS-2365: Fix crash in tls dynamic record size

### DIFF
--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -351,6 +351,7 @@ private:
   SessionAccept *sessionAcceptPtr  = nullptr;
   bool sslTrace                    = false;
   bool SNIMapping                  = false;
+  int64_t redoWriteSize            = 0;
 #ifdef SSL_MODE_ASYNC
   EventIO signalep;
 #endif

--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -73,6 +73,7 @@ enum SSL_Stats {
   ssl_total_tickets_renewed_stat,
   ssl_total_dyn_def_tls_record_count,
   ssl_total_dyn_max_tls_record_count,
+  ssl_total_dyn_redo_tls_record_count,
   ssl_session_cache_hit,
   ssl_session_cache_miss,
   ssl_session_cache_eviction,

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -714,18 +714,26 @@ SSLNetVConnection::load_buffer_and_write(int64_t towrite, MIOBufferAccessor &buf
     // TS-2365: If the SSL max record size is set and we have
     // more data than that, break this into smaller write
     // operations.
-    if (SSLConfigParams::ssl_maxrecord > 0 && l > SSLConfigParams::ssl_maxrecord) {
-      l = SSLConfigParams::ssl_maxrecord;
-    } else if (SSLConfigParams::ssl_maxrecord == -1) {
-      if (sslTotalBytesSent < SSL_DEF_TLS_RECORD_BYTE_THRESHOLD) {
-        dynamic_tls_record_size = SSL_DEF_TLS_RECORD_SIZE;
-        SSL_INCREMENT_DYN_STAT(ssl_total_dyn_def_tls_record_count);
-      } else {
-        dynamic_tls_record_size = SSL_MAX_TLS_RECORD_SIZE;
-        SSL_INCREMENT_DYN_STAT(ssl_total_dyn_max_tls_record_count);
-      }
-      if (l > dynamic_tls_record_size) {
-        l = dynamic_tls_record_size;
+    //
+    // TS-4424: Don't mess with record size if last SSL_write failed with
+    // needs write
+    if (redoWriteSize) {
+      l             = redoWriteSize;
+      redoWriteSize = 0;
+    } else {
+      if (SSLConfigParams::ssl_maxrecord > 0 && l > SSLConfigParams::ssl_maxrecord) {
+        l = SSLConfigParams::ssl_maxrecord;
+      } else if (SSLConfigParams::ssl_maxrecord == -1) {
+        if (sslTotalBytesSent < SSL_DEF_TLS_RECORD_BYTE_THRESHOLD) {
+          dynamic_tls_record_size = SSL_DEF_TLS_RECORD_SIZE;
+          SSL_INCREMENT_DYN_STAT(ssl_total_dyn_def_tls_record_count);
+        } else {
+          dynamic_tls_record_size = SSL_MAX_TLS_RECORD_SIZE;
+          SSL_INCREMENT_DYN_STAT(ssl_total_dyn_max_tls_record_count);
+        }
+        if (l > dynamic_tls_record_size) {
+          l = dynamic_tls_record_size;
+        }
       }
     }
 
@@ -764,6 +772,7 @@ SSLNetVConnection::load_buffer_and_write(int64_t towrite, MIOBufferAccessor &buf
     sslLastWriteTime = now;
     sslTotalBytesSent += total_written;
   }
+  redoWriteSize = 0;
   if (num_really_written > 0) {
     needs |= EVENTIO_WRITE;
   } else {
@@ -781,6 +790,7 @@ SSLNetVConnection::load_buffer_and_write(int64_t towrite, MIOBufferAccessor &buf
     case SSL_ERROR_WANT_X509_LOOKUP: {
       if (SSL_ERROR_WANT_WRITE == err) {
         SSL_INCREMENT_DYN_STAT(ssl_error_want_write);
+        redoWriteSize = l;
       } else if (SSL_ERROR_WANT_X509_LOOKUP == err) {
         SSL_INCREMENT_DYN_STAT(ssl_error_want_x509_lookup);
         TraceOut(trace, get_remote_addr(), get_remote_port(), "Want X509 lookup");

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1057,6 +1057,14 @@ SSLInitializeStatistics()
   RecRegisterRawStat(ssl_rsb, RECT_PROCESS, "proxy.process.ssl.ssl_session_cache_lock_contention", RECD_COUNTER, RECP_PERSISTENT,
                      (int)ssl_session_cache_lock_contention, RecRawStatSyncCount);
 
+  /* Track dynamic record size */
+  RecRegisterRawStat(ssl_rsb, RECT_PROCESS, "proxy.process.ssl.default_record_size_count", RECD_COUNTER, RECP_PERSISTENT,
+                     (int)ssl_total_dyn_def_tls_record_count, RecRawStatSyncSum);
+  RecRegisterRawStat(ssl_rsb, RECT_PROCESS, "proxy.process.ssl.max_record_size_count", RECD_COUNTER, RECP_PERSISTENT,
+                     (int)ssl_total_dyn_max_tls_record_count, RecRawStatSyncSum);
+  RecRegisterRawStat(ssl_rsb, RECT_PROCESS, "proxy.process.ssl.redo_record_size_count", RECD_COUNTER, RECP_PERSISTENT,
+                     (int)ssl_total_dyn_redo_tls_record_count, RecRawStatSyncCount);
+
   /* error stats */
   RecRegisterRawStat(ssl_rsb, RECT_PROCESS, "proxy.process.ssl.ssl_error_want_write", RECD_COUNTER, RECP_PERSISTENT,
                      (int)ssl_error_want_write, RecRawStatSyncCount);


### PR DESCRIPTION
Storing the record size used for the SSL_write that failed with SSL_ERROR_WANT_WRITE.  This should avoid the crash on openssl due to changing the record size on retry.

Also finished wiring in the dynamic record metrics.