### PR TITLE
Keep frame id and frame generator instead of actual frame instance

### DIFF
--- a/iocore/net/P_QUICNetVConnection.h
+++ b/iocore/net/P_QUICNetVConnection.h
@@ -297,13 +297,13 @@ private:
 
   uint64_t _maximum_stream_frame_data_size();
   void _store_frame(ats_unique_buf &buf, size_t &offset, uint64_t &max_frame_size, QUICFrameUPtr &frame,
-                    std::vector<QUICFrameUPtr> &frames);
+                    std::vector<QUICFrameInfo> &frames);
   QUICPacketUPtr _packetize_frames(QUICEncryptionLevel level, uint64_t max_packet_size);
   void _packetize_closing_frame();
   QUICPacketUPtr _build_packet(ats_unique_buf buf, size_t len, bool retransmittable, bool probing,
-                               std::vector<QUICFrameUPtr> &frames, QUICPacketType type = QUICPacketType::UNINITIALIZED);
+                               std::vector<QUICFrameInfo> &frames, QUICPacketType type = QUICPacketType::UNINITIALIZED);
   QUICPacketUPtr _build_packet(QUICEncryptionLevel level, ats_unique_buf buf, size_t len, bool retransmittable, bool probing,
-                               std::vector<QUICFrameUPtr> &frames);
+                               std::vector<QUICFrameInfo> &frames);
 
   QUICConnectionErrorUPtr _recv_and_ack(QUICPacket &packet, bool *has_non_probing_frame = nullptr);
 

--- a/iocore/net/quic/QUICFrameGenerator.h
+++ b/iocore/net/quic/QUICFrameGenerator.h
@@ -33,11 +33,11 @@ public:
   virtual QUICFrameUPtr generate_frame(QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size) = 0;
 
   virtual void
-  on_frame_acked(QUICFrameUPtr &frame, QUICEncryptionLevel level)
+  on_frame_acked(QUICFrameId id)
   {
   }
   virtual void
-  on_frame_lost(QUICFrameUPtr &frame, QUICEncryptionLevel level)
+  on_frame_lost(QUICFrameId id)
   {
   }
 

--- a/iocore/net/quic/QUICLossDetector.cc
+++ b/iocore/net/quic/QUICLossDetector.cc
@@ -304,13 +304,13 @@ QUICLossDetector::_on_packet_acked(const PacketInfo &acked_packet)
   this->_tlp_count       = 0;
   this->_rto_count       = 0;
 
