### PR TITLE
Fix HdrHeap unit test.

### DIFF
--- a/proxy/hdrs/unit_tests/test_Hdrs.cc
+++ b/proxy/hdrs/unit_tests/test_Hdrs.cc
@@ -68,7 +68,7 @@ TEST_CASE("HdrTest", "[proxy][hdrtest]")
 
   for (auto const &test : tests) {
     HTTPHdr req_hdr;
-    HdrHeap *heap = new_HdrHeap(HDR_HEAP_DEFAULT_SIZE + 64); // extra to prevent proxy allocation.
+    HdrHeap *heap = new_HdrHeap(HdrHeap::DEFAULT_SIZE + 64); // extra to prevent proxy allocation.
 
     req_hdr.create(HTTP_TYPE_REQUEST, heap);
 


### PR DESCRIPTION
I think this was the interaction of two different PRs that affected similar areas and ran successfully independently but not not together (which was not detected because the tests had already passed).

At least for me, this doesn't compile on master and I can't see how it could, given the `HDR_HEAP_DEFAULT_SIZE` symbol simply doesn't exist anywhere else.