### PR TITLE
Doc: change code snippet highlighting scheme

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -161,7 +161,7 @@ exclude_patterns = []
 #show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = 'default'
 
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []


### PR DESCRIPTION
The lime green background for code snippets doesn't go with the light
blue background. The 'default' code highlighting scheme uses a moderate
gray background, but similar font colors for syntax highlighting.