### PR TITLE
Allow enabling MPTCP on a listening socket through the records.config

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -609,6 +609,7 @@ HTTP Engine
    tr-in                       Inbound transparent.
    tr-out                      Outbound transparent.
    tr-pass                     Pass through enabled.
+   mptcp                       Multipath TCP.
    =========== =============== ========================================
 
 *number*
@@ -673,6 +674,11 @@ ip-resolve
    Set the :ts:cv:`host resolution style <proxy.config.hostdb.ip_resolve>` for transactions on this proxy port.
 
    Not compatible with: ``tr-out`` - this option requires a value of ``client;none`` which is forced and should not be explicitly specified.
+
+mptcp
+   Enable Multipath TCP on this proxy port.
+
+   Requires custom Linux kernel available at https://multipath-tcp.org.
 
 .. topic:: Example
 

--- a/lib/records/I_RecHttp.h
+++ b/lib/records/I_RecHttp.h
@@ -245,6 +245,8 @@ public:
   bool m_outbound_transparent_p;
   // True if transparent pass-through is enabled on this port.
   bool m_transparent_passthrough;
+  /// True if MPTCP is enabled on this port.
+  bool m_mptcp;
   /// Local address for inbound connections (listen address).
   IpAddr m_inbound_ip;
   /// Local address for outbound connections (to origin server).
@@ -395,6 +397,7 @@ public:
   static const char *const OPT_COMPRESSED;              ///< Compressed.
   static const char *const OPT_HOST_RES_PREFIX;         ///< Set DNS family preference.
   static const char *const OPT_PROTO_PREFIX;            ///< Transport layer protocols.
+  static const char *const OPT_MPTCP;                   ///< MPTCP.
 
   static std::vector<self> &m_global; ///< Global ("default") data.
 

--- a/lib/records/RecHttp.cc
+++ b/lib/records/RecHttp.cc
@@ -25,6 +25,7 @@
 #include <records/I_RecHttp.h>
 #include "tscore/ink_defs.h"
 #include "tscore/ink_hash_table.h"
+#include "tscore/TextBuffer.h"
 #include "tscore/Tokenizer.h"
 #include <strings.h>
 #include "tscore/ink_inet.h"
@@ -69,6 +70,22 @@ SessionProtocolSet HTTP_PROTOCOL_SET;
 SessionProtocolSet HTTP2_PROTOCOL_SET;
 SessionProtocolSet DEFAULT_NON_TLS_SESSION_PROTOCOL_SET;
 SessionProtocolSet DEFAULT_TLS_SESSION_PROTOCOL_SET;
+
+static bool
+mptcp_supported()
+{
+  ats_scoped_fd fd(::open("/proc/sys/net/mptcp/mptcp_enabled", O_RDONLY));
+  int value = 0;
+
+  if (fd) {
+    TextBuffer buffer(16);
+
+    buffer.slurp(fd.get());
+    value = atoi(buffer.bufPtr());
+  }
+
+  return value != 0;
+}
 
 void
 RecHttpLoadIp(const char *value_name, IpAddr &ip4, IpAddr &ip6)
@@ -130,6 +147,7 @@ const char *const HttpProxyPort::OPT_SSL                     = "ssl";
 const char *const HttpProxyPort::OPT_PLUGIN                  = "plugin";
 const char *const HttpProxyPort::OPT_BLIND_TUNNEL            = "blind";
 const char *const HttpProxyPort::OPT_COMPRESSED              = "compressed";
+const char *const HttpProxyPort::OPT_MPTCP                   = "mptcp";
 
 // File local constants.
 namespace
@@ -160,7 +178,8 @@ HttpProxyPort::HttpProxyPort()
     m_family(AF_INET),
     m_inbound_transparent_p(false),
     m_outbound_transparent_p(false),
-    m_transparent_passthrough(false)
+    m_transparent_passthrough(false),
+    m_mptcp(false)
 {
   memcpy(m_host_res_preference, host_res_default_preference_order, sizeof(m_host_res_preference));
 }
@@ -364,6 +383,12 @@ HttpProxyPort::processOptions(const char *opts)
 #else
       Warning("Transparent pass-through requested [%s] in port descriptor '%s' but TPROXY was not configured.", item, opts);
 #endif
+    } else if (0 == strcasecmp(OPT_MPTCP, item)) {
+      if (mptcp_supported()) {
+        m_mptcp = true;
+      } else {
+        Warning("Multipath TCP requested [%s] in port descriptor '%s' but it is not supported by this host.", item, opts);
+      }
     } else if (nullptr != (value = this->checkPrefix(item, OPT_HOST_RES_PREFIX, OPT_HOST_RES_PREFIX_LEN))) {
       this->processFamilyPreference(value);
       host_res_set_p = true;
@@ -539,6 +564,10 @@ HttpProxyPort::print(char *out, size_t n)
     zret += snprintf(out + zret, n - zret, ":%s", OPT_TRANSPARENT_INBOUND);
   } else if (m_outbound_transparent_p) {
     zret += snprintf(out + zret, n - zret, ":%s", OPT_TRANSPARENT_OUTBOUND);
+  }
+
+  if (m_mptcp) {
+    zret += snprintf(out + zret, n - zret, ":%s", OPT_MPTCP);
   }
 
   if (m_transparent_passthrough) {


### PR DESCRIPTION
This change allows to enable MPTCP on a listener socket. We check whether the running host has the necessary sysctl that indicates that the kernel has been built with the right support.

When the socket-option fails, we just log a message and gracefully continue.

P.S.: Multipath TCP is currently in a forked Linux Kernel at https://multipath-tcp.org.