### PR TITLE
Remove QUICFrame allocators

### DIFF
--- a/iocore/net/P_QUICNetVConnection.h
+++ b/iocore/net/P_QUICNetVConnection.h
@@ -224,7 +224,8 @@ public:
 
   // QUICFrameGenerator
   bool will_generate_frame(QUICEncryptionLevel level) override;
-  QUICFrameUPtr generate_frame(QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size) override;
+  QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit,
+                            uint16_t maximum_frame_size) override;
 
   int in_closed_queue = 0;
 
@@ -309,7 +310,7 @@ private:
   Event *_ack_manager_periodic = nullptr;
 
   uint64_t _maximum_stream_frame_data_size();
-  void _store_frame(ats_unique_buf &buf, size_t &offset, uint64_t &max_frame_size, QUICFrameUPtr &frame,
+  void _store_frame(ats_unique_buf &buf, size_t &offset, uint64_t &max_frame_size, QUICFrame &frame,
                     std::vector<QUICFrameInfo> &frames);
   QUICPacketUPtr _packetize_frames(QUICEncryptionLevel level, uint64_t max_packet_size);
   void _packetize_closing_frame();

--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -1462,7 +1462,7 @@ QUICNetVConnection::_packetize_closing_frame()
   QUICFrame *frame = nullptr;
 
   // CONNECTION_CLOSE
-  uint8_t frame_buf[1024];
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   frame = QUICFrameFactory::create_connection_close_frame(frame_buf, *this->_connection_error);
 
   uint32_t max_size  = this->maximum_quic_packet_size();

--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -1369,7 +1369,7 @@ QUICNetVConnection::_packetize_frames(QUICEncryptionLevel level, uint64_t max_pa
   }
 
   bool ack_only = true;
-  uint8_t frame_instance_buffer[1024]; // This is for a frame instance but not serialized frame data
+  uint8_t frame_instance_buffer[QUICFrame::MAX_INSTANCE_SIZE]; // This is for a frame instance but not serialized frame data
   QUICFrame *frame = nullptr;
   for (auto g : this->_frame_generators) {
     while (g->will_generate_frame(level)) {

--- a/iocore/net/quic/QUICAckFrameCreator.h
+++ b/iocore/net/quic/QUICAckFrameCreator.h
@@ -54,7 +54,7 @@ public:
     void set_max_ack_delay(uint16_t delay);
 
     // Checks maximum_frame_size and return _ack_frame
-    std::unique_ptr<QUICAckFrame, QUICFrameDeleterFunc> generate_ack_frame(uint16_t maximum_frame_size);
+    QUICAckFrame *generate_ack_frame(uint8_t *buf, uint16_t maximum_frame_size);
 
     // refresh state when frame lost
     void refresh_state();
@@ -64,7 +64,7 @@ public:
 
   private:
     uint64_t _calculate_delay();
-    std::unique_ptr<QUICAckFrame, QUICFrameDeleterFunc> _create_ack_frame();
+    QUICAckFrame *_create_ack_frame(uint8_t *buf);
 
     std::list<RecvdPacket> _packet_numbers;
     bool _available                         = false; // packet_number has data to sent
@@ -106,7 +106,8 @@ public:
   /*
    * Calls create directly.
    */
-  QUICFrameUPtr generate_frame(QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size) override;
+  QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit,
+                            uint16_t maximum_frame_size) override;
 
   QUICFrameId issue_frame_id();
   uint8_t ack_delay_exponent() const;
@@ -119,7 +120,7 @@ private:
    * Returns QUICAckFrame only if ACK frame is able to be sent.
    * Caller must send the ACK frame to the peer if it was returned.
    */
-  std::unique_ptr<QUICAckFrame, QUICFrameDeleterFunc> _create_ack_frame(QUICEncryptionLevel level);
+  QUICAckFrame *_create_ack_frame(uint8_t *buf, QUICEncryptionLevel level);
   uint64_t _calculate_delay(QUICEncryptionLevel level);
   std::vector<QUICEncryptionLevel>
   _encryption_level_filter() override

--- a/iocore/net/quic/QUICAltConnectionManager.h
+++ b/iocore/net/quic/QUICAltConnectionManager.h
@@ -83,7 +83,8 @@ public:
 
   // QUICFrameGenerator
   bool will_generate_frame(QUICEncryptionLevel level) override;
-  QUICFrameUPtr generate_frame(QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size) override;
+  QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit,
+                            uint16_t maximum_frame_size) override;
 
 private:
   struct AltConnectionInfo {

--- a/iocore/net/quic/QUICFlowController.h
+++ b/iocore/net/quic/QUICFlowController.h
@@ -61,15 +61,16 @@ public:
 
   // QUICFrameGenerator
   bool will_generate_frame(QUICEncryptionLevel level) override;
-  QUICFrameUPtr generate_frame(QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size) override;
+  QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit,
+                            uint16_t maximum_frame_size) override;
 
 protected:
   QUICFlowController(uint64_t initial_limit) : _limit(initial_limit) {}
-  virtual QUICFrameUPtr _create_frame() = 0;
+  virtual QUICFrame *_create_frame(uint8_t *buf) = 0;
 
-  QUICOffset _offset   = 0; //< Largest sent/received offset
-  QUICOffset _limit    = 0; //< Maximum amount of data to send/receive
-  QUICFrameUPtr _frame = QUICFrameFactory::create_null_frame();
+  QUICOffset _offset        = 0; //< Largest sent/received offset
+  QUICOffset _limit         = 0; //< Maximum amount of data to send/receive
+  bool _should_create_frame = false;
 };
 
 class QUICRemoteFlowController : public QUICFlowController
@@ -112,7 +113,7 @@ class QUICRemoteConnectionFlowController : public QUICRemoteFlowController
 {
 public:
   QUICRemoteConnectionFlowController(uint64_t initial_limit) : QUICRemoteFlowController(initial_limit) {}
-  QUICFrameUPtr _create_frame() override;
+  QUICFrame *_create_frame(uint8_t *buf) override;
 };
 
 class QUICLocalConnectionFlowController : public QUICLocalFlowController
@@ -122,7 +123,7 @@ public:
     : QUICLocalFlowController(rtt_provider, initial_limit)
   {
   }
-  QUICFrameUPtr _create_frame() override;
+  QUICFrame *_create_frame(uint8_t *buf) override;
 };
 
 class QUICRemoteStreamFlowController : public QUICRemoteFlowController
@@ -132,7 +133,7 @@ public:
     : QUICRemoteFlowController(initial_limit), _stream_id(stream_id)
   {
   }
-  QUICFrameUPtr _create_frame() override;
+  QUICFrame *_create_frame(uint8_t *buf) override;
 
 private:
   QUICStreamId _stream_id = 0;
@@ -145,7 +146,7 @@ public:
     : QUICLocalFlowController(rtt_provider, initial_limit), _stream_id(stream_id)
   {
   }
-  QUICFrameUPtr _create_frame() override;
+  QUICFrame *_create_frame(uint8_t *buf) override;
 
 private:
   QUICStreamId _stream_id = 0;

--- a/iocore/net/quic/QUICFrame.cc
+++ b/iocore/net/quic/QUICFrame.cc
@@ -2516,10 +2516,11 @@ QUICFrameFactory::fast_create(const uint8_t *buf, size_t len)
     return this->_unknown_frame;
   }
 
-  QUICFrame *frame = this->_reusable_frames[static_cast<ptrdiff_t>(QUICFrame::type(buf))];
+  ptrdiff_t type_index = static_cast<ptrdiff_t>(QUICFrame::type(buf));
+  QUICFrame *frame     = this->_reusable_frames[type_index];
 
   if (frame == nullptr) {
-    frame = QUICFrameFactory::create(static_cast<uint8_t *>(malloc(1024)), buf, len);
+    frame = QUICFrameFactory::create(this->_buf_for_fast_create + (type_index * QUICFrame::MAX_INSTANCE_SIZE), buf, len);
     if (frame != nullptr) {
       this->_reusable_frames[static_cast<ptrdiff_t>(QUICFrame::type(buf))] = frame;
     }

--- a/iocore/net/quic/QUICFrame.h
+++ b/iocore/net/quic/QUICFrame.h
@@ -53,6 +53,8 @@ using QUICFrameId = uint64_t;
 class QUICFrame
 {
 public:
+  constexpr static int MAX_INSTANCE_SIZE = 256;
+
   virtual ~QUICFrame() {}
   static QUICFrameType type(const uint8_t *buf);
 
@@ -849,6 +851,7 @@ public:
 private:
   // FIXME Actual number of frame types is several but some of the values are not sequential.
   QUICFrame *_reusable_frames[256] = {nullptr};
+  uint8_t _buf_for_fast_create[256 * QUICFrame::MAX_INSTANCE_SIZE];
   QUICUnknownFrame _unknown_frame;
 };
 

--- a/iocore/net/quic/QUICFrame.h
+++ b/iocore/net/quic/QUICFrame.h
@@ -58,7 +58,6 @@ public:
 
   QUICFrameId id() const;
 
-  virtual QUICFrameUPtr clone() const = 0;
   virtual QUICFrameType type() const;
   virtual size_t size() const = 0;
   virtual bool is_probing_frame() const;
@@ -91,8 +90,8 @@ public:
   QUICStreamFrame(Ptr<IOBufferBlock> &block, QUICStreamId streamid, QUICOffset offset, bool last = false,
                   bool has_offset_field = true, bool has_length_field = true, QUICFrameId id = 0,
                   QUICFrameGenerator *owner = nullptr);
+  QUICStreamFrame(const QUICStreamFrame &o);
 
-  QUICFrameUPtr clone() const override;
   virtual QUICFrameType type() const override;
   virtual size_t size() const override;
   virtual bool is_flow_controlled() const override;
@@ -132,8 +131,8 @@ public:
   QUICCryptoFrame(QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr) : QUICFrame(id, owner) {}
   QUICCryptoFrame(const uint8_t *buf, size_t len);
   QUICCryptoFrame(Ptr<IOBufferBlock> &block, QUICOffset offset, QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr);
+  QUICCryptoFrame(const QUICCryptoFrame &o);
 
-  QUICFrameUPtr clone() const override;
   virtual QUICFrameType type() const override;
   virtual size_t size() const override;
   virtual size_t store(uint8_t *buf, size_t *len, size_t limit) const override;
@@ -257,7 +256,6 @@ public:
                QUICFrameGenerator *owner = nullptr);
 
   virtual ~QUICAckFrame();
-  QUICFrameUPtr clone() const override;
   virtual QUICFrameType type() const override;
   virtual size_t size() const override;
   virtual size_t store(uint8_t *buf, size_t *len, size_t limit) const override;
@@ -293,7 +291,6 @@ public:
   QUICRstStreamFrame(QUICStreamId stream_id, QUICAppErrorCode error_code, QUICOffset final_offset, QUICFrameId id = 0,
                      QUICFrameGenerator *owner = nullptr);
 
-  QUICFrameUPtr clone() const override;
   virtual QUICFrameType type() const override;
   virtual size_t size() const override;
   virtual size_t store(uint8_t *buf, size_t *len, size_t limit) const override;
@@ -320,7 +317,6 @@ class QUICPingFrame : public QUICFrame
 public:
   QUICPingFrame(QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr) : QUICFrame(id, owner) {}
   QUICPingFrame(const uint8_t *buf, size_t len);
-  QUICFrameUPtr clone() const override;
   virtual QUICFrameType type() const override;
   virtual size_t size() const override;
   virtual size_t store(uint8_t *buf, size_t *len, size_t limit) const override;
@@ -338,7 +334,6 @@ class QUICPaddingFrame : public QUICFrame
 public:
   QUICPaddingFrame() {}
   QUICPaddingFrame(const uint8_t *buf, size_t len);
-  QUICFrameUPtr clone() const override;
   virtual QUICFrameType type() const override;
   virtual size_t size() const override;
   virtual bool is_probing_frame() const override;
@@ -361,7 +356,6 @@ public:
   // Constructor for application protocol error codes
   QUICConnectionCloseFrame(uint16_t error_code, uint64_t reason_phrase_length, const char *reason_phrase, QUICFrameId id = 0,
                            QUICFrameGenerator *owner = nullptr);
-  QUICFrameUPtr clone() const override;
   virtual QUICFrameType type() const override;
   virtual size_t size() const override;
   virtual size_t store(uint8_t *buf, size_t *len, size_t limit) const override;
@@ -393,7 +387,6 @@ public:
   QUICMaxDataFrame(QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr) : QUICFrame(id, owner) {}
   QUICMaxDataFrame(const uint8_t *buf, size_t len);
   QUICMaxDataFrame(uint64_t maximum_data, QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr);
-  QUICFrameUPtr clone() const override;
   virtual QUICFrameType type() const override;
   virtual size_t size() const override;
   virtual size_t store(uint8_t *buf, size_t *len, size_t limit) const override;
@@ -419,7 +412,6 @@ public:
   QUICMaxStreamDataFrame(const uint8_t *buf, size_t len);
   QUICMaxStreamDataFrame(QUICStreamId stream_id, uint64_t maximum_stream_data, QUICFrameId id = 0,
                          QUICFrameGenerator *owner = nullptr);
-  QUICFrameUPtr clone() const override;
   virtual QUICFrameType type() const override;
   virtual size_t size() const override;
   virtual void parse(const uint8_t *buf, size_t len) override;
@@ -446,7 +438,6 @@ public:
   QUICMaxStreamsFrame(QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr) : QUICFrame(id, owner) {}
   QUICMaxStreamsFrame(const uint8_t *buf, size_t len);
   QUICMaxStreamsFrame(QUICStreamId maximum_streams, QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr);
-  QUICFrameUPtr clone() const override;
   virtual QUICFrameType type() const override;
   virtual size_t size() const override;
   virtual size_t store(uint8_t *buf, size_t *len, size_t limit) const override;
@@ -470,7 +461,6 @@ public:
   QUICDataBlockedFrame(QUICOffset offset, QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr)
     : QUICFrame(id, owner), _offset(offset){};
 
-  QUICFrameUPtr clone() const override;
   virtual QUICFrameType type() const override;
   virtual size_t size() const override;
   virtual void parse(const uint8_t *buf, size_t len) override;
@@ -497,7 +487,6 @@ public:
   QUICStreamDataBlockedFrame(QUICStreamId s, QUICOffset o, QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr)
     : QUICFrame(id, owner), _stream_id(s), _offset(o){};
 
-  QUICFrameUPtr clone() const override;
   virtual QUICFrameType type() const override;
   virtual size_t size() const override;
   virtual size_t store(uint8_t *buf, size_t *len, size_t limit) const override;
@@ -526,7 +515,6 @@ public:
     : QUICFrame(id, owner), _stream_id(s)
   {
   }
-  QUICFrameUPtr clone() const override;
   virtual QUICFrameType type() const override;
   virtual size_t size() const override;
   virtual size_t store(uint8_t *buf, size_t *len, size_t limit) const override;
@@ -553,7 +541,6 @@ public:
                            QUICFrameGenerator *owner = nullptr)
     : QUICFrame(id, owner), _sequence(seq), _connection_id(cid), _stateless_reset_token(token){};
 
-  QUICFrameUPtr clone() const override;
   virtual QUICFrameType type() const override;
   virtual size_t size() const override;
   virtual size_t store(uint8_t *buf, size_t *len, size_t limit) const override;
@@ -584,7 +571,6 @@ public:
   QUICStopSendingFrame(QUICStreamId stream_id, QUICAppErrorCode error_code, QUICFrameId id = 0,
                        QUICFrameGenerator *owner = nullptr);
 
-  QUICFrameUPtr clone() const override;
   virtual QUICFrameType type() const override;
   virtual size_t size() const override;
   virtual void parse(const uint8_t *buf, size_t len) override;
@@ -614,7 +600,6 @@ public:
     : QUICFrame(id, owner), _data(std::move(data))
   {
   }
-  QUICFrameUPtr clone() const override;
   virtual QUICFrameType type() const override;
   virtual size_t size() const override;
   virtual bool is_probing_frame() const override;
@@ -643,7 +628,6 @@ public:
     : QUICFrame(id, owner), _data(std::move(data))
   {
   }
-  QUICFrameUPtr clone() const override;
   virtual QUICFrameType type() const override;
   virtual size_t size() const override;
   virtual bool is_probing_frame() const override;
@@ -671,7 +655,6 @@ public:
     : QUICFrame(id, owner), _token_length(token_length), _token(std::move(token))
   {
   }
-  QUICFrameUPtr clone() const override;
   virtual QUICFrameType type() const override;
   virtual size_t size() const override;
   virtual size_t store(uint8_t *buf, size_t *len, size_t limit) const override;
@@ -700,7 +683,6 @@ public:
     : QUICFrame(id, owner), _seq_num(seq_num)
   {
   }
-  QUICFrameUPtr clone() const override;
   virtual QUICFrameType type() const override;
   virtual size_t size() const override;
   virtual size_t store(uint8_t *buf, size_t *len, size_t limit) const override;
@@ -715,168 +697,17 @@ private:
   uint64_t _seq_num = 0;
 };
 
-extern ClassAllocator<QUICStreamFrame> quicStreamFrameAllocator;
-extern ClassAllocator<QUICCryptoFrame> quicCryptoFrameAllocator;
-extern ClassAllocator<QUICAckFrame> quicAckFrameAllocator;
-extern ClassAllocator<QUICPaddingFrame> quicPaddingFrameAllocator;
-extern ClassAllocator<QUICRstStreamFrame> quicRstStreamFrameAllocator;
-extern ClassAllocator<QUICConnectionCloseFrame> quicConnectionCloseFrameAllocator;
-extern ClassAllocator<QUICMaxDataFrame> quicMaxDataFrameAllocator;
-extern ClassAllocator<QUICMaxStreamDataFrame> quicMaxStreamDataFrameAllocator;
-extern ClassAllocator<QUICMaxStreamsFrame> quicMaxStreamIdFrameAllocator;
-extern ClassAllocator<QUICPingFrame> quicPingFrameAllocator;
-extern ClassAllocator<QUICDataBlockedFrame> quicBlockedFrameAllocator;
-extern ClassAllocator<QUICStreamDataBlockedFrame> quicStreamBlockedFrameAllocator;
-extern ClassAllocator<QUICStreamIdBlockedFrame> quicStreamIdBlockedFrameAllocator;
-extern ClassAllocator<QUICNewConnectionIdFrame> quicNewConnectionIdFrameAllocator;
-extern ClassAllocator<QUICStopSendingFrame> quicStopSendingFrameAllocator;
-extern ClassAllocator<QUICPathChallengeFrame> quicPathChallengeFrameAllocator;
-extern ClassAllocator<QUICPathResponseFrame> quicPathResponseFrameAllocator;
-extern ClassAllocator<QUICNewTokenFrame> quicNewTokenFrameAllocator;
-extern ClassAllocator<QUICRetireConnectionIdFrame> quicRetireConnectionIdFrameAllocator;
+//
+// UNKNOWN
+//
 
