### PR TITLE
Fix HTTPInfo::unmarshal function memory leak by call ats_malloc.

### DIFF
--- a/iocore/cache/CacheWrite.cc
+++ b/iocore/cache/CacheWrite.cc
@@ -106,7 +106,7 @@ CacheVC::updateVector(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
          data should remain valid.
       */
       if (alternate_index >= 0) {
-        alternate.copy_frag_offsets_from(write_vector->get(alternate_index));
+        alternate.copy_frag_offsets_from_and_free(write_vector->get(alternate_index));
       }
       alternate_index = write_vector->insert(&alternate, alternate_index);
     }

--- a/proxy/hdrs/HTTP.h
+++ b/proxy/hdrs/HTTP.h
@@ -1303,6 +1303,7 @@ struct HTTPCacheAlt {
   HTTPCacheAlt();
   void copy(HTTPCacheAlt *to_copy);
   void copy_frag_offsets_from(HTTPCacheAlt *src);
+  void copy_frag_offsets_from_and_free(HTTPCacheAlt *src);
   void destroy();
 
   uint32_t m_magic;
@@ -1383,6 +1384,7 @@ public:
     m_alt = info->m_alt;
   }
   void copy_frag_offsets_from(HTTPInfo *src);
+  void copy_frag_offsets_from_and_free(HTTPInfo *src);
   HTTPInfo &operator=(const HTTPInfo &m);
 
   inkcoreapi int marshal_length();


### PR DESCRIPTION
about Issue 2436 https://github.com/apache/trafficserver/issues/2436. @SolidWallOfCode 