### PR TITLE
Runroot: Fix a issue caused by restructured headers

### DIFF
--- a/src/traffic_layout/file_system.cc
+++ b/src/traffic_layout/file_system.cc
@@ -243,7 +243,8 @@ ts_copy_function(const char *src_path, const struct stat *sb, int flag)
     }
     if (copy_dir == LAYOUT_INCLUDEDIR) {
       // check if include file is contained in atscppapi/ and ts/. If not, end the copying.
-      if (dst_path.find("/atscppapi/") == std::string::npos && dst_path.find("/ts/") == std::string::npos) {
+      if (dst_path.find("/atscppapi/") == std::string::npos && dst_path.find("/ts/") == std::string::npos &&
+          dst_path.find("/tscpp/") == std::string::npos) {
         break;
       }
     }


### PR DESCRIPTION
``include/tscpp`` is added.