### PR TITLE
Fix off-by-one access in header_rewrite config parser

### DIFF
--- a/plugins/header_rewrite/header_rewrite.cc
+++ b/plugins/header_rewrite/header_rewrite.cc
@@ -171,7 +171,7 @@ RulesConfig::parse_config(const std::string &fname, TSHttpHookID default_hook)
       line.erase(0, 1);
     }
 
-    while (std::isspace(line[line.length() - 1])) {
+    while (line.length() > 0 && std::isspace(line[line.length() - 1])) {
       line.erase(line.length() - 1, 1);
     }
 


### PR DESCRIPTION
If the line got empty in the previous block, this block accesses `line[-1]`.

This should be backported to both 8.0.x and 7.1.x.