### PR TITLE
Unify plugin hooks dispatch

### DIFF
--- a/iocore/net/test_I_UDPNet.cc
+++ b/iocore/net/test_I_UDPNet.cc
@@ -300,7 +300,7 @@ Log::trace_out(sockaddr const *, unsigned short, char const *, ...)
 
 #include "InkAPIInternal.h"
 int
-APIHook::invoke(int, void *)
+APIHook::invoke(int, void *) const
 {
   ink_assert(false);
   return 0;
@@ -314,7 +314,14 @@ APIHook::next() const
 }
 
 APIHook *
-APIHooks::get() const
+APIHook::prev() const
+{
+  ink_assert(false);
+  return nullptr;
+}
+
+APIHook *
+APIHooks::head() const
 {
   ink_assert(false);
   return nullptr;

--- a/proxy/InkAPIInternal.h
+++ b/proxy/InkAPIInternal.h
@@ -31,12 +31,15 @@
 #include "ProxyConfig.h"
 #include "P_Cache.h"
 #include "I_Tasks.h"
+#include "Plugin.h"
 
 #include "ts/InkAPIPrivateIOCore.h"
 #include "ts/experimental.h"
 
 #include <typeinfo>
 
+class ProxyClientSession;
+class HttpSM;
 /* Some defines that might be candidates for configurable settings later.
  */
 #define TS_HTTP_MAX_USER_ARG 16 /* max number of user arguments for Transactions and Sessions */
@@ -121,8 +124,9 @@ class APIHook
 {
 public:
   INKContInternal *m_cont;
-  int invoke(int event, void *edata);
+  int invoke(int event, void *edata) const;
   APIHook *next() const;
+  APIHook *prev() const;
   LINK(APIHook, m_link);
 };
 
@@ -130,10 +134,12 @@ public:
 class APIHooks
 {
 public:
-  void prepend(INKContInternal *cont);
   void append(INKContInternal *cont);
-  APIHook *get() const;
+  /// Get the first hook.
+  APIHook *head() const;
+  /// Remove all hooks.
   void clear();
+  /// Check if there are no hooks.
   bool is_empty() const;
   void invoke(int event, void *data);
 
@@ -174,8 +180,6 @@ public:
 
   /// Remove all hooks.
   void clear();
-  /// Add the hook @a cont to the front of the hooks for @a id.
-  void prepend(ID id, INKContInternal *cont);
   /// Add the hook @a cont to the end of the hooks for @a id.
   void append(ID id, INKContInternal *cont);
   /// Get the list of hooks for @a id.
@@ -196,13 +200,16 @@ public:
   /// @return @c true if any hooks of type @a id are present.
   bool has_hooks_for(ID id) const;
 
+  /// Get a pointer to the set of hooks for a specific hook @id
+  APIHooks const *operator[](ID id) const;
+
 private:
-  bool hooks_p; ///< Flag for (not) empty container.
+  bool m_hooks_p = false; ///< Flag for (not) empty container.
   /// The array of hooks lists.
   APIHooks m_hooks[N];
 };
 
-template <typename ID, ID N> FeatureAPIHooks<ID, N>::FeatureAPIHooks() : hooks_p(false) {}
+template <typename ID, ID N> FeatureAPIHooks<ID, N>::FeatureAPIHooks() {}
 
 template <typename ID, ID N> FeatureAPIHooks<ID, N>::~FeatureAPIHooks()
 {
@@ -213,28 +220,18 @@ template <typename ID, ID N>
 void
 FeatureAPIHooks<ID, N>::clear()
 {
-  for (int i = 0; i < N; ++i) {
-    m_hooks[i].clear();
+  for (auto &h : m_hooks) {
+    h.clear();
   }
-  hooks_p = false;
-}
-
-template <typename ID, ID N>
-void
-FeatureAPIHooks<ID, N>::prepend(ID id, INKContInternal *cont)
-{
-  if (likely(is_valid(id))) {
-    hooks_p = true;
-    m_hooks[id].prepend(cont);
-  }
+  m_hooks_p = false;
 }
 
 template <typename ID, ID N>
 void
 FeatureAPIHooks<ID, N>::append(ID id, INKContInternal *cont)
 {
-  if (likely(is_valid(id))) {
-    hooks_p = true;
+  if (is_valid(id)) {
+    m_hooks_p = true;
     m_hooks[id].append(cont);
   }
 }
@@ -243,7 +240,12 @@ template <typename ID, ID N>
 APIHook *
 FeatureAPIHooks<ID, N>::get(ID id) const
 {
-  return likely(is_valid(id)) ? m_hooks[id].get() : nullptr;
+  return likely(is_valid(id)) ? m_hooks[id].head() : nullptr;
+}
+
+template <typename ID, ID N> APIHooks const *FeatureAPIHooks<ID, N>::operator[](ID id) const
+{
+  return likely(is_valid(id)) ? &(m_hooks[id]) : nullptr;
 }
 
 template <typename ID, ID N>
@@ -259,7 +261,7 @@ template <typename ID, ID N>
 bool
 FeatureAPIHooks<ID, N>::has_hooks() const
 {
-  return hooks_p;
+  return m_hooks_p;
 }
 
 template <typename ID, ID N>
@@ -339,6 +341,59 @@ public:
 private:
   std::unordered_map<std::string, INKContInternal *> cb_table;
 };
+
+class HttpHookState
+{
+public:
+  /// Scope tags for interacting with a live instance.
+  enum ScopeTag { GLOBAL, SSN, TXN };
+
+  /// Default Constructor
+  HttpHookState();
+
+  /// Initialize the hook state to track up to 3 sources of hooks.
+  /// The argument order to this method is used to break priority ties (callbacks from earlier args are invoked earlier)
+  /// The order in terms of @a ScopeTag is GLOBAL, SESSION, TRANSACTION.
+  void init(TSHttpHookID id, HttpAPIHooks const *global, HttpAPIHooks const *ssn = nullptr, HttpAPIHooks const *txn = nullptr);
+
+  /// Select a hook for invocation and advance the state to the next valid hook
+  /// @return nullptr if no current hook.
+  APIHook const *getNext();
+
+  /// Get the hook ID
+  TSHttpHookID id() const;
+
+  /// Temporary function to return true. Later will be used to decide if a plugin is enabled for the hooks
+  bool is_enabled();
+
+protected:
+  /// Track the state of one scope of hooks.
+  struct Scope {
+    APIHook const *_c; ///< Current hook (candidate for invocation).
+    APIHook const *_p; ///< Previous hook (already invoked).
+
+    /// Initialize the scope.
+    void init(HttpAPIHooks const *scope, TSHttpHookID id);
+    /// Clear the scope.
+    void clear();
+    /// Return the current candidate.
+    APIHook const *candidate();
+    /// Advance state to the next hook.
+    void operator++();
+  };
+
+private:
+  TSHttpHookID _id;
+  Scope _global; ///< Chain from global hooks.
+  Scope _ssn;    ///< Chain from session hooks.
+  Scope _txn;    ///< Chain from transaction hooks.
+};
+
+inline TSHttpHookID
+HttpHookState::id() const
+{
+  return _id;
+}
 
 void api_init();
 

--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -87,19 +87,13 @@ public:
   virtual const char *get_protocol_string() const = 0;
 
   virtual void
-  ssn_hook_append(TSHttpHookID id, INKContInternal *cont)
+  hook_add(TSHttpHookID id, INKContInternal *cont)
   {
     this->api_hooks.append(id, cont);
   }
 
-  virtual void
-  ssn_hook_prepend(TSHttpHookID id, INKContInternal *cont)
-  {
-    this->api_hooks.prepend(id, cont);
-  }
-
   APIHook *
-  ssn_hook_get(TSHttpHookID id) const
+  hook_get(TSHttpHookID id) const
   {
     return this->api_hooks.get(id);
   }
@@ -159,6 +153,11 @@ public:
     return draining != 0;
   }
 
+  HttpAPIHooks const *
+  feature_hooks() const
+  {
+    return &api_hooks;
+  }
   // Initiate an API hook invocation.
   void do_api_callout(TSHttpHookID id);
 
@@ -228,7 +227,7 @@ public:
   TSHttpHookID
   get_hookid() const
   {
-    return api_hookid;
+    return hook_state.id();
   }
 
   virtual void
@@ -307,6 +306,9 @@ public:
   ProxyClientSession &operator=(const ProxyClientSession &) = delete;
 
 protected:
+  // Hook dispatching state
+  HttpHookState hook_state;
+
   // XXX Consider using a bitwise flags variable for the following flags, so
   // that we can make the best use of internal alignment padding.
 
@@ -322,9 +324,7 @@ private:
   void handle_api_return(int event);
   int state_api_callout(int event, void *edata);
 
-  APIHookScope api_scope  = API_HOOK_SCOPE_NONE;
-  TSHttpHookID api_hookid = TS_HTTP_READ_REQUEST_HDR_HOOK;
-  APIHook *api_current    = nullptr;
+  APIHook const *cur_hook = nullptr;
   HttpAPIHooks api_hooks;
   void *user_args[TS_HTTP_MAX_USER_ARG];
 

--- a/proxy/ProxyClientTransaction.h
+++ b/proxy/ProxyClientTransaction.h
@@ -105,9 +105,15 @@ public:
   }
 
   APIHook *
-  ssn_hook_get(TSHttpHookID id) const
+  hook_get(TSHttpHookID id) const
   {
-    return parent ? parent->ssn_hook_get(id) : nullptr;
+    return parent ? parent->hook_get(id) : nullptr;
+  }
+
+  HttpAPIHooks const *
+  feature_hooks() const
+  {
+    return parent ? parent->feature_hooks() : nullptr;
   }
 
   bool

--- a/proxy/Transform.cc
+++ b/proxy/Transform.cc
@@ -546,7 +546,7 @@ TransformControl::handle_event(int event, void * /* edata ATS_UNUSED */)
     if (http_global_hooks && http_global_hooks->get(TS_HTTP_RESPONSE_TRANSFORM_HOOK)) {
       m_tvc = transformProcessor.open(this, http_global_hooks->get(TS_HTTP_RESPONSE_TRANSFORM_HOOK));
     } else {
-      m_tvc = transformProcessor.open(this, m_hooks.get());
+      m_tvc = transformProcessor.open(this, m_hooks.head());
     }
     ink_assert(m_tvc != nullptr);
 

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -1402,87 +1402,63 @@ plugins required to work with sni_routing.
     }
   // FALLTHROUGH
   case HTTP_API_CONTINUE:
