### PR TITLE
LibSWOC++ code drop.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,9 @@ CPP_LIB(records lib/records lib/records)
 
 CPP_LIB(tsconfig lib/tsconfig lib/tsconfig)
 CPP_LIB(wccp src/wccp include/wccp)
+CPP_LIB(swoc++ lib/swoc++/src lib/swoc++/include/swoc)
+CPP_LIB(yamlcpp lib/yamlcpp/src lib/yamlcpp/include/yaml-cpp)
+set_target_properties(yamlcpp PROPERTIES LINKER_LANGUAGE CXX)
 
 file(GLOB plugin_files
         plugins/*/*.h

--- a/configure.ac
+++ b/configure.ac
@@ -2035,6 +2035,7 @@ AC_CONFIG_FILES([
   lib/tsconfig/Makefile
   src/wccp/Makefile
   lib/yamlcpp/Makefile
+  lib/swoc++/Makefile
   mgmt/Makefile
   mgmt/api/Makefile
   mgmt/api/include/Makefile

--- a/lib/swoc++/Makefile.am
+++ b/lib/swoc++/Makefile.am
@@ -1,4 +1,5 @@
-# lib Makefile.am
+#
+# Makefile.am for LibSWOC++.
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
@@ -16,21 +17,18 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-SUBDIRS = . swoc++ records tsconfig
+include $(top_srcdir)/build/tidy.mk
 
-if BUILD_PERL_LIB
-SUBDIRS += perl
-endif
+AM_CPPFLAGS += -I$(abs_top_srcdir)/lib/swoc++/include
 
-# to prevent Clang Analyzer warning
-LOCAL =
+noinst_LTLIBRARIES = libswoc++.la
 
-if BUILD_YAML_CPP
-LOCAL += yamlcpp
-endif
+libswoc___la_SOURCES = \
+	src/bw_format.cc \
+	src/Errata.cc \
+	src/MemArena.cc \
+	src/swoc_file.cc \
+	src/TextView.cc
 
-all-local:	$(LOCAL)
-	$(MAKE) -C yamlcpp
-
-clean-local:
-	$(MAKE) -C yamlcpp clean
+clang-tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/lib/swoc++/include/swoc/BufferWriter.h
+++ b/lib/swoc++/include/swoc/BufferWriter.h
@@ -1,0 +1,547 @@
+/** @file
+
+    Utilities for generating character sequences in buffers.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements.  See the NOTICE file distributed with this work for additional information regarding
+    copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with the License.  You may
+    obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdlib>
+#include <utility>
+#include <cstring>
+#include <vector>
+#include <string>
+#include <iosfwd>
+#include <string_view>
+
+#include "swoc/TextView.h"
+#include "swoc/MemSpan.h"
+
+namespace swoc
+{
+namespace bwf
+{
+  struct Spec;
+  class Format;
+  class BoundNames;
+} // namespace bwf
+
+/** Base (abstract) class for concrete buffer writers.
+ */
+class BufferWriter
+{
+public:
+  /** Add the character @a c to the buffer.
+
+      @a c is added only if there is room in the buffer. If not, the instance is put in to an error
+      state. In either case the value for @c extent is incremented.
+
+      @internal If any variant of @c write discards any characters, the instance must be put in an
+      error state (indicated by the override of @c error).  Derived classes must not assume the
+      write() functions will not be called when the instance is in an error state.
+
+      @return @c *this
+  */
+  virtual BufferWriter &write(char c) = 0;
+
+  /** Add @a data to the buffer, up to @a length bytes.
+
+      Data is added only up to the remaining room in the buffer. If the remaining capacity is
+      exceeded (i.e. data is not written to the output), the instance is put in to an error
+      state. In either case the value for @c extent is incremented by @a length.
+
+      @internal This uses the single character write to output the data. It is presumed concrete
+      subclasses will override this method to use more efficient mechanisms, dependent on the type
+      of output buffer.
+
+      @return @c *this
+  */
+  virtual BufferWriter &write(const void *data, size_t length);
+
+  /** Add the contents of @a sv to the buffer, up to the size of the view.
+
+      Data is added only up to the remaining room in the buffer. If the remaining capacity is
+      exceeded (i.e. data is not written to the output), the instance is put in to an error
+      state. In either case the value for @c extent is incremented by the size of @a sv.
+
+      @return @c *this
+  */
+  BufferWriter &write(const std::string_view &sv);
+
+  /// Get the address of the first byte in the output buffer.
+  virtual const char *data() const = 0;
+
+  /// Get the error state.
+  /// @return @c true if in an error state, @c false if not.
+  virtual bool error() const = 0;
+
+  /** Get the address of the next output byte in the buffer.
+
+      Succeeding calls to non-const member functions, other than this method, must be presumed to
+      invalidate the current auxiliary buffer (contents and address).
+
+      Care must be taken to not write to data beyond this plus @c remaining bytes. Usually the
+      safest mechanism is to create a @c FixedBufferWriter on the auxillary buffer and write to that.
+
+      @code
+      swoc::FixedBufferWriter subw(w.aux_data(), w.remaining());
+      write_some_stuff(subw); // generate output into the buffer.
+      w.fill(subw.extent()); // update main buffer writer.
+      @endcode
+
+      @return Address of the next output byte, or @c nullptr if there is no remaining capacity.
+   */
+  virtual char *aux_data();
+
+  /// Get the total capacity.
+  /// @return The total number of bytes that can be written without causing an error condition.
+  virtual size_t capacity() const = 0;
+
+  /// Get the extent.
+  /// @return Total number of characters that have been written, including those discarded due to an error condition.
+  virtual size_t extent() const = 0;
+
+  /// Get the output size.
+  /// @return Total number of characters that are in the buffer (successfully written and not discarded)
+  size_t size() const;
+
+  /// Get the remaining buffer space.
+  /// @return Number of additional characters that can be written without causing an error condidtion.
+  size_t remaining() const;
+
+  /** Increase the extent by @a n bytes.
+
+      @param n The number of bytes to add to the extent.
+
+      The buffer content is unchanged, only the extent value is adjusted.
+
+      This is useful
+      when doing local buffer filling using @c aux_data. After writing data there, it can be
+      added to the extent using this method.
+
+      @internal Concrete subclasses @b must override this to advance in a way consistent with the
+      specific buffer type.
+
+      @return @c *this
+  */
+  virtual BufferWriter &commit(size_t n) = 0;
+
+  /** Decrease the extent by @a n.
+   *
+   * @param n Number of bytes to remove from the extent.
+   *
+   * The buffer content is unchanged, only the extent value is adjusted.
+   */
+  virtual BufferWriter &discard(size_t n) = 0;
+
+  /// Reduce the capacity by @a n bytes
+  /// If the capacity is reduced below the current @c size the instance goes in to an error state.
+  /// @see restore
+  /// @return @c *this
+  virtual BufferWriter &restrict(size_t n) = 0;
+
+  /// Restore @a n bytes of capacity.
+  /// If there is an error condition, this function clears it and sets the extent to the size.  It
+  /// then increases the capacity by n characters.
+  /// @note It is required that any restored capacity have been previously removed by @c shrink.
+  /// @see shrink
+  virtual BufferWriter &restore(size_t n) = 0;
+
+  /** Copy data from one part of the buffer to another.
+   *
+   * The copy is guaranteed to be correct even if the @a src and @a dst overlap. The regions are
+   * clipped by the current extent. That is, bytes cannot be copied to nor from unwritten buffer.
+   * If the extent is currently more than the capacity, the copy is performed as if the buffer
+   * existed and then clipped to the actual buffer space.
+   *
+   * @param dst Offset of the first by to copy onto.
+   * @param src Offset of the first byte to copy from.
+   * @param n Number of bytes to copy.
+   * @return @c *this
+   */
+  virtual BufferWriter &copy(size_t dst, size_t src, size_t n) = 0;
+
+  // Force virtual destructor.
+  virtual ~BufferWriter();
+
+  /** BufferWriter print.
+
+      This prints its arguments to the @c BufferWriter @a w according to the format @a fmt. The format
+      string is based on Python style formating, each argument substitution marked by braces, {}. Each
+      specification has three parts, a @a name, a @a specifier, and an @a extention. These are
+      separated by colons. The name should be either omitted or a number, the index of the argument to
+      use. If omitted the place in the format string is used as the argument index. E.g. "{} {} {}",
+      "{} {1} {}", and "{0} {1} {2}" are equivalent. Using an explicit index does not reset the
+      position of subsequent substiations, therefore "{} {0} {}" is equivalent to "{0} {0} {2}".
+
+      @note This must be declared here, but the implementation is in @c bwf_base.h
+  */
+  template <typename... Rest> BufferWriter &print(const TextView &fmt, Rest &&... rest);
+
+  /** Print overload to take arguments as a tuple instead of explicitly.
+      This is useful for forwarding variable arguments from other functions / methods.
+  */
+  template <typename... Args> BufferWriter &printv(const TextView &fmt, const std::tuple<Args...> &args);
+
+  /// Print using a preparsed @a fmt.
+  template <typename... Args> BufferWriter &print(const bwf::Format &fmt, Args &&... args);
+  template <typename... Args> BufferWriter &printv(const bwf::Format &fmt, const std::tuple<Args...> &args);
+
+  /** Print the arguments on to the buffer.
+   *
+   * This is the base implementation, all of the other variants are wrappers for this.
+   *
+   * @tparam F Format processor - returns chunks of the format.
+   * @tparam Args Arguments for the format.
+   * @param names Name set for specifier names.
+   */
+  template <typename F, typename... Args>
+  BufferWriter &print_nv(bwf::BoundNames const &names, F &&f, std::tuple<Args...> const &args);
+  /// Convenience for no format argument style invocation.
+  template <typename F> BufferWriter &print_nv(const bwf::BoundNames &names, F &&f);
+
+  /// Output the buffer contents to the @a stream.
+  /// @return The destination stream.
+  virtual std::ostream &operator>>(std::ostream &stream) const = 0;
+};
+
+/** A @c BufferWrite concrete subclass to write to a fixed size buffer.
+ */
+class FixedBufferWriter : public BufferWriter
+{
+  using super_type = BufferWriter;
+  using self_type  = FixedBufferWriter;
+
+public:
+  /** Construct a buffer writer on a fixed @a buffer of size @a capacity.
+
+      If writing goes past the end of the buffer, the excess is dropped.
+
+      @note If you create a instance of this class with capacity == 0 (and a nullptr buffer), you
+      can use it to measure the number of characters a series of writes would result it (from the
+      extent() value) without actually writing.
+   */
+  FixedBufferWriter(char *buffer, size_t capacity);
+
+  /** Construct from span
+   *
+   */
+  FixedBufferWriter(MemSpan<char> const &span);
+
+  /** Construct empty buffer.
+   * This is useful for doing sizing before allocating a buffer.
+   */
+  FixedBufferWriter(std::nullptr_t);
+
+  FixedBufferWriter(const FixedBufferWriter &) = delete;
+
+  FixedBufferWriter &operator=(const FixedBufferWriter &) = delete;
+
+  /// Move constructor.
+  FixedBufferWriter(FixedBufferWriter &&) = default;
+
+  /// Move assignment.
+  FixedBufferWriter &operator=(FixedBufferWriter &&) = default;
+
+  /// Write a single character @a c to the buffer.
+  FixedBufferWriter &write(char c) override;
+
+  /// Write @a data to the buffer, up to @a length bytes.
+  FixedBufferWriter &write(const void *data, size_t length) override;
+
+  // Bring in non-overridden methods.
+  using super_type::write;
+
+  /// Return the output buffer.
+  const char *data() const override;
+
+  /// Return whether there has been an error.
+  bool error() const override;
+
+  /// Get the start of the unused output buffer.
+  char *aux_data() override;
+
+  /// Get the total capacity of the output buffer.
+  size_t capacity() const override;
+
+  /// Get the total output sent to the writer.
+  size_t extent() const override;
+
+  /// Advance the used part of the output buffer.
+  self_type &commit(size_t n) override;
+
+  /// Drop @a n characters from the end of the buffer.
+  /// The extent is reduced but the data is not overwritten and can be recovered with
+  /// @c fill.
+  self_type &discard(size_t n) override;
+
+  /// Reduce the capacity by @a n.
+  self_type &restrict(size_t n) override;
+
+  /// Extend the capacity by @a n.
+  self_type &restore(size_t n) override;
+
+  /// Copy data in the buffer.
+  FixedBufferWriter &copy(size_t dst, size_t src, size_t n) override;
+
+  /// Clear the buffer, reset to empty (no data).
+  /// This is a convenience for reusing a buffer. For instance
+  /// @code
+  ///   bw.reset().print("....."); // clear old data and print new data.
+  /// @endcode
+  /// This is equivalent to @c reduce(0) but clearer for that case.
+  self_type &clear();
+
+  /// Provide a string_view of all successfully written characters.
+  std::string_view view() const;
+
+  /// Provide a @c string_view of all successfully written characters as a user conversion.
+  operator std::string_view() const;
+
+  /// Output the buffer contents to the @a stream.
+  std::ostream &operator>>(std::ostream &stream) const override;
+
+  // Overrides for co-variance
+  template <typename... Rest> self_type &print(TextView fmt, Rest &&... rest);
+
+  template <typename... Args> self_type &printv(TextView fmt, std::tuple<Args...> const &args);
+
+  template <typename... Args> self_type &print(bwf::Format const &fmt, Args &&... args);
+
+  template <typename... Args> self_type &printv(bwf::Format const &fmt, std::tuple<Args...> const &args);
+
+protected:
+  char *const _buf;        ///< Output buffer.
+  size_t _capacity;        ///< Size of output buffer.
+  size_t _attempted   = 0; ///< Number of characters written, including those discarded due error condition.
+  size_t _restriction = 0; ///< Restricted capacity.
+};
+
+/** A buffer writer that writes to an array of char (of fixed size N) that is internal to the writer instance.
+
+    It's called 'local' because instances are typically declared as stack-allocated, local function
+    variables.
+*/
+template <size_t N> class LocalBufferWriter : public FixedBufferWriter
+{
+  using self_type  = LocalBufferWriter;
+  using super_type = FixedBufferWriter;
+
+public:
+  /// Construct an empty writer.
+  LocalBufferWriter();
+  LocalBufferWriter(const LocalBufferWriter &that) = delete;
+  LocalBufferWriter &operator=(const LocalBufferWriter &that) = delete;
+
+protected:
+  char _arr[N]; ///< output buffer.
+};
+
+// --------------- Implementation --------------------
+
+inline BufferWriter::~BufferWriter() {}
+
+inline BufferWriter &
+BufferWriter::write(const void *data, size_t length)
+{
+  const char *d = static_cast<const char *>(data);
+
+  while (length--) {
+    this->write(*(d++));
+  }
+  return *this;
+}
+
+inline BufferWriter &
+BufferWriter::write(const std::string_view &sv)
+{
+  return this->write(sv.data(), sv.size());
+}
+
+inline char *
+BufferWriter::aux_data()
+{
+  return nullptr;
+}
+
+inline size_t
+BufferWriter::size() const
+{
+  return std::min(this->extent(), this->capacity());
+}
+
+inline size_t
+BufferWriter::remaining() const
+{
+  return this->capacity() - this->size();
+}
+
+// --- FixedBufferWriter ---
+inline FixedBufferWriter::FixedBufferWriter(char *buffer, size_t capacity) : _buf(buffer), _capacity(capacity)
+{
+  if (_capacity != 0 && buffer == nullptr) {
+    throw(std::invalid_argument{"FixedBufferWriter created with null buffer and non-zero size."});
+  };
+}
+
+inline FixedBufferWriter::FixedBufferWriter(MemSpan<char> const &span) : _buf{span.begin()}, _capacity{span.size()} {}
+
+inline FixedBufferWriter::FixedBufferWriter(std::nullptr_t) : _buf(nullptr), _capacity(0) {}
+
+inline FixedBufferWriter &
+FixedBufferWriter::write(char c)
+{
+  if (_attempted < _capacity) {
+    _buf[_attempted] = c;
+  }
+  ++_attempted;
+
+  return *this;
+}
+
+inline FixedBufferWriter &
+FixedBufferWriter::write(const void *data, size_t length)
+{
+  const size_t newSize = _attempted + length;
+
+  if (_buf) {
+    if (newSize <= _capacity) {
+      std::memcpy(_buf + _attempted, data, length);
+    } else if (_attempted < _capacity) {
+      std::memcpy(_buf + _attempted, data, _capacity - _attempted);
+    }
+  }
+  _attempted = newSize;
+
+  return *this;
+}
+
+/// Return the output buffer.
+inline const char *
+FixedBufferWriter::data() const
+{
+  return _buf;
+}
+
+inline bool
+FixedBufferWriter::error() const
+{
+  return _attempted > _capacity;
+}
+
+inline char *
+FixedBufferWriter::aux_data()
+{
+  return error() ? nullptr : _buf + _attempted;
+}
+
+inline auto
+FixedBufferWriter::commit(size_t n) -> self_type &
+{
+  _attempted += n;
+
+  return *this;
+}
+
+inline size_t
+FixedBufferWriter::capacity() const
+{
+  return _capacity;
+}
+
+inline size_t
+FixedBufferWriter::extent() const
+{
+  return _attempted;
+}
+
+inline auto
+FixedBufferWriter::restrict(size_t n) -> self_type &
+{
+  if (n > _capacity) {
+    throw(std::invalid_argument{"FixedBufferWriter restrict value more than capacity"});
+  }
+
+  _capacity -= n;
+  _restriction += n;
+
+  return *this;
+}
+
+inline auto
+FixedBufferWriter::restore(size_t n) -> self_type &
+{
+  if (error()) {
+    _attempted = _capacity;
+  }
+  n = std::min(n, _restriction);
+
+  _capacity += n;
+  _restriction -= n;
+
+  return *this;
+}
+
+inline auto
+FixedBufferWriter::discard(size_t n) -> self_type &
+{
+  _attempted -= std::min(_attempted, n);
+  return *this;
+}
+
+inline auto
+FixedBufferWriter::clear() -> self_type &
+{
+  _attempted = 0;
+  return *this;
+}
+
+inline auto
+FixedBufferWriter::copy(size_t dst, size_t src, size_t n) -> self_type &
+{
+  auto limit = std::min<size_t>(_capacity, _attempted); // max offset of region possible.
+  MemSpan<char> src_span{_buf + src, std::min(limit, src + n)};
+  MemSpan<char> dst_span{_buf + dst, std::min(limit, dst + n)};
+  std::memmove(dst_span.data(), src_span.data(), std::min(dst_span.size(), src_span.size()));
+  return *this;
+}
+
+inline std::string_view
+FixedBufferWriter::view() const
+{
+  return std::string_view(_buf, size());
+}
+
+/// Provide a @c string_view of all successfully written characters as a user conversion.
+inline FixedBufferWriter::operator std::string_view() const
+{
+  return this->view();
+}
+
+// --- LocalBufferWriter ---
+template <size_t N> LocalBufferWriter<N>::LocalBufferWriter() : super_type(_arr, N) {}
+
+} // namespace swoc
+
+namespace std
+{
+inline ostream &
+operator<<(ostream &s, swoc::BufferWriter const &w)
+{
+  return w >> s;
+}
+} // end namespace std

--- a/lib/swoc++/include/swoc/Errata.h
+++ b/lib/swoc++/include/swoc/Errata.h
@@ -1,0 +1,863 @@
+/** @file
+ *
+    Stacking error message handling.
+
+    The problem addressed by this library is the ability to pass back detailed error messages from
+    failures. It is hard to get good diagnostics because the specific failures and general context
+    are located in very different stack frames. This library allows local functions to pass back
+    local messages which can be easily augmented as the error travels up the stack frame.
+
+    This aims to improve over exceptions by being lower cost and not requiring callers to handle the
+    messages. On the other hand, the messages could be used just as easily with exceptions.
+
+    Each message on a stack contains text and a numeric identifier. The identifier value zero is
+    reserved for messages that are not errors so that information can be passed back even in the
+    success case.
+
+    The implementation takes the position that success must be fast and failure is expensive.
+    Therefore Errata is optimized for the success path, imposing very little overhead in that case.
+    On the other hand, if an error occurs and is handled, that is generally so expensive that
+    optimizations are pointless (although, of course, code should not be gratuitiously expensive).
+
+    The library provides the @c Rv ("return value") template to make returning values and status
+    easier. This template allows a function to return a value and status pair with minimal changes.
+    The pair acts like the value type in most situations, while providing access to the status.
+
+    Each instance of an erratum is a wrapper class that emulates value semantics (copy on write).
+    This means passing even large message stacks is inexpensive, involving only a pointer copy and
+    reference counter increment and decrement. A success value is represented by an internal @c NULL
+    so it is even cheaper to copy.
+
+    To further ease use, the library has the ability to define @a sinks.  A sink is a function that
+    acts on an erratum when it becomes unreferenced. The indended use is to send the messages to an
+    output log. This makes reporting errors to a log from even deeply nested functions easy while
+    preserving the ability of the top level logic to control such logging.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements.  See the NOTICE file distributed with this work for additional information regarding
+    copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with the License.  You may
+    obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#pragma once
+
+#include <vector>
+#include <string_view>
+#include <functional>
+#include <atomic>
+#include "swoc/MemArena.h"
+#include "swoc/bwf_base.h"
+#include "swoc/IntrusiveDList.h"
+
+namespace swoc
+{
+/// Severity levels for Errata.
+enum class Severity {
+  DIAG,  ///< Diagnostic (internal use).
+  INFO,  ///< User visible but not a problem.
+  WARN,  ///< Warning.
+  ERROR, ///< Error.
+};
+
+/** Class to hold a stack of error messages (the "errata"). This is a smart handle class, which
+ * wraps the actual data and can therefore be treated a value type with cheap copy semantics.
+ * Default construction is very cheap.
+ */
+class Errata
+{
+public:
+  using Severity = swoc::Severity; ///< Import for associated classes.
+
+  /// Severity used if not specified.
+  static constexpr Severity DEFAULT_SEVERITY{Severity::DIAG};
+  /// Severity level at which the instance is a failure of some sort.
+  static constexpr Severity FAILURE_SEVERITY{Severity::WARN};
+
+  struct Annotation {             // Forward declaration.
+    using self_type = Annotation; ///< Self reference type.
+
+    /// Default constructor.
+    /// The message has default severity and empty text.
+    Annotation();
+
+    /** Construct with severity @a level and @a text.
+     *
+     * @param level Severity level.
+     * @param text Annotation content (literal).
+     */
+    Annotation(Severity level, std::string_view text);
+
+    /// Reset to the message to default state.
+    self_type &clear();
+
+    /// Get the severity.
+    Severity severity() const;
+
+    /// Get the text of the message.
+    std::string_view text() const;
+
+    // Get the nesting level.
+    unsigned level() const;
+
+    /// Set the text of the message.
+    self_type &assign(std::string_view text);
+
+    /// Set the severity @a level
+    self_type &assign(Severity level);
+
+  protected:
+    Severity _severity{Errata::DEFAULT_SEVERITY}; ///< Annotation code.
+    unsigned _level{0};                           ///< Nesting level.
+    std::string_view _text;                       ///< Annotation text.
+
+    /// Policy and links for intrusive list.
+    self_type *_next{nullptr};
+    self_type *_prev{nullptr};
+    using Linkage = swoc::IntrusiveLinkage<self_type>;
+
+    friend class Errata;
+  };
+
+protected:
+  using self_type = Errata; ///< Self reference type.
+  /// Storage type for list of messages.
+  /// Internally the vector is accessed backwards, in order to make it LIFO.
+  using Container = IntrusiveDList<Annotation::Linkage>;
+
+  /// Implementation class.
+  struct Data {
+    using self_type = Data; ///< Self reference type.
+
+    /// Construct into @c MemArena.
+    Data(swoc::MemArena &&arena);
+
+    /// Check if there are any notes.
+    bool empty() const;
+
+    /** Duplicate @a src in the arena for this instance.
+     *
+     * @param src Source data.
+     * @return View of copy in this arena.
+     */
+    std::string_view localize(std::string_view src);
+
+    /// Get the remnant of the curret block in the arena.
+    swoc::MemSpan<char> remnant();
+
+    /// Allocate from the arena.
+    swoc::MemSpan<char> alloc(size_t n);
+
+    /// Reference count.
+    std::atomic<int> _ref_count{0};
+
+    /// The message stack.
+    Container _notes;
+    /// Annotation text storage.
+    swoc::MemArena _arena;
+    /// Nesting level.
+    unsigned _level{0};
+    /// The effective severity of the message stack.
+    Severity _severity{Errata::DEFAULT_SEVERITY};
+  };
+
+public:
+  /// Default constructor - empty errata, very fast.
+  Errata();
+  Errata(self_type const &that);                                   ///< Reference counting copy constructor.
+  Errata(self_type &&that);                                        ///< Move constructor.
+  self_type &operator=(self_type const &that) = delete;            // no copy assignemnt.
+  self_type &operator                         =(self_type &&that); ///< Move assignment.
+  ~Errata();                                                       ///< Destructor.
+
+  /** Add a new message to the top of stack with severity @a level and @a text.
+   * @param level Severity of the message.
+   * @param text Text of the message.
+   * @return *this
+   */
+  self_type &note(Severity level, std::string_view text);
+
+  /** Push a constructed @c Annotation.
+      The @c Annotation is set to have the @a id and @a code. The other arguments are converted
+      to strings and concatenated to form the messsage text.
+      @return A reference to this object.
+  */
+  template <typename... Args> self_type &note(Severity level, std::string_view fmt, Args &&... args);
+
+  /** Push a constructed @c Annotation.
+      The @c Annotation is set to have the @a id and @a code. The other arguments are converted
+      to strings and concatenated to form the messsage text.
+      @return A reference to this object.
+  */
+  template <typename... Args> self_type &note_v(Severity level, std::string_view fmt, std::tuple<Args...> const &args);
+
+  /** Copy messages from @a that to @a this.
+   *
+   * @param that Source object from which to copy.
+   * @return @a *this
+   */
+  self_type &note(self_type const &that);
+
+  /** Copy messages from @a that to @a this, then clear @that.
+   *
+   * @param that Source object from which to copy.
+   * @return @a *this
+   */
+  self_type &note(self_type &&that);
+
+  /// Overload for @c DIAG severity notes.
+  template <typename... Args> self_type &diag(std::string_view fmt, Args &&... args);
+  /// Overload for @c INFO severity notes.
+  template <typename... Args> self_type &info(std::string_view fmt, Args &&... args);
+  /// Overload for @c WARN severity notes.
+  template <typename... Args> self_type &warn(std::string_view fmt, Args &&... args);
+  /// Overload for @c ERROR severity notes.
+  template <typename... Args> self_type &error(std::string_view fmt, Args &&... args);
+
+  /// Remove all messages.
+  /// @note This is also used to prevent logging.
+  self_type &clear();
+
+  friend std::ostream &operator<<(std::ostream &, self_type const &);
+
+  /// Default glue value (a newline) for text rendering.
+  static const std::string_view DEFAULT_GLUE;
+
+  /** Test status.
+
+      Equivalent to @c success but more convenient for use in
+      control statements.
+
+      @return @c true if no messages or last message has a zero
+      message ID, @c false otherwise.
+   */
+  explicit operator bool() const;
+
+  /** Test errata for no failure condition.
+
+      Equivalent to @c operator @c bool but easier to invoke.
+
+      @return @c true if no messages or last message has a zero
+      message ID, @c false otherwise.
+   */
+  bool is_ok() const;
+
+  /** Get the maximum severity of the messages in the erratum.
+   *
+   * @return Max severity for all messages.
+   */
+  Severity severity() const;
+
+  /// Number of messages in the errata.
+  size_t count() const;
+  /// Check for no messages
+  /// @return @c true if there is one or messages.
+  bool empty() const;
+
+  using iterator       = Container::iterator;
+  using const_iterator = Container::const_iterator;
+
+  /// Reference to top item on the stack.
+  iterator begin();
+  /// Reference to top item on the stack.
+  const_iterator begin() const;
+  //! Reference one past bottom item on the stack.
+  iterator end();
+  //! Reference one past bottom item on the stack.
+  const_iterator end() const;
+
+  const Annotation &front() const;
+
+  // Logging support.
+
+  /** Base class for erratum sink.
+
+      When an errata is abandoned, this will be called on it to perform any client specific logging.
+      It is passed around by handle so that it doesn't have to support copy semantics (and is not
+      destructed until application shutdown). Clients can subclass this class in order to preserve
+      arbitrary data for the sink or retain a handle to the sink for runtime modifications.
+   */
+  class Sink
+  {
+    using self_type = Sink;
+
+  public:
+    using Handle = std::shared_ptr<self_type>; ///< Handle type.
+
+    /// Handle an abandoned errata.
+    virtual void operator()(Errata const &) const = 0;
+    /// Force virtual destructor.
+    virtual ~Sink() {}
+  };
+
+  //! Register a sink for discarded erratum.
+  static void register_sink(Sink::Handle const &s);
+
+  /// Register a function as a sink.
+  using SinkHandler = std::function<void(Errata const &)>;
+
+  /// Convenience wrapper class to enable using functions directly for sinks.
+  struct SinkWrapper : public Sink {
+    /// Constructor.
+    SinkWrapper(SinkHandler f) : _f(f) {}
+    /// Operator to invoke the function.
+    void operator()(Errata const &e) const override;
+    SinkHandler _f; ///< Client supplied handler.
+  };
+
+  /// Register a sink function for abandonded erratum.
+  static void
+  register_sink(SinkHandler const &f)
+  {
+    register_sink(Sink::Handle(new SinkWrapper(f)));
+  }
+
+  /** Simple formatted output.
+   */
+  std::ostream &write(std::ostream &out) const;
+
+protected:
+  /// Release internal memory.
+  void release();
+
+  /// Implementation instance.
+  // Although it may seem like move semantics make reference counting unnecessary, that's not the
+  // case. The problem is code that wants to work with an instance, which is common. In such cases
+  // the instance is constructed just as it is returned (e.g. std::string). Code would therefore
+  // have to call std::move for every return, which is not going to be done reliably.
+  Data *_data{nullptr};
+
+  /// Force data existence.
+  /// @return A pointer to the data.
+  const Data *data();
+
+  /// Get a writeable data pointer.
+  /// @internal It is a fatal error to ask for writeable data if there are shared references.
+  Data *writeable_data();
+
+  /** Allocate a span of memory.
+   *
+   * @param n Number of bytes to allocate.
+   * @return A span of the allocated memory.
+   */
+  MemSpan<char> alloc(size_t n);
+
+  /// Add a note which is already localized.
+  self_type &note_localized(Severity, std::string_view const &text);
+
+  /// Used for returns when no data is present.
+  static Annotation const NIL_NOTE;
+
+  friend struct Data;
+  friend class Item;
+};
+
+extern std::ostream &operator<<(std::ostream &os, Errata const &stat);
+
+/** Return type for returning a value and status (errata).  In general, a method wants to return
+    both a result and a status so that errors are logged properly. This structure is used to do that
+    in way that is more usable than just @c std::pair.  - Simpler and shorter typography - Force use
+    of @c errata rather than having to remember it (and the order) each time - Enable assignment
+    directly to @a R for ease of use and compatibility so clients can upgrade asynchronously.
+ */
+template <typename R> struct Rv : public std::tuple<R, Errata> {
+  using self_type   = Rv; ///< Standard self reference type.
+  using super_type  = std::tuple<R, Errata>;
+  using result_type = R; ///< Type of result value.
+
+  static constexpr int RESULT = 0; ///< Tuple index for result.
+  static constexpr int ERRATA = 1; ///< Tuple index for Errata.
+
+  result_type _result{}; ///< The actual result of the function.
+
+  /** Default constructor.
+      The default constructor for @a R is used.
+      The status is initialized to SUCCESS.
+  */
+  Rv();
+
+  /** Construct with copy of @a result and empty Errata.
+   *
+   * Construct with a specified @a result and a default (successful) @c Errata.
+   * @param result Return value / result.
+   */
+  Rv(result_type const &result);
+
+  /** Construct with copy of @a result and move @a errata.
+   *
+   * Construct with a specified @a result and a default (successful) @c Errata.
+   * @param result Return value / result.
+   */
+  Rv(result_type const &result, Errata &&errata);
+  Rv(result_type const &result, const Errata &errata);
+
+  /** Construct with move of @a result and empty Errata.
+   *
+   * @param result The return / result value.
+   */
+  Rv(result_type &&result);
+
+  /** Construct with result and move of @a errata.
+   *
+   * @param result The return / result value to assign.
+   * @param errata Status to move.
+   */
+  Rv(result_type &&result, Errata &&errata);
+  Rv(result_type &&result, const Errata &errata);
+
+  /** Push a message in to the result.
+   *
+   * @param level Severity of the message.
+   * @param text Text of the message.
+   * @return @a *this
+   */
+  self_type &note(Severity level, std::string_view text);
+
+  /** Push a message in to the result.
+   *
+   * @param level Severity of the message.
+   * @param text Text of the message.
+   * @return @a *this
+   */
+  template <typename... Args> self_type &note(Severity level, std::string_view fmt, Args &&... args);
+
+  /** User conversion to the result type.
+
+      This makes it easy to use the function normally or to pass the
+      result only to other functions without having to extract it by
+      hand.
+  */
+  operator result_type const &() const;
+
+  /** Assignment from result type.
+
+      This allows the result to be assigned to a pre-declared return
+      value structure.  The return value is a reference to the
+      internal result so that this operator can be chained in other
+      assignments to instances of result type. This is most commonly
+      used when the result is computed in to a local variable to be
+      both returned and stored in a member.
+
+      @code
+      Rv<int> zret;
+      int value;
+      // ... complex computations, result in value
+      this->m_value = zret = value;
+      // ...
+      return zret;
+      @endcode
+
+      @return A reference to the copy of @a r stored in this object.
+  */
+  result_type &
+  operator=(result_type const &r ///< result_type to assign
+  )
+  {
+    _result = r;
+    return _result;
+  }
+
+  /** Set the result.
+
+      This differs from assignment of the function result in that the
+      return value is a reference to the @c Rv, not the internal
+      result. This makes it useful for assigning a result local
+      variable and then returning.
+
+   * @param result Value to move.
+   * @return @a this
+
+      @code
+      Rv<int> func(...) {
+        Rv<int> zret;
+        int value;
+        // ... complex computation, result in value
+        return zret.assign(value);
+      }
+      @endcode
+  */
+  self_type &assign(result_type const &result);
+
+  /** Move the @a result to @a this.
+   *
+   * @param result Value to move.
+   * @return @a this,
+   */
+  self_type &assign(result_type &&result);
+
+  /** Return the result.
+      @return A reference to the result value in this object.
+  */
+  result_type &result();
+
+  /** Return the result.
+      @return A reference to the result value in this object.
+  */
+  result_type const &result() const;
+
+  /** Return the status.
+      @return A reference to the @c errata in this object.
+  */
+  Errata &errata();
+
+  /** Return the status.
+      @return A reference to the @c errata in this object.
+  */
+  Errata const &errata() const;
+
+  /** Get the internal @c Errata.
+   *
+   * @return Reference to internal @c Errata.
+   */
+  operator Errata &();
+
+  /** Replace current status with @a status.
+   *
+   * @param status Errata to move in to this instance.
+   * @return *this
+   */
+  self_type &operator=(Errata &&status);
+
+  /** Check the status of the return value.
+   *
+   * @return @a true if the value is valid / OK, @c false otherwise.
+   */
+  inline bool is_ok() const;
+
+  /// Clear the errata.
+  self_type &clear();
+};
+
+/** Combine a function result and status in to an @c Rv.
+    This is useful for clients that want to declare the status object
+    and result independently.
+ */
+template <typename R>
+Rv<typename std::remove_reference<R>::type>
+MakeRv(R &&r,           ///< The function result
+       Errata &&erratum ///< The pre-existing status object
+)
+{
+  return Rv<typename std::remove_reference<R>::type>(std::forward<R>(r), std::move(erratum));
+}
+/* ----------------------------------------------------------------------- */
+// Inline methods for Annotation
+
+inline Errata::Annotation::Annotation() {}
+
+inline Errata::Annotation::Annotation(Severity level, std::string_view text) : _severity(level), _text(text) {}
+
+inline Errata::Annotation &
+Errata::Annotation::clear()
+{
+  _severity = Errata::DEFAULT_SEVERITY;
+  _text     = std::string_view{};
+  return *this;
+}
+
+inline std::string_view
+Errata::Annotation::text() const
+{
+  return _text;
+}
+
+inline unsigned
+Errata::Annotation::level() const
+{
+  return _level;
+}
+
+inline Errata::Severity
+Errata::Annotation::severity() const
+{
+  return _severity;
+}
+
+inline Errata::Annotation &
+Errata::Annotation::assign(std::string_view text)
+{
+  _text = text;
+  return *this;
+}
+
+inline Errata::Annotation &
+Errata::Annotation::assign(Severity level)
+{
+  _severity = level;
+  return *this;
+}
+/* ----------------------------------------------------------------------- */
+// Inline methods for Errata::Data
+
+inline Errata::Data::Data(MemArena &&arena)
+{
+  _arena = std::move(arena);
+}
+
+inline swoc::MemSpan<char>
+Errata::Data::remnant()
+{
+  return _arena.remnant().rebind<char>();
+}
+
+inline swoc::MemSpan<char>
+Errata::Data::alloc(size_t n)
+{
+  return _arena.alloc(n).rebind<char>();
+}
+
+inline bool
+Errata::Data::empty() const
+{
+  return _notes.empty();
+}
+
+/* ----------------------------------------------------------------------- */
+// Inline methods for Errata
+
+inline Errata::Errata() {}
+
+inline Errata::Errata(self_type &&that)
+{
+  std::swap(_data, that._data);
+}
+
+inline Errata::Errata(self_type const &that)
+{
+  if (nullptr != (_data = that._data)) {
+    ++(_data->_ref_count);
+  }
+}
+
+inline auto
+Errata::operator=(self_type &&that) -> self_type &
+{
+  if (this != &that) {
+    this->release();
+    std::swap(_data, that._data);
+  }
+  return *this;
+}
+
+inline Errata::operator bool() const
+{
+  return this->is_ok();
+}
+
+inline bool
+Errata::empty() const
+{
+  return _data == nullptr || _data->_notes.count() == 0;
+}
+
+inline size_t
+Errata::count() const
+{
+  return _data ? _data->_notes.count() : 0;
+}
+
+inline bool
+Errata::is_ok() const
+{
+  return 0 == _data || 0 == _data->_notes.count() || _data->_severity < FAILURE_SEVERITY;
+}
+
+inline const Errata::Annotation &
+Errata::front() const
+{
+  return *(_data->_notes.head());
+}
+
+template <typename... Args>
+Errata &
+Errata::note(Severity level, std::string_view fmt, Args &&... args)
+{
+  return this->note_v(level, fmt, std::forward_as_tuple(args...));
+}
+
+template <typename... Args>
+Errata &
+Errata::diag(std::string_view fmt, Args &&... args)
+{
+  return this->note_v(Severity::DIAG, fmt, std::forward_as_tuple(args...));
+}
+
+template <typename... Args>
+Errata &
+Errata::info(std::string_view fmt, Args &&... args)
+{
+  return this->note_v(Severity::INFO, fmt, std::forward_as_tuple(args...));
+}
+
+template <typename... Args>
+Errata &
+Errata::warn(std::string_view fmt, Args &&... args)
+{
+  return this->note_v(Severity::WARN, fmt, std::forward_as_tuple(args...));
+}
+
+template <typename... Args>
+Errata &
+Errata::error(std::string_view fmt, Args &&... args)
+{
+  return this->note_v(Severity::ERROR, fmt, std::forward_as_tuple(args...));
+}
+
+inline Errata &
+Errata::note(self_type &&that)
+{
+  this->note(that);
+  that.clear();
+  return *this;
+}
+
+template <typename... Args>
+Errata &
+Errata::note_v(Severity level, std::string_view fmt, std::tuple<Args...> const &args)
+{
+  Data *data = this->writeable_data();
+  auto span  = data->remnant();
+  FixedBufferWriter bw{span};
+  if (!bw.printv(fmt, args).error()) {
+    span = span.prefix(bw.extent());
+    data->alloc(bw.extent()); // reserve the part of the remnant actually used.
+  } else {
+    // Not enough space, get a big enough chunk and do it again.
+    span = this->alloc(bw.extent());
+    FixedBufferWriter{span}.printv(fmt, args);
+  }
+  this->note_localized(level, span.view());
+  return *this;
+}
+
+inline void
+Errata::SinkWrapper::operator()(Errata const &e) const
+{
+  _f(e);
+}
+/* ----------------------------------------------------------------------- */
+// Inline methods for Rv
+
+template <typename R>
+inline bool
+Rv<R>::is_ok() const
+{
+  return std::get<ERRATA>(*this).is_ok();
+}
+
+template <typename R>
+inline auto
+Rv<R>::clear() -> self_type &
+{
+  std::get<ERRATA>(*this).clear();
+}
+
+template <typename T> Rv<T>::Rv() {}
+
+template <typename T> Rv<T>::Rv(result_type const &r) : super_type(r, Errata()) {}
+
+template <typename T> Rv<T>::Rv(result_type const &r, Errata &&errata) : super_type(r, std::move(errata)) {}
+
+template <typename T> Rv<T>::Rv(result_type const &r, const Errata &errata) : super_type(r, errata) {}
+
+template <typename R> Rv<R>::Rv(R &&r) : super_type(std::move(r), Errata()) {}
+
+template <typename R> Rv<R>::Rv(R &&r, Errata &&errata) : super_type(std::move(r), std::move(errata)) {}
+
+template <typename R> Rv<R>::Rv(R &&r, const Errata &errata) : super_type(std::move(r), errata) {}
+
+template <typename T> Rv<T>::operator result_type const &() const
+{
+  return std::get<RESULT>(*this);
+}
+
+template <typename T>
+T const &
+Rv<T>::result() const
+{
+  return std::get<RESULT>(*this);
+}
+
+template <typename T>
+T &
+Rv<T>::result()
+{
+  return std::get<RESULT>(*this);
+}
+
+template <typename T>
+Errata const &
+Rv<T>::errata() const
+{
+  return std::get<ERRATA>(*this);
+}
+
+template <typename T>
+Errata &
+Rv<T>::errata()
+{
+  return std::get<ERRATA>(*this);
+}
+
+template <typename T> Rv<T>::operator Errata &()
+{
+  return std::get<ERRATA>(*this);
+}
+
+template <typename T>
+Rv<T> &
+Rv<T>::assign(result_type const &r)
+{
+  std::get<RESULT>(*this) = r;
+  return *this;
+}
+
+template <typename R>
+Rv<R> &
+Rv<R>::assign(R &&r)
+{
+  std::get<RESULT>(*this) = std::forward<R>(r);
+  return *this;
+}
+
+template <typename R>
+auto
+Rv<R>::operator=(Errata &&errata) -> self_type &
+{
+  std::get<ERRATA>(*this) = std::move(errata);
+  return *this;
+}
+
+template <typename R>
+auto
+Rv<R>::note(Severity level, std::string_view text) -> self_type &
+{
+  std::get<ERRATA>(*this).note(level, text);
+  return *this;
+}
+
+template <typename R>
+template <typename... Args>
+Rv<R> &
+Rv<R>::note(Severity level, std::string_view fmt, Args &&... args)
+{
+  std::get<ERRATA>(*this).note_v(level, fmt, std::forward_as_tuple(args...));
+  return *this;
+}
+
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, Severity);
+
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, Errata::Annotation const &);
+
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, Errata const &);
+
+} // namespace swoc

--- a/lib/swoc++/include/swoc/IntrusiveDList.h
+++ b/lib/swoc++/include/swoc/IntrusiveDList.h
@@ -1,0 +1,882 @@
+/** @file
+
+    Intrusive double linked list container.
+
+    This provides support for a doubly linked list container. Items in the list must provide links
+    inside the class and accessor functions for those links.
+
+    @note This is a header only library.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements.  See the NOTICE file distributed with this work for additional information regarding
+    copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with the License.  You may
+    obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+#pragma once
+
+/// Clang doesn't like just declaring the tag struct we need so we have to include the file.
+#include <iterator>
+#include <type_traits>
+
+namespace swoc
+{
+/** Intrusive doubly linked list container.
+
+    This holds items in a doubly linked list using links in the items. Items are placed in the list
+    by changing the pointers. An item can be in only one list for a set of links, but an item can
+    contain multiple sets of links. This requires different specializations of this template because
+    link access is part of the type specification. Memory for items is not managed by this class -
+    instances must be allocated and released elsewhere. In particular removing an item from the list
+    does not destruct or free the item.
+
+    Access to the links is described by a linkage class which is required to contain the following
+    members:
+
+    - The static method @c next_ptr which returns a reference to the pointer to the next item.
+
+    - The static method @c prev_ptr which returns a reference to the pointer to the previous item.
+
+    The pointer methods take a single argument of @c Item* and must return a reference to a pointer
+    instance. This type is deduced from the methods and is not explicitly specified. It must be
+    cheaply copyable and stateless.
+
+    It is the responsibility of the item class to initialize the link pointers. When an item is
+    removed from the list the link pointers are set to @c nullptr.
+
+    An example declaration woudl be
+
+    @code
+      // Item in the list.
+      struct Thing {
+        Thing* _next {nullptr};
+        Thing* _prev {nullptr};
+        Data _payload;
+
+        // Linkage descriptor.
+        struct Linkage {
+          static Thing*& next_ptr(Thing* Thing) { return Thing->_next; }
+          static Thing*& prev_ptr(Thing* Thing) { return Thing->_prev; }
+        };
+      };
+
+      using ThingList = IntrusiveDList<Thing::Linkage>;
+    @endcode
+
+    Item access is done by using either STL style iteration, or direct access to the member
+    pointers. A client can have its own mechanism for getting an element to start, or use the @c
+    head and/or @c tail methods to get the first and last elements in the list respectively. Note if
+    the list is empty then @c nullptr will be returned. There are simple and fast conversions
+    between item pointers and iterators.
+
+  */
+template <typename L> class IntrusiveDList
+{
+  friend class iterator;
+
+public:
+  using self_type = IntrusiveDList; ///< Self reference type.
+  /// The list item type.
+  using value_type = typename std::remove_pointer<typename std::remove_reference<decltype(L::next_ptr(nullptr))>::type>::type;
+
+  /// Const iterator.
+  class const_iterator
+  {
+    using self_type = const_iterator; ///< Self reference type.
+    friend class IntrusiveDList;
+
+  public:
+    using list_type  = IntrusiveDList;                       ///< Container type.
+    using value_type = const typename list_type::value_type; /// Import for API compliance.
+    // STL algorithm compliance.
+    using iterator_category = std::bidirectional_iterator_tag;
+    using pointer           = value_type *;
+    using reference         = value_type &;
+    using difference_type   = int;
+
+    /// Default constructor.
+    const_iterator();
+
+    /// Pre-increment.
+    /// Move to the next element in the list.
+    /// @return The iterator.
+    self_type &operator++();
+
+    /// Pre-decrement.
+    /// Move to the previous element in the list.
+    /// @return The iterator.
+    self_type &operator--();
+
+    /// Post-increment.
+    /// Move to the next element in the list.
+    /// @return The iterator value before the increment.
+    self_type operator++(int);
+
+    /// Post-decrement.
+    /// Move to the previous element in the list.
+    /// @return The iterator value before the decrement.
+    self_type operator--(int);
+
+    /// Dereference.
+    /// @return A reference to the referent.
+    value_type &operator*() const;
+
+    /// Dereference.
+    /// @return A pointer to the referent.
+    value_type *operator->() const;
+
+    /// Convenience conversion to pointer type
+    /// Because of how this list is normally used, being able to pass an iterator as a pointer is quite convienent.
+    /// If the iterator isn't valid, it converts to @c nullptr.
+    operator value_type *() const;
+
+    /// Equality
+    bool operator==(self_type const &that) const;
+
+    /// Inequality
+    bool operator!=(self_type const &that) const;
+
+  protected:
+    // These are stored non-const to make implementing @c iterator easier. This class provides the required @c const
+    // protection.
+    list_type *_list{nullptr};                   ///< Needed to descrement from @c end() position.
+    typename list_type::value_type *_v{nullptr}; ///< Referenced element.
+
+    /// Internal constructor for containers.
+    const_iterator(const list_type *list, value_type *v);
+  };
+
+  /// Iterator for the list.
+  class iterator : public const_iterator
+  {
+    using self_type  = iterator;       ///< Self reference type.
+    using super_type = const_iterator; ///< Super class type.
+
+    friend class IntrusiveDList;
+
+  public:
+    using list_type  = IntrusiveDList;                 /// Must hoist this for direct use.
+    using value_type = typename list_type::value_type; /// Import for API compliance.
+    // STL algorithm compliance.
+    using iterator_category = std::bidirectional_iterator_tag;
+    using pointer           = value_type *;
+    using reference         = value_type &;
+
+    /// Default constructor.
+    iterator();
+
+    /// Pre-increment.
+    /// Move to the next element in the list.
+    /// @return The iterator.
+    self_type &operator++();
+
+    /// Pre-decrement.
+    /// Move to the previous element in the list.
+    /// @return The iterator.
+    self_type &operator--();
+
+    /// Post-increment.
+    /// Move to the next element in the list.
+    /// @return The iterator value before the increment.
+    self_type operator++(int);
+
+    /// Post-decrement.
+    /// Move to the previous element in the list.
+    /// @return The iterator value before the decrement.
+    self_type operator--(int);
+
+    /// Dereference.
+    /// @return A reference to the referent.
+    value_type &operator*() const;
+
+    /// Dereference.
+    /// @return A pointer to the referent.
+    value_type *operator->() const;
+
+    /// Convenience conversion to pointer type
+    /// Because of how this list is normally used, being able to pass an iterator as a pointer is quite convenient.
+    /// If the iterator isn't valid, it converts to @c nullptr.
+    operator value_type *() const;
+
+  protected:
+    /// Internal constructor for containers.
+    iterator(list_type *list, value_type *v);
+  };
+
+  /// Construct to empty list.
+  IntrusiveDList() = default;
+
+  /// Move list to @a this and leave @a that empty.
+  IntrusiveDList(self_type &&that);
+
+  /// No copy assignment because items can't be in two lists and can't copy items.
+  self_type &operator=(const self_type &that) = delete;
+  /// Move @a that to @a this.
+  self_type &operator=(self_type &&that);
+
+  /// Empty check.
+  /// @return @c true if the list is empty.
+  bool empty() const;
+
+  /// Presence check (linear time).
+  /// @return @c true if @a v is in the list, @c false if not.
+  bool contains(const value_type *v) const;
+
+  /// Add @a elt as the first element in the list.
+  /// @return This container.
+  self_type &prepend(value_type *v);
+
+  /// Add @elt as the last element in the list.
+  /// @return This container.
+  self_type &append(value_type *v);
+
+  /// Remove the first element of the list.
+  /// @return A poiner to the removed item, or @c nullptr if the list was empty.
+  value_type *take_head();
+
+  /// Remove the last element of the list.
+  /// @return A poiner to the removed item, or @c nullptr if the list was empty.
+  value_type *take_tail();
+
+  /// Insert a new element @a elt after @a target.
+  /// The caller is responsible for ensuring @a target is in this list and @a elt is not in a list.
+  /// @return This list.
+  self_type &insert_after(value_type *target, value_type *v);
+
+  /// Insert a new element @a v before @a target.
+  /// The caller is responsible for ensuring @a target is in this list and @a elt is not in a list.
+  /// @return This list.
+  self_type &insert_before(value_type *target, value_type *v);
+
+  /// Insert a new element @a elt after @a target.
+  /// If @a target is the end iterator, @a v is appended to the list.
+  /// @return This list.
+  self_type &insert_after(iterator const &target, value_type *v);
+
+  /// Insert a new element @a v before @a target.
+  /// If @a target is the end iterator, @a v is appended to the list.
+  /// @return This list.
+  self_type &insert_before(iterator const &target, value_type *v);
+
+  /// Take @a v out of this list.
+  /// @return The element after @a v.
+  value_type *erase(value_type *v);
+
+  /// Take the element at @a loc out of this list.
+  /// @return Iterator for the next element.
+  iterator erase(const iterator &loc);
+
+  /// Take elements out of the list.
+  /// Remove elements start with @a start up to but not including @a limit.
+  /// @return @a limit
+  iterator erase(const iterator &start, const iterator &limit);
+
+  /// Remove all elements.
+  /// @note @b No memory management is done!
+  /// @return This container.
+  self_type &clear();
+
+  /// @return Number of elements in the list.
+  size_t count() const;
+
+  /// Get an iterator to the first element.
+  iterator begin();
+
+  /// Get an iterator to the first element.
+  const_iterator begin() const;
+
+  /// Get an iterator past the last element.
+  iterator end();
+
+  /// Get an iterator past the last element.
+  const_iterator end() const;
+
+  /** Get an iterator for the item @a v.
+   *
+   * It is the responsibility of the caller that @a v is in the list. The purpose is to make
+   * iteration starting at a specific element easier (i.e. all of the link manipulation and checking
+   * is done by the iterator).
+   *
+   * @return An @c iterator that refers to @a v.
+   */
+  iterator iterator_for(value_type *v);
+  const_iterator iterator_for(const value_type *v) const;
+
+  /// Get the first element.
+  value_type *head();
+  const value_type *head() const;
+
+  /// Get the last element.
+  value_type *tail();
+  const value_type *tail() const;
+
+  /** Apply a functor to every element in the list.
+   * This iterates over the list correctly even if the functor destroys or removes elements.
+   */
+  template <typename F> self_type &apply(F &&f);
+
+protected:
+  value_type *_head{nullptr}; ///< First element in list.
+  value_type *_tail{nullptr}; ///< Last element in list.
+  size_t _count{0};           ///< # of elements in list.
+};
+
+/** Utility class to provide intrusive links.
+ *
+ * @tparam T Class to link.
+ *
+ * The normal use is to declare this as a member to provide the links and the linkage functions.
+ * @code
+ * class Thing {
+ *   // blah blah
+ *   Thing* _next{nullptr};
+ *   Thing* _prev{nullptr};
+ *   using Linkage = swoc::IntrusiveLinkage<Thing, &Thing::_next, &Thing::_prev>;
+ * };
+ * using ThingList = swoc::IntrusiveDList<Thing::Linkage>;
+ * @endcode
+ * The template will default to the names '_next' and '_prev' therefore in the example it could
+ * have been done as
+ * @code
+ *   using Linkage = swoc::IntrusiveLinkage<Thing>;
+ * @endcode
+ */
+template <typename T, T *(T::*NEXT) = &T::_next, T *(T::*PREV) = &T::_prev> struct IntrusiveLinkage {
+  static T *&next_ptr(T *thing); ///< Retrieve reference to next pointer.
+  static T *&prev_ptr(T *thing); ///< Retrive reference to previous pointer.
+};
+
+template <typename T, T *(T::*NEXT), T *(T::*PREV)>
+T *&
+IntrusiveLinkage<T, NEXT, PREV>::next_ptr(T *thing)
+{
+  return thing->*NEXT;
+}
+template <typename T, T *(T::*NEXT), T *(T::*PREV)>
+T *&
+IntrusiveLinkage<T, NEXT, PREV>::prev_ptr(T *thing)
+{
+  return thing->*PREV;
+}
+
+/** Utility cast to change the underlying type of a pointer reference.
+ *
+ * @tparam T The resulting pointer reference type.
+ * @tparam P The starting pointer reference type.
+ * @param p A reference to pointer to @a P.
+ * @return A reference to the same pointer memory of type @c T*&.
+ *
+ * This changes a reference to a pointer to @a P to a reference to a pointer to @a T. This is useful
+ * for intrusive links that are inherited. For instance
+ *
+ * @code
+ * class Thing { Thing* _next; ... }
+ * class BetterThing : public Thing { ... };
+ * @endcode
+ *
+ * To make @c BetterThing work with an intrusive container without making new link members,
+ *
+ * @code
+ * static BetterThing*& next_ptr(BetterThing* bt) {
+ *   return swoc::ptr_ref_cast<BetterThing>(_next);
+ * }
+ * @endcode
+ *
+ * This is both convenient and gets around aliasing warnings from the compiler that can arise from
+ * using @c reinterpret_cast.
+ */
+template <typename T, typename P>
+T *&
+ptr_ref_cast(P *&p)
+{
+  union {
+    P **_p;
+    T **_t;
+  } u{&p};
+  return *(u._t);
+};
+
+// --- Implementation ---
+
+template <typename L> IntrusiveDList<L>::const_iterator::const_iterator() {}
+
+template <typename L>
+IntrusiveDList<L>::const_iterator::const_iterator(const list_type *list, value_type *v)
+  : _list(const_cast<list_type *>(list)), _v(const_cast<typename list_type::value_type *>(v))
+{
+}
+
+template <typename L> IntrusiveDList<L>::iterator::iterator() {}
+
+template <typename L> IntrusiveDList<L>::iterator::iterator(IntrusiveDList *list, value_type *v) : super_type(list, v) {}
+
+template <typename L>
+auto
+IntrusiveDList<L>::const_iterator::operator++() -> self_type &
+{
+  _v = L::next_ptr(_v);
+  return *this;
+}
+
+template <typename L>
+auto
+IntrusiveDList<L>::iterator::operator++() -> self_type &
+{
+  this->super_type::operator++();
+  return *this;
+}
+
+template <typename L>
+auto
+IntrusiveDList<L>::const_iterator::operator++(int) -> self_type
+{
+  self_type tmp(*this);
+  ++*this;
+  return tmp;
+}
+
+template <typename L>
+auto
+IntrusiveDList<L>::iterator::operator++(int) -> self_type
+{
+  self_type tmp(*this);
+  ++*this;
+  return tmp;
+}
+
+template <typename L>
+auto
+IntrusiveDList<L>::const_iterator::operator--() -> self_type &
+{
+  if (_v) {
+    _v = L::prev_ptr(_v);
+  } else if (_list) {
+    _v = _list->_tail;
+  }
+  return *this;
+}
+
+template <typename L>
+auto
+IntrusiveDList<L>::iterator::operator--() -> self_type &
+{
+  this->super_type::operator--();
+  return *this;
+}
+
+template <typename L>
+auto
+IntrusiveDList<L>::const_iterator::operator--(int) -> self_type
+{
+  self_type tmp(*this);
+  --*this;
+  return tmp;
+}
+
+template <typename L>
+auto
+IntrusiveDList<L>::iterator::operator--(int) -> self_type
+{
+  self_type tmp(*this);
+  --*this;
+  return tmp;
+}
+
+template <typename L> auto IntrusiveDList<L>::const_iterator::operator-> () const -> value_type *
+{
+  return _v;
+}
+
+template <typename L> auto IntrusiveDList<L>::iterator::operator-> () const -> value_type *
+{
+  return super_type::_v;
+}
+
+template <typename L> IntrusiveDList<L>::const_iterator::operator value_type *() const
+{
+  return _v;
+}
+
+template <typename L> auto IntrusiveDList<L>::const_iterator::operator*() const -> value_type &
+{
+  return *_v;
+}
+
+template <typename L> auto IntrusiveDList<L>::iterator::operator*() const -> value_type &
+{
+  return *super_type::_v;
+}
+
+template <typename L> IntrusiveDList<L>::iterator::operator value_type *() const
+{
+  return super_type::_v;
+}
+
+/// --- Main class
+
+template <typename L>
+IntrusiveDList<L>::IntrusiveDList(self_type &&that) : _head(that._head), _tail(that._tail), _count(that._count)
+{
+  that.clear();
+}
+
+template <typename L>
+bool
+IntrusiveDList<L>::empty() const
+{
+  return _head == nullptr;
+}
+
+template <typename L>
+bool
+IntrusiveDList<L>::contains(const value_type *v) const
+{
+  for (auto thing = _head; thing; thing = L::next_ptr(thing)) {
+    if (thing == v)
+      return true;
+  }
+  return false;
+}
+
+template <typename L>
+bool
+IntrusiveDList<L>::const_iterator::operator==(self_type const &that) const
+{
+  return this->_v == that._v;
+}
+
+template <typename L>
+bool
+IntrusiveDList<L>::const_iterator::operator!=(self_type const &that) const
+{
+  return this->_v != that._v;
+}
+
+template <typename L>
+auto
+IntrusiveDList<L>::prepend(value_type *v) -> self_type &
+{
+  L::prev_ptr(v) = nullptr;
+  if (nullptr != (L::next_ptr(v) = _head)) {
+    L::prev_ptr(_head) = v;
+  } else {
+    _tail = v; // transition empty -> non-empty
+  }
+  _head = v;
+  ++_count;
+  return *this;
+}
+
+template <typename L>
+auto
+IntrusiveDList<L>::append(value_type *v) -> self_type &
+{
+  L::next_ptr(v) = nullptr;
+  if (nullptr != (L::prev_ptr(v) = _tail)) {
+    L::next_ptr(_tail) = v;
+  } else {
+    _head = v; // transition empty -> non-empty
+  }
+  _tail = v;
+  ++_count;
+  return *this;
+}
+
+template <typename L>
+auto
+IntrusiveDList<L>::take_head() -> value_type *
+{
+  value_type *zret = _head;
+  if (_head) {
+    if (nullptr == (_head = L::next_ptr(_head))) {
+      _tail = nullptr; // transition non-empty -> empty
+    } else {
+      L::prev_ptr(_head) = nullptr;
+    }
+    L::next_ptr(zret) = L::prev_ptr(zret) = nullptr;
+    --_count;
+  }
+  return zret;
+}
+
+template <typename L>
+auto
+IntrusiveDList<L>::take_tail() -> value_type *
+{
+  value_type *zret = _tail;
+  if (_tail) {
+    if (nullptr == (_tail = L::prev_ptr(_tail))) {
+      _head = nullptr; // transition non-empty -> empty
+    } else {
+      L::next_ptr(_tail) = nullptr;
+    }
+    L::next_ptr(zret) = L::prev_ptr(zret) = nullptr;
+    --_count;
+  }
+  return zret;
+}
+
+template <typename L>
+auto
+IntrusiveDList<L>::insert_after(value_type *target, value_type *v) -> self_type &
+{
+  if (target) {
+    if (nullptr != (L::next_ptr(v) = L::next_ptr(target))) {
+      L::prev_ptr(L::next_ptr(v)) = v;
+    } else if (_tail == target) {
+      _tail = v;
+    }
+    L::prev_ptr(v)      = target;
+    L::next_ptr(target) = v;
+
+    ++_count;
+  } else {
+    this->append(v);
+  }
+  return *this;
+}
+
+template <typename L>
+auto
+IntrusiveDList<L>::insert_after(iterator const &target, value_type *v) -> self_type &
+{
+  return this->insert_after(target._v, v);
+}
+
+template <typename L>
+auto
+IntrusiveDList<L>::insert_before(value_type *target, value_type *v) -> self_type &
+{
+  if (target) {
+    if (nullptr != (L::prev_ptr(v) = L::prev_ptr(target))) {
+      L::next_ptr(L::prev_ptr(v)) = v;
+    } else if (target == _head) {
+      _head = v;
+    }
+    L::next_ptr(v)      = target;
+    L::prev_ptr(target) = v;
+
+    ++_count;
+  } else {
+    this->append(v);
+  }
+  return *this;
+}
+
+template <typename L>
+auto
+IntrusiveDList<L>::insert_before(iterator const &target, value_type *v) -> self_type &
+{
+  return this->insert_before(target._v, v);
+}
+
+template <typename L>
+auto
+IntrusiveDList<L>::erase(value_type *v) -> value_type *
+{
+  value_type *zret{nullptr};
+
+  if (L::prev_ptr(v)) {
+    L::next_ptr(L::prev_ptr(v)) = L::next_ptr(v);
+  }
+  if (L::next_ptr(v)) {
+    zret                        = L::next_ptr(v);
+    L::prev_ptr(L::next_ptr(v)) = L::prev_ptr(v);
+  }
+  if (v == _head) {
+    _head = L::next_ptr(v);
+  }
+  if (v == _tail) {
+    _tail = L::prev_ptr(v);
+  }
+  L::prev_ptr(v) = L::next_ptr(v) = nullptr;
+  --_count;
+
+  return zret;
+}
+
+template <typename L>
+auto
+IntrusiveDList<L>::erase(const iterator &loc) -> iterator
+{
+  return this->iterator_for(this->erase(loc._v));
+};
+
+template <typename L>
+auto
+IntrusiveDList<L>::erase(const iterator &first, const iterator &limit) -> iterator
+{
+  value_type *spot = first;
+  value_type *prev{L::prev_ptr(spot)};
+  if (prev) {
+    L::next_ptr(prev) = limit;
+  }
+  if (spot == _head) {
+    _head = limit;
+  }
+  // tail is only updated if @a limit is @a end (e.g., @c nullptr).
+  if (nullptr == limit) {
+    _tail = prev;
+  } else {
+    L::prev_ptr(limit) = prev;
+  }
+  // Clear links in removed elements.
+  while (spot != limit) {
+    value_type *target{spot};
+    spot                = L::next_ptr(spot);
+    L::prev_ptr(target) = L::next_ptr(target) = nullptr;
+  };
+
+  return {limit._v, this};
+};
+
+template <typename L>
+auto
+IntrusiveDList<L>::operator=(self_type &&that) -> self_type &
+{
+  if (this != &that) {
+    this->_head  = that._head;
+    this->_tail  = that._tail;
+    this->_count = that._count;
+    that.clear();
+  }
+  return *this;
+}
+
+template <typename L>
+size_t
+IntrusiveDList<L>::count() const
+{
+  return _count;
+};
+
+template <typename L>
+auto
+IntrusiveDList<L>::begin() const -> const_iterator
+{
+  return const_iterator{this, _head};
+};
+
+template <typename L>
+auto
+IntrusiveDList<L>::begin() -> iterator
+{
+  return iterator{this, _head};
+};
+
+template <typename L>
+auto
+IntrusiveDList<L>::end() const -> const_iterator
+{
+  return const_iterator{this, nullptr};
+};
+
+template <typename L>
+auto
+IntrusiveDList<L>::end() -> iterator
+{
+  return iterator{this, nullptr};
+};
+
+template <typename L>
+auto
+IntrusiveDList<L>::iterator_for(value_type *v) -> iterator
+{
+  return iterator{this, v};
+};
+
+template <typename L>
+auto
+IntrusiveDList<L>::iterator_for(const value_type *v) const -> const_iterator
+{
+  return const_iterator{this, v};
+};
+
+template <typename L>
+auto
+IntrusiveDList<L>::tail() -> value_type *
+{
+  return _tail;
+}
+
+template <typename L>
+auto
+IntrusiveDList<L>::tail() const -> const value_type *
+{
+  return _tail;
+}
+
+template <typename L>
+auto
+IntrusiveDList<L>::head() -> value_type *
+{
+  return _head;
+}
+
+template <typename L>
+auto
+IntrusiveDList<L>::head() const -> const value_type *
+{
+  return _head;
+}
+
+template <typename L>
+auto
+IntrusiveDList<L>::clear() -> self_type &
+{
+  _head = _tail = nullptr;
+  _count        = 0;
+  return *this;
+};
+
+namespace detail
+{
+  // Make @c apply more convenient by allowing the function to take a reference type or pointer type
+  // to the container elements. The pointer type is the base, plus a shim to convert from a reference
+  // type functor to a pointer pointer type. The complex return type definition forces only one, but
+  // not both, to be valid for a particular functor. This also must be done via free functions and not
+  // method overloads because the compiler forces a match up of method definitions and declarations
+  // before any template instantiation.
+
+  template <typename L, typename F>
+  auto
+  Intrusive_DList_Apply(IntrusiveDList<L> &list, F &&f)
+    -> decltype(f(*static_cast<typename IntrusiveDList<L>::value_type *>(nullptr)), list)
+  {
+    return list.apply([&f](typename IntrusiveDList<L>::value_type *v) { return f(*v); });
+  }
+
+  template <typename L, typename F>
+  auto
+  Intrusive_DList_Apply(IntrusiveDList<L> &list, F &&f)
+    -> decltype(f(static_cast<typename IntrusiveDList<L>::value_type *>(nullptr)), list)
+  {
+    auto spot{list.begin()};
+    auto limit{list.end()};
+    while (spot != limit) {
+      f(spot++); // post increment means @a spot is updated before @a f is applied.
+    }
+    return list;
+  }
+} // namespace detail
+
+template <typename L>
+template <typename F>
+auto
+IntrusiveDList<L>::apply(F &&f) -> self_type &
+{
+  return detail::Intrusive_DList_Apply(*this, f);
+};
+
+} // namespace swoc

--- a/lib/swoc++/include/swoc/IntrusiveHashMap.h
+++ b/lib/swoc++/include/swoc/IntrusiveHashMap.h
@@ -1,0 +1,730 @@
+/** @file
+
+  Instrusive hash map.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
+  See the NOTICE file distributed with this work for additional information regarding copyright
+  ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance with the License.  You may obtain a
+  copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License
+  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  or implied. See the License for the specific language governing permissions and limitations under
+  the License.
+*/
+
+#pragma once
+
+#include <vector>
+#include <array>
+#include <algorithm>
+#include "swoc/IntrusiveDList.h"
+
+namespace swoc
+{
+/** Intrusive Hash Table.
+
+    Values stored in this container are not destroyed when the container is destroyed or removed from the container.
+    They must be released by the client.
+
+    Duplicate keys are allowed. Clients must walk the list for multiple entries.
+    @see @c Location::operator++()
+
+    By default the table automatically expands to limit the average chain length. This can be tuned. If set
+    to @c MANUAL then the table will expand @b only when explicitly requested to do so by the client.
+    @see @c ExpansionPolicy
+    @see @c setExpansionPolicy()
+    @see @c setExpansionLimit()
+    @see @c expand()
+
+    The hash table is configured by a descriptor class. This must contain the following members
+
+    - The static method <tt>key_type key_of(value_type *)</tt> which returns the key for an instance of @c value_type.
+
+    - The static method <tt>bool equal(key_type lhs, key_type rhs)</tt> which checks if two instances of @c Key are the same.
+
+    - The static method <tt>hash_id hash_of(key_type)</tt> which computes the hash value of the key. @c ID must a numeric type.
+
+    - The static method <tt>value_type *& next_ptr(value_type *)</tt> which returns a reference to a forward pointer.
+
+    - The static method <tt>value_type *& prev_ptr(value_type *)</tt> which returns a reference to a backwards pointer.
+
+    These are the required members, it is permitted to have other methods (if the descriptor is used for other purposes)
+    or to provide overloads of the methods. Note this is compatible with @c IntrusiveDList.
+
+    Several internal types are deduced from these arguments.
+
+    @a Key is the return type of @a key_of and represents the key that distinguishes instances of @a value_type. Two
+    instances of @c value_type are considered the same if their respective @c Key values are @c equal. @c Key is
+    presumed cheap to copy. If the underlying key is not a simple type then @a Key should be a constant pointer or a
+    constant reference. The hash table will never attempt to modify a key.
+
+    @a ID The numeric type that is the hash value for an instance of @a Key.
+
+    Example for @c HttpServerSession keyed by the origin server IP address.
+
+    @code
+    struct Descriptor {
+      static sockaddr const* key_of(HttpServerSession const* value) { return &value->ip.sa }
+      static bool equal(sockaddr const* lhs, sockaddr const* rhs) { return ats_ip_eq(lhs, rhs); }
+      static uint32_t hash_of(sockaddr const* key) { return ats_ip_hash(key); }
+      static HttpServerSession *& next_ptr(HttpServerSession * ssn) { return ssn->_next; }
+      static HttpServerSession *& prev_ptr(HttpServerSession * ssn) { return ssn->_prev; }
+    };
+    using Table = IntrusiveHashMap<Descriptor>;
+    @endcode
+
+ */
+template <typename H> class IntrusiveHashMap
+{
+  using self_type = IntrusiveHashMap;
+
+public:
+  /// Type of elements in the map.
+  using value_type = typename std::remove_pointer<typename std::remove_reference<decltype(H::next_ptr(nullptr))>::type>::type;
+  /// Key type for the elements.
+  using key_type = decltype(H::key_of(static_cast<value_type *>(nullptr)));
+  /// The numeric hash ID computed from a key.
+  using hash_id = decltype(H::hash_of(H::key_of(static_cast<value_type *>(nullptr))));
+
+  /// When the hash table is expanded.
+  enum ExpansionPolicy {
+    MANUAL,  ///< Client must explicitly expand the table.
+    AVERAGE, ///< Table expands if average chain length exceeds limit. [default]
+    MAXIMUM  ///< Table expands if any chain length exceeds limit.
+  };
+
+protected:
+  /** List of elements.
+   * All table elements are in this list. The buckets reference their starting element in the list, or nothing if
+   * no elements are in that bucket.
+   */
+  using List = IntrusiveDList<H>;
+
+  /// A bucket for the hash map.
+  struct Bucket {
+    /// Support for IntrusiveDList<Bucket::Linkage>, definitions and link storage.
+    struct Linkage {
+      static Bucket *&next_ptr(Bucket *b); ///< Access next pointer.
+      static Bucket *&prev_ptr(Bucket *b); ///< Access prev pointer.
+      Bucket *_prev{nullptr};              ///< Prev pointer.
+      Bucket *_next{nullptr};              ///< Next pointer.
+    } _link;
+
+    value_type *_v{nullptr}; ///< First element in the bucket.
+    size_t _count{0};        ///< Number of elements in the bucket.
+
+    /** Marker for the chain having different keys.
+
+        This is used to determine if expanding the hash map would be useful - buckets that are not mixed
+        will not be changed by an expansion.
+     */
+    bool _mixed_p{false};
+
+    /// Compute the limit value for iteration in this bucket.
+    /// This is the value of the next bucket, or @c nullptr if no next bucket.
+    value_type *limit() const;
+
+    /// Verify @a v is in this bucket.
+    bool contains(value_type *v) const;
+
+    void clear(); ///< Reset to initial state.
+  };
+
+public:
+  /// The default starting number of buckets.
+  static size_t constexpr DEFAULT_BUCKET_COUNT = 7; ///< POOMA.
+  /// The default expansion policy limit.
+  static size_t constexpr DEFAULT_EXPANSION_LIMIT = 4; ///< Value from previous version.
+  /// Expansion policy if not specified in constructor.
+  static ExpansionPolicy constexpr DEFAULT_EXPANSION_POLICY = AVERAGE;
+
+  using iterator       = typename List::iterator;
+  using const_iterator = typename List::const_iterator;
+
+  /// A range of elements in the map.
+  /// It is a half open range, [first, last) in the usual STL style.
+  /// @internal I tried @c std::pair as a base for this but was unable to get STL container operations to work.
+  struct range : public std::pair<iterator, iterator> {
+    using super_type = std::pair<iterator, iterator>; ///< Super type.
+    using super_type::super_type;                     ///< Use super type constructors.
+
+    // These methods enable treating the range as a view in to the hash map.
+
+    /// Return @a first
+    iterator const &begin() const;
+    /// Return @a last
+    iterator const &end() const;
+  };
+
+  /// A range of constant elements in the map.
+  struct const_range : public std::pair<const_iterator, const_iterator> {
+    using super_type = std::pair<const_iterator, const_iterator>; ///< Super type.
+
+    /// Allow implicit conversion of range to const_range.
+    const_range(range const &r);
+
+    using super_type::super_type; ///< Use super type constructors.
+
+    // These methods enable treating the range as a view in to the hash map.
+
+    /// Return @a first
+    const_iterator const &begin() const;
+    /// Return @a last
+    const_iterator const &end() const;
+  };
+
+  /// Construct, starting with @n buckets.
+  /// This doubles as the default constructor.
+  IntrusiveHashMap(size_t n = DEFAULT_BUCKET_COUNT);
+
+  /** Remove all values from the table.
+
+      The values are not cleaned up. The values are not touched in this method, therefore it is safe
+      to destroy them first and then @c clear this table.
+  */
+  self_type &clear();
+
+  iterator begin();             ///< First element.
+  const_iterator begin() const; ///< First element.
+  iterator end();               ///< Past last element.
+  const_iterator end() const;   ///< Past last element.
+
+  /** Insert a value in to the table.
+      The @a value must @b NOT already be in a table of this type.
+      @note The value itself is put in the table, @b not a copy.
+  */
+  void insert(value_type *v);
+
+  /** Find an element with a key equal to @a key.
+
+      @return A element with a matching key, or the end iterator if not found.
+  */
+  const_iterator find(key_type key) const;
+  iterator find(key_type key);
+
+  /** Get an iterator for an existing value @a v.
+
+      @return An iterator that references @a v, or the end iterator if @a v is not in the table.
+  */
+  const_iterator find(value_type const *v) const;
+  iterator find(value_type *v);
+
+  /** Find the range of objects with keys equal to @a key.
+
+      @return A iterator pair of [first, last) items with equal keys.
+  */
+  const_range equal_range(key_type key) const;
+  range equal_range(key_type key);
+
+  /** Get an @c iterator for the value @a v.
+
+      This is a bit obscure but needed in certain cases. Because the interface assumes iterators are always valid
+      this avoid containment checks, which is useful if @a v is already known to be in the container.
+   */
+  iterator iterator_for(value_type *v);
+  const_iterator iterator_for(const value_type *v) const;
+
+  /** Remove the value at @a loc from the table.
+
+      @note This does @b not clean up the removed elements. Use carefully to avoid leaks.
+
+      @return An iterator the next value past @a loc. [STL compatibility]
+  */
+  iterator erase(iterator const &loc);
+
+  /// Remove all elements in the @c range @a r.
+  iterator erase(range const &r);
+
+  /// Remove all elements in the range (start, limit]
+  iterator erase(iterator const &start, iterator const &limit);
+
+  /// Remove a @a value from the container.
+  /// @a value is checked for being a member of the container.
+  /// @return @c true if @a value was in the container and removed, @c false if it was not in the container.
+  bool erase(value_type *value);
+
+  /** Apply @a F(value_type&) to every element in the hash map.
+   *
+   * This is similar to a range for loop except the iteration is done in a way where destruction or alternation of
+   * the element does @b not affect the iterator. Primarily this is useful for @c delete to clean up the elements
+   * but it can have other uses.
+   *
+   * @tparam F A functional object of the form <tt>void F(value_type&)</tt>
+   * @param f The function to apply.
+   * @return
+   */
+  template <typename F> self_type &apply(F &&f);
+
+  /** Expand the hash if needed.
+
+      Useful primarily when the expansion policy is set to @c MANUAL.
+   */
+  void expand();
+
+  /// Number of elements in the map.
+  size_t count() const;
+
+  /// Number of buckets in the array.
+  size_t bucket_count() const;
+
+  /// Set the expansion policy to @a policy.
+  self_type &set_expansion_policy(ExpansionPolicy policy);
+
+  /// Get the current expansion policy
+  ExpansionPolicy get_expansion_policy() const;
+
+  /// Set the limit value for the expansion policy.
+  self_type &set_expansion_limit(size_t n);
+
+  /// Set the limit value for the expansion policy.
+  size_t get_expansion_limit() const;
+
+protected:
+  /// The type of storage for the buckets.
+  using Table = std::vector<Bucket>;
+
+  List _list;   ///< Elements in the table.
+  Table _table; ///< Array of buckets.
+
+  /// List of non-empty buckets.
+  IntrusiveDList<typename Bucket::Linkage> _active_buckets;
+
+  Bucket *bucket_for(key_type key);
+
+  ExpansionPolicy _expansion_policy{DEFAULT_EXPANSION_POLICY}; ///< When to exand the table.
+  size_t _expansion_limit{DEFAULT_EXPANSION_LIMIT};            ///< Limit value for expansion.
+
+  // noncopyable
+  IntrusiveHashMap(const IntrusiveHashMap &) = delete;
+  IntrusiveHashMap &operator=(const IntrusiveHashMap &) = delete;
+
+  // Hash table size prime list.
+  static constexpr std::array<size_t, 29> PRIME = {{1,        3,        7,         13,        31,       61,      127,     251,
+                                                    509,      1021,     2039,      4093,      8191,     16381,   32749,   65521,
+                                                    131071,   262139,   524287,    1048573,   2097143,  4194301, 8388593, 16777213,
+                                                    33554393, 67108859, 134217689, 268435399, 536870909}};
+};
+
+template <typename H>
+auto
+IntrusiveHashMap<H>::Bucket::Linkage::next_ptr(Bucket *b) -> Bucket *&
+{
+  return b->_link._next;
+}
+
+template <typename H>
+auto
+IntrusiveHashMap<H>::Bucket::Linkage::prev_ptr(Bucket *b) -> Bucket *&
+{
+  return b->_link._prev;
+}
+
+// This is designed so that if the bucket is empty, then @c nullptr is returned, which will immediately terminate
+// a search loop on an empty bucket because that will start with a nullptr candidate, matching the limit.
+template <typename H>
+auto
+IntrusiveHashMap<H>::Bucket::limit() const -> value_type *
+{
+  Bucket *n{_link._next};
+  return n ? n->_v : nullptr;
+};
+
+template <typename H>
+void
+IntrusiveHashMap<H>::Bucket::clear()
+{
+  _v       = nullptr;
+  _count   = 0;
+  _mixed_p = false;
+}
+
+template <typename H>
+bool
+IntrusiveHashMap<H>::Bucket::contains(value_type *v) const
+{
+  value_type *x     = _v;
+  value_type *limit = this->limit();
+  while (x != limit && x != v) {
+    x = H::next_ptr(x);
+  }
+  return x == v;
+}
+
+// ---------------------
+template <typename H>
+auto
+IntrusiveHashMap<H>::range::begin() const -> iterator const &
+{
+  return super_type::first;
+}
+template <typename H>
+auto
+IntrusiveHashMap<H>::range::end() const -> iterator const &
+{
+  return super_type::second;
+}
+
+template <typename H>
+auto
+IntrusiveHashMap<H>::const_range::begin() const -> const_iterator const &
+{
+  return super_type::first;
+}
+
+template <typename H>
+auto
+IntrusiveHashMap<H>::const_range::end() const -> const_iterator const &
+{
+  return super_type::second;
+}
+
+// ---------------------
+
+template <typename H> IntrusiveHashMap<H>::IntrusiveHashMap(size_t n)
+{
+  if (n) {
+    _table.resize(*std::lower_bound(PRIME.begin(), PRIME.end(), n));
+  }
+}
+
+template <typename H>
+auto
+IntrusiveHashMap<H>::bucket_for(key_type key) -> Bucket *
+{
+  return &_table[H::hash_of(key) % _table.size()];
+}
+
+template <typename H>
+auto
+IntrusiveHashMap<H>::begin() -> iterator
+{
+  return _list.begin();
+}
+
+template <typename H>
+auto
+IntrusiveHashMap<H>::begin() const -> const_iterator
+{
+  return _list.begin();
+}
+
+template <typename H>
+auto
+IntrusiveHashMap<H>::end() -> iterator
+{
+  return _list.end();
+}
+
+template <typename H>
+auto
+IntrusiveHashMap<H>::end() const -> const_iterator
+{
+  return _list.end();
+}
+
+template <typename H>
+auto
+IntrusiveHashMap<H>::clear() -> self_type &
+{
+  for (auto &b : _table) {
+    b.clear();
+  }
+  // Clear container data.
+  _list.clear();
+  _active_buckets.clear();
+  return *this;
+}
+
+template <typename H>
+auto
+IntrusiveHashMap<H>::find(key_type key) -> iterator
+{
+  Bucket *b         = this->bucket_for(key);
+  value_type *v     = b->_v;
+  value_type *limit = b->limit();
+  while (v != limit && !H::equal(key, H::key_of(v))) {
+    v = H::next_ptr(v);
+  }
+  return v == limit ? _list.end() : _list.iterator_for(v);
+}
+
+template <typename H>
+auto
+IntrusiveHashMap<H>::find(key_type key) const -> const_iterator
+{
+  return const_cast<self_type *>(this)->find(key);
+}
+
+template <typename H>
+auto
+IntrusiveHashMap<H>::equal_range(key_type key) -> range
+{
+  iterator first{this->find(key)};
+  iterator last{first};
+  iterator limit{this->end()};
+
+  while (last != limit && H::equal(key, H::key_of(&*last))) {
+    ++last;
+  }
+
+  return range{first, last};
+}
+
+template <typename H>
+auto
+IntrusiveHashMap<H>::equal_range(key_type key) const -> const_range
+{
+  return const_cast<self_type *>(this)->equal_range(key);
+}
+
+template <typename H>
+auto
+IntrusiveHashMap<H>::iterator_for(const value_type *v) const -> const_iterator
+{
+  return _list.iterator_for(v);
+}
+
+template <typename H>
+auto
+IntrusiveHashMap<H>::iterator_for(value_type *v) -> iterator
+{
+  return _list.iterator_for(v);
+}
+
+template <typename H>
+auto
+IntrusiveHashMap<H>::find(value_type *v) -> iterator
+{
+  Bucket *b = this->bucket_for(H::key_of(v));
+  return b->contains(v) ? _list.iterator_for(v) : this->end();
+}
+
+template <typename H>
+auto
+IntrusiveHashMap<H>::find(value_type const *v) const -> const_iterator
+{
+  return const_cast<self_type *>(this)->find(const_cast<value_type *>(v));
+}
+
+template <typename H>
+void
+IntrusiveHashMap<H>::insert(value_type *v)
+{
+  auto key         = H::key_of(v);
+  Bucket *bucket   = this->bucket_for(key);
+  value_type *spot = bucket->_v;
+  bool mixed_p     = false; // Found a different key in the bucket.
+
+  if (nullptr == spot) { // currently empty bucket, set it and add to active list.
+    _list.append(v);
+    bucket->_v = v;
+    _active_buckets.append(bucket);
+  } else {
+    value_type *limit = bucket->limit();
+
+    // First search the bucket to see if the key is already in it.
+    while (spot != limit && !H::equal(key, H::key_of(spot))) {
+      spot = H::next_ptr(spot);
+    }
+    if (spot != bucket->_v) {
+      mixed_p = true; // found some other key, it's going to be mixed.
+    }
+    if (spot != limit) {
+      // If an equal key was found, walk past those to insert at the upper end of the range.
+      do {
+        spot = H::next_ptr(spot);
+      } while (spot != limit && H::equal(key, H::key_of(spot)));
+      if (spot != limit) { // something not equal past last equivalent, it's going to be mixed.
+        mixed_p = true;
+      }
+    }
+
+    _list.insert_before(spot, v);
+    if (spot == bucket->_v) { // added before the bucket start, update the start.
+      bucket->_v = v;
+    }
+    bucket->_mixed_p = mixed_p;
+  }
+  ++bucket->_count;
+
+  // auto expand if appropriate.
+  if ((AVERAGE == _expansion_policy && (_list.count() / _table.size()) > _expansion_limit) ||
+      (MAXIMUM == _expansion_policy && bucket->_count > _expansion_limit && bucket->_mixed_p)) {
+    this->expand();
+  }
+}
+
+template <typename H>
+auto
+IntrusiveHashMap<H>::erase(iterator const &loc) -> iterator
+{
+  value_type *v     = loc;
+  iterator zret     = ++(this->iterator_for(v)); // get around no const_iterator -> iterator.
+  Bucket *b         = this->bucket_for(H::key_of(v));
+  value_type *nv    = H::next_ptr(v);
+  value_type *limit = b->limit();
+  if (b->_v == v) {    // removed first element in bucket, update bucket
+    if (limit == nv) { // that was also the only element, deactivate bucket
+      _active_buckets.erase(b);
+      b->clear();
+    } else {
+      b->_v = nv;
+      --b->_count;
+    }
+  }
+  _list.erase(loc);
+  return zret;
+}
+
+template <typename H>
+bool
+IntrusiveHashMap<H>::erase(value_type *value)
+{
+  auto loc = this->find(value);
+  if (loc != this->end()) {
+    this->erase(loc);
+    return true;
+  }
+  return false;
+}
+
+template <typename H>
+auto
+IntrusiveHashMap<H>::erase(iterator const &start, iterator const &limit) -> iterator
+{
+  auto spot{start};
+  Bucket *bucket{this->bucket_for(spot)};
+  while (spot != limit) {
+    auto target         = bucket;
+    bucket              = bucket->_link._next; // bump now to avoid forward iteration problems in case of bucket removal.
+    value_type *v_limit = bucket ? bucket->_v : nullptr;
+    while (spot != v_limit && spot != limit) {
+      --(target->_count);
+      ++spot;
+    }
+    if (target->_count == 0) {
+      _active_buckets.erase(target);
+    }
+  }
+  _list.erase(start, limit);
+  return _list.iterator_for(limit); // convert from const_iterator back to iterator
+};
+
+template <typename H>
+auto
+IntrusiveHashMap<H>::erase(range const &r) -> iterator
+{
+  return this->erase(r.first, r.second);
+}
+
+namespace detail
+{
+  // Make @c apply more convenient by allowing the function to take a reference type or pointer type to the container
+  // elements. The pointer type is the base, plus a shim to convert from a reference type functor to a pointer pointer
+  // type. The complex return type definition forces only one, but not both, to be valid for a particular functor. This
+  // also must be done via free functions and not method overloads because the compiler forces a match up of method
+  // definitions and declarations before any template instantiation.
+
+  template <typename H, typename F>
+  auto
+  IntrusiveHashMapApply(IntrusiveHashMap<H> &map, F &&f)
+    -> decltype(f(*static_cast<typename IntrusiveHashMap<H>::value_type *>(nullptr)), map)
+  {
+    return map.apply([&f](typename IntrusiveHashMap<H>::value_type *v) { return f(*v); });
+  }
+
+  template <typename H, typename F>
+  auto
+  IntrusiveHashMapApply(IntrusiveHashMap<H> &map, F &&f)
+    -> decltype(f(static_cast<typename IntrusiveHashMap<H>::value_type *>(nullptr)), map)
+  {
+    auto spot{map.begin()};
+    auto limit{map.end()};
+    while (spot != limit) {
+      f(spot++); // post increment means @a spot is updated before @a f is applied.
+    }
+    return map;
+  }
+} // namespace detail
+
+template <typename H>
+template <typename F>
+auto
+IntrusiveHashMap<H>::apply(F &&f) -> self_type &
+{
+  return detail::IntrusiveHashMapApply(*this, f);
+};
+
+template <typename H>
+void
+IntrusiveHashMap<H>::expand()
+{
+  ExpansionPolicy org_expansion_policy = _expansion_policy; // save for restore.
+  value_type *old                      = _list.head();      // save for repopulating.
+  auto old_size                        = _table.size();
+
+  // Reset to empty state.
+  this->clear();
+  _table.resize(*std::lower_bound(PRIME.begin(), PRIME.end(), old_size + 1));
+
+  _expansion_policy = MANUAL; // disable any auto expand while we're expanding.
+  while (old) {
+    value_type *v = old;
+    old           = H::next_ptr(old);
+    this->insert(v);
+  }
+  // stashed array gets cleaned up when @a tmp goes out of scope.
+  _expansion_policy = org_expansion_policy; // reset to original value.
+}
+
+template <typename H>
+size_t
+IntrusiveHashMap<H>::count() const
+{
+  return _list.count();
+}
+
+template <typename H>
+size_t
+IntrusiveHashMap<H>::bucket_count() const
+{
+  return _table.size();
+}
+
+template <typename H>
+auto
+IntrusiveHashMap<H>::set_expansion_policy(ExpansionPolicy policy) -> self_type &
+{
+  _expansion_policy = policy;
+  return *this;
+}
+
+template <typename H>
+auto
+IntrusiveHashMap<H>::get_expansion_policy() const -> ExpansionPolicy
+{
+  return _expansion_policy;
+}
+
+template <typename H>
+auto
+IntrusiveHashMap<H>::set_expansion_limit(size_t n) -> self_type &
+{
+  _expansion_limit = n;
+  return *this;
+}
+
+template <typename H>
+size_t
+IntrusiveHashMap<H>::get_expansion_limit() const
+{
+  return _expansion_limit;
+}
+
+} // namespace swoc

--- a/lib/swoc++/include/swoc/Lexicon.h
+++ b/lib/swoc++/include/swoc/Lexicon.h
@@ -1,0 +1,733 @@
+/** @file
+
+    Assistant class for translating strings to and from enumeration values.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements.  See the NOTICE file distributed with this work for additional information regarding
+    copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with the License.  You may
+    obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#pragma once
+
+#include <string_view>
+#include <initializer_list>
+#include <tuple>
+#include <functional>
+#include <array>
+#include "swoc/IntrusiveHashMap.h"
+#include "swoc/MemArena.h"
+#include "swoc/bwf_base.h"
+#include "swoc/ext/HashFNV.h"
+
+namespace swoc
+{
+namespace detail
+{
+  template <typename... Args>
+  std::string
+  what(std::string_view const &fmt, Args &&... args)
+  {
+    std::string zret;
+    swoc::bwprintv(zret, fmt, std::forward_as_tuple(args...));
+    return std::move(zret);
+  }
+} // namespace detail
+
+/** A bidirectional mapping between names and enumeration values.
+
+    This is intended to be a support class to make interacting with enumerations easier for
+    configuration and logging. Names and enumerations can then be easily and reliably interchanged.
+    The names are case insensitive but preserving.
+
+    Each enumeration has a @a primary name and an arbitrary number of @a secondary names. When
+    converting from an enumeration, the primary name is used. However, any of the names will be
+    converted to the enumeration. For instance, a @c Lexicon for a boolean might have the primary
+    name of @c TRUE be "true" with the secondary names "1", "yes", "enable". In that case converting
+    @c TRUE would always be "true", while converting any of "true", "1", "yes", or "enable" would
+    yield @c TRUE. This is convenient for parsing configurations to be more tolerant of input.
+
+    @note All names and value must be unique across the Lexicon. All name comparisons are case
+    insensitive.
+ */
+template <typename E> class Lexicon
+{
+  using self_type = Lexicon; ///< Self reference type.
+
+protected:
+  struct Item;
+
+public:
+  /// Used for initializer lists that have just a primary value.
+  using Pair = std::tuple<E, std::string_view>;
+  /// A function to be called if a value is not found.
+  using UnknownValueHandler = std::function<std::string_view(E)>;
+  /// A function to be called if a name is not found.
+  using UnknownNameHandler = std::function<E(std::string_view)>;
+
+  /// Element of an initializer list that contains secondary names.
+  struct Definition {
+    const E &value;                                       ///< Value for definition.
+    const std::initializer_list<std::string_view> &names; ///< Primary then secondary names.
+  };
+
+  /// Template argument carrying struct.
+  /// @note Needed to pass a compile time constant to a constructor as compile time constant.
+  template <E e> struct Require {
+  };
+
+  /// Construct empty instance.
+  Lexicon();
+  /// Construct with secondary names.
+  Lexicon(const std::initializer_list<Definition> &items);
+  /// Construct with primary names only.
+  Lexicon(const std::initializer_list<Pair> &items);
+  /// Construct and verify the number of definitions.
+  template <E e> Lexicon(const Require<e> &, const std::array<Definition, static_cast<size_t>(e)> &defines);
+  /// Construct and verify the number of pairs.
+  template <E e> Lexicon(const Require<e> &, const std::array<Pair, static_cast<size_t>(e)> &defines);
+
+  /// Convert a value to a name
+  std::string_view operator[](E value);
+
+  /// Convert a name to a value
+  E operator[](std::string_view name);
+
+  /// Define the @a names for a @a value.
+  /// The first name is the primary name. All @a names must be convertible to @c std::string_view.
+  /// <tt>lexicon.define(Value, primary, [secondary, ... ]);</tt>
+  template <typename... Args> self_type &define(E value, Args &&... names);
+  // These are really for consistency with constructors, they're not expected to be commonly used.
+  /// Define a value and names.
+  /// <tt>lexicon.define(Value, { primary, [secondary, ...] });</tt>
+  self_type &define(E value, const std::initializer_list<std::string_view> &names);
+  self_type &define(const Pair &pair);
+  self_type &define(const Definition &init);
+
+  /** Set a default @a value.
+   *
+   * @param value Value to return if a name is not found.
+   * @return @c *this
+   */
+  self_type &set_default(E value);
+
+  /** Set a default @a name.
+   *
+   * @param name Name to return if a value is not found.
+   * @return @c *this
+   *
+   * @note The @a name is copied to local storage.
+   */
+  self_type &set_default(std::string_view name);
+
+  /** Set a default @a handler for names that are not found.
+   *
+   * @param handler Function to call with a name that was not found.
+   * @return @c this
+   *
+   * @a handler is passed the name that was not found as a @c std::string_view and must return a
+   * value which is then returned to the caller.
+   */
+  self_type &set_default(const UnknownNameHandler &handler);
+
+  /** Set a default @a handler for values that are not found.
+   *
+   * @param handler Function to call with a value that was not found.
+   * @return @c *this
+   *
+   * @a handler is passed the value that was not found and must return a name as a @c std::string_view.
+   * Caution must be used because the returned name must not leak and must be thread safe. The most
+   * common use would be for logging bad values.
+   */
+  self_type &set_default(const UnknownValueHandler &handler);
+
+  /// Get the number of values with definitions.
+  size_t count() const;
+
+  /// Iterator over pairs of values and primary name pairs.
+  class const_iterator
+  {
+    using self_type = const_iterator;
+
+  public:
+    using value_type        = const Pair;
+    using pointer           = value_type *;
+    using reference         = value_type &;
+    using difference_type   = ptrdiff_t;
+    using iterator_category = std::bidirectional_iterator_tag;
+
+    const_iterator()                      = default;
+    const_iterator(self_type const &that) = default;
+    const_iterator(self_type &&that)      = default;
+
+    reference operator*() const;
+    pointer operator->() const;
+
+    self_type &operator=(self_type const &that) = default;
+    bool operator==(self_type const &that) const;
+    bool operator!=(self_type const &that) const;
+
+    self_type &operator++();
+    self_type operator++(int);
+
+    self_type &operator--();
+    self_type operator--(int);
+
+  protected:
+    const_iterator(const Item *item);
+    void update();
+    const Item *_item{nullptr};
+    typename std::remove_const<value_type>::type _v;
+
+    friend Lexicon;
+  };
+
+  // There is no modifying elements in the Lexicon so only constant iteration.
+  using iterator = const_iterator;
+
+  const_iterator begin() const;
+  const_iterator end() const;
+
+protected:
+  // Because std::variant is broken up through clang 6, we have to do something uglier.
+  //  using NameDefault  = std::variant<std::monostate, std::string_view, UnknownValueHandler>;
+  //  using ValueDefault = std::variant<std::monostate, E, UnknownNameHandler>;
+
+  enum class Content {
+    NIL,    ///< Nothing, not set.
+    SCALAR, ///< A specific value/name.
+    HANDLER ///< A function
+  };
+
+  struct NilValue {
+  };
+
+  struct NameDefault {
+    using self_type = NameDefault;
+
+    NameDefault() = default;
+    ~NameDefault();
+
+    self_type &operator=(std::string_view name);
+    self_type &operator=(const UnknownValueHandler &handler);
+
+    std::string_view operator()(E value);
+
+    self_type &destroy();
+
+    Content _content{Content::NIL};
+    static constexpr size_t N = std::max<size_t>(sizeof(std::string_view), sizeof(UnknownValueHandler));
+    char _store[N];
+  };
+
+  struct ValueDefault {
+    using self_type = ValueDefault;
+
+    ValueDefault() = default;
+    ~ValueDefault();
+
+    self_type &operator=(E value);
+    self_type &operator=(const UnknownNameHandler &handler);
+
+    E operator()(std::string_view name);
+
+    self_type &destroy();
+
+    Content _content{Content::NIL};
+    static constexpr size_t N = std::max<size_t>(sizeof(E), sizeof(UnknownNameHandler));
+    char _store[N];
+  };
+
+  /// Each unique pair of value and name is stored as an instance of this class.
+  /// The primary is stored first and is therefore found by normal lookup.
+  struct Item {
+    Item(E, std::string_view);
+
+    E _value;               ///< Definition value.
+    std::string_view _name; ///< Definition name
+
+    /// Intrusive linkage for name lookup.
+    struct NameLinkage {
+      Item *_next{nullptr};
+      Item *_prev{nullptr};
+
+      static Item *&next_ptr(Item *);
+
+      static Item *&prev_ptr(Item *);
+
+      static std::string_view key_of(Item *);
+
+      static uint32_t hash_of(std::string_view s);
+
+      static bool equal(std::string_view const &lhs, std::string_view const &rhs);
+    } _name_link;
+
+    /// Intrusive linkage for value lookup.
+    struct ValueLinkage {
+      Item *_next{nullptr};
+      Item *_prev{nullptr};
+
+      static Item *&next_ptr(Item *);
+
+      static Item *&prev_ptr(Item *);
+
+      static E key_of(Item *);
+
+      static uintmax_t hash_of(E);
+
+      static bool equal(E lhs, E rhs);
+    } _value_link;
+  };
+
+  /// Copy @a name in to local storage.
+  std::string_view localize(std::string_view name);
+
+  /// Storage for names.
+  MemArena _arena{1024};
+  /// Access by name.
+  IntrusiveHashMap<typename Item::NameLinkage> _by_name;
+  /// Access by value.
+  IntrusiveHashMap<typename Item::ValueLinkage> _by_value;
+  NameDefault _name_default;   ///< Name to return if no value not found.
+  ValueDefault _value_default; ///< Value to return if name not found.
+};
+
+// ==============
+// Implementation
+
+// ----
+// Item
+
+template <typename E> Lexicon<E>::Item::Item(E value, std::string_view name) : _value(value), _name(name) {}
+
+template <typename E>
+auto
+Lexicon<E>::Item::NameLinkage::next_ptr(Item *item) -> Item *&
+{
+  return item->_name_link._next;
+}
+
+template <typename E>
+auto
+Lexicon<E>::Item::NameLinkage::prev_ptr(Item *item) -> Item *&
+{
+  return item->_name_link._prev;
+}
+
+template <typename E>
+auto
+Lexicon<E>::Item::ValueLinkage::next_ptr(Item *item) -> Item *&
+{
+  return item->_value_link._next;
+}
+
+template <typename E>
+auto
+Lexicon<E>::Item::ValueLinkage::prev_ptr(Item *item) -> Item *&
+{
+  return item->_value_link._prev;
+}
+
+template <typename E>
+std::string_view
+Lexicon<E>::Item::NameLinkage::key_of(Item *item)
+{
+  return item->_name;
+}
+
+template <typename E>
+E
+Lexicon<E>::Item::ValueLinkage::key_of(Item *item)
+{
+  return item->_value;
+}
+
+template <typename E>
+uint32_t
+Lexicon<E>::Item::NameLinkage::hash_of(std::string_view s)
+{
+  return Hash32FNV1a().hash_immediate(transform_view_of(&toupper, s));
+}
+
+template <typename E>
+uintmax_t
+Lexicon<E>::Item::ValueLinkage::hash_of(E value)
+{
+  // In almost all cases, the values will be (roughly) sequential, so an identity hash works well.
+  return static_cast<uintmax_t>(value);
+}
+
+template <typename E>
+bool
+Lexicon<E>::Item::NameLinkage::equal(std::string_view const &lhs, std::string_view const &rhs)
+{
+  return 0 == strcasecmp(lhs, rhs);
+}
+
+template <typename E>
+bool
+Lexicon<E>::Item::ValueLinkage::equal(E lhs, E rhs)
+{
+  return lhs == rhs;
+}
+
+// -------
+
+template <typename E>
+auto
+Lexicon<E>::NameDefault::destroy() -> self_type &
+{
+  if (_content == Content::HANDLER) {
+    reinterpret_cast<UnknownValueHandler *>(_store)->~UnknownValueHandler();
+  }
+  _content = Content::NIL;
+  return *this;
+}
+
+template <typename E> Lexicon<E>::NameDefault::~NameDefault()
+{
+  this->destroy();
+}
+
+template <typename E>
+auto
+Lexicon<E>::NameDefault::operator=(std::string_view name) -> self_type &
+{
+  this->destroy();
+  new (_store) std::string_view(name);
+  _content = Content::SCALAR;
+  return *this;
+}
+
+template <typename E>
+auto
+Lexicon<E>::NameDefault::operator=(const UnknownValueHandler &handler) -> self_type &
+{
+  this->destroy();
+  new (_store) UnknownValueHandler(handler);
+  _content = Content::HANDLER;
+  return *this;
+}
+
+template <typename E>
+std::string_view
+Lexicon<E>::NameDefault::operator()(E value)
+{
+  switch (_content) {
+  case Content::SCALAR:
+    return *reinterpret_cast<std::string_view *>(_store);
+    break;
+  case Content::HANDLER:
+    return (*(reinterpret_cast<UnknownValueHandler *>(_store)))(value);
+    break;
+  default:
+    throw std::domain_error(detail::what("Lexicon: unknown enumeration '{}'", static_cast<uintmax_t>(value)));
+    break;
+  }
+}
+
+// -------
+
+template <typename E>
+auto
+Lexicon<E>::ValueDefault::destroy() -> self_type &
+{
+  if (_content == Content::HANDLER) {
+    reinterpret_cast<UnknownNameHandler *>(_store)->~UnknownNameHandler();
+  }
+  _content = Content::NIL;
+  return *this;
+}
+
+template <typename E> Lexicon<E>::ValueDefault::~ValueDefault()
+{
+  this->destroy();
+}
+
+template <typename E>
+auto
+Lexicon<E>::ValueDefault::operator=(E value) -> self_type &
+{
+  this->destroy();
+  *(reinterpret_cast<E *>(_store)) = value;
+  _content                         = Content::SCALAR;
+  return *this;
+}
+
+template <typename E>
+auto
+Lexicon<E>::ValueDefault::operator=(const UnknownNameHandler &handler) -> self_type &
+{
+  this->destroy();
+  new (_store) UnknownNameHandler(handler);
+  _content = Content::HANDLER;
+  return *this;
+}
+
+template <typename E>
+E
+Lexicon<E>::ValueDefault::operator()(std::string_view name)
+{
+  switch (_content) {
+  case Content::SCALAR:
+    return *(reinterpret_cast<E *>(_store));
+    break;
+  case Content::HANDLER:
+    return (*(reinterpret_cast<UnknownNameHandler *>(_store)))(name);
+    break;
+  default:
+    throw std::domain_error(swoc::LocalBufferWriter<128>().print("Lexicon: unknown name '{}'\0", name).data());
+    break;
+  }
+}
+// -------
+// Lexicon
+
+template <typename E> Lexicon<E>::Lexicon() {}
+
+template <typename E> Lexicon<E>::Lexicon(const std::initializer_list<Definition> &items)
+{
+  for (auto item : items) {
+    this->define(item.value, item.names);
+  }
+}
+
+template <typename E> Lexicon<E>::Lexicon(const std::initializer_list<Pair> &items)
+{
+  for (auto item : items) {
+    this->define(item);
+  }
+}
+
+template <typename E>
+template <E e>
+Lexicon<E>::Lexicon(const Require<e> &, const std::array<Definition, static_cast<size_t>(e)> &defines)
+{
+  for (auto &def : defines) {
+    this->define(def);
+  }
+}
+
+template <typename E>
+template <E e>
+Lexicon<E>::Lexicon(const Require<e> &, const std::array<Pair, static_cast<size_t>(e)> &defines)
+{
+  for (auto &def : defines) {
+    this->define(def);
+  }
+}
+
+template <typename E>
+std::string_view
+Lexicon<E>::localize(std::string_view name)
+{
+  auto span = _arena.alloc(name.size());
+  memcpy(span.data(), name.data(), name.size());
+  return span.view();
+}
+
+template <typename E> std::string_view Lexicon<E>::Lexicon::operator[](E value)
+{
+  auto spot = _by_value.find(value);
+  if (spot != _by_value.end()) {
+    return spot->_name;
+  }
+  return _name_default(value);
+}
+
+template <typename E> E Lexicon<E>::Lexicon::operator[](std::string_view name)
+{
+  auto spot = _by_name.find(name);
+  if (spot != _by_name.end()) {
+    return spot->_value;
+  }
+  return _value_default(name);
+}
+
+template <typename E>
+auto
+Lexicon<E>::Lexicon::define(E value, const std::initializer_list<std::string_view> &names) -> self_type &
+{
+  if (names.size() < 1) {
+    throw std::invalid_argument("A defined value must have at least a primary name");
+  }
+  for (auto name : names) {
+    if (_by_name.find(name) != _by_name.end()) {
+      throw std::invalid_argument(detail::what("Duplicate name '{}' in Lexicon", name));
+    }
+    auto i = new Item(value, this->localize(name));
+    _by_name.insert(i);
+    // Only put primary names in the value table.
+    if (_by_value.find(value) == _by_value.end()) {
+      _by_value.insert(i);
+    }
+  }
+  return *this;
+}
+
+template <typename E>
+template <typename... Args>
+auto
+Lexicon<E>::Lexicon::define(E value, Args &&... names) -> self_type &
+{
+  static_assert(sizeof...(Args) > 0, "A defined value must have at least a priamry name");
+  return this->define(value, {std::forward<Args>(names)...});
+}
+
+template <typename E>
+auto
+Lexicon<E>::Lexicon::define(const Pair &pair) -> self_type &
+{
+  return this->define(std::get<0>(pair), {std::get<1>(pair)});
+}
+
+template <typename E>
+auto
+Lexicon<E>::Lexicon::define(const Definition &init) -> self_type &
+{
+  return this->define(init.value, init.names);
+}
+
+template <typename E>
+auto
+Lexicon<E>::Lexicon::set_default(std::string_view name) -> self_type &
+{
+  _name_default = this->localize(name);
+  return *this;
+}
+
+template <typename E>
+auto
+Lexicon<E>::Lexicon::set_default(E value) -> self_type &
+{
+  _value_default = value;
+  return *this;
+}
+
+template <typename E>
+auto
+Lexicon<E>::Lexicon::set_default(const UnknownValueHandler &handler) -> self_type &
+{
+  _name_default = handler;
+  return *this;
+}
+
+template <typename E>
+auto
+Lexicon<E>::Lexicon::set_default(const UnknownNameHandler &handler) -> self_type &
+{
+  _value_default = handler;
+  return *this;
+}
+
+template <typename E>
+size_t
+Lexicon<E>::Lexicon::count() const
+{
+  return _by_value.count();
+}
+
+template <typename E>
+auto
+Lexicon<E>::Lexicon::begin() const -> const_iterator
+{
+  return const_iterator{static_cast<const Item *>(_by_value.begin())};
+}
+
+template <typename E>
+auto
+Lexicon<E>::Lexicon::end() const -> const_iterator
+{
+  return {};
+}
+
+// Iterators
+
+template <typename E>
+void
+Lexicon<E>::const_iterator::update()
+{
+  std::get<0>(_v) = _item->_value;
+  std::get<1>(_v) = _item->_name;
+}
+
+template <typename E> Lexicon<E>::const_iterator::const_iterator(const Item *item) : _item(item)
+{
+  if (_item) {
+    this->update();
+  };
+}
+
+template <typename E> auto Lexicon<E>::const_iterator::operator*() const -> reference
+{
+  return _v;
+}
+
+template <typename E> auto Lexicon<E>::const_iterator::operator-> () const -> pointer
+{
+  return &_v;
+}
+
+template <typename E>
+bool
+Lexicon<E>::const_iterator::operator==(self_type const &that) const
+{
+  return _item == that._item;
+}
+
+template <typename E>
+bool
+Lexicon<E>::const_iterator::operator!=(self_type const &that) const
+{
+  return _item != that._item;
+}
+
+template <typename E>
+auto
+Lexicon<E>::const_iterator::operator++() -> self_type &
+{
+  if (nullptr != (_item = _item->_value_link._next)) {
+    this->update();
+  }
+  return *this;
+}
+
+template <typename E>
+auto
+Lexicon<E>::const_iterator::operator++(int) -> self_type
+{
+  self_type tmp{*this};
+  ++*this;
+  return tmp;
+}
+
+template <typename E>
+auto
+Lexicon<E>::const_iterator::operator--() -> self_type &
+{
+  if (nullptr != (_item = _item->_value_link->_prev)) {
+    this->update();
+  }
+  return *this;
+}
+
+template <typename E>
+auto
+Lexicon<E>::const_iterator::operator--(int) -> self_type
+{
+  self_type tmp;
+  ++*this;
+  return tmp;
+}
+
+} // namespace swoc

--- a/lib/swoc++/include/swoc/MemArena.h
+++ b/lib/swoc++/include/swoc/MemArena.h
@@ -1,0 +1,342 @@
+/** @file
+
+    Memory arena for allocations
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements.  See the NOTICE file distributed with this work for additional information regarding
+    copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with the License.  You may
+    obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#pragma once
+
+#include <new>
+#include <mutex>
+#include <memory>
+#include <utility>
+
+#include "swoc/MemSpan.h"
+#include "swoc/Scalar.h"
+#include "swoc/IntrusiveDList.h"
+
+namespace swoc
+{
+/** A memory arena.
+
+    The intended use is for allocating many small chunks of memory - few, large allocations are best
+    handled through other mechanisms. The purpose is to amortize the cost of allocation of each
+    chunk across larger internal allocations ("reserving memory"). In addition the allocated memory
+    chunks are presumed to have similar lifetimes so all of the memory in the arena can be released
+    when the arena is destroyed.
+ */
+class MemArena
+{
+  using self_type = MemArena; ///< Self reference type.
+protected:
+  /// Simple internal arena block of memory. Maintains the underlying memory.
+  struct Block {
+    size_t size;         ///< Actual block size.
+    size_t allocated{0}; ///< Current allocated (in use) bytes.
+    struct Linkage {
+      Block *_next{nullptr};
+      Block *_prev{nullptr};
+
+      static Block *&next_ptr(Block *);
+
+      static Block *&prev_ptr(Block *);
+    } _link;
+
+    /** Construct to have @a n bytes of available storage.
+     *
+     * Note this is descriptive - this presumes use via placement new and the size value describes
+     * memory already allocated immediately after this instance.
+     * @param n The amount of storage.
+     */
+    Block(size_t n);
+
+    /// Get the start of the data in this block.
+    char *data();
+
+    /// Get the start of the data in this block.
+    const char *data() const;
+
+    /// Amount of unallocated storage.
+    size_t remaining() const;
+
+    /// Span of unallocated storage.
+    MemSpan<void> remnant();
+
+    /** Allocate @a n bytes from this block.
+     *
+     * @param n Number of bytes to allocate.
+     * @return The span of memory allocated.
+     */
+    MemSpan<void> alloc(size_t n);
+
+    /** Check if the byte at address @a ptr is in this block.
+     *
+     * @param ptr Address of byte to check.
+     * @return @c true if @a ptr is in this block, @c false otherwise.
+     */
+    bool contains(const void *ptr) const;
+
+    /** Override standard delete.
+     *
+     * This is required because the allocated memory size is larger than the class size which requires
+     * calling @c free differently.
+     *
+     * @param ptr Memory to be de-allocated.
+     */
+    static void operator delete(void *ptr);
+  };
+
+  using BlockList = IntrusiveDList<Block::Linkage>;
+
+public:
+  /** Construct with reservation hint.
+   *
+   * No memory is initially reserved, but when memory is needed this will be done so at least
+   * @a n bytes of available memory is reserved.
+   *
+   * To pre-reserve call @c alloc(0), e.g.
+   * @code
+   * MemArena arena(512); // Make sure at least 512 bytes available in first block.
+   * arena.alloc(0); // Force allocation of first block.
+   * @endcode
+   *
+   * @param n Minimum number of available bytes in the first internally reserved block.
+   */
+  explicit MemArena(size_t n = DEFAULT_BLOCK_SIZE);
+
+  /// no copying
+  MemArena(self_type const &that) = delete;
+  MemArena(self_type &&that)      = default;
+
+  /// Destructor.
+  ~MemArena();
+
+  self_type &operator=(self_type const &that) = delete;
+  self_type &operator=(self_type &&that) = default;
+
+  /** Allocate @a n bytes of storage.
+
+      Returns a span of memory within the arena. alloc() is self expanding but DOES NOT self
+      coalesce. This means that no matter the arena size, the caller will always be able to alloc()
+      @a n bytes.
+
+      @param n number of bytes to allocate.
+      @return a MemSpan of the allocated memory.
+   */
+  MemSpan<void> alloc(size_t n);
+
+  /** Allocate and initialize a block of memory.
+
+      The template type specifies the type to create and any arguments are forwarded to the constructor. Example:
+      @code
+      struct Thing { ... };
+      Thing* thing = arena.make<Thing>(...constructor args...);
+      @endcode
+
+      Do @b not call @c delete an object created this way - that will attempt to free the memory and break. A
+      destructor may be invoked explicitly but the point of this class is that no object in it needs to be
+      deleted, the memory will all be reclaimed when the Arena is destroyed. In general it is a bad idea
+      to make objects in the Arena that own memory that is not also in the Arena.
+  */
+  template <typename T, typename... Args> T *make(Args &&... args);
+
+  /** Freeze reserved memory.
+
+      All internal memory blocks are frozen and will not be involved in future allocations. Subsequent
+      allocation will reserve new internal blocks. By default the first reserved block will be large
+      enough to contain all frozen memory. If this is not correct a different target can be
+      specified as @a n.
+
+      @param n Target number of available bytes in the next reserved internal block.
+      @return @c *this
+   */
+  MemArena &freeze(size_t n = 0);
+
+  /** Unfreeze arena.
+   *
+   * Frozen memory is released.
+   *
+   * @return @c *this
+   */
+  self_type &thaw();
+
+  /** Release all memory.
+
+      Empties the entire arena and deallocates all underlying memory. The hint for the next reservered block size will
+      be @a n if @a n is not zero, otherwise it will be the sum of all allocations when this method was called.
+
+      @return @c *this
+
+   */
+  MemArena &clear(size_t n = 0);
+
+  /// @returns the memory allocated in the generation.
+  size_t size() const;
+
+  /// @returns the @c remaining space within the generation.
+  size_t remaining() const;
+
+  /// @returns the remaining contiguous space in the active generation.
+  MemSpan<void> remnant();
+
+  /// @returns the total number of bytes allocated within the arena.
+  size_t allocated_size() const;
+
+  /** Check if a the byte at @a ptr is in memory owned by this arena.
+   *
+   * @param ptr Address of byte to check.
+   * @return @c true if the byte at @a ptr is in the arena, @c false if not.
+   */
+  bool contains(const void *ptr) const;
+
+  /** Total memory footprint, including wasted space.
+   * @return Total memory footprint.
+   */
+  size_t reserved_size() const;
+
+protected:
+  /** Internally allocates a new block of memory of size @a n bytes.
+   *
+   * @param n Size of block to allocate.
+   * @return
+   */
+  Block *make_block(size_t n);
+  /// Clean up the frozen list.
+  void destroy_frozen();
+  /// Clean up the active list
+  void destroy_active();
+
+  using Page      = Scalar<4096>; ///< Size for rounding block sizes.
+  using Paragraph = Scalar<16>;   ///< Minimum unit of memory allocation.
+
+  static constexpr size_t ALLOC_HEADER_SIZE = 16; ///< Guess of overhead of @c malloc
+  /// Initial block size to allocate if not specified via API.
+  static constexpr size_t DEFAULT_BLOCK_SIZE = Page::SCALE - Paragraph{round_up(ALLOC_HEADER_SIZE + sizeof(Block))};
+
+  size_t _active_allocated = 0; ///< Total allocations in the active generation.
+  size_t _active_reserved  = 0; ///< Total current reserved memory.
+  /// Total allocations in the previous generation. This is only non-zero while the arena is frozen.
+  size_t _frozen_allocated = 0;
+  /// Total frozen reserved memory.
+  size_t _frozen_reserved = 0;
+
+  /// Minimum free space needed in the next allocated block.
+  /// This is not zero iff @c reserve was called.
+  size_t _reserve_hint = 0;
+
+  BlockList _frozen; ///< Previous generation, frozen memory.
+  BlockList _active; ///< Current generation. Allocate here.
+};
+
+// Implementation
+
+inline auto
+MemArena::Block::Linkage::next_ptr(Block *b) -> Block *&
+{
+  return b->_link._next;
+}
+
+inline auto
+MemArena::Block::Linkage::prev_ptr(Block *b) -> Block *&
+{
+  return b->_link._prev;
+}
+
+inline MemArena::Block::Block(size_t n) : size(n) {}
+
+inline char *
+MemArena::Block::data()
+{
+  return reinterpret_cast<char *>(this + 1);
+}
+
+inline const char *
+MemArena::Block::data() const
+{
+  return reinterpret_cast<const char *>(this + 1);
+}
+
+inline bool
+MemArena::Block::contains(const void *ptr) const
+{
+  const char *base = this->data();
+  return base <= ptr && ptr < base + size;
+}
+
+inline size_t
+MemArena::Block::remaining() const
+{
+  return size - allocated;
+}
+
+inline MemSpan<void>
+MemArena::Block::alloc(size_t n)
+{
+  if (n > this->remaining()) {
+    throw(std::invalid_argument{"MemArena::Block::alloc size is more than remaining."});
+  }
+  MemSpan<void> zret = this->remnant().prefix(n);
+  allocated += n;
+  return zret;
+}
+
+template <typename T, typename... Args>
+T *
+MemArena::make(Args &&... args)
+{
+  return new (this->alloc(sizeof(T)).data()) T(std::forward<Args>(args)...);
+}
+
+inline MemArena::MemArena(size_t n) : _reserve_hint(n) {}
+
+inline MemSpan<void>
+MemArena::Block::remnant()
+{
+  return {this->data() + allocated, this->remaining()};
+}
+
+inline size_t
+MemArena::size() const
+{
+  return _active_allocated;
+}
+
+inline size_t
+MemArena::allocated_size() const
+{
+  return _frozen_allocated + _active_allocated;
+}
+
+inline size_t
+MemArena::remaining() const
+{
+  return _active.empty() ? 0 : _active.head()->remaining();
+}
+
+inline MemSpan<void>
+MemArena::remnant()
+{
+  return _active.empty() ? MemSpan<void>() : _active.head()->remnant();
+}
+
+inline size_t
+MemArena::reserved_size() const
+{
+  return _active_reserved + _frozen_reserved;
+}
+
+} // namespace swoc

--- a/lib/swoc++/include/swoc/MemSpan.h
+++ b/lib/swoc++/include/swoc/MemSpan.h
@@ -1,0 +1,829 @@
+/** @file
+
+   Spans of memory. This is similar but independently developed from @c std::span. The goal is
+   to provide convenient handling for chunks of memory. These chunks can be treated as arrays
+   of arbitrary types via template methods.
+
+
+   @section license License
+
+   Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+   agreements.  See the NOTICE file distributed with this work for additional information regarding
+   copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with the License.  You may obtain
+   a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software distributed under the License
+   is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+   or implied. See the License for the specific language governing permissions and limitations under
+   the License.
+ */
+
+#pragma once
+#include <cstring>
+#include <iosfwd>
+#include <iostream>
+#include <cstddef>
+#include <string_view>
+#include <type_traits>
+#include <ratio>
+#include <exception>
+
+/// Apache Traffic Server commons.
+namespace swoc
+{
+/** A span of contiguous piece of memory.
+
+    A @c MemSpan does not own the memory to which it refers, it is simply a span of part of some
+    (presumably) larger memory object. The purpose is that frequently code needs to work on a specific
+    part of the memory. This can avoid copying or allocation by allocating all needed memory at once
+    and then working with it via instances of this class.
+ */
+template <typename T> class MemSpan
+{
+  using self_type = MemSpan; ///< Self reference type.
+
+protected:
+  T *_ptr       = nullptr; ///< Pointer to base of memory chunk.
+  size_t _count = 0;       ///< Number of elements.
+
+public:
+  using value_type = T;
+
+  /// Default constructor (empty buffer).
+  constexpr MemSpan() = default;
+
+  /** Construct from a first element @a start and a @a count of elements.
+   *
+   * @param start First element.
+   * @param count Total number of elements.
+   */
+  constexpr MemSpan(value_type *start, size_t count);
+
+  /** Construct from a half open range [start, last).
+   *
+   * @param start Start of range.
+   * @param last Past end of range.
+   */
+  constexpr MemSpan(value_type *start, value_type *last);
+
+  /** Construct to cover an array.
+   *
+   * @tparam N Number of elements in the array.
+   * @param a The array.
+   */
+  template <size_t N> MemSpan(T (&a)[N]);
+
+  /** Construct from nullptr.
+      This implicitly makes the length 0.
+  */
+  constexpr MemSpan(std::nullptr_t);
+
+  /** Equality.
+
+      Compare the span contents.
+
+      @return @c true if the contents of @a that are the same as the content of @a this,
+      @c false otherwise.
+   */
+  bool operator==(self_type const &that) const;
+
+  /** Identical.
+
+      Check if the spans refer to the same span of memory.
+      @return @c true if @a this and @a that refer to the same span, @c false if not.
+   */
+  bool is_same(self_type const &that) const;
+
+  /** Inequality.
+      @return @c true if @a that does not refer to the same span as @a this,
+      @c false otherwise.
+   */
+  bool operator!=(self_type const &that) const;
+
+  /// Assignment - the span is copied, not the content.
+  self_type &operator=(self_type const &that);
+
+  /// Access element at index @a idx.
+  T &operator[](size_t idx) const;
+
+  /// Check for empty span.
+  /// @return @c true if the span is empty (no contents), @c false otherwise.
+  bool operator!() const;
+
+  /// Check for non-empty span.
+  /// @return @c true if the span contains bytes.
+  explicit operator bool() const;
+
+  /// Check for empty span (no content).
+  /// @see operator bool
+  bool empty() const;
+
+  /// @name Accessors.
+  //@{
+  /// Pointer to the first element in the span.
+  T *begin() const;
+
+  /// Pointer to first element not in the span.
+  T *end() const;
+
+  /// Number of elements in the span
+  size_t count() const;
+
+  /// Number of bytes in the span.
+  size_t size() const;
+
+  /// Pointer to memory in the span.
+  T *data() const;
+
+  /** Create a new span for a different type @a V on the same memory.
+   *
+   * @tparam V Type for the created span.
+   * @return A @c MemSpan which contains the same memory as instances of @a V.
+   */
+  template <typename U = void> MemSpan<U> rebind() const;
+
+  /// Set the span.
+  /// This is faster but equivalent to constructing a new span with the same
+  /// arguments and assigning it.
+  /// @return @c this.
+  self_type &assign(T *ptr,      ///< Buffer start.
+                    size_t count ///< # of elements.
+  );
+
+  /// Set the span.
+  /// This is faster but equivalent to constructing a new span with the same
+  /// arguments and assigning it.
+  /// @return @c this.
+  self_type &assign(T *first,     ///< First valid element.
+                    T const *last ///< First invalid element.
+  );
+
+  /// Clear the span (become an empty span).
+  self_type &clear();
+
+  /// @return @c true if the byte at @a *p is in the span.
+  bool contains(value_type const *p) const;
+
+  /** Get the initial segment of @a count elements.
+
+      @return An instance that contains the leading @a count elements of @a this.
+  */
+  self_type prefix(size_t count) const;
+
+  /** Shrink the span by removing @a count leading elements.
+   *
+   * @param count The number of elements to remove.
+   * @return @c *this
+   */
+  self_type &remove_prefix(size_t count);
+
+  /** Get the trailing segment of @a count elements.
+   *
+   * @param count Number of elements to retrieve.
+   * @return An instance that contains the trailing @a count elements of @a this.
+   */
+  self_type suffix(size_t count) const;
+
+  /** Shrink the span by removing @a count trailing elements.
+   *
+   * @param count Number of elements to remove.
+   * @return @c *this
+   */
+  self_type &remove_suffix(size_t count);
+
+  /** Return a view of the memory.
+   *
+   * @return A @c string_view covering the span contents.
+   */
+  std::string_view view() const;
+
+  /** Support automatic conversion to string_view.
+   *
+   * @return A view of the memory in this span.
+   */
+  operator std::string_view() const;
+
+  template <typename U> friend class MemSpan;
+};
+
+/** Specialization for void pointers.
+ *
+ * Key differences:
+ *
+ * - No subscript operator.
+ * - No array initialization.
+ *
+ * @internal I tried to be clever about the base template but there were too many differences
+ * One major issue was the array initialization did not work at all if the @c void case didn't
+ * exclude that. Once separate there are a number of useful tweaks available.
+ */
+template <> class MemSpan<void>
+{
+  using self_type = MemSpan; ///< Self reference type.
+  template <typename U> friend class MemSpan;
+
+protected:
+  void *_ptr   = nullptr; ///< Pointer to base of memory chunk.
+  size_t _size = 0;       ///< Number of elements.
+
+public:
+  using value_type = void;
+
+  /// Default constructor (empty buffer).
+  constexpr MemSpan() = default;
+
+  /** Construct from a pointer @a start and a size @a n bytes.
+   *
+   * @param start Start of the span.
+   * @param n # of bytes in the span.
+   */
+  constexpr MemSpan(value_type *start, size_t n);
+
+  /** Construct from a half open range of [start, last).
+   *
+   * @param start Start of the range.
+   * @param last Past end of range.
+   */
+  MemSpan(value_type *start, value_type *last);
+
+  /** Construct from nullptr.
+      This implicitly makes the length 0.
+  */
+  constexpr MemSpan(std::nullptr_t);
+
+  /** Equality.
+
+      Compare the span contents.
+
+      @return @c true if the contents of @a that are bytewise the same as the content of @a this,
+      @c false otherwise.
+   */
+  bool operator==(self_type const &that) const;
+
+  /** Identical.
+
+      Check if the spans refer to the same span of memory.
+
+      @return @c true if @a this and @a that refer to the same memory, @c false if not.
+   */
+  bool is_same(self_type const &that) const;
+
+  /** Inequality.
+      @return @c true if @a that does not refer to the same span as @a this,
+      @c false otherwise.
+   */
+  bool operator!=(self_type const &that) const;
+
+  /// Assignment - the span is copied, not the content.
+  /// Any type of @c MemSpan can be assigned to @c MemSpan<void>.
+  template <typename U> self_type &operator=(MemSpan<U> const &that);
+
+  /// Check for empty span.
+  /// @return @c true if the span is empty (no contents), @c false otherwise.
+  bool operator!() const;
+
+  /// Check for non-empty span.
+  /// @return @c true if the span contains bytes.
+  explicit operator bool() const;
+
+  /// Check for empty span (no content).
+  /// @see operator bool
+  bool empty() const;
+
+  /// Number of bytes in the span.
+  size_t size() const;
+
+  /// Pointer to memory in the span.
+  value_type *data() const;
+
+  /// Pointer to memory in the span.
+  value_type *data_end() const;
+
+  /** Create a new span for a different type @a V on the same memory.
+   *
+   * @tparam V Type for the created span.
+   * @return A @c MemSpan which contains the same memory as instances of @a V.
+   */
+  template <typename U> MemSpan<U> rebind() const;
+
+  /// Set the span.
+  /// This is faster but equivalent to constructing a new span with the same
+  /// arguments and assigning it.
+  /// @return @c this.
+  self_type &assign(value_type *ptr, ///< Buffer start.
+                    size_t n         ///< # of bytes
+  );
+
+  /// Set the span.
+  /// This is faster but equivalent to constructing a new span with the same
+  /// arguments and assigning it.
+  /// @return @c this.
+  self_type &assign(value_type *first,     ///< First valid element.
+                    value_type const *last ///< First invalid element.
+  );
+
+  /// Clear the span (become an empty span).
+  self_type &clear();
+
+  /// @return @c true if the byte at @a *ptr is in the span.
+  bool contains(value_type const *ptr) const;
+
+  /** Get the initial segment of @a n bytes.
+
+      @return An instance that contains the leading @a n bytes of @a this.
+  */
+  self_type prefix(size_t n) const;
+
+  /** Shrink the span by removing @a n leading bytes.
+   *
+   * @param count The number of elements to remove.
+   * @return @c *this
+   */
+
+  self_type &remove_prefix(size_t n);
+
+  /** Get the trailing segment of @a n bytes.
+   *
+   * @param n Number of bytes to retrieve.
+   * @return An instance that contains the trailing @a count elements of @a this.
+   */
+  self_type suffix(size_t n) const;
+
+  /** Shrink the span by removing @a n bytes.
+   *
+   * @param n Number of bytes to remove.
+   * @return @c *this
+   */
+  self_type &remove_suffix(size_t n);
+
+  /** Return a view of the memory.
+   *
+   * @return A @c string_view covering the span contents.
+   */
+  std::string_view view() const;
+
+  /** Support automatic conversion to string_view.
+   *
+   * @return A view of the memory in this span.
+   */
+  operator std::string_view() const;
+};
+
+// -- Implementation --
+
+namespace detail
+{
+  /// Suport pointer distance calculations for all types, @b include @c <void*>.
+  /// This is useful in templates.
+  inline size_t
+  ptr_distance(void const *first, void const *last)
+  {
+    return static_cast<const char *>(last) - static_cast<const char *>(first);
+  }
+
+  template <typename T>
+  size_t
+  ptr_distance(T const *first, T const *last)
+  {
+    return last - first;
+  }
+
+  /* More void handling. This can't go in @c MemSpan because template specialization is invalid
+   * in class scope.
+   */
+  // Check if the conversion from @a T to @a U is reasonable.
+  template <typename T, typename U> struct is_span_compatible {
+    static constexpr bool value = std::ratio<sizeof(T), sizeof(U)>::num == 1 || std::ratio<sizeof(U), sizeof(T)>::num == 1;
+    static size_t
+    count(size_t size)
+    {
+      if (size % sizeof(U)) {
+        throw std::invalid_argument("MemSpan rebind where span size is not a multiple of the element size");
+      }
+      return size / sizeof(U);
+    }
+  };
+
+  template <typename T> struct is_span_compatible<T, void> {
+    static constexpr bool value = true;
+    static size_t
+    count(size_t size)
+    {
+      return size;
+    }
+  };
+
+} // namespace detail
+
+// --- Standard memory operations ---
+
+template <typename T>
+int
+memcmp(MemSpan<T> const &lhs, MemSpan<T> const &rhs)
+{
+  int zret = 0;
+  size_t n = lhs.size();
+
+  // Seems a bit ugly but size comparisons must be done anyway to get the memcmp args.
+  if (lhs.count() < rhs.count()) {
+    zret = 1;
+  } else if (lhs.count() > rhs.count()) {
+    zret = -1;
+    n    = rhs.size();
+  }
+  // else the counts are equal therefore @a n and @a zret are already correct.
+
+  int r = std::memcmp(lhs.data(), rhs.data(), n);
+  if (0 != r) { // If we got a not-equal, override the size based result.
+    zret = r;
+  }
+
+  return zret;
+}
+
+template <typename T>
+inline T *
+memcpy(MemSpan<T> &dst, T *src)
+{
+  return memcpy(dst.data(), src, dst.size());
+}
+// need to bring memcmp in so this is an overload, not an override.
+using std::memcmp;
+
+template <typename T>
+inline T *
+memcpy(T *dst, MemSpan<T> &src)
+{
+  return memcpy(dst, src.data(), src.size());
+}
+using std::memcpy;
+
+template <typename T>
+inline MemSpan<T> const&
+memset(MemSpan<T> const& dst, T const& t)
+{
+  for ( auto & e : dst ) {
+    e = t;
+  }
+  return dst;
+}
+
+inline MemSpan<char> const&
+memset(MemSpan<char> const& dst, char c)
+{
+  std::memset(dst.data(), c, dst.size());
+  return dst;
+}
+
+inline MemSpan<unsigned char> const&
+memset(MemSpan<unsigned char> const& dst, unsigned char c)
+{
+  std::memset(dst.data(), c, dst.size());
+  return dst;
+}
+
+inline MemSpan<void> const&
+memset(MemSpan<void> const& dst, char c)
+{
+  std::memset(dst.data(), c, dst.size());
+  return dst;
+}
+
+using std::memset;
+
+// --- MemSpan<T> ---
+
+template <typename T> constexpr MemSpan<T>::MemSpan(T *ptr, size_t count) : _ptr{ptr}, _count{count} {}
+
+template <typename T> constexpr MemSpan<T>::MemSpan(T *first, T *last) : _ptr{first}, _count{detail::ptr_distance(first, last)} {}
+
+template <typename T> template <size_t N> MemSpan<T>::MemSpan(T (&a)[N]) : _ptr{a}, _count{N} {}
+
+template <typename T> constexpr MemSpan<T>::MemSpan(std::nullptr_t) {}
+
+template <typename T>
+MemSpan<T> &
+MemSpan<T>::assign(T *ptr, size_t count)
+{
+  _ptr   = ptr;
+  _count = count;
+  return *this;
+}
+
+template <typename T>
+MemSpan<T> &
+MemSpan<T>::assign(T *first, T const *last)
+{
+  _ptr   = first;
+  _count = detail::ptr_distance(first, last);
+  return *this;
+}
+
+template <typename T>
+MemSpan<T> &
+MemSpan<T>::clear()
+{
+  _ptr   = nullptr;
+  _count = 0;
+  return *this;
+}
+
+template <typename T>
+bool
+MemSpan<T>::is_same(self_type const &that) const
+{
+  return _ptr == that._ptr && _count == that._count;
+}
+
+template <typename T>
+bool
+MemSpan<T>::operator==(self_type const &that) const
+{
+  return _count == that._count && (_ptr == that._ptr || 0 == memcmp(_ptr, that._ptr, this->size()));
+}
+
+template <typename T>
+bool
+MemSpan<T>::operator!=(self_type const &that) const
+{
+  return !(*this == that);
+}
+
+template <typename T> bool MemSpan<T>::operator!() const
+{
+  return _count == 0;
+}
+
+template <typename T> MemSpan<T>::operator bool() const
+{
+  return _count != 0;
+}
+
+template <typename T>
+bool
+MemSpan<T>::empty() const
+{
+  return _count == 0;
+}
+
+template <typename T>
+T *
+MemSpan<T>::begin() const
+{
+  return _ptr;
+}
+
+template <typename T>
+T *
+MemSpan<T>::data() const
+{
+  return _ptr;
+}
+
+template <typename T>
+T *
+MemSpan<T>::end() const
+{
+  return _ptr + _count;
+}
+
+template <typename T> T &MemSpan<T>::operator[](size_t idx) const
+{
+  return _ptr[idx];
+}
+
+template <typename T>
+size_t
+MemSpan<T>::count() const
+{
+  return _count;
+}
+
+template <typename T>
+size_t
+MemSpan<T>::size() const
+{
+  return _count * sizeof(T);
+}
+
+template <typename T>
+auto
+MemSpan<T>::operator=(self_type const &that) -> self_type &
+{
+  _ptr   = that._ptr;
+  _count = that._count;
+  return *this;
+}
+
+template <typename T>
+bool
+MemSpan<T>::contains(T const *ptr) const
+{
+  return _ptr <= ptr && ptr < _ptr + _count;
+}
+
+template <typename T>
+auto
+MemSpan<T>::prefix(size_t count) const -> self_type
+{
+  return {_ptr, std::min(count, _count)};
+}
+
+template <typename T>
+auto
+MemSpan<T>::remove_prefix(size_t count) -> self_type &
+{
+  count = std::min(_count, count);
+  _count -= count;
+  _ptr += count;
+  return *this;
+}
+
+template <typename T>
+auto
+MemSpan<T>::suffix(size_t count) const -> self_type
+{
+  count = std::min(_count, count);
+  return {(_ptr + _count) - count, count};
+}
+
+template <typename T>
+MemSpan<T> &
+MemSpan<T>::remove_suffix(size_t count)
+{
+  _count -= std::min(count, _count);
+  return *this;
+}
+
+template <typename T>
+template <typename U>
+MemSpan<U>
+MemSpan<T>::rebind() const
+{
+  static_assert(detail::is_span_compatible<T, U>::value,
+                "MemSpan only allows rebinding between types who sizes are integral multiples.");
+  return {static_cast<U *>(static_cast<void *>(_ptr)), detail::is_span_compatible<T, U>::count(this->size())};
+}
+
+template <typename T>
+std::string_view
+MemSpan<T>::view() const
+{
+  return {static_cast<const char *>(_ptr), this->size()};
+}
+
+template <typename T> MemSpan<T>::operator std::string_view() const
+{
+  return this->view();
+}
+
+// --- void specialization ---
+
+inline constexpr MemSpan<void>::MemSpan(value_type *ptr, size_t n) : _ptr{ptr}, _size{n} {}
+
+inline MemSpan<void>::MemSpan(value_type *first, value_type *last) : _ptr{first}, _size{detail::ptr_distance(first, last)} {}
+
+inline constexpr MemSpan<void>::MemSpan(std::nullptr_t) {}
+
+inline MemSpan<void> &
+MemSpan<void>::assign(value_type *ptr, size_t n)
+{
+  _ptr  = ptr;
+  _size = n;
+  return *this;
+}
+
+inline MemSpan<void> &
+MemSpan<void>::assign(value_type *first, value_type const *last)
+{
+  _ptr  = first;
+  _size = detail::ptr_distance(first, last);
+  return *this;
+}
+
+inline MemSpan<void> &
+MemSpan<void>::clear()
+{
+  _ptr  = nullptr;
+  _size = 0;
+  return *this;
+}
+
+inline bool
+MemSpan<void>::is_same(self_type const &that) const
+{
+  return _ptr == that._ptr && _size == that._size;
+}
+
+inline bool
+MemSpan<void>::operator==(self_type const &that) const
+{
+  return _size == that._size && (_ptr == that._ptr || 0 == memcmp(_ptr, that._ptr, _size));
+}
+
+inline bool
+MemSpan<void>::operator!=(self_type const &that) const
+{
+  return !(*this == that);
+}
+
+inline bool MemSpan<void>::operator!() const
+{
+  return _size == 0;
+}
+
+inline MemSpan<void>::operator bool() const
+{
+  return _size != 0;
+}
+
+inline bool
+MemSpan<void>::empty() const
+{
+  return _size == 0;
+}
+
+inline void *
+MemSpan<void>::data() const
+{
+  return _ptr;
+}
+
+inline void *
+MemSpan<void>::data_end() const
+{
+  return static_cast<char *>(_ptr) + _size;
+}
+
+inline size_t
+MemSpan<void>::size() const
+{
+  return _size;
+}
+
+template <typename U>
+auto
+MemSpan<void>::operator=(MemSpan<U> const &that) -> self_type &
+{
+  _ptr  = that._ptr;
+  _size = that.size();
+  return *this;
+}
+
+inline bool
+MemSpan<void>::contains(value_type const *ptr) const
+{
+  return _ptr <= ptr && ptr < this->data_end();
+}
+
+inline MemSpan<void>
+MemSpan<void>::prefix(size_t n) const
+{
+  return {_ptr, std::min(n, _size)};
+}
+
+inline MemSpan<void> &
+MemSpan<void>::remove_prefix(size_t n)
+{
+  n = std::max(_size, n);
+  _size -= n;
+  _ptr = static_cast<char *>(_ptr) + n;
+  return *this;
+}
+
+inline MemSpan<void>
+MemSpan<void>::suffix(size_t count) const
+{
+  count = std::max(count, _size);
+  return {static_cast<char *>(this->data_end()) - count, size_t(count)};
+}
+
+inline MemSpan<void> &
+MemSpan<void>::remove_suffix(size_t count)
+{
+  _size -= std::max(count, _size);
+  return *this;
+}
+
+template <typename U>
+MemSpan<U>
+MemSpan<void>::rebind() const
+{
+  return {static_cast<U *>(_ptr), detail::is_span_compatible<void, U>::count(_size)};
+}
+
+inline std::string_view
+MemSpan<void>::view() const
+{
+  return {static_cast<char const *>(_ptr), _size};
+}
+
+inline MemSpan<void>::operator std::string_view() const
+{
+  return this->view();
+}
+
+} // namespace swoc

--- a/lib/swoc++/include/swoc/Scalar.h
+++ b/lib/swoc++/include/swoc/Scalar.h
@@ -1,0 +1,938 @@
+/** @file
+
+  Scaled integral values.
+
+  In many situations it is desirable to define scaling factors or base units (a "metric"). This template
+  enables this to be done in a type and scaling safe manner where the defined factors carry their scaling
+  information as part of the type.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
+  See the NOTICE file distributed with this work for additional information regarding copyright
+  ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance with the License.  You may obtain a
+  copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License
+  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  or implied. See the License for the specific language governing permissions and limitations under
+  the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <ratio>
+#include <ostream>
+#include <type_traits>
+
+#include "swoc/swoc_meta.h"
+
+namespace tag
+{
+struct generic;
+}
+
+namespace swoc
+{
+template <intmax_t N, typename C, typename T> class Scalar;
+
+namespace detail
+{
+  // @internal - althought these conversion methods look bulky, in practice they compile down to
+  // very small amounts of code due to dead code elimination and that all of the conditions are
+  // compile time constants.
+
+  // The general case where neither N nor S are a multiple of the other seems a bit long but this
+  // minimizes the risk of integer overflow.  I need to validate that under -O2 the compiler will
+  // only do 1 division to get both the quotient and remainder for (n/N) and (n%N). In cases where
+  // N,S are powers of 2 I have verified recent GNU compilers will optimize to bit operations.
+
+  /// Convert a count @a c that is scale @s S to scale @c N
+  template <intmax_t N, intmax_t S>
+  intmax_t
+  scale_conversion_round_up(intmax_t c)
+  {
+    typedef std::ratio<N, S> R;
+    if (N == S) {
+      return c;
+    } else if (R::den == 1) {
+      return c / R::num + (0 != c % R::num); // N is a multiple of S.
+    } else if (R::num == 1) {
+      return c * R::den; // S is a multiple of N.
+    } else {
+      return (c / R::num) * R::den + ((c % R::num) * R::den) / R::num + (0 != (c % R::num));
+    }
+  }
+
+  /// Convert a count @a c that is scale @s S to scale @c N
+  template <intmax_t N, intmax_t S>
+  intmax_t
+  scale_conversion_round_down(intmax_t c)
+  {
+    typedef std::ratio<N, S> R;
+    if (N == S) {
+      return c;
+    } else if (R::den == 1) {
+      return c / R::num; // N = k S
+    } else if (R::num == 1) {
+      return c * R::den; // S = k N
+    } else {
+      return (c / R::num) * R::den + ((c % R::num) * R::den) / R::num;
+    }
+  }
+
+  /* Helper classes for @c Scalar
+
+     These wrap values to capture extra information for @c Scalar methods. This includes whether to
+     round up or down when converting and, when the wrapped data is also a @c Scalar, the scale.
+
+     These are not intended for direct use but by the @c round_up and @c round_down free functions
+     which capture the information about the argument and construct an instance of one of these
+     classes to pass it on to a @c Scalar method.
+
+     Scale conversions between @c Scalar instances are handled in these classes via the templated
+     methods @c scale_conversion_round_up and @c scale_conversion_round_down.
+
+     Conversions between scales and types for the scalar helpers is done inside the helper classes
+     and a user type conversion operator exists so the helper can be converted by the compiler to
+     the correct type. For the units bases conversion this is done in @c Scalar because the
+     generality of the needed conversion is too broad to be easily used. It can be done but there is
+     some ugliness due to the fact that in some cases two user conversions which is difficult to
+     deal with. I have tried it both ways and overall this seems a cleaner implementation.
+
+     Much of this is driven by the fact that the assignment operator, in some cases, can not be
+     templated and therefore to have a nice interface for assignment this split is needed.
+   */
+
+  // Unit value, to be rounded up.
+  template <typename C> struct scalar_unit_round_up_t {
+    C _n;
+    //    template <typename I> constexpr operator scalar_unit_round_up_t<I>() { return {static_cast<I>(_count)}; }
+    template <intmax_t N, typename I>
+    constexpr I
+    scale() const
+    {
+      return static_cast<I>(_n / N + (0 != (_n % N)));
+    }
+  };
+  // Unit value, to be rounded down.
+  template <typename C> struct scalar_unit_round_down_t {
+    C _n;
+    //    template <typename I> operator scalar_unit_round_down_t<I>() { return {static_cast<I>(_count)}; }
+    template <intmax_t N, typename I>
+    constexpr I
+    scale() const
+    {
+      return static_cast<I>(_n / N);
+    }
+  };
+  // Scalar value, to be rounded up.
+  template <intmax_t N, typename C, typename T> struct scalar_round_up_t {
+    C _n;
+    template <intmax_t S, typename I> constexpr operator Scalar<S, I, T>() const
+    {
+      return Scalar<S, I, T>(scale_conversion_round_up<S, N>(_n));
+    }
+  };
+  // Scalar value, to be rounded down.
+  template <intmax_t N, typename C, typename T> struct scalar_round_down_t {
+    C _n;
+    template <intmax_t S, typename I> constexpr operator Scalar<S, I, T>() const
+    {
+      return Scalar<S, I, T>(scale_conversion_round_down<S, N>(_n));
+    }
+  };
+} // namespace detail
+
+/// Mark a unit value to be scaled, rounding down.
+template <typename C>
+constexpr detail::scalar_unit_round_up_t<C>
+round_up(C n)
+{
+  return {n};
+}
+
+/// Mark a @c Scalar value to be scaled, rounding up.
+template <intmax_t N, typename C, typename T>
+constexpr detail::scalar_round_up_t<N, C, T>
+round_up(Scalar<N, C, T> v)
+{
+  return {v.count()};
+}
+
+/// Mark a unit value to be scaled, rounding down.
+template <typename C>
+constexpr detail::scalar_unit_round_down_t<C>
+round_down(C n)
+{
+  return {n};
+}
+
+/// Mark a @c Scalar value, to be rounded down.
+template <intmax_t N, typename C, typename T>
+constexpr detail::scalar_round_down_t<N, C, T>
+round_down(Scalar<N, C, T> v)
+{
+  return {v.count()};
+}
+
+/** A class to hold scaled values.
+
+    Instances of this class have a @a count and a @a scale. The "value" of the instance is @a
+    count * @a scale.  The scale is stored in the compiler in the class symbol table and so only
+    the count is a run time value. An instance with a large scale can be assign to an instance
+    with a smaller scale and the conversion is done automatically. Conversions from a smaller to
+    larger scale must be explicit using @c round_up and @c round_down. This prevents
+    inadvertent changes in value. Because the scales are not the same these conversions can be
+    lossy and the two conversions determine whether, in such a case, the result should be rounded
+    up or down to the nearest scale value.
+
+    @a N sets the scale. @a C is the type used to hold the count, which is in units of @a N.
+
+    @a T is a "tag" type which is used only to distinguish the base metric for the scale. Scalar
+    types that have different tags are not interoperable although they can be converted manually by
+    converting to units and then explicitly constructing a new Scalar instance. This is by
+    design. This can be ignored - if not specified then it defaults to a "generic" tag. The type can
+    be (and usually is) defined in name only).
+
+    @note This is modeled somewhat on @c std::chrono and serves a similar function for different
+    and simpler cases (where the ratio is always an integer, never a fraction).
+
+    @see round_up
+    @see round_down
+ */
+template <intmax_t N, typename C = int, typename T = tag::generic> class Scalar
+{
+  typedef Scalar self; ///< Self reference type.
+
+public:
+  /// Scaling factor - make it external accessible.
+  constexpr static intmax_t SCALE = N;
+  typedef C Counter; ///< Type used to hold the count.
+  typedef T Tag;     ///< Make tag accessible.
+
+  static_assert(N > 0, "The scaling factor (1st template argument) must be a positive integer");
+  static_assert(std::is_integral<C>::value, "The counter type (2nd template argument) must be an integral type");
+
+  constexpr Scalar(); ///< Default contructor.
+  ///< Construct to have @a n scaled units.
+  explicit constexpr Scalar(Counter n);
+  /// Copy constructor.
+  constexpr Scalar(self const &that); /// Copy constructor.
+  /// Copy constructor for same scale.
+  template <typename I> constexpr Scalar(Scalar<N, I, T> const &that);
+  /// Direct conversion constructor.
+  /// @note Requires that @c S be an integer multiple of @c SCALE.
+  template <intmax_t S, typename I> constexpr Scalar(Scalar<S, I, T> const &that);
+  /// Conversion constructor.
+  constexpr Scalar(detail::scalar_round_up_t<N, C, T> const &that);
+  /// Conversion constructor.
+  constexpr Scalar(detail::scalar_round_down_t<N, C, T> const &that);
+  /// Conversion constructor.
+  template <typename I> constexpr Scalar(detail::scalar_unit_round_up_t<I> v);
+  /// Conversion constructor.
+  template <typename I> constexpr Scalar(detail::scalar_unit_round_down_t<I> v);
+
+  /// Assignment operator.
+  /// The value @a that is scaled appropriately.
+  /// @note Requires the scale of @a that be an integer multiple of the scale of @a this. If this isn't the case then
+  /// the @c round_up or @c round_down must be used to indicate the rounding direction.
+  template <intmax_t S, typename I> self &operator=(Scalar<S, I, T> const &that);
+  /// Assignment from same scale.
+  self &operator=(self const &that);
+  // Conversion assignments.
+  template <typename I> self &operator=(detail::scalar_unit_round_up_t<I> n);
+  template <typename I> self &operator=(detail::scalar_unit_round_down_t<I> n);
+  self &operator                      =(detail::scalar_round_up_t<N, C, T> v);
+  self &operator                      =(detail::scalar_round_down_t<N, C, T> v);
+
+  /// Direct assignment.
+  /// The count is set to @a n.
+  self &assign(Counter n);
+  /// The value @a that is scaled appropriately.
+  /// @note Requires the scale of @a that be an integer multiple of the scale of @a this. If this isn't the case then
+  /// the @c round_up or @c round_down must be used to indicate the rounding direction.
+  template <intmax_t S, typename I> self &assign(Scalar<S, I, T> const &that);
+  // Conversion assignments.
+  template <typename I> self &assign(detail::scalar_unit_round_up_t<I> n);
+  template <typename I> self &assign(detail::scalar_unit_round_down_t<I> n);
+  self &assign(detail::scalar_round_up_t<N, C, T> v);
+  self &assign(detail::scalar_round_down_t<N, C, T> v);
+
+  /// The number of scale units.
+  constexpr Counter count() const;
+  /// The scaled value.
+  constexpr intmax_t value() const;
+  /// User conversion to scaled value.
+  constexpr operator intmax_t() const;
+
+  /// Addition operator.
+  /// The value is scaled from @a that to @a this.
+  /// @note Requires the scale of @a that be an integer multiple of the scale of @a this. If this isn't the case then
+  /// the @c scale_up or @c scale_down casts must be used to indicate the rounding direction.
+  self &operator+=(self const &that);
+  template <intmax_t S, typename I> self &operator+=(Scalar<S, I, T> const &that);
+  template <typename I> self &operator+=(detail::scalar_unit_round_up_t<I> n);
+  template <typename I> self &operator+=(detail::scalar_unit_round_down_t<I> n);
+  self &operator+=(detail::scalar_round_up_t<N, C, T> v);
+  self &operator+=(detail::scalar_round_down_t<N, C, T> v);
+
+  /// Increment - increase count by 1.
+  self &operator++();
+  /// Increment - increase count by 1.
+  self operator++(int);
+  /// Decrement - decrease count by 1.
+  self &operator--();
+  /// Decrement - decrease count by 1.
+  self operator--(int);
+  /// Increment by @a n.
+  self &inc(Counter n);
+  /// Decrement by @a n.
+  self &dec(Counter n);
+
+  /// Subtraction operator.
+  /// The value is scaled from @a that to @a this.
+  /// @note Requires the scale of @a that be an integer multiple of the scale of @a this. If this isn't the case then
+  /// the @c scale_up or @c scale_down casts must be used to indicate the rounding direction.
+  self &operator-=(self const &that);
+  template <intmax_t S, typename I> self &operator-=(Scalar<S, I, T> const &that);
+  template <typename I> self &operator-=(detail::scalar_unit_round_up_t<I> n);
+  template <typename I> self &operator-=(detail::scalar_unit_round_down_t<I> n);
+  self &operator-=(detail::scalar_round_up_t<N, C, T> v);
+  self &operator-=(detail::scalar_round_down_t<N, C, T> v);
+
+  /// Multiplication - multiple the count by @a n.
+  self &operator*=(C n);
+
+  /// Division - divide (rounding down) the count by @a n.
+  self &operator/=(C n);
+
+  /// Utility overload of the function operator to create instances at the same scale.
+  self operator()(Counter n) const;
+
+  /// Return a value at the same scale with a count increased by @a n.
+  self plus(Counter n) const;
+
+  /// Return a value at the same scale with a count decreased by @a n.
+  self minus(Counter n) const;
+
+  /// Run time access to the scale (template arg @a N).
+  static constexpr intmax_t scale();
+
+protected:
+  Counter _n; ///< Number of scale units.
+};
+
+template <intmax_t N, typename C, typename T> constexpr Scalar<N, C, T>::Scalar() : _n() {}
+template <intmax_t N, typename C, typename T> constexpr Scalar<N, C, T>::Scalar(Counter n) : _n(n) {}
+template <intmax_t N, typename C, typename T> constexpr Scalar<N, C, T>::Scalar(self const &that) : _n(that._n) {}
+template <intmax_t N, typename C, typename T>
+template <typename I>
+constexpr Scalar<N, C, T>::Scalar(Scalar<N, I, T> const &that) : _n(static_cast<C>(that.count()))
+{
+}
+template <intmax_t N, typename C, typename T>
+template <intmax_t S, typename I>
+constexpr Scalar<N, C, T>::Scalar(Scalar<S, I, T> const &that) : _n(std::ratio<S, N>::num * that.count())
+{
+  static_assert(std::ratio<S, N>::den == 1,
+                "Construction not permitted - target scale is not an integral multiple of source scale.");
+}
+template <intmax_t N, typename C, typename T>
+constexpr Scalar<N, C, T>::Scalar(detail::scalar_round_up_t<N, C, T> const &v) : _n(v._n)
+{
+}
+template <intmax_t N, typename C, typename T>
+constexpr Scalar<N, C, T>::Scalar(detail::scalar_round_down_t<N, C, T> const &v) : _n(v._n)
+{
+}
+template <intmax_t N, typename C, typename T>
+template <typename I>
+constexpr Scalar<N, C, T>::Scalar(detail::scalar_unit_round_up_t<I> v) : _n(v.template scale<N, C>())
+{
+}
+template <intmax_t N, typename C, typename T>
+template <typename I>
+constexpr Scalar<N, C, T>::Scalar(detail::scalar_unit_round_down_t<I> v) : _n(v.template scale<N, C>())
+{
+}
+
+template <intmax_t N, typename C, typename T>
+constexpr auto
+Scalar<N, C, T>::count() const -> Counter
+{
+  return _n;
+}
+
+template <intmax_t N, typename C, typename T>
+constexpr intmax_t
+Scalar<N, C, T>::value() const
+{
+  return _n * SCALE;
+}
+
+template <intmax_t N, typename C, typename T> constexpr Scalar<N, C, T>::operator intmax_t() const
+{
+  return _n * SCALE;
+}
+
+template <intmax_t N, typename C, typename T>
+inline auto
+Scalar<N, C, T>::assign(Counter n) -> self &
+{
+  _n = n;
+  return *this;
+}
+
+template <intmax_t N, typename C, typename T>
+inline auto
+Scalar<N, C, T>::operator=(self const &that) -> self &
+{
+  _n = that._n;
+  return *this;
+}
+
+template <intmax_t N, typename C, typename T>
+inline auto
+Scalar<N, C, T>::operator=(detail::scalar_round_up_t<N, C, T> v) -> self &
+{
+  _n = v._n;
+  return *this;
+}
+template <intmax_t N, typename C, typename T>
+inline auto
+Scalar<N, C, T>::assign(detail::scalar_round_up_t<N, C, T> v) -> self &
+{
+  _n = v._n;
+  return *this;
+}
+template <intmax_t N, typename C, typename T>
+inline auto
+Scalar<N, C, T>::operator=(detail::scalar_round_down_t<N, C, T> v) -> self &
+{
+  _n = v._n;
+  return *this;
+}
+template <intmax_t N, typename C, typename T>
+inline auto
+Scalar<N, C, T>::assign(detail::scalar_round_down_t<N, C, T> v) -> self &
+{
+  _n = v._n;
+  return *this;
+}
+template <intmax_t N, typename C, typename T>
+template <typename I>
+inline auto
+Scalar<N, C, T>::operator=(detail::scalar_unit_round_up_t<I> v) -> self &
+{
+  _n = v.template scale<N, C>();
+  return *this;
+}
+template <intmax_t N, typename C, typename T>
+template <typename I>
+inline auto
+Scalar<N, C, T>::assign(detail::scalar_unit_round_up_t<I> v) -> self &
+{
+  _n = v.template scale<N, C>();
+  return *this;
+}
+template <intmax_t N, typename C, typename T>
+template <typename I>
+inline auto
+Scalar<N, C, T>::operator=(detail::scalar_unit_round_down_t<I> v) -> self &
+{
+  _n = v.template scale<N, C>();
+  return *this;
+}
+template <intmax_t N, typename C, typename T>
+template <typename I>
+inline auto
+Scalar<N, C, T>::assign(detail::scalar_unit_round_down_t<I> v) -> self &
+{
+  _n = v.template scale<N, C>();
+  return *this;
+}
+template <intmax_t N, typename C, typename T>
+template <intmax_t S, typename I>
+auto
+Scalar<N, C, T>::operator=(Scalar<S, I, T> const &that) -> self &
+{
+  typedef std::ratio<S, N> R;
+  static_assert(R::den == 1, "Assignment not permitted - target scale is not an integral multiple of source scale.");
+  _n = that.count() * R::num;
+  return *this;
+}
+template <intmax_t N, typename C, typename T>
+template <intmax_t S, typename I>
+auto
+Scalar<N, C, T>::assign(Scalar<S, I, T> const &that) -> self &
+{
+  typedef std::ratio<S, N> R;
+  static_assert(R::den == 1, "Assignment not permitted - target scale is not an integral multiple of source scale.");
+  _n = that.count() * R::num;
+  return *this;
+}
+
+template <intmax_t N, typename C, typename T>
+constexpr inline intmax_t
+Scalar<N, C, T>::scale()
+{
+  return SCALE;
+}
+
+// --- Compare operators
+// These optimize nicely because if R::num or R::den is 1 the compiler will drop it.
+
+template <intmax_t N, typename C1, intmax_t S, typename I, typename T>
+bool
+operator<(Scalar<N, C1, T> const &lhs, Scalar<S, I, T> const &rhs)
+{
+  typedef std::ratio<N, S> R;
+  return lhs.count() * R::num < rhs.count() * R::den;
+}
+
+template <intmax_t N, typename C1, intmax_t S, typename I, typename T>
+bool
+operator==(Scalar<N, C1, T> const &lhs, Scalar<S, I, T> const &rhs)
+{
+  typedef std::ratio<N, S> R;
+  return lhs.count() * R::num == rhs.count() * R::den;
+}
+
+template <intmax_t N, typename C1, intmax_t S, typename I, typename T>
+bool
+operator<=(Scalar<N, C1, T> const &lhs, Scalar<S, I, T> const &rhs)
+{
+  typedef std::ratio<N, S> R;
+  return lhs.count() * R::num <= rhs.count() * R::den;
+}
+
+// Derived compares.
+template <intmax_t N, typename C, intmax_t S, typename I, typename T>
+bool
+operator>(Scalar<N, C, T> const &lhs, Scalar<S, I, T> const &rhs)
+{
+  return rhs < lhs;
+}
+
+template <intmax_t N, typename C, intmax_t S, typename I, typename T>
+bool
+operator>=(Scalar<N, C, T> const &lhs, Scalar<S, I, T> const &rhs)
+{
+  return rhs <= lhs;
+}
+
+// Arithmetic operators
+template <intmax_t N, typename C, typename T>
+auto
+Scalar<N, C, T>::operator+=(self const &that) -> self &
+{
+  _n += that._n;
+  return *this;
+}
+
+template <intmax_t N, typename C, typename T>
+template <intmax_t S, typename I>
+auto
+Scalar<N, C, T>::operator+=(Scalar<S, I, T> const &that) -> self &
+{
+  typedef std::ratio<S, N> R;
+  static_assert(R::den == 1, "Addition not permitted - target scale is not an integral multiple of source scale.");
+  _n += that.count() * R::num;
+  return *this;
+}
+
+template <intmax_t N, typename C, typename T>
+template <typename I>
+auto
+Scalar<N, C, T>::operator+=(detail::scalar_unit_round_up_t<I> v) -> self &
+{
+  _n += v.template scale<N, C>();
+  return *this;
+}
+
+template <intmax_t N, typename C, typename T>
+template <typename I>
+auto
+Scalar<N, C, T>::operator+=(detail::scalar_unit_round_down_t<I> v) -> self &
+{
+  _n += v.template scale<N, C>();
+  return *this;
+}
+template <intmax_t N, typename C, typename T>
+auto
+Scalar<N, C, T>::operator+=(detail::scalar_round_up_t<N, C, T> v) -> self &
+{
+  _n += v._n;
+  return *this;
+}
+template <intmax_t N, typename C, typename T>
+auto
+Scalar<N, C, T>::operator+=(detail::scalar_round_down_t<N, C, T> v) -> self &
+{
+  _n += v._n;
+  return *this;
+}
+
+template <intmax_t N, typename C, intmax_t S, typename I, typename T>
+auto
+operator+(Scalar<N, C, T> lhs, Scalar<S, I, T> const &rhs) -> typename std::common_type<Scalar<N, C, T>, Scalar<S, I, T>>::type
+{
+  return typename std::common_type<Scalar<N, C, T>, Scalar<S, I, T>>::type(lhs) += rhs;
+}
+
+template <intmax_t N, typename C, typename T>
+Scalar<N, C, T>
+operator+(Scalar<N, C, T> const &lhs, Scalar<N, C, T> const &rhs)
+{
+  return Scalar<N, C, T>(lhs) += rhs;
+}
+
+template <intmax_t N, typename C, typename T, typename I>
+Scalar<N, C, T>
+operator+(detail::scalar_unit_round_up_t<I> lhs, Scalar<N, C, T> const &rhs)
+{
+  return Scalar<N, C, T>(rhs) += lhs;
+}
+
+template <intmax_t N, typename C, typename T, typename I>
+Scalar<N, C, T>
+operator+(Scalar<N, C, T> const &lhs, detail::scalar_unit_round_up_t<I> rhs)
+{
+  return Scalar<N, C, T>(lhs) += rhs;
+}
+
+template <intmax_t N, typename C, typename T, typename I>
+Scalar<N, C, T>
+operator+(detail::scalar_unit_round_down_t<I> lhs, Scalar<N, C, T> const &rhs)
+{
+  return Scalar<N, C, T>(rhs) += lhs;
+}
+template <intmax_t N, typename C, typename T, typename I>
+Scalar<N, C, T>
+operator+(Scalar<N, C, T> const &lhs, detail::scalar_unit_round_down_t<I> rhs)
+{
+  return Scalar<N, C, T>(lhs) += rhs;
+}
+template <intmax_t N, typename C, typename T>
+Scalar<N, C, T>
+operator+(detail::scalar_round_up_t<N, C, T> lhs, Scalar<N, C, T> const &rhs)
+{
+  return Scalar<N, C, T>(rhs) += lhs._n;
+}
+template <intmax_t N, typename C, typename T>
+Scalar<N, C, T>
+operator+(Scalar<N, C, T> const &lhs, detail::scalar_round_up_t<N, C, T> rhs)
+{
+  return Scalar<N, C, T>(lhs) += rhs._n;
+}
+template <intmax_t N, typename C, typename T>
+Scalar<N, C, T>
+operator+(detail::scalar_round_down_t<N, C, T> lhs, Scalar<N, C, T> const &rhs)
+{
+  return Scalar<N, C, T>(rhs) += lhs._n;
+}
+template <intmax_t N, typename C, typename T>
+Scalar<N, C, T>
+operator+(Scalar<N, C, T> const &lhs, detail::scalar_round_down_t<N, C, T> rhs)
+{
+  return Scalar<N, C, T>(lhs) += rhs._n;
+}
+
+template <intmax_t N, typename C, typename T>
+auto
+Scalar<N, C, T>::operator-=(self const &that) -> self &
+{
+  _n -= that._n;
+  return *this;
+}
+
+template <intmax_t N, typename C, typename T>
+template <intmax_t S, typename I>
+auto
+Scalar<N, C, T>::operator-=(Scalar<S, I, T> const &that) -> self &
+{
+  typedef std::ratio<S, N> R;
+  static_assert(R::den == 1, "Subtraction not permitted - target scale is not an integral multiple of source scale.");
+  _n -= that.count() * R::num;
+  return *this;
+}
+
+template <intmax_t N, typename C, typename T>
+template <typename I>
+auto
+Scalar<N, C, T>::operator-=(detail::scalar_unit_round_up_t<I> v) -> self &
+{
+  _n -= v.template scale<N, C>();
+  return *this;
+}
+template <intmax_t N, typename C, typename T>
+template <typename I>
+auto
+Scalar<N, C, T>::operator-=(detail::scalar_unit_round_down_t<I> v) -> self &
+{
+  _n -= v.template scale<N, C>();
+  return *this;
+}
+template <intmax_t N, typename C, typename T>
+auto
+Scalar<N, C, T>::operator-=(detail::scalar_round_up_t<N, C, T> v) -> self &
+{
+  _n -= v._n;
+  return *this;
+}
+template <intmax_t N, typename C, typename T>
+auto
+Scalar<N, C, T>::operator-=(detail::scalar_round_down_t<N, C, T> v) -> self &
+{
+  _n -= v._n;
+  return *this;
+}
+
+template <intmax_t N, typename C, intmax_t S, typename I, typename T>
+auto
+operator-(Scalar<N, C, T> lhs, Scalar<S, I, T> const &rhs) -> typename std::common_type<Scalar<N, C, T>, Scalar<S, I, T>>::type
+{
+  return typename std::common_type<Scalar<N, C, T>, Scalar<S, I, T>>::type(lhs) -= rhs;
+}
+
+template <intmax_t N, typename C, typename T>
+Scalar<N, C, T>
+operator-(Scalar<N, C, T> const &lhs, Scalar<N, C, T> const &rhs)
+{
+  return Scalar<N, C, T>(lhs) -= rhs;
+}
+
+template <intmax_t N, typename C, typename T, typename I>
+Scalar<N, C, T>
+operator-(detail::scalar_unit_round_up_t<I> lhs, Scalar<N, C, T> const &rhs)
+{
+  return Scalar<N, C, T>(lhs.template scale<N, C>()) -= rhs;
+}
+
+template <intmax_t N, typename C, typename T, typename I>
+Scalar<N, C, T>
+operator-(Scalar<N, C, T> const &lhs, detail::scalar_unit_round_up_t<I> rhs)
+{
+  return Scalar<N, C, T>(lhs) -= rhs;
+}
+
+template <intmax_t N, typename C, typename T, typename I>
+Scalar<N, C, T>
+operator-(detail::scalar_unit_round_down_t<I> lhs, Scalar<N, C, T> const &rhs)
+{
+  return Scalar<N, C, T>(lhs.template scale<N, C>()) -= rhs;
+}
+
+template <intmax_t N, typename C, typename T, typename I>
+Scalar<N, C, T>
+operator-(Scalar<N, C, T> const &lhs, detail::scalar_unit_round_down_t<I> rhs)
+{
+  return Scalar<N, C, T>(lhs) -= rhs;
+}
+
+template <intmax_t N, typename C, typename T>
+Scalar<N, C, T>
+operator-(detail::scalar_round_up_t<N, C, T> lhs, Scalar<N, C, T> const &rhs)
+{
+  return Scalar<N, C, T>(lhs._n) -= rhs;
+}
+
+template <intmax_t N, typename C, typename T>
+Scalar<N, C, T>
+operator-(Scalar<N, C, T> const &lhs, detail::scalar_round_up_t<N, C, T> rhs)
+{
+  return Scalar<N, C, T>(lhs) -= rhs._n;
+}
+
+template <intmax_t N, typename C, typename T>
+Scalar<N, C, T>
+operator-(detail::scalar_round_down_t<N, C, T> lhs, Scalar<N, C, T> const &rhs)
+{
+  return Scalar<N, C, T>(lhs._n) -= rhs;
+}
+
+template <intmax_t N, typename C, typename T>
+Scalar<N, C, T>
+operator-(Scalar<N, C, T> const &lhs, detail::scalar_round_down_t<N, C, T> rhs)
+{
+  return Scalar<N, C, T>(lhs) -= rhs._n;
+}
+
+template <intmax_t N, typename C, typename T>
+auto
+Scalar<N, C, T>::operator++() -> self &
+{
+  ++_n;
+  return *this;
+}
+
+template <intmax_t N, typename C, typename T>
+auto
+Scalar<N, C, T>::operator++(int) -> self
+{
+  self zret(*this);
+  ++_n;
+  return zret;
+}
+
+template <intmax_t N, typename C, typename T>
+auto
+Scalar<N, C, T>::operator--() -> self &
+{
+  --_n;
+  return *this;
+}
+
+template <intmax_t N, typename C, typename T>
+auto
+Scalar<N, C, T>::operator--(int) -> self
+{
+  self zret(*this);
+  --_n;
+  return zret;
+}
+
+template <intmax_t N, typename C, typename T>
+auto
+Scalar<N, C, T>::inc(Counter n) -> self &
+{
+  _n += n;
+  return *this;
+}
+
+template <intmax_t N, typename C, typename T>
+auto
+Scalar<N, C, T>::dec(Counter n) -> self &
+{
+  _n -= n;
+  return *this;
+}
+
+template <intmax_t N, typename C, typename T>
+auto
+Scalar<N, C, T>::operator*=(C n) -> self &
+{
+  _n *= n;
+  return *this;
+}
+
+template <intmax_t N, typename C, typename T> Scalar<N, C, T> operator*(Scalar<N, C, T> const &lhs, C n)
+{
+  return Scalar<N, C, T>(lhs) *= n;
+}
+template <intmax_t N, typename C, typename T> Scalar<N, C, T> operator*(C n, Scalar<N, C, T> const &rhs)
+{
+  return Scalar<N, C, T>(rhs) *= n;
+}
+template <intmax_t N, typename C, typename T> Scalar<N, C, T> operator*(Scalar<N, C, T> const &lhs, int n)
+{
+  return Scalar<N, C, T>(lhs) *= n;
+}
+template <intmax_t N, typename C, typename T> Scalar<N, C, T> operator*(int n, Scalar<N, C, T> const &rhs)
+{
+  return Scalar<N, C, T>(rhs) *= n;
+}
+template <intmax_t N> Scalar<N, int> operator*(Scalar<N, int> const &lhs, int n)
+{
+  return Scalar<N, int>(lhs) *= n;
+}
+template <intmax_t N> Scalar<N, int> operator*(int n, Scalar<N, int> const &rhs)
+{
+  return Scalar<N, int>(rhs) *= n;
+}
+
+template <intmax_t N, typename C, typename T>
+auto
+Scalar<N, C, T>::operator/=(C n) -> self &
+{
+  _n /= n;
+  return *this;
+}
+
+template <intmax_t N, typename C, intmax_t S, typename I, typename T>
+auto
+operator/(Scalar<N, C, T> lhs, Scalar<S, I, T> rhs) -> typename std::common_type<C, I>::type
+{
+  using R = std::ratio<N, S>;
+  return (lhs.count() * R::num) / (rhs.count() * R::den);
+}
+
+template <intmax_t N, typename C, typename T, typename I>
+Scalar<N, C, T>
+operator/(Scalar<N, C, T> lhs, I n)
+{
+  static_assert(std::is_integral<I>::value, "Scalar divsion only support integral types.");
+  return Scalar<N, C, T>(lhs) /= n;
+}
+
+template <intmax_t N, typename C, typename T>
+auto
+Scalar<N, C, T>::operator()(Counter n) const -> self
+{
+  return self{n};
+}
+
+template <intmax_t N, typename C, typename T>
+auto
+Scalar<N, C, T>::plus(Counter n) const -> self
+{
+  return {_n + n};
+}
+
+template <intmax_t N, typename C, typename T>
+auto
+Scalar<N, C, T>::minus(Counter n) const -> self
+{
+  return {_n - n};
+}
+
+namespace detail
+{
+  template <typename T>
+  auto
+  tag_label(std::ostream &, const meta::CaseTag<0> &) -> void
+  {
+  }
+
+  template <typename T>
+  auto
+  tag_label(std::ostream &w, const meta::CaseTag<1> &) -> decltype(T::label, meta::CaseVoidFunc())
+  {
+    w << T::label;
+  }
+
+  template <typename T>
+  inline std::ostream &
+  tag_label(std::ostream &w)
+  {
+    tag_label<T>(w, meta::CaseArg);
+    return w;
+  }
+} // namespace detail
+} // namespace swoc
+
+namespace std
+{
+/// Compute common type of two scalars.
+/// In `std` to overload the base definition. This yields a type that has the common type of the
+/// counter type and a scale that is the GCF of the input scales.
+template <intmax_t N, typename C, intmax_t S, typename I, typename T>
+struct common_type<swoc::Scalar<N, C, T>, swoc::Scalar<S, I, T>> {
+  using R    = std::ratio<N, S>;
+  using type = swoc::Scalar<N / R::num, typename common_type<C, I>::type, T>;
+};
+
+template <intmax_t N, typename C, typename T>
+ostream &
+operator<<(ostream &s, swoc::Scalar<N, C, T> const &x)
+{
+  s << x.value();
+  return swoc::detail::tag_label<T>(s);
+}
+
+} // namespace std

--- a/lib/swoc++/include/swoc/TextView.h
+++ b/lib/swoc++/include/swoc/TextView.h
@@ -1,0 +1,1428 @@
+/** @file
+
+   Class for handling "views" of text. Views presume the memory for the buffer is managed
+   elsewhere and allow efficient access to segments of the buffer without copies. Views are read
+   only as the view doesn't own the memory. Along with generic buffer methods are specialized
+   methods to support better string parsing, particularly token based parsing.
+
+   This class is based on @c std::string_view and is easily and cheaply converted to and from that class.
+
+
+   @section license License
+
+   Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+   agreements.  See the NOTICE file distributed with this work for additional information regarding
+   copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with the License.  You may obtain
+   a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software distributed under the License
+   is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+   or implied. See the License for the specific language governing permissions and limitations under
+   the License.
+ */
+
+#pragma once
+#include <bitset>
+#include <functional>
+#include <type_traits>
+#include <iosfwd>
+#include <memory.h>
+#include <algorithm>
+#include <string>
+#include <string_view>
+
+/// Compare the strings in two views.
+/// Return based on the first different character. If one argument is a prefix of the other, the prefix
+/// is considered the "smaller" value. The values are compared ignoring case.
+/// @note This works for @c swoc::TextView because it is a subclass of @c std::string_view.
+/// @return
+/// - -1 if @a lhs char is less than @a rhs char.
+/// -  1 if @a lhs char is greater than @a rhs char.
+/// -  0 if the views contain identical strings.
+int strcasecmp(const std::string_view &lhs, const std::string_view &rhs);
+
+namespace swoc
+{
+class TextView;
+/// Compare the memory in two views.
+/// Return based on the first different byte. If one argument is a prefix of the other, the prefix
+/// is considered the "smaller" value.
+/// @return
+/// - -1 if @a lhs byte is less than @a rhs byte.
+/// -  1 if @a lhs byte is greater than @a rhs byte.
+/// -  0 if the views contain identical memory.
+int memcmp(TextView const &lhs, TextView const &rhs);
+using ::memcmp; // Make this an overload, not an override.
+/// Compare the strings in two views.
+/// Return based on the first different character. If one argument is a prefix of the other, the prefix
+/// is considered the "smaller" value.
+/// @return
+/// - -1 if @a lhs char is less than @a rhs char.
+/// -  1 if @a lhs char is greater than @a rhs char.
+/// -  0 if the views contain identical strings.
+int strcmp(TextView const &lhs, TextView const &rhs);
+using ::strcmp; // Make this an overload, not an override.
+
+/** A read only view of contiguous piece of memory.
+
+    A @c TextView does not own the memory to which it refers, it is simply a view of part of some
+    (presumably) larger memory object. The purpose is to allow working in a read only way a specific
+    part of the memory. A classic example for ATS is working with HTTP header fields and values
+    which need to be accessed independently but preferably without copying. A @c TextView supports this style.
+
+    @c TextView is based on an earlier classes @c ConstBuffer, @c StringView and influenced by @c
+    Boost.string_ref and @c std::string_view. None of these were adequate for how use of @c
+    ConstBuffer evolved with regard to text based manipulations. @c TextView is a super set of @c
+    std::string_view (and therefore our local implementation, @std::string_view). It is designed to
+    be a drop in replacement.
+
+    @note To simplify the interface there is no constructor just a character pointer. Constructors require
+    either a literal string or an explicit length. This avoid ambiguities which are much more annoying that
+    explicitly calling @c strlen on a character pointer.
+ */
+class TextView : public std::string_view
+{
+  using self_type  = TextView;         ///< Self reference type.
+  using super_type = std::string_view; ///< Parent type.
+
+public:
+  /// Default constructor (empty buffer).
+  constexpr TextView();
+
+  /** Construct explicitly with a pointer and size.
+   */
+  constexpr TextView(const char *ptr, ///< Pointer to buffer.
+                     size_t n         ///< Size of buffer.
+  );
+
+  /** Construct explicitly with a pointer and size.
+      If @a n is negative it is treated as 0.
+      @internal Overload for convience, otherwise get "narrow conversion" errors.
+   */
+  constexpr TextView(const char *ptr, ///< Pointer to buffer.
+                     int n            ///< Size of buffer.
+  );
+
+  /** Construct from a half open range of two pointers.
+      @note The byte at @start is in the view but the byte at @a end is not.
+  */
+  constexpr TextView(const char *start, ///< First byte in the view.
+                     const char *end    ///< First byte not in the view.
+  );
+
+  /** Constructor from constant string.
+
+      Construct directly from an array of characters. All elements of the array are
+      included in the view unless the last element is nul, in which case it is elided.
+      If this is inapropriate then a constructor with an explicit size should be used.
+
+      @code
+        TextView a("A literal string");
+      @endcode
+   */
+  template <size_t N> constexpr TextView(const char (&s)[N]);
+
+  /** Construct from nullptr.
+      This implicitly makes the length 0.
+  */
+  constexpr TextView(std::nullptr_t);
+
+  /// Construct from a @c std::string_view.
+  constexpr TextView(super_type const &that);
+
+  /// Construct from @c std::string, referencing the entire string contents.
+  /// @internal Not all compilers make @c std::string methods called @c constexpr
+  TextView(std::string const &str);
+
+  /// Pointer to byte past the last byte in the view.
+  const char *data_end() const;
+
+  /// Assignment.
+  self_type &operator                    =(super_type const &that);
+  template <size_t N> self_type &operator=(const char (&s)[N]);
+  self_type &operator                    =(const std::string &s);
+
+  /// Explicitly set the view.
+  self_type &assign(char const *ptr, size_t n);
+
+  /// Explicitly set the view to the range [ @a b , @a e )
+  self_type &assign(char const *b, char const *e);
+
+  /// Explicitly set the view from a @c std::string
+  self_type &assign(std::string const &s);
+
+  /** Dereference operator.
+
+      @note This allows the view to be used as if it were a character iterator to a null terminated
+      string which is handy for several other STL interfaces.
+
+      @return The first byte in the view, or a nul character if the view is empty.
+  */
+  /// @return The first byte in the view.
+  char operator*() const;
+
+  /** Shift the view to discard the first byte.
+      @return @a this.
+  */
+  self_type &operator++();
+
+  /// Shift the view to discard the first byte.
+  /// @return A pre-increment copy of the view.
+  self_type operator++(int);
+
+  /** Shift the view to discard the leading @a n bytes.
+      Equivalent to @c std::string_view::remove_prefix
+      @return @a this
+  */
+  self_type &operator+=(size_t n);
+
+  /// Check for empty view.
+  /// @return @c true if the view has a zero pointer @b or size.
+  bool operator!() const;
+
+  /// Check for non-empty view.
+  /// @return @c true if the view refers to a non-empty range of bytes.
+  explicit operator bool() const;
+
+  /// Clear the view (become an empty view).
+  self_type &clear();
+
+  /// Get the offset of the first character for which @a pred is @c true.
+  template <typename F> size_t find_if(F const &pred) const;
+  /// Get the offset of the last character for which @a pred is @c true.
+  template <typename F> size_t rfind_if(F const &pred) const;
+
+  /** Remove bytes that match @a c from the start of the view.
+   */
+  self_type &ltrim(char c);
+
+  /** Remove bytes from the start of the view that are in @a delimiters.
+   */
+  self_type &ltrim(super_type const &delimiters);
+
+  /** Remove bytes from the start of the view that are in @a delimiters.
+      @internal This is needed to avoid collisions with the templated predicate style.
+      @return @c *this
+  */
+  self_type &ltrim(const char *delimiters);
+
+  /** Remove bytes from the start of the view for which @a pred is @c true.
+      @a pred must be a functor taking a @c char argument and returning @c bool.
+      @return @c *this
+  */
+  template <typename F> self_type &ltrim_if(F const &pred);
+
+  /** Remove bytes that match @a c from the end of the view.
+   */
+  self_type &rtrim(char c);
+
+  /** Remove bytes from the end of the view that are in @a delimiters.
+   */
+  self_type &rtrim(super_type const &delimiters);
+
+  /** Remove bytes from the end of the view that are in @a delimiters.
+      @internal This is needed to avoid collisions with the templated predicate style.
+      @return @c *this
+   */
+  self_type &rtrim(const char *delimiters);
+
+  /** Remove bytes from the start and end of the view for which @a pred is @c true.
+      @a pred must be a functor taking a @c char argument and returning @c bool.
+      @return @c *this
+  */
+  template <typename F> self_type &rtrim_if(F const &pred);
+
+  /** Remove bytes that match @a c from the end of the view.
+   */
+  self_type &trim(char c);
+
+  /** Remove bytes from the start and end of the view that are in @a delimiters.
+   */
+  self_type &trim(super_type const &delimiters);
+
+  /** Remove bytes from the start and end of the view that are in @a delimiters.
+      @internal This is needed to avoid collisions with the templated predicate style.
+      @return @c *this
+  */
+  self_type &trim(const char *delimiters);
+
+  /** Remove bytes from the start and end of the view for which @a pred is @c true.
+      @a pred must be a functor taking a @c char argument and returning @c bool.
+      @return @c *this
+  */
+  template <typename F> self_type &trim_if(F const &pred);
+
+  /** Get the prefix of size @a n.
+
+      If @a n is greater than the size the entire view is returned.
+
+      @return A view of the prefix.
+  */
+  self_type prefix(size_t n) const;
+  /// Convenience overload to avoid ambiguity for literal numbers.
+  self_type prefix(int n) const;
+  /** Get the prefix delimited by the first occurence of the character @a c.
+
+      If @a c is not found the entire view is returned.
+      The delimiter character is not included in the returned view.
+
+      @return A view of the prefix.
+  */
+  self_type prefix(char c) const;
+  /** Get the prefix delimited by the first occurence of a character in @a delimiters.
+
+      If no such character is found the entire view is returned.
+      The delimiter character is not included in the returned view.
+
+      @return A view of the prefix.
+  */
+  self_type prefix(super_type const &delimiters) const;
+  /** Get the prefix delimited by the first character for which @a pred is @c true.
+
+      If no such character is found the entire view is returned
+      The delimiter character is not included in the returned view.
+
+      @return A view of the prefix.
+  */
+  template <typename F> self_type prefix_if(F const &pred) const;
+
+  /// Overload to provide better return type.
+  self_type &remove_prefix(size_t n);
+
+  /// Remove the prefix delimited by the first occurence of @a c.
+  self_type &remove_prefix_at(char c);
+
+  /// Remove the prefix delimited by the first occurence of a character for which @a pred is @c true.
+  template <typename F> self_type &remove_prefix_if(F const &pred);
+
+  /** Split a prefix from the view on the character at offset @a n.
+
+      The view is split in to two parts and the byte at offset @a n is discarded. @a this retains
+      all data @b after offset @a n (equivalent to <tt>TextView::substr(n+1)</tt>). A new view
+      containing the initial bytes up to but not including the byte at offset @a n is returned,
+      (equivalent to <tt>TextView(0, n)</tt>).
+
+      This is convenient when tokenizing.
+
+      If @a n is larger than the size of the view no change is made and an empty buffer is
+      returned. Therefore this method is most useful when checking for the presence of the delimiter
+      is desirable, as the result of @c find methods can be passed directly to this method.
+
+      @note This method and its overloads always remove the delimiter character.
+
+      @code
+        void f(TextView& text) {
+          TextView token = text.get_prefix_at(text.find(delimiter));
+          if (token) { // ... process token }
+      @endcode
+
+      @return The prefix bounded at offset @a n or an empty view if @a n is more than the view
+      size.
+
+      @see take_prefix_at
+  */
+  self_type split_prefix_at(size_t n);
+
+  /// Convenience overload for literal numbers.
+  self_type split_prefix_at(int n);
+  /// Convenience overload, split on character.
+  self_type split_prefix_at(char c);
+  /// Convenience overload, split on delimiter set.
+  self_type split_prefix_at(super_type const &delimiters);
+  /// Convenience overload, split on predicate.
+  template <typename F> self_type split_prefix_if(F const &pred);
+
+  /** Split a prefix from the view on the character at offset @a n.
+
+      The view is split in to two parts and the byte at offset @a n is discarded. @a this retains
+      all data @b after offset @a n (equivalent to <tt>TextView::substr(n+1)</tt>). A new view
+      containing the initial bytes up to but not including the byte at offset @a n is returned,
+      (equivalent to <tt>TextView(0, n)</tt>).
+
+      This is convenient when tokenizing.
+
+      If @a n is larger than the view size then the entire view is removed and returned, leaving an
+      empty view. Therefore if @this is not empty, a non-empty view is always returned. This is desirable
+      if a non-empty return view is always wanted, regardless of whether a delimiter is present.
+
+      @note This method and its overloads always remove the delimiter character.
+
+      @code
+      TextView text;
+      while (text) {
+        TextView token = text.take_prefix_at(text.find(delimiter));
+        // token will always be non-empty because text was not empty.
+      }
+      @endcode
+
+      @return The prefix bounded at offset @a n or the entire view if @a n is more than the view
+      size.
+
+      @see split_prefix_at
+  */
+  self_type take_prefix_at(size_t n);
+
+  /// Convenience overload, extract on delimiter set.
+  self_type take_prefix_at(char c);
+  /// Convenience overload, extract on delimiter set.
+  self_type take_prefix_at(super_type const &delimiters);
+  /// Convenience overload, extract on predicate.
+  template <typename F> self_type take_prefix_if(F const &pred);
+
+  /** Get the last @a n characters of the view.
+
+      @return A buffer that contains @a n characters at the end of the view.
+  */
+  self_type suffix(size_t n) const;
+
+  /// Convenience overload to avoid ambiguity for literal numbers.
+  self_type suffix(int n) const;
+  /// Convenience overload for character.
+  self_type suffix(char c) const;
+  /// Convenience overload for delimiter set.
+  self_type suffix(super_type const &delimiters) const;
+  /// Convenience overload for delimiter set.
+  self_type suffix(const char *delimiters) const;
+  /// Get the prefix delimited by the first character for which @a pred is @c true.
+  template <typename F> self_type suffix_if(F const &pred) const;
+
+  /// Overload to provide better return type.
+  self_type &remove_suffix(size_t n);
+
+  /// Remove a suffix, delimited by the last occurence of @c c.
+  self_type &remove_suffix_at(char c);
+
+  /// Remove a suffix, delimited by the last occurence of a character for which @a pred is @c true.
+  template <typename F> self_type &remove_suffix_if(F const &f);
+
+  /** Split the view to get a suffix of size @a n.
+
+      The view is split in to two parts, a suffix of size @a n and a remainder which is the original
+      view less @a n + 1 characters at the end. That is, the character between the suffix and the
+      remainder is discarded. This is equivalent to <tt>TextView::suffix(this->size()-n)</tt> and
+      <tt>TextView::remove_suffix(this->size() - (n+1))</tt>.
+
+      If @a n is equal to or larger than the size of the view the entire view is removed as the
+      suffix.
+
+      @return The suffix of size @a n.
+
+      @see split_suffix_at
+  */
+  self_type split_suffix(size_t n);
+  /// Convenience overload for literal integers.
+  self_type split_suffix(int n);
+
+  /** Split the view on the character at offset @a n.
+
+      The view is split in to two parts and the byte at offset @a n is discarded. @a this retains
+      all data @b before offset @a n (equivalent to <tt>TextView::prefix(this->size()-n-1)</tt>). A
+      new view containing the trailing bytes after offset @a n is returned, (equivalent to
+      <tt>TextView::suffix(n))</tt>).
+
+      If @a n is larger than the size of the view no change is made and an empty buffer is
+      returned. Therefore this method is most useful when checking for the presence of the delimiter
+      is desirable, as the result of @c find methods can be passed directly to this method.
+
+      @note This method and its overloads always remove the delimiter character.
+
+      @return The suffix bounded at offset @a n or an empty view if @a n is more than the view
+      size.
+  */
+  self_type split_suffix_at(size_t n);
+
+  /// Convenience overload for literal integers.
+  self_type split_suffix_at(int n);
+  /// Convenience overload for character.
+  self_type split_suffix_at(char c);
+  /// Convenience overload for delimiter set.
+  self_type split_suffix_at(super_type const &delimiters);
+  /// Split the view on the last character for which @a pred is @c true.
+  template <typename F> self_type split_suffix_if(F const &pred);
+
+  /** Split the view on the character at offset @a n.
+
+      The view is split in to two parts and the byte at offset @a n is discarded. @a this retains
+      all data @b before offset @a n (equivalent to <tt>TextView::prefix(this->size()-n-1)</tt>). A
+      new view containing the trailing bytes after offset @a n is returned, (equivalent to
+      <tt>TextView::suffix(n))</tt>).
+
+      If @a n is larger than the view size then the entire view is removed and returned, leaving an
+      empty view. Therefore if @this is not empty, a non-empty view is always returned. This is desirable
+      if a non-empty return view is always wanted, regardless of whether a delimiter is present.
+
+      @note This method and its overloads always remove the delimiter character.
+
+      @return The suffix bounded at offset @a n or the entire view if @a n is more than the view
+      size.
+  */
+  self_type take_suffix_at(size_t n);
+
+  /// Convenience overload for literal integers.
+  self_type take_suffix_at(int n);
+  /// Convenience overload for character.
+  self_type take_suffix_at(char c);
+  /// Convenience overload for delimiter set.
+  self_type take_suffix_at(super_type const &delimiters);
+  /// Split the view on the last character for which @a pred is @c true.
+  template <typename F> self_type take_suffix_if(F const &pred);
+
+  /** Prefix check.
+      @return @c true if @a this is a prefix of @a that.
+  */
+  bool isPrefixOf(super_type const &that) const;
+
+  /** Case ignoring prefix check.
+      @return @c true if @a this is a prefix of @a that, ignoring case.
+  */
+  bool isNoCasePrefixOf(super_type const &that) const;
+
+  // Functors for using this class in STL containers.
+  /// Ordering functor, lexicographic comparison.
+  struct LessThan {
+    bool
+    operator()(self_type const &lhs, self_type const &rhs)
+    {
+      return -1 == strcmp(lhs, rhs);
+    }
+  };
+  /// Ordering functor, case ignoring lexicographic comparison.
+  struct LessThanNoCase {
+    bool
+    operator()(self_type const &lhs, self_type const &rhs)
+    {
+      return -1 == strcasecmp(lhs, rhs);
+    }
+  };
+
+  /// Specialized stream operator implementation.
+  /// @note Use the standard stream operator unless there is a specific need for this, which is unlikely.
+  /// @return The stream @a os.
+  /// @internal Needed because @c std::ostream::write must be used and
+  /// so alignment / fill have to be explicitly handled.
+  template <typename Stream> Stream &stream_write(Stream &os, const TextView &b) const;
+
+protected:
+  /// Faster find on a delimiter set, taking advantage of supporting only ASCII.
+  size_t search(super_type const &delimiters) const;
+  /// Faster reverse find on a delimiter set, taking advantage of supporting only ASCII.
+  size_t rsearch(super_type const &delimiters) const;
+
+  /// Initialize a bit mask to mark which characters are in this view.
+  static void init_delimiter_set(super_type const &delimiters, std::bitset<256> &set);
+};
+
+// Internal character conversion table.
+// Converts a character to the numeric digit value, or negative if the character is not a valid digit.
+extern const int8_t svtoi_convert[256];
+;
+
+/** Convert the text in @c TextView @a src to a numeric value.
+
+    If @a parsed is non-null then the part of the string actually parsed is placed there.
+    @a base sets the conversion base. This defaults to 10 with two special cases:
+
+    - If the number starts with a literal '0' then it is treated as base 8.
+    - If the number starts with the literal characters '0x' or '0X' then it is treated as base 16.
+*/
+intmax_t svtoi(TextView src, TextView *parsed = nullptr, int base = 0);
+
+/** Convert the text in @c src to an unsigned numeric value.
+ *
+ * @tparam N The radix (must be  1..36)
+ * @param src The source text. Updated during parsing.
+ * @return The converted numeric value.
+ *
+ * This is a specialized function useful only where conversion performance is critical. It is used
+ * inside @c svtoi for the common cases of 8, 10, and 16, therefore normally this isn't much more
+ * performant in those cases than just @c svtoi. Because of this only positive values are parsed.
+ * If determining the radix from the text or signed value parsing is needed, used @c svtoi.
+ *
+ * @a src is updated in place to indicate what characters were parsed. Parsing stops on the first
+ * invalid digit, so any leading non-digit characters (e.g. whitespace) must already be removed.
+ */
+template <uintmax_t N>
+uintmax_t
+svto_radix(swoc::TextView &src)
+{
+  static_assert(0 < N && N <= 36, "Radix must be in the range 1..36");
+  uintmax_t zret{0};
+  uintmax_t v;
+  while (src.size() && (0 <= (v = swoc::svtoi_convert[static_cast<unsigned char>(*src)])) && v < N) {
+    zret *= N;
+    zret += v;
+    ++src;
+  }
+  return zret;
+};
+
+// ----------------------------------------------------------
+// Inline implementations.
+
+// === TextView Implementation ===
+inline constexpr TextView::TextView() {}
+inline constexpr TextView::TextView(const char *ptr, size_t n) : super_type(ptr, n) {}
+inline constexpr TextView::TextView(const char *ptr, int n) : super_type(ptr, n < 0 ? 0 : n) {}
+inline constexpr TextView::TextView(const char *start, const char *end) : super_type(start, end - start) {}
+inline constexpr TextView::TextView(std::nullptr_t) : super_type(nullptr, 0) {}
+inline TextView::TextView(std::string const &str) : super_type(str) {}
+inline constexpr TextView::TextView(super_type const &that) : super_type(that) {}
+template <size_t N> constexpr TextView::TextView(const char (&s)[N]) : super_type(s, s[N - 1] ? N : N - 1) {}
+
+inline void
+TextView::init_delimiter_set(super_type const &delimiters, std::bitset<256> &set)
+{
+  set.reset();
+  for (char c : delimiters)
+    set[static_cast<uint8_t>(c)] = true;
+}
+
+inline const char *
+TextView::data_end() const
+{
+  return this->data() + this->size();
+}
+
+inline TextView &
+TextView::clear()
+{
+  new (this) self_type();
+  return *this;
+}
+
+inline char TextView::operator*() const
+{
+  return this->empty() ? 0 : *(this->data());
+}
+
+inline bool TextView::operator!() const
+{
+  return this->empty();
+}
+
+inline TextView::operator bool() const
+{
+  return !this->empty();
+}
+
+inline TextView &
+TextView::operator++()
+{
+  this->remove_prefix(1);
+  return *this;
+}
+
+inline TextView
+TextView::operator++(int)
+{
+  self_type zret{*this};
+  this->remove_prefix(1);
+  return zret;
+}
+
+inline TextView &
+TextView::operator+=(size_t n)
+{
+  this->remove_prefix(n);
+  return *this;
+}
+
+template <size_t N>
+inline TextView &
+TextView::operator=(const char (&s)[N])
+{
+  return *this = self_type{s, s[N - 1] ? N : N - 1};
+}
+
+inline TextView &
+TextView::operator=(super_type const &that)
+{
+  this->super_type::operator=(that);
+  return *this;
+}
+
+inline TextView &
+TextView::operator=(const std::string &s)
+{
+  this->super_type::operator=(s);
+  return *this;
+}
+
+inline TextView &
+TextView::assign(const std::string &s)
+{
+  *this = super_type(s);
+  return *this;
+}
+
+inline TextView &
+TextView::assign(char const *ptr, size_t n)
+{
+  *this = super_type(ptr, n);
+  return *this;
+}
+
+inline TextView &
+TextView::assign(char const *b, char const *e)
+{
+  *this = super_type(b, e - b);
+  return *this;
+}
+
+inline size_t
+TextView::search(super_type const &delimiters) const
+{
+  std::bitset<256> valid;
+  this->init_delimiter_set(delimiters, valid);
+
+  for (const char *spot = this->data(), *limit = this->data_end(); spot < limit; ++spot)
+    if (valid[static_cast<uint8_t>(*spot)])
+      return spot - this->data();
+  return npos;
+}
+
+inline size_t
+TextView::rsearch(super_type const &delimiters) const
+{
+  std::bitset<256> valid;
+  this->init_delimiter_set(delimiters, valid);
+
+  for (const char *spot = this->data_end(), *limit = this->data(); spot > limit;)
+    if (valid[static_cast<uint8_t>(*--spot)])
+      return spot - this->data();
+  return npos;
+}
+
+inline TextView
+TextView::prefix(size_t n) const
+{
+  return self_type(this->data(), std::min(n, this->size()));
+}
+
+inline TextView
+TextView::prefix(int n) const
+{
+  return this->prefix(static_cast<size_t>(n));
+}
+
+inline TextView
+TextView::prefix(char c) const
+{
+  return this->prefix(this->find(c));
+}
+
+inline TextView
+TextView::prefix(super_type const &delimiters) const
+{
+  return this->prefix(this->search(delimiters));
+}
+
+template <typename F>
+inline TextView
+TextView::prefix_if(F const &pred) const
+{
+  return this->prefix(this->find_if(pred));
+}
+
+inline TextView &
+TextView::remove_prefix(size_t n)
+{
+  if (n > this->size()) {
+    this->clear();
+  } else {
+    this->super_type::remove_prefix(n);
+  }
+  return *this;
+}
+
+inline TextView &
+TextView::remove_prefix_at(char c)
+{
+  auto n = this->find(c);
+  if (n == npos) {
+    this->clear();
+  } else {
+    this->super_type::remove_prefix(n + 1);
+  }
+  return *this;
+}
+
+template <typename F>
+TextView &
+TextView::remove_prefix_if(F const &pred)
+{
+  auto n = this->find_if(pred);
+  if (n == npos) {
+    this->clear();
+  } else {
+    this->super_type::remove_prefix(n + 1);
+  }
+  return *this;
+}
+
+inline TextView
+TextView::split_prefix_at(size_t n)
+{
+  self_type zret; // default to empty return.
+  if (n < this->size()) {
+    zret = this->prefix(n);
+    this->remove_prefix(std::min(n + 1, this->size()));
+  }
+  return zret;
+}
+
+inline TextView
+TextView::split_prefix_at(int n)
+{
+  return this->split_prefix_at(static_cast<size_t>(n));
+}
+
+inline TextView
+TextView::split_prefix_at(char c)
+{
+  return this->split_prefix_at(this->find(c));
+}
+
+inline TextView
+TextView::split_prefix_at(super_type const &delimiters)
+{
+  return this->split_prefix_at(this->search(delimiters));
+}
+
+template <typename F>
+inline TextView
+TextView::split_prefix_if(F const &pred)
+{
+  return this->split_prefix_at(this->find_if(pred));
+}
+
+inline TextView
+TextView::take_prefix_at(size_t n)
+{
+  n              = std::min(n, this->size());
+  self_type zret = this->prefix(n);
+  this->remove_prefix(std::min(n + 1, this->size()));
+  return zret;
+}
+
+inline TextView
+TextView::take_prefix_at(char c)
+{
+  return this->take_prefix_at(this->find(c));
+}
+
+inline TextView
+TextView::take_prefix_at(super_type const &delimiters)
+{
+  return this->take_prefix_at(this->search(delimiters));
+}
+
+template <typename F>
+inline TextView
+TextView::take_prefix_if(F const &pred)
+{
+  return this->take_prefix_at(this->find_if(pred));
+}
+
+inline TextView
+TextView::suffix(size_t n) const
+{
+  n = std::min(n, this->size());
+  return self_type(this->data_end() - n, n);
+}
+
+inline TextView
+TextView::suffix(int n) const
+{
+  return this->suffix(static_cast<size_t>(n));
+}
+
+inline TextView
+TextView::suffix(char c) const
+{
+  return this->suffix((this->size() - std::min(this->size(), this->rfind(c))) - 1);
+}
+
+inline TextView
+TextView::suffix(super_type const &delimiters) const
+{
+  return this->suffix((this->size() - std::min(this->size(), this->rsearch(delimiters))) - 1);
+}
+
+template <typename F>
+inline TextView
+TextView::suffix_if(F const &pred) const
+{
+  return this->suffix((this->size() - std::min(this->size(), this->rfind_if(pred))) - 1);
+}
+
+inline TextView &
+TextView::remove_suffix_at(char c)
+{
+  auto n = this->rfind(c);
+  if (n == npos) {
+    this->clear();
+  } else {
+    this->remove_suffix(this->size() - n);
+  }
+  return *this;
+}
+
+template <typename F>
+TextView &
+TextView::remove_suffix_if(F const &pred)
+{
+  auto n = this->rfind_if(pred);
+  if (n == npos) {
+    this->clear();
+  } else {
+    this->remove_suffix(this->size() - n);
+  }
+  return *this;
+}
+
+inline auto
+TextView::remove_suffix(size_t n) -> self_type &
+{
+  if (n > this->size()) {
+    this->clear();
+  } else {
+    this->super_type::remove_suffix(n);
+  }
+  return *this;
+}
+
+inline TextView
+TextView::split_suffix(size_t n)
+{
+  self_type zret;
+  n    = std::min(n, this->size());
+  zret = this->suffix(n);
+  this->remove_suffix(n + 1); // haha, saved by integer overflow!
+  return zret;
+}
+
+inline TextView
+TextView::split_suffix(int n)
+{
+  return this->split_suffix(static_cast<size_t>(n));
+}
+
+inline TextView
+TextView::split_suffix_at(size_t n)
+{
+  self_type zret;
+  if (n < this->size()) {
+    n    = this->size() - n;
+    zret = this->suffix(n - 1);
+    this->remove_suffix(n);
+  }
+  return zret;
+}
+
+inline TextView
+TextView::split_suffix_at(int n)
+{
+  return this->split_suffix_at(static_cast<size_t>(n));
+}
+
+inline TextView
+TextView::split_suffix_at(char c)
+{
+  return this->split_suffix_at(this->rfind(c));
+}
+
+inline TextView
+TextView::split_suffix_at(super_type const &delimiters)
+{
+  return this->split_suffix_at(this->rsearch(delimiters));
+}
+
+template <typename F>
+inline TextView
+TextView::split_suffix_if(F const &pred)
+{
+  return this->split_suffix_at(this->rfind_if(pred));
+}
+
+inline TextView
+TextView::take_suffix_at(size_t n)
+{
+  self_type zret{*this};
+  *this = zret.split_prefix_at(n);
+  return zret;
+}
+
+inline TextView
+TextView::take_suffix_at(int n)
+{
+  return this->take_suffix_at(static_cast<size_t>(n));
+}
+
+inline TextView
+TextView::take_suffix_at(char c)
+{
+  return this->take_suffix_at(this->rfind(c));
+}
+
+inline TextView
+TextView::take_suffix_at(super_type const &delimiters)
+{
+  return this->take_suffix_at(this->rsearch(delimiters));
+}
+
+template <typename F>
+inline TextView
+TextView::take_suffix_if(F const &pred)
+{
+  return this->take_suffix_at(this->rfind_if(pred));
+}
+
+template <typename F>
+inline size_t
+TextView::find_if(F const &pred) const
+{
+  for (const char *spot = this->data(), *limit = this->data_end(); spot < limit; ++spot)
+    if (pred(*spot))
+      return spot - this->data();
+  return npos;
+}
+
+template <typename F>
+inline size_t
+TextView::rfind_if(F const &pred) const
+{
+  for (const char *spot = this->data_end(), *limit = this->data(); spot > limit;)
+    if (pred(*--spot))
+      return spot - this->data();
+  return npos;
+}
+
+inline TextView &
+TextView::ltrim(char c)
+{
+  this->remove_prefix(this->find_first_not_of(c));
+  return *this;
+}
+
+inline TextView &
+TextView::rtrim(char c)
+{
+  auto n = this->find_last_not_of(c);
+  this->remove_suffix(this->size() - (n == npos ? 0 : n + 1));
+  return *this;
+}
+
+inline TextView &
+TextView::trim(char c)
+{
+  return this->ltrim(c).rtrim(c);
+}
+
+inline TextView &
+TextView::ltrim(super_type const &delimiters)
+{
+  std::bitset<256> valid;
+  this->init_delimiter_set(delimiters, valid);
+  const char *spot;
+  const char *limit;
+
+  for (spot = this->data(), limit = this->data_end(); spot < limit && valid[static_cast<uint8_t>(*spot)]; ++spot)
+    ;
+  this->remove_prefix(spot - this->data());
+
+  return *this;
+}
+
+inline TextView &
+TextView::ltrim(const char *delimiters)
+{
+  return this->ltrim(std::string_view(delimiters));
+}
+
+inline TextView &
+TextView::rtrim(super_type const &delimiters)
+{
+  std::bitset<256> valid;
+  this->init_delimiter_set(delimiters, valid);
+  const char *spot  = this->data_end();
+  const char *limit = this->data();
+
+  while (limit < spot && valid[static_cast<uint8_t>(*--spot)])
+    ;
+
+  this->remove_suffix(this->data_end() - (spot + 1));
+  return *this;
+}
+
+inline TextView &
+TextView::trim(super_type const &delimiters)
+{
+  std::bitset<256> valid;
+  this->init_delimiter_set(delimiters, valid);
+  const char *spot;
+  const char *limit;
+
+  // Do this explicitly, so we don't have to initialize the character set twice.
+  for (spot = this->data(), limit = this->data_end(); spot < limit && valid[static_cast<uint8_t>(*spot)]; ++spot)
+    ;
+  this->remove_prefix(spot - this->data());
+
+  for (spot = this->data_end(), limit = this->data(); limit < spot && valid[static_cast<uint8_t>(*--spot)];)
+    ;
+  this->remove_suffix(this->data_end() - (spot + 1));
+
+  return *this;
+}
+
+inline TextView &
+TextView::trim(const char *delimiters)
+{
+  return this->trim(std::string_view(delimiters));
+}
+
+template <typename F>
+inline TextView &
+TextView::ltrim_if(F const &pred)
+{
+  const char *spot;
+  const char *limit;
+  for (spot = this->data(), limit = this->data_end(); spot < limit && pred(*spot); ++spot)
+    ;
+  this->remove_prefix(spot - this->data());
+  return *this;
+}
+
+template <typename F>
+inline TextView &
+TextView::rtrim_if(F const &pred)
+{
+  const char *spot;
+  const char *limit;
+  for (spot = this->data_end(), limit = this->data(); limit < spot && pred(*--spot);)
+    ;
+  this->remove_suffix(this->data_end() - (spot + 1));
+  return *this;
+}
+
+template <typename F>
+inline TextView &
+TextView::trim_if(F const &pred)
+{
+  return this->ltrim_if(pred).rtrim_if(pred);
+}
+
+inline bool
+TextView::isPrefixOf(super_type const &that) const
+{
+  return this->size() <= that.size() && 0 == memcmp(this->data(), that.data(), this->size());
+}
+
+inline bool
+TextView::isNoCasePrefixOf(super_type const &that) const
+{
+  return this->size() <= that.size() && 0 == strncasecmp(this->data(), that.data(), this->size());
+}
+
+inline int
+strcmp(TextView const &lhs, TextView const &rhs)
+{
+  return memcmp(lhs, rhs);
+}
+
+template <typename Stream>
+Stream &
+TextView::stream_write(Stream &os, const TextView &b) const
+{
+  // Local function, avoids extra template work.
+  static const auto stream_fill = [](Stream &os, size_t n) -> Stream & {
+    static constexpr size_t pad_size = 8;
+    typename Stream::char_type padding[pad_size];
+
+    std::fill_n(padding, pad_size, os.fill());
+    for (; n >= pad_size && os.good(); n -= pad_size)
+      os.write(padding, pad_size);
+    if (n > 0 && os.good())
+      os.write(padding, n);
+    return os;
+  };
+
+  const std::size_t w = os.width();
+  if (w <= b.size()) {
+    os.write(b.data(), b.size());
+  } else {
+    const std::size_t pad_size = w - b.size();
+    const bool align_left      = (os.flags() & Stream::adjustfield) == Stream::left;
+    if (!align_left && os.good())
+      stream_fill(os, pad_size);
+    if (os.good())
+      os.write(b.data(), b.size());
+    if (align_left && os.good())
+      stream_fill(os, pad_size);
+  }
+  return os;
+}
+
+// Provide an instantiation for @c std::ostream as it's likely this is the only one ever used.
+extern template std::ostream &TextView::stream_write(std::ostream &, const TextView &) const;
+
+/** A transform view.
+ *
+ * @tparam X Transform functor type.
+ * @tparam V Source view type.
+ *
+ * A transform view acts like a view on the original source view @a V with each element transformed by
+ * @a X.
+ *
+ * This is used most commonly with @c std::string_view. For example, if the goal is to handle a
+ * piece of text as if it were lower case without changing the actual text, the following would
+ * make that possible.
+ * @code
+ * std:::string_view source; // original text.
+ * TransformView<int (*)(int) noexcept, std::string_view> xv(&tolower, source);
+ * @endcode
+ *
+ * To avoid having to figure out the exact signature of the transform, the convenience function
+ * @c transform_view_of is provide.
+ * @code
+ * std::string_view source; // original text.
+ * auto xv = transform_view_of(&tolower, source);
+ * @endcode
+ */
+template <typename X, typename V> class TransformView
+{
+  using self_type = TransformView; ///< Self reference type.
+  using iter      = decltype(static_cast<V *>(nullptr)->begin());
+
+public:
+  using transform_type    = X; ///< Export transform functor type.
+  using source_view_type  = V; ///< Export source view type.
+  using source_value_type = decltype(**static_cast<iter *>(nullptr));
+  /// Result type of calling the transform on an element of the source view.
+  using value_type = decltype(
+    (*static_cast<transform_type *>(nullptr))(*static_cast<typename std::remove_reference<source_value_type>::type *>(nullptr)));
+
+  /** Construct a transform view using transform @a xf on source view @a v.
+   *
+   * @param xf Transform instance.
+   * @param v Source view.
+   */
+  TransformView(transform_type &&xf, source_view_type const &v);
+
+  /** Construct a transform view using transform @a xf on source view @a v.
+   *
+   * @param xf Transform instance.
+   * @param v Source view.
+   */
+  TransformView(transform_type const &xf, source_view_type const &v);
+
+  /// Copy constructor.
+  TransformView(self_type const &that) = default;
+  /// Move constructor.
+  TransformView(self_type &&that) = default;
+
+  /// Copy assignment.
+  self_type &operator=(self_type const &that) = default;
+  /// Move assignment.
+  self_type &operator=(self_type &&that) = default;
+
+  /// Equality.
+  bool operator==(self_type const &that) const;
+  /// Inequality.
+  bool operator!=(self_type const &that) const;
+
+  /// Get the current element.
+  value_type operator*() const;
+  /// Move to next element.
+  self_type &operator++();
+  /// Move to next element.
+  self_type operator++(int);
+
+  /// Check if view is empty.
+  bool empty() const;
+  /// Check if bool is not empty.
+  explicit operator bool() const;
+
+protected:
+  transform_type _xf;
+  iter _spot;
+  iter _limit;
+};
+
+template <typename X, typename V>
+TransformView<X, V>::TransformView(transform_type &&xf, source_view_type const &v) : _xf(xf), _spot(v.begin()), _limit(v.end())
+{
+}
+
+template <typename X, typename V>
+TransformView<X, V>::TransformView(transform_type const &xf, source_view_type const &v) : _xf(xf), _spot(v.begin()), _limit(v.end())
+{
+}
+
+template <typename X, typename V> auto TransformView<X, V>::operator*() const -> value_type
+{
+  return _xf(*_spot);
+}
+
+template <typename X, typename V>
+auto
+TransformView<X, V>::operator++() -> self_type &
+{
+  ++_spot;
+  return *this;
+}
+
+template <typename X, typename V>
+auto
+TransformView<X, V>::operator++(int) -> self_type
+{
+  self_type zret{*this};
+  ++_spot;
+  return zret;
+}
+
+template <typename X, typename V>
+bool
+TransformView<X, V>::empty() const
+{
+  return _spot == _limit;
+}
+
+template <typename X, typename V> TransformView<X, V>::operator bool() const
+{
+  return _spot != _limit;
+}
+
+template <typename X, typename V>
+bool
+TransformView<X, V>::operator==(self_type const &that) const
+{
+  return _spot == that._spot && _limit == that._limit;
+}
+
+template <typename X, typename V>
+bool
+TransformView<X, V>::operator!=(self_type const &that) const
+{
+  return _spot != that._spot || _limit != that._limit;
+}
+
+template <typename X, typename V>
+TransformView<X, V>
+transform_view_of(X const &xf, V const &v)
+{
+  return TransformView<X, V>(xf, v);
+}
+
+// Specialization for identity transform.
+template <typename V> class TransformView<void, V>
+{
+  using self_type = TransformView; ///< Self reference type.
+  using iter      = decltype(static_cast<V *>(nullptr)->begin());
+
+public:
+  using source_view_type  = V; ///< Export source view type.
+  using source_value_type = decltype(**static_cast<iter *>(nullptr));
+  /// Result type of calling the transform on an element of the source view.
+  using value_type = source_value_type;
+
+  /** Construct identity transform view from @a v.
+   *
+   * @param v Source view.
+   */
+  TransformView(source_view_type const &v) : _spot(v.begin()), _limit(v.end()) {}
+
+  /// Copy constructor.
+  TransformView(self_type const &that) = default;
+  /// Move constructor.
+  TransformView(self_type &&that) = default;
+
+  /// Copy assignment.
+  self_type &operator=(self_type const &that) = default;
+  /// Move assignment.
+  self_type &operator=(self_type &&that) = default;
+
+  /// Equality.
+  bool operator==(self_type const &that) const;
+  /// Inequality.
+  bool operator!=(self_type const &that) const;
+
+  /// Get the current element.
+  value_type operator*() const { return *_spot; }
+  /// Move to next element.
+  self_type &
+  operator++()
+  {
+    ++_spot;
+    return *this;
+  }
+  /// Move to next element.
+  self_type
+  operator++(int)
+  {
+    auto zret{*this};
+    ++*this;
+    return zret;
+  }
+
+  /// Check if view is empty.
+  bool
+  empty() const
+  {
+    return _spot == _limit;
+  }
+  /// Check if bool is not empty.
+  explicit operator bool() const { return _spot != _limit; }
+
+protected:
+  iter _spot;
+  iter _limit;
+};
+
+template <typename V>
+TransformView<void, V>
+transform_view_of(V const &v)
+{
+  return TransformView<void, V>(v);
+}
+
+}; // namespace swoc
+
+namespace std
+{
+ostream &operator<<(ostream &os, const swoc::TextView &b);
+
+/* For interaction with specific STL interfaces, primarily std::filesystem. Along with the
+ * dereference operator, this enables a @c TextView to act as a character iterator to a C string
+ * even if the internal view is not nul terminated.
+ * @note Putting these directly in the class doesn't seem to work.
+ */
+template <> struct iterator_traits<swoc::TextView> {
+  using value_type        = char;
+  using pointer_type      = const char *;
+  using reference_type    = const char &;
+  using difference_type   = ssize_t;
+  using iterator_category = forward_iterator_tag;
+};
+
+template <typename X, typename V> struct iterator_traits<swoc::TransformView<X, V>> {
+  using value_type        = typename swoc::TransformView<X, V>::value_type;
+  using pointer_type      = const value_type *;
+  using reference_type    = const value_type &;
+  using difference_type   = ssize_t;
+  using iterator_category = forward_iterator_tag;
+};
+} // namespace std
+
+// @c constexpr literal constructor for @c std::string_view
+// For unknown reasons, this enables creating @c constexpr constructs using @c std::string_view while the standard
+// one (""sv) does not.
+// I couldn't think of any better place to put this, so it's here. At least @c TextView is strongly related
+// to @c std::string_view.
+constexpr std::string_view operator"" _sv(const char *s, size_t n)
+{
+  return {s, n};
+}

--- a/lib/swoc++/include/swoc/bwf_base.h
+++ b/lib/swoc++/include/swoc/bwf_base.h
@@ -1,0 +1,975 @@
+/** @file
+
+    Basic formatting support for @c BufferWriter.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements.  See the NOTICE file distributed with this work for additional information regarding
+    copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with the License.  You may
+    obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdlib>
+#include <utility>
+#include <cstring>
+#include <vector>
+#include <unordered_map>
+#include <string>
+#include <iosfwd>
+#include <string_view>
+#include <tuple>
+#include <any>
+
+#include "swoc/TextView.h"
+#include "swoc/MemSpan.h"
+#include "swoc/MemArena.h"
+#include "swoc/BufferWriter.h"
+#include "swoc/swoc_meta.h"
+
+namespace swoc
+{
+namespace bwf
+{
+  /** Parsed version of a format specifier.
+   *
+   * Literals are represented as an instance of this class, with the type set to
+   * @c LITERAL_TYPE and the literal text in the @a _ext field.
+   */
+  struct Spec {
+    using self_type = Spec; ///< Self reference type.
+
+    static constexpr char DEFAULT_TYPE = 'g'; ///< Default format type.
+    static constexpr char INVALID_TYPE = 0;   ///< Type for missing or invalid specifier.
+    static constexpr char LITERAL_TYPE = '"'; ///< Internal type to mark a literal.
+    static constexpr char CAPTURE_TYPE = 1;   ///< Internal type to mark a capture.
+
+    static constexpr char SIGN_ALWAYS = '+'; ///< Always print a sign character.
+    static constexpr char SIGN_NEVER  = ' '; ///< Never print a sign character.
+    static constexpr char SIGN_NEG    = '-'; ///< Print a sign character only for negative values (default).
+
+    /// Constructor a default instance.
+    constexpr Spec() {}
+
+    /// Construct by parsing @a fmt.
+    Spec(const TextView &fmt);
+    /// Parse a specifier
+    bool parse(TextView fmt);
+
+    char _fill = ' ';      ///< Fill character.
+    char _sign = SIGN_NEG; ///< Numeric sign style.
+    enum class Align : char {
+      NONE,                            ///< No alignment.
+      LEFT,                            ///< Left alignment '<'.
+      RIGHT,                           ///< Right alignment '>'.
+      CENTER,                          ///< Center alignment '^'.
+      SIGN                             ///< Align plus/minus sign before numeric fill. '='
+    } _align           = Align::NONE;  ///< Output field alignment.
+    char _type         = DEFAULT_TYPE; ///< Type / radix indicator.
+    bool _radix_lead_p = false;        ///< Print leading radix indication.
+    // @a _min is unsigned because there's no point in an invalid default, 0 works fine.
+    unsigned int _min = 0;                                        ///< Minimum width.
+    int _prec         = -1;                                       ///< Precision
+    unsigned int _max = std::numeric_limits<unsigned int>::max(); ///< Maximum width
+    int _idx          = -1;                                       ///< Positional "name" of the specification.
+    std::string_view _name;                                       ///< Name of the specification.
+    std::string_view _ext;                                        ///< Extension if provided.
+
+    /// Global default instance for use in situations where a format specifier isn't available.
+    static const self_type DEFAULT;
+
+    /// Validate @a c is a specifier type indicator.
+    static bool is_type(char c);
+
+    /// Check if the type flag is numeric.
+    static bool is_numeric_type(char c);
+
+    /// Check if the type is an upper case variant.
+    static bool is_upper_case_type(char c);
+
+    /// Check if the type @a in @a this is numeric.
+    bool has_numeric_type() const;
+
+    /// Check if the type in @a this is an upper case variant.
+    bool has_upper_case_type() const;
+
+    /// Check if the type is a raw pointer.
+    bool has_pointer_type() const;
+
+    /// Check if the type is valid.
+    bool has_valid_type() const;
+
+  protected:
+    /// Validate character is alignment character and return the appropriate enum value.
+    Align align_of(char c);
+
+    /// Validate is sign indicator.
+    bool is_sign(char c);
+
+    /// Handrolled initialization the character syntactic property data.
+    static const struct Property {
+      Property(); ///< Default constructor, creates initialized flag set.
+      /// Flag storage, indexed by character value.
+      uint8_t _data[0x100];
+      /// Flag mask values.
+      static constexpr uint8_t ALIGN_MASK        = 0x0F; ///< Alignment type.
+      static constexpr uint8_t TYPE_CHAR         = 0x10; ///< A valid type character.
+      static constexpr uint8_t UPPER_TYPE_CHAR   = 0x20; ///< Upper case flag.
+      static constexpr uint8_t NUMERIC_TYPE_CHAR = 0x40; ///< Numeric output.
+      static constexpr uint8_t SIGN_CHAR         = 0x80; ///< Is sign character.
+    } _prop;
+  };
+
+  /** Format string support.
+   *
+   * This contains the parsing logic for format strings and also serves as the type for pre-compiled
+   * format string.
+   *
+   * When used by the print formatting logic, there is an abstraction layer, "extraction", which
+   * performs the equivalent of the @c parse method. This allows the formatting to treat pre-compiled
+   * or immediately parsed format strings the same. It also enables providing any parser that can
+   * deliver literals and @c Spec instances.
+   */
+  class Format
+  {
+  public:
+    /// Construct from a format string @a fmt.
+    Format(TextView fmt);
+
+    /// Extraction support for TextView.
+    struct TextViewExtractor {
+      TextView _fmt;
+      explicit operator bool() const;
+      bool operator()(std::string_view &literal_v, Spec &spec);
+
+      /** Parse elements of a format string.
+
+          @param fmt The format string [in|out]
+          @param literal A literal if found
+          @param spec A specifier if found (less enclosing braces)
+          @return @c true if a specifier was found, @c false if not.
+
+          Pull off the next literal and/or specifier from @a fmt. The return value distinguishes
+          the case of no specifier found (@c false) or an empty specifier (@c true).
+
+       */
+      static bool parse(TextView &fmt, std::string_view &literal, std::string_view &spec);
+    };
+    /// Wrap the format string in an extractor.
+    static TextViewExtractor bind(TextView fmt);
+
+    /// Extraction support for pre-parsed format strings.
+    struct FormatExtractor {
+      const std::vector<Spec> &_fmt; ///< Parsed format string.
+      int _idx = 0;                  ///< Element index.
+      explicit operator bool() const;
+      bool operator()(std::string_view &literal_v, Spec &spec);
+    };
+    /// Wrap the format instance in an extractor.
+    FormatExtractor bind() const;
+
+  protected:
+    /// Default constructor for use by subclasses with alternate formatting.
+    Format() = default;
+
+    std::vector<Spec> _items; ///< Items from format string.
+  };
+
+  // Name binding - support for having format specifier names.
+
+  /// Generic name generator signature.
+  using BoundNameSignature = BufferWriter &(BufferWriter &, Spec const &);
+
+  /** Protocol class for handling bound names.
+   *
+   * This is an API facade for names that are fully bound and do not need any data / context
+   * beyond that of the @c BufferWriter. It is expected other name collections will subclass
+   * this to pass to the formatting logic.
+   */
+  class BoundNames
+  {
+  public:
+    virtual ~BoundNames();
+    /** Generate output text for @a name on the output @a w using the format specifier @a spec.
+     * This must match the @c BoundNameSignature type.
+     *
+     * @param w Output stream.
+     * @param spec Parsed format specifier.
+     *
+     * @note The tag name can be found in @c spec._name.
+     *
+     * @return
+     */
+    virtual BufferWriter &operator()(BufferWriter &w, Spec const &spec) const = 0;
+
+    /** Capture an argument.
+     *
+     * @param w Output.
+     * @param spec Capturing specifier.
+     * @param arg The captured argument.
+     *
+     * @note This is really for C / printf support where some specifiers are dependent on values
+     * passed in other arguments.
+     */
+    virtual void capture(BufferWriter &w, Spec const &spec, std::any const &arg) const;
+
+  protected:
+    /// Write missing name output.
+    BufferWriter &err_invalid_name(BufferWriter &w, Spec const &) const;
+  };
+
+  /// Empty bound names - used for where no name binding is available or desired.
+  /// Throws if any name is used.
+  class NilBoundNames : public BoundNames
+  {
+  public:
+    BufferWriter &operator()(BufferWriter &, Spec const &) const override;
+  };
+
+  /** Binding names to generators.
+   *  @tparam F The function signature for generators in this container.
+   *
+   * This is a base class used by different types of name containers. It is not expected to be used
+   * directly.
+   */
+  template <typename F> class NameBinding
+  {
+  private:
+    using self_type = NameBinding; ///< self reference type.
+  public:
+    using Generator = std::function<F>;
+
+    /// Construct an empty name set.
+    NameBinding();
+    /// Construct and assign the names and generators in @a list
+    NameBinding(std::initializer_list<std::tuple<std::string_view, const Generator &>> list);
+
+    /** Assign the @a generator to the @a name.
+     *
+     * @param name Name associated with the @a generator.
+     * @param generator The generator function.
+     */
+    self_type &assign(std::string_view name, const Generator &generator);
+
+  protected:
+    /// Copy @a name in to local storage and return a view of it.
+    std::string_view localize(std::string_view name);
+
+    using Map = std::unordered_map<std::string_view, Generator>;
+    Map _map;              ///< Mapping of name -> generator
+    MemArena _arena{1024}; ///< Local name storage.
+  };
+
+  /** A class to hold global name bindings.
+   *
+   * These names access global data and therefore have no context. An instance of this is used
+   * as the default if no explicit name set is provided.
+   */
+  class GlobalNames : public NameBinding<BoundNameSignature>
+  {
+    using self_type  = GlobalNames;
+    using super_type = NameBinding<BoundNameSignature>;
+    using Map        = super_type::Map;
+
+  public:
+    using super_type::super_type;
+    /// Provide an accessor for formatting.
+    BoundNames &bind();
+
+  protected:
+    class Binding : public BoundNames
+    {
+    public:
+      Binding(const super_type::Map &map);
+      BufferWriter &operator()(BufferWriter &w, const Spec &spec) const override;
+
+    protected:
+      const Map &_map;
+    } _binding{super_type::_map};
+  };
+
+  /** Binding for context based names.
+   *
+   * @tparam T The context type. This is used directly. If the context needs to be @c const
+   * then this parameter should make that explicit, e.g. @c Names<const Context>. This
+   * paramater is accessible via the @c context_type alias.
+   *
+   * This enables named format specifications, such as "{tag}", generated from a context of type @a
+   * T. Each supported tag requires a @a Generator which is a functor of type
+   *
+   * @code
+   *   BufferWriter & generator(BufferWriter & w, const Spec & spec, T & context);
+   * @endcode
+   */
+  template <typename T> class ContextNames : public NameBinding<BufferWriter &(BufferWriter &, const Spec &, T &)>
+  {
+  private:
+    using self_type  = ContextNames; ///< self reference type.
+    using super_type = NameBinding<BufferWriter &(BufferWriter &, const Spec &, T &)>;
+
+  public:
+    using context_type = T; ///< Export for external convenience.
+    /// Functional type for a generator.
+    using Generator      = typename super_type::Generator;
+    using BoundGenerator = std::function<BoundNameSignature>;
+
+    using super_type::super_type; // inherit @c super_type constructors.
+
+    /** Assign the bound generator @a bg to @a name.
+     *
+     * This is used for generators in the namespace that do not require the context.
+     *
+     * @param name Name associated with the generator.
+     * @param bg A bound generator that requires no context.
+     * @return @c *this
+     */
+    self_type &assign(std::string_view name, const BoundGenerator &bg);
+
+    /// Inherit unbound generator assignment from the @c super_type.
+    using super_type::assign;
+
+    /** Bind the names to a specific @a context.
+     *
+     * @param context The instance of @a T to use in the generators.
+     * @return A reference to an internal instance of a subclass of the protocol class @c BoundNames.
+     */
+    const BoundNames &bind(context_type &context);
+
+  protected:
+    using Map = typename super_type::Map;
+    /// Subclass of @a BoundNames used to bind this set of names to a context.
+    class Binding : public BoundNames
+    {
+      using self_type  = Binding;
+      using super_type = BoundNames;
+
+    public:
+      /// Invoke the generator for @a name.
+      BufferWriter &operator()(BufferWriter &w, const Spec &spec) const override;
+
+    protected:
+      Binding(Map const &map); ///< Must have a map reference.
+      self_type &assign(context_type *);
+
+      Map const &_map;              ///< The mapping for name look ups.
+      context_type *_ctx = nullptr; ///< Context for generators.
+
+      friend ContextNames;
+    } _binding{super_type::_map};
+  };
+
+  /** Default global names.
+   * This nameset is used if no other is provided. Therefore bindings added to this nameset will be
+   * available in the default formatting use.
+   */
+  extern GlobalNames Global_Names;
+
+  // --------------- Implementation --------------------
+  /// --- Spec ---
+
+  inline Spec::Align
+  Spec::align_of(char c)
+  {
+    return static_cast<Align>(_prop._data[static_cast<unsigned>(c)] & Property::ALIGN_MASK);
+  }
+
+  inline bool
+  Spec::is_sign(char c)
+  {
+    return _prop._data[static_cast<unsigned>(c)] & Property::SIGN_CHAR;
+  }
+
+  inline bool
+  Spec::is_type(char c)
+  {
+    return _prop._data[static_cast<unsigned>(c)] & Property::TYPE_CHAR;
+  }
+
+  inline bool
+  Spec::is_upper_case_type(char c)
+  {
+    return _prop._data[static_cast<unsigned>(c)] & Property::UPPER_TYPE_CHAR;
+  }
+
+  inline bool
+  Spec::is_numeric_type(char c)
+  {
+    return _prop._data[static_cast<unsigned>(c)] & Property::NUMERIC_TYPE_CHAR;
+  }
+
+  inline bool
+  Spec::has_numeric_type() const
+  {
+    return _prop._data[static_cast<unsigned>(_type)] & Property::NUMERIC_TYPE_CHAR;
+  }
+
+  inline bool
+  Spec::has_upper_case_type() const
+  {
+    return _prop._data[static_cast<unsigned>(_type)] & Property::UPPER_TYPE_CHAR;
+  }
+
+  inline bool
+  Spec::has_pointer_type() const
+  {
+    return _type == 'p' || _type == 'P';
+  }
+
+  inline bool
+  Spec::has_valid_type() const
+  {
+    return _type != INVALID_TYPE;
+  }
+
+  inline auto
+  Format::bind(swoc::TextView fmt) -> TextViewExtractor
+  {
+    return {fmt};
+  }
+
+  inline auto
+  Format::bind() const -> FormatExtractor
+  {
+    return {_items};
+  }
+
+  inline Format::TextViewExtractor::operator bool() const { return !_fmt.empty(); }
+  inline Format::FormatExtractor::operator bool() const { return _idx < static_cast<int>(_fmt.size()); }
+
+  /// --- Names / Generators ---
+
+  // Base implementation does nothing as this is rarely used.
+  inline void
+  BoundNames::capture(BufferWriter &, swoc::bwf::Spec const &, std::any const &) const
+  {
+  }
+
+  inline BufferWriter &
+  BoundNames::err_invalid_name(BufferWriter &w, const Spec &spec) const
+  {
+    return w.print("{{~{}~}}", spec._name);
+  }
+
+  inline BufferWriter &
+  NilBoundNames::operator()(BufferWriter &, bwf::Spec const &) const
+  {
+    throw std::runtime_error("Use of nil bound names in BW formating");
+  }
+
+  template <typename T> inline ContextNames<T>::Binding::Binding(Map const &map) : _map(map) {}
+
+  template <typename T>
+  inline const BoundNames &
+  ContextNames<T>::bind(context_type &ctx)
+  {
+    return _binding.assign(&ctx);
+  }
+
+  template <typename T>
+  inline auto
+  ContextNames<T>::Binding::assign(context_type *ctx) -> self_type &
+  {
+    _ctx = ctx;
+    return *this;
+  }
+
+  template <typename T>
+  BufferWriter &
+  ContextNames<T>::Binding::operator()(BufferWriter &w, const Spec &spec) const
+  {
+    if (!spec._name.empty()) {
+      if (auto spot = _map.find(spec._name); spot != _map.end()) {
+        spot->second(w, spec, *_ctx);
+      } else {
+        this->err_invalid_name(w, spec);
+      }
+    }
+    return w;
+  }
+
+  template <typename F> NameBinding<F>::NameBinding() {}
+
+  template <typename F> NameBinding<F>::NameBinding(std::initializer_list<std::tuple<std::string_view, const Generator &>> list)
+  {
+    for (auto &&[name, generator] : list) {
+      this->assign(name, generator);
+    }
+  }
+
+  template <typename F>
+  std::string_view
+  NameBinding<F>::localize(std::string_view name)
+  {
+    auto span = _arena.alloc(name.size());
+    memcpy(span.data(), name.data(), name.size());
+    return span.view();
+  }
+
+  template <typename F>
+  auto
+  NameBinding<F>::assign(std::string_view name, const Generator &generator) -> self_type &
+  {
+    name       = this->localize(name);
+    _map[name] = generator;
+    return *this;
+  }
+
+  inline GlobalNames::Binding::Binding(const super_type::Map &map) : _map(map) {}
+
+  inline BufferWriter &
+  GlobalNames::Binding::operator()(BufferWriter &w, const Spec &spec) const
+  {
+    if (!spec._name.empty()) {
+      if (auto spot = _map.find(spec._name); spot != _map.end()) {
+        spot->second(w, spec);
+      } else {
+        this->err_invalid_name(w, spec);
+      }
+    }
+    return w;
+  }
+
+  inline BoundNames &
+  GlobalNames::bind()
+  {
+    return _binding;
+  }
+
+  /// --- Formatting ---
+
+  /// Internal signature for template generated formatting.
+  /// @a args is a forwarded tuple of arguments to be processed.
+  template <typename TUPLE> using ArgFormatterSignature = BufferWriter &(*)(BufferWriter &w, Spec const &, TUPLE const &args);
+
+  /// Internal error / reporting message generators
+  void Err_Bad_Arg_Index(BufferWriter &w, int i, size_t n);
+
+  // MSVC will expand the parameter pack inside a lambda but not gcc, so this indirection is required.
+
+  /// This selects the @a I th argument in the @a TUPLE arg pack and calls the formatter on it. This
+  /// (or the equivalent lambda) is needed because the array of formatters must have a homogenous
+  /// signature, not vary per argument. Effectively this indirection erases the type of the specific
+  /// argument being formatted. Instances of this have the signature @c ArgFormatterSignature.
+  template <typename TUPLE, size_t I>
+  BufferWriter &
+  Arg_Formatter(BufferWriter &w, Spec const &spec, TUPLE const &args)
+  {
+    return bwformat(w, spec, std::get<I>(args));
+  }
+
+  /// This exists only to expand the index sequence into an array of formatters for the tuple type
+  /// @a TUPLE.  Due to langauge limitations it cannot be done directly. The formatters can be
+  /// accessed via standard array access in contrast to templated tuple access. The actual array is
+  /// static and therefore at run time the only operation is loading the address of the array.
+  template <typename TUPLE, size_t... N>
+  ArgFormatterSignature<TUPLE> *
+  Get_Arg_Formatter_Array(std::index_sequence<N...>)
+  {
+    static ArgFormatterSignature<TUPLE> fa[sizeof...(N)] = {&bwf::Arg_Formatter<TUPLE, N>...};
+    return fa;
+  }
+
+  /// Perform alignment adjustments / fill on @a w of the content in @a lw.
+  /// This is the normal mechanism, in cases where the length can be known or limited before
+  /// conversion, it can be more efficient to work in a temporary local buffer and copy out
+  /// as neeed without moving data in the output buffer.
+  void Adjust_Alignment(BufferWriter &aux, Spec const &spec);
+
+  /// Generic integral conversion.
+  BufferWriter &Format_Integer(BufferWriter &w, Spec const &spec, uintmax_t n, bool negative_p);
+
+  /// Generic floating point conversion.
+  BufferWriter &Format_Float(BufferWriter &w, Spec const &spec, double n, bool negative_p);
+
+  /* Capture support, which allows format extractors to capture arguments and consume them.
+   * This was built in order to support C style formatting, which needs to capture arguments
+   * to set the minimum width and/or the precision of other arguments.
+   *
+   * The key component is the ability to dynamically access an element of a tuple using
+   * @c std::any.
+   *
+   * Note: Much of this was originally in the meta support but it caused problems in use if
+   * the tuple header wasn't also included. I was unable to determine why, as this code doesn't
+   * depend on tuple explicitly.
+   */
+  /// The signature for accessing an element of a tuple.
+  template <typename T> using TupleAccessorSignature = std::any (*)(T const &t);
+  /// Template access method.
+  template <size_t IDX, typename T>
+  std::any
+  TupleAccessor(T const &t)
+  {
+    return std::any(&std::get<IDX>(t));
+  }
+  /// Create and return an array of specialized accessors, indexed by tuple index.
+  template <typename T, size_t... N>
+  std::array<TupleAccessorSignature<T>, sizeof...(N)> &
+  Tuple_Accessor_Array(std::index_sequence<N...>)
+  {
+    static std::array<TupleAccessorSignature<T>, sizeof...(N)> accessors = {&TupleAccessor<N>...};
+    return accessors;
+  }
+  /// Get the Nth element of the tuple as @c std::any.
+  template <typename T>
+  std::any
+  Tuple_Nth(T const &t, size_t idx)
+  {
+    return Tuple_Accessor_Array<T>(std::make_index_sequence<std::tuple_size<T>::value>())[idx](t);
+  }
+  /// If capture is used, the format extractor must provide a @c capture method. This isn't required
+  /// so make it compile time optional, but throw if the extractor sets up for capture and didn't
+  /// provide one.
+  template <typename F>
+  auto
+  arg_capture(F &&f, BufferWriter &, Spec const &, std::any &&, swoc::meta::CaseTag<0>) -> void
+  {
+    throw std::runtime_error("Capture specification used in format extractor that does not support capture");
+  }
+  template <typename F>
+  auto
+  arg_capture(F &&f, BufferWriter &w, Spec const &spec, std::any &&value, swoc::meta::CaseTag<1>)
+    -> decltype(f.capture(w, spec, value))
+  {
+    return f.capture(w, spec, value);
+  }
+
+} // namespace bwf
+
+/* [Need to clip this out and put it in Sphinx
+ *
+ * The format parser :arg:`F` performs parsing of the format specifier, which is presumed to be
+ * bound to this instance of :arg:`F`. The parser is called as a functor and must have a function
+ * method with the signature
+ *
+ * bool (string_view & literal_v, bwf::Spec & spec)
+ *
+ * The parser must parse out to the next specifier in the format, or the end of the format if there
+ * are no more specifiers. If the format is exhausted this should return @c false. A return of @c true
+ * indicates there is either a literal, a specifier, or both.
+ *
+ * When a literal is found, it should be returned in :arg:`literal_v`. If a specifier is found and
+ * parsed, it should be put in :arg:`spec`. Both of these *must* be cleared if the corresponding
+ * data is not found in the incremental parse of the format.
+ */
+
+// This is the real printing logic, all other variants pack up their arguments and send them here.
+template <typename F, typename... Args>
+BufferWriter &
+BufferWriter::print_nv(bwf::BoundNames const &names, F &&f, std::tuple<Args...> const &args)
+{
+  using namespace std::literals;
+  static constexpr int N = sizeof...(Args); // used as loop limit
+  static const auto fa   = bwf::Get_Arg_Formatter_Array<decltype(args)>(std::index_sequence_for<Args...>{});
+  int arg_idx            = 0; // the next argument index to be processed.
+
+  // Parser is required to return @c false if there's no more data, @c true if something was parsed.
+  while (f) {
+    std::string_view lit_v;
+    bwf::Spec spec;
+    bool spec_p = f(lit_v, spec);
+    if (lit_v.size()) {
+      this->write(lit_v);
+    }
+
+    if (spec_p) {
+      size_t width = this->remaining();
+      if (spec._max < width) {
+        width = spec._max;
+      }
+      FixedBufferWriter lw{this->aux_data(), width};
+
+      if (spec._name.size() == 0) {
+        spec._idx = arg_idx++;
+      }
+      if (0 <= spec._idx) {
+        if (spec._idx < N) {
+          if (spec._type == bwf::Spec::CAPTURE_TYPE) {
+            bwf::arg_capture(f, lw, spec, bwf::Tuple_Nth(args, static_cast<size_t>(spec._idx)), swoc::meta::CaseArg);
+          } else {
+            fa[spec._idx](lw, spec, args);
+          }
+        } else {
+          bwf::Err_Bad_Arg_Index(lw, spec._idx, N);
+        }
+      } else if (spec._name.size()) {
+        names(lw, spec);
+      }
+      if (lw.extent()) {
+        bwf::Adjust_Alignment(lw, spec);
+        this->commit(lw.extent());
+      }
+    }
+  }
+  return *this;
+}
+
+template <typename... Args>
+BufferWriter &
+BufferWriter::print(const TextView &fmt, Args &&... args)
+{
+  return this->print_nv(bwf::Global_Names.bind(), bwf::Format::bind(fmt), std::forward_as_tuple(args...));
+}
+
+template <typename... Args>
+BufferWriter &
+BufferWriter::print(bwf::Format const &fmt, Args &&... args)
+{
+  return this->print_nv(bwf::Global_Names.bind(), fmt.bind(), std::forward_as_tuple(args...));
+}
+
+template <typename... Args>
+BufferWriter &
+BufferWriter::printv(TextView const &fmt, std::tuple<Args...> const &args)
+{
+  return this->print_nv(bwf::Global_Names.bind(), bwf::Format::bind(fmt), args);
+}
+
+template <typename... Args>
+BufferWriter &
+BufferWriter::printv(const bwf::Format &fmt, const std::tuple<Args...> &args)
+{
+  return this->print_nv(bwf::Global_Names.bind(), fmt.bind(), args);
+}
+
+template <typename F>
+BufferWriter &
+BufferWriter::print_nv(const bwf::BoundNames &names, F &&f)
+{
+  return print_nv(names, f, std::make_tuple());
+}
+
+// ---- Formatting for specific types.
+
+// Pointers that are not specialized.
+inline BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &spec, const void *ptr)
+{
+  bwf::Spec ptr_spec{spec};
+  ptr_spec._radix_lead_p = true;
+  if (ptr_spec._type == bwf::Spec::DEFAULT_TYPE || ptr_spec._type == 'p') {
+    ptr_spec._type = 'x'; // if default or 'p;, switch to lower hex.
+  } else if (ptr_spec._type == 'P') {
+    ptr_spec._type = 'X'; // P means upper hex, overriding other specializations.
+  }
+  return bwf::Format_Integer(w, ptr_spec, reinterpret_cast<intptr_t>(ptr), false);
+}
+
+// MemSpan
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, MemSpan<void> const &span);
+
+template <typename T>
+BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &spec, MemSpan<T> const &span)
+{
+  bwf::Spec s{spec};
+  // If the precision isn't already specified, make it the size of the objects in the span.
+  // This will break the output into blocks of that size.
+  if (spec._prec <= 0) {
+    s._prec = sizeof(T);
+  }
+  return bwformat(w, s, span.template rebind<void>());
+};
+// -- Common formatters --
+
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, std::string_view sv);
+
+template <size_t N>
+BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &spec, const char (&a)[N])
+{
+  return bwformat(w, spec, std::string_view(a, N - 1));
+}
+
+inline BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &spec, const char *v)
+{
+  if (spec._type == 'x' || spec._type == 'X') {
+    bwformat(w, spec, static_cast<const void *>(v));
+  } else {
+    bwformat(w, spec, std::string_view(v));
+  }
+  return w;
+}
+
+inline BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &spec, TextView tv)
+{
+  return bwformat(w, spec, static_cast<std::string_view>(tv));
+}
+
+inline BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &spec, std::string const &s)
+{
+  return bwformat(w, spec, std::string_view{s});
+}
+
+template <typename F>
+auto
+bwformat(BufferWriter &w, bwf::Spec const &spec, F &&f) ->
+  typename std::enable_if<std::is_floating_point<typename std::remove_reference<F>::type>::value, BufferWriter &>::type
+{
+  return f < 0 ? bwf::Format_Float(w, spec, -f, true) : bwf::Format_Float(w, spec, f, false);
+}
+
+/* Integer types.
+
+   Due to some oddities for MacOS building, need a bit more template magic here. The underlying
+   integer rendering is in @c Format_Integer which takes @c intmax_t or @c uintmax_t. For @c
+   bwformat templates are defined, one for signed and one for unsigned. These forward their argument
+   to the internal renderer. To avoid additional ambiguity the template argument is checked with @c
+   std::enable_if to invalidate the overload if the argument type isn't a signed / unsigned
+   integer. One exception to this is @c char which is handled by a previous overload in order to
+   treat the value as a character and not an integer. The overall benefit is this works for any set
+   of integer types, rather tuning and hoping to get just the right set of overloads.
+ */
+
+template <typename I>
+auto
+bwformat(BufferWriter &w, bwf::Spec const &spec, I &&i) ->
+  typename std::enable_if<std::is_unsigned<typename std::remove_reference<I>::type>::value &&
+                            std::is_integral<typename std::remove_reference<I>::type>::value,
+                          BufferWriter &>::type
+{
+  return bwf::Format_Integer(w, spec, i, false);
+}
+
+template <typename I>
+auto
+bwformat(BufferWriter &w, bwf::Spec const &spec, I &&i) ->
+  typename std::enable_if<std::is_signed<typename std::remove_reference<I>::type>::value &&
+                            std::is_integral<typename std::remove_reference<I>::type>::value,
+                          BufferWriter &>::type
+{
+  bool neg_p  = false;
+  uintmax_t n = static_cast<uintmax_t>(i);
+  if (i < 0) {
+    n     = static_cast<uintmax_t>(-i);
+    neg_p = true;
+  }
+  return bwf::Format_Integer(w, spec, n, neg_p);
+}
+
+inline BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &, char c)
+{
+  return w.write(c);
+}
+
+inline BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &spec, bool f)
+{
+  using namespace std::literals;
+  if ('s' == spec._type) {
+    w.write(f ? "true"sv : "false"sv);
+  } else if ('S' == spec._type) {
+    w.write(f ? "TRUE"sv : "FALSE"sv);
+  } else {
+    bwf::Format_Integer(w, spec, static_cast<uintmax_t>(f), false);
+  }
+  return w;
+}
+
+// std::string support
+/** Print to a @c std::string
+
+    Print to the string @a s. If there is overflow then resize the string sufficiently to hold the output
+    and print again. The effect is the string is resized only as needed to hold the output.
+ */
+template <typename... Args>
+std::string &
+bwprintv(std::string &s, TextView fmt, std::tuple<Args...> const &args)
+{
+  auto len = s.size(); // remember initial size
+  size_t n = FixedBufferWriter(const_cast<char *>(s.data()), s.size()).printv(fmt, std::move(args)).extent();
+  s.resize(n);   // always need to resize - if shorter, must clip pre-existing text.
+  if (n > len) { // dropped data, try again.
+    FixedBufferWriter(const_cast<char *>(s.data()), s.size()).printv(fmt, std::move(args));
+  }
+  return s;
+}
+
+template <typename... Args>
+std::string &
+bwprint(std::string &s, TextView fmt, Args &&... args)
+{
+  return bwprintv(s, fmt, std::forward_as_tuple(args...));
+}
+
+template <typename... Args>
+inline auto
+FixedBufferWriter::print(TextView fmt, Args &&... args) -> self_type &
+{
+  return static_cast<self_type &>(this->super_type::printv(fmt, std::forward_as_tuple(args...)));
+}
+
+template <typename... Args>
+inline auto
+FixedBufferWriter::printv(TextView fmt, std::tuple<Args...> const &args) -> self_type &
+{
+  return static_cast<self_type &>(this->super_type::printv(fmt, args));
+}
+
+template <typename... Args>
+inline auto
+FixedBufferWriter::print(bwf::Format const &fmt, Args &&... args) -> self_type &
+{
+  return static_cast<self_type &>(this->super_type::printv(fmt, std::forward_as_tuple(args...)));
+}
+
+template <typename... Args>
+inline auto
+FixedBufferWriter::printv(bwf::Format const &fmt, std::tuple<Args...> const &args) -> self_type &
+{
+  return static_cast<self_type &>(this->super_type::printv(fmt, args));
+}
+
+// Special case support for @c Scalar, because @c Scalar is a base utility for some other utilities
+// there can be some unpleasant cirularities if @c Scalar includes BufferWriter formatting. If the
+// support is here then it's fine because anything using BWF for @c Scalar must include this header.
+template <intmax_t N, typename C, typename T> class Scalar;
+namespace detail
+{
+  template <typename T>
+  auto
+  tag_label(BufferWriter &w, const bwf::Spec &, meta::CaseTag<0>) -> void
+  {
+  }
+
+  template <typename T>
+  auto
+  tag_label(BufferWriter &w, const bwf::Spec &, meta::CaseTag<1>) -> decltype(T::label, meta::CaseVoidFunc())
+  {
+    w.print("{}", T::label);
+  }
+} // namespace detail
+
+template <intmax_t N, typename C, typename T>
+BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &spec, Scalar<N, C, T> const &x)
+{
+  bwformat(w, spec, x.value());
+  if (!spec.has_numeric_type()) {
+    detail::tag_label<T>(w, spec, meta::CaseArg);
+  }
+  return w;
+}
+
+// Generically a stream operator is a formatter with the default specification.
+template <typename V>
+BufferWriter &
+operator<<(BufferWriter &w, V &&v)
+{
+  return bwformat(w, bwf::Spec::DEFAULT, std::forward<V>(v));
+}
+
+} // namespace swoc

--- a/lib/swoc++/include/swoc/bwf_ex.h
+++ b/lib/swoc++/include/swoc/bwf_ex.h
@@ -1,0 +1,127 @@
+/** @file
+
+    BufferWriter formatters for types in the std namespace.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#pragma once
+
+#include <array>
+#include <string_view>
+
+#include "swoc/bwf_base.h"
+
+namespace swoc
+{
+namespace bwf
+{
+  using namespace std::literals; // enable ""sv
+
+  /** Output @a text @a n times.
+   *
+   */
+  struct Pattern {
+    int _n;                 ///< # of instances of @a pattern.
+    std::string_view _text; ///< output text.
+  };
+  /** Format wrapper for @c errno.
+   * This stores a copy of the argument or @c errno if an argument isn't provided. The output
+   * is then formatted with the short, long, and numeric value of @c errno. If the format specifier
+   * is type 'd' then just the numeric value is printed.
+   */
+  struct Errno {
+    int _e;
+    explicit Errno(int e = errno) : _e(e) {}
+  };
+
+  /** Format wrapper for time stamps.
+   * If the time isn't provided, the current epoch time is used. If the format string isn't
+   * provided a format like "2017 Jun 29 14:11:29" is used.
+   */
+  struct Date {
+    static constexpr std::string_view DEFAULT_FORMAT{"%Y %b %d %H:%M:%S"_sv};
+    time_t _epoch;
+    std::string_view _fmt;
+    Date(time_t t, std::string_view fmt = DEFAULT_FORMAT) : _epoch(t), _fmt(fmt) {}
+    Date(std::string_view fmt = DEFAULT_FORMAT);
+  };
+
+  namespace detail
+  {
+    // Special case conversions - these handle nullptr because the @c std::string_view spec is stupid.
+    inline std::string_view FirstOfConverter(std::nullptr_t) { return std::string_view{}; }
+    inline std::string_view
+    FirstOfConverter(char const *s)
+    {
+      return std::string_view{s ? s : ""};
+    }
+    // Otherwise do any compliant conversion.
+    template <typename T>
+    std::string_view
+    FirstOfConverter(T &&t)
+    {
+      return t;
+    }
+  } // namespace detail
+  /// Print the first of a list of strings that is not an empty string.
+  /// All arguments must be convertible to @c std::string.
+  template <typename... Args>
+  std::string_view
+  FirstOf(Args &&... args)
+  {
+    std::array<std::string_view, sizeof...(args)> strings{{detail::FirstOfConverter(args)...}};
+    for (auto &s : strings) {
+      if (!s.empty())
+        return s;
+    }
+    return std::string_view{};
+  };
+  /** For optional printing strings along with suffixes and prefixes.
+   *  If the wrapped string is null or empty, nothing is printed. Otherwise the prefix, string,
+   *  and suffix are printed. The default are a single space for suffix and nothing for the prefix.
+   */
+  struct OptionalAffix {
+    std::string_view _text;
+    std::string_view _suffix;
+    std::string_view _prefix;
+
+    OptionalAffix(const char *text, std::string_view suffix = " "sv, std::string_view prefix = ""sv)
+      : OptionalAffix(std::string_view(text ? text : ""), suffix, prefix)
+    {
+    }
+
+    OptionalAffix(std::string_view text, std::string_view suffix = " "sv, std::string_view prefix = ""sv)
+    {
+      // If text is null or empty, leave the members empty too.
+      if (!text.empty()) {
+        _text   = text;
+        _prefix = prefix;
+        _suffix = suffix;
+      }
+    }
+  };
+} // namespace bwf
+
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::Pattern const &pattern);
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::Errno const &e);
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::Date const &date);
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::OptionalAffix const &opts);
+
+} // namespace swoc

--- a/lib/swoc++/include/swoc/bwf_printf.h
+++ b/lib/swoc++/include/swoc/bwf_printf.h
@@ -1,0 +1,79 @@
+/** @file
+
+    BufferWriter formatting in snprintf style.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements.  See the NOTICE file distributed with this work for additional information regarding
+    copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with the License.  You may
+    obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#pragma once
+
+#include <string_view>
+
+#include "swoc/TextView.h"
+#include "swoc/bwf_base.h"
+
+namespace swoc
+{
+namespace bwf
+{
+  /** C / printf style formatting for BufferWriter.
+   *
+   * This is a wrapper style class, it is not for use in a persistent context. The general use pattern
+   * will be to pass a temporary instance in to the @c BufferWriter formatting. E.g
+   *
+   * @code
+   * void bwprintf(BufferWriter& w, TextView fmt, arg1, arg2, arg3, ...) {
+   *   w.print_v(C_Format(fmt), std::forward_as_tuple(args));
+   * @endcode
+   */
+  class C_Format
+  {
+  public:
+    /// Construct for @a fmt.
+    C_Format(TextView const &fmt);
+
+    /// Check if there is any more format to process.
+    explicit operator bool() const;
+
+    /// Get the next pieces of the format.
+    bool operator()(std::string_view &literal, Spec &spec);
+
+    void capture(BufferWriter &w, Spec const &spec, std::any const &value);
+
+  protected:
+    TextView _fmt;
+    Spec _saved;          // spec for which the width and/or prec is needed.
+    bool _saved_p{false}; // flag for having a saved _spec.
+    bool _prec_p{false};  // need the precision captured?
+  };
+
+  // ---- Implementation ----
+  inline C_Format::C_Format(TextView const &fmt) : _fmt(fmt) {}
+
+  inline C_Format::operator bool() const { return _saved_p || !_fmt.empty(); }
+
+} // namespace bwf
+
+template <typename... Args>
+int
+bwprintf(BufferWriter &w, TextView const &fmt, Args &&... args)
+{
+  size_t n = w.size();
+  w.print_nv(bwf::NilBoundNames(), bwf::C_Format(fmt), std::forward_as_tuple(args...));
+  return static_cast<int>(w.size() - n);
+}
+
+} // namespace swoc

--- a/lib/swoc++/include/swoc/bwf_std.h
+++ b/lib/swoc++/include/swoc/bwf_std.h
@@ -1,0 +1,37 @@
+/** @file
+
+    BufferWriter formatters for types in the std namespace.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include "swoc/bwf_base.h"
+
+namespace std
+{
+template <typename T>
+swoc::BufferWriter &
+bwformat(swoc::BufferWriter &w, swoc::bwf::Spec const &spec, atomic<T> const &v)
+{
+  return swoc::bwformat(w, spec, v.load());
+}
+} // end namespace std

--- a/lib/swoc++/include/swoc/ext/HashFNV.h
+++ b/lib/swoc++/include/swoc/ext/HashFNV.h
@@ -1,0 +1,193 @@
+/** @file
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
+  See the NOTICE file distributed with this work for additional information regarding copyright
+  ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance with the License.  You may obtain a
+  copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License
+  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  or implied. See the License for the specific language governing permissions and limitations under
+  the License.
+ */
+
+/*
+  http://www.isthe.com/chongo/tech/comp/fnv/
+
+  Currently implemented FNV-1a 32bit and FNV-1a 64bit
+ */
+
+#pragma once
+
+#include <cstdint>
+#include "swoc/TextView.h"
+
+namespace swoc
+{
+struct Hash32FNV1a {
+protected:
+  using self_type                = Hash32FNV1a;
+  static constexpr uint32_t INIT = 0x811c9dc5u;
+
+public:
+  using value_type = uint32_t;
+
+  Hash32FNV1a() = default;
+
+  self_type &update(std::string_view const &data);
+
+  self_type & final();
+
+  value_type get() const;
+
+  self_type &clear();
+
+  template <typename X, typename V> self_type &update(TransformView<X, V> view);
+
+  template <typename X, typename V> value_type hash_immediate(TransformView<X, V> const &view);
+
+  value_type hash_immediate(std::string_view const &data);
+
+private:
+  value_type hval{INIT};
+};
+
+struct Hash64FNV1a {
+protected:
+  using self_type                = Hash64FNV1a;
+  static constexpr uint64_t INIT = 0xcbf29ce484222325ull;
+
+public:
+  using value_type = uint64_t;
+
+  Hash64FNV1a() = default;
+
+  self_type &update(std::string_view const &data);
+
+  self_type & final();
+
+  value_type get() const;
+
+  self_type &clear();
+
+  template <typename X, typename V> self_type &update(TransformView<X, V> view);
+
+  template <typename X, typename V> value_type hash_immediate(TransformView<X, V> const &view);
+
+  value_type hash_immediate(std::string_view const &data);
+
+private:
+  value_type hval{INIT};
+};
+
+// ----------
+// Implementation
+
+// -- 32 --
+
+inline auto
+Hash32FNV1a::clear() -> self_type &
+{
+  hval = INIT;
+  return *this;
+}
+
+template <typename X, typename V>
+auto
+Hash32FNV1a::update(TransformView<X, V> view) -> self_type &
+{
+  for (; view; ++view) {
+    hval ^= static_cast<value_type>(*view);
+    hval += (hval << 1) + (hval << 4) + (hval << 7) + (hval << 8) + (hval << 24);
+  }
+  return *this;
+}
+
+inline auto
+Hash32FNV1a::update(std::string_view const &data) -> self_type &
+{
+  return this->update(transform_view_of(data));
+}
+
+inline auto
+Hash32FNV1a::final() -> self_type &
+{
+  return *this;
+}
+
+inline auto
+Hash32FNV1a::get() const -> value_type
+{
+  return hval;
+}
+
+template <typename X, typename V>
+auto
+Hash32FNV1a::hash_immediate(swoc::TransformView<X, V> const &view) -> value_type
+{
+  return this->update(view).get();
+}
+
+inline auto
+Hash32FNV1a::hash_immediate(std::string_view const &data) -> value_type
+{
+  return this->update(data).final().get();
+}
+
+// -- 64 --
+
+inline auto
+Hash64FNV1a::clear() -> self_type &
+{
+  hval = INIT;
+  return *this;
+}
+
+template <typename X, typename V>
+auto
+Hash64FNV1a::update(TransformView<X, V> view) -> self_type &
+{
+  for (; view; ++view) {
+    hval ^= static_cast<value_type>(*view);
+    hval += (hval << 1) + (hval << 4) + (hval << 5) + (hval << 7) + (hval << 8) + (hval << 40);
+  }
+  return *this;
+}
+
+inline auto
+Hash64FNV1a::update(std::string_view const &data) -> self_type &
+{
+  return this->update(transform_view_of(data));
+}
+
+inline auto
+Hash64FNV1a::final() -> self_type &
+{
+  return *this;
+}
+
+inline auto
+Hash64FNV1a::get() const -> value_type
+{
+  return hval;
+}
+
+template <typename X, typename V>
+auto
+Hash64FNV1a::hash_immediate(swoc::TransformView<X, V> const &view) -> value_type
+{
+  return this->update(view).final().get();
+}
+
+inline auto
+Hash64FNV1a::hash_immediate(std::string_view const &data) -> value_type
+{
+  return this->update(data).final().get();
+}
+
+} // namespace swoc

--- a/lib/swoc++/include/swoc/ext/catch.hpp
+++ b/lib/swoc++/include/swoc/ext/catch.hpp
@@ -1,0 +1,13050 @@
+/*
+ *  Catch v2.2.2
+ *  Generated: 2018-04-06 12:05:03.186665
+ *  ----------------------------------------------------------
+ *  This file has been merged from multiple headers. Please don't edit it directly
+ *  Copyright (c) 2018 Two Blue Cubes Ltd. All rights reserved.
+ *
+ *  Distributed under the Boost Software License, Version 1.0. (See accompanying
+ *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+#ifndef TWOBLUECUBES_SINGLE_INCLUDE_CATCH_HPP_INCLUDED
+#define TWOBLUECUBES_SINGLE_INCLUDE_CATCH_HPP_INCLUDED
+// start catch.hpp
+
+
+#define CATCH_VERSION_MAJOR 2
+#define CATCH_VERSION_MINOR 2
+#define CATCH_VERSION_PATCH 2
+
+#ifdef __clang__
+#    pragma clang system_header
+#elif defined __GNUC__
+#    pragma GCC system_header
+#endif
+
+// start catch_suppress_warnings.h
+
+#ifdef __clang__
+#   ifdef __ICC // icpc defines the __clang__ macro
+#       pragma warning(push)
+#       pragma warning(disable: 161 1682)
+#   else // __ICC
+#       pragma clang diagnostic ignored "-Wunused-variable"
+#       pragma clang diagnostic push
+#       pragma clang diagnostic ignored "-Wpadded"
+#       pragma clang diagnostic ignored "-Wswitch-enum"
+#       pragma clang diagnostic ignored "-Wcovered-switch-default"
+#    endif
+#elif defined __GNUC__
+#    pragma GCC diagnostic ignored "-Wparentheses"
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wunused-variable"
+#    pragma GCC diagnostic ignored "-Wpadded"
+#endif
+// end catch_suppress_warnings.h
+#if defined(CATCH_CONFIG_MAIN) || defined(CATCH_CONFIG_RUNNER)
+#  define CATCH_IMPL
+#  define CATCH_CONFIG_ALL_PARTS
+#endif
+
+// In the impl file, we want to have access to all parts of the headers
+// Can also be used to sanely support PCHs
+#if defined(CATCH_CONFIG_ALL_PARTS)
+#  define CATCH_CONFIG_EXTERNAL_INTERFACES
+#  if defined(CATCH_CONFIG_DISABLE_MATCHERS)
+#    undef CATCH_CONFIG_DISABLE_MATCHERS
+#  endif
+#  define CATCH_CONFIG_ENABLE_CHRONO_STRINGMAKER
+#endif
+
+#if !defined(CATCH_CONFIG_IMPL_ONLY)
+// start catch_platform.h
+
+#ifdef __APPLE__
+# include <TargetConditionals.h>
+# if TARGET_OS_OSX == 1
+#  define CATCH_PLATFORM_MAC
+# elif TARGET_OS_IPHONE == 1
+#  define CATCH_PLATFORM_IPHONE
+# endif
+
+#elif defined(linux) || defined(__linux) || defined(__linux__)
+#  define CATCH_PLATFORM_LINUX
+
+#elif defined(WIN32) || defined(__WIN32__) || defined(_WIN32) || defined(_MSC_VER)
+#  define CATCH_PLATFORM_WINDOWS
+#endif
+
+// end catch_platform.h
+
+#ifdef CATCH_IMPL
+#  ifndef CLARA_CONFIG_MAIN
+#    define CLARA_CONFIG_MAIN_NOT_DEFINED
+#    define CLARA_CONFIG_MAIN
+#  endif
+#endif
+
+// start catch_user_interfaces.h
+
+namespace Catch {
+    unsigned int rngSeed();
+}
+
+// end catch_user_interfaces.h
+// start catch_tag_alias_autoregistrar.h
+
+// start catch_common.h
+
+// start catch_compiler_capabilities.h
+
+// Detect a number of compiler features - by compiler
+// The following features are defined:
+//
+// CATCH_CONFIG_COUNTER : is the __COUNTER__ macro supported?
+// CATCH_CONFIG_WINDOWS_SEH : is Windows SEH supported?
+// CATCH_CONFIG_POSIX_SIGNALS : are POSIX signals supported?
+// ****************
+// Note to maintainers: if new toggles are added please document them
+// in configuration.md, too
+// ****************
+
+// In general each macro has a _NO_<feature name> form
+// (e.g. CATCH_CONFIG_NO_POSIX_SIGNALS) which disables the feature.
+// Many features, at point of detection, define an _INTERNAL_ macro, so they
+// can be combined, en-mass, with the _NO_ forms later.
+
+#ifdef __cplusplus
+
+#  if __cplusplus >= 201402L
+#    define CATCH_CPP14_OR_GREATER
+#  endif
+
+#  if __cplusplus >= 201703L
+#    define CATCH_CPP17_OR_GREATER
+#  endif
+
+#endif
+
+#if defined(CATCH_CPP17_OR_GREATER)
+#  define CATCH_INTERNAL_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS
+#endif
+
+#ifdef __clang__
+
+#       define CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \
+            _Pragma( "clang diagnostic push" ) \
+            _Pragma( "clang diagnostic ignored \"-Wexit-time-destructors\"" ) \
+            _Pragma( "clang diagnostic ignored \"-Wglobal-constructors\"")
+#       define CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS \
+            _Pragma( "clang diagnostic pop" )
+
+#       define CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS \
+            _Pragma( "clang diagnostic push" ) \
+            _Pragma( "clang diagnostic ignored \"-Wparentheses\"" )
+#       define CATCH_INTERNAL_UNSUPPRESS_PARENTHESES_WARNINGS \
+            _Pragma( "clang diagnostic pop" )
+
+#endif // __clang__
+
+////////////////////////////////////////////////////////////////////////////////
+// Assume that non-Windows platforms support posix signals by default
+#if !defined(CATCH_PLATFORM_WINDOWS)
+    #define CATCH_INTERNAL_CONFIG_POSIX_SIGNALS
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+// We know some environments not to support full POSIX signals
+#if defined(__CYGWIN__) || defined(__QNX__) || defined(__EMSCRIPTEN__) || defined(__DJGPP__)
+    #define CATCH_INTERNAL_CONFIG_NO_POSIX_SIGNALS
+#endif
+
+#ifdef __OS400__
+#       define CATCH_INTERNAL_CONFIG_NO_POSIX_SIGNALS
+#       define CATCH_CONFIG_COLOUR_NONE
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+// Cygwin
+#ifdef __CYGWIN__
+
+// Required for some versions of Cygwin to declare gettimeofday
+// see: http://stackoverflow.com/questions/36901803/gettimeofday-not-declared-in-this-scope-cygwin
+#   define _BSD_SOURCE
+
+#endif // __CYGWIN__
+
+////////////////////////////////////////////////////////////////////////////////
+// Visual C++
+#ifdef _MSC_VER
+
+#  if _MSC_VER >= 1900 // Visual Studio 2015 or newer
+#    define CATCH_INTERNAL_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS
+#  endif
+
+// Universal Windows platform does not support SEH
+// Or console colours (or console at all...)
+#  if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
+#    define CATCH_CONFIG_COLOUR_NONE
+#  else
+#    define CATCH_INTERNAL_CONFIG_WINDOWS_SEH
+#  endif
+
+#endif // _MSC_VER
+
+////////////////////////////////////////////////////////////////////////////////
+
+// DJGPP
+#ifdef __DJGPP__
+#  define CATCH_INTERNAL_CONFIG_NO_WCHAR
+#endif // __DJGPP__
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Use of __COUNTER__ is suppressed during code analysis in
+// CLion/AppCode 2017.2.x and former, because __COUNTER__ is not properly
+// handled by it.
+// Otherwise all supported compilers support COUNTER macro,
+// but user still might want to turn it off
+#if ( !defined(__JETBRAINS_IDE__) || __JETBRAINS_IDE__ >= 20170300L )
+    #define CATCH_INTERNAL_CONFIG_COUNTER
+#endif
+
+#if defined(CATCH_INTERNAL_CONFIG_COUNTER) && !defined(CATCH_CONFIG_NO_COUNTER) && !defined(CATCH_CONFIG_COUNTER)
+#   define CATCH_CONFIG_COUNTER
+#endif
+#if defined(CATCH_INTERNAL_CONFIG_WINDOWS_SEH) && !defined(CATCH_CONFIG_NO_WINDOWS_SEH) && !defined(CATCH_CONFIG_WINDOWS_SEH)
+#   define CATCH_CONFIG_WINDOWS_SEH
+#endif
+// This is set by default, because we assume that unix compilers are posix-signal-compatible by default.
+#if defined(CATCH_INTERNAL_CONFIG_POSIX_SIGNALS) && !defined(CATCH_INTERNAL_CONFIG_NO_POSIX_SIGNALS) && !defined(CATCH_CONFIG_NO_POSIX_SIGNALS) && !defined(CATCH_CONFIG_POSIX_SIGNALS)
+#   define CATCH_CONFIG_POSIX_SIGNALS
+#endif
+// This is set by default, because we assume that compilers with no wchar_t support are just rare exceptions.
+#if !defined(CATCH_INTERNAL_CONFIG_NO_WCHAR) && !defined(CATCH_CONFIG_NO_WCHAR) && !defined(CATCH_CONFIG_WCHAR)
+#   define CATCH_CONFIG_WCHAR
+#endif
+
+#if defined(CATCH_INTERNAL_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS) && !defined(CATCH_CONFIG_NO_CPP17_UNCAUGHT_EXCEPTIONS) && !defined(CATCH_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS)
+#  define CATCH_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS
+#endif
+
+#if !defined(CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS)
+#   define CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS
+#   define CATCH_INTERNAL_UNSUPPRESS_PARENTHESES_WARNINGS
+#endif
+#if !defined(CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS)
+#   define CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS
+#   define CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS
+#endif
+
+// end catch_compiler_capabilities.h
+#define INTERNAL_CATCH_UNIQUE_NAME_LINE2( name, line ) name##line
+#define INTERNAL_CATCH_UNIQUE_NAME_LINE( name, line ) INTERNAL_CATCH_UNIQUE_NAME_LINE2( name, line )
+#ifdef CATCH_CONFIG_COUNTER
+#  define INTERNAL_CATCH_UNIQUE_NAME( name ) INTERNAL_CATCH_UNIQUE_NAME_LINE( name, __COUNTER__ )
+#else
+#  define INTERNAL_CATCH_UNIQUE_NAME( name ) INTERNAL_CATCH_UNIQUE_NAME_LINE( name, __LINE__ )
+#endif
+
+#include <iosfwd>
+#include <string>
+#include <cstdint>
+
+namespace Catch {
+
+    struct CaseSensitive { enum Choice {
+        Yes,
+        No
+    }; };
+
+    class NonCopyable {
+        NonCopyable( NonCopyable const& )              = delete;
+        NonCopyable( NonCopyable && )                  = delete;
+        NonCopyable& operator = ( NonCopyable const& ) = delete;
+        NonCopyable& operator = ( NonCopyable && )     = delete;
+
+    protected:
+        NonCopyable();
+        virtual ~NonCopyable();
+    };
+
+    struct SourceLineInfo {
+
+        SourceLineInfo() = delete;
+        SourceLineInfo( char const* _file, std::size_t _line ) noexcept
+        :   file( _file ),
+            line( _line )
+        {}
+
+        SourceLineInfo( SourceLineInfo const& other )        = default;
+        SourceLineInfo( SourceLineInfo && )                  = default;
+        SourceLineInfo& operator = ( SourceLineInfo const& ) = default;
+        SourceLineInfo& operator = ( SourceLineInfo && )     = default;
+
+        bool empty() const noexcept;
+        bool operator == ( SourceLineInfo const& other ) const noexcept;
+        bool operator < ( SourceLineInfo const& other ) const noexcept;
+
+        char const* file;
+        std::size_t line;
+    };
+
+    std::ostream& operator << ( std::ostream& os, SourceLineInfo const& info );
+
+    // Use this in variadic streaming macros to allow
+    //    >> +StreamEndStop
+    // as well as
+    //    >> stuff +StreamEndStop
+    struct StreamEndStop {
+        std::string operator+() const;
+    };
+    template<typename T>
+    T const& operator + ( T const& value, StreamEndStop ) {
+        return value;
+    }
+}
+
+#define CATCH_INTERNAL_LINEINFO \
+    ::Catch::SourceLineInfo( __FILE__, static_cast<std::size_t>( __LINE__ ) )
+
+// end catch_common.h
+namespace Catch {
+
+    struct RegistrarForTagAliases {
+        RegistrarForTagAliases( char const* alias, char const* tag, SourceLineInfo const& lineInfo );
+    };
+
+} // end namespace Catch
+
+#define CATCH_REGISTER_TAG_ALIAS( alias, spec ) \
+    CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \
+    namespace{ Catch::RegistrarForTagAliases INTERNAL_CATCH_UNIQUE_NAME( AutoRegisterTagAlias )( alias, spec, CATCH_INTERNAL_LINEINFO ); } \
+    CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS
+
+// end catch_tag_alias_autoregistrar.h
+// start catch_test_registry.h
+
+// start catch_interfaces_testcase.h
+
+#include <vector>
+#include <memory>
+
+namespace Catch {
+
+    class TestSpec;
+
+    struct ITestInvoker {
+        virtual void invoke () const = 0;
+        virtual ~ITestInvoker();
+    };
+
+    using ITestCasePtr = std::shared_ptr<ITestInvoker>;
+
+    class TestCase;
+    struct IConfig;
+
+    struct ITestCaseRegistry {
+        virtual ~ITestCaseRegistry();
+        virtual std::vector<TestCase> const& getAllTests() const = 0;
+        virtual std::vector<TestCase> const& getAllTestsSorted( IConfig const& config ) const = 0;
+    };
+
+    bool matchTest( TestCase const& testCase, TestSpec const& testSpec, IConfig const& config );
+    std::vector<TestCase> filterTests( std::vector<TestCase> const& testCases, TestSpec const& testSpec, IConfig const& config );
+    std::vector<TestCase> const& getAllTestCasesSorted( IConfig const& config );
+
+}
+
+// end catch_interfaces_testcase.h
+// start catch_stringref.h
+
+#include <cstddef>
+#include <string>
+#include <iosfwd>
+
+namespace Catch {
+
+    class StringData;
+
+    /// A non-owning string class (similar to the forthcoming std::string_view)
+    /// Note that, because a StringRef may be a substring of another string,
+    /// it may not be null terminated. c_str() must return a null terminated
+    /// string, however, and so the StringRef will internally take ownership
+    /// (taking a copy), if necessary. In theory this ownership is not externally
+    /// visible - but it does mean (substring) StringRefs should not be shared between
+    /// threads.
+    class StringRef {
+    public:
+        using size_type = std::size_t;
+
+    private:
+        friend struct StringRefTestAccess;
+
+        char const* m_start;
+        size_type m_size;
+
+        char* m_data = nullptr;
+
+        void takeOwnership();
+
+        static constexpr char const* const s_empty = "";
+
+    public: // construction/ assignment
+        StringRef() noexcept
+        :   StringRef( s_empty, 0 )
+        {}
+
+        StringRef( StringRef const& other ) noexcept
+        :   m_start( other.m_start ),
+            m_size( other.m_size )
+        {}
+
+        StringRef( StringRef&& other ) noexcept
+        :   m_start( other.m_start ),
+            m_size( other.m_size ),
+            m_data( other.m_data )
+        {
+            other.m_data = nullptr;
+        }
+
+        StringRef( char const* rawChars ) noexcept;
+
+        StringRef( char const* rawChars, size_type size ) noexcept
+        :   m_start( rawChars ),
+            m_size( size )
+        {}
+
+        StringRef( std::string const& stdString ) noexcept
+        :   m_start( stdString.c_str() ),
+            m_size( stdString.size() )
+        {}
+
+        ~StringRef() noexcept {
+            delete[] m_data;
+        }
+
+        auto operator = ( StringRef const &other ) noexcept -> StringRef& {
+            delete[] m_data;
+            m_data = nullptr;
+            m_start = other.m_start;
+            m_size = other.m_size;
+            return *this;
+        }
+
+        operator std::string() const;
+
+        void swap( StringRef& other ) noexcept;
+
+    public: // operators
+        auto operator == ( StringRef const& other ) const noexcept -> bool;
+        auto operator != ( StringRef const& other ) const noexcept -> bool;
+
+        auto operator[] ( size_type index ) const noexcept -> char;
+
+    public: // named queries
+        auto empty() const noexcept -> bool {
+            return m_size == 0;
+        }
+        auto size() const noexcept -> size_type {
+            return m_size;
+        }
+
+        auto numberOfCharacters() const noexcept -> size_type;
+        auto c_str() const -> char const*;
+
+    public: // substrings and searches
+        auto substr( size_type start, size_type size ) const noexcept -> StringRef;
+
+        // Returns the current start pointer.
+        // Note that the pointer can change when if the StringRef is a substring
+        auto currentData() const noexcept -> char const*;
+
+    private: // ownership queries - may not be consistent between calls
+        auto isOwned() const noexcept -> bool;
+        auto isSubstring() const noexcept -> bool;
+    };
+
+    auto operator + ( StringRef const& lhs, StringRef const& rhs ) -> std::string;
+    auto operator + ( StringRef const& lhs, char const* rhs ) -> std::string;
+    auto operator + ( char const* lhs, StringRef const& rhs ) -> std::string;
+
+    auto operator += ( std::string& lhs, StringRef const& sr ) -> std::string&;
+    auto operator << ( std::ostream& os, StringRef const& sr ) -> std::ostream&;
+
+    inline auto operator "" _sr( char const* rawChars, std::size_t size ) noexcept -> StringRef {
+        return StringRef( rawChars, size );
+    }
+
+} // namespace Catch
+
+// end catch_stringref.h
+namespace Catch {
+
+template<typename C>
+class TestInvokerAsMethod : public ITestInvoker {
+    void (C::*m_testAsMethod)();
+public:
+    TestInvokerAsMethod( void (C::*testAsMethod)() ) noexcept : m_testAsMethod( testAsMethod ) {}
+
+    void invoke() const override {
+        C obj;
+        (obj.*m_testAsMethod)();
+    }
+};
+
+auto makeTestInvoker( void(*testAsFunction)() ) noexcept -> ITestInvoker*;
+
+template<typename C>
+auto makeTestInvoker( void (C::*testAsMethod)() ) noexcept -> ITestInvoker* {
+    return new(std::nothrow) TestInvokerAsMethod<C>( testAsMethod );
+}
+
+struct NameAndTags {
+    NameAndTags( StringRef const& name_ = StringRef(), StringRef const& tags_ = StringRef() ) noexcept;
+    StringRef name;
+    StringRef tags;
+};
+
+struct AutoReg : NonCopyable {
+    AutoReg( ITestInvoker* invoker, SourceLineInfo const& lineInfo, StringRef const& classOrMethod, NameAndTags const& nameAndTags ) noexcept;
+    ~AutoReg();
+};
+
+} // end namespace Catch
+
+#if defined(CATCH_CONFIG_DISABLE)
+    #define INTERNAL_CATCH_TESTCASE_NO_REGISTRATION( TestName, ... ) \
+        static void TestName()
+    #define INTERNAL_CATCH_TESTCASE_METHOD_NO_REGISTRATION( TestName, ClassName, ... ) \
+        namespace{                        \
+            struct TestName : ClassName { \
+                void test();              \
+            };                            \
+        }                                 \
+        void TestName::test()
+
+#endif
+
+    ///////////////////////////////////////////////////////////////////////////////
+    #define INTERNAL_CATCH_TESTCASE2( TestName, ... ) \
+        static void TestName(); \
+        CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \
+        namespace{ Catch::AutoReg INTERNAL_CATCH_UNIQUE_NAME( autoRegistrar )( Catch::makeTestInvoker( &TestName ), CATCH_INTERNAL_LINEINFO, "", Catch::NameAndTags{ __VA_ARGS__ } ); } /* NOLINT */ \
+        CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS \
+        static void TestName()
+    #define INTERNAL_CATCH_TESTCASE( ... ) \
+        INTERNAL_CATCH_TESTCASE2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ), __VA_ARGS__ )
+
+    ///////////////////////////////////////////////////////////////////////////////
+    #define INTERNAL_CATCH_METHOD_AS_TEST_CASE( QualifiedMethod, ... ) \
+        CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \
+        namespace{ Catch::AutoReg INTERNAL_CATCH_UNIQUE_NAME( autoRegistrar )( Catch::makeTestInvoker( &QualifiedMethod ), CATCH_INTERNAL_LINEINFO, "&" #QualifiedMethod, Catch::NameAndTags{ __VA_ARGS__ } ); } /* NOLINT */ \
+        CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS
+
+    ///////////////////////////////////////////////////////////////////////////////
+    #define INTERNAL_CATCH_TEST_CASE_METHOD2( TestName, ClassName, ... )\
+        CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \
+        namespace{ \
+            struct TestName : ClassName{ \
+                void test(); \
+            }; \
+            Catch::AutoReg INTERNAL_CATCH_UNIQUE_NAME( autoRegistrar ) ( Catch::makeTestInvoker( &TestName::test ), CATCH_INTERNAL_LINEINFO, #ClassName, Catch::NameAndTags{ __VA_ARGS__ } ); /* NOLINT */ \
+        } \
+        CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS \
+        void TestName::test()
+    #define INTERNAL_CATCH_TEST_CASE_METHOD( ClassName, ... ) \
+        INTERNAL_CATCH_TEST_CASE_METHOD2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ), ClassName, __VA_ARGS__ )
+
+    ///////////////////////////////////////////////////////////////////////////////
+    #define INTERNAL_CATCH_REGISTER_TESTCASE( Function, ... ) \
+        CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \
+        Catch::AutoReg INTERNAL_CATCH_UNIQUE_NAME( autoRegistrar )( Catch::makeTestInvoker( Function ), CATCH_INTERNAL_LINEINFO, "", Catch::NameAndTags{ __VA_ARGS__ } ); /* NOLINT */ \
+        CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS
+
+// end catch_test_registry.h
+// start catch_capture.hpp
+
+// start catch_assertionhandler.h
+
+// start catch_assertioninfo.h
+
+// start catch_result_type.h
+
+namespace Catch {
+
+    // ResultWas::OfType enum
+    struct ResultWas { enum OfType {
+        Unknown = -1,
+        Ok = 0,
+        Info = 1,
+        Warning = 2,
+
+        FailureBit = 0x10,
+
+        ExpressionFailed = FailureBit | 1,
+        ExplicitFailure = FailureBit | 2,
+
+        Exception = 0x100 | FailureBit,
+
+        ThrewException = Exception | 1,
+        DidntThrowException = Exception | 2,
+
+        FatalErrorCondition = 0x200 | FailureBit
+
+    }; };
+
+    bool isOk( ResultWas::OfType resultType );
+    bool isJustInfo( int flags );
+
+    // ResultDisposition::Flags enum
+    struct ResultDisposition { enum Flags {
+        Normal = 0x01,
+
+        ContinueOnFailure = 0x02,   // Failures fail test, but execution continues
+        FalseTest = 0x04,           // Prefix expression with !
+        SuppressFail = 0x08         // Failures are reported but do not fail the test
+    }; };
+
+    ResultDisposition::Flags operator | ( ResultDisposition::Flags lhs, ResultDisposition::Flags rhs );
+
+    bool shouldContinueOnFailure( int flags );
+    inline bool isFalseTest( int flags ) { return ( flags & ResultDisposition::FalseTest ) != 0; }
+    bool shouldSuppressFailure( int flags );
+
+} // end namespace Catch
+
+// end catch_result_type.h
+namespace Catch {
+
+    struct AssertionInfo
+    {
+        StringRef macroName;
+        SourceLineInfo lineInfo;
+        StringRef capturedExpression;
+        ResultDisposition::Flags resultDisposition;
+
+        // We want to delete this constructor but a compiler bug in 4.8 means
+        // the struct is then treated as non-aggregate
+        //AssertionInfo() = delete;
+    };
+
+} // end namespace Catch
+
+// end catch_assertioninfo.h
+// start catch_decomposer.h
+
+// start catch_tostring.h
+
+#include <vector>
+#include <cstddef>
+#include <type_traits>
+#include <string>
+// start catch_stream.h
+
+#include <iosfwd>
+#include <cstddef>
+#include <ostream>
+
+namespace Catch {
+
+    std::ostream& cout();
+    std::ostream& cerr();
+    std::ostream& clog();
+
+    class StringRef;
+
+    struct IStream {
+        virtual ~IStream();
+        virtual std::ostream& stream() const = 0;
+    };
+
+    auto makeStream( StringRef const &filename ) -> IStream const*;
+
+    class ReusableStringStream {
+        std::size_t m_index;
+        std::ostream* m_oss;
+    public:
+        ReusableStringStream();
+        ~ReusableStringStream();
+
+        auto str() const -> std::string;
+
+        template<typename T>
+        auto operator << ( T const& value ) -> ReusableStringStream& {
+            *m_oss << value;
+            return *this;
+        }
+        auto get() -> std::ostream& { return *m_oss; }
+
+        static void cleanup();
+    };
+}
+
+// end catch_stream.h
+
+#ifdef __OBJC__
+// start catch_objc_arc.hpp
+
+#import <Foundation/Foundation.h>
+
+#ifdef __has_feature
+#define CATCH_ARC_ENABLED __has_feature(objc_arc)
+#else
+#define CATCH_ARC_ENABLED 0
+#endif
+
+void arcSafeRelease( NSObject* obj );
+id performOptionalSelector( id obj, SEL sel );
+
+#if !CATCH_ARC_ENABLED
+inline void arcSafeRelease( NSObject* obj ) {
+    [obj release];
+}
+inline id performOptionalSelector( id obj, SEL sel ) {
+    if( [obj respondsToSelector: sel] )
+        return [obj performSelector: sel];
+    return nil;
+}
+#define CATCH_UNSAFE_UNRETAINED
+#define CATCH_ARC_STRONG
+#else
+inline void arcSafeRelease( NSObject* ){}
+inline id performOptionalSelector( id obj, SEL sel ) {
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+#endif
+    if( [obj respondsToSelector: sel] )
+        return [obj performSelector: sel];
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+    return nil;
+}
+#define CATCH_UNSAFE_UNRETAINED __unsafe_unretained
+#define CATCH_ARC_STRONG __strong
+#endif
+
+// end catch_objc_arc.hpp
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4180) // We attempt to stream a function (address) by const&, which MSVC complains about but is harmless
+#endif
+
+// We need a dummy global operator<< so we can bring it into Catch namespace later
+struct Catch_global_namespace_dummy {};
+std::ostream& operator<<(std::ostream&, Catch_global_namespace_dummy);
+
+namespace Catch {
+    // Bring in operator<< from global namespace into Catch namespace
+    using ::operator<<;
+
+    namespace Detail {
+
+        extern const std::string unprintableString;
+
+        std::string rawMemoryToString( const void *object, std::size_t size );
+
+        template<typename T>
+        std::string rawMemoryToString( const T& object ) {
+          return rawMemoryToString( &object, sizeof(object) );
+        }
+
+        template<typename T>
+        class IsStreamInsertable {
+            template<typename SS, typename TT>
+            static auto test(int)
+                -> decltype(std::declval<SS&>() << std::declval<TT>(), std::true_type());
+
+            template<typename, typename>
+            static auto test(...)->std::false_type;
+
+        public:
+            static const bool value = decltype(test<std::ostream, const T&>(0))::value;
+        };
+
+        template<typename E>
+        std::string convertUnknownEnumToString( E e );
+
+        template<typename T>
+        typename std::enable_if<!std::is_enum<T>::value, std::string>::type convertUnstreamable( T const& value ) {
+#if !defined(CATCH_CONFIG_FALLBACK_STRINGIFIER)
+            (void)value;
+            return Detail::unprintableString;
+#else
+            return CATCH_CONFIG_FALLBACK_STRINGIFIER(value);
+#endif
+        }
+        template<typename T>
+        typename std::enable_if<std::is_enum<T>::value, std::string>::type convertUnstreamable( T const& value ) {
+            return convertUnknownEnumToString( value );
+        }
+
+#if defined(_MANAGED)
+        //! Convert a CLR string to a utf8 std::string
+        template<typename T>
+        std::string clrReferenceToString( T^ ref ) {
+            if (ref == nullptr)
+                return std::string("null");
+            auto bytes = System::Text::Encoding::UTF8->GetBytes(ref->ToString());
+            cli::pin_ptr<System::Byte> p = &bytes[0];
+            return std::string(reinterpret_cast<char const *>(p), bytes->Length);
+        }
+#endif
+
+    } // namespace Detail
+
+    // If we decide for C++14, change these to enable_if_ts
+    template <typename T, typename = void>
+    struct StringMaker {
+        template <typename Fake = T>
+        static
+        typename std::enable_if<::Catch::Detail::IsStreamInsertable<Fake>::value, std::string>::type
+            convert(const Fake& value) {
+                ReusableStringStream rss;
+                rss << value;
+                return rss.str();
+        }
+
+        template <typename Fake = T>
+        static
+        typename std::enable_if<!::Catch::Detail::IsStreamInsertable<Fake>::value, std::string>::type
+            convert( const Fake& value ) {
+                return Detail::convertUnstreamable( value );
+        }
+    };
+
+    namespace Detail {
+
+        // This function dispatches all stringification requests inside of Catch.
+        // Should be preferably called fully qualified, like ::Catch::Detail::stringify
+        template <typename T>
+        std::string stringify(const T& e) {
+            return ::Catch::StringMaker<typename std::remove_cv<typename std::remove_reference<T>::type>::type>::convert(e);
+        }
+
+        template<typename E>
+        std::string convertUnknownEnumToString( E e ) {
+            return ::Catch::Detail::stringify(static_cast<typename std::underlying_type<E>::type>(e));
+        }
+
+#if defined(_MANAGED)
+        template <typename T>
+        std::string stringify( T^ e ) {
+            return ::Catch::StringMaker<T^>::convert(e);
+        }
+#endif
+
+    } // namespace Detail
+
+    // Some predefined specializations
+
+    template<>
+    struct StringMaker<std::string> {
+        static std::string convert(const std::string& str);
+    };
+#ifdef CATCH_CONFIG_WCHAR
+    template<>
+    struct StringMaker<std::wstring> {
+        static std::string convert(const std::wstring& wstr);
+    };
+#endif
+
+    template<>
+    struct StringMaker<char const *> {
+        static std::string convert(char const * str);
+    };
+    template<>
+    struct StringMaker<char *> {
+        static std::string convert(char * str);
+    };
+
+#ifdef CATCH_CONFIG_WCHAR
+    template<>
+    struct StringMaker<wchar_t const *> {
+        static std::string convert(wchar_t const * str);
+    };
+    template<>
+    struct StringMaker<wchar_t *> {
+        static std::string convert(wchar_t * str);
+    };
+#endif
+
+    // TBD: Should we use `strnlen` to ensure that we don't go out of the buffer,
+    //      while keeping string semantics?
+    template<int SZ>
+    struct StringMaker<char[SZ]> {
+        static std::string convert(char const* str) {
+            return ::Catch::Detail::stringify(std::string{ str });
+        }
+    };
+    template<int SZ>
+    struct StringMaker<signed char[SZ]> {
+        static std::string convert(signed char const* str) {
+            return ::Catch::Detail::stringify(std::string{ reinterpret_cast<char const *>(str) });
+        }
+    };
+    template<int SZ>
+    struct StringMaker<unsigned char[SZ]> {
+        static std::string convert(unsigned char const* str) {
+            return ::Catch::Detail::stringify(std::string{ reinterpret_cast<char const *>(str) });
+        }
+    };
+
+    template<>
+    struct StringMaker<int> {
+        static std::string convert(int value);
+    };
+    template<>
+    struct StringMaker<long> {
+        static std::string convert(long value);
+    };
+    template<>
+    struct StringMaker<long long> {
+        static std::string convert(long long value);
+    };
+    template<>
+    struct StringMaker<unsigned int> {
+        static std::string convert(unsigned int value);
+    };
+    template<>
+    struct StringMaker<unsigned long> {
+        static std::string convert(unsigned long value);
+    };
+    template<>
+    struct StringMaker<unsigned long long> {
+        static std::string convert(unsigned long long value);
+    };
+
+    template<>
+    struct StringMaker<bool> {
+        static std::string convert(bool b);
+    };
+
+    template<>
+    struct StringMaker<char> {
+        static std::string convert(char c);
+    };
+    template<>
+    struct StringMaker<signed char> {
+        static std::string convert(signed char c);
+    };
+    template<>
+    struct StringMaker<unsigned char> {
+        static std::string convert(unsigned char c);
+    };
+
+    template<>
+    struct StringMaker<std::nullptr_t> {
+        static std::string convert(std::nullptr_t);
+    };
+
+    template<>
+    struct StringMaker<float> {
+        static std::string convert(float value);
+    };
+    template<>
+    struct StringMaker<double> {
+        static std::string convert(double value);
+    };
+
+    template <typename T>
+    struct StringMaker<T*> {
+        template <typename U>
+        static std::string convert(U* p) {
+            if (p) {
+                return ::Catch::Detail::rawMemoryToString(p);
+            } else {
+                return "nullptr";
+            }
+        }
+    };
+
+    template <typename R, typename C>
+    struct StringMaker<R C::*> {
+        static std::string convert(R C::* p) {
+            if (p) {
+                return ::Catch::Detail::rawMemoryToString(p);
+            } else {
+                return "nullptr";
+            }
+        }
+    };
+
+#if defined(_MANAGED)
+    template <typename T>
+    struct StringMaker<T^> {
+        static std::string convert( T^ ref ) {
+            return ::Catch::Detail::clrReferenceToString(ref);
+        }
+    };
+#endif
+
+    namespace Detail {
+        template<typename InputIterator>
+        std::string rangeToString(InputIterator first, InputIterator last) {
+            ReusableStringStream rss;
+            rss << "{ ";
+            if (first != last) {
+                rss << ::Catch::Detail::stringify(*first);
+                for (++first; first != last; ++first)
+                    rss << ", " << ::Catch::Detail::stringify(*first);
+            }
+            rss << " }";
+            return rss.str();
+        }
+    }
+
+#ifdef __OBJC__
+    template<>
+    struct StringMaker<NSString*> {
+        static std::string convert(NSString * nsstring) {
+            if (!nsstring)
+                return "nil";
+            return std::string("@") + [nsstring UTF8String];
+        }
+    };
+    template<>
+    struct StringMaker<NSObject*> {
+        static std::string convert(NSObject* nsObject) {
+            return ::Catch::Detail::stringify([nsObject description]);
+        }
+
+    };
+    namespace Detail {
+        inline std::string stringify( NSString* nsstring ) {
+            return StringMaker<NSString*>::convert( nsstring );
+        }
+
+    } // namespace Detail
+#endif // __OBJC__
+
+} // namespace Catch
+
+//////////////////////////////////////////////////////
+// Separate std-lib types stringification, so it can be selectively enabled
+// This means that we do not bring in
+
+#if defined(CATCH_CONFIG_ENABLE_ALL_STRINGMAKERS)
+#  define CATCH_CONFIG_ENABLE_PAIR_STRINGMAKER
+#  define CATCH_CONFIG_ENABLE_TUPLE_STRINGMAKER
+#  define CATCH_CONFIG_ENABLE_CHRONO_STRINGMAKER
+#endif
+
+// Separate std::pair specialization
+#if defined(CATCH_CONFIG_ENABLE_PAIR_STRINGMAKER)
+#include <utility>
+namespace Catch {
+    template<typename T1, typename T2>
+    struct StringMaker<std::pair<T1, T2> > {
+        static std::string convert(const std::pair<T1, T2>& pair) {
+            ReusableStringStream rss;
+            rss << "{ "
+                << ::Catch::Detail::stringify(pair.first)
+                << ", "
+                << ::Catch::Detail::stringify(pair.second)
+                << " }";
+            return rss.str();
+        }
+    };
+}
+#endif // CATCH_CONFIG_ENABLE_PAIR_STRINGMAKER
+
+// Separate std::tuple specialization
+#if defined(CATCH_CONFIG_ENABLE_TUPLE_STRINGMAKER)
+#include <tuple>
+namespace Catch {
+    namespace Detail {
+        template<
+            typename Tuple,
+            std::size_t N = 0,
+            bool = (N < std::tuple_size<Tuple>::value)
+            >
+            struct TupleElementPrinter {
+            static void print(const Tuple& tuple, std::ostream& os) {
+                os << (N ? ", " : " ")
+                    << ::Catch::Detail::stringify(std::get<N>(tuple));
+                TupleElementPrinter<Tuple, N + 1>::print(tuple, os);
+            }
+        };
+
+        template<
+            typename Tuple,
+            std::size_t N
+        >
+            struct TupleElementPrinter<Tuple, N, false> {
+            static void print(const Tuple&, std::ostream&) {}
+        };
+
+    }
+
+    template<typename ...Types>
+    struct StringMaker<std::tuple<Types...>> {
+        static std::string convert(const std::tuple<Types...>& tuple) {
+            ReusableStringStream rss;
+            rss << '{';
+            Detail::TupleElementPrinter<std::tuple<Types...>>::print(tuple, rss.get());
+            rss << " }";
+            return rss.str();
+        }
+    };
+}
+#endif // CATCH_CONFIG_ENABLE_TUPLE_STRINGMAKER
+
+namespace Catch {
+    struct not_this_one {}; // Tag type for detecting which begin/ end are being selected
+
+    // Import begin/ end from std here so they are considered alongside the fallback (...) overloads in this namespace
+    using std::begin;
+    using std::end;
+
+    not_this_one begin( ... );
+    not_this_one end( ... );
+
+    template <typename T>
+    struct is_range {
+        static const bool value =
+            !std::is_same<decltype(begin(std::declval<T>())), not_this_one>::value &&
+            !std::is_same<decltype(end(std::declval<T>())), not_this_one>::value;
+    };
+
+#if defined(_MANAGED) // Managed types are never ranges
+    template <typename T>
+    struct is_range<T^> {
+        static const bool value = false;
+    };
+#endif
+
+    template<typename Range>
+    std::string rangeToString( Range const& range ) {
+        return ::Catch::Detail::rangeToString( begin( range ), end( range ) );
+    }
+
+    // Handle vector<bool> specially
+    template<typename Allocator>
+    std::string rangeToString( std::vector<bool, Allocator> const& v ) {
+        ReusableStringStream rss;
+        rss << "{ ";
+        bool first = true;
+        for( bool b : v ) {
+            if( first )
+                first = false;
+            else
+                rss << ", ";
+            rss << ::Catch::Detail::stringify( b );
+        }
+        rss << " }";
+        return rss.str();
+    }
+
+    template<typename R>
+    struct StringMaker<R, typename std::enable_if<is_range<R>::value && !::Catch::Detail::IsStreamInsertable<R>::value>::type> {
+        static std::string convert( R const& range ) {
+            return rangeToString( range );
+        }
+    };
+
+    template <typename T, int SZ>
+    struct StringMaker<T[SZ]> {
+        static std::string convert(T const(&arr)[SZ]) {
+            return rangeToString(arr);
+        }
+    };
+
+} // namespace Catch
+
+// Separate std::chrono::duration specialization
+#if defined(CATCH_CONFIG_ENABLE_CHRONO_STRINGMAKER)
+#include <ctime>
+#include <ratio>
+#include <chrono>
+
+namespace Catch {
+
+template <class Ratio>
+struct ratio_string {
+    static std::string symbol();
+};
+
+template <class Ratio>
+std::string ratio_string<Ratio>::symbol() {
+    Catch::ReusableStringStream rss;
+    rss << '[' << Ratio::num << '/'
+        << Ratio::den << ']';
+    return rss.str();
+}
+template <>
+struct ratio_string<std::atto> {
+    static std::string symbol();
+};
+template <>
+struct ratio_string<std::femto> {
+    static std::string symbol();
+};
+template <>
+struct ratio_string<std::pico> {
+    static std::string symbol();
+};
+template <>
+struct ratio_string<std::nano> {
+    static std::string symbol();
+};
+template <>
+struct ratio_string<std::micro> {
+    static std::string symbol();
+};
+template <>
+struct ratio_string<std::milli> {
+    static std::string symbol();
+};
+
+    ////////////
+    // std::chrono::duration specializations
+    template<typename Value, typename Ratio>
+    struct StringMaker<std::chrono::duration<Value, Ratio>> {
+        static std::string convert(std::chrono::duration<Value, Ratio> const& duration) {
+            ReusableStringStream rss;
+            rss << duration.count() << ' ' << ratio_string<Ratio>::symbol() << 's';
+            return rss.str();
+        }
+    };
+    template<typename Value>
+    struct StringMaker<std::chrono::duration<Value, std::ratio<1>>> {
+        static std::string convert(std::chrono::duration<Value, std::ratio<1>> const& duration) {
+            ReusableStringStream rss;
+            rss << duration.count() << " s";
+            return rss.str();
+        }
+    };
+    template<typename Value>
+    struct StringMaker<std::chrono::duration<Value, std::ratio<60>>> {
+        static std::string convert(std::chrono::duration<Value, std::ratio<60>> const& duration) {
+            ReusableStringStream rss;
+            rss << duration.count() << " m";
+            return rss.str();
+        }
+    };
+    template<typename Value>
+    struct StringMaker<std::chrono::duration<Value, std::ratio<3600>>> {
+        static std::string convert(std::chrono::duration<Value, std::ratio<3600>> const& duration) {
+            ReusableStringStream rss;
+            rss << duration.count() << " h";
+            return rss.str();
+        }
+    };
+
+    ////////////
+    // std::chrono::time_point specialization
+    // Generic time_point cannot be specialized, only std::chrono::time_point<system_clock>
+    template<typename Clock, typename Duration>
+    struct StringMaker<std::chrono::time_point<Clock, Duration>> {
+        static std::string convert(std::chrono::time_point<Clock, Duration> const& time_point) {
+            return ::Catch::Detail::stringify(time_point.time_since_epoch()) + " since epoch";
+        }
+    };
+    // std::chrono::time_point<system_clock> specialization
+    template<typename Duration>
+    struct StringMaker<std::chrono::time_point<std::chrono::system_clock, Duration>> {
+        static std::string convert(std::chrono::time_point<std::chrono::system_clock, Duration> const& time_point) {
+            auto converted = std::chrono::system_clock::to_time_t(time_point);
+
+#ifdef _MSC_VER
+            std::tm timeInfo = {};
+            gmtime_s(&timeInfo, &converted);
+#else
+            std::tm* timeInfo = std::gmtime(&converted);
+#endif
+
+            auto const timeStampSize = sizeof("2017-01-16T17:06:45Z");
+            char timeStamp[timeStampSize];
+            const char * const fmt = "%Y-%m-%dT%H:%M:%SZ";
+
+#ifdef _MSC_VER
+            std::strftime(timeStamp, timeStampSize, fmt, &timeInfo);
+#else
+            std::strftime(timeStamp, timeStampSize, fmt, timeInfo);
+#endif
+            return std::string(timeStamp);
+        }
+    };
+}
+#endif // CATCH_CONFIG_ENABLE_CHRONO_STRINGMAKER
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+// end catch_tostring.h
+#include <iosfwd>
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4389) // '==' : signed/unsigned mismatch
+#pragma warning(disable:4018) // more "signed/unsigned mismatch"
+#pragma warning(disable:4312) // Converting int to T* using reinterpret_cast (issue on x64 platform)
+#pragma warning(disable:4180) // qualifier applied to function type has no meaning
+#endif
+
+namespace Catch {
+
+    struct ITransientExpression {
+        auto isBinaryExpression() const -> bool { return m_isBinaryExpression; }
+        auto getResult() const -> bool { return m_result; }
+        virtual void streamReconstructedExpression( std::ostream &os ) const = 0;
+
+        ITransientExpression( bool isBinaryExpression, bool result )
+        :   m_isBinaryExpression( isBinaryExpression ),
+            m_result( result )
+        {}
+
+        // We don't actually need a virtual destructor, but many static analysers
+        // complain if it's not here :-(
+        virtual ~ITransientExpression();
+
+        bool m_isBinaryExpression;
+        bool m_result;
+
+    };
+
+    void formatReconstructedExpression( std::ostream &os, std::string const& lhs, StringRef op, std::string const& rhs );
+
+    template<typename LhsT, typename RhsT>
+    class BinaryExpr  : public ITransientExpression {
+        LhsT m_lhs;
+        StringRef m_op;
+        RhsT m_rhs;
+
+        void streamReconstructedExpression( std::ostream &os ) const override {
+            formatReconstructedExpression
+                    ( os, Catch::Detail::stringify( m_lhs ), m_op, Catch::Detail::stringify( m_rhs ) );
+        }
+
+    public:
+        BinaryExpr( bool comparisonResult, LhsT lhs, StringRef op, RhsT rhs )
+        :   ITransientExpression{ true, comparisonResult },
+            m_lhs( lhs ),
+            m_op( op ),
+            m_rhs( rhs )
+        {}
+    };
+
+    template<typename LhsT>
+    class UnaryExpr : public ITransientExpression {
+        LhsT m_lhs;
+
+        void streamReconstructedExpression( std::ostream &os ) const override {
+            os << Catch::Detail::stringify( m_lhs );
+        }
+
+    public:
+        explicit UnaryExpr( LhsT lhs )
+        :   ITransientExpression{ false, lhs ? true : false },
+            m_lhs( lhs )
+        {}
+    };
+
+    // Specialised comparison functions to handle equality comparisons between ints and pointers (NULL deduces as an int)
+    template<typename LhsT, typename RhsT>
+    auto compareEqual( LhsT const& lhs, RhsT const& rhs ) -> bool { return static_cast<bool>(lhs == rhs); }
+    template<typename T>
+    auto compareEqual( T* const& lhs, int rhs ) -> bool { return lhs == reinterpret_cast<void const*>( rhs ); }
+    template<typename T>
+    auto compareEqual( T* const& lhs, long rhs ) -> bool { return lhs == reinterpret_cast<void const*>( rhs ); }
+    template<typename T>
+    auto compareEqual( int lhs, T* const& rhs ) -> bool { return reinterpret_cast<void const*>( lhs ) == rhs; }
+    template<typename T>
+    auto compareEqual( long lhs, T* const& rhs ) -> bool { return reinterpret_cast<void const*>( lhs ) == rhs; }
+
+    template<typename LhsT, typename RhsT>
+    auto compareNotEqual( LhsT const& lhs, RhsT&& rhs ) -> bool { return static_cast<bool>(lhs != rhs); }
+    template<typename T>
+    auto compareNotEqual( T* const& lhs, int rhs ) -> bool { return lhs != reinterpret_cast<void const*>( rhs ); }
+    template<typename T>
+    auto compareNotEqual( T* const& lhs, long rhs ) -> bool { return lhs != reinterpret_cast<void const*>( rhs ); }
+    template<typename T>
+    auto compareNotEqual( int lhs, T* const& rhs ) -> bool { return reinterpret_cast<void const*>( lhs ) != rhs; }
+    template<typename T>
+    auto compareNotEqual( long lhs, T* const& rhs ) -> bool { return reinterpret_cast<void const*>( lhs ) != rhs; }
+
+    template<typename LhsT>
+    class ExprLhs {
+        LhsT m_lhs;
+    public:
+        explicit ExprLhs( LhsT lhs ) : m_lhs( lhs ) {}
+
+        template<typename RhsT>
+        auto operator == ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
+            return { compareEqual( m_lhs, rhs ), m_lhs, "==", rhs };
+        }
+        auto operator == ( bool rhs ) -> BinaryExpr<LhsT, bool> const {
+            return { m_lhs == rhs, m_lhs, "==", rhs };
+        }
+
+        template<typename RhsT>
+        auto operator != ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
+            return { compareNotEqual( m_lhs, rhs ), m_lhs, "!=", rhs };
+        }
+        auto operator != ( bool rhs ) -> BinaryExpr<LhsT, bool> const {
+            return { m_lhs != rhs, m_lhs, "!=", rhs };
+        }
+
+        template<typename RhsT>
+        auto operator > ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
+            return { static_cast<bool>(m_lhs > rhs), m_lhs, ">", rhs };
+        }
+        template<typename RhsT>
+        auto operator < ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
+            return { static_cast<bool>(m_lhs < rhs), m_lhs, "<", rhs };
+        }
+        template<typename RhsT>
+        auto operator >= ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
+            return { static_cast<bool>(m_lhs >= rhs), m_lhs, ">=", rhs };
+        }
+        template<typename RhsT>
+        auto operator <= ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
+            return { static_cast<bool>(m_lhs <= rhs), m_lhs, "<=", rhs };
+        }
+
+        auto makeUnaryExpr() const -> UnaryExpr<LhsT> {
+            return UnaryExpr<LhsT>{ m_lhs };
+        }
+    };
+
+    void handleExpression( ITransientExpression const& expr );
+
+    template<typename T>
+    void handleExpression( ExprLhs<T> const& expr ) {
+        handleExpression( expr.makeUnaryExpr() );
+    }
+
+    struct Decomposer {
+        template<typename T>
+        auto operator <= ( T const& lhs ) -> ExprLhs<T const&> {
+            return ExprLhs<T const&>{ lhs };
+        }
+
+        auto operator <=( bool value ) -> ExprLhs<bool> {
+            return ExprLhs<bool>{ value };
+        }
+    };
+
+} // end namespace Catch
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+// end catch_decomposer.h
+// start catch_interfaces_capture.h
+
+#include <string>
+
+namespace Catch {
+
+    class AssertionResult;
+    struct AssertionInfo;
+    struct SectionInfo;
+    struct SectionEndInfo;
+    struct MessageInfo;
+    struct Counts;
+    struct BenchmarkInfo;
+    struct BenchmarkStats;
+    struct AssertionReaction;
+
+    struct ITransientExpression;
+
+    struct IResultCapture {
+
+        virtual ~IResultCapture();
+
+        virtual bool sectionStarted(    SectionInfo const& sectionInfo,
+                                        Counts& assertions ) = 0;
+        virtual void sectionEnded( SectionEndInfo const& endInfo ) = 0;
+        virtual void sectionEndedEarly( SectionEndInfo const& endInfo ) = 0;
+
+        virtual void benchmarkStarting( BenchmarkInfo const& info ) = 0;
+        virtual void benchmarkEnded( BenchmarkStats const& stats ) = 0;
+
+        virtual void pushScopedMessage( MessageInfo const& message ) = 0;
+        virtual void popScopedMessage( MessageInfo const& message ) = 0;
+
+        virtual void handleFatalErrorCondition( StringRef message ) = 0;
+
+        virtual void handleExpr
+                (   AssertionInfo const& info,
+                    ITransientExpression const& expr,
+                    AssertionReaction& reaction ) = 0;
+        virtual void handleMessage
+                (   AssertionInfo const& info,
+                    ResultWas::OfType resultType,
+                    StringRef const& message,
+                    AssertionReaction& reaction ) = 0;
+        virtual void handleUnexpectedExceptionNotThrown
+                (   AssertionInfo const& info,
+                    AssertionReaction& reaction ) = 0;
+        virtual void handleUnexpectedInflightException
+                (   AssertionInfo const& info,
+                    std::string const& message,
+                    AssertionReaction& reaction ) = 0;
+        virtual void handleIncomplete
+                (   AssertionInfo const& info ) = 0;
+        virtual void handleNonExpr
+                (   AssertionInfo const &info,
+                    ResultWas::OfType resultType,
+                    AssertionReaction &reaction ) = 0;
+
+        virtual bool lastAssertionPassed() = 0;
+        virtual void assertionPassed() = 0;
+
+        // Deprecated, do not use:
+        virtual std::string getCurrentTestName() const = 0;
+        virtual const AssertionResult* getLastResult() const = 0;
+        virtual void exceptionEarlyReported() = 0;
+    };
+
+    IResultCapture& getResultCapture();
+}
+
+// end catch_interfaces_capture.h
+namespace Catch {
+
+    struct TestFailureException{};
+    struct AssertionResultData;
+    struct IResultCapture;
+    class RunContext;
+
+    class LazyExpression {
+        friend class AssertionHandler;
+        friend struct AssertionStats;
+        friend class RunContext;
+
+        ITransientExpression const* m_transientExpression = nullptr;
+        bool m_isNegated;
+    public:
+        LazyExpression( bool isNegated );
+        LazyExpression( LazyExpression const& other );
+        LazyExpression& operator = ( LazyExpression const& ) = delete;
+
+        explicit operator bool() const;
+
+        friend auto operator << ( std::ostream& os, LazyExpression const& lazyExpr ) -> std::ostream&;
+    };
+
+    struct AssertionReaction {
+        bool shouldDebugBreak = false;
+        bool shouldThrow = false;
+    };
+
+    class AssertionHandler {
+        AssertionInfo m_assertionInfo;
+        AssertionReaction m_reaction;
+        bool m_completed = false;
+        IResultCapture& m_resultCapture;
+
+    public:
+        AssertionHandler
+            (   StringRef macroName,
+                SourceLineInfo const& lineInfo,
+                StringRef capturedExpression,
+                ResultDisposition::Flags resultDisposition );
+        ~AssertionHandler() {
+            if ( !m_completed ) {
+                m_resultCapture.handleIncomplete( m_assertionInfo );
+            }
+        }
+
+        template<typename T>
+        void handleExpr( ExprLhs<T> const& expr ) {
+            handleExpr( expr.makeUnaryExpr() );
+        }
+        void handleExpr( ITransientExpression const& expr );
+
+        void handleMessage(ResultWas::OfType resultType, StringRef const& message);
+
+        void handleExceptionThrownAsExpected();
+        void handleUnexpectedExceptionNotThrown();
+        void handleExceptionNotThrownAsExpected();
+        void handleThrowingCallSkipped();
+        void handleUnexpectedInflightException();
+
+        void complete();
+        void setCompleted();
+
+        // query
+        auto allowThrows() const -> bool;
+    };
+
+    void handleExceptionMatchExpr( AssertionHandler& handler, std::string const& str, StringRef matcherString );
+
+} // namespace Catch
+
+// end catch_assertionhandler.h
+// start catch_message.h
+
+#include <string>
+
+namespace Catch {
+
+    struct MessageInfo {
+        MessageInfo(    std::string const& _macroName,
+                        SourceLineInfo const& _lineInfo,
+                        ResultWas::OfType _type );
+
+        std::string macroName;
+        std::string message;
+        SourceLineInfo lineInfo;
+        ResultWas::OfType type;
+        unsigned int sequence;
+
+        bool operator == ( MessageInfo const& other ) const;
+        bool operator < ( MessageInfo const& other ) const;
+    private:
+        static unsigned int globalCount;
+    };
+
+    struct MessageStream {
+
+        template<typename T>
+        MessageStream& operator << ( T const& value ) {
+            m_stream << value;
+            return *this;
+        }
+
+        ReusableStringStream m_stream;
+    };
+
+    struct MessageBuilder : MessageStream {
+        MessageBuilder( std::string const& macroName,
+                        SourceLineInfo const& lineInfo,
+                        ResultWas::OfType type );
+
+        template<typename T>
+        MessageBuilder& operator << ( T const& value ) {
+            m_stream << value;
+            return *this;
+        }
+
+        MessageInfo m_info;
+    };
+
+    class ScopedMessage {
+    public:
+        explicit ScopedMessage( MessageBuilder const& builder );
+        ~ScopedMessage();
+
+        MessageInfo m_info;
+    };
+
+} // end namespace Catch
+
+// end catch_message.h
+#if !defined(CATCH_CONFIG_DISABLE)
+
+#if !defined(CATCH_CONFIG_DISABLE_STRINGIFICATION)
+  #define CATCH_INTERNAL_STRINGIFY(...) #__VA_ARGS__
+#else
+  #define CATCH_INTERNAL_STRINGIFY(...) "Disabled by CATCH_CONFIG_DISABLE_STRINGIFICATION"
+#endif
+
+#if defined(CATCH_CONFIG_FAST_COMPILE)
+
+///////////////////////////////////////////////////////////////////////////////
+// Another way to speed-up compilation is to omit local try-catch for REQUIRE*
+// macros.
+#define INTERNAL_CATCH_TRY
+#define INTERNAL_CATCH_CATCH( capturer )
+
+#else // CATCH_CONFIG_FAST_COMPILE
+
+#define INTERNAL_CATCH_TRY try
+#define INTERNAL_CATCH_CATCH( handler ) catch(...) { handler.handleUnexpectedInflightException(); }
+
+#endif
+
+#define INTERNAL_CATCH_REACT( handler ) handler.complete();
+
+///////////////////////////////////////////////////////////////////////////////
+#define INTERNAL_CATCH_TEST( macroName, resultDisposition, ... ) \
+    do { \
+        Catch::AssertionHandler catchAssertionHandler( macroName, CATCH_INTERNAL_LINEINFO, CATCH_INTERNAL_STRINGIFY(__VA_ARGS__), resultDisposition ); \
+        INTERNAL_CATCH_TRY { \
+            CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS \
+            catchAssertionHandler.handleExpr( Catch::Decomposer() <= __VA_ARGS__ ); \
+            CATCH_INTERNAL_UNSUPPRESS_PARENTHESES_WARNINGS \
+        } INTERNAL_CATCH_CATCH( catchAssertionHandler ) \
+        INTERNAL_CATCH_REACT( catchAssertionHandler ) \
+    } while( (void)0, false && static_cast<bool>( !!(__VA_ARGS__) ) ) // the expression here is never evaluated at runtime but it forces the compiler to give it a look
+    // The double negation silences MSVC's C4800 warning, the static_cast forces short-circuit evaluation if the type has overloaded &&.
+
+///////////////////////////////////////////////////////////////////////////////
+#define INTERNAL_CATCH_IF( macroName, resultDisposition, ... ) \
+    INTERNAL_CATCH_TEST( macroName, resultDisposition, __VA_ARGS__ ); \
+    if( Catch::getResultCapture().lastAssertionPassed() )
+
+///////////////////////////////////////////////////////////////////////////////
+#define INTERNAL_CATCH_ELSE( macroName, resultDisposition, ... ) \
+    INTERNAL_CATCH_TEST( macroName, resultDisposition, __VA_ARGS__ ); \
+    if( !Catch::getResultCapture().lastAssertionPassed() )
+
+///////////////////////////////////////////////////////////////////////////////
+#define INTERNAL_CATCH_NO_THROW( macroName, resultDisposition, ... ) \
+    do { \
+        Catch::AssertionHandler catchAssertionHandler( macroName, CATCH_INTERNAL_LINEINFO, CATCH_INTERNAL_STRINGIFY(__VA_ARGS__), resultDisposition ); \
+        try { \
+            static_cast<void>(__VA_ARGS__); \
+            catchAssertionHandler.handleExceptionNotThrownAsExpected(); \
+        } \
+        catch( ... ) { \
+            catchAssertionHandler.handleUnexpectedInflightException(); \
+        } \
+        INTERNAL_CATCH_REACT( catchAssertionHandler ) \
+    } while( false )
+
+///////////////////////////////////////////////////////////////////////////////
+#define INTERNAL_CATCH_THROWS( macroName, resultDisposition, ... ) \
+    do { \
+        Catch::AssertionHandler catchAssertionHandler( macroName, CATCH_INTERNAL_LINEINFO, CATCH_INTERNAL_STRINGIFY(__VA_ARGS__), resultDisposition); \
+        if( catchAssertionHandler.allowThrows() ) \
+            try { \
+                static_cast<void>(__VA_ARGS__); \
+                catchAssertionHandler.handleUnexpectedExceptionNotThrown(); \
+            } \
+            catch( ... ) { \
+                catchAssertionHandler.handleExceptionThrownAsExpected(); \
+            } \
+        else \
+            catchAssertionHandler.handleThrowingCallSkipped(); \
+        INTERNAL_CATCH_REACT( catchAssertionHandler ) \
+    } while( false )
+
+///////////////////////////////////////////////////////////////////////////////
+#define INTERNAL_CATCH_THROWS_AS( macroName, exceptionType, resultDisposition, expr ) \
+    do { \
+        Catch::AssertionHandler catchAssertionHandler( macroName, CATCH_INTERNAL_LINEINFO, CATCH_INTERNAL_STRINGIFY(expr) ", " CATCH_INTERNAL_STRINGIFY(exceptionType), resultDisposition ); \
+        if( catchAssertionHandler.allowThrows() ) \
+            try { \
+                static_cast<void>(expr); \
+                catchAssertionHandler.handleUnexpectedExceptionNotThrown(); \
+            } \
+            catch( exceptionType const& ) { \
+                catchAssertionHandler.handleExceptionThrownAsExpected(); \
+            } \
+            catch( ... ) { \
+                catchAssertionHandler.handleUnexpectedInflightException(); \
+            } \
+        else \
+            catchAssertionHandler.handleThrowingCallSkipped(); \
+        INTERNAL_CATCH_REACT( catchAssertionHandler ) \
+    } while( false )
+
+///////////////////////////////////////////////////////////////////////////////
+#define INTERNAL_CATCH_MSG( macroName, messageType, resultDisposition, ... ) \
+    do { \
+        Catch::AssertionHandler catchAssertionHandler( macroName, CATCH_INTERNAL_LINEINFO, "", resultDisposition ); \
+        catchAssertionHandler.handleMessage( messageType, ( Catch::MessageStream() << __VA_ARGS__ + ::Catch::StreamEndStop() ).m_stream.str() ); \
+        INTERNAL_CATCH_REACT( catchAssertionHandler ) \
+    } while( false )
+
+///////////////////////////////////////////////////////////////////////////////
+#define INTERNAL_CATCH_INFO( macroName, log ) \
+    Catch::ScopedMessage INTERNAL_CATCH_UNIQUE_NAME( scopedMessage )( Catch::MessageBuilder( macroName, CATCH_INTERNAL_LINEINFO, Catch::ResultWas::Info ) << log );
+
+///////////////////////////////////////////////////////////////////////////////
+// Although this is matcher-based, it can be used with just a string
+#define INTERNAL_CATCH_THROWS_STR_MATCHES( macroName, resultDisposition, matcher, ... ) \
+    do { \
+        Catch::AssertionHandler catchAssertionHandler( macroName, CATCH_INTERNAL_LINEINFO, CATCH_INTERNAL_STRINGIFY(__VA_ARGS__) ", " CATCH_INTERNAL_STRINGIFY(matcher), resultDisposition ); \
+        if( catchAssertionHandler.allowThrows() ) \
+            try { \
+                static_cast<void>(__VA_ARGS__); \
+                catchAssertionHandler.handleUnexpectedExceptionNotThrown(); \
+            } \
+            catch( ... ) { \
+                Catch::handleExceptionMatchExpr( catchAssertionHandler, matcher, #matcher ); \
+            } \
+        else \
+            catchAssertionHandler.handleThrowingCallSkipped(); \
+        INTERNAL_CATCH_REACT( catchAssertionHandler ) \
+    } while( false )
+
+#endif // CATCH_CONFIG_DISABLE
+
+// end catch_capture.hpp
+// start catch_section.h
+
+// start catch_section_info.h
+
+// start catch_totals.h
+
+#include <cstddef>
+
+namespace Catch {
+
+    struct Counts {
+        Counts operator - ( Counts const& other ) const;
+        Counts& operator += ( Counts const& other );
+
+        std::size_t total() const;
+        bool allPassed() const;
+        bool allOk() const;
+
+        std::size_t passed = 0;
+        std::size_t failed = 0;
+        std::size_t failedButOk = 0;
+    };
+
+    struct Totals {
+
+        Totals operator - ( Totals const& other ) const;
+        Totals& operator += ( Totals const& other );
+
+        Totals delta( Totals const& prevTotals ) const;
+
+        int error = 0;
+        Counts assertions;
+        Counts testCases;
+    };
+}
+
+// end catch_totals.h
+#include <string>
+
+namespace Catch {
+
+    struct SectionInfo {
+        SectionInfo
+            (   SourceLineInfo const& _lineInfo,
+                std::string const& _name,
+                std::string const& _description = std::string() );
+
+        std::string name;
+        std::string description;
+        SourceLineInfo lineInfo;
+    };
+
+    struct SectionEndInfo {
+        SectionEndInfo( SectionInfo const& _sectionInfo, Counts const& _prevAssertions, double _durationInSeconds );
+
+        SectionInfo sectionInfo;
+        Counts prevAssertions;
+        double durationInSeconds;
+    };
+
+} // end namespace Catch
+
+// end catch_section_info.h
+// start catch_timer.h
+
+#include <cstdint>
+
+namespace Catch {
+
+    auto getCurrentNanosecondsSinceEpoch() -> uint64_t;
+    auto getEstimatedClockResolution() -> uint64_t;
+
+    class Timer {
+        uint64_t m_nanoseconds = 0;
+    public:
+        void start();
+        auto getElapsedNanoseconds() const -> uint64_t;
+        auto getElapsedMicroseconds() const -> uint64_t;
+        auto getElapsedMilliseconds() const -> unsigned int;
+        auto getElapsedSeconds() const -> double;
+    };
+
+} // namespace Catch
+
+// end catch_timer.h
+#include <string>
+
+namespace Catch {
+
+    class Section : NonCopyable {
+    public:
+        Section( SectionInfo const& info );
+        ~Section();
+
+        // This indicates whether the section should be executed or not
+        explicit operator bool() const;
+
+    private:
+        SectionInfo m_info;
+
+        std::string m_name;
+        Counts m_assertions;
+        bool m_sectionIncluded;
+        Timer m_timer;
+    };
+
+} // end namespace Catch
+
+    #define INTERNAL_CATCH_SECTION( ... ) \
+        if( Catch::Section const& INTERNAL_CATCH_UNIQUE_NAME( catch_internal_Section ) = Catch::SectionInfo( CATCH_INTERNAL_LINEINFO, __VA_ARGS__ ) )
+
+// end catch_section.h
+// start catch_benchmark.h
+
+#include <cstdint>
+#include <string>
+
+namespace Catch {
+
+    class BenchmarkLooper {
+
+        std::string m_name;
+        std::size_t m_count = 0;
+        std::size_t m_iterationsToRun = 1;
+        uint64_t m_resolution;
+        Timer m_timer;
+
+        static auto getResolution() -> uint64_t;
+    public:
+        // Keep most of this inline as it's on the code path that is being timed
+        BenchmarkLooper( StringRef name )
+        :   m_name( name ),
+            m_resolution( getResolution() )
+        {
+            reportStart();
+            m_timer.start();
+        }
+
+        explicit operator bool() {
+            if( m_count < m_iterationsToRun )
+                return true;
+            return needsMoreIterations();
+        }
+
+        void increment() {
+            ++m_count;
+        }
+
+        void reportStart();
+        auto needsMoreIterations() -> bool;
+    };
+
+} // end namespace Catch
+
+#define BENCHMARK( name ) \
+    for( Catch::BenchmarkLooper looper( name ); looper; looper.increment() )
+
+// end catch_benchmark.h
+// start catch_interfaces_exception.h
+
+// start catch_interfaces_registry_hub.h
+
+#include <string>
+#include <memory>
+
+namespace Catch {
+
+    class TestCase;
+    struct ITestCaseRegistry;
+    struct IExceptionTranslatorRegistry;
+    struct IExceptionTranslator;
+    struct IReporterRegistry;
+    struct IReporterFactory;
+    struct ITagAliasRegistry;
+    class StartupExceptionRegistry;
+
+    using IReporterFactoryPtr = std::shared_ptr<IReporterFactory>;
+
+    struct IRegistryHub {
+        virtual ~IRegistryHub();
+
+        virtual IReporterRegistry const& getReporterRegistry() const = 0;
+        virtual ITestCaseRegistry const& getTestCaseRegistry() const = 0;
+        virtual ITagAliasRegistry const& getTagAliasRegistry() const = 0;
+
+        virtual IExceptionTranslatorRegistry& getExceptionTranslatorRegistry() = 0;
+
+        virtual StartupExceptionRegistry const& getStartupExceptionRegistry() const = 0;
+    };
+
+    struct IMutableRegistryHub {
+        virtual ~IMutableRegistryHub();
+        virtual void registerReporter( std::string const& name, IReporterFactoryPtr const& factory ) = 0;
+        virtual void registerListener( IReporterFactoryPtr const& factory ) = 0;
+        virtual void registerTest( TestCase const& testInfo ) = 0;
+        virtual void registerTranslator( const IExceptionTranslator* translator ) = 0;
+        virtual void registerTagAlias( std::string const& alias, std::string const& tag, SourceLineInfo const& lineInfo ) = 0;
+        virtual void registerStartupException() noexcept = 0;
+    };
+
+    IRegistryHub& getRegistryHub();
+    IMutableRegistryHub& getMutableRegistryHub();
+    void cleanUp();
+    std::string translateActiveException();
+
+}
+
+// end catch_interfaces_registry_hub.h
+#if defined(CATCH_CONFIG_DISABLE)
+    #define INTERNAL_CATCH_TRANSLATE_EXCEPTION_NO_REG( translatorName, signature) \
+        static std::string translatorName( signature )
+#endif
+
+#include <exception>
+#include <string>
+#include <vector>
+
+namespace Catch {
+    using exceptionTranslateFunction = std::string(*)();
+
+    struct IExceptionTranslator;
+    using ExceptionTranslators = std::vector<std::unique_ptr<IExceptionTranslator const>>;
+
+    struct IExceptionTranslator {
+        virtual ~IExceptionTranslator();
+        virtual std::string translate( ExceptionTranslators::const_iterator it, ExceptionTranslators::const_iterator itEnd ) const = 0;
+    };
+
+    struct IExceptionTranslatorRegistry {
+        virtual ~IExceptionTranslatorRegistry();
+
+        virtual std::string translateActiveException() const = 0;
+    };
+
+    class ExceptionTranslatorRegistrar {
+        template<typename T>
+        class ExceptionTranslator : public IExceptionTranslator {
+        public:
+
+            ExceptionTranslator( std::string(*translateFunction)( T& ) )
+            : m_translateFunction( translateFunction )
+            {}
+
+            std::string translate( ExceptionTranslators::const_iterator it, ExceptionTranslators::const_iterator itEnd ) const override {
+                try {
+                    if( it == itEnd )
+                        std::rethrow_exception(std::current_exception());
+                    else
+                        return (*it)->translate( it+1, itEnd );
+                }
+                catch( T& ex ) {
+                    return m_translateFunction( ex );
+                }
+            }
+
+        protected:
+            std::string(*m_translateFunction)( T& );
+        };
+
+    public:
+        template<typename T>
+        ExceptionTranslatorRegistrar( std::string(*translateFunction)( T& ) ) {
+            getMutableRegistryHub().registerTranslator
+                ( new ExceptionTranslator<T>( translateFunction ) );
+        }
+    };
+}
+
+///////////////////////////////////////////////////////////////////////////////
+#define INTERNAL_CATCH_TRANSLATE_EXCEPTION2( translatorName, signature ) \
+    static std::string translatorName( signature ); \
+    CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \
+    namespace{ Catch::ExceptionTranslatorRegistrar INTERNAL_CATCH_UNIQUE_NAME( catch_internal_ExceptionRegistrar )( &translatorName ); } \
+    CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS \
+    static std::string translatorName( signature )
+
+#define INTERNAL_CATCH_TRANSLATE_EXCEPTION( signature ) INTERNAL_CATCH_TRANSLATE_EXCEPTION2( INTERNAL_CATCH_UNIQUE_NAME( catch_internal_ExceptionTranslator ), signature )
+
+// end catch_interfaces_exception.h
+// start catch_approx.h
+
+#include <type_traits>
+#include <stdexcept>
+
+namespace Catch {
+namespace Detail {
+
+    class Approx {
+    private:
+        bool equalityComparisonImpl(double other) const;
+
+    public:
+        explicit Approx ( double value );
+
+        static Approx custom();
+
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        Approx operator()( T const& value ) {
+            Approx approx( static_cast<double>(value) );
+            approx.epsilon( m_epsilon );
+            approx.margin( m_margin );
+            approx.scale( m_scale );
+            return approx;
+        }
+
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        explicit Approx( T const& value ): Approx(static_cast<double>(value))
+        {}
+
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        friend bool operator == ( const T& lhs, Approx const& rhs ) {
+            auto lhs_v = static_cast<double>(lhs);
+            return rhs.equalityComparisonImpl(lhs_v);
+        }
+
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        friend bool operator == ( Approx const& lhs, const T& rhs ) {
+            return operator==( rhs, lhs );
+        }
+
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        friend bool operator != ( T const& lhs, Approx const& rhs ) {
+            return !operator==( lhs, rhs );
+        }
+
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        friend bool operator != ( Approx const& lhs, T const& rhs ) {
+            return !operator==( rhs, lhs );
+        }
+
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        friend bool operator <= ( T const& lhs, Approx const& rhs ) {
+            return static_cast<double>(lhs) < rhs.m_value || lhs == rhs;
+        }
+
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        friend bool operator <= ( Approx const& lhs, T const& rhs ) {
+            return lhs.m_value < static_cast<double>(rhs) || lhs == rhs;
+        }
+
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        friend bool operator >= ( T const& lhs, Approx const& rhs ) {
+            return static_cast<double>(lhs) > rhs.m_value || lhs == rhs;
+        }
+
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        friend bool operator >= ( Approx const& lhs, T const& rhs ) {
+            return lhs.m_value > static_cast<double>(rhs) || lhs == rhs;
+        }
+
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        Approx& epsilon( T const& newEpsilon ) {
+            double epsilonAsDouble = static_cast<double>(newEpsilon);
+            if( epsilonAsDouble < 0 || epsilonAsDouble > 1.0 ) {
+                throw std::domain_error
+                    (   "Invalid Approx::epsilon: " +
+                        Catch::Detail::stringify( epsilonAsDouble ) +
+                        ", Approx::epsilon has to be between 0 and 1" );
+            }
+            m_epsilon = epsilonAsDouble;
+            return *this;
+        }
+
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        Approx& margin( T const& newMargin ) {
+            double marginAsDouble = static_cast<double>(newMargin);
+            if( marginAsDouble < 0 ) {
+                throw std::domain_error
+                    (   "Invalid Approx::margin: " +
+                         Catch::Detail::stringify( marginAsDouble ) +
+                         ", Approx::Margin has to be non-negative." );
+
+            }
+            m_margin = marginAsDouble;
+            return *this;
+        }
+
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        Approx& scale( T const& newScale ) {
+            m_scale = static_cast<double>(newScale);
+            return *this;
+        }
+
+        std::string toString() const;
+
+    private:
+        double m_epsilon;
+        double m_margin;
+        double m_scale;
+        double m_value;
+    };
+}
+
+template<>
+struct StringMaker<Catch::Detail::Approx> {
+    static std::string convert(Catch::Detail::Approx const& value);
+};
+
+} // end namespace Catch
+
+// end catch_approx.h
+// start catch_string_manip.h
+
+#include <string>
+#include <iosfwd>
+
+namespace Catch {
+
+    bool startsWith( std::string const& s, std::string const& prefix );
+    bool startsWith( std::string const& s, char prefix );
+    bool endsWith( std::string const& s, std::string const& suffix );
+    bool endsWith( std::string const& s, char suffix );
+    bool contains( std::string const& s, std::string const& infix );
+    void toLowerInPlace( std::string& s );
+    std::string toLower( std::string const& s );
+    std::string trim( std::string const& str );
+    bool replaceInPlace( std::string& str, std::string const& replaceThis, std::string const& withThis );
+
+    struct pluralise {
+        pluralise( std::size_t count, std::string const& label );
+
+        friend std::ostream& operator << ( std::ostream& os, pluralise const& pluraliser );
+
+        std::size_t m_count;
+        std::string m_label;
+    };
+}
+
+// end catch_string_manip.h
+#ifndef CATCH_CONFIG_DISABLE_MATCHERS
+// start catch_capture_matchers.h
+
+// start catch_matchers.h
+
+#include <string>
+#include <vector>
+
+namespace Catch {
+namespace Matchers {
+    namespace Impl {
+
+        template<typename ArgT> struct MatchAllOf;
+        template<typename ArgT> struct MatchAnyOf;
+        template<typename ArgT> struct MatchNotOf;
+
+        class MatcherUntypedBase {
+        public:
+            MatcherUntypedBase() = default;
+            MatcherUntypedBase ( MatcherUntypedBase const& ) = default;
+            MatcherUntypedBase& operator = ( MatcherUntypedBase const& ) = delete;
+            std::string toString() const;
+
+        protected:
+            virtual ~MatcherUntypedBase();
+            virtual std::string describe() const = 0;
+            mutable std::string m_cachedToString;
+        };
+
+        template<typename ObjectT>
+        struct MatcherMethod {
+            virtual bool match( ObjectT const& arg ) const = 0;
+        };
+        template<typename PtrT>
+        struct MatcherMethod<PtrT*> {
+            virtual bool match( PtrT* arg ) const = 0;
+        };
+
+        template<typename T>
+        struct MatcherBase : MatcherUntypedBase, MatcherMethod<T> {
+
+            MatchAllOf<T> operator && ( MatcherBase const& other ) const;
+            MatchAnyOf<T> operator || ( MatcherBase const& other ) const;
+            MatchNotOf<T> operator ! () const;
+        };
+
+        template<typename ArgT>
+        struct MatchAllOf : MatcherBase<ArgT> {
+            bool match( ArgT const& arg ) const override {
+                for( auto matcher : m_matchers ) {
+                    if (!matcher->match(arg))
+                        return false;
+                }
+                return true;
+            }
+            std::string describe() const override {
+                std::string description;
+                description.reserve( 4 + m_matchers.size()*32 );
+                description += "( ";
+                bool first = true;
+                for( auto matcher : m_matchers ) {
+                    if( first )
+                        first = false;
+                    else
+                        description += " and ";
+                    description += matcher->toString();
+                }
+                description += " )";
+                return description;
+            }
+
+            MatchAllOf<ArgT>& operator && ( MatcherBase<ArgT> const& other ) {
+                m_matchers.push_back( &other );
+                return *this;
+            }
+
+            std::vector<MatcherBase<ArgT> const*> m_matchers;
+        };
+        template<typename ArgT>
+        struct MatchAnyOf : MatcherBase<ArgT> {
+
+            bool match( ArgT const& arg ) const override {
+                for( auto matcher : m_matchers ) {
+                    if (matcher->match(arg))
+                        return true;
+                }
+                return false;
+            }
+            std::string describe() const override {
+                std::string description;
+                description.reserve( 4 + m_matchers.size()*32 );
+                description += "( ";
+                bool first = true;
+                for( auto matcher : m_matchers ) {
+                    if( first )
+                        first = false;
+                    else
+                        description += " or ";
+                    description += matcher->toString();
+                }
+                description += " )";
+                return description;
+            }
+
+            MatchAnyOf<ArgT>& operator || ( MatcherBase<ArgT> const& other ) {
+                m_matchers.push_back( &other );
+                return *this;
+            }
+
+            std::vector<MatcherBase<ArgT> const*> m_matchers;
+        };
+
+        template<typename ArgT>
+        struct MatchNotOf : MatcherBase<ArgT> {
+
+            MatchNotOf( MatcherBase<ArgT> const& underlyingMatcher ) : m_underlyingMatcher( underlyingMatcher ) {}
+
+            bool match( ArgT const& arg ) const override {
+                return !m_underlyingMatcher.match( arg );
+            }
+
+            std::string describe() const override {
+                return "not " + m_underlyingMatcher.toString();
+            }
+            MatcherBase<ArgT> const& m_underlyingMatcher;
+        };
+
+        template<typename T>
+        MatchAllOf<T> MatcherBase<T>::operator && ( MatcherBase const& other ) const {
+            return MatchAllOf<T>() && *this && other;
+        }
+        template<typename T>
+        MatchAnyOf<T> MatcherBase<T>::operator || ( MatcherBase const& other ) const {
+            return MatchAnyOf<T>() || *this || other;
+        }
+        template<typename T>
+        MatchNotOf<T> MatcherBase<T>::operator ! () const {
+            return MatchNotOf<T>( *this );
+        }
+
+    } // namespace Impl
+
+} // namespace Matchers
+
+using namespace Matchers;
+using Matchers::Impl::MatcherBase;
+
+} // namespace Catch
+
+// end catch_matchers.h
+// start catch_matchers_floating.h
+
+#include <type_traits>
+#include <cmath>
+
+namespace Catch {
+namespace Matchers {
+
+    namespace Floating {
+
+        enum class FloatingPointKind : uint8_t;
+
+        struct WithinAbsMatcher : MatcherBase<double> {
+            WithinAbsMatcher(double target, double margin);
+            bool match(double const& matchee) const override;
+            std::string describe() const override;
+        private:
+            double m_target;
+            double m_margin;
+        };
+
+        struct WithinUlpsMatcher : MatcherBase<double> {
+            WithinUlpsMatcher(double target, int ulps, FloatingPointKind baseType);
+            bool match(double const& matchee) const override;
+            std::string describe() const override;
+        private:
+            double m_target;
+            int m_ulps;
+            FloatingPointKind m_type;
+        };
+
+    } // namespace Floating
+
+    // The following functions create the actual matcher objects.
+    // This allows the types to be inferred
+    Floating::WithinUlpsMatcher WithinULP(double target, int maxUlpDiff);
+    Floating::WithinUlpsMatcher WithinULP(float target, int maxUlpDiff);
+    Floating::WithinAbsMatcher WithinAbs(double target, double margin);
+
+} // namespace Matchers
+} // namespace Catch
+
+// end catch_matchers_floating.h
+// start catch_matchers_generic.hpp
+
+#include <functional>
+#include <string>
+
+namespace Catch {
+namespace Matchers {
+namespace Generic {
+
+namespace Detail {
+    std::string finalizeDescription(const std::string& desc);
+}
+
+template <typename T>
+class PredicateMatcher : public MatcherBase<T> {
+    std::function<bool(T const&)> m_predicate;
+    std::string m_description;
+public:
+
+    PredicateMatcher(std::function<bool(T const&)> const& elem, std::string const& descr)
+        :m_predicate(std::move(elem)),
+        m_description(Detail::finalizeDescription(descr))
+    {}
+
+    bool match( T const& item ) const override {
+        return m_predicate(item);
+    }
+
+    std::string describe() const override {
+        return m_description;
+    }
+};
+
+} // namespace Generic
+
+    // The following functions create the actual matcher objects.
+    // The user has to explicitly specify type to the function, because
+    // infering std::function<bool(T const&)> is hard (but possible) and
+    // requires a lot of TMP.
+    template<typename T>
+    Generic::PredicateMatcher<T> Predicate(std::function<bool(T const&)> const& predicate, std::string const& description = "") {
+        return Generic::PredicateMatcher<T>(predicate, description);
+    }
+
+} // namespace Matchers
+} // namespace Catch
+
+// end catch_matchers_generic.hpp
+// start catch_matchers_string.h
+
+#include <string>
+
+namespace Catch {
+namespace Matchers {
+
+    namespace StdString {
+
+        struct CasedString
+        {
+            CasedString( std::string const& str, CaseSensitive::Choice caseSensitivity );
+            std::string adjustString( std::string const& str ) const;
+            std::string caseSensitivitySuffix() const;
+
+            CaseSensitive::Choice m_caseSensitivity;
+            std::string m_str;
+        };
+
+        struct StringMatcherBase : MatcherBase<std::string> {
+            StringMatcherBase( std::string const& operation, CasedString const& comparator );
+            std::string describe() const override;
+
+            CasedString m_comparator;
+            std::string m_operation;
+        };
+
+        struct EqualsMatcher : StringMatcherBase {
+            EqualsMatcher( CasedString const& comparator );
+            bool match( std::string const& source ) const override;
+        };
+        struct ContainsMatcher : StringMatcherBase {
+            ContainsMatcher( CasedString const& comparator );
+            bool match( std::string const& source ) const override;
+        };
+        struct StartsWithMatcher : StringMatcherBase {
+            StartsWithMatcher( CasedString const& comparator );
+            bool match( std::string const& source ) const override;
+        };
+        struct EndsWithMatcher : StringMatcherBase {
+            EndsWithMatcher( CasedString const& comparator );
+            bool match( std::string const& source ) const override;
+        };
+
+        struct RegexMatcher : MatcherBase<std::string> {
+            RegexMatcher( std::string regex, CaseSensitive::Choice caseSensitivity );
+            bool match( std::string const& matchee ) const override;
+            std::string describe() const override;
+
+        private:
+            std::string m_regex;
+            CaseSensitive::Choice m_caseSensitivity;
+        };
+
+    } // namespace StdString
+
+    // The following functions create the actual matcher objects.
+    // This allows the types to be inferred
+
+    StdString::EqualsMatcher Equals( std::string const& str, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes );
+    StdString::ContainsMatcher Contains( std::string const& str, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes );
+    StdString::EndsWithMatcher EndsWith( std::string const& str, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes );
+    StdString::StartsWithMatcher StartsWith( std::string const& str, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes );
+    StdString::RegexMatcher Matches( std::string const& regex, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes );
+
+} // namespace Matchers
+} // namespace Catch
+
+// end catch_matchers_string.h
+// start catch_matchers_vector.h
+
+#include <algorithm>
+
+namespace Catch {
+namespace Matchers {
+
+    namespace Vector {
+        namespace Detail {
+            template <typename InputIterator, typename T>
+            size_t count(InputIterator first, InputIterator last, T const& item) {
+                size_t cnt = 0;
+                for (; first != last; ++first) {
+                    if (*first == item) {
+                        ++cnt;
+                    }
+                }
+                return cnt;
+            }
+            template <typename InputIterator, typename T>
+            bool contains(InputIterator first, InputIterator last, T const& item) {
+                for (; first != last; ++first) {
+                    if (*first == item) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+
+        template<typename T>
+        struct ContainsElementMatcher : MatcherBase<std::vector<T>> {
+
+            ContainsElementMatcher(T const &comparator) : m_comparator( comparator) {}
+
+            bool match(std::vector<T> const &v) const override {
+                for (auto const& el : v) {
+                    if (el == m_comparator) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            std::string describe() const override {
+                return "Contains: " + ::Catch::Detail::stringify( m_comparator );
+            }
+
+            T const& m_comparator;
+        };
+
+        template<typename T>
+        struct ContainsMatcher : MatcherBase<std::vector<T>> {
+
+            ContainsMatcher(std::vector<T> const &comparator) : m_comparator( comparator ) {}
+
+            bool match(std::vector<T> const &v) const override {
+                // !TBD: see note in EqualsMatcher
+                if (m_comparator.size() > v.size())
+                    return false;
+                for (auto const& comparator : m_comparator) {
+                    auto present = false;
+                    for (const auto& el : v) {
+                        if (el == comparator) {
+                            present = true;
+                            break;
+                        }
+                    }
+                    if (!present) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            std::string describe() const override {
+                return "Contains: " + ::Catch::Detail::stringify( m_comparator );
+            }
+
+            std::vector<T> const& m_comparator;
+        };
+
+        template<typename T>
+        struct EqualsMatcher : MatcherBase<std::vector<T>> {
+
+            EqualsMatcher(std::vector<T> const &comparator) : m_comparator( comparator ) {}
+
+            bool match(std::vector<T> const &v) const override {
+                // !TBD: This currently works if all elements can be compared using !=
+                // - a more general approach would be via a compare template that defaults
+                // to using !=. but could be specialised for, e.g. std::vector<T> etc
+                // - then just call that directly
+                if (m_comparator.size() != v.size())
+                    return false;
+                for (std::size_t i = 0; i < v.size(); ++i)
+                    if (m_comparator[i] != v[i])
+                        return false;
+                return true;
+            }
+            std::string describe() const override {
+                return "Equals: " + ::Catch::Detail::stringify( m_comparator );
+            }
+            std::vector<T> const& m_comparator;
+        };
+
+        template<typename T>
+        struct UnorderedEqualsMatcher : MatcherBase<std::vector<T>> {
+            UnorderedEqualsMatcher(std::vector<T> const& target) : m_target(target) {}
+            bool match(std::vector<T> const& vec) const override {
+                // Note: This is a reimplementation of std::is_permutation,
+                //       because I don't want to include <algorithm> inside the common path
+                if (m_target.size() != vec.size()) {
+                    return false;
+                }
+                auto lfirst = m_target.begin(), llast = m_target.end();
+                auto rfirst = vec.begin(), rlast = vec.end();
+                // Cut common prefix to optimize checking of permuted parts
+                while (lfirst != llast && *lfirst != *rfirst) {
+                    ++lfirst; ++rfirst;
+                }
+                if (lfirst == llast) {
+                    return true;
+                }
+
+                for (auto mid = lfirst; mid != llast; ++mid) {
+                    // Skip already counted items
+                    if (Detail::contains(lfirst, mid, *mid)) {
+                        continue;
+                    }
+                    size_t num_vec = Detail::count(rfirst, rlast, *mid);
+                    if (num_vec == 0 || Detail::count(lfirst, llast, *mid) != num_vec) {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            std::string describe() const override {
+                return "UnorderedEquals: " + ::Catch::Detail::stringify(m_target);
+            }
+        private:
+            std::vector<T> const& m_target;
+        };
+
+    } // namespace Vector
+
+    // The following functions create the actual matcher objects.
+    // This allows the types to be inferred
+
+    template<typename T>
+    Vector::ContainsMatcher<T> Contains( std::vector<T> const& comparator ) {
+        return Vector::ContainsMatcher<T>( comparator );
+    }
+
+    template<typename T>
+    Vector::ContainsElementMatcher<T> VectorContains( T const& comparator ) {
+        return Vector::ContainsElementMatcher<T>( comparator );
+    }
+
+    template<typename T>
+    Vector::EqualsMatcher<T> Equals( std::vector<T> const& comparator ) {
+        return Vector::EqualsMatcher<T>( comparator );
+    }
+
+    template<typename T>
+    Vector::UnorderedEqualsMatcher<T> UnorderedEquals(std::vector<T> const& target) {
+        return Vector::UnorderedEqualsMatcher<T>(target);
+    }
+
+} // namespace Matchers
+} // namespace Catch
+
+// end catch_matchers_vector.h
+namespace Catch {
+
+    template<typename ArgT, typename MatcherT>
+    class MatchExpr : public ITransientExpression {
+        ArgT const& m_arg;
+        MatcherT m_matcher;
+        StringRef m_matcherString;
+    public:
+        MatchExpr( ArgT const& arg, MatcherT const& matcher, StringRef matcherString )
+        :   ITransientExpression{ true, matcher.match( arg ) },
+            m_arg( arg ),
+            m_matcher( matcher ),
+            m_matcherString( matcherString )
+        {}
+
+        void streamReconstructedExpression( std::ostream &os ) const override {
+            auto matcherAsString = m_matcher.toString();
+            os << Catch::Detail::stringify( m_arg ) << ' ';
+            if( matcherAsString == Detail::unprintableString )
+                os << m_matcherString;
+            else
+                os << matcherAsString;
+        }
+    };
+
+    using StringMatcher = Matchers::Impl::MatcherBase<std::string>;
+
+    void handleExceptionMatchExpr( AssertionHandler& handler, StringMatcher const& matcher, StringRef matcherString  );
+
+    template<typename ArgT, typename MatcherT>
+    auto makeMatchExpr( ArgT const& arg, MatcherT const& matcher, StringRef matcherString  ) -> MatchExpr<ArgT, MatcherT> {
+        return MatchExpr<ArgT, MatcherT>( arg, matcher, matcherString );
+    }
+
+} // namespace Catch
+
+///////////////////////////////////////////////////////////////////////////////
+#define INTERNAL_CHECK_THAT( macroName, matcher, resultDisposition, arg ) \
+    do { \
+        Catch::AssertionHandler catchAssertionHandler( macroName, CATCH_INTERNAL_LINEINFO, CATCH_INTERNAL_STRINGIFY(arg) ", " CATCH_INTERNAL_STRINGIFY(matcher), resultDisposition ); \
+        INTERNAL_CATCH_TRY { \
+            catchAssertionHandler.handleExpr( Catch::makeMatchExpr( arg, matcher, #matcher ) ); \
+        } INTERNAL_CATCH_CATCH( catchAssertionHandler ) \
+        INTERNAL_CATCH_REACT( catchAssertionHandler ) \
+    } while( false )
+
+///////////////////////////////////////////////////////////////////////////////
+#define INTERNAL_CATCH_THROWS_MATCHES( macroName, exceptionType, resultDisposition, matcher, ... ) \
+    do { \
+        Catch::AssertionHandler catchAssertionHandler( macroName, CATCH_INTERNAL_LINEINFO, CATCH_INTERNAL_STRINGIFY(__VA_ARGS__) ", " CATCH_INTERNAL_STRINGIFY(exceptionType) ", " CATCH_INTERNAL_STRINGIFY(matcher), resultDisposition ); \
+        if( catchAssertionHandler.allowThrows() ) \
+            try { \
+                static_cast<void>(__VA_ARGS__ ); \
+                catchAssertionHandler.handleUnexpectedExceptionNotThrown(); \
+            } \
+            catch( exceptionType const& ex ) { \
+                catchAssertionHandler.handleExpr( Catch::makeMatchExpr( ex, matcher, #matcher ) ); \
+            } \
+            catch( ... ) { \
+                catchAssertionHandler.handleUnexpectedInflightException(); \
+            } \
+        else \
+            catchAssertionHandler.handleThrowingCallSkipped(); \
+        INTERNAL_CATCH_REACT( catchAssertionHandler ) \
+    } while( false )
+
+// end catch_capture_matchers.h
+#endif
+
+// These files are included here so the single_include script doesn't put them
+// in the conditionally compiled sections
+// start catch_test_case_info.h
+
+#include <string>
+#include <vector>
+#include <memory>
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpadded"
+#endif
+
+namespace Catch {
+
+    struct ITestInvoker;
+
+    struct TestCaseInfo {
+        enum SpecialProperties{
+            None = 0,
+            IsHidden = 1 << 1,
+            ShouldFail = 1 << 2,
+            MayFail = 1 << 3,
+            Throws = 1 << 4,
+            NonPortable = 1 << 5,
+            Benchmark = 1 << 6
+        };
+
+        TestCaseInfo(   std::string const& _name,
+                        std::string const& _className,
+                        std::string const& _description,
+                        std::vector<std::string> const& _tags,
+                        SourceLineInfo const& _lineInfo );
+
+        friend void setTags( TestCaseInfo& testCaseInfo, std::vector<std::string> tags );
+
+        bool isHidden() const;
+        bool throws() const;
+        bool okToFail() const;
+        bool expectedToFail() const;
+
+        std::string tagsAsString() const;
+
+        std::string name;
+        std::string className;
+        std::string description;
+        std::vector<std::string> tags;
+        std::vector<std::string> lcaseTags;
+        SourceLineInfo lineInfo;
+        SpecialProperties properties;
+    };
+
+    class TestCase : public TestCaseInfo {
+    public:
+
+        TestCase( ITestInvoker* testCase, TestCaseInfo&& info );
+
+        TestCase withName( std::string const& _newName ) const;
+
+        void invoke() const;
+
+        TestCaseInfo const& getTestCaseInfo() const;
+
+        bool operator == ( TestCase const& other ) const;
+        bool operator < ( TestCase const& other ) const;
+
+    private:
+        std::shared_ptr<ITestInvoker> test;
+    };
+
+    TestCase makeTestCase(  ITestInvoker* testCase,
+                            std::string const& className,
+                            NameAndTags const& nameAndTags,
+                            SourceLineInfo const& lineInfo );
+}
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+// end catch_test_case_info.h
+// start catch_interfaces_runner.h
+
+namespace Catch {
+
+    struct IRunner {
+        virtual ~IRunner();
+        virtual bool aborting() const = 0;
+    };
+}
+
+// end catch_interfaces_runner.h
+
+#ifdef __OBJC__
+// start catch_objc.hpp
+
+#import <objc/runtime.h>
+
+#include <string>
+
+// NB. Any general catch headers included here must be included
+// in catch.hpp first to make sure they are included by the single
+// header for non obj-usage
+
+///////////////////////////////////////////////////////////////////////////////
+// This protocol is really only here for (self) documenting purposes, since
+// all its methods are optional.
+@protocol OcFixture
+
+@optional
+
+-(void) setUp;
+-(void) tearDown;
+
+@end
+
+namespace Catch {
+
+    class OcMethod : public ITestInvoker {
+
+    public:
+        OcMethod( Class cls, SEL sel ) : m_cls( cls ), m_sel( sel ) {}
+
+        virtual void invoke() const {
+            id obj = [[m_cls alloc] init];
+
+            performOptionalSelector( obj, @selector(setUp)  );
+            performOptionalSelector( obj, m_sel );
+            performOptionalSelector( obj, @selector(tearDown)  );
+
+            arcSafeRelease( obj );
+        }
+    private:
+        virtual ~OcMethod() {}
+
+        Class m_cls;
+        SEL m_sel;
+    };
+
+    namespace Detail{
+
+        inline std::string getAnnotation(   Class cls,
+                                            std::string const& annotationName,
+                                            std::string const& testCaseName ) {
+            NSString* selStr = [[NSString alloc] initWithFormat:@"Catch_%s_%s", annotationName.c_str(), testCaseName.c_str()];
+            SEL sel = NSSelectorFromString( selStr );
+            arcSafeRelease( selStr );
+            id value = performOptionalSelector( cls, sel );
+            if( value )
+                return [(NSString*)value UTF8String];
+            return "";
+        }
+    }
+
+    inline std::size_t registerTestMethods() {
+        std::size_t noTestMethods = 0;
+        int noClasses = objc_getClassList( nullptr, 0 );
+
+        Class* classes = (CATCH_UNSAFE_UNRETAINED Class *)malloc( sizeof(Class) * noClasses);
+        objc_getClassList( classes, noClasses );
+
+        for( int c = 0; c < noClasses; c++ ) {
+            Class cls = classes[c];
+            {
+                u_int count;
+                Method* methods = class_copyMethodList( cls, &count );
+                for( u_int m = 0; m < count ; m++ ) {
+                    SEL selector = method_getName(methods[m]);
+                    std::string methodName = sel_getName(selector);
+                    if( startsWith( methodName, "Catch_TestCase_" ) ) {
+                        std::string testCaseName = methodName.substr( 15 );
+                        std::string name = Detail::getAnnotation( cls, "Name", testCaseName );
+                        std::string desc = Detail::getAnnotation( cls, "Description", testCaseName );
+                        const char* className = class_getName( cls );
+
+                        getMutableRegistryHub().registerTest( makeTestCase( new OcMethod( cls, selector ), className, name.c_str(), desc.c_str(), SourceLineInfo("",0) ) );
+                        noTestMethods++;
+                    }
+                }
+                free(methods);
+            }
+        }
+        return noTestMethods;
+    }
+
+#if !defined(CATCH_CONFIG_DISABLE_MATCHERS)
+
+    namespace Matchers {
+        namespace Impl {
+        namespace NSStringMatchers {
+
+            struct StringHolder : MatcherBase<NSString*>{
+                StringHolder( NSString* substr ) : m_substr( [substr copy] ){}
+                StringHolder( StringHolder const& other ) : m_substr( [other.m_substr copy] ){}
+                StringHolder() {
+                    arcSafeRelease( m_substr );
+                }
+
+                bool match( NSString* arg ) const override {
+                    return false;
+                }
+
+                NSString* CATCH_ARC_STRONG m_substr;
+            };
+
+            struct Equals : StringHolder {
+                Equals( NSString* substr ) : StringHolder( substr ){}
+
+                bool match( NSString* str ) const override {
+                    return  (str != nil || m_substr == nil ) &&
+                            [str isEqualToString:m_substr];
+                }
+
+                std::string describe() const override {
+                    return "equals string: " + Catch::Detail::stringify( m_substr );
+                }
+            };
+
+            struct Contains : StringHolder {
+                Contains( NSString* substr ) : StringHolder( substr ){}
+
+                bool match( NSString* str ) const {
+                    return  (str != nil || m_substr == nil ) &&
+                            [str rangeOfString:m_substr].location != NSNotFound;
+                }
+
+                std::string describe() const override {
+                    return "contains string: " + Catch::Detail::stringify( m_substr );
+                }
+            };
+
+            struct StartsWith : StringHolder {
+                StartsWith( NSString* substr ) : StringHolder( substr ){}
+
+                bool match( NSString* str ) const override {
+                    return  (str != nil || m_substr == nil ) &&
+                            [str rangeOfString:m_substr].location == 0;
+                }
+
+                std::string describe() const override {
+                    return "starts with: " + Catch::Detail::stringify( m_substr );
+                }
+            };
+            struct EndsWith : StringHolder {
+                EndsWith( NSString* substr ) : StringHolder( substr ){}
+
+                bool match( NSString* str ) const override {
+                    return  (str != nil || m_substr == nil ) &&
+                            [str rangeOfString:m_substr].location == [str length] - [m_substr length];
+                }
+
+                std::string describe() const override {
+                    return "ends with: " + Catch::Detail::stringify( m_substr );
+                }
+            };
+
+        } // namespace NSStringMatchers
+        } // namespace Impl
+
+        inline Impl::NSStringMatchers::Equals
+            Equals( NSString* substr ){ return Impl::NSStringMatchers::Equals( substr ); }
+
+        inline Impl::NSStringMatchers::Contains
+            Contains( NSString* substr ){ return Impl::NSStringMatchers::Contains( substr ); }
+
+        inline Impl::NSStringMatchers::StartsWith
+            StartsWith( NSString* substr ){ return Impl::NSStringMatchers::StartsWith( substr ); }
+
+        inline Impl::NSStringMatchers::EndsWith
+            EndsWith( NSString* substr ){ return Impl::NSStringMatchers::EndsWith( substr ); }
+
+    } // namespace Matchers
+
+    using namespace Matchers;
+
+#endif // CATCH_CONFIG_DISABLE_MATCHERS
+
+} // namespace Catch
+
+///////////////////////////////////////////////////////////////////////////////
+#define OC_MAKE_UNIQUE_NAME( root, uniqueSuffix ) root##uniqueSuffix
+#define OC_TEST_CASE2( name, desc, uniqueSuffix ) \
++(NSString*) OC_MAKE_UNIQUE_NAME( Catch_Name_test_, uniqueSuffix ) \
+{ \
+return @ name; \
+} \
++(NSString*) OC_MAKE_UNIQUE_NAME( Catch_Description_test_, uniqueSuffix ) \
+{ \
+return @ desc; \
+} \
+-(void) OC_MAKE_UNIQUE_NAME( Catch_TestCase_test_, uniqueSuffix )
+
+#define OC_TEST_CASE( name, desc ) OC_TEST_CASE2( name, desc, __LINE__ )
+
+// end catch_objc.hpp
+#endif
+
+#ifdef CATCH_CONFIG_EXTERNAL_INTERFACES
+// start catch_external_interfaces.h
+
+// start catch_reporter_bases.hpp
+
+// start catch_interfaces_reporter.h
+
+// start catch_config.hpp
+
+// start catch_test_spec_parser.h
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpadded"
+#endif
+
+// start catch_test_spec.h
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpadded"
+#endif
+
+// start catch_wildcard_pattern.h
+
+namespace Catch
+{
+    class WildcardPattern {
+        enum WildcardPosition {
+            NoWildcard = 0,
+            WildcardAtStart = 1,
+            WildcardAtEnd = 2,
+            WildcardAtBothEnds = WildcardAtStart | WildcardAtEnd
+        };
+
+    public:
+
+        WildcardPattern( std::string const& pattern, CaseSensitive::Choice caseSensitivity );
+        virtual ~WildcardPattern() = default;
+        virtual bool matches( std::string const& str ) const;
+
+    private:
+        std::string adjustCase( std::string const& str ) const;
+        CaseSensitive::Choice m_caseSensitivity;
+        WildcardPosition m_wildcard = NoWildcard;
+        std::string m_pattern;
+    };
+}
+
+// end catch_wildcard_pattern.h
+#include <string>
+#include <vector>
+#include <memory>
+
+namespace Catch {
+
+    class TestSpec {
+        struct Pattern {
+            virtual ~Pattern();
+            virtual bool matches( TestCaseInfo const& testCase ) const = 0;
+        };
+        using PatternPtr = std::shared_ptr<Pattern>;
+
+        class NamePattern : public Pattern {
+        public:
+            NamePattern( std::string const& name );
+            virtual ~NamePattern();
+            virtual bool matches( TestCaseInfo const& testCase ) const override;
+        private:
+            WildcardPattern m_wildcardPattern;
+        };
+
+        class TagPattern : public Pattern {
+        public:
+            TagPattern( std::string const& tag );
+            virtual ~TagPattern();
+            virtual bool matches( TestCaseInfo const& testCase ) const override;
+        private:
+            std::string m_tag;
+        };
+
+        class ExcludedPattern : public Pattern {
+        public:
+            ExcludedPattern( PatternPtr const& underlyingPattern );
+            virtual ~ExcludedPattern();
+            virtual bool matches( TestCaseInfo const& testCase ) const override;
+        private:
+            PatternPtr m_underlyingPattern;
+        };
+
+        struct Filter {
+            std::vector<PatternPtr> m_patterns;
+
+            bool matches( TestCaseInfo const& testCase ) const;
+        };
+
+    public:
+        bool hasFilters() const;
+        bool matches( TestCaseInfo const& testCase ) const;
+
+    private:
+        std::vector<Filter> m_filters;
+
+        friend class TestSpecParser;
+    };
+}
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+// end catch_test_spec.h
+// start catch_interfaces_tag_alias_registry.h
+
+#include <string>
+
+namespace Catch {
+
+    struct TagAlias;
+
+    struct ITagAliasRegistry {
+        virtual ~ITagAliasRegistry();
+        // Nullptr if not present
+        virtual TagAlias const* find( std::string const& alias ) const = 0;
+        virtual std::string expandAliases( std::string const& unexpandedTestSpec ) const = 0;
+
+        static ITagAliasRegistry const& get();
+    };
+
+} // end namespace Catch
+
+// end catch_interfaces_tag_alias_registry.h
+namespace Catch {
+
+    class TestSpecParser {
+        enum Mode{ None, Name, QuotedName, Tag, EscapedName };
+        Mode m_mode = None;
+        bool m_exclusion = false;
+        std::size_t m_start = std::string::npos, m_pos = 0;
+        std::string m_arg;
+        std::vector<std::size_t> m_escapeChars;
+        TestSpec::Filter m_currentFilter;
+        TestSpec m_testSpec;
+        ITagAliasRegistry const* m_tagAliases = nullptr;
+
+    public:
+        TestSpecParser( ITagAliasRegistry const& tagAliases );
+
+        TestSpecParser& parse( std::string const& arg );
+        TestSpec testSpec();
+
+    private:
+        void visitChar( char c );
+        void startNewMode( Mode mode, std::size_t start );
+        void escape();
+        std::string subString() const;
+
+        template<typename T>
+        void addPattern() {
+            std::string token = subString();
+            for( std::size_t i = 0; i < m_escapeChars.size(); ++i )
+                token = token.substr( 0, m_escapeChars[i]-m_start-i ) + token.substr( m_escapeChars[i]-m_start-i+1 );
+            m_escapeChars.clear();
+            if( startsWith( token, "exclude:" ) ) {
+                m_exclusion = true;
+                token = token.substr( 8 );
+            }
+            if( !token.empty() ) {
+                TestSpec::PatternPtr pattern = std::make_shared<T>( token );
+                if( m_exclusion )
+                    pattern = std::make_shared<TestSpec::ExcludedPattern>( pattern );
+                m_currentFilter.m_patterns.push_back( pattern );
+            }
+            m_exclusion = false;
+            m_mode = None;
+        }
+
+        void addFilter();
+    };
+    TestSpec parseTestSpec( std::string const& arg );
+
+} // namespace Catch
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+// end catch_test_spec_parser.h
+// start catch_interfaces_config.h
+
+#include <iosfwd>
+#include <string>
+#include <vector>
+#include <memory>
+
+namespace Catch {
+
+    enum class Verbosity {
+        Quiet = 0,
+        Normal,
+        High
+    };
+
+    struct WarnAbout { enum What {
+        Nothing = 0x00,
+        NoAssertions = 0x01,
+        NoTests = 0x02
+    }; };
+
+    struct ShowDurations { enum OrNot {
+        DefaultForReporter,
+        Always,
+        Never
+    }; };
+    struct RunTests { enum InWhatOrder {
+        InDeclarationOrder,
+        InLexicographicalOrder,
+        InRandomOrder
+    }; };
+    struct UseColour { enum YesOrNo {
+        Auto,
+        Yes,
+        No
+    }; };
+    struct WaitForKeypress { enum When {
+        Never,
+        BeforeStart = 1,
+        BeforeExit = 2,
+        BeforeStartAndExit = BeforeStart | BeforeExit
+    }; };
+
+    class TestSpec;
+
+    struct IConfig : NonCopyable {
+
+        virtual ~IConfig();
+
+        virtual bool allowThrows() const = 0;
+        virtual std::ostream& stream() const = 0;
+        virtual std::string name() const = 0;
+        virtual bool includeSuccessfulResults() const = 0;
+        virtual bool shouldDebugBreak() const = 0;
+        virtual bool warnAboutMissingAssertions() const = 0;
+        virtual bool warnAboutNoTests() const = 0;
+        virtual int abortAfter() const = 0;
+        virtual bool showInvisibles() const = 0;
+        virtual ShowDurations::OrNot showDurations() const = 0;
+        virtual TestSpec const& testSpec() const = 0;
+        virtual bool hasTestFilters() const = 0;
+        virtual RunTests::InWhatOrder runOrder() const = 0;
+        virtual unsigned int rngSeed() const = 0;
+        virtual int benchmarkResolutionMultiple() const = 0;
+        virtual UseColour::YesOrNo useColour() const = 0;
+        virtual std::vector<std::string> const& getSectionsToRun() const = 0;
+        virtual Verbosity verbosity() const = 0;
+    };
+
+    using IConfigPtr = std::shared_ptr<IConfig const>;
+}
+
+// end catch_interfaces_config.h
+// Libstdc++ doesn't like incomplete classes for unique_ptr
+
+#include <memory>
+#include <vector>
+#include <string>
+
+#ifndef CATCH_CONFIG_CONSOLE_WIDTH
+#define CATCH_CONFIG_CONSOLE_WIDTH 80
+#endif
+
+namespace Catch {
+
+    struct IStream;
+
+    struct ConfigData {
+        bool listTests = false;
+        bool listTags = false;
+        bool listReporters = false;
+        bool listTestNamesOnly = false;
+
+        bool showSuccessfulTests = false;
+        bool shouldDebugBreak = false;
+        bool noThrow = false;
+        bool showHelp = false;
+        bool showInvisibles = false;
+        bool filenamesAsTags = false;
+        bool libIdentify = false;
+
+        int abortAfter = -1;
+        unsigned int rngSeed = 0;
+        int benchmarkResolutionMultiple = 100;
+
+        Verbosity verbosity = Verbosity::Normal;
+        WarnAbout::What warnings = WarnAbout::Nothing;
+        ShowDurations::OrNot showDurations = ShowDurations::DefaultForReporter;
+        RunTests::InWhatOrder runOrder = RunTests::InDeclarationOrder;
+        UseColour::YesOrNo useColour = UseColour::Auto;
+        WaitForKeypress::When waitForKeypress = WaitForKeypress::Never;
+
+        std::string outputFilename;
+        std::string name;
+        std::string processName;
+
+        std::vector<std::string> reporterNames;
+        std::vector<std::string> testsOrTags;
+        std::vector<std::string> sectionsToRun;
+    };
+
+    class Config : public IConfig {
+    public:
+
+        Config() = default;
+        Config( ConfigData const& data );
+        virtual ~Config() = default;
+
+        std::string const& getFilename() const;
+
+        bool listTests() const;
+        bool listTestNamesOnly() const;
+        bool listTags() const;
+        bool listReporters() const;
+
+        std::string getProcessName() const;
+
+        std::vector<std::string> const& getReporterNames() const;
+        std::vector<std::string> const& getTestsOrTags() const;
+        std::vector<std::string> const& getSectionsToRun() const override;
+
+        virtual TestSpec const& testSpec() const override;
+        bool hasTestFilters() const override;
+
+        bool showHelp() const;
+
+        // IConfig interface
+        bool allowThrows() const override;
+        std::ostream& stream() const override;
+        std::string name() const override;
+        bool includeSuccessfulResults() const override;
+        bool warnAboutMissingAssertions() const override;
+        bool warnAboutNoTests() const override;
+        ShowDurations::OrNot showDurations() const override;
+        RunTests::InWhatOrder runOrder() const override;
+        unsigned int rngSeed() const override;
+        int benchmarkResolutionMultiple() const override;
+        UseColour::YesOrNo useColour() const override;
+        bool shouldDebugBreak() const override;
+        int abortAfter() const override;
+        bool showInvisibles() const override;
+        Verbosity verbosity() const override;
+
+    private:
+
+        IStream const* openStream();
+        ConfigData m_data;
+
+        std::unique_ptr<IStream const> m_stream;
+        TestSpec m_testSpec;
+        bool m_hasTestFilters = false;
+    };
+
+} // end namespace Catch
+
+// end catch_config.hpp
+// start catch_assertionresult.h
+
+#include <string>
+
+namespace Catch {
+
+    struct AssertionResultData
+    {
+        AssertionResultData() = delete;
+
+        AssertionResultData( ResultWas::OfType _resultType, LazyExpression const& _lazyExpression );
+
+        std::string message;
+        mutable std::string reconstructedExpression;
+        LazyExpression lazyExpression;
+        ResultWas::OfType resultType;
+
+        std::string reconstructExpression() const;
+    };
+
+    class AssertionResult {
+    public:
+        AssertionResult() = delete;
+        AssertionResult( AssertionInfo const& info, AssertionResultData const& data );
+
+        bool isOk() const;
+        bool succeeded() const;
+        ResultWas::OfType getResultType() const;
+        bool hasExpression() const;
+        bool hasMessage() const;
+        std::string getExpression() const;
+        std::string getExpressionInMacro() const;
+        bool hasExpandedExpression() const;
+        std::string getExpandedExpression() const;
+        std::string getMessage() const;
+        SourceLineInfo getSourceInfo() const;
+        StringRef getTestMacroName() const;
+
+    //protected:
+        AssertionInfo m_info;
+        AssertionResultData m_resultData;
+    };
+
+} // end namespace Catch
+
+// end catch_assertionresult.h
+// start catch_option.hpp
+
+namespace Catch {
+
+    // An optional type
+    template<typename T>
+    class Option {
+    public:
+        Option() : nullableValue( nullptr ) {}
+        Option( T const& _value )
+        : nullableValue( new( storage ) T( _value ) )
+        {}
+        Option( Option const& _other )
+        : nullableValue( _other ? new( storage ) T( *_other ) : nullptr )
+        {}
+
+        ~Option() {
+            reset();
+        }
+
+        Option& operator= ( Option const& _other ) {
+            if( &_other != this ) {
+                reset();
+                if( _other )
+                    nullableValue = new( storage ) T( *_other );
+            }
+            return *this;
+        }
+        Option& operator = ( T const& _value ) {
+            reset();
+            nullableValue = new( storage ) T( _value );
+            return *this;
+        }
+
+        void reset() {
+            if( nullableValue )
+                nullableValue->~T();
+            nullableValue = nullptr;
+        }
+
+        T& operator*() { return *nullableValue; }
+        T const& operator*() const { return *nullableValue; }
+        T* operator->() { return nullableValue; }
+        const T* operator->() const { return nullableValue; }
+
+        T valueOr( T const& defaultValue ) const {
+            return nullableValue ? *nullableValue : defaultValue;
+        }
+
+        bool some() const { return nullableValue != nullptr; }
+        bool none() const { return nullableValue == nullptr; }
+
+        bool operator !() const { return nullableValue == nullptr; }
+        explicit operator bool() const {
+            return some();
+        }
+
+    private:
+        T *nullableValue;
+        alignas(alignof(T)) char storage[sizeof(T)];
+    };
+
+} // end namespace Catch
+
+// end catch_option.hpp
+#include <string>
+#include <iosfwd>
+#include <map>
+#include <set>
+#include <memory>
+
+namespace Catch {
+
+    struct ReporterConfig {
+        explicit ReporterConfig( IConfigPtr const& _fullConfig );
+
+        ReporterConfig( IConfigPtr const& _fullConfig, std::ostream& _stream );
+
+        std::ostream& stream() const;
+        IConfigPtr fullConfig() const;
+
+    private:
+        std::ostream* m_stream;
+        IConfigPtr m_fullConfig;
+    };
+
+    struct ReporterPreferences {
+        bool shouldRedirectStdOut = false;
+    };
+
+    template<typename T>
+    struct LazyStat : Option<T> {
+        LazyStat& operator=( T const& _value ) {
+            Option<T>::operator=( _value );
+            used = false;
+            return *this;
+        }
+        void reset() {
+            Option<T>::reset();
+            used = false;
+        }
+        bool used = false;
+    };
+
+    struct TestRunInfo {
+        TestRunInfo( std::string const& _name );
+        std::string name;
+    };
+    struct GroupInfo {
+        GroupInfo(  std::string const& _name,
+                    std::size_t _groupIndex,
+                    std::size_t _groupsCount );
+
+        std::string name;
+        std::size_t groupIndex;
+        std::size_t groupsCounts;
+    };
+
+    struct AssertionStats {
+        AssertionStats( AssertionResult const& _assertionResult,
+                        std::vector<MessageInfo> const& _infoMessages,
+                        Totals const& _totals );
+
+        AssertionStats( AssertionStats const& )              = default;
+        AssertionStats( AssertionStats && )                  = default;
+        AssertionStats& operator = ( AssertionStats const& ) = default;
+        AssertionStats& operator = ( AssertionStats && )     = default;
+        virtual ~AssertionStats();
+
+        AssertionResult assertionResult;
+        std::vector<MessageInfo> infoMessages;
+        Totals totals;
+    };
+
+    struct SectionStats {
+        SectionStats(   SectionInfo const& _sectionInfo,
+                        Counts const& _assertions,
+                        double _durationInSeconds,
+                        bool _missingAssertions );
+        SectionStats( SectionStats const& )              = default;
+        SectionStats( SectionStats && )                  = default;
+        SectionStats& operator = ( SectionStats const& ) = default;
+        SectionStats& operator = ( SectionStats && )     = default;
+        virtual ~SectionStats();
+
+        SectionInfo sectionInfo;
+        Counts assertions;
+        double durationInSeconds;
+        bool missingAssertions;
+    };
+
+    struct TestCaseStats {
+        TestCaseStats(  TestCaseInfo const& _testInfo,
+                        Totals const& _totals,
+                        std::string const& _stdOut,
+                        std::string const& _stdErr,
+                        bool _aborting );
+
+        TestCaseStats( TestCaseStats const& )              = default;
+        TestCaseStats( TestCaseStats && )                  = default;
+        TestCaseStats& operator = ( TestCaseStats const& ) = default;
+        TestCaseStats& operator = ( TestCaseStats && )     = default;
+        virtual ~TestCaseStats();
+
+        TestCaseInfo testInfo;
+        Totals totals;
+        std::string stdOut;
+        std::string stdErr;
+        bool aborting;
+    };
+
+    struct TestGroupStats {
+        TestGroupStats( GroupInfo const& _groupInfo,
+                        Totals const& _totals,
+                        bool _aborting );
+        TestGroupStats( GroupInfo const& _groupInfo );
+
+        TestGroupStats( TestGroupStats const& )              = default;
+        TestGroupStats( TestGroupStats && )                  = default;
+        TestGroupStats& operator = ( TestGroupStats const& ) = default;
+        TestGroupStats& operator = ( TestGroupStats && )     = default;
+        virtual ~TestGroupStats();
+
+        GroupInfo groupInfo;
+        Totals totals;
+        bool aborting;
+    };
+
+    struct TestRunStats {
+        TestRunStats(   TestRunInfo const& _runInfo,
+                        Totals const& _totals,
+                        bool _aborting );
+
+        TestRunStats( TestRunStats const& )              = default;
+        TestRunStats( TestRunStats && )                  = default;
+        TestRunStats& operator = ( TestRunStats const& ) = default;
+        TestRunStats& operator = ( TestRunStats && )     = default;
+        virtual ~TestRunStats();
+
+        TestRunInfo runInfo;
+        Totals totals;
+        bool aborting;
+    };
+
+    struct BenchmarkInfo {
+        std::string name;
+    };
+    struct BenchmarkStats {
+        BenchmarkInfo info;
+        std::size_t iterations;
+        uint64_t elapsedTimeInNanoseconds;
+    };
+
+    struct IStreamingReporter {
+        virtual ~IStreamingReporter() = default;
+
+        // Implementing class must also provide the following static methods:
+        // static std::string getDescription();
+        // static std::set<Verbosity> getSupportedVerbosities()
+
+        virtual ReporterPreferences getPreferences() const = 0;
+
+        virtual void noMatchingTestCases( std::string const& spec ) = 0;
+
+        virtual void testRunStarting( TestRunInfo const& testRunInfo ) = 0;
+        virtual void testGroupStarting( GroupInfo const& groupInfo ) = 0;
+
+        virtual void testCaseStarting( TestCaseInfo const& testInfo ) = 0;
+        virtual void sectionStarting( SectionInfo const& sectionInfo ) = 0;
+
+        // *** experimental ***
+        virtual void benchmarkStarting( BenchmarkInfo const& ) {}
+
+        virtual void assertionStarting( AssertionInfo const& assertionInfo ) = 0;
+
+        // The return value indicates if the messages buffer should be cleared:
+        virtual bool assertionEnded( AssertionStats const& assertionStats ) = 0;
+
+        // *** experimental ***
+        virtual void benchmarkEnded( BenchmarkStats const& ) {}
+
+        virtual void sectionEnded( SectionStats const& sectionStats ) = 0;
+        virtual void testCaseEnded( TestCaseStats const& testCaseStats ) = 0;
+        virtual void testGroupEnded( TestGroupStats const& testGroupStats ) = 0;
+        virtual void testRunEnded( TestRunStats const& testRunStats ) = 0;
+
+        virtual void skipTest( TestCaseInfo const& testInfo ) = 0;
+
+        // Default empty implementation provided
+        virtual void fatalErrorEncountered( StringRef name );
+
+        virtual bool isMulti() const;
+    };
+    using IStreamingReporterPtr = std::unique_ptr<IStreamingReporter>;
+
+    struct IReporterFactory {
+        virtual ~IReporterFactory();
+        virtual IStreamingReporterPtr create( ReporterConfig const& config ) const = 0;
+        virtual std::string getDescription() const = 0;
+    };
+    using IReporterFactoryPtr = std::shared_ptr<IReporterFactory>;
+
+    struct IReporterRegistry {
+        using FactoryMap = std::map<std::string, IReporterFactoryPtr>;
+        using Listeners = std::vector<IReporterFactoryPtr>;
+
+        virtual ~IReporterRegistry();
+        virtual IStreamingReporterPtr create( std::string const& name, IConfigPtr const& config ) const = 0;
+        virtual FactoryMap const& getFactories() const = 0;
+        virtual Listeners const& getListeners() const = 0;
+    };
+
+    void addReporter( IStreamingReporterPtr& existingReporter, IStreamingReporterPtr&& additionalReporter );
+
+} // end namespace Catch
+
+// end catch_interfaces_reporter.h
+#include <algorithm>
+#include <cstring>
+#include <cfloat>
+#include <cstdio>
+#include <assert.h>
+#include <memory>
+#include <ostream>
+
+namespace Catch {
+    void prepareExpandedExpression(AssertionResult& result);
+
+    // Returns double formatted as %.3f (format expected on output)
+    std::string getFormattedDuration( double duration );
+
+    template<typename DerivedT>
+    struct StreamingReporterBase : IStreamingReporter {
+
+        StreamingReporterBase( ReporterConfig const& _config )
+        :   m_config( _config.fullConfig() ),
+            stream( _config.stream() )
+        {
+            m_reporterPrefs.shouldRedirectStdOut = false;
+            if( !DerivedT::getSupportedVerbosities().count( m_config->verbosity() ) )
+                throw std::domain_error( "Verbosity level not supported by this reporter" );
+        }
+
+        ReporterPreferences getPreferences() const override {
+            return m_reporterPrefs;
+        }
+
+        static std::set<Verbosity> getSupportedVerbosities() {
+            return { Verbosity::Normal };
+        }
+
+        ~StreamingReporterBase() override = default;
+
+        void noMatchingTestCases(std::string const&) override {}
+
+        void testRunStarting(TestRunInfo const& _testRunInfo) override {
+            currentTestRunInfo = _testRunInfo;
+        }
+        void testGroupStarting(GroupInfo const& _groupInfo) override {
+            currentGroupInfo = _groupInfo;
+        }
+
+        void testCaseStarting(TestCaseInfo const& _testInfo) override  {
+            currentTestCaseInfo = _testInfo;
+        }
+        void sectionStarting(SectionInfo const& _sectionInfo) override {
+            m_sectionStack.push_back(_sectionInfo);
+        }
+
+        void sectionEnded(SectionStats const& /* _sectionStats */) override {
+            m_sectionStack.pop_back();
+        }
+        void testCaseEnded(TestCaseStats const& /* _testCaseStats */) override {
+            currentTestCaseInfo.reset();
+        }
+        void testGroupEnded(TestGroupStats const& /* _testGroupStats */) override {
+            currentGroupInfo.reset();
+        }
+        void testRunEnded(TestRunStats const& /* _testRunStats */) override {
+            currentTestCaseInfo.reset();
+            currentGroupInfo.reset();
+            currentTestRunInfo.reset();
+        }
+
+        void skipTest(TestCaseInfo const&) override {
+            // Don't do anything with this by default.
+            // It can optionally be overridden in the derived class.
+        }
+
+        IConfigPtr m_config;
+        std::ostream& stream;
+
+        LazyStat<TestRunInfo> currentTestRunInfo;
+        LazyStat<GroupInfo> currentGroupInfo;
+        LazyStat<TestCaseInfo> currentTestCaseInfo;
+
+        std::vector<SectionInfo> m_sectionStack;
+        ReporterPreferences m_reporterPrefs;
+    };
+
+    template<typename DerivedT>
+    struct CumulativeReporterBase : IStreamingReporter {
+        template<typename T, typename ChildNodeT>
+        struct Node {
+            explicit Node( T const& _value ) : value( _value ) {}
+            virtual ~Node() {}
+
+            using ChildNodes = std::vector<std::shared_ptr<ChildNodeT>>;
+            T value;
+            ChildNodes children;
+        };
+        struct SectionNode {
+            explicit SectionNode(SectionStats const& _stats) : stats(_stats) {}
+            virtual ~SectionNode() = default;
+
+            bool operator == (SectionNode const& other) const {
+                return stats.sectionInfo.lineInfo == other.stats.sectionInfo.lineInfo;
+            }
+            bool operator == (std::shared_ptr<SectionNode> const& other) const {
+                return operator==(*other);
+            }
+
+            SectionStats stats;
+            using ChildSections = std::vector<std::shared_ptr<SectionNode>>;
+            using Assertions = std::vector<AssertionStats>;
+            ChildSections childSections;
+            Assertions assertions;
+            std::string stdOut;
+            std::string stdErr;
+        };
+
+        struct BySectionInfo {
+            BySectionInfo( SectionInfo const& other ) : m_other( other ) {}
+            BySectionInfo( BySectionInfo const& other ) : m_other( other.m_other ) {}
+            bool operator() (std::shared_ptr<SectionNode> const& node) const {
+                return ((node->stats.sectionInfo.name == m_other.name) &&
+                        (node->stats.sectionInfo.lineInfo == m_other.lineInfo));
+            }
+            void operator=(BySectionInfo const&) = delete;
+
+        private:
+            SectionInfo const& m_other;
+        };
+
+        using TestCaseNode = Node<TestCaseStats, SectionNode>;
+        using TestGroupNode = Node<TestGroupStats, TestCaseNode>;
+        using TestRunNode = Node<TestRunStats, TestGroupNode>;
+
+        CumulativeReporterBase( ReporterConfig const& _config )
+        :   m_config( _config.fullConfig() ),
+            stream( _config.stream() )
+        {
+            m_reporterPrefs.shouldRedirectStdOut = false;
+            if( !DerivedT::getSupportedVerbosities().count( m_config->verbosity() ) )
+                throw std::domain_error( "Verbosity level not supported by this reporter" );
+        }
+        ~CumulativeReporterBase() override = default;
+
+        ReporterPreferences getPreferences() const override {
+            return m_reporterPrefs;
+        }
+
+        static std::set<Verbosity> getSupportedVerbosities() {
+            return { Verbosity::Normal };
+        }
+
+        void testRunStarting( TestRunInfo const& ) override {}
+        void testGroupStarting( GroupInfo const& ) override {}
+
+        void testCaseStarting( TestCaseInfo const& ) override {}
+
+        void sectionStarting( SectionInfo const& sectionInfo ) override {
+            SectionStats incompleteStats( sectionInfo, Counts(), 0, false );
+            std::shared_ptr<SectionNode> node;
+            if( m_sectionStack.empty() ) {
+                if( !m_rootSection )
+                    m_rootSection = std::make_shared<SectionNode>( incompleteStats );
+                node = m_rootSection;
+            }
+            else {
+                SectionNode& parentNode = *m_sectionStack.back();
+                auto it =
+                    std::find_if(   parentNode.childSections.begin(),
+                                    parentNode.childSections.end(),
+                                    BySectionInfo( sectionInfo ) );
+                if( it == parentNode.childSections.end() ) {
+                    node = std::make_shared<SectionNode>( incompleteStats );
+                    parentNode.childSections.push_back( node );
+                }
+                else
+                    node = *it;
+            }
+            m_sectionStack.push_back( node );
+            m_deepestSection = std::move(node);
+        }
+
+        void assertionStarting(AssertionInfo const&) override {}
+
+        bool assertionEnded(AssertionStats const& assertionStats) override {
+            assert(!m_sectionStack.empty());
+            // AssertionResult holds a pointer to a temporary DecomposedExpression,
+            // which getExpandedExpression() calls to build the expression string.
+            // Our section stack copy of the assertionResult will likely outlive the
+            // temporary, so it must be expanded or discarded now to avoid calling
+            // a destroyed object later.
+            prepareExpandedExpression(const_cast<AssertionResult&>( assertionStats.assertionResult ) );
+            SectionNode& sectionNode = *m_sectionStack.back();
+            sectionNode.assertions.push_back(assertionStats);
+            return true;
+        }
+        void sectionEnded(SectionStats const& sectionStats) override {
+            assert(!m_sectionStack.empty());
+            SectionNode& node = *m_sectionStack.back();
+            node.stats = sectionStats;
+            m_sectionStack.pop_back();
+        }
+        void testCaseEnded(TestCaseStats const& testCaseStats) override {
+            auto node = std::make_shared<TestCaseNode>(testCaseStats);
+            assert(m_sectionStack.size() == 0);
+            node->children.push_back(m_rootSection);
+            m_testCases.push_back(node);
+            m_rootSection.reset();
+
+            assert(m_deepestSection);
+            m_deepestSection->stdOut = testCaseStats.stdOut;
+            m_deepestSection->stdErr = testCaseStats.stdErr;
+        }
+        void testGroupEnded(TestGroupStats const& testGroupStats) override {
+            auto node = std::make_shared<TestGroupNode>(testGroupStats);
+            node->children.swap(m_testCases);
+            m_testGroups.push_back(node);
+        }
+        void testRunEnded(TestRunStats const& testRunStats) override {
+            auto node = std::make_shared<TestRunNode>(testRunStats);
+            node->children.swap(m_testGroups);
+            m_testRuns.push_back(node);
+            testRunEndedCumulative();
+        }
+        virtual void testRunEndedCumulative() = 0;
+
+        void skipTest(TestCaseInfo const&) override {}
+
+        IConfigPtr m_config;
+        std::ostream& stream;
+        std::vector<AssertionStats> m_assertions;
+        std::vector<std::vector<std::shared_ptr<SectionNode>>> m_sections;
+        std::vector<std::shared_ptr<TestCaseNode>> m_testCases;
+        std::vector<std::shared_ptr<TestGroupNode>> m_testGroups;
+
+        std::vector<std::shared_ptr<TestRunNode>> m_testRuns;
+
+        std::shared_ptr<SectionNode> m_rootSection;
+        std::shared_ptr<SectionNode> m_deepestSection;
+        std::vector<std::shared_ptr<SectionNode>> m_sectionStack;
+        ReporterPreferences m_reporterPrefs;
+    };
+
+    template<char C>
+    char const* getLineOfChars() {
+        static char line[CATCH_CONFIG_CONSOLE_WIDTH] = {0};
+        if( !*line ) {
+            std::memset( line, C, CATCH_CONFIG_CONSOLE_WIDTH-1 );
+            line[CATCH_CONFIG_CONSOLE_WIDTH-1] = 0;
+        }
+        return line;
+    }
+
+    struct TestEventListenerBase : StreamingReporterBase<TestEventListenerBase> {
+        TestEventListenerBase( ReporterConfig const& _config );
+
+        void assertionStarting(AssertionInfo const&) override;
+        bool assertionEnded(AssertionStats const&) override;
+    };
+
+} // end namespace Catch
+
+// end catch_reporter_bases.hpp
+// start catch_console_colour.h
+
+namespace Catch {
+
+    struct Colour {
+        enum Code {
+            None = 0,
+
+            White,
+            Red,
+            Green,
+            Blue,
+            Cyan,
+            Yellow,
+            Grey,
+
+            Bright = 0x10,
+
+            BrightRed = Bright | Red,
+            BrightGreen = Bright | Green,
+            LightGrey = Bright | Grey,
+            BrightWhite = Bright | White,
+            BrightYellow = Bright | Yellow,
+
+            // By intention
+            FileName = LightGrey,
+            Warning = BrightYellow,
+            ResultError = BrightRed,
+            ResultSuccess = BrightGreen,
+            ResultExpectedFailure = Warning,
+
+            Error = BrightRed,
+            Success = Green,
+
+            OriginalExpression = Cyan,
+            ReconstructedExpression = BrightYellow,
+
+            SecondaryText = LightGrey,
+            Headers = White
+        };
+
+        // Use constructed object for RAII guard
+        Colour( Code _colourCode );
+        Colour( Colour&& other ) noexcept;
+        Colour& operator=( Colour&& other ) noexcept;
+        ~Colour();
+
+        // Use static method for one-shot changes
+        static void use( Code _colourCode );
+
+    private:
+        bool m_moved = false;
+    };
+
+    std::ostream& operator << ( std::ostream& os, Colour const& );
+
+} // end namespace Catch
+
+// end catch_console_colour.h
+// start catch_reporter_registrars.hpp
+
+
+namespace Catch {
+
+    template<typename T>
+    class ReporterRegistrar {
+
+        class ReporterFactory : public IReporterFactory {
+
+            virtual IStreamingReporterPtr create( ReporterConfig const& config ) const override {
+                return std::unique_ptr<T>( new T( config ) );
+            }
+
+            virtual std::string getDescription() const override {
+                return T::getDescription();
+            }
+        };
+
+    public:
+
+        explicit ReporterRegistrar( std::string const& name ) {
+            getMutableRegistryHub().registerReporter( name, std::make_shared<ReporterFactory>() );
+        }
+    };
+
+    template<typename T>
+    class ListenerRegistrar {
+
+        class ListenerFactory : public IReporterFactory {
+
+            virtual IStreamingReporterPtr create( ReporterConfig const& config ) const override {
+                return std::unique_ptr<T>( new T( config ) );
+            }
+            virtual std::string getDescription() const override {
+                return std::string();
+            }
+        };
+
+    public:
+
+        ListenerRegistrar() {
+            getMutableRegistryHub().registerListener( std::make_shared<ListenerFactory>() );
+        }
+    };
+}
+
+#if !defined(CATCH_CONFIG_DISABLE)
+
+#define CATCH_REGISTER_REPORTER( name, reporterType ) \
+    CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS          \
+    namespace{ Catch::ReporterRegistrar<reporterType> catch_internal_RegistrarFor##reporterType( name ); } \
+    CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS
+
+#define CATCH_REGISTER_LISTENER( listenerType ) \
+     CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS   \
+     namespace{ Catch::ListenerRegistrar<listenerType> catch_internal_RegistrarFor##listenerType; } \
+     CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS
+#else // CATCH_CONFIG_DISABLE
+
+#define CATCH_REGISTER_REPORTER(name, reporterType)
+#define CATCH_REGISTER_LISTENER(listenerType)
+
+#endif // CATCH_CONFIG_DISABLE
+
+// end catch_reporter_registrars.hpp
+// Allow users to base their work off existing reporters
+// start catch_reporter_compact.h
+
+namespace Catch {
+
+    struct CompactReporter : StreamingReporterBase<CompactReporter> {
+
+        using StreamingReporterBase::StreamingReporterBase;
+
+        ~CompactReporter() override;
+
+        static std::string getDescription();
+
+        ReporterPreferences getPreferences() const override;
+
+        void noMatchingTestCases(std::string const& spec) override;
+
+        void assertionStarting(AssertionInfo const&) override;
+
+        bool assertionEnded(AssertionStats const& _assertionStats) override;
+
+        void sectionEnded(SectionStats const& _sectionStats) override;
+
+        void testRunEnded(TestRunStats const& _testRunStats) override;
+
+    };
+
+} // end namespace Catch
+
+// end catch_reporter_compact.h
+// start catch_reporter_console.h
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4061) // Not all labels are EXPLICITLY handled in switch
+                              // Note that 4062 (not all labels are handled
+                              // and default is missing) is enabled
+#endif
+
+namespace Catch {
+    // Fwd decls
+    struct SummaryColumn;
+    class TablePrinter;
+
+    struct ConsoleReporter : StreamingReporterBase<ConsoleReporter> {
+        std::unique_ptr<TablePrinter> m_tablePrinter;
+
+        ConsoleReporter(ReporterConfig const& config);
+        ~ConsoleReporter() override;
+        static std::string getDescription();
+
+        void noMatchingTestCases(std::string const& spec) override;
+
+        void assertionStarting(AssertionInfo const&) override;
+
+        bool assertionEnded(AssertionStats const& _assertionStats) override;
+
+        void sectionStarting(SectionInfo const& _sectionInfo) override;
+        void sectionEnded(SectionStats const& _sectionStats) override;
+
+        void benchmarkStarting(BenchmarkInfo const& info) override;
+        void benchmarkEnded(BenchmarkStats const& stats) override;
+
+        void testCaseEnded(TestCaseStats const& _testCaseStats) override;
+        void testGroupEnded(TestGroupStats const& _testGroupStats) override;
+        void testRunEnded(TestRunStats const& _testRunStats) override;
+
+    private:
+
+        void lazyPrint();
+
+        void lazyPrintWithoutClosingBenchmarkTable();
+        void lazyPrintRunInfo();
+        void lazyPrintGroupInfo();
+        void printTestCaseAndSectionHeader();
+
+        void printClosedHeader(std::string const& _name);
+        void printOpenHeader(std::string const& _name);
+
+        // if string has a : in first line will set indent to follow it on
+        // subsequent lines
+        void printHeaderString(std::string const& _string, std::size_t indent = 0);
+
+        void printTotals(Totals const& totals);
+        void printSummaryRow(std::string const& label, std::vector<SummaryColumn> const& cols, std::size_t row);
+
+        void printTotalsDivider(Totals const& totals);
+        void printSummaryDivider();
+
+    private:
+        bool m_headerPrinted = false;
+    };
+
+} // end namespace Catch
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+// end catch_reporter_console.h
+// start catch_reporter_junit.h
+
+// start catch_xmlwriter.h
+
+#include <vector>
+
+namespace Catch {
+
+    class XmlEncode {
+    public:
+        enum ForWhat { ForTextNodes, ForAttributes };
+
+        XmlEncode( std::string const& str, ForWhat forWhat = ForTextNodes );
+
+        void encodeTo( std::ostream& os ) const;
+
+        friend std::ostream& operator << ( std::ostream& os, XmlEncode const& xmlEncode );
+
+    private:
+        std::string m_str;
+        ForWhat m_forWhat;
+    };
+
+    class XmlWriter {
+    public:
+
+        class ScopedElement {
+        public:
+            ScopedElement( XmlWriter* writer );
+
+            ScopedElement( ScopedElement&& other ) noexcept;
+            ScopedElement& operator=( ScopedElement&& other ) noexcept;
+
+            ~ScopedElement();
+
+            ScopedElement& writeText( std::string const& text, bool indent = true );
+
+            template<typename T>
+            ScopedElement& writeAttribute( std::string const& name, T const& attribute ) {
+                m_writer->writeAttribute( name, attribute );
+                return *this;
+            }
+
+        private:
+            mutable XmlWriter* m_writer = nullptr;
+        };
+
+        XmlWriter( std::ostream& os = Catch::cout() );
+        ~XmlWriter();
+
+        XmlWriter( XmlWriter const& ) = delete;
+        XmlWriter& operator=( XmlWriter const& ) = delete;
+
+        XmlWriter& startElement( std::string const& name );
+
+        ScopedElement scopedElement( std::string const& name );
+
+        XmlWriter& endElement();
+
+        XmlWriter& writeAttribute( std::string const& name, std::string const& attribute );
+
+        XmlWriter& writeAttribute( std::string const& name, bool attribute );
+
+        template<typename T>
+        XmlWriter& writeAttribute( std::string const& name, T const& attribute ) {
+            ReusableStringStream rss;
+            rss << attribute;
+            return writeAttribute( name, rss.str() );
+        }
+
+        XmlWriter& writeText( std::string const& text, bool indent = true );
+
+        XmlWriter& writeComment( std::string const& text );
+
+        void writeStylesheetRef( std::string const& url );
+
+        XmlWriter& writeBlankLine();
+
+        void ensureTagClosed();
+
+    private:
+
+        void writeDeclaration();
+
+        void newlineIfNecessary();
+
+        bool m_tagIsOpen = false;
+        bool m_needsNewline = false;
+        std::vector<std::string> m_tags;
+        std::string m_indent;
+        std::ostream& m_os;
+    };
+
+}
+
+// end catch_xmlwriter.h
+namespace Catch {
+
+    class JunitReporter : public CumulativeReporterBase<JunitReporter> {
+    public:
+        JunitReporter(ReporterConfig const& _config);
+
+        ~JunitReporter() override;
+
+        static std::string getDescription();
+
+        void noMatchingTestCases(std::string const& /*spec*/) override;
+
+        void testRunStarting(TestRunInfo const& runInfo) override;
+
+        void testGroupStarting(GroupInfo const& groupInfo) override;
+
+        void testCaseStarting(TestCaseInfo const& testCaseInfo) override;
+        bool assertionEnded(AssertionStats const& assertionStats) override;
+
+        void testCaseEnded(TestCaseStats const& testCaseStats) override;
+
+        void testGroupEnded(TestGroupStats const& testGroupStats) override;
+
+        void testRunEndedCumulative() override;
+
+        void writeGroup(TestGroupNode const& groupNode, double suiteTime);
+
+        void writeTestCase(TestCaseNode const& testCaseNode);
+
+        void writeSection(std::string const& className,
+                          std::string const& rootName,
+                          SectionNode const& sectionNode);
+
+        void writeAssertions(SectionNode const& sectionNode);
+        void writeAssertion(AssertionStats const& stats);
+
+        XmlWriter xml;
+        Timer suiteTimer;
+        std::string stdOutForSuite;
+        std::string stdErrForSuite;
+        unsigned int unexpectedExceptions = 0;
+        bool m_okToFail = false;
+    };
+
+} // end namespace Catch
+
+// end catch_reporter_junit.h
+// start catch_reporter_xml.h
+
+namespace Catch {
+    class XmlReporter : public StreamingReporterBase<XmlReporter> {
+    public:
+        XmlReporter(ReporterConfig const& _config);
+
+        ~XmlReporter() override;
+
+        static std::string getDescription();
+
+        virtual std::string getStylesheetRef() const;
+
+        void writeSourceInfo(SourceLineInfo const& sourceInfo);
+
+    public: // StreamingReporterBase
+
+        void noMatchingTestCases(std::string const& s) override;
+
+        void testRunStarting(TestRunInfo const& testInfo) override;
+
+        void testGroupStarting(GroupInfo const& groupInfo) override;
+
+        void testCaseStarting(TestCaseInfo const& testInfo) override;
+
+        void sectionStarting(SectionInfo const& sectionInfo) override;
+
+        void assertionStarting(AssertionInfo const&) override;
+
+        bool assertionEnded(AssertionStats const& assertionStats) override;
+
+        void sectionEnded(SectionStats const& sectionStats) override;
+
+        void testCaseEnded(TestCaseStats const& testCaseStats) override;
+
+        void testGroupEnded(TestGroupStats const& testGroupStats) override;
+
+        void testRunEnded(TestRunStats const& testRunStats) override;
+
+    private:
+        Timer m_testCaseTimer;
+        XmlWriter m_xml;
+        int m_sectionDepth = 0;
+    };
+
+} // end namespace Catch
+
+// end catch_reporter_xml.h
+
+// end catch_external_interfaces.h
+#endif
+
+#endif // ! CATCH_CONFIG_IMPL_ONLY
+
+#ifdef CATCH_IMPL
+// start catch_impl.hpp
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif
+
+// Keep these here for external reporters
+// start catch_test_case_tracker.h
+
+#include <string>
+#include <vector>
+#include <memory>
+
+namespace Catch {
+namespace TestCaseTracking {
+
+    struct NameAndLocation {
+        std::string name;
+        SourceLineInfo location;
+
+        NameAndLocation( std::string const& _name, SourceLineInfo const& _location );
+    };
+
+    struct ITracker;
+
+    using ITrackerPtr = std::shared_ptr<ITracker>;
+
+    struct ITracker {
+        virtual ~ITracker();
+
+        // static queries
+        virtual NameAndLocation const& nameAndLocation() const = 0;
+
+        // dynamic queries
+        virtual bool isComplete() const = 0; // Successfully completed or failed
+        virtual bool isSuccessfullyCompleted() const = 0;
+        virtual bool isOpen() const = 0; // Started but not complete
+        virtual bool hasChildren() const = 0;
+
+        virtual ITracker& parent() = 0;
+
+        // actions
+        virtual void close() = 0; // Successfully complete
+        virtual void fail() = 0;
+        virtual void markAsNeedingAnotherRun() = 0;
+
+        virtual void addChild( ITrackerPtr const& child ) = 0;
+        virtual ITrackerPtr findChild( NameAndLocation const& nameAndLocation ) = 0;
+        virtual void openChild() = 0;
+
+        // Debug/ checking
+        virtual bool isSectionTracker() const = 0;
+        virtual bool isIndexTracker() const = 0;
+    };
+
+    class TrackerContext {
+
+        enum RunState {
+            NotStarted,
+            Executing,
+            CompletedCycle
+        };
+
+        ITrackerPtr m_rootTracker;
+        ITracker* m_currentTracker = nullptr;
+        RunState m_runState = NotStarted;
+
+    public:
+
+        static TrackerContext& instance();
+
+        ITracker& startRun();
+        void endRun();
+
+        void startCycle();
+        void completeCycle();
+
+        bool completedCycle() const;
+        ITracker& currentTracker();
+        void setCurrentTracker( ITracker* tracker );
+    };
+
+    class TrackerBase : public ITracker {
+    protected:
+        enum CycleState {
+            NotStarted,
+            Executing,
+            ExecutingChildren,
+            NeedsAnotherRun,
+            CompletedSuccessfully,
+            Failed
+        };
+
+        class TrackerHasName {
+            NameAndLocation m_nameAndLocation;
+        public:
+            TrackerHasName( NameAndLocation const& nameAndLocation );
+            bool operator ()( ITrackerPtr const& tracker ) const;
+        };
+
+        using Children = std::vector<ITrackerPtr>;
+        NameAndLocation m_nameAndLocation;
+        TrackerContext& m_ctx;
+        ITracker* m_parent;
+        Children m_children;
+        CycleState m_runState = NotStarted;
+
+    public:
+        TrackerBase( NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent );
+
+        NameAndLocation const& nameAndLocation() const override;
+        bool isComplete() const override;
+        bool isSuccessfullyCompleted() const override;
+        bool isOpen() const override;
+        bool hasChildren() const override;
+
+        void addChild( ITrackerPtr const& child ) override;
+
+        ITrackerPtr findChild( NameAndLocation const& nameAndLocation ) override;
+        ITracker& parent() override;
+
+        void openChild() override;
+
+        bool isSectionTracker() const override;
+        bool isIndexTracker() const override;
+
+        void open();
+
+        void close() override;
+        void fail() override;
+        void markAsNeedingAnotherRun() override;
+
+    private:
+        void moveToParent();
+        void moveToThis();
+    };
+
+    class SectionTracker : public TrackerBase {
+        std::vector<std::string> m_filters;
+    public:
+        SectionTracker( NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent );
+
+        bool isSectionTracker() const override;
+
+        static SectionTracker& acquire( TrackerContext& ctx, NameAndLocation const& nameAndLocation );
+
+        void tryOpen();
+
+        void addInitialFilters( std::vector<std::string> const& filters );
+        void addNextFilters( std::vector<std::string> const& filters );
+    };
+
+    class IndexTracker : public TrackerBase {
+        int m_size;
+        int m_index = -1;
+    public:
+        IndexTracker( NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent, int size );
+
+        bool isIndexTracker() const override;
+        void close() override;
+
+        static IndexTracker& acquire( TrackerContext& ctx, NameAndLocation const& nameAndLocation, int size );
+
+        int index() const;
+
+        void moveNext();
+    };
+
+} // namespace TestCaseTracking
+
+using TestCaseTracking::ITracker;
+using TestCaseTracking::TrackerContext;
+using TestCaseTracking::SectionTracker;
+using TestCaseTracking::IndexTracker;
+
+} // namespace Catch
+
+// end catch_test_case_tracker.h
+
+// start catch_leak_detector.h
+
+namespace Catch {
+
+    struct LeakDetector {
+        LeakDetector();
+    };
+
+}
+// end catch_leak_detector.h
+// Cpp files will be included in the single-header file here
+// start catch_approx.cpp
+
+#include <cmath>
+#include <limits>
+
+namespace {
+
+// Performs equivalent check of std::fabs(lhs - rhs) <= margin
+// But without the subtraction to allow for INFINITY in comparison
+bool marginComparison(double lhs, double rhs, double margin) {
+    return (lhs + margin >= rhs) && (rhs + margin >= lhs);
+}
+
+}
+
+namespace Catch {
+namespace Detail {
+
+    Approx::Approx ( double value )
+    :   m_epsilon( std::numeric_limits<float>::epsilon()*100 ),
+        m_margin( 0.0 ),
+        m_scale( 0.0 ),
+        m_value( value )
+    {}
+
+    Approx Approx::custom() {
+        return Approx( 0 );
+    }
+
+    std::string Approx::toString() const {
+        ReusableStringStream rss;
+        rss << "Approx( " << ::Catch::Detail::stringify( m_value ) << " )";
+        return rss.str();
+    }
+
+    bool Approx::equalityComparisonImpl(const double other) const {
+        // First try with fixed margin, then compute margin based on epsilon, scale and Approx's value
+        // Thanks to Richard Harris for his help refining the scaled margin value
+        return marginComparison(m_value, other, m_margin) || marginComparison(m_value, other, m_epsilon * (m_scale + std::fabs(m_value)));
+    }
+
+} // end namespace Detail
+
+std::string StringMaker<Catch::Detail::Approx>::convert(Catch::Detail::Approx const& value) {
+    return value.toString();
+}
+
+} // end namespace Catch
+// end catch_approx.cpp
+// start catch_assertionhandler.cpp
+
+// start catch_context.h
+
+#include <memory>
+
+namespace Catch {
+
+    struct IResultCapture;
+    struct IRunner;
+    struct IConfig;
+    struct IMutableContext;
+
+    using IConfigPtr = std::shared_ptr<IConfig const>;
+
+    struct IContext
+    {
+        virtual ~IContext();
+
+        virtual IResultCapture* getResultCapture() = 0;
+        virtual IRunner* getRunner() = 0;
+        virtual IConfigPtr const& getConfig() const = 0;
+    };
+
+    struct IMutableContext : IContext
+    {
+        virtual ~IMutableContext();
+        virtual void setResultCapture( IResultCapture* resultCapture ) = 0;
+        virtual void setRunner( IRunner* runner ) = 0;
+        virtual void setConfig( IConfigPtr const& config ) = 0;
+
+    private:
+        static IMutableContext *currentContext;
+        friend IMutableContext& getCurrentMutableContext();
+        friend void cleanUpContext();
+        static void createContext();
+    };
+
+    inline IMutableContext& getCurrentMutableContext()
+    {
+        if( !IMutableContext::currentContext )
+            IMutableContext::createContext();
+        return *IMutableContext::currentContext;
+    }
+
+    inline IContext& getCurrentContext()
+    {
+        return getCurrentMutableContext();
+    }
+
+    void cleanUpContext();
+}
+
+// end catch_context.h
+// start catch_debugger.h
+
+namespace Catch {
+    bool isDebuggerActive();
+}
+
+#ifdef CATCH_PLATFORM_MAC
+
+    #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
+
+#elif defined(CATCH_PLATFORM_LINUX)
+    // If we can use inline assembler, do it because this allows us to break
+    // directly at the location of the failing check instead of breaking inside
+    // raise() called from it, i.e. one stack frame below.
+    #if defined(__GNUC__) && (defined(__i386) || defined(__x86_64))
+        #define CATCH_TRAP() asm volatile ("int $3") /* NOLINT */
+    #else // Fall back to the generic way.
+        #include <signal.h>
+
+        #define CATCH_TRAP() raise(SIGTRAP)
+    #endif
+#elif defined(_MSC_VER)
+    #define CATCH_TRAP() __debugbreak()
+#elif defined(__MINGW32__)
+    extern "C" __declspec(dllimport) void __stdcall DebugBreak();
+    #define CATCH_TRAP() DebugBreak()
+#endif
+
+#ifdef CATCH_TRAP
+    #define CATCH_BREAK_INTO_DEBUGGER() if( Catch::isDebuggerActive() ) { CATCH_TRAP(); }
+#else
+    namespace Catch {
+        inline void doNothing() {}
+    }
+    #define CATCH_BREAK_INTO_DEBUGGER() Catch::doNothing()
+#endif
+
+// end catch_debugger.h
+// start catch_run_context.h
+
+// start catch_fatal_condition.h
+
+// start catch_windows_h_proxy.h
+
+
+#if defined(CATCH_PLATFORM_WINDOWS)
+
+#if !defined(NOMINMAX) && !defined(CATCH_CONFIG_NO_NOMINMAX)
+#  define CATCH_DEFINED_NOMINMAX
+#  define NOMINMAX
+#endif
+#if !defined(WIN32_LEAN_AND_MEAN) && !defined(CATCH_CONFIG_NO_WIN32_LEAN_AND_MEAN)
+#  define CATCH_DEFINED_WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+#endif
+
+#ifdef __AFXDLL
+#include <AfxWin.h>
+#else
+#include <windows.h>
+#endif
+
+#ifdef CATCH_DEFINED_NOMINMAX
+#  undef NOMINMAX
+#endif
+#ifdef CATCH_DEFINED_WIN32_LEAN_AND_MEAN
+#  undef WIN32_LEAN_AND_MEAN
+#endif
+
+#endif // defined(CATCH_PLATFORM_WINDOWS)
+
+// end catch_windows_h_proxy.h
+#if defined( CATCH_CONFIG_WINDOWS_SEH )
+
+namespace Catch {
+
+    struct FatalConditionHandler {
+
+        static LONG CALLBACK handleVectoredException(PEXCEPTION_POINTERS ExceptionInfo);
+        FatalConditionHandler();
+        static void reset();
+        ~FatalConditionHandler();
+
+    private:
+        static bool isSet;
+        static ULONG guaranteeSize;
+        static PVOID exceptionHandlerHandle;
+    };
+
+} // namespace Catch
+
+#elif defined ( CATCH_CONFIG_POSIX_SIGNALS )
+
+#include <signal.h>
+
+namespace Catch {
+
+    struct FatalConditionHandler {
+
+        static bool isSet;
+        static struct sigaction oldSigActions[];
+        static stack_t oldSigStack;
+        static char altStackMem[];
+
+        static void handleSignal( int sig );
+
+        FatalConditionHandler();
+        ~FatalConditionHandler();
+        static void reset();
+    };
+
+} // namespace Catch
+
+#else
+
+namespace Catch {
+    struct FatalConditionHandler {
+        void reset();
+    };
+}
+
+#endif
+
+// end catch_fatal_condition.h
+#include <string>
+
+namespace Catch {
+
+    struct IMutableContext;
+
+    ///////////////////////////////////////////////////////////////////////////
+
+    class RunContext : public IResultCapture, public IRunner {
+
+    public:
+        RunContext( RunContext const& ) = delete;
+        RunContext& operator =( RunContext const& ) = delete;
+
+        explicit RunContext( IConfigPtr const& _config, IStreamingReporterPtr&& reporter );
+
+        ~RunContext() override;
+
+        void testGroupStarting( std::string const& testSpec, std::size_t groupIndex, std::size_t groupsCount );
+        void testGroupEnded( std::string const& testSpec, Totals const& totals, std::size_t groupIndex, std::size_t groupsCount );
+
+        Totals runTest(TestCase const& testCase);
+
+        IConfigPtr config() const;
+        IStreamingReporter& reporter() const;
+
+    public: // IResultCapture
+
+        // Assertion handlers
+        void handleExpr
+                (   AssertionInfo const& info,
+                    ITransientExpression const& expr,
+                    AssertionReaction& reaction ) override;
+        void handleMessage
+                (   AssertionInfo const& info,
+                    ResultWas::OfType resultType,
+                    StringRef const& message,
+                    AssertionReaction& reaction ) override;
+        void handleUnexpectedExceptionNotThrown
+                (   AssertionInfo const& info,
+                    AssertionReaction& reaction ) override;
+        void handleUnexpectedInflightException
+                (   AssertionInfo const& info,
+                    std::string const& message,
+                    AssertionReaction& reaction ) override;
+        void handleIncomplete
+                (   AssertionInfo const& info ) override;
+        void handleNonExpr
+                (   AssertionInfo const &info,
+                    ResultWas::OfType resultType,
+                    AssertionReaction &reaction ) override;
+
+        bool sectionStarted( SectionInfo const& sectionInfo, Counts& assertions ) override;
+
+        void sectionEnded( SectionEndInfo const& endInfo ) override;
+        void sectionEndedEarly( SectionEndInfo const& endInfo ) override;
+
+        void benchmarkStarting( BenchmarkInfo const& info ) override;
+        void benchmarkEnded( BenchmarkStats const& stats ) override;
+
+        void pushScopedMessage( MessageInfo const& message ) override;
+        void popScopedMessage( MessageInfo const& message ) override;
+
+        std::string getCurrentTestName() const override;
+
+        const AssertionResult* getLastResult() const override;
+
+        void exceptionEarlyReported() override;
+
+        void handleFatalErrorCondition( StringRef message ) override;
+
+        bool lastAssertionPassed() override;
+
+        void assertionPassed() override;
+
+    public:
+        // !TBD We need to do this another way!
+        bool aborting() const final;
+
+    private:
+
+        void runCurrentTest( std::string& redirectedCout, std::string& redirectedCerr );
+        void invokeActiveTestCase();
+
+        void resetAssertionInfo();
+        bool testForMissingAssertions( Counts& assertions );
+
+        void assertionEnded( AssertionResult const& result );
+        void reportExpr
+                (   AssertionInfo const &info,
+                    ResultWas::OfType resultType,
+                    ITransientExpression const *expr,
+                    bool negated );
+
+        void populateReaction( AssertionReaction& reaction );
+
+    private:
+
+        void handleUnfinishedSections();
+
+        TestRunInfo m_runInfo;
+        IMutableContext& m_context;
+        TestCase const* m_activeTestCase = nullptr;
+        ITracker* m_testCaseTracker;
+        Option<AssertionResult> m_lastResult;
+
+        IConfigPtr m_config;
+        Totals m_totals;
+        IStreamingReporterPtr m_reporter;
+        std::vector<MessageInfo> m_messages;
+        AssertionInfo m_lastAssertionInfo;
+        std::vector<SectionEndInfo> m_unfinishedSections;
+        std::vector<ITracker*> m_activeSections;
+        TrackerContext m_trackerContext;
+        bool m_lastAssertionPassed = false;
+        bool m_shouldReportUnexpected = true;
+        bool m_includeSuccessfulResults;
+    };
+
+} // end namespace Catch
+
+// end catch_run_context.h
+namespace Catch {
+
+    auto operator <<( std::ostream& os, ITransientExpression const& expr ) -> std::ostream& {
+        expr.streamReconstructedExpression( os );
+        return os;
+    }
+
+    LazyExpression::LazyExpression( bool isNegated )
+    :   m_isNegated( isNegated )
+    {}
+
+    LazyExpression::LazyExpression( LazyExpression const& other ) : m_isNegated( other.m_isNegated ) {}
+
+    LazyExpression::operator bool() const {
+        return m_transientExpression != nullptr;
+    }
+
+    auto operator << ( std::ostream& os, LazyExpression const& lazyExpr ) -> std::ostream& {
+        if( lazyExpr.m_isNegated )
+            os << "!";
+
+        if( lazyExpr ) {
+            if( lazyExpr.m_isNegated && lazyExpr.m_transientExpression->isBinaryExpression() )
+                os << "(" << *lazyExpr.m_transientExpression << ")";
+            else
+                os << *lazyExpr.m_transientExpression;
+        }
+        else {
+            os << "{** error - unchecked empty expression requested **}";
+        }
+        return os;
+    }
+
+    AssertionHandler::AssertionHandler
+        (   StringRef macroName,
+            SourceLineInfo const& lineInfo,
+            StringRef capturedExpression,
+            ResultDisposition::Flags resultDisposition )
+    :   m_assertionInfo{ macroName, lineInfo, capturedExpression, resultDisposition },
+        m_resultCapture( getResultCapture() )
+    {}
+
+    void AssertionHandler::handleExpr( ITransientExpression const& expr ) {
+        m_resultCapture.handleExpr( m_assertionInfo, expr, m_reaction );
+    }
+    void AssertionHandler::handleMessage(ResultWas::OfType resultType, StringRef const& message) {
+        m_resultCapture.handleMessage( m_assertionInfo, resultType, message, m_reaction );
+    }
+
+    auto AssertionHandler::allowThrows() const -> bool {
+        return getCurrentContext().getConfig()->allowThrows();
+    }
+
+    void AssertionHandler::complete() {
+        setCompleted();
+        if( m_reaction.shouldDebugBreak ) {
+
+            // If you find your debugger stopping you here then go one level up on the
+            // call-stack for the code that caused it (typically a failed assertion)
+
+            // (To go back to the test and change execution, jump over the throw, next)
+            CATCH_BREAK_INTO_DEBUGGER();
+        }
+        if( m_reaction.shouldThrow )
+            throw Catch::TestFailureException();
+    }
+    void AssertionHandler::setCompleted() {
+        m_completed = true;
+    }
+
+    void AssertionHandler::handleUnexpectedInflightException() {
+        m_resultCapture.handleUnexpectedInflightException( m_assertionInfo, Catch::translateActiveException(), m_reaction );
+    }
+
+    void AssertionHandler::handleExceptionThrownAsExpected() {
+        m_resultCapture.handleNonExpr(m_assertionInfo, ResultWas::Ok, m_reaction);
+    }
+    void AssertionHandler::handleExceptionNotThrownAsExpected() {
+        m_resultCapture.handleNonExpr(m_assertionInfo, ResultWas::Ok, m_reaction);
+    }
+
+    void AssertionHandler::handleUnexpectedExceptionNotThrown() {
+        m_resultCapture.handleUnexpectedExceptionNotThrown( m_assertionInfo, m_reaction );
+    }
+
+    void AssertionHandler::handleThrowingCallSkipped() {
+        m_resultCapture.handleNonExpr(m_assertionInfo, ResultWas::Ok, m_reaction);
+    }
+
+    // This is the overload that takes a string and infers the Equals matcher from it
+    // The more general overload, that takes any string matcher, is in catch_capture_matchers.cpp
+    void handleExceptionMatchExpr( AssertionHandler& handler, std::string const& str, StringRef matcherString  ) {
+        handleExceptionMatchExpr( handler, Matchers::Equals( str ), matcherString );
+    }
+
+} // namespace Catch
+// end catch_assertionhandler.cpp
+// start catch_assertionresult.cpp
+
+namespace Catch {
+    AssertionResultData::AssertionResultData(ResultWas::OfType _resultType, LazyExpression const & _lazyExpression):
+        lazyExpression(_lazyExpression),
+        resultType(_resultType) {}
+
+    std::string AssertionResultData::reconstructExpression() const {
+
+        if( reconstructedExpression.empty() ) {
+            if( lazyExpression ) {
+                ReusableStringStream rss;
+                rss << lazyExpression;
+                reconstructedExpression = rss.str();
+            }
+        }
+        return reconstructedExpression;
+    }
+
+    AssertionResult::AssertionResult( AssertionInfo const& info, AssertionResultData const& data )
+    :   m_info( info ),
+        m_resultData( data )
+    {}
+
+    // Result was a success
+    bool AssertionResult::succeeded() const {
+        return Catch::isOk( m_resultData.resultType );
+    }
+
+    // Result was a success, or failure is suppressed
+    bool AssertionResult::isOk() const {
+        return Catch::isOk( m_resultData.resultType ) || shouldSuppressFailure( m_info.resultDisposition );
+    }
+
+    ResultWas::OfType AssertionResult::getResultType() const {
+        return m_resultData.resultType;
+    }
+
+    bool AssertionResult::hasExpression() const {
+        return m_info.capturedExpression[0] != 0;
+    }
+
+    bool AssertionResult::hasMessage() const {
+        return !m_resultData.message.empty();
+    }
+
+    std::string AssertionResult::getExpression() const {
+        if( isFalseTest( m_info.resultDisposition ) )
+            return "!(" + m_info.capturedExpression + ")";
+        else
+            return m_info.capturedExpression;
+    }
+
+    std::string AssertionResult::getExpressionInMacro() const {
+        std::string expr;
+        if( m_info.macroName[0] == 0 )
+            expr = m_info.capturedExpression;
+        else {
+            expr.reserve( m_info.macroName.size() + m_info.capturedExpression.size() + 4 );
+            expr += m_info.macroName;
+            expr += "( ";
+            expr += m_info.capturedExpression;
+            expr += " )";
+        }
+        return expr;
+    }
+
+    bool AssertionResult::hasExpandedExpression() const {
+        return hasExpression() && getExpandedExpression() != getExpression();
+    }
+
+    std::string AssertionResult::getExpandedExpression() const {
+        std::string expr = m_resultData.reconstructExpression();
+        return expr.empty()
+                ? getExpression()
+                : expr;
+    }
+
+    std::string AssertionResult::getMessage() const {
+        return m_resultData.message;
+    }
+    SourceLineInfo AssertionResult::getSourceInfo() const {
+        return m_info.lineInfo;
+    }
+
+    StringRef AssertionResult::getTestMacroName() const {
+        return m_info.macroName;
+    }
+
+} // end namespace Catch
+// end catch_assertionresult.cpp
+// start catch_benchmark.cpp
+
+namespace Catch {
+
+    auto BenchmarkLooper::getResolution() -> uint64_t {
+        return getEstimatedClockResolution() * getCurrentContext().getConfig()->benchmarkResolutionMultiple();
+    }
+
+    void BenchmarkLooper::reportStart() {
+        getResultCapture().benchmarkStarting( { m_name } );
+    }
+    auto BenchmarkLooper::needsMoreIterations() -> bool {
+        auto elapsed = m_timer.getElapsedNanoseconds();
+
+        // Exponentially increasing iterations until we're confident in our timer resolution
+        if( elapsed < m_resolution ) {
+            m_iterationsToRun *= 10;
+            return true;
+        }
+
+        getResultCapture().benchmarkEnded( { { m_name }, m_count, elapsed } );
+        return false;
+    }
+
+} // end namespace Catch
+// end catch_benchmark.cpp
+// start catch_capture_matchers.cpp
+
+namespace Catch {
+
+    using StringMatcher = Matchers::Impl::MatcherBase<std::string>;
+
+    // This is the general overload that takes a any string matcher
+    // There is another overload, in catch_assertionhandler.h/.cpp, that only takes a string and infers
+    // the Equals matcher (so the header does not mention matchers)
+    void handleExceptionMatchExpr( AssertionHandler& handler, StringMatcher const& matcher, StringRef matcherString  ) {
+        std::string exceptionMessage = Catch::translateActiveException();
+        MatchExpr<std::string, StringMatcher const&> expr( exceptionMessage, matcher, matcherString );
+        handler.handleExpr( expr );
+    }
+
+} // namespace Catch
+// end catch_capture_matchers.cpp
+// start catch_commandline.cpp
+
+// start catch_commandline.h
+
+// start catch_clara.h
+
+// Use Catch's value for console width (store Clara's off to the side, if present)
+#ifdef CLARA_CONFIG_CONSOLE_WIDTH
+#define CATCH_TEMP_CLARA_CONFIG_CONSOLE_WIDTH CATCH_CLARA_TEXTFLOW_CONFIG_CONSOLE_WIDTH
+#undef CATCH_CLARA_TEXTFLOW_CONFIG_CONSOLE_WIDTH
+#endif
+#define CATCH_CLARA_TEXTFLOW_CONFIG_CONSOLE_WIDTH CATCH_CONFIG_CONSOLE_WIDTH-1
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#pragma clang diagnostic ignored "-Wexit-time-destructors"
+#pragma clang diagnostic ignored "-Wshadow"
+#endif
+
+// start clara.hpp
+// Copyright 2017 Two Blue Cubes Ltd. All rights reserved.
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// See https://github.com/philsquared/Clara for more details
+
+// Clara v1.1.4
+
+
+#ifndef CATCH_CLARA_CONFIG_CONSOLE_WIDTH
+#define CATCH_CLARA_CONFIG_CONSOLE_WIDTH 80
+#endif
+
+#ifndef CATCH_CLARA_TEXTFLOW_CONFIG_CONSOLE_WIDTH
+#define CATCH_CLARA_TEXTFLOW_CONFIG_CONSOLE_WIDTH CATCH_CLARA_CONFIG_CONSOLE_WIDTH
+#endif
+
+#ifndef CLARA_CONFIG_OPTIONAL_TYPE
+#ifdef __has_include
+#if __has_include(<optional>) && __cplusplus >= 201703L
+#include <optional>
+#define CLARA_CONFIG_OPTIONAL_TYPE std::optional
+#endif
+#endif
+#endif
+
+// ----------- #included from clara_textflow.hpp -----------
+
+// TextFlowCpp
+//
+// A single-header library for wrapping and laying out basic text, by Phil Nash
+//
+// This work is licensed under the BSD 2-Clause license.
+// See the accompanying LICENSE file, or the one at https://opensource.org/licenses/BSD-2-Clause
+//
+// This project is hosted at https://github.com/philsquared/textflowcpp
+
+
+#include <cassert>
+#include <ostream>
+#include <sstream>
+#include <vector>
+
+#ifndef CATCH_CLARA_TEXTFLOW_CONFIG_CONSOLE_WIDTH
+#define CATCH_CLARA_TEXTFLOW_CONFIG_CONSOLE_WIDTH 80
+#endif
+
+namespace Catch { namespace clara { namespace TextFlow {
+
+    inline auto isWhitespace( char c ) -> bool {
+        static std::string chars = " \t\n\r";
+        return chars.find( c ) != std::string::npos;
+    }
+    inline auto isBreakableBefore( char c ) -> bool {
+        static std::string chars = "[({<|";
+        return chars.find( c ) != std::string::npos;
+    }
+    inline auto isBreakableAfter( char c ) -> bool {
+        static std::string chars = "])}>.,:;*+-=&/\\";
+        return chars.find( c ) != std::string::npos;
+    }
+
+    class Columns;
+
+    class Column {
+        std::vector<std::string> m_strings;
+        size_t m_width = CATCH_CLARA_TEXTFLOW_CONFIG_CONSOLE_WIDTH;
+        size_t m_indent = 0;
+        size_t m_initialIndent = std::string::npos;
+
+    public:
+        class iterator {
+            friend Column;
+
+            Column const& m_column;
+            size_t m_stringIndex = 0;
+            size_t m_pos = 0;
+
+            size_t m_len = 0;
+            size_t m_end = 0;
+            bool m_suffix = false;
+
+            iterator( Column const& column, size_t stringIndex )
+            :   m_column( column ),
+                m_stringIndex( stringIndex )
+            {}
+
+            auto line() const -> std::string const& { return m_column.m_strings[m_stringIndex]; }
+
+            auto isBoundary( size_t at ) const -> bool {
+                assert( at > 0 );
+                assert( at <= line().size() );
+
+                return at == line().size() ||
+                       ( isWhitespace( line()[at] ) && !isWhitespace( line()[at-1] ) ) ||
+                       isBreakableBefore( line()[at] ) ||
+                       isBreakableAfter( line()[at-1] );
+            }
+
+            void calcLength() {
+                assert( m_stringIndex < m_column.m_strings.size() );
+
+                m_suffix = false;
+                auto width = m_column.m_width-indent();
+                m_end = m_pos;
+                while( m_end < line().size() && line()[m_end] != '\n' )
+                    ++m_end;
+
+                if( m_end < m_pos + width ) {
+                    m_len = m_end - m_pos;
+                }
+                else {
+                    size_t len = width;
+                    while (len > 0 && !isBoundary(m_pos + len))
+                        --len;
+                    while (len > 0 && isWhitespace( line()[m_pos + len - 1] ))
+                        --len;
+
+                    if (len > 0) {
+                        m_len = len;
+                    } else {
+                        m_suffix = true;
+                        m_len = width - 1;
+                    }
+                }
+            }
+
+            auto indent() const -> size_t {
+                auto initial = m_pos == 0 && m_stringIndex == 0 ? m_column.m_initialIndent : std::string::npos;
+                return initial == std::string::npos ? m_column.m_indent : initial;
+            }
+
+            auto addIndentAndSuffix(std::string const &plain) const -> std::string {
+                return std::string( indent(), ' ' ) + (m_suffix ? plain + "-" : plain);
+            }
+
+        public:
+            explicit iterator( Column const& column ) : m_column( column ) {
+                assert( m_column.m_width > m_column.m_indent );
+                assert( m_column.m_initialIndent == std::string::npos || m_column.m_width > m_column.m_initialIndent );
+                calcLength();
+                if( m_len == 0 )
+                    m_stringIndex++; // Empty string
+            }
+
+            auto operator *() const -> std::string {
+                assert( m_stringIndex < m_column.m_strings.size() );
+                assert( m_pos <= m_end );
+                if( m_pos + m_column.m_width < m_end )
+                    return addIndentAndSuffix(line().substr(m_pos, m_len));
+                else
+                    return addIndentAndSuffix(line().substr(m_pos, m_end - m_pos));
+            }
+
+            auto operator ++() -> iterator& {
+                m_pos += m_len;
+                if( m_pos < line().size() && line()[m_pos] == '\n' )
+                    m_pos += 1;
+                else
+                    while( m_pos < line().size() && isWhitespace( line()[m_pos] ) )
+                        ++m_pos;
+
+                if( m_pos == line().size() ) {
+                    m_pos = 0;
+                    ++m_stringIndex;
+                }
+                if( m_stringIndex < m_column.m_strings.size() )
+                    calcLength();
+                return *this;
+            }
+            auto operator ++(int) -> iterator {
+                iterator prev( *this );
+                operator++();
+                return prev;
+            }
+
+            auto operator ==( iterator const& other ) const -> bool {
+                return
+                    m_pos == other.m_pos &&
+                    m_stringIndex == other.m_stringIndex &&
+                    &m_column == &other.m_column;
+            }
+            auto operator !=( iterator const& other ) const -> bool {
+                return !operator==( other );
+            }
+        };
+        using const_iterator = iterator;
+
+        explicit Column( std::string const& text ) { m_strings.push_back( text ); }
+
+        auto width( size_t newWidth ) -> Column& {
+            assert( newWidth > 0 );
+            m_width = newWidth;
+            return *this;
+        }
+        auto indent( size_t newIndent ) -> Column& {
+            m_indent = newIndent;
+            return *this;
+        }
+        auto initialIndent( size_t newIndent ) -> Column& {
+            m_initialIndent = newIndent;
+            return *this;
+        }
+
+        auto width() const -> size_t { return m_width; }
+        auto begin() const -> iterator { return iterator( *this ); }
+        auto end() const -> iterator { return { *this, m_strings.size() }; }
+
+        inline friend std::ostream& operator << ( std::ostream& os, Column const& col ) {
+            bool first = true;
+            for( auto line : col ) {
+                if( first )
+                    first = false;
+                else
+                    os << "\n";
+                os <<  line;
+            }
+            return os;
+        }
+
+        auto operator + ( Column const& other ) -> Columns;
+
+        auto toString() const -> std::string {
+            std::ostringstream oss;
+            oss << *this;
+            return oss.str();
+        }
+    };
+
+    class Spacer : public Column {
+
+    public:
+        explicit Spacer( size_t spaceWidth ) : Column( "" ) {
+            width( spaceWidth );
+        }
+    };
+
+    class Columns {
+        std::vector<Column> m_columns;
+
+    public:
+
+        class iterator {
+            friend Columns;
+            struct EndTag {};
+
+            std::vector<Column> const& m_columns;
+            std::vector<Column::iterator> m_iterators;
+            size_t m_activeIterators;
+
+            iterator( Columns const& columns, EndTag )
+            :   m_columns( columns.m_columns ),
+                m_activeIterators( 0 )
+            {
+                m_iterators.reserve( m_columns.size() );
+
+                for( auto const& col : m_columns )
+                    m_iterators.push_back( col.end() );
+            }
+
+        public:
+            explicit iterator( Columns const& columns )
+            :   m_columns( columns.m_columns ),
+                m_activeIterators( m_columns.size() )
+            {
+                m_iterators.reserve( m_columns.size() );
+
+                for( auto const& col : m_columns )
+                    m_iterators.push_back( col.begin() );
+            }
+
+            auto operator ==( iterator const& other ) const -> bool {
+                return m_iterators == other.m_iterators;
+            }
+            auto operator !=( iterator const& other ) const -> bool {
+                return m_iterators != other.m_iterators;
+            }
+            auto operator *() const -> std::string {
+                std::string row, padding;
+
+                for( size_t i = 0; i < m_columns.size(); ++i ) {
+                    auto width = m_columns[i].width();
+                    if( m_iterators[i] != m_columns[i].end() ) {
+                        std::string col = *m_iterators[i];
+                        row += padding + col;
+                        if( col.size() < width )
+                            padding = std::string( width - col.size(), ' ' );
+                        else
+                            padding = "";
+                    }
+                    else {
+                        padding += std::string( width, ' ' );
+                    }
+                }
+                return row;
+            }
+            auto operator ++() -> iterator& {
+                for( size_t i = 0; i < m_columns.size(); ++i ) {
+                    if (m_iterators[i] != m_columns[i].end())
+                        ++m_iterators[i];
+                }
+                return *this;
+            }
+            auto operator ++(int) -> iterator {
+                iterator prev( *this );
+                operator++();
+                return prev;
+            }
+        };
+        using const_iterator = iterator;
+
+        auto begin() const -> iterator { return iterator( *this ); }
+        auto end() const -> iterator { return { *this, iterator::EndTag() }; }
+
+        auto operator += ( Column const& col ) -> Columns& {
+            m_columns.push_back( col );
+            return *this;
+        }
+        auto operator + ( Column const& col ) -> Columns {
+            Columns combined = *this;
+            combined += col;
+            return combined;
+        }
+
+        inline friend std::ostream& operator << ( std::ostream& os, Columns const& cols ) {
+
+            bool first = true;
+            for( auto line : cols ) {
+                if( first )
+                    first = false;
+                else
+                    os << "\n";
+                os << line;
+            }
+            return os;
+        }
+
+        auto toString() const -> std::string {
+            std::ostringstream oss;
+            oss << *this;
+            return oss.str();
+        }
+    };
+
+    inline auto Column::operator + ( Column const& other ) -> Columns {
+        Columns cols;
+        cols += *this;
+        cols += other;
+        return cols;
+    }
+}}} // namespace Catch::clara::TextFlow
+
+// ----------- end of #include from clara_textflow.hpp -----------
+// ........... back in clara.hpp
+
+#include <memory>
+#include <set>
+#include <algorithm>
+
+#if !defined(CATCH_PLATFORM_WINDOWS) && ( defined(WIN32) || defined(__WIN32__) || defined(_WIN32) || defined(_MSC_VER) )
+#define CATCH_PLATFORM_WINDOWS
+#endif
+
+namespace Catch { namespace clara {
+namespace detail {
+
+    // Traits for extracting arg and return type of lambdas (for single argument lambdas)
+    template<typename L>
+    struct UnaryLambdaTraits : UnaryLambdaTraits<decltype( &L::operator() )> {};
+
+    template<typename ClassT, typename ReturnT, typename... Args>
+    struct UnaryLambdaTraits<ReturnT( ClassT::* )( Args... ) const> {
+        static const bool isValid = false;
+    };
+
+    template<typename ClassT, typename ReturnT, typename ArgT>
+    struct UnaryLambdaTraits<ReturnT( ClassT::* )( ArgT ) const> {
+        static const bool isValid = true;
+        using ArgType = typename std::remove_const<typename std::remove_reference<ArgT>::type>::type;
+        using ReturnType = ReturnT;
+    };
+
+    class TokenStream;
+
+    // Transport for raw args (copied from main args, or supplied via init list for testing)
+    class Args {
+        friend TokenStream;
+        std::string m_exeName;
+        std::vector<std::string> m_args;
+
+    public:
+        Args( int argc, char const* const* argv )
+            : m_exeName(argv[0]),
+              m_args(argv + 1, argv + argc) {}
+
+        Args( std::initializer_list<std::string> args )
+        :   m_exeName( *args.begin() ),
+            m_args( args.begin()+1, args.end() )
+        {}
+
+        auto exeName() const -> std::string {
+            return m_exeName;
+        }
+    };
+
+    // Wraps a token coming from a token stream. These may not directly correspond to strings as a single string
+    // may encode an option + its argument if the : or = form is used
+    enum class TokenType {
+        Option, Argument
+    };
+    struct Token {
+        TokenType type;
+        std::string token;
+    };
+
+    inline auto isOptPrefix( char c ) -> bool {
+        return c == '-'
+#ifdef CATCH_PLATFORM_WINDOWS
+            || c == '/'
+#endif
+        ;
+    }
+
+    // Abstracts iterators into args as a stream of tokens, with option arguments uniformly handled
+    class TokenStream {
+        using Iterator = std::vector<std::string>::const_iterator;
+        Iterator it;
+        Iterator itEnd;
+        std::vector<Token> m_tokenBuffer;
+
+        void loadBuffer() {
+            m_tokenBuffer.resize( 0 );
+
+            // Skip any empty strings
+            while( it != itEnd && it->empty() )
+                ++it;
+
+            if( it != itEnd ) {
+                auto const &next = *it;
+                if( isOptPrefix( next[0] ) ) {
+                    auto delimiterPos = next.find_first_of( " :=" );
+                    if( delimiterPos != std::string::npos ) {
+                        m_tokenBuffer.push_back( { TokenType::Option, next.substr( 0, delimiterPos ) } );
+                        m_tokenBuffer.push_back( { TokenType::Argument, next.substr( delimiterPos + 1 ) } );
+                    } else {
+                        if( next[1] != '-' && next.size() > 2 ) {
+                            std::string opt = "- ";
+                            for( size_t i = 1; i < next.size(); ++i ) {
+                                opt[1] = next[i];
+                                m_tokenBuffer.push_back( { TokenType::Option, opt } );
+                            }
+                        } else {
+                            m_tokenBuffer.push_back( { TokenType::Option, next } );
+                        }
+                    }
+                } else {
+                    m_tokenBuffer.push_back( { TokenType::Argument, next } );
+                }
+            }
+        }
+
+    public:
+        explicit TokenStream( Args const &args ) : TokenStream( args.m_args.begin(), args.m_args.end() ) {}
+
+        TokenStream( Iterator it, Iterator itEnd ) : it( it ), itEnd( itEnd ) {
+            loadBuffer();
+        }
+
+        explicit operator bool() const {
+            return !m_tokenBuffer.empty() || it != itEnd;
+        }
+
+        auto count() const -> size_t { return m_tokenBuffer.size() + (itEnd - it); }
+
+        auto operator*() const -> Token {
+            assert( !m_tokenBuffer.empty() );
+            return m_tokenBuffer.front();
+        }
+
+        auto operator->() const -> Token const * {
+            assert( !m_tokenBuffer.empty() );
+            return &m_tokenBuffer.front();
+        }
+
+        auto operator++() -> TokenStream & {
+            if( m_tokenBuffer.size() >= 2 ) {
+                m_tokenBuffer.erase( m_tokenBuffer.begin() );
+            } else {
+                if( it != itEnd )
+                    ++it;
+                loadBuffer();
+            }
+            return *this;
+        }
+    };
+
+    class ResultBase {
+    public:
+        enum Type {
+            Ok, LogicError, RuntimeError
+        };
+
+    protected:
+        ResultBase( Type type ) : m_type( type ) {}
+        virtual ~ResultBase() = default;
+
+        virtual void enforceOk() const = 0;
+
+        Type m_type;
+    };
+
+    template<typename T>
+    class ResultValueBase : public ResultBase {
+    public:
+        auto value() const -> T const & {
+            enforceOk();
+            return m_value;
+        }
+
+    protected:
+        ResultValueBase( Type type ) : ResultBase( type ) {}
+
+        ResultValueBase( ResultValueBase const &other ) : ResultBase( other ) {
+            if( m_type == ResultBase::Ok )
+                new( &m_value ) T( other.m_value );
+        }
+
+        ResultValueBase( Type, T const &value ) : ResultBase( Ok ) {
+            new( &m_value ) T( value );
+        }
+
+        auto operator=( ResultValueBase const &other ) -> ResultValueBase & {
+            if( m_type == ResultBase::Ok )
+                m_value.~T();
+            ResultBase::operator=(other);
+            if( m_type == ResultBase::Ok )
+                new( &m_value ) T( other.m_value );
+            return *this;
+        }
+
+        ~ResultValueBase() override {
+            if( m_type == Ok )
+                m_value.~T();
+        }
+
+        union {
+            T m_value;
+        };
+    };
+
+    template<>
+    class ResultValueBase<void> : public ResultBase {
+    protected:
+        using ResultBase::ResultBase;
+    };
+
+    template<typename T = void>
+    class BasicResult : public ResultValueBase<T> {
+    public:
+        template<typename U>
+        explicit BasicResult( BasicResult<U> const &other )
+        :   ResultValueBase<T>( other.type() ),
+            m_errorMessage( other.errorMessage() )
+        {
+            assert( type() != ResultBase::Ok );
+        }
+
+        template<typename U>
+        static auto ok( U const &value ) -> BasicResult { return { ResultBase::Ok, value }; }
+        static auto ok() -> BasicResult { return { ResultBase::Ok }; }
+        static auto logicError( std::string const &message ) -> BasicResult { return { ResultBase::LogicError, message }; }
+        static auto runtimeError( std::string const &message ) -> BasicResult { return { ResultBase::RuntimeError, message }; }
+
+        explicit operator bool() const { return m_type == ResultBase::Ok; }
+        auto type() const -> ResultBase::Type { return m_type; }
+        auto errorMessage() const -> std::string { return m_errorMessage; }
+
+    protected:
+        void enforceOk() const override {
+
+            // Errors shouldn't reach this point, but if they do
+            // the actual error message will be in m_errorMessage
+            assert( m_type != ResultBase::LogicError );
+            assert( m_type != ResultBase::RuntimeError );
+            if( m_type != ResultBase::Ok )
+                std::abort();
+        }
+
+        std::string m_errorMessage; // Only populated if resultType is an error
+
+        BasicResult( ResultBase::Type type, std::string const &message )
+        :   ResultValueBase<T>(type),
+            m_errorMessage(message)
+        {
+            assert( m_type != ResultBase::Ok );
+        }
+
+        using ResultValueBase<T>::ResultValueBase;
+        using ResultBase::m_type;
+    };
+
+    enum class ParseResultType {
+        Matched, NoMatch, ShortCircuitAll, ShortCircuitSame
+    };
+
+    class ParseState {
+    public:
+
+        ParseState( ParseResultType type, TokenStream const &remainingTokens )
+        : m_type(type),
+          m_remainingTokens( remainingTokens )
+        {}
+
+        auto type() const -> ParseResultType { return m_type; }
+        auto remainingTokens() const -> TokenStream { return m_remainingTokens; }
+
+    private:
+        ParseResultType m_type;
+        TokenStream m_remainingTokens;
+    };
+
+    using Result = BasicResult<void>;
+    using ParserResult = BasicResult<ParseResultType>;
+    using InternalParseResult = BasicResult<ParseState>;
+
+    struct HelpColumns {
+        std::string left;
+        std::string right;
+    };
+
+    template<typename T>
+    inline auto convertInto( std::string const &source, T& target ) -> ParserResult {
+        std::stringstream ss;
+        ss << source;
+        ss >> target;
+        if( ss.fail() )
+            return ParserResult::runtimeError( "Unable to convert '" + source + "' to destination type" );
+        else
+            return ParserResult::ok( ParseResultType::Matched );
+    }
+    inline auto convertInto( std::string const &source, std::string& target ) -> ParserResult {
+        target = source;
+        return ParserResult::ok( ParseResultType::Matched );
+    }
+    inline auto convertInto( std::string const &source, bool &target ) -> ParserResult {
+        std::string srcLC = source;
+        std::transform( srcLC.begin(), srcLC.end(), srcLC.begin(), []( char c ) { return static_cast<char>( ::tolower(c) ); } );
+        if (srcLC == "y" || srcLC == "1" || srcLC == "true" || srcLC == "yes" || srcLC == "on")
+            target = true;
+        else if (srcLC == "n" || srcLC == "0" || srcLC == "false" || srcLC == "no" || srcLC == "off")
+            target = false;
+        else
+            return ParserResult::runtimeError( "Expected a boolean value but did not recognise: '" + source + "'" );
+        return ParserResult::ok( ParseResultType::Matched );
+    }
+#ifdef CLARA_CONFIG_OPTIONAL_TYPE
+    template<typename T>
+    inline auto convertInto( std::string const &source, CLARA_CONFIG_OPTIONAL_TYPE<T>& target ) -> ParserResult {
+        T temp;
+        auto result = convertInto( source, temp );
+        if( result )
+            target = std::move(temp);
+        return result;
+    }
+#endif // CLARA_CONFIG_OPTIONAL_TYPE
+
+    struct NonCopyable {
+        NonCopyable() = default;
+        NonCopyable( NonCopyable const & ) = delete;
+        NonCopyable( NonCopyable && ) = delete;
+        NonCopyable &operator=( NonCopyable const & ) = delete;
+        NonCopyable &operator=( NonCopyable && ) = delete;
+    };
+
+    struct BoundRef : NonCopyable {
+        virtual ~BoundRef() = default;
+        virtual auto isContainer() const -> bool { return false; }
+        virtual auto isFlag() const -> bool { return false; }
+    };
+    struct BoundValueRefBase : BoundRef {
+        virtual auto setValue( std::string const &arg ) -> ParserResult = 0;
+    };
+    struct BoundFlagRefBase : BoundRef {
+        virtual auto setFlag( bool flag ) -> ParserResult = 0;
+        virtual auto isFlag() const -> bool { return true; }
+    };
+
+    template<typename T>
+    struct BoundValueRef : BoundValueRefBase {
+        T &m_ref;
+
+        explicit BoundValueRef( T &ref ) : m_ref( ref ) {}
+
+        auto setValue( std::string const &arg ) -> ParserResult override {
+            return convertInto( arg, m_ref );
+        }
+    };
+
+    template<typename T>
+    struct BoundValueRef<std::vector<T>> : BoundValueRefBase {
+        std::vector<T> &m_ref;
+
+        explicit BoundValueRef( std::vector<T> &ref ) : m_ref( ref ) {}
+
+        auto isContainer() const -> bool override { return true; }
+
+        auto setValue( std::string const &arg ) -> ParserResult override {
+            T temp;
+            auto result = convertInto( arg, temp );
+            if( result )
+                m_ref.push_back( temp );
+            return result;
+        }
+    };
+
+    struct BoundFlagRef : BoundFlagRefBase {
+        bool &m_ref;
+
+        explicit BoundFlagRef( bool &ref ) : m_ref( ref ) {}
+
+        auto setFlag( bool flag ) -> ParserResult override {
+            m_ref = flag;
+            return ParserResult::ok( ParseResultType::Matched );
+        }
+    };
+
+    template<typename ReturnType>
+    struct LambdaInvoker {
+        static_assert( std::is_same<ReturnType, ParserResult>::value, "Lambda must return void or clara::ParserResult" );
+
+        template<typename L, typename ArgType>
+        static auto invoke( L const &lambda, ArgType const &arg ) -> ParserResult {
+            return lambda( arg );
+        }
+    };
+
+    template<>
+    struct LambdaInvoker<void> {
+        template<typename L, typename ArgType>
+        static auto invoke( L const &lambda, ArgType const &arg ) -> ParserResult {
+            lambda( arg );
+            return ParserResult::ok( ParseResultType::Matched );
+        }
+    };
+
+    template<typename ArgType, typename L>
+    inline auto invokeLambda( L const &lambda, std::string const &arg ) -> ParserResult {
+        ArgType temp{};
+        auto result = convertInto( arg, temp );
+        return !result
+           ? result
+           : LambdaInvoker<typename UnaryLambdaTraits<L>::ReturnType>::invoke( lambda, temp );
+    }
+
+    template<typename L>
+    struct BoundLambda : BoundValueRefBase {
+        L m_lambda;
+
+        static_assert( UnaryLambdaTraits<L>::isValid, "Supplied lambda must take exactly one argument" );
+        explicit BoundLambda( L const &lambda ) : m_lambda( lambda ) {}
+
+        auto setValue( std::string const &arg ) -> ParserResult override {
+            return invokeLambda<typename UnaryLambdaTraits<L>::ArgType>( m_lambda, arg );
+        }
+    };
+
+    template<typename L>
+    struct BoundFlagLambda : BoundFlagRefBase {
+        L m_lambda;
+
+        static_assert( UnaryLambdaTraits<L>::isValid, "Supplied lambda must take exactly one argument" );
+        static_assert( std::is_same<typename UnaryLambdaTraits<L>::ArgType, bool>::value, "flags must be boolean" );
+
+        explicit BoundFlagLambda( L const &lambda ) : m_lambda( lambda ) {}
+
+        auto setFlag( bool flag ) -> ParserResult override {
+            return LambdaInvoker<typename UnaryLambdaTraits<L>::ReturnType>::invoke( m_lambda, flag );
+        }
+    };
+
+    enum class Optionality { Optional, Required };
+
+    struct Parser;
+
+    class ParserBase {
+    public:
+        virtual ~ParserBase() = default;
+        virtual auto validate() const -> Result { return Result::ok(); }
+        virtual auto parse( std::string const& exeName, TokenStream const &tokens) const -> InternalParseResult  = 0;
+        virtual auto cardinality() const -> size_t { return 1; }
+
+        auto parse( Args const &args ) const -> InternalParseResult {
+            return parse( args.exeName(), TokenStream( args ) );
+        }
+    };
+
+    template<typename DerivedT>
+    class ComposableParserImpl : public ParserBase {
+    public:
+        template<typename T>
+        auto operator|( T const &other ) const -> Parser;
+
+		template<typename T>
+        auto operator+( T const &other ) const -> Parser;
+    };
+
+    // Common code and state for Args and Opts
+    template<typename DerivedT>
+    class ParserRefImpl : public ComposableParserImpl<DerivedT> {
+    protected:
+        Optionality m_optionality = Optionality::Optional;
+        std::shared_ptr<BoundRef> m_ref;
+        std::string m_hint;
+        std::string m_description;
+
+        explicit ParserRefImpl( std::shared_ptr<BoundRef> const &ref ) : m_ref( ref ) {}
+
+    public:
+        template<typename T>
+        ParserRefImpl( T &ref, std::string const &hint )
+        :   m_ref( std::make_shared<BoundValueRef<T>>( ref ) ),
+            m_hint( hint )
+        {}
+
+        template<typename LambdaT>
+        ParserRefImpl( LambdaT const &ref, std::string const &hint )
+        :   m_ref( std::make_shared<BoundLambda<LambdaT>>( ref ) ),
+            m_hint(hint)
+        {}
+
+        auto operator()( std::string const &description ) -> DerivedT & {
+            m_description = description;
+            return static_cast<DerivedT &>( *this );
+        }
+
+        auto optional() -> DerivedT & {
+            m_optionality = Optionality::Optional;
+            return static_cast<DerivedT &>( *this );
+        };
+
+        auto required() -> DerivedT & {
+            m_optionality = Optionality::Required;
+            return static_cast<DerivedT &>( *this );
+        };
+
+        auto isOptional() const -> bool {
+            return m_optionality == Optionality::Optional;
+        }
+
+        auto cardinality() const -> size_t override {
+            if( m_ref->isContainer() )
+                return 0;
+            else
+                return 1;
+        }
+
+        auto hint() const -> std::string { return m_hint; }
+    };
+
+    class ExeName : public ComposableParserImpl<ExeName> {
+        std::shared_ptr<std::string> m_name;
+        std::shared_ptr<BoundValueRefBase> m_ref;
+
+        template<typename LambdaT>
+        static auto makeRef(LambdaT const &lambda) -> std::shared_ptr<BoundValueRefBase> {
+            return std::make_shared<BoundLambda<LambdaT>>( lambda) ;
+        }
+
+    public:
+        ExeName() : m_name( std::make_shared<std::string>( "<executable>" ) ) {}
+
+        explicit ExeName( std::string &ref ) : ExeName() {
+            m_ref = std::make_shared<BoundValueRef<std::string>>( ref );
+        }
+
+        template<typename LambdaT>
+        explicit ExeName( LambdaT const& lambda ) : ExeName() {
+            m_ref = std::make_shared<BoundLambda<LambdaT>>( lambda );
+        }
+
+        // The exe name is not parsed out of the normal tokens, but is handled specially
+        auto parse( std::string const&, TokenStream const &tokens ) const -> InternalParseResult override {
+            return InternalParseResult::ok( ParseState( ParseResultType::NoMatch, tokens ) );
+        }
+
+        auto name() const -> std::string { return *m_name; }
+        auto set( std::string const& newName ) -> ParserResult {
+
+            auto lastSlash = newName.find_last_of( "\\/" );
+            auto filename = ( lastSlash == std::string::npos )
+                    ? newName
+                    : newName.substr( lastSlash+1 );
+
+            *m_name = filename;
+            if( m_ref )
+                return m_ref->setValue( filename );
+            else
+                return ParserResult::ok( ParseResultType::Matched );
+        }
+    };
+
+    class Arg : public ParserRefImpl<Arg> {
+    public:
+        using ParserRefImpl::ParserRefImpl;
+
+        auto parse( std::string const &, TokenStream const &tokens ) const -> InternalParseResult override {
+            auto validationResult = validate();
+            if( !validationResult )
+                return InternalParseResult( validationResult );
+
+            auto remainingTokens = tokens;
+            auto const &token = *remainingTokens;
+            if( token.type != TokenType::Argument )
+                return InternalParseResult::ok( ParseState( ParseResultType::NoMatch, remainingTokens ) );
+
+            assert( !m_ref->isFlag() );
+            auto valueRef = static_cast<detail::BoundValueRefBase*>( m_ref.get() );
+
+            auto result = valueRef->setValue( remainingTokens->token );
+            if( !result )
+                return InternalParseResult( result );
+            else
+                return InternalParseResult::ok( ParseState( ParseResultType::Matched, ++remainingTokens ) );
+        }
+    };
+
+    inline auto normaliseOpt( std::string const &optName ) -> std::string {
+#ifdef CATCH_PLATFORM_WINDOWS
+        if( optName[0] == '/' )
+            return "-" + optName.substr( 1 );
+        else
+#endif
+            return optName;
+    }
+
+    class Opt : public ParserRefImpl<Opt> {
+    protected:
+        std::vector<std::string> m_optNames;
+
+    public:
+        template<typename LambdaT>
+        explicit Opt( LambdaT const &ref ) : ParserRefImpl( std::make_shared<BoundFlagLambda<LambdaT>>( ref ) ) {}
+
+        explicit Opt( bool &ref ) : ParserRefImpl( std::make_shared<BoundFlagRef>( ref ) ) {}
+
+        template<typename LambdaT>
+        Opt( LambdaT const &ref, std::string const &hint ) : ParserRefImpl( ref, hint ) {}
+
+        template<typename T>
+        Opt( T &ref, std::string const &hint ) : ParserRefImpl( ref, hint ) {}
+
+        auto operator[]( std::string const &optName ) -> Opt & {
+            m_optNames.push_back( optName );
+            return *this;
+        }
+
+        auto getHelpColumns() const -> std::vector<HelpColumns> {
+            std::ostringstream oss;
+            bool first = true;
+            for( auto const &opt : m_optNames ) {
+                if (first)
+                    first = false;
+                else
+                    oss << ", ";
+                oss << opt;
+            }
+            if( !m_hint.empty() )
+                oss << " <" << m_hint << ">";
+            return { { oss.str(), m_description } };
+        }
+
+        auto isMatch( std::string const &optToken ) const -> bool {
+            auto normalisedToken = normaliseOpt( optToken );
+            for( auto const &name : m_optNames ) {
+                if( normaliseOpt( name ) == normalisedToken )
+                    return true;
+            }
+            return false;
+        }
+
+        using ParserBase::parse;
+
+        auto parse( std::string const&, TokenStream const &tokens ) const -> InternalParseResult override {
+            auto validationResult = validate();
+            if( !validationResult )
+                return InternalParseResult( validationResult );
+
+            auto remainingTokens = tokens;
+            if( remainingTokens && remainingTokens->type == TokenType::Option ) {
+                auto const &token = *remainingTokens;
+                if( isMatch(token.token ) ) {
+                    if( m_ref->isFlag() ) {
+                        auto flagRef = static_cast<detail::BoundFlagRefBase*>( m_ref.get() );
+                        auto result = flagRef->setFlag( true );
+                        if( !result )
+                            return InternalParseResult( result );
+                        if( result.value() == ParseResultType::ShortCircuitAll )
+                            return InternalParseResult::ok( ParseState( result.value(), remainingTokens ) );
+                    } else {
+                        auto valueRef = static_cast<detail::BoundValueRefBase*>( m_ref.get() );
+                        ++remainingTokens;
+                        if( !remainingTokens )
+                            return InternalParseResult::runtimeError( "Expected argument following " + token.token );
+                        auto const &argToken = *remainingTokens;
+                        if( argToken.type != TokenType::Argument )
+                            return InternalParseResult::runtimeError( "Expected argument following " + token.token );
+                        auto result = valueRef->setValue( argToken.token );
+                        if( !result )
+                            return InternalParseResult( result );
+                        if( result.value() == ParseResultType::ShortCircuitAll )
+                            return InternalParseResult::ok( ParseState( result.value(), remainingTokens ) );
+                    }
+                    return InternalParseResult::ok( ParseState( ParseResultType::Matched, ++remainingTokens ) );
+                }
+            }
+            return InternalParseResult::ok( ParseState( ParseResultType::NoMatch, remainingTokens ) );
+        }
+
+        auto validate() const -> Result override {
+            if( m_optNames.empty() )
+                return Result::logicError( "No options supplied to Opt" );
+            for( auto const &name : m_optNames ) {
+                if( name.empty() )
+                    return Result::logicError( "Option name cannot be empty" );
+#ifdef CATCH_PLATFORM_WINDOWS
+                if( name[0] != '-' && name[0] != '/' )
+                    return Result::logicError( "Option name must begin with '-' or '/'" );
+#else
+                if( name[0] != '-' )
+                    return Result::logicError( "Option name must begin with '-'" );
+#endif
+            }
+            return ParserRefImpl::validate();
+        }
+    };
+
+    struct Help : Opt {
+        Help( bool &showHelpFlag )
+        :   Opt([&]( bool flag ) {
+                showHelpFlag = flag;
+                return ParserResult::ok( ParseResultType::ShortCircuitAll );
+            })
+        {
+            static_cast<Opt &>( *this )
+                    ("display usage information")
+                    ["-?"]["-h"]["--help"]
+                    .optional();
+        }
+    };
+
+    struct Parser : ParserBase {
+
+        mutable ExeName m_exeName;
+        std::vector<Opt> m_options;
+        std::vector<Arg> m_args;
+
+        auto operator|=( ExeName const &exeName ) -> Parser & {
+            m_exeName = exeName;
+            return *this;
+        }
+
+        auto operator|=( Arg const &arg ) -> Parser & {
+            m_args.push_back(arg);
+            return *this;
+        }
+
+        auto operator|=( Opt const &opt ) -> Parser & {
+            m_options.push_back(opt);
+            return *this;
+        }
+
+        auto operator|=( Parser const &other ) -> Parser & {
+            m_options.insert(m_options.end(), other.m_options.begin(), other.m_options.end());
+            m_args.insert(m_args.end(), other.m_args.begin(), other.m_args.end());
+            return *this;
+        }
+
+        template<typename T>
+        auto operator|( T const &other ) const -> Parser {
+            return Parser( *this ) |= other;
+        }
+
+        // Forward deprecated interface with '+' instead of '|'
+        template<typename T>
+        auto operator+=( T const &other ) -> Parser & { return operator|=( other ); }
+        template<typename T>
+        auto operator+( T const &other ) const -> Parser { return operator|( other ); }
+
+        auto getHelpColumns() const -> std::vector<HelpColumns> {
+            std::vector<HelpColumns> cols;
+            for (auto const &o : m_options) {
+                auto childCols = o.getHelpColumns();
+                cols.insert( cols.end(), childCols.begin(), childCols.end() );
+            }
+            return cols;
+        }
+
+        void writeToStream( std::ostream &os ) const {
+            if (!m_exeName.name().empty()) {
+                os << "usage:\n" << "  " << m_exeName.name() << " ";
+                bool required = true, first = true;
+                for( auto const &arg : m_args ) {
+                    if (first)
+                        first = false;
+                    else
+                        os << " ";
+                    if( arg.isOptional() && required ) {
+                        os << "[";
+                        required = false;
+                    }
+                    os << "<" << arg.hint() << ">";
+                    if( arg.cardinality() == 0 )
+                        os << " ... ";
+                }
+                if( !required )
+                    os << "]";
+                if( !m_options.empty() )
+                    os << " options";
+                os << "\n\nwhere options are:" << std::endl;
+            }
+
+            auto rows = getHelpColumns();
+            size_t consoleWidth = CATCH_CLARA_CONFIG_CONSOLE_WIDTH;
+            size_t optWidth = 0;
+            for( auto const &cols : rows )
+                optWidth = (std::max)(optWidth, cols.left.size() + 2);
+
+            optWidth = (std::min)(optWidth, consoleWidth/2);
+
+            for( auto const &cols : rows ) {
+                auto row =
+                        TextFlow::Column( cols.left ).width( optWidth ).indent( 2 ) +
+                        TextFlow::Spacer(4) +
+                        TextFlow::Column( cols.right ).width( consoleWidth - 7 - optWidth );
+                os << row << std::endl;
+            }
+        }
+
+        friend auto operator<<( std::ostream &os, Parser const &parser ) -> std::ostream& {
+            parser.writeToStream( os );
+            return os;
+        }
+
+        auto validate() const -> Result override {
+            for( auto const &opt : m_options ) {
+                auto result = opt.validate();
+                if( !result )
+                    return result;
+            }
+            for( auto const &arg : m_args ) {
+                auto result = arg.validate();
+                if( !result )
+                    return result;
+            }
+            return Result::ok();
+        }
+
+        using ParserBase::parse;
+
+        auto parse( std::string const& exeName, TokenStream const &tokens ) const -> InternalParseResult override {
+
+            struct ParserInfo {
+                ParserBase const* parser = nullptr;
+                size_t count = 0;
+            };
+            const size_t totalParsers = m_options.size() + m_args.size();
+            assert( totalParsers < 512 );
+            // ParserInfo parseInfos[totalParsers]; // <-- this is what we really want to do
+            ParserInfo parseInfos[512];
+
+            {
+                size_t i = 0;
+                for (auto const &opt : m_options) parseInfos[i++].parser = &opt;
+                for (auto const &arg : m_args) parseInfos[i++].parser = &arg;
+            }
+
+            m_exeName.set( exeName );
+
+            auto result = InternalParseResult::ok( ParseState( ParseResultType::NoMatch, tokens ) );
+            while( result.value().remainingTokens() ) {
+                bool tokenParsed = false;
+
+                for( size_t i = 0; i < totalParsers; ++i ) {
+                    auto&  parseInfo = parseInfos[i];
+                    if( parseInfo.parser->cardinality() == 0 || parseInfo.count < parseInfo.parser->cardinality() ) {
+                        result = parseInfo.parser->parse(exeName, result.value().remainingTokens());
+                        if (!result)
+                            return result;
+                        if (result.value().type() != ParseResultType::NoMatch) {
+                            tokenParsed = true;
+                            ++parseInfo.count;
+                            break;
+                        }
+                    }
+                }
+
+                if( result.value().type() == ParseResultType::ShortCircuitAll )
+                    return result;
+                if( !tokenParsed )
+                    return InternalParseResult::runtimeError( "Unrecognised token: " + result.value().remainingTokens()->token );
+            }
+            // !TBD Check missing required options
+            return result;
+        }
+    };
+
+    template<typename DerivedT>
+    template<typename T>
+    auto ComposableParserImpl<DerivedT>::operator|( T const &other ) const -> Parser {
+        return Parser() | static_cast<DerivedT const &>( *this ) | other;
+    }
+} // namespace detail
+
+// A Combined parser
+using detail::Parser;
+
+// A parser for options
+using detail::Opt;
+
+// A parser for arguments
+using detail::Arg;
+
+// Wrapper for argc, argv from main()
+using detail::Args;
+
+// Specifies the name of the executable
+using detail::ExeName;
+
+// Convenience wrapper for option parser that specifies the help option
+using detail::Help;
+
+// enum of result types from a parse
+using detail::ParseResultType;
+
+// Result type for parser operation
+using detail::ParserResult;
+
+}} // namespace Catch::clara
+
+// end clara.hpp
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+// Restore Clara's value for console width, if present
+#ifdef CATCH_TEMP_CLARA_CONFIG_CONSOLE_WIDTH
+#define CATCH_CLARA_TEXTFLOW_CONFIG_CONSOLE_WIDTH CATCH_TEMP_CLARA_CONFIG_CONSOLE_WIDTH
+#undef CATCH_TEMP_CLARA_CONFIG_CONSOLE_WIDTH
+#endif
+
+// end catch_clara.h
+namespace Catch {
+
+    clara::Parser makeCommandLineParser( ConfigData& config );
+
+} // end namespace Catch
+
+// end catch_commandline.h
+#include <fstream>
+#include <ctime>
+
+namespace Catch {
+
+    clara::Parser makeCommandLineParser( ConfigData& config ) {
+
+        using namespace clara;
+
+        auto const setWarning = [&]( std::string const& warning ) {
+                auto warningSet = [&]() {
+                    if( warning == "NoAssertions" )
+                        return WarnAbout::NoAssertions;
+
+                    if ( warning == "NoTests" )
+                        return WarnAbout::NoTests;
+
+                    return WarnAbout::Nothing;
+                }();
+
+                if (warningSet == WarnAbout::Nothing)
+                    return ParserResult::runtimeError( "Unrecognised warning: '" + warning + "'" );
+                config.warnings = static_cast<WarnAbout::What>( config.warnings | warningSet );
+                return ParserResult::ok( ParseResultType::Matched );
+            };
+        auto const loadTestNamesFromFile = [&]( std::string const& filename ) {
+                std::ifstream f( filename.c_str() );
+                if( !f.is_open() )
+                    return ParserResult::runtimeError( "Unable to load input file: '" + filename + "'" );
+
+                std::string line;
+                while( std::getline( f, line ) ) {
+                    line = trim(line);
+                    if( !line.empty() && !startsWith( line, '#' ) ) {
+                        if( !startsWith( line, '"' ) )
+                            line = '"' + line + '"';
+                        config.testsOrTags.push_back( line + ',' );
+                    }
+                }
+                return ParserResult::ok( ParseResultType::Matched );
+            };
+        auto const setTestOrder = [&]( std::string const& order ) {
+                if( startsWith( "declared", order ) )
+                    config.runOrder = RunTests::InDeclarationOrder;
+                else if( startsWith( "lexical", order ) )
+                    config.runOrder = RunTests::InLexicographicalOrder;
+                else if( startsWith( "random", order ) )
+                    config.runOrder = RunTests::InRandomOrder;
+                else
+                    return clara::ParserResult::runtimeError( "Unrecognised ordering: '" + order + "'" );
+                return ParserResult::ok( ParseResultType::Matched );
+            };
+        auto const setRngSeed = [&]( std::string const& seed ) {
+                if( seed != "time" )
+                    return clara::detail::convertInto( seed, config.rngSeed );
+                config.rngSeed = static_cast<unsigned int>( std::time(nullptr) );
+                return ParserResult::ok( ParseResultType::Matched );
+            };
+        auto const setColourUsage = [&]( std::string const& useColour ) {
+                    auto mode = toLower( useColour );
+
+                    if( mode == "yes" )
+                        config.useColour = UseColour::Yes;
+                    else if( mode == "no" )
+                        config.useColour = UseColour::No;
+                    else if( mode == "auto" )
+                        config.useColour = UseColour::Auto;
+                    else
+                        return ParserResult::runtimeError( "colour mode must be one of: auto, yes or no. '" + useColour + "' not recognised" );
+                return ParserResult::ok( ParseResultType::Matched );
+            };
+        auto const setWaitForKeypress = [&]( std::string const& keypress ) {
+                auto keypressLc = toLower( keypress );
+                if( keypressLc == "start" )
+                    config.waitForKeypress = WaitForKeypress::BeforeStart;
+                else if( keypressLc == "exit" )
+                    config.waitForKeypress = WaitForKeypress::BeforeExit;
+                else if( keypressLc == "both" )
+                    config.waitForKeypress = WaitForKeypress::BeforeStartAndExit;
+                else
+                    return ParserResult::runtimeError( "keypress argument must be one of: start, exit or both. '" + keypress + "' not recognised" );
+            return ParserResult::ok( ParseResultType::Matched );
+            };
+        auto const setVerbosity = [&]( std::string const& verbosity ) {
+            auto lcVerbosity = toLower( verbosity );
+            if( lcVerbosity == "quiet" )
+                config.verbosity = Verbosity::Quiet;
+            else if( lcVerbosity == "normal" )
+                config.verbosity = Verbosity::Normal;
+            else if( lcVerbosity == "high" )
+                config.verbosity = Verbosity::High;
+            else
+                return ParserResult::runtimeError( "Unrecognised verbosity, '" + verbosity + "'" );
+            return ParserResult::ok( ParseResultType::Matched );
+        };
+
+        auto cli
+            = ExeName( config.processName )
+            | Help( config.showHelp )
+            | Opt( config.listTests )
+                ["-l"]["--list-tests"]
+                ( "list all/matching test cases" )
+            | Opt( config.listTags )
+                ["-t"]["--list-tags"]
+                ( "list all/matching tags" )
+            | Opt( config.showSuccessfulTests )
+                ["-s"]["--success"]
+                ( "include successful tests in output" )
+            | Opt( config.shouldDebugBreak )
+                ["-b"]["--break"]
+                ( "break into debugger on failure" )
+            | Opt( config.noThrow )
+                ["-e"]["--nothrow"]
+                ( "skip exception tests" )
+            | Opt( config.showInvisibles )
+                ["-i"]["--invisibles"]
+                ( "show invisibles (tabs, newlines)" )
+            | Opt( config.outputFilename, "filename" )
+                ["-o"]["--out"]
+                ( "output filename" )
+            | Opt( config.reporterNames, "name" )
+                ["-r"]["--reporter"]
+                ( "reporter to use (defaults to console)" )
+            | Opt( config.name, "name" )
+                ["-n"]["--name"]
+                ( "suite name" )
+            | Opt( [&]( bool ){ config.abortAfter = 1; } )
+                ["-a"]["--abort"]
+                ( "abort at first failure" )
+            | Opt( [&]( int x ){ config.abortAfter = x; }, "no. failures" )
+                ["-x"]["--abortx"]
+                ( "abort after x failures" )
+            | Opt( setWarning, "warning name" )
+                ["-w"]["--warn"]
+                ( "enable warnings" )
+            | Opt( [&]( bool flag ) { config.showDurations = flag ? ShowDurations::Always : ShowDurations::Never; }, "yes|no" )
+                ["-d"]["--durations"]
+                ( "show test durations" )
+            | Opt( loadTestNamesFromFile, "filename" )
+                ["-f"]["--input-file"]
+                ( "load test names to run from a file" )
+            | Opt( config.filenamesAsTags )
+                ["-#"]["--filenames-as-tags"]
+                ( "adds a tag for the filename" )
+            | Opt( config.sectionsToRun, "section name" )
+                ["-c"]["--section"]
+                ( "specify section to run" )
+            | Opt( setVerbosity, "quiet|normal|high" )
+                ["-v"]["--verbosity"]
+                ( "set output verbosity" )
+            | Opt( config.listTestNamesOnly )
+                ["--list-test-names-only"]
+                ( "list all/matching test cases names only" )
+            | Opt( config.listReporters )
+                ["--list-reporters"]
+                ( "list all reporters" )
+            | Opt( setTestOrder, "decl|lex|rand" )
+                ["--order"]
+                ( "test case order (defaults to decl)" )
+            | Opt( setRngSeed, "'time'|number" )
+                ["--rng-seed"]
+                ( "set a specific seed for random numbers" )
+            | Opt( setColourUsage, "yes|no" )
+                ["--use-colour"]
+                ( "should output be colourised" )
+            | Opt( config.libIdentify )
+                ["--libidentify"]
+                ( "report name and version according to libidentify standard" )
+            | Opt( setWaitForKeypress, "start|exit|both" )
+                ["--wait-for-keypress"]
+                ( "waits for a keypress before exiting" )
+            | Opt( config.benchmarkResolutionMultiple, "multiplier" )
+                ["--benchmark-resolution-multiple"]
+                ( "multiple of clock resolution to run benchmarks" )
+
+            | Arg( config.testsOrTags, "test name|pattern|tags" )
+                ( "which test or tests to use" );
+
+        return cli;
+    }
+
+} // end namespace Catch
+// end catch_commandline.cpp
+// start catch_common.cpp
+
+#include <cstring>
+#include <ostream>
+
+namespace Catch {
+
+    bool SourceLineInfo::empty() const noexcept {
+        return file[0] == '\0';
+    }
+    bool SourceLineInfo::operator == ( SourceLineInfo const& other ) const noexcept {
+        return line == other.line && (file == other.file || std::strcmp(file, other.file) == 0);
+    }
+    bool SourceLineInfo::operator < ( SourceLineInfo const& other ) const noexcept {
+        return line < other.line || ( line == other.line && (std::strcmp(file, other.file) < 0));
+    }
+
+    std::ostream& operator << ( std::ostream& os, SourceLineInfo const& info ) {
+#ifndef __GNUG__
+        os << info.file << '(' << info.line << ')';
+#else
+        os << info.file << ':' << info.line;
+#endif
+        return os;
+    }
+
+    std::string StreamEndStop::operator+() const {
+        return std::string();
+    }
+
+    NonCopyable::NonCopyable() = default;
+    NonCopyable::~NonCopyable() = default;
+
+}
+// end catch_common.cpp
+// start catch_config.cpp
+
+// start catch_enforce.h
+
+#include <stdexcept>
+
+#define CATCH_PREPARE_EXCEPTION( type, msg ) \
+    type( ( Catch::ReusableStringStream() << msg ).str() )
+#define CATCH_INTERNAL_ERROR( msg ) \
+    throw CATCH_PREPARE_EXCEPTION( std::logic_error, CATCH_INTERNAL_LINEINFO << ": Internal Catch error: " << msg);
+#define CATCH_ERROR( msg ) \
+    throw CATCH_PREPARE_EXCEPTION( std::domain_error, msg )
+#define CATCH_ENFORCE( condition, msg ) \
+    do{ if( !(condition) ) CATCH_ERROR( msg ); } while(false)
+
+// end catch_enforce.h
+namespace Catch {
+
+    Config::Config( ConfigData const& data )
+    :   m_data( data ),
+        m_stream( openStream() )
+    {
+        TestSpecParser parser(ITagAliasRegistry::get());
+        if (data.testsOrTags.empty()) {
+            parser.parse("~[.]"); // All not hidden tests
+        }
+        else {
+            m_hasTestFilters = true;
+            for( auto const& testOrTags : data.testsOrTags )
+                parser.parse( testOrTags );
+        }
+        m_testSpec = parser.testSpec();
+    }
+
+    std::string const& Config::getFilename() const {
+        return m_data.outputFilename ;
+    }
+
+    bool Config::listTests() const          { return m_data.listTests; }
+    bool Config::listTestNamesOnly() const  { return m_data.listTestNamesOnly; }
+    bool Config::listTags() const           { return m_data.listTags; }
+    bool Config::listReporters() const      { return m_data.listReporters; }
+
+    std::string Config::getProcessName() const { return m_data.processName; }
+
+    std::vector<std::string> const& Config::getReporterNames() const { return m_data.reporterNames; }
+    std::vector<std::string> const& Config::getTestsOrTags() const { return m_data.testsOrTags; }
+    std::vector<std::string> const& Config::getSectionsToRun() const { return m_data.sectionsToRun; }
+
+    TestSpec const& Config::testSpec() const { return m_testSpec; }
+    bool Config::hasTestFilters() const { return m_hasTestFilters; }
+
+    bool Config::showHelp() const { return m_data.showHelp; }
+
+    // IConfig interface
+    bool Config::allowThrows() const                   { return !m_data.noThrow; }
+    std::ostream& Config::stream() const               { return m_stream->stream(); }
+    std::string Config::name() const                   { return m_data.name.empty() ? m_data.processName : m_data.name; }
+    bool Config::includeSuccessfulResults() const      { return m_data.showSuccessfulTests; }
+    bool Config::warnAboutMissingAssertions() const    { return !!(m_data.warnings & WarnAbout::NoAssertions); }
+    bool Config::warnAboutNoTests() const              { return !!(m_data.warnings & WarnAbout::NoTests); }
+    ShowDurations::OrNot Config::showDurations() const { return m_data.showDurations; }
+    RunTests::InWhatOrder Config::runOrder() const     { return m_data.runOrder; }
+    unsigned int Config::rngSeed() const               { return m_data.rngSeed; }
+    int Config::benchmarkResolutionMultiple() const    { return m_data.benchmarkResolutionMultiple; }
+    UseColour::YesOrNo Config::useColour() const       { return m_data.useColour; }
+    bool Config::shouldDebugBreak() const              { return m_data.shouldDebugBreak; }
+    int Config::abortAfter() const                     { return m_data.abortAfter; }
+    bool Config::showInvisibles() const                { return m_data.showInvisibles; }
+    Verbosity Config::verbosity() const                { return m_data.verbosity; }
+
+    IStream const* Config::openStream() {
+        return Catch::makeStream(m_data.outputFilename);
+    }
+
+} // end namespace Catch
+// end catch_config.cpp
+// start catch_console_colour.cpp
+
+#if defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wexit-time-destructors"
+#endif
+
+// start catch_errno_guard.h
+
+namespace Catch {
+
+    class ErrnoGuard {
+    public:
+        ErrnoGuard();
+        ~ErrnoGuard();
+    private:
+        int m_oldErrno;
+    };
+
+}
+
+// end catch_errno_guard.h
+#include <sstream>
+
+namespace Catch {
+    namespace {
+
+        struct IColourImpl {
+            virtual ~IColourImpl() = default;
+            virtual void use( Colour::Code _colourCode ) = 0;
+        };
+
+        struct NoColourImpl : IColourImpl {
+            void use( Colour::Code ) {}
+
+            static IColourImpl* instance() {
+                static NoColourImpl s_instance;
+                return &s_instance;
+            }
+        };
+
+    } // anon namespace
+} // namespace Catch
+
+#if !defined( CATCH_CONFIG_COLOUR_NONE ) && !defined( CATCH_CONFIG_COLOUR_WINDOWS ) && !defined( CATCH_CONFIG_COLOUR_ANSI )
+#   ifdef CATCH_PLATFORM_WINDOWS
+#       define CATCH_CONFIG_COLOUR_WINDOWS
+#   else
+#       define CATCH_CONFIG_COLOUR_ANSI
+#   endif
+#endif
+
+#if defined ( CATCH_CONFIG_COLOUR_WINDOWS ) /////////////////////////////////////////
+
+namespace Catch {
+namespace {
+
+    class Win32ColourImpl : public IColourImpl {
+    public:
+        Win32ColourImpl() : stdoutHandle( GetStdHandle(STD_OUTPUT_HANDLE) )
+        {
+            CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
+            GetConsoleScreenBufferInfo( stdoutHandle, &csbiInfo );
+            originalForegroundAttributes = csbiInfo.wAttributes & ~( BACKGROUND_GREEN | BACKGROUND_RED | BACKGROUND_BLUE | BACKGROUND_INTENSITY );
+            originalBackgroundAttributes = csbiInfo.wAttributes & ~( FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY );
+        }
+
+        virtual void use( Colour::Code _colourCode ) override {
+            switch( _colourCode ) {
+                case Colour::None:      return setTextAttribute( originalForegroundAttributes );
+                case Colour::White:     return setTextAttribute( FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE );
+                case Colour::Red:       return setTextAttribute( FOREGROUND_RED );
+                case Colour::Green:     return setTextAttribute( FOREGROUND_GREEN );
+                case Colour::Blue:      return setTextAttribute( FOREGROUND_BLUE );
+                case Colour::Cyan:      return setTextAttribute( FOREGROUND_BLUE | FOREGROUND_GREEN );
+                case Colour::Yellow:    return setTextAttribute( FOREGROUND_RED | FOREGROUND_GREEN );
+                case Colour::Grey:      return setTextAttribute( 0 );
+
+                case Colour::LightGrey:     return setTextAttribute( FOREGROUND_INTENSITY );
+                case Colour::BrightRed:     return setTextAttribute( FOREGROUND_INTENSITY | FOREGROUND_RED );
+                case Colour::BrightGreen:   return setTextAttribute( FOREGROUND_INTENSITY | FOREGROUND_GREEN );
+                case Colour::BrightWhite:   return setTextAttribute( FOREGROUND_INTENSITY | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE );
+                case Colour::BrightYellow:  return setTextAttribute( FOREGROUND_INTENSITY | FOREGROUND_RED | FOREGROUND_GREEN );
+
+                case Colour::Bright: CATCH_INTERNAL_ERROR( "not a colour" );
+
+                default:
+                    CATCH_ERROR( "Unknown colour requested" );
+            }
+        }
+
+    private:
+        void setTextAttribute( WORD _textAttribute ) {
+            SetConsoleTextAttribute( stdoutHandle, _textAttribute | originalBackgroundAttributes );
+        }
+        HANDLE stdoutHandle;
+        WORD originalForegroundAttributes;
+        WORD originalBackgroundAttributes;
+    };
+
+    IColourImpl* platformColourInstance() {
+        static Win32ColourImpl s_instance;
+
+        IConfigPtr config = getCurrentContext().getConfig();
+        UseColour::YesOrNo colourMode = config
+            ? config->useColour()
+            : UseColour::Auto;
+        if( colourMode == UseColour::Auto )
+            colourMode = UseColour::Yes;
+        return colourMode == UseColour::Yes
+            ? &s_instance
+            : NoColourImpl::instance();
+    }
+
+} // end anon namespace
+} // end namespace Catch
+
+#elif defined( CATCH_CONFIG_COLOUR_ANSI ) //////////////////////////////////////
+
+#include <unistd.h>
+
+namespace Catch {
+namespace {
+
+    // use POSIX/ ANSI console terminal codes
+    // Thanks to Adam Strzelecki for original contribution
+    // (http://github.com/nanoant)
+    // https://github.com/philsquared/Catch/pull/131
+    class PosixColourImpl : public IColourImpl {
+    public:
+        virtual void use( Colour::Code _colourCode ) override {
+            switch( _colourCode ) {
+                case Colour::None:
+                case Colour::White:     return setColour( "[0m" );
+                case Colour::Red:       return setColour( "[0;31m" );
+                case Colour::Green:     return setColour( "[0;32m" );
+                case Colour::Blue:      return setColour( "[0;34m" );
+                case Colour::Cyan:      return setColour( "[0;36m" );
+                case Colour::Yellow:    return setColour( "[0;33m" );
+                case Colour::Grey:      return setColour( "[1;30m" );
+
+                case Colour::LightGrey:     return setColour( "[0;37m" );
+                case Colour::BrightRed:     return setColour( "[1;31m" );
+                case Colour::BrightGreen:   return setColour( "[1;32m" );
+                case Colour::BrightWhite:   return setColour( "[1;37m" );
+                case Colour::BrightYellow:  return setColour( "[1;33m" );
+
+                case Colour::Bright: CATCH_INTERNAL_ERROR( "not a colour" );
+                default: CATCH_INTERNAL_ERROR( "Unknown colour requested" );
+            }
+        }
+        static IColourImpl* instance() {
+            static PosixColourImpl s_instance;
+            return &s_instance;
+        }
+
+    private:
+        void setColour( const char* _escapeCode ) {
+            Catch::cout() << '\033' << _escapeCode;
+        }
+    };
+
+    bool useColourOnPlatform() {
+        return
+#ifdef CATCH_PLATFORM_MAC
+            !isDebuggerActive() &&
+#endif
+#if !(defined(__DJGPP__) && defined(__STRICT_ANSI__))
+            isatty(STDOUT_FILENO)
+#else
+            false
+#endif
+            ;
+    }
+    IColourImpl* platformColourInstance() {
+        ErrnoGuard guard;
+        IConfigPtr config = getCurrentContext().getConfig();
+        UseColour::YesOrNo colourMode = config
+            ? config->useColour()
+            : UseColour::Auto;
+        if( colourMode == UseColour::Auto )
+            colourMode = useColourOnPlatform()
+                ? UseColour::Yes
+                : UseColour::No;
+        return colourMode == UseColour::Yes
+            ? PosixColourImpl::instance()
+            : NoColourImpl::instance();
+    }
+
+} // end anon namespace
+} // end namespace Catch
+
+#else  // not Windows or ANSI ///////////////////////////////////////////////
+
+namespace Catch {
+
+    static IColourImpl* platformColourInstance() { return NoColourImpl::instance(); }
+
+} // end namespace Catch
+
+#endif // Windows/ ANSI/ None
+
+namespace Catch {
+
+    Colour::Colour( Code _colourCode ) { use( _colourCode ); }
+    Colour::Colour( Colour&& rhs ) noexcept {
+        m_moved = rhs.m_moved;
+        rhs.m_moved = true;
+    }
+    Colour& Colour::operator=( Colour&& rhs ) noexcept {
+        m_moved = rhs.m_moved;
+        rhs.m_moved  = true;
+        return *this;
+    }
+
+    Colour::~Colour(){ if( !m_moved ) use( None ); }
+
+    void Colour::use( Code _colourCode ) {
+        static IColourImpl* impl = platformColourInstance();
+        impl->use( _colourCode );
+    }
+
+    std::ostream& operator << ( std::ostream& os, Colour const& ) {
+        return os;
+    }
+
+} // end namespace Catch
+
+#if defined(__clang__)
+#    pragma clang diagnostic pop
+#endif
+
+// end catch_console_colour.cpp
+// start catch_context.cpp
+
+namespace Catch {
+
+    class Context : public IMutableContext, NonCopyable {
+
+    public: // IContext
+        virtual IResultCapture* getResultCapture() override {
+            return m_resultCapture;
+        }
+        virtual IRunner* getRunner() override {
+            return m_runner;
+        }
+
+        virtual IConfigPtr const& getConfig() const override {
+            return m_config;
+        }
+
+        virtual ~Context() override;
+
+    public: // IMutableContext
+        virtual void setResultCapture( IResultCapture* resultCapture ) override {
+            m_resultCapture = resultCapture;
+        }
+        virtual void setRunner( IRunner* runner ) override {
+            m_runner = runner;
+        }
+        virtual void setConfig( IConfigPtr const& config ) override {
+            m_config = config;
+        }
+
+        friend IMutableContext& getCurrentMutableContext();
+
+    private:
+        IConfigPtr m_config;
+        IRunner* m_runner = nullptr;
+        IResultCapture* m_resultCapture = nullptr;
+    };
+
+    IMutableContext *IMutableContext::currentContext = nullptr;
+
+    void IMutableContext::createContext()
+    {
+        currentContext = new Context();
+    }
+
+    void cleanUpContext() {
+        delete IMutableContext::currentContext;
+        IMutableContext::currentContext = nullptr;
+    }
+    IContext::~IContext() = default;
+    IMutableContext::~IMutableContext() = default;
+    Context::~Context() = default;
+}
+// end catch_context.cpp
+// start catch_debug_console.cpp
+
+// start catch_debug_console.h
+
+#include <string>
+
+namespace Catch {
+    void writeToDebugConsole( std::string const& text );
+}
+
+// end catch_debug_console.h
+#ifdef CATCH_PLATFORM_WINDOWS
+
+    namespace Catch {
+        void writeToDebugConsole( std::string const& text ) {
+            ::OutputDebugStringA( text.c_str() );
+        }
+    }
+
+#else
+
+    namespace Catch {
+        void writeToDebugConsole( std::string const& text ) {
+            // !TBD: Need a version for Mac/ XCode and other IDEs
+            Catch::cout() << text;
+        }
+    }
+
+#endif // Platform
+// end catch_debug_console.cpp
+// start catch_debugger.cpp
+
+#ifdef CATCH_PLATFORM_MAC
+
+#  include <assert.h>
+#  include <stdbool.h>
+#  include <sys/types.h>
+#  include <unistd.h>
+#  include <sys/sysctl.h>
+#  include <cstddef>
+#  include <ostream>
+
+namespace Catch {
+
+        // The following function is taken directly from the following technical note:
+        // http://developer.apple.com/library/mac/#qa/qa2004/qa1361.html
+
+        // Returns true if the current process is being debugged (either
+        // running under the debugger or has a debugger attached post facto).
+        bool isDebuggerActive(){
+
+            int                 mib[4];
+            struct kinfo_proc   info;
+            std::size_t         size;
+
+            // Initialize the flags so that, if sysctl fails for some bizarre
+            // reason, we get a predictable result.
+
+            info.kp_proc.p_flag = 0;
+
+            // Initialize mib, which tells sysctl the info we want, in this case
+            // we're looking for information about a specific process ID.
+
+            mib[0] = CTL_KERN;
+            mib[1] = KERN_PROC;
+            mib[2] = KERN_PROC_PID;
+            mib[3] = getpid();
+
+            // Call sysctl.
+
+            size = sizeof(info);
+            if( sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, nullptr, 0) != 0 ) {
+                Catch::cerr() << "\n** Call to sysctl failed - unable to determine if debugger is active **\n" << std::endl;
+                return false;
+            }
+
+            // We're being debugged if the P_TRACED flag is set.
+
+            return ( (info.kp_proc.p_flag & P_TRACED) != 0 );
+        }
+    } // namespace Catch
+
+#elif defined(CATCH_PLATFORM_LINUX)
+    #include <fstream>
+    #include <string>
+
+    namespace Catch{
+        // The standard POSIX way of detecting a debugger is to attempt to
+        // ptrace() the process, but this needs to be done from a child and not
+        // this process itself to still allow attaching to this process later
+        // if wanted, so is rather heavy. Under Linux we have the PID of the
+        // "debugger" (which doesn't need to be gdb, of course, it could also
+        // be strace, for example) in /proc/$PID/status, so just get it from
+        // there instead.
+        bool isDebuggerActive(){
+            // Libstdc++ has a bug, where std::ifstream sets errno to 0
+            // This way our users can properly assert over errno values
+            ErrnoGuard guard;
+            std::ifstream in("/proc/self/status");
+            for( std::string line; std::getline(in, line); ) {
+                static const int PREFIX_LEN = 11;
+                if( line.compare(0, PREFIX_LEN, "TracerPid:\t") == 0 ) {
+                    // We're traced if the PID is not 0 and no other PID starts
+                    // with 0 digit, so it's enough to check for just a single
+                    // character.
+                    return line.length() > PREFIX_LEN && line[PREFIX_LEN] != '0';
+                }
+            }
+
+            return false;
+        }
+    } // namespace Catch
+#elif defined(_MSC_VER)
+    extern "C" __declspec(dllimport) int __stdcall IsDebuggerPresent();
+    namespace Catch {
+        bool isDebuggerActive() {
+            return IsDebuggerPresent() != 0;
+        }
+    }
+#elif defined(__MINGW32__)
+    extern "C" __declspec(dllimport) int __stdcall IsDebuggerPresent();
+    namespace Catch {
+        bool isDebuggerActive() {
+            return IsDebuggerPresent() != 0;
+        }
+    }
+#else
+    namespace Catch {
+       bool isDebuggerActive() { return false; }
+    }
+#endif // Platform
+// end catch_debugger.cpp
+// start catch_decomposer.cpp
+
+namespace Catch {
+
+    ITransientExpression::~ITransientExpression() = default;
+
+    void formatReconstructedExpression( std::ostream &os, std::string const& lhs, StringRef op, std::string const& rhs ) {
+        if( lhs.size() + rhs.size() < 40 &&
+                lhs.find('\n') == std::string::npos &&
+                rhs.find('\n') == std::string::npos )
+            os << lhs << " " << op << " " << rhs;
+        else
+            os << lhs << "\n" << op << "\n" << rhs;
+    }
+}
+// end catch_decomposer.cpp
+// start catch_errno_guard.cpp
+
+#include <cerrno>
+
+namespace Catch {
+        ErrnoGuard::ErrnoGuard():m_oldErrno(errno){}
+        ErrnoGuard::~ErrnoGuard() { errno = m_oldErrno; }
+}
+// end catch_errno_guard.cpp
+// start catch_exception_translator_registry.cpp
+
+// start catch_exception_translator_registry.h
+
+#include <vector>
+#include <string>
+#include <memory>
+
+namespace Catch {
+
+    class ExceptionTranslatorRegistry : public IExceptionTranslatorRegistry {
+    public:
+        ~ExceptionTranslatorRegistry();
+        virtual void registerTranslator( const IExceptionTranslator* translator );
+        virtual std::string translateActiveException() const override;
+        std::string tryTranslators() const;
+
+    private:
+        std::vector<std::unique_ptr<IExceptionTranslator const>> m_translators;
+    };
+}
+
+// end catch_exception_translator_registry.h
+#ifdef __OBJC__
+#import "Foundation/Foundation.h"
+#endif
+
+namespace Catch {
+
+    ExceptionTranslatorRegistry::~ExceptionTranslatorRegistry() {
+    }
+
+    void ExceptionTranslatorRegistry::registerTranslator( const IExceptionTranslator* translator ) {
+        m_translators.push_back( std::unique_ptr<const IExceptionTranslator>( translator ) );
+    }
+
+    std::string ExceptionTranslatorRegistry::translateActiveException() const {
+        try {
+#ifdef __OBJC__
+            // In Objective-C try objective-c exceptions first
+            @try {
+                return tryTranslators();
+            }
+            @catch (NSException *exception) {
+                return Catch::Detail::stringify( [exception description] );
+            }
+#else
+            // Compiling a mixed mode project with MSVC means that CLR
+            // exceptions will be caught in (...) as well. However, these
+            // do not fill-in std::current_exception and thus lead to crash
+            // when attempting rethrow.
+            // /EHa switch also causes structured exceptions to be caught
+            // here, but they fill-in current_exception properly, so
+            // at worst the output should be a little weird, instead of
+            // causing a crash.
+            if (std::current_exception() == nullptr) {
+                return "Non C++ exception. Possibly a CLR exception.";
+            }
+            return tryTranslators();
+#endif
+        }
+        catch( TestFailureException& ) {
+            std::rethrow_exception(std::current_exception());
+        }
+        catch( std::exception& ex ) {
+            return ex.what();
+        }
+        catch( std::string& msg ) {
+            return msg;
+        }
+        catch( const char* msg ) {
+            return msg;
+        }
+        catch(...) {
+            return "Unknown exception";
+        }
+    }
+
+    std::string ExceptionTranslatorRegistry::tryTranslators() const {
+        if( m_translators.empty() )
+            std::rethrow_exception(std::current_exception());
+        else
+            return m_translators[0]->translate( m_translators.begin()+1, m_translators.end() );
+    }
+}
+// end catch_exception_translator_registry.cpp
+// start catch_fatal_condition.cpp
+
+#if defined(__GNUC__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
+
+#if defined( CATCH_CONFIG_WINDOWS_SEH ) || defined( CATCH_CONFIG_POSIX_SIGNALS )
+
+namespace {
+    // Report the error condition
+    void reportFatal( char const * const message ) {
+        Catch::getCurrentContext().getResultCapture()->handleFatalErrorCondition( message );
+    }
+}
+
+#endif // signals/SEH handling
+
+#if defined( CATCH_CONFIG_WINDOWS_SEH )
+
+namespace Catch {
+    struct SignalDefs { DWORD id; const char* name; };
+
+    // There is no 1-1 mapping between signals and windows exceptions.
+    // Windows can easily distinguish between SO and SigSegV,
+    // but SigInt, SigTerm, etc are handled differently.
+    static SignalDefs signalDefs[] = {
+        { EXCEPTION_ILLEGAL_INSTRUCTION,  "SIGILL - Illegal instruction signal" },
+        { EXCEPTION_STACK_OVERFLOW, "SIGSEGV - Stack overflow" },
+        { EXCEPTION_ACCESS_VIOLATION, "SIGSEGV - Segmentation violation signal" },
+        { EXCEPTION_INT_DIVIDE_BY_ZERO, "Divide by zero error" },
+    };
+
+    LONG CALLBACK FatalConditionHandler::handleVectoredException(PEXCEPTION_POINTERS ExceptionInfo) {
+        for (auto const& def : signalDefs) {
+            if (ExceptionInfo->ExceptionRecord->ExceptionCode == def.id) {
+                reportFatal(def.name);
+            }
+        }
+        // If its not an exception we care about, pass it along.
+        // This stops us from eating debugger breaks etc.
+        return EXCEPTION_CONTINUE_SEARCH;
+    }
+
+    FatalConditionHandler::FatalConditionHandler() {
+        isSet = true;
+        // 32k seems enough for Catch to handle stack overflow,
+        // but the value was found experimentally, so there is no strong guarantee
+        guaranteeSize = 32 * 1024;
+        exceptionHandlerHandle = nullptr;
+        // Register as first handler in current chain
+        exceptionHandlerHandle = AddVectoredExceptionHandler(1, handleVectoredException);
+        // Pass in guarantee size to be filled
+        SetThreadStackGuarantee(&guaranteeSize);
+    }
+
+    void FatalConditionHandler::reset() {
+        if (isSet) {
+            RemoveVectoredExceptionHandler(exceptionHandlerHandle);
+            SetThreadStackGuarantee(&guaranteeSize);
+            exceptionHandlerHandle = nullptr;
+            isSet = false;
+        }
+    }
+
+    FatalConditionHandler::~FatalConditionHandler() {
+        reset();
+    }
+
+bool FatalConditionHandler::isSet = false;
+ULONG FatalConditionHandler::guaranteeSize = 0;
+PVOID FatalConditionHandler::exceptionHandlerHandle = nullptr;
+
+} // namespace Catch
+
+#elif defined( CATCH_CONFIG_POSIX_SIGNALS )
+
+namespace Catch {
+
+    struct SignalDefs {
+        int id;
+        const char* name;
+    };
+    static SignalDefs signalDefs[] = {
+        { SIGINT,  "SIGINT - Terminal interrupt signal" },
+        { SIGILL,  "SIGILL - Illegal instruction signal" },
+        { SIGFPE,  "SIGFPE - Floating point error signal" },
+        { SIGSEGV, "SIGSEGV - Segmentation violation signal" },
+        { SIGTERM, "SIGTERM - Termination request signal" },
+        { SIGABRT, "SIGABRT - Abort (abnormal termination) signal" }
+    };
+
+    void FatalConditionHandler::handleSignal( int sig ) {
+        char const * name = "<unknown signal>";
+        for (auto const& def : signalDefs) {
+            if (sig == def.id) {
+                name = def.name;
+                break;
+            }
+        }
+        reset();
+        reportFatal(name);
+        raise( sig );
+    }
+
+    FatalConditionHandler::FatalConditionHandler() {
+        isSet = true;
+        stack_t sigStack;
+        sigStack.ss_sp = altStackMem;
+        sigStack.ss_size = SIGSTKSZ;
+        sigStack.ss_flags = 0;
+        sigaltstack(&sigStack, &oldSigStack);
+        struct sigaction sa = { };
+
+        sa.sa_handler = handleSignal;
+        sa.sa_flags = SA_ONSTACK;
+        for (std::size_t i = 0; i < sizeof(signalDefs)/sizeof(SignalDefs); ++i) {
+            sigaction(signalDefs[i].id, &sa, &oldSigActions[i]);
+        }
+    }
+
+    FatalConditionHandler::~FatalConditionHandler() {
+        reset();
+    }
+
+    void FatalConditionHandler::reset() {
+        if( isSet ) {
+            // Set signals back to previous values -- hopefully nobody overwrote them in the meantime
+            for( std::size_t i = 0; i < sizeof(signalDefs)/sizeof(SignalDefs); ++i ) {
+                sigaction(signalDefs[i].id, &oldSigActions[i], nullptr);
+            }
+            // Return the old stack
+            sigaltstack(&oldSigStack, nullptr);
+            isSet = false;
+        }
+    }
+
+    bool FatalConditionHandler::isSet = false;
+    struct sigaction FatalConditionHandler::oldSigActions[sizeof(signalDefs)/sizeof(SignalDefs)] = {};
+    stack_t FatalConditionHandler::oldSigStack = {};
+    char FatalConditionHandler::altStackMem[SIGSTKSZ] = {};
+
+} // namespace Catch
+
+#else
+
+namespace Catch {
+    void FatalConditionHandler::reset() {}
+}
+
+#endif // signals/SEH handling
+
+#if defined(__GNUC__)
+#    pragma GCC diagnostic pop
+#endif
+// end catch_fatal_condition.cpp
+// start catch_interfaces_capture.cpp
+
+namespace Catch {
+    IResultCapture::~IResultCapture() = default;
+}
+// end catch_interfaces_capture.cpp
+// start catch_interfaces_config.cpp
+
+namespace Catch {
+    IConfig::~IConfig() = default;
+}
+// end catch_interfaces_config.cpp
+// start catch_interfaces_exception.cpp
+
+namespace Catch {
+    IExceptionTranslator::~IExceptionTranslator() = default;
+    IExceptionTranslatorRegistry::~IExceptionTranslatorRegistry() = default;
+}
+// end catch_interfaces_exception.cpp
+// start catch_interfaces_registry_hub.cpp
+
+namespace Catch {
+    IRegistryHub::~IRegistryHub() = default;
+    IMutableRegistryHub::~IMutableRegistryHub() = default;
+}
+// end catch_interfaces_registry_hub.cpp
+// start catch_interfaces_reporter.cpp
+
+// start catch_reporter_multi.h
+
+namespace Catch {
+
+    class MultipleReporters : public IStreamingReporter {
+        using Reporters = std::vector<IStreamingReporterPtr>;
+        Reporters m_reporters;
+
+    public:
+        void add( IStreamingReporterPtr&& reporter );
+
+    public: // IStreamingReporter
+
+        ReporterPreferences getPreferences() const override;
+
+        void noMatchingTestCases( std::string const& spec ) override;
+
+        static std::set<Verbosity> getSupportedVerbosities();
+
+        void benchmarkStarting( BenchmarkInfo const& benchmarkInfo ) override;
+        void benchmarkEnded( BenchmarkStats const& benchmarkStats ) override;
+
+        void testRunStarting( TestRunInfo const& testRunInfo ) override;
+        void testGroupStarting( GroupInfo const& groupInfo ) override;
+        void testCaseStarting( TestCaseInfo const& testInfo ) override;
+        void sectionStarting( SectionInfo const& sectionInfo ) override;
+        void assertionStarting( AssertionInfo const& assertionInfo ) override;
+
+        // The return value indicates if the messages buffer should be cleared:
+        bool assertionEnded( AssertionStats const& assertionStats ) override;
+        void sectionEnded( SectionStats const& sectionStats ) override;
+        void testCaseEnded( TestCaseStats const& testCaseStats ) override;
+        void testGroupEnded( TestGroupStats const& testGroupStats ) override;
+        void testRunEnded( TestRunStats const& testRunStats ) override;
+
+        void skipTest( TestCaseInfo const& testInfo ) override;
+        bool isMulti() const override;
+
+    };
+
+} // end namespace Catch
+
+// end catch_reporter_multi.h
+namespace Catch {
+
+    ReporterConfig::ReporterConfig( IConfigPtr const& _fullConfig )
+    :   m_stream( &_fullConfig->stream() ), m_fullConfig( _fullConfig ) {}
+
+    ReporterConfig::ReporterConfig( IConfigPtr const& _fullConfig, std::ostream& _stream )
+    :   m_stream( &_stream ), m_fullConfig( _fullConfig ) {}
+
+    std::ostream& ReporterConfig::stream() const { return *m_stream; }
+    IConfigPtr ReporterConfig::fullConfig() const { return m_fullConfig; }
+
+    TestRunInfo::TestRunInfo( std::string const& _name ) : name( _name ) {}
+
+    GroupInfo::GroupInfo(  std::string const& _name,
+                           std::size_t _groupIndex,
+                           std::size_t _groupsCount )
+    :   name( _name ),
+        groupIndex( _groupIndex ),
+        groupsCounts( _groupsCount )
+    {}
+
+     AssertionStats::AssertionStats( AssertionResult const& _assertionResult,
+                                     std::vector<MessageInfo> const& _infoMessages,
+                                     Totals const& _totals )
+    :   assertionResult( _assertionResult ),
+        infoMessages( _infoMessages ),
+        totals( _totals )
+    {
+        assertionResult.m_resultData.lazyExpression.m_transientExpression = _assertionResult.m_resultData.lazyExpression.m_transientExpression;
+
+        if( assertionResult.hasMessage() ) {
+            // Copy message into messages list.
+            // !TBD This should have been done earlier, somewhere
+            MessageBuilder builder( assertionResult.getTestMacroName(), assertionResult.getSourceInfo(), assertionResult.getResultType() );
+            builder << assertionResult.getMessage();
+            builder.m_info.message = builder.m_stream.str();
+
+            infoMessages.push_back( builder.m_info );
+        }
+    }
+
+     AssertionStats::~AssertionStats() = default;
+
+    SectionStats::SectionStats(  SectionInfo const& _sectionInfo,
+                                 Counts const& _assertions,
+                                 double _durationInSeconds,
+                                 bool _missingAssertions )
+    :   sectionInfo( _sectionInfo ),
+        assertions( _assertions ),
+        durationInSeconds( _durationInSeconds ),
+        missingAssertions( _missingAssertions )
+    {}
+
+    SectionStats::~SectionStats() = default;
+
+    TestCaseStats::TestCaseStats(  TestCaseInfo const& _testInfo,
+                                   Totals const& _totals,
+                                   std::string const& _stdOut,
+                                   std::string const& _stdErr,
+                                   bool _aborting )
+    : testInfo( _testInfo ),
+        totals( _totals ),
+        stdOut( _stdOut ),
+        stdErr( _stdErr ),
+        aborting( _aborting )
+    {}
+
+    TestCaseStats::~TestCaseStats() = default;
+
+    TestGroupStats::TestGroupStats( GroupInfo const& _groupInfo,
+                                    Totals const& _totals,
+                                    bool _aborting )
+    :   groupInfo( _groupInfo ),
+        totals( _totals ),
+        aborting( _aborting )
+    {}
+
+    TestGroupStats::TestGroupStats( GroupInfo const& _groupInfo )
+    :   groupInfo( _groupInfo ),
+        aborting( false )
+    {}
+
+    TestGroupStats::~TestGroupStats() = default;
+
+    TestRunStats::TestRunStats(   TestRunInfo const& _runInfo,
+                    Totals const& _totals,
+                    bool _aborting )
+    :   runInfo( _runInfo ),
+        totals( _totals ),
+        aborting( _aborting )
+    {}
+
+    TestRunStats::~TestRunStats() = default;
+
+    void IStreamingReporter::fatalErrorEncountered( StringRef ) {}
+    bool IStreamingReporter::isMulti() const { return false; }
+
+    IReporterFactory::~IReporterFactory() = default;
+    IReporterRegistry::~IReporterRegistry() = default;
+
+    void addReporter( IStreamingReporterPtr& existingReporter, IStreamingReporterPtr&& additionalReporter ) {
+
+        if( !existingReporter ) {
+            existingReporter = std::move( additionalReporter );
+            return;
+        }
+
+        MultipleReporters* multi = nullptr;
+
+        if( existingReporter->isMulti() ) {
+            multi = static_cast<MultipleReporters*>( existingReporter.get() );
+        }
+        else {
+            auto newMulti = std::unique_ptr<MultipleReporters>( new MultipleReporters );
+            newMulti->add( std::move( existingReporter ) );
+            multi = newMulti.get();
+            existingReporter = std::move( newMulti );
+        }
+        multi->add( std::move( additionalReporter ) );
+    }
+
+} // end namespace Catch
+// end catch_interfaces_reporter.cpp
+// start catch_interfaces_runner.cpp
+
+namespace Catch {
+    IRunner::~IRunner() = default;
+}
+// end catch_interfaces_runner.cpp
+// start catch_interfaces_testcase.cpp
+
+namespace Catch {
+    ITestInvoker::~ITestInvoker() = default;
+    ITestCaseRegistry::~ITestCaseRegistry() = default;
+}
+// end catch_interfaces_testcase.cpp
+// start catch_leak_detector.cpp
+
+#ifdef CATCH_CONFIG_WINDOWS_CRTDBG
+#include <crtdbg.h>
+
+namespace Catch {
+
+	LeakDetector::LeakDetector() {
+		int flag = _CrtSetDbgFlag(_CRTDBG_REPORT_FLAG);
+		flag |= _CRTDBG_LEAK_CHECK_DF;
+		flag |= _CRTDBG_ALLOC_MEM_DF;
+		_CrtSetDbgFlag(flag);
+		_CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+		_CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDERR);
+		// Change this to leaking allocation's number to break there
+		_CrtSetBreakAlloc(-1);
+	}
+}
+
+#else
+
+    Catch::LeakDetector::LeakDetector() {}
+
+#endif
+// end catch_leak_detector.cpp
+// start catch_list.cpp
+
+// start catch_list.h
+
+#include <set>
+
+namespace Catch {
+
+    std::size_t listTests( Config const& config );
+
+    std::size_t listTestsNamesOnly( Config const& config );
+
+    struct TagInfo {
+        void add( std::string const& spelling );
+        std::string all() const;
+
+        std::set<std::string> spellings;
+        std::size_t count = 0;
+    };
+
+    std::size_t listTags( Config const& config );
+
+    std::size_t listReporters( Config const& /*config*/ );
+
+    Option<std::size_t> list( Config const& config );
+
+} // end namespace Catch
+
+// end catch_list.h
+// start catch_text.h
+
+namespace Catch {
+    using namespace clara::TextFlow;
+}
+
+// end catch_text.h
+#include <limits>
+#include <algorithm>
+#include <iomanip>
+
+namespace Catch {
+
+    std::size_t listTests( Config const& config ) {
+        TestSpec testSpec = config.testSpec();
+        if( config.hasTestFilters() )
+            Catch::cout() << "Matching test cases:\n";
+        else {
+            Catch::cout() << "All available test cases:\n";
+        }
+
+        auto matchedTestCases = filterTests( getAllTestCasesSorted( config ), testSpec, config );
+        for( auto const& testCaseInfo : matchedTestCases ) {
+            Colour::Code colour = testCaseInfo.isHidden()
+                ? Colour::SecondaryText
+                : Colour::None;
+            Colour colourGuard( colour );
+
+            Catch::cout() << Column( testCaseInfo.name ).initialIndent( 2 ).indent( 4 ) << "\n";
+            if( config.verbosity() >= Verbosity::High ) {
+                Catch::cout() << Column( Catch::Detail::stringify( testCaseInfo.lineInfo ) ).indent(4) << std::endl;
+                std::string description = testCaseInfo.description;
+                if( description.empty() )
+                    description = "(NO DESCRIPTION)";
+                Catch::cout() << Column( description ).indent(4) << std::endl;
+            }
+            if( !testCaseInfo.tags.empty() )
+                Catch::cout() << Column( testCaseInfo.tagsAsString() ).indent( 6 ) << "\n";
+        }
+
+        if( !config.hasTestFilters() )
+            Catch::cout() << pluralise( matchedTestCases.size(), "test case" ) << '\n' << std::endl;
+        else
+            Catch::cout() << pluralise( matchedTestCases.size(), "matching test case" ) << '\n' << std::endl;
+        return matchedTestCases.size();
+    }
+
+    std::size_t listTestsNamesOnly( Config const& config ) {
+        TestSpec testSpec = config.testSpec();
+        std::size_t matchedTests = 0;
+        std::vector<TestCase> matchedTestCases = filterTests( getAllTestCasesSorted( config ), testSpec, config );
+        for( auto const& testCaseInfo : matchedTestCases ) {
+            matchedTests++;
+            if( startsWith( testCaseInfo.name, '#' ) )
+               Catch::cout() << '"' << testCaseInfo.name << '"';
+            else
+               Catch::cout() << testCaseInfo.name;
+            if ( config.verbosity() >= Verbosity::High )
+                Catch::cout() << "\t@" << testCaseInfo.lineInfo;
+            Catch::cout() << std::endl;
+        }
+        return matchedTests;
+    }
+
+    void TagInfo::add( std::string const& spelling ) {
+        ++count;
+        spellings.insert( spelling );
+    }
+
+    std::string TagInfo::all() const {
+        std::string out;
+        for( auto const& spelling : spellings )
+            out += "[" + spelling + "]";
+        return out;
+    }
+
+    std::size_t listTags( Config const& config ) {
+        TestSpec testSpec = config.testSpec();
+        if( config.hasTestFilters() )
+            Catch::cout() << "Tags for matching test cases:\n";
+        else {
+            Catch::cout() << "All available tags:\n";
+        }
+
+        std::map<std::string, TagInfo> tagCounts;
+
+        std::vector<TestCase> matchedTestCases = filterTests( getAllTestCasesSorted( config ), testSpec, config );
+        for( auto const& testCase : matchedTestCases ) {
+            for( auto const& tagName : testCase.getTestCaseInfo().tags ) {
+                std::string lcaseTagName = toLower( tagName );
+                auto countIt = tagCounts.find( lcaseTagName );
+                if( countIt == tagCounts.end() )
+                    countIt = tagCounts.insert( std::make_pair( lcaseTagName, TagInfo() ) ).first;
+                countIt->second.add( tagName );
+            }
+        }
+
+        for( auto const& tagCount : tagCounts ) {
+            ReusableStringStream rss;
+            rss << "  " << std::setw(2) << tagCount.second.count << "  ";
+            auto str = rss.str();
+            auto wrapper = Column( tagCount.second.all() )
+                                                    .initialIndent( 0 )
+                                                    .indent( str.size() )
+                                                    .width( CATCH_CONFIG_CONSOLE_WIDTH-10 );
+            Catch::cout() << str << wrapper << '\n';
+        }
+        Catch::cout() << pluralise( tagCounts.size(), "tag" ) << '\n' << std::endl;
+        return tagCounts.size();
+    }
+
+    std::size_t listReporters( Config const& /*config*/ ) {
+        Catch::cout() << "Available reporters:\n";
+        IReporterRegistry::FactoryMap const& factories = getRegistryHub().getReporterRegistry().getFactories();
+        std::size_t maxNameLen = 0;
+        for( auto const& factoryKvp : factories )
+            maxNameLen = (std::max)( maxNameLen, factoryKvp.first.size() );
+
+        for( auto const& factoryKvp : factories ) {
+            Catch::cout()
+                    << Column( factoryKvp.first + ":" )
+                            .indent(2)
+                            .width( 5+maxNameLen )
+                    +  Column( factoryKvp.second->getDescription() )
+                            .initialIndent(0)
+                            .indent(2)
+                            .width( CATCH_CONFIG_CONSOLE_WIDTH - maxNameLen-8 )
+                    << "\n";
+        }
+        Catch::cout() << std::endl;
+        return factories.size();
+    }
+
+    Option<std::size_t> list( Config const& config ) {
+        Option<std::size_t> listedCount;
+        if( config.listTests() )
+            listedCount = listedCount.valueOr(0) + listTests( config );
+        if( config.listTestNamesOnly() )
+            listedCount = listedCount.valueOr(0) + listTestsNamesOnly( config );
+        if( config.listTags() )
+            listedCount = listedCount.valueOr(0) + listTags( config );
+        if( config.listReporters() )
+            listedCount = listedCount.valueOr(0) + listReporters( config );
+        return listedCount;
+    }
+
+} // end namespace Catch
+// end catch_list.cpp
+// start catch_matchers.cpp
+
+namespace Catch {
+namespace Matchers {
+    namespace Impl {
+
+        std::string MatcherUntypedBase::toString() const {
+            if( m_cachedToString.empty() )
+                m_cachedToString = describe();
+            return m_cachedToString;
+        }
+
+        MatcherUntypedBase::~MatcherUntypedBase() = default;
+
+    } // namespace Impl
+} // namespace Matchers
+
+using namespace Matchers;
+using Matchers::Impl::MatcherBase;
+
+} // namespace Catch
+// end catch_matchers.cpp
+// start catch_matchers_floating.cpp
+
+#include <cstdlib>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+
+namespace Catch {
+namespace Matchers {
+namespace Floating {
+enum class FloatingPointKind : uint8_t {
+    Float,
+    Double
+};
+}
+}
+}
+
+namespace {
+
+template <typename T>
+struct Converter;
+
+template <>
+struct Converter<float> {
+    static_assert(sizeof(float) == sizeof(int32_t), "Important ULP matcher assumption violated");
+    Converter(float f) {
+        std::memcpy(&i, &f, sizeof(f));
+    }
+    int32_t i;
+};
+
+template <>
+struct Converter<double> {
+    static_assert(sizeof(double) == sizeof(int64_t), "Important ULP matcher assumption violated");
+    Converter(double d) {
+        std::memcpy(&i, &d, sizeof(d));
+    }
+    int64_t i;
+};
+
+template <typename T>
+auto convert(T t) -> Converter<T> {
+    return Converter<T>(t);
+}
+
+template <typename FP>
+bool almostEqualUlps(FP lhs, FP rhs, int maxUlpDiff) {
+    // Comparison with NaN should always be false.
+    // This way we can rule it out before getting into the ugly details
+    if (std::isnan(lhs) || std::isnan(rhs)) {
+        return false;
+    }
+
+    auto lc = convert(lhs);
+    auto rc = convert(rhs);
+
+    if ((lc.i < 0) != (rc.i < 0)) {
+        // Potentially we can have +0 and -0
+        return lhs == rhs;
+    }
+
+    auto ulpDiff = std::abs(lc.i - rc.i);
+    return ulpDiff <= maxUlpDiff;
+}
+
+}
+
+namespace Catch {
+namespace Matchers {
+namespace Floating {
+    WithinAbsMatcher::WithinAbsMatcher(double target, double margin)
+        :m_target{ target }, m_margin{ margin } {
+        if (m_margin < 0) {
+            throw std::domain_error("Allowed margin difference has to be >= 0");
+        }
+    }
+
+    // Performs equivalent check of std::fabs(lhs - rhs) <= margin
+    // But without the subtraction to allow for INFINITY in comparison
+    bool WithinAbsMatcher::match(double const& matchee) const {
+        return (matchee + m_margin >= m_target) && (m_target + m_margin >= matchee);
+    }
+
+    std::string WithinAbsMatcher::describe() const {
+        return "is within " + ::Catch::Detail::stringify(m_margin) + " of " + ::Catch::Detail::stringify(m_target);
+    }
+
+    WithinUlpsMatcher::WithinUlpsMatcher(double target, int ulps, FloatingPointKind baseType)
+        :m_target{ target }, m_ulps{ ulps }, m_type{ baseType } {
+        if (m_ulps < 0) {
+            throw std::domain_error("Allowed ulp difference has to be >= 0");
+        }
+    }
+
+    bool WithinUlpsMatcher::match(double const& matchee) const {
+        switch (m_type) {
+        case FloatingPointKind::Float:
+            return almostEqualUlps<float>(static_cast<float>(matchee), static_cast<float>(m_target), m_ulps);
+        case FloatingPointKind::Double:
+            return almostEqualUlps<double>(matchee, m_target, m_ulps);
+        default:
+            throw std::domain_error("Unknown FloatingPointKind value");
+        }
+    }
+
+    std::string WithinUlpsMatcher::describe() const {
+        return "is within " + std::to_string(m_ulps) + " ULPs of " + ::Catch::Detail::stringify(m_target) + ((m_type == FloatingPointKind::Float)? "f" : "");
+    }
+
+}// namespace Floating
+
+Floating::WithinUlpsMatcher WithinULP(double target, int maxUlpDiff) {
+    return Floating::WithinUlpsMatcher(target, maxUlpDiff, Floating::FloatingPointKind::Double);
+}
+
+Floating::WithinUlpsMatcher WithinULP(float target, int maxUlpDiff) {
+    return Floating::WithinUlpsMatcher(target, maxUlpDiff, Floating::FloatingPointKind::Float);
+}
+
+Floating::WithinAbsMatcher WithinAbs(double target, double margin) {
+    return Floating::WithinAbsMatcher(target, margin);
+}
+
+} // namespace Matchers
+} // namespace Catch
+
+// end catch_matchers_floating.cpp
+// start catch_matchers_generic.cpp
+
+std::string Catch::Matchers::Generic::Detail::finalizeDescription(const std::string& desc) {
+    if (desc.empty()) {
+        return "matches undescribed predicate";
+    } else {
+        return "matches predicate: \"" + desc + '"';
+    }
+}
+// end catch_matchers_generic.cpp
+// start catch_matchers_string.cpp
+
+#include <regex>
+
+namespace Catch {
+namespace Matchers {
+
+    namespace StdString {
+
+        CasedString::CasedString( std::string const& str, CaseSensitive::Choice caseSensitivity )
+        :   m_caseSensitivity( caseSensitivity ),
+            m_str( adjustString( str ) )
+        {}
+        std::string CasedString::adjustString( std::string const& str ) const {
+            return m_caseSensitivity == CaseSensitive::No
+                   ? toLower( str )
+                   : str;
+        }
+        std::string CasedString::caseSensitivitySuffix() const {
+            return m_caseSensitivity == CaseSensitive::No
+                   ? " (case insensitive)"
+                   : std::string();
+        }
+
+        StringMatcherBase::StringMatcherBase( std::string const& operation, CasedString const& comparator )
+        : m_comparator( comparator ),
+          m_operation( operation ) {
+        }
+
+        std::string StringMatcherBase::describe() const {
+            std::string description;
+            description.reserve(5 + m_operation.size() + m_comparator.m_str.size() +
+                                        m_comparator.caseSensitivitySuffix().size());
+            description += m_operation;
+            description += ": \"";
+            description += m_comparator.m_str;
+            description += "\"";
+            description += m_comparator.caseSensitivitySuffix();
+            return description;
+        }
+
+        EqualsMatcher::EqualsMatcher( CasedString const& comparator ) : StringMatcherBase( "equals", comparator ) {}
+
+        bool EqualsMatcher::match( std::string const& source ) const {
+            return m_comparator.adjustString( source ) == m_comparator.m_str;
+        }
+
+        ContainsMatcher::ContainsMatcher( CasedString const& comparator ) : StringMatcherBase( "contains", comparator ) {}
+
+        bool ContainsMatcher::match( std::string const& source ) const {
+            return contains( m_comparator.adjustString( source ), m_comparator.m_str );
+        }
+
+        StartsWithMatcher::StartsWithMatcher( CasedString const& comparator ) : StringMatcherBase( "starts with", comparator ) {}
+
+        bool StartsWithMatcher::match( std::string const& source ) const {
+            return startsWith( m_comparator.adjustString( source ), m_comparator.m_str );
+        }
+
+        EndsWithMatcher::EndsWithMatcher( CasedString const& comparator ) : StringMatcherBase( "ends with", comparator ) {}
+
+        bool EndsWithMatcher::match( std::string const& source ) const {
+            return endsWith( m_comparator.adjustString( source ), m_comparator.m_str );
+        }
+
+        RegexMatcher::RegexMatcher(std::string regex, CaseSensitive::Choice caseSensitivity): m_regex(std::move(regex)), m_caseSensitivity(caseSensitivity) {}
+
+        bool RegexMatcher::match(std::string const& matchee) const {
+            auto flags = std::regex::ECMAScript; // ECMAScript is the default syntax option anyway
+            if (m_caseSensitivity == CaseSensitive::Choice::No) {
+                flags |= std::regex::icase;
+            }
+            auto reg = std::regex(m_regex, flags);
+            return std::regex_match(matchee, reg);
+        }
+
+        std::string RegexMatcher::describe() const {
+            return "matches " + ::Catch::Detail::stringify(m_regex) + ((m_caseSensitivity == CaseSensitive::Choice::Yes)? " case sensitively" : " case insensitively");
+        }
+
+    } // namespace StdString
+
+    StdString::EqualsMatcher Equals( std::string const& str, CaseSensitive::Choice caseSensitivity ) {
+        return StdString::EqualsMatcher( StdString::CasedString( str, caseSensitivity) );
+    }
+    StdString::ContainsMatcher Contains( std::string const& str, CaseSensitive::Choice caseSensitivity ) {
+        return StdString::ContainsMatcher( StdString::CasedString( str, caseSensitivity) );
+    }
+    StdString::EndsWithMatcher EndsWith( std::string const& str, CaseSensitive::Choice caseSensitivity ) {
+        return StdString::EndsWithMatcher( StdString::CasedString( str, caseSensitivity) );
+    }
+    StdString::StartsWithMatcher StartsWith( std::string const& str, CaseSensitive::Choice caseSensitivity ) {
+        return StdString::StartsWithMatcher( StdString::CasedString( str, caseSensitivity) );
+    }
+
+    StdString::RegexMatcher Matches(std::string const& regex, CaseSensitive::Choice caseSensitivity) {
+        return StdString::RegexMatcher(regex, caseSensitivity);
+    }
+
+} // namespace Matchers
+} // namespace Catch
+// end catch_matchers_string.cpp
+// start catch_message.cpp
+
+// start catch_uncaught_exceptions.h
+
+namespace Catch {
+    bool uncaught_exceptions();
+} // end namespace Catch
+
+// end catch_uncaught_exceptions.h
+namespace Catch {
+
+    MessageInfo::MessageInfo(   std::string const& _macroName,
+                                SourceLineInfo const& _lineInfo,
+                                ResultWas::OfType _type )
+    :   macroName( _macroName ),
+        lineInfo( _lineInfo ),
+        type( _type ),
+        sequence( ++globalCount )
+    {}
+
+    bool MessageInfo::operator==( MessageInfo const& other ) const {
+        return sequence == other.sequence;
+    }
+
+    bool MessageInfo::operator<( MessageInfo const& other ) const {
+        return sequence < other.sequence;
+    }
+
+    // This may need protecting if threading support is added
+    unsigned int MessageInfo::globalCount = 0;
+
+    ////////////////////////////////////////////////////////////////////////////
+
+    Catch::MessageBuilder::MessageBuilder( std::string const& macroName,
+                                           SourceLineInfo const& lineInfo,
+                                           ResultWas::OfType type )
+        :m_info(macroName, lineInfo, type) {}
+
+    ////////////////////////////////////////////////////////////////////////////
+
+    ScopedMessage::ScopedMessage( MessageBuilder const& builder )
+    : m_info( builder.m_info )
+    {
+        m_info.message = builder.m_stream.str();
+        getResultCapture().pushScopedMessage( m_info );
+    }
+
+    ScopedMessage::~ScopedMessage() {
+        if ( !uncaught_exceptions() ){
+            getResultCapture().popScopedMessage(m_info);
+        }
+    }
+} // end namespace Catch
+// end catch_message.cpp
+// start catch_random_number_generator.cpp
+
+// start catch_random_number_generator.h
+
+#include <algorithm>
+
+namespace Catch {
+
+    struct IConfig;
+
+    void seedRng( IConfig const& config );
+
+    unsigned int rngSeed();
+
+    struct RandomNumberGenerator {
+        using result_type = unsigned int;
+
+        static constexpr result_type (min)() { return 0; }
+        static constexpr result_type (max)() { return 1000000; }
+
+        result_type operator()( result_type n ) const;
+        result_type operator()() const;
+
+        template<typename V>
+        static void shuffle( V& vector ) {
+            RandomNumberGenerator rng;
+            std::shuffle( vector.begin(), vector.end(), rng );
+        }
+    };
+
+}
+
+// end catch_random_number_generator.h
+#include <cstdlib>
+
+namespace Catch {
+
+    void seedRng( IConfig const& config ) {
+        if( config.rngSeed() != 0 )
+            std::srand( config.rngSeed() );
+    }
+    unsigned int rngSeed() {
+        return getCurrentContext().getConfig()->rngSeed();
+    }
+
+    RandomNumberGenerator::result_type RandomNumberGenerator::operator()( result_type n ) const {
+        return std::rand() % n;
+    }
+    RandomNumberGenerator::result_type RandomNumberGenerator::operator()() const {
+        return std::rand() % (max)();
+    }
+
+}
+// end catch_random_number_generator.cpp
+// start catch_registry_hub.cpp
+
+// start catch_test_case_registry_impl.h
+
+#include <vector>
+#include <set>
+#include <algorithm>
+#include <ios>
+
+namespace Catch {
+
+    class TestCase;
+    struct IConfig;
+
+    std::vector<TestCase> sortTests( IConfig const& config, std::vector<TestCase> const& unsortedTestCases );
+    bool matchTest( TestCase const& testCase, TestSpec const& testSpec, IConfig const& config );
+
+    void enforceNoDuplicateTestCases( std::vector<TestCase> const& functions );
+
+    std::vector<TestCase> filterTests( std::vector<TestCase> const& testCases, TestSpec const& testSpec, IConfig const& config );
+    std::vector<TestCase> const& getAllTestCasesSorted( IConfig const& config );
+
+    class TestRegistry : public ITestCaseRegistry {
+    public:
+        virtual ~TestRegistry() = default;
+
+        virtual void registerTest( TestCase const& testCase );
+
+        std::vector<TestCase> const& getAllTests() const override;
+        std::vector<TestCase> const& getAllTestsSorted( IConfig const& config ) const override;
+
+    private:
+        std::vector<TestCase> m_functions;
+        mutable RunTests::InWhatOrder m_currentSortOrder = RunTests::InDeclarationOrder;
+        mutable std::vector<TestCase> m_sortedFunctions;
+        std::size_t m_unnamedCount = 0;
+        std::ios_base::Init m_ostreamInit; // Forces cout/ cerr to be initialised
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+
+    class TestInvokerAsFunction : public ITestInvoker {
+        void(*m_testAsFunction)();
+    public:
+        TestInvokerAsFunction( void(*testAsFunction)() ) noexcept;
+
+        void invoke() const override;
+    };
+
+    std::string extractClassName( StringRef const& classOrQualifiedMethodName );
+
+    ///////////////////////////////////////////////////////////////////////////
+
+} // end namespace Catch
+
+// end catch_test_case_registry_impl.h
+// start catch_reporter_registry.h
+
+#include <map>
+
+namespace Catch {
+
+    class ReporterRegistry : public IReporterRegistry {
+
+    public:
+
+        ~ReporterRegistry() override;
+
+        IStreamingReporterPtr create( std::string const& name, IConfigPtr const& config ) const override;
+
+        void registerReporter( std::string const& name, IReporterFactoryPtr const& factory );
+        void registerListener( IReporterFactoryPtr const& factory );
+
+        FactoryMap const& getFactories() const override;
+        Listeners const& getListeners() const override;
+
+    private:
+        FactoryMap m_factories;
+        Listeners m_listeners;
+    };
+}
+
+// end catch_reporter_registry.h
+// start catch_tag_alias_registry.h
+
+// start catch_tag_alias.h
+
+#include <string>
+
+namespace Catch {
+
+    struct TagAlias {
+        TagAlias(std::string const& _tag, SourceLineInfo _lineInfo);
+
+        std::string tag;
+        SourceLineInfo lineInfo;
+    };
+
+} // end namespace Catch
+
+// end catch_tag_alias.h
+#include <map>
+
+namespace Catch {
+
+    class TagAliasRegistry : public ITagAliasRegistry {
+    public:
+        ~TagAliasRegistry() override;
+        TagAlias const* find( std::string const& alias ) const override;
+        std::string expandAliases( std::string const& unexpandedTestSpec ) const override;
+        void add( std::string const& alias, std::string const& tag, SourceLineInfo const& lineInfo );
+
+    private:
+        std::map<std::string, TagAlias> m_registry;
+    };
+
+} // end namespace Catch
+
+// end catch_tag_alias_registry.h
+// start catch_startup_exception_registry.h
+
+#include <vector>
+#include <exception>
+
+namespace Catch {
+
+    class StartupExceptionRegistry {
+    public:
+        void add(std::exception_ptr const& exception) noexcept;
+        std::vector<std::exception_ptr> const& getExceptions() const noexcept;
+    private:
+        std::vector<std::exception_ptr> m_exceptions;
+    };
+
+} // end namespace Catch
+
+// end catch_startup_exception_registry.h
+namespace Catch {
+
+    namespace {
+
+        class RegistryHub : public IRegistryHub, public IMutableRegistryHub,
+                            private NonCopyable {
+
+        public: // IRegistryHub
+            RegistryHub() = default;
+            IReporterRegistry const& getReporterRegistry() const override {
+                return m_reporterRegistry;
+            }
+            ITestCaseRegistry const& getTestCaseRegistry() const override {
+                return m_testCaseRegistry;
+            }
+            IExceptionTranslatorRegistry& getExceptionTranslatorRegistry() override {
+                return m_exceptionTranslatorRegistry;
+            }
+            ITagAliasRegistry const& getTagAliasRegistry() const override {
+                return m_tagAliasRegistry;
+            }
+            StartupExceptionRegistry const& getStartupExceptionRegistry() const override {
+                return m_exceptionRegistry;
+            }
+
+        public: // IMutableRegistryHub
+            void registerReporter( std::string const& name, IReporterFactoryPtr const& factory ) override {
+                m_reporterRegistry.registerReporter( name, factory );
+            }
+            void registerListener( IReporterFactoryPtr const& factory ) override {
+                m_reporterRegistry.registerListener( factory );
+            }
+            void registerTest( TestCase const& testInfo ) override {
+                m_testCaseRegistry.registerTest( testInfo );
+            }
+            void registerTranslator( const IExceptionTranslator* translator ) override {
+                m_exceptionTranslatorRegistry.registerTranslator( translator );
+            }
+            void registerTagAlias( std::string const& alias, std::string const& tag, SourceLineInfo const& lineInfo ) override {
+                m_tagAliasRegistry.add( alias, tag, lineInfo );
+            }
+            void registerStartupException() noexcept override {
+                m_exceptionRegistry.add(std::current_exception());
+            }
+
+        private:
+            TestRegistry m_testCaseRegistry;
+            ReporterRegistry m_reporterRegistry;
+            ExceptionTranslatorRegistry m_exceptionTranslatorRegistry;
+            TagAliasRegistry m_tagAliasRegistry;
+            StartupExceptionRegistry m_exceptionRegistry;
+        };
+
+        // Single, global, instance
+        RegistryHub*& getTheRegistryHub() {
+            static RegistryHub* theRegistryHub = nullptr;
+            if( !theRegistryHub )
+                theRegistryHub = new RegistryHub();
+            return theRegistryHub;
+        }
+    }
+
+    IRegistryHub& getRegistryHub() {
+        return *getTheRegistryHub();
+    }
+    IMutableRegistryHub& getMutableRegistryHub() {
+        return *getTheRegistryHub();
+    }
+    void cleanUp() {
+        delete getTheRegistryHub();
+        getTheRegistryHub() = nullptr;
+        cleanUpContext();
+        ReusableStringStream::cleanup();
+    }
+    std::string translateActiveException() {
+        return getRegistryHub().getExceptionTranslatorRegistry().translateActiveException();
+    }
+
+} // end namespace Catch
+// end catch_registry_hub.cpp
+// start catch_reporter_registry.cpp
+
+namespace Catch {
+
+    ReporterRegistry::~ReporterRegistry() = default;
+
+    IStreamingReporterPtr ReporterRegistry::create( std::string const& name, IConfigPtr const& config ) const {
+        auto it =  m_factories.find( name );
+        if( it == m_factories.end() )
+            return nullptr;
+        return it->second->create( ReporterConfig( config ) );
+    }
+
+    void ReporterRegistry::registerReporter( std::string const& name, IReporterFactoryPtr const& factory ) {
+        m_factories.emplace(name, factory);
+    }
+    void ReporterRegistry::registerListener( IReporterFactoryPtr const& factory ) {
+        m_listeners.push_back( factory );
+    }
+
+    IReporterRegistry::FactoryMap const& ReporterRegistry::getFactories() const {
+        return m_factories;
+    }
+    IReporterRegistry::Listeners const& ReporterRegistry::getListeners() const {
+        return m_listeners;
+    }
+
+}
+// end catch_reporter_registry.cpp
+// start catch_result_type.cpp
+
+namespace Catch {
+
+    bool isOk( ResultWas::OfType resultType ) {
+        return ( resultType & ResultWas::FailureBit ) == 0;
+    }
+    bool isJustInfo( int flags ) {
+        return flags == ResultWas::Info;
+    }
+
+    ResultDisposition::Flags operator | ( ResultDisposition::Flags lhs, ResultDisposition::Flags rhs ) {
+        return static_cast<ResultDisposition::Flags>( static_cast<int>( lhs ) | static_cast<int>( rhs ) );
+    }
+
+    bool shouldContinueOnFailure( int flags )    { return ( flags & ResultDisposition::ContinueOnFailure ) != 0; }
+    bool shouldSuppressFailure( int flags )      { return ( flags & ResultDisposition::SuppressFail ) != 0; }
+
+} // end namespace Catch
+// end catch_result_type.cpp
+// start catch_run_context.cpp
+
+#include <cassert>
+#include <algorithm>
+#include <sstream>
+
+namespace Catch {
+
+    class RedirectedStream {
+        std::ostream& m_originalStream;
+        std::ostream& m_redirectionStream;
+        std::streambuf* m_prevBuf;
+
+    public:
+        RedirectedStream( std::ostream& originalStream, std::ostream& redirectionStream )
+        :   m_originalStream( originalStream ),
+            m_redirectionStream( redirectionStream ),
+            m_prevBuf( m_originalStream.rdbuf() )
+        {
+            m_originalStream.rdbuf( m_redirectionStream.rdbuf() );
+        }
+        ~RedirectedStream() {
+            m_originalStream.rdbuf( m_prevBuf );
+        }
+    };
+
+    class RedirectedStdOut {
+        ReusableStringStream m_rss;
+        RedirectedStream m_cout;
+    public:
+        RedirectedStdOut() : m_cout( Catch::cout(), m_rss.get() ) {}
+        auto str() const -> std::string { return m_rss.str(); }
+    };
+
+    // StdErr has two constituent streams in C++, std::cerr and std::clog
+    // This means that we need to redirect 2 streams into 1 to keep proper
+    // order of writes
+    class RedirectedStdErr {
+        ReusableStringStream m_rss;
+        RedirectedStream m_cerr;
+        RedirectedStream m_clog;
+    public:
+        RedirectedStdErr()
+        :   m_cerr( Catch::cerr(), m_rss.get() ),
+            m_clog( Catch::clog(), m_rss.get() )
+        {}
+        auto str() const -> std::string { return m_rss.str(); }
+    };
+
+    RunContext::RunContext(IConfigPtr const& _config, IStreamingReporterPtr&& reporter)
+    :   m_runInfo(_config->name()),
+        m_context(getCurrentMutableContext()),
+        m_config(_config),
+        m_reporter(std::move(reporter)),
+        m_lastAssertionInfo{ StringRef(), SourceLineInfo("",0), StringRef(), ResultDisposition::Normal },
+        m_includeSuccessfulResults( m_config->includeSuccessfulResults() )
+    {
+        m_context.setRunner(this);
+        m_context.setConfig(m_config);
+        m_context.setResultCapture(this);
+        m_reporter->testRunStarting(m_runInfo);
+    }
+
+    RunContext::~RunContext() {
+        m_reporter->testRunEnded(TestRunStats(m_runInfo, m_totals, aborting()));
+    }
+
+    void RunContext::testGroupStarting(std::string const& testSpec, std::size_t groupIndex, std::size_t groupsCount) {
+        m_reporter->testGroupStarting(GroupInfo(testSpec, groupIndex, groupsCount));
+    }
+
+    void RunContext::testGroupEnded(std::string const& testSpec, Totals const& totals, std::size_t groupIndex, std::size_t groupsCount) {
+        m_reporter->testGroupEnded(TestGroupStats(GroupInfo(testSpec, groupIndex, groupsCount), totals, aborting()));
+    }
+
+    Totals RunContext::runTest(TestCase const& testCase) {
+        Totals prevTotals = m_totals;
+
+        std::string redirectedCout;
+        std::string redirectedCerr;
+
+        auto const& testInfo = testCase.getTestCaseInfo();
+
+        m_reporter->testCaseStarting(testInfo);
+
+        m_activeTestCase = &testCase;
+
+        ITracker& rootTracker = m_trackerContext.startRun();
+        assert(rootTracker.isSectionTracker());
+        static_cast<SectionTracker&>(rootTracker).addInitialFilters(m_config->getSectionsToRun());
+        do {
+            m_trackerContext.startCycle();
+            m_testCaseTracker = &SectionTracker::acquire(m_trackerContext, TestCaseTracking::NameAndLocation(testInfo.name, testInfo.lineInfo));
+            runCurrentTest(redirectedCout, redirectedCerr);
+        } while (!m_testCaseTracker->isSuccessfullyCompleted() && !aborting());
+
+        Totals deltaTotals = m_totals.delta(prevTotals);
+        if (testInfo.expectedToFail() && deltaTotals.testCases.passed > 0) {
+            deltaTotals.assertions.failed++;
+            deltaTotals.testCases.passed--;
+            deltaTotals.testCases.failed++;
+        }
+        m_totals.testCases += deltaTotals.testCases;
+        m_reporter->testCaseEnded(TestCaseStats(testInfo,
+                                  deltaTotals,
+                                  redirectedCout,
+                                  redirectedCerr,
+                                  aborting()));
+
+        m_activeTestCase = nullptr;
+        m_testCaseTracker = nullptr;
+
+        return deltaTotals;
+    }
+
+    IConfigPtr RunContext::config() const {
+        return m_config;
+    }
+
+    IStreamingReporter& RunContext::reporter() const {
+        return *m_reporter;
+    }
+
+    void RunContext::assertionEnded(AssertionResult const & result) {
+        if (result.getResultType() == ResultWas::Ok) {
+            m_totals.assertions.passed++;
+            m_lastAssertionPassed = true;
+        } else if (!result.isOk()) {
+            m_lastAssertionPassed = false;
+            if( m_activeTestCase->getTestCaseInfo().okToFail() )
+                m_totals.assertions.failedButOk++;
+            else
+                m_totals.assertions.failed++;
+        }
+        else {
+            m_lastAssertionPassed = true;
+        }
+
+        // We have no use for the return value (whether messages should be cleared), because messages were made scoped
+        // and should be let to clear themselves out.
+        static_cast<void>(m_reporter->assertionEnded(AssertionStats(result, m_messages, m_totals)));
+
+        // Reset working state
+        resetAssertionInfo();
+        m_lastResult = result;
+    }
+    void RunContext::resetAssertionInfo() {
+        m_lastAssertionInfo.macroName = StringRef();
+        m_lastAssertionInfo.capturedExpression = "{Unknown expression after the reported line}"_sr;
+    }
+
+    bool RunContext::sectionStarted(SectionInfo const & sectionInfo, Counts & assertions) {
+        ITracker& sectionTracker = SectionTracker::acquire(m_trackerContext, TestCaseTracking::NameAndLocation(sectionInfo.name, sectionInfo.lineInfo));
+        if (!sectionTracker.isOpen())
+            return false;
+        m_activeSections.push_back(&sectionTracker);
+
+        m_lastAssertionInfo.lineInfo = sectionInfo.lineInfo;
+
+        m_reporter->sectionStarting(sectionInfo);
+
+        assertions = m_totals.assertions;
+
+        return true;
+    }
+
+    bool RunContext::testForMissingAssertions(Counts& assertions) {
+        if (assertions.total() != 0)
+            return false;
+        if (!m_config->warnAboutMissingAssertions())
+            return false;
+        if (m_trackerContext.currentTracker().hasChildren())
+            return false;
+        m_totals.assertions.failed++;
+        assertions.failed++;
+        return true;
+    }
+
+    void RunContext::sectionEnded(SectionEndInfo const & endInfo) {
+        Counts assertions = m_totals.assertions - endInfo.prevAssertions;
+        bool missingAssertions = testForMissingAssertions(assertions);
+
+        if (!m_activeSections.empty()) {
+            m_activeSections.back()->close();
+            m_activeSections.pop_back();
+        }
+
+        m_reporter->sectionEnded(SectionStats(endInfo.sectionInfo, assertions, endInfo.durationInSeconds, missingAssertions));
+        m_messages.clear();
+    }
+
+    void RunContext::sectionEndedEarly(SectionEndInfo const & endInfo) {
+        if (m_unfinishedSections.empty())
+            m_activeSections.back()->fail();
+        else
+            m_activeSections.back()->close();
+        m_activeSections.pop_back();
+
+        m_unfinishedSections.push_back(endInfo);
+    }
+    void RunContext::benchmarkStarting( BenchmarkInfo const& info ) {
+        m_reporter->benchmarkStarting( info );
+    }
+    void RunContext::benchmarkEnded( BenchmarkStats const& stats ) {
+        m_reporter->benchmarkEnded( stats );
+    }
+
+    void RunContext::pushScopedMessage(MessageInfo const & message) {
+        m_messages.push_back(message);
+    }
+
+    void RunContext::popScopedMessage(MessageInfo const & message) {
+        m_messages.erase(std::remove(m_messages.begin(), m_messages.end(), message), m_messages.end());
+    }
+
+    std::string RunContext::getCurrentTestName() const {
+        return m_activeTestCase
+            ? m_activeTestCase->getTestCaseInfo().name
+            : std::string();
+    }
+
+    const AssertionResult * RunContext::getLastResult() const {
+        return &(*m_lastResult);
+    }
+
+    void RunContext::exceptionEarlyReported() {
+        m_shouldReportUnexpected = false;
+    }
+
+    void RunContext::handleFatalErrorCondition( StringRef message ) {
+        // First notify reporter that bad things happened
+        m_reporter->fatalErrorEncountered(message);
+
+        // Don't rebuild the result -- the stringification itself can cause more fatal errors
+        // Instead, fake a result data.
+        AssertionResultData tempResult( ResultWas::FatalErrorCondition, { false } );
+        tempResult.message = message;
+        AssertionResult result(m_lastAssertionInfo, tempResult);
+
+        assertionEnded(result);
+
+        handleUnfinishedSections();
+
+        // Recreate section for test case (as we will lose the one that was in scope)
+        auto const& testCaseInfo = m_activeTestCase->getTestCaseInfo();
+        SectionInfo testCaseSection(testCaseInfo.lineInfo, testCaseInfo.name, testCaseInfo.description);
+
+        Counts assertions;
+        assertions.failed = 1;
+        SectionStats testCaseSectionStats(testCaseSection, assertions, 0, false);
+        m_reporter->sectionEnded(testCaseSectionStats);
+
+        auto const& testInfo = m_activeTestCase->getTestCaseInfo();
+
+        Totals deltaTotals;
+        deltaTotals.testCases.failed = 1;
+        deltaTotals.assertions.failed = 1;
+        m_reporter->testCaseEnded(TestCaseStats(testInfo,
+                                  deltaTotals,
+                                  std::string(),
+                                  std::string(),
+                                  false));
+        m_totals.testCases.failed++;
+        testGroupEnded(std::string(), m_totals, 1, 1);
+        m_reporter->testRunEnded(TestRunStats(m_runInfo, m_totals, false));
+    }
+
+    bool RunContext::lastAssertionPassed() {
+         return m_lastAssertionPassed;
+    }
+
+    void RunContext::assertionPassed() {
+        m_lastAssertionPassed = true;
+        ++m_totals.assertions.passed;
+        resetAssertionInfo();
+    }
+
+    bool RunContext::aborting() const {
+        return m_totals.assertions.failed == static_cast<std::size_t>(m_config->abortAfter());
+    }
+
+    void RunContext::runCurrentTest(std::string & redirectedCout, std::string & redirectedCerr) {
+        auto const& testCaseInfo = m_activeTestCase->getTestCaseInfo();
+        SectionInfo testCaseSection(testCaseInfo.lineInfo, testCaseInfo.name, testCaseInfo.description);
+        m_reporter->sectionStarting(testCaseSection);
+        Counts prevAssertions = m_totals.assertions;
+        double duration = 0;
+        m_shouldReportUnexpected = true;
+        m_lastAssertionInfo = { "TEST_CASE"_sr, testCaseInfo.lineInfo, StringRef(), ResultDisposition::Normal };
+
+        seedRng(*m_config);
+
+        Timer timer;
+        try {
+            if (m_reporter->getPreferences().shouldRedirectStdOut) {
+                RedirectedStdOut redirectedStdOut;
+                RedirectedStdErr redirectedStdErr;
+                timer.start();
+                invokeActiveTestCase();
+                redirectedCout += redirectedStdOut.str();
+                redirectedCerr += redirectedStdErr.str();
+
+            } else {
+                timer.start();
+                invokeActiveTestCase();
+            }
+            duration = timer.getElapsedSeconds();
+        } catch (TestFailureException&) {
+            // This just means the test was aborted due to failure
+        } catch (...) {
+            // Under CATCH_CONFIG_FAST_COMPILE, unexpected exceptions under REQUIRE assertions
+            // are reported without translation at the point of origin.
+            if( m_shouldReportUnexpected ) {
+                AssertionReaction dummyReaction;
+                handleUnexpectedInflightException( m_lastAssertionInfo, translateActiveException(), dummyReaction );
+            }
+        }
+        Counts assertions = m_totals.assertions - prevAssertions;
+        bool missingAssertions = testForMissingAssertions(assertions);
+
+        m_testCaseTracker->close();
+        handleUnfinishedSections();
+        m_messages.clear();
+
+        SectionStats testCaseSectionStats(testCaseSection, assertions, duration, missingAssertions);
+        m_reporter->sectionEnded(testCaseSectionStats);
+    }
+
+    void RunContext::invokeActiveTestCase() {
+        FatalConditionHandler fatalConditionHandler; // Handle signals
+        m_activeTestCase->invoke();
+        fatalConditionHandler.reset();
+    }
+
+    void RunContext::handleUnfinishedSections() {
+        // If sections ended prematurely due to an exception we stored their
+        // infos here so we can tear them down outside the unwind process.
+        for (auto it = m_unfinishedSections.rbegin(),
+             itEnd = m_unfinishedSections.rend();
+             it != itEnd;
+             ++it)
+            sectionEnded(*it);
+        m_unfinishedSections.clear();
+    }
+
+    void RunContext::handleExpr(
+        AssertionInfo const& info,
+        ITransientExpression const& expr,
+        AssertionReaction& reaction
+    ) {
+        m_reporter->assertionStarting( info );
+
+        bool negated = isFalseTest( info.resultDisposition );
+        bool result = expr.getResult() != negated;
+
+        if( result ) {
+            if (!m_includeSuccessfulResults) {
+                assertionPassed();
+            }
+            else {
+                reportExpr(info, ResultWas::Ok, &expr, negated);
+            }
+        }
+        else {
+            reportExpr(info, ResultWas::ExpressionFailed, &expr, negated );
+            populateReaction( reaction );
+        }
+    }
+    void RunContext::reportExpr(
+            AssertionInfo const &info,
+            ResultWas::OfType resultType,
+            ITransientExpression const *expr,
+            bool negated ) {
+
+        m_lastAssertionInfo = info;
+        AssertionResultData data( resultType, LazyExpression( negated ) );
+
+        AssertionResult assertionResult{ info, data };
+        assertionResult.m_resultData.lazyExpression.m_transientExpression = expr;
+
+        assertionEnded( assertionResult );
+    }
+
+    void RunContext::handleMessage(
+            AssertionInfo const& info,
+            ResultWas::OfType resultType,
+            StringRef const& message,
+            AssertionReaction& reaction
+    ) {
+        m_reporter->assertionStarting( info );
+
+        m_lastAssertionInfo = info;
+
+        AssertionResultData data( resultType, LazyExpression( false ) );
+        data.message = message;
+        AssertionResult assertionResult{ m_lastAssertionInfo, data };
+        assertionEnded( assertionResult );
+        if( !assertionResult.isOk() )
+            populateReaction( reaction );
+    }
+    void RunContext::handleUnexpectedExceptionNotThrown(
+            AssertionInfo const& info,
+            AssertionReaction& reaction
+    ) {
+        handleNonExpr(info, Catch::ResultWas::DidntThrowException, reaction);
+    }
+
+    void RunContext::handleUnexpectedInflightException(
+            AssertionInfo const& info,
+            std::string const& message,
+            AssertionReaction& reaction
+    ) {
+        m_lastAssertionInfo = info;
+
+        AssertionResultData data( ResultWas::ThrewException, LazyExpression( false ) );
+        data.message = message;
+        AssertionResult assertionResult{ info, data };
+        assertionEnded( assertionResult );
+        populateReaction( reaction );
+    }
+
+    void RunContext::populateReaction( AssertionReaction& reaction ) {
+        reaction.shouldDebugBreak = m_config->shouldDebugBreak();
+        reaction.shouldThrow = aborting() || (m_lastAssertionInfo.resultDisposition & ResultDisposition::Normal);
+    }
+
+    void RunContext::handleIncomplete(
+            AssertionInfo const& info
+    ) {
+        m_lastAssertionInfo = info;
+
+        AssertionResultData data( ResultWas::ThrewException, LazyExpression( false ) );
+        data.message = "Exception translation was disabled by CATCH_CONFIG_FAST_COMPILE";
+        AssertionResult assertionResult{ info, data };
+        assertionEnded( assertionResult );
+    }
+    void RunContext::handleNonExpr(
+            AssertionInfo const &info,
+            ResultWas::OfType resultType,
+            AssertionReaction &reaction
+    ) {
+        m_lastAssertionInfo = info;
+
+        AssertionResultData data( resultType, LazyExpression( false ) );
+        AssertionResult assertionResult{ info, data };
+        assertionEnded( assertionResult );
+
+        if( !assertionResult.isOk() )
+            populateReaction( reaction );
+    }
+
+    IResultCapture& getResultCapture() {
+        if (auto* capture = getCurrentContext().getResultCapture())
+            return *capture;
+        else
+            CATCH_INTERNAL_ERROR("No result capture instance");
+    }
+}
+// end catch_run_context.cpp
+// start catch_section.cpp
+
+namespace Catch {
+
+    Section::Section( SectionInfo const& info )
+    :   m_info( info ),
+        m_sectionIncluded( getResultCapture().sectionStarted( m_info, m_assertions ) )
+    {
+        m_timer.start();
+    }
+
+    Section::~Section() {
+        if( m_sectionIncluded ) {
+            SectionEndInfo endInfo( m_info, m_assertions, m_timer.getElapsedSeconds() );
+            if( uncaught_exceptions() )
+                getResultCapture().sectionEndedEarly( endInfo );
+            else
+                getResultCapture().sectionEnded( endInfo );
+        }
+    }
+
+    // This indicates whether the section should be executed or not
+    Section::operator bool() const {
+        return m_sectionIncluded;
+    }
+
+} // end namespace Catch
+// end catch_section.cpp
+// start catch_section_info.cpp
+
+namespace Catch {
+
+    SectionInfo::SectionInfo
+        (   SourceLineInfo const& _lineInfo,
+            std::string const& _name,
+            std::string const& _description )
+    :   name( _name ),
+        description( _description ),
+        lineInfo( _lineInfo )
+    {}
+
+    SectionEndInfo::SectionEndInfo( SectionInfo const& _sectionInfo, Counts const& _prevAssertions, double _durationInSeconds )
+    : sectionInfo( _sectionInfo ), prevAssertions( _prevAssertions ), durationInSeconds( _durationInSeconds )
+    {}
+
+} // end namespace Catch
+// end catch_section_info.cpp
+// start catch_session.cpp
+
+// start catch_session.h
+
+#include <memory>
+
+namespace Catch {
+
+    class Session : NonCopyable {
+    public:
+
+        Session();
+        ~Session() override;
+
+        void showHelp() const;
+        void libIdentify();
+
+        int applyCommandLine( int argc, char const * const * argv );
+
+        void useConfigData( ConfigData const& configData );
+
+        int run( int argc, char* argv[] );
+    #if defined(CATCH_CONFIG_WCHAR) && defined(WIN32) && defined(UNICODE)
+        int run( int argc, wchar_t* const argv[] );
+    #endif
+        int run();
+
+        clara::Parser const& cli() const;
+        void cli( clara::Parser const& newParser );
+        ConfigData& configData();
+        Config& config();
+    private:
+        int runInternal();
+
+        clara::Parser m_cli;
+        ConfigData m_configData;
+        std::shared_ptr<Config> m_config;
+        bool m_startupExceptions = false;
+    };
+
+} // end namespace Catch
+
+// end catch_session.h
+// start catch_version.h
+
+#include <iosfwd>
+
+namespace Catch {
+
+    // Versioning information
+    struct Version {
+        Version( Version const& ) = delete;
+        Version& operator=( Version const& ) = delete;
+        Version(    unsigned int _majorVersion,
+                    unsigned int _minorVersion,
+                    unsigned int _patchNumber,
+                    char const * const _branchName,
+                    unsigned int _buildNumber );
+
+        unsigned int const majorVersion;
+        unsigned int const minorVersion;
+        unsigned int const patchNumber;
+
+        // buildNumber is only used if branchName is not null
+        char const * const branchName;
+        unsigned int const buildNumber;
+
+        friend std::ostream& operator << ( std::ostream& os, Version const& version );
+    };
+
+    Version const& libraryVersion();
+}
+
+// end catch_version.h
+#include <cstdlib>
+#include <iomanip>
+
+namespace Catch {
+
+    namespace {
+        const int MaxExitCode = 255;
+
+        IStreamingReporterPtr createReporter(std::string const& reporterName, IConfigPtr const& config) {
+            auto reporter = Catch::getRegistryHub().getReporterRegistry().create(reporterName, config);
+            CATCH_ENFORCE(reporter, "No reporter registered with name: '" << reporterName << "'");
+
+            return reporter;
+        }
+
+#ifndef CATCH_CONFIG_DEFAULT_REPORTER
+#define CATCH_CONFIG_DEFAULT_REPORTER "console"
+#endif
+
+        IStreamingReporterPtr makeReporter(std::shared_ptr<Config> const& config) {
+            auto const& reporterNames = config->getReporterNames();
+            if (reporterNames.empty())
+                return createReporter(CATCH_CONFIG_DEFAULT_REPORTER, config);
+
+            IStreamingReporterPtr reporter;
+            for (auto const& name : reporterNames)
+                addReporter(reporter, createReporter(name, config));
+            return reporter;
+        }
+
+#undef CATCH_CONFIG_DEFAULT_REPORTER
+
+        void addListeners(IStreamingReporterPtr& reporters, IConfigPtr const& config) {
+            auto const& listeners = Catch::getRegistryHub().getReporterRegistry().getListeners();
+            for (auto const& listener : listeners)
+                addReporter(reporters, listener->create(Catch::ReporterConfig(config)));
+        }
+
+        Catch::Totals runTests(std::shared_ptr<Config> const& config) {
+            IStreamingReporterPtr reporter = makeReporter(config);
+            addListeners(reporter, config);
+
+            RunContext context(config, std::move(reporter));
+
+            Totals totals;
+
+            context.testGroupStarting(config->name(), 1, 1);
+
+            TestSpec testSpec = config->testSpec();
+
+            auto const& allTestCases = getAllTestCasesSorted(*config);
+            for (auto const& testCase : allTestCases) {
+                if (!context.aborting() && matchTest(testCase, testSpec, *config))
+                    totals += context.runTest(testCase);
+                else
+                    context.reporter().skipTest(testCase);
+            }
+
+            if (config->warnAboutNoTests() && totals.testCases.total() == 0) {
+                ReusableStringStream testConfig;
+
+                bool first = true;
+                for (const auto& input : config->getTestsOrTags()) {
+                    if (!first) { testConfig << ' '; }
+                    first = false;
+                    testConfig << input;
+                }
+
+                context.reporter().noMatchingTestCases(testConfig.str());
+                totals.error = -1;
+            }
+
+            context.testGroupEnded(config->name(), totals, 1, 1);
+            return totals;
+        }
+
+        void applyFilenamesAsTags(Catch::IConfig const& config) {
+            auto& tests = const_cast<std::vector<TestCase>&>(getAllTestCasesSorted(config));
+            for (auto& testCase : tests) {
+                auto tags = testCase.tags;
+
+                std::string filename = testCase.lineInfo.file;
+                auto lastSlash = filename.find_last_of("\\/");
+                if (lastSlash != std::string::npos) {
+                    filename.erase(0, lastSlash);
+                    filename[0] = '#';
+                }
+
+                auto lastDot = filename.find_last_of('.');
+                if (lastDot != std::string::npos) {
+                    filename.erase(lastDot);
+                }
+
+                tags.push_back(std::move(filename));
+                setTags(testCase, tags);
+            }
+        }
+
+    } // anon namespace
+
+    Session::Session() {
+        static bool alreadyInstantiated = false;
+        if( alreadyInstantiated ) {
+            try         { CATCH_INTERNAL_ERROR( "Only one instance of Catch::Session can ever be used" ); }
+            catch(...)  { getMutableRegistryHub().registerStartupException(); }
+        }
+
+        const auto& exceptions = getRegistryHub().getStartupExceptionRegistry().getExceptions();
+        if ( !exceptions.empty() ) {
+            m_startupExceptions = true;
+            Colour colourGuard( Colour::Red );
+            Catch::cerr() << "Errors occurred during startup!" << '\n';
+            // iterate over all exceptions and notify user
+            for ( const auto& ex_ptr : exceptions ) {
+                try {
+                    std::rethrow_exception(ex_ptr);
+                } catch ( std::exception const& ex ) {
+                    Catch::cerr() << Column( ex.what() ).indent(2) << '\n';
+                }
+            }
+        }
+
+        alreadyInstantiated = true;
+        m_cli = makeCommandLineParser( m_configData );
+    }
+    Session::~Session() {
+        Catch::cleanUp();
+    }
+
+    void Session::showHelp() const {
+        Catch::cout()
+                << "\nCatch v" << libraryVersion() << "\n"
+                << m_cli << std::endl
+                << "For more detailed usage please see the project docs\n" << std::endl;
+    }
+    void Session::libIdentify() {
+        Catch::cout()
+                << std::left << std::setw(16) << "description: " << "A Catch test executable\n"
+                << std::left << std::setw(16) << "category: " << "testframework\n"
+                << std::left << std::setw(16) << "framework: " << "Catch Test\n"
+                << std::left << std::setw(16) << "version: " << libraryVersion() << std::endl;
+    }
+
+    int Session::applyCommandLine( int argc, char const * const * argv ) {
+        if( m_startupExceptions )
+            return 1;
+
+        auto result = m_cli.parse( clara::Args( argc, argv ) );
+        if( !result ) {
+            Catch::cerr()
+                << Colour( Colour::Red )
+                << "\nError(s) in input:\n"
+                << Column( result.errorMessage() ).indent( 2 )
+                << "\n\n";
+            Catch::cerr() << "Run with -? for usage\n" << std::endl;
+            return MaxExitCode;
+        }
+
+        if( m_configData.showHelp )
+            showHelp();
+        if( m_configData.libIdentify )
+            libIdentify();
+        m_config.reset();
+        return 0;
+    }
+
+    void Session::useConfigData( ConfigData const& configData ) {
+        m_configData = configData;
+        m_config.reset();
+    }
+
+    int Session::run( int argc, char* argv[] ) {
+        if( m_startupExceptions )
+            return 1;
+        int returnCode = applyCommandLine( argc, argv );
+        if( returnCode == 0 )
+            returnCode = run();
+        return returnCode;
+    }
+
+#if defined(CATCH_CONFIG_WCHAR) && defined(WIN32) && defined(UNICODE)
+    int Session::run( int argc, wchar_t* const argv[] ) {
+
+        char **utf8Argv = new char *[ argc ];
+
+        for ( int i = 0; i < argc; ++i ) {
+            int bufSize = WideCharToMultiByte( CP_UTF8, 0, argv[i], -1, NULL, 0, NULL, NULL );
+
+            utf8Argv[ i ] = new char[ bufSize ];
+
+            WideCharToMultiByte( CP_UTF8, 0, argv[i], -1, utf8Argv[i], bufSize, NULL, NULL );
+        }
+
+        int returnCode = run( argc, utf8Argv );
+
+        for ( int i = 0; i < argc; ++i )
+            delete [] utf8Argv[ i ];
+
+        delete [] utf8Argv;
+
+        return returnCode;
+    }
+#endif
+    int Session::run() {
+        if( ( m_configData.waitForKeypress & WaitForKeypress::BeforeStart ) != 0 ) {
+            Catch::cout() << "...waiting for enter/ return before starting" << std::endl;
+            static_cast<void>(std::getchar());
+        }
+        int exitCode = runInternal();
+        if( ( m_configData.waitForKeypress & WaitForKeypress::BeforeExit ) != 0 ) {
+            Catch::cout() << "...waiting for enter/ return before exiting, with code: " << exitCode << std::endl;
+            static_cast<void>(std::getchar());
+        }
+        return exitCode;
+    }
+
+    clara::Parser const& Session::cli() const {
+        return m_cli;
+    }
+    void Session::cli( clara::Parser const& newParser ) {
+        m_cli = newParser;
+    }
+    ConfigData& Session::configData() {
+        return m_configData;
+    }
+    Config& Session::config() {
+        if( !m_config )
+            m_config = std::make_shared<Config>( m_configData );
+        return *m_config;
+    }
+
+    int Session::runInternal() {
+        if( m_startupExceptions )
+            return 1;
+
+        if( m_configData.showHelp || m_configData.libIdentify )
+            return 0;
+
+        try
+        {
+            config(); // Force config to be constructed
+
+            seedRng( *m_config );
+
+            if( m_configData.filenamesAsTags )
+                applyFilenamesAsTags( *m_config );
+
+            // Handle list request
+            if( Option<std::size_t> listed = list( config() ) )
+                return static_cast<int>( *listed );
+
+            auto totals = runTests( m_config );
+            // Note that on unices only the lower 8 bits are usually used, clamping
+            // the return value to 255 prevents false negative when some multiple
+            // of 256 tests has failed
+            return (std::min) (MaxExitCode, (std::max) (totals.error, static_cast<int>(totals.assertions.failed)));
+        }
+        catch( std::exception& ex ) {
+            Catch::cerr() << ex.what() << std::endl;
+            return MaxExitCode;
+        }
+    }
+
+} // end namespace Catch
+// end catch_session.cpp
+// start catch_startup_exception_registry.cpp
+
+namespace Catch {
+    void StartupExceptionRegistry::add( std::exception_ptr const& exception ) noexcept {
+        try {
+            m_exceptions.push_back(exception);
+        }
+        catch(...) {
+            // If we run out of memory during start-up there's really not a lot more we can do about it
+            std::terminate();
+        }
+    }
+
+    std::vector<std::exception_ptr> const& StartupExceptionRegistry::getExceptions() const noexcept {
+        return m_exceptions;
+    }
+
+} // end namespace Catch
+// end catch_startup_exception_registry.cpp
+// start catch_stream.cpp
+
+#include <cstdio>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <vector>
+#include <memory>
+
+#if defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wexit-time-destructors"
+#endif
+
+namespace Catch {
+
+    Catch::IStream::~IStream() = default;
+
+    namespace detail { namespace {
+        template<typename WriterF, std::size_t bufferSize=256>
+        class StreamBufImpl : public std::streambuf {
+            char data[bufferSize];
+            WriterF m_writer;
+
+        public:
+            StreamBufImpl() {
+                setp( data, data + sizeof(data) );
+            }
+
+            ~StreamBufImpl() noexcept {
+                StreamBufImpl::sync();
+            }
+
+        private:
+            int overflow( int c ) override {
+                sync();
+
+                if( c != EOF ) {
+                    if( pbase() == epptr() )
+                        m_writer( std::string( 1, static_cast<char>( c ) ) );
+                    else
+                        sputc( static_cast<char>( c ) );
+                }
+                return 0;
+            }
+
+            int sync() override {
+                if( pbase() != pptr() ) {
+                    m_writer( std::string( pbase(), static_cast<std::string::size_type>( pptr() - pbase() ) ) );
+                    setp( pbase(), epptr() );
+                }
+                return 0;
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////////
+
+        struct OutputDebugWriter {
+
+            void operator()( std::string const&str ) {
+                writeToDebugConsole( str );
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////////
+
+        class FileStream : public IStream {
+            mutable std::ofstream m_ofs;
+        public:
+            FileStream( StringRef filename ) {
+                m_ofs.open( filename.c_str() );
+                CATCH_ENFORCE( !m_ofs.fail(), "Unable to open file: '" << filename << "'" );
+            }
+            ~FileStream() override = default;
+        public: // IStream
+            std::ostream& stream() const override {
+                return m_ofs;
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////////
+
+        class CoutStream : public IStream {
+            mutable std::ostream m_os;
+        public:
+            // Store the streambuf from cout up-front because
+            // cout may get redirected when running tests
+            CoutStream() : m_os( Catch::cout().rdbuf() ) {}
+            ~CoutStream() override = default;
+
+        public: // IStream
+            std::ostream& stream() const override { return m_os; }
+        };
+
+        ///////////////////////////////////////////////////////////////////////////
+
+        class DebugOutStream : public IStream {
+            std::unique_ptr<StreamBufImpl<OutputDebugWriter>> m_streamBuf;
+            mutable std::ostream m_os;
+        public:
+            DebugOutStream()
+            :   m_streamBuf( new StreamBufImpl<OutputDebugWriter>() ),
+                m_os( m_streamBuf.get() )
+            {}
+
+            ~DebugOutStream() override = default;
+
+        public: // IStream
+            std::ostream& stream() const override { return m_os; }
+        };
+
+    }} // namespace anon::detail
+
+    ///////////////////////////////////////////////////////////////////////////
+
+    auto makeStream( StringRef const &filename ) -> IStream const* {
+        if( filename.empty() )
+            return new detail::CoutStream();
+        else if( filename[0] == '%' ) {
+            if( filename == "%debug" )
+                return new detail::DebugOutStream();
+            else
+                CATCH_ERROR( "Unrecognised stream: '" << filename << "'" );
+        }
+        else
+            return new detail::FileStream( filename );
+    }
+
+    // This class encapsulates the idea of a pool of ostringstreams that can be reused.
+    struct StringStreams {
+        std::vector<std::unique_ptr<std::ostringstream>> m_streams;
+        std::vector<std::size_t> m_unused;
+        std::ostringstream m_referenceStream; // Used for copy state/ flags from
+        static StringStreams* s_instance;
+
+        auto add() -> std::size_t {
+            if( m_unused.empty() ) {
+                m_streams.push_back( std::unique_ptr<std::ostringstream>( new std::ostringstream ) );
+                return m_streams.size()-1;
+            }
+            else {
+                auto index = m_unused.back();
+                m_unused.pop_back();
+                return index;
+            }
+        }
+
+        void release( std::size_t index ) {
+            m_streams[index]->copyfmt( m_referenceStream ); // Restore initial flags and other state
+            m_unused.push_back(index);
+        }
+
+        // !TBD: put in TLS
+        static auto instance() -> StringStreams& {
+            if( !s_instance )
+                s_instance = new StringStreams();
+            return *s_instance;
+        }
+        static void cleanup() {
+            delete s_instance;
+            s_instance = nullptr;
+        }
+    };
+
+    StringStreams* StringStreams::s_instance = nullptr;
+
+    void ReusableStringStream::cleanup() {
+        StringStreams::cleanup();
+    }
+
+    ReusableStringStream::ReusableStringStream()
+    :   m_index( StringStreams::instance().add() ),
+        m_oss( StringStreams::instance().m_streams[m_index].get() )
+    {}
+
+    ReusableStringStream::~ReusableStringStream() {
+        static_cast<std::ostringstream*>( m_oss )->str("");
+        m_oss->clear();
+        StringStreams::instance().release( m_index );
+    }
+
+    auto ReusableStringStream::str() const -> std::string {
+        return static_cast<std::ostringstream*>( m_oss )->str();
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+
+#ifndef CATCH_CONFIG_NOSTDOUT // If you #define this you must implement these functions
+    std::ostream& cout() { return std::cout; }
+    std::ostream& cerr() { return std::cerr; }
+    std::ostream& clog() { return std::clog; }
+#endif
+}
+
+#if defined(__clang__)
+#    pragma clang diagnostic pop
+#endif
+// end catch_stream.cpp
+// start catch_string_manip.cpp
+
+#include <algorithm>
+#include <ostream>
+#include <cstring>
+#include <cctype>
+
+namespace Catch {
+
+    bool startsWith( std::string const& s, std::string const& prefix ) {
+        return s.size() >= prefix.size() && std::equal(prefix.begin(), prefix.end(), s.begin());
+    }
+    bool startsWith( std::string const& s, char prefix ) {
+        return !s.empty() && s[0] == prefix;
+    }
+    bool endsWith( std::string const& s, std::string const& suffix ) {
+        return s.size() >= suffix.size() && std::equal(suffix.rbegin(), suffix.rend(), s.rbegin());
+    }
+    bool endsWith( std::string const& s, char suffix ) {
+        return !s.empty() && s[s.size()-1] == suffix;
+    }
+    bool contains( std::string const& s, std::string const& infix ) {
+        return s.find( infix ) != std::string::npos;
+    }
+    char toLowerCh(char c) {
+        return static_cast<char>( std::tolower( c ) );
+    }
+    void toLowerInPlace( std::string& s ) {
+        std::transform( s.begin(), s.end(), s.begin(), toLowerCh );
+    }
+    std::string toLower( std::string const& s ) {
+        std::string lc = s;
+        toLowerInPlace( lc );
+        return lc;
+    }
+    std::string trim( std::string const& str ) {
+        static char const* whitespaceChars = "\n\r\t ";
+        std::string::size_type start = str.find_first_not_of( whitespaceChars );
+        std::string::size_type end = str.find_last_not_of( whitespaceChars );
+
+        return start != std::string::npos ? str.substr( start, 1+end-start ) : std::string();
+    }
+
+    bool replaceInPlace( std::string& str, std::string const& replaceThis, std::string const& withThis ) {
+        bool replaced = false;
+        std::size_t i = str.find( replaceThis );
+        while( i != std::string::npos ) {
+            replaced = true;
+            str = str.substr( 0, i ) + withThis + str.substr( i+replaceThis.size() );
+            if( i < str.size()-withThis.size() )
+                i = str.find( replaceThis, i+withThis.size() );
+            else
+                i = std::string::npos;
+        }
+        return replaced;
+    }
+
+    pluralise::pluralise( std::size_t count, std::string const& label )
+    :   m_count( count ),
+        m_label( label )
+    {}
+
+    std::ostream& operator << ( std::ostream& os, pluralise const& pluraliser ) {
+        os << pluraliser.m_count << ' ' << pluraliser.m_label;
+        if( pluraliser.m_count != 1 )
+            os << 's';
+        return os;
+    }
+
+}
+// end catch_string_manip.cpp
+// start catch_stringref.cpp
+
+#if defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wexit-time-destructors"
+#endif
+
+#include <ostream>
+#include <cstring>
+#include <cstdint>
+
+namespace {
+    const uint32_t byte_2_lead = 0xC0;
+    const uint32_t byte_3_lead = 0xE0;
+    const uint32_t byte_4_lead = 0xF0;
+}
+
+namespace Catch {
+    StringRef::StringRef( char const* rawChars ) noexcept
+    : StringRef( rawChars, static_cast<StringRef::size_type>(std::strlen(rawChars) ) )
+    {}
+
+    StringRef::operator std::string() const {
+        return std::string( m_start, m_size );
+    }
+
+    void StringRef::swap( StringRef& other ) noexcept {
+        std::swap( m_start, other.m_start );
+        std::swap( m_size, other.m_size );
+        std::swap( m_data, other.m_data );
+    }
+
+    auto StringRef::c_str() const -> char const* {
+        if( isSubstring() )
+           const_cast<StringRef*>( this )->takeOwnership();
+        return m_start;
+    }
+    auto StringRef::currentData() const noexcept -> char const* {
+        return m_start;
+    }
+
+    auto StringRef::isOwned() const noexcept -> bool {
+        return m_data != nullptr;
+    }
+    auto StringRef::isSubstring() const noexcept -> bool {
+        return m_start[m_size] != '\0';
+    }
+
+    void StringRef::takeOwnership() {
+        if( !isOwned() ) {
+            m_data = new char[m_size+1];
+            memcpy( m_data, m_start, m_size );
+            m_data[m_size] = '\0';
+            m_start = m_data;
+        }
+    }
+    auto StringRef::substr( size_type start, size_type size ) const noexcept -> StringRef {
+        if( start < m_size )
+            return StringRef( m_start+start, size );
+        else
+            return StringRef();
+    }
+    auto StringRef::operator == ( StringRef const& other ) const noexcept -> bool {
+        return
+            size() == other.size() &&
+            (std::strncmp( m_start, other.m_start, size() ) == 0);
+    }
+    auto StringRef::operator != ( StringRef const& other ) const noexcept -> bool {
+        return !operator==( other );
+    }
+
+    auto StringRef::operator[](size_type index) const noexcept -> char {
+        return m_start[index];
+    }
+
+    auto StringRef::numberOfCharacters() const noexcept -> size_type {
+        size_type noChars = m_size;
+        // Make adjustments for uft encodings
+        for( size_type i=0; i < m_size; ++i ) {
+            char c = m_start[i];
+            if( ( c & byte_2_lead ) == byte_2_lead ) {
+                noChars--;
+                if (( c & byte_3_lead ) == byte_3_lead )
+                    noChars--;
+                if( ( c & byte_4_lead ) == byte_4_lead )
+                    noChars--;
+            }
+        }
+        return noChars;
+    }
+
+    auto operator + ( StringRef const& lhs, StringRef const& rhs ) -> std::string {
+        std::string str;
+        str.reserve( lhs.size() + rhs.size() );
+        str += lhs;
+        str += rhs;
+        return str;
+    }
+    auto operator + ( StringRef const& lhs, const char* rhs ) -> std::string {
+        return std::string( lhs ) + std::string( rhs );
+    }
+    auto operator + ( char const* lhs, StringRef const& rhs ) -> std::string {
+        return std::string( lhs ) + std::string( rhs );
+    }
+
+    auto operator << ( std::ostream& os, StringRef const& str ) -> std::ostream& {
+        return os.write(str.currentData(), str.size());
+    }
+
+    auto operator+=( std::string& lhs, StringRef const& rhs ) -> std::string& {
+        lhs.append(rhs.currentData(), rhs.size());
+        return lhs;
+    }
+
+} // namespace Catch
+
+#if defined(__clang__)
+#    pragma clang diagnostic pop
+#endif
+// end catch_stringref.cpp
+// start catch_tag_alias.cpp
+
+namespace Catch {
+    TagAlias::TagAlias(std::string const & _tag, SourceLineInfo _lineInfo): tag(_tag), lineInfo(_lineInfo) {}
+}
+// end catch_tag_alias.cpp
+// start catch_tag_alias_autoregistrar.cpp
+
+namespace Catch {
+
+    RegistrarForTagAliases::RegistrarForTagAliases(char const* alias, char const* tag, SourceLineInfo const& lineInfo) {
+        try {
+            getMutableRegistryHub().registerTagAlias(alias, tag, lineInfo);
+        } catch (...) {
+            // Do not throw when constructing global objects, instead register the exception to be processed later
+            getMutableRegistryHub().registerStartupException();
+        }
+    }
+
+}
+// end catch_tag_alias_autoregistrar.cpp
+// start catch_tag_alias_registry.cpp
+
+#include <sstream>
+
+namespace Catch {
+
+    TagAliasRegistry::~TagAliasRegistry() {}
+
+    TagAlias const* TagAliasRegistry::find( std::string const& alias ) const {
+        auto it = m_registry.find( alias );
+        if( it != m_registry.end() )
+            return &(it->second);
+        else
+            return nullptr;
+    }
+
+    std::string TagAliasRegistry::expandAliases( std::string const& unexpandedTestSpec ) const {
+        std::string expandedTestSpec = unexpandedTestSpec;
+        for( auto const& registryKvp : m_registry ) {
+            std::size_t pos = expandedTestSpec.find( registryKvp.first );
+            if( pos != std::string::npos ) {
+                expandedTestSpec =  expandedTestSpec.substr( 0, pos ) +
+                                    registryKvp.second.tag +
+                                    expandedTestSpec.substr( pos + registryKvp.first.size() );
+            }
+        }
+        return expandedTestSpec;
+    }
+
+    void TagAliasRegistry::add( std::string const& alias, std::string const& tag, SourceLineInfo const& lineInfo ) {
+        CATCH_ENFORCE( startsWith(alias, "[@") && endsWith(alias, ']'),
+                      "error: tag alias, '" << alias << "' is not of the form [@alias name].\n" << lineInfo );
+
+        CATCH_ENFORCE( m_registry.insert(std::make_pair(alias, TagAlias(tag, lineInfo))).second,
+                      "error: tag alias, '" << alias << "' already registered.\n"
+                      << "\tFirst seen at: " << find(alias)->lineInfo << "\n"
+                      << "\tRedefined at: " << lineInfo );
+    }
+
+    ITagAliasRegistry::~ITagAliasRegistry() {}
+
+    ITagAliasRegistry const& ITagAliasRegistry::get() {
+        return getRegistryHub().getTagAliasRegistry();
+    }
+
+} // end namespace Catch
+// end catch_tag_alias_registry.cpp
+// start catch_test_case_info.cpp
+
+#include <cctype>
+#include <exception>
+#include <algorithm>
+#include <sstream>
+
+namespace Catch {
+
+    TestCaseInfo::SpecialProperties parseSpecialTag( std::string const& tag ) {
+        if( startsWith( tag, '.' ) ||
+            tag == "!hide" )
+            return TestCaseInfo::IsHidden;
+        else if( tag == "!throws" )
+            return TestCaseInfo::Throws;
+        else if( tag == "!shouldfail" )
+            return TestCaseInfo::ShouldFail;
+        else if( tag == "!mayfail" )
+            return TestCaseInfo::MayFail;
+        else if( tag == "!nonportable" )
+            return TestCaseInfo::NonPortable;
+        else if( tag == "!benchmark" )
+            return static_cast<TestCaseInfo::SpecialProperties>( TestCaseInfo::Benchmark | TestCaseInfo::IsHidden );
+        else
+            return TestCaseInfo::None;
+    }
+    bool isReservedTag( std::string const& tag ) {
+        return parseSpecialTag( tag ) == TestCaseInfo::None && tag.size() > 0 && !std::isalnum( tag[0] );
+    }
+    void enforceNotReservedTag( std::string const& tag, SourceLineInfo const& _lineInfo ) {
+        CATCH_ENFORCE( !isReservedTag(tag),
+                      "Tag name: [" << tag << "] is not allowed.\n"
+                      << "Tag names starting with non alpha-numeric characters are reserved\n"
+                      << _lineInfo );
+    }
+
+    TestCase makeTestCase(  ITestInvoker* _testCase,
+                            std::string const& _className,
+                            NameAndTags const& nameAndTags,
+                            SourceLineInfo const& _lineInfo )
+    {
+        bool isHidden = false;
+
+        // Parse out tags
+        std::vector<std::string> tags;
+        std::string desc, tag;
+        bool inTag = false;
+        std::string _descOrTags = nameAndTags.tags;
+        for (char c : _descOrTags) {
+            if( !inTag ) {
+                if( c == '[' )
+                    inTag = true;
+                else
+                    desc += c;
+            }
+            else {
+                if( c == ']' ) {
+                    TestCaseInfo::SpecialProperties prop = parseSpecialTag( tag );
+                    if( ( prop & TestCaseInfo::IsHidden ) != 0 )
+                        isHidden = true;
+                    else if( prop == TestCaseInfo::None )
+                        enforceNotReservedTag( tag, _lineInfo );
+
+                    tags.push_back( tag );
+                    tag.clear();
+                    inTag = false;
+                }
+                else
+                    tag += c;
+            }
+        }
+        if( isHidden ) {
+            tags.push_back( "." );
+        }
+
+        TestCaseInfo info( nameAndTags.name, _className, desc, tags, _lineInfo );
+        return TestCase( _testCase, std::move(info) );
+    }
+
+    void setTags( TestCaseInfo& testCaseInfo, std::vector<std::string> tags ) {
+        std::sort(begin(tags), end(tags));
+        tags.erase(std::unique(begin(tags), end(tags)), end(tags));
+        testCaseInfo.lcaseTags.clear();
+
+        for( auto const& tag : tags ) {
+            std::string lcaseTag = toLower( tag );
+            testCaseInfo.properties = static_cast<TestCaseInfo::SpecialProperties>( testCaseInfo.properties | parseSpecialTag( lcaseTag ) );
+            testCaseInfo.lcaseTags.push_back( lcaseTag );
+        }
+        testCaseInfo.tags = std::move(tags);
+    }
+
+    TestCaseInfo::TestCaseInfo( std::string const& _name,
+                                std::string const& _className,
+                                std::string const& _description,
+                                std::vector<std::string> const& _tags,
+                                SourceLineInfo const& _lineInfo )
+    :   name( _name ),
+        className( _className ),
+        description( _description ),
+        lineInfo( _lineInfo ),
+        properties( None )
+    {
+        setTags( *this, _tags );
+    }
+
+    bool TestCaseInfo::isHidden() const {
+        return ( properties & IsHidden ) != 0;
+    }
+    bool TestCaseInfo::throws() const {
+        return ( properties & Throws ) != 0;
+    }
+    bool TestCaseInfo::okToFail() const {
+        return ( properties & (ShouldFail | MayFail ) ) != 0;
+    }
+    bool TestCaseInfo::expectedToFail() const {
+        return ( properties & (ShouldFail ) ) != 0;
+    }
+
+    std::string TestCaseInfo::tagsAsString() const {
+        std::string ret;
+        // '[' and ']' per tag
+        std::size_t full_size = 2 * tags.size();
+        for (const auto& tag : tags) {
+            full_size += tag.size();
+        }
+        ret.reserve(full_size);
+        for (const auto& tag : tags) {
+            ret.push_back('[');
+            ret.append(tag);
+            ret.push_back(']');
+        }
+
+        return ret;
+    }
+
+    TestCase::TestCase( ITestInvoker* testCase, TestCaseInfo&& info ) : TestCaseInfo( std::move(info) ), test( testCase ) {}
+
+    TestCase TestCase::withName( std::string const& _newName ) const {
+        TestCase other( *this );
+        other.name = _newName;
+        return other;
+    }
+
+    void TestCase::invoke() const {
+        test->invoke();
+    }
+
+    bool TestCase::operator == ( TestCase const& other ) const {
+        return  test.get() == other.test.get() &&
+                name == other.name &&
+                className == other.className;
+    }
+
+    bool TestCase::operator < ( TestCase const& other ) const {
+        return name < other.name;
+    }
+
+    TestCaseInfo const& TestCase::getTestCaseInfo() const
+    {
+        return *this;
+    }
+
+} // end namespace Catch
+// end catch_test_case_info.cpp
+// start catch_test_case_registry_impl.cpp
+
+#include <sstream>
+
+namespace Catch {
+
+    std::vector<TestCase> sortTests( IConfig const& config, std::vector<TestCase> const& unsortedTestCases ) {
+
+        std::vector<TestCase> sorted = unsortedTestCases;
+
+        switch( config.runOrder() ) {
+            case RunTests::InLexicographicalOrder:
+                std::sort( sorted.begin(), sorted.end() );
+                break;
+            case RunTests::InRandomOrder:
+                seedRng( config );
+                RandomNumberGenerator::shuffle( sorted );
+                break;
+            case RunTests::InDeclarationOrder:
+                // already in declaration order
+                break;
+        }
+        return sorted;
+    }
+    bool matchTest( TestCase const& testCase, TestSpec const& testSpec, IConfig const& config ) {
+        return testSpec.matches( testCase ) && ( config.allowThrows() || !testCase.throws() );
+    }
+
+    void enforceNoDuplicateTestCases( std::vector<TestCase> const& functions ) {
+        std::set<TestCase> seenFunctions;
+        for( auto const& function : functions ) {
+            auto prev = seenFunctions.insert( function );
+            CATCH_ENFORCE( prev.second,
+                    "error: TEST_CASE( \"" << function.name << "\" ) already defined.\n"
+                    << "\tFirst seen at " << prev.first->getTestCaseInfo().lineInfo << "\n"
+                    << "\tRedefined at " << function.getTestCaseInfo().lineInfo );
+        }
+    }
+
+    std::vector<TestCase> filterTests( std::vector<TestCase> const& testCases, TestSpec const& testSpec, IConfig const& config ) {
+        std::vector<TestCase> filtered;
+        filtered.reserve( testCases.size() );
+        for( auto const& testCase : testCases )
+            if( matchTest( testCase, testSpec, config ) )
+                filtered.push_back( testCase );
+        return filtered;
+    }
+    std::vector<TestCase> const& getAllTestCasesSorted( IConfig const& config ) {
+        return getRegistryHub().getTestCaseRegistry().getAllTestsSorted( config );
+    }
+
+    void TestRegistry::registerTest( TestCase const& testCase ) {
+        std::string name = testCase.getTestCaseInfo().name;
+        if( name.empty() ) {
+            ReusableStringStream rss;
+            rss << "Anonymous test case " << ++m_unnamedCount;
+            return registerTest( testCase.withName( rss.str() ) );
+        }
+        m_functions.push_back( testCase );
+    }
+
+    std::vector<TestCase> const& TestRegistry::getAllTests() const {
+        return m_functions;
+    }
+    std::vector<TestCase> const& TestRegistry::getAllTestsSorted( IConfig const& config ) const {
+        if( m_sortedFunctions.empty() )
+            enforceNoDuplicateTestCases( m_functions );
+
+        if(  m_currentSortOrder != config.runOrder() || m_sortedFunctions.empty() ) {
+            m_sortedFunctions = sortTests( config, m_functions );
+            m_currentSortOrder = config.runOrder();
+        }
+        return m_sortedFunctions;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    TestInvokerAsFunction::TestInvokerAsFunction( void(*testAsFunction)() ) noexcept : m_testAsFunction( testAsFunction ) {}
+
+    void TestInvokerAsFunction::invoke() const {
+        m_testAsFunction();
+    }
+
+    std::string extractClassName( StringRef const& classOrQualifiedMethodName ) {
+        std::string className = classOrQualifiedMethodName;
+        if( startsWith( className, '&' ) )
+        {
+            std::size_t lastColons = className.rfind( "::" );
+            std::size_t penultimateColons = className.rfind( "::", lastColons-1 );
+            if( penultimateColons == std::string::npos )
+                penultimateColons = 1;
+            className = className.substr( penultimateColons, lastColons-penultimateColons );
+        }
+        return className;
+    }
+
+} // end namespace Catch
+// end catch_test_case_registry_impl.cpp
+// start catch_test_case_tracker.cpp
+
+#include <algorithm>
+#include <assert.h>
+#include <stdexcept>
+#include <memory>
+#include <sstream>
+
+#if defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wexit-time-destructors"
+#endif
+
+namespace Catch {
+namespace TestCaseTracking {
+
+    NameAndLocation::NameAndLocation( std::string const& _name, SourceLineInfo const& _location )
+    :   name( _name ),
+        location( _location )
+    {}
+
+    ITracker::~ITracker() = default;
+
+    TrackerContext& TrackerContext::instance() {
+        static TrackerContext s_instance;
+        return s_instance;
+    }
+
+    ITracker& TrackerContext::startRun() {
+        m_rootTracker = std::make_shared<SectionTracker>( NameAndLocation( "{root}", CATCH_INTERNAL_LINEINFO ), *this, nullptr );
+        m_currentTracker = nullptr;
+        m_runState = Executing;
+        return *m_rootTracker;
+    }
+
+    void TrackerContext::endRun() {
+        m_rootTracker.reset();
+        m_currentTracker = nullptr;
+        m_runState = NotStarted;
+    }
+
+    void TrackerContext::startCycle() {
+        m_currentTracker = m_rootTracker.get();
+        m_runState = Executing;
+    }
+    void TrackerContext::completeCycle() {
+        m_runState = CompletedCycle;
+    }
+
+    bool TrackerContext::completedCycle() const {
+        return m_runState == CompletedCycle;
+    }
+    ITracker& TrackerContext::currentTracker() {
+        return *m_currentTracker;
+    }
+    void TrackerContext::setCurrentTracker( ITracker* tracker ) {
+        m_currentTracker = tracker;
+    }
+
+    TrackerBase::TrackerHasName::TrackerHasName( NameAndLocation const& nameAndLocation ) : m_nameAndLocation( nameAndLocation ) {}
+    bool TrackerBase::TrackerHasName::operator ()( ITrackerPtr const& tracker ) const {
+        return
+            tracker->nameAndLocation().name == m_nameAndLocation.name &&
+            tracker->nameAndLocation().location == m_nameAndLocation.location;
+    }
+
+    TrackerBase::TrackerBase( NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent )
+    :   m_nameAndLocation( nameAndLocation ),
+        m_ctx( ctx ),
+        m_parent( parent )
+    {}
+
+    NameAndLocation const& TrackerBase::nameAndLocation() const {
+        return m_nameAndLocation;
+    }
+    bool TrackerBase::isComplete() const {
+        return m_runState == CompletedSuccessfully || m_runState == Failed;
+    }
+    bool TrackerBase::isSuccessfullyCompleted() const {
+        return m_runState == CompletedSuccessfully;
+    }
+    bool TrackerBase::isOpen() const {
+        return m_runState != NotStarted && !isComplete();
+    }
+    bool TrackerBase::hasChildren() const {
+        return !m_children.empty();
+    }
+
+    void TrackerBase::addChild( ITrackerPtr const& child ) {
+        m_children.push_back( child );
+    }
+
+    ITrackerPtr TrackerBase::findChild( NameAndLocation const& nameAndLocation ) {
+        auto it = std::find_if( m_children.begin(), m_children.end(), TrackerHasName( nameAndLocation ) );
+        return( it != m_children.end() )
+            ? *it
+            : nullptr;
+    }
+    ITracker& TrackerBase::parent() {
+        assert( m_parent ); // Should always be non-null except for root
+        return *m_parent;
+    }
+
+    void TrackerBase::openChild() {
+        if( m_runState != ExecutingChildren ) {
+            m_runState = ExecutingChildren;
+            if( m_parent )
+                m_parent->openChild();
+        }
+    }
+
+    bool TrackerBase::isSectionTracker() const { return false; }
+    bool TrackerBase::isIndexTracker() const { return false; }
+
+    void TrackerBase::open() {
+        m_runState = Executing;
+        moveToThis();
+        if( m_parent )
+            m_parent->openChild();
+    }
+
+    void TrackerBase::close() {
+
+        // Close any still open children (e.g. generators)
+        while( &m_ctx.currentTracker() != this )
+            m_ctx.currentTracker().close();
+
+        switch( m_runState ) {
+            case NeedsAnotherRun:
+                break;
+
+            case Executing:
+                m_runState = CompletedSuccessfully;
+                break;
+            case ExecutingChildren:
+                if( m_children.empty() || m_children.back()->isComplete() )
+                    m_runState = CompletedSuccessfully;
+                break;
+
+            case NotStarted:
+            case CompletedSuccessfully:
+            case Failed:
+                CATCH_INTERNAL_ERROR( "Illogical state: " << m_runState );
+
+            default:
+                CATCH_INTERNAL_ERROR( "Unknown state: " << m_runState );
+        }
+        moveToParent();
+        m_ctx.completeCycle();
+    }
+    void TrackerBase::fail() {
+        m_runState = Failed;
+        if( m_parent )
+            m_parent->markAsNeedingAnotherRun();
+        moveToParent();
+        m_ctx.completeCycle();
+    }
+    void TrackerBase::markAsNeedingAnotherRun() {
+        m_runState = NeedsAnotherRun;
+    }
+
+    void TrackerBase::moveToParent() {
+        assert( m_parent );
+        m_ctx.setCurrentTracker( m_parent );
+    }
+    void TrackerBase::moveToThis() {
+        m_ctx.setCurrentTracker( this );
+    }
+
+    SectionTracker::SectionTracker( NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent )
+    :   TrackerBase( nameAndLocation, ctx, parent )
+    {
+        if( parent ) {
+            while( !parent->isSectionTracker() )
+                parent = &parent->parent();
+
+            SectionTracker& parentSection = static_cast<SectionTracker&>( *parent );
+            addNextFilters( parentSection.m_filters );
+        }
+    }
+
+    bool SectionTracker::isSectionTracker() const { return true; }
+
+    SectionTracker& SectionTracker::acquire( TrackerContext& ctx, NameAndLocation const& nameAndLocation ) {
+        std::shared_ptr<SectionTracker> section;
+
+        ITracker& currentTracker = ctx.currentTracker();
+        if( ITrackerPtr childTracker = currentTracker.findChild( nameAndLocation ) ) {
+            assert( childTracker );
+            assert( childTracker->isSectionTracker() );
+            section = std::static_pointer_cast<SectionTracker>( childTracker );
+        }
+        else {
+            section = std::make_shared<SectionTracker>( nameAndLocation, ctx, &currentTracker );
+            currentTracker.addChild( section );
+        }
+        if( !ctx.completedCycle() )
+            section->tryOpen();
+        return *section;
+    }
+
+    void SectionTracker::tryOpen() {
+        if( !isComplete() && (m_filters.empty() || m_filters[0].empty() ||  m_filters[0] == m_nameAndLocation.name ) )
+            open();
+    }
+
+    void SectionTracker::addInitialFilters( std::vector<std::string> const& filters ) {
+        if( !filters.empty() ) {
+            m_filters.push_back(""); // Root - should never be consulted
+            m_filters.push_back(""); // Test Case - not a section filter
+            m_filters.insert( m_filters.end(), filters.begin(), filters.end() );
+        }
+    }
+    void SectionTracker::addNextFilters( std::vector<std::string> const& filters ) {
+        if( filters.size() > 1 )
+            m_filters.insert( m_filters.end(), ++filters.begin(), filters.end() );
+    }
+
+    IndexTracker::IndexTracker( NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent, int size )
+    :   TrackerBase( nameAndLocation, ctx, parent ),
+        m_size( size )
+    {}
+
+    bool IndexTracker::isIndexTracker() const { return true; }
+
+    IndexTracker& IndexTracker::acquire( TrackerContext& ctx, NameAndLocation const& nameAndLocation, int size ) {
+        std::shared_ptr<IndexTracker> tracker;
+
+        ITracker& currentTracker = ctx.currentTracker();
+        if( ITrackerPtr childTracker = currentTracker.findChild( nameAndLocation ) ) {
+            assert( childTracker );
+            assert( childTracker->isIndexTracker() );
+            tracker = std::static_pointer_cast<IndexTracker>( childTracker );
+        }
+        else {
+            tracker = std::make_shared<IndexTracker>( nameAndLocation, ctx, &currentTracker, size );
+            currentTracker.addChild( tracker );
+        }
+
+        if( !ctx.completedCycle() && !tracker->isComplete() ) {
+            if( tracker->m_runState != ExecutingChildren && tracker->m_runState != NeedsAnotherRun )
+                tracker->moveNext();
+            tracker->open();
+        }
+
+        return *tracker;
+    }
+
+    int IndexTracker::index() const { return m_index; }
+
+    void IndexTracker::moveNext() {
+        m_index++;
+        m_children.clear();
+    }
+
+    void IndexTracker::close() {
+        TrackerBase::close();
+        if( m_runState == CompletedSuccessfully && m_index < m_size-1 )
+            m_runState = Executing;
+    }
+
+} // namespace TestCaseTracking
+
+using TestCaseTracking::ITracker;
+using TestCaseTracking::TrackerContext;
+using TestCaseTracking::SectionTracker;
+using TestCaseTracking::IndexTracker;
+
+} // namespace Catch
+
+#if defined(__clang__)
+#    pragma clang diagnostic pop
+#endif
+// end catch_test_case_tracker.cpp
+// start catch_test_registry.cpp
+
+namespace Catch {
+
+    auto makeTestInvoker( void(*testAsFunction)() ) noexcept -> ITestInvoker* {
+        return new(std::nothrow) TestInvokerAsFunction( testAsFunction );
+    }
+
+    NameAndTags::NameAndTags( StringRef const& name_ , StringRef const& tags_ ) noexcept : name( name_ ), tags( tags_ ) {}
+
+    AutoReg::AutoReg( ITestInvoker* invoker, SourceLineInfo const& lineInfo, StringRef const& classOrMethod, NameAndTags const& nameAndTags ) noexcept {
+        try {
+            getMutableRegistryHub()
+                    .registerTest(
+                        makeTestCase(
+                            invoker,
+                            extractClassName( classOrMethod ),
+                            nameAndTags,
+                            lineInfo));
+        } catch (...) {
+            // Do not throw when constructing global objects, instead register the exception to be processed later
+            getMutableRegistryHub().registerStartupException();
+        }
+    }
+
+    AutoReg::~AutoReg() = default;
+}
+// end catch_test_registry.cpp
+// start catch_test_spec.cpp
+
+#include <algorithm>
+#include <string>
+#include <vector>
+#include <memory>
+
+namespace Catch {
+
+    TestSpec::Pattern::~Pattern() = default;
+    TestSpec::NamePattern::~NamePattern() = default;
+    TestSpec::TagPattern::~TagPattern() = default;
+    TestSpec::ExcludedPattern::~ExcludedPattern() = default;
+
+    TestSpec::NamePattern::NamePattern( std::string const& name )
+    : m_wildcardPattern( toLower( name ), CaseSensitive::No )
+    {}
+    bool TestSpec::NamePattern::matches( TestCaseInfo const& testCase ) const {
+        return m_wildcardPattern.matches( toLower( testCase.name ) );
+    }
+
+    TestSpec::TagPattern::TagPattern( std::string const& tag ) : m_tag( toLower( tag ) ) {}
+    bool TestSpec::TagPattern::matches( TestCaseInfo const& testCase ) const {
+        return std::find(begin(testCase.lcaseTags),
+                         end(testCase.lcaseTags),
+                         m_tag) != end(testCase.lcaseTags);
+    }
+
+    TestSpec::ExcludedPattern::ExcludedPattern( PatternPtr const& underlyingPattern ) : m_underlyingPattern( underlyingPattern ) {}
+    bool TestSpec::ExcludedPattern::matches( TestCaseInfo const& testCase ) const { return !m_underlyingPattern->matches( testCase ); }
+
+    bool TestSpec::Filter::matches( TestCaseInfo const& testCase ) const {
+        // All patterns in a filter must match for the filter to be a match
+        for( auto const& pattern : m_patterns ) {
+            if( !pattern->matches( testCase ) )
+                return false;
+        }
+        return true;
+    }
+
+    bool TestSpec::hasFilters() const {
+        return !m_filters.empty();
+    }
+    bool TestSpec::matches( TestCaseInfo const& testCase ) const {
+        // A TestSpec matches if any filter matches
+        for( auto const& filter : m_filters )
+            if( filter.matches( testCase ) )
+                return true;
+        return false;
+    }
+}
+// end catch_test_spec.cpp
+// start catch_test_spec_parser.cpp
+
+namespace Catch {
+
+    TestSpecParser::TestSpecParser( ITagAliasRegistry const& tagAliases ) : m_tagAliases( &tagAliases ) {}
+
+    TestSpecParser& TestSpecParser::parse( std::string const& arg ) {
+        m_mode = None;
+        m_exclusion = false;
+        m_start = std::string::npos;
+        m_arg = m_tagAliases->expandAliases( arg );
+        m_escapeChars.clear();
+        for( m_pos = 0; m_pos < m_arg.size(); ++m_pos )
+            visitChar( m_arg[m_pos] );
+        if( m_mode == Name )
+            addPattern<TestSpec::NamePattern>();
+        return *this;
+    }
+    TestSpec TestSpecParser::testSpec() {
+        addFilter();
+        return m_testSpec;
+    }
+
+    void TestSpecParser::visitChar( char c ) {
+        if( m_mode == None ) {
+            switch( c ) {
+            case ' ': return;
+            case '~': m_exclusion = true; return;
+            case '[': return startNewMode( Tag, ++m_pos );
+            case '"': return startNewMode( QuotedName, ++m_pos );
+            case '\\': return escape();
+            default: startNewMode( Name, m_pos ); break;
+            }
+        }
+        if( m_mode == Name ) {
+            if( c == ',' ) {
+                addPattern<TestSpec::NamePattern>();
+                addFilter();
+            }
+            else if( c == '[' ) {
+                if( subString() == "exclude:" )
+                    m_exclusion = true;
+                else
+                    addPattern<TestSpec::NamePattern>();
+                startNewMode( Tag, ++m_pos );
+            }
+            else if( c == '\\' )
+                escape();
+        }
+        else if( m_mode == EscapedName )
+            m_mode = Name;
+        else if( m_mode == QuotedName && c == '"' )
+            addPattern<TestSpec::NamePattern>();
+        else if( m_mode == Tag && c == ']' )
+            addPattern<TestSpec::TagPattern>();
+    }
+    void TestSpecParser::startNewMode( Mode mode, std::size_t start ) {
+        m_mode = mode;
+        m_start = start;
+    }
+    void TestSpecParser::escape() {
+        if( m_mode == None )
+            m_start = m_pos;
+        m_mode = EscapedName;
+        m_escapeChars.push_back( m_pos );
+    }
+    std::string TestSpecParser::subString() const { return m_arg.substr( m_start, m_pos - m_start ); }
+
+    void TestSpecParser::addFilter() {
+        if( !m_currentFilter.m_patterns.empty() ) {
+            m_testSpec.m_filters.push_back( m_currentFilter );
+            m_currentFilter = TestSpec::Filter();
+        }
+    }
+
+    TestSpec parseTestSpec( std::string const& arg ) {
+        return TestSpecParser( ITagAliasRegistry::get() ).parse( arg ).testSpec();
+    }
+
+} // namespace Catch
+// end catch_test_spec_parser.cpp
+// start catch_timer.cpp
+
+#include <chrono>
+
+static const uint64_t nanosecondsInSecond = 1000000000;
+
+namespace Catch {
+
+    auto getCurrentNanosecondsSinceEpoch() -> uint64_t {
+        return std::chrono::duration_cast<std::chrono::nanoseconds>( std::chrono::high_resolution_clock::now().time_since_epoch() ).count();
+    }
+
+    auto estimateClockResolution() -> uint64_t {
+        uint64_t sum = 0;
+        static const uint64_t iterations = 1000000;
+
+        auto startTime = getCurrentNanosecondsSinceEpoch();
+
+        for( std::size_t i = 0; i < iterations; ++i ) {
+
+            uint64_t ticks;
+            uint64_t baseTicks = getCurrentNanosecondsSinceEpoch();
+            do {
+                ticks = getCurrentNanosecondsSinceEpoch();
+            } while( ticks == baseTicks );
+
+            auto delta = ticks - baseTicks;
+            sum += delta;
+
+            // If we have been calibrating for over 3 seconds -- the clock
+            // is terrible and we should move on.
+            // TBD: How to signal that the measured resolution is probably wrong?
+            if (ticks > startTime + 3 * nanosecondsInSecond) {
+                return sum / i;
+            }
+        }
+
+        // We're just taking the mean, here. To do better we could take the std. dev and exclude outliers
+        // - and potentially do more iterations if there's a high variance.
+        return sum/iterations;
+    }
+    auto getEstimatedClockResolution() -> uint64_t {
+        static auto s_resolution = estimateClockResolution();
+        return s_resolution;
+    }
+
+    void Timer::start() {
+       m_nanoseconds = getCurrentNanosecondsSinceEpoch();
+    }
+    auto Timer::getElapsedNanoseconds() const -> uint64_t {
+        return getCurrentNanosecondsSinceEpoch() - m_nanoseconds;
+    }
+    auto Timer::getElapsedMicroseconds() const -> uint64_t {
+        return getElapsedNanoseconds()/1000;
+    }
+    auto Timer::getElapsedMilliseconds() const -> unsigned int {
+        return static_cast<unsigned int>(getElapsedMicroseconds()/1000);
+    }
+    auto Timer::getElapsedSeconds() const -> double {
+        return getElapsedMicroseconds()/1000000.0;
+    }
+
+} // namespace Catch
+// end catch_timer.cpp
+// start catch_tostring.cpp
+
+#if defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wexit-time-destructors"
+#    pragma clang diagnostic ignored "-Wglobal-constructors"
+#endif
+
+// Enable specific decls locally
+#if !defined(CATCH_CONFIG_ENABLE_CHRONO_STRINGMAKER)
+#define CATCH_CONFIG_ENABLE_CHRONO_STRINGMAKER
+#endif
+
+#include <cmath>
+#include <iomanip>
+
+namespace Catch {
+
+namespace Detail {
+
+    const std::string unprintableString = "{?}";
+
+    namespace {
+        const int hexThreshold = 255;
+
+        struct Endianness {
+            enum Arch { Big, Little };
+
+            static Arch which() {
+                union _{
+                    int asInt;
+                    char asChar[sizeof (int)];
+                } u;
+
+                u.asInt = 1;
+                return ( u.asChar[sizeof(int)-1] == 1 ) ? Big : Little;
+            }
+        };
+    }
+
+    std::string rawMemoryToString( const void *object, std::size_t size ) {
+        // Reverse order for little endian architectures
+        int i = 0, end = static_cast<int>( size ), inc = 1;
+        if( Endianness::which() == Endianness::Little ) {
+            i = end-1;
+            end = inc = -1;
+        }
+
+        unsigned char const *bytes = static_cast<unsigned char const *>(object);
+        ReusableStringStream rss;
+        rss << "0x" << std::setfill('0') << std::hex;
+        for( ; i != end; i += inc )
+             rss << std::setw(2) << static_cast<unsigned>(bytes[i]);
+       return rss.str();
+    }
+}
+
+template<typename T>
+std::string fpToString( T value, int precision ) {
+    if (std::isnan(value)) {
+        return "nan";
+    }
+
+    ReusableStringStream rss;
+    rss << std::setprecision( precision )
+        << std::fixed
+        << value;
+    std::string d = rss.str();
+    std::size_t i = d.find_last_not_of( '0' );
+    if( i != std::string::npos && i != d.size()-1 ) {
+        if( d[i] == '.' )
+            i++;
+        d = d.substr( 0, i+1 );
+    }
+    return d;
+}
+
+//// ======================================================= ////
+//
+//   Out-of-line defs for full specialization of StringMaker
+//
+//// ======================================================= ////
+
+std::string StringMaker<std::string>::convert(const std::string& str) {
+    if (!getCurrentContext().getConfig()->showInvisibles()) {
+        return '"' + str + '"';
+    }
+
+    std::string s("\"");
+    for (char c : str) {
+        switch (c) {
+        case '\n':
+            s.append("\\n");
+            break;
+        case '\t':
+            s.append("\\t");
+            break;
+        default:
+            s.push_back(c);
+            break;
+        }
+    }
+    s.append("\"");
+    return s;
+}
+
+#ifdef CATCH_CONFIG_WCHAR
+std::string StringMaker<std::wstring>::convert(const std::wstring& wstr) {
+    std::string s;
+    s.reserve(wstr.size());
+    for (auto c : wstr) {
+        s += (c <= 0xff) ? static_cast<char>(c) : '?';
+    }
+    return ::Catch::Detail::stringify(s);
+}
+#endif
+
+std::string StringMaker<char const*>::convert(char const* str) {
+    if (str) {
+        return ::Catch::Detail::stringify(std::string{ str });
+    } else {
+        return{ "{null string}" };
+    }
+}
+std::string StringMaker<char*>::convert(char* str) {
+    if (str) {
+        return ::Catch::Detail::stringify(std::string{ str });
+    } else {
+        return{ "{null string}" };
+    }
+}
+#ifdef CATCH_CONFIG_WCHAR
+std::string StringMaker<wchar_t const*>::convert(wchar_t const * str) {
+    if (str) {
+        return ::Catch::Detail::stringify(std::wstring{ str });
+    } else {
+        return{ "{null string}" };
+    }
+}
+std::string StringMaker<wchar_t *>::convert(wchar_t * str) {
+    if (str) {
+        return ::Catch::Detail::stringify(std::wstring{ str });
+    } else {
+        return{ "{null string}" };
+    }
+}
+#endif
+
+std::string StringMaker<int>::convert(int value) {
+    return ::Catch::Detail::stringify(static_cast<long long>(value));
+}
+std::string StringMaker<long>::convert(long value) {
+    return ::Catch::Detail::stringify(static_cast<long long>(value));
+}
+std::string StringMaker<long long>::convert(long long value) {
+    ReusableStringStream rss;
+    rss << value;
+    if (value > Detail::hexThreshold) {
+        rss << " (0x" << std::hex << value << ')';
+    }
+    return rss.str();
+}
+
+std::string StringMaker<unsigned int>::convert(unsigned int value) {
+    return ::Catch::Detail::stringify(static_cast<unsigned long long>(value));
+}
+std::string StringMaker<unsigned long>::convert(unsigned long value) {
+    return ::Catch::Detail::stringify(static_cast<unsigned long long>(value));
+}
+std::string StringMaker<unsigned long long>::convert(unsigned long long value) {
+    ReusableStringStream rss;
+    rss << value;
+    if (value > Detail::hexThreshold) {
+        rss << " (0x" << std::hex << value << ')';
+    }
+    return rss.str();
+}
+
+std::string StringMaker<bool>::convert(bool b) {
+    return b ? "true" : "false";
+}
+
+std::string StringMaker<char>::convert(char value) {
+    if (value == '\r') {
+        return "'\\r'";
+    } else if (value == '\f') {
+        return "'\\f'";
+    } else if (value == '\n') {
+        return "'\\n'";
+    } else if (value == '\t') {
+        return "'\\t'";
+    } else if ('\0' <= value && value < ' ') {
+        return ::Catch::Detail::stringify(static_cast<unsigned int>(value));
+    } else {
+        char chstr[] = "' '";
+        chstr[1] = value;
+        return chstr;
+    }
+}
+std::string StringMaker<signed char>::convert(signed char c) {
+    return ::Catch::Detail::stringify(static_cast<char>(c));
+}
+std::string StringMaker<unsigned char>::convert(unsigned char c) {
+    return ::Catch::Detail::stringify(static_cast<char>(c));
+}
+
+std::string StringMaker<std::nullptr_t>::convert(std::nullptr_t) {
+    return "nullptr";
+}
+
+std::string StringMaker<float>::convert(float value) {
+    return fpToString(value, 5) + 'f';
+}
+std::string StringMaker<double>::convert(double value) {
+    return fpToString(value, 10);
+}
+
+std::string ratio_string<std::atto>::symbol() { return "a"; }
+std::string ratio_string<std::femto>::symbol() { return "f"; }
+std::string  ratio_string<std::pico>::symbol() { return "p"; }
+std::string  ratio_string<std::nano>::symbol() { return "n"; }
+std::string ratio_string<std::micro>::symbol() { return "u"; }
+std::string ratio_string<std::milli>::symbol() { return "m"; }
+
+} // end namespace Catch
+
+#if defined(__clang__)
+#    pragma clang diagnostic pop
+#endif
+
+// end catch_tostring.cpp
+// start catch_totals.cpp
+
+namespace Catch {
+
+    Counts Counts::operator - ( Counts const& other ) const {
+        Counts diff;
+        diff.passed = passed - other.passed;
+        diff.failed = failed - other.failed;
+        diff.failedButOk = failedButOk - other.failedButOk;
+        return diff;
+    }
+
+    Counts& Counts::operator += ( Counts const& other ) {
+        passed += other.passed;
+        failed += other.failed;
+        failedButOk += other.failedButOk;
+        return *this;
+    }
+
+    std::size_t Counts::total() const {
+        return passed + failed + failedButOk;
+    }
+    bool Counts::allPassed() const {
+        return failed == 0 && failedButOk == 0;
+    }
+    bool Counts::allOk() const {
+        return failed == 0;
+    }
+
+    Totals Totals::operator - ( Totals const& other ) const {
+        Totals diff;
+        diff.assertions = assertions - other.assertions;
+        diff.testCases = testCases - other.testCases;
+        return diff;
+    }
+
+    Totals& Totals::operator += ( Totals const& other ) {
+        assertions += other.assertions;
+        testCases += other.testCases;
+        return *this;
+    }
+
+    Totals Totals::delta( Totals const& prevTotals ) const {
+        Totals diff = *this - prevTotals;
+        if( diff.assertions.failed > 0 )
+            ++diff.testCases.failed;
+        else if( diff.assertions.failedButOk > 0 )
+            ++diff.testCases.failedButOk;
+        else
+            ++diff.testCases.passed;
+        return diff;
+    }
+
+}
+// end catch_totals.cpp
+// start catch_uncaught_exceptions.cpp
+
+#include <exception>
+
+namespace Catch {
+    bool uncaught_exceptions() {
+#if defined(CATCH_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS)
+        return std::uncaught_exceptions() > 0;
+#else
+        return std::uncaught_exception();
+#endif
+  }
+} // end namespace Catch
+// end catch_uncaught_exceptions.cpp
+// start catch_version.cpp
+
+#include <ostream>
+
+namespace Catch {
+
+    Version::Version
+        (   unsigned int _majorVersion,
+            unsigned int _minorVersion,
+            unsigned int _patchNumber,
+            char const * const _branchName,
+            unsigned int _buildNumber )
+    :   majorVersion( _majorVersion ),
+        minorVersion( _minorVersion ),
+        patchNumber( _patchNumber ),
+        branchName( _branchName ),
+        buildNumber( _buildNumber )
+    {}
+
+    std::ostream& operator << ( std::ostream& os, Version const& version ) {
+        os  << version.majorVersion << '.'
+            << version.minorVersion << '.'
+            << version.patchNumber;
+        // branchName is never null -> 0th char is \0 if it is empty
+        if (version.branchName[0]) {
+            os << '-' << version.branchName
+               << '.' << version.buildNumber;
+        }
+        return os;
+    }
+
+    Version const& libraryVersion() {
+        static Version version( 2, 2, 2, "", 0 );
+        return version;
+    }
+
+}
+// end catch_version.cpp
+// start catch_wildcard_pattern.cpp
+
+#include <sstream>
+
+namespace Catch {
+
+    WildcardPattern::WildcardPattern( std::string const& pattern,
+                                      CaseSensitive::Choice caseSensitivity )
+    :   m_caseSensitivity( caseSensitivity ),
+        m_pattern( adjustCase( pattern ) )
+    {
+        if( startsWith( m_pattern, '*' ) ) {
+            m_pattern = m_pattern.substr( 1 );
+            m_wildcard = WildcardAtStart;
+        }
+        if( endsWith( m_pattern, '*' ) ) {
+            m_pattern = m_pattern.substr( 0, m_pattern.size()-1 );
+            m_wildcard = static_cast<WildcardPosition>( m_wildcard | WildcardAtEnd );
+        }
+    }
+
+    bool WildcardPattern::matches( std::string const& str ) const {
+        switch( m_wildcard ) {
+            case NoWildcard:
+                return m_pattern == adjustCase( str );
+            case WildcardAtStart:
+                return endsWith( adjustCase( str ), m_pattern );
+            case WildcardAtEnd:
+                return startsWith( adjustCase( str ), m_pattern );
+            case WildcardAtBothEnds:
+                return contains( adjustCase( str ), m_pattern );
+            default:
+                CATCH_INTERNAL_ERROR( "Unknown enum" );
+        }
+    }
+
+    std::string WildcardPattern::adjustCase( std::string const& str ) const {
+        return m_caseSensitivity == CaseSensitive::No ? toLower( str ) : str;
+    }
+}
+// end catch_wildcard_pattern.cpp
+// start catch_xmlwriter.cpp
+
+#include <iomanip>
+
+using uchar = unsigned char;
+
+namespace Catch {
+
+namespace {
+
+    size_t trailingBytes(unsigned char c) {
+        if ((c & 0xE0) == 0xC0) {
+            return 2;
+        }
+        if ((c & 0xF0) == 0xE0) {
+            return 3;
+        }
+        if ((c & 0xF8) == 0xF0) {
+            return 4;
+        }
+        CATCH_INTERNAL_ERROR("Invalid multibyte utf-8 start byte encountered");
+    }
+
+    uint32_t headerValue(unsigned char c) {
+        if ((c & 0xE0) == 0xC0) {
+            return c & 0x1F;
+        }
+        if ((c & 0xF0) == 0xE0) {
+            return c & 0x0F;
+        }
+        if ((c & 0xF8) == 0xF0) {
+            return c & 0x07;
+        }
+        CATCH_INTERNAL_ERROR("Invalid multibyte utf-8 start byte encountered");
+    }
+
+    void hexEscapeChar(std::ostream& os, unsigned char c) {
+        os << "\\x"
+            << std::uppercase << std::hex << std::setfill('0') << std::setw(2)
+            << static_cast<int>(c);
+    }
+
+} // anonymous namespace
+
+    XmlEncode::XmlEncode( std::string const& str, ForWhat forWhat )
+    :   m_str( str ),
+        m_forWhat( forWhat )
+    {}
+
+    void XmlEncode::encodeTo( std::ostream& os ) const {
+        // Apostrophe escaping not necessary if we always use " to write attributes
+        // (see: http://www.w3.org/TR/xml/#syntax)
+
+        for( std::size_t idx = 0; idx < m_str.size(); ++ idx ) {
+            uchar c = m_str[idx];
+            switch (c) {
+            case '<':   os << "&lt;"; break;
+            case '&':   os << "&amp;"; break;
+
+            case '>':
+                // See: http://www.w3.org/TR/xml/#syntax
+                if (idx > 2 && m_str[idx - 1] == ']' && m_str[idx - 2] == ']')
+                    os << "&gt;";
+                else
+                    os << c;
+                break;
+
+            case '\"':
+                if (m_forWhat == ForAttributes)
+                    os << "&quot;";
+                else
+                    os << c;
+                break;
+
+            default:
+                // Check for control characters and invalid utf-8
+
+                // Escape control characters in standard ascii
+                // see http://stackoverflow.com/questions/404107/why-are-control-characters-illegal-in-xml-1-0
+                if (c < 0x09 || (c > 0x0D && c < 0x20) || c == 0x7F) {
+                    hexEscapeChar(os, c);
+                    break;
+                }
+
+                // Plain ASCII: Write it to stream
+                if (c < 0x7F) {
+                    os << c;
+                    break;
+                }
+
+                // UTF-8 territory
+                // Check if the encoding is valid and if it is not, hex escape bytes.
+                // Important: We do not check the exact decoded values for validity, only the encoding format
+                // First check that this bytes is a valid lead byte:
+                // This means that it is not encoded as 1111 1XXX
+                // Or as 10XX XXXX
+                if (c <  0xC0 ||
+                    c >= 0xF8) {
+                    hexEscapeChar(os, c);
+                    break;
+                }
+
+                auto encBytes = trailingBytes(c);
+                // Are there enough bytes left to avoid accessing out-of-bounds memory?
+                if (idx + encBytes - 1 >= m_str.size()) {
+                    hexEscapeChar(os, c);
+                    break;
+                }
+                // The header is valid, check data
+                // The next encBytes bytes must together be a valid utf-8
+                // This means: bitpattern 10XX XXXX and the extracted value is sane (ish)
+                bool valid = true;
+                uint32_t value = headerValue(c);
+                for (std::size_t n = 1; n < encBytes; ++n) {
+                    uchar nc = m_str[idx + n];
+                    valid &= ((nc & 0xC0) == 0x80);
+                    value = (value << 6) | (nc & 0x3F);
+                }
+
+                if (
+                    // Wrong bit pattern of following bytes
+                    (!valid) ||
+                    // Overlong encodings
+                    (value < 0x80) ||
+                    (0x80 <= value && value < 0x800   && encBytes > 2) ||
+                    (0x800 < value && value < 0x10000 && encBytes > 3) ||
+                    // Encoded value out of range
+                    (value >= 0x110000)
+                    ) {
+                    hexEscapeChar(os, c);
+                    break;
+                }
+
+                // If we got here, this is in fact a valid(ish) utf-8 sequence
+                for (std::size_t n = 0; n < encBytes; ++n) {
+                    os << m_str[idx + n];
+                }
+                idx += encBytes - 1;
+                break;
+            }
+        }
+    }
+
+    std::ostream& operator << ( std::ostream& os, XmlEncode const& xmlEncode ) {
+        xmlEncode.encodeTo( os );
+        return os;
+    }
+
+    XmlWriter::ScopedElement::ScopedElement( XmlWriter* writer )
+    :   m_writer( writer )
+    {}
+
+    XmlWriter::ScopedElement::ScopedElement( ScopedElement&& other ) noexcept
+    :   m_writer( other.m_writer ){
+        other.m_writer = nullptr;
+    }
+    XmlWriter::ScopedElement& XmlWriter::ScopedElement::operator=( ScopedElement&& other ) noexcept {
+        if ( m_writer ) {
+            m_writer->endElement();
+        }
+        m_writer = other.m_writer;
+        other.m_writer = nullptr;
+        return *this;
+    }
+
+    XmlWriter::ScopedElement::~ScopedElement() {
+        if( m_writer )
+            m_writer->endElement();
+    }
+
+    XmlWriter::ScopedElement& XmlWriter::ScopedElement::writeText( std::string const& text, bool indent ) {
+        m_writer->writeText( text, indent );
+        return *this;
+    }
+
+    XmlWriter::XmlWriter( std::ostream& os ) : m_os( os )
+    {
+        writeDeclaration();
+    }
+
+    XmlWriter::~XmlWriter() {
+        while( !m_tags.empty() )
+            endElement();
+    }
+
+    XmlWriter& XmlWriter::startElement( std::string const& name ) {
+        ensureTagClosed();
+        newlineIfNecessary();
+        m_os << m_indent << '<' << name;
+        m_tags.push_back( name );
+        m_indent += "  ";
+        m_tagIsOpen = true;
+        return *this;
+    }
+
+    XmlWriter::ScopedElement XmlWriter::scopedElement( std::string const& name ) {
+        ScopedElement scoped( this );
+        startElement( name );
+        return scoped;
+    }
+
+    XmlWriter& XmlWriter::endElement() {
+        newlineIfNecessary();
+        m_indent = m_indent.substr( 0, m_indent.size()-2 );
+        if( m_tagIsOpen ) {
+            m_os << "/>";
+            m_tagIsOpen = false;
+        }
+        else {
+            m_os << m_indent << "</" << m_tags.back() << ">";
+        }
+        m_os << std::endl;
+        m_tags.pop_back();
+        return *this;
+    }
+
+    XmlWriter& XmlWriter::writeAttribute( std::string const& name, std::string const& attribute ) {
+        if( !name.empty() && !attribute.empty() )
+            m_os << ' ' << name << "=\"" << XmlEncode( attribute, XmlEncode::ForAttributes ) << '"';
+        return *this;
+    }
+
+    XmlWriter& XmlWriter::writeAttribute( std::string const& name, bool attribute ) {
+        m_os << ' ' << name << "=\"" << ( attribute ? "true" : "false" ) << '"';
+        return *this;
+    }
+
+    XmlWriter& XmlWriter::writeText( std::string const& text, bool indent ) {
+        if( !text.empty() ){
+            bool tagWasOpen = m_tagIsOpen;
+            ensureTagClosed();
+            if( tagWasOpen && indent )
+                m_os << m_indent;
+            m_os << XmlEncode( text );
+            m_needsNewline = true;
+        }
+        return *this;
+    }
+
+    XmlWriter& XmlWriter::writeComment( std::string const& text ) {
+        ensureTagClosed();
+        m_os << m_indent << "<!--" << text << "-->";
+        m_needsNewline = true;
+        return *this;
+    }
+
+    void XmlWriter::writeStylesheetRef( std::string const& url ) {
+        m_os << "<?xml-stylesheet type=\"text/xsl\" href=\"" << url << "\"?>\n";
+    }
+
+    XmlWriter& XmlWriter::writeBlankLine() {
+        ensureTagClosed();
+        m_os << '\n';
+        return *this;
+    }
+
+    void XmlWriter::ensureTagClosed() {
+        if( m_tagIsOpen ) {
+            m_os << ">" << std::endl;
+            m_tagIsOpen = false;
+        }
+    }
+
+    void XmlWriter::writeDeclaration() {
+        m_os << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+    }
+
+    void XmlWriter::newlineIfNecessary() {
+        if( m_needsNewline ) {
+            m_os << std::endl;
+            m_needsNewline = false;
+        }
+    }
+}
+// end catch_xmlwriter.cpp
+// start catch_reporter_bases.cpp
+
+#include <cstring>
+#include <cfloat>
+#include <cstdio>
+#include <assert.h>
+#include <memory>
+
+namespace Catch {
+    void prepareExpandedExpression(AssertionResult& result) {
+        result.getExpandedExpression();
+    }
+
+    // Because formatting using c++ streams is stateful, drop down to C is required
+    // Alternatively we could use stringstream, but its performance is... not good.
+    std::string getFormattedDuration( double duration ) {
+        // Max exponent + 1 is required to represent the whole part
+        // + 1 for decimal point
+        // + 3 for the 3 decimal places
+        // + 1 for null terminator
+        const std::size_t maxDoubleSize = DBL_MAX_10_EXP + 1 + 1 + 3 + 1;
+        char buffer[maxDoubleSize];
+
+        // Save previous errno, to prevent sprintf from overwriting it
+        ErrnoGuard guard;
+#ifdef _MSC_VER
+        sprintf_s(buffer, "%.3f", duration);
+#else
+        sprintf(buffer, "%.3f", duration);
+#endif
+        return std::string(buffer);
+    }
+
+    TestEventListenerBase::TestEventListenerBase(ReporterConfig const & _config)
+        :StreamingReporterBase(_config) {}
+
+    void TestEventListenerBase::assertionStarting(AssertionInfo const &) {}
+
+    bool TestEventListenerBase::assertionEnded(AssertionStats const &) {
+        return false;
+    }
+
+} // end namespace Catch
+// end catch_reporter_bases.cpp
+// start catch_reporter_compact.cpp
+
+namespace {
+
+#ifdef CATCH_PLATFORM_MAC
+    const char* failedString() { return "FAILED"; }
+    const char* passedString() { return "PASSED"; }
+#else
+    const char* failedString() { return "failed"; }
+    const char* passedString() { return "passed"; }
+#endif
+
+    // Colour::LightGrey
+    Catch::Colour::Code dimColour() { return Catch::Colour::FileName; }
+
+    std::string bothOrAll( std::size_t count ) {
+        return count == 1 ? std::string() :
+               count == 2 ? "both " : "all " ;
+    }
+
+} // anon namespace
+
+namespace Catch {
+namespace {
+// Colour, message variants:
+// - white: No tests ran.
+// -   red: Failed [both/all] N test cases, failed [both/all] M assertions.
+// - white: Passed [both/all] N test cases (no assertions).
+// -   red: Failed N tests cases, failed M assertions.
+// - green: Passed [both/all] N tests cases with M assertions.
+void printTotals(std::ostream& out, const Totals& totals) {
+    if (totals.testCases.total() == 0) {
+        out << "No tests ran.";
+    } else if (totals.testCases.failed == totals.testCases.total()) {
+        Colour colour(Colour::ResultError);
+        const std::string qualify_assertions_failed =
+            totals.assertions.failed == totals.assertions.total() ?
+            bothOrAll(totals.assertions.failed) : std::string();
+        out <<
+            "Failed " << bothOrAll(totals.testCases.failed)
+            << pluralise(totals.testCases.failed, "test case") << ", "
+            "failed " << qualify_assertions_failed <<
+            pluralise(totals.assertions.failed, "assertion") << '.';
+    } else if (totals.assertions.total() == 0) {
+        out <<
+            "Passed " << bothOrAll(totals.testCases.total())
+            << pluralise(totals.testCases.total(), "test case")
+            << " (no assertions).";
+    } else if (totals.assertions.failed) {
+        Colour colour(Colour::ResultError);
+        out <<
+            "Failed " << pluralise(totals.testCases.failed, "test case") << ", "
+            "failed " << pluralise(totals.assertions.failed, "assertion") << '.';
+    } else {
+        Colour colour(Colour::ResultSuccess);
+        out <<
+            "Passed " << bothOrAll(totals.testCases.passed)
+            << pluralise(totals.testCases.passed, "test case") <<
+            " with " << pluralise(totals.assertions.passed, "assertion") << '.';
+    }
+}
+
+// Implementation of CompactReporter formatting
+class AssertionPrinter {
+public:
+    AssertionPrinter& operator= (AssertionPrinter const&) = delete;
+    AssertionPrinter(AssertionPrinter const&) = delete;
+    AssertionPrinter(std::ostream& _stream, AssertionStats const& _stats, bool _printInfoMessages)
+        : stream(_stream)
+        , result(_stats.assertionResult)
+        , messages(_stats.infoMessages)
+        , itMessage(_stats.infoMessages.begin())
+        , printInfoMessages(_printInfoMessages) {}
+
+    void print() {
+        printSourceInfo();
+
+        itMessage = messages.begin();
+
+        switch (result.getResultType()) {
+        case ResultWas::Ok:
+            printResultType(Colour::ResultSuccess, passedString());
+            printOriginalExpression();
+            printReconstructedExpression();
+            if (!result.hasExpression())
+                printRemainingMessages(Colour::None);
+            else
+                printRemainingMessages();
+            break;
+        case ResultWas::ExpressionFailed:
+            if (result.isOk())
+                printResultType(Colour::ResultSuccess, failedString() + std::string(" - but was ok"));
+            else
+                printResultType(Colour::Error, failedString());
+            printOriginalExpression();
+            printReconstructedExpression();
+            printRemainingMessages();
+            break;
+        case ResultWas::ThrewException:
+            printResultType(Colour::Error, failedString());
+            printIssue("unexpected exception with message:");
+            printMessage();
+            printExpressionWas();
+            printRemainingMessages();
+            break;
+        case ResultWas::FatalErrorCondition:
+            printResultType(Colour::Error, failedString());
+            printIssue("fatal error condition with message:");
+            printMessage();
+            printExpressionWas();
+            printRemainingMessages();
+            break;
+        case ResultWas::DidntThrowException:
+            printResultType(Colour::Error, failedString());
+            printIssue("expected exception, got none");
+            printExpressionWas();
+            printRemainingMessages();
+            break;
+        case ResultWas::Info:
+            printResultType(Colour::None, "info");
+            printMessage();
+            printRemainingMessages();
+            break;
+        case ResultWas::Warning:
+            printResultType(Colour::None, "warning");
+            printMessage();
+            printRemainingMessages();
+            break;
+        case ResultWas::ExplicitFailure:
+            printResultType(Colour::Error, failedString());
+            printIssue("explicitly");
+            printRemainingMessages(Colour::None);
+            break;
+            // These cases are here to prevent compiler warnings
+        case ResultWas::Unknown:
+        case ResultWas::FailureBit:
+        case ResultWas::Exception:
+            printResultType(Colour::Error, "** internal error **");
+            break;
+        }
+    }
+
+private:
+    void printSourceInfo() const {
+        Colour colourGuard(Colour::FileName);
+        stream << result.getSourceInfo() << ':';
+    }
+
+    void printResultType(Colour::Code colour, std::string const& passOrFail) const {
+        if (!passOrFail.empty()) {
+            {
+                Colour colourGuard(colour);
+                stream << ' ' << passOrFail;
+            }
+            stream << ':';
+        }
+    }
+
+    void printIssue(std::string const& issue) const {
+        stream << ' ' << issue;
+    }
+
+    void printExpressionWas() {
+        if (result.hasExpression()) {
+            stream << ';';
+            {
+                Colour colour(dimColour());
+                stream << " expression was:";
+            }
+            printOriginalExpression();
+        }
+    }
+
+    void printOriginalExpression() const {
+        if (result.hasExpression()) {
+            stream << ' ' << result.getExpression();
+        }
+    }
+
+    void printReconstructedExpression() const {
+        if (result.hasExpandedExpression()) {
+            {
+                Colour colour(dimColour());
+                stream << " for: ";
+            }
+            stream << result.getExpandedExpression();
+        }
+    }
+
+    void printMessage() {
+        if (itMessage != messages.end()) {
+            stream << " '" << itMessage->message << '\'';
+            ++itMessage;
+        }
+    }
+
+    void printRemainingMessages(Colour::Code colour = dimColour()) {
+        if (itMessage == messages.end())
+            return;
+
+        // using messages.end() directly yields (or auto) compilation error:
+        std::vector<MessageInfo>::const_iterator itEnd = messages.end();
+        const std::size_t N = static_cast<std::size_t>(std::distance(itMessage, itEnd));
+
+        {
+            Colour colourGuard(colour);
+            stream << " with " << pluralise(N, "message") << ':';
+        }
+
+        for (; itMessage != itEnd; ) {
+            // If this assertion is a warning ignore any INFO messages
+            if (printInfoMessages || itMessage->type != ResultWas::Info) {
+                stream << " '" << itMessage->message << '\'';
+                if (++itMessage != itEnd) {
+                    Colour colourGuard(dimColour());
+                    stream << " and";
+                }
+            }
+        }
+    }
+
+private:
+    std::ostream& stream;
+    AssertionResult const& result;
+    std::vector<MessageInfo> messages;
+    std::vector<MessageInfo>::const_iterator itMessage;
+    bool printInfoMessages;
+};
+
+} // anon namespace
+
+        std::string CompactReporter::getDescription() {
+            return "Reports test results on a single line, suitable for IDEs";
+        }
+
+        ReporterPreferences CompactReporter::getPreferences() const {
+            ReporterPreferences prefs;
+            prefs.shouldRedirectStdOut = false;
+            return prefs;
+        }
+
+        void CompactReporter::noMatchingTestCases( std::string const& spec ) {
+            stream << "No test cases matched '" << spec << '\'' << std::endl;
+        }
+
+        void CompactReporter::assertionStarting( AssertionInfo const& ) {}
+
+        bool CompactReporter::assertionEnded( AssertionStats const& _assertionStats ) {
+            AssertionResult const& result = _assertionStats.assertionResult;
+
+            bool printInfoMessages = true;
+
+            // Drop out if result was successful and we're not printing those
+            if( !m_config->includeSuccessfulResults() && result.isOk() ) {
+                if( result.getResultType() != ResultWas::Warning )
+                    return false;
+                printInfoMessages = false;
+            }
+
+            AssertionPrinter printer( stream, _assertionStats, printInfoMessages );
+            printer.print();
+
+            stream << std::endl;
+            return true;
+        }
+
+        void CompactReporter::sectionEnded(SectionStats const& _sectionStats) {
+            if (m_config->showDurations() == ShowDurations::Always) {
+                stream << getFormattedDuration(_sectionStats.durationInSeconds) << " s: " << _sectionStats.sectionInfo.name << std::endl;
+            }
+        }
+
+        void CompactReporter::testRunEnded( TestRunStats const& _testRunStats ) {
+            printTotals( stream, _testRunStats.totals );
+            stream << '\n' << std::endl;
+            StreamingReporterBase::testRunEnded( _testRunStats );
+        }
+
+        CompactReporter::~CompactReporter() {}
+
+    CATCH_REGISTER_REPORTER( "compact", CompactReporter )
+
+} // end namespace Catch
+// end catch_reporter_compact.cpp
+// start catch_reporter_console.cpp
+
+#include <cfloat>
+#include <cstdio>
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4061) // Not all labels are EXPLICITLY handled in switch
+ // Note that 4062 (not all labels are handled
+ // and default is missing) is enabled
+#endif
+
+namespace Catch {
+
+namespace {
+
+// Formatter impl for ConsoleReporter
+class ConsoleAssertionPrinter {
+public:
+    ConsoleAssertionPrinter& operator= (ConsoleAssertionPrinter const&) = delete;
+    ConsoleAssertionPrinter(ConsoleAssertionPrinter const&) = delete;
+    ConsoleAssertionPrinter(std::ostream& _stream, AssertionStats const& _stats, bool _printInfoMessages)
+        : stream(_stream),
+        stats(_stats),
+        result(_stats.assertionResult),
+        colour(Colour::None),
+        message(result.getMessage()),
+        messages(_stats.infoMessages),
+        printInfoMessages(_printInfoMessages) {
+        switch (result.getResultType()) {
+        case ResultWas::Ok:
+            colour = Colour::Success;
+            passOrFail = "PASSED";
+            //if( result.hasMessage() )
+            if (_stats.infoMessages.size() == 1)
+                messageLabel = "with message";
+            if (_stats.infoMessages.size() > 1)
+                messageLabel = "with messages";
+            break;
+        case ResultWas::ExpressionFailed:
+            if (result.isOk()) {
+                colour = Colour::Success;
+                passOrFail = "FAILED - but was ok";
+            } else {
+                colour = Colour::Error;
+                passOrFail = "FAILED";
+            }
+            if (_stats.infoMessages.size() == 1)
+                messageLabel = "with message";
+            if (_stats.infoMessages.size() > 1)
+                messageLabel = "with messages";
+            break;
+        case ResultWas::ThrewException:
+            colour = Colour::Error;
+            passOrFail = "FAILED";
+            messageLabel = "due to unexpected exception with ";
+            if (_stats.infoMessages.size() == 1)
+                messageLabel += "message";
+            if (_stats.infoMessages.size() > 1)
+                messageLabel += "messages";
+            break;
+        case ResultWas::FatalErrorCondition:
+            colour = Colour::Error;
+            passOrFail = "FAILED";
+            messageLabel = "due to a fatal error condition";
+            break;
+        case ResultWas::DidntThrowException:
+            colour = Colour::Error;
+            passOrFail = "FAILED";
+            messageLabel = "because no exception was thrown where one was expected";
+            break;
+        case ResultWas::Info:
+            messageLabel = "info";
+            break;
+        case ResultWas::Warning:
+            messageLabel = "warning";
+            break;
+        case ResultWas::ExplicitFailure:
+            passOrFail = "FAILED";
+            colour = Colour::Error;
+            if (_stats.infoMessages.size() == 1)
+                messageLabel = "explicitly with message";
+            if (_stats.infoMessages.size() > 1)
+                messageLabel = "explicitly with messages";
+            break;
+            // These cases are here to prevent compiler warnings
+        case ResultWas::Unknown:
+        case ResultWas::FailureBit:
+        case ResultWas::Exception:
+            passOrFail = "** internal error **";
+            colour = Colour::Error;
+            break;
+        }
+    }
+
+    void print() const {
+        printSourceInfo();
+        if (stats.totals.assertions.total() > 0) {
+            if (result.isOk())
+                stream << '\n';
+            printResultType();
+            printOriginalExpression();
+            printReconstructedExpression();
+        } else {
+            stream << '\n';
+        }
+        printMessage();
+    }
+
+private:
+    void printResultType() const {
+        if (!passOrFail.empty()) {
+            Colour colourGuard(colour);
+            stream << passOrFail << ":\n";
+        }
+    }
+    void printOriginalExpression() const {
+        if (result.hasExpression()) {
+            Colour colourGuard(Colour::OriginalExpression);
+            stream << "  ";
+            stream << result.getExpressionInMacro();
+            stream << '\n';
+        }
+    }
+    void printReconstructedExpression() const {
+        if (result.hasExpandedExpression()) {
+            stream << "with expansion:\n";
+            Colour colourGuard(Colour::ReconstructedExpression);
+            stream << Column(result.getExpandedExpression()).indent(2) << '\n';
+        }
+    }
+    void printMessage() const {
+        if (!messageLabel.empty())
+            stream << messageLabel << ':' << '\n';
+        for (auto const& msg : messages) {
+            // If this assertion is a warning ignore any INFO messages
+            if (printInfoMessages || msg.type != ResultWas::Info)
+                stream << Column(msg.message).indent(2) << '\n';
+        }
+    }
+    void printSourceInfo() const {
+        Colour colourGuard(Colour::FileName);
+        stream << result.getSourceInfo() << ": ";
+    }
+
+    std::ostream& stream;
+    AssertionStats const& stats;
+    AssertionResult const& result;
+    Colour::Code colour;
+    std::string passOrFail;
+    std::string messageLabel;
+    std::string message;
+    std::vector<MessageInfo> messages;
+    bool printInfoMessages;
+};
+
+std::size_t makeRatio(std::size_t number, std::size_t total) {
+    std::size_t ratio = total > 0 ? CATCH_CONFIG_CONSOLE_WIDTH * number / total : 0;
+    return (ratio == 0 && number > 0) ? 1 : ratio;
+}
+
+std::size_t& findMax(std::size_t& i, std::size_t& j, std::size_t& k) {
+    if (i > j && i > k)
+        return i;
+    else if (j > k)
+        return j;
+    else
+        return k;
+}
+
+struct ColumnInfo {
+    enum Justification { Left, Right };
+    std::string name;
+    int width;
+    Justification justification;
+};
+struct ColumnBreak {};
+struct RowBreak {};
+
+class Duration {
+    enum class Unit {
+        Auto,
+        Nanoseconds,
+        Microseconds,
+        Milliseconds,
+        Seconds,
+        Minutes
+    };
+    static const uint64_t s_nanosecondsInAMicrosecond = 1000;
+    static const uint64_t s_nanosecondsInAMillisecond = 1000 * s_nanosecondsInAMicrosecond;
+    static const uint64_t s_nanosecondsInASecond = 1000 * s_nanosecondsInAMillisecond;
+    static const uint64_t s_nanosecondsInAMinute = 60 * s_nanosecondsInASecond;
+
+    uint64_t m_inNanoseconds;
+    Unit m_units;
+
+public:
+    explicit Duration(uint64_t inNanoseconds, Unit units = Unit::Auto)
+        : m_inNanoseconds(inNanoseconds),
+        m_units(units) {
+        if (m_units == Unit::Auto) {
+            if (m_inNanoseconds < s_nanosecondsInAMicrosecond)
+                m_units = Unit::Nanoseconds;
+            else if (m_inNanoseconds < s_nanosecondsInAMillisecond)
+                m_units = Unit::Microseconds;
+            else if (m_inNanoseconds < s_nanosecondsInASecond)
+                m_units = Unit::Milliseconds;
+            else if (m_inNanoseconds < s_nanosecondsInAMinute)
+                m_units = Unit::Seconds;
+            else
+                m_units = Unit::Minutes;
+        }
+
+    }
+
+    auto value() const -> double {
+        switch (m_units) {
+        case Unit::Microseconds:
+            return m_inNanoseconds / static_cast<double>(s_nanosecondsInAMicrosecond);
+        case Unit::Milliseconds:
+            return m_inNanoseconds / static_cast<double>(s_nanosecondsInAMillisecond);
+        case Unit::Seconds:
+            return m_inNanoseconds / static_cast<double>(s_nanosecondsInASecond);
+        case Unit::Minutes:
+            return m_inNanoseconds / static_cast<double>(s_nanosecondsInAMinute);
+        default:
+            return static_cast<double>(m_inNanoseconds);
+        }
+    }
+    auto unitsAsString() const -> std::string {
+        switch (m_units) {
+        case Unit::Nanoseconds:
+            return "ns";
+        case Unit::Microseconds:
+            return "µs";
+        case Unit::Milliseconds:
+            return "ms";
+        case Unit::Seconds:
+            return "s";
+        case Unit::Minutes:
+            return "m";
+        default:
+            return "** internal error **";
+        }
+
+    }
+    friend auto operator << (std::ostream& os, Duration const& duration) -> std::ostream& {
+        return os << duration.value() << " " << duration.unitsAsString();
+    }
+};
+} // end anon namespace
+
+class TablePrinter {
+    std::ostream& m_os;
+    std::vector<ColumnInfo> m_columnInfos;
+    std::ostringstream m_oss;
+    int m_currentColumn = -1;
+    bool m_isOpen = false;
+
+public:
+    TablePrinter( std::ostream& os, std::vector<ColumnInfo> columnInfos )
+    :   m_os( os ),
+        m_columnInfos( std::move( columnInfos ) ) {}
+
+    auto columnInfos() const -> std::vector<ColumnInfo> const& {
+        return m_columnInfos;
+    }
+
+    void open() {
+        if (!m_isOpen) {
+            m_isOpen = true;
+            *this << RowBreak();
+            for (auto const& info : m_columnInfos)
+                *this << info.name << ColumnBreak();
+            *this << RowBreak();
+            m_os << Catch::getLineOfChars<'-'>() << "\n";
+        }
+    }
+    void close() {
+        if (m_isOpen) {
+            *this << RowBreak();
+            m_os << std::endl;
+            m_isOpen = false;
+        }
+    }
+
+    template<typename T>
+    friend TablePrinter& operator << (TablePrinter& tp, T const& value) {
+        tp.m_oss << value;
+        return tp;
+    }
+
+    friend TablePrinter& operator << (TablePrinter& tp, ColumnBreak) {
+        auto colStr = tp.m_oss.str();
+        // This takes account of utf8 encodings
+        auto strSize = Catch::StringRef(colStr).numberOfCharacters();
+        tp.m_oss.str("");
+        tp.open();
+        if (tp.m_currentColumn == static_cast<int>(tp.m_columnInfos.size() - 1)) {
+            tp.m_currentColumn = -1;
+            tp.m_os << "\n";
+        }
+        tp.m_currentColumn++;
+
+        auto colInfo = tp.m_columnInfos[tp.m_currentColumn];
+        auto padding = (strSize + 2 < static_cast<std::size_t>(colInfo.width))
+            ? std::string(colInfo.width - (strSize + 2), ' ')
+            : std::string();
+        if (colInfo.justification == ColumnInfo::Left)
+            tp.m_os << colStr << padding << " ";
+        else
+            tp.m_os << padding << colStr << " ";
+        return tp;
+    }
+
+    friend TablePrinter& operator << (TablePrinter& tp, RowBreak) {
+        if (tp.m_currentColumn > 0) {
+            tp.m_os << "\n";
+            tp.m_currentColumn = -1;
+        }
+        return tp;
+    }
+};
+
+ConsoleReporter::ConsoleReporter(ReporterConfig const& config)
+    : StreamingReporterBase(config),
+    m_tablePrinter(new TablePrinter(config.stream(),
+    {
+        { "benchmark name", CATCH_CONFIG_CONSOLE_WIDTH - 32, ColumnInfo::Left },
+        { "iters", 8, ColumnInfo::Right },
+        { "elapsed ns", 14, ColumnInfo::Right },
+        { "average", 14, ColumnInfo::Right }
+    })) {}
+ConsoleReporter::~ConsoleReporter() = default;
+
+std::string ConsoleReporter::getDescription() {
+    return "Reports test results as plain lines of text";
+}
+
+void ConsoleReporter::noMatchingTestCases(std::string const& spec) {
+    stream << "No test cases matched '" << spec << '\'' << std::endl;
+}
+
+void ConsoleReporter::assertionStarting(AssertionInfo const&) {}
+
+bool ConsoleReporter::assertionEnded(AssertionStats const& _assertionStats) {
+    AssertionResult const& result = _assertionStats.assertionResult;
+
+    bool includeResults = m_config->includeSuccessfulResults() || !result.isOk();
+
+    // Drop out if result was successful but we're not printing them.
+    if (!includeResults && result.getResultType() != ResultWas::Warning)
+        return false;
+
+    lazyPrint();
+
+    ConsoleAssertionPrinter printer(stream, _assertionStats, includeResults);
+    printer.print();
+    stream << std::endl;
+    return true;
+}
+
+void ConsoleReporter::sectionStarting(SectionInfo const& _sectionInfo) {
+    m_headerPrinted = false;
+    StreamingReporterBase::sectionStarting(_sectionInfo);
+}
+void ConsoleReporter::sectionEnded(SectionStats const& _sectionStats) {
+    m_tablePrinter->close();
+    if (_sectionStats.missingAssertions) {
+        lazyPrint();
+        Colour colour(Colour::ResultError);
+        if (m_sectionStack.size() > 1)
+            stream << "\nNo assertions in section";
+        else
+            stream << "\nNo assertions in test case";
+        stream << " '" << _sectionStats.sectionInfo.name << "'\n" << std::endl;
+    }
+    if (m_config->showDurations() == ShowDurations::Always) {
+        stream << getFormattedDuration(_sectionStats.durationInSeconds) << " s: " << _sectionStats.sectionInfo.name << std::endl;
+    }
+    if (m_headerPrinted) {
+        m_headerPrinted = false;
+    }
+    StreamingReporterBase::sectionEnded(_sectionStats);
+}
+
+void ConsoleReporter::benchmarkStarting(BenchmarkInfo const& info) {
+    lazyPrintWithoutClosingBenchmarkTable();
+
+    auto nameCol = Column( info.name ).width( static_cast<std::size_t>( m_tablePrinter->columnInfos()[0].width - 2 ) );
+
+    bool firstLine = true;
+    for (auto line : nameCol) {
+        if (!firstLine)
+            (*m_tablePrinter) << ColumnBreak() << ColumnBreak() << ColumnBreak();
+        else
+            firstLine = false;
+
+        (*m_tablePrinter) << line << ColumnBreak();
+    }
+}
+void ConsoleReporter::benchmarkEnded(BenchmarkStats const& stats) {
+    Duration average(stats.elapsedTimeInNanoseconds / stats.iterations);
+    (*m_tablePrinter)
+        << stats.iterations << ColumnBreak()
+        << stats.elapsedTimeInNanoseconds << ColumnBreak()
+        << average << ColumnBreak();
+}
+
+void ConsoleReporter::testCaseEnded(TestCaseStats const& _testCaseStats) {
+    m_tablePrinter->close();
+    StreamingReporterBase::testCaseEnded(_testCaseStats);
+    m_headerPrinted = false;
+}
+void ConsoleReporter::testGroupEnded(TestGroupStats const& _testGroupStats) {
+    if (currentGroupInfo.used) {
+        printSummaryDivider();
+        stream << "Summary for group '" << _testGroupStats.groupInfo.name << "':\n";
+        printTotals(_testGroupStats.totals);
+        stream << '\n' << std::endl;
+    }
+    StreamingReporterBase::testGroupEnded(_testGroupStats);
+}
+void ConsoleReporter::testRunEnded(TestRunStats const& _testRunStats) {
+    printTotalsDivider(_testRunStats.totals);
+    printTotals(_testRunStats.totals);
+    stream << std::endl;
+    StreamingReporterBase::testRunEnded(_testRunStats);
+}
+
+void ConsoleReporter::lazyPrint() {
+
+    m_tablePrinter->close();
+    lazyPrintWithoutClosingBenchmarkTable();
+}
+
+void ConsoleReporter::lazyPrintWithoutClosingBenchmarkTable() {
+
+    if (!currentTestRunInfo.used)
+        lazyPrintRunInfo();
+    if (!currentGroupInfo.used)
+        lazyPrintGroupInfo();
+
+    if (!m_headerPrinted) {
+        printTestCaseAndSectionHeader();
+        m_headerPrinted = true;
+    }
+}
+void ConsoleReporter::lazyPrintRunInfo() {
+    stream << '\n' << getLineOfChars<'~'>() << '\n';
+    Colour colour(Colour::SecondaryText);
+    stream << currentTestRunInfo->name
+        << " is a Catch v" << libraryVersion() << " host application.\n"
+        << "Run with -? for options\n\n";
+
+    if (m_config->rngSeed() != 0)
+        stream << "Randomness seeded to: " << m_config->rngSeed() << "\n\n";
+
+    currentTestRunInfo.used = true;
+}
+void ConsoleReporter::lazyPrintGroupInfo() {
+    if (!currentGroupInfo->name.empty() && currentGroupInfo->groupsCounts > 1) {
+        printClosedHeader("Group: " + currentGroupInfo->name);
+        currentGroupInfo.used = true;
+    }
+}
+void ConsoleReporter::printTestCaseAndSectionHeader() {
+    assert(!m_sectionStack.empty());
+    printOpenHeader(currentTestCaseInfo->name);
+
+    if (m_sectionStack.size() > 1) {
+        Colour colourGuard(Colour::Headers);
+
+        auto
+            it = m_sectionStack.begin() + 1, // Skip first section (test case)
+            itEnd = m_sectionStack.end();
+        for (; it != itEnd; ++it)
+            printHeaderString(it->name, 2);
+    }
+
+    SourceLineInfo lineInfo = m_sectionStack.back().lineInfo;
+
+    if (!lineInfo.empty()) {
+        stream << getLineOfChars<'-'>() << '\n';
+        Colour colourGuard(Colour::FileName);
+        stream << lineInfo << '\n';
+    }
+    stream << getLineOfChars<'.'>() << '\n' << std::endl;
+}
+
+void ConsoleReporter::printClosedHeader(std::string const& _name) {
+    printOpenHeader(_name);
+    stream << getLineOfChars<'.'>() << '\n';
+}
+void ConsoleReporter::printOpenHeader(std::string const& _name) {
+    stream << getLineOfChars<'-'>() << '\n';
+    {
+        Colour colourGuard(Colour::Headers);
+        printHeaderString(_name);
+    }
+}
+
+// if string has a : in first line will set indent to follow it on
+// subsequent lines
+void ConsoleReporter::printHeaderString(std::string const& _string, std::size_t indent) {
+    std::size_t i = _string.find(": ");
+    if (i != std::string::npos)
+        i += 2;
+    else
+        i = 0;
+    stream << Column(_string).indent(indent + i).initialIndent(indent) << '\n';
+}
+
+struct SummaryColumn {
+
+    SummaryColumn( std::string _label, Colour::Code _colour )
+    :   label( std::move( _label ) ),
+        colour( _colour ) {}
+    SummaryColumn addRow( std::size_t count ) {
+        ReusableStringStream rss;
+        rss << count;
+        std::string row = rss.str();
+        for (auto& oldRow : rows) {
+            while (oldRow.size() < row.size())
+                oldRow = ' ' + oldRow;
+            while (oldRow.size() > row.size())
+                row = ' ' + row;
+        }
+        rows.push_back(row);
+        return *this;
+    }
+
+    std::string label;
+    Colour::Code colour;
+    std::vector<std::string> rows;
+
+};
+
+void ConsoleReporter::printTotals( Totals const& totals ) {
+    if (totals.testCases.total() == 0) {
+        stream << Colour(Colour::Warning) << "No tests ran\n";
+    } else if (totals.assertions.total() > 0 && totals.testCases.allPassed()) {
+        stream << Colour(Colour::ResultSuccess) << "All tests passed";
+        stream << " ("
+            << pluralise(totals.assertions.passed, "assertion") << " in "
+            << pluralise(totals.testCases.passed, "test case") << ')'
+            << '\n';
+    } else {
+
+        std::vector<SummaryColumn> columns;
+        columns.push_back(SummaryColumn("", Colour::None)
+                          .addRow(totals.testCases.total())
+                          .addRow(totals.assertions.total()));
+        columns.push_back(SummaryColumn("passed", Colour::Success)
+                          .addRow(totals.testCases.passed)
+                          .addRow(totals.assertions.passed));
+        columns.push_back(SummaryColumn("failed", Colour::ResultError)
+                          .addRow(totals.testCases.failed)
+                          .addRow(totals.assertions.failed));
+        columns.push_back(SummaryColumn("failed as expected", Colour::ResultExpectedFailure)
+                          .addRow(totals.testCases.failedButOk)
+                          .addRow(totals.assertions.failedButOk));
+
+        printSummaryRow("test cases", columns, 0);
+        printSummaryRow("assertions", columns, 1);
+    }
+}
+void ConsoleReporter::printSummaryRow(std::string const& label, std::vector<SummaryColumn> const& cols, std::size_t row) {
+    for (auto col : cols) {
+        std::string value = col.rows[row];
+        if (col.label.empty()) {
+            stream << label << ": ";
+            if (value != "0")
+                stream << value;
+            else
+                stream << Colour(Colour::Warning) << "- none -";
+        } else if (value != "0") {
+            stream << Colour(Colour::LightGrey) << " | ";
+            stream << Colour(col.colour)
+                << value << ' ' << col.label;
+        }
+    }
+    stream << '\n';
+}
+
+void ConsoleReporter::printTotalsDivider(Totals const& totals) {
+    if (totals.testCases.total() > 0) {
+        std::size_t failedRatio = makeRatio(totals.testCases.failed, totals.testCases.total());
+        std::size_t failedButOkRatio = makeRatio(totals.testCases.failedButOk, totals.testCases.total());
+        std::size_t passedRatio = makeRatio(totals.testCases.passed, totals.testCases.total());
+        while (failedRatio + failedButOkRatio + passedRatio < CATCH_CONFIG_CONSOLE_WIDTH - 1)
+            findMax(failedRatio, failedButOkRatio, passedRatio)++;
+        while (failedRatio + failedButOkRatio + passedRatio > CATCH_CONFIG_CONSOLE_WIDTH - 1)
+            findMax(failedRatio, failedButOkRatio, passedRatio)--;
+
+        stream << Colour(Colour::Error) << std::string(failedRatio, '=');
+        stream << Colour(Colour::ResultExpectedFailure) << std::string(failedButOkRatio, '=');
+        if (totals.testCases.allPassed())
+            stream << Colour(Colour::ResultSuccess) << std::string(passedRatio, '=');
+        else
+            stream << Colour(Colour::Success) << std::string(passedRatio, '=');
+    } else {
+        stream << Colour(Colour::Warning) << std::string(CATCH_CONFIG_CONSOLE_WIDTH - 1, '=');
+    }
+    stream << '\n';
+}
+void ConsoleReporter::printSummaryDivider() {
+    stream << getLineOfChars<'-'>() << '\n';
+}
+
+CATCH_REGISTER_REPORTER("console", ConsoleReporter)
+
+} // end namespace Catch
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+// end catch_reporter_console.cpp
+// start catch_reporter_junit.cpp
+
+#include <assert.h>
+#include <sstream>
+#include <ctime>
+#include <algorithm>
+
+namespace Catch {
+
+    namespace {
+        std::string getCurrentTimestamp() {
+            // Beware, this is not reentrant because of backward compatibility issues
+            // Also, UTC only, again because of backward compatibility (%z is C++11)
+            time_t rawtime;
+            std::time(&rawtime);
+            auto const timeStampSize = sizeof("2017-01-16T17:06:45Z");
+
+#ifdef _MSC_VER
+            std::tm timeInfo = {};
+            gmtime_s(&timeInfo, &rawtime);
+#else
+            std::tm* timeInfo;
+            timeInfo = std::gmtime(&rawtime);
+#endif
+
+            char timeStamp[timeStampSize];
+            const char * const fmt = "%Y-%m-%dT%H:%M:%SZ";
+
+#ifdef _MSC_VER
+            std::strftime(timeStamp, timeStampSize, fmt, &timeInfo);
+#else
+            std::strftime(timeStamp, timeStampSize, fmt, timeInfo);
+#endif
+            return std::string(timeStamp);
+        }
+
+        std::string fileNameTag(const std::vector<std::string> &tags) {
+            auto it = std::find_if(begin(tags),
+                                   end(tags),
+                                   [] (std::string const& tag) {return tag.front() == '#'; });
+            if (it != tags.end())
+                return it->substr(1);
+            return std::string();
+        }
+    } // anonymous namespace
+
+    JunitReporter::JunitReporter( ReporterConfig const& _config )
+        :   CumulativeReporterBase( _config ),
+            xml( _config.stream() )
+        {
+            m_reporterPrefs.shouldRedirectStdOut = true;
+        }
+
+    JunitReporter::~JunitReporter() {}
+
+    std::string JunitReporter::getDescription() {
+        return "Reports test results in an XML format that looks like Ant's junitreport target";
+    }
+
+    void JunitReporter::noMatchingTestCases( std::string const& /*spec*/ ) {}
+
+    void JunitReporter::testRunStarting( TestRunInfo const& runInfo )  {
+        CumulativeReporterBase::testRunStarting( runInfo );
+        xml.startElement( "testsuites" );
+    }
+
+    void JunitReporter::testGroupStarting( GroupInfo const& groupInfo ) {
+        suiteTimer.start();
+        stdOutForSuite.clear();
+        stdErrForSuite.clear();
+        unexpectedExceptions = 0;
+        CumulativeReporterBase::testGroupStarting( groupInfo );
+    }
+
+    void JunitReporter::testCaseStarting( TestCaseInfo const& testCaseInfo ) {
+        m_okToFail = testCaseInfo.okToFail();
+    }
+
+    bool JunitReporter::assertionEnded( AssertionStats const& assertionStats ) {
+        if( assertionStats.assertionResult.getResultType() == ResultWas::ThrewException && !m_okToFail )
+            unexpectedExceptions++;
+        return CumulativeReporterBase::assertionEnded( assertionStats );
+    }
+
+    void JunitReporter::testCaseEnded( TestCaseStats const& testCaseStats ) {
+        stdOutForSuite += testCaseStats.stdOut;
+        stdErrForSuite += testCaseStats.stdErr;
+        CumulativeReporterBase::testCaseEnded( testCaseStats );
+    }
+
+    void JunitReporter::testGroupEnded( TestGroupStats const& testGroupStats ) {
+        double suiteTime = suiteTimer.getElapsedSeconds();
+        CumulativeReporterBase::testGroupEnded( testGroupStats );
+        writeGroup( *m_testGroups.back(), suiteTime );
+    }
+
+    void JunitReporter::testRunEndedCumulative() {
+        xml.endElement();
+    }
+
+    void JunitReporter::writeGroup( TestGroupNode const& groupNode, double suiteTime ) {
+        XmlWriter::ScopedElement e = xml.scopedElement( "testsuite" );
+        TestGroupStats const& stats = groupNode.value;
+        xml.writeAttribute( "name", stats.groupInfo.name );
+        xml.writeAttribute( "errors", unexpectedExceptions );
+        xml.writeAttribute( "failures", stats.totals.assertions.failed-unexpectedExceptions );
+        xml.writeAttribute( "tests", stats.totals.assertions.total() );
+        xml.writeAttribute( "hostname", "tbd" ); // !TBD
+        if( m_config->showDurations() == ShowDurations::Never )
+            xml.writeAttribute( "time", "" );
+        else
+            xml.writeAttribute( "time", suiteTime );
+        xml.writeAttribute( "timestamp", getCurrentTimestamp() );
+
+        // Write test cases
+        for( auto const& child : groupNode.children )
+            writeTestCase( *child );
+
+        xml.scopedElement( "system-out" ).writeText( trim( stdOutForSuite ), false );
+        xml.scopedElement( "system-err" ).writeText( trim( stdErrForSuite ), false );
+    }
+
+    void JunitReporter::writeTestCase( TestCaseNode const& testCaseNode ) {
+        TestCaseStats const& stats = testCaseNode.value;
+
+        // All test cases have exactly one section - which represents the
+        // test case itself. That section may have 0-n nested sections
+        assert( testCaseNode.children.size() == 1 );
+        SectionNode const& rootSection = *testCaseNode.children.front();
+
+        std::string className = stats.testInfo.className;
+
+        if( className.empty() ) {
+            className = fileNameTag(stats.testInfo.tags);
+            if ( className.empty() )
+                className = "global";
+        }
+
+        if ( !m_config->name().empty() )
+            className = m_config->name() + "." + className;
+
+        writeSection( className, "", rootSection );
+    }
+
+    void JunitReporter::writeSection(  std::string const& className,
+                        std::string const& rootName,
+                        SectionNode const& sectionNode ) {
+        std::string name = trim( sectionNode.stats.sectionInfo.name );
+        if( !rootName.empty() )
+            name = rootName + '/' + name;
+
+        if( !sectionNode.assertions.empty() ||
+            !sectionNode.stdOut.empty() ||
+            !sectionNode.stdErr.empty() ) {
+            XmlWriter::ScopedElement e = xml.scopedElement( "testcase" );
+            if( className.empty() ) {
+                xml.writeAttribute( "classname", name );
+                xml.writeAttribute( "name", "root" );
+            }
+            else {
+                xml.writeAttribute( "classname", className );
+                xml.writeAttribute( "name", name );
+            }
+            xml.writeAttribute( "time", ::Catch::Detail::stringify( sectionNode.stats.durationInSeconds ) );
+
+            writeAssertions( sectionNode );
+
+            if( !sectionNode.stdOut.empty() )
+                xml.scopedElement( "system-out" ).writeText( trim( sectionNode.stdOut ), false );
+            if( !sectionNode.stdErr.empty() )
+                xml.scopedElement( "system-err" ).writeText( trim( sectionNode.stdErr ), false );
+        }
+        for( auto const& childNode : sectionNode.childSections )
+            if( className.empty() )
+                writeSection( name, "", *childNode );
+            else
+                writeSection( className, name, *childNode );
+    }
+
+    void JunitReporter::writeAssertions( SectionNode const& sectionNode ) {
+        for( auto const& assertion : sectionNode.assertions )
+            writeAssertion( assertion );
+    }
+
+    void JunitReporter::writeAssertion( AssertionStats const& stats ) {
+        AssertionResult const& result = stats.assertionResult;
+        if( !result.isOk() ) {
+            std::string elementName;
+            switch( result.getResultType() ) {
+                case ResultWas::ThrewException:
+                case ResultWas::FatalErrorCondition:
+                    elementName = "error";
+                    break;
+                case ResultWas::ExplicitFailure:
+                    elementName = "failure";
+                    break;
+                case ResultWas::ExpressionFailed:
+                    elementName = "failure";
+                    break;
+                case ResultWas::DidntThrowException:
+                    elementName = "failure";
+                    break;
+
+                // We should never see these here:
+                case ResultWas::Info:
+                case ResultWas::Warning:
+                case ResultWas::Ok:
+                case ResultWas::Unknown:
+                case ResultWas::FailureBit:
+                case ResultWas::Exception:
+                    elementName = "internalError";
+                    break;
+            }
+
+            XmlWriter::ScopedElement e = xml.scopedElement( elementName );
+
+            xml.writeAttribute( "message", result.getExpandedExpression() );
+            xml.writeAttribute( "type", result.getTestMacroName() );
+
+            ReusableStringStream rss;
+            if( !result.getMessage().empty() )
+                rss << result.getMessage() << '\n';
+            for( auto const& msg : stats.infoMessages )
+                if( msg.type == ResultWas::Info )
+                    rss << msg.message << '\n';
+
+            rss << "at " << result.getSourceInfo();
+            xml.writeText( rss.str(), false );
+        }
+    }
+
+    CATCH_REGISTER_REPORTER( "junit", JunitReporter )
+
+} // end namespace Catch
+// end catch_reporter_junit.cpp
+// start catch_reporter_multi.cpp
+
+namespace Catch {
+
+    void MultipleReporters::add( IStreamingReporterPtr&& reporter ) {
+        m_reporters.push_back( std::move( reporter ) );
+    }
+
+    ReporterPreferences MultipleReporters::getPreferences() const {
+        return m_reporters[0]->getPreferences();
+    }
+
+    std::set<Verbosity> MultipleReporters::getSupportedVerbosities() {
+        return std::set<Verbosity>{ };
+    }
+
+    void MultipleReporters::noMatchingTestCases( std::string const& spec ) {
+        for( auto const& reporter : m_reporters )
+            reporter->noMatchingTestCases( spec );
+    }
+
+    void MultipleReporters::benchmarkStarting( BenchmarkInfo const& benchmarkInfo ) {
+        for( auto const& reporter : m_reporters )
+            reporter->benchmarkStarting( benchmarkInfo );
+    }
+    void MultipleReporters::benchmarkEnded( BenchmarkStats const& benchmarkStats ) {
+        for( auto const& reporter : m_reporters )
+            reporter->benchmarkEnded( benchmarkStats );
+    }
+
+    void MultipleReporters::testRunStarting( TestRunInfo const& testRunInfo ) {
+        for( auto const& reporter : m_reporters )
+            reporter->testRunStarting( testRunInfo );
+    }
+
+    void MultipleReporters::testGroupStarting( GroupInfo const& groupInfo ) {
+        for( auto const& reporter : m_reporters )
+            reporter->testGroupStarting( groupInfo );
+    }
+
+    void MultipleReporters::testCaseStarting( TestCaseInfo const& testInfo ) {
+        for( auto const& reporter : m_reporters )
+            reporter->testCaseStarting( testInfo );
+    }
+
+    void MultipleReporters::sectionStarting( SectionInfo const& sectionInfo ) {
+        for( auto const& reporter : m_reporters )
+            reporter->sectionStarting( sectionInfo );
+    }
+
+    void MultipleReporters::assertionStarting( AssertionInfo const& assertionInfo ) {
+        for( auto const& reporter : m_reporters )
+            reporter->assertionStarting( assertionInfo );
+    }
+
+    // The return value indicates if the messages buffer should be cleared:
+    bool MultipleReporters::assertionEnded( AssertionStats const& assertionStats ) {
+        bool clearBuffer = false;
+        for( auto const& reporter : m_reporters )
+            clearBuffer |= reporter->assertionEnded( assertionStats );
+        return clearBuffer;
+    }
+
+    void MultipleReporters::sectionEnded( SectionStats const& sectionStats ) {
+        for( auto const& reporter : m_reporters )
+            reporter->sectionEnded( sectionStats );
+    }
+
+    void MultipleReporters::testCaseEnded( TestCaseStats const& testCaseStats ) {
+        for( auto const& reporter : m_reporters )
+            reporter->testCaseEnded( testCaseStats );
+    }
+
+    void MultipleReporters::testGroupEnded( TestGroupStats const& testGroupStats ) {
+        for( auto const& reporter : m_reporters )
+            reporter->testGroupEnded( testGroupStats );
+    }
+
+    void MultipleReporters::testRunEnded( TestRunStats const& testRunStats ) {
+        for( auto const& reporter : m_reporters )
+            reporter->testRunEnded( testRunStats );
+    }
+
+    void MultipleReporters::skipTest( TestCaseInfo const& testInfo ) {
+        for( auto const& reporter : m_reporters )
+            reporter->skipTest( testInfo );
+    }
+
+    bool MultipleReporters::isMulti() const {
+        return true;
+    }
+
+} // end namespace Catch
+// end catch_reporter_multi.cpp
+// start catch_reporter_xml.cpp
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4061) // Not all labels are EXPLICITLY handled in switch
+                              // Note that 4062 (not all labels are handled
+                              // and default is missing) is enabled
+#endif
+
+namespace Catch {
+    XmlReporter::XmlReporter( ReporterConfig const& _config )
+    :   StreamingReporterBase( _config ),
+        m_xml(_config.stream())
+    {
+        m_reporterPrefs.shouldRedirectStdOut = true;
+    }
+
+    XmlReporter::~XmlReporter() = default;
+
+    std::string XmlReporter::getDescription() {
+        return "Reports test results as an XML document";
+    }
+
+    std::string XmlReporter::getStylesheetRef() const {
+        return std::string();
+    }
+
+    void XmlReporter::writeSourceInfo( SourceLineInfo const& sourceInfo ) {
+        m_xml
+            .writeAttribute( "filename", sourceInfo.file )
+            .writeAttribute( "line", sourceInfo.line );
+    }
+
+    void XmlReporter::noMatchingTestCases( std::string const& s ) {
+        StreamingReporterBase::noMatchingTestCases( s );
+    }
+
+    void XmlReporter::testRunStarting( TestRunInfo const& testInfo ) {
+        StreamingReporterBase::testRunStarting( testInfo );
+        std::string stylesheetRef = getStylesheetRef();
+        if( !stylesheetRef.empty() )
+            m_xml.writeStylesheetRef( stylesheetRef );
+        m_xml.startElement( "Catch" );
+        if( !m_config->name().empty() )
+            m_xml.writeAttribute( "name", m_config->name() );
+    }
+
+    void XmlReporter::testGroupStarting( GroupInfo const& groupInfo ) {
+        StreamingReporterBase::testGroupStarting( groupInfo );
+        m_xml.startElement( "Group" )
+            .writeAttribute( "name", groupInfo.name );
+    }
+
+    void XmlReporter::testCaseStarting( TestCaseInfo const& testInfo ) {
+        StreamingReporterBase::testCaseStarting(testInfo);
+        m_xml.startElement( "TestCase" )
+            .writeAttribute( "name", trim( testInfo.name ) )
+            .writeAttribute( "description", testInfo.description )
+            .writeAttribute( "tags", testInfo.tagsAsString() );
+
+        writeSourceInfo( testInfo.lineInfo );
+
+        if ( m_config->showDurations() == ShowDurations::Always )
+            m_testCaseTimer.start();
+        m_xml.ensureTagClosed();
+    }
+
+    void XmlReporter::sectionStarting( SectionInfo const& sectionInfo ) {
+        StreamingReporterBase::sectionStarting( sectionInfo );
+        if( m_sectionDepth++ > 0 ) {
+            m_xml.startElement( "Section" )
+                .writeAttribute( "name", trim( sectionInfo.name ) )
+                .writeAttribute( "description", sectionInfo.description );
+            writeSourceInfo( sectionInfo.lineInfo );
+            m_xml.ensureTagClosed();
+        }
+    }
+
+    void XmlReporter::assertionStarting( AssertionInfo const& ) { }
+
+    bool XmlReporter::assertionEnded( AssertionStats const& assertionStats ) {
+
+        AssertionResult const& result = assertionStats.assertionResult;
+
+        bool includeResults = m_config->includeSuccessfulResults() || !result.isOk();
+
+        if( includeResults || result.getResultType() == ResultWas::Warning ) {
+            // Print any info messages in <Info> tags.
+            for( auto const& msg : assertionStats.infoMessages ) {
+                if( msg.type == ResultWas::Info && includeResults ) {
+                    m_xml.scopedElement( "Info" )
+                            .writeText( msg.message );
+                } else if ( msg.type == ResultWas::Warning ) {
+                    m_xml.scopedElement( "Warning" )
+                            .writeText( msg.message );
+                }
+            }
+        }
+
+        // Drop out if result was successful but we're not printing them.
+        if( !includeResults && result.getResultType() != ResultWas::Warning )
+            return true;
+
+        // Print the expression if there is one.
+        if( result.hasExpression() ) {
+            m_xml.startElement( "Expression" )
+                .writeAttribute( "success", result.succeeded() )
+                .writeAttribute( "type", result.getTestMacroName() );
+
+            writeSourceInfo( result.getSourceInfo() );
+
+            m_xml.scopedElement( "Original" )
+                .writeText( result.getExpression() );
+            m_xml.scopedElement( "Expanded" )
+                .writeText( result.getExpandedExpression() );
+        }
+
+        // And... Print a result applicable to each result type.
+        switch( result.getResultType() ) {
+            case ResultWas::ThrewException:
+                m_xml.startElement( "Exception" );
+                writeSourceInfo( result.getSourceInfo() );
+                m_xml.writeText( result.getMessage() );
+                m_xml.endElement();
+                break;
+            case ResultWas::FatalErrorCondition:
+                m_xml.startElement( "FatalErrorCondition" );
+                writeSourceInfo( result.getSourceInfo() );
+                m_xml.writeText( result.getMessage() );
+                m_xml.endElement();
+                break;
+            case ResultWas::Info:
+                m_xml.scopedElement( "Info" )
+                    .writeText( result.getMessage() );
+                break;
+            case ResultWas::Warning:
+                // Warning will already have been written
+                break;
+            case ResultWas::ExplicitFailure:
+                m_xml.startElement( "Failure" );
+                writeSourceInfo( result.getSourceInfo() );
+                m_xml.writeText( result.getMessage() );
+                m_xml.endElement();
+                break;
+            default:
+                break;
+        }
+
+        if( result.hasExpression() )
+            m_xml.endElement();
+
+        return true;
+    }
+
+    void XmlReporter::sectionEnded( SectionStats const& sectionStats ) {
+        StreamingReporterBase::sectionEnded( sectionStats );
+        if( --m_sectionDepth > 0 ) {
+            XmlWriter::ScopedElement e = m_xml.scopedElement( "OverallResults" );
+            e.writeAttribute( "successes", sectionStats.assertions.passed );
+            e.writeAttribute( "failures", sectionStats.assertions.failed );
+            e.writeAttribute( "expectedFailures", sectionStats.assertions.failedButOk );
+
+            if ( m_config->showDurations() == ShowDurations::Always )
+                e.writeAttribute( "durationInSeconds", sectionStats.durationInSeconds );
+
+            m_xml.endElement();
+        }
+    }
+
+    void XmlReporter::testCaseEnded( TestCaseStats const& testCaseStats ) {
+        StreamingReporterBase::testCaseEnded( testCaseStats );
+        XmlWriter::ScopedElement e = m_xml.scopedElement( "OverallResult" );
+        e.writeAttribute( "success", testCaseStats.totals.assertions.allOk() );
+
+        if ( m_config->showDurations() == ShowDurations::Always )
+            e.writeAttribute( "durationInSeconds", m_testCaseTimer.getElapsedSeconds() );
+
+        if( !testCaseStats.stdOut.empty() )
+            m_xml.scopedElement( "StdOut" ).writeText( trim( testCaseStats.stdOut ), false );
+        if( !testCaseStats.stdErr.empty() )
+            m_xml.scopedElement( "StdErr" ).writeText( trim( testCaseStats.stdErr ), false );
+
+        m_xml.endElement();
+    }
+
+    void XmlReporter::testGroupEnded( TestGroupStats const& testGroupStats ) {
+        StreamingReporterBase::testGroupEnded( testGroupStats );
+        // TODO: Check testGroupStats.aborting and act accordingly.
+        m_xml.scopedElement( "OverallResults" )
+            .writeAttribute( "successes", testGroupStats.totals.assertions.passed )
+            .writeAttribute( "failures", testGroupStats.totals.assertions.failed )
+            .writeAttribute( "expectedFailures", testGroupStats.totals.assertions.failedButOk );
+        m_xml.endElement();
+    }
+
+    void XmlReporter::testRunEnded( TestRunStats const& testRunStats ) {
+        StreamingReporterBase::testRunEnded( testRunStats );
+        m_xml.scopedElement( "OverallResults" )
+            .writeAttribute( "successes", testRunStats.totals.assertions.passed )
+            .writeAttribute( "failures", testRunStats.totals.assertions.failed )
+            .writeAttribute( "expectedFailures", testRunStats.totals.assertions.failedButOk );
+        m_xml.endElement();
+    }
+
+    CATCH_REGISTER_REPORTER( "xml", XmlReporter )
+
+} // end namespace Catch
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+// end catch_reporter_xml.cpp
+
+namespace Catch {
+    LeakDetector leakDetector;
+}
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+// end catch_impl.hpp
+#endif
+
+#ifdef CATCH_CONFIG_MAIN
+// start catch_default_main.hpp
+
+#ifndef __OBJC__
+
+#if defined(CATCH_CONFIG_WCHAR) && defined(WIN32) && defined(_UNICODE) && !defined(DO_NOT_USE_WMAIN)
+// Standard C/C++ Win32 Unicode wmain entry point
+extern "C" int wmain (int argc, wchar_t * argv[], wchar_t * []) {
+#else
+// Standard C/C++ main entry point
+int main (int argc, char * argv[]) {
+#endif
+
+    return Catch::Session().run( argc, argv );
+}
+
+#else // __OBJC__
+
+// Objective-C entry point
+int main (int argc, char * const argv[]) {
+#if !CATCH_ARC_ENABLED
+    NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
+#endif
+
+    Catch::registerTestMethods();
+    int result = Catch::Session().run( argc, (char**)argv );
+
+#if !CATCH_ARC_ENABLED
+    [pool drain];
+#endif
+
+    return result;
+}
+
+#endif // __OBJC__
+
+// end catch_default_main.hpp
+#endif
+
+#if !defined(CATCH_CONFIG_IMPL_ONLY)
+
+#ifdef CLARA_CONFIG_MAIN_NOT_DEFINED
+#  undef CLARA_CONFIG_MAIN
+#endif
+
+#if !defined(CATCH_CONFIG_DISABLE)
+//////
+// If this config identifier is defined then all CATCH macros are prefixed with CATCH_
+#ifdef CATCH_CONFIG_PREFIX_ALL
+
+#define CATCH_REQUIRE( ... ) INTERNAL_CATCH_TEST( "CATCH_REQUIRE", Catch::ResultDisposition::Normal, __VA_ARGS__ )
+#define CATCH_REQUIRE_FALSE( ... ) INTERNAL_CATCH_TEST( "CATCH_REQUIRE_FALSE", Catch::ResultDisposition::Normal | Catch::ResultDisposition::FalseTest, __VA_ARGS__ )
+
+#define CATCH_REQUIRE_THROWS( ... ) INTERNAL_CATCH_THROWS( "CATCH_REQUIRE_THROWS", Catch::ResultDisposition::Normal, "", __VA_ARGS__ )
+#define CATCH_REQUIRE_THROWS_AS( expr, exceptionType ) INTERNAL_CATCH_THROWS_AS( "CATCH_REQUIRE_THROWS_AS", exceptionType, Catch::ResultDisposition::Normal, expr )
+#define CATCH_REQUIRE_THROWS_WITH( expr, matcher ) INTERNAL_CATCH_THROWS_STR_MATCHES( "CATCH_REQUIRE_THROWS_WITH", Catch::ResultDisposition::Normal, matcher, expr )
+#if !defined(CATCH_CONFIG_DISABLE_MATCHERS)
+#define CATCH_REQUIRE_THROWS_MATCHES( expr, exceptionType, matcher ) INTERNAL_CATCH_THROWS_MATCHES( "CATCH_REQUIRE_THROWS_MATCHES", exceptionType, Catch::ResultDisposition::Normal, matcher, expr )
+#endif// CATCH_CONFIG_DISABLE_MATCHERS
+#define CATCH_REQUIRE_NOTHROW( ... ) INTERNAL_CATCH_NO_THROW( "CATCH_REQUIRE_NOTHROW", Catch::ResultDisposition::Normal, __VA_ARGS__ )
+
+#define CATCH_CHECK( ... ) INTERNAL_CATCH_TEST( "CATCH_CHECK", Catch::ResultDisposition::ContinueOnFailure, __VA_ARGS__ )
+#define CATCH_CHECK_FALSE( ... ) INTERNAL_CATCH_TEST( "CATCH_CHECK_FALSE", Catch::ResultDisposition::ContinueOnFailure | Catch::ResultDisposition::FalseTest, __VA_ARGS__ )
+#define CATCH_CHECKED_IF( ... ) INTERNAL_CATCH_IF( "CATCH_CHECKED_IF", Catch::ResultDisposition::ContinueOnFailure, __VA_ARGS__ )
+#define CATCH_CHECKED_ELSE( ... ) INTERNAL_CATCH_ELSE( "CATCH_CHECKED_ELSE", Catch::ResultDisposition::ContinueOnFailure, __VA_ARGS__ )
+#define CATCH_CHECK_NOFAIL( ... ) INTERNAL_CATCH_TEST( "CATCH_CHECK_NOFAIL", Catch::ResultDisposition::ContinueOnFailure | Catch::ResultDisposition::SuppressFail, __VA_ARGS__ )
+
+#define CATCH_CHECK_THROWS( ... )  INTERNAL_CATCH_THROWS( "CATCH_CHECK_THROWS", Catch::ResultDisposition::ContinueOnFailure, "", __VA_ARGS__ )
+#define CATCH_CHECK_THROWS_AS( expr, exceptionType ) INTERNAL_CATCH_THROWS_AS( "CATCH_CHECK_THROWS_AS", exceptionType, Catch::ResultDisposition::ContinueOnFailure, expr )
+#define CATCH_CHECK_THROWS_WITH( expr, matcher ) INTERNAL_CATCH_THROWS_STR_MATCHES( "CATCH_CHECK_THROWS_WITH", Catch::ResultDisposition::ContinueOnFailure, matcher, expr )
+#if !defined(CATCH_CONFIG_DISABLE_MATCHERS)
+#define CATCH_CHECK_THROWS_MATCHES( expr, exceptionType, matcher ) INTERNAL_CATCH_THROWS_MATCHES( "CATCH_CHECK_THROWS_MATCHES", exceptionType, Catch::ResultDisposition::ContinueOnFailure, matcher, expr )
+#endif // CATCH_CONFIG_DISABLE_MATCHERS
+#define CATCH_CHECK_NOTHROW( ... ) INTERNAL_CATCH_NO_THROW( "CATCH_CHECK_NOTHROW", Catch::ResultDisposition::ContinueOnFailure, __VA_ARGS__ )
+
+#if !defined(CATCH_CONFIG_DISABLE_MATCHERS)
+#define CATCH_CHECK_THAT( arg, matcher ) INTERNAL_CHECK_THAT( "CATCH_CHECK_THAT", matcher, Catch::ResultDisposition::ContinueOnFailure, arg )
+
+#define CATCH_REQUIRE_THAT( arg, matcher ) INTERNAL_CHECK_THAT( "CATCH_REQUIRE_THAT", matcher, Catch::ResultDisposition::Normal, arg )
+#endif // CATCH_CONFIG_DISABLE_MATCHERS
+
+#define CATCH_INFO( msg ) INTERNAL_CATCH_INFO( "CATCH_INFO", msg )
+#define CATCH_WARN( msg ) INTERNAL_CATCH_MSG( "CATCH_WARN", Catch::ResultWas::Warning, Catch::ResultDisposition::ContinueOnFailure, msg )
+#define CATCH_CAPTURE( msg ) INTERNAL_CATCH_INFO( "CATCH_CAPTURE", #msg " := " << ::Catch::Detail::stringify(msg) )
+
+#define CATCH_TEST_CASE( ... ) INTERNAL_CATCH_TESTCASE( __VA_ARGS__ )
+#define CATCH_TEST_CASE_METHOD( className, ... ) INTERNAL_CATCH_TEST_CASE_METHOD( className, __VA_ARGS__ )
+#define CATCH_METHOD_AS_TEST_CASE( method, ... ) INTERNAL_CATCH_METHOD_AS_TEST_CASE( method, __VA_ARGS__ )
+#define CATCH_REGISTER_TEST_CASE( Function, ... ) INTERNAL_CATCH_REGISTER_TESTCASE( Function, __VA_ARGS__ )
+#define CATCH_SECTION( ... ) INTERNAL_CATCH_SECTION( __VA_ARGS__ )
+#define CATCH_FAIL( ... ) INTERNAL_CATCH_MSG( "CATCH_FAIL", Catch::ResultWas::ExplicitFailure, Catch::ResultDisposition::Normal, __VA_ARGS__ )
+#define CATCH_FAIL_CHECK( ... ) INTERNAL_CATCH_MSG( "CATCH_FAIL_CHECK", Catch::ResultWas::ExplicitFailure, Catch::ResultDisposition::ContinueOnFailure, __VA_ARGS__ )
+#define CATCH_SUCCEED( ... ) INTERNAL_CATCH_MSG( "CATCH_SUCCEED", Catch::ResultWas::Ok, Catch::ResultDisposition::ContinueOnFailure, __VA_ARGS__ )
+
+#define CATCH_ANON_TEST_CASE() INTERNAL_CATCH_TESTCASE()
+
+// "BDD-style" convenience wrappers
+#define CATCH_SCENARIO( ... ) CATCH_TEST_CASE( "Scenario: " __VA_ARGS__ )
+#define CATCH_SCENARIO_METHOD( className, ... ) INTERNAL_CATCH_TEST_CASE_METHOD( className, "Scenario: " __VA_ARGS__ )
+#define CATCH_GIVEN( desc )    CATCH_SECTION( std::string( "Given: ") + desc )
+#define CATCH_WHEN( desc )     CATCH_SECTION( std::string( " When: ") + desc )
+#define CATCH_AND_WHEN( desc ) CATCH_SECTION( std::string( "  And: ") + desc )
+#define CATCH_THEN( desc )     CATCH_SECTION( std::string( " Then: ") + desc )
+#define CATCH_AND_THEN( desc ) CATCH_SECTION( std::string( "  And: ") + desc )
+
+// If CATCH_CONFIG_PREFIX_ALL is not defined then the CATCH_ prefix is not required
+#else
+
+#define REQUIRE( ... ) INTERNAL_CATCH_TEST( "REQUIRE", Catch::ResultDisposition::Normal, __VA_ARGS__  )
+#define REQUIRE_FALSE( ... ) INTERNAL_CATCH_TEST( "REQUIRE_FALSE", Catch::ResultDisposition::Normal | Catch::ResultDisposition::FalseTest, __VA_ARGS__ )
+
+#define REQUIRE_THROWS( ... ) INTERNAL_CATCH_THROWS( "REQUIRE_THROWS", Catch::ResultDisposition::Normal, __VA_ARGS__ )
+#define REQUIRE_THROWS_AS( expr, exceptionType ) INTERNAL_CATCH_THROWS_AS( "REQUIRE_THROWS_AS", exceptionType, Catch::ResultDisposition::Normal, expr )
+#define REQUIRE_THROWS_WITH( expr, matcher ) INTERNAL_CATCH_THROWS_STR_MATCHES( "REQUIRE_THROWS_WITH", Catch::ResultDisposition::Normal, matcher, expr )
+#if !defined(CATCH_CONFIG_DISABLE_MATCHERS)
+#define REQUIRE_THROWS_MATCHES( expr, exceptionType, matcher ) INTERNAL_CATCH_THROWS_MATCHES( "REQUIRE_THROWS_MATCHES", exceptionType, Catch::ResultDisposition::Normal, matcher, expr )
+#endif // CATCH_CONFIG_DISABLE_MATCHERS
+#define REQUIRE_NOTHROW( ... ) INTERNAL_CATCH_NO_THROW( "REQUIRE_NOTHROW", Catch::ResultDisposition::Normal, __VA_ARGS__ )
+
+#define CHECK( ... ) INTERNAL_CATCH_TEST( "CHECK", Catch::ResultDisposition::ContinueOnFailure, __VA_ARGS__ )
+#define CHECK_FALSE( ... ) INTERNAL_CATCH_TEST( "CHECK_FALSE", Catch::ResultDisposition::ContinueOnFailure | Catch::ResultDisposition::FalseTest, __VA_ARGS__ )
+#define CHECKED_IF( ... ) INTERNAL_CATCH_IF( "CHECKED_IF", Catch::ResultDisposition::ContinueOnFailure, __VA_ARGS__ )
+#define CHECKED_ELSE( ... ) INTERNAL_CATCH_ELSE( "CHECKED_ELSE", Catch::ResultDisposition::ContinueOnFailure, __VA_ARGS__ )
+#define CHECK_NOFAIL( ... ) INTERNAL_CATCH_TEST( "CHECK_NOFAIL", Catch::ResultDisposition::ContinueOnFailure | Catch::ResultDisposition::SuppressFail, __VA_ARGS__ )
+
+#define CHECK_THROWS( ... )  INTERNAL_CATCH_THROWS( "CHECK_THROWS", Catch::ResultDisposition::ContinueOnFailure, __VA_ARGS__ )
+#define CHECK_THROWS_AS( expr, exceptionType ) INTERNAL_CATCH_THROWS_AS( "CHECK_THROWS_AS", exceptionType, Catch::ResultDisposition::ContinueOnFailure, expr )
+#define CHECK_THROWS_WITH( expr, matcher ) INTERNAL_CATCH_THROWS_STR_MATCHES( "CHECK_THROWS_WITH", Catch::ResultDisposition::ContinueOnFailure, matcher, expr )
+#if !defined(CATCH_CONFIG_DISABLE_MATCHERS)
+#define CHECK_THROWS_MATCHES( expr, exceptionType, matcher ) INTERNAL_CATCH_THROWS_MATCHES( "CHECK_THROWS_MATCHES", exceptionType, Catch::ResultDisposition::ContinueOnFailure, matcher, expr )
+#endif // CATCH_CONFIG_DISABLE_MATCHERS
+#define CHECK_NOTHROW( ... ) INTERNAL_CATCH_NO_THROW( "CHECK_NOTHROW", Catch::ResultDisposition::ContinueOnFailure, __VA_ARGS__ )
+
+#if !defined(CATCH_CONFIG_DISABLE_MATCHERS)
+#define CHECK_THAT( arg, matcher ) INTERNAL_CHECK_THAT( "CHECK_THAT", matcher, Catch::ResultDisposition::ContinueOnFailure, arg )
+
+#define REQUIRE_THAT( arg, matcher ) INTERNAL_CHECK_THAT( "REQUIRE_THAT", matcher, Catch::ResultDisposition::Normal, arg )
+#endif // CATCH_CONFIG_DISABLE_MATCHERS
+
+#define INFO( msg ) INTERNAL_CATCH_INFO( "INFO", msg )
+#define WARN( msg ) INTERNAL_CATCH_MSG( "WARN", Catch::ResultWas::Warning, Catch::ResultDisposition::ContinueOnFailure, msg )
+#define CAPTURE( msg ) INTERNAL_CATCH_INFO( "CAPTURE", #msg " := " << ::Catch::Detail::stringify(msg) )
+
+#define TEST_CASE( ... ) INTERNAL_CATCH_TESTCASE( __VA_ARGS__ )
+#define TEST_CASE_METHOD( className, ... ) INTERNAL_CATCH_TEST_CASE_METHOD( className, __VA_ARGS__ )
+#define METHOD_AS_TEST_CASE( method, ... ) INTERNAL_CATCH_METHOD_AS_TEST_CASE( method, __VA_ARGS__ )
+#define REGISTER_TEST_CASE( Function, ... ) INTERNAL_CATCH_REGISTER_TESTCASE( Function, __VA_ARGS__ )
+#define SECTION( ... ) INTERNAL_CATCH_SECTION( __VA_ARGS__ )
+#define FAIL( ... ) INTERNAL_CATCH_MSG( "FAIL", Catch::ResultWas::ExplicitFailure, Catch::ResultDisposition::Normal, __VA_ARGS__ )
+#define FAIL_CHECK( ... ) INTERNAL_CATCH_MSG( "FAIL_CHECK", Catch::ResultWas::ExplicitFailure, Catch::ResultDisposition::ContinueOnFailure, __VA_ARGS__ )
+#define SUCCEED( ... ) INTERNAL_CATCH_MSG( "SUCCEED", Catch::ResultWas::Ok, Catch::ResultDisposition::ContinueOnFailure, __VA_ARGS__ )
+#define ANON_TEST_CASE() INTERNAL_CATCH_TESTCASE()
+
+#endif
+
+#define CATCH_TRANSLATE_EXCEPTION( signature ) INTERNAL_CATCH_TRANSLATE_EXCEPTION( signature )
+
+// "BDD-style" convenience wrappers
+#define SCENARIO( ... ) TEST_CASE( "Scenario: " __VA_ARGS__ )
+#define SCENARIO_METHOD( className, ... ) INTERNAL_CATCH_TEST_CASE_METHOD( className, "Scenario: " __VA_ARGS__ )
+
+#define GIVEN( desc )    SECTION( std::string("   Given: ") + desc )
+#define WHEN( desc )     SECTION( std::string("    When: ") + desc )
+#define AND_WHEN( desc ) SECTION( std::string("And when: ") + desc )
+#define THEN( desc )     SECTION( std::string("    Then: ") + desc )
+#define AND_THEN( desc ) SECTION( std::string("     And: ") + desc )
+
+using Catch::Detail::Approx;
+
+#else
+//////
+// If this config identifier is defined then all CATCH macros are prefixed with CATCH_
+#ifdef CATCH_CONFIG_PREFIX_ALL
+
+#define CATCH_REQUIRE( ... )        (void)(0)
+#define CATCH_REQUIRE_FALSE( ... )  (void)(0)
+
+#define CATCH_REQUIRE_THROWS( ... ) (void)(0)
+#define CATCH_REQUIRE_THROWS_AS( expr, exceptionType ) (void)(0)
+#define CATCH_REQUIRE_THROWS_WITH( expr, matcher )     (void)(0)
+#if !defined(CATCH_CONFIG_DISABLE_MATCHERS)
+#define CATCH_REQUIRE_THROWS_MATCHES( expr, exceptionType, matcher ) (void)(0)
+#endif// CATCH_CONFIG_DISABLE_MATCHERS
+#define CATCH_REQUIRE_NOTHROW( ... ) (void)(0)
+
+#define CATCH_CHECK( ... )         (void)(0)
+#define CATCH_CHECK_FALSE( ... )   (void)(0)
+#define CATCH_CHECKED_IF( ... )    if (__VA_ARGS__)
+#define CATCH_CHECKED_ELSE( ... )  if (!(__VA_ARGS__))
+#define CATCH_CHECK_NOFAIL( ... )  (void)(0)
+
+#define CATCH_CHECK_THROWS( ... )  (void)(0)
+#define CATCH_CHECK_THROWS_AS( expr, exceptionType ) (void)(0)
+#define CATCH_CHECK_THROWS_WITH( expr, matcher )     (void)(0)
+#if !defined(CATCH_CONFIG_DISABLE_MATCHERS)
+#define CATCH_CHECK_THROWS_MATCHES( expr, exceptionType, matcher ) (void)(0)
+#endif // CATCH_CONFIG_DISABLE_MATCHERS
+#define CATCH_CHECK_NOTHROW( ... ) (void)(0)
+
+#if !defined(CATCH_CONFIG_DISABLE_MATCHERS)
+#define CATCH_CHECK_THAT( arg, matcher )   (void)(0)
+
+#define CATCH_REQUIRE_THAT( arg, matcher ) (void)(0)
+#endif // CATCH_CONFIG_DISABLE_MATCHERS
+
+#define CATCH_INFO( msg )    (void)(0)
+#define CATCH_WARN( msg )    (void)(0)
+#define CATCH_CAPTURE( msg ) (void)(0)
+
+#define CATCH_TEST_CASE( ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ))
+#define CATCH_TEST_CASE_METHOD( className, ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ))
+#define CATCH_METHOD_AS_TEST_CASE( method, ... )
+#define CATCH_REGISTER_TEST_CASE( Function, ... ) (void)(0)
+#define CATCH_SECTION( ... )
+#define CATCH_FAIL( ... ) (void)(0)
+#define CATCH_FAIL_CHECK( ... ) (void)(0)
+#define CATCH_SUCCEED( ... ) (void)(0)
+
+#define CATCH_ANON_TEST_CASE() INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ))
+
+// "BDD-style" convenience wrappers
+#define CATCH_SCENARIO( ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ))
+#define CATCH_SCENARIO_METHOD( className, ... ) INTERNAL_CATCH_TESTCASE_METHOD_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ), className )
+#define CATCH_GIVEN( desc )
+#define CATCH_WHEN( desc )
+#define CATCH_AND_WHEN( desc )
+#define CATCH_THEN( desc )
+#define CATCH_AND_THEN( desc )
+
+// If CATCH_CONFIG_PREFIX_ALL is not defined then the CATCH_ prefix is not required
+#else
+
+#define REQUIRE( ... )       (void)(0)
+#define REQUIRE_FALSE( ... ) (void)(0)
+
+#define REQUIRE_THROWS( ... ) (void)(0)
+#define REQUIRE_THROWS_AS( expr, exceptionType ) (void)(0)
+#define REQUIRE_THROWS_WITH( expr, matcher ) (void)(0)
+#if !defined(CATCH_CONFIG_DISABLE_MATCHERS)
+#define REQUIRE_THROWS_MATCHES( expr, exceptionType, matcher ) (void)(0)
+#endif // CATCH_CONFIG_DISABLE_MATCHERS
+#define REQUIRE_NOTHROW( ... ) (void)(0)
+
+#define CHECK( ... ) (void)(0)
+#define CHECK_FALSE( ... ) (void)(0)
+#define CHECKED_IF( ... ) if (__VA_ARGS__)
+#define CHECKED_ELSE( ... ) if (!(__VA_ARGS__))
+#define CHECK_NOFAIL( ... ) (void)(0)
+
+#define CHECK_THROWS( ... )  (void)(0)
+#define CHECK_THROWS_AS( expr, exceptionType ) (void)(0)
+#define CHECK_THROWS_WITH( expr, matcher ) (void)(0)
+#if !defined(CATCH_CONFIG_DISABLE_MATCHERS)
+#define CHECK_THROWS_MATCHES( expr, exceptionType, matcher ) (void)(0)
+#endif // CATCH_CONFIG_DISABLE_MATCHERS
+#define CHECK_NOTHROW( ... ) (void)(0)
+
+#if !defined(CATCH_CONFIG_DISABLE_MATCHERS)
+#define CHECK_THAT( arg, matcher ) (void)(0)
+
+#define REQUIRE_THAT( arg, matcher ) (void)(0)
+#endif // CATCH_CONFIG_DISABLE_MATCHERS
+
+#define INFO( msg ) (void)(0)
+#define WARN( msg ) (void)(0)
+#define CAPTURE( msg ) (void)(0)
+
+#define TEST_CASE( ... )  INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ))
+#define TEST_CASE_METHOD( className, ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ))
+#define METHOD_AS_TEST_CASE( method, ... )
+#define REGISTER_TEST_CASE( Function, ... ) (void)(0)
+#define SECTION( ... )
+#define FAIL( ... ) (void)(0)
+#define FAIL_CHECK( ... ) (void)(0)
+#define SUCCEED( ... ) (void)(0)
+#define ANON_TEST_CASE() INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ))
+
+#endif
+
+#define CATCH_TRANSLATE_EXCEPTION( signature ) INTERNAL_CATCH_TRANSLATE_EXCEPTION_NO_REG( INTERNAL_CATCH_UNIQUE_NAME( catch_internal_ExceptionTranslator ), signature )
+
+// "BDD-style" convenience wrappers
+#define SCENARIO( ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ) )
+#define SCENARIO_METHOD( className, ... ) INTERNAL_CATCH_TESTCASE_METHOD_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ), className )
+
+#define GIVEN( desc )
+#define WHEN( desc )
+#define AND_WHEN( desc )
+#define THEN( desc )
+#define AND_THEN( desc )
+
+using Catch::Detail::Approx;
+
+#endif
+
+#endif // ! CATCH_CONFIG_IMPL_ONLY
+
+// start catch_reenable_warnings.h
+
+
+#ifdef __clang__
+#    ifdef __ICC // icpc defines the __clang__ macro
+#        pragma warning(pop)
+#    else
+#        pragma clang diagnostic pop
+#    endif
+#elif defined __GNUC__
+#    pragma GCC diagnostic pop
+#endif
+
+// end catch_reenable_warnings.h
+// end catch.hpp
+#endif // TWOBLUECUBES_SINGLE_INCLUDE_CATCH_HPP_INCLUDED
+

--- a/lib/swoc++/include/swoc/swoc_file.h
+++ b/lib/swoc++/include/swoc/swoc_file.h
@@ -1,0 +1,239 @@
+/** @file
+
+  Simple path and file utilities.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
+  See the NOTICE file distributed with this work for additional information regarding copyright
+  ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance with the License.  You may obtain a
+  copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License
+  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  or implied. See the License for the specific language governing permissions and limitations under
+  the License.
+ */
+
+#pragma once
+
+#include <sys/stat.h>
+
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#include "swoc/TextView.h"
+
+namespace swoc
+{
+namespace file
+{
+  /** Utility class for file system paths.
+   */
+  class path
+  {
+    using self_type = path;
+
+  public:
+    static constexpr char SEPARATOR = '/';
+
+    /// Default construct empty path.
+    path() = default;
+
+    /// Copy constructor - copies the path.
+    path(const self_type &that) = default;
+
+    /// Move constructor.
+    path(self_type &&that) = default;
+
+    /// Construct from a null terminated string.
+    explicit path(const char *src);
+
+    /// Construct from a string view.
+    path(std::string_view src);
+    //  template < typename ... Args > explicit path(std::string_view base, Args... rest);
+
+    /// Move from an existing string
+    path(std::string &&that);
+
+    /// Replace the path with a copy of @a that.
+    self_type &operator=(const self_type &that) = default;
+
+    /// Replace the path with the contents of @a that.
+    self_type &operator=(self_type &&that) = default;
+
+    /// Assign @a p as the path.
+    self_type &operator=(std::string_view p);
+
+    /** Append or replace path with @a that.
+     *
+     * If @a that is absolute, it replaces @a this. Otherwise @a that is appended with exactly one
+     * separator.
+     *
+     * @param that Filesystem path.
+     * @return @a this
+     */
+    self_type &operator/=(const self_type &that);
+    self_type &operator/=(std::string_view that);
+
+    /// Check if the path is empty.
+    bool empty() const;
+
+    /// Check if the path is absolute.
+    bool is_absolute() const;
+
+    /// Check if the path is not absolute.
+    bool is_relative() const;
+
+    /// Access the path explicitly.
+    char const *c_str() const;
+
+    /// Get a copy of the path.
+    std::string string() const;
+
+  protected:
+    std::string _path; ///< File path.
+  };
+
+  /// Information about a file.
+  class file_status
+  {
+    using self_type = file_status;
+
+  public:
+  protected:
+    struct ::stat _stat; ///< File information.
+
+    friend self_type status(const path &, std::error_code &) noexcept;
+
+    friend int file_type(const self_type &);
+    friend off_t file_size(const self_type &);
+    friend bool is_regular_file(const file_status &);
+    friend bool is_dir(const file_status &);
+    friend bool is_char_device(const file_status &);
+    friend bool is_block_device(const file_status &);
+  };
+
+  /** Get the status of the file at @a p.
+   *
+   * @param p Path to file.
+   * @param ec Error code return.
+   * @return Status of the file.
+   */
+  file_status status(const path &p, std::error_code &ec) noexcept;
+
+  // Related free functions.
+  // These are separate because they are not part of std::filesystem::path.
+
+  /// Return the file type value.
+  int file_type(const file_status &fs);
+
+  /// Check if the path is to a regular file.
+  bool is_regular_file(const file_status &fs);
+
+  /// Check if the path is to a directory.
+  bool is_dir(const file_status &p);
+
+  /// Check if the path is to a character device.
+  bool is_char_device(const file_status &fs);
+
+  /// Check if the path is to a block device.
+  bool is_block_device(const file_status &fs);
+
+  /// Size of the file or block device.
+  off_t file_size(const file_status &fs);
+
+  /// Check if file is readable.
+  bool is_readable(const path &s);
+
+  /** Load the file at @a p into a @c std::string.
+   *
+   * @param p Path to file
+   * @return The contents of the file.
+   */
+  std::string load(const path &p, std::error_code &ec);
+  /* ------------------------------------------------------------------- */
+
+  inline path::path(char const *src) : _path(src) {}
+
+  inline path::path(std::string_view base) : _path(base) {}
+
+  inline path::path(std::string &&that) : _path(std::move(that)) {}
+
+  inline path &
+  path::operator=(std::string_view p)
+  {
+    _path.assign(p);
+    return *this;
+  }
+
+  inline char const *
+  path::c_str() const
+  {
+    return _path.c_str();
+  }
+
+  inline std::string
+  path::string() const
+  {
+    return _path;
+  }
+
+  inline bool
+  path::empty() const
+  {
+    return _path.empty();
+  }
+
+  inline bool
+  path::is_absolute() const
+  {
+    return !_path.empty() && '/' == _path[0];
+  }
+
+  inline bool
+  path::is_relative() const
+  {
+    return !this->is_absolute();
+  }
+
+  inline path &
+  path::operator/=(const self_type &that)
+  {
+    return *this /= std::string_view(that._path);
+  }
+
+  /** Combine two strings as file paths.
+
+       @return A @c path with the combined path.
+  */
+  inline path
+  operator/(const path &lhs, const path &rhs)
+  {
+    return path(lhs) /= rhs;
+  }
+
+  inline path
+  operator/(path &&lhs, const path &rhs)
+  {
+    return path(std::move(lhs)) /= rhs;
+  }
+
+  inline path
+  operator/(const path &lhs, std::string_view rhs)
+  {
+    return path(lhs) /= rhs;
+  }
+
+  inline path
+  operator/(path &&lhs, std::string_view rhs)
+  {
+    return path(std::move(lhs)) /= rhs;
+  }
+
+} // namespace file
+} // namespace swoc

--- a/lib/swoc++/include/swoc/swoc_meta.h
+++ b/lib/swoc++/include/swoc/swoc_meta.h
@@ -1,0 +1,98 @@
+/** @file
+
+  Meta programming support utilities.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
+  See the NOTICE file distributed with this work for additional information regarding copyright
+  ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance with the License.  You may obtain a
+  copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License
+  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  or implied. See the License for the specific language governing permissions and limitations under
+  the License.
+*/
+
+#pragma once
+
+namespace swoc
+{
+namespace meta
+{
+  /** This creates an ordered series of meta template cases that can be used to select one of a set
+   * of functions in a priority ordering. A set of templated overloads take an (extra) argument of
+   * the case structures, each a different one. Calling the function invokes the highest case that
+   * is valid. Because of SFINAE the templates can have errors, as long as at least one doesn't.
+   * The root technique is to use @c decltype to check an expression for the overload to be valid.
+   * Because the compiler will evaluate everything it can while parsing the template this
+   * expression must be delayed until the template is instantiated. This is done by making the
+   * return type @c auto and making the @c decltype dependent on the template parameter. In
+   * addition, the comma operator can be used to force a specific return type while also checking
+   * the expression for validity. E.g.
+   *
+   * @code
+   * template <typename T> auto func(T && t, CaseTag<0>) -> decltype(t.item, int()) { }
+   * @endcode
+   *
+   * The comma operator discards the type and value of the left operand therefore the return type of
+   * the function is @c int but this overload will not be available if @c t.item does not compile
+   * (e.g., there is no such member). The presence of @c t.item also prevents this compilation check
+   * from happening until overload selection is needed. Therefore if the goal was a function that
+   * would return the value of the @c T::count member if present and 0 if not, the code would be
+   *
+   * @code
+   * template <typename T> auto Get_Count(T && t, CaseTag<0>)
+   *   -> int
+   * { return 0; }
+   * template <typename T> auto Get_Count(T && t, CaseTag<1>)
+   *   -> decltype(t.count, int())
+   * { return t.count; }
+   * int Get_Count(Thing& t) { return GetCount(t, CaseArg); }
+   * @endcode
+   *
+   * Note the overloads will be checked from the highest case to the lowest and the first one that
+   * is valid (via SFINAE) is used. This is the point of using the case arguments, to force an
+   * ordering on the overload selection. Unfortunately this means the functions @b must be
+   * templated, even if there's no other reason for it, because it depends on SFINAE which doesn't
+   * apply to normal overloads.
+   *
+   * The key point is the expression in the @c decltype should be the same expression used in the
+   * method to verify it will compile. It is annoying to type it twice but there's not a better
+   * option.
+   *
+   * Note @c decltype does not accept explicit types - to have the type of "int" an @c int must be
+   * constructed. This is easy for builtin types except @c void. @c CaseVoidFunc is provided for that
+   * situation, e.g. <tt>decltype(CaseVoidFunc())</tt> provides @c void via @c decltype.
+   */
+
+  /// Case hierarchy.
+  template <unsigned N> struct CaseTag : public CaseTag<N - 1> {
+    constexpr CaseTag() {}
+    static constexpr unsigned value = N;
+  };
+
+  /// Anchor the hierarchy.
+  template <> struct CaseTag<0> {
+    constexpr CaseTag() {}
+    static constexpr unsigned value = 0;
+  };
+
+  /** This is the final case - it forces the super class hierarchy.
+   * After defining the cases using the indexed case arguments, this is used to to perform the call.
+   * To increase the hierarchy depth, change the template argument to a larger number.
+   */
+  static constexpr CaseTag<9> CaseArg{};
+
+  // A function to provide a @c void type for use in cases.
+  // Other types can use the default constructor, e.g. "int()" for @c int.
+  inline void
+  CaseVoidFunc()
+  {
+  }
+} // namespace meta
+} // namespace swoc

--- a/lib/swoc++/src/Errata.cc
+++ b/lib/swoc++/src/Errata.cc
@@ -1,0 +1,222 @@
+/** @file
+    Errata implementation.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#include <iostream>
+#include <sstream>
+#include <algorithm>
+#include <memory.h>
+#include "swoc/Errata.h"
+#include "swoc/bwf_ex.h"
+
+using swoc::MemArena;
+using std::string_view;
+
+namespace swoc
+{
+/** List of sinks for abandoned erratum.
+ */
+namespace
+{
+  std::vector<Errata::Sink::Handle> Sink_List;
+}
+
+std::string_view const Errata::DEFAULT_GLUE{"\n", 1};
+
+/** This is the implementation class for Errata.
+
+    It holds the actual messages and is treated as a passive data object with nice constructors.
+*/
+string_view
+Errata::Data::localize(string_view src)
+{
+  auto span = _arena.alloc(src.size());
+  memcpy(span.data(), src.data(), src.size());
+  return span;
+}
+
+/* ----------------------------------------------------------------------- */
+// methods for Errata
+
+Errata::~Errata()
+{
+  this->release();
+}
+
+void
+Errata::release()
+{
+  if (_data) {
+    if (--(_data->_ref_count) == 0) {
+      if (!_data->empty()) {
+        for (auto &f : Sink_List) {
+          (*f)(*this);
+        }
+      }
+      _data->~Data();
+    }
+    _data = nullptr;
+  }
+}
+
+const Errata::Data *
+Errata::data()
+{
+  if (!_data) {
+    MemArena arena{512};
+    _data = arena.make<Data>(std::move(arena));
+    ++(_data->_ref_count);
+  }
+  return _data;
+}
+
+Errata::Data *
+Errata::writeable_data()
+{
+  if (!_data) {
+    this->data(); // force data existence, must be unique.
+  } else if (_data->_ref_count > 1) {
+    // Pondering this, there's really no good use case for shared write access to an Errata.
+    // The shared_ptr is used only to make function returns efficient. Explicit copying is
+    // easy using @c note.
+    throw std::runtime_error("Shared write to Errata");
+  };
+  return _data;
+}
+
+Errata::iterator
+Errata::begin()
+{
+  return _data ? _data->_notes.begin() : iterator();
+}
+
+Errata::const_iterator
+Errata::begin() const
+{
+  return _data ? _data->_notes.begin() : const_iterator();
+}
+
+Errata::iterator
+Errata::end()
+{
+  return _data ? _data->_notes.end() : iterator();
+}
+
+Errata::const_iterator
+Errata::end() const
+{
+  return _data ? _data->_notes.end() : const_iterator();
+}
+
+Severity
+Errata::severity() const
+{
+  return _data ? _data->_severity : DEFAULT_SEVERITY;
+}
+
+Errata &
+Errata::note(Severity level, std::string_view text)
+{
+  auto d        = this->writeable_data();
+  Annotation *n = d->_arena.make<Annotation>(level, d->localize(text));
+  d->_notes.prepend(n);
+  _data->_severity = std::max(_data->_severity, level);
+  return *this;
+}
+
+Errata &
+Errata::note_localized(Severity level, std::string_view const &text)
+{
+  auto d        = this->writeable_data();
+  Annotation *n = d->_arena.make<Annotation>(level, text);
+  n->_level     = d->_level;
+  d->_notes.prepend(n);
+  _data->_severity = std::max(_data->_severity, level);
+  return *this;
+}
+
+MemSpan<char>
+Errata::alloc(size_t n)
+{
+  return this->writeable_data()->_arena.alloc(n).rebind<char>();
+}
+
+Errata &
+Errata::note(const self_type &that)
+{
+  for (auto const &m : that) {
+    this->note(m._severity, m._text);
+  }
+  return *this;
+}
+
+Errata &
+Errata::clear()
+{
+  if (_data) {
+    _data->_notes.clear(); // Prevent sink processing.
+    this->release();
+  }
+  return *this;
+}
+
+void
+Errata::register_sink(Sink::Handle const &s)
+{
+  Sink_List.push_back(s);
+}
+
+std::ostream &
+Errata::write(std::ostream &out) const
+{
+  string_view lead;
+  for (auto &m : *this) {
+    out << lead << " [" << static_cast<int>(m._severity) << "]: " << m._text << std::endl;
+    if (0 == lead.size()) {
+      lead = "  "_sv;
+    }
+  }
+  return out;
+}
+
+BufferWriter &
+bwformat(BufferWriter &bw, bwf::Spec const &spec, Errata::Severity level)
+{
+  static constexpr std::string_view name[] = {"DIAG", "DEBUG", "INFO", "NOTE", "WARNING", "ERROR", "FATAL", "ALERT", "EMERGENCY"};
+  return bwformat(bw, spec, name[static_cast<int>(level)]);
+}
+
+BufferWriter &
+bwformat(BufferWriter &bw, bwf::Spec const &spec, Errata const &errata)
+{
+  for (auto &m : errata) {
+    bw.print("{}[{}] {}\n", swoc::bwf::Pattern{int(m.level()), "  "}, m.severity(), m.text());
+  }
+  return bw;
+}
+
+std::ostream &
+operator<<(std::ostream &os, Errata const &err)
+{
+  return err.write(os);
+}
+
+} // namespace swoc

--- a/lib/swoc++/src/MemArena.cc
+++ b/lib/swoc++/src/MemArena.cc
@@ -1,0 +1,161 @@
+/** @file
+
+    MemArena memory allocator. Chunks of memory are allocated, frozen into generations and
+     thawed away when unused.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#include <algorithm>
+#include "swoc/MemArena.h"
+
+using namespace swoc;
+
+void
+MemArena::Block::operator delete(void *ptr)
+{
+  ::free(ptr);
+}
+
+MemArena::Block *
+MemArena::make_block(size_t n)
+{
+  // If there's no reservation hint, use the extent. This is transient because the hint is cleared.
+  if (_reserve_hint == 0) {
+    if (_active_reserved) {
+      _reserve_hint = _active_reserved;
+    } else if (_frozen_allocated) {
+      _reserve_hint = _frozen_allocated;
+    }
+  }
+
+  // If post-freeze or reserved, allocate at least that much.
+  n             = std::max<size_t>(n, _reserve_hint);
+  _reserve_hint = 0; // did this, clear for next time.
+  // Add in overhead and round up to paragraph units.
+  n = Paragraph{round_up(n + ALLOC_HEADER_SIZE + sizeof(Block))};
+  // If a page or more, round up to page unit size and clip back to account for alloc header.
+  if (n >= Page::SCALE) {
+    n = Page{round_up(n)} - ALLOC_HEADER_SIZE;
+  }
+
+  // Allocate space for the Block instance and the request memory and construct a Block at the front.
+  // In theory this could use ::operator new(n) but this causes a size mismatch during ::operator delete.
+  // Easier to use malloc and override @c delete.
+  auto free_space = n - sizeof(Block);
+  _active_reserved += free_space;
+  return new (::malloc(n)) Block(free_space);
+}
+
+MemSpan<void>
+MemArena::alloc(size_t n)
+{
+  Block *block = _active.head();
+
+  if (nullptr == block) {
+    block = this->make_block(n);
+    _active.prepend(block);
+  } else if (n > block->remaining()) { // too big, need another block
+    block = this->make_block(n);
+    // For the resulting active allocation block, pick the block which will have the most free space
+    // after taking the request space out of the new block.
+    if (block->remaining() - n > _active.head()->remaining()) {
+      _active.prepend(block);
+    } else {
+      _active.insert_after(_active.head(), block);
+    }
+  }
+  _active_allocated += n;
+  return block->alloc(n);
+}
+
+MemArena &
+MemArena::freeze(size_t n)
+{
+  this->destroy_frozen();
+  _frozen = std::move(_active);
+  // Update the meta data.
+  _frozen_allocated = _active_allocated;
+  _active_allocated = 0;
+  _frozen_reserved  = _active_reserved;
+  _active_reserved  = 0;
+
+  _reserve_hint = n;
+
+  return *this;
+}
+
+MemArena &
+MemArena::thaw()
+{
+  this->destroy_frozen();
+  _frozen_reserved = _frozen_allocated = 0;
+  return *this;
+}
+
+bool
+MemArena::contains(const void *ptr) const
+{
+  auto pred = [ptr](const Block &b) -> bool { return b.contains(ptr); };
+
+  return std::any_of(_active.begin(), _active.end(), pred) || std::any_of(_frozen.begin(), _frozen.end(), pred);
+}
+
+void
+MemArena::destroy_active()
+{
+  _active.apply([](Block *b) { delete b; }).clear();
+}
+
+void
+MemArena::destroy_frozen()
+{
+  _frozen.apply([](Block *b) { delete b; }).clear();
+}
+
+MemArena &
+MemArena::clear(size_t n)
+{
+  _reserve_hint    = n ? n : _frozen_allocated + _active_allocated;
+  _frozen_reserved = _frozen_allocated = 0;
+  _active_reserved = _active_allocated = 0;
+  this->destroy_frozen();
+  this->destroy_active();
+
+  return *this;
+}
+
+MemArena::~MemArena()
+{
+  // Destruct in a way that makes it safe for the instance to be in one of its own memory blocks.
+  Block *ba = _active.head();
+  Block *bf = _frozen.head();
+  _active.clear();
+  _frozen.clear();
+  while (bf) {
+    Block *b = bf;
+    bf       = bf->_link._next;
+    delete b;
+  }
+  while (ba) {
+    Block *b = ba;
+    ba       = ba->_link._next;
+    delete b;
+  }
+}

--- a/lib/swoc++/src/TextView.cc
+++ b/lib/swoc++/src/TextView.cc
@@ -1,0 +1,165 @@
+/** @file
+
+    Class for handling "views" of a buffer. Views presume the memory for the
+    buffer is managed elsewhere and allow efficient access to segments of the
+    buffer without copies. Views are read only as the view doesn't own the
+    memory. Along with generic buffer methods are specialized methods to support
+    better string parsing, particularly token based parsing.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with this
+    work for additional information regarding copyright ownership.  The ASF
+    licenses this file to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations under
+    the License.
+*/
+#include "swoc/TextView.h"
+#include <cctype>
+#include <sstream>
+
+int
+swoc::memcmp(TextView const &lhs, TextView const &rhs)
+{
+  int zret;
+  size_t n;
+
+  // Seems a bit ugly but size comparisons must be done anyway to get the memcmp args.
+  if (lhs.size() < rhs.size()) {
+    zret = 1, n = lhs.size();
+  } else {
+    n    = rhs.size();
+    zret = rhs.size() < lhs.size() ? -1 : 0;
+  }
+
+  int r = ::memcmp(lhs.data(), rhs.data(), n);
+  if (0 != r) { // If we got a not-equal, override the size based result.
+    zret = r;
+  }
+
+  return zret;
+}
+
+int
+strcasecmp(const std::string_view &lhs, const std::string_view &rhs)
+{
+  size_t len = std::min(lhs.size(), rhs.size());
+  int zret   = strncasecmp(lhs.data(), rhs.data(), len);
+  if (0 == zret) {
+    if (lhs.size() < rhs.size()) {
+      zret = -1;
+    } else if (lhs.size() > rhs.size()) {
+      zret = 1;
+    }
+  }
+  return zret;
+}
+
+const int8_t swoc::svtoi_convert[256] = {
+  /* [can't do this nicely because clang format won't allow exdented comments]
+   0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+  */
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 00
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 10
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 20
+  0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  -1, -1, -1, -1, -1, -1, // 30
+  -1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, // 40
+  25, 26, 27, 28, 20, 30, 31, 32, 33, 34, 35, -1, -1, -1, -1, -1, // 50
+  -1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, // 60
+  25, 26, 27, 28, 20, 30, 31, 32, 33, 34, 35, -1, -1, -1, -1, -1, // 70
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 80
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 90
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // A0
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // B0
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // C0
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // D0
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // E0
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // F0
+};
+
+intmax_t
+swoc::svtoi(TextView src, TextView *out, int base)
+{
+  intmax_t zret = 0;
+
+  if (out) {
+    out->clear();
+  }
+  if (!(0 <= base && base <= 36)) {
+    return 0;
+  }
+  if (src.ltrim_if(&isspace) && src) {
+    const char *start = src.data();
+    int8_t v;
+    bool neg = false;
+    if ('-' == *src) {
+      ++src;
+      neg = true;
+    }
+    // If base is 0, it wasn't specified - check for standard base prefixes
+    if (0 == base) {
+      base = 10;
+      if ('0' == *src) {
+        ++src;
+        base = 8;
+        if (src && ('x' == *src || 'X' == *src)) {
+          ++src;
+          base = 16;
+        }
+      }
+    }
+
+    // For performance in common cases, use the templated conversion.
+    switch (base) {
+    case 8:
+      zret = svto_radix<8>(src);
+      break;
+    case 10:
+      zret = svto_radix<10>(src);
+      break;
+    case 16:
+      zret = svto_radix<16>(src);
+      break;
+    default:
+      while (src.size() && (0 <= (v = svtoi_convert[static_cast<unsigned char>(*src)])) && v < base) {
+        zret = zret * base + v;
+        ++src;
+      }
+      break;
+    }
+
+    if (out && (src.data() > (neg ? start + 1 : start))) {
+      out->assign(start, src.data());
+    }
+
+    if (neg) {
+      zret = -zret;
+    }
+  }
+  return zret;
+}
+
+// Do the template instantions.
+template std::ostream &swoc::TextView::stream_write(std::ostream &, const swoc::TextView &) const;
+
+namespace std
+{
+ostream &
+operator<<(ostream &os, const swoc::TextView &b)
+{
+  if (os.good()) {
+    b.stream_write<ostream>(os, b);
+    os.width(0);
+  }
+  return os;
+}
+} // namespace std

--- a/lib/swoc++/src/bw_format.cc
+++ b/lib/swoc++/src/bw_format.cc
@@ -1,0 +1,1113 @@
+/** @file
+
+    Formatted output for BufferWriter.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#include <array>
+#include <cctype>
+#include <chrono>
+#include <cmath>
+#include <ctime>
+#include <sys/param.h>
+#include <unistd.h>
+
+#include "swoc/BufferWriter.h"
+#include "swoc/bwf_base.h"
+#include "swoc/bwf_ex.h"
+#include "swoc/bwf_printf.h"
+#include "swoc/swoc_meta.h"
+
+using namespace std::literals;
+
+swoc::bwf::GlobalNames swoc::bwf::Global_Names;
+
+namespace
+{
+// Customized version of string to int. Using this instead of the general @c svtoi function made @c
+// bwprint performance test run in < 30% of the time, changing it from about 2.5 times slower than
+// snprintf to a little faster. This version handles only positive integers in decimal.
+
+inline unsigned
+radix10(swoc::TextView src, swoc::TextView &out)
+{
+  unsigned zret = 0;
+
+  out.clear();
+  src.ltrim_if(&isspace);
+  if (src.size()) {
+    auto start = src.data();
+    zret       = swoc::svto_radix<10>(src);
+    if (start != src.data()) {
+      out.assign(start, src.data());
+    }
+  }
+  return zret;
+}
+} // namespace
+
+namespace swoc
+{
+namespace bwf
+{
+  const Spec Spec::DEFAULT;
+
+  const Spec::Property Spec::_prop;
+
+#pragma GCC diagnostic ignored "-Wchar-subscripts"
+  Spec::Property::Property()
+  {
+    memset(_data, 0, sizeof(_data));
+    _data['b'] = TYPE_CHAR | NUMERIC_TYPE_CHAR;
+    _data['B'] = TYPE_CHAR | NUMERIC_TYPE_CHAR | UPPER_TYPE_CHAR;
+    _data['d'] = TYPE_CHAR | NUMERIC_TYPE_CHAR;
+    _data['g'] = TYPE_CHAR;
+    _data['o'] = TYPE_CHAR | NUMERIC_TYPE_CHAR;
+    _data['p'] = TYPE_CHAR;
+    _data['P'] = TYPE_CHAR | UPPER_TYPE_CHAR;
+    _data['s'] = TYPE_CHAR;
+    _data['S'] = TYPE_CHAR | UPPER_TYPE_CHAR;
+    _data['x'] = TYPE_CHAR | NUMERIC_TYPE_CHAR;
+    _data['X'] = TYPE_CHAR | NUMERIC_TYPE_CHAR | UPPER_TYPE_CHAR;
+
+    _data[SIGN_NEVER]  = SIGN_CHAR;
+    _data[SIGN_NEG]    = SIGN_CHAR;
+    _data[SIGN_ALWAYS] = SIGN_CHAR;
+
+    _data['<'] = static_cast<uint8_t>(Spec::Align::LEFT);
+    _data['>'] = static_cast<uint8_t>(Spec::Align::RIGHT);
+    _data['^'] = static_cast<uint8_t>(Spec::Align::CENTER);
+    _data['='] = static_cast<uint8_t>(Spec::Align::SIGN);
+  }
+
+  Spec::Spec(const TextView &fmt) { this->parse(fmt); }
+  /// Parse a format specification.
+  bool
+  Spec::parse(TextView fmt)
+  {
+    TextView num; // temporary for number parsing.
+    intmax_t n;
+
+    _name = fmt.take_prefix_at(':');
+    // if it's parsable as a number, treat it as an index.
+    n = radix10(_name, num);
+    if (num.size() == _name.size()) {
+      _idx = static_cast<decltype(_idx)>(n);
+    }
+
+    if (fmt.size()) {
+      TextView sz = fmt.take_prefix_at(':'); // the format specifier.
+      _ext        = fmt;                     // anything past the second ':' is the extension.
+      if (sz.size()) {
+        // fill and alignment
+        if ('%' == *sz) { // enable URI encoding of the fill character so
+                          // metasyntactic chars can be used if needed.
+          if (sz.size() < 4) {
+            throw std::invalid_argument("Fill URI encoding without 2 hex characters and align mark");
+          }
+          if (Align::NONE == (_align = align_of(sz[3]))) {
+            throw std::invalid_argument("Fill URI without alignment mark");
+          }
+          char d1 = sz[1], d0 = sz[2];
+          if (!isxdigit(d0) || !isxdigit(d1)) {
+            throw std::invalid_argument("URI encoding with non-hex characters");
+          }
+          _fill = isdigit(d0) ? d0 - '0' : tolower(d0) - 'a' + 10;
+          _fill += (isdigit(d1) ? d1 - '0' : tolower(d1) - 'a' + 10) << 4;
+          sz += 4;
+        } else if (sz.size() > 1 && Align::NONE != (_align = align_of(sz[1]))) {
+          _fill = *sz;
+          sz += 2;
+        } else if (Align::NONE != (_align = align_of(*sz))) {
+          ++sz;
+        }
+        if (!sz.size()) {
+          return true;
+        }
+        // sign
+        if (is_sign(*sz)) {
+          _sign = *sz;
+          if (!(++sz).size()) {
+            return true;
+          }
+        }
+        // radix prefix
+        if ('#' == *sz) {
+          _radix_lead_p = true;
+          if (!(++sz).size()) {
+            return true;
+          }
+        }
+        // 0 fill for integers
+        if ('0' == *sz) {
+          if (Align::NONE == _align) {
+            _align = Align::SIGN;
+          }
+          _fill = '0';
+          ++sz;
+        }
+        n = radix10(sz, num);
+        if (num.size()) {
+          _min = static_cast<decltype(_min)>(n);
+          sz.remove_prefix(num.size());
+          if (!sz.size()) {
+            return true;
+          }
+        }
+        // precision
+        if ('.' == *sz) {
+          n = radix10(++sz, num);
+          if (num.size()) {
+            _prec = static_cast<decltype(_prec)>(n);
+            sz.remove_prefix(num.size());
+            if (!sz.size()) {
+              return true;
+            }
+          } else {
+            throw std::invalid_argument("Precision mark without precision");
+          }
+        }
+        // style (type). Hex, octal, etc.
+        if (is_type(*sz)) {
+          _type = *sz;
+          if (!(++sz).size()) {
+            return true;
+          }
+        }
+        // maximum width
+        if (',' == *sz) {
+          n = radix10(++sz, num);
+          if (num.size()) {
+            _max = static_cast<decltype(_max)>(n);
+            sz.remove_prefix(num.size());
+            if (!sz.size()) {
+              return true;
+            }
+          } else {
+            throw std::invalid_argument("Maximum width mark without width");
+          }
+          // Can only have a type indicator here if there was a max width.
+          if (is_type(*sz)) {
+            _type = *sz;
+            if (!(++sz).size()) {
+              return true;
+            }
+          }
+        }
+      }
+    }
+    return true;
+  }
+
+  /// Parse out the next literal and/or format specifier from the format string.
+  /// Pass the results back in @a literal and @a specifier as appropriate.
+  /// Update @a fmt to strip the parsed text.
+  /// @return @c true if a specifier was parsed, @c false if not.
+  bool
+  Format::TextViewExtractor::parse(TextView &fmt, std::string_view &literal, std::string_view &specifier)
+  {
+    TextView::size_type off;
+
+    // Check for brace delimiters.
+    off = fmt.find_if([](char c) { return '{' == c || '}' == c; });
+    if (off == TextView::npos) {
+      // not found, it's a literal, ship it.
+      literal = fmt;
+      fmt.remove_prefix(literal.size());
+      return false;
+    }
+
+    // Processing for braces that don't enclose specifiers.
+    if (fmt.size() > off + 1) {
+      char c1 = fmt[off];
+      char c2 = fmt[off + 1];
+      if (c1 == c2) {
+        // double braces count as literals, but must tweak to output only 1 brace.
+        literal = fmt.take_prefix_at(off + 1);
+        return false;
+      } else if ('}' == c1) {
+        throw std::invalid_argument("Unopened } in format string.");
+      } else {
+        literal = std::string_view{fmt.data(), off};
+        fmt.remove_prefix(off + 1);
+      }
+    } else {
+      throw std::invalid_argument("Invalid trailing character in format string.");
+    }
+
+    if (fmt.size()) {
+      // Need to be careful, because an empty format is OK and it's hard to tell
+      // if take_prefix_at failed to find the delimiter or found it as the first
+      // byte.
+      off = fmt.find('}');
+      if (off == TextView::npos) {
+        throw std::invalid_argument("BWFormat: Unclosed { in format string");
+      }
+      specifier = fmt.take_prefix_at(off);
+      return true;
+    }
+    return false;
+  }
+
+  bool
+  Format::TextViewExtractor::operator()(std::string_view &literal_v, Spec &spec)
+  {
+    if (!_fmt.empty()) {
+      std::string_view spec_v;
+      if (parse(_fmt, literal_v, spec_v)) {
+        return spec.parse(spec_v);
+      }
+    }
+    return false;
+  }
+
+  bool
+  Format::FormatExtractor::operator()(std::string_view &literal_v, swoc::bwf::Spec &spec)
+  {
+    literal_v = {};
+    if (_idx < int(_fmt.size()) && _fmt[_idx]._type == Spec::LITERAL_TYPE) {
+      literal_v = _fmt[_idx++]._ext;
+    }
+    if (_idx < int(_fmt.size()) && _fmt[_idx]._type != Spec::LITERAL_TYPE) {
+      spec = _fmt[_idx++];
+      return true;
+    }
+    return false;
+  }
+
+  void
+  Err_Bad_Arg_Index(BufferWriter &w, int i, size_t n)
+  {
+    static const Format fmt{"{{BAD_ARG_INDEX:{} of {}}}"sv};
+    w.print(fmt, i, n);
+  }
+
+  /** This performs generic alignment operations.
+
+     If a formatter specialization performs this operation instead, that should
+     result in output that is at least @a spec._min characters wide, which will
+     cause this function to make no further adjustments.
+   */
+  void
+  Adjust_Alignment(BufferWriter &aux, Spec const &spec)
+  {
+    size_t extent = aux.extent();
+    size_t min    = spec._min;
+    if (extent < min) {
+      size_t delta      = min - extent;
+      size_t left_delta = 0, right_delta = delta; // left justify values
+      if (Spec::Align::RIGHT == spec._align) {
+        left_delta  = delta;
+        right_delta = 0;
+      } else if (Spec::Align::CENTER == spec._align) {
+        left_delta  = delta / 2;
+        right_delta = (delta + 1) / 2;
+      }
+      if (left_delta > 0) {
+        size_t work_area = extent + left_delta;
+        aux.commit(left_delta);          // cover work area.
+        aux.copy(left_delta, 0, extent); // move to create space for left fill.
+        aux.discard(work_area);          // roll back to write the left fill.
+        for (int i = left_delta; i > 0; --i) {
+          aux.write(spec._fill);
+        }
+        aux.commit(extent);
+      }
+      for (int i = right_delta; i > 0; --i) {
+        aux.write(spec._fill);
+      }
+
+    } else {
+      size_t max = spec._max;
+      if (max < extent) {
+        aux.discard(extent - max);
+      }
+    }
+  }
+
+  // Conversions from remainder to character, in upper and lower case versions.
+  // Really only useful for hexadecimal currently.
+  namespace
+  {
+    char UPPER_DIGITS[]                                 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    char LOWER_DIGITS[]                                 = "0123456789abcdefghijklmnopqrstuvwxyz";
+    static const std::array<uint64_t, 11> POWERS_OF_TEN = {
+      {1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000, 10000000000}};
+  } // namespace
+
+  /// Templated radix based conversions. Only a small number of radix are
+  /// supported and providing a template minimizes cut and paste code while also
+  /// enabling compiler optimizations (e.g. for power of 2 radix the modulo /
+  /// divide become bit operations).
+  template <size_t RADIX>
+  size_t
+  To_Radix(uintmax_t n, char *buff, size_t width, char *digits)
+  {
+    static_assert(1 < RADIX && RADIX <= 36, "RADIX must be in the range 2..36");
+    char *out = buff + width;
+    if (n) {
+      while (n) {
+        *--out = digits[n % RADIX];
+        n /= RADIX;
+      }
+    } else {
+      *--out = '0';
+    }
+    return (buff + width) - out;
+  }
+
+  template <typename F>
+  void
+  Write_Aligned(BufferWriter &w, F const &f, Spec::Align align, int width, char fill, char neg)
+  {
+    switch (align) {
+    case Spec::Align::LEFT:
+      if (neg) {
+        w.write(neg);
+      }
+      f();
+      while (width-- > 0) {
+        w.write(fill);
+      }
+      break;
+    case Spec::Align::RIGHT:
+      while (width-- > 0) {
+        w.write(fill);
+      }
+      if (neg) {
+        w.write(neg);
+      }
+      f();
+      break;
+    case Spec::Align::CENTER:
+      for (int i = width / 2; i > 0; --i) {
+        w.write(fill);
+      }
+      if (neg) {
+        w.write(neg);
+      }
+      f();
+      for (int i = (width + 1) / 2; i > 0; --i) {
+        w.write(fill);
+      }
+      break;
+    case Spec::Align::SIGN:
+      if (neg) {
+        w.write(neg);
+      }
+      while (width-- > 0) {
+        w.write(fill);
+      }
+      f();
+      break;
+    default:
+      if (neg) {
+        w.write(neg);
+      }
+      f();
+      break;
+    }
+  }
+
+  BufferWriter &
+  Format_Integer(BufferWriter &w, Spec const &spec, uintmax_t i, bool neg_p)
+  {
+    size_t n     = 0;
+    int width    = static_cast<int>(spec._min); // amount left to fill.
+    char neg     = 0;
+    char prefix1 = spec._radix_lead_p ? '0' : 0;
+    char prefix2 = 0;
+    char buff[std::numeric_limits<uintmax_t>::digits + 1];
+
+    if (spec._sign != Spec::SIGN_NEVER) {
+      if (neg_p) {
+        neg = '-';
+      } else if (spec._sign == Spec::SIGN_ALWAYS) {
+        neg = spec._sign;
+      }
+    }
+
+    switch (spec._type) {
+    case 'x':
+      prefix2 = 'x';
+      n       = bwf::To_Radix<16>(i, buff, sizeof(buff), bwf::LOWER_DIGITS);
+      break;
+    case 'X':
+      prefix2 = 'X';
+      n       = bwf::To_Radix<16>(i, buff, sizeof(buff), bwf::UPPER_DIGITS);
+      break;
+    case 'b':
+      prefix2 = 'b';
+      n       = bwf::To_Radix<2>(i, buff, sizeof(buff), bwf::LOWER_DIGITS);
+      break;
+    case 'B':
+      prefix2 = 'B';
+      n       = bwf::To_Radix<2>(i, buff, sizeof(buff), bwf::UPPER_DIGITS);
+      break;
+    case 'o':
+      n = bwf::To_Radix<8>(i, buff, sizeof(buff), bwf::LOWER_DIGITS);
+      break;
+    default:
+      prefix1 = 0;
+      n       = bwf::To_Radix<10>(i, buff, sizeof(buff), bwf::LOWER_DIGITS);
+      break;
+    }
+    // Clip fill width by stuff that's already committed to be written.
+    if (neg) {
+      --width;
+    }
+    if (prefix1) {
+      --width;
+      if (prefix2) {
+        --width;
+      }
+    }
+    width -= static_cast<int>(n);
+    std::string_view digits{buff + sizeof(buff) - n, n};
+
+    if (spec._align == Spec::Align::SIGN) { // custom for signed case because
+                                            // prefix and digits are seperated.
+      if (neg) {
+        w.write(neg);
+      }
+      if (prefix1) {
+        w.write(prefix1);
+        if (prefix2) {
+          w.write(prefix2);
+        }
+      }
+      while (width-- > 0) {
+        w.write(spec._fill);
+      }
+      w.write(digits);
+    } else { // use generic Write_Aligned
+      Write_Aligned(w,
+                    [&]() {
+                      if (prefix1) {
+                        w.write(prefix1);
+                        if (prefix2) {
+                          w.write(prefix2);
+                        }
+                      }
+                      w.write(digits);
+                    },
+                    spec._align, width, spec._fill, neg);
+    }
+    return w;
+  }
+
+  /// Format for floating point values. Seperates floating point into a whole
+  /// number and a fraction. The fraction is converted into an unsigned integer
+  /// based on the specified precision, spec._prec. ie. 3.1415 with precision two
+  /// is seperated into two unsigned integers 3 and 14. The different pieces are
+  /// assembled and placed into the BufferWriter. The default is two decimal
+  /// places. ie. X.XX. The value is always written in base 10.
+  ///
+  /// format: whole.fraction
+  ///     or: left.right
+  BufferWriter &
+  Format_Float(BufferWriter &w, Spec const &spec, double f, bool neg_p)
+  {
+    static const std::string_view infinity_bwf{"Inf"};
+    static const std::string_view nan_bwf{"NaN"};
+    static const std::string_view zero_bwf{"0"};
+    static const std::string_view subnormal_bwf{"subnormal"};
+    static const std::string_view unknown_bwf{"unknown float"};
+
+    // Handle floating values that are not normal
+    if (!std::isnormal(f)) {
+      std::string_view unnormal;
+      switch (std::fpclassify(f)) {
+      case FP_INFINITE:
+        unnormal = infinity_bwf;
+        break;
+      case FP_NAN:
+        unnormal = nan_bwf;
+        break;
+      case FP_ZERO:
+        unnormal = zero_bwf;
+        break;
+      case FP_SUBNORMAL:
+        unnormal = subnormal_bwf;
+        break;
+      default:
+        unnormal = unknown_bwf;
+      }
+
+      w.write(unnormal);
+      return w;
+    }
+
+    uint64_t whole_part = static_cast<uint64_t>(f);
+    if (whole_part == f || spec._prec == 0) { // integral
+      return Format_Integer(w, spec, whole_part, neg_p);
+    }
+
+    static constexpr char dec = '.';
+    double frac;
+    size_t l = 0;
+    size_t r = 0;
+    char whole[std::numeric_limits<double>::digits10 + 1];
+    char fraction[std::numeric_limits<double>::digits10 + 1];
+    char neg               = 0;
+    int width              = static_cast<int>(spec._min);                          // amount left to fill.
+    unsigned int precision = (spec._prec == Spec::DEFAULT._prec) ? 2 : spec._prec; // default precision 2
+
+    frac = f - whole_part; // split the number
+
+    if (neg_p) {
+      neg = '-';
+    } else if (spec._sign != '-') {
+      neg = spec._sign;
+    }
+
+    // Shift the floating point based on the precision. Used to convert
+    //  trailing fraction into an integer value.
+    uint64_t shift;
+    if (precision < POWERS_OF_TEN.size()) {
+      shift = POWERS_OF_TEN[precision];
+    } else { // not precomputed.
+      shift = POWERS_OF_TEN.back();
+      for (precision -= (POWERS_OF_TEN.size() - 1); precision > 0; --precision) {
+        shift *= 10;
+      }
+    }
+
+    uint64_t frac_part = static_cast<uint64_t>(frac * shift + 0.5 /* rounding */);
+
+    l = bwf::To_Radix<10>(whole_part, whole, sizeof(whole), bwf::LOWER_DIGITS);
+    r = bwf::To_Radix<10>(frac_part, fraction, sizeof(fraction), bwf::LOWER_DIGITS);
+
+    // Clip fill width
+    if (neg) {
+      --width;
+    }
+    width -= static_cast<int>(l);
+    --width; // '.'
+    width -= static_cast<int>(r);
+
+    std::string_view whole_digits{whole + sizeof(whole) - l, l};
+    std::string_view frac_digits{fraction + sizeof(fraction) - r, r};
+
+    Write_Aligned(w,
+                  [&]() {
+                    w.write(whole_digits);
+                    w.write(dec);
+                    w.write(frac_digits);
+                  },
+                  spec._align, width, spec._fill, neg);
+
+    return w;
+  }
+
+  /// Write out the @a data as hexadecimal, using @a digits as the conversion.
+  void
+  Hex_Dump(BufferWriter &w, std::string_view data, const char *digits)
+  {
+    const char *ptr = data.data();
+    for (auto n = data.size(); n > 0; --n) {
+      char c = *ptr++;
+      w.write(digits[(c >> 4) & 0xF]);
+      w.write(digits[c & 0xf]);
+    }
+  }
+
+  /// Preparse format string for later use.
+  Format::Format(TextView fmt)
+  {
+    Spec lit_spec;
+    int arg_idx = 0;
+    auto ex{bind(fmt)};
+    std::string_view literal_v;
+
+    lit_spec._type = Spec::LITERAL_TYPE;
+
+    while (ex) {
+      Spec spec;
+      bool spec_p = ex(literal_v, spec);
+
+      if (literal_v.size()) {
+        lit_spec._ext = literal_v;
+        _items.emplace_back(lit_spec);
+      }
+
+      if (spec_p) {
+        if (spec._name.size() == 0) { // no name provided, use implicit index.
+          spec._idx = arg_idx++;
+        }
+        if (spec._idx >= 0) {
+          ++arg_idx;
+        }
+        _items.emplace_back(spec);
+      }
+    }
+  }
+
+  BoundNames::~BoundNames() {}
+} // namespace bwf
+
+BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &spec, std::string_view sv)
+{
+  int width = static_cast<int>(spec._min); // amount left to fill.
+  if (spec._prec > 0) {
+    sv = sv.substr(0, spec._prec);
+  }
+
+  if ('x' == spec._type || 'X' == spec._type) {
+    const char *digits = 'x' == spec._type ? bwf::LOWER_DIGITS : bwf::UPPER_DIGITS;
+    width -= sv.size() * 2;
+    if (spec._radix_lead_p) {
+      w.write('0');
+      w.write(spec._type);
+      width -= 2;
+    }
+    bwf::Write_Aligned(w, [&w, &sv, digits]() { bwf::Hex_Dump(w, sv, digits); }, spec._align, width, spec._fill, 0);
+  } else {
+    width -= sv.size();
+    bwf::Write_Aligned(w, [&w, &sv]() { w.write(sv); }, spec._align, width, spec._fill, 0);
+  }
+  return w;
+}
+
+BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &spec, MemSpan<void> const &span)
+{
+  if (spec._ext.size() && 'd' == spec._ext.front()) {
+    const char *digits = 'X' == spec._type ? bwf::UPPER_DIGITS : bwf::LOWER_DIGITS;
+    size_t block       = spec._prec > 0 ? spec._prec : span.size();
+    TextView view{span.view()};
+    bool space_p = false;
+    while (view) {
+      if (space_p)
+        w.write(' ');
+      space_p = true;
+      if (spec._radix_lead_p) {
+        w.write('0');
+        w.write(digits[33]);
+      }
+      bwf::Hex_Dump(w, view.prefix(block), digits);
+      view.remove_prefix(block);
+    }
+  } else {
+    static const bwf::Format default_fmt{"{:#x}@{:p}"};
+    w.print(default_fmt, span.size(), span.data());
+  }
+  return w;
+}
+
+std::ostream &
+FixedBufferWriter::operator>>(std::ostream &s) const
+{
+  return s << this->view();
+}
+
+BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::Errno const &e)
+{
+  // Hand rolled, might not be totally compliant everywhere, but probably close
+  // enough. The long string will be locally accurate. Clang requires the double
+  // braces. Why, Turing only knows.
+  static const std::array<std::string_view, 134> SHORT_NAME = {{
+    "SUCCESS: ",
+    "EPERM: ",
+    "ENOENT: ",
+    "ESRCH: ",
+    "EINTR: ",
+    "EIO: ",
+    "ENXIO: ",
+    "E2BIG ",
+    "ENOEXEC: ",
+    "EBADF: ",
+    "ECHILD: ",
+    "EAGAIN: ",
+    "ENOMEM: ",
+    "EACCES: ",
+    "EFAULT: ",
+    "ENOTBLK: ",
+    "EBUSY: ",
+    "EEXIST: ",
+    "EXDEV: ",
+    "ENODEV: ",
+    "ENOTDIR: ",
+    "EISDIR: ",
+    "EINVAL: ",
+    "ENFILE: ",
+    "EMFILE: ",
+    "ENOTTY: ",
+    "ETXTBSY: ",
+    "EFBIG: ",
+    "ENOSPC: ",
+    "ESPIPE: ",
+    "EROFS: ",
+    "EMLINK: ",
+    "EPIPE: ",
+    "EDOM: ",
+    "ERANGE: ",
+    "EDEADLK: ",
+    "ENAMETOOLONG: ",
+    "ENOLCK: ",
+    "ENOSYS: ",
+    "ENOTEMPTY: ",
+    "ELOOP: ",
+    "EWOULDBLOCK: ",
+    "ENOMSG: ",
+    "EIDRM: ",
+    "ECHRNG: ",
+    "EL2NSYNC: ",
+    "EL3HLT: ",
+    "EL3RST: ",
+    "ELNRNG: ",
+    "EUNATCH: ",
+    "ENOCSI: ",
+    "EL2HTL: ",
+    "EBADE: ",
+    "EBADR: ",
+    "EXFULL: ",
+    "ENOANO: ",
+    "EBADRQC: ",
+    "EBADSLT: ",
+    "EDEADLOCK: ",
+    "EBFONT: ",
+    "ENOSTR: ",
+    "ENODATA: ",
+    "ETIME: ",
+    "ENOSR: ",
+    "ENONET: ",
+    "ENOPKG: ",
+    "EREMOTE: ",
+    "ENOLINK: ",
+    "EADV: ",
+    "ESRMNT: ",
+    "ECOMM: ",
+    "EPROTO: ",
+    "EMULTIHOP: ",
+    "EDOTDOT: ",
+    "EBADMSG: ",
+    "EOVERFLOW: ",
+    "ENOTUNIQ: ",
+    "EBADFD: ",
+    "EREMCHG: ",
+    "ELIBACC: ",
+    "ELIBBAD: ",
+    "ELIBSCN: ",
+    "ELIBMAX: ",
+    "ELIBEXEC: ",
+    "EILSEQ: ",
+    "ERESTART: ",
+    "ESTRPIPE: ",
+    "EUSERS: ",
+    "ENOTSOCK: ",
+    "EDESTADDRREQ: ",
+    "EMSGSIZE: ",
+    "EPROTOTYPE: ",
+    "ENOPROTOOPT: ",
+    "EPROTONOSUPPORT: ",
+    "ESOCKTNOSUPPORT: ",
+    "EOPNOTSUPP: ",
+    "EPFNOSUPPORT: ",
+    "EAFNOSUPPORT: ",
+    "EADDRINUSE: ",
+    "EADDRNOTAVAIL: ",
+    "ENETDOWN: ",
+    "ENETUNREACH: ",
+    "ENETRESET: ",
+    "ECONNABORTED: ",
+    "ECONNRESET: ",
+    "ENOBUFS: ",
+    "EISCONN: ",
+    "ENOTCONN: ",
+    "ESHUTDOWN: ",
+    "ETOOMANYREFS: ",
+    "ETIMEDOUT: ",
+    "ECONNREFUSED: ",
+    "EHOSTDOWN: ",
+    "EHOSTUNREACH: ",
+    "EALREADY: ",
+    "EINPROGRESS: ",
+    "ESTALE: ",
+    "EUCLEAN: ",
+    "ENOTNAM: ",
+    "ENAVAIL: ",
+    "EISNAM: ",
+    "EREMOTEIO: ",
+    "EDQUOT: ",
+    "ENOMEDIUM: ",
+    "EMEDIUMTYPE: ",
+    "ECANCELED: ",
+    "ENOKEY: ",
+    "EKEYEXPIRED: ",
+    "EKEYREVOKED: ",
+    "EKEYREJECTED: ",
+    "EOWNERDEAD: ",
+    "ENOTRECOVERABLE: ",
+    "ERFKILL: ",
+    "EHWPOISON: ",
+  }};
+  // This provides convenient safe access to the errno short name array.
+  auto short_name = [](int n) { return n < int(SHORT_NAME.size()) ? SHORT_NAME[n] : "Unknown: "sv; };
+  static const bwf::Format number_fmt{"[{}]"sv}; // numeric value format.
+  if (spec.has_numeric_type()) {                 // if numeric type, print just the numeric
+                                                 // part.
+    w.print(number_fmt, e._e);
+  } else {
+    w.write(short_name(e._e));
+    w.write(strerror(e._e));
+    if (spec._type != 's' && spec._type != 'S') {
+      w.write(' ');
+      w.print(number_fmt, e._e);
+    }
+  }
+  return w;
+}
+
+bwf::Date::Date(std::string_view fmt) : _epoch(std::chrono::system_clock::to_time_t(std::chrono::system_clock::now())), _fmt(fmt) {}
+
+BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::Date const &date)
+{
+  if (spec.has_numeric_type()) {
+    bwformat(w, spec, date._epoch);
+  } else {
+    struct tm t;
+    auto r = w.remaining();
+    size_t n{0};
+    // Verify @a fmt is null terminated, even outside the bounds of the view.
+    if (date._fmt.data()[date._fmt.size() - 1] != 0 && date._fmt.data()[date._fmt.size()] != 0) {
+      throw(std::invalid_argument{"BWF Date String is not null terminated."});
+    }
+    // Get the time, GMT or local if specified.
+    if (spec._ext == "local"sv) {
+      localtime_r(&date._epoch, &t);
+    } else {
+      gmtime_r(&date._epoch, &t);
+    }
+    // Try a direct write, faster if it works.
+    if (r > 0) {
+      n = strftime(w.aux_data(), r, date._fmt.data(), &t);
+    }
+    if (n > 0) {
+      w.commit(n);
+    } else {
+      // Direct write didn't work. Unfortunately need to write to a temporary
+      // buffer or the sizing isn't correct if @a w is clipped because @c
+      // strftime returns 0 if the buffer isn't large enough.
+      char buff[256]; // hope for the best - no real way to resize appropriately on failure.
+      n = strftime(buff, sizeof(buff), date._fmt.data(), &t);
+      w.write(buff, n);
+    }
+  }
+  return w;
+}
+
+BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::OptionalAffix const &opts)
+{
+  return w.write(opts._prefix).write(opts._text).write(opts._suffix);
+}
+
+BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::Pattern const &pattern)
+{
+  auto limit        = std::min<size_t>(spec._max, pattern._text.size() * pattern._n);
+  decltype(limit) n = 0;
+  while (n < limit) {
+    w.write(pattern._text);
+    n += pattern._text.size();
+  }
+  return w;
+}
+
+} // namespace swoc
+
+namespace std
+{
+ostream &
+operator<<(ostream &s, swoc::FixedBufferWriter &w)
+{
+  return s << w.view();
+}
+} // namespace std
+
+// --- C_Format / printf support ----
+
+namespace swoc
+{
+namespace bwf
+{
+  void
+  C_Format::capture(BufferWriter &w, Spec const &spec, std::any const &value)
+  {
+    unsigned v;
+    if (typeid(int *) == value.type())
+      v = static_cast<unsigned>(*std::any_cast<int *>(value));
+    else if (typeid(unsigned *) == value.type())
+      v = *std::any_cast<unsigned *>(value);
+    else if (typeid(size_t *) == value.type())
+      v = static_cast<unsigned>(*std::any_cast<size_t *>(value));
+    else
+      return;
+
+    if (spec._ext == "w")
+      _saved._min = v;
+    if (spec._ext == "p") {
+      _saved._prec = v;
+    }
+  }
+
+  bool
+  C_Format::operator()(std::string_view &literal, Spec &spec)
+  {
+    TextView parsed;
+
+    // clean up any old business from a previous specifier.
+    if (_prec_p) {
+      spec._type = Spec::CAPTURE_TYPE;
+      spec._ext  = "p";
+      _prec_p    = false;
+      return true;
+    } else if (_saved_p) {
+      spec     = _saved;
+      _saved_p = false;
+      return true;
+    }
+
+    if (!_fmt.empty()) {
+      bool width_p = false;
+      literal      = _fmt.take_prefix_at('%');
+      if (_fmt.empty()) {
+        return false;
+      }
+      if (!_fmt.empty()) {
+        if ('%' == *_fmt) {
+          literal = {literal.data(), literal.size() + 1};
+          ++_fmt;
+          return false;
+        }
+      }
+
+      spec._align = Spec::Align::RIGHT; // default unless overridden.
+      do {
+        char c = *_fmt;
+        if ('-' == c) {
+          spec._align = Spec::Align::LEFT;
+        } else if ('+' == c) {
+          spec._sign = Spec::SIGN_ALWAYS;
+        } else if (' ' == c) {
+          spec._sign = Spec::SIGN_NEVER;
+        } else if ('#' == c) {
+          spec._radix_lead_p = true;
+        } else if ('0' == c) {
+          spec._fill = '0';
+        } else {
+          break;
+        }
+        ++_fmt;
+      } while (!_fmt.empty());
+
+      if (_fmt.empty()) {
+        literal = TextView{literal.data(), _fmt.data()};
+        return false;
+      }
+
+      if ('*' == *_fmt) {
+        width_p = true; // signal need to capture width.
+        ++_fmt;
+      } else {
+        auto width = radix10(_fmt, parsed);
+        if (!parsed.empty()) {
+          spec._min = width;
+        }
+      }
+
+      if ('.' == *_fmt) {
+        ++_fmt;
+        if ('*' == *_fmt) {
+          _prec_p = true;
+          ++_fmt;
+        } else {
+          auto x = radix10(_fmt, parsed);
+          if (!parsed.empty()) {
+            spec._prec = x;
+          } else {
+            spec._prec = 0;
+          }
+        }
+      }
+
+      if (_fmt.empty()) {
+        literal = TextView{literal.data(), _fmt.data()};
+        return false;
+      }
+
+      char c = *_fmt++;
+      // strip length modifiers.
+      if ('l' == c || 'h' == c)
+        c = *_fmt++;
+      if ('l' == c || 'z' == c || 'j' == c || 't' == c || 'h' == c)
+        c = *_fmt++;
+
+      switch (c) {
+      case 'c':
+        spec._type = c;
+        break;
+      case 'i':
+      case 'd':
+      case 'j':
+      case 'z':
+        spec._type = 'd';
+        break;
+      case 'x':
+      case 'X':
+        spec._type = c;
+        break;
+      case 'f':
+        spec._type = 'f';
+        break;
+      case 's':
+        spec._type = 's';
+        break;
+      case 'p':
+        spec._type = c;
+        break;
+      default:
+        literal = TextView{literal.data(), _fmt.data()};
+        return false;
+      }
+      if (width_p || _prec_p) {
+        _saved_p = true;
+        _saved   = spec;
+        spec     = Spec::DEFAULT;
+        if (width_p) {
+          spec._type = Spec::CAPTURE_TYPE;
+          spec._ext  = "w";
+        } else if (_prec_p) {
+          _prec_p    = false;
+          spec._type = Spec::CAPTURE_TYPE;
+          spec._ext  = "p";
+        }
+      }
+      return true;
+    }
+    return false;
+  }
+
+} // namespace bwf
+} // namespace swoc

--- a/lib/swoc++/src/swoc_file.cc
+++ b/lib/swoc++/src/swoc_file.cc
@@ -1,0 +1,128 @@
+/** @file
+
+    Minimalist version of std::filesystem.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements.  See the NOTICE file distributed with this work for additional information regarding
+    copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with the License.  You may
+    obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#include "swoc/swoc_file.h"
+#include <fcntl.h>
+#include <unistd.h>
+
+namespace swoc
+{
+namespace file
+{
+  path &
+  path::operator/=(std::string_view that)
+  {
+    if (!that.empty()) { // don't waste time appending nothing.
+      if (that.front() == SEPARATOR || _path.empty()) {
+        _path.assign(that);
+      } else {
+        if (_path.back() == SEPARATOR) {
+          _path.reserve(_path.size() + that.size());
+        } else {
+          _path.reserve(_path.size() + that.size() + 1);
+          _path.push_back(SEPARATOR);
+        }
+        _path.append(that);
+      }
+    }
+    return *this;
+  }
+
+  file_status
+  status(const path &p, std::error_code &ec) noexcept
+  {
+    file_status zret;
+    if (::stat(p.c_str(), &zret._stat) >= 0) {
+      ec.clear();
+    } else {
+      ec = std::error_code(errno, std::system_category());
+    }
+    return zret;
+  }
+
+  int
+  file_type(const file_status &fs)
+  {
+    return fs._stat.st_mode & S_IFMT;
+  }
+
+  off_t
+  file_size(const file_status &fs)
+  {
+    return fs._stat.st_size;
+  }
+
+  bool
+  is_char_device(const file_status &fs)
+  {
+    return file_type(fs) == S_IFCHR;
+  }
+
+  bool
+  is_block_device(const file_status &fs)
+  {
+    return file_type(fs) == S_IFBLK;
+  }
+
+  bool
+  is_regular_file(const file_status &fs)
+  {
+    return file_type(fs) == S_IFREG;
+  }
+
+  bool
+  is_dir(const file_status &fs)
+  {
+    return file_type(fs) == S_IFDIR;
+  }
+
+  bool
+  is_readable(const path &p)
+  {
+    return 0 == access(p.c_str(), R_OK);
+  }
+
+  std::string
+  load(const path &p, std::error_code &ec)
+  {
+    std::string zret;
+    int fd(::open(p.c_str(), O_RDONLY));
+    ec.clear();
+    if (fd < 0) {
+      ec = std::error_code(errno, std::system_category());
+    } else {
+      struct stat info;
+      if (0 != ::fstat(fd, &info)) {
+        ec = std::error_code(errno, std::system_category());
+      } else {
+        int n = info.st_size;
+        zret.resize(n);
+        auto read_len = ::read(fd, const_cast<char *>(zret.data()), n);
+        if (read_len < n) {
+          ec = std::error_code(errno, std::system_category());
+        }
+      }
+    }
+    ::close(fd);
+    return zret;
+  }
+
+} // namespace file
+} // namespace swoc

--- a/lib/swoc++/src/unit_tests/test_BufferWriter.cc
+++ b/lib/swoc++/src/unit_tests/test_BufferWriter.cc
@@ -1,0 +1,306 @@
+/** @file
+
+    Unit tests for BufferWriter.h.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements.  See the NOTICE file distributed with this work for additional information regarding
+    copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with the License.  You may
+    obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#include <cstring>
+#include "swoc/BufferWriter.h"
+#include "swoc/ext/catch.hpp"
+
+namespace
+{
+std::string_view three[] = {"a", "", "bcd"};
+}
+
+TEST_CASE("BufferWriter::write(StringView)", "[BWWSV]")
+{
+  class X : public swoc::BufferWriter
+  {
+    size_t i, j;
+
+  public:
+    bool good;
+
+    X() : i(0), j(0), good(true) {}
+
+    X &
+    write(char c) override
+    {
+      while (j == three[i].size()) {
+        ++i;
+        j = 0;
+      }
+
+      if ((i >= 3) or (c != three[i][j])) {
+        good = false;
+      }
+
+      ++j;
+
+      return *this;
+    }
+
+    bool
+    error() const override
+    {
+      return false;
+    }
+
+    // Dummies.
+    const char *
+    data() const override
+    {
+      return nullptr;
+    }
+    size_t
+    capacity() const override
+    {
+      return 0;
+    }
+    size_t
+    extent() const override
+    {
+      return 0;
+    }
+    X &restrict(size_t) override { return *this; }
+    X &restore(size_t) override { return *this; }
+    X &commit(size_t) override { return *this; }
+    X &discard(size_t) override { return *this; }
+    X &copy(size_t, size_t, size_t) { return *this; }
+    std::ostream &
+    operator>>(std::ostream &stream) const override
+    {
+      return stream;
+    }
+  };
+
+  X x;
+
+  static_cast<swoc::BufferWriter &>(x).write(three[0]).write(three[1]).write(three[2]);
+
+  REQUIRE(x.good);
+}
+
+namespace
+{
+template <size_t N> using LBW = swoc::LocalBufferWriter<N>;
+}
+
+TEST_CASE("Minimal Local Buffer Writer", "[BWLM]")
+{
+  LBW<1> bw;
+
+  REQUIRE(!((bw.capacity() != 1) or (bw.size() != 0) or bw.error() or (bw.remaining() != 1)));
+
+  bw.write('#');
+
+  REQUIRE(!((bw.capacity() != 1) or (bw.size() != 1) or bw.error() or (bw.remaining() != 0)));
+
+  REQUIRE(bw.view() == "#");
+
+  bw.write('!');
+
+  REQUIRE(bw.error());
+
+  bw.discard(1);
+
+  REQUIRE(!((bw.capacity() != 1) or (bw.size() != 1) or bw.error() or (bw.remaining() != 0)));
+
+  REQUIRE(bw.view() == "#");
+}
+
+namespace
+{
+template <class BWType>
+bool
+twice(BWType &bw)
+{
+  if ((bw.capacity() != 20) or (bw.size() != 0) or bw.error() or (bw.remaining() != 20)) {
+    return false;
+  }
+
+  bw.write('T');
+
+  if ((bw.capacity() != 20) or (bw.size() != 1) or bw.error() or (bw.remaining() != 19)) {
+    return false;
+  }
+
+  if (bw.view() != "T") {
+    return false;
+  }
+
+  bw.write("he").write(' ').write("quick").write(' ').write("brown");
+
+  if ((bw.capacity() != 20) or bw.error() or (bw.remaining() != (21 - sizeof("The quick brown")))) {
+    return false;
+  }
+
+  if (bw.view() != "The quick brown") {
+    return false;
+  }
+
+  bw.clear();
+
+  bw << "The" << ' ' << "quick" << ' ' << "brown";
+
+  if ((bw.capacity() != 20) or bw.error() or (bw.remaining() != (21 - sizeof("The quick brown")))) {
+    return false;
+  }
+
+  if (bw.view() != "The quick brown") {
+    return false;
+  }
+
+  bw.clear();
+
+  bw.write("The", 3).write(' ').write("quick", 5).write(' ').write(std::string_view("brown", 5));
+
+  if ((bw.capacity() != 20) or bw.error() or (bw.remaining() != (21 - sizeof("The quick brown")))) {
+    return false;
+  }
+
+  if (bw.view() != "The quick brown") {
+    return false;
+  }
+
+  std::strcpy(bw.aux_buffer(), " fox");
+  bw.commit(sizeof(" fox") - 1);
+
+  if (bw.error()) {
+    return false;
+  }
+
+  if (bw.view() != "The quick brown fox") {
+    return false;
+  }
+
+  bw.write('x');
+
+  if (bw.error()) {
+    return false;
+  }
+
+  bw.write('x');
+
+  if (!bw.error()) {
+    return false;
+  }
+
+  bw.write('x');
+
+  if (!bw.error()) {
+    return false;
+  }
+
+  bw.reduce(0);
+
+  if (bw.error()) {
+    return false;
+  }
+
+  if (bw.view() != "The quick brown fox") {
+    return false;
+  }
+
+  bw.reduce(4);
+  bw.discard(bw.capacity() + 2 - (sizeof("The quick brown fox") - 1)).write(" fox");
+
+  if (bw.view() != "The quick brown f") {
+    return false;
+  }
+
+  if (!bw.error()) {
+    return false;
+  }
+
+  bw.restore(2).write("ox");
+
+  if (bw.error()) {
+    return false;
+  }
+
+  if (bw.view() != "The quick brown fox") {
+    return false;
+  }
+
+  return true;
+}
+
+} // end anonymous namespace
+
+TEST_CASE("Discard Buffer Writer", "[BWD]")
+{
+  char scratch[1] = {'!'};
+  swoc::FixedBufferWriter bw(scratch, 0);
+
+  REQUIRE(bw.size() == 0);
+  REQUIRE(bw.extent() == 0);
+
+  bw.write('T');
+
+  REQUIRE(bw.size() == 0);
+  REQUIRE(bw.extent() == 1);
+
+  bw.write("he").write(' ').write("quick").write(' ').write("brown");
+
+  REQUIRE(bw.size() == 0);
+  REQUIRE(bw.extent() == (sizeof("The quick brown") - 1));
+
+  bw.clear();
+
+  bw.write("The", 3).write(' ').write("quick", 5).write(' ').write(std::string_view("brown", 5));
+
+  REQUIRE(bw.size() == 0);
+  REQUIRE(bw.extent() == (sizeof("The quick brown") - 1));
+
+  bw.commit(sizeof(" fox") - 1);
+
+  REQUIRE(bw.size() == 0);
+  REQUIRE(bw.extent() == (sizeof("The quick brown fox") - 1));
+
+  bw.discard(0);
+
+  REQUIRE(bw.size() == 0);
+  REQUIRE(bw.extent() == (sizeof("The quick brown fox") - 1));
+
+  bw.discard(4);
+
+  REQUIRE(bw.size() == 0);
+  REQUIRE(bw.extent() == (sizeof("The quick brown") - 1));
+
+  // Make sure no actual writing.
+  //
+  REQUIRE(scratch[0] == '!');
+}
+
+TEST_CASE("LocalBufferWriter discard/restore", "[BWD]")
+{
+  swoc::LocalBufferWriter<10> bw;
+
+  bw.restrict(7);
+  bw.write("aaaaaa");
+  REQUIRE(bw.view() == "aaa");
+
+  bw.restore(3);
+  bw.write("bbbbbb");
+  REQUIRE(bw.view() == "aaabbb");
+
+  bw.restore(4);
+  bw.commit(static_cast<size_t>(snprintf(bw.aux_data(), bw.remaining(), "ccc")));
+  REQUIRE(bw.view() == "aaabbbccc");
+}

--- a/lib/swoc++/src/unit_tests/test_Errata.cc
+++ b/lib/swoc++/src/unit_tests/test_Errata.cc
@@ -1,0 +1,79 @@
+/** @file
+
+    Errata unit tests.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements.  See the NOTICE file distributed with this work for additional information regarding
+    copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with the License.  You may
+    obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "swoc/Errata.h"
+#include "swoc/ext/catch.hpp"
+
+using swoc::Errata;
+using namespace std::literals;
+
+Errata
+Noteworthy(std::string_view text)
+{
+  Errata notes;
+  notes.info(text);
+  return notes;
+}
+
+Errata
+cycle(Errata &erratum)
+{
+  erratum.info("Note well, young one!");
+  return erratum;
+}
+
+TEST_CASE("Errata copy", "[libswoc][Errata]")
+{
+  auto notes = Noteworthy("Evil Dave Rulz.");
+  REQUIRE(notes.count() == 1);
+  REQUIRE(notes.begin()->text() == "Evil Dave Rulz.");
+
+  notes = cycle(notes);
+  REQUIRE(notes.count() == 2);
+
+  Errata erratum;
+  erratum.clear();
+  REQUIRE(erratum.count() == 0);
+  erratum.diag("Diagnostics");
+  REQUIRE(erratum.count() == 1);
+  erratum.info("Information");
+  REQUIRE(erratum.count() == 2);
+  erratum.warn("Warning");
+  REQUIRE(erratum.count() == 3);
+  erratum.error("Error");
+  REQUIRE(erratum.count() == 4);
+
+  // Test internal allocation boundaries.
+  notes.clear();
+  std::string_view text{"0123456789012345678901234567890123456789"};
+  for (int i = 0; i < 50; ++i) {
+    notes.info(text);
+  }
+  REQUIRE(notes.count() == 50);
+  REQUIRE(notes.begin()->text() == text);
+  bool match_p = true;
+  for (auto &&note : notes) {
+    if (note.text() != text) {
+      match_p = false;
+      break;
+    }
+  }
+  REQUIRE(match_p);
+};

--- a/lib/swoc++/src/unit_tests/test_IntrusiveDList.cc
+++ b/lib/swoc++/src/unit_tests/test_IntrusiveDList.cc
@@ -1,0 +1,295 @@
+/** @file
+
+    IntrusiveDList unit tests.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements.  See the NOTICE file distributed with this work for additional information regarding
+    copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with the License.  You may
+    obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <iostream>
+#include <string_view>
+#include <string>
+#include <algorithm>
+
+#include "swoc/IntrusiveDList.h"
+#include "swoc/bwf_base.h"
+
+#include "swoc/ext/catch.hpp"
+
+using swoc::IntrusiveDList;
+
+// --------------------
+// Code for documentation - placed here to guarantee the examples at least compile.
+// First so that additional tests do not require updating the documentation source links.
+
+class Message
+{
+  using self_type = Message; ///< Self reference type.
+
+public:
+  // Message severity level.
+  enum Severity { LVL_DEBUG, LVL_INFO, LVL_WARN, LVL_ERROR };
+
+protected:
+  std::string _text; // Text of the message.
+  Severity _severity{LVL_DEBUG};
+  int _indent{0}; // indentation level for display.
+
+  // Intrusive list support.
+  struct Linkage {
+    static self_type *&next_ptr(self_type *); // Link accessor.
+    static self_type *&prev_ptr(self_type *); // Link accessor.
+
+    self_type *_next{nullptr}; // Forward link.
+    self_type *_prev{nullptr}; // Backward link.
+  } _link;
+
+  bool is_in_list() const;
+
+  friend class Container;
+};
+
+auto
+Message::Linkage::next_ptr(self_type *that) -> self_type *&
+{
+  return that->_link._next;
+}
+auto
+Message::Linkage::prev_ptr(self_type *that) -> self_type *&
+{
+  return that->_link._prev;
+}
+
+bool
+Message::is_in_list() const
+{
+  return _link._next || _link._prev;
+}
+
+class Container
+{
+  using self_type   = Container;
+  using MessageList = IntrusiveDList<Message::Linkage>;
+
+public:
+  ~Container();
+
+  template <typename... Args> self_type &debug(std::string_view fmt, Args &&... args);
+
+  size_t count() const;
+  self_type &clear();
+  Message::Severity max_severity() const;
+  void print() const;
+
+protected:
+  MessageList _msgs;
+};
+
+Container::~Container()
+{
+  this->clear(); // clean up memory.
+}
+
+auto
+Container::clear() -> self_type &
+{
+  Message *msg;
+  while (nullptr != (msg = _msgs.take_head())) {
+    delete msg;
+  }
+  _msgs.clear();
+  return *this;
+}
+
+size_t
+Container::count() const
+{
+  return _msgs.count();
+}
+
+template <typename... Args>
+auto
+Container::debug(std::string_view fmt, Args &&... args) -> self_type &
+{
+  Message *msg = new Message;
+  swoc::bwprintv(msg->_text, fmt, std::forward_as_tuple(args...));
+  msg->_severity = Message::LVL_DEBUG;
+  _msgs.append(msg);
+  return *this;
+}
+
+Message::Severity
+Container::max_severity() const
+{
+  auto spot = std::max_element(_msgs.begin(), _msgs.end(),
+                               [](Message const &lhs, Message const &rhs) { return lhs._severity < rhs._severity; });
+  return spot == _msgs.end() ? Message::Severity::LVL_DEBUG : spot->_severity;
+}
+
+void
+Container::print() const
+{
+  for (auto &&elt : _msgs) {
+    std::cout << static_cast<unsigned int>(elt._severity) << ": " << elt._text << std::endl;
+  }
+}
+
+TEST_CASE("IntrusiveDList Example", "[libswoc][IntrusiveDList]")
+{
+  Container container;
+
+  container.debug("This is message {}", 1);
+  REQUIRE(container.count() == 1);
+  // Destructor is checked for non-crashing as container goes out of scope.
+}
+
+struct Thing {
+  Thing *_next{nullptr};
+  Thing *_prev{nullptr};
+  std::string _payload;
+
+  Thing(std::string_view text) : _payload(text) {}
+
+  struct Linkage {
+    static Thing *&
+    next_ptr(Thing *t)
+    {
+      return t->_next;
+    }
+    static Thing *&
+    prev_ptr(Thing *t)
+    {
+      return t->_prev;
+    }
+  };
+};
+
+// Just for you, @maskit ! Demonstrating non-public links and subclassing.
+class PrivateThing : protected Thing
+{
+  using self_type  = PrivateThing;
+  using super_type = Thing;
+
+public:
+  PrivateThing(std::string_view text) : super_type(text) {}
+
+  struct Linkage {
+    static self_type *&
+    next_ptr(self_type *t)
+    {
+      return swoc::ptr_ref_cast<self_type>(t->_next);
+    }
+    static self_type *&
+    prev_ptr(self_type *t)
+    {
+      return swoc::ptr_ref_cast<self_type>(t->_prev);
+    }
+  };
+
+  std::string const &
+  payload() const
+  {
+    return _payload;
+  }
+};
+
+// End of documentation example code.
+// If any lines above here are changed, the documentation must be updated.
+// --------------------
+
+using ThingList        = IntrusiveDList<Thing::Linkage>;
+using PrivateThingList = IntrusiveDList<PrivateThing::Linkage>;
+
+TEST_CASE("IntrusiveDList", "[libswoc][IntrusiveDList]")
+{
+  ThingList list;
+  int n;
+
+  REQUIRE(list.count() == 0);
+  REQUIRE(list.head() == nullptr);
+  REQUIRE(list.tail() == nullptr);
+  REQUIRE(list.begin() == list.end());
+  REQUIRE(list.empty());
+
+  n = 0;
+  for ([[maybe_unused]] auto &thing : list)
+    ++n;
+  REQUIRE(n == 0);
+  // Check const iteration (mostly compile checks here).
+  for ([[maybe_unused]] auto &thing : static_cast<ThingList const &>(list))
+    ++n;
+  REQUIRE(n == 0);
+
+  list.append(new Thing("one"));
+  REQUIRE(list.begin() != list.end());
+  REQUIRE(list.tail() == list.head());
+
+  list.prepend(new Thing("two"));
+  REQUIRE(list.count() == 2);
+  REQUIRE(list.head()->_payload == "two");
+  REQUIRE(list.tail()->_payload == "one");
+  list.prepend(list.take_tail());
+  REQUIRE(list.head()->_payload == "one");
+  REQUIRE(list.tail()->_payload == "two");
+  list.insert_after(list.head(), new Thing("middle"));
+  list.insert_before(list.tail(), new Thing("muddle"));
+  REQUIRE(list.count() == 4);
+  auto spot = list.begin();
+  REQUIRE((*spot++)._payload == "one");
+  REQUIRE((*spot++)._payload == "middle");
+  REQUIRE((*spot++)._payload == "muddle");
+  REQUIRE((*spot++)._payload == "two");
+  REQUIRE(spot == list.end());
+
+  Thing *thing = list.take_head();
+  REQUIRE(thing->_payload == "one");
+  REQUIRE(list.count() == 3);
+  REQUIRE(list.head() != nullptr);
+  REQUIRE(list.head()->_payload == "middle");
+
+  list.prepend(thing);
+  list.erase(list.head());
+  REQUIRE(list.count() == 3);
+  REQUIRE(list.head() != nullptr);
+  REQUIRE(list.head()->_payload == "middle");
+  list.prepend(thing);
+
+  thing = list.take_tail();
+  REQUIRE(thing->_payload == "two");
+  REQUIRE(list.count() == 3);
+  REQUIRE(list.tail() != nullptr);
+  REQUIRE(list.tail()->_payload == "muddle");
+
+  list.append(thing);
+  list.erase(list.tail());
+  REQUIRE(list.count() == 3);
+  REQUIRE(list.tail() != nullptr);
+  REQUIRE(list.tail()->_payload == "muddle");
+  REQUIRE(list.head()->_payload == "one");
+
+  list.insert_before(list.end(), new Thing("trailer"));
+  REQUIRE(list.count() == 4);
+  REQUIRE(list.tail()->_payload == "trailer");
+
+  PrivateThingList priv_list;
+  for (int i = 1; i <= 23; ++i) {
+    std::string name;
+    swoc::bwprint(name, "Item {}", i);
+    priv_list.append(new PrivateThing(name));
+    REQUIRE(priv_list.count() == i);
+  }
+  REQUIRE(priv_list.head()->payload() == "Item 1");
+  REQUIRE(priv_list.tail()->payload() == "Item 23");
+}

--- a/lib/swoc++/src/unit_tests/test_IntrusiveHashMap.cc
+++ b/lib/swoc++/src/unit_tests/test_IntrusiveHashMap.cc
@@ -1,0 +1,235 @@
+/** @file
+
+    IntrusiveHashMap unit tests.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements.  See the NOTICE file distributed with this work for additional information regarding
+    copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with the License.  You may
+    obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <iostream>
+#include <string_view>
+#include <string>
+#include <bitset>
+#include <random>
+
+#include "swoc/IntrusiveHashMap.h"
+#include "swoc/bwf_base.h"
+#include "swoc/ext/catch.hpp"
+
+using swoc::IntrusiveHashMap;
+
+// -------------
+// --- TESTS ---
+// -------------
+
+using namespace std::literals;
+
+namespace
+{
+struct Thing {
+  std::string _payload;
+  int _n{0};
+
+  Thing(std::string_view text) : _payload(text) {}
+  Thing(std::string_view text, int x) : _payload(text), _n(x) {}
+
+  Thing *_next{nullptr};
+  Thing *_prev{nullptr};
+};
+
+struct ThingMapDescriptor {
+  static Thing *&
+  next_ptr(Thing *thing)
+  {
+    return thing->_next;
+  }
+  static Thing *&
+  prev_ptr(Thing *thing)
+  {
+    return thing->_prev;
+  }
+  static std::string_view
+  key_of(Thing *thing)
+  {
+    return thing->_payload;
+  }
+  static constexpr std::hash<std::string_view> hasher{};
+  static auto
+  hash_of(std::string_view s) -> decltype(hasher(s))
+  {
+    return hasher(s);
+  }
+  static bool
+  equal(std::string_view const &lhs, std::string_view const &rhs)
+  {
+    return lhs == rhs;
+  }
+};
+
+using Map = IntrusiveHashMap<ThingMapDescriptor>;
+
+} // namespace
+
+TEST_CASE("IntrusiveHashMap", "[libts][IntrusiveHashMap]")
+{
+  Map map;
+  map.insert(new Thing("bob"));
+  REQUIRE(map.count() == 1);
+  map.insert(new Thing("dave"));
+  map.insert(new Thing("persia"));
+  REQUIRE(map.count() == 3);
+  for (auto &thing : map) {
+    delete &thing;
+  }
+  map.clear();
+  REQUIRE(map.count() == 0);
+
+  size_t nb = map.bucket_count();
+  std::bitset<64> marks;
+  for (int i = 1; i <= 63; ++i) {
+    std::string name;
+    swoc::bwprint(name, "{} squared is {}", i, i * i);
+    Thing *thing = new Thing(name);
+    thing->_n    = i;
+    map.insert(thing);
+    REQUIRE(map.count() == i);
+    REQUIRE(map.find(name) != map.end());
+  }
+  REQUIRE(map.count() == 63);
+  REQUIRE(map.bucket_count() > nb);
+  for (auto &thing : map) {
+    REQUIRE(0 == marks[thing._n]);
+    marks[thing._n] = 1;
+  }
+  marks[0] = 1;
+  REQUIRE(marks.all());
+  map.insert(new Thing("dup"sv, 79));
+  map.insert(new Thing("dup"sv, 80));
+  map.insert(new Thing("dup"sv, 81));
+
+  auto r = map.equal_range("dup"sv);
+  REQUIRE(r.first != r.second);
+  REQUIRE(r.first->_payload == "dup"sv);
+  REQUIRE(r.first->_n == 79);
+
+  Map::iterator idx;
+
+  // Erase all the non-"dup" and see if the range is still correct.
+  map.apply([&map](Thing &thing) {
+    if (thing._payload != "dup"sv)
+      map.erase(map.iterator_for(&thing));
+  });
+  r = map.equal_range("dup"sv);
+  REQUIRE(r.first != r.second);
+  idx = r.first;
+  REQUIRE(idx->_payload == "dup"sv);
+  REQUIRE(idx->_n == 79);
+  REQUIRE((++idx)->_payload == "dup"sv);
+  REQUIRE(idx->_n != r.first->_n);
+  REQUIRE(idx->_n == 80);
+  REQUIRE((++idx)->_payload == "dup"sv);
+  REQUIRE(idx->_n != r.first->_n);
+  REQUIRE(idx->_n == 81);
+  REQUIRE(++idx == map.end());
+  // Verify only the "dup" items are left.
+  for (auto &&elt : map) {
+    REQUIRE(elt._payload == "dup"sv);
+  }
+  // clean up the last bits.
+  map.apply([](Thing *thing) { delete thing; });
+};
+
+// Some more involved tests.
+TEST_CASE("IntrusiveHashMapManyStrings", "[IntrusiveHashMap]")
+{
+  std::vector<std::string_view> strings;
+
+  std::uniform_int_distribution<short> char_gen{'a', 'z'};
+  std::uniform_int_distribution<short> length_gen{20, 40};
+  std::minstd_rand randu;
+  constexpr int N = 1009;
+
+  Map ihm;
+
+  strings.reserve(N);
+  for (int i = 0; i < N; ++i) {
+    auto len = length_gen(randu);
+    char *s  = static_cast<char *>(malloc(len + 1));
+    for (decltype(len) j = 0; j < len; ++j) {
+      s[j] = char_gen(randu);
+    }
+    s[len] = 0;
+    strings.push_back({s, size_t(len)});
+  }
+
+  // Fill the IntrusiveHashMap
+  for (int i = 0; i < N; ++i) {
+    ihm.insert(new Thing{strings[i], i});
+  }
+
+  REQUIRE(ihm.count() == N);
+
+  // Do some lookups - just require the whole loop, don't artificially inflate the test count.
+  bool miss_p = false;
+  for (int j = 0, idx = 17; j < N; ++j, idx = (idx + 17) % N) {
+    if (auto spot = ihm.find(strings[idx]); spot == ihm.end() || spot->_n != idx) {
+      miss_p = true;
+    }
+  }
+  REQUIRE(miss_p == false);
+
+  // Let's try some duplicates when there's a lot of data in the map.
+  miss_p = false;
+  for (int idx = 23; idx < N; idx += 23) {
+    ihm.insert(new Thing(strings[idx], 2000 + idx));
+  }
+  for (int idx = 23; idx < N; idx += 23) {
+    auto spot = ihm.find(strings[idx]);
+    if (spot == ihm.end() || spot->_n != idx || ++spot == ihm.end() || spot->_n != 2000 + idx) {
+      miss_p = true;
+    }
+  }
+  REQUIRE(miss_p == false);
+
+  // Do a different stepping, special cases the intersection with the previous stepping.
+  miss_p = false;
+  for (int idx = 31; idx < N; idx += 31) {
+    ihm.insert(new Thing(strings[idx], 3000 + idx));
+  }
+  for (int idx = 31; idx < N; idx += 31) {
+    auto spot = ihm.find(strings[idx]);
+    if (spot == ihm.end() || spot->_n != idx || ++spot == ihm.end() || (idx != (23 * 31) && spot->_n != 3000 + idx) ||
+        (idx == (23 * 31) && spot->_n != 2000 + idx)) {
+      miss_p = true;
+    }
+  }
+  REQUIRE(miss_p == false);
+
+  // Check for misses.
+  miss_p = false;
+  for (int i = 0; i < 99; ++i) {
+    char s[41];
+    auto len = length_gen(randu);
+    for (decltype(len) j = 0; j < len; ++j) {
+      s[j] = char_gen(randu);
+    }
+    std::string_view name(s, len);
+    auto spot = ihm.find(name);
+    if (spot != ihm.end() && name != spot->_payload) {
+      miss_p = true;
+    }
+  }
+  REQUIRE(miss_p == false);
+};

--- a/lib/swoc++/src/unit_tests/test_Lexicon.cc
+++ b/lib/swoc++/src/unit_tests/test_Lexicon.cc
@@ -1,0 +1,149 @@
+/** @file
+
+    Lexicon unit tests.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements.  See the NOTICE file distributed with this work for additional information regarding
+    copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with the License.  You may
+    obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "swoc/Lexicon.h"
+#include "swoc/ext/catch.hpp"
+
+// Example code for documentatoin
+// ---
+
+enum class Example { INVALID, Value_0, Value_1, Value_2, Value_3 };
+
+using ExampleNames = swoc::Lexicon<Example>;
+
+TEST_CASE("Lexicon Example", "[libts][Lexicon]")
+{
+  ExampleNames exnames{{Example::Value_0, {"zero", "0"}},
+                       {Example::Value_1, {"one", "1"}},
+                       {Example::Value_2, {"two", "2"}},
+                       {Example::Value_3, {"three", "3"}},
+                       {Example::INVALID, {"INVALID"}}};
+
+  ExampleNames exnames2{{Example::Value_0, "zero"},
+                        {Example::Value_1, "one"},
+                        {Example::Value_2, "two"},
+                        {Example::Value_3, "three"},
+                        {Example::INVALID, "INVALID"}};
+
+  exnames.set_default(Example::INVALID).set_default("INVALID");
+
+  REQUIRE(exnames[Example::INVALID] == "INVALID");
+  REQUIRE(exnames[Example::Value_0] == "zero");
+  REQUIRE(exnames["zero"] == Example::Value_0);
+  REQUIRE(exnames["Zero"] == Example::Value_0);
+  REQUIRE(exnames["ZERO"] == Example::Value_0);
+  REQUIRE(exnames["one"] == Example::Value_1);
+  REQUIRE(exnames["1"] == Example::Value_1);
+  REQUIRE(exnames["Evil Dave"] == Example::INVALID);
+  REQUIRE(exnames[static_cast<Example>(0xBADD00D)] == "INVALID");
+  REQUIRE(exnames[exnames[static_cast<Example>(0xBADD00D)]] == Example::INVALID);
+
+  // Case of an enumeration with a "LAST_VALUE".
+  enum class Radio { INVALID, ALPHA, BRAVO, CHARLIE, DELTA, LAST_VALUE };
+  using Lex = swoc::Lexicon<Radio>;
+  Lex lex(Lex::Require<Radio::LAST_VALUE>(), {{{Radio::INVALID, {"Invalid"}},
+                                               {Radio::ALPHA, {"Alpha"}},
+                                               {Radio::BRAVO, {"Bravo", "Beta"}},
+                                               {Radio::CHARLIE, {"Charlie"}},
+                                               {Radio::DELTA, {"Delta"}}}});
+};
+
+// ---
+// End example code.
+
+enum Values { NoValue, LowValue, HighValue, Priceless };
+enum Hex { A, B, C, D, E, F, INVALID };
+
+using ValueLexicon = swoc::Lexicon<Values>;
+
+TEST_CASE("Lexicon Constructor", "[libts][Lexicon]")
+{
+  // Construct with a secondary name for NoValue
+  ValueLexicon vl{{NoValue, {"NoValue", "garbage"}}, {LowValue, {"LowValue"}}};
+
+  REQUIRE("LowValue" == vl[LowValue]);                 // Primary name
+  REQUIRE(NoValue == vl["NoValue"]);                   // Primary name
+  REQUIRE(NoValue == vl["garbage"]);                   // Secondary name
+  REQUIRE_THROWS_AS(vl["monkeys"], std::domain_error); // No default, so throw.
+  vl.set_default(NoValue);                             // Put in a default.
+  REQUIRE(NoValue == vl["monkeys"]);                   // Returns default instead of throw
+  REQUIRE(LowValue == vl["lowVALUE"]);                 // Check case insensitivity.
+
+  REQUIRE(NoValue == vl["HighValue"]);               // Not defined yet.
+  vl.define(HighValue, {"HighValue", "High_Value"}); // Add it.
+  REQUIRE(HighValue == vl["HighValue"]);             // Verify it's there and is case insensitive.
+  REQUIRE(HighValue == vl["highVALUE"]);
+  REQUIRE(HighValue == vl["HIGH_VALUE"]);
+  REQUIRE("HighValue" == vl[HighValue]); // Verify value -> primary name.
+
+  // A few more checks on primary/secondary.
+  REQUIRE(NoValue == vl["Priceless"]);
+  REQUIRE(NoValue == vl["unique"]);
+  vl.define(Priceless, "Priceless", "Unique");
+  REQUIRE("Priceless" == vl[Priceless]);
+  REQUIRE(Priceless == vl["unique"]);
+
+  // Check default handlers.
+  using LL         = swoc::Lexicon<Hex>;
+  bool bad_value_p = false;
+  LL ll_1({{A, "A"}, {B, "B"}, {C, "C"}, {E, "E"}});
+  ll_1.set_default([&bad_value_p](std::string_view name) mutable -> Hex {
+    bad_value_p = true;
+    return INVALID;
+  });
+  ll_1.set_default([&bad_value_p](Hex value) mutable -> std::string_view {
+    bad_value_p = true;
+    return "INVALID";
+  });
+  REQUIRE(bad_value_p == false);
+  REQUIRE(INVALID == ll_1["F"]);
+  REQUIRE(bad_value_p == true);
+  bad_value_p = false;
+  REQUIRE("INVALID" == ll_1[F]);
+  REQUIRE(bad_value_p == true);
+  bad_value_p = false;
+  // Verify that INVALID / "INVALID" are equal because of the default handlers.
+  REQUIRE("INVALID" == ll_1[INVALID]);
+  REQUIRE(INVALID == ll_1["INVALID"]);
+  REQUIRE(bad_value_p == true);
+  // Define the value/name, verify the handlers are *not* invoked.
+  ll_1.define(INVALID, "INVALID");
+  bad_value_p = false;
+  REQUIRE("INVALID" == ll_1[INVALID]);
+  REQUIRE(INVALID == ll_1["INVALID"]);
+  REQUIRE(bad_value_p == false);
+
+  ll_1.define({D, "D"});          // Pair style
+  ll_1.define({F, {"F", "0xf"}}); // Definition style
+  REQUIRE(ll_1[D] == "D");
+  REQUIRE(ll_1["0XF"] == F);
+
+  // iteration
+  std::bitset<INVALID + 1> mark;
+  for (auto [value, name] : ll_1) {
+    if (mark[value]) {
+      std::cerr << "Lexicon: " << name << ':' << value << " double iterated" << std::endl;
+      mark.reset();
+      break;
+    }
+    mark[value] = true;
+  }
+  REQUIRE(mark.all());
+};

--- a/lib/swoc++/src/unit_tests/test_MemArena.cc
+++ b/lib/swoc++/src/unit_tests/test_MemArena.cc
@@ -1,0 +1,266 @@
+/** @file
+
+    MemArena unit tests.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements.  See the NOTICE file distributed with this work for additional information regarding
+    copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with the License.  You may
+    obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <string_view>
+#include "swoc/MemArena.h"
+#include "swoc/ext/catch.hpp"
+
+using swoc::MemSpan;
+using swoc::MemArena;
+using namespace std::literals;
+
+TEST_CASE("MemArena generic", "[libswoc][MemArena]")
+{
+  swoc::MemArena arena{64};
+  REQUIRE(arena.size() == 0);
+  REQUIRE(arena.reserved_size() == 0);
+  arena.alloc(0);
+  REQUIRE(arena.size() == 0);
+  REQUIRE(arena.reserved_size() >= 64);
+  REQUIRE(arena.remaining() >= 64);
+
+  swoc::MemSpan span1 = arena.alloc(32);
+  REQUIRE(span1.size() == 32);
+  REQUIRE(arena.remaining() >= 32);
+
+  swoc::MemSpan span2 = arena.alloc(32);
+  REQUIRE(span2.size() == 32);
+
+  REQUIRE(span1.data() != span2.data());
+  REQUIRE(arena.size() == 64);
+
+  auto extent{arena.reserved_size()};
+  span1 = arena.alloc(128);
+  REQUIRE(extent < arena.reserved_size());
+}
+
+TEST_CASE("MemArena freeze and thaw", "[libswoc][MemArena]")
+{
+  MemArena arena;
+  MemSpan span1{arena.alloc(1024)};
+  REQUIRE(span1.size() == 1024);
+  REQUIRE(arena.size() == 1024);
+  REQUIRE(arena.reserved_size() >= 1024);
+
+  arena.freeze();
+
+  REQUIRE(arena.size() == 0);
+  REQUIRE(arena.allocated_size() == 1024);
+  REQUIRE(arena.reserved_size() >= 1024);
+
+  arena.thaw();
+  REQUIRE(arena.size() == 0);
+  REQUIRE(arena.allocated_size() == 0);
+  REQUIRE(arena.reserved_size() == 0);
+
+  span1 = arena.alloc(1024);
+  arena.freeze();
+  auto extent{arena.reserved_size()};
+  arena.alloc(512);
+  REQUIRE(arena.reserved_size() > extent); // new extent should be bigger.
+  arena.thaw();
+  REQUIRE(arena.size() == 512);
+  REQUIRE(arena.reserved_size() >= 1024);
+
+  arena.clear();
+  REQUIRE(arena.size() == 0);
+  REQUIRE(arena.reserved_size() == 0);
+
+  span1 = arena.alloc(262144);
+  arena.freeze();
+  extent = arena.reserved_size();
+  arena.alloc(512);
+  REQUIRE(arena.reserved_size() > extent); // new extent should be bigger.
+  arena.thaw();
+  REQUIRE(arena.size() == 512);
+  REQUIRE(arena.reserved_size() >= 262144);
+
+  arena.clear();
+
+  span1  = arena.alloc(262144);
+  extent = arena.reserved_size();
+  arena.freeze();
+  for (int i = 0; i < 262144 / 512; ++i)
+    arena.alloc(512);
+  REQUIRE(arena.reserved_size() > extent); // Bigger while frozen memory is still around.
+  arena.thaw();
+  REQUIRE(arena.size() == 262144);
+  REQUIRE(arena.reserved_size() == extent); // should be identical to before freeze.
+
+  arena.alloc(512);
+  arena.alloc(768);
+  arena.freeze(32000);
+  arena.thaw();
+  arena.alloc(0);
+  REQUIRE(arena.reserved_size() >= 32000);
+  REQUIRE(arena.reserved_size() < 2 * 32000);
+}
+
+TEST_CASE("MemArena helper", "[libswoc][MemArena]")
+{
+  struct Thing {
+    int ten{10};
+    std::string name{"name"};
+
+    Thing() {}
+    Thing(int x) : ten(x) {}
+    Thing(std::string const &s) : name(s) {}
+    Thing(int x, std::string_view s) : ten(x), name(s) {}
+    Thing(std::string const &s, int x) : ten(x), name(s) {}
+  };
+
+  swoc::MemArena arena{256};
+  REQUIRE(arena.size() == 0);
+  swoc::MemSpan s = arena.alloc(56).rebind<char>();
+  REQUIRE(arena.size() == 56);
+  REQUIRE(arena.remaining() >= 200);
+  void *ptr = s.begin();
+
+  REQUIRE(arena.contains((char *)ptr));
+  REQUIRE(arena.contains((char *)ptr + 100)); // even though span isn't this large, this pointer should still be in arena
+  REQUIRE(!arena.contains((char *)ptr + 300));
+  REQUIRE(!arena.contains((char *)ptr - 1));
+
+  arena.freeze(128);
+  REQUIRE(arena.contains((char *)ptr));
+  REQUIRE(arena.contains((char *)ptr + 100));
+  swoc::MemSpan s2 = arena.alloc(10).rebind<char>();
+  void *ptr2       = s2.begin();
+  REQUIRE(arena.contains((char *)ptr));
+  REQUIRE(arena.contains((char *)ptr2));
+  REQUIRE(arena.allocated_size() == 56 + 10);
+
+  arena.thaw();
+  REQUIRE(!arena.contains((char *)ptr));
+  REQUIRE(arena.contains((char *)ptr2));
+
+  Thing *thing_one{arena.make<Thing>()};
+
+  REQUIRE(thing_one->ten == 10);
+  REQUIRE(thing_one->name == "name");
+
+  thing_one = arena.make<Thing>(17, "bob"sv);
+
+  REQUIRE(thing_one->name == "bob");
+  REQUIRE(thing_one->ten == 17);
+
+  thing_one = arena.make<Thing>("Dave", 137);
+
+  REQUIRE(thing_one->name == "Dave");
+  REQUIRE(thing_one->ten == 137);
+
+  thing_one = arena.make<Thing>(9999);
+
+  REQUIRE(thing_one->ten == 9999);
+  REQUIRE(thing_one->name == "name");
+
+  thing_one = arena.make<Thing>("Persia");
+
+  REQUIRE(thing_one->ten == 10);
+  REQUIRE(thing_one->name == "Persia");
+}
+
+TEST_CASE("MemArena large alloc", "[libswoc][MemArena]")
+{
+  swoc::MemArena arena;
+  auto s = arena.alloc(4000);
+  REQUIRE(s.size() == 4000);
+
+  decltype(s) s_a[10];
+  s_a[0] = arena.alloc(100);
+  s_a[1] = arena.alloc(200);
+  s_a[2] = arena.alloc(300);
+  s_a[3] = arena.alloc(400);
+  s_a[4] = arena.alloc(500);
+  s_a[5] = arena.alloc(600);
+  s_a[6] = arena.alloc(700);
+  s_a[7] = arena.alloc(800);
+  s_a[8] = arena.alloc(900);
+  s_a[9] = arena.alloc(1000);
+
+  // ensure none of the spans have any overlap in memory.
+  for (int i = 0; i < 10; ++i) {
+    s = s_a[i];
+    for (int j = i + 1; j < 10; ++j) {
+      REQUIRE(s_a[i].data() != s_a[j].data());
+    }
+  }
+}
+
+TEST_CASE("MemArena block allocation", "[libswoc][MemArena]")
+{
+  swoc::MemArena arena{64};
+  swoc::MemSpan s  = arena.alloc(32).rebind<char>();
+  swoc::MemSpan s2 = arena.alloc(16).rebind<char>();
+  swoc::MemSpan s3 = arena.alloc(16).rebind<char>();
+
+  REQUIRE(s.size() == 32);
+  REQUIRE(arena.allocated_size() == 64);
+
+  REQUIRE(arena.contains((char *)s.begin()));
+  REQUIRE(arena.contains((char *)s2.begin()));
+  REQUIRE(arena.contains((char *)s3.begin()));
+
+  REQUIRE((char *)s.begin() + 32 == (char *)s2.begin());
+  REQUIRE((char *)s.begin() + 48 == (char *)s3.begin());
+  REQUIRE((char *)s2.begin() + 16 == (char *)s3.begin());
+
+  REQUIRE(s.end() == s2.begin());
+  REQUIRE(s2.end() == s3.begin());
+  REQUIRE((char *)s.begin() + 64 == s3.end());
+}
+
+TEST_CASE("MemArena full blocks", "[libswoc][MemArena]")
+{
+  // couple of large allocations - should be exactly sized in the generation.
+  size_t init_size = 32000;
+  swoc::MemArena arena(init_size);
+
+  MemSpan m1{arena.alloc(init_size - 64).rebind<uint8_t>()};
+  MemSpan m2{arena.alloc(32000).rebind<unsigned char>()};
+  MemSpan m3{arena.alloc(64000).rebind<char>()};
+
+  REQUIRE(arena.remaining() >= 64);
+  REQUIRE(arena.reserved_size() > 32000 + 64000 + init_size);
+  REQUIRE(arena.reserved_size() < 2 * (32000 + 64000 + init_size));
+
+  // Let's see if that memory is really there.
+  memset(m1, 0xa5);
+  memset(m2, 0xc2);
+  memset(m3, 0x56);
+
+  REQUIRE(std::all_of(m1.begin(), m1.end(), [](uint8_t c) { return 0xa5 == c; }));
+  REQUIRE(std::all_of(m2.begin(), m2.end(), [](unsigned char c) { return 0xc2 == c; }));
+  REQUIRE(std::all_of(m3.begin(), m3.end(), [](char c) { return 0x56 == c; }));
+}
+
+TEST_CASE("MemArena esoterica", "[libswoc][MemArena]")
+{
+  MemArena a1;
+  MemSpan<char> span;
+  {
+    MemArena a2{512};
+    span = a2.alloc(128).rebind<char>();
+    REQUIRE(a2.contains(span.data()));
+    a1 = std::move(a2);
+  }
+  REQUIRE(a1.contains(span.data()));
+  REQUIRE(a1.remaining() >= 384);
+}

--- a/lib/swoc++/src/unit_tests/test_MemSpan.cc
+++ b/lib/swoc++/src/unit_tests/test_MemSpan.cc
@@ -1,0 +1,94 @@
+/** @file
+
+    MemSpan unit tests.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <iostream>
+#include "swoc/MemSpan.h"
+#include "swoc/ext/catch.hpp"
+
+using swoc::MemSpan;
+
+TEST_CASE("MemSpan", "[libswoc][MemSpan]")
+{
+  int32_t idx[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  char buff[1024];
+
+  MemSpan<char> span(buff, sizeof(buff));
+  MemSpan<char> left = span.prefix(512);
+  REQUIRE(left.size() == 512);
+  REQUIRE(span.size() == 1024);
+  span.remove_prefix(512);
+  REQUIRE(span.size() == 512);
+  REQUIRE(left.end() == span.begin());
+
+  left.assign(buff, sizeof(buff));
+  span = left.suffix(768);
+  left.remove_suffix(768);
+  REQUIRE(left.end() == span.begin());
+  REQUIRE(left.size() + span.size() == 1024);
+
+  MemSpan<int32_t> idx_span(idx);
+  REQUIRE(idx_span.count() == 11);
+  REQUIRE(idx_span.size() == sizeof(idx));
+  REQUIRE(idx_span.data() == idx);
+
+  auto sp2 = idx_span.rebind<int16_t>();
+  REQUIRE(sp2.size() == idx_span.size());
+  REQUIRE(sp2.count() == 2 * idx_span.count());
+  REQUIRE(sp2[0] == 0);
+  REQUIRE(sp2[1] == 0);
+  // exactly one of { le, be } must be true.
+  bool le = sp2[2] == 1 && sp2[3] == 0;
+  bool be = sp2[2] == 0 && sp2[3] == 1;
+  REQUIRE(le != be);
+  auto idx2 = sp2.rebind<int32_t>(); // still the same if converted back to original?
+  REQUIRE(idx_span.is_same(idx2));
+
+  // Verify attempts to rebind on non-integral sized arrays fails.
+  span.assign(buff, 1022);
+  REQUIRE(span.size() == 1022);
+  REQUIRE(span.count() == 1022);
+  auto vs = span.rebind<void>();
+  REQUIRE_THROWS_AS(span.rebind<uint32_t>(), std::invalid_argument);
+  REQUIRE_THROWS_AS(vs.rebind<uint32_t>(), std::invalid_argument);
+
+  // Check for defaulting to a void rebind.
+  vs = span.rebind();
+  REQUIRE(vs.size() == 1022);
+
+  // Check for assignment to void.
+  vs = span;
+  REQUIRE(vs.size() == 1022);
+
+  // Test array constructors.
+  MemSpan<char> a{buff};
+  REQUIRE(a.size() == sizeof(buff));
+  REQUIRE(a.data() == buff);
+  float floats[] = {1.1, 2.2, 3.3, 4.4, 5.5};
+  MemSpan<float> fspan{floats};
+  REQUIRE(fspan.count() == 5);
+  REQUIRE(fspan[3] == 4.4f);
+  MemSpan<float> f2span{floats, floats + 5};
+  REQUIRE(fspan.data() == f2span.data());
+  REQUIRE(fspan.count() == f2span.count());
+  REQUIRE(fspan.is_same(f2span));
+};

--- a/lib/swoc++/src/unit_tests/test_Scalar.cc
+++ b/lib/swoc++/src/unit_tests/test_Scalar.cc
@@ -1,0 +1,243 @@
+/** @file
+
+    Scalar unit testing.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements.  See the NOTICE file distributed with this work for additional information regarding
+    copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with the License.  You may
+    obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "swoc/Scalar.h"
+#include "swoc/bwf_base.h"
+#include "swoc/ext/catch.hpp"
+
+using Bytes      = swoc::Scalar<1, off_t>;
+using Paragraphs = swoc::Scalar<16, off_t>;
+using KB         = swoc::Scalar<1024, off_t>;
+using MB         = swoc::Scalar<KB::SCALE * 1024, off_t>;
+
+TEST_CASE("Scalar", "[libts][Scalar]")
+{
+  constexpr static int SCALE   = 4096;
+  constexpr static int SCALE_1 = 8192;
+  constexpr static int SCALE_2 = 512;
+
+  using PageSize = swoc::Scalar<SCALE>;
+
+  PageSize pg1(1);
+  REQUIRE(pg1.count() == 1);
+  REQUIRE(pg1.value() == SCALE);
+
+  using Size_1 = swoc::Scalar<SCALE_1>;
+  using Size_2 = swoc::Scalar<SCALE_2>;
+
+  Size_2 sz_a(2);
+  Size_2 sz_b(57);
+  Size_2 sz_c(SCALE_1 / SCALE_2);
+  Size_2 sz_d(29 * SCALE_1 / SCALE_2);
+
+  Size_1 sz = swoc::round_up(sz_a);
+  REQUIRE(sz.count() == 1);
+  sz = swoc::round_down(sz_a);
+  REQUIRE(sz.count() == 0);
+
+  sz = swoc::round_up(sz_b);
+  REQUIRE(sz.count() == 4);
+  sz = swoc::round_down(sz_b);
+  REQUIRE(sz.count() == 3);
+
+  sz = swoc::round_up(sz_c);
+  REQUIRE(sz.count() == 1);
+  sz = swoc::round_down(sz_c);
+  REQUIRE(sz.count() == 1);
+
+  sz = swoc::round_up(sz_d);
+  REQUIRE(sz.count() == 29);
+  sz = swoc::round_down(sz_d);
+  REQUIRE(sz.count() == 29);
+
+  sz.assign(119);
+  sz_b = sz; // Should be OK because SCALE_1 is an integer multiple of SCALE_2
+  //  sz = sz_b; // Should not compile.
+  REQUIRE(sz_b.count() == 119 * (SCALE_1 / SCALE_2));
+}
+
+TEST_CASE("Scalar Factors", "[libts][Scalar][factors]")
+{
+  constexpr static int SCALE_1 = 30;
+  constexpr static int SCALE_2 = 20;
+
+  using Size_1 = swoc::Scalar<SCALE_1>;
+  using Size_2 = swoc::Scalar<SCALE_2>;
+
+  Size_2 sz_a(2);
+  Size_2 sz_b(97);
+
+  Size_1 sz = round_up(sz_a);
+  REQUIRE(sz.count() == 2);
+  sz = round_down(sz_a);
+  REQUIRE(sz.count() == 1);
+
+  sz = swoc::round_up(sz_b);
+  REQUIRE(sz.count() == 65);
+  sz = swoc::round_down(sz_b);
+  REQUIRE(sz.count() == 64);
+
+  swoc::Scalar<9> m_9;
+  swoc::Scalar<4> m_4, m_test;
+
+  m_9.assign(95);
+  //  m_4 = m_9; // Should fail to compile with static assert.
+  //  m_9 = m_4; // Should fail to compile with static assert.
+
+  m_4 = swoc::round_up(m_9);
+  REQUIRE(m_4.count() == 214);
+  m_4 = swoc::round_down(m_9);
+  REQUIRE(m_4.count() == 213);
+
+  m_4.assign(213);
+  m_9 = swoc::round_up(m_4);
+  REQUIRE(m_9.count() == 95);
+  m_9 = swoc::round_down(m_4);
+  REQUIRE(m_9.count() == 94);
+
+  m_test = m_4; // Verify assignment of identical scale values compiles.
+  REQUIRE(m_test.count() == 213);
+}
+
+TEST_CASE("Scalar Arithmetic", "[libts][Scalar][arithmetic]")
+{
+  using KBytes  = swoc::Scalar<1024>;
+  using KiBytes = swoc::Scalar<1024, long int>;
+  using Bytes   = swoc::Scalar<1, int64_t>;
+  using MBytes  = swoc::Scalar<1024 * KBytes::SCALE>;
+
+  Bytes bytes(96);
+  KBytes kbytes(2);
+  MBytes mbytes(5);
+
+  Bytes z1 = swoc::round_up(bytes + 128);
+  REQUIRE(z1.count() == 224);
+  KBytes z2 = kbytes + kbytes(3);
+  REQUIRE(z2.count() == 5);
+  Bytes z3(bytes);
+  z3 += kbytes;
+  REQUIRE(z3.value() == 2048 + 96);
+  MBytes z4 = mbytes;
+  z4.inc(5);
+  z2 += z4;
+  REQUIRE(z2.value() == (10 << 20) + (5 << 10));
+
+  z1.inc(128);
+  REQUIRE(z1.count() == 352);
+
+  z2.assign(2);
+  z1 = 3 * z2;
+  REQUIRE(z1.count() == 6144);
+  z1 *= 5;
+  REQUIRE(z1.count() == 30720);
+  z1 /= 3;
+  REQUIRE(z1.count() == 10240);
+
+  z2.assign(3148);
+  auto x = z2 + MBytes(1);
+  REQUIRE(x.scale() == z2.scale());
+  REQUIRE(x.count() == 4172);
+
+  z2 = swoc::round_down(262150);
+  REQUIRE(z2.count() == 256);
+
+  z2 = swoc::round_up(262150);
+  REQUIRE(z2.count() == 257);
+
+  KBytes q(swoc::round_down(262150));
+  REQUIRE(q.count() == 256);
+
+  z2 += swoc::round_up(97384);
+  REQUIRE(z2.count() == 353);
+
+  decltype(z2) a = swoc::round_down(z2 + 167229);
+  REQUIRE(a.count() == 516);
+
+  KiBytes k(3148);
+  auto kx = k + MBytes(1);
+  REQUIRE(kx.scale() == k.scale());
+  REQUIRE(kx.count() == 4172);
+
+  k = swoc::round_down(262150);
+  REQUIRE(k.count() == 256);
+
+  k = swoc::round_up(262150);
+  REQUIRE(k.count() == 257);
+
+  KBytes kq(swoc::round_down(262150));
+  REQUIRE(kq.count() == 256);
+
+  k += swoc::round_up(97384);
+  REQUIRE(k.count() == 353);
+
+  decltype(k) ka = swoc::round_down(k + 167229);
+  REQUIRE(ka.count() == 516);
+
+  using StoreBlocks = swoc::Scalar<8 * KB::SCALE, off_t>;
+  using SpanBlocks  = swoc::Scalar<127 * MB::SCALE, off_t>;
+
+  StoreBlocks store_b(80759700);
+  SpanBlocks span_b(4968);
+  SpanBlocks delta(1);
+
+  REQUIRE(store_b < span_b);
+  REQUIRE(span_b < store_b + delta);
+  store_b += delta;
+  REQUIRE(span_b < store_b);
+
+  static const off_t N = 7 * 1024;
+  Bytes b(N + 384);
+  KB kb(round_down(b));
+
+  REQUIRE(kb == N);
+  REQUIRE(kb < N + 1);
+  REQUIRE(kb > N - 1);
+
+  REQUIRE(kb < b);
+  REQUIRE(kb <= b);
+  REQUIRE(b > kb);
+  REQUIRE(b >= kb);
+
+  ++kb;
+
+  REQUIRE(b < kb);
+  REQUIRE(b <= kb);
+  REQUIRE(kb > b);
+  REQUIRE(kb >= b);
+}
+
+struct KBytes_tag {
+  static constexpr std::string_view label{" bytes"};
+};
+
+TEST_CASE("Scalar Formatting", "[libts][Scalar][bwf]")
+{
+  using KBytes  = swoc::Scalar<1024, long int, KBytes_tag>;
+  using KiBytes = swoc::Scalar<1000, int>;
+
+  KBytes x(12);
+  KiBytes y(12);
+  swoc::LocalBufferWriter<128> w;
+
+  w.print("x is {}", x);
+  REQUIRE(w.view() == "x is 12288 bytes");
+  w.clear().print("y is {}", y);
+  REQUIRE(w.view() == "y is 12000");
+}

--- a/lib/swoc++/src/unit_tests/test_TextView.cc
+++ b/lib/swoc++/src/unit_tests/test_TextView.cc
@@ -1,0 +1,351 @@
+/** @file
+
+    TextView unit tests.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "swoc/TextView.h"
+#include "swoc/ext/catch.hpp"
+
+using swoc::TextView;
+using namespace std::literals;
+
+TEST_CASE("TextView Constructor", "[libts][TextView]")
+{
+  static std::string base = "Evil Dave Rulez!";
+  TextView tv(base);
+  TextView a{"Evil Dave Rulez"};
+  TextView b{base.data(), base.size()};
+  TextView c{std::string_view(base)};
+  constexpr TextView d{"Grigor!"sv};
+}
+
+TEST_CASE("TextView Operations", "[libts][TextView]")
+{
+  TextView tv{"Evil Dave Rulez"};
+  TextView tv_lower{"evil dave rulez"};
+  TextView nothing;
+  size_t off;
+
+  REQUIRE(tv.find('l') == 3);
+  off = tv.find_if([](char c) { return c == 'D'; });
+  REQUIRE(off == tv.find('D'));
+
+  REQUIRE(tv);
+  REQUIRE(!tv == false);
+  if (nothing) {
+    REQUIRE(nullptr == "bad operator bool on TextView");
+  }
+  REQUIRE(!nothing == true);
+  REQUIRE(nothing.empty() == true);
+
+  REQUIRE(memcmp(tv, tv) == 0);
+  REQUIRE(memcmp(tv, tv_lower) != 0);
+  REQUIRE(strcmp(tv, tv) == 0);
+  REQUIRE(strcmp(tv, tv_lower) != 0);
+  REQUIRE(strcasecmp(tv, tv) == 0);
+  REQUIRE(strcasecmp(tv, tv_lower) == 0);
+  REQUIRE(strcasecmp(nothing, tv) != 0);
+}
+
+TEST_CASE("TextView Trimming", "[libts][TextView]")
+{
+  TextView tv("  Evil Dave Rulz   ...");
+  TextView tv2{"More Text1234567890"};
+  REQUIRE("Evil Dave Rulz   ..." == TextView(tv).ltrim_if(&isspace));
+  REQUIRE(tv2 == TextView{tv2}.ltrim_if(&isspace));
+  REQUIRE("More Text" == TextView{tv2}.rtrim_if(&isdigit));
+  REQUIRE("  Evil Dave Rulz   " == TextView(tv).rtrim('.'));
+  REQUIRE("Evil Dave Rulz" == TextView(tv).trim(" ."));
+}
+
+TEST_CASE("TextView Find", "[libts][TextView]")
+{
+  TextView addr{"172.29.145.87:5050"};
+  REQUIRE(addr.find(':') == 13);
+  REQUIRE(addr.rfind(':') == 13);
+  REQUIRE(addr.find('.') == 3);
+  REQUIRE(addr.rfind('.') == 10);
+}
+
+TEST_CASE("TextView Affixes", "[libts][TextView]")
+{
+  TextView s; // scratch.
+  TextView tv1("0123456789;01234567890");
+  TextView prefix{tv1.prefix(10)};
+
+  REQUIRE("0123456789" == prefix);
+  REQUIRE("67890" == tv1.suffix(5));
+
+  TextView tv2 = tv1.prefix(';');
+  REQUIRE(tv2 == "0123456789");
+
+  TextView right{tv1};
+  TextView left{right.split_prefix_at(';')};
+  REQUIRE(right.size() == 11);
+  REQUIRE(left.size() == 10);
+
+  TextView tv3 = "abcdefg:gfedcba";
+  left         = tv3;
+  right        = left.split_suffix_at(";:,");
+  TextView pre{tv3}, post{pre.split_suffix_at(7)};
+  REQUIRE(right.size() == 7);
+  REQUIRE(left.size() == 7);
+  REQUIRE(left == "abcdefg");
+  REQUIRE(right == "gfedcba");
+
+  TextView addr1{"[fe80::fc54:ff:fe60:d886]"};
+  TextView addr2{"[fe80::fc54:ff:fe60:d886]:956"};
+  TextView addr3{"192.168.1.1:5050"};
+
+  TextView t = addr1;
+  ++t;
+  REQUIRE("fe80::fc54:ff:fe60:d886]" == t);
+  TextView a = t.take_prefix_at(']');
+  REQUIRE("fe80::fc54:ff:fe60:d886" == a);
+  REQUIRE(t.empty());
+
+  t = addr2;
+  ++t;
+  a = t.take_prefix_at(']');
+  REQUIRE("fe80::fc54:ff:fe60:d886" == a);
+  REQUIRE(':' == *t);
+  ++t;
+  REQUIRE("956" == t);
+
+  t = addr3;
+  TextView sf{t.suffix(':')};
+  REQUIRE("5050" == sf);
+  REQUIRE(t == addr3);
+
+  t = addr3;
+  s = t.split_suffix_at(11);
+  REQUIRE("5050" == s);
+  REQUIRE("192.168.1.1" == t);
+
+  t = addr3;
+  s = t.split_suffix_at(':');
+  REQUIRE("5050" == s);
+  REQUIRE("192.168.1.1" == t);
+
+  t = addr3;
+  s = t.split_suffix_at('Q');
+  REQUIRE(s.empty());
+  REQUIRE(t == addr3);
+
+  t = addr3;
+  s = t.take_suffix_at(':');
+  REQUIRE("5050" == s);
+  REQUIRE("192.168.1.1" == t);
+
+  t = addr3;
+  s = t.take_suffix_at('Q');
+  REQUIRE(s == addr3);
+  REQUIRE(t.empty());
+
+  auto is_sep{[](char c) { return isspace(c) || ',' == c || ';' == c; }};
+  TextView token;
+  t = ";; , ;;one;two,th:ree  four,, ; ,,f-ive="sv;
+  // Do an unrolled loop.
+  REQUIRE(!t.ltrim_if(is_sep).empty());
+  REQUIRE(t.take_prefix_if(is_sep) == "one");
+  REQUIRE(!t.ltrim_if(is_sep).empty());
+  REQUIRE(t.take_prefix_if(is_sep) == "two");
+  REQUIRE(!t.ltrim_if(is_sep).empty());
+  REQUIRE(t.take_prefix_if(is_sep) == "th:ree");
+  REQUIRE(!t.ltrim_if(is_sep).empty());
+  REQUIRE(t.take_prefix_if(is_sep) == "four");
+  REQUIRE(!t.ltrim_if(is_sep).empty());
+  REQUIRE(t.take_prefix_if(is_sep) == "f-ive=");
+  REQUIRE(t.empty());
+
+  // Simulate pulling off FQDN pieces in reverse order from a string_view.
+  // Simulates operations in HostLookup.cc, where the use of string_view
+  // necessitates this workaround of failures in the string_view API. With a
+  // TextView, it would just be repeated @c take_suffix_at('.')
+  std::string_view fqdn{"bob.ne1.corp.ngeo.com"};
+  TextView elt{TextView{fqdn}.suffix('.')};
+  REQUIRE(elt == "com");
+
+  // Unroll loop for testing.
+  fqdn.remove_suffix(std::min(fqdn.size(), elt.size() + 1));
+  elt = TextView{fqdn}.suffix('.');
+  REQUIRE(elt == "ngeo");
+  fqdn.remove_suffix(std::min(fqdn.size(), elt.size() + 1));
+  elt = TextView{fqdn}.suffix('.');
+  REQUIRE(elt == "corp");
+  fqdn.remove_suffix(std::min(fqdn.size(), elt.size() + 1));
+  elt = TextView{fqdn}.suffix('.');
+  REQUIRE(elt == "ne1");
+  fqdn.remove_suffix(std::min(fqdn.size(), elt.size() + 1));
+  elt = TextView{fqdn}.suffix('.');
+  REQUIRE(elt == "bob");
+  fqdn.remove_suffix(std::min(fqdn.size(), elt.size() + 1));
+  elt = TextView{fqdn}.suffix('.');
+  REQUIRE(elt.empty());
+
+  // Check some edge cases.
+  fqdn  = "."sv;
+  token = TextView{fqdn}.take_suffix_at('.');
+  REQUIRE(token.size() == 0);
+  REQUIRE(token.empty());
+
+  s = "."sv;
+  REQUIRE(s.size() == 1);
+  REQUIRE(s.rtrim('.').empty());
+  token = s.take_suffix_at('.');
+  REQUIRE(token.size() == 0);
+  REQUIRE(token.empty());
+
+  s = "."sv;
+  REQUIRE(s.size() == 1);
+  REQUIRE(s.ltrim('.').empty());
+  token = s.take_prefix_at('.');
+  REQUIRE(token.size() == 0);
+  REQUIRE(token.empty());
+
+  auto is_not_alnum = [](char c) { return !isalnum(c); };
+
+  s = "file.cc";
+  REQUIRE(s.suffix('.') == "cc");
+  REQUIRE(s.suffix_if(is_not_alnum) == "cc");
+  REQUIRE(s.prefix('.') == "file");
+  REQUIRE(s.prefix_if(is_not_alnum) == "file");
+  s.remove_suffix_at('.');
+  REQUIRE(s == "file");
+  s = "file.cc.org.123";
+  REQUIRE(s.suffix('.') == "123");
+  REQUIRE(s.prefix('.') == "file");
+  s.remove_suffix_if(is_not_alnum);
+  REQUIRE(s == "file.cc.org");
+  s.remove_suffix_at('.');
+  REQUIRE(s == "file.cc");
+  s.remove_prefix_at('.');
+  REQUIRE(s == "cc");
+  s = "file.cc.org.123";
+  s.remove_prefix_if(is_not_alnum);
+  REQUIRE(s == "cc.org.123");
+  s.remove_suffix_at('!');
+  REQUIRE(s.empty());
+  s = "file.cc.org";
+  s.remove_prefix('!');
+  REQUIRE(s.empty());
+};
+
+TEST_CASE("TextView Formatting", "[libts][TextView]")
+{
+  TextView a("01234567");
+  {
+    std::ostringstream buff;
+    buff << '|' << a << '|';
+    REQUIRE(buff.str() == "|01234567|");
+  }
+  {
+    std::ostringstream buff;
+    buff << '|' << std::setw(5) << a << '|';
+    REQUIRE(buff.str() == "|01234567|");
+  }
+  {
+    std::ostringstream buff;
+    buff << '|' << std::setw(12) << a << '|';
+    REQUIRE(buff.str() == "|    01234567|");
+  }
+  {
+    std::ostringstream buff;
+    buff << '|' << std::setw(12) << std::right << a << '|';
+    REQUIRE(buff.str() == "|    01234567|");
+  }
+  {
+    std::ostringstream buff;
+    buff << '|' << std::setw(12) << std::left << a << '|';
+    REQUIRE(buff.str() == "|01234567    |");
+  }
+  {
+    std::ostringstream buff;
+    buff << '|' << std::setw(12) << std::right << std::setfill('_') << a << '|';
+    REQUIRE(buff.str() == "|____01234567|");
+  }
+  {
+    std::ostringstream buff;
+    buff << '|' << std::setw(12) << std::left << std::setfill('_') << a << '|';
+    REQUIRE(buff.str() == "|01234567____|");
+  }
+}
+
+TEST_CASE("TextView Conversions", "[libts][TextView]")
+{
+  TextView n  = "   956783";
+  TextView n2 = n;
+  TextView n3 = "031";
+  TextView n4 = "13f8q";
+  TextView n5 = "0x13f8";
+  TextView n6 = "0X13f8";
+  TextView x;
+  n2.ltrim_if(&isspace);
+
+  REQUIRE(956783 == svtoi(n));
+  REQUIRE(956783 == svtoi(n2));
+  REQUIRE(0x13f8 == svtoi(n4, &x, 16));
+  REQUIRE(x == "13f8");
+  REQUIRE(0x13f8 == svtoi(n5));
+  REQUIRE(0x13f8 == svtoi(n6));
+
+  REQUIRE(25 == svtoi(n3));
+  REQUIRE(31 == svtoi(n3, nullptr, 10));
+}
+
+TEST_CASE("TransformView", "[libts][TransformView]")
+{
+  std::string_view source{"Evil Dave Rulz"};
+  swoc::TransformView<int (*)(int) noexcept, std::string_view> xv1(&tolower, source);
+  auto xv2 = swoc::transform_view_of(&tolower, source);
+  TextView tv{source};
+
+  REQUIRE(xv1 == xv2);
+
+  bool match_p = true;
+  while (xv1) {
+    if (*xv1 != tolower(*tv)) {
+      match_p = false;
+      break;
+    }
+    ++xv1;
+    ++tv;
+  }
+  REQUIRE(match_p);
+  REQUIRE(xv1 != xv2);
+
+  tv      = source;
+  match_p = true;
+  while (xv2) {
+    if (*xv2 != tolower(*tv)) {
+      match_p = false;
+      break;
+    }
+    ++xv2;
+    ++tv;
+  }
+  REQUIRE(match_p);
+};

--- a/lib/swoc++/src/unit_tests/test_bw_format.cc
+++ b/lib/swoc++/src/unit_tests/test_bw_format.cc
@@ -1,0 +1,724 @@
+/** @file
+
+    Unit tests for BufferFormat and bwprint.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements.  See the NOTICE file distributed with this work for additional information regarding
+    copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with the License.  You may
+    obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#include <chrono>
+#include <iostream>
+#include <variant>
+
+#include "swoc/MemSpan.h"
+#include "swoc/BufferWriter.h"
+#include "swoc/bwf_std.h"
+#include "swoc/bwf_ex.h"
+#include "swoc/bwf_printf.h"
+
+#include "swoc/ext/catch.hpp"
+
+using namespace std::literals;
+using swoc::TextView;
+
+TEST_CASE("Buffer Writer << operator", "[bufferwriter][stream]")
+{
+  swoc::LocalBufferWriter<50> bw;
+
+  bw << "The" << ' ' << "quick" << ' ' << "brown fox";
+
+  REQUIRE(bw.view() == "The quick brown fox");
+
+  bw.clear();
+  bw << "x=" << bw.capacity();
+  REQUIRE(bw.view() == "x=50");
+}
+
+TEST_CASE("bwprint basics", "[bwprint]")
+{
+  swoc::LocalBufferWriter<256> bw;
+  std::string_view fmt1{"Some text"sv};
+
+  bw.print(fmt1);
+  REQUIRE(bw.view() == fmt1);
+  bw.clear();
+  bw.print("Arg {}", 1);
+  REQUIRE(bw.view() == "Arg 1");
+  bw.clear();
+  bw.print("arg 1 {1} and 2 {2} and 0 {0}", "zero", "one", "two");
+  REQUIRE(bw.view() == "arg 1 one and 2 two and 0 zero");
+  bw.clear();
+  bw.print("args {2}{0}{1}", "zero", "one", "two");
+  REQUIRE(bw.view() == "args twozeroone");
+  bw.clear();
+  bw.print("left |{:<10}|", "text");
+  REQUIRE(bw.view() == "left |text      |");
+  bw.clear();
+  bw.print("right |{:>10}|", "text");
+  REQUIRE(bw.view() == "right |      text|");
+  bw.clear();
+  bw.print("right |{:.>10}|", "text");
+  REQUIRE(bw.view() == "right |......text|");
+  bw.clear();
+  bw.print("center |{:.^10}|", "text");
+  REQUIRE(bw.view() == "center |...text...|");
+  bw.clear();
+  bw.print("center |{:.^11}|", "text");
+  REQUIRE(bw.view() == "center |...text....|");
+  bw.clear();
+  bw.print("center |{:^^10}|", "text");
+  REQUIRE(bw.view() == "center |^^^text^^^|");
+  bw.clear();
+  bw.print("center |{:%3A^10}|", "text");
+  REQUIRE(bw.view() == "center |:::text:::|");
+  bw.clear();
+  bw.print("left >{0:<9}< right >{0:>9}< center >{0:^9}<", 956);
+  REQUIRE(bw.view() == "left >956      < right >      956< center >   956   <");
+
+  bw.clear();
+  bw.print("Format |{:>#010x}|", -956);
+  REQUIRE(bw.view() == "Format |0000-0x3bc|");
+  bw.clear();
+  bw.print("Format |{:<#010x}|", -956);
+  REQUIRE(bw.view() == "Format |-0x3bc0000|");
+  bw.clear();
+  bw.print("Format |{:#010x}|", -956);
+  REQUIRE(bw.view() == "Format |-0x00003bc|");
+
+  bw.clear();
+  bw.print("{{BAD_ARG_INDEX:{} of {}}}", 17, 23);
+  REQUIRE(bw.view() == "{BAD_ARG_INDEX:17 of 23}");
+
+  bw.clear();
+  bw.print("Arg {0} Arg {3}", 0, 1);
+  REQUIRE(bw.view() == "Arg 0 Arg {BAD_ARG_INDEX:3 of 2}");
+
+  bw.clear().print("{{stuff}} Arg {0} Arg {}", 0, 1, 2);
+  REQUIRE(bw.view() == "{stuff} Arg 0 Arg 0");
+  bw.clear().print("{{stuff}} Arg {0} Arg {} {}", 0, 1, 2);
+  REQUIRE(bw.view() == "{stuff} Arg 0 Arg 0 1");
+  bw.clear();
+  bw.print("Arg {0} Arg {} and {{stuff}}", 3, 4);
+  REQUIRE(bw.view() == "Arg 3 Arg 3 and {stuff}");
+  bw.clear().print("Arg {{{0}}} Arg {} and {{stuff}}", 5, 6);
+  REQUIRE(bw.view() == "Arg {5} Arg 5 and {stuff}");
+  bw.clear().print("Arg {{{0}}} Arg {} {1} {} {0} and {{stuff}}", 5, 6);
+  REQUIRE(bw.view() == "Arg {5} Arg 5 6 6 5 and {stuff}");
+  bw.clear();
+  bw.print("Arg {0} Arg {{}}{{}} {} and {} {{stuff}}", 7, 8);
+  REQUIRE(bw.view() == "Arg 7 Arg {}{} 7 and 8 {stuff}");
+  bw.clear();
+  bw.print("Arg {} Arg {{{{}}}} {} {1} {0}", 9, 10);
+  REQUIRE(bw.view() == "Arg 9 Arg {{}} 10 10 9");
+
+  bw.clear();
+  bw.print("Arg {} Arg {{{{}}}} {}", 9, 10);
+  REQUIRE(bw.view() == "Arg 9 Arg {{}} 10");
+  bw.clear();
+
+  bw.clear().print("{leif}");
+  REQUIRE(bw.view() == "{~leif~}"); // expected to be missing.
+
+  //  bw.clear().print("Thread: {thread-name} [{thread-id:#x}] - Tick: {tick} - Epoch: {now} - timestamp: {timestamp} !{0}", 31267);
+  //  REQUIRE(swoc::TextView(bw.view()).take_suffix_at('!') == "31267");
+}
+
+TEST_CASE("BWFormat numerics", "[bwprint][bwformat]")
+{
+  swoc::LocalBufferWriter<256> bw;
+  swoc::bwf::Format fmt("left >{0:<9}< right >{0:>9}< center >{0:^9}<");
+  std::string_view text{"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"};
+
+  bw.clear();
+  static const swoc::bwf::Format bad_arg_fmt{"{{BAD_ARG_INDEX:{} of {}}}"};
+  bw.print(bad_arg_fmt, 17, 23);
+  REQUIRE(bw.view() == "{BAD_ARG_INDEX:17 of 23}");
+
+  bw.clear();
+  bw.print(fmt, 956);
+  REQUIRE(bw.view() == "left >956      < right >      956< center >   956   <");
+
+  bw.clear().print("Text: _{0:20.10}_", text);
+  REQUIRE(bw.view() == "Text: _0123456789          _");
+  bw.clear().print("Text: _{0:>20.10}_", text);
+  REQUIRE(bw.view() == "Text: _          0123456789_");
+  bw.clear().print("Text: _{0:-<20.10,20}_", text.substr(52));
+  REQUIRE(bw.view() == "Text: _QRSTUVWXYZ----------_");
+
+  void *ptr = reinterpret_cast<void *>(0XBADD0956);
+  bw.clear();
+  bw.print("{}", ptr);
+  REQUIRE(bw.view() == "0xbadd0956");
+  bw.clear();
+  bw.print("{:X}", ptr);
+  REQUIRE(bw.view() == "0XBADD0956");
+  int *int_ptr = static_cast<int *>(ptr);
+  bw.clear();
+  bw.print("{}", int_ptr);
+  REQUIRE(bw.view() == "0xbadd0956");
+  char char_ptr[] = "delain";
+  bw.clear();
+  bw.print("{:x}", static_cast<char *>(ptr));
+  REQUIRE(bw.view() == "0xbadd0956");
+  bw.clear();
+  bw.print("{}", char_ptr);
+  REQUIRE(bw.view() == "delain");
+
+  swoc::MemSpan span{ptr, 0x200};
+  bw.clear().print("{}", span);
+  REQUIRE(bw.view() == "0x200@0xbadd0956");
+
+  swoc::MemSpan cspan{char_ptr, 6};
+  bw.clear().print("{::d}", cspan);
+  REQUIRE(bw.view() == "64 65 6c 61 69 6e");
+  bw.clear().print("{:#:d}", cspan);
+  REQUIRE(bw.view() == "0x64 0x65 0x6c 0x61 0x69 0x6e");
+  bw.clear().print("{:#.2:d}", cspan);
+  REQUIRE(bw.view() == "0x6465 0x6c61 0x696e");
+  bw.clear().print("{::d}", cspan.rebind());
+  REQUIRE(bw.view() == "64656c61696e");
+
+  std::string_view sv{"abc123"};
+  bw.clear();
+  bw.print("{}", sv);
+  REQUIRE(bw.view() == sv);
+  bw.clear();
+  bw.print("{:x}", sv);
+  REQUIRE(bw.view() == "616263313233");
+  bw.clear();
+  bw.print("{:#x}", sv);
+  REQUIRE(bw.view() == "0x616263313233");
+  bw.clear();
+  bw.print("|{:16x}|", sv);
+  REQUIRE(bw.view() == "|616263313233    |");
+  bw.clear();
+  bw.print("|{:>16x}|", sv);
+  REQUIRE(bw.view() == "|    616263313233|");
+  bw.clear();
+  bw.print("|{:^16x}|", sv);
+  REQUIRE(bw.view() == "|  616263313233  |");
+  bw.clear();
+  bw.print("|{:>16.2x}|", sv);
+  REQUIRE(bw.view() == "|            6162|");
+  bw.clear().print("|{:<0.4,7x}|", sv);
+  REQUIRE(bw.view() == "|6162633|");
+  bw.clear().print("|{:<5.2,7x}|", sv);
+  REQUIRE(bw.view() == "|6162 |");
+  bw.clear().print("|{:<5.3,7x}|", sv);
+  REQUIRE(bw.view() == "|616263|");
+  bw.clear().print("|{:<7.3x}|", sv);
+  REQUIRE(bw.view() == "|616263 |");
+
+  bw.clear();
+  bw.print("|{}|", true);
+  REQUIRE(bw.view() == "|1|");
+  bw.clear();
+  bw.print("|{}|", false);
+  REQUIRE(bw.view() == "|0|");
+  bw.clear();
+  bw.print("|{:s}|", true);
+  REQUIRE(bw.view() == "|true|");
+  bw.clear();
+  bw.print("|{:S}|", false);
+  REQUIRE(bw.view() == "|FALSE|");
+  bw.clear();
+  bw.print("|{:>9s}|", false);
+  REQUIRE(bw.view() == "|    false|");
+  bw.clear();
+  bw.print("|{:^10s}|", true);
+  REQUIRE(bw.view() == "|   true   |");
+
+  // Test clipping a bit.
+  swoc::LocalBufferWriter<20> bw20;
+  bw20.print("0123456789abc|{:^10s}|", true);
+  REQUIRE(bw20.view() == "0123456789abc|   tru");
+  bw20.clear();
+  bw20.print("012345|{:^10s}|6789abc", true);
+  REQUIRE(bw20.view() == "012345|   true   |67");
+
+  bw.clear().print("Char '{}'", 'a');
+  REQUIRE(bw.view() == "Char 'a'");
+  bw.clear().print("Byte '{}'", uint8_t{'a'});
+  REQUIRE(bw.view() == "Byte '97'");
+}
+
+TEST_CASE("bwstring", "[bwprint][bwstring]")
+{
+  std::string s;
+  swoc::TextView fmt("{} -- {}");
+  std::string_view text{"e99a18c428cb38d5f260853678922e03"};
+
+  swoc::bwprint(s, fmt, "string", 956);
+  REQUIRE(s.size() == 13);
+  REQUIRE(s == "string -- 956");
+
+  swoc::bwprint(s, fmt, 99999, text);
+  REQUIRE(s == "99999 -- e99a18c428cb38d5f260853678922e03");
+
+  swoc::bwprint(s, "{} .. |{:,20}|", 32767, text);
+  REQUIRE(s == "32767 .. |e99a18c428cb38d5f260|");
+
+  swoc::LocalBufferWriter<128> bw;
+  char buff[128];
+  snprintf(buff, sizeof(buff), "|%s|", bw.print("Deep Silent Complete by {}\0", "Nightwish"sv).data());
+  REQUIRE(std::string_view(buff) == "|Deep Silent Complete by Nightwish|");
+  snprintf(buff, sizeof(buff), "|%s|", bw.clear().print("Deep Silent Complete by {}\0elided junk", "Nightwish"sv).data());
+  REQUIRE(std::string_view(buff) == "|Deep Silent Complete by Nightwish|");
+
+  // Special tests for clang analyzer failures - special asserts are needed to make it happy but
+  // those can break functionality.
+  fmt = "Did you know? {}{} is {}"sv;
+  s.resize(0);
+  swoc::bwprint(s, fmt, "Lady "sv, "Persia"sv, "not mean");
+  REQUIRE(s == "Did you know? Lady Persia is not mean");
+  s.resize(0);
+  swoc::bwprint(s, fmt, ""sv, "Phil", "correct");
+  REQUIRE(s == "Did you know? Phil is correct");
+  s.resize(0);
+  swoc::bwprint(s, fmt, std::string_view(), "Leif", "confused");
+  REQUIRE(s == "Did you know? Leif is confused");
+
+  {
+    std::string out;
+    swoc::bwprint(out, fmt, ""sv, "Phil", "correct");
+    REQUIRE(out == "Did you know? Phil is correct");
+  }
+  {
+    std::string out;
+    swoc::bwprint(out, fmt, std::string_view(), "Leif", "confused");
+    REQUIRE(out == "Did you know? Leif is confused");
+  }
+}
+
+TEST_CASE("BWFormat integral", "[bwprint][bwformat]")
+{
+  swoc::LocalBufferWriter<256> bw;
+  swoc::bwf::Spec spec;
+  uint32_t num = 30;
+  int num_neg  = -30;
+
+  // basic
+  bwformat(bw, spec, num);
+  REQUIRE(bw.view() == "30");
+  bw.clear();
+  bwformat(bw, spec, num_neg);
+  REQUIRE(bw.view() == "-30");
+  bw.clear();
+
+  // radix
+  swoc::bwf::Spec spec_hex;
+  spec_hex._radix_lead_p = true;
+  spec_hex._type         = 'x';
+  bwformat(bw, spec_hex, num);
+  REQUIRE(bw.view() == "0x1e");
+  bw.clear();
+
+  swoc::bwf::Spec spec_dec;
+  spec_dec._type = '0';
+  bwformat(bw, spec_dec, num);
+  REQUIRE(bw.view() == "30");
+  bw.clear();
+
+  swoc::bwf::Spec spec_bin;
+  spec_bin._radix_lead_p = true;
+  spec_bin._type         = 'b';
+  bwformat(bw, spec_bin, num);
+  REQUIRE(bw.view() == "0b11110");
+  bw.clear();
+
+  int one     = 1;
+  int two     = 2;
+  int three_n = -3;
+  // alignment
+  swoc::bwf::Spec left;
+  left._align = swoc::bwf::Spec::Align::LEFT;
+  left._min   = 5;
+  swoc::bwf::Spec right;
+  right._align = swoc::bwf::Spec::Align::RIGHT;
+  right._min   = 5;
+  swoc::bwf::Spec center;
+  center._align = swoc::bwf::Spec::Align::CENTER;
+  center._min   = 5;
+
+  bwformat(bw, left, one);
+  bwformat(bw, right, two);
+  REQUIRE(bw.view() == "1        2");
+  bwformat(bw, right, two);
+  REQUIRE(bw.view() == "1        2    2");
+  bwformat(bw, center, three_n);
+  REQUIRE(bw.view() == "1        2    2 -3  ");
+
+  std::atomic<int> ax{0};
+  bw.clear().print("ax == {}", ax);
+  REQUIRE(bw.view() == "ax == 0");
+  ++ax;
+  bw.clear().print("ax == {}", ax);
+  REQUIRE(bw.view() == "ax == 1");
+}
+
+TEST_CASE("BWFormat floating", "[bwprint][bwformat]")
+{
+  swoc::LocalBufferWriter<256> bw;
+  swoc::bwf::Spec spec;
+
+  bw.clear();
+  bw.print("{}", 3.14);
+  REQUIRE(bw.view() == "3.14");
+  bw.clear();
+  bw.print("{} {:.2} {:.0} ", 32.7, 32.7, 32.7);
+  REQUIRE(bw.view() == "32.70 32.70 32 ");
+  bw.clear();
+  bw.print("{} neg {:.3}", -123.2, -123.2);
+  REQUIRE(bw.view() == "-123.20 neg -123.200");
+  bw.clear();
+  bw.print("zero {} quarter {} half {} 3/4 {}", 0, 0.25, 0.50, 0.75);
+  REQUIRE(bw.view() == "zero 0 quarter 0.25 half 0.50 3/4 0.75");
+  bw.clear();
+  bw.print("long {:.11}", 64.9);
+  REQUIRE(bw.view() == "long 64.90000000000");
+  bw.clear();
+
+  double n   = 180.278;
+  double neg = -238.47;
+  bwformat(bw, spec, n);
+  REQUIRE(bw.view() == "180.28");
+  bw.clear();
+  bwformat(bw, spec, neg);
+  REQUIRE(bw.view() == "-238.47");
+  bw.clear();
+
+  spec._prec = 5;
+  bwformat(bw, spec, n);
+  REQUIRE(bw.view() == "180.27800");
+  bw.clear();
+  bwformat(bw, spec, neg);
+  REQUIRE(bw.view() == "-238.47000");
+  bw.clear();
+
+  float f    = 1234;
+  float fneg = -1;
+  bwformat(bw, spec, f);
+  REQUIRE(bw.view() == "1234");
+  bw.clear();
+  bwformat(bw, spec, fneg);
+  REQUIRE(bw.view() == "-1");
+  bw.clear();
+  f          = 1234.5667;
+  spec._prec = 4;
+  bwformat(bw, spec, f);
+  REQUIRE(bw.view() == "1234.5667");
+  bw.clear();
+
+  bw << 1234 << .567;
+  REQUIRE(bw.view() == "12340.57");
+  bw.clear();
+  bw << f;
+  REQUIRE(bw.view() == "1234.57");
+  bw.clear();
+  bw << n;
+  REQUIRE(bw.view() == "180.28");
+  bw.clear();
+  bw << f << n;
+  REQUIRE(bw.view() == "1234.57180.28");
+  bw.clear();
+
+  double edge = 0.345;
+  spec._prec  = 3;
+  bwformat(bw, spec, edge);
+  REQUIRE(bw.view() == "0.345");
+  bw.clear();
+  edge = .1234;
+  bwformat(bw, spec, edge);
+  REQUIRE(bw.view() == "0.123");
+  bw.clear();
+  edge = 1.0;
+  bwformat(bw, spec, edge);
+  REQUIRE(bw.view() == "1");
+  bw.clear();
+
+  // alignment
+  double first  = 1.23;
+  double second = 2.35;
+  double third  = -3.5;
+  swoc::bwf::Spec left;
+  left._align = swoc::bwf::Spec::Align::LEFT;
+  left._min   = 5;
+  swoc::bwf::Spec right;
+  right._align = swoc::bwf::Spec::Align::RIGHT;
+  right._min   = 5;
+  swoc::bwf::Spec center;
+  center._align = swoc::bwf::Spec::Align::CENTER;
+  center._min   = 5;
+
+  bwformat(bw, left, first);
+  bwformat(bw, right, second);
+  REQUIRE(bw.view() == "1.23  2.35");
+  bwformat(bw, right, second);
+  REQUIRE(bw.view() == "1.23  2.35 2.35");
+  bwformat(bw, center, third);
+  REQUIRE(bw.view() == "1.23  2.35 2.35-3.50");
+  bw.clear();
+
+  double over = 1.4444444;
+  swoc::bwf::Spec over_min;
+  over_min._prec = 7;
+  over_min._min  = 5;
+  bwformat(bw, over_min, over);
+  REQUIRE(bw.view() == "1.4444444");
+  bw.clear();
+
+  // Edge
+  bw.print("{}", (1.0 / 0.0));
+  REQUIRE(bw.view() == "Inf");
+  bw.clear();
+
+  double inf = std::numeric_limits<double>::infinity();
+  bw.print("  {} ", inf);
+  REQUIRE(bw.view() == "  Inf ");
+  bw.clear();
+
+  double nan_1 = std::nan("1");
+  bw.print("{} {}", nan_1, nan_1);
+  REQUIRE(bw.view() == "NaN NaN");
+  bw.clear();
+
+  double z = 0.0;
+  bw.print("{}  ", z);
+  REQUIRE(bw.view() == "0  ");
+  bw.clear();
+}
+
+TEST_CASE("bwstring std formats", "[libswoc][bwprint]")
+{
+  swoc::LocalBufferWriter<120> w;
+
+  w.print("{}", swoc::bwf::Errno(13));
+  REQUIRE(w.view() == "EACCES: Permission denied [13]"sv);
+  w.clear().print("{}", swoc::bwf::Errno(134));
+  REQUIRE(w.view().substr(0, 22) == "Unknown: Unknown error"sv);
+
+  time_t t = 1528484137;
+  // default is GMT
+  w.clear().print("{} is {}", t, swoc::bwf::Date(t));
+  REQUIRE(w.view() == "1528484137 is 2018 Jun 08 18:55:37");
+  w.clear().print("{} is {}", t, swoc::bwf::Date(t, "%a, %d %b %Y at %H.%M.%S"));
+  REQUIRE(w.view() == "1528484137 is Fri, 08 Jun 2018 at 18.55.37");
+  // OK to be explicit
+  w.clear().print("{} is {::gmt}", t, swoc::bwf::Date(t));
+  REQUIRE(w.view() == "1528484137 is 2018 Jun 08 18:55:37");
+  w.clear().print("{} is {::gmt}", t, swoc::bwf::Date(t, "%a, %d %b %Y at %H.%M.%S"));
+  REQUIRE(w.view() == "1528484137 is Fri, 08 Jun 2018 at 18.55.37");
+  // Local time - set it to something specific or the test will be geographically sensitive.
+  setenv("TZ", "CST6", 1);
+  tzset();
+  w.clear().print("{} is {::local}", t, swoc::bwf::Date(t));
+  REQUIRE(w.view() == "1528484137 is 2018 Jun 08 12:55:37");
+  w.clear().print("{} is {::local}", t, swoc::bwf::Date(t, "%a, %d %b %Y at %H.%M.%S"));
+  REQUIRE(w.view() == "1528484137 is Fri, 08 Jun 2018 at 12.55.37");
+
+  // Verify these compile and run, not really much hope to check output.
+  w.clear().print("|{}|   |{}|", swoc::bwf::Date(), swoc::bwf::Date("%a, %d %b %Y"));
+
+  w.clear().print("name = {}", swoc::bwf::FirstOf("Persia"));
+  REQUIRE(w.view() == "name = Persia");
+  w.clear().print("name = {}", swoc::bwf::FirstOf("Persia", "Evil Dave"));
+  REQUIRE(w.view() == "name = Persia");
+  w.clear().print("name = {}", swoc::bwf::FirstOf("", "Evil Dave"));
+  REQUIRE(w.view() == "name = Evil Dave");
+  w.clear().print("name = {}", swoc::bwf::FirstOf(nullptr, "Evil Dave"));
+  REQUIRE(w.view() == "name = Evil Dave");
+  w.clear().print("name = {}", swoc::bwf::FirstOf("Persia", "Evil Dave", "Leif"));
+  REQUIRE(w.view() == "name = Persia");
+  w.clear().print("name = {}", swoc::bwf::FirstOf("Persia", nullptr, "Leif"));
+  REQUIRE(w.view() == "name = Persia");
+  w.clear().print("name = {}", swoc::bwf::FirstOf("", nullptr, "Leif"));
+  REQUIRE(w.view() == "name = Leif");
+
+  const char *empty{nullptr};
+  std::string s1{"Persia"};
+  std::string_view s2{"Evil Dave"};
+  swoc::TextView s3{"Leif"};
+  w.clear().print("name = {}", swoc::bwf::FirstOf(empty, s3));
+  REQUIRE(w.view() == "name = Leif");
+  w.clear().print("name = {}", swoc::bwf::FirstOf(s2, s3));
+  REQUIRE(w.view() == "name = Evil Dave");
+  w.clear().print("name = {}", swoc::bwf::FirstOf(s1, empty, s2));
+  REQUIRE(w.view() == "name = Persia");
+  w.clear().print("name = {}", swoc::bwf::FirstOf(empty, s2, s1, s3));
+  REQUIRE(w.view() == "name = Evil Dave");
+  w.clear().print("name = {}", swoc::bwf::FirstOf(empty, empty, s3, empty, s2, s1));
+  REQUIRE(w.view() == "name = Leif");
+}
+
+// Test alternate format parsing.
+struct AltFormatEx {
+  AltFormatEx(TextView fmt);
+
+  explicit operator bool() const;
+  bool operator()(std::string_view &literal, swoc::bwf::Spec &spec);
+  TextView _fmt;
+};
+
+AltFormatEx::AltFormatEx(TextView fmt) : _fmt{fmt} {}
+
+AltFormatEx::operator bool() const
+{
+  return !_fmt.empty();
+}
+
+bool
+AltFormatEx::operator()(std::string_view &literal, swoc::bwf::Spec &spec)
+{
+  if (_fmt.size()) {
+    literal = _fmt.split_prefix_at('%');
+    if (literal.empty()) {
+      literal = _fmt;
+      _fmt.clear();
+      return false;
+    }
+
+    if (_fmt.size() >= 1) {
+      char c = _fmt[0];
+      if (c == '%') {
+        literal = {literal.data(), literal.size() + 1};
+        ++_fmt;
+      } else if (c == '<') {
+        size_t off = 0;
+        do {
+          off = _fmt.find('>', off + 1);
+          if (off == TextView::npos) {
+            throw std::invalid_argument("Unclosed leading angle bracket");
+          }
+        } while (':' == _fmt[off - 1]);
+        spec.parse(_fmt.substr(1, off - 1));
+        if (spec._name.empty()) {
+          throw std::invalid_argument("No name in specifier");
+        }
+        _fmt.remove_prefix(off + 1);
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+struct Header {
+  TextView
+  proto() const
+  {
+    return "ipv4";
+  }
+  TextView
+  chi() const
+  {
+    return "10.56.128.96";
+  }
+};
+
+using AltNames = swoc::bwf::ContextNames<Header>;
+
+TEST_CASE("bwf alternate", "[libswoc][bwf]")
+{
+  using BW   = swoc::BufferWriter;
+  using Spec = swoc::bwf::Spec;
+  AltNames names;
+  Header hdr;
+  names.assign("proto", [](BW &w, Spec const &spec, Header &hdr) -> BW & { return swoc::bwformat(w, spec, hdr.proto()); });
+  names.assign("chi", [](BW &w, Spec const &spec, Header &hdr) -> BW & { return swoc::bwformat(w, spec, hdr.chi()); });
+
+  swoc::LocalBufferWriter<256> w;
+  w.print_nv(names.bind(hdr), AltFormatEx("This is chi - %<chi>"));
+  REQUIRE(w.view() == "This is chi - 10.56.128.96");
+  w.clear().print_nv(names.bind(hdr), AltFormatEx("Use %% for a single"));
+  REQUIRE(w.view() == "Use % for a single");
+  w.clear().print_nv(names.bind(hdr), AltFormatEx("Use %%<proto> for %<proto>, dig?"));
+  REQUIRE(w.view() == "Use %<proto> for ipv4, dig?");
+  w.clear().print_nv(names.bind(hdr), AltFormatEx("Width |%<proto:10>| dig?"));
+  REQUIRE(w.view() == "Width |ipv4      | dig?");
+  w.clear().print_nv(names.bind(hdr), AltFormatEx("Width |%<proto:>10>| dig?"));
+  REQUIRE(w.view() == "Width |      ipv4| dig?");
+
+  swoc::bwprintf(w.clear(), "Fifty Six = %d", 56);
+  REQUIRE(w.view() == "Fifty Six = 56");
+  swoc::bwprintf(w.clear(), "int is %i", 101);
+  REQUIRE(w.view() == "int is 101");
+  swoc::bwprintf(w.clear(), "int is %zd", 102);
+  REQUIRE(w.view() == "int is 102");
+  swoc::bwprintf(w.clear(), "int is %ld", 103);
+  REQUIRE(w.view() == "int is 103");
+  swoc::bwprintf(w.clear(), "int is %s", 104);
+  REQUIRE(w.view() == "int is 104");
+  swoc::bwprintf(w.clear(), "int is %ld", -105);
+  REQUIRE(w.view() == "int is -105");
+
+  TextView digits{"0123456789"};
+  swoc::bwprintf(w.clear(), "Chars |%*s|", 12, digits);
+  REQUIRE(w.view() == "Chars |  0123456789|");
+  swoc::bwprintf(w.clear(), "Chars %.*s", 4, digits);
+  REQUIRE(w.view() == "Chars 0123");
+  swoc::bwprintf(w.clear(), "Chars |%*.*s|", 12, 5, digits);
+  REQUIRE(w.view() == "Chars |       01234|");
+}
+
+// Normally there's no point in running the performance tests, but it's worth keeping the code
+// for when additional testing needs to be done.
+#if 0
+TEST_CASE("bwperf", "[bwprint][performance]")
+{
+  // Force these so I can easily change the set of tests.
+  auto start            = std::chrono::high_resolution_clock::now();
+  auto delta = std::chrono::high_resolution_clock::now() - start;
+  constexpr int N_LOOPS = 1000000;
+
+  static constexpr const char * FMT = "Format |{:#010x}| '{}'";
+  static constexpr swoc::TextView fmt{FMT, strlen(FMT)};
+  static constexpr std::string_view text{"e99a18c428cb38d5f260853678922e03"sv};
+  swoc::LocalBufferWriter<256> bw;
+
+  swoc::bwf::Spec spec;
+
+  bw.clear();
+  bw.print(fmt, -956, text);
+  REQUIRE(bw.view() == "Format |-0x00003bc| 'e99a18c428cb38d5f260853678922e03'");
+
+  start = std::chrono::high_resolution_clock::now();
+  for (int i = 0; i < N_LOOPS; ++i) {
+    bw.clear();
+    bw.print(fmt, -956, text);
+  }
+  delta = std::chrono::high_resolution_clock::now() - start;
+  std::cout << "bw.print() " << delta.count() << "ns or " << std::chrono::duration_cast<std::chrono::milliseconds>(delta).count()
+            << "ms" << std::endl;
+
+  swoc::bwf::Format pre_fmt(fmt);
+  start = std::chrono::high_resolution_clock::now();
+  for (int i = 0; i < N_LOOPS; ++i) {
+    bw.clear();
+    bw.print(pre_fmt, -956, text);
+  }
+  delta = std::chrono::high_resolution_clock::now() - start;
+  std::cout << "Preformatted: " << delta.count() << "ns or "
+            << std::chrono::duration_cast<std::chrono::milliseconds>(delta).count() << "ms" << std::endl;
+
+  char buff[256];
+  start = std::chrono::high_resolution_clock::now();
+  for (int i = 0; i < N_LOOPS; ++i) {
+    snprintf(buff, sizeof(buff), "Format |%#0x10| '%.*s'", -956, static_cast<int>(text.size()), text.data());
+  }
+  delta = std::chrono::high_resolution_clock::now() - start;
+  std::cout << "snprint Timing is " << delta.count() << "ns or "
+            << std::chrono::duration_cast<std::chrono::milliseconds>(delta).count() << "ms" << std::endl;
+}
+#endif

--- a/lib/swoc++/src/unit_tests/test_meta.cc
+++ b/lib/swoc++/src/unit_tests/test_meta.cc
@@ -1,0 +1,107 @@
+/** @file
+
+    Unit tests for ts_meta.h and other meta programming.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements.  See the NOTICE file distributed with this work for additional information regarding
+    copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with the License.  You may
+    obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#include <cstring>
+
+#include "swoc/swoc_meta.h"
+#include "swoc/TextView.h"
+
+#include "swoc/ext/catch.hpp"
+
+struct A {
+  int _value;
+};
+
+struct AA : public A {
+};
+
+struct B {
+  std::string _value;
+};
+
+struct C {
+};
+
+struct D {
+};
+
+// Some example meta-programming, saving it for possible later use.
+
+template <typename...> struct is_any_of_1 {
+  static constexpr bool value = false;
+};
+template <typename T, typename T0> struct is_any_of_1<T, T0> {
+  static constexpr bool value = std::is_same<T, T0>::value;
+};
+template <typename T, typename T0, typename... Rest> struct is_any_of_1<T, T0, Rest...> {
+  static constexpr bool value = std::is_same<T, T0>::value || (sizeof...(Rest) > 0 && is_any_of_1<T, Rest...>::value);
+};
+
+// Requires C++17
+template <typename T, typename... Rest> struct is_any_of_2 {
+  static constexpr bool value = std::disjunction<std::is_same<T, Rest>...>::value;
+};
+
+TEST_CASE("Meta Example", "[meta][example]")
+{
+  REQUIRE(is_any_of_1<A, A, B, C>::value);
+  REQUIRE(!is_any_of_1<D, A, B, C>::value);
+  REQUIRE(is_any_of_1<A, A>::value);
+  REQUIRE(!is_any_of_1<A, D>::value);
+  REQUIRE(!is_any_of_1<A>::value);
+
+  REQUIRE(is_any_of_2<A, A, B, C>::value);
+  REQUIRE(!is_any_of_2<D, A, B, C>::value);
+  REQUIRE(is_any_of_2<A, A>::value);
+  REQUIRE(!is_any_of_2<A, D>::value);
+  REQUIRE(!is_any_of_2<A>::value);
+}
+
+// Start of ts::meta testing.
+
+namespace
+{
+template <typename T>
+auto
+detect(T &&t, swoc::meta::CaseTag<0>) -> std::string_view
+{
+  return "none";
+}
+template <typename T>
+auto
+detect(T &&t, swoc::meta::CaseTag<1>) -> decltype(t._value, std::string_view())
+{
+  return "value";
+}
+template <typename T>
+std::string_view
+detect(T &&t)
+{
+  return detect(t, swoc::meta::CaseArg);
+}
+} // namespace
+
+TEST_CASE("Meta", "[meta]")
+{
+  REQUIRE(detect(A()) == "value");
+  REQUIRE(detect(B()) == "value");
+  REQUIRE(detect(C()) == "none");
+  REQUIRE(detect(AA()) == "value");
+}

--- a/lib/swoc++/src/unit_tests/test_swoc_file.cc
+++ b/lib/swoc++/src/unit_tests/test_swoc_file.cc
@@ -1,0 +1,66 @@
+/** @file
+
+    swoc::file unit tests.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements.  See the NOTICE file distributed with this work for additional information regarding
+    copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with the License.  You may
+    obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <iostream>
+
+#include "swoc/swoc_file.h"
+#include "swoc/ext/catch.hpp"
+
+using swoc::file::path;
+
+// --------------------
+TEST_CASE("swoc_file", "[libts][swoc_file]")
+{
+  path p1("/home");
+  REQUIRE(p1.string() == "/home");
+  auto p2 = p1 / "bob";
+  REQUIRE(p2.string() == "/home/bob");
+  p2 = p2 / "git/ats/";
+  REQUIRE(p2.string() == "/home/bob/git/ats/");
+  p2 /= "lib/ts";
+  REQUIRE(p2.string() == "/home/bob/git/ats/lib/ts");
+  p2 /= "/home/dave";
+  REQUIRE(p2.string() == "/home/dave");
+  path p3 = path("/home/dave") / "git/tools";
+  REQUIRE(p3.string() == "/home/dave/git/tools");
+}
+
+TEST_CASE("swoc_file_io", "[libts][swoc_file_io]")
+{
+  path file("src/unit_tests/test_swoc_file.cc");
+  std::error_code ec;
+  std::string content = swoc::file::load(file, ec);
+  REQUIRE(ec.value() == 0);
+  REQUIRE(content.size() > 0);
+  REQUIRE(content.find("swoc::file::path") != content.npos);
+
+  // Check some file properties.
+  REQUIRE(swoc::file::is_readable(file) == true);
+  auto fs = swoc::file::status(file, ec);
+  REQUIRE(ec.value() == 0);
+  REQUIRE(swoc::file::is_dir(fs) == false);
+  REQUIRE(swoc::file::is_regular_file(fs) == true);
+
+  // Failure case.
+  file    = "unit-tests/no_such_file.txt";
+  content = swoc::file::load(file, ec);
+  REQUIRE(ec.value() == 2);
+  REQUIRE(swoc::file::is_readable(file) == false);
+}

--- a/lib/swoc++/src/unit_tests/unit_test_main.cc
+++ b/lib/swoc++/src/unit_tests/unit_test_main.cc
@@ -1,0 +1,24 @@
+/** @file
+
+  This file used for catch based tests. It is the main() stub.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one or more contributor
+  license agreements. See the NOTICE file distributed with this work for
+  additional information regarding copyright ownership.  The ASF licenses this
+  file to you under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License.  You may obtain a copy of
+  the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+ */
+
+#define CATCH_CONFIG_MAIN
+#include "swoc/ext/catch.hpp"


### PR DESCRIPTION
For the Canned-YAML effort, there is a dependency on an updated version of some of the ATS infrastructure. I was requested to add it as a single code drop in the same format as it will be used by Canned-YAML. This adds it to the code base in that style, the same as for YAMLCPP.

This PR would replace the other YAML related infrastructure PRs.

For commenting on the code you can go to the [original repository](https://github.com/SolidWallOfCode/libswoc).