### PR TITLE
Runroot: add new option to specify layout during creating

### DIFF
--- a/doc/appendices/command-line/traffic_layout.en.rst
+++ b/doc/appendices/command-line/traffic_layout.en.rst
@@ -103,6 +103,10 @@ Options
 
     Specify the way of copying executables when creating runroot
 
+.. option:: --layout=[<YAML file>]
+
+    Use specific layout (providing YAML file) to create runroot
+
 ========
 Examples
 ========

--- a/lib/records/RecConfigParse.cc
+++ b/lib/records/RecConfigParse.cc
@@ -28,6 +28,7 @@
 #include "ts/Tokenizer.h"
 #include "ts/ink_defs.h"
 #include "ts/ink_string.h"
+#include "ts/runroot.h"
 
 #include "P_RecFile.h"
 #include "P_RecUtils.h"
@@ -83,6 +84,20 @@ RecFileImport_Xmalloc(const char *file, char **file_buf, int *file_size)
 }
 
 //-------------------------------------------------------------------------
+// RecConfigOverrideFromRunroot
+//-------------------------------------------------------------------------
+bool
+RecConfigOverrideFromRunroot(const char *name)
+{
+  if (use_runroot()) {
+    if (!strcmp(name, "proxy.config.bin_path") || !strcmp(name, "proxy.config.local_state_dir") ||
+        !strcmp(name, "proxy.config.log.logfile_dir") || !strcmp(name, "proxy.config.plugin.plugin_dir"))
+      return true;
+  }
+  return false;
+}
+
+//-------------------------------------------------------------------------
 // RecConfigOverrideFromEnvironment
 //-------------------------------------------------------------------------
 const char *
@@ -106,6 +121,8 @@ RecConfigOverrideFromEnvironment(const char *name, const char *value)
   envval = getenv((const char *)envname);
   if (envval) {
     return envval;
+  } else if (RecConfigOverrideFromRunroot(name)) {
+    return nullptr;
   }
 
   return value;

--- a/lib/ts/runroot.cc
+++ b/lib/ts/runroot.cc
@@ -246,3 +246,9 @@ check_runroot()
   }
   return runroot_map(using_runroot);
 }
+
+bool
+use_runroot()
+{
+  return !using_runroot.empty();
+}

--- a/lib/ts/runroot.h
+++ b/lib/ts/runroot.h
@@ -61,3 +61,6 @@ RunrootMapType runroot_map(const std::string &prefix);
 
 // help check runroot for layout
 RunrootMapType check_runroot();
+
+// helper method for records config to check using runroot or not
+bool use_runroot();

--- a/src/traffic_layout/engine.h
+++ b/src/traffic_layout/engine.h
@@ -29,8 +29,9 @@
 #include <string>
 #include <unordered_map>
 
-#define RUNROOT_WORD_LENGTH 10
-#define COPYSTYLE_WORD_LENGTH 12
+static const std::string_view RUNROOT_WORD{"--run-root"};
+static const std::string_view COPYSTYLE_WORD{"--copy-style"};
+static const std::string_view LAYOUT_WORD{"--layout"};
 
 typedef std::unordered_map<std::string, std::string> RunrootMapType;
 
@@ -73,6 +74,8 @@ struct RunrootEngine {
   bool verify_default = false;
   // for parsing
   int command_num = 0;
+
+  std::string layout_file;
 
   CopyStyle copy_style = HARD;
 

--- a/src/traffic_layout/file_system.cc
+++ b/src/traffic_layout/file_system.cc
@@ -191,7 +191,7 @@ ts_copy_function(const char *src_path, const struct stat *sb, int flag)
   std::string full_src_path = src_path;
   if (full_src_path == src_root) {
     if (!create_directory(dst_root)) {
-      ink_fatal("create directory failed during copy");
+      ink_fatal("create directory '%s' failed during copy", dst_root.c_str());
     }
     return 0;
   }

--- a/src/traffic_layout/traffic_layout.cc
+++ b/src/traffic_layout/traffic_layout.cc
@@ -46,7 +46,6 @@ struct subcommand {
 
 // Command line arguments (parsing)
 struct CommandLineArgs {
-  int layout;
   int features;
   int json;
 };
@@ -54,7 +53,6 @@ struct CommandLineArgs {
 static CommandLineArgs cl;
 
 const ArgumentDescription argument_descriptions[] = {
-  {"layout", 'l', "Show the layout (this is the default with no options given)", "T", &cl.layout, nullptr, nullptr},
   {"features", 'f', "Show the compiled features", "T", &cl.features, nullptr, nullptr},
   {"json", 'j', "Produce output in JSON format (when supported)", "T", &cl.json, nullptr, nullptr},
   VERSION_ARGUMENT_DESCRIPTION(),

--- a/tests/gold_tests/runroot/runroot_init.test.py
+++ b/tests/gold_tests/runroot/runroot_init.test.py
@@ -66,7 +66,8 @@ tr.Processes.Default.Streams.All = Testers.ContainsExpression("Forcing creating 
 path5 = os.path.join(ts_root, "runroot5")
 junk1 = os.path.join(path1, "bin/junk1")
 junk2 = os.path.join(path1, "lib/junk2")
-junk3 = os.path.join(path1, "include/junk3")
+junk3 = os.path.join(path1, "var/junk3")
+
 tr = Test.AddTestRun("Test traffic_layout init #5")
 # create the junk files in runroot1 and create(init and copy) runroot5 from runroot 1
 tr.Processes.Default.Command = "touch " + junk1 + ";" + "touch " + junk2 + ";" + \
@@ -77,13 +78,13 @@ f.Exists = True
 # check if the junk file is created and not copied to the new runroot
 f = tr.Disk.File(junk1)
 f.Exists = True
-f = tr.Disk.File(os.path.join(path5, "bin/junk"))
+f = tr.Disk.File(os.path.join(path5, "bin/junk1"))
 f.Exists = False
 f = tr.Disk.File(junk2)
 f.Exists = True
-f = tr.Disk.File(os.path.join(path5, "lib/junk"))
+f = tr.Disk.File(os.path.join(path5, "lib/junk2"))
 f.Exists = False
 f = tr.Disk.File(junk3)
 f.Exists = True
-f = tr.Disk.File(os.path.join(path5, "include/junk"))
+f = tr.Disk.File(os.path.join(path5, "var/junk3"))
 f.Exists = False


### PR DESCRIPTION
With this option, the user is able to create the runroot given a specific YAML file to use the layout in it.

It performs some overwrite of the path config variable proxy.config... to make the record read the correct runroot path from the `Layout` object

One previous test is also updated.

This PR depends on https://github.com/apache/trafficserver/pull/3930 and https://github.com/apache/trafficserver/pull/3941