### PR TITLE
YAML: Inline BufferWriter formatting functions.

### DIFF
--- a/include/tscore/CryptoHash.h
+++ b/include/tscore/CryptoHash.h
@@ -180,19 +180,9 @@ CryptoContext::finalize(CryptoHash &hash)
   return reinterpret_cast<CryptoContextBase *>(_obj)->finalize(hash);
 }
 
-} // namespace ats
+ts::BufferWriter &bwformat(ts::BufferWriter &w, ts::BWFSpec const &spec, ats::CryptoHash const &hash);
 
-namespace ts
-{
-inline BufferWriter &
-bwformat(BufferWriter &w, BWFSpec const &spec, ats::CryptoHash const &hash)
-{
-  BWFSpec local_spec{spec};
-  if ('X' != local_spec._type)
-    local_spec._type = 'x';
-  return bwformat(w, local_spec, std::string_view(reinterpret_cast<const char *>(hash.u8), CRYPTO_HASH_SIZE));
-}
-} // namespace ts
+} // namespace ats
 
 using ats::CryptoHash;
 using ats::CryptoContext;

--- a/proxy/http/HttpConnectionCount.cc
+++ b/proxy/http/HttpConnectionCount.cc
@@ -407,6 +407,17 @@ OutboundConnTrack::TxnState::Warn_Blocked(TxnConfig *config, int64_t sm_id, int 
 namespace ts
 {
 BufferWriter &
+bwformat(BufferWriter &w, BWFSpec const &spec, OutboundConnTrack::MatchType type)
+{
+  if (spec.has_numeric_type()) {
+    bwformat(w, spec, static_cast<unsigned int>(type));
+  } else {
+    bwformat(w, spec, OutboundConnTrack::MATCH_TYPE_NAME[type]);
+  }
+  return w;
+}
+
+BufferWriter &
 bwformat(BufferWriter &w, BWFSpec const &spec, OutboundConnTrack::Group::Key const &key)
 {
   switch (key._match_type) {

--- a/proxy/http/HttpConnectionCount.h
+++ b/proxy/http/HttpConnectionCount.h
@@ -430,17 +430,7 @@ Action *register_ShowConnectionCount(Continuation *, HTTPHdr *);
 
 namespace ts
 {
-inline BufferWriter &
-bwformat(BufferWriter &w, BWFSpec const &spec, OutboundConnTrack::MatchType type)
-{
-  if (spec.has_numeric_type()) {
-    bwformat(w, spec, static_cast<unsigned int>(type));
-  } else {
-    bwformat(w, spec, OutboundConnTrack::MATCH_TYPE_NAME[type]);
-  }
-  return w;
-}
-
+BufferWriter &bwformat(BufferWriter &w, BWFSpec const &spec, OutboundConnTrack::MatchType type);
 BufferWriter &bwformat(BufferWriter &w, BWFSpec const &spec, OutboundConnTrack::Group::Key const &key);
 BufferWriter &bwformat(BufferWriter &w, BWFSpec const &spec, OutboundConnTrack::Group const &g);
 } // namespace ts

--- a/proxy/http/HttpDebugNames.cc
+++ b/proxy/http/HttpDebugNames.cc
@@ -476,3 +476,43 @@ HttpDebugNames::get_api_hook_name(TSHttpHookID t)
 
   return "unknown hook";
 }
+
+ts::BufferWriter &
+bwformat(ts::BufferWriter &w, ts::BWFSpec const &spec, HttpTransact::ServerState_t state)
+{
+  if (spec.has_numeric_type()) {
+    return bwformat(w, spec, static_cast<uintmax_t>(state));
+  } else {
+    return bwformat(w, spec, HttpDebugNames::get_server_state_name(state));
+  }
+}
+
+ts::BufferWriter &
+bwformat(ts::BufferWriter &w, ts::BWFSpec const &spec, HttpTransact::CacheAction_t state)
+{
+  if (spec.has_numeric_type()) {
+    return bwformat(w, spec, static_cast<uintmax_t>(state));
+  } else {
+    return bwformat(w, spec, HttpDebugNames::get_cache_action_name(state));
+  }
+}
+
+ts::BufferWriter &
+bwformat(ts::BufferWriter &w, ts::BWFSpec const &spec, HttpTransact::StateMachineAction_t state)
+{
+  if (spec.has_numeric_type()) {
+    return bwformat(w, spec, static_cast<uintmax_t>(state));
+  } else {
+    return bwformat(w, spec, HttpDebugNames::get_action_name(state));
+  }
+}
+
+ts::BufferWriter &
+bwformat(ts::BufferWriter &w, ts::BWFSpec const &spec, TSHttpHookID id)
+{
+  if (spec.has_numeric_type()) {
+    return bwformat(w, spec, static_cast<uintmax_t>(id));
+  } else {
+    return bwformat(w, spec, HttpDebugNames::get_api_hook_name(id));
+  }
+}

--- a/proxy/http/HttpDebugNames.h
+++ b/proxy/http/HttpDebugNames.h
@@ -37,42 +37,7 @@ public:
   static const char *get_server_state_name(HttpTransact::ServerState_t state);
 };
 
-inline ts::BufferWriter &
-bwformat(ts::BufferWriter &w, ts::BWFSpec const &spec, HttpTransact::ServerState_t state)
-{
-  if (spec.has_numeric_type()) {
-    return bwformat(w, spec, static_cast<uintmax_t>(state));
-  } else {
-    return bwformat(w, spec, HttpDebugNames::get_server_state_name(state));
-  }
-}
-
-inline ts::BufferWriter &
-bwformat(ts::BufferWriter &w, ts::BWFSpec const &spec, HttpTransact::CacheAction_t state)
-{
-  if (spec.has_numeric_type()) {
-    return bwformat(w, spec, static_cast<uintmax_t>(state));
-  } else {
-    return bwformat(w, spec, HttpDebugNames::get_cache_action_name(state));
-  }
-}
-
-inline ts::BufferWriter &
-bwformat(ts::BufferWriter &w, ts::BWFSpec const &spec, HttpTransact::StateMachineAction_t state)
-{
-  if (spec.has_numeric_type()) {
-    return bwformat(w, spec, static_cast<uintmax_t>(state));
-  } else {
-    return bwformat(w, spec, HttpDebugNames::get_action_name(state));
-  }
-}
-
-inline ts::BufferWriter &
-bwformat(ts::BufferWriter &w, ts::BWFSpec const &spec, TSHttpHookID id)
-{
-  if (spec.has_numeric_type()) {
-    return bwformat(w, spec, static_cast<uintmax_t>(id));
-  } else {
-    return bwformat(w, spec, HttpDebugNames::get_api_hook_name(id));
-  }
-}
+ts::BufferWriter &bwformat(ts::BufferWriter &w, ts::BWFSpec const &spec, HttpTransact::ServerState_t state);
+ts::BufferWriter &bwformat(ts::BufferWriter &w, ts::BWFSpec const &spec, HttpTransact::CacheAction_t state);
+ts::BufferWriter &bwformat(ts::BufferWriter &w, ts::BWFSpec const &spec, HttpTransact::StateMachineAction_t state);
+ts::BufferWriter &bwformat(ts::BufferWriter &w, ts::BWFSpec const &spec, TSHttpHookID id);

--- a/src/tscore/CryptoHash.cc
+++ b/src/tscore/CryptoHash.cc
@@ -107,3 +107,15 @@ CryptoHash::toHexStr(char buffer[(CRYPTO_HASH_SIZE * 2) + 1]) const
 {
   return ink_code_to_hex_str(buffer, u8);
 }
+
+namespace ats
+{
+ts::BufferWriter &
+bwformat(ts::BufferWriter &w, ts::BWFSpec const &spec, ats::CryptoHash const &hash)
+{
+  ts::BWFSpec local_spec{spec};
+  if ('X' != local_spec._type)
+    local_spec._type = 'x';
+  return bwformat(w, local_spec, std::string_view(reinterpret_cast<const char *>(hash.u8), CRYPTO_HASH_SIZE));
+}
+} // namespace ats


### PR DESCRIPTION
Move some inline / header defined formatting to source files. This makes further work on upgrading BufferWriter formatting easier. It also reduces the downstream include pile by not requiring the inclusion of the formatting support headers.

[The overall work](https://github.com/SolidWallOfCode/trafficserver/pull/27).