### PR TITLE
Ability to turn off traffic manager listening to proxy ports

### DIFF
--- a/doc/appendices/command-line/traffic_manager.en.rst
+++ b/doc/appendices/command-line/traffic_manager.en.rst
@@ -36,6 +36,7 @@ Description
 .. option:: --path FILE
 .. option:: --proxyBackDoor PORT
 .. option:: --proxyOff
+.. option:: --listenOff
 .. option:: --proxyPort PORT
 .. option:: --recordsConf FILE
 .. option:: --tsArgs ARGUMENTS

--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -193,7 +193,7 @@ LocalManager::processRunning()
   }
 }
 
-LocalManager::LocalManager(bool proxy_on) : BaseManager(), run_proxy(proxy_on)
+LocalManager::LocalManager(bool proxy_on, bool listen) : BaseManager(), run_proxy(proxy_on), listen_for_proxy(listen)
 {
   bool found;
   std::string rundir(RecConfigReadRuntimeDir());
@@ -981,7 +981,7 @@ LocalManager::closeProxyPorts()
 void
 LocalManager::listenForProxy()
 {
-  if (!run_proxy) {
+  if (!run_proxy || !listen_for_proxy) {
     return;
   }
 

--- a/mgmt/LocalManager.h
+++ b/mgmt/LocalManager.h
@@ -56,7 +56,7 @@ enum ManagementPendingOperation {
 class LocalManager : public BaseManager
 {
 public:
-  explicit LocalManager(bool proxy_on);
+  explicit LocalManager(bool proxy_on, bool listen);
   ~LocalManager();
 
   void initAlarm();
@@ -93,6 +93,7 @@ public:
   bool processRunning();
 
   bool run_proxy;
+  bool listen_for_proxy;
   bool proxy_recoverable = true; // false if traffic_server cannot recover with a reboot
   time_t manager_started_at;
   time_t proxy_started_at                              = -1;

--- a/src/traffic_manager/traffic_manager.cc
+++ b/src/traffic_manager/traffic_manager.cc
@@ -84,6 +84,7 @@ static inkcoreapi DiagsConfig *diagsConfig;
 static char debug_tags[1024]  = "";
 static char action_tags[1024] = "";
 static int proxy_off          = false;
+static int listen_off         = false;
 static char bind_stdout[512]  = "";
 static char bind_stderr[512]  = "";
 
@@ -491,6 +492,7 @@ main(int argc, const char **argv)
 
   ArgumentDescription argument_descriptions[] = {
     {"proxyOff", '-', "Disable proxy", "F", &proxy_off, nullptr, nullptr},
+    {"listenOff", '-', "Disable traffic manager listen to proxy ports", "F", &listen_off, nullptr, nullptr},
     {"path", '-', "Path to the management socket", "S*", &mgmt_path, nullptr, nullptr},
     {"recordsConf", '-', "Path to records.config", "S*", &recs_conf, nullptr, nullptr},
     {"tsArgs", '-', "Additional arguments for traffic_server", "S*", &tsArgs, nullptr, nullptr},
@@ -572,7 +574,7 @@ main(int argc, const char **argv)
 #endif
   ts_host_res_global_init();
   ts_session_protocol_well_known_name_indices_init();
-  lmgmt = new LocalManager(proxy_off == false);
+  lmgmt = new LocalManager(proxy_off == false, listen_off == false);
   RecLocalInitMessage();
   lmgmt->initAlarm();
 


### PR DESCRIPTION
Have the ability in traffic manager to not listen to traffic server ports.

