### PR TITLE
Deals better with Cc: max-age=0

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -7627,7 +7627,7 @@ HttpTransact::what_is_document_freshness(State *s, HTTPHdr *client_request, HTTP
   // now, see if the age is "fresh enough" //
   ///////////////////////////////////////////
 
-  if (do_revalidate || current_age > age_limit) { // client-modified limit
+  if (do_revalidate || !age_limit || current_age > age_limit) { // client-modified limit
     DebugTxn("http_match", "[..._document_freshness] document needs revalidate/too old; "
                            "returning FRESHNESS_STALE");
     return (FRESHNESS_STALE);


### PR DESCRIPTION
There's a small window where we can still serve cached responses even
when they have a Cache-Control: max-age=0.

This fixes the cache-tests checks for id=freshness-max-age-0 and
id=freshness-max-age-0-expires.

(cherry picked from commit 0b80592bc472d5394c777d0fca66f72779276cf2)

 Conflicts:
	proxy/http/HttpTransact.cc