### PR TITLE
Make mutex lock routines deal with null mutex and general clean up.

### DIFF
--- a/iocore/hostdb/P_HostDB.h
+++ b/iocore/hostdb/P_HostDB.h
@@ -47,6 +47,6 @@
 
 static constexpr ts::ModuleVersion HOSTDB_MODULE_INTERNAL_VERSION{HOSTDB_MODULE_PUBLIC_VERSION, ts::ModuleVersion::PRIVATE};
 
-Ptr<HostDBInfo> probe(ProxyMutex *mutex, CryptoHash const &hash, bool ignore_timeout);
+Ptr<HostDBInfo> probe(Ptr<ProxyMutex> mutex, CryptoHash const &hash, bool ignore_timeout);
 
 void make_crypto_hash(CryptoHash &hash, const char *hostname, int len, int port, const char *pDNSServers, HostDBMark mark);

--- a/iocore/hostdb/P_RefCountCache.h
+++ b/iocore/hostdb/P_RefCountCache.h
@@ -408,7 +408,7 @@ public:
 
   // Some methods to get some internal state
   int partition_for_key(uint64_t key);
-  ProxyMutex *lock_for_key(uint64_t key);
+  Ptr<ProxyMutex> lock_for_key(uint64_t key);
   size_t partition_count() const;
   RefCountCachePartition<C> &get_partition(int pnum);
   size_t count() const;
@@ -510,10 +510,10 @@ RefCountCache<C>::get_header()
 }
 
 template <class C>
-ProxyMutex *
+Ptr<ProxyMutex>
 RefCountCache<C>::lock_for_key(uint64_t key)
 {
-  return this->partitions[this->partition_for_key(key)]->lock.get();
+  return this->partitions[this->partition_for_key(key)]->lock;
 }
 
 template <class C>

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -78,7 +78,7 @@ net_accept(NetAccept *na, void *ep, bool blockable)
   Connection con;
 
   if (!blockable) {
-    if (!MUTEX_TAKE_TRY_LOCK(na->action_->mutex.get(), e->ethread)) {
+    if (!MUTEX_TAKE_TRY_LOCK(na->action_->mutex, e->ethread)) {
       return 0;
     }
   }
@@ -149,7 +149,7 @@ net_accept(NetAccept *na, void *ep, bool blockable)
 
 Ldone:
   if (!blockable) {
-    MUTEX_UNTAKE_LOCK(na->action_->mutex.get(), e->ethread);
+    MUTEX_UNTAKE_LOCK(na->action_->mutex, e->ethread);
   }
   return count;
 }
@@ -379,12 +379,12 @@ NetAccept::acceptEvent(int event, void *ep)
   (void)event;
   Event *e = (Event *)ep;
   // PollDescriptor *pd = get_PollDescriptor(e->ethread);
-  ProxyMutex *m = nullptr;
+  Ptr<ProxyMutex> m;
 
   if (action_->mutex) {
-    m = action_->mutex.get();
+    m = action_->mutex;
   } else {
-    m = mutex.get();
+    m = mutex;
   }
 
   MUTEX_TRY_LOCK(lock, m, e->ethread);

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -1428,34 +1428,19 @@ plugins required to work with sni_routing.
           callout_state = HTTP_API_IN_CALLOUT;
         }
 
-        /* The MUTEX_TRY_LOCK macro was changed so
-           that it can't handle NULL mutex'es.  The plugins
-           can use null mutexes so we have to do this manually.
-           We need to take a smart pointer to the mutex since
-           the plugin could release it's mutex while we're on
-           the callout
-         */
-        bool plugin_lock;
-        Ptr<ProxyMutex> plugin_mutex;
-        if (cur_hook->m_cont->mutex) {
-          plugin_mutex = cur_hook->m_cont->mutex;
-          plugin_lock  = MUTEX_TAKE_TRY_LOCK(cur_hook->m_cont->mutex, mutex->thread_holding);
-
-          if (!plugin_lock) {
-            api_timer = -Thread::get_hrtime_updated();
-            HTTP_SM_SET_DEFAULT_HANDLER(&HttpSM::state_api_callout);
-            ink_assert(pending_action == nullptr);
-            pending_action = mutex->thread_holding->schedule_in(this, HRTIME_MSECONDS(10));
-            // Should @a callout_state be reset back to HTTP_API_NO_CALLOUT here? Because the default
-            // handler has been changed the value isn't important to the rest of the state machine
-            // but not resetting means there is no way to reliably detect re-entrance to this state with an
-            // outstanding callout.
-            return 0;
-          }
-        } else {
-          plugin_lock = false;
+        MUTEX_TRY_LOCK(lock, cur_hook->m_cont->mutex, mutex->thread_holding);
+        // Have a mutex but didn't get the lock, reschedule
+        if (!lock.is_locked()) {
+          api_timer = -Thread::get_hrtime_updated();
+          HTTP_SM_SET_DEFAULT_HANDLER(&HttpSM::state_api_callout);
+          ink_assert(pending_action == nullptr);
+          pending_action = mutex->thread_holding->schedule_in(this, HRTIME_MSECONDS(10));
+          // Should @a callout_state be reset back to HTTP_API_NO_CALLOUT here? Because the default
+          // handler has been changed the value isn't important to the rest of the state machine
+          // but not resetting means there is no way to reliably detect re-entrance to this state with an
+          // outstanding callout.
+          return 0;
         }
-
         SMDebug("http", "[%" PRId64 "] calling plugin on hook %s at hook %p", sm_id, HttpDebugNames::get_api_hook_name(cur_hook_id),
                 cur_hook);
 
@@ -1473,11 +1458,6 @@ plugins required to work with sni_routing.
           // tracking a non-complete callout from a chain so just let it ride. It will get cleaned
           // up in state_api_callback when the plugin re-enables this transaction.
         }
