### PR TITLE
Update common.m4 to correctly use $LIBS instead of $LDFLAGS

### DIFF
--- a/build/common.m4
+++ b/build/common.m4
@@ -196,17 +196,17 @@ AC_DEFUN([TS_TRY_COMPILE_NO_WARNING],
 ])
 
 dnl
-dnl TS_LINK_WITH_FLAGS_IFELSE(LDFLAGS, FUNCTION-BODY,
+dnl TS_LINK_WITH_FLAGS_IFELSE(LIBS, FUNCTION-BODY,
 dnl                           [ACTIONS-IF-LINKS], [ACTIONS-IF-LINK-FAILS])
 dnl
 dnl Tries a link test with the provided flags.
 dnl
 
 AC_DEFUN([TS_LINK_WITH_FLAGS_IFELSE],
-[ats_save_LDFLAGS=$LDFLAGS
- LDFLAGS="$LDFLAGS $1"
+[ats_save_LIBS=$LIBS
+ LIBS="$LIBS $1"
  AC_LINK_IFELSE([$2],[$3],[$4])
- LDFLAGS=$ats_save_LDFLAGS
+ LIBS=$ats_save_LIBS
 ])
 
 


### PR DESCRIPTION
With Ubuntu, the wl,asneeded flags i injected automatically.
This causes the link fail, because of LDFLAGS being put before common.c when autoconf runs.
$CC $CPPFLAGS $CFLAGS $LDFLAGS sourcefile.c $LIBS
^^ gcc strips the library because it is put before the file being compiled and then fails.

failure:
configure:26271: $? = 1
configure:26590: checking for LUAJIT
configure:26597: $PKG_CONFIG --exists --print-errors "luajit >= 2.0.4"
configure:26600: $? = 0
configure:26614: $PKG_CONFIG --exists --print-errors "luajit >= 2.0.4"
configure:26617: $? = 0
configure:27005: result: yes
configure:27061: checking jansson.h usability
configure:27061: cc -c -g -O2 -fdebug-prefix-map=/trafficserver-8.0.1=. -fstack-protector-strong -Wformat -Werror=format-security -O3 -Wdate-time -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE -DOPENSSL_NO_SSL_INTERN conftest.c >&5
configure:27061: $? = 0
configure:27061: result: yes
configure:27061: checking jansson.h presence
configure:27061: cc -E -Wdate-time -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE -DOPENSSL_NO_SSL_INTERN conftest.c
configure:27061: $? = 0
configure:27061: result: yes
configure:27061: checking for jansson.h
configure:27061: result: yes
configure:27067: checking whether jansson is dynamic
configure:27082: cc -o conftest -g -O2 -fdebug-prefix-map=/trafficserver-8.0.1=. -fstack-protector-strong -Wformat -Werror=format-security -O3 -Wdate-time -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE -DOPENSSL_NO_SSL_INTERN -Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now -fPIC -ljansson conftest.c -lbrotlienc -lpthread -ldl  >&5
/usr/bin/ld: /tmp/cc2Ctsj4.o: in function `main':
./conftest.c:96: undefined reference to `json_object'
collect2: error: ld returned 1 exit status
configure:27082: $? = 1

with this patch:
configure:26271: $? = 1
configure:26590: checking for LUAJIT
configure:26597: $PKG_CONFIG --exists --print-errors "luajit >= 2.0.4"
configure:26600: $? = 0
configure:26614: $PKG_CONFIG --exists --print-errors "luajit >= 2.0.4"
configure:26617: $? = 0
configure:27005: result: yes
configure:27061: checking jansson.h usability
configure:27061: cc -c -g -O2 -fdebug-prefix-map=/trafficserver-8.0.1=. -fstack-protector-strong -Wformat -Werror=format-security -O3 -Wdate-time -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE -DOPENSSL_NO_SSL_INTERN conftest.c >&5
configure:27061: $? = 0
configure:27061: result: yes
configure:27061: checking jansson.h presence
configure:27061: cc -E -Wdate-time -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE -DOPENSSL_NO_SSL_INTERN conftest.c
configure:27061: $? = 0
configure:27061: result: yes
configure:27061: checking for jansson.h
configure:27061: result: yes
configure:27067: checking whether jansson is dynamic
configure:27082: cc -o conftest -g -O2 -fdebug-prefix-map=/trafficserver-8.0.1=. -fstack-protector-strong -Wformat -Werror=format-security -O3 -Wdate-time -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE -DOPENSSL_NO_SSL_INTERN -Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now conftest.c -lbrotlienc -lpthread -ldl  -fPIC -ljansson >&5
configure:27082: $? = 0
configure:27083: result: yes