### PR TITLE
YAML: LibSWOC IntrusiveDList update.

### DIFF
--- a/doc/developer-guide/internal-libraries/intrusive-list.en.rst
+++ b/doc/developer-guide/internal-libraries/intrusive-list.en.rst
@@ -134,7 +134,7 @@ Examples
 In this example the goal is to have a list of :code:`Message` objects. First the class is declared
 along with the internal linkage support.
 
-.. literalinclude:: ../../../src/tscore/unit_tests/test_IntrusiveDList.cc
+.. literalinclude:: ../../../src/tscpp/util/unit_tests/test_IntrusiveDList.cc
    :lines: 38-63
 
 The struct :code:`Linkage` is used both to provide the descriptor to :class:`IntrusiveDList` and to
@@ -144,35 +144,35 @@ used only by a specific container class (:code:`Container`) the struct is made p
 
 The implementation of the link accessor methods.
 
-.. literalinclude:: ../../../src/tscore/unit_tests/test_IntrusiveDList.cc
+.. literalinclude:: ../../../src/tscpp/util/unit_tests/test_IntrusiveDList.cc
    :lines: 65-74
 
 A method to check if the message is in a list.
 
-.. literalinclude:: ../../../src/tscore/unit_tests/test_IntrusiveDList.cc
+.. literalinclude:: ../../../src/tscpp/util/unit_tests/test_IntrusiveDList.cc
    :lines: 76-80
 
 The container class for the messages could be implemented as
 
-.. literalinclude:: ../../../src/tscore/unit_tests/test_IntrusiveDList.cc
+.. literalinclude:: ../../../src/tscpp/util/unit_tests/test_IntrusiveDList.cc
    :lines: 82-99
 
 The :code:`debug` method takes a format string (:arg:`fmt`) and an arbitrary set of arguments, formats
 the arguments in to the string, and adds the new message to the list.
 
-.. literalinclude:: ../../../src/tscore/unit_tests/test_IntrusiveDList.cc
+.. literalinclude:: ../../../src/tscpp/util/unit_tests/test_IntrusiveDList.cc
    :lines: 122-131
 
 The :code:`print` method demonstrates the use of the range :code:`for` loop on a list.
 
-.. literalinclude:: ../../../src/tscore/unit_tests/test_IntrusiveDList.cc
+.. literalinclude:: ../../../src/tscpp/util/unit_tests/test_IntrusiveDList.cc
    :lines: 142-148
 
 The maximum severity level can also be computed even more easily using :code:`std::max_element`.
 This find the element with the maximum severity and returns that severity, or :code:`LVL_DEBUG` if
 no element is found (which happens if the list is empty).
 
-.. literalinclude:: ../../../src/tscore/unit_tests/test_IntrusiveDList.cc
+.. literalinclude:: ../../../src/tscpp/util/unit_tests/test_IntrusiveDList.cc
    :lines: 134-140
 
 Other methods for the various severity levels would be implemented in a similar fashion. Because the
