### PR TITLE
Adjust follow redirect logic to address a crash and avoid arguments shadowing

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -7703,7 +7703,7 @@ HttpSM::do_redirect()
 }
 
 void
-HttpSM::redirect_request(const char *redirect_url, const int redirect_len)
+HttpSM::redirect_request(const char *arg_redirect_url, const int arg_redirect_len)
 {
   SMDebug("http_redirect", "[HttpSM::redirect_request]");
   // get a reference to the client request header and client url and check to see if the url is valid
@@ -7754,22 +7754,22 @@ HttpSM::redirect_request(const char *redirect_url, const int redirect_len)
   // reset the path from previous redirects (if any)
   t_state.redirect_info.redirect_url.path_set(nullptr, 0);
 
-  // redirectUrl.user_set(redirect_url, redirect_len);
-  redirectUrl.parse(redirect_url, redirect_len);
+  redirectUrl.parse(arg_redirect_url, arg_redirect_len);
   {
     int _scheme_len = -1;
     int _host_len   = -1;
-    if (redirectUrl.scheme_get(&_scheme_len) == nullptr && redirectUrl.host_get(&_host_len) != nullptr && redirect_url[0] != '/') {
+    if (redirectUrl.scheme_get(&_scheme_len) == nullptr && redirectUrl.host_get(&_host_len) != nullptr &&
+        arg_redirect_url[0] != '/') {
       // RFC7230 § 5.5
       // The redirect URL lacked a scheme and so it is a relative URL.
       // The redirect URL did not begin with a slash, so we parsed some or all
       // of the the relative URI path as the host.
       // Prepend a slash and parse again.
-      char redirect_url_leading_slash[redirect_len + 1];
+      char redirect_url_leading_slash[arg_redirect_len + 1];
       redirect_url_leading_slash[0] = '/';
-      memcpy(redirect_url_leading_slash + 1, redirect_url, redirect_len + 1);
+      memcpy(redirect_url_leading_slash + 1, arg_redirect_url, arg_redirect_len + 1);
       url_nuke_proxy_stuff(redirectUrl.m_url_impl);
-      redirectUrl.parse(redirect_url_leading_slash, redirect_len + 1);
+      redirectUrl.parse(redirect_url_leading_slash, arg_redirect_len + 1);
     }
   }
 

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -7556,7 +7556,7 @@ HttpTransact::build_request(State *s, HTTPHdr *base_request, HTTPHdr *outgoing_r
       URL *r_url = &s->redirect_info.redirect_url;
 
       ink_assert(r_url->valid());
-      base_request->url_get()->copy(r_url);
+      base_request->url_set(r_url);
     } else {
       // this is for multiple cache lookup
       URL *o_url = &s->cache_info.original_url;


### PR DESCRIPTION
Two changes.  The change in HttpSM, is just renaming the parameters for HttpSM::redirect_request so they don't shadow HttpSM member variables.

The fix in HttpTransact::build_request addresses a crash we were seeing which I still do not fully understand.  We have a cluster of machines configured as forward proxies that follow redirects.  On this machine after I moved our build machine to use gcc-6.3, the builds would crash after around 5 minutes with the following stack.

```
[ 00 ] libc-2.17.so        __GI_raise                                                           
[ 01 ] libc-2.17.so        __GI_abort                                                           
[ 02 ] libc-2.17.so        __libc_message                                                       
[ 03 ] libc-2.17.so        _int_free                                                            
[ 04 ] traffic_server      destroy                                                              ( HdrHeap.h:463 )
[ 05 ] traffic_server      destroy                                                              ( HttpTransact.h:1145 )
[ 06 ] traffic_server      HttpSM::cleanup()                                                    ( HttpSM.cc:369 )
[ 07 ] traffic_server      HttpSM::destroy()                                                    ( HttpSM.cc:392 )
[ 08 ] traffic_server      HttpSM::kill_this()                                                  ( HttpSM.cc:7145 )
[ 09 ] traffic_server      HttpSM::main_handler(int, void*)                                     ( HttpSM.cc:2827 )
[ 10 ] traffic_server      Continuation::dispatchEvent(int, void*)                              ( Continuation.cc:46 )
[ 11 ] traffic_server      HttpTunnel::main_handler(int, void*)                                 ( HttpTunnel.cc:1657 )
[ 12 ] traffic_server      Http2Stream::main_event_handler(int, void*)                          ( Http2Stream.cc:93 )
[ 13 ] traffic_server      EThread::process_event(Event*, int)                                  ( UnixEThread.cc:136 )
[ 14 ] traffic_server      EThread::process_queue(Queue<Event, Event::Link_link>*, int*, int*)  ( UnixEThread.cc:175 )
[ 15 ] traffic_server      EThread::execute_regular()                                           ( UnixEThread.cc:235 )
[ 16 ] traffic_server      spawn_thread_internal                                                ( Thread.cc:85 )
[ 17 ] libpthread-2.17.so  start_thread                                                         
```

Building the code with compilers from devtoolset 7 or 8 would avoid the problem.  Removing the redirect_info.redirect_url completely also solves the problem.  And truthfully I don't see why we need to set the request_url again in build_request when we had just set it in redirect_request.  I ran an instrumented build to make more checks to see when the client_request (base_request) URL differs from the redirect_info.redirect_urls, and in my runs it never differed, but perhaps there is an additional edge case that our deployment does not exercise? 

This change also seems to make the crash go away.  

Looking at the details of the stack, m_size is 0, so the system heap free() is called instead of the ATS thread_allocator free method.  I don't know why the m_size is set to 0.  I assume that the rediredt_url URL object is already corrupted before it gets to this destroy call.  

But I have stared at this for a couple days already.  This semantically equivalent (and shorter) sequence seems to address the issue.

I am also open to replacing redirect_info.redirect_url with a local variable in the HttpSM::redirect_request method if we decide that we don't need to double set the client request URL.