### PR TITLE
Fix to allow runroot to override the configuration directory

### DIFF
--- a/lib/records/RecCore.cc
+++ b/lib/records/RecCore.cc
@@ -21,6 +21,7 @@
   limitations under the License.
  */
 
+#include "tscore/runroot.h"
 #include "tscore/ink_platform.h"
 #include "tscore/ink_memory.h"
 #include "tscore/ink_string.h"
@@ -1131,7 +1132,7 @@ RecConfigReadConfigDir()
 
   if (const char *env = getenv("PROXY_CONFIG_CONFIG_DIR")) {
     ink_strlcpy(buf, env, sizeof(buf));
-  } else {
+  } else if (get_runroot().empty()) {
     RecGetRecordString("proxy.config.config_dir", buf, sizeof(buf));
   }
 


### PR DESCRIPTION
This issue was fixed with 9a6b5d617939744067e57db53549448a42339c6a.  However, that change also removed the configuration option proxy.config.config_dir, which is an incompatible change and can't be cherry picked to 8.x.