### PR TITLE
Fixed coredump with origin throttling

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -4637,7 +4637,7 @@ void
 HttpSM::send_origin_throttled_response()
 {
   t_state.current.attempts = t_state.txn_conf->connect_attempts_max_retries;
-  // t_state.current.state = HttpTransact::CONNECTION_ERROR;
+  t_state.current.state    = HttpTransact::CONNECTION_ERROR;
   call_transact_and_set_next_state(HttpTransact::HandleResponse);
 }
 


### PR DESCRIPTION
This was broke by: 4e6237562 Remove Congestion Control Feature