### PR TITLE
Only increment currently_open if socket connects

### DIFF
--- a/iocore/net/UnixNetProcessor.cc
+++ b/iocore/net/UnixNetProcessor.cc
@@ -219,7 +219,6 @@ UnixNetProcessor::connect_re_internal(Continuation *cont, sockaddr const *target
                         );
   SocksEntry *socksEntry = nullptr;
 
-  NET_SUM_GLOBAL_DYN_STAT(net_connections_currently_open_stat, 1);
   vc->id          = net_next_connection_number();
   vc->submit_time = Thread::get_hrtime();
   vc->mutex       = cont->mutex;

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1344,10 +1344,6 @@ UnixNetVConnection::connectUp(EThread *t, int fd)
     con.is_bound     = true;
   }
 
-  // Did not fail, increment connection count
-  NET_SUM_GLOBAL_DYN_STAT(net_connections_currently_open_stat, 1);
-  ink_release_assert(con.fd != NO_FD);
-
   // Must connect after EventIO::Start() to avoid a race condition
   // when edge triggering is used.
   if (ep.start(get_PollDescriptor(t), this, EVENTIO_READ | EVENTIO_WRITE) < 0) {
@@ -1363,8 +1359,11 @@ UnixNetVConnection::connectUp(EThread *t, int fd)
     }
   }
 
-  // start up next round immediately
+  // Did not fail, increment connection count
+  NET_SUM_GLOBAL_DYN_STAT(net_connections_currently_open_stat, 1);
+  ink_release_assert(con.fd != NO_FD);
 
+  // start up next round immediately
   SET_HANDLER(&UnixNetVConnection::mainEvent);
 
   nh = get_NetHandler(t);

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1344,6 +1344,10 @@ UnixNetVConnection::connectUp(EThread *t, int fd)
     con.is_bound     = true;
   }
 
+  // Did not fail, increment connection count
+  NET_SUM_GLOBAL_DYN_STAT(net_connections_currently_open_stat, 1);
+  ink_release_assert(con.fd != NO_FD);
+
   // Must connect after EventIO::Start() to avoid a race condition
   // when edge triggering is used.
   if (ep.start(get_PollDescriptor(t), this, EVENTIO_READ | EVENTIO_WRITE) < 0) {


### PR DESCRIPTION
With out this change, the currently open connection count will fall out of sync on connect failures and the system will get stuck in throttling mode. 