### PR TITLE
Add support for 'fwd' value to X-Debug header, and move to later hook any deletion of X-Debug header from client request.

### DIFF
--- a/doc/admin-guide/plugins/xdebug.en.rst
+++ b/doc/admin-guide/plugins/xdebug.en.rst
@@ -27,8 +27,11 @@ the Traffic Server cache using the default ``X-Debug`` header. The plugin
 is triggered by the presence of the ``X-Debug`` or the configured header in
 the client request. The contents of this header should be the names of the
 debug headers that are desired in the response. The `XDebug` plugin
-will remove the ``X-Debug`` header from the client request and
-inject the desired headers into the client response.
+will inject the desired headers into the client response.  In addition, a value of the
+form ``fwd=n`` may appear in the ``X-Debug`` header, where ``n`` is a nonnegative
+number.  If ``n`` is zero, the ``X-Debug`` header will be deleted.  Otherwise, ``n`` is
+decremented by 1.  ``=n`` may be omitted, in which case the ``X-Debug`` header will
+not be modified or deleted.
 
 `XDebug` is a global plugin. It is installed by adding it to the
 :file:`plugin.config` file. It currently takes a single, optional

--- a/lib/ts/Makefile.am
+++ b/lib/ts/Makefile.am
@@ -20,7 +20,7 @@ include $(top_srcdir)/build/tidy.mk
 
 library_includedir=$(includedir)/ts
 
-library_include_HEADERS = apidefs.h TextView.h PostScript.h
+library_include_HEADERS = apidefs.h PostScript.h TextView.h
 
 noinst_PROGRAMS = mkdfa CompileParseRules
 check_PROGRAMS = test_tsutil test_arena test_atomic test_freelist test_geometry test_List test_Map test_Vec test_X509HostnameValidator test_tslib
@@ -75,7 +75,6 @@ libtsutil_la_SOURCES = \
 	EventNotify.h \
 	fastlz.c \
 	fastlz.h \
-	PostScript.h \
 	Hash.cc \
 	HashFNV.cc \
 	HashFNV.h \
@@ -183,6 +182,7 @@ libtsutil_la_SOURCES = \
 	MT_hashtable.h \
 	ParseRules.cc \
 	ParseRules.h \
+	PostScript.h \
 	PriorityQueue.h \
 	Ptr.h \
 	RawHashTable.cc \
@@ -266,7 +266,6 @@ test_tslib_SOURCES = \
 	unit-tests/unit_test_main.cc \
 	unit-tests/test_BufferWriter.cc \
 	unit-tests/test_BufferWriterFormat.cc \
-	unit-tests/test_PostScript.cc \
 	unit-tests/test_History.cc \
 	unit-tests/test_ink_inet.cc \
 	unit-tests/test_IntrusiveDList.cc \
@@ -276,6 +275,7 @@ test_tslib_SOURCES = \
 	unit-tests/test_MemSpan.cc \
 	unit-tests/test_MemArena.cc \
 	unit-tests/test_MT_hashtable.cc \
+	unit-tests/test_PostScript.cc \
 	unit-tests/test_Ptr.cc \
 	unit-tests/test_Regex.cc \
 	unit-tests/test_Scalar.cc \

--- a/lib/ts/PostScript.h
+++ b/lib/ts/PostScript.h
@@ -35,7 +35,7 @@ namespace ts
 //
 // Helpful in avoiding errors due to exception throws or error function return points (like the one that caused Heartbleed).
 //
