### PR TITLE
Change serverName member back to const char * to avoid crash.

### DIFF
--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -361,7 +361,11 @@ public:
   ink_hrtime sslHandshakeEndTime   = 0;
   ink_hrtime sslLastWriteTime      = 0;
   int64_t sslTotalBytesSent        = 0;
-  std::string serverName;
+  // The serverName is either a pointer to the name fetched from the
+  // SSL object or the empty string.  Therefore, we do not allocate
+  // extra memory for this value.  If plugins in the future can set the
+  // serverName value, this strategy will have to change.
+  const char *serverName = nullptr;
 
   /// Set by asynchronous hooks to request a specific operation.
   SslVConnOp hookOpRequested = SSL_HOOK_OP_DEFAULT;

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -472,9 +472,11 @@ ssl_servername_only_callback(SSL *ssl, int * /* ad */, void * /*arg*/)
   SSLNetVConnection *netvc = SSLNetVCAccess(ssl);
   netvc->callHooks(TS_EVENT_SSL_SERVERNAME);
 
-  const char *name  = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
-  netvc->serverName = std::string{name ? name : ""};
-  int ret           = PerformAction(netvc, netvc->serverName.c_str());
+  netvc->serverName = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
+  if (nullptr == netvc->serverName) {
+    netvc->serverName = "";
+  }
+  int ret = PerformAction(netvc, netvc->serverName);
   if (ret != SSL_TLSEXT_ERR_OK) {
     return SSL_TLSEXT_ERR_ALERT_FATAL;
   }

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -583,7 +583,7 @@ HttpSM::setup_blind_tunnel_port()
           t_state.hdr_info.client_request.url_get()->port_set(t_state.state_machine->ua_txn->get_netvc()->get_local_port());
         }
       } else {
-        t_state.hdr_info.client_request.url_get()->host_set(ssl_vc->serverName.c_str(), ssl_vc->serverName.length());
+        t_state.hdr_info.client_request.url_get()->host_set(ssl_vc->serverName, strlen(ssl_vc->serverName));
         t_state.hdr_info.client_request.url_get()->port_set(t_state.state_machine->ua_txn->get_netvc()->get_local_port());
       }
     }
@@ -1394,7 +1394,7 @@ plugins required to work with sni_routing.
           t_state.hdr_info.client_request.url_get()->port_set(t_state.state_machine->ua_txn->get_netvc()->get_local_port());
         }
       } else if (ssl_vc) {
-        t_state.hdr_info.client_request.url_get()->host_set(ssl_vc->serverName.data(), ssl_vc->serverName.length());
+        t_state.hdr_info.client_request.url_get()->host_set(ssl_vc->serverName, strlen(ssl_vc->serverName));
         t_state.hdr_info.client_request.url_get()->port_set(t_state.state_machine->ua_txn->get_netvc()->get_local_port());
       }
     }


### PR DESCRIPTION
Fixes issue introduced in PR #4666.  Any release that includes that commit also needs this one.

That PR made the serverName member a std::string.  However, the SSLNetVC is a proxy allocated object, and we cannot initialize the std::string object.  One the first assignment it is possible that the initial value of the std::string object is bogus and the free will mess up the heap.

This PR changes the serverName member back to a const char *.  Since the value is either data from the SSL object or the constant empty string, we do not need to do any copies or additional memory allocation for the serverName member variable.