### PR TITLE
Acquire a lock before checking H2ConnectionState::ua_session

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1242,13 +1242,9 @@ Http2ConnectionState::release_stream(Http2Stream *stream)
     --total_client_streams_count;
   }
 
-  if (ua_session) {
-    SCOPED_MUTEX_LOCK(lock, this->ua_session->mutex, this_ethread());
-    if (!ua_session) {
-      // Workaround fix for GitHub #4504. The `ua_session` could be freed while waiting for acquiring the above lock.
-      return;
-    }
-
+  SCOPED_MUTEX_LOCK(lock, this->mutex, this_ethread());
+  if (this->ua_session) {
+    ink_assert(this->mutex == ua_session->mutex);
     // If the number of clients is 0 and ua_session is active, then mark the connection as inactive
     if (total_client_streams_count == 0 && ua_session->is_active()) {
       ua_session->clear_session_active();


### PR DESCRIPTION
Current `ua_session` check here could guarantee nothing effectively.

`this->ua_session->mutex` and `this->mutex` are the same (#3228). Which means the current code is equivalent to:

```c++
  if (this->ua_session) {
    SCOPED_MUTEX_LOCK(lock, this->mutex, this_ethread());
```
This doesn't make sense. It's checking `ua_session` without holding the lock for `this`.

Also, we check `ua_session` again inside this check, but it could be removed as an optimization because both of the `if` statement check the same thing. If so, these checks do not guarantee anything.

The right thing to do here I think is acquiring the lock first, before checking `this->ua_session`. Even If the second check was not removed by optimization, this change makes the check simple and it should still have the same effect as the current code.
