### PR TITLE
Adds support for a YAML formatted parent.config file.

### DIFF
--- a/configs/Makefile.am
+++ b/configs/Makefile.am
@@ -32,6 +32,7 @@ dist_sysconf_DATA =	\
 	ip_allow.config.default \
 	logging.yaml.default \
 	parent.config.default \
+	parent.yaml.default \
 	plugin.config.default \
 	remap.config.default \
 	socks.config.default \

--- a/configs/parent.schema.json
+++ b/configs/parent.schema.json
@@ -1,0 +1,174 @@
+{
+  "title": "Traffic Server parents configuration",
+  "description": "parent configuration file structure. Licensed under Apache V2 https://www.apache.org/licenses/LICENSE-2.0",
+  "type": "object",
+  "properties": {
+    "parents": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "properties": {
+          "dest_domain": {
+            "description": "A requested domain name, and its subdomains.",
+            "type": "string"
+          },
+          "dest_host": {
+            "description": "A requested hostname.",
+            "type": "string"
+          },
+          "dest_ip": {
+            "description": "A requested IP address or range of IP addresses separated by a dash (-)..",
+            "type": "string"
+          },
+          "url_regex": {
+            "description": "A regular expression (regex) to be found in a URL.",
+            "type": "string"
+          },
+          "internal": {
+            "description": "A boolean value, true or false, specifying if the rule should match (or not match) a transaction originating from an internal API.",
+            "enum": [
+              true,
+              false
+            ]
+          },
+          "go_direct": {
+            "description": "send the request directly to the origin bypassing the parent list.",
+            "enum": [
+              true,
+              false
+            ]
+          },
+          "max_simple_retries": {
+            "description": "The maximum number of retries for a simple retry.",
+            "type": "number",
+            "minimum": 1,
+            "maximum": 5
+          },
+          "max_unavailable_server_retries": {
+            "description": "The maximum number of retries for an unavailable server retry.",
+            "type": "number",
+            "minimum": 1,
+            "maximum": 5
+          },
+          "method": {
+            "description": "A request URL method",
+            "type": "string",
+            "enum": [
+              "get",
+              "post",
+              "put",
+              "trace"
+            ]
+          },
+          "parent_retry": {
+            "description": "Use one or both of 'simple_retry', or 'unavailable_server_retry'",
+            "type": "string",
+            "enum": [
+              "simple_retry",
+              "unavailable_server_retry",
+              "both"
+            ]
+          },
+          "parent_is_proxy": {
+            "description": "The parents listed in parent and secondary_parent are caching proxies, set to false if they are origins",
+            "enum": [
+              true,
+              false
+            ]
+          },
+          "port": {
+            "description": "A requested URL port.",
+            "type": "number"
+          },
+          "prefix": {
+            "description": "A prefix in the path part of a URL.",
+            "type": "string"
+          },
+          "qstring": {
+            "description": "use or ignore the query string when looking up a parent with consistent_hash",
+            "type": "string",
+            "enum": [
+              "consider",
+              "ignore"
+            ]
+          },
+          "round_robin": {
+            "description": "select to use one of the parent strategy algorithms, default is 'false'",
+            "enum": [
+              "true",
+              "false",
+              "strict",
+              "consistent_hash",
+              "latched"
+            ]
+          },
+          "scheme": {
+            "description": "A request URL method.",
+            "type": "string",
+            "enum": [
+              "http",
+              "https"
+            ]
+          },
+          "secondary_mode": {
+            "description": "The secondary parent list mode (see parent.config doc), defaults to 1.",
+            "type": "number",
+            "minimum": 1,
+            "maximum": 3
+          },
+          "src_ip": {
+            "description": "A client IP address.",
+            "type": "string"
+          },
+          "suffix": {
+            "description": "A file suffix in the URL.",
+            "type": "string"
+          },
+          "time": {
+            "description": "A time range, such as 08:00-14:00, during which the parent cache is used to serve requests.",
+            "type": "string"
+          },
+          "parent": {
+            "description": "list of primary parents",
+            "type": "string"
+          },
+          "secondary_parent": {
+            "description": "list of secondary parents",
+            "type": "string"
+          },
+          "unavailable_server_retry_responses": {
+            "description": "When using unavailable_server retry, use this to specify a csv separated list of 5xx resposne codes, default is '503'",
+            "type": "string"
+          }
+        },
+        "oneOf": [
+          {
+            "required": [
+              "dest_domain"
+            ]
+          },
+          {
+            "required": [
+              "dest_host"
+            ]
+          },
+          {
+            "required": [
+              "dest_ip"
+            ]
+          },
+          {
+            "required": [
+              "url_regex"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "parents"
+  ]
+}

--- a/configs/parent.schema.json
+++ b/configs/parent.schema.json
@@ -27,17 +27,11 @@
           },
           "internal": {
             "description": "A boolean value, true or false, specifying if the rule should match (or not match) a transaction originating from an internal API.",
-            "enum": [
-              true,
-              false
-            ]
+            "type": "boolean"
           },
           "go_direct": {
             "description": "send the request directly to the origin bypassing the parent list.",
-            "enum": [
-              true,
-              false
-            ]
+            "type": "boolean"
           },
           "max_simple_retries": {
             "description": "The maximum number of retries for a simple retry.",
@@ -72,10 +66,7 @@
           },
           "parent_is_proxy": {
             "description": "The parents listed in parent and secondary_parent are caching proxies, set to false if they are origins",
-            "enum": [
-              true,
-              false
-            ]
+            "type": "boolean"
           },
           "port": {
             "description": "A requested URL port.",

--- a/configs/parent.yaml.default
+++ b/configs/parent.yaml.default
@@ -1,0 +1,79 @@
+#
+# parent.yaml
+#
+# Documentation:
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/parent.config.en.html
+#
+# The purpose of this file is to specify the parent proxy for
+#   specific objects or sets of objects
+#
+# This is the yaml version of the parent.config.  Set 'proxy.config.http.parent_proxy.file'
+# to 'parent.yaml' to use a yaml formatted configuration, ie:
+#
+#   CONFIG proxy.config.http.parent_proxy.file STRING parent.yaml
+#
+# All entries are part of a yaml sequence, both sequence formats are supported, see below.
+#
+# Each record must include exactly one primary specifier
+#
+#   Primary destination specifiers are
+#     dest_domain:
+#     dest_host:
+#     dest_ip:
+#     url_regex:
+#
+#
+# record may include any number of the secondary specifiers but
+#    secondary specifiers may not be duplicated in the same record
+#
+#   Secondary specifiers are
+#     port:
+#     scheme:
+#     prefix:
+#     suffix:
+#     method:
+#     time:
+#     src_ip:
+#     internal: {true,false}
+#
+# Available parent directives are:
+#     parent:    (a semicolon separated list of parent proxies)
+#     go_direct: {true,false}
+#     round_robin: {strict,true,false,consistent_hash,latched}
+#
+# Note: for round_robin, strict means strict round_robin - parents are
+#	tried one by one, true means round_robin based on client IP
+#	addresses, false means no round_robin, consisten_hash means a hash
+#	algorithm over the url path is used, latched is the same as false
+#	but will stay latched to a selected parent until it is marked down.
+#
+# Each line must include a parent: directive or a go_direct:
+#   directive.  If both appear, Traffic Server will directly
+#   contact the origin server if all the listed parent proxies
+#   are down
+#
+# Example for two records one in two different yaml sequence formats:
+#
+#  Alternate requests between proxy1 and proxy2
+#
+# Sequence Format 1 (2 entries), most readable, dashes matter:
+#
+# - { dest_domain: "stooges.net", parent: "curly:80|1.0;joe:80|1.0;larry:80|1.0",
+#     round_robin: "consistent_hash", go_direct: true}
+# - { dest_domain: "lucy.net", parent: "ethel:80|1.0;fred:80|1.0;ricky:80|1.0",
+#     roun_robin: "true", go_direct: false}
+#
+# Sequence Format 2 (two entries), tabs and dashes matter.
+#
+# - 
+#   dest_domain: "stooges.net"
+#   parent: "curly:80|1.0;joe:80|1.0;larry:80|1.0"
+#   round_robin: "consistent_hash" 
+#   go_direct: true
+# - 
+#   dest_domain: "lucy.net" 
+#   parent: "ethel:80|1.0;fred:80|1.0;ricky:80|1.0"
+#   roun_robin: "true" 
+#   go_direct: false
+#
+#

--- a/doc/admin-guide/files/parent.config.en.rst
+++ b/doc/admin-guide/files/parent.config.en.rst
@@ -21,23 +21,33 @@
 parent.config
 =============
 
-.. configfile:: parent.config
+.. configfile:: parent.config, parent.yaml
 
-The :file:`parent.config` file identifies the parent proxies used in an
+The :file:`parent.config` or optionally `parent.yaml` file identifies the parent proxies used in an
 cache hierarchy. Use this file to perform the following configuration:
 
 -  Set up parent cache hierarchies, with multiple parents and parent
    failover
 -  Configure selected URL requests to bypass parent proxies
 
-Traffic Server uses the :file:`parent.config` file only when the parent
+Traffic Server uses the :file:`parent.config` or `parent.yaml` file only when the parent
 caching option is enabled (refer to :ref:`configuring-traffic-server-to-use-a-parent-cache`).
 
-After you modify the :file:`parent.config` file, run the :option:`traffic_ctl config reload`
+After you modify the :file:`parent.config` or `parent.yaml` file, run the :option:`traffic_ctl config reload`
 command to apply your changes.
 
 Format
 ======
+
+Optionally the parent configuration may be expressed using a yaml configuration file. 
+To use `parent.yaml`, set the following in `records.config`::
+
+  CONFIG proxy.config.http.parent_proxy.file STRING parent.yaml
+
+When Yaml is used, each line as described here become yaml object which
+is part of a sequence.  For a YAML example configuration file see::
+
+  configs/parent.yaml.default 
 
 Each line in the :file:`parent.config` file must contain a parent caching
 rule. Traffic Server recognizes three space-delimited tags: ::

--- a/include/tscore/MatcherUtils.h
+++ b/include/tscore/MatcherUtils.h
@@ -34,6 +34,7 @@
 #include "tscore/ParseRules.h"
 #include "tscore/Result.h"
 #include "tscore/ink_inet.h"
+#include "yaml-cpp/yaml.h"
 
 // Look in MatcherUtils.cc for comments on function usage
 char *readIntoBuffer(const char *file_path, const char *module_name, int *read_size_ptr);
@@ -86,6 +87,7 @@ struct matcher_line {
   int num_el;                        // Number of elements
   char *line[2][MATCHER_MAX_TOKENS]; // label, value pairs
   int line_num;                      // config file line number
+  const YAML::Node *node;            // the yaml node if we're parsing yaml
   matcher_line *next;                // use for linked list
 };
 
@@ -113,6 +115,7 @@ extern const matcher_tags ip_allow_dest_tags;
 extern const matcher_tags socks_server_tags;
 
 const char *parseConfigLine(char *line, matcher_line *p_line, const matcher_tags *tags);
+const char *parseYamlDoc(const YAML::Node node, matcher_line *p_line, const matcher_tags *tags);
 
 // inline void LowerCaseStr(char* str)
 //

--- a/iocore/aio/Makefile.am
+++ b/iocore/aio/Makefile.am
@@ -20,7 +20,8 @@ AM_CPPFLAGS += \
 	-I$(abs_top_srcdir)/iocore/eventsystem \
 	-I$(abs_top_srcdir)/include \
 	-I$(abs_top_srcdir)/lib \
-	$(TS_INCLUDES)
+	$(TS_INCLUDES) \
+	@YAMLCPP_INCLUDES@
 
 TESTS = test_AIO.sample
 

--- a/iocore/cache/Makefile.am
+++ b/iocore/cache/Makefile.am
@@ -27,7 +27,8 @@ AM_CPPFLAGS += \
 	-I$(abs_top_srcdir)/proxy/http/remap \
 	-I$(abs_top_srcdir)/mgmt \
 	-I$(abs_top_srcdir)/mgmt/utils \
-	$(TS_INCLUDES)
+	$(TS_INCLUDES) \
+	@YAMLCPP_INCLUDES@
 
 noinst_LIBRARIES = libinkcache.a
 

--- a/iocore/dns/Makefile.am
+++ b/iocore/dns/Makefile.am
@@ -25,7 +25,8 @@ AM_CPPFLAGS += \
 	-I$(abs_top_srcdir)/proxy/hdrs \
 	-I$(abs_top_srcdir)/mgmt \
 	-I$(abs_top_srcdir)/mgmt/utils \
-	$(TS_INCLUDES)
+	$(TS_INCLUDES) \
+	@YAMLCPP_INCLUDES@
 
 noinst_LIBRARIES = libinkdns.a
 

--- a/iocore/hostdb/Makefile.am
+++ b/iocore/hostdb/Makefile.am
@@ -25,7 +25,8 @@ AM_CPPFLAGS += \
 	-I$(abs_top_srcdir)/proxy/http \
 	-I$(abs_top_srcdir)/mgmt \
 	-I$(abs_top_srcdir)/mgmt/utils \
-	$(TS_INCLUDES)
+	$(TS_INCLUDES) \
+	@YAMLCPP_INCLUDES@
 
 EXTRA_DIST = I_HostDB.h
 

--- a/mgmt/Makefile.am
+++ b/mgmt/Makefile.am
@@ -34,7 +34,8 @@ AM_CPPFLAGS += \
 	-I$(abs_top_srcdir)/proxy \
 	-I$(abs_top_srcdir)/proxy/http \
 	-I$(abs_top_srcdir)/proxy/hdrs \
-	$(TS_INCLUDES)
+	$(TS_INCLUDES) \
+	@YAMLCPP_INCLUDES@
 
 libmgmt_c_la_SOURCES = \
 	RecordsConfig.cc \

--- a/proxy/ControlMatcher.h
+++ b/proxy/ControlMatcher.h
@@ -92,6 +92,8 @@
 
 #include "tscore/ink_apidefs.h"
 #include "tscore/ink_defs.h"
+#include "tscore/ts_file.h"
+#include "tscpp/util/TextView.h"
 #include "HTTP.h"
 #include "tscore/Regex.h"
 #include "URL.h"
@@ -301,7 +303,7 @@ template <class Data, class MatchResult> class ControlMatcher
 public:
   // Parameter name must not be deallocated before this
   //  object is
-  ControlMatcher(const char *file_var, const char *name, const matcher_tags *tags,
+  ControlMatcher(const char *file_var, const char *name, const matcher_tags *tags, const char *_yaml_namespace = nullptr,
                  int flags_in = (ALLOW_HOST_TABLE | ALLOW_IP_TABLE | ALLOW_REGEX_TABLE | ALLOW_HOST_REGEX_TABLE | ALLOW_URL_TABLE));
   ~ControlMatcher();
   int BuildTable();
@@ -357,4 +359,8 @@ public:
   int flags                = 0;
   int m_numEntries         = 0;
   const char *matcher_name = "unknown"; // Used for Debug/Warning/Error messages
+  bool config_is_yaml      = false;     // config file is in yaml format.
+  YAML::Node config;
+  YAML::Node root;
+  const char *yaml_namespace = nullptr; // config file top level yaml namespace.
 };

--- a/proxy/Makefile.am
+++ b/proxy/Makefile.am
@@ -32,8 +32,9 @@ AM_CPPFLAGS += \
 	-I$(abs_srcdir)/hdrs \
 	-I$(abs_top_srcdir)/mgmt \
 	-I$(abs_top_srcdir)/mgmt/utils \
-	$(TS_INCLUDES)
-
+	$(TS_INCLUDES) \
+	@YAMLCPP_INCLUDES@
+ 
 noinst_HEADERS = \
 	Show.h
 
@@ -75,7 +76,6 @@ libproxy_a_SOURCES += \
 	RegressionSM.h \
 	RegressionSM.cc
 endif
-
 
 # These are currently built separate, as part of building the lib/ tree, using
 # the normal LuaJIT build system. We are using the .o's directly, instead of the

--- a/proxy/ParentSelection.h
+++ b/proxy/ParentSelection.h
@@ -37,7 +37,9 @@
 #include "tscore/ConsistentHash.h"
 #include "tscore/Tokenizer.h"
 #include "tscore/ink_apidefs.h"
+#include "tscore/ts_file.h"
 #include "HostStatus.h"
+#include "yaml-cpp/yaml.h"
 
 #include <algorithm>
 #include <vector>

--- a/proxy/http/Makefile.am
+++ b/proxy/http/Makefile.am
@@ -32,7 +32,8 @@ AM_CPPFLAGS += \
 	-I$(abs_top_srcdir)/proxy/http/remap \
 	-I$(abs_top_srcdir)/proxy/logging \
 	-I$(abs_top_srcdir)/proxy/http2 \
-	$(TS_INCLUDES)
+	$(TS_INCLUDES) \
+	@YAMLCPP_INCLUDES@
 
 noinst_HEADERS = HttpProxyServerMain.h
 noinst_LIBRARIES = libhttp.a

--- a/proxy/http/remap/Makefile.am
+++ b/proxy/http/remap/Makefile.am
@@ -28,7 +28,8 @@ AM_CPPFLAGS += \
 	-I$(abs_top_srcdir)/proxy/hdrs \
 	-I$(abs_top_srcdir)/proxy/shared \
 	-I$(abs_top_srcdir)/proxy/http \
-	$(TS_INCLUDES)
+	$(TS_INCLUDES) \
+	@YAMLCPP_INCLUDES@
 
 noinst_LIBRARIES = libhttp_remap.a
 

--- a/proxy/http2/Makefile.am
+++ b/proxy/http2/Makefile.am
@@ -29,7 +29,8 @@ AM_CPPFLAGS += \
 	-I$(abs_top_srcdir)/proxy/hdrs \
 	-I$(abs_top_srcdir)/proxy/shared \
 	-I$(abs_top_srcdir)/proxy/http/remap \
-	$(TS_INCLUDES)
+	$(TS_INCLUDES) \
+	@YAMLCPP_INCLUDES@
 
 noinst_LIBRARIES = libhttp2.a
 

--- a/proxy/shared/Makefile.am
+++ b/proxy/shared/Makefile.am
@@ -35,7 +35,8 @@ AM_CPPFLAGS += \
 	-I$(abs_top_srcdir)/proxy/http \
 	-I$(abs_top_srcdir)/proxy/hdrs \
 	-I$(abs_top_srcdir)/proxy/logging \
-	$(TS_INCLUDES)
+	$(TS_INCLUDES) \
+	@YAMLCPP_INCLUDES@
 
 libdiagsconfig_a_SOURCES = \
 	DiagsConfig.cc

--- a/src/traffic_crashlog/Makefile.inc
+++ b/src/traffic_crashlog/Makefile.inc
@@ -25,7 +25,8 @@ traffic_crashlog_traffic_crashlog_CPPFLAGS = \
     -I$(abs_top_srcdir)/mgmt \
     -I$(abs_top_srcdir)/mgmt/utils \
     -I$(abs_top_srcdir)/mgmt/api/include \
-    $(TS_INCLUDES)
+    $(TS_INCLUDES) \
+    @YAMLCPP_INCLUDES@
 
 traffic_crashlog_traffic_crashlog_LDFLAGS = \
     $(AM_LDFLAGS) \

--- a/src/traffic_ctl/Makefile.inc
+++ b/src/traffic_ctl/Makefile.inc
@@ -27,7 +27,8 @@ traffic_ctl_traffic_ctl_CPPFLAGS = \
     -I$(abs_top_srcdir)/mgmt \
     -I$(abs_top_srcdir)/mgmt/api/include \
     -I$(abs_top_srcdir)/proxy \
-    $(TS_INCLUDES)
+    $(TS_INCLUDES) \
+    @YAMLCPP_INCLUDES@
 
 traffic_ctl_traffic_ctl_SOURCES = \
 	traffic_ctl/alarm.cc \

--- a/src/traffic_logcat/Makefile.inc
+++ b/src/traffic_logcat/Makefile.inc
@@ -29,7 +29,8 @@ traffic_logcat_traffic_logcat_CPPFLAGS = \
 	-I$(abs_top_srcdir)/proxy/shared \
 	-I$(abs_top_srcdir)/mgmt \
 	-I$(abs_top_srcdir)/mgmt/utils \
-	$(TS_INCLUDES)
+	$(TS_INCLUDES) \
+  @YAMLCPP_INCLUDES@
 
 traffic_logcat_traffic_logcat_LDFLAGS = \
 	$(AM_LDFLAGS) \

--- a/src/traffic_logstats/Makefile.inc
+++ b/src/traffic_logstats/Makefile.inc
@@ -29,7 +29,8 @@ traffic_logstats_traffic_logstats_CPPFLAGS = \
 	-I$(abs_top_srcdir)/proxy/shared \
 	-I$(abs_top_srcdir)/mgmt \
 	-I$(abs_top_srcdir)/mgmt/utils \
-	$(TS_INCLUDES)
+	$(TS_INCLUDES) \
+  @YAMLCPP_INCLUDES@
 
 traffic_logstats_traffic_logstats_LDFLAGS = \
 	$(AM_LDFLAGS) \

--- a/src/traffic_manager/Makefile.inc
+++ b/src/traffic_manager/Makefile.inc
@@ -28,7 +28,8 @@ traffic_manager_traffic_manager_CPPFLAGS = \
 	-I$(abs_top_srcdir)/mgmt/api \
 	-I$(abs_top_srcdir)/mgmt/api/include \
 	-I$(abs_top_srcdir)/mgmt/utils \
-	$(TS_INCLUDES)
+	$(TS_INCLUDES) \
+  @YAMLCPP_INCLUDES@
 
 traffic_manager_traffic_manager_LDFLAGS = \
 	$(AM_LDFLAGS) \

--- a/src/traffic_server/Makefile.inc
+++ b/src/traffic_server/Makefile.inc
@@ -34,7 +34,8 @@ traffic_server_traffic_server_CPPFLAGS = \
 	-I$(abs_top_srcdir)/mgmt \
 	-I$(abs_top_srcdir)/mgmt/utils \
 	$(TS_INCLUDES) \
-	@OPENSSL_INCLUDES@
+	@OPENSSL_INCLUDES@ \
+  @YAMLCPP_INCLUDES@
 
 traffic_server_traffic_server_LDFLAGS = \
 	$(AM_LDFLAGS) \

--- a/src/tscore/MatcherUtils.cc
+++ b/src/tscore/MatcherUtils.cc
@@ -618,3 +618,73 @@ parseConfigLine(char *line, matcher_line *p_line, const matcher_tags *tags)
 
   return nullptr;
 }
+
+// char* parseYamlDoc(YAML::Node node, matcher_line* p_line, const matcher_tags* tags)
+//
+//   Parse out a yaml node object suitable for passing to
+//    a ControlMatcher object
+//
+//   If successful, nullptr is returned.  If unsuccessful,
+//     a static error string is returned
+//
+const char *
+parseYamlDoc(const YAML::Node node, matcher_line *p, const matcher_tags *tags)
+{
+  const char *label;
+  std::string_view val;
+  matcher_type type = MATCH_NONE;
+
+  uint dest = 0;
+  if (node[tags->match_ip]) {
+    type  = MATCH_IP;
+    label = tags->match_ip;
+    val   = node[tags->match_ip].Scalar();
+    dest++;
+  } else if (node[tags->match_host]) {
+    type  = MATCH_HOST;
+    label = tags->match_host;
+    val   = node[tags->match_host].Scalar();
+    dest++;
+  } else if (node[tags->match_domain]) {
+    type  = MATCH_DOMAIN;
+    label = tags->match_domain;
+    val   = node[tags->match_domain].Scalar();
+    dest++;
+  } else if (node[tags->match_regex]) {
+    type  = MATCH_REGEX;
+    label = tags->match_regex;
+    val   = node[tags->match_regex].Scalar();
+    dest++;
+  } else if (node[tags->match_url]) {
+    type  = MATCH_URL;
+    label = tags->match_url;
+    val   = node[tags->match_url].Scalar();
+    dest++;
+  } else if (node[tags->match_host_regex]) {
+    type  = MATCH_HOST_REGEX;
+    label = tags->match_host_regex;
+    val   = node[tags->match_host_regex].Scalar();
+    dest++;
+  }
+
+  if (type == MATCH_NONE) {
+    if (tags->dest_error_msg == false) {
+      return "No Source specifier";
+    } else {
+      return "No destination specifier";
+    }
+  } else if (dest != 1) {
+    if (tags->dest_error_msg == false) {
+      return "Multiple Sources Specified";
+    } else {
+      return "Multiple Destinations Specified";
+    }
+  }
+  p->type       = type;
+  p->dest_entry = 0;
+  p->num_el     = 0;
+  p->line[0][0] = const_cast<char *>(label);
+  p->line[1][0] = const_cast<char *>(val.data());
+  p->next       = nullptr;
+  return nullptr;
+}


### PR DESCRIPTION
This PR adds YAML configuration support to the trafficserver parent.config file.  By default, The current style line by line format is parsed and loaded.  To use a YAML parent configuration file edit records.config and change "proxy.config.http.parent_proxy.file" so that the file name is "parent.yaml" instead of "parent.config".