### PR TITLE
Add ifdef so tls test client will compile on non-openssl-1.1.x

### DIFF
--- a/tests/gold_tests/tls/ssl-post.c
+++ b/tests/gold_tests/tls/ssl-post.c
@@ -89,7 +89,10 @@ spawn_same_session_send(void *arg)
 
   SSL_CTX *client_ctx = SSL_CTX_new(SSLv23_client_method());
   SSL *ssl            = SSL_new(client_ctx);
+#if OPENSSL_VERSION_NUMBER >= 0x10100000
   SSL_set_max_proto_version(ssl, TLS1_2_VERSION);
+#endif
+
   SSL_set_session(ssl, tinfo->session);
 
   SSL_set_fd(ssl, sfd);
@@ -283,7 +286,9 @@ main(int argc, char *argv[])
 
   SSL_CTX *client_ctx = SSL_CTX_new(SSLv23_client_method());
   SSL *ssl            = SSL_new(client_ctx);
+#if OPENSSL_VERSION_NUMBER >= 0x10100000
   SSL_set_max_proto_version(ssl, TLS1_2_VERSION);
+#endif
 
   SSL_set_fd(ssl, sfd);
   int ret         = SSL_connect(ssl);


### PR DESCRIPTION
SSL_set_max_protocol_version is only available openssl-1.1.0 and beyond.  Not needed for this test in earlier versions.