### PR TITLE
Make documentation build successfull with Python 3

### DIFF
--- a/doc/checkvers.py
+++ b/doc/checkvers.py
@@ -29,30 +29,30 @@ if __name__ == '__main__':
     # Check whether we have a recent version of sphinx. EPEL and CentOS are completely crazy and I don't understand their
     # packaging at all. The test below works on Ubuntu and places where sphinx is installed sanely AFAICT.
     if options.checkvers:
-        print 'checking for sphinx version >= 1.2... ',
+        print('checking for sphinx version >= 1.2... '),
         # Need at least 1.2 because of some command line options stuff HRP added.
         # Also 1.2 guarantees sphinx.version_info is available.
         try:
             import sphinx
 
             if 'version_info' in dir(sphinx):
-                print 'Found Sphinx version {0}'.format(sphinx.version_info)
+                print('Found Sphinx version {0}'.format(sphinx.version_info))
             else:
                 version = sphinx.__version__
-                print 'Found Sphinx version (old) {0}'.format(sphinx.__version__)
+                print('Found Sphinx version (old) {0}'.format(sphinx.__version__))
                 sphinx.version_info = version.split('.')
 
             if sphinx.version_info < (1, 2):
                 sys.exit(1)
 
         except Exception as e:
-            print e
+            print(e)
             sys.exit(1)
 
-        print 'checking for sphinx.writers.manpage... ',
+        print('checking for sphinx.writers.manpage... '),
         try:
             from sphinx.writers import manpage
-            print 'yes'
+            print('yes')
         except Exception as e:
-            print e
+            print(e)
             sys.exit(1)

--- a/doc/ext/traffic-server.py
+++ b/doc/ext/traffic-server.py
@@ -440,6 +440,14 @@ def setup(app):
     app.add_crossref_type('configfile', 'file',
                           objname='Configuration file',
                           indextemplate='pair: %s; Configuration files')
+    
+    # Very ugly, but as of Sphinx 1.8 it must be done. There is an `override` option to add_crossref_type
+    # but it only applies to the directive, not the role (`file` in this case). If this isn't cleared
+    # explicitly the build will fail out due to the conflict. In this case, since the role action is the
+    # same in all cases, the output is correct. This does assume the config file names and log files
+    # names are disjoint sets.
+    del app.registry.domain_roles['std']['file']
+
     app.add_crossref_type('logfile', 'file',
                           objname='Log file',
                           indextemplate='pair: %s; Log files')

--- a/doc/ext/traffic-server.py
+++ b/doc/ext/traffic-server.py
@@ -47,7 +47,6 @@ except NameError:
     def is_string_type(s):
         return isinstance(s, str)
 
-
 class TSConfVar(std.Target):
     """
     Description of a traffic server configuration variable.

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -66,4 +66,4 @@ if __name__ == '__main__':
     # Print the names of the man pages for the requested manual section.
     for page in man_pages:
         if options.section == 0 or options.section == int(page[4][0]):
-            print page[1] + '.' + page[4]
+            print(page[1] + '.' + page[4])

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -20,7 +20,7 @@ import os
 man_pages = [
     # Add all files in the reference/api directory to the list of manual
     # pages
-    ('developer-guide/api/functions/' + filename[:-4], filename.split('.', 1)[0], '', None, '3ts') for filename in os.listdir('developer-guide/api/functions/') if filename != 'index.en.rst' and filename.endswith('.rst')] + [
+    ('developer-guide/api/functions/' + filename[:-4], filename.split('.', 1)[0], filename.split('.', 1)[0] + ' API function', None, '3ts') for filename in os.listdir('developer-guide/api/functions/') if filename != 'index.en.rst' and filename.endswith('.rst')] + [
 
     ('appendices/command-line/traffic_cop.en', 'traffic_cop', u'Traffic Server watchdog', None, '8'),
     ('appendices/command-line/traffic_ctl.en', 'traffic_ctl', u'Traffic Server command line tool', None, '8'),


### PR DESCRIPTION
Improve man pages, adding generic 'whatis' entry. Avoids warnings with Debian packages quality check tool (lintian)

Remove Python 3 compatibility block (Already implemented). Fix remaining print without parenthesis

(cherry picked from commit 7bb532283e5b7d5a970bdbcf45eed963bcfc1913)

 Conflicts:
	doc/checkvers.py

Note: I ended up only taking small portions of the changes to checkvers.py, because they had
deviated from this branch quite a lot.