### PR TITLE
Rewrite TunnelHashMap in modern standard

### DIFF
--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -1709,8 +1709,7 @@ SSLNetVConnection::callHooks(TSEvent eventId)
 
   this->serverName = const_cast<char *>(SSL_get_servername(this->ssl, TLSEXT_NAMETYPE_host_name));
   if (this->serverName) {
-    auto *hs = TunnelMap.find(this->serverName);
-    if (hs != nullptr) {
+    if (auto it = TunnelMap.find(this->serverName); it != TunnelMap.end()) {
       this->SNIMapping = true;
       this->attributes = HttpProxyPort::TRANSPORT_BLIND_TUNNEL;
       return reenabled;

--- a/iocore/net/SSLSNIConfig.cc
+++ b/iocore/net/SSLSNIConfig.cc
@@ -79,7 +79,7 @@ SNIConfigParams::loadSNIConfig()
     }
 
     if (item.tunnel_destination.length()) {
-      TunnelMap.emplace(item.fqdn.data(), item.tunnel_destination);
+      TunnelMap.emplace(item.fqdn, item.tunnel_destination);
     }
 
     auto ai3 = new SNI_IpAllow(item.ip_allow, servername);

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -2111,8 +2111,6 @@ SSLParseCertificateConfiguration(const SSLConfigParams *params, SSLCertLookup *l
 
   Note("loading SSL certificate configuration from %s", params->configFilePath);
 
-  //  TunnelMap.clear();
-
   if (params->configFilePath) {
     file_buf = readIntoBuffer(params->configFilePath, __func__, nullptr);
   }

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -575,11 +575,10 @@ HttpSM::setup_blind_tunnel_port()
       t_state.hdr_info.client_request.url_create(&u);
       u.scheme_set(URL_SCHEME_TUNNEL, URL_LEN_TUNNEL);
       t_state.hdr_info.client_request.url_set(&u);
-      auto *hs = TunnelMap.find(ssl_vc->serverName);
-      if (hs != nullptr) {
-        t_state.hdr_info.client_request.url_get()->host_set(hs->hostname, hs->len);
-        if (hs->port > 0) {
-          t_state.hdr_info.client_request.url_get()->port_set(hs->port);
+      if (auto it = TunnelMap.find(ssl_vc->serverName); it != TunnelMap.end()) {
+        t_state.hdr_info.client_request.url_get()->host_set(it->second.hostname.c_str(), it->second.hostname.size());
+        if (it->second.port > 0) {
+          t_state.hdr_info.client_request.url_get()->port_set(it->second.port);
         } else {
           t_state.hdr_info.client_request.url_get()->port_set(t_state.state_machine->ua_txn->get_netvc()->get_local_port());
         }
@@ -1386,11 +1385,10 @@ plugins required to work with sni_routing.
       SSLNetVConnection *ssl_vc = dynamic_cast<SSLNetVConnection *>(netvc);
 
       if (ssl_vc && ssl_vc->GetSNIMapping()) {
-        auto *hs = TunnelMap.find(ssl_vc->serverName);
-        if (hs != nullptr) {
-          t_state.hdr_info.client_request.url_get()->host_set(hs->hostname, hs->len);
-          if (hs->port > 0) {
-            t_state.hdr_info.client_request.url_get()->port_set(hs->port);
+        if (auto it = TunnelMap.find(ssl_vc->serverName); it != TunnelMap.end()) {
+          t_state.hdr_info.client_request.url_get()->host_set(it->second.hostname.c_str(), it->second.hostname.size());
+          if (it->second.port > 0) {
+            t_state.hdr_info.client_request.url_get()->port_set(it->second.port);
           } else {
             t_state.hdr_info.client_request.url_get()->port_set(t_state.state_machine->ua_txn->get_netvc()->get_local_port());
           }


### PR DESCRIPTION
This is another step towards removing `Map.h`.