-class QUICFrameDeleter
+class QUICUnknownFrame : public QUICFrame
 {
-public:
-  // TODO Probably these methods should call destructor
-  static void
-  delete_null_frame(QUICFrame *frame)
-  {
-    ink_assert(frame == nullptr);
-  }
-
-  static void
-  delete_stream_frame(QUICFrame *frame)
-  {
-    frame->~QUICFrame();
-    quicStreamFrameAllocator.free(static_cast<QUICStreamFrame *>(frame));
-  }
-
-  static void
-  delete_crypto_frame(QUICFrame *frame)
-  {
-    frame->~QUICFrame();
-    quicCryptoFrameAllocator.free(static_cast<QUICCryptoFrame *>(frame));
-  }
-
-  static void
-  delete_ack_frame(QUICFrame *frame)
-  {
-    frame->~QUICFrame();
-    quicAckFrameAllocator.free(static_cast<QUICAckFrame *>(frame));
-  }
-
-  static void
-  delete_padding_frame(QUICFrame *frame)
-  {
-    frame->~QUICFrame();
-    quicPaddingFrameAllocator.free(static_cast<QUICPaddingFrame *>(frame));
-  }
-
-  static void
-  delete_rst_stream_frame(QUICFrame *frame)
-  {
-    frame->~QUICFrame();
-    quicRstStreamFrameAllocator.free(static_cast<QUICRstStreamFrame *>(frame));
-  }
-
-  static void
-  delete_connection_close_frame(QUICFrame *frame)
-  {
-    frame->~QUICFrame();
-    quicConnectionCloseFrameAllocator.free(static_cast<QUICConnectionCloseFrame *>(frame));
-  }
-
-  static void
-  delete_max_data_frame(QUICFrame *frame)
-  {
-    frame->~QUICFrame();
-    quicMaxDataFrameAllocator.free(static_cast<QUICMaxDataFrame *>(frame));
-  }
-
-  static void
-  delete_max_stream_data_frame(QUICFrame *frame)
-  {
-    frame->~QUICFrame();
-    quicMaxStreamDataFrameAllocator.free(static_cast<QUICMaxStreamDataFrame *>(frame));
-  }
-
-  static void
-  delete_max_streams_frame(QUICFrame *frame)
-  {
-    frame->~QUICFrame();
-    quicMaxStreamIdFrameAllocator.free(static_cast<QUICMaxStreamsFrame *>(frame));
-  }
-
-  static void
-  delete_ping_frame(QUICFrame *frame)
-  {
-    frame->~QUICFrame();
-    quicPingFrameAllocator.free(static_cast<QUICPingFrame *>(frame));
-  }
-
-  static void
-  delete_blocked_frame(QUICFrame *frame)
-  {
-    frame->~QUICFrame();
-    quicBlockedFrameAllocator.free(static_cast<QUICDataBlockedFrame *>(frame));
-  }
-
-  static void
-  delete_stream_blocked_frame(QUICFrame *frame)
-  {
-    frame->~QUICFrame();
-    quicStreamBlockedFrameAllocator.free(static_cast<QUICStreamDataBlockedFrame *>(frame));
-  }
-
-  static void
-  delete_stream_id_blocked_frame(QUICFrame *frame)
-  {
-    frame->~QUICFrame();
-    quicStreamIdBlockedFrameAllocator.free(static_cast<QUICStreamIdBlockedFrame *>(frame));
-  }
-
-  static void
-  delete_new_connection_id_frame(QUICFrame *frame)
-  {
-    frame->~QUICFrame();
-    quicNewConnectionIdFrameAllocator.free(static_cast<QUICNewConnectionIdFrame *>(frame));
-  }
-
-  static void
-  delete_stop_sending_frame(QUICFrame *frame)
-  {
-    frame->~QUICFrame();
-    quicStopSendingFrameAllocator.free(static_cast<QUICStopSendingFrame *>(frame));
-  }
-
-  static void
-  delete_path_challenge_frame(QUICFrame *frame)
-  {
-    frame->~QUICFrame();
-    quicPathChallengeFrameAllocator.free(static_cast<QUICPathChallengeFrame *>(frame));
-  }
-
-  static void
-  delete_path_response_frame(QUICFrame *frame)
-  {
-    frame->~QUICFrame();
-    quicPathResponseFrameAllocator.free(static_cast<QUICPathResponseFrame *>(frame));
-  }
-
-  static void
-  delete_new_token_frame(QUICFrame *frame)
-  {
-    frame->~QUICFrame();
-    quicNewTokenFrameAllocator.free(static_cast<QUICNewTokenFrame *>(frame));
-  }
-
-  static void
-  delete_retire_connection_id_frame(QUICFrame *frame)
-  {
-    frame->~QUICFrame();
-    quicRetireConnectionIdFrameAllocator.free(static_cast<QUICRetireConnectionIdFrame *>(frame));
-  }
+  QUICFrameType type() const override;
+  size_t size() const override;
+  size_t store(uint8_t *buf, size_t *len, size_t limit) const override;
+  void parse(const uint8_t *buf, size_t len) override;
+  int debug_msg(char *msg, size_t msg_len) const override;
 };
 
 //
@@ -886,155 +717,139 @@ class QUICFrameFactory
 {
 public:
   /*
-   * This is for an empty QUICFrameUptr.
-   * Empty frames are used for variable initialization and return value of frame creation failure
-   */
-  static QUICFrameUPtr create_null_frame();
-  static std::unique_ptr<QUICAckFrame, QUICFrameDeleterFunc> create_null_ack_frame();
-
-  /*
    * This is used for creating a QUICFrame object based on received data.
    */
-  static QUICFrameUPtr create(const uint8_t *buf, size_t len);
+  static QUICFrame *create(uint8_t *buf, const uint8_t *src, size_t len);
 
   /*
    * This works almost the same as create() but it reuses created objects for performance.
    * If you create a frame object which has the same frame type that you created before, the object will be reset by new data.
    */
-  std::shared_ptr<const QUICFrame> fast_create(const uint8_t *buf, size_t len);
+  const QUICFrame &fast_create(const uint8_t *buf, size_t len);
 
   /*
    * Creates a STREAM frame.
    * You have to make sure that the data size won't exceed the maximum size of QUIC packet.
    */
-  static QUICStreamFrameUPtr create_stream_frame(Ptr<IOBufferBlock> &block, QUICStreamId stream_id, QUICOffset offset,
-                                                 bool last = false, bool has_offset_field = true, bool has_length_field = true,
-                                                 QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr);
+  static QUICStreamFrame *create_stream_frame(uint8_t *buf, Ptr<IOBufferBlock> &block, QUICStreamId stream_id, QUICOffset offset,
+                                              bool last = false, bool has_offset_field = true, bool has_length_field = true,
+                                              QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr);
 
   /*
    * Creates a CRYPTO frame.
    * You have to make sure that the data size won't exceed the maximum size of QUIC packet.
    */
-  static QUICCryptoFrameUPtr create_crypto_frame(Ptr<IOBufferBlock> &block, QUICOffset offset, QUICFrameId id = 0,
-                                                 QUICFrameGenerator *owner = nullptr);
+  static QUICCryptoFrame *create_crypto_frame(uint8_t *buf, Ptr<IOBufferBlock> &block, QUICOffset offset, QUICFrameId id = 0,
+                                              QUICFrameGenerator *owner = nullptr);
 
   /*
    * Creates a ACK frame.
    * You shouldn't call this directly but through QUICAckFrameCreator because QUICAckFrameCreator manages packet numbers that we
    * need to ack.
    */
-  static std::unique_ptr<QUICAckFrame, QUICFrameDeleterFunc> create_ack_frame(QUICPacketNumber largest_acknowledged,
-                                                                              uint64_t ack_delay, uint64_t first_ack_block,
-                                                                              QUICFrameId id            = 0,
-                                                                              QUICFrameGenerator *owner = nullptr);
+  static QUICAckFrame *create_ack_frame(uint8_t *buf, QUICPacketNumber largest_acknowledged, uint64_t ack_delay,
+                                        uint64_t first_ack_block, QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr);
   /*
    * Creates a CONNECTION_CLOSE frame.
    */
-  static std::unique_ptr<QUICConnectionCloseFrame, QUICFrameDeleterFunc> create_connection_close_frame(
-    uint16_t error_code, QUICFrameType frame_type, uint16_t reason_phrase_length = 0, const char *reason_phrase = nullptr,
-    QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr);
+  static QUICConnectionCloseFrame *create_connection_close_frame(uint8_t *buf, uint16_t error_code, QUICFrameType frame_type,
+                                                                 uint16_t reason_phrase_length = 0,
+                                                                 const char *reason_phrase = nullptr, QUICFrameId id = 0,
+                                                                 QUICFrameGenerator *owner = nullptr);
 
-  static std::unique_ptr<QUICConnectionCloseFrame, QUICFrameDeleterFunc> create_connection_close_frame(
-    QUICConnectionError &error, QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr);
+  static QUICConnectionCloseFrame *create_connection_close_frame(uint8_t *buf, QUICConnectionError &error, QUICFrameId id = 0,
+                                                                 QUICFrameGenerator *owner = nullptr);
 
   /*
    * Creates a MAX_DATA frame.
    */
-  static std::unique_ptr<QUICMaxDataFrame, QUICFrameDeleterFunc> create_max_data_frame(uint64_t maximum_data, QUICFrameId id = 0,
-                                                                                       QUICFrameGenerator *owner = nullptr);
+  static QUICMaxDataFrame *create_max_data_frame(uint8_t *buf, uint64_t maximum_data, QUICFrameId id = 0,
+                                                 QUICFrameGenerator *owner = nullptr);
 
   /*
  /  * Creates a MAX_STREAM_DATA frame.
    */
-  static std::unique_ptr<QUICMaxStreamDataFrame, QUICFrameDeleterFunc> create_max_stream_data_frame(
-    QUICStreamId stream_id, uint64_t maximum_stream_data, QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr);
+  static QUICMaxStreamDataFrame *create_max_stream_data_frame(uint8_t *buf, QUICStreamId stream_id, uint64_t maximum_stream_data,
+                                                              QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr);
   /*
    * Creates a MAX_STREAMS frame.
    */
-  static std::unique_ptr<QUICMaxStreamsFrame, QUICFrameDeleterFunc> create_max_streams_frame(QUICStreamId maximum_streams,
-                                                                                             QUICFrameId id            = 0,
-                                                                                             QUICFrameGenerator *owner = nullptr);
+  static QUICMaxStreamsFrame *create_max_streams_frame(uint8_t *buf, QUICStreamId maximum_streams, QUICFrameId id = 0,
+                                                       QUICFrameGenerator *owner = nullptr);
 
   /*
    * Creates a PING frame
    */
-  static std::unique_ptr<QUICPingFrame, QUICFrameDeleterFunc> create_ping_frame(QUICFrameId id            = 0,
-                                                                                QUICFrameGenerator *owner = nullptr);
+  static QUICPingFrame *create_ping_frame(uint8_t *buf, QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr);
 
   /*
    * Creates a PATH_CHALLENGE frame
    */
-  static std::unique_ptr<QUICPathChallengeFrame, QUICFrameDeleterFunc> create_path_challenge_frame(
-    const uint8_t *data, QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr);
+  static QUICPathChallengeFrame *create_path_challenge_frame(uint8_t *buf, const uint8_t *data, QUICFrameId id = 0,
+                                                             QUICFrameGenerator *owner = nullptr);
 
   /*
    * Creates a PATH_RESPONSE frame
    */
-  static std::unique_ptr<QUICPathResponseFrame, QUICFrameDeleterFunc> create_path_response_frame(
-    const uint8_t *data, QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr);
+  static QUICPathResponseFrame *create_path_response_frame(uint8_t *buf, const uint8_t *data, QUICFrameId id = 0,
+                                                           QUICFrameGenerator *owner = nullptr);
 
   /*
    * Creates a BLOCKED frame.
    */
-  static std::unique_ptr<QUICDataBlockedFrame, QUICFrameDeleterFunc> create_data_blocked_frame(QUICOffset offset,
-                                                                                               QUICFrameId id            = 0,
-                                                                                               QUICFrameGenerator *owner = nullptr);
+  static QUICDataBlockedFrame *create_data_blocked_frame(uint8_t *buf, QUICOffset offset, QUICFrameId id = 0,
+                                                         QUICFrameGenerator *owner = nullptr);
 
   /*
    * Creates a STREAM_DATA_BLOCKED frame.
    */
-  static std::unique_ptr<QUICStreamDataBlockedFrame, QUICFrameDeleterFunc> create_stream_data_blocked_frame(
-    QUICStreamId stream_id, QUICOffset offset, QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr);
+  static QUICStreamDataBlockedFrame *create_stream_data_blocked_frame(uint8_t *buf, QUICStreamId stream_id, QUICOffset offset,
+                                                                      QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr);
 
   /*
    * Creates a STREAMS_BLOCKED frame.
    */
-  static std::unique_ptr<QUICStreamIdBlockedFrame, QUICFrameDeleterFunc> create_stream_id_blocked_frame(
-    QUICStreamId stream_id, QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr);
+  static QUICStreamIdBlockedFrame *create_stream_id_blocked_frame(uint8_t *buf, QUICStreamId stream_id, QUICFrameId id = 0,
+                                                                  QUICFrameGenerator *owner = nullptr);
 
   /*
    * Creates a RESET_STREAM frame.
    */
-  static std::unique_ptr<QUICRstStreamFrame, QUICFrameDeleterFunc> create_rst_stream_frame(QUICStreamId stream_id,
-                                                                                           QUICAppErrorCode error_code,
-                                                                                           QUICOffset final_offset,
-                                                                                           QUICFrameId id            = 0,
-                                                                                           QUICFrameGenerator *owner = nullptr);
-  static std::unique_ptr<QUICRstStreamFrame, QUICFrameDeleterFunc> create_rst_stream_frame(QUICStreamError &error,
-                                                                                           QUICFrameId id            = 0,
-                                                                                           QUICFrameGenerator *owner = nullptr);
+  static QUICRstStreamFrame *create_rst_stream_frame(uint8_t *buf, QUICStreamId stream_id, QUICAppErrorCode error_code,
+                                                     QUICOffset final_offset, QUICFrameId id = 0,
+                                                     QUICFrameGenerator *owner = nullptr);
+  static QUICRstStreamFrame *create_rst_stream_frame(uint8_t *buf, QUICStreamError &error, QUICFrameId id = 0,
+                                                     QUICFrameGenerator *owner = nullptr);
 
   /*
    * Creates a STOP_SENDING frame.
    */
-  static std::unique_ptr<QUICStopSendingFrame, QUICFrameDeleterFunc> create_stop_sending_frame(QUICStreamId stream_id,
-                                                                                               QUICAppErrorCode error_code,
-                                                                                               QUICFrameId id            = 0,
-                                                                                               QUICFrameGenerator *owner = nullptr);
+  static QUICStopSendingFrame *create_stop_sending_frame(uint8_t *buf, QUICStreamId stream_id, QUICAppErrorCode error_code,
+                                                         QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr);
 
   /*
    * Creates a NEW_CONNECTION_ID frame.
    */
-  static std::unique_ptr<QUICNewConnectionIdFrame, QUICFrameDeleterFunc> create_new_connection_id_frame(
-    uint32_t sequence, QUICConnectionId connectoin_id, QUICStatelessResetToken stateless_reset_token, QUICFrameId id = 0,
-    QUICFrameGenerator *owner = nullptr);
+  static QUICNewConnectionIdFrame *create_new_connection_id_frame(uint8_t *buf, uint32_t sequence, QUICConnectionId connectoin_id,
+                                                                  QUICStatelessResetToken stateless_reset_token, QUICFrameId id = 0,
+                                                                  QUICFrameGenerator *owner = nullptr);
 
   /*
    * Creates a NEW_TOKEN frame
    */
-  static std::unique_ptr<QUICNewTokenFrame, QUICFrameDeleterFunc> create_new_token_frame(const QUICResumptionToken &token,
-                                                                                         QUICFrameId id            = 0,
-                                                                                         QUICFrameGenerator *owner = nullptr);
+  static QUICNewTokenFrame *create_new_token_frame(uint8_t *buf, const QUICResumptionToken &token, QUICFrameId id = 0,
+                                                   QUICFrameGenerator *owner = nullptr);
 
   /*
    * Creates a RETIRE_CONNECTION_ID frame
    */
-  static std::unique_ptr<QUICRetireConnectionIdFrame, QUICFrameDeleterFunc> create_retire_connection_id_frame(
-    uint64_t seq_num, QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr);
+  static QUICRetireConnectionIdFrame *create_retire_connection_id_frame(uint8_t *buf, uint64_t seq_num, QUICFrameId id = 0,
+                                                                        QUICFrameGenerator *owner = nullptr);
 
 private:
   // FIXME Actual number of frame types is several but some of the values are not sequential.
-  std::shared_ptr<QUICFrame> _reusable_frames[256] = {nullptr};
+  QUICFrame *_reusable_frames[256] = {nullptr};
+  QUICUnknownFrame _unknown_frame;
 };
 
 class QUICFrameInfo

--- a/iocore/net/quic/QUICFrame.h
+++ b/iocore/net/quic/QUICFrame.h
@@ -257,6 +257,9 @@ public:
   QUICAckFrame(QUICPacketNumber largest_acknowledged, uint64_t ack_delay, uint64_t first_ack_block, QUICFrameId id = 0,
                QUICFrameGenerator *owner = nullptr);
 
+  // There's no reasont restrict copy, but we need to write the copy constructor. Otherwise it will crash on destruct.
+  QUICAckFrame(const QUICAckFrame &) = delete;
+
   virtual ~QUICAckFrame();
   virtual QUICFrameType type() const override;
   virtual size_t size() const override;

