### PR TITLE
Split current active client connections stats into HTTP/1.1 and HTTP/2

### DIFF
--- a/doc/admin-guide/monitoring/statistics/core/http-connection.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/http-connection.en.rst
@@ -45,6 +45,9 @@ HTTP Connection
 .. ts:stat:: global proxy.process.http.current_active_client_connections integer
    :type: gauge
 
+   Represents the current number of HTTP/1.0 and HTTP/1.1 connections
+   from client to the |TS|.
+
 .. ts:stat:: global proxy.process.http.current_cache_connections integer
    :type: gauge
    :ungathered:
@@ -132,3 +135,8 @@ HTTP Connection
    :type: counter
 
 This tracks the number of origin connections denied due to being over the :ts:cv:`proxy.config.http.origin_max_connections` limit.
+
+.. ts:stat:: global proxy.process.http2.current_active_client_connections integer
+   :type: gauge
+
+   Represents the current number of HTTP/2 connections from client to the |TS|.

--- a/proxy/ProxyClientSession.cc
+++ b/proxy/ProxyClientSession.cc
@@ -37,7 +37,7 @@ ProxyClientSession::set_session_active()
 {
   if (!m_active) {
     m_active = true;
-    HTTP_INCREMENT_DYN_STAT(http_current_active_client_connections_stat);
+    this->increment_current_active_client_connections_stat();
   }
 }
 
@@ -46,7 +46,7 @@ ProxyClientSession::clear_session_active()
 {
   if (m_active) {
     m_active = false;
-    HTTP_DECREMENT_DYN_STAT(http_current_active_client_connections_stat);
+    this->decrement_current_active_client_connections_stat();
   }
 }
 

--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -269,6 +269,8 @@ public:
 
   void set_session_active();
   void clear_session_active();
+  virtual void increment_current_active_client_connections_stat() = 0;
+  virtual void decrement_current_active_client_connections_stat() = 0;
 
   static int64_t next_connection_id();
 

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -542,3 +542,15 @@ Http1ClientSession::attach_server_session(HttpServerSession *ssession, bool tran
     slave_ka_vio = nullptr;
   }
 }
+
+void
+Http1ClientSession::increment_current_active_client_connections_stat()
+{
+  HTTP_INCREMENT_DYN_STAT(http_current_active_client_connections_stat);
+}
+
+void
+Http1ClientSession::decrement_current_active_client_connections_stat()
+{
+  HTTP_DECREMENT_DYN_STAT(http_current_active_client_connections_stat);
+}

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -176,6 +176,9 @@ public:
     return f_transparent_passthrough;
   }
 
+  void increment_current_active_client_connections_stat() override;
+  void decrement_current_active_client_connections_stat() override;
+
 private:
   Http1ClientSession(Http1ClientSession &);
 

--- a/proxy/http2/HTTP2.cc
+++ b/proxy/http2/HTTP2.cc
@@ -50,18 +50,19 @@ static const int HTTP2_MAX_TABLE_SIZE_LIMIT = 64 * 1024;
 RecRawStatBlock *http2_rsb;
 static const char *const HTTP2_STAT_CURRENT_CLIENT_SESSION_NAME    = "proxy.process.http2.current_client_sessions"; // DEPRECATED
 static const char *const HTTP2_STAT_CURRENT_CLIENT_CONNECTION_NAME = "proxy.process.http2.current_client_connections";
