### PR TITLE
Fix RecConfigReadPluginDir and clean up RecCore

### DIFF
--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -143,7 +143,7 @@ set_paths_helper(const char *path, const char *filename, char **final_path, char
 {
   if (final_path) {
     if (path && path[0] != '/') {
-      *final_path = ats_stringdup(RecConfigReadPrefixPath(nullptr, path));
+      *final_path = ats_stringdup(Layout::get()->relative_to(Layout::get()->prefix, path));
     } else if (!path || path[0] == '\0') {
       *final_path = ats_stringdup(RecConfigReadConfigDir());
     } else {

--- a/lib/records/I_RecCore.h
+++ b/lib/records/I_RecCore.h
@@ -67,9 +67,6 @@ std::string RecConfigReadPluginDir();
 // value, nullptr is returned.
 std::string RecConfigReadConfigPath(const char *file_variable, const char *default_value = nullptr);
 
-// This is the same as RecConfigReadConfigPath, except it makes the paths relative to $PREFIX.
-std::string RecConfigReadPrefixPath(const char *file_variable, const char *default_value = nullptr);
-
 // Return a copy of the persistent stats file. This is $RUNTIMEDIR/records.snap.
 std::string RecConfigReadPersistentStatsPath();
 

--- a/lib/records/RecCore.cc
+++ b/lib/records/RecCore.cc
@@ -1199,7 +1199,15 @@ RecConfigReadBinDir()
 std::string
 RecConfigReadPluginDir()
 {
-  return RecConfigReadPrefixPath("proxy.config.plugin.plugin_dir");
+  char buf[PATH_NAME_MAX];
+
+  buf[0] = '\0';
+  RecGetRecordString("proxy.config.plugin.plugin_dir", buf, PATH_NAME_MAX);
+  if (strlen(buf) > 0) {
+    return Layout::get()->relative(buf);
+  } else {
+    return Layout::get()->libexecdir;
+  }
 }
 
 //-------------------------------------------------------------------------
@@ -1224,31 +1232,6 @@ RecConfigReadConfigPath(const char *file_variable, const char *default_value)
   // Otherwise take the default ...
   if (default_value) {
     return Layout::get()->relative_to(sysconfdir, default_value);
-  }
-
-  return {};
-}
-
-//-------------------------------------------------------------------------
-// RecConfigReadPrefixPath
-//-------------------------------------------------------------------------
-std::string
-RecConfigReadPrefixPath(const char *file_variable, const char *default_value)
-{
-  char buf[PATH_NAME_MAX];
-
-  // If the file name is in a configuration variable, look it up first ...
-  if (file_variable) {
-    buf[0] = '\0';
-    RecGetRecordString(file_variable, buf, PATH_NAME_MAX);
-    if (strlen(buf) > 0) {
-      return Layout::get()->relative_to(Layout::get()->prefix, buf);
-    }
-  }
-
-  // Otherwise take the default ...
-  if (default_value) {
-    return Layout::get()->relative_to(Layout::get()->prefix, default_value);
   }
 
   return {};


### PR DESCRIPTION
The method `RecConfigReadPluginDir()` cannot get the plugin directory `libexecdir` correctly from the `Layout` object if the `proxy.config.plugin.plugin_dir` is not set perfectly. 

The method `RecConfigReadPrefixPath` is also removed.