### PR TITLE
Do not reload remap.config when calling verify_config

### DIFF
--- a/proxy/ReverseProxy.h
+++ b/proxy/ReverseProxy.h
@@ -56,5 +56,6 @@ bool response_url_remap(HTTPHdr *response_header, UrlRewrite *table);
 
 // Reload Functions
 bool reloadUrlRewrite();
+bool urlRewriteVerify();
 
 int url_rewrite_CB(const char *name, RecDataT data_type, RecData data, void *cookie);

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -848,7 +848,7 @@ cmd_verify(char * /* cmd ATS_UNUSED */)
     Layout::get()->update_sysconfdir(conf_dir);
   }
 
-  if (!reloadUrlRewrite()) {
+  if (!urlRewriteVerify()) {
     exitStatus |= (1 << 0);
     fprintf(stderr, "ERROR: Failed to load remap.config, exitStatus %d\n\n", exitStatus);
   } else {


### PR DESCRIPTION
Calling `verify_config` should not swap the currently loaded
configuration, but simply check whether the configuration files are
valid.

This fixes issue #4466