### PR TITLE
Clean up ua_entry when client_vc is closed

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -3307,7 +3307,9 @@ HttpSM::tunnel_handler_ua(int event, HttpTunnelConsumer *c)
       ua_txn->set_half_close_flag(true);
     }
 
+    vc_table.remove_entry(this->ua_entry);
     ua_txn->do_io_close();
+    ua_txn = nullptr;
   } else {
     ink_assert(ua_buffer_reader != nullptr);
     ua_txn->release(ua_buffer_reader);


### PR DESCRIPTION
The client vc might be closed when we call `ua_txn->do_io_close()` and freed by `write_signal_and_update /root/trafficserver/iocore/net/UnixNetVConnection.cc:133`. But tunnel is still alive because cache write are not finishing. So we need to clean up `ua_entry` before call `kill_sm->vc_table->cleanup_all()`.  