### PR TITLE
Wildcard matching for SNI and bug fix in SNI loading

### DIFF
--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -263,7 +263,7 @@ public:
   {
     std::string_view addr, port;
     if (ats_ip_parse(std::string_view(hostname), &addr, &port) == 0) {
-      auto *hs = new HostStruct(ats_strdup(addr.data()), addr.length(), atoi(port.data()));
+      auto *hs = new HostStruct(ats_strdup(addr.data()), addr.length(), ts::svtoi(port));
       TunnelhMap.put(ats_strdup(key), hs);
     }
   }

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -89,6 +89,7 @@
 #endif
 
 TunnelHashMap TunnelMap; // stores the name of the servers to tunnel to
+TunnelHashMap wildTunnelMap; // stores wildcard versions of the above
 /*
  * struct ssl_user_config: gather user provided settings from ssl_multicert.config in to this single struct
  * ssl_ticket_enabled - session ticket enabled


### PR DESCRIPTION
In addition to wildcard matching, here was a bug in SNI loading where if the tunnel_route does not a have a port number, it would cause ATS to crash.