### PR TITLE
Fix traffic_via problem with string length

### DIFF
--- a/src/traffic_via/tests/[u c s f p eS;tNc  p s ]
+++ b/src/traffic_via/tests/[u c s f p eS;tNc  p s ]
@@ -1,4 +1,4 @@
-Via header is [u c s f p eS;tNc   p s ], Length is 25
+Via header is [u c s f p eS;tNc  p s ], Length is 24
 Via Header Details:
 Request headers received from client                   :unknown
 Result of Traffic Server cache lookup for URL          :no cache lookup

--- a/src/traffic_via/tests/[uIcRs f p eN;t cCHp s ]
+++ b/src/traffic_via/tests/[uIcRs f p eN;t cCHp s ]
@@ -1,6 +1,6 @@
-Via header is [uScRs f p eN;t cCH p s ], Length is 25
+Via header is [uIcRs f p eN;t cCHp s ], Length is 24
 Via Header Details:
-Request headers received from client                   :simple request (not conditional)
+Request headers received from client                   :IMS
 Result of Traffic Server cache lookup for URL          :in cache, fresh Ram hit (a cache "HIT")
 Response information received from origin server       :no server connection needed
 Result of document write-to-cache:                     :no cache write performed

--- a/src/traffic_via/tests/[uIcRs f p eN;t cCNp s ]
+++ b/src/traffic_via/tests/[uIcRs f p eN;t cCNp s ]
@@ -1,4 +1,4 @@
-Via header is [uIcRs f p eN;t cCN p s ], Length is 25
+Via header is [uIcRs f p eN;t cCNp s ], Length is 24
 Via Header Details:
 Request headers received from client                   :IMS
 Result of Traffic Server cache lookup for URL          :in cache, fresh Ram hit (a cache "HIT")

--- a/src/traffic_via/tests/[uScMsSf pSeN;t cCMp sS]
+++ b/src/traffic_via/tests/[uScMsSf pSeN;t cCMp sS]
@@ -1,4 +1,4 @@
-Via header is [uScMsSf pSeN;t cCM p sS], Length is 25
+Via header is [uScMsSf pSeN;t cCMp sS], Length is 24
 Via Header Details:
 Request headers received from client                   :simple request (not conditional)
 Result of Traffic Server cache lookup for URL          :miss (a cache "MISS")

--- a/src/traffic_via/tests/[uScRs f p eN;t cCHp s ]
+++ b/src/traffic_via/tests/[uScRs f p eN;t cCHp s ]
@@ -1,6 +1,6 @@
-Via header is [uIcRs f p eN;t cCH p s ], Length is 25
+Via header is [uScRs f p eN;t cCHp s ], Length is 24
 Via Header Details:
-Request headers received from client                   :IMS
+Request headers received from client                   :simple request (not conditional)
 Result of Traffic Server cache lookup for URL          :in cache, fresh Ram hit (a cache "HIT")
 Response information received from origin server       :no server connection needed
 Result of document write-to-cache:                     :no cache write performed

--- a/src/traffic_via/tests/long rubbish via code2
+++ b/src/traffic_via/tests/long rubbish via code2
@@ -12,6 +12,6 @@ traffic_via: Invalid VIA header character: i
 traffic_via: Invalid VIA header character: a
 traffic_via: Invalid VIA header character: o
 traffic_via: Invalid VIA header character: d
-Via header is long rubbish via code 2, Length is 23
+Via header is long rubbish via code2, Length is 22
 Via Header Details:
-Error codes (if any)                                   :unknown
+Error codes (if any)                                   :Invalid sequence

--- a/src/traffic_via/tests/rubbish
+++ b/src/traffic_via/tests/rubbish
@@ -1,4 +1,4 @@
 Via header is rubbish, Length is 7
 
-Invalid VIA header. VIA header length should be 6 or 23 characters
+Invalid VIA header. VIA header length should be 6 or 22 characters
 Valid via header format is [u<client-stuff>c<cache-lookup-stuff>s<server-stuff>f<cache-fill-stuff>p<proxy-stuff>e<error-codes>:t<tunneling-info>c<cache type><cache-lookup-result>p<parent-proxy-conn-info>s<server-conn-info>]

--- a/src/traffic_via/traffic_via.cc
+++ b/src/traffic_via/traffic_via.cc
@@ -238,13 +238,13 @@ decodeViaHeader(const char *str)
     ++viaHdrLength;
   }
 
-  if (viaHdrLength == 23 || viaHdrLength == 6) {
+  if (viaHdrLength == 22 || viaHdrLength == 6) {
     // Decode via header
     printViaHeader(Via);
     return TS_ERR_OKAY;
   }
   // Invalid header size, come out.
-  printf("\nInvalid VIA header. VIA header length should be 6 or 23 characters\n");
+  printf("\nInvalid VIA header. VIA header length should be 6 or 22 characters\n");
   printf("Valid via header format is "
          "[u<client-stuff>c<cache-lookup-stuff>s<server-stuff>f<cache-fill-stuff>p<proxy-stuff>e<error-codes>:t<tunneling-info>c<"
          "cache type><cache-lookup-result>p<parent-proxy-conn-info>s<server-conn-info>]\n");


### PR DESCRIPTION
I think we have a problem with traffic_via since commit 925cbb40ea132bcbf9a68303d4833f73f0d7e22b 

We should be removing 2 characters instead of 1. 