### PR TITLE
Remove useless SCOPED_MUTEX_LOCK in NetAccept::do_blocking_accept()

### DIFF
--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -322,7 +322,6 @@ NetAccept::do_blocking_accept(EThread *t)
         return 0;
       }
       if (!action_->cancelled) {
-        SCOPED_MUTEX_LOCK(lock, action_->mutex, t);
         action_->continuation->handleEvent(EVENT_ERROR, (void *)(intptr_t)res);
         Warning("accept thread received fatal error: errno = %d", errno);
       }


### PR DESCRIPTION
While tracking #4726, we found a SCOPED_MUTEX_LOCK which doesn't make sense.
This might introduce other crash, but it will give us some clues of root cause.