### PR TITLE
QUIC: Uses reference to the callback QUICFrameInformation

### DIFF
--- a/iocore/net/quic/QUICAckFrameCreator.cc
+++ b/iocore/net/quic/QUICAckFrameCreator.cc
@@ -96,7 +96,7 @@ QUICAckFrameManager::will_generate_frame(QUICEncryptionLevel level)
 }
 
 void
-QUICAckFrameManager::_on_frame_acked(QUICFrameInformation info)
+QUICAckFrameManager::_on_frame_acked(QUICFrameInformation &info)
 {
   ink_assert(info.type == QUICFrameType::ACK);
   AckFrameInfomation *ack_info = reinterpret_cast<AckFrameInfomation *>(info.data);

--- a/iocore/net/quic/QUICAckFrameCreator.h
+++ b/iocore/net/quic/QUICAckFrameCreator.h
@@ -115,7 +115,7 @@ private:
     QUICPacketNumber largest_acknowledged = 0;
   };
 
-  virtual void _on_frame_acked(QUICFrameInformation info) override;
+  virtual void _on_frame_acked(QUICFrameInformation &info) override;
 
   /*
    * Returns QUICAckFrame only if ACK frame is able to be sent.

--- a/iocore/net/quic/QUICFlowController.cc
+++ b/iocore/net/quic/QUICFlowController.cc
@@ -149,7 +149,7 @@ QUICRemoteFlowController::update(QUICOffset offset)
 }
 
 void
-QUICRemoteFlowController::_on_frame_lost(QUICFrameInformation info)
+QUICRemoteFlowController::_on_frame_lost(QUICFrameInformation &info)
 {
   ink_assert(info.type == QUICFrameType::BLOCKED || info.type == QUICFrameType::STREAM_BLOCKED);
   if (this->_offset == *reinterpret_cast<QUICOffset *>(info.data)) {
@@ -192,7 +192,7 @@ QUICLocalFlowController::set_limit(QUICOffset limit)
 }
 
 void
-QUICLocalFlowController::_on_frame_lost(QUICFrameInformation info)
+QUICLocalFlowController::_on_frame_lost(QUICFrameInformation &info)
 {
   ink_assert(info.type == QUICFrameType::MAX_DATA || info.type == QUICFrameType::MAX_STREAM_DATA);
   if (this->_limit == *reinterpret_cast<QUICOffset *>(info.data)) {

--- a/iocore/net/quic/QUICFlowController.h
+++ b/iocore/net/quic/QUICFlowController.h
@@ -80,7 +80,7 @@ public:
   void forward_limit(QUICOffset new_limit) override;
 
 private:
-  void _on_frame_lost(QUICFrameInformation info) override;
+  void _on_frame_lost(QUICFrameInformation &info) override;
   bool _blocked = false;
 };
 
@@ -101,7 +101,7 @@ public:
   void set_limit(QUICOffset limit) override;
 
 private:
-  void _on_frame_lost(QUICFrameInformation info) override;
+  void _on_frame_lost(QUICFrameInformation &info) override;
   bool _need_to_forward_limit();
 
   QUICRateAnalyzer _analyzer;

--- a/iocore/net/quic/QUICFrameGenerator.h
+++ b/iocore/net/quic/QUICFrameGenerator.h
@@ -50,12 +50,12 @@ protected:
   }
 
   virtual void
-  _on_frame_acked(QUICFrameInformation info)
+  _on_frame_acked(QUICFrameInformation &info)
   {
   }
 
   virtual void
-  _on_frame_lost(QUICFrameInformation info)
+  _on_frame_lost(QUICFrameInformation &info)
   {
   }
 

--- a/iocore/net/quic/QUICStream.cc
+++ b/iocore/net/quic/QUICStream.cc
@@ -569,7 +569,7 @@ QUICStream::_records_max_stream_data_frame(const QUICMaxStreamDataFrame &frame)
 }
 
 void
-QUICStream::_on_frame_acked(QUICFrameInformation info)
+QUICStream::_on_frame_acked(QUICFrameInformation &info)
 {
   StreamFrameInfo *frame_info = nullptr;
   switch (info.type) {
@@ -593,7 +593,7 @@ QUICStream::_on_frame_acked(QUICFrameInformation info)
 }
 
 void
-QUICStream::_on_frame_lost(QUICFrameInformation info)
+QUICStream::_on_frame_lost(QUICFrameInformation &info)
 {
   StreamFrameInfo *frame_info = nullptr;
   switch (info.type) {
@@ -908,7 +908,7 @@ QUICCryptoStream::generate_frame(QUICEncryptionLevel level, uint64_t connection_
 }
 
 void
-QUICCryptoStream::_on_frame_acked(QUICFrameInformation info)
+QUICCryptoStream::_on_frame_acked(QUICFrameInformation &info)
 {
   ink_assert(info.type == QUICFrameType::CRYPTO);
   CryptoFrameInformation *crypto_frame_info = reinterpret_cast<CryptoFrameInformation *>(info.data);
@@ -916,7 +916,7 @@ QUICCryptoStream::_on_frame_acked(QUICFrameInformation info)
 }
 
 void
-QUICCryptoStream::_on_frame_lost(QUICFrameInformation info)
+QUICCryptoStream::_on_frame_lost(QUICFrameInformation &info)
 {
   ink_assert(info.type == QUICFrameType::CRYPTO);
   CryptoFrameInformation *crypto_frame_info = reinterpret_cast<CryptoFrameInformation *>(info.data);

--- a/iocore/net/quic/QUICStream.h
+++ b/iocore/net/quic/QUICStream.h
@@ -164,8 +164,8 @@ protected:
   QUICBidirectionalStreamState _state;
 
   // QUICFrameGenerator
-  void _on_frame_acked(QUICFrameInformation info) override;
-  void _on_frame_lost(QUICFrameInformation info) override;
+  void _on_frame_acked(QUICFrameInformation &info) override;
+  void _on_frame_lost(QUICFrameInformation &info) override;
 };
 
 /**
@@ -212,8 +212,8 @@ private:
     Ptr<IOBufferBlock> block;
   };
 
-  void _on_frame_acked(QUICFrameInformation info) override;
-  void _on_frame_lost(QUICFrameInformation info) override;
+  void _on_frame_acked(QUICFrameInformation &info) override;
+  void _on_frame_lost(QUICFrameInformation &info) override;
 
   QUICStreamErrorUPtr _reset_reason = nullptr;
   QUICOffset _send_offset           = 0;


### PR DESCRIPTION
QUIC: Uses reference to the callback QUICFrameInformation to avoid copying.