### PR TITLE
Make atscppapi::RegisterGlobalPlugin return a value.

### DIFF
--- a/example/cppapi/async_http_fetch/AsyncHttpFetch.cc
+++ b/example/cppapi/async_http_fetch/AsyncHttpFetch.cc
@@ -218,6 +218,8 @@ void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
   TS_DEBUG(TAG, "Loaded async_http_fetch_example plugin");
-  RegisterGlobalPlugin("CPP_Example_AsyncHttpFetch", "apache", "dev@trafficserver.apache.org");
+  if (!RegisterGlobalPlugin("CPP_Example_AsyncHttpFetch", "apache", "dev@trafficserver.apache.org")) {
+    return;
+  }
   plugin = new GlobalHookPlugin();
 }

--- a/example/cppapi/async_http_fetch_streaming/AsyncHttpFetchStreaming.cc
+++ b/example/cppapi/async_http_fetch_streaming/AsyncHttpFetchStreaming.cc
@@ -79,7 +79,9 @@ public:
 void
 TSPluginInit(int /* argc ATS_UNUSED */, const char * /* argv ATS_UNUSED */ [])
 {
-  RegisterGlobalPlugin("CPP_Example_AsyncHttpFetchStreaming", "apache", "dev@trafficserver.apache.org");
+  if (!RegisterGlobalPlugin("CPP_Example_AsyncHttpFetchStreaming", "apache", "dev@trafficserver.apache.org")) {
+    return;
+  }
   plugin = new InterceptInstaller();
 }
 

--- a/example/cppapi/async_timer/AsyncTimer.cc
+++ b/example/cppapi/async_timer/AsyncTimer.cc
@@ -60,7 +60,9 @@ private:
 void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
-  RegisterGlobalPlugin("CPP_Example_AsyncTimer", "apache", "dev@trafficserver.apache.org");
+  if (!RegisterGlobalPlugin("CPP_Example_AsyncTimer", "apache", "dev@trafficserver.apache.org")) {
+    return;
+  }
   int period_in_ms           = 1000;
   TimerEventReceiver *timer1 = new TimerEventReceiver(AsyncTimer::TYPE_PERIODIC, period_in_ms);
   TS_DEBUG(TAG, "Created periodic timer %p with initial period 0, regular period %d and max instances 0", timer1, period_in_ms);

--- a/example/cppapi/boom/boom.cc
+++ b/example/cppapi/boom/boom.cc
@@ -433,7 +433,9 @@ BoomGlobalPlugin::handleReadResponseHeaders(Transaction &transaction)
 void
 TSPluginInit(int argc, const char *argv[])
 {
-  RegisterGlobalPlugin("CPP_Example_Boom", "apache", "dev@trafficserver.apache.org");
+  if (!RegisterGlobalPlugin("CPP_Example_Boom", "apache", "dev@trafficserver.apache.org")) {
+    return;
+  }
   boom_counter.init(BOOM_COUNTER);
   BoomResponseRegistry *pregistry = new BoomResponseRegistry();
 

--- a/example/cppapi/clientredirect/ClientRedirect.cc
+++ b/example/cppapi/clientredirect/ClientRedirect.cc
@@ -80,6 +80,8 @@ public:
 void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
-  RegisterGlobalPlugin("CPP_Example_ClientDirect", "apache", "dev@trafficserver.apache.org");
+  if (!RegisterGlobalPlugin("CPP_Example_ClientDirect", "apache", "dev@trafficserver.apache.org")) {
+    return;
+  }
   plugin = new ClientRedirectGlobalPlugin();
 }

--- a/example/cppapi/clientrequest/ClientRequest.cc
+++ b/example/cppapi/clientrequest/ClientRequest.cc
@@ -137,6 +137,8 @@ public:
 void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
-  RegisterGlobalPlugin("CPP_Example_ClientRequest", "apache", "dev@trafficserver.apache.org");
+  if (!RegisterGlobalPlugin("CPP_Example_ClientRequest", "apache", "dev@trafficserver.apache.org")) {
+    return;
+  }
   plugin = new GlobalHookPlugin();
 }

--- a/example/cppapi/customresponse/CustomResponse.cc
+++ b/example/cppapi/customresponse/CustomResponse.cc
@@ -88,6 +88,8 @@ public:
 void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
