### PR TITLE
Fix typo in header_normalize plugin.

### DIFF
--- a/plugins/experimental/header_normalize/header_normalize.cc
+++ b/plugins/experimental/header_normalize/header_normalize.cc
@@ -171,7 +171,7 @@ TSRemapNewInstance(int /* argc */, char * /* argv[] */, void ** /* ih */, char *
 }
 
 void
-TSRemapDelteInstance(void * /* ih */)
+TSRemapDeleteInstance(void * /* ih */)
 {
 }
 


### PR DESCRIPTION
(cherry picked from commit 9d2e6df5f8a4f5899fe0f7f7441fda7dedf3d15c)