### PR TITLE
ats_scoped_str: c++17 cleanup.

### DIFF
--- a/include/tscore/ink_memory.h
+++ b/include/tscore/ink_memory.h
@@ -280,10 +280,18 @@ public:
   /// Construct with contained resource.
   explicit ats_scoped_resource(value_type rt) : _r(rt) {}
   /// Destructor.
-  ~ats_scoped_resource()
+  ~ats_scoped_resource() { this->clear(); }
+
+  /** Remove and clean up any existing resource in this object, and return to a default constructed state.
+   *
+   */
+  void
+  clear()
   {
-    if (Traits::isValid(_r))
+    if (Traits::isValid(_r)) {
       Traits::destroy(_r);
+    }
+    _r = Traits::initValue();
   }
 
   /// Automatic conversion to resource type.
@@ -326,8 +334,7 @@ public:
   self &
   operator=(value_type rt)
   {
-    if (Traits::isValid(_r))
-      Traits::destroy(_r);
+    this->clear();
     _r = rt;
     return *this;
   }
@@ -473,59 +480,73 @@ struct SCOPED_OBJECT_TRAITS {
 class ats_scoped_str : public ats_scoped_resource<detail::SCOPED_MALLOC_TRAITS<char>>
 {
 public:
-  typedef ats_scoped_resource<detail::SCOPED_MALLOC_TRAITS<char>> super; ///< Super type.
-  typedef ats_scoped_str self;                                           ///< Self reference type.
+  using super     = ats_scoped_resource<detail::SCOPED_MALLOC_TRAITS<char>>; ///< Super type.
+  using self_type = ats_scoped_str;                                          ///< Self reference type.
 
-  /// Default constructor (no string).
-  ats_scoped_str() {}
-  /// Construct and allocate @a n bytes for a string.
+  /** Default constructor.
+   * Constructs an empty container.
+   */
+  ats_scoped_str() = default;
+
+  /** Construct an empty buffer of @a n bytes.
+   *
+   * @param n Size of the contained buffer.
+   *
+   * The memory is left uninitialized, presumably ready for a @c memcpy.
+   */
   explicit ats_scoped_str(size_t n) : super(static_cast<char *>(ats_malloc(n))) {}
-  /// Put string @a s in this container for cleanup.
+
+  /** Construct with an existing buffer.
+   *
+   * @param s The string.
+   *
+   * This container takes ownership of the string memory. For this reason @a s must be independently
+   * allocated, not part of a larger memory allocation.
+   */
   explicit ats_scoped_str(char *s) : super(s) {}
-  // constructor with std::string
-  explicit ats_scoped_str(const std::string &s)
-  {
-    if (s.empty())
-      _r = nullptr;
-    else
-      _r = strdup(s.c_str());
-  }
-  // constructor with string_view
-  explicit ats_scoped_str(const std::string_view &s)
-  {
-    if (s.empty())
-      _r = nullptr;
-    else
-      _r = strdup(s.data());
-  }
-  /// Assign a string @a s to this container.
-  self &
-  operator=(char *s)
-  {
-    super::operator=(s);
-    return *this;
-  }
-  // std::string case
-  self &
-  operator=(const std::string &s)
-  {
-    if (s.empty())
-      _r = nullptr;
-    else
-      _r = strdup(s.c_str());
-    return *this;
-  }
-  // string_view case
-  self &
-  operator=(const std::string_view &s)
-  {
-    if (s.empty())
-      _r = nullptr;
-    else
-      _r = strdup(s.data());
-    return *this;
-  }
+
+  /** Construct from a @c string_view.
+   *
+   * @param s The string to copy.
+   *
+   * The string in @a s is duplicated into this container.
+   */
+  explicit ats_scoped_str(std::string_view s);
+
+  /** Put an existing buffer in this container.
+   *
+   * @param s The string buffer.
+   * @return @a this
+   *
+   * The container takes ownership of @a s. For this reason @a s must be independently allocated,
+   * not part of a larger memory allocation. Any currently contained resource is destroyed.
+   */
+  self_type &operator=(char *s);
+
+  /** Assign from a @c string_view
+   *
+   * @param s The source string.
+   * @return @a this
+   *
+   * The string data is duplicated into this object and guaranteed to be null terminated. Any currently
+   * contained resource is destroyed.
+   */
+  self_type &operator=(std::string_view s);
 };
+
+inline ats_scoped_str::ats_scoped_str(std::string_view s)
+{
+  if (!s.empty()) {
+    *this = s;
+  }
+}
+
+inline ats_scoped_str &
+ats_scoped_str::operator=(char *s)
+{
+  super::operator=(s);
+  return *this;
+}
 
 /** Specialization of @c ats_scoped_resource for pointers allocated with @c ats_malloc.
  */

--- a/src/tscore/ink_memory.cc
+++ b/src/tscore/ink_memory.cc
@@ -277,3 +277,15 @@ _xstrdup(const char *str, int length, const char * /* path ATS_UNUSED */)
   }
   return nullptr;
 }
+
+ats_scoped_str &
+ats_scoped_str::operator=(std::string_view s)
+{
+  this->clear();
+  if (!s.empty()) {
+    _r = static_cast<char *>(ats_malloc(s.size() + 1));
+    memcpy(_r, s.data(), s.size());
+    _r[s.size()] = '\0';
+  }
+  return *this;
+}


### PR DESCRIPTION
Ran in to some issues working on the MIME view project. This does a number of things.

*  Add an explicit `clear` method to `ats_scoped_resource` so the resource can be cleared by subclasses, and also reduce cut and paste internally.
*  Improve code comments.
*  Fix some brace style problems.
*  Remove the `std::string` constructor / assignment from `ats_scoped_str` - these are handled by the `string_view` overloads.
*  Force null termination for `string_view` copies, since the content is already being duplicated.
*  Remove assumption that `string_view` is null terminated (via call to `strdup`).
