### PR TITLE
Move %<pqsn> logic to %<shn> for 7.x

### DIFF
--- a/proxy/logging/LogAccessHttp.cc
+++ b/proxy/logging/LogAccessHttp.cc
@@ -1174,21 +1174,18 @@ LogAccessHttp::marshal_server_host_ip(char *buf)
 int
 LogAccessHttp::marshal_server_host_name(char *buf)
 {
-  const char *str = nullptr;
-  int padded_len  = INK_MIN_ALIGN;
-  int actual_len  = 0;
+  char *str = nullptr;
+  int len   = INK_MIN_ALIGN;
 
-  if (m_client_request) {
-    str = m_client_request->host_get(&actual_len);
-
-    if (str) {
-      padded_len = round_strlen(actual_len + 1); // +1 for trailing 0
-    }
+  if (m_http_sm->t_state.current.server) {
+    str = m_http_sm->t_state.current.server->name;
+    len = LogAccess::strlen(str);
   }
+
   if (buf) {
-    marshal_mem(buf, str, actual_len, padded_len);
+    marshal_str(buf, str, len);
   }
-  return padded_len;
+  return len;
 }
 
 /*-------------------------------------------------------------------------


### PR DESCRIPTION
Right now `%<pqsn>` seems to be logging what `%<shn>` is supposed to log according to the documentation. https://docs.trafficserver.apache.org/en/latest/admin-guide/logging/formatting.en.html

This PR duplicates `%<pqsn>` logic (`marshal_proxy_req_server_name`) in `%<shn>` (`marshal_server_host_name`) such that `%<shn>` will do its job properly.