### PR TITLE
LibRecords: Change global config table to be keyed by string_view

### DIFF
--- a/lib/records/I_RecCore.h
+++ b/lib/records/I_RecCore.h
@@ -140,8 +140,14 @@ RecErrT RecRegisterRawStatUpdateFunc(const char *name, RecRawStatBlock *rsb, int
 // already been taken out for the callback.
 
 // RecSetRecordConvert -> WebMgmtUtils.cc::varSetFromStr()
-RecErrT RecSetRecordConvert(const char *name, const RecString rec_string, RecSourceT source, bool lock = true,
+RecErrT RecSetRecordConvert(std::string_view const &name, const RecString rec_string, RecSourceT source, bool lock = true,
                             bool inc_version = true);
+inline RecErrT
+RecSetRecordConvert(const char *name, const RecString rec_string, RecSourceT source, bool lock = true, bool inc_version = true)
+{
+  return RecSetRecordConvert(std::string_view{name ? name : ""}, rec_string, source, lock, inc_version);
+}
+
 RecErrT RecSetRecordInt(const char *name, RecInt rec_int, RecSourceT source, bool lock = true, bool inc_version = true);
 RecErrT RecSetRecordFloat(const char *name, RecFloat rec_float, RecSourceT source, bool lock = true, bool inc_version = true);
 RecErrT RecSetRecordString(const char *name, const RecString rec_string, RecSourceT source, bool lock = true,
@@ -168,7 +174,12 @@ RecErrT RecLookupMatchingRecords(unsigned rec_type, const char *match, RecLookup
 
 RecErrT RecGetRecordType(const char *name, RecT *rec_type, bool lock = true);
 RecErrT RecGetRecordDataType(const char *name, RecDataT *data_type, bool lock = true);
-RecErrT RecGetRecordPersistenceType(const char *name, RecPersistT *persist_type, bool lock = true);
+RecErrT RecGetRecordPersistenceType(std::string_view name, RecPersistT *persist_type, bool lock = true);
+inline RecErrT
+RecGetRecordPersistenceType(const char *name, RecPersistT *persist_type, bool lock = true)
+{
+  return RecGetRecordPersistenceType(std::string_view{name ? name : ""}, persist_type, lock);
+}
 RecErrT RecGetRecordOrderAndId(const char *name, int *order, int *id, bool lock = true);
 RecErrT RecGetRecordUpdateType(const char *name, RecUpdateT *update_type, bool lock = true);
 RecErrT RecGetRecordCheckType(const char *name, RecCheckT *check_type, bool lock = true);
@@ -296,7 +307,12 @@ RecString REC_readString(const char *name, bool *found, bool lock = true);
 //------------------------------------------------------------------------
 // Clear Statistics
 //------------------------------------------------------------------------
-RecErrT RecResetStatRecord(const char *name);
+RecErrT RecResetStatRecord(std::string_view name);
+inline RecErrT
+RecResetStatRecord(const char *name)
+{
+  return RecResetStatRecord(std::string_view{name ? name : ""});
+}
 RecErrT RecResetStatRecord(RecT type = RECT_NULL, bool all = false);
 
 //------------------------------------------------------------------------

--- a/lib/records/P_RecMessage.h
+++ b/lib/records/P_RecMessage.h
@@ -40,8 +40,8 @@ RecMessage *RecMessageAlloc(RecMessageT msg_type, int initial_size = 256);
 int RecMessageFree(RecMessage *msg);
 
 RecMessage *RecMessageMarshal_Realloc(RecMessage *msg, const RecRecord *record);
-int RecMessageUnmarshalFirst(RecMessage *msg, RecMessageItr *itr, RecRecord **record);
-int RecMessageUnmarshalNext(RecMessage *msg, RecMessageItr *itr, RecRecord **record);
+int RecMessageUnmarshalFirst(RecMessage *msg, RecMessageItr *itr, RecRecordSerialized **record);
+int RecMessageUnmarshalNext(RecMessage *msg, RecMessageItr *itr, RecRecordSerialized **record);
 
 int RecMessageSend(RecMessage *msg);
 int RecMessageRegisterRecvCb(RecMessageRecvCb recv_cb, void *cookie);

--- a/lib/records/P_RecUtils.h
+++ b/lib/records/P_RecUtils.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <string_view>
+
 #include "tscore/Diags.h"
 #include "tscore/ink_atomic.h"
 
@@ -41,7 +43,7 @@
 //-------------------------------------------------------------------------
 void RecRecordInit(RecRecord *r);
 void RecRecordFree(RecRecord *r);
-RecRecord *RecAlloc(RecT rec_type, const char *name, RecDataT data_type);
+RecRecord *RecAlloc(RecT rec_type, std::string_view name, RecDataT data_type);
 
 //-------------------------------------------------------------------------
 // RecData Utils

--- a/lib/records/RecConfigParse.cc
+++ b/lib/records/RecConfigParse.cc
@@ -38,7 +38,7 @@
 
 const char *g_rec_config_fpath = nullptr;
 LLQ *g_rec_config_contents_llq = nullptr;
-std::unordered_set<std::string> g_rec_config_contents_ht;
+std::unordered_set<std::string_view> g_rec_config_contents_ht;
 ink_mutex g_rec_config_lock;
 
 //-------------------------------------------------------------------------

--- a/lib/records/RecRawStats.cc
+++ b/lib/records/RecRawStats.cc
@@ -582,7 +582,7 @@ RecExecRawStatSyncCbs()
           raw_stat_clear(r->stat_meta.sync_rsb, r->stat_meta.sync_id);
           r->stat_meta.sync_rsb->global[r->stat_meta.sync_id]->version = r->version;
         } else {
-          (*(r->stat_meta.sync_cb))(r->name, r->data_type, &(r->data), r->stat_meta.sync_rsb, r->stat_meta.sync_id);
+          (*(r->stat_meta.sync_cb))(r->name.data(), r->data_type, &(r->data), r->stat_meta.sync_rsb, r->stat_meta.sync_id);
         }
         r->sync_required = REC_SYNC_REQUIRED;
       }

--- a/lib/records/RecUtils.cc
+++ b/lib/records/RecUtils.cc
@@ -33,7 +33,7 @@
 void
 RecRecordInit(RecRecord *r)
 {
-  ink_zero(*r);
+  //  ink_zero(*r);
   rec_mutex_init(&(r->lock), nullptr);
 }
 
@@ -47,7 +47,7 @@ RecRecordFree(RecRecord *r)
 // RecAlloc
 //-------------------------------------------------------------------------
 RecRecord *
-RecAlloc(RecT rec_type, const char *name, RecDataT data_type)
+RecAlloc(RecT rec_type, std::string_view name, RecDataT data_type)
 {
   if (g_num_records >= REC_MAX_RECORDS) {
     Warning("too many stats/configs, please increase REC_MAX_RECORDS or rebuild with --with_max_api_stats=<n>");
@@ -58,10 +58,11 @@ RecAlloc(RecT rec_type, const char *name, RecDataT data_type)
   RecRecord *r = &(g_records[i]);
 
   RecRecordInit(r);
-  r->rec_type  = rec_type;
-  r->name      = ats_strdup(name);
-  r->order     = i;
-  r->data_type = data_type;
+  r->rec_type   = rec_type;
+  r->name_store = name;
+  r->name       = r->name_store;
+  r->order      = i;
+  r->data_type  = data_type;
 
   return r;
 }

--- a/mgmt/api/NetworkMessage.cc
+++ b/mgmt/api/NetworkMessage.cc
@@ -284,7 +284,7 @@ send_mgmt_response(int fd, OpType optype, ...)
 
   ink_assert(msglen >= 0);
 
-  reply.ptr = (char *)ats_malloc(msglen);
+  reply.ptr = static_cast<char *>(ats_malloc(msglen));
   reply.len = msglen;
 
   // Marshall the message itself.

--- a/mgmt/api/TSControlMain.cc
+++ b/mgmt/api/TSControlMain.cc
@@ -1,3 +1,4 @@
+
 /** @file
 
   A brief file description
@@ -292,7 +293,7 @@ send_record_get_response(int fd, const RecRecord *rec)
   if (rec) {
     type   = rec->data_type;
     rclass = rec->rec_type;
-    name   = const_cast<MgmtMarshallString>(rec->name);
+    name   = const_cast<MgmtMarshallString>(rec->name.data());
   } else {
     type   = RECD_NULL;
     rclass = RECT_NULL;
@@ -302,17 +303,17 @@ send_record_get_response(int fd, const RecRecord *rec)
   switch (type) {
   case RECD_INT:
     type      = TS_REC_INT;
-    value.ptr = (void *)&rec->data.rec_int;
+    value.ptr = const_cast<void *>(static_cast<void const *>(&rec->data.rec_int));
     value.len = sizeof(RecInt);
     break;
   case RECD_COUNTER:
     type      = TS_REC_COUNTER;
-    value.ptr = (void *)&rec->data.rec_counter;
+    value.ptr = const_cast<void *>(static_cast<void const *>(&rec->data.rec_counter));
     value.len = sizeof(RecCounter);
     break;
   case RECD_FLOAT:
     type      = TS_REC_FLOAT;
-    value.ptr = (void *)&rec->data.rec_float;
+    value.ptr = const_cast<void *>(static_cast<void const *>(&rec->data.rec_float));
     value.len = sizeof(RecFloat);
     break;
   case RECD_STRING:
@@ -893,7 +894,7 @@ send_record_describe(const RecRecord *rec, void *edata)
       return;
     }
 
-    rec_name       = const_cast<char *>(rec->name);
+    rec_name       = const_cast<char *>(rec->name.data());
     rec_type       = rec->data_type;
     rec_class      = rec->rec_type;
     rec_version    = rec->version;

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -950,7 +950,7 @@ void
 load_negative_caching_var(RecRecord const *r, void *cookie)
 {
   HttpConfigParams *c = static_cast<HttpConfigParams *>(cookie);
-  set_negative_caching_list(r->name, r->data_type, r->data, c, false);
+  set_negative_caching_list(r->name.data(), r->data_type, r->data, c, false);
 }
 
 ////////////////////////////////////////////////////////////////

--- a/proxy/http/HttpConnectionCount.cc
+++ b/proxy/http/HttpConnectionCount.cc
@@ -142,7 +142,7 @@ void
 Load_Config_Var(RecRecord const *r, void *)
 {
   for (auto cb = r->config_meta.update_cb_list; nullptr != cb; cb = cb->next) {
-    cb->update_cb(r->name, r->data_type, r->data, cb->update_cookie);
+    cb->update_cb(r->name.data(), r->data_type, r->data, cb->update_cookie);
   }
 }
 

--- a/src/traffic_server/HostStatus.cc
+++ b/src/traffic_server/HostStatus.cc
@@ -187,16 +187,11 @@ static void
 handle_record_read(const RecRecord *rec, void *edata)
 {
   HostStatus &hs = HostStatus::instance();
-  std::string hostname;
 
   if (rec) {
-    Debug("host_statuses", "name: %s", rec->name);
+    Debug("host_statuses", "name: %.*s", static_cast<int>(rec->name.size()), rec->name.data());
+    std::string hostname(ts::TextView{rec->name}.remove_prefix(stat_prefix.length()));
 
-    // parse the hostname from the stat name
-    char *s = const_cast<char *>(rec->name);
-    // 1st move the pointer past the stat prefix.
-    s += stat_prefix.length();
-    hostname = s;
     hs.createHostStat(hostname.c_str(), rec->data.rec_string);
     HostStatRec h(rec->data.rec_string);
     hs.loadRecord(hostname, h);


### PR DESCRIPTION
Changing the key from `string` to `string_view` means that a `string` does not have to be constructed on every record lookup. This is a side effect of the TCL conversion that should be cleaned up. At the time it seemed better to push forward on removing TCL.

This is a precursor to changing the lib records API to use `string_view` which is needed for the planned upgrades to the overridable configuration variables.

This isn't a complete overhaul, that seemed too large. In many cases free functions were overloaded to preserve the current C string style interface. Over the long term these should be removed.