### PR TITLE
Output diag logs with some padding

### DIFF
--- a/lib/ts/Diags.cc
+++ b/lib/ts/Diags.cc
@@ -264,8 +264,9 @@ Diags::print_va(const char *debug_tag, DiagsLevel diags_level, const SourceLocat
     lp = loc->str(buf, sizeof(buf));
     if (lp) {
       format_writer.write('<');
-      format_writer.write(lp, std::min(strlen(lp), sizeof(buf)));
+      format_writer.write(lp, std::min(std::min(strlen(lp), sizeof(buf)), 40UL));
       format_writer.write("> ", 2);
+      format_writer.write("                                        ", 40 - std::min(std::min(strlen(lp), sizeof(buf)), 40UL));
     }
   }
   //////////////////////////
@@ -276,6 +277,7 @@ Diags::print_va(const char *debug_tag, DiagsLevel diags_level, const SourceLocat
     format_writer.write('(');
     format_writer.write(debug_tag, strlen(debug_tag));
     format_writer.write(") ", 2);
+    format_writer.write("                              ", 30 - strlen(debug_tag));
   }
   //////////////////////////////////////////////////////
   // append original format string, ensure there is a //


### PR DESCRIPTION
What do you think about adding some spaces around debug tags? It makes reading debug log much easier I think.

It should be configurable but I want some feedback before spending much time for this.

Before:
```
[Jun  5 16:22:50.195] {0xb000a000} DEBUG: <Http2ConnectionState.cc:1435 (send_data_frames)> (http2_con) [0] [13] Shutdown stream
[Jun  5 16:22:50.195] {0xb000a000} DEBUG: <Http2ConnectionState.cc:1184 (delete_stream)> (http2_con) [0] [13] Delete stream
[Jun  5 16:22:50.195] {0xb000a000} DEBUG: <Http2Stream.cc:390 (initiating_close)> (http2_stream) [0] [13] initiating_close
[Jun  5 16:22:50.195] {0xb000a000} DEBUG: <Http2Stream.cc:418 (initiating_close)> (http2_stream) [0] [13] handle write from destroy (event=103)
[Jun  5 16:22:50.195] {0xb000a000} DEBUG: <Http2Stream.cc:713 (destroy)> (http2_stream) [0] [13] Destroy stream, sent 16384 bytes
[Jun  5 16:22:50.197] {0xb000a000} DEBUG: <Http2ClientSession.cc:424 (state_start_frame_read)> (http2_cs) [0] [&Http2ClientSession::state_start_frame_read, VC_EVENT_READ_READY]
[Jun  5 16:22:50.197] {0xb000a000} DEBUG: <Http2ClientSession.cc:438 (do_start_frame_read)> (http2_cs) [0] receiving frame header
[Jun  5 16:22:50.197] {0xb000a000} DEBUG: <Http2ClientSession.cc:448 (do_start_frame_read)> (http2_cs) [0] frame header length=8, type=7, flags=0x0, streamid=0
[Jun  5 16:22:50.197] {0xb000a000} DEBUG: <Http2ConnectionState.cc:627 (rcv_goaway_frame)> (http2_con) [0] [0] Received GOAWAY frame
[Jun  5 16:22:50.197] {0xb000a000} DEBUG: <Http2ConnectionState.cc:646 (rcv_goaway_frame)> (http2_con) [0] [0] GOAWAY: last stream id=0, error code=0
[Jun  5 16:22:50.197] {0xb000a000} DEBUG: <Http2ClientSession.cc:68 (destroy)> (http2_cs) [0] session destroy
[Jun  5 16:22:50.197] {0xb000a000} DEBUG: <Http2ClientSession.cc:95 (free)> (http2_cs) [0] session free
```

After:
```
[Jun  5 16:24:15.632] {0xb000a000} DEBUG: <Http2ConnectionState.cc:1435 (send_data_> (http2_con)                      [0] [13] Shutdown stream
[Jun  5 16:24:15.632] {0xb000a000} DEBUG: <Http2ConnectionState.cc:1184 (delete_str> (http2_con)                      [0] [13] Delete stream
[Jun  5 16:24:15.632] {0xb000a000} DEBUG: <Http2Stream.cc:390 (initiating_close)>    (http2_stream)                   [0] [13] initiating_close
[Jun  5 16:24:15.632] {0xb000a000} DEBUG: <Http2Stream.cc:418 (initiating_close)>    (http2_stream)                   [0] [13] handle write from destroy (event=103)
[Jun  5 16:24:15.633] {0xb000a000} DEBUG: <Http2Stream.cc:713 (destroy)>             (http2_stream)                   [0] [13] Destroy stream, sent 16384 bytes
[Jun  5 16:24:15.634] {0xb000a000} DEBUG: <Http2ClientSession.cc:424 (state_start_f> (http2_cs)                       [0] [&Http2ClientSession::state_start_frame_read, VC_EVENT_READ_READY]
[Jun  5 16:24:15.634] {0xb000a000} DEBUG: <Http2ClientSession.cc:438 (do_start_fram> (http2_cs)                       [0] receiving frame header
[Jun  5 16:24:15.634] {0xb000a000} DEBUG: <Http2ClientSession.cc:448 (do_start_fram> (http2_cs)                       [0] frame header length=8, type=7, flags=0x0, streamid=0
[Jun  5 16:24:15.634] {0xb000a000} DEBUG: <Http2ConnectionState.cc:627 (rcv_goaway_> (http2_con)                      [0] [0] Received GOAWAY frame
[Jun  5 16:24:15.634] {0xb000a000} DEBUG: <Http2ConnectionState.cc:646 (rcv_goaway_> (http2_con)                      [0] [0] GOAWAY: last stream id=0, error code=0
[Jun  5 16:24:15.634] {0xb000a000} DEBUG: <Http2ClientSession.cc:68 (destroy)>       (http2_cs)                       [0] session destroy
[Jun  5 16:24:15.634] {0xb000a000} DEBUG: <Http2ClientSession.cc:95 (free)>          (http2_cs)                       [0] session free
```