### PR TITLE
Removes references to STAT_PROCESSOR

### DIFF
--- a/lib/records/I_RecDefs.h
+++ b/lib/records/I_RecDefs.h
@@ -27,8 +27,6 @@
 #include "ts/ink_rwlock.h"
 #include "I_RecMutex.h"
 
-#define STAT_PROCESSOR
-
 //-------------------------------------------------------------------------
 // Error Values
 //-------------------------------------------------------------------------
@@ -67,10 +65,6 @@ enum RecDataT {
   RECD_STRING,
   RECD_COUNTER,
 
-#if defined(STAT_PROCESSOR)
-  RECD_CONST, // Added for the StatProcessor, store as RECD_FLOAT
-  RECD_FX,    // Added for the StatProcessor, store as RECD_INT
-#endif
   RECD_MAX
 };
 

--- a/lib/records/RecUtils.cc
+++ b/lib/records/RecUtils.cc
@@ -82,16 +82,10 @@ void
 RecDataSetMax(RecDataT type, RecData *data)
 {
   switch (type) {
-#if defined(STAT_PROCESSOR)
-  case RECD_FX:
-#endif
   case RECD_INT:
   case RECD_COUNTER:
     data->rec_int = INT64_MAX; // Assumes rec_int is int64_t, which it currently is
     break;
-#if defined(STAT_PROCESSOR)
-  case RECD_CONST:
-#endif
   case RECD_FLOAT:
     data->rec_float = FLT_MAX;
     break;
@@ -104,16 +98,10 @@ void
 RecDataSetMin(RecDataT type, RecData *data)
 {
   switch (type) {
-#if defined(STAT_PROCESSOR)
-  case RECD_FX:
-#endif
   case RECD_INT:
   case RECD_COUNTER:
     data->rec_int = INT64_MIN; // Assumes rec_int is int64_t, which it currently is
     break;
-#if defined(STAT_PROCESSOR)
-  case RECD_CONST:
-#endif
   case RECD_FLOAT:
     data->rec_float = FLT_MIN;
     break;
@@ -183,9 +171,6 @@ int
 RecDataCmp(RecDataT type, RecData left, RecData right)
 {
   switch (type) {
-#if defined(STAT_PROCESSOR)
-  case RECD_FX:
-#endif
   case RECD_INT:
   case RECD_COUNTER:
     if (left.rec_int > right.rec_int) {
@@ -195,9 +180,6 @@ RecDataCmp(RecDataT type, RecData left, RecData right)
     } else {
       return -1;
     }
-#if defined(STAT_PROCESSOR)
-  case RECD_CONST:
-#endif
   case RECD_FLOAT:
     if (left.rec_float > right.rec_float) {
       return 1;
@@ -219,16 +201,10 @@ RecDataAdd(RecDataT type, RecData left, RecData right)
   memset(&val, 0, sizeof(val));
 
   switch (type) {
-#if defined(STAT_PROCESSOR)
-  case RECD_FX:
-#endif
   case RECD_INT:
   case RECD_COUNTER:
     val.rec_int = left.rec_int + right.rec_int;
     break;
-#if defined(STAT_PROCESSOR)
-  case RECD_CONST:
-#endif
   case RECD_FLOAT:
     val.rec_float = left.rec_float + right.rec_float;
     break;
@@ -246,16 +222,10 @@ RecDataSub(RecDataT type, RecData left, RecData right)
   memset(&val, 0, sizeof(val));
 
   switch (type) {
-#if defined(STAT_PROCESSOR)
-  case RECD_FX:
-#endif
   case RECD_INT:
   case RECD_COUNTER:
     val.rec_int = left.rec_int - right.rec_int;
     break;
-#if defined(STAT_PROCESSOR)
-  case RECD_CONST:
-#endif
   case RECD_FLOAT:
     val.rec_float = left.rec_float - right.rec_float;
     break;
@@ -273,16 +243,10 @@ RecDataMul(RecDataT type, RecData left, RecData right)
   memset(&val, 0, sizeof(val));
 
   switch (type) {
-#if defined(STAT_PROCESSOR)
-  case RECD_FX:
-#endif
   case RECD_INT:
   case RECD_COUNTER:
     val.rec_int = left.rec_int * right.rec_int;
     break;
-#if defined(STAT_PROCESSOR)
-  case RECD_CONST:
-#endif
   case RECD_FLOAT:
     val.rec_float = left.rec_float * right.rec_float;
     break;
@@ -300,16 +264,10 @@ RecDataDiv(RecDataT type, RecData left, RecData right)
   memset(&val, 0, sizeof(val));
 
   switch (type) {
-#if defined(STAT_PROCESSOR)
-  case RECD_FX:
-#endif
   case RECD_INT:
   case RECD_COUNTER:
     val.rec_int = left.rec_int / right.rec_int;
     break;
-#if defined(STAT_PROCESSOR)
-  case RECD_CONST:
-#endif
   case RECD_FLOAT:
     val.rec_float = left.rec_float / right.rec_float;
     break;
@@ -327,15 +285,9 @@ bool
 RecDataSetFromInk64(RecDataT data_type, RecData *data_dst, int64_t data_int64)
 {
   switch (data_type) {
-#if defined(STAT_PROCESSOR)
-  case RECD_FX:
-#endif
   case RECD_INT:
     data_dst->rec_int = data_int64;
     break;
-#if defined(STAT_PROCESSOR)
-  case RECD_CONST:
-#endif
   case RECD_FLOAT:
     data_dst->rec_float = (float)(data_int64);
     break;
@@ -365,15 +317,9 @@ bool
 RecDataSetFromFloat(RecDataT data_type, RecData *data_dst, float data_float)
 {
   switch (data_type) {
-#if defined(STAT_PROCESSOR)
-  case RECD_FX:
-#endif
   case RECD_INT:
     data_dst->rec_int = (RecInt)data_float;
     break;
-#if defined(STAT_PROCESSOR)
-  case RECD_CONST:
-#endif
   case RECD_FLOAT:
     data_dst->rec_float = (float)(data_float);
     break;
@@ -406,15 +352,9 @@ RecDataSetFromString(RecDataT data_type, RecData *data_dst, const char *data_str
   RecData data_src;
 
   switch (data_type) {
-#if defined(STAT_PROCESSOR)
-  case RECD_FX:
-#endif
   case RECD_INT:
     data_src.rec_int = ink_atoi64(data_string);
     break;
-#if defined(STAT_PROCESSOR)
-  case RECD_CONST:
-#endif
   case RECD_FLOAT:
     data_src.rec_float = atof(data_string);
     break;


### PR DESCRIPTION
This was part of the XML-based stats processor removed in 4502c1adbfb067058621d232080c5a469fa1a58d