### PR TITLE
Issue #4637 - Clean up / unify hex conversions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Makefile.in
 
 .project
 .cproject
+.idea
 
 .diags.log.meta
 

--- a/include/tscore/BufferWriter.h
+++ b/include/tscore/BufferWriter.h
@@ -906,6 +906,51 @@ FixedBufferWriter::printv(BWFormat const &fmt, std::tuple<Args...> const &args) 
   return static_cast<self_type &>(this->super_type::printv(fmt, args));
 }
 
+// Basic format wrappers - these are here because they're used internally.
+namespace bwf
+{
+  namespace detail
+  {
+    /** Write out raw memory in hexadecimal wrapper.
+     *
+     * This wrapper indicates the contained view should be dumped as raw memory in hexadecimal format.
+     * This is intended primarily for internal use by other formatting logic.
+     *
+     * @see Hex_Dump
+     */
+    struct MemDump {
+      std::string_view _view;
+
+      /** Dump @a n bytes starting at @a mem as hex.
+       *
+       * @param mem First byte of memory to dump.
+       * @param n Number of bytes.
+       */
+      MemDump(void const *mem, size_t n) : _view(static_cast<char const *>(mem), n) {}
+    };
+  } // namespace detail
+
+  /** Treat @a t as raw memory and dump the memory as hexadecimal.
+   *
+   * @tparam T Type of argument.
+   * @param t Object to dump.
+   * @return @a A wrapper to do a hex dump.
+   *
+   * This is the standard way to do a hexadecimal memory dump of an object.
+   *
+   * @internal This function exists so that other types can overload it for special processing,
+   * which would not be possible with just @c HexDump.
+   */
+  template <typename T>
+  detail::MemDump
+  Hex_Dump(T const &t)
+  {
+    return {&t, sizeof(T)};
+  }
+} // namespace bwf
+
+BufferWriter &bwformat(BufferWriter &w, BWFSpec const &spec, bwf::detail::MemDump const &hex);
+
 } // end namespace ts
 
 namespace std

--- a/include/tscore/bwf_std_format.h
+++ b/include/tscore/bwf_std_format.h
@@ -121,7 +121,8 @@ namespace bwf
       }
     }
   };
-} // namespace bwf
+
+}; // namespace bwf
 
 BufferWriter &bwformat(BufferWriter &w, BWFSpec const &spec, bwf::Errno const &e);
 BufferWriter &bwformat(BufferWriter &w, BWFSpec const &spec, bwf::Date const &date);

--- a/include/tscore/ink_inet.h
+++ b/include/tscore/ink_inet.h
@@ -1558,4 +1558,14 @@ bwformat(BufferWriter &w, BWFSpec const &spec, IpEndpoint const &addr)
 {
   return bwformat(w, spec, &addr.sa);
 }
+
+namespace bwf
+{
+  namespace detail
+  {
+    struct MemDump;
+  } // namespace detail
+
+  detail::MemDump Hex_Dump(IpEndpoint const &addr);
+} // namespace bwf
 } // namespace ts

--- a/src/tscore/ink_inet.cc
+++ b/src/tscore/ink_inet.cc
@@ -937,4 +937,13 @@ bwformat(BufferWriter &w, BWFSpec const &spec, sockaddr const *addr)
   return w;
 }
 
+namespace bwf
+{
+  detail::MemDump
+  Hex_Dump(IpEndpoint const &addr)
+  {
+    return detail::MemDump(ats_ip_addr8_cast(&addr), ats_ip_addr_size(&addr));
+  }
+} // namespace bwf
+
 } // namespace ts

--- a/src/tscore/unit_tests/test_ink_inet.cc
+++ b/src/tscore/unit_tests/test_ink_inet.cc
@@ -219,6 +219,10 @@ TEST_CASE("inet formatting", "[libts][ink_inet][bwformat]")
   REQUIRE(w.view() == "172. 17. 99.231");
   w.reset().print("{::=a}", ep);
   REQUIRE(w.view() == "172.017.099.231");
+  w.reset().print("{}", ts::bwf::Hex_Dump(ep));
+  REQUIRE(w.view() == "ac1163e7");
+  w.reset().print("{:#X}", ts::bwf::Hex_Dump(ep));
+  REQUIRE(w.view() == "0XAC1163E7");
 
   // Documentation examples
   REQUIRE(0 == ats_ip_pton(addr_7, &ep.sa));
@@ -247,4 +251,8 @@ TEST_CASE("inet formatting", "[libts][ink_inet][bwformat]")
 
   w.reset().print("{:p}", reinterpret_cast<sockaddr const *>(0x1337beef));
   REQUIRE(w.view() == "0x1337beef");
+
+  ats_ip_pton(addr_1, &ep.sa);
+  w.reset().print("{}", ts::bwf::Hex_Dump(ep));
+  REQUIRE(w.view() == "ffee00000000000024c333493cee0143");
 }


### PR DESCRIPTION
Clean up port hex conversion in SSLAddressLookupKey. This is a better example of how I think the cleanup should be done.

Related to #4637.