### PR TITLE
Runroot: Add an option to specify copy style and reformat the doc

### DIFF
--- a/doc/appendices/command-line/traffic_layout.en.rst
+++ b/doc/appendices/command-line/traffic_layout.en.rst
@@ -20,22 +20,12 @@
 traffic_layout
 **************
 
+========
 Synopsis
 ========
 :program:`traffic_layout` SUBCOMMAND [OPTIONS]
 
-Options
-=============
-.. program:: traffic_layout
-
-.. option:: --run-root=[<path>]
-
-   Use the run root file at :arg:`path`.
-
-.. option:: -V, --version
-
-    Print version information and exit.
-
+===========
 Environment
 ===========
 
@@ -43,8 +33,9 @@ Environment
 
    The path to the run root file. It has the same effect as the command line option :option:`--run-root`.
 
+===========
 Description
-=============
+===========
 Document for the special functionality of ``runroot`` inside :program:`traffic_layout`. This feature
 is for the setup of traffic server runroot. It will create a runtime sandbox for any program of
 traffic server to run under.
@@ -60,59 +51,78 @@ How it works
 #. Emit a yaml file that defines layout structure for other programs to use (relative path).
 #. Users are able to remove runroot and verify permission of the runroot.
 
+===========
 Subcommands
-=============
+===========
 
-- Initialize the runroot: ::
+``init``
+   Use the current working directory or the specific path to create runroot. 
+   The path can be relative or set up in :envvar:`TS_RUNROOT`.
 
-      traffic_layout init (--path /path/to/sandbox/)
+``remove``
+   Find the sandbox to remove in following order: 
+      #. specified in --path as absolute or relative.
+      #. ENV variable: :envvar:`TS_RUNROOT`
+      #. current working directory
+      #. installed directory.
+   
+``verify``
+   Verify the permission of the sandbox.
 
-      Use the current working directory or the specific path to create runroot.
-      The path can be relative or set up in :envvar:`TS_RUNROOT`.
+=======
+Options
+=======
+.. program:: traffic_layout
+
+.. option:: --run-root=[<path>]
+
+    Use the run root file at :arg:`path`.
+   
+.. option:: -V, --version
+
+    Print version information and exit.
+
+.. option:: -h, --help
+
+    Print usage information and exit.
+
+.. option:: --force
+
+    Force init will create sandbox even if the directory is not empty.
+    Force remove will remove a directory even if directory has no yaml file.
+
+.. option:: --absolute
+
+    Put directories in the yaml file in the form of absolute path when creating.
+    
+.. option:: --fix
+
+    Fix the permission issues verify found. ``--fix`` requires root privilege (sudo).
+
+.. option:: --copy-style=[HARD/SOFT/FULL]
+
+    Specify the way of copying executables when creating runroot
+
+========
+Examples
+========
+
+Initialize the runroot. ::
+
+    traffic_layout init (--path /path/to/sandbox/) (--force) (--absolute) (--copy-style=[HARD/SOFT/FULL])
+
+Remove the runroot. ::
+
+    traffic_layout remove (--path /path/to/sandbox/) (--force)
+
+Verify the runroot. ::
+    
+    traffic_layout verify (--path /path/to/sandbox/) (--fix)
 
 
-- Remove the runroot: ::
-
-      traffic_layout remove (--path /path/to/sandbox/)
-
-      Find the sandbox to remove in following order: 
-
-            1. specified in --path as absolute or relative.
-            2. :envvar:`TS_RUNROOT`
-            3. current working directory
-            4. installed directory.
-
-- Verify the runroot: ::
-
-      traffic_layout verify (--path /path/to/sandbox/)
-
-      Verify the permission of the sandbox.
-
-Subcommands options
--------------------
-
-- Force option: ::
-
-      traffic_layout init --force (--path /path/to/sandbox)
-      traffic_layout remove --force (--path /path/to/sandbox)
-
-      Force init will create sandbox even if the directory is not empty.
-      Force remove will remove a directory even if directory has no yaml file.
-
-- Absolute option: ::
-
-      traffic_layout init --absolute (--path /path/to/sandbox)
-
-      create the sandbox and put directories in the yaml file in the form of absolute path.
-
-- Fix option: ::
-
-      traffic_layout verify --fix (--path /path/to/sandbox)
-
-      Fix the permission issues verify found. ``--fix`` requires root privilege (sudo).
-
+=========================
 Usage for other programs:
-==============================================
+=========================
 
 All programs can find the runroot to use in the following order
 

--- a/src/traffic_layout/engine.h
+++ b/src/traffic_layout/engine.h
@@ -23,11 +23,14 @@
 
 #pragma once
 
+#include "file_system.h"
+
 #include <vector>
 #include <string>
 #include <unordered_map>
 
 #define RUNROOT_WORD_LENGTH 10
+#define COPYSTYLE_WORD_LENGTH 12
 
 typedef std::unordered_map<std::string, std::string> RunrootMapType;
 
@@ -70,6 +73,8 @@ struct RunrootEngine {
   bool verify_default = false;
   // for parsing
   int command_num = 0;
+
+  CopyStyle copy_style = HARD;
 
   // the path for create & remove
   std::string path;

--- a/src/traffic_layout/file_system.h
+++ b/src/traffic_layout/file_system.h
@@ -29,6 +29,9 @@
 // size can be changed accordingly
 #define OPEN_MAX_FILE 256
 
+// full copy, hardlink, softlink
+enum CopyStyle { FULL, HARD, SOFT };
+
 // append slash & remove slash of path for convinient use
 void append_slash(std::string &path);
 
@@ -47,4 +50,4 @@ bool remove_directory(const std::string &dir);
 // remove everything inside this directory
 bool remove_inside_directory(const std::string &dir);
 
-bool copy_directory(const std::string &src, const std::string &dst, const std::string &dir = "");
+bool copy_directory(const std::string &src, const std::string &dst, const std::string &dir = "", CopyStyle style = HARD);


### PR DESCRIPTION
Add a new option ``--copy-style`` to traffic_layout runroot.
This option enables users to copy runroot executables in three ways: full copy, hard link or soft link.
The default style is hard link.

The doc is also reformatted.