### PR TITLE
Allow client_cert and client_key to be specified by relative path

### DIFF
--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -419,9 +419,7 @@ SSLConfigParams::initialize()
   ssl_client_cert_path     = nullptr;
   REC_ReadConfigStringAlloc(ssl_client_cert_filename, "proxy.config.ssl.client.cert.filename");
   REC_ReadConfigStringAlloc(ssl_client_cert_path, "proxy.config.ssl.client.cert.path");
-  if (ssl_client_cert_filename && ssl_client_cert_path) {
-    set_paths_helper(ssl_client_cert_path, ssl_client_cert_filename, &clientCertPathOnly, &clientCertPath);
-  }
+  set_paths_helper(ssl_client_cert_path, ssl_client_cert_filename, &clientCertPathOnly, &clientCertPath);
   ats_free_null(ssl_client_cert_filename);
   ats_free_null(ssl_client_cert_path);
 

--- a/iocore/net/SSLSNIConfig.cc
+++ b/iocore/net/SSLSNIConfig.cc
@@ -35,6 +35,7 @@
 #include "P_SSLConfig.h"
 #include "tscore/ink_memory.h"
 #include "tscpp/util/TextView.h"
+#include "tscore/I_Layout.h"
 #include <sstream>
 #include <pcre.h>
 
@@ -82,11 +83,11 @@ SNIConfigParams::loadSNIConfig()
 
     // set the next hop properties
     SSLConfig::scoped_config params;
-    auto clientCTX       = params->getClientSSL_CTX();
-    const char *certFile = item.client_cert.data();
-    const char *keyFile  = item.client_key.data();
-    if (certFile && certFile[0] != '\0') {
-      clientCTX = params->getCTX(certFile, keyFile, params->clientCACertFilename, params->clientCACertPath);
+    auto clientCTX = params->getClientSSL_CTX();
+    if (!item.client_cert.empty() && !item.client_key.empty()) {
+      std::string certFilePath = Layout::get()->relative_to(params->clientCertPathOnly, item.client_cert.data());
+      std::string keyFilePath  = Layout::get()->relative_to(params->clientKeyPathOnly, item.client_key.data());
+      clientCTX = params->getCTX(certFilePath.c_str(), keyFilePath.c_str(), params->clientCACertFilename, params->clientCACertPath);
     }
 
     auto nps = next_hop_list.emplace(next_hop_list.end());

--- a/plugins/experimental/ssl_session_reuse/src/ssl_init.cc
+++ b/plugins/experimental/ssl_session_reuse/src/ssl_init.cc
@@ -23,6 +23,7 @@
  */
 
 #include <string>
+#include <string.h>
 #include "ssl_utils.h"
 #include "Config.h"
 #include "common.h"

--- a/plugins/experimental/ssl_session_reuse/src/subscriber.cc
+++ b/plugins/experimental/ssl_session_reuse/src/subscriber.cc
@@ -26,6 +26,7 @@
 #include <ts/ts.h>
 #include <openssl/ssl.h>
 #include <hiredis/hiredis.h>
+#include <string.h>
 #include "common.h"
 
 #include "subscriber.h"

--- a/tests/gold_tests/tls/tls.test.py
+++ b/tests/gold_tests/tls/tls.test.py
@@ -75,6 +75,7 @@ ts.Disk.records_config.update({
     # enable ssl port
     'proxy.config.http.server_ports': '{0} {1}:proto=http2;http:ssl'.format(ts.Variables.port, ts.Variables.ssl_port),
     'proxy.config.ssl.client.verify.server':  0,
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
     'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
 })
 
@@ -86,4 +87,3 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.ssl_port))
 tr.Processes.Default.Streams.stdout = "gold/ssl-post.gold"
 tr.StillRunningAfter = server
-tr.Processes.Default.TimeOut = 10

--- a/tests/gold_tests/tls/tls_check_cert_selection.test.py
+++ b/tests/gold_tests/tls/tls_check_cert_selection.test.py
@@ -59,14 +59,13 @@ ts.Disk.ssl_multicert_config.AddLines([
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
 ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.diags.debug.tags': 'http|ssl|dns|hostdb',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.http.server_ports': '{0} {1}:proto=http2;http:ssl'.format(ts.Variables.port, ts.Variables.ssl_port),
     'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
     'proxy.config.url_remap.pristine_host_hdr': 1,
     'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
     'proxy.config.dns.resolv_conf': 'NULL'
 })
 
@@ -84,7 +83,6 @@ tr.Processes.Default.StartBefore(dns)
 tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.ssl_port))
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 tr.Processes.Default.Streams.All += Testers.ContainsExpression(" CN=bar.com", "Cert should contain bar.com")
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression(" CN=foo.com", "Cert should not contain foo.com")
@@ -95,7 +93,6 @@ tr2 = Test.AddTestRun("foo.com cert")
 tr2.Processes.Default.Command = "curl -v --cacert signer.pem --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}".format(ts.Variables.ssl_port)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
-tr2.Processes.Default.TimeOut = 10
 tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 tr2.Processes.Default.Streams.All += Testers.ContainsExpression(" CN=foo.com", "Cert should contain foo.com")
@@ -107,7 +104,6 @@ tr2 = Test.AddTestRun("random.server.com cert")
 tr2.Processes.Default.Command = "curl -v -k --resolve 'random.server.com:{0}:127.0.0.1' https://random.server.com:{0}".format(ts.Variables.ssl_port)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
-tr2.Processes.Default.TimeOut = 10
 tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 tr2.Processes.Default.Streams.All += Testers.ContainsExpression(" CN=random.server.com", "Cert should contain random.server.com")
@@ -121,7 +117,6 @@ tr2 = Test.AddTestRun("Bad SNI")
 tr2.Processes.Default.Command = "curl -v -k --cacert signer.pem --resolve 'bad.sni.com:{0}:127.0.0.1' https://bad.sni.com:{0}".format(ts.Variables.ssl_port)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
-tr2.Processes.Default.TimeOut = 10
 tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 tr2.Processes.Default.Streams.All += Testers.ContainsExpression(" CN=foo.com", "Cert should contain foo.com")

