### PR TITLE
reenable timeout and change microServer timeout logic

### DIFF
--- a/tests/gold_tests/timeout/timeout.test.py
+++ b/tests/gold_tests/timeout/timeout.test.py
@@ -21,7 +21,6 @@ Test.Summary = 'Testing ATS TCP handshake timeout'
 Test.SkipUnless(
     Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
 )
-Test.SkipIf(Condition.true("Currently fixing a race condition in this test."))
 
 ts = Test.MakeATSProcess("ts")
 server = Test.MakeOriginServer("server", delay=15)
@@ -40,7 +39,6 @@ ts.Disk.records_config.update({
 })
 
 tr = Test.AddTestRun("tr")
-tr.StartupTimeout = 30
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(ts, ready=When.PortOpen(ts.Variables.port))
 tr.Processes.Default.StartBefore(dns)

--- a/tests/tools/microServer/uWServer.py
+++ b/tests/tools/microServer/uWServer.py
@@ -389,7 +389,8 @@ class MyHandler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         global G_replay_dict, test_mode_enabled
-        if test_mode_enabled:
+        # skip time delay for the autest ready check
+        if test_mode_enabled and self.requestline != "GET /ruok HTTP/1.1":
             time.sleep(time_delay)
 
         try:


### PR DESCRIPTION
Microserver no longer delays on autest's ready checks