### PR TITLE
Add test and fix regression with disable_h2 option

### DIFF
--- a/iocore/net/YamlSNIConfig.cc
+++ b/iocore/net/YamlSNIConfig.cc
@@ -60,7 +60,7 @@ TsEnumDescriptor POLICY_DESCRIPTOR     = {{{"DISABLED", 0}, {"PERMISSIVE", 1}, {
 TsEnumDescriptor PROPERTIES_DESCRIPTOR = {{{"NONE", 0}, {"SIGNATURE", 0x1}, {"NAME", 0x2}, {"ALL", 0x3}}};
 
 std::set<std::string> valid_sni_config_keys = {TS_fqdn,
-                                               TS_disable_H2,
+                                               TS_disable_h2,
                                                TS_verify_client,
                                                TS_tunnel_route,
                                                TS_verify_origin_server,
@@ -88,8 +88,8 @@ template <> struct convert<YamlSNIConfig::Item> {
     } else {
       return false; // servername must be present
     }
-    if (node[TS_disable_H2]) {
-      item.disable_h2 = node[TS_disable_H2].as<bool>();
+    if (node[TS_disable_h2]) {
+      item.disable_h2 = node[TS_disable_h2].as<bool>();
     }
 
     // enum

--- a/iocore/net/YamlSNIConfig.h
+++ b/iocore/net/YamlSNIConfig.h
@@ -28,7 +28,7 @@
 
 #define TSDECL(id) constexpr char TS_##id[] = #id
 TSDECL(fqdn);
-TSDECL(disable_H2);
+TSDECL(disable_h2);
 TSDECL(verify_client);
 TSDECL(tunnel_route);
 TSDECL(verify_server_policy);


### PR DESCRIPTION
Added test for the disable_h2 option in ssl_server_name.yaml.

Fix regression introduced by macro tidy up in 490495431f1f11e9e52cff12df54d51115cef2c0