### PR TITLE
Replace TSHashTable in server session management with IntrusiveHashMap

### DIFF
--- a/doc/developer-guide/internal-libraries/intrusive-list.en.rst
+++ b/doc/developer-guide/internal-libraries/intrusive-list.en.rst
@@ -23,7 +23,9 @@ IntrusiveDList
 :class:`IntrusiveDList` is a class that provides a double linked list using pointers embeded in the
 object. :class:`IntrusiveDList` also acts as a queue. No memory management is done - objects can be
 added to and removed from the list but the allocation and deallocation of the objects must be
-handled outside the class. This class supports an STL compliant bidirectional iteration.
+handled outside the class. This class supports an STL compliant bidirectional iteration. The
+iterators automatically convert to pointer as in normal use of this class the contained elements
+will be referenced by pointers.
 
 Definition
 **********
@@ -51,6 +53,16 @@ Definition
       .. function:: static value_type * & prev_ptr(value_type * elt)
 
          Return a reference to the previous element pointer embedded in the element :arg:`elt`.
+
+   .. type:: iterator
+
+      An STL compliant bidirectional iterator on elements in the list. :type:`iterator` has a user
+      defined conversion to :code:`value_type *` for convenience in use.
+
+   .. type:: const_iterator
+
+      An STL compliant bidirectional constant iterator on elements in the list. :type:`const_iterator` has a user
+      defined conversion to :code:`const value_type *` for convenience in use.
 
    .. function:: value_type * head()
 
@@ -83,6 +95,27 @@ Definition
    .. function:: value_type * take_tail()
 
       Remove the tail element and return a pointer to it. May be :code:`nullptr` if the list is empty.
+
+   .. function:: iterator erase(const iterator & loc)
+
+      Remove the element at :arg:`loc`. Return the element after :arg:`loc`.
+
+   .. function:: iterator erase(const iterator & start, const iterator & limit)
+
+      Remove the elements in the half open range from and including :arg:`start`
+      to but not including :arg:`limit`.
+
+   .. function:: iterator iterator_for(value_type * value)
+
+      Return an :type:`iterator` that refers to :arg:`value`. :arg:`value` is checked for being in a
+      list but there is no guarantee it is in this list. If :arg:`value` is not in a list then the
+      end iterator is returned.
+
+   .. function:: const_iterator iterator_for(const value_type * value)
+
+      Return a :type:`const_iterator` that refers to :arg:`value`. :arg:`value` is checked for being
+      in a list but there is no guarantee it is in this list. If :arg:`value` is not in a list then
+      the end iterator is returned.
 
 Usage
 *****

--- a/lib/ts/IntrusiveDList.h
+++ b/lib/ts/IntrusiveDList.h
@@ -142,6 +142,11 @@ public:
     /// @return A pointer to the referent.
     value_type *operator->() const;
 
+    /// Convenience conversion to pointer type
+    /// Because of how this list is normally used, being able to pass an iterator as a pointer is quite convienent.
+    /// If the iterator isn't valid, it converts to @c nullptr.
+    operator value_type *() const;
+
     /// Equality
     bool operator==(self_type const &that) const;
 
@@ -205,6 +210,11 @@ public:
     /// Dereference.
     /// @return A pointer to the referent.
     value_type *operator->() const;
+
+    /// Convenience conversion to pointer type
+    /// Because of how this list is normally used, being able to pass an iterator as a pointer is quite convienent.
+    /// If the iterator isn't valid, it converts to @c nullptr.
+    operator value_type *() const;
 
   protected:
     /// Internal constructor for containers.
@@ -395,6 +405,11 @@ template <typename L> auto IntrusiveDList<L>::iterator::operator-> () const -> v
   return super_type::_v;
 }
 
