### PR TITLE
Issue #4637: Clean up / unify hex conversions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ CPP_ADD_SOURCES(proxy proxy/http)
 CPP_ADD_SOURCES(proxy proxy/http2)
 CPP_ADD_SOURCES(proxy proxy/http/remap)
 CPP_ADD_SOURCES(proxy proxy/hdrs)
+CPP_ADD_SOURCES(proxy proxy/logging)
 
 CPP_LIB(iocore iocore iocore)
 CPP_ADD_SOURCES(iocore iocore/eventsystem)

--- a/proxy/logging/LogFieldAliasMap.h
+++ b/proxy/logging/LogFieldAliasMap.h
@@ -183,34 +183,4 @@ public:
   }
 };
 
-/*****************************************************************************
-
-The LogFieldAliasTimehex class implements a LogFieldAliasMap that converts time
-from their integer value to the "hex" notation and back.
-
- *****************************************************************************/
-
-class LogFieldAliasTimeHex : public LogFieldAliasMap
-{
-public:
-  int
-  asInt(char *str, IntType *time, bool /* case_sensitive ATS_UNUSED */) const override
-  {
-    unsigned long a;
-    // coverity[secure_coding]
-    if (sscanf(str, "%lx", (unsigned long *)&a) == 1) {
-      *time = (IntType)a;
-      return ALL_OK;
-    } else {
-      return INVALID_STRING;
-    }
-  }
-
-  int
-  asString(IntType time, char *buf, size_t bufLen, size_t *numCharsPtr = nullptr) const override
-  {
-    return (LogUtils::timestamp_to_hex_str(time, buf, bufLen, numCharsPtr) ? BUFFER_TOO_SMALL : ALL_OK);
-  }
-};
-
 // LOG_FIELD_ALIAS_MAP_H

--- a/proxy/logging/LogUtils.cc
+++ b/proxy/logging/LogUtils.cc
@@ -434,42 +434,6 @@ LogUtils::remove_content_type_attributes(char *type_str, int *type_len)
   }
 }
 
-/*-------------------------------------------------------------------------
-  LogUtils::timestamp_to_hex_str
-
-  This routine simply writes the given timestamp integer [time_t] in the equivalent
-  hexadecimal string format "xxxxxxxxxx" into the provided buffer [buf] of
-  size [bufLen].
-
-  It returns 1 if the provided buffer is not big enough to hold the
-  equivalent ip string (and its null terminator), and 0 otherwise.
-  If the buffer is not big enough, only the ip "segments" that completely
-  fit into it are written, and the buffer is null terminated.
-  -------------------------------------------------------------------------*/
-
-int
-LogUtils::timestamp_to_hex_str(unsigned ip, char *buf, size_t bufLen, size_t *numCharsPtr)
-{
-  static const char *table = "0123456789abcdef@";
-  int retVal               = 1;
-  int shift                = 28;
-  if (buf && bufLen > 0) {
-    if (bufLen > 8) {
-      bufLen = 8;
-    }
-    for (retVal = 0; retVal < (int)bufLen;) {
-      buf[retVal++] = (char)table[((ip >> shift) & 0xf)];
-      shift -= 4;
-    }
-
-    if (numCharsPtr) {
-      *numCharsPtr = (size_t)retVal;
-    }
-    retVal = (retVal == 8) ? 0 : 1;
-  }
-  return retVal;
-}
-
 /*
 int
 LogUtils::ip_to_str (unsigned ip, char *str, unsigned len)


### PR DESCRIPTION
Remove hex conversion in logging that is not used. I originally tried to improve the code using `TextView` and `BufferWriter`, but when I tried to track down where it was used to check for API consistency and testing, I couldn't find any reference. Therefore the simplest approach seems to be to KIWF.

Related to #4637.