### PR TITLE
Fixes compiler flags used for gzip plugin

### DIFF
--- a/plugins/gzip/Makefile.inc
+++ b/plugins/gzip/Makefile.inc
@@ -20,4 +20,4 @@ gzip_gzip_la_SOURCES = gzip/gzip.cc gzip/configuration.cc gzip/misc.cc
 gzip_gzip_la_LDFLAGS = \
   $(AM_LDFLAGS) $(LIB_BROTLIENC)
 
-gzip_gzip_la_CFLAGS = $(AM_CFLAGS) $(CFLAGS_BROTLIENC)
+gzip_gzip_la_CXXFLAGS = $(AM_CXXFLAGS) $(CFLAGS_BROTLIENC)


### PR DESCRIPTION
use CXXFLAGS not CFLAGS for C++ code

(cherry picked from commit f242d1d016ceb0debb9b2b22e5b03eb58c25902f)