### PR TITLE
ssl_session_reuse plugin

### DIFF
--- a/build/hiredis.m4
+++ b/build/hiredis.m4
@@ -1,0 +1,93 @@
+dnl -------------------------------------------------------- -*- autoconf -*-
+dnl Licensed to the Apache Software Foundation (ASF) under one or more
+dnl contributor license agreements.  See the NOTICE file distributed with
+dnl this work for additional information regarding copyright ownership.
+dnl The ASF licenses this file to You under the Apache License, Version 2.0
+dnl (the "License"); you may not use this file except in compliance with
+dnl the License.  You may obtain a copy of the License at
+dnl
+dnl     http://www.apache.org/licenses/LICENSE-2.0
+dnl
+dnl Unless required by applicable law or agreed to in writing, software
+dnl distributed under the License is distributed on an "AS IS" BASIS,
+dnl WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+dnl See the License for the specific language governing permissions and
+dnl limitations under the License.
+
+dnl
+dnl hiredis.m4: Trafficserver's hiredis autoconf macros
+dnl
+
+dnl
+dnl TS_CHECK_HIREDIS: look for hiredis libraries and headers
+dnl
+
+AC_DEFUN([TS_CHECK_HIREDIS], [
+hiredis_base_dir='/usr'
+has_hiredis=0
+AC_ARG_WITH(hiredis, [AC_HELP_STRING([--with-hiredis=DIR],[use a specific hiredis library])],
+[
+  has_hiredis=1
+  if test "x$withval" != "xyes" && test "x$withval" != "x"; then
+    hiredis_base_dir="$withval"
+    if test "$withval" != "no"; then
+      case "$withval" in
+      *":"*)
+        hidredis_include="`echo $withval |sed -e 's/:.*$//'`"
+        hiredis_ldflags="`echo $withval |sed -e 's/^.*://'`"
+        AC_MSG_CHECKING(checking for hiredis includes in $hiredis_include libs in $hiredis_ldflags )
+        ;;
+      *)
+        hiredis_include="$withval/include"
+        hiredis_ldflags="$withval/lib"
+        AC_MSG_CHECKING(checking for hiredis includes in $withval)
+        ;;
+      esac
+    fi
+  fi
+
+  if test -d $hiredis_include && test -d $hiredis_ldflags && test -f $hiredis_include/hiredis/hiredis.h; then
+    AC_MSG_RESULT([ok])
+  else
+    has_hiredis=0
+    AC_MSG_RESULT([not found])
+  fi
+
+if test "$has_hiredis" != "0"; then
+  saved_ldflags=$LDFLAGS
+  saved_cppflags=$CPPFLAGS
+  hiredis_have_headers=0
+  hiredis_have_libs=0
+  if test "$hiredis_base_dir" != "/usr"; then
+    TS_ADDTO(CPPFLAGS, [-I${hiredis_include}])
+    TS_ADDTO(LDFLAGS, [-L${hiredis_ldflags}])
+    TS_ADDTO_RPATH(${hiredis_ldflags})
+  fi
+
+  AC_CHECK_LIB([hiredis], redisConnect, [hiredis_have_libs=1])
+  if test "$hiredis_have_libs" != "0"; then
+    AC_CHECK_HEADERS(hiredis/hiredis.h, [hiredis_have_headers=1])
+  fi
+  if test "$hiredis_have_headers" != "0"; then
+    AC_SUBST([LIB_HIREDIS], [-lhiredis])
+    AC_SUBST([CFLAGS_HIREDIS], [-I${hiredis_include}])
+  else
+    has_hiredis=0
+    CPPFLAGS=$saved_cppflags
+    LDFLAGS=$saved_ldflags
+  fi
+fi
+],
+[
+has_hiredis=1
+AC_CHECK_HEADER([hiredis/hiredis.h], [], [has_hiredis=0])
+AC_CHECK_LIB([hiredis], redisConnect, [], [has_hiredis=0])
+
+if test "x$has_hiredis" == "x1"; then
+    AC_SUBST([LIB_HIREDIS], [-lhiredis])
+fi
+])
+
+])
+
+

--- a/configure.ac
+++ b/configure.ac
@@ -1339,6 +1339,11 @@ AC_SUBST([LIBJANSSON])
 TS_CHECK_YAML_CPP
 AM_CONDITIONAL([BUILD_YAML_CPP], [test x"$has_yaml_cpp" = x"no"])
 
+# Check for optional hiredis library
+TS_CHECK_HIREDIS
+
+AM_CONDITIONAL([BUILD_SSL_SESSION_REUSE_PLUGIN], [test ! -z "${LIB_HIREDIS}" -a "x${has_hiredis}" = "x1" ])
+
 # Check for backtrace() support
 has_backtrace=0
 AC_CHECK_HEADERS([execinfo.h], [has_backtrace=1],[])

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3361,6 +3361,10 @@ SSL Termination
    ``1`` Disable the SSL session cache for a connection during lock contention.
    ===== ======================================================================
 
+.. ts:cv:: CONFIG proxy.config.ssl.server.session_ticket.enable INT 1
+
+  Set to 1 to enable Traffic Server to process TLS tickets for TLS session resumption.
+
 .. ts:cv:: CONFIG proxy.config.ssl.hsts_max_age INT -1
    :overridable:
 

--- a/doc/admin-guide/plugins/index.en.rst
+++ b/doc/admin-guide/plugins/index.en.rst
@@ -159,6 +159,7 @@ directory of the |TS| source tree. Experimental plugins can be compiled by passi
    MySQL Remap <mysql_remap.en>
    Signed URLs <url_sig.en>
    SSL Headers <sslheaders.en>
+   SSL Session Reuse <ssl_session_reuse.en>
    Stale While Revalidate <stale_while_revalidate.en>
    System Statistics <system_stats.en>
    Traffic Dump <traffic_dump.en>
@@ -220,6 +221,9 @@ directory of the |TS| source tree. Experimental plugins can be compiled by passi
 
 :doc:`Signed URLs <url_sig.en>`
    Adds support for verifying URL signatures for incoming requests to either deny or redirect access.
+
+:doc:`SSL Session Reuse <ssl_session_reuse.en>`
+   Coordinates Session ID and ticket based TLS session resumption between a group of ATS machines.
 
 :doc:`SSL Headers <sslheaders.en>`
    Populate request headers with SSL session information.

--- a/doc/admin-guide/plugins/ssl_session_reuse.en.rst
+++ b/doc/admin-guide/plugins/ssl_session_reuse.en.rst
@@ -1,0 +1,94 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+   under the License.
+
+.. include:: ../../common.defs
+
+.. _admin-plugins-ssl_session_reuse:
+
+SSL Session Reuse Plugin
+************************
+
+This plugin coordinates session state data between ATS instances running in a group.  This should 
+improve TLS session reuse (both ticket and ID based) for a set of machines fronted by some form of
+layer 4 connection load balancer.
+
+How It Works
+============
+
+The plugin coordinates TLS session reuse for both Session ID based resumption and ticket based resumption.
+For Session ID base resumption in uses the ATS SSL Session Cache for the local store of TLS sessions.  It uses
+Redis to communication new sessions with its peers.  When a new session is seen by an ATS instances it 
+publishes an encrypted copy of the session state to the local Redis channel.  When a new session is received
+on the Redis channel, the plugin stores that session state into its local ATS SSL session cache.  Once the
+session state is in the local ATS SSL session cache it is avalible to the openssl library for future TLS 
+handshakes.
+
+For the ticket based session resumption, the plugin implements logic to decide on a Session Ticket Encryption Key (STEK)
+master.  The master will periodically create a new STEK key and use the Redis channel to publish the new STEK key 
+to the other ATS boxes in the group.  When the plugin starts up, it will publish a Redis message requesting the master to
+resend the STEK key.  The plugin uses the TSSslTicketKeyUpdate call to update ATS with the last two STEK's it has received.
+
+All communication over the Redis channel is encrypted with a preshared key.  All the ATS boxes participating in the session
+resuse must have access to that preshared key.
+
+Building
+========
+
+This plugin uses Redis for communication.  The hiredis client development library must be installed 
+for this plugin to build.  It can be installed in the standard system location or the install location
+can be specified by the --with-hiredis argument to configure.
+
+As part of the expermental plugs, the --enable-experimental-plugins option must also be given to configure
+to build this plugin.
+
+Deploying
+=========
+
+The SSL Session Reuse plugin relies on Redis for communication.  To deploy build your own redis server or use a standard rpm
+package.  It must be installed on at least one box in the ATS group.  We have it installed on two boxes in a failover 
+scenario.  The SSL Session Resuse configuration file describes how to communicate with the redis servers.  
+
+* :ts:cv:`proxy.config.ssl.session_cache` should be set to 2 to enable the ATS implementation of session cache
+* :ts:cv:`proxy.config.ssl.session_cache.size` and :ts:cv:`proxy.config.ssl.session_cache.num_buckets` may need to be adjusted to ensure good hash table performance for your workload.  For example, we needed to increase the number of buckets to avoid long hash chains.
+* :ts:cv:`proxy.config.ssl.server.session_ticket_enable` should be set to 1 to enable session ticket support.
+
+
+Config File
+===========
+
+SSL Session Reuse is a global plugin.  Its configuration file is given as a argument to the plugin. 
+
+* redis.RedisEndpoints - This is a comma separated list of Redis servers to connect to.  The description of the redis server may include a port
+* redis.RedisConnectTimeout - Timeout on the redis connect attempt in milliseconds.
+* redis.RedisRetryDelay - Timeout on retrying redis operations in miliseconds.
+* pubconfig.PubNumWorkers - Number of worker threads.  Must be at least as many as the number of redis servers.
+* pubconfig.PubRedisPublishTries - Number of times to attempt publishing data
+* pubconfig.PubRedisConnectTries - Number of times to retry a redis connection attempt
+* pubconfig.PubMaxQueuedMessages - Maximum number of undelivered messages to leave in the queue
+* ssl_session.ClusterName - Name associated with the group of machines.  Used to form basis of the redis channel name, e.g. Pool1
+* ssl_session.KeyUpdateInterval - How often to update the STEK key in seconds.
+* ssl_session.STEKMaster - If set to 1, the machine will assume it is the STEK master on startup
+* ssl_session.redis_auth_key_file - The location of the file containing the redis preshared secret.
+* subconfig.SubColoChannel - The redis channels to subscribe to, e.g. Pool1.*
+
+
+
+Example Config File
+===================
+
+.. literalinclude:: ../../../plugins/experimental/ssl_session_reuse/example_config.config
+

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -87,6 +87,10 @@ if BUILD_URI_SIGNING_PLUGIN
 include experimental/uri_signing/Makefile.inc
 endif
 
+if BUILD_SSL_SESSION_REUSE_PLUGIN
+include experimental/ssl_session_reuse/Makefile.inc
+endif
+
 if BUILD_MEMCACHED_REMAP_PLUGIN
 include experimental/memcached_remap/Makefile.inc
 endif

--- a/plugins/experimental/ssl_session_reuse/.gitignore
+++ b/plugins/experimental/ssl_session_reuse/.gitignore
@@ -1,0 +1,2 @@
+# This one gets written a few times with different content by the tests.
+tests/configs/reload.conf

--- a/plugins/experimental/ssl_session_reuse/Makefile.inc
+++ b/plugins/experimental/ssl_session_reuse/Makefile.inc
@@ -1,0 +1,34 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Only build if LIB_HIREDIS is set to a non-empty value
+pkglib_LTLIBRARIES += experimental/ssl_session_reuse/ssl_session_reuse.la
+
+experimental_ssl_session_reuse_ssl_session_reuse_la_SOURCES = \
+         experimental/ssl_session_reuse/src/openssl_utils.cc \
+         experimental/ssl_session_reuse/src/session_process.cc  \
+         experimental/ssl_session_reuse/src/ssl_init.cc \
+         experimental/ssl_session_reuse/src/config.cc \
+         experimental/ssl_session_reuse/src/redis_endpoint.cc  \
+         experimental/ssl_session_reuse/src/simple_pool.cc \
+         experimental/ssl_session_reuse/src/ssl_key_utils.cc \
+         experimental/ssl_session_reuse/src/connection.cc  \
+         experimental/ssl_session_reuse/src/publish.cc \
+         experimental/ssl_session_reuse/src/subscriber.cc \
+  	 experimental/ssl_session_reuse/src/ats_ssl_plugin.cc
+
+experimental_ssl_session_reuse_ssl_session_reuse_la_LIBADD = @LIB_HIREDIS@ 
+