-  RegisterGlobalPlugin("CPP_Example_CustomResponse", "apache", "dev@trafficserver.apache.org");
+  if (!RegisterGlobalPlugin("CPP_Example_CustomResponse", "apache", "dev@trafficserver.apache.org")) {
+    return;
+  }
   plugin = new ClientRedirectGlobalPlugin();
 }

--- a/example/cppapi/delay_transformation_plugin/DelayTransformationPlugin.cc
+++ b/example/cppapi/delay_transformation_plugin/DelayTransformationPlugin.cc
@@ -116,7 +116,9 @@ public:
 void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
-  RegisterGlobalPlugin("CPP_Example_DelayTransformation", "apache", "dev@trafficserver.apache.org");
+  if (!RegisterGlobalPlugin("CPP_Example_DelayTransformation", "apache", "dev@trafficserver.apache.org")) {
+    return;
+  }
   TS_DEBUG(TAG, "TSPluginInit");
   plugin = new GlobalHookPlugin();
 }

--- a/example/cppapi/globalhook/GlobalHookPlugin.cc
+++ b/example/cppapi/globalhook/GlobalHookPlugin.cc
@@ -44,7 +44,9 @@ public:
 void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
-  RegisterGlobalPlugin("CPP_Example_GlobalHookPplugin", "apache", "dev@trafficserver.apache.org");
+  if (!RegisterGlobalPlugin("CPP_Example_GlobalHookPplugin", "apache", "dev@trafficserver.apache.org")) {
+    return;
+  }
   std::cout << "Hello from " << argv[0] << std::endl;
   plugin = new GlobalHookPlugin();
 }

--- a/example/cppapi/gzip_transformation/GzipTransformationPlugin.cc
+++ b/example/cppapi/gzip_transformation/GzipTransformationPlugin.cc
@@ -198,7 +198,9 @@ public:
 void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
-  RegisterGlobalPlugin("CPP_Example_GzipTransformation", "apache", "dev@trafficserver.apache.org");
+  if (!RegisterGlobalPlugin("CPP_Example_GzipTransformation", "apache", "dev@trafficserver.apache.org")) {
+    return;
+  }
   TS_DEBUG(TAG, "TSPluginInit");
   plugin = new GlobalHookPlugin();
 }

--- a/example/cppapi/helloworld/HelloWorldPlugin.cc
+++ b/example/cppapi/helloworld/HelloWorldPlugin.cc
@@ -35,7 +35,9 @@ public:
 void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
+  if (!atscppapi::RegisterGlobalPlugin("CPP_Example_HelloWorld", "apache", "dev@trafficserver.apache.org")) {
+    return;
+  }
   std::cout << "Hello from " << argv[0] << std::endl;
-  atscppapi::RegisterGlobalPlugin("CPP_Example_HelloWorld", "apache", "dev@trafficserver.apache.org");
   plugin = new HelloWorldPlugin();
 }

--- a/example/cppapi/intercept/intercept.cc
+++ b/example/cppapi/intercept/intercept.cc
@@ -60,7 +60,9 @@ public:
 void
 TSPluginInit(int /* argc ATS_UNUSED */, const char * /* argv ATS_UNUSED */ [])
 {
-  RegisterGlobalPlugin("CPP_Example_Intercept", "apache", "dev@trafficserver.apache.org");
+  if (!RegisterGlobalPlugin("CPP_Example_Intercept", "apache", "dev@trafficserver.apache.org")) {
+    return;
+  }
   plugin = new InterceptInstaller();
 }
 

--- a/example/cppapi/internal_transaction_handling/InternalTransactionHandling.cc
+++ b/example/cppapi/internal_transaction_handling/InternalTransactionHandling.cc
@@ -76,7 +76,9 @@ public:
 void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
-  RegisterGlobalPlugin("CPP_Example_InternalTransactionHandling", "apache", "dev@trafficserver.apache.org");
+  if (!RegisterGlobalPlugin("CPP_Example_InternalTransactionHandling", "apache", "dev@trafficserver.apache.org")) {
+    return;
+  }
   TS_DEBUG(TAG, "Loaded async_http_fetch_example plugin");
   plugin  = new AllTransactionsGlobalPlugin();
   plugin2 = new NoInternalTransactionsGlobalPlugin();

--- a/example/cppapi/logger_example/LoggerExample.cc
+++ b/example/cppapi/logger_example/LoggerExample.cc
@@ -103,7 +103,9 @@ private:
 void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
