### PR TITLE
Fix a TM crash on alarms

### DIFF
--- a/lib/records/I_RecCore.h
+++ b/lib/records/I_RecCore.h
@@ -188,7 +188,7 @@ void RecSignalManager(int id, const char *, size_t);
 static inline void
 RecSignalManager(int id, const char *str)
 {
-  RecSignalManager(id, str, strlen(str + 1));
+  RecSignalManager(id, str, strlen(str) + 1);
 }
 
 // Format a message, and send it to the manager and to the Warning diagnostic.


### PR DESCRIPTION
An alarm receiver expects null terminated message but a sender calculated message size incorrectly, and it caused a buffer overflow.

**BEFORE FIX**
```
traffic_server: using root directory '/opt/ats'
=================================================================
==7777==ERROR: AddressSanitizer: dynamic-stack-buffer-overflow on address 0x7fffffffd2c6 at pc 0x7ffff6a62ec7 bp 0x7fffffffcab0 sp 0x7fffffffcaa0
READ of size 1 at 0x7fffffffd2c6 thread T0
    #0 0x7ffff6a62ec6 in ink_strlcpy(char*, char const*, unsigned long) /usr/local/src/trafficserver/src/tscore/ink_string.cc:183
    #1 0x46cf67 in Alarms::signalAlarm(int, char const*, char const*) /usr/local/src/trafficserver/mgmt/Alarms.cc:208
    #2 0x47db34 in LocalManager::handleMgmtMsgFromProcesses(_mgmt_message_hdr_type*) /usr/local/src/trafficserver/mgmt/LocalManager.cc:544
    #3 0x47ccb3 in LocalManager::pollMgmtProcessServer() /usr/local/src/trafficserver/mgmt/LocalManager.cc:424
    #4 0x449ec7 in main traffic_manager/traffic_manager.cc:710
    #5 0x7ffff509211a in __libc_start_main (/lib64/libc.so.6+0x2311a)
    #6 0x444269 in _start (/opt/ats/bin/traffic_manager+0x444269)
```

Sent message is this:
```
#define DISK_IS_CONFIG_LOW_MESSAGE                     \                            
  "Access logging to local log directory suspended - " \                            
  "configured space allocation almost exhausted."
```

But a period at the end is missing.
```
Thread 1 "traffic_manager" hit Breakpoint 1, LocalManager::handleMgmtMsgFromProcesses (this=0x6120000283c0, mh=0x7fffffffd260) at LocalManager.cc:496
496	  char *data_raw = (char *)mh + sizeof(MgmtMessageHdr);
(gdb) n
497	  switch (mh->msg_id) {
(gdb) p data_raw
$1 = 0x7fffffffd268 "Access logging to local log directory suspended - configured space allocation almost exhausted"
```

```
(gdb) x/128x data_raw
0x7fffffffd268:	0x41	0x63	0x63	0x65	0x73	0x73	0x20	0x6c
0x7fffffffd270:	0x6f	0x67	0x67	0x69	0x6e	0x67	0x20	0x74
0x7fffffffd278:	0x6f	0x20	0x6c	0x6f	0x63	0x61	0x6c	0x20
0x7fffffffd280:	0x6c	0x6f	0x67	0x20	0x64	0x69	0x72	0x65
0x7fffffffd288:	0x63	0x74	0x6f	0x72	0x79	0x20	0x73	0x75
0x7fffffffd290:	0x73	0x70	0x65	0x6e	0x64	0x65	0x64	0x20
0x7fffffffd298:	0x2d	0x20	0x63	0x6f	0x6e	0x66	0x69	0x67
0x7fffffffd2a0:	0x75	0x72	0x65	0x64	0x20	0x73	0x70	0x61
0x7fffffffd2a8:	0x63	0x65	0x20	0x61	0x6c	0x6c	0x6f	0x63
0x7fffffffd2b0:	0x61	0x74	0x69	0x6f	0x6e	0x20	0x61	0x6c
0x7fffffffd2b8:	0x6d	0x6f	0x73	0x74	0x20	0x65	0x78	0x68
0x7fffffffd2c0:	0x61	0x75	0x73	0x74	0x65	0x64	0x00	0x00
0x7fffffffd2c8:	0x08	0x00	0x00	0x00	0x0e	0x00	0x00	0x00
0x7fffffffd2d0:	0x00	0xd3	0xff	0xff	0xff	0x7f	0x00	0x00
0x7fffffffd2d8:	0x06	0x78	0x49	0x00	0x00	0x00	0x00	0x00
0x7fffffffd2e0:	0x00	0xd4	0xff	0xff	0xff	0x7f	0x00	0x00
```

NULL is not a part of the message.
```
(gdb) p *mh
$3 = {msg_id = 9, data_len = 94}
```

**AFTER FIX**

The message has a period at the end.
```
Thread 1 "traffic_manager" hit Breakpoint 1, LocalManager::handleMgmtMsgFromProcesses (this=0x6120000283c0, mh=0x7fffffffd260) at LocalManager.cc:496
496	  char *data_raw = (char *)mh + sizeof(MgmtMessageHdr);
(gdb) n
497	  switch (mh->msg_id) {
(gdb) p data_raw
$1 = 0x7fffffffd268 "Access logging to local log directory suspended - configured space allocation almost exhausted."
```

```
(gdb) x/128b data_raw
0x7fffffffd268:	0x41	0x63	0x63	0x65	0x73	0x73	0x20	0x6c
0x7fffffffd270:	0x6f	0x67	0x67	0x69	0x6e	0x67	0x20	0x74
0x7fffffffd278:	0x6f	0x20	0x6c	0x6f	0x63	0x61	0x6c	0x20
0x7fffffffd280:	0x6c	0x6f	0x67	0x20	0x64	0x69	0x72	0x65
0x7fffffffd288:	0x63	0x74	0x6f	0x72	0x79	0x20	0x73	0x75
0x7fffffffd290:	0x73	0x70	0x65	0x6e	0x64	0x65	0x64	0x20
0x7fffffffd298:	0x2d	0x20	0x63	0x6f	0x6e	0x66	0x69	0x67
0x7fffffffd2a0:	0x75	0x72	0x65	0x64	0x20	0x73	0x70	0x61
0x7fffffffd2a8:	0x63	0x65	0x20	0x61	0x6c	0x6c	0x6f	0x63
0x7fffffffd2b0:	0x61	0x74	0x69	0x6f	0x6e	0x20	0x61	0x6c
0x7fffffffd2b8:	0x6d	0x6f	0x73	0x74	0x20	0x65	0x78	0x68
0x7fffffffd2c0:	0x61	0x75	0x73	0x74	0x65	0x64	0x2e	0x00
0x7fffffffd2c8:	0x08	0x00	0x00	0x00	0x0e	0x00	0x00	0x00
0x7fffffffd2d0:	0x00	0xd3	0xff	0xff	0xff	0x7f	0x00	0x00
0x7fffffffd2d8:	0x06	0x78	0x49	0x00	0x00	0x00	0x00	0x00
0x7fffffffd2e0:	0x00	0xd4	0xff	0xff	0xff	0x7f	0x00	0x00
```

NULL is a part of the message
```
(gdb) p *mh
$3 = {msg_id = 9, data_len = 96}
```