--- a/plugins/experimental/ssl_session_reuse/example_config.config
+++ b/plugins/experimental/ssl_session_reuse/example_config.config
@@ -1,0 +1,61 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+#
+## start generic redis config parameters
+# endpoints
+redis.RedisEndpoints=host1.com:6379,host2.com:6379
+# in milliseconds
+redis.RedisConnectTimeout=20000
+# in milliseconds
+resis.RedisRetryDelay=5000000
+## end generic redis config parameters
+
+## start pub config settings
+pubconfig.PubNumWorkers=5
+pubconfig.PubRedisPublishTries=3
+pubconfig.PubRedisConnectTries=3
+pubconfig.PubMaxQueuedMessages=10000
+pubconfig.PubColoChannelId=sja
+## end pub config settings
+
+## start subconfig settings
+subconfig.SubColoChannel=sja.*
+## end subconfig settings
+
+#############################################################
+# This config file contains the starting values for the
+#  ATS plugin ats_ssl_session_reuse.
+#  Upon pkg install, settings may have been derived from yinst settings
+#############################################################
+## start ssl_session settings
+ssl_session.ClusterName=sja
+
+#############################################################
+# session-ticket-encryption-key (STEK) configs
+# KeyUpdateInterval (in seconds)
+#  Specifies frequency of STEK rotation in POD, if I am STEK Master
+#  maximum is 86400 (24 hours),  default is 25200 (7 hours)
+
+ssl_session.KeyUpdateInterval=25200
+
+# STEKMaster= 1 (This instance will start as the STEK Master, initiating rotation)
+#          or 0 (start as STEK slave)
+ssl_session.STEKMaster=0
+
+ssl_session.redis_auth_key_file=/path/to/key/file
+
+## end ssl_session settings

--- a/plugins/experimental/ssl_session_reuse/src/Config.h
+++ b/plugins/experimental/ssl_session_reuse/src/Config.h
@@ -1,0 +1,106 @@
+/** @file
+
+  Config.h - configuration file support
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <sstream>
+#include <mutex>
+
+struct fromstring {
+  fromstring(const std::string &string) : _string(string) {}
+
+  template <typename _T> operator _T() const
+  {
+    _T t;
+    std::istringstream ss(_string);
+    ss >> t;
+    return t;
+  }
+
+protected:
+  std::string _string;
+};
+
+class Config
+{
+public:
+  virtual bool loadConfig(const std::string &filename);
+
+  static Config &
+  getSingleton()
+  {
+    static Config onlyInstance;
+    return onlyInstance;
+  }
+
+  bool getValue(const std::string &category, const std::string &key, std::string &value);
+
+  template <typename _T>
+  bool
+  getValue(const std::string &category, const std::string &key, _T &value)
+  {
+    std::string strvalue;
+    if (!getValue(category, key, strvalue))
+      return false;
+    value = fromstring(strvalue);
+    return true;
+  }
+
+  template <typename _T>
+  _T
+  returnValue(const std::string &category, const std::string &key, _T default_value)
+  {
+    std::string strvalue;
+    if (!getValue(category, key, strvalue))
+      return default_value;
+    return fromstring(strvalue);
+  }
+
+  bool configHasChanged();
+
+private:
+  // make sure the unit tests can access internals
+  friend class sslSessionReuseConfigTest;
+
+  Config();
+  virtual ~Config();
+
+  bool loadConfigOnChange();
+
+  static const int cCheckDivisor = 5;
+
+  // returns true if the mtime is newer than m_lastmtime
+  // forcefully changes m_lastmtime.
+  bool setLastConfigChange();
+
+  std::string m_filename;
+  std::map<std::string, std::string> m_config;
+  std::mutex m_yconfigLock;
+  bool m_noConfig;
+  bool m_alreadyLoaded;
+  time_t m_lastCheck;
+  time_t m_lastmtime;
+};

--- a/plugins/experimental/ssl_session_reuse/src/ats_ssl_plugin.cc
+++ b/plugins/experimental/ssl_session_reuse/src/ats_ssl_plugin.cc
@@ -1,0 +1,59 @@
+/** @file
+
+  ats_ssl_plugin.cc - plugin setup
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+
+#include <stdio.h>
+#include <ts/ts.h>
+#include <ts/apidefs.h>
+#include <openssl/ssl.h>
+
+#include "ssl_utils.h"
+int SSL_session_callback(TSCont contp, TSEvent event, void *edata);
+void
+TSPluginInit(int argc, const char *argv[])
+{
+  TSPluginRegistrationInfo info;
+
+  info.plugin_name   = (char *)("ats_session_reuse");
+  info.vendor_name   = (char *)("ats");
+  info.support_email = (char *)("ats-devel@oath.com");
+
+#if (TS_VERSION_NUMBER >= 7000000)
+  if (TSPluginRegister(&info) != TS_SUCCESS) {
+    TSError("Plugin registration failed.");
+  }
+#else
+  if (TSPluginRegister(TS_SDK_VERSION_3_0, &info) != TS_SUCCESS) {
+    TSError("Plugin registration failed.");
+  }
+#endif
+  if (argc < 2) {
+    TSError("Must specify config file");
+  } else if (!init_ssl_params(argv[1])) {
+    init_subscriber();
+    TSCont cont = TSContCreate(SSL_session_callback, nullptr);
+    TSHttpHookAdd(TS_SSL_SESSION_HOOK, cont);
+  } else {
+    TSError("init_ssl_params failed.");
+  }
+}

--- a/plugins/experimental/ssl_session_reuse/src/common.h
+++ b/plugins/experimental/ssl_session_reuse/src/common.h
@@ -1,0 +1,28 @@
+/** @file
+
+  commmon.h - Things that need to be everywhere
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+#pragma once
+
+#define PLUGIN "ssl_session_reuse"
+
+extern const unsigned char salt[];

--- a/plugins/experimental/ssl_session_reuse/src/config.cc
+++ b/plugins/experimental/ssl_session_reuse/src/config.cc
@@ -1,0 +1,149 @@
+/** @file
+
+  config.cc - config file support
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+
+#include <ts/ts.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include "tscpp/util/TextView.h"
+
+#include "Config.h"
+#include "common.h"
+
+Config::Config()
+{
+  m_filename = "";
+  m_config.clear();
+  m_noConfig      = false;
+  m_alreadyLoaded = false;
+  m_lastCheck     = 0;
+  m_lastmtime     = 0;
+}
+
+Config::~Config() {}
+
+bool
+Config::loadConfig(const std::string &filename)
+{
+  if (m_alreadyLoaded) {
+    return true;
+  }
+
+  bool success = false;
+
+  m_filename = filename;
+
+  int fd = (this->m_filename.length() > 0 ? open(m_filename.c_str(), O_RDONLY) : 0);
+  struct stat info;
+  if (0 == fstat(fd, &info)) {
+    size_t n = info.st_size;
+    std::string config_data;
+    config_data.resize(n);
+    read(fd, const_cast<char *>(config_data.data()), n);
+
+    ts::TextView content(config_data);
+    while (content) {
+      ts::TextView line = content.take_prefix_at('\n');
+      if (line.empty() || '#' == *line) {
+        continue;
+      }
+      line.ltrim_if(&isspace);
+      ts::TextView field = line.take_prefix_at('=');
+      TSDebug(PLUGIN, "%.*s=%.*s", static_cast<int>(field.size()), field.data(), static_cast<int>(line.size()), line.data());
+      if (field.size() > 0) {
+        m_config[std::string(field.data(), field.size())] = std::string(line.data(), line.size());
+      }
+    }
+  }
+  m_noConfig      = false;
+  success         = true;
+  m_alreadyLoaded = true;
+
+  return success;
+}
+
+bool
+Config::setLastConfigChange()
+{
+  struct stat s;
+  time_t oldLastmtime = m_lastmtime;
+
+  memset(&s, 0, sizeof(s));
+  stat(m_filename.c_str(), &s);
+
+  m_lastmtime = s.st_mtim.tv_sec;
+
+  if (s.st_mtim.tv_sec > oldLastmtime) {
+    return true;
+  }
+  return false;
+}
+
+bool
+Config::configHasChanged()
+{
+  time_t checkTime = time(0) / cCheckDivisor;
+
+  if (0 == m_lastmtime || m_lastCheck != checkTime) {
+    m_lastCheck = checkTime;
+    return setLastConfigChange();
+  }
+  return false;
+}
+
+bool
+Config::loadConfigOnChange()
+{
+  if (configHasChanged()) {
+    // loadConfig will check this, and if it hasn't been set it'll just bail.
+    m_alreadyLoaded = false;
+    return loadConfig(m_filename);
+  }
+
+  return true;
+}
+
+bool
+Config::getValue(const std::string &category, const std::string &key, std::string &value)
+{
+  if (!m_noConfig) {
+    m_yconfigLock.lock();
+
+    if (loadConfigOnChange()) {
+      // convert to category.key= value.
+      std::string keyname                             = category + "." + key;
+      std::map<std::string, std::string>::iterator it = m_config.find(keyname);
+
+      // we have to use find so we don't overwrite defaults when we don't find anything.
+      if (m_config.end() != it) {
+        value = it->second;
+      }
+    }
+    m_yconfigLock.unlock();
+  }
+
+  return !value.empty();
+}

--- a/plugins/experimental/ssl_session_reuse/src/connection.cc
+++ b/plugins/experimental/ssl_session_reuse/src/connection.cc
@@ -1,0 +1,56 @@
+/** @file
+
+  connection.cc - connect to redis
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+
+#include "connection.h"
+
+connection::connection(const std::string &host, const unsigned int port, const unsigned int timeout)
+{
+  struct timeval tv;
+  tv.tv_sec  = timeout / 1000;
+  tv.tv_usec = (timeout % 1000) * 1000;
+
+  c = redisConnectWithTimeout(host.c_str(), port, tv);
+  if (c) {
+    if (c->err != REDIS_OK) {
+      redisFree(c);
+      c = nullptr;
+    }
+  }
+}
+
+connection::~connection()
+{
+  if (c) {
+    redisFree(c);
+  }
+}
+
+bool
+connection::is_valid() const
+{
+  if (c) {
+    return c->err == REDIS_OK;
+  }
+  return false;
+}

--- a/plugins/experimental/ssl_session_reuse/src/connection.h
+++ b/plugins/experimental/ssl_session_reuse/src/connection.h
@@ -1,0 +1,68 @@
+/** @file
+
+  Connection.h - connection class
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+#pragma once
+
+#include <string>
+#include <hiredis/hiredis.h>
+
+/**
+ * @brief The connection class, represent a connection to a Redis server
+ */
+class connection
+{
+public:
+  /**
+   * @brief Create and open a new connection
+   * @param host hostname or ip of redis server, default localhost
+   * @param port port of redis server, default: 6379
+   * @param timeout time out in milli-seconds, default: 5
+   * @return
+   */
+  inline static connection *
+  create(const std::string &host = "localhost", const unsigned int port = 6379, const unsigned int timeout = 5)
+  {
+    return (new connection(host, port, timeout));
+  }
+
+  ~connection();
+
+  bool is_valid() const;
+
+  /**
+   * @brief Returns raw ptr to hiredis library connection.
+   * Use it with caution and pay attention on memory
+   * management.
+   * @return
+   */
+  inline redisContext *const
+  c_ptr() const
+  {
+    return c;
+  }
+
+private:
+  friend class connection_pool;
+  connection(const std::string &host, const unsigned int port, const unsigned int timeout);
+  redisContext *c;
+};

