### PR TITLE
Cause traffic_server to die fast if a plugin is loaded that was not built with the correct core version.

### DIFF
--- a/build/plugins.mk
+++ b/build/plugins.mk
@@ -22,7 +22,7 @@ TS_PLUGIN_LD_FLAGS = \
   -module \
   -shared \
   -avoid-version \
-  -export-symbols-regex '^(TSRemapInit|TSRemapDone|TSRemapDoRemap|TSRemapNewInstance|TSRemapDeleteInstance|TSRemapOSResponse|TSPluginInit|TSRemapPreConfigReload|TSRemapPostConfigReload)$$'
+  -export-symbols-regex '^(TSRemapInit|TSRemapDone|TSRemapDoRemap|TSRemapNewInstance|TSRemapDeleteInstance|TSRemapOSResponse|TSPluginInit_@TS_VERSION_MAJOR@|TSRemapPreConfigReload|TSRemapPostConfigReload)$$'
 
 TS_PLUGIN_CPPFLAGS = \
   -I$(abs_top_builddir)/proxy/api \

--- a/doc/developer-guide/api/functions/TSPluginInit.en.rst
+++ b/doc/developer-guide/api/functions/TSPluginInit.en.rst
@@ -44,6 +44,12 @@ calls this initialization routine when it loads the plugin and sets
 argument vector is the plugins name, which must exist in order for
 the plugin to be loaded.
 
+(Note that the identifier ``TSPluginInit`` is really a preprocessor symbol,
+defined by including ``<ts/ts.h>``,
+that translates to ``TSPluginInit_<M>``, where <M> is the Traffic Server major release number.
+This helps ensure that plugins are rebuilt before use with a new major release of Traffic
+Server.)
+
 :func:`TSPluginRegister` registers the appropriate SDK version specific in
 :arg:`sdk_version` for your plugin. Use this function to make sure that the
 version of Traffic Server on which your plugin is running supports the plugin.

--- a/example/plugins/c-api/thread_pool/test/SDKTest/psi_server.c
+++ b/example/plugins/c-api/thread_pool/test/SDKTest/psi_server.c
@@ -39,6 +39,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include "ServerAPI.h"
+#include <ts/apidefs.h>
 
 #define PSI_TAG_FORMAT "<!--include=file%d.txt-->"
 #define PSI_TAG_MAX_SIZE 128

--- a/example/plugins/cpp-api/websocket/WebSocket.cc
+++ b/example/plugins/cpp-api/websocket/WebSocket.cc
@@ -24,6 +24,7 @@
 #include "WebSocket.h"
 
 #include "tscpp/api/Logger.h"
+#include <tscpp/api/PluginInit.h>
 
 // DISCLAIMER: this is intended for demonstration purposes only and
 // does not pretend to implement a complete (or useful) server.

--- a/include/ts/apidefs.h.in
+++ b/include/ts/apidefs.h.in
@@ -950,6 +950,16 @@ typedef struct TSSslSessionID_s {
    Init */
 
 /**
+    Cause TSPluginInit to have _<m> appended, when <m> is the major TS version nunber.
+ */
+#define TSPluginInit TS_PLUGIN_INIT_(TS_VERSION_MAJOR)
+
+/* PRIVATE -- do not use these diredtly *****/
+#define TS_PLUGIN_INIT_(MAJOR) TS_PLUGIN_INIT__(MAJOR)
+#define TS_PLUGIN_INIT__(MAJOR) TSPluginInit_##MAJOR
+/********************************************/
+
+/**
     This function must be defined by all plugins. Traffic Server
     calls this initialization routine when it loads the plugin (at
     startup), and sets argc and argv appropriately based on the values

--- a/mgmt/api/INKMgmtAPI.cc
+++ b/mgmt/api/INKMgmtAPI.cc
@@ -41,6 +41,7 @@
 #include "CoreAPIShared.h"
 
 #include "tscore/TextBuffer.h"
+#include "ts/apidefs.h"
 
 /***************************************************************************
  * API Memory Management

--- a/proxy/Plugin.cc
+++ b/proxy/Plugin.cc
@@ -112,13 +112,22 @@ plugin_load(int argc, char *argv[], bool validateOnly)
     plugin_reg_current->plugin_path = ats_strdup(path);
     plugin_reg_current->dlh         = handle;
 
-    init = reinterpret_cast<init_func_t>(dlsym(plugin_reg_current->dlh, "TSPluginInit"));
+#define X(P) Y(P)
+#define Y(P) #P
+
+    init = reinterpret_cast<init_func_t>(dlsym(plugin_reg_current->dlh, X(TSPluginInit)));
+
+#undef X
+#undef Y
+
     if (!init) {
       delete plugin_reg_current;
       if (validateOnly) {
         return false;
       }
-      Fatal("unable to find TSPluginInit function in '%s': %s", path, dlerror());
+      Fatal("unable to find TSPluginInit function in '%s': %s\n"
+            "make sure plugin was built with include files and libraries exported by major version %d of Traffic Server",
+            path, dlerror(), TS_VERSION_MAJOR);
       return false; // this line won't get called since Fatal brings down ATS
     }
 

--- a/proxy/Plugin.h
+++ b/proxy/Plugin.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include "ts/apidefs.h"
 #include "tscore/List.h"
 
 struct PluginRegInfo {

--- a/proxy/http/remap/unit-tests/test_PluginDso.cc
+++ b/proxy/http/remap/unit-tests/test_PluginDso.cc
@@ -371,8 +371,15 @@ SCENARIO("looking for symbols inside a plugin DSO", "[plugin][core]")
     {
       THEN("expect to find them all")
       {
+        // TSPluginInit is a preprocessor symbol.  Expand it, then turn it into a string.
+#undef MS
+#undef MS_
+#define MS(X) MS_(X)
+#define MS_(X) #X
         std::vector<const char *> list{"TSRemapInit",           "TSRemapDone",       "TSRemapDoRemap", "TSRemapNewInstance",
-                                       "TSRemapDeleteInstance", "TSRemapOSResponse", "TSPluginInit",   "pluginDsoVersionTest"};
+                                       "TSRemapDeleteInstance", "TSRemapOSResponse", MS(TSPluginInit), "pluginDsoVersionTest"};
+#undef MS
+#undef MS_
         for (auto symbol : list) {
           void *s = nullptr;
           CHECK(plugin.getSymbol(symbol, s, error));


### PR DESCRIPTION
The TSPluginInit function name will now have a suffix that specifies the major and minor core version number.  This is transparent to the plugin author, who uses the preprocessor symbol TS_PLUGIN_INIT in place of the name TSPluginInit.