### PR TITLE
Augment cryptic diag message when log line fails to print

### DIFF
--- a/proxy/logging/LogField.cc
+++ b/proxy/logging/LogField.cc
@@ -716,6 +716,7 @@ LogFieldList::clear()
     delete f; // safe given the semantics stated above
   }
   m_marshal_len = 0;
+  _badSymbols.clear();
 }
 
 void
@@ -821,4 +822,13 @@ LogFieldList::display(FILE *fd)
   for (LogField *f = first(); f; f = next(f)) {
     f->display(fd);
   }
+}
+
+void
+LogFieldList::addBadSymbol(std::string_view badSymbol)
+{
+  if (_badSymbols.size() > 0) {
+    _badSymbols += ", ";
+  }
+  _badSymbols += badSymbol;
 }

--- a/proxy/logging/LogField.h
+++ b/proxy/logging/LogField.h
@@ -23,6 +23,9 @@
 
 #pragma once
 
+#include <string_view>
+#include <string>
+
 #include "tscore/ink_platform.h"
 #include "tscore/List.h"
 #include "tscore/TsBuffer.h"
@@ -243,6 +246,18 @@ public:
   unsigned count();
   void display(FILE *fd = stdout);
 
+  // Add a bad symbol seen in the log format to the list of bad symbols.
+  //
+  void addBadSymbol(std::string_view badSymbol);
+
+  // Return blank-separated list of added bad symbols.
+  //
+  std::string_view
+  badSymbols() const
+  {
+    return _badSymbols;
+  }
+
   // noncopyable
   // -- member functions that are not allowed --
   LogFieldList(const LogFieldList &rhs) = delete;
@@ -251,6 +266,7 @@ public:
 private:
   unsigned m_marshal_len;
   Queue<LogField> m_field_list;
+  std::string _badSymbols;
 };
 
 /** Base IP address data.

--- a/proxy/logging/LogFormat.cc
+++ b/proxy/logging/LogFormat.cc
@@ -550,6 +550,7 @@ LogFormat::parse_symbol_string(const char *symbol_string, LogFieldList *field_li
         Note("The log format symbol %s was not found in the "
              "list of known symbols.",
              symbol);
+        field_list->addBadSymbol(symbol);
       }
     }
 


### PR DESCRIPTION
 Due to unknown field specifier in custom log format.