### PR TITLE
ArgParser: enable default command and help message update

### DIFF
--- a/doc/developer-guide/internal-libraries/ArgParser.en.rst
+++ b/doc/developer-guide/internal-libraries/ArgParser.en.rst
@@ -142,12 +142,10 @@ from the :class:`Arguments` object returned from the parsing. The function can b
 
     args.invoke();
 
-Help and Version messages
+Help message
 -------------------------
 
 - Help message will be outputted when a wrong usage of the program is detected or `--help` option found.
-
-- Version message is defined unified in :code:`ArgParser::version_message()`.
 
 Classes
 +++++++
@@ -175,13 +173,13 @@ Classes
 
       Output usage to the console.
 
-   .. function:: void version_message() const
-
-      Output version string to the console.
-
    .. function:: void add_global_usage(std::string const &usage)
 
       Add a global_usage for :code:`help_message()`. Example: `traffic_blabla [--SWITCH [ARG]]`.
+
+   .. function:: void set_default_command(std::string const &cmd);
+
+      Set a default command to the parser. This method should be called after the adding of the commands.
 
    .. function:: Command &require_commands()
 
@@ -222,6 +220,10 @@ Classes
 
       Add an example usage for the command to output in `help_message`.
       For Example: :code:`command.add_example_usage("traffic_blabla init --path=/path/to/file")`.
+
+   .. function:: Command &set_default()
+
+      set the current command as default
 
 .. class:: Arguments
 

--- a/include/tscore/ArgParser.h
+++ b/include/tscore/ArgParser.h
@@ -35,9 +35,8 @@ constexpr unsigned MORE_THAN_ZERO_ARG_N = ~0;
 // more than one arguments
 constexpr unsigned MORE_THAN_ONE_ARG_N = ~0 - 1;
 // customizable indent for help message
-constexpr int INDENT_ONE   = 24;
-constexpr int INDENT_TWO   = 32;
-constexpr int INDENT_THREE = 46;
+constexpr int INDENT_ONE = 32;
+constexpr int INDENT_TWO = 46;
 
 namespace ts
 {
@@ -155,6 +154,10 @@ public:
         @return The Command instance for chained calls.
     */
     Command &require_commands();
+    /** set the current command as default
+        @return The Command instance for chained calls.
+    */
+    Command &set_default();
 
   protected:
     // Main constructor called by add_command()
@@ -166,11 +169,12 @@ public:
     void check_command(std::string const &name, std::string const &key) const;
     // Helper method for ArgParser::help_message
     void output_command(std::ostream &out, std::string const &prefix) const;
+    // Helper method for ArgParser::help_message
+    void output_option() const;
     // Helper method for ArgParser::parse
     bool parse(Arguments &ret, AP_StrVec &args);
     // The help & version messages
     void help_message(std::string_view err = "") const;
-    void version_message() const;
     // Helpr method for parse()
     void append_option_data(Arguments &ret, AP_StrVec &args, int index);
     // The command name and help message
@@ -222,7 +226,8 @@ public:
                        std::string const &key = "");
   Command &add_command(std::string const &cmd_name, std::string const &cmd_description, std::string const &cmd_envvar,
                        unsigned cmd_arg_num, Function const &f = nullptr, std::string const &key = "");
-
+  // give a defaut command to this parser
+  void set_default_command(std::string const &cmd);
   /** Main parsing function
       @return The Arguments object available for program using
   */

--- a/src/traffic_layout/traffic_layout.cc
+++ b/src/traffic_layout/traffic_layout.cc
@@ -40,14 +40,14 @@ main(int argc, const char **argv)
   engine.parser.add_global_usage("traffic_layout CMD [OPTIONS]");
 
   // global options
-  engine.parser.add_option("--features", "", "Show the compiled features");
-  engine.parser.add_option("--json", "-j", "Produce output in JSON format (when supported)");
-  engine.parser.add_option("--version", "-V", "Print version string");
   engine.parser.add_option("--help", "-h", "Print usage information");
   engine.parser.add_option("--run-root", "", "using TS_RUNROOT as sandbox", "", 1);
 
   // info command
-  engine.parser.add_command("info", "Show the layout information. <Default>", [&]() { engine.info(); });
+  engine.parser.add_command("info", "Show the layout as default", [&]() { engine.info(); })
+    .add_option("--features", "", "Show the compiled features")
+    .add_option("--json", "-j", "Produce output in JSON format (when supported)")
+    .set_default();
   // init command
   engine.parser.add_command("init", "Initialize(create) the runroot sandbox", [&]() { engine.create_runroot(); })
     .add_option("--absolute", "-a", "Produce absolute path in the runroot.yaml")
@@ -70,11 +70,7 @@ main(int argc, const char **argv)
   runroot_handler(argv, engine.arguments.get("json"));
   Layout::create();
 
-  if (engine.arguments.has_action()) {
-    engine.arguments.invoke();
-  } else {
-    engine.info();
-  }
+  engine.arguments.invoke();
 
   return 0;
 }


### PR DESCRIPTION
1. ArgParser now can take a default command with method ``void set_default_command(std::string const &cmd)``.
2. Update the help message for better output.
3. The version message is taken out from ArgParser.