### PR TITLE
Enable ECDH explicitly only if OpenSSL version is v1.0.2 or lower

### DIFF
--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -539,9 +539,13 @@ ssl_context_enable_dhe(const char *dhparams_file, SSL_CTX *ctx)
   return ctx;
 }
 
+// SSL_CTX_set_ecdh_auto() is removed by OpenSSL v1.1.0 and ECDH is enabled in default.
+// TODO: remove this function when we drop support of OpenSSL v1.0.2* and lower.
 static SSL_CTX *
 ssl_context_enable_ecdh(SSL_CTX *ctx)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000
+
 #if TS_USE_TLS_ECKEY
 
 #if defined(SSL_CTRL_SET_ECDH_AUTO)
@@ -553,6 +557,7 @@ ssl_context_enable_ecdh(SSL_CTX *ctx)
     SSL_CTX_set_tmp_ecdh(ctx, ecdh);
     EC_KEY_free(ecdh);
   }
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
SSL_CTX_set_ecdh_auto() has been removed and ECDH is enabled in default
since OpenSSL v1.1.0.

(cherry picked from commit 034c25b5b8ebe764e94f5bb3beca6a2599c40c66)

----

Backport #4039 