### PR TITLE
Doc: Add missing overrides and sort

### DIFF
--- a/doc/developer-guide/api/functions/TSHttpOverridableConfig.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpOverridableConfig.en.rst
@@ -78,6 +78,7 @@ TSOverridableConfigKey Value                                        Configuratio
 :c:macro:`TS_CONFIG_HTTP_BACKGROUND_FILL_COMPLETED_THRESHOLD`       :ts:cv:`proxy.config.http.background_fill_completed_threshold`
 :c:macro:`TS_CONFIG_HTTP_CACHE_CACHE_RESPONSES_TO_COOKIES`          :ts:cv:`proxy.config.http.cache.cache_responses_to_cookies`
 :c:macro:`TS_CONFIG_HTTP_CACHE_CACHE_URLS_THAT_LOOK_DYNAMIC`        :ts:cv:`proxy.config.http.cache.cache_urls_that_look_dynamic`
+:c:macro:`TS_CONFIG_HTTP_CACHE_ENABLE_DEFAULT_VARY_HEADER`          :ts:cv:`proxy.config.http.cache.enable_default_vary_headers`
 :c:macro:`TS_CONFIG_HTTP_CACHE_GENERATION`                          :ts:cv:`proxy.config.http.cache.generation`
 :c:macro:`TS_CONFIG_HTTP_CACHE_GUARANTEED_MAX_LIFETIME`             :ts:cv:`proxy.config.http.cache.guaranteed_max_lifetime`
 :c:macro:`TS_CONFIG_HTTP_CACHE_GUARANTEED_MIN_LIFETIME`             :ts:cv:`proxy.config.http.cache.guaranteed_min_lifetime`
@@ -85,6 +86,10 @@ TSOverridableConfigKey Value                                        Configuratio
 :c:macro:`TS_CONFIG_HTTP_CACHE_HEURISTIC_MAX_LIFETIME`              :ts:cv:`proxy.config.http.cache.heuristic_max_lifetime`
 :c:macro:`TS_CONFIG_HTTP_CACHE_HEURISTIC_MIN_LIFETIME`              :ts:cv:`proxy.config.http.cache.heuristic_min_lifetime`
 :c:macro:`TS_CONFIG_HTTP_CACHE_HTTP`                                :ts:cv:`proxy.config.http.cache.http`
+:c:macro:`TS_CONFIG_HTTP_CACHE_IGNORE_ACCEPT_MISMATCH`              :ts:cv:`proxy.config.http.cache.ignore_accept_mismatch`
+:c:macro:`TS_CONFIG_HTTP_CACHE_IGNORE_ACCEPT_CHARSET_MISMATCH`      :ts:cv:`proxy.config.http.cache.ignore_accept_charset_mismatch`
+:c:macro:`TS_CONFIG_HTTP_CACHE_IGNORE_ACCEPT_ENCODING_MISMATCH`     :ts:cv:`proxy.config.http.cache.ignore_accept_encoding_mismatch`
+:c:macro:`TS_CONFIG_HTTP_CACHE_IGNORE_ACCEPT_LANGUAGE_MISMATCH`     :ts:cv:`proxy.config.http.cache.ignore_accept_language_mismatch`
 :c:macro:`TS_CONFIG_HTTP_CACHE_IGNORE_AUTHENTICATION`               :ts:cv:`proxy.config.http.cache.ignore_authentication`
 :c:macro:`TS_CONFIG_HTTP_CACHE_IGNORE_CLIENT_CC_MAX_AGE`            :ts:cv:`proxy.config.http.cache.ignore_client_cc_max_age`
 :c:macro:`TS_CONFIG_HTTP_CACHE_IGNORE_CLIENT_NO_CACHE`              :ts:cv:`proxy.config.http.cache.ignore_client_no_cache`
@@ -98,6 +103,9 @@ TSOverridableConfigKey Value                                        Configuratio
 :c:macro:`TS_CONFIG_HTTP_CACHE_RANGE_LOOKUP`                        :ts:cv:`proxy.config.http.cache.range.lookup`
 :c:macro:`TS_CONFIG_HTTP_CACHE_RANGE_WRITE`                         :ts:cv:`proxy.config.http.cache.range.write`
 :c:macro:`TS_CONFIG_HTTP_CACHE_REQUIRED_HEADERS`                    :ts:cv:`proxy.config.http.cache.required_headers`
