### PR TITLE
Fix bug on loading speed up for lua script

### DIFF
--- a/plugins/lua/ts_lua.c
+++ b/plugins/lua/ts_lua.c
@@ -133,8 +133,9 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_s
     }
 
     memset(conf, 0, sizeof(ts_lua_instance_conf));
-    conf->states = states;
-    conf->remap  = 1;
+    conf->states    = states;
+    conf->remap     = 1;
+    conf->init_func = 0;
 
     if (fn) {
       snprintf(conf->script, TS_LUA_MAX_SCRIPT_FNAME_LENGTH, "%s", argv[optind]);
@@ -150,7 +151,8 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_s
       return TS_ERROR;
     }
 
-    if (fn) {
+    // register the script only if it is from a file and has no __init__ function
+    if (fn && !conf->init_func) {
       // we only need to register the script for the first lua VM
       ts_lua_script_register(ts_lua_main_ctx_array[0].lua, conf->script, conf);
     }

--- a/plugins/lua/ts_lua_common.h
+++ b/plugins/lua/ts_lua_common.h
@@ -97,6 +97,8 @@ typedef struct {
 
   int remap;
   int states;
+
+  int init_func;
 } ts_lua_instance_conf;
 
 /* lua state for http request */

--- a/plugins/lua/ts_lua_util.c
+++ b/plugins/lua/ts_lua_util.c
@@ -227,6 +227,9 @@ ts_lua_add_module(ts_lua_instance_conf *conf, ts_lua_main_ctx *arr, int n, int a
     lua_getglobal(L, "__init__");
 
     if (lua_type(L, -1) == LUA_TFUNCTION) {
+      // specifying that the file has an __init__ function
+      conf->init_func = 1;
+
       lua_newtable(L);
 
       for (t = 0; t < argc; t++) {


### PR DESCRIPTION
There was an enhancement on ats_lua plugin in ATS7 - #2696
The enhancement allows the speed up of the loading of lua plugin during start up time. Basically script with the same name and no extra parameter will not be loaded and initialized for subsequence line in remap.config again. The assumption is that if the script name is the same and there is no parameter, we can assume that the context can be shared across rules.

However, we did not take care of the case when the same script can be run with or without parameter and the context for these rules will still need to be separate. The fix is to check if the script has __init__ function or not and stop doing these kinds of speedup for the script. 