### PR TITLE
Scalar: add generic rounding.

### DIFF
--- a/src/tscore/unit_tests/test_Scalar.cc
+++ b/src/tscore/unit_tests/test_Scalar.cc
@@ -76,6 +76,24 @@ TEST_CASE("Scalar", "[libts][Scalar]")
   sz_b = sz; // Should be OK because SCALE_1 is an integer multiple of SCALE_2
   //  sz = sz_b; // Should not compile.
   REQUIRE(sz_b.count() == 119 * (SCALE_1 / SCALE_2));
+
+  // Test generic rounding.
+  REQUIRE(120 == ts::round_up<10>(118));
+  REQUIRE(120 == ts::round_up<10>(120));
+  REQUIRE(130 == ts::round_up<10>(121));
+
+  REQUIRE(110 == ts::round_down<10>(118));
+  REQUIRE(120 == ts::round_down<10>(120));
+  REQUIRE(120 == ts::round_down<10>(121));
+
+  REQUIRE(1200 == ts::round_up<100>(1108));
+  REQUIRE(1200 == ts::round_up<100>(1200));
+  REQUIRE(1300 == ts::round_up<100>(1201));
+
+  REQUIRE(100 == ts::round_down<100>(118));
+  REQUIRE(1100 == ts::round_down<100>(1108));
+  REQUIRE(1200 == ts::round_down<100>(1200));
+  REQUIRE(1200 == ts::round_down<100>(1208));
 }
 
 TEST_CASE("Scalar Factors", "[libts][Scalar][factors]")


### PR DESCRIPTION
This adds another flavor of `round_up` / `round_down` that can be directly used without explicit Scalar
instances. As can be seen in the unit tests, integer rounding can be done with just
```
int x = ts::round_up<256>(value); // round value up to the nearest multiple of 256
```
The goal is to get rid of the duplicative `#define` mechanisms for this, and make the case where Scalar is overkill easier to use.