### PR TITLE
background_fetch heap-buffer-overflow fix (7.1.x)

### DIFF
--- a/plugins/background_fetch/rules.cc
+++ b/plugins/background_fetch/rules.cc
@@ -23,6 +23,7 @@
 */
 
 #include <cstdlib>
+#include "ts/string_view.h"
 
 #include "configs.h"
 #include "rules.h"
@@ -131,7 +132,7 @@ BgFetchRule::check_field_configured(TSHttpTxn txnp) const
           TSDebug(PLUGIN_NAME, "invalid field");
         } else {
           TSDebug(PLUGIN_NAME, "comparing with %s", _value);
-          if (nullptr != strstr(val_str, _value)) {
+          if (ts::string_view::npos != ts::string_view(val_str, val_len).find(_value)) {
             hdr_found = true;
           }
         }


### PR DESCRIPTION
A separate fix to backport PR #3863 to `7.1.x` since `std::string_view`
is not available in `7.1.x`, using `ts::string_view` instead.