### PR TITLE
Runroot: Update verify command and refactor

### DIFF
--- a/doc/appendices/command-line/traffic_layout.en.rst
+++ b/doc/appendices/command-line/traffic_layout.en.rst
@@ -54,7 +54,7 @@ First we need to create a runroot. It can be created simply by calling command `
 A runroot will be created in ``/path/to/runroot``, available for other programs to use.
 If the path is not specified, the current working directory will be used.
 
-To run traffic_manager, for example, using the runroot, there are several ways:
+For example, to run traffic_manager, using the runroot, there are several ways:
     #. ``/path/to/runroot/bin/traffic_manager``
     #. ``traffic_manager --run-root=/path/to/runroot``
     #. ``traffic_manager --run-root=/path/to/runroot/runroot.yaml``
@@ -126,6 +126,13 @@ Verify the permission of the sandbox. The permission issues can be fixed with ``
 Example: ::
 
     traffic_layout verify (--path /path/to/sandbox/) (--fix) (--with-user root)
+
+.. Warning::
+
+   If a custom layout is used and system files are included in some directories, ``--fix`` option might potentially have unexpected behaviors.
+   For example, if sysconfdir is defined as ``/etc`` instead of ``/etc/trafficserver`` in ``runroot.yaml``,
+   ``--fix`` may perform permission changes on the system configuration files. With normally created runroot with default layout,
+   there is no such issue since traffic server related files are filtered.
 
 =======
 Options

--- a/src/traffic_layout/engine.h
+++ b/src/traffic_layout/engine.h
@@ -26,7 +26,21 @@
 #include "tscore/ArgParser.h"
 #include <unordered_map>
 
-typedef std::unordered_map<std::string, std::string> RunrootMapType;
+// used by runroot verify
+struct PermissionEntry {
+  std::string name; // sysconfdir, libdir ...
+  std::string path; // real path of the directory
+  // required permission
+  mode_t r_mode;
+  mode_t w_mode;
+  mode_t e_mode;
+  // result set by set_permission()
+  bool result = true;
+};
+
+// this map contain the corresponding permission information of directories
+// PermissionEntry contains the read/write/execute mode and the result of output
+using PermissionMapType = std::unordered_map<std::string, PermissionEntry>;
 
 // structure for informaiton of the runroot passing around
 struct LayoutEngine {
@@ -49,4 +63,6 @@ struct LayoutEngine {
   ts::Arguments arguments;
   // mordern argv
   std::vector<std::string> _argv;
+
+  int status_code = 0;
 };

--- a/src/traffic_layout/traffic_layout.cc
+++ b/src/traffic_layout/traffic_layout.cc
@@ -74,5 +74,5 @@ main(int argc, const char **argv)
 
   engine.arguments.invoke();
 
-  return 0;
+  return engine.status_code;
 }

--- a/src/tscore/ArgParser.cc
+++ b/src/tscore/ArgParser.cc
@@ -34,6 +34,10 @@ std::string global_usage;
 std::string parser_program_name;
 std::string default_command;
 
+// by default return EX_USAGE(64) when usage is called.
+// if -h or --help is called specifically, return 0
+int usage_return_code = EX_USAGE;
+
 namespace ts
 {
 ArgParser::ArgParser() {}
@@ -107,7 +111,7 @@ ArgParser::Command::help_message(std::string_view err) const
     std::cout << "\nExample Usage: " << _example_usage << std::endl;
   }
   // standard return code
-  exit(EX_USAGE);
+  exit(usage_return_code);
 }
 
 void
@@ -436,6 +440,7 @@ ArgParser::Command::append_option_data(Arguments &ret, AP_StrVec &args, int inde
           }
           command = &it->second;
         }
+        usage_return_code = 0;
         command->help_message();
       }
       // deal with normal --arg val1 val2 ...

--- a/tests/gold_tests/runroot/runroot_init.test.py
+++ b/tests/gold_tests/runroot/runroot_init.test.py
@@ -59,7 +59,6 @@ tr.Processes.Default.Command = "mkdir " + path4 + ";touch " + randomfile + ";$AT
 tr.Processes.Default.ReturnCode = 0
 f = tr.Disk.File(os.path.join(path4, "runroot.yaml"))
 f.Exists = True
-tr.Processes.Default.Streams.All = Testers.ContainsExpression("Forcing creating runroot", "force message")
 
 # create runroot with junk to guarantee only traffic server related files are copied
 bin_path = Test.Variables.BINDIR[Test.Variables.BINDIR.find(Test.Variables.PREFIX) + len(Test.Variables.PREFIX) + 1:]

--- a/tests/gold_tests/runroot/runroot_verify.test.py
+++ b/tests/gold_tests/runroot/runroot_verify.test.py
@@ -42,12 +42,7 @@ tr.Processes.Default.Streams.All = Testers.ContainsExpression(
     os.path.join(path, "bin"), "example bindir output")
 tr.Processes.Default.Streams.All = Testers.ContainsExpression(
     os.path.join(path, "var/log/trafficserver"), "example logdir output")
-tr.Processes.Default.Streams.All = Testers.ContainsExpression(
-    "Read Permission: ", "read permission output")
-tr.Processes.Default.Streams.All = Testers.ContainsExpression(
-    "Execute Permission: ", "execute permission output")
-tr.Processes.Default.Streams.All = Testers.ContainsExpression(
-    "Write Permission: ", "write permission output")
+tr.Processes.Default.Streams.All = Testers.ContainsExpression("PASSED", "contain passed message")
 
 # verify test #2
 bin_path = Test.Variables.BINDIR[Test.Variables.BINDIR.find(
@@ -60,9 +55,5 @@ tr.Processes.Default.Streams.All = Testers.ContainsExpression(
     os.path.join(path, "bin"), "example bindir output")
 tr.Processes.Default.Streams.All = Testers.ContainsExpression(
     os.path.join(path, "var/log/trafficserver"), "example logdir output")
-tr.Processes.Default.Streams.All = Testers.ContainsExpression(
-    "Read Permission: ", "read permission output")
-tr.Processes.Default.Streams.All = Testers.ContainsExpression(
-    "Execute Permission: ", "execute permission output")
-tr.Processes.Default.Streams.All = Testers.ContainsExpression(
-    "Write Permission: ", "write permission output")
+tr.Processes.Default.Streams.All = Testers.ContainsExpression("PASSED", "contain passed message")
+


### PR DESCRIPTION
This PR is a rewrite of `verify` command of `traffic_layout`.

Previously, `verify` is not very powerful because it only verifies the directory itself but not files within, and the `--fix` option only uniformly set permissions on all those files within.

With this update, `verify` command can verify the directories and files in a better way and `--fix` also is able to set the correct permission nicely.

There is also some refactoring performed.