### PR TITLE
tsconfig/IntrusivePtr refresh - updated for eleventy and better conformance with std::shared_ptr.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1319,6 +1319,7 @@ add_executable(test_tslib
 	lib/ts/unit-tests/test_BufferWriter.cc
 	lib/ts/unit-tests/test_BufferWriterFormat.cc
 	lib/ts/unit-tests/test_ink_inet.cc
+	lib/ts/unit-tests/test_IntrusivePtr.cc
 	lib/ts/unit-tests/test_IpMap.cc
 	lib/ts/unit-tests/test_layout.cc
 	lib/ts/unit-tests/test_MemArena.cc

--- a/lib/ts/Makefile.am
+++ b/lib/ts/Makefile.am
@@ -267,6 +267,7 @@ test_tslib_SOURCES = \
 	unit-tests/test_BufferWriter.cc \
 	unit-tests/test_BufferWriterFormat.cc \
 	unit-tests/test_ink_inet.cc \
+	unit-tests/test_IntrusivePtr.cc \
 	unit-tests/test_IpMap.cc \
 	unit-tests/test_layout.cc \
 	unit-tests/test_MemSpan.cc \

--- a/lib/ts/unit-tests/test_IntrusivePtr.cc
+++ b/lib/ts/unit-tests/test_IntrusivePtr.cc
@@ -1,0 +1,134 @@
+/** @file
+
+    IntrusivePtr tests.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <string>
+#include <sstream>
+#include <tsconfig/IntrusivePtr.h>
+#include <catch.hpp>
+
+struct Thing : public ts::IntrusivePtrCounter {
+  Thing() { ++_count; }
+  ~Thing() { --_count; }
+  std::string _name;
+  static int _count; // instance count.
+};
+
+struct Stuff : public Thing {
+  int _value{0};
+};
+
+struct Obscure : private ts::IntrusivePtrCounter {
+  std::string _text;
+
+  friend class ts::IntrusivePtr<Obscure>;
+};
+
+struct Atomic : ts::IntrusivePtrAtomicCounter {
+  int _q{0};
+};
+
+int Thing::_count{0};
+
+TEST_CASE("IntrusivePtr", "[libts][IntrusivePtr]")
+{
+  using Ptr = ts::IntrusivePtr<Thing>;
+
+  Ptr p1{new Thing};
+  REQUIRE(p1.use_count() == 1);
+  REQUIRE(Thing::_count == 1);
+  p1.reset(nullptr);
+  REQUIRE(Thing::_count == 0);
+
+  p1.reset(new Thing);
+  Ptr p2 = p1;
+  REQUIRE(Thing::_count == 1);
+  REQUIRE(p1.use_count() == p2.use_count());
+  REQUIRE(p2.use_count() == 2);
+
+  Ptr p3{new Thing};
+  REQUIRE(Thing::_count == 2);
+  p1 = p3;
+  p2 = p3;
+  REQUIRE(Thing::_count == 1);
+
+  Ptr p4;
+
+  REQUIRE(static_cast<bool>(p4) == false);
+  REQUIRE(!p4 == true);
+
+  REQUIRE(static_cast<bool>(p3) == true);
+  REQUIRE(!p3 == false);
+
+  // This is a compile check to make sure IntrusivePtr can be used with private inheritance
+  // of ts::InstrusivePtrCounter if IntrusivePtr is declared a friend.
+  ts::IntrusivePtr<Obscure> op{new Obscure};
+  op->_text.assign("Text");
+}
+
+// Cross type tests.
+TEST_CASE("IntrusivePtr CrossType", "[libts][IntrusivePtr]")
+{
+  using ThingPtr = ts::IntrusivePtr<Thing>;
+  using StuffPtr = ts::IntrusivePtr<Stuff>;
+
+  ThingPtr tp1{new Stuff};
+  StuffPtr sp1{new Stuff};
+
+  ThingPtr tp2{sp1};
+  REQUIRE(tp2.get() == sp1.get());
+  REQUIRE(Thing::_count == 2);
+  REQUIRE(tp2.use_count() == 2);
+  tp2 = sp1; // should be a no-op, verify it compiles.
+  REQUIRE(tp2.get() == sp1.get());
+  REQUIRE(Thing::_count == 2);
+  REQUIRE(sp1.use_count() == 2);
+  sp1 = ts::ptr_cast<Stuff>(tp1); // move assign
+  REQUIRE(sp1.get() == tp1.get());
+  REQUIRE(sp1.use_count() == 2);
+  REQUIRE(tp2.use_count() == 1);
+  tp1 = ts::ptr_cast<Stuff>(tp2); // cross type move assign
+  REQUIRE(sp1.use_count() == 1);
+  REQUIRE(tp1.get() == tp2.get());
+  REQUIRE(tp1.use_count() == 2);
+  sp1 = ts::ptr_cast<Stuff>(tp1);
+  REQUIRE(Thing::_count == 1);
+  REQUIRE(sp1.use_count() == 3);
+  tp1 = tp2; // same object assign check.
+  {
+    StuffPtr sp2{sp1};
+    REQUIRE(sp1.use_count() == 4);
+  }
+  sp1.reset();
+  tp1 = std::move(tp2); // should clear tp2
+  tp1.reset();
+  REQUIRE(Thing::_count == 0);
+}
+
+TEST_CASE("IntrusiveAtomicPtr", "[libts][IntrusivePtr]")
+{
+  using Ptr = ts::IntrusivePtr<Atomic>;
+
+  Ptr p1{new Atomic};
+  REQUIRE(p1.use_count() == 1);
+  p1.reset(nullptr);
+}

--- a/lib/tsconfig/TsValue.h
+++ b/lib/tsconfig/TsValue.h
@@ -642,7 +642,7 @@ namespace detail {
   inline size_t ValueTable::size() const { return _ptr ? _ptr->_values.size() : 0; }
   inline Generation ValueTable::generation() const { return _ptr ? _ptr->_generation : Generation(0); }
   inline ValueItem const& ValueTable::operator [] (ValueIndex idx) const { return const_cast<self*>(this)->operator [] (idx); }
-  inline ValueTable& ValueTable::reset() { _ptr = nullptr; return *this; }
+  inline ValueTable& ValueTable::reset() { _ptr.reset(); return *this; }
 
   inline ValueItem::ValueItem() : _type(VoidValue), _local_index(0), _srcLine(0), _srcColumn(0) {}
   inline ValueItem::ValueItem(ValueType type) : _type(type), _local_index(0), _srcLine(0), _srcColumn(0) {}
@@ -716,7 +716,7 @@ inline Value& Value::setSource(int line, int col) {
 inline Path::ImplType::ImplType() { }
 
 inline Path::Path() { }
-inline Path::ImplType* Path::instance() { if (!_ptr) _ptr = new ImplType; return _ptr.get(); }
+inline Path::ImplType* Path::instance() { if (!_ptr) _ptr.reset(new ImplType); return _ptr.get(); }
 inline Path& Path::append(ConstBuffer const& tag) { this->instance()->_elements.push_back(tag); return *this; }
 inline Path& Path::append(size_t index) { this->instance()->_elements.push_back(ConstBuffer(nullptr, index)); return *this; }
 inline size_t Path::count() const { return _ptr ? _ptr->_elements.size() : 0; }

--- a/lib/wccp/WccpEndPoint.cc
+++ b/lib/wccp/WccpEndPoint.cc
@@ -1165,7 +1165,7 @@ Cache::~Cache() {}
 EndPoint::ImplType *
 Cache::make()
 {
-  m_ptr.assign(new ImplType);
+  m_ptr.reset(new ImplType);
   return m_ptr.get();
 }
 
@@ -1219,7 +1219,7 @@ Router::~Router() {}
 EndPoint::ImplType *
 Router::make()
 {
-  m_ptr.assign(new ImplType);
+  m_ptr.reset(new ImplType);
   return m_ptr.get();
 }
 


### PR DESCRIPTION
This updates `IntrusivePtr` to take advantage of eleventy constructs for more robust code. It removes an intermediate class that is no longer needed and adds the ability to use atomic counters. Unit tests are added for this class.