### PR TITLE
Clang-Analyzer: Fix false positive in IntrusivePtr.

### DIFF
--- a/lib/tsconfig/IntrusivePtr.h
+++ b/lib/tsconfig/IntrusivePtr.h
@@ -502,19 +502,7 @@ void
 IntrusivePtr<T>::unset()
 {
   if (nullptr != m_obj) {
-    /* magic: our target is required to inherit from IntrusivePtrCounter,
-     * which provides a protected counter variable and access via our
-     * super class. We call the super class method to get a raw pointer
-     * to the counter variable.
-     */
     auto &cp = m_obj->m_intrusive_pointer_reference_count;
-
-    /* If you hit this assert you've got a cycle of objects that
-       reference each other. A delete in the cycle will eventually
-       result in one of the objects getting deleted twice, which is
-       what this assert indicates.
-    */
-    assert(cp);
 
     if (0 == --cp) {
       IntrusivePtrPolicy<T>::finalize(m_obj);


### PR DESCRIPTION
Related to 40f01aa0c4fb2ab72459dcc16d63989f40bb8b9b. This wasn't detected in the initial PR but for some reason updates to `MemArena` (#3767) caused clang analyzer to become upset. This check is somewhat useful, but not enough to justify more clang analyzer conditional code. I think the built in double free detection will suffice and this additional check can be dropped.