### PR TITLE
Fixes more leaks when no OCSP URL is available

### DIFF
--- a/iocore/net/OCSPStapling.cc
+++ b/iocore/net/OCSPStapling.cc
@@ -116,9 +116,6 @@ stapling_get_issuer(SSL_CTX *ssl_ctx, X509 *x)
     }
   }
 
-  if (!X509_STORE_CTX_init(inctx, st, nullptr, nullptr)) {
-    goto end;
-  }
   if (X509_STORE_CTX_get1_issuer(&issuer, inctx, x) <= 0) {
     issuer = nullptr;
   }
@@ -165,12 +162,14 @@ ssl_stapling_init_cert(SSL_CTX *ctx, X509 *cert, const char *certname)
   issuer = stapling_get_issuer(ctx, cert);
   if (issuer == nullptr) {
     Note("cannot get issuer certificate from %s", certname);
-    return false;
+    goto err;
   }
 
   cinf->cid = OCSP_cert_to_id(nullptr, cert, issuer);
-  if (!cinf->cid)
-    return false;
+  if (!cinf->cid) {
+    goto err;
+  }
+
   X509_digest(cert, EVP_sha1(), cinf->idx, nullptr);
 
   aia = X509_get1_ocsp(cert);
@@ -180,17 +179,28 @@ ssl_stapling_init_cert(SSL_CTX *ctx, X509 *cert, const char *certname)
   }
 
   if (!cinf->uri) {
-    OCSP_CERTID_free(cinf->cid);
-    cinf->cid = nullptr;
-
     Note("no OCSP responder URI for %s", certname);
-    return false;
+    goto err;
   }
 
   SSL_CTX_set_ex_data(ctx, ssl_stapling_index, cinf);
 
-  Note("successfully initialized certinfo for %s into SSL_CTX: %p", certname, ctx);
+  Note("successfully initialized stapling for %s into SSL_CTX: %p", certname, ctx);
   return true;
+
+err:
+  if (cinf->uri) {
+    OCSP_CERTID_free(cinf->cid);
+  }
+
+  if (cinf->certname) {
+    ats_free(cinf->certname);
+  }
+
+  if (cinf) {
+    OPENSSL_free(cinf);
+  }
+  return false;
 }
 
 static certinfo *


### PR DESCRIPTION
This is a follow up and more complete version of
19a55a2679dda03f1258e097a82c27c98f00efbc

(cherry picked from commit 82a1368b46701da95524a3b2d71a279753768bbb)

Conflicts:
	iocore/net/OCSPStapling.cc