### PR TITLE
IntrusiveDList: Add ptr_ref_cast to make inheritance easier

### DIFF
--- a/doc/developer-guide/internal-libraries/intrusive-list.en.rst
+++ b/doc/developer-guide/internal-libraries/intrusive-list.en.rst
@@ -186,6 +186,31 @@ avoid the need for any explicit cleanup.
 .. literalinclude:: ../../../lib/ts/unit-tests/test_IntrusiveDList.cc
    :lines: 106-114
 
+In some cases the elements of the list are subclasses and the links are declared in a super class
+and are therefore of the super class type. For instance, in the unit test a class :code:`Thing` is
+defined for testing.
+
+.. literalinclude:: ../../../lib/ts/unit-tests/test_IntrusiveDList.cc
+   :lines: 159
+
+Later on, to validate use on a subclass, :code:`PrivateThing` is defined as a subclass of
+:code:`Thing`.
+
+.. literalinclude:: ../../../lib/ts/unit-tests/test_IntrusiveDList.cc
+   :lines: 181
+
+However, the link members :code:`_next` and :code:`_prev` are of type :code:`Thing*` but the
+descriptor for a list of :code:`PrivateThing` must have link accessors that return
+:code:`PrivateThing *&`. To make this easier a conversion template function is provided,
+:code:`ts::ptr_ref_cast<X, T>` that converts a member of type :code:`T*` to a reference to a pointer
+to :code:`X`, e.g. :code:`X*&`. This is used in the setup for testing :code:`PrivateThing`.
+
+.. literalinclude:: ../../../lib/ts/unit-tests/test_IntrusiveDList.cc
+   :lines: 190-199
+
+While this can be done directly with :code:`reinterpret_cast<>`, use of :code:`ts::ptr_cast` avoids
+typographic errors and warnings about type punning caused by :code:`-fstrict-aliasing`.
+
 Design Notes
 ************
 

--- a/lib/ts/IntrusiveDList.h
+++ b/lib/ts/IntrusiveDList.h
@@ -320,6 +320,47 @@ protected:
   size_t _count{0};           ///< # of elements in list.
 };
 
+namespace ts
+{
+/** Utility cast to change the underlying type of a pointer reference.
+ *
+ * This changes a reference to a pointer to @a P to a reference to a pointer to @a T. This is useful
+ * for intrusive links that are inherited. For instance
+ *
+ * @code
+ * class Thing { Thing* _next; ... }
+ * class BetterThing : public Thing { ... };
+ * @endcode
+ *
+ * To make @c BetterThing work with an intrusive container without making new link members,
+ *
+ * @code
+ * static BetterThing*& next_ptr(BetterThing* bt) { return ts::ptr_ref_cast<BetterThing>(_next); }
+ * @endcode
+ *
+ * This is both convenient and gets around aliasing warnings from the compiler that can arise from
+ * using @c reinterpret_cast.
+ *
+ * @tparam T The resulting pointer reference type.
+ * @tparam P The starting pointer reference type.
+ * @param p A reference to pointer to @a P.
+ * @return A reference to the same pointer memory of type @c T*&.
+ */
+template <typename T, typename P>
+T *&
+ptr_ref_cast(P *&p)
+{
+  union {
+    P **_p;
+    T **_t;
+  } u{&p};
+  return *(u._t);
+};
+
+} // namespace ts
+
+// --- Implementation ---
+
 template <typename L> IntrusiveDList<L>::const_iterator::const_iterator() {}
 
 template <typename L>

--- a/lib/ts/unit-tests/test_IntrusiveDList.cc
+++ b/lib/ts/unit-tests/test_IntrusiveDList.cc
@@ -156,9 +156,6 @@ TEST_CASE("IntrusiveDList Example", "[libts][IntrusiveDList]")
   // Destructor is checked for non-crashing as container goes out of scope.
 }
 
-// End of documentation example code.
-// --------------------
-
 struct Thing {
   Thing *_next{nullptr};
   Thing *_prev{nullptr};
@@ -193,12 +190,12 @@ public:
     static self_type *&
     next_ptr(self_type *t)
     {
-      return *reinterpret_cast<self_type **>(&t->_next);
+      return ts::ptr_ref_cast<self_type>(t->_next);
     }
     static self_type *&
     prev_ptr(self_type *t)
     {
-      return *reinterpret_cast<self_type **>(&t->_prev);
+      return ts::ptr_ref_cast<self_type>(t->_prev);
     }
   };
 
@@ -208,6 +205,10 @@ public:
     return _payload;
   }
 };
+
+// End of documentation example code.
+// If any lines above here are changed, the documentation must be updated.
+// --------------------
 
 using ThingList        = IntrusiveDList<Thing::Linkage>;
 using PrivateThingList = IntrusiveDList<PrivateThing::Linkage>;


### PR DESCRIPTION
This also avoids compiler complaints about aliasing violations, which is really the main reason I did this.