### PR TITLE
Adds configurable behavior on redirect to loopback

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -1326,6 +1326,61 @@ HTTP Redirection
    This setting determines the maximum size in bytes of uploaded content to be
    buffered for HTTP methods such as POST and PUT.
 
+.. ts:cv:: CONFIG proxy.config.http.redirect.actions STRING routable:follow
+   :reloadable:
+
+   This setting determines how redirects should be handled. The setting consists
+   of a comma-separated list of key-value pairs, where the keys are named IP
+   address ranges and the values are actions.
+
+   The following are valid keys:
+
+   ============= ===============================================================
+   Key           Description
+   ============= ===============================================================
+   ``self``      Addresses of the host's interfaces
+   ``loopback``  IPv4 ``127.0.0.0/8`` and IPv6 ``::1``
+   ``private``   IPv4 ``10.0.0.0/8`` ``100.64.0.0/10`` ``172.16.0.0/12`` ``192.168.0.0/16`` and IPv6 ``fc00::/7``
+   ``multicast`` IPv4 ``224.0.0.0/4`` and IPv6 ``ff00::/8``
+   ``linklocal`` IPv4 ``169.254.0.0/16`` and IPv6 ``fe80::/10``
+   ``routable``  All publicly routable addresses
+   ``default``   All address ranges not configured specifically
+   ============= ===============================================================
+
+   The following are valid values:
+
+   ========== ==================================================================
+   Value      Description
+   ========== ==================================================================
+   ``return`` Do not process the redirect, send it as the proxy response.
+   ``reject`` Do not process the redirect, send a 403 as the proxy response.
+   ``follow`` Internally follow the redirect up to :ts:cv:`proxy.config.http.number_of_redirections`. **Use this setting with caution!**
+   ========== ==================================================================
+
+   .. warning:: Following a redirect to other than ``routable`` addresses can be
+      dangerous, as it allows the controller of an origin to arrange a probe the
+      |TS| host. Enabling these redirects makes |TS| open to third party attacks
+      and probing and therefore should be considered only in known safe
+      environments.
+
+   For example, a setting of
+   ``loopback:reject,private:reject,routable:follow,default:return`` would send
+   ``403`` as the proxy response to loopback and private addresses, routable
+   addresses would be followed up to
+   :ts:cv:`proxy.config.http.number_of_redirections`, and redirects to all other
+   ranges will be sent as the proxy response.
+
+   The action for ``self`` has the highest priority when an address would match
+   multiple keys, and the action for ``default`` has the lowest priority. Other
+   keys represent disjoint sets of addresses that will not conflict. If
+   duplicate keys are present in the setting, the right-most key-value pair is
+   used.
+
+   The default value is ``routable:follow``, which means "follow routable
+   redirects, return all other redirects". Note that
+   :ts:cv:`proxy.config.http.number_of_redirections` must be positive also,
+   otherwise redirects will be returned rather than followed.
+
 Origin Server Connect Attempts
 ==============================
 

--- a/iocore/utils/I_Machine.h
+++ b/iocore/utils/I_Machine.h
@@ -81,6 +81,7 @@ struct Machine {
   static self *instance();
   bool is_self(const char *name);
   bool is_self(const IpAddr *ipaddr);
+  bool is_self(struct sockaddr const *addr);
   void insert_id(char *id);
   void insert_id(IpAddr *ipaddr);
 

--- a/iocore/utils/Machine.cc
+++ b/iocore/utils/Machine.cc
@@ -288,6 +288,19 @@ Machine::is_self(const IpAddr *ipaddr)
   return ink_hash_table_lookup(machine_id_ipaddrs, string_value, &value) == 1 ? true : false;
 }
 
