### PR TITLE
Makes SSL treating certs as children configs optional

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3283,6 +3283,13 @@ SSL Termination
    :file:`ssl_multicert.config` file successfully load.  If false (``0``), SSL certificate
    load failures will not prevent |TS| from starting.
 
+.. ts:cv:: CONFIG proxy.config.ssl.server.multicert.certs_are_child_configs INT 1
+
+   By default (``1``), |TS| treats SSL certificates listed in the :file:`ssl_multicert.config`
+   file as children config files to it.  If a certificate changes, and a reload is requested,
+   all certificates will be reloaded. If false (``0``), |TS| does not track changes to certificates,
+   only to :file:`ssl_multicert.config`
+
 .. ts:cv:: CONFIG proxy.config.ssl.server.cert.path STRING /config
 
    The location of the SSL certificates and chains used for accepting
@@ -3544,7 +3551,7 @@ Client-Related Configuration
 .. ts:cv:: CONFIG proxy.config.ssl.client.sni_policy STRING NULL
    :overridable:
 
-   Indicate how the SNI value for the TLS connection to the origin is selected.  By default it is 
+   Indicate how the SNI value for the TLS connection to the origin is selected.  By default it is
    `host` which means the host header field value is used for the SNI.  If `remap` is specified, the
    remapped origin name is used for the SNI value.
 

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1126,6 +1126,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.ssl.server.multicert.exit_on_load_fail", RECD_INT, "1", RECU_RESTART_TS, RR_NULL, RECC_NULL, "[0-1]", RECA_NULL}
 ,
+  {RECT_CONFIG, "proxy.config.ssl.server.multicert.certs_are_child_configs", RECD_INT, "1", RECU_RESTART_TS, RR_NULL, RECC_NULL, "[0-1]", RECA_NULL}
+,
   {RECT_CONFIG, "proxy.config.ssl.servername.filename", RECD_STRING, "ssl_server_name.yaml", RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.ssl.server.ticket_key.filename", RECD_STRING, nullptr, RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -1897,8 +1897,14 @@ main(int /* argc ATS_UNUSED */, const char **argv)
     // Init plugins as soon as logging is ready.
     (void)plugin_init(); // plugin.config
 
-    SSLConfigParams::init_ssl_ctx_cb  = init_ssl_ctx_callback;
-    SSLConfigParams::load_ssl_file_cb = load_ssl_file_callback;
+    SSLConfigParams::init_ssl_ctx_cb = init_ssl_ctx_callback;
+
+    int certs_are_child_configs = 0;
+    REC_ReadConfigInteger(certs_are_child_configs, "proxy.config.ssl.server.multicert.certs_are_child_configs");
+    if (certs_are_child_configs) {
+      SSLConfigParams::load_ssl_file_cb = load_ssl_file_callback;
+    }
+
     sslNetProcessor.start(-1, stacksize);
 
     pmgmt->registerPluginCallbacks(global_config_cbs);


### PR DESCRIPTION
This adds a new option "proxy.config.ssl.server.multicert.certs_are_child_configs",
which allows an operator to disable ssl_multicert.config child file tracking added in 4d2c262c