### PR TITLE
Log deletion rewrite

### DIFF
--- a/doc/admin-guide/files/logging.yaml.en.rst
+++ b/doc/admin-guide/files/logging.yaml.en.rst
@@ -313,6 +313,8 @@ rolling_offset_hr      number      Specifies an hour (from 0 to 23) at which log
                                    :ts:cv:`proxy.config.log.rolling_offset_hr`.
 rolling_size_mb        number      Size, in megabytes, at which log files are
                                    rolled.
+rolling_min_count      number      Specifies the minimum number of rolled logs to
+                                   keep.
 filters                array of    The optional list of filter objects which
                        filters     restrict the individual events logged. The array
                                    may only contain one accept filter.

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -277,7 +277,7 @@ System Variables
 
    Specifies the minimum count of rolled output logs to keep. This value will be used to decide the
    order of auto-deletion (if enabled). A default value of 0 means auto-deletion will try to keep
-   output logs as much as possible.
+   output logs as much as possible. See :doc:`../logging/rotation.en.rst` for guidance.
 
 Thread Variables
 ----------------
@@ -2961,7 +2961,7 @@ Logging Configuration
 
    Specifies the minimum count of rolled (event) logs to keep. This value will be used to decide the
    order of auto-deletion (if enabled). A default value of 0 means auto-deletion will try to keep
-   logs as much as possible. This value can be and should be overridden in logging.yaml.
+   logs as much as possible. This value can be and should be overridden in logging.yaml. See :doc:`../logging/rotation.en.rst` for guidance.
 
 .. ts:cv:: CONFIG proxy.config.log.auto_delete_rolled_files INT 1
    :reloadable:
@@ -3130,7 +3130,7 @@ Diagnostic Logging Configuration
 
    Specifies the minimum count of rolled diagnostic logs to keep. This value will be used to decide the
    order of auto-deletion (if enabled). A default value of 0 means auto-deletion will try to keep
-   diagnostic logs as much as possible.
+   diagnostic logs as much as possible. See :doc:`../logging/rotation.en.rst` for guidance.
 
 Reverse Proxy
 =============

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -272,6 +272,12 @@ System Variables
 
    Specifies at what size to roll the output log at.
 
+.. ts:cv:: CONFIG proxy.config.output.logfile.rolling_min_count INT 0
+   :reloadable:
+
+   Specifies the minimum count of rolled output logs to keep. This value will be used to decide the
+   order of auto-deletion (if enabled). A default value of 0 means auto-deletion will try to keep
+   output logs as much as possible.
 
 Thread Variables
 ----------------
@@ -2950,6 +2956,13 @@ Logging Configuration
    The size, in megabytes, that log files must reach before rolling takes place.
    The minimum value for this setting is ``10``.
 
+.. ts:cv:: CONFIG proxy.config.log.rolling_min_count INT 0
+   :reloadable:
+
+   Specifies the minimum count of rolled (event) logs to keep. This value will be used to decide the
+   order of auto-deletion (if enabled). A default value of 0 means auto-deletion will try to keep
+   logs as much as possible. This value can be and should be overridden in logging.yaml.
+
 .. ts:cv:: CONFIG proxy.config.log.auto_delete_rolled_files INT 1
    :reloadable:
 
@@ -3111,6 +3124,13 @@ Diagnostic Logging Configuration
    :units: megabytes
 
    Specifies at what size to roll the diagnostics log at.
+
+.. ts:cv:: CONFIG proxy.config.diags.logfile.rolling_min_count INT 0
+   :reloadable:
+
+   Specifies the minimum count of rolled diagnostic logs to keep. This value will be used to decide the
+   order of auto-deletion (if enabled). A default value of 0 means auto-deletion will try to keep
+   diagnostic logs as much as possible.
 
 Reverse Proxy
 =============
@@ -3457,11 +3477,11 @@ Client-Related Configuration
 
    You can override this global setting on a per domain basis in the ssl_servername.yaml file using the :ref:`verify_server_policy attribute<override-verify-server-policy>`.
 
-:code:`DISABLED` 
+:code:`DISABLED`
    Server Certificate will not be verified
-:code:`PERMISSIVE` 
+:code:`PERMISSIVE`
    Certificate will be verified and the connection will not be established if verification fails.
-:code:`ENFORCED` 
+:code:`ENFORCED`
    The provided certificate will be verified and the connection will be established irrespective of the verification result. If verification fails the name of the server will be logged.
 
 .. ts:cv:: CONFIG proxy.config.ssl.client.verify.server.properties STRING ALL
@@ -3494,7 +3514,7 @@ Client-Related Configuration
 
    :0: Server Certificate will not be verified
    :1: Certificate will be verified and the connection will not be established if verification fail
-   :2: The provided certificate will be verified and the connection will be established 
+   :2: The provided certificate will be verified and the connection will be established
 
 .. ts:cv:: CONFIG proxy.config.ssl.client.cert.filename STRING NULL
    :overridable:
@@ -3927,7 +3947,7 @@ Sockets
 
         Reduce the number of worker threads (net-threads)
         Reduce the number of disk (AIO) threads
-	Make sure accept threads are enabled
+   Make sure accept threads are enabled
 
    The relevant configurations for this are::
 

--- a/doc/admin-guide/logging/rotation.en.rst
+++ b/doc/admin-guide/logging/rotation.en.rst
@@ -195,9 +195,14 @@ following actions:
 
 -  If the autodelete option is enabled, then |TS| identifies previously-rolled
    log files (log files with the ``.old`` extension). It starts deleting files
