### PR TITLE
Runroot: pass runroot down from manager and error message update

### DIFF
--- a/lib/records/RecConfigParse.cc
+++ b/lib/records/RecConfigParse.cc
@@ -89,7 +89,7 @@ RecFileImport_Xmalloc(const char *file, char **file_buf, int *file_size)
 bool
 RecConfigOverrideFromRunroot(const char *name)
 {
-  if (use_runroot()) {
+  if (!get_runroot().empty()) {
     if (!strcmp(name, "proxy.config.bin_path") || !strcmp(name, "proxy.config.local_state_dir") ||
         !strcmp(name, "proxy.config.log.logfile_dir") || !strcmp(name, "proxy.config.plugin.plugin_dir"))
       return true;

--- a/lib/ts/runroot.h
+++ b/lib/ts/runroot.h
@@ -58,5 +58,5 @@ RunrootMapType runroot_map(const std::string &prefix);
 // help check runroot for layout
 RunrootMapType check_runroot();
 
-// helper method for records config to check using runroot or not
-bool use_runroot();
+// To get the runroot value
+std::string_view get_runroot();

--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -27,6 +27,7 @@
 #include "ts/ink_error.h"
 #include "MgmtUtils.h"
 #include "ts/I_Layout.h"
+#include "ts/runroot.h"
 #include "LocalManager.h"
 #include "MgmtSocket.h"
 #include "ts/ink_cap.h"
@@ -43,6 +44,7 @@
 
 using namespace std::literals;
 static const std::string_view MGMT_OPT{"-M"};
+static const std::string_view RUNROOT_OPT{"--run-root="};
 
 void
 LocalManager::mgmtCleanup()
@@ -896,6 +898,14 @@ LocalManager::startProxy(const char *onetime_options)
     // Make sure we're starting the proxy in mgmt mode
     if (w.view().find(MGMT_OPT) == std::string_view::npos) {
       w.write(MGMT_OPT);
+      w.write(' ');
+    }
+
+    // pass the runroot option to traffic_server
+    std::string_view runroot_arg = get_runroot();
+    if (!runroot_arg.empty()) {
+      w.write(RUNROOT_OPT);
+      w.write(runroot_arg);
       w.write(' ');
     }
 

--- a/src/traffic_layout/engine.cc
+++ b/src/traffic_layout/engine.cc
@@ -52,11 +52,13 @@ std::string
 check_path(const std::string &path)
 {
   std::ifstream check_file;
-  check_file.open(Layout::relative_to(path, "runroot_path.yml"));
-  if (check_file.good()) {
-    return path;
+  std::string yaml_file = Layout::relative_to(path, "runroot_path.yml");
+  check_file.open(yaml_file);
+  if (!check_file.good()) {
+    ink_warning("Unable to access runroot: '%s' - %s", yaml_file.c_str(), strerror(errno));
+    return {};
   }
-  return {};
+  return path;
 }
 
 // the function for the checking of the yaml file in passed in directory or parent directory
@@ -73,7 +75,9 @@ check_parent_path(const std::string &path)
     if (yaml_path.empty()) {
       return {};
     }
-    if (!check_path(yaml_path).empty()) {
+    std::ifstream check_file;
+    check_file.open(Layout::relative_to(yaml_path, "runroot_path.yml"));
+    if (check_file.good()) {
       return yaml_path;
     }
     yaml_path = yaml_path.substr(0, yaml_path.find_last_of("/"));

--- a/src/traffic_manager/traffic_manager.cc
+++ b/src/traffic_manager/traffic_manager.cc
@@ -663,6 +663,9 @@ main(int argc, const char **argv)
   std::string apisock(Layout::relative_to(rundir, MGMTAPI_MGMT_SOCKET_NAME));
   std::string eventsock(Layout::relative_to(rundir, MGMTAPI_EVENT_SOCKET_NAME));
 
+  Debug("lm", "using main socket file '%s'", apisock.c_str());
+  Debug("lm", "using event socket file '%s'", eventsock.c_str());
+
   mode_t oldmask = umask(0);
   mode_t newmode = api_socket_is_restricted() ? 00700 : 00777;
 

--- a/tests/gold_tests/runroot/runroot_error.test.py
+++ b/tests/gold_tests/runroot/runroot_error.test.py
@@ -25,11 +25,8 @@ Test for expected error and failure of runroot from traffic_layout.
 '''
 Test.ContinueOnFail = True
 
-p = Test.MakeATSProcess("ts")
-ts_root = p.Env['TS_ROOT']
-
 # create runroot
-path = os.path.join(ts_root, "runroot")
+path = os.path.join(Test.RunDirectory, "runroot")
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = "$ATS_BIN/traffic_layout init --path " + path
 f = tr.Disk.File(os.path.join(path, "runroot_path.yml"))
@@ -59,7 +56,7 @@ f = tr.Disk.File(os.path.join(path_inside, "runroot_path.yml"))
 f.Exists = False
 
 # remove invalid runroot
-path_invalid = os.path.join(ts_root, "tmp")
+path_invalid = os.path.join(Test.RunDirectory, "tmp")
 tr = Test.AddTestRun("remove invalid runroot")
 tr.Processes.Default.Command = "$ATS_BIN/traffic_layout remove --path " + path_invalid
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("Unable to read", "remove incorrect usage")

--- a/tests/gold_tests/runroot/runroot_init.test.py
+++ b/tests/gold_tests/runroot/runroot_init.test.py
@@ -25,11 +25,8 @@ Test for init of runroot from traffic_layout.
 '''
 Test.ContinueOnFail = True
 
-p = Test.MakeATSProcess("ts")
-ts_root = p.Env['TS_ROOT']
-
 # init from pass in path
-path1 = os.path.join(ts_root, "runroot1")
+path1 = os.path.join(Test.RunDirectory, "runroot1")
 tr = Test.AddTestRun("Test traffic_layout init #1")
 tr.Processes.Default.Command = "$ATS_BIN/traffic_layout init --path " + path1
 tr.Processes.Default.ReturnCode = 0
@@ -37,15 +34,15 @@ f = tr.Disk.File(os.path.join(path1, "runroot_path.yml"))
 f.Exists = True
 
 # init to relative directory
-path2 = os.path.join(ts_root, "runroot2")
+path2 = os.path.join(Test.RunDirectory, "runroot2")
 tr = Test.AddTestRun("Test traffic_layout init #2")
-tr.Processes.Default.Command = "cd " + ts_root + ";$ATS_BIN/traffic_layout init --path runroot2"
+tr.Processes.Default.Command = "cd " + Test.RunDirectory + ";$ATS_BIN/traffic_layout init --path runroot2"
 tr.Processes.Default.ReturnCode = 0
 f = tr.Disk.File(os.path.join(path2, "runroot_path.yml"))
 f.Exists = True
 
 # init to cwd
-path3 = os.path.join(ts_root, "runroot3")
+path3 = os.path.join(Test.RunDirectory, "runroot3")
 tr = Test.AddTestRun("Test traffic_layout init #3")
 tr.Processes.Default.Command = "mkdir " + path3 + ";cd " + path3 + ";$ATS_BIN/traffic_layout init"
 tr.Processes.Default.ReturnCode = 0
@@ -53,7 +50,7 @@ f = tr.Disk.File(os.path.join(path3, "runroot_path.yml"))
 f.Exists = True
 
 # --force init to an non-empty directory
-path4 = os.path.join(ts_root, "runroot4")
+path4 = os.path.join(Test.RunDirectory, "runroot4")
 tr = Test.AddTestRun("Test traffic_layout init #4")
 randomfile = os.path.join(path4, "foo")
 tr.Processes.Default.Command = "mkdir " + path4 + ";touch " + randomfile + ";$ATS_BIN/traffic_layout init --force --path " + path4
@@ -63,7 +60,7 @@ f.Exists = True
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("Forcing creating runroot", "force message")
 
 # create runroot with junk to guarantee only traffic server related files are copied
-path5 = os.path.join(ts_root, "runroot5")
+path5 = os.path.join(Test.RunDirectory, "runroot5")
 junk1 = os.path.join(path1, "bin/junk1")
 junk2 = os.path.join(path1, "lib/junk2")
 junk3 = os.path.join(path1, "var/junk3")

--- a/tests/gold_tests/runroot/runroot_manager.test.py
+++ b/tests/gold_tests/runroot/runroot_manager.test.py
@@ -1,0 +1,52 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import sys
+import time
+
+Test.Summary = '''
+Test for using of runroot of traffic_manager.
+'''
+Test.ContinueOnFail = False
+
+# create runroot for testing
+path = os.path.join(Test.RunDirectory, "runroot")
+rr_file = os.path.join(Test.RunDirectory, "rr_tmp")
+
+tr = Test.AddTestRun("create runroot and deal with it")
+tr.Processes.Default.Command = "$ATS_BIN/traffic_layout init --path " + path + " --absolute; " + \
+    "mkdir " + rr_file + "; mv " + \
+    os.path.join(path, "runroot_path.yml") + " " + \
+    os.path.join(rr_file, "runroot_path.yml")
+f = tr.Disk.File(os.path.join(rr_file, "runroot_path.yml"))
+f.Exists = True
+
+
+def StopProcess(event, time):
+    if event.TotalRunTime > time:
+        event.object.Stop()
+    return 0, "stop manager process", "manager will be killed"
+
+
+tr = Test.AddTestRun("manager runroot test")
+p = tr.Processes.Default
+p.Command = "$ATS_BIN/traffic_manager --run-root=" + rr_file
+p.RunningEvent.Connect(Testers.Lambda(lambda ev: StopProcess(ev, 10)))
+p.Streams.All = Testers.ContainsExpression("traffic_server: using root directory '" +
+                                           path + "'", "check if the right runroot is passed down")

--- a/tests/gold_tests/runroot/runroot_remove.test.py
+++ b/tests/gold_tests/runroot/runroot_remove.test.py
@@ -25,24 +25,20 @@ Test for remove of runroot from traffic_layout.
 '''
 Test.ContinueOnFail = True
 
-p = Test.MakeATSProcess("ts")
-ts_root = p.Env['TS_ROOT']
-
-
 # create three runroot for removing testing
-path1 = os.path.join(ts_root, "runroot1")
+path1 = os.path.join(Test.RunDirectory, "runroot1")
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = "$ATS_BIN/traffic_layout init --path " + path1
 f = tr.Disk.File(os.path.join(path1, "runroot_path.yml"))
 f.Exists = True
 
-path2 = os.path.join(ts_root, "runroot2")
+path2 = os.path.join(Test.RunDirectory, "runroot2")
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = "$ATS_BIN/traffic_layout init --path " + path2
 f = tr.Disk.File(os.path.join(path2, "runroot_path.yml"))
 f.Exists = True
 
-path3 = os.path.join(ts_root, "runroot3")
+path3 = os.path.join(Test.RunDirectory, "runroot3")
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = "$ATS_BIN/traffic_layout init --path " + path3
 f = tr.Disk.File(os.path.join(path3, "runroot_path.yml"))
@@ -59,7 +55,7 @@ d.Exists = False
 
 # remove of relative path
 tr = Test.AddTestRun("Test traffic_layout remove #2")
-tr.Processes.Default.Command = "cd " + ts_root + ";$ATS_BIN/traffic_layout remove --path runroot2"
+tr.Processes.Default.Command = "cd " + Test.RunDirectory + ";$ATS_BIN/traffic_layout remove --path runroot2"
 tr.Processes.Default.ReturnCode = 0
 f = tr.Disk.File(os.path.join(path2, "runroot_path.yml"))
 f.Exists = False

--- a/tests/gold_tests/runroot/runroot_use.test.py
+++ b/tests/gold_tests/runroot/runroot_use.test.py
@@ -25,17 +25,14 @@ Test for using of runroot from traffic_layout.
 '''
 Test.ContinueOnFail = True
 
-p = Test.MakeATSProcess("ts")
-ts_root = p.Env['TS_ROOT']
-
 # create two runroot for testing
-path = os.path.join(ts_root, "runroot")
+path = os.path.join(Test.RunDirectory, "runroot")
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = "$ATS_BIN/traffic_layout init --path " + path
 f = tr.Disk.File(os.path.join(path, "runroot_path.yml"))
 f.Exists = True
 
-path2 = os.path.join(ts_root, "runroot2")
+path2 = os.path.join(Test.RunDirectory, "runroot2")
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = "$ATS_BIN/traffic_layout init --path " + path2
 f = tr.Disk.File(os.path.join(path2, "runroot_path.yml"))

--- a/tests/gold_tests/runroot/runroot_verify.test.py
+++ b/tests/gold_tests/runroot/runroot_verify.test.py
@@ -25,11 +25,8 @@ Test for verify of runroot from traffic_layout.
 '''
 Test.ContinueOnFail = True
 
-p = Test.MakeATSProcess("ts")
-ts_root = p.Env['TS_ROOT']
-
 # create runroot
-path = os.path.join(ts_root, "runroot")
+path = os.path.join(Test.RunDirectory, "runroot")
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = "$ATS_BIN/traffic_layout init --path " + path
 f = tr.Disk.File(os.path.join(path, "runroot_path.yml"))


### PR DESCRIPTION
1. Previously, when `traffic_manager` uses runroot, the option is not passed down correctly to `traffic_server` in some cases.

2. Some better error messages support is included

3. Tests are also updated