### PR TITLE
Fixes some var-args missing va_start/end

### DIFF
--- a/lib/ts/ink_sprintf.cc
+++ b/lib/ts/ink_sprintf.cc
@@ -69,6 +69,7 @@ ink_bvsprintf(char *buffer, const char *format, va_list ap)
   const char *s;
   char *d, *p, *s_val, d_buffer[32];
   va_list ap_local;
+
   va_copy(ap_local, ap);
 
   s = format;

--- a/proxy/http/HttpBodyFactory.h
+++ b/proxy/http/HttpBodyFactory.h
@@ -162,15 +162,21 @@ public:
   getFormat(int64_t max_buffer_length, int64_t *resulting_buffer_length, const char *format, ...)
   {
     char *msg = nullptr;
-    va_list ap;
     if (format) {
+      va_list ap;
+
+      va_start(ap, format);
+
       // The length from ink_bvsprintf includes the trailing NUL, so adjust the final
-      // length accordingly.
+      // length accordingly. Note that ink_bvsprintf() copies the va_list, so we only
+      // have to set it up once.
       int l = ink_bvsprintf(nullptr, format, ap);
+
       if (l <= max_buffer_length) {
         msg                      = (char *)ats_malloc(l);
         *resulting_buffer_length = ink_bvsprintf(msg, format, ap) - 1;
       }
+      va_end(ap);
     }
     return msg;
   }


### PR DESCRIPTION
This was introduced in

     https://github.com/apache/trafficserver/pull/1299

But, the good news is that this has not been part of a release.