### PR TITLE
Add configs for groups list

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3126,6 +3126,30 @@ SSL Termination
    connections to origin or next hop. This configuration works
    with OpenSSL v1.1.1 and above.
 
+.. ts:cv:: CONFIG proxy.config.ssl.server.groups_list STRING <See notes>
+
+   Configures the list of supported groups provided by OpenSSL which
+   |TS| will be used to determine the set of shared groups. The value
+   is a colon separated list of group NIDs or names, for example
+   "P-521:P-384:P-256". For instructions, see "Groups" section of
+   `TLS1.3 - OpenSSLWiki <https://wiki.openssl.org/index.php/TLS1.3#Groups>`_.
+
+   The current default value with OpenSSL is:
+
+   X25519:P-256:X448:P-521:P-384
+
+   This configuration works with OpenSSL v1.1.1 and above.
+
+.. ts:cv:: CONFIG proxy.config.ssl.client.groups_list STRING <See notes under proxy.config.ssl.server.groups_list.>
+
+   Configures the list of supported groups provided by OpenSSL which
+   |TS| will use for the "key_share" and "supported groups" extention
+   of TLSv1.3 connections. The value is a colon separated list of
+   group NIDs or names, for example "P-521:P-384:P-256". For
+   instructions, see "Groups" section of `TLS1.3 - OpenSSLWiki <https://wiki.openssl.org/index.php/TLS1.3#Groups>`_.
+
+   This configuration works with OpenSSL v1.1.1 and above.
+
 .. ts:cv:: CONFIG proxy.config.ssl.TLSv1 INT 1
 
    Enables (``1``) or disables (``0``) TLSv1.

--- a/iocore/net/P_SSLConfig.h
+++ b/iocore/net/P_SSLConfig.h
@@ -89,6 +89,8 @@ struct SSLConfigParams : public ConfigInfo {
 
   char *server_tls13_cipher_suites;
   char *client_tls13_cipher_suites;
+  char *server_groups_list;
+  char *client_groups_list;
 
   static int ssl_maxrecord;
   static bool ssl_allow_client_renegotiation;

--- a/iocore/net/SSLClientUtils.cc
+++ b/iocore/net/SSLClientUtils.cc
@@ -146,6 +146,15 @@ SSLInitClientContext(const SSLConfigParams *params)
   }
 #endif
 
+#ifdef SSL_CTX_set1_groups_list
+  if (params->client_groups_list != nullptr) {
+    if (!SSL_CTX_set1_groups_list(client_ctx, params->client_groups_list)) {
+      SSLError("invalid groups list for client in records.config");
+      goto fail;
+    }
+  }
+#endif
+
   // if no path is given for the client private key,
   // assume it is contained in the client certificate file.
   clientKeyPtr = params->clientKeyPath;

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -96,6 +96,8 @@ SSLConfigParams::reset()
       nullptr;
   server_tls13_cipher_suites = nullptr;
   client_tls13_cipher_suites = nullptr;
+  server_groups_list         = nullptr;
+  client_groups_list         = nullptr;
   client_ctx                 = nullptr;
   clientCertLevel = client_verify_depth = verify_depth = clientVerify = 0;
   ssl_ctx_options                                                     = SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3;
@@ -129,6 +131,8 @@ SSLConfigParams::cleanup()
 
   server_tls13_cipher_suites = (char *)ats_free_null(server_tls13_cipher_suites);
   client_tls13_cipher_suites = (char *)ats_free_null(client_tls13_cipher_suites);
+  server_groups_list         = (char *)ats_free_null(server_groups_list);
+  client_groups_list         = (char *)ats_free_null(client_groups_list);
 
   freeCTXmap();
   SSLReleaseContext(client_ctx);
@@ -312,6 +316,8 @@ SSLConfigParams::initialize()
   REC_ReadConfigInt32(async_handshake_enabled, "proxy.config.ssl.async.handshake.enabled");
   REC_ReadConfigStringAlloc(engine_conf_file, "proxy.config.ssl.engine.conf_file");
 
+  REC_ReadConfigStringAlloc(server_groups_list, "proxy.config.ssl.server.groups_list");
+
   // ++++++++++++++++++++++++ Client part ++++++++++++++++++++
   client_verify_depth = 7;
   REC_EstablishStaticConfigByte(clientVerify, "proxy.config.ssl.client.verify.server");
@@ -337,6 +343,8 @@ SSLConfigParams::initialize()
   set_paths_helper(clientCACertRelativePath, ssl_client_ca_cert_filename, &clientCACertPath, &clientCACertFilename);
   ats_free(clientCACertRelativePath);
   ats_free(ssl_client_ca_cert_filename);
+
+  REC_ReadConfigStringAlloc(client_groups_list, "proxy.config.ssl.client.groups_list");
 
   // Enable/disable sni mapping
   REC_ReadConfigInteger(sni_map_enable, "proxy.config.ssl.sni.map.enable");

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1852,6 +1852,15 @@ SSLInitServerContext(const SSLConfigParams *params, const ssl_user_config *sslMu
   }
 #endif
 
+#ifdef SSL_CTX_set1_groups_list
+  if (params->server_groups_list != nullptr) {
+    if (!SSL_CTX_set1_groups_list(ctx, params->server_groups_list)) {
+      SSLError("invalid groups list for server in records.config");
+      goto fail;
+    }
+  }
+#endif
+
   if (!ssl_context_enable_dhe(params->dhparamsFile, ctx)) {
     goto fail;
   }

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1175,6 +1175,10 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.ssl.cert.load_elevated", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_READ_ONLY}
   ,
+  {RECT_CONFIG, "proxy.config.ssl.server.groups_list", RECD_STRING, nullptr, RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
+  {RECT_CONFIG, "proxy.config.ssl.client.groups_list", RECD_STRING, nullptr, RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
 
   //##############################################################################
   //#


### PR DESCRIPTION
Fix #3604. This needs #4039 to work correctly.

Add new configs for supported groups
```
proxy.config.ssl.server.groups_list
proxy.config.ssl.client.groups_list
```