### PR TITLE
Back-port to 8.0.x - Log Collation Memory Leak

### DIFF
--- a/proxy/logging/LogHost.cc
+++ b/proxy/logging/LogHost.cc
@@ -302,8 +302,8 @@ LogHost::orphan_write_and_try_delete(LogBuffer *&lb)
     m_orphan_file->preproc_and_try_delete(lb);
   } else {
     Debug("log-host", "logging space exhausted, failed to write orphan file, drop(%" PRIu32 ") bytes", lb->header()->byte_count);
-    LogBuffer::destroy(lb);
   }
+  LogBuffer::destroy(lb);
 }
 
 void


### PR DESCRIPTION
There were two of these commits (two separate leaks) in master, but only one was back-ported to 8.0.x. So this is a separate PR for the missing second commit.