### PR TITLE
If the stream is closing don't send a responding ping.

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1745,6 +1745,11 @@ Http2ConnectionState::send_ping_frame(Http2StreamId id, uint8_t flag, const uint
 {
   Http2StreamDebug(ua_session, id, "Send PING frame");
 
+  // If the connection is the process of shutting down, do not send ping response
+  if (is_state_closed()) {
+    return;
+  }
+
   Http2Frame ping(HTTP2_FRAME_TYPE_PING, id, flag);
 
   ping.alloc(buffer_size_index[HTTP2_FRAME_TYPE_PING]);


### PR DESCRIPTION
On the install of a recent build, I saw the following stack 4 times within a relatively short amount of time.  I've been running with this fix since then and haven't noticed any problems.  I'm curious why I haven't seen this before.  It could be a malformed/malicious client suddenly appeared?  In any case, not sending a responding ping if the HTTP/2 session is shutting down seems reasonable

```
(gdb) bt
#0  0x00002aec07e931d7 in raise () from /lib64/libc.so.6
#1  0x00002aec07e948c8 in abort () from /lib64/libc.so.6
#2  0x00002aec05d2036b in ink_abort (message_format=message_format@entry=0x2aec05d3d8cf "%s:%d: failed assertion `%s`") at ink_error.cc:99
#3  0x00002aec05d1de65 in _ink_assert (expression=expression@entry=0x7ebd9b "false", file=file@entry=0x7b4518 "ProxyClientSession.cc", line=line@entry=165) at ink_assert.cc:37
#4  0x0000000000511864 in ProxyClientSession::state_api_callout (this=0x2af27eeb0d50, event=<optimized out>, data=<optimized out>) at ProxyClientSession.cc:165
#5  0x000000000061b66a in Http2ConnectionState::send_ping_frame (this=this@entry=0x2af27eeb0ff0, id=id@entry=0, flag=flag@entry=1 '\001', opaque_data=opaque_data@entry=0x2aec113005b0 "") at Http2ConnectionState.cc:1752
#6  0x000000000061e9ba in rcv_ping_frame (cstate=..., frame=...) at Http2ConnectionState.cc:622
#7  0x0000000000622389 in Http2ConnectionState::main_event_handler (this=0x2af27eeb0ff0, event=<optimized out>, edata=<optimized out>) at Http2ConnectionState.cc:938
#8  0x0000000000615ee9 in send_connection_event (cont=cont@entry=0x2af27eeb0ff0, event=event@entry=2253, edata=edata@entry=0x2aec11300720) at Http2ClientSession.cc:58
#9  0x00000000006160d8 in Http2ClientSession::do_complete_frame_read (this=this@entry=0x2af27eeb0d50) at Http2ClientSession.cc:514
#10 0x00000000006166e1 in Http2ClientSession::state_process_frame_read (this=this@entry=0x2af27eeb0d50, event=event@entry=100, vio=vio@entry=0x2aee481b8438, inside_frame=inside_frame@entry=false) at Http2ClientSession.cc:551
#11 0x000000000061696f in Http2ClientSession::state_start_frame_read (this=0x2af27eeb0d50, event=100, edata=0x2aee481b8438) at Http2ClientSession.cc:444
#12 0x0000000000616fab in Http2ClientSession::main_event_handler (this=0x2af27eeb0d50, event=100, edata=0x2aee481b8438) at Http2ClientSession.cc:330
#13 0x00000000006123fd in Http2ClientSession::state_read_connection_preface (this=0x2af27eeb0d50, event=<optimized out>, edata=0x2aee481b8438) at Http2ClientSession.cc:424
#14 0x0000000000616fab in Http2ClientSession::main_event_handler (this=0x2af27eeb0d50, event=100, edata=0x2aee481b8438) at Http2ClientSession.cc:330
#15 0x0000000000772533 in read_signal_and_update (vc=0x2aee481b82e0, vc@entry=0x1, event=event@entry=100) at UnixNetVConnection.cc:144
#16 UnixNetVConnection::readSignalAndUpdate (this=this@entry=0x2aee481b82e0, event=event@entry=100) at UnixNetVConnection.cc:1102
#17 0x000000000074bc22 in SSLNetVConnection::net_read_io (this=0x2aee481b82e0, nh=0x2aec0a9b2cf0, lthread=0x2aec0a9af010) at SSLNetVConnection.cc:608
#18 0x0000000000764d7e in NetHandler::waitForActivity (this=0x2aec0a9b2cf0, timeout=<optimized out>) at UnixNet.cc:497
#19 0x00000000007a0ce9 in EThread::execute_regular (this=0x2aec0a9af010) at UnixEThread.cc:273
#20 0x000000000079f342 in spawn_thread_internal (a=0x2811f40) at Thread.cc:85
#21 0x00002aec07226dc5 in start_thread () from /lib64/libpthread.so.0
#22 0x00002aec07f5576d in clone () from /lib64/libc.so.6
```

The assert is because ProxyClientSession::state_api_callout did not expect a XMIT_EVENT.  Since the Http2CientSession was in the process of shutting down (had received a fini event and was running the SESSION_CLOSE hooks) it shouldn't be sending out any new frames.
