### PR TITLE
Add forward_route in ssl_server_name

### DIFF
--- a/doc/admin-guide/files/ssl_server_name.yaml.en.rst
+++ b/doc/admin-guide/files/ssl_server_name.yaml.en.rst
@@ -91,6 +91,16 @@ disable_h2                :code:`true` or :code:`false`.
                           for proxy ports on which HTTP/2 is not enabled.
 
 tunnel_route              Destination as an FQDN and port, separated by a colon ``:``.
+
+
+                          This will forward all traffic to the specified destination without first terminating 
+                          the incoming TLS connection.
+
+forward_route             Destination as an FQDN and port, separated by a colon ``:``.
+
+                          This is similar to tunnel_route, but it terminates the TLS connection and forwards the
+                          decrypted traffic. |TS| will not interpret the decrypted data, so the contents do not 
+                          need to be HTTP.
 ========================= ==============================================================================
 
 Client verification, via ``verify_client``, correponds to setting

--- a/iocore/net/P_SNIActionPerformer.h
+++ b/iocore/net/P_SNIActionPerformer.h
@@ -38,15 +38,17 @@
 #include <unordered_map>
 
 extern std::unordered_map<int, SSLNextProtocolSet *> snpsMap;
-// enum of all the actions
+
+/*// enum of all the actions
 enum AllActions {
   TS_DISABLE_H2 = 0,
   TS_VERIFY_CLIENT, // this applies to server side vc only
   TS_TUNNEL_ROUTE,  // blind tunnel action
 };
+*/
 
 /** action for setting next hop properties should be listed in the following enum*/
-enum PropertyActions { TS_VERIFY_SERVER = 200, TS_CLIENT_CERT };
+/* enum PropertyActions { TS_VERIFY_SERVER = 200, TS_CLIENT_CERT }; */
 
 class ActionItem
 {
@@ -78,7 +80,7 @@ public:
 class TunnelDestination : public ActionItem
 {
 public:
-  TunnelDestination(const std::string_view &dest) : destination(dest) {}
+  TunnelDestination(const std::string_view &dest, bool decrypt) : destination(dest), tunnel_decrypt(decrypt) {}
   ~TunnelDestination() {}
 
   int
@@ -87,11 +89,12 @@ public:
     // Set the netvc option?
     SSLNetVConnection *ssl_netvc = dynamic_cast<SSLNetVConnection *>(cont);
     if (ssl_netvc) {
-      ssl_netvc->set_tunnel_destination(destination);
+      ssl_netvc->set_tunnel_destination(destination, tunnel_decrypt);
     }
     return SSL_TLSEXT_ERR_OK;
   }
   std::string destination;
+  bool tunnel_decrypt = false;
 };
 
 class VerifyClient : public ActionItem

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -330,8 +330,16 @@ public:
     return tunnel_port;
   }
 
+  /* Returns true if this vc was configured for forward_route
+   */
+  bool
+  decrypt_tunnel()
+  {
+    return has_tunnel_destination() && tunnel_decrypt;
+  }
+
   void
-  set_tunnel_destination(const std::string_view &destination)
+  set_tunnel_destination(const std::string_view &destination, bool decrypt)
   {
     auto pos = destination.find(":");
     if (nullptr != tunnel_host) {
@@ -344,6 +352,7 @@ public:
       tunnel_port = 0;
       tunnel_host = ats_strndup(destination.data(), destination.length());
     }
+    tunnel_decrypt = decrypt;
   }
 
   int populate_protocol(std::string_view *results, int n) const override;
@@ -409,6 +418,7 @@ private:
   int64_t redoWriteSize            = 0;
   char *tunnel_host                = nullptr;
   in_port_t tunnel_port            = 0;
+  bool tunnel_decrypt              = false;
 };
 
 typedef int (SSLNetVConnection::*SSLNetVConnHandler)(int, void *);

