### PR TITLE
TextView: Add TransformView for doing in place transforms on string views.

### DIFF
--- a/src/tscpp/util/unit_tests/test_TextView.cc
+++ b/src/tscpp/util/unit_tests/test_TextView.cc
@@ -315,3 +315,39 @@ TEST_CASE("TextView Conversions", "[libts][TextView]")
   REQUIRE(25 == svtoi(n3));
   REQUIRE(31 == svtoi(n3, nullptr, 10));
 }
+
+TEST_CASE("TransformView", "[libts][TransformView]")
+{
+  std::string_view source{"Evil Dave Rulz"};
+  ts::TransformView<int (*)(int), std::string_view> xv1(&tolower, source);
+  // clang and gnu differ on the type of tolower wrt "noexcept". This makes xv1 a different type
+  // from xv2 (or not) depending on the compiler. Therefore we need xv3 to test the equality operator.
+  auto xv2 = ts::transform_view_of(&tolower, source);
+  auto xv3 = ts::transform_view_of(&tolower, source);
+  TextView tv{source};
+
+  bool match_p = true;
+  while (xv1) {
+    if (*xv1 != tolower(*tv)) {
+      match_p = false;
+      break;
+    }
+    ++xv1;
+    ++tv;
+  }
+  REQUIRE(match_p);
+
+  REQUIRE(xv2 == xv3);
+  tv      = source;
+  match_p = true;
+  while (xv2) {
+    if (*xv2 != tolower(*tv)) {
+      match_p = false;
+      break;
+    }
+    ++xv2;
+    ++tv;
+  }
+  REQUIRE(match_p);
+  REQUIRE(xv2 != xv3);
+};


### PR DESCRIPTION
This is inline with efforts in C++20 to do "Ranges" for this same purpose. The initial point of this is better support for hashing, in particular for caseless hashing. Rather that it being a special purpose mechanism, this creates a more general mechanism that can be used for the same purpose. That makes adding it to various hash functors easier, and makes it available for other uses.