### PR TITLE
Turns off HostDB disk sync by default

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -2715,9 +2715,10 @@ HostDB
 
    The filename to persist hostdb to on disk.
 
-.. ts:cv:: CONFIG proxy.config.cache.hostdb.sync_frequency INT 120
+.. ts:cv:: CONFIG proxy.config.cache.hostdb.sync_frequency INT 0
 
-   Set the frequency (in seconds) to sync hostdb to disk.
+   Set the frequency (in seconds) to sync hostdb to disk. If set to zero (default as of v9.0.0), we won't
+   sync to disk ever.
 
    Note: hostdb is syncd to disk on a per-partition basis (of which there are 64).
    This means that the minimum time to sync all data to disk is :ts:cv:`proxy.config.cache.hostdb.sync_frequency` * 64

--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -59,7 +59,7 @@ static ink_time_t hostdb_hostfile_update_timestamp = 0;
 static char hostdb_filename[PATH_NAME_MAX]         = DEFAULT_HOST_DB_FILENAME;
 int hostdb_max_count                               = DEFAULT_HOST_DB_SIZE;
 char hostdb_hostfile_path[PATH_NAME_MAX]           = "";
-int hostdb_sync_frequency                          = 120;
+int hostdb_sync_frequency                          = 0;
 int hostdb_disable_reverse_lookup                  = 0;
 
 ClassAllocator<HostDBContinuation> hostDBContAllocator("hostDBContAllocator");

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -961,7 +961,7 @@ static const RecordElement RecordsConfig[] =
   {RECT_CONFIG, "proxy.config.hostdb.timed_round_robin", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
   //       # how often should the hostdb be synced (seconds)
-  {RECT_CONFIG, "proxy.config.cache.hostdb.sync_frequency", RECD_INT, "120", RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  {RECT_CONFIG, "proxy.config.cache.hostdb.sync_frequency", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.hostdb.host_file.path", RECD_STRING, nullptr, RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,


### PR DESCRIPTION
We've been running with this set to 0 for quite a while, and I still
feel that the whole disk synching mechanism of HostDB is not particularly
valid. This is a step towards simplifying HostDB, such that moving to a
non-persistent / in memory "DB" is more straight forward.