### PR TITLE
Corrects description for proxy.config.http.origin_max_connections

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -1365,7 +1365,7 @@ Origin Server Connect Attempts
    :reloadable:
    :overridable:
 
-   Limits the number of socket connections per origin server to the value specified. To enable, set to one (``1``).
+   Limits the number of socket connections per origin server to the value specified. To disable, set to zero (``0``).
 
 .. ts:cv:: CONFIG proxy.config.http.origin_max_connections_queue INT -1
    :reloadable:


### PR DESCRIPTION
Backport Rationale: The fixes the description for the same functionality in older ATS.