--- a/plugins/experimental/ssl_session_reuse/src/globals.h
+++ b/plugins/experimental/ssl_session_reuse/src/globals.h
@@ -1,0 +1,46 @@
+/** @file
+
+  globals.h - global default values
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+#include <sstream>
+
+const std::string cDefaultConfig("ats_ssl_session_reuse.xml");
+const unsigned int cPubNumWorkerThreads(100);
+const int cDefaultRedisPort(6379);
+const std::string cDefaultRedisHost("localhost");
+const std::string cDefaultRedisEndpoint("localhost:6379");
+const unsigned int cDefaultRedisConnectTimeout(1000000);
+const unsigned int cDefaultRedisPublishTries(5);
+const unsigned int cDefaultRedisConnectTries(5);
+const unsigned int cDefaultRedisRetryDelay(5000000);
+const unsigned int cDefaultMaxQueuedMessages(1000);
+const std::string cDefaultSubColoChannel("test.*");
+const unsigned int cDefaultRedisMessageWaitTime(100000);
+const unsigned int cDefaultMdbmCleanupTime(100);
+const unsigned int cDefaultMdbmMaxSize(65536);
+const unsigned int cDefaultMdbmPageSize(2048);
+const int SUCCESS(0);
+const int FAILURE(-1);

--- a/plugins/experimental/ssl_session_reuse/src/message.h
+++ b/plugins/experimental/ssl_session_reuse/src/message.h
@@ -1,0 +1,40 @@
+/** @file
+
+  messages.h - message class
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+#pragma once
+
+#include <string>
+#include <set>
+#include "redis_endpoint.h"
+
+typedef struct message {
+  std::string channel;
+  std::string data;
+  bool cleanup;
+  std::set<RedisEndpoint, RedisEndpointCompare> hosts_tried;
+
+  message() {}
+  message(const std::string &c, const std::string &d, bool quit = false) : channel(c), data(d), cleanup(quit) {}
+  virtual ~message() {}
+
+} Message;

--- a/plugins/experimental/ssl_session_reuse/src/openssl_utils.cc
+++ b/plugins/experimental/ssl_session_reuse/src/openssl_utils.cc
@@ -1,0 +1,116 @@
+/** @file
+
+  openssl_utils.cc - Interaction with openssl constructs
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+#include <pthread.h>
+#include <errno.h>
+#include <math.h>
+#include <openssl/rand.h>
+#include <pthread.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <ts/ts.h>
+
+#include "ssl_utils.h"
+#include "Config.h"
+#include "session_process.h"
+#include "common.h"
+
+static int
+ssl_new_session(TSSslSessionID &sid)
+{
+  // Encode ID
+  std::string encoded_id;
+  int ret = encode_id(sid.bytes, sid.len, encoded_id);
+  if (ret < 0) {
+    TSError("encoded id failed.");
+    return 0;
+  }
+
+  int session_ret_len = SSL_SESSION_MAX_DER;
+  char session_data[SSL_SESSION_MAX_DER];
+  if (!TSSslSessionGetBuffer(&sid, session_data, &session_ret_len)) {
+    TSError("session data is too large. %d", session_ret_len);
+    return 0;
+  }
+
+  std::string encrypted_data;
+  ret = encrypt_session(session_data, session_ret_len, (unsigned char *)get_key_ptr(), get_key_length(), encrypted_data);
+  if (ret < 0) {
+    TSError("encrypt_session failed.");
+    return 0;
+  }
+
+  std::string redis_channel = ssl_param.cluster_name + "." + encoded_id;
+  ssl_param.pub->publish(redis_channel, encrypted_data);
+
+  TSDebug(PLUGIN, "create new session id: %s  encoded: \"%s\" channel: %s", encoded_id.c_str(), encrypted_data.c_str(),
+          redis_channel.c_str());
+
+  return 0;
+}
+
+static int
+ssl_access_session(TSSslSessionID &sid)
+{
+  return 0;
+}
+
+static int
+ssl_del_session(TSSslSessionID &sid)
+{
+  std::string encoded_id;
+
+  int ret = encode_id(sid.bytes, sid.len, encoded_id);
+  if (!ret) {
+    TSDebug(PLUGIN, "session is deleted. id: \"%s\"", encoded_id.c_str());
+  }
+
+  return 0;
+}
+
+int
+SSL_session_callback(TSCont contp, TSEvent event, void *edata)
+{
+  TSSslSessionID *sessionid = reinterpret_cast<TSSslSessionID *>(edata);
+
+  switch (event) {
+  case TS_EVENT_SSL_SESSION_NEW:
+    ssl_new_session(*sessionid);
+    break;
+  case TS_EVENT_SSL_SESSION_REMOVE:
+    ssl_del_session(*sessionid);
+    break;
+  case TS_EVENT_SSL_SESSION_GET:
+    ssl_access_session(*sessionid);
+    break;
+  default:
+    break;
+  }
+  return 0;
+}

--- a/plugins/experimental/ssl_session_reuse/src/publish.cc
+++ b/plugins/experimental/ssl_session_reuse/src/publish.cc
@@ -1,0 +1,383 @@
+/** @file
+
+  publish.cc - redis publisher class
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+
+#include <sys/time.h>
+#include <unistd.h>
+#include <iostream>
+#include <exception>
+#include <string.h>
+#include <memory>
+#include <ts/ts.h>
+#include "common.h"
+#include "publisher.h"
+#include "Config.h"
+#include "redis_auth.h"
+
+void *
+RedisPublisher::start_worker_thread(void *arg)
+{
+  RedisPublisher *publisher = static_cast<RedisPublisher *>(arg);
+  publisher->runWorker();
+  return arg;
+}
+
+RedisPublisher::RedisPublisher(const std::string &conf)
+  : m_redisEndpointsStr(cDefaultRedisEndpoint),
+    m_endpointIndex(0),
+    m_numWorkers(cPubNumWorkerThreads),
+    m_redisConnectTimeout(cDefaultRedisConnectTimeout),
+    m_redisConnectTries(cDefaultRedisConnectTries),
+    m_redisPublishTries(cDefaultRedisPublishTries),
+    m_redisRetryDelay(cDefaultRedisRetryDelay),
+    m_maxQueuedMessages(cDefaultMaxQueuedMessages),
+    err(false)
+{
+  if (Config::getSingleton().loadConfig(conf)) {
+    Config::getSingleton().getValue("pubconfig", "PubNumWorkers", m_numWorkers);
+    Config::getSingleton().getValue("redis", "RedisEndpoints", m_redisEndpointsStr);
+    Config::getSingleton().getValue("redis", "RedisConnectTimeout", m_redisConnectTimeout);
+    Config::getSingleton().getValue("pubconfig", "PubRedisPublishTries", m_redisPublishTries);
+    Config::getSingleton().getValue("pubconfig", "PubRedisConnectTries", m_redisConnectTries);
+    Config::getSingleton().getValue("redis", "RedisRetryDelay", m_redisRetryDelay);
+    Config::getSingleton().getValue("pubconfig", "PubMaxQueuedMessages", m_maxQueuedMessages);
+    Config::getSingleton().getValue("redis", "RedisConnectTimeout", m_poolRedisConnectTimeout);
+  }
+
+  // get our psk to access session_reuse redis network.
+  char redis_auth_key[MAX_REDIS_KEYSIZE];
+  if (!(get_redis_auth_key(redis_auth_key, MAX_REDIS_KEYSIZE))) {
+    err = true;
+    TSError("RedisPublisher::RedisPublisher.Cannot get redis AUTH password.");
+    redis_passwd.clear();
+  } else {
+    redis_passwd = redis_auth_key;
+    memset(redis_auth_key, 0, MAX_REDIS_KEYSIZE); // tidy up our stack
+  }
+
+  addto_endpoint_vector(m_redisEndpoints, m_redisEndpointsStr);
+
+  TSDebug(PLUGIN, "RedisPublisher::RedisPublisher.NumWorkers= %d RedisConnectTimeout=%d", m_numWorkers, m_redisConnectTimeout);
+  TSDebug(PLUGIN,
+          "RedisPublisher::RedisPublisher.RedisPublishTries= %d RedisConnectTries=%d RedisRetryDelay=%d MaxQueuedMessages=%d",
+          m_redisPublishTries, m_redisConnectTries, m_redisRetryDelay, m_maxQueuedMessages);
+
+  TSDebug(PLUGIN, "RedisPublisher::RedisPublisher.Redis Publish endpoints are as follows:");
+  for (std::vector<RedisEndpoint>::iterator it = m_redisEndpoints.begin(); it != m_redisEndpoints.end(); ++it) {
+    // LOGDEBUG(PUB, *it);
+    simple_pool *pool = simple_pool::create(it->m_hostname, it->m_port, m_poolRedisConnectTimeout);
+    pools.push_back(pool);
+  }
+
+  TSDebug(PLUGIN, "RedisPublisher::RedisPublisher.PoolRedisConnectTimeout= %d", m_poolRedisConnectTimeout);
+
+  ::sem_init(&m_workerSem, 0, 0);
+
+  if (m_redisEndpoints.size() > m_numWorkers) {
+    err = true;
+    TSError("RedisPublisher::RedisPublisher.Number of threads in the thread pool less than the number of redis endpoints");
+  }
+
+  if (!err) {
+    for (int i = 0; i < static_cast<int>(m_numWorkers); i++) {
+      TSThreadCreate(RedisPublisher::start_worker_thread, static_cast<void *>(this));
+    }
+  }
+}
+
+bool
+RedisPublisher::is_good()
+{
+  return !err;
+}
+
+::redisContext *
+RedisPublisher::setup_connection(const RedisEndpoint &re)
+{
+  ::pthread_t my_id = ::pthread_self();
+  TSDebug(PLUGIN, "RedisPublisher::setup_connection.called by threadId: %d", static_cast<int>(my_id));
+
+  RedisContextPtr my_context;
+  struct ::timeval timeout;
+  timeout.tv_sec  = m_redisConnectTimeout / 1000;
+  timeout.tv_usec = (m_redisConnectTimeout % 1000) * 1000;
+
+  for (int i = 0; i < static_cast<int>(m_redisConnectTries); ++i) {
+    my_context.reset(::redisConnectWithTimeout(re.m_hostname.c_str(), re.m_port, timeout));
+    if (!my_context) {
+      TSError("RedisPublisher::setup_connection.connect to host: %s and port: %d fail count: %d threadId: %d",
+              re.m_hostname.c_str(), re.m_port, i + 1, static_cast<int>(my_id));
+    } else if (my_context->err) {
+      TSError("RedisPublisher::setup_connection.connect to host: %s port: %d fail count: %d and threadId: %d",
+              re.m_hostname.c_str(), re.m_port, i + 1, static_cast<int>(my_id));
+      my_context.reset(nullptr);
+    } else {
+      TSDebug(PLUGIN, "RedisPublisher::setup_connection.threadId: %d  successfully connected to the redis instance",
+              static_cast<int>(my_id));
+
+      redisReply *reply = static_cast<redisReply *>(redisCommand(my_context.get(), "AUTH %s", redis_passwd.c_str()));
+
+      if (reply == nullptr) {
+        TSError("RedisPublisher::setup_connection. Cannot AUTH redis server, no reply.");
+        my_context.reset(nullptr);
+      } else if (reply->type == REDIS_REPLY_ERROR) {
+        TSError("RedisPublisher::setup_connection. Cannot AUTH redis server, error reply.");
+        freeReplyObject(reply);
+        my_context.reset(nullptr);
+      } else {
+        TSDebug(PLUGIN, "RedisPublisher::setup_connection. Successfully AUTH redis server.");
+        freeReplyObject(reply);
+      }
+      break;
+    }
+
+    TSError("RedisPublisher::setup_connection.connect failed.will wait for: %d microseconds and try again.", m_redisRetryDelay);
+    ::usleep(m_redisRetryDelay);
+  }
+
+  return my_context.release();
+}
+
+::redisReply *
+RedisPublisher::send_publish(RedisContextPtr &ctx, const RedisEndpoint &re, const Message &msg)
+{
+  ::pthread_t my_id = ::pthread_self();
+  TSDebug(PLUGIN, "RedisPublisher::send_publish.called by threadId: %d", static_cast<int>(my_id));
+
+  ::redisReply *current_reply(nullptr);
+
+  for (int i = 0; i < static_cast<int>(m_redisPublishTries); ++i) {
+    if (!ctx) {
+      ctx.reset(setup_connection(re));
+
+      if (!ctx) {
+        TSError("RedisPublisher::send_publish.Unable to setup a connection to the redis server: %s:%d .ThreadId: %d Try: %d",
+                re.m_hostname.c_str(), re.m_port, static_cast<int>(my_id), (i + 1));
+        continue;
+      }
+    }
+
+    current_reply = static_cast<redisReply *>(::redisCommand(ctx.get(), "PUBLISH %s %s", msg.channel.c_str(), msg.data.c_str()));
+    if (!current_reply) {
+      TSError("RedisPublisher::send_publish.Unable to get a reply from the server for publish.ThreadId: %d Try: %d",
+              static_cast<int>(my_id), (i + 1));
+      ctx.reset(nullptr); // Clean up previous attempt
+
+    } else if (REDIS_REPLY_ERROR == current_reply->type) {
+      TSError("RedisPublisher::send_publish.Server responded with error for publish.ThreadId: %d Try: %d", static_cast<int>(my_id),
+              i + 1);
+      clear_reply(current_reply);
+      current_reply = nullptr;
+      ctx.reset(nullptr); // Clean up previous attempt
+    } else {
+      break;
+    }
+  }
+
+  return current_reply;
+}
+
+void
+RedisPublisher::clear_reply(::redisReply *reply)
+{
+  if (reply) {
+    ::freeReplyObject(reply);
+  }
+}
+
+void
+RedisPublisher::runWorker()
+{
+  m_endpointIndexMutex.lock();
+  RedisEndpoint &my_endpoint(m_redisEndpoints[m_endpointIndex]);
+
+  if (static_cast<int>(m_redisEndpoints.size() - 1) == m_endpointIndex) {
+    m_endpointIndex = 0;
+  } else {
+    ++m_endpointIndex;
+  }
+  m_endpointIndexMutex.unlock();
+
+  ::pthread_t my_id = ::pthread_self();
+  RedisContextPtr my_context;
+  ::redisReply *current_reply(nullptr);
+
+  while (true) {
+    ::sem_post(&m_workerSem);
+    int readyWorkers = 0;
+    ::sem_getvalue(&m_workerSem, &readyWorkers);
+
+    // LOGDEBUG(PUB, "RedisPublisher::runWorker.Ready worker count: " << readyWorkers);
+
+    m_messageQueueMutex.lock();
+
+    if (m_messageQueue.empty()) {
+      ::sem_wait(&m_workerSem);
+      m_messageQueueMutex.unlock();
+      usleep(1000);
+      continue;
+    }
+
+    Message &current_message(m_messageQueue.front());
+
+    m_messageQueueMutex.unlock();
+    ::sem_wait(&m_workerSem);
+
+    if (current_message.cleanup) {
+      TSDebug(PLUGIN, "RedisPublisher::runWorker.Thread id: %d received the cleanup message. exiting!", static_cast<int>(my_id));
+      break;
+    }
+    current_reply = send_publish(my_context, my_endpoint, current_message);
+
+    if (!current_reply) {
+      current_message.hosts_tried.insert(my_endpoint);
+      if (current_message.hosts_tried.size() < m_redisEndpoints.size()) {
+        // all endpoints are not tried
+        // someone else might be able to transmit
+        m_messageQueueMutex.lock();
+
+        if (!m_messageQueue.front().cleanup) {
+          m_messageQueue.push_front(current_message);
+        }
+
+        m_messageQueueMutex.unlock();
+      }
+    }
+
+    if (!current_message.cleanup) {
+      m_messageQueue.pop_front();
+    }
+
+    clear_reply(current_reply);
+    current_reply = nullptr;
+  }
+  my_context.reset(nullptr);
+  clear_reply(current_reply);
+
+  ::pthread_exit(nullptr);
+}
+
+int
+RedisPublisher::publish(const std::string &channel, const std::string &data)
+{
+  TSDebug(PLUGIN, "RedisPublisher::publish.Publish request for channel: %s and message: \"%s\" received", channel.c_str(),
+          data.c_str());
+
+  m_messageQueueMutex.lock();
+
+  m_messageQueue.emplace_back(channel, data);
+
+  if (m_maxQueuedMessages < m_messageQueue.size()) {
+    m_messageQueue.pop_front();
+  }
+  m_messageQueueMutex.unlock();
+
+  return SUCCESS;
+}
+
+int
+RedisPublisher::signal_cleanup()
+{
+  TSDebug(PLUGIN, "RedisPublisher::signal_cleanup.called");
+  Message cleanup_message("", "", true);
+
+  m_messageQueueMutex.lock();
+
+  m_messageQueue.push_front(cleanup_message); // highest priority
+
+  m_messageQueueMutex.unlock();
+
+  return SUCCESS;
+}
+
+RedisPublisher::~RedisPublisher()
+{
+  TSDebug(PLUGIN, "RedisPublisher::~RedisPublisher.called");
+  RedisPublisher::signal_cleanup();
+
+  ::sem_destroy(&m_workerSem);
+}
+
+std::string
+RedisPublisher::get_session(const std::string &channel)
+{
+  TSDebug(PLUGIN, "RedisPublisher::get_session. Called by threadId: %d", static_cast<int>(pthread_self()));
+  std::string ret;
+  uint32_t index    = get_hash_index(channel);
+  redisReply *reply = nullptr;
+  TSDebug(PLUGIN, "RedisPublisher::get_session. Start to try to get session.");
+  for (uint32_t i = 0; i < m_redisEndpoints.size(); i++) {
+    connection *conn = pools[index]->get();
+
+    if (conn) {
+      reply = static_cast<redisReply *>(redisCommand(conn->c_ptr(), "GET %s", channel.c_str()));
+      if (reply && reply->type == REDIS_REPLY_STRING) {
+        TSDebug(PLUGIN, "RedisPublisher::get_session. Success to GET a value from redis server index: %d", index);
+        pools[index]->put(conn);
+        ret = reply->str;
+        clear_reply(reply);
+        return ret;
+      }
+      pools[index]->put(conn);
+      clear_reply(reply);
+    }
+    TSError("RedisPublisher::get_session. Fail to GET a value from this redis server index: %d", index);
+    index = get_next_index(index);
+    TSDebug(PLUGIN, "RedisPublisher::get_session. Will try the next redis server: %d", index);
+  }
+
+  TSError("RedisPublisher::get_session. Fail to GET a value from all redis servers!");
+  return ret;
+}
+
+redisReply *
+RedisPublisher::set_session(const Message &msg)
+{
+  TSDebug(PLUGIN, "RedisPublisher::set_session. Called by threadId: %d", static_cast<int>(pthread_self()));
+  uint32_t index    = get_hash_index(msg.channel);
+  redisReply *reply = nullptr;
+  for (uint32_t i = 0; i < m_redisEndpoints.size(); i++) {
+    connection *conn = pools[index]->get();
+
+    if (conn) {
+      reply = static_cast<redisReply *>(redisCommand(conn->c_ptr(), "SET %s %s", msg.channel.c_str(), msg.data.c_str()));
+      if (reply && reply->type == REDIS_REPLY_STATUS && strcasecmp(reply->str, "OK") == 0) {
+        TSDebug(PLUGIN, "RedisPublisher::set_session. Success to SET a value to redis server: %s:%d",
+                m_redisEndpoints[index].m_hostname.c_str(), m_redisEndpoints[index].m_port);
+        pools[index]->put(conn);
+        return reply;
+      }
+      pools[index]->put(conn);
+      clear_reply(reply);
+    }
+    TSError("RedisPublisher::set_session. Fail to SET a value to this redis server %s:%d",
+            m_redisEndpoints[index].m_hostname.c_str(), m_redisEndpoints[index].m_port);
+
+    index = get_next_index(index);
+    TSDebug(PLUGIN, "RedisPublisher::set_session. Will try the next redis server: %s:%d",
+            m_redisEndpoints[index].m_hostname.c_str(), m_redisEndpoints[index].m_port);
+  }
+
+  TSError("RedisPublisher::set_session. Fail to SET a value to all redis servers!");
+  return nullptr;
+}

--- a/plugins/experimental/ssl_session_reuse/src/publisher.h
+++ b/plugins/experimental/ssl_session_reuse/src/publisher.h
@@ -1,0 +1,104 @@
+/** @file
+
+  publisher.h - Redis publisher
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+#pragma once
+
+#include <string>
+#include <deque>
+#include <vector>
+#include <mutex>
+#include <memory>
+#include <semaphore.h>
+#include <hiredis/hiredis.h>
+#include "message.h"
+#include "globals.h"
+#include "redis_endpoint.h"
+#include "simple_pool.h"
+#include "tscore/HashFNV.h"
+
+struct RedisContextDeleter {
+  void
+  operator()(::redisContext *ctx)
+  {
+    ::redisFree(ctx);
+  }
+};
+
+typedef std::unique_ptr<::redisContext, RedisContextDeleter> RedisContextPtr;
+
+class RedisPublisher
+{
+  std::string redis_passwd;
+  std::deque<Message> m_messageQueue;
+  std::mutex m_messageQueueMutex;
+  ::sem_t m_workerSem;
+
+  std::vector<RedisEndpoint> m_redisEndpoints;
+  std::string m_redisEndpointsStr;
+  int m_endpointIndex;
+  std::mutex m_endpointIndexMutex;
+
+  std::vector<simple_pool *> pools;
+
+  unsigned int m_numWorkers;
+  unsigned int m_redisConnectTimeout; // milliseconds
+  unsigned int m_redisConnectTries;
+  unsigned int m_redisPublishTries;
+  unsigned int m_redisRetryDelay; // milliseconds
+  unsigned int m_maxQueuedMessages;
+  unsigned int m_poolRedisConnectTimeout; // milliseconds
+
+  bool err;
+
+  void runWorker();
+
+  ::redisContext *setup_connection(const RedisEndpoint &re);
+
+  ::redisReply *send_publish(RedisContextPtr &ctx, const RedisEndpoint &re, const Message &msg);
+  ::redisReply *set_session(const Message &msg);
+  void clear_reply(::redisReply *reply);
+
+  uint32_t
+  get_hash_index(const std::string &str) const
+  {
+    ATSHash32FNV1a hashFNV;
+    hashFNV.update(str.c_str(), str.length());
+    return hashFNV.get();
+  }
+
+  uint32_t
+  get_next_index(uint32_t index) const
+  {
+    return (index + 1) % m_redisEndpoints.size();
+  }
+
+  int signal_cleanup();
+  static void *start_worker_thread(void *arg);
+
+public:
+  RedisPublisher(const std::string &conf = cDefaultConfig);
+  virtual ~RedisPublisher();
+  int publish(const std::string &channel, const std::string &message);
+  std::string get_session(const std::string &channel);
+  bool is_good();
+};

--- a/plugins/experimental/ssl_session_reuse/src/redis_auth.h
+++ b/plugins/experimental/ssl_session_reuse/src/redis_auth.h
@@ -1,0 +1,28 @@
+/** @file
+
+  redis_auth.h
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+#pragma once
+
+#define MAX_REDIS_KEYSIZE 256
+
+int get_redis_auth_key(char *retKeyBuff, int buffSize);

--- a/plugins/experimental/ssl_session_reuse/src/redis_endpoint.cc
+++ b/plugins/experimental/ssl_session_reuse/src/redis_endpoint.cc
@@ -1,0 +1,66 @@
+/** @file
+
+  redis_endpoint.cc - represent Redis endpoints
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+
+#include "redis_endpoint.h"
+
+redis_endpoint::redis_endpoint(const std::string &endpoint_spec)
+{
+  std::stringstream ss;
+  size_t delim_pos(endpoint_spec.find(':'));
+  m_hostname = endpoint_spec.substr(0, delim_pos);
+
+  if (m_hostname.empty()) {
+    m_hostname = cDefaultRedisHost;
+  }
+
+  if (delim_pos != std::string::npos) {
+    ss << endpoint_spec.substr(delim_pos + 1);
+    ss >> m_port;
+  } else {
+    m_port = cDefaultRedisPort;
+  }
+}
+
+void
+addto_endpoint_vector(std::vector<RedisEndpoint> &endpoints, const std::string &endpoint_str)
+{
+  char delim(',');
+  size_t current_start_pos(0);
+  size_t current_end_pos(0);
+  std::string current_endpoint;
+
+  while ((std::string::npos != current_end_pos) && (current_start_pos < endpoint_str.size())) {
+    current_end_pos = endpoint_str.find(delim, current_start_pos);
+
+    if (std::string::npos != current_end_pos) {
+      current_endpoint = endpoint_str.substr(current_start_pos, current_end_pos - current_start_pos);
+    } else {
+      current_endpoint = endpoint_str.substr(current_start_pos);
+    }
+
+    endpoints.push_back(RedisEndpoint(current_endpoint));
+
+    current_start_pos = current_end_pos + 1;
+  }
+}

--- a/plugins/experimental/ssl_session_reuse/src/redis_endpoint.h
+++ b/plugins/experimental/ssl_session_reuse/src/redis_endpoint.h
@@ -1,0 +1,48 @@
+/** @file
+
+  redis_endpoint.h
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+#include "globals.h"
+
+typedef struct redis_endpoint {
+  std::string m_hostname;
+  int m_port;
+
+  redis_endpoint() : m_hostname(cDefaultRedisHost), m_port(cDefaultRedisPort) {}
+  redis_endpoint(const std::string &endpoint_spec);
+
+} RedisEndpoint;
+
+typedef struct redis_endpoint_compare {
+  bool
+  operator()(const RedisEndpoint &lhs, const RedisEndpoint &rhs)
+  {
+    return lhs.m_hostname < rhs.m_hostname || (lhs.m_hostname == rhs.m_hostname && lhs.m_port < rhs.m_port);
+  }
+
+} RedisEndpointCompare;
+
+void addto_endpoint_vector(std::vector<RedisEndpoint> &endpoints, const std::string &endpoint_str);

--- a/plugins/experimental/ssl_session_reuse/src/session_process.cc
+++ b/plugins/experimental/ssl_session_reuse/src/session_process.cc
@@ -1,0 +1,252 @@
+/** @file
+
+  session_process.cc - encrypt and decrypt sessions
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+
+#include <math.h>
+#include <string.h>
+#include <errno.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <openssl/rand.h>
+#include <ts/ts.h>
+
+#include "session_process.h"
+#include "ssl_utils.h"
+
+#include "common.h"
+
+const unsigned char salt[] = {115, 97, 108, 117, 0, 85, 137, 229};
+
+int
+encrypt_session(const char *session_data, int32_t session_data_len, const unsigned char *key, int key_length,
+                std::string &encrypted_data)
+{
+  size_t len_all = 0;
+  size_t offset  = 0;
+  char *pBuf     = nullptr;
+
+  int encrypted_buffer_size    = 0;
+  int encrypted_msg_len        = 0;
+  unsigned char *encrypted_msg = nullptr;
+  int ret                      = 0;
+
+  offset  = 0;
+  len_all = sizeof(int64_t) + sizeof(int32_t) + session_data_len;
+
+  pBuf = new char[len_all];
+
+  // Put in a fixed experation time of 7 hours, just to have communication consistency with the original
+  // protocol
+  int64_t expire_time = time(nullptr) + 2 * 3600;
+  memcpy(pBuf + offset, &expire_time, sizeof(expire_time));
+  offset += sizeof(int64_t);
+
+  memcpy(pBuf + offset, &session_data_len, sizeof(int32_t));
+  offset += sizeof(session_data_len);
+  memcpy(pBuf + offset, session_data, session_data_len);
+
+  // Initialize context
+  EVP_CIPHER_CTX *context = EVP_CIPHER_CTX_new();
+  unsigned char iv[EVP_MAX_IV_LENGTH];
+  unsigned char gen_key[EVP_MAX_KEY_LENGTH];
+
+  // generate key and iv
+  int generated_key_len = EVP_BytesToKey(EVP_aes_256_cbc(), EVP_md5(), (unsigned char *)salt, key, key_length, 1, gen_key, iv);
+  if (generated_key_len <= 0) {
+    TSDebug(PLUGIN, "Error generating key");
+  }
+
+  // Set context AES128 with the generated key and iv
+  if (1 != EVP_EncryptInit_ex(context, EVP_aes_256_cbc(), nullptr, gen_key, iv)) {
+    TSDebug(PLUGIN, "Encryption of session data failed");
+    ret = -1;
+    goto Cleanup;
+  }
+
+  int elen;
+  encrypted_buffer_size = ENCRYPT_LEN(len_all);
+  encrypted_msg_len     = encrypted_buffer_size;
+  encrypted_msg         = new unsigned char[encrypted_buffer_size];
+  if (1 != EVP_EncryptUpdate(context, (unsigned char *)encrypted_msg, &elen, (unsigned char *)pBuf, len_all)) {
+    TSDebug(PLUGIN, "Encryption of session data failed");
+    ret = -1;
+    goto Cleanup;
+  }
+  encrypted_msg_len = elen;
+  if (1 != EVP_EncryptFinal_ex(context, encrypted_msg + elen, &elen)) {
+    TSDebug(PLUGIN, "Encryption of session data failed");
+    ret = -1;
+    goto Cleanup;
+  }
+  encrypted_msg_len += elen;
+
+  TSDebug(PLUGIN, "Encrypted buffer of size %d to buffer of size %d\n", session_data_len, encrypted_msg_len);
+
+  encrypted_data.assign((char *)encrypted_msg, encrypted_msg_len);
+
+Cleanup:
+
+  if (pBuf)
+    delete[] pBuf;
+  if (encrypted_msg)
+    delete[] encrypted_msg;
+  if (context) {
+    EVP_CIPHER_CTX_free(context);
+  }
+
+  return ret;
+}
+
+/**
+ * The initial value of session_data_len is the number of bytes in session_data
+ * The return value of session_data_len is the number of bytes actually stored in session_data
+ * The return value is -1 on error or the number of bytes in the decrypted session data (may be more
+ * than the initial value of sesion_data_len
+ */
+int
+decrypt_session(const std::string &encrypted_data, const unsigned char *key, int key_length, char *session_data,
+                int32_t &session_data_len)
+{
+  unsigned char *ssl_sess_ptr  = nullptr;
+  int decrypted_buffer_size    = 0;
+  int decrypted_msg_len        = 0;
+  unsigned char *decrypted_msg = nullptr;
+  int ret                      = 0;
+
+  // Initialize context
+  // Initialize context
+  EVP_CIPHER_CTX *context = EVP_CIPHER_CTX_new();
+  unsigned char iv[EVP_MAX_IV_LENGTH];
+  unsigned char gen_key[EVP_MAX_KEY_LENGTH];
+
+  // generate key and iv
+  int generated_key_len = EVP_BytesToKey(EVP_aes_256_cbc(), EVP_md5(), (unsigned char *)salt, key, key_length, 1, gen_key, iv);
+
+  if (generated_key_len <= 0) {
+    TSDebug(PLUGIN, "Error generating key");
+  }
+  // set context with the generated key and iv
+  if (1 != EVP_DecryptInit_ex(context, EVP_aes_256_cbc(), nullptr, gen_key, iv)) {
+    TSDebug(PLUGIN, "Decryption of encrypted session data failed");
+    goto Cleanup;
+  }
+
+  decrypted_buffer_size = DECRYPT_LEN(encrypted_data.length());
+  decrypted_msg         = (unsigned char *)new char[decrypted_buffer_size + 1];
+  decrypted_msg_len     = decrypted_buffer_size + 1;
+  if (decrypted_msg == nullptr)
+    TSError("decrypted_msg allocate failure");
+  if (1 != EVP_DecryptUpdate(context, decrypted_msg, &decrypted_msg_len, (unsigned char *)encrypted_data.c_str(),
+                             encrypted_data.length())) {
+    TSDebug(PLUGIN, "Decryption of encrypted session data failed");
+    goto Cleanup;
+  }
+
+  // Retrieve ssl_session
+  ssl_sess_ptr = (unsigned char *)decrypted_msg;
+
+  // Skip the expiration time.  Just a place holder to interact with the old version
+  ssl_sess_ptr += sizeof(int64_t);
+
+  // Length
+  ret = *(int32_t *)ssl_sess_ptr;
+  ssl_sess_ptr += sizeof(int32_t);
+  TSDebug(PLUGIN, "Decrypted buffer of size %d from buffer of size %d\n", ret, session_data_len);
+  // If there is less data than the maxiumum buffer size, reduce accordingly
+  if (ret < session_data_len) {
+    session_data_len = ret;
+  }
+  memcpy(session_data, ssl_sess_ptr, session_data_len);
+
+Cleanup:
+
+  if (decrypted_msg)
+    delete[] decrypted_msg;
+
+  if (context) {
+    EVP_CIPHER_CTX_free(context);
+  }
+
+  return ret;
+}
+
+int
+decode_id(std::string encoded_id, char *decoded_data, int &decoded_data_len)
+{
+  size_t decode_len = 0;
+  memset(decoded_data, 0, decoded_data_len);
+  if (TSBase64Decode((const char *)encoded_id.c_str(), encoded_id.length(), (unsigned char *)decoded_data, decoded_data_len,
+                     &decode_len) != 0) {
+    TSError("Base 64 decoding failed.");
+    return -1;
+  }
+  decoded_data_len = decode_len;
+  return 0;
+}
+
+int
+encode_id(const char *id, int idlen, std::string &encoded_data)
+{
+  char *encoded = new char[ENCODED_LEN(idlen)];
+  memset(encoded, 0, ENCODED_LEN(idlen));
+  size_t encoded_len = 0;
+  if (TSBase64Encode((const char *)id, idlen, encoded, ENCODED_LEN(idlen), &encoded_len) != 0) {
+    TSError("Base 64 encoding failed.");
+    if (encoded)
+      delete[] encoded;
+    return -1;
+  }
+
+  encoded_data.assign(encoded);
+  if (encoded)
+    delete[] encoded;
+
+  return 0;
+}
+
+int
+add_session(char *session_id, int session_id_len, const std::string &encrypted_session)
+{
+  char session_data[SSL_SESSION_MAX_DER];
+  int32_t session_data_len = SSL_SESSION_MAX_DER;
+  if (decrypt_session(encrypted_session, (unsigned char *)get_key_ptr(), get_key_length(), session_data, session_data_len) < 0) {
+    TSError("Failed to decrypt session %.*s", session_id_len, session_id);
+    return -1;
+  }
+  const unsigned char *loc = reinterpret_cast<const unsigned char *>(session_data);
+  SSL_SESSION *sess        = d2i_SSL_SESSION(nullptr, &loc, session_data_len);
+  if (nullptr == sess) {
+    TSError("Failed to transform session buffer %.*s", session_id_len, session_id);
+  }
+  TSSslSessionID sid;
+  memcpy(reinterpret_cast<char *>(sid.bytes), session_id, session_id_len);
+  sid.len = session_id_len;
+  if (sid.len > sizeof(sid.bytes)) {
+    sid.len = sizeof(sid.bytes);
+  }
+  TSSslSessionInsert(&sid, reinterpret_cast<TSSslSession>(sess));
+  // Free the sesison object created by d2i_SSL_SESSION
+  // We should make an API that just takes the ASN buffer
+  SSL_SESSION_free(sess);
+  return 0;
+}

