### PR TITLE
 IP: Use meta case logic to handle sockaddr length field instead of autotools.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1794,27 +1794,6 @@ AC_LINK_IFELSE([
     AC_MSG_RESULT([no])
 ])
 
-# BSD-derived systems populate the socket length in the structure itself. It's
-# redundant to check all of these, but hey, I need the typing practice.
-AC_CHECK_MEMBER([struct sockaddr.sa_len], [], [], [#include <netinet/in.h>])
-AC_CHECK_MEMBER([struct sockaddr_in.sin_len], [], [], [#include <netinet/in.h>])
-AC_CHECK_MEMBER([struct sockaddr_in6.sin6_len], [], [], [#include <netinet/in.h>])
-
-if test "x${ac_cv_member_struct_sockaddr_sa_len}" = "xyes"; then
-    AC_DEFINE(HAVE_STRUCT_SOCKADDR_SA_LEN, 1,
-            [Whether struct sockaddr_in has the sa_len member])
-fi
-
-if test "x${ac_cv_member_struct_sockaddr_in_sin_len}" = "xyes"; then
-AC_DEFINE(HAVE_STRUCT_SOCKADDR_IN_SIN_LEN, 1,
-            [Whether struct sockaddr_in has the sin_len member])
-fi
-
-if test "x${ac_cv_member_struct_sockaddr_in6_sin6_len}" = "xyes"; then
-    AC_DEFINE(HAVE_STRUCT_SOCKADDR_IN6_SIN6_LEN, 1,
-            [Whether struct sockaddr_in6 has the sin6_len member])
-fi
-
 if test "x${with_profiler}" = "xyes"; then
 AC_CHECK_HEADERS([google/profiler.h \
                   ], [], [])


### PR DESCRIPTION
This depends on #4140.

This removes the autotools checking for whether `sockaddr` structs have a length field and does it directly inline using the meta case utility.