### PR TITLE
logstats conditionally disable format check

### DIFF
--- a/doc/appendices/command-line/traffic_logstats.en.rst
+++ b/doc/appendices/command-line/traffic_logstats.en.rst
@@ -52,39 +52,85 @@ Options
 
 .. option:: -f FILE, --log_file FILE
 
+   Specific logfile to parse
+
 .. option:: -o LIST, --origin_list LIST
+
+   Only show stats for listed Origins
 
 .. option:: -O FILE, --origin_file FILE
 
+   File listing Origins to show
+
 .. option:: -M COUNT, --max_origins COUNT
+
+   Max number of Origins to show
 
 .. option:: -u COUNT, --urls COUNT
 
+   Produce JSON stats for URLs, argument is LRU size
+
 .. option:: -U COUNT, --show_urls COUNT
+
+   Only show max this number of URLs
 
 .. option:: -A, --as_object
 
+   Produce URL stats as a JSON object instead of array
+
 .. option:: -C, --concise
+
+   Eliminate metrics that can be inferred from other values
 
 .. option:: -i, --incremental
 
+   Incremental log parsing
+
 .. option:: -S FILE, --statetag FILE
+
+   Name of the state file to use
 
 .. option:: -t, --tail
 
+   Parse the last <sec> seconds of log
+
 .. option:: -s, --summary
+
+   Only produce the summary
 
 .. option:: -j, --json
 
+   Produce JSON formatted output
+
 .. option:: -c, --cgi
+
+   Produce HTTP headers suitable as a CGI
 
 .. option:: -m, --min_hits
 
+   Minimum total hits for an Origin
+
 .. option:: -a, --max_age
+
+   Max age for log entries to be considered
 
 .. option:: -l COUNT, --line_len COUNT
 
+   Output line length
+
 .. option:: -T TAGS, --debug_tags TAGS
+
+   Colon-Separated Debug Tags
+
+.. option:: -r, --report_per_user
+
+   Report stats per username of the authenticated client ``caun`` instead of host, see `squid log format <../../admin-guide/logging/examples.en.html#squid>`_
+
+.. option:: -n, --no_format_check
+
+   Don't validate the log format field names according to the `squid log format <../../admin-guide/logging/examples.en.html#squid>`_.
+   This would allow squid format fields to be replaced, i.e. the username of the authenticated client ``caun`` with a random header value by using ``cqh``,
+   or to remove the client's host IP address from the log for privacy reasons.
 
 .. option:: -h, --help
 


### PR DESCRIPTION
Don’t validate the log format field names according to the squid log format.
This would allow squid format fields to be replaced, i.e. the username of
the authenticated client `caun` with a random header value by using `cqh`,
or to remove the client’s host IP address from the log for privacy reasons.

Added command line option `--no_format_check` (default false) and some documentation.

Related to [TS-5069](https://issues.apache.org/jira/browse/TS-5069)