### PR TITLE
The mutex of NetAccept::action_->continuation is optional when the EVENT_ERROR event is called back.

### DIFF
--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -322,7 +322,7 @@ NetAccept::do_blocking_accept(EThread *t)
         return 0;
       }
       if (!action_->cancelled) {
-        SCOPED_MUTEX_LOCK(lock, action_->mutex, t);
+        SCOPED_MUTEX_LOCK(lock, action_->mutex ? action_->mutex : t->mutex, t);
         action_->continuation->handleEvent(EVENT_ERROR, (void *)(intptr_t)res);
         Warning("accept thread received fatal error: errno = %d", errno);
       }


### PR DESCRIPTION
In general, `NetAccept::action_->continuation` is a type of `ProtocolProbeSessionAccept` object.

The mutex of `ProtocolProbeSessionAccept` is NULL to allow parallel accepts.

Resolve issue #4726.