--- a/tests/gold_tests/tls/tls_client_cert.test.py
+++ b/tests/gold_tests/tls/tls_client_cert.test.py
@@ -75,6 +75,7 @@ ts.Disk.records_config.update({
     'proxy.config.ssl.client.cert.filename': 'signed-foo.pem',
     'proxy.config.ssl.client.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.client.private_key.filename': 'signed-foo.key',
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
     'proxy.config.url_remap.pristine_host_hdr' : 1,
 })
 
@@ -107,7 +108,6 @@ tr.StillRunningAfter = server
 tr.StillRunningAfter = server2
 tr.Processes.Default.Command = "curl -H host:example.com  http://127.0.0.1:{0}/case1".format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
 #Should fail
@@ -117,7 +117,6 @@ trfail.StillRunningAfter = server
 trfail.StillRunningAfter = server2
 trfail.Processes.Default.Command = 'curl -H host:example.com  http://127.0.0.1:{0}/case2'.format(ts.Variables.port)
 trfail.Processes.Default.ReturnCode = 0
-trfail.Processes.Default.TimeOut = 10
 trfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
 # Should succeed
@@ -127,7 +126,6 @@ trbar.StillRunningAfter = server
 trbar.StillRunningAfter = server2
 trbar.Processes.Default.Command = "curl -H host:bar.com  http://127.0.0.1:{0}/case2".format(ts.Variables.port)
 trbar.Processes.Default.ReturnCode = 0
-trbar.Processes.Default.TimeOut = 10
 trbar.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
 #Should fail
@@ -137,7 +135,6 @@ trbarfail.StillRunningAfter = server
 trbarfail.StillRunningAfter = server2
 trbarfail.Processes.Default.Command = 'curl -H host:bar.com  http://127.0.0.1:{0}/case1'.format(ts.Variables.port)
 trbarfail.Processes.Default.ReturnCode = 0
-trbarfail.Processes.Default.TimeOut = 10
 trbarfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
 tr2 = Test.AddTestRun("Update config files")
