### PR TITLE
DBTable, DBHost, DBAddr, DBAddrPort

### DIFF
--- a/lib/ts/DBAddr.cc
+++ b/lib/ts/DBAddr.cc
@@ -1,0 +1,9 @@
+#include "DBAddr.h"
+
+// thread safe map: sockaddr -> Extendible
+static const int DBAddr_partitions = 64;
+DBAddr::TableType DBAddr::map(DBAddr_partitions);
+
+// thread safe map: sockaddrport -> Extendible
+static const int DBAddrPort_partitions = 64;
+DBAddrPort::TableType DBAddrPort::map(DBAddrPort_partitions);

--- a/lib/ts/DBAddr.h
+++ b/lib/ts/DBAddr.h
@@ -1,0 +1,52 @@
+#pragma once
+#include "DBTable.h"
+#include "Extendible.h"
+#include "ts/ink_inet.h"
+
+/**
+ * @file
+ *
+ * @brief this file defines structures to store data about each ip.
+ *
+ * DBAddr - stores a concurrnet table of Extendible data indexed by sockaddr.
+ *    @see DBTable - allows concurrent row access.
+ *    @see Extendible - allows concurrent column access.
+ *
+ * Extend by calling DBAddr::schema.addField()
+ */
+class DBAddr : public MT::Extendible<DBAddr>
+{
+public:
+  using KeyType   = socksaddr; ///< an Ip address of a host (1 of many)
+  using TableType = DBTable<KeyType, DBAddr, CustomHasher<socksaddr, ats_ip_hash>>;
+
+  static TableType table;
+
+  // restrict lifetime management
+protected:
+  // Note, this uses Extendible::new and delete to manage allocations.
+  DBAddr();
+  DBAddr(DBAddr &) = delete;
+
+  // thread safe map: addr -> Extendible
+  friend TableType; // allow the map to allocate
+};
+
+/// Concurrent map: addr+port -> Extendible
+class DBAddrPort : public MT::Extendible<DBAddrPort>
+{
+public:
+  using KeyType   = socksaddr; ///< an Ip:Port address of a host (1 of many)
+  using TableType = DBTable<KeyType, DBAddr, CustomHasher<socksaddr, ats_ip_port_hash>>> ;
+
+  static TableType table;
+
+  // restrict lifetime management
+protected:
+  // Note, this uses Extendible::new and delete to manage allocations.
+  DBAddrPort();
+  DBAddrPort(DBAddr &) = delete;
+
+  // thread safe map: addr -> Extendible
+  friend TableType; // allow the map to allocate
+};

--- a/lib/ts/DBHost.cc
+++ b/lib/ts/DBHost.cc
@@ -1,0 +1,7 @@
+#include "DBHost.h"
+
+/// internal lookup table
+
+// thread safe table: host_name -> host_rec
+static const int DBHost_partitions = 64;
+DBHost::TableType DBHost::table(DBHost_partitions);

--- a/lib/ts/DBHost.h
+++ b/lib/ts/DBHost.h
@@ -1,0 +1,32 @@
+#pragma once
+#include "DBTable.h"
+#include "Extendible.h"
+
+/**
+ * @file
+ *
+ * @brief this file defines structures to store data about each host.
+ *
+ * DBHost - stores a concurrnet table of Extendible data indexed by FQDN.
+ *    @see DBTable - allows concurrent row access.
+ *    @see Extendible - allows concurrent column access.
+ */
+class DBHost : public MT::Extendible<DBHost>
+{
+public:
+  using KeyType   = std::string_view; ///< the FQDN of a host, used as the table's unique key.
+  using TableType = DBTable<KeyType, DBHost>;
+
+  static TableType table;
+
+  // Add TSCore Variables below or use DBHost.schema.addField() to extend the structure dynamically.
+
+protected:
+  // Restrict lifetime management
+  DBHost(){};
+  DBHost(DBHost &) = delete;
+  // Note, this uses Extendible::new and delete to manage allocations.
+  // see obtain and destroy
+
+  friend TableType;
+};

