### PR TITLE
Initialize redir_len, compiler warnings

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -7778,7 +7778,7 @@ HttpSM::do_redirect()
         HTTP_INCREMENT_DYN_STAT(http_total_x_redirect_stat);
       } else {
         // get the location header and setup the redirect
-        int redir_len;
+        int redir_len   = 0;
         char *redir_url = (char *)t_state.hdr_info.client_response.value_get(MIME_FIELD_LOCATION, MIME_LEN_LOCATION, &redir_len);
         redirect_request(redir_url, redir_len);
       }


### PR DESCRIPTION
It turns out, t_state.hdr_info.client_response.value_get() can actually
fail, at which point, redir_len is undefined. I don't know if this
happens in reality though, but has made wrong assumptions.

(cherry picked from commit c7efd7cb07098685505ba882a2a2c8fc9189611c)