@@ -154,8 +151,6 @@ tr2.Disk.ssl_server_name_yaml.AddLine(
 # recreate the records.config with the cert filename changed
 tr2.Disk.File(recordspath, id = "records_config", typename="ats:config:records"),
 tr2.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'ssl|http',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.http.server_ports': '{0}'.format(ts.Variables.port),
@@ -174,7 +169,6 @@ tr2.Processes.Default.Command = 'echo Updated configs'
 # Need to copy over the environment so traffic_ctl knows where to find the unix domain socket
 tr2.Processes.Default.Env = ts.Env
 tr2.Processes.Default.ReturnCode = 0
-tr2.Processes.Default.TimeOut = 10
 
 tr2reload = Test.AddTestRun("Reload config")
 tr2reload.StillRunningAfter = ts
@@ -184,7 +178,6 @@ tr2reload.Processes.Default.Command = 'traffic_ctl config reload'
 # Need to copy over the environment so traffic_ctl knows where to find the unix domain socket
 tr2reload.Processes.Default.Env = ts.Env
 tr2reload.Processes.Default.ReturnCode = 0
-tr2reload.Processes.Default.TimeOut = 10
 
 
 #Should succeed
@@ -196,7 +189,6 @@ tr3bar.StillRunningAfter = server
 tr3bar.StillRunningAfter = server2
 tr3bar.Processes.Default.Command = 'curl  -H host:bar.com http://127.0.0.1:{0}/case1'.format(ts.Variables.port)
 tr3bar.Processes.Default.ReturnCode = 0
-tr3bar.Processes.Default.TimeOut = 10
 tr3bar.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
 #Should fail
@@ -206,7 +198,6 @@ tr3barfail.StillRunningAfter = server
 tr3barfail.StillRunningAfter = server2
 tr3barfail.Processes.Default.Command = 'curl  -H host:bar.com http://127.0.0.1:{0}/case2'.format(ts.Variables.port)
 tr3barfail.Processes.Default.ReturnCode = 0
-tr3barfail.Processes.Default.TimeOut = 10
 tr3barfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
 #Should succeed
@@ -217,7 +208,6 @@ tr3.StillRunningAfter = server
 tr3.StillRunningAfter = server2
 tr3.Processes.Default.Command = 'curl  -H host:example.com http://127.0.0.1:{0}/case2'.format(ts.Variables.port)
 tr3.Processes.Default.ReturnCode = 0
-tr3.Processes.Default.TimeOut = 10
 tr3.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
 #Should fail
@@ -227,7 +217,6 @@ tr3fail.StillRunningAfter = server
 tr3fail.StillRunningAfter = server2
 tr3fail.Processes.Default.Command = 'curl  -H host:example.com http://127.0.0.1:{0}/case1'.format(ts.Variables.port)
 tr3fail.Processes.Default.ReturnCode = 0
-tr3fail.Processes.Default.TimeOut = 10
 tr3fail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
 
@@ -244,7 +233,6 @@ trupdate.Processes.Default.Command = 'traffic_ctl config set proxy.config.ssl.cl
 # Need to copy over the environment so traffic_ctl knows where to find the unix domain socket
 trupdate.Processes.Default.Env = ts.Env
 trupdate.Processes.Default.ReturnCode = 0
-trupdate.Processes.Default.TimeOut = 10
 
 trreload = Test.AddTestRun("Reload config after renaming certs")
 trreload.StillRunningAfter = ts
@@ -253,7 +241,6 @@ trreload.StillRunningAfter = server2
 trreload.Processes.Default.Command = 'traffic_ctl config reload'
 trreload.Processes.Default.Env = ts.Env
 trreload.Processes.Default.ReturnCode = 0
-trreload.Processes.Default.TimeOut = 10
 
 #Should succeed
 tr4bar = Test.AddTestRun("Make request with renamed bar cert to second server")
@@ -264,7 +251,6 @@ tr4bar.StillRunningAfter = server
 tr4bar.StillRunningAfter = server2
 tr4bar.Processes.Default.Command = 'curl  -H host:bar.com http://127.0.0.1:{0}/case2'.format(ts.Variables.port)
 tr4bar.Processes.Default.ReturnCode = 0
-tr4bar.Processes.Default.TimeOut = 10
 tr4bar.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
 #Should fail
@@ -274,7 +260,6 @@ tr4barfail.StillRunningAfter = server
 tr4barfail.StillRunningAfter = server2
 tr4barfail.Processes.Default.Command = 'curl  -H host:bar.com http://127.0.0.1:{0}/case1'.format(ts.Variables.port)
 tr4barfail.Processes.Default.ReturnCode = 0
-tr4barfail.Processes.Default.TimeOut = 10
 tr4barfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
 #Should succeed
@@ -284,7 +269,6 @@ tr4.StillRunningAfter = server
 tr4.StillRunningAfter = server2
 tr4.Processes.Default.Command = 'curl  -H host:example.com http://127.0.0.1:{0}/case1'.format(ts.Variables.port)
 tr4.Processes.Default.ReturnCode = 0
-tr4.Processes.Default.TimeOut = 10
 tr4.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
 #Should fail
@@ -294,6 +278,5 @@ tr4fail.StillRunningAfter = server
 tr4fail.StillRunningAfter = server2
 tr4fail.Processes.Default.Command = 'curl  -H host:example.com http://127.0.0.1:{0}/case2'.format(ts.Variables.port)
 tr4fail.Processes.Default.ReturnCode = 0
-tr4fail.Processes.Default.TimeOut = 10
 tr4fail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 

--- a/tests/gold_tests/tls/tls_client_cert2.test.py
+++ b/tests/gold_tests/tls/tls_client_cert2.test.py
@@ -64,8 +64,6 @@ ts.addSSLfile("ssl/signed-bar.key")
 
 ts.Variables.ssl_port = 4443
 ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'ssl_verify_test',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.client.cert.path': '{0}'.format(ts.Variables.SSLDir),
@@ -73,6 +71,7 @@ ts.Disk.records_config.update({
     'proxy.config.http.server_ports': '{0}'.format(ts.Variables.port),
     'proxy.config.ssl.client.verify.server':  0,
     'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
     'proxy.config.url_remap.pristine_host_hdr' : 1,
 })
 
@@ -110,7 +109,6 @@ tr.StillRunningAfter = server
 tr.StillRunningAfter = server2
 tr.Processes.Default.Command = "curl -H host:bob.bar.com  http://127.0.0.1:{0}/case1".format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
 #Should fail
@@ -120,7 +118,6 @@ trfail.StillRunningAfter = server
 trfail.StillRunningAfter = server2
 trfail.Processes.Default.Command = 'curl -H host:bob.bar.com  http://127.0.0.1:{0}/case2'.format(ts.Variables.port)
 trfail.Processes.Default.ReturnCode = 0
-trfail.Processes.Default.TimeOut = 10
 trfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
 # Should succeed
@@ -130,7 +127,6 @@ tr.StillRunningAfter = server
 tr.StillRunningAfter = server2
 tr.Processes.Default.Command = "curl -H host:bob.foo.com  http://127.0.0.1:{0}/case1".format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
 #Should fail
@@ -140,7 +136,6 @@ trfail.StillRunningAfter = server
 trfail.StillRunningAfter = server2
 trfail.Processes.Default.Command = 'curl -H host:bob.foo.com  http://127.0.0.1:{0}/case2'.format(ts.Variables.port)
 trfail.Processes.Default.ReturnCode = 0
-trfail.Processes.Default.TimeOut = 10
 trfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
 # Should succeed
@@ -150,7 +145,6 @@ tr.StillRunningAfter = server
 tr.StillRunningAfter = server2
 tr.Processes.Default.Command = "curl -H host:random.bar.com  http://127.0.0.1:{0}/case2".format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
 #Should fail
@@ -160,6 +154,5 @@ trfail.StillRunningAfter = server
 trfail.StillRunningAfter = server2
 trfail.Processes.Default.Command = 'curl -H host:random.bar.com  http://127.0.0.1:{0}/case1'.format(ts.Variables.port)
 trfail.Processes.Default.ReturnCode = 0
-trfail.Processes.Default.TimeOut = 10
 trfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 

--- a/tests/gold_tests/tls/tls_client_cert2.test.py
+++ b/tests/gold_tests/tls/tls_client_cert2.test.py
@@ -68,6 +68,8 @@ ts.Disk.records_config.update({
     'proxy.config.diags.debug.tags': 'ssl_verify_test',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    'proxy.config.ssl.client.cert.path': '{0}'.format(ts.Variables.SSLDir),
+    'proxy.config.ssl.client.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.http.server_ports': '{0}'.format(ts.Variables.port),
     'proxy.config.ssl.client.verify.server':  0,
     'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
@@ -87,8 +89,8 @@ ts.Disk.remap_config.AddLine(
 
 ts.Disk.ssl_server_name_yaml.AddLines([
     '- fqdn: bob.bar.com',
-    '  client_cert: {0}/signed-bar.pem'.format(ts.Variables.SSLDir),
-    '  client_key: {0}/signed-bar.key'.format(ts.Variables.SSLDir),
+    '  client_cert: signed-bar.pem',
+    '  client_key: signed-bar.key',
     '- fqdn: bob.*.com',
     '  client_cert: {0}/signed-foo.pem'.format(ts.Variables.SSLDir),
     '  client_key: {0}/signed-foo.key'.format(ts.Variables.SSLDir),

--- a/tests/gold_tests/tls/tls_client_cert_override.test.py
+++ b/tests/gold_tests/tls/tls_client_cert_override.test.py
@@ -64,8 +64,6 @@ ts.addSSLfile("ssl/signed-bar.key")
 
 ts.Variables.ssl_port = 4443
 ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.diags.debug.tags': 'ssl',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.http.server_ports': '{0}'.format(ts.Variables.port),
@@ -75,6 +73,7 @@ ts.Disk.records_config.update({
     'proxy.config.ssl.client.cert.filename': 'signed-foo.pem',
     'proxy.config.ssl.client.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.client.private_key.filename': 'signed-foo.key',
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
     'proxy.config.url_remap.pristine_host_hdr' : 1,
 })
 
@@ -105,7 +104,6 @@ tr.StillRunningAfter = server
 tr.StillRunningAfter = server2
 tr.Processes.Default.Command = "curl -H host:example.com  http://127.0.0.1:{0}/case1".format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
 #Should fail
@@ -115,7 +113,6 @@ trfail.StillRunningAfter = server
 trfail.StillRunningAfter = server2
 trfail.Processes.Default.Command = 'curl -H host:example.com  http://127.0.0.1:{0}/badcase1'.format(ts.Variables.port)
 trfail.Processes.Default.ReturnCode = 0
-trfail.Processes.Default.TimeOut = 10
 trfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
 # Should succeed
@@ -125,7 +122,6 @@ trbar.StillRunningAfter = server
 trbar.StillRunningAfter = server2
 trbar.Processes.Default.Command = "curl -H host:bar.com  http://127.0.0.1:{0}/case2".format(ts.Variables.port)
 trbar.Processes.Default.ReturnCode = 0
-trbar.Processes.Default.TimeOut = 10
 trbar.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
 #Should fail
@@ -135,7 +131,6 @@ trbarfail.StillRunningAfter = server
 trbarfail.StillRunningAfter = server2
 trbarfail.Processes.Default.Command = 'curl -H host:bar.com  http://127.0.0.1:{0}/badcase2'.format(ts.Variables.port)
 trbarfail.Processes.Default.ReturnCode = 0
-trbarfail.Processes.Default.TimeOut = 10
 trbarfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
 

--- a/tests/gold_tests/tls/tls_client_verify.test.py
+++ b/tests/gold_tests/tls/tls_client_verify.test.py
@@ -44,8 +44,6 @@ ts.addSSLfile("ssl/signer.pem")
 
 ts.Variables.ssl_port = 4443
 ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'ssl',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.http.server_ports': '{0}:ssl'.format(ts.Variables.ssl_port),
@@ -54,6 +52,7 @@ ts.Disk.records_config.update({
     'proxy.config.url_remap.pristine_host_hdr' : 1,
     'proxy.config.ssl.client.certification_level': 2,
     'proxy.config.ssl.CA.cert.filename': '{0}/signer.pem'.format(ts.Variables.SSLDir),
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
     'proxy.config.ssl.TLSv1_3': 0
 })
 
@@ -84,7 +83,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 35
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("alert", "TLS handshake should fail")
 
 tr = Test.AddTestRun("Connect to foo.com with bad cert")
@@ -95,7 +93,6 @@ tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert server.pem --key server.key --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}/case1".format(ts.Variables.ssl_port)
 # Should fail with badly signed certs
 tr.Processes.Default.ReturnCode = 35
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("alert unknown ca", "TLS handshake should fail")
 
 tr = Test.AddTestRun("Connect to foo.com with cert")
@@ -105,7 +102,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert signed-foo.pem --key signed-foo.key --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
 tr = Test.AddTestRun("Connect to bob.bar.com without cert")
@@ -113,7 +109,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("alert", "TLS handshake should succeed")
 
 tr = Test.AddTestRun("Connect to bob.bar.com with cert")
@@ -123,7 +118,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert signed-bob-bar.pem --key signed-bar.key --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
 tr = Test.AddTestRun("Connect to bob.bar.com with bad cert")
@@ -133,7 +127,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert server.pem --key server.key --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
 tr = Test.AddTestRun("Connect to bob.foo.com without cert")
@@ -141,7 +134,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("alert", "TLS handshake should succeed")
 
 tr = Test.AddTestRun("Connect to bob.foo.com with cert")
@@ -151,7 +143,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert signed-bob-foo.pem --key signed-foo.key --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
 tr = Test.AddTestRun("Connect to bob.foo.com with bad cert")
@@ -161,7 +152,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert server.pem --key server.key --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
 tr = Test.AddTestRun("Connect to bar.com without cert")
@@ -169,7 +159,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 35
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("alert handshake failure", "TLS handshake should fail")
 
 tr = Test.AddTestRun("Connect to bar.com with cert")
@@ -179,7 +168,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert signed-bar.pem --key signed-bar.key --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "TLS handshake should succeed")
 
 tr = Test.AddTestRun("Connect to bar.com with bad cert")
@@ -189,7 +177,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert server.pem --key server.key --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 35
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("alert unknown ca", "TLS handshake should fail")
 
 

--- a/tests/gold_tests/tls/tls_client_verify2.test.py
+++ b/tests/gold_tests/tls/tls_client_verify2.test.py
@@ -44,8 +44,6 @@ ts.addSSLfile("ssl/signer.pem")
 
 ts.Variables.ssl_port = 4443
 ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'ssl',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.http.server_ports': '{0}:ssl'.format(ts.Variables.ssl_port),
@@ -54,6 +52,7 @@ ts.Disk.records_config.update({
     'proxy.config.url_remap.pristine_host_hdr' : 1,
     'proxy.config.ssl.client.certification_level': 0,
     'proxy.config.ssl.CA.cert.path': '',
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
     'proxy.config.ssl.CA.cert.filename': '{0}/signer.pem'.format(ts.Variables.SSLDir)
 })
 
@@ -84,7 +83,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
 tr = Test.AddTestRun("Connect to foo.com with cert")
@@ -94,7 +92,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert signed-foo.pem --key signed-foo.key --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
 tr = Test.AddTestRun("Connect to bob.bar.com without cert")
@@ -102,7 +99,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 35 
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("alert", "TLS handshake should fail")
 
 tr = Test.AddTestRun("Connect to bob.bar.com with cert")
@@ -112,7 +108,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert signed-bob-bar.pem --key signed-bar.key --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "TLS handshake should succeed")
 
 tr = Test.AddTestRun("Connect to bob.bar.com with bad cert")
@@ -122,7 +117,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert server.pem --key server.key --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 35 
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("error", "TLS handshake should fail")
 
 tr = Test.AddTestRun("Connect to bob.foo.com without cert")
@@ -130,7 +124,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 35 
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("alert", "TLS handshake should fail")
 
 tr = Test.AddTestRun("Connect to bob.foo.com with cert")
@@ -140,7 +133,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert signed-bob-foo.pem --key signed-foo.key --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "TLS handshake should succeed")
 
 tr = Test.AddTestRun("Connect to bob.foo.com with bad cert")
@@ -150,7 +142,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert server.pem --key server.key --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 35 
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("error", "TLS handshake should fail")
 
 tr = Test.AddTestRun("Connect to bar.com without cert")
@@ -158,7 +149,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0 
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("alert", "TLS handshake should succeed")
 
 tr = Test.AddTestRun("Connect to bar.com with cert")
@@ -168,7 +158,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert signed-bar.pem --key signed-bar.key --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
 tr = Test.AddTestRun("Connect to bar.com with bad cert")
@@ -178,6 +167,5 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert server.pem --key server.key --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("alert unknown ca", "TLS handshake should succeed")
 

--- a/tests/gold_tests/tls/tls_client_versions.test.py
+++ b/tests/gold_tests/tls/tls_client_versions.test.py
@@ -52,8 +52,6 @@ ts.Disk.ssl_multicert_config.AddLine(
 )
 
 ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.diags.debug.tags': 'http|ssl',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     # enable ssl port
@@ -63,6 +61,7 @@ ts.Disk.records_config.update({
     'proxy.config.url_remap.pristine_host_hdr': 1,
     'proxy.config.ssl.TLSv1': 0,
     'proxy.config.ssl.TLSv1_1': 0,
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
     'proxy.config.ssl.TLSv1_2': 1
 })
 
@@ -81,7 +80,6 @@ tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Varia
 tr.Processes.Default.Command = "curl -v --tls-max 1.2 --tlsv1.2 --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(ts.Variables.ssl_port)
 tr.ReturnCode = 35 
 tr.StillRunningAfter = ts
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("ssl_choose_client_version:unsupported protocol", "Should not allow TLSv1_2")
 
 # Target foo.com for TLSv1.  Should succeed
@@ -89,14 +87,12 @@ tr = Test.AddTestRun("foo.com TLSv1")
 tr.Processes.Default.Command = "curl -v --tls-max 1.0 --tlsv1 --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(ts.Variables.ssl_port)
 tr.ReturnCode = 0
 tr.StillRunningAfter = ts
-tr.Processes.Default.TimeOut = 10
 
 # Target bar.com for TLSv1.  Should fail
 tr = Test.AddTestRun("bar.com TLSv1")
 tr.Processes.Default.Command = "curl -v --tls-max 1.0 --tlsv1 --resolve 'bar.com:{0}:127.0.0.1' -k  https://bar.com:{0}".format(ts.Variables.ssl_port)
 tr.ReturnCode = 35 
 tr.StillRunningAfter = ts
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("alert protocol version", "Should not allow TLSv1_0")
 
 # Target bar.com for TLSv1_2.  Should succeed
@@ -104,5 +100,4 @@ tr = Test.AddTestRun("bar.com TLSv1_2")
 tr.Processes.Default.Command = "curl -v --tls-max 1.2 --tlsv1.2 --resolve 'bar.com:{0}:127.0.0.1' -k  https://bar.com:{0}".format(ts.Variables.ssl_port)
 tr.ReturnCode = 0
 tr.StillRunningAfter = ts
-tr.Processes.Default.TimeOut = 10
 

--- a/tests/gold_tests/tls/tls_forward_nonhttp.test.py
+++ b/tests/gold_tests/tls/tls_forward_nonhttp.test.py
@@ -45,14 +45,13 @@ ts.Disk.ssl_multicert_config.AddLine(
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
 ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http|ssl',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     # enable ssl port
     'proxy.config.http.server_ports': '{0} {1}:proto=http2;http:ssl'.format(ts.Variables.port, ts.Variables.ssl_port),
     'proxy.config.http.connect_ports': '{0} 4444'.format(ts.Variables.ssl_port),
     'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
     'proxy.config.url_remap.pristine_host_hdr': 1
 })
 
@@ -69,7 +68,6 @@ tr.Processes.Default.Command = "sh test-nc-s_client.sh 4444 4443"
 tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.ssl_port))
 tr.StillRunningAfter = ts
