### PR TITLE
ink_inet: Fix family string printing, add IpAddr::isAnyAddr.

### DIFF
--- a/include/tscore/ink_inet.h
+++ b/include/tscore/ink_inet.h
@@ -1282,6 +1282,9 @@ struct IpAddr {
   /// Test for loopback
   bool isLoopback() const;
 
+  /// Test for any addr
+  bool isAnyAddr() const;
+
   uint16_t _family; ///< Protocol family.
   /// Address data.
   union {
@@ -1339,6 +1342,12 @@ inline bool
 IpAddr::isLoopback() const
 {
   return (AF_INET == _family && 0x7F == _addr._byte[0]) || (AF_INET6 == _family && IN6_IS_ADDR_LOOPBACK(&_addr._ip6));
+}
+
+inline bool
+IpAddr::isAnyAddr() const
+{
+  return (AF_INET == _family && INADDR_ANY == _addr._ip4) || (AF_INET6 == _family && IN6_IS_ADDR_UNSPECIFIED(&_addr._ip6));
 }
 
 /// Assign sockaddr storage.

--- a/src/tscore/ink_inet.cc
+++ b/src/tscore/ink_inet.cc
@@ -841,7 +841,7 @@ bwformat(BufferWriter &w, BWFSpec const &spec, IpAddr const &addr)
     if (spec.has_numeric_type()) {
       bwformat(w, local_spec, static_cast<uintmax_t>(addr.family()));
     } else {
-      bwformat(w, local_spec, addr.family());
+      bwformat(w, local_spec, ats_ip_family_name(addr.family()));
     }
   }
   return w;


### PR DESCRIPTION
Add

*  `IpAddr::isAnyAddr` in parallel to `IpEndpoint::isAnyAddr`.
*  Fix formatting problem with address family for `IpAddr`.