### PR TITLE
Avoid dangling dead SM's

### DIFF
--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -116,9 +116,9 @@ struct HttpVCTable {
   HttpVCTableEntry *new_entry();
   HttpVCTableEntry *find_entry(VConnection *);
   HttpVCTableEntry *find_entry(VIO *);
-  void remove_entry(HttpVCTableEntry *);
-  void cleanup_entry(HttpVCTableEntry *);
-  void cleanup_all();
+  void remove_entry(HttpVCTableEntry *, Continuation *);
+  void cleanup_entry(HttpVCTableEntry *, Continuation *);
+  void cleanup_all(Continuation *);
   bool is_table_clear() const;
 
 private:
@@ -645,7 +645,7 @@ HttpSM::allocate()
 inline void
 HttpSM::remove_ua_entry()
 {
-  vc_table.remove_entry(ua_entry);
+  vc_table.remove_entry(ua_entry, this);
   ua_entry = nullptr;
 }
 
@@ -653,7 +653,7 @@ inline void
 HttpSM::remove_server_entry()
 {
   if (server_entry) {
-    vc_table.remove_entry(server_entry);
+    vc_table.remove_entry(server_entry, this);
     server_entry = nullptr;
   }
 }


### PR DESCRIPTION
Opening this in place of PR #3904.  While tracking down crashes with the early post shutdown cafd146, I was seeing crashes where the SM wasn't locked and where the state machine had been deleted (more obvious when running without free lists).

The original PR tried to lock and reschedule, but changing the HttpSM to clear any remaining references to the state machine in the read and write vios seemed to clean up in the issue.  And could explain some of the inactivity timeout crashes with stale SM's we have been seeing.

I am leaving the lock logic in read_signal_and_update, but instead of trying to reschedule on lock failure, I just added an assert . There is a very fundamental problem if there is a true lock contention at this point.