### PR TITLE
Log deletion

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -2892,6 +2892,11 @@ Logging Configuration
 
    Enables (``1``) or disables (``0``) automatic deletion of rolled files.
 
+.. ts:cv:: CONFIG proxy.config.log.auto_delete_files_space_limits_mb STRING diags.log=500, traffic.out=500
+   :reloadable:
+
+   The string is comprised of log filename and its space limit pair separated by comma. For this example, diags.log and traffic.out are set with space limit of 500 MB.
+
 .. ts:cv:: CONFIG proxy.config.log.sampling_frequency INT 1
    :reloadable:
 

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -218,6 +218,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.diags.output.emergency", RECD_STRING, "L", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.diags.logfile", RECD_STRING, "diags.log", RECU_RESTART_TM, RR_REQUIRED, RECC_NULL, nullptr, RECA_NULL}
+   ,
   {RECT_CONFIG, "proxy.config.diags.logfile_perm", RECD_STRING, "rw-r--r--", RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
   // diags.log rotation, default is 0 (aka rolling turned off) to preserve compatibility

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1019,6 +1019,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.log.collation_host", RECD_STRING, nullptr, RECU_DYNAMIC, RR_NULL, RECC_STR, "^[^[:space:]]*$", RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.log.auto_delete_files_space_limits_mb", RECD_STRING, nullptr, RECU_DYNAMIC, RR_NULL, RECC_STR, "^[^[:space:]]*$", RECA_NULL}
+  ,
   {RECT_CONFIG, "proxy.config.log.collation_port", RECD_INT, "8085", RECU_DYNAMIC, RR_REQUIRED, RECC_INT, "[0-65535]", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.log.collation_secret", RECD_STRING, "foobar", RECU_DYNAMIC, RR_NULL, RECC_STR, ".*", RECA_NULL}

--- a/proxy/logging/LogConfig.cc
+++ b/proxy/logging/LogConfig.cc
@@ -232,16 +232,17 @@ LogConfig::read_configuration_variables()
 
   char *limits = REC_ConfigReadString("proxy.config.log.auto_delete_files_space_limits_mb");
   if (limits) {
-    TextView limits_view(limits);
+    ts::TextView limits_view(limits, strlen(limits));
     while (limits_view) {
-      TextView value(limits_view.take_prefix_at(','));
-      TextView key(value.trim(&isspace).split_prefix_at('=').rtrim(&isspace));
+      ts::TextView value(limits_view.take_prefix_at(','));
+      ts::TextView key(value.trim(' ').split_prefix_at('=').rtrim(' '));
       if (key) {
-        value.ltrim(&isspace);
+        value.ltrim(' ');
         // Build new LogDeletingInfo based on the [type]=[limit] pair
-        deleting_info.insert(new LogDeletingInfo(key, static_cast<int64_t>(ts::svtoi(value))));
+        deleting_info.insert(new LogDeletingInfo(key, static_cast<int64_t>(ts::svtoi(value)) * LOG_MEGABYTE));
       } else {
-        Warning("invalid key-value pair '%s' for '%s', skipping this pair", value.data(), "proxy.config.log.auto_delete_files_space_limits_mb");
+        Warning("invalid key-value pair '%s' for '%s', skipping this pair", value.data(),
+                "proxy.config.log.auto_delete_files_space_limits_mb");
       }
     }
     ats_free(limits);
@@ -730,7 +731,7 @@ LogConfig::update_space_used()
     return;
   }
 
-  int i, total_candidate_count;
+  int total_candidate_count;
   int64_t total_space_used, partition_space_left;
   char path[MAXPATHLEN];
   int sret;
@@ -771,8 +772,8 @@ LogConfig::update_space_used()
     return;
   }
 
