### PR TITLE
Don't buffer the logging for TSError

### DIFF
--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -411,14 +411,8 @@ TSError(const char *fmt, ...)
 {
   va_list args;
 
-  if (is_action_tag_set("deft") || is_action_tag_set("sdk_vbos_errors")) {
-    va_start(args, fmt);
-    ErrorV(fmt, args);
-    va_end(args);
-  }
-
   va_start(args, fmt);
-  Log::va_error((char *)fmt, args);
+  ErrorV(fmt, args);
   va_end(args);
 }
 

--- a/tests/gold_tests/headers/domain-blacklist-30x.test.py
+++ b/tests/gold_tests/headers/domain-blacklist-30x.test.py
@@ -112,3 +112,6 @@ passthroughtr.Processes.Default.Command = "python tcp_client.py 127.0.0.1 {0} {1
 passthroughtr.Processes.Default.TimeOut = 5  # seconds
 passthroughtr.Processes.Default.ReturnCode = 0
 passthroughtr.Processes.Default.Streams.stdout = "passthrough_get.gold"
+
+# Overriding the built in ERROR check since we expect some ERROR messages
+ts.Disk.diags_log.Content = Testers.ContainsExpression("unsupported redirect status 0", "This test is a failure test")

--- a/tests/gold_tests/pluginTest/url_sig/url_sig.test.py
+++ b/tests/gold_tests/pluginTest/url_sig/url_sig.test.py
@@ -254,3 +254,6 @@ tr.Processes.Default.Command = (
     "foo/abcde/qrstuvwxyz?E=33046618506&A=1&K=7&P=1&S=acae22b0e1ba6ea6fbb5d26018dbf152558e98cb'" +
     LogTee + " ; grep -F -e '< HTTP' -e Authorization {0}/url_sig_long.log > {0}/url_sig_short.log ".format(ts.RunDirectory)
 )
+
+# Overriding the built in ERROR check since we expect some ERROR messages
+ts.Disk.diags_log.Content = Testers.ContainsExpression("ERROR", "Some tests are failure tests")


### PR DESCRIPTION
Don't buffer the logging of errors for TSError.  The problem happens that when a plugin tries to print out error messages they get buffered and never go to the error log if traffic_server exits on startup.