### PR TITLE
Clearout shutdown_cont_event when the event has been processed

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1006,6 +1006,8 @@ Http2ConnectionState::state_closed(int /* event */, void *edata)
     ink_release_assert(zombie_event == nullptr);
   } else if (edata == fini_event) {
     fini_event = nullptr;
+  } else if (edata == shutdown_cont_event) {
+    shutdown_cont_event = nullptr;
   }
   return 0;
 }


### PR DESCRIPTION
`shutdown_cont_event` was cleared out in `main_event_handler` but not in `state_closed`. It can cause a crash during ATS is draining connections.