### PR TITLE
Orders k-v pairs to avoid making too many files

### DIFF
--- a/tests/gold_tests/redirect/redirect_actions.test.py
+++ b/tests/gold_tests/redirect/redirect_actions.test.py
@@ -94,7 +94,7 @@ def makeTestCase(redirectTarget, expectedAction, scenario):
     :param scenario: Defines the ACL to configure and the addresses to test.
     '''
 
-    config = ','.join(':'.join(t) for t in ((addr.name.lower(),action.name.lower()) for (addr,action) in scenario.items()))
+    config = ','.join(':'.join(t) for t in sorted((addr.name.lower(),action.name.lower()) for (addr,action) in scenario.items()))
 
     normRedirectTarget = normalizeForAutest(redirectTarget)
     normConfig = normalizeForAutest(config)


### PR DESCRIPTION
Python dictionaries hash the value of the keys, so iterating over its entries is unordered by default. I found by experimentation that this can result in generating more than one test file that serves the same purpose when tests are run repeatedly.

This change prevents that by ordering the entries that are iterated upon.

This test is still skipped by default due to #4120.