### PR TITLE
Fixed memory leaking introduced by 4873

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -3289,7 +3289,6 @@ HttpSM::tunnel_handler_ua(int event, HttpTunnelConsumer *c)
 
     vc_table.remove_entry(this->ua_entry);
     ua_txn->do_io_close();
-    ua_txn = nullptr;
   } else {
     ink_assert(ua_buffer_reader != nullptr);
     ua_txn->release(ua_buffer_reader);


### PR DESCRIPTION
Based on #4873, The ua_txn set to nullptr,  `transaction_done` is never called by HttpSM. So the Session is never freed.