### PR TITLE
Replace TRY_MUTEX_LOCK_FOR with equivalent TRY_MUTEX_LOCK

### DIFF
--- a/iocore/eventsystem/I_Lock.h
+++ b/iocore/eventsystem/I_Lock.h
@@ -70,42 +70,8 @@
 */
 #define MUTEX_TRY_LOCK(_l, _m, _t) MutexTryLock _l(MakeSourceLocation(), (char *)nullptr, _m, _t)
 
-/**
-  Attempts to acquire the lock to the ProxyMutex.
-
-  This macro performs up to the specified number of attempts to
-  acquire the lock on the ProxyMutex object. It does so by running
-  a busy loop (busy wait) '_sc' times. You should use it with care
-  since it blocks the thread during that time and wastes CPU time.
-
-  @param _l Arbitrary name for the lock to use in this call (lock variable)
-  @param _m A pointer to (or address of) a ProxyMutex object
-  @param _t The current EThread executing your code.
-  @param _sc The number of attempts or spin count. It must be a positive value.
-
-*/
-#define MUTEX_TRY_LOCK_SPIN(_l, _m, _t, _sc) MutexTryLock _l(MakeSourceLocation(), (char *)nullptr, _m, _t, _sc)
-
-/**
-  Attempts to acquire the lock to the ProxyMutex.
-
-  This macro attempts to acquire the lock to the specified ProxyMutex
-  object in a non-blocking manner. After using the macro you can
-  see if it was successful by comparing the lock variable with true
-  or false (the variable name passed in the _l parameter).
-
-  @param _l Arbitrary name for the lock to use in this call (lock variable)
-  @param _m A pointer to (or address of) a ProxyMutex object
-  @param _t The current EThread executing your code.
-  @param _c Continuation whose mutex will be attempted to lock.
-
-*/
-
-#define MUTEX_TRY_LOCK_FOR(_l, _m, _t, _c) MutexTryLock _l(MakeSourceLocation(), nullptr, _m, _t)
 #else // DEBUG
 #define MUTEX_TRY_LOCK(_l, _m, _t) MutexTryLock _l(_m, _t)
-#define MUTEX_TRY_LOCK_SPIN(_l, _m, _t, _sc) MutexTryLock _l(_m, _t, _sc)
-#define MUTEX_TRY_LOCK_FOR(_l, _m, _t, _c) MutexTryLock _l(_m, _t)
 #endif // DEBUG
 
 /**
@@ -126,12 +92,8 @@
 // DEPRECATED DEPRECATED DEPRECATED
 #ifdef DEBUG
 #define MUTEX_TAKE_TRY_LOCK(_m, _t) Mutex_trylock(MakeSourceLocation(), (char *)nullptr, _m, _t)
-#define MUTEX_TAKE_TRY_LOCK_FOR(_m, _t, _c) Mutex_trylock(MakeSourceLocation(), (char *)nullptr, _m, _t)
-#define MUTEX_TAKE_TRY_LOCK_FOR_SPIN(_m, _t, _c, _sc) Mutex_trylock_spin(MakeSourceLocation(), nullptr, _m, _t, _sc)
 #else
 #define MUTEX_TAKE_TRY_LOCK(_m, _t) Mutex_trylock(_m, _t)
-#define MUTEX_TAKE_TRY_LOCK_FOR(_m, _t, _c) Mutex_trylock(_m, _t)
-#define MUTEX_TAKE_TRY_LOCK_FOR_SPIN(_m, _t, _c, _sc) Mutex_trylock_spin(_m, _t, _sc)
 #endif
 
 #ifdef DEBUG

--- a/iocore/eventsystem/UnixEThread.cc
+++ b/iocore/eventsystem/UnixEThread.cc
@@ -118,7 +118,7 @@ void
 EThread::process_event(Event *e, int calling_code)
 {
   ink_assert((!e->in_the_prot_queue && !e->in_the_priority_queue));
-  MUTEX_TRY_LOCK_FOR(lock, e->mutex, this, e->continuation);
+  MUTEX_TRY_LOCK(lock, e->mutex, this);
   if (!lock.is_locked()) {
     e->timeout_at = cur_time + DELAY_FOR_RETRY;
     EventQueueExternal.enqueue_local(e);

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -458,7 +458,7 @@ SSLNetVConnection::net_read_io(NetHandler *nh, EThread *lthread)
     return;
   }
 
-  MUTEX_TRY_LOCK_FOR(lock, s->vio.mutex, lthread, s->vio.cont);
+  MUTEX_TRY_LOCK(lock, s->vio.mutex, lthread);
   if (!lock.is_locked()) {
     readReschedule(nh);
     return;

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -188,7 +188,7 @@ read_from_net(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
   ProxyMutex *mutex = thread->mutex.get();
   int64_t r         = 0;
 
-  MUTEX_TRY_LOCK_FOR(lock, s->vio.mutex, thread, s->vio.cont);
+  MUTEX_TRY_LOCK(lock, s->vio.mutex, thread);
 
   if (!lock.is_locked()) {
     read_reschedule(nh, vc);
@@ -367,7 +367,7 @@ write_to_net_io(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
   NetState *s       = &vc->write;
   ProxyMutex *mutex = thread->mutex.get();
 
-  MUTEX_TRY_LOCK_FOR(lock, s->vio.mutex, thread, s->vio.cont);
+  MUTEX_TRY_LOCK(lock, s->vio.mutex, thread);
 
   if (!lock.is_locked() || lock.get_mutex() != s->vio.mutex.get()) {
     write_reschedule(nh, vc);

--- a/iocore/net/UnixUDPNet.cc
+++ b/iocore/net/UnixUDPNet.cc
@@ -217,7 +217,7 @@ UDPNetProcessorInternal::udp_callback(UDPNetHandler *nh, UDPConnection *xuc, ETh
   UnixUDPConnection *uc = (UnixUDPConnection *)xuc;
 
   if (uc->continuation && uc->mutex) {
-    MUTEX_TRY_LOCK_FOR(lock, uc->mutex, thread, uc->continuation);
+    MUTEX_TRY_LOCK(lock, uc->mutex, thread);
     if (!lock.is_locked()) {
       return 1;
     }


### PR DESCRIPTION
The continuation parameter for TRY_MUTEX_LOCK_FOR is unused making it equivalent to TRY_MUTEX_LOCK.  The unused continuation parameter is confusing when reading the code making you thing the continuation is involved somehow in the operation.

This PR removes TRY_MUTEX_LOCK_FOR and replaces all uses with TRY_MUTEX_LOCK.

TRY_MUTEX_LOCK_SPIN was unused, so I removed that while I was in there.