### PR TITLE
client_bytes should be initialized as 0, it is exclusevely used by ge…

### DIFF
--- a/src/traffic_server/FetchSM.h
+++ b/src/traffic_server/FetchSM.h
@@ -146,7 +146,7 @@ private:
   MIOBuffer *req_buffer       = nullptr;
   IOBufferReader *req_reader  = nullptr;
   char *client_response       = nullptr;
-  int client_bytes            = -1;
+  int client_bytes            = 0;
   MIOBuffer *resp_buffer      = nullptr; // response to HttpConnect Call
   IOBufferReader *resp_reader = nullptr;
   Continuation *contp         = nullptr;


### PR DESCRIPTION
…t_info_from_buffer to count the number of copied bytes and set the last byte to 0