### PR TITLE
Corrects IPv4 multicast ip address check

### DIFF
--- a/lib/ts/ink_inet.h
+++ b/lib/ts/ink_inet.h
@@ -620,7 +620,7 @@ ats_is_ip_loopback(IpEndpoint const *ip)
 inline bool
 ats_is_ip_multicast(sockaddr const *ip)
 {
-  return ip && ((AF_INET == ip->sa_family && 0xe == *ats_ip_addr8_cast(ip)) ||
+  return ip && ((AF_INET == ip->sa_family && 0xe0 == *ats_ip_addr8_cast(ip)) ||
                 (AF_INET6 == ip->sa_family && IN6_IS_ADDR_MULTICAST(&ats_ip6_addr_cast(ip))));
 }
 /// Check for multicast.


### PR DESCRIPTION
Requesting back-port to LTS branches because this is a bug that could affect stability/correctness.
Assuming 6.x will be retired, but we could back-port if needed.