### PR TITLE
Change MIMEHdr::value_append_or_set to handle duplicate headers

### DIFF
--- a/proxy/hdrs/MIME.h
+++ b/proxy/hdrs/MIME.h
@@ -1383,6 +1383,9 @@ MIMEHdr::value_append_or_set(const char *name, const int name_length, char *valu
   MIMEField *field = nullptr;
 
   if ((field = field_find(name, name_length)) != nullptr) {
+    while (field->m_next_dup) {
+      field = field->m_next_dup;
+    }
     field_value_append(field, value, value_length, true);
   } else {
     value_set(name, name_length, value, value_length);


### PR DESCRIPTION
As far as I can tell from reading the HTTP specification, if there is already a header the new value should be appended to the last duplicate if the field is multi-valued (comma separated list). This would match the behavior of `MIMEHdr::value_set_xxx` methods which call `mime_hdr_prepare_for_value_set` to get to the last duplicate. The assumption is that if `value_append_or_set` is called this implies the field is expected to be multi-valued (or some `value_set_xxx` would have been called, although bizarrely that family does handle duplicates, albeit by deleting all but one).