### PR TITLE
Add TS_EVENT_AIO_DONE, deprecate TS_AIO_EVENT_DONE (8.0.x).

### DIFF
--- a/include/ts/apidefs.h.in
+++ b/include/ts/apidefs.h.in
@@ -426,7 +426,8 @@ typedef enum {
   TS_EVENT_SSL_SESSION_GET                      = 2000,
   TS_EVENT_SSL_SESSION_NEW                      = 2001,
   TS_EVENT_SSL_SESSION_REMOVE                   = 2002,
-  TS_AIO_EVENT_DONE                             = 3900,
+  TS_EVENT_AIO_DONE                             = 3900,
+  TS_AIO_EVENT_DONE                             = TS_EVENT_AIO_DONE,  // Deprecated, do not use in new code.
   TS_EVENT_HTTP_CONTINUE                        = 60000,
   TS_EVENT_HTTP_ERROR                           = 60001,
   TS_EVENT_HTTP_READ_REQUEST_HDR                = 60002,


### PR DESCRIPTION
(cherry picked from commit 8b40c578c77d8a31ee4fb57a912f269ad9a23aec)