--- a/plugins/experimental/ssl_session_reuse/src/session_process.h
+++ b/plugins/experimental/ssl_session_reuse/src/session_process.h
@@ -1,0 +1,47 @@
+/** @file
+
+  session_process.h
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+#pragma once
+
+#include <string>
+#include <math.h>
+
+#define SSL_SESSION_MAX_DER 1024 * 10
+
+// Base 64 encoding takes 4*(floor(n/3)) bytes
+#define ENCODED_LEN(len) ((int)ceil(1.34 * len + 5)) + 1
+#define DECODED_LEN(len) ((int)ceil(0.75 * len)) + 1
+// 3DES encryption will take at most 8 extra bytes.  Plus we base 64 encode the result
+#define ENCRYPT_LEN(len) (int)ceil(1.34 * (len + 8) + 5) + 1
+#define DECRYPT_LEN(len) (int)ceil(1.34 * (len + 8) + 5) + 1
+
+int encrypt_session(const char *session_data, int32_t session_data_len, const unsigned char *key, int key_length,
+                    std::string &encrypted_data);
+
+int decrypt_session(const std::string &encrypted_data, const unsigned char *key, int key_length, char *session_data,
+                    int32_t &session_len);
+
+int encode_id(const char *id, int idlen, std::string &decoded_data);
+int decode_id(std::string encoded_id, char *decoded_data, int &decoded_data_len);
+
+int add_session(char *session_id, int session_id_len, const std::string &encrypted_session);

--- a/plugins/experimental/ssl_session_reuse/src/simple_pool.cc
+++ b/plugins/experimental/ssl_session_reuse/src/simple_pool.cc
@@ -1,0 +1,76 @@
+/** @file
+
+  simple_pool.cc - a containuer of connection objects
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+
+#include "simple_pool.h"
+
+connection *
+simple_pool::get()
+{
+  connection *ret = nullptr;
+
+  access_mutex.lock();
+  for (std::set<connection *>::iterator it = connections.begin(); it != connections.end();) {
+    if (*it) {
+      if ((*it)->is_valid()) {
+        ret = *it;
+        connections.erase(it++);
+        break;
+      } else {
+        delete *it;
+        connections.erase(it++);
+      }
+    }
+  }
+  access_mutex.unlock();
+
+  if (ret == nullptr) {
+    ret = connection::create(_host, _port, _timeout);
+    if (ret && !ret->is_valid()) {
+      delete ret;
+      ret = nullptr;
+    }
+  }
+
+  return ret;
+}
+
+void
+simple_pool::put(connection *conn)
+{
+  if (conn == nullptr)
+    return;
+
+  if (!conn->is_valid()) {
+    delete conn;
+    return;
+  }
+  access_mutex.lock();
+  connections.insert(conn);
+  access_mutex.unlock();
+}
+
+simple_pool::simple_pool(const std::string &host, unsigned int port, unsigned int timeout)
+  : _host(host), _port(port), _timeout(timeout)
+{
+}

--- a/plugins/experimental/ssl_session_reuse/src/simple_pool.h
+++ b/plugins/experimental/ssl_session_reuse/src/simple_pool.h
@@ -1,0 +1,62 @@
+/** @file
+
+  simple_pool.h
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+#pragma once
+
+#include "connection.h"
+#include <set>
+#include <mutex>
+
+/**
+ * @brief Manages a pool of connections to a single Redis server
+ */
+class simple_pool
+{
+public:
+  static inline simple_pool *
+  create(const std::string &host = "localhost", unsigned int port = 6379, unsigned int timeout = 5)
+  {
+    return (new simple_pool(host, port, timeout));
+  }
+
+  /**
+   * @brief Get a working connection
+   * @return
+   */
+  connection *get();
+
+  /**
+   * @brief Put back a connection for reuse
+   * @param conn
+   */
+  void put(connection *conn);
+
+private:
+  simple_pool(const std::string &host, unsigned int port, unsigned int timeout);
+
+  std::string _host;
+  unsigned int _port;
+  unsigned int _timeout;
+  std::set<connection *> connections;
+  std::mutex access_mutex;
+};

