### PR TITLE
Cache: update internal counters to be std::atomic.

### DIFF
--- a/iocore/cache/CacheHosting.cc
+++ b/iocore/cache/CacheHosting.cc
@@ -772,7 +772,6 @@ extern CacheDisk **gdisks;
 extern Queue<CacheVol> cp_list;
 extern int cp_list_len;
 extern ConfigVolumes config_volumes;
-extern int gnvol;
 
 extern void cplist_init();
 extern int cplist_reconfigure();

--- a/iocore/cache/CachePagesInternal.cc
+++ b/iocore/cache/CachePagesInternal.cc
@@ -52,7 +52,6 @@ extern ShowCacheInternal *theshowcacheInternal;
 Action *register_ShowCacheInternal(Continuation *c, HTTPHdr *h);
 
 extern Vol **gvol;
-extern int gnvol;
 
 // Stat Pages
 ShowCacheInternal *theshowcacheInternal = nullptr;

--- a/iocore/cache/P_CacheVol.h
+++ b/iocore/cache/P_CacheVol.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #define CACHE_BLOCK_SHIFT 9
 #define CACHE_BLOCK_SIZE (1 << CACHE_BLOCK_SHIFT) // 512, smallest sector size
 #define ROUND_TO_STORE_BLOCK(_x) INK_ALIGN((_x), STORE_BLOCK_SIZE)
@@ -328,7 +330,7 @@ struct Doc {
 // Global Data
 
 extern Vol **gvol;
-extern int gnvol;
+extern std::atomic<int> gnvol;
 extern ClassAllocator<OpenDirEntry> openDirEntryAllocator;
 extern ClassAllocator<EvacuationBlock> evacuationBlockAllocator;
 extern ClassAllocator<EvacuationKey> evacuationKeyAllocator;


### PR DESCRIPTION
Minor fix to use `std::atomic` instead of the hand rolled `ink_atomic_...` functions.