### PR TITLE
Mark H2 connection inactive only if it is NOT shutting down

### DIFF
--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -282,6 +282,8 @@ Http2ClientSession::do_io_close(int alerrno)
     SCOPED_MUTEX_LOCK(lock, this->connection_state.mutex, this_ethread());
     this->connection_state.release_stream(nullptr);
   }
+
+  this->clear_session_active();
 }
 
 void


### PR DESCRIPTION
Prior this change, HTTP/2 connection is marked as inactive regardless it is shutting down or not.

(cherry picked from commit a4227747277759c27c63ba948d96fbd6204dc8db)

Conflicts:
	proxy/http2/Http2ConnectionState.cc

----

Backport #4936 to 7.1.x