### PR TITLE
Added clear_event function to cancel inactive event before marking it…

### DIFF
--- a/proxy/PluginVC.h
+++ b/proxy/PluginVC.h
@@ -152,6 +152,10 @@ private:
   void process_close();
   void process_timeout(Event **e, int event_to_send);
 
+  // Clear the Event pointer pointed to by e
+  // Cancel the action first if it is a periodic event
+  void clear_event(Event **e);
+
   void setup_event_cb(ink_hrtime in, Event **e_ptr);
 
   void update_inactive_time();


### PR DESCRIPTION
… as nullptr

(cherry picked from commit cb784429ec035f4f669bc2d62ad94d26b58c825d)

See PR https://github.com/apache/trafficserver/pull/4074

@zwoop 