### PR TITLE
Set thread affinity using type info

### DIFF
--- a/iocore/eventsystem/P_UnixEventProcessor.h
+++ b/iocore/eventsystem/P_UnixEventProcessor.h
@@ -71,6 +71,9 @@ EventProcessor::schedule(Event *e, EventType etype, bool fast_signal)
     e->ethread = ethread;
   } else {
     e->ethread = assign_thread(etype);
+    if (ethread == nullptr) {
+      e->continuation->setThreadAffinity(e->ethread);
+    }
   }
 
   if (e->continuation->mutex) {

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -4409,8 +4409,7 @@ TSContSchedule(TSCont contp, TSHRTime timeout)
 
   EThread *eth = i->getThreadAffinity();
   if (eth == nullptr) {
-    eth = this_event_thread();
-    i->setThreadAffinity(eth);
+    return nullptr;
   }
 
   TSAction action;
@@ -4436,10 +4435,6 @@ TSContScheduleOnPool(TSCont contp, TSHRTime timeout, TSThreadPool tp)
 
   if (ink_atomic_increment(static_cast<int *>(&i->m_event_count), 1) < 0) {
     ink_assert(!"not reached");
-  }
-
-  if (i->getThreadAffinity() == nullptr) {
-    i->setThreadAffinity(this_event_thread());
   }
 
   EventType etype;
@@ -4527,8 +4522,7 @@ TSContScheduleEvery(TSCont contp, TSHRTime every /* millisecs */)
 
   EThread *eth = i->getThreadAffinity();
   if (eth == nullptr) {
-    eth = this_event_thread();
-    i->setThreadAffinity(eth);
+    return nullptr;
   }
 
   TSAction action = reinterpret_cast<TSAction>(eth->schedule_every(i, HRTIME_MSECONDS(every)));
@@ -4549,10 +4543,6 @@ TSContScheduleEveryOnPool(TSCont contp, TSHRTime every, TSThreadPool tp)
 
   if (ink_atomic_increment(static_cast<int *>(&i->m_event_count), 1) < 0) {
     ink_assert(!"not reached");
-  }
-
-  if (i->getThreadAffinity() == nullptr) {
-    i->setThreadAffinity(this_event_thread());
   }
 
   EventType etype;

--- a/tests/gold_tests/cont_schedule/gold/thread_affinity.gold
+++ b/tests/gold_tests/cont_schedule/gold/thread_affinity.gold
@@ -1,5 +1,5 @@
 ``
-``pass [affinity thread is null]
-``pass [affinity thread is set]
+``pass [affinity thread is not null]
 ``pass [affinity thread is cleared]
+``pass [affinity thread is set]
 ``

--- a/tests/tools/plugins/cont_schedule.cc
+++ b/tests/tools/plugins/cont_schedule.cc
@@ -175,22 +175,22 @@ TSContThreadAffinity_handler(TSCont contp, TSEvent event, void *edata)
 
   test_thread = TSEventThreadSelf();
 
-  if (TSContThreadAffinityGet(contp) == nullptr) {
-    TSDebug(DEBUG_TAG_CHK, "pass [affinity thread is null]");
-    TSContThreadAffinitySet(contp, TSEventThreadSelf());
-    if (TSContThreadAffinityGet(contp) == test_thread) {
-      TSDebug(DEBUG_TAG_CHK, "pass [affinity thread is set]");
-      TSContThreadAffinityClear(contp);
-      if (TSContThreadAffinityGet(contp) == nullptr) {
-        TSDebug(DEBUG_TAG_CHK, "pass [affinity thread is cleared]");
+  if (TSContThreadAffinityGet(contp) != nullptr) {
+    TSDebug(DEBUG_TAG_CHK, "pass [affinity thread is not null]");
+    TSContThreadAffinityClear(contp);
+    if (TSContThreadAffinityGet(contp) == nullptr) {
+      TSDebug(DEBUG_TAG_CHK, "pass [affinity thread is cleared]");
+      TSContThreadAffinitySet(contp, TSEventThreadSelf());
+      if (TSContThreadAffinityGet(contp) == test_thread) {
+        TSDebug(DEBUG_TAG_CHK, "pass [affinity thread is set]");
       } else {
-        TSDebug(DEBUG_TAG_CHK, "fail [affinity thread is not cleared]");
+        TSDebug(DEBUG_TAG_CHK, "fail [affinity thread is not set]");
       }
     } else {
-      TSDebug(DEBUG_TAG_CHK, "fail [affinity thread is not set]");
+      TSDebug(DEBUG_TAG_CHK, "fail [affinity thread is not cleared]");
     }
   } else {
-    TSDebug(DEBUG_TAG_CHK, "fail [affinity thread is not null]");
+    TSDebug(DEBUG_TAG_CHK, "fail [affinity thread is null]");
   }
 
   return 0;
@@ -207,6 +207,7 @@ TSContSchedule_test()
   } else {
     TSDebug(DEBUG_TAG_SCHD, "[%s] scheduling continuation", plugin_name);
     TSContScheduleOnPool(contp, 0, TS_THREAD_POOL_NET);
+    TSContThreadAffinityClear(contp);
     TSContScheduleOnPool(contp, 200, TS_THREAD_POOL_NET);
   }
 }
@@ -223,8 +224,10 @@ TSContScheduleOnPool_test()
   } else {
     TSDebug(DEBUG_TAG_SCHD, "[%s] scheduling continuation", plugin_name);
     TSContScheduleOnPool(contp_1, 0, TS_THREAD_POOL_NET);
+    TSContThreadAffinityClear(contp_1);
     TSContScheduleOnPool(contp_1, 100, TS_THREAD_POOL_NET);
     TSContScheduleOnPool(contp_2, 200, TS_THREAD_POOL_TASK);
+    TSContThreadAffinityClear(contp_2);
     TSContScheduleOnPool(contp_2, 300, TS_THREAD_POOL_TASK);
   }
 }
@@ -240,6 +243,7 @@ TSContScheduleOnThread_test()
   } else {
     TSDebug(DEBUG_TAG_SCHD, "[%s] scheduling continuation", plugin_name);
     TSContScheduleOnPool(contp, 0, TS_THREAD_POOL_NET);
+    TSContThreadAffinityClear(contp);
     TSContScheduleOnPool(contp, 200, TS_THREAD_POOL_NET);
   }
 }


### PR DESCRIPTION
Currently the thread affinity is set if to the event thread the scheduler is on if the continuation has no thread affinity information (i.e. the first time it gets scheduled). For example, `Thread A` wants to schedule `Continuation B` on a `ET_TASK` thread, if `Continuation B` doesn't have an affinity then `Thread A` will be set as the affinity thread instead of one of the `ET_TASK` threads it will be scheduled on. This PR will fix that issue, so now if `Continuation B` has no affinity thread, whichever thread it gets assigned to will be its affinity thread.

This behavior was introduced in #4878.