### PR TITLE
Fix crash on shutdown

### DIFF
--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -309,9 +309,13 @@ NetAccept::do_blocking_accept(EThread *t)
       return -1;
     }
 
+    if (shutdown_event_system == true) {
+      return -1;
+    }
+
     // Use 'nullptr' to Bypass thread allocator
     vc = (UnixNetVConnection *)this->getNetProcessor()->allocate_vc(nullptr);
-    if (unlikely(!vc || shutdown_event_system == true)) {
+    if (unlikely(!vc)) {
       return -1;
     }
 


### PR DESCRIPTION
We're seeing crashes quite frequently during shutdown, the stack trace looks something like this.
The fix here prevents ats from crashing, but the real source of the problem is still unknown, I'm still investigating what is causing this to happen.

```
#0  0x00002b3a12a22128 in ?? () from /lib64/libgcc_s.so.1
#1  0x00002b3a12a23029 in _Unwind_Backtrace () from /lib64/libgcc_s.so.1
#2  0x00002b3a12d34666 in backtrace () from /lib64/libc.so.6
#3  0x00002b3a10484a0a in ink_stack_trace_dump () at ../../../../trafficserver/lib/ts/ink_stack_trace.cc:61
#4  0x00002b3a10490a8d in signal_crash_handler (signo=11) at ../../../../trafficserver/lib/ts/signals.cc:180
#5  0x000000000054bae8 in crash_logger_invoke (signo=11, info=0x2b3ac7b0f8b0, ctx=0x2b3ac7b0f780) at ../../../trafficserver/proxy/Crash.cc:169
#6  <signal handler called>
#7  0x000000000000726f in ?? ()
#8  0x00000000007dd46f in NetAccept::do_blocking_accept (this=0x2b3a9804d930, t=0x2b3a984179d0) at ../../../../trafficserver/iocore/net/UnixNetAccept.cc:290
#9  0x00000000007de36f in NetAccept::acceptLoopEvent (this=0x2b3a9804d930, event=1, e=0x2b3a981f7cc0) at ../../../../trafficserver/iocore/net/UnixNetAccept.cc:506
#10 0x000000000054e7bc in Continuation::handleEvent (this=0x2b3a9804d930, event=1, data=0x2b3a981f7cc0)
    at /var/builds/workspace/157188-v3-component/BUILD_CONTAINER/rhel7-gcc6_2/label/DOCKER-HIGH/app_root/_build/ats_build/../../trafficserver/iocore/eventsystem/I_Continuation.h:153
#11 0x0000000000806ad1 in EThread::execute (this=0x2b3a984179d0) at ../../../../trafficserver/iocore/eventsystem/UnixEThread.cc:317
#12 0x0000000000805764 in spawn_thread_internal (a=0x2b3a9804daa0) at ../../../../trafficserver/iocore/eventsystem/Thread.cc:85
#13 0x00002b3a11ff1dc5 in start_thread () from /lib64/libpthread.so.0
#14 0x00002b3a12d2076d in clone () from /lib64/libc.so.6
```