--- a/plugins/experimental/ssl_session_reuse/src/ssl_init.cc
+++ b/plugins/experimental/ssl_session_reuse/src/ssl_init.cc
@@ -1,0 +1,122 @@
+/** @file
+
+  ssl_init.cc - set up things
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+
+#include <string>
+#include "ssl_utils.h"
+#include "Config.h"
+#include "common.h"
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+ssl_session_param ssl_param; // <- global containing all operational info
+std::string conf_file;
+
+int
+init_subscriber()
+{
+  ssl_param.sub = new RedisSubscriber(conf_file);
+  if ((!ssl_param.sub) || (!ssl_param.sub->is_good())) {
+    TSError("Construct RedisSubscriber error.");
+    return -1;
+  }
+  return 0;
+}
+
+int
+init_ssl_params(const std::string &conf)
+{
+  conf_file = conf;
+  if (Config::getSingleton().loadConfig(conf)) {
+    Config::getSingleton().getValue("ssl_session", "ClusterName", ssl_param.cluster_name);
+    Config::getSingleton().getValue("ssl_session", "KeyUpdateInterval", ssl_param.key_update_interval);
+    Config::getSingleton().getValue("ssl_session", "STEKMaster", ssl_param.stek_master);
+    Config::getSingleton().getValue("ssl_session", "redis_auth_key_file", ssl_param.redis_auth_key_file);
+  } else {
+    return -1;
+  }
+
+  if (ssl_param.key_update_interval > STEK_MAX_LIFETIME) {
+    ssl_param.key_update_interval = STEK_MAX_LIFETIME;
+    TSDebug(PLUGIN, "KeyUpdateInterval too high, resetting session ticket key rotation to %d seconds",
+            (int)ssl_param.key_update_interval);
+  }
+
+  TSDebug(PLUGIN, "init_ssl_params: I %s been configured to initially be stek_master",
+          ((ssl_param.stek_master) ? "HAVE" : "HAVE NOT"));
+  TSDebug(PLUGIN, "init_ssl_params: Rotation interval (ssl_param.key_update_interval)set to %d\n", ssl_param.key_update_interval);
+  TSDebug(PLUGIN, "init_ssl_params: cluster_name set to %s", ssl_param.cluster_name.c_str());
+
+  int ret = STEK_init_keys();
+  if (ret < 0) {
+    TSError("init keys failure. %s", conf.c_str());
+    return -1;
+  }
+
+  ssl_param.pub = new RedisPublisher(conf);
+  if ((!ssl_param.pub) || (!ssl_param.pub->is_good())) {
+    TSError("Construct RedisPublisher error.");
+    return -1;
+  }
+  return 0;
+}
+
+ssl_session_param::ssl_session_param() : pub(nullptr) {}
+
+ssl_session_param::~ssl_session_param()
+{
+  // Let the publish object leak for now, we are shutting down anyway
+  /*if (pub)
+      delete pub; */
+}
+
+/*
+ Read the redis auth key from file ssl_param.redis_auth_key_file in retKeyBuff
+
+ */
+int
+get_redis_auth_key(char *retKeyBuff, int buffSize)
+{
+  // Get the Key
+  if (ssl_param.redis_auth_key_file.length()) {
+    int fd = open(ssl_param.redis_auth_key_file.c_str(), O_RDONLY);
+    struct stat info;
+    if (0 == fstat(fd, &info)) {
+      size_t n = info.st_size;
+      std::string key_data;
+      key_data.resize(n);
+      auto read_len = read(fd, const_cast<char *>(key_data.data()), n);
+      // Strip any trailing newlines
+      while (read_len > 1 && key_data[read_len - 1] == '\n') {
+        --read_len;
+      }
+      strncpy(retKeyBuff, key_data.c_str(), read_len);
+    }
+  } else {
+    TSError("can not get redis auth key");
+    return 0; /* error */
+  }
+
+  return 1; /* ok */
+}

