### PR TITLE
Revert "Do not do DNS to origin if the object is HIT-STALE and parent…

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -2322,7 +2322,16 @@ HttpTransact::HandleCacheOpenReadHitFreshness(State *s)
     SET_VIA_STRING(VIA_CACHE_RESULT, VIA_IN_CACHE_STALE);
   }
 
-  TRANSACT_RETURN(SM_ACTION_API_CACHE_LOOKUP_COMPLETE, HttpTransact::HandleCacheOpenReadHit);
+  if (!s->force_dns) { // If DNS is not performed before
+    if (need_to_revalidate(s)) {
+      TRANSACT_RETURN(SM_ACTION_API_CACHE_LOOKUP_COMPLETE,
+                      CallOSDNSLookup); // content needs to be revalidated and we did not perform a dns ....calling DNS lookup
+    } else {                            // document can be served can cache
+      TRANSACT_RETURN(SM_ACTION_API_CACHE_LOOKUP_COMPLETE, HttpTransact::HandleCacheOpenReadHit);
+    }
+  } else { // we have done dns . Its up to HandleCacheOpenReadHit to decide to go OS or serve from cache
+    TRANSACT_RETURN(SM_ACTION_API_CACHE_LOOKUP_COMPLETE, HttpTransact::HandleCacheOpenReadHit);
+  }
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
… exists"

This reverts commit a8ec551a846690fee16c3ed5f502de96ac763c79.

See #4009 for details on the crasher that occurs with this original
commit.