### PR TITLE
Remove unnecessary line in src/Makefile.am

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -41,8 +41,6 @@ include traffic_ctl/Makefile.inc
 include traffic_layout/Makefile.inc
 include traffic_logcat/Makefile.inc
 
-	$(check_PROGRAMS)
-
 clang-tidy-local: $(DIST_SOURCES)
 	$(CXX_Clang_Tidy)
 	$(CC_Clang_Tidy)


### PR DESCRIPTION
Found an odd line in Makefile.am. It seems like removal of TESTS line on #3724 was incomplete.