### PR TITLE
Remove proxy.config.http.push_method_enabled which has done nothing since 2009

### DIFF
--- a/doc/admin-guide/configuration/cache-basics.en.rst
+++ b/doc/admin-guide/configuration/cache-basics.en.rst
@@ -289,21 +289,6 @@ Traffic Server supports the HTTP ``PUSH`` method of content delivery.
 Using HTTP ``PUSH``, you can deliver content directly into the cache
 without client requests.
 
-Configuring Traffic Server for PUSH Requests
---------------------------------------------
-
-Before you can deliver content into your cache using HTTP ``PUSH``, you
-must configure Traffic Server to accept ``PUSH`` requests.
-
-#. Edit :file:`ip_allow.config` to allow ``PUSH`` from the appropriate addresses.
-
-#. Update :ts:cv:`proxy.config.http.push_method_enabled` in
-   :file:`records.config`::
-
-        CONFIG proxy.config.http.push_method_enabled INT 1
-
-#. Run the command :option:`traffic_ctl config reload` to apply the configuration changes.
-
 Understanding HTTP PUSH
 -----------------------
 

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -1749,18 +1749,6 @@ Proxy User Variables
 Security
 ========
 
-.. ts:cv:: CONFIG proxy.config.http.push_method_enabled INT 0
-   :reloadable:
-
-   Enables (``1``) or disables (``0``) the HTTP ``PUSH`` option, which allows you to deliver content directly to the cache without a user
-   request.
-
-   .. important::
-
-       If you enable this option, then you must also specify
-       a filtering rule in the ip_allow.config file to allow only certain
-       machines to push content into the cache.
-
 .. ts:cv:: CONFIG proxy.config.http.max_post_size INT 0
    :reloadable:
 

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -553,8 +553,6 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.http.response_header_max_size", RECD_INT, "131072", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.http.push_method_enabled", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
-  ,
 
   //        #################
   //        # cache control #

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -1167,8 +1167,6 @@ HttpConfig::startup()
   HttpEstablishStaticConfigLongLong(c.oride.request_hdr_max_size, "proxy.config.http.request_header_max_size");
   HttpEstablishStaticConfigLongLong(c.oride.response_hdr_max_size, "proxy.config.http.response_header_max_size");
 
-  HttpEstablishStaticConfigByte(c.push_method_enabled, "proxy.config.http.push_method_enabled");
-
   HttpEstablishStaticConfigByte(c.reverse_proxy_enabled, "proxy.config.reverse_proxy.enabled");
   HttpEstablishStaticConfigByte(c.url_remap_required, "proxy.config.url_remap.remap_required");
 
@@ -1450,8 +1448,6 @@ HttpConfig::reconfigure()
 
   params->oride.request_hdr_max_size  = m_master.oride.request_hdr_max_size;
   params->oride.response_hdr_max_size = m_master.oride.response_hdr_max_size;
-
-  params->push_method_enabled = INT_TO_BOOL(m_master.push_method_enabled);
 
   params->reverse_proxy_enabled            = INT_TO_BOOL(m_master.reverse_proxy_enabled);
   params->url_remap_required               = INT_TO_BOOL(m_master.url_remap_required);

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -877,8 +877,6 @@ public:
 
   MgmtByte cache_post_method = 0;
 
-  MgmtByte push_method_enabled = 0;
-
   MgmtByte referer_filter_enabled  = 0;
   MgmtByte referer_format_redirect = 0;
 

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -1756,65 +1756,25 @@ HttpTransact::OSDNSLookup(State *s)
   }
 }
 
+/*
+ * TODO: It looks like the StartAccessControl logic was cannibalized before 2009.
+ * We should re-examine this logic and probably simplify it.  Just removing the
+ * really old commented out code for now.
+ */
 void
 HttpTransact::StartAccessControl(State *s)
 {
-  // if (s->cop_test_page  || (s->state_machine->authAdapter.disabled() == true)) {
-  // Heartbeats should always be allowed.
-  // s->content_control.access = ACCESS_ALLOW;
   HandleRequestAuthorized(s);
-  //  return;
-  // }
-  // ua_txn is NULL for scheduled updates.
-  // Don't use req_flavor to do the test because if updated
-  // urls are remapped, the req_flavor is changed to REV_PROXY.
-  // if (s->state_machine->ua_txn == NULL) {
-  // Scheduled updates should always be allowed
-  // return;
-  //}
-  // pass the access control logic to the ACC module.
-  //(s->state_machine->authAdapter).StartLookup(s);
 }
 
 void
 HttpTransact::HandleRequestAuthorized(State *s)
 {
-  //(s->state_machine->authAdapter).SetState(s);
-  //(s->state_machine->authAdapter).UserAuthorized(NULL);
-  // TRANSACT_RETURN(HTTP_API_OS_DNS, HandleFiltering);
   if (s->force_dns) {
     TRANSACT_RETURN(SM_ACTION_API_OS_DNS, HttpTransact::DecideCacheLookup);
   } else {
     HttpTransact::DecideCacheLookup(s);
   }
-}
-
-void
-HttpTransact::HandleFiltering(State *s)
-{
-  ink_release_assert(!"Fix-Me AUTH MERGE");
-
-  if (s->method == HTTP_WKSIDX_PUSH && s->http_config_param->push_method_enabled == 0) {
-    // config file says this request is not authorized.
-    // send back error response to client.
-    TxnDebug("http_trans", "[HandleFiltering] access denied.");
-    TxnDebug("http_seq", "[HttpTransact::HandleFiltering] Access Denied.");
-
-    SET_VIA_STRING(VIA_DETAIL_TUNNEL, VIA_DETAIL_TUNNEL_NO_FORWARD);
-    // adding a comment so that cvs recognizes that I added a space in the text below
-    build_error_response(s, HTTP_STATUS_FORBIDDEN, "Access Denied", "access#denied");
-    // s->cache_info.action = CACHE_DO_NO_ACTION;
-    TRANSACT_RETURN(SM_ACTION_SEND_ERROR_CACHE_NOOP, nullptr);
-  }
-
-  TxnDebug("http_seq", "[HttpTransact::HandleFiltering] Request Authorized.");
-  //////////////////////////////////////////////////////////////
-  // ok, the config file says that the request is authorized. //
-  //////////////////////////////////////////////////////////////
-
-  // request is not black listed so now decided if we ought to
-  //  lookup the cache
-  DecideCacheLookup(s);
 }
 
 void


### PR DESCRIPTION
Based on "git blame" it looks like the code that effectively comments out enforcement of the push_method_enabled has been commented out since the code base moved to git (in 2009).

This has caused security problems due to deployments that assumed this configuration was actually doing something.  I think we have decided to concentrate on the IpAllow mechanism to control which methods are permitted, so the remnants of this mechanism should be removed to avoid confusion.