### PR TITLE
Make autests friendlier with openssl 1.1.1

### DIFF
--- a/tests/gold_tests/headers/forwarded.gold
+++ b/tests/gold_tests/headers/forwarded.gold
@@ -31,11 +31,11 @@ for=127.0.0.1;by=unknown;by=Poxy_Proxy;__BY_EQUAL_UUID__;by=127.0.0.1;proto=http
 for=0.6.6.6
 for=_argh, for=127.0.0.1;by=unknown;by=Poxy_Proxy;__BY_EQUAL_UUID__;by=127.0.0.1;proto=http;host=www.no-oride.com;connection=http;connection=http/1.0;connection=http/1.0-tcp-ipv4
 -
-for=127.0.0.1;by=unknown;by=Poxy_Proxy;__BY_EQUAL_UUID__;by=127.0.0.1;proto=https;host=www.no-oride.com;connection=https;connection=https/2;connection=http/1.1-h2-tls/1.2-tcp-ipv4
+for=127.0.0.1;by=unknown;by=Poxy_Proxy;__BY_EQUAL_UUID__;by=127.0.0.1;proto=https;host=www.no-oride.com;connection=https;connection=https/2;connection=http/1.1-h2-tls/1.{}-tcp-ipv4
 -
-for=127.0.0.1;by=unknown;by=Poxy_Proxy;__BY_EQUAL_UUID__;by=127.0.0.1;proto=https;host=www.no-oride.com;connection=https;connection=https/1.1;connection=http/1.1-tls/1.2-tcp-ipv4
+for=127.0.0.1;by=unknown;by=Poxy_Proxy;__BY_EQUAL_UUID__;by=127.0.0.1;proto=https;host=www.no-oride.com;connection=https;connection=https/1.1;connection=http/1.1-tls/1.{}-tcp-ipv4
 -
 for="[::1]";by=unknown;by=Poxy_Proxy;__BY_EQUAL_UUID__;by="[::1]";proto=http;host=www.no-oride.com;connection=http;connection=http/1.1;connection=http/1.1-tcp-ipv6
 -
-for="[::1]";by=unknown;by=Poxy_Proxy;__BY_EQUAL_UUID__;by="[::1]";proto=https;host=www.no-oride.com;connection=https;connection=https/1.1;connection=http/1.1-tls/1.2-tcp-ipv6
+for="[::1]";by=unknown;by=Poxy_Proxy;__BY_EQUAL_UUID__;by="[::1]";proto=https;host=www.no-oride.com;connection=https;connection=https/1.1;connection=http/1.1-tls/1.{}-tcp-ipv6
 -

--- a/tests/gold_tests/headers/via.gold
+++ b/tests/gold_tests/headers/via.gold
@@ -1,6 +1,6 @@
 Via: http/1.1 = http/1.1 tcp ipv4
 Via: http/1.0 = http/1.0 tcp ipv4
-Via: https/2 = http/1.1 h2 tls/1.2 tcp ipv4
-Via: https/1.1 = http/1.1 tls/1.2 tcp ipv4
+Via: https/2 = http/1.1 h2 tls/1.{} tcp ipv4
+Via: https/1.1 = http/1.1 tls/1.{} tcp ipv4
 Via: http/1.1 = http/1.1 tcp ipv6
-Via: https/1.1 = http/1.1 tls/1.2 tcp ipv6
+Via: https/1.1 = http/1.1 tls/1.{} tcp ipv6

--- a/tests/gold_tests/redirect/gold/redirect.gold
+++ b/tests/gold_tests/redirect/gold/redirect.gold
@@ -1,4 +1,5 @@
 HTTP/1.1 204 No Content
+``
 Age: ``
 Connection: keep-alive
 

--- a/tests/gold_tests/tls/ssl-post.c
+++ b/tests/gold_tests/tls/ssl-post.c
@@ -89,6 +89,7 @@ spawn_same_session_send(void *arg)
 
   SSL_CTX *client_ctx = SSL_CTX_new(SSLv23_client_method());
   SSL *ssl            = SSL_new(client_ctx);
