### PR TITLE
Adjust connection timeout for TLS

### DIFF
--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -358,8 +358,9 @@ write_to_net_io(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
   // vc is an SSLNetVConnection.
   if (!vc->getSSLHandShakeComplete()) {
     if (vc->trackFirstHandshake()) {
-      // Send the write ready on up to the state machine
-      write_signal_and_update(VC_EVENT_WRITE_READY, vc);
+      // Eat the first write-ready.  Until the TLS handshake is complete,
+      // we should still be under the connect timeout and shouldn't bother
+      // the state machine until the TLS handshake is complete
       vc->write.triggered = 0;
       nh->write_ready_list.remove(vc);
     }

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -1784,6 +1784,7 @@ HttpSM::state_http_server_open(int event, void *data)
     }
     return 0;
   }
+  case VC_EVENT_READ_COMPLETE:
   case VC_EVENT_WRITE_READY:
   case VC_EVENT_WRITE_COMPLETE:
     // Update the time out to the regular connection timeout.


### PR DESCRIPTION
Found the following crash. 
```
[ 0 ] traffic_server      write_to_net_io                    ( UnixNetVConnection.cc:445 )
[ 1 ] traffic_server      NetHandler::waitForActivity(long)  ( UnixNet.cc:514 )
[ 2 ] traffic_server      EThread::execute_regular()         ( UnixEThread.cc:277 )
[ 3 ] traffic_server      spawn_thread_internal              ( Thread.cc:85 )
[ 4 ] libpthread-2.17.so  start_thread                       
```
Line numbers on our branch are off from open source master, but top of stack from write_to_net_io is in code below
```
 if (!vc->getSSLHandShakeComplete()) {
    if (vc->trackFirstHandshake()) {
      // Send the write ready on up to the state machine
      write_signal_and_update(VC_EVENT_WRITE_READY, vc);
      vc->write.triggered = 0;
      nh->write_ready_list.remove(vc);
    }

    int err, ret;

    if (vc->get_context() == NET_VCONNECTION_OUT) {
      ret = vc->sslStartHandShake(SSL_EVENT_CLIENT, err);
    } else {
      ret = vc->sslStartHandShake(SSL_EVENT_SERVER, err);
    }
```
Specifically the crash is at the "ret = vc->sslStartHandShake(SSL_EVENT_CLIENT, err);" and looking in the core shows that "vc" has been freed (vtable pointer is bogus).

I think the issue is how we are handling notifying the state machine that the socket is in a write-ready state (SYN exchange has completed) with the call to write_signal_and_update.  We assume that the vc is in a good state after this call, but it is quite possible that the HttpSM has determined it is in an error state and closed the vc.  

I think we should reconsider how the connect timeout should apply to the TLS connection.  Rather than just covering the SYN exchange, I would argue that it should cover the entire TLS handshake.  If the TLS handshake stalls out, that should be covered by the connection timeout not the data no-activity timeout.  Making that change would remove the write_signal_and_update here.  Instead we don't notify the state machine until the read_complete signal sent at the end of the TLS handshake.

This PR makes that change.

We haven't see this crash very often, but the original TTFB timeout fix was backed out of the 8.0.x branch I assume due to instability issues.