--- a/iocore/net/quic/QUICFrameDispatcher.cc
+++ b/iocore/net/quic/QUICFrameDispatcher.cc
@@ -45,24 +45,23 @@ QUICConnectionErrorUPtr
 QUICFrameDispatcher::receive_frames(QUICEncryptionLevel level, const uint8_t *payload, uint16_t size, bool &ack_only,
                                     bool &is_flow_controlled, bool *has_non_probing_frame)
 {
-  std::shared_ptr<const QUICFrame> frame(nullptr);
   uint16_t cursor               = 0;
   ack_only                      = true;
   is_flow_controlled            = false;
   QUICConnectionErrorUPtr error = nullptr;
 
   while (cursor < size) {
-    frame = this->_frame_factory.fast_create(payload + cursor, size - cursor);
-    if (frame == nullptr) {
+    const QUICFrame &frame = this->_frame_factory.fast_create(payload + cursor, size - cursor);
+    if (frame.type() == QUICFrameType::UNKNOWN) {
       QUICDebug("Failed to create a frame (%u bytes skipped)", size - cursor);
       break;
     }
     if (has_non_probing_frame) {
-      *has_non_probing_frame |= !frame->is_probing_frame();
+      *has_non_probing_frame |= !frame.is_probing_frame();
     }
-    cursor += frame->size();
+    cursor += frame.size();
 
-    QUICFrameType type = frame->type();
+    QUICFrameType type = frame.type();
 
     if (type == QUICFrameType::STREAM) {
       is_flow_controlled = true;
@@ -70,7 +69,7 @@ QUICFrameDispatcher::receive_frames(QUICEncryptionLevel level, const uint8_t *pa
 
     if (is_debug_tag_set(tag) && type != QUICFrameType::PADDING) {
       char msg[1024];
-      frame->debug_msg(msg, sizeof(msg));
+      frame.debug_msg(msg, sizeof(msg));
       QUICDebug("[RX] %s", msg);
     }
 
@@ -80,7 +79,7 @@ QUICFrameDispatcher::receive_frames(QUICEncryptionLevel level, const uint8_t *pa
 
     std::vector<QUICFrameHandler *> handlers = this->_handlers[static_cast<uint8_t>(type)];
     for (auto h : handlers) {
-      error = h->handle_frame(level, *frame.get());
+      error = h->handle_frame(level, frame);
       // TODO: is there any case to continue this loop even if error?
       if (error != nullptr) {
         return error;

--- a/iocore/net/quic/QUICFrameGenerator.h
+++ b/iocore/net/quic/QUICFrameGenerator.h
@@ -30,8 +30,14 @@ class QUICFrameGenerator
 {
 public:
   virtual ~QUICFrameGenerator(){};
-  virtual bool will_generate_frame(QUICEncryptionLevel level)                                                              = 0;
-  virtual QUICFrameUPtr generate_frame(QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size) = 0;
+  virtual bool will_generate_frame(QUICEncryptionLevel level) = 0;
+
+  /*
+   * This function constructs an instance of QUICFrame on buf.
+   * It returns a pointer for the frame if it succeeded, and returns nullptr if it failed.
+   */
+  virtual QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit,
+                                    uint16_t maximum_frame_size) = 0;
 
   void on_frame_acked(QUICFrameId id);
   void on_frame_lost(QUICFrameId id);

--- a/iocore/net/quic/QUICFrameRetransmitter.h
+++ b/iocore/net/quic/QUICFrameRetransmitter.h
@@ -71,15 +71,15 @@ struct AckFrameInfo {
 class QUICFrameRetransmitter
 {
 public:
-  virtual QUICFrameUPtr create_retransmitted_frame(QUICEncryptionLevel level, uint16_t maximum_frame_size, QUICFrameId id = 0,
-                                                   QUICFrameGenerator *owner = nullptr);
+  virtual QUICFrame *create_retransmitted_frame(uint8_t *buf, QUICEncryptionLevel level, uint16_t maximum_frame_size,
+                                                QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr);
   virtual void save_frame_info(QUICFrameInformationUPtr info);
 
 private:
-  QUICFrameUPtr _create_stream_frame(QUICFrameInformationUPtr &info, uint16_t maximum_frame_size,
-                                     std::deque<QUICFrameInformationUPtr> &tmp_queue, QUICFrameId id, QUICFrameGenerator *owner);
-  QUICFrameUPtr _create_crypto_frame(QUICFrameInformationUPtr &info, uint16_t maximum_frame_size,
-                                     std::deque<QUICFrameInformationUPtr> &tmp_queue, QUICFrameId id, QUICFrameGenerator *owner);
+  QUICFrame *_create_stream_frame(uint8_t *buf, QUICFrameInformationUPtr &info, uint16_t maximum_frame_size,
+                                  std::deque<QUICFrameInformationUPtr> &tmp_queue, QUICFrameId id, QUICFrameGenerator *owner);
+  QUICFrame *_create_crypto_frame(uint8_t *buf, QUICFrameInformationUPtr &info, uint16_t maximum_frame_size,
+                                  std::deque<QUICFrameInformationUPtr> &tmp_queue, QUICFrameId id, QUICFrameGenerator *owner);
 
   void _append_info_queue(std::deque<QUICFrameInformationUPtr> &tmp_queue);
 

--- a/iocore/net/quic/QUICHandshake.cc
+++ b/iocore/net/quic/QUICHandshake.cc
@@ -346,19 +346,17 @@ QUICHandshake::will_generate_frame(QUICEncryptionLevel level)
   return this->_crypto_streams[static_cast<int>(level)].will_generate_frame(level);
 }
 
-QUICFrameUPtr
-QUICHandshake::generate_frame(QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size)
+QUICFrame *
+QUICHandshake::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size)
 {
-  QUICFrameUPtr frame = QUICFrameFactory::create_null_frame();
-
   // CRYPTO frame is not flow-controlled
-  connection_credit = UINT64_MAX;
+  // connection_credit = UINT64_MAX;
 
-  if (!this->_is_level_matched(level)) {
-    return frame;
+  QUICFrame *frame = nullptr;
+
+  if (this->_is_level_matched(level)) {
+    frame = this->_crypto_streams[static_cast<int>(level)].generate_frame(buf, level, connection_credit, maximum_frame_size);
   }
-
-  frame = this->_crypto_streams[static_cast<int>(level)].generate_frame(level, connection_credit, maximum_frame_size);
 
   return frame;
 }

--- a/iocore/net/quic/QUICHandshake.h
+++ b/iocore/net/quic/QUICHandshake.h
@@ -52,7 +52,8 @@ public:
 
   // QUICFrameGenerator
   bool will_generate_frame(QUICEncryptionLevel level) override;
-  QUICFrameUPtr generate_frame(QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size) override;
+  QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit,
+                            uint16_t maximum_frame_size) override;
 
   // for client side
   QUICConnectionErrorUPtr start(QUICPacketFactory *packet_factory, bool vn_exercise_enabled);

--- a/iocore/net/quic/QUICIncomingFrameBuffer.h
+++ b/iocore/net/quic/QUICIncomingFrameBuffer.h
@@ -33,11 +33,9 @@
 class QUICIncomingFrameBuffer
 {
 public:
-  virtual const QUICFrame *pop() = 0;
-  /*
-   * Becasue frames passed by FrameDispatcher is temporal, this clones a passed frame to ensure that we can use it later.
-   */
-  virtual QUICConnectionErrorUPtr insert(const QUICFrame &frame) = 0;
+  ~QUICIncomingFrameBuffer();
+  virtual const QUICFrame *pop()                                 = 0;
+  virtual QUICConnectionErrorUPtr insert(const QUICFrame *frame) = 0;
   virtual void clear();
   virtual bool empty();
 
@@ -57,7 +55,7 @@ public:
   ~QUICIncomingStreamFrameBuffer();
 
   const QUICFrame *pop() override;
-  QUICConnectionErrorUPtr insert(const QUICFrame &frame) override;
+  QUICConnectionErrorUPtr insert(const QUICFrame *frame) override;
   void clear() override;
 
   // QUICTransferProgressProvider
@@ -82,7 +80,7 @@ public:
   ~QUICIncomingCryptoFrameBuffer();
 
   const QUICFrame *pop() override;
-  QUICConnectionErrorUPtr insert(const QUICFrame &frame) override;
+  QUICConnectionErrorUPtr insert(const QUICFrame *frame) override;
 
 private:
 };

--- a/iocore/net/quic/QUICIncomingFrameBuffer.h
+++ b/iocore/net/quic/QUICIncomingFrameBuffer.h
@@ -33,7 +33,7 @@
 class QUICIncomingFrameBuffer
 {
 public:
-  virtual QUICFrameSPtr pop() = 0;
+  virtual const QUICFrame *pop() = 0;
   /*
    * Becasue frames passed by FrameDispatcher is temporal, this clones a passed frame to ensure that we can use it later.
    */
@@ -44,8 +44,8 @@ public:
 protected:
   QUICOffset _recv_offset = 0;
 
-  std::queue<QUICFrameSPtr> _recv_buffer;
-  std::map<QUICOffset, QUICFrameSPtr> _out_of_order_queue;
+  std::queue<const QUICFrame *> _recv_buffer;
+  std::map<QUICOffset, const QUICFrame *> _out_of_order_queue;
 };
 
 class QUICIncomingStreamFrameBuffer : public QUICIncomingFrameBuffer, public QUICTransferProgressProvider
@@ -56,7 +56,7 @@ public:
   QUICIncomingStreamFrameBuffer() {}
   ~QUICIncomingStreamFrameBuffer();
 
-  QUICFrameSPtr pop() override;
+  const QUICFrame *pop() override;
   QUICConnectionErrorUPtr insert(const QUICFrame &frame) override;
   void clear() override;
 
@@ -81,7 +81,7 @@ public:
   QUICIncomingCryptoFrameBuffer() {}
   ~QUICIncomingCryptoFrameBuffer();
 
-  QUICFrameSPtr pop() override;
+  const QUICFrame *pop() override;
   QUICConnectionErrorUPtr insert(const QUICFrame &frame) override;
 
 private:

--- a/iocore/net/quic/QUICPathValidator.h
+++ b/iocore/net/quic/QUICPathValidator.h
@@ -42,7 +42,8 @@ public:
 
   // QUICFrameGeneratro
   bool will_generate_frame(QUICEncryptionLevel level) override;
-  QUICFrameUPtr generate_frame(QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size) override;
+  QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit,
+                            uint16_t maximum_frame_size) override;
 
 private:
   enum class ValidationState : int {

--- a/iocore/net/quic/QUICPinger.cc
+++ b/iocore/net/quic/QUICPinger.cc
@@ -43,10 +43,10 @@ QUICPinger::will_generate_frame(QUICEncryptionLevel level)
   return this->_need_to_fire[QUICTypeUtil::pn_space_index(level)] > 0;
 }
 
-QUICFrameUPtr
-QUICPinger::generate_frame(QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size)
+QUICFrame *
+QUICPinger::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size)
 {
-  QUICFrameUPtr frame = QUICFrameFactory::create_null_frame();
+  QUICFrame *frame = nullptr;
 
   if (!this->_is_level_matched(level)) {
     return frame;
@@ -54,7 +54,7 @@ QUICPinger::generate_frame(QUICEncryptionLevel level, uint64_t connection_credit
 
   if (this->_need_to_fire[static_cast<int>(level)] > 0 && maximum_frame_size > 0) {
     // don't care ping frame lost or acked
-    frame                                        = QUICFrameFactory::create_ping_frame(0, nullptr);
+    frame                                        = QUICFrameFactory::create_ping_frame(buf, 0, nullptr);
     this->_need_to_fire[static_cast<int>(level)] = 0;
   }
 

--- a/iocore/net/quic/QUICPinger.h
+++ b/iocore/net/quic/QUICPinger.h
@@ -38,7 +38,8 @@ public:
 
   // QUICFrameGenerator
   bool will_generate_frame(QUICEncryptionLevel level) override;
-  QUICFrameUPtr generate_frame(QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size) override;
+  QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit,
+                            uint16_t maximum_frame_size) override;
 
 private:
   // Initial, 0/1-RTT, and Handshake

--- a/iocore/net/quic/QUICStream.h
+++ b/iocore/net/quic/QUICStream.h
@@ -92,7 +92,8 @@ public:
 
   // QUICFrameGenerator
   bool will_generate_frame(QUICEncryptionLevel level) override;
-  QUICFrameUPtr generate_frame(QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size) override;
+  QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit,
+                            uint16_t maximum_frame_size) override;
 
   // QUICTransferProgressProvider
   bool is_transfer_goal_set() const override;
@@ -186,7 +187,8 @@ public:
 
   // QUICFrameGenerator
   bool will_generate_frame(QUICEncryptionLevel level) override;
-  QUICFrameUPtr generate_frame(QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size) override;
+  QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit,
+                            uint16_t maximum_frame_size) override;
 
 private:
   void _on_frame_acked(QUICFrameInformationUPtr &info) override;

--- a/iocore/net/quic/QUICStreamManager.h
+++ b/iocore/net/quic/QUICStreamManager.h
@@ -65,7 +65,8 @@ public:
 
   // QUICFrameGenerator
   bool will_generate_frame(QUICEncryptionLevel level) override;
-  QUICFrameUPtr generate_frame(QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size) override;
+  QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit,
+                            uint16_t maximum_frame_size) override;
 
 private:
   QUICStream *_find_stream(QUICStreamId id);

--- a/iocore/net/quic/test/test_QUICFrame.cc
+++ b/iocore/net/quic/test/test_QUICFrame.cc
@@ -75,6 +75,8 @@ TEST_CASE("QUICFrame Type", "[quic]")
 
 TEST_CASE("Load STREAM Frame", "[quic]")
 {
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
+
   SECTION("OLF=000")
   {
     uint8_t buf1[] = {
@@ -82,10 +84,10 @@ TEST_CASE("Load STREAM Frame", "[quic]")
       0x01,                   // Stream ID
       0x01, 0x02, 0x03, 0x04, // Stream Data
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::STREAM);
     CHECK(frame1->size() == 6);
-    std::shared_ptr<const QUICStreamFrame> stream_frame = std::dynamic_pointer_cast<const QUICStreamFrame>(frame1);
+    const QUICStreamFrame *stream_frame = static_cast<const QUICStreamFrame *>(frame1);
     CHECK(stream_frame->stream_id() == 0x01);
     CHECK(stream_frame->offset() == 0x00);
     CHECK(stream_frame->data_length() == 4);
@@ -101,10 +103,10 @@ TEST_CASE("Load STREAM Frame", "[quic]")
       0x05,                         // Data Length
       0x01, 0x02, 0x03, 0x04, 0x05, // Stream Data
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::STREAM);
     CHECK(frame1->size() == 8);
-    std::shared_ptr<const QUICStreamFrame> stream_frame = std::dynamic_pointer_cast<const QUICStreamFrame>(frame1);
+    const QUICStreamFrame *stream_frame = static_cast<const QUICStreamFrame *>(frame1);
     CHECK(stream_frame->stream_id() == 0x01);
     CHECK(stream_frame->offset() == 0x00);
     CHECK(stream_frame->data_length() == 5);
@@ -121,11 +123,11 @@ TEST_CASE("Load STREAM Frame", "[quic]")
       0x05,                         // Data Length
       0x01, 0x02, 0x03, 0x04, 0x05, // Stream Data
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::STREAM);
     CHECK(frame1->size() == 9);
 
-    std::shared_ptr<const QUICStreamFrame> stream_frame = std::dynamic_pointer_cast<const QUICStreamFrame>(frame1);
+    const QUICStreamFrame *stream_frame = static_cast<const QUICStreamFrame *>(frame1);
     CHECK(stream_frame->stream_id() == 0x01);
     CHECK(stream_frame->offset() == 0x02);
     CHECK(stream_frame->data_length() == 5);
@@ -142,11 +144,11 @@ TEST_CASE("Load STREAM Frame", "[quic]")
       0x05,                         // Data Length
       0x01, 0x02, 0x03, 0x04, 0x05, // Stream Data
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::STREAM);
     CHECK(frame1->size() == 9);
 
-    std::shared_ptr<const QUICStreamFrame> stream_frame = std::dynamic_pointer_cast<const QUICStreamFrame>(frame1);
+    const QUICStreamFrame *stream_frame = static_cast<const QUICStreamFrame *>(frame1);
     CHECK(stream_frame->stream_id() == 0x01);
     CHECK(stream_frame->offset() == 0x02);
     CHECK(stream_frame->data_length() == 5);
@@ -163,7 +165,7 @@ TEST_CASE("Load STREAM Frame", "[quic]")
       0x05,                   // Data Length
       0x01, 0x02, 0x03, 0x04, // BAD Stream Data
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::STREAM);
     CHECK(frame1->valid() == false);
   }
@@ -174,7 +176,7 @@ TEST_CASE("Load STREAM Frame", "[quic]")
       0x0e, // 0b00001OLF (OLF=110)
       0x01, // Stream ID
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::STREAM);
     CHECK(frame1->valid() == false);
   }
@@ -385,6 +387,7 @@ TEST_CASE("Store STREAM Frame", "[quic]")
 
 TEST_CASE("CRYPTO Frame", "[quic]")
 {
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   SECTION("Loading")
   {
     uint8_t buf[] = {
@@ -393,11 +396,11 @@ TEST_CASE("CRYPTO Frame", "[quic]")
       0x05,                         // Length
       0x01, 0x02, 0x03, 0x04, 0x05, // Crypto Data
     };
-    std::shared_ptr<const QUICFrame> frame = QUICFrameFactory::create(buf, sizeof(buf));
+    const QUICFrame *frame = QUICFrameFactory::create(frame_buf, buf, sizeof(buf));
     CHECK(frame->type() == QUICFrameType::CRYPTO);
     CHECK(frame->size() == sizeof(buf));
 
-    std::shared_ptr<const QUICCryptoFrame> crypto_frame = std::dynamic_pointer_cast<const QUICCryptoFrame>(frame);
+    const QUICCryptoFrame *crypto_frame = static_cast<const QUICCryptoFrame *>(frame);
     CHECK(crypto_frame->offset() == 0x010000);
     CHECK(crypto_frame->data_length() == 5);
     CHECK(memcmp(crypto_frame->data()->start(), "\x01\x02\x03\x04\x05", 5) == 0);
@@ -409,7 +412,7 @@ TEST_CASE("CRYPTO Frame", "[quic]")
       0x06,                   // Type
       0x80, 0x01, 0x00, 0x00, // Offset
     };
-    std::shared_ptr<const QUICFrame> frame = QUICFrameFactory::create(buf, sizeof(buf));
+    const QUICFrame *frame = QUICFrameFactory::create(frame_buf, buf, sizeof(buf));
     CHECK(frame->type() == QUICFrameType::CRYPTO);
     CHECK(frame->valid() == false);
   }