-  total_space_used = 0LL;
-  total_candidate_count  = 0;
+  total_space_used      = 0LL;
+  total_candidate_count = 0;
 
   while ((entry = readdir(ld))) {
     snprintf(path, MAXPATHLEN, "%s/%s", logfile_dir, entry->d_name);
@@ -783,9 +784,9 @@ LogConfig::update_space_used()
 
       if (auto_delete_rolled_files && LogFile::rolled_logfile(entry->d_name) && total_candidate_count < MAX_CANDIDATES) {
         //
-        // then add this entry to the candidate list
+        // then check if the candidate belongs to any given log types with allowable space
         //
-        int len = strchr(strchr(entry->d_name, '.')+1, '.') - entry->d_name;
+        int len = strchr(strchr(entry->d_name, '.') + 1, '.') - entry->d_name;
         std::string type_name(entry->d_name, len);
         auto iter = deleting_info.find(type_name);
         if (iter == deleting_info.end()) {
@@ -793,8 +794,10 @@ LogConfig::update_space_used()
           break;
         }
 
-        auto &candidates = iter->candidates;
-        auto &candidate_count = iter->candidate_count;
+        // then add the candidate to the given log type's list
+        // and update related size/count
+        auto &candidates                  = iter->candidates;
+        auto &candidate_count             = iter->candidate_count;
         candidates[candidate_count].name  = ats_strdup(path);
         candidates[candidate_count].size  = (int64_t)sbuf.st_size;
         candidates[candidate_count].mtime = sbuf.st_mtime;
@@ -836,6 +839,12 @@ LogConfig::update_space_used()
   // we might consider deleting some files that are stored in the
   // candidate array.
   //
+  // The decision will be made based on ratio between max space allowed
+  // for each file type configured by
+  // "proxy.config.log.auto_delete_files_max_space_mb" and
+  // total size of existing log files. Once the type of log files to
+  // remove is decided, we try to delete the oldest file.
+  //
   // To delete oldest files first, we'll sort our candidate array by
   // timestamps, making the oldest files first in the array (thus first
   // selected).
@@ -848,7 +857,8 @@ LogConfig::update_space_used()
     Debug("logspace", "headroom reached, trying to clear space ...");
     Debug("logspace", "sorting %d delete candidates ...", total_candidate_count);
     for (auto iter = deleting_info.begin(); iter != deleting_info.end(); iter++) {
-      qsort(iter->candidates, iter->candidate_count, sizeof(LogDeleteCandidate), (int (*)(const void *, const void *))delete_candidate_compare);
+      qsort(iter->candidates, iter->candidate_count, sizeof(LogDeleteCandidate),
+            (int (*)(const void *, const void *))delete_candidate_compare);
     }
 
     while (total_candidate_count > 0) {
@@ -856,16 +866,19 @@ LogConfig::update_space_used()
         Debug("logspace", "low water mark reached; stop deleting");
         break;
       }
+
       // Select the group with biggest ratio
-      auto target = std::max_element(deleting_info.begin(), deleting_info.end(),
-        [](LogDeletingInfo A, LogDeletingInfo B){
-          double diff = static_cast<double>(A.total_size)/A.space_limit_mb - static_cast<double>(B.total_size)/B.space_limit_mb;
-          return diff > 0.0;
-        } );
+      auto target = std::max_element(deleting_info.begin(), deleting_info.end(), [](LogDeletingInfo A, LogDeletingInfo B) {
+        double diff = static_cast<double>(A.total_size) / A.space_limit_mb - static_cast<double>(B.total_size) / B.space_limit_mb;
+        return diff < 0.0;
+      });
 
       auto &candidates = target->candidates;
-      auto &victim = target->victim;
+      auto &victim     = target->victim;
+
+      // Check if all candidates are already unlinked
       if (victim >= target->candidate_count) {
+        // This shouldn't be triggered unless we didn't configure allowable space for all types
         Debug("logspace", "No more victims for log type %s", target->name.c_str());
       }
       Debug("logspace", "auto-deleting %s", candidates[victim].name);
@@ -879,10 +892,13 @@ LogConfig::update_space_used()
               "The rolled logfile, %s, was auto-deleted; "
               "%" PRId64 " bytes were reclaimed.",
               candidates[victim].name, candidates[victim].size);
+
+        // update space after successful unlink
         m_space_used -= candidates[victim].size;
         m_partition_space_left += candidates[victim].size;
         target->total_size -= candidates[victim].size;
       }
+      // Update total candidates and victim
       total_candidate_count--;
       victim++;
     }

