### PR TITLE
RecHttp.cc unit tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ CPP_LIB(tscppapi src/tscpp/api include/tscpp/api)
 
 CC_EXEC(test_tscore src/tscore/unit_tests)
 CC_EXEC(test_tsutil src/tscpp/util/unit_tests)
+CC_EXEC(test_librecords lib/records/unit_tests)
 
 CPP_LIB(proxy proxy proxy)
 CPP_ADD_SOURCES(proxy proxy/http)

--- a/include/tscore/Diags.h
+++ b/include/tscore/Diags.h
@@ -113,7 +113,7 @@ class Diags
 public:
   Diags(const char *prefix_string, const char *base_debug_tags, const char *base_action_tags, BaseLogFile *_diags_log,
         int diags_log_perm = -1, int output_log_perm = -1);
-  ~Diags();
+  virtual ~Diags();
 
   BaseLogFile *diags_log;
   BaseLogFile *stdout_log;
@@ -208,7 +208,7 @@ public:
     va_end(ap);
   }
 
-  void error_va(DiagsLevel level, const SourceLocation *loc, const char *fmt, va_list ap) const;
+  virtual void error_va(DiagsLevel level, const SourceLocation *loc, const char *fmt, va_list ap) const;
 
   void dump(FILE *fp = stdout) const;
 

--- a/lib/records/Makefile.am
+++ b/lib/records/Makefile.am
@@ -18,6 +18,8 @@
 
 include $(top_srcdir)/build/tidy.mk
 
+check_PROGRAMS = test_librecords
+
 AM_CPPFLAGS += \
 	-I$(abs_top_srcdir)/iocore/eventsystem \
 	-I$(abs_top_srcdir)/iocore/utils \
@@ -66,6 +68,25 @@ librecords_p_a_SOURCES = \
 	I_RecProcess.h \
 	P_RecProcess.h \
 	RecProcess.cc
+
+TESTS = $(check_PROGRAMS)
+
+test_librecords_CPPFLAGS = $(AM_CPPFLAGS)\
+        -I$(abs_top_srcdir)/tests/include
+
+test_librecords_SOURCES = \
+    unit_tests/unit_test_main.cc \
+    unit_tests/test_RecHttp.cc
+
+test_librecords_LDADD = \
+	$(top_builddir)/lib/records/librecords_p.a \
+	$(top_builddir)/mgmt/libmgmt_p.la \
+	$(top_builddir)/iocore/eventsystem/libinkevent.a \
+	$(top_builddir)/src/tscpp/util/libtscpputil.la \
+	$(top_builddir)/src/tscore/libtscore.la \
+	$(top_builddir)/proxy/shared/libUglyLogStubs.a \
+	@HWLOC_LIBS@ @LIBCAP@
+
 
 clang-tidy-local: $(sort $(DIST_SOURCES))
 	$(CXX_Clang_Tidy)

--- a/lib/records/unit_tests/test_Diags.h
+++ b/lib/records/unit_tests/test_Diags.h
@@ -1,0 +1,38 @@
+/** @file
+
+  This file used for catch based tests. It is the main() stub.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
+  See the NOTICE file distributed with this work for additional information regarding copyright
+  ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance with the License.  You may obtain a
+  copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License
+  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  or implied. See the License for the specific language governing permissions and limitations under
+  the License.
+ */
+
+#include "tscore/Diags.h"
+
+class CatchDiags : public Diags
+{
+public:
+  mutable std::vector<std::string> messages;
+
+  CatchDiags() : Diags("catch", "", "", nullptr) {}
+
+  void
+  error_va(DiagsLevel diags_level, const SourceLocation *loc, const char *fmt, va_list ap) const override
+  {
+    char buff[32768];
+    vsnprintf(buff, sizeof(buff), fmt, ap);
+    messages.push_back(std::string{buff});
+    va_end(ap);
+  }
+};

