### PR TITLE
HdrHeap: Remove pointless code and misleading comment.

### DIFF
--- a/proxy/hdrs/HdrHeap.cc
+++ b/proxy/hdrs/HdrHeap.cc
@@ -40,7 +40,6 @@
 #define MAX_LOST_STR_SPACE 1024
 
 Allocator hdrHeapAllocator("hdrHeap", HDR_HEAP_DEFAULT_SIZE);
-static HdrHeap proto_heap;
 
 Allocator strHeapAllocator("hdrStrHeap", HDR_STR_HEAP_DEFAULT_SIZE);
 
@@ -121,11 +120,6 @@ new_HdrHeap(int size)
   } else {
     h = (HdrHeap *)ats_malloc(size);
   }
-
-  //    Debug("hdrs", "Allocated header heap in size %d", size);
-
-  // Patch virtual function table ptr
-  *((void **)h) = *((void **)&proto_heap);
 
   h->m_size = size;
   h->init();


### PR DESCRIPTION
By design for serialization, HdrHeap has no virtual methods and therefore no virtual function pointer. This actually just copies over the `m_magic` member which is also set by `HdrHeap::init`.