-tr.Processes.Default.TimeOut = 10
 testout_path = os.path.join(Test.RunDirectory, "test.out")
 tr.Disk.File(testout_path, id = "testout")
 tr.Processes.Default.Streams.All += Testers.IncludesExpression("This is a reply", "s_client should get response")

--- a/tests/gold_tests/tls/tls_hooks_verify.test.py
+++ b/tests/gold_tests/tls/tls_hooks_verify.test.py
@@ -38,6 +38,7 @@ ts.addSSLfile("ssl/server.key")
 
 ts.Variables.ssl_port = 4443
 ts.Disk.records_config.update({
+    # Test looks for debug output from the plugin
     'proxy.config.diags.debug.enabled': 1,
     'proxy.config.diags.debug.tags': 'ssl_verify_test',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
@@ -47,6 +48,7 @@ ts.Disk.records_config.update({
     'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
     'proxy.config.ssl.client.verify.server.policy': 'ENFORCED',
     'proxy.config.ssl.client.verify.server.properties': 'NONE',
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
     'proxy.config.url_remap.pristine_host_hdr': 1
 })
 

--- a/tests/gold_tests/tls/tls_keepalive.test.py
+++ b/tests/gold_tests/tls/tls_keepalive.test.py
@@ -36,14 +36,13 @@ ts.addSSLfile("ssl/server.key")
 
 ts.Variables.ssl_port = 4443
 ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'ssl_hook_test|log',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     # enable ssl port
     'proxy.config.http.server_ports': '{0}:ssl'.format(ts.Variables.ssl_port),
     'proxy.config.ssl.TLSv1_3': 0,
     'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
     'proxy.config.log.max_secs_per_buffer': 1
 })
 
