### PR TITLE
Changed some traffic_layout related codes to memory efficient string_view

### DIFF
--- a/cmd/traffic_layout/file_system.cc
+++ b/cmd/traffic_layout/file_system.cc
@@ -58,7 +58,7 @@ remove_slash(std::string &path)
 }
 
 bool
-exists(std::string const &dir)
+exists(const std::string &dir)
 {
   struct stat buffer;
   int result = stat(dir.c_str(), &buffer);
@@ -66,7 +66,7 @@ exists(std::string const &dir)
 }
 
 bool
-is_directory(std::string const &directory)
+is_directory(const std::string &directory)
 {
   struct stat buffer;
   int result = stat(directory.c_str(), &buffer);

--- a/cmd/traffic_layout/info.cc
+++ b/cmd/traffic_layout/info.cc
@@ -29,22 +29,23 @@
 // Produce output about compile time features, useful for checking how things were built, as well
 // as for our TSQA test harness.
 static void
-print_feature(const char *name, int value, bool json, bool last = false)
+print_feature(std::string_view name, int value, bool json, bool last = false)
 {
   if (json) {
-    printf("    \"%s\": %d%s", name, value, last ? "\n" : ",\n");
+    printf("    \"%.*s\": %d%s", static_cast<int>(name.size()), name.data(), value, last ? "\n" : ",\n");
   } else {
-    printf("#define %s %d\n", name, value);
+    printf("#define %.*s %d\n", static_cast<int>(name.size()), name.data(), value);
   }
 }
 
 static void
-print_feature(const char *name, const char *value, bool json, bool last = false)
+print_feature(std::string_view name, std::string_view value, bool json, bool last = false)
 {
   if (json) {
-    printf(R"(    "%s": "%s"%s)", name, value, last ? "\n" : ",\n");
+    printf(R"(    "%.*s": "%.*s"%s)", static_cast<int>(name.size()), name.data(), static_cast<int>(value.size()), value.data(),
+           last ? "\n" : ",\n");
   } else {
-    printf("#define %s \"%s\"\n", name, value);
+    printf("#define %.*s \"%.*s\"\n", static_cast<int>(name.size()), name.data(), static_cast<int>(value.size()), value.data());
   }
 }
 

--- a/lib/ts/ink_args.cc
+++ b/lib/ts/ink_args.cc
@@ -223,7 +223,7 @@ process_args_ex(const AppVersionInfo *appinfo, const ArgumentDescription *argume
       // Deal with long options ...
       for (i = 0; i < n_argument_descriptions; i++) {
         // handle the runroot arg
-        std::string cur_argv = *argv + 2;
+        std::string_view cur_argv = *argv + 2;
         if (cur_argv.size() >= 8 && cur_argv.substr(0, 8) == "run-root") {
           break;
         }

--- a/lib/ts/runroot.cc
+++ b/lib/ts/runroot.cc
@@ -108,9 +108,9 @@ runroot_handler(const char **argv, bool json)
 
   int i = 0;
   while (argv[i]) {
-    std::string command = argv[i];
+    std::string_view command = argv[i];
     if (command.substr(0, prefix.size()) == prefix) {
-      arg = command;
+      arg = command.data();
       break;
     }
     i++;


### PR DESCRIPTION
Some changes to std::string_view corresponding to previous closed PR #3580 

``lib/ts/ink_args``
``lib/ts/runroot.cc``
``cmd/traffic_layout/info.cc``

@SolidWallOfCode 