@@ -441,6 +444,7 @@ TEST_CASE("CRYPTO Frame", "[quic]")
 
 TEST_CASE("Load Ack Frame 1", "[quic]")
 {
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   SECTION("0 Ack Block, 8 bit packet number length, 8 bit block length")
   {
     uint8_t buf1[] = {
@@ -450,10 +454,10 @@ TEST_CASE("Load Ack Frame 1", "[quic]")
       0x00,       // Ack Block Count
       0x00,       // Ack Block Section
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::ACK);
     CHECK(frame1->size() == 6);
-    std::shared_ptr<const QUICAckFrame> ack_frame1 = std::dynamic_pointer_cast<const QUICAckFrame>(frame1);
+    const QUICAckFrame *ack_frame1 = static_cast<const QUICAckFrame *>(frame1);
     CHECK(ack_frame1 != nullptr);
     CHECK(ack_frame1->ack_block_count() == 0);
     CHECK(ack_frame1->largest_acknowledged() == 0x12);
@@ -469,11 +473,11 @@ TEST_CASE("Load Ack Frame 1", "[quic]")
       0x00,                   // Ack Block Count
       0x80, 0x00, 0x00, 0x01, // Ack Block Section (First ACK Block Length)
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::ACK);
     CHECK(frame1->size() == 12);
 
-    std::shared_ptr<const QUICAckFrame> ack_frame1 = std::dynamic_pointer_cast<const QUICAckFrame>(frame1);
+    const QUICAckFrame *ack_frame1 = static_cast<const QUICAckFrame *>(frame1);
     CHECK(ack_frame1 != nullptr);
     CHECK(ack_frame1->largest_acknowledged() == 0x01);
     CHECK(ack_frame1->ack_delay() == 0x0171);
@@ -498,10 +502,10 @@ TEST_CASE("Load Ack Frame 1", "[quic]")
       0xc9, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, // Ack Block Section (ACK Block 2 Length)
     };
 
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::ACK);
     CHECK(frame1->size() == 21);
-    std::shared_ptr<const QUICAckFrame> ack_frame1 = std::dynamic_pointer_cast<const QUICAckFrame>(frame1);
+    const QUICAckFrame *ack_frame1 = static_cast<const QUICAckFrame *>(frame1);
     CHECK(ack_frame1 != nullptr);
     CHECK(ack_frame1->largest_acknowledged() == 0x12);
     CHECK(ack_frame1->ack_delay() == 0x3456);
@@ -529,7 +533,7 @@ TEST_CASE("Load Ack Frame 1", "[quic]")
       0x12, // Largest Acknowledged
     };
 
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::ACK);
     CHECK(frame1->valid() == false);
   }
@@ -547,7 +551,7 @@ TEST_CASE("Load Ack Frame 1", "[quic]")
       0x85, 0x06, 0x07, 0x08, // Ack Block Section (Gap 2)
     };
 
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::ACK);
     CHECK(frame1->valid() == false);
   }
@@ -565,10 +569,10 @@ TEST_CASE("Load Ack Frame 1", "[quic]")
       0x02, // ECT1
       0x03, // ECN-CE
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::ACK);
     CHECK(frame1->size() == 9);
-    std::shared_ptr<const QUICAckFrame> ack_frame1 = std::dynamic_pointer_cast<const QUICAckFrame>(frame1);
+    const QUICAckFrame *ack_frame1 = static_cast<const QUICAckFrame *>(frame1);
     CHECK(ack_frame1 != nullptr);
     CHECK(ack_frame1->ack_block_count() == 0);
     CHECK(ack_frame1->largest_acknowledged() == 0x12);
@@ -591,7 +595,7 @@ TEST_CASE("Load Ack Frame 1", "[quic]")
       0x01, // ECT0
       0x02, // ECT1
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::ACK);
     CHECK(frame1->valid() == false);
   }
@@ -646,37 +650,11 @@ TEST_CASE("Store Ack Frame", "[quic]")
     CHECK(len == 21);
     CHECK(memcmp(buf, expected, len) == 0);
   }
-
-  SECTION("Clone ACK frame", "[quic]")
-  {
-    uint8_t buf[32] = {0};
-    size_t len;
-
-    uint8_t expected[] = {
-      0x02,                                           // Type
-      0x12,                                           // Largest Acknowledged
-      0x74, 0x56,                                     // Ack Delay
-      0x02,                                           // Ack Block Count
-      0x01,                                           // Ack Block Section (First ACK Block Length)
-      0x02,                                           // Ack Block Section (Gap 1)
-      0x43, 0x04,                                     // Ack Block Section (ACK Block 1 Length)
-      0x85, 0x06, 0x07, 0x08,                         // Ack Block Section (Gap 2)
-      0xc9, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, // Ack Block Section (ACK Block 2 Length)
-    };
-    QUICAckFrame ack_frame(0x12, 0x3456, 0x01);
-    QUICAckFrame::AckBlockSection *section = ack_frame.ack_block_section();
-    section->add_ack_block({0x02, 0x0304});
-    section->add_ack_block({0x05060708, 0x090a0b0c0d0e0f10});
-
-    auto cloned = ack_frame.clone();
-    cloned->store(buf, &len, sizeof(buf));
-    CHECK(len == 21);
-    CHECK(memcmp(buf, expected, len) == 0);
-  }
 }
 
 TEST_CASE("Load RESET_STREAM Frame", "[quic]")
 {
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   SECTION("Load")
   {
     uint8_t buf1[] = {
@@ -685,10 +663,10 @@ TEST_CASE("Load RESET_STREAM Frame", "[quic]")
       0x00, 0x01,                                    // Error Code
       0xd1, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88 // Final Offset
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::RESET_STREAM);
     CHECK(frame1->size() == 15);
-    std::shared_ptr<const QUICRstStreamFrame> rst_stream_frame1 = std::dynamic_pointer_cast<const QUICRstStreamFrame>(frame1);
+    const QUICRstStreamFrame *rst_stream_frame1 = static_cast<const QUICRstStreamFrame *>(frame1);
     CHECK(rst_stream_frame1 != nullptr);
     CHECK(rst_stream_frame1->error_code() == 0x0001);
     CHECK(rst_stream_frame1->stream_id() == 0x12345678);
@@ -702,7 +680,7 @@ TEST_CASE("Load RESET_STREAM Frame", "[quic]")
       0x92, 0x34, 0x56, 0x78, // Stream ID
       0x00, 0x01,             // Error Code
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::RESET_STREAM);
     CHECK(frame1->valid() == false);
   }
@@ -729,14 +707,15 @@ TEST_CASE("Store RESET_STREAM Frame", "[quic]")
 
 TEST_CASE("Load Ping Frame", "[quic]")
 {
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   uint8_t buf[] = {
     0x01, // Type
   };
-  std::shared_ptr<const QUICFrame> frame = QUICFrameFactory::create(buf, sizeof(buf));
+  const QUICFrame *frame = QUICFrameFactory::create(frame_buf, buf, sizeof(buf));
   CHECK(frame->type() == QUICFrameType::PING);
   CHECK(frame->size() == 1);
 
-  std::shared_ptr<const QUICPingFrame> ping_frame = std::dynamic_pointer_cast<const QUICPingFrame>(frame);
+  const QUICPingFrame *ping_frame = static_cast<const QUICPingFrame *>(frame);
   CHECK(ping_frame != nullptr);
 }
 
@@ -759,13 +738,14 @@ TEST_CASE("Store Ping Frame", "[quic]")
 
 TEST_CASE("Load Padding Frame", "[quic]")
 {
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   uint8_t buf1[] = {
     0x00, // Type
   };
-  std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+  const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
   CHECK(frame1->type() == QUICFrameType::PADDING);
   CHECK(frame1->size() == 1);
-  std::shared_ptr<const QUICPaddingFrame> paddingFrame1 = std::dynamic_pointer_cast<const QUICPaddingFrame>(frame1);
+  const QUICPaddingFrame *paddingFrame1 = static_cast<const QUICPaddingFrame *>(frame1);
   CHECK(paddingFrame1 != nullptr);
 }
 
@@ -785,6 +765,7 @@ TEST_CASE("Store Padding Frame", "[quic]")
 
 TEST_CASE("ConnectionClose Frame", "[quic]")
 {
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   uint8_t reason_phrase[]  = {0x41, 0x42, 0x43, 0x44, 0x45};
   size_t reason_phrase_len = sizeof(reason_phrase);
 
@@ -798,12 +779,11 @@ TEST_CASE("ConnectionClose Frame", "[quic]")
       0x41, 0x42, 0x43, 0x44, 0x45 // Reason Phrase ("ABCDE");
     };
 
-    std::shared_ptr<const QUICFrame> frame = QUICFrameFactory::create(buf, sizeof(buf));
+    const QUICFrame *frame = QUICFrameFactory::create(frame_buf, buf, sizeof(buf));
     CHECK(frame->type() == QUICFrameType::CONNECTION_CLOSE);
     CHECK(frame->size() == sizeof(buf));
 
-    std::shared_ptr<const QUICConnectionCloseFrame> conn_close_frame =
-      std::dynamic_pointer_cast<const QUICConnectionCloseFrame>(frame);
+    const QUICConnectionCloseFrame *conn_close_frame = static_cast<const QUICConnectionCloseFrame *>(frame);
     CHECK(conn_close_frame != nullptr);
     CHECK(conn_close_frame->error_code() == static_cast<uint16_t>(QUICTransErrorCode::PROTOCOL_VIOLATION));
     CHECK(conn_close_frame->frame_type() == QUICFrameType::UNKNOWN);
@@ -820,7 +800,7 @@ TEST_CASE("ConnectionClose Frame", "[quic]")
       0x05,       // Reason Phrase Length
     };
 
-    std::shared_ptr<const QUICFrame> frame = QUICFrameFactory::create(buf, sizeof(buf));
+    const QUICFrame *frame = QUICFrameFactory::create(frame_buf, buf, sizeof(buf));
     CHECK(frame->type() == QUICFrameType::CONNECTION_CLOSE);
     CHECK(frame->valid() == false);
   }
@@ -833,12 +813,11 @@ TEST_CASE("ConnectionClose Frame", "[quic]")
       0x04,       // Frame Type
       0x00,       // Reason Phrase Length
     };
-    std::shared_ptr<const QUICFrame> frame = QUICFrameFactory::create(buf, sizeof(buf));
+    const QUICFrame *frame = QUICFrameFactory::create(frame_buf, buf, sizeof(buf));
     CHECK(frame->type() == QUICFrameType::CONNECTION_CLOSE);
     CHECK(frame->size() == sizeof(buf));
 
-    std::shared_ptr<const QUICConnectionCloseFrame> conn_close_frame =
-      std::dynamic_pointer_cast<const QUICConnectionCloseFrame>(frame);
+    const QUICConnectionCloseFrame *conn_close_frame = static_cast<const QUICConnectionCloseFrame *>(frame);
     CHECK(conn_close_frame != nullptr);
     CHECK(conn_close_frame->error_code() == static_cast<uint16_t>(QUICTransErrorCode::PROTOCOL_VIOLATION));
     CHECK(conn_close_frame->frame_type() == QUICFrameType::RESET_STREAM);
@@ -887,16 +866,17 @@ TEST_CASE("ConnectionClose Frame", "[quic]")
 
 TEST_CASE("Load MaxData Frame", "[quic]")
 {
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   SECTION("Load")
   {
     uint8_t buf1[] = {
       0x10,                                          // Type
       0xd1, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88 // Maximum Data
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::MAX_DATA);
     CHECK(frame1->size() == 9);
-    std::shared_ptr<const QUICMaxDataFrame> max_data_frame = std::dynamic_pointer_cast<const QUICMaxDataFrame>(frame1);
+    const QUICMaxDataFrame *max_data_frame = static_cast<const QUICMaxDataFrame *>(frame1);
     CHECK(max_data_frame != nullptr);
     CHECK(max_data_frame->maximum_data() == 0x1122334455667788ULL);
   }
@@ -906,7 +886,7 @@ TEST_CASE("Load MaxData Frame", "[quic]")
     uint8_t buf1[] = {
       0x10, // Type
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::MAX_DATA);
     CHECK(frame1->valid() == false);
   }
@@ -931,6 +911,7 @@ TEST_CASE("Store MaxData Frame", "[quic]")
 
 TEST_CASE("Load MaxStreamData Frame", "[quic]")
 {
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   SECTION("Load")
   {
     uint8_t buf1[] = {
@@ -938,11 +919,10 @@ TEST_CASE("Load MaxStreamData Frame", "[quic]")
       0x81, 0x02, 0x03, 0x04,                        // Stream ID
       0xd1, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88 // Maximum Stream Data
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::MAX_STREAM_DATA);
     CHECK(frame1->size() == 13);
-    std::shared_ptr<const QUICMaxStreamDataFrame> maxStreamDataFrame1 =
-      std::dynamic_pointer_cast<const QUICMaxStreamDataFrame>(frame1);
+    const QUICMaxStreamDataFrame *maxStreamDataFrame1 = static_cast<const QUICMaxStreamDataFrame *>(frame1);
     CHECK(maxStreamDataFrame1 != nullptr);
     CHECK(maxStreamDataFrame1->stream_id() == 0x01020304);
     CHECK(maxStreamDataFrame1->maximum_stream_data() == 0x1122334455667788ULL);
@@ -954,7 +934,7 @@ TEST_CASE("Load MaxStreamData Frame", "[quic]")
       0x11,                   // Type
       0x81, 0x02, 0x03, 0x04, // Stream ID
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::MAX_STREAM_DATA);
     CHECK(frame1->valid() == false);
   }
@@ -980,16 +960,17 @@ TEST_CASE("Store MaxStreamData Frame", "[quic]")
 
 TEST_CASE("Load MaxStreams Frame", "[quic]")
 {
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   SECTION("load")
   {
     uint8_t buf1[] = {
       0x12,                   // Type
       0x81, 0x02, 0x03, 0x04, // Stream ID
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::MAX_STREAMS);
     CHECK(frame1->size() == 5);
-    std::shared_ptr<const QUICMaxStreamsFrame> max_streams_frame = std::dynamic_pointer_cast<const QUICMaxStreamsFrame>(frame1);
+    const QUICMaxStreamsFrame *max_streams_frame = static_cast<const QUICMaxStreamsFrame *>(frame1);
     CHECK(max_streams_frame != nullptr);
     CHECK(max_streams_frame->maximum_streams() == 0x01020304);
   }
@@ -998,7 +979,7 @@ TEST_CASE("Load MaxStreams Frame", "[quic]")
     uint8_t buf1[] = {
       0x12, // Type
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::MAX_STREAMS);
     CHECK(frame1->valid() == false);
   }
@@ -1023,17 +1004,17 @@ TEST_CASE("Store MaxStreams Frame", "[quic]")
 
 TEST_CASE("Load DataBlocked Frame", "[quic]")
 {
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   SECTION("load")
   {
     uint8_t buf1[] = {
       0x14, // Type
       0x07, // Offset
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::DATA_BLOCKED);
     CHECK(frame1->size() == 2);
-    std::shared_ptr<const QUICDataBlockedFrame> blocked_stream_frame =
-      std::dynamic_pointer_cast<const QUICDataBlockedFrame>(frame1);
+    const QUICDataBlockedFrame *blocked_stream_frame = static_cast<const QUICDataBlockedFrame *>(frame1);
     CHECK(blocked_stream_frame != nullptr);
     CHECK(blocked_stream_frame->offset() == 0x07);
   }
@@ -1043,7 +1024,7 @@ TEST_CASE("Load DataBlocked Frame", "[quic]")
     uint8_t buf1[] = {
       0x14, // Type
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::DATA_BLOCKED);
     CHECK(frame1->valid() == false);
   }
@@ -1068,6 +1049,7 @@ TEST_CASE("Store DataBlocked Frame", "[quic]")
 
 TEST_CASE("Load StreamDataBlocked Frame", "[quic]")
 {
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   SECTION("Load")
   {
     uint8_t buf1[] = {
@@ -1075,11 +1057,10 @@ TEST_CASE("Load StreamDataBlocked Frame", "[quic]")
       0x81, 0x02, 0x03, 0x04, // Stream ID
       0x07,                   // Offset
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::STREAM_DATA_BLOCKED);
     CHECK(frame1->size() == 6);
-    std::shared_ptr<const QUICStreamDataBlockedFrame> stream_blocked_frame =
-      std::dynamic_pointer_cast<const QUICStreamDataBlockedFrame>(frame1);
+    const QUICStreamDataBlockedFrame *stream_blocked_frame = static_cast<const QUICStreamDataBlockedFrame *>(frame1);
     CHECK(stream_blocked_frame != nullptr);
     CHECK(stream_blocked_frame->stream_id() == 0x01020304);
     CHECK(stream_blocked_frame->offset() == 0x07);
@@ -1091,7 +1072,7 @@ TEST_CASE("Load StreamDataBlocked Frame", "[quic]")
       0x15,                   // Type
       0x81, 0x02, 0x03, 0x04, // Stream ID
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::STREAM_DATA_BLOCKED);
     CHECK(frame1->valid() == false);
   }
@@ -1117,17 +1098,17 @@ TEST_CASE("Store StreamDataBlocked Frame", "[quic]")
 
 TEST_CASE("Load StreamsBlocked Frame", "[quic]")
 {
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   SECTION("Load")
   {
     uint8_t buf1[] = {
       0x16,       // Type
       0x41, 0x02, // Stream ID
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::STREAMS_BLOCKED);
     CHECK(frame1->size() == 3);
-    std::shared_ptr<const QUICStreamIdBlockedFrame> stream_id_blocked_frame =
-      std::dynamic_pointer_cast<const QUICStreamIdBlockedFrame>(frame1);
+    const QUICStreamIdBlockedFrame *stream_id_blocked_frame = static_cast<const QUICStreamIdBlockedFrame *>(frame1);
     CHECK(stream_id_blocked_frame != nullptr);
     CHECK(stream_id_blocked_frame->stream_id() == 0x0102);
   }
@@ -1137,7 +1118,7 @@ TEST_CASE("Load StreamsBlocked Frame", "[quic]")
     uint8_t buf1[] = {
       0x16, // Type
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::STREAMS_BLOCKED);
     CHECK(frame1->valid() == false);
   }
