### PR TITLE
add API to replace OCSP refresh function

### DIFF
--- a/iocore/net/OCSPStapling.cc
+++ b/iocore/net/OCSPStapling.cc
@@ -360,6 +360,16 @@ err:
   goto done;
 }
 
+static bool
+ocsp_refresher(certinfo *cinf, OCSP_RESPONSE **prsp)
+{
+  if (SSLConfigParams::ocsp_refresh_cb != NULL) {
+    return SSLConfigParams::ocsp_refresh_cb(cinf, prsp);
+  } else {
+    return stapling_refresh_response(cinf, prsp);
+  }
+}
+
 void
 ocsp_update()
 {
@@ -381,7 +391,7 @@ ocsp_update()
         current_time = time(NULL);
         if (cinf->resp_derlen == 0 || cinf->is_expire || cinf->expire_time < current_time) {
           ink_mutex_release(&cinf->stapling_mutex);
-          if (stapling_refresh_response(cinf, &resp)) {
+          if (ocsp_refresher(cinf, &resp)) {
             Note("Success to refresh OCSP response for 1 certificate.");
           } else {
             Note("Fail to refresh OCSP response for 1 certificate.");

--- a/iocore/net/P_SSLConfig.h
+++ b/iocore/net/P_SSLConfig.h
@@ -36,6 +36,8 @@
 #include "ts/ink_inet.h"
 
 struct SSLCertLookup;
+struct certinfo;
+typedef struct ocsp_response_st OCSP_RESPONSE;
 
 /////////////////////////////////////////////////////////////
 //
@@ -47,6 +49,7 @@ struct SSLCertLookup;
 
 typedef void (*init_ssl_ctx_func)(void *, bool);
 typedef void (*load_ssl_file_func)(const char *, unsigned int);
+typedef bool (*ocsp_refresh_func)(certinfo *, OCSP_RESPONSE **);
 
 struct SSLConfigParams : public ConfigInfo {
   enum SSL_SESSION_CACHE_MODE {
@@ -108,6 +111,8 @@ struct SSLConfigParams : public ConfigInfo {
 
   static init_ssl_ctx_func init_ssl_ctx_cb;
   static load_ssl_file_func load_ssl_file_cb;
+
+  static ocsp_refresh_func ocsp_refresh_cb;
 
   void initialize();
   void cleanup();

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -54,6 +54,7 @@ bool SSLConfigParams::session_cache_skip_on_lock_contention = false;
 size_t SSLConfigParams::session_cache_max_bucket_size       = 100;
 init_ssl_ctx_func SSLConfigParams::init_ssl_ctx_cb          = NULL;
 load_ssl_file_func SSLConfigParams::load_ssl_file_cb        = NULL;
+ocsp_refresh_func SSLConfigParams::ocsp_refresh_cb          = NULL;
 
 // TS-3534 Wiretracing for SSL Connections
 int SSLConfigParams::ssl_wire_trace_enabled       = 0;

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -42,6 +42,7 @@
 #include "P_UDPNet.h"
 #include "P_HostDB.h"
 #include "P_Cache.h"
+#include "P_SSLConfig.h"
 #include "I_RecCore.h"
 #include "ProxyConfig.h"
 #include "Plugin.h"
@@ -8936,4 +8937,20 @@ TSVConnReenable(TSVConn vconn)
       ssl_vc->thread->schedule_imm(new TSSslCallback(ssl_vc));
     }
   }
+}
+
+void
+TSRegisterOCSPRefresher(TSOCSPRefreshFunc funcp)
+{
+  SSLConfigParams *ssl_config_param = SSLConfig::acquire();
+  if (ssl_config_param == NULL) {
+    return;
+  }
+
+  if (ssl_config_param->ocsp_refresh_cb) {
+    Warning("The OCSP stabling refresh function has already been set and will be updated.");
+  }
+
+  ssl_config_param->ocsp_refresh_cb = funcp;
+  SSLConfig::release(ssl_config_param);
 }

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -2385,6 +2385,19 @@ tsapi const char *TSHttpHookNameLookup(TSHttpHookID hook);
 */
 tsapi const char *TSHttpEventNameLookup(TSEvent event);
 
+/**
+ * Declaration of OCSP stapling refresher register function.
+ * The function will accept a function pointer and store it into SSLConfigParams.
+ * During OCSP Stapling, if the function pointer is registered, Traffic Server will call it alternatively.
+ * struct cert is defined in iocore/net/OCSPStapling.cc
+ *
+ * @param funcp, the refresher function, use to send OCSP request and refreh local cache
+ */
+struct certinfo;
+typedef struct ocsp_response_st OCSP_RESPONSE;
+typedef bool (*TSOCSPRefreshFunc)(struct certinfo *, OCSP_RESPONSE **);
+tsapi void TSRegisterOCSPRefresher(TSOCSPRefreshFunc funcp);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */


### PR DESCRIPTION
Add an API to register user-customized OCSP refresh function.