### PR TITLE
ts_file: Fix test file location for out of tree build.

### DIFF
--- a/src/tscore/unit_tests/test_ts_file.cc
+++ b/src/tscore/unit_tests/test_ts_file.cc
@@ -47,12 +47,12 @@ TEST_CASE("ts_file", "[libts][ts_file]")
 
 TEST_CASE("ts_file_io", "[libts][ts_file_io]")
 {
-  path file("unit_tests/test_ts_file.cc");
+  path file("test_tscore");
   std::error_code ec;
   std::string content = ts::file::load(file, ec);
   REQUIRE(ec.value() == 0);
   REQUIRE(content.size() > 0);
-  REQUIRE(content.find("ts::file::path") != content.npos);
+  REQUIRE(content.find("progdir") != content.npos);
 
   // Check some file properties.
   REQUIRE(ts::file::is_readable(file) == true);


### PR DESCRIPTION
This fixes the unit tests which depended on a file in the source directory. This now depends on the test executable script, which must be there if the test is running.