### PR TITLE
Ignore config.cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ build/lt~obsolete.m4
 
 Makefile
 Makefile-pl
+config.cache
 config.status
 config.nice
 config.h


### PR DESCRIPTION
Ignore `config.cache` file which is created by `configure` with `--config-cache` (or `-C`) option.