### PR TITLE
Runroot: make runroot accept defective yaml file

### DIFF
--- a/include/tscore/I_Layout.h
+++ b/include/tscore/I_Layout.h
@@ -42,21 +42,24 @@ struct Layout {
   ~Layout();
 
   /**
-   Return file path relative to Layout->prefix
+   Setup the runroot for layout class
+   Return true if runroot is setup succesfully and false if runroot is not used
+   */
+  bool runroot_setup();
 
+  /**
+   Return file path relative to Layout->prefix
   */
   std::string relative(std::string_view file);
 
   /**
    update the sysconfdir to a test conf dir
-
    */
   void update_sysconfdir(std::string_view dir);
 
   /**
    Return file path relative to dir
    Example usage: Layout::relative_to(default_layout()->sysconfdir, "foo.bar");
-
   */
   static std::string relative_to(std::string_view dir, std::string_view file);
 
@@ -64,7 +67,6 @@ struct Layout {
    Return file path relative to dir
    Store the path to buf. The buf should be large eough to store
    Example usage: Layout::relative_to(default_layout()->sysconfdir, "foo.bar");
-
   */
   static void relative_to(char *buf, size_t bufsz, std::string_view dir, std::string_view file);
 
@@ -72,13 +74,11 @@ struct Layout {
    Creates a Layout Object with the given prefix.  If no
    prefix is given, the prefix defaults to the one specified
    at the compile time.
-
   */
   static void create(std::string_view const prefix = {});
 
   /**
    Returns the Layout object created by create_default_layout().
-
   */
   static Layout *get();
 

--- a/src/tscore/Layout.cc
+++ b/src/tscore/Layout.cc
@@ -111,32 +111,49 @@ Layout::relative_to(char *buf, size_t bufsz, std::string_view dir, std::string_v
   }
 }
 
+bool
+Layout::runroot_setup()
+{
+  std::string runroot_file = get_runroot().data();
+  if (runroot_file.empty()) {
+    // runroot is not used
+    return false;
+  }
+  RunrootMapType dir_map = check_runroot();
+  if (dir_map.empty()) {
+    ink_warning("No value provided in runroot.yaml\n");
+  }
+  // If some path values are not in runroot.yaml, we give it a default value instead of error out.
+  prefix      = dir_map[LAYOUT_PREFIX].empty() ? runroot_file.substr(0, runroot_file.find_last_of('/')) : dir_map[LAYOUT_PREFIX];
+  exec_prefix = dir_map[LAYOUT_EXEC_PREFIX].empty() ? prefix : dir_map[LAYOUT_EXEC_PREFIX];
+  bindir = dir_map[LAYOUT_BINDIR].empty() ? layout_relative(prefix, TS_BUILD_BINDIR) : bindir = dir_map[LAYOUT_BINDIR];
+  sbindir    = dir_map[LAYOUT_SBINDIR].empty() ? layout_relative(prefix, TS_BUILD_SBINDIR) : dir_map[LAYOUT_SBINDIR];
+  sysconfdir = dir_map[LAYOUT_SYSCONFDIR].empty() ? layout_relative(prefix, TS_BUILD_SYSCONFDIR) : dir_map[LAYOUT_SYSCONFDIR];
+  datadir    = dir_map[LAYOUT_DATADIR].empty() ? layout_relative(prefix, TS_BUILD_DATADIR) : dir_map[LAYOUT_DATADIR];
+  includedir = dir_map[LAYOUT_INCLUDEDIR].empty() ? layout_relative(prefix, TS_BUILD_INCLUDEDIR) : dir_map[LAYOUT_INCLUDEDIR];
+  libdir     = dir_map[LAYOUT_LIBDIR].empty() ? layout_relative(prefix, TS_BUILD_LIBDIR) : dir_map[LAYOUT_LIBDIR];
+  libexecdir = dir_map[LAYOUT_LIBEXECDIR].empty() ? layout_relative(prefix, TS_BUILD_LIBEXECDIR) : dir_map[LAYOUT_LIBEXECDIR];
+  localstatedir =
+    dir_map[LAYOUT_LOCALSTATEDIR].empty() ? layout_relative(prefix, TS_BUILD_LOCALSTATEDIR) : dir_map[LAYOUT_LOCALSTATEDIR];
+  runtimedir = dir_map[LAYOUT_RUNTIMEDIR].empty() ? layout_relative(prefix, TS_BUILD_RUNTIMEDIR) : dir_map[LAYOUT_RUNTIMEDIR];
+  logdir     = dir_map[LAYOUT_LOGDIR].empty() ? layout_relative(prefix, TS_BUILD_LOGDIR) : dir_map[LAYOUT_LOGDIR];
+  mandir     = dir_map[LAYOUT_MANDIR].empty() ? layout_relative(prefix, TS_BUILD_MANDIR) : dir_map[LAYOUT_MANDIR];
+  infodir    = dir_map[LAYOUT_INFODIR].empty() ? layout_relative(prefix, TS_BUILD_INFODIR) : dir_map[LAYOUT_INFODIR];
+  cachedir   = dir_map[LAYOUT_CACHEDIR].empty() ? layout_relative(prefix, TS_BUILD_CACHEDIR) : dir_map[LAYOUT_CACHEDIR];
+  return true;
+}
+
 Layout::Layout(std::string_view const _prefix)
 {
+  // if runroot is used, we set it up directly
+  if (runroot_setup()) {
+    return;
+  }
   if (!_prefix.empty()) {
     prefix.assign(_prefix.data(), _prefix.size());
   } else {
     std::string path;
     int len;
-    RunrootMapType dir_map = check_runroot();
-    if (dir_map.size() != 0) {
-      prefix        = dir_map[LAYOUT_PREFIX];
-      exec_prefix   = dir_map[LAYOUT_EXEC_PREFIX];
-      bindir        = dir_map[LAYOUT_BINDIR];
-      sbindir       = dir_map[LAYOUT_SBINDIR];
-      sysconfdir    = dir_map[LAYOUT_SYSCONFDIR];
-      datadir       = dir_map[LAYOUT_DATADIR];
-      includedir    = dir_map[LAYOUT_INCLUDEDIR];
-      libdir        = dir_map[LAYOUT_LIBDIR];
-      libexecdir    = dir_map[LAYOUT_LIBEXECDIR];
-      localstatedir = dir_map[LAYOUT_LOCALSTATEDIR];
-      runtimedir    = dir_map[LAYOUT_RUNTIMEDIR];
-      logdir        = dir_map[LAYOUT_LOGDIR];
-      mandir        = dir_map[LAYOUT_MANDIR];
-      infodir       = dir_map[LAYOUT_INFODIR];
-      cachedir      = dir_map[LAYOUT_CACHEDIR];
-      return;
-    }
     if (getenv("TS_ROOT") != nullptr) {
       std::string env_path(getenv("TS_ROOT"));
       len = env_path.size();


### PR DESCRIPTION
If some path values are not set up in `runroot.yaml`, we give it a default value instead of error out.
So runroot can take any `runroot.yaml` even if it is defective.