### PR TITLE
Fixed AuTests breaking when run outside a virtualenv

### DIFF
--- a/tests/gold_tests/autest-site/build.test.ext
+++ b/tests/gold_tests/autest-site/build.test.ext
@@ -1,6 +1,7 @@
 '''
 Build random code for running as part of a test
 '''
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -18,23 +19,36 @@ Build random code for running as part of a test
 #  limitations under the License.
 
 import re
+import typing
 import autest.common.is_a as is_a
 
 
-def Build(Test, target, sources, CPPFLAGS='', LDFLAGS='', LIBS='', CC=None):
+def Build(Test,
+          target: str,
+          sources: typing.Union[typing.Sequence[str], str],
+          CPPFLAGS: str = '',
+          LDFLAGS: str = '',
+          LIBS: str = '',
+          CC: str = None) -> 'TestRun':
+    '''
+    Builds c++ source files using compiler `CC`, compiler flags `CPPFLAGS`,
+    linker flags `LDFLAGS` and libraries `LIBS`, outputting to `target`.
+
+    If not specified, uses the system's default values for flags, libraries,
+    and compiler.
+    '''
     if is_a.OrderedSequence(sources):
         sources = " ".join(sources)
     tr = Test.AddTestRun("Build", "Build test files: {0}".format(sources))
