### PR TITLE
Runroot: make runroot_handler support both ink_args and ArgParser

### DIFF
--- a/include/tscore/runroot.h
+++ b/include/tscore/runroot.h
@@ -54,6 +54,8 @@ typedef std::unordered_map<std::string, std::string> RunrootMapType;
 bool exists(const std::string &dir);
 bool is_directory(const std::string &directory);
 
+// argparser_runroot_handler should replace runroot_handler below when all program use ArgParser.
+void argparser_runroot_handler(std::string const &value, const char *executable, bool json);
 void runroot_handler(const char **argv, bool json = false);
 
 // get a map from default layout

--- a/src/traffic_layout/traffic_layout.cc
+++ b/src/traffic_layout/traffic_layout.cc
@@ -41,7 +41,7 @@ main(int argc, const char **argv)
 
   // global options
   engine.parser.add_option("--help", "-h", "Print usage information")
-    .add_option("--run-root", "", "using TS_RUNROOT as sandbox", "", 1)
+    .add_option("--run-root", "", "using TS_RUNROOT as sandbox", "TS_RUNROOT", 1)
     .add_option("--version", "-V", "Print version string");
 
   // info command
@@ -68,7 +68,8 @@ main(int argc, const char **argv)
 
   engine.arguments = engine.parser.parse(argv);
 
-  runroot_handler(argv, engine.arguments.get("json"));
+  auto runroot_arg = engine.arguments.get("run-root");
+  argparser_runroot_handler(runroot_arg.value(), argv[0], engine.arguments.get("json"));
   Layout::create();
 
   engine.arguments.invoke();


### PR DESCRIPTION
Now, we want to make the runroot support both the previous `ink_args` and the new `ArgParser`.

A new method called `argparser_runroot_handler` is added temporarily and it will replace the previous `runroot_handler` when all programs are updated to use ArgParser.