### PR TITLE
Test: Fix issues with new Catch unit tests

### DIFF
--- a/src/tscore/unit_tests/test_Map.cc
+++ b/src/tscore/unit_tests/test_Map.cc
@@ -155,11 +155,14 @@ TEST_CASE("test Map", "[libts][Map]")
     to_delete.push_back(item);
   }
 
+  int failures = 0;
   for (uint32_t i = 1; i <= N; ++i) {
     Table::Location l = t.find(i);
-    REQUIRE(l.isValid());
-    REQUIRE(i == l->_value);
+    if (!l.isValid() || i != l->_value) {
+      failures++;
+    }
   }
+  REQUIRE(failures == 0);
 
   REQUIRE(!(t.find(N * 2).isValid()));
 
@@ -180,20 +183,30 @@ TEST_CASE("test Map", "[libts][Map]")
     t.remove(i);
   }
 
+  failures = 0;
   for (uint32_t i = 1; i <= N; ++i) {
     Table::Location l = t.find(i);
     if (1 & i) {
-      REQUIRE(!l.isValid());
+      if (l.isValid()) {
+        failures++;
+      }
     } else {
-      REQUIRE(l.isValid());
+      if (!l.isValid()) {
+        failures++;
+      }
     }
   }
+  REQUIRE(failures == 0);
 
-  int n = 0;
+  int n    = 0;
+  failures = 0;
   for (Table::iterator spot = t.begin(), limit = t.end(); spot != limit; ++spot) {
     ++n;
-    REQUIRE((spot->_value & 1) == 0);
+    if ((spot->_value & 1) != 0) {
+      failures++;
+    }
   }
+  REQUIRE(failures == 0);
   REQUIRE(n == N / 2);
 
   for (auto it : to_delete) {

--- a/src/tscore/unit_tests/test_Vec.cc
+++ b/src/tscore/unit_tests/test_Vec.cc
@@ -221,10 +221,14 @@ TEST_CASE("test append", "[Vec]")
   str.clear();
   REQUIRE(str.length() == 0);
 
+  int failures = 0;
   for (unsigned i = 0; i < 1000; ++i) {
     str.append(value, len);
-    REQUIRE(memcmp(&str[i * len], value, len) == 0);
+    if (memcmp(&str[i * len], value, len) != 0) {
+      failures++;
+    }
   }
+  REQUIRE(failures == 0);
 
   REQUIRE(str.length() == 1000 * len);
 }
@@ -270,7 +274,6 @@ TEST_CASE("test basic", "[libts][Vec]")
     t += (int)(intptr_t)v.v[i];
   }
   REQUIRE(t == 999 * 500);
-  printf("%zu %zu\n", v.n, v.i);
 
   Intervals in;
   in.insert(1);
@@ -320,19 +323,26 @@ TEST_CASE("test sort", "[libts][Vec]")
     v.add(reinterpret_cast<void *>(static_cast<intptr_t>(((i * 149) % 1000) + 1)));
   }
   v.qsort(&compare);
+  int failures = 0;
   for (int i = 0; i < 1000; ++i) {
-    REQUIRE(reinterpret_cast<void *>(static_cast<intptr_t>(i + 1)) == v[i]);
+    if (reinterpret_cast<void *>(static_cast<intptr_t>(i + 1)) != v[i]) {
+      failures++;
+    }
   }
+  REQUIRE(failures == 0);
 
   v.clear();
   for (long i = 1; i <= 1000000; ++i) {
     v.add(reinterpret_cast<void *>(static_cast<intptr_t>(((i * 51511) % 1000000) + 1)));
   }
   v.qsort(&compare);
-
+  failures = 0;
   for (long i = 0; i < 1000000; ++i) {
-    REQUIRE(reinterpret_cast<void *>(static_cast<intptr_t>(i + 1)) == v[i]);
+    if (reinterpret_cast<void *>(static_cast<intptr_t>(i + 1)) != v[i]) {
+      failures++;
+    }
   }
+  REQUIRE(failures == 0);
 
   v.clear();
   for (long i = 1; i <= 1000000; ++i) {
@@ -340,10 +350,13 @@ TEST_CASE("test sort", "[libts][Vec]")
     v.add(reinterpret_cast<void *>(static_cast<intptr_t>(((i * 199999) % 500000) + 1)));
   }
   v.qsort(&compare);
-
+  failures = 0;
   for (long i = 0; i < 1000000; ++i) {
-    REQUIRE(reinterpret_cast<void *>(static_cast<intptr_t>((i / 2) + 1)) == v[i]);
+    if (reinterpret_cast<void *>(static_cast<intptr_t>((i / 2) + 1)) != v[i]) {
+      failures++;
+    }
   }
+  REQUIRE(failures == 0);
 
   // Very long array, already sorted. This is what broke before.
   v.clear();
@@ -351,9 +364,13 @@ TEST_CASE("test sort", "[libts][Vec]")
     v.add(reinterpret_cast<void *>(static_cast<intptr_t>(i)));
   }
   v.qsort(&compare);
+  failures = 0;
   for (long i = 0; i < 10000000; ++i) {
-    REQUIRE(reinterpret_cast<void *>(static_cast<intptr_t>(i + 1)) == v[i]);
+    if (reinterpret_cast<void *>(static_cast<intptr_t>(i + 1)) != v[i]) {
+      failures++;
+    }
   }
+  REQUIRE(failures == 0);
 
   // very long, reverse sorted.
   v.clear();
@@ -361,7 +378,11 @@ TEST_CASE("test sort", "[libts][Vec]")
     v.add(reinterpret_cast<void *>(static_cast<intptr_t>(i)));
   }
   v.qsort(&compare);
+  failures = 0;
   for (long i = 0; i < 10000000; ++i) {
-    REQUIRE(reinterpret_cast<void *>(static_cast<intptr_t>(i + 1)) == v[i]);
+    if (reinterpret_cast<void *>(static_cast<intptr_t>(i + 1)) != v[i]) {
+      failures++;
+    }
   }
+  REQUIRE(failures == 0);
 }

--- a/src/tscore/unit_tests/test_arena.cc
+++ b/src/tscore/unit_tests/test_arena.cc
@@ -71,14 +71,18 @@ TEST_CASE("test arena", "[libts][arena]")
       fill_test_data(test_regions[j], test_size, j);
     }
 
+    int failures = 0;
     // Now check to make sure the data is correct
     for (j = 0; j < regions_to_test; j++) {
       char a = 'a' + (j % 52);
       for (int k = 0; k < test_size; k++) {
-        REQUIRE(test_regions[j][k] == a);
+        if (test_regions[j][k] != a) {
+          failures++;
+        }
         a = (a + 1) % 52;
       }
     }
+    REQUIRE(failures == 0);
     // Now free the regions
     for (j = 0; j < regions_to_test; j++) {
       a->free(test_regions[j], test_size);


### PR DESCRIPTION
After the conversion, some `for loops` generate too many assertions. 
A `printf` is also gotten rid of.