### PR TITLE
Adds websocket note for remap config

### DIFF
--- a/doc/admin-guide/files/remap.config.en.rst
+++ b/doc/admin-guide/files/remap.config.en.rst
@@ -107,6 +107,8 @@ Traffic Server recognizes three space-delimited fields: ``type``,
 
     where ``scheme`` is ``http``, ``https``, ``ws`` or ``wss``.
 
+   .. note:: A remap rule for requests that upgrade from HTTP to WebSocket still require a remap rule with the ``ws`` or ``wss`` scheme.
+
 
 .. _remap-config-precedence:
 


### PR DESCRIPTION
![screen shot 2019-02-18 at 13 51 40](https://user-images.githubusercontent.com/905298/52973663-67b31500-3384-11e9-9311-c7f0060c04b1.png)

Backport Rationale: This functionality is unlikely to have changed, and could help administrators using older versions when proxying HTTP/S requests that upgrade to WS/S.