### PR TITLE
Inherit parent config file root-required attribute

### DIFF
--- a/mgmt/FileManager.cc
+++ b/mgmt/FileManager.cc
@@ -275,9 +275,7 @@ FileManager::configFileChild(const char *parent, const char *child, unsigned fla
   int htfound = ink_hash_table_lookup(bindings, parent, &lookup);
   if (htfound) {
     parentRollback = (Rollback *)lookup;
-  }
-  if (htfound) {
-    addFileHelper(child, true, parentRollback, flags);
+    addFileHelper(child, parentRollback->rootAccessNeeded(), parentRollback, flags);
   }
   ink_mutex_release(&accessLock);
 }

--- a/mgmt/Rollback.h
+++ b/mgmt/Rollback.h
@@ -212,6 +212,11 @@ public:
   {
     return numberBackups > 0;
   }
+  bool
+  rootAccessNeeded() const
+  {
+    return root_access_needed;
+  }
 
   FileManager *configFiles; // Manager to notify on an update.
 


### PR DESCRIPTION
Running as non-root, traffic_manager would fail during config load
attempting to add child subconfigs because process couldn't become
root to load child config.