### PR TITLE
Only increment currently_open count if FD is really open

### DIFF
--- a/iocore/net/UnixNetProcessor.cc
+++ b/iocore/net/UnixNetProcessor.cc
@@ -234,7 +234,6 @@ UnixNetProcessor::connect_re_internal(Continuation *cont, sockaddr const *target
   );
   SocksEntry *socksEntry = nullptr;
 
-  NET_SUM_GLOBAL_DYN_STAT(net_connections_currently_open_stat, 1);
   vc->id          = net_next_connection_number();
   vc->submit_time = Thread::get_hrtime();
   vc->mutex       = cont->mutex;

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1277,6 +1277,10 @@ UnixNetVConnection::connectUp(EThread *t, int fd)
     con.is_bound     = true;
   }
 
+  // Did not fail, increment connection count
+  NET_SUM_GLOBAL_DYN_STAT(net_connections_currently_open_stat, 1);
+  ink_release_assert(con.fd != NO_FD);
+
   // Must connect after EventIO::Start() to avoid a race condition
   // when edge triggering is used.
   if ((res = get_NetHandler(t)->startIO(this)) < 0) {


### PR DESCRIPTION
This caused a throttle problem in production.  The currently_open_count is only decremented if on the con.fd is not NO_FD.  We had a situation with a lot of network failures.  The currently_open count would increase but not decrease causing our processes to be stuck in the throttling state.
