### PR TITLE
G++ 8.1.1: Fix complaint about lack of storage definitiona for class static constant

### DIFF
--- a/proxy/http/remap/UrlRewrite.h
+++ b/proxy/http/remap/UrlRewrite.h
@@ -87,7 +87,7 @@ public:
     return _valid;
   };
 
-  static const int MAX_REGEX_SUBS = 10;
+  static constexpr int MAX_REGEX_SUBS = 10;
 
   struct RegexMapping {
     url_mapping *url_map;


### PR DESCRIPTION
Apparently this is a problem with g++ 8.1.1, which technically seems a correct diagnosis.