### PR TITLE
Print error message for unimplemented commands

### DIFF
--- a/src/traffic_ctl/traffic_ctl.cc
+++ b/src/traffic_ctl/traffic_ctl.cc
@@ -186,7 +186,7 @@ CtrlProcessArguments(int /* argc */, const char **argv, const ArgumentDescriptio
 int
 CtrlUnimplementedCommand(unsigned /* argc */, const char **argv)
 {
-  CtrlDebug("the '%s' command is not implemented", *argv);
+  fprintf(stderr, "'%s' command is not implemented\n", *argv);
   return CTRL_EX_UNIMPLEMENTED;
 }
 


### PR DESCRIPTION
This message should not be a debug log. All subcommands are listed up on command usage even if unimplemented, and users would not realize those are unimplemented without this message.

I'm fine with removing the unimplemented subcommands but not sure why they are left as unimplemented.