@@ -102,4 +101,3 @@ tr.Processes.Default.ReturnCode = 0
 
 ts.Disk.squid_log.Content = "gold/accesslog.gold"
 
-tr.Processes.Default.TimeOut = 10

--- a/tests/gold_tests/tls/tls_ticket.test.py
+++ b/tests/gold_tests/tls/tls_ticket.test.py
@@ -66,6 +66,7 @@ ts.Disk.records_config.update({
     'proxy.config.http.server_ports': '{0}:proto=http2;http:ssl'.format(ts.Variables.ssl_port),
     'proxy.config.ssl.client.verify.server':  0,
     'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
     'proxy.config.ssl.server.session_ticket.enable': '1',
     'proxy.config.ssl.server.ticket_key.filename': '../../file.ticket'
 })
@@ -76,6 +77,7 @@ ts2.Disk.records_config.update({
     'proxy.config.ssl.client.verify.server':  0,
     'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
     'proxy.config.ssl.server.session_ticket.enable': '1',
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
     'proxy.config.ssl.server.ticket_key.filename': '../../file.ticket'
 })
 
@@ -89,7 +91,6 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.ssl_port))
 path1 = tr.Processes.Default.Streams.stdout.AbsPath
 tr.StillRunningAfter = server
-tr.Processes.Default.TimeOut = 10
 
 # Pull out session created in tr to test for session id in tr2
 def checkSession(ev) :
