### PR TITLE
Rewrite url after running all remap plugins

### DIFF
--- a/proxy/http/remap/RemapPlugins.h
+++ b/proxy/http/remap/RemapPlugins.h
@@ -38,13 +38,17 @@
  * A class that represents a queue of plugins to run
  **/
 struct RemapPlugins : public Continuation {
-  RemapPlugins() : _cur(0) {}
+  RemapPlugins() : _cur(0), _rewriten(0) {}
   RemapPlugins(HttpTransact::State *s, URL *u, HTTPHdr *h, host_hdr_info *hi)
-    : _cur(0), _s(s), _request_url(u), _request_header(h), _hh_ptr(hi)
+    : _cur(0), _rewriten(0), _s(s), _request_url(u), _request_header(h), _hh_ptr(hi)
   {
   }
 
-  ~RemapPlugins() override { _cur = 0; }
+  ~RemapPlugins() override
+  {
+    _cur      = 0;
+    _rewriten = 0;
+  }
   // Some basic setters
   void
   setState(HttpTransact::State *state)
@@ -75,6 +79,7 @@ struct RemapPlugins : public Continuation {
 
 private:
   unsigned int _cur        = 0;
+  unsigned int _rewriten   = 0;
   HttpTransact::State *_s  = nullptr;
   URL *_request_url        = nullptr;
   HTTPHdr *_request_header = nullptr;


### PR DESCRIPTION
Described at https://github.com/apache/trafficserver/issues/2877

When we configure remap.config like the following snippet, the second remap plugin using `rri->requestUrl` get post-remap url information from ATS.
```
map http://before-remap.com/ http://after-remap.com/ @plugin=<first plugin>.so @pparam=... @plugin=<second plugin>.so @pparam=...
```

The cause of this behavior is ATS executes `url_rewrite_remap_request` function after running the first remap plugin.
Therefore, behavior of a remap plugin as the first plugin is different from that as the second plugin.

I think ATS should execute all remap plugins and then rewrite url.