### PR TITLE
Add infodir back to Layout and clean up some code

### DIFF
--- a/cmd/traffic_layout/engine.cc
+++ b/cmd/traffic_layout/engine.cc
@@ -429,6 +429,7 @@ RunrootEngine::copy_runroot(const std::string &original_root, const std::string 
   original_map["runtimedir"]    = TS_BUILD_RUNTIMEDIR;
   original_map["logdir"]        = TS_BUILD_LOGDIR;
   original_map["mandir"]        = TS_BUILD_MANDIR;
+  original_map["infodir"]       = TS_BUILD_INFODIR;
   original_map["cachedir"]      = TS_BUILD_CACHEDIR;
 
   // copy each directory to the runroot path
@@ -451,8 +452,8 @@ RunrootEngine::copy_runroot(const std::string &original_root, const std::string 
       path_map[it.first] = Layout::relative_to(".", join_path);
     }
 
-    // don't copy the prefix, mandir and localstatedir
-    if (it.first != "exec_prefix" && it.first != "localstatedir" && it.first != "mandir") {
+    // don't copy the prefix, mandir, localstatedir and infodir
+    if (it.first != "exec_prefix" && it.first != "localstatedir" && it.first != "mandir" && it.first != "infodir") {
       if (!copy_directory(old_path, new_path, it.first)) {
         ink_warning("Copy failed for '%s' - %s", it.first.c_str(), strerror(errno));
       }
@@ -564,7 +565,7 @@ fix_runroot(RunrootMapType &path_map, RunrootMapType &permission_map, RunrootMap
         ink_warning("Unable to change file mode on %s: %s", path.c_str(), strerror(errno));
       }
     }
-    if (name == "localstatedir" || name == "logdir" || name == "runtimedir" || name == "cachedir") {
+    if (name == "logdir" || name == "runtimedir" || name == "cachedir") {
       // write
       if (permission[1] != '1') {
         if (chmod(path.c_str(), stat_buffer.st_mode | read_permission | write_permission) < 0) {
@@ -677,11 +678,11 @@ RunrootEngine::verify_runroot()
     std::cout << name << ": \x1b[1m" + path_map[name] + "\x1b[0m" << std::endl;
 
     // output read permission
-    if (name == "includedir" || name == "sysconfdir" || name == "datadir") {
+    if (name == "localstatedir" || name == "includedir" || name == "sysconfdir" || name == "datadir") {
       output_read_permission(permission);
     }
     // output write permission
-    if (name == "localstatedir" || name == "logdir" || name == "runtimedir" || name == "cachedir") {
+    if (name == "logdir" || name == "runtimedir" || name == "cachedir") {
       output_read_permission(permission);
       output_write_permission(permission);
     }

--- a/cmd/traffic_layout/engine.h
+++ b/cmd/traffic_layout/engine.h
@@ -78,5 +78,5 @@ struct RunrootEngine {
                                          "runtimedir", "logdir",      "cachedir"};
 
   // map for yaml file emit
-  std::unordered_map<std::string, std::string> path_map;
+  RunrootMapType path_map;
 };

--- a/lib/ts/I_Layout.h
+++ b/lib/ts/I_Layout.h
@@ -95,5 +95,6 @@ struct Layout {
   std::string runtimedir;
   std::string logdir;
   std::string mandir;
+  std::string infodir;
   std::string cachedir;
 };

--- a/lib/ts/Layout.cc
+++ b/lib/ts/Layout.cc
@@ -118,7 +118,7 @@ Layout::Layout(std::string_view const _prefix)
   } else {
     std::string path;
     int len;
-    std::unordered_map<std::string, std::string> dir_map = check_runroot();
+    RunrootMapType dir_map = check_runroot();
     if (dir_map.size() != 0) {
       prefix        = dir_map["prefix"];
       exec_prefix   = dir_map["exec_prefix"];
@@ -133,6 +133,7 @@ Layout::Layout(std::string_view const _prefix)
       runtimedir    = dir_map["runtimedir"];
       logdir        = dir_map["logdir"];
       mandir        = dir_map["mandir"];
+      infodir       = dir_map["infodir"];
       cachedir      = dir_map["cachedir"];
       return;
     }
@@ -164,6 +165,7 @@ Layout::Layout(std::string_view const _prefix)
   runtimedir    = layout_relative(prefix, TS_BUILD_RUNTIMEDIR);
   logdir        = layout_relative(prefix, TS_BUILD_LOGDIR);
   mandir        = layout_relative(prefix, TS_BUILD_MANDIR);
+  infodir       = layout_relative(prefix, TS_BUILD_INFODIR);
   cachedir      = layout_relative(prefix, TS_BUILD_CACHEDIR);
 }
 

--- a/lib/ts/runroot.cc
+++ b/lib/ts/runroot.cc
@@ -33,7 +33,7 @@ Example: ./traffic_server --run-root=/path/to/sandbox
 Need a yaml file in the sandbox with key value pairs of all directory locations for other programs to use
 
 Directories needed in the yaml file:
-prefix, exec_prefix, includedir, localstatedir, bindir, logdir, mandir, sbindir, sysconfdir,
+prefix, exec_prefix, includedir, localstatedir, bindir, logdir, sbindir, sysconfdir,
 datadir, libexecdir, libdir, runtimedir, cachedir.
 */
 
@@ -183,7 +183,7 @@ runroot_handler(const char **argv, bool json)
 }
 
 // return a map of all path in runroot_path.yml
-std::unordered_map<std::string, std::string>
+RunrootMapType
 runroot_map(const std::string &prefix)
 {
   std::string yaml_path = Layout::relative_to(prefix, "runroot_path.yml");
@@ -191,11 +191,11 @@ runroot_map(const std::string &prefix)
   file.open(yaml_path);
   if (!file.good()) {
     ink_warning("Bad path '%s', continue with default value", prefix.c_str());
-    return std::unordered_map<std::string, std::string>{};
+    return RunrootMapType{};
   }
 
   std::ifstream yamlfile(yaml_path);
-  std::unordered_map<std::string, std::string> map;
+  RunrootMapType map;
   std::string str;
   while (std::getline(yamlfile, str)) {
     int pos                 = str.find(':');
@@ -214,11 +214,11 @@ runroot_map(const std::string &prefix)
 // check for the using of runroot
 // a map of all path will be returned
 // if we do not use runroot, a empty map will be returned.
-std::unordered_map<std::string, std::string>
+RunrootMapType
 check_runroot()
 {
   if (using_runroot.empty()) {
-    return std::unordered_map<std::string, std::string>{};
+    return RunrootMapType{};
   }
 
   int len = using_runroot.size();

--- a/lib/ts/runroot.h
+++ b/lib/ts/runroot.h
@@ -29,6 +29,8 @@
 #include <string>
 #include <unordered_map>
 
+typedef std::unordered_map<std::string, std::string> RunrootMapType;
+
 std::string check_path(const std::string &path);
 
 std::string check_parent_path(const std::string &path);
@@ -36,7 +38,7 @@ std::string check_parent_path(const std::string &path);
 void runroot_handler(const char **argv, bool json = false);
 
 // get runroot map from yaml path and prefix
-std::unordered_map<std::string, std::string> runroot_map(const std::string &prefix);
+RunrootMapType runroot_map(const std::string &prefix);
 
 // help check runroot for layout
-std::unordered_map<std::string, std::string> check_runroot();
+RunrootMapType check_runroot();


### PR DESCRIPTION
``infodir`` was removed in commit 24c57a2056a0936063f616beeb51b8c5904a436a. 

Although ``infodir`` is not used anywhere, it is better to add it back to keep the consistency of GNU standard and at least have it stored somewhere. It is also taken out from traffic_layout runroot.

Clean up some code of traffic_layout about the ``RunrootMapType`` and ``localstatedir``.