### PR TITLE
Restrict access to request headers for ESI variables

### DIFF
--- a/doc/admin-guide/plugins/esi.en.rst
+++ b/doc/admin-guide/plugins/esi.en.rst
@@ -151,4 +151,4 @@ Differences from Spec - http://www.w3.org/TR/esi-lang
 
 5. HTTP_COOKIE supports fetching for sub-key
 
-6. HTTP_HEADER supports accessing request headers as variables
+6. HTTP_HEADER supports accessing request headers as variables except "Cookie"

--- a/plugins/experimental/esi/lib/Variables.cc
+++ b/plugins/experimental/esi/lib/Variables.cc
@@ -235,6 +235,12 @@ Variables::getValue(const string &name) const
     return EMPTY_STRING;
   }
 
+  // Disallow Cookie retrieval though HTTP_HEADER
+  if (dict_index == HTTP_HEADER && ((attr_len == 6) && (strncasecmp(attr, "Cookie", 6) == 0))) {
+    _errorLog("[%s] Cannot use HTTP_HEADER to retrieve Cookie", __FUNCTION__);
+    return EMPTY_STRING;
+  }
+
   // change variable name to use only the attribute field
   search_key.assign(attr, attr_len);
 

--- a/plugins/experimental/esi/test/vars_test.cc
+++ b/plugins/experimental/esi/test/vars_test.cc
@@ -418,12 +418,14 @@ main()
     esi_vars.populate(HttpHeader("hdr1", -1, "hval1", -1));
     esi_vars.populate(HttpHeader("Hdr2", -1, "hval2", -1));
     esi_vars.populate(HttpHeader("@Intenal-hdr1", -1, "internal-hval1", -1));
+    esi_vars.populate(HttpHeader("cookie", -1, "x=y", -1));
 
     assert(esi_vars.getValue("HTTP_HEADER{hdr1}") == "hval1");
     assert(esi_vars.getValue("HTTP_HEADER{hdr2}") == "");
     assert(esi_vars.getValue("HTTP_HEADER{Hdr2}") == "hval2");
     assert(esi_vars.getValue("HTTP_HEADER{non-existent}") == "");
     assert(esi_vars.getValue("HTTP_HEADER{@Intenal-hdr1}") == "internal-hval1");
+    assert(esi_vars.getValue("HTTP_HEADER{cookie}") == "");
   }
 
   cout << endl << "All tests passed!" << endl;


### PR DESCRIPTION
(cherry picked from commit 2f4a5b7a3eb4904d59913d4b38e54a4caeecceae)

 Conflicts:
	plugins/esi/lib/Variables.cc
	plugins/esi/test/vars_test.cc