+bool
+Machine::is_self(struct sockaddr const *addr)
+{
+  void *value                             = nullptr;
+  char string_value[INET6_ADDRSTRLEN + 1] = {0};
+
+  if (addr == nullptr) {
+    return false;
+  }
+  ats_ip_ntop(addr, string_value, sizeof(string_value));
+  return ink_hash_table_lookup(machine_id_ipaddrs, string_value, &value) == 1 ? true : false;
+}
+
 void
 Machine::insert_id(char *id)
 {

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -165,6 +165,7 @@ static const RecordElement RecordsConfig[] =
   //# 2. proxy.config.http.redirect_use_orig_cache_key: Location Header if set to 0 (default), else use original request cache key
   //# 3. redirection_host_no_port: do not include default port in host header during redirection
   //# 4. post_copy_size: The maximum POST data size TS permits to copy
+  //# 5. redirect.actions: How to handle redirects.
   //#
   //##############################################################################
   {RECT_CONFIG, "proxy.config.http.number_of_redirections", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
@@ -174,6 +175,8 @@ static const RecordElement RecordsConfig[] =
   {RECT_CONFIG, "proxy.config.http.redirect_host_no_port", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.http.post_copy_size", RECD_INT, "2048", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
+  {RECT_CONFIG, "proxy.config.http.redirect.actions", RECD_STRING, "routable:follow", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
 
   //##############################################################################

--- a/tests/gold_tests/redirect/redirect.test.py
+++ b/tests/gold_tests/redirect/redirect.test.py
@@ -32,12 +32,12 @@ dns = Test.MakeDNServer("dns")
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 1,
     'proxy.config.diags.debug.tags': 'http|dns|redirect',
-    'proxy.config.http.redirection_enabled': 1,
     'proxy.config.http.number_of_redirections': 1,
     'proxy.config.http.cache.http': 0,
     'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
     'proxy.config.dns.resolv_conf': 'NULL',
-    'proxy.config.url_remap.remap_required': 0  # need this so the domain gets a chance to be evaluated through DNS
+    'proxy.config.url_remap.remap_required': 0,  # need this so the domain gets a chance to be evaluated through DNS
+    'proxy.config.http.redirect.actions': 'self:follow', # redirects to self are not followed by default
 })
 
 Test.Setup.Copy(os.path.join(Test.Variables.AtsTestToolsDir,'tcp_client.py'))

--- a/tests/gold_tests/redirect/redirect_actions.test.py
+++ b/tests/gold_tests/redirect/redirect_actions.test.py
@@ -1,0 +1,243 @@
+'''
+Test redirection behavior to invalid addresses
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from enum import Enum
+import re
+import os
+import socket
+Test.Summary = '''
+Test redirection behavior to invalid addresses
+'''
+
+Test.SkipIf(Condition.true('autest sometimes does not capture output on the last test case of a scenario'))
+Test.ContinueOnFail = False
+
+Test.Setup.Copy(os.path.join(Test.Variables.AtsTestToolsDir,'tcp_client.py'))
+
+dns = Test.MakeDNServer('dns')
+# This record is used in each test case to get the initial redirect response from the origin that we will handle.
+dnsRecords = {'iwillredirect.test': ['127.0.0.1']}
+
+host = socket.gethostname()
+ipv4addrs = set()
+try:
+    ipv4addrs = set([ip for \
+            (family,_,_,_,(ip,*_)) in \
+            socket.getaddrinfo(host,port=None) if \
+            socket.AF_INET == family])
+except socket.gaierror:
+    pass
+
+ipv6addrs = set()
+try:
+    ipv6addrs = set(["[{0}]".format(ip.split('%')[0]) for \
+            (family,_,_,_,(ip,*_)) in \
+            socket.getaddrinfo(host,port=None) if \
+            socket.AF_INET6 == family and 'fe80' != ip[0:4]]) # Skip link-local addresses.
+except socket.gaierror:
+    pass
+
+origin = Test.MakeOriginServer('origin', ip='0.0.0.0')
+ArbitraryTimestamp='12345678'
+
+# This is for cases when the content is actually fetched from the invalid address.
+request_header = {
+        'headers': ('GET / HTTP/1.1\r\n'
+                    'Host: *\r\n\r\n'),
+        'timestamp': ArbitraryTimestamp,
+        'body': ''}
+response_header = {
+        'headers': ('HTTP/1.1 204 No Content\r\n'
+                    'Connection: close\r\n\r\n'),
+        'timestamp': ArbitraryTimestamp,
+        'body': ''}
+origin.addResponse('sessionfile.log', request_header, response_header)
+
+# Map scenarios to trafficserver processes.
+trafficservers={}
+
+data_dirname = 'generated_test_data'
+data_path = os.path.join(Test.TestDirectory, data_dirname)
+os.makedirs(data_path, exist_ok=True)
+
+def normalizeForAutest(value):
+    '''
+    autest uses "test run" names to build file and directory names, so we must transform them in case there are incompatible or
+    annoying characters.
+    This means we can also use them in URLs.
+    '''
+    if not value:
+        return None
+    return re.sub(r'[^a-z0-9-]', '_', value, flags=re.I)
+
+def makeTestCase(redirectTarget, expectedAction, scenario):
+    '''
+    Helper method that creates a "meta-test" from which autest generates a test case.
+
+    :param redirectTarget: The target address of a redirect from origin to be handled.
+    :param scenario: Defines the ACL to configure and the addresses to test.
+    '''
+
+    config = ','.join(':'.join(t) for t in ((addr.name.lower(),action.name.lower()) for (addr,action) in scenario.items()))
+
+    normRedirectTarget = normalizeForAutest(redirectTarget)
+    normConfig = normalizeForAutest(config)
+    tr = Test.AddTestRun('With_Config_{0}_Redirect_to_{1}'.format(normConfig, normRedirectTarget))
+
+    if trafficservers:
+        tr.StillRunningAfter = origin
+        tr.StillRunningAfter = dns
+    else:
+        tr.Processes.Default.StartBefore(origin)
+        tr.Processes.Default.StartBefore(dns)
+
+    if config not in trafficservers:
+        trafficservers[config] = Test.MakeATSProcess('ts_{0}'.format(normConfig))
+        trafficservers[config].Disk.records_config.update({
+            'proxy.config.diags.debug.enabled':               1,
+            'proxy.config.diags.debug.tags':                  'http|dns|redirect',
+            'proxy.config.http.number_of_redirections':       1,
+            'proxy.config.http.cache.http':                   0,
+            'proxy.config.dns.nameservers':                   '127.0.0.1:{0}'.format(dns.Variables.Port),
+            'proxy.config.dns.resolv_conf':                   'NULL',
+            'proxy.config.url_remap.remap_required':          0,
+            'proxy.config.http.redirect.actions':             config,
+            'proxy.config.http.connect_attempts_timeout':     5,
+            'proxy.config.http.connect_attempts_max_retries': 0,
+        })
+        tr.Processes.Default.StartBefore(trafficservers[config])
+    else:
+        tr.StillRunningAfter = trafficservers[config]
+
+    testDomain = 'testdomain{0}.test'.format(normRedirectTarget)
+    # The micro DNS server can't tell us whether it has a record of the domain already, so we use a dictionary to avoid duplicates.
+    # We remove any surrounding brackets that are common to IPv6 addresses.
+    if redirectTarget:
+        dnsRecords[testDomain] = [redirectTarget.strip('[]')]
+
+    # A GET request parameterized on the config and on the target.
+    request_header = {
+            'headers': ('GET /redirect?config={0}&target={1} HTTP/1.1\r\n'
+                        'Host: *\r\n\r\n').\
+                                format(normConfig, normRedirectTarget),
+            'timestamp': ArbitraryTimestamp,
+            'body': ''}
+    # Returns a redirect to the test domain for the given target & the port number for the TS of the given config.
+    response_header = {
+            'headers': ('HTTP/1.1 307 Temporary Redirect\r\n'
+                        'Location: http://{0}:{1}/\r\n'
+                        'Connection: close\r\n\r\n').\
+                                format(testDomain, origin.Variables.Port),
+            'timestamp': ArbitraryTimestamp,
+            'body': ''}
+    origin.addResponse('sessionfile.log', request_header, response_header)
+
+    # Generate the request data file.
+    with open(os.path.join(data_path, tr.Name), 'w') as f:
+        f.write(('GET /redirect?config={0}&target={1} HTTP/1.1\r\n'
+                 'Host: iwillredirect.test:{2}\r\n\r\n').\
+                         format(normConfig, normRedirectTarget, origin.Variables.Port))
+    # Set the command with the appropriate URL.
+    tr.Processes.Default.Command = "bash -o pipefail -c 'python tcp_client.py 127.0.0.1 {0} {1} | head -n 1'".\
+            format(trafficservers[config].Variables.port, os.path.join(data_dirname, tr.Name))
+    tr.Processes.Default.ReturnCode = 0
+    # Generate and set the 'gold file' to check stdout
+    goldFilePath = os.path.join(data_path, '{0}.gold'.format(tr.Name))
+    with open(goldFilePath, 'w') as f:
+        f.write(expectedAction.value['expectedStatusLine'])
+    tr.Processes.Default.Streams.stdout = goldFilePath
+
+class AddressE(Enum):
+    '''
+    Classes of addresses are mapped to example addresses.
+    '''
+    Private   = ('10.0.0.1',    '[fc00::1]')
+    Loopback  = (['127.1.2.3'])  # [::1] is ommitted here because it is likely overwritten by Self, and there are no others in IPv6.
+    Multicast = ('224.1.2.3',   '[ff42::]')
+    Linklocal = ('169.254.0.1', '[fe80::]')
+    Routable  = ('72.30.35.10', '[2001:4998:58:1836::10]') # Do not Follow redirects to these in an automated test.
+    Self      = ipv4addrs | ipv6addrs # Addresses of this host.
+    Default   = None # All addresses apply, nothing in particular to test.
+
+class ActionE(Enum):
+    # Title case because 'return' is a Python keyword.
+    Return = {'config':'return', 'expectedStatusLine':'HTTP/1.1 307 Temporary Redirect\r\n'}
+    Reject = {'config':'reject', 'expectedStatusLine':'HTTP/1.1 403 Forbidden\r\n'}
+    Follow = {'config':'follow', 'expectedStatusLine':'HTTP/1.1 204 No Content\r\n'}
+
+    # Added to test failure modes.
+    Break  = {'expectedStatusLine': 'HTTP/1.1 502 Cannot find server.\r\n'}
+
+scenarios = [
+    {
+        # Follow to loopback, but alternately reject/return others.
+        AddressE.Private:   ActionE.Reject,
+        AddressE.Loopback:  ActionE.Follow,
+        AddressE.Multicast: ActionE.Reject,
+        AddressE.Linklocal: ActionE.Return,
+        AddressE.Routable:  ActionE.Reject,
+        AddressE.Self:      ActionE.Return,
+        AddressE.Default:   ActionE.Reject,
+        },
+
+    {
+        # Follow to loopback, but alternately reject/return others, flipped from the previous scenario.
+        AddressE.Private:   ActionE.Return,
+        AddressE.Loopback:  ActionE.Follow,
+        AddressE.Multicast: ActionE.Return,
+        AddressE.Linklocal: ActionE.Reject,
+        AddressE.Routable:  ActionE.Return,
+        AddressE.Self:      ActionE.Reject,
+        AddressE.Default:   ActionE.Return,
+    },
+
+    {
+        # Return loopback, but reject everything else.
+        AddressE.Loopback:  ActionE.Return,
+        AddressE.Default:   ActionE.Reject,
+    },
+
+    {
+        # Reject loopback, but return everything else.
+        AddressE.Loopback:  ActionE.Reject,
+        AddressE.Default:   ActionE.Return,
+    },
+
+    {
+        # Return everything.
+        AddressE.Default:   ActionE.Return,
+    },
+    ]
+
+for scenario in scenarios:
+    for addressClass in AddressE:
+        if not addressClass.value:
+            # Default has no particular addresses to test.
+            continue
+        for address in addressClass.value:
+            expectedAction = scenario[addressClass] if addressClass in scenario else scenario[AddressE.Default]
+            makeTestCase(redirectTarget=address, expectedAction=expectedAction, scenario=scenario)
+
+    # Test redirects to names that cannot be resolved.
+    makeTestCase(redirectTarget=None, expectedAction=ActionE.Break, scenario=scenario)
+
+dns.addRecords(records=dnsRecords)
+
+# Make sure this runs only after local files have been created.
+Test.Setup.Copy(data_path)

--- a/tests/gold_tests/redirect/redirect_post.test.py
+++ b/tests/gold_tests/redirect/redirect_post.test.py
@@ -39,8 +39,9 @@ dest_serv = Test.MakeOriginServer("dest_server")
 ts.Disk.records_config.update({
     'proxy.config.http.number_of_redirections': MAX_REDIRECT,
     'proxy.config.http.post_copy_size' : 919430601,
-    'proxy.config.http.cache.http': 0  # ,
-    # 'proxy.config.diags.debug.enabled': 1
+    'proxy.config.http.cache.http': 0,
+    'proxy.config.http.redirect.actions': 'self:follow', # redirects to self are not followed by default
+    # 'proxy.config.diags.debug.enabled': 1,
 })
 
 redirect_request_header = {"headers": "POST /redirect1 HTTP/1.1\r\nHost: *\r\nContent-Length: 52428800\r\n\r\n", "timestamp": "5678", "body": ""}


### PR DESCRIPTION
Requesting a backport to 8.x because although this has a functionality change with scope that is best reserved for major releases, 8.x is not yet released. It is intended to be considered for the 8.x release rather than waiting for another major release.

[Discussion Thread](https://lists.apache.org/thread.html/c46e9f0493896744ffbfb6eb0d8eed53bb77003a8abbfa1ac5b63c16@%3Cdev.trafficserver.apache.org%3E)

~~Depends on #4166 because a new assert gets tripped in this failure mode.~~
Dropping the dependency on #4166 because the bug was determined to be local to this PR and not directly related to #4166.