+template <typename L> IntrusiveDList<L>::const_iterator::operator value_type *() const
+{
+  return _v;
+}
+
 template <typename L> auto IntrusiveDList<L>::const_iterator::operator*() const -> value_type &
 {
   return *_v;
@@ -403,6 +418,11 @@ template <typename L> auto IntrusiveDList<L>::const_iterator::operator*() const 
 template <typename L> auto IntrusiveDList<L>::iterator::operator*() const -> value_type &
 {
   return *super_type::_v;
+}
+
+template <typename L> IntrusiveDList<L>::iterator::operator value_type *() const
+{
+  return super_type::_v;
 }
 
 template <typename L>

--- a/lib/ts/IntrusiveDList.h
+++ b/lib/ts/IntrusiveDList.h
@@ -265,9 +265,18 @@ public:
   /// @return This list.
   self_type &insert_before(iterator const &target, value_type *v);
 
-  /// Take @a elt out of this list.
-  /// @return This list.
-  self_type &erase(value_type *v);
+  /// Take @a v out of this list.
+  /// @return The element after @a v.
+  value_type *erase(value_type *v);
+
+  /// Take the element at @a loc out of this list.
+  /// @return Iterator for the next element.
+  iterator erase(const iterator &loc);
+
+  /// Take elements out of the list.
+  /// Remove elements start with @a start up to but not including @a limit.
+  /// @return @a limit
+  iterator erase(const iterator &start, const iterator &limit);
 
   /// Remove all elements.
   /// @note @b No memory management is done!
@@ -577,12 +586,15 @@ IntrusiveDList<L>::insert_before(iterator const &target, value_type *v) -> self_
 
 template <typename L>
 auto
-IntrusiveDList<L>::erase(value_type *v) -> self_type &
+IntrusiveDList<L>::erase(value_type *v) -> value_type *
 {
+  value_type *zret{nullptr};
+
   if (L::prev_ptr(v)) {
     L::next_ptr(L::prev_ptr(v)) = L::next_ptr(v);
   }
   if (L::next_ptr(v)) {
+    zret                        = L::next_ptr(v);
     L::prev_ptr(L::next_ptr(v)) = L::prev_ptr(v);
   }
   if (v == _head) {
@@ -594,8 +606,43 @@ IntrusiveDList<L>::erase(value_type *v) -> self_type &
   L::prev_ptr(v) = L::next_ptr(v) = nullptr;
   --_count;
 
-  return *this;
+  return zret;
 }
+
+template <typename L>
+auto
+IntrusiveDList<L>::erase(const iterator &loc) -> iterator
+{
+  return this->iterator_for(this->erase(loc._v));
+};
+
+template <typename L>
+auto
+IntrusiveDList<L>::erase(const iterator &first, const iterator &limit) -> iterator
+{
+  value_type *spot = first;
+  value_type *prev{L::prev_ptr(spot)};
+  if (prev) {
+    L::next_ptr(prev) = limit;
+  }
+  if (spot == _head) {
+    _head = limit;
+  }
+  // tail is only updated if @a limit is @a end (e.g., @c nullptr).
+  if (nullptr == limit) {
+    _tail = prev;
+  } else {
+    L::prev_ptr(limit) = prev;
+  }
+  // Clear links in removed elements.
+  while (spot != limit) {
+    value_type *target{spot};
+    spot                = L::next_ptr(spot);
+    L::prev_ptr(target) = L::next_ptr(target) = nullptr;
+  };
+
+  return {limit._v, this};
+};
 
 template <typename L>
 size_t

--- a/lib/ts/IntrusiveHashMap.h
+++ b/lib/ts/IntrusiveHashMap.h
@@ -28,8 +28,6 @@
 #include <algorithm>
 #include <ts/IntrusiveDList.h>
 
-namespace ts
-{
 /** Intrusive Hash Table.
 
     Values stored in this container are not destroyed when the container is destroyed or removed from the container.
@@ -658,5 +656,3 @@ IntrusiveHashMap<H>::get_expansion_limit() const
   return _expansion_limit;
 }
 /* ---------------------------------------------------------------------------------------------- */
-
-} // namespace ts

--- a/lib/ts/unit-tests/test_IntrusiveHashMap.cc
+++ b/lib/ts/unit-tests/test_IntrusiveHashMap.cc
@@ -144,5 +144,5 @@ TEST_CASE("IntrusiveHashMap", "[libts][IntrusiveHashMap]")
     REQUIRE(elt._payload == "dup"sv);
   }
   // clean up the last bits.
-  map.apply([](Thing &thing) { delete &thing; });
+  map.apply([](Thing *thing) { delete thing; });
 };