@@ -123,5 +124,4 @@ tr2.Command = 'echo -e "GET / HTTP/1.0\r\n" | openssl s_client -tls1_2 -connect 
 tr2.Processes.Default.StartBefore(Test.Processes.ts2, ready=When.PortOpen(ts2.Variables.ssl_port))
 tr2.ReturnCode = 0
 path2 = tr2.Processes.Default.Streams.stdout.AbsPath
-tr2.Processes.Default.TimeOut = 10
 tr2.Processes.Default.Streams.All.Content = Testers.Lambda(checkSession)

--- a/tests/gold_tests/tls/tls_tunnel_forward.test.py
+++ b/tests/gold_tests/tls/tls_tunnel_forward.test.py
@@ -64,8 +64,6 @@ ts.Disk.ssl_multicert_config.AddLine(
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
 ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http|ssl',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     # enable ssl port
@@ -74,6 +72,7 @@ ts.Disk.records_config.update({
     'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
     'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
     'proxy.config.url_remap.pristine_host_hdr': 1
 })
 
@@ -96,7 +95,6 @@ tr.Processes.Default.StartBefore(server_bar)
 tr.Processes.Default.StartBefore(server_random)
 tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.ssl_port))
 tr.StillRunningAfter = ts
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("Not Found on Accelerato", "Should not try to remap on Traffic Server")
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("CN=foo.com", "Should not TLS terminate on Traffic Server")
@@ -107,7 +105,6 @@ tr2 = Test.AddTestRun("Forward-test")
 tr2.Processes.Default.Command = "curl -v --http1.1  -H 'host:bar.com' --resolve 'bar.com:{0}:127.0.0.1' -k https://bar.com:{0}".format(ts.Variables.ssl_port)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server_bar
-tr2.Processes.Default.TimeOut = 10
 tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.All += Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 tr2.Processes.Default.Streams.All += Testers.ExcludesExpression("Not Found on Accelerato", "Should not try to remap on Traffic Server")
@@ -119,7 +116,6 @@ tr3 = Test.AddTestRun("no-sni-forward-test")
 tr3.Processes.Default.Command = "curl --http1.1 -v -k -H 'host:random.com' https://127.0.0.1:{0}".format(ts.Variables.ssl_port)
 tr3.ReturnCode = 0
 tr3.StillRunningAfter = server_random
-tr3.Processes.Default.TimeOut = 10
 tr3.StillRunningAfter = ts
 tr3.Processes.Default.Streams.All += Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 tr3.Processes.Default.Streams.All += Testers.ExcludesExpression("Not Found on Accelerato", "Should not try to remap on Traffic Server")

--- a/tests/gold_tests/tls/tls_tunnel_plugin_rename.test.py
+++ b/tests/gold_tests/tls/tls_tunnel_plugin_rename.test.py
@@ -62,8 +62,6 @@ ts.Disk.ssl_multicert_config.AddLine(
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
 ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http|ssl',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     # enable ssl port
@@ -72,6 +70,7 @@ ts.Disk.records_config.update({
     'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
     'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
     'proxy.config.url_remap.pristine_host_hdr': 1
 })
 
@@ -93,7 +92,6 @@ tr.Processes.Default.StartBefore(server_bar)
 tr.Processes.Default.StartBefore(server_random)
 tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.ssl_port))
 tr.StillRunningAfter = server_random
-tr.Processes.Default.TimeOut = 10
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("Not Found on Accelerato", "Should not try to remap on Traffic Server")

--- a/tests/gold_tests/tls/tls_verify.test.py
+++ b/tests/gold_tests/tls/tls_verify.test.py
@@ -71,8 +71,6 @@ ts.Disk.ssl_multicert_config.AddLine(
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
 ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.diags.debug.tags': 'http|ssl',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     # enable ssl port
@@ -83,6 +81,7 @@ ts.Disk.records_config.update({
     'proxy.config.ssl.client.verify.server.properties': 'SIGNATURE',
     'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
     'proxy.config.url_remap.pristine_host_hdr': 1
 })
 
@@ -109,7 +108,6 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.ssl_port))
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr2 = Test.AddTestRun("Override-enforcing-Test")
@@ -117,7 +115,6 @@ tr2.Processes.Default.Command = "curl -v -k -H \"host: bar.com\"  https://127.0.
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.StillRunningAfter = ts
-tr2.Processes.Default.TimeOut = 10
 tr2.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr3 = Test.AddTestRun("Override-enforcing-Test-fail-name-check")
@@ -126,7 +123,6 @@ tr3.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Con
 tr3.ReturnCode = 0
 tr3.StillRunningAfter = server
 tr3.StillRunningAfter = ts
-tr3.Processes.Default.TimeOut = 10
 
 # Over riding the built in ERROR check since we expect tr3 to fail
 ts.Disk.diags_log.Content = Testers.ExcludesExpression("verification failed", "Make sure the signatures didn't fail")

--- a/tests/gold_tests/tls/tls_verify2.test.py
+++ b/tests/gold_tests/tls/tls_verify2.test.py
@@ -71,8 +71,6 @@ ts.Disk.ssl_multicert_config.AddLine(
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
 ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.diags.debug.tags': 'http|ssl',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     # enable ssl port
@@ -83,6 +81,7 @@ ts.Disk.records_config.update({
     'proxy.config.ssl.client.verify.server.properties': 'ALL',
     'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
     'proxy.config.url_remap.pristine_host_hdr': 1
 })
 
@@ -116,14 +115,12 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.ssl_port))
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr2 = Test.AddTestRun("override-disabled")
 tr2.Processes.Default.Command = "curl -k -H \"host: random.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
-tr2.Processes.Default.TimeOut = 10
 tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
@@ -132,7 +129,6 @@ tr3.Processes.Default.Command = "curl -k -H \"host: bar.com\"  https://127.0.0.1
 tr3.ReturnCode = 0
 tr3.StillRunningAfter = server
 tr3.StillRunningAfter = ts
