### PR TITLE
Print thread name instead of thread id

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1807,6 +1807,46 @@ AC_LINK_IFELSE([
     AC_MSG_RESULT([no])
 ])
 
+# pthread_getname_np / pthread_get_name_np:
+AC_MSG_CHECKING([pthread_getname_np()])
+AC_LINK_IFELSE([
+    AC_LANG_PROGRAM([
+#if HAVE_PTHREAD_H
+#include <pthread.h>
+#endif
+#if PTHREAD_NP_H
+#include <pthread_np.h>
+#endif
+      ], [
+        char name[[32]];
+        pthread_getname_np(pthread_self(), name, sizeof(name));
+    ])
+  ], [
+    AC_DEFINE(HAVE_PTHREAD_GETNAME_NP, 1, [Whether pthread_getname_np() is available])
+    AC_MSG_RESULT([yes])
+  ], [
+    AC_MSG_RESULT([no])
+    AC_MSG_CHECKING([pthread_get_name_np()])
+    AC_LINK_IFELSE([
+        AC_LANG_PROGRAM([
+    #if HAVE_PTHREAD_H
+    #include <pthread.h>
+    #endif
+    #if PTHREAD_NP_H
+    #include <pthread_np.h>
+    #endif
+          ], [
+            char name[[32]];
+            pthread_get_name_np(pthread_self(), name, sizeof(name));
+        ])
+      ], [
+        AC_DEFINE(HAVE_PTHREAD_GET_NAME_NP, 1, [Whether pthread_get_name_np() is available])
+        AC_MSG_RESULT([yes])
+      ], [
+        AC_MSG_RESULT([no])
+    ])
+])
+
 # BSD-derived systems populate the socket length in the structure itself. It's
 # redundant to check all of these, but hey, I need the typing practice.
 AC_CHECK_MEMBER([struct sockaddr.sa_len], [], [], [#include <netinet/in.h>])

--- a/include/tscore/ink_thread.h
+++ b/include/tscore/ink_thread.h
@@ -47,6 +47,10 @@
 #include <pthread_np.h>
 #endif
 
+#if HAVE_SYS_PRCTL_H && defined(PR_SET_NAME)
+#include <sys/prctl.h>
+#endif
+
 #define INK_MUTEX_INIT PTHREAD_MUTEX_INITIALIZER
 #define INK_THREAD_STACK_MIN PTHREAD_STACK_MIN
 
@@ -304,6 +308,20 @@ ink_set_thread_name(const char *name ATS_UNUSED)
   pthread_set_name_np(pthread_self(), name);
 #elif defined(HAVE_SYS_PRCTL_H) && defined(PR_SET_NAME)
   prctl(PR_SET_NAME, name, 0, 0, 0);
+#endif
+}
+
+static inline void
+ink_get_thread_name(char *name, size_t len)
+{
+#if defined(HAVE_PTHREAD_GETNAME_NP)
+  pthread_getname_np(pthread_self(), name, len);
+#elif defined(HAVE_PTHREAD_GET_NAME_NP)
+  pthread_get_name_np(pthread_self(), name, len);
+#elif defined(HAVE_SYS_PRCTL_H) && defined(PR_GET_NAME)
+  prctl(PR_GET_NAME, name, 0, 0, 0);
+#else
+  snprintf(name, len, "0x%" PRIx64, (uint64_t)ink_thread_self());
 #endif
 }
 

--- a/src/tscore/BufferWriterFormat.cc
+++ b/src/tscore/BufferWriterFormat.cc
@@ -23,6 +23,7 @@
 
 #include "tscore/BufferWriter.h"
 #include "tscore/bwf_std_format.h"
+#include "tscore/ink_thread.h"
 #include <unistd.h>
 #include <sys/param.h>
 #include <cctype>
@@ -993,13 +994,9 @@ BWF_ThreadID(ts::BufferWriter &w, ts::BWFSpec const &spec)
 void
 BWF_ThreadName(ts::BufferWriter &w, ts::BWFSpec const &spec)
 {
-#if defined(__FreeBSD_version)
-  bwformat(w, spec, "thread"sv); // no thread names in FreeBSD.
-#else
   char name[32]; // manual says at least 16, bump that up a bit.
-  pthread_getname_np(pthread_self(), name, sizeof(name));
+  ink_get_thread_name(name, sizeof(name));
   bwformat(w, spec, std::string_view{name});
-#endif
 }
 
 static bool BW_INITIALIZED __attribute__((unused)) = []() -> bool {

--- a/src/tscore/Diags.cc
+++ b/src/tscore/Diags.cc
@@ -243,10 +243,9 @@ Diags::print_va(const char *debug_tag, DiagsLevel diags_level, const SourceLocat
   size_t timestamp_end_offset = format_writer.size();
 
   ///////////////////////
-  // add the thread id //
+  // add the thread name //
   ///////////////////////
-  format_writer.fill(
-    snprintf(format_writer.auxBuffer(), format_writer.remaining(), "{0x%" PRIx64 "} ", (uint64_t)ink_thread_self()));
+  format_writer.print("{thread-name} ");
 
   //////////////////////////////////
   // append the diag level prefix //


### PR DESCRIPTION
```
[Nov 11 21:52:48.020] [ET_NET 0] DEBUG: <HttpSM.cc:1788 (state_http_server_open)> (http_ss) [0] TCP Handshake complete
```

`pthread_get_name_np` will be added to FreeBSD 12. On older versions (and platforms that don't have any way to retrieve thread names), it prints thread id instead.