### PR TITLE
Don't allow the old body to be used when refreshing

### DIFF
--- a/iocore/cache/CacheWrite.cc
+++ b/iocore/cache/CacheWrite.cc
@@ -88,8 +88,9 @@ CacheVC::updateVector(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
           return openWriteCloseDir(EVENT_IMMEDIATE, nullptr);
         }
       }
-      if (update_key == od->single_doc_key && (total_len || !vec))
+      if (update_key == od->single_doc_key && (total_len || f.allow_empty_doc || !vec)) {
         od->move_resident_alt = false;
+      }
     }
     if (cache_config_http_max_alts > 1 && write_vector->count() >= cache_config_http_max_alts && alternate_index < 0) {
       if (od->move_resident_alt && get_alternate_index(write_vector, od->single_doc_key) == 0)
@@ -1073,11 +1074,11 @@ CacheVC::openWriteCloseDir(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED *
   }
   if (is_debug_tag_set("cache_update")) {
     if (f.update && closed > 0) {
-      if (!total_len && alternate_index != CACHE_ALT_REMOVED) {
+      if (!total_len && !f.allow_empty_doc && alternate_index != CACHE_ALT_REMOVED) {
         Debug("cache_update", "header only %d (%" PRIu64 ", %" PRIu64 ")", DIR_MASK_TAG(first_key.slice32(2)), update_key.b[0],
               update_key.b[1]);
 
-      } else if (total_len && alternate_index != CACHE_ALT_REMOVED) {
+      } else if ((total_len || f.allow_empty_doc) && alternate_index != CACHE_ALT_REMOVED) {
         Debug("cache_update", "header body, %d, (%" PRIu64 ", %" PRIu64 "), (%" PRIu64 ", %" PRIu64 ")",
               DIR_MASK_TAG(first_key.slice32(2)), update_key.b[0], update_key.b[1], earliest_key.b[0], earliest_key.b[1]);
       } else if (!total_len && alternate_index == CACHE_ALT_REMOVED) {


### PR DESCRIPTION
This fixes #4753.

The problem happens because the previous body (with CL: > 0) is "moved", which
then is served even though the body is now empty (CL: 0).

(cherry picked from commit 7ed14f5b3b956ae0dd8b8fd43311c51d500b4401)

 Conflicts:
	iocore/cache/CacheWrite.cc