### PR TITLE
Cleanup: Convert HTTPHdr::length_get to real method.

### DIFF
--- a/proxy/hdrs/HTTP.cc
+++ b/proxy/hdrs/HTTP.cc
@@ -592,21 +592,21 @@ http_hdr_describe(HdrHeapObjImpl *raw, bool recurse)
   -------------------------------------------------------------------------*/
 
 int
-http_hdr_length_get(HTTPHdrImpl *hdr)
+HTTPHdr::length_get() const
 {
   int length = 0;
 
-  if (hdr->m_polarity == HTTP_TYPE_REQUEST) {
-    if (hdr->u.req.m_ptr_method) {
-      length = hdr->u.req.m_len_method;
+  if (m_http->m_polarity == HTTP_TYPE_REQUEST) {
+    if (m_http->u.req.m_ptr_method) {
+      length = m_http->u.req.m_len_method;
     } else {
       length = 0;
     }
 
     length += 1; // " "
 
-    if (hdr->u.req.m_url_impl) {
-      length += url_length_get(hdr->u.req.m_url_impl);
+    if (m_http->u.req.m_url_impl) {
+      length += url_length_get(m_http->u.req.m_url_impl);
     }
 
     length += 1; // " "
@@ -614,9 +614,9 @@ http_hdr_length_get(HTTPHdrImpl *hdr)
     length += 8; // HTTP/%d.%d
 
     length += 2; // "\r\n"
-  } else if (hdr->m_polarity == HTTP_TYPE_RESPONSE) {
-    if (hdr->u.resp.m_ptr_reason) {
-      length = hdr->u.resp.m_len_reason;
+  } else if (m_http->m_polarity == HTTP_TYPE_RESPONSE) {
+    if (m_http->u.resp.m_ptr_reason) {
+      length = m_http->u.resp.m_len_reason;
     } else {
       length = 0;
     }
@@ -632,7 +632,7 @@ http_hdr_length_get(HTTPHdrImpl *hdr)
     length += 2; // "\r\n"
   }
 
-  length += mime_hdr_length_get(hdr->m_fields_impl);
+  length += mime_hdr_length_get(m_http->m_fields_impl);
 
   return length;
 }

--- a/proxy/hdrs/HTTP.h
+++ b/proxy/hdrs/HTTP.h
@@ -423,9 +423,6 @@ inkcoreapi int http_hdr_print(HdrHeap *heap, HTTPHdrImpl *hh, char *buf, int buf
 
 void http_hdr_describe(HdrHeapObjImpl *obj, bool recurse = true);
 
-int http_hdr_length_get(HTTPHdrImpl *hh);
-// HTTPType               http_hdr_type_get (HTTPHdrImpl *hh);
-
 // int32_t                  http_hdr_version_get (HTTPHdrImpl *hh);
 inkcoreapi void http_hdr_version_set(HTTPHdrImpl *hh, int32_t ver);
 
@@ -520,7 +517,7 @@ public:
 
   int print(char *buf, int bufsize, int *bufindex, int *dumpoffset);
 
-  int length_get();
+  int length_get() const;
 
   HTTPType type_get() const;
 
@@ -841,16 +838,6 @@ HTTPHdr::print(char *buf, int bufsize, int *bufindex, int *dumpoffset)
 {
   ink_assert(valid());
   return http_hdr_print(m_heap, m_http, buf, bufsize, bufindex, dumpoffset);
-}
-
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-
-inline int
-HTTPHdr::length_get()
-{
-  ink_assert(valid());
-  return http_hdr_length_get(m_http);
 }
 
 /*-------------------------------------------------------------------------


### PR DESCRIPTION
One step toward changing from C to C++ code in the HTTP/MIME headers.