### PR TITLE
Handle response parsing case where EOF happens before any data arrives.

### DIFF
--- a/proxy/hdrs/HdrTSOnly.cc
+++ b/proxy/hdrs/HdrTSOnly.cc
@@ -100,13 +100,21 @@ HTTPHdr::parse_resp(HTTPParser *parser, IOBufferReader *r, int *bytes_used, bool
 
   do {
     int64_t b_avail = r->block_read_avail();
+    tmp = start = r->start();
 
-    if (b_avail <= 0 && eof == false) {
-      break;
+    // No data currently available.
+    if (b_avail <= 0) {
+      if (eof == false) { // more data may arrive later, return CONTINUE state.
+        break;
+      } else if (nullptr == start) {
+        // EOF on empty MIOBuffer - that's a fail, don't bother with parsing.
+        // (otherwise will attempt to attach_block a non-existent block)
+        state = PARSE_RESULT_ERROR;
+        break;
+      }
     }
 
-    tmp = start = r->start();
-    end         = start + b_avail;
+    end = start + b_avail;
 
     int heap_slot = m_heap->attach_block(r->get_current_block(), start);
 


### PR DESCRIPTION
We have had this crash in production. The root cause is `parse_resp` is called with `eof == true` and no data in the `MIOBuffer` for the reader. This means there is no current block at all for the reader and the call to `m_heap->attach_block` fails trying to attach a non-existent (`nullptr`) block. This change looks for that and directly fails because if the upstream is EOF and no data ever arrived, that's a parse fail.