### PR TITLE
Adds new log tags: nhi and nhp

### DIFF
--- a/doc/admin-guide/logging/formatting.en.rst
+++ b/doc/admin-guide/logging/formatting.en.rst
@@ -447,6 +447,8 @@ Network Addresses, Ports, and Interfaces
 .. _pqsp:
 .. _shi:
 .. _shn:
+.. _nhi:
+.. _nhp:
 
 The following log fields are used to log details of the network (IP) addresses,
 incoming/outgoing ports, and network interfaces used during transactions.
@@ -471,6 +473,8 @@ shi   Origin Server  IP address resolved via DNS by |TS| for the origin server.
                      |TS| for the connection will be reported. See note below
                      regarding misleading values from cached documents.
 shn   Origin Server  Host name of the origin server.
+nhi   Origin Server  Destination IP address of next hop
+nhp   Origin Server  Destination port of next hop
 ===== ============== ==========================================================
 
 .. note::

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -677,6 +677,14 @@ Log::init_fields()
   global_field_list.add(field, false);
   ink_hash_table_insert(field_symbol_hash, "pqsp", field);
 
+  field = new LogField("next_hop_ip", "nhi", LogField::IP, &LogAccess::marshal_next_hop_ip, &LogAccess::unmarshal_ip_to_str);
+  global_field_list.add(field, false);
+  ink_hash_table_insert(field_symbol_hash, "nhi", field);
+
+  field = new LogField("next_hop_port", "nhp", LogField::IP, &LogAccess::marshal_next_hop_port, &LogAccess::unmarshal_int_to_str);
+  global_field_list.add(field, false);
+  ink_hash_table_insert(field_symbol_hash, "nhp", field);
+
   Ptr<LogFieldAliasTable> hierarchy_map = make_ptr(new LogFieldAliasTable);
   hierarchy_map->init(
     36, SQUID_HIER_EMPTY, "EMPTY", SQUID_HIER_NONE, "NONE", SQUID_HIER_DIRECT, "DIRECT", SQUID_HIER_SIBLING_HIT, "SIBLING_HIT",

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -303,6 +303,19 @@ LOG_ACCESS_DEFAULT_FIELD(marshal_proxy_req_server_port, DEFAULT_INT_FIELD)
 
 LOG_ACCESS_DEFAULT_FIELD(marshal_proxy_hierarchy_route, DEFAULT_INT_FIELD)
 
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+LOG_ACCESS_DEFAULT_FIELD(marshal_next_hop_ip, DEFAULT_IP_FIELD)
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+LOG_ACCESS_DEFAULT_FIELD(marshal_next_hop_port, DEFAULT_INT_FIELD)
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
 LOG_ACCESS_DEFAULT_FIELD(marshal_client_retry_after_time, DEFAULT_INT_FIELD)
 
 /*-------------------------------------------------------------------------

--- a/proxy/logging/LogAccess.h
+++ b/proxy/logging/LogAccess.h
@@ -223,6 +223,8 @@ public:
   inkcoreapi virtual int marshal_proxy_req_server_ip(char *);   // INT
   inkcoreapi virtual int marshal_proxy_req_server_port(char *); // INT
   inkcoreapi virtual int marshal_proxy_hierarchy_route(char *); // INT
+  inkcoreapi virtual int marshal_next_hop_ip(char *);           // STR
+  inkcoreapi virtual int marshal_next_hop_port(char *);         // INT
   inkcoreapi virtual int marshal_proxy_host_name(char *);       // STR
   inkcoreapi virtual int marshal_proxy_host_ip(char *);         // STR
   inkcoreapi virtual int marshal_proxy_req_is_ssl(char *);      // INT

--- a/proxy/logging/LogAccessHttp.cc
+++ b/proxy/logging/LogAccessHttp.cc
@@ -1102,6 +1102,22 @@ LogAccessHttp::marshal_proxy_req_server_port(char *buf)
   return INK_MIN_ALIGN;
 }
 
+int
+LogAccessHttp::marshal_next_hop_ip(char *buf)
+{
+  return marshal_ip(buf, m_http_sm->t_state.current.server != nullptr ? &m_http_sm->t_state.current.server->dst_addr.sa : nullptr);
+}
+
+int
+LogAccessHttp::marshal_next_hop_port(char *buf)
+{
+  if (buf) {
+    uint16_t port = ntohs(m_http_sm->t_state.current.server != nullptr ? m_http_sm->t_state.current.server->dst_addr.port() : 0);
+    marshal_int(buf, port);
+  }
+  return INK_MIN_ALIGN;
+}
+
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 

--- a/proxy/logging/LogAccessHttp.h
+++ b/proxy/logging/LogAccessHttp.h
@@ -110,6 +110,8 @@ public:
   int marshal_proxy_hierarchy_route(char *) override; // INT
   int marshal_proxy_host_port(char *) override;       // INT
   int marshal_proxy_req_is_ssl(char *) override;      // INT
+  int marshal_next_hop_ip(char *) override;           // STR
+  int marshal_next_hop_port(char *) override;         // INT
 
   //
   // server -> proxy fields


### PR DESCRIPTION
next-hop-ip (nhi) is the IP of the next hop

Uses the original logic that pqsi used for marshalling
(pre 01201739e252f84e7c8a7c62c0ee31feb0def616)