### PR TITLE
Add slave queue to NetAccept in order to stop all NetAccept objects cloned from it

### DIFF
--- a/iocore/net/P_NetAccept.h
+++ b/iocore/net/P_NetAccept.h
@@ -99,7 +99,7 @@ struct NetAccept : public Continuation {
   void init_accept_loop();
   void init_accept_per_thread();
   virtual void stop_accept();
-  virtual NetAccept *clone() const;
+  virtual NetAccept *clone();
 
   // 0 == success
   int do_listen(bool non_blocking);
@@ -113,6 +113,8 @@ struct NetAccept : public Continuation {
 
   explicit NetAccept(const NetProcessor::AcceptOptions &);
   ~NetAccept() override { action_ = nullptr; }
+
+  Que(NetAccept, link) slaves;
 };
 
 extern Ptr<ProxyMutex> naVecMutex;

--- a/iocore/net/P_SSLNetAccept.h
+++ b/iocore/net/P_SSLNetAccept.h
@@ -48,7 +48,7 @@
 //
 struct SSLNetAccept : public NetAccept {
   NetProcessor *getNetProcessor() const override;
-  NetAccept *clone() const override;
+  NetAccept *clone() override;
 
   SSLNetAccept(const NetProcessor::AcceptOptions &opt);
   ~SSLNetAccept() override;

--- a/iocore/net/SSLNetAccept.cc
+++ b/iocore/net/SSLNetAccept.cc
@@ -33,10 +33,11 @@ SSLNetAccept::getNetProcessor() const
 }
 
 NetAccept *
-SSLNetAccept::clone() const
+SSLNetAccept::clone()
 {
   NetAccept *na;
   na  = new SSLNetAccept(opt);
   *na = *this;
+  slaves.push(na);
   return na;
 }


### PR DESCRIPTION
ATS creates ```epoll fd``` for each of ET_NET threads and the ```listen fd``` is added into these ```epoll fd```s.
The ```listen fd``` will be removed from ```epoll fd``` automatically only if the ```listen fd``` is actually closed.
But the ```listen fd``` is not actually closed because the ```listen fd``` is delivered from the parent process (traffic_manager).