### PR TITLE
Revert "Two more places to check whether attempting half_closed connecton logic is feasible"

### DIFF
--- a/proxy/ProxyClientSession.cc
+++ b/proxy/ProxyClientSession.cc
@@ -202,8 +202,7 @@ ProxyClientSession::handle_api_return(int event)
     break;
   }
   default:
-    Error("received invalid session hook %s (%d)", HttpDebugNames::get_api_hook_name(hookid), hookid);
-    ink_release_assert(false);
+    Fatal("received invalid session hook %s (%d)", HttpDebugNames::get_api_hook_name(hookid), hookid);
     break;
   }
 }

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -3241,8 +3241,7 @@ HttpSM::tunnel_handler_ua(int event, HttpTunnelConsumer *c)
     c->write_success          = true;
     t_state.client_info.abort = HttpTransact::DIDNOT_ABORT;
     if (t_state.client_info.keep_alive == HTTP_KEEPALIVE) {
-      if (ua_txn->allow_half_open() &&
-          (t_state.www_auth_content != HttpTransact::CACHE_AUTH_SERVE || ua_txn->get_server_session())) {
+      if (t_state.www_auth_content != HttpTransact::CACHE_AUTH_SERVE || ua_txn->get_server_session()) {
         // successful keep-alive
         close_connection = false;
       }
@@ -3303,8 +3302,8 @@ HttpSM::tunnel_handler_ua(int event, HttpTunnelConsumer *c)
         is_eligible_post_request &= !vc->get_is_internal_request();
       }
     }
-    if ((is_eligible_post_request || t_state.client_info.pipeline_possible == true) && ua_txn->allow_half_open() &&
-        c->producer->vc_type != HT_STATIC && event == VC_EVENT_WRITE_COMPLETE) {
+    if ((is_eligible_post_request || t_state.client_info.pipeline_possible == true) && c->producer->vc_type != HT_STATIC &&
+        event == VC_EVENT_WRITE_COMPLETE) {
       ua_txn->set_half_close_flag(true);
     }
 


### PR DESCRIPTION
This reverts commit 653927f9aab9a3cbe8f09521dd8c8154ccbc1614.

Erroneous fix caused KEEPALIVE to fail on HTTP/1.1 over HTTPS

Found by @zwoop, @mlibbey, @masaori335  and @maskit to have bad interactions with PR #4213.  In a separate PR I will add tests to catch regressions in client-side keep alive.