### PR TITLE
Fix typo of the nofiles ulimit to a sane number

### DIFF
--- a/rc/trafficserver.in
+++ b/rc/trafficserver.in
@@ -294,7 +294,7 @@ rc_start_hook()
 
 # Make sure the NOFILES limit is set high in case this process is not 
 # started from a logged in prompt
-ulimit -n 5000000
+ulimit -n 500000
 
 # main
 case "$1" in


### PR DESCRIPTION
Typo'd my original fix to set nofiles to 5 million instead of 500K.