### PR TITLE
Allows to run Spinx builds on portions of the docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ Makefile.in
 /build-aux
 /configure
 /tags
+/_build
 
 build/_aux/
 build/libtool.m4

--- a/doc/ext/local-config.py.in
+++ b/doc/ext/local-config.py.in
@@ -14,5 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-plantuml='@JAVA@ -jar {}'.format(os.environ['PLANTUML_JAR'])
-plantuml_output_format='svg'
+import os
+import subprocess
+
+if "PLANTUML_JAR" in os.environ:
+    _plantuml_jar = os.environ["PLANTUML_JAR"]
+else:
+    _plantuml_jar = subprocess.check_output("./doc/plantuml_fetch.sh| tail -1",
+                                            shell=True, universal_newlines=True)
+
+plantuml = '@JAVA@ -jar {}'.format(_plantuml_jar.rstrip('\n'))
+plantuml_output_format = 'svg'


### PR DESCRIPTION
This turns out to be useful, for example in Visual Code, we can
now render the Restructured Text inline in the editor, which is
nice when you are editing the docs files.

This change essentially allows us to run the Sphinx command on a
single file, without having to "make" the entire Docs tree.