### PR TITLE
Allow disable throttling.

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -411,7 +411,7 @@ Network
    given time. Roughly 10% of these connections are reserved for origin server
    connections, i.e. from the default, only ~9,000 client connections can be
    handled. This should be tuned according to your memory size, and expected
-   work load.
+   work load.  If this is set to 0, the throttling logic is disabled.
 
 .. ts:cv:: CONFIG proxy.config.net.default_inactivity_timeout INT 86400
    :reloadable:

--- a/iocore/net/P_UnixNet.h
+++ b/iocore/net/P_UnixNet.h
@@ -408,7 +408,7 @@ check_net_throttle(ThrottleType t)
 {
   int connections = net_connections_to_throttle(t);
 
-  if (connections >= net_connections_throttle)
+  if (net_connections_throttle != 0 && connections >= net_connections_throttle)
     return true;
 
   return false;
@@ -435,9 +435,11 @@ change_net_connections_throttle(const char *token, RecDataT data_type, RecData v
   (void)value;
   (void)data;
   int throttle = fds_limit - THROTTLE_FD_HEADROOM;
-  if (fds_throttle < 0)
+  if (fds_throttle == 0) {
+    net_connections_throttle = fds_throttle;
+  } else if (fds_throttle < 0) {
     net_connections_throttle = throttle;
-  else {
+  } else {
     net_connections_throttle = fds_throttle;
     if (net_connections_throttle > throttle)
       net_connections_throttle = throttle;


### PR DESCRIPTION
Set proxy.config.net.connections_throttle to 0 to disable throttling.  

We have been battling problems accurately tracking currently_open_connections stat.  Want the option to just be able to turn off that feature.