-  RegisterGlobalPlugin("CPP_Example_Logger", "apache", "dev@trafficserver.apache.org");
+  if (!RegisterGlobalPlugin("CPP_Example_Logger", "apache", "dev@trafficserver.apache.org")) {
+    return;
+  }
   // Create a new logger
   // This will create a log file with the name logger_example.log (since we left off
   //    the extension it will automatically add .log)

--- a/example/cppapi/multiple_transaction_hooks/MultipleTransactionHookPlugins.cc
+++ b/example/cppapi/multiple_transaction_hooks/MultipleTransactionHookPlugins.cc
@@ -105,6 +105,8 @@ public:
 void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
-  RegisterGlobalPlugin("CPP_Example_MultipleTransactionHook", "apache", "dev@trafficserver.apache.org");
+  if (!RegisterGlobalPlugin("CPP_Example_MultipleTransactionHook", "apache", "dev@trafficserver.apache.org")) {
+    return;
+  }
   plugin = new GlobalHookPlugin();
 }

--- a/example/cppapi/null_transformation_plugin/NullTransformationPlugin.cc
+++ b/example/cppapi/null_transformation_plugin/NullTransformationPlugin.cc
@@ -100,7 +100,9 @@ public:
 void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
-  RegisterGlobalPlugin("CPP_Example_NullTransformation", "apache", "dev@trafficserver.apache.org");
+  if (!RegisterGlobalPlugin("CPP_Example_NullTransformation", "apache", "dev@trafficserver.apache.org")) {
+    return;
+  }
   TS_DEBUG(TAG, "TSPluginInit");
   plugin = new GlobalHookPlugin();
 }

--- a/example/cppapi/post_buffer/PostBuffer.cc
+++ b/example/cppapi/post_buffer/PostBuffer.cc
@@ -84,6 +84,8 @@ public:
 void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
-  RegisterGlobalPlugin("CPP_Example_PostBuffer", "apache", "dev@trafficserver.apache.org");
+  if (!RegisterGlobalPlugin("CPP_Example_PostBuffer", "apache", "dev@trafficserver.apache.org")) {
+    return;
+  }
   plugin = new GlobalHookPlugin();
 }

--- a/example/cppapi/serverresponse/ServerResponse.cc
+++ b/example/cppapi/serverresponse/ServerResponse.cc
@@ -118,6 +118,8 @@ private:
 void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
-  RegisterGlobalPlugin("CPP_Example_ServerResponse", "apache", "dev@trafficserver.apache.org");
+  if (!RegisterGlobalPlugin("CPP_Example_ServerResponse", "apache", "dev@trafficserver.apache.org")) {
+    return;
+  }
   plugin = new ServerResponsePlugin();
 }

--- a/example/cppapi/stat_example/StatExample.cc
+++ b/example/cppapi/stat_example/StatExample.cc
@@ -68,7 +68,9 @@ public:
 void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
-  RegisterGlobalPlugin("CPP_Example_Stat", "apache", "dev@trafficserver.apache.org");
+  if (!RegisterGlobalPlugin("CPP_Example_Stat", "apache", "dev@trafficserver.apache.org")) {
+    return;
+  }
   TS_DEBUG(TAG, "Loaded stat_example plugin");
 
   // Since this stat is not persistent it will be initialized to 0.

--- a/example/cppapi/timeout_example/TimeoutExamplePlugin.cc
+++ b/example/cppapi/timeout_example/TimeoutExamplePlugin.cc
@@ -61,7 +61,9 @@ public:
 void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
-  RegisterGlobalPlugin("CPP_Example_Timeout", "apache", "dev@trafficserver.apache.org");
+  if (!RegisterGlobalPlugin("CPP_Example_Timeout", "apache", "dev@trafficserver.apache.org")) {
+    return;
+  }
   TS_DEBUG(TAG, "TSPluginInit");
   plugin = new TimeoutExamplePlugin();
 }

--- a/example/cppapi/transactionhook/TransactionHookPlugin.cc
+++ b/example/cppapi/transactionhook/TransactionHookPlugin.cc
@@ -69,6 +69,8 @@ public:
 void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
