### PR TITLE
Only increment currently_open if socket connects (take 2)

### DIFF
--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1277,10 +1277,6 @@ UnixNetVConnection::connectUp(EThread *t, int fd)
     con.is_bound     = true;
   }
 
-  // Did not fail, increment connection count
-  NET_SUM_GLOBAL_DYN_STAT(net_connections_currently_open_stat, 1);
-  ink_release_assert(con.fd != NO_FD);
-
   // Must connect after EventIO::Start() to avoid a race condition
   // when edge triggering is used.
   if ((res = get_NetHandler(t)->startIO(this)) < 0) {
@@ -1295,6 +1291,10 @@ UnixNetVConnection::connectUp(EThread *t, int fd)
       goto fail;
     }
   }
+
+  // Did not fail, increment connection count
+  NET_SUM_GLOBAL_DYN_STAT(net_connections_currently_open_stat, 1);
+  ink_release_assert(con.fd != NO_FD);
 
   // Setup a timeout callback handler.
   SET_HANDLER(&UnixNetVConnection::mainEvent);


### PR DESCRIPTION
A follow on to PR #3750.  Should do the currently_open increment if the con.connect() succeeds. Not just the con.open() (which I guess is a bind).