### PR TITLE
Docs: Change to run python directly, require python 3.4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -291,20 +291,19 @@ AM_CONDITIONAL([BUILD_TESTS], [test 0 -ne $has_tests])
 # makes the diagnostic output ugly and hard to follow.
 AC_ARG_VAR(JAVA, [path to java executor])
 AC_CHECK_PROG(JAVA, java, java)
-AC_MSG_CHECKING([whether to build documentation])
+AC_MSG_RESULT([Checking whether to build documentation:])
 AC_ARG_ENABLE([docs],
   [AS_HELP_STRING([--enable-docs],[enable documentation building])],
   [
     enable_doc_build=yes
-    AM_PATH_PYTHON([2.4], [
-      dnl action-if-found
+    AM_PATH_PYTHON([3.4], [
       TS_MAN1_MANPAGES=`cd $srcdir/doc && $PYTHON manpages.py --section=1 | $AWK '{print "$(BUILDDIR)/man/" $0 }' | tr '\n' ' '`
       TS_MAN3_MANPAGES=`cd $srcdir/doc && $PYTHON manpages.py --section=3 | $AWK '{print "$(BUILDDIR)/man/" $0 }' | tr '\n' ' '`
       TS_MAN5_MANPAGES=`cd $srcdir/doc && $PYTHON manpages.py --section=5 | $AWK '{print "$(BUILDDIR)/man/" $0 }' | tr '\n' ' '`
       TS_MAN8_MANPAGES=`cd $srcdir/doc && $PYTHON manpages.py --section=8 | $AWK '{print "$(BUILDDIR)/man/" $0 }' | tr '\n' ' '`
     ], [
-      dnl action-if-not-found
-      :
+      enable_doc_build=no
+      AC_ERROR([Doc building disabled, python 3.4 or better required])
     ])
 
     AS_IF([test -z "$JAVA"],
@@ -314,7 +313,7 @@ AC_ARG_ENABLE([docs],
       ])
     AC_ARG_VAR(SPHINXBUILD, [the sphinx-build documentation generator])
     AC_ARG_VAR(SPHINXOPTS, [additional sphinx-build options])
-    AC_PATH_PROG([SPHINXBUILD], [sphinx-build], [])
+    AC_PATH_PROG([SPHINXBUILD], [$SPHINXBUILD], [$PYTHON -m sphinx])
     AS_IF(["$PYTHON" "$srcdir/doc/checkvers.py" --check-version],
       [
         sphinx_version_check=yes
@@ -342,7 +341,7 @@ AC_ARG_ENABLE([docs],
   ],
   [enable_doc_build=no]
 )
-AC_MSG_RESULT([$enable_doc_build])
+AC_MSG_RESULT([Will build documentation: $enable_doc_build])
 AM_CONDITIONAL([BUILD_DOCS], [test "xyes" = "x$enable_doc_build"])
 AM_CONDITIONAL([BUILD_MANPAGES], [test "xtrue" = "x$build_manpages"])
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -62,7 +62,7 @@ I18NSPHINXOPTS  = $(SPHINXOPTS)
 # detects as non-portable. We bounce this through a shell script and do the expansion there.
 SBUILD = PAPEROPT_a4="$(PAPEROPT_a4)" PAPEROPT_letter="$(PAPEROPT_letter)" PAPER="$(PAPER)" \
 	PLANTUML_JAR="$(shell ext/plantuml_fetch.sh | tail -1)" \
-	$(srcdir)/sbuild $(SPHINXBUILD) \
+	$(srcdir)/sbuild "$(SPHINXBUILD)" \
 	-c $(srcdir) \
 	$(ALLSPHINXOPTS)
 

--- a/doc/checkvers.py
+++ b/doc/checkvers.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
         min_sphinx_version_info = (1,7,5)
         min_sphinx_version = '.'.join([str(x) for x in min_sphinx_version_info])
 
-        print('checking for sphinx version >= {0}... '.format(min_sphinx_version))
+        print('checking for sphinx version >= {0}... '.format(min_sphinx_version), end="")
         # Need at least 1.5.1 to use svg
         # version >= 1.2 guarantees sphinx.version_info is available.
         try:
@@ -52,7 +52,7 @@ if __name__ == '__main__':
             print(e)
             sys.exit(1)
 
-        print('checking for sphinx.writers.manpage... '),
+        print('checking for sphinx.writers.manpage... ', end="")
         try:
             from sphinx.writers import manpage
             print('yes')
@@ -60,7 +60,7 @@ if __name__ == '__main__':
             print(e)
             sys.exit(1)
 
-        print('checking for sphinxcontrib.plantuml...'),
+        print('checking for sphinxcontrib.plantuml...', end="")
         try:
             import sphinxcontrib.plantuml
             print('yes')


### PR DESCRIPTION
As discussed on the dev list, the documentation build will be changed to

* Require python 3.4

* Use python directly rather than the system build script "sbuild".

The point of this is to move to python 3 before python 2 is officially EOL, and to localize the level of install required to build the documentation. With this change, everything needed can be installed via `pip install --user` without any system privileges. Previously Sphinx in some cases required `yum` or `dnf` in order to install the "sbuild" script in a system directory.
