### PR TITLE
Add logic to clean up vios on HttpSM shutdown

### DIFF
--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -218,7 +218,7 @@ Http1ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOB
 VIO *
 Http1ClientSession::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
 {
-  return client_vc->do_io_read(c, nbytes, buf);
+  return (client_vc) ? client_vc->do_io_read(c, nbytes, buf) : nullptr;
 }
 
 VIO *

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -105,13 +105,14 @@ struct HttpVCTableEntry {
   VIO *write_vio;
   HttpSMHandler vc_handler;
   HttpVC_t vc_type;
+  HttpSM *sm;
   bool eos;
   bool in_tunnel;
 };
 
 struct HttpVCTable {
   static const int vc_table_max_entries = 4;
-  HttpVCTable();
+  HttpVCTable(HttpSM *);
 
   HttpVCTableEntry *new_entry();
   HttpVCTableEntry *find_entry(VConnection *);
@@ -123,6 +124,7 @@ struct HttpVCTable {
 
 private:
   HttpVCTableEntry vc_table[vc_table_max_entries];
+  HttpSM *sm = nullptr;
 };
 
 inline bool
@@ -220,8 +222,9 @@ public:
   virtual void destroy();
 
   static HttpSM *allocate();
-  HttpCacheSM &get_cache_sm();      // Added to get the object of CacheSM YTS Team, yamsat
-  HttpVCTableEntry *get_ua_entry(); // Added to get the ua_entry pointer  - YTS-TEAM
+  HttpCacheSM &get_cache_sm();          // Added to get the object of CacheSM YTS Team, yamsat
+  HttpVCTableEntry *get_ua_entry();     // Added to get the ua_entry pointer  - YTS-TEAM
+  HttpVCTableEntry *get_server_entry(); // Added to get the server_entry pointer
 
   void init();
 
@@ -238,6 +241,12 @@ public:
   get_server_session()
   {
     return server_session;
+  }
+
+  ProxyClientTransaction *
+  get_ua_txn()
+  {
+    return ua_txn;
   }
 
   // Called by transact.  Updates are fire and forget
@@ -633,6 +642,12 @@ inline HttpVCTableEntry *
 HttpSM::get_ua_entry()
 {
   return ua_entry;
+}
+
+inline HttpVCTableEntry *
+HttpSM::get_server_entry()
+{
+  return server_entry;
 }
 
 inline HttpSM *

--- a/proxy/http/HttpServerSession.cc
+++ b/proxy/http/HttpServerSession.cc
@@ -101,13 +101,13 @@ HttpServerSession::enable_outbound_connection_tracking(OutboundConnTrack::Group 
 VIO *
 HttpServerSession::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
 {
-  return server_vc->do_io_read(c, nbytes, buf);
+  return server_vc ? server_vc->do_io_read(c, nbytes, buf) : nullptr;
 }
 
 VIO *
 HttpServerSession::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool owner)
 {
-  return server_vc->do_io_write(c, nbytes, buf, owner);
+  return server_vc ? server_vc->do_io_write(c, nbytes, buf, owner) : nullptr;
 }
 
 void

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -233,13 +233,21 @@ Http2ClientSession::set_upgrade_context(HTTPHdr *h)
 VIO *
 Http2ClientSession::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
 {
-  return this->client_vc->do_io_read(c, nbytes, buf);
+  if (client_vc) {
+    return this->client_vc->do_io_read(c, nbytes, buf);
+  } else {
+    return nullptr;
+  }
 }
 
 VIO *
 Http2ClientSession::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool owner)
 {
-  return this->client_vc->do_io_write(c, nbytes, buf, owner);
+  if (client_vc) {
+    return this->client_vc->do_io_write(c, nbytes, buf, owner);
+  } else {
+    return nullptr;
+  }
 }
 
 void


### PR DESCRIPTION
Added this logic while debugging an openssl engine using ASYNC jobs.  This and PR #4019 are underlying issues I fixed that were revealed by the timing differences of the engine.

This PR cleans up any VIOs against the the HttpSM that is being killed.  This ends up preventing inactivity timeouts on stale HttpSM's. 