### PR TITLE
BWF: Add "OptionalAffix", clean up some minor BWF wrapper class issues.

### DIFF
--- a/lib/ts/BufferWriter.h
+++ b/lib/ts/BufferWriter.h
@@ -35,8 +35,6 @@
 #include <ts/MemSpan.h>
 #include <ts/BufferWriterForward.h>
 
-using namespace std::literals;
-
 namespace ts
 {
 /** Base (abstract) class for concrete buffer writers.
@@ -611,6 +609,7 @@ template <typename... Args>
 BufferWriter &
 BufferWriter::printv(TextView fmt, std::tuple<Args...> const &args)
 {
+  using namespace std::literals;
   static constexpr int N = sizeof...(Args); // used as loop limit
   static const auto fa   = bw_fmt::Get_Arg_Formatter_Array<decltype(args)>(std::index_sequence_for<Args...>{});
   int arg_idx            = 0; // the next argument index to be processed.
@@ -671,6 +670,7 @@ template <typename... Args>
 BufferWriter &
 BufferWriter::printv(BWFormat const &fmt, std::tuple<Args...> const &args)
 {
+  using namespace std::literals;
   static constexpr int N = sizeof...(Args);
   static const auto fa   = bw_fmt::Get_Arg_Formatter_Array<decltype(args)>(std::index_sequence_for<Args...>{});
 
@@ -795,6 +795,7 @@ bwformat(BufferWriter &w, BWFSpec const &, char c)
 inline BufferWriter &
 bwformat(BufferWriter &w, BWFSpec const &spec, bool f)
 {
+  using namespace std::literals;
   if ('s' == spec._type) {
     w.write(f ? "true"sv : "false"sv);
   } else if ('S' == spec._type) {

--- a/lib/ts/BufferWriterFormat.cc
+++ b/lib/ts/BufferWriterFormat.cc
@@ -951,6 +951,12 @@ bwformat(BufferWriter &w, BWFSpec const &spec, bwf::Date const &date)
   return w;
 }
 
+BufferWriter &
+bwformat(BufferWriter &w, BWFSpec const &spec, bwf::OptionalAffix const &opts)
+{
+  return w.write(opts._prefix).write(opts._text).write(opts._suffix);
+}
+
 } // namespace ts
 
 namespace

--- a/lib/ts/TextView.h
+++ b/lib/ts/TextView.h
@@ -1018,3 +1018,13 @@ namespace std
 {
 ostream &operator<<(ostream &os, const ts::TextView &b);
 }
+
+// @c constexpr literal constructor for @c std::string_view
+// For unknown reasons, this enables creating @c constexpr constructs using @c std::string_view while the standard
+// one (""sv) does not.
+// I couldn't think of any better place to put this, so it's here. At least @c TextView is strongly related
+// to @c std::string_view.
+constexpr std::string_view operator"" _sv(const char *s, size_t n)
+{
+  return {s, n};
+}

--- a/lib/ts/bwf_std_format.h
+++ b/lib/ts/bwf_std_format.h
@@ -25,12 +25,14 @@
 
 #include <atomic>
 #include <string_view>
+#include <ts/TextView.h>
+#include <ts/BufferWriterForward.h>
 
 namespace std
 {
 template <typename T>
 ts::BufferWriter &
-bwformat(ts::BufferWriter &w, ts::BWFSpec const &spec, std::atomic<T> const &v)
+bwformat(ts::BufferWriter &w, ts::BWFSpec const &spec, atomic<T> const &v)
 {
   return ts::bwformat(w, spec, v.load());
 }
@@ -40,17 +42,30 @@ namespace ts
 {
 namespace bwf
 {
+  using namespace std::literals; // enable ""sv
+
+  /** Format wrapper for @c errno.
+   * This stores a copy of the argument or @c errno if an argument isn't provided. The output
+   * is then formatted with the short, long, and numeric value of @c errno. If the format specifier
+   * is type 'd' then just the numeric value is printed.
+   */
   struct Errno {
     int _e;
-    explicit Errno(int e) : _e(e) {}
+    explicit Errno(int e = errno) : _e(e) {}
   };
 
+  /** Format wrapper for time stamps.
+   * If the time isn't provided, the current epoch time is used. If the format string isn't
+   * provided a format like "2017 Jun 29 14:11:29" is used.
+   */
   struct Date {
+    static constexpr std::string_view DEFAULT_FORMAT{"%Y %b %d %H:%M:%S"_sv};
     time_t _epoch;
     std::string_view _fmt;
-    Date(time_t t, std::string_view fmt = "%Y %b %d %H:%M:%S"sv) : _epoch(t), _fmt(fmt) {}
-    Date(std::string_view fmt = "%Y %b %d %H:%M:%S"sv);
+    Date(time_t t, std::string_view fmt = DEFAULT_FORMAT) : _epoch(t), _fmt(fmt) {}
+    Date(std::string_view fmt = DEFAULT_FORMAT);
   };
+
 } // namespace bwf
 
 BufferWriter &bwformat(BufferWriter &w, BWFSpec const &spec, bwf::Errno const &e);

--- a/lib/ts/bwf_std_format.h
+++ b/lib/ts/bwf_std_format.h
@@ -66,9 +66,34 @@ namespace bwf
     Date(std::string_view fmt = DEFAULT_FORMAT);
   };
 
+  /** For optional printing strings along with suffixes and prefixes.
+   *  If the wrapped string is null or empty, nothing is printed. Otherwise the prefix, string,
+   *  and suffix are printed. The default are a single space for suffix and nothing for the prefix.
+   */
+  struct OptionalAffix {
+    std::string_view _text;
+    std::string_view _suffix;
+    std::string_view _prefix;
+
+    OptionalAffix(const char *text, std::string_view suffix = " "sv, std::string_view prefix = ""sv)
+      : OptionalAffix(std::string_view(text ? text : ""), suffix, prefix)
+    {
+    }
+
+    OptionalAffix(std::string_view text, std::string_view suffix = " "sv, std::string_view prefix = ""sv)
+    {
+      // If text is null or empty, leave the members empty too.
+      if (!text.empty()) {
+        _text   = text;
+        _prefix = prefix;
+        _suffix = suffix;
+      }
+    }
+  };
 } // namespace bwf
 
 BufferWriter &bwformat(BufferWriter &w, BWFSpec const &spec, bwf::Errno const &e);
 BufferWriter &bwformat(BufferWriter &w, BWFSpec const &spec, bwf::Date const &date);
+BufferWriter &bwformat(BufferWriter &w, BWFSpec const &spec, bwf::OptionalAffix const &opts);
 
 } // namespace ts


### PR DESCRIPTION
This is support for (not) printing possibly empty strings with prefix and/or suffix. If the string is null or empty, nothing is printed, but if there is a string the prefix, string, and suffix are printed. This avoids code that does this check to provide separators between items in print statements, or complex ternary operators in printing argument lists.

In conjuction a few minor other improvements in the Buffer Writer wrapper classes.

This is broken out of #3903 as requested.