### PR TITLE
Keep-Alive Fix for remap_http

### DIFF
--- a/tests/gold_tests/remap/gold/remap-DNS-200.gold
+++ b/tests/gold_tests/remap/gold/remap-DNS-200.gold
@@ -8,7 +8,7 @@
 < Date: ``
 < Age: ``
 < Transfer-Encoding: chunked
-< Proxy-Connection: keep-alive
+< Proxy-Connection: ``
 < Server: ATS/``
 < 
 ``


### PR DESCRIPTION
remap_http test would occasionally fail because gold file matching would fail on the capitalization of `keep-alive` vs `Keep-Alive`. 