--- a/iocore/net/SSLSNIConfig.cc
+++ b/iocore/net/SSLSNIConfig.cc
@@ -73,7 +73,7 @@ SNIConfigParams::loadSNIConfig()
       ai->actions.push_back(std::make_unique<VerifyClient>(item.verify_client_level));
     }
     if (item.tunnel_destination.length() > 0) {
-      ai->actions.push_back(std::make_unique<TunnelDestination>(item.tunnel_destination));
+      ai->actions.push_back(std::make_unique<TunnelDestination>(item.tunnel_destination, item.tunnel_decrypt));
     }
 
     ai->actions.push_back(std::make_unique<SNI_IpAllow>(item.ip_allow, item.fqdn));

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -478,7 +478,7 @@ ssl_servername_only_callback(SSL *ssl, int * /* ad */, void * /*arg*/)
   if (ret != SSL_TLSEXT_ERR_OK) {
     return SSL_TLSEXT_ERR_ALERT_FATAL;
   }
-  if (netvc->has_tunnel_destination()) {
+  if (netvc->has_tunnel_destination() && !netvc->decrypt_tunnel()) {
     netvc->attributes = HttpProxyPort::TRANSPORT_BLIND_TUNNEL;
   }
 

--- a/iocore/net/YamlSNIConfig.cc
+++ b/iocore/net/YamlSNIConfig.cc
@@ -63,6 +63,7 @@ std::set<std::string> valid_sni_config_keys = {TS_fqdn,
                                                TS_disable_h2,
                                                TS_verify_client,
                                                TS_tunnel_route,
+                                               TS_forward_route,
                                                TS_verify_origin_server,
                                                TS_verify_server_policy,
                                                TS_verify_server_properties,
@@ -104,7 +105,12 @@ template <> struct convert<YamlSNIConfig::Item> {
 
     if (node[TS_tunnel_route]) {
       item.tunnel_destination = node[TS_tunnel_route].as<std::string>();
+      item.tunnel_decrypt     = false;
+    } else if (node[TS_forward_route]) {
+      item.tunnel_destination = node[TS_forward_route].as<std::string>();
+      item.tunnel_decrypt     = true;
     }
+
     // remove before 9.0.0 release
     // backwards compatibiity
     if (node[TS_verify_origin_server]) {

--- a/iocore/net/YamlSNIConfig.h
+++ b/iocore/net/YamlSNIConfig.h
@@ -31,6 +31,7 @@ TSDECL(fqdn);
 TSDECL(disable_h2);
 TSDECL(verify_client);
 TSDECL(tunnel_route);
+TSDECL(forward_route);
 TSDECL(verify_server_policy);
 TSDECL(verify_server_properties);
 TSDECL(verify_origin_server);
@@ -45,6 +46,7 @@ struct YamlSNIConfig {
     disable_h2 = start,
     verify_client,
     tunnel_route,             // blind tunnel action
+    forward_route,            // decrypt data and then blind tunnel action
     verify_server_policy,     // this applies to server side vc only
     verify_server_properties, // this applies to server side vc only
     client_cert
@@ -60,6 +62,7 @@ struct YamlSNIConfig {
     bool disable_h2             = false;
     uint8_t verify_client_level = 255;
     std::string tunnel_destination;
+    bool tunnel_decrypt               = false;
     Policy verify_server_policy       = Policy::DISABLED;
     Property verify_server_properties = Property::NONE;
     std::string client_cert;

--- a/tests/gold_tests/tls/test-nc-s_client.sh
+++ b/tests/gold_tests/tls/test-nc-s_client.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+nc -l -p $1  -c 'echo -e "This is a reply"'  -o test.out &
+echo "This is a test" | openssl s_client -servername bar.com -connect localhost:$2 -ign_eof 

--- a/tests/gold_tests/tls/tls_forward_nonhttp.test.py
+++ b/tests/gold_tests/tls/tls_forward_nonhttp.test.py
@@ -1,0 +1,77 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+Test.Summary = '''
+Forwarding a non-HTTP protocol out of TLS
+'''
+
+# need Curl
+Test.SkipUnless(
+    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
+)
+
+# Define default ATS
+ts = Test.MakeATSProcess("ts", select_ports=False)
+
+# add ssl materials like key, certificates for the server
+ts.addSSLfile("ssl/server.pem")
+ts.addSSLfile("ssl/server.key")
+
+ts.Variables.ssl_port = 4443
+
+# Need no remap rules.  Everything should be proccessed by ssl_server_name
+
+# Make sure the TS server certs are different from the origin certs
+ts.Disk.ssl_multicert_config.AddLine(
+    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
+)
+
+# Case 1, global config policy=permissive properties=signature
+#         override for foo.com policy=enforced properties=all
+ts.Disk.records_config.update({
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'http|ssl',
+    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    # enable ssl port
+    'proxy.config.http.server_ports': '{0} {1}:proto=http2;http:ssl'.format(ts.Variables.port, ts.Variables.ssl_port),
+    'proxy.config.http.connect_ports': '{0} 4444'.format(ts.Variables.ssl_port),
+    'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
+    'proxy.config.url_remap.pristine_host_hdr': 1
+})
+
+# foo.com should not terminate.  Just tunnel to server_foo
+# bar.com should terminate.  Forward its tcp stream to server_bar
+ts.Disk.ssl_server_name_yaml.AddLines([
+  "- fqdn: bar.com",
+  "  forward_route: localhost:4444"
+  ])
+
+tr = Test.AddTestRun("forward-non-http")
+tr.Setup.Copy("test-nc-s_client.sh")
+tr.Processes.Default.Command = "sh test-nc-s_client.sh 4444 4443"
+tr.ReturnCode = 0
+tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.ssl_port))
+tr.StillRunningAfter = ts
+tr.Processes.Default.TimeOut = 5
+tr.TimeOut = 5
+testout_path = os.path.join(Test.RunDirectory, "test.out")
+tr.Disk.File(testout_path, id = "testout")
+tr.Processes.Default.Streams.All += Testers.IncludesExpression("This is a reply", "s_client should get response")
+

--- a/tests/gold_tests/tls/tls_tunnel_forward.test.py
+++ b/tests/gold_tests/tls/tls_tunnel_forward.test.py
@@ -1,0 +1,132 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+Test.Summary = '''
+Test tunneling and forwarding based on SNI
+'''
+
+# need Curl
+Test.SkipUnless(
+    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
+)
+
+# Define default ATS
+ts = Test.MakeATSProcess("ts", select_ports=False)
+server_foo = Test.MakeOriginServer("server_foo", ssl=True)
+server_bar = Test.MakeOriginServer("server_bar", ssl=False)
+server_random = Test.MakeOriginServer("server_random", ssl=False)
+
+request_foo_header = {"headers": "GET / HTTP/1.1\r\nHost: foo.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+request_bar_header = {"headers": "GET / HTTP/1.1\r\nHost: bar.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+request_random_header = {"headers": "GET / HTTP/1.1\r\nHost: random.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+response_foo_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": "ok foo"}
+response_bar_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": "ok bar"}
+response_random_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": "ok random"}
+server_foo.addResponse("sessionlog_foo.json", request_foo_header, response_foo_header)
+server_bar.addResponse("sessionlog_bar.json", request_bar_header, response_bar_header)
+server_random.addResponse("sessionlog_random.json", request_random_header, response_random_header)
+
+# add ssl materials like key, certificates for the server
+ts.addSSLfile("ssl/signed-foo.pem")
+ts.addSSLfile("ssl/signed-foo.key")
+ts.addSSLfile("ssl/signed-bar.pem")
+ts.addSSLfile("ssl/signed-bar.key")
+ts.addSSLfile("ssl/server.pem")
+ts.addSSLfile("ssl/server.key")
+ts.addSSLfile("ssl/signer.pem")
+ts.addSSLfile("ssl/signer.key")
+
+ts.Variables.ssl_port = 4443
+
+# Need no remap rules.  Everything should be proccessed by ssl_server_name
+
+# Make sure the TS server certs are different from the origin certs
+ts.Disk.ssl_multicert_config.AddLine(
+    'dest_ip=* ssl_cert_name=signed-foo.pem ssl_key_name=signed-foo.key'
+)
+
+# Case 1, global config policy=permissive properties=signature
+#         override for foo.com policy=enforced properties=all
+ts.Disk.records_config.update({
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'http|ssl',
+    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    # enable ssl port
+    'proxy.config.http.server_ports': '{0} {1}:proto=http2;http:ssl'.format(ts.Variables.port, ts.Variables.ssl_port),
+    'proxy.config.http.connect_ports': '{0} {1} {2} {3}'.format(ts.Variables.ssl_port,server_foo.Variables.Port,server_bar.Variables.Port,server_random.Variables.Port),
+    'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
+    'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
+    'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
+    'proxy.config.url_remap.pristine_host_hdr': 1
+})
+
+# foo.com should not terminate.  Just tunnel to server_foo
+# bar.com should terminate.  Forward its tcp stream to server_bar
+ts.Disk.ssl_server_name_yaml.AddLines([
+  "- fqdn: 'foo.com'",
+  "  tunnel_route: 'localhost:{0}'".format(server_foo.Variables.Port),
+  "- fqdn: 'bar.com'",
+  "  forward_route: 'localhost:{0}'".format(server_bar.Variables.Port),
+  "- fqdn: ''",  #default case
+  "  forward_route: 'localhost:{0}'".format(server_random.Variables.Port),
+  ])
+
+tr = Test.AddTestRun("Tunnel-test")
+tr.Processes.Default.Command = "curl -v  --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(ts.Variables.ssl_port)
+tr.ReturnCode = 0
+tr.Processes.Default.StartBefore(server_foo)
+tr.Processes.Default.StartBefore(server_bar)
+tr.Processes.Default.StartBefore(server_random)
+tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.ssl_port))
+tr.StillRunningAfter = ts
+tr.Processes.Default.TimeOut = 5
+tr.TimeOut = 5
+tr.Processes.Default.Streams.All += Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
+tr.Processes.Default.Streams.All += Testers.ExcludesExpression("Not Found on Accelerato", "Should not try to remap on Traffic Server")
+tr.Processes.Default.Streams.All += Testers.ExcludesExpression("CN=foo.com", "Should not TLS terminate on Traffic Server")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/1.1 200 OK", "Should get a successful response")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("ok foo", "Body is expected")
+
+tr2 = Test.AddTestRun("Forward-test")
+tr2.Processes.Default.Command = "curl -v --http1.1  -H 'host:bar.com' --resolve 'bar.com:{0}:127.0.0.1' -k https://bar.com:{0}".format(ts.Variables.ssl_port)
+tr2.ReturnCode = 0
+tr2.StillRunningAfter = server_bar
+tr2.Processes.Default.TimeOut = 5
+tr2.StillRunningAfter = ts
+tr2.TimeOut = 5
+tr2.Processes.Default.Streams.All += Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
+tr2.Processes.Default.Streams.All += Testers.ExcludesExpression("Not Found on Accelerato", "Should not try to remap on Traffic Server")
+tr2.Processes.Default.Streams.All += Testers.ContainsExpression("CN=foo.com", "Should TLS terminate on Traffic Server")
+tr2.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/1.1 200 OK", "Should get a successful response")
+tr2.Processes.Default.Streams.All += Testers.ContainsExpression("ok bar", "Body is expected")
+
+tr3 = Test.AddTestRun("no-sni-forward-test")
+tr3.Processes.Default.Command = "curl --http1.1 -v -k -H 'host:random.com' https://127.0.0.1:{0}".format(ts.Variables.ssl_port)
+tr3.ReturnCode = 0
+tr3.StillRunningAfter = server_random
+tr3.Processes.Default.TimeOut = 5
+tr3.StillRunningAfter = ts
+tr3.TimeOut = 5
+tr3.Processes.Default.Streams.All += Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
+tr3.Processes.Default.Streams.All += Testers.ExcludesExpression("Not Found on Accelerato", "Should not try to remap on Traffic Server")
+tr3.Processes.Default.Streams.All += Testers.ContainsExpression("CN=foo.com", "Should TLS terminate on Traffic Server")
+tr3.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/1.1 200 OK", "Should get a successful response")
+tr3.Processes.Default.Streams.All += Testers.ContainsExpression("ok random", "Body is expected")
+


### PR DESCRIPTION
This PR also includes the commit in PR #4666 so that PR must be committed first.

Adding a new action in ssl_server_name which is similar to tunnel_route, but forward_route terminates the client's TLS connection and forwards the decrypted data to the origin without interpreting the data.  This allows Traffic Server to act as a TLS terminator for non-HTTP protocols.