### PR TITLE
Adjust tests to work with more versions of curl.

### DIFF
--- a/tests/gold_tests/h2/gold/priority_0_stderr.gold
+++ b/tests/gold_tests/h2/gold/priority_0_stderr.gold
@@ -1,11 +1,11 @@
 ``
-> GET /bigfile HTTP/2
+> GET /bigfile HTTP/{}
 > Host: ``
 > User-Agent: curl/``
 > Accept: */*
 ``
-< HTTP/2 200 ``
-< server: ATS/``
+< HTTP/2{} 200 ``
+< server:{}ATS/``
 ``
-< content-length: 1048576
+< content-length:{}1048576
 ``

--- a/tests/gold_tests/h2/http2.test.py
+++ b/tests/gold_tests/h2/http2.test.py
@@ -129,8 +129,9 @@ tr.Processes.Default.Streams.All = "gold/active_timeout.gold"
 tr.StillRunningAfter = server
 
 # Test Case 6: Post with chunked body
+# cannot explicitly specify Transfer-Encoding with a HTTP/2 requests because this is against the HTTP/2 spec.  ATS will error with malformed request
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'curl -s -k -H "Transfer-Encoding: chunked" -d "{0}" https://127.0.0.1:{1}/postchunked'.format( post_body, ts.Variables.ssl_port)
+tr.Processes.Default.Command = 'curl -s -k -d "{0}" https://127.0.0.1:{1}/postchunked'.format( post_body, ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = "gold/post_chunked.gold"
 tr.StillRunningAfter = server


### PR DESCRIPTION
I used a new version of curl that supports http2.  In the output check for the h2 priority test it was showing headers without spaces and HTTP/2.0 instead of HTTP/2.

For the http2 chunked test, my curl was passing along the Transfer-Encoding which caused ATS's H2 processing to fail the request as malformed.  I think other versions of curl just don't pass along the the Transfer-Encoding header since it violates the HTTP/2 spec.