### PR TITLE
Use hash string when it is provided for hashing

### DIFF
--- a/doc/admin-guide/files/parent.config.en.rst
+++ b/doc/admin-guide/files/parent.config.en.rst
@@ -141,6 +141,14 @@ The following list shows the possible actions and their allowed values.
 
         parent="p1.x.com:8080|2.0, 192.168.0.3:80|3.0, 192.168.0.4:80|5.0"
 
+    If ``round_robin`` is set to ``consistent_hash``, you may add a ``unique hash string``
+    following the ``weight`` for each parent.  The ``hash string`` must start with ``&``
+	  and is used to build both the primary and secondary rings using the ``hash string``
+    for each parent insted of the parents ``hostname`` or ``ip address``. This can be
+    useful so that two different hosts may be used to cache the same requests.  Example::
+
+        parent="p1.x.com:80|1.0&abcdef, p2.x.com:80|1.0&xyzl, p3.x.com:80|1.0&ldffg" round_robin=consistent_hash
+
 .. _parent-config-format-secondary-parent:
 
 ``secondary_parent``

--- a/proxy/ParentSelection.h
+++ b/proxy/ParentSelection.h
@@ -102,6 +102,7 @@ struct pRecord : ATSConsistentHashNode {
   const char *scheme; // for which parent matches (if any)
   int idx;
   float weight;
+  char hash_string[MAXDNAME + 1];
 };
 
 typedef ControlMatcher<ParentRecord, ParentResult> P_table;


### PR DESCRIPTION
Use hash string when it is provided for hashing instead of host name.