-  RegisterGlobalPlugin("CPP_Example_TransactionHook", "apache", "dev@trafficserver.apache.org");
+  if (!RegisterGlobalPlugin("CPP_Example_TransactionHook", "apache", "dev@trafficserver.apache.org")) {
+    return;
+  }
   plugin = new GlobalHookPlugin();
 }

--- a/example/cppapi/websocket/WebSocket.cc
+++ b/example/cppapi/websocket/WebSocket.cc
@@ -38,7 +38,9 @@ using namespace atscppapi;
 void
 TSPluginInit(int argc, const char *argv[])
 {
-  RegisterGlobalPlugin("CPP_Example_WebSocket", "apache", "dev@trafficserver.apache.org");
+  if (!RegisterGlobalPlugin("CPP_Example_WebSocket", "apache", "dev@trafficserver.apache.org")) {
+    return;
+  }
   plugin = new WebSocketInstaller(); // We keep a pointer to this so that clang-analyzer doesn't think it's a leak
 }
 

--- a/lib/cppapi/Plugin.cc
+++ b/lib/cppapi/Plugin.cc
@@ -28,14 +28,17 @@ const std::string atscppapi::HOOK_TYPE_STRINGS[] = {
   std::string("HOOK_READ_REQUEST_HEADERS"),           std::string("HOOK_READ_CACHE_HEADERS"),
   std::string("HOOK_CACHE_LOOKUP_COMPLETE"),          std::string("HOOK_SELECT_ALT")};
 
-void
+bool
 atscppapi::RegisterGlobalPlugin(const char *name, const char *vendor, const char *email)
 {
   TSPluginRegistrationInfo info;
   info.plugin_name   = name;
   info.vendor_name   = vendor;
   info.support_email = email;
-  if (TSPluginRegister(&info) != TS_SUCCESS) {
+
+  bool success = (TSPluginRegister(&info) == TS_SUCCESS);
+  if (!success) {
     TSError("[Plugin.cc] Plugin registration failed");
   }
+  return success;
 }

--- a/lib/cppapi/include/atscppapi/Plugin.h
+++ b/lib/cppapi/include/atscppapi/Plugin.h
@@ -162,11 +162,11 @@ protected:
 /**< Human readable strings for each HookType, you can access them as HOOK_TYPE_STRINGS[HOOK_OS_DNS] for example. */
 extern const std::string HOOK_TYPE_STRINGS[];
 
-void RegisterGlobalPlugin(const char *name, const char *vendor, const char *email);
-inline void
+bool RegisterGlobalPlugin(const char *name, const char *vendor, const char *email);
+inline bool
 RegisterGlobalPlugin(std::string const &name, std::string const &vendor, std::string const &email)
 {
-  RegisterGlobalPlugin(name.c_str(), vendor.c_str(), email.c_str());
+  return RegisterGlobalPlugin(name.c_str(), vendor.c_str(), email.c_str());
 }
 
 } // namespace atscppapi

--- a/plugins/experimental/server_push_preload/server_push_preload.cc
+++ b/plugins/experimental/server_push_preload/server_push_preload.cc
@@ -138,6 +138,8 @@ void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
   TSDebug(PLUGIN_NAME, "Init");
-  RegisterGlobalPlugin("ServerPushPreloadPlugin", PLUGIN_NAME, "dev@trafficserver.apache.org");
+  if (!RegisterGlobalPlugin("ServerPushPreloadPlugin", PLUGIN_NAME, "dev@trafficserver.apache.org")) {
+    return;
+  }
   plugin = new LinkServerPushPlugin();
 }

--- a/plugins/experimental/webp_transform/ImageTransform.cc
+++ b/plugins/experimental/webp_transform/ImageTransform.cc
@@ -99,7 +99,9 @@ public:
 void
 TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
 {
-  RegisterGlobalPlugin("CPP_Webp_Transform", "apache", "dev@trafficserver.apache.org");
+  if (!RegisterGlobalPlugin("CPP_Webp_Transform", "apache", "dev@trafficserver.apache.org")) {
+    return;
+  }
   InitializeMagick("");
   new GlobalHookPlugin();
 }


### PR DESCRIPTION
TSError doesn't abort the execution, so a plugin might fail to be
registered and TSPluginInit might continue execution.

With this change, atscppapi::RegisterGlobalPlugin returns a boolean that
a plugin can check to decide whether to abort or continue.

Signed-off-by: David Calavera <david.calavera@gmail.com>