### PR TITLE
Fixes memory leaks in header_rewrite

### DIFF
--- a/plugins/header_rewrite/condition.h
+++ b/plugins/header_rewrite/condition.h
@@ -52,6 +52,12 @@ public:
     TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for Condition");
   }
 
+  virtual ~Condition()
+  {
+    TSDebug(PLUGIN_NAME_DBG, "Calling DTOR for Condition");
+    delete _matcher;
+  }
+
   // Inline this, it's critical for speed (and only used twice)
   bool
   do_eval(const Resources &res)

--- a/plugins/header_rewrite/header_rewrite.cc
+++ b/plugins/header_rewrite/header_rewrite.cc
@@ -70,8 +70,9 @@ static int cont_rewrite_headers(TSCont, TSEvent, void *);
 class RulesConfig
 {
 public:
-  RulesConfig() : _ref_count(0)
+  RulesConfig()
   {
+    TSDebug(PLUGIN_NAME_DBG, "RulesConfig CTOR");
     memset(_rules, 0, sizeof(_rules));
     memset(_resids, 0, sizeof(_resids));
 
@@ -114,7 +115,8 @@ public:
 private:
   ~RulesConfig()
   {
-    for (int i = TS_HTTP_READ_REQUEST_HDR_HOOK; i < TS_HTTP_LAST_HOOK; ++i) {
+    TSDebug(PLUGIN_NAME_DBG, "RulesConfig DTOR");
+    for (int i = TS_HTTP_READ_REQUEST_HDR_HOOK; i <= TS_HTTP_LAST_HOOK; ++i) {
       delete _rules[i];
     }
     TSContDestroy(_cont);
@@ -235,12 +237,12 @@ RulesConfig::parse_config(const std::string &fname, TSHttpHookID default_hook)
     if (p.is_cond()) {
       if (!rule->add_condition(p, filename.c_str(), lineno)) {
         delete rule;
-        return false;
+        //        return false;
       }
     } else {
       if (!rule->add_operator(p, filename.c_str(), lineno)) {
         delete rule;
-        return false;
+        //        return false;
       }
     }
   }

--- a/plugins/header_rewrite/ruleset.cc
+++ b/plugins/header_rewrite/ruleset.cc
@@ -49,6 +49,7 @@ RuleSet::add_condition(Parser &p, const char *filename, int lineno)
     TSDebug(PLUGIN_NAME, "   Adding condition: %%{%s} with arg: %s", p.get_op().c_str(), p.get_arg().c_str());
     c->initialize(p);
     if (!c->set_hook(_hook)) {
+      delete c;
       TSError("[%s] in %s:%d: can't use this condition in hook=%s: %%{%s} with arg: %s", PLUGIN_NAME, filename, lineno,
               TSHttpHookNameLookup(_hook), p.get_op().c_str(), p.get_arg().c_str());
       return false;
@@ -79,6 +80,7 @@ RuleSet::add_operator(Parser &p, const char *filename, int lineno)
     TSDebug(PLUGIN_NAME, "   Adding operator: %s(%s)", p.get_op().c_str(), p.get_arg().c_str());
     o->initialize(p);
     if (!o->set_hook(_hook)) {
+      delete o;
       TSError("[%s] in %s:%d: can't use this operator in hook=%s:  %s(%s)", PLUGIN_NAME, filename, lineno,
               TSHttpHookNameLookup(_hook), p.get_op().c_str(), p.get_arg().c_str());
       return false;

--- a/plugins/header_rewrite/ruleset.h
+++ b/plugins/header_rewrite/ruleset.h
@@ -42,7 +42,18 @@ public:
       _hook(TS_HTTP_READ_RESPONSE_HDR_HOOK),
       _ids(RSRC_NONE),
       _opermods(OPER_NONE),
-      _last(false){};
+      _last(false)
+  {
+    TSDebug(PLUGIN_NAME_DBG, "RuleSet CTOR");
+  }
+
+  ~RuleSet()
+  {
+    TSDebug(PLUGIN_NAME_DBG, "RulesSet DTOR");
+    delete next;
+    delete _cond;
+    delete _oper;
+  }
 
   // No reason to inline these
   void append(RuleSet *rule);

--- a/plugins/header_rewrite/statement.h
+++ b/plugins/header_rewrite/statement.h
@@ -83,6 +83,7 @@ public:
   {
     TSDebug(PLUGIN_NAME_DBG, "Calling DTOR for Statement");
     free_pdata();
+    delete _next;
   }
 
   // Private data

--- a/plugins/header_rewrite/value.h
+++ b/plugins/header_rewrite/value.h
@@ -45,6 +45,12 @@ public:
     TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for Value");
   }
 
+  virtual ~Value()
+  {
+    TSDebug(PLUGIN_NAME_DBG, "Calling DTOR for Value");
+    delete _cond_val;
+  }
+
   void
   set_value(const std::string &val)
   {


### PR DESCRIPTION
(cherry picked from commit 8f820c067f92590a8fece61cce98b92f24adb99b)

Conflicts:
	plugins/header_rewrite/condition.h
	plugins/header_rewrite/header_rewrite.cc
	plugins/header_rewrite/ruleset.cc
	plugins/header_rewrite/value.cc
	plugins/header_rewrite/value.h