### PR TITLE
Set LDFLAGS when building with jemalloc

### DIFF
--- a/build/jemalloc.m4
+++ b/build/jemalloc.m4
@@ -56,6 +56,7 @@ if test "$enable_jemalloc" != "no"; then
   if test "$jemalloc_base_dir" != "/usr"; then
     TS_ADDTO(CPPFLAGS, [-I${jemalloc_include}])
     TS_ADDTO(LDFLAGS, [-L${jemalloc_ldflags}])
+    TS_ADDTO(LDFLAGS, [-Wl,--add-needed -L${jemalloc_base_dir}/lib -Wl,-rpath,${jemalloc_base_dir}/lib -Wl,--no-as-needed])
     TS_ADDTO_RPATH(${jemalloc_ldflags})
   fi
   # On Darwin, jemalloc symbols are prefixed with je_. Search for that first, then fall back

--- a/mgmt/utils/Makefile.am
+++ b/mgmt/utils/Makefile.am
@@ -56,7 +56,6 @@ libutils_p_la_SOURCES = \
 	MgmtProcessCleanup.cc
 
 test_marshall_LDFLAGS = \
-	-static-libstdc++ \
 	@AM_LDFLAGS@ \
 	@OPENSSL_LDFLAGS@
 


### PR DESCRIPTION
Revert #3789 which is causing some problems, and set the LDFLAGS such that when building with jemalloc, things will be linked correctly.