### PR TITLE
Add BufferWriter formatting support to IpMap

### DIFF
--- a/include/tscore/IpMap.h
+++ b/include/tscore/IpMap.h
@@ -32,6 +32,7 @@
 #include "tscore/ink_inet.h"
 #include "tscpp/util/IntrusiveDList.h"
 #include "tscore/ink_assert.h"
+#include "tscore/BufferWriterForward.h"
 
 namespace ts
 {
@@ -184,7 +185,7 @@ public:
     Node *_node        = nullptr; //!< Current node.
   };
 
-  IpMap(); ///< Default constructor.
+  IpMap()                      = default; ///< Default constructor.
   IpMap(self_type const &that) = delete;
   IpMap(self_type &&that) noexcept;
   ~IpMap(); ///< Destructor.
@@ -350,9 +351,13 @@ public:
   */
   void validate();
 
-  /// Print all spans.
-  /// @return This map.
-  //  self& print();
+  /** Generate formatted output.
+   *
+   * @param w Destination of formatted output.
+   * @param spec Formatting specification.
+   * @return @a w
+   */
+  ts::BufferWriter &describe(ts::BufferWriter &w, ts::BWFSpec const &spec) const;
 
 protected:
   /// Force the IPv4 map to exist.
@@ -466,4 +471,11 @@ inline IpMap::iterator::pointer IpMap::iterator::operator->() const
   return _node;
 }
 
-inline IpMap::IpMap() : _m4(nullptr), _m6(nullptr) {}
+namespace ts
+{
+inline BufferWriter &
+bwformat(BufferWriter &w, BWFSpec const &spec, IpMap const &map)
+{
+  return map.describe(w, spec);
+}
+} // namespace ts

--- a/src/tscore/unit_tests/test_IpMap.cc
+++ b/src/tscore/unit_tests/test_IpMap.cc
@@ -24,6 +24,7 @@
 #include "tscore/IpMap.h"
 #include <sstream>
 #include <catch.hpp>
+#include <tscore/BufferWriter.h>
 
 std::ostream &
 operator<<(std::ostream &s, IpEndpoint const &addr)
@@ -620,4 +621,13 @@ TEST_CASE("IpMap CloseIntersection", "[libts][ipmap]")
   CHECK_THAT(m2, IsMarkedWith(c_3_m, markC));
   CHECK_THAT(m2, IsMarkedWith(d_2_l, markD));
   CHECK(m2.count() == 13);
+
+#if 0
+  ts::LocalBufferWriter<1024> w;
+  std::cout << "Basic map dump" << std::endl;
+  std::cout << w.print("{}", m2).view() << std::endl;
+  w.reset();
+  std::cout << "With tree detail" << std::endl;
+  std::cout << w.print("{::x}", m2).view() << std::endl;
+#endif
 };


### PR DESCRIPTION
~This depends on #5030 (which is the first commit).~

For some other work, I need to be able to dump an `IpMap` to someplace not `stdout`. The easiest thing to do is provide support for using it in `BufferWriter`.