### PR TITLE
access_control: changes after 1st integration

### DIFF
--- a/plugins/experimental/access_control/headers.cc
+++ b/plugins/experimental/access_control/headers.cc
@@ -133,7 +133,7 @@ getHeader(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen, char
  * @return true - OK, false - failed
  */
 bool
-setHeader(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen, const char *value, int valuelen)
+setHeader(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen, const char *value, int valuelen, bool duplicateOk)
 {
   if (!bufp || !hdrLoc || !header || headerlen <= 0 || !value || valuelen <= 0) {
     return false;
@@ -142,8 +142,8 @@ setHeader(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen, cons
   bool ret        = false;
   TSMLoc fieldLoc = TSMimeHdrFieldFind(bufp, hdrLoc, header, headerlen);
 
-  if (!fieldLoc) {
-    // No existing header, so create one
+  if (!fieldLoc || duplicateOk) {
+    // No existing header or duplicates ok, so create one
     if (TS_SUCCESS == TSMimeHdrFieldCreateNamed(bufp, hdrLoc, header, headerlen, &fieldLoc)) {
       if (TS_SUCCESS == TSMimeHdrFieldValueStringSet(bufp, hdrLoc, fieldLoc, -1, value, valuelen)) {
         TSMimeHdrFieldAppend(bufp, hdrLoc, fieldLoc);

--- a/plugins/experimental/access_control/headers.h
+++ b/plugins/experimental/access_control/headers.h
@@ -28,5 +28,5 @@
 int removeHeader(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len);
 bool headerExist(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len);
 char *getHeader(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int headerlen, char *value, int *valuelen);
-bool setHeader(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len, const char *val, int val_len);
+bool setHeader(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len, const char *val, int val_len, bool duplicateOk = false);
 void dumpHeaders(TSMBuffer bufp, TSMLoc hdr_loc);

--- a/plugins/experimental/access_control/plugin.cc
+++ b/plugins/experimental/access_control/plugin.cc
@@ -385,11 +385,11 @@ contHandleAccessControl(const TSCont contp, TSEvent event, void *edata)
                *            a secure channel, typically HTTP over Transport Layer Security (TLS)
                * HttpOnly - instructs the UA to omit the cookie when providing access to cookies via “non-HTTP” APIs such as a web
                *            browser API that exposes cookies to scripts */
-              cookieValue.append("Secure; HttpOnly");
+              cookieValue.append("path=/; Secure; HttpOnly");
 
               AccessControlDebug("%.*s: %s", TS_MIME_LEN_SET_COOKIE, TS_MIME_FIELD_SET_COOKIE, cookieValue.c_str());
               setHeader(clientRespBufp, clientRespHdrLoc, TS_MIME_FIELD_SET_COOKIE, TS_MIME_LEN_SET_COOKIE, cookieValue.c_str(),
-                        cookieValue.size());
+                        cookieValue.size(), /* duplicateOk = */ true);
 
               delete token;
             } else {


### PR DESCRIPTION
- allow multiple set-cookie headers in the response
- associate the cookie with path=/ (needed by all known use-cases).