### PR TITLE
Cleanup: Remove "hooks_on" and associated machinery.

### DIFF
--- a/proxy/ProxyClientSession.cc
+++ b/proxy/ProxyClientSession.cc
@@ -170,7 +170,7 @@ ProxyClientSession::do_api_callout(TSHttpHookID id)
   this->api_scope   = API_HOOK_SCOPE_GLOBAL;
   this->api_current = nullptr;
 
-  if (this->hooks_on && this->has_hooks()) {
+  if (this->has_hooks()) {
     SET_HANDLER(&ProxyClientSession::state_api_callout);
     this->state_api_callout(EVENT_NONE, nullptr);
   } else {

--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -135,12 +135,6 @@ public:
   }
 
   bool
-  hooks_enabled() const
-  {
-    return this->hooks_on;
-  }
-
-  bool
   has_hooks() const
   {
     return this->api_hooks.has_hooks() || http_global_hooks->has_hooks();
@@ -311,7 +305,6 @@ protected:
 
   // Session specific debug flag.
   bool debug_on   = false;
-  bool hooks_on   = true;
   bool in_destroy = false;
 
   int64_t con_id        = 0;

--- a/proxy/ProxyClientTransaction.h
+++ b/proxy/ProxyClientTransaction.h
@@ -98,11 +98,6 @@ public:
   {
     return parent ? parent->debug() : false;
   }
-  bool
-  hooks_enabled() const
-  {
-    return parent ? parent->hooks_enabled() : false;
-  }
 
   APIHook *
   ssn_hook_get(TSHttpHookID id) const

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -503,7 +503,6 @@ HttpSM::attach_client_session(ProxyClientTransaction *client_vc, IOBufferReader 
   ats_ip_copy(&t_state.client_info.dst_addr, netvc->get_local_addr());
   t_state.client_info.dst_addr.port() = netvc->get_local_port();
   t_state.client_info.is_transparent  = netvc->get_is_transparent();
-  t_state.backdoor_request            = !client_vc->hooks_enabled();
   t_state.client_info.port_attribute  = static_cast<HttpProxyPort::TransportType>(netvc->attributes);
 
   // Record api hook set state
@@ -5106,11 +5105,6 @@ HttpSM::do_http_server_open(bool raw)
 void
 HttpSM::do_api_callout_internal()
 {
-  if (t_state.backdoor_request) {
-    handle_api_return();
-    return;
-  }
-
   switch (t_state.api_next_action) {
   case HttpTransact::SM_ACTION_API_SM_START:
     cur_hook_id = TS_HTTP_TXN_START_HOOK;

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -714,7 +714,6 @@ public:
     bool cdn_remap_complete                           = false;
     bool first_dns_lookup                             = true;
 
-    bool backdoor_request = false; // internal
     HttpRequestData request_data;
     ParentConfigParams *parent_params = nullptr;
     ParentResult parent_result;

--- a/proxy/http/HttpUpdateSM.cc
+++ b/proxy/http/HttpUpdateSM.cc
@@ -72,7 +72,6 @@ HttpUpdateSM::start_scheduled_update(Continuation *cont, HTTPHdr *request)
   // Fix ME: What should these be set to since there is not a
   //   real client
   ats_ip4_set(&t_state.client_info.src_addr, htonl(INADDR_LOOPBACK), 0);
-  t_state.backdoor_request           = false;
   t_state.client_info.port_attribute = HttpProxyPort::TRANSPORT_DEFAULT;
 
   t_state.req_flavor = HttpTransact::REQ_FLAVOR_SCHEDULED_UPDATE;


### PR DESCRIPTION
This is initialized to `true` and can never change. This is left over from #4866 - I think it's the last of that legacy. If the backdoor proxy port isn't created, this can never be not `true`, so it's pointless.