### PR TITLE
Clean up zombie_event that didn't expire.

### DIFF
--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -157,6 +157,9 @@ public:
     if (fini_event) {
       fini_event->cancel();
     }
+    if (zombie_event) {
+      zombie_event->cancel();
+    }
   }
 
   // Event handlers


### PR DESCRIPTION
A fix on PR #3713.  Lost the event cleanup when tidying up for open source.