### PR TITLE
Fix copying issue of traffic_layout init

### DIFF
--- a/cmd/traffic_layout/engine.cc
+++ b/cmd/traffic_layout/engine.cc
@@ -451,8 +451,11 @@ RunrootEngine::copy_runroot(const std::string &original_root, const std::string 
       path_map[it.first] = Layout::relative_to(".", join_path);
     }
 
-    if (!copy_directory(old_path, new_path)) {
-      ink_warning("Copy failed for '%s' - %s", it.first.c_str(), strerror(errno));
+    // don't copy the prefix, mandir and localstatedir
+    if (it.first != "exec_prefix" && it.first != "localstatedir" && it.first != "mandir") {
+      if (!copy_directory(old_path, new_path, it.first)) {
+        ink_warning("Copy failed for '%s' - %s", it.first.c_str(), strerror(errno));
+      }
     }
   }
 
@@ -674,7 +677,7 @@ RunrootEngine::verify_runroot()
     std::cout << name << ": \x1b[1m" + path_map[name] + "\x1b[0m" << std::endl;
 
     // output read permission
-    if (name == "includedir" || name == "mandir" || name == "sysconfdir" || name == "datadir") {
+    if (name == "includedir" || name == "sysconfdir" || name == "datadir") {
       output_read_permission(permission);
     }
     // output write permission

--- a/cmd/traffic_layout/engine.h
+++ b/cmd/traffic_layout/engine.h
@@ -73,9 +73,9 @@ struct RunrootEngine {
   std::string path;
 
   // vector containing all directory names
-  std::vector<std::string> dir_vector = {"prefix",     "exec_prefix", "bindir", "sbindir",    "sysconfdir",
-                                         "datadir",    "includedir",  "libdir", "libexecdir", "localstatedir",
-                                         "runtimedir", "logdir",      "mandir", "cachedir"};
+  std::vector<std::string> dir_vector = {"prefix",     "exec_prefix", "bindir",  "sbindir",    "sysconfdir",
+                                         "datadir",    "includedir",  "libdir",  "libexecdir", "localstatedir",
+                                         "runtimedir", "logdir",      "cachedir"};
 
   // map for yaml file emit
   std::unordered_map<std::string, std::string> path_map;

--- a/cmd/traffic_layout/file_system.h
+++ b/cmd/traffic_layout/file_system.h
@@ -47,4 +47,4 @@ bool remove_directory(const std::string &dir);
 // remove everything inside this directory
 bool remove_inside_directory(const std::string &dir);
 
-bool copy_directory(const std::string &src, const std::string &dst);
+bool copy_directory(const std::string &src, const std::string &dst, const std::string &dir = "");

--- a/tests/gold_tests/runroot/runroot_init.test.py
+++ b/tests/gold_tests/runroot/runroot_init.test.py
@@ -61,3 +61,29 @@ tr.Processes.Default.ReturnCode = 0
 f = tr.Disk.File(os.path.join(path4, "runroot_path.yml"))
 f.Exists = True
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("Forcing creating runroot", "force message")
+
+# create runroot with junk to guarantee only traffic server related files are copied
+path5 = os.path.join(ts_root, "runroot5")
+junk1 = os.path.join(path1, "bin/junk1")
+junk2 = os.path.join(path1, "lib/junk2")
+junk3 = os.path.join(path1, "include/junk3")
+tr = Test.AddTestRun("Test traffic_layout init #5")
+# create the junk files in runroot1 and create(init and copy) runroot5 from runroot 1
+tr.Processes.Default.Command = "touch " + junk1 + ";" + "touch " + junk2 + ";" + \
+    "touch " + junk3 + ";" + path1 + "/bin/traffic_layout init --path " + path5
+tr.Processes.Default.ReturnCode = 0
+f = tr.Disk.File(os.path.join(path5, "runroot_path.yml"))
+f.Exists = True
+# check if the junk file is created and not copied to the new runroot
+f = tr.Disk.File(junk1)
+f.Exists = True
+f = tr.Disk.File(os.path.join(path5, "bin/junk"))
+f.Exists = False
+f = tr.Disk.File(junk2)
+f.Exists = True
+f = tr.Disk.File(os.path.join(path5, "lib/junk"))
+f.Exists = False
+f = tr.Disk.File(junk3)
+f.Exists = True
+f = tr.Disk.File(os.path.join(path5, "include/junk"))
+f.Exists = False


### PR DESCRIPTION
This PR fixes the copying issue of traffic_layout: https://github.com/apache/trafficserver/issues/3646.
A filter is applied during the creating of the runroot to only copy or hard link the traffic server related files.
@dragon512 @bryancall 

Note: ``mandir`` is removed from the runroot.