### PR TITLE
HdrHeap default size unit test fix.

### DIFF
--- a/doc/developer-guide/core-architecture/heap.en.rst
+++ b/doc/developer-guide/core-architecture/heap.en.rst
@@ -132,10 +132,10 @@ Classes
 
 .. function:: HdrHeap * new_HdrHeap(int n)
 
-   Create and return a new instance of :class:`HdrHeap`. If :arg:`n` is less than ``HDR_HEAP_DEFAULT_SIZE``
+   Create and return a new instance of :class:`HdrHeap`. If :arg:`n` is less than ``HdrHeap::DEFAULT_SIZE``
    it is increased to that value.
 
-   If the allocated size is ``HDR_HEAP_DEFAULT_SIZE`` (or smaller and upsized to that value) then
+   If the allocated size is ``HdrHeap::DEFAULT_SIZE`` (or smaller and upsized to that value) then
    the instance is allocated from a thread local pool via :code:`hdrHeapAllocator`. If larger it
    is allocated from global memory via :code:`ats_malloc`.
 

--- a/proxy/hdrs/unit_tests/test_Hdrs.cc
+++ b/proxy/hdrs/unit_tests/test_Hdrs.cc
@@ -68,7 +68,7 @@ TEST_CASE("HdrTest", "[proxy][hdrtest]")
 
   for (auto const &test : tests) {
     HTTPHdr req_hdr;
-    HdrHeap *heap = new_HdrHeap(HDR_HEAP_DEFAULT_SIZE + 64); // extra to prevent proxy allocation.
+    HdrHeap *heap = new_HdrHeap(HdrHeap::DEFAULT_SIZE + 64); // extra to prevent proxy allocation.
 
     req_hdr.create(HTTP_TYPE_REQUEST, heap);
 


### PR DESCRIPTION
After refactoring "HdrHeap refresh" in PR #4953 unit test need
to be updated as well. Changing `HDR_HEAP_DEFAULT_SIZE` to 
`HdrHeap::DEFAULT_SIZE`