### PR TITLE
For tls tests look at logs until config has been reloaded

### DIFF
--- a/tests/gold_tests/tls/tls_tunnel.test.py
+++ b/tests/gold_tests/tls/tls_tunnel.test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 
 import os
+import subprocess
 Test.Summary = '''
 Test tunneling based on SNI
 '''
@@ -30,6 +31,7 @@ Test.SkipUnless(
 ts = Test.MakeATSProcess("ts", command="traffic_manager", select_ports=False)
 server_foo = Test.MakeOriginServer("server_foo", ssl=True)
 server_bar = Test.MakeOriginServer("server_bar", ssl=True)
+server2 = Test.MakeOriginServer("server2")
 
 request_foo_header = {"headers": "GET / HTTP/1.1\r\nHost: foo.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""} 
 request_bar_header = {"headers": "GET / HTTP/1.1\r\nHost: bar.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
@@ -153,11 +155,25 @@ trreload.Processes.Default.Command = 'traffic_ctl config reload'
 trreload.Processes.Default.Env = ts.Env
 trreload.Processes.Default.ReturnCode = 0
 
+# Parking this as a ready tester on a meaningless process
+# Stall the test runs until the ssl_server_name reload has completed
+# At that point the new ssl_server_name settings are ready to go
+def ssl_server_name_reload_done(tsenv):
+  def done_reload(process, hasRunFor, **kw):
+    cmd = "grep 'ssl_server_name.yaml done reloading!' {0} | wc -l > {1}/test.out".format(ts.Disk.diags_log.Name, Test.RunDirectory)
+    retval = subprocess.run(cmd, shell=True, env=tsenv)
+    if retval.returncode == 0:
+      cmd ="if [ -f {0}/test.out -a \"`cat {0}/test.out`\" = \"2\" ] ; then true; else false; fi".format(Test.RunDirectory)
+      retval = subprocess.run(cmd, shell = True, env=tsenv)
+    return retval.returncode == 0
+
+  return done_reload
+
 # Should termimate on traffic_server (not tunnel)
 tr = Test.AddTestRun("foo.com no Tunnel-test")
 tr.StillRunningAfter = ts
-# Wait for the reload to complete
-tr.DelayStart = 5
+# Wait for the reload to complete by running the ssl_server_name_reload_done test
+tr.Processes.Default.StartBefore(server2, ready=ssl_server_name_reload_done(ts.Env))
 tr.Processes.Default.Command = "curl -v --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(ts.Variables.ssl_port)
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("Not Found on Accelerato", "Terminates on on Traffic Server")
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("ATS", "Terminate on Traffic Server")


### PR DESCRIPTION
Hopefully make the tests more resilient rather that just waiting for arbitrary time delays.