### PR TITLE
Check version in the snap file on ATS upgrade

### DIFF
--- a/lib/records/P_RecFile.h
+++ b/lib/records/P_RecFile.h
@@ -30,6 +30,7 @@
 #define REC_HANDLE_INVALID -1
 typedef int RecHandle;
 
+static constexpr unsigned VERSION_HDR_SIZE = 5;
 //-------------------------------------------------------------------------
 // RecFile
 //-------------------------------------------------------------------------
@@ -38,7 +39,9 @@ RecHandle RecFileOpenR(const char *file);
 RecHandle RecFileOpenW(const char *file);
 int RecFileClose(RecHandle h_file);
 int RecFileRead(RecHandle h_file, char *buf, int size, int *bytes_read);
+int RecSnapFileRead(RecHandle h_file, char *buf, int size, int *bytes_read);
 int RecFileWrite(RecHandle h_file, char *buf, int size, int *bytes_written);
+int RecSnapFileWrite(RecHandle h_file, char *buf, int size, int *bytes_written);
 int RecFileGetSize(RecHandle h_file);
 int RecFileExists(const char *file);
 int RecFileSync(RecHandle h_file);

--- a/lib/records/RecCore.cc
+++ b/lib/records/RecCore.cc
@@ -47,7 +47,7 @@ register_record(RecT rec_type, const char *name, RecDataT data_type, RecData dat
   RecRecord *r = nullptr;
 
   // Metrics are restored from persistence before they are registered. In this case, when the registration arrives, we
-  // might find that they yave changed. For example, a metric might change it's type due to a software upgrade. Records
+  // might find that they have changed. For example, a metric might change it's type due to a software upgrade. Records
   // must not flip between config and metrics, but changing within those classes is OK.
   if (ink_hash_table_lookup(g_records_ht, name, (void **)&r)) {
     if (REC_TYPE_IS_STAT(rec_type)) {

--- a/lib/records/RecMessage.cc
+++ b/lib/records/RecMessage.cc
@@ -266,12 +266,12 @@ RecMessageReadFromDisk(const char *fpath)
   if ((h_file = RecFileOpenR(fpath)) == REC_HANDLE_INVALID) {
     goto Lerror;
   }
-  if (RecFileRead(h_file, (char *)(&msg_hdr), sizeof(RecMessageHdr), &bytes_read) == REC_ERR_FAIL) {
+  if (RecSnapFileRead(h_file, (char *)(&msg_hdr), sizeof(RecMessageHdr), &bytes_read) == REC_ERR_FAIL) {
     goto Lerror;
   }
   msg = (RecMessage *)ats_malloc((msg_hdr.o_end - msg_hdr.o_start) + sizeof(RecMessageHdr));
   memcpy(msg, &msg_hdr, sizeof(RecMessageHdr));
-  if (RecFileRead(h_file, (char *)(msg) + msg_hdr.o_start, msg_hdr.o_end - msg_hdr.o_start, &bytes_read) == REC_ERR_FAIL) {
+  if (RecSnapFileRead(h_file, (char *)(msg) + msg_hdr.o_start, msg_hdr.o_end - msg_hdr.o_start, &bytes_read) == REC_ERR_FAIL) {
     goto Lerror;
   }
 
@@ -307,7 +307,7 @@ RecMessageWriteToDisk(RecMessage *msg, const char *fpath)
 
   msg_size = sizeof(RecMessageHdr) + (msg->o_write - msg->o_start);
   if ((h_file = RecFileOpenW(fpath)) != REC_HANDLE_INVALID) {
-    if (RecFileWrite(h_file, (char *)msg, msg_size, &bytes_written) == REC_ERR_FAIL) {
+    if (RecSnapFileWrite(h_file, (char *)msg, msg_size, &bytes_written) == REC_ERR_FAIL) {
       RecFileClose(h_file);
       return REC_ERR_FAIL;
     }


### PR DESCRIPTION
This PR resolve the snap file incompatibility when we upgrade/downgrade trafficserver.

It puts the version bytes into` records.snap` and check this version when running traffic server.
If the version does not match the current program, the snap file will be deleted.
