### PR TITLE
Clang-format: Redo clang-format error that slipped through.

### DIFF
--- a/lib/cppapi/include/atscppapi/Transaction.h
+++ b/lib/cppapi/include/atscppapi/Transaction.h
@@ -306,8 +306,8 @@ public:
     CACHE_LOOKUP_SKIPPED,   /**< Cache lookup was not performed */
     CACHE_LOOKUP_NONE
   };
-  
-  #define CACHE_LOOKUP_SKIPED CACHE_LOOKUP_SKIPPED
+
+#define CACHE_LOOKUP_SKIPED CACHE_LOOKUP_SKIPPED
 
   CacheStatus getCacheStatus();
 


### PR DESCRIPTION
Every time I `clang-format` this file changes on me. To avoid that problem in the future, this is a fix. Clearly the `#define` should not be indented, so I'm not sure how this slipped through in the first place.