### PR TITLE
Adjusts the format for header_rewrite string concatenation

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -828,14 +828,13 @@ Variable                New condition variable to use
 
 The %<INBOUND:...> tags can now be replaced with the %{INBOUND:...} equivalent.
 
-You can concatenate values using strings, condition values and variable expansions via the ``+`` operator.
-Variables (eg %<tag>) in the concatenation must be enclosed in double quotes ``"``::
+You can concatenate values using strings, condition values and variable expansions on the same line.
 
-    add-header CustomHeader "Hello from " + %{IP:SERVER} + ":" + "%<INBOUND:LOCAL-PORT>"
+    add-header CustomHeader "Hello from %{IP:SERVER}:%<INBOUND:LOCAL-PORT>"
 
 However, the above example is somewhat contrived to show the old tags, it should instead be written as
 
-    add-header CustomHeader "Hello from " + %{IP:SERVER} + ":" + %{INBOUND:LOCAL-PORT}
+    add-header CustomHeader "Hello from %{IP:SERVER}:%{INBOUND:LOCAL-PORT}"
 
 
 Concatenation is not supported in condition testing.

--- a/plugins/header_rewrite/header_rewrite.cc
+++ b/plugins/header_rewrite/header_rewrite.cc
@@ -184,7 +184,7 @@ RulesConfig::parse_config(const std::string &fname, TSHttpHookID default_hook)
       continue;
     }
 
-    Parser p(line, true); // Tokenize and parse this line preserving quotes from input
+    Parser p(line); // Tokenize and parse this line
     if (p.empty()) {
       continue;
     }
@@ -470,6 +470,6 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
     rule = rule->next;
   }
 
-  TSDebug(PLUGIN_NAME_DBG, "Returing from TSRemapDoRemap with status: %d", rval);
+  TSDebug(PLUGIN_NAME_DBG, "Returning from TSRemapDoRemap with status: %d", rval);
   return rval;
 }

--- a/plugins/header_rewrite/parser.h
+++ b/plugins/header_rewrite/parser.h
@@ -33,7 +33,7 @@
 class Parser
 {
 public:
-  explicit Parser(const std::string &line, bool preserve_quotes = false);
+  explicit Parser(const std::string &line);
 
   bool
   empty() const
@@ -84,6 +84,20 @@ private:
   std::string _op;
   std::string _arg;
   std::string _val;
+
+protected:
+  std::vector<std::string> _tokens;
+};
+
+class SimpleTokenizer
+{
+public:
+  explicit SimpleTokenizer(const std::string &line);
+
+  const std::vector<std::string> &get_tokens() const;
+
+private:
+  DISALLOW_COPY_AND_ASSIGN(SimpleTokenizer);
 
 protected:
   std::vector<std::string> _tokens;

--- a/plugins/header_rewrite/regex_helper.cc
+++ b/plugins/header_rewrite/regex_helper.cc
@@ -40,18 +40,6 @@ regexHelper::setRegexMatch(const std::string &s)
   return true;
 }
 
-const std::string &
-regexHelper::getRegexString() const
-{
-  return regexString;
-}
-
-int
-regexHelper::getRegexCcount() const
-{
-  return regexCcount;
-}
-
 int
 regexHelper::regexMatch(const char *str, int len, int ovector[]) const
 {

--- a/plugins/header_rewrite/regex_helper.h
+++ b/plugins/header_rewrite/regex_helper.h
@@ -39,8 +39,6 @@ public:
   }
 
   bool setRegexMatch(const std::string &s);
-  const std::string &getRegexString() const;
-  int getRegexCcount() const;
   int regexMatch(const char *, int, int ovector[]) const;
 
 private:

--- a/plugins/header_rewrite/value.cc
+++ b/plugins/header_rewrite/value.cc
@@ -43,26 +43,26 @@ Value::set_value(const std::string &val)
 {
   _value = val;
 
-  if (_value.find("%{") != std::string::npos || _value.find("%<") != std::string::npos || _value.find("\"") != std::string::npos) {
-    Parser parser(_value);
-    auto tokens = parser.get_tokens();
+  if (_value.find("%{") != std::string::npos || _value.find("%<") != std::string::npos) {
+    SimpleTokenizer tokenizer(_value);
+
+    auto tokens = tokenizer.get_tokens();
     for (auto it = tokens.begin(); it != tokens.end(); it++) {
-      Parser tparser(*it);
+      std::string token = *it;
 
       Condition *tcond_val = nullptr;
-      if ((*it).substr(0, 2) == "%<") {
+      if (token.substr(0, 2) == "%<") {
         tcond_val = new ConditionExpandableString(*it);
-      } else if ((*it) == "+") {
-        // Skip concat token
-        continue;
-      } else {
-        tcond_val = condition_factory(tparser.get_op());
+      } else if (token.substr(0, 2) == "%{") {
+        std::string cond_token = token.substr(2, token.size() - 3);
+        tcond_val              = condition_factory(cond_token);
+      }
 
-        if (tcond_val) {
-          tcond_val->initialize(tparser);
-        } else {
-          tcond_val = new ConditionStringLiteral(*it);
-        }
+      if (tcond_val) {
+        Parser parser(_value);
+        tcond_val->initialize(parser);
+      } else {
+        tcond_val = new ConditionStringLiteral(token);
       }
       _cond_vals.push_back(tcond_val);
     }


### PR DESCRIPTION
Drop the "+" from the syntax. This syntax was never released and
therefore doesn't have backwards compatibilty requirements.

eg
add-header X-Party "let's party like it's %{NOW:YEAR}!"

(quotes optional)