### PR TITLE
Cleanup: Make _next_round_robin uint64_t

### DIFF
--- a/iocore/eventsystem/I_EventProcessor.h
+++ b/iocore/eventsystem/I_EventProcessor.h
@@ -303,9 +303,9 @@ public:
   /// The thread group ID is the index into an array of these and so is not stored explicitly.
   struct ThreadGroupDescriptor {
     std::string _name;                               ///< Name for the thread group.
-    int _count                = 0;                   ///< # of threads of this type.
-    std::atomic<int> _started = 0;                   ///< # of started threads of this type.
-    int _next_round_robin     = 0;                   ///< Index of thread to use for events assigned to this group.
+    int _count                 = 0;                  ///< # of threads of this type.
+    std::atomic<int> _started  = 0;                  ///< # of started threads of this type.
+    uint64_t _next_round_robin = 0;                  ///< Index of thread to use for events assigned to this group.
     Que(Event, link) _spawnQueue;                    ///< Events to dispatch when thread is spawned.
     EThread *_thread[MAX_THREADS_IN_EACH_TYPE] = {}; ///< The actual threads in this group.
     std::function<void()> _afterStartCallback  = nullptr;

--- a/iocore/eventsystem/P_UnixEventProcessor.h
+++ b/iocore/eventsystem/P_UnixEventProcessor.h
@@ -54,12 +54,7 @@ EventProcessor::assign_thread(EventType etype)
 
   ink_assert(etype < MAX_EVENT_TYPES);
   if (tg->_count > 1) {
-    // When "_next_round_robin" grows big enough, it becomes a negative number,
-    // meaning "next" is also negative. And since "next" is used as an index
-    // into array "_thread", the result is returning NULL when assigning threads.
-    // So we need to cast "_next_round_robin" to unsigned int so the result stays
-    // positive.
-    next = static_cast<unsigned int>(++tg->_next_round_robin) % tg->_count;
+    next = ++tg->_next_round_robin % tg->_count;
   } else {
     next = 0;
   }


### PR DESCRIPTION
- To avoid cast. And `uint64_t` is preferable for counter like this.
- This is just cleanup, we don't need to backport this.