@@ -183,20 +183,20 @@ risky. One approach, illustrated here, is to use :func:`IntrusiveDList::take_hea
 element before destroying it. Another option is to allocation the elements in a :class:`MemArena` to
 avoid the need for any explicit cleanup.
 
-.. literalinclude:: ../../../src/tscore/unit_tests/test_IntrusiveDList.cc
+.. literalinclude:: ../../../src/tscpp/util/unit_tests/test_IntrusiveDList.cc
    :lines: 106-114
 
 In some cases the elements of the list are subclasses and the links are declared in a super class
 and are therefore of the super class type. For instance, in the unit test a class :code:`Thing` is
 defined for testing.
 
-.. literalinclude:: ../../../src/tscore/unit_tests/test_IntrusiveDList.cc
+.. literalinclude:: ../../../src/tscpp/util/unit_tests/test_IntrusiveDList.cc
    :lines: 159
 
 Later on, to validate use on a subclass, :code:`PrivateThing` is defined as a subclass of
 :code:`Thing`.
 
-.. literalinclude:: ../../../src/tscore/unit_tests/test_IntrusiveDList.cc
+.. literalinclude:: ../../../src/tscpp/util/unit_tests/test_IntrusiveDList.cc
    :lines: 181
 
 However, the link members :code:`_next` and :code:`_prev` are of type :code:`Thing*` but the
@@ -205,7 +205,7 @@ descriptor for a list of :code:`PrivateThing` must have link accessors that retu
 :code:`ts::ptr_ref_cast<X, T>` that converts a member of type :code:`T*` to a reference to a pointer
 to :code:`X`, e.g. :code:`X*&`. This is used in the setup for testing :code:`PrivateThing`.
 
-.. literalinclude:: ../../../src/tscore/unit_tests/test_IntrusiveDList.cc
+.. literalinclude:: ../../../src/tscpp/util/unit_tests/test_IntrusiveDList.cc
    :lines: 190-199
 
 While this can be done directly with :code:`reinterpret_cast<>`, use of :code:`ts::ptr_cast` avoids

--- a/include/tscore/IntrusiveHashMap.h
+++ b/include/tscore/IntrusiveHashMap.h
@@ -26,7 +26,7 @@
 #include <vector>
 #include <array>
 #include <algorithm>
-#include "tscore/IntrusiveDList.h"
+#include "tscpp/util/IntrusiveDList.h"
 
 /** Intrusive Hash Table.
 
@@ -105,11 +105,11 @@ protected:
    * All table elements are in this list. The buckets reference their starting element in the list, or nothing if
    * no elements are in that bucket.
    */
-  using List = IntrusiveDList<H>;
+  using List = ts::IntrusiveDList<H>;
 
   /// A bucket for the hash map.
   struct Bucket {
-    /// Support for IntrusiveDList<Bucket::Linkage>, definitions and link storage.
+    /// Support for ts::IntrusiveDList<Bucket::Linkage>, definitions and link storage.
     struct Linkage {
       static Bucket *&next_ptr(Bucket *b); ///< Access next pointer.
       static Bucket *&prev_ptr(Bucket *b); ///< Access prev pointer.
@@ -294,7 +294,7 @@ protected:
   Table _table; ///< Array of buckets.
 
   /// List of non-empty buckets.
-  IntrusiveDList<typename Bucket::Linkage> _active_buckets;
+  ts::IntrusiveDList<typename Bucket::Linkage> _active_buckets;
 
   Bucket *bucket_for(key_type key);
 

--- a/include/tscore/IpMap.h
+++ b/include/tscore/IpMap.h
@@ -27,7 +27,7 @@
 #include "tscore/ink_defs.h"
 #include "tscore/RbTree.h"
 #include "tscore/ink_inet.h"
-#include "tscore/IntrusiveDList.h"
+#include "tscpp/util/IntrusiveDList.h"
 #include "tscore/ink_assert.h"
 
 namespace ts

--- a/include/tscpp/util/Makefile.am
+++ b/include/tscpp/util/Makefile.am
@@ -19,5 +19,6 @@
 library_includedir=$(includedir)/tscpp/util
 
 library_include_HEADERS = \
+	IntrusiveDList.h \
         PostScript.h \
         TextView.h

--- a/src/tscore/IntrusivePtrTest.cc
+++ b/src/tscore/IntrusivePtrTest.cc
@@ -22,7 +22,7 @@
 */
 
 #include "tscore/IntrusivePtr.h"
-#include "tscore/IntrusiveDList.h"
+#include "tscpp/util/IntrusiveDList.h"
 #include "tscore/TestBox.h"
 
 namespace

--- a/src/tscore/IpMap.cc
+++ b/src/tscore/IpMap.cc
@@ -282,8 +282,8 @@ namespace detail
         return n->_prev;
       }
     };
-    using NodeList = IntrusiveDList<NodeLinkage>;
-    //    typedef IntrusiveDList<RBNode, &RBNode::_next, &RBNode::_prev> NodeList;
+    using NodeList = ts::IntrusiveDList<NodeLinkage>;
+    //    typedef ts::IntrusiveDList<RBNode, &RBNode::_next, &RBNode::_prev> NodeList;
     /// This keeps track of all allocated nodes in order.
     /// Iteration depends on this list being maintained.
     NodeList _list;

--- a/src/tscore/Makefile.am
+++ b/src/tscore/Makefile.am
@@ -160,7 +160,6 @@ libtscore_la_SOURCES = \
 	ink_time.h \
 	ink_uuid.cc \
 	ink_uuid.h \
-	IntrusiveDList.h \
 	IpMap.cc \
 	IpMapConf.cc \
 	IpMapConf.h \
@@ -257,7 +256,6 @@ test_tscore_SOURCES = \
 	unit_tests/test_Extendible.cc \
 	unit_tests/test_History.cc \
 	unit_tests/test_ink_inet.cc \
-	unit_tests/test_IntrusiveDList.cc \
 	unit_tests/test_IntrusiveHashMap.cc \
 	unit_tests/test_IntrusivePtr.cc \
 	unit_tests/test_IpMap.cc \

--- a/src/tscpp/util/Makefile.am
+++ b/src/tscpp/util/Makefile.am
@@ -27,6 +27,7 @@ AM_CPPFLAGS += -I$(abs_top_srcdir)/include
 libtscpputil_la_LDFLAGS = -no-undefined -version-info @TS_LIBTOOL_VERSION@
 
 libtscpputil_la_SOURCES = \
+	IntrusiveDList.h \
 	PostScript.h \
 	TextView.h TextView.cc
 

--- a/src/tscpp/util/unit_tests/test_IntrusiveDList.cc
+++ b/src/tscpp/util/unit_tests/test_IntrusiveDList.cc
@@ -4,20 +4,17 @@
 
     @section license License
 
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements.  See the NOTICE file distributed with this work for additional information regarding
+    copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with the License.  You may
+    obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the License for the specific language governing permissions and
     limitations under the License.
 */
 
@@ -26,10 +23,12 @@
 #include <string>
 #include <algorithm>
 
-#include "tscore/IntrusiveDList.h"
-#include "tscore/BufferWriter.h"
+#include "tscpp/util/IntrusiveDList.h"
+#include "tscpp/util/bwf_base.h"
 
-#include <catch.hpp>
+#include "catch.hpp"
+
+using ts::IntrusiveDList;
 
 // --------------------
 // Code for documentation - placed here to guarantee the examples at least compile.
@@ -82,7 +81,7 @@ Message::is_in_list() const
 class Container
 {
   using self_type   = Container;
-  using MessageList = IntrusiveDList<Message::Linkage>;
+  using MessageList = ts::IntrusiveDList<Message::Linkage>;
 
 public:
   ~Container();
@@ -147,7 +146,7 @@ Container::print() const
   }
 }
 
-TEST_CASE("IntrusiveDList Example", "[libts][IntrusiveDList]")
+TEST_CASE("IntrusiveDList Example", "[libtscpputil][IntrusiveDList]")
 {
   Container container;
 
@@ -210,10 +209,10 @@ public:
 // If any lines above here are changed, the documentation must be updated.
 // --------------------
 
-using ThingList        = IntrusiveDList<Thing::Linkage>;
-using PrivateThingList = IntrusiveDList<PrivateThing::Linkage>;
+using ThingList        = ts::IntrusiveDList<Thing::Linkage>;
+using PrivateThingList = ts::IntrusiveDList<PrivateThing::Linkage>;
 
-TEST_CASE("IntrusiveDList", "[libts][IntrusiveDList]")
+TEST_CASE("IntrusiveDList", "[libtscpputil][IntrusiveDList]")
 {
   ThingList list;
   int n;


### PR DESCRIPTION
This is the start of backporting the necessary infrastructure updates to ATS to support Canned-YAML. The current [full change list is here](https://github.com/SolidWallOfCode/trafficserver/pull/27).

Nothing major, but a number of minor fixes. This also moves `IntrusiveDList` to the `ts` namespace.