### PR TITLE
Remove the APIHooks::invoke() function.

### DIFF
--- a/proxy/InkAPIInternal.h
+++ b/proxy/InkAPIInternal.h
@@ -135,7 +135,6 @@ public:
   APIHook *get() const;
   void clear();
   bool is_empty() const;
-  void invoke(int event, void *data);
 
 private:
   Que(APIHook, m_link) m_hooks;
@@ -145,13 +144,6 @@ inline bool
 APIHooks::is_empty() const
 {
   return nullptr == m_hooks.head;
-}
-
-inline void
-APIHooks::invoke(int event, void *data)
-{
-  for (APIHook *hook = m_hooks.head; nullptr != hook; hook = hook->next())
-    hook->invoke(event, data);
 }
 
 /** Container for API hooks for a specific feature.


### PR DESCRIPTION
In general, it is bad to have functions that are not used, and for which there is no clear potential use.
This one is particularly bad.  It creates the false impression that there is a possibility of simultaneous
execution of continuations that are attached to the same hook (prior to calling the reenable function).