### PR TITLE
Avoid rescheduling HostDBContinuation to the ET_DNS thread.

### DIFF
--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -679,14 +679,7 @@ Lretry:
   c->init(hash, opt);
   SET_CONTINUATION_HANDLER(c, (HostDBContHandler)&HostDBContinuation::probeEvent);
 
-  // Since ProxyMutexPtr has a cast operator, gcc-3.x get upset
-  // about ambiguity when doing this comparison, so by reversing
-  // the operands, I force it to pick the cast operation /leif.
-  if (thread->mutex == cont->mutex) {
-    thread->schedule_in(c, MUTEX_RETRY_DELAY);
-  } else {
-    dnsProcessor.thread->schedule_imm(c);
-  }
+  thread->schedule_in(c, MUTEX_RETRY_DELAY);
 
   return &c->action;
 }
@@ -797,11 +790,7 @@ HostDBProcessor::getSRVbyname_imm(Continuation *cont, process_srv_info_pfn proce
   c->init(hash, copt);
   SET_CONTINUATION_HANDLER(c, (HostDBContHandler)&HostDBContinuation::probeEvent);
 
-  if (thread->mutex == cont->mutex) {
-    thread->schedule_in(c, MUTEX_RETRY_DELAY);
-  } else {
-    dnsProcessor.thread->schedule_imm(c);
-  }
+  thread->schedule_in(c, MUTEX_RETRY_DELAY);
 
   return &c->action;
 }
@@ -903,11 +892,7 @@ HostDBProcessor::iterate(Continuation *cont)
   c->current_iterate_pos = 0;
   SET_CONTINUATION_HANDLER(c, (HostDBContHandler)&HostDBContinuation::iterateEvent);
 
-  if (thread->mutex == cont->mutex) {
-    thread->schedule_in(c, HOST_DB_RETRY_PERIOD);
-  } else {
-    dnsProcessor.thread->schedule_imm(c);
-  }
+  thread->schedule_in(c, HOST_DB_RETRY_PERIOD);
 
   return &c->action;
 }


### PR DESCRIPTION
With TS-196 (commit a5345da8), the HostDBContinuation is no longer
reschedule to the ET_DNS. However, the changes only applied to the
`HostDBProcessor::getbyname_imm` interface.

And the NCA feature was removed by TS-455 (commit 112b03aa), so it is
safe to bring the changes to all the interfaces of HostDBProcessor.