### PR TITLE
Fix crashes from early post return fix.

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -1812,6 +1812,11 @@ HttpSM::state_read_server_response_header(int event, void *data)
   case VC_EVENT_READ_READY:
   case VC_EVENT_READ_COMPLETE:
     // More data to parse
+
+    // If there is still a post body underway, defer processing until post body is done
+    if (ua_entry->in_tunnel && !server_entry->eos) {
+      return 0;
+    }
     break;
 
   case VC_EVENT_ERROR:
@@ -2687,6 +2692,10 @@ HttpSM::tunnel_handler_post(int event, void *data)
     handle_post_failure();
     break;
   case HTTP_SM_POST_UA_FAIL:
+    // Cancel out the server read if present. Left over attempt to read server response.
+    if (server_entry && server_entry->read_vio && server_session && server_entry->read_vio->cont) {
+      server_entry->read_vio = server_session->do_io_read(nullptr, 0, nullptr);
+    }
     break;
   case HTTP_SM_POST_SUCCESS:
     // It's time to start reading the response
@@ -2698,7 +2707,11 @@ HttpSM::tunnel_handler_post(int event, void *data)
       call_transact_and_set_next_state(HttpTransact::HandleRequestBufferDone);
       break;
     }
-    // Read reasponse already setup
+    // Read response already setup
+    // Signal if data is waiting
+    if (server_entry->read_vio && server_entry->read_vio->ndone > 0) {
+      handleEvent(VC_EVENT_READ_READY, server_entry->read_vio);
+    }
     break;
   default:
     ink_release_assert(0);


### PR DESCRIPTION
When running with commit cafd146 to address early post responses, we would sometimes get crashes.  This code change adds coordination between the post tunnel and the server response to avoid this crash.