### PR TITLE
header_rewrite: Removes deprecated %{CLIENT-IP} condition

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -175,17 +175,6 @@ header operated on by this condition will be a comma separated string of the
 values from every occurrence of the header. More details are provided in
 `Repeated Headers`_ below.
 
-CLIENT-IP
-~~~~~~~~~
-::
-
-    cond %{CLIENT-IP} <operand>
-
-Remote IP address, as a string, of the client connection for the current
-transaction.
-
-This condition is *deprecated* as of ATS v7.1.x, please use `%{INBOUND:REMOTE-ADDR}` instead.
-
 CLIENT-URL
 ~~~~~~~~~~
 ::

--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -584,38 +584,6 @@ ConditionInternalTxn::eval(const Resources &res)
 }
 
 void
-ConditionClientIp::initialize(Parser &p)
-{
-  Condition::initialize(p);
-
-  MatcherType *match = new MatcherType(_cond_op);
-
-  match->set(p.get_arg());
-  _matcher = match;
-}
-
-bool
-ConditionClientIp::eval(const Resources &res)
-{
-  std::string s;
-
-  append_value(s, res);
-  TSDebug(PLUGIN_NAME, "Evaluating CLIENT-IP()");
-
-  return static_cast<MatcherType *>(_matcher)->test(s);
-}
-
-void
-ConditionClientIp::append_value(std::string &s, const Resources &res)
-{
-  char ip[INET6_ADDRSTRLEN];
-
-  if (getIP(TSHttpTxnClientAddrGet(res.txnp), ip)) {
-    s += ip;
-  }
-}
-
-void
 ConditionIp::initialize(Parser &p)
 {
   Condition::initialize(p);

--- a/plugins/header_rewrite/conditions.h
+++ b/plugins/header_rewrite/conditions.h
@@ -376,18 +376,6 @@ private:
   IpQualifiers _ip_qual;
 };
 
-class ConditionClientIp : public Condition
-{
-  typedef Matchers<std::string> MatcherType;
-
-public:
-  void initialize(Parser &p) override;
-  void append_value(std::string &s, const Resources &res) override;
-
-protected:
-  bool eval(const Resources &res) override;
-};
-
 class ConditionIncomingPort : public Condition
 {
   typedef Matchers<uint16_t> MatcherType;

--- a/plugins/header_rewrite/factory.cc
+++ b/plugins/header_rewrite/factory.cc
@@ -127,10 +127,6 @@ condition_factory(const std::string &cond)
     c = new ConditionInternalTxn();
   } else if (c_name == "IP") {
     c = new ConditionIp();
-  } else if (c_name == "CLIENT-IP") {
-    TSDebug(PLUGIN_NAME, "\tWARNING: configuration uses deprecated condition, CLIENT-IP()");
-    TSError("warning: CLIENT-IP() is deprecated, use %%{IP:CLIENT} instead");
-    c = new ConditionClientIp();
   } else if (c_name == "INCOMING-PORT") {
     c = new ConditionIncomingPort();
   } else if (c_name == "METHOD") {


### PR DESCRIPTION
This was deprecated in 7.1.x