### PR TITLE
update regex_revalidate to use stdatomic.h

### DIFF
--- a/tests/gold_tests/pluginTest/regex_revalidate/gold/regex_reval-hit.gold
+++ b/tests/gold_tests/pluginTest/regex_revalidate/gold/regex_reval-hit.gold
@@ -1,5 +1,4 @@
 HTTP/1.1 200 OK
-Etag: ``
 Cache-Control: max-age=``,public
 Content-Length: 3
 Date: ``

--- a/tests/gold_tests/pluginTest/regex_revalidate/gold/regex_reval-miss.gold
+++ b/tests/gold_tests/pluginTest/regex_revalidate/gold/regex_reval-miss.gold
@@ -1,5 +1,4 @@
 HTTP/1.1 200 OK
-Etag: ``
 Cache-Control: max-age=``,public
 Content-Length: 3
 Date: ``

--- a/tests/gold_tests/pluginTest/regex_revalidate/gold/regex_reval-stale.gold
+++ b/tests/gold_tests/pluginTest/regex_revalidate/gold/regex_reval-stale.gold
@@ -1,5 +1,4 @@
 HTTP/1.1 200 OK
-Etag: ``
 Cache-Control: max-age=``,public
 Content-Length: 3
 Date: ``

--- a/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate.test.py
+++ b/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate.test.py
@@ -77,7 +77,6 @@ request_header_1 = {"headers":
 response_header_1 = {"headers":
     "HTTP/1.1 200 OK\r\n" +
     "Connection: close\r\n" +
-    'Etag: "path1"\r\n' +
     "Cache-Control: max-age=600,public\r\n" +
     "\r\n",
     "timestamp": "1469733493.993",
@@ -95,7 +94,6 @@ request_header_2 = {"headers":
 response_header_2 = {"headers":
     "HTTP/1.1 200 OK\r\n" +
     "Connection: close\r\n" +
-    'Etag: "path1a"\r\n' +
     "Cache-Control: max-age=600,public\r\n" +
     "\r\n",
     "timestamp": "1469733493.993",
@@ -113,7 +111,6 @@ request_header_3 = {"headers":
 response_header_3 = {"headers":
     "HTTP/1.1 200 OK\r\n" +
     "Connection: close\r\n" +
-    'Etag: "path2a"\r\n' +
     "Cache-Control: max-age=900,public\r\n" +
     "\r\n",
     "timestamp": "1469733493.993",


### PR DESCRIPTION
Update the invalidate list pointer protection to use C11 semantics from stdatomic.h.

Currently regex_revalidate uses the atomic __sync_val_compare_and_swap (gcc specific extension) to protect installing a new invalidate list pointer.

config_handler() is a unique single continuation with its own TSMutex which ensures only one config_handler() can run at a time.

With this fix:

Inside config_handler() a non-atomic copy is made of the currently active invalidate list pointer and *if* updated it is atomically installed via atomic_store();

In the case of a TS_CACHE_LOOKUP_HIT_FRESH a transaction handler now atomically gets a copy of the invalidate list pointer via atomic_load().  Before this load was not protected.

Extras:
-  Removes the redundant TSMutexLock()/TSMutexUnlock() inside config_handler() that is already taken care of by the config_handler's caller.

- Removes extraneous ETags from the regex_revalidate autest as the arbitrary header ordering causes the autest validation checks to break.