### PR TITLE
Schedule event to ensure contination is locked before handler is called.

### DIFF
--- a/iocore/hostdb/P_RefCountCacheSerializer.h
+++ b/iocore/hostdb/P_RefCountCacheSerializer.h
@@ -117,7 +117,9 @@ template <class C> RefCountCacheSerializer<C>::~RefCountCacheSerializer()
 
   // Note that we have to do the unlink before we send the completion event, otherwise
   // we could unlink the sync file out from under another serializer.
-  cont->handleEvent(REFCOUNT_CACHE_EVENT_SYNC, nullptr);
+
+  // Schedule off the REFCOUNT event, so the continuation gets properly locked
+  this_ethread()->schedule_imm(cont, REFCOUNT_CACHE_EVENT_SYNC);
 }
 
 template <class C>


### PR DESCRIPTION
We saw this issue as a missing lock before calling handler on some error cases. Specifically the most recent error was that the traffic_server process did not have access to the directory where host.db should be created.

```
Core was generated by `/opt/oath/trafficserver/7.1/bin/traffic_server'.
Program terminated with signal 6, Aborted.
#0  0x00007fc1cc5eb277 in raise () from /lib64/libc.so.6
Missing separate debuginfos, use: debuginfo-install oath-trafficserver-7.1-7.1.2.39-0.1.b23.el7.x86_64
(gdb) bt
#0  0x00007fc1cc5eb277 in raise () from /lib64/libc.so.6
#1  0x00007fc1cc5ec968 in abort () from /lib64/libc.so.6
#2  0x00007fc1cf43462b in ink_abort (message_format=message_format@entry=0x7fc1cf4516ef "%s:%d: failed assertion `%s`")
    at ink_error.cc:99
#3  0x00007fc1cf431fd5 in _ink_assert (
    expression=expression@entry=0x7ffd28 "!mutex || mutex->thread_holding == this_ethread()", 
    file=file@entry=0x7ffd16 "Continuation.cc", line=line@entry=32) at ink_assert.cc:37
#4  0x000000000078beec in Continuation::handleEvent (this=0x7fc1cbb8ddc0, event=event@entry=1000, data=data@entry=0x0)
    at Continuation.cc:32
#5  0x000000000068c8f7 in RefCountCacheSerializer<HostDBInfo>::~RefCountCacheSerializer (this=0x7fc1c68ef000, 
    __in_chrg=<optimized out>) at P_RefCountCacheSerializer.h:119
#6  0x000000000068ca09 in RefCountCacheSerializer<HostDBInfo>::~RefCountCacheSerializer (this=0x7fc1c68ef000, 
    __in_chrg=<optimized out>) at P_RefCountCacheSerializer.h:120
#7  0x000000000068b413 in RefCountCacheSerializer<HostDBInfo>::initialize_storage (this=0x7fc1c68ef000, 
    e=0x7fc1cbbeebe0) at P_RefCountCacheSerializer.h:241
#8  0x000000000078cfe7 in EThread::process_event (this=this@entry=0x7fc1c9ee33c0, e=e@entry=0x7fc1cbbeebe0, 
    calling_code=1) at UnixEThread.cc:132
#9  0x000000000078d7de in EThread::process_queue (this=this@entry=0x7fc1c9ee33c0, 
    NegativeQueue=NegativeQueue@entry=0x7fc1c90e0670, ev_count=ev_count@entry=0x7fc1c90e066c, 
    nq_count=nq_count@entry=0x7fc1c90e0668) at UnixEThread.cc:171
#10 0x000000000078dde1 in EThread::execute_regular (this=0x7fc1c9ee33c0) at UnixEThread.cc:231
#11 0x000000000078c8f2 in spawn_thread_internal (a=0x7fc1cbb92f80) at Thread.cc:85
#12 0x00007fc1cd3ace25 in start_thread () from /lib64/libpthread.so.0
#13 0x00007fc1cc6b3bad in clone () from /lib64/libc.so.6
(gdb) frame 5
#5  0x000000000068c8f7 in RefCountCacheSerializer<HostDBInfo>::~RefCountCacheSerializer (this=0x7fc1c68ef000, 
    __in_chrg=<optimized out>) at P_RefCountCacheSerializer.h:119
119    P_RefCountCacheSerializer.h: No such file or directory.
```