### PR TITLE
Start QUICNetVConnection after thread is assigned

### DIFF
--- a/iocore/net/QUICNetProcessor.cc
+++ b/iocore/net/QUICNetProcessor.cc
@@ -154,8 +154,6 @@ QUICNetProcessor::connect_re(Continuation *cont, sockaddr const *remote_addr, Ne
 
   SET_CONTINUATION_HANDLER(vc, &QUICNetVConnection::startEvent);
 
-  vc->start();
-
   if (t->is_event_type(opt->etype)) {
     MUTEX_TRY_LOCK(lock, cont->mutex, t);
     if (lock.is_locked()) {

--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -208,6 +208,8 @@ QUICNetVConnection::acceptEvent(int event, Event *e)
     set_active_timeout(active_timeout_in);
   }
 
+  this->start();
+
   action_.continuation->handleEvent(NET_EVENT_ACCEPT, this);
   this->_schedule_packet_write_ready();
 
@@ -367,6 +369,8 @@ QUICNetVConnection::connectUp(EThread *t, int fd)
 
   // FIXME: complete do_io_xxxx instead
   this->read.enabled = 1;
+
+  this->start();
 
   // start QUIC handshake
   this->_schedule_packet_write_ready();
@@ -554,7 +558,7 @@ QUICNetVConnection::handle_frame(QUICEncryptionLevel level, const QUICFrame &fra
 }
 
 // XXX Setup QUICNetVConnection on regular EThread.
-// QUICNetVConnection::init() and QUICNetVConnection::start() might be called on ET_UDP EThread.
+// QUICNetVConnection::init() might be called on ET_UDP EThread.
 int
 QUICNetVConnection::state_pre_handshake(int event, Event *data)
 {

--- a/iocore/net/QUICPacketHandler.cc
+++ b/iocore/net/QUICPacketHandler.cc
@@ -321,12 +321,10 @@ QUICPacketHandlerIn::_recv_packet(int event, UDPPacket *udp_packet)
     vc->id = net_next_connection_number();
     vc->con.move(con);
     vc->submit_time = Thread::get_hrtime();
-    vc->thread      = eth;
     vc->mutex       = new_ProxyMutex();
     vc->action_     = *this->action_;
     vc->set_is_transparent(this->opt.f_inbound_transparent);
     vc->set_context(NET_VCONNECTION_IN);
-    vc->start();
     vc->options.ip_proto  = NetVCOptions::USE_UDP;
     vc->options.ip_family = udp_packet->from.sa.sa_family;
 


### PR DESCRIPTION
Another approach of #4775. 

Look at `UnixNetVConnection`, the `thread` member is always assigned inside of it. From that perspective, below wouldd be better.

- Assigning thread inside of the `QUICNetVConnection`
- Calling `QUICNetVConnection::start()` after the thread is assigned

An advantage of this approach is  we can make sure `QUICNetVConnection::start()` run on ET_NET thread on server side.