### PR TITLE
TCL: All ink_hash_table in proxy converted to use STL

### DIFF
--- a/proxy/ControlMatcher.h
+++ b/proxy/ControlMatcher.h
@@ -87,7 +87,6 @@
 #pragma once
 
 #include "tscore/DynArray.h"
-#include "tscore/ink_hash_table.h"
 #include "tscore/IpMap.h"
 #include "tscore/Result.h"
 #include "tscore/MatcherUtils.h"
@@ -97,6 +96,8 @@
 #include "HTTP.h"
 #include "tscore/Regex.h"
 #include "URL.h"
+
+#include <unordered_map>
 
 #ifdef HAVE_CTYPE_H
 #include <cctype>
@@ -203,7 +204,7 @@ public:
   using super::array_len;
 
 private:
-  InkHashTable *url_ht;
+  std::unordered_map<std::string, int> url_ht;
   char **url_str = nullptr; // array of url strings
   int *url_value = nullptr; // array of posion of url strings
 };

--- a/proxy/InkAPIInternal.h
+++ b/proxy/InkAPIInternal.h
@@ -335,7 +335,7 @@ public:
   void invoke(INKContInternal *contp);
 
 private:
-  InkHashTable *cb_table;
+  std::unordered_map<std::string, INKContInternal *> cb_table;
 };
 
 void api_init();

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -74,10 +74,6 @@ Http2ClientSession::destroy()
 void
 Http2ClientSession::free()
 {
-  if (h2_pushed_urls) {
-    this->h2_pushed_urls = ink_hash_table_destroy(this->h2_pushed_urls);
-  }
-
   if (client_vc) {
     client_vc->do_io_close();
     client_vc = nullptr;
@@ -181,8 +177,6 @@ Http2ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOB
   this->read_buffer             = iobuf ? iobuf : new_MIOBuffer(HTTP2_HEADER_BUFFER_SIZE_INDEX);
   this->read_buffer->water_mark = connection_state.server_settings.get(HTTP2_SETTINGS_MAX_FRAME_SIZE);
   this->sm_reader               = reader ? reader : this->read_buffer->alloc_reader();
-  this->h2_pushed_urls          = ink_hash_table_create(InkHashTableKeyType_String);
-  this->h2_pushed_urls_size     = 0;
 
   this->write_buffer = new_MIOBuffer(HTTP2_HEADER_BUFFER_SIZE_INDEX);
   this->sm_writer    = this->write_buffer->alloc_reader();

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -284,20 +284,14 @@ public:
   bool
   is_url_pushed(const char *url, int url_len)
   {
-    char *dup_url            = ats_strndup(url, url_len);
-    InkHashTableEntry *entry = ink_hash_table_lookup_entry(h2_pushed_urls, dup_url);
-    ats_free(dup_url);
-    return entry != nullptr;
+    return h2_pushed_urls.find(url) != h2_pushed_urls.end();
   }
 
   void
   add_url_to_pushed_table(const char *url, int url_len)
   {
-    if (h2_pushed_urls_size < Http2::push_diary_size) {
-      char *dup_url = ats_strndup(url, url_len);
-      ink_hash_table_insert(h2_pushed_urls, dup_url, nullptr);
-      h2_pushed_urls_size++;
-      ats_free(dup_url);
+    if (h2_pushed_urls.size() < Http2::push_diary_size) {
+      h2_pushed_urls.emplace(url);
     }
   }
 
@@ -345,8 +339,7 @@ private:
   bool half_close_local = false;
   int recursion         = 0;
 
-  InkHashTable *h2_pushed_urls = nullptr;
-  uint32_t h2_pushed_urls_size = 0;
+  std::unordered_set<std::string> h2_pushed_urls;
 };
 
 extern ClassAllocator<Http2ClientSession> http2ClientSessionAllocator;

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -1353,50 +1353,33 @@ APIHooks::clear()
 //
 ////////////////////////////////////////////////////////////////////
 
-ConfigUpdateCbTable::ConfigUpdateCbTable()
-{
-  cb_table = ink_hash_table_create(InkHashTableKeyType_String);
-}
+ConfigUpdateCbTable::ConfigUpdateCbTable() {}
 
-ConfigUpdateCbTable::~ConfigUpdateCbTable()
-{
-  ink_assert(cb_table != nullptr);
-
-  ink_hash_table_destroy(cb_table);
-}
+ConfigUpdateCbTable::~ConfigUpdateCbTable() {}
 
 void
 ConfigUpdateCbTable::insert(INKContInternal *contp, const char *name)
 {
-  ink_assert(cb_table != nullptr);
-
   if (contp && name) {
-    ink_hash_table_insert(cb_table, (InkHashTableKey)name, (InkHashTableValue)contp);
+    cb_table.emplace(name, contp);
   }
 }
 
 void
 ConfigUpdateCbTable::invoke(const char *name)
 {
-  ink_assert(cb_table != nullptr);
-
-  InkHashTableIteratorState ht_iter;
-  InkHashTableEntry *ht_entry;
   INKContInternal *contp;
 
   if (name != nullptr) {
     if (strcmp(name, "*") == 0) {
-      ht_entry = ink_hash_table_iterator_first(cb_table, &ht_iter);
-      while (ht_entry != nullptr) {
-        contp = (INKContInternal *)ink_hash_table_entry_value(cb_table, ht_entry);
+      for (auto &&it : cb_table) {
+        contp = it.second;
         ink_assert(contp != nullptr);
         invoke(contp);
-        ht_entry = ink_hash_table_iterator_next(cb_table, &ht_iter);
       }
     } else {
-      ht_entry = ink_hash_table_lookup_entry(cb_table, (InkHashTableKey)name);
-      if (ht_entry != nullptr) {
-        contp = (INKContInternal *)ink_hash_table_entry_value(cb_table, ht_entry);
+      if (auto it = cb_table.find(name); it != cb_table.end()) {
+        contp = it->second;
         ink_assert(contp != nullptr);
         invoke(contp);
       }


### PR DESCRIPTION
We are pretty close! 

This PR contains the conversion of:
1. `h2_pushed_urls` from `Http2ClientSession.h`
2. `url_ht` from `ControlMatcher.h`
3. `cb_table` from `InkAPIInternal.h`

The only place left is `RawHashTable`. It will be replaced.