### PR TITLE
Rename Session and Transaction classes

### DIFF
--- a/doc/developer-guide/client-session-architecture.en.rst
+++ b/doc/developer-guide/client-session-architecture.en.rst
@@ -27,34 +27,34 @@ The User Agent interacts with ATS by creating a session with the ATS server and
 submitting sequences of requests over the session. ATS supports several session protocols including
 HTTP/1.x and HTTP/2. A HTTP State Machine is created for each request to process the request.
 
-ATS uses the generic classes ProxyClientSession and ProxyClientTransaction to hide the details of
+ATS uses the generic classes ProxySession and ProxyTransaction to hide the details of
 the underlaying protocols from the HTTP State Machine.
 
 Classes
 =======
 
-ProxyClientSession
+ProxySession
 ------------------
 
 .. figure:: /static/images/sessions/session_hierarchy.png
    :align: center
-   :alt: ProxyClientSession hierarchy
+   :alt: ProxySession hierarchy
 
-The ProxyClientSession class abstracts the key features of a client session.  It contains zero or more ProxyClientTransaction objects.  It also has a reference to the associated NetVC (either UnixNetVConnection or SSLNetVConnection).  The session class is responsible for interfacing with the user agent protocol.
+The ProxySession class abstracts the key features of a client session.  It contains zero or more ProxyTransaction objects.  It also has a reference to the associated NetVC (either UnixNetVConnection or SSLNetVConnection).  The session class is responsible for interfacing with the user agent protocol.
 
 At this point there are two concrete subclasses: Http1ClientSession and Http2ClientSession.  The Http1ClientSession
 only has at most one transaction active at a time.  The HTTP/2 protocol allows for multiple simultaneous active
 transactions
 
-ProxyClientTransaction
+ProxyTransaction
 ----------------------
 
 .. figure:: /static/images/sessions/transaction_hierarchy.png
    :align: center
-   :alt: ProxyClientTransaction hierarchy
+   :alt: ProxyTransaction hierarchy
 
-The ProxyClientTransaction class abstracts the key features of a client transaction.  It has a reference to its
-paraent ProxyClientSession.  One HttpSM is created for each ProxyClientTransaction.
+The ProxyTransaction class abstracts the key features of a client transaction.  It has a reference to its
+paraent ProxySession.  One HttpSM is created for each ProxyTransaction.
 
 There are two concrete subclasses: Http1ClientTransaction and Http2Stream.
 
@@ -70,18 +70,18 @@ HTTP/1.x Objects
 
 This diagram shows the relationships between objects created as part of a HTTP/1.x session.  A NetVC
 object performs the basic network level protocols.  The Http1ClientSession object has a reference to the
-associated NetVC object.  The NetVC object is available via the :code:`ProxyClientSession::get_netvc()` method.
+associated NetVC object.  The NetVC object is available via the :code:`ProxySession::get_netvc()` method.
 
 The Http1ClientSession object contains a Http1ClientTransaction objet.  For each HTTP request, it calls
-the :code:`ProxyClientSession::new_transaction()` method to instantiate the Http1ClientTransaction object.  With the HTTP/1.x
+the :code:`ProxySession::new_transaction()` method to instantiate the Http1ClientTransaction object.  With the HTTP/1.x
 protocol at most one transaction can be active at a time.
 
-When the Http1ClientTransaction object is instantiated via :code:`ProxyClientTransaction::new_transaction()` it allocates a
+When the Http1ClientTransaction object is instantiated via :code:`ProxyTransaction::new_transaction()` it allocates a
 new HttpSM object, initializes it, and calls :code:`HttpSM::attach_client_session()` to associate the
 Http1ClientTransaction object with the new HttpSM.
 
