### PR TITLE
Fix event loop metrics to gather only from ET_NET threads.

### DIFF
--- a/iocore/eventsystem/I_EventProcessor.h
+++ b/iocore/eventsystem/I_EventProcessor.h
@@ -373,6 +373,13 @@ public:
     return {all_dthreads, n_dthreads};
   }
 
+  active_threads_type
+  active_group_threads(int type) const
+  {
+    ThreadGroupDescriptor const &group{thread_group[type]};
+    return {group._thread, group._count};
+  }
+
 private:
   void initThreadState(EThread *);
 

--- a/iocore/eventsystem/UnixEventProcessor.cc
+++ b/iocore/eventsystem/UnixEventProcessor.cc
@@ -79,8 +79,8 @@ EventMetricStatSync(const char *, RecDataT, RecData *, RecRawStatBlock *rsb, int
   EThread::EventMetrics summary[EThread::N_EVENT_TIMESCALES];
 
   // scan the thread local values
-  for (int i = 0; i < eventProcessor.n_ethreads; ++i) {
-    eventProcessor.all_ethreads[i]->summarize_stats(summary);
+  for (EThread *t : eventProcessor.active_group_threads(ET_CALL)) {
+    t->summarize_stats(summary);
   }
 
   ink_mutex_acquire(&(rsb->mutex));


### PR DESCRIPTION
This has been causing us race condition problems in production, although only in certain install scenarios. The stat handling is started at the same time as the `ET_NET` threads so those are correctly initialized but not necessary other thread types. In general, though, the event loop metrics should not be including non `ET_NET` thread information because it will distort the data therefore the best fix is to limit the metrics to `ET_NET` only.