### PR TITLE
turn the logging.config binding into a static LogConfig entity

### DIFF
--- a/proxy/logging/LogConfig.cc
+++ b/proxy/logging/LogConfig.cc
@@ -263,11 +263,10 @@ LogConfig::read_configuration_variables()
 
 static BindingInstance *binding = nullptr;
 
-static
-void
+static void
 setup_bindings()
 {
-   if (nullptr == binding) {
+  if (nullptr == binding) {
     binding = new BindingInstance;
     ink_assert(nullptr != binding);
 


### PR DESCRIPTION
A fix to make sure that a single reusable lua context is opened and used for logging.config