### PR TITLE
Install pre-commit only if ".git/hooks/pre-commit" exists

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -95,8 +95,9 @@ install-examples: examples
 	@cd example && $(MAKE) $(AM_MAKEFLAGS) install pkglibdir=$(pkglibexecdir)
 
 $(abs_top_srcdir)/.git/hooks/pre-commit: $(abs_top_srcdir)/tools/git/pre-commit
-	[ -d $(abs_top_srcdir)/.git/hooks ] && \
-		cp $(abs_top_srcdir)/tools/git/pre-commit $(abs_top_srcdir)/.git/hooks/pre-commit
+	if [ -d $(abs_top_srcdir)/.git/hooks ]; then \
+		cp $(abs_top_srcdir)/tools/git/pre-commit $(abs_top_srcdir)/.git/hooks/pre-commit; \
+	fi
 
 install-data-hook:
 if BUILD_DOCS


### PR DESCRIPTION
Logically doing same thing. But prior this change, `make all` returns error like below in my git-worktree directory. Because `$(abs_top_srcdir)/.git/hooks/` doesn't exist.

```
[ -d /Users/masaori/src/trafficserver/trafficserver-master/.git/hooks ] && \
                cp /Users/masaori/src/trafficserver/trafficserver-master/tools/git/pre-commit /Users/masaori/src/trafficserver/trafficserver-master/.git/hooks/pre-commit
make[1]: *** [/Users/masaori/src/trafficserver/trafficserver-master/.git/hooks/pre-commit] Error 1
make: *** [all-recursive] Error 1
```