### PR TITLE
header age not critical to HSTS header test result.

### DIFF
--- a/tests/gold_tests/headers/hsts.200.gold
+++ b/tests/gold_tests/headers/hsts.200.gold
@@ -1,6 +1,6 @@
 HTTP/1.1 200 OK
 Date:``
-Age: 0
+Age: ``
 Transfer-Encoding: chunked
 Connection: keep-alive
 Strict-Transport-Security: max-age=300


### PR DESCRIPTION
Age 0 or age 1 causes autest to fail randomly.