### PR TITLE
IntrusiveDList: Refreshed for C++ eleventy, added const_iterator.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1161,6 +1161,7 @@ add_executable(test_tslib
 	lib/ts/unit-tests/test_BufferWriter.cc
 	lib/ts/unit-tests/test_BufferWriterFormat.cc
 	lib/ts/unit-tests/test_ink_inet.cc
+	lib/ts/unit-tests/test_IntrusiveDList.cc
 	lib/ts/unit-tests/test_IntrusivePtr.cc
 	lib/ts/unit-tests/test_IpMap.cc
 	lib/ts/unit-tests/test_layout.cc

--- a/doc/developer-guide/internal-libraries/index.en.rst
+++ b/doc/developer-guide/internal-libraries/index.en.rst
@@ -32,4 +32,5 @@ development team.
    MemSpan.en
    scalar.en
    buffer-writer.en
+   intrusive-list.en
    MemArena.en

--- a/doc/developer-guide/internal-libraries/intrusive-list.en.rst
+++ b/doc/developer-guide/internal-libraries/intrusive-list.en.rst
@@ -1,0 +1,153 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements. See the NOTICE file distributed with this work for
+   additional information regarding copyright ownership. The ASF licenses this file to you under the
+   Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+   the License. You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software distributed under the License
+   is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+   or implied. See the License for the specific language governing permissions and limitations under
+   the License.
+
+.. include:: ../../common.defs
+
+.. _lib-intrusive-list:
+.. highlight:: cpp
+.. default-domain:: cpp
+
+IntrusiveDList
+**************
+
+:class:`IntrusiveDList` is a class that provides a double linked list using pointers embeded in the
+object. :class:`IntrusiveDList` also acts as a queue. No memory management is done - objects can be
+added to and removed from the list but the allocation and deallocation of the objects must be
+handled outside the class. This class supports an STL compliant bidirectional iteration.
+
+Definition
+**********
+
+.. class:: template < typename L > IntrusiveDList
+
+   A double linked list / queue based on links inside the objects. The element type, :code:`T`, is
+   deduced from the return type of the link accessor methods in :arg:`L`.
+
+   :tparam L: List item descriptor
+
+   The descriptor, :arg:`L`, is a type that provides the operations on list elements required by
+   the container.
+
+   .. type:: value_type
+
+      The class for elements in the container, deduced from the return types of the link accessor methods
+      in :class:`L`.
+
+   .. class:: L
+
+      .. function:: static IntrusiveDList::value_type*& next_ptr(IntrusiveDList::value_type* elt)
+
+         Return a reference to the next element pointer embedded in the element :arg:`elt`.
+
+      .. function:: static IntrusiveDList::value_type*& prev_ptr(IntrusiveDList::value_type* elt)
+
+         Return a reference to the previous element pointer embedded in the element :arg:`elt`.
+
+   .. function:: value_type* head()
+
+      Return a pointer to the head element in the list. This may be :code:`nullptr` if the list is empty.
+
+   .. function:: value_type* tail()
+
+      Return a pointer to the tail element in the list. This may be :code:`nullptr` if the list is empty.
+
+   .. function:: IntrusiveDList& clear()
+
+      Remove all elements from the list. This only removes, no deallocation nor destruction is performed.
+
+   .. function:: size_t count() const
+
+      Return the number of elements in the list.
+
+   .. function:: IntrusiveDList& append(value_type * elt)
+
+      Append :arg:`elt` to the list.
+
+   .. function:: IntrusiveDList& prepend(value_type * elt)
+
+      Prepend :arg:`elt` to the list.
+
+Usage
+*****
+
+An instance of :class:`IntrusiveDList` acts as a container for items, maintaining a doubly linked
+list / queue of the objects and tracking the number of objects in the container. There are methods
+for appending, prepending, and inserting (both before and after a specific element already in the
+list). Some care must be taken because it is too expensive to check for an element already being in
+the list or in another list. The internal links are set to :code:`nullptr`, therefore one simple check
+for being in a list is if either internal link is not :code:`nullptr`. This requires initializing the
+internal links to :code:`nullptr`.
+
+Examples
+========
+
+In this example the goal is to have a list of :code:`Message` objects. First the class is declared
+along with the internal linkage support.
+
+.. literalinclude:: ../../../lib/ts/unit-tests/test_IntrusiveDList.cc
+   :lines: 37-62
+
+The struct :code:`Linkage` is used both to provide the descriptor to :class:`IntrusiveDList` but to
+contain the link pointers as well. This isn't necessary - the links could have been direct members
+and the implementation of the link accessor methods adjusted. Because the links are intended to be
+used only by a specific container class (:code:`Container`) the struct is made protected.
+
+The implementation of the link accessor methods.
+
+.. literalinclude:: ../../../lib/ts/unit-tests/test_IntrusiveDList.cc
+   :lines: 64-73
+
+An example method to check if the message is in a list.
+
+.. literalinclude:: ../../../lib/ts/unit-tests/test_IntrusiveDList.cc
+   :lines: 75-79
+
+The container class for the messages could be implemented as
+
+.. literalinclude:: ../../../lib/ts/unit-tests/test_IntrusiveDList.cc
+   :lines: 81-96
+
+The :code:`debug` method takes a format string (:arg:`fmt`) and an arbitrary set of arguments, formats
+the arguments in to the string, and adds the new message to the list.
+
+.. literalinclude:: ../../../lib/ts/unit-tests/test_IntrusiveDList.cc
+   :lines: 119-128
+
+Other methods for the various severity levels would be implemented in a similar fashion. Because the
+intrusive list does not do memory management, the container must clean that up itself, as in the
+:code:`clear` method. The STL iteration support makes this easy.
+
+.. literalinclude:: ../../../lib/ts/unit-tests/test_IntrusiveDList.cc
+   :lines: 103-111
+
+Design Notes
+************
+
+The historic goal of this class is to replace the :code:`DLL` list support. The benefits of this are
+
+*  Remove dependency on the C preprocessor.
+
+*  Provide greater flexibility in the internal link members. Because of the use of the descriptor
+   and its static methods, the links can be anywhere in the object, including in nested structures
+   or super classes. The links are declared like normal members and do not require specific macros.
+
+*  Provide STL compliant iteration. This makes the class easier to use in general and particularly
+   in the case of range :code:`for` loops.
+
+*  Track the number of items in the list.
+
+*  Provide queue support, which is of such low marginal expense there is, IMHO, no point in
+   providing a separate class for it.
+
+
+

--- a/iocore/net/P_SNIActionPerformer.h
+++ b/iocore/net/P_SNIActionPerformer.h
@@ -123,7 +123,7 @@ public:
   SNIAction(Continuation *cont) override
   {
     // i.e, ip filtering is not required
-    if (ip_map.getCount() == 0) {
+    if (ip_map.count() == 0) {
       return SSL_TLSEXT_ERR_OK;
     }
 

--- a/lib/ts/IpMap.h
+++ b/lib/ts/IpMap.h
@@ -335,7 +335,7 @@ public:
   /// Iterator past last element.
   iterator end() const;
   /// @return Number of distinct ranges in the map.
-  size_t getCount() const;
+  size_t count() const;
 
   /** Validate internal data structures.
       @note Intended for debugging, not general client use.

--- a/lib/ts/Makefile.am
+++ b/lib/ts/Makefile.am
@@ -269,6 +269,7 @@ test_tslib_SOURCES = \
 	unit-tests/test_BufferWriter.cc \
 	unit-tests/test_BufferWriterFormat.cc \
 	unit-tests/test_ink_inet.cc \
+	unit-tests/test_IntrusiveDList.cc \
 	unit-tests/test_IntrusivePtr.cc \
 	unit-tests/test_IpMap.cc \
 	unit-tests/test_layout.cc \

--- a/lib/ts/unit-tests/test_IntrusiveDList.cc
+++ b/lib/ts/unit-tests/test_IntrusiveDList.cc
@@ -1,0 +1,274 @@
+/** @file
+
+    IntrusiveDList unit tests.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <iostream>
+#include <string_view>
+#include <string>
+
+#include <ts/IntrusiveDList.h>
+#include <ts/BufferWriter.h>
+
+#include <catch.hpp>
+
+// --------------------
+// Code for documentation - placed here to guarantee the examples at least compile.
+// First so that additional tests do not require updating the documentation source links.
+
+class Message
+{
+  using self_type = Message;
+
+public:
+  // Message severity level.
+  enum Severity { LVL_DEBUG, LVL_INFO, LVL_WARN, LVL_ERROR };
+
+protected:
+  std::string _text; // Text of the message.
+  Severity _severity{LVL_DEBUG};
+  int _indent{0}; // indentation level for display.
+
+  // Intrusive list support.
+  struct Linkage {
+    static self_type *&next_ptr(self_type *); // Link accessor.
+    static self_type *&prev_ptr(self_type *); // Link accessor.
+
+    self_type *_next{nullptr}; // Forward link.
+    self_type *_prev{nullptr}; // Backward link.
+  } _link;
+
+  bool is_in_list() const;
+
+  friend class Container;
+};
+
+auto
+Message::Linkage::next_ptr(self_type *that) -> self_type *&
+{
+  return that->_link._next;
+}
+auto
+Message::Linkage::prev_ptr(self_type *that) -> self_type *&
+{
+  return that->_link._prev;
+}
+
+bool
+Message::is_in_list() const
+{
+  return _link._next || _link._prev;
+}
+
+class Container
+{
+  using self_type   = Container;
+  using MessageList = IntrusiveDList<Message::Linkage>;
+
+public:
+  ~Container();
+
+  template <typename... Args> self_type &debug(std::string_view fmt, Args &&... args);
+
+  size_t count() const;
+  self_type &clear();
+
+protected:
+  MessageList _msgs;
+};
+
+Container::~Container()
+{
+  this->clear(); // clean up memory.
+}
+
+auto
+Container::clear() -> self_type &
+{
+  for (auto &&msg : _msgs) {
+    delete &msg;
+  }
+  _msgs.clear();
+  return *this;
+}
+
+size_t
+Container::count() const
+{
+  return _msgs.count();
+}
+
+template <typename... Args>
+auto
+Container::debug(std::string_view fmt, Args &&... args) -> self_type &
+{
+  Message *msg = new Message;
+  ts::bwprintv(msg->_text, fmt, std::forward_as_tuple(args...));
+  msg->_severity = Message::LVL_DEBUG;
+  _msgs.append(msg);
+  return *this;
+}
+
+TEST_CASE("IntrusiveDList Example", "[libts][IntrusiveDList]")
+{
+  Container container;
+
+  container.debug("This is message {}", 1);
+  REQUIRE(container.count() == 1);
+  // Destructor is checked for non-crashing as container goes out of scope.
+}
+
+// --------------------
+
+struct Thing {
+  Thing *_next{nullptr};
+  Thing *_prev{nullptr};
+  std::string _payload;
+
+  Thing(std::string_view text) : _payload(text) {}
+
+  struct Linkage {
+    static Thing *&
+    next_ptr(Thing *t)
+    {
+      return t->_next;
+    }
+    static Thing *&
+    prev_ptr(Thing *t)
+    {
+      return t->_prev;
+    }
+  };
+};
+
+// Just for you, @maskit ! Demonstrating non-public links and subclassing.
+class PrivateThing : protected Thing
+{
+  using self_type  = PrivateThing;
+  using super_type = Thing;
+
+public:
+  PrivateThing(std::string_view text) : super_type(text) {}
+
+  struct Linkage {
+    static self_type *&
+    next_ptr(self_type *t)
+    {
+      return *reinterpret_cast<self_type **>(&t->_next);
+    }
+    static self_type *&
+    prev_ptr(self_type *t)
+    {
+      return *reinterpret_cast<self_type **>(&t->_prev);
+    }
+  };
+
+  std::string const &
+  payload() const
+  {
+    return _payload;
+  }
+};
+
+using ThingList        = IntrusiveDList<Thing::Linkage>;
+using PrivateThingList = IntrusiveDList<PrivateThing::Linkage>;
+
+TEST_CASE("IntrusiveDList", "[libts][IntrusiveDList]")
+{
+  ThingList list;
+  int n;
+
+  REQUIRE(list.count() == 0);
+  REQUIRE(list.head() == nullptr);
+  REQUIRE(list.tail() == nullptr);
+  REQUIRE(list.begin() == list.end());
+  REQUIRE(list.empty());
+
+  n = 0;
+  for ([[maybe_unused]] auto &thing : list)
+    ++n;
+  REQUIRE(n == 0);
+  // Check const iteration (mostly compile checks here).
+  for ([[maybe_unused]] auto &thing : static_cast<ThingList const &>(list))
+    ++n;
+  REQUIRE(n == 0);
+
+  list.append(new Thing("one"));
+  REQUIRE(list.begin() != list.end());
+  REQUIRE(list.tail() == list.head());
+
+  list.prepend(new Thing("two"));
+  REQUIRE(list.count() == 2);
+  REQUIRE(list.head()->_payload == "two");
+  REQUIRE(list.tail()->_payload == "one");
+  list.prepend(list.take_tail());
+  REQUIRE(list.head()->_payload == "one");
+  REQUIRE(list.tail()->_payload == "two");
+  list.insert_after(list.head(), new Thing("middle"));
+  list.insert_before(list.tail(), new Thing("muddle"));
+  REQUIRE(list.count() == 4);
+  auto spot = list.begin();
+  REQUIRE((*spot++)._payload == "one");
+  REQUIRE((*spot++)._payload == "middle");
+  REQUIRE((*spot++)._payload == "muddle");
+  REQUIRE((*spot++)._payload == "two");
+  REQUIRE(spot == list.end());
+
+  Thing *thing = list.take_head();
+  REQUIRE(thing->_payload == "one");
+  REQUIRE(list.count() == 3);
+  REQUIRE(list.head() != nullptr);
+  REQUIRE(list.head()->_payload == "middle");
+
+  list.prepend(thing);
+  list.erase(list.head());
+  REQUIRE(list.count() == 3);
+  REQUIRE(list.head() != nullptr);
+  REQUIRE(list.head()->_payload == "middle");
+  list.prepend(thing);
+
+  thing = list.take_tail();
+  REQUIRE(thing->_payload == "two");
+  REQUIRE(list.count() == 3);
+  REQUIRE(list.tail() != nullptr);
+  REQUIRE(list.tail()->_payload == "muddle");
+
+  list.append(thing);
+  list.erase(list.tail());
+  REQUIRE(list.count() == 3);
+  REQUIRE(list.tail() != nullptr);
+  REQUIRE(list.tail()->_payload == "muddle");
+  REQUIRE(list.head()->_payload == "one");
+
+  list.insert_before(list.end(), new Thing("trailer"));
+  REQUIRE(list.count() == 4);
+  REQUIRE(list.tail()->_payload == "trailer");
+
+  PrivateThingList priv_list;
+  for (int i = 1; i <= 23; ++i) {
+    std::string name;
+    ts::bwprint(name, "Item {}", i);
+    priv_list.append(new PrivateThing(name));
+    REQUIRE(priv_list.count() == i);
+  }
+  REQUIRE(priv_list.head()->payload() == "Item 1");
+  REQUIRE(priv_list.tail()->payload() == "Item 23");
+}

--- a/lib/ts/unit-tests/test_IpMap.cc
+++ b/lib/ts/unit-tests/test_IpMap.cc
@@ -135,7 +135,7 @@ TEST_CASE("IpMap Basic", "[libts][ipmap]")
   map.mark(ip5, ip9, markA);
   {
     INFO("Coalesce failed");
-    CHECK(map.getCount() == 1);
+    CHECK(map.count() == 1);
   }
   {
     INFO("Range max not found.");
@@ -153,7 +153,7 @@ TEST_CASE("IpMap Basic", "[libts][ipmap]")
   map.fill(ip15, ip100, markB);
   {
     INFO("Fill failed.");
-    CHECK(map.getCount() == 2);
+    CHECK(map.count() == 2);
   }
   {
     INFO("fill interior missing");
@@ -179,13 +179,13 @@ TEST_CASE("IpMap Basic", "[libts][ipmap]")
   map.clear();
   {
     INFO("Clear failed.");
-    CHECK(map.getCount() == 0);
+    CHECK(map.count() == 0);
   }
 
   map.mark(ip20, ip50, markA);
   map.mark(ip100, ip150, markB);
   map.fill(ip10, ip200, markC);
-  CHECK(map.getCount() == 5);
+  CHECK(map.count() == 5);
   {
     INFO("Left span missing");
     CHECK(map.contains(ip15, &mark));
@@ -214,7 +214,7 @@ TEST_CASE("IpMap Basic", "[libts][ipmap]")
   map.unmark(ip140, ip160);
   {
     INFO("unmark failed");
-    CHECK(map.getCount() == 5);
+    CHECK(map.count() == 5);
   }
   {
     INFO("unmark left edge still there.");
@@ -247,7 +247,7 @@ TEST_CASE("IpMap Basic", "[libts][ipmap]")
   map.mark(ip0, ipmax, markC);
   {
     INFO("IpMap: Full range fill left extra ranges.");
-    CHECK(map.getCount() == 1);
+    CHECK(map.count() == 1);
   }
 }
 
@@ -285,12 +285,12 @@ TEST_CASE("IpMap Unmark", "[libts][ipmap]")
   map.mark(&a_0, &a_max, markA);
   {
     INFO("IpMap Unmark: Full range not single.");
-    CHECK(map.getCount() == 1);
+    CHECK(map.count() == 1);
   }
   map.unmark(&a_10_28_56_0, &a_10_28_56_255);
   {
     INFO("IpMap Unmark: Range unmark failed.");
-    CHECK(map.getCount() == 2);
+    CHECK(map.count() == 2);
   }
   // Generic range check.
   {
@@ -420,7 +420,7 @@ TEST_CASE("IpMap Fill", "[libts][ipmap]")
     map.fill(&a0, &a_max, markC);
     {
       INFO("IpMap[2]: Fill failed.");
-      CHECK(map.getCount() == 5);
+      CHECK(map.count() == 5);
     }
     {
       INFO("invalid mark in range gap");
@@ -443,7 +443,7 @@ TEST_CASE("IpMap Fill", "[libts][ipmap]")
     map.fill(&a0, &a_max, deny);
     {
       INFO("range count incorrect");
-      CHECK(map.getCount() == 5);
+      CHECK(map.count() == 5);
     }
     {
       INFO("mark between ranges");
@@ -485,7 +485,7 @@ TEST_CASE("IpMap Fill", "[libts][ipmap]")
 
     {
       INFO("IpMap Fill[pre-refill]: Bad range count.");
-      CHECK(map.getCount() == 10);
+      CHECK(map.count() == 10);
     }
     // These should be ignored by the map as it is completely covered for IPv6.
     map.fill(&a_fe80_9d90, &a_fe80_9d9d, markA);
@@ -493,7 +493,7 @@ TEST_CASE("IpMap Fill", "[libts][ipmap]")
     map.fill(&a_0000_0000, &a_ffff_ffff, markB);
     {
       INFO("IpMap Fill[post-refill]: Bad range count.");
-      CHECK(map.getCount() == 10);
+      CHECK(map.count() == 10);
     }
   }
 
@@ -601,5 +601,5 @@ TEST_CASE("IpMap CloseIntersection", "[libts][ipmap]")
   map.mark(d_2_l, d_2_u, markD);
   CHECK_THAT(map, IsMarkedAt(a_1_m));
 
-  CHECK(map.getCount() == 13);
+  CHECK(map.count() == 13);
 }

--- a/proxy/ControlMatcher.cc
+++ b/proxy/ControlMatcher.cc
@@ -667,7 +667,7 @@ template <class Data, class MatchResult>
 void
 IpMatcher<Data, MatchResult>::Print()
 {
-  printf("\tIp Matcher with %d elements, %zu ranges.\n", num_el, ip_map.getCount());
+  printf("\tIp Matcher with %d elements, %zu ranges.\n", num_el, ip_map.count());
   for (IpMap::iterator spot(ip_map.begin()), limit(ip_map.end()); spot != limit; ++spot) {
     char b1[INET6_ADDRSTRLEN], b2[INET6_ADDRSTRLEN];
     printf("\tRange %s - %s ", ats_ip_ntop(spot->min(), b1, sizeof b1), ats_ip_ntop(spot->max(), b2, sizeof b2));

--- a/proxy/IPAllow.cc
+++ b/proxy/IPAllow.cc
@@ -111,7 +111,7 @@ void
 IpAllow::PrintMap(IpMap *map)
 {
   std::ostringstream s;
-  s << map->getCount() << " ACL entries.";
+  s << map->count() << " ACL entries.";
   for (auto &spot : *map) {
     char text[INET6_ADDRSTRLEN];
     AclRecord const *ar = static_cast<AclRecord const *>(spot.data());
@@ -178,7 +178,7 @@ IpAllow::BuildTable()
   bool alarmAlready = false;
 
   // Table should be empty
-  ink_assert(_src_map.getCount() == 0 && _dest_map.getCount() == 0);
+  ink_assert(_src_map.count() == 0 && _dest_map.count() == 0);
 
   file_buf = readIntoBuffer(config_file_path, module_name, nullptr);
 
@@ -297,7 +297,7 @@ IpAllow::BuildTable()
     line = tokLine(nullptr, &tok_state);
   }
 
-  if (_src_map.getCount() == 0 && _dest_map.getCount() == 0) { // TODO: check
+  if (_src_map.count() == 0 && _dest_map.count() == 0) { // TODO: check
     Warning("%s No entries in %s. All IP Addresses will be blocked", module_name, config_file_path);
   } else {
     // convert the coloring from indices to pointers.

--- a/proxy/logging/LogFilter.cc
+++ b/proxy/logging/LogFilter.cc
@@ -767,7 +767,7 @@ void
 LogFilterIP::init()
 {
   m_type       = IP_FILTER;
-  m_num_values = m_map.getCount();
+  m_num_values = m_map.count();
 }
 
 /*-------------------------------------------------------------------------
@@ -886,7 +886,7 @@ LogFilterIP::display(FILE *fd)
 {
   ink_assert(fd != nullptr);
 
-  if (0 == m_map.getCount()) {
+  if (0 == m_map.count()) {
     fprintf(fd, "Filter \"%s\" is inactive, no values specified\n", m_name);
   } else {
     fprintf(fd, "Filter \"%s\" %sS records if %s %s ", m_name, ACTION_NAME[m_action], m_field->symbol(), OPERATOR_NAME[m_operator]);


### PR DESCRIPTION
This is a refresh of `IntrusiveDList`. This is used in `IpMap` and I intended to upgrade `TSHashTable` to use it as well. Some method names were changed to be more inline with other practice in TS and a `const_iterator` was added for better STL compliance. All of the method implementations were moved out of the class declaration to make the latter cleaner and easier to read.

Some of the key points

* It is pure C++ and does not depend on use of the pre-processor, while being more flexible in how the internal links are arranged (for instance, there is no need for separate macros depending on whether the links are directly in the target class or in a nested class).

* It is also a queue as the additional work of supporting queue operations was trivial.

* The number of elements is tracked.

* There is also documentary comments detailing usage and implementation.

* STL style iteration is supported which means range style for loops work as expected.