### PR TITLE
Remove Http2ConnectionState::continued_buffer

### DIFF
--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -146,11 +146,7 @@ public:
   {
     local_hpack_handle  = new HpackHandle(HTTP2_HEADER_TABLE_SIZE);
     remote_hpack_handle = new HpackHandle(HTTP2_HEADER_TABLE_SIZE);
-
-    continued_buffer.iov_base = NULL;
-    continued_buffer.iov_len  = 0;
-
-    dependency_tree = new DependencyTree(Http2::max_concurrent_streams_in);
+    dependency_tree     = new DependencyTree(Http2::max_concurrent_streams_in);
   }
 
   void
@@ -161,9 +157,6 @@ public:
     mutex = NULL; // magic happens - assigning to NULL frees the ProxyMutex
     delete local_hpack_handle;
     delete remote_hpack_handle;
-
-    ats_free(continued_buffer.iov_base);
-
     delete dependency_tree;
     this->ua_session = nullptr;
 
@@ -305,7 +298,6 @@ private:
   //     "If the END_HEADERS bit is not set, this frame MUST be followed by
   //     another CONTINUATION frame."
   Http2StreamId continued_stream_id;
-  IOVec continued_buffer;
   bool _scheduled;
   bool fini_received;
   int recursion;


### PR DESCRIPTION
continued_buffer is not used at all

(cherry picked from commit e4a94b9cec7119c96fde1205611cb60ceed8428d)

Conflicts:
	proxy/http2/Http2ConnectionState.h

----

Backport #3970 to 7.1.x