### PR TITLE
Cleans up brotli compiler and linker flags

### DIFF
--- a/build/brotli.m4
+++ b/build/brotli.m4
@@ -31,8 +31,8 @@ AC_ARG_WITH(brotli, [AC_HELP_STRING([--with-brotli=DIR],[use a specific brotli l
       has_brotli=1
       case "$withval" in
       *":"*)
-        brotli_include="`echo $withval |sed -e 's/:.*$//'`"
-        brotli_ldflags="`echo $withval |sed -e 's/^.*://'`"
+        brotli_include="`echo $withval | sed -e 's/:.*$//'`"
+        brotli_ldflags="`echo $withval | sed -e 's/^.*://'`"
         AC_MSG_CHECKING(checking for brotli includes in $brotli_include libs in $brotli_ldflags )
         ;;
       *)
@@ -66,8 +66,8 @@ if test "$has_brotli" != "0"; then
     AC_CHECK_HEADERS(brotli/encode.h, [brotli_have_headers=1])
   fi
   if test "$brotli_have_headers" != "0"; then
-    AC_SUBST([LIB_BROTLIENC], [-lbrotlienc])
-    AC_SUBST([CFLAGS_BROTLIENC], [-I${brotli_include}])
+    AC_SUBST([BROTLIENC_LIB], [-lbrotlienc])
+    AC_SUBST([BROTLIENC_CFLAGS], [-I${brotli_include}])
   else
     has_brotli=0
     CPPFLAGS=$saved_cppflags
@@ -80,15 +80,15 @@ AC_CHECK_HEADER([brotli/encode.h], [], [has_brotli=0])
 AC_CHECK_LIB([brotlienc], BrotliEncoderCreateInstance, [], [has_brotli=0])
 
 if test "x$has_brotli" == "x0"; then
-    PKG_CHECK_EXISTS([libbrotlienc],
+    PKG_CHECK_EXISTS([LIBBROTLIENC],
     [
-      PKG_CHECK_MODULES([libbrotlienc], [libbrotlienc >= 0.6.0], [
-        AC_SUBST([LIB_BROTLIENC], [$libbrotlienc_LIBS])
-        AC_SUBST([CFLAGS_BROTLIENC], [$libbrotlienc_CFLAGS])
+      PKG_CHECK_MODULES([LIBBROTLIENC], [libbrotlienc >= 0.6.0], [
+        AC_SUBST([BROTLIENC_LIB], [$LIBBROTLIENC_LIBS])
+        AC_SUBST([BROTLIENC_CFLAGS], [$LIBBROTLIENC_CFLAGS])
       ], [])
     ], [])
 else
-    AC_SUBST([LIB_BROTLIENC], [-lbrotlienc])
+    AC_SUBST([BROTLIENC_LIB], [-lbrotlienc])
 fi
 ])
 

--- a/plugins/compress/Makefile.inc
+++ b/plugins/compress/Makefile.inc
@@ -18,6 +18,6 @@ pkglib_LTLIBRARIES += compress/compress.la
 compress_compress_la_SOURCES = compress/compress.cc compress/configuration.cc compress/misc.cc
 
 compress_compress_la_LDFLAGS = \
-  $(AM_LDFLAGS) $(LIB_BROTLIENC)
+  $(AM_LDFLAGS) $(BROTLIENC_LIB)
 
-compress_compress_la_CXXFLAGS = $(AM_CXXFLAGS) $(CFLAGS_BROTLIENC)
+compress_compress_la_CXXFLAGS = $(AM_CXXFLAGS) $(BROTLIENC_CFLAGS)


### PR DESCRIPTION
Use more standard form of X_FLAGS variable naming and switch to
uppercase LIBBROTLIENC for pkg-config to match other libraries