### PR TITLE
URI signing support for JWS to be passed as path parameter

### DIFF
--- a/plugins/experimental/uri_signing/parse.h
+++ b/plugins/experimental/uri_signing/parse.h
@@ -19,7 +19,7 @@
 #include <stdlib.h>
 
 struct _cjose_jws_int;
-struct _cjose_jws_int *get_jws_from_query(const char *uri, size_t uri_ct, const char *paramName);
+struct _cjose_jws_int *get_jws_from_uri(const char *uri, size_t uri_ct, const char *paramName);
 struct _cjose_jws_int *get_jws_from_cookie(const char **cookie, size_t *cookie_ct, const char *paramName);
 
 struct config;

--- a/plugins/experimental/uri_signing/uri_signing.c
+++ b/plugins/experimental/uri_signing/uri_signing.c
@@ -175,7 +175,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
   if (cpi < max_cpi) {
     checkpoints[cpi++] = mark_timer(&t);
   }
-  cjose_jws_t *jws = get_jws_from_query(url, url_ct, package);
+  cjose_jws_t *jws = get_jws_from_uri(url, url_ct, package);
   if (cpi < max_cpi) {
     checkpoints[cpi++] = mark_timer(&t);
   }


### PR DESCRIPTION
Previously, the URI signing plugin only supported passing JWTs as URI query string parameters. This implements the latest URI Signing Internet draft's logic for parsing signed JWTs from URIs. The latest logic allows for JWTs to be parsed from either path parameters or query parameters. 

This also fixes a small bug where keys that were substrings of the target parameter name where being accepted as valid JWT parameters. 

Latest Internet Draft: https://tools.ietf.org/html/draft-ietf-cdni-uri-signing-16