### PR TITLE
Do not call dns_result repeatedly for a valid dns result.

### DIFF
--- a/iocore/dns/P_DNSProcessor.h
+++ b/iocore/dns/P_DNSProcessor.h
@@ -159,8 +159,9 @@ struct DNSEntry : public Continuation {
 
   int mainEvent(int event, Event *e);
   int delayEvent(int event, Event *e);
+  int postAllEvent(int event, Event *e);
   int post(DNSHandler *h, HostEnt *ent);
-  int postEvent(int event, Event *e);
+  int postOneEvent(int event, Event *e);
   void init(const char *x, int len, int qtype_arg, Continuation *acont, DNSProcessor::Options const &opt);
 
   DNSEntry()


### PR DESCRIPTION
The `dns_result(DNSHandler *h, DNSEntry *e, HostEnt *ent, bool retry)` does:

- Try to retry operation
- Statistics for DNS sub-system
   - `dns_fail_time_stat` and `dns_lookup_fail_stat` for bad dns result (ent == NULL)
   - `dns_success_time_stat` and `dns_lookup_success_stat` for valid dns result (ent != NULL)
- Callback HostEnt for all DNSEntry in the dups queue
- Release DNS Query ID

It may failed to obtain lock during the callback and try to call `dns_result()` again to process all the DNSEntry in the dups queue.

Repeated calls to the `dns_result()` will result in inaccurate statistics for the DNS subsystem.

It will release query ID only all of these DNSEntry are called back.
Now the query ID is released once a valid dns result is received.