-   one by one, beginning with the oldest file with largest ratio to the minimum
-   rolling count, until it emerges from the low state. |TS| logs a record of all
-   deleted files in the system error log.
+   one by one, beginning with the oldest file with largest ratio between current
+   number of files and the minimum rolling count, until it emerges from the low
+   state. The default minimum rolling count of 0 is treated as INT_MAX during
+   ratio calculation. Hence the `rolling_min_count` is not guaranteed to be
+   reserved; instead, it is used as a reference to decide the priority of log
+   files to delete. In low space state, even when all log files are below minimum
+   count, |TS| still tries to delete files until it emerges from the low state.
+   |TS| logs a record of all deleted files in the system error log.
 
 -  If the autodelete option is disabled or there are not enough old log files
    to delete for the system to emerge from its low space state, then |TS|

--- a/doc/admin-guide/logging/rotation.en.rst
+++ b/doc/admin-guide/logging/rotation.en.rst
@@ -167,6 +167,11 @@ they reach a certain size, adjust the following settings in
 
     CONFIG proxy.config.log.rolling_interval_sec INT 21600
 
+#. Set the minimum number of rolled files with
+   :ts:cv:`proxy.config.log.rolling_min_count`. ::
+
+    CONFIG proxy.config.log.rolling_min_count INT 0
+
 #. Run the command :option:`traffic_ctl config reload` to apply the configuration
    changes.
 
@@ -190,8 +195,9 @@ following actions:
 
 -  If the autodelete option is enabled, then |TS| identifies previously-rolled
    log files (log files with the ``.old`` extension). It starts deleting files
-   one by one, beginning with the oldest file, until it emerges from the low
-   state. |TS| logs a record of all deleted files in the system error log.
+   one by one, beginning with the oldest file with largest ratio to the minimum
+   rolling count, until it emerges from the low state. |TS| logs a record of all
+   deleted files in the system error log.
 
 -  If the autodelete option is disabled or there are not enough old log files
    to delete for the system to emerge from its low space state, then |TS|

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -95,6 +95,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.output.logfile.rolling_size_mb", RECD_INT, "100", RECU_DYNAMIC, RR_NULL, RECC_STR, "^0*[1-9][0-9]*$", RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.output.logfile.rolling_min_count", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_STR, "^0*[1-9][0-9]*$", RECA_NULL}
+  ,
   //# 0 = disable
   {RECT_CONFIG, "proxy.config.res_track_memory", RECD_INT, "0", RECU_RESTART_TS, RR_REQUIRED, RECC_INT,  "[0-2]", RECA_NULL}
   ,
@@ -229,6 +231,8 @@ static const RecordElement RecordsConfig[] =
   {RECT_CONFIG, "proxy.config.diags.logfile.rolling_interval_sec", RECD_INT, "3600", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.diags.logfile.rolling_size_mb", RECD_INT, "10", RECU_DYNAMIC, RR_NULL, RECC_STR, "^0*[1-9][0-9]*$", RECA_NULL}
+  ,
+  {RECT_CONFIG, "proxy.config.diags.logfile.rolling_min_count", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_STR, "^0*[1-9][0-9]*$", RECA_NULL}
   ,
 
   //##############################################################################
@@ -1043,6 +1047,8 @@ static const RecordElement RecordsConfig[] =
   {RECT_CONFIG, "proxy.config.log.rolling_offset_hr", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.log.rolling_size_mb", RECD_INT, "10", RECU_DYNAMIC, RR_NULL, RECC_STR, "^0*[1-9][0-9]*$", RECA_NULL}
+  ,
+  {RECT_CONFIG, "proxy.config.log.rolling_min_count", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_STR, "^0*[1-9][0-9]*$", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.log.auto_delete_rolled_files", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
   ,

--- a/proxy/logging/LogConfig.cc
+++ b/proxy/logging/LogConfig.cc
@@ -768,9 +768,6 @@ LogConfig::update_space_used()
   total_space_used = 0LL;
   candidate_count  = 0;
 
-  for (auto it = deleting_info.begin(); it != deleting_info.end(); it++) {
-    Debug("%s", it->name.c_str());
-  }
   while ((entry = readdir(ld))) {
     snprintf(path, MAXPATHLEN, "%s/%s", logfile_dir, entry->d_name);
 

--- a/proxy/logging/LogConfig.cc
+++ b/proxy/logging/LogConfig.cc
@@ -851,9 +851,7 @@ LogConfig::update_space_used()
       // Select the group with biggest ratio
       auto target =
         std::max_element(deleting_info.begin(), deleting_info.end(), [](LogDeletingInfo const &A, LogDeletingInfo const &B) {
-          double diff =
-            static_cast<double>(A.candidates.size()) / A.min_count - static_cast<double>(B.candidates.size()) / B.min_count;
-          return diff < 0.0;
+          return static_cast<double>(A.candidates.size()) / A.min_count < static_cast<double>(B.candidates.size()) / B.min_count;
         });
 
       auto &candidates = target->candidates;


### PR DESCRIPTION
#4277 
As discussed during the summit, a “min-count” configuration is added to specify the minimum number of rolled log files to keep for each log file type. When disk headroom is below the minimum, rotated log files will be deleted as the oldest log file of the type with the largest ratio of rolled files to minimum file count. 