### PR TITLE
TCL: Remove TCL dependency from RecCore

### DIFF
--- a/lib/records/P_RecCore.h
+++ b/lib/records/P_RecCore.h
@@ -24,7 +24,6 @@
 #pragma once
 
 #include "tscore/ink_thread.h"
-#include "tscore/ink_hash_table.h"
 #include "tscore/ink_llqueue.h"
 #include "tscore/ink_rwlock.h"
 #include "tscore/TextBuffer.h"
@@ -33,9 +32,12 @@
 #include "P_RecDefs.h"
 #include "P_RecUtils.h"
 
+#include <unordered_set>
+#include <unordered_map>
+
 // records, record hash-table, and hash-table rwlock
 extern RecRecord *g_records;
-extern InkHashTable *g_records_ht;
+extern std::unordered_map<std::string, RecRecord *> g_records_ht;
 extern ink_rwlock g_records_rwlock;
 extern int g_num_records;
 extern RecModeT g_mode_type;
@@ -43,7 +45,7 @@ extern RecModeT g_mode_type;
 // records.config items
 extern const char *g_rec_config_fpath;
 extern LLQ *g_rec_config_contents_llq;
-extern InkHashTable *g_rec_config_contents_ht;
+extern std::unordered_set<std::string> g_rec_config_contents_ht;
 extern ink_mutex g_rec_config_lock;
 
 //-------------------------------------------------------------------------

--- a/lib/records/RecRawStats.cc
+++ b/lib/records/RecRawStats.cc
@@ -531,11 +531,10 @@ int
 RecRegisterRawStatSyncCb(const char *name, RecRawStatSyncCb sync_cb, RecRawStatBlock *rsb, int id)
 {
   int err = REC_ERR_FAIL;
-  RecRecord *r;
 
   ink_rwlock_rdlock(&g_records_rwlock);
-
-  if (ink_hash_table_lookup(g_records_ht, name, (void **)&r)) {
+  if (auto it = g_records_ht.find(name); it != g_records_ht.end()) {
+    RecRecord *r = it->second;
     rec_mutex_acquire(&(r->lock));
     if (REC_TYPE_IS_STAT(r->rec_type)) {
       if (r->stat_meta.sync_cb) {


### PR DESCRIPTION
With this conversion, there won't be any TCL dependency in `lib/records`. 