### PR TITLE
Remove the ignore_keep_alive method entirely

### DIFF
--- a/proxy/ProxyClientTransaction.h
+++ b/proxy/ProxyClientTransaction.h
@@ -180,12 +180,6 @@ public:
   {
   }
 
-  virtual bool
-  ignore_keep_alive()
-  {
-    return true;
-  }
-
   virtual void destroy();
 
   virtual void transaction_done() = 0;

--- a/proxy/http/Http1ClientTransaction.h
+++ b/proxy/http/Http1ClientTransaction.h
@@ -81,12 +81,6 @@ public:
 
   void release(IOBufferReader *r) override;
 
-  bool
-  ignore_keep_alive() override
-  {
-    return false;
-  }
-
   bool allow_half_open() const override;
 
   void set_parent(ProxyClientSession *new_parent) override;

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -5748,7 +5748,7 @@ HttpTransact::initialize_state_variables_from_request(State *s, HTTPHdr *obsolet
   }
 
   // If this is an internal request, never keep alive
-  if (!s->txn_conf->keep_alive_enabled_in || (s->state_machine->ua_session && s->state_machine->ua_session->ignore_keep_alive())) {
+  if (!s->txn_conf->keep_alive_enabled_in) {
     s->client_info.keep_alive = HTTP_NO_KEEPALIVE;
   } else if (vc && vc->get_is_internal_request()) {
     // Following the trail of JIRAs back from TS-4960, there can be issues with

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -185,7 +185,7 @@ public:
   void update_write_request(IOBufferReader *buf_reader, int64_t write_len, bool send_update);
   void signal_write_event(bool call_update);
   void reenable(VIO *vio) override;
-  virtual void transaction_done() override;
+  void transaction_done() override;
 
   void restart_sending();
   void push_promise(URL &url, const MIMEField *accept_encoding);


### PR DESCRIPTION
(cherry picked from commit da9edd5feba06da6ebbe47eaf9696c37c5483fa1)

Conflicts:
	proxy/http/Http1ClientTransaction.h
	proxy/http/HttpTransact.cc
	proxy/http2/Http2Stream.h