-The ProxyClientTransaction object refers to the HttpSM via the current_reader member variable.  The HttpSM object
-refers to ProxyClientTransaction via the ua_session member variable (session in the member name is
+The ProxyTransaction object refers to the HttpSM via the current_reader member variable.  The HttpSM object
+refers to ProxyTransaction via the ua_session member variable (session in the member name is
 historical because the HttpSM used to refer directly to the ClientSession object).
 
 HTTP/2 Objects
@@ -93,11 +93,11 @@ HTTP/2 Objects
 
 This diagram shows the relationships between objects created as part of a HTTP/2 session.  It is very similar
 to the HTTP/1.x case.  The Http2ClientSession object interacts with the NetVC.  The Http2Stream object creates
-a HttpSM object object when :code:`ProxyClient::new_transaction()` is called.
+a HttpSM object object when :code:`ProxySession::new_transaction()` is called.
 
 One difference is that the Http/2 protocol allows for multiple simultaneous transactions, so the Http2ClientSession
 object must be able to manage multiple streams. From the HttpSM perspective it is interacting with a
-ProxyClientTransaction object, and there is no difference between working with a Http2Stream and a Http1ClientTransaction.
+ProxyTransaction object, and there is no difference between working with a Http2Stream and a Http1ClientTransaction.
 
 Transaction and Session Shutdown
 ================================
@@ -114,5 +114,5 @@ cause use-after-free and other related memory corruption errors.
 To ensure that sessions and transactions are correctly shutdown the following assertions are maintained.
 
 * The Session object will not call :code:`::destroy()` on itself until all child transaction objects are fully shutdown (i.e. TXN_CLOSE hooks are called and the transaction objects have been freed).
-* The Transaction object will not call :code:`::destroy()` on itself until the associated HttpSM has been shutdown.  In :code:`HttpSM::kill_this()`, the HttpSM will call :code:`ProxyClientTransaction::transaction_done()` on the ua_session object.  If the user agent initiates the termination, the ProxyClientTransaction object will send a WRITE_COMPLETE, EOS, or ERROR event on the open VIO object.  This should signal to the HttpSM object to shut itself down.
+* The Transaction object will not call :code:`::destroy()` on itself until the associated HttpSM has been shutdown.  In :code:`HttpSM::kill_this()`, the HttpSM will call :code:`ProxyTransaction::transaction_done()` on the ua_session object.  If the user agent initiates the termination, the ProxyTransaction object will send a WRITE_COMPLETE, EOS, or ERROR event on the open VIO object.  This should signal to the HttpSM object to shut itself down.
 

--- a/include/tscore/IntrusiveHashMap.h
+++ b/include/tscore/IntrusiveHashMap.h
@@ -67,15 +67,15 @@
 
     @a ID The numeric type that is the hash value for an instance of @a Key.
 
-    Example for @c HttpServerSession keyed by the origin server IP address.
+    Example for @c Http1ServerSession keyed by the origin server IP address.
 
     @code
     struct Descriptor {
-      static sockaddr const* key_of(HttpServerSession const* value) { return &value->ip.sa }
+      static sockaddr const* key_of(Http1ServerSession const* value) { return &value->ip.sa }
       static bool equal(sockaddr const* lhs, sockaddr const* rhs) { return ats_ip_eq(lhs, rhs); }
       static uint32_t hash_of(sockaddr const* key) { return ats_ip_hash(key); }
-      static HttpServerSession *& next_ptr(HttpServerSession * ssn) { return ssn->_next; }
-      static HttpServerSession *& prev_ptr(HttpServerSession * ssn) { return ssn->_prev; }
+      static Http1ServerSession *& next_ptr(Http1ServerSession * ssn) { return ssn->_next; }
+      static Http1ServerSession *& prev_ptr(Http1ServerSession * ssn) { return ssn->_prev; }
     };
     using Table = IntrusiveHashMap<Descriptor>;
     @endcode

--- a/iocore/eventsystem/I_Thread.h
+++ b/iocore/eventsystem/I_Thread.h
@@ -120,7 +120,7 @@ public:
   ProxyAllocator http1ClientSessionAllocator;
   ProxyAllocator http2ClientSessionAllocator;
   ProxyAllocator http2StreamAllocator;
-  ProxyAllocator httpServerSessionAllocator;
+  ProxyAllocator http1ServerSessionAllocator;
   ProxyAllocator hdrHeapAllocator;
   ProxyAllocator strHeapAllocator;
   ProxyAllocator cacheVConnectionAllocator;

--- a/proxy/Makefile.am
+++ b/proxy/Makefile.am
@@ -59,10 +59,10 @@ libproxy_a_SOURCES = \
 	PluginVC.h \
 	ProtocolProbeSessionAccept.cc \
 	ProtocolProbeSessionAccept.h \
-	ProxyClientSession.cc \
-	ProxyClientSession.h \
-	ProxyClientTransaction.cc \
-	ProxyClientTransaction \
+	ProxySession.cc \
+	ProxySession.h \
+	ProxyTransaction.cc \
+	ProxyTransaction.h \
 	ReverseProxy.cc \
 	ReverseProxy.h \
 	StatPages.cc \

--- a/proxy/ProxySession.h
+++ b/proxy/ProxySession.h
@@ -1,6 +1,6 @@
 /** @file
 
-  ProxyClientSession - Base class for protocol client sessions.
+  ProxySession - Base class for protocol client & server sessions.
 
   @section license License
 
@@ -28,7 +28,7 @@
 #include <string_view>
 #include "P_Net.h"
 #include "InkAPIInternal.h"
-#include "http/HttpServerSession.h"
+#include "http/Http1ServerSession.h"
 #include "IPAllow.h"
 
 // Emit a debug message conditional on whether this particular client session
@@ -36,7 +36,7 @@
 // member function.
 #define SsnDebug(ssn, tag, ...) SpecificDebug((ssn)->debug(), tag, __VA_ARGS__)
 
-class ProxyClientTransaction;
+class ProxyTransaction;
 
 enum class ProxyErrorClass {
   NONE,
@@ -72,10 +72,11 @@ struct ProxyError {
 // A little ugly, but this global is tracked by traffic_server.
 extern bool ts_is_draining;
 
-class ProxyClientSession : public VConnection
+/// Abstract class for HttpSM to interface with any session
+class ProxySession : public VConnection
 {
 public:
-  ProxyClientSession();
+  ProxySession();
 
   virtual void destroy() = 0;
   virtual void free();
@@ -181,7 +182,7 @@ public:
   }
 
   // Indicate we are done with a transaction.
-  virtual void release(ProxyClientTransaction *trans) = 0;
+  virtual void release(ProxyTransaction *trans) = 0;
 
   virtual in_port_t
   get_outbound_port() const
@@ -208,11 +209,11 @@ public:
   }
 
   virtual void
-  attach_server_session(HttpServerSession *ssession, bool transaction_done = true)
+  attach_server_session(Http1ServerSession *ssession, bool transaction_done = true)
   {
   }
 
-  virtual HttpServerSession *
+  virtual Http1ServerSession *
   get_server_session() const
   {
     return nullptr;
@@ -296,8 +297,8 @@ public:
   ink_hrtime ssn_last_txn_time = 0;
 
   // noncopyable
-  ProxyClientSession(ProxyClientSession &) = delete;
-  ProxyClientSession &operator=(const ProxyClientSession &) = delete;
+  ProxySession(ProxySession &) = delete;
+  ProxySession &operator=(const ProxySession &) = delete;
 
 protected:
   // XXX Consider using a bitwise flags variable for the following flags, so

--- a/proxy/ProxyTransaction.cc
+++ b/proxy/ProxyTransaction.cc
@@ -1,6 +1,6 @@
 /** @file
 
-  ProxyClientTransaction - Base class for protocol client transactions.
+  ProxyTransaction - Base class for protocol client transactions.
 
   @section license License
 
@@ -22,12 +22,12 @@
  */
 
 #include "http/HttpSM.h"
-#include "http/HttpServerSession.h"
+#include "http/Http1ServerSession.h"
 #include "Plugin.h"
 
 #define HttpTxnDebug(fmt, ...) SsnDebug(this, "http_txn", fmt, __VA_ARGS__)
 
-ProxyClientTransaction::ProxyClientTransaction()
+ProxyTransaction::ProxyTransaction()
   : VConnection(nullptr),
     parent(nullptr),
     current_reader(nullptr),
@@ -38,7 +38,7 @@ ProxyClientTransaction::ProxyClientTransaction()
 }
 
 void
-ProxyClientTransaction::new_transaction()
+ProxyTransaction::new_transaction()
 {
   ink_assert(current_reader == nullptr);
 
@@ -61,7 +61,7 @@ ProxyClientTransaction::new_transaction()
 }
 
 void
-ProxyClientTransaction::release(IOBufferReader *r)
+ProxyTransaction::release(IOBufferReader *r)
 {
   HttpTxnDebug("[%" PRId64 "] session released by sm [%" PRId64 "]", parent ? parent->connection_id() : 0,
                current_reader ? current_reader->sm_id : 0);
@@ -73,20 +73,20 @@ ProxyClientTransaction::release(IOBufferReader *r)
 }
 
 void
-ProxyClientTransaction::attach_server_session(HttpServerSession *ssession, bool transaction_done)
+ProxyTransaction::attach_server_session(Http1ServerSession *ssession, bool transaction_done)
 {
   parent->attach_server_session(ssession, transaction_done);
 }
 
 void
-ProxyClientTransaction::destroy()
+ProxyTransaction::destroy()
 {
   current_reader = nullptr;
   this->mutex.clear();
 }
 
 Action *
