### PR TITLE
Log lock cleanup

### DIFF
--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -45,13 +45,9 @@
 
 #define HTTP_RELEASE_ASSERT(X) ink_release_assert(X)
 
-#define ACQUIRE_PRINT_LOCK() // ink_mutex_acquire(&print_lock);
-#define RELEASE_PRINT_LOCK() // ink_mutex_release(&print_lock);
-
 #define DUMP_HEADER(T, H, I, S)                                 \
   {                                                             \
     if (diags->on(T)) {                                         \
-      ACQUIRE_PRINT_LOCK()                                      \
       fprintf(stderr, "+++++++++ %s +++++++++\n", S);           \
       fprintf(stderr, "-- State Machine Id: %" PRId64 "\n", I); \
       char b[4096];                                             \
@@ -68,7 +64,6 @@
           fprintf(stderr, "%s", b);                             \
         } while (!done);                                        \
       }                                                         \
-      RELEASE_PRINT_LOCK()                                      \
     }                                                           \
   }
 

--- a/proxy/http/HttpTransactCache.cc
+++ b/proxy/http/HttpTransactCache.cc
@@ -180,9 +180,7 @@ HttpTransactCache::SelectFromAlternates(CacheHTTPInfoVector *cache_vector, HTTPH
   Debug("http_match", "[SelectFromAlternates] # alternates = %d", alt_count);
   Debug("http_seq", "[SelectFromAlternates] %d alternates for this cached doc", alt_count);
   if (is_debug_tag_set("http_alts")) {
-    ACQUIRE_PRINT_LOCK()
     fprintf(stderr, "[alts] There are %d alternates for this request header.\n", alt_count);
-    RELEASE_PRINT_LOCK()
   }
 
   if (!client_request->valid()) {
@@ -256,9 +254,7 @@ HttpTransactCache::SelectFromAlternates(CacheHTTPInfoVector *cache_vector, HTTPH
   }
   Debug("http_seq", "[SelectFromAlternates] Chosen alternate # %d", best_index);
   if (is_debug_tag_set("http_alts")) {
-    ACQUIRE_PRINT_LOCK()
     fprintf(stderr, "[alts] and the winner is alternate number %d\n", best_index);
-    RELEASE_PRINT_LOCK()
   }
 
   if ((best_index != -1) && (best_Q > unacceptable_Q)) {

--- a/proxy/http/HttpTransactCache.cc
+++ b/proxy/http/HttpTransactCache.cc
@@ -183,9 +183,6 @@ HttpTransactCache::SelectFromAlternates(CacheHTTPInfoVector *cache_vector, HTTPH
     fprintf(stderr, "[alts] There are %d alternates for this request header.\n", alt_count);
   }
 
-  if (!client_request->valid()) {
-    return 0;
-  }
   // so that plugins can make cache reads for http
   // docs to check if the doc exists in the cache
   if (!client_request->valid()) {


### PR DESCRIPTION
Removes some no-op macros and a duplicated validity check

