### PR TITLE
Fix TSHttpTxnEffectiveUrlStringGet to correctly set the port when non-standard

### DIFF
--- a/proxy/hdrs/HTTP.cc
+++ b/proxy/hdrs/HTTP.cc
@@ -1689,6 +1689,7 @@ class UrlPrintHack
         ink_assert(nullptr == ui->m_ptr_port); // shouldn't be set if not in URL.
         ui->m_ptr_port    = m_port_buff;
         ui->m_len_port    = snprintf(m_port_buff, sizeof(m_port_buff), "%d", hdr->m_port);
+        ui->m_port        = hdr->m_port;
         m_port_modified_p = true;
       } else {
         m_port_modified_p = false;
@@ -1712,6 +1713,7 @@ class UrlPrintHack
       if (m_port_modified_p) {
         ui->m_len_port = 0;
         ui->m_ptr_port = nullptr;
+        ui->m_port     = 0;
       }
       if (m_host_modified_p) {
         ui->m_len_host = 0;


### PR DESCRIPTION
We have an internal problem where `TSHttpTxnEffectiveUrlStringGet` returns an incorrect result if the port is specified only in the `Host` header. The failure is that the port is not printed at all. This fixes that problem and we are trying to test it internally.