### PR TITLE
Regex: update to use string_view.

### DIFF
--- a/proxy/http/remap/UrlRewrite.cc
+++ b/proxy/http/remap/UrlRewrite.cc
@@ -897,7 +897,8 @@ UrlRewrite::_regexMappingLookup(RegexMappingList &regex_mappings, URL *request_u
     }
 
     int matches_info[MAX_REGEX_SUBS * 3];
-    bool match_result = list_iter->regular_expression.exec(request_host, request_host_len, matches_info, countof(matches_info));
+    bool match_result =
+      list_iter->regular_expression.exec(std::string_view(request_host, request_host_len), matches_info, countof(matches_info));
 
     if (match_result == true) {
       Debug("url_rewrite_regex",


### PR DESCRIPTION
This changes the `Regex` class to use `string_view` as the API type rather than `const char*`.

Other C++ style updates have been made, and additional comments have  been added to make the code more understandable.

The longer range goal is to start at this bottom layer and work upwards to convert to `string_view`, which is an officially supported change to the code base.