### PR TITLE
Remove the ssl wire trace feature.

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3450,25 +3450,6 @@ SSL Termination
 
    See :ref:`admin-performance-timeouts` for more discussion on |TS| timeouts.
 
-.. ts:cv:: CONFIG proxy.config.ssl.wire_trace_enabled INT 0
-
-   When enabled this turns on wire tracing of SSL connections that meet
-   the conditions specified by wire_trace_percentage, wire_trace_addr
-   and wire_trace_server_name.
-
-.. ts:cv:: CONFIG proxy.config.ssl.wire_trace_percentage INT 0
-
-   This specifies the percentage of traffic meeting the other wire_trace
-   conditions to be traced.
-
-.. ts:cv:: CONFIG proxy.config.ssl.wire_trace_addr STRING NULL
-
-   This specifies the client IP for which wire_traces should be printed.
-
-.. ts:cv:: CONFIG proxy.config.ssl.wire_trace_server_name STRING NULL
-
-   This specifies the server name for which wire_traces should be printed.
-
 Client-Related Configuration
 ----------------------------
 

--- a/iocore/net/P_SSLConfig.h
+++ b/iocore/net/P_SSLConfig.h
@@ -107,13 +107,6 @@ struct SSLConfigParams : public ConfigInfo {
   static size_t session_cache_max_bucket_size;
   static bool session_cache_skip_on_lock_contention;
 
-  // TS-3435 Wiretracing for SSL Connections
-  static int ssl_wire_trace_enabled;
-  static char *ssl_wire_trace_addr;
-  static IpAddr *ssl_wire_trace_ip;
-  static int ssl_wire_trace_percentage;
-  static char *ssl_wire_trace_server_name;
-
   static init_ssl_ctx_func init_ssl_ctx_cb;
   static load_ssl_file_func load_ssl_file_cb;
 

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -286,19 +286,6 @@ public:
     }
     return retval;
   }
-  bool
-  getSSLTrace() const
-  {
-    return sslTrace || super::origin_trace;
-  }
-
-  void
-  setSSLTrace(bool state)
-  {
-    sslTrace = state;
-  }
-
-  bool computeSSLTrace();
 
   const char *
   getSSLProtocol(void) const

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -58,14 +58,8 @@ size_t SSLConfigParams::session_cache_max_bucket_size       = 100;
 init_ssl_ctx_func SSLConfigParams::init_ssl_ctx_cb          = nullptr;
 load_ssl_file_func SSLConfigParams::load_ssl_file_cb        = nullptr;
 
-// TS-3534 Wiretracing for SSL Connections
-int SSLConfigParams::ssl_wire_trace_enabled       = 0;
-char *SSLConfigParams::ssl_wire_trace_addr        = nullptr;
-IpAddr *SSLConfigParams::ssl_wire_trace_ip        = nullptr;
-int SSLConfigParams::ssl_wire_trace_percentage    = 0;
-char *SSLConfigParams::ssl_wire_trace_server_name = nullptr;
-int SSLConfigParams::async_handshake_enabled      = 0;
-char *SSLConfigParams::engine_conf_file           = nullptr;
+int SSLConfigParams::async_handshake_enabled = 0;
+char *SSLConfigParams::engine_conf_file      = nullptr;
 
 static std::unique_ptr<ConfigUpdateHandler<SSLCertificateConfig>> sslCertUpdate;
 static std::unique_ptr<ConfigUpdateHandler<SSLConfig>> sslConfigUpdate;
@@ -131,7 +125,6 @@ SSLConfigParams::cleanup()
   cipherSuite             = (char *)ats_free_null(cipherSuite);
   client_cipherSuite      = (char *)ats_free_null(client_cipherSuite);
   dhparamsFile            = (char *)ats_free_null(dhparamsFile);
-  ssl_wire_trace_ip       = (IpAddr *)ats_free_null(ssl_wire_trace_ip);
 
   server_tls13_cipher_suites = (char *)ats_free_null(server_tls13_cipher_suites);
   client_tls13_cipher_suites = (char *)ats_free_null(client_tls13_cipher_suites);
@@ -438,26 +431,6 @@ SSLConfigParams::initialize()
 
   REC_ReadConfigInt32(ssl_allow_client_renegotiation, "proxy.config.ssl.allow_client_renegotiation");
 