--- a/lib/records/unit_tests/test_RecHttp.cc
+++ b/lib/records/unit_tests/test_RecHttp.cc
@@ -1,0 +1,99 @@
+/** @file
+
+   Catch-based tests for HdrsUtils.cc
+
+   @section license License
+
+   Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
+   See the NOTICE file distributed with this work for additional information regarding copyright
+   ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance with the License.  You may obtain a
+   copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software distributed under the License
+   is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+   or implied. See the License for the specific language governing permissions and limitations under
+   the License.
+ */
+
+#include <string>
+#include <string_view>
+#include <array>
+
+#include "catch.hpp"
+
+#include "tscore/BufferWriter.h"
+#include "records/I_RecHttp.h"
+#include "test_Diags.h"
+
+using ts::TextView;
+
+TEST_CASE("RecHttp", "[librecords][RecHttp]")
+{
+  std::vector<HttpProxyPort> ports;
+  CatchDiags *cdiag = static_cast<CatchDiags *>(diags);
+  cdiag->messages.clear();
+
+  SECTION("base")
+  {
+    HttpProxyPort::loadValue(ports, "8080");
+    REQUIRE(ports.size() == 1);
+    REQUIRE(ports[0].m_port == 8080);
+  }
+
+  SECTION("two")
+  {
+    HttpProxyPort::loadValue(ports, "8080 8090");
+    REQUIRE(ports.size() == 2);
+    REQUIRE(ports[0].m_port == 8080);
+    REQUIRE(ports[1].m_port == 8090);
+  }
+
+  SECTION("family")
+  {
+    HttpProxyPort::loadValue(ports, "7070:ipv4:ip-in=192.168.56.1");
+    REQUIRE(ports.size() == 1);
+    REQUIRE(ports[0].m_port == 7070);
+    REQUIRE(ports[0].m_family == AF_INET);
+    REQUIRE(ports[0].isSSL() == false);
+  }
+
+  SECTION("crossed-family")
+  {
+    HttpProxyPort::loadValue(ports, "7070:ipv6:ip-in=192.168.56.1");
+    REQUIRE(ports.size() == 0);
+    REQUIRE(cdiag->messages.size() == 2);
+    REQUIRE(cdiag->messages[0].find("[ipv6]") != std::string::npos);
+    REQUIRE(cdiag->messages[0].find("[ipv4]") != std::string::npos);
+  }
+
+  SECTION("ipv6-a")
+  {
+    TextView descriptor{"4443:ssl:ip-in=[ffee::24c3:3349:3cee:0143]"};
+    HttpProxyPort::loadValue(ports, descriptor.data());
+    REQUIRE(ports.size() == 1);
+    REQUIRE(ports[0].m_port == 4443);
+    REQUIRE(ports[0].m_family == AF_INET6);
+    REQUIRE(ports[0].isSSL() == true);
+  }
+
+  SECTION("dual-addr")
+  {
+    TextView descriptor{"4443:ssl:ipv6:ip-out=[ffee::24c3:3349:3cee:0143]:ip-out=10.1.2.3"};
+    HttpProxyPort::loadValue(ports, descriptor.data());
+    char buff[256];
+    ports[0].print(buff, sizeof(buff));
+    std::string_view view{buff};
+    REQUIRE(ports.size() == 1);
+    REQUIRE(ports[0].m_port == 4443);
+    REQUIRE(ports[0].m_family == AF_INET6);
+    REQUIRE(ports[0].isSSL() == true);
+    REQUIRE(ports[0].m_outbound_ip6.isValid() == true);
+    REQUIRE(ports[0].m_outbound_ip4.isValid() == true);
+    REQUIRE(ports[0].m_inbound_ip.isValid() == false);
+    REQUIRE(view.find(":ssl") != TextView::npos);
+    REQUIRE(view.find(":proto") == TextView::npos); // it's default, should not have this.
+  }
+}

--- a/lib/records/unit_tests/unit_test_main.cc
+++ b/lib/records/unit_tests/unit_test_main.cc
@@ -1,0 +1,46 @@
+/** @file
+
+  This file used for catch based tests. It is the main() stub.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
+  See the NOTICE file distributed with this work for additional information regarding copyright
+  ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance with the License.  You may obtain a
+  copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License
+  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  or implied. See the License for the specific language governing permissions and limitations under
+  the License.
+ */
+
+#include <vector>
+#include <string>
+#include "tscore/BufferWriter.h"
+#include "tscore/ink_resolver.h"
+#include "test_Diags.h"
+
+#define CATCH_CONFIG_RUNNER
+#include "catch.hpp"
+
+Diags *diags = new CatchDiags;
+extern void ts_session_protocol_well_known_name_indices_init();
+
+int
+main(int argc, char *argv[])
+{
+  // Global data initialization needed for the unit tests.
+  ts_session_protocol_well_known_name_indices_init();
+  // Cheat for ts_host_res_global_init as there's no records.config to check for non-default.
+  memcpy(host_res_default_preference_order, HOST_RES_DEFAULT_PREFERENCE_ORDER, sizeof(host_res_default_preference_order));
+
+  int result = Catch::Session().run(argc, argv);
+
+  // global clean-up...
+
+  return result;
+}


### PR DESCRIPTION
This is split in to two commits.

*  Convert `Diags::error_va` to be `virtual` (plus the destructor, to make the compiler happy).
*  Add unit tests to "lib/records" and "RecHttp.cc" in particular.

The utility of the first commit is demonstrated by the second. This change enables unit tests like this to examine error messages. The base `Diags` is subclassed and `Diags::error_va` is overridden so that
error messages are captured to a local list/vector which can be then examined by the unit test code. Doing this makes it possible to verify configuration error detection and to some extent the correct output of error situations without requiring a full up test that must restart TS multiple times in order to check the various error conditions.