### PR TITLE
Update libexecdir of Layout GNU from config.layout

### DIFF
--- a/config.layout
+++ b/config.layout
@@ -77,7 +77,7 @@
     bindir:        ${exec_prefix}/bin
     sbindir:       ${exec_prefix}/sbin
     libdir:        ${exec_prefix}/lib
-    libexecdir:    ${exec_prefix}/libexec
+    libexecdir:    ${exec_prefix}/libexec+
     infodir:       ${prefix}/info
     mandir:        ${prefix}/share/man
     sysconfdir:    ${prefix}/etc+


### PR DESCRIPTION
The original hard-coded Layout GNU has libexecdir that should better be ``${exec_prefix}/libexec+`` instead of ``${exec_prefix}/libexec``.

From the GNU Coding Standards: "The definition of ‘libexecdir’ is the same for all packages, so you should install your data in a subdirectory thereof."(https://www.gnu.org/prep/standards/html_node/Directory-Variables.html)

This is also an issue for the correct performing of traffic_layout runroot.
