### PR TITLE
Add support for 'fwd' value to X-Debug header, and move to later hook any deletion of X-Debug header from client request.

### DIFF
--- a/doc/admin-guide/plugins/xdebug.en.rst
+++ b/doc/admin-guide/plugins/xdebug.en.rst
@@ -27,8 +27,11 @@ the Traffic Server cache using the default ``X-Debug`` header. The plugin
 is triggered by the presence of the ``X-Debug`` or the configured header in
 the client request. The contents of this header should be the names of the
 debug headers that are desired in the response. The `XDebug` plugin
-will remove the ``X-Debug`` header from the client request and
-inject the desired headers into the client response.
+will inject the desired headers into the client response.  In addition, a value of the
+form ``fwd=n`` may appear in the ``X-Debug`` header, where ``n`` is a nonnegative
+number.  If ``n`` is zero, the ``X-Debug`` header will be deleted.  Otherwise, ``n`` id
+decremented by 1.  ``=n`` may be omitted, in which case the ``X-Debug`` header will
+not be modified or deleted.
 
 `XDebug` is a global plugin. It is installed by adding it to the
 :file:`plugin.config` file. It currently takes a single, optional

--- a/lib/ts/PostScript.h
+++ b/lib/ts/PostScript.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <tuple>
+#include <utility>
 
 namespace ts
 {
@@ -37,10 +38,16 @@ namespace ts
 // Helpful in avoiding errors due to exception throws or error function return points, like the one that caused
 // Heartbleed.
 //
+// Note that there is a bug when an actual parameter to the constructor is a pointer lvalue.  It only works properly
+// with pointer rvalues.  So instead of a variable name, say p, the actual parameter must be p+0, &*p, or some such
+// conversion to an rvalue.  See the unit tests (test_PostScript.cc) for an example.
+// See also:
+// https://stackoverflow.com/questions/51483598/in-c17-why-is-pointer-type-deduction-apparently-inconsistent-for-class-templa
+//
 template <typename Callable, typename... Args> class PostScript
 {
 public:
-  PostScript(Callable f, Args &&... args) : _f(f), _argsTuple(args...) {}
+  PostScript(Callable f, Args &&... args) : _f(f), _argsTuple(std::forward<Args>(args)...) {}
 
   ~PostScript()
   {

--- a/lib/ts/unit-tests/test_PostScript.cc
+++ b/lib/ts/unit-tests/test_PostScript.cc
@@ -21,6 +21,8 @@
     limitations under the License.
  */
 
+#include <functional>
+
 #include "catch.hpp"
 #include <ts/PostScript.h>
 
@@ -30,14 +32,17 @@ int f1Called;
 int f2Called;
 int f3Called;
 
+int dummy;
+
 void
-f1(int a, double b, int c)
+f1(int a, double b, int *c, int &d)
 {
   ++f1Called;
 
   REQUIRE(a == 1);
   REQUIRE(b == 2.0);
-  REQUIRE(c == 3);
+  REQUIRE(c == &dummy);
+  REQUIRE(&d == &dummy);
 }
 
 void
@@ -62,7 +67,8 @@ TEST_CASE("PostScript", "[PSC]")
   int lambdaCalled = 0;
 
   {
-    ts::PostScript g1(f1, 1, 2.0, 3);
+    int *p = &dummy;
+    ts::PostScript g1(f1, 1, 2.0, p + 0, std::ref(dummy));
     ts::PostScript g2(f2, 4);
     ts::PostScript g3(f3, 5, 6.0);
     ts::PostScript g4([&]() -> void { ++lambdaCalled; });

--- a/plugins/xdebug/xdebug.cc
+++ b/plugins/xdebug/xdebug.cc
@@ -23,9 +23,13 @@
 #include <sstream>
 #include <cstring>
 #include <getopt.h>
+#include <cstdint>
+#include <cinttypes>
 
-#include "ts/ts.h"
-#include "ts/ink_defs.h"
+#include <ts/ts.h>
+#include <ts/ink_defs.h>
+#include <ts/PostScript.h>
+#include <ts/TextView.h>
 
 #define DEBUG_TAG_LOG_HEADERS "xdebug.headers"
 
@@ -35,17 +39,18 @@ static struct {
 } xDebugHeader = {nullptr, 0};
 
 enum {
-  XHEADER_X_CACHE_KEY      = 0x0004u,
-  XHEADER_X_MILESTONES     = 0x0008u,
-  XHEADER_X_CACHE          = 0x0010u,
-  XHEADER_X_GENERATION     = 0x0020u,
-  XHEADER_X_TRANSACTION_ID = 0x0040u,
-  XHEADER_X_DUMP_HEADERS   = 0x0080u,
-  XHEADER_X_REMAP          = 0x0100u,
+  XHEADER_X_CACHE_KEY      = 1u << 2,
+  XHEADER_X_MILESTONES     = 1u << 3,
+  XHEADER_X_CACHE          = 1u << 4,
+  XHEADER_X_GENERATION     = 1u << 5,
+  XHEADER_X_TRANSACTION_ID = 1u << 6,
+  XHEADER_X_DUMP_HEADERS   = 1u << 7,
+  XHEADER_X_REMAP          = 1u << 8,
 };
 
-static int XArgIndex             = 0;
-static TSCont XInjectHeadersCont = nullptr;
+static int XArgIndex              = 0;
+static TSCont XInjectHeadersCont  = nullptr;
+static TSCont XDeleteDebugHdrCont = nullptr;
 
 // Return the length of a string literal.
 template <int N>
@@ -360,14 +365,13 @@ log_headers(TSHttpTxn txn, TSMBuffer bufp, TSMLoc hdr_loc, const char *msg_type)
 static int
 XInjectResponseHeaders(TSCont /* contp */, TSEvent event, void *edata)
 {
-  TSHttpTxn txn     = (TSHttpTxn)edata;
-  intptr_t xheaders = 0;
+  TSHttpTxn txn = (TSHttpTxn)edata;
   TSMBuffer buffer;
   TSMLoc hdr;
 
   TSReleaseAssert(event == TS_EVENT_HTTP_SEND_RESPONSE_HDR);
 
-  xheaders = (intptr_t)TSHttpTxnArgGet(txn, XArgIndex);
+  uintptr_t xheaders = reinterpret_cast<uintptr_t>(TSHttpTxnArgGet(txn, XArgIndex));
   if (xheaders == 0) {
     goto done;
   }
@@ -409,21 +413,73 @@ done:
   return TS_EVENT_NONE;
 }
 
+static bool
+isFwdFieldValue(const char *value, int valueLen, intmax_t &fwdCnt)
+{
+  ts::TextView paramName("fwd");
+
+  if (valueLen < static_cast<int>(paramName.size())) {
+    return false;
+  }
+
+  ts::TextView val(value, valueLen);
+
+  if (ts::strcasecmp(paramName, val.prefix(paramName.size())) != 0) {
+    return false;
+  }
+
+  val.remove_prefix(paramName.size());
+
+  if (val.size() == 0) {
+    // Value is 'fwd' with no '=<count>'.
+    fwdCnt = -1;
+    return true;
+  }
+
+  const char httpSpace[] = " \t";
+
+  val.ltrim(httpSpace);
+
+  if (val[0] != '=') {
+    return false;
+  }
+
+  val.remove_prefix(1);
+  val.ltrim(httpSpace);
+
+  size_t sz  = val.size();
+  intmax_t i = ts::svtoi(val, &val);
+
+  if ((val.size() != sz) or (i < 0)) {
+    // There were crud characters after the number, or the number was negative.
+    return false;
+  }
+
+  fwdCnt = i;
+
+  return true;
+}
+
 // Scan the client request headers and determine which debug headers they
 // want in the response.
 static int
 XScanRequestHeaders(TSCont /* contp */, TSEvent event, void *edata)
 {
-  TSHttpTxn txn     = (TSHttpTxn)edata;
-  intptr_t xheaders = 0;
+  TSHttpTxn txn      = (TSHttpTxn)edata;
+  uintptr_t xheaders = 0;
+  intmax_t fwdCnt    = 0;
   TSMLoc field, next;
   TSMBuffer buffer;
   TSMLoc hdr;
 
+  // Make sure TSHttpTxnReenable(txn, TS_EVENT_HTTP_CONTINUE) is called before exiting function.
+  //
+  ts::PostScript ps(TSHttpTxnReenable, &*txn, TS_EVENT_HTTP_CONTINUE);
+
   TSReleaseAssert(event == TS_EVENT_HTTP_READ_REQUEST_HDR);
 
   if (TSHttpTxnClientReqGet(txn, &buffer, &hdr) == TS_ERROR) {
-    goto done;
+    return TS_EVENT_NONE;
   }
 
   TSDebug("xdebug", "scanning for %s header values", xDebugHeader.str);
@@ -501,6 +557,13 @@ XScanRequestHeaders(TSCont /* contp */, TSEvent event, void *edata)
         };
         TSHttpTxnHookAdd(txn, TS_HTTP_READ_RESPONSE_HDR_HOOK, TSContCreate(read_resp_dump, nullptr));
 
+      } else if (isFwdFieldValue(value, vsize, fwdCnt)) {
+        if (fwdCnt > 0) {
+          // Decrement forward count in X-Debug header.
+          char newVal[128];
+          snprintf(newVal, sizeof(newVal), "fwd=%" PRIiMAX, fwdCnt - 1);
+          TSMimeHdrFieldValueStringSet(buffer, hdr, field, i, newVal, std::strlen(newVal));
+        }
       } else {
         TSDebug("xdebug", "ignoring unrecognized debug tag '%.*s'", vsize, value);
       }
@@ -511,9 +574,6 @@ XScanRequestHeaders(TSCont /* contp */, TSEvent event, void *edata)
     // Get the next duplicate.
     next = TSMimeHdrFieldNextDup(buffer, hdr, field);
 
-    // Destroy the current field that we have. We don't want this to go through and potentially confuse the origin.
-    TSMimeHdrFieldDestroy(buffer, hdr, field);
-
     // Now release our reference.
     TSHandleMLocRelease(buffer, hdr, field);
 
@@ -522,13 +582,51 @@ XScanRequestHeaders(TSCont /* contp */, TSEvent event, void *edata)
   }
 
   if (xheaders) {
-    TSDebug("xdebug", "adding response hook for header mask %p", (void *)xheaders);
+    TSDebug("xdebug", "adding response hook for header mask %p and forward count %" PRIiMAX, reinterpret_cast<void *>(xheaders),
+            fwdCnt);
     TSHttpTxnHookAdd(txn, TS_HTTP_SEND_RESPONSE_HDR_HOOK, XInjectHeadersCont);
-    TSHttpTxnArgSet(txn, XArgIndex, (void *)xheaders);
+    TSHttpTxnArgSet(txn, XArgIndex, reinterpret_cast<void *>(xheaders));
+
+    if (fwdCnt == 0) {
+      // X-Debug header has to be deleted, but not too soon for other plugins to see it.
+      TSHttpTxnHookAdd(txn, TS_HTTP_CACHE_LOOKUP_COMPLETE_HOOK, XDeleteDebugHdrCont);
+    }
   }
 
-done:
-  TSHttpTxnReenable(txn, TS_EVENT_HTTP_CONTINUE);
+  return TS_EVENT_NONE;
+}
+
+// Continuation function to delete the x-debug header.
+//
+static int
+XDeleteDebugHdr(TSCont /* contp */, TSEvent event, void *edata)
+{
+  TSHttpTxn txn = static_cast<TSHttpTxn>(edata);
+  TSMLoc hdr, field;
+  TSMBuffer buffer;
+
+  // Make sure TSHttpTxnReenable(txn, TS_EVENT_HTTP_CONTINUE) is called before exiting function.
+  //
+  ts::PostScript ps(TSHttpTxnReenable, &*txn, TS_EVENT_HTTP_CONTINUE);
+
+  TSReleaseAssert(event == TS_EVENT_HTTP_CACHE_LOOKUP_COMPLETE);
+
+  if (TSHttpTxnClientReqGet(txn, &buffer, &hdr) == TS_ERROR) {
+    return TS_EVENT_NONE;
+  }
+
+  field = TSMimeHdrFieldFind(buffer, hdr, xDebugHeader.str, xDebugHeader.len);
+  if (field == TS_NULL_MLOC) {
+    TSError("Missing %s header", xDebugHeader.str);
+    return TS_EVENT_NONE;
+  }
+
+  if (TSMimeHdrFieldDestroy(buffer, hdr, field) == TS_ERROR) {
+    TSError("Failure destroying %s header", xDebugHeader.str);
+  }
+
+  TSHandleMLocRelease(buffer, hdr, field);
+
   return TS_EVENT_NONE;
 }
 
@@ -570,5 +668,6 @@ TSPluginInit(int argc, const char *argv[])
   // Setup the global hook
   TSReleaseAssert(TSHttpTxnArgIndexReserve("xdebug", "xdebug header requests", &XArgIndex) == TS_SUCCESS);
   TSReleaseAssert(XInjectHeadersCont = TSContCreate(XInjectResponseHeaders, nullptr));
+  TSReleaseAssert(XDeleteDebugHdrCont = TSContCreate(XDeleteDebugHdr, nullptr));
   TSHttpHookAdd(TS_HTTP_READ_REQUEST_HDR_HOOK, TSContCreate(XScanRequestHeaders, nullptr));
 }

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/fwd1.in
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/fwd1.in
@@ -1,0 +1,4 @@
+GET /argh HTTP/1.1
+Host: two
+X-Debug: X-Remap, fwd
+

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/fwd2.in
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/fwd2.in
@@ -1,0 +1,4 @@
+GET /argh HTTP/1.1
+Host: two
+X-Debug: X-Remap, fwd=0
+

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/fwd3.in
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/fwd3.in
@@ -1,0 +1,4 @@
+GET /argh HTTP/1.1
+Host: two
+X-Debug: X-Remap, fwd= 1
+

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/fwd4.in
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/fwd4.in
@@ -1,0 +1,4 @@
+GET /argh HTTP/1.1
+Host: two
+X-Debug: X-Remap, fwd = 999999
+

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/fwd5.in
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/fwd5.in
@@ -1,0 +1,4 @@
+GET /argh HTTP/1.1
+Host: two
+X-Debug: X-Remap, fwd = 999999xxx
+

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/out.gold
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/out.gold
@@ -1,7 +1,7 @@
 HTTP/1.1 502 Cannot find server.
