### PR TITLE
Completes code comment for redirect configs

### DIFF
--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -163,7 +163,8 @@ static const RecordElement RecordsConfig[] =
   //#
   //# 1. number_of_redirections: The maximum number of redirections TS permits. Disabled if set to 0 (default)
   //# 2. proxy.config.http.redirect_use_orig_cache_key: Location Header if set to 0 (default), else use original request cache key
-  //# 3. post_copy_size: The maximum POST data size TS permits to copy
+  //# 3. redirection_host_no_port: do not include default port in host header during redirection
+  //# 4. post_copy_size: The maximum POST data size TS permits to copy
   //#
   //##############################################################################
   {RECT_CONFIG, "proxy.config.http.number_of_redirections", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -1210,10 +1210,7 @@ HttpConfig::startup()
   //#
   //# Redirection
   //#
-  //# 1. number_of_redirections: The maximum number of redirections YTS permits. 0 == disabled
-  //# 2. redirect_use_orig_cache_key: if set to 1, use original request cache key.
-  //# 3. post_copy_size: The maximum POST data size YTS permits to copy
-  //# 4. redirection_host_no_port: do not include default port in host header during redirection
+  //# See RecordsConfig definition.
   //#
   //##############################################################################
   HttpEstablishStaticConfigByte(c.oride.redirect_use_orig_cache_key, "proxy.config.http.redirect_use_orig_cache_key");


### PR DESCRIPTION
While looking into other changes planned for the 8.x release, I found a simple inconsistency in a code comment.

I wanted to fix this in a separate PR first, so that if something happens to other unrelated changes, this simple correction can remain separate. That is why it is requested to be back-ported to 8.x.