@@ -1162,6 +1143,7 @@ TEST_CASE("Store StreamsBlocked Frame", "[quic]")
 
 TEST_CASE("Load NewConnectionId Frame", "[quic]")
 {
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   SECTION("load")
   {
     uint8_t buf1[] = {
@@ -1172,11 +1154,10 @@ TEST_CASE("Load NewConnectionId Frame", "[quic]")
       0x00, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, // Stateless Reset Token
       0x80, 0x90, 0xa0, 0xb0, 0xc0, 0xd0, 0xe0, 0xf0,
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::NEW_CONNECTION_ID);
     CHECK(frame1->size() == 28);
-    std::shared_ptr<const QUICNewConnectionIdFrame> new_con_id_frame =
-      std::dynamic_pointer_cast<const QUICNewConnectionIdFrame>(frame1);
+    const QUICNewConnectionIdFrame *new_con_id_frame = static_cast<const QUICNewConnectionIdFrame *>(frame1);
     CHECK(new_con_id_frame != nullptr);
     CHECK(new_con_id_frame->sequence() == 0x0102);
     CHECK((new_con_id_frame->connection_id() ==
@@ -1193,7 +1174,7 @@ TEST_CASE("Load NewConnectionId Frame", "[quic]")
       0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, // Connection ID
       0x00, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, // Stateless Reset Token
     };
-    std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+    const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
     CHECK(frame1->type() == QUICFrameType::NEW_CONNECTION_ID);
     CHECK(frame1->valid() == false);
   }
@@ -1223,6 +1204,7 @@ TEST_CASE("Store NewConnectionId Frame", "[quic]")
 
 TEST_CASE("Load STOP_SENDING Frame", "[quic]")
 {
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   SECTION("LOAD")
   {
     uint8_t buf[] = {
@@ -1230,11 +1212,11 @@ TEST_CASE("Load STOP_SENDING Frame", "[quic]")
       0x92, 0x34, 0x56, 0x78, // Stream ID
       0x00, 0x01,             // Error Code
     };
-    std::shared_ptr<const QUICFrame> frame = QUICFrameFactory::create(buf, sizeof(buf));
+    const QUICFrame *frame = QUICFrameFactory::create(frame_buf, buf, sizeof(buf));
     CHECK(frame->type() == QUICFrameType::STOP_SENDING);
     CHECK(frame->size() == 7);
 
-    std::shared_ptr<const QUICStopSendingFrame> stop_sending_frame = std::dynamic_pointer_cast<const QUICStopSendingFrame>(frame);
+    const QUICStopSendingFrame *stop_sending_frame = static_cast<const QUICStopSendingFrame *>(frame);
     CHECK(stop_sending_frame != nullptr);
     CHECK(stop_sending_frame->stream_id() == 0x12345678);
     CHECK(stop_sending_frame->error_code() == 0x0001);
@@ -1246,7 +1228,7 @@ TEST_CASE("Load STOP_SENDING Frame", "[quic]")
       0x05,                   // Type
       0x92, 0x34, 0x56, 0x78, // Stream ID
     };
-    std::shared_ptr<const QUICFrame> frame = QUICFrameFactory::create(buf, sizeof(buf));
+    const QUICFrame *frame = QUICFrameFactory::create(frame_buf, buf, sizeof(buf));
     CHECK(frame->type() == QUICFrameType::STOP_SENDING);
     CHECK(frame->valid() == false);
   }
@@ -1272,18 +1254,18 @@ TEST_CASE("Store STOP_SENDING Frame", "[quic]")
 
 TEST_CASE("Load PATH_CHALLENGE Frame", "[quic]")
 {
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   SECTION("Load")
   {
     uint8_t buf[] = {
       0x1a,                                           // Type
       0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, // Data
     };
-    std::shared_ptr<const QUICFrame> frame = QUICFrameFactory::create(buf, sizeof(buf));
+    const QUICFrame *frame = QUICFrameFactory::create(frame_buf, buf, sizeof(buf));
     CHECK(frame->type() == QUICFrameType::PATH_CHALLENGE);
     CHECK(frame->size() == 9);
 
-    std::shared_ptr<const QUICPathChallengeFrame> path_challenge_frame =
-      std::dynamic_pointer_cast<const QUICPathChallengeFrame>(frame);
+    const QUICPathChallengeFrame *path_challenge_frame = static_cast<const QUICPathChallengeFrame *>(frame);
     CHECK(path_challenge_frame != nullptr);
     CHECK(memcmp(path_challenge_frame->data(), "\x01\x23\x45\x67\x89\xab\xcd\xef", QUICPathChallengeFrame::DATA_LEN) == 0);
   }
@@ -1294,7 +1276,7 @@ TEST_CASE("Load PATH_CHALLENGE Frame", "[quic]")
       0x1a,                                     // Type
       0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xef, // Data
     };
-    std::shared_ptr<const QUICFrame> frame = QUICFrameFactory::create(buf, sizeof(buf));
+    const QUICFrame *frame = QUICFrameFactory::create(frame_buf, buf, sizeof(buf));
     CHECK(frame->type() == QUICFrameType::PATH_CHALLENGE);
     CHECK(frame->valid() == false);
   }
@@ -1325,18 +1307,18 @@ TEST_CASE("Store PATH_CHALLENGE Frame", "[quic]")
 
 TEST_CASE("Load PATH_RESPONSE Frame", "[quic]")
 {
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   SECTION("Load")
   {
     uint8_t buf[] = {
       0x1b,                                           // Type
       0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, // Data
     };
-    std::shared_ptr<const QUICFrame> frame = QUICFrameFactory::create(buf, sizeof(buf));
+    const QUICFrame *frame = QUICFrameFactory::create(frame_buf, buf, sizeof(buf));
     CHECK(frame->type() == QUICFrameType::PATH_RESPONSE);
     CHECK(frame->size() == 9);
 
-    std::shared_ptr<const QUICPathResponseFrame> path_response_frame =
-      std::dynamic_pointer_cast<const QUICPathResponseFrame>(frame);
+    const QUICPathResponseFrame *path_response_frame = static_cast<const QUICPathResponseFrame *>(frame);
     CHECK(path_response_frame != nullptr);
     CHECK(memcmp(path_response_frame->data(), "\x01\x23\x45\x67\x89\xab\xcd\xef", QUICPathResponseFrame::DATA_LEN) == 0);
   }
@@ -1347,7 +1329,7 @@ TEST_CASE("Load PATH_RESPONSE Frame", "[quic]")
       0x1b,                                     // Type
       0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, // Data
     };
-    std::shared_ptr<const QUICFrame> frame = QUICFrameFactory::create(buf, sizeof(buf));
+    const QUICFrame *frame = QUICFrameFactory::create(frame_buf, buf, sizeof(buf));
     CHECK(frame->type() == QUICFrameType::PATH_RESPONSE);
     CHECK(frame->valid() == false);
   }
