### PR TITLE
Fix traffic_crashlog zombie issue

### DIFF
--- a/proxy/Crash.cc
+++ b/proxy/Crash.cc
@@ -79,7 +79,7 @@ check_logger_path(const char *path)
 }
 
 void
-crash_logger_init()
+crash_logger_init(const char *user)
 {
   ats_scoped_str logger(create_logger_path());
   const char *basename;
@@ -119,7 +119,8 @@ crash_logger_init()
       }
     }
 
-    ink_release_assert(execl(logger, basename, "--syslog", "--wait", "--host", TS_BUILD_CANONICAL_HOST, NULL) != -1);
+    ink_release_assert(execl(logger, basename, "--syslog", "--wait", "--host", TS_BUILD_CANONICAL_HOST, "--user", user, NULL) !=
+                       -1);
     return; // not reached.
   }
 

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -1655,19 +1655,19 @@ main(int /* argc ATS_UNUSED */, const char **argv)
     REC_ReadConfigInteger(num_task_threads, "proxy.config.task_threads");
   }
 
-  // Set up crash logging. We need to do this while we are still privileged so that the crash
-  // logging helper runs as root. Don't bother setting up a crash logger if we are going into
-  // command mode since that's not going to daemonize or run for a long time unattended.
-  if (!command_flag) {
-    crash_logger_init();
-    signal_register_crash_handler(crash_logger_invoke);
-  }
-
   ats_scoped_str user(MAX_LOGIN + 1);
 
   *user        = '\0';
   admin_user_p = ((REC_ERR_OKAY == REC_ReadConfigString(user, "proxy.config.admin.user_id", MAX_LOGIN)) && (*user != '\0') &&
                   (0 != strcmp(user, "#-1")));
+
+  // Set up crash logging. We need to do this while we are still privileged so that the crash
+  // logging helper runs as root. Don't bother setting up a crash logger if we are going into
+  // command mode since that's not going to daemonize or run for a long time unattended.
+  if (!command_flag) {
+    crash_logger_init(user);
+    signal_register_crash_handler(crash_logger_invoke);
+  }
 
 #if TS_USE_POSIX_CAP
   // Change the user of the process.

--- a/proxy/Main.h
+++ b/proxy/Main.h
@@ -76,5 +76,5 @@ maintainance_mode()
 
 extern AppVersionInfo appVersionInfo;
 
-void crash_logger_init();
+void crash_logger_init(const char *user);
 void crash_logger_invoke(int signo, siginfo_t *info, void *ctx);


### PR DESCRIPTION
When using a custom startup script by setting configs `proxy.config.bin_path` and `proxy.config.proxy_binary`, process `traffic_crashlog` will not be dropped to the appropriate privilege. This causes the process not able to receive the kill signal when `traffic_server` dies.

For testing, the startup script can be a simple wrapper such as:
```
#!/bin/bash

# path to traffic_server binary file
/xxx/bin/traffic_server $@ 
```