### PR TITLE
Doc: TSHttpTxnHdrLengthGet, TSMBuffer, TSMLoc.

### DIFF
--- a/doc/developer-guide/api/functions/TSHttpHdrLengthGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpHdrLengthGet.en.rst
@@ -26,7 +26,16 @@ Synopsis
 
 `#include <ts/ts.h>`
 
-.. function:: int TSHttpHdrLengthGet(TSMBuffer bufp, TSMLoc offset)
+.. function:: int TSHttpHdrLengthGet(TSMBuffer bufp, TSMLoc mloc)
 
 Description
 ===========
+
+Return the length in characters of the HTTP header specified by :arg:`bufp` and :arg:`mloc` which
+must specify a valid HTTP header. Usually these values would have been obtained via an earlier call
+to
+:func:`TSHttpTxnServerReqGet`,
+:func:`TSHttpTxnClientReqGet`,
+:func:`TSHttpTxnServerRespGet`,
+:func:`TSHttpTxnClientRespGet`,
+or via calls to create a new HTTP header such as :func:`TSHttpHdrCreate`.

--- a/doc/developer-guide/api/functions/TSTypes.en.rst
+++ b/doc/developer-guide/api/functions/TSTypes.en.rst
@@ -102,6 +102,11 @@ more widely. Those are described on this page.
 
 .. type:: TSMBuffer
 
+   Internally, data for a transaction is stored in one more more :term:`header heap`\s. These are
+   storage local to the transaction, and generally each HTTP header is stored in a separate one.
+   This type is a handle to a header heap, and is provided or required by functions that locate HTTP
+   header related data.
+
 .. type:: TSMgmtCounter
 
 .. type:: TSMgmtFloat
@@ -119,6 +124,12 @@ more widely. Those are described on this page.
 .. type:: TSMimeParser
 
 .. type:: TSMLoc
+
+   This is a memory location relative to a :term:`header heap` represented by a :c:type:`TSMBuffer` and
+   must always be used in conjuction with that :c:type:`TSMBuffer` instance. It identifies a specific
+   object in the :c:type:`TSMBuffer`. This indirection is needed so that the :c:type:`TSMBuffer`
+   can reallocate space as needed. Therefore a raw address obtained from a :c:type:`TSMLoc` should
+   be considered volatile that may become invalid across any API call.
 
 .. var:: TSMLoc TS_NULL_MLOC
 

--- a/doc/developer-guide/core-architecture/heap.en.rst
+++ b/doc/developer-guide/core-architecture/heap.en.rst
@@ -121,7 +121,7 @@ Classes
 
       :arg:`type` must be one of the values specified in :class:`HdrHeapObjImpl`.
 
-   .. function:: int marshal_length
+   .. function:: int marshal_length()
 
       Compute and return the size of the buffer needed to serialize :arg:`this`.
 


### PR DESCRIPTION
I messed up the `HdrHeap` docs a bit, so this corrects that but I didn't want to have a PR for just that, so I documented a few other things.