### PR TITLE
Switch to a safer snprintf(), makes compilers more happy

### DIFF
--- a/plugins/experimental/mysql_remap/lib/iniparser.c
+++ b/plugins/experimental/mysql_remap/lib/iniparser.c
@@ -646,7 +646,7 @@ iniparser_load(const char *ininame)
       break;
 
     case LINE_VALUE:
-      sprintf(tmp, "%s:%s", section, key);
+      snprintf(tmp, sizeof(tmp), "%s:%s", section, key);
       errs = dictionary_set(dict, tmp, val);
       break;
 


### PR DESCRIPTION
Compilers on F28 actually errors out on this, with a  potential buffer overflow.