### PR TITLE
QUIC Client session reused with new session ticket msg

### DIFF
--- a/iocore/net/quic/QUICConfig.cc
+++ b/iocore/net/quic/QUICConfig.cc
@@ -115,6 +115,11 @@ quic_init_client_ssl_ctx(const QUICConfigParams *params)
     }
   }
 
+  if (params->session_file() != nullptr) {
+    SSL_CTX_set_session_cache_mode(ssl_ctx, SSL_SESS_CACHE_CLIENT | SSL_SESS_CACHE_NO_INTERNAL_STORE);
+    SSL_CTX_sess_set_new_cb(ssl_ctx, QUIC::ssl_client_new_session);
+  }
+
   return ssl_ctx;
 }
 
@@ -142,6 +147,7 @@ QUICConfigParams::initialize()
 
   REC_ReadConfigStringAlloc(this->_server_supported_groups, "proxy.config.quic.server.supported_groups");
   REC_ReadConfigStringAlloc(this->_client_supported_groups, "proxy.config.quic.client.supported_groups");
+  REC_ReadConfigStringAlloc(this->_session_file, "proxy.config.quic.client.session_file");
 
   // Transport Parameters
   REC_EstablishStaticConfigInt32U(this->_no_activity_timeout_in, "proxy.config.quic.no_activity_timeout_in");
@@ -414,6 +420,12 @@ uint8_t
 QUICConfigParams::scid_len()
 {
   return QUICConfigParams::_scid_len;
+}
+
+const char *
+QUICConfigParams::session_file() const
+{
+  return _session_file;
 }
 
 //

--- a/iocore/net/quic/QUICConfig.h
+++ b/iocore/net/quic/QUICConfig.h
@@ -43,6 +43,7 @@ public:
 
   const char *server_supported_groups() const;
   const char *client_supported_groups() const;
+  const char *session_file() const;
 
   SSL_CTX *server_ssl_ctx() const;
   SSL_CTX *client_ssl_ctx() const;
@@ -95,6 +96,7 @@ private:
 
   char *_server_supported_groups = nullptr;
   char *_client_supported_groups = nullptr;
+  char *_session_file            = nullptr;
 
   // TODO: integrate with SSLCertLookup or SNIConfigParams
   SSL_CTX *_server_ssl_ctx = nullptr;

--- a/iocore/net/quic/QUICGlobals.cc
+++ b/iocore/net/quic/QUICGlobals.cc
@@ -27,6 +27,7 @@
 
 #include "P_SSLNextProtocolSet.h"
 #include "QUICStats.h"
+#include "QUICConfig.h"
 #include "QUICConnection.h"
 
 RecRawStatBlock *quic_rsb;
@@ -58,6 +59,21 @@ QUIC::ssl_select_next_protocol(SSL *ssl, const unsigned char **out, unsigned cha
   *out    = nullptr;
   *outlen = 0;
   return SSL_TLSEXT_ERR_NOACK;
+}
+
+int
+QUIC::ssl_client_new_session(SSL *ssl, SSL_SESSION *session)
+{
+  QUICConfig::scoped_config params;
+  auto file = BIO_new_file(params->session_file(), "w");
+  if (file == nullptr) {
+    Debug("quic_global", "Could not write TLS session in %s", params->session_file());
+    return 0;
+  }
+
+  PEM_write_bio_SSL_SESSION(file, session);
+  BIO_free(file);
+  return 0;
 }
 
 void

--- a/iocore/net/quic/QUICGlobals.h
+++ b/iocore/net/quic/QUICGlobals.h
@@ -33,6 +33,7 @@ public:
   // SSL callbacks
   static int ssl_select_next_protocol(SSL *ssl, const unsigned char **out, unsigned char *outlen, const unsigned char *in,
                                       unsigned inlen, void *);
+  static int ssl_client_new_session(SSL *ssl, SSL_SESSION *session);
 
   static int ssl_quic_qc_index;
   static int ssl_quic_tls_index;

--- a/iocore/net/quic/QUICTLS.h
+++ b/iocore/net/quic/QUICTLS.h
@@ -103,6 +103,7 @@ private:
   QUICPacketProtection *_server_pp       = nullptr;
   NetVConnectionContext_t _netvc_context = NET_VCONNECTION_UNSET;
   bool _early_data_processed             = false;
+  bool _is_session_reused                = false;
   bool _early_data                       = true;
   QUICEncryptionLevel _current_level     = QUICEncryptionLevel::INITIAL;
   HandshakeState _state                  = HandshakeState::PROCESSING;

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1345,6 +1345,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.quic.client.supported_groups", RECD_STRING, "P-256:X25519:P-384:P-521" , RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.quic.client.session_file", RECD_STRING, nullptr , RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
   // Transport Parameters
   {RECT_CONFIG, "proxy.config.quic.no_activity_timeout_in", RECD_INT, "30", RECU_DYNAMIC, RR_NULL, RECC_STR, "^-?[0-9]+$", RECA_NULL}
   ,


### PR DESCRIPTION
This pr tries to reuse session with new session ticket msg. And should not be merged until #4399 merged.