### PR TITLE
Docs: Fix proxy.config.net.connections_throttle text.

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -396,7 +396,7 @@ Network
    can handle simultaneously. This is in fact the max number of file
    descriptors that the :program:`traffic_server` process can have open at any
    given time. Roughly 10% of these connections are reserved for origin server
-   connections, i.e. from the default, only ~9,000 client connections can be
+   connections, i.e. from the default, only ~27,000 client connections can be
    handled. This should be tuned according to your memory size, and expected
    work load.  If this is set to 0, the throttling logic is disabled.
 


### PR DESCRIPTION
This fixes an inaccuracy introduced [here](https://github.com/apache/trafficserver/commit/879bedcebeca8a354d2ee910183c8ed241c10f79#diff-ce5e07442e57cfad25eb0335e63931f9R259) where the value was bumped up but the explanatory text was not changed.