### PR TITLE
RemapPluginInfo Refresh.

### DIFF
--- a/proxy/ReverseProxy.cc
+++ b/proxy/ReverseProxy.cc
@@ -43,8 +43,7 @@
 
 // Global Ptrs
 static Ptr<ProxyMutex> reconfig_mutex;
-UrlRewrite *rewrite_table        = nullptr;
-remap_plugin_info *remap_pi_list = nullptr; // We never reload the remap plugins, just append to 'em.
+UrlRewrite *rewrite_table = nullptr;
 
 // Tokens for the Callback function
 #define FILE_CHANGED 0

--- a/proxy/ReverseProxy.h
+++ b/proxy/ReverseProxy.h
@@ -46,7 +46,6 @@ class url_mapping;
 struct host_hdr_info;
 
 extern UrlRewrite *rewrite_table;
-extern remap_plugin_info *remap_pi_list;
 
 // API Functions
 int init_reverse_proxy();

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -768,8 +768,8 @@ public:
     // INK API/Remap API plugin interface
     void *remap_plugin_instance = nullptr;
     void *user_args[TS_HTTP_MAX_USER_ARG];
-    remap_plugin_info::_tsremap_os_response *fp_tsremap_os_response = nullptr;
-    HTTPStatus http_return_code                                     = HTTP_STATUS_NONE;
+    RemapPluginInfo::OS_Response_F *fp_tsremap_os_response = nullptr;
+    HTTPStatus http_return_code                            = HTTP_STATUS_NONE;
 
     int api_txn_active_timeout_value      = -1;
     int api_txn_connect_timeout_value     = -1;

--- a/proxy/http/remap/RemapPluginInfo.cc
+++ b/proxy/http/remap/RemapPluginInfo.cc
@@ -1,6 +1,6 @@
 /** @file
 
-  A brief file description
+  Information about remap plugin libraries.
 
   @section license License
 
@@ -25,102 +25,56 @@
 #include "tscore/ink_string.h"
 #include "tscore/ink_memory.h"
 
-remap_plugin_info::remap_plugin_info(char *_path)
-  : next(nullptr),
-    path(nullptr),
-    path_size(0),
-    dlh(nullptr),
-    fp_tsremap_init(nullptr),
-    fp_tsremap_config_reload(nullptr),
-    fp_tsremap_done(nullptr),
-    fp_tsremap_new_instance(nullptr),
-    fp_tsremap_delete_instance(nullptr),
-    fp_tsremap_do_remap(nullptr),
-    fp_tsremap_os_response(nullptr)
-{
-  // coverity did not see ats_free
-  // coverity[ctor_dtor_leak]
-  if (_path && likely((path = ats_strdup(_path)) != nullptr)) {
-    path_size = strlen(path);
-  }
-}
+RemapPluginInfo::List RemapPluginInfo::g_list;
 
-remap_plugin_info::~remap_plugin_info()
+RemapPluginInfo::RemapPluginInfo(ts::file::path &&library_path) : path(std::move(library_path)) {}
+
+RemapPluginInfo::~RemapPluginInfo()
 {
-  ats_free(path);
-  if (dlh) {
-    dlclose(dlh);
+  if (dl_handle) {
+    dlclose(dl_handle);
   }
 }
 
 //
 // Find a plugin by path from our linked list
 //
-remap_plugin_info *
-remap_plugin_info::find_by_path(char *_path)
+RemapPluginInfo *
+RemapPluginInfo::find_by_path(std::string_view library_path)
 {
-  int _path_size        = 0;
-  remap_plugin_info *pi = nullptr;
-
-  if (likely(_path && (_path_size = strlen(_path)) > 0)) {
-    for (pi = this; pi; pi = pi->next) {
-      if (pi->path && pi->path_size == _path_size && !strcmp(pi->path, _path)) {
-        break;
-      }
-    }
-  }
-
-  return pi;
+  auto spot = std::find_if(g_list.begin(), g_list.end(),
+                           [&](self_type const &info) -> bool { return 0 == library_path.compare(info.path.view()); });
+  return spot == g_list.end() ? nullptr : static_cast<self_type *>(spot);
 }
 
 //
 // Add a plugin to the linked list
 //
 void
-remap_plugin_info::add_to_list(remap_plugin_info *pi)
+RemapPluginInfo::add_to_list(RemapPluginInfo *pi)
 {
-  remap_plugin_info *p = this;
-
-  if (likely(pi)) {
-    while (p->next) {
-      p = p->next;
-    }
-
-    p->next  = pi;
-    pi->next = nullptr;
-  }
+  g_list.append(pi);
 }
 
 //
-// Remove and delete all plugins from a list, including ourselves.
+// Remove and delete all plugins from a list.
 //
 void
-remap_plugin_info::delete_my_list()
+RemapPluginInfo::delete_list()
 {
-  remap_plugin_info *p = this->next;
-
-  while (p) {
-    remap_plugin_info *tmp = p;
-
-    p = p->next;
-    delete tmp;
-  }
-
-  delete this;
+  g_list.apply([](self_type *info) -> void { delete info; });
+  g_list.clear();
 }
 
 //
 // Tell all plugins (that so wish) that remap.config is being reloaded
 //
 void
-remap_plugin_info::indicate_reload()
+RemapPluginInfo::indicate_reload()
 {
-  remap_plugin_info *p = this;
-
-  while (p) {
-    if (p->fp_tsremap_config_reload) {
-      p->fp_tsremap_config_reload();
+  g_list.apply([](self_type *info) -> void {
+    if (info->config_reload_cb) {
+      info->config_reload_cb();
     }
-    p = p->next;
-  }
+  });
 }

--- a/proxy/http/remap/RemapPlugins.cc
+++ b/proxy/http/remap/RemapPlugins.cc
@@ -26,7 +26,7 @@
 ClassAllocator<RemapPlugins> pluginAllocator("RemapPluginsAlloc");
 
 TSRemapStatus
-RemapPlugins::run_plugin(remap_plugin_info *plugin)
+RemapPlugins::run_plugin(RemapPluginInfo *plugin)
 {
   ink_assert(_s);
 
@@ -51,11 +51,11 @@ RemapPlugins::run_plugin(remap_plugin_info *plugin)
 
   // Prepare State for the future
   if (_cur == 0) {
-    _s->fp_tsremap_os_response = plugin->fp_tsremap_os_response;
+    _s->fp_tsremap_os_response = plugin->os_response_cb;
     _s->remap_plugin_instance  = ih;
   }
 
-  plugin_retcode = plugin->fp_tsremap_do_remap(ih, reinterpret_cast<TSHttpTxn>(_s->state_machine), &rri);
+  plugin_retcode = plugin->do_remap_cb(ih, reinterpret_cast<TSHttpTxn>(_s->state_machine), &rri);
   // TODO: Deal with negative return codes here
   if (plugin_retcode < 0) {
     plugin_retcode = TSREMAP_NO_REMAP;
@@ -82,7 +82,7 @@ bool
 RemapPlugins::run_single_remap()
 {
   url_mapping *map             = _s->url_map.getMapping();
-  remap_plugin_info *plugin    = map->get_plugin(_cur); // get the nth plugin in our list of plugins
+  RemapPluginInfo *plugin      = map->get_plugin(_cur); // get the nth plugin in our list of plugins
   TSRemapStatus plugin_retcode = TSREMAP_NO_REMAP;
   bool zret                    = true; // default - last iteration.
   Debug("url_rewrite", "running single remap rule id %d for the %d%s time", map->map_id, _cur,

--- a/proxy/http/remap/RemapPlugins.h
+++ b/proxy/http/remap/RemapPlugins.h
@@ -68,7 +68,7 @@ struct RemapPlugins : public Continuation {
 
   int run_remap(int event, Event *e);
   bool run_single_remap();
-  TSRemapStatus run_plugin(remap_plugin_info *plugin);
+  TSRemapStatus run_plugin(RemapPluginInfo *plugin);
 
   Action action;
 

--- a/proxy/http/remap/UrlMapping.cc
+++ b/proxy/http/remap/UrlMapping.cc
@@ -30,7 +30,7 @@
  *
  **/
 bool
