### PR TITLE
Fix gzip(compress) plugin not linked correctly with zlib

### DIFF
--- a/plugins/compress/Makefile.inc
+++ b/plugins/compress/Makefile.inc
@@ -18,6 +18,6 @@ pkglib_LTLIBRARIES += compress/compress.la
 compress_compress_la_SOURCES = compress/compress.cc compress/configuration.cc compress/misc.cc
 
 compress_compress_la_LDFLAGS = \
-  $(AM_LDFLAGS) $(BROTLIENC_LIB)
+  $(AM_LDFLAGS) $(BROTLIENC_LIB) $(LIBZ)
 
 compress_compress_la_CXXFLAGS = $(AM_CXXFLAGS) $(BROTLIENC_CFLAGS)


### PR DESCRIPTION
Experienced failures of `trafficserver/gzip.so: undefined symbol: deflate`. 
Solved by adding $(LIBZ) to `_LDFLAGS` to link zlib correctly.