### PR TITLE
Mark H2 connection inactive only if it is NOT shutting down

### DIFF
--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -272,6 +272,8 @@ Http2ClientSession::do_io_close(int alerrno)
     SCOPED_MUTEX_LOCK(lock, this->connection_state.mutex, this_ethread());
     this->connection_state.release_stream(nullptr);
   }
+
+  this->clear_session_active();
 }
 
 void


### PR DESCRIPTION
Prior this change, HTTP/2 connection is marked as inactive regardless it is shutting down or not.
I think we don't need to add it to keep-alive queue, if it is shutting down.

Fix #4504