### PR TITLE
Clarifies code comment for DL_Emergency

### DIFF
--- a/lib/ts/Diags.h
+++ b/lib/ts/Diags.h
@@ -69,7 +69,7 @@ enum DiagsLevel { // do not renumber --- used as array index
   DL_Error,       // process does not die
   DL_Fatal,       // causes process termination
   DL_Alert,       // causes process termination
-  DL_Emergency,   // causes process termination
+  DL_Emergency,   // causes process termination, exits with UNRECOVERABLE_EXIT
   DL_Undefined    // must be last, used for size!
 };
 


### PR DESCRIPTION
Asking for backport ONLY IF #4145 makes it into 8.x. Reason is that it uses `Emergency` and so we should clarify its purpose.