### PR TITLE
Doc minor fixes.

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -277,7 +277,7 @@ System Variables
 
    Specifies the minimum count of rolled output logs to keep. This value will be used to decide the
    order of auto-deletion (if enabled). A default value of 0 means auto-deletion will try to keep
-   output logs as much as possible. See :doc:`../logging/rotation.en.rst` for guidance.
+   output logs as much as possible. See :doc:`../logging/rotation.en` for guidance.
 
 Thread Variables
 ----------------
@@ -2961,7 +2961,7 @@ Logging Configuration
 
    Specifies the minimum count of rolled (event) logs to keep. This value will be used to decide the
    order of auto-deletion (if enabled). A default value of 0 means auto-deletion will try to keep
-   logs as much as possible. This value can be and should be overridden in logging.yaml. See :doc:`../logging/rotation.en.rst` for guidance.
+   logs as much as possible. This value can be and should be overridden in logging.yaml. See :doc:`../logging/rotation.en` for guidance.
 
 .. ts:cv:: CONFIG proxy.config.log.auto_delete_rolled_files INT 1
    :reloadable:
@@ -3130,7 +3130,7 @@ Diagnostic Logging Configuration
 
    Specifies the minimum count of rolled diagnostic logs to keep. This value will be used to decide the
    order of auto-deletion (if enabled). A default value of 0 means auto-deletion will try to keep
-   diagnostic logs as much as possible. See :doc:`../logging/rotation.en.rst` for guidance.
+   diagnostic logs as much as possible. See :doc:`../logging/rotation.en` for guidance.
 
 Reverse Proxy
 =============
@@ -3954,6 +3954,7 @@ Sockets
 
         Reduce the number of worker threads (net-threads)
         Reduce the number of disk (AIO) threads
+
    Make sure accept threads are enabled
 
    The relevant configurations for this are::

--- a/doc/admin-guide/plugins/ssl_session_reuse.en.rst
+++ b/doc/admin-guide/plugins/ssl_session_reuse.en.rst
@@ -64,7 +64,7 @@ scenario.  The SSL Session Resuse configuration file describes how to communicat
 
 * :ts:cv:`proxy.config.ssl.session_cache` should be set to 2 to enable the ATS implementation of session cache
 * :ts:cv:`proxy.config.ssl.session_cache.size` and :ts:cv:`proxy.config.ssl.session_cache.num_buckets` may need to be adjusted to ensure good hash table performance for your workload.  For example, we needed to increase the number of buckets to avoid long hash chains.
-* :ts:cv:`proxy.config.ssl.server.session_ticket_enable` should be set to 1 to enable session ticket support.
+* :ts:cv:`proxy.config.ssl.server.session_ticket.enable` should be set to 1 to enable session ticket support.
 
 
 Config File

--- a/doc/developer-guide/plugins/hooks-and-transactions/ssl-hooks.en.rst
+++ b/doc/developer-guide/plugins/hooks-and-transactions/ssl-hooks.en.rst
@@ -93,7 +93,7 @@ get the SSL object from the TSVConn argument and use that to access the client
 certificate and make any additional checks.
 
 Processing will continue regardless of whether the hook callback executes
-:c:func:`TSSslVConnReenable()` since the openssl implementation does not allow
+:c:func:`TSVConnReenable()` since the openssl implementation does not allow
 for pausing processing during the certificate verify callback.
 
 TS_SSL_VERIFY_SERVER_HOOK
@@ -104,7 +104,7 @@ presents a certificate.  The callback can get the SSL object from the TSVConn
 argument and use that to access the origin certificate and make any additional checks.
 
 Processing will continue regardless of whether the hook callback executes
-:c:func:`TSSslVConnReenable()` since the openssl implementation does not allow
+:c:func:`TSVConnReenable()` since the openssl implementation does not allow
 for pausing processing during the certificate verify callback.
 
 TS_VCONN_OUTBOUND_START_HOOK
@@ -115,7 +115,7 @@ overriding the default SSL connection options on the SSL object.
 
 In theory this hook could apply and be useful for non-SSL connections as well, but at this point this hook is only called in the SSL sequence.
 
-The TLS handshake processing will not proceed until :c:func:`TSSslVConnReenable()` is called either from within the hook
+The TLS handshake processing will not proceed until :c:func:`TSVConnReenable()` is called either from within the hook
 callback or from another piece of code.
 
 TS_VCONN_OUTBOUND_CLOSE_HOOK
@@ -165,8 +165,8 @@ TLS Hook State Diagram
 
    digraph tls_hook_state_diagram{
      HANDSHAKE_HOOKS_OUTBOUND_PRE -> HANDSHAKE_HOOKS_OUTBOUND_PRE_INVOKE;
-     HANDSHAKE_HOOKS_PRE_INVOKE -> TSSslVConnReenable;
-     TSSslVConnReenable -> HANDSHAKE_HOOKS_OUTBOUND_PRE;
+     HANDSHAKE_HOOKS_PRE_INVOKE -> TSVConnReenable;
+     TSVConnReenable -> HANDSHAKE_HOOKS_OUTBOUND_PRE;
      HANDSHAKE_HOOKS_OUTBOUND_PRE -> HANDSHAKE_HOOKS_DONE;
      HANDSHAKE_HOOKS_DONE -> HANDSHAKE_HOOKS_OUTBOUND_CLOSE;
    }

--- a/doc/ext/traffic-server.py
+++ b/doc/ext/traffic-server.py
@@ -327,11 +327,11 @@ class TrafficServerDomain(Domain):
 
     def clear_doc(self, docname):
         cv_list = self.data['cv']
-        for var, doc in cv_list.items():
+        for var, doc in list(cv_list.items()):
             if doc == docname:
                 del cv_list[var]
         stat_list = self.data['stat']
-        for var, doc in stat_list.items():
+        for var, doc in list(stat_list.items()):
             if doc == docname:
                 del stat_list[var]
 


### PR DESCRIPTION
Depends on #4539.

This cleans up some minor doc errors, and changes the map cleanup in `traffic-server.py` to be correct for dict modification during a loop in python 3.