### PR TITLE
Prevent linking everything against brotli

### DIFF
--- a/build/brotli.m4
+++ b/build/brotli.m4
@@ -77,7 +77,7 @@ fi
 ],
 [
 AC_CHECK_HEADER([brotli/encode.h], [], [has_brotli=0])
-AC_CHECK_LIB([brotlienc], BrotliEncoderCreateInstance, [], [has_brotli=0])
+AC_CHECK_LIB([brotlienc], BrotliEncoderCreateInstance, [:], [has_brotli=0])
 
 if test "x$has_brotli" == "x0"; then
     PKG_CHECK_EXISTS([LIBBROTLIENC],


### PR DESCRIPTION
Defines an empty function for "action-if-found" to prevent default
autoconf behavior (prepending -llibrary to LIBS and defining ‘HAVE_LIBlibrary’)