### PR TITLE
lua plugin: add support for relative path scripts; moves inline script to switch

### DIFF
--- a/plugins/lua/ts_lua.c
+++ b/plugins/lua/ts_lua.c
@@ -63,11 +63,14 @@ TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 TSReturnCode
 TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_size)
 {
-  int fn;
   int ret;
+  char script[TS_LUA_MAX_SCRIPT_FNAME_LENGTH];
+  char *inline_script                  = "";
+  int fn                               = 0;
   int states                           = TS_LUA_MAX_STATE_COUNT;
   static const struct option longopt[] = {
     {"states", required_argument, 0, 's'},
+    {"inline", required_argument, 0, 'i'},
     {0, 0, 0, 0},
   };
 
@@ -84,6 +87,8 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_s
       TSDebug(TS_LUA_DEBUG_TAG, "[%s] setting number of lua VM [%d]", __FUNCTION__, states);
       // set state
       break;
+    case 'i':
+      inline_script = optarg;
     }
 
     if (opt == -1) {
@@ -97,17 +102,24 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_s
     return TS_ERROR;
   }
 
-  if (argc - optind < 1) {
+  if (argc - optind > 0) {
+    fn = 1;
+    if (argv[optind][0] == '/') {
+      snprintf(script, sizeof(script), "%s", argv[optind]);
+    } else {
+      snprintf(script, sizeof(script), "%s/%s", TSConfigDirGet(), argv[optind]);
+    }
+  }
+
+  if (strlen(inline_script) == 0 && argc - optind < 1) {
     strncpy(errbuf, "[TSRemapNewInstance] - lua script file or string is required !!", errbuf_size - 1);
     errbuf[errbuf_size - 1] = '\0';
     return TS_ERROR;
   }
 
-  fn = 1;
-
-  if (argv[optind][0] != '/') {
-    fn = 0;
-  } else if (strlen(argv[optind]) >= TS_LUA_MAX_SCRIPT_FNAME_LENGTH - 16) {
+  if (strlen(script) >= TS_LUA_MAX_SCRIPT_FNAME_LENGTH - 16) {
+    strncpy(errbuf, "[TSRemapNewInstance] - lua script file name too long !!", errbuf_size - 1);
+    errbuf[errbuf_size - 1] = '\0';
     return TS_ERROR;
   }
 
@@ -116,8 +128,7 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_s
   // check to make sure it is a lua file and there is no parameter for the lua file
   if (fn && (argc - optind < 2)) {
     TSDebug(TS_LUA_DEBUG_TAG, "[%s] checking if script has been registered", __FUNCTION__);
-    char script[TS_LUA_MAX_SCRIPT_FNAME_LENGTH];
-    snprintf(script, TS_LUA_MAX_SCRIPT_FNAME_LENGTH, "%s", argv[optind]);
+
     // we only need to check the first lua VM for script registration
     conf = ts_lua_script_registered(ts_lua_main_ctx_array[0].lua, script);
   }
@@ -138,9 +149,9 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_s
     conf->init_func = 0;
 
     if (fn) {
-      snprintf(conf->script, TS_LUA_MAX_SCRIPT_FNAME_LENGTH, "%s", argv[optind]);
+      snprintf(conf->script, TS_LUA_MAX_SCRIPT_FNAME_LENGTH, "%s", script);
     } else {
-      conf->content = argv[optind];
+      conf->content = inline_script;
     }
 
     ts_lua_init_instance(conf);
@@ -508,7 +519,11 @@ TSPluginInit(int argc, const char *argv[])
   conf->remap  = 0;
   conf->states = states;
 
-  snprintf(conf->script, TS_LUA_MAX_SCRIPT_FNAME_LENGTH, "%s", argv[optind]);
+  if (argv[optind][0] == '/') {
+    snprintf(conf->script, TS_LUA_MAX_SCRIPT_FNAME_LENGTH, "%s", argv[optind]);
+  } else {
+    snprintf(conf->script, TS_LUA_MAX_SCRIPT_FNAME_LENGTH, "%s/%s", TSConfigDirGet(), argv[optind]);
+  }
 
   ts_lua_init_instance(conf);
 

--- a/plugins/lua/ts_lua_util.c
+++ b/plugins/lua/ts_lua_util.c
@@ -201,7 +201,7 @@ ts_lua_add_module(ts_lua_instance_conf *conf, ts_lua_main_ctx *arr, int n, int a
 
     if (conf->content) {
       if (luaL_loadstring(L, conf->content)) {
-        snprintf(errbuf, errbuf_size, "[%s] luaL_loadstring %s failed: %s", __FUNCTION__, conf->script, lua_tostring(L, -1));
+        snprintf(errbuf, errbuf_size, "[%s] luaL_loadstring failed: %s", __FUNCTION__, lua_tostring(L, -1));
         lua_pop(L, 1);
         TSMutexUnlock(arr[i].mutexp);
         return -1;


### PR DESCRIPTION
To use inline scripts, prefix with --inline;
eg:
   @plugin=tslua.so @pparam=--states=4 @pparam=--inline=print(123)