### PR TITLE
YAML: Move ts_meta to external C++ library.

### DIFF
--- a/include/tscpp/util/ts_meta.h
+++ b/include/tscpp/util/ts_meta.h
@@ -36,7 +36,7 @@ namespace meta
    * the expression for validity. E.g.
    *
    * @code
-   * template <typename T> auto func(T && t, CaseArg_0 const&) -> decltype(t.item, int()) { }
+   * template <typename T> auto func(T && t, CaseTag<0>) -> decltype(t.item, int()) { }
    * @endcode
    *
    * The comma operator discards the type and value of the left operand therefore the return type of

--- a/src/tscore/Makefile.am
+++ b/src/tscore/Makefile.am
@@ -273,7 +273,6 @@ test_tscore_SOURCES = \
 	unit_tests/test_Scalar.cc \
 	unit_tests/test_scoped_resource.cc \
 	unit_tests/test_ts_file.cc \
-	unit_tests/test_ts_meta.cc \
 	unit_tests/test_Vec.cc
 
 CompileParseRules_SOURCES = CompileParseRules.cc

--- a/src/tscpp/util/Makefile.am
+++ b/src/tscpp/util/Makefile.am
@@ -38,7 +38,8 @@ test_tscpputil_LDADD = libtscpputil.la
 test_tscpputil_SOURCES = \
 	unit_tests/unit_test_main.cc \
 	unit_tests/test_PostScript.cc \
-	unit_tests/test_TextView.cc
+	unit_tests/test_TextView.cc \
+	unit_tests/test_ts_meta.cc
 
 clean-local:
 	rm -f ParseRulesCType ParseRulesCTypeToLower ParseRulesCTypeToUpper

--- a/src/tscpp/util/unit_tests/test_ts_meta.cc
+++ b/src/tscpp/util/unit_tests/test_ts_meta.cc
@@ -20,7 +20,8 @@
 
 #include <cstring>
 
-#include "tscore/ts_meta.h"
+#include "tscpp/util/ts_meta.h"
+#include "tscpp/util/TextView.h"
 
 #include "catch.hpp"
 


### PR DESCRIPTION
Future YAML support will require this, and that will be need to be externalized for plugin access, so this needs to move first.