### PR TITLE
Make ATS buildable with BoringSSL again

### DIFF
--- a/iocore/net/P_OCSPStapling.h
+++ b/iocore/net/P_OCSPStapling.h
@@ -23,8 +23,13 @@
 
 #include <openssl/ssl.h>
 
+#ifdef OCSP_sendreq_new
 #define HAVE_OPENSSL_OCSP_STAPLING 1
+#endif
+
+#ifdef HAVE_OPENSSL_OCSP_STAPLING
 void ssl_stapling_ex_init();
 bool ssl_stapling_init_cert(SSL_CTX *ctx, X509 *cert, const char *certname);
 void ocsp_update();
 int ssl_callback_ocsp_stapling(SSL *);
+#endif

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -888,7 +888,9 @@ void
 SSLPostConfigInitialize()
 {
   if (SSLConfigParams::engine_conf_file) {
+#ifndef OPENSSL_IS_BORINGSSL
     ENGINE_load_dynamic();
+#endif
 
     OPENSSL_load_builtin_modules();
     if (CONF_modules_load_file(SSLConfigParams::engine_conf_file, nullptr, 0) <= 0) {
@@ -1505,7 +1507,12 @@ ssl_callback_info(const SSL *ssl, int where, int ret)
 #ifdef SSL3_ST_SR_CLNT_HELLO_A
     if (state == SSL3_ST_SR_CLNT_HELLO_A) {
 #else
+#ifdef SSL_ST_RENEGOTIATE
+    // This is for BoringSSL
+    if (state == SSL_ST_RENEGOTIATE) {
+#else
     if (state == TLS_ST_SR_CLNT_HELLO) {
+#endif
 #endif
 #endif
       netvc->setSSLClientRenegotiationAbort(true);

--- a/lib/ts/HashMD5.cc
+++ b/lib/ts/HashMD5.cc
@@ -68,7 +68,13 @@ ATSHashMD5::size() const
 void
 ATSHashMD5::clear()
 {
+#ifndef OPENSSL_IS_BORINGSSL
   int ret = EVP_MD_CTX_reset(ctx);
+#else
+  // OpenSSL's EVP_MD_CTX_reset always returns 1
+  int ret = 1;
+  EVP_MD_CTX_reset(ctx);
+#endif
   ink_assert(ret == 1);
   ret = EVP_DigestInit_ex(ctx, EVP_md5(), nullptr);
   ink_assert(ret == 1);

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -9279,6 +9279,7 @@ TSSslServerContextCreate(TSSslX509 cert, const char *certname)
   SSLConfigParams *config = SSLConfig::acquire();
   if (config != nullptr) {
     ret = reinterpret_cast<TSSslContext>(SSLCreateServerContext(config));
+#ifdef HAVE_OPENSSL_OCSP_STAPLING
     if (ret && SSLConfigParams::ssl_ocsp_enabled && cert && certname) {
       if (SSL_CTX_set_tlsext_status_cb(reinterpret_cast<SSL_CTX *>(ret), ssl_callback_ocsp_stapling)) {
         if (!ssl_stapling_init_cert(reinterpret_cast<SSL_CTX *>(ret), reinterpret_cast<X509 *>(cert), certname)) {
@@ -9286,6 +9287,7 @@ TSSslServerContextCreate(TSSslX509 cert, const char *certname)
         }
       }
     }
+#endif
     SSLConfig::release(config);
   }
   return ret;


### PR DESCRIPTION
I realized that master is not buildable with BoringSSL. Do we still support BoringSSL?

With this patch, it will be buildable but OCSP stapling won't be available with BoringSSL because the APIs for OCSP are completely different.