-ProxyClientTransaction::adjust_thread(Continuation *cont, int event, void *data)
+ProxyTransaction::adjust_thread(Continuation *cont, int event, void *data)
 {
   NetVConnection *vc   = this->get_netvc();
   EThread *this_thread = this_ethread();
@@ -101,7 +101,7 @@ ProxyClientTransaction::adjust_thread(Continuation *cont, int event, void *data)
 }
 
 void
-ProxyClientTransaction::set_rx_error_code(ProxyError e)
+ProxyTransaction::set_rx_error_code(ProxyError e)
 {
   if (this->current_reader) {
     this->current_reader->t_state.client_info.rx_error_code = e;
@@ -109,7 +109,7 @@ ProxyClientTransaction::set_rx_error_code(ProxyError e)
 }
 
 void
-ProxyClientTransaction::set_tx_error_code(ProxyError e)
+ProxyTransaction::set_tx_error_code(ProxyError e)
 {
   if (this->current_reader) {
     this->current_reader->t_state.client_info.tx_error_code = e;

--- a/proxy/ProxyTransaction.h
+++ b/proxy/ProxyTransaction.h
@@ -1,6 +1,6 @@
 /** @file
 
-  ProxyClientTransaction - Base class for protocol client transactions.
+  ProxyTransaction - Base class for protocol client/server transactions.
 
   @section license License
 
@@ -23,15 +23,17 @@
 
 #pragma once
 
-#include "ProxyClientSession.h"
+#include "ProxySession.h"
 #include <string_view>
 
 class HttpSM;
-class HttpServerSession;
-class ProxyClientTransaction : public VConnection
+class Http1ServerSession;
+
+// Abstract Class for any transaction with-in the HttpSM
+class ProxyTransaction : public VConnection
 {
 public:
-  ProxyClientTransaction();
+  ProxyTransaction();
 
   // do_io methods implemented by subclasses
 
@@ -47,7 +49,7 @@ public:
   virtual void set_inactivity_timeout(ink_hrtime timeout_in) = 0;
   virtual void cancel_inactivity_timeout()                   = 0;
 
-  virtual void attach_server_session(HttpServerSession *ssession, bool transaction_done = true);
+  virtual void attach_server_session(Http1ServerSession *ssession, bool transaction_done = true);
 
   // See if we need to schedule on the primary thread for the transaction or change the thread that is associated with the VC.
   // If we reschedule, the scheduled action is returned.  Otherwise, NULL is returned
@@ -195,14 +197,14 @@ public:
 
   virtual void transaction_done() = 0;
 
-  ProxyClientSession *
+  ProxySession *
   get_parent()
   {
     return parent;
   }
 
   virtual void
-  set_parent(ProxyClientSession *new_parent)
+  set_parent(ProxySession *new_parent)
   {
     parent         = new_parent;
     host_res_style = parent->host_res_style;
@@ -212,7 +214,7 @@ public:
   {
   }
 
-  HttpServerSession *
+  Http1ServerSession *
   get_server_session() const
   {
     return parent ? parent->get_server_session() : nullptr;
@@ -263,7 +265,7 @@ public:
   void set_tx_error_code(ProxyError e);
 
 protected:
-  ProxyClientSession *parent;
+  ProxySession *parent;
   HttpSM *current_reader;
   IOBufferReader *sm_reader;
 

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -32,10 +32,10 @@
 
 #include "tscore/ink_resolver.h"
 #include "Http1ClientSession.h"
-#include "Http1ClientTransaction.h"
+#include "Http1Transaction.h"
 #include "HttpSM.h"
 #include "HttpDebugNames.h"
-#include "HttpServerSession.h"
+#include "Http1ServerSession.h"
 #include "Plugin.h"
 
 #define HttpSsnDebug(fmt, ...) SsnDebug(this, "http_cs", fmt, __VA_ARGS__)
@@ -160,7 +160,7 @@ Http1ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOB
   ink_assert(lock.is_locked());
 
   // Unique client session identifier.
-  con_id = ProxyClientSession::next_connection_id();
+  con_id = ProxySession::next_connection_id();
 
   schedule_event = nullptr;
 
@@ -448,9 +448,9 @@ Http1ClientSession::reenable(VIO *vio)
   client_vc->reenable(vio);
 }
 
-// Called from the Http1ClientTransaction::release
+// Called from the Http1Transaction::release
 void
-Http1ClientSession::release(ProxyClientTransaction *trans)
+Http1ClientSession::release(ProxyTransaction *trans)
 {
   ink_assert(read_state == HCS_ACTIVE_READER || read_state == HCS_INIT);
 
@@ -506,7 +506,7 @@ Http1ClientSession::new_transaction()
 }
 
 void
-Http1ClientSession::attach_server_session(HttpServerSession *ssession, bool transaction_done)
+Http1ClientSession::attach_server_session(Http1ServerSession *ssession, bool transaction_done)
 {
   if (ssession) {
     ink_assert(bound_ss == nullptr);

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -37,23 +37,24 @@
 #include "HTTP.h"
 #include "HttpConfig.h"
 #include "IPAllow.h"
-#include "ProxyClientSession.h"
-#include "Http1ClientTransaction.h"
+#include "ProxySession.h"
+#include "Http1Transaction.h"
 
 #ifdef USE_HTTP_DEBUG_LISTS
 extern ink_mutex debug_cs_list_mutex;
 #endif
 
 class HttpSM;
-class HttpServerSession;
+class Http1ServerSession;
 
-class Http1ClientSession : public ProxyClientSession
+/// Class to manage a Http v1 session to a client
+class Http1ClientSession : public ProxySession
 {
 public:
-  typedef ProxyClientSession super; ///< Parent type.
+  typedef ProxySession super; ///< Parent type.
   Http1ClientSession();
 
-  // Implement ProxyClientSession interface.
+  // Implement ProxySession interface.
   void destroy() override;
   void free() override;
   void release_transaction();
@@ -120,11 +121,11 @@ public:
   }
 
   // Indicate we are done with a transaction
-  void release(ProxyClientTransaction *trans) override;
+  void release(ProxyTransaction *trans) override;
 
-  void attach_server_session(HttpServerSession *ssession, bool transaction_done = true) override;
+  void attach_server_session(Http1ServerSession *ssession, bool transaction_done = true) override;
 
-  HttpServerSession *
+  Http1ServerSession *
   get_server_session() const override
   {
     return bound_ss;
@@ -199,7 +200,7 @@ private:
   VIO *ka_vio;
   VIO *slave_ka_vio;
 
-  HttpServerSession *bound_ss;
+  Http1ServerSession *bound_ss;
 
   int released_transactions;
 
@@ -212,7 +213,7 @@ public:
   /// Transparently pass-through non-HTTP traffic.
   bool f_transparent_passthrough;
 
-  Http1ClientTransaction trans;
+  Http1Transaction trans;
 };
 
 extern ClassAllocator<Http1ClientSession> http1ClientSessionAllocator;

--- a/proxy/http/Http1ServerSession.h
+++ b/proxy/http/Http1ServerSession.h
@@ -23,7 +23,7 @@
 
 /****************************************************************************
 
-   HttpServerSession.h
+   Http1ServerSession.h
 
    Description:
 
@@ -64,14 +64,16 @@ enum {
   HTTP_SS_MAGIC_DEAD  = 0xDEADFEED,
 };
 
-class HttpServerSession : public VConnection
+/// Class to manage a Http v1 session to a server
+// TODO: inherit from ProxySession
+class Http1ServerSession : public VConnection
 {
-  using self_type  = HttpServerSession;
+  using self_type  = Http1ServerSession;
   using super_type = VConnection;
 
 public:
-  HttpServerSession() : super_type(nullptr) {}
-  HttpServerSession(self_type const &) = delete;
+  Http1ServerSession() : super_type(nullptr) {}
+  Http1ServerSession(self_type const &) = delete;
   self_type &operator=(self_type const &) = delete;
 
   void destroy();
@@ -170,8 +172,8 @@ public:
     static sockaddr const *key_of(self_type const *ssn);
     static bool equal(sockaddr const *lhs, sockaddr const *rhs);
     // Add a couple overloads for internal convenience.
-    static bool equal(sockaddr const *lhs, HttpServerSession const *rhs);
-    static bool equal(HttpServerSession const *lhs, sockaddr const *rhs);
+    static bool equal(sockaddr const *lhs, Http1ServerSession const *rhs);
+    static bool equal(Http1ServerSession const *lhs, sockaddr const *rhs);
   } _ip_link;
 
   /// Hash map descriptor class for FQDN map.
@@ -220,86 +222,86 @@ private:
   IOBufferReader *buf_reader = nullptr;
 };
 
-extern ClassAllocator<HttpServerSession> httpServerSessionAllocator;
+extern ClassAllocator<Http1ServerSession> http1ServerSessionAllocator;
 
 // --- Implementation ---
 
 inline void
-HttpServerSession::attach_hostname(const char *hostname)
+Http1ServerSession::attach_hostname(const char *hostname)
 {
   if (CRYPTO_HASH_ZERO == hostname_hash) {
     CryptoContext().hash_immediate(hostname_hash, (unsigned char *)hostname, strlen(hostname));
   }
 }
 
-inline HttpServerSession *&
-HttpServerSession::IPLinkage::next_ptr(self_type *ssn)
+inline Http1ServerSession *&
+Http1ServerSession::IPLinkage::next_ptr(self_type *ssn)
 {
   return ssn->_ip_link._next;
 }
 
-inline HttpServerSession *&
-HttpServerSession::IPLinkage::prev_ptr(self_type *ssn)
+inline Http1ServerSession *&
+Http1ServerSession::IPLinkage::prev_ptr(self_type *ssn)
 {
   return ssn->_ip_link._prev;
 }
 
 inline uint32_t
-HttpServerSession::IPLinkage::hash_of(sockaddr const *key)
+Http1ServerSession::IPLinkage::hash_of(sockaddr const *key)
 {
   return ats_ip_hash(key);
 }
 
 inline sockaddr const *
-HttpServerSession::IPLinkage::key_of(self_type const *ssn)
+Http1ServerSession::IPLinkage::key_of(self_type const *ssn)
 {
   return &ssn->get_server_ip().sa;
 }
 
 inline bool
-HttpServerSession::IPLinkage::equal(sockaddr const *lhs, sockaddr const *rhs)
+Http1ServerSession::IPLinkage::equal(sockaddr const *lhs, sockaddr const *rhs)
 {
   return ats_ip_addr_port_eq(lhs, rhs);
 }
 
 inline bool
-HttpServerSession::IPLinkage::equal(sockaddr const *lhs, HttpServerSession const *rhs)
+Http1ServerSession::IPLinkage::equal(sockaddr const *lhs, Http1ServerSession const *rhs)
 {
   return ats_ip_addr_port_eq(lhs, key_of(rhs));
 }
 
 inline bool
-HttpServerSession::IPLinkage::equal(HttpServerSession const *lhs, sockaddr const *rhs)
+Http1ServerSession::IPLinkage::equal(Http1ServerSession const *lhs, sockaddr const *rhs)
 {
   return ats_ip_addr_port_eq(key_of(lhs), rhs);
 }
 
-inline HttpServerSession *&
-HttpServerSession::FQDNLinkage::next_ptr(self_type *ssn)
+inline Http1ServerSession *&
+Http1ServerSession::FQDNLinkage::next_ptr(self_type *ssn)
 {
   return ssn->_fqdn_link._next;
 }
 
-inline HttpServerSession *&
-HttpServerSession::FQDNLinkage::prev_ptr(self_type *ssn)
+inline Http1ServerSession *&
+Http1ServerSession::FQDNLinkage::prev_ptr(self_type *ssn)
 {
   return ssn->_fqdn_link._prev;
 }
 
 inline uint64_t
-HttpServerSession::FQDNLinkage::hash_of(CryptoHash const &key)
+Http1ServerSession::FQDNLinkage::hash_of(CryptoHash const &key)
 {
   return key.fold();
 }
 
 inline CryptoHash const &
-HttpServerSession::FQDNLinkage::key_of(self_type *ssn)
+Http1ServerSession::FQDNLinkage::key_of(self_type *ssn)
 {
   return ssn->hostname_hash;
 }
 
 inline bool
-HttpServerSession::FQDNLinkage::equal(CryptoHash const &lhs, CryptoHash const &rhs)
+Http1ServerSession::FQDNLinkage::equal(CryptoHash const &lhs, CryptoHash const &rhs)
 {
   return lhs == rhs;
 }

--- a/proxy/http/Http1Transaction.cc
+++ b/proxy/http/Http1Transaction.cc
@@ -1,6 +1,6 @@
 /** @file
 
-  Http1ClientTransaction.cc - The Transaction class for Http1*
+  Http1Transaction.cc - The Transaction class for Http1*
 
   @section license License
 
@@ -21,12 +21,12 @@
   limitations under the License.
  */
 
-#include "Http1ClientTransaction.h"
+#include "Http1Transaction.h"
 #include "Http1ClientSession.h"
 #include "HttpSM.h"
 
 void
-Http1ClientTransaction::release(IOBufferReader *r)
+Http1Transaction::release(IOBufferReader *r)
 {
   // Must set this inactivity count here rather than in the session because the state machine
   // is not availble then
@@ -47,7 +47,7 @@ Http1ClientTransaction::release(IOBufferReader *r)
 }
 
 void
-Http1ClientTransaction::set_parent(ProxyClientSession *new_parent)
+Http1Transaction::set_parent(ProxySession *new_parent)
 {
   parent                           = new_parent;
   Http1ClientSession *http1_parent = dynamic_cast<Http1ClientSession *>(new_parent);
@@ -61,7 +61,7 @@ Http1ClientTransaction::set_parent(ProxyClientSession *new_parent)
 }
 
 void
-Http1ClientTransaction::transaction_done()
+Http1Transaction::transaction_done()
 {
   if (parent) {
     static_cast<Http1ClientSession *>(parent)->release_transaction();
@@ -69,7 +69,7 @@ Http1ClientTransaction::transaction_done()
 }
 
 bool
-Http1ClientTransaction::allow_half_open() const
+Http1Transaction::allow_half_open() const
 {
   bool config_allows_it = (current_reader) ? current_reader->t_state.txn_conf->allow_half_open > 0 : true;
   if (config_allows_it) {

--- a/proxy/http/Http1Transaction.h
+++ b/proxy/http/Http1Transaction.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Http1ClientTransaction.h - The Transaction class for Http1*
+  Http1Transaction.h - The Transaction class for Http1*
 
   @section license License
 
@@ -23,16 +23,16 @@
 
 #pragma once
 
-#include "../ProxyClientTransaction.h"
+#include "../ProxyTransaction.h"
 
 class Continuation;
-
-class Http1ClientTransaction : public ProxyClientTransaction
+/// Concrete class for any Http1 Transaction
+class Http1Transaction : public ProxyTransaction
 {
 public:
-  using super_type = ProxyClientTransaction;
+  using super_type = ProxyTransaction;
 
-  Http1ClientTransaction() {}
+  Http1Transaction() {}
   // Implement VConnection interface.
   VIO *
   do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = nullptr) override
@@ -53,7 +53,7 @@ public:
   }
 
   // Don't destroy your elements.  Rely on the Http1ClientSession to clean up the
-  // Http1ClientTransaction class as necessary.  The super::destroy() clears the
+  // Http1Transaction class as necessary.  The super::destroy() clears the
   // mutex, which Http1ClientSession owns.
   void
   destroy() override
@@ -83,7 +83,7 @@ public:
 
   bool allow_half_open() const override;
 
-  void set_parent(ProxyClientSession *new_parent) override;
+  void set_parent(ProxySession *new_parent) override;
 
   bool
   is_outbound_transparent() const override

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -22,12 +22,12 @@
 
  */
 
-#include "../ProxyClientTransaction.h"
+#include "../ProxyTransaction.h"
 #include "HttpSM.h"
 #include "HttpTransact.h"
 #include "HttpTransactHeaders.h"
 #include "ProxyConfig.h"
-#include "HttpServerSession.h"
+#include "Http1ServerSession.h"
 #include "HttpDebugNames.h"
 #include "HttpSessionManager.h"
 #include "P_Cache.h"
@@ -443,7 +443,7 @@ HttpSM::start_sub_sm()
 }
 
 void
-HttpSM::attach_client_session(ProxyClientTransaction *client_vc, IOBufferReader *buffer_reader)
+HttpSM::attach_client_session(ProxyTransaction *client_vc, IOBufferReader *buffer_reader)
 {
   milestones[TS_MILESTONE_UA_BEGIN] = Thread::get_hrtime();
   ink_assert(client_vc != nullptr);
@@ -639,7 +639,7 @@ HttpSM::state_read_client_request_header(int event, void *data)
 
   // Reset the inactivity timeout if this is the first
   //   time we've been called.  The timeout had been set to
-  //   the accept timeout by the ProxyClientTransaction
+  //   the accept timeout by the ProxyTransaction
   //
   if ((ua_buffer_reader->read_avail() > 0) && (client_request_hdr_bytes == 0)) {
     milestones[TS_MILESTONE_UA_FIRST_READ] = Thread::get_hrtime();
@@ -1734,14 +1734,14 @@ HttpSM::state_http_server_open(int event, void *data)
     pending_action = nullptr;
   }
   milestones[TS_MILESTONE_SERVER_CONNECT_END] = Thread::get_hrtime();
-  HttpServerSession *session;
+  Http1ServerSession *session;
   NetVConnection *netvc = nullptr;
 
   switch (event) {
   case NET_EVENT_OPEN: {
     session = (TS_SERVER_SESSION_SHARING_POOL_THREAD == t_state.http_config_param->server_session_sharing_pool) ?
-                THREAD_ALLOC_INIT(httpServerSessionAllocator, mutex->thread_holding) :
-                httpServerSessionAllocator.alloc();
+                THREAD_ALLOC_INIT(http1ServerSessionAllocator, mutex->thread_holding) :
+                http1ServerSessionAllocator.alloc();
     session->sharing_pool  = static_cast<TSServerSessionSharingPoolType>(t_state.http_config_param->server_session_sharing_pool);
     session->sharing_match = static_cast<TSServerSessionSharingMatchType>(t_state.txn_conf->server_session_sharing_match);
 
@@ -4901,7 +4901,7 @@ HttpSM::do_http_server_open(bool raw)
   // session when we already have an attached server session.
   else if ((TS_SERVER_SESSION_SHARING_MATCH_NONE == t_state.txn_conf->server_session_sharing_match || is_private()) &&
            (ua_txn != nullptr)) {
-    HttpServerSession *existing_ss = ua_txn->get_server_session();
+    Http1ServerSession *existing_ss = ua_txn->get_server_session();
 
     if (existing_ss) {
       // [amc] Not sure if this is the best option, but we don't get here unless session sharing is disabled
@@ -4928,7 +4928,7 @@ HttpSM::do_http_server_open(bool raw)
   // to get a new one.
   // ua_txn is null when t_state.req_flavor == REQ_FLAVOR_SCHEDULED_UPDATE
   else if (ua_txn != nullptr) {
-    HttpServerSession *existing_ss = ua_txn->get_server_session();
+    Http1ServerSession *existing_ss = ua_txn->get_server_session();
     if (existing_ss) {
       existing_ss->get_netvc()->set_inactivity_timeout(HRTIME_SECONDS(t_state.txn_conf->keep_alive_no_activity_timeout_out));
       existing_ss->release();
@@ -5898,7 +5898,7 @@ HttpSM::write_header_into_buffer(HTTPHdr *h, MIOBuffer *b)
 }
 
 void
-HttpSM::attach_server_session(HttpServerSession *s)
+HttpSM::attach_server_session(Http1ServerSession *s)
 {
   hsm_release_assert(server_session == nullptr);
   hsm_release_assert(server_entry == nullptr);
@@ -7973,7 +7973,7 @@ HttpSM::is_private()
   if (server_session) {
     res = server_session->private_session;
   } else if (ua_txn) {
-    HttpServerSession *ss = ua_txn->get_server_session();
+    Http1ServerSession *ss = ua_txn->get_server_session();
     if (ss) {
       res = ss->private_session;
     } else if (will_be_private_ss) {

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -39,7 +39,7 @@
 #include "UrlRewrite.h"
 #include "HttpTunnel.h"
 #include "InkAPIInternal.h"
-#include "../ProxyClientTransaction.h"
+#include "../ProxyTransaction.h"
 #include "HdrUtils.h"
 #include <string_view>
 #include "tscore/History.h"
@@ -53,7 +53,7 @@
  * the buffer. By allocating memory only when it is required we can
  * reduce the memory consumed by TS process.
  *
- * IMPORTANT NOTE: enable/disable LAZY_BUF_ALLOC in HttpServerSession.h
+ * IMPORTANT NOTE: enable/disable LAZY_BUF_ALLOC in Http1ServerSession.h
  * as well.
  */
 #define LAZY_BUF_ALLOC
@@ -72,7 +72,7 @@ static size_t const HTTP_HEADER_BUFFER_SIZE_INDEX = CLIENT_CONNECTION_FIRST_READ
 //   the larger buffer size
 static size_t const HTTP_SERVER_RESP_HDR_BUFFER_INDEX = BUFFER_SIZE_INDEX_8K;
 
-class HttpServerSession;
+class Http1ServerSession;
 class AuthHttpAdapter;
 
 class HttpSM;
@@ -228,22 +228,22 @@ public:
 
   void init();
 
-  void attach_client_session(ProxyClientTransaction *client_vc_arg, IOBufferReader *buffer_reader);
+  void attach_client_session(ProxyTransaction *client_vc_arg, IOBufferReader *buffer_reader);
 
   // Called by httpSessionManager so that we can reset
   //  the session timeouts and initiate a read while
   //  holding the lock for the server session
-  void attach_server_session(HttpServerSession *s);
+  void attach_server_session(Http1ServerSession *s);
 
   // Used to read attributes of
   // the current active server session
-  HttpServerSession *
+  Http1ServerSession *
   get_server_session()
   {
     return server_session;
   }
 
-  ProxyClientTransaction *
+  ProxyTransaction *
   get_ua_txn()
   {
     return ua_txn;
@@ -363,7 +363,7 @@ protected:
   void remove_ua_entry();
 
 public:
-  ProxyClientTransaction *ua_txn   = nullptr;
+  ProxyTransaction *ua_txn         = nullptr;
   BackgroundFill_t background_fill = BACKGROUND_FILL_NONE;
   // AuthHttpAdapter authAdapter;
   void set_http_schedule(Continuation *);
@@ -375,8 +375,8 @@ protected:
   IOBufferReader *ua_buffer_reader     = nullptr;
   IOBufferReader *ua_raw_buffer_reader = nullptr;
 
-  HttpVCTableEntry *server_entry    = nullptr;
-  HttpServerSession *server_session = nullptr;
+  HttpVCTableEntry *server_entry     = nullptr;
+  Http1ServerSession *server_session = nullptr;
 
   /* Because we don't want to take a session from a shared pool if we know that it will be private,
    * but we cannot set it to private until we have an attached server session.

--- a/proxy/http/HttpSessionManager.h
+++ b/proxy/http/HttpSessionManager.h
@@ -33,10 +33,10 @@
 #pragma once
 
 #include "P_EventSystem.h"
-#include "HttpServerSession.h"
+#include "Http1ServerSession.h"
 #include "tscore/IntrusiveHashMap.h"
 
-class ProxyClientTransaction;
+class ProxyTransaction;
 class HttpSM;
 
 void initialize_thread_for_http_sessions(EThread *thread, int thread_index);
@@ -67,13 +67,13 @@ public:
   static bool validate_sni(HttpSM *sm, NetVConnection *netvc);
 
 protected:
-  using IPTable   = IntrusiveHashMap<HttpServerSession::IPLinkage>;
-  using FQDNTable = IntrusiveHashMap<HttpServerSession::FQDNLinkage>;
+  using IPTable   = IntrusiveHashMap<Http1ServerSession::IPLinkage>;
+  using FQDNTable = IntrusiveHashMap<Http1ServerSession::FQDNLinkage>;
 
 public:
   /** Check if a session matches address and host name.
    */
-  static bool match(HttpServerSession *ss, sockaddr const *addr, CryptoHash const &host_hash,
+  static bool match(Http1ServerSession *ss, sockaddr const *addr, CryptoHash const &host_hash,
                     TSServerSessionSharingMatchType match_style);
 
   /** Get a session from the pool.
@@ -84,10 +84,10 @@ public:
       @return A pointer to the session or @c NULL if not matching session was found.
   */
   HSMresult_t acquireSession(sockaddr const *addr, CryptoHash const &host_hash, TSServerSessionSharingMatchType match_style,
-                             HttpSM *sm, HttpServerSession *&server_session);
+                             HttpSM *sm, Http1ServerSession *&server_session);
   /** Release a session to to pool.
    */
-  void releaseSession(HttpServerSession *ss);
+  void releaseSession(Http1ServerSession *ss);
 
   /// Close all sessions and then clear the table.
   void purge();
@@ -103,9 +103,8 @@ class HttpSessionManager
 public:
   HttpSessionManager() : m_g_pool(nullptr) {}
   ~HttpSessionManager() {}
-  HSMresult_t acquire_session(Continuation *cont, sockaddr const *addr, const char *hostname, ProxyClientTransaction *ua_txn,
-                              HttpSM *sm);
-  HSMresult_t release_session(HttpServerSession *to_release);
+  HSMresult_t acquire_session(Continuation *cont, sockaddr const *addr, const char *hostname, ProxyTransaction *ua_txn, HttpSM *sm);
+  HSMresult_t release_session(Http1ServerSession *to_release);
   void purge_keepalives();
   void init();
   int main_handler(int event, void *data);

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -39,7 +39,7 @@
 #include "RemapPluginInfo.h"
 #include "UrlMapping.h"
 #include "records/I_RecHttp.h"
-#include "ProxyClientSession.h"
+#include "ProxySession.h"
 
 #define HTTP_RELEASE_ASSERT(X) ink_release_assert(X)
 

--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -932,7 +932,7 @@ HttpTunnel::producer_run(HttpTunnelProducer *p)
       // the amount to read since we know it.  We will forward the FIN
       // to the server on VC_EVENT_WRITE_COMPLETE.
       if (p->vc_type == HT_HTTP_CLIENT) {
-        ProxyClientTransaction *ua_vc = static_cast<ProxyClientTransaction *>(p->vc);
+        ProxyTransaction *ua_vc = static_cast<ProxyTransaction *>(p->vc);
         if (ua_vc->get_half_close_flag()) {
           c_write          = c->buffer_reader->read_avail();
           p->alive         = false;

--- a/proxy/http/Makefile.am
+++ b/proxy/http/Makefile.am
@@ -46,8 +46,8 @@ libhttp_a_SOURCES = \
 	HttpCacheSM.h \
 	Http1ClientSession.cc \
 	Http1ClientSession.h \
-	Http1ClientTransaction.cc \
-	Http1ClientTransaction.h \
+	Http1Transaction.cc \
+	Http1Transaction.h \
 	HttpConfig.cc \
 	HttpConfig.h \
 	HttpConnectionCount.cc \
@@ -60,8 +60,8 @@ libhttp_a_SOURCES = \
 	HttpProxyServerMain.h \
 	HttpSM.cc \
 	HttpSM.h \
-	HttpServerSession.cc \
-	HttpServerSession.h \
+	Http1ServerSession.cc \
+	Http1ServerSession.h \
 	HttpSessionManager.cc \
 	HttpSessionManager.h \
 	HttpTransact.cc \

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -158,7 +158,7 @@ Http2ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOB
   HTTP2_INCREMENT_THREAD_DYN_STAT(HTTP2_STAT_TOTAL_CLIENT_CONNECTION_COUNT, new_vc->mutex->thread_holding);
 
   // Unique client session identifier.
-  this->con_id    = ProxyClientSession::next_connection_id();
+  this->con_id    = ProxySession::next_connection_id();
   this->client_vc = new_vc;
   client_vc->set_inactivity_timeout(HRTIME_SECONDS(Http2::accept_no_activity_timeout));
   this->schedule_event = nullptr;

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -25,7 +25,7 @@
 
 #include "HTTP2.h"
 #include "Plugin.h"
-#include "ProxyClientSession.h"
+#include "ProxySession.h"
 #include "Http2ConnectionState.h"
 #include <string_view>
 #include "tscore/ink_inet.h"
@@ -152,15 +152,15 @@ private:
   IOBufferReader *ioreader;
 };
 
-class Http2ClientSession : public ProxyClientSession
+class Http2ClientSession : public ProxySession
 {
 public:
-  typedef ProxyClientSession super; ///< Parent type.
+  typedef ProxySession super; ///< Parent type.
   typedef int (Http2ClientSession::*SessionHandler)(int, void *);
 
   Http2ClientSession();
 
-  // Implement ProxyClientSession interface.
+  // Implement ProxySession interface.
   void start() override;
   void destroy() override;
   void free() override;
@@ -219,7 +219,7 @@ public:
   }
 
   void
-  release(ProxyClientTransaction *trans) override
+  release(ProxyTransaction *trans) override
   {
   }
 

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -24,7 +24,7 @@
 #pragma once
 
 #include "HTTP2.h"
-#include "../ProxyClientTransaction.h"
+#include "../ProxyTransaction.h"
 #include "Http2DebugNames.h"
 #include "../http/HttpTunnel.h" // To get ChunkedHandler
 #include "Http2DependencyTree.h"
@@ -34,10 +34,10 @@ class Http2ConnectionState;
 
 typedef Http2DependencyTree::Tree<Http2Stream *> DependencyTree;
 
-class Http2Stream : public ProxyClientTransaction
+class Http2Stream : public ProxyTransaction
 {
 public:
-  typedef ProxyClientTransaction super; ///< Parent type.
+  typedef ProxyTransaction super; ///< Parent type.
   Http2Stream(Http2StreamId sid = 0, ssize_t initial_rwnd = Http2::initial_window_size) : client_rwnd(initial_rwnd), _id(sid)
   {
     SET_HANDLER(&Http2Stream::main_event_handler);

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -37,9 +37,9 @@
 #include "URL.h"
 #include "MIME.h"
 #include "HTTP.h"
-#include "ProxyClientSession.h"
+#include "ProxySession.h"
 #include "Http2ClientSession.h"
-#include "HttpServerSession.h"
+#include "Http1ServerSession.h"
 #include "HttpSM.h"
 #include "HttpConfig.h"
 #include "P_Net.h"
@@ -4739,7 +4739,7 @@ TSHttpSsnHookAdd(TSHttpSsn ssnp, TSHttpHookID id, TSCont contp)
   sdk_assert(sdk_sanity_check_continuation(contp) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_hook_id(id) == TS_SUCCESS);
 
-  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
+  ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
   cs->ssn_hook_append(id, (INKContInternal *)contp);
 }
 
@@ -4748,28 +4748,28 @@ TSHttpSsnTransactionCount(TSHttpSsn ssnp)
 {
   sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
 
-  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
+  ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
   return cs->get_transact_count();
 }
 
 TSVConn
 TSHttpSsnClientVConnGet(TSHttpSsn ssnp)
 {
-  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
+  ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
   return reinterpret_cast<TSVConn>(cs->get_netvc());
 }
 
 TSVConn
 TSHttpSsnServerVConnGet(TSHttpSsn ssnp)
 {
-  HttpServerSession *ss = reinterpret_cast<HttpServerSession *>(ssnp);
+  Http1ServerSession *ss = reinterpret_cast<Http1ServerSession *>(ssnp);
   return reinterpret_cast<TSVConn>(ss->get_netvc());
 }
 
 class TSHttpSsnCallback : public Continuation
 {
 public:
-  TSHttpSsnCallback(ProxyClientSession *cs, TSEvent event) : Continuation(cs->mutex), m_cs(cs), m_event(event)
+  TSHttpSsnCallback(ProxySession *cs, TSEvent event) : Continuation(cs->mutex), m_cs(cs), m_event(event)
   {
     SET_HANDLER(&TSHttpSsnCallback::event_handler);
   }
@@ -4783,7 +4783,7 @@ public:
   }
 
 private:
-  ProxyClientSession *m_cs;
+  ProxySession *m_cs;
   TSEvent m_event;
 };
 
@@ -4792,8 +4792,8 @@ TSHttpSsnReenable(TSHttpSsn ssnp, TSEvent event)
 {
   sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
 
-  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
-  EThread *eth           = this_ethread();
+  ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
+  EThread *eth     = this_ethread();
 
   // If this function is being executed on a thread created by the API
   // which is DEDICATED, the continuation needs to be called back on a
@@ -5493,7 +5493,7 @@ TSHttpTxnTransformRespGet(TSHttpTxn txnp, TSMBuffer *bufp, TSMLoc *obj)
 sockaddr const *
 TSHttpSsnClientAddrGet(TSHttpSsn ssnp)
 {
-  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
+  ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
 
   if (cs == nullptr) {
     return nullptr;
@@ -5512,7 +5512,7 @@ TSHttpTxnClientAddrGet(TSHttpTxn txnp)
 sockaddr const *
 TSHttpSsnIncomingAddrGet(TSHttpSsn ssnp)
 {
-  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
+  ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
 
   if (cs == nullptr) {
     return nullptr;
@@ -5535,7 +5535,7 @@ TSHttpTxnOutgoingAddrGet(TSHttpTxn txnp)
 
   HttpSM *sm = reinterpret_cast<HttpSM *>(txnp);
 
-  HttpServerSession *ssn = sm->get_server_session();
+  Http1ServerSession *ssn = sm->get_server_session();
   if (ssn == nullptr) {
     return nullptr;
   }
@@ -5653,7 +5653,7 @@ TSHttpTxnServerPacketMarkSet(TSHttpTxn txnp, int mark)
 
   // change the mark on an active server session
   if (nullptr != sm->ua_txn) {
-    HttpServerSession *ssn = sm->ua_txn->get_server_session();
+    Http1ServerSession *ssn = sm->ua_txn->get_server_session();
     if (nullptr != ssn) {
       NetVConnection *vc = ssn->get_netvc();
       if (vc != nullptr) {
@@ -5695,7 +5695,7 @@ TSHttpTxnServerPacketTosSet(TSHttpTxn txnp, int tos)
 
   // change the tos on an active server session
   if (nullptr != sm->ua_txn) {
-    HttpServerSession *ssn = sm->ua_txn->get_server_session();
+    Http1ServerSession *ssn = sm->ua_txn->get_server_session();
     if (nullptr != ssn) {
       NetVConnection *vc = ssn->get_netvc();
       if (vc != nullptr) {
@@ -5737,7 +5737,7 @@ TSHttpTxnServerPacketDscpSet(TSHttpTxn txnp, int dscp)
 
   // change the tos on an active server session
   if (nullptr != sm->ua_txn) {
-    HttpServerSession *ssn = sm->ua_txn->get_server_session();
+    Http1ServerSession *ssn = sm->ua_txn->get_server_session();
     if (nullptr != ssn) {
       NetVConnection *vc = ssn->get_netvc();
       if (vc != nullptr) {
@@ -6090,7 +6090,7 @@ TSHttpSsnArgSet(TSHttpSsn ssnp, int arg_idx, void *arg)
   sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
   sdk_assert(arg_idx >= 0 && arg_idx < TS_HTTP_MAX_USER_ARG);
 
-  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
+  ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
 
   cs->set_user_arg(arg_idx, arg);
 }
@@ -6101,7 +6101,7 @@ TSHttpSsnArgGet(TSHttpSsn ssnp, int arg_idx)
   sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
   sdk_assert(arg_idx >= 0 && arg_idx < TS_HTTP_MAX_USER_ARG);
 
-  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
+  ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
   return cs->get_user_arg(arg_idx);
 }
 
@@ -6236,14 +6236,14 @@ void
 TSHttpSsnDebugSet(TSHttpSsn ssnp, int on)
 {
   sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
-  (reinterpret_cast<ProxyClientSession *>(ssnp))->set_debug(0 != on);
+  (reinterpret_cast<ProxySession *>(ssnp))->set_debug(0 != on);
 }
 
 int
 TSHttpSsnDebugGet(TSHttpSsn ssnp)
 {
   sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
-  return (reinterpret_cast<ProxyClientSession *>(ssnp))->debug();
+  return (reinterpret_cast<ProxySession *>(ssnp))->debug();
 }
 
 int
@@ -7404,8 +7404,8 @@ TSHttpSsnClientFdGet(TSHttpSsn ssnp, int *fdp)
 {
   sdk_assert(sdk_sanity_check_null_ptr((void *)fdp) == TS_SUCCESS);
 
-  VConnection *basecs    = reinterpret_cast<VConnection *>(ssnp);
-  ProxyClientSession *cs = dynamic_cast<ProxyClientSession *>(basecs);
+  VConnection *basecs = reinterpret_cast<VConnection *>(ssnp);
+  ProxySession *cs    = dynamic_cast<ProxySession *>(basecs);
 
   if (cs == nullptr) {
     return TS_ERROR;
@@ -7438,7 +7438,7 @@ TSHttpTxnServerFdGet(TSHttpTxn txnp, int *fdp)
   HttpSM *sm = reinterpret_cast<HttpSM *>(txnp);
   *fdp       = -1;
 
-  HttpServerSession *ss = sm->get_server_session();
+  Http1ServerSession *ss = sm->get_server_session();
   if (ss == nullptr) {
     return TS_ERROR;
   }
@@ -7806,7 +7806,7 @@ TSFetchRespHdrMLocGet(TSFetchSM fetch_sm)
 int
 TSHttpSsnIsInternal(TSHttpSsn ssnp)
 {
-  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
+  ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
 
   if (!cs) {
     return 0;
@@ -9312,7 +9312,7 @@ int64_t
 TSHttpSsnIdGet(TSHttpSsn ssnp)
 {
   sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
-  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
+  ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
   return cs->connection_id();
 }
 
@@ -9342,8 +9342,8 @@ TSHttpSsnClientProtocolStackGet(TSHttpSsn ssnp, int n, const char **result, int 
 {
   sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
   sdk_assert(n == 0 || result != nullptr);
-  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
-  int count              = 0;
+  ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
+  int count        = 0;
   if (cs && n > 0) {
     auto mem = static_cast<std::string_view *>(alloca(sizeof(std::string_view) * n));
     count    = cs->populate_protocol(mem, n);
@@ -9375,7 +9375,7 @@ const char *
 TSHttpSsnClientProtocolStackContains(TSHttpSsn ssnp, const char *tag)
 {
   sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
-  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
+  ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
   return cs->protocol_contains(std::string_view{tag});
 }
 

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -76,7 +76,7 @@ extern "C" int plock(int);
 #include "ProxyConfig.h"
 #include "HttpProxyServerMain.h"
 #include "HttpBodyFactory.h"
-#include "ProxyClientSession.h"
+#include "ProxySession.h"
 #include "logging/Log.h"
 #include "CacheControl.h"
 #include "IPAllow.h"


### PR DESCRIPTION
In an effort to cleanup HttpSM specific code for H1/H2/H3, I'm starting to cleanup transaction abstraction per @shinrich design and presentation. 

This PR is simply renaming the following classes: 
ProxyClientSession -> ProxySession
ProxyClientTransaction -> ProxyTransaction
HttpServerSession -> Http1ServerSession
HttpClientTransaction -> Http1Transaction

This contains no functional change. 
Refactoring will come next.