### PR TITLE
Handle various kinds of errors during cache scan

### DIFF
--- a/cmd/traffic_cache_tool/CacheScan.h
+++ b/cmd/traffic_cache_tool/CacheScan.h
@@ -48,9 +48,10 @@ public:
   Errata get_alternates(const char *buf, int length);
   Errata unmarshal(char *buf, int len, RefCountObj *block_ref);
   Errata unmarshal(HTTPHdrImpl *obj, intptr_t offset);
-  Errata unmarshal(MIMEHdrImpl *obj, intptr_t offset);
   Errata unmarshal(URLImpl *obj, intptr_t offset);
   Errata unmarshal(MIMEFieldBlockImpl *mf, intptr_t offset);
+  Errata unmarshal(MIMEHdrImpl *obj, intptr_t offset);
+  bool check_url(ts::MemSpan &mem, URLImpl *url);
 };
 } // namespace ct
 


### PR DESCRIPTION
I am testing cache tool on real traffic data in cache and encountering various kinds of problems like: invalid memory address, garbage data, invalid values etc. which all lead to segmentation faults and terminate cache tool. This PR contains the error handings I have added for the problems I have faced so far.