### PR TITLE
A restructuring of dispatchEvent that does not lose the scheduleEvent.

### DIFF
--- a/iocore/eventsystem/I_Continuation.h
+++ b/iocore/eventsystem/I_Continuation.h
@@ -45,6 +45,7 @@ class ContinuationQueue;
 class Processor;
 class ProxyMutex;
 class EThread;
+class Event;
 
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -165,10 +166,12 @@ public:
 
     @param event Event code to be passed at callback (Processor specific).
     @param data General purpose data related to the event code (Processor specific).
+    @param schedule_event If the continuation could not be locked, the scheduled event will be returned here. 
+    If this parameter is null, displatchEvent will block on the getting the lock.
     @return State machine and processor specific return code.
 
   */
-  int dispatchEvent(int event = CONTINUATION_EVENT_NONE, void *data = nullptr);
+  int dispatchEvent(int event = CONTINUATION_EVENT_NONE, void *data = nullptr, Event **scheduled_event = nullptr);
 
 protected:
   /**


### PR DESCRIPTION
Originally part of https://github.com/apache/trafficserver/pull/4136  Check out the discussion there.

Adding a return parameter to dispatchEvent to return the scheduled event in the case that the lock could not be obtained.  If the return parameter is not specified,  the call will block.  Thus, calling without a schedule event return parameter will block but it will not lose the event and expose the possibility of calling the handler on a deleted continuation.