### PR TITLE
Skip to next term if the ExternQue is not empty

### DIFF
--- a/iocore/eventsystem/I_EThread.h
+++ b/iocore/eventsystem/I_EThread.h
@@ -329,8 +329,8 @@ public:
 
   void execute() override;
   void execute_regular();
-  void process_queue(Que(Event, link) * NegativeQueue, int *ev_count, int *nq_count);
-  void process_event(Event *e, int calling_code);
+  void process_queue(Que(Event, link) * NegativeQueue, Que(Event, link) * PostEvent, int *ev_count, int *nq_count);
+  void process_event(Event *e, int calling_code, Que(Event, link) * PostEvent);
   void free_event(Event *e);
   LoopTailHandler *tail_cb = &DEFAULT_TAIL_HANDLER;
 

--- a/iocore/eventsystem/I_ProtectedQueue.h
+++ b/iocore/eventsystem/I_ProtectedQueue.h
@@ -46,6 +46,7 @@ struct ProtectedQueue {
   void dequeue_timed(ink_hrtime cur_time, ink_hrtime timeout, bool sleep);
   void dequeue_external();       // Dequeue any external events.
   void wait(ink_hrtime timeout); // Wait for @a timeout nanoseconds on a condition variable if there are no events.
+  bool empty() const;
 
   InkAtomicList al;
   ink_mutex lock;

--- a/iocore/eventsystem/P_ProtectedQueue.h
+++ b/iocore/eventsystem/P_ProtectedQueue.h
@@ -91,3 +91,9 @@ ProtectedQueue::dequeue_local()
   }
   return e;
 }
+
+TS_INLINE bool
+ProtectedQueue::empty() const
+{
+  return INK_ATOMICLIST_EMPTY(al) && this->localQueue.empty();
+}


### PR DESCRIPTION
# before
```
[Dec  7 20:06:39.335] [ET_NET 0] DIAG: (add_header) event_handler
[Dec  7 20:06:39.396] [ET_NET 0] DIAG: (add_header) imm_handler
```

# after
```
[Dec  7 20:25:19.468] [ET_NET 0] DIAG: (add_header) event_handler
[Dec  7 20:25:19.468] [ET_NET 0] DIAG: (add_header) imm_handler
[Dec  7 20:25:19.468] [ET_NET 0] DIAG: (add_header) event_handler
[Dec  7 20:25:19.468] [ET_NET 0] DIAG: (add_header) imm_handler
[Dec  7 20:25:19.468] [ET_NET 0] DIAG: (add_header) event_handler
[Dec  7 20:25:19.468] [ET_NET 0] DIAG: (add_header) imm_handler
[Dec  7 20:25:19.469] [ET_NET 0] DIAG: (add_header) event_handler
[Dec  7 20:25:19.469] [ET_NET 0] DIAG: (add_header) imm_handler
```

test code 
```
#include <stdio.h>
#include <string.h>

#include "ts/ts.h"
#include "tscore/ink_defs.h"

#define PLUGIN_NAME "add_header"


static int
imm_handler(TSCont contp, TSEvent event, void *edata)
{
   TSDebug(PLUGIN_NAME, "imm_handler");
   TSContDestroy(contp);
    return TS_SUCCESS;
}

static int
event_handler(TSCont contp, TSEvent event, void *edata)
{
   TSDebug(PLUGIN_NAME, "event_handler");
   auto cont = TSContCreate(imm_handler, TSMutexCreate());
   TSContSchedule(cont, 0, TS_THREAD_POOL_DEFAULT);
   return TS_SUCCESS;
}

void
TSPluginInit(int argc, const char *argv[])
{
  /* Create a continuation with a mutex as there is a shared global structure
     containing the headers to add */
  TSPluginRegistrationInfo info;

      info.plugin_name   = (char *)PLUGIN_NAME;
        info.vendor_name   = (char *)"Apache Software Foundation";
          info.support_email = (char *)"dev@trafficserver.apache.org";

            if (TS_SUCCESS != TSPluginRegister(&info)) {
                TSError("[%s] Plugin registration failed", PLUGIN_NAME);
              }

  auto cont = TSContCreate(event_handler, TSMutexCreate());
  TSContScheduleEvery(cont, -1, TS_THREAD_POOL_DEFAULT);
  goto done;

  TSError("[%s] Plugin not initialized", PLUGIN_NAME);

done:
  return;
}

```