-    vars = Test.ComposeVariables()
-    if CC is None:
-        cc = vars.CXX
-    else:
-        cc = CC
+
+    variables = Test.ComposeVariables()
+
+    cc = CC if CC else variables.CXX
 
     tr.Processes.Default.Command = '{cc} -o {target} {cppflags} {sources} {ldflags} {libs}'.format(
-        cppflags="{0} {1}".format(vars.CPPFLAGS, CPPFLAGS),
-        ldflags="{0} {1}".format(vars.LDFLAGS, LDFLAGS),
-        libs="{0} {1}".format(vars.LIBS, LIBS),
+        cppflags="{0} {1}".format(variables.CPPFLAGS, CPPFLAGS),
+        ldflags="{0} {1}".format(variables.LDFLAGS, LDFLAGS),
+        libs="{0} {1}".format(variables.LIBS, LIBS),
         target=target,
         sources=sources,
         cc=cc

--- a/tests/gold_tests/autest-site/cli_tools.test.ext
+++ b/tests/gold_tests/autest-site/cli_tools.test.ext
@@ -1,6 +1,7 @@
 '''
 Tools to help with TestRun commands
 '''
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -24,32 +25,38 @@ Tools to help with TestRun commands
 # curlcmd = 'curl -vs -k https:127.0.0.1:{port}'.format(port = ts.Variables.port)
 #
 # tr = Test.AddTestRun()
-# ps = tr.SpawnCommands(cmdstr=cmdstr, count=25)
+# ps = tr.SpawnCommands(cmd=cmdstr, count=25)
 # tr.Processes.Default.StartBefore(ts)
 # ts.StartAfter(*ps)
 # tr.StillRunningAfter = ts
 #
-# Note that by default, the Default Process is created in this function. 
+# Note that by default, the Default Process is created in this function.
 
-def spawn_commands(self, cmdstr, count, retcode = 0, use_default=True):
-    ret=[] 
+def spawn_commands(self, cmd: str, count: int, retcode: int = 0, use_default: bool=True) -> list:
+    '''
+    Returns a list of `count` processes used to run `cmd` and expected to return `retcode`
+
+    If use_default is True (default), sets the tests's default process.
+    '''
+
+    ret=[]
 
     if use_default:
-        count = int(count) - 1  
-    for cnt in range(0,count):  
-        ret.append(  
-            self.Processes.Process(  
-                name="cmdline-{num}".format(num=cnt),  
-                cmdstr = cmdstr,  
+        count = int(count) - 1
+    for cnt in range(count):
+        ret.append(
+            self.Processes.Process(
+                name="cmdline-{num}".format(num=cnt),
+                cmdstr = cmd,
                 returncode = retcode
-                )  
+                )
             )
     if use_default:
-        self.Processes.Default.Command = cmdstr
+        self.Processes.Default.Command = cmd
         self.Processes.Default.ReturnCode = retcode
         self.Processes.Default.StartBefore(
             *ret
         )
-    return ret 
+    return ret
 
 ExtendTestRun(spawn_commands, name="SpawnCommands")

--- a/tests/gold_tests/autest-site/conditions.test.ext
+++ b/tests/gold_tests/autest-site/conditions.test.ext
@@ -1,4 +1,5 @@
 '''
+This module defines condition helper functions for tests to check against before running
 '''
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
@@ -15,13 +16,26 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import os
 
-def HasOpenSSLVersion(self, version):
+def HasOpenSSLVersion(self, version: str) -> bool:
+    '''
+    Returns whether the current testing environment has OpenSSL version >= `version`
+    '''
     return self.EnsureVersion(["openssl","version"],min_version=version)
 
-def HasCurlFeature(self, feature):
+def HasCurlFeature(self, feature: str) -> bool:
+    '''
+    Returns whether or not the system's 'curl' supports `feature`.
+    '''
 
-    def default(output):
+    def default(output: str) -> bool:
+        '''
+        A function that operates on the output of 'curl --version'
+        to supply the information needed by `HasCurlFeature`
+        '''
+        nonlocal feature
+
         FEATURE_TAG = 'Features:'
         tag = feature.lower()
         for line in output.splitlines():
@@ -29,9 +43,8 @@ def HasCurlFeature(self, feature):
             if line.startswith(FEATURE_TAG):
                 # get a features and lower case then for safety
                 line = line[len(FEATURE_TAG):].lower()
-                tokens = line.split()
-                for t in tokens:
-                    if t == tag:
+                for token in line.split():
+                    if token == tag:
                         return True
         return False
 
@@ -42,24 +55,28 @@ def HasCurlFeature(self, feature):
     )
 
 
-def HasATSFeature(self, feature):
+def HasATSFeature(self, feature: str) -> bool:
+    '''
+    Checks for the presence of `feature` in the testing environment's ATS installation
+    '''
 
     val = self.Variables.get(feature, None)
 
     return self.Condition(
-        lambda: val == True,
+        lambda: bool(val),
         "ATS feature not enabled: {feature}".format(feature=feature)
     )
 
-#test if a plugin exists in the libexec folder
-def PluginExists(self, pluginname):
+def PluginExists(self, pluginname: str) -> bool:
+    '''
+    test if a plugin exists in the libexec folder
+    '''
 
     path = os.path.join(self.Variables.PLUGINDIR, pluginname)
-    return self.Condition(lambda: os.path.isfile(path) == True, path + " not found." )
+    return self.Condition(lambda: os.path.isfile(path), path + " not found." )
 
 
 ExtendCondition(HasOpenSSLVersion)
 ExtendCondition(HasATSFeature)
 ExtendCondition(HasCurlFeature)
 ExtendCondition(PluginExists)
-

--- a/tests/gold_tests/autest-site/copy_config.test.ext
+++ b/tests/gold_tests/autest-site/copy_config.test.ext
@@ -1,5 +1,8 @@
 '''
+Defines a class for copying ATS config files from the system's
+installation into a particular test's environment
 '''
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,25 +19,35 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import os
-from future.utils import native_str
-
+import typing
 
 class CopyATSConfig(SetupItem):
-    def __init__(self, file, targetname=None, process=None):
+    '''
+    This class is responsible for attaching a config file
+    to a testing process.
+    '''
+
+    def __init__(self, file, targetname:typing.Union[str, 'Process']=None, process:'Process'=None):
         super(CopyATSConfig, self).__init__(itemname="CopyATSConfig")
         self.file = file
         # some protection
-        if process is None and not isinstance(targetname, native_str):
+        if process is None and not isinstance(targetname, str):
             self.process = targetname
         else:
             self.process = process
         self.targetname = targetname
 
     def setup(self):
+        '''
+        Does the actual work of copying a config file into
+        the process's execution environment.
+
+        Raises a SetupError if the environment is not properly initialized.
+        '''
         process = self.process if self.process else self
         try:
             ts_dir = process.Env['TS_ROOT']
-        except:
+        except KeyError:
             if self.process:
                 raise SetupError(
                     'TS_ROOT is not defined. Cannot copy ats config file without location to copy to.'
@@ -46,7 +59,7 @@ class CopyATSConfig(SetupItem):
 
         # set up the config path for test manually
         config_dir = os.path.join(ts_dir, "config")
-        
+
         host.WriteVerbose("CopyATSConfig", "Copying {0} to {1}".format(
             self.file, config_dir))
         self.CopyAs(self.file, config_dir, self.targetname)

--- a/tests/gold_tests/autest-site/httpbin.test.ext
+++ b/tests/gold_tests/autest-site/httpbin.test.ext
@@ -1,4 +1,6 @@
 '''
+This module defines a function for creating an HTTP server, then adds it
+to the Test
 '''
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
@@ -15,19 +17,30 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import os
+import typing
 from ports import get_port
 
 
-def MakeHttpBinServer(self, name, port=False, ip=False, delay=False, public_ip=False, ssl=False, options={}):
+def MakeHttpBinServer(self,
+                      name:    str,
+                      port:    int = None,
+                      ip:      str = None,
+                      delay:   int = False,
+                      options: typing.Dict[str, str] = {}) -> 'Process':
+    '''
+    Sets up an http server with the passed options.
+    '''
+
     data_dir = os.path.join(self.RunDirectory, name)
+
     # create Process
     p = self.Processes.Process(name)
-    if (port == False):
+    if not port:
         port = get_port(p, "Port")
-    if (ip == False):
+    if not ip:
         ip = '127.0.0.1'
-    if (delay == False):
+    if not delay:
         delay = 0
 
     self._RootRunable.SkipUnless(

--- a/tests/gold_tests/autest-site/init.cli.ext
+++ b/tests/gold_tests/autest-site/init.cli.ext
@@ -1,4 +1,6 @@
 '''
+Checks versions of Python interpreter and AuTest package, and sets
+up command-line arguments for this test suite.
 '''
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
@@ -15,8 +17,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-import os
 
 import sys
 if sys.version_info < (3, 5, 0):

--- a/tests/gold_tests/autest-site/microDNS.test.ext
+++ b/tests/gold_tests/autest-site/microDNS.test.ext
@@ -1,4 +1,5 @@
 '''
+This module defines tools for creating and configuring a minimal DNS server.
 '''
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
@@ -16,59 +17,62 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from ports import get_port
 import json
 import os
 import sys
+import typing
+from ports import get_port
 
-# AddRecord registers a list of ip address against hostname
-def AddRecord(hostname, list_ip_addr):
+def addRecords(self, records: typing.Dict[str, typing.List[str]]=None, jsonFile: str=None):
+    '''
+    Registers a dictionary `records` of DNS mappings with a microDNS server.
 
-    record = dict()
-    record[hostname] = list_ip_addr
-    return record
-
-# dict in format {'domain': [IPs]}
-# json file in the same mappings/otherwise format that uDNS takes
-
-
-def addRecords(self, records=None, jsonFile=None):
-    jsondata = None
+    dict in format {'domain': [IPs]}
+    json file in the same mappings/otherwise format that uDNS takes
+    '''
+    records = records if records else {}
 
     # at this point the default file and fields should have been created
     if os.path.exists(self.Variables.zone_file):
-        with open(self.Variables.zone_file, 'r') as f:
+        with open(self.Variables.zone_file) as f:
             jsondata = json.load(f)
     else:
         raise FileNotFoundError("default zone file doesn't exist, but it should.")
 
-    if records:
-        for domain in records:
-            # Let's do this for the test writer's convenience.
-            normalized_domain = domain
-            if normalized_domain[-1] != '.':
-                normalized_domain += '.'
-            record = AddRecord(normalized_domain, records[domain])
+    for domain, ips in records.items():
+        # Let's do this for the test writer's convenience.
+        if not domain.endswith('.'):
+            domain += '.'
 
-            jsondata["mappings"].append(record)
+        jsondata["mappings"].append({domain: ips})
 
     if jsonFile:
         jsonFile = os.path.join(self.TestDirectory, jsonFile)
         self.Setup.Copy(jsonFile, self.Variables.DataDir)
 
-        with open(jsonFile, 'r') as f:
+        with open(jsonFile) as f:
             entries = json.load(f)
 
-            if entries:
-                # not copying over entries['otherwise']. dont see the need to
-                for record in entries["mappings"]:
-                    jsondata["mappings"].append(record)
+        if entries and "mappings" in entries:
+            # not copying over entries['otherwise']. dont see the need to
+            jsondata["mappings"].extend(entries["mappings"])
 
     with open(self.Variables.zone_file, 'w+') as f:
         f.write(json.dumps(jsondata))
 
 
-def MakeDNServer(obj, name, filename="dns_file.json", port=False, ip='INADDR_LOOPBACK', rr=False, default=None, options={}):
+def MakeDNServer(obj,
+                 name: str,
+                 filename: str = "dns_file.json",
+                 port: int = None,
+                 ip: str = 'INADDR_LOOPBACK',
+                 rr: bool = False,
+                 default: typing.Dict[str, typing.List[str]] = None) -> 'Process':
+    '''
+    Starts up a uDNS server, optionally with some default records, and returns a
+    'Process' object which refers to it.
+    '''
+
     server_path = os.path.join(obj.Variables.AtsTestToolsDir, 'microDNS/uDNS.py')
     data_dir = os.path.join(obj.RunDirectory, name)
     filepath = os.path.join(data_dir, filename)
@@ -88,9 +92,16 @@ def MakeDNServer(obj, name, filename="dns_file.json", port=False, ip='INADDR_LOO
 
     # create Process
     p = obj.Processes.Process(name)
-    if (port == False):
+    if not port:
         port = get_port(p, "Port")
-    command = "python3 {0} {1} {2} {3}".format(server_path, ip, port, filepath)
+
+    # Sometimes the absolute interpreter path cannot be determined, so this sets
+    # up a reasonable default.
+    command = " ".join((sys.executable if sys.executable else 'python3',
+                        server_path,
+                        ip,
+                        str(port),
+                        filepath))
 
     if rr:
         command += " --rr"
@@ -103,14 +114,13 @@ def MakeDNServer(obj, name, filename="dns_file.json", port=False, ip='INADDR_LOO
 
     # to get the IP keywords in tools/lib
     sys.path.append(obj.Variables.AtsTestToolsDir)
-    import lib.IPConstants as IPConstants
+    from lib import IPConstants
 
     if IPConstants.isIPv6(ip):
         p.Ready = When.PortOpenv6(port)
     else:
         p.Ready = When.PortOpenv4(port)
-        
-    AddMethodToInstance(p, AddRecord)
+
     AddMethodToInstance(p, addRecords)
 
     return p

--- a/tests/gold_tests/autest-site/microserver.test.ext
+++ b/tests/gold_tests/autest-site/microserver.test.ext
@@ -1,5 +1,8 @@
 '''
+This module contains all the bits and pieces needed to assemble
+and manipulate a servicable mock origin server.
 '''
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,45 +19,54 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from autest.api import AddWhenFunction
-from ports import get_port
 import json
 import socket
 import ssl
-import time
+import typing
 import sys
+import os
+from ports import get_port
+from autest.api import AddWhenFunction
 
 
 def addMethod(self, testName, request_header, functionName):
-    return
-
-# creates the full request or response block using headers and message data
-
-
-def httpObject(self, header, data):
-    r = dict()
-    r["timestamp"] = ""
-    r["headers"] = header
-    r["body"] = data
-    return r
+    '''
+    idk what this does, but I'm leaving it to avoid breaking things
+    '''
+    pass
 
 
-def getHeaderFieldVal(request_header, field):
+def httpObject(self, header: str, data: str) -> typing.Dict[str, str]:
+    '''
+    creates the full request or response block using headers and message data
+    '''
+    return {'timestamp': "", "headers": header, "body": data}
+
+
+def getHeaderFieldVal(request_header: typing.Dict[str, str], field: str) -> str:
+    '''
+    Extracts the value of the 'field' header from the full request header `request_header`
+    '''
     requestline = request_header["headers"].split("\r\n")[0]
     requestline = requestline.split(" ")[1]
-    field = field + ':'
+    field += ':'
     valField = request_header["headers"].split(field, 1)
     val = ""
     if len(valField) > 1:
         field_v = valField[1].split("\r\n", 1)
-        if len(field_v) > 0:
+        if field_v:
             val = field_v[0].strip()
     return val
 
-# addResponse adds customized response with respect to request_header. request_header and response_header are both dictionaries
 
 
-def addResponse(self, filename, request_header, response_header):
+def addResponse(self,
+                filename:        str,
+                request_header:  typing.Dict[str, str],
+                response_header: typing.Dict[str, str]):
+    '''
+    adds customized `response` with respect to `request_header`.
+    '''
     requestline = request_header["headers"].split("\r\n")[0]
     host_ = ""
     path_ = ""
@@ -68,127 +80,162 @@ def addResponse(self, filename, request_header, response_header):
                 path_ = url_part[1].split("/", 1)[1]
 
     kpath = ""
-
     argsList = []
-    keyslist = self.Variables.lookup_key.split("}")
-    for keystr in keyslist:
-        if keystr == '{PATH':
-            kpath = kpath + path_
-            continue
-        if keystr == '{HOST':
-            kpath = kpath + host_
-            continue
-        if keystr == '':  # empty
-            continue
-        stringk = keystr.replace("{%", "")
-        argsList.append(stringk)
+    for keystr in self.Variables.lookup_key.split('}'):
+        if keystr:
+            if keystr == '{PATH':
+                kpath += path_
+            if keystr == '{HOST':
+                kpath += host_
+            else:
+                argsList.append(keystr.replace("{%", ""))
+
     KeyList = []
     for argsL in argsList:
         field_val = getHeaderFieldVal(request_header, argsL)
-        if field_val != None:
+        if field_val is not None:
             KeyList.append(field_val)
-    rl = "".join(KeyList) + kpath
-    txn = dict()
-    txn["timestamp"] = ""
-    txn["uuid"] = rl
-    txn["request"] = request_header
-    txn["response"] = response_header
-    absFilepath = os.path.join(self.Variables.DataDir, filename)
-    addTransactionToSession(txn, absFilepath)
-    # absFilepath=os.path.abspath(filename)
-    # self.Setup.CopyAs(absFilepath,self.Variables.DataDir)
-    return
 
-# adds transaction in json format to the specified file
+    txn = {
+           "timestamp": "",
+           "uuid": "".join(KeyList) + kpath,
+           "request": request_header,
+           "response": response_header
+          }
+
+    addTransactionToSession(txn, os.path.join(self.Variables.DataDir, filename))
 
 
-def addTransactionToSession(txn, JFile):
-    jsondata = None
-    if not os.path.exists(os.path.dirname(JFile)):
-        os.makedirs(os.path.dirname(JFile))
+def addTransactionToSession(txn: typing.Dict[str, str], JFile: str):
+    '''
+    adds transaction in json format to the specified file
+    '''
+    jsondata, jsonDir = None, os.path.dirname(JFile)
+
+    if not os.path.exists(jsonDir):
+        os.makedirs(jsonDir)
+
     if os.path.exists(JFile):
-        jf = open(JFile, 'r')
+        jf = open(JFile, 'r+')
         jsondata = json.load(jf)
+        jf.truncate(0)
+        jf.seek(0)
+    else:
+        jf = open(JFile, 'x')
 
-    if jsondata == None:
-        jsondata = dict()
-        jsondata["version"] = '0.2'
-        jsondata["timestamp"] = "1234567890.098"
-        jsondata["encoding"] = "url_encoded"
-        jsondata["txns"] = list()
-        jsondata["txns"].append(txn)
+    if jsondata is None:
+        jsondata = {
+                    "version": '0.2',
+                    "timestamp": "1234567890.098",
+                    "encoding": "url_encoded",
+                    "txns": [txn],
+                   }
     else:
         jsondata["txns"].append(txn)
-    with open(JFile, 'w+') as jf:
-        jf.write(json.dumps(jsondata))
+
+    jf.write(json.dumps(jsondata))
+    jf.close()
 
 
-# make headers with the key and values provided
-def makeHeader(self, requestString, **kwargs):
-    headerStr = requestString + '\r\n'
-    for k, v in kwargs.iteritems():
-        headerStr += k + ': ' + v + '\r\n'
-    headerStr = headerStr + '\r\n'
-    return headerStr
+def makeHeader(self, requestString: str, **kwargs) -> str:
+    '''
+    make headers with the key and values provided
+    '''
+    header = [requestString]
+    header.extend("%s: %s" % item for item in kwargs.items())
+    header.append('')
+
+    return '\r\n'.join(header)
 
 
-def uServerUpAndRunning(host, port, isSsl, isIPv6):
-    if isIPv6:
-        plain_sock = socket.socket(socket.AF_INET6)
-    else:
-        plain_sock = socket.socket(socket.AF_INET)
+def uServerUpAndRunning(host: str, port: int, isSsl: bool, isIPv6: bool) -> bool:
+    '''
+    Checks that an ipv4/6 HTTP(S) server is listening at `host`:`port`.
 
-    sock = ssl.wrap_socket(plain_sock) if isSsl else plain_sock
-    try:
-        sock.connect((host, port))
-    except ConnectionRefusedError:
-        return False
+    Raises a RuntimeError if a connection can be made, but the server isn't
+    sending intelligible HTTP(S) responses.
+    '''
+    sock_family = socket.AF_INET6 if isIPv6 else socket.AF_INET
 
-    sock.sendall("GET /ruok HTTP/1.1\r\nHost: {}\r\n\r\n".format(host).encode())
-    decoded_output=''
-    while True:
-        output = sock.recv(4096)  # suggested bufsize from docs.python.org
-        if len(output) <= 0:
-            break
-        else:
-            decoded_output+=output.decode()
-    sock.close()
-    sock = None
+    with socket.socket(sock_family) as sock:
+        if isSsl:
+            sock = ssl.wrap_socket(sock)
 
-    expected_response="HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 4\r\n\r\nimok"
-    if decoded_output == expected_response:
+        try:
+            sock.connect((host, port))
+        except ConnectionRefusedError:
+            return False
+
+        sock.sendall(b"GET /ruok HTTP/1.1\r\nHost: %s\r\n\r\n" % (host.encode(),))
+
+        response=b''
+        while True:
+            output = sock.recv(4096)  # suggested bufsize from docs.python.org
+            if len(output) <= 0:
+                break
+            else:
+                response+=output
+
+    expected_response=b"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 4\r\n\r\nimok"
+    if response == expected_response:
         return True
     raise RuntimeError('\n'.join([
             'Got invalid response from microserver:',
             '----',
-            decoded_output,
+            response.decode(),
             '----']))
 AddWhenFunction(uServerUpAndRunning)
 
 
-def MakeOriginServer(obj, name, port=False, ip='INADDR_LOOPBACK', delay=False, ssl=False, lookup_key='{PATH}', mode='test', options={}):
+def MakeOriginServer(obj,
+                     name:       str,
+                     port:       int = None,
+                     ip:         str = 'INADDR_LOOPBACK',
+                     delay:      int = None,
+                     use_ssl:    bool = False,
+                     lookup_key: str = '{PATH}',
+                     mode:       str = 'test',
+                     options:    typing.Dict[str, str] = None) -> 'Process':
+    '''
+    Pretty self-explanitory, sets up a minimal mock origin server with the passed
+    parameters.
+
+    Returns a `Process` object that represents the started server.
+    '''
     # to get the IP keywords in tools/lib
     sys.path.append(obj.Variables.AtsTestToolsDir)
-    import lib.IPConstants as IPConstants
+    from lib import IPConstants
 
-    server_path = os.path.join(obj.Variables.AtsTestToolsDir, 'microServer/uWServer.py')
+    if not options:
+        options = {}
+
+    server_path = os.path.join(obj.Variables.AtsTestToolsDir, 'microServer', 'uWServer.py')
     data_dir = os.path.join(obj.RunDirectory, name)
     # create Process
     p = obj.Processes.Process(name)
 
-    if (port == False):
+    if not port:
         port = get_port(p, "Port")
 
     ipaddr = IPConstants.getIP(ip)
 
-    if (delay == False):
+    if not delay:
         delay = 0
 
-    command = "python3 {0} --data-dir {1} --port {2} --ip_address {3} --delay {4} -m test --ssl {5} --lookupkey '{6}' -m {7}".format(
-        server_path, data_dir, port, ipaddr, delay, ssl, lookup_key, mode)
+    command="%s %s --data-dir %s --port %s --ip_address %s --delay %s -m test --ssl %s --lookupkey '%s' -m %s"
+    # sometimes the absolute path to the interpreter cannot be determined, so this sets
+    # up a reasonable fallback value in that case.
+    command %= (sys.executable if sys.executable else 'python3',
+                server_path,
+                data_dir,
+                port,
+                ipaddr,
+                delay,
+                use_ssl,
+                lookup_key,
+                mode)
 
-    for flag, value in options.items():
-        command += " {} {}".format(flag, value)
+    command += " ".join("%s %s" % option for option in options.items())
 
     p.Command = command
     p.Setup.MakeDir(data_dir)
@@ -209,7 +256,7 @@ def MakeOriginServer(obj, name, port=False, ip='INADDR_LOOPBACK', delay=False, s
         "options": "skipHooks"
     })
 
-    p.Ready = When.uServerUpAndRunning(ipaddr, port, ssl, IPConstants.isIPv6(ip))
+    p.Ready = When.uServerUpAndRunning(ipaddr, port, use_ssl, IPConstants.isIPv6(ip))
     p.ReturnCode = Any(None, 0)
 
     return p

--- a/tests/gold_tests/autest-site/setup.cli.ext
+++ b/tests/gold_tests/autest-site/setup.cli.ext
@@ -1,4 +1,7 @@
 '''
+This module is responsible for checking the status of the ATS install at
+runtime, and also for setting up the testing environment and logging all
+of this information.
 '''
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
@@ -42,9 +45,8 @@ if ENV['ATS_BIN'] is not None:
         out = subprocess.check_output([traffic_layout, "--json"])
     except subprocess.CalledProcessError:
         host.WriteError("traffic_layout is broken. Aborting tests - The build of traffic server is bad.", show_stack=False)
-    out = json.loads(out.decode("utf-8"))
-    for k, v in out.items():
-        out[k] = v[:-1] if v.endswith('/') else v
+    out = {k: v.rstrip('/') for k,v in json.loads(out.decode()).items()}
+
     Variables.update(out)
     host.WriteVerbose(['ats'], "Traffic server layout Data:\n", pprint.pformat(out))
     # if the above worked this should as well
@@ -54,11 +56,11 @@ if ENV['ATS_BIN'] is not None:
     Variables.update(out)
     host.WriteVerbose(['ats'], "Traffic server feature data:\n", pprint.pformat(out))
 
-    # update version number 
-    out = subprocess.check_output([traffic_layout, "--version"]) 
-    out = Version(out.decode("utf-8").split("-")[2].strip()) 
+    # update version number
+    out = subprocess.check_output([traffic_layout, "--version"])
+    out = Version(out.decode("utf-8").split("-")[2].strip())
     Variables.trafficserver_version = out
-    host.WriteVerbose(['ats'], "Traffic server version:", out) 
+    host.WriteVerbose(['ats'], "Traffic server version:", out)
 
     # this querys tsxs for build flags so we can build code for the tests and get certain
     # useful flags as which openssl to use when we don't use the system version
@@ -69,7 +71,7 @@ if ENV['ATS_BIN'] is not None:
         'CXX': ''
     }
     if os.path.isfile(tsxs):
-        for flag in out.keys():
+        for flag in out:
             try:
                 data = subprocess.check_output([tsxs, "-q", flag])
                 out[flag] = data.decode("utf-8")[:-1]

--- a/tests/gold_tests/autest-site/trafficserver.test.ext
+++ b/tests/gold_tests/autest-site/trafficserver.test.ext
@@ -1,5 +1,9 @@
 '''
+This module is responsible for setting up a mock ATS instance,
+utilizing the compiled binaries, shared object files, and
+various configuration files of the host system.
 '''
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,20 +20,24 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from __future__ import print_function
 import os
-import socket
+import typing
 from ports import get_port
 
 
-def make_id(s):
+def make_id(s: str) -> str:
+    """Strips out bad word-separators for ids"""
     return s.replace(".", "_").replace('-', '_')
 
 
 # this forms is for the global process define
 
 
-def MakeATSProcess(obj, name, command='traffic_server', select_ports=True):
+def MakeATSProcess(obj,
+                   name:         str,
+                   command:      str = 'traffic_server',
+                   select_ports: bool = True) -> 'Process':
+    """Constructs and returns an ATS instance as a `Process` object"""
     #####################################
     # common locations
 
@@ -177,8 +185,8 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True):
     p.Disk.diags_log.Content += Testers.ExcludesExpression(
         "FATAL:", "diags.log should not contain errors")
 
-    # config files
-    def MakeConfigFile(self, fname):
+    def MakeConfigFile(self, fname: str) -> 'File':
+        """config files"""
         tmpname = os.path.join(config_dir, fname)
         return self.File(tmpname, id=make_id(fname), typename="ats:config")
 
@@ -306,22 +314,28 @@ class Config(File):
         self.content = content
         self._added = False
 
-    def AddLines(self, lines):
+    def AddLines(self, lines: typing.Sequence[str]):
+        '''
+        Convenience function to add multiple lines from an iterable
+        '''
         for line in lines:
             self.AddLine(line)
 
-    def _do_write(self, name):
+    def _do_write(self, name: str) -> typing.Tuple[bool, str, str]:
         '''
         Write contents to disk
         '''
-        host.WriteVerbosef('ats-config-file', "Writting out file {0}",
+        host.WriteVerbosef('ats-config-file', "Writing out file {0}",
                            self.Name)
         if self.content is not None:
             with open(name, 'w') as f:
                 f.write(self.content)
         return (False, "Appended file {0}".format(self.Name), "Success")
 
-    def AddLine(self, line):
+    def AddLine(self, line: str):
+        """
+        Adds a single line to the config.
+        """
         if not self._added:
             self.WriteCustomOn(self._do_write)
             self._added = True
@@ -368,14 +382,17 @@ class RecordsConfig(Config, dict):
             runtime=True)
         self.WriteCustomOn(self._do_write)
 
-    def _do_write(self, name):
+    def _do_write(self, name: str) -> typing.Tuple[bool, str, str]:
+        '''
+        Write contents to disk
+        '''
         host.WriteVerbosef('ats-config-file', "Writting out file {0}", name)
-        if len(self) > 0:
+        if self:
             with open(name, 'w') as f:
-                for name, val in self.items():
+                for option, val in self.items():
                     f.write(
                         self.line_template.format(
-                            name=name,
+                            name=option,
                             kind=self.reverse_kind_map[type(val)],
                             val=val)
                     )
@@ -387,7 +404,10 @@ class RecordsConfig(Config, dict):
 ##########################################################################
 
 
-def addSSLfile(self, filename):
+def addSSLfile(self, filename: str):
+    '''
+    adds an ssl file to the current execution environment
+    '''
     self.Setup.CopyAs(filename, self.Variables.SSLDir)
 
 

--- a/tests/gold_tests/autest-site/trafficserver_plugins.test.ext
+++ b/tests/gold_tests/autest-site/trafficserver_plugins.test.ext
@@ -19,7 +19,7 @@ Builds, installs, and enables an ATS plugin in the sandbox environment
 
 import os
 
-def prepare_plugin(self, path, tsproc, plugin_args = ""):
+def prepare_plugin(self, path: os.PathLike, tsproc: 'Process', plugin_args: str = ""):
     """Builds, installs, and enables an ATS plugin in the sandbox environment
 
     The source file at the given path is copied to the sandbox directory of the
@@ -33,7 +33,7 @@ def prepare_plugin(self, path, tsproc, plugin_args = ""):
 
     tsxs = os.path.join(self.Variables.BINDIR,'tsxs')
     # get the top level object ( ie Test) to add a condition
-    # need to change this API in AuTest to be a better name as it now has value 
+    # need to change this API in AuTest to be a better name as it now has value
     # to be called by user API - dragon512
     self._RootRunable.SkipUnless(
         Condition.HasProgram(tsxs, "tsxs needs be installed with trafficserver package for this test to run")

--- a/tests/gold_tests/basic/basic-manager.test.py
+++ b/tests/gold_tests/basic/basic-manager.test.py
@@ -1,4 +1,5 @@
 '''
+Test that Trafficserver starts with default configurations.
 '''
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/tests/gold_tests/basic/basic.test.py
+++ b/tests/gold_tests/basic/basic.test.py
@@ -1,4 +1,5 @@
 '''
+Test that Trafficserver starts with default configurations.
 '''
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/tests/gold_tests/basic/config.test.py
+++ b/tests/gold_tests/basic/config.test.py
@@ -1,4 +1,5 @@
 '''
+Test start up of Traffic server with configuration modification of starting port
 '''
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/tests/gold_tests/basic/copy_config.test.py
+++ b/tests/gold_tests/basic/copy_config.test.py
@@ -1,4 +1,5 @@
 '''
+Test start up of Traffic server with configuration modification of starting port of different servers at the same time
 '''
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/tests/gold_tests/basic/copy_config2.test.py
+++ b/tests/gold_tests/basic/copy_config2.test.py
@@ -1,4 +1,5 @@
 '''
+Test start up of Traffic server with generated ports of more than one servers at the same time
 '''
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/tests/gold_tests/body_factory/http204_response.test.py
+++ b/tests/gold_tests/body_factory/http204_response.test.py
@@ -16,7 +16,7 @@ Tests that 204 responses conform to rfc2616, unless custom templates override.
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import sys
 import os
 
 Test.Summary = '''
@@ -70,6 +70,8 @@ ts.Disk.MakeConfigFile(regex_remap_conf_file).AddLine(
     '//.*/ http://127.0.0.1:{0} @status=204'
     .format(server.Variables.Port)
 )
+# This sets up a reasonable fallback in the event the absolute path to this interpreter cannot be determined
+executable = sys.executable if sys.executable else 'python3'
 
 Test.Setup.Copy(os.path.join(os.pardir, os.pardir, 'tools', 'tcp_client.py'))
 Test.Setup.Copy('data')
@@ -78,8 +80,8 @@ defaultTr = Test.AddTestRun("Test domain {0}".format(DEFAULT_204_HOST))
 defaultTr.Processes.Default.StartBefore(Test.Processes.ts)
 defaultTr.StillRunningAfter = ts
 
-defaultTr.Processes.Default.Command = "python tcp_client.py 127.0.0.1 {0} {1} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
-    format(ts.Variables.port, 'data/{0}_get.txt'.format(DEFAULT_204_HOST))
+defaultTr.Processes.Default.Command = "{0} tcp_client.py 127.0.0.1 {1} {2} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
+    format(executable, ts.Variables.port, 'data/{0}_get.txt'.format(DEFAULT_204_HOST))
 defaultTr.Processes.Default.TimeOut = 5  # seconds
 defaultTr.Processes.Default.ReturnCode = 0
 defaultTr.Processes.Default.Streams.stdout = "gold/http-204.gold"
@@ -88,8 +90,8 @@ defaultTr.Processes.Default.Streams.stdout = "gold/http-204.gold"
 customTemplateTr = Test.AddTestRun("Test domain {0}".format(CUSTOM_TEMPLATE_204_HOST))
 customTemplateTr.StillRunningBefore = ts
 customTemplateTr.StillRunningAfter = ts
-customTemplateTr.Processes.Default.Command = "python tcp_client.py 127.0.0.1 {0} {1} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
-    format(ts.Variables.port, 'data/{0}_get.txt'.format(CUSTOM_TEMPLATE_204_HOST))
+customTemplateTr.Processes.Default.Command = "{0} tcp_client.py 127.0.0.1 {1} {2} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
+    format(executable, ts.Variables.port, 'data/{0}_get.txt'.format(CUSTOM_TEMPLATE_204_HOST))
 customTemplateTr.Processes.Default.TimeOut = 5  # seconds
 customTemplateTr.Processes.Default.ReturnCode = 0
 customTemplateTr.Processes.Default.Streams.stdout = "gold/http-204-custom.gold"

--- a/tests/gold_tests/body_factory/http204_response_plugin.test.py
+++ b/tests/gold_tests/body_factory/http204_response_plugin.test.py
@@ -18,6 +18,7 @@ Tests that plugins may break HTTP by sending 204 respose bodies
 #  limitations under the License.
 
 import os
+import sys
 
 Test.Summary = '''
 Tests that plugins may break HTTP by sending 204 respose bodies
@@ -48,8 +49,10 @@ tr = Test.AddTestRun("Test domain {0}".format(CUSTOM_PLUGIN_204_HOST))
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 
-tr.Processes.Default.Command = "python tcp_client.py 127.0.0.1 {0} {1} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
-    format(ts.Variables.port, 'data/{0}_get.txt'.format(CUSTOM_PLUGIN_204_HOST))
+# This sets up a reasonable fallback in the event the absolute path to this interpreter cannot be determined
+executable = sys.executable if sys.executable else 'python3'
+tr.Processes.Default.Command = "{0} tcp_client.py 127.0.0.1 {1} {2} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
+    format(executable, ts.Variables.port, 'data/{0}_get.txt'.format(CUSTOM_PLUGIN_204_HOST))
 tr.Processes.Default.TimeOut = 5  # seconds
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/http-204-custom-plugin.gold"

--- a/tests/gold_tests/body_factory/http304_response.test.py
+++ b/tests/gold_tests/body_factory/http304_response.test.py
@@ -16,7 +16,7 @@ Tests 304 responses
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import sys
 import os
 
 Test.Summary = '''
@@ -50,8 +50,10 @@ tr = Test.AddTestRun("Test domain {0}".format(DEFAULT_304_HOST))
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 
-cmd_tpl = "python tcp_client.py 127.0.0.1 {0} {1} | grep -v '^Date: '| grep -v '^Server: ATS/' | sed 's;ApacheTrafficServer\/[^ ]*;VERSION;'"
-tr.Processes.Default.Command = cmd_tpl.format(ts.Variables.port, 'data/{0}_get.txt'.format(DEFAULT_304_HOST))
+# This sets up a reasonable fallback in the event the absolute path to this interpreter cannot be determined
+executable = sys.executable if sys.executable else 'python3'
+cmd_tpl = "{0} tcp_client.py 127.0.0.1 {1} {2} | grep -v '^Date: '| grep -v '^Server: ATS/' | sed 's;ApacheTrafficServer\/[^ ]*;VERSION;'"
+tr.Processes.Default.Command = cmd_tpl.format(executable, ts.Variables.port, 'data/{0}_get.txt'.format(DEFAULT_304_HOST))
 tr.Processes.Default.TimeOut = 5  # seconds
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/http-304.gold"

--- a/tests/gold_tests/body_factory/http_head_no_origin.test.py
+++ b/tests/gold_tests/body_factory/http_head_no_origin.test.py
@@ -16,7 +16,7 @@ Tests that HEAD requests return proper responses when origin fails
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import sys
 import os
 
 Test.Summary = '''
@@ -38,8 +38,10 @@ tr = Test.AddTestRun("Test domain {0}".format(HOST))
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 
-tr.Processes.Default.Command = "python tcp_client.py 127.0.0.1 {0} {1} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
-    format(ts.Variables.port, 'data/{0}_head.txt'.format(HOST))
+# This sets up a reasonable fallback in the event the absolute path to this interpreter cannot be determined
+executable = sys.executable if sys.executable else 'python3'
+tr.Processes.Default.Command = "{0} tcp_client.py 127.0.0.1 {1} {2} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
+    format(executable, ts.Variables.port, 'data/{0}_head.txt'.format(HOST))
 tr.Processes.Default.TimeOut = 5  # seconds
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/http-head-no-origin.gold"

--- a/tests/gold_tests/body_factory/http_with_origin.test.py
+++ b/tests/gold_tests/body_factory/http_with_origin.test.py
@@ -16,7 +16,7 @@ Tests that HEAD requests return proper responses
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import sys
 import os
 
 Test.Summary = '''
@@ -70,14 +70,17 @@ server.addResponse("sessionfile.log", {
 Test.Setup.Copy(os.path.join(os.pardir, os.pardir, 'tools', 'tcp_client.py'))
 Test.Setup.Copy('data')
 
+# This sets up a reasonable fallback in the event the absolute path to this interpreter cannot be determined
+executable = sys.executable if sys.executable else 'python3'
+
 trhead200 = Test.AddTestRun("Test domain {0}".format(HOST))
 trhead200.Processes.Default.StartBefore(Test.Processes.ts)
 trhead200.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Port))
 trhead200.StillRunningAfter = ts
 trhead200.StillRunningAfter = server
 
-trhead200.Processes.Default.Command = "python tcp_client.py 127.0.0.1 {0} {1} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
-    format(ts.Variables.port, 'data/{0}_head_200.txt'.format(HOST))
+trhead200.Processes.Default.Command = "{0} tcp_client.py 127.0.0.1 {1} {2} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
+    format(executable, ts.Variables.port, 'data/{0}_head_200.txt'.format(HOST))
 trhead200.Processes.Default.TimeOut = 5  # seconds
 trhead200.Processes.Default.ReturnCode = 0
 trhead200.Processes.Default.Streams.stdout = "gold/http-head-200.gold"
@@ -89,8 +92,8 @@ trget200.StillRunningBefore = server
 trget200.StillRunningAfter = ts
 trget200.StillRunningAfter = server
 
-trget200.Processes.Default.Command = "python tcp_client.py 127.0.0.1 {0} {1} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
-    format(ts.Variables.port, 'data/{0}_get_200.txt'.format(HOST))
+trget200.Processes.Default.Command = "{0} tcp_client.py 127.0.0.1 {1} {2} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
+    format(executable, ts.Variables.port, 'data/{0}_get_200.txt'.format(HOST))
 trget200.Processes.Default.TimeOut = 5  # seconds
 trget200.Processes.Default.ReturnCode = 0
 trget200.Processes.Default.Streams.stdout = "gold/http-get-200.gold"
@@ -102,8 +105,8 @@ trget304.StillRunningBefore = server
 trget304.StillRunningAfter = ts
 trget304.StillRunningAfter = server
 
-cmd_tpl = "python tcp_client.py 127.0.0.1 {0} {1} | grep -v '^Date: '| grep -v '^Server: ATS/' | sed 's;ApacheTrafficServer\/[^ ]*;VERSION;'"
-trget304.Processes.Default.Command = cmd_tpl.format(ts.Variables.port, 'data/{0}_get_304.txt'.format(HOST))
+cmd_tpl = "{0} tcp_client.py 127.0.0.1 {1} {2} | grep -v '^Date: '| grep -v '^Server: ATS/' | sed 's;ApacheTrafficServer\/[^ ]*;VERSION;'"
+trget304.Processes.Default.Command = cmd_tpl.format(executable, ts.Variables.port, 'data/{0}_get_304.txt'.format(HOST))
 trget304.Processes.Default.TimeOut = 5  # seconds
 trget304.Processes.Default.ReturnCode = 0
 trget304.Processes.Default.Streams.stdout = "gold/http-get-304.gold"

--- a/tests/gold_tests/chunked_encoding/chunked_encoding.test.py
+++ b/tests/gold_tests/chunked_encoding/chunked_encoding.test.py
@@ -30,7 +30,7 @@ Test.ContinueOnFail = True
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server = Test.MakeOriginServer("server")
-server2 = Test.MakeOriginServer("server2", ssl=True)
+server2 = Test.MakeOriginServer("server2", use_ssl=True)
 server3 = Test.MakeOriginServer("server3")
 
 testName = ""

--- a/tests/gold_tests/continuations/double.test.py
+++ b/tests/gold_tests/continuations/double.test.py
@@ -53,8 +53,8 @@ numberOfRequests = 25
 
 tr = Test.AddTestRun()
 
-# Create a bunch of curl commands to be executed in parallel. Default.Process is set in SpawnCommands. 
-ps = tr.SpawnCommands(cmdstr=cmd,  count=numberOfRequests)
+# Create a bunch of curl commands to be executed in parallel. Default.Process is set in SpawnCommands.
+ps = tr.SpawnCommands(cmd=cmd,  count=numberOfRequests)
 tr.Processes.Default.Env = ts.Env
 
 # Execution order is: ts/server, ps(curl cmds), Default Process.

--- a/tests/gold_tests/continuations/double_h2.test.py
+++ b/tests/gold_tests/continuations/double_h2.test.py
@@ -84,8 +84,8 @@ numberOfRequests = 25
 
 tr = Test.AddTestRun()
 
-# Create a bunch of curl commands to be executed in parallel. Default.Process is set in SpawnCommands. 
-ps = tr.SpawnCommands(cmdstr=cmd, count=numberOfRequests)
+# Create a bunch of curl commands to be executed in parallel. Default.Process is set in SpawnCommands.
+ps = tr.SpawnCommands(cmd=cmd, count=numberOfRequests)
 tr.Processes.Default.Env = ts.Env
 
 # Execution order is: ts/server, ps(curl cmds), Default Process.

--- a/tests/gold_tests/continuations/openclose.test.py
+++ b/tests/gold_tests/continuations/openclose.test.py
@@ -58,8 +58,8 @@ cmd = 'curl -vs http://127.0.0.1:{0}'.format(ts.Variables.port)
 numberOfRequests = 25
 
 tr = Test.AddTestRun()
-# Create a bunch of curl commands to be executed in parallel. Default.Process is set in SpawnCommands. 
-ps = tr.SpawnCommands(cmdstr=cmd,  count=numberOfRequests)
+# Create a bunch of curl commands to be executed in parallel. Default.Process is set in SpawnCommands.
+ps = tr.SpawnCommands(cmd=cmd,  count=numberOfRequests)
 tr.Processes.Default.Env = ts.Env
 
 # Execution order is: ts/server, ps(curl cmds), Default Process.

--- a/tests/gold_tests/continuations/openclose_h2.test.py
+++ b/tests/gold_tests/continuations/openclose_h2.test.py
@@ -81,14 +81,14 @@ cmd = 'curl --http2 -k -vs https://127.0.0.1:{0}/'.format(ts.Variables.ssl_port)
 numberOfRequests = 25
 
 tr = Test.AddTestRun()
-# Create a bunch of curl commands to be executed in parallel. Default.Process is set in SpawnCommands. 
-ps = tr.SpawnCommands(cmdstr=cmd, count=numberOfRequests)
+# Create a bunch of curl commands to be executed in parallel. Default.Process is set in SpawnCommands.
+ps = tr.SpawnCommands(cmd=cmd, count=numberOfRequests)
 tr.Processes.Default.Env = ts.Env
 
 # Execution order is: ts/server, ps(curl cmds), Default Process.
 tr.Processes.Default.StartBefore(
     server, ready=When.PortOpen(server.Variables.Port))
-# Adds a delay once the ts port is ready. This is because we cannot test the ts state. 
+# Adds a delay once the ts port is ready. This is because we cannot test the ts state.
 tr.Processes.Default.StartBefore(ts, ready=10)
 ts.StartAfter(*ps)
 server.StartAfter(*ps)

--- a/tests/gold_tests/headers/domain-blacklist-30x.test.py
+++ b/tests/gold_tests/headers/domain-blacklist-30x.test.py
@@ -16,7 +16,7 @@ Tests 30x responses are returned for matching domains
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import sys
 import os
 
 Test.Summary = '''
@@ -58,11 +58,16 @@ set-redirect {0} "%<cque>"
 Test.Setup.Copy(os.path.join(os.pardir, os.pardir, 'tools', 'tcp_client.py'))
 Test.Setup.Copy('data')
 
+
+# This sets up a reasonable fallback in the event the absolute path to this interpreter cannot be determined
+executable = sys.executable if sys.executable else 'python3'
+
+
 redirect301tr = Test.AddTestRun("Test domain {0}".format(REDIRECT_301_HOST))
 redirect301tr.Processes.Default.StartBefore(Test.Processes.ts)
 redirect301tr.StillRunningAfter = ts
-redirect301tr.Processes.Default.Command = "python tcp_client.py 127.0.0.1 {0} {1} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
-    format(ts.Variables.port, 'data/{0}_get.txt'.format(REDIRECT_301_HOST))
+redirect301tr.Processes.Default.Command = "{0} tcp_client.py 127.0.0.1 {1} {2} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
+    format(executable, ts.Variables.port, 'data/{0}_get.txt'.format(REDIRECT_301_HOST))
 redirect301tr.Processes.Default.TimeOut = 5  # seconds
 redirect301tr.Processes.Default.ReturnCode = 0
 redirect301tr.Processes.Default.Streams.stdout = "redirect301_get.gold"
@@ -70,8 +75,8 @@ redirect301tr.Processes.Default.Streams.stdout = "redirect301_get.gold"
 redirect302tr = Test.AddTestRun("Test domain {0}".format(REDIRECT_302_HOST))
 redirect302tr.StillRunningBefore = ts
 redirect302tr.StillRunningAfter = ts
-redirect302tr.Processes.Default.Command = "python tcp_client.py 127.0.0.1 {0} {1} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
-    format(ts.Variables.port, 'data/{0}_get.txt'.format(REDIRECT_302_HOST))
+redirect302tr.Processes.Default.Command = "{0} tcp_client.py 127.0.0.1 {1} {2} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
+    format(executable, ts.Variables.port, 'data/{0}_get.txt'.format(REDIRECT_302_HOST))
 redirect302tr.Processes.Default.TimeOut = 5  # seconds
 redirect302tr.Processes.Default.ReturnCode = 0
 redirect302tr.Processes.Default.Streams.stdout = "redirect302_get.gold"
@@ -80,8 +85,8 @@ redirect302tr.Processes.Default.Streams.stdout = "redirect302_get.gold"
 redirect307tr = Test.AddTestRun("Test domain {0}".format(REDIRECT_307_HOST))
 redirect302tr.StillRunningBefore = ts
 redirect307tr.StillRunningAfter = ts
-redirect307tr.Processes.Default.Command = "python tcp_client.py 127.0.0.1 {0} {1} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
-    format(ts.Variables.port, 'data/{0}_get.txt'.format(REDIRECT_307_HOST))
+redirect307tr.Processes.Default.Command = "{0} tcp_client.py 127.0.0.1 {1} {2} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
+    format(executable, ts.Variables.port, 'data/{0}_get.txt'.format(REDIRECT_307_HOST))
 redirect307tr.Processes.Default.TimeOut = 5  # seconds
 redirect307tr.Processes.Default.ReturnCode = 0
 redirect307tr.Processes.Default.Streams.stdout = "redirect307_get.gold"
@@ -89,8 +94,8 @@ redirect307tr.Processes.Default.Streams.stdout = "redirect307_get.gold"
 redirect308tr = Test.AddTestRun("Test domain {0}".format(REDIRECT_308_HOST))
 redirect308tr.StillRunningBefore = ts
 redirect308tr.StillRunningAfter = ts
-redirect308tr.Processes.Default.Command = "python tcp_client.py 127.0.0.1 {0} {1} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
-    format(ts.Variables.port, 'data/{0}_get.txt'.format(REDIRECT_308_HOST))
+redirect308tr.Processes.Default.Command = "{0} tcp_client.py 127.0.0.1 {1} {2} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
+    format(executable, ts.Variables.port, 'data/{0}_get.txt'.format(REDIRECT_308_HOST))
 redirect308tr.Processes.Default.TimeOut = 5  # seconds
 redirect308tr.Processes.Default.ReturnCode = 0
 redirect308tr.Processes.Default.Streams.stdout = "redirect308_get.gold"
@@ -98,8 +103,8 @@ redirect308tr.Processes.Default.Streams.stdout = "redirect308_get.gold"
 redirect0tr = Test.AddTestRun("Test domain {0}".format(REDIRECT_0_HOST))
 redirect0tr.StillRunningBefore = ts
 redirect0tr.StillRunningAfter = ts
-redirect0tr.Processes.Default.Command = "python tcp_client.py 127.0.0.1 {0} {1} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
-    format(ts.Variables.port, 'data/{0}_get.txt'.format(REDIRECT_0_HOST))
+redirect0tr.Processes.Default.Command = "{0} tcp_client.py 127.0.0.1 {1} {2} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
+    format(executable, ts.Variables.port, 'data/{0}_get.txt'.format(REDIRECT_0_HOST))
 redirect0tr.Processes.Default.TimeOut = 5  # seconds
 redirect0tr.Processes.Default.ReturnCode = 0
 redirect0tr.Processes.Default.Streams.stdout = "redirect0_get.gold"
@@ -107,8 +112,8 @@ redirect0tr.Processes.Default.Streams.stdout = "redirect0_get.gold"
 passthroughtr = Test.AddTestRun("Test domain {0}".format(PASSTHRU_HOST))
 passthroughtr.StillRunningBefore = ts
 passthroughtr.StillRunningAfter = ts
-passthroughtr.Processes.Default.Command = "python tcp_client.py 127.0.0.1 {0} {1} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
-    format(ts.Variables.port, 'data/{0}_get.txt'.format(PASSTHRU_HOST))
+passthroughtr.Processes.Default.Command = "{0} tcp_client.py 127.0.0.1 {1} {2} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
+    format(executable, ts.Variables.port, 'data/{0}_get.txt'.format(PASSTHRU_HOST))
 passthroughtr.Processes.Default.TimeOut = 5  # seconds
 passthroughtr.Processes.Default.ReturnCode = 0
 passthroughtr.Processes.Default.Streams.stdout = "passthrough_get.gold"

--- a/tests/gold_tests/headers/http408.test.py
+++ b/tests/gold_tests/headers/http408.test.py
@@ -1,5 +1,5 @@
 '''
-Test the 408 reponse header. 
+Test the 408 reponse header.
 '''
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
@@ -16,7 +16,7 @@ Test the 408 reponse header.
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import sys
 import os
 import subprocess
 
@@ -48,11 +48,14 @@ ts.Disk.records_config.update({
 Test.Setup.Copy(os.path.join(os.pardir, os.pardir, 'tools', 'tcp_client.py'))
 Test.Setup.Copy('data')
 
+# This sets up a reasonable fallback in the event the absolute path to this interpreter cannot be determined
+executable = sys.executable if sys.executable else 'python3'
+
 tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
-tr.Processes.Default.Command = 'python tcp_client.py 127.0.0.1 {0} {1} --delay-after-send {2}'\
-        .format(ts.Variables.port, 'data/{0}.txt'.format(HTTP_408_HOST), TIMEOUT + 2)
+tr.Processes.Default.Command = '{0} tcp_client.py 127.0.0.1 {1} {2} --delay-after-send {3}'\
+        .format(executable, ts.Variables.port, 'data/{0}.txt'.format(HTTP_408_HOST), TIMEOUT + 2)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.stdout = "http408.gold"

--- a/tests/gold_tests/logging/ccid_ctid.test.py
+++ b/tests/gold_tests/logging/ccid_ctid.test.py
@@ -15,7 +15,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import sys
 import os
 import subprocess
 
@@ -92,11 +92,15 @@ tr.Processes.Default.Command = 'curl "https://127.0.0.1:{0}" "https://127.0.0.1:
     ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 
+# This sets up a reasonable fallback in the event the absolute path to this interpreter cannot be determined
+executable = sys.executable if sys.executable else 'python3'
+
 # Delay to allow TS to flush report to disk, then validate generated log.
 #
 tr = Test.AddTestRun()
 tr.DelayStart = 10
-tr.Processes.Default.Command = 'python {0} < {1}'.format(
+tr.Processes.Default.Command = '{0} {1} < {2}'.format(
+    executable,
     os.path.join(Test.TestDirectory, 'ccid_ctid_observer.py'),
     os.path.join(ts.Variables.LOGDIR, 'test_ccid_ctid.log'))
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/x_remap.test.py
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/x_remap.test.py
@@ -14,6 +14,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import sys
+
 Test.Summary = '''
 Test xdebug plugin X-Remap header
 '''
@@ -52,12 +54,14 @@ tr.Processes.Default.Command = "cp {}/tcp_client.py {}/tcp_client.py".format(
     Test.Variables.AtsTestToolsDir, Test.RunDirectory)
 tr.Processes.Default.ReturnCode = 0
 
-def sendMsg(msgFile):
+# This sets up a reasonable fallback in the event the absolute path to this interpreter cannot be determined
+executable = sys.executable if sys.executable else 'python3'
 
+def sendMsg(msgFile):
     tr = Test.AddTestRun()
     tr.Processes.Default.Command = (
-        "( python {}/tcp_client.py 127.0.0.1 {} {}/{}.in".format(
-            Test.RunDirectory, ts.Variables.port, Test.TestDirectory, msgFile) +
+        "( {} {}/tcp_client.py 127.0.0.1 {} {}/{}.in".format(
+            executable, Test.RunDirectory, ts.Variables.port, Test.TestDirectory, msgFile) +
         " ; echo '======' ) | sed 's/:{}/:SERVER_PORT/' >>  {}/out.log 2>&1 ".format(
             server.Variables.Port, Test.RunDirectory)
     )

--- a/tests/gold_tests/post_error/post_error.test.py
+++ b/tests/gold_tests/post_error/post_error.test.py
@@ -1,4 +1,5 @@
 '''
+Test post_err
 '''
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
@@ -15,7 +16,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import sys
 import os
 Test.Summary = '''
 Test post_error
@@ -31,9 +32,12 @@ Test.ContinueOnFail = True
 tr=Test.Build(target='post_server',sources=['post_server.c'])
 tr.Setup.Copy('post_server.c')
 
+# This sets up a reasonable fallback in the event the absolute path to this interpreter cannot be determined
+executable = sys.executable if sys.executable else 'python3'
+
 tr = Test.AddTestRun()
 tr.Setup.Copy('create_post_body.py')
-tr.Processes.Default.Command = "python create_post_body.py"
+tr.Processes.Default.Command = "%s create_post_body.py" % executable
 
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=False)

--- a/tests/gold_tests/redirect/redirect.test.py
+++ b/tests/gold_tests/redirect/redirect.test.py
@@ -16,7 +16,7 @@ Test redirection
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import sys
 import os
 Test.Summary = '''
 Test redirection
@@ -57,12 +57,15 @@ data_dirname = 'generated_test_data'
 data_path = os.path.join(Test.TestDirectory, data_dirname)
 os.makedirs(data_path, exist_ok=True)
 
+# This sets up a reasonable fallback in the event the absolute path to this interpreter cannot be determined
+executable = sys.executable if sys.executable else 'python3'
+
 # Here and below: spaces are deliberately omitted from the test run names because autest creates directories using these names.
 tr = Test.AddTestRun("FollowsRedirectWithAbsoluteLocationURI")
 # Here and below: because autest's Copy does not behave like standard cp, it's easiest to write all of our files out and copy last.
 with open(os.path.join(data_path, tr.Name), 'w') as f:
     f.write('GET /redirect HTTP/1.1\r\nHost: iwillredirect.test:{port}\r\n\r\n'.format(port=redirect_serv.Variables.Port))
-tr.Processes.Default.Command = "python tcp_client.py 127.0.0.1 {0} {1} | egrep -v '^(Date: |Server: ATS/)'".format(ts.Variables.port, os.path.join(data_dirname, tr.Name))
+tr.Processes.Default.Command = "{0} tcp_client.py 127.0.0.1 {1} {2} | egrep -v '^(Date: |Server: ATS/)'".format(executable, ts.Variables.port, os.path.join(data_dirname, tr.Name))
 tr.Processes.Default.StartBefore(ts)
 tr.Processes.Default.StartBefore(redirect_serv)
 tr.Processes.Default.StartBefore(dest_serv)
@@ -83,7 +86,7 @@ redirect_serv.addResponse("sessionfile.log", redirect_request_header, redirect_r
 tr = Test.AddTestRun("FollowsRedirectWithRelativeLocationURI")
 with open(os.path.join(data_path, tr.Name), 'w') as f:
     f.write('GET /redirect-relative-path HTTP/1.1\r\nHost: iwillredirect.test:{port}\r\n\r\n'.format(port=redirect_serv.Variables.Port))
-tr.Processes.Default.Command = "python tcp_client.py 127.0.0.1 {0} {1} | egrep -v '^(Date: |Server: ATS/)'".format(ts.Variables.port, os.path.join(data_dirname, tr.Name))
+tr.Processes.Default.Command = "{0} tcp_client.py 127.0.0.1 {1} {2} | egrep -v '^(Date: |Server: ATS/)'".format(executable, ts.Variables.port, os.path.join(data_dirname, tr.Name))
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = redirect_serv
 tr.StillRunningAfter = dest_serv
@@ -100,7 +103,7 @@ redirect_serv.addResponse("sessionfile.log", redirect_request_header, redirect_r
 tr = Test.AddTestRun("FollowsRedirectWithRelativeLocationURIMissingLeadingSlash")
 with open(os.path.join(data_path, tr.Name), 'w') as f:
     f.write('GET /redirect-relative-path-no-leading-slash HTTP/1.1\r\nHost: iwillredirect.test:{port}\r\n\r\n'.format(port=redirect_serv.Variables.Port))
-tr.Processes.Default.Command = "python tcp_client.py 127.0.0.1 {0} {1} | egrep -v '^(Date: |Server: ATS/)'".format(ts.Variables.port, os.path.join(data_dirname, tr.Name))
+tr.Processes.Default.Command = "{0} tcp_client.py 127.0.0.1 {1} {2} | egrep -v '^(Date: |Server: ATS/)'".format(executable, ts.Variables.port, os.path.join(data_dirname, tr.Name))
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = redirect_serv
 tr.StillRunningAfter = dest_serv

--- a/tests/gold_tests/remap/remap_https.test.py
+++ b/tests/gold_tests/remap/remap_https.test.py
@@ -28,7 +28,7 @@ Test.ContinueOnFail = True
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server = Test.MakeOriginServer("server")
-server2 = Test.MakeOriginServer("server2", ssl=True)
+server2 = Test.MakeOriginServer("server2", use_ssl=True)
 
 #**testname is required**
 testName = ""

--- a/tests/gold_tests/slow_post/slow_post.test.py
+++ b/tests/gold_tests/slow_post/slow_post.test.py
@@ -15,8 +15,12 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import sys
 import os
+
+
+# This sets up a reasonable fallback in the event the absolute path to this interpreter cannot be determined
+executable = sys.executable if sys.executable else 'python3'
 
 
 class SlowPostAttack:
@@ -60,7 +64,7 @@ class SlowPostAttack:
 
     def run(self):
         tr = Test.AddTestRun()
-        tr.Processes.Default.Command = 'python3 {0} -p {1} -c {2}'.format(
+        tr.Processes.Default.Command = '{0} {1} -p {2} -c {3}'.format( executable,
             self._slow_post_client, self._ts.Variables.port, self._origin_max_connections)
         tr.Processes.Default.ReturnCode = 0
         tr.Processes.Default.StartBefore(self._server)

--- a/tests/gold_tests/thread_config/thread_100_0.test.py
+++ b/tests/gold_tests/thread_config/thread_100_0.test.py
@@ -15,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
 import sys
 
 
@@ -63,6 +62,9 @@ tr.Processes.Default.Streams.stderr = 'gold/http_200.gold'
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 
+# This sets up a reasonable fallback in the event the absolute path to this interpreter cannot be determined
+executable = sys.executable if sys.executable else 'python3'
+
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 check_threads.py -t {0} -e {1} -a {2}'.format(ts.Env['TS_ROOT'], 100, 0)
+tr.Processes.Default.Command = '{0} check_threads.py -t {1} -e {2} -a {3}'.format(executable, ts.Env['TS_ROOT'], 100, 0)
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/thread_config/thread_100_1.test.py
+++ b/tests/gold_tests/thread_config/thread_100_1.test.py
@@ -64,6 +64,9 @@ tr.Processes.Default.Streams.stderr = 'gold/http_200.gold'
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 
+# This sets up a reasonable fallback in the event the absolute path to this interpreter cannot be determined
+executable = sys.executable if sys.executable else 'python3'
+
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 check_threads.py -t {0} -e {1} -a {2}'.format(ts.Env['TS_ROOT'], 100, 1)
+tr.Processes.Default.Command = '{0} check_threads.py -t {1} -e {2} -a {3}'.format(executable, ts.Env['TS_ROOT'], 100, 1)
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/thread_config/thread_100_10.test.py
+++ b/tests/gold_tests/thread_config/thread_100_10.test.py
@@ -63,6 +63,9 @@ tr.Processes.Default.Streams.stderr = 'gold/http_200.gold'
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 
+# This sets up a reasonable fallback in the event the absolute path to this interpreter cannot be determined
+executable = sys.executable if sys.executable else 'python3'
+
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 check_threads.py -t {0} -e {1} -a {2}'.format(ts.Env['TS_ROOT'], 100, 10)
+tr.Processes.Default.Command = '{0} check_threads.py -t {1} -e {2} -a {3}'.format(executable, ts.Env['TS_ROOT'], 100, 10)
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/thread_config/thread_1_0.test.py
+++ b/tests/gold_tests/thread_config/thread_1_0.test.py
@@ -63,6 +63,9 @@ tr.Processes.Default.Streams.stderr = 'gold/http_200.gold'
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 
+# This sets up a reasonable fallback in the event the absolute path to this interpreter cannot be determined
+executable = sys.executable if sys.executable else 'python3'
+
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 check_threads.py -t {0} -e {1} -a {2}'.format(ts.Env['TS_ROOT'], 1, 0)
+tr.Processes.Default.Command = '{0} check_threads.py -t {1} -e {2} -a {3}'.format(executable, ts.Env['TS_ROOT'], 1, 0)
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/thread_config/thread_1_1.test.py
+++ b/tests/gold_tests/thread_config/thread_1_1.test.py
@@ -63,6 +63,9 @@ tr.Processes.Default.Streams.stderr = 'gold/http_200.gold'
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 
+# This sets up a reasonable fallback in the event the absolute path to this interpreter cannot be determined
+executable = sys.executable if sys.executable else 'python3'
+
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 check_threads.py -t {0} -e {1} -a {2}'.format(ts.Env['TS_ROOT'], 1, 1)
+tr.Processes.Default.Command = '{0} check_threads.py -t {1} -e {2} -a {3}'.format(executable, ts.Env['TS_ROOT'], 1, 1)
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/thread_config/thread_1_10.test.py
+++ b/tests/gold_tests/thread_config/thread_1_10.test.py
@@ -63,6 +63,9 @@ tr.Processes.Default.Streams.stderr = 'gold/http_200.gold'
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 
+# This sets up a reasonable fallback in the event the absolute path to this interpreter cannot be determined
+executable = sys.executable if sys.executable else 'python3'
+
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 check_threads.py -t {0} -e {1} -a {2}'.format(ts.Env['TS_ROOT'], 1, 10)
+tr.Processes.Default.Command = '{0} check_threads.py -t {1} -e {2} -a {3}'.format(executable, ts.Env['TS_ROOT'], 1, 10)
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/thread_config/thread_2_0.test.py
+++ b/tests/gold_tests/thread_config/thread_2_0.test.py
@@ -63,6 +63,9 @@ tr.Processes.Default.Streams.stderr = 'gold/http_200.gold'
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 
+# This sets up a reasonable fallback in the event the absolute path to this interpreter cannot be determined
+executable = sys.executable if sys.executable else 'python3'
+
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 check_threads.py -t {0} -e {1} -a {2}'.format(ts.Env['TS_ROOT'], 2, 0)
+tr.Processes.Default.Command = '{0} check_threads.py -t {1} -e {2} -a {3}'.format(executable, ts.Env['TS_ROOT'], 2, 0)
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/thread_config/thread_2_1.test.py
+++ b/tests/gold_tests/thread_config/thread_2_1.test.py
@@ -63,6 +63,9 @@ tr.Processes.Default.Streams.stderr = 'gold/http_200.gold'
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 
+# This sets up a reasonable fallback in the event the absolute path to this interpreter cannot be determined
+executable = sys.executable if sys.executable else 'python3'
+
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 check_threads.py -t {0} -e {1} -a {2}'.format(ts.Env['TS_ROOT'], 2, 1)
+tr.Processes.Default.Command = '{0} check_threads.py -t {1} -e {2} -a {3}'.format(executable, ts.Env['TS_ROOT'], 2, 1)
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/thread_config/thread_2_10.test.py
+++ b/tests/gold_tests/thread_config/thread_2_10.test.py
@@ -63,6 +63,9 @@ tr.Processes.Default.Streams.stderr = 'gold/http_200.gold'
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 
+# This sets up a reasonable fallback in the event the absolute path to this interpreter cannot be determined
+executable = sys.executable if sys.executable else 'python3'
+
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 check_threads.py -t {0} -e {1} -a {2}'.format(ts.Env['TS_ROOT'], 2, 10)
+tr.Processes.Default.Command = '{0} check_threads.py -t {1} -e {2} -a {3}'.format(executable, ts.Env['TS_ROOT'], 2, 10)
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/thread_config/thread_32_0.test.py
+++ b/tests/gold_tests/thread_config/thread_32_0.test.py
@@ -63,6 +63,9 @@ tr.Processes.Default.Streams.stderr = 'gold/http_200.gold'
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 
+# This sets up a reasonable fallback in the event the absolute path to this interpreter cannot be determined
+executable = sys.executable if sys.executable else 'python3'
+
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 check_threads.py -t {0} -e {1} -a {2}'.format(ts.Env['TS_ROOT'], 32, 0)
+tr.Processes.Default.Command = '{0} check_threads.py -t {1} -e {2} -a {3}'.format(executable, ts.Env['TS_ROOT'], 32, 0)
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/thread_config/thread_32_1.test.py
+++ b/tests/gold_tests/thread_config/thread_32_1.test.py
@@ -63,6 +63,9 @@ tr.Processes.Default.Streams.stderr = 'gold/http_200.gold'
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 
+# This sets up a reasonable fallback in the event the absolute path to this interpreter cannot be determined
+executable = sys.executable if sys.executable else 'python3'
+
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 check_threads.py -t {0} -e {1} -a {2}'.format(ts.Env['TS_ROOT'], 32, 1)
+tr.Processes.Default.Command = '{0} check_threads.py -t {1} -e {2} -a {3}'.format(executable, ts.Env['TS_ROOT'], 32, 1)
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/thread_config/thread_32_10.test.py
+++ b/tests/gold_tests/thread_config/thread_32_10.test.py
@@ -63,6 +63,9 @@ tr.Processes.Default.Streams.stderr = 'gold/http_200.gold'
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 
+# This sets up a reasonable fallback in the event the absolute path to this interpreter cannot be determined
+executable = sys.executable if sys.executable else 'python3'
+
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 check_threads.py -t {0} -e {1} -a {2}'.format(ts.Env['TS_ROOT'], 32, 10)
+tr.Processes.Default.Command = '{0} check_threads.py -t {1} -e {2} -a {3}'.format(executable, ts.Env['TS_ROOT'], 32, 10)
 tr.Processes.Default.ReturnCode = 0


### PR DESCRIPTION
I changed a bunch of subprocess that call `python` or `python3` to call `sys.executable` instead. I also added a little bit of type hinting in `autest-site/`.