### PR TITLE
Remove unnecessary storing of redirect_url in redirect_info

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -7727,13 +7727,8 @@ HttpSM::redirect_request(const char *arg_redirect_url, const int arg_redirect_le
   t_state.redirect_info.redirect_in_process = true;
 
   // set the passed in location url and parse it
-  URL &redirectUrl = t_state.redirect_info.redirect_url;
-  if (!redirectUrl.valid()) {
-    redirectUrl.create(nullptr);
-  }
-
-  // reset the path from previous redirects (if any)
-  t_state.redirect_info.redirect_url.path_set(nullptr, 0);
+  URL redirectUrl;
+  redirectUrl.create(nullptr);
 
   redirectUrl.parse(arg_redirect_url, arg_redirect_len);
   {
@@ -7762,6 +7757,8 @@ HttpSM::redirect_request(const char *arg_redirect_url, const int arg_redirect_le
   }
   // copy the redirect url to the client url
   clientUrl.copy(&redirectUrl);
+
+  redirectUrl.destroy();
 
   //(bug 2540703) Clear the previous response if we will attempt the redirect
   if (t_state.hdr_info.client_response.valid()) {

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -7551,13 +7551,7 @@ HttpTransact::build_request(State *s, HTTPHdr *base_request, HTTPHdr *outgoing_r
   //
   // notice that currently, based_request IS client_request
   if (base_request == &s->hdr_info.client_request) {
-    if (s->redirect_info.redirect_in_process) {
-      // this is for auto redirect
-      URL *r_url = &s->redirect_info.redirect_url;
-
-      ink_assert(r_url->valid());
-      base_request->url_set(r_url);
-    } else {
+    if (!s->redirect_info.redirect_in_process) {
       // this is for multiple cache lookup
       URL *o_url = &s->cache_info.original_url;
 

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -530,7 +530,6 @@ public:
   typedef struct _RedirectInfo {
     bool redirect_in_process = false;
     URL original_url;
-    URL redirect_url;
 
     _RedirectInfo() {}
   } RedirectInfo;
@@ -882,7 +881,6 @@ public:
       cache_info.object_store.destroy();
       cache_info.transform_store.destroy();
       redirect_info.original_url.destroy();
-      redirect_info.redirect_url.destroy();
 
       url_map.clear();
       arena.reset();


### PR DESCRIPTION
We have been having very frequent crashes with our forward caching machines running with follow redirect enabled.  It seems to have started occurring when we changed our compiler to gcc 6.2.3.  If I recompile with gcc7 the crash goes away.  Otherwise, it crashes within 5 minutes.  Seems likely there is some underlying issue which the stack trace is so consistent.

```
[ 00 ] libc-2.17.so        __GI_raise                                                           
[ 01 ] libc-2.17.so        __GI_abort                                                           
[ 02 ] libc-2.17.so        __libc_message                                                       
[ 03 ] libc-2.17.so        _int_free                                                            
[ 04 ] traffic_server      destroy                                                              ( HdrHeap.h:463 )
[ 05 ] traffic_server      destroy                                                              ( HttpTransact.h:1145 )
[ 06 ] traffic_server      HttpSM::cleanup()                                                    ( HttpSM.cc:369 )
[ 07 ] traffic_server      HttpSM::destroy()                                                    ( HttpSM.cc:392 )
[ 08 ] traffic_server      HttpSM::kill_this()                                                  ( HttpSM.cc:7145 )
[ 09 ] traffic_server      HttpSM::main_handler(int, void*)                                     ( HttpSM.cc:2827 )
[ 10 ] traffic_server      Continuation::dispatchEvent(int, void*)                              ( Continuation.cc:46 )
[ 11 ] traffic_server      HttpTunnel::main_handler(int, void*)                                 ( HttpTunnel.cc:1657 )
[ 12 ] traffic_server      Http2Stream::main_event_handler(int, void*)                          ( Http2Stream.cc:93 )
[ 13 ] traffic_server      EThread::process_event(Event*, int)                                  ( UnixEThread.cc:136 )
[ 14 ] traffic_server      EThread::process_queue(Queue<Event, Event::Link_link>*, int*, int*)  ( UnixEThread.cc:175 )
[ 15 ] traffic_server      EThread::execute_regular()                                           ( UnixEThread.cc:235 )
[ 16 ] traffic_server      spawn_thread_internal                                                ( Thread.cc:85 )
[ 17 ] libpthread-2.17.so  start_thread                                                         
```

I had thought that we fixed it in PR #4902, but alas our production builds are still showing this crash.

So this PR just pulls out storing redirect_info.redirect_url entirely.  It doesn't seem like it should be necessary.  The client_request URL is set in HttpSM::redirect_request.  Then it is reset from redirect_info.redirect_url in HttpTransact::build_request.  The comment above that reassignment is below which implies there is some path through the cache logic that will scrozzle the client request URL so we must reset it.  I cannot see that scenario.  I ran a patched version that did additional URL testing and ran it in our environment, and there never seemed to be a meaningful reset of the redirect url.
```
// this part is to restore the original URL in case, multiple cache
// lookups have happened - client request has been changed as the result
```

Of course running in one environment is not exhaustive.  Perhaps there are others longer with the project or more intimately acquainted with the follow redirect logic who know why and whether it is necessary to store and reset the redirect_url. 