### PR TITLE
Test: fix failed clang link for test_proxy_http.

### DIFF
--- a/proxy/http/Makefile.am
+++ b/proxy/http/Makefile.am
@@ -97,14 +97,15 @@ test_proxy_http_SOURCES = \
 	HttpBodyFactory.h
 
 test_proxy_http_LDADD = \
-	$(top_builddir)/src/tscore/libtscore.la \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
+	$(top_builddir)/src/tscore/libtscore.la \
 	$(top_builddir)/proxy/hdrs/libhdrs.a \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/lib/records/librecords_p.a \
-	$(top_builddir)/proxy/shared/libUglyLogStubs.a \
 	$(top_builddir)/proxy/logging/liblogging.a \
+	$(top_builddir)/proxy/shared/libUglyLogStubs.a \
 	$(top_builddir)/mgmt/libmgmt_p.la \
+	$(top_builddir)/iocore/utils/libinkutils.a \
 	@HWLOC_LIBS@ \
 	@LIBTCL@ @LIBCAP@
 


### PR DESCRIPTION
I think this fixes the current clang link issues for test_proxy_http. It works for me with clang on Fedora 28, but breaks without these changes in the same way as the CI.