### PR TITLE
Fixes spelling in spec summary

### DIFF
--- a/tools/package/trafficserver.spec
+++ b/tools/package/trafficserver.spec
@@ -21,7 +21,7 @@
 %define _hardened_build 1
 %endif
 
-Summary:	Apache Traffi Server, a reverse, forward and transparent HTTP proxy cache
+Summary:	Apache Traffic Server, a reverse, forward and transparent HTTP proxy cache
 Name:		trafficserver
 Version:	7.1.2
 Release:	3%{?dist}
@@ -98,9 +98,9 @@ make DESTDIR=%{buildroot} install
 mkdir -p %{buildroot}/lib/systemd/system
 cp rc/trafficserver.service %{buildroot}/lib/systemd/system
 %else
-mkdir -p %{buildroot}/etc/init.d  
-mv %{buildroot}%{_bindir}/trafficserver %{buildroot}/etc/init.d  
-%endif  
+mkdir -p %{buildroot}/etc/init.d
+mv %{buildroot}%{_bindir}/trafficserver %{buildroot}/etc/init.d
+%endif
 
 # Remove libtool archives and static libs
 find %{buildroot} -type f -name "*.la" -delete
@@ -122,7 +122,7 @@ mv %{buildroot}%{_libdir}/trafficserver/pkgconfig/trafficserver.pc %{buildroot}%
 /sbin/ldconfig
 %if %{?fedora}0 > 0 || %{?rhel}0 >= 70
 %systemd_post trafficserver.service
-%endif  
+%endif
 
 # These UID/GIDs are retained from the upstream Fedora .spec, not sure if there's a registry for these?
 %pre
@@ -132,14 +132,14 @@ getent passwd ats >/dev/null || useradd -r -u 176 -g ats -d / -s /sbin/nologin -
 %preun
 %if %{?fedora}0 > 0 || %{?rhel}0 >= 70
 %systemd_preun trafficserver.service
-%endif  
+%endif
 
 %postun
 /sbin/ldconfig
 
 %if %{?fedora}0 > 0 || %{?rhel}0 >= 70
 %systemd_postun_with_restart trafficserver.service
-%endif  
+%endif
 
 %files
 %defattr(-, root, root, -)
@@ -160,7 +160,7 @@ getent passwd ats >/dev/null || useradd -r -u 176 -g ats -d / -s /sbin/nologin -
 /lib/systemd/system/trafficserver.service
 %else
 %config(noreplace) /etc/init.d/trafficserver
-%endif  
+%endif
 
 %attr(0755, ats, ats) %dir /var/log/trafficserver
 %attr(0755, ats, ats) %dir /run/trafficserver


### PR DESCRIPTION
(cherry picked from commit baf9aa5230838d9e1f49dff24a67a8da45d00723)