### PR TITLE
Handle inactivity timeout event in state_http_server_open

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -1757,6 +1757,7 @@ HttpSM::state_http_server_open(int event, void *data)
     }
     break;
   case VC_EVENT_ERROR:
+  case VC_EVENT_INACTIVITY_TIMEOUT:
   case NET_EVENT_OPEN_FAILED:
     t_state.current.state = HttpTransact::CONNECTION_ERROR;
     // save the errno from the connect fail for future use (passed as negative value, flip back)


### PR DESCRIPTION
Fixes coredump when testing in production

(cherry picked from commit 77be1357d5a50f31811e13b04648a4c5558e95ff)