### PR TITLE
Fixes erroneous messages during configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -537,9 +537,8 @@ PKG_CHECK_MODULES([LIBMAGICKCPP],[Magick++ >= 7], [
   AS_IF([test "x$enable_experimental_plugins" = "xyes"], [
     enable_image_magick_plugins=yes
   ])
-],
-
-  PKG_CHECK_MODULES([LIBMAGICKCPP],[Magick++ < 7], [
+  ],
+  [PKG_CHECK_MODULES([LIBMAGICKCPP],[Magick++ < 7], [
     TS_ADDTO(LIBMAGICKCPP_CFLAGS, [-DMAGICK_VERSION=6])
     have_libmagickcpp=yes
     AS_IF([test "x$enable_experimental_plugins" = "xyes"], [
@@ -548,7 +547,9 @@ PKG_CHECK_MODULES([LIBMAGICKCPP],[Magick++ >= 7], [
   ],
   [
     have_libmagickcpp=no
-  ]))
+  ])
+  ]
+  )
 
 AM_CONDITIONAL([BUILD_IMAGE_MAGICK_PLUGINS], [test "x${enable_image_magick_plugins}" = "xyes"])
 


### PR DESCRIPTION
checking for LIBMAGICKCPP... no
../configure: line 5964: LIBMAGICKCPP_CFLAGS: command not found
../configure: line 5965: C: command not found
../configure: line 5966: LIBMAGICKCPP_LIBS: command not found
../configure: line 5967: linker: command not found
checking for LIBMAGICKCPP... no