### PR TITLE
traffic_manager: Fix error, clean up argument handling.

### DIFF
--- a/mgmt/LocalManager.h
+++ b/mgmt/LocalManager.h
@@ -33,6 +33,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "Alarms.h"
 #include "BaseManager.h"
 #include <records/I_RecHttp.h>
@@ -119,7 +121,7 @@ public:
   char *absolute_proxy_binary;
   char *proxy_name;
   char *proxy_binary;
-  char *proxy_options = nullptr; // These options should persist across proxy reboots
+  std::string proxy_options; // These options should persist across proxy reboots
   char *env_prep;
 
   int process_server_sockfd = ts::NO_FD;

--- a/mgmt/api/CoreAPI.cc
+++ b/mgmt/api/CoreAPI.cc
@@ -183,7 +183,7 @@ ProxyStateSet(TSProxyStateT state, TSCacheClearT clear)
       ink_strlcat(tsArgs, " -k", sizeof(tsArgs));
     }
 
-    mgmt_log("[ProxyStateSet] Traffic Server Args: '%s %s'\n", lmgmt->proxy_options ? lmgmt->proxy_options : "", tsArgs);
+    mgmt_log("[ProxyStateSet] Traffic Server Args: '%s %s'\n", lmgmt->proxy_options.c_str(), tsArgs);
 
     lmgmt->run_proxy = true;
     lmgmt->listenForProxy();

--- a/src/traffic_manager/traffic_manager.cc
+++ b/src/traffic_manager/traffic_manager.cc
@@ -639,11 +639,6 @@ main(int argc, const char **argv)
   // stat the 'sync_thr' until 'configFiles' has been initialized.
   RecLocalStart(configFiles);
 
-  /* Update cmd line overrides/environmental overrides/etc */
-  if (tsArgs) { /* Passed command line args for proxy */
-    lmgmt->proxy_options = ats_strdup(tsArgs);
-  }
-
   // TS needs to be started up with the same outputlog bindings each time,
   // so we append the outputlog location to the persistent proxy options
   //
@@ -658,6 +653,9 @@ main(int argc, const char **argv)
   if (*bind_stderr) {
     const char *space = args.empty() ? "" : " ";
     args.format("%s%s %s", space, "--" TM_OPT_BIND_STDERR, bind_stderr);
+  }
+  if (tsArgs) {
+    args.format("%s", tsArgs);
   }
 
   lmgmt->proxy_options = args.release();

--- a/src/traffic_manager/traffic_manager.cc
+++ b/src/traffic_manager/traffic_manager.cc
@@ -56,6 +56,7 @@
 #endif
 #include <grp.h>
 #include <atomic>
+#include <ts/bwf_std_format.h>
 
 #define FD_THROTTLE_HEADROOM (128 + 64) // TODO: consolidate with THROTTLE_FD_HEADROOM
 #define DIAGS_LOG_FILENAME "manager.log"
@@ -63,6 +64,8 @@
 #if ATOMIC_INT_LOCK_FREE != 2
 #error "Need lock free std::atomic<int>"
 #endif
+
+using namespace std::literals;
 
 // These globals are still referenced directly by management API.
 LocalManager *lmgmt = nullptr;
@@ -643,22 +646,9 @@ main(int argc, const char **argv)
   // so we append the outputlog location to the persistent proxy options
   //
   // TS needs them to be able to create BaseLogFiles for each value
-  TextBuffer args(1024);
-
-  if (*bind_stdout) {
-    const char *space = args.empty() ? "" : " ";
-    args.format("%s%s %s", space, "--" TM_OPT_BIND_STDOUT, bind_stdout);
-  }
-
-  if (*bind_stderr) {
-    const char *space = args.empty() ? "" : " ";
-    args.format("%s%s %s", space, "--" TM_OPT_BIND_STDERR, bind_stderr);
-  }
-  if (tsArgs) {
-    args.format("%s", tsArgs);
-  }
-
-  lmgmt->proxy_options = args.release();
+  ts::bwprint(lmgmt->proxy_options, "{}{}{}", ts::bwf::OptionalAffix(tsArgs),
+              ts::bwf::OptionalAffix(bind_stdout, " "sv, "--bind_stdout "sv),
+              ts::bwf::OptionalAffix(bind_stderr, " "sv, "--bind_stderr "sv));
 
   if (proxy_port) {
     HttpProxyPort::loadValue(lmgmt->m_proxy_ports, proxy_port);


### PR DESCRIPTION
It looks like `--tsArgs` was broken by the log rotation changes. This restores that to a working state and does some other cleanup on the argument processing for `traffic_manager`. I added a format wrapper to Buffer Writer for this and updated the related documentation.

Waiting on #3908.