### PR TITLE
Fix tls_client_verify curl command missing certificate

### DIFF
--- a/tests/gold_tests/tls/tls_client_verify.test.py
+++ b/tests/gold_tests/tls/tls_client_verify.test.py
@@ -89,7 +89,7 @@ tr.Setup.Copy("ssl/server.pem")
 tr.Setup.Copy("ssl/server.key")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert server.pem --key server.key --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}/case1".format(ts.Variables.ssl_port)
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./server.pem --key ./server.key --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}/case1".format(ts.Variables.ssl_port)
 # Should fail with badly signed certs
 tr.Processes.Default.ReturnCode = 35
 
@@ -98,7 +98,7 @@ tr.Setup.Copy("ssl/signed-foo.pem")
 tr.Setup.Copy("ssl/signed-foo.key")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert signed-foo.pem --key signed-foo.key --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}/case1".format(ts.Variables.ssl_port)
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./signed-foo.pem --key ./signed-foo.key --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
@@ -114,7 +114,7 @@ tr.Setup.Copy("ssl/signed-bob-bar.pem")
 tr.Setup.Copy("ssl/signed-bar.key")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert signed-bob-bar.pem --key signed-bar.key --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case1".format(ts.Variables.ssl_port)
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./signed-bob-bar.pem --key ./signed-bar.key --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
@@ -123,7 +123,7 @@ tr.Setup.Copy("ssl/server.pem")
 tr.Setup.Copy("ssl/server.key")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert server.pem --key server.key --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case1".format(ts.Variables.ssl_port)
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./server.pem --key ./server.key --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
@@ -139,7 +139,7 @@ tr.Setup.Copy("ssl/signed-bob-foo.pem")
 tr.Setup.Copy("ssl/signed-foo.key")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert signed-bob-foo.pem --key signed-foo.key --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case1".format(ts.Variables.ssl_port)
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./signed-bob-foo.pem --key ./signed-foo.key --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
@@ -148,7 +148,7 @@ tr.Setup.Copy("ssl/server.pem")
 tr.Setup.Copy("ssl/server.key")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert server.pem --key server.key --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case1".format(ts.Variables.ssl_port)
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./server.pem --key ./server.key --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
@@ -163,7 +163,7 @@ tr.Setup.Copy("ssl/signed-bar.pem")
 tr.Setup.Copy("ssl/signed-bar.key")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert signed-bar.pem --key signed-bar.key --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case1".format(ts.Variables.ssl_port)
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./signed-bar.pem --key ./signed-bar.key --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "TLS handshake should succeed")
 
@@ -172,7 +172,7 @@ tr.Setup.Copy("ssl/server.pem")
 tr.Setup.Copy("ssl/server.key")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert server.pem --key server.key --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case1".format(ts.Variables.ssl_port)
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./server.pem --key ./server.key --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 35
 
 

--- a/tests/gold_tests/tls/tls_client_verify2.test.py
+++ b/tests/gold_tests/tls/tls_client_verify2.test.py
@@ -90,7 +90,7 @@ tr.Setup.Copy("ssl/signed-foo.pem")
 tr.Setup.Copy("ssl/signed-foo.key")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert signed-foo.pem --key signed-foo.key --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}/case1".format(ts.Variables.ssl_port)
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./signed-foo.pem --key ./signed-foo.key --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
@@ -98,14 +98,14 @@ tr = Test.AddTestRun("Connect to bob.bar.com without cert")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case1".format(ts.Variables.ssl_port)
-tr.Processes.Default.ReturnCode = 35 
+tr.Processes.Default.ReturnCode = 35
 
 tr = Test.AddTestRun("Connect to bob.bar.com with cert")
 tr.Setup.Copy("ssl/signed-bob-bar.pem")
 tr.Setup.Copy("ssl/signed-bar.key")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert signed-bob-bar.pem --key signed-bar.key --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case1".format(ts.Variables.ssl_port)
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./signed-bob-bar.pem --key ./signed-bar.key --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "TLS handshake should succeed")
 
@@ -114,21 +114,21 @@ tr.Setup.Copy("ssl/server.pem")
 tr.Setup.Copy("ssl/server.key")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert server.pem --key server.key --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case1".format(ts.Variables.ssl_port)
-tr.Processes.Default.ReturnCode = 35 
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./server.pem --key ./server.key --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case1".format(ts.Variables.ssl_port)
+tr.Processes.Default.ReturnCode = 35
 
 tr = Test.AddTestRun("Connect to bob.foo.com without cert")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case1".format(ts.Variables.ssl_port)
-tr.Processes.Default.ReturnCode = 35 
+tr.Processes.Default.ReturnCode = 35
 
 tr = Test.AddTestRun("Connect to bob.foo.com with cert")
 tr.Setup.Copy("ssl/signed-bob-foo.pem")
 tr.Setup.Copy("ssl/signed-foo.key")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert signed-bob-foo.pem --key signed-foo.key --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case1".format(ts.Variables.ssl_port)
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./signed-bob-foo.pem --key ./signed-foo.key --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "TLS handshake should succeed")
 
@@ -137,14 +137,14 @@ tr.Setup.Copy("ssl/server.pem")
 tr.Setup.Copy("ssl/server.key")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert server.pem --key server.key --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case1".format(ts.Variables.ssl_port)
-tr.Processes.Default.ReturnCode = 35 
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./server.pem --key ./server.key --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case1".format(ts.Variables.ssl_port)
+tr.Processes.Default.ReturnCode = 35
 
 tr = Test.AddTestRun("Connect to bar.com without cert")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case1".format(ts.Variables.ssl_port)
-tr.Processes.Default.ReturnCode = 0 
+tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("alert", "TLS handshake should succeed")
 
 tr = Test.AddTestRun("Connect to bar.com with cert")
@@ -152,7 +152,7 @@ tr.Setup.Copy("ssl/signed-bar.pem")
 tr.Setup.Copy("ssl/signed-bar.key")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert signed-bar.pem --key signed-bar.key --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case1".format(ts.Variables.ssl_port)
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./signed-bar.pem --key ./signed-bar.key --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
@@ -161,7 +161,7 @@ tr.Setup.Copy("ssl/server.pem")
 tr.Setup.Copy("ssl/server.key")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert server.pem --key server.key --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case1".format(ts.Variables.ssl_port)
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./server.pem --key ./server.key --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("alert unknown ca", "TLS handshake should succeed")
 


### PR DESCRIPTION
Use relative path in curl commands to avoid confusion with NSS database nickname.

In Curl man page: 

> If curl is built against the NSS SSL library then this option can tell curl the nickname of the certificate to use within the NSS database defined by the environment variable SSL_DIR (or by default /etc/pki/nssdb). If the NSS PEM PKCS#11 module (libnsspem.so) is available then PEM files may be loaded. If you want to use a file from the current directory, please precede it with "./" prefix, in order to avoid confusion with a nickname.