--- a/plugins/experimental/ssl_session_reuse/src/ssl_key_utils.cc
+++ b/plugins/experimental/ssl_session_reuse/src/ssl_key_utils.cc
@@ -1,0 +1,467 @@
+/** @file
+
+  ssl_key_utils.cc - Deal with STEK
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+
+#include <unistd.h>
+#include <string.h>
+#include <mutex>
+#include <sys/time.h>
+#include <ts/ts.h>
+#include <openssl/rand.h>
+
+#include "ssl_utils.h"
+#include "assert.h"
+#include "redis_auth.h"
+#include "stek.h"
+#include "common.h"
+
+#define SSL_AES_KEY_SUFFIX "_aes_key"
+#define SSL_HMAC_KEY_SUFFIX "_hmac_key"
+
+#define STEK_MAX_ENC_SIZE 512
+
+// Lock for when changing Session-Ticket-Encrypt-Key
+std::mutex ssl_key_lock;
+
+static char channel_key[MAX_REDIS_KEYSIZE] = {
+  0,
+};
+static int channel_key_length = 0;
+
+static int stek_master_setter_running = 0; /* stek master setter thread running */
+
+static bool stek_initialized = false;
+
+bool
+isSTEKMaster()
+{
+  return stek_master_setter_running != 0;
+}
+
+/*****************************************************************************
+ * Overview of this module:   Session-Ticket-Encryption-Key (STEK) functionality
+ *    which include generating, setting, getting of stek for the POD
+ *    (redis connected network of nodes that share a common STEK).
+ *    All aspects of code in this module run in the ats_ssl_session_reuse plugin
+ *    execution space, (as opposed to redis_subscriber, or redis server execution space).
+ *
+ * Three main areas of interest in this module:
+ *
+ * 1) Initialization - STEK_init_keys()
+ *
+ * 2) STEK_Update_Setter_Thread() or  Master STEK setter - Ultimately there is one Master-STEK
+ * setter node per POD where a POD is determined by all nodes on the redis network.
+ * At regular intervals this thread will generate a new STEK and publish it to the POD.
+ * This ensures proper key rotation.
+ *
+ * One node in the pod is configured to be Master STEK setter in charge of key rotations.
+ * The alogrithm implemented allows for the POD to dynamically self configure a master
+ * which can recover from death of master, misconfigurations, ultimately ineffective rotations.
+ *
+ * General description:
+ *
+ * - Master thread (of ATS plugin)-
+ * 	Create and send STEK
+ * 	sleep for configured period (e.g. 7 hours)
+ *	After wake up, if I'm no longer using STEK I created, then the POD is sync'd to a new
+ *		POD stek-master...yield to it by exiting this thread.
+ */
+
+/*----------------------------------------------------------------------------------------*/
+
+const char *
+get_key_ptr()
+{
+  return channel_key;
+}
+
+int
+get_key_length()
+{
+  return channel_key_length;
+}
+
+static int
+STEK_GetGoodRandom(char *buffer, int size, int needGoodEntropy)
+{
+  FILE *fp;
+  int numread = 0;
+  char *randFileName;
+
+  /* /dev/random blocks until good entropy and can take up to 2 seconds per byte on idle machines */
+  /* /dev/urandom does not have entropy check, and is very quick.
+   * Caller decides quality needed */
+  randFileName = (char *)((needGoodEntropy) ? /* Good & slow */ "/dev/random" : /*Fast*/ "/dev/urandom");
+
+  if (nullptr == (fp = fopen(randFileName, "r"))) {
+    // printf("Can't open %s",randFileName);
+    return 0; /* failure */
+  }
+  numread = (int)fread(buffer, 1, size, fp);
+  fclose(fp);
+
+  return ((numread == size) ? 1 /* success*/ : 0 /*failure*/);
+
+} /* STEK_GetRandom() */
+
+static int
+STEK_CreateNew(struct ssl_ticket_key_t *returnSTEK, int globalkey, int entropyEnsured)
+{
+  /* Create a new Session-Ticket-Encryption-Key and places it into buffer provided
+   * return 0 on failure, 1 on success.
+   * if boolean globalkey is set (inidcating it's the global key space),
+     will get global key lock before setting */
+
+  struct ssl_ticket_key_t newKey; // tmp local buffer
+
+  /* We create key in local buff to minimize lock time on global,
+   * because entropy ensuring can take a very long time e.g. 2 seconds per byte of entropy*/
+  if ((!STEK_GetGoodRandom((char *)&(newKey.aes_key), SSL_KEY_LEN, (entropyEnsured) ? 1 : 0)) ||
+      (!STEK_GetGoodRandom((char *)&(newKey.hmac_secret), SSL_KEY_LEN, (entropyEnsured) ? 1 : 0)) ||
+      (!STEK_GetGoodRandom((char *)&(newKey.key_name), SSL_KEY_LEN, 0))) {
+    return 0; /* couldn't generate new STEK */
+  }
+
+  // we presume return buffer may be the global active STEK, so we get lock first before setting
+  if (globalkey) {
+    ssl_key_lock.lock();
+  }
+  memcpy(returnSTEK, &newKey, sizeof(struct ssl_ticket_key_t));
+  if (globalkey) {
+    ssl_key_lock.unlock();
+  }
+
+  memset(&newKey, 0, sizeof(struct ssl_ticket_key_t)); // keep our stack clean
+
+  return 1; /* success */
+}
+
+static int
+STEK_encrypt(struct ssl_ticket_key_t *stek, const char *key, int key_length, char *retEncrypted, int *retLength)
+{
+  EVP_CIPHER_CTX *context = EVP_CIPHER_CTX_new();
+  unsigned char iv[EVP_MAX_IV_LENGTH];
+  unsigned char gen_key[EVP_MAX_KEY_LENGTH];
+  int retval = 0;
+
+  /* Encrypted stek will be placed in caller allocated retEncrypted buffer */
+  /* NOTE: retLength must initially contain the size of the retEncrypted buffer */
+  /* return 1 on success, 0 on failure  */
+
+  int stek_len     = sizeof(struct ssl_ticket_key_t);
+  int stek_enc_len = 0;
+
+  // generate key and iv
+  int generated_key_len = EVP_BytesToKey(EVP_aes_256_cbc(), EVP_md5(), (const unsigned char *)salt, (const unsigned char *)key,
+                                         key_length, 1, gen_key, iv);
+  if (generated_key_len <= 0) {
+    TSDebug(PLUGIN, "Key setup for encryption of session ticket failed");
+    goto cleanup;
+  }
+
+  if (1 != EVP_EncryptInit_ex(context, EVP_aes_256_cbc(), nullptr, (const unsigned char *)gen_key, iv)) {
+    TSDebug(PLUGIN, "Encryption init of session ticket failed");
+    goto cleanup;
+  }
+
+  if (1 != EVP_EncryptUpdate(context, (unsigned char *)retEncrypted, &stek_enc_len, (const unsigned char *)stek, stek_len)) {
+    TSDebug(PLUGIN, "Encryption of session ticket failed");
+    goto cleanup;
+  }
+  *retLength = stek_enc_len;
+  if (1 != EVP_EncryptFinal_ex(context, (unsigned char *)retEncrypted + stek_enc_len, &stek_enc_len)) {
+    TSDebug(PLUGIN, "Final encryption of session ticket failed");
+    goto cleanup;
+  }
+  *retLength += stek_enc_len;
+
+  retval = 1;
+cleanup:
+  EVP_CIPHER_CTX_free(context);
+  return retval; // success
+}
+
+static int
+STEK_decrypt(const std::string &encrypted_data, const char *key, int key_length, struct ssl_ticket_key_t *retSTEK)
+{
+  if (!retSTEK)
+    return 0;
+
+  EVP_CIPHER_CTX *context = EVP_CIPHER_CTX_new();
+  unsigned char iv[EVP_MAX_IV_LENGTH];
+  unsigned char gen_key[EVP_MAX_KEY_LENGTH];
+  unsigned char decryptBuff[4 * sizeof(struct ssl_ticket_key_t)] = {
+    0,
+  };
+  int decryptLength = sizeof(decryptBuff);
+  int retval        = 0;
+
+  TSDebug(PLUGIN, "STEK_decrypt(): requested to decrypt %d bytes", static_cast<int>(encrypted_data.length()));
+
+  // generate key and iv
+  int generated_key_len = EVP_BytesToKey(EVP_aes_256_cbc(), EVP_md5(), (const unsigned char *)salt, (const unsigned char *)key,
+                                         key_length, 1, gen_key, iv);
+  if (generated_key_len <= 0) {
+    TSDebug(PLUGIN, "Key setup for decryption of session ticket failed");
+    goto cleanup;
+  }
+
+  if (1 != EVP_DecryptInit_ex(context, EVP_aes_256_cbc(), nullptr, (const unsigned char *)gen_key, iv)) {
+    TSDebug(PLUGIN, "Encryption of session data failed");
+    goto cleanup;
+  }
+
+  if (1 !=
+      EVP_DecryptUpdate(context, decryptBuff, &decryptLength, (unsigned char *)encrypted_data.c_str(), encrypted_data.length())) {
+    TSDebug(PLUGIN, "Decryption of encrypted ticket key failed");
+    goto cleanup;
+  }
+
+  if (sizeof(struct ssl_ticket_key_t) != decryptLength) {
+    TSError("STEK received is unexpected size length=%d not %d", decryptLength, static_cast<int>(sizeof(struct ssl_ticket_key_t)));
+    goto cleanup;
+  }
+
+  memcpy(retSTEK, decryptBuff, sizeof(struct ssl_ticket_key_t));
+  memset(decryptBuff, 0, sizeof(decryptBuff)); // warm fuzzies
+  retval = 1;
+
+cleanup:
+  if (context) {
+    EVP_CIPHER_CTX_free(context);
+  }
+
+  return retval; /* ok, length of data in retSTEK will be sizeof(struct ssl_ticket_key_t) */
+}
+
+int
+STEK_Send_To_Network(struct ssl_ticket_key_t *stekToSend)
+{
+  /* Send new STEK to redis network */
+  /* This function encrypts the STEK and then sends it to the redis network. */
+  /* Description: The subscriber thread listens on the redis network and updates its ATS
+   * core with the new data
+   */
+  char encryptedData[STEK_MAX_ENC_SIZE] = {
+    0,
+  };
+  int encryptedDataLength = 0;
+
+  // encrypt the STEK before sending
+  encryptedDataLength = sizeof(encryptedData);
+  if (!STEK_encrypt(stekToSend, get_key_ptr(), get_key_length(), encryptedData, &encryptedDataLength)) {
+    TSError("Can't encrypt STEK.  Not sending");
+    return 0; // failure
+  }
+
+  std::string redis_channel = ssl_param.cluster_name + "." + STEK_ID_NAME;
+  ssl_param.pub->publish(redis_channel, encryptedData); // send it
+
+  memset(encryptedData, 0, sizeof(encryptedData)); // warm fuzzies
+  return 1;
+}
+
+static void *
+STEK_Update_Setter_Thread(void *arg)
+{
+  int sleepInterval;
+  struct ssl_ticket_key_t newKey;
+  int startProblem = 0; // counter for start up and retry issues.
+
+  /* This STEK-Master thread runs for the life of the executable setting the
+   * Session-Ticket-Encryption-Key at every configured interval.
+   * The key is generated and then redis published to the POD.
+   * where the subscribers will pick it up and replace their ATS keys
+   * If it detects another master in the POD setting keys, it will shut itself down */
+
+  if (stek_master_setter_running) {
+    /* Sanity check triggered.  Already running...don't do another. */
+    TSDebug(PLUGIN, "Faulty STEK-master launch. Internal error. Moving on...");
+    return nullptr;
+  }
+
+  stek_master_setter_running = 1;
+  TSDebug(PLUGIN, "Will now act as the STEK rotator for pod");
+
+  while (1) {
+    // Create new STEK, set it for me, and then send it to the POD.
+    if ((!STEK_CreateNew(&newKey, 0, 1 /* entropy ensured */)) || (!STEK_Send_To_Network(&newKey))) {
+      // Error occurred. We will retry after a short interval.
+      // perhaps publishig isn't up yet.
+      startProblem++;     // count how many times we have this problem.
+      sleepInterval = 60; // short sleep for error retry
+      TSError("Could not create/send new STEK for key rotation...try again in %d seconds", sleepInterval);
+    } else {
+      //  Everything good. will sleep for normal rotation time period and then repeat
+      startProblem = 0;
+      TSDebug(PLUGIN, "New POD STEK created and sent to network.");
+
+      sleepInterval = ssl_param.key_update_interval;
+    }
+
+    ::sleep(sleepInterval);
+
+    if ((!startProblem) && (memcmp(&newKey, &ssl_param.ticket_keys[0], sizeof(struct ssl_ticket_key_t)))) {
+      /* I am not using the key I set before sleeping.  This means node (and POD) has
+       * sync'd onto a more recent master,  which we will now yield to by exiting
+       * out of this thread. */
+      goto done_master_setter;
+    }
+
+    if (startProblem > 60) {
+      /* We've been trying every minute for more than an hour. Time to give up and move on..*/
+      /* Another node in pod will notice and pick up responsibility, else we'll try again later */
+      goto done_master_setter;
+    }
+
+  } // while(forever)
+
+done_master_setter:
+  TSDebug(PLUGIN, "Yielding STEK-Master rotation responsibility to another node in POD");
+  memset(&newKey, 0, sizeof(struct ssl_ticket_key_t));
+  stek_master_setter_running = 0;
+  return nullptr;
+}
+
+time_t lastChangeTime = 0;
+
+void
+STEK_update(const std::string &encrypted_stek)
+{
+  struct ssl_ticket_key_t newSTEK;
+  if (STEK_decrypt(encrypted_stek, get_key_ptr(), get_key_length(), &newSTEK)) {
+    if (memcmp(&newSTEK, &ssl_param.ticket_keys[0], sizeof(struct ssl_ticket_key_t))) {
+      /* ... and it's a new one,  so we will now set and use it. */
+      ssl_key_lock.lock();
+      memcpy(&ssl_param.ticket_keys[1], &ssl_param.ticket_keys[0], sizeof(struct ssl_ticket_key_t));
+      memcpy(&ssl_param.ticket_keys[0], &newSTEK, sizeof(struct ssl_ticket_key_t));
+
+      // Let TSAPI know about new ticket information
+      stek_initialized = true;
+      TSSslTicketKeyUpdate(reinterpret_cast<char *>(ssl_param.ticket_keys), sizeof(ssl_param.ticket_keys));
+      time(&lastChangeTime);
+      ssl_key_lock.unlock();
+    }
+  }
+}
+
+static void *
+STEK_Update_Checker_Thread(void *arg)
+{
+  time_t currentTime;
+  time_t lastWarningTime; // last time we put out a warning
+
+  /* STEK_Update_Checker_Thread() - This thread runs forever, sleeping most
+   * of the time, then checking and updating our Session-Ticket-Encryption-Key
+   * If we don't get a STEK rotation during a certain time period,log warning
+   * that something is up with our STEK master, and nominate a new STEK master.
+   */
+
+  TSDebug(PLUGIN, "Starting Update Checker Thread");
+
+  lastChangeTime = lastWarningTime = time(&currentTime); // init to current to supress a startup warning.
+
+  while (1) {
+    if (!stek_initialized && ssl_param.pub) {
+      // Launch a request for the master to resend you the ticket key
+      std::string redis_channel = ssl_param.cluster_name + "." + STEK_ID_RESEND;
+      ssl_param.pub->publish(redis_channel, ""); // send it
+      TSDebug(PLUGIN, "Request for ticket");
+    }
+    time(&currentTime);
+    time_t sleepUntil;
+    if (stek_initialized) {
+      // Sleep until we are overdue for a key update
+      sleepUntil = 2 * STEK_MAX_LIFETIME - (currentTime - lastChangeTime);
+    } else {
+      // Wait for a while in hopes that the server gets back to us
+      sleepUntil = 30;
+    }
+    ::sleep(sleepUntil);
+
+    /* We track last time STEK changed. If we haven't gotten a new STEK in twice the max,
+     * then we figure something is wrong with the POD STEK master and nominate a new master.
+     * STEK master may have been misconfigured, disconnected, died or who-knows.
+     * ...no problem we will will recover POD STEK rotation now */
+
+    time(&currentTime);
+    if ((currentTime - lastChangeTime) > (2 * STEK_MAX_LIFETIME)) {
+      // Yes we were way past due for a new STEK, and haven't received it.
+      if ((currentTime - lastWarningTime) > STEK_NOT_CHANGED_WARNING_INTERVAL) {
+        // Yes it's time to put another warning in log file.
+        TSError("Session Ticket Encryption Key not syncd in past %d hours.",
+                static_cast<int>(((currentTime - lastChangeTime) / 3600)));
+
+        lastWarningTime = currentTime;
+      }
+
+      /* Time to nominate a new stek master for pod key rotation... */
+      if (!stek_master_setter_running) {
+        TSDebug(PLUGIN, "Will nominate a new STEK-master thread now for pod key rotation");
+        TSThreadCreate(STEK_Update_Setter_Thread, nullptr);
+      }
+    }
+
+  } // while(forever)
+
+} // STEK_Update_Checker_Thread()
+
+int
+STEK_init_keys()
+{
+  ssl_ticket_key_t initKey;
+
+  if (!get_redis_auth_key(channel_key, MAX_REDIS_KEYSIZE)) {
+    TSError("STEK_init_keys: could not get redis authentication key");
+    return -1;
+  }
+
+  //  Initialize starter Session Ticket Encryption Key
+  //  Will sync up with master later
+  if (!STEK_CreateNew(&initKey, 0, 0 /*fast start*/)) {
+    TSError("Cant init STEK");
+    return -1;
+  }
+  memcpy(&ssl_param.ticket_keys[0], &initKey, sizeof(struct ssl_ticket_key_t));
+  memcpy(&ssl_param.ticket_keys[1], &initKey, sizeof(struct ssl_ticket_key_t));
+  memset(&initKey, 0, sizeof(struct ssl_ticket_key_t));
+
+  // Call into TSAPI to register the ticket info
+  TSSslTicketKeyUpdate(reinterpret_cast<char *>(ssl_param.ticket_keys), sizeof(ssl_param.ticket_keys));
+
+  stek_initialized = false;
+  if (ssl_param.stek_master) {
+    /* config has chosen this instance to initially launch the STEK setting master thread */
+    /* We will generate and set STEK for the POD.  If things go weird, another node may
+     * may take over this responsibility, so we only refer to this config parm at init. */
+    TSThreadCreate(STEK_Update_Setter_Thread, nullptr);
+    stek_initialized = true;
+  } else {
+    // Note that we have a temp key.  Probe the master once we are up
+  }
+
+  // Launch thread to listen for incoming STEK update rotation
+  TSThreadCreate(STEK_Update_Checker_Thread, nullptr);
+
+  return 1; // init ok
+}

