### PR TITLE
Split current client transactions metrics into HTTP/1.1 and HTTP/2

### DIFF
--- a/doc/admin-guide/monitoring/statistics/core/http-connection.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/http-connection.en.rst
@@ -58,6 +58,8 @@ HTTP Connection
 .. ts:stat:: global proxy.process.http.current_client_transactions integer
    :type: gauge
 
+   Represents the current number of HTTP/1.0 and HTTP/1.1 transactions from client to the |TS|.
+
 .. ts:stat:: global proxy.process.http.current_server_connections integer
    :type: gauge
 
@@ -140,3 +142,8 @@ HTTP Connection
    :type: gauge
 
    Represents the current number of HTTP/2 connections from client to the |TS|.
+
+.. ts:stat:: global proxy.process.http2.current_client_streams integer
+   :type: gauge
+
+   Represents the current number of HTTP/2 streams from client to the |TS|.

--- a/proxy/ProxyTransaction.cc
+++ b/proxy/ProxyTransaction.cc
@@ -57,6 +57,7 @@ ProxyTransaction::new_transaction()
     current_reader->plugin_id  = pi->getPluginId();
   }
 
+  this->increment_client_transactions_stat();
   current_reader->attach_client_session(this, sm_reader);
 }
 
@@ -65,6 +66,8 @@ ProxyTransaction::release(IOBufferReader *r)
 {
   HttpTxnDebug("[%" PRId64 "] session released by sm [%" PRId64 "]", parent ? parent->connection_id() : 0,
                current_reader ? current_reader->sm_id : 0);
+
+  this->decrement_client_transactions_stat();
 
   // Pass along the release to the session
   if (parent) {

--- a/proxy/ProxyTransaction.h
+++ b/proxy/ProxyTransaction.h
@@ -264,6 +264,9 @@ public:
   void set_rx_error_code(ProxyError e);
   void set_tx_error_code(ProxyError e);
 
+  virtual void increment_client_transactions_stat() = 0;
+  virtual void decrement_client_transactions_stat() = 0;
+
 protected:
   ProxySession *parent;
   HttpSM *current_reader;

--- a/proxy/http/Http1Transaction.cc
+++ b/proxy/http/Http1Transaction.cc
@@ -78,3 +78,15 @@ Http1Transaction::allow_half_open() const
   }
   return false;
 }
+
+void
+Http1Transaction::increment_client_transactions_stat()
+{
+  HTTP_INCREMENT_DYN_STAT(http_current_client_transactions_stat);
+}
+
+void
+Http1Transaction::decrement_client_transactions_stat()
+{
+  HTTP_DECREMENT_DYN_STAT(http_current_client_transactions_stat);
+}

--- a/proxy/http/Http1Transaction.h
+++ b/proxy/http/Http1Transaction.h
@@ -127,6 +127,9 @@ public:
     return get_transact_count();
   }
 
+  void increment_client_transactions_stat() override;
+  void decrement_client_transactions_stat() override;
+
 protected:
   bool outbound_transparent{false};
 };

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -486,7 +486,6 @@ HttpSM::attach_client_session(ProxyTransaction *client_vc, IOBufferReader *buffe
 
   ink_release_assert(ua_txn->get_half_close_flag() == false);
   mutex = client_vc->mutex;
-  HTTP_INCREMENT_DYN_STAT(http_current_client_transactions_stat);
   if (ua_txn->debug()) {
     debug_on = true;
   }
@@ -6919,7 +6918,6 @@ HttpSM::kill_this()
 
     SMDebug("http", "[%" PRId64 "] deallocating sm", sm_id);
     //    authAdapter.destroyState();
-    HTTP_DECREMENT_DYN_STAT(http_current_client_transactions_stat);
     destroy();
   }
 }

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -738,7 +738,6 @@ Http2Stream::destroy()
   // Clean up the write VIO in case of inactivity timeout
   this->do_io_write(nullptr, 0, nullptr);
 
-  HTTP2_DECREMENT_THREAD_DYN_STAT(HTTP2_STAT_CURRENT_CLIENT_STREAM_COUNT, _thread);
   ink_hrtime end_time = Thread::get_hrtime();
   HTTP2_SUM_THREAD_DYN_STAT(HTTP2_STAT_TOTAL_TRANSACTIONS_TIME, _thread, end_time - _start_time);
   _req_header.destroy();
@@ -891,6 +890,19 @@ Http2Stream::release(IOBufferReader *r)
   super::release(r);
   current_reader = nullptr; // State machine is on its own way down.
   this->do_io_close();
+}
+
+void
+Http2Stream::increment_client_transactions_stat()
+{
+  HTTP2_INCREMENT_THREAD_DYN_STAT(HTTP2_STAT_CURRENT_CLIENT_STREAM_COUNT, _thread);
+  HTTP2_INCREMENT_THREAD_DYN_STAT(HTTP2_STAT_TOTAL_CLIENT_STREAM_COUNT, _thread);
+}
+
+void
+Http2Stream::decrement_client_transactions_stat()
+{
+  HTTP2_DECREMENT_THREAD_DYN_STAT(HTTP2_STAT_CURRENT_CLIENT_STREAM_COUNT, _thread);
 }
 
 bool

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -51,8 +51,6 @@ public:
     _start_time       = Thread::get_hrtime();
     _thread           = this_ethread();
     this->client_rwnd = initial_rwnd;
-    HTTP2_INCREMENT_THREAD_DYN_STAT(HTTP2_STAT_CURRENT_CLIENT_STREAM_COUNT, _thread);
-    HTTP2_INCREMENT_THREAD_DYN_STAT(HTTP2_STAT_TOTAL_CLIENT_STREAM_COUNT, _thread);
     sm_reader = request_reader = request_buffer.alloc_reader();
     http_parser_init(&http_parser);
     // FIXME: Are you sure? every "stream" needs request_header?
@@ -221,6 +219,9 @@ public:
   {
     return is_first_transaction_flag;
   }
+
+  void increment_client_transactions_stat() override;
+  void decrement_client_transactions_stat() override;
 
 private:
   void response_initialize_data_handling(bool &is_done);


### PR DESCRIPTION
`proxy.process.http.current_client_transactions` has number of transactions regardless protocols.
It’s useful that each protocol has its own metrics.

// Before
- `proxy.process.http.current_client_transactions` for HTTP/1.1 & HTTP/2
- `proxy.process.http2.current_client_streams` for HTTP/2

// After
- `proxy.process.http.current_client_transactions` for HTTP/1.1
- `proxy.process.http2.current_client_streams` for HTTP/2

----
This is client transaction version of #4388.

