### PR TITLE
Add unit tests for the URI signing plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,8 @@ plugins/esi/processor_test
 plugins/esi/utils_test
 plugins/esi/vars_test
 
+plugins/experimental/uri_signing/test_uri_signing
+
 mgmt/api/traffic_api_cli_remote
 mgmt/tools/traffic_mcast_snoop
 mgmt/tools/traffic_net_config

--- a/plugins/experimental/uri_signing/Makefile.inc
+++ b/plugins/experimental/uri_signing/Makefile.inc
@@ -26,3 +26,17 @@ experimental_uri_signing_uri_signing_la_SOURCES = \
   experimental/uri_signing/timing.c
 
 experimental_uri_signing_uri_signing_la_LIBADD = @LIBJANSSON@ @LIBCJOSE@ @LIBPCRE@ -lm -lcrypto
+
+check_PROGRAMS += experimental/uri_signing/test_uri_signing
+
+experimental_uri_signing_test_uri_signing_CPPFLAGS = $(AM_CPPFLAGS) -I$(abs_top_srcdir)/tests/include -DURI_SIGNING_UNIT_TEST 
+experimental_uri_signing_test_uri_signing_LDADD = @LIBJANSSON@ @LIBCJOSE@ @LIBPCRE@ -lm -lcrypto
+experimental_uri_signing_test_uri_signing_SOURCES = \
+	experimental/uri_signing/unit_tests/uri_signing_test.cc \
+    experimental/uri_signing/jwt.c \
+    experimental/uri_signing/common.c \
+    experimental/uri_signing/parse.c \
+    experimental/uri_signing/cookie.c \
+    experimental/uri_signing/config.c \
+    experimental/uri_signing/timing.c \
+    experimental/uri_signing/match.c

--- a/plugins/experimental/uri_signing/README.md
+++ b/plugins/experimental/uri_signing/README.md
@@ -147,6 +147,9 @@ This builds in-tree with the rest of the ATS plugins. Of special note, however,
 are the first two libraries: cjose and jansson. These libraries are not
 currently used anywhere else, so they may not be installed.
 
+Note that the default prefix value for cjose is /usr/local. Ensure this is visible to
+any executables that are being run using this library.
+
 As of this writing, both libraries install a dynamic library and a static
 archive. However, by default, the static archive is not compiled with Position
 Independent Code. The build script will detect this and build a dynamic

--- a/plugins/experimental/uri_signing/common.c
+++ b/plugins/experimental/uri_signing/common.c
@@ -1,0 +1,32 @@
+/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include "common.h"
+
+#ifdef URI_SIGNING_UNIT_TEST
+
+void
+PrintToStdErr(const char *fmt, ...)
+{
+  va_list args;
+  va_start(args, fmt);
+  vfprintf(stderr, fmt, args);
+  va_end(args);
+}
+
+#endif

--- a/plugins/experimental/uri_signing/common.h
+++ b/plugins/experimental/uri_signing/common.h
@@ -18,5 +18,17 @@
 
 #define PLUGIN_NAME "uri_signing"
 
+#ifdef URI_SIGNING_UNIT_TEST
+#include <stdio.h>
+#include <stdarg.h>
+
+#define PluginDebug(fmt, ...) PrintToStdErr("(%s) %s:%d:%s() " fmt "\n", PLUGIN_NAME, __FILE__, __LINE__, __func__, ##__VA_ARGS__)
+#define PluginError(fmt, ...) PrintToStdErr("(%s) %s:%d:%s() " fmt "\n", PLUGIN_NAME, __FILE__, __LINE__, __func__, ##__VA_ARGS__)
+void PrintToStdErr(const char *fmt, ...);
+
+#else
+
 #define PluginDebug(...) TSDebug("uri_signing", PLUGIN_NAME " " __VA_ARGS__)
 #define PluginError(...) PluginDebug(__VA_ARGS__), TSError(PLUGIN_NAME " " __VA_ARGS__)
+
+#endif

--- a/plugins/experimental/uri_signing/config.c
+++ b/plugins/experimental/uri_signing/config.c
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-#include "uri_signing.h"
+#include "common.h"
 #include "config.h"
 #include "timing.h"
 #include "jwt.h"

--- a/plugins/experimental/uri_signing/cookie.c
+++ b/plugins/experimental/uri_signing/cookie.c
@@ -17,7 +17,7 @@
  */
 
 #include "cookie.h"
-#include "uri_signing.h"
+#include "common.h"
 #include <ts/ts.h>
 #include <string.h>
 