--- a/plugins/experimental/ssl_session_reuse/src/ssl_utils.h
+++ b/plugins/experimental/ssl_session_reuse/src/ssl_utils.h
@@ -1,0 +1,68 @@
+/** @file
+
+  ssl_utils.h - a containuer of connection objects
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+#pragma once
+
+#include <openssl/ssl.h>
+#include <string>
+#include <ts/ts.h>
+
+#include "publisher.h"
+#include "subscriber.h"
+
+#include "stek.h"
+
+struct ssl_session_param {
+  std::string cluster_name;
+  int key_update_interval;         // STEK master rotation period seconds
+  int stek_master;                 // bool - Am I the STEK setter/rotator for POD?
+  ssl_ticket_key_t ticket_keys[2]; // current and past STEK
+  std::string redis_auth_key_file;
+  RedisPublisher *pub;
+  RedisSubscriber *sub;
+
+  ssl_session_param();
+  ~ssl_session_param();
+};
+
+int STEK_init_keys();
+
+const char *get_key_ptr();
+int get_key_length();
+
+/* Initialize ssl parameters */
+/**
+   Return the result of initialization. If 0 is returned, it means
+   the initializtion is success, -1 means it is failure.
+
+   @param conf_file the configuration file
+
+   @return @c 0 if it is success.
+
+*/
+int init_ssl_params(const std::string &conf_file);
+int init_subscriber();
+
+int SSL_session_callback(TSCont contp, TSEvent event, void *edata);
+
+extern ssl_session_param ssl_param; // almost everything one needs is stored in here

--- a/plugins/experimental/ssl_session_reuse/src/stek.h
+++ b/plugins/experimental/ssl_session_reuse/src/stek.h
@@ -1,0 +1,45 @@
+/** @file
+
+  stek.h - a containuer of connection objects
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+#pragma once
+
+/* STEK - Session Ticket Encryption Key stuff */
+
+#define STEK_ID_NAME "stek" // ACTUALLY it is redis channel minus cluster_name prefix, aka mdbm keyname
+#define STEK_ID_RESEND "resendstek"
+#define STEK_MAX_LIFETIME 86400 // 24 hours max - should rotate STEK
+
+#define STEK_NOT_CHANGED_WARNING_INTERVAL (2 * STEK_MAX_LIFETIME) // warn on non-stek rotate every X secs.
+
+#define SSL_KEY_LEN 16
+
+struct ssl_ticket_key_t // an STEK
+{
+  unsigned char key_name[SSL_KEY_LEN]; // tickets use this name to identify who encrypted
+  unsigned char hmac_secret[SSL_KEY_LEN];
+  unsigned char aes_key[SSL_KEY_LEN];
+};
+
+void STEK_update(const std::string &encrypted_stek);
+bool isSTEKMaster();
+int STEK_Send_To_Network(struct ssl_ticket_key_t *stekToSend);

