### PR TITLE
Doc: centering images is not in view

### DIFF
--- a/doc/admin-guide/configuration/hierachical-caching.en.rst
+++ b/doc/admin-guide/configuration/hierachical-caching.en.rst
@@ -66,7 +66,6 @@ can now be served directly from the Traffic Server cache (until the data
 is stale or expired).
 
 .. figure:: /static/images/admin/cachehrc.jpg
-   :align: center
    :alt: Parent caching
 
    Parent caching

--- a/doc/admin-guide/configuration/proxy-protocol.en.rst
+++ b/doc/admin-guide/configuration/proxy-protocol.en.rst
@@ -63,7 +63,6 @@ Example
 As an example, consider the following topology:
 
 .. figure:: ../../static/images/admin/proxy-protocol.png
-   :align: center
    :alt: PROXY protocol transformed into a Forwarded: header
 
    PROXY protocol header flow

--- a/doc/admin-guide/configuration/redirecting-http-requests.en.rst
+++ b/doc/admin-guide/configuration/redirecting-http-requests.en.rst
@@ -66,7 +66,6 @@ Traffic Server can act as the virtual origin server for multiple backup
 origin servers, as shown in the figure below.
 
 .. figure:: /static/images/admin/revproxy.jpg
-   :align: center
    :alt: Traffic Server as reverse proxy for a pair of origin servers
 
    Traffic Server as reverse proxy for a pair of origin servers
@@ -127,7 +126,6 @@ a web server. The figure below illustrates how Traffic Server in reverse
 proxy mode serves an HTTP request from a client browser.
 
 .. figure:: /static/images/admin/httprvs.jpg
-   :align: center
    :alt: HTTP reverse proxy
 
    HTTP reverse proxy

--- a/doc/admin-guide/configuration/transparent-proxy.en.rst
+++ b/doc/admin-guide/configuration/transparent-proxy.en.rst
@@ -36,7 +36,6 @@ The general network structure that will be used in this documentation is
 shown in the following figure.
 
 .. figure:: ../../static/images/admin/ats-basic-traffic.png
-   :align: center
    :alt: ATS basic traffic flow of Transparent Proxy
 
    ATS basic traffic flow of Transparent Proxy

--- a/doc/admin-guide/configuring-traffic-server.en.rst
+++ b/doc/admin-guide/configuring-traffic-server.en.rst
@@ -69,7 +69,6 @@ full restart of Traffic Server.
 The following is a sample portion of :file:`records.config`:
 
 .. figure:: ../static/images/admin/records.jpg
-   :align: center
    :alt: Sample records.config file
 
    Sample records.config file

--- a/doc/admin-guide/introduction.en.rst
+++ b/doc/admin-guide/introduction.en.rst
@@ -190,7 +190,6 @@ requests and manage, control, and monitor the health of the system.
 The figure below illustrates the |TS| processes.
 
 .. figure:: ../static/images/admin/process.jpg
-   :align: center
    :alt: Illustration of the |TS| Processes
 
    Illustration of the |TS| Processes

--- a/doc/admin-guide/layer-4-routing.en.rst
+++ b/doc/admin-guide/layer-4-routing.en.rst
@@ -29,7 +29,6 @@ destination. The initial data is then sent to the destination and subsequently |
 data read on one connection to the other and vice versa.
 
 .. image:: ../uml/images/l4-basic-sequence.svg
-   :align: center
 
 In this way it acts similary to `nc <https://linux.die.net/man/1/nc>`__.
 
@@ -79,7 +78,6 @@ services.
 The basic set up is therefore
 
 .. figure:: ../uml/images/l4-example-cdn-layout.svg
-   :align: center
 
    A Client connects to an edge |TS| which forwards the connection to the internal Service.
    The Client then negotiates TLS with the Service.
@@ -117,7 +115,6 @@ In addition to this, in the :file:`records.config` file, edit the following vari
 The sequence of network activity for a Client connecting to ``service-2`` is
 
 .. image:: ../uml/images/l4-sni-routing-seq.svg
-   :align: center
 
 Note the destination for the outbound TCP connection and the HTTP ``CONNECT`` is the same. If this
 is a problem (which it will be in general) a plugin is needed to change the URL in the ``CONNECT``.

--- a/doc/admin-guide/logging/examples.en.rst
+++ b/doc/admin-guide/logging/examples.en.rst
@@ -47,7 +47,6 @@ Netscape Common
 The following figure shows a sample log entry in a Netscape Common log file.
 
 .. figure:: /static/images/admin/netscape_common_format.jpg
