### PR TITLE
Add warning of body_factory templates are not loaded due to missing dot file

### DIFF
--- a/proxy/http/HttpBodyFactory.cc
+++ b/proxy/http/HttpBodyFactory.cc
@@ -707,6 +707,7 @@ HttpBodyFactory::load_body_set_from_directory(char *set_name, char *tmpl_dir)
   ink_filepath_make(path, sizeof(path), tmpl_dir, ".body_factory_info");
   status = stat(path, &stat_buf);
   if ((status < 0) || !S_ISREG(stat_buf.st_mode)) {
+    Warning("Missing .body_factory_info in %s.  Not loading body_factory templates", tmpl_dir);
     closedir(dir);
     return nullptr;
   }


### PR DESCRIPTION
Hopefully save some other soul from slogging though the debugger to figure out that the body_factory files weren't being loaded because the empty .body_factory_info file was missing.