-static const char *const HTTP2_STAT_CURRENT_CLIENT_STREAM_NAME     = "proxy.process.http2.current_client_streams";
-static const char *const HTTP2_STAT_TOTAL_CLIENT_STREAM_NAME       = "proxy.process.http2.total_client_streams";
-static const char *const HTTP2_STAT_TOTAL_TRANSACTIONS_TIME_NAME   = "proxy.process.http2.total_transactions_time";
-static const char *const HTTP2_STAT_TOTAL_CLIENT_CONNECTION_NAME   = "proxy.process.http2.total_client_connections";
-static const char *const HTTP2_STAT_CONNECTION_ERRORS_NAME         = "proxy.process.http2.connection_errors";
-static const char *const HTTP2_STAT_STREAM_ERRORS_NAME             = "proxy.process.http2.stream_errors";
-static const char *const HTTP2_STAT_SESSION_DIE_DEFAULT_NAME       = "proxy.process.http2.session_die_default";
-static const char *const HTTP2_STAT_SESSION_DIE_OTHER_NAME         = "proxy.process.http2.session_die_other";
-static const char *const HTTP2_STAT_SESSION_DIE_ACTIVE_NAME        = "proxy.process.http2.session_die_active";
-static const char *const HTTP2_STAT_SESSION_DIE_INACTIVE_NAME      = "proxy.process.http2.session_die_inactive";
-static const char *const HTTP2_STAT_SESSION_DIE_EOS_NAME           = "proxy.process.http2.session_die_eos";
-static const char *const HTTP2_STAT_SESSION_DIE_ERROR_NAME         = "proxy.process.http2.session_die_error";
+static const char *const HTTP2_STAT_CURRENT_ACTIVE_CLIENT_CONNECTION_NAME = "proxy.process.http2.current_active_client_connections";
+static const char *const HTTP2_STAT_CURRENT_CLIENT_STREAM_NAME            = "proxy.process.http2.current_client_streams";
+static const char *const HTTP2_STAT_TOTAL_CLIENT_STREAM_NAME              = "proxy.process.http2.total_client_streams";
+static const char *const HTTP2_STAT_TOTAL_TRANSACTIONS_TIME_NAME          = "proxy.process.http2.total_transactions_time";
+static const char *const HTTP2_STAT_TOTAL_CLIENT_CONNECTION_NAME          = "proxy.process.http2.total_client_connections";
+static const char *const HTTP2_STAT_CONNECTION_ERRORS_NAME                = "proxy.process.http2.connection_errors";
+static const char *const HTTP2_STAT_STREAM_ERRORS_NAME                    = "proxy.process.http2.stream_errors";
+static const char *const HTTP2_STAT_SESSION_DIE_DEFAULT_NAME              = "proxy.process.http2.session_die_default";
+static const char *const HTTP2_STAT_SESSION_DIE_OTHER_NAME                = "proxy.process.http2.session_die_other";
+static const char *const HTTP2_STAT_SESSION_DIE_ACTIVE_NAME               = "proxy.process.http2.session_die_active";
+static const char *const HTTP2_STAT_SESSION_DIE_INACTIVE_NAME             = "proxy.process.http2.session_die_inactive";
+static const char *const HTTP2_STAT_SESSION_DIE_EOS_NAME                  = "proxy.process.http2.session_die_eos";
+static const char *const HTTP2_STAT_SESSION_DIE_ERROR_NAME                = "proxy.process.http2.session_die_error";
 
 union byte_pointer {
   byte_pointer(void *p) : ptr(p) {}
@@ -770,6 +771,9 @@ Http2::init()
   RecRegisterRawStat(http2_rsb, RECT_PROCESS, HTTP2_STAT_CURRENT_CLIENT_CONNECTION_NAME, RECD_INT, RECP_NON_PERSISTENT,
                      static_cast<int>(HTTP2_STAT_CURRENT_CLIENT_SESSION_COUNT), RecRawStatSyncSum);
   HTTP2_CLEAR_DYN_STAT(HTTP2_STAT_CURRENT_CLIENT_SESSION_COUNT);
+  RecRegisterRawStat(http2_rsb, RECT_PROCESS, HTTP2_STAT_CURRENT_ACTIVE_CLIENT_CONNECTION_NAME, RECD_INT, RECP_NON_PERSISTENT,
+                     static_cast<int>(HTTP2_STAT_CURRENT_ACTIVE_CLIENT_CONNECTION_COUNT), RecRawStatSyncSum);
+  HTTP2_CLEAR_DYN_STAT(HTTP2_STAT_CURRENT_ACTIVE_CLIENT_CONNECTION_COUNT);
   RecRegisterRawStat(http2_rsb, RECT_PROCESS, HTTP2_STAT_CURRENT_CLIENT_STREAM_NAME, RECD_INT, RECP_NON_PERSISTENT,
                      static_cast<int>(HTTP2_STAT_CURRENT_CLIENT_STREAM_COUNT), RecRawStatSyncSum);
   HTTP2_CLEAR_DYN_STAT(HTTP2_STAT_CURRENT_CLIENT_STREAM_COUNT);

--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -69,9 +69,9 @@ const uint8_t HTTP2_PRIORITY_DEFAULT_WEIGHT             = 15;
 
 // Statistics
 enum {
-  HTTP2_STAT_CURRENT_CLIENT_SESSION_COUNT, // Current # of active HTTP2
-                                           // sessions.
-  HTTP2_STAT_CURRENT_CLIENT_STREAM_COUNT,  // Current # of active HTTP2 streams.
+  HTTP2_STAT_CURRENT_CLIENT_SESSION_COUNT,           // Current # of HTTP2 connections
+  HTTP2_STAT_CURRENT_ACTIVE_CLIENT_CONNECTION_COUNT, // Current # of active HTTP2 connections
+  HTTP2_STAT_CURRENT_CLIENT_STREAM_COUNT,            // Current # of active HTTP2 streams
   HTTP2_STAT_TOTAL_CLIENT_STREAM_COUNT,
   HTTP2_STAT_TOTAL_TRANSACTIONS_TIME,       // Total stream time and streams
   HTTP2_STAT_TOTAL_CLIENT_CONNECTION_COUNT, // Total connections running http2

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -539,3 +539,15 @@ Http2ClientSession::state_process_frame_read(int event, VIO *vio, bool inside_fr
   }
   return 0;
 }
+
+void
+Http2ClientSession::increment_current_active_client_connections_stat()
+{
+  HTTP2_INCREMENT_THREAD_DYN_STAT(HTTP2_STAT_CURRENT_ACTIVE_CLIENT_CONNECTION_COUNT, this_ethread());
+}
+
+void
+Http2ClientSession::decrement_current_active_client_connections_stat()
+{
+  HTTP2_DECREMENT_THREAD_DYN_STAT(HTTP2_STAT_CURRENT_ACTIVE_CLIENT_CONNECTION_COUNT, this_ethread());
+}

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -285,6 +285,9 @@ public:
     return retval;
   }
 
+  void increment_current_active_client_connections_stat() override;
+  void decrement_current_active_client_connections_stat() override;
+
   void set_half_close_local_flag(bool flag);
   bool
   get_half_close_local_flag() const


### PR DESCRIPTION
`proxy.process.http.current_active_client_connections` was stats of active
client connections regardless protocols.
It’s useful that each protocol has its own metrics.

// Before
- `proxy.process.http.current_active_client_connections` for HTTP/1.1 & HTTP/2

// After
- `proxy.process.http.current_active_client_connections` for HTTP/1.1
- `proxy.process.http2.current_active_client_connections` for HTTP/2

(cherry picked from commit 4efed05ea8647328444c6c7780f88bf5f9f72575)

Conflicts:
	doc/admin-guide/monitoring/statistics/core/http-connection.en.rst

----

Backport #4388