-   :align: center
    :alt: Sample Netscape Common log entry
 
 The numbered sections correspond to the following log fields in |TS|:
@@ -82,7 +81,6 @@ Netscape Extended
 The following figure shows a sample log entry in a Netscape Extended log file.
 
 .. figure:: /static/images/admin/netscape_extended_format.jpg
-   :align: center
    :alt: Sample Netscape Extended log entry
 
 In addition to fields 1-7 from the Netscape Common log format, the Extended
@@ -129,7 +127,6 @@ Netscape Extended-2
 The following figure shows a sample log entry in a Netscape Extended2 log file.
 
 .. figure:: /static/images/admin/netscape_extended2_format.jpg
-   :align: center
    :alt: Sample Netscape Extended-2 log entry
 
 In addition to fields 1-16 from the Netscape Common and Netscape Extended log
@@ -168,7 +165,6 @@ Squid
 The following figure shows a sample log entry in a Squid log file.
 
 .. figure:: /static/images/admin/squid_format.jpg
-   :align: center
    :alt: Sample Squid log entry
 
 The numbered sections correspond to the following log fields in |TS|:

--- a/doc/admin-guide/security/index.en.rst
+++ b/doc/admin-guide/security/index.en.rst
@@ -70,7 +70,6 @@ termination option is enabled and configured for Client/Traffic
 Server connections only.
 
 .. figure:: ../../static/images/admin/ssl_c.jpg
-   :align: center
    :alt: Client and Traffic Server communication using SSL termination
 
    Client and Traffic Server communication using SSL termination

--- a/doc/developer-guide/cache-architecture/architecture.en.rst
+++ b/doc/developer-guide/cache-architecture/architecture.en.rst
@@ -64,7 +64,6 @@ line in the file defines a :term:`cache span` which is treated as a uniform
 persistent store.
 
 .. figure:: images/cache-spans.png
-   :align: center
 
    Two cache spans
 
@@ -81,12 +80,10 @@ stripe is in a single cache span and part of a single cache volume.
 If the cache volumes for the example cache spans were defined as:
 
 .. image:: images/ats-cache-volume-definition.png
-   :align: center
 
 Then the actual layout would look like:
 
 .. image:: images/cache-span-layout.png
-   :align: center
 
 Cache stripes are the fundamental unit of cache for the implementation. A
 cached object is stored entirely in a single stripe, and therefore in a single
@@ -116,7 +113,6 @@ file system. A cache stripe is structured data contained in a span block and alw
 entire span block.
 
 .. image:: images/span-header.svg
-   :align: center
 
 Stripe Structure
 ----------------
@@ -175,7 +171,6 @@ memory as more content is stored in the cache. If there is enough memory to run
 |TS| with an empty cache there is enough to run it with a full cache.
 
 .. figure:: images/cache-directory-structure.png
-   :align: center
 
 Each entry stores an offset in the stripe and a size. The size stored in the
 directory entry is an :ref:`approximate size <dir-size>` which is at least as
@@ -215,7 +210,6 @@ a stripe is chosen so that each segment has as many buckets as possible without
 exceeding 65,535 (2\ :sup:`16`\ -1) entries in a segment.
 
 .. figure:: images/dir-segment-bucket.png
-   :align: center
 
 Each directory entry has a previous and next index value which is used to link
 entries in the same segment. Because no segment has more than 65,535 entries,
@@ -237,7 +231,6 @@ bucket locality (that is, :term:`cache IDs <cache ID>` that map to the same
 hash bucket will also tend to use the same directory bucket).
 
 .. figure:: images/dir-bucket-assign.png
-   :align: center
 
 Entries are removed from the free list when used and returned when no longer in
 use. When a :term:`fragment <cache fragment>` needs to be put in to the
@@ -263,7 +256,6 @@ without the segment free lists. This makes the size of the header dependent on
 the directory but not that of the footer.
 
 .. figure:: images/cache-stripe-layout.png
-   :align: center
 
 Each stripe has several values that describe its basic layout:
 
@@ -326,7 +318,6 @@ Instead it will be noted if the object is accessed in the future and the disk
 read of the fragment fails.
 
 .. figure:: images/ats-cache-write-cursor.png
-   :align: center
 
    The write cursor and documents in the cache.
 
@@ -381,7 +372,6 @@ area of the on disk image, followed by information about additional fragments
 if needed to store the object.
 
 .. figure:: images/cache-doc-layout-3-2-0.png
