### PR TITLE
Meta: Add conditional compilation case meta structures.

### DIFF
--- a/include/tscore/ts_meta.h
+++ b/include/tscore/ts_meta.h
@@ -1,0 +1,98 @@
+/** @file
+
+  Meta programming support utilities.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
+  See the NOTICE file distributed with this work for additional information regarding copyright
+  ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance with the License.  You may obtain a
+  copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License
+  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  or implied. See the License for the specific language governing permissions and limitations under
+  the License.
+*/
+
+#pragma once
+
+namespace ts
+{
+namespace meta
+{
+  /** This creates an ordered series of meta template cases that can be used to select one of a set
+   * of functions in a priority ordering. A set of templated overloads take an (extra) argument of
+   * the case structures, each a different one. Calling the function invokes the highest case that
+   * is valid. Because of SFINAE the templates can have errors, as long as at least one doesn't.
+   * The root technique is to use @c decltype to check an expression for the overload to be valid.
+   * Because the compiler will evaluate everything it can while parsing the template this
+   * expression must be delayed until the template is instantiated. This is done by making the
+   * return type @c auto and making the @c decltype dependent on the template parameter. In
+   * addition, the comma operator can be used to force a specific return type while also checking
+   * the expression for validity. E.g.
+   *
+   * @code
+   * template <typename T> auto func(T && t, CaseArg_0 const&) -> decltype(t.item, int()) { }
+   * @endcode
+   *
+   * The comma operator discards the type and value of the left operand therefore the return type of
+   * the function is @c int but this overload will not be available if @c t.item does not compile
+   * (e.g., there is no such member). The presence of @c t.item also prevents this compilation check
+   * from happening until overload selection is needed. Therefore if the goal was a function that
+   * would return the value of the @c T::count member if present and 0 if not, the code would be
+   *
+   * @code
+   * template <typename T> auto Get_Count(T && t, CaseTag<0>)
+   *   -> int
+   * { return 0; }
+   * template <typename T> auto Get_Count(T && t, CaseTag<1>)
+   *   -> decltype(t.count, int())
+   * { return t.count; }
+   * int Get_Count(Thing& t) { return GetCount(t, CaseArg); }
+   * @endcode
+   *
+   * Note the overloads will be checked from the highest case to the lowest and the first one that
+   * is valid (via SFINAE) is used. This is the point of using the case arguments, to force an
+   * ordering on the overload selection. Unfortunately this means the functions @b must be
+   * templated, even if there's no other reason for it, because it depends on SFINAE which doesn't
+   * apply to normal overloads.
+   *
+   * The key point is the expression in the @c decltype should be the same expression used in the
+   * method to verify it will compile. It is annoying to type it twice but there's not a better
+   * option.
+   *
+   * Note @c decltype does not accept explicit types - to have the type of "int" an @c int must be
+   * constructed. This is easy for builtin types except @c void. @c CaseVoidFunc is provided for that
+   * situation, e.g. <tt>decltype(CaseVoidFunc())</tt> provides @c void via @c decltype.
+   */
+
+  /// Case hierarchy.
+  template <unsigned N> struct CaseTag : public CaseTag<N - 1> {
+    constexpr CaseTag() {}
+    static constexpr unsigned value = N;
+  };
+
+  /// Anchor the hierarchy.
+  template <> struct CaseTag<0> {
+    constexpr CaseTag() {}
+    static constexpr unsigned value = 0;
+  };
+
+  /** This is the final case - it forces the super class hierarchy.
+   * After defining the cases using the indexed case arguments, this is used to to perform the call.
+   * To increase the hierarchy depth, change the template argument to a larger number.
+   */
+  static constexpr CaseTag<9> CaseArg{};
+
+  // A function to provide a @c void type for use in cases.
+  // Other types can use the default constructor, e.g. "int()" for @c int.
+  inline void
+  CaseVoidFunc()
+  {
+  }
+} // namespace meta
+} // namespace ts

--- a/src/tscore/Makefile.am
+++ b/src/tscore/Makefile.am
@@ -273,6 +273,7 @@ test_tscore_SOURCES = \
 	unit_tests/test_Scalar.cc \
 	unit_tests/test_scoped_resource.cc \
 	unit_tests/test_ts_file.cc \
+	unit_tests/test_ts_meta.cc \
 	unit_tests/test_Vec.cc
 
 CompileParseRules_SOURCES = CompileParseRules.cc

