### PR TITLE
Set log code when closing half open connections.

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -870,6 +870,7 @@ HttpSM::state_watch_for_client_abort(int event, void *data)
       ua_entry = nullptr;
       tunnel.kill_tunnel();
       terminate_sm = true; // Just die already, the requester is gone
+      set_ua_abort(HttpTransact::ABORTED, event);
     }
     break;
   }


### PR DESCRIPTION
Since we now disallow half open connections for HTTP1/TLS we need
to set the log code when we close these connections so that
the 'crc' code is ERR_CLIENT_ABORT rather than ERR_UNKNOWN.