### PR TITLE
Removes proxy.config.http.parse.allow_non_http

### DIFF
--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -299,8 +299,6 @@ static const RecordElement RecordsConfig[] =
   //        ###########
   {RECT_CONFIG, "proxy.config.header.parse.no_host_url_redirect", RECD_STRING, nullptr, RECU_DYNAMIC, RR_NULL, RECC_STR, ".*", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.http.parse.allow_non_http", RECD_INT, "1", RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
-  ,
 
   //##############################################################################
   //#

--- a/proxy/hdrs/HTTP.cc
+++ b/proxy/hdrs/HTTP.cc
@@ -834,15 +834,6 @@ http_hdr_reason_lookup(unsigned status)
   return nullptr;
 }
 
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-
-void
-_http_parser_init(HTTPParser *parser)
-{
-  parser->m_parsing_http = true;
-}
-
 //////////////////////////////////////////////////////
 // init     first time structure setup              //
 // clear    resets an already-initialized structure //
@@ -851,14 +842,14 @@ _http_parser_init(HTTPParser *parser)
 void
 http_parser_init(HTTPParser *parser)
 {
-  _http_parser_init(parser);
+  parser->m_parsing_http = true;
   mime_parser_init(&parser->m_mime_parser);
 }
 
 void
 http_parser_clear(HTTPParser *parser)
 {
-  _http_parser_init(parser);
+  parser->m_parsing_http = true;
   mime_parser_clear(&parser->m_mime_parser);
 }
 
@@ -1384,11 +1375,7 @@ http_parser_parse_resp(HTTPParser *parser, HdrHeap *heap, HTTPHdrImpl *hh, const
 
   eoh:
     *start = old_start;
-    if (parser->m_allow_non_http) {
-      return PARSE_RESULT_DONE;
-    } else {
-      return PARSE_RESULT_ERROR;
-    }
+    return PARSE_RESULT_ERROR; // This used to return PARSE_RESULT_DONE by default before
 
   done:
     if (!version_start || !version_end) {

--- a/proxy/hdrs/HTTP.h
+++ b/proxy/hdrs/HTTP.h
@@ -322,8 +322,7 @@ struct HTTPValTE {
 };
 
 struct HTTPParser {
-  bool m_parsing_http   = false;
-  bool m_allow_non_http = false;
+  bool m_parsing_http = false;
   MIMEParser m_mime_parser;
 };
 

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -1152,7 +1152,6 @@ HttpConfig::startup()
 
   HttpEstablishStaticConfigByte(c.send_100_continue_response, "proxy.config.http.send_100_continue_response");
   HttpEstablishStaticConfigByte(c.disallow_post_100_continue, "proxy.config.http.disallow_post_100_continue");
-  HttpEstablishStaticConfigByte(c.parser_allow_non_http, "proxy.config.http.parse.allow_non_http");
 
   HttpEstablishStaticConfigByte(c.keepalive_internal_vc, "proxy.config.http.keepalive_internal_vc");
 
@@ -1437,7 +1436,6 @@ HttpConfig::reconfigure()
 
   params->send_100_continue_response = INT_TO_BOOL(m_master.send_100_continue_response);
   params->disallow_post_100_continue = INT_TO_BOOL(m_master.disallow_post_100_continue);
-  params->parser_allow_non_http      = INT_TO_BOOL(m_master.parser_allow_non_http);
   params->keepalive_internal_vc      = INT_TO_BOOL(m_master.keepalive_internal_vc);
 
   params->oride.cache_open_write_fail_action = m_master.oride.cache_open_write_fail_action;

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -904,7 +904,6 @@ public:
 
   MgmtByte send_100_continue_response = 0;
   MgmtByte disallow_post_100_continue = 0;
-  MgmtByte parser_allow_non_http      = 1;
   MgmtByte keepalive_internal_vc      = 0;
 
   MgmtByte server_session_sharing_pool = TS_SERVER_SESSION_SHARING_POOL_THREAD;

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -341,7 +341,6 @@ HttpSM::init()
   t_state.force_dns = (ip_rule_in_CacheControlTable() || t_state.parent_params->parent_table->ipMatch ||
                        !(t_state.txn_conf->doc_in_cache_skip_dns) || !(t_state.txn_conf->cache_http));
 
-  http_parser.m_allow_non_http = t_state.http_config_param->parser_allow_non_http;
   http_parser_init(&http_parser);
 
   SET_HANDLER(&HttpSM::main_handler);


### PR DESCRIPTION
In addition, it changes the default / code such that we do not
allow parse failues on the HTTP/ version parsing.