### PR TITLE
Disables the double test for inconsistent execution

### DIFF
--- a/tests/gold_tests/continuations/double.test.py
+++ b/tests/gold_tests/continuations/double.test.py
@@ -20,6 +20,7 @@ import os
 Test.Summary = '''
 Test transactions and sessions, making sure two continuations catch the same number of hooks.
 '''
+Test.SkipIf(Condition.true('This test errors frequently, and so it is disabled.'))
 Test.SkipUnless(
     Condition.HasProgram("curl", "Curl needs to be installed on system for this test to work")
 )


### PR DESCRIPTION
This test appears to be brittle, but it is being used to gate acceptance of pull request. Therefore it should be disabled by default until the inconsistency can be sorted out.

Found in #4131, but I have seen this before in a local environment and in other Pull Requests.

Relates to #4113 

A permanent fix for this work-around is tracked by #4120 .