### PR TITLE
Avoid doubling the size of ats_unique_buf instances.

### DIFF
--- a/include/tscore/ink_memory.h
+++ b/include/tscore/ink_memory.h
@@ -600,7 +600,14 @@ path_join(ats_scoped_str const &lhs, ats_scoped_str const &rhs)
   return x.release();
 }
 
-using ats_unique_buf = std::unique_ptr<uint8_t, decltype(&ats_free)>;
+struct ats_unique_buf_deleter {
+  void
+  operator()(uint8_t *p)
+  {
+    ats_free(p);
+  }
+};
+using ats_unique_buf = std::unique_ptr<uint8_t[], ats_unique_buf_deleter>;
 ats_unique_buf ats_unique_malloc(size_t size);
 
 #endif /* __cplusplus */

--- a/src/tscore/ink_memory.cc
+++ b/src/tscore/ink_memory.cc
@@ -164,7 +164,7 @@ ats_mallopt(int param ATS_UNUSED, int value ATS_UNUSED)
 ats_unique_buf
 ats_unique_malloc(size_t size)
 {
-  return ats_unique_buf(reinterpret_cast<uint8_t *>(ats_malloc(size)), [](void *p) { ats_free(p); });
+  return ats_unique_buf(static_cast<uint8_t *>(ats_malloc(size)));
 }
 
 int


### PR DESCRIPTION
It is not necessary to have a pointer to the ats_free() function in each instance.

http://coliru.stacked-crooked.com/a/bf9a683da11820c2