### PR TITLE
Cleanup: replace multiple HashMap with STL unordered_map

### DIFF
--- a/iocore/net/P_SNIActionPerformer.h
+++ b/iocore/net/P_SNIActionPerformer.h
@@ -31,13 +31,13 @@
 #pragma once
 
 #include "I_EventSystem.h"
-#include "tscore/Map.h"
 //#include"P_UnixNetProcessor.h"
 #include <vector>
 #include "P_SSLNextProtocolAccept.h"
 #include "tscore/ink_inet.h"
+#include <unordered_map>
 
-extern Map<int, SSLNextProtocolSet *> snpsMap;
+extern std::unordered_map<int, SSLNextProtocolSet *> snpsMap;
 // enum of all the actions
 enum AllActions {
   TS_DISABLE_H2 = 0,
@@ -67,8 +67,9 @@ public:
     auto ssl_vc     = reinterpret_cast<SSLNetVConnection *>(cont);
     auto accept_obj = ssl_vc ? ssl_vc->accept_object : nullptr;
     if (accept_obj && accept_obj->snpa && ssl_vc) {
-      auto nps = snpsMap.get(accept_obj->id);
-      ssl_vc->registerNextProtocolSet(reinterpret_cast<SSLNextProtocolSet *>(nps));
+      if (auto it = snpsMap.find(accept_obj->id); it != snpsMap.end()) {
+        ssl_vc->registerNextProtocolSet(it->second);
+      }
     }
     return SSL_TLSEXT_ERR_OK;
   }

--- a/iocore/net/P_SSLConfig.h
+++ b/iocore/net/P_SSLConfig.h
@@ -123,7 +123,7 @@ struct SSLConfigParams : public ConfigInfo {
 
   SSL_CTX *client_ctx;
 
-  mutable HashMap<cchar *, class StringHashFns, SSL_CTX *> ctx_map;
+  mutable std::unordered_map<std::string, SSL_CTX *> ctx_map;
   mutable ink_mutex ctxMapLock;
 
   SSL_CTX *getClientSSL_CTX(void) const;

--- a/iocore/net/P_SSLSNI.h
+++ b/iocore/net/P_SSLSNI.h
@@ -31,13 +31,14 @@
 #pragma once
 
 #include "ProxyConfig.h"
-#include "tscore/Map.h"
 #include "P_SNIActionPerformer.h"
 #include "tscore/MatcherUtils.h"
 #include "openssl/ossl_typ.h"
 #include <vector>
 #include <strings.h>
 #include "YamlSNIConfig.h"
+
+#include <unordered_map>
 
 // Properties for the next hop server
 struct NextHopProperty {
@@ -48,9 +49,9 @@ struct NextHopProperty {
   NextHopProperty();
 };
 
-typedef std::vector<ActionItem *> actionVector;
-typedef HashMap<cchar *, StringHashFns, actionVector *> SNIMap;
-typedef HashMap<cchar *, StringHashFns, NextHopProperty *> NextHopPropertyTable;
+using actionVector         = std::vector<ActionItem *>;
+using SNIMap               = std::unordered_map<std::string, actionVector *>;
+using NextHopPropertyTable = std::unordered_map<std::string, NextHopProperty *>;
 
 struct SNIConfigParams : public ConfigInfo {
   char *sni_filename = nullptr;

--- a/iocore/net/SNIActionPerformer.cc
+++ b/iocore/net/SNIActionPerformer.cc
@@ -35,7 +35,7 @@
 #include "P_SSLNextProtocolAccept.h"
 #include "P_SSLUtils.h"
 
-extern Map<int, SSLNextProtocolSet *> snpsMap;
+extern std::unordered_map<int, SSLNextProtocolSet *> snpsMap;
 
 int
 SNIActionPerformer::PerformAction(Continuation *cont, cchar *servername)

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -140,7 +140,7 @@ static ink_mutex *mutex_buf      = nullptr;
 static bool open_ssl_initialized = false;
 
 RecRawStatBlock *ssl_rsb = nullptr;
-HashMap<cchar *, class StringHashFns, intptr_t> cipher_map;
+std::unordered_map<std::string, intptr_t> cipher_map;
 
 /* Using pthread thread ID and mutex functions directly, instead of
  * ATS this_ethread / ProxyMutex, so that other linked libraries
@@ -1127,8 +1127,8 @@ SSLInitializeStatistics()
     }
 
     // If not already registered ...
-    if (0 == cipher_map.get(cipherName)) {
-      cipher_map.put(cipherName, (intptr_t)(ssl_cipher_stats_start + index));
+    if (cipherName && cipher_map.find(cipherName) == cipher_map.end()) {
+      cipher_map.emplace(cipherName, (intptr_t)(ssl_cipher_stats_start + index));
       // Register as non-persistent since the order/index is dependent upon configuration.
       RecRegisterRawStat(ssl_rsb, RECT_PROCESS, statName.c_str(), RECD_INT, RECP_NON_PERSISTENT,
                          (int)ssl_cipher_stats_start + index, RecRawStatSyncSum);
@@ -1540,9 +1540,8 @@ ssl_callback_info(const SSL *ssl, int where, int ret)
     if (cipher) {
       const char *cipherName = SSL_CIPHER_get_name(cipher);
       // lookup index of stat by name and incr count
-      auto data = cipher_map.get(cipherName);
-      if (data != 0) {
-        SSL_INCREMENT_DYN_STAT((intptr_t)data);
+      if (auto it = cipher_map.find(cipherName); it != cipher_map.end()) {
+        SSL_INCREMENT_DYN_STAT((intptr_t)it->second);
       }
     }
   }


### PR DESCRIPTION
This is not related to TCL but we are also trying to get rid of `Map.h`.
It's interesting that we have so many different kinds of hash tables in different places.