### PR TITLE
QUIC: Introduces QUICFrameRetranmsitter to retransmit frame

### DIFF
--- a/iocore/net/P_QUICNetVConnection.h
+++ b/iocore/net/P_QUICNetVConnection.h
@@ -382,7 +382,7 @@ private:
   bool _has_ack_only_packet_out = false;
 
   // QUICFrameGenerator
-  void _on_frame_lost(QUICFrameInformation &info) override;
+  void _on_frame_lost(QUICFrameInformationUPtr &info) override;
   std::vector<QUICEncryptionLevel>
   _encryption_level_filter() override
   {

--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -2211,7 +2211,7 @@ QUICNetVConnection::generate_frame(QUICEncryptionLevel level, uint64_t connectio
 }
 
 void
-QUICNetVConnection::_on_frame_lost(QUICFrameInformation &info)
+QUICNetVConnection::_on_frame_lost(QUICFrameInformationUPtr &info)
 {
   this->_is_resumption_token_sent = false;
 }

--- a/iocore/net/quic/Makefile.am
+++ b/iocore/net/quic/Makefile.am
@@ -79,7 +79,8 @@ libquic_a_SOURCES = \
   QUICPacketRetransmitter.cc \
   QUICPathValidator.cc \
   QUICPinger.cc \
-  QUICFrameGenerator.cc
+  QUICFrameGenerator.cc \
+  QUICFrameRetransmitter.cc
 
 #
 # Check Programs
@@ -103,7 +104,8 @@ check_PROGRAMS = \
   test_QUICTransportParameters \
   test_QUICType \
   test_QUICTypeUtil \
-  test_QUICVersionNegotiator
+  test_QUICVersionNegotiator \
+  test_QUICFrameRetransmitter
 
 TESTS = $(check_PROGRAMS)
 
@@ -269,6 +271,13 @@ test_QUICVersionNegotiator_LDADD = $(test_LDADD)
 test_QUICVersionNegotiator_SOURCES = \
   $(test_main_SOURCES) \
   ./test/test_QUICVersionNegotiator.cc
+
+test_QUICFrameRetransmitter_CPPFLAGS = $(test_CPPFLAGS)
+test_QUICFrameRetransmitter_LDFLAGS = @AM_LDFLAGS@
+test_QUICFrameRetransmitter_LDADD = $(test_LDADD)
+test_QUICFrameRetransmitter_SOURCES = \
+  $(test_main_SOURCES) \
+  ./test/test_QUICFrameRetransmitter.cc
 
 #
 # clang-tidy

--- a/iocore/net/quic/QUICAckFrameCreator.cc
+++ b/iocore/net/quic/QUICAckFrameCreator.cc
@@ -71,13 +71,13 @@ QUICAckFrameManager::generate_frame(QUICEncryptionLevel level, uint64_t connecti
   ack_frame         = ack_creator->generate_ack_frame(maximum_frame_size);
 
   if (ack_frame != nullptr) {
-    QUICFrameInformation info;
-    AckFrameInfomation *ack_info   = reinterpret_cast<AckFrameInfomation *>(info.data);
+    QUICFrameInformationUPtr info  = std::make_unique<QUICFrameInformation>();
+    AckFrameInfo *ack_info         = reinterpret_cast<AckFrameInfo *>(info->data);
     ack_info->largest_acknowledged = ack_frame->largest_acknowledged();
 
-    info.level = level;
-    info.type  = ack_frame->type();
-    this->_records_frame(ack_frame->id(), info);
+    info->level = level;
+    info->type  = ack_frame->type();
+    this->_records_frame(ack_frame->id(), std::move(info));
   }
 
   return ack_frame;
@@ -96,11 +96,11 @@ QUICAckFrameManager::will_generate_frame(QUICEncryptionLevel level)
 }
 
 void
-QUICAckFrameManager::_on_frame_acked(QUICFrameInformation &info)
+QUICAckFrameManager::_on_frame_acked(QUICFrameInformationUPtr &info)
 {
-  ink_assert(info.type == QUICFrameType::ACK);
-  AckFrameInfomation *ack_info = reinterpret_cast<AckFrameInfomation *>(info.data);
-  int index                    = QUICTypeUtil::pn_space_index(info.level);
+  ink_assert(info->type == QUICFrameType::ACK);
+  AckFrameInfo *ack_info = reinterpret_cast<AckFrameInfo *>(info->data);
+  int index              = QUICTypeUtil::pn_space_index(info->level);
   this->_ack_creator[index]->forget(ack_info->largest_acknowledged);
 }
 

--- a/iocore/net/quic/QUICAckFrameCreator.cc
+++ b/iocore/net/quic/QUICAckFrameCreator.cc
@@ -71,7 +71,7 @@ QUICAckFrameManager::generate_frame(QUICEncryptionLevel level, uint64_t connecti
   ack_frame         = ack_creator->generate_ack_frame(maximum_frame_size);
 
   if (ack_frame != nullptr) {
-    QUICFrameInformationUPtr info  = std::make_unique<QUICFrameInformation>();
+    QUICFrameInformationUPtr info  = QUICFrameInformationUPtr(quicFrameInformationAllocator.alloc());
     AckFrameInfo *ack_info         = reinterpret_cast<AckFrameInfo *>(info->data);
     ack_info->largest_acknowledged = ack_frame->largest_acknowledged();
 

--- a/iocore/net/quic/QUICAckFrameCreator.h
+++ b/iocore/net/quic/QUICAckFrameCreator.h
@@ -111,11 +111,7 @@ public:
   uint8_t ack_delay_exponent() const;
 
 private:
-  struct AckFrameInfomation {
-    QUICPacketNumber largest_acknowledged = 0;
-  };
-
-  virtual void _on_frame_acked(QUICFrameInformation &info) override;
+  virtual void _on_frame_acked(QUICFrameInformationUPtr &info) override;
 
   /*
    * Returns QUICAckFrame only if ACK frame is able to be sent.

--- a/iocore/net/quic/QUICFlowController.cc
+++ b/iocore/net/quic/QUICFlowController.cc
@@ -232,7 +232,7 @@ QUICFrameUPtr
 QUICRemoteConnectionFlowController::_create_frame()
 {
   auto frame                    = QUICFrameFactory::create_blocked_frame(this->_offset, this->_issue_frame_id(), this);
-  QUICFrameInformationUPtr info = std::make_unique<QUICFrameInformation>();
+  QUICFrameInformationUPtr info = QUICFrameInformationUPtr(quicFrameInformationAllocator.alloc());
   BlockedFrameInfo *frame_info  = reinterpret_cast<BlockedFrameInfo *>(info->data);
   info->type                    = frame->type();
   info->level                   = QUICEncryptionLevel::NONE;
@@ -245,7 +245,7 @@ QUICFrameUPtr
 QUICLocalConnectionFlowController::_create_frame()
 {
   auto frame                    = QUICFrameFactory::create_max_data_frame(this->_limit, this->_issue_frame_id(), this);
-  QUICFrameInformationUPtr info = std::make_unique<QUICFrameInformation>();
+  QUICFrameInformationUPtr info = QUICFrameInformationUPtr(quicFrameInformationAllocator.alloc());
   MaxDataFrameInfo *frame_info  = reinterpret_cast<MaxDataFrameInfo *>(info->data);
   info->type                    = frame->type();
   info->level                   = QUICEncryptionLevel::NONE;
@@ -258,7 +258,7 @@ QUICFrameUPtr
 QUICRemoteStreamFlowController::_create_frame()
 {
   auto frame = QUICFrameFactory::create_stream_blocked_frame(this->_stream_id, this->_offset, this->_issue_frame_id(), this);
-  QUICFrameInformationUPtr info      = std::make_unique<QUICFrameInformation>();
+  QUICFrameInformationUPtr info      = QUICFrameInformationUPtr(quicFrameInformationAllocator.alloc());
   StreamBlockedFrameInfo *frame_info = reinterpret_cast<StreamBlockedFrameInfo *>(info->data);
   info->type                         = frame->type();
   info->level                        = QUICEncryptionLevel::NONE;
@@ -272,7 +272,7 @@ QUICFrameUPtr
 QUICLocalStreamFlowController::_create_frame()
 {
   auto frame = QUICFrameFactory::create_max_stream_data_frame(this->_stream_id, this->_limit, this->_issue_frame_id(), this);
-  QUICFrameInformationUPtr info      = std::make_unique<QUICFrameInformation>();
+  QUICFrameInformationUPtr info      = QUICFrameInformationUPtr(quicFrameInformationAllocator.alloc());
   MaxStreamDataFrameInfo *frame_info = reinterpret_cast<MaxStreamDataFrameInfo *>(info->data);
   info->type                         = frame->type();
   info->level                        = QUICEncryptionLevel::NONE;

--- a/iocore/net/quic/QUICFlowController.h
+++ b/iocore/net/quic/QUICFlowController.h
@@ -80,7 +80,7 @@ public:
   void forward_limit(QUICOffset new_limit) override;
 
 private:
-  void _on_frame_lost(QUICFrameInformation &info) override;
+  void _on_frame_lost(QUICFrameInformationUPtr &info) override;
   bool _blocked = false;
 };
 
@@ -101,7 +101,7 @@ public:
   void set_limit(QUICOffset limit) override;
 
 private:
-  void _on_frame_lost(QUICFrameInformation &info) override;
+  void _on_frame_lost(QUICFrameInformationUPtr &info) override;
   bool _need_to_forward_limit();
 
   QUICRateAnalyzer _analyzer;

--- a/iocore/net/quic/QUICFrame.cc
+++ b/iocore/net/quic/QUICFrame.cc
@@ -338,7 +338,7 @@ QUICStreamFrame::store(uint8_t *buf, size_t *len, size_t limit, bool include_len
   }
 
   // Stream Data (*)
-  memcpy(buf + *len, this->data(), this->data_length());
+  memcpy(buf + *len, this->data()->start(), this->data_length());
   *len += this->data_length();
 
   return *len;
@@ -366,10 +366,10 @@ QUICStreamFrame::data_length() const
   return this->_block->read_avail();
 }
 
-const uint8_t *
+IOBufferBlock *
 QUICStreamFrame::data() const
 {
-  return reinterpret_cast<const uint8_t *>(this->_block->start());
+  return this->_block.get();
 }
 
 /**

--- a/iocore/net/quic/QUICFrame.cc
+++ b/iocore/net/quic/QUICFrame.cc
@@ -2887,8 +2887,9 @@ QUICStreamFrameUPtr
 QUICFrameFactory::create_stream_frame(Ptr<IOBufferBlock> &block, QUICStreamId stream_id, QUICOffset offset, bool last,
                                       bool has_offset_field, bool has_length_field, QUICFrameId id, QUICFrameGenerator *owner)
 {
-  QUICStreamFrame *frame = quicStreamFrameAllocator.alloc();
-  new (frame) QUICStreamFrame(block, stream_id, offset, last, has_offset_field, has_length_field, id, owner);
+  Ptr<IOBufferBlock> new_block = make_ptr<IOBufferBlock>(block->clone());
+  QUICStreamFrame *frame       = quicStreamFrameAllocator.alloc();
+  new (frame) QUICStreamFrame(new_block, stream_id, offset, last, has_offset_field, has_length_field, id, owner);
   return QUICStreamFrameUPtr(frame, &QUICFrameDeleter::delete_stream_frame);
 }
 

--- a/iocore/net/quic/QUICFrame.h
+++ b/iocore/net/quic/QUICFrame.h
@@ -103,7 +103,7 @@ public:
   size_t store(uint8_t *buf, size_t *len, size_t limit, bool include_length_field) const;
   QUICStreamId stream_id() const;
   QUICOffset offset() const;
-  const uint8_t *data() const;
+  IOBufferBlock *data() const;
   uint64_t data_length() const;
   bool has_offset_field() const;
   bool has_length_field() const;

--- a/iocore/net/quic/QUICFrameGenerator.cc
+++ b/iocore/net/quic/QUICFrameGenerator.cc
@@ -24,9 +24,9 @@
 #include "QUICFrameGenerator.h"
 
 void
-QUICFrameGenerator::_records_frame(QUICFrameId id, QUICFrameInformation info)
+QUICFrameGenerator::_records_frame(QUICFrameId id, QUICFrameInformationUPtr info)
 {
-  this->_info.insert(std::make_pair(id, info));
+  this->_info.insert(std::make_pair(id, std::move(info)));
 }
 
 std::vector<QUICEncryptionLevel>

--- a/iocore/net/quic/QUICFrameGenerator.h
+++ b/iocore/net/quic/QUICFrameGenerator.h
@@ -24,13 +24,7 @@
 #pragma once
 
 #include "QUICFrame.h"
-
-struct QUICFrameInformation {
-  QUICFrameType type;
-  QUICEncryptionLevel level;
-
-  uint8_t data[1024] = {};
-};
+#include "QUICFrameRetransmitter.h"
 
 class QUICFrameGenerator
 {
@@ -50,20 +44,20 @@ protected:
   }
 
   virtual void
-  _on_frame_acked(QUICFrameInformation &info)
+  _on_frame_acked(QUICFrameInformationUPtr &info)
   {
   }
 
   virtual void
-  _on_frame_lost(QUICFrameInformation &info)
+  _on_frame_lost(QUICFrameInformationUPtr &info)
   {
   }
 
   virtual std::vector<QUICEncryptionLevel> _encryption_level_filter();
   virtual bool _is_level_matched(QUICEncryptionLevel level);
-  void _records_frame(QUICFrameId id, QUICFrameInformation info);
+  void _records_frame(QUICFrameId id, QUICFrameInformationUPtr info);
 
 private:
   QUICFrameId _latest_frame_Id = 0;
-  std::map<QUICFrameId, QUICFrameInformation> _info;
+  std::map<QUICFrameId, QUICFrameInformationUPtr> _info;
 };

--- a/iocore/net/quic/QUICFrameRetransmitter.cc
+++ b/iocore/net/quic/QUICFrameRetransmitter.cc
@@ -27,6 +27,8 @@
 #include "QUICFrameGenerator.h"
 #include "QUICDebugNames.h"
 
+ClassAllocator<QUICFrameInformation> quicFrameInformationAllocator("quicFrameInformationAllocator");
+
 QUICFrameUPtr
 QUICFrameRetransmitter::create_retransmitted_frame(QUICEncryptionLevel level, uint16_t maximum_frame_size, QUICFrameId id,
                                                    QUICFrameGenerator *owner)

--- a/iocore/net/quic/QUICFrameRetransmitter.cc
+++ b/iocore/net/quic/QUICFrameRetransmitter.cc
@@ -1,0 +1,197 @@
+/** @file
+ *
+ *  A brief file description
+ *
+ *  @section license License
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "tscore/Diags.h"
+
+#include "QUICFrameRetransmitter.h"
+#include "QUICFrameGenerator.h"
+#include "QUICDebugNames.h"
+
+QUICFrameUPtr
+QUICFrameRetransmitter::create_retransmitted_frame(QUICEncryptionLevel level, uint16_t maximum_frame_size, QUICFrameId id,
+                                                   QUICFrameGenerator *owner)
+{
+  QUICFrameUPtr frame = QUICFrameFactory::create_null_frame();
+  if (this->_lost_frame_info_queue.empty()) {
+    return frame;
+  }
+
+  std::deque<QUICFrameInformationUPtr> tmp_queue;
+  for (auto it = this->_lost_frame_info_queue.begin(); it != this->_lost_frame_info_queue.end();
+       it      = this->_lost_frame_info_queue.begin()) {
+    QUICFrameInformationUPtr &info = *it;
+
+    if (info->level != QUICEncryptionLevel::NONE && info->level != level) {
+      // skip unmapped info.
+      tmp_queue.push_back(std::move(info));
+      this->_lost_frame_info_queue.pop_front();
+      continue;
+    }
+
+    switch (info->type) {
+    case QUICFrameType::STREAM:
+      frame = this->_create_stream_frame(info, maximum_frame_size, tmp_queue, id, owner);
+      break;
+    case QUICFrameType::RST_STREAM:
+      frame = this->_create_reset_stream_frame(info, maximum_frame_size, tmp_queue, id, owner);
+      break;
+    case QUICFrameType::STOP_SENDING:
+      frame = this->_create_stop_sending_frame(info, maximum_frame_size, tmp_queue, id, owner);
+      break;
+    case QUICFrameType::MAX_STREAM_DATA:
+      frame = this->_create_max_stream_data_frame(info, maximum_frame_size, tmp_queue, id, owner);
+      break;
+    case QUICFrameType::MAX_DATA:
+      frame = this->_create_max_data_frame(info, maximum_frame_size, tmp_queue, id, owner);
+      break;
+    default:
+      ink_assert("unknown frame type");
+      Error("unknown frame type: %s", QUICDebugNames::frame_type(info->type));
+    }
+
+    this->_lost_frame_info_queue.pop_front();
+    if (frame != nullptr) {
+      break;
+    }
+  }
+
+  this->_append_info_queue(tmp_queue);
+  return frame;
+}
+
+void
+QUICFrameRetransmitter::save_frame_info(QUICFrameInformationUPtr &info)
+{
+  for (auto type : RETRANSMITTED_FRAME_TYPE) {
+    if (type == info->type) {
+      this->_lost_frame_info_queue.push_back(std::move(info));
+      break;
+    }
+  }
+}
+
+void
+QUICFrameRetransmitter::_append_info_queue(std::deque<QUICFrameInformationUPtr> &tmp_queue)
+{
+  auto it = tmp_queue.begin();
+  while (it != tmp_queue.end()) {
+    this->_lost_frame_info_queue.push_back(std::move(*it));
+    tmp_queue.pop_front();
+    it = tmp_queue.begin();
+  }
+}
+
+QUICFrameUPtr
+QUICFrameRetransmitter::_create_stream_frame(QUICFrameInformationUPtr &info, uint16_t maximum_frame_size,
+                                             std::deque<QUICFrameInformationUPtr> &tmp_queue, QUICFrameId id,
+                                             QUICFrameGenerator *owner)
+{
+  StreamFrameInfo *stream_info = reinterpret_cast<StreamFrameInfo *>(info->data);
+  // FIXME: has_offset and has_length should be configurable.
+  auto frame = QUICFrameFactory::create_stream_frame(stream_info->block, stream_info->stream_id, stream_info->offset,
+                                                     stream_info->has_fin, true, true, id, owner);
+  if (frame->size() > maximum_frame_size) {
+    auto new_frame = QUICFrameFactory::split_frame(frame.get(), maximum_frame_size);
+    if (new_frame == nullptr) {
+      // can not split stream frame. Because of too small maximum_frame_size.
+      tmp_queue.push_back(std::move(info));
+      return QUICFrameFactory::create_null_frame();
+    } else {
+      QUICStreamFrame *stream_frame = static_cast<QUICStreamFrame *>(frame.get());
+      stream_info->block->consume(stream_frame->data_length());
+      stream_info->offset += stream_frame->data_length();
+      ink_assert(frame->size() <= maximum_frame_size);
+      tmp_queue.push_back(std::move(info));
+      return frame;
+    }
+  }
+
+  stream_info->block = nullptr;
+  ink_assert(frame != nullptr);
+  return frame;
+}
+
+QUICFrameUPtr
+QUICFrameRetransmitter::_create_reset_stream_frame(QUICFrameInformationUPtr &info, uint16_t maximum_frame_size,
+                                                   std::deque<QUICFrameInformationUPtr> &tmp_queue, QUICFrameId id,
+                                                   QUICFrameGenerator *owner)
+{
+  RstStreamFrameInfo *rst_info = reinterpret_cast<RstStreamFrameInfo *>(info->data);
+  auto frame =
+    QUICFrameFactory::create_rst_stream_frame(rst_info->stream_id, rst_info->error_code, rst_info->final_offset, id, owner);
+  if (frame->size() > maximum_frame_size) {
+    tmp_queue.push_back(std::move(info));
+    return QUICFrameFactory::create_null_frame();
+  }
+
+  ink_assert(frame != nullptr);
+  return frame;
+}
+
+QUICFrameUPtr
+QUICFrameRetransmitter::_create_max_stream_data_frame(QUICFrameInformationUPtr &info, uint16_t maximum_frame_size,
+                                                      std::deque<QUICFrameInformationUPtr> &tmp_queue, QUICFrameId id,
+                                                      QUICFrameGenerator *owner)
+{
+  MaxStreamDataFrameInfo *frame_info = reinterpret_cast<MaxStreamDataFrameInfo *>(info->data);
+  auto frame = QUICFrameFactory::create_max_stream_data_frame(frame_info->stream_id, frame_info->maximum_stream_data, id, owner);
+  if (frame->size() > maximum_frame_size) {
+    tmp_queue.push_back(std::move(info));
+    return QUICFrameFactory::create_null_frame();
+  }
+
+  ink_assert(frame != nullptr);
+  return frame;
+}
+
+QUICFrameUPtr
+QUICFrameRetransmitter::_create_max_data_frame(QUICFrameInformationUPtr &info, uint16_t maximum_frame_size,
+                                               std::deque<QUICFrameInformationUPtr> &tmp_queue, QUICFrameId id,
+                                               QUICFrameGenerator *owner)
+{
+  MaxDataFrameInfo *frame_info = reinterpret_cast<MaxDataFrameInfo *>(info->data);
+  auto frame                   = QUICFrameFactory::create_max_data_frame(frame_info->maximum_data, id, owner);
+  if (frame->size() > maximum_frame_size) {
+    tmp_queue.push_back(std::move(info));
+    return QUICFrameFactory::create_null_frame();
+  }
+
+  ink_assert(frame != nullptr);
+  return frame;
+}
+
+QUICFrameUPtr
+QUICFrameRetransmitter::_create_stop_sending_frame(QUICFrameInformationUPtr &info, uint16_t maximum_frame_size,
+                                                   std::deque<QUICFrameInformationUPtr> &tmp_queue, QUICFrameId id,
+                                                   QUICFrameGenerator *owner)
+{
+  StopSendingFrameInfo *frame_info = reinterpret_cast<StopSendingFrameInfo *>(info->data);
+  auto frame = QUICFrameFactory::create_stop_sending_frame(frame_info->stream_id, frame_info->error_code, id, owner);
+  if (frame->size() > maximum_frame_size) {
+    tmp_queue.push_back(std::move(info));
+    return QUICFrameFactory::create_null_frame();
+  }
+
+  ink_assert(frame != nullptr);
+  return frame;
+}

--- a/iocore/net/quic/QUICFrameRetransmitter.cc
+++ b/iocore/net/quic/QUICFrameRetransmitter.cc
@@ -54,18 +54,6 @@ QUICFrameRetransmitter::create_retransmitted_frame(QUICEncryptionLevel level, ui
     case QUICFrameType::STREAM:
       frame = this->_create_stream_frame(info, maximum_frame_size, tmp_queue, id, owner);
       break;
-    case QUICFrameType::RST_STREAM:
-      frame = this->_create_reset_stream_frame(info, maximum_frame_size, tmp_queue, id, owner);
-      break;
-    case QUICFrameType::STOP_SENDING:
-      frame = this->_create_stop_sending_frame(info, maximum_frame_size, tmp_queue, id, owner);
-      break;
-    case QUICFrameType::MAX_STREAM_DATA:
-      frame = this->_create_max_stream_data_frame(info, maximum_frame_size, tmp_queue, id, owner);
-      break;
-    case QUICFrameType::MAX_DATA:
-      frame = this->_create_max_data_frame(info, maximum_frame_size, tmp_queue, id, owner);
-      break;
     default:
       ink_assert("unknown frame type");
       Error("unknown frame type: %s", QUICDebugNames::frame_type(info->type));
@@ -129,71 +117,6 @@ QUICFrameRetransmitter::_create_stream_frame(QUICFrameInformationUPtr &info, uin
   }
 
   stream_info->block = nullptr;
-  ink_assert(frame != nullptr);
-  return frame;
-}
-
-QUICFrameUPtr
-QUICFrameRetransmitter::_create_reset_stream_frame(QUICFrameInformationUPtr &info, uint16_t maximum_frame_size,
-                                                   std::deque<QUICFrameInformationUPtr> &tmp_queue, QUICFrameId id,
-                                                   QUICFrameGenerator *owner)
-{
-  RstStreamFrameInfo *rst_info = reinterpret_cast<RstStreamFrameInfo *>(info->data);
-  auto frame =
-    QUICFrameFactory::create_rst_stream_frame(rst_info->stream_id, rst_info->error_code, rst_info->final_offset, id, owner);
-  if (frame->size() > maximum_frame_size) {
-    tmp_queue.push_back(std::move(info));
-    return QUICFrameFactory::create_null_frame();
-  }
-
-  ink_assert(frame != nullptr);
-  return frame;
-}
-
-QUICFrameUPtr
-QUICFrameRetransmitter::_create_max_stream_data_frame(QUICFrameInformationUPtr &info, uint16_t maximum_frame_size,
-                                                      std::deque<QUICFrameInformationUPtr> &tmp_queue, QUICFrameId id,
-                                                      QUICFrameGenerator *owner)
-{
-  MaxStreamDataFrameInfo *frame_info = reinterpret_cast<MaxStreamDataFrameInfo *>(info->data);
-  auto frame = QUICFrameFactory::create_max_stream_data_frame(frame_info->stream_id, frame_info->maximum_stream_data, id, owner);
-  if (frame->size() > maximum_frame_size) {
-    tmp_queue.push_back(std::move(info));
-    return QUICFrameFactory::create_null_frame();
-  }
-
-  ink_assert(frame != nullptr);
-  return frame;
-}
-
-QUICFrameUPtr
-QUICFrameRetransmitter::_create_max_data_frame(QUICFrameInformationUPtr &info, uint16_t maximum_frame_size,
-                                               std::deque<QUICFrameInformationUPtr> &tmp_queue, QUICFrameId id,
-                                               QUICFrameGenerator *owner)
-{
-  MaxDataFrameInfo *frame_info = reinterpret_cast<MaxDataFrameInfo *>(info->data);
-  auto frame                   = QUICFrameFactory::create_max_data_frame(frame_info->maximum_data, id, owner);
-  if (frame->size() > maximum_frame_size) {
-    tmp_queue.push_back(std::move(info));
-    return QUICFrameFactory::create_null_frame();
-  }
-
-  ink_assert(frame != nullptr);
-  return frame;
-}
-
-QUICFrameUPtr
-QUICFrameRetransmitter::_create_stop_sending_frame(QUICFrameInformationUPtr &info, uint16_t maximum_frame_size,
-                                                   std::deque<QUICFrameInformationUPtr> &tmp_queue, QUICFrameId id,
-                                                   QUICFrameGenerator *owner)
-{
-  StopSendingFrameInfo *frame_info = reinterpret_cast<StopSendingFrameInfo *>(info->data);
-  auto frame = QUICFrameFactory::create_stop_sending_frame(frame_info->stream_id, frame_info->error_code, id, owner);
-  if (frame->size() > maximum_frame_size) {
-    tmp_queue.push_back(std::move(info));
-    return QUICFrameFactory::create_null_frame();
-  }
-
   ink_assert(frame != nullptr);
   return frame;
 }

--- a/iocore/net/quic/QUICFrameRetransmitter.h
+++ b/iocore/net/quic/QUICFrameRetransmitter.h
@@ -1,0 +1,114 @@
+/** @file
+ *
+ *  A brief file description
+ *
+ *  @section license License
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#include <deque>
+#include "QUICFrame.h"
+
+class QUICFrameGenerator;
+
+struct QUICFrameInformation {
+  QUICFrameType type;
+  QUICEncryptionLevel level;
+
+  uint8_t data[1024] = {};
+};
+
+typedef std::unique_ptr<QUICFrameInformation> QUICFrameInformationUPtr;
+
+constexpr QUICFrameType RETRANSMITTED_FRAME_TYPE[] = {QUICFrameType::STREAM, QUICFrameType::STOP_SENDING,
+                                                      QUICFrameType::MAX_STREAM_DATA, QUICFrameType::RST_STREAM,
+                                                      QUICFrameType::MAX_DATA};
+
+struct StreamFrameInfo {
+  QUICStreamId stream_id;
+  QUICOffset offset;
+  bool has_fin;
+  Ptr<IOBufferBlock> block;
+};
+
+struct MaxStreamDataFrameInfo {
+  QUICStreamId stream_id;
+  uint64_t maximum_stream_data;
+};
+
+struct RstStreamFrameInfo {
+  QUICStreamId stream_id;
+  QUICAppErrorCode error_code;
+  QUICOffset final_offset;
+};
+
+struct StopSendingFrameInfo {
+  QUICStreamId stream_id;
+  QUICAppErrorCode error_code;
+};
+
+struct MaxDataFrameInfo {
+  uint64_t maximum_data;
+};
+
+struct BlockedFrameInfo {
+  QUICOffset offset;
+};
+
+struct StreamBlockedFrameInfo {
+  QUICStreamId stream_id;
+  QUICOffset offset;
+};
+
+struct CryptoFrameInfo {
+  QUICOffset offset;
+  Ptr<IOBufferBlock> block;
+};
+
+struct AckFrameInfo {
+  QUICPacketNumber largest_acknowledged;
+};
+
+class QUICFrameRetransmitter
+{
+public:
+  virtual QUICFrameUPtr create_retransmitted_frame(QUICEncryptionLevel level, uint16_t maximum_frame_size, QUICFrameId id = 0,
+                                                   QUICFrameGenerator *owner = nullptr);
+  virtual void save_frame_info(QUICFrameInformationUPtr &info);
+
+private:
+  QUICFrameUPtr _create_stream_frame(QUICFrameInformationUPtr &info, uint16_t maximum_frame_size,
+                                     std::deque<QUICFrameInformationUPtr> &tmp_queue, QUICFrameId id, QUICFrameGenerator *owner);
+  QUICFrameUPtr _create_reset_stream_frame(QUICFrameInformationUPtr &info, uint16_t maximum_frame_size,
+                                           std::deque<QUICFrameInformationUPtr> &tmp_queue, QUICFrameId id,
+                                           QUICFrameGenerator *owner);
+  QUICFrameUPtr _create_max_stream_data_frame(QUICFrameInformationUPtr &info, uint16_t maximum_frame_size,
+                                              std::deque<QUICFrameInformationUPtr> &tmp_queue, QUICFrameId id,
+                                              QUICFrameGenerator *owner);
+  QUICFrameUPtr _create_stop_sending_frame(QUICFrameInformationUPtr &info, uint16_t maximum_frame_size,
+                                           std::deque<QUICFrameInformationUPtr> &tmp_queue, QUICFrameId id,
+                                           QUICFrameGenerator *owner);
+  QUICFrameUPtr _create_max_data_frame(QUICFrameInformationUPtr &info, uint16_t maximum_frame_size,
+                                       std::deque<QUICFrameInformationUPtr> &tmp_queue, QUICFrameId id, QUICFrameGenerator *owner);
+
+  void _append_info_queue(std::deque<QUICFrameInformationUPtr> &tmp_queue);
+
+  std::deque<QUICFrameInformationUPtr> _lost_frame_info_queue;
+};

--- a/iocore/net/quic/QUICFrameRetransmitter.h
+++ b/iocore/net/quic/QUICFrameRetransmitter.h
@@ -41,9 +41,7 @@ struct QUICFrameInformationDeleter {
 
 using QUICFrameInformationUPtr = std::unique_ptr<QUICFrameInformation, QUICFrameInformationDeleter>;
 
-constexpr QUICFrameType RETRANSMITTED_FRAME_TYPE[] = {QUICFrameType::STREAM, QUICFrameType::STOP_SENDING,
-                                                      QUICFrameType::MAX_STREAM_DATA, QUICFrameType::RST_STREAM,
-                                                      QUICFrameType::MAX_DATA};
+constexpr QUICFrameType RETRANSMITTED_FRAME_TYPE[] = {QUICFrameType::STREAM};
 
 struct StreamFrameInfo {
   QUICStreamId stream_id;
@@ -52,38 +50,18 @@ struct StreamFrameInfo {
   Ptr<IOBufferBlock> block;
 };
 
-struct MaxStreamDataFrameInfo {
-  QUICStreamId stream_id;
-  uint64_t maximum_stream_data;
+struct CryptoFrameInfo {
+  QUICOffset offset;
+  Ptr<IOBufferBlock> block;
 };
 
 struct RstStreamFrameInfo {
-  QUICStreamId stream_id;
   QUICAppErrorCode error_code;
   QUICOffset final_offset;
 };
 
 struct StopSendingFrameInfo {
-  QUICStreamId stream_id;
   QUICAppErrorCode error_code;
-};
-
-struct MaxDataFrameInfo {
-  uint64_t maximum_data;
-};
-
-struct BlockedFrameInfo {
-  QUICOffset offset;
-};
-
-struct StreamBlockedFrameInfo {
-  QUICStreamId stream_id;
-  QUICOffset offset;
-};
-
-struct CryptoFrameInfo {
-  QUICOffset offset;
-  Ptr<IOBufferBlock> block;
 };
 
 struct AckFrameInfo {
@@ -100,17 +78,6 @@ public:
 private:
   QUICFrameUPtr _create_stream_frame(QUICFrameInformationUPtr &info, uint16_t maximum_frame_size,
                                      std::deque<QUICFrameInformationUPtr> &tmp_queue, QUICFrameId id, QUICFrameGenerator *owner);
-  QUICFrameUPtr _create_reset_stream_frame(QUICFrameInformationUPtr &info, uint16_t maximum_frame_size,
-                                           std::deque<QUICFrameInformationUPtr> &tmp_queue, QUICFrameId id,
-                                           QUICFrameGenerator *owner);
-  QUICFrameUPtr _create_max_stream_data_frame(QUICFrameInformationUPtr &info, uint16_t maximum_frame_size,
-                                              std::deque<QUICFrameInformationUPtr> &tmp_queue, QUICFrameId id,
-                                              QUICFrameGenerator *owner);
-  QUICFrameUPtr _create_stop_sending_frame(QUICFrameInformationUPtr &info, uint16_t maximum_frame_size,
-                                           std::deque<QUICFrameInformationUPtr> &tmp_queue, QUICFrameId id,
-                                           QUICFrameGenerator *owner);
-  QUICFrameUPtr _create_max_data_frame(QUICFrameInformationUPtr &info, uint16_t maximum_frame_size,
-                                       std::deque<QUICFrameInformationUPtr> &tmp_queue, QUICFrameId id, QUICFrameGenerator *owner);
 
   void _append_info_queue(std::deque<QUICFrameInformationUPtr> &tmp_queue);
 

--- a/iocore/net/quic/QUICStream.cc
+++ b/iocore/net/quic/QUICStream.cc
@@ -527,7 +527,7 @@ QUICStream::generate_frame(QUICEncryptionLevel level, uint64_t connection_credit
 void
 QUICStream::_records_stream_frame(const QUICStreamFrame &frame, Ptr<IOBufferBlock> &block)
 {
-  QUICFrameInformationUPtr info = std::make_unique<QUICFrameInformation>();
+  QUICFrameInformationUPtr info = QUICFrameInformationUPtr(quicFrameInformationAllocator.alloc());
   info->type                    = frame.type();
   StreamFrameInfo *frame_info   = reinterpret_cast<StreamFrameInfo *>(info->data);
   frame_info->offset            = frame.offset();
@@ -539,7 +539,7 @@ QUICStream::_records_stream_frame(const QUICStreamFrame &frame, Ptr<IOBufferBloc
 void
 QUICStream::_records_rst_stream_frame(const QUICRstStreamFrame &frame)
 {
-  QUICFrameInformationUPtr info  = std::make_unique<QUICFrameInformation>();
+  QUICFrameInformationUPtr info  = QUICFrameInformationUPtr(quicFrameInformationAllocator.alloc());
   info->type                     = frame.type();
   RstStreamFrameInfo *frame_info = reinterpret_cast<RstStreamFrameInfo *>(info->data);
   frame_info->error_code         = frame.error_code();
@@ -550,7 +550,7 @@ QUICStream::_records_rst_stream_frame(const QUICRstStreamFrame &frame)
 void
 QUICStream::_records_stop_sending_frame(const QUICStopSendingFrame &frame)
 {
-  QUICFrameInformationUPtr info    = std::make_unique<QUICFrameInformation>();
+  QUICFrameInformationUPtr info    = QUICFrameInformationUPtr(quicFrameInformationAllocator.alloc());
   info->type                       = frame.type();
   StopSendingFrameInfo *frame_info = reinterpret_cast<StopSendingFrameInfo *>(info->data);
   frame_info->error_code           = frame.error_code();
@@ -879,7 +879,7 @@ QUICCryptoStream::generate_frame(QUICEncryptionLevel level, uint64_t connection_
   block->_end = std::min(block->start() + frame_payload_size, block->_buf_end);
   ink_assert(static_cast<uint64_t>(block->read_avail()) == frame_payload_size);
 
-  QUICFrameInformationUPtr info      = std::make_unique<QUICFrameInformation>();
+  QUICFrameInformationUPtr info      = QUICFrameInformationUPtr(quicFrameInformationAllocator.alloc());
   info->type                         = QUICFrameType::CRYPTO;
   QUICFrameId frame_id               = this->_issue_frame_id();
   CryptoFrameInfo *crypto_frame_info = reinterpret_cast<CryptoFrameInfo *>(info->data);

--- a/iocore/net/quic/QUICStream.cc
+++ b/iocore/net/quic/QUICStream.cc
@@ -338,8 +338,8 @@ QUICStream::recv(const QUICStreamFrame &frame)
   while (new_frame != nullptr) {
     stream_frame = std::static_pointer_cast<const QUICStreamFrame>(new_frame);
 
-    this->_write_to_read_vio(stream_frame->offset(), stream_frame->data(), stream_frame->data_length(),
-                             stream_frame->has_fin_flag());
+    this->_write_to_read_vio(stream_frame->offset(), reinterpret_cast<uint8_t *>(stream_frame->data()->start()),
+                             stream_frame->data_length(), stream_frame->has_fin_flag());
     this->_state.update_with_receiving_frame(*new_frame);
 
     new_frame = this->_received_stream_frame_buffer.pop();

--- a/iocore/net/quic/test/test_QUICFrame.cc
+++ b/iocore/net/quic/test/test_QUICFrame.cc
@@ -83,7 +83,7 @@ TEST_CASE("Load STREAM Frame", "[quic]")
     CHECK(stream_frame->stream_id() == 0x01);
     CHECK(stream_frame->offset() == 0x00);
     CHECK(stream_frame->data_length() == 4);
-    CHECK(memcmp(stream_frame->data(), "\x01\x02\x03\x04", 4) == 0);
+    CHECK(memcmp(stream_frame->data()->start(), "\x01\x02\x03\x04", 4) == 0);
     CHECK(stream_frame->has_fin_flag() == false);
   }
 
@@ -102,7 +102,7 @@ TEST_CASE("Load STREAM Frame", "[quic]")
     CHECK(stream_frame->stream_id() == 0x01);
     CHECK(stream_frame->offset() == 0x00);
     CHECK(stream_frame->data_length() == 5);
-    CHECK(memcmp(stream_frame->data(), "\x01\x02\x03\x04\x05", 5) == 0);
+    CHECK(memcmp(stream_frame->data()->start(), "\x01\x02\x03\x04\x05", 5) == 0);
     CHECK(stream_frame->has_fin_flag() == false);
   }
 
@@ -123,7 +123,7 @@ TEST_CASE("Load STREAM Frame", "[quic]")
     CHECK(stream_frame->stream_id() == 0x01);
     CHECK(stream_frame->offset() == 0x02);
     CHECK(stream_frame->data_length() == 5);
-    CHECK(memcmp(stream_frame->data(), "\x01\x02\x03\x04\x05", 5) == 0);
+    CHECK(memcmp(stream_frame->data()->start(), "\x01\x02\x03\x04\x05", 5) == 0);
     CHECK(stream_frame->has_fin_flag() == false);
   }
 
@@ -144,7 +144,7 @@ TEST_CASE("Load STREAM Frame", "[quic]")
     CHECK(stream_frame->stream_id() == 0x01);
     CHECK(stream_frame->offset() == 0x02);
     CHECK(stream_frame->data_length() == 5);
-    CHECK(memcmp(stream_frame->data(), "\x01\x02\x03\x04\x05", 5) == 0);
+    CHECK(memcmp(stream_frame->data()->start(), "\x01\x02\x03\x04\x05", 5) == 0);
     CHECK(stream_frame->has_fin_flag() == true);
   }
 
@@ -397,11 +397,11 @@ TEST_CASE("Store STREAM Frame", "[quic]")
     QUICStreamFrame *stream_frame2 = dynamic_cast<QUICStreamFrame *>(stream_frame->split(16));
     CHECK(stream_frame->stream_id() == 0x01);
     CHECK(stream_frame->data_length() == 5);
-    CHECK(memcmp(stream_frame->data(), "\x01\x02\x03\x04\x05", stream_frame->data_length()) == 0);
+    CHECK(memcmp(stream_frame->data()->start(), "\x01\x02\x03\x04\x05", stream_frame->data_length()) == 0);
     CHECK(stream_frame->offset() == 0x100000000);
 
     CHECK(stream_frame2->data_length() == 5);
-    CHECK(memcmp(stream_frame2->data(), "\x11\x22\x33\x44\x55", stream_frame2->data_length()) == 0);
+    CHECK(memcmp(stream_frame2->data()->start(), "\x11\x22\x33\x44\x55", stream_frame2->data_length()) == 0);
     CHECK(stream_frame2->offset() == 0x100000000 + 5);
     CHECK(stream_frame2->stream_id() == 0x01);
 

--- a/iocore/net/quic/test/test_QUICFrameRetransmitter.cc
+++ b/iocore/net/quic/test/test_QUICFrameRetransmitter.cc
@@ -112,7 +112,7 @@ TEST_CASE("QUICFrameRetransmitter successfully create stream frame", "[quic]")
   CHECK(stream_frame->stream_id() == 0x12345);
   CHECK(stream_frame->offset() == 0x67890);
   CHECK(stream_frame->data_length() == sizeof(data));
-  CHECK(memcmp(stream_frame->data(), data, sizeof(data)) == 0);
+  CHECK(memcmp(stream_frame->data()->start(), data, sizeof(data)) == 0);
   frame = QUICFrameFactory::create_null_frame();
   // Becasue the info has been released, the refcount should be 1 (var block).
   CHECK(block->refcount() == 1);
@@ -147,7 +147,7 @@ TEST_CASE("QUICFrameRetransmitter successfully split stream frame", "[quic]")
   CHECK(stream_frame->size() <= 15);
 
   auto size = stream_frame->data_length();
-  CHECK(memcmp(stream_frame->data(), data, stream_frame->data_length()) == 0);
+  CHECK(memcmp(stream_frame->data()->start(), data, stream_frame->data_length()) == 0);
   // one for var block, one for the left data which saved in retransmitter
   CHECK(block->data->refcount() == 2);
   // one for var block, one for the left data which saved in retransmitter, one for var frame
@@ -164,7 +164,7 @@ TEST_CASE("QUICFrameRetransmitter successfully split stream frame", "[quic]")
   CHECK(stream_frame->stream_id() == 0x12345);
   CHECK(stream_frame->offset() == 0x67890 + size);
   CHECK(stream_frame->data_length() == sizeof(data) - size);
-  CHECK(memcmp(stream_frame->data(), data + size, stream_frame->data_length()) == 0);
+  CHECK(memcmp(stream_frame->data()->start(), data + size, stream_frame->data_length()) == 0);
   CHECK(block->refcount() == 1); // one for var block
 
   frame = QUICFrameFactory::create_null_frame();

--- a/iocore/net/quic/test/test_QUICFrameRetransmitter.cc
+++ b/iocore/net/quic/test/test_QUICFrameRetransmitter.cc
@@ -1,0 +1,163 @@
+/** @file
+ *
+ *  A brief file description
+ *
+ *  @section license License
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "catch.hpp"
+
+#include "QUICFrameRetransmitter.h"
+
+constexpr static uint8_t data[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10};
+
+TEST_CASE("QUICFrameRetransmitter ignore frame which can not be retranmistted", "[quic]")
+{
+  QUICFrameRetransmitter retransmitter;
+  QUICFrameInformationUPtr info = std::make_unique<QUICFrameInformation>();
+  info->type                    = QUICFrameType::PING;
+  info->level                   = QUICEncryptionLevel::NONE;
+
+  retransmitter.save_frame_info(info);
+  CHECK(retransmitter.create_retransmitted_frame(QUICEncryptionLevel::INITIAL, UINT16_MAX) == nullptr);
+}
+
+TEST_CASE("QUICFrameRetransmitter ignore frame which can not be split", "[quic]")
+{
+  QUICFrameRetransmitter retransmitter;
+  QUICFrameInformationUPtr info = std::make_unique<QUICFrameInformation>();
+  info->type                    = QUICFrameType::STOP_SENDING;
+  info->level                   = QUICEncryptionLevel::NONE;
+
+  retransmitter.save_frame_info(info);
+  CHECK(retransmitter.create_retransmitted_frame(QUICEncryptionLevel::INITIAL, 0) == nullptr);
+}
+
+TEST_CASE("QUICFrameRetransmitter ignore frame which has wrong level", "[quic]")
+{
+  QUICFrameRetransmitter retransmitter;
+  QUICFrameInformationUPtr info = std::make_unique<QUICFrameInformation>();
+  info->type                    = QUICFrameType::STOP_SENDING;
+  info->level                   = QUICEncryptionLevel::HANDSHAKE;
+
+  retransmitter.save_frame_info(info);
+  CHECK(retransmitter.create_retransmitted_frame(QUICEncryptionLevel::INITIAL, UINT16_MAX) == nullptr);
+}
+
+TEST_CASE("QUICFrameRetransmitter successfully create retransmitted frame", "[quic]")
+{
+  QUICFrameRetransmitter retransmitter;
+  QUICFrameInformationUPtr info = std::make_unique<QUICFrameInformation>();
+  info->type                    = QUICFrameType::STOP_SENDING;
+  info->level                   = QUICEncryptionLevel::INITIAL;
+
+  retransmitter.save_frame_info(info);
+
+  auto frame = retransmitter.create_retransmitted_frame(QUICEncryptionLevel::INITIAL, UINT16_MAX);
+  CHECK(frame != nullptr);
+  CHECK(frame->type() == QUICFrameType::STOP_SENDING);
+}
+
+TEST_CASE("QUICFrameRetransmitter successfully create stream frame", "[quic]")
+{
+  QUICFrameRetransmitter retransmitter;
+  QUICFrameInformationUPtr info = std::make_unique<QUICFrameInformation>();
+  info->type                    = QUICFrameType::STREAM;
+  info->level                   = QUICEncryptionLevel::INITIAL;
+
+  Ptr<IOBufferBlock> block = make_ptr<IOBufferBlock>(new_IOBufferBlock());
+  block->alloc();
+  memcpy(block->start(), data, sizeof(data));
+  block->fill(sizeof(data));
+
+  StreamFrameInfo *frame_info = reinterpret_cast<StreamFrameInfo *>(info->data);
+  frame_info->stream_id       = 0x12345;
+  frame_info->offset          = 0x67890;
+  frame_info->block           = block;
+
+  CHECK(block->refcount() == 2);
+  retransmitter.save_frame_info(info);
+  CHECK(block->refcount() == 2); // block's refcount doesn't change
+
+  auto frame = retransmitter.create_retransmitted_frame(QUICEncryptionLevel::INITIAL, UINT16_MAX);
+  CHECK(frame != nullptr);
+  CHECK(frame->type() == QUICFrameType::STREAM);
+  auto stream_frame = static_cast<QUICStreamFrame *>(frame.get());
+  CHECK(stream_frame->stream_id() == 0x12345);
+  CHECK(stream_frame->offset() == 0x67890);
+  CHECK(stream_frame->data_length() == sizeof(data));
+  CHECK(memcmp(stream_frame->data(), data, sizeof(data)) == 0);
+  frame = QUICFrameFactory::create_null_frame();
+  // Becasue the info has been released, the refcount should be 1 (var block).
+  CHECK(block->refcount() == 1);
+}
+
+TEST_CASE("QUICFrameRetransmitter successfully split stream frame", "[quic]")
+{
+  QUICFrameRetransmitter retransmitter;
+  QUICFrameInformationUPtr info = std::make_unique<QUICFrameInformation>();
+  info->type                    = QUICFrameType::STREAM;
+  info->level                   = QUICEncryptionLevel::INITIAL;
+
+  Ptr<IOBufferBlock> block = make_ptr<IOBufferBlock>(new_IOBufferBlock());
+  block->alloc();
+  memcpy(block->start(), data, sizeof(data));
+  block->fill(sizeof(data));
+
+  StreamFrameInfo *frame_info = reinterpret_cast<StreamFrameInfo *>(info->data);
+  frame_info->stream_id       = 0x12345;
+  frame_info->offset          = 0x67890;
+  frame_info->block           = block;
+  CHECK(block->refcount() == 2);
+
+  retransmitter.save_frame_info(info);
+
+  auto frame = retransmitter.create_retransmitted_frame(QUICEncryptionLevel::INITIAL, 15);
+  CHECK(frame != nullptr);
+  CHECK(frame->type() == QUICFrameType::STREAM);
+  auto stream_frame = static_cast<QUICStreamFrame *>(frame.get());
+  CHECK(stream_frame->stream_id() == 0x12345);
+  CHECK(stream_frame->offset() == 0x67890);
+  CHECK(stream_frame->size() <= 15);
+
+  auto size = stream_frame->data_length();
+  CHECK(memcmp(stream_frame->data(), data, stream_frame->data_length()) == 0);
+  // one for var block, one for the left data which saved in retransmitter
+  CHECK(block->data->refcount() == 2);
+  // one for var block, one for the left data which saved in retransmitter, one for var frame
+  CHECK(block->refcount() == 2);
+  frame = QUICFrameFactory::create_null_frame();
+  // one for var block, one for var info
+  CHECK(block->refcount() == 2);
+  CHECK(block->data->refcount() == 1);
+
+  frame = retransmitter.create_retransmitted_frame(QUICEncryptionLevel::INITIAL, UINT16_MAX);
+  CHECK(frame != nullptr);
+  CHECK(frame->type() == QUICFrameType::STREAM);
+  stream_frame = static_cast<QUICStreamFrame *>(frame.get());
+  CHECK(stream_frame->stream_id() == 0x12345);
+  CHECK(stream_frame->offset() == 0x67890 + size);
+  CHECK(stream_frame->data_length() == sizeof(data) - size);
+  CHECK(memcmp(stream_frame->data(), data + size, stream_frame->data_length()) == 0);
+  CHECK(block->refcount() == 1); // one for var block
+
+  frame = QUICFrameFactory::create_null_frame();
+  CHECK(block->refcount() == 1);
+  CHECK(block->data->refcount() == 1);
+}

--- a/iocore/net/quic/test/test_QUICFrameRetransmitter.cc
+++ b/iocore/net/quic/test/test_QUICFrameRetransmitter.cc
@@ -30,7 +30,7 @@ constexpr static uint8_t data[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x0
 TEST_CASE("QUICFrameRetransmitter ignore frame which can not be retranmistted", "[quic]")
 {
   QUICFrameRetransmitter retransmitter;
-  QUICFrameInformationUPtr info = std::make_unique<QUICFrameInformation>();
+  QUICFrameInformationUPtr info = QUICFrameInformationUPtr(quicFrameInformationAllocator.alloc());
   info->type                    = QUICFrameType::PING;
   info->level                   = QUICEncryptionLevel::NONE;
 
@@ -41,7 +41,7 @@ TEST_CASE("QUICFrameRetransmitter ignore frame which can not be retranmistted", 
 TEST_CASE("QUICFrameRetransmitter ignore frame which can not be split", "[quic]")
 {
   QUICFrameRetransmitter retransmitter;
-  QUICFrameInformationUPtr info = std::make_unique<QUICFrameInformation>();
+  QUICFrameInformationUPtr info = QUICFrameInformationUPtr(quicFrameInformationAllocator.alloc());
   info->type                    = QUICFrameType::STOP_SENDING;
   info->level                   = QUICEncryptionLevel::NONE;
 
@@ -52,7 +52,7 @@ TEST_CASE("QUICFrameRetransmitter ignore frame which can not be split", "[quic]"
 TEST_CASE("QUICFrameRetransmitter ignore frame which has wrong level", "[quic]")
 {
   QUICFrameRetransmitter retransmitter;
-  QUICFrameInformationUPtr info = std::make_unique<QUICFrameInformation>();
+  QUICFrameInformationUPtr info = QUICFrameInformationUPtr(quicFrameInformationAllocator.alloc());
   info->type                    = QUICFrameType::STOP_SENDING;
   info->level                   = QUICEncryptionLevel::HANDSHAKE;
 
@@ -63,7 +63,7 @@ TEST_CASE("QUICFrameRetransmitter ignore frame which has wrong level", "[quic]")
 TEST_CASE("QUICFrameRetransmitter successfully create retransmitted frame", "[quic]")
 {
   QUICFrameRetransmitter retransmitter;
-  QUICFrameInformationUPtr info = std::make_unique<QUICFrameInformation>();
+  QUICFrameInformationUPtr info = QUICFrameInformationUPtr(quicFrameInformationAllocator.alloc());
   info->type                    = QUICFrameType::STOP_SENDING;
   info->level                   = QUICEncryptionLevel::INITIAL;
 
@@ -77,7 +77,7 @@ TEST_CASE("QUICFrameRetransmitter successfully create retransmitted frame", "[qu
 TEST_CASE("QUICFrameRetransmitter successfully create stream frame", "[quic]")
 {
   QUICFrameRetransmitter retransmitter;
-  QUICFrameInformationUPtr info = std::make_unique<QUICFrameInformation>();
+  QUICFrameInformationUPtr info = QUICFrameInformationUPtr(quicFrameInformationAllocator.alloc());
   info->type                    = QUICFrameType::STREAM;
   info->level                   = QUICEncryptionLevel::INITIAL;
 
@@ -111,7 +111,7 @@ TEST_CASE("QUICFrameRetransmitter successfully create stream frame", "[quic]")
 TEST_CASE("QUICFrameRetransmitter successfully split stream frame", "[quic]")
 {
   QUICFrameRetransmitter retransmitter;
-  QUICFrameInformationUPtr info = std::make_unique<QUICFrameInformation>();
+  QUICFrameInformationUPtr info = QUICFrameInformationUPtr(quicFrameInformationAllocator.alloc());
   info->type                    = QUICFrameType::STREAM;
   info->level                   = QUICEncryptionLevel::INITIAL;
 


### PR DESCRIPTION
Once a component wants to retransmit a frame through QUICFrameInfo, it should call `save_frame_info` to save QUICFrameInfo in `_lost_frame_info_queue`. Then call `_create_retransmitted_frame` to generate a new frame.


```
// First inheriting from QUICFrameRetransmitted.
class QUICStream : public QUICFrameRetransmitted 
{
};

// Second saving Information
QUICStream::_on_frame_lost(QUICFrameInfoUPtr &info)
{
  this->save_frame_info(info).
}

// Finally creating the new frame
QUICStream::generate_frame()
{
   this->create_retransmitted_frame(id, owner);
}
```