### PR TITLE
traffic_ctl: Refactor and convert traffic_ctl to use ArgParser

### DIFF
--- a/include/tscore/runroot.h
+++ b/include/tscore/runroot.h
@@ -55,7 +55,7 @@ bool exists(const std::string &dir);
 bool is_directory(const std::string &directory);
 
 // argparser_runroot_handler should replace runroot_handler below when all program use ArgParser.
-void argparser_runroot_handler(std::string const &value, const char *executable, bool json);
+void argparser_runroot_handler(std::string const &value, const char *executable, bool json = false);
 void runroot_handler(const char **argv, bool json = false);
 
 // get a map from default layout

--- a/src/traffic_ctl/plugin.cc
+++ b/src/traffic_ctl/plugin.cc
@@ -23,30 +23,16 @@
 
 #include "traffic_ctl.h"
 
-static int
-plugin_msg(unsigned argc, const char **argv)
+void
+CtrlEngine::plugin_msg()
 {
-  if (!CtrlProcessArguments(argc, argv, nullptr, 0) || n_file_arguments != 2) {
-    return CtrlCommandUsage("plugin msg TAG DATA");
-  }
-
   TSMgmtError error;
+  auto msg_data = arguments.get("msg");
 
-  error = TSLifecycleMessage(file_arguments[0], file_arguments[1], strlen(file_arguments[1]) + 1);
+  error = TSLifecycleMessage(msg_data[0].c_str(), msg_data[1].c_str(), msg_data[1].size() + 1);
   if (error != TS_ERR_OKAY) {
-    CtrlMgmtError(error, "message '%s' not sent", file_arguments[0]);
-    return CTRL_EX_ERROR;
+    CtrlMgmtError(error, "message '%s' not sent", msg_data[0].c_str());
+    status_code = CTRL_EX_ERROR;
+    return;
   }
-
-  return CTRL_EX_OK;
-}
-
-int
-subcommand_plugin(unsigned argc, const char **argv)
-{
-  const subcommand commands[] = {
-    {plugin_msg, "msg", "Send message to plugins - a TAG and the message DATA"},
-  };
-
-  return CtrlGenericSubcommand("plugin", commands, countof(commands), argc, argv);
 }

--- a/src/traffic_ctl/storage.cc
+++ b/src/traffic_ctl/storage.cc
@@ -23,33 +23,18 @@
 
 #include "traffic_ctl.h"
 
-static int
-storage_offline(unsigned argc, const char **argv)
+void
+CtrlEngine::storage_offline()
 {
-  if (!CtrlProcessArguments(argc, argv, nullptr, 0) || n_file_arguments == 0) {
-    return CtrlCommandUsage("storage offline DEVICE [DEVICE ...]");
-  }
-
-  for (unsigned i = 0; i < n_file_arguments; ++i) {
+  auto offline_data = arguments.get("offline");
+  for (const auto &it : offline_data) {
     TSMgmtError error;
 
-    error = TSStorageDeviceCmdOffline(file_arguments[i]);
+    error = TSStorageDeviceCmdOffline(it.c_str());
     if (error != TS_ERR_OKAY) {
-      CtrlMgmtError(error, "failed to take %s offline", file_arguments[0]);
-      return CTRL_EX_ERROR;
+      CtrlMgmtError(error, "failed to take %s offline", offline_data[0].c_str());
+      status_code = CTRL_EX_ERROR;
+      return;
     }
   }
-
-  return CTRL_EX_OK;
-}
-
-int
-subcommand_storage(unsigned argc, const char **argv)
-{
-  const subcommand commands[] = {
-    {storage_offline, "offline", "Take one or more storage volumes offline"},
-    {CtrlUnimplementedCommand, "status", "Show the storage configuration"},
-  };
-
-  return CtrlGenericSubcommand("storage", commands, countof(commands), argc, argv);
 }


### PR DESCRIPTION
This is a refactoring of traffic_ctl to use the new command line parsing library ArgParser. There are almost 300 lines of codes less than previous and all the commands, subcommands and option handling are unified in the main function.

An engine, called `CtrlEngine` used for the parser and all methods, is defined in `traffic_ctl.h`. This engine makes the traffic_ctl more stable.

Some `printf`'s are converted to `cout`.