### PR TITLE
Disable the HttpSM half open logic if the underlying transport is TLS

### DIFF
--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -76,6 +76,13 @@ public:
   void do_io_shutdown(ShutdownHowTo_t howto) override;
   void reenable(VIO *vio) override;
 
+  bool
+  allow_half_open()
+  {
+    // Only allow half open connections if the not over TLS
+    return (client_vc && dynamic_cast<SSLNetVConnection *>(client_vc) == nullptr);
+  }
+
   void
   set_half_close_flag(bool flag) override
   {

--- a/proxy/http/Http1ClientTransaction.cc
+++ b/proxy/http/Http1ClientTransaction.cc
@@ -71,5 +71,10 @@ Http1ClientTransaction::transaction_done()
 bool
 Http1ClientTransaction::allow_half_open() const
 {
-  return current_reader ? current_reader->t_state.txn_conf->allow_half_open > 0 : true;
+  bool config_allows_it = (current_reader) ? current_reader->t_state.txn_conf->allow_half_open > 0 : true;
+  if (config_allows_it) {
+    // Check with the session to make sure the underlying transport allows the half open scenario
+    return static_cast<Http1ClientSession *>(parent)->allow_half_open();
+  }
+  return false;
 }


### PR DESCRIPTION
Jeremy and @pbchou reported having a TLS client send a client-notify and FIN but ATS would continue sending data back.  This sounded like a bad side effect of the half-open logic in HttpSM.  If the underlying protocol is just TCP it could be legitimate to sending back traffic after the client sends a FIN.  The client may still be listening.  But if the underlying protocol is TLS, this half-open scenario makes no sense.

For HTTP2, we always disable the HttpSM half open logic.  This PR extends that logic for HTTP1 if the client_vc is a SSLNetVConn.

Jermey did some initial testing with a patch against 7.1.x and this solves the problem.   The patch is a little different for master since that already includes the setting to turn of the half open logic entirely.