### PR TITLE
Plugin Traffic Dump: new feature for setting limit on disk usage. 

### DIFF
--- a/doc/admin-guide/plugins/traffic_dump.en.rst
+++ b/doc/admin-guide/plugins/traffic_dump.en.rst
@@ -36,14 +36,20 @@ Plugin Configuration
 * ``Traffic Dump`` is a global plugin and is configured via :file:`plugin.config`.
    .. option:: --logdir <path_to_dump>
 
-   (`required`, default:empty/unused) - specifies the directory for writing all dump files. If path is relative, it is relative to the Traffic Server directory. The plugin will use first three characters of client ip to create subdirs in an attempt to spread dumps evenly and avoid too many files in a single directory.
+   (`required`) - specifies the directory for writing all dump files. If path is relative, it is relative to the Traffic Server directory. The plugin will use first three characters of client ip to create subdirs in an attempt to spread dumps evenly and avoid too many files in a single directory.
 
    .. option:: --sample <N>
 
-   (`optional`, default:1000) - specifies the sampling ratio N. Traffic Dump will capture every one out of N sessions. This ratio can also be changed via traffic_ctl without restarting ATS.
+   (`required`) - specifies the sampling ratio N. Traffic Dump will capture every one out of N sessions. This ratio can also be changed via traffic_ctl without restarting ATS.
+
+   .. option:: --limit <N>
+
+   (`required`) - specifies the max disk usage N bytes(approximate). Traffic Dump will stop capturing new sessions once disk usage exceeds this limit.
 
 * ``traffic_ctl`` command.
    ``traffic_ctl plugin msg traffic_dump.sample N`` - changes the sampling ratio N as mentioned above.
+   ``traffic_ctl plugin msg traffic_dump.reset`` - resets the disk usage counter.
+   ``traffic_ctl plugin msg traffic_dump.limit N`` - changes the max disk usage.
 
 Replay Format
 =============

--- a/plugins/experimental/traffic_dump/README
+++ b/plugins/experimental/traffic_dump/README
@@ -11,6 +11,13 @@ Traffic Dump is a global plugin and is configured by arguments in plugin.config.
 --sample <N>
   The sampling ratio. By setting this number to N, Traffic Dump will capture every one out of N sessions. This ratio can also be changed via traffic_ctl without restarting ATS.
 
+--limit <N>
+  The max disk usage (approximate). By setting this number to N, Traffic Dump will stop capturing new sessions once the disk usage exceeds N bytes.
+
 Traffic_Ctl Command:
 traffic_ctl plugin msg traffic_dump.sample N
   Same as setting --sample=N in plugin.config.
+traffic_ctl plugin msg traffic_dump.reset
+  Reset disk usage.
+traffic_ctl plugin msg traffic_dump.limit N
+  Set max disk usage.


### PR DESCRIPTION
Added a config option and plugin messages to set a disk usage limit such that Traffic Dump will stop capturing sessions once the disk usage exceeds the limit.
Updated doc.
Minor changes to use std::string_view and ts::file.