### PR TITLE
limit m_current_range to max value in RangeTransform

### DIFF
--- a/proxy/Transform.cc
+++ b/proxy/Transform.cc
@@ -847,6 +847,10 @@ RangeTransform::transform_to_range()
   int64_t prev_end = 0;
   int64_t *done_byte;
 
+  if (m_current_range >= m_num_range_fields) {
+    return;
+  }
+
   end       = &m_ranges[m_current_range]._end;
   done_byte = &m_ranges[m_current_range]._done_byte;
   start     = &m_ranges[m_current_range]._start;


### PR DESCRIPTION
```
(gdb) bt
#0  0x000015555445aa60 in __asan::ReportGenericError(unsigned long, unsigned long, unsigned long, unsigned long, bool, unsigned long, unsigned int, bool) () from /lib64/libasan.so.5
#1  0x000015555445b83b in __asan_report_load8 () from /lib64/libasan.so.5
#2  0x0000000000a5a707 in RangeTransform::transform_to_range (this=0x6130002866c0) at Transform.cc:862
#3  0x0000000000a5a42e in RangeTransform::handle_event (this=0x6130002866c0, event=1, edata=0x62c000002a40) at Transform.cc:836
#4  0x000000000054fe47 in Continuation::handleEvent (this=0x6130002866c0, event=1, data=0x62c000002a40) at /root/ccc/trafficserver/iocore/eventsystem/I_Continuation.h:160
#5  0x0000000000b53484 in EThread::process_event (this=0x15554c052800, e=0x62c000002a40, calling_code=1) at UnixEThread.cc:131
#6  0x0000000000b53a1b in EThread::process_queue (this=0x15554c052800, NegativeQueue=0x155549dead10, ev_count=0x155549deac10, nq_count=0x155549deabd0) at UnixEThread.cc:170
#7  0x0000000000b5414c in EThread::execute_regular (this=0x15554c052800) at UnixEThread.cc:230
#8  0x0000000000b54fe6 in EThread::execute (this=0x15554c052800) at UnixEThread.cc:325
#9  0x0000000000b51612 in spawn_thread_internal (a=0x60600001d840) at Thread.cc:85
#10 0x0000155552198594 in start_thread () from /lib64/libpthread.so.0
#11 0x0000155551388f4f in clone () from /lib64/libc.so.6

(gdb) c
Continuing.
=================================================================
==19320==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6030000370b8 at pc 0x000000a5a707 bp 0x155549dea750 sp 0x155549dea740
READ of size 8 at 0x6030000370b8 thread T20 ([ET_NET 18])
    #0 0xa5a706 in RangeTransform::transform_to_range() /root/ccc/trafficserver/proxy/Transform.cc:862
    #1 0xa5a42d in RangeTransform::handle_event(int, void*) /root/ccc/trafficserver/proxy/Transform.cc:836
    #2 0x54fe46 in Continuation::handleEvent(int, void*) /root/ccc/trafficserver/iocore/eventsystem/I_Continuation.h:160
    #3 0xb53483 in EThread::process_event(Event*, int) /root/ccc/trafficserver/iocore/eventsystem/UnixEThread.cc:131
    #4 0xb53a1a in EThread::process_queue(Queue<Event, Event::Link_link>*, int*, int*) /root/ccc/trafficserver/iocore/eventsystem/UnixEThread.cc:170
    #5 0xb5414b in EThread::execute_regular() /root/ccc/trafficserver/iocore/eventsystem/UnixEThread.cc:230
    #6 0xb54fe5 in EThread::execute() /root/ccc/trafficserver/iocore/eventsystem/UnixEThread.cc:325
    #7 0xb51611 in spawn_thread_internal /root/ccc/trafficserver/iocore/eventsystem/Thread.cc:85
    #8 0x155552198593 in start_thread (/lib64/libpthread.so.0+0x7593)
    #9 0x155551388f4e in clone (/lib64/libc.so.6+0xf9f4e)

0x6030000370b8 is located 16 bytes to the right of 24-byte region [0x603000037090,0x6030000370a8)
allocated by thread T19 ([ET_NET 17]) here:
    #0 0x155554451a50 in operator new[](unsigned long) (/lib64/libasan.so.5+0xf0a50)
    #1 0x644e6f in HttpSM::parse_range_and_compare(MIMEField*, long) /root/ccc/trafficserver/proxy/http/HttpSM.cc:4200
    #2 0x6467d3 in HttpSM::do_range_parse(MIMEField*) /root/ccc/trafficserver/proxy/http/HttpSM.cc:4372
    #3 0x646c8b in HttpSM::do_range_setup_if_necessary() /root/ccc/trafficserver/proxy/http/HttpSM.cc:4395
    #4 0x6b98b9 in HttpTransact::build_response_from_cache(HttpTransact::State*, HTTPWarningCode) /root/ccc/trafficserver/proxy/http/HttpTransact.cc:2766
    #5 0x6b8926 in HttpTransact::HandleCacheOpenReadHit(HttpTransact::State*) /root/ccc/trafficserver/proxy/http/HttpTransact.cc:2677
    #6 0x664413 in HttpSM::call_transact_and_set_next_state(void (*)(HttpTransact::State*)) /root/ccc/trafficserver/proxy/http/HttpSM.cc:7114
    #7 0x62605f in HttpSM::handle_api_return() /root/ccc/trafficserver/proxy/http/HttpSM.cc:1582
    #8 0x6259fd in HttpSM::state_api_callout(int, void*) /root/ccc/trafficserver/proxy/http/HttpSM.cc:1517
    #9 0x623528 in HttpSM::state_api_callback(int, void*) /root/ccc/trafficserver/proxy/http/HttpSM.cc:1284
    #10 0x573c12 in TSHttpTxnReenable traffic_server/InkAPI.cc:5819
    #11 0x15553da4cb7c in service_from_this /root/localdown/main.cpp:1825
    #12 0x15553da55b78 in cachefun /root/localdown/main.cpp:2533
    #13 0x55acc4 in INKContInternal::handle_event(int, void*) traffic_server/InkAPI.cc:1064
    #14 0x54fe46 in Continuation::handleEvent(int, void*) /root/ccc/trafficserver/iocore/eventsystem/I_Continuation.h:160
    #15 0x55bf1c in APIHook::invoke(int, void*) traffic_server/InkAPI.cc:1284
    #16 0x62535c in HttpSM::state_api_callout(int, void*) /root/ccc/trafficserver/proxy/http/HttpSM.cc:1444
    #17 0x64f44a in HttpSM::do_api_callout_internal() /root/ccc/trafficserver/proxy/http/HttpSM.cc:5062
    #18 0x67b9e3 in HttpSM::do_api_callout() /root/ccc/trafficserver/proxy/http/HttpSM.cc:340
    #19 0x664b32 in HttpSM::set_next_state() /root/ccc/trafficserver/proxy/http/HttpSM.cc:7156
    #20 0x6647a9 in HttpSM::call_transact_and_set_next_state(void (*)(HttpTransact::State*)) /root/ccc/trafficserver/proxy/http/HttpSM.cc:7122
    #21 0x62605f in HttpSM::handle_api_return() /root/ccc/trafficserver/proxy/http/HttpSM.cc:1582
    #22 0x6259fd in HttpSM::state_api_callout(int, void*) /root/ccc/trafficserver/proxy/http/HttpSM.cc:1517
    #23 0x64f44a in HttpSM::do_api_callout_internal() /root/ccc/trafficserver/proxy/http/HttpSM.cc:5062
    #24 0x67b9e3 in HttpSM::do_api_callout() /root/ccc/trafficserver/proxy/http/HttpSM.cc:340
    #25 0x664b32 in HttpSM::set_next_state() /root/ccc/trafficserver/proxy/http/HttpSM.cc:7156
    #26 0x6647a9 in HttpSM::call_transact_and_set_next_state(void (*)(HttpTransact::State*)) /root/ccc/trafficserver/proxy/http/HttpSM.cc:7122
    #27 0x630b40 in HttpSM::state_cache_open_read(int, void*) /root/ccc/trafficserver/proxy/http/HttpSM.cc:2482
    #28 0x631914 in HttpSM::main_handler(int, void*) /root/ccc/trafficserver/proxy/http/HttpSM.cc:2544
    #29 0x54fe46 in Continuation::handleEvent(int, void*) /root/ccc/trafficserver/iocore/eventsystem/I_Continuation.h:160

Thread T20 ([ET_NET 18]) created by T0 ([TS_MAIN]) here:
    #0 0x1555543ac443 in pthread_create (/lib64/libasan.so.5+0x4b443)
    #1 0xb50f0f in ink_thread_create ../../include/tscore/ink_thread.h:155
    #2 0xb5173f in Thread::start(char const*, void*, unsigned long, std::function<void ()> const&) /root/ccc/trafficserver/iocore/eventsystem/Thread.cc:102
    #3 0xb5b129 in EventProcessor::spawn_event_threads(int, int, unsigned long) /root/ccc/trafficserver/iocore/eventsystem/UnixEventProcessor.cc:382
    #4 0xb5ba14 in EventProcessor::start(int, unsigned long) /root/ccc/trafficserver/iocore/eventsystem/UnixEventProcessor.cc:446
    #5 0x5a5b20 in main traffic_server/traffic_server.cc:1817
    #6 0x1555512b211a in __libc_start_main (/lib64/libc.so.6+0x2311a)

Thread T19 ([ET_NET 17]) created by T0 ([TS_MAIN]) here:
    #0 0x1555543ac443 in pthread_create (/lib64/libasan.so.5+0x4b443)
    #1 0xb50f0f in ink_thread_create ../../include/tscore/ink_thread.h:155
    #2 0xb5173f in Thread::start(char const*, void*, unsigned long, std::function<void ()> const&) /root/ccc/trafficserver/iocore/eventsystem/Thread.cc:102
    #3 0xb5b129 in EventProcessor::spawn_event_threads(int, int, unsigned long) /root/ccc/trafficserver/iocore/eventsystem/UnixEventProcessor.cc:382
    #4 0xb5ba14 in EventProcessor::start(int, unsigned long) /root/ccc/trafficserver/iocore/eventsystem/UnixEventProcessor.cc:446
    #5 0x5a5b20 in main traffic_server/traffic_server.cc:1817
    #6 0x1555512b211a in __libc_start_main (/lib64/libc.so.6+0x2311a)

SUMMARY: AddressSanitizer: heap-buffer-overflow /root/ccc/trafficserver/proxy/Transform.cc:862 in RangeTransform::transform_to_range()
Shadow bytes around the buggy address:
  0x0c067fffedc0: fd fd fa fa 00 00 00 07 fa fa fd fd fd fd fa fa
  0x0c067fffedd0: fd fd fd fd fa fa fd fd fd fd fa fa fd fd fd fd
  0x0c067fffede0: fa fa fd fd fd fd fa fa fd fd fd fd fa fa fd fd
  0x0c067fffedf0: fd fd fa fa fd fd fd fd fa fa fd fd fd fd fa fa
  0x0c067fffee00: fd fd fd fd fa fa fd fd fd fa fa fa fd fd fd fd
=>0x0c067fffee10: fa fa 00 00 00 fa fa[fa]fa fa fa fa fa fa fa fa
  0x0c067fffee20: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c067fffee30: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c067fffee40: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c067fffee50: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c067fffee60: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
```