-
-        if (plugin_lock) {
-          Mutex_unlock(plugin_mutex, mutex->thread_holding);
-        }
-
         return 0;
       }
     }

--- a/proxy/http/HttpSessionManager.cc
+++ b/proxy/http/HttpSessionManager.cc
@@ -320,10 +320,11 @@ HttpSessionManager::acquire_session(Continuation * /* cont ATS_UNUSED */, sockad
   // client session
   {
     // Now check to see if we have a connection in our shared connection pool
-    EThread *ethread       = this_ethread();
-    ProxyMutex *pool_mutex = (TS_SERVER_SESSION_SHARING_POOL_THREAD == sm->t_state.http_config_param->server_session_sharing_pool) ?
-                               ethread->server_session_pool->mutex.get() :
-                               m_g_pool->mutex.get();
+    EThread *ethread = this_ethread();
+    Ptr<ProxyMutex> pool_mutex =
+      (TS_SERVER_SESSION_SHARING_POOL_THREAD == sm->t_state.http_config_param->server_session_sharing_pool) ?
+        ethread->server_session_pool->mutex :
+        m_g_pool->mutex;
     MUTEX_TRY_LOCK(lock, pool_mutex, ethread);
     if (lock.is_locked()) {
       if (TS_SERVER_SESSION_SHARING_POOL_THREAD == sm->t_state.http_config_param->server_session_sharing_pool) {

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -1295,16 +1295,12 @@ APIHook::invoke(int event, void *edata)
       ink_assert(!"not reached");
     }
   }
-  if (m_cont->mutex != nullptr) {
-    MUTEX_TRY_LOCK(lock, m_cont->mutex, this_ethread());
-    if (!lock.is_locked()) {
-      // If we cannot get the lock, the caller needs to restructure to handle rescheduling
-      ink_release_assert(0);
-    }
-    return m_cont->handleEvent(event, edata);
-  } else {
-    return m_cont->handleEvent(event, edata);
+  MUTEX_TRY_LOCK(lock, m_cont->mutex, this_ethread());
+  if (!lock.is_locked()) {
+    // If we cannot get the lock, the caller needs to restructure to handle rescheduling
+    ink_release_assert(0);
   }
+  return m_cont->handleEvent(event, edata);
 }
 
 APIHook *
@@ -4682,16 +4678,12 @@ int
 TSContCall(TSCont contp, TSEvent event, void *edata)
 {
   Continuation *c = (Continuation *)contp;
-  if (c->mutex != nullptr) {
-    MUTEX_TRY_LOCK(lock, c->mutex, this_ethread());
-    if (!lock.is_locked()) {
-      // If we cannot get the lock, the caller needs to restructure to handle rescheduling
-      ink_release_assert(0);
-    }
-    return c->handleEvent((int)event, edata);
-  } else {
-    return c->handleEvent((int)event, edata);
+  MUTEX_TRY_LOCK(lock, c->mutex, this_ethread());
+  if (!lock.is_locked()) {
+    // If we cannot get the lock, the caller needs to restructure to handle rescheduling
+    ink_release_assert(0);
   }
+  return c->handleEvent((int)event, edata);
 }
 
 TSMutex


### PR DESCRIPTION
The original change I made was to MUTEX_TRY_LOCK and underlying classes to handle the case when the mutex is null.  We were getting some rather convoluted code to deal with scoped lock pointers and the two cases where the mutex was null or not. And ultimately ran into an internal change that messed up the scoped pointer logic introducing a small window locking error.  We have been running that logic on our internal build for the past week.

As I was pulling this PR together I noticed the following comment from HttpSM
```
/* The MUTEX_TRY_LOCK macro was changed so
     that it can't handle NULL mutex'es.  The plugins
     can use null mutexes so we have to do this manually.
    We need to take a smart pointer to the mutex since
    the plugin could release it's mutex while we're on
    the callout
 */
```
So it appears at some point (before the first commit to git in 2009), the logic to deal with null mutexes was pulled from the MUTEX_TRY_LOCK area.  I don't know why.  The null check seems like pretty low overhead.

Then I noticed the second part of the comment about needing to take the smart pointer in case the continuation released the mutex along the way.  Looking into I_Lock.h it wasn't clear why we had versions that stored the ProxyMutex pointer directly and others that stored the Ptr<ProxyMutex>, so I got rid of the raw pointer version and the spin lock version which doesn't seem to be used.  This required some fixes through the code (mostly in HostDB) to stop calling the .get() method on the Ptr<ProxyMutex> before making locking calls.

The one point that needed a direct ProxyMutex * interface was through the TSAPI since that is a C interface.  But if we have TSMutexCreate bump the reference count before returning the ProxyMutex * and TSMutexDestroy correspondingly decrement the reference count, we should be able to put the InkAPI provided ProxyMutex * back into the smart pointer for core processing.  This was found through the "make check" unit tests.
