### PR TITLE
cppapi :InterceptPlugin fix

### DIFF
--- a/lib/cppapi/InterceptPlugin.cc
+++ b/lib/cppapi/InterceptPlugin.cc
@@ -84,7 +84,7 @@ struct InterceptPlugin::State {
   TSAction timeout_action_ = nullptr;
   bool plugin_io_done_     = false;
 
-  State(TSCont cont, InterceptPlugin *plugin) : cont_(cont)
+  State(TSCont cont, InterceptPlugin *plugin) : cont_(cont), plugin_(plugin)
   {
     plugin_mutex_ = plugin->getMutex();
     http_parser_  = TSHttpParserCreate();


### PR DESCRIPTION
This change unbreaks using cppapi ServerIntercepts

(Ran into a hanging FastCGI plugin while trying address comments in
https://github.com/apache/trafficserver/pull/3749)