### PR TITLE
cachekey: capture cache key elements from headers

### DIFF
--- a/doc/admin-guide/plugins/cachekey.en.rst
+++ b/doc/admin-guide/plugins/cachekey.en.rst
@@ -110,14 +110,16 @@ Cache key structure and related plugin parameters
 
 ::
 
-  Optional components      | ┌───────────────────┐
-                           | │ --include-headers │
-                           | ├───────────────────┤
-  Default values if no     | │ (empty)           |
-  optional components      | └───────────────────┘
+  Optional components      | ┌───────────────────┬────────────────────┐
+                           | │ --include-headers │  --capture-headers │
+                           | ├────────────────────────────────────────┤
+  Default values if no     | │ (empty)           |  (empty)           |
+  optional components      | └───────────────────┴────────────────────┘
   configured               |
 
-* ``--include-headers`` (default: empty list) - comma separated list of headers to be added to the cache key. The list of headers defined by ``--include-headers`` are always sorted before adding them to the cache  key.
+* ``--include-headers`` (default: empty list) - comma separated list of headers to be added to the cache key. The list of headers defined by ``--include-headers`` are always sorted before adding them to the cache key.
+
+* ``--capture-header=<headername>:<capture_definition>`` (default: empty) - captures elements from header <headername> using <capture_definition> and adds them to the cache key.
 
 "Cookies" section
 ^^^^^^^^^^^^^^^^^
@@ -399,6 +401,21 @@ Include certain headers in the cache key
 The following headers ``HeaderA`` and ``HeaderB`` will be used when constructing the cache key and the rest will be ignored. ::
 
   @plugin=cachekey.so @pparam=--include-headers=HeaderA,HeaderB
+
+The following would capture from the ``Authorization`` header and will add the captured element to the cache key ::
+
+  @plugin=cachekey.so \
+      @pparam=--capture-header=Authorization:/AWS\s(?<clientID>[^:]+).*/clientID:$1/"
+
+If the request looks like the following::
+
+  http://example-cdn.com/path/file
+  Authorization: AWS MKIARYMOG51PT0DLD:DLiWQ2lyS49H4Zyx34kW0URtg6s=
+
+Cache key would be set to::
+
+  /example-cdn.com/80/clientID:MKIARYMOG51PTCKQ0DLD/path/file
+
 
 HTTP Cookies
 ^^^^^^^^^^^^

--- a/plugins/cachekey/cachekey.h
+++ b/plugins/cachekey/cachekey.h
@@ -73,6 +73,10 @@ public:
 private:
   CacheKey(); // disallow
 
+  template <class T>
+  void processHeader(const String &name_s, const ConfigHeaders &config, T &dst,
+                     void (*fun)(const ConfigHeaders &config, const String &name_s, const String &value_s, T &captures));
+
   /* Information from the request */
   TSHttpTxn _txn;      /**< @brief transaction handle */
   TSMBuffer _buf;      /**< @brief marshal buffer */

--- a/plugins/cachekey/common.h
+++ b/plugins/cachekey/common.h
@@ -26,11 +26,13 @@
 #define PLUGIN_NAME "cachekey"
 
 #include <string>
+#include <string_view>
 #include <set>
 #include <list>
 #include <vector>
 
 typedef std::string String;
+typedef std::string_view StringView;
 typedef std::set<std::string> StringSet;
 typedef std::list<std::string> StringList;
 typedef std::vector<std::string> StringVector;

--- a/plugins/cachekey/configs.cc
+++ b/plugins/cachekey/configs.cc
@@ -70,6 +70,47 @@ setPattern(MultiPattern &multiPattern, const char *arg)
   }
 }
 