-template <typename Callable, typename... Args> class PostScript
+template <typename Callable> class PostScript
 {
 public:
   PostScript(Callable f) : _f(f) {}

--- a/lib/ts/PostScript.h
+++ b/lib/ts/PostScript.h
@@ -24,28 +24,26 @@
 
 #pragma once
 
-#include <tuple>
-
 namespace ts
 {
-// The destructor of this class calls the function object passed to its constructor, with the given arguments.
-// For example:
-//   ts::PostScript g(TSHandleMLocRelease, bufp, parent, hdr);
+// The destructor of this class calls the function object passed to its constructor.  The function object must support a
+// function call operator with no parameters.  For example:
+//
+//   ts::PostScript g([=]() -> void { TSHandleMLocRelease(bufp, parent, hdr); });
 //
 // The release() member will prevent the call to the function upon destruction.
 //
-// Helpful in avoiding errors due to exception throws or error function return points, like the one that caused
-// Heartbleed.
+// Helpful in avoiding errors due to exception throws or error function return points (like the one that caused Heartbleed).
 //
 template <typename Callable, typename... Args> class PostScript
 {
 public:
-  PostScript(Callable f, Args &&... args) : _f(f), _argsTuple(args...) {}
+  PostScript(Callable f) : _f(f) {}
 
   ~PostScript()
   {
     if (_armed) {
-      std::apply(_f, _argsTuple);
+      _f();
     }
   }
 
@@ -62,7 +60,6 @@ public:
 private:
   bool _armed = true;
   Callable _f;
-  std::tuple<Args...> _argsTuple;
 };
 
 } // end namespace ts

--- a/lib/ts/unit-tests/test_PostScript.cc
+++ b/lib/ts/unit-tests/test_PostScript.cc
@@ -30,14 +30,17 @@ int f1Called;
 int f2Called;
 int f3Called;
 
+int dummy;
+
 void
-f1(int a, double b, int c)
+f1(int a, double b, int *c, int &d)
 {
   ++f1Called;
 
   REQUIRE(a == 1);
   REQUIRE(b == 2.0);
-  REQUIRE(c == 3);
+  REQUIRE(c == &dummy);
+  REQUIRE(&d == &dummy);
 }
 
 void
@@ -55,17 +58,15 @@ f3(int a, double b)
   REQUIRE(b == 6.0);
 }
 
-} // namespace
+} // end anonymous namespace
 
 TEST_CASE("PostScript", "[PSC]")
 {
-  int lambdaCalled = 0;
-
   {
-    ts::PostScript g1(f1, 1, 2.0, 3);
-    ts::PostScript g2(f2, 4);
-    ts::PostScript g3(f3, 5, 6.0);
-    ts::PostScript g4([&]() -> void { ++lambdaCalled; });
+    int *p = &dummy;
+    ts::PostScript g1([&]() -> void { f1(1, 2.0, p, dummy); });
+    ts::PostScript g2([=]() -> void { f2(4); });
+    ts::PostScript g3([=]() -> void { f3(5, 6.0); });
 
     g2.release();
   }
@@ -73,5 +74,4 @@ TEST_CASE("PostScript", "[PSC]")
   REQUIRE(f1Called == 1);
   REQUIRE(f2Called == 0);
   REQUIRE(f3Called == 1);
-  REQUIRE(lambdaCalled == 1);
 }

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/fwd1.in
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/fwd1.in
@@ -1,0 +1,4 @@
+GET /argh HTTP/1.1
+Host: two
+X-Debug: X-Remap, fwd
+

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/fwd2.in
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/fwd2.in
@@ -1,0 +1,4 @@
+GET /argh HTTP/1.1
+Host: two
+X-Debug: X-Remap, fwd=0
+

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/fwd3.in
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/fwd3.in
@@ -1,0 +1,4 @@
+GET /argh HTTP/1.1
+Host: two
+X-Debug: X-Remap, fwd= 1
+

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/fwd4.in
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/fwd4.in
@@ -1,0 +1,4 @@
+GET /argh HTTP/1.1
+Host: two
+X-Debug: X-Remap, fwd = 999999
+

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/fwd5.in
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/fwd5.in
@@ -1,0 +1,4 @@
+GET /argh HTTP/1.1
+Host: two
+X-Debug: X-Remap, fwd = 999999xxx
+

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/out.gold
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/out.gold
@@ -1,7 +1,7 @@
 HTTP/1.1 502 Cannot find server.
-Date:``
+Date: ``
 Connection: keep-alive
-Server:``
+Server: ATS/``
 Cache-Control: no-store
 Content-Type: text/html
 Content-Language: en
@@ -27,34 +27,89 @@ name and try again.
 </BODY>
 ======
 HTTP/1.1 200 OK
-Date:``
-Age:``
+Date: ``
+Age: ``
 Transfer-Encoding: chunked
 Connection: keep-alive
-Server:``
+Server: ATS/``
 X-Remap: from=http://one/, to=http://127.0.0.1:SERVER_PORT/
 
 0
 
 ======
 HTTP/1.1 200 OK
-Date:``
-Age:``
+Date: ``
+Age: ``
 Transfer-Encoding: chunked
 Connection: keep-alive