-Date:``
+Date: ``
 Connection: keep-alive
-Server:``
+Server: ATS/``
 Cache-Control: no-store
 Content-Type: text/html
 Content-Language: en
@@ -27,34 +27,89 @@ name and try again.
 </BODY>
 ======
 HTTP/1.1 200 OK
-Date:``
-Age:``
+Date: ``
+Age: 0
 Transfer-Encoding: chunked
 Connection: keep-alive
-Server:``
+Server: ATS/``
 X-Remap: from=http://one/, to=http://127.0.0.1:SERVER_PORT/
 
 0
 
 ======
 HTTP/1.1 200 OK
-Date:``
-Age:``
+Date: ``
+Age: 0
 Transfer-Encoding: chunked
 Connection: keep-alive
-Server:``
+Server: ATS/``
 X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
 
 0
 
 ======
 HTTP/1.1 200 OK
-Date:``
-Age:``
+Date: ``
+Age: 0
 Transfer-Encoding: chunked
 Connection: keep-alive
-Server:``
+Server: ATS/``
 X-Remap: from=http://three[0-9]+/, to=http://127.0.0.1:SERVER_PORT/
+
+0
+
+======
+HTTP/1.1 200 OK
+Date: ``
+Age: 0
+Transfer-Encoding: chunked
+Connection: keep-alive
+Server: ATS/``
+X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
+
+0
+
+======
+HTTP/1.1 200 OK
+Date: ``
+Age: 0
+Transfer-Encoding: chunked
+Connection: keep-alive
+Server: ATS/``
+X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
+
+0
+
+======
+HTTP/1.1 200 OK
+Date: ``
+Age: 0
+Transfer-Encoding: chunked
+Connection: keep-alive
+Server: ATS/``
+X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
+
+0
+
+======
+HTTP/1.1 200 OK
+Date: ``
+Age: 0
+Transfer-Encoding: chunked
+Connection: keep-alive
+Server: ATS/``
+X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
+
+0
+
+======
+HTTP/1.1 200 OK
+Date: ``
+Age: 0
+Transfer-Encoding: chunked
+Connection: keep-alive
+Server: ATS/``
+X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
 
 0
 

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/x_remap-observer.py
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/x_remap-observer.py
@@ -1,0 +1,35 @@
+'''
+Extract the protocol information from the FORWARDED headers and store it in a log file for later verification.
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+log = open('x_remap.log', 'w')
+
+def observe(headers):
+    seen = False
+
+    for h in headers.items():
+        if h[0].lower() == "x-debug":
+            log.write(h[1] + "\n")
+            seen = True
+
+    if not seen:
+        log.write("X_DEBUG MISSING\n")
+    log.write("-\n")
+    log.flush()
+
+Hooks.register(Hooks.ReadRequestHook, observe)

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/x_remap.gold
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/x_remap.gold
@@ -1,0 +1,16 @@
+X_DEBUG MISSING
+-
+X_DEBUG MISSING
+-
+X_DEBUG MISSING
+-
+X-Remap, fwd
+-
+X_DEBUG MISSING
+-
+X-Remap, fwd=0
+-
+X-Remap, fwd=999998
+-
+X_DEBUG MISSING
+-

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/x_remap.test.py
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/x_remap.test.py
@@ -15,10 +15,10 @@
 #  limitations under the License.
 
 Test.Summary = '''
