### PR TITLE
Runroot: verify functionality update and other minor fixes

### DIFF
--- a/doc/appendices/command-line/traffic_layout.en.rst
+++ b/doc/appendices/command-line/traffic_layout.en.rst
@@ -121,10 +121,11 @@ Example: ::
 verify
 ------
 Verify the permission of the sandbox. The permission issues can be fixed with ``--fix`` option.
+``--with-user`` option can be used to verify the permission of the runroot for specific user.
 
 Example: ::
 
-    traffic_layout verify (--path /path/to/sandbox/) (--fix)
+    traffic_layout verify (--path /path/to/sandbox/) (--fix) (--with-user root)
 
 =======
 Options
@@ -142,38 +143,42 @@ Options
 
     Print usage information and exit.
 
-.. option:: --path
+.. option:: -p, --path
 
     Specify the path of runroot for commands (init, remove, verify).
 
 init
 ----
-.. option:: --force
+.. option:: -f, --force
 
     Force init will create sandbox even if the directory is not empty.
 
-.. option:: --absolute
+.. option:: -a, --absolute
 
     Put directories in the YAML file in the form of absolute paths when creating.
 
-.. option:: --copy-style=[HARD/SOFT/FULL]
+.. option:: -c, --copy-style [HARD/SOFT/FULL]
 
     Specify the way of copying executables when creating runroot.
     HARD means hard link. SOFT means symlink. FULL means full copy.
 
-.. option:: --layout=[<YAML file>]
+.. option:: -l, --layout [<YAML file>]
 
     Use specific layout (providing YAML file) to create runroot.
 
 remove
 ------
-.. option:: `--force`
+.. option:: `-f`, `--force`
 
     Force remove will remove the directory even if it has no YAML file.
 
 verify
 ------
 
-.. option:: --fix
+.. option:: -x, --fix
 
     Fix the permission issues verify found. ``--fix`` requires root privilege (sudo).
+
+.. option:: -w, --with-user
+
+    Verify runroot with certain user. The value can be passed in as the username or ``#`` followed by uid.

--- a/src/traffic_layout/Makefile.inc
+++ b/src/traffic_layout/Makefile.inc
@@ -29,7 +29,6 @@ traffic_layout_traffic_layout_CPPFLAGS = \
 
 traffic_layout_traffic_layout_LDFLAGS =	\
     $(AM_LDFLAGS) \
-    @OPENSSL_LDFLAGS@ \
     @YAMLCPP_LDFLAGS@
 
 traffic_layout_traffic_layout_SOURCES = \

--- a/src/traffic_layout/file_system.cc
+++ b/src/traffic_layout/file_system.cc
@@ -163,6 +163,57 @@ remove_inside_directory(const std::string &dir)
   }
 }
 
