### PR TITLE
Cached object's size can be used as content length for 304 response

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -6873,7 +6873,13 @@ HttpTransact::handle_content_length_header(State *s, HTTPHdr *header, HTTPHdr *b
     DebugTxn("http_trans", "[handle_content_length_header] RESPONSE cont len in hdr is %" PRId64, header->get_content_length());
   } else {
     // No content length header.
-    if (s->source == SOURCE_CACHE) {
+    // If the source is cache or server returned 304 response,
+    // we can try to get the content length based on object size.
+    // Also, we should check the scenario of server sending't  a unexpected 304 response for a non conditional request( no cached
+    // object )
+    if (s->source == SOURCE_CACHE ||
+        (s->source == SOURCE_HTTP_ORIGIN_SERVER && s->hdr_info.server_response.status_get() == HTTP_STATUS_NOT_MODIFIED &&
+         s->cache_info.object_read != nullptr)) {
       // If there is no content-length header, we can
       //   insert one since the cache knows definately
       //   how long the object is unless we're in a
@@ -6888,18 +6894,14 @@ HttpTransact::handle_content_length_header(State *s, HTTPHdr *header, HTTPHdr *b
       } else if (s->range_setup == RANGE_NOT_TRANSFORM_REQUESTED) {
         // if we are doing a single Range: request, calculate the new
         // C-L: header
+        // either the object is in cache or origin returned a 304 Not Modified response. We can still turn this into a proper Range
+        // response from the cached object.
         change_response_header_because_of_range_request(s, header);
         s->hdr_info.trust_response_cl = true;
       } else {
         header->set_content_length(cl);
         s->hdr_info.trust_response_cl = true;
       }
-    } else if (s->source == SOURCE_HTTP_ORIGIN_SERVER && s->hdr_info.server_response.status_get() == HTTP_STATUS_NOT_MODIFIED &&
-               s->range_setup == RANGE_NOT_TRANSFORM_REQUESTED) {
-      // In this case, we had a cached object, possibly chunked encoded (so we don't have a CL: header), but the origin did a
-      // 304 Not Modified response. We can still turn this into a proper Range response from the cached object.
-      change_response_header_because_of_range_request(s, header);
-      s->hdr_info.trust_response_cl = true;
     } else {
       // Check to see if there is no content length
       //  header because the response precludes a


### PR DESCRIPTION
(cherry picked from commit 23cdf765e3ca4ac15c7fdbe83ca67cc0a36bcdda)