### PR TITLE
Remove explicit free of ref-counted object.

### DIFF
--- a/mgmt/ProxyConfig.h
+++ b/mgmt/ProxyConfig.h
@@ -109,7 +109,8 @@ ConfigScheduleUpdate(Ptr<ProxyMutex> &mutex)
 
 template <typename UpdateClass> struct ConfigUpdateHandler {
   ConfigUpdateHandler() : mutex(new_ProxyMutex()) {}
-  ~ConfigUpdateHandler() { mutex->free(); }
+  // The mutex member is ref-counted so should not explicitly free it
+  ~ConfigUpdateHandler() {}
   int
   attach(const char *name)
   {


### PR DESCRIPTION
The destructor of the ConfigUpdateHandler was explicitly freeing the mutex which is a Ptr<> ref-counted object.  This was causing a double free on shutdown.

This latent issue was made more relevant thanks to some cleanup in commit d483f495.  Any branch that picks up that commit, will also need this fix.