+bool
+filter_ts_directories(const std::string &dir, const std::string &dst_path)
+{
+  // ----- filter traffic server related directories -----
+  if (dir == LAYOUT_BINDIR || dir == LAYOUT_SBINDIR) {
+    // no directory from bindir and sbindir should be copied.
+    return false;
+  }
+  if (dir == LAYOUT_LIBDIR) {
+    // valid directory of libdir are perl5 and pkgconfig. If not one of those, end the copying.
+    if (dst_path.find("/perl5") == std::string::npos && dst_path.find("/pkgconfig") == std::string::npos) {
+      return false;
+    }
+  }
+  if (dir == LAYOUT_INCLUDEDIR) {
+    // valid directory of includedir are atscppapi and ts. If not one of those, end the copying.
+    if (dst_path.find("/atscppapi") == std::string::npos && dst_path.find("/ts") == std::string::npos) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool
+filter_ts_files(const std::string &dir, const std::string &dst_path)
+{
+  // ----- filter traffic server related files -----
+  if (dir == LAYOUT_BINDIR || dir == LAYOUT_SBINDIR) {
+    // check if executable is in the list of traffic server executables. If not, end the copying.
+    if (executables.find(dst_path.substr(dst_path.find_last_of("/") + 1)) == executables.end()) {
+      return false;
+    }
+  }
+  if (dir == LAYOUT_LIBDIR) {
+    // check if library file starts with libats, libts or contained in perl5/ and pkgconfig/.
+    // If not, end the copying.
+    if (dst_path.find("/perl5/") == std::string::npos && dst_path.find("/pkgconfig/") == std::string::npos &&
+        dst_path.find("libats") == std::string::npos && dst_path.find("libts") == std::string::npos) {
+      return false;
+    }
+  }
+  if (dir == LAYOUT_INCLUDEDIR) {
+    // check if include file is contained in atscppapi/ and ts/. If not, end the copying.
+    if (dst_path.find("/atscppapi/") == std::string::npos && dst_path.find("/ts/") == std::string::npos &&
+        dst_path.find("/tscpp/") == std::string::npos) {
+      return false;
+    }
+  }
+  return true;
+}
+
 static int
 ts_copy_function(const char *src_path, const struct stat *sb, int flag)
 {
@@ -180,24 +231,9 @@ ts_copy_function(const char *src_path, const struct stat *sb, int flag)
   switch (flag) {
   // copying a directory
   case FTW_D:
-    // ----- filter traffic server related files -----
-    if (copy_dir == LAYOUT_BINDIR || copy_dir == LAYOUT_SBINDIR) {
-      // no directory from bindir and sbindir should be copied.
+    if (!filter_ts_directories(copy_dir, dst_path)) {
       break;
     }
-    if (copy_dir == LAYOUT_LIBDIR) {
-      // valid directory of libdir are perl5 and pkgconfig. If not one of those, end the copying.
-      if (dst_path.find("/perl5") == std::string::npos && dst_path.find("/pkgconfig") == std::string::npos) {
-        break;
-      }
-    }
-    if (copy_dir == LAYOUT_INCLUDEDIR) {
-      // valid directory of includedir are atscppapi and ts. If not one of those, end the copying.
-      if (dst_path.find("/atscppapi") == std::string::npos && dst_path.find("/ts") == std::string::npos) {
-        break;
-      }
-    }
-
     // create directory for FTW_D type
     if (!create_directory(dst_path)) {
       ink_fatal("create directory failed during copy");
@@ -205,29 +241,9 @@ ts_copy_function(const char *src_path, const struct stat *sb, int flag)
     break;
   // copying a file
   case FTW_F:
-    // ----- filter traffic server related files -----
-    if (copy_dir == LAYOUT_BINDIR || copy_dir == LAYOUT_SBINDIR) {
-      // check if executable is in the list of traffic server executables. If not, end the copying.
-      if (executables.find(dst_path.substr(dst_path.find_last_of("/") + 1)) == executables.end()) {
-        break;
-      }
+    if (!filter_ts_files(copy_dir, dst_path)) {
+      break;
     }
-    if (copy_dir == LAYOUT_LIBDIR) {
-      // check if library file starts with libats, libts or contained in perl5/ and pkgconfig/.
-      // If not, end the copying.
-      if (dst_path.find("/perl5/") == std::string::npos && dst_path.find("/pkgconfig/") == std::string::npos &&
-          dst_path.find("libats") == std::string::npos && dst_path.find("libts") == std::string::npos) {
-        break;
-      }
-    }
-    if (copy_dir == LAYOUT_INCLUDEDIR) {
-      // check if include file is contained in atscppapi/ and ts/. If not, end the copying.
-      if (dst_path.find("/atscppapi/") == std::string::npos && dst_path.find("/ts/") == std::string::npos &&
-          dst_path.find("/tscpp/") == std::string::npos) {
-        break;
-      }
-    }
-
     // if the file already exist, overwrite it
     if (exists(dst_path)) {
       if (remove(dst_path.c_str())) {

--- a/src/traffic_layout/file_system.h
+++ b/src/traffic_layout/file_system.h
@@ -43,4 +43,11 @@ bool remove_directory(const std::string &dir);
 // remove everything inside this directory
 bool remove_inside_directory(const std::string &dir);
 
+// filter the ts related files and directories to copy / verify
+// return true if the file/directory is from traffic server
+// IMPORTANT: this should be updated if the directory structure of build is changed
+bool filter_ts_directories(const std::string &dir, const std::string &dst_path);
+bool filter_ts_files(const std::string &dir, const std::string &dst_path);
+
+// copy directory recursively
 bool copy_directory(const std::string &src, const std::string &dst, const std::string &dir = "", CopyStyle style = HARD);

--- a/src/traffic_layout/traffic_layout.cc
+++ b/src/traffic_layout/traffic_layout.cc
@@ -40,29 +40,30 @@ main(int argc, const char **argv)
   engine.parser.add_global_usage("traffic_layout CMD [OPTIONS]");
 
   // global options
-  engine.parser.add_option("--features", "-f", "Show the compiled features");
+  engine.parser.add_option("--features", "", "Show the compiled features");
   engine.parser.add_option("--json", "-j", "Produce output in JSON format (when supported)");
   engine.parser.add_option("--version", "-V", "Print version string");
   engine.parser.add_option("--help", "-h", "Print usage information");
   engine.parser.add_option("--run-root", "", "using TS_RUNROOT as sandbox", "", 1);
 
   // info command
-  engine.parser.add_command("info", "Show the layout as default", [&]() { engine.info(); });
+  engine.parser.add_command("info", "Show the layout information. <Default>", [&]() { engine.info(); });
   // init command
   engine.parser.add_command("init", "Initialize(create) the runroot sandbox", [&]() { engine.create_runroot(); })
-    .add_option("--absolute", "", "Produce absolute path in the runroot.yaml")
-    .add_option("--force", "", "Create runroot even if the directory is not empty")
-    .add_option("--path", "", "Specify the path of the runroot", "", 1)
-    .add_option("--copy-style", "", "Specify the way of copying (FULL/HARD/SOFT)", "", 1)
-    .add_option("--layout", "", "Use specific layout (providing YAML file) to create runroot", "", 1);
+    .add_option("--absolute", "-a", "Produce absolute path in the runroot.yaml")
+    .add_option("--force", "-f", "Create runroot even if the directory is not empty")
+    .add_option("--path", "-p", "Specify the path of the runroot", "", 1)
+    .add_option("--copy-style", "-c", "Specify the way of copying (full/hard/soft)", "", 1)
+    .add_option("--layout", "-l", "Use specific layout (providing YAML file) to create runroot", "", 1);
   // remove command
   engine.parser.add_command("remove", "Remove the runroot sandbox", [&]() { engine.remove_runroot(); })
-    .add_option("--force", "", "Remove runroot even if runroot.yaml is not found")
-    .add_option("--path", "", "Specify the path of the runroot", "", 1);
+    .add_option("--force", "-f", "Remove runroot even if runroot.yaml is not found")
+    .add_option("--path", "-p", "Specify the path of the runroot", "", 1);
   // verify command
   engine.parser.add_command("verify", "Verify the runroot permissions", [&]() { engine.verify_runroot(); })
-    .add_option("--fix", "", "Fix the permission issues of runroot")
-    .add_option("--path", "", "Specify the path of the runroot", "", 1);
+    .add_option("--fix", "-x", "Fix the permission issues of runroot")
+    .add_option("--path", "-p", "Specify the path of the runroot", "", 1)
+    .add_option("--with-user", "-w", "verify runroot with certain user", "", 1);
 
   engine.arguments = engine.parser.parse(argv);
 

--- a/tests/gold_tests/autest-site/setup.cli.ext
+++ b/tests/gold_tests/autest-site/setup.cli.ext
@@ -49,7 +49,7 @@ if ENV['ATS_BIN'] is not None:
     host.WriteVerbose(['ats'], "Traffic server layout Data:\n", pprint.pformat(out))
     # if the above worked this should as well
     # this gets feature data
-    out = subprocess.check_output([traffic_layout, "-f", "--json"])
+    out = subprocess.check_output([traffic_layout, "--features", "--json"])
     out = json.loads(out.decode("utf-8"))
     Variables.update(out)
     host.WriteVerbose(['ats'], "Traffic server feature data:\n", pprint.pformat(out))


### PR DESCRIPTION
Several updates to the runroot before the Summit.

1. Added several short options.
2. `remove --force` logic is changed.
3. `--copy-style` will error out if invalid input is given.
4. `verify --fix` will fix the permission of all traffic server related file inside each directory.
5. Added a new option `--with-user` to specify the user to verify.
6. basic logic changed for verifying groups.