### PR TITLE
Assert when sm callback to wrong thread

### DIFF
--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -5920,13 +5920,14 @@ TSHttpTxnReenable(TSHttpTxn txnp, TSEvent event)
   // If this function is being executed on a thread created by the API
   // which is DEDICATED, the continuation needs to be called back on a
   // REGULAR thread.
-  if (eth == nullptr || eth->tt != REGULAR) {
+  if (eth == nullptr || eth->tt != REGULAR || !eth->is_event_type(ET_NET)) {
     eventProcessor.schedule_imm(new TSHttpSMCallback(sm, event), ET_NET);
   } else {
     MUTEX_TRY_LOCK(trylock, sm->mutex, eth);
     if (!trylock.is_locked()) {
       eventProcessor.schedule_imm(new TSHttpSMCallback(sm, event), ET_NET);
     } else {
+      ink_assert(eth->is_event_type(ET_NET));
       sm->state_api_callback((int)event, nullptr);
     }
   }


### PR DESCRIPTION
The plugin might schedule the sm to task thread. And it will crash here because task thread doses not have thread session pool. 

```
static int
task_cont_handler(TSCont contp, TSEvent event, void *edata)
{
  TSHttpTxn txn = (TSHttpTxn)TSContDataGet(contp);
  TSHttpTxnReenable(txn, TS_EVENT_HTTP_CONTINUE);
  TSContDestroy(contp);
  return 0;
}

static int
cont_handler(TSCont contp, TSEvent event, void *edata)
{

  auto cont = TSContCreate(task_cont_handler, TSMutexCreate());
  TSContDataSet(cont, edata);
  TSContScheduleOnPool(cont, 0, TS_THREAD_POOL_TASK);
  return 0;
}

void
TSPluginInit(int argc, const char *argv[])
{
  TSPluginRegistrationInfo info;

  info.plugin_name   = PLUGIN_NAME;
  info.vendor_name   = "Apache Software Foundation";
  info.support_email = "dev@trafficserver.apache.org";

  if (TSPluginRegister(&info) != TS_SUCCESS) {
    TSError("[%s] Plugin registration failed", PLUGIN_NAME);
  }

  TSDebug(PLUGIN_NAME, "Hello World!");

  TSHttpHookAdd(TS_HTTP_SEND_RESPONSE_HDR_HOOK, TSContCreate(cont_handler, TSMutexCreate()));
}

```