### PR TITLE
Fix storage.config path issue for runroot

### DIFF
--- a/iocore/cache/Store.cc
+++ b/iocore/cache/Store.cc
@@ -391,12 +391,7 @@ Store::read_config()
       }
     }
 
-    std::string pp;
-    if (get_runroot().empty()) {
-      pp = Layout::get()->relative(path);
-    } else {
-      pp = Layout::get()->cachedir;
-    }
+    std::string pp = Layout::get()->relative(path);
 
     ns = new Span;
     Debug("cache_init", "Store::read_config - ns = new Span; ns->init(\"%s\",%" PRId64 "), forced volume=%d%s%s", pp.c_str(), size,


### PR DESCRIPTION
We want to switch back to the old logic and make people to change `storage.config` for runroot themselves.