### PR TITLE
allow regex_revalidate per remap rule, remove direct ink includes

### DIFF
--- a/doc/admin-guide/plugins/regex_revalidate.en.rst
+++ b/doc/admin-guide/plugins/regex_revalidate.en.rst
@@ -24,7 +24,8 @@ Regex Revalidate Plugin
 
 This plugin allows for the creation of rules which match regular expressions
 against mapped URLs to determine if and when a cache object revalidation should
-be forced.
+be forced.  This plugin can be used both globally and for individual remap
+rules.
 
 Purpose
 =======
@@ -60,7 +61,7 @@ The rule configuration file format is described below in `Revalidation Rules`_.
 
 By default The plugin regularly (every 60 seconds) checks its rules configuration
 file for changes and it will also check for changes when ``traffic_ctl config reload``
-is run. If the file has been modified since its last scan, the contents
+is run. If the file has been modified since its last scan, the contents 
 are read and the in-memory rules list is updated. Thus, new rules may be added and
 existing ones modified without requiring a service restart.
 


### PR DESCRIPTION
We have one remap rule (delivery service) with 10k+ assets that need invalidation.  Allowing per remap regex revalidation limits the cpu and latency hit to the one misbehaving remap rule (delivery service).