### PR TITLE
Fix for #4413 - avoid ASAN crash on use after free for file name.

### DIFF
--- a/mgmt/FileManager.cc
+++ b/mgmt/FileManager.cc
@@ -110,7 +110,7 @@ FileManager::addFileHelper(const char *fileName, const char *configName, bool ro
   Rollback *rb    = new Rollback(fileName, configName, root_access_needed, parentRollback, flags);
   rb->configFiles = this;
 
-  bindings.emplace(fileName, rb);
+  bindings.emplace(rb->getFileName(), rb);
 }
 
 // bool FileManager::getRollbackObj(char* fileName, Rollback** rbPtr)


### PR DESCRIPTION
This is intended to fix a bug introduced in #4413.