### PR TITLE
Reset the inactivity timeout when reusing connections

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -5955,6 +5955,8 @@ HttpSM::attach_server_session(HttpServerSession *s)
 void
 HttpSM::setup_server_send_request_api()
 {
+  // Make sure the VC is on the correct timeout
+  server_session->get_netvc()->set_inactivity_timeout(HRTIME_SECONDS(t_state.txn_conf->transaction_no_activity_timeout_out));
   t_state.api_next_action = HttpTransact::SM_ACTION_API_SEND_REQUEST_HDR;
   do_api_callout();
 }


### PR DESCRIPTION
In commit 9b47aa6799db12fd302ea58e3ae0ba8485fd0bbe we fixed the logic to move from connect timeout to transaction no activity timeout after the new connection had completed.  However, there was still a problem with sitting on the connection timeout until the first byte is received from the origin in the case of server connection reuse for GETs (not POST or PUSH).  The setup for post requests were setting the inactivity timeout correctly but the set up for gets was not.

This has been running in production and verified.