### PR TITLE
MIME: Update MIMEField::name_get and MIMEField::value_get to return string_view

### DIFF
--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -2684,7 +2684,7 @@ TSMimeFieldValueGet(TSMBuffer /* bufp ATS_UNUSED */, TSMLoc field_obj, int idx, 
   if (idx >= 0) {
     return mime_field_value_get_comma_val(handle->field_ptr, value_len_ptr, idx);
   } else {
-    return mime_field_value_get(handle->field_ptr, value_len_ptr);
+    return handle->field_ptr->value_get(value_len_ptr);
   }
 }
 
@@ -3135,8 +3135,8 @@ TSMimeHdrFieldNameGet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int *length)
   sdk_assert(sdk_sanity_check_field_handle(field, hdr) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_null_ptr((void *)length) == TS_SUCCESS);
 
-  MIMEFieldSDKHandle *handle = (MIMEFieldSDKHandle *)field;
-  return mime_field_name_get(handle->field_ptr, length);
+  MIMEFieldSDKHandle *handle = reinterpret_cast<MIMEFieldSDKHandle *>(field);
+  return handle->field_ptr->name_get(length);
 }
 
 TSReturnCode


### PR DESCRIPTION
This is just the start of a long term conversion of the MIME support to use `string_view`. This effort will focus on two things:

*  Return `string_view` as a result and take `string_view` as a parameter any place a `char* ptr`, `int length` is used.

*  Convert the MIME handling methods from shells that call free functions to actual methods.

For now the old methods will be kept and re-implemented using the `string_view` methods. Eventually these should be deprecated and removed. It's not feasible to remove them before most of the conversions have been done.