### PR TITLE
Restructure dispatchEvent and bring back most handlEvent calls

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -555,7 +555,7 @@ HttpSM::setup_client_read_request_header()
   ua_entry->read_vio = ua_txn->do_io_read(this, INT64_MAX, ua_buffer_reader->mbuf);
   // The header may already be in the buffer if this
   //  a request from a keep-alive connection
-  dispatchEvent(VC_EVENT_READ_READY, ua_entry->read_vio);
+  handleEvent(VC_EVENT_READ_READY, ua_entry->read_vio);
 }
 
 void
@@ -887,7 +887,7 @@ HttpSM::state_watch_for_client_abort(int event, void *data)
                 "[%" PRId64 "] [watch_for_client_abort] "
                 "forwarding event %s to tunnel",
                 sm_id, HttpDebugNames::get_event_name(event));
-        tunnel.dispatchEvent(event, c->write_vio);
+        tunnel.handleEvent(event, c->write_vio);
         return 0;
       } else {
         tunnel.kill_tunnel();
@@ -4004,7 +4004,7 @@ HttpSM::do_remap_request(bool run_inline)
   if (!ret) {
     SMDebug("url_rewrite", "Could not find a valid remapping entry for this request [%" PRId64 "]", sm_id);
     if (!run_inline) {
-      dispatchEvent(EVENT_REMAP_COMPLETE, nullptr);
+      handleEvent(EVENT_REMAP_COMPLETE, nullptr);
     }
     return;
   }
@@ -5428,13 +5428,13 @@ HttpSM::handle_server_setup_error(int event, void *data)
 
         ua_producer->alive         = false;
         ua_producer->handler_state = HTTP_SM_POST_SERVER_FAIL;
-        tunnel.dispatchEvent(VC_EVENT_ERROR, c->write_vio);
+        tunnel.handleEvent(VC_EVENT_ERROR, c->write_vio);
         return;
       }
     } else {
       // c could be null here as well
       if (c != nullptr) {
-        tunnel.dispatchEvent(event, c->write_vio);
+        tunnel.handleEvent(event, c->write_vio);
         return;
       }
     }

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -1290,7 +1290,11 @@ APIHook::invoke(int event, void *edata)
       ink_assert(!"not reached");
     }
   }
-  return m_cont->dispatchEvent(event, edata);
+  // The invoke logic in HttpSM gets the m_cont lock before invoking
+  // However the invoke logic in HttpTransactCache does not get the lock
+  // And as the code is currently structure it will not deall with rescheduling, so
+  // we call handleEvent and hope for the best.
+  return m_cont->handleEvent(event, edata);
 }
 
 APIHook *


### PR DESCRIPTION
There were concerns from the changes in https://github.com/apache/trafficserver/pull/4104.  Specifically, the dispatchEvent did not have the option for the Event object in the reschedule case.  The handleEvent code was not in the header file making it unlikely to be inlined.  And there was not a crisp explanation for why some handleEvents were replaced with dispatchEvent.

This PR moves handleEvent back into the header file.  Adds an optional return argument to dispatchEvent to return the schedule event.  And it leaves only one call to dispatchEvent in a place where it did fix a race/memory corruption issue for our customer.

It does leave the ink_release_assert in handleEvent to catch earlier rather than later where we have timing problems where the continuation is not locked before having the handler called.  This will enable us to more precisely address these issues.