### PR TITLE
Fix method call on null object for background_fetch

### DIFF
--- a/plugins/background_fetch/background_fetch.cc
+++ b/plugins/background_fetch/background_fetch.cc
@@ -509,7 +509,7 @@ cont_handle_response(TSCont contp, TSEvent event, void *edata)
   } else {
     switch (event) {
     case TS_EVENT_HTTP_READ_RESPONSE_HDR:
-      if (config->getRules()->bgFetchAllowed(txnp)) {
+      if (config->bgFetchAllowed(txnp)) {
         TSMBuffer response;
         TSMLoc resp_hdr;
 

--- a/plugins/background_fetch/configs.h
+++ b/plugins/background_fetch/configs.h
@@ -70,6 +70,8 @@ public:
   // This parses and populates the BgFetchRule linked list (_rules).
   bool readConfig(const char *file_name);
 
+  bool bgFetchAllowed(TSHttpTxn txnp) const;
+
 private:
   ~BgFetchConfig()
   {

--- a/plugins/background_fetch/rules.h
+++ b/plugins/background_fetch/rules.h
@@ -58,8 +58,8 @@ public:
 
   // Main evaluation entry point.
   bool bgFetchAllowed(TSHttpTxn txnp) const;
+  bool check_field_configured(TSHttpTxn txnp) const;
 
-private:
   bool _exclude;
   const char *_field;
   const char *_value;


### PR DESCRIPTION
When run in remap mode, _rules is null (unless you specify a rules file which we do not).  This means we are calling a method on a null object.  glibc is ok with this, but when compiled against jemalloc this fails.

Moving the logic into the config object to avoid the null dereference.