### PR TITLE
QUIC: Retransmit NEW/RETIRE_CONNECTION_ID frame

### DIFF
--- a/iocore/net/quic/QUICAltConnectionManager.cc
+++ b/iocore/net/quic/QUICAltConnectionManager.cc
@@ -283,7 +283,7 @@ QUICAltConnectionManager::generate_frame(QUICEncryptionLevel level, uint64_t con
           this->_alt_quic_connection_ids_local[i].advertised = true;
         }
 
-        this->_records_new_connection_id_frame(level, *static_cast<QUICNewConnectionIdFrame *>(frame.get()));
+        this->_records_new_connection_id_frame(level, static_cast<const QUICNewConnectionIdFrame &>(*frame));
         return frame;
       }
     }
@@ -293,7 +293,7 @@ QUICAltConnectionManager::generate_frame(QUICEncryptionLevel level, uint64_t con
   if (!this->_retired_seq_nums.empty()) {
     if (auto s = this->_retired_seq_nums.front()) {
       frame = QUICFrameFactory::create_retire_connection_id_frame(s);
-      this->_records_retire_connection_id_frame(level, *static_cast<QUICRetireConnectionIdFrame *>(frame.get()));
+      this->_records_retire_connection_id_frame(level, static_cast<const QUICRetireConnectionIdFrame &>(*frame));
       this->_retired_seq_nums.pop();
       return frame;
     }

--- a/iocore/net/quic/QUICAltConnectionManager.h
+++ b/iocore/net/quic/QUICAltConnectionManager.h
@@ -86,9 +86,7 @@ public:
   QUICFrameUPtr generate_frame(QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size) override;
 
 private:
-  class AltConnectionInfo
-  {
-  public:
+  struct AltConnectionInfo {
     uint64_t seq_num;
     QUICConnectionId id;
     QUICStatelessResetToken token;
@@ -112,6 +110,11 @@ private:
   AltConnectionInfo _generate_next_alt_con_info();
   void _init_alt_connection_ids(const IpEndpoint *preferred_endpoint = nullptr);
   bool _update_alt_connection_id(uint64_t chosen_seq_num);
+
+  void _records_new_connection_id_frame(QUICEncryptionLevel level, const QUICNewConnectionIdFrame &frame);
+  void _records_retire_connection_id_frame(QUICEncryptionLevel, const QUICRetireConnectionIdFrame &frame);
+
+  void _on_frame_lost(QUICFrameInformationUPtr &info);
 
   QUICConnectionErrorUPtr _register_remote_connection_id(const QUICNewConnectionIdFrame &frame);
   QUICConnectionErrorUPtr _retire_remote_connection_id(const QUICRetireConnectionIdFrame &frame);

--- a/iocore/net/quic/QUICPacketRetransmitter.cc
+++ b/iocore/net/quic/QUICPacketRetransmitter.cc
@@ -56,6 +56,8 @@ QUICPacketRetransmitter::retransmit_packet(const QUICPacket &packet)
     case QUICFrameType::CONNECTION_CLOSE:
     case QUICFrameType::STREAM:
     case QUICFrameType::CRYPTO:
+    case QUICFrameType::NEW_CONNECTION_ID:
+    case QUICFrameType::RETIRE_CONNECTION_ID:
       break;
     default:
       frame     = QUICFrameFactory::create_retransmission_frame(frame->clone(), packet);


### PR DESCRIPTION
>New connection IDs are sent in NEW_CONNECTION_ID frames and retransmitted if the packet containing them is lost. Retransmissions of this frame carry the same sequence number value. Likewise, retired connection IDs are sent in RETIRE_CONNECTION_ID frames and retransmitted if the packet containing them is lost.