### PR TITLE
ArgParser: standardize version message and usage exit code

### DIFF
--- a/doc/developer-guide/internal-libraries/ArgParser.en.rst
+++ b/doc/developer-guide/internal-libraries/ArgParser.en.rst
@@ -144,10 +144,12 @@ from the :class:`Arguments` object returned from the parsing. The function can b
 
     args.invoke();
 
-Help message
+Help and Version messages
 -------------------------
 
 - Help message will be outputted when a wrong usage of the program is detected or `--help` option found.
+
+- Version message is defined unified in :code:`ArgParser::version_message()`.
 
 Classes
 +++++++
@@ -174,6 +176,10 @@ Classes
    .. function:: void help_message() const
 
       Output usage to the console.
+
+   .. function:: void version_message() const
+
+      Output version string to the console.
 
    .. function:: void add_global_usage(std::string const &usage)
 

--- a/include/tscore/ArgParser.h
+++ b/include/tscore/ArgParser.h
@@ -175,6 +175,7 @@ public:
     bool parse(Arguments &ret, AP_StrVec &args);
     // The help & version messages
     void help_message(std::string_view err = "") const;
+    void version_message() const;
     // Helpr method for parse()
     void append_option_data(Arguments &ret, AP_StrVec &args, int index);
     // The command name and help message

--- a/src/traffic_cache_tool/Makefile.inc
+++ b/src/traffic_cache_tool/Makefile.inc
@@ -48,4 +48,9 @@ traffic_cache_tool_traffic_cache_tool_LDADD = \
     $(top_builddir)/src/tscore/.libs/Regex.o \
     $(top_builddir)/src/tscore/.libs/CryptoHash.o \
     $(top_builddir)/src/tscore/.libs/MMH.o \
+    $(top_builddir)/src/tscore/.libs/Version.o \
+    $(top_builddir)/src/tscore/.libs/Regression.o \
+    $(top_builddir)/src/tscore/.libs/ink_args.o \
+    $(top_builddir)/src/tscore/.libs/ParseRules.o \
+    $(top_builddir)/src/tscore/.libs/SourceLocation.o \
     @OPENSSL_LIBS@ @LIBPCRE@ @LIBTCL@

--- a/src/traffic_layout/traffic_layout.cc
+++ b/src/traffic_layout/traffic_layout.cc
@@ -40,8 +40,9 @@ main(int argc, const char **argv)
   engine.parser.add_global_usage("traffic_layout CMD [OPTIONS]");
 
   // global options
-  engine.parser.add_option("--help", "-h", "Print usage information");
-  engine.parser.add_option("--run-root", "", "using TS_RUNROOT as sandbox", "", 1);
+  engine.parser.add_option("--help", "-h", "Print usage information")
+    .add_option("--run-root", "", "using TS_RUNROOT as sandbox", "", 1)
+    .add_option("--version", "-V", "Print version string");
 
   // info command
   engine.parser.add_command("info", "Show the layout as default", [&]() { engine.info(); })


### PR DESCRIPTION
1. Standardize the --version method.
2. For the help message, we exit with the standard EX_USAGE code.
3. small update on the way we output usage message when some unknown arguments is found.