-  for (QUICFrameUPtr &frame : acked_packet.packet->frames()) {
-    auto reactor = frame->generated_by();
+  for (QUICFrameInfo &frame_info : acked_packet.packet->frames()) {
+    auto reactor = frame_info.generated_by();
     if (reactor == nullptr) {
       continue;
     }
 
-    reactor->on_frame_acked(frame, QUICTypeUtil::encryption_level(acked_packet.packet->type()));
+    reactor->on_frame_acked(frame_info.id());
   }
 
   this->_remove_from_sent_packet_list(acked_packet.packet_number);
@@ -554,13 +554,13 @@ QUICLossDetector::_retransmit_lost_packet(QUICPacketUPtr &packet)
   SCOPED_MUTEX_LOCK(transmitter_lock, this->_transmitter->get_packet_transmitter_mutex().get(), this_ethread());
   SCOPED_MUTEX_LOCK(lock, this->_loss_detection_mutex, this_ethread());
 
-  for (QUICFrameUPtr &frame : packet->frames()) {
-    auto reactor = frame->generated_by();
+  for (QUICFrameInfo &frame_info : packet->frames()) {
+    auto reactor = frame_info.generated_by();
     if (reactor == nullptr) {
       continue;
     }
 
-    reactor->on_frame_lost(frame, QUICTypeUtil::encryption_level(packet->type()));
+    reactor->on_frame_lost(frame_info.id());
   }
   this->_transmitter->retransmit_packet(*packet);
 }

--- a/iocore/net/quic/QUICPacket.h
+++ b/iocore/net/quic/QUICPacket.h
@@ -54,12 +54,12 @@ class QUICTrackablePacket
 {
 public:
   virtual ~QUICTrackablePacket() {}
-  std::vector<QUICFrameUPtr> &frames();
+  std::vector<QUICFrameInfo> &frames();
 
 protected:
   QUICTrackablePacket() {}
-  QUICTrackablePacket(std::vector<QUICFrameUPtr> &frames);
-  std::vector<QUICFrameUPtr> _frames;
+  QUICTrackablePacket(std::vector<QUICFrameInfo> &frames);
+  std::vector<QUICFrameInfo> _frames;
 };
 
 class QUICPacketHeader
@@ -332,7 +332,7 @@ public:
    */
   QUICPacket(QUICPacketHeaderUPtr header, ats_unique_buf payload, size_t payload_len);
 
-  QUICPacket(QUICPacketHeaderUPtr header, ats_unique_buf payload, size_t payload_len, std::vector<QUICFrameUPtr> &frames);
+  QUICPacket(QUICPacketHeaderUPtr header, ats_unique_buf payload, size_t payload_len, std::vector<QUICFrameInfo> &frames);
 
   /*
    * Creates a QUICPacket with a QUICPacketHeader, a buffer that contains payload and a flag that indicates whether the packet is
@@ -344,7 +344,7 @@ public:
   QUICPacket(QUICPacketHeaderUPtr header, ats_unique_buf payload, size_t payload_len, bool retransmittable, bool probing);
 
   QUICPacket(QUICPacketHeaderUPtr header, ats_unique_buf payload, size_t payload_len, bool retransmittable, bool probing,
-             std::vector<QUICFrameUPtr> &frames);
+             std::vector<QUICFrameInfo> &frames);
 
   ~QUICPacket();
 
@@ -442,17 +442,17 @@ public:
                         QUICPacketCreationResult &result);
   QUICPacketUPtr create_initial_packet(QUICConnectionId destination_cid, QUICConnectionId source_cid,
                                        QUICPacketNumber base_packet_number, ats_unique_buf payload, size_t len,
-                                       bool retransmittable, bool probing, std::vector<QUICFrameUPtr> &frame,
+                                       bool retransmittable, bool probing, std::vector<QUICFrameInfo> &frame,
                                        ats_unique_buf token = ats_unique_buf(nullptr), size_t token_len = 0);
   QUICPacketUPtr create_handshake_packet(QUICConnectionId destination_cid, QUICConnectionId source_cid,
                                          QUICPacketNumber base_packet_number, ats_unique_buf payload, size_t len,
-                                         bool retransmittable, bool probing, std::vector<QUICFrameUPtr> &frame);
+                                         bool retransmittable, bool probing, std::vector<QUICFrameInfo> &frames);
   QUICPacketUPtr create_zero_rtt_packet(QUICConnectionId destination_cid, QUICConnectionId source_cid,
                                         QUICPacketNumber base_packet_number, ats_unique_buf payload, size_t len,
-                                        bool retransmittable, bool probing, std::vector<QUICFrameUPtr> &frame);
+                                        bool retransmittable, bool probing, std::vector<QUICFrameInfo> &frames);
   QUICPacketUPtr create_protected_packet(QUICConnectionId connection_id, QUICPacketNumber base_packet_number,
                                          ats_unique_buf payload, size_t len, bool retransmittable, bool probing,
-                                         std::vector<QUICFrameUPtr> &frame);
+                                         std::vector<QUICFrameInfo> &frames);
   void set_version(QUICVersion negotiated_version);
 
   // FIXME We don't need QUICHandshakeProtocol here, and should pass QUICCryptoInfoProvider or somethign instead.
@@ -470,5 +470,5 @@ private:
 
   static QUICPacketUPtr _create_unprotected_packet(QUICPacketHeaderUPtr header);
   QUICPacketUPtr _create_encrypted_packet(QUICPacketHeaderUPtr header, bool retransmittable, bool probing,
-                                          std::vector<QUICFrameUPtr> &frame);
+                                          std::vector<QUICFrameInfo> &frames);
 };

--- a/iocore/net/quic/test/test_QUICFrame.cc
+++ b/iocore/net/quic/test/test_QUICFrame.cc
@@ -881,7 +881,7 @@ TEST_CASE("Store MaxData Frame", "[quic]")
     0x04,                                          // Type
     0xd1, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88 // Maximum Data
   };
-  QUICMaxDataFrame max_data_frame(0x1122334455667788);
+  QUICMaxDataFrame max_data_frame(0x1122334455667788, 0, nullptr);
   CHECK(max_data_frame.size() == 9);
 
   max_data_frame.store(buf, &len, 65535);
@@ -947,7 +947,7 @@ TEST_CASE("Store MaxStreamId Frame", "[quic]")
     0x06,                   // Type
     0x81, 0x02, 0x03, 0x04, // Stream ID
   };
-  QUICMaxStreamIdFrame max_stream_id_frame(0x01020304);
+  QUICMaxStreamIdFrame max_stream_id_frame(0x01020304, 0, nullptr);
   CHECK(max_stream_id_frame.size() == 5);
 
   max_stream_id_frame.store(buf, &len, 65535);
@@ -978,7 +978,7 @@ TEST_CASE("Store Blocked Frame", "[quic]")
     0x08, // Type
     0x07, // Offset
   };
-  QUICBlockedFrame blocked_stream_frame(0x07);
+  QUICBlockedFrame blocked_stream_frame(0x07, 0, nullptr);
   CHECK(blocked_stream_frame.size() == 2);
 
   blocked_stream_frame.store(buf, &len, 65535);
@@ -1045,7 +1045,7 @@ TEST_CASE("Store StreamIdBlocked Frame", "[quic]")
     0x0a,       // Type
     0x41, 0x02, // Stream ID
   };
-  QUICStreamIdBlockedFrame stream_id_blocked_frame(0x0102);
+  QUICStreamIdBlockedFrame stream_id_blocked_frame(0x0102, 0, nullptr);
   CHECK(stream_id_blocked_frame.size() == 3);
 
   stream_id_blocked_frame.store(buf, &len, 65535);
@@ -1277,7 +1277,7 @@ TEST_CASE("RETIRE_CONNECTION_ID Frame", "[quic]")
     uint8_t buf[32];
     size_t len;
 
-    QUICRetireConnectionIdFrame frame(seq_num);
+    QUICRetireConnectionIdFrame frame(seq_num, 0, nullptr);
     CHECK(frame.size() == raw_retire_connection_id_frame_len);
 
     frame.store(buf, &len, 16);
@@ -1373,7 +1373,7 @@ TEST_CASE("Retransmit", "[quic][frame][retransmit]")
   QUICPacketFactory factory;
   MockQUICHandshakeProtocol hs_protocol;
   factory.set_hs_protocol(&hs_protocol);
-  std::vector<QUICFrameUPtr> frames;
+  std::vector<QUICFrameInfo> frames;
   QUICPacketUPtr packet = factory.create_protected_packet({reinterpret_cast<const uint8_t *>("\x01\x02\x03\x04"), 4}, 0, {nullptr},
                                                           0, true, false, frames);
   SECTION("STREAM frame split")

--- a/iocore/net/quic/test/test_QUICLossDetector.cc
+++ b/iocore/net/quic/test/test_QUICLossDetector.cc
@@ -45,7 +45,7 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
   size_t payload_len                  = 16;
   QUICPacketUPtr packet               = QUICPacketFactory::create_null_packet();
   std::shared_ptr<QUICAckFrame> frame = QUICFrameFactory::create_null_ack_frame();
-  std::vector<QUICFrameUPtr> dummy_frames;
+  std::vector<QUICFrameInfo> dummy_frames;
 
   SECTION("Handshake")
   {

--- a/iocore/net/quic/test/test_QUICPacketFactory.cc
+++ b/iocore/net/quic/test/test_QUICPacketFactory.cc
@@ -90,7 +90,7 @@ TEST_CASE("QUICPacketFactory_Create_Handshake", "[quic]")
   MockQUICHandshakeProtocol hs_protocol;
   factory.set_hs_protocol(&hs_protocol);
   factory.set_version(0x11223344);
-  std::vector<QUICFrameUPtr> dummy_frames;
+  std::vector<QUICFrameInfo> dummy_frames;
 
   uint8_t raw[]          = {0xaa, 0xbb, 0xcc, 0xdd};
   ats_unique_buf payload = ats_unique_malloc(sizeof(raw));

--- a/iocore/net/quic/test/test_QUICVersionNegotiator.cc
+++ b/iocore/net/quic/test/test_QUICVersionNegotiator.cc
@@ -32,7 +32,7 @@ TEST_CASE("QUICVersionNegotiator - Server Side", "[quic]")
   MockQUICHandshakeProtocol hs_protocol;
   packet_factory.set_hs_protocol(&hs_protocol);
   QUICVersionNegotiator vn;
-  std::vector<QUICFrameUPtr> dummy_frame;
+  std::vector<QUICFrameInfo> dummy_frames;
 
   SECTION("Normal case")
   {
@@ -42,7 +42,7 @@ TEST_CASE("QUICVersionNegotiator - Server Side", "[quic]")
     // Negotiate version
     packet_factory.set_version(QUIC_SUPPORTED_VERSIONS[0]);
     QUICPacketUPtr initial_packet =
-      packet_factory.create_initial_packet({}, {}, 0, ats_unique_malloc(0), 0, true, false, dummy_frame);
+      packet_factory.create_initial_packet({}, {}, 0, ats_unique_malloc(0), 0, true, false, dummy_frames);
     vn.negotiate(initial_packet.get());
     CHECK(vn.status() == QUICVersionNegotiationStatus::NEGOTIATED);
 
@@ -61,7 +61,7 @@ TEST_CASE("QUICVersionNegotiator - Server Side", "[quic]")
     // Negotiate version
     packet_factory.set_version(QUIC_SUPPORTED_VERSIONS[0]);
     QUICPacketUPtr initial_packet =
-      packet_factory.create_initial_packet({}, {}, 0, ats_unique_malloc(0), 0, true, false, dummy_frame);
+      packet_factory.create_initial_packet({}, {}, 0, ats_unique_malloc(0), 0, true, false, dummy_frames);
     vn.negotiate(initial_packet.get());
     CHECK(vn.status() == QUICVersionNegotiationStatus::NEGOTIATED);
 
@@ -80,7 +80,7 @@ TEST_CASE("QUICVersionNegotiator - Server Side", "[quic]")
     // Negotiate version
     packet_factory.set_version(QUIC_EXERCISE_VERSIONS);
     QUICPacketUPtr initial_packet =
-      packet_factory.create_initial_packet({}, {}, 0, ats_unique_malloc(0), 0, true, false, dummy_frame);
+      packet_factory.create_initial_packet({}, {}, 0, ats_unique_malloc(0), 0, true, false, dummy_frames);
     vn.negotiate(initial_packet.get());
     CHECK(vn.status() == QUICVersionNegotiationStatus::NOT_NEGOTIATED);
 
@@ -98,7 +98,7 @@ TEST_CASE("QUICVersionNegotiator - Client Side", "[quic]")
   MockQUICHandshakeProtocol hs_protocol;
   packet_factory.set_hs_protocol(&hs_protocol);
   QUICVersionNegotiator vn;
-  std::vector<QUICFrameUPtr> dummy_frame;
+  std::vector<QUICFrameInfo> dummy_frames;
 
   SECTION("Normal case")
   {
@@ -124,7 +124,7 @@ TEST_CASE("QUICVersionNegotiator - Client Side", "[quic]")
     // Negotiate version
     packet_factory.set_version(QUIC_EXERCISE_VERSIONS);
     QUICPacketUPtr initial_packet =
-      packet_factory.create_initial_packet({}, {}, 0, ats_unique_malloc(0), 0, true, false, dummy_frame);
+      packet_factory.create_initial_packet({}, {}, 0, ats_unique_malloc(0), 0, true, false, dummy_frames);
 
     // Server send VN packet based on Initial packet
     QUICPacketUPtr vn_packet =


### PR DESCRIPTION
We probably don't need to keep actual frame instances.

The idea is eliminating class allocators for various QUIC frames. If we don't keep actual frames, we can create QUICFrame instances on one pre-allocated local buffer (hopefully on stack).

As the first step, this PR does these things:
- Add ID to QUICFrame
- Keep only frame id and frame generator in `frames` vector, instead of actual frame instances
 
`QUICFrameGenerator`s are expected to maintain which frame have what information. Callback functions (`on_frame_acked` and `on_frame_lost`) will be called with a frame id, so frame generators can take action against the ack / lost (e.g. regenerating frames).