### PR TITLE
Remove unused Http2Stream destructor

### DIFF
--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -59,7 +59,6 @@ public:
     response_header.create(HTTP_TYPE_RESPONSE);
   }
 
-  ~Http2Stream() { this->destroy(); }
   int main_event_handler(int event, void *edata);
 
   void destroy() override;


### PR DESCRIPTION
The destructor of Http2Stream is not used. Because Http2Stream is allocated/freed by THREAD_ALLOC_INIT/THREAD_FREE.