### PR TITLE
Fix logic to support ASYNC_pause_job

### DIFF
--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -352,9 +352,6 @@ private:
   bool sslTrace                    = false;
   bool SNIMapping                  = false;
   int64_t redoWriteSize            = 0;
-#ifdef SSL_MODE_ASYNC
-  EventIO signalep;
-#endif
 };
 
 typedef int (SSLNetVConnection::*SSLNetVConnHandler)(int, void *);


### PR DESCRIPTION
Fixes I made while creating a crypto engine that really exercises the ASYNC_pause_job feature.  Without these changes the Handshake logic was triggering SSL_accept before the job signaled, (e.g. the read event was on the read_ready_queue).  This could our blocked job to unpause too soon and block on the job's signal read cleanup.

Since we should not be reading the client's network socket at the same time as waiting for the job signal, we just temporarily replace the client socket with the job signal socket in the epoll object.  

Working on open sourcing my crypto engine with the next month.

Need PR #4020 and PR #4019 for stability fixes too.