### PR TITLE
s3_auth:fixed uncaught exception on invalid input

### DIFF
--- a/plugins/s3_auth/unit_tests/test_aws_auth_v4.h
+++ b/plugins/s3_auth/unit_tests/test_aws_auth_v4.h
@@ -121,7 +121,7 @@ public:
 /* Expose the following methods only to the unit tests */
 String base16Encode(const char *in, size_t inLen);
 String uriEncode(const String &in, bool isObjectName = false);
-String uriDecode(const String &in);
+bool isUriEncoded(const String &in, bool isObjectName = false);
 String lowercase(const char *in, size_t inLen);
 const char *trimWhiteSpaces(const char *in, size_t inLen, size_t &newLen);
 


### PR DESCRIPTION
Instead of fixing the URI decoding functionality to handle the exception
(re)implemented a check for percent encoding which was what was needed.

During signature calculation AWS avoids URI encoding of already encoded
query parameters (rfc3986#section-2.4 says "implementations must not
percent-encode or decode the same string more than once ...")