### PR TITLE
Prohibit mutexes on SSL hook continuations.

### DIFF
--- a/doc/developer-guide/plugins/hooks-and-transactions/ssl-hooks.en.rst
+++ b/doc/developer-guide/plugins/hooks-and-transactions/ssl-hooks.en.rst
@@ -19,13 +19,19 @@
 
 .. _developer-plugins-ssl-hooks:
 
-TLS User Agent Hooks
+TLS Hooks
 ********************
 
 In addition to the HTTP oriented hooks, a plugin can add hooks (by calling :c:func:`TSHttpHookAdd`)
-to trigger code during the TLS handshake with the user agent.  This TLS handshake occurs well
+to trigger code during the TLS handshake with the user agent.  This TLS handshake from the user agent occurs well
 before the HTTP transaction is available, so a separate state machine is required to track the
 TLS hooks.
+
+Since some of the TLS hook points cannot be interrupted and resumed later, |TS| cannot automatically lock the
+mutexes of the continuations called from the hooks, as a failure to get the lock requires blocking (which is not 
+acceptable), making a lock failure unrecoverable. For simplicity and consistency, it is better to forbid mutexes on
+all continuations attached to a TLS hook. Therefore, when adding a continuation to a TLS hook, if the continuation
+has a mutex an assertion will occur.
 
 TLS Hooks
 ---------

--- a/proxy/InkAPIInternal.h
+++ b/proxy/InkAPIInternal.h
@@ -167,9 +167,9 @@ public:
   /// Remove all hooks.
   void clear();
   /// Add the hook @a cont to the front of the hooks for @a id.
-  void prepend(ID id, INKContInternal *cont);
+  virtual void prepend(ID id, INKContInternal *cont);
   /// Add the hook @a cont to the end of the hooks for @a id.
-  void append(ID id, INKContInternal *cont);
+  virtual void append(ID id, INKContInternal *cont);
   /// Get the list of hooks for @a id.
   APIHook *get(ID id) const;
   /// @return @c true if @a id is a valid id, @c false otherwise.