--- a/src/tscore/unit_tests/test_ts_meta.cc
+++ b/src/tscore/unit_tests/test_ts_meta.cc
@@ -1,0 +1,106 @@
+/** @file
+
+    Unit tests for ts_meta.h and other meta programming.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements.  See the NOTICE file distributed with this work for additional information regarding
+    copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with the License.  You may
+    obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#include <cstring>
+
+#include "tscore/ts_meta.h"
+
+#include "catch.hpp"
+
+struct A {
+  int _value;
+};
+
+struct AA : public A {
+};
+
+struct B {
+  std::string _value;
+};
+
+struct C {
+};
+
+struct D {
+};
+
+// Some example meta-programming, saving it for possible later use.
+
+template <typename...> struct is_any_of_1 {
+  static constexpr bool value = false;
+};
+template <typename T, typename T0> struct is_any_of_1<T, T0> {
+  static constexpr bool value = std::is_same<T, T0>::value;
+};
+template <typename T, typename T0, typename... Rest> struct is_any_of_1<T, T0, Rest...> {
+  static constexpr bool value = std::is_same<T, T0>::value || (sizeof...(Rest) > 0 && is_any_of_1<T, Rest...>::value);
+};
+
+// Requires C++17
+template <typename T, typename... Rest> struct is_any_of_2 {
+  static constexpr bool value = std::disjunction<std::is_same<T, Rest>...>::value;
+};
+
+TEST_CASE("Meta Example", "[meta][example]")
+{
+  REQUIRE(is_any_of_1<A, A, B, C>::value);
+  REQUIRE(!is_any_of_1<D, A, B, C>::value);
+  REQUIRE(is_any_of_1<A, A>::value);
+  REQUIRE(!is_any_of_1<A, D>::value);
+  REQUIRE(!is_any_of_1<A>::value);
+
+  REQUIRE(is_any_of_2<A, A, B, C>::value);
+  REQUIRE(!is_any_of_2<D, A, B, C>::value);
+  REQUIRE(is_any_of_2<A, A>::value);
+  REQUIRE(!is_any_of_2<A, D>::value);
+  REQUIRE(!is_any_of_2<A>::value);
+}
+
+// Start of ts::meta testing.
+
+namespace
+{
+template <typename T>
+auto
+detect(T &&t, ts::meta::CaseTag<0>) -> std::string_view
+{
+  return "none";
+}
+template <typename T>
+auto
+detect(T &&t, ts::meta::CaseTag<1>) -> decltype(t._value, std::string_view())
+{
+  return "value";
+}
+template <typename T>
+std::string_view
+detect(T &&t)
+{
+  return detect(t, ts::meta::CaseArg);
+}
+} // namespace
+
+TEST_CASE("Meta", "[meta]")
+{
+  REQUIRE(detect(A()) == "value");
+  REQUIRE(detect(B()) == "value");
+  REQUIRE(detect(C()) == "none");
+  REQUIRE(detect(AA()) == "value");
+}


### PR DESCRIPTION
This enables conditional compilation checks in pure C++ code, without support from `configure.ac` or `#define`. It is a bit more verbose but has the advantage of being self contained - the code does not depend on external tools in order to compile correctly. It is also more robust because it does its checks with the exact compiler and library environment. Therefore changing the environment and recompiling will change the output without other rebuilding.

The basic structure is a wrapper function is created to cover the conditional code. A set of "case" functions, analogous to `switch` /  `case`, are created as overloads. These are called from the wrapper, and checked by the compiler in order and the first one that successfully compiles is chosen. The checking involves attempting to compile an expression - if the expression _compiles_ successfully that is a success. It is not a visible error if the expression does not compile, except for the base case because at least one of the overloads must be a success. It is not an error if multiple overloads succeed, the highest ranked will be used. This is a critical difference from `std::enable_if`, which requires disjoint success that can be very challenging to achieve.

An example of its use in a real life situation [is here](https://github.com/apache/trafficserver/pull/4040#discussion_r211333263) in #4040. This creates a wrapper function for an `openSSL` call that compiles to the underlying call if present, and nothing if not. In that case, the conditional compilation check is
```
SSL_CTX_set1_groups_list(static_cast<T *>(nullptr), static_cast<char*>(nullptr))
```
This compiles if there is an `SSL_CTX_set1_groups_list` function that takes a `T` (in this case an `SSL_CTX` because the wrapper function forces that) and a `char *`. If not, that case is not used. Note that if BoringSSL has something similar but with a different name, another case could be added (with `CaseArg_2`) to check for that and provide a shim to call it correctly.