### PR TITLE
Fix and Update build ordering of lib

### DIFF
--- a/ci/jenkins/bin/clang-analyzer.sh
+++ b/ci/jenkins/bin/clang-analyzer.sh
@@ -75,6 +75,12 @@ ${LLVM_BASE}/bin/scan-build ./configure ${configure} \
     CXXFLAGS="-stdlib=libc++ -I${LLVM_BASE}/include/c++/v1 -std=c++17" \
     LDFLAGS="-L${LLVM_BASE}/lib64 -Wl,-rpath=${LLVM_BASE}/lib64"
 
+# Since we don't want the analyzer to look at yamlcpp, build it first
+# without scan-build. The subsequent make will then skip it.
+# the all-local can be taken out and lib changed to lib/yamlcpp 
+# by making yaml cpp a SUBDIRS in lib/Makefile.am.
+${ATS_MAKE} -j $NPROCS -C lib all-local V=1 Q=
+
 ${LLVM_BASE}/bin/scan-build ${checkers} ${options} -o ${output} \
     --html-title="clang-analyzer: ${ATS_BRANCH}${github_pr}" \
     ${ATS_MAKE} -j $NPROCS V=1 Q=

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -16,7 +16,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-SUBDIRS = ts records . tsconfig cppapi
+SUBDIRS = . ts records tsconfig cppapi
 
 if BUILD_PERL_LIB
 SUBDIRS += perl
@@ -26,6 +26,7 @@ if BUILD_WCCP
 SUBDIRS += wccp
 endif
 
+# to prevent Clang Analyzer warning
 LOCAL =
 
 if BUILD_YAML_CPP


### PR DESCRIPTION
The yaml-cpp should be built before lib/ts. 
I have a PR requiring a dependency of yaml-cpp from lib/ts: https://github.com/apache/trafficserver/pull/3840

@randall @SolidWallOfCode 