### PR TITLE
Remove unnecessary TSHandleMLocRelease

### DIFF
--- a/src/tscpp/api/Request.cc
+++ b/src/tscpp/api/Request.cc
@@ -204,10 +204,6 @@ Request::~Request()
       TSMLoc null_parent_loc = nullptr;
       TSHandleMLocRelease(state_->hdr_buf_, null_parent_loc, state_->url_loc_);
       TSMBufferDestroy(state_->hdr_buf_);
-    } else {
-      LOG_DEBUG("Destroying request object on hdr_buf=%p, hdr_loc=%p, url_loc=%p", state_->hdr_buf_, state_->hdr_loc_,
-                state_->url_loc_);
-      TSHandleMLocRelease(state_->hdr_buf_, state_->hdr_loc_, state_->url_loc_);
     }
   }
   delete state_;


### PR DESCRIPTION
Have been seeing crashes due to an assertion in `TSHandleMLocRelease`. And since for a OBJ_URL object `TSHandleMLocRelease` is a no-op, removing it solves the problem.