-tr3.Processes.Default.TimeOut = 10
 tr3.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr4 = Test.AddTestRun("override-permissive-bad-name")
@@ -140,7 +136,6 @@ tr4.Processes.Default.Command = "curl -k -H \"host: bad_bar.com\"  https://127.0
 tr4.ReturnCode = 0
 tr4.StillRunningAfter = server
 tr4.StillRunningAfter = ts
-tr4.Processes.Default.TimeOut = 10
 tr4.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr5 = Test.AddTestRun("default-enforce-bad-sig")
@@ -149,7 +144,6 @@ tr5.ReturnCode = 0
 tr5.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Curl attempt should have failed")
 tr5.StillRunningAfter = server
 tr5.StillRunningAfter = ts
-tr5.Processes.Default.TimeOut = 10
 
 tr6 = Test.AddTestRun("default-enforce-fail")
 tr6.Processes.Default.Command = "curl -k -H \"host: bad_foo.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port)
@@ -157,7 +151,6 @@ tr6.ReturnCode = 0
 tr6.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Curl attempt should have failed")
 tr6.StillRunningAfter = server
 tr6.StillRunningAfter = ts
-tr6.Processes.Default.TimeOut = 10
 
 
 # No name checking for the sig-only permissive override for bad_bar

--- a/tests/gold_tests/tls/tls_verify3.test.py
+++ b/tests/gold_tests/tls/tls_verify3.test.py
@@ -71,8 +71,6 @@ ts.Disk.ssl_multicert_config.AddLine(
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
 ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'ssl|http|url',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     # enable ssl port
@@ -83,6 +81,7 @@ ts.Disk.records_config.update({
     'proxy.config.ssl.client.verify.server.properties': 'ALL',
     'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
     'proxy.config.url_remap.pristine_host_hdr': 1
 })
 
@@ -110,7 +109,6 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.ssl_port))
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr = Test.AddTestRun("my.foo.com Permissive-Test log failure")
@@ -118,7 +116,6 @@ tr.Processes.Default.Command = "curl -v -k --resolve 'my.foo.com:{0}:127.0.0.1' 
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 
@@ -126,7 +123,6 @@ tr2 = Test.AddTestRun("bob.bar.com Override-enforcing-Test")
 tr2.Processes.Default.Command = "curl -v -k --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/".format(ts.Variables.ssl_port)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
-tr2.Processes.Default.TimeOut = 10
 tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Curl attempt should have succeeded")
 
@@ -136,7 +132,6 @@ tr3.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Con
 tr3.ReturnCode = 0
 tr3.StillRunningAfter = server
 tr3.StillRunningAfter = ts
-tr3.Processes.Default.TimeOut = 10
 
 tr3 = Test.AddTestRun("random.bar.com override-no-test")
 tr3.Processes.Default.Command = "curl -v -k --resolve 'random.bar.com:{0}:127.0.0.1' https://random.bar.com:{0}".format(ts.Variables.ssl_port)
@@ -144,7 +139,6 @@ tr3.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Con
 tr3.ReturnCode = 0
 tr3.StillRunningAfter = server
 tr3.StillRunningAfter = ts
-tr3.Processes.Default.TimeOut = 10
 
 
 # Over riding the built in ERROR check since we expect tr3 to fail

--- a/tests/gold_tests/tls/tls_verify_base.test.py
+++ b/tests/gold_tests/tls/tls_verify_base.test.py
@@ -71,8 +71,6 @@ ts.Disk.ssl_multicert_config.AddLine(
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
 ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.diags.debug.tags': 'http|ssl',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     # enable ssl port
@@ -83,6 +81,7 @@ ts.Disk.records_config.update({
     'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
     'proxy.config.url_remap.pristine_host_hdr': 1,
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
     'proxy.config.ssl.client.sni_policy': 'host'
 })
 
@@ -108,7 +107,6 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.ssl_port))
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr = Test.AddTestRun("Permissive-Test with logged failure")
@@ -116,7 +114,6 @@ tr.Processes.Default.Command = "curl -v -k -H \"host: random.com\" https://127.0
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 
@@ -124,7 +121,6 @@ tr2 = Test.AddTestRun("Override-enforcing-Test")
 tr2.Processes.Default.Command = "curl -v -k -H \"host: bar.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
-tr2.Processes.Default.TimeOut = 10
 tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
@@ -134,7 +130,6 @@ tr3.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Con
 tr3.ReturnCode = 0
 tr3.StillRunningAfter = server
 tr3.StillRunningAfter = ts
-tr3.Processes.Default.TimeOut = 10
 
 # Over riding the built in ERROR check since we expect tr3 to fail
 ts.Disk.diags_log.Content = Testers.ContainsExpression("WARNING: SNI \(bad_bar.com\) not in certificate. Action=Terminate", "Make sure bad_bar name checked failed.")

--- a/tests/gold_tests/tls/tls_verify_ca_override.test.py
+++ b/tests/gold_tests/tls/tls_verify_ca_override.test.py
@@ -73,8 +73,6 @@ ts.Disk.ssl_multicert_config.AddLine(
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
 ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http|ssl',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     # enable ssl port
@@ -85,6 +83,7 @@ ts.Disk.records_config.update({
     'proxy.config.ssl.client.verify.server.properties': 'SIGNATURE',
     'proxy.config.ssl.client.CA.cert.path': '/tmp',
     'proxy.config.ssl.client.CA.cert.filename': '{0}/signer.pem'.format(ts.Variables.SSLDir),
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
     'proxy.config.url_remap.pristine_host_hdr': 1
 })
 
@@ -100,7 +99,6 @@ tr.Processes.Default.StartBefore(server2)
 tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.port))
 tr.StillRunningAfter = server1
 tr.StillRunningAfter = ts
-tr.Processes.Default.TimeOut = 10
 # Should succed.  No message
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
@@ -108,7 +106,6 @@ tr2 = Test.AddTestRun("Use incorrect ca  bundle for server 1")
 tr2.Processes.Default.Command = "curl -k -H \"host: bar.com\"  http://127.0.0.1:{0}/badcase1".format(ts.Variables.port)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server1
