### PR TITLE
Remove proxy.config.config_dir from records.config

### DIFF
--- a/contrib/python/compare_RecordsConfigcc.py
+++ b/contrib/python/compare_RecordsConfigcc.py
@@ -39,7 +39,6 @@ ignore_keys = {
     "proxy.config.ssl.client.CA.cert.path": 1,
     "proxy.config.ssl.server.private_key.path": 1,
     "proxy.config.ssl.client.CA.cert.path": 1,
-    "proxy.config.config_dir": 1,
     "proxy.config.proxy_name": 1,
     "proxy.config.ssl.client.private_key.path": 1,
     "proxy.config.net.defer_accept": 1  # Specified in RecordsConfig.cc funny

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -22,12 +22,17 @@
 records.config
 **************
 
-The :file:`records.config` file (by default (:ts:cv:`proxy.config.config_dir`), located in
+The :file:`records.config` file (by default, located in
 ``/usr/local/etc/trafficserver/``) is a list of configurable variables used by
 the |TS| software. Many of the variables in :file:`records.config` are set
 automatically when you set configuration options with :option:`traffic_ctl config set`. After you
 modify :file:`records.config`, run the command :option:`traffic_ctl config reload`
 to apply the changes.
+
+Note: The configuration directory, containing the ``SYSCONFDIR`` value specified at build time
+relative to the installation prefix, contains Traffic Server configuration files.
+The ``$TS_ROOT`` environment variable can be used alter the installation prefix at run time.
+The directory must allow read/write access for configuration reloads.
 
 Format
 ======
@@ -204,15 +209,6 @@ System Variables
 
    The script executed before the :program:`traffic_manager` process spawns
    the :program:`traffic_server` process.
-
-.. ts:cv:: CONFIG proxy.config.config_dir STRING etc/trafficserver
-
-   The directory that contains Traffic Server configuration files.
-   This is a read-only configuration option that contains the
-   ``SYSCONFDIR`` value specified at build time relative to the
-   installation prefix. The ``$TS_ROOT`` environment variable can
-   be used alter the installation prefix at run time. The directory must
-   allow read/write access for configuration reloads.
 
 .. ts:cv:: CONFIG proxy.config.syslog_facility STRING LOG_DAEMON
 
@@ -3132,8 +3128,8 @@ SSL Termination
 
 .. ts:cv:: CONFIG proxy.config.ssl.servername.filename STRING ssl_server_name.yaml
 
-   The filename of the :file:`ssl_server_name.yaml` configuration file. If relative, it is relative to the
-   configuration directory (ts:cv:`proxy.config.config_dir`).
+   The filename of the :file:`ssl_server_name.yaml` configuration file.
+   If relative, it is relative to the configuration directory.
 
 .. ts:cv:: CONFIG proxy.config.ssl.max_record_size INT 0
 

--- a/doc/admin-guide/plugins/compress.en.rst
+++ b/doc/admin-guide/plugins/compress.en.rst
@@ -82,7 +82,7 @@ configuration provided with the plugin's source)::
    compress.so <path-to-plugin>/sample.compress.config
 
 This can be used as remap plugin by pointing to config file in remap rule
-:file:`remap.config`:: (relative to the ts:cv:`proxy.config.config_dir`)
+:file:`remap.config`::
 
    @plugin=compress.so @pparam=sample.compress.config
 

--- a/lib/perl/lib/Apache/TS/AdminClient.pm
+++ b/lib/perl/lib/Apache/TS/AdminClient.pm
@@ -358,7 +358,6 @@ The Apache Traffic Server Administration Manual will explain what these strings 
  proxy.config.cache.storage_filename
  proxy.config.cache.threads_per_disk
  proxy.config.cache.mutex_retry_delay
- proxy.config.config_dir
  proxy.config.cop.core_signal
  proxy.config.cop.linux_min_memfree_kb
  proxy.config.cop.linux_min_swapfree_kb

--- a/lib/records/I_RecCore.h
+++ b/lib/records/I_RecCore.h
@@ -47,19 +47,19 @@ typedef void (*RecConfigEntryCallback)(RecT rec_type, RecDataT data_type, const 
 void RecConfigFileInit(void);
 int RecConfigFileParse(const char *path, RecConfigEntryCallback handler, bool inc_version);
 
-// Return a copy of the system's configuration directory, taking proxy.config.config_dir into account. The
+// Return a copy of the system's configuration directory.
 std::string RecConfigReadConfigDir();
 
-// Return a copy of the system's local state directory, taking proxy.config.local_state_dir into account. The
+// Return a copy of the system's local state directory, taking proxy.config.local_state_dir into account.
 std::string RecConfigReadRuntimeDir();
 
-// Return a copy of the system's log directory, taking proxy.config.log.logfile_dir into account. The caller
+// Return a copy of the system's log directory, taking proxy.config.log.logfile_dir into account.
 std::string RecConfigReadLogDir();
 
-// Return a copy of the system's bin directory, taking proxy.config.bin_path into account. The caller MUST
+// Return a copy of the system's bin directory, taking proxy.config.bin_path into account.
 std::string RecConfigReadBinDir();
 
-// Return a copy of the system's plugin directory, taking proxy.config.plugin.plugin_dir into account. The caller MUST
+// Return a copy of the system's plugin directory, taking proxy.config.plugin.plugin_dir into account.
 std::string RecConfigReadPluginDir();
 
 // Return a copy of a configuration file that is relative to sysconfdir. The relative path to the configuration

--- a/lib/records/RecCore.cc
+++ b/lib/records/RecCore.cc
@@ -1120,23 +1120,14 @@ REC_readString(const char *name, bool *found, bool lock)
   return _tmp;
 }
 
-// RecConfigReadConfigDir. Note that we handle environmental configuration
-// overrides specially here. Normally we would override the configuration
-// variable when we read records.config but to avoid the bootstrapping
-// problem, we make an explicit check here.
+//-------------------------------------------------------------------------
+// RecConfigReadConfigDir
+//-------------------------------------------------------------------------
 std::string
 RecConfigReadConfigDir()
 {
-  char buf[PATH_NAME_MAX] = {0};
-
   if (const char *env = getenv("PROXY_CONFIG_CONFIG_DIR")) {
-    ink_strlcpy(buf, env, sizeof(buf));
-  } else {
-    RecGetRecordString("proxy.config.config_dir", buf, sizeof(buf));
-  }
-
-  if (strlen(buf) > 0) {
-    return Layout::get()->relative(buf);
+    return Layout::get()->relative(env);
   } else {
     return Layout::get()->sysconfdir;
   }

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -60,8 +60,6 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.env_prep", RECD_STRING, nullptr, RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.config_dir", RECD_STRING, TS_BUILD_SYSCONFDIR, RECU_RESTART_TM, RR_NULL, RECC_NULL, nullptr, RECA_READ_ONLY}
-  ,
   // Jira TS-21
   {RECT_CONFIG, "proxy.config.local_state_dir", RECD_STRING, TS_BUILD_RUNTIMEDIR, RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_READ_ONLY}
   ,


### PR DESCRIPTION
Logically, we are not supposed to read the `proxy.config.config_dir` from records.config. This config path value was read from a file (`records.config`) that is in the config path, which is a contradiction and may have potential problems. 

The config path is already nicely built in the Layout code from `TS_BUILD_SYSCONFDIR`. If specifically needed, the config path can be overwritten with Env variable: `PROXY_CONFIG_CONFIG_DIR`.

Something similar to this was talked about in https://github.com/apache/trafficserver/pull/2799 @dragon512 @SolidWallOfCode . But that PR which removes all path variables from `records.config` was too aggressive. Only the `proxy.config.config_dir` should be removed.