-url_mapping::add_plugin(remap_plugin_info *i, void *ih)
+url_mapping::add_plugin(RemapPluginInfo *i, void *ih)
 {
   _plugin_list.push_back(i);
   _instance_data.push_back(ih);
@@ -41,7 +41,7 @@ url_mapping::add_plugin(remap_plugin_info *i, void *ih)
 /**
  *
  **/
-remap_plugin_info *
+RemapPluginInfo *
 url_mapping::get_plugin(std::size_t index) const
 {
   Debug("url_rewrite", "get_plugin says we have %zu plugins and asking for plugin %zu", plugin_count(), index);
@@ -66,11 +66,11 @@ url_mapping::get_instance(std::size_t index) const
 void
 url_mapping::delete_instance(unsigned int index)
 {
-  void *ih             = get_instance(index);
-  remap_plugin_info *p = get_plugin(index);
+  void *ih           = get_instance(index);
+  RemapPluginInfo *p = get_plugin(index);
 
-  if (ih && p && p->fp_tsremap_delete_instance) {
-    p->fp_tsremap_delete_instance(ih);
+  if (ih && p && p->delete_instance_cb) {
+    p->delete_instance_cb(ih);
   }
 }
 

--- a/proxy/http/remap/UrlMapping.h
+++ b/proxy/http/remap/UrlMapping.h
@@ -79,8 +79,8 @@ class url_mapping
 public:
   ~url_mapping();
 
-  bool add_plugin(remap_plugin_info *i, void *ih);
-  remap_plugin_info *get_plugin(std::size_t) const;
+  bool add_plugin(RemapPluginInfo *i, void *ih);
+  RemapPluginInfo *get_plugin(std::size_t) const;
   void *get_instance(std::size_t) const;
 
   std::size_t
@@ -122,7 +122,7 @@ public:
   };
 
 private:
-  std::vector<remap_plugin_info *> _plugin_list;
+  std::vector<RemapPluginInfo *> _plugin_list;
   std::vector<void *> _instance_data;
   int _rank = 0;
 };


### PR DESCRIPTION
I need a better version of `remap_plugin_info`, therefore I did a full clean up on it. The changes

*  Rename the class to be more consistent.
*  Change from hand rolled intrusive list to `IntrusiveDList`. Distinguish between lists and elements.
*  Make the global list a singleton in the class, rather than an instance pointer elsewhere.
*  Use `ts::file`.
*  Change search to use a view.
*  Change `#define` in to C++ constants.
*  Add comments.