### PR TITLE
Adds a reasonable rip-grep config file

### DIFF
--- a/.ripgreprc
+++ b/.ripgreprc
@@ -1,0 +1,7 @@
+--color=auto
+--no-heading
+--smart-case
+--line-number
+--multiline
+--trim
+--one-file-system

--- a/ci/rat-regex.txt
+++ b/ci/rat-regex.txt
@@ -28,6 +28,7 @@
 ^\.indent.pro$
 ^\.vimrc$
 ^\.clang-.*$
+^\.ripgreprc$
 ^Doxyfile$
 ^CHANGES$
 ^CHANGELOG.*$


### PR DESCRIPTION
For this to be used though, you have to do e.g.

    export RIPGREP_CONFIG_PATH=.ripgreprc

or make a rip-grep alias that sets it for a specific command only