### PR TITLE
Fixed http/2 issue with Http2Stream being updated after it was destroyed

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -679,6 +679,7 @@ void
 Http2Stream::send_response_body(bool call_update)
 {
   Http2ClientSession *parent = static_cast<Http2ClientSession *>(this->get_parent());
+  inactive_timeout_at        = Thread::get_hrtime() + inactive_timeout;
 
   if (Http2::stream_priority_enabled) {
     SCOPED_MUTEX_LOCK(lock, parent->connection_state.mutex, this_ethread());
@@ -689,8 +690,9 @@ Http2Stream::send_response_body(bool call_update)
     SCOPED_MUTEX_LOCK(lock, parent->connection_state.mutex, this_ethread());
     parent->connection_state.send_data_frames(this);
     this->signal_write_event(call_update);
+    // XXX The call to signal_write_event can destroy/free the Http2Stream.
+    // Don't modify the Http2Stream after calling this method.
   }
-  inactive_timeout_at = Thread::get_hrtime() + inactive_timeout;
 }
 
 void


### PR DESCRIPTION
This fixes issue #3944.

The problem is that in Http2Stream::send_response_body() the call to this->signal_write_event() can destroy the Http2Stream and after returning from the method we update the objects inactivity timeout.

I changed to so that the inactivity timeout gets updated before the method call.