--- a/plugins/experimental/ssl_session_reuse/src/subscriber.cc
+++ b/plugins/experimental/ssl_session_reuse/src/subscriber.cc
@@ -1,0 +1,215 @@
+/** @file
+
+  subscriber.cc - Redis subscriber
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+
+#include <unistd.h>
+#include <ts/ts.h>
+#include <openssl/ssl.h>
+#include <hiredis/hiredis.h>
+#include "common.h"
+
+#include "subscriber.h"
+#include "Config.h"
+#include "redis_auth.h"
+#include "session_process.h"
+#include "stek.h"
+#include "ssl_utils.h"
+
+void *
+setup_subscriber(void *arg)
+{
+  RedisSubscriber *me = static_cast<RedisSubscriber *>(arg);
+  me->run();
+  return (void *)1;
+}
+
+RedisSubscriber::RedisSubscriber(const std::string &conf)
+  : m_channel(cDefaultSubColoChannel),
+    m_redisConnectTimeout(cDefaultRedisConnectTimeout),
+    m_redisRetryDelay(cDefaultRedisRetryDelay),
+    err(false)
+{
+  std::string redisEndpointsStr;
+
+  if (Config::getSingleton().loadConfig(conf)) {
+    Config::getSingleton().getValue("redis", "RedisConnectTimeout", m_redisConnectTimeout);
+    Config::getSingleton().getValue("redis", "RedisRetryDelay", m_redisRetryDelay);
+    Config::getSingleton().getValue("subconfig", "SubColoChannel", m_channel);
+    Config::getSingleton().getValue("redis", "RedisEndpoints", redisEndpointsStr);
+  }
+
+  // get our psk to access session_reuse redis network.
+  char redis_auth_key[MAX_REDIS_KEYSIZE];
+  if (!(get_redis_auth_key(redis_auth_key, MAX_REDIS_KEYSIZE))) {
+    err = true;
+    TSError("RedisPublisher::RedisPublisher.Cannot get redis AUTH password.");
+    redis_passwd.clear();
+  } else {
+    redis_passwd = redis_auth_key;
+    memset(redis_auth_key, 0, MAX_REDIS_KEYSIZE); // tidy up our stack
+  }
+
+  m_channel_prefix = m_channel.substr(0, m_channel.find('*'));
+
+  TSDebug(PLUGIN, "RedisSubscriber::RedisSubscriber.SubscriberChannel= %s SubscriberChannelPrefix= %s", m_channel.c_str(),
+          m_channel_prefix.c_str());
+
+  addto_endpoint_vector(m_redisEndpoints, redisEndpointsStr);
+  m_redisEndpointsIndex = 0;
+
+  for (unsigned int i = 0; i < m_redisEndpoints.size(); i++) {
+    TSThreadCreate(setup_subscriber, static_cast<void *>(this));
+  }
+}
+
+bool
+RedisSubscriber::is_good()
+{
+  return !err;
+}
+
+int
+RedisSubscriber::get_endpoint_index()
+{
+  int retval = m_redisEndpointsIndex++;
+  return retval;
+}
+
+::redisContext *
+RedisSubscriber::setup_connection(int index)
+{
+  TSDebug(PLUGIN, "RedisSubscriber::setup_connection.called for host= %s and port= %d", m_redisEndpoints[index].m_hostname.c_str(),
+          m_redisEndpoints[index].m_port);
+
+  ::redisContext *my_context(nullptr);
+  struct ::timeval timeout_connect;
+  timeout_connect.tv_sec  = m_redisConnectTimeout / 1000;
+  timeout_connect.tv_usec = (m_redisConnectTimeout % 1000) * 1000;
+
+  while (true) {
+    my_context =
+      ::redisConnectWithTimeout(m_redisEndpoints[index].m_hostname.c_str(), m_redisEndpoints[index].m_port, timeout_connect);
+    if (!my_context) {
+      TSError("RedisSubscriber::setup_connection.connect to host: %s and port: %d failed",
+              m_redisEndpoints[index].m_hostname.c_str(), m_redisEndpoints[index].m_port);
+    } else if (my_context->err) {
+      TSError("RedisSubscriber::setup_connection.connect to host: %s and port: %d  failed.",
+              m_redisEndpoints[index].m_hostname.c_str(), m_redisEndpoints[index].m_port);
+    } else {
+      TSDebug(PLUGIN, "RedisSubscriber::setup_connection: successfully connected to the redis host: %s on port: %d",
+              m_redisEndpoints[index].m_hostname.c_str(), m_redisEndpoints[index].m_port);
+
+      redisReply *reply = static_cast<redisReply *>(redisCommand(my_context, "AUTH %s", redis_passwd.c_str()));
+
+      if (reply == nullptr) {
+        TSError("RedisSubscriber::setup_connection Cannot AUTH redis server, no reply.");
+      } else if (reply->type == REDIS_REPLY_ERROR) {
+        TSError("RedisSubscriber::setup_connection Cannot AUTH redis server, error reply.");
+        freeReplyObject(reply);
+      } else {
+        TSDebug(PLUGIN, "RedisSubscriber::setup_connection. Successfully AUTH redis server.");
+        freeReplyObject(reply);
+      }
+
+      break;
+    }
+
+    TSError("RedisSubscriber::setup_connection.will wait for: %d microseconds and try again.", m_redisRetryDelay);
+
+    ::usleep(m_redisRetryDelay);
+  }
+
+  return my_context;
+}
+
+void
+RedisSubscriber::run()
+{
+  TSDebug(PLUGIN, "RedisSubscriber::runMaster.called");
+  int my_endpoint_index = get_endpoint_index();
+  ::redisContext *my_context(setup_connection(my_endpoint_index));
+  ::redisReply *current_reply(nullptr);
+
+  while (true) {
+    while ((!my_context) || (my_context->err)) {
+      ::usleep(m_redisRetryDelay);
+      my_context = setup_connection(my_endpoint_index);
+    }
+
+    TSDebug(PLUGIN, "RedisSubscriber::runMaster.Issuing command: \"PSUBSCRIBE %s\"", m_channel.c_str());
+    current_reply = static_cast<redisReply *>(::redisCommand(my_context, "PSUBSCRIBE %s", m_channel.c_str()));
+
+    if (!current_reply || (REDIS_REPLY_ERROR == current_reply->type)) {
+      TSError("RedisSubscriber::runMaster.subscribe to redis server on channel: %s failed.", m_channel.c_str());
+      ::usleep(1000 * 1000);
+      continue;
+    } else {
+      TSDebug(PLUGIN, "RedisSubscriber::runMaster.Successfully subscribed to channel: \"%s\"", m_channel.c_str());
+      TSDebug(PLUGIN, "RedisSubscriber::runMaster.Waiting for messages to appear on the channel!");
+      ::freeReplyObject(current_reply);
+    }
+
+    // Blocking read
+    while (REDIS_OK == ::redisGetReply(my_context, reinterpret_cast<void **>(&current_reply))) {
+      // Process Message
+      std::string channel(current_reply->element[2]->str, current_reply->element[2]->len);
+      std::string data(current_reply->element[3]->str, current_reply->element[3]->len);
+      TSDebug(PLUGIN, "Redis request channel=%s message=%s", channel.c_str(), data.c_str());
+
+      std::string key = "";
+      // Strip the channel name to get the key
+      if (channel.compare(0, m_channel_prefix.length(), m_channel_prefix) == 0) {
+        key = channel.substr(m_channel_prefix.length());
+      }
+
+      // If this is new keys, go do the ticket key updates
+      if (strncmp(key.c_str(), STEK_ID_NAME, strlen(STEK_ID_NAME)) == 0) {
+        STEK_update(data);
+        // Requesting last ticket to be resent
+      } else if (strncmp(key.c_str(), STEK_ID_RESEND, strlen(STEK_ID_RESEND)) == 0) {
+        if (isSTEKMaster()) {
+          TSDebug(PLUGIN, "RedisSubscriber Resend ticket");
+          STEK_Send_To_Network(ssl_param.ticket_keys);
+        }
+      } else { // Otherwise this is a new session.  Let ATS core know about it
+        char session_id[SSL_MAX_SSL_SESSION_ID_LENGTH * 2];
+        int session_id_len = sizeof(session_id);
+        if (decode_id(key, session_id, session_id_len) == 0) { // Decrypt the data
+          TSDebug(PLUGIN, "Add session encoded_id=%s decoded_id=%.*s %d", key.c_str(), session_id_len, session_id, session_id_len);
+          add_session(session_id, session_id_len, data);
+        } else {
+          TSDebug(PLUGIN, "failed to decode key=%s", key.c_str());
+        }
+      }
+
+      ::freeReplyObject(current_reply);
+
+      TSDebug(PLUGIN, "RedisSubscriber::runMaster.Got message: %s on channel: %s", data.c_str(), channel.c_str());
+    }
+  }
+}
+
+RedisSubscriber::~RedisSubscriber()
+{
+  TSDebug(PLUGIN, "RedisSubscriber::~RedisSubscriber.called for endpoint");
+}

--- a/plugins/experimental/ssl_session_reuse/src/subscriber.h
+++ b/plugins/experimental/ssl_session_reuse/src/subscriber.h
@@ -1,0 +1,57 @@
+/** @file
+
+  subscriber.h - a containuer of connection objects
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+#pragma once
+
+#include <vector>
+#include <string>
+#include "message.h"
+#include "globals.h"
+#include "redis_endpoint.h"
+
+class RedisSubscriber
+{
+private:
+  std::string redis_passwd;
+
+  std::vector<RedisEndpoint> m_redisEndpoints;
+  int m_redisEndpointsIndex;
+  std::string m_channel;
+  std::string m_channel_prefix;
+
+  unsigned int m_redisConnectTimeout; // milliseconds
+  unsigned int m_redisRetryDelay;     // milliseconds
+
+  bool err;
+
+  ::redisContext *setup_connection(int index);
+
+  friend void *start(void *arg);
+
+public:
+  void run();
+  RedisSubscriber(const std::string &conf = cDefaultConfig);
+  virtual ~RedisSubscriber();
+  bool is_good();
+  int get_endpoint_index();
+};

--- a/plugins/experimental/ssl_session_reuse/tests/plug-load.test.py
+++ b/plugins/experimental/ssl_session_reuse/tests/plug-load.test.py
@@ -1,0 +1,68 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+Test.Summary = '''
+Test a basic remap of a http connection
+'''
+
+pluginName = 'ats_ssl_plugin'
+path=os.path.abspath(".")
+configFile='./packages/rhel.6.5.package/conf/trafficserver/ats_ssl_session_reuse.xml'
+
+# need Curl
+Test.SkipUnless(
+    Condition.HasProgram("curl","Curl need to be installed on system for this test to work")
+    )
+Test.ContinueOnFail=True
+# Define default ATS
+ts=Test.MakeATSProcess("ts")
+server=Test.MakeOriginServer("server")
+
+Test.testName = ""
+request_header={"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+#expected response from the origin server
+response_header={"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+
+#add response to the server dictionary
+server.addResponse("sessionfile.log", request_header, response_header)
+ts.Disk.records_config.update({
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': '{0}'.format(pluginName),
+    })
+
+ts.Disk.plugin_config.AddLine(
+    '# {1}/{0}.so {2}'.format(pluginName,path,configFile)
+)
+ts.Disk.remap_config.AddLine(
+    'map http://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port)
+)
+
+goldFile = os.path.join(Test.RunDirectory,"{0}.gold".format(pluginName))
+with open(goldFile,'w+') as jf:
+        jf.write("``loading plugin ``{0}.so``".format(pluginName))
+
+# call localhost straight
+tr=Test.AddTestRun()
+tr.Processes.Default.Command='curl --proxy 127.0.0.1:{0} "http://www.example.com" --verbose'.format(ts.Variables.port)
+tr.Processes.Default.ReturnCode=0
+# time delay as proxy.config.http.wait_for_cache could be broken
+tr.Processes.Default.StartBefore(server,ready=When.PortOpen(server.Variables.Port))
+tr.Processes.Default.StartBefore(Test.Processes.ts)
+tr.StillRunningAfter=server
+
+#ts.Streams.All=goldFile
+#ts.Disk.diags_log.Content+=goldFile


### PR DESCRIPTION
This is based on a plugin that has been running within Yahoo/Oath for over 4 years.  Many people have contributed this this plugin over that time.  @suenway was one of the original developers.

About a year ago @DaveThompson rewrote our Ticket support (STEK) to locally generate and distribute new ticket keys in fixed intervals within a group of servers.  The previous version relied on installed ticket key files from a central location which means they rotated very rarely.

We recently leveraged additions to the TSAPI to remove use of another library for external persistence and install used the Traffic Server session cache.  We have been running that version in production for 6 months or so.

@persiaAziz then took a pass to remove the last of the Yahoo-specific support libraries.  She did dev testing on that, but we have not run this version in production.  Therefore, I put a WIP label on this PR.  I need to push this back and do some prod testing to make sure we didn't break anything in the cleanup.   I did want to put something up, to push things along and give people an early look.

From April I looked at a few our our installations in the TLS session resumptions were around 30-50% of all TLS connections.   Session resumption is still a useful performance benefit.

The hiredis-devel package must be present to build the ssl_session_reuse library, so it seems unlikely that the CI build will do much with this code.