### PR TITLE
preventing crashing when calling TSSslContextFindByName with a nullptr or a 0 length string

### DIFF
--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -8816,6 +8816,10 @@ TSVConnSSLConnectionGet(TSVConn sslp)
 tsapi TSSslContext
 TSSslContextFindByName(const char *name)
 {
+  if (nullptr == name || 0 == strlen(name)) {
+    // an empty name is an invalid input
+    return nullptr;
+  }
   TSSslContext ret      = nullptr;
   SSLCertLookup *lookup = SSLCertificateConfig::acquire();
   if (lookup != nullptr) {


### PR DESCRIPTION
@shinrich 