### PR TITLE
Fix tunnel_route action in ssl_server_name and various test fixes for Fedora 28 and 29

### DIFF
--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -248,7 +248,7 @@ public:
   struct HostStruct {
     std::string hostname;
     int port;
-    HostStruct(const std::string &name, int port_) : hostname(name), port(port_) {}
+    HostStruct(const std::string_view &name, int port_) : hostname(name), port(port_) {}
   };
   using Tunnel_hashMap = std::unordered_map<std::string, HostStruct>;
   Tunnel_hashMap TunnelhMap;
@@ -258,7 +258,7 @@ public:
   {
     std::string_view addr, port;
     if (ats_ip_parse(std::string_view(hostname), &addr, &port) == 0) {
-      TunnelhMap.emplace(key, HostStruct(addr.data(), atoi(port.data())));
+      TunnelhMap.emplace(key, HostStruct(addr, atoi(port.data())));
     }
   }
 

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -420,6 +420,11 @@ ssl_cert_callback(SSL *ssl, void * /*arg*/)
   bool reenabled;
   int retval = 1;
 
+  // If we are in tunnel mode, don't select a cert.  Pause!
+  if (HttpProxyPort::TRANSPORT_BLIND_TUNNEL == netvc->attributes) {
+    return -1; // Pause
+  }
+
   // Do the common certificate lookup only once.  If we pause
   // and restart processing, do not execute the common logic again
   if (!netvc->calledHooks(TS_EVENT_SSL_CERT)) {
@@ -469,6 +474,11 @@ ssl_servername_and_cert_callback(SSL *ssl, int * /* ad */, void * /*arg*/)
   SSLNetVConnection *netvc = SSLNetVCAccess(ssl);
   bool reenabled;
   int retval = 1;
+
+  // If we are in tunnel mode, don't select a cert.  Pause!
+  if (HttpProxyPort::TRANSPORT_BLIND_TUNNEL == netvc->attributes) {
+    return -1; // Pause
+  }
 
   // Do the common certificate lookup only once.  If we pause
   // and restart processing, do not execute the common logic again

--- a/tests/bootstrap.py
+++ b/tests/bootstrap.py
@@ -26,7 +26,7 @@ import platform
 import sys
 
 pip_packages = [
-    "autest==1.7.0",
+    "autest==1.7.2",
     "hyper",
     "requests",
     "dnslib",

--- a/tests/gold_tests/autest-site/init.cli.ext
+++ b/tests/gold_tests/autest-site/init.cli.ext
@@ -23,7 +23,7 @@ if sys.version_info < (3, 5, 0):
     host.WriteError(
         "You need python 3.5 or later to run these tests\n", show_stack=False)
 
-autest_version ="1.7.0"
+autest_version ="1.7.2"
 if AuTestVersion() < autest_version:
     host.WriteError(
         "Tests need AuTest version {ver} or better\n Please update AuTest:\n  pip install --upgrade autest\n".format(ver=autest_version), show_stack=False)

--- a/tests/gold_tests/cache/cache-control.test.py
+++ b/tests/gold_tests/cache/cache-control.test.py
@@ -53,6 +53,7 @@ ts.Disk.records_config.update({
     'proxy.config.http.response_via_str': 3,
     'proxy.config.http.cache.http': 1,
     'proxy.config.http.wait_for_cache': 1,
+    'proxy.config.http.insert_age_in_response': 0,
 })
 
 ts.Disk.remap_config.AddLine(

--- a/tests/gold_tests/cache/gold/cache_and_req_body-hit.gold
+++ b/tests/gold_tests/cache/gold/cache_and_req_body-hit.gold
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Cache-Control: max-age=10,public
 Content-Length: 11
 Date: ``
-Age: ``
 Connection: keep-alive
 Via: ``
 Server: ``

--- a/tests/gold_tests/cache/gold/cache_and_req_body-miss.gold
+++ b/tests/gold_tests/cache/gold/cache_and_req_body-miss.gold
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Cache-Control: max-age=10,public
 Content-Length: 11
 Date: ``
-Age: ``
 Connection: keep-alive
 Via: ``
 Server: ``

--- a/tests/gold_tests/cache/gold/cache_hit_stale.gold
+++ b/tests/gold_tests/cache/gold/cache_hit_stale.gold
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Cache-Control: max-age=10,public
 Content-Length: 11
 Date: ``
-Age: 0
 Connection: keep-alive
 Via: ``
 Server: ``

--- a/tests/gold_tests/cache/gold/cache_no_cc.gold
+++ b/tests/gold_tests/cache/gold/cache_no_cc.gold
@@ -1,7 +1,6 @@
 HTTP/1.1 200 OK
 Content-Length: 14
 Date: ``
-Age: 0
 Connection: keep-alive
 Via: ``
 Server: ``

--- a/tests/gold_tests/tls/tls_client_cert.test.py
+++ b/tests/gold_tests/tls/tls_client_cert.test.py
@@ -65,7 +65,7 @@ ts.addSSLfile("ssl/signed-bar.key")
 ts.Variables.ssl_port = 4443
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'ssl|http',
+    'proxy.config.diags.debug.tags': 'ssl_verify_test',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.http.server_ports': '{0}'.format(ts.Variables.port),
@@ -310,5 +310,3 @@ tr4fail.Processes.Default.TimeOut = 5
 tr4fail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 tr4fail.TimeOut = 5
 
-# Allow for error messages in diags
-ts.Disk.diags_log.Content = Testers.ContainsExpression("ERROR", "Some connections should fail")

--- a/tests/gold_tests/tls/tls_hooks_verify.test.py
+++ b/tests/gold_tests/tls/tls_hooks_verify.test.py
@@ -95,10 +95,8 @@ tr3.Processes.Default.Command = "curl --resolve \"bar.com:{0}:127.0.0.1\" -k  ht
 tr3.Processes.Default.ReturnCode = 0
 tr3.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have failed")
 
-# Over riding the built in ERROR check since we expect tr2 to fail
-ts.Disk.diags_log.Content = Testers.ContainsExpression("WARNING: TS_EVENT_SSL_VERIFY_SERVER plugin failed the origin certificate check for 127.0.0.1.  Action=Terminate SNI=random.com", "random.com should fail")
+ts.Disk.diags_log.Content += Testers.ContainsExpression("WARNING: TS_EVENT_SSL_VERIFY_SERVER plugin failed the origin certificate check for 127.0.0.1.  Action=Terminate SNI=random.com", "random.com should fail")
 ts.Disk.diags_log.Content += Testers.ContainsExpression("WARNING: TS_EVENT_SSL_VERIFY_SERVER plugin failed the origin certificate check for 127.0.0.1.  Action=Continue SNI=bar.com", "bar.com should fail but continue")
-ts.Disk.diags_log.Content += Testers.ContainsExpression("ERROR: SSL connection failed for 'random.com': .+?:certificate verify failed", "random.com should really fail")
 ts.Disk.diags_log.Content += Testers.ExcludesExpression("SNI=foo.com", "foo.com should not fail in any way")
 
 ts.Streams.All += Testers.ContainsExpression("Server verify callback 0 [\da-fx]+? - event is good SNI=foo.com good HS", "verify callback happens 2 times")

--- a/tests/gold_tests/tls/tls_tunnel.test.py
+++ b/tests/gold_tests/tls/tls_tunnel.test.py
@@ -1,0 +1,95 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+Test.Summary = '''
+Test tunneling based on SNI
+'''
+
+# need Curl
+Test.SkipUnless(
+    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
+)
+
+# Define default ATS
+ts = Test.MakeATSProcess("ts", select_ports=False)
+server_foo = Test.MakeOriginServer("server_foo", ssl=True)
+server_bar = Test.MakeOriginServer("server_bar", ssl=False)
+
+request_foo_header = {"headers": "GET / HTTP/1.1\r\nHost: foo.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+request_bar_header = {"headers": "GET / HTTP/1.1\r\nHost: bar.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+server_foo.addResponse("sessionlog.json", request_foo_header, response_header)
+server_bar.addResponse("sessionlog.json", request_bar_header, response_header)
+
+# add ssl materials like key, certificates for the server
+ts.addSSLfile("ssl/signed-foo.pem")
+ts.addSSLfile("ssl/signed-foo.key")
+ts.addSSLfile("ssl/signed-bar.pem")
+ts.addSSLfile("ssl/signed-bar.key")
+ts.addSSLfile("ssl/server.pem")
+ts.addSSLfile("ssl/server.key")
+ts.addSSLfile("ssl/signer.pem")
+ts.addSSLfile("ssl/signer.key")
+
+ts.Variables.ssl_port = 4443
+
+# Need no remap rules.  Everything should be proccessed by ssl_server_name
+
+# Make sure the TS server certs are different from the origin certs
+ts.Disk.ssl_multicert_config.AddLine(
+    'dest_ip=* ssl_cert_name=signed-foo.pem ssl_key_name=signed-foo.key'
+)
+
+# Case 1, global config policy=permissive properties=signature
+#         override for foo.com policy=enforced properties=all
+ts.Disk.records_config.update({
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'http|ssl',
+    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    # enable ssl port
+    'proxy.config.http.server_ports': '{0} {1}:proto=http2;http:ssl'.format(ts.Variables.port, ts.Variables.ssl_port),
+    'proxy.config.http.connect_ports': '{0} {1} {2}'.format(ts.Variables.ssl_port,server_foo.Variables.Port,server_bar.Variables.Port),
+    'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
+    'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
+    'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
+    'proxy.config.url_remap.pristine_host_hdr': 1
+})
+
+# foo.com should not terminate.  Just tunnel to server_foo
+# bar.com should terminate.  Forward its tcp stream to server_bar
+ts.Disk.ssl_server_name_yaml.AddLines([
+  '- fqdn: foo.com',
+  "  tunnel_route: localhost:{0}".format(server_foo.Variables.Port) ])
+
+tr = Test.AddTestRun("Tunnel-test")
+tr.Processes.Default.Command = "curl -v --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(ts.Variables.ssl_port)
+tr.ReturnCode = 0
+tr.Processes.Default.StartBefore(server_foo)
+tr.Processes.Default.StartBefore(server_bar)
+tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.ssl_port))
+tr.StillRunningAfter = ts
+tr.Processes.Default.TimeOut = 5
+tr.TimeOut = 5
+tr.Processes.Default.Streams.All += Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
+tr.Processes.Default.Streams.All += Testers.ExcludesExpression("Not Found on Accelerato", "Should not try to remap on Traffic Server")
+tr.Processes.Default.Streams.All += Testers.ExcludesExpression("CN=foo.com", "Should not TLS terminate on Traffic Server")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/1.1 200 OK", "Should get a successful response")
+
+

--- a/tests/gold_tests/tls/tls_verify.test.py
+++ b/tests/gold_tests/tls/tls_verify.test.py
@@ -71,7 +71,7 @@ ts.Disk.ssl_multicert_config.AddLine(
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
 ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.enabled': 0,
     'proxy.config.diags.debug.tags': 'http|ssl',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
@@ -104,7 +104,7 @@ tr.Setup.Copy("ssl/signed-foo.key")
 tr.Setup.Copy("ssl/signed-foo.pem")
 tr.Setup.Copy("ssl/signed-bar.key")
 tr.Setup.Copy("ssl/signed-bar.pem")
-tr.Processes.Default.Command = "curl -k -H \"host: foo.com\" https://127.0.0.1:{0}".format(ts.Variables.ssl_port)
+tr.Processes.Default.Command = "curl -v -k -H \"host: foo.com\" https://127.0.0.1:{0}".format(ts.Variables.ssl_port)
 tr.ReturnCode = 0
 # time delay as proxy.config.http.wait_for_cache could be broken
 tr.Processes.Default.StartBefore(server_foo)
@@ -118,7 +118,7 @@ tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Conn
 tr.TimeOut = 5
 
 tr2 = Test.AddTestRun("Override-enforcing-Test")
-tr2.Processes.Default.Command = "curl -k -H \"host: bar.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port)
+tr2.Processes.Default.Command = "curl -v -k -H \"host: bar.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.Processes.Default.TimeOut = 5
@@ -127,7 +127,7 @@ tr2.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Con
 tr2.TimeOut = 5
 
 tr3 = Test.AddTestRun("Override-enforcing-Test-fail-name-check")
-tr3.Processes.Default.Command = "curl -k -H \"host: bad_bar.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port)
+tr3.Processes.Default.Command = "curl -v -k -H \"host: bad_bar.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port)
 tr3.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Curl attempt should have failed")
 tr3.ReturnCode = 0
 tr3.StillRunningAfter = server

--- a/tests/gold_tests/tls/tls_verify2.test.py
+++ b/tests/gold_tests/tls/tls_verify2.test.py
@@ -71,7 +71,7 @@ ts.Disk.ssl_multicert_config.AddLine(
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
 ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.enabled': 0,
     'proxy.config.diags.debug.tags': 'http|ssl',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
@@ -162,14 +162,10 @@ tr6.StillRunningAfter = ts
 tr6.Processes.Default.TimeOut = 5
 
 
-# Over riding the built in ERROR check since we expect tr4 and tr7 to fail
 # No name checking for the sig-only permissive override for bad_bar
-ts.Disk.diags_log.Content = Testers.ExcludesExpression("WARNING: SNI \(bad_bar.com\) not in certificate", "bad_bar name checked should be skipped.")
+ts.Disk.diags_log.Content += Testers.ExcludesExpression("WARNING: SNI \(bad_bar.com\) not in certificate", "bad_bar name checked should be skipped.")
 ts.Disk.diags_log.Content = Testers.ExcludesExpression("WARNING: SNI \(foo.com\) not in certificate", "foo name checked should be skipped.")
 # No checking for the self-signed on random.com.  No messages
 ts.Disk.diags_log.Content += Testers.ExcludesExpression("WARNING: Core server certificate verification failed for \(random.com\)", "signature check for random.com should be skipped")
-ts.Disk.diags_log.Content += Testers.ExcludesExpression("ERROR: SSL connection failed for 'random.com'", "random.com should not fail")
-ts.Disk.diags_log.Content += Testers.ContainsExpression("ERROR: SSL connection failed for 'random2.com'", "random2.com should fail")
 ts.Disk.diags_log.Content += Testers.ContainsExpression("WARNING: Core server certificate verification failed for \(random2.com\)", "signature check for random.com should fail'")
 ts.Disk.diags_log.Content += Testers.ContainsExpression("WARNING: SNI \(bad_foo.com\) not in certificate", "bad_foo name checked should be checked.")
-ts.Disk.diags_log.Content += Testers.ContainsExpression("ERROR: SSL connection failed for 'bad_foo.com'", "bad_foo.com should fail")


### PR DESCRIPTION
A configuration parsing error.  Also a flaw introduced by one of the recent TLS hook clean up commits.

Also added an autest to catch future regressions