### PR TITLE
TCL: Remove TCL dependency from iocore

### DIFF
--- a/iocore/utils/I_Machine.h
+++ b/iocore/utils/I_Machine.h
@@ -32,7 +32,10 @@
 
 #include "tscore/ink_inet.h"
 #include "tscore/ink_uuid.h"
-#include "tscore/ink_hash_table.h"
+
+#include <unordered_map>
+#include <unordered_set>
+#include <memory>
 
 /**
   The Machine is a simple place holder for the hostname and the ip
@@ -89,7 +92,6 @@ protected:
   Machine(char const *hostname, sockaddr const *addr);
 
   static self *_instance; ///< Singleton for the class.
-
-  InkHashTable *machine_id_strings;
-  InkHashTable *machine_id_ipaddrs;
+  std::unordered_set<std::string> machine_id_strings;
+  std::unordered_map<std::string, IpAddr *> machine_id_ipaddrs;
 };


### PR DESCRIPTION
This PR contains the conversion inside iocore from the ink_hash_table to std::unordered_map.
With this change, there shouldn't be any TCL dependency in iocore.