### PR TITLE
Update cache.config to support minimum and maximum cache times, not just exact time.

### DIFF
--- a/configs/cache.config.default
+++ b/configs/cache.config.default
@@ -41,6 +41,7 @@
 #     pin-in-cache=<time>
 #     revalidate=<time>
 #     ttl-in-cache=<time>             (force caching and expire after <time>)
+#     ttl-mode=<mode>                 (control use of ttl-in-cache value vs. response)
 #
 # Each line may also contain various "tweaks" which adjust caching parameters.
 #   Tweaks are

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -338,7 +338,7 @@ HttpSM::init()
   // Added to skip dns if the document is in cache. DNS will be forced if there is a ip based ACL in
   // cache control or parent.config or if the doc_in_cache_skip_dns is disabled or if http caching is disabled
   // TODO: This probably doesn't honor this as a per-transaction overridable config.
-  t_state.force_dns = (ip_rule_in_CacheControlTable() || t_state.parent_params->parent_table->ipMatch ||
+  t_state.force_dns = (CacheControl_has_ip_rule() || t_state.parent_params->parent_table->ipMatch ||
                        !(t_state.txn_conf->doc_in_cache_skip_dns) || !(t_state.txn_conf->cache_http));
 
   http_parser_init(&http_parser);


### PR DESCRIPTION
This is a feature discussed on the mailing list. The "ttl-in-cache" can be specified with a '<' or '>' to indicate a maximum or a minimum, which bounds the TTL instead of fixing it.

As always, the work here expanded. I ended up addressing #2796 and sort of some other issues with "cache.config". In particular, with this fix, the current documentation is now accurate. It is currently wrong, as noted in #2796, but this PR changes the code to correspond to the documented behavior which was changed in 2016 for ATS 6. Looking back before that, the documentation was silent on how multiple matching rules were handled. I'm not sure this rates as "incompatible" as the new behavior corresponds to the documented behavior.

P.S. As a side effect of fixing the behavior, it is now possible to set a minimum and maximum TTL.