### PR TITLE
docs: reference to overridable config not parsed

### DIFF
--- a/doc/admin-guide/plugins/regex_remap.en.rst
+++ b/doc/admin-guide/plugins/regex_remap.en.rst
@@ -135,7 +135,7 @@ remap.config. The following options are available ::
     @connect_timeout=<nnn>      - Connect timeouts (in ms)
     @dns_timeout=<nnn>          - Connect timeouts (in ms)
 
-    @overridable-config=<value> - see :ref:`Overridable Configurations <ts-overridable-config>`
+    @overridable-config=<value> - see :ref:`ts-overridable-config`
 
     @caseless                   - Make regular expressions case insensitive
     @lowercase_substitutions    - Turn on (enable) lower case substitutions


### PR DESCRIPTION
Users visting https://docs.trafficserver.apache.org/en/7.1.x/admin-guide/plugins/regex_remap.en.html
see
@overridable-config=<value> - see :ref:`Overridable Configurations <ts-overridable-config>`