--- a/proxy/logging/LogConfig.h
+++ b/proxy/logging/LogConfig.h
@@ -81,10 +81,6 @@ struct LogDeleteCandidate {
   time_t mtime;
   char *name;
   int64_t size;
-  ~LogDeleteCandidate() {
-    if (name)
-      ats_free(name);
-  }
 };
 
 struct LogDeletingInfo {
@@ -99,6 +95,15 @@ struct LogDeletingInfo {
   LogDeletingInfo *_prev{nullptr};
 
   LogDeletingInfo(std::string_view type, int64_t limit) : name(type), space_limit_mb(limit) {}
+  LogDeletingInfo::clear() {
+    victim = 0;
+    total_size = 0LL;
+    for (int i = 0; i < candidate_count; i++) {
+      if (candidates[i].name)
+        ats_free(candidates[i].name);
+    }
+    candidate_count = 0;
+  }
 };
 
 struct LogDeletingInfoDescriptor {

--- a/proxy/logging/LogConfig.h
+++ b/proxy/logging/LogConfig.h
@@ -95,8 +95,10 @@ struct LogDeletingInfo {
   LogDeletingInfo *_prev{nullptr};
 
   LogDeletingInfo(std::string_view type, int64_t limit) : name(type), space_limit_mb(limit) {}
-  LogDeletingInfo::clear() {
-    victim = 0;
+  void
+  clear()
+  {
+    victim     = 0;
     total_size = 0LL;
     for (int i = 0; i < candidate_count; i++) {
       if (candidates[i].name)
@@ -107,15 +109,35 @@ struct LogDeletingInfo {
 };
 
 struct LogDeletingInfoDescriptor {
-  using key_type = std::string_view;
+  using key_type   = std::string_view;
   using value_type = LogDeletingInfo;
 
-  static key_type key_of(value_type *value) { return value->name; }
-  static bool equal(key_type const &lhs, key_type const &rhs) { return lhs == rhs; }
-  static value_type *& next_ptr(value_type *value) { return value->_next; }
-  static value_type *& prev_ptr(value_type *value) { return value->_prev; }
+  static key_type
+  key_of(value_type *value)
+  {
+    return value->name;
+  }
+  static bool
+  equal(key_type const &lhs, key_type const &rhs)
+  {
+    return lhs == rhs;
+  }
+  static value_type *&
+  next_ptr(value_type *value)
+  {
+    return value->_next;
+  }
+  static value_type *&
+  prev_ptr(value_type *value)
+  {
+    return value->_prev;
+  }
   static constexpr std::hash<std::string_view> hasher{};
-  static auto hash_of(key_type s) -> decltype(hasher(s)) { return hasher(s); }
+  static auto
+  hash_of(key_type s) -> decltype(hasher(s))
+  {
+    return hasher(s);
+  }
 };
 
 /*-------------------------------------------------------------------------
@@ -277,6 +299,3 @@ private:
 /*-------------------------------------------------------------------------
   LogDeleteCandidate
   -------------------------------------------------------------------------*/
-
-
-

--- a/proxy/logging/LogConfig.h
+++ b/proxy/logging/LogConfig.h
@@ -89,7 +89,7 @@ struct LogDeleteCandidate {
 
 struct LogDeletingInfo {
   std::string name;
-  int rolling_size_mb{0};
+  int64_t space_limit_mb{0};
   int candidate_count{0};
   int victim{0};
   int64_t total_size{0LL};
@@ -97,6 +97,8 @@ struct LogDeletingInfo {
 
   LogDeletingInfo *_next{nullptr};
   LogDeletingInfo *_prev{nullptr};
+
+  LogDeletingInfo(std::string_view type, int64_t limit) : name(type), space_limit_mb(limit) {}
 };
 
 struct LogDeletingInfoDescriptor {


### PR DESCRIPTION
Small logs that rotate more frequently are wiped out and the loss of diagnostic logs make it harder to debug. This pull request brings a new deletion mechanism with a config option of max space allowed for all types of log files. (`proxy.config.log.auto_delete_files_max_space_mb`)

The deletion will happen on the oldest file from the log type with biggest ratio=(total size used by the type)/(max space allowed for the type). Log types that are not configured with the max space allowed will not be considered for deletion. (If the config option is empty, then traffic server won't delete any files.)