### PR TITLE
[WEBP] Transform images when a client accepts image/webp.

### DIFF
--- a/plugins/experimental/webp_transform/ImageTransform.cc
+++ b/plugins/experimental/webp_transform/ImageTransform.cc
@@ -92,7 +92,12 @@ public:
   {
     string ctype      = transaction.getServerResponse().getHeaders().values("Content-Type");
     string user_agent = transaction.getServerRequest().getHeaders().values("User-Agent");
-    if (user_agent.find("Chrome") != string::npos && (ctype.find("jpeg") != string::npos || ctype.find("png") != string::npos)) {
+    string accept     = transaction.getServerRequest().getHeaders().values("Accept");
+
+    bool webp_supported = accept.find("image/webp") != string::npos || user_agent.find("Chrome") != string::npos;
+    bool image_format   = ctype.find("jpeg") != string::npos || ctype.find("png") != string::npos;
+
+    if (webp_supported && image_format) {
       TS_DEBUG(TAG, "Content type is either jpeg or png. Converting to webp");
       transaction.addPlugin(new ImageTransform(transaction));
     }


### PR DESCRIPTION
More browsers besides Chrome have started to support webp
as image format. To advertise their support, they include
image/webp content type in the Accept header.

This change allows this plugin to detect support for webp
by checking the Accept header and keeps the old User-Agent
check for old versions of Chrome.

Signed-off-by: David Calavera <david.calavera@gmail.com>