### PR TITLE
cachekey: running as global plugin

### DIFF
--- a/doc/admin-guide/plugins/cachekey.en.rst
+++ b/doc/admin-guide/plugins/cachekey.en.rst
@@ -177,6 +177,46 @@ Cache key elements separator
 * ``--separator=<string>`` - the cache key is constructed by extracting elements from HTTP URI and headers or by using the UA classifiers and they are appended during the key construction and separated by ``/`` (by default). This options allows to override the default separator to any string (including an empty string).
 
 
+How to run the plugin
+=====================
+
+The plugin can run as a global plugin (a single global instance configured using `plugin.config`) or as per-remap plugin (a separate instance configured per remap rule in `remap.config`).
+
+Global instance
+^^^^^^^^^^^^^^^
+
+::
+
+  $ cat plugin.config
+  cachekey.so \
+      --include-params=a,b,c \
+      --sort-params=true
+
+
+Per-remap instance
+^^^^^^^^^^^^^^^^^^
+
+::
+
+  $cat remap.config
+  map http://www.example.com http://www.origin.com \
+      @plugin=cachekey.so \
+          @pparam=--include-params=a,b,c \
+          @pparam=--sort-params=true
+
+
+If both global and per-remap instance are used the per-remap configuration would take precedence (per-remap configuration would be applied and the global configuration ignored).
+
+Because of the ATS core (remap) and the CacheKey plugin implementation there is a slight difference between the global and the per-remap functionality when ``--uri-type=remap`` is used.
+
+* The global instance always uses the URI **after** remap (at ``TS_HTTP_POST_REMAP_HOOK``).
+
+* The per-remap instance uses the URI **during** remap (after ``TS_HTTP_PRE_REMAP_HOOK`` and  before ``TS_HTTP_POST_REMAP_HOOK``) which leads to a different URI to be used depending on plugin order in the remap rule.
+
+    * If CacheKey plugin is the first plugin in the remap rule the URI used will be practically the same as the pristine URI.
+    * If the CacheKey plugin is the last plugin in the remap rule (which is right before ``TS_HTTP_POST_REMAP_HOOK``) the behavior will be simillar to the global instnance.
+
+
 Detailed examples and troubleshooting
 =====================================
 

--- a/plugins/cachekey/cachekey.h
+++ b/plugins/cachekey/cachekey.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include "ts/ts.h"
+#include "ts/remap.h"
 #include "common.h"
 #include "configs.h"
 
@@ -48,7 +50,8 @@
 class CacheKey
 {
 public:
-  CacheKey(TSHttpTxn txn, TSMBuffer buf, TSMLoc url, TSMLoc hdrs, String separator);
+  CacheKey(TSHttpTxn txn, String separator, CacheKeyUriType urlType, TSRemapRequestInfo *rri = nullptr);
+  ~CacheKey();
 
   void append(unsigned number);
   void append(const String &);
@@ -71,11 +74,14 @@ private:
   CacheKey(); // disallow
 
   /* Information from the request */
-  TSHttpTxn _txn; /**< @brief transaction handle */
-  TSMBuffer _buf; /**< @brief marshal buffer */
-  TSMLoc _url;    /**< @brief URI handle */
-  TSMLoc _hdrs;   /**< @brief headers handle */
+  TSHttpTxn _txn;      /**< @brief transaction handle */
+  TSMBuffer _buf;      /**< @brief marshal buffer */
+  TSMLoc _url;         /**< @brief URI handle */
+  TSMLoc _hdrs;        /**< @brief headers handle */
+  bool _valid = false; /**< @brief shows if the constructor discovered the input correctly */
+  bool _remap = false; /**< @brief shows if the input URI was from remap info */
 
-  String _key;       /**< @brief cache key */
-  String _separator; /**< @brief a separator used to separate the cache key elements extracted from the URI */
+  String _key;              /**< @brief cache key */
+  String _separator;        /**< @brief a separator used to separate the cache key elements extracted from the URI */
+  CacheKeyUriType _uriType; /**< @brief the URI type used as a cachekey base: pristine, remap, etc. */
 };

--- a/plugins/cachekey/configs.cc
+++ b/plugins/cachekey/configs.cc
@@ -321,9 +321,11 @@ Configs::loadClassifiers(const String &args, bool blacklist)
  * @brief initializes plugin configuration.
  * @param argc number of plugin parameters
  * @param argv plugin parameters
+ * @param perRemapConfig boolean showing if this is per-remap config (vs global config).
+ *
  */
 bool
-Configs::init(int argc, char *argv[])
+Configs::init(int argc, const char *argv[], bool perRemapConfig)
 {
   static const struct option longopt[] = {
     {const_cast<char *>("exclude-params"), optional_argument, nullptr, 'a'},
@@ -351,9 +353,12 @@ Configs::init(int argc, char *argv[])
 
   bool status = true;
 
-  /* argv contains the "to" and "from" URLs. Skip the first so that the second one poses as the program name. */
-  argc--;
-  argv++;
+  /* For remap.config: argv contains the "to" and "from" URLs. Skip the first so that the second one poses as the program name.
+   * For plugin.config: argv contains the plugin shared object name. Don't skip any */
+  if (perRemapConfig) {
+    argc--;
+    argv++;
+  }
 
   for (;;) {
     int opt;

--- a/plugins/cachekey/configs.h
+++ b/plugins/cachekey/configs.h
@@ -131,8 +131,9 @@ public:
    * @brief initializes plugin configuration.
    * @param argc number of plugin parameters
    * @param argv plugin parameters
+   * @param perRemapConfig boolean showing if this is per-remap config (vs global config).
    */
-  bool init(int argc, char *argv[]);
+  bool init(int argc, const char *argv[], bool perRemapConfig);
 
   /**
    * @brief provides means for post-processing of the plugin parameters to finalize the configuration or to "cache" some of the


### PR DESCRIPTION
The plugin can now run as a global plugin (a single global instance
configured using `plugin.config`) or as per-remap plugin
(a separate instance configured per remap rule in `remap.config`).

If both global and per-remap instance are used the per-remap
configuration would take precedence (per-remap configuration
would be applied and the global configuration ignored).