### PR TITLE
WIP: Support SO_REUSEPORT in NetAccept

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -294,8 +294,12 @@ Thread Variables
 
 .. ts:cv:: CONFIG proxy.config.accept_threads INT 1
 
-   The number of accept threads. If disabled (``0``), then accepts will be done
-   in each of the worker threads.
+   The number of dedicated accept threads for a server port.
+   If equal or less than ``0``, a new thread group ET_ACCEPT will be created,
+   the number of ET_ACCEPT threads is the same as ET_NET.
+   If equal ``0``, then accepts will be done in each of the ET_ACCEPT threads.
+   If less than ``0``, then accepts will be done in only ``-accept_threads`` of
+   ET_ACCEPT threads.
 
 .. ts:cv:: CONFIG proxy.config.thread.default.stacksize INT 1048576
 

--- a/iocore/net/Connection.cc
+++ b/iocore/net/Connection.cc
@@ -211,6 +211,11 @@ Server::setup_fd_for_listen(bool non_blocking, const NetProcessor::AcceptOptions
   if ((res = safe_setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, SOCKOPT_ON, sizeof(int))) < 0) {
     goto Lerror;
   }
+#ifdef SO_REUSEPORT
+  if ((res = safe_setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, SOCKOPT_ON, sizeof(int))) < 0) {
+    goto Lerror;
+  }
+#endif
 
   if ((opt.sockopt_flags & NetVCOptions::SOCK_OPT_NO_DELAY) &&
       (res = safe_setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, SOCKOPT_ON, sizeof(int))) < 0) {

--- a/iocore/net/I_Net.h
+++ b/iocore/net/I_Net.h
@@ -88,6 +88,7 @@ extern int net_throttle_delay;
  */
 
 #define ET_NET ET_CALL
+extern EventType ET_ACCEPT;
 
 #include "I_NetVConnection.h"
 #include "I_NetProcessor.h"

--- a/iocore/net/I_NetProcessor.h
+++ b/iocore/net/I_NetProcessor.h
@@ -179,6 +179,7 @@ public:
 
   */
   virtual void init() = 0;
+  virtual int start_accept(int n_accept_threads, size_t stacksize = DEFAULT_STACKSIZE) = 0;
 
   inkcoreapi virtual NetVConnection *allocate_vc(EThread *) = 0;
 

--- a/iocore/net/P_NetAccept.h
+++ b/iocore/net/P_NetAccept.h
@@ -63,8 +63,8 @@ struct NetAcceptAction : public Action, public RefCountObj {
   void
   cancel(Continuation *cont = nullptr) override
   {
-    Action::cancel(cont);
     server->close();
+    Action::cancel(cont);
   }
 
   Continuation *
@@ -84,7 +84,6 @@ struct NetAccept : public Continuation {
   ink_hrtime period = 0;
   Server server;
   AcceptFunctionPtr accept_fn = nullptr;
-  int ifd                     = NO_FD;
   int id                      = -1;
   Ptr<NetAcceptAction> action_;
   SSLNextProtocolAccept *snpa = nullptr;

--- a/iocore/net/P_UnixNetProcessor.h
+++ b/iocore/net/P_UnixNetProcessor.h
@@ -43,6 +43,7 @@ public:
   NetVConnection *allocate_vc(EThread *t) override;
 
   void init() override;
+  int start_accept(int n_accept_threads, size_t stacksize) override;
 
   Event *accept_thread_event;
 
@@ -69,5 +70,6 @@ extern UnixNetProcessor unix_netProcessor;
 // accept such events by the EventProcesor.
 //
 extern void initialize_thread_for_net(EThread *thread);
+extern void initialize_thread_for_accept(EThread *thread);
 
 //#include "UnixNet.h"

--- a/iocore/net/UnixNetProcessor.cc
+++ b/iocore/net/UnixNetProcessor.cc
@@ -29,6 +29,7 @@
 // For Stat Pages
 #include "StatPages.h"
 
+EventType ET_ACCEPT = ET_NET;
 int net_accept_number = 0;
 NetProcessor::AcceptOptions const NetProcessor::DEFAULT_ACCEPT_OPTIONS;
 
@@ -336,6 +337,17 @@ UnixNetProcessor::init()
   if (etype == ET_NET) {
     statPagesManager.register_http("net", register_ShowNet);
   }
+}
+
+int
+UnixNetProcessor::start_accept(int n_accept_threads, size_t stacksize)
+{
+  ET_ACCEPT = eventProcessor.register_event_type("ET_ACCEPT");
+  NetHandler::active_thread_types[ET_ACCEPT] = true;
+  eventProcessor.schedule_spawn(&initialize_thread_for_accept, ET_ACCEPT);
+  eventProcessor.spawn_event_threads(ET_ACCEPT, n_accept_threads, stacksize);
+
+  return 0;
 }
 
 // Virtual function allows creation of an

--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -1033,6 +1033,11 @@ LocalManager::bindProxyPort(HttpProxyPort &port)
   if (setsockopt(port.m_fd, SOL_SOCKET, SO_REUSEADDR, (char *)&one, sizeof(int)) < 0) {
     mgmt_fatal(0, "[bindProxyPort] Unable to set socket options: %d : %s\n", port.m_port, strerror(errno));
   }
+#ifdef SO_REUSEPORT
+  if (setsockopt(port.m_fd, SOL_SOCKET, SO_REUSEPORT, (char *)&one, sizeof(int)) < 0) {
+    mgmt_fatal(0, "[bindProxyPort] Unable to set socket options: %d : %s\n", port.m_port, strerror(errno));
+  }
+#endif
 
   if (port.m_inbound_transparent_p) {
 #if TS_USE_TPROXY

--- a/proxy/shared/UglyLogStubs.cc
+++ b/proxy/shared/UglyLogStubs.cc
@@ -104,6 +104,11 @@ UnixNetProcessor::init()
   ink_release_assert(false);
 }
 
+int UnixNetProcessor::start_accept(int n_accept_threads, size_t stacksize)
+{
+  ink_release_assert(false);
+}
+
 // TODO: The following was necessary only for Solaris, should examine more.
 NetVCOptions const Connection::DEFAULT_OPTIONS;
 NetProcessor::AcceptOptions const NetProcessor::DEFAULT_ACCEPT_OPTIONS;

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -1845,6 +1845,12 @@ main(int /* argc ATS_UNUSED */, const char **argv)
       }
     }
   } else {
+    int accept_threads;
+    REC_ReadConfigInteger(accept_threads, "proxy.config.accept_threads");
+    if (accept_threads <= 0) {
+      // Create a new thread group (ET_ACCEPT) for NetAccept::acceptLoopEvent
+      netProcessor.start_accept(num_of_net_threads, stacksize);
+    }
     remapProcessor.start(num_remap_threads, stacksize);
     RecProcessStart();
     initCacheControl();


### PR DESCRIPTION
Every listen fd has its own backlog queue. With SO_REUSEPORT, ATS could create multiple listen FDs on the same  server ports, that means there are multiple backlog queues for the same server ports.
The kernel guarantees that the incoming connections are load balanced into each backlog queue.

if the  `proxy.config.accept_threads` set to `0`, NetAccept will be created in each ET_NET thread and each NetAccept has its own listen fd and backlog queue.

The listen fd is added into the epoll fd. These ET_NET threads are blocked on epoll_wait and returned on timeout or any new incoming connection or any NetVC I/O events.
Then the NetAccept is triggered by negative event and calls `accept()` for the new connections until errno is EAGAIN. It is unnecessary to trigger the NetAccept when epoll_wait returned on timeout or any NetVC I/O events.

NetAccept and NetHandler block each other because they run in the same ET_NET thread.

With this patch:

- NetAccept run in the ET_ACCEPT thread. NetAccept does not block NetHandler and is not blocked by it.
- If you don't want to create NetAccept as many as there are ET_NET threads, set the  `proxy.config.accept_threads` set to `-n`, or set it to `0`.
- NetVCs are `born` in ET_ACCEPT and `grow up` in ET_NET. The NetAccept guarantees that the NetVCs 
 are load balanced into each ET_NET thread.
- These ET_ACCEPT threads are blocked on epoll_wait and returned on timeout or any new incoming connection.