### PR TITLE
Update runroot to use yaml-cpp library

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -23,6 +23,7 @@
                 "${workspaceFolder}/lib/cppapi/include",
                 "${workspaceFolder}/lib/records",
                 "${workspaceFolder}/lib/ts",
+                "${workspaceFolder}/lib/yamlcpp/include",
                 "${workspaceFolder}/mgmt",
                 "${workspaceFolder}/mgmt/api",
                 "${workspaceFolder}/mgmt/api/include",

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -16,7 +16,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-SUBDIRS = ts records . tsconfig cppapi
+SUBDIRS = . ts records tsconfig cppapi
 
 if BUILD_PERL_LIB
 SUBDIRS += perl

--- a/lib/ts/Makefile.am
+++ b/lib/ts/Makefile.am
@@ -35,9 +35,10 @@ AM_CPPFLAGS += \
 	$(iocore_include_dirs) \
 	-I$(abs_top_srcdir)/lib \
 	-I$(abs_top_srcdir)/lib/records \
-	$(TS_INCLUDES)
+	$(TS_INCLUDES) \
+	@YAMLCPP_INCLUDES@
 
-libtsutil_la_LDFLAGS = -no-undefined -version-info @TS_LIBTOOL_VERSION@
+libtsutil_la_LDFLAGS = -no-undefined -version-info @TS_LIBTOOL_VERSION@ @YAMLCPP_LDFLAGS@
 libtsutil_la_LIBADD = \
 	@HWLOC_LIBS@ \
 	@LIBOBJS@ \
@@ -46,6 +47,7 @@ libtsutil_la_LIBADD = \
 	@LIBTCL@ \
 	@LIBRESOLV@ \
 	@LIBCAP@ \
+	@YAMLCPP_LIBS@ \
 	-lc
 
 libtsutil_la_SOURCES = \

--- a/src/traffic_layout/Makefile.inc
+++ b/src/traffic_layout/Makefile.inc
@@ -24,11 +24,13 @@ traffic_layout_traffic_layout_CPPFLAGS = \
     -I$(abs_top_srcdir)/lib/records \
     -I$(abs_top_srcdir)/mgmt \
     -I$(abs_top_srcdir)/mgmt/utils \
+    @YAMLCPP_INCLUDES@ \
     $(TS_INCLUDES)
 
 traffic_layout_traffic_layout_LDFLAGS =	\
     $(AM_LDFLAGS) \
-    @OPENSSL_LDFLAGS@
+    @OPENSSL_LDFLAGS@ \
+    @YAMLCPP_LDFLAGS@
 
 traffic_layout_traffic_layout_SOURCES = \
 	traffic_layout/traffic_layout.cc \
@@ -45,4 +47,4 @@ traffic_layout_traffic_layout_LDADD = \
 	$(top_builddir)/proxy/shared/libUglyLogStubs.a \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/lib/ts/libtsutil.la \
-	@LIBTCL@ @HWLOC_LIBS@
+	@LIBTCL@ @HWLOC_LIBS@ @YAMLCPP_LIBS@

--- a/src/traffic_layout/engine.cc
+++ b/src/traffic_layout/engine.cc
@@ -40,6 +40,7 @@
 #include <iostream>
 #include <ftw.h>
 #include <pwd.h>
+#include <yaml-cpp/yaml.h>
 
 // for nftw check_directory
 std::string directory_check = "";
@@ -402,15 +403,18 @@ RunrootEngine::create_runroot()
   // create new root & copy from original to new runroot. then fill in the map
   copy_runroot(original_root, ts_runroot);
 
-  // create and emit to yaml file the key value pairs of path
-  std::ofstream yamlfile;
-  std::string yaml_path = Layout::relative_to(ts_runroot, "runroot_path.yml");
-  yamlfile.open(yaml_path);
-
+  YAML::Emitter yamlfile;
+  // emit key value pairs to the yaml file
+  yamlfile << YAML::BeginMap;
   for (uint i = 0; i < dir_vector.size(); i++) {
-    // out put key value pairs of path
-    yamlfile << dir_vector[i] << ": " << path_map[dir_vector[i]] << std::endl;
+    yamlfile << YAML::Key << dir_vector[i];
+    yamlfile << YAML::Value << path_map[dir_vector[i]];
   }
+  yamlfile << YAML::EndMap;
+
+  // create the file
+  std::ofstream f(Layout::relative_to(ts_runroot, "runroot_path.yml"));
+  f << yamlfile.c_str();
 }
 
 // copy the stuff from original_root to ts_runroot

--- a/tests/gold_tests/runroot/runroot_error.test.py
+++ b/tests/gold_tests/runroot/runroot_error.test.py
@@ -62,9 +62,9 @@ f.Exists = False
 path_invalid = os.path.join(ts_root, "tmp")
 tr = Test.AddTestRun("remove invalid runroot")
 tr.Processes.Default.Command = "$ATS_BIN/traffic_layout remove --path " + path_invalid
-tr.Processes.Default.Streams.All = Testers.ContainsExpression("Bad path", "init incorrect usage")
+tr.Processes.Default.Streams.All = Testers.ContainsExpression("Unable to read runroot_path.yml", "remove incorrect usage")
 
 # verify invalid runroot
 tr = Test.AddTestRun("verify invalid runroot")
 tr.Processes.Default.Command = "$ATS_BIN/traffic_layout verify --path " + path_invalid
-tr.Processes.Default.Streams.All = Testers.ContainsExpression("Bad path", "init incorrect usage")
+tr.Processes.Default.Streams.All = Testers.ContainsExpression("Unable to read runroot_path.yml", "verify incorrect usage")


### PR DESCRIPTION
This PR update the runroot to use the newly introduced yaml-cpp lib.
The library path is also included in ``.vscode/c_cpp_properties.json``