### PR TITLE
Avoid an assertion in a rare case of PUSH

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -2427,7 +2427,7 @@ HttpSM::state_cache_open_write(int event, void *data)
 
       return 0;
     }
-  // Fallthrough
+    break;
   default:
     ink_release_assert(0);
   }


### PR DESCRIPTION
I'm not 100% positive about this, but the hope is that instead of asserting (essentially crashing) we can just close down this transaction.