+:c:macro:`TS_CONFIG_HTTP_CACHE_VARY_DEFAULT_IMAGES`                 :ts:cv:`proxy.config.http.cache.vary_default_images`
+:c:macro:`TS_CONFIG_HTTP_CACHE_VARY_DEFAULT_OTHER`                  :ts:cv:`proxy.config.http.cache.vary_default_other`
+:c:macro:`TS_CONFIG_HTTP_CACHE_VARY_DEFAULT_TEXT`                   :ts:cv:`proxy.config.http.cache.vary_default_text`
 :c:macro:`TS_CONFIG_HTTP_CACHE_WHEN_TO_REVALIDATE`                  :ts:cv:`proxy.config.http.cache.when_to_revalidate`
 :c:macro:`TS_CONFIG_HTTP_CHUNKING_ENABLED`                          :ts:cv:`proxy.config.http.chunking_enabled`
 :c:macro:`TS_CONFIG_HTTP_CHUNKING_SIZE`                             :ts:cv:`proxy.config.http.chunking.size`
@@ -136,6 +144,7 @@ TSOverridableConfigKey Value                                        Configuratio
 :c:macro:`TS_CONFIG_HTTP_POST_CHECK_CONTENT_LENGTH_ENABLED`         :ts:cv:`proxy.config.http.post.check.content_length.enabled`
 :c:macro:`TS_CONFIG_HTTP_POST_CONNECT_ATTEMPTS_TIMEOUT`             :ts:cv:`proxy.config.http.post_connect_attempts_timeout`
 :c:macro:`TS_CONFIG_HTTP_REDIRECT_USE_ORIG_CACHE_KEY`               :ts:cv:`proxy.config.http.redirect_use_orig_cache_key`
+:c:macro:`TS_CONFIG_HTTP_REQUEST_BUFFER_ENABLED`                    :ts:cv:`proxy.config.http.request_buffer_enabled`
 :c:macro:`TS_CONFIG_HTTP_REQUEST_HEADER_MAX_SIZE`                   :ts:cv:`proxy.config.http.request_header_max_size`
 :c:macro:`TS_CONFIG_HTTP_RESPONSE_HEADER_MAX_SIZE`                  :ts:cv:`proxy.config.http.response_header_max_size`
 :c:macro:`TS_CONFIG_HTTP_RESPONSE_SERVER_ENABLED`                   :ts:cv:`proxy.config.http.response_server_enabled`
@@ -162,6 +171,7 @@ TSOverridableConfigKey Value                                        Configuratio
 :c:macro:`TS_CONFIG_WEBSOCKET_NO_ACTIVITY_TIMEOUT`                  :ts:cv:`proxy.config.websocket.no_activity_timeout`
 :c:macro:`TS_CONFIG_SSL_CERT_FILEPATH`                              :ts:cv:`proxy.config.ssl.client.cert.path`
 :c:macro:`TS_CONFIG_SSL_CERT_FILENAME`                              :ts:cv:`proxy.config.ssl.client.cert.filename`
+:c:macro:`TS_CONFIG_SSL_CLIENT_VERIFY_SERVER`                       :ts:cv:`proxy.config.ssl.client.verify.server`
 :c:macro:`TS_CONFIG_HTTP_PARENT_PROXY_FAIL_THRESHOLD`               :ts:cv:`proxy.config.http.parent_proxy.fail_threshold`
 :c:macro:`TS_CONFIG_HTTP_PARENT_PROXY_RETRY_TIME`                   :ts:cv:`proxy.config.http.parent_proxy.retry_time`
 :c:macro:`TS_CONFIG_HTTP_PER_PARENT_CONNECT_ATTEMPTS`               :ts:cv:`proxy.config.http.parent_proxy.per_parent_connect_attempts`


### PR DESCRIPTION
#4202 Added
TS_CONFIG_HTTP_CACHE_ENABLE_DEFAULT_VARY_HEADER
TS_CONFIG_HTTP_CACHE_IGNORE_ACCEPT_CHARSET_MISMATCH
TS_CONFIG_HTTP_CACHE_IGNORE_ACCEPT_ENCODING_MISMATCH
TS_CONFIG_HTTP_CACHE_IGNORE_ACCEPT_LANGUAGE_MISMATCH
TS_CONFIG_HTTP_CACHE_IGNORE_ACCEPT_MISMATCH
TS_CONFIG_HTTP_CACHE_VARY_DEFAULT_IMAGES
TS_CONFIG_HTTP_CACHE_VARY_DEFAULT_OTHER
TS_CONFIG_HTTP_CACHE_VARY_DEFAULT_TEXT
TS_CONFIG_HTTP_REQUEST_BUFFER_ENABLED
TS_CONFIG_SSL_CLIENT_VERIFY_SERVER

and sorted the list alphabetically