-Server:``
+Server: ATS/``
 X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
 
 0
 
 ======
 HTTP/1.1 200 OK
-Date:``
-Age:``
+Date: ``
+Age: ``
 Transfer-Encoding: chunked
 Connection: keep-alive
-Server:``
+Server: ATS/``
 X-Remap: from=http://three[0-9]+/, to=http://127.0.0.1:SERVER_PORT/
+
+0
+
+======
+HTTP/1.1 200 OK
+Date: ``
+Age: ``
+Transfer-Encoding: chunked
+Connection: keep-alive
+Server: ATS/``
+X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
+
+0
+
+======
+HTTP/1.1 200 OK
+Date: ``
+Age: ``
+Transfer-Encoding: chunked
+Connection: keep-alive
+Server: ATS/``
+X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
+
+0
+
+======
+HTTP/1.1 200 OK
+Date: ``
+Age: ``
+Transfer-Encoding: chunked
+Connection: keep-alive
+Server: ATS/``
+X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
+
+0
+
+======
+HTTP/1.1 200 OK
+Date: ``
+Age: ``
+Transfer-Encoding: chunked
+Connection: keep-alive
+Server: ATS/``
+X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
+
+0
+
+======
+HTTP/1.1 200 OK
+Date: ``
+Age: ``
+Transfer-Encoding: chunked
+Connection: keep-alive
+Server: ATS/``
+X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
 
 0
 

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/x_remap-observer.py
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/x_remap-observer.py
@@ -1,0 +1,35 @@
+'''
+Extract the protocol information from the FORWARDED headers and store it in a log file for later verification.
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+log = open('x_remap.log', 'w')
+
+def observe(headers):
+    seen = False
+
+    for h in headers.items():
+        if h[0].lower() == "x-debug":
+            log.write(h[1] + "\n")
+            seen = True
+
+    if not seen:
+        log.write("X_DEBUG MISSING\n")
+    log.write("-\n")
+    log.flush()
+
+Hooks.register(Hooks.ReadRequestHook, observe)

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/x_remap.gold
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/x_remap.gold
@@ -1,0 +1,16 @@
+X_DEBUG MISSING
+-
+X_DEBUG MISSING
+-
+X_DEBUG MISSING
+-
+X-Remap, fwd
+-
+X_DEBUG MISSING
+-
+X-Remap, fwd=0
+-
+X-Remap, fwd=999998
+-
+X_DEBUG MISSING
+-

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/x_remap.test.py
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/x_remap.test.py
@@ -15,10 +15,10 @@
 #  limitations under the License.
 
 Test.Summary = '''
-Test xdebug plugin X-Remap header
+Test xdebug plugin X-Remap and fwd headers
 '''
 
-server = Test.MakeOriginServer("server")
+server = Test.MakeOriginServer("server", options={'--load': (Test.TestDirectory + '/x_remap-observer.py')})
 
 request_header = {
     "headers": "GET /argh HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": "" }
@@ -30,7 +30,8 @@ ts = Test.MakeATSProcess("ts")
 ts.Disk.records_config.update({
     'proxy.config.url_remap.remap_required': 0,
     'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.diags.debug.tags': 'http'
+    # 'proxy.config.diags.debug.tags': 'http|xdebug'
+    # 'proxy.config.diags.debug.tags': 'xdebug'
 })
 
 ts.Disk.plugin_config.AddLine('xdebug.so')
@@ -67,9 +68,20 @@ sendMsg('none')
 sendMsg('one')
 sendMsg('two')
 sendMsg('three')
+sendMsg('fwd1')
+sendMsg('fwd2')
+sendMsg('fwd3')
+sendMsg('fwd4')
+sendMsg('fwd5')
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = "echo test gold"
+tr.Processes.Default.Command = "echo test out.gold"
 tr.Processes.Default.ReturnCode = 0
 f = tr.Disk.File("out.log")
 f.Content = "out.gold"
+
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = "echo test x_remap.gold"
+tr.Processes.Default.ReturnCode = 0
+f = tr.Disk.File("x_remap.log")
+f.Content = "x_remap.gold"


### PR DESCRIPTION
Deletion of the X-Debug header is moved to the TS_HTTP_CACHE_LOOKUP_COMPLETE_HOOK . This allows other, custom plugins to make use of the X-Debug header.