-tr2.Processes.Default.TimeOut = 10
 tr2.StillRunningAfter = ts
 # Should succeed, but will be message in log about name mismatch
 tr2.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Curl attempt should have succeeded")
@@ -117,7 +114,6 @@ tr2 = Test.AddTestRun("Use currect ca bundle for server 2")
 tr2.Processes.Default.Command = "curl -k -H \"host: random.com\"  http://127.0.0.1:{0}/case2".format(ts.Variables.port)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server2
-tr2.Processes.Default.TimeOut = 10
 tr2.StillRunningAfter = ts
 # Should succeed, but will be message in log about signature 
 tr2.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
@@ -129,6 +125,5 @@ tr3.StillRunningAfter = server2
 tr3.StillRunningAfter = ts
 # Should succeed.  No error messages
 tr3.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Curl attempt should have succeeded")
-tr3.Processes.Default.TimeOut = 10
 
 

--- a/tests/gold_tests/tls/tls_verify_not_pristine.test.py
+++ b/tests/gold_tests/tls/tls_verify_not_pristine.test.py
@@ -61,8 +61,6 @@ ts.Disk.ssl_multicert_config.AddLine(
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
 ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.diags.debug.tags': 'http|ssl|dns|hostdb',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     # enable ssl port
@@ -75,6 +73,7 @@ ts.Disk.records_config.update({
     'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
     'proxy.config.url_remap.pristine_host_hdr': 0,
     'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
     'proxy.config.dns.resolv_conf': 'NULL'
 })
 
@@ -95,7 +94,6 @@ tr.Processes.Default.StartBefore(dns)
 tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.ssl_port))
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 # foo.com in.  bar.com out.  Should not verify
@@ -103,7 +101,6 @@ tr2 = Test.AddTestRun("Enforced-bad-test")
 tr2.Processes.Default.Command = "curl -v -k --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}".format(ts.Variables.ssl_port)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
-tr2.Processes.Default.TimeOut = 10
 tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Curl attempt should not have succeeded")
 

--- a/tests/gold_tests/tls/tls_verify_override_base.test.py
+++ b/tests/gold_tests/tls/tls_verify_override_base.test.py
@@ -89,8 +89,6 @@ ts.Disk.ssl_multicert_config.AddLine(
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
 ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http|ssl',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     # enable ssl port
@@ -101,6 +99,7 @@ ts.Disk.records_config.update({
     'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
     'proxy.config.url_remap.pristine_host_hdr': 1,
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
     'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
     'proxy.config.dns.resolv_conf': 'NULL'
 })
@@ -123,7 +122,6 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.port))
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-tr.Processes.Default.TimeOut = 10
 # Should succed.  No message
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
@@ -131,7 +129,6 @@ tr2 = Test.AddTestRun("default-permissive-fail")
 tr2.Processes.Default.Command = "curl -k -H \"host: bar.com\"  http://127.0.0.1:{0}/basic".format(ts.Variables.port)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
-tr2.Processes.Default.TimeOut = 10
 tr2.StillRunningAfter = ts
 # Should succeed, but will be message in log about name mismatch
 tr2.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
@@ -140,7 +137,6 @@ tr2 = Test.AddTestRun("default-permissive-fail2")
 tr2.Processes.Default.Command = "curl -k -H \"host: random.com\"  http://127.0.0.1:{0}/basic".format(ts.Variables.port)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
-tr2.Processes.Default.TimeOut = 10
 tr2.StillRunningAfter = ts
 # Should succeed, but will be message in log about signature 
 tr2.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
@@ -152,7 +148,6 @@ tr3.StillRunningAfter = server
 tr3.StillRunningAfter = ts
 # Should succeed.  No error messages
 tr3.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
-tr3.Processes.Default.TimeOut = 10
 
 tr4 = Test.AddTestRun("override-bar-disabled")
 tr4.Processes.Default.Command = "curl -k -H \"host: bad_bar.com\"  http://127.0.0.1:{0}/overridedisabled".format(ts.Variables.port)
@@ -161,7 +156,6 @@ tr4.StillRunningAfter = server
 tr4.StillRunningAfter = ts
 # Succeed. No error messages
 tr4.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
-tr4.Processes.Default.TimeOut = 10
 
 tr5 = Test.AddTestRun("override-bar-signature-enforced")
 tr5.Processes.Default.Command = "curl -k -H \"host: bar.com\"  http://127.0.0.1:{0}/overridesignature".format(ts.Variables.port)
@@ -169,7 +163,6 @@ tr5.ReturnCode = 0
 tr5.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 tr5.StillRunningAfter = server
 tr5.StillRunningAfter = ts
-tr5.Processes.Default.TimeOut = 10
 
 tr6 = Test.AddTestRun("override-bar-enforced")
 tr6.Processes.Default.Command = "curl -k -H \"host: bar.com\"  http://127.0.0.1:{0}/overrideenforced".format(ts.Variables.port)
@@ -178,7 +171,6 @@ tr6.ReturnCode = 0
 tr6.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Curl attempt should have failed")
 tr6.StillRunningAfter = server
 tr6.StillRunningAfter = ts
-tr6.Processes.Default.TimeOut = 10
 
 # Should succeed
 tr = Test.AddTestRun("foo-to-bar-sni-policy-remap")
@@ -186,7 +178,6 @@ tr.Processes.Default.Command = "curl -k -H \"host: foo.com\"  http://127.0.0.1:{
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could not connect", "Curl attempt should succeed")
 
 # Should fail
@@ -195,7 +186,6 @@ tr.Processes.Default.Command = "curl -k -H \"host: foo.com\"  http://127.0.0.1:{
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could not connect", "Curl attempt should fail")
 
 # Should fail
@@ -204,7 +194,6 @@ tr.Processes.Default.Command = "curl -k -H \"host: bar.com\"  http://127.0.0.1:{
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could not connect", "Curl attempt should fail")
 
 # Should succeed
@@ -213,7 +202,6 @@ tr.Processes.Default.Command = "curl -k -H \"host: bar.com\"  http://127.0.0.1:{
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could not connect", "Curl attempt should succeed")
 
 


### PR DESCRIPTION
Update logic to use the proxy.config.ssl.client.cert.path and proxy.config.ssl.client.private_key.path settings when loading client_cert and client_key from the ssl_server_name.yaml file.

Updated one of the tests to exercise this case. 