### PR TITLE
Fix OCSP stapling with dual cert

### DIFF
--- a/iocore/net/OCSPStapling.cc
+++ b/iocore/net/OCSPStapling.cc
@@ -46,25 +46,32 @@ struct certinfo {
   time_t expire_time;
 };
 
-void
-certinfo_free(void * /*parent*/, void *ptr, CRYPTO_EX_DATA * /*ad*/, int /*idx*/, long /*argl*/, void * /*argp*/)
-{
-  certinfo *cinf = (certinfo *)ptr;
+/*
+ * In the case of multiple certificates associated with a SSL_CTX, we must store a map
+ * of cached responses
+ */
+using certinfo_map = std::map<X509 *, certinfo *>;
 
-  if (!cinf) {
+void
+certinfo_map_free(void * /*parent*/, void *ptr, CRYPTO_EX_DATA * /*ad*/, int /*idx*/, long /*argl*/, void * /*argp*/)
+{
+  certinfo_map *map = (certinfo_map *)ptr;
+
+  if (!map) {
     return;
   }
-  if (cinf->uri) {
-    OPENSSL_free(cinf->uri);
+
+  for (certinfo_map::iterator iter = map->begin(); iter != map->end(); ++iter) {
+    if (iter->second->uri) {
+      OPENSSL_free(iter->second->uri);
+    }
+    if (iter->second->certname) {
+      ats_free(iter->second->certname);
+    }
+    ink_mutex_destroy(&iter->second->stapling_mutex);
+    OPENSSL_free(iter->second);
   }
-  if (cinf->certname) {
-    ats_free(cinf->certname);
-  }
-  if (cinf->cid) {
-    OCSP_CERTID_free(cinf->cid);
-  }
-  ink_mutex_destroy(&cinf->stapling_mutex);
-  OPENSSL_free(cinf);
+  free(map);
 }
 
 static int ssl_stapling_index = -1;
@@ -75,7 +82,7 @@ ssl_stapling_ex_init()
   if (ssl_stapling_index != -1) {
     return;
   }
-  ssl_stapling_index = SSL_CTX_get_ex_new_index(0, nullptr, nullptr, nullptr, certinfo_free);
+  ssl_stapling_index = SSL_CTX_get_ex_new_index(0, nullptr, nullptr, nullptr, certinfo_map_free);
 }
 
 static X509 *
@@ -136,7 +143,6 @@ end:
 bool
 ssl_stapling_init_cert(SSL_CTX *ctx, X509 *cert, const char *certname)
 {
-  certinfo *cinf;
   scoped_X509 issuer;
   STACK_OF(OPENSSL_STRING) *aia = nullptr;
 
@@ -145,15 +151,19 @@ ssl_stapling_init_cert(SSL_CTX *ctx, X509 *cert, const char *certname)
     return false;
   }
 
-  cinf = (certinfo *)SSL_CTX_get_ex_data(ctx, ssl_stapling_index);
-  if (cinf) {
+  certinfo_map *map = static_cast<certinfo_map *>(SSL_CTX_get_ex_data(ctx, ssl_stapling_index));
+  if (map && map->find(cert) != map->end()) {
     Note("certificate already initialized for %s", certname);
     return false;
   }
 
-  cinf = (certinfo *)OPENSSL_malloc(sizeof(certinfo));
+  if (!map) {
+    map = new certinfo_map;
+  }
+  certinfo *cinf = static_cast<certinfo *>(OPENSSL_malloc(sizeof(certinfo)));
   if (!cinf) {
     Error("error allocating memory for %s", certname);
+    delete map;
     return false;
   }
 
@@ -190,7 +200,8 @@ ssl_stapling_init_cert(SSL_CTX *ctx, X509 *cert, const char *certname)
     goto err;
   }
 
-  SSL_CTX_set_ex_data(ctx, ssl_stapling_index, cinf);
+  map->insert(std::make_pair(cert, cinf));
+  SSL_CTX_set_ex_data(ctx, ssl_stapling_index, map);
 
   Note("successfully initialized stapling for %s into SSL_CTX: %p", certname, ctx);
   return true;
@@ -207,17 +218,21 @@ err:
   if (cinf) {
     OPENSSL_free(cinf);
   }
+  if (map) {
+    delete map;
+  }
   return false;
 }
 
-static certinfo *
+static certinfo_map *
 stapling_get_cert_info(SSL_CTX *ctx)
 {
-  certinfo *cinf;
+  certinfo_map *map;
 
-  cinf = (certinfo *)SSL_CTX_get_ex_data(ctx, ssl_stapling_index);
-  if (cinf && cinf->cid) {
-    return cinf;
+  // Only return the map if it contains at least one element with a valid entry
+  map = static_cast<certinfo_map *>(SSL_CTX_get_ex_data(ctx, ssl_stapling_index));
+  if (map && !map->empty() && map->begin()->second && map->begin()->second->cid) {
+    return map;
   }
 
   return nullptr;
@@ -427,7 +442,6 @@ void
 ocsp_update()
 {
   SSL_CTX *ctx;
-  certinfo *cinf      = nullptr;
   OCSP_RESPONSE *resp = nullptr;
   time_t current_time;
 
@@ -437,22 +451,27 @@ ocsp_update()
   for (unsigned i = 0; i < ctxCount; i++) {
     SSLCertContext *cc = certLookup->get(i);
     if (cc && cc->ctx) {
-      ctx  = cc->ctx;
-      cinf = stapling_get_cert_info(ctx);
-      if (cinf) {
-        ink_mutex_acquire(&cinf->stapling_mutex);
-        current_time = time(nullptr);
-        if (cinf->resp_derlen == 0 || cinf->is_expire || cinf->expire_time < current_time) {
-          ink_mutex_release(&cinf->stapling_mutex);
-          if (stapling_refresh_response(cinf, &resp)) {
-            Debug("Successfully refreshed OCSP for %s certificate. url=%s", cinf->certname, cinf->uri);
-            SSL_INCREMENT_DYN_STAT(ssl_ocsp_refreshed_cert_stat);
+      ctx               = cc->ctx;
+      certinfo *cinf    = nullptr;
+      certinfo_map *map = stapling_get_cert_info(ctx);
+      if (map) {
+        // Walk over all certs associated with this CTX
+        for (certinfo_map::iterator iter = map->begin(); iter != map->end(); ++iter) {
+          cinf = iter->second;
+          ink_mutex_acquire(&cinf->stapling_mutex);
+          current_time = time(nullptr);
+          if (cinf->resp_derlen == 0 || cinf->is_expire || cinf->expire_time < current_time) {
+            ink_mutex_release(&cinf->stapling_mutex);
+            if (stapling_refresh_response(cinf, &resp)) {
+              Debug("Successfully refreshed OCSP for %s certificate. url=%s", cinf->certname, cinf->uri);
+              SSL_INCREMENT_DYN_STAT(ssl_ocsp_refreshed_cert_stat);
+            } else {
+              Error("Failed to refresh OCSP for %s certificate. url=%s", cinf->certname, cinf->uri);
+              SSL_INCREMENT_DYN_STAT(ssl_ocsp_refresh_cert_failure_stat);
+            }
           } else {
-            Error("Failed to refresh OCSP for %s certificate. url=%s", cinf->certname, cinf->uri);
-            SSL_INCREMENT_DYN_STAT(ssl_ocsp_refresh_cert_failure_stat);
+            ink_mutex_release(&cinf->stapling_mutex);
           }
-        } else {
-          ink_mutex_release(&cinf->stapling_mutex);
         }
       }
     }
@@ -463,20 +482,29 @@ ocsp_update()
 int
 ssl_callback_ocsp_stapling(SSL *ssl)
 {
-  certinfo *cinf = nullptr;
-  time_t current_time;
-
   // Assume SSL_get_SSL_CTX() is the same as reaching into the ssl structure
   // Using the official call, to avoid leaking internal openssl knowledge
   // originally was, cinf = stapling_get_cert_info(ssl->ctx);
-  cinf = stapling_get_cert_info(SSL_get_SSL_CTX(ssl));
-  if (cinf == nullptr) {
-    Debug("ssl_ocsp", "ssl_callback_ocsp_stapling: failed to get certificate information");
+  certinfo_map *map = stapling_get_cert_info(SSL_get_SSL_CTX(ssl));
+  if (map == nullptr) {
+    Debug("ssl_ocsp", "ssl_callback_ocsp_stapling: failed to get certificate map");
     return SSL_TLSEXT_ERR_NOACK;
   }
+  // Fetch the specific certificate used in this negotiation
+  X509 *cert = SSL_get_certificate(ssl);
+  if (!cert) {
+    Error("ssl_callback_ocsp_stapling: failed to get certificate");
+    return SSL_TLSEXT_ERR_NOACK;
+  }
+  certinfo_map::iterator iter = map->find(cert);
+  if (iter == map->end()) {
+    Error("ssl_callback_ocsp_stapling: failed to get certificate information");
+    return SSL_TLSEXT_ERR_NOACK;
+  }
+  certinfo *cinf = iter->second;
 
   ink_mutex_acquire(&cinf->stapling_mutex);
-  current_time = time(nullptr);
+  time_t current_time = time(nullptr);
   if (cinf->resp_derlen == 0 || cinf->is_expire || cinf->expire_time < current_time) {
     ink_mutex_release(&cinf->stapling_mutex);
     Debug("ssl_ocsp", "ssl_callback_ocsp_stapling: failed to get certificate status for %s", cinf->certname);

--- a/iocore/net/SSLNetProcessor.cc
+++ b/iocore/net/SSLNetProcessor.cc
@@ -77,6 +77,8 @@ SSLNetProcessor::start(int, size_t stacksize)
 
 #ifdef TS_USE_TLS_OCSP
   if (SSLConfigParams::ssl_ocsp_enabled) {
+    // Call the update initially to get things populated
+    ocsp_update();
     EventType ET_OCSP = eventProcessor.spawn_event_threads("ET_OCSP", 1, stacksize);
     eventProcessor.schedule_every(new OCSPContinuation(), HRTIME_SECONDS(SSLConfigParams::ssl_ocsp_update_period), ET_OCSP);
   }


### PR DESCRIPTION
This PR fixes two issues.  

1. The OCSP cache is not set for the first ocsp.update_period (defaults to 60 seconds).

2. The OCSP information for only one of the certificates associated with the SSL_CTX is stapled (it appeared to be the first certificate listed in the comma separated list in ssl_multicert.config.  I was testing this with alternating calls to the following
```
openssl s_client --connect localhost:443 -cipher 'ECDHE-ECDSA-AES256-SHA' -tls1_2 -status
openssl s_client --connect localhost:443 -cipher 'ECDHE-RSA-AES256-SHA' -tls1_2 -status
```
In the current code, both requests would return the following OCSP repsponse:
```
OCSP response: 
======================================
OCSP Response Data:
    OCSP Response Status: successful (0x0)
    Response Type: Basic OCSP Response
    Version: 1 (0x0)
    Responder Id: 5168FF90AF0207753CCCD9656462A212B859723B
    Produced At: Jan  7 09:19:56 2019 GMT
    Responses:
    Certificate ID:
      Hash Algorithm: sha1
      Issuer Name Hash: CF26F518FAC97E8F8CB342E01C2F6A109E8E5F0A
      Issuer Key Hash: 5168FF90AF0207753CCCD9656462A212B859723B
      Serial Number: 029FD28F5532A4F9158D26390D478AA2
    Cert Status: good
    This Update: Jan  7 09:19:56 2019 GMT
    Next Update: Jan 14 08:34:56 2019 GMT

    Signature Algorithm: sha256WithRSAEncryption
         01:ce:a8:85:c0:25:b2:40:0c:91:ea:8e:c5:1d:cf:37:65:2f:
         79:86:fb:34:91:d1:fc:ba:6c:dd:59:8e:34:07:5f:87:1a:c7:
         f1:dc:32:0d:36:2e:13:11:95:17:66:bd:eb:7d:eb:7b:3d:51:
         07:aa:30:d5:64:08:65:0d:11:0c:79:f5:db:b9:9b:1b:2c:2c:
         47:69:ca:6d:29:3e:e4:e6:69:9c:25:d3:ef:5c:1e:75:78:fb:
         14:eb:54:d1:1d:68:8b:1c:b5:12:42:5e:47:c4:94:43:ef:81:
         51:ff:3a:27:58:99:b4:f4:bd:0c:51:44:5d:ff:e6:ce:e6:68:
         56:b2:8d:13:07:03:84:98:92:a7:71:33:c3:17:2b:e2:89:ac:
         d4:52:fc:b0:6f:51:b5:e7:b7:d3:fc:b8:f8:0a:84:ad:da:86:
         47:d1:83:80:78:42:f0:95:63:81:8b:28:92:34:e3:7a:bc:74:
         09:c4:ca:dd:05:66:1b:10:b8:a2:a9:13:ad:4b:3a:4b:87:a7:
         b5:f5:0a:f4:ba:ea:42:9b:f8:c8:14:03:92:4c:d6:9c:a8:fd:
         91:1f:89:d3:2a:76:92:ac:9c:22:fe:bb:d4:8e:c7:6c:67:03:
         cf:24:e4:39:1a:42:02:65:0c:54:f5:15:2a:48:c5:84:31:1f:
         5b:d9:26:d8
======================================
```
Where serial # 029FD28F5532A4F9158D26390D478AA2 corresponds to my EC certificate which would have been used in the negotiation of the first request but not the second request.

With this code change, the request that negotiates a RSA authentication returns reference to serial number in the RSA certificate.
