### PR TITLE
Add clang-format build target to CMake editor file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,3 +122,4 @@ file(GLOB plugin_files
         )
 add_library(plugins SHARED ${plugin_files})
 
+add_custom_target(clang-format WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY} COMMAND make clang-format)


### PR DESCRIPTION
This makes it easy to clang format from inside a CMake based editor.