### PR TITLE
TextView: Better support for std::string assignment.

### DIFF
--- a/lib/ts/TextView.h
+++ b/lib/ts/TextView.h
@@ -155,12 +155,16 @@ public:
   /// Assignment.
   self_type &operator                    =(super_type const &that);
   template <size_t N> self_type &operator=(const char (&s)[N]);
+  self_type &operator                    =(const std::string &s);
 
   /// Explicitly set the view.
   self_type &assign(char const *ptr, size_t n);
 
   /// Explicitly set the view to the range [ @a b , @a e )
   self_type &assign(char const *b, char const *e);
+
+  /// Explicitly set the view from a @c std::string
+  self_type &assign(std::string const &s);
 
   /// @return The first byte in the view.
   char operator*() const;
@@ -573,6 +577,20 @@ inline TextView &
 TextView::operator=(super_type const &that)
 {
   this->super_type::operator=(that);
+  return *this;
+}
+
+inline TextView &
+TextView::operator=(const std::string &s)
+{
+  this->super_type::operator=(s);
+  return *this;
+}
+
+inline TextView &
+TextView::assign(const std::string &s)
+{
+  *this = super_type(s);
   return *this;
 }
 


### PR DESCRIPTION
For inexplicable reasons, `std::string_view` doesn't have good support for assignment from `std::string` and we can't `using` the methods down because there are subtle differences that need to be preserved.

This is split out of #4168.