### PR TITLE
Runroot: Update test to support different layout

### DIFF
--- a/tests/gold_tests/runroot/runroot_init.test.py
+++ b/tests/gold_tests/runroot/runroot_init.test.py
@@ -24,6 +24,8 @@ Test.Summary = '''
 Test for init of runroot from traffic_layout.
 '''
 Test.ContinueOnFail = True
+Test.SkipUnless(Test.Variables.BINDIR.startswith(Test.Variables.PREFIX),
+                "need to guarantee bin path starts with prefix for runroot")
 
 # init from pass in path
 path1 = os.path.join(Test.RunDirectory, "runroot1")
@@ -60,28 +62,20 @@ f.Exists = True
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("Forcing creating runroot", "force message")
 
 # create runroot with junk to guarantee only traffic server related files are copied
+bin_path = Test.Variables.BINDIR[Test.Variables.BINDIR.find(Test.Variables.PREFIX) + len(Test.Variables.PREFIX) + 1:]
 path5 = os.path.join(Test.RunDirectory, "runroot5")
-junk1 = os.path.join(path1, "bin/junk1")
-junk2 = os.path.join(path1, "lib/junk2")
-junk3 = os.path.join(path1, "var/junk3")
+exe_path = os.path.join(bin_path, "traffic_layout")
+junk_file = os.path.join(bin_path, "junk")
+junk = os.path.join(path1, junk_file)
 
 tr = Test.AddTestRun("Test traffic_layout init #5")
 # create the junk files in runroot1 and create(init and copy) runroot5 from runroot 1
-tr.Processes.Default.Command = "touch " + junk1 + ";" + "touch " + junk2 + ";" + \
-    "touch " + junk3 + ";" + path1 + "/bin/traffic_layout init --path " + path5
+tr.Processes.Default.Command = "touch " + junk + ";" + os.path.join(path1, exe_path) + " init --path " + path5
 tr.Processes.Default.ReturnCode = 0
 f = tr.Disk.File(os.path.join(path5, "runroot_path.yml"))
 f.Exists = True
 # check if the junk file is created and not copied to the new runroot
-f = tr.Disk.File(junk1)
+f = tr.Disk.File(junk)
 f.Exists = True
-f = tr.Disk.File(os.path.join(path5, "bin/junk1"))
-f.Exists = False
-f = tr.Disk.File(junk2)
-f.Exists = True
-f = tr.Disk.File(os.path.join(path5, "lib/junk2"))
-f.Exists = False
-f = tr.Disk.File(junk3)
-f.Exists = True
-f = tr.Disk.File(os.path.join(path5, "var/junk3"))
+f = tr.Disk.File(os.path.join(path5, junk_file))
 f.Exists = False

--- a/tests/gold_tests/runroot/runroot_use.test.py
+++ b/tests/gold_tests/runroot/runroot_use.test.py
@@ -24,6 +24,8 @@ Test.Summary = '''
 Test for using of runroot from traffic_layout.
 '''
 Test.ContinueOnFail = True
+Test.SkipUnless(Test.Variables.BINDIR.startswith(Test.Variables.PREFIX),
+                "need to guarantee bin path starts with prefix for runroot")
 
 # create two runroot for testing
 path = os.path.join(Test.RunDirectory, "runroot")
@@ -51,8 +53,9 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("PREFIX: " + path, "cwd runroot path")
 
 # 4. use path directly bin
+bin_path = Test.Variables.BINDIR[Test.Variables.BINDIR.find(Test.Variables.PREFIX) + len(Test.Variables.PREFIX) + 1:]
 tr = Test.AddTestRun("use runroot via bin executable")
-tr.Processes.Default.Command = os.path.join(path, "bin/traffic_layout info")
+tr.Processes.Default.Command = os.path.join(path, os.path.join(bin_path, "traffic_layout") + " info")
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("PREFIX: " + path, "bin path")
 

--- a/tests/gold_tests/runroot/runroot_verify.test.py
+++ b/tests/gold_tests/runroot/runroot_verify.test.py
@@ -24,6 +24,8 @@ Test.Summary = '''
 Test for verify of runroot from traffic_layout.
 '''
 Test.ContinueOnFail = True
+Test.SkipUnless(Test.Variables.BINDIR.startswith(Test.Variables.PREFIX),
+                "need to guarantee bin path starts with prefix for runroot")
 
 # create runroot
 path = os.path.join(Test.RunDirectory, "runroot")
@@ -48,9 +50,11 @@ tr.Processes.Default.Streams.All = Testers.ContainsExpression(
     "Write Permission: ", "write permission output")
 
 # verify test #2
+bin_path = Test.Variables.BINDIR[Test.Variables.BINDIR.find(
+    Test.Variables.PREFIX) + len(Test.Variables.PREFIX) + 1:]
 tr = Test.AddTestRun("verify runroot test2")
-tr.Processes.Default.Command = "cd " + path + \
-    ";" + "bin/traffic_layout verify --path " + path
+tr.Processes.Default.Command = "cd " + path + ";" + \
+    os.path.join(bin_path, "traffic_layout") + " verify --path " + path
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ContainsExpression(
     os.path.join(path, "bin"), "example bindir output")


### PR DESCRIPTION
Some failures of runroot tests are detected when different layout is used when trafficserver is built.
The updated tests will support all layouts.