### PR TITLE
Fix Http/2 priority crashes.

### DIFF
--- a/proxy/http2/test_Http2DependencyTree.cc
+++ b/proxy/http2/test_Http2DependencyTree.cc
@@ -657,6 +657,102 @@ REGRESSION_TEST(Http2DependencyTree_reprioritize_3)(RegressionTest *t, int /* at
   delete tree;
 }
 
+/**
+ * https://github.com/apache/trafficserver/issues/4057
+ * Reprioritization to root
+ *
+ *    x                x
+ *    |               / \
+ *    A              A   D
+ *   / \            / \  |
+ *  B   C     ==>  B   C F
+ *     / \             |
+ *    D   E            E
+ *    |
+ *    F
+ */
+REGRESSION_TEST(Http2DependencyTree_reprioritize_4)(RegressionTest *t, int /* atype ATS_UNUSED */, int *pstatus)
+{
+  TestBox box(t, pstatus);
+  box = REGRESSION_TEST_PASSED;
+
+  Tree *tree = new Tree(100);
+  string a("A"), b("B"), c("C"), d("D"), e("E"), f("F");
+
+  tree->add(0, 1, 0, false, &a);
+  tree->add(1, 3, 0, false, &b);
+  tree->add(1, 5, 0, false, &c);
+  tree->add(5, 7, 0, false, &d);
+  tree->add(5, 9, 0, false, &e);
+  tree->add(7, 11, 0, false, &f);
+
+  Node *node_x = tree->find(0);
+  Node *node_a = tree->find(1);
+  Node *node_c = tree->find(5);
+  Node *node_d = tree->find(7);
+  Node *node_f = tree->find(11);
+
+  tree->activate(node_f);
+  tree->reprioritize(7, 0, false);
+
+  box.check(!node_a->queue->in(node_f->entry), "F should not be in A's queue");
+  box.check(node_d->queue->in(node_f->entry), "F should be in D's queue");
+  box.check(node_x->queue->in(node_d->entry), "D should be in x's queue");
+  box.check(!node_a->queue->in(node_c->entry), "C should not be in A's queue");
+  box.check(node_c->queue->empty(), "C's queue should be empty");
+
+  delete tree;
+}
+
+/**
+ * https://github.com/apache/trafficserver/issues/4057
+ * Reprioritization to unrelated node
+ *
+ *    x                x
+ *    |                |
+ *    A                A
+ *   / \              / \
+ *  B   C     ==>    B   C
+ *     / \           |   |
+ *    D   E          D   E
+ *    |              |
+ *    F              F
+ */
+REGRESSION_TEST(Http2DependencyTree_reprioritize_5)(RegressionTest *t, int /* atype ATS_UNUSED */, int *pstatus)
+{
+  TestBox box(t, pstatus);
+  box = REGRESSION_TEST_PASSED;
+
+  Tree *tree = new Tree(100);
+  string a("A"), b("B"), c("C"), d("D"), e("E"), f("F");
+
+  tree->add(0, 1, 0, false, &a);
+  tree->add(1, 3, 0, false, &b);
+  tree->add(1, 5, 0, false, &c);
+  tree->add(5, 7, 0, false, &d);
+  tree->add(5, 9, 0, false, &e);
+  tree->add(7, 11, 0, false, &f);
+
+  Node *node_x = tree->find(0);
+  Node *node_a = tree->find(1);
+  Node *node_b = tree->find(3);
+  Node *node_c = tree->find(5);
+  Node *node_d = tree->find(7);
+  Node *node_f = tree->find(11);
+
+  tree->activate(node_f);
+  tree->reprioritize(7, 3, false);
+
+  box.check(node_a->queue->in(node_b->entry), "B should be in A's queue");
+  box.check(node_b->queue->in(node_d->entry), "D should be in B's queue");
+  box.check(!node_c->queue->in(node_d->entry), "D should not be in C's queue");
+  box.check(node_x->queue->in(node_a->entry), "A should be in x's queue");
+  box.check(!node_a->queue->in(node_c->entry), "C should not be in A's queue");
+  box.check(node_c->queue->empty(), "C's queue should be empty");
+
+  delete tree;
+}
+
 /** test for https://github.com/apache/trafficserver/issues/2268
  *
  *    root            root                  root


### PR DESCRIPTION
This addresses the crashes reported in issue #4057 

I will probably make another pass to remove some of the debugging asserts.  The main problem was in the first call to _change_parent in reprioritize.  This call should only be done of the change in dependence would cause a loop.  Otherwise that call will cause a direct crash or a parent loop.

From section 5.3.3 of the spec https://http2.github.io/http2-spec/#reprioritize
```
If a stream is made dependent on one of its own dependencies, the formerly dependent stream is first moved to be dependent on the reprioritized stream's previous parent. The moved dependency retains its weight.
```