+  SSL_set_max_proto_version(ssl, TLS1_2_VERSION);
   SSL_set_session(ssl, tinfo->session);
 
   SSL_set_fd(ssl, sfd);
@@ -282,6 +283,7 @@ main(int argc, char *argv[])
 
   SSL_CTX *client_ctx = SSL_CTX_new(SSLv23_client_method());
   SSL *ssl            = SSL_new(client_ctx);
+  SSL_set_max_proto_version(ssl, TLS1_2_VERSION);
 
   SSL_set_fd(ssl, sfd);
   int ret         = SSL_connect(ssl);

--- a/tests/gold_tests/tls/tls.test.py
+++ b/tests/gold_tests/tls/tls.test.py
@@ -40,10 +40,11 @@ reHost = "www.example.com"
 testName = ""
 
 header_count = 378
+#header_count = 78
 
 header_string = "POST /post HTTP/1.1\r\nHost: www.example.com\r\nContent-Length:1000\r\n"
 
-for i in range(0, 378):
+for i in range(0, header_count):
     header_string = "{1}header{0}:{0}\r\n".format(i, header_string)
 header_string = "{0}\r\n".format(header_string)
 
@@ -78,7 +79,7 @@ ts.Disk.records_config.update({
 })
 
 tr = Test.AddTestRun("Run-Test")
-tr.Command = './ssl-post 127.0.0.1 40 378 4443'
+tr.Command = './ssl-post 127.0.0.1 40 {0} 4443'.format(header_count)
 tr.ReturnCode = 0
 # time delay as proxy.config.http.wait_for_cache could be broken
 tr.Processes.Default.StartBefore(server)

--- a/tests/gold_tests/tls/tls_ticket.test.py
+++ b/tests/gold_tests/tls/tls_ticket.test.py
@@ -82,7 +82,7 @@ ts2.Disk.records_config.update({
 
 tr = Test.AddTestRun("Create ticket")
 tr.Setup.Copy('file.ticket')
-tr.Command = 'echo -e "GET / HTTP/1.0\r\n" | openssl s_client -connect 127.0.0.1:{0} -sess_out ticket.out'.format(ts.Variables.ssl_port)
+tr.Command = 'echo -e "GET / HTTP/1.0\r\n" | openssl s_client -tls1_2 -connect 127.0.0.1:{0} -sess_out ticket.out'.format(ts.Variables.ssl_port)
 tr.ReturnCode = 0
 # time delay as proxy.config.http.wait_for_cache could be broken
 tr.Processes.Default.StartBefore(server)
@@ -120,7 +120,7 @@ def checkSession(ev) :
 
 tr2 = Test.AddTestRun("Test ticket")
 tr2.Setup.Copy('file.ticket')
-tr2.Command = 'echo -e "GET / HTTP/1.0\r\n" | openssl s_client -connect 127.0.0.1:{0} -sess_in ticket.out'.format(ts2.Variables.ssl_port)
+tr2.Command = 'echo -e "GET / HTTP/1.0\r\n" | openssl s_client -tls1_2 -connect 127.0.0.1:{0} -sess_in ticket.out'.format(ts2.Variables.ssl_port)
 tr2.Processes.Default.StartBefore(Test.Processes.ts2, ready=When.PortOpen(ts2.Variables.ssl_port))
 tr2.ReturnCode = 0
 path2 = tr2.Processes.Default.Streams.stdout.AbsPath


### PR DESCRIPTION
Ran autest on my dev box (Centos 7) against openssl-1.1.1.  Had to change several tests that did not behave well with TLS 1.3

tls_ticket needs to be set to use at most TLS 1.2 to exercise the ticket logic.

tls (ssl-post) needs to be pinned to at most TLS 1.2.  

The gold test for redirect_port had to be generalized because the new  logic was inserting a Date header.

There were more errors moving up to Fedora 29 which appeared to be related to TLS 1.3, but that could be due to using the system version of openssl 1.1.1 rather than the patched one ATS needs to do certificate selection correctly.

Updated my test to use a curl linked against openssl 1.1.1.  This caused forwarded and via tests to fail as well.  Updated the commit to adjust the gold files.