-Test xdebug plugin X-Remap header
+Test xdebug plugin X-Remap and fwd headers
 '''
 
-server = Test.MakeOriginServer("server")
+server = Test.MakeOriginServer("server", options={'--load': (Test.TestDirectory + '/x_remap-observer.py')})
 
 request_header = {
     "headers": "GET /argh HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": "" }
@@ -30,7 +30,8 @@ ts = Test.MakeATSProcess("ts")
 ts.Disk.records_config.update({
     'proxy.config.url_remap.remap_required': 0,
     'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.diags.debug.tags': 'http'
+    # 'proxy.config.diags.debug.tags': 'http|xdebug'
+    # 'proxy.config.diags.debug.tags': 'xdebug'
 })
 
 ts.Disk.plugin_config.AddLine('xdebug.so')
@@ -67,9 +68,20 @@ sendMsg('none')
 sendMsg('one')
 sendMsg('two')
 sendMsg('three')
+sendMsg('fwd1')
+sendMsg('fwd2')
+sendMsg('fwd3')
+sendMsg('fwd4')
+sendMsg('fwd5')
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = "echo test gold"
+tr.Processes.Default.Command = "echo test out.gold"
 tr.Processes.Default.ReturnCode = 0
 f = tr.Disk.File("out.log")
 f.Content = "out.gold"
+
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = "echo test x_remap.gold"
+tr.Processes.Default.ReturnCode = 0
+f = tr.Disk.File("x_remap.log")
+f.Content = "x_remap.gold"


### PR DESCRIPTION
Deletion of the X-Debug header is moved to the TS_HTTP_CACHE_LOOKUP_COMPLETE_HOOK .  This allows other, custom plugins to make use of the X-Debug header.