### PR TITLE
MIMEScanner: Make MIMEScanner a class, not a POD with free functions.

### DIFF
--- a/proxy/hdrs/HdrTest.h
+++ b/proxy/hdrs/HdrTest.h
@@ -51,7 +51,6 @@ private:
   int test_parse_date();
   int test_format_date();
   int test_url();
-  int test_http_parser_eos_boundary_cases();
   int test_arena();
   int test_regex();
   int test_accept_language_match();

--- a/proxy/hdrs/Makefile.am
+++ b/proxy/hdrs/Makefile.am
@@ -82,6 +82,7 @@ test_proxy_hdrs_CPPFLAGS = $(AM_CPPFLAGS)\
 
 test_proxy_hdrs_SOURCES = \
 	unit_tests/unit_test_main.cc \
+	unit_tests/test_Hdrs.cc \
 	unit_tests/test_HdrUtils.cc
 
 test_proxy_hdrs_LDADD = \

--- a/proxy/hdrs/unit_tests/test_Hdrs.cc
+++ b/proxy/hdrs/unit_tests/test_Hdrs.cc
@@ -1,0 +1,86 @@
+/** @file
+
+   Catch-based unit tests for various header logic.
+   This replaces the old regression tests in HdrTest.cc.
+
+   @section license License
+
+   Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
+   See the NOTICE file distributed with this work for additional information regarding copyright
+   ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance with the License.  You may obtain a
+   copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software distributed under the License
+   is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+   or implied. See the License for the specific language governing permissions and limitations under
+   the License.
+ */
+
+#include <string>
+#include <cstring>
+#include <cctype>
+#include <bitset>
+#include <initializer_list>
+#include <array>
+#include <new>
+
+#include "catch.hpp"
+
+#include "HTTP.h"
+
+// replaces test_http_parser_eos_boundary_cases
+TEST_CASE("HdrTest", "[proxy][hdrtest]")
+{
+  struct Test {
+    ts::TextView msg;
+    int expected_result;
+    int expected_bytes_consumed;
+  };
+  static const std::array<Test, 20> tests = {{
+    {"GET /index.html HTTP/1.0\r\n", PARSE_RESULT_DONE, 26},
+    {"GET /index.html HTTP/1.0\r\n\r\n***BODY****", PARSE_RESULT_DONE, 28},
+    {"GET /index.html HTTP/1.0\r\nUser-Agent: foobar\r\n\r\n***BODY****", PARSE_RESULT_DONE, 48},
+    {"GET", PARSE_RESULT_ERROR, 3},
+    {"GET /index.html", PARSE_RESULT_ERROR, 15},
+    {"GET /index.html\r\n", PARSE_RESULT_ERROR, 17},
+    {"GET /index.html HTTP/1.0", PARSE_RESULT_ERROR, 24},
+    {"GET /index.html HTTP/1.0\r", PARSE_RESULT_ERROR, 25},
+    {"GET /index.html HTTP/1.0\n", PARSE_RESULT_DONE, 25},
+    {"GET /index.html HTTP/1.0\n\n", PARSE_RESULT_DONE, 26},
+    {"GET /index.html HTTP/1.0\r\n\r\n", PARSE_RESULT_DONE, 28},
+    {"GET /index.html HTTP/1.0\r\nUser-Agent: foobar", PARSE_RESULT_ERROR, 44},
+    {"GET /index.html HTTP/1.0\r\nUser-Agent: foobar\n", PARSE_RESULT_DONE, 45},
+    {"GET /index.html HTTP/1.0\r\nUser-Agent: foobar\r\n", PARSE_RESULT_DONE, 46},
+    {"GET /index.html HTTP/1.0\r\nUser-Agent: foobar\r\n\r\n", PARSE_RESULT_DONE, 48},
+    {"GET /index.html HTTP/1.0\nUser-Agent: foobar\n", PARSE_RESULT_DONE, 44},
+    {"GET /index.html HTTP/1.0\nUser-Agent: foobar\nBoo: foo\n", PARSE_RESULT_DONE, 53},
+    {"GET /index.html HTTP/1.0\r\nUser-Agent: foobar\r\n", PARSE_RESULT_DONE, 46},
+    {"GET /index.html HTTP/1.0\r\n", PARSE_RESULT_DONE, 26},
+    {"", PARSE_RESULT_ERROR, 0},
+  }};
+
+  HTTPParser parser;
+
+  http_parser_init(&parser);
+
+  for (auto const &test : tests) {
+    HTTPHdr req_hdr;
+    HdrHeap *heap = new_HdrHeap(HDR_HEAP_DEFAULT_SIZE + 64); // extra to prevent proxy allocation.
+
+    req_hdr.create(HTTP_TYPE_REQUEST, heap);
+
+    http_parser_clear(&parser);
+
+    auto start          = test.msg.data();
+    auto ret            = req_hdr.parse_req(&parser, &start, test.msg.data_end(), true);
+    auto bytes_consumed = start - test.msg.data();
+
+    REQUIRE(bytes_consumed == test.expected_bytes_consumed);
+    REQUIRE(ret == test.expected_result);
+
+    req_hdr.destroy();
+  }
+}

--- a/proxy/hdrs/unit_tests/unit_test_main.cc
+++ b/proxy/hdrs/unit_tests/unit_test_main.cc
@@ -21,5 +21,24 @@
   limitations under the License.
  */
 
-#define CATCH_CONFIG_MAIN
+#include "HTTP.h"
+
+#define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
+
+extern int cmd_disable_pfreelist;
+
+int
+main(int argc, char *argv[])
+{
+  // No thread setup, forbid use of thread local allocators.
+  cmd_disable_pfreelist = true;
+  // Get all of the HTTP WKS items populated.
+  http_init();
+
+  int result = Catch::Session().run(argc, argv);
+
+  // global clean-up...
+
+  return result;
+}


### PR DESCRIPTION
This PR does several things, which I wanted to do separately but were just too intertwined.

*  Make `MIMEScanner` a class, instead of something with related free functions.
*  Use views in the scanner, as part of the overall view refresh of the MIME logic.
*  Determine how to run test code that is now in the regression testing in the Catch framework.

I hadn't planned on moving the test code quite yet, but it was quite handy to have while debugging.