--- a/lib/ts/unit-tests/test_IntrusiveHashMap.cc
+++ b/lib/ts/unit-tests/test_IntrusiveHashMap.cc
@@ -120,7 +120,7 @@ TEST_CASE("IntrusiveHashMap", "[libts][IntrusiveHashMap]")
   map.insert(new Thing("dup"sv, 81));
 
   auto r = map.equal_range("dup"sv);
-  REQUIRE(r.first != r.last);
+  REQUIRE(r.first != r.second);
   REQUIRE(r.first->_payload == "dup"sv);
 
   Map::iterator idx;
@@ -131,7 +131,7 @@ TEST_CASE("IntrusiveHashMap", "[libts][IntrusiveHashMap]")
       map.erase(map.iterator_for(&thing));
   });
   r = map.equal_range("dup"sv);
-  REQUIRE(r.first != r.last);
+  REQUIRE(r.first != r.second);
   idx = r.first;
   REQUIRE(idx->_payload == "dup"sv);
   REQUIRE((++idx)->_payload == "dup"sv);

--- a/lib/ts/unit-tests/test_IntrusiveHashMap.cc
+++ b/lib/ts/unit-tests/test_IntrusiveHashMap.cc
@@ -78,7 +78,7 @@ struct ThingMapDescriptor {
   }
 };
 
-using Map = ts::IntrusiveHashMap<ThingMapDescriptor>;
+using Map = IntrusiveHashMap<ThingMapDescriptor>;
 
 } // namespace
 

--- a/proxy/http/HttpConnectionCount.cc
+++ b/proxy/http/HttpConnectionCount.cc
@@ -181,7 +181,7 @@ OutboundConnTrack::obtain(TxnConfig const &txn_cnf, std::string_view fqdn, IpEnd
   Group::Key key{addr, hash, txn_cnf.match};
   std::lock_guard<std::mutex> lock(_imp._mutex); // Table lock
   auto loc = _imp._table.find(key);
-  if (loc.isValid()) {
+  if (loc != _imp._table.end()) {
     zret._g = loc;
   } else {
     zret._g = new Group(key, fqdn);


### PR DESCRIPTION
This depends on #3955 which provides a refresh of `TSHashTable` in the form of `IntrusiveHashMap`. This is part of that refresh in replacing uses of the obsolete `TSHashTable` with `IntrusiveHashMap`.

This PR has a number of commits, which are additional upgrades to `IntrusiveDList` and `IntrusiveHashMap`. While working with this in the server session management there were some additional optimizations that could be done if these features were added to `InstrusiveHashMap` which in turns required some additions to `InstrusiveDList`. These are

* Add a user defined conversion of `IntrusiveDList::iterator` to `value_type*`. Because of the nature of where this class is used, that kind of version is very handy during iteration. In general other methods will require a pointer and having to to `&*iter` repeatedly is confusing and annoying.
* Update `erase` in `IntrusiveDList`. This adds more STL compliance, enabling using `erase` with iterators and iterator defined ranges.
* Change `IntrusiveHashMap::range` to use `std::pair` as a base class. This provides noticeably better integration with the STL algorithms.
* Update `erase` for `IntrusiveHashMap` as was done for `IntrusiveDList`. This was the original change, which require the updates to `IntrusiveDList`. However, I think it's clearer to have the latter changes first.
* Add overloads to `IntrusiveHashMap::apply` so that the functor can take a reference or a pointer. In general the STL containers work with references and `apply` was originally implemented in that way. However, because as noted earlier, the nature of use for intrusive containers uses pointers instead of references, this is a bit awkward. Adding this overload means that in most cases already existing methods / functions can be used, without additional shimming.

Finally, there are the actual changes to server session management.