### PR TITLE
IpMap: Add move constructor.

### DIFF
--- a/include/tscore/IpMap.h
+++ b/include/tscore/IpMap.h
@@ -23,6 +23,9 @@
 
 #pragma once
 
+#include <algorithm>
+#include <utility>
+
 #include "tscore/ink_platform.h"
 #include "tscore/ink_defs.h"
 #include "tscore/RbTree.h"
@@ -42,8 +45,8 @@ namespace detail
             typename A = T const & ///< Argument type.
             >
   struct Interval {
-    typedef T Metric;  ///< Metric (storage) type.
-    typedef A ArgType; ///< Type used to pass instances of @c Metric.
+    using Metric  = T; ///< Metric (storage) type.
+    using ArgType = A; ///< Type used to pass instances of @c Metric.
 
     Interval() {} ///< Default constructor.
     /// Construct with values.
@@ -95,7 +98,7 @@ namespace detail
 class IpMap
 {
 public:
-  typedef IpMap self; ///< Self reference type.
+  using self_type = IpMap; ///< Self reference type.
 
   class iterator; // forward declare.
 
@@ -107,7 +110,7 @@ public:
     friend class IpMap;
 
   public:
-    typedef Node self; ///< Self reference type.
+    using self_type = Node; ///< Self reference type.
     /// Default constructor.
     Node() : _data(nullptr) {}
     /// Construct with @a data.
@@ -119,7 +122,7 @@ public:
       return _data;
     }
     /// Set client data.
-    virtual self &
+    virtual self_type &
     setData(void *data ///< Client data pointer to store.
     )
     {
@@ -146,30 +149,30 @@ public:
     friend class IpMap;
 
   public:
-    typedef iterator self;       ///< Self reference type.
-    typedef Node value_type;     ///< Referenced type for iterator.
-    typedef int difference_type; ///< Distance type.
-    typedef Node *pointer;       ///< Pointer to referent.
-    typedef Node &reference;     ///< Reference to referent.
-    typedef std::bidirectional_iterator_tag iterator_category;
+    using self_type         = iterator; ///< Self reference type.
+    using value_type        = Node;     ///< Referenced type for iterator.
+    using difference_type   = int;      ///< Distance type.
+    using pointer           = Node *;   ///< Pointer to referent.
+    using reference         = Node &;   ///< Reference to referent.
+    using iterator_category = std::bidirectional_iterator_tag;
     /// Default constructor.
-    iterator() : _tree(nullptr), _node(nullptr) {}
+    iterator() = default;
     reference operator*() const; //!< value operator
     pointer operator->() const;  //!< dereference operator
-    self &operator++();          //!< next node (prefix)
-    self operator++(int);        //!< next node (postfix)
-    self &operator--();          ///< previous node (prefix)
-    self operator--(int);        ///< next node (postfix)
+    self_type &operator++();     //!< next node (prefix)
+    self_type operator++(int);   //!< next node (postfix)
+    self_type &operator--();     ///< previous node (prefix)
+    self_type operator--(int);   ///< next node (postfix)
 
     /** Equality.
         @return @c true if the iterators refer to the same node.
     */
-    bool operator==(self const &that) const;
+    bool operator==(self_type const &that) const;
     /** Inequality.
         @return @c true if the iterators refer to different nodes.
     */
     bool
-    operator!=(self const &that) const
+    operator!=(self_type const &that) const
     {
       return !(*this == that);
     }
@@ -177,20 +180,25 @@ public:
   private:
     /// Construct a valid iterator.
     iterator(IpMap const *tree, Node *node) : _tree(tree), _node(node) {}
-    IpMap const *_tree; ///< Container.
-    Node *_node;        //!< Current node.
+    IpMap const *_tree = nullptr; ///< Container.
+    Node *_node        = nullptr; //!< Current node.
   };
 
-  IpMap();  ///< Default constructor.
+  IpMap(); ///< Default constructor.
+  IpMap(self_type const &that) = delete;
+  IpMap(self_type &&that) noexcept;
   ~IpMap(); ///< Destructor.
 
+  self_type &operator=(self_type const &that) = delete;
+  self_type &operator                         =(self_type &&that);
+
   /** Mark a range.
       All addresses in the range [ @a min , @a max ] are marked with @a data.
       @return This object.
   */
-  self &mark(sockaddr const *min, ///< Minimum value in range.
-             sockaddr const *max, ///< Maximum value in range.
-             void *data = nullptr ///< Client data payload.
+  self_type &mark(sockaddr const *min, ///< Minimum value in range.
+                  sockaddr const *max, ///< Maximum value in range.
+                  void *data = nullptr ///< Client data payload.
   );
 
   /** Mark a range.
@@ -198,9 +206,9 @@ public:
       @note Convenience overload for IPv4 addresses.
       @return This object.
   */
-  self &mark(in_addr_t min,       ///< Minimum address (network order).
-             in_addr_t max,       ///< Maximum address (network order).
-             void *data = nullptr ///< Client data.
+  self_type &mark(in_addr_t min,       ///< Minimum address (network order).
+                  in_addr_t max,       ///< Maximum address (network order).
+                  void *data = nullptr ///< Client data.
   );
 
   /** Mark a range.
@@ -208,9 +216,9 @@ public:
       @note Convenience overload for IPv4 addresses.
       @return This object.
   */
-  self &mark(IpAddr const &min,   ///< Minimum address (network order).
-             IpAddr const &max,   ///< Maximum address (network order).
-             void *data = nullptr ///< Client data.
+  self_type &mark(IpAddr const &min,   ///< Minimum address (network order).
+                  IpAddr const &max,   ///< Maximum address (network order).
+                  void *data = nullptr ///< Client data.
   );
 
   /** Mark an IPv4 address @a addr with @a data.
@@ -218,8 +226,8 @@ public:
       @note Convenience overload for IPv4 addresses.
       @return This object.
   */
-  self &mark(in_addr_t addr,      ///< Address (network order).
-             void *data = nullptr ///< Client data.
+  self_type &mark(in_addr_t addr,      ///< Address (network order).
+                  void *data = nullptr ///< Client data.
   );
 
   /** Mark a range.
@@ -227,9 +235,9 @@ public:
       @note Convenience overload.
       @return This object.
   */
-  self &mark(IpEndpoint const *min, ///< Minimum address (network order).
-             IpEndpoint const *max, ///< Maximum address (network order).
-             void *data = nullptr   ///< Client data.
+  self_type &mark(IpEndpoint const *min, ///< Minimum address (network order).
+                  IpEndpoint const *max, ///< Maximum address (network order).
+                  void *data = nullptr   ///< Client data.
   );
 
   /** Mark an address @a addr with @a data.
@@ -237,8 +245,8 @@ public:
       @note Convenience overload.
       @return This object.
   */
-  self &mark(IpEndpoint const *addr, ///< Address (network order).
-             void *data = nullptr    ///< Client data.
+  self_type &mark(IpEndpoint const *addr, ///< Address (network order).
+                  void *data = nullptr    ///< Client data.
   );
 
   /** Unmark addresses.
@@ -248,14 +256,14 @@ public:
 
       @return This object.
   */
-  self &unmark(sockaddr const *min, ///< Minimum value.
-               sockaddr const *max  ///< Maximum value.
+  self_type &unmark(sockaddr const *min, ///< Minimum value.
+                    sockaddr const *max  ///< Maximum value.
   );
   /// Unmark addresses (overload).
-  self &unmark(IpEndpoint const *min, IpEndpoint const *max);
+  self_type &unmark(IpEndpoint const *min, IpEndpoint const *max);
   /// Unmark overload.
-  self &unmark(in_addr_t min, ///< Minimum of range to unmark.
-               in_addr_t max  ///< Maximum of range to unmark.
+  self_type &unmark(in_addr_t min, ///< Minimum of range to unmark.
+                    in_addr_t max  ///< Maximum of range to unmark.
   );
 
   /** Fill addresses.
@@ -269,13 +277,13 @@ public:
 
       @return This object.
   */
-  self &fill(sockaddr const *min, sockaddr const *max, void *data = nullptr);
+  self_type &fill(sockaddr const *min, sockaddr const *max, void *data = nullptr);
   /// Fill addresses (overload).
-  self &fill(IpEndpoint const *min, IpEndpoint const *max, void *data = nullptr);
+  self_type &fill(IpEndpoint const *min, IpEndpoint const *max, void *data = nullptr);
   /// Fill addresses (overload).
-  self &fill(IpAddr const &min, IpAddr const &max, void *data = nullptr);
+  self_type &fill(IpAddr const &min, IpAddr const &max, void *data = nullptr);
   /// Fill addresses (overload).
-  self &fill(in_addr_t min, in_addr_t max, void *data = nullptr);
+  self_type &fill(in_addr_t min, in_addr_t max, void *data = nullptr);
 
   /** Test for membership.
 
@@ -328,7 +336,7 @@ public:
       @note This is much faster than @c unmark.
       @return This object.
   */
-  self &clear();
+  self_type &clear();
 
   /// Iterator for first element.
   iterator begin() const;
@@ -354,8 +362,8 @@ protected:
   /// @return The IPv6 map.
   ts::detail::Ip6Map *force6();
 
-  ts::detail::Ip4Map *_m4; ///< Map of IPv4 addresses.
-  ts::detail::Ip6Map *_m6; ///< Map of IPv6 addresses.
+  ts::detail::Ip4Map *_m4 = nullptr; ///< Map of IPv4 addresses.
+  ts::detail::Ip6Map *_m6 = nullptr; ///< Map of IPv6 addresses.
 };
 
 inline IpMap &
@@ -437,7 +445,7 @@ IpMap::iterator::operator++(int)
 inline IpMap::iterator
 IpMap::iterator::operator--(int)
 {
-  self tmp(*this);
+  self_type tmp(*this);
   --*this;
   return tmp;
 }

--- a/src/tscore/unit_tests/test_IpMap.cc
+++ b/src/tscore/unit_tests/test_IpMap.cc
@@ -540,11 +540,11 @@ TEST_CASE("IpMap CloseIntersection", "[libts][ipmap]")
   void *const markB = reinterpret_cast<void *>(2);
   void *const markC = reinterpret_cast<void *>(3);
   void *const markD = reinterpret_cast<void *>(4);
-  // void *mark; // for retrieval
 
   IpEndpoint a_1_l, a_1_u, a_2_l, a_2_u, a_3_l, a_3_u, a_4_l, a_4_u, a_5_l, a_5_u, a_6_l, a_6_u, a_7_l, a_7_u;
   IpEndpoint b_1_l, b_1_u;
   IpEndpoint c_1_l, c_1_u, c_2_l, c_2_u, c_3_l, c_3_u;
+  IpEndpoint c_3_m;
   IpEndpoint d_1_l, d_1_u, d_2_l, d_2_u;
 
   IpEndpoint a_1_m;
@@ -573,6 +573,7 @@ TEST_CASE("IpMap CloseIntersection", "[libts][ipmap]")
   ats_ip_pton("123.90.112.0", &c_2_l);
   ats_ip_pton("123.90.119.255", &c_2_u);
   ats_ip_pton("123.90.132.0", &c_3_l);
+  ats_ip_pton("123.90.134.157", &c_3_m);
   ats_ip_pton("123.90.135.255", &c_3_u);
 
   ats_ip_pton("123.82.196.0", &d_1_l);
@@ -590,16 +591,33 @@ TEST_CASE("IpMap CloseIntersection", "[libts][ipmap]")
   CHECK_THAT(map, IsMarkedAt(a_1_m));
 
   map.mark(b_1_l, b_1_u, markB);
-  CHECK_THAT(map, IsMarkedAt(a_1_m));
+  CHECK_THAT(map, IsMarkedWith(a_1_m, markA));
 
   map.mark(c_1_l, c_1_u, markC);
   map.mark(c_2_l, c_2_u, markC);
   map.mark(c_3_l, c_3_u, markC);
-  CHECK_THAT(map, IsMarkedAt(a_1_m));
+  CHECK_THAT(map, IsMarkedWith(a_1_m, markA));
 
   map.mark(d_1_l, d_1_u, markD);
   map.mark(d_2_l, d_2_u, markD);
   CHECK_THAT(map, IsMarkedAt(a_1_m));
+  CHECK_THAT(map, IsMarkedWith(b_1_u, markB));
+  CHECK_THAT(map, IsMarkedWith(c_3_m, markC));
+  CHECK_THAT(map, IsMarkedWith(d_2_l, markD));
 
   CHECK(map.count() == 13);
-}
+
+  // Check move constructor.
+  IpMap m2{std::move(map)};
+  // Original map should be empty.
+  REQUIRE(map.count() == 0);
+  // Do all these again on the destination map.
+  CHECK_THAT(m2, IsMarkedWith(a_1_m, markA));
+  CHECK_THAT(m2, IsMarkedWith(a_1_m, markA));
+  CHECK_THAT(m2, IsMarkedWith(a_1_m, markA));
+  CHECK_THAT(m2, IsMarkedWith(a_1_m, markA));
+  CHECK_THAT(m2, IsMarkedWith(b_1_u, markB));
+  CHECK_THAT(m2, IsMarkedWith(c_3_m, markC));
+  CHECK_THAT(m2, IsMarkedWith(d_2_l, markD));
+  CHECK(m2.count() == 13);
+};


### PR DESCRIPTION
`IpMap`

*  Add move constructor, assignment operator
*  Change deprecated `self` to `self_type`.
*  Change `typedef` to `using`.
*  Use declaration initialization in preference to member initialization in constructors.
*  Add tests for move constructor.