### PR TITLE
Do not follow redirects after cache hit

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -1313,6 +1313,8 @@ HTTP Redirection
    This setting determines the maximum number of times Trafficserver does a redirect follow location on receiving a 3XX Redirect response
    for a given client request.
 
+   .. note:: When :ts:cv:`proxy.config.http.number_of_redirections` is set to a positive value and |TS| has previously cached a 3XX Redirect response, the cached response will continue to be refreshed and returned until the response is no longer in the cache.
+
 .. ts:cv:: CONFIG proxy.config.http.redirect_host_no_port INT 1
    :reloadable:
 

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -24,6 +24,7 @@
 
 #include "../ProxyClientTransaction.h"
 #include "HttpSM.h"
+#include "HttpTransact.h"
 #include "HttpTransactHeaders.h"
 #include "ProxyConfig.h"
 #include "HttpServerSession.h"
@@ -1616,14 +1617,11 @@ HttpSM::handle_api_return()
     }
 
     // We only follow 3xx when redirect_in_process == false. Otherwise the redirection has already been launched (in
-    // SM_ACTION_SERVE_FROM_CACHE or SM_ACTION_SERVER_READ).redirect_in_process is set before this logic if we need more direction.
+    // SM_ACTION_SERVER_READ).redirect_in_process is set before this logic if we need more direction.
     // This redirection is only used with the build_error_reponse. Then, the redirection_tries will be increased by
     // state_read_server_reponse_header and never get into this logic again.
-    if (enable_redirection && !t_state.redirect_info.redirect_in_process && is_redirect_required() &&
-        (redirection_tries <= t_state.txn_conf->number_of_redirections)) {
+    if (enable_redirection && !t_state.redirect_info.redirect_in_process && is_redirect_required()) {
       do_redirect();
-    } else if (redirection_tries > t_state.txn_conf->number_of_redirections) {
-      t_state.squid_codes.subcode = SQUID_SUBCODE_NUM_REDIRECTIONS_EXCEEDED;
     }
     // we have further processing to do
     //  based on what t_state.next_action is
@@ -7408,11 +7406,10 @@ HttpSM::set_next_state()
       perform_cache_write_action();
       t_state.api_next_action = HttpTransact::SM_ACTION_API_SEND_RESPONSE_HDR;
 
-      // check to see if we are going to handle the redirection from server response and if there is a plugin hook set
-      if (hooks_set && is_redirect_required() == false) {
+      // check to see if there is a plugin hook set
+      if (hooks_set) {
         do_api_callout_internal();
       } else {
-        do_redirect();
         handle_api_return();
       }
     }
@@ -7597,6 +7594,11 @@ HttpSM::do_redirect()
   SMDebug("http_redirect", "[HttpSM::do_redirect]");
   if (!enable_redirection || redirection_tries > t_state.txn_conf->number_of_redirections) {
     this->postbuf_clear();
+
+    if (enable_redirection && redirection_tries > t_state.txn_conf->number_of_redirections) {
+      t_state.squid_codes.subcode = SQUID_SUBCODE_NUM_REDIRECTIONS_EXCEEDED;
+    }
+
     return;
   }
 
@@ -7936,7 +7938,8 @@ HttpSM::is_private()
 inline bool
 HttpSM::is_redirect_required()
 {
-  bool redirect_required = (enable_redirection && (redirection_tries <= t_state.txn_conf->number_of_redirections));
+  bool redirect_required = (enable_redirection && (redirection_tries <= t_state.txn_conf->number_of_redirections) &&
+                            !HttpTransact::is_cache_hit(t_state.cache_lookup_result));
 
   SMDebug("http_redirect", "is_redirect_required %u", redirect_required);
 

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -1034,6 +1034,7 @@ public:
   static bool setup_auth_lookup(State *s);
   static bool will_this_request_self_loop(State *s);
   static bool is_request_likely_cacheable(State *s, HTTPHdr *request);
+  static bool is_cache_hit(CacheLookupResult_t r);
 
   static void build_request(State *s, HTTPHdr *base_request, HTTPHdr *outgoing_request, HTTPVersion outgoing_version);
   static void build_response(State *s, HTTPHdr *base_response, HTTPHdr *outgoing_response, HTTPVersion outgoing_version,


### PR DESCRIPTION
See #4263 

Following a redirect response that was a cache hit is not correct behavior, but it can happen in cases when a 3xx response was cached prior to a config change. If the cache key generated from a client request matches an object in the cache, then that object should be used for the client response.