### PR TITLE
IP support: Make IpAddr constexpr constructible, define min/max addresses in IpMap

### DIFF
--- a/include/tscore/IpMap.h
+++ b/include/tscore/IpMap.h
@@ -102,6 +102,16 @@ public:
 
   class iterator; // forward declare.
 
+  static constexpr in_addr_t RAW_IP4_MIN_ADDR = 0;
+  static constexpr IpAddr IP4_MIN_ADDR{RAW_IP4_MIN_ADDR};
+  static constexpr in_addr_t RAW_IP4_MAX_ADDR = ~0;
+  static constexpr IpAddr IP4_MAX_ADDR{RAW_IP4_MAX_ADDR};
+
+  static constexpr in6_addr RAW_IP6_MIN_ADDR = {{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}};
+  static constexpr IpAddr IP6_MIN_ADDR{RAW_IP6_MIN_ADDR};
+  static constexpr in6_addr RAW_IP6_MAX_ADDR = {{{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}}};
+  static constexpr IpAddr IP6_MAX_ADDR{RAW_IP6_MAX_ADDR};
+
   /** Public API for intervals in the map.
    */
   class Node : protected ts::detail::RBNode
@@ -260,6 +270,8 @@ public:
                     sockaddr const *max  ///< Maximum value.
   );
   /// Unmark addresses (overload).
+  self_type &unmark(IpAddr const &min, IpAddr const &max);
+  /// Unmark addresses (overload).
   self_type &unmark(IpEndpoint const *min, IpEndpoint const *max);
   /// Unmark overload.
   self_type &unmark(in_addr_t min, ///< Minimum of range to unmark.
@@ -397,6 +409,15 @@ inline IpMap &
 IpMap::unmark(IpEndpoint const *min, IpEndpoint const *max)
 {
   return this->unmark(&min->sa, &max->sa);
+}
+
+inline IpMap &
+IpMap::unmark(IpAddr const &min, IpAddr const &max)
+{
+  IpEndpoint x, y;
+  x.assign(min);
+  y.assign(max);
+  return this->unmark(&x.sa, &y.sa);
 }
 
 inline IpMap &

--- a/include/tscore/ink_inet.h
+++ b/include/tscore/ink_inet.h
@@ -1150,20 +1150,19 @@ struct IpAddr {
 
   /// Default construct (invalid address).
   IpAddr() : _family(AF_UNSPEC) {}
-  /// Construct as IPv4 @a addr.
-  explicit IpAddr(in_addr_t addr ///< Address to assign.
-                  )
-    : _family(AF_INET)
-  {
-    _addr._ip4 = addr;
-  }
-  /// Construct as IPv6 @a addr.
-  explicit IpAddr(in6_addr const &addr ///< Address to assign.
-                  )
-    : _family(AF_INET6)
-  {
-    _addr._ip6 = addr;
-  }
+
+  /** Construct from IPv4 address.
+   *
+   * @param addr Source address.
+   */
+  explicit constexpr IpAddr(in_addr_t addr) : _family(AF_INET), _addr(addr) {}
+
+  /** Construct from IPv6 address.
+   *
+   * @param addr Source address.
+   */
+  explicit constexpr IpAddr(in6_addr const &addr) : _family(AF_INET6), _addr(addr) {}
+
   /// Construct from @c sockaddr.
   explicit IpAddr(sockaddr const *addr) { this->assign(addr); }
   /// Construct from @c sockaddr_in6.
@@ -1287,12 +1286,17 @@ struct IpAddr {
 
   uint16_t _family; ///< Protocol family.
   /// Address data.
-  union {
+  union Addr {
     in_addr_t _ip4;                                                    ///< IPv4 address storage.
     in6_addr _ip6;                                                     ///< IPv6 address storage.
     uint8_t _byte[TS_IP6_SIZE];                                        ///< As raw bytes.
     uint32_t _u32[TS_IP6_SIZE / (sizeof(uint32_t) / sizeof(uint8_t))]; ///< As 32 bit chunks.
     uint64_t _u64[TS_IP6_SIZE / (sizeof(uint64_t) / sizeof(uint8_t))]; ///< As 64 bit chunks.
+
+    // This is required by the @c constexpr constructor.
+    constexpr Addr() : _ip4(0) {}
+    constexpr Addr(in_addr_t addr) : _ip4(addr) {}
+    constexpr Addr(in6_addr const &addr) : _ip6(addr) {}
   } _addr;
 
   ///< Pre-constructed invalid instance.


### PR DESCRIPTION
It's a bit awkward doing inverted IP address range mapping with `IpMap`, but it's much more worse without
predefined min/max address values.