### PR TITLE
process early data during handshake

### DIFF
--- a/iocore/net/quic/QUICPacket.cc
+++ b/iocore/net/quic/QUICPacket.cc
@@ -1131,6 +1131,11 @@ QUICPacketFactory::set_hs_protocol(QUICHandshakeProtocol *hs_protocol)
   this->_hs_protocol = hs_protocol;
 }
 
+bool
+QUICPacketFactory::is_ready_to_create_protected_packet()
+{
+  return this->_hs_protocol->is_handshake_finished();
+}
 //
 // QUICPacketNumberGenerator
 //

--- a/iocore/net/quic/QUICPacket.h
+++ b/iocore/net/quic/QUICPacket.h
@@ -394,6 +394,7 @@ public:
                                                 ats_unique_buf payload, size_t len, bool retransmittable);
   void set_version(QUICVersion negotiated_version);
   void set_hs_protocol(QUICHandshakeProtocol *hs_protocol);
+  bool is_ready_to_create_protected_packet();
 
 private:
   QUICVersion _version                = QUIC_SUPPORTED_VERSIONS[0];

--- a/iocore/net/quic/QUICPacketReceiveQueue.cc
+++ b/iocore/net/quic/QUICPacketReceiveQueue.cc
@@ -133,6 +133,15 @@ QUICPacketReceiveQueue::dequeue(QUICPacketCreationResult &result)
       this->_offset      = 0;
     }
   } else {
+    if (!this->_packet_factory.is_ready_to_create_protected_packet() && udp_packet) {
+      this->enqueue(udp_packet);
+      this->_payload.release();
+      this->_payload     = nullptr;
+      this->_payload_len = 0;
+      this->_offset      = 0;
+      result = QUICPacketCreationResult::NOT_READY;
+      return quic_packet;
+    }
     pkt                = std::move(this->_payload);
     pkt_len            = this->_payload_len;
     this->_payload     = nullptr;


### PR DESCRIPTION
I came across an "Ignore PROTECTED(1) packet" error when running quic in test environment. Looked into the issue, it seems the early data packet was not processed before handshake completion. I made a minor change that worked in my environment, pls take a look. (My local branch was a bit older, please ignore if it's already fixed)  @masaori335 @maskit 