### PR TITLE
Added null value init for VConn args array

### DIFF
--- a/iocore/eventsystem/I_VConnection.h
+++ b/iocore/eventsystem/I_VConnection.h
@@ -406,7 +406,7 @@ public:
   };
 
 protected:
-  std::array<void *, TS_VCONN_MAX_USER_ARG> user_args;
+  std::array<void *, TS_VCONN_MAX_USER_ARG> user_args{nullptr};
 };
 
 struct DummyVConnection : public AnnotatedVConnection {


### PR DESCRIPTION
This solves crashes due to garbage value in vconn user args array.