### PR TITLE
Uri signing regex as POSIX ERE

### DIFF
--- a/plugins/experimental/uri_signing/match.c
+++ b/plugins/experimental/uri_signing/match.c
@@ -16,10 +16,10 @@
  * limitations under the License.
  */
 
+#include <regex.h>
 #include "common.h"
 #include "ts/ts.h"
 #include <stdbool.h>
-#include <pcre.h>
 #include <string.h>
 
 bool
@@ -31,16 +31,27 @@ match_hash(const char *needle, const char *haystack)
 bool
 match_regex(const char *pattern, const char *uri)
 {
-  const char *err;
-  int err_off;
+  struct re_pattern_buffer pat_buff;
+
+  pat_buff.translate = 0;
+  pat_buff.fastmap   = 0;
+  pat_buff.buffer    = 0;
+  pat_buff.allocated = 0;
+
+  re_syntax_options = RE_SYNTAX_POSIX_MINIMAL_EXTENDED;
+
   PluginDebug("Testing regex pattern /%s/ against \"%s\"", pattern, uri);
-  pcre *re = pcre_compile(pattern, PCRE_ANCHORED | PCRE_UCP | PCRE_UTF8, &err, &err_off, NULL);
-  if (!re) {
-    PluginDebug("Regex /%s/ failed to compile.", pattern);
+
+  const char *comp_err = re_compile_pattern(pattern, strlen(pattern), &pat_buff);
+
+  if (comp_err) {
+    PluginDebug("Regex Compilation ERROR: %s", comp_err);
     return false;
   }
 
-  int rc = pcre_exec(re, NULL, uri, strlen(uri), 0, 0, NULL, 0);
-  pcre_free(re);
-  return rc >= 0;
+  int match_ret;
+  match_ret = re_match(&pat_buff, uri, strlen(uri), 0, 0);
+  regfree(&pat_buff);
+
+  return match_ret >= 0;
 }

--- a/plugins/experimental/uri_signing/unit_tests/uri_signing_test.cc
+++ b/plugins/experimental/uri_signing/unit_tests/uri_signing_test.cc
@@ -29,6 +29,7 @@ extern "C" {
 #include "../jwt.h"
 #include "../normalize.h"
 #include "../parse.h"
+#include "../match.h"
 }
 
 bool
@@ -445,4 +446,33 @@ TEST_CASE("4", "[NormalizeTest]")
 
   SECTION("Testing empty uri after http://?/") { REQUIRE(!normalize_uri_helper("http://?/", NULL)); }
   fprintf(stderr, "\n");
+}
+
+TEST_CASE("5", "[RegexTests]")
+{
+  INFO("TEST 5, Test Regex Matching");
+
+  SECTION("Standard regex")
+  {
+    REQUIRE(match_regex("http://kelloggsTester.souza.local/KellogsDir/*",
+                        "http://kelloggsTester.souza.local/KellogsDir/some_manifest.m3u8"));
+  }
+
+  SECTION("Back references are not supported") { REQUIRE(!match_regex("(b*a)\\1$", "bbbbba")); }
+
+  SECTION("Escape a special character") { REQUIRE(match_regex("money\\$", "money$bags")); }
+
+  SECTION("Dollar sign")
+  {
+    REQUIRE(!match_regex(".+foobar$", "foobarfoofoo"));
+    REQUIRE(match_regex(".+foobar$", "foofoofoobar"));
+  }
+
+  SECTION("Number Quantifier with Groups")
+  {
+    REQUIRE(match_regex("(abab){2}", "abababab"));
+    REQUIRE(!match_regex("(abab){2}", "abab"));
+  }
+
+  SECTION("Alternation") { REQUIRE(match_regex("cat|dog", "dog")); }
 }


### PR DESCRIPTION
The latest URI Signing Internet-Draft states that regex comparison in the cdniuc comparison must use a POSIX ERE regex engine. 

Internet Draft: https://tools.ietf.org/html/draft-ietf-cdni-uri-signing-16
New regex engine being used:
https://docs.freebsd.org/info/regex/regex.info.GNU_Matching.html
Regex syntaxes for re_match available:
https://docs.freebsd.org/info/regex/regex.info.Predefined_Syntaxes.html