@@ -281,6 +281,25 @@ typedef enum {
 
 class SslAPIHooks : public FeatureAPIHooks<TSSslHookInternalID, TS_SSL_INTERNAL_LAST_HOOK>
 {
+public:
+  void
+  append(TSSslHookInternalID id, INKContInternal *cont) override
+  {
+    if (cont->mutex == nullptr) {
+      FeatureAPIHooks<TSSslHookInternalID, TS_SSL_INTERNAL_LAST_HOOK>::append(id, cont);
+    } else {
+      ink_release_assert(!"Cannot have continuation with mutex on SSL hook");
+    }
+  }
+  void
+  prepend(TSSslHookInternalID id, INKContInternal *cont) override
+  {
+    if (cont->mutex == nullptr) {
+      FeatureAPIHooks<TSSslHookInternalID, TS_SSL_INTERNAL_LAST_HOOK>::prepend(id, cont);
+    } else {
+      ink_release_assert(!"Cannot have continuation with mutex on SSL hook");
+    }
+  }
 };
 
 class LifecycleAPIHooks : public FeatureAPIHooks<TSLifecycleHookID, TS_LIFECYCLE_LAST_HOOK>

--- a/tests/tools/plugins/ssl_hook_test.cc
+++ b/tests/tools/plugins/ssl_hook_test.cc
@@ -258,7 +258,7 @@ setup_callbacks(TSHttpTxn txn, int preaccept_count, int sni_count, int cert_coun
   TSDebug(PN, "Setup callbacks pa=%d sni=%d cert=%d cert_imm=%d pa_delay=%d", preaccept_count, sni_count, cert_count,
           cert_count_immediate, preaccept_count_delay);
   for (i = 0; i < preaccept_count; i++) {
-    cb = TSContCreate(&CB_Pre_Accept, TSMutexCreate());
+    cb = TSContCreate(&CB_Pre_Accept, nullptr);
     TSContDataSet(cb, (void *)(intptr_t)i);
     if (txn) {
       TSHttpTxnHookAdd(txn, TS_VCONN_START_HOOK, cb);
@@ -267,7 +267,7 @@ setup_callbacks(TSHttpTxn txn, int preaccept_count, int sni_count, int cert_coun
     }
   }
   for (i = 0; i < preaccept_count_delay; i++) {
-    cb = TSContCreate(&CB_Pre_Accept_Delay, TSMutexCreate());
+    cb = TSContCreate(&CB_Pre_Accept_Delay, nullptr);
     TSContDataSet(cb, (void *)(intptr_t)i);
     if (txn) {
       TSHttpTxnHookAdd(txn, TS_VCONN_START_HOOK, cb);
@@ -276,7 +276,7 @@ setup_callbacks(TSHttpTxn txn, int preaccept_count, int sni_count, int cert_coun
     }
   }
   for (i = 0; i < sni_count; i++) {
-    cb = TSContCreate(&CB_SNI, TSMutexCreate());
+    cb = TSContCreate(&CB_SNI, nullptr);
     TSContDataSet(cb, (void *)(intptr_t)i);
     if (txn) {
       TSHttpTxnHookAdd(txn, TS_SSL_SERVERNAME_HOOK, cb);
@@ -285,7 +285,7 @@ setup_callbacks(TSHttpTxn txn, int preaccept_count, int sni_count, int cert_coun
     }
   }
   for (i = 0; i < cert_count; i++) {
-    cb = TSContCreate(&CB_Cert, TSMutexCreate());
+    cb = TSContCreate(&CB_Cert, nullptr);
     TSContDataSet(cb, (void *)(intptr_t)i);
     if (txn) {
       TSHttpTxnHookAdd(txn, TS_SSL_CERT_HOOK, cb);
@@ -294,7 +294,7 @@ setup_callbacks(TSHttpTxn txn, int preaccept_count, int sni_count, int cert_coun
     }
   }
   for (i = 0; i < cert_count_immediate; i++) {
-    cb = TSContCreate(&CB_Cert_Immediate, TSMutexCreate());
+    cb = TSContCreate(&CB_Cert_Immediate, nullptr);
     TSContDataSet(cb, (void *)(intptr_t)i);
     if (txn) {
       TSHttpTxnHookAdd(txn, TS_SSL_CERT_HOOK, cb);
@@ -304,7 +304,7 @@ setup_callbacks(TSHttpTxn txn, int preaccept_count, int sni_count, int cert_coun
   }
 
   for (i = 0; i < close_count; i++) {
-    cb = TSContCreate(&CB_close, TSMutexCreate());
+    cb = TSContCreate(&CB_close, nullptr);
     TSContDataSet(cb, (void *)(intptr_t)i);
     if (txn) {
       TSHttpTxnHookAdd(txn, TS_VCONN_CLOSE_HOOK, cb);
@@ -313,7 +313,7 @@ setup_callbacks(TSHttpTxn txn, int preaccept_count, int sni_count, int cert_coun
     }
   }
   for (i = 0; i < out_start_count; i++) {
-    cb = TSContCreate(&CB_out_start, TSMutexCreate());
+    cb = TSContCreate(&CB_out_start, nullptr);
     TSContDataSet(cb, (void *)(intptr_t)i);
     if (txn) {
       TSHttpTxnHookAdd(txn, TS_VCONN_OUTBOUND_START_HOOK, cb);
@@ -322,7 +322,7 @@ setup_callbacks(TSHttpTxn txn, int preaccept_count, int sni_count, int cert_coun
     }
   }
   for (i = 0; i < out_start_delay_count; i++) {
-    cb = TSContCreate(&CB_out_start_delay, TSMutexCreate());
+    cb = TSContCreate(&CB_out_start_delay, nullptr);
     TSContDataSet(cb, (void *)(intptr_t)i);
     if (txn) {
       TSHttpTxnHookAdd(txn, TS_VCONN_OUTBOUND_START_HOOK, cb);
@@ -331,7 +331,7 @@ setup_callbacks(TSHttpTxn txn, int preaccept_count, int sni_count, int cert_coun
     }
   }
   for (i = 0; i < out_close_count; i++) {
-    cb = TSContCreate(&CB_out_close, TSMutexCreate());
+    cb = TSContCreate(&CB_out_close, nullptr);
     TSContDataSet(cb, (void *)(intptr_t)i);
     if (txn) {
       TSHttpTxnHookAdd(txn, TS_VCONN_OUTBOUND_CLOSE_HOOK, cb);

--- a/tests/tools/plugins/ssl_sni_rename_test.cc
+++ b/tests/tools/plugins/ssl_sni_rename_test.cc
@@ -66,7 +66,7 @@ TSPluginInit(int argc, const char *argv[])
   if (TSPluginRegister(&info) != TS_SUCCESS) {
     TSError("[%s] Plugin registration failed", PN);
   }
-  TSCont cb = TSContCreate(&CB_server_rename, TSMutexCreate());
+  TSCont cb = TSContCreate(&CB_server_rename, nullptr);
   TSHttpHookAdd(TS_SSL_SERVERNAME_HOOK, cb);
 
   return;

--- a/tests/tools/plugins/ssl_verify_test.cc
+++ b/tests/tools/plugins/ssl_verify_test.cc
@@ -99,7 +99,7 @@ setup_callbacks(int count)
 
   TSDebug(PN, "Setup callbacks count=%d", count);
   for (i = 0; i < count; i++) {
-    cb = TSContCreate(&CB_server_verify, TSMutexCreate());
+    cb = TSContCreate(&CB_server_verify, nullptr);
     TSContDataSet(cb, (void *)(intptr_t)i);
     TSHttpHookAdd(TS_SSL_VERIFY_SERVER_HOOK, cb);
   }


### PR DESCRIPTION
@macisasandwich ran into this when working with port ready changes in autest.  The extra port probe tied up the test ssl plugin (for tls_hooks15) which exercised a TLS hook on a continuation with a mutex.  Since the invoke method could not grab the lock, the assertion went off.

I went back to look at how the TLS code should grab the continuation lock before calling invoke.  But there are many (most) cases where the TLS hook cannot be delayed by a reschedule in the case when the lock cannot be obtained.

In most cases for such global continuations, you would not want a lock on the continuation for performance reasons.  In the case where locking is needed, it would be better done by the plugin writer internal to the plugin.

This PR adds logic to assert in case the plugin writer attempts to attach a continuation with a mutex to a TLS hook.  It also updates the test plugins to not have mutexes for the TLS continuations.  