### PR TITLE
QUIC: Fix some case in SendStreamState transition

### DIFF
--- a/iocore/net/quic/QUICStreamState.h
+++ b/iocore/net/quic/QUICStreamState.h
@@ -116,6 +116,7 @@ public:
   QUICReceiveStreamState(QUICTransferProgressProvider *in, QUICTransferProgressProvider *out)
     : QUICUnidirectionalStreamState(in, out)
   {
+    this->_set_state(State::Recv);
   }
 
   void update_with_sending_frame(const QUICFrame &frame) override;


### PR DESCRIPTION
I'm really confusing with the initial and invalid state. How does it work?