### PR TITLE
Disable the HttpSM half open logic if the underlying transport is TLS

### DIFF
--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -75,6 +75,13 @@ public:
   virtual void do_io_shutdown(ShutdownHowTo_t howto);
   virtual void reenable(VIO *vio);
 
+  bool
+  allow_half_open()
+  {
+    // Only allow half open connections if the not over TLS
+    return (client_vc && dynamic_cast<SSLNetVConnection *>(client_vc) == nullptr);
+  }
+
   void
   set_half_close_flag(bool flag)
   {

--- a/proxy/http/Http1ClientTransaction.cc
+++ b/proxy/http/Http1ClientTransaction.cc
@@ -67,3 +67,10 @@ Http1ClientTransaction::transaction_done()
     static_cast<Http1ClientSession *>(parent)->release_transaction();
   }
 }
+
+bool
+Http1ClientTransaction::allow_half_open() const
+{
+  // Check with the session to make sure the underlying transport allows the half open scenario
+  return static_cast<Http1ClientSession *>(parent)->allow_half_open();
+}

--- a/proxy/http/Http1ClientTransaction.h
+++ b/proxy/http/Http1ClientTransaction.h
@@ -87,11 +87,7 @@ public:
     return false;
   }
 
-  bool
-  allow_half_open() const override
-  {
-    return true;
-  }
+  bool allow_half_open() const override;
 
   void set_parent(ProxyClientSession *new_parent) override;
 


### PR DESCRIPTION
(cherry picked from commit 422e81057070d405a1aa24575d36383e8a7c8d2e)

Conflicts:
	proxy/http/Http1ClientTransaction.cc