### PR TITLE
Force linking with libstdc++ for test_marshall

### DIFF
--- a/mgmt/utils/Makefile.am
+++ b/mgmt/utils/Makefile.am
@@ -56,6 +56,7 @@ libutils_p_la_SOURCES = \
 	MgmtProcessCleanup.cc
 
 test_marshall_LDFLAGS = \
+	-static-libstdc++ \
 	@AM_LDFLAGS@ \
 	@OPENSSL_LDFLAGS@
 


### PR DESCRIPTION
~~If jemalloc isn't compiled with the `--disable-cxx` flag, it might cause double free issues with some class destructors. This fixes the problem when running `test_marshall` when ATS is compiled jemalloc (without the `--disable-cxx` flag).~~

The problem is that for some reason, the `new Regex()` call is using libc, but `delete` is going through jemalloc's code path for c++ support.