### PR TITLE
Fix crash in Http2ClientSession::release_netvc

### DIFF
--- a/proxy/ProxyClientSession.cc
+++ b/proxy/ProxyClientSession.cc
@@ -208,7 +208,6 @@ ProxyClientSession::handle_api_return(int event)
     NetVConnection *vc = this->get_netvc();
     if (vc) {
       vc->do_io_close();
-      this->release_netvc();
     }
     free(); // You can now clean things up
     break;

--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -49,7 +49,6 @@ public:
   virtual void new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader, bool backdoor) = 0;
 
   virtual NetVConnection *get_netvc() const = 0;
-  virtual void release_netvc()              = 0;
 
   virtual int get_transact_count() const = 0;
 

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -93,19 +93,6 @@ public:
     return client_vc;
   }
 
-  virtual void
-  release_netvc()
-  {
-    // Make sure the vio's are also released to avoid
-    // later surprises in inactivity timeout
-    if (client_vc) {
-      client_vc->do_io_read(NULL, 0, NULL);
-      client_vc->do_io_write(NULL, 0, NULL);
-      client_vc->set_action(NULL);
-      client_vc = NULL;
-    }
-  }
-
   int
   get_transact_count() const
   {

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -91,7 +91,6 @@ Http2ClientSession::free()
   }
 
   if (client_vc) {
-    release_netvc();
     client_vc->do_io_close();
     client_vc = nullptr;
   }
@@ -275,7 +274,6 @@ Http2ClientSession::do_io_close(int alerrno)
   // Don't send the SSN_CLOSE_HOOK until we got rid of all the streams
   // And handled all the TXN_CLOSE_HOOK's
   if (client_vc) {
-    this->release_netvc();
     client_vc->do_io_close();
     client_vc = nullptr;
   }

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -182,17 +182,6 @@ public:
     return client_vc;
   }
 
-  void
-  release_netvc() override
-  {
-    // Make sure the vio's are also released to avoid later surprises in inactivity timeout
-    if (client_vc) {
-      client_vc->do_io_read(NULL, 0, NULL);
-      client_vc->do_io_write(NULL, 0, NULL);
-      client_vc->set_action(NULL);
-    }
-  }
-
   sockaddr const *
   get_client_addr()
   {


### PR DESCRIPTION
(cherry picked from commit 507368d035bce23d35832fb3c9dbae9158ba452d)

Conflicts:
	proxy/http/Http1ClientSession.h
	proxy/http2/Http2ClientSession.cc
	proxy/http2/Http2ClientSession.h

----
Backport #4147