### PR TITLE
Update logic to watch config files even if they are not default

### DIFF
--- a/mgmt/FileManager.h
+++ b/mgmt/FileManager.h
@@ -30,7 +30,7 @@
 class ExpandingArray;
 class Rollback;
 
-typedef void (*FileCallbackFunc)(char *, bool);
+typedef void (*FileCallbackFunc)(char *, char *, bool);
 
 struct callbackListable {
 public:
@@ -47,7 +47,7 @@ enum lockAction_t {
 //
 //  public functions:
 //
-//  addFile(char*, configFileInfo*) - adds a new config file to be
+//  addFile(char*, char *, configFileInfo*) - adds a new config file to be
 //       managed.  A rollback object is created for the file.
 //       if the file_info ptr is not NULL, a WebFileEdit object
 //       is also created
@@ -65,7 +65,7 @@ enum lockAction_t {
 //       callback function should NOT use the calling thread to
 //       access any Rollback objects or block for a long time
 //
-//  fileChanged(const char* fileName) - called by Rollback objects
+//  fileChanged(const char* fileName, const char *configName) - called by Rollback objects
 //       when their contents change.  Triggers callbacks to FileCallbackFuncs
 //
 //  isConfigStale() - returns whether the in-memory files might be stale
@@ -79,10 +79,11 @@ class FileManager
 public:
   FileManager();
   ~FileManager();
-  void addFile(const char *fileName, bool root_access_needed, Rollback *parentRollback = nullptr, unsigned flags = 0);
+  void addFile(const char *fileName, const char *configName, bool root_access_needed, Rollback *parentRollback = nullptr,
+               unsigned flags = 0);
   bool getRollbackObj(const char *fileName, Rollback **rbPtr);
   void registerCallback(FileCallbackFunc func);
-  void fileChanged(const char *fileName, bool incVersion);
+  void fileChanged(const char *fileName, const char *configName, bool incVersion);
   void rereadConfig();
   bool isConfigStale();
   void configFileChild(const char *parent, const char *child, unsigned int options);
@@ -92,7 +93,8 @@ private:
   ink_mutex cbListLock; // Protects the CallBack List
   DLL<callbackListable> cblist;
   InkHashTable *bindings;
-  void addFileHelper(const char *fileName, bool root_access_needed, Rollback *parentRollback, unsigned flags = 0);
+  void addFileHelper(const char *fileName, const char *configName, bool root_access_needed, Rollback *parentRollback,
+                     unsigned flags = 0);
 };
 
 void initializeRegistry(); // implemented in AddConfigFilesHere.cc

--- a/mgmt/Rollback.cc
+++ b/mgmt/Rollback.cc
@@ -52,7 +52,8 @@ constexpr int INVALID_VERSION = -1;
 const char *RollbackStrings[] = {"Rollback Ok", "File was not found", "Version was out of date", "System Call Error",
                                  "Invalid Version - Version Numbers Must Increase"};
 
-Rollback::Rollback(const char *fileName_, bool root_access_needed_, Rollback *parentRollback_, unsigned flags)
+Rollback::Rollback(const char *fileName_, const char *configName_, bool root_access_needed_, Rollback *parentRollback_,
+                   unsigned flags)
   : configFiles(nullptr),
     root_access_needed(root_access_needed_),
     parentRollback(parentRollback_),
@@ -86,6 +87,7 @@ Rollback::Rollback(const char *fileName_, bool root_access_needed_, Rollback *pa
   // Copy the file name.
   fileNameLen = strlen(fileName_);
   fileName    = ats_strdup(fileName_);
+  configName  = ats_strdup(configName_);
 
   // Extract the file base name.
   fileBaseName = strrchr(fileName, '/');
@@ -479,7 +481,7 @@ Rollback::internalUpdate(TextBuffer *buf, version_t newVersion, bool notifyChang
 
   // Post the change to the config file manager
   if (notifyChange && configFiles) {
-    configFiles->fileChanged(fileName, incVersion);
+    configFiles->fileChanged(fileName, configName, incVersion);
   }
 
 UPDATE_CLEANUP:

--- a/mgmt/Rollback.h
+++ b/mgmt/Rollback.h
@@ -135,7 +135,8 @@ class Rollback
 {
 public:
   // fileName_ should be rooted or a base file name.
-  Rollback(const char *fileName_, bool root_access_needed, Rollback *parentRollback = nullptr, unsigned flags = 0);
+  Rollback(const char *fileName_, const char *configName_, bool root_access_needed, Rollback *parentRollback = nullptr,
+           unsigned flags = 0);
   ~Rollback();
 
   // Manual take out of lock required
@@ -197,6 +198,11 @@ public:
   {
     return fileName;
   }
+  const char *
+  getConfigName() const
+  {
+    return configName;
+  }
   bool
   isChildRollback() const
   {
@@ -233,6 +239,7 @@ private:
   ink_mutex fileAccessLock;
   char *fileName;
   char *fileBaseName;
+  char *configName;
   size_t fileNameLen;
   bool root_access_needed;
   Rollback *parentRollback;

--- a/src/traffic_manager/AddConfigFilesHere.cc
+++ b/src/traffic_manager/AddConfigFilesHere.cc
@@ -36,9 +36,19 @@ extern FileManager *configFiles;
  ****************************************************************************/
 
 void
-testcall(char *foo, bool /* incVersion */)
+testcall(char *foo, char * /*configName */, bool /* incVersion */)
 {
   Debug("lm", "Received Callback that %s has changed", foo);
+}
+
+void
+registerFile(const char *configName, const char *defaultName)
+{
+  bool found        = false;
+  const char *fname = REC_readString(configName, &found);
+  if (!found)
+    fname = defaultName;
+  configFiles->addFile(fname, configName, false);
 }
 
 //
@@ -61,19 +71,20 @@ initializeRegistry()
     ink_assert(!"Configuration Object Registry Initialized More than Once");
   }
 
-  configFiles->addFile("logging.yaml", false);
-  configFiles->addFile("storage.config", false);
-  configFiles->addFile("socks.config", false);
-  configFiles->addFile("records.config", false);
-  configFiles->addFile("cache.config", false);
-  configFiles->addFile("ip_allow.config", false);
-  configFiles->addFile("parent.config", false);
-  configFiles->addFile("remap.config", false);
-  configFiles->addFile("volume.config", false);
-  configFiles->addFile("hosting.config", false);
-  configFiles->addFile("plugin.config", false);
-  configFiles->addFile("splitdns.config", false);
-  configFiles->addFile("ssl_multicert.config", false);
-  configFiles->addFile(SSL_SERVER_NAME_CONFIG, false);
+  registerFile("proxy.config.log.config.filename", "logging.yaml");
+  registerFile("", "storage.config");
+  registerFile("proxy.config.socks.socks_config_file", "socks.config");
+  registerFile("records.config", "records.config");
+  registerFile("proxy.config.cache.control.filename", "cache.config");
+  registerFile("proxy.config.cache.ip_allow.filename", "ip_allow.config");
+  registerFile("proxy.config.http.parent_proxy.file", "parent.config");
+  registerFile("proxy.config.url_remap.filename", "remap.config");
+  registerFile("", "volume.config");
+  registerFile("proxy.config.cache.hosting_filename", "hosting.config");
+  registerFile("", "plugin.config");
+  registerFile("proxy.config.dns.splitdns.filename", "splitdns.config");
+  registerFile("proxy.config.ssl.server.multicert.filename", "ssl_multicert.config");
+  registerFile("proxy.config.ssl.servername.filename", SSL_SERVER_NAME_CONFIG);
+
   configFiles->registerCallback(testcall);
 }

--- a/src/traffic_manager/traffic_manager.cc
+++ b/src/traffic_manager/traffic_manager.cc
@@ -71,7 +71,7 @@ using namespace std::literals;
 LocalManager *lmgmt = nullptr;
 FileManager *configFiles;
 
-static void fileUpdated(char *fname, bool incVersion);
+static void fileUpdated(char *fname, char *configName, bool incVersion);
 static void runAsUser(const char *userName);
 
 #if defined(freebsd)
@@ -948,56 +948,15 @@ SigChldHandler(int /* sig ATS_UNUSED */)
 }
 
 void
-fileUpdated(char *fname, bool incVersion)
+fileUpdated(char *fname, char *configName, bool incVersion)
 {
-  if (strcmp(fname, "remap.config") == 0) {
-    lmgmt->signalFileChange("proxy.config.url_remap.filename");
-
-  } else if (strcmp(fname, "socks.config") == 0) {
-    lmgmt->signalFileChange("proxy.config.socks.socks_config_file");
-
-  } else if (strcmp(fname, "records.config") == 0) {
-    lmgmt->signalFileChange("records.config", incVersion);
-
-  } else if (strcmp(fname, "cache.config") == 0) {
-    lmgmt->signalFileChange("proxy.config.cache.control.filename");
-
-  } else if (strcmp(fname, "parent.config") == 0) {
-    lmgmt->signalFileChange("proxy.config.http.parent_proxy.file");
-
-  } else if (strcmp(fname, "ip_allow.config") == 0) {
-    lmgmt->signalFileChange("proxy.config.cache.ip_allow.filename");
-
-  } else if (strcmp(fname, "storage.config") == 0) {
-    mgmt_log("[fileUpdated] storage.config changed, need restart auto-rebuild mode\n");
-
-  } else if (strcmp(fname, "volume.config") == 0) {
-    mgmt_log("[fileUpdated] volume.config changed, need restart\n");
-
-  } else if (strcmp(fname, "hosting.config") == 0) {
-    lmgmt->signalFileChange("proxy.config.cache.hosting_filename");
-
-  } else if (strcmp(fname, "logging.yaml") == 0) {
-    lmgmt->signalFileChange("proxy.config.log.config.filename");
-
-  } else if (strcmp(fname, "splitdns.config") == 0) {
-    lmgmt->signalFileChange("proxy.config.dns.splitdns.filename");
-
-  } else if (strcmp(fname, "plugin.config") == 0) {
-    mgmt_log("[fileUpdated] plugin.config file has been modified\n");
-
-  } else if (strcmp(fname, "ssl_multicert.config") == 0) {
-    lmgmt->signalFileChange("proxy.config.ssl.server.multicert.filename");
-
-  } else if (strcmp(fname, "proxy.config.body_factory.template_sets_dir") == 0) {
-    lmgmt->signalFileChange("proxy.config.body_factory.template_sets_dir");
-
-  } else if (strcmp(fname, "proxy.config.ssl.server.ticket_key.filename") == 0) {
-    lmgmt->signalFileChange("proxy.config.ssl.server.ticket_key.filename");
-  } else if (strcmp(fname, SSL_SERVER_NAME_CONFIG) == 0) {
-    lmgmt->signalFileChange("proxy.config.ssl.servername.filename");
+  // If there is no config name recorded, assume this file is not reloadable
+  // Just log a message
+  if (configName == nullptr || configName[0] == '\0') {
+    mgmt_log("[fileUpdated] %s changed, need restart", fname);
   } else {
-    mgmt_log("[fileUpdated] Unknown config file updated '%s'\n", fname);
+    // Signal based on the config entry that has the changed file name
+    lmgmt->signalFileChange(configName);
   }
   return;
 } /* End fileUpdate */


### PR DESCRIPTION
Without this change, if you updates records.config to use a non-default name for a configuration file, the file watching would still watch the original file name.  So config reload wouldn't trigger for changes to the non-default named file.

Reworked the logic to read the config and watch the configured files.  Also carrying along the config name that corresponds to the file because the later stage wanted the config name rather than the file name.