+bool
+ConfigElements::setCapture(const String &name, const String &pattern)
+{
+  auto it = _captures.find(name);
+  if (_captures.end() == it) {
+    auto mp = new MultiPattern(name);
+    if (nullptr != mp) {
+      _captures[name] = mp;
+    } else {
+      return false;
+    }
+  }
+  setPattern(*_captures[name], pattern.c_str());
+  CacheKeyDebug("added capture pattern '%s' for element '%s'", pattern.c_str(), name.c_str());
+  return true;
+}
+
+void
+ConfigElements::addCapture(const char *arg)
+{
+  StringView args(arg);
+  StringView::size_type pos = args.find_first_of(':');
+  if (StringView::npos != pos) {
+    String name(args.substr(0, pos));
+    if (!name.empty()) {
+      String pattern(args.substr(pos + 1));
+      if (!pattern.empty()) {
+        if (!setCapture(name, pattern)) {
+          CacheKeyError("failed to add capture: '%s'", arg);
+        }
+      } else {
+        CacheKeyError("missing pattern in capture: '%s'", arg);
+      }
+    } else {
+      CacheKeyError("missing element name in capture: %s", arg);
+    }
+  } else {
+    CacheKeyError("invalid capture: %s, should be 'name:<capture_definition>", arg);
+  }
+}
+
 void
 ConfigElements::setExcludePatterns(const char *arg)
 {
@@ -138,6 +179,13 @@ inline bool
 ConfigElements::noIncludeExcludeRules() const
 {
   return _exclude.empty() && _excludePatterns.empty() && _include.empty() && _includePatterns.empty();
+}
+
+ConfigElements::~ConfigElements()
+{
+  for (auto it = _captures.begin(); it != _captures.end(); it++) {
+    delete it->second;
+  }
 }
 
 /**
@@ -348,6 +396,7 @@ Configs::init(int argc, const char *argv[], bool perRemapConfig)
     {const_cast<char *>("remove-path"), optional_argument, nullptr, 'r'},
     {const_cast<char *>("separator"), optional_argument, nullptr, 's'},
     {const_cast<char *>("uri-type"), optional_argument, nullptr, 't'},
+    {const_cast<char *>("capture-header"), optional_argument, nullptr, 'u'},
     {nullptr, 0, nullptr, 0},
   };
 
@@ -451,6 +500,9 @@ Configs::init(int argc, const char *argv[], bool perRemapConfig)
       break;
     case 't': /* uri-type */
       setUriType(optarg);
+      break;
+    case 'u': /* capture-header */
+      _headers.addCapture(optarg);
       break;
     }
   }

--- a/plugins/cachekey/configs.h
+++ b/plugins/cachekey/configs.h
@@ -26,6 +26,8 @@
 #include "pattern.h"
 #include "common.h"
 
+#include <map>
+
 enum CacheKeyUriType {
   REMAP,
   PRISTINE,
@@ -40,14 +42,19 @@ class ConfigElements
 {
 public:
   ConfigElements() : _sort(false), _remove(false), _skip(false) {}
-  virtual ~ConfigElements() {}
+  virtual ~ConfigElements();
   void setExclude(const char *arg);
   void setInclude(const char *arg);
   void setExcludePatterns(const char *arg);
   void setIncludePatterns(const char *arg);
   void setRemove(const char *arg);
   void setSort(const char *arg);
-
+  void addCapture(const char *arg);
+  const auto &
+  getCaptures() const
+  {
+    return _captures;
+  }
   /** @brief shows if the elements are to be sorted in the result */
   bool toBeSorted() const;
   /** @brief shows if the elements are to be removed from the result */
@@ -67,6 +74,7 @@ public:
 
 protected:
   bool noIncludeExcludeRules() const;
+  bool setCapture(const String &name, const String &pattern);
 
   StringSet _exclude;
   StringSet _include;
@@ -77,6 +85,8 @@ protected:
   bool _sort;
   bool _remove;
   bool _skip;
+
+  std::map<String, MultiPattern *> _captures;
 };
 
 /**

--- a/plugins/cachekey/pattern.cc
+++ b/plugins/cachekey/pattern.cc
@@ -452,6 +452,18 @@ MultiPattern::name() const
   return _name;
 }
 
+bool
+MultiPattern::process(const String &subject, StringVector &result) const
+{
+  bool res = false;
+  for (auto p : this->_list) {
+    if (nullptr != p && p->process(subject, result)) {
+      res = true;
+    }
+  }
+  return res;
+}
+
 /**
  * @brief Destructor, deletes all multi-patterns.
  */

--- a/plugins/cachekey/pattern.h
+++ b/plugins/cachekey/pattern.h
@@ -85,6 +85,8 @@ public:
   virtual bool match(const String &subject) const;
   const String &name() const;
 
+  bool process(const String &subject, StringVector &result) const;
+
 protected:
   std::vector<Pattern *> _list; /**< @brief vector which dictates the order of the pattern evaluation. */
   String _name;                 /**< @brief multi-pattern name */


### PR DESCRIPTION
`--capture-header=<headername>:<capture_definition>`
captures elements from header `<headername>` using `<capture_definition>`
and adds them to the cache key.