### PR TITLE
Add TS_EVENT_AIO_DONE, remove TS_AIO_EVENT_DONE

### DIFF
--- a/include/ts/apidefs.h.in
+++ b/include/ts/apidefs.h.in
@@ -430,7 +430,6 @@ typedef enum {
   TS_EVENT_SSL_SESSION_NEW                      = 2001,
   TS_EVENT_SSL_SESSION_REMOVE                   = 2002,
   TS_EVENT_AIO_DONE                             = 3900,
-  TS_AIO_EVENT_DONE                             = TS_EVENT_AIO_DONE,  // Deprecated, do not use in new code.
   TS_EVENT_HTTP_CONTINUE                        = 60000,
   TS_EVENT_HTTP_ERROR                           = 60001,
   TS_EVENT_HTTP_READ_REQUEST_HDR                = 60002,

--- a/include/ts/apidefs.h.in
+++ b/include/ts/apidefs.h.in
@@ -429,7 +429,8 @@ typedef enum {
   TS_EVENT_SSL_SESSION_GET                      = 2000,
   TS_EVENT_SSL_SESSION_NEW                      = 2001,
   TS_EVENT_SSL_SESSION_REMOVE                   = 2002,
-  TS_AIO_EVENT_DONE                             = 3900,
+  TS_EVENT_AIO_DONE                             = 3900,
+  TS_AIO_EVENT_DONE                             = TS_EVENT_AIO_DONE,  // Deprecated, do not use in new code.
   TS_EVENT_HTTP_CONTINUE                        = 60000,
   TS_EVENT_HTTP_ERROR                           = 60001,
   TS_EVENT_HTTP_READ_REQUEST_HDR                = 60002,

--- a/plugins/experimental/buffer_upload/buffer_upload.cc
+++ b/plugins/experimental/buffer_upload/buffer_upload.cc
@@ -543,12 +543,12 @@ pvc_plugin(TSCont contp, TSEvent event, void *edata)
     pvc_process_n_read(contp, event, my_state);
   } else if (edata == my_state->n_write_vio) {
     pvc_process_n_write(contp, event, my_state);
-  } else if (event == TS_AIO_EVENT_DONE && uconfig->use_disk_buffer) {
+  } else if (event == TS_EVENT_AIO_DONE && uconfig->use_disk_buffer) {
     TSMutexLock(my_state->disk_io_mutex);
     int size  = TSAIONBytesGet(callback);
     char *buf = TSAIOBufGet(callback);
     if (buf != my_state->chunk_buffer) {
-      // this TS_AIO_EVENT_DONE event is from TSAIOWrite()
+      // this TS_EVENT_AIO_DONE event is from TSAIOWrite()
       TSDebug(DEBUG_TAG, "aio write size: %d", size);
       my_state->size_written += size;
       if (buf != nullptr) {
@@ -561,7 +561,7 @@ pvc_plugin(TSCont contp, TSEvent event, void *edata)
         }
       }
     } else {
-      // this TS_AIO_EVENT_DONE event is from TSAIORead()
+      // this TS_EVENT_AIO_DONE event is from TSAIORead()
       TSDebug(DEBUG_TAG, "aio read size: %d", size);
       TSIOBufferWrite(my_state->req_buffer, my_state->chunk_buffer, size);
       my_state->size_read += size;

--- a/plugins/experimental/traffic_dump/traffic_dump.cc
+++ b/plugins/experimental/traffic_dump/traffic_dump.cc
@@ -290,7 +290,7 @@ int
 session_aio_handler(TSCont contp, TSEvent event, void *edata)
 {
   switch (event) {
-  case TS_AIO_EVENT_DONE: {
+  case TS_EVENT_AIO_DONE: {
     TSAIOCallback cb = static_cast<TSAIOCallback>(edata);
     SsnData *ssnData = static_cast<SsnData *>(TSContDataGet(contp));
     if (!ssnData) {


### PR DESCRIPTION
This is two commits so that the first one (adding TS_EVENT_AIO_DONE) can be cherry picked back to 8.0.