### PR TITLE
Don't Alert and immediate shutdown during a normal shutdown.

### DIFF
--- a/mgmt/ProcessManager.cc
+++ b/mgmt/ProcessManager.cc
@@ -164,13 +164,13 @@ ProcessManager::processManagerThread(void *arg)
 
     if (pmgmt->require_lm) {
       ret = pmgmt->pollLMConnection();
-      if (ret < 0 && pmgmt->running) {
+      if (ret < 0 && pmgmt->running && !shutdown_event_system) {
         Alert("exiting with read error from process manager: %s", strerror(-ret));
       }
     }
 
     ret = pmgmt->processSignalQueue();
-    if (ret < 0 && pmgmt->running) {
+    if (ret < 0 && pmgmt->running && !shutdown_event_system) {
       Alert("exiting with write error from process manager: %s", strerror(-ret));
     }
   }


### PR DESCRIPTION
Earlier cleanups replaced the Fatal (shutdown and core) with an Alert (shutdown).  But if the system is already in the process of shutting down these failures are normal, and we shouldn't make it look like an error shutdown.  You lose logging information in this case, and the Alert messages confuse people.