-  // SSL Wire Trace configurations
-  REC_EstablishStaticConfigInt32(ssl_wire_trace_enabled, "proxy.config.ssl.wire_trace_enabled");
-  if (ssl_wire_trace_enabled) {
-    // wire trace specific source ip
-    REC_EstablishStaticConfigStringAlloc(ssl_wire_trace_addr, "proxy.config.ssl.wire_trace_addr");
-    if (ssl_wire_trace_addr) {
-      ssl_wire_trace_ip = new IpAddr();
-      ssl_wire_trace_ip->load(ssl_wire_trace_addr);
-    } else {
-      ssl_wire_trace_ip = nullptr;
-    }
-    // wire trace percentage of requests
-    REC_EstablishStaticConfigInt32(ssl_wire_trace_percentage, "proxy.config.ssl.wire_trace_percentage");
-    REC_EstablishStaticConfigStringAlloc(ssl_wire_trace_server_name, "proxy.config.ssl.wire_trace_server_name");
-  } else {
-    ssl_wire_trace_addr        = nullptr;
-    ssl_wire_trace_ip          = nullptr;
-    ssl_wire_trace_percentage  = 0;
-    ssl_wire_trace_server_name = nullptr;
-  }
   // Enable client regardless of config file settings as remap file
   // can cause HTTP layer to connect using SSL. But only if SSL
   // initialization hasn't failed already.

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -330,11 +330,6 @@ set_context_cert(SSL *ssl)
   int retval               = 1;
 
   Debug("ssl", "set_context_cert ssl=%p server=%s handshake_complete=%d", ssl, servername, netvc->getSSLHandShakeComplete());
-  if (SSLConfigParams::ssl_wire_trace_enabled) {
-    bool trace = netvc->computeSSLTrace();
-    Debug("ssl", "sslnetvc. setting trace to=%s", trace ? "true" : "false");
-    netvc->setSSLTrace(trace);
-  }
 
   // catch the client renegotiation early on
   if (SSLConfigParams::ssl_allow_client_renegotiation == false && netvc->getSSLHandShakeComplete()) {

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1178,14 +1178,6 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.ssl.handshake_timeout_in", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-65535]", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.ssl.wire_trace_enabled", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-2]", RECA_NULL}
-  ,
-  {RECT_CONFIG, "proxy.config.ssl.wire_trace_addr", RECD_STRING, nullptr , RECU_DYNAMIC, RR_NULL, RECC_IP, R"([0-255]\.[0-255]\.[0-255]\.[0-255])", RECA_NULL}
-  ,
-  {RECT_CONFIG, "proxy.config.ssl.wire_trace_percentage", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-100]", RECA_NULL}
-  ,
-  {RECT_CONFIG, "proxy.config.ssl.wire_trace_server_name", RECD_STRING, nullptr , RECU_DYNAMIC, RR_NULL, RECC_STR, ".*", RECA_NULL}
-  ,
   {RECT_CONFIG, "proxy.config.ssl.cert.load_elevated", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_READ_ONLY}
   ,
   {RECT_CONFIG, "proxy.config.ssl.server.groups_list", RECD_STRING, nullptr, RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -5860,30 +5860,9 @@ HttpSM::attach_server_session(HttpServerSession *s)
   // Get server and client connections
   UnixNetVConnection *server_vc = dynamic_cast<UnixNetVConnection *>(server_session->get_netvc());
   UnixNetVConnection *client_vc = (UnixNetVConnection *)(ua_txn->get_netvc());
-  SSLNetVConnection *ssl_vc     = dynamic_cast<SSLNetVConnection *>(client_vc);
 
   // Verifying that the user agent and server sessions/transactions are operating on the same thread.
   ink_release_assert(!server_vc || !client_vc || server_vc->thread == client_vc->thread);
-  bool associated_connection = false;
-  if (server_vc) { // if server_vc isn't a PluginVC
-    if (ssl_vc) {  // if incoming connection is SSL
-      bool client_trace = ssl_vc->getSSLTrace();
-      if (client_trace) {
-        // get remote address and port to mark corresponding traces
-        const sockaddr *remote_addr = ssl_vc->get_remote_addr();
-        uint16_t remote_port        = ssl_vc->get_remote_port();
-        server_vc->setOriginTrace(true);
-        server_vc->setOriginTraceAddr(remote_addr);
-        server_vc->setOriginTracePort(remote_port);
-        associated_connection = true;
-      }
-    }
-  }
-  if (!associated_connection && server_vc) {
-    server_vc->setOriginTrace(false);
-    server_vc->setOriginTraceAddr(nullptr);
-    server_vc->setOriginTracePort(0);
-  }
 
   // set flag for server session is SSL
   SSLNetVConnection *server_ssl_vc = dynamic_cast<SSLNetVConnection *>(server_vc);


### PR DESCRIPTION
I don't think anyone uses this feature.  We added a while back and used it for a while, but for the past couple years it has been lingering.   Since it is fairly interwoven with the TLS code, I'm concerned that the wire trace will continue to work if no one is using it.

Suggested its removal in issue #4652.