### PR TITLE
Remove start_HttpProxyServerBackDoor.

### DIFF
--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -81,7 +81,7 @@ public:
   virtual void free();
   virtual void start() = 0;
 
-  virtual void new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader, bool backdoor) = 0;
+  virtual void new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader) = 0;
 
   virtual NetVConnection *get_netvc() const = 0;
 

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -145,7 +145,7 @@ Http1ClientSession::free()
 }
 
 void
-Http1ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader, bool backdoor)
+Http1ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader)
 {
   ink_assert(new_vc != nullptr);
   ink_assert(client_vc == nullptr);
@@ -158,9 +158,6 @@ Http1ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOB
 
   MUTEX_TRY_LOCK(lock, mutex, this_ethread());
   ink_assert(lock.is_locked());
-
-  // Disable hooks for backdoor connections.
-  this->hooks_on = !backdoor;
 
   // Unique client session identifier.
   con_id = ProxyClientSession::next_connection_id();

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -65,7 +65,7 @@ public:
     this->release(&trans);
   }
 
-  void new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader, bool backdoor) override;
+  void new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader) override;
 
   // Implement VConnection interface.
   VIO *do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = nullptr) override;

--- a/proxy/http/HttpProxyServerMain.cc
+++ b/proxy/http/HttpProxyServerMain.cc
@@ -369,22 +369,6 @@ start_HttpProxyServer()
 }
 
 void
-start_HttpProxyServerBackDoor(int port, int accept_threads)
-{
-  NetProcessor::AcceptOptions opt;
-  HttpSessionAccept::Options ha_opt;
-
-  opt.local_port     = port;
-  opt.accept_threads = accept_threads;
-  opt.localhost_only = true;
-  ha_opt.backdoor    = true;
-  opt.backdoor       = true;
-
-  // The backdoor only binds the loopback interface
-  netProcessor.main_accept(new HttpSessionAccept(ha_opt), NO_FD, opt);
-}
-
-void
 stop_HttpProxyServer()
 {
   sslNetProcessor.stop_accept();

--- a/proxy/http/HttpProxyServerMain.h
+++ b/proxy/http/HttpProxyServerMain.h
@@ -47,8 +47,6 @@ void start_HttpProxyServer();
 
 void stop_HttpProxyServer();
 
-void start_HttpProxyServerBackDoor(int port, int accept_threads = 0);
-
 NetProcessor::AcceptOptions make_net_accept_options(const HttpProxyPort *port, unsigned nthreads);
 
 extern std::mutex proxyServerMutex;

--- a/proxy/http/HttpSessionAccept.cc
+++ b/proxy/http/HttpSessionAccept.cc
@@ -33,16 +33,10 @@ HttpSessionAccept::accept(NetVConnection *netvc, MIOBuffer *iobuf, IOBufferReade
   IpAllow::ACL acl;
   ip_port_text_buffer ipb;
 
-  // The backdoor port is now only bound to "localhost", so no
-  // reason to check for if it's incoming from "localhost" or not.
-  if (backdoor) {
-    acl = IpAllow::makeAllowAllACL();
-  } else {
-    acl = IpAllow::match(client_ip, IpAllow::SRC_ADDR);
-    if (!acl.isValid()) { // if there's no ACL, it's a hard deny.
-      Warning("client '%s' prohibited by ip-allow policy", ats_ip_ntop(client_ip, ipb, sizeof(ipb)));
-      return false;
-    }
+  acl = IpAllow::match(client_ip, IpAllow::SRC_ADDR);
+  if (!acl.isValid()) { // if there's no ACL, it's a hard deny.
+    Warning("client '%s' prohibited by ip-allow policy", ats_ip_ntop(client_ip, ipb, sizeof(ipb)));
+    return false;
   }
 
   // Set the transport type if not already set
@@ -66,7 +60,7 @@ HttpSessionAccept::accept(NetVConnection *netvc, MIOBuffer *iobuf, IOBufferReade
   new_session->host_res_style            = ats_host_res_from(client_ip->sa_family, host_res_preference);
   new_session->acl                       = std::move(acl);
 
-  new_session->new_connection(netvc, iobuf, reader, backdoor);
+  new_session->new_connection(netvc, iobuf, reader);
 
   return true;
 }

--- a/proxy/http/HttpSessionAccept.h
+++ b/proxy/http/HttpSessionAccept.h
@@ -81,10 +81,6 @@ public:
   bool f_transparent_passthrough;
   /// Set transparent passthrough.
   self &setTransparentPassthrough(bool);
-  /// Accepting backdoor connections.
-  bool backdoor;
-  /// Set backdoor accept.
-  self &setBackdoor(bool);
   /// Host address resolution preference order.
   HostResPreferenceOrder host_res_preference;
   /// Set the host query preference.
@@ -96,7 +92,7 @@ public:
 };
 
 inline HttpSessionAcceptOptions::HttpSessionAcceptOptions()
-  : transport_type(0), outbound_port(0), f_outbound_transparent(false), f_transparent_passthrough(false), backdoor(false)
+  : transport_type(0), outbound_port(0), f_outbound_transparent(false), f_transparent_passthrough(false)
 {
   memcpy(host_res_preference, host_res_default_preference_order, sizeof(host_res_preference));
 }
@@ -146,13 +142,6 @@ inline HttpSessionAcceptOptions &
 HttpSessionAcceptOptions::setTransparentPassthrough(bool flag)
 {
   f_transparent_passthrough = flag;
-  return *this;
-}
-
-inline HttpSessionAcceptOptions &
-HttpSessionAcceptOptions::setBackdoor(bool flag)
-{
-  backdoor = flag;
   return *this;
 }
 

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -151,14 +151,11 @@ Http2ClientSession::start()
 }
 
 void
-Http2ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader, bool backdoor)
+Http2ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader)
 {
   ink_assert(new_vc->mutex->thread_holding == this_ethread());
   HTTP2_INCREMENT_THREAD_DYN_STAT(HTTP2_STAT_CURRENT_CLIENT_SESSION_COUNT, new_vc->mutex->thread_holding);
   HTTP2_INCREMENT_THREAD_DYN_STAT(HTTP2_STAT_TOTAL_CLIENT_CONNECTION_COUNT, new_vc->mutex->thread_holding);
-
-  // HTTP/2 for the backdoor connections? Let's not deal woth that yet.
-  ink_release_assert(backdoor == false);
 
   // Unique client session identifier.
   this->con_id    = ProxyClientSession::next_connection_id();

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -164,7 +164,7 @@ public:
   void start() override;
   void destroy() override;
   void free() override;
-  void new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader, bool backdoor) override;
+  void new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader) override;
 
   bool
   ready_to_free() const

--- a/proxy/http2/Http2SessionAccept.cc
+++ b/proxy/http2/Http2SessionAccept.cc
@@ -59,7 +59,7 @@ Http2SessionAccept::accept(NetVConnection *netvc, MIOBuffer *iobuf, IOBufferRead
   new_session->outbound_ip4       = options.outbound_ip4;
   new_session->outbound_ip6       = options.outbound_ip6;
   new_session->outbound_port      = options.outbound_port;
-  new_session->new_connection(netvc, iobuf, reader, false /* backdoor */);
+  new_session->new_connection(netvc, iobuf, reader);
 
   return true;
 }


### PR DESCRIPTION
Reviewing local changes for 7.1 to port to 8.x, I was unable to find where this is used. I think it's debris left from the destruction of `traffic_cop` which used the backdoor to do health checks.