### PR TITLE
Adjust tests to make them more resilient for different curl versions.

### DIFF
--- a/tests/gold_tests/tls/tls_client_verify.test.py
+++ b/tests/gold_tests/tls/tls_client_verify.test.py
@@ -83,7 +83,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 35
-tr.Processes.Default.Streams.All = Testers.ContainsExpression("alert", "TLS handshake should fail")
 
 tr = Test.AddTestRun("Connect to foo.com with bad cert")
 tr.Setup.Copy("ssl/server.pem")
@@ -93,7 +92,6 @@ tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert server.pem --key server.key --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}/case1".format(ts.Variables.ssl_port)
 # Should fail with badly signed certs
 tr.Processes.Default.ReturnCode = 35
-tr.Processes.Default.Streams.All = Testers.ContainsExpression("alert unknown ca", "TLS handshake should fail")
 
 tr = Test.AddTestRun("Connect to foo.com with cert")
 tr.Setup.Copy("ssl/signed-foo.pem")
@@ -159,7 +157,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 35
-tr.Processes.Default.Streams.All = Testers.ContainsExpression("alert handshake failure", "TLS handshake should fail")
 
 tr = Test.AddTestRun("Connect to bar.com with cert")
 tr.Setup.Copy("ssl/signed-bar.pem")
@@ -177,6 +174,5 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert server.pem --key server.key --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 35
-tr.Processes.Default.Streams.All = Testers.ContainsExpression("alert unknown ca", "TLS handshake should fail")
 
 

--- a/tests/gold_tests/tls/tls_client_verify2.test.py
+++ b/tests/gold_tests/tls/tls_client_verify2.test.py
@@ -99,7 +99,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 35 
-tr.Processes.Default.Streams.All = Testers.ContainsExpression("alert", "TLS handshake should fail")
 
 tr = Test.AddTestRun("Connect to bob.bar.com with cert")
 tr.Setup.Copy("ssl/signed-bob-bar.pem")
@@ -117,14 +116,12 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert server.pem --key server.key --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 35 
-tr.Processes.Default.Streams.All = Testers.ContainsExpression("error", "TLS handshake should fail")
 
 tr = Test.AddTestRun("Connect to bob.foo.com without cert")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 35 
-tr.Processes.Default.Streams.All = Testers.ContainsExpression("alert", "TLS handshake should fail")
 
 tr = Test.AddTestRun("Connect to bob.foo.com with cert")
 tr.Setup.Copy("ssl/signed-bob-foo.pem")
@@ -142,7 +139,6 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert server.pem --key server.key --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 35 
-tr.Processes.Default.Streams.All = Testers.ContainsExpression("error", "TLS handshake should fail")
 
 tr = Test.AddTestRun("Connect to bar.com without cert")
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/tls/tls_keepalive.test.py
+++ b/tests/gold_tests/tls/tls_keepalive.test.py
@@ -24,6 +24,11 @@ Test.Summary = '''
 Verify that the client-side keep alive is honored for TLS and different versions of HTTP
 '''
 
+Test.SkipUnless(
+    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work"),
+    Condition.HasCurlFeature('http2')
+)
+
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server = Test.MakeOriginServer("server")
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}


### PR DESCRIPTION
For some reason our CI is using a curl built against nss.  The error messages differ from the openssl version if a client certificate is expected but not provided.  Both versions will return 35 in this case.  So I removed the message check and the test will just rely on the return code.

Also added a feature check for http2 in tls_keep_alive test.  Even if we fail on skip, this will give a more informative message.