### PR TITLE
Fixes heap-use-after-free in RangeTransform

### DIFF
--- a/proxy/Transform.cc
+++ b/proxy/Transform.cc
@@ -782,7 +782,11 @@ RangeTransform::handle_event(int event, void *edata)
 
   if (m_closed) {
     if (m_deletable) {
-      Debug("http_trans", "RangeTransform destroy: %p ndone=%" PRId64, this, m_output_vio ? m_output_vio->ndone : 0);
+      if (m_output_vc != nullptr) {
+        Debug("http_trans", "RangeTransform destroy: %p ndone=%" PRId64, this, m_output_vio ? m_output_vio->ndone : 0);
+      } else {
+        Debug("http_trans", "RangeTransform destroy");
+      }
       delete this;
     }
   } else {


### PR DESCRIPTION
```
==30656==ERROR: AddressSanitizer: heap-use-after-free on address 0x612000020230 at pc 0x000000bdc439 bp 0x7fffeed9c890 sp 0x7fffeed9c880
READ of size 8 at 0x612000020230 thread T2 ([ET_NET 0])
    #0 0xbdc438 in RangeTransform::handle_event(int, void*) /root/trafficserver/proxy/Transform.cc:785
    #1 0x63964d in Continuation::handleEvent(int, void*) /root/trafficserver/iocore/eventsystem/I_Continuation.h:165
    #2 0xcf3b6b in EThread::process_event(Event*, int) /root/trafficserver/iocore/eventsystem/UnixEThread.cc:132
    #3 0xcf4104 in EThread::process_queue(Queue<Event, Event::Link_link>*, int*, int*) /root/trafficserver/iocore/eventsystem/UnixEThread.cc:171
    #4 0xcf4838 in EThread::execute_regular() /root/trafficserver/iocore/eventsystem/UnixEThread.cc:231
    #5 0xcf56e5 in EThread::execute() /root/trafficserver/iocore/eventsystem/UnixEThread.cc:334
    #6 0xcf1da7 in spawn_thread_internal /root/trafficserver/iocore/eventsystem/Thread.cc:92
    #7 0x7ffff51036b9 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76b9)
    #8 0x7ffff438c41c in clone (/lib/x86_64-linux-gnu/libc.so.6+0x10741c)

0x612000020230 is located 240 bytes inside of 320-byte region [0x612000020140,0x612000020280)
freed by thread T2 ([ET_NET 0]) here:
    #0 0x7ffff6eff7a8 in operator delete(void*, unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe17a8)
    #1 0xbd8ddc in TransformVConnection::~TransformVConnection() /root/trafficserver/proxy/Transform.cc:413
    #2 0xbd6914 in TransformTerminus::handle_event(int, void*) /root/trafficserver/proxy/Transform.cc:155
    #3 0x63964d in Continuation::handleEvent(int, void*) /root/trafficserver/iocore/eventsystem/I_Continuation.h:165
    #4 0xcf3b6b in EThread::process_event(Event*, int) /root/trafficserver/iocore/eventsystem/UnixEThread.cc:132
    #5 0xcf4104 in EThread::process_queue(Queue<Event, Event::Link_link>*, int*, int*) /root/trafficserver/iocore/eventsystem/UnixEThread.cc:171
    #6 0xcf4838 in EThread::execute_regular() /root/trafficserver/iocore/eventsystem/UnixEThread.cc:231
    #7 0xcf56e5 in EThread::execute() /root/trafficserver/iocore/eventsystem/UnixEThread.cc:334
    #8 0xcf1da7 in spawn_thread_internal /root/trafficserver/iocore/eventsystem/Thread.cc:92
    #9 0x7ffff51036b9 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76b9)

previously allocated by thread T2 ([ET_NET 0]) here:
    #0 0x7ffff6efe228 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0228)
    #1 0xbd5e3b in TransformProcessor::open(Continuation*, APIHook*) /root/trafficserver/proxy/Transform.cc:85
    #2 0x79f4f2 in HttpSM::do_transform_open() /root/trafficserver/proxy/http/HttpSM.cc:5199
    #3 0x81147a in HttpTransact::build_response_from_cache(HttpTransact::State*, HTTPWarningCode) /root/trafficserver/proxy/http/HttpTransact.cc:2832
    #4 0x81001c in HttpTransact::HandleCacheOpenReadHit(HttpTransact::State*) /root/trafficserver/proxy/http/HttpTransact.cc:2721
    #5 0x7b4000 in HttpSM::call_transact_and_set_next_state(void (*)(HttpTransact::State*)) /root/trafficserver/proxy/http/HttpSM.cc:7187
    #6 0x774b9c in HttpSM::handle_api_return() /root/trafficserver/proxy/http/HttpSM.cc:1610
    #7 0x7c9d33 in HttpSM::do_api_callout() /root/trafficserver/proxy/http/HttpSM.cc:367
    #8 0x7b471f in HttpSM::set_next_state() /root/trafficserver/proxy/http/HttpSM.cc:7229
    #9 0x7b4396 in HttpSM::call_transact_and_set_next_state(void (*)(HttpTransact::State*)) /root/trafficserver/proxy/http/HttpSM.cc:7195
    #10 0x774b9c in HttpSM::handle_api_return() /root/trafficserver/proxy/http/HttpSM.cc:1610
    #11 0x7c9d33 in HttpSM::do_api_callout() /root/trafficserver/proxy/http/HttpSM.cc:367
    #12 0x7b471f in HttpSM::set_next_state() /root/trafficserver/proxy/http/HttpSM.cc:7229
    #13 0x7b4396 in HttpSM::call_transact_and_set_next_state(void (*)(HttpTransact::State*)) /root/trafficserver/proxy/http/HttpSM.cc:7195
    #14 0x78054d in HttpSM::state_cache_open_read(int, void*) /root/trafficserver/proxy/http/HttpSM.cc:2542
    #15 0x7813b4 in HttpSM::main_handler(int, void*) /root/trafficserver/proxy/http/HttpSM.cc:2604
    #16 0x63964d in Continuation::handleEvent(int, void*) /root/trafficserver/iocore/eventsystem/I_Continuation.h:165
    #17 0x88da44 in HttpCacheSM::state_cache_open_read(int, void*) /root/trafficserver/proxy/http/HttpCacheSM.cc:130
    #18 0x63964d in Continuation::handleEvent(int, void*) /root/trafficserver/iocore/eventsystem/I_Continuation.h:165
    #19 0xb183a0 in CacheVC::callcont(int) /root/trafficserver/iocore/cache/P_CacheInternal.h:642
    #20 0xb162d4 in CacheVC::openReadStartHead(int, Event*) /root/trafficserver/iocore/cache/CacheRead.cc:1210
    #21 0x63964d in Continuation::handleEvent(int, void*) /root/trafficserver/iocore/eventsystem/I_Continuation.h:165
    #22 0xab6d8f in CacheVC::handleReadDone(int, Event*) /root/trafficserver/iocore/cache/Cache.cc:2387
    #23 0x63964d in Continuation::handleEvent(int, void*) /root/trafficserver/iocore/eventsystem/I_Continuation.h:165
    #24 0xac4c6a in AIOCallbackInternal::io_complete(int, void*) (/usr/local/trafficserver/bin/traffic_server+0xac4c6a)
    #25 0x63964d in Continuation::handleEvent(int, void*) /root/trafficserver/iocore/eventsystem/I_Continuation.h:165
    #26 0xcf3b6b in EThread::process_event(Event*, int) /root/trafficserver/iocore/eventsystem/UnixEThread.cc:132
    #27 0xcf4104 in EThread::process_queue(Queue<Event, Event::Link_link>*, int*, int*) /root/trafficserver/iocore/eventsystem/UnixEThread.cc:171
    #28 0xcf4838 in EThread::execute_regular() /root/trafficserver/iocore/eventsystem/UnixEThread.cc:231
    #29 0xcf56e5 in EThread::execute() /root/trafficserver/iocore/eventsystem/UnixEThread.cc:334
```