### PR TITLE
Fix a TM crash on alarms

### DIFF
--- a/lib/records/I_RecCore.h
+++ b/lib/records/I_RecCore.h
@@ -194,7 +194,7 @@ void RecSignalManager(int id, const char *, size_t);
 static inline void
 RecSignalManager(int id, const char *str)
 {
-  RecSignalManager(id, str, strlen(str + 1));
+  RecSignalManager(id, str, strlen(str) + 1);
 }
 
 // Format a message, and send it to the manager and to the Warning diagnostic.


### PR DESCRIPTION
An alarm receiver expects null terminated message but a sender calculated message size incorrectly, and it caused a buffer overflow.

(cherry picked from commit 58bd441976cb5c9e4422e1de26c07572af40271b)