### PR TITLE
Add IOBufferReader::block_read_view method.

### DIFF
--- a/iocore/eventsystem/I_IOBuffer.h
+++ b/iocore/eventsystem/I_IOBuffer.h
@@ -714,6 +714,12 @@ public:
   */
   int64_t block_read_avail();
 
+  /** Get a view of the data available to read.
+   *
+   * @return A view encompassing currently available readable data.
+   */
+  std::string_view block_read_view();
+
   void skip_empty_blocks();
 
   /**

--- a/iocore/eventsystem/P_IOBuffer.h
+++ b/iocore/eventsystem/P_IOBuffer.h
@@ -621,6 +621,13 @@ IOBufferReader::block_read_avail()
   return (int64_t)(block->end() - (block->start() + start_offset));
 }
 
+inline std::string_view
+IOBufferReader::block_read_view()
+{
+  const char *start = this->start(); // empty blocks are skipped in here.
+  return start ? std::string_view{start, static_cast<size_t>(block->end() - start)} : std::string_view{};
+}
+
 TS_INLINE int
 IOBufferReader::block_count()
 {


### PR DESCRIPTION
This enables use of `string_view` in the MIME and HTTP header classes, where those classes pull data out of `IOBufferReader` instances. The main thing is to simplify / eliminate the `nullptr` checks by the caller by having `IOBufferReader::block_read_view` make sure the view is empty if the start pointer is `nullptr`.