### PR TITLE
Runroot: make traffic_top use runroot

### DIFF
--- a/src/traffic_top/traffic_top.cc
+++ b/src/traffic_top/traffic_top.cc
@@ -57,6 +57,7 @@
 #include "tscore/ink_args.h"
 #include "records/I_RecProcess.h"
 #include "RecordsConfig.h"
+#include "tscore/runroot.h"
 
 using namespace std;
 
@@ -407,6 +408,7 @@ main(int argc, const char **argv)
 
   process_args(&version, argument_descriptions, countof(argument_descriptions), argv, USAGE);
 
+  runroot_handler(argv);
   Layout::create();
   RecProcessInit(RECM_STAND_ALONE, nullptr /* diags */);
   LibRecordsConfigInit();


### PR DESCRIPTION
Runroot was not involved in traffic_top and don't know why it's not in there. So this should make runroot work for traffic_top.