### PR TITLE
Ensure NOFILES ulimit is set high

### DIFF
--- a/rc/trafficserver.in
+++ b/rc/trafficserver.in
@@ -292,6 +292,10 @@ rc_start_hook()
     return $?
 }
 
+# Make sure the NOFILES limit is set high in case this process is not 
+# started from a logged in prompt
+ulimit -n 5000000
+
 # main
 case "$1" in
     start)


### PR DESCRIPTION
If script is not started from a pam process, the system limits are not set.

Issue is described in https://superuser.com/questions/454465/make-ulimits-work-with-start-stop-daemon

We see this problem in our environment when Traffic Server is auto started after system reboot.