### PR TITLE
Clear up evnets and timers for a H2 stream before destroying its mutex

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -750,10 +750,10 @@ Http2Stream::destroy()
     ats_free(header_blocks);
   }
   chunked_handler.clear();
-  super::destroy();
   clear_timers();
   clear_io_events();
 
+  super::destroy();
   THREAD_FREE(this, http2StreamAllocator, this_ethread());
 }
 


### PR DESCRIPTION
On #4062, @masaori335 pointed out that calling `super::destroy()` destroys its mutex. We must not touch any members after calling it and it has to be called at the end of cleanup process.

I'm not sure whether this fixes #4062, but I think this fixes a potential bug.