### PR TITLE
YAML: LibSWOC++ update for MemArena.

### DIFF
--- a/include/tscpp/util/Makefile.am
+++ b/include/tscpp/util/Makefile.am
@@ -20,5 +20,7 @@ library_includedir=$(includedir)/tscpp/util
 
 library_include_HEADERS = \
 	IntrusiveDList.h \
+	MemArena.h \
+	MemSpan.h \
         PostScript.h \
         TextView.h

--- a/src/tscore/Makefile.am
+++ b/src/tscore/Makefile.am
@@ -174,9 +174,6 @@ libtscore_la_SOURCES = \
 	Map.h \
 	MatcherUtils.cc \
 	MatcherUtils.h \
-	MemSpan.h \
-	MemArena.cc \
-	MemArena.h \
 	MMH.cc \
 	MMH.h \
 	MT_hashtable.h \
@@ -262,7 +259,6 @@ test_tscore_SOURCES = \
 	unit_tests/test_layout.cc \
 	unit_tests/test_Map.cc \
 	unit_tests/test_List.cc \
-	unit_tests/test_MemArena.cc \
 	unit_tests/test_MT_hashtable.cc \
 	unit_tests/test_PriorityQueue.cc \
 	unit_tests/test_Ptr.cc \

--- a/src/tscpp/util/Makefile.am
+++ b/src/tscpp/util/Makefile.am
@@ -28,6 +28,9 @@ libtscpputil_la_LDFLAGS = -no-undefined -version-info @TS_LIBTOOL_VERSION@
 
 libtscpputil_la_SOURCES = \
 	IntrusiveDList.h \
+	MemArena.h \
+	MemArena.cc \
+	MemSpan.h \
 	PostScript.h \
 	TextView.h TextView.cc
 
@@ -38,6 +41,7 @@ test_tscpputil_CXXFLAGS = -Wno-array-bounds $(AM_CXXFLAGS)
 test_tscpputil_LDADD = libtscpputil.la
 test_tscpputil_SOURCES = \
 	unit_tests/unit_test_main.cc \
+	unit_tests/test_MemArena.cc \
 	unit_tests/test_MemSpan.cc \
 	unit_tests/test_PostScript.cc \
 	unit_tests/test_TextView.cc \


### PR DESCRIPTION
A significant update to improve the memory characteristics. In particular the memory block list uses `IntrusiveDList` instead of shared or intrusive pointers. This simplifies the internal logic. The destructor has also been updated so that a `MemArena` can exist inside its own memory and still destruct cleanly.