### PR TITLE
Fix mysql_remap plugin build with MySQL 8

### DIFF
--- a/plugins/experimental/mysql_remap/mysql_remap.cc
+++ b/plugins/experimental/mysql_remap/mysql_remap.cc
@@ -187,7 +187,7 @@ TSPluginInit(int argc, const char *argv[])
   my_data *data = (my_data *)malloc(1 * sizeof(my_data));
 
   TSPluginRegistrationInfo info;
-  my_bool reconnect = 1;
+  bool reconnect = 1;
 
   info.plugin_name   = const_cast<char *>(PLUGIN_NAME);
   info.vendor_name   = const_cast<char *>("Apache Software Foundation");


### PR DESCRIPTION
Starting MySQL 8.0.1 release, the `my_bool` type has been removed, leading `mysql_remap` build to fail.
Details in https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-1.html#mysqld-8-0-1-compiling state that `my_bool` should be replaced with C type `bool`.
Although not yet tested with MySQL 8, this changes is backwards-compatible with older versions of MySQL and MariaDB.