### PR TITLE
Fix libjansson & libcjose static or dynamic detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1311,21 +1311,21 @@ TS_CHECK_LUAJIT
 #
 AC_CHECK_HEADERS([jansson.h], [
   AC_MSG_CHECKING([whether jansson is dynamic])
-  TS_LINK_WITH_FLAGS_IFELSE([-shared -fPIC -l:libjansson.a],[AC_LANG_PROGRAM(
+  TS_LINK_WITH_FLAGS_IFELSE([-fPIC -ljansson],[AC_LANG_PROGRAM(
                             [#include <jansson.h>],
                             [(void) json_object();])],
-                            [AC_MSG_RESULT([no]);  LIBJANSSON=-l:libjansson.a],
-                            [AC_MSG_RESULT([yes]); LIBJANSSON=-ljansson])
+                            [AC_MSG_RESULT([yes]); LIBJANSSON=-ljansson],
+                            [AC_MSG_RESULT([no]);  LIBJANSSON=-l:libjansson.a])
   ],
   [LIBJANSSON=])
 
 AC_CHECK_HEADERS([cjose/cjose.h], [
   AC_MSG_CHECKING([whether cjose is dynamic])
-  TS_LINK_WITH_FLAGS_IFELSE([-shared -fPIC -l:libcjose.a],[AC_LANG_PROGRAM(
+  TS_LINK_WITH_FLAGS_IFELSE([-fPIC -lcjose],[AC_LANG_PROGRAM(
                             [#include <cjose/cjose.h>],
                             [(void) cjose_jws_import("", 0, NULL);])],
-                            [AC_MSG_RESULT([no]);  LIBCJOSE=-l:libcjose.a],
-                            [AC_MSG_RESULT([yes]); LIBCJOSE=-lcjose])
+                            [AC_MSG_RESULT([yes]); LIBCJOSE=-lcjose],
+                            [AC_MSG_RESULT([no]);  LIBCJOSE=-l:libcjose.a])
   ],
   [LIBCJOSE=])
 AC_CHECK_LIB([crypto],[HMAC],[has_libcrypto=1],[has_libcrypto=0])


### PR DESCRIPTION
libjansson and libcjose were wrongly detected as static libs on Debian, leading uri_signin plugin compilation to fail.
This patch aims to revert the detection logic, really checking for dynamic library first and falling back to static setup if the check fails.