### PR TITLE
Setup better defaults for service file logic

### DIFF
--- a/rc/trafficserver.in
+++ b/rc/trafficserver.in
@@ -97,6 +97,12 @@ SLEEP_TIME=5
 TS_PREFIX="@prefix@"
 
 TS_ROOT=${TS_ROOT:-$TS_PREFIX}
+
+# ####################################
+# run root is not used by default
+# set this value if using a custom layout structure
+# TS_RUNROOT="" 
+
 # TS_BASE is offset inside the file system from where the layout starts
 # For standard installations TS_BASE will be empty
 eval TS_BASE="`echo $TS_ROOT | ${ESED} -e 's;@prefix@$;;'`"
@@ -108,6 +114,7 @@ TM_DAEMON_ARGS=""
 TS_DAEMON=${TS_DAEMON:-$TS_BASE@exp_bindir@/traffic_server}
 TS_DAEMON_ARGS=""
 TL_BINARY=${TL_BINARY:-$TS_BASE@exp_bindir@/traffic_ctl}
+TY_BINARY=${TL_BINARY:-$TS_BASE@exp_bindir@/traffic_layout}
 TM_PIDFILE=${TM_PIDFILE:-$TS_BASE@exp_runtimedir@/manager.lock}
 TS_PIDFILE=${TS_PIDFILE:-$TS_BASE@exp_runtimedir@/server.lock}
 # number of times to retry check on pid lock file

--- a/rc/trafficserver.service.in
+++ b/rc/trafficserver.service.in
@@ -22,9 +22,16 @@ After=syslog.target network.target
 [Service]
 Type=simple
 EnvironmentFile=-/etc/sysconfig/trafficserver
-PIDFile=@exp_runtimedir@/manager.pid
-ExecStart=@exp_bindir@/traffic_manager --bind_stdout @exp_logdir@/traffic.out --bind_stderr @exp_logdir@/traffic.out $TM_DAEMON_ARGS
+ExecStart=@exp_bindir@/traffic_manager $TM_DAEMON_ARGS
+Restart=on-failure
+RestartSec=5s
+ExecStopPost=/bin/sh -c ' \
+        export TM_PIDFILE=$(@exp_bindir@/traffic_layout} 2>/dev/null | grep RUNTIMEDIR | cut -d: -f2)/manager.lock ; \
+        /bin/rm -f $TM_PIDFILE ; \
+        if [[ $? -ne 0 ]]; then echo "ERROR: Unable to delete PID"; exit 1; fi'
+TimeoutStopSec=5s
 ExecReload=@exp_bindir@/traffic_ctl config reload
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Add support for the TS_RUNROOT feature.
Tweak stop logic to clean up files.
Don't hide output from traffic_manger from service daemon.