-    if ((cur_hook_id >= 0) && (cur_hook_id < TS_HTTP_LAST_HOOK)) {
-      if (!cur_hook) {
-        if (cur_hooks == 0) {
-          cur_hook = http_global_hooks->get(cur_hook_id);
-          cur_hooks++;
-        }
+    if (nullptr == cur_hook) {
+      cur_hook = hook_state.getNext();
+    }
+    if (cur_hook) {
+      if (callout_state == HTTP_API_NO_CALLOUT) {
+        callout_state = HTTP_API_IN_CALLOUT;
       }
-      // even if ua_txn is NULL, cur_hooks must
-      // be incremented otherwise cur_hooks is not set to 2 and
-      // transaction hooks (stored in api_hooks object) are not called.
-      if (!cur_hook) {
-        if (cur_hooks == 1) {
-          if (ua_txn) {
-            cur_hook = ua_txn->ssn_hook_get(cur_hook_id);
-          }
-          cur_hooks++;
+
+      /* The MUTEX_TRY_LOCK macro was changed so
+         that it can't handle NULL mutex'es.  The plugins
+         can use null mutexes so we have to do this manually.
+         We need to take a smart pointer to the mutex since
+         the plugin could release it's mutex while we're on
+         the callout
+       */
+      bool plugin_lock;
+      Ptr<ProxyMutex> plugin_mutex;
+      if (cur_hook->m_cont->mutex) {
+        plugin_mutex = cur_hook->m_cont->mutex;
+        MUTEX_TRY_LOCK(lock, cur_hook->m_cont->mutex, mutex->thread_holding);
+
+        if (!(plugin_lock = lock.is_locked())) {
+          api_timer = -Thread::get_hrtime_updated();
+          HTTP_SM_SET_DEFAULT_HANDLER(&HttpSM::state_api_callout);
+          ink_assert(pending_action == nullptr);
+          pending_action = mutex->thread_holding->schedule_in(this, HRTIME_MSECONDS(10));
+          return 0;
         }
+      } else {
+        plugin_lock = false;
       }
-      if (!cur_hook) {
-        if (cur_hooks == 2) {
-          cur_hook = api_hooks.get(cur_hook_id);
-          cur_hooks++;
-        }
+
+      SMDebug("http", "[%" PRId64 "] calling plugin on hook %s at hook %p", sm_id, HttpDebugNames::get_api_hook_name(cur_hook_id),
+              cur_hook);
+
+      APIHook const *hook = cur_hook;
+      // Need to delay the next hook update until after this hook is called to handle dynamic
+      // callback manipulation. cur_hook isn't needed to track state (in hook_state).
+      cur_hook = nullptr;
+
+      if (!api_timer) {
+        api_timer = Thread::get_hrtime();
       }
-      if (cur_hook) {
-        if (callout_state == HTTP_API_NO_CALLOUT) {
-          callout_state = HTTP_API_IN_CALLOUT;
-        }
-
-        /* The MUTEX_TRY_LOCK macro was changed so
-           that it can't handle NULL mutex'es.  The plugins
-           can use null mutexes so we have to do this manually.
-           We need to take a smart pointer to the mutex since
-           the plugin could release it's mutex while we're on
-           the callout
-         */
-        bool plugin_lock;
-        Ptr<ProxyMutex> plugin_mutex;
-        if (cur_hook->m_cont->mutex) {
-          plugin_mutex = cur_hook->m_cont->mutex;
-          plugin_lock  = MUTEX_TAKE_TRY_LOCK(cur_hook->m_cont->mutex, mutex->thread_holding);
-
-          if (!plugin_lock) {
-            api_timer = -Thread::get_hrtime_updated();
-            HTTP_SM_SET_DEFAULT_HANDLER(&HttpSM::state_api_callout);
-            ink_assert(pending_action == nullptr);
-            pending_action = mutex->thread_holding->schedule_in(this, HRTIME_MSECONDS(10));
-            // Should @a callout_state be reset back to HTTP_API_NO_CALLOUT here? Because the default
-            // handler has been changed the value isn't important to the rest of the state machine
-            // but not resetting means there is no way to reliably detect re-entrance to this state with an
-            // outstanding callout.
-            return 0;
-          }
-        } else {
-          plugin_lock = false;
-        }
-
-        SMDebug("http", "[%" PRId64 "] calling plugin on hook %s at hook %p", sm_id, HttpDebugNames::get_api_hook_name(cur_hook_id),
-                cur_hook);
-
-        APIHook *hook = cur_hook;
-        cur_hook      = cur_hook->next();
-
-        if (!api_timer) {
-          api_timer = Thread::get_hrtime_updated();
-        }
-        hook->invoke(TS_EVENT_HTTP_READ_REQUEST_HDR + cur_hook_id, this);
-        if (api_timer > 0) { // true if the hook did not call TxnReenable()
-          milestone_update_api_time(milestones, api_timer);
-          api_timer = -Thread::get_hrtime_updated(); // set in order to track non-active callout duration
-          // which means that if we get back from the invoke with api_timer < 0 we're already
-          // tracking a non-complete callout from a chain so just let it ride. It will get cleaned
-          // up in state_api_callback when the plugin re-enables this transaction.
-        }
-
-        if (plugin_lock) {
-          Mutex_unlock(plugin_mutex, mutex->thread_holding);
-        }
-
-        return 0;
+      hook->invoke(TS_EVENT_HTTP_READ_REQUEST_HDR + cur_hook_id, this);
+      if (api_timer > 0) { // true if the hook did not call TxnReenable()
+        milestone_update_api_time(milestones, api_timer);
+        api_timer = -Thread::get_hrtime(); // set in order to track non-active callout duration
+        // which means that if we get back from the invoke with api_timer < 0 we're already
+        // tracking a non-complete callout from a chain so just let it ride. It will get cleaned
+        // up in state_api_callback when the plugin re-enables this transaction.
       }
+
+      if (plugin_lock) {
+        Mutex_unlock(plugin_mutex, mutex->thread_holding);
+      }
+
+      return 0;
     }
     // Map the callout state into api_next
     switch (callout_state) {
@@ -5106,6 +5082,7 @@ HttpSM::do_api_callout_internal()
     ink_assert(!"not reached");
   }
 
+  hook_state.init(cur_hook_id, http_global_hooks, ua_txn ? ua_txn->feature_hooks() : nullptr, &api_hooks);
   cur_hook  = nullptr;
   cur_hooks = 0;
   state_api_callout(0, nullptr);
@@ -5117,7 +5094,7 @@ HttpSM::do_post_transform_open()
   ink_assert(post_transform_info.vc == nullptr);
 
   if (is_action_tag_set("http_post_nullt")) {
-    txn_hook_prepend(TS_HTTP_REQUEST_TRANSFORM_HOOK, transformProcessor.null_transform(mutex.get()));
+    txn_hook_add(TS_HTTP_REQUEST_TRANSFORM_HOOK, transformProcessor.null_transform(mutex.get()));
   }
 
   post_transform_info.vc = transformProcessor.open(this, api_hooks.get(TS_HTTP_REQUEST_TRANSFORM_HOOK));
@@ -5138,7 +5115,7 @@ HttpSM::do_transform_open()
   APIHook *hooks;
 
   if (is_action_tag_set("http_nullt")) {
-    txn_hook_prepend(TS_HTTP_RESPONSE_TRANSFORM_HOOK, transformProcessor.null_transform(mutex.get()));
+    txn_hook_add(TS_HTTP_RESPONSE_TRANSFORM_HOOK, transformProcessor.null_transform(mutex.get()));
   }
 
   hooks = api_hooks.get(TS_HTTP_RESPONSE_TRANSFORM_HOOK);

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -304,8 +304,7 @@ public:
   void dump_state_hdr(HTTPHdr *h, const char *s);
 
   // Functions for manipulating api hooks
-  void txn_hook_append(TSHttpHookID id, INKContInternal *cont);
-  void txn_hook_prepend(TSHttpHookID id, INKContInternal *cont);
+  void txn_hook_add(TSHttpHookID id, INKContInternal *cont);
   APIHook *txn_hook_get(TSHttpHookID id);
 
   bool is_private();
@@ -575,7 +574,8 @@ public:
 
 protected:
   TSHttpHookID cur_hook_id = TS_HTTP_LAST_HOOK;
-  APIHook *cur_hook        = nullptr;
+  APIHook const *cur_hook  = nullptr;
+  HttpHookState hook_state;
 
   //
   // Continuation time keeper
@@ -690,16 +690,9 @@ HttpSM::find_server_buffer_size()
 }
 
 inline void
-HttpSM::txn_hook_append(TSHttpHookID id, INKContInternal *cont)
+HttpSM::txn_hook_add(TSHttpHookID id, INKContInternal *cont)
 {
   api_hooks.append(id, cont);
-  hooks_set = true;
-}
-
-inline void
-HttpSM::txn_hook_prepend(TSHttpHookID id, INKContInternal *cont)
-{
-  api_hooks.prepend(id, cont);
   hooks_set = true;
 }
 

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -1289,12 +1289,23 @@ INKVConnInternal::set_data(int id, void *data)
 
 ////////////////////////////////////////////////////////////////////
 //
-// APIHook, APIHooks, HttpAPIHooks
+// APIHook, APIHooks, HttpAPIHooks, HttpHookState
 //
 ////////////////////////////////////////////////////////////////////
+APIHook *
+APIHook::next() const
+{
+  return m_link.next;
+}
+
+APIHook *
+APIHook::prev() const
+{
+  return m_link.prev;
+}
 
 int
-APIHook::invoke(int event, void *edata)
+APIHook::invoke(int event, void *edata) const
 {
   if ((event == EVENT_IMMEDIATE) || (event == EVENT_INTERVAL) || event == TS_EVENT_HTTP_TXN_CLOSE) {
     if (ink_atomic_increment((int *)&m_cont->m_event_count, 1) < 0) {
@@ -1305,20 +1316,9 @@ APIHook::invoke(int event, void *edata)
 }
 
 APIHook *
-APIHook::next() const
+APIHooks::head() const
 {
-  return m_link.next;
-}
-
-void
-APIHooks::prepend(INKContInternal *cont)
-{
-  APIHook *api_hook;
-
-  api_hook         = apiHookAllocator.alloc();
-  api_hook->m_cont = cont;
-
-  m_hooks.push(api_hook);
+  return m_hooks.head;
 }
 
 void
@@ -1332,12 +1332,6 @@ APIHooks::append(INKContInternal *cont)
   m_hooks.enqueue(api_hook);
 }
 
-APIHook *
-APIHooks::get() const
-{
-  return m_hooks.head;
-}
-
 void
 APIHooks::clear()
 {
@@ -1345,6 +1339,94 @@ APIHooks::clear()
   while (nullptr != (hook = m_hooks.pop())) {
     apiHookAllocator.free(hook);
   }
+}
+
+HttpHookState::HttpHookState() : _id(TS_HTTP_LAST_HOOK) {}
+
+void
+HttpHookState::init(TSHttpHookID id, HttpAPIHooks const *global, HttpAPIHooks const *ssn, HttpAPIHooks const *txn)
+{
+  _id = id;
+
+  if (global) {
+    _global.init(global, id);
+  } else {
+    _global.clear();
+  }
+
+  if (ssn) {
+    _ssn.init(ssn, id);
+  } else {
+    _ssn.clear();
+  }
+
+  if (txn) {
+    _txn.init(txn, id);
+  } else {
+    _txn.clear();
+  }
+}
+
+APIHook const *
+HttpHookState::getNext()
+{
+  APIHook const *zret = nullptr;
+  do {
+    APIHook const *hg   = _global.candidate();
+    APIHook const *hssn = _ssn.candidate();
+    APIHook const *htxn = _txn.candidate();
+    zret                = nullptr;
+
+    Debug("plugin", "computing next callback for hook %d", _id);
+
+    if (hg) {
+      zret = hg;
+      ++_global;
+    } else if (hssn) {
+      zret = hssn;
+      ++_ssn;
+    } else if (htxn) {
+      zret = htxn;
+      ++_txn;
+    }
+  } while (zret != nullptr && !this->is_enabled());
+
+  return zret;
+}
+
+bool
+HttpHookState::is_enabled()
+{
+  return true;
+}
+
+void
+HttpHookState::Scope::init(HttpAPIHooks const *feature_hooks, TSHttpHookID id)
+{
+  APIHooks const *hooks = (*feature_hooks)[id];
+
+  _p = nullptr;
+  _c = hooks->head();
+}
+
+APIHook const *
+HttpHookState::Scope::candidate()
+{
+  /// Simply returns _c hook for now. Later will do priority checking here
+  return _c;
+}
+
+void
+HttpHookState::Scope::operator++()
+{
+  _p = _c;
+  _c = _c->next();
+}
+
+void
+HttpHookState::Scope::clear()
+{
+  _p = _c = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -4565,7 +4647,7 @@ TSHttpSsnHookAdd(TSHttpSsn ssnp, TSHttpHookID id, TSCont contp)
   sdk_assert(sdk_sanity_check_hook_id(id) == TS_SUCCESS);
 
   ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
-  cs->ssn_hook_append(id, (INKContInternal *)contp);
+  cs->hook_add(id, (INKContInternal *)contp);
 }
 
 int
@@ -4653,7 +4735,7 @@ TSHttpTxnHookAdd(TSHttpTxn txnp, TSHttpHookID id, TSCont contp)
     }
     hook = hook->m_link.next;
   }
-  sm->txn_hook_append(id, (INKContInternal *)contp);
+  sm->txn_hook_add(id, (INKContInternal *)contp);
 }
 
 // Private api function for gzip plugin.


### PR DESCRIPTION
1. Added`HttpHookState` class that manages all http hooks. This will be useful for later plugin coordination work.
2. Changed `ProxyClientSession` and `HttpSM` to use `HttpHookState` for hooks dispatch
3. Minor changes to `APIHook`, `APIHooks`, and `FeatureAPIHooks`