### PR TITLE
Clear up evnets and timers for a H2 stream before destroying its mutex

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -734,10 +734,10 @@ Http2Stream::destroy()
     ats_free(header_blocks);
   }
   chunked_handler.clear();
-  super::destroy();
   clear_timers();
   clear_io_events();
 
+  super::destroy();
   THREAD_FREE(this, http2StreamAllocator, this_ethread());
 }
 


### PR DESCRIPTION
(cherry picked from commit bb428f89c647e5d27e29e5faa86cc6eafe350324)