### PR TITLE
Fix heap use after free in DNSProcessor::getby()

### DIFF
--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -1200,7 +1200,7 @@ DNSEntry::mainEvent(int event, Event *e)
     } else {
       Debug("dns", "adding first to collapsing queue");
       dnsH->entries.enqueue(this);
-      write_dns(dnsH);
+      dnsProcessor.thread->schedule_imm(dnsH);
     }
     return EVENT_DONE;
   }


### PR DESCRIPTION
```
1225 Action *
1226 DNSProcessor::getby(const char *x, int len, int type, Continuation *cont, Options const &opt)
1227 {
1228   Debug("dns", "received query %s type = %d, timeout = %d", x, type, opt.timeout);
1229   if (type == T_SRV) {
1230     Debug("dns_srv", "DNSProcessor::getby attempting an SRV lookup for %s, timeout = %d", x, opt.timeout);
1231   }
1232   DNSEntry *e = dnsEntryAllocator.alloc();
1233   e->retries  = dns_retries;
1234   e->init(x, len, type, cont, opt);
1235   MUTEX_TRY_LOCK(lock, e->mutex, this_ethread());
1236   if (!lock.is_locked()) {
1237     thread->schedule_imm(e);
1238   } else {
1239     e->handleEvent(EVENT_IMMEDIATE, nullptr);    ---> The `e` may be freed.
1240   }
1241   return &e->action;
1242 }
```

There are 2 scenarios:

1. no dns server in resolv.conf or splitdns.config
2. get failed from _ink_res_mkquery()

