### PR TITLE
QUIC: Refresh ack frame when previous ack_frame lost

### DIFF
--- a/iocore/net/P_QUICNetVConnection.h
+++ b/iocore/net/P_QUICNetVConnection.h
@@ -304,7 +304,6 @@ private:
 
   void _unschedule_ack_manager_periodic();
   Event *_ack_manager_periodic = nullptr;
-  bool _refresh_ack_frame_manager();
 
   uint64_t _maximum_stream_frame_data_size();
   void _store_frame(ats_unique_buf &buf, size_t &offset, uint64_t &max_frame_size, QUICFrameUPtr &frame,

--- a/iocore/net/quic/QUICAckFrameCreator.h
+++ b/iocore/net/quic/QUICAckFrameCreator.h
@@ -51,12 +51,13 @@ public:
     void forget(QUICPacketNumber largest_acknowledged);
     bool available() const;
     bool is_ack_frame_ready();
+    void set_max_ack_delay(uint16_t delay);
 
     // Checks maximum_frame_size and return _ack_frame
     std::unique_ptr<QUICAckFrame, QUICFrameDeleterFunc> generate_ack_frame(uint16_t maximum_frame_size);
 
-    // timer event handler, refresh _ack_frame;
-    void refresh_frame();
+    // refresh state when frame lost
+    void refresh_state();
 
     QUICPacketNumber largest_ack_number();
     ink_hrtime largest_ack_received_time();
@@ -70,6 +71,7 @@ public:
     bool _should_send                       = false; // ack frame should be sent immediately
     bool _has_new_data                      = false; // new data after last sent
     size_t _size_unsend                     = 0;
+    uint16_t _max_ack_delay                 = 25;
     QUICPacketNumber _largest_ack_number    = 0;
     QUICPacketNumber _expect_next           = 0;
     ink_hrtime _largest_ack_received_time   = 0;
@@ -86,6 +88,7 @@ public:
   ~QUICAckFrameManager();
 
   void set_ack_delay_exponent(uint8_t ack_delay_exponent);
+  void set_max_ack_delay(uint16_t delay);
   void set_force_to_send(bool on = true);
   bool force_to_send() const;
 

--- a/iocore/net/quic/QUICAckFrameCreator.h
+++ b/iocore/net/quic/QUICAckFrameCreator.h
@@ -50,14 +50,13 @@ public:
     void sort();
     void forget(QUICPacketNumber largest_acknowledged);
     bool available() const;
-    bool is_ack_frame_ready() const;
-    std::unique_ptr<QUICAckFrame, QUICFrameDeleterFunc> create_ack_frame();
+    bool is_ack_frame_ready();
 
     // Checks maximum_frame_size and return _ack_frame
     std::unique_ptr<QUICAckFrame, QUICFrameDeleterFunc> generate_ack_frame(uint16_t maximum_frame_size);
 
     // timer event handler, refresh _ack_frame;
-    void refresh_frame(bool force = false);
+    void refresh_frame();
 
     QUICPacketNumber largest_ack_number();
     ink_hrtime largest_ack_received_time();
@@ -67,16 +66,16 @@ public:
     std::unique_ptr<QUICAckFrame, QUICFrameDeleterFunc> _create_ack_frame();
 
     std::list<RecvdPacket> _packet_numbers;
-    bool _available                         = false;
-    bool _should_send                       = false;
+    bool _available                         = false; // packet_number has data to sent
+    bool _should_send                       = false; // ack frame should be sent immediately
+    bool _has_new_data                      = false; // new data after last sent
     size_t _size_unsend                     = 0;
     QUICPacketNumber _largest_ack_number    = 0;
     QUICPacketNumber _expect_next           = 0;
     ink_hrtime _largest_ack_received_time   = 0;
     ink_hrtime _latest_packet_received_time = 0;
 
-    std::unique_ptr<QUICAckFrame, QUICFrameDeleterFunc> _ack_frame = QUICFrameFactory::create_null_ack_frame();
-    QUICAckFrameManager *_ack_manager                              = nullptr;
+    QUICAckFrameManager *_ack_manager = nullptr;
 
     QUICEncryptionLevel _level = QUICEncryptionLevel::NONE;
   };
@@ -106,7 +105,6 @@ public:
    */
   QUICFrameUPtr generate_frame(QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size) override;
 
-  int timer_fired();
   QUICFrameId issue_frame_id();
   uint8_t ack_delay_exponent() const;
 

--- a/iocore/net/quic/QUICAckFrameCreator.h
+++ b/iocore/net/quic/QUICAckFrameCreator.h
@@ -57,7 +57,7 @@ public:
     std::unique_ptr<QUICAckFrame, QUICFrameDeleterFunc> generate_ack_frame(uint16_t maximum_frame_size);
 
     // timer event handler, refresh _ack_frame;
-    void refresh_frame();
+    void refresh_frame(bool force = false);
 
     QUICPacketNumber largest_ack_number();
     ink_hrtime largest_ack_received_time();
@@ -112,6 +112,7 @@ public:
 
 private:
   virtual void _on_frame_acked(QUICFrameInformationUPtr &info) override;
+  virtual void _on_frame_lost(QUICFrameInformationUPtr &info) override;
 
   /*
    * Returns QUICAckFrame only if ACK frame is able to be sent.

--- a/iocore/net/quic/test/test_QUICAckFrameCreator.cc
+++ b/iocore/net/quic/test/test_QUICAckFrameCreator.cc
@@ -177,7 +177,8 @@ TEST_CASE("QUICAckFrameManager should send", "[quic]")
     ack_manager.update(level, 0, 1, false);
     CHECK(ack_manager.will_generate_frame(level) == false);
 
-    ack_manager.timer_fired();
+    sleep(1);
+    Thread::get_hrtime_updated();
     CHECK(ack_manager.will_generate_frame(level) == true);
   }
 
@@ -197,7 +198,8 @@ TEST_CASE("QUICAckFrameManager should send", "[quic]")
     ack_manager.update(level, 2, 1, false);
 
     // Delay due to some reason, the frame is not valued any more, but still valued
-    ack_manager.timer_fired();
+    sleep(1);
+    Thread::get_hrtime_updated();
     CHECK(ack_manager.will_generate_frame(level) == true);
     ack_frame = ack_manager.generate_frame(level, UINT16_MAX, UINT16_MAX);
     frame     = std::static_pointer_cast<QUICAckFrame>(ack_frame);
@@ -334,4 +336,6 @@ TEST_CASE("QUICAckFrameManager lost_frame", "[quic]")
   CHECK(frame->largest_acknowledged() == 9);
   CHECK(frame->ack_block_section()->first_ack_block() == 5);
   CHECK(frame->ack_block_section()->begin()->gap() == 0);
+
+  CHECK(ack_manager.will_generate_frame(level) == false);
 }


### PR DESCRIPTION
>13.2. Retransmission of Information
>The most recent set of acknowledgments are sent in ACK frames. An ACK frame SHOULD contain all unacknowledged acknowledgments, as described in Section 13.1.1.