### PR TITLE
Eliminates frequent librecords lookup

### DIFF
--- a/iocore/net/I_Net.h
+++ b/iocore/net/I_Net.h
@@ -61,6 +61,9 @@ extern int net_accept_period;
 extern int net_retry_delay;
 extern int net_throttle_delay;
 
+extern std::string_view net_ccp_in;
+extern std::string_view net_ccp_out;
+
 #define NET_EVENT_OPEN (NET_EVENT_EVENTS_START)
 #define NET_EVENT_OPEN_FAILED (NET_EVENT_EVENTS_START + 1)
 #define NET_EVENT_ACCEPT (NET_EVENT_EVENTS_START + 2)

--- a/iocore/net/Net.cc
+++ b/iocore/net/Net.cc
@@ -40,6 +40,10 @@ int net_accept_period       = 10;
 int net_retry_delay         = 10;
 int net_throttle_delay      = 50; /* milliseconds */
 
+// For the in/out congestion control: ToDo: this probably would be better as ports: specifications
+std::string_view net_ccp_in;
+std::string_view net_ccp_out;
+
 static inline void
 configure_net()
 {
@@ -52,6 +56,20 @@ configure_net()
   // These are not reloadable
   REC_ReadConfigInteger(net_event_period, "proxy.config.net.event_period");
   REC_ReadConfigInteger(net_accept_period, "proxy.config.net.accept_period");
+
+  // This is kinda fugly, but better than it was before (on every connection in and out)
+  // Note that these would need to be ats_free()'d if we ever want to clean that up, but
+  // we have no good way of dealing with that on such globals I think?
+  RecString ccp;
+
+  REC_ReadConfigStringAlloc(ccp, "proxy.config.net.tcp_congestion_control_in");
+  if (ccp && *ccp != '\0') {
+    net_ccp_in = {ccp};
+  }
+  REC_ReadConfigStringAlloc(ccp, "proxy.config.net.tcp_congestion_control_out");
+  if (ccp && *ccp != '\0') {
+    net_ccp_out = {ccp};
+  }
 }
 
 static inline void

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -398,41 +398,6 @@ UnixNetVConnection::set_tcp_init_cwnd(int init_cwnd)
 #endif
 }
 
-inline int
-UnixNetVConnection::set_tcp_congestion_control(int side)
-{
-#ifdef TCP_CONGESTION
-  RecString congestion_control;
-  int ret;
-
-  if (side == CLIENT_SIDE) {
-    ret = REC_ReadConfigStringAlloc(congestion_control, "proxy.config.net.tcp_congestion_control_in");
-  } else {
-    ret = REC_ReadConfigStringAlloc(congestion_control, "proxy.config.net.tcp_congestion_control_out");
-  }
-
-  if (ret == REC_ERR_OKAY) {
-    int len = strlen(congestion_control);
-    if (len > 0) {
-      int rv = 0;
-      rv     = setsockopt(con.fd, IPPROTO_TCP, TCP_CONGESTION, reinterpret_cast<void *>(congestion_control), len);
-      if (rv < 0) {
-        Error("Unable to set TCP congestion control on socket %d to \"%.*s\", errno=%d (%s)", con.fd, len, congestion_control,
-              errno, strerror(errno));
-      } else {
-        Debug("socket", "Setting TCP congestion control on socket [%d] to \"%.*s\" -> %d", con.fd, len, congestion_control, rv);
-      }
-    }
-    ats_free(congestion_control);
-    return 0;
-  }
-  return -1;
-#else
-  Debug("socket", "Setting TCP congestion control is not supported on this platform.");
-  return -1;
-#endif
-}
-
 inline UnixNetVConnection::~UnixNetVConnection() {}
 
 inline SOCKET

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1524,3 +1524,33 @@ UnixNetVConnection::protocol_contains(std::string_view tag) const
   }
   return retval.data();
 }
+
+int
+UnixNetVConnection::set_tcp_congestion_control(int side)
+{
+#ifdef TCP_CONGESTION
+  std::string_view ccp;
+
+  if (side == CLIENT_SIDE) {
+    ccp = net_ccp_in;
+  } else {
+    ccp = net_ccp_out;
+  }
+
+  if (!ccp.empty()) {
+    int rv = setsockopt(con.fd, IPPROTO_TCP, TCP_CONGESTION, reinterpret_cast<const void *>(ccp.data()), ccp.length());
+
+    if (rv < 0) {
+      Error("Unable to set TCP congestion control on socket %d to \"%s\", errno=%d (%s)", con.fd, ccp.data(), errno,
+            strerror(errno));
+    } else {
+      Debug("socket", "Setting TCP congestion control on socket [%d] to \"%s\" -> %d", con.fd, ccp.data(), rv);
+    }
+    return 0;
+  }
+  return -1;
+#else
+  Debug("socket", "Setting TCP congestion control is not supported on this platform.");
+  return -1;
+#endif
+}

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -793,9 +793,9 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.net.sock_option_tfo_queue_size_in", RECD_INT, "10000", RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.net.tcp_congestion_control_in", RECD_STRING, "", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  {RECT_CONFIG, "proxy.config.net.tcp_congestion_control_in", RECD_STRING, "", RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.net.tcp_congestion_control_out", RECD_STRING, "", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  {RECT_CONFIG, "proxy.config.net.tcp_congestion_control_out", RECD_STRING, "", RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
 
   //##############################################################################


### PR DESCRIPTION
This also avoids up to two malloc(1) calls/connection, even when the congestion
configurations aren't used. I'm making this as simple as possible, for
backporting to 7.x and 8.x, but it also means these configs are no longer
reloadable (they were never marked as reloadable in the Docs though).

For v9.0.0, I think we should change these configurations to be in the ports
specifications, rather than the globals for all of ATS. E.g.

```
80:ip-ccp-in=bbr:ip-ccp-out=reno
```