### PR TITLE
JWT validation uses a token-stripped URI

### DIFF
--- a/plugins/experimental/uri_signing/parse.h
+++ b/plugins/experimental/uri_signing/parse.h
@@ -19,7 +19,8 @@
 #include <stdlib.h>
 
 struct _cjose_jws_int;
-struct _cjose_jws_int *get_jws_from_uri(const char *uri, size_t uri_ct, const char *paramName);
+struct _cjose_jws_int *get_jws_from_uri(const char *uri, size_t uri_ct, const char *paramName, char *strip_uri, size_t buff_ct,
+                                        size_t *strip_ct);
 struct _cjose_jws_int *get_jws_from_cookie(const char **cookie, size_t *cookie_ct, const char *paramName);
 
 struct config;

--- a/plugins/experimental/uri_signing/uri_signing.c
+++ b/plugins/experimental/uri_signing/uri_signing.c
@@ -175,7 +175,11 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
   if (cpi < max_cpi) {
     checkpoints[cpi++] = mark_timer(&t);
   }
-  cjose_jws_t *jws = get_jws_from_uri(url, url_ct, package);
+
+  char strip_uri[2000] = {0};
+  size_t strip_ct;
+  cjose_jws_t *jws = get_jws_from_uri(url, url_ct, package, strip_uri, 2000, &strip_ct);
+
   if (cpi < max_cpi) {
     checkpoints[cpi++] = mark_timer(&t);
   }
@@ -222,7 +226,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
   if (cpi < max_cpi) {
     checkpoints[cpi++] = mark_timer(&t);
   }
-  struct jwt *jwt = validate_jws(jws, (struct config *)ih, url, url_ct);
+  struct jwt *jwt = validate_jws(jws, (struct config *)ih, strip_uri, strip_ct);
   cjose_jws_release(jws);
   if (cpi < max_cpi) {
     checkpoints[cpi++] = mark_timer(&t);


### PR DESCRIPTION
According to the latest internet draft for URI signing, the token must be stripped from the URI before cdniuc validation. The JWT Parsing function places a stripped URI in a buffer so that the stripped URI can then be passed for JWT validation. 