### PR TITLE
Fix a regression in the traffic_ctl host status subcommand. 

### DIFF
--- a/proxy/HostStatus.h
+++ b/proxy/HostStatus.h
@@ -84,13 +84,13 @@ struct HostStatus {
   void setHostStatus(const char *name, const HostStatus_t status, const unsigned int down_time, const char *reason);
   HostStatus_t getHostStatus(const char *name);
   void createHostStat(const char *name);
+  int getHostStatId(const char *name);
 
 private:
   int next_stat_id = 1;
   HostStatus();
   HostStatus(const HostStatus &obj) = delete;
   HostStatus &operator=(HostStatus const &) = delete;
-  int getHostStatId(const char *name);
 
   InkHashTable *hosts_statuses;  // next hop status, key is hostname or ip string, data is bool (available).
   InkHashTable *hosts_stats_ids; // next hop stat ids, key is hostname or ip string, data is int stat id.

--- a/src/traffic_ctl/host.cc
+++ b/src/traffic_ctl/host.cc
@@ -37,14 +37,17 @@ status_get(unsigned argc, const char **argv)
     TSMgmtError error;
     std::string str = stat_prefix + file_arguments[i];
 
-    error = record.fetch(str.c_str());
-    if (error != TS_ERR_OKAY) {
-      CtrlMgmtError(error, "failed to fetch %s", file_arguments[i]);
-      return CTRL_EX_ERROR;
-    }
+    for (const char *_reason_tag : Reasons::reasons) {
+      std::string _stat = str + "_" + _reason_tag;
+      error             = record.fetch(_stat.c_str());
+      if (error != TS_ERR_OKAY) {
+        CtrlMgmtError(error, "failed to fetch %s", file_arguments[i]);
+        return CTRL_EX_ERROR;
+      }
 
-    if (REC_TYPE_IS_STAT(record.rclass())) {
-      printf("%s %s\n", record.name(), CtrlMgmtRecordValue(record).c_str());
+      if (REC_TYPE_IS_STAT(record.rclass())) {
+        printf("%s %s\n", record.name(), CtrlMgmtRecordValue(record).c_str());
+      }
     }
   }
 

--- a/src/traffic_server/HostStatus.cc
+++ b/src/traffic_server/HostStatus.cc
@@ -44,6 +44,7 @@ mgmt_host_status_up_callback(void *x, char *data, int len)
   MgmtMarshallString name;
   MgmtMarshallInt down_time;
   MgmtMarshallString reason;
+  std::string reason_stat;
   static const MgmtMarshallType fields[] = {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING, MGMT_MARSHALL_STRING, MGMT_MARSHALL_INT};
   Debug("host_statuses", "%s:%s:%d - data: %s, len: %d\n", __FILE__, __func__, __LINE__, data, len);
 
@@ -55,6 +56,9 @@ mgmt_host_status_up_callback(void *x, char *data, int len)
   if (data != nullptr) {
     Debug("host_statuses", "marking up server %s", data);
     HostStatus &hs = HostStatus::instance();
+    if (hs.getHostStatId(reason_stat.c_str()) == -1) {
+      hs.createHostStat(name);
+    }
     hs.setHostStatus(name, HostStatus_t::HOST_STATUS_UP, down_time, reason);
   }
   return nullptr;
@@ -67,6 +71,7 @@ mgmt_host_status_down_callback(void *x, char *data, int len)
   MgmtMarshallString name;
   MgmtMarshallInt down_time;
   MgmtMarshallString reason;
+  std::string reason_stat;
   static const MgmtMarshallType fields[] = {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING, MGMT_MARSHALL_STRING, MGMT_MARSHALL_INT};
   Debug("host_statuses", "%s:%s:%d - data: %s, len: %d\n", __FILE__, __func__, __LINE__, data, len);
 
@@ -79,6 +84,9 @@ mgmt_host_status_down_callback(void *x, char *data, int len)
   if (data != nullptr) {
     Debug("host_statuses", "marking down server %s", name);
     HostStatus &hs = HostStatus::instance();
+    if (hs.getHostStatId(reason_stat.c_str()) == -1) {
+      hs.createHostStat(name);
+    }
     hs.setHostStatus(name, HostStatus_t::HOST_STATUS_DOWN, down_time, reason);
   }
   return nullptr;


### PR DESCRIPTION
the traffic_ctl host status subcommand was unable to fetch the proper status stats as the reason tag was not used in the search.  This fixes the problem so that host status is now found for all reason tags.

Should also be backported to 8.0