### PR TITLE
Hdrheap more modernization

### DIFF
--- a/doc/developer-guide/core-architecture/heap.en.rst
+++ b/doc/developer-guide/core-architecture/heap.en.rst
@@ -159,10 +159,17 @@ collection operation on the writeable string heap in the header heap by calling
 
 *  An external string heap is being added and all current read only string heap slots are used.
 
+The mechanism is simple in design - the size of the live string data in the current string heaps is
+calculated and a new heap is allocated sufficient to contain all existing strings, with additional
+space for new string data. Each heap object is required to provide a :code:`strings_length` method
+which returns the size of the live string data for that object (recursively as needed). The strings
+are copied to the new string heap, all of the previous string heaps are discarded, and the new heap
+becomes the writable string heap for the header heap.
+
 Each heap object is responsible for providing a :code:`move_strings` method which copies its strings
-to a new string heap. This is a source of pointer invalidation for other parts of the core and the
-plugin API. For the latter, insulating from such string movement is the point of the
-:c:type:`TSMLoc` type.
+to a new string heap, passed as an argument. This is a source of pointer invalidation for other
+parts of the core and the plugin API. For the latter, insulating from such string movement is the
+point of the :c:type:`TSMLoc` type.
 
 String Allocation
 -----------------

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -3289,18 +3289,18 @@ CacheProcessor::find_by_path(const char *path, int len)
 
 namespace cache_bc
 {
-static size_t const HTTP_ALT_MARSHAL_SIZE = ROUND(sizeof(HTTPCacheAlt), HDR_PTR_SIZE); // current size.
+static size_t const HTTP_ALT_MARSHAL_SIZE = HdrHeapMarshalBlocks{ts::round_up(sizeof(HTTPCacheAlt))}; // current size.
 size_t
 HTTPInfo_v21::marshalled_length(void *data)
 {
-  size_t zret           = ROUND(sizeof(HTTPCacheAlt_v21), HDR_PTR_SIZE);
+  size_t zret           = HdrHeapMarshalBlocks{ts::round_up(sizeof(HTTPCacheAlt_v21))};
   HTTPCacheAlt_v21 *alt = static_cast<HTTPCacheAlt_v21 *>(data);
   HdrHeap *hdr;
 
   hdr = reinterpret_cast<HdrHeap *>(reinterpret_cast<char *>(alt) + reinterpret_cast<uintptr_t>(alt->m_request_hdr.m_heap));
-  zret += ROUND(hdr->unmarshal_size(), HDR_PTR_SIZE);
+  zret += HdrHeapMarshalBlocks{ts::round_up(hdr->unmarshal_size())};
   hdr = reinterpret_cast<HdrHeap *>(reinterpret_cast<char *>(alt) + reinterpret_cast<uintptr_t>(alt->m_response_hdr.m_heap));
-  zret += ROUND(hdr->unmarshal_size(), HDR_PTR_SIZE);
+  zret += HdrHeapMarshalBlocks{ts::round_up(hdr->unmarshal_size())};
   return zret;
 }
 
@@ -3363,7 +3363,7 @@ HTTPInfo_v21::copy_and_upgrade_unmarshalled_to_v23(char *&dst, char *&src, size_
   s_hdr =
     reinterpret_cast<HdrHeap_v23 *>(reinterpret_cast<char *>(s_alt) + reinterpret_cast<uintptr_t>(s_alt->m_request_hdr.m_heap));
   d_hdr    = reinterpret_cast<HdrHeap_v23 *>(dst);
-  hdr_size = ROUND(s_hdr->unmarshal_size(), HDR_PTR_SIZE);
+  hdr_size = HdrHeapMarshalBlocks{ts::round_up(s_hdr->unmarshal_size())};
   if (hdr_size > length) {
     return false;
   }
@@ -3375,7 +3375,7 @@ HTTPInfo_v21::copy_and_upgrade_unmarshalled_to_v23(char *&dst, char *&src, size_
   s_hdr =
     reinterpret_cast<HdrHeap_v23 *>(reinterpret_cast<char *>(s_alt) + reinterpret_cast<uintptr_t>(s_alt->m_response_hdr.m_heap));
   d_hdr    = reinterpret_cast<HdrHeap_v23 *>(dst);
-  hdr_size = ROUND(s_hdr->unmarshal_size(), HDR_PTR_SIZE);
+  hdr_size = HdrHeapMarshalBlocks{ts::round_up(s_hdr->unmarshal_size())};
   if (hdr_size > length) {
     return false;
   }

--- a/proxy/hdrs/HTTP.cc
+++ b/proxy/hdrs/HTTP.cc
@@ -1950,7 +1950,7 @@ HTTPCacheAlt::copy_frag_offsets_from(HTTPCacheAlt *src)
   }
 }
 
-const int HTTP_ALT_MARSHAL_SIZE = ROUND(sizeof(HTTPCacheAlt), HDR_PTR_SIZE);
+const int HTTP_ALT_MARSHAL_SIZE = HdrHeapMarshalBlocks{ts::round_up(sizeof(HTTPCacheAlt))};
 
 void
 HTTPInfo::create()

--- a/proxy/hdrs/HdrTSOnly.cc
+++ b/proxy/hdrs/HdrTSOnly.cc
@@ -170,30 +170,29 @@ HdrHeap::attach_block(IOBufferBlock *b, const char *use_start)
 
 RETRY:
 
-  // It's my contention that since heaps are add to the
-  //   first available slot, one you find an empty slot
-  //   it's not possible that a heap ptr for this block
-  //   exists in a later slot
-  for (int i = 0; i < HDR_BUF_RONLY_HEAPS; i++) {
-    if (m_ronly_heap[i].m_heap_start == nullptr) {
+  // It's my contention that since heaps are add to the first available slot, one you find an empty
+  // slot it's not possible that a heap ptr for this block exists in a later slot
+
+  for (auto &heap : m_ronly_heap) {
+    if (heap.m_heap_start == nullptr) {
       // Add block to heap in this slot
-      m_ronly_heap[i].m_heap_start    = (char *)use_start;
-      m_ronly_heap[i].m_heap_len      = (int)(b->end() - b->start());
-      m_ronly_heap[i].m_ref_count_ptr = b->data.object();
+      heap.m_heap_start    = static_cast<char const *>(use_start);
+      heap.m_heap_len      = static_cast<int>(b->end() - b->start());
+      heap.m_ref_count_ptr = b->data.object();
       //          printf("Attaching block at %X for %d in slot %d\n",
       //                 m_ronly_heap[i].m_heap_start,
       //                 m_ronly_heap[i].m_heap_len,
       //                 i);
-      return i;
-    } else if (m_ronly_heap[i].m_heap_start == b->buf()) {
+      return &heap - m_ronly_heap;
+    } else if (heap.m_heap_start == b->buf()) {
       // This block is already on the heap so just extend
       //   it's range
-      m_ronly_heap[i].m_heap_len = (int)(b->end() - b->buf());
+      heap.m_heap_len = static_cast<int>(b->end() - b->buf());
       //          printf("Extending block at %X to %d in slot %d\n",
       //                 m_ronly_heap[i].m_heap_start,
       //                 m_ronly_heap[i].m_heap_len,
       //                 i);
-      return i;
+      return &heap - m_ronly_heap;
     }
   }
 

--- a/proxy/hdrs/unit_tests/test_HdrUtils.cc
+++ b/proxy/hdrs/unit_tests/test_HdrUtils.cc
@@ -47,7 +47,7 @@ TEST_CASE("HdrUtils", "[proxy][hdrutils]")
   static constexpr std::string_view FOUR_TAG{"Four"};
   static constexpr std::string_view FIVE_TAG{"Five"};
 
-  HdrHeap *heap = new_HdrHeap(HDR_HEAP_DEFAULT_SIZE + 64);
+  HdrHeap *heap = new_HdrHeap(HdrHeap::DEFAULT_SIZE + 64);
   MIMEParser parser;
   char const *real_s = text.data();
   char const *real_e = text.data_end();

--- a/src/traffic_cache_tool/CacheScan.cc
+++ b/src/traffic_cache_tool/CacheScan.cc
@@ -29,7 +29,7 @@
 
 // using namespace ct;
 
-const int HTTP_ALT_MARSHAL_SIZE = ROUND(sizeof(HTTPCacheAlt), HDR_PTR_SIZE);
+constexpr HdrHeapMarshalBlocks HTTP_ALT_MARSHAL_SIZE = ts::round_up(sizeof(HTTPCacheAlt));
 
 namespace ct
 {
@@ -248,8 +248,7 @@ CacheScan::unmarshal(HdrHeap *hh, int buf_length, int obj_type, HdrHeapObjImpl *
 
   hh->m_magic = HDR_BUF_MAGIC_ALIVE;
 
-  int unmarshal_length = ROUND(hh->unmarshal_size(), HDR_PTR_SIZE);
-  return unmarshal_length;
+  return HdrHeapMarshalBlocks(ts::round_up(hh->unmarshal_size()));
 }
 
 Errata

--- a/src/traffic_server/CoreUtils.cc
+++ b/src/traffic_server/CoreUtils.cc
@@ -469,10 +469,7 @@ CoreUtils::load_http_hdr(HTTPHdr *core_hdr, HTTPHdr *live_hdr)
   intptr_t ptr_heap_size = 0;
   intptr_t str_size      = 0;
   intptr_t str_heaps     = 0;
-  std::vector<struct MarshalXlate> ptr_xlation(2);
-  // MarshalXlate static_table[2];
-  // MarshalXlate* ptr_xlation = static_table;
-  intptr_t used;
+  std::vector<MarshalXlate> ptr_xlation(2);
   intptr_t i;
   intptr_t copy_size;
 
@@ -544,7 +541,7 @@ CoreUtils::load_http_hdr(HTTPHdr *core_hdr, HTTPHdr *live_hdr)
   swizzle_heap->m_ronly_heap[0].m_heap_start          = (char *)(intptr_t)swizzle_heap->m_size; // offset
   swizzle_heap->m_ronly_heap[0].m_ref_count_ptr.m_ptr = nullptr;
 
-  for (int i = 1; i < HDR_BUF_RONLY_HEAPS; i++) {
+  for (unsigned i = 1; i < HDR_BUF_RONLY_HEAPS; ++i) {
     swizzle_heap->m_ronly_heap[i].m_heap_start = nullptr;
   }
 
@@ -650,10 +647,7 @@ CoreUtils::load_http_hdr(HTTPHdr *core_hdr, HTTPHdr *live_hdr)
   }
 
   // Add up the total bytes used
-  used = ptr_heap_size + str_size + HDR_HEAP_HDR_SIZE;
-  used = ROUND(used, HDR_PTR_SIZE);
-
-  return used;
+  return HdrHeapMarshalBlocks{ts::round_up(ptr_heap_size + str_size + HDR_HEAP_HDR_SIZE)};
 
 Failed:
   swizzle_heap->m_magic = HDR_BUF_MAGIC_CORRUPT;


### PR DESCRIPTION
This depends on #4953.

This is a generic pass for C++17 fixing, before I start on the actual project of extending `HdrHeap` to support easily adding more heap types. I would end up doing this anyway, and it's better to have it separate to reduce confusion.

*  Change `#define` constants to C++ constants.
*  Add more `const` on character pointers.
*  Get rid of the `ROUND` `#define`.
*  Convert C style casts to C++ style casts.