### PR TITLE
Clone the url object into the new heap

### DIFF
--- a/proxy/hdrs/HdrHeap.h
+++ b/proxy/hdrs/HdrHeap.h
@@ -476,6 +476,7 @@ HdrHeapSDKHandle::set(const HdrHeapSDKHandle *from)
   m_heap = from->m_heap;
 }
 
+HdrStrHeap *new_HdrStrHeap(int requested_size);
 inkcoreapi HdrHeap *new_HdrHeap(int size = HDR_HEAP_DEFAULT_SIZE);
 
 void hdr_heap_test();


### PR DESCRIPTION
This code makes calling TSHttpHdrUrlSet() more resilient.  If you look at how this is used in background_fetch.cc, the code calls TSHttpTxnPristineUrlGet() and then TSUrlClone() to make a copy of the URL in the heap associated with mbuf.  The TSHttpHdrUrlSet() is called against the mbuf.  So the new URL object is already in the right heap.  If you missed to call to TSUrlClone(), the new url object would still have been allocated against the old heap and be a dangling reference in the new request.

We have an internal plugin that did exactly that (omitted the TSUrlClone).  We have been running this plugin for quite a while and had not noticed any problems until we started testing our builds with openssl 1.1 and jemalloc.  I'm guessing moving from glibc to jemalloc caused this latent bug to become apparent.  We started seeing quite a few messages of the following in diags.log after running this build for around 12 hours.  

```
NOTE: OpenReadHead failed for cachekey 928FA61E : vector inconsistency - unmarshalled -1 expecting 4168 in 4240 (base=72, ver=24:0) - vector n=0 size=0first alt=-1412571411[alive]
```

After running with enable-debug and then adding a number of HdrHeap::sanity_check_strs(), we found that in some cases the URLImpl had strings that were not in the current heap.  If the original heap was freed or reused, this could cause corruption on writing to disk.  

We could have also fixed this by adding a call to TSUrlClone() in our plugin, but augmenting the core seemed like the more resilient solution.

Doing a quick review of the API, I do not see any other calls that take a TSMloc (with associated heap) as an input to set to a potentially different heap.