@@ -1378,6 +1360,7 @@ TEST_CASE("Store PATH_RESPONSE Frame", "[quic]")
 
 TEST_CASE("NEW_TOKEN Frame", "[quic]")
 {
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   uint8_t raw_new_token_frame[] = {
     0x07,                                           // Type
     0x08,                                           // Token Length (i)
@@ -1390,11 +1373,11 @@ TEST_CASE("NEW_TOKEN Frame", "[quic]")
 
   SECTION("load")
   {
-    std::shared_ptr<const QUICFrame> frame = QUICFrameFactory::create(raw_new_token_frame, raw_new_token_frame_len);
+    const QUICFrame *frame = QUICFrameFactory::create(frame_buf, raw_new_token_frame, raw_new_token_frame_len);
     CHECK(frame->type() == QUICFrameType::NEW_TOKEN);
     CHECK(frame->size() == raw_new_token_frame_len);
 
-    std::shared_ptr<const QUICNewTokenFrame> new_token_frame = std::dynamic_pointer_cast<const QUICNewTokenFrame>(frame);
+    const QUICNewTokenFrame *new_token_frame = static_cast<const QUICNewTokenFrame *>(frame);
     CHECK(new_token_frame != nullptr);
     CHECK(new_token_frame->token_length() == raw_token_len);
     CHECK(memcmp(new_token_frame->token(), raw_token, raw_token_len) == 0);
@@ -1402,7 +1385,7 @@ TEST_CASE("NEW_TOKEN Frame", "[quic]")
 
   SECTION("bad load")
   {
-    std::shared_ptr<const QUICFrame> frame = QUICFrameFactory::create(raw_new_token_frame, raw_new_token_frame_len - 5);
+    const QUICFrame *frame = QUICFrameFactory::create(frame_buf, raw_new_token_frame, raw_new_token_frame_len - 5);
     CHECK(frame->type() == QUICFrameType::NEW_TOKEN);
     CHECK(frame->valid() == false);
   }
@@ -1426,6 +1409,7 @@ TEST_CASE("NEW_TOKEN Frame", "[quic]")
 
 TEST_CASE("RETIRE_CONNECTION_ID Frame", "[quic]")
 {
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   uint8_t raw_retire_connection_id_frame[] = {
     0x19, // Type
     0x08, // Sequence Number (i)
@@ -1435,21 +1419,20 @@ TEST_CASE("RETIRE_CONNECTION_ID Frame", "[quic]")
 
   SECTION("load")
   {
-    std::shared_ptr<const QUICFrame> frame =
-      QUICFrameFactory::create(raw_retire_connection_id_frame, raw_retire_connection_id_frame_len);
+    const QUICFrame *frame =
+      QUICFrameFactory::create(frame_buf, raw_retire_connection_id_frame, raw_retire_connection_id_frame_len);
     CHECK(frame->type() == QUICFrameType::RETIRE_CONNECTION_ID);
     CHECK(frame->size() == raw_retire_connection_id_frame_len);
 
-    std::shared_ptr<const QUICRetireConnectionIdFrame> retire_connection_id_frame =
-      std::dynamic_pointer_cast<const QUICRetireConnectionIdFrame>(frame);
+    const QUICRetireConnectionIdFrame *retire_connection_id_frame = static_cast<const QUICRetireConnectionIdFrame *>(frame);
     CHECK(retire_connection_id_frame != nullptr);
     CHECK(retire_connection_id_frame->seq_num() == seq_num);
   }
 
   SECTION("bad load")
   {
-    std::shared_ptr<const QUICFrame> frame =
-      QUICFrameFactory::create(raw_retire_connection_id_frame, raw_retire_connection_id_frame_len - 1);
+    const QUICFrame *frame =
+      QUICFrameFactory::create(frame_buf, raw_retire_connection_id_frame, raw_retire_connection_id_frame_len - 1);
     CHECK(frame->type() == QUICFrameType::RETIRE_CONNECTION_ID);
     CHECK(frame->valid() == false);
   }
@@ -1470,10 +1453,11 @@ TEST_CASE("RETIRE_CONNECTION_ID Frame", "[quic]")
 
 TEST_CASE("QUICFrameFactory Create Unknown Frame", "[quic]")
 {
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   uint8_t buf1[] = {
     0x20, // Type
   };
-  std::shared_ptr<const QUICFrame> frame1 = QUICFrameFactory::create(buf1, sizeof(buf1));
+  const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
   CHECK(frame1 == nullptr);
 }
 
@@ -1489,21 +1473,19 @@ TEST_CASE("QUICFrameFactory Fast Create Frame", "[quic]")
     0x12,                   // Type
     0x85, 0x06, 0x07, 0x08, // Stream Data
   };
-  std::shared_ptr<const QUICFrame> frame1 = factory.fast_create(buf1, sizeof(buf1));
-  CHECK(frame1 != nullptr);
+  const QUICFrame &frame1 = factory.fast_create(buf1, sizeof(buf1));
+  CHECK(frame1.type() == QUICFrameType::MAX_STREAMS);
 
-  std::shared_ptr<const QUICMaxStreamsFrame> max_streams_frame1 = std::dynamic_pointer_cast<const QUICMaxStreamsFrame>(frame1);
-  CHECK(max_streams_frame1 != nullptr);
-  CHECK(max_streams_frame1->maximum_streams() == 0x01020304);
+  const QUICMaxStreamsFrame &max_streams_frame1 = static_cast<const QUICMaxStreamsFrame &>(frame1);
+  CHECK(max_streams_frame1.maximum_streams() == 0x01020304);
 
-  std::shared_ptr<const QUICFrame> frame2 = factory.fast_create(buf2, sizeof(buf2));
-  CHECK(frame2 != nullptr);
+  const QUICFrame &frame2 = factory.fast_create(buf2, sizeof(buf2));
+  CHECK(frame2.type() == QUICFrameType::MAX_STREAMS);
 
-  std::shared_ptr<const QUICMaxStreamsFrame> max_streams_frame2 = std::dynamic_pointer_cast<const QUICMaxStreamsFrame>(frame2);
-  CHECK(max_streams_frame2 != nullptr);
-  CHECK(max_streams_frame2->maximum_streams() == 0x05060708);
+  const QUICMaxStreamsFrame &max_streams_frame2 = static_cast<const QUICMaxStreamsFrame &>(frame2);
+  CHECK(max_streams_frame2.maximum_streams() == 0x05060708);
 
-  CHECK(frame1 == frame2);
+  CHECK(&frame1 == &frame2);
 }
 
 TEST_CASE("QUICFrameFactory Fast Create Unknown Frame", "[quic]")
@@ -1513,23 +1495,23 @@ TEST_CASE("QUICFrameFactory Fast Create Unknown Frame", "[quic]")
   uint8_t buf1[] = {
     0x20, // Type
   };
-  std::shared_ptr<const QUICFrame> frame1 = factory.fast_create(buf1, sizeof(buf1));
-  CHECK(frame1 == nullptr);
+  const QUICFrame &frame1 = factory.fast_create(buf1, sizeof(buf1));
+  CHECK(frame1.type() == QUICFrameType::UNKNOWN);
 }
 
 TEST_CASE("QUICFrameFactory Create CONNECTION_CLOSE with a QUICConnectionError", "[quic]")
 {
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
+
   std::unique_ptr<QUICConnectionError> error =
     std::unique_ptr<QUICConnectionError>(new QUICConnectionError(QUICTransErrorCode::INTERNAL_ERROR));
-  std::unique_ptr<QUICConnectionCloseFrame, QUICFrameDeleterFunc> connection_close_frame1 =
-    QUICFrameFactory::create_connection_close_frame(*error);
+  const QUICConnectionCloseFrame *connection_close_frame1 = QUICFrameFactory::create_connection_close_frame(frame_buf, *error);
   CHECK(connection_close_frame1->error_code() == static_cast<uint16_t>(QUICTransErrorCode::INTERNAL_ERROR));
   CHECK(connection_close_frame1->reason_phrase_length() == 0);
   CHECK(connection_close_frame1->reason_phrase() == nullptr);
 
   error = std::unique_ptr<QUICConnectionError>(new QUICConnectionError(QUICTransErrorCode::INTERNAL_ERROR, "test"));
-  std::unique_ptr<QUICConnectionCloseFrame, QUICFrameDeleterFunc> connection_close_frame2 =
-    QUICFrameFactory::create_connection_close_frame(*error);
+  const QUICConnectionCloseFrame *connection_close_frame2 = QUICFrameFactory::create_connection_close_frame(frame_buf, *error);
   CHECK(connection_close_frame2->error_code() == static_cast<uint16_t>(QUICTransErrorCode::INTERNAL_ERROR));
   CHECK(connection_close_frame2->reason_phrase_length() == 4);
   CHECK(memcmp(connection_close_frame2->reason_phrase(), "test", 4) == 0);
@@ -1537,12 +1519,13 @@ TEST_CASE("QUICFrameFactory Create CONNECTION_CLOSE with a QUICConnectionError",
 
 TEST_CASE("QUICFrameFactory Create RESET_STREAM with a QUICStreamError", "[quic]")
 {
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   MockQUICRTTProvider mock_rtt;
   MockQUICConnection mock_connection;
   QUICStream stream(&mock_rtt, &mock_connection, 0x1234, 0, 0);
   std::unique_ptr<QUICStreamError> error =
     std::unique_ptr<QUICStreamError>(new QUICStreamError(&stream, static_cast<QUICAppErrorCode>(0x01)));
-  std::unique_ptr<QUICRstStreamFrame, QUICFrameDeleterFunc> rst_stream_frame1 = QUICFrameFactory::create_rst_stream_frame(*error);
+  const QUICRstStreamFrame *rst_stream_frame1 = QUICFrameFactory::create_rst_stream_frame(frame_buf, *error);
   CHECK(rst_stream_frame1->error_code() == 0x01);
   CHECK(rst_stream_frame1->stream_id() == 0x1234);
   CHECK(rst_stream_frame1->final_offset() == 0);

--- a/iocore/net/quic/test/test_QUICFrameRetransmitter.cc
+++ b/iocore/net/quic/test/test_QUICFrameRetransmitter.cc
@@ -36,7 +36,8 @@ TEST_CASE("QUICFrameRetransmitter ignore frame which can not be retranmistted", 
   info->level                   = QUICEncryptionLevel::NONE;
 
   retransmitter.save_frame_info(std::move(info));
-  CHECK(retransmitter.create_retransmitted_frame(QUICEncryptionLevel::INITIAL, UINT16_MAX) == nullptr);
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  CHECK(retransmitter.create_retransmitted_frame(frame_buf, QUICEncryptionLevel::INITIAL, UINT16_MAX) == nullptr);
 }
 
 // TEST_CASE("QUICFrameRetransmitter ignore frame which can not be split", "[quic]")
@@ -58,7 +59,8 @@ TEST_CASE("QUICFrameRetransmitter ignore frame which has wrong level", "[quic]")
   info->level                   = QUICEncryptionLevel::HANDSHAKE;
 
   retransmitter.save_frame_info(std::move(info));
-  CHECK(retransmitter.create_retransmitted_frame(QUICEncryptionLevel::INITIAL, UINT16_MAX) == nullptr);
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  CHECK(retransmitter.create_retransmitted_frame(frame_buf, QUICEncryptionLevel::INITIAL, UINT16_MAX) == nullptr);
 }
 
 TEST_CASE("QUICFrameRetransmitter successfully create retransmitted frame", "[quic]")
@@ -80,7 +82,8 @@ TEST_CASE("QUICFrameRetransmitter successfully create retransmitted frame", "[qu
 
   retransmitter.save_frame_info(std::move(info));
 
-  auto frame = retransmitter.create_retransmitted_frame(QUICEncryptionLevel::INITIAL, UINT16_MAX);
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  auto frame = retransmitter.create_retransmitted_frame(frame_buf, QUICEncryptionLevel::INITIAL, UINT16_MAX);
   CHECK(frame != nullptr);
   CHECK(frame->type() == QUICFrameType::STREAM);
 }
@@ -106,15 +109,17 @@ TEST_CASE("QUICFrameRetransmitter successfully create stream frame", "[quic]")
   retransmitter.save_frame_info(std::move(info));
   CHECK(block->refcount() == 2); // block's refcount doesn't change
 
-  auto frame = retransmitter.create_retransmitted_frame(QUICEncryptionLevel::INITIAL, UINT16_MAX);
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  auto frame = retransmitter.create_retransmitted_frame(frame_buf, QUICEncryptionLevel::INITIAL, UINT16_MAX);
   CHECK(frame != nullptr);
   CHECK(frame->type() == QUICFrameType::STREAM);
-  auto stream_frame = static_cast<QUICStreamFrame *>(frame.get());
+  auto stream_frame = static_cast<QUICStreamFrame *>(frame);
   CHECK(stream_frame->stream_id() == 0x12345);
   CHECK(stream_frame->offset() == 0x67890);
   CHECK(stream_frame->data_length() == sizeof(data));
   CHECK(memcmp(stream_frame->data()->start(), data, sizeof(data)) == 0);
-  frame = QUICFrameFactory::create_null_frame();
+  std::destroy_at(frame);
+  frame = nullptr;
   // Becasue the info has been released, the refcount should be 1 (var block).
   CHECK(block->refcount() == 1);
 }
@@ -139,10 +144,11 @@ TEST_CASE("QUICFrameRetransmitter successfully split stream frame", "[quic]")
 
   retransmitter.save_frame_info(std::move(info));
 
-  auto frame = retransmitter.create_retransmitted_frame(QUICEncryptionLevel::INITIAL, 25);
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  auto frame = retransmitter.create_retransmitted_frame(frame_buf, QUICEncryptionLevel::INITIAL, 25);
   CHECK(frame != nullptr);
   CHECK(frame->type() == QUICFrameType::STREAM);
-  auto stream_frame = static_cast<QUICStreamFrame *>(frame.get());
+  auto stream_frame = static_cast<QUICStreamFrame *>(frame);
   CHECK(stream_frame->stream_id() == 0x12345);
   CHECK(stream_frame->offset() == 0x67890);
   CHECK(stream_frame->size() <= 25);
@@ -153,22 +159,24 @@ TEST_CASE("QUICFrameRetransmitter successfully split stream frame", "[quic]")
   CHECK(block->data->refcount() == 2);
   // one for var block, one for the left data which saved in retransmitter, one for var frame
   CHECK(block->refcount() == 2);
-  frame = QUICFrameFactory::create_null_frame();
+  std::destroy_at(frame);
+  frame = nullptr;
   // one for var block, one for var info
   CHECK(block->refcount() == 2);
   CHECK(block->data->refcount() == 1);
 
-  frame = retransmitter.create_retransmitted_frame(QUICEncryptionLevel::INITIAL, UINT16_MAX);
+  frame = retransmitter.create_retransmitted_frame(frame_buf, QUICEncryptionLevel::INITIAL, UINT16_MAX);
   CHECK(frame != nullptr);
   CHECK(frame->type() == QUICFrameType::STREAM);
-  stream_frame = static_cast<QUICStreamFrame *>(frame.get());
+  stream_frame = static_cast<QUICStreamFrame *>(frame);
   CHECK(stream_frame->stream_id() == 0x12345);
   CHECK(stream_frame->offset() == 0x67890 + size);
   CHECK(stream_frame->data_length() == sizeof(data) - size);
   CHECK(memcmp(stream_frame->data()->start(), data + size, stream_frame->data_length()) == 0);
   CHECK(block->refcount() == 1); // one for var block
 
-  frame = QUICFrameFactory::create_null_frame();
+  std::destroy_at(frame);
+  frame = nullptr;
   CHECK(block->refcount() == 1);
   CHECK(block->data->refcount() == 1);
 }
@@ -192,10 +200,11 @@ TEST_CASE("QUICFrameRetransmitter successfully split crypto frame", "[quic]")
 
   retransmitter.save_frame_info(std::move(info));
 
-  auto frame = retransmitter.create_retransmitted_frame(QUICEncryptionLevel::INITIAL, 25);
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  auto frame = retransmitter.create_retransmitted_frame(frame_buf, QUICEncryptionLevel::INITIAL, 25);
   CHECK(frame != nullptr);
   CHECK(frame->type() == QUICFrameType::CRYPTO);
-  auto crypto_frame = static_cast<QUICCryptoFrame *>(frame.get());
+  auto crypto_frame = static_cast<QUICCryptoFrame *>(frame);
   CHECK(crypto_frame->offset() == 0x67890);
   CHECK(crypto_frame->size() <= 25);
 
@@ -205,21 +214,23 @@ TEST_CASE("QUICFrameRetransmitter successfully split crypto frame", "[quic]")
   CHECK(block->data->refcount() == 2);
   // one for var block, one for the left data which saved in retransmitter, one for var frame
   CHECK(block->refcount() == 2);
-  frame = QUICFrameFactory::create_null_frame();
+  std::destroy_at(frame);
+  frame = nullptr;
   // one for var block, one for var info
   CHECK(block->refcount() == 2);
   CHECK(block->data->refcount() == 1);
 
-  frame = retransmitter.create_retransmitted_frame(QUICEncryptionLevel::INITIAL, UINT16_MAX);
+  frame = retransmitter.create_retransmitted_frame(frame_buf, QUICEncryptionLevel::INITIAL, UINT16_MAX);
   CHECK(frame != nullptr);
   CHECK(frame->type() == QUICFrameType::CRYPTO);
-  crypto_frame = static_cast<QUICCryptoFrame *>(frame.get());
+  crypto_frame = static_cast<QUICCryptoFrame *>(frame);
   CHECK(crypto_frame->offset() == 0x67890 + size);
   CHECK(crypto_frame->data_length() == sizeof(data) - size);
   CHECK(memcmp(crypto_frame->data()->start(), data + size, crypto_frame->data_length()) == 0);
   CHECK(block->refcount() == 1); // one for var block
 
-  frame = QUICFrameFactory::create_null_frame();
+  std::destroy_at(frame);
+  frame = nullptr;
   CHECK(block->refcount() == 1);
   CHECK(block->data->refcount() == 1);
 }
@@ -245,10 +256,11 @@ TEST_CASE("QUICFrameRetransmitter successfully split stream frame with fin flag"
 
   retransmitter.save_frame_info(std::move(info));
 
-  auto frame = retransmitter.create_retransmitted_frame(QUICEncryptionLevel::INITIAL, 25);
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  auto frame = retransmitter.create_retransmitted_frame(frame_buf, QUICEncryptionLevel::INITIAL, 25);
   CHECK(frame != nullptr);
   CHECK(frame->type() == QUICFrameType::STREAM);
-  auto stream_frame = static_cast<QUICStreamFrame *>(frame.get());
+  auto stream_frame = static_cast<QUICStreamFrame *>(frame);
   CHECK(stream_frame->stream_id() == 0x12345);
   CHECK(stream_frame->offset() == 0x67890);
   CHECK(stream_frame->size() <= 25);
@@ -260,15 +272,16 @@ TEST_CASE("QUICFrameRetransmitter successfully split stream frame with fin flag"
   CHECK(block->data->refcount() == 2);
   // one for var block, one for the left data which saved in retransmitter, one for var frame
   CHECK(block->refcount() == 2);
-  frame = QUICFrameFactory::create_null_frame();
+  std::destroy_at(frame);
+  frame = nullptr;
   // one for var block, one for var info
   CHECK(block->refcount() == 2);
   CHECK(block->data->refcount() == 1);
 
-  frame = retransmitter.create_retransmitted_frame(QUICEncryptionLevel::INITIAL, UINT16_MAX);
+  frame = retransmitter.create_retransmitted_frame(frame_buf, QUICEncryptionLevel::INITIAL, UINT16_MAX);
   CHECK(frame != nullptr);
   CHECK(frame->type() == QUICFrameType::STREAM);
-  stream_frame = static_cast<QUICStreamFrame *>(frame.get());
+  stream_frame = static_cast<QUICStreamFrame *>(frame);
   CHECK(stream_frame->stream_id() == 0x12345);
   CHECK(stream_frame->offset() == 0x67890 + size);
   CHECK(stream_frame->data_length() == sizeof(data) - size);
@@ -276,7 +289,8 @@ TEST_CASE("QUICFrameRetransmitter successfully split stream frame with fin flag"
   CHECK(block->refcount() == 1); // one for var block
   CHECK(stream_frame->has_fin_flag() == true);
 
-  frame = QUICFrameFactory::create_null_frame();
+  std::destroy_at(frame);
+  frame = nullptr;
   CHECK(block->refcount() == 1);
   CHECK(block->data->refcount() == 1);
 }

--- a/iocore/net/quic/test/test_QUICIncomingFrameBuffer.cc
+++ b/iocore/net/quic/test/test_QUICIncomingFrameBuffer.cc
@@ -29,6 +29,7 @@
 
 TEST_CASE("QUICIncomingStreamFrameBuffer_fin_offset", "[quic]")
 {
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   QUICStream *stream = new QUICStream();
   QUICIncomingStreamFrameBuffer buffer;
   QUICErrorUPtr err = nullptr;
@@ -44,7 +45,7 @@ TEST_CASE("QUICIncomingStreamFrameBuffer_fin_offset", "[quic]")
 
   SECTION("single frame")
   {
-    std::shared_ptr<QUICStreamFrame> stream1_frame_0_r = QUICFrameFactory::create_stream_frame(block_1024, 1, 0, true);
+    QUICStreamFrame *stream1_frame_0_r = QUICFrameFactory::create_stream_frame(frame_buf, block_1024, 1, 0, true);
 
     err = buffer.insert(*stream1_frame_0_r);
     CHECK(err == nullptr);
@@ -52,11 +53,16 @@ TEST_CASE("QUICIncomingStreamFrameBuffer_fin_offset", "[quic]")
 
   SECTION("multiple frames")
   {
-    std::shared_ptr<QUICStreamFrame> stream1_frame_0_r = QUICFrameFactory::create_stream_frame(block_1024, 1, 0);
-    std::shared_ptr<QUICStreamFrame> stream1_frame_1_r = QUICFrameFactory::create_stream_frame(block_1024, 1, 1024);
-    std::shared_ptr<QUICStreamFrame> stream1_frame_2_r = QUICFrameFactory::create_stream_frame(block_1024, 1, 2048, true);
-    std::shared_ptr<QUICStreamFrame> stream1_frame_3_r = QUICFrameFactory::create_stream_frame(block_1024, 1, 3072, true);
-    std::shared_ptr<QUICStreamFrame> stream1_frame_4_r = QUICFrameFactory::create_stream_frame(block_1024, 1, 4096);
+    uint8_t frame_buf0[QUICFrame::MAX_INSTANCE_SIZE];
+    uint8_t frame_buf1[QUICFrame::MAX_INSTANCE_SIZE];
+    uint8_t frame_buf2[QUICFrame::MAX_INSTANCE_SIZE];
+    uint8_t frame_buf3[QUICFrame::MAX_INSTANCE_SIZE];
+    uint8_t frame_buf4[QUICFrame::MAX_INSTANCE_SIZE];
+    QUICStreamFrame *stream1_frame_0_r = QUICFrameFactory::create_stream_frame(frame_buf0, block_1024, 1, 0);
+    QUICStreamFrame *stream1_frame_1_r = QUICFrameFactory::create_stream_frame(frame_buf1, block_1024, 1, 1024);
+    QUICStreamFrame *stream1_frame_2_r = QUICFrameFactory::create_stream_frame(frame_buf2, block_1024, 1, 2048, true);
+    QUICStreamFrame *stream1_frame_3_r = QUICFrameFactory::create_stream_frame(frame_buf3, block_1024, 1, 3072, true);
+    QUICStreamFrame *stream1_frame_4_r = QUICFrameFactory::create_stream_frame(frame_buf4, block_1024, 1, 4096);
 
     buffer.insert(*stream1_frame_0_r);
     buffer.insert(*stream1_frame_1_r);
@@ -84,9 +90,12 @@ TEST_CASE("QUICIncomingStreamFrameBuffer_fin_offset", "[quic]")
 
   SECTION("Pure FIN")
   {
-    std::shared_ptr<QUICStreamFrame> stream1_frame_0_r      = QUICFrameFactory::create_stream_frame(block_1024, 1, 0);
-    std::shared_ptr<QUICStreamFrame> stream1_frame_empty    = QUICFrameFactory::create_stream_frame(block_0, 1, 1024);
-    std::shared_ptr<QUICStreamFrame> stream1_frame_pure_fin = QUICFrameFactory::create_stream_frame(block_0, 1, 1024, true);
+    uint8_t frame_buf0[QUICFrame::MAX_INSTANCE_SIZE];
+    uint8_t frame_buf1[QUICFrame::MAX_INSTANCE_SIZE];
+    uint8_t frame_buf2[QUICFrame::MAX_INSTANCE_SIZE];
+    QUICStreamFrame *stream1_frame_0_r      = QUICFrameFactory::create_stream_frame(frame_buf0, block_1024, 1, 0);
+    QUICStreamFrame *stream1_frame_empty    = QUICFrameFactory::create_stream_frame(frame_buf1, block_0, 1, 1024);
+    QUICStreamFrame *stream1_frame_pure_fin = QUICFrameFactory::create_stream_frame(frame_buf2, block_0, 1, 1024, true);
 
     err = buffer.insert(*stream1_frame_0_r);
     CHECK(err == nullptr);
@@ -116,12 +125,19 @@ TEST_CASE("QUICIncomingStreamFrameBuffer_pop", "[quic]")
   block_0->alloc();
   CHECK(block_0->read_avail() == 0);
 
-  std::shared_ptr<QUICStreamFrame> stream1_frame_0_r   = QUICFrameFactory::create_stream_frame(block_1024, 1, 0);
-  std::shared_ptr<QUICStreamFrame> stream1_frame_1_r   = QUICFrameFactory::create_stream_frame(block_1024, 1, 1024);
-  std::shared_ptr<QUICStreamFrame> stream1_frame_empty = QUICFrameFactory::create_stream_frame(block_0, 1, 2048);
-  std::shared_ptr<QUICStreamFrame> stream1_frame_2_r   = QUICFrameFactory::create_stream_frame(block_1024, 1, 2048);
-  std::shared_ptr<QUICStreamFrame> stream1_frame_3_r   = QUICFrameFactory::create_stream_frame(block_1024, 1, 3072);
-  std::shared_ptr<QUICStreamFrame> stream1_frame_4_r   = QUICFrameFactory::create_stream_frame(block_1024, 1, 4096, true);
+  uint8_t frame_buf0[QUICFrame::MAX_INSTANCE_SIZE];
+  uint8_t frame_buf1[QUICFrame::MAX_INSTANCE_SIZE];
+  uint8_t frame_buf2[QUICFrame::MAX_INSTANCE_SIZE];
+  uint8_t frame_buf3[QUICFrame::MAX_INSTANCE_SIZE];
+  uint8_t frame_buf4[QUICFrame::MAX_INSTANCE_SIZE];
+  uint8_t frame_buf5[QUICFrame::MAX_INSTANCE_SIZE];
+  uint8_t frame_buf6[QUICFrame::MAX_INSTANCE_SIZE];
+  QUICStreamFrame *stream1_frame_0_r   = QUICFrameFactory::create_stream_frame(frame_buf0, block_1024, 1, 0);
+  QUICStreamFrame *stream1_frame_1_r   = QUICFrameFactory::create_stream_frame(frame_buf1, block_1024, 1, 1024);
+  QUICStreamFrame *stream1_frame_empty = QUICFrameFactory::create_stream_frame(frame_buf2, block_0, 1, 2048);
+  QUICStreamFrame *stream1_frame_2_r   = QUICFrameFactory::create_stream_frame(frame_buf3, block_1024, 1, 2048);
+  QUICStreamFrame *stream1_frame_3_r   = QUICFrameFactory::create_stream_frame(frame_buf4, block_1024, 1, 3072);
+  QUICStreamFrame *stream1_frame_4_r   = QUICFrameFactory::create_stream_frame(frame_buf5, block_1024, 1, 4096, true);
 
   buffer.insert(*stream1_frame_0_r);
   buffer.insert(*stream1_frame_1_r);
@@ -131,15 +147,15 @@ TEST_CASE("QUICIncomingStreamFrameBuffer_pop", "[quic]")
   buffer.insert(*stream1_frame_4_r);
   CHECK(!buffer.empty());
 
-  auto frame = std::static_pointer_cast<const QUICStreamFrame>(buffer.pop());
+  auto frame = static_cast<const QUICStreamFrame *>(buffer.pop());
   CHECK(frame->offset() == 0);
-  frame = std::static_pointer_cast<const QUICStreamFrame>(buffer.pop());
+  frame = static_cast<const QUICStreamFrame *>(buffer.pop());
   CHECK(frame->offset() == 1024);
-  frame = std::static_pointer_cast<const QUICStreamFrame>(buffer.pop());
+  frame = static_cast<const QUICStreamFrame *>(buffer.pop());
   CHECK(frame->offset() == 2048);
-  frame = std::static_pointer_cast<const QUICStreamFrame>(buffer.pop());
+  frame = static_cast<const QUICStreamFrame *>(buffer.pop());
   CHECK(frame->offset() == 3072);
-  frame = std::static_pointer_cast<const QUICStreamFrame>(buffer.pop());
+  frame = static_cast<const QUICStreamFrame *>(buffer.pop());
   CHECK(frame->offset() == 4096);
   CHECK(buffer.empty());
 
@@ -152,15 +168,15 @@ TEST_CASE("QUICIncomingStreamFrameBuffer_pop", "[quic]")
   buffer.insert(*stream1_frame_0_r);
   CHECK(!buffer.empty());
 
-  frame = std::static_pointer_cast<const QUICStreamFrame>(buffer.pop());
+  frame = static_cast<const QUICStreamFrame *>(buffer.pop());
   CHECK(frame->offset() == 0);
-  frame = std::static_pointer_cast<const QUICStreamFrame>(buffer.pop());
+  frame = static_cast<const QUICStreamFrame *>(buffer.pop());
   CHECK(frame->offset() == 1024);
-  frame = std::static_pointer_cast<const QUICStreamFrame>(buffer.pop());
+  frame = static_cast<const QUICStreamFrame *>(buffer.pop());
   CHECK(frame->offset() == 2048);
-  frame = std::static_pointer_cast<const QUICStreamFrame>(buffer.pop());
+  frame = static_cast<const QUICStreamFrame *>(buffer.pop());
   CHECK(frame->offset() == 3072);
-  frame = std::static_pointer_cast<const QUICStreamFrame>(buffer.pop());
+  frame = static_cast<const QUICStreamFrame *>(buffer.pop());
   CHECK(frame->offset() == 4096);
   CHECK(buffer.empty());
 
@@ -182,10 +198,18 @@ TEST_CASE("QUICIncomingStreamFrameBuffer_dup_frame", "[quic]")
   block_0->alloc();
   CHECK(block_0->read_avail() == 0);
 
-  std::shared_ptr<QUICStreamFrame> stream1_frame_0_r = QUICFrameFactory::create_stream_frame(block_1024, 1, 0);
-  std::shared_ptr<QUICStreamFrame> stream1_frame_1_r = QUICFrameFactory::create_stream_frame(block_1024, 1, 1024);
-  std::shared_ptr<QUICStreamFrame> stream1_frame_2_r = QUICFrameFactory::create_stream_frame(block_1024, 1, 2048, true);
-  std::shared_ptr<QUICStreamFrame> stream1_frame_3_r = QUICFrameFactory::create_stream_frame(block_1024, 1, 2048, true);
+  uint8_t frame_buf0[QUICFrame::MAX_INSTANCE_SIZE];
+  uint8_t frame_buf1[QUICFrame::MAX_INSTANCE_SIZE];
+  uint8_t frame_buf2[QUICFrame::MAX_INSTANCE_SIZE];
+  uint8_t frame_buf3[QUICFrame::MAX_INSTANCE_SIZE];
+  uint8_t frame_buf4[QUICFrame::MAX_INSTANCE_SIZE];
+  uint8_t frame_buf5[QUICFrame::MAX_INSTANCE_SIZE];
+  uint8_t frame_buf6[QUICFrame::MAX_INSTANCE_SIZE];
+  uint8_t frame_buf7[QUICFrame::MAX_INSTANCE_SIZE];
+  QUICStreamFrame *stream1_frame_0_r = QUICFrameFactory::create_stream_frame(frame_buf0, block_1024, 1, 0);
+  QUICStreamFrame *stream1_frame_1_r = QUICFrameFactory::create_stream_frame(frame_buf1, block_1024, 1, 1024);
+  QUICStreamFrame *stream1_frame_2_r = QUICFrameFactory::create_stream_frame(frame_buf2, block_1024, 1, 2048, true);
+  QUICStreamFrame *stream1_frame_3_r = QUICFrameFactory::create_stream_frame(frame_buf3, block_1024, 1, 2048, true);
 
   buffer.insert(*stream1_frame_0_r);
   buffer.insert(*stream1_frame_1_r);
@@ -193,22 +217,22 @@ TEST_CASE("QUICIncomingStreamFrameBuffer_dup_frame", "[quic]")
   err = buffer.insert(*stream1_frame_3_r);
   CHECK(err == nullptr);
 
-  auto frame = std::static_pointer_cast<const QUICStreamFrame>(buffer.pop());
+  auto frame = static_cast<const QUICStreamFrame *>(buffer.pop());
   CHECK(frame->offset() == 0);
-  frame = std::static_pointer_cast<const QUICStreamFrame>(buffer.pop());
+  frame = static_cast<const QUICStreamFrame *>(buffer.pop());
   CHECK(frame->offset() == 1024);
-  frame = std::static_pointer_cast<const QUICStreamFrame>(buffer.pop());
+  frame = static_cast<const QUICStreamFrame *>(buffer.pop());
   CHECK(frame->offset() == 2048);
-  frame = std::static_pointer_cast<const QUICStreamFrame>(buffer.pop());
+  frame = static_cast<const QUICStreamFrame *>(buffer.pop());
   CHECK(frame == nullptr);
   CHECK(buffer.empty());
 
   buffer.clear();
 
-  std::shared_ptr<QUICStreamFrame> stream2_frame_0_r = QUICFrameFactory::create_stream_frame(block_1024, 1, 0);
-  std::shared_ptr<QUICStreamFrame> stream2_frame_1_r = QUICFrameFactory::create_stream_frame(block_1024, 1, 1024);
-  std::shared_ptr<QUICStreamFrame> stream2_frame_2_r = QUICFrameFactory::create_stream_frame(block_1024, 1, 1024);
-  std::shared_ptr<QUICStreamFrame> stream2_frame_3_r = QUICFrameFactory::create_stream_frame(block_1024, 1, 2048, true);
+  QUICStreamFrame *stream2_frame_0_r = QUICFrameFactory::create_stream_frame(frame_buf4, block_1024, 1, 0);
+  QUICStreamFrame *stream2_frame_1_r = QUICFrameFactory::create_stream_frame(frame_buf5, block_1024, 1, 1024);
+  QUICStreamFrame *stream2_frame_2_r = QUICFrameFactory::create_stream_frame(frame_buf6, block_1024, 1, 1024);
+  QUICStreamFrame *stream2_frame_3_r = QUICFrameFactory::create_stream_frame(frame_buf7, block_1024, 1, 2048, true);
 
   buffer.insert(*stream2_frame_0_r);
   buffer.insert(*stream2_frame_1_r);
@@ -216,13 +240,13 @@ TEST_CASE("QUICIncomingStreamFrameBuffer_dup_frame", "[quic]")
   err = buffer.insert(*stream2_frame_3_r);
   CHECK(err == nullptr);
 
-  frame = std::static_pointer_cast<const QUICStreamFrame>(buffer.pop());
+  frame = static_cast<const QUICStreamFrame *>(buffer.pop());
   CHECK(frame->offset() == 0);
-  frame = std::static_pointer_cast<const QUICStreamFrame>(buffer.pop());
+  frame = static_cast<const QUICStreamFrame *>(buffer.pop());
   CHECK(frame->offset() == 1024);
-  frame = std::static_pointer_cast<const QUICStreamFrame>(buffer.pop());
+  frame = static_cast<const QUICStreamFrame *>(buffer.pop());
   CHECK(frame->offset() == 2048);
-  frame = std::static_pointer_cast<const QUICStreamFrame>(buffer.pop());
+  frame = static_cast<const QUICStreamFrame *>(buffer.pop());
   CHECK(frame == nullptr);
   CHECK(buffer.empty());
 

--- a/iocore/net/quic/test/test_QUICIncomingFrameBuffer.cc
+++ b/iocore/net/quic/test/test_QUICIncomingFrameBuffer.cc
@@ -47,8 +47,10 @@ TEST_CASE("QUICIncomingStreamFrameBuffer_fin_offset", "[quic]")
   {
     QUICStreamFrame *stream1_frame_0_r = QUICFrameFactory::create_stream_frame(frame_buf, block_1024, 1, 0, true);
 
-    err = buffer.insert(*stream1_frame_0_r);
+    err = buffer.insert(new QUICStreamFrame(*stream1_frame_0_r));
     CHECK(err == nullptr);
+
+    buffer.clear();
   }
 
   SECTION("multiple frames")
@@ -64,28 +66,34 @@ TEST_CASE("QUICIncomingStreamFrameBuffer_fin_offset", "[quic]")
     QUICStreamFrame *stream1_frame_3_r = QUICFrameFactory::create_stream_frame(frame_buf3, block_1024, 1, 3072, true);
     QUICStreamFrame *stream1_frame_4_r = QUICFrameFactory::create_stream_frame(frame_buf4, block_1024, 1, 4096);
 
-    buffer.insert(*stream1_frame_0_r);
-    buffer.insert(*stream1_frame_1_r);
-    buffer.insert(*stream1_frame_2_r);
-    err = buffer.insert(*stream1_frame_3_r);
+    buffer.insert(new QUICStreamFrame(*stream1_frame_0_r));
+    buffer.insert(new QUICStreamFrame(*stream1_frame_1_r));
+    buffer.insert(new QUICStreamFrame(*stream1_frame_2_r));
+    err = buffer.insert(new QUICStreamFrame(*stream1_frame_3_r));
     CHECK(err->cls == QUICErrorClass::TRANSPORT);
     CHECK(err->code == static_cast<uint16_t>(QUICTransErrorCode::FINAL_OFFSET_ERROR));
+
+    buffer.clear();
 
     QUICIncomingStreamFrameBuffer buffer2;
 
-    buffer2.insert(*stream1_frame_3_r);
-    buffer2.insert(*stream1_frame_0_r);
-    buffer2.insert(*stream1_frame_1_r);
-    err = buffer2.insert(*stream1_frame_2_r);
+    buffer2.insert(new QUICStreamFrame(*stream1_frame_3_r));
+    buffer2.insert(new QUICStreamFrame(*stream1_frame_0_r));
+    buffer2.insert(new QUICStreamFrame(*stream1_frame_1_r));
+    err = buffer2.insert(new QUICStreamFrame(*stream1_frame_2_r));
     CHECK(err->cls == QUICErrorClass::TRANSPORT);
     CHECK(err->code == static_cast<uint16_t>(QUICTransErrorCode::FINAL_OFFSET_ERROR));
+
+    buffer2.clear();
 
     QUICIncomingStreamFrameBuffer buffer3;
 
-    buffer3.insert(*stream1_frame_4_r);
-    err = buffer3.insert(*stream1_frame_3_r);
+    buffer3.insert(new QUICStreamFrame(*stream1_frame_4_r));
+    err = buffer3.insert(new QUICStreamFrame(*stream1_frame_3_r));
     CHECK(err->cls == QUICErrorClass::TRANSPORT);
     CHECK(err->code == static_cast<uint16_t>(QUICTransErrorCode::FINAL_OFFSET_ERROR));
+
+    buffer3.clear();
   }
 
   SECTION("Pure FIN")
@@ -97,14 +105,16 @@ TEST_CASE("QUICIncomingStreamFrameBuffer_fin_offset", "[quic]")
     QUICStreamFrame *stream1_frame_empty    = QUICFrameFactory::create_stream_frame(frame_buf1, block_0, 1, 1024);
     QUICStreamFrame *stream1_frame_pure_fin = QUICFrameFactory::create_stream_frame(frame_buf2, block_0, 1, 1024, true);
 
-    err = buffer.insert(*stream1_frame_0_r);
+    err = buffer.insert(new QUICStreamFrame(*stream1_frame_0_r));
     CHECK(err == nullptr);
 
-    err = buffer.insert(*stream1_frame_empty);
+    err = buffer.insert(new QUICStreamFrame(*stream1_frame_empty));
     CHECK(err == nullptr);
 
-    err = buffer.insert(*stream1_frame_pure_fin);
+    err = buffer.insert(new QUICStreamFrame(*stream1_frame_pure_fin));
     CHECK(err == nullptr);
+
+    buffer.clear();
   }
 
   delete stream;
@@ -139,12 +149,12 @@ TEST_CASE("QUICIncomingStreamFrameBuffer_pop", "[quic]")
   QUICStreamFrame *stream1_frame_3_r   = QUICFrameFactory::create_stream_frame(frame_buf4, block_1024, 1, 3072);
   QUICStreamFrame *stream1_frame_4_r   = QUICFrameFactory::create_stream_frame(frame_buf5, block_1024, 1, 4096, true);
 
-  buffer.insert(*stream1_frame_0_r);
-  buffer.insert(*stream1_frame_1_r);
-  buffer.insert(*stream1_frame_empty);
-  buffer.insert(*stream1_frame_2_r);
-  buffer.insert(*stream1_frame_3_r);
-  buffer.insert(*stream1_frame_4_r);
+  buffer.insert(new QUICStreamFrame(*stream1_frame_0_r));
+  buffer.insert(new QUICStreamFrame(*stream1_frame_1_r));
+  buffer.insert(new QUICStreamFrame(*stream1_frame_empty));
+  buffer.insert(new QUICStreamFrame(*stream1_frame_2_r));
+  buffer.insert(new QUICStreamFrame(*stream1_frame_3_r));
+  buffer.insert(new QUICStreamFrame(*stream1_frame_4_r));
   CHECK(!buffer.empty());
 
   auto frame = static_cast<const QUICStreamFrame *>(buffer.pop());
@@ -161,11 +171,11 @@ TEST_CASE("QUICIncomingStreamFrameBuffer_pop", "[quic]")
 
   buffer.clear();
 
-  buffer.insert(*stream1_frame_4_r);
-  buffer.insert(*stream1_frame_3_r);
-  buffer.insert(*stream1_frame_2_r);
-  buffer.insert(*stream1_frame_1_r);
-  buffer.insert(*stream1_frame_0_r);
+  buffer.insert(new QUICStreamFrame(*stream1_frame_4_r));
+  buffer.insert(new QUICStreamFrame(*stream1_frame_3_r));
+  buffer.insert(new QUICStreamFrame(*stream1_frame_2_r));
+  buffer.insert(new QUICStreamFrame(*stream1_frame_1_r));
+  buffer.insert(new QUICStreamFrame(*stream1_frame_0_r));
   CHECK(!buffer.empty());
 
   frame = static_cast<const QUICStreamFrame *>(buffer.pop());
@@ -211,10 +221,10 @@ TEST_CASE("QUICIncomingStreamFrameBuffer_dup_frame", "[quic]")
   QUICStreamFrame *stream1_frame_2_r = QUICFrameFactory::create_stream_frame(frame_buf2, block_1024, 1, 2048, true);
   QUICStreamFrame *stream1_frame_3_r = QUICFrameFactory::create_stream_frame(frame_buf3, block_1024, 1, 2048, true);
 
-  buffer.insert(*stream1_frame_0_r);
-  buffer.insert(*stream1_frame_1_r);
-  buffer.insert(*stream1_frame_2_r);
-  err = buffer.insert(*stream1_frame_3_r);
+  buffer.insert(new QUICStreamFrame(*stream1_frame_0_r));
+  buffer.insert(new QUICStreamFrame(*stream1_frame_1_r));
+  buffer.insert(new QUICStreamFrame(*stream1_frame_2_r));
+  err = buffer.insert(new QUICStreamFrame(*stream1_frame_3_r));
   CHECK(err == nullptr);
 
   auto frame = static_cast<const QUICStreamFrame *>(buffer.pop());
@@ -234,10 +244,10 @@ TEST_CASE("QUICIncomingStreamFrameBuffer_dup_frame", "[quic]")
   QUICStreamFrame *stream2_frame_2_r = QUICFrameFactory::create_stream_frame(frame_buf6, block_1024, 1, 1024);
   QUICStreamFrame *stream2_frame_3_r = QUICFrameFactory::create_stream_frame(frame_buf7, block_1024, 1, 2048, true);
 
-  buffer.insert(*stream2_frame_0_r);
-  buffer.insert(*stream2_frame_1_r);
-  buffer.insert(*stream2_frame_2_r);
-  err = buffer.insert(*stream2_frame_3_r);
+  buffer.insert(new QUICStreamFrame(*stream2_frame_0_r));
+  buffer.insert(new QUICStreamFrame(*stream2_frame_1_r));
+  buffer.insert(new QUICStreamFrame(*stream2_frame_2_r));
+  err = buffer.insert(new QUICStreamFrame(*stream2_frame_3_r));
   CHECK(err == nullptr);
 
   frame = static_cast<const QUICStreamFrame *>(buffer.pop());

--- a/iocore/net/quic/test/test_QUICLossDetector.cc
+++ b/iocore/net/quic/test/test_QUICLossDetector.cc
@@ -41,10 +41,10 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
   MockQUICConnectionInfoProvider info;
   MockQUICCongestionController cc(&info);
   QUICLossDetector detector(&tx, &info, &cc, &rtt_measure, 0);
-  ats_unique_buf payload              = ats_unique_malloc(512);
-  size_t payload_len                  = 512;
-  QUICPacketUPtr packet               = QUICPacketFactory::create_null_packet();
-  std::shared_ptr<QUICAckFrame> frame = QUICFrameFactory::create_null_ack_frame();
+  ats_unique_buf payload = ats_unique_malloc(512);
+  size_t payload_len     = 512;
+  QUICPacketUPtr packet  = QUICPacketFactory::create_null_packet();
+  QUICAckFrame *frame    = nullptr;
   std::vector<QUICFrameInfo> dummy_frames;
 
   SECTION("Handshake")
@@ -142,9 +142,10 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
     afm.update(QUICEncryptionLevel::INITIAL, pn8, payload_len, false);
     afm.update(QUICEncryptionLevel::INITIAL, pn9, payload_len, false);
     ink_hrtime_sleep(HRTIME_MSECONDS(1000));
-    std::shared_ptr<QUICFrame> x = afm.generate_frame(QUICEncryptionLevel::INITIAL, 2048, 2048);
-    frame                        = std::dynamic_pointer_cast<QUICAckFrame>(x);
-    detector.handle_frame(QUICEncryptionLevel::INITIAL, *frame.get());
+    uint8_t buf[QUICFrame::MAX_INSTANCE_SIZE];
+    QUICFrame *x = afm.generate_frame(buf, QUICEncryptionLevel::INITIAL, 2048, 2048);
+    frame        = static_cast<QUICAckFrame *>(x);
+    detector.handle_frame(QUICEncryptionLevel::INITIAL, *frame);
     ink_hrtime_sleep(HRTIME_MSECONDS(5000));
 
     CHECK(cc.lost_packets.size() == 3);
@@ -163,6 +164,7 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
 
 TEST_CASE("QUICLossDetector_HugeGap", "[quic]")
 {
+  uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   MockQUICPacketTransmitter tx;
   MockQUICConnectionInfoProvider info;
   MockQUICCongestionController cc(&info);
@@ -172,10 +174,10 @@ TEST_CASE("QUICLossDetector_HugeGap", "[quic]")
   // Check initial state
   CHECK(tx.retransmitted.size() == 0);
 
-  auto t1                           = Thread::get_hrtime();
-  std::shared_ptr<QUICAckFrame> ack = QUICFrameFactory::create_ack_frame(100000000, 100, 10000000);
+  auto t1           = Thread::get_hrtime();
+  QUICAckFrame *ack = QUICFrameFactory::create_ack_frame(frame_buf, 100000000, 100, 10000000);
   ack->ack_block_section()->add_ack_block({20000000, 30000000});
-  detector.handle_frame(QUICEncryptionLevel::INITIAL, *ack.get());
+  detector.handle_frame(QUICEncryptionLevel::INITIAL, *ack);
   auto t2 = Thread::get_hrtime();
   CHECK(t2 - t1 < HRTIME_MSECONDS(100));
 }

--- a/iocore/net/quic/test/test_QUICStream.cc
+++ b/iocore/net/quic/test/test_QUICStream.cc
@@ -38,44 +38,44 @@ TEST_CASE("QUICStream", "[quic]")
 
   uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
 
-  Ptr<IOBufferBlock> new_block             = make_ptr<IOBufferBlock>(block->clone());
-  new_block->_end                          = new_block->_start + 2;
-  std::shared_ptr<QUICStreamFrame> frame_1 = std::make_shared<QUICStreamFrame>(new_block, stream_id, 0);
+  Ptr<IOBufferBlock> new_block = make_ptr<IOBufferBlock>(block->clone());
+  new_block->_end              = new_block->_start + 2;
+  QUICStreamFrame frame_1(new_block, stream_id, 0);
   block->consume(2);
 
-  new_block                                = block->clone();
-  new_block->_end                          = new_block->_start + 2;
-  std::shared_ptr<QUICStreamFrame> frame_2 = std::make_shared<QUICStreamFrame>(new_block, stream_id, 2);
+  new_block       = block->clone();
+  new_block->_end = new_block->_start + 2;
+  QUICStreamFrame frame_2(new_block, stream_id, 2);
   block->consume(2);
 
-  new_block                                = block->clone();
-  new_block->_end                          = new_block->_start + 2;
-  std::shared_ptr<QUICStreamFrame> frame_3 = std::make_shared<QUICStreamFrame>(new_block, stream_id, 4);
+  new_block       = block->clone();
+  new_block->_end = new_block->_start + 2;
+  QUICStreamFrame frame_3(new_block, stream_id, 4);
   block->consume(2);
 
-  new_block                                = block->clone();
-  new_block->_end                          = new_block->_start + 2;
-  std::shared_ptr<QUICStreamFrame> frame_4 = std::make_shared<QUICStreamFrame>(new_block, stream_id, 6);
+  new_block       = block->clone();
+  new_block->_end = new_block->_start + 2;
+  QUICStreamFrame frame_4(new_block, stream_id, 6);
   block->consume(2);
 
-  new_block                                = block->clone();
-  new_block->_end                          = new_block->_start + 2;
-  std::shared_ptr<QUICStreamFrame> frame_5 = std::make_shared<QUICStreamFrame>(new_block, stream_id, 8);
+  new_block       = block->clone();
+  new_block->_end = new_block->_start + 2;
+  QUICStreamFrame frame_5(new_block, stream_id, 8);
   block->consume(2);
 
-  new_block                                = block->clone();
-  new_block->_end                          = new_block->_start + 2;
-  std::shared_ptr<QUICStreamFrame> frame_6 = std::make_shared<QUICStreamFrame>(new_block, stream_id, 10);
+  new_block       = block->clone();
+  new_block->_end = new_block->_start + 2;
+  QUICStreamFrame frame_6(new_block, stream_id, 10);
   block->consume(2);
 
-  new_block                                = block->clone();
-  new_block->_end                          = new_block->_start + 2;
-  std::shared_ptr<QUICStreamFrame> frame_7 = std::make_shared<QUICStreamFrame>(new_block, stream_id, 12);
+  new_block       = block->clone();
+  new_block->_end = new_block->_start + 2;
+  QUICStreamFrame frame_7(new_block, stream_id, 12);
   block->consume(2);
 
-  new_block                                = block->clone();
-  new_block->_end                          = new_block->_start + 2;
-  std::shared_ptr<QUICStreamFrame> frame_8 = std::make_shared<QUICStreamFrame>(new_block, stream_id, 14);
+  new_block       = block->clone();
+  new_block->_end = new_block->_start + 2;
+  QUICStreamFrame frame_8(new_block, stream_id, 14);
   block->consume(2);
 
   SECTION("QUICStream_assembling_byte_stream_1")
@@ -88,14 +88,14 @@ TEST_CASE("QUICStream", "[quic]")
     std::unique_ptr<QUICStream> stream(new QUICStream(&rtt_provider, &cinfo_provider, stream_id, 1024, 1024));
     stream->do_io_read(nullptr, INT64_MAX, read_buffer);
 
-    stream->recv(*frame_1);
-    stream->recv(*frame_2);
-    stream->recv(*frame_3);
-    stream->recv(*frame_4);
-    stream->recv(*frame_5);
-    stream->recv(*frame_6);
-    stream->recv(*frame_7);
-    stream->recv(*frame_8);
+    stream->recv(frame_1);
+    stream->recv(frame_2);
+    stream->recv(frame_3);
+    stream->recv(frame_4);
+    stream->recv(frame_5);
+    stream->recv(frame_6);
+    stream->recv(frame_7);
+    stream->recv(frame_8);
 
     uint8_t buf[32];
     int64_t len = reader->read_avail();
@@ -115,14 +115,14 @@ TEST_CASE("QUICStream", "[quic]")
     std::unique_ptr<QUICStream> stream(new QUICStream(&rtt_provider, &cinfo_provider, stream_id, UINT64_MAX, UINT64_MAX));
     stream->do_io_read(nullptr, INT64_MAX, read_buffer);
 
-    stream->recv(*frame_8);
-    stream->recv(*frame_7);
-    stream->recv(*frame_6);
-    stream->recv(*frame_5);
-    stream->recv(*frame_4);
-    stream->recv(*frame_3);
-    stream->recv(*frame_2);
-    stream->recv(*frame_1);
+    stream->recv(frame_8);
+    stream->recv(frame_7);
+    stream->recv(frame_6);
+    stream->recv(frame_5);
+    stream->recv(frame_4);
+    stream->recv(frame_3);
+    stream->recv(frame_2);
+    stream->recv(frame_1);
 
     uint8_t buf[32];
     int64_t len = reader->read_avail();
@@ -142,16 +142,16 @@ TEST_CASE("QUICStream", "[quic]")
     std::unique_ptr<QUICStream> stream(new QUICStream(&rtt_provider, &cinfo_provider, stream_id, UINT64_MAX, UINT64_MAX));
     stream->do_io_read(nullptr, INT64_MAX, read_buffer);
 
-    stream->recv(*frame_8);
-    stream->recv(*frame_7);
-    stream->recv(*frame_6);
-    stream->recv(*frame_7); // duplicated frame
-    stream->recv(*frame_5);
-    stream->recv(*frame_3);
-    stream->recv(*frame_1);
-    stream->recv(*frame_2);
-    stream->recv(*frame_4);
-    stream->recv(*frame_5); // duplicated frame
+    stream->recv(frame_8);
+    stream->recv(frame_7);
+    stream->recv(frame_6);
+    stream->recv(frame_7); // duplicated frame
+    stream->recv(frame_5);
+    stream->recv(frame_3);
+    stream->recv(frame_1);
+    stream->recv(frame_2);
+    stream->recv(frame_4);
+    stream->recv(frame_5); // duplicated frame
 
     uint8_t buf[32];
     int64_t len = reader->read_avail();

--- a/iocore/net/quic/test/test_QUICStreamManager.cc
+++ b/iocore/net/quic/test/test_QUICStreamManager.cc
@@ -69,8 +69,10 @@ TEST_CASE("QUICStreamManager_NewStream", "[quic]")
   block->fill(4);
   CHECK(block->read_avail() == 4);
 
-  std::shared_ptr<QUICFrame> stream_frame_0 = QUICFrameFactory::create_stream_frame(block, 0, 0);
-  std::shared_ptr<QUICFrame> stream_frame_4 = QUICFrameFactory::create_stream_frame(block, 4, 0);
+  uint8_t stream_frame_0_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  uint8_t stream_frame_4_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  QUICFrame *stream_frame_0 = QUICFrameFactory::create_stream_frame(stream_frame_0_buf, block, 0, 0);
+  QUICFrame *stream_frame_4 = QUICFrameFactory::create_stream_frame(stream_frame_4_buf, block, 4, 0);
   CHECK(sm.stream_count() == 0);
   sm.handle_frame(level, *stream_frame_0);
   CHECK(sm.stream_count() == 1);
@@ -78,24 +80,28 @@ TEST_CASE("QUICStreamManager_NewStream", "[quic]")
   CHECK(sm.stream_count() == 2);
 
   // RESET_STREAM frames create new streams
-  std::shared_ptr<QUICFrame> rst_stream_frame =
-    QUICFrameFactory::create_rst_stream_frame(8, static_cast<QUICAppErrorCode>(0x01), 0);
+  uint8_t rst_stream_frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  QUICFrame *rst_stream_frame =
+    QUICFrameFactory::create_rst_stream_frame(rst_stream_frame_buf, 8, static_cast<QUICAppErrorCode>(0x01), 0);
   sm.handle_frame(level, *rst_stream_frame);
   CHECK(sm.stream_count() == 3);
 
   // MAX_STREAM_DATA frames create new streams
-  std::shared_ptr<QUICFrame> max_stream_data_frame = QUICFrameFactory::create_max_stream_data_frame(0x0c, 0);
+  uint8_t max_stream_data_frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  QUICFrame *max_stream_data_frame = QUICFrameFactory::create_max_stream_data_frame(max_stream_data_frame_buf, 0x0c, 0);
   sm.handle_frame(level, *max_stream_data_frame);
   CHECK(sm.stream_count() == 4);
 
   // STREAM_DATA_BLOCKED frames create new streams
-  std::shared_ptr<QUICFrame> stream_blocked_frame = QUICFrameFactory::create_stream_data_blocked_frame(0x10, 0);
+  uint8_t stream_blocked_frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  QUICFrame *stream_blocked_frame = QUICFrameFactory::create_stream_data_blocked_frame(stream_blocked_frame_buf, 0x10, 0);
   sm.handle_frame(level, *stream_blocked_frame);
   CHECK(sm.stream_count() == 5);
 
   // Set local maximum stream id
   sm.set_max_streams_bidi(5);
-  std::shared_ptr<QUICFrame> stream_blocked_frame_x = QUICFrameFactory::create_stream_data_blocked_frame(0x18, 0);
+  uint8_t stream_blocked_frame_x_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  QUICFrame *stream_blocked_frame_x = QUICFrameFactory::create_stream_data_blocked_frame(stream_blocked_frame_x_buf, 0x18, 0);
   sm.handle_frame(level, *stream_blocked_frame_x);
   CHECK(sm.stream_count() == 5);
 }
@@ -122,7 +128,8 @@ TEST_CASE("QUICStreamManager_first_initial_map", "[quic]")
   block->fill(4);
   CHECK(block->read_avail() == 4);
 
-  std::shared_ptr<QUICFrame> stream_frame_0 = QUICFrameFactory::create_stream_frame(block, 0, 7);
+  uint8_t stream_frame_0_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  QUICFrame *stream_frame_0 = QUICFrameFactory::create_stream_frame(stream_frame_0_buf, block, 0, 7);
 
   sm.handle_frame(level, *stream_frame_0);
   CHECK("succeed");
@@ -167,8 +174,10 @@ TEST_CASE("QUICStreamManager_total_offset_received", "[quic]")
   sm.init_flow_control_params(local_tp, remote_tp);
 
   // Create a stream with STREAM_DATA_BLOCKED (== noop)
-  std::shared_ptr<QUICFrame> stream_blocked_frame_0 = QUICFrameFactory::create_stream_data_blocked_frame(0, 0);
-  std::shared_ptr<QUICFrame> stream_blocked_frame_1 = QUICFrameFactory::create_stream_data_blocked_frame(4, 0);
+  uint8_t stream_blocked_frame_0_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  uint8_t stream_blocked_frame_1_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  QUICFrame *stream_blocked_frame_0 = QUICFrameFactory::create_stream_data_blocked_frame(stream_blocked_frame_0_buf, 0, 0);
+  QUICFrame *stream_blocked_frame_1 = QUICFrameFactory::create_stream_data_blocked_frame(stream_blocked_frame_1_buf, 4, 0);
   sm.handle_frame(level, *stream_blocked_frame_0);
   sm.handle_frame(level, *stream_blocked_frame_1);
   CHECK(sm.stream_count() == 2);
@@ -180,7 +189,8 @@ TEST_CASE("QUICStreamManager_total_offset_received", "[quic]")
   block->fill(1024);
   CHECK(block->read_avail() == 1024);
 
-  std::shared_ptr<QUICFrame> stream_frame_1 = QUICFrameFactory::create_stream_frame(block, 8, 0);
+  uint8_t stream_frame_1_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  QUICFrame *stream_frame_1 = QUICFrameFactory::create_stream_frame(stream_frame_1_buf, block, 8, 0);
   sm.handle_frame(level, *stream_frame_1);
   CHECK(sm.total_offset_received() == 1024);
 }
@@ -223,8 +233,10 @@ TEST_CASE("QUICStreamManager_total_offset_sent", "[quic]")
   block_3->fill(3);
   CHECK(block_3->read_avail() == 3);
 
-  std::shared_ptr<QUICFrame> stream_frame_0_r = QUICFrameFactory::create_stream_frame(block_3, 0, 0);
-  std::shared_ptr<QUICFrame> stream_frame_4_r = QUICFrameFactory::create_stream_frame(block_3, 4, 0);
+  uint8_t stream_frame0_buf_r[QUICFrame::MAX_INSTANCE_SIZE];
+  uint8_t stream_frame4_buf_r[QUICFrame::MAX_INSTANCE_SIZE];
+  QUICFrame *stream_frame_0_r = QUICFrameFactory::create_stream_frame(stream_frame0_buf_r, block_3, 0, 0);
+  QUICFrame *stream_frame_4_r = QUICFrameFactory::create_stream_frame(stream_frame4_buf_r, block_3, 4, 0);
   sm.handle_frame(level, *stream_frame_0_r);
   sm.handle_frame(level, *stream_frame_4_r);
   CHECK(sm.stream_count() == 2);
@@ -236,14 +248,16 @@ TEST_CASE("QUICStreamManager_total_offset_sent", "[quic]")
   CHECK(block_1024->read_avail() == 1024);
 
   // total_offset should be a integer in unit of octets
-  QUICFrameUPtr stream_frame_0 = QUICFrameFactory::create_stream_frame(block_1024, 0, 0);
+  uint8_t stream_frame0_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  QUICFrame *stream_frame_0 = QUICFrameFactory::create_stream_frame(stream_frame0_buf, block_1024, 0, 0);
   mock_app.send(reinterpret_cast<uint8_t *>(block_1024->buf()), 1024, 0);
   sm.add_total_offset_sent(1024);
   sleep(2);
   CHECK(sm.total_offset_sent() == 1024);
 
   // total_offset should be a integer in unit of octets
-  QUICFrameUPtr stream_frame_4 = QUICFrameFactory::create_stream_frame(block_1024, 4, 0);
+  uint8_t stream_frame4_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  QUICFrame *stream_frame_4 = QUICFrameFactory::create_stream_frame(stream_frame4_buf, block_1024, 4, 0);
   mock_app.send(reinterpret_cast<uint8_t *>(block_1024->buf()), 1024, 4);
   sm.add_total_offset_sent(1024);
   sleep(2);

--- a/iocore/net/quic/test/test_QUICStreamState.cc
+++ b/iocore/net/quic/test/test_QUICStreamState.cc
@@ -37,10 +37,16 @@ TEST_CASE("QUICSendStreamState", "[quic]")
   block_4->fill(4);
   CHECK(block_4->read_avail() == 4);
 
-  auto stream_frame              = QUICFrameFactory::create_stream_frame(block_4, 1, 0);
-  auto stream_frame_with_fin     = QUICFrameFactory::create_stream_frame(block_4, 1, 0, true);
-  auto rst_stream_frame          = QUICFrameFactory::create_rst_stream_frame(0, static_cast<QUICAppErrorCode>(0x01), 0);
-  auto stream_data_blocked_frame = QUICFrameFactory::create_stream_data_blocked_frame(0, 0);
+  uint8_t stream_frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  uint8_t stream_frame_with_fin_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  uint8_t rst_stream_frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  uint8_t stream_data_blocked_frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
+
+  auto stream_frame          = QUICFrameFactory::create_stream_frame(stream_frame_buf, block_4, 1, 0);
+  auto stream_frame_with_fin = QUICFrameFactory::create_stream_frame(stream_frame_with_fin_buf, block_4, 1, 0, true);
+  auto rst_stream_frame =
+    QUICFrameFactory::create_rst_stream_frame(rst_stream_frame_buf, 0, static_cast<QUICAppErrorCode>(0x01), 0);
+  auto stream_data_blocked_frame = QUICFrameFactory::create_stream_data_blocked_frame(stream_data_blocked_frame_buf, 0, 0);
   MockQUICTransferProgressProvider pp;
 
   SECTION("Ready -> Send -> Data Sent -> Data Recvd")
@@ -182,11 +188,18 @@ TEST_CASE("QUICReceiveStreamState", "[quic]")
   block_4->fill(4);
   CHECK(block_4->read_avail() == 4);
 
-  auto stream_frame              = QUICFrameFactory::create_stream_frame(block_4, 1, 0);
-  auto stream_frame_delayed      = QUICFrameFactory::create_stream_frame(block_4, 1, 1);
-  auto stream_frame_with_fin     = QUICFrameFactory::create_stream_frame(block_4, 1, 2, true);
-  auto rst_stream_frame          = QUICFrameFactory::create_rst_stream_frame(0, static_cast<QUICAppErrorCode>(0x01), 0);
-  auto stream_data_blocked_frame = QUICFrameFactory::create_stream_data_blocked_frame(0, 0);
+  uint8_t stream_frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  uint8_t stream_frame_delayed_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  uint8_t stream_frame_with_fin_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  uint8_t rst_stream_frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
+  uint8_t stream_data_blocked_frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
+
+  auto stream_frame          = QUICFrameFactory::create_stream_frame(stream_frame_buf, block_4, 1, 0);
+  auto stream_frame_delayed  = QUICFrameFactory::create_stream_frame(stream_frame_delayed_buf, block_4, 1, 1);
+  auto stream_frame_with_fin = QUICFrameFactory::create_stream_frame(stream_frame_with_fin_buf, block_4, 1, 2, true);
+  auto rst_stream_frame =
+    QUICFrameFactory::create_rst_stream_frame(rst_stream_frame_buf, 0, static_cast<QUICAppErrorCode>(0x01), 0);
+  auto stream_data_blocked_frame = QUICFrameFactory::create_stream_data_blocked_frame(stream_data_blocked_frame_buf, 0, 0);
 
   SECTION("Recv -> Size Known -> Data Recvd -> Data Read")
   {


### PR DESCRIPTION
This is for #4621

- Remove QUICFrame allocators and deleters -- use pre-allocated buffer instead
- Remove QUICFrame::clone -- use copy constructor instead

Because we use placement new and the buffer is allocated outside the frame factory, I removed use of unique_ptr and shared_ptr for now. We may be able to add it back but maybe on the next step.