### PR TITLE
Acquire mutex lock before call free

### DIFF
--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -366,7 +366,10 @@ Http2ClientSession::main_event_handler(int event, void *edata)
 
   recursion--;
   if (!connection_state.is_recursing() && this->recursion == 0 && kill_me) {
-    this->free();
+    MUTEX_TRY_LOCK(lock, this->mutex, this_ethread());
+    if (lock.is_locked()) {
+      this->free();
+    }
   }
   return retval;
 }


### PR DESCRIPTION
Possible fix for #4504. The `ua_session` could be freed by below 3 places. So while calling `Http2ConnectionState::release_stream()`, some of them ran on another thread.

A). `ProxyClientSession::handle_api_return()`
https://github.com/apache/trafficserver/blob/322e97b84a8f7e9d2956c902d619ef959411000a/proxy/ProxyClientSession.cc#L201

B). `Http2ConnectionState::main_event_handler()`
https://github.com/apache/trafficserver/blob/322e97b84a8f7e9d2956c902d619ef959411000a/proxy/http2/Http2ConnectionState.cc#L1000-L1002

C). `Http2ClientSession::main_event_handler()`
https://github.com/apache/trafficserver/blob/322e97b84a8f7e9d2956c902d619ef959411000a/proxy/http2/Http2ClientSession.cc#L369

As for C, there is no guarantee of that the mutex of Http2ClientSession is locked on the thread before calling free(). This change covers this case.