--- a/lib/ts/DBTable.h
+++ b/lib/ts/DBTable.h
@@ -1,0 +1,204 @@
+#pragma once
+#include "stdint.h"
+#include <cstddef>
+#include <mutex>
+#include <shared_mutex>
+#include <vector>
+#include <unordered_map>
+#include <functional>
+#include <memory>
+#include <string_view>
+
+/** What is DBTable?
+ * A concurrent hash table.
+ * 1. uses bin hashing to allow concurrent operations on seperate locked maps. @see PartitionedMap
+ * 2. uses std::shared_ptr<element> to provide durable references. @see DBTable
+ *
+ * WARNING: this table is thread safe, but the elements are not protected from concurrency by these locks.
+ * Locks only protect access operations from concurrent insert and delete, not from concurrent value modification.
+ * So you should only store atomic-like elements in it.
+ */
+
+////////////////////////////////////////////////////////////////////////////////////////
+// PartitionedMap
+//
+/// Intended to provide a thread safe lookup.
+/** A key is hashed into a bin.
+ * Each bin has independent map of Ket,Value pairs.
+ * Each bin has shared_mutex to allow multilple readers or one writer to the table.
+ * The lock only protects against rehashing that part of map.
+ * It does not protect the values in the map, they are expected to be atomic, or protected through other methods. @see Extendible
+ */
+template <typename Key_t, typename Value_t, typename Hasher_t = std::hash<Key_t>, typename Mutex_t = std::shared_mutex>
+struct PartitionedMap {
+  using KeyType      = Key_t;
+  using ValueType    = Value_t;
+  using HasherType   = Hasher_t;
+  using Map_t        = std::unordered_map<Key_t, Value_t, Hasher_t>;
+  using AccessLock_t = std::shared_lock<Mutex_t>; // shared access when reading data
+  using ResizeLock_t = std::unique_lock<Mutex_t>; // exclusive access when adding or removing data
+
+public:
+  PartitionedMap(size_t num_partitions) : part_maps(num_partitions), part_access(num_partitions)
+  {
+    for (auto map : part_maps) {
+      map.max_load_factor(16);
+    }
+  }
+
+  Map_t &
+  lockPartMap(const Key_t &key, ResizeLock_t &lock)
+  {
+    size_t hash   = HasherType()(key);
+    auto part_idx = hash % part_access.size();
+    lock          = ResizeLock_t(part_access[part_idx]);
+
+    return part_maps[part_idx];
+  }
+
+  Map_t const &
+  getPartMap(const Key_t &key, AccessLock_t &lock)
+  {
+    size_t hash   = HasherType()(key);
+    auto part_idx = hash % part_access.size();
+    lock          = AccessLock_t(part_access[part_idx]);
+
+    return part_maps[part_idx];
+  }
+
+  /// return true if value retrieved.
+  bool
+  find(const Key_t &key, Value_t &val)
+  {
+    // the map could rehash during a concurrent put, and mess with the elm
+    AccessLock_t lck;
+    Map_t const &map = getPartMap(key, lck);
+    auto elm         = map.find(key);
+    if (elm != map.end()) {
+      val = elm->second;
+      return true;
+    }
+
+    return false;
+  }
+
+  // lock access and read value
+  Value_t operator[](const Key_t &key) const
+  {
+    Value_t val = {};
+    find(key, val);
+    return val;
+  }
+
+  // lock access and reference value
+  Value_t &
+  obtain(const Key_t &key)
+  {
+    ResizeLock_t lck;
+    return lockPartMap(key, lck)[key];
+  }
+
+  // lock access and reference value
+  Value_t &operator[](const Key_t &key) { return obtain(key); }
+
+  void
+  put(const Key_t &key, Value_t &val)
+  {
+    ResizeLock_t lck;
+    lockPartMap(key, lck)[key] = val;
+  }
+
+  Value_t
+  pop(const Key_t &key)
+  {
+    ResizeLock_t lck;
+    Map_t &map = lockPartMap(key, lck);
+
+    Value_t val = map[key];
+    map.erase(key);
+    return val;
+  }
+
+  void
+  clear()
+  {
+    for (int part_idx = 0; part_idx < part_access.size(); ++part_idx) {
+      ResizeLock_t lck(part_access[part_idx]);
+      part_maps[part_idx].clear();
+    }
+  }
+
+  /**
+   * @brief used inplace of an iterator.
+   * @param callback - processes and element. Return true if we can abort iteration.
+   */
+  void
+  visit(std::function<bool(Key_t const &, Value_t &)> callback)
+  {
+    for (int part_idx = 0; part_idx < part_access.size(); ++part_idx) {
+      AccessLock_t lck(part_access[part_idx]);
+      for (Value_t val : part_maps[part_idx]) {
+        bool done = callback(val);
+        if (done) {
+          return;
+        }
+      }
+    }
+  }
+
+private:
+  std::vector<Map_t> part_maps;
+  std::vector<Mutex_t> part_access;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////
+// DBTable
+//
+/// DBTable stores all values as shared pointers so you don't worry about data being destroyed while in use.
+template <typename Key_t, typename Value_t, typename Hasher_t = std::hash<Key_t>>
+class DBTable : public PartitionedMap<Key_t, std::shared_ptr<Value_t>, Hasher_t, std::shared_mutex>
+{
+  using KeyType = Key_t;
+  using Base_t  = PartitionedMap<Key_t, std::shared_ptr<Value_t>, Hasher_t, std::shared_mutex>;
+
+public:
+  DBTable(size_t num_partitions) : Base_t(num_partitions) {}
+
+  std::shared_ptr<Value_t>
+  obtain(Key_t const &key)
+  {
+    typename Base_t::ResizeLock_t lck;
+    typename Base_t::Map_t &map = Base_t::lockPartMap(key, lck); // lock once
+    std::shared_ptr<Value_t> &r = map[key];                      // find or alloc a shared_ptr
+    if (r.get() == nullptr) {                                    // if it is new
+      r.reset(new Value_t{});                                    // alloc a value, and set ptr
+    }
+    return r;
+  }
+};
+
+/////////////////////////////////////////////
+// CustomHasher
+template <typename Key_t, std::size_t (*HashFn)(Key_t const &)> struct CustomHasher {
+  std::size_t
+  operator()(const Key_t &k) const
+  {
+    return HashFn(k);
+  }
+};
+
+/////////////////////////////////////////////
+// Helper macros
+/// If you are keying on a custom class, you will need to define std::hash<Key>()
+// this macro makes it easy.
+#define std_hasher_macro(T, var, hash_var_expr) \
+  namespace std                                 \
+  {                                             \
+    template <> struct hash<T> {                \
+      std::size_t                               \
+      operator()(const T &var) const            \
+      {                                         \
+        return hash_var_expr;                   \
+      }                                         \
+    };                                          \
+  }

--- a/lib/ts/Makefile.am
+++ b/lib/ts/Makefile.am
@@ -69,6 +69,9 @@ libtsutil_la_SOURCES = \
 	ContFlags.h \
 	CryptoHash.cc \
 	CryptoHash.h \
+	DBHost.cc \
+	DBHost.h \
+	DBTable.h \
 	defalloc.h \
 	Diags.cc \
 	Diags.h \
@@ -269,6 +272,7 @@ test_tslib_SOURCES = \
 	unit-tests/test_AcidPtr.cc \
 	unit-tests/test_BufferWriter.cc \
 	unit-tests/test_BufferWriterFormat.cc \
+	unit-tests/test_DBHost.cc \
 	unit-tests/test_Extendible.cc \
 	unit-tests/test_History.cc \
 	unit-tests/test_ink_inet.cc \

--- a/lib/ts/unit-tests/test_AcidPtr.cc
+++ b/lib/ts/unit-tests/test_AcidPtr.cc
@@ -1,5 +1,5 @@
 /** @file
-  Test file for Extendible
+  Test file for AcidPtr
   @section license License
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file

--- a/lib/ts/unit-tests/test_DBHost.cc
+++ b/lib/ts/unit-tests/test_DBHost.cc
@@ -1,0 +1,207 @@
+/** @file
+  Test file for DBHost
+  @section license License
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "catch.hpp"
+
+#include "DBTable.h"
+#include "DBHost.h"
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+using namespace std;
+
+std::size_t
+Hash32fnv(std::string_view const &s)
+{
+  std::size_t hval = 0;
+  for (const char &c : s) {
+    hval *= 0x01000193;
+    hval ^= (std::size_t)c;
+  }
+  return hval;
+}
+
+std::size_t
+Hash32fnv(std::string const &s)
+{
+  std::size_t hval = 0;
+  for (const char &c : s) {
+    hval *= 0x01000193;
+    hval ^= (std::size_t)c;
+  }
+  return hval;
+}
+
+TEST_CASE("DBTable <int,int>", "[DBTable] [constructor]")
+{
+  auto db_test       = DBTable<int, int>(2);
+  *db_test.obtain(4) = 4;
+}
+TEST_CASE("DBTable <sting,int>", "[DBTable] [constructor]")
+{
+  auto db_test                 = DBTable<string, int>(2);
+  *(db_test.obtain({"hello"})) = 1;
+  *(db_test.obtain({"world"})) = 2;
+}
+TEST_CASE("DBTable <string,int,CustomHasher>", "[DBTable] [constructor]")
+{
+  auto db_test                 = DBTable<string, int, CustomHasher<string, &Hash32fnv>>(2);
+  *(db_test.obtain({"hello"})) = 1;
+  *(db_test.obtain({"world"})) = 2;
+}
+TEST_CASE("DBTable <string_view,int>", "[DBTable] [constructor]")
+{
+  auto db_test                 = DBTable<string_view, int>(2);
+  *(db_test.obtain({"hello"})) = 1;
+  *(db_test.obtain({"world"})) = 2;
+}
+
+TEST_CASE("DBTable <string_view,int,CustomHasher>", "[DBTable] [constructor]")
+{
+  auto db_test                 = DBTable<string_view, int, CustomHasher<string_view, &Hash32fnv>>(2);
+  *(db_test.obtain({"hello"})) = 1;
+  *(db_test.obtain({"world"})) = 2;
+}
+/*
+template <typename TableType, typename KeyType>
+uint64_t
+time_trial(std::vector<KeyType> const &indexes)
+{
+  TableType table(64);
+  int ref;
+  for (const auto idx_str : indexes) {
+    table.obtain({idx_str}) = 1;
+  }
+  auto start = std::chrono::system_clock::now();
+  for (const auto idx_str : indexes) {
+    table.find({idx_str}, ref);
+  }
+  auto end = std::chrono::system_clock::now();
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+};
+
+
+// Conclusion of multiple performance tests:
+// * where baseline is keyType std::string and std::hash
+// 1. wrapping a key with a key&hash pair slightly improves performance by 7% when hash is precomputed and hurts performance by 14%
+when not pre-hashed. The bad out weighs the good and it convolutes code.
+// 2. keying on string_view is 5% faster than string
+// 3. CustomHasher has equivalent performance to std::hash
+TEST_CASE("CustomHasher time test", "")
+{
+  // max thread priority
+  struct sched_param params;
+  params.sched_priority = sched_get_priority_max(SCHED_FIFO);
+  pthread_setschedparam(pthread_self(), SCHED_FIFO, &params);
+
+  using TypeA = PartitionedMap<string, int>;
+  using TypeB = PartitionedMap<string, int, CustomHasher<string, &Hash32fnv>>;
+  using TypeC = PartitionedMap<string_view, int, CustomHasher<string_view, &Hash32fnv>>;
+  using TypeD = PartitionedMap<string_view, int>;
+
+  std::vector<TypeA::KeyType> indexes;
+  std::vector<TypeB::KeyType> indexesHashed;
+  char buf[2000];
+  const int data_len = 10000;
+  const int rounds   = 1000;
+
+  for (int i = 0; i < data_len; i++) {
+    sprintf(buf, "%d", i * i);
+    indexes.push_back({buf});
+    indexesHashed.push_back({buf});
+  }
+
+  std::vector<double> time_a, time_b, time_b1, time_c, time_d;
+
+  for (int round = 0; round < rounds; round++) {
+    time_a.push_back(time_trial<TypeA, TypeA::KeyType>(indexes) / data_len);
+    time_b.push_back(time_trial<TypeB, TypeB::KeyType>(indexesHashed) / data_len);
+    time_b1.push_back(time_trial<TypeB, string>(indexes) / data_len);
+    time_c.push_back(time_trial<TypeC, string>(indexes) / data_len);
+    time_d.push_back(time_trial<TypeD, string>(indexes) / data_len);
+  }
+
+  auto median = [](std::vector<double> &v) {
+    std::nth_element(v.begin(), v.begin() + v.size() * 9 / 10, v.end());
+    return v[v.size() * 9 / 10];
+  };
+
+  printf("A:%f B:%f b:%f C:%f D:%f", median(time_a), median(time_b), median(time_b1), median(time_c), median(time_d));
+  CHECK(0);
+}*/
+
+typename DBHost::BitFieldId bit_a, bit_b;
+shared_ptr<DBHost> host_ptr, host_ptr2;
+
+// ======= test for DBHost ========
+
+TEST_CASE("DBHost constructor", "[NextHop] [DBHost] [constructor]")
+{
+  typename DBHost::KeyType fqdn_1{"test_host.com"};
+
+  INFO("Declare fields")
+  {
+    REQUIRE(DBHost::schema.addField(bit_a, "bit_a"));
+    REQUIRE(DBHost::schema.addField(bit_b, "bit_b"));
+  }
+
+  INFO("obtain")
+  {
+    host_ptr = DBHost::table.obtain(fqdn_1);
+    REQUIRE(host_ptr);
+    host_ptr2 = DBHost::table.obtain({"test_host.com"});
+    REQUIRE(host_ptr2);
+    REQUIRE(host_ptr.get() == host_ptr2.get()); // point to same instance
+  }
+
+  INFO("find")
+  {
+    //
+    host_ptr2.reset();
+    REQUIRE(DBHost::table.find(fqdn_1, host_ptr2) == true);
+    REQUIRE(host_ptr.get() == host_ptr2.get()); // point to same instance
+    REQUIRE(DBHost::table.find({"fail_host.com"}, host_ptr2) == false);
+  }
+
+  INFO("use fields")
+  {
+    auto &host = *host_ptr;
+    host.writeBit(bit_a, 1);
+    REQUIRE(host[bit_a] == 1);
+    REQUIRE(host[bit_b] == 0);
+    host.writeBit(bit_b, 1);
+    host.writeBit(bit_a, 0);
+    REQUIRE(host[bit_a] == 0);
+    REQUIRE(host[bit_b] == 1);
+  }
+
+  INFO("pop")
+  {
+    //
+    REQUIRE(DBHost::table.pop(fqdn_1) == host_ptr);
+    REQUIRE(DBHost::table.find(fqdn_1, host_ptr2) == false);
+    // shared_ptr retain data while in scope
+    REQUIRE(host_ptr);
+    host_ptr.reset();
+    host_ptr2.reset();
+  }
+
+  INFO("end DBHost Tests");
+}

--- a/lib/ts/unit-tests/test_Extendible.cc
+++ b/lib/ts/unit-tests/test_Extendible.cc
@@ -70,12 +70,12 @@ TEST_CASE("Extendible", "")
   {
     ptr = new Derived();
     REQUIRE(ptr != nullptr);
+    delete ptr;
   }
 
   INFO("~Extendible")
   {
     //
-    delete ptr;
   }
 
   INFO("Schema Reset")
@@ -225,6 +225,7 @@ TEST_CASE("Extendible", "")
     CHECK(reader.getPtr()->arr[0] == 99);
     free(mem);
   }
+
   INFO("ACIDPTR block-free reader")
   {
     auto tf_a = Derived::schema.find<ACIDPTR, testField>("tf_a");


### PR DESCRIPTION
Yet another Hashmap. 
This takes many ideas from the HostDB and RefCountCache, simplifies it and implements them using std library; std::unordered_map, std::shared_mutex and std::shared_ptr. The result is a concurrent map that appears lock-free from the calling code. There is no need for try_locks or continuations to access data that is atomic. 

Future work: 
1. (WIP) Extendible to use ClassAllocator
2. port HostStatus and HostDB to DBHost
3. implement TTL style garbage collection external to DBTable
4. Deprecate HostDB, RefCountCache and miscellaneous hash tables indexed by host, IP, or port. 
5. Relocate DBHost.h and DBAddr.h to be used in cppapi and core.