-   :align: center
 
    ``Doc`` layout 3.2.0
 
@@ -392,7 +382,6 @@ metadata to being directly incorporated in to the :cpp:class:`CacheHTTPInfoVecto
 yielding a layout of the following form.
 
 .. figure:: images/cache-doc-layout-4-0-1.png
-   :align: center
 
    ``Doc`` layout 4.0.1
 
@@ -444,7 +433,6 @@ of a single object are ordered they are not necessarily contiguous, as data from
 different objects are interleaved as the data arrives in |TS|.
 
 .. figure:: images/cache-multi-fragment.png
-   :align: center
 
    Multi-alternate and multi-fragment object storage
 

--- a/doc/developer-guide/client-session-architecture.en.rst
+++ b/doc/developer-guide/client-session-architecture.en.rst
@@ -37,7 +37,6 @@ ProxySession
 ------------------
 
 .. figure:: /static/images/sessions/session_hierarchy.png
-   :align: center
    :alt: ProxySession hierarchy
 
 The ProxySession class abstracts the key features of a client session.  It contains zero or more ProxyTransaction objects.  It also has a reference to the associated NetVC (either UnixNetVConnection or SSLNetVConnection).  The session class is responsible for interfacing with the user agent protocol.
@@ -50,7 +49,6 @@ ProxyTransaction
 ----------------------
 
 .. figure:: /static/images/sessions/transaction_hierarchy.png
-   :align: center
    :alt: ProxyTransaction hierarchy
 
 The ProxyTransaction class abstracts the key features of a client transaction.  It has a reference to its
@@ -65,7 +63,6 @@ HTTP/1.x Objects
 ----------------
 
 .. figure:: /static/images/sessions/http1_session_objects.png
-   :align: center
    :alt: HTTP1 session objects
 
 This diagram shows the relationships between objects created as part of a HTTP/1.x session.  A NetVC
@@ -88,7 +85,6 @@ HTTP/2 Objects
 --------------
 
 .. figure:: /static/images/sessions/http2_session_objects.png
-   :align: center
    :alt: HTTP/2 session objects
 
 This diagram shows the relationships between objects created as part of a HTTP/2 session.  It is very similar

--- a/doc/developer-guide/plugins/example-plugins/tls_bridge.en.rst
+++ b/doc/developer-guide/plugins/example-plugins/tls_bridge.en.rst
@@ -273,7 +273,6 @@ The overall exchange looks like the following:
 A detailed view of the plugin operation.
 
 .. image:: ../../../uml/images/TLS-Bridge-Plugin.svg
-   :align: center
 
 A sequence diagram focusing on the request / response data flow. There is a :code:`NetVConn` for the
 connection to the Peer |TS| which is omitted for clarity.
@@ -288,7 +287,6 @@ means there was an error and the tunnel is shut down. To deal with the Client re
 response code is stored and used later during cleanup.
 
 .. image:: ../../../uml/images/TLS-Bridge-Messages.svg
-   :align: center
 
 A restartable state machine is used to recognize the end of the Peer |TS| response. The initial part
 of the response is easy because all that is needed is to wait until there is sufficient data for a

--- a/doc/developer-guide/plugins/getting-started/index.en.rst
+++ b/doc/developer-guide/plugins/getting-started/index.en.rst
@@ -83,7 +83,6 @@ call-back functions you've registered for that event type.
 .. _PluginProcess:
 
 .. figure:: /static/images/sdk/plugin_process.jpg
-   :align: center
    :alt: Plugin Process
 
    Plugin Process
@@ -130,7 +129,6 @@ The figure below, :ref:`possibleTSplugins`, illustrates several types of plugins
 .. _possibleTSplugins:
 
 .. figure:: /static/images/sdk/Uses.jpg
-   :align: center
    :alt: Possible Traffic Server Plugins
 
    Possible Traffic Server Plugins

--- a/doc/developer-guide/plugins/http-transformations/index.en.rst
+++ b/doc/developer-guide/plugins/http-transformations/index.en.rst
@@ -88,7 +88,6 @@ relationship between the transformation ``VConnection`` and its
 
 .. figure:: /static/images/sdk/vconnection.jpg
    :alt: A Transformation and its VIOs
-   :align: center
 
    **A Transformation and its VIOs**
 


### PR DESCRIPTION
When we center images/figures, it frequently extends into the full browser
width, not the more constrained view. Removing the centering makes them
fit better.