### PR TITLE
Plugins: Cleanup up dependencies on core headers - sslheaders

### DIFF
--- a/lib/cppapi/Transaction.cc
+++ b/lib/cppapi/Transaction.cc
@@ -398,7 +398,7 @@ void
 Transaction::redirectTo(std::string const &url)
 {
   // Must re-alloc the string locally because ownership is transferred to the transaction.
-  char * const buffer = static_cast<char *>(TSmalloc(url.size() + 1));
+  char *const buffer = static_cast<char *>(TSmalloc(url.size() + 1));
   memcpy(buffer, url.c_str(), url.size());
   buffer[url.size()] = '\0';
   TSHttpTxnRedirectUrlSet(state_->txn_, buffer, url.size());

--- a/plugins/experimental/sslheaders/expand.cc
+++ b/plugins/experimental/sslheaders/expand.cc
@@ -16,8 +16,8 @@
  * limitations under the License.
  */
 
+#include <array>
 #include "sslheaders.h"
-#include "ts/ink_defs.h"
 
 #include <openssl/x509.h>
 #include <openssl/pem.h>
@@ -70,16 +70,15 @@ x509_expand_serial(X509 *x509, BIO *bio)
 static void
 x509_expand_signature(X509 *x509, BIO *bio)
 {
-#ifndef HAVE_X509_GET0_SIGNATURE
-  const ASN1_BIT_STRING *sig = x509->signature;
-#else
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-#define X509_get0_signature(psig, palg, x) (X509_get0_signature(const_cast<ASN1_BIT_STRING **>(psig), (palg), (x)))
-#endif
   const ASN1_BIT_STRING *sig;
+#if OPENSSL_VERSION_NUMBER >= 0x010100000
   X509_get0_signature(&sig, nullptr, x509);
+#elif OPENSSL_VERSION_NUMBER >= 0x010002000
+  X509_get0_signature(const_cast<ASN1_BIT_STRING **>(&sig), nullptr, x509);
+#else
+  sig = x509->signature;
 #endif
-  const char *ptr = (const char *)sig->data;
+  const char *ptr = reinterpret_cast<const char *>(sig->data);
   const char *end = ptr + sig->length;
 
   // The canonical OpenSSL way to format the signature seems to be
@@ -106,7 +105,7 @@ x509_expand_notafter(X509 *x509, BIO *bio)
   ASN1_TIME_print(bio, time);
 }
 
-static const x509_expansion expansions[SSL_HEADERS_FIELD_MAX] = {
+static const std::array<x509_expansion, SSL_HEADERS_FIELD_MAX> expansions = {{
   x509_expand_none,        // SSL_HEADERS_FIELD_NONE
   x509_expand_certificate, // SSL_HEADERS_FIELD_CERTIFICATE
   x509_expand_subject,     // SSL_HEADERS_FIELD_SUBJECT
@@ -115,7 +114,7 @@ static const x509_expansion expansions[SSL_HEADERS_FIELD_MAX] = {
   x509_expand_signature,   // SSL_HEADERS_FIELD_SIGNATURE
   x509_expand_notbefore,   // SSL_HEADERS_FIELD_NOTBEFORE
   x509_expand_notafter,    // SSL_HEADERS_FIELD_NOTBEFORE
-};
+}};
 
 bool
 SslHdrExpandX509Field(BIO *bio, X509 *x509, ExpansionField field)
@@ -123,7 +122,7 @@ SslHdrExpandX509Field(BIO *bio, X509 *x509, ExpansionField field)
   // Rewind the BIO.
   (void)BIO_reset(bio);
 
-  if ((int)field < (int)countof(expansions)) {
+  if (field < expansions.size()) {
     expansions[field](x509, bio);
   }
 

--- a/plugins/experimental/sslheaders/util.cc
+++ b/plugins/experimental/sslheaders/util.cc
@@ -16,25 +16,29 @@
  * limitations under the License.
  */
 
+#include <array>
 #include "sslheaders.h"
 #include <memory>
-#include "ts/ink_defs.h"
 
 // Count of fields (not including SSL_HEADERS_FIELD_NONE).
 #define NUMFIELDS (SSL_HEADERS_FIELD_MAX - 1)
 
-static const struct _f {
+namespace
+{
+struct _f {
   const char *name;
   ExpansionField field;
-} fields[] = {
-  {"certificate", SSL_HEADERS_FIELD_CERTIFICATE}, {"subject", SSL_HEADERS_FIELD_SUBJECT},
-  {"issuer", SSL_HEADERS_FIELD_ISSUER},           {"serial", SSL_HEADERS_FIELD_SERIAL},
-  {"signature", SSL_HEADERS_FIELD_SIGNATURE},     {"notbefore", SSL_HEADERS_FIELD_NOTBEFORE},
-  {"notafter", SSL_HEADERS_FIELD_NOTAFTER},
 };
-
-// Static assert to guarantee the fields table is current.
-extern char assert_fields_are_populated[((sizeof(fields) / sizeof(fields[0])) - NUMFIELDS) == 0 ? 0 : -1];
+const std::array<_f, SSL_HEADERS_FIELD_MAX - 1> fields = {{
+  {"certificate", SSL_HEADERS_FIELD_CERTIFICATE},
+  {"subject", SSL_HEADERS_FIELD_SUBJECT},
+  {"issuer", SSL_HEADERS_FIELD_ISSUER},
+  {"serial", SSL_HEADERS_FIELD_SERIAL},
+  {"signature", SSL_HEADERS_FIELD_SIGNATURE},
+  {"notbefore", SSL_HEADERS_FIELD_NOTBEFORE},
+  {"notafter", SSL_HEADERS_FIELD_NOTAFTER},
+}};
+} // namespace
 
 bool
 SslHdrParseExpansion(const char *spec, SslHdrExpansion &exp)
@@ -74,7 +78,7 @@ SslHdrParseExpansion(const char *spec, SslHdrExpansion &exp)
 
   // Push sep to point to the field selector.
   selector = sep + 1;
-  for (unsigned i = 0; i < countof(fields); ++i) {
+  for (unsigned i = 0; i < fields.size(); ++i) {
     if (strcmp(selector, fields[i].name) == 0) {
       exp.field = fields[i].field;
       return true;


### PR DESCRIPTION
This cleans up the `sslheaders` plugin to not depend on `ink_defs.h`.

Depends on #4186.