### PR TITLE
Repurpose sub claim and add cdniuc support for URI signing

### DIFF
--- a/plugins/experimental/uri_signing/jwt.c
+++ b/plugins/experimental/uri_signing/jwt.c
@@ -63,6 +63,7 @@ parse_jwt(json_t *raw)
   jwt->cdniv      = parse_integer_default(json_object_get(raw, "cdniv"), 1);
   jwt->cdnicrit   = json_string_value(json_object_get(raw, "cdnicrit"));
   jwt->cdniip     = json_string_value(json_object_get(raw, "cdniip"));
+  jwt->cdniuc     = json_string_value(json_object_get(raw, "cdniuc"));
   jwt->cdniets    = json_integer_value(json_object_get(raw, "cdniets"));
   jwt->cdnistt    = json_integer_value(json_object_get(raw, "cdnistt"));
   jwt->cdnistd    = parse_integer_default(json_object_get(raw, "cdnistd"), 0);
@@ -114,13 +115,8 @@ jwt_validate(struct jwt *jwt)
     return false;
   }
 
-  if (!jwt->sub) { /* Mandatory claim. Will be validated after key verification. */
-    PluginDebug("Initial JWT Failure: missing sub");
-    return false;
-  }
-
   if (!unsupported_string_claim(jwt->aud)) {
-    PluginDebug("Initial JWT Failure: missing sub");
+    PluginDebug("Initial JWT Failure: aud unsupported");
     return false;
   }
 
@@ -163,17 +159,17 @@ jwt_validate(struct jwt *jwt)
 }
 
 bool
-jwt_check_uri(const char *sub, const char *uri)
+jwt_check_uri(const char *cdniuc, const char *uri)
 {
   static const char CONT_URI_STR[]         = "uri";
   static const char CONT_URI_PATTERN_STR[] = "uri-pattern";
   static const char CONT_URI_REGEX_STR[]   = "uri-regex";
 
-  if (!sub || !*sub || !uri) {
+  if (!cdniuc || !*cdniuc || !uri) {
     return false;
   }
 
-  const char *kind = sub, *container = sub;
+  const char *kind = cdniuc, *container = cdniuc;
   while (*container && *container != ':') {
     ++container;
   }

--- a/plugins/experimental/uri_signing/jwt.h
+++ b/plugins/experimental/uri_signing/jwt.h
@@ -31,6 +31,7 @@ struct jwt {
   int cdniv;
   const char *cdnicrit;
   const char *cdniip;
+  const char *cdniuc;
   int cdniets;
   int cdnistt;
   int cdnistd;
@@ -38,7 +39,7 @@ struct jwt {
 struct jwt *parse_jwt(json_t *raw);
 void jwt_delete(struct jwt *jwt);
 bool jwt_validate(struct jwt *jwt);
-bool jwt_check_uri(const char *sub, const char *uri);
+bool jwt_check_uri(const char *cdniuc, const char *uri);
 
 struct _cjose_jwk_int;
 char *renew(struct jwt *jwt, const char *iss, struct _cjose_jwk_int *jwk, const char *alg, const char *package);

--- a/plugins/experimental/uri_signing/parse.c
+++ b/plugins/experimental/uri_signing/parse.c
@@ -184,7 +184,7 @@ validate_jws(cjose_jws_t *jws, struct config *cfg, const char *uri, size_t uri_c
     }
   }
 
-  if (!jwt_check_uri(jwt->sub, uri)) {
+  if (!jwt_check_uri(jwt->cdniuc, uri)) {
     PluginDebug("Valid key for %16p that does not match uri.", jws);
     goto jwt_fail;
   }


### PR DESCRIPTION
With the latest RFC for URI signing, the sub claim has been repurposed and a new cdniuc claim has been introduced. The sub claim is now rejected if passed in the token and the cdniuc claim now is processed as the sub claim was. 

https://tools.ietf.org/html/draft-ietf-cdni-uri-signing-16