### PR TITLE
Doc: centering images is not in view

### DIFF
--- a/doc/admin-guide/layer-4-routing.en.rst
+++ b/doc/admin-guide/layer-4-routing.en.rst
@@ -28,7 +28,7 @@ accomplished by examining the initial data from the inbound connection to decide
 destination. The initial data is then sent to the destination and subsequently |TS| forwards all
 data read on one connection to the other and vice versa.
 
-.. image:: ../uml/images/l4-basic-sequence.svg
+.. figure:: ../uml/images/l4-basic-sequence.svg
    :align: center
 
 In this way it acts similary to `nc <https://linux.die.net/man/1/nc>`__.
@@ -116,7 +116,7 @@ In addition to this, in the :file:`records.config` file, edit the following vari
 
 The sequence of network activity for a Client connecting to ``service-2`` is
 
-.. image:: ../uml/images/l4-sni-routing-seq.svg
+.. figure:: ../uml/images/l4-sni-routing-seq.svg
    :align: center
 
 Note the destination for the outbound TCP connection and the HTTP ``CONNECT`` is the same. If this

--- a/doc/admin-guide/monitoring/monitoring/third-party/circonus.en.rst
+++ b/doc/admin-guide/monitoring/monitoring/third-party/circonus.en.rst
@@ -62,7 +62,7 @@ environment.
 #. Begin the new check creation process from within your Circonus account by
    clicking the *New Check* button near the top-right of the checks screen.
 
-   .. image:: ../../../../static/images/admin/monitor/circonus/new-check-button.png
+   .. figure:: ../../../../static/images/admin/monitor/circonus/new-check-button.png
       :alt: Circonus New Check button
       :align: center
 
@@ -71,7 +71,7 @@ environment.
    you and will depend largely on whether you are using on-site Circonus or the
    hosted service, as well as the geographic location of your |TS| instance(s).
 
-   .. image:: ../../../../static/images/admin/monitor/circonus/check-config-1.png
+   .. figure:: ../../../../static/images/admin/monitor/circonus/check-config-1.png
       :alt: Choosing a check type
       :align: center
 
@@ -83,7 +83,7 @@ environment.
    any of the other options to match your environment if necessary (for this
    guide, only *Host* and *URI* will need to be entered).
 
-   .. image:: ../../../../static/images/admin/monitor/circonus/check-config-2.png
+   .. figure:: ../../../../static/images/admin/monitor/circonus/check-config-2.png
       :alt: Advanced check configuration
       :align: center
 
@@ -94,7 +94,7 @@ environment.
    running and use ``curl`` to manually fetch the statistics data from your
    server.
 
-   .. image:: ../../../../static/images/admin/monitor/circonus/check-config-3.png
+   .. figure:: ../../../../static/images/admin/monitor/circonus/check-config-3.png
       :alt: Check test
       :align: center
 
@@ -110,7 +110,7 @@ environment.
    clicking on *Metrics Grid* for an overview visualization of all the data
    being collected.
 
-   .. image:: ../../../../static/images/admin/monitor/circonus/metric-grid.png
+   .. figure:: ../../../../static/images/admin/monitor/circonus/metric-grid.png
       :alt: Circonus metric grid
       :align: center
 

--- a/doc/developer-guide/cache-architecture/architecture.en.rst
+++ b/doc/developer-guide/cache-architecture/architecture.en.rst
@@ -80,12 +80,12 @@ stripe is in a single cache span and part of a single cache volume.
 
 If the cache volumes for the example cache spans were defined as:
 
-.. image:: images/ats-cache-volume-definition.png
+.. figure:: images/ats-cache-volume-definition.png
    :align: center
 
 Then the actual layout would look like:
 
-.. image:: images/cache-span-layout.png
+.. figure:: images/cache-span-layout.png
    :align: center
 
 Cache stripes are the fundamental unit of cache for the implementation. A
@@ -115,7 +115,7 @@ relationship between a span block and a cache stripe is the same as between a di
 file system. A cache stripe is structured data contained in a span block and always occupies the
 entire span block.
 
-.. image:: images/span-header.svg
+.. figure:: images/span-header.svg
    :align: center
 
 Stripe Structure
@@ -292,7 +292,8 @@ The header for a stripe is a variably sized instance of :class:`VolHeaderFooter`
 The variable trailing section contains the head indices of the directory entry
 free lists for the segments.
 
-.. image:: images/stripe-header.svg
+.. figure:: images/stripe-header.svg
+   :align: center
 
 The trailing :member:`VolHeaderFooter::freelist` array overlays the disk storage with
 an entry for every segment, even though the array is declared to have length `1`.

--- a/doc/developer-guide/core-architecture/rpc.en.rst
+++ b/doc/developer-guide/core-architecture/rpc.en.rst
@@ -65,7 +65,7 @@ Message Passing
 
 Sequence diagram for a command sent from |TCtl| to when it is recieved by a plugin.
 
-.. image:: ../../uml/images/RPC-sequence-diagram.svg
+.. figure:: ../../uml/images/RPC-sequence-diagram.svg
 
 .. note::
 
@@ -231,7 +231,7 @@ Now, using this macro, messages can easily be sent. For example:
 RPC API for |TServer| and |TManager|
 ====================================
 
-.. image:: ../../uml/images/RPC-states.svg
+.. figure:: ../../uml/images/RPC-states.svg
    :align: center
 
 |LM| and |PM| follow similar workflows. A manager will poll the socket for any messages. If it is able to read a message, it will handle it based on the :arg:`msg_id` from the :class:`MgmtMessageHdr` and select a callback to run asynchoronously. The async callback will add a response, if any, to an outgoing event queue within the class. A manager will continue to poll and read on the socket as long as there are messages avaliable. Two things can stop a manager from polling.

--- a/doc/developer-guide/plugins/example-plugins/tls_bridge.en.rst
+++ b/doc/developer-guide/plugins/example-plugins/tls_bridge.en.rst
@@ -272,7 +272,7 @@ The overall exchange looks like the following:
 
 A detailed view of the plugin operation.
 
-.. image:: ../../../uml/images/TLS-Bridge-Plugin.svg
+.. figure:: ../../../uml/images/TLS-Bridge-Plugin.svg
    :align: center
 
 A sequence diagram focusing on the request / response data flow. There is a :code:`NetVConn` for the
@@ -287,7 +287,7 @@ The :code:`200 OK` sent from the Peer |TS| is parsed and consumed by the plugin.
 means there was an error and the tunnel is shut down. To deal with the Client response clean up the
 response code is stored and used later during cleanup.
 
-.. image:: ../../../uml/images/TLS-Bridge-Messages.svg
+.. figure:: ../../../uml/images/TLS-Bridge-Messages.svg
    :align: center
 
 A restartable state machine is used to recognize the end of the Peer |TS| response. The initial part

--- a/doc/static/override.css
+++ b/doc/static/override.css
@@ -19,6 +19,11 @@ dd {
     overflow: visible;
 }
 
+div.figure.align-center{
+    margin: initial;
+    max-width: 800px;
+}
+
 /* pre inside paragraphs gets weird spacing  */
 span.pre {
     line-height: initial;


### PR DESCRIPTION
When we center images/figures, it frequently extends into the full browser
width, not the more constrained view. Figures have a surrounding div that allows
for better styling than images. In Sphinx, an image is a simple picture, whereas
a figure is a image and surrounding data (caption, legend, etc). So, they are
effectively interchangeable.