### PR TITLE
Build: Fix array bounds error under -O3.

### DIFF
--- a/proxy/hdrs/HdrHeap.cc
+++ b/proxy/hdrs/HdrHeap.cc
@@ -962,7 +962,7 @@ HdrHeap::unmarshal(int buf_length, int obj_type, HdrHeapObjImpl **found_obj, Ref
 inline bool
 HdrHeap::attach_str_heap(char const *h_start, int h_len, RefCountObj *h_ref_obj, int *index)
 {
-  if (static_cast<unsigned>(*index) >= HDR_BUF_RONLY_HEAPS) {
+  if (*index >= static_cast<int>(HDR_BUF_RONLY_HEAPS)) {
     return false;
   }
 

--- a/proxy/hdrs/HdrHeap.h
+++ b/proxy/hdrs/HdrHeap.h
@@ -206,20 +206,20 @@ public:
   //  by a heap consolidation.  Does NOT lock for Multi-Threaed
   //  access!
   void
-  lock_ronly_str_heap(int i)
+  lock_ronly_str_heap(unsigned i)
   {
     m_ronly_heap[i].m_locked = true;
   }
 
   void
-  unlock_ronly_str_heap(int i)
+  unlock_ronly_str_heap(unsigned i)
   {
     m_ronly_heap[i].m_locked = false;
     // INKqa11238
     // Move slot i to the first available slot in m_ronly_heap[].
     // The move is necessary because the rest of the code assumes
     // heaps are always allocated in order.
-    for (int j = 0; j < i; j++) {
+    for (unsigned j = 0; j < i; j++) {
       if (m_ronly_heap[j].m_heap_start == nullptr) {
         // move slot i to slot j
         m_ronly_heap[j].m_ref_count_ptr = m_ronly_heap[i].m_ref_count_ptr;
@@ -230,6 +230,7 @@ public:
         m_ronly_heap[i].m_heap_start    = nullptr;
         m_ronly_heap[i].m_heap_len      = 0;
         m_ronly_heap[i].m_locked        = false;
+        break; // Did the move, time to go.
       }
     }
   }


### PR DESCRIPTION
This fixes the `-O3` build issue on my CentOS 7. I'm not sure why there wasn't a build issue without the `break` before, but perhaps the change to `unsigned` made a difference?