### PR TITLE
Restructured SSL client context mapping to 2-level

### DIFF
--- a/iocore/net/P_SSLConfig.h
+++ b/iocore/net/P_SSLConfig.h
@@ -120,10 +120,12 @@ struct SSLConfigParams : public ConfigInfo {
 
   SSL_CTX *client_ctx;
 
-  // Making this mutable since this is a updatable
-  // cache on an otherwise immutable config object
-  // The ctx_map owns the client SSL_CTX objects and is responseible for cleaning them up
-  mutable std::unordered_map<std::string, SSL_CTX *> ctx_map;
+  // Client contexts are held by 2-level map:
+  // The first level maps from CA bundle file&path to next level map;
+  // The second level maps from cert&key to actual SSL_CTX;
+  // The second level map owns the client SSL_CTX objects and is responsible for cleaning them up
+  using CTX_MAP = std::unordered_map<std::string, SSL_CTX *>;
+  mutable std::unordered_map<std::string, CTX_MAP *> top_level_ctx_map;
   mutable ink_mutex ctxMapLock;
 
   SSL_CTX *getClientSSL_CTX(void) const;


### PR DESCRIPTION
The first level lookup key would be CA bundle & CA bundle path;
The second level lookup key would be cert & key;

This 2-level mapping prepares for the dynamic client cert updating API.
@shinrich 