--- a/plugins/experimental/uri_signing/jwt.c
+++ b/plugins/experimental/uri_signing/jwt.c
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-#include "uri_signing.h"
+#include "common.h"
 #include "jwt.h"
 #include "match.h"
 #include "ts/ts.h"

--- a/plugins/experimental/uri_signing/match.c
+++ b/plugins/experimental/uri_signing/match.c
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-#include "uri_signing.h"
+#include "common.h"
 #include "ts/ts.h"
 #include <stdbool.h>
 #include <pcre.h>

--- a/plugins/experimental/uri_signing/parse.c
+++ b/plugins/experimental/uri_signing/parse.c
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-#include "uri_signing.h"
+#include "common.h"
 #include "parse.h"
 #include "config.h"
 #include "jwt.h"

--- a/plugins/experimental/uri_signing/unit_tests/uri_signing_test.cc
+++ b/plugins/experimental/uri_signing/unit_tests/uri_signing_test.cc
@@ -1,0 +1,92 @@
+/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/*
+ * These are misc unit tests for uri signing
+ */
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+extern "C" {
+#include <jansson.h>
+#include <cjose/cjose.h>
+#include "../jwt.h"
+}
+
+bool
+jwt_parsing_helper(const char *jwt_string)
+{
+  fprintf(stderr, "Parsing JWT from string: %s\n", jwt_string);
+  bool resp;
+  json_error_t jerr = {};
+  size_t pt_ct      = strlen(jwt_string);
+  struct jwt *jwt   = parse_jwt(json_loadb(jwt_string, pt_ct, 0, &jerr));
+
+  if (jwt) {
+    resp = jwt_validate(jwt);
+  } else {
+    resp = false;
+  }
+
+  jwt_delete(jwt);
+  return resp;
+}
+
+TEST_CASE("1", "[JWSParsingTest]")
+{
+  INFO("TEST 1, Test JWT Parsing From Token Strings");
+
+  SECTION("Standard JWT Parsing")
+  {
+    REQUIRE(jwt_parsing_helper("{\"cdniets\":30,\"cdnistt\":1,\"exp\":7284188499,\"iss\":\"Content Access "
+                               "Manager\",\"cdniuc\":\"uri-regex:http://foobar.local/testDir/*\"}"));
+  }
+
+  SECTION("JWT Parsing With Unknown Claim")
+  {
+    REQUIRE(jwt_parsing_helper("{\"cdniets\":30,\"cdnistt\":1,\"exp\":7284188499,\"iss\":\"Content Access "
+                               "Manager\",\"cdniuc\":\"uri-regex:http://foobar.local/testDir/"
+                               "*\",\"jamesBond\":\"Something,Something_else\"}"));
+  }
+
+  SECTION("JWT Parsing with unsupported crit claim passed")
+  {
+    REQUIRE(!jwt_parsing_helper("{\"cdniets\":30,\"cdnistt\":1,\"exp\":7284188499,\"iss\":\"Content Access "
+                                "Manager\",\"cdniuc\":\"uri-regex:http://foobar.local/testDir/"
+                                "*\",\"cdnicrit\":\"Something,Something_else\"}"));
+  }
+
+  SECTION("JWT Parsing with empty exp claim")
+  {
+    REQUIRE(jwt_parsing_helper("{\"cdniets\":30,\"cdnistt\":1,\"iss\":\"Content Access "
+                               "Manager\",\"cdniuc\":\"uri-regex:http://foobar.local/testDir/*\"}"));
+  }
+
+  SECTION("JWT Parsing with unsupported cdniip claim")
+  {
+    REQUIRE(!jwt_parsing_helper("{\"cdniets\":30,\"cdnistt\":1,\"cdniip\":\"123.123.123.123\",\"iss\":\"Content Access "
+                                "Manager\",\"cdniuc\":\"uri-regex:http://foobar.local/testDir/*\"}"));
+  }
+
+  SECTION("JWT Parsing with unsupported value for cdnistd claim")
+  {
+    REQUIRE(!jwt_parsing_helper("{\"cdniets\":30,\"cdnistt\":1,\"cdnistd\":4,\"iss\":\"Content Access "
+                                "Manager\",\"cdniuc\":\"uri-regex:http://foobar.local/testDir/*\"}"));
+  }
+}

--- a/plugins/experimental/uri_signing/uri_signing.c
+++ b/plugins/experimental/uri_signing/uri_signing.c
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-#include "uri_signing.h"
+#include "common.h"
 #include "config.h"
 #include "parse.h"
 #include "jwt.h"


### PR DESCRIPTION
Uses the catch framework to create a unit test suite that can be run with 'make check'. This only includes basic tests for the creation of JWT structs with the parse_jwt function. 