### PR TITLE
Revert "Rename Session and Transaction classes"

### DIFF
--- a/doc/developer-guide/client-session-architecture.en.rst
+++ b/doc/developer-guide/client-session-architecture.en.rst
@@ -27,34 +27,34 @@ The User Agent interacts with ATS by creating a session with the ATS server and
 submitting sequences of requests over the session. ATS supports several session protocols including
 HTTP/1.x and HTTP/2. A HTTP State Machine is created for each request to process the request.
 
-ATS uses the generic classes ProxySession and ProxyTransaction to hide the details of
+ATS uses the generic classes ProxyClientSession and ProxyClientTransaction to hide the details of
 the underlaying protocols from the HTTP State Machine.
 
 Classes
 =======
 
-ProxySession
+ProxyClientSession
 ------------------
 
 .. figure:: /static/images/sessions/session_hierarchy.png
    :align: center
-   :alt: ProxySession hierarchy
+   :alt: ProxyClientSession hierarchy
 
-The ProxySession class abstracts the key features of a client session.  It contains zero or more ProxyTransaction objects.  It also has a reference to the associated NetVC (either UnixNetVConnection or SSLNetVConnection).  The session class is responsible for interfacing with the user agent protocol.
+The ProxyClientSession class abstracts the key features of a client session.  It contains zero or more ProxyClientTransaction objects.  It also has a reference to the associated NetVC (either UnixNetVConnection or SSLNetVConnection).  The session class is responsible for interfacing with the user agent protocol.
 
 At this point there are two concrete subclasses: Http1ClientSession and Http2ClientSession.  The Http1ClientSession
 only has at most one transaction active at a time.  The HTTP/2 protocol allows for multiple simultaneous active
 transactions
 
-ProxyTransaction
+ProxyClientTransaction
 ----------------------
 
 .. figure:: /static/images/sessions/transaction_hierarchy.png
    :align: center
-   :alt: ProxyTransaction hierarchy
+   :alt: ProxyClientTransaction hierarchy
 
-The ProxyTransaction class abstracts the key features of a client transaction.  It has a reference to its
-paraent ProxySession.  One HttpSM is created for each ProxyTransaction.
+The ProxyClientTransaction class abstracts the key features of a client transaction.  It has a reference to its
+paraent ProxyClientSession.  One HttpSM is created for each ProxyClientTransaction.
 
 There are two concrete subclasses: Http1ClientTransaction and Http2Stream.
 
@@ -70,18 +70,18 @@ HTTP/1.x Objects
 
 This diagram shows the relationships between objects created as part of a HTTP/1.x session.  A NetVC
 object performs the basic network level protocols.  The Http1ClientSession object has a reference to the
-associated NetVC object.  The NetVC object is available via the :code:`ProxySession::get_netvc()` method.
+associated NetVC object.  The NetVC object is available via the :code:`ProxyClientSession::get_netvc()` method.
 
 The Http1ClientSession object contains a Http1ClientTransaction objet.  For each HTTP request, it calls
-the :code:`ProxySession::new_transaction()` method to instantiate the Http1ClientTransaction object.  With the HTTP/1.x
+the :code:`ProxyClientSession::new_transaction()` method to instantiate the Http1ClientTransaction object.  With the HTTP/1.x
 protocol at most one transaction can be active at a time.
 
-When the Http1ClientTransaction object is instantiated via :code:`ProxyTransaction::new_transaction()` it allocates a
+When the Http1ClientTransaction object is instantiated via :code:`ProxyClientTransaction::new_transaction()` it allocates a
 new HttpSM object, initializes it, and calls :code:`HttpSM::attach_client_session()` to associate the
 Http1ClientTransaction object with the new HttpSM.
 
-The ProxyTransaction object refers to the HttpSM via the current_reader member variable.  The HttpSM object
-refers to ProxyTransaction via the ua_session member variable (session in the member name is
+The ProxyClientTransaction object refers to the HttpSM via the current_reader member variable.  The HttpSM object
+refers to ProxyClientTransaction via the ua_session member variable (session in the member name is
 historical because the HttpSM used to refer directly to the ClientSession object).
 
 HTTP/2 Objects
@@ -93,11 +93,11 @@ HTTP/2 Objects
 
 This diagram shows the relationships between objects created as part of a HTTP/2 session.  It is very similar
 to the HTTP/1.x case.  The Http2ClientSession object interacts with the NetVC.  The Http2Stream object creates
-a HttpSM object object when :code:`ProxySession::new_transaction()` is called.
+a HttpSM object object when :code:`ProxyClient::new_transaction()` is called.
 
 One difference is that the Http/2 protocol allows for multiple simultaneous transactions, so the Http2ClientSession
 object must be able to manage multiple streams. From the HttpSM perspective it is interacting with a
-ProxyTransaction object, and there is no difference between working with a Http2Stream and a Http1ClientTransaction.
+ProxyClientTransaction object, and there is no difference between working with a Http2Stream and a Http1ClientTransaction.
 
 Transaction and Session Shutdown
 ================================
@@ -114,5 +114,5 @@ cause use-after-free and other related memory corruption errors.
 To ensure that sessions and transactions are correctly shutdown the following assertions are maintained.
 
 * The Session object will not call :code:`::destroy()` on itself until all child transaction objects are fully shutdown (i.e. TXN_CLOSE hooks are called and the transaction objects have been freed).
-* The Transaction object will not call :code:`::destroy()` on itself until the associated HttpSM has been shutdown.  In :code:`HttpSM::kill_this()`, the HttpSM will call :code:`ProxyTransaction::transaction_done()` on the ua_session object.  If the user agent initiates the termination, the ProxyTransaction object will send a WRITE_COMPLETE, EOS, or ERROR event on the open VIO object.  This should signal to the HttpSM object to shut itself down.
+* The Transaction object will not call :code:`::destroy()` on itself until the associated HttpSM has been shutdown.  In :code:`HttpSM::kill_this()`, the HttpSM will call :code:`ProxyClientTransaction::transaction_done()` on the ua_session object.  If the user agent initiates the termination, the ProxyClientTransaction object will send a WRITE_COMPLETE, EOS, or ERROR event on the open VIO object.  This should signal to the HttpSM object to shut itself down.
 

--- a/include/tscore/IntrusiveHashMap.h
+++ b/include/tscore/IntrusiveHashMap.h
@@ -67,15 +67,15 @@
 
     @a ID The numeric type that is the hash value for an instance of @a Key.
 
-    Example for @c Http1ServerSession keyed by the origin server IP address.
+    Example for @c HttpServerSession keyed by the origin server IP address.
 
     @code
     struct Descriptor {
-      static sockaddr const* key_of(Http1ServerSession const* value) { return &value->ip.sa }
+      static sockaddr const* key_of(HttpServerSession const* value) { return &value->ip.sa }
       static bool equal(sockaddr const* lhs, sockaddr const* rhs) { return ats_ip_eq(lhs, rhs); }
       static uint32_t hash_of(sockaddr const* key) { return ats_ip_hash(key); }
-      static Http1ServerSession *& next_ptr(Http1ServerSession * ssn) { return ssn->_next; }
-      static Http1ServerSession *& prev_ptr(Http1ServerSession * ssn) { return ssn->_prev; }
+      static HttpServerSession *& next_ptr(HttpServerSession * ssn) { return ssn->_next; }
+      static HttpServerSession *& prev_ptr(HttpServerSession * ssn) { return ssn->_prev; }
     };
     using Table = IntrusiveHashMap<Descriptor>;
     @endcode

--- a/iocore/eventsystem/I_Thread.h
+++ b/iocore/eventsystem/I_Thread.h
@@ -120,7 +120,7 @@ public:
   ProxyAllocator http1ClientSessionAllocator;
   ProxyAllocator http2ClientSessionAllocator;
   ProxyAllocator http2StreamAllocator;
-  ProxyAllocator http1ServerSessionAllocator;
+  ProxyAllocator httpServerSessionAllocator;
   ProxyAllocator hdrHeapAllocator;
   ProxyAllocator strHeapAllocator;
   ProxyAllocator cacheVConnectionAllocator;

--- a/proxy/Makefile.am
+++ b/proxy/Makefile.am
@@ -59,10 +59,10 @@ libproxy_a_SOURCES = \
 	PluginVC.h \
 	ProtocolProbeSessionAccept.cc \
 	ProtocolProbeSessionAccept.h \
-	ProxySession.cc \
-	ProxySession.h \
-	ProxyTransaction.cc \
-	ProxyTransaction.h \
+	ProxyClientSession.cc \
+	ProxyClientSession.h \
+	ProxyClientTransaction.cc \
+	ProxyClientTransaction \
 	ReverseProxy.cc \
 	ReverseProxy.h \
 	StatPages.cc \

--- a/proxy/ProxyClientSession.cc
+++ b/proxy/ProxyClientSession.cc
@@ -1,6 +1,6 @@
 /** @file
 
-  ProxySession - Base class for protocol client & server sessions.
+  ProxyClientSession - Base class for protocol client sessions.
 
   @section license License
 
@@ -23,17 +23,17 @@
 
 #include "HttpConfig.h"
 #include "HttpDebugNames.h"
-#include "ProxySession.h"
+#include "ProxyClientSession.h"
 
 static int64_t next_cs_id = 0;
 
-ProxySession::ProxySession() : VConnection(nullptr)
+ProxyClientSession::ProxyClientSession() : VConnection(nullptr)
 {
   ink_zero(this->user_args);
 }
 
 void
-ProxySession::set_session_active()
+ProxyClientSession::set_session_active()
 {
   if (!m_active) {
     m_active = true;
@@ -42,7 +42,7 @@ ProxySession::set_session_active()
 }
 
 void
-ProxySession::clear_session_active()
+ProxyClientSession::clear_session_active()
 {
   if (m_active) {
     m_active = false;
@@ -51,7 +51,7 @@ ProxySession::clear_session_active()
 }
 
 int64_t
-ProxySession::next_connection_id()
+ProxyClientSession::next_connection_id()
 {
   return ink_atomic_increment(&next_cs_id, 1);
 }
@@ -84,7 +84,7 @@ is_valid_hook(TSHttpHookID hookid)
 }
 
 void
-ProxySession::free()
+ProxyClientSession::free()
 {
   if (schedule_event) {
     schedule_event->cancel();
@@ -96,7 +96,7 @@ ProxySession::free()
 }
 
 int
-ProxySession::state_api_callout(int event, void *data)
+ProxyClientSession::state_api_callout(int event, void *data)
 {
   Event *e = static_cast<Event *>(data);
   if (e == schedule_event) {
@@ -124,7 +124,7 @@ ProxySession::state_api_callout(int event, void *data)
         MUTEX_TRY_LOCK(lock, hook->m_cont->mutex, mutex->thread_holding);
         // Have a mutex but did't get the lock, reschedule
         if (!lock.is_locked()) {
-          SET_HANDLER(&ProxySession::state_api_callout);
+          SET_HANDLER(&ProxyClientSession::state_api_callout);
           if (!schedule_event) { // Don't bother to schedule is there is already one out.
             schedule_event = mutex->thread_holding->schedule_in(this, HRTIME_MSECONDS(10));
           }
@@ -153,7 +153,7 @@ ProxySession::state_api_callout(int event, void *data)
 }
 
 void
-ProxySession::do_api_callout(TSHttpHookID id)
+ProxyClientSession::do_api_callout(TSHttpHookID id)
 {
   ink_assert(id == TS_HTTP_SSN_START_HOOK || id == TS_HTTP_SSN_CLOSE_HOOK);
 
@@ -162,7 +162,7 @@ ProxySession::do_api_callout(TSHttpHookID id)
   this->api_current = nullptr;
 
   if (this->has_hooks()) {
-    SET_HANDLER(&ProxySession::state_api_callout);
+    SET_HANDLER(&ProxyClientSession::state_api_callout);
     this->state_api_callout(EVENT_NONE, nullptr);
   } else {
     this->handle_api_return(TS_EVENT_HTTP_CONTINUE);
@@ -170,11 +170,11 @@ ProxySession::do_api_callout(TSHttpHookID id)
 }
 
 void
-ProxySession::handle_api_return(int event)
+ProxyClientSession::handle_api_return(int event)
 {
   TSHttpHookID hookid = this->api_hookid;
 
-  SET_HANDLER(&ProxySession::state_api_callout);
+  SET_HANDLER(&ProxyClientSession::state_api_callout);
 
   this->api_hookid  = TS_HTTP_LAST_HOOK;
   this->api_scope   = API_HOOK_SCOPE_NONE;

--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -1,6 +1,6 @@
 /** @file
 
-  ProxySession - Base class for protocol client & server sessions.
+  ProxyClientSession - Base class for protocol client sessions.
 
   @section license License
 
@@ -28,7 +28,7 @@
 #include <string_view>
 #include "P_Net.h"
 #include "InkAPIInternal.h"
-#include "http/Http1ServerSession.h"
+#include "http/HttpServerSession.h"
 #include "IPAllow.h"
 
 // Emit a debug message conditional on whether this particular client session
@@ -36,7 +36,7 @@
 // member function.
 #define SsnDebug(ssn, tag, ...) SpecificDebug((ssn)->debug(), tag, __VA_ARGS__)
 
-class ProxyTransaction;
+class ProxyClientTransaction;
 
 enum class ProxyErrorClass {
   NONE,
@@ -72,11 +72,10 @@ struct ProxyError {
 // A little ugly, but this global is tracked by traffic_server.
 extern bool ts_is_draining;
 
-/// Abstract class for HttpSM to interface with any session
-class ProxySession : public VConnection
+class ProxyClientSession : public VConnection
 {
 public:
-  ProxySession();
+  ProxyClientSession();
 
   virtual void destroy() = 0;
   virtual void free();
@@ -182,7 +181,7 @@ public:
   }
 
   // Indicate we are done with a transaction.
-  virtual void release(ProxyTransaction *trans) = 0;
+  virtual void release(ProxyClientTransaction *trans) = 0;
 
   virtual in_port_t
   get_outbound_port() const
@@ -209,11 +208,11 @@ public:
   }
 
   virtual void
-  attach_server_session(Http1ServerSession *ssession, bool transaction_done = true)
+  attach_server_session(HttpServerSession *ssession, bool transaction_done = true)
   {
   }
 
-  virtual Http1ServerSession *
+  virtual HttpServerSession *
   get_server_session() const
   {
     return nullptr;
@@ -297,8 +296,8 @@ public:
   ink_hrtime ssn_last_txn_time = 0;
 
   // noncopyable
-  ProxySession(ProxySession &) = delete;
-  ProxySession &operator=(const ProxySession &) = delete;
+  ProxyClientSession(ProxyClientSession &) = delete;
+  ProxyClientSession &operator=(const ProxyClientSession &) = delete;
 
 protected:
   // XXX Consider using a bitwise flags variable for the following flags, so

--- a/proxy/ProxyClientTransaction.cc
+++ b/proxy/ProxyClientTransaction.cc
@@ -1,6 +1,6 @@
 /** @file
 
-  ProxyTransaction - Base class for protocol client transactions.
+  ProxyClientTransaction - Base class for protocol client transactions.
 
   @section license License
 
@@ -22,12 +22,12 @@
  */
 
 #include "http/HttpSM.h"
-#include "http/Http1ServerSession.h"
+#include "http/HttpServerSession.h"
 #include "Plugin.h"
 
 #define HttpTxnDebug(fmt, ...) SsnDebug(this, "http_txn", fmt, __VA_ARGS__)
 
-ProxyTransaction::ProxyTransaction()
+ProxyClientTransaction::ProxyClientTransaction()
   : VConnection(nullptr),
     parent(nullptr),
     current_reader(nullptr),
@@ -38,7 +38,7 @@ ProxyTransaction::ProxyTransaction()
 }
 
 void
-ProxyTransaction::new_transaction()
+ProxyClientTransaction::new_transaction()
 {
   ink_assert(current_reader == nullptr);
 
@@ -62,7 +62,7 @@ ProxyTransaction::new_transaction()
 }
 
 void
-ProxyTransaction::release(IOBufferReader *r)
+ProxyClientTransaction::release(IOBufferReader *r)
 {
   HttpTxnDebug("[%" PRId64 "] session released by sm [%" PRId64 "]", parent ? parent->connection_id() : 0,
                current_reader ? current_reader->sm_id : 0);
@@ -76,20 +76,20 @@ ProxyTransaction::release(IOBufferReader *r)
 }
 
 void
-ProxyTransaction::attach_server_session(Http1ServerSession *ssession, bool transaction_done)
+ProxyClientTransaction::attach_server_session(HttpServerSession *ssession, bool transaction_done)
 {
   parent->attach_server_session(ssession, transaction_done);
 }
 
 void
-ProxyTransaction::destroy()
+ProxyClientTransaction::destroy()
 {
   current_reader = nullptr;
   this->mutex.clear();
 }
 
 Action *
-ProxyTransaction::adjust_thread(Continuation *cont, int event, void *data)
+ProxyClientTransaction::adjust_thread(Continuation *cont, int event, void *data)
 {
   NetVConnection *vc   = this->get_netvc();
   EThread *this_thread = this_ethread();
@@ -104,7 +104,7 @@ ProxyTransaction::adjust_thread(Continuation *cont, int event, void *data)
 }
 
 void
-ProxyTransaction::set_rx_error_code(ProxyError e)
+ProxyClientTransaction::set_rx_error_code(ProxyError e)
 {
   if (this->current_reader) {
     this->current_reader->t_state.client_info.rx_error_code = e;
@@ -112,7 +112,7 @@ ProxyTransaction::set_rx_error_code(ProxyError e)
 }
 
 void
-ProxyTransaction::set_tx_error_code(ProxyError e)
+ProxyClientTransaction::set_tx_error_code(ProxyError e)
 {
   if (this->current_reader) {
     this->current_reader->t_state.client_info.tx_error_code = e;

--- a/proxy/ProxyClientTransaction.h
+++ b/proxy/ProxyClientTransaction.h
@@ -1,6 +1,6 @@
 /** @file
 
-  ProxyTransaction - Base class for protocol client/server transactions.
+  ProxyClientTransaction - Base class for protocol client transactions.
 
   @section license License
 
@@ -23,17 +23,15 @@
 
 #pragma once
 
-#include "ProxySession.h"
+#include "ProxyClientSession.h"
 #include <string_view>
 
 class HttpSM;
-class Http1ServerSession;
-
-// Abstract Class for any transaction with-in the HttpSM
-class ProxyTransaction : public VConnection
+class HttpServerSession;
+class ProxyClientTransaction : public VConnection
 {
 public:
-  ProxyTransaction();
+  ProxyClientTransaction();
 
   // do_io methods implemented by subclasses
 
@@ -49,7 +47,7 @@ public:
   virtual void set_inactivity_timeout(ink_hrtime timeout_in) = 0;
   virtual void cancel_inactivity_timeout()                   = 0;
 
-  virtual void attach_server_session(Http1ServerSession *ssession, bool transaction_done = true);
+  virtual void attach_server_session(HttpServerSession *ssession, bool transaction_done = true);
 
   // See if we need to schedule on the primary thread for the transaction or change the thread that is associated with the VC.
   // If we reschedule, the scheduled action is returned.  Otherwise, NULL is returned
@@ -197,14 +195,14 @@ public:
 
   virtual void transaction_done() = 0;
 
-  ProxySession *
+  ProxyClientSession *
   get_parent()
   {
     return parent;
   }
 
   virtual void
-  set_parent(ProxySession *new_parent)
+  set_parent(ProxyClientSession *new_parent)
   {
     parent         = new_parent;
     host_res_style = parent->host_res_style;
@@ -214,7 +212,7 @@ public:
   {
   }
 
-  Http1ServerSession *
+  HttpServerSession *
   get_server_session() const
   {
     return parent ? parent->get_server_session() : nullptr;
@@ -268,7 +266,7 @@ public:
   virtual void decrement_client_transactions_stat() = 0;
 
 protected:
-  ProxySession *parent;
+  ProxyClientSession *parent;
   HttpSM *current_reader;
   IOBufferReader *sm_reader;
 

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -32,10 +32,10 @@
 
 #include "tscore/ink_resolver.h"
 #include "Http1ClientSession.h"
-#include "Http1Transaction.h"
+#include "Http1ClientTransaction.h"
 #include "HttpSM.h"
 #include "HttpDebugNames.h"
-#include "Http1ServerSession.h"
+#include "HttpServerSession.h"
 #include "Plugin.h"
 
 #define HttpSsnDebug(fmt, ...) SsnDebug(this, "http_cs", fmt, __VA_ARGS__)
@@ -160,7 +160,7 @@ Http1ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOB
   ink_assert(lock.is_locked());
 
   // Unique client session identifier.
-  con_id = ProxySession::next_connection_id();
+  con_id = ProxyClientSession::next_connection_id();
 
   schedule_event = nullptr;
 
@@ -448,9 +448,9 @@ Http1ClientSession::reenable(VIO *vio)
   client_vc->reenable(vio);
 }
 
-// Called from the Http1Transaction::release
+// Called from the Http1ClientTransaction::release
 void
-Http1ClientSession::release(ProxyTransaction *trans)
+Http1ClientSession::release(ProxyClientTransaction *trans)
 {
   ink_assert(read_state == HCS_ACTIVE_READER || read_state == HCS_INIT);
 
@@ -506,7 +506,7 @@ Http1ClientSession::new_transaction()
 }
 
 void
-Http1ClientSession::attach_server_session(Http1ServerSession *ssession, bool transaction_done)
+Http1ClientSession::attach_server_session(HttpServerSession *ssession, bool transaction_done)
 {
   if (ssession) {
     ink_assert(bound_ss == nullptr);

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -37,24 +37,23 @@
 #include "HTTP.h"
 #include "HttpConfig.h"
 #include "IPAllow.h"
-#include "ProxySession.h"
-#include "Http1Transaction.h"
+#include "ProxyClientSession.h"
+#include "Http1ClientTransaction.h"
 
 #ifdef USE_HTTP_DEBUG_LISTS
 extern ink_mutex debug_cs_list_mutex;
 #endif
 
 class HttpSM;
-class Http1ServerSession;
+class HttpServerSession;
 
-/// Class to manage a Http v1 session to a client
-class Http1ClientSession : public ProxySession
+class Http1ClientSession : public ProxyClientSession
 {
 public:
-  typedef ProxySession super; ///< Parent type.
+  typedef ProxyClientSession super; ///< Parent type.
   Http1ClientSession();
 
-  // Implement ProxySession interface.
+  // Implement ProxyClientSession interface.
   void destroy() override;
   void free() override;
   void release_transaction();
@@ -121,11 +120,11 @@ public:
   }
 
   // Indicate we are done with a transaction
-  void release(ProxyTransaction *trans) override;
+  void release(ProxyClientTransaction *trans) override;
 
-  void attach_server_session(Http1ServerSession *ssession, bool transaction_done = true) override;
+  void attach_server_session(HttpServerSession *ssession, bool transaction_done = true) override;
 
-  Http1ServerSession *
+  HttpServerSession *
   get_server_session() const override
   {
     return bound_ss;
@@ -200,7 +199,7 @@ private:
   VIO *ka_vio;
   VIO *slave_ka_vio;
 
-  Http1ServerSession *bound_ss;
+  HttpServerSession *bound_ss;
 
   int released_transactions;
 
@@ -213,7 +212,7 @@ public:
   /// Transparently pass-through non-HTTP traffic.
   bool f_transparent_passthrough;
 
-  Http1Transaction trans;
+  Http1ClientTransaction trans;
 };
 
 extern ClassAllocator<Http1ClientSession> http1ClientSessionAllocator;

--- a/proxy/http/Http1ClientTransaction.cc
+++ b/proxy/http/Http1ClientTransaction.cc
@@ -1,6 +1,6 @@
 /** @file
 
-  Http1Transaction.cc - The Transaction class for Http1*
+  Http1ClientTransaction.cc - The Transaction class for Http1*
 
   @section license License
 
@@ -21,12 +21,12 @@
   limitations under the License.
  */
 
-#include "Http1Transaction.h"
+#include "Http1ClientTransaction.h"
 #include "Http1ClientSession.h"
 #include "HttpSM.h"
 
 void
-Http1Transaction::release(IOBufferReader *r)
+Http1ClientTransaction::release(IOBufferReader *r)
 {
   // Must set this inactivity count here rather than in the session because the state machine
   // is not availble then
@@ -47,7 +47,7 @@ Http1Transaction::release(IOBufferReader *r)
 }
 
 void
-Http1Transaction::set_parent(ProxySession *new_parent)
+Http1ClientTransaction::set_parent(ProxyClientSession *new_parent)
 {
   parent                           = new_parent;
   Http1ClientSession *http1_parent = dynamic_cast<Http1ClientSession *>(new_parent);
@@ -61,7 +61,7 @@ Http1Transaction::set_parent(ProxySession *new_parent)
 }
 
 void
-Http1Transaction::transaction_done()
+Http1ClientTransaction::transaction_done()
 {
   if (parent) {
     static_cast<Http1ClientSession *>(parent)->release_transaction();
@@ -69,7 +69,7 @@ Http1Transaction::transaction_done()
 }
 
 bool
-Http1Transaction::allow_half_open() const
+Http1ClientTransaction::allow_half_open() const
 {
   bool config_allows_it = (current_reader) ? current_reader->t_state.txn_conf->allow_half_open > 0 : true;
   if (config_allows_it) {
@@ -80,13 +80,13 @@ Http1Transaction::allow_half_open() const
 }
 
 void
-Http1Transaction::increment_client_transactions_stat()
+Http1ClientTransaction::increment_client_transactions_stat()
 {
   HTTP_INCREMENT_DYN_STAT(http_current_client_transactions_stat);
 }
 
 void
-Http1Transaction::decrement_client_transactions_stat()
+Http1ClientTransaction::decrement_client_transactions_stat()
 {
   HTTP_DECREMENT_DYN_STAT(http_current_client_transactions_stat);
 }

--- a/proxy/http/Http1ClientTransaction.h
+++ b/proxy/http/Http1ClientTransaction.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Http1Transaction.h - The Transaction class for Http1*
+  Http1ClientTransaction.h - The Transaction class for Http1*
 
   @section license License
 
@@ -23,16 +23,16 @@
 
 #pragma once
 
-#include "../ProxyTransaction.h"
+#include "../ProxyClientTransaction.h"
 
 class Continuation;
-/// Concrete class for any Http1 Transaction
-class Http1Transaction : public ProxyTransaction
+
+class Http1ClientTransaction : public ProxyClientTransaction
 {
 public:
-  using super_type = ProxyTransaction;
+  using super_type = ProxyClientTransaction;
 
-  Http1Transaction() {}
+  Http1ClientTransaction() {}
   // Implement VConnection interface.
   VIO *
   do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = nullptr) override
@@ -53,7 +53,7 @@ public:
   }
 
   // Don't destroy your elements.  Rely on the Http1ClientSession to clean up the
-  // Http1Transaction class as necessary.  The super::destroy() clears the
+  // Http1ClientTransaction class as necessary.  The super::destroy() clears the
   // mutex, which Http1ClientSession owns.
   void
   destroy() override
@@ -83,7 +83,7 @@ public:
 
   bool allow_half_open() const override;
 
-  void set_parent(ProxySession *new_parent) override;
+  void set_parent(ProxyClientSession *new_parent) override;
 
   bool
   is_outbound_transparent() const override

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -22,12 +22,12 @@
 
  */
 
-#include "../ProxyTransaction.h"
+#include "../ProxyClientTransaction.h"
 #include "HttpSM.h"
 #include "HttpTransact.h"
 #include "HttpTransactHeaders.h"
 #include "ProxyConfig.h"
-#include "Http1ServerSession.h"
+#include "HttpServerSession.h"
 #include "HttpDebugNames.h"
 #include "HttpSessionManager.h"
 #include "P_Cache.h"
@@ -443,7 +443,7 @@ HttpSM::start_sub_sm()
 }
 
 void
-HttpSM::attach_client_session(ProxyTransaction *client_vc, IOBufferReader *buffer_reader)
+HttpSM::attach_client_session(ProxyClientTransaction *client_vc, IOBufferReader *buffer_reader)
 {
   milestones[TS_MILESTONE_UA_BEGIN] = Thread::get_hrtime();
   ink_assert(client_vc != nullptr);
@@ -638,7 +638,7 @@ HttpSM::state_read_client_request_header(int event, void *data)
 
   // Reset the inactivity timeout if this is the first
   //   time we've been called.  The timeout had been set to
-  //   the accept timeout by the ProxyTransaction
+  //   the accept timeout by the ProxyClientTransaction
   //
   if ((ua_buffer_reader->read_avail() > 0) && (client_request_hdr_bytes == 0)) {
     milestones[TS_MILESTONE_UA_FIRST_READ] = Thread::get_hrtime();
@@ -1713,14 +1713,14 @@ HttpSM::state_http_server_open(int event, void *data)
     pending_action = nullptr;
   }
   milestones[TS_MILESTONE_SERVER_CONNECT_END] = Thread::get_hrtime();
-  Http1ServerSession *session;
+  HttpServerSession *session;
   NetVConnection *netvc = nullptr;
 
   switch (event) {
   case NET_EVENT_OPEN: {
     session = (TS_SERVER_SESSION_SHARING_POOL_THREAD == t_state.http_config_param->server_session_sharing_pool) ?
-                THREAD_ALLOC_INIT(http1ServerSessionAllocator, mutex->thread_holding) :
-                http1ServerSessionAllocator.alloc();
+                THREAD_ALLOC_INIT(httpServerSessionAllocator, mutex->thread_holding) :
+                httpServerSessionAllocator.alloc();
     session->sharing_pool  = static_cast<TSServerSessionSharingPoolType>(t_state.http_config_param->server_session_sharing_pool);
     session->sharing_match = static_cast<TSServerSessionSharingMatchType>(t_state.txn_conf->server_session_sharing_match);
 
@@ -4883,7 +4883,7 @@ HttpSM::do_http_server_open(bool raw)
   // session when we already have an attached server session.
   else if ((TS_SERVER_SESSION_SHARING_MATCH_NONE == t_state.txn_conf->server_session_sharing_match || is_private()) &&
            (ua_txn != nullptr)) {
-    Http1ServerSession *existing_ss = ua_txn->get_server_session();
+    HttpServerSession *existing_ss = ua_txn->get_server_session();
 
     if (existing_ss) {
       // [amc] Not sure if this is the best option, but we don't get here unless session sharing is disabled
@@ -4910,7 +4910,7 @@ HttpSM::do_http_server_open(bool raw)
   // to get a new one.
   // ua_txn is null when t_state.req_flavor == REQ_FLAVOR_SCHEDULED_UPDATE
   else if (ua_txn != nullptr) {
-    Http1ServerSession *existing_ss = ua_txn->get_server_session();
+    HttpServerSession *existing_ss = ua_txn->get_server_session();
     if (existing_ss) {
       existing_ss->get_netvc()->set_inactivity_timeout(HRTIME_SECONDS(t_state.txn_conf->keep_alive_no_activity_timeout_out));
       existing_ss->release();
@@ -5880,7 +5880,7 @@ HttpSM::write_header_into_buffer(HTTPHdr *h, MIOBuffer *b)
 }
 
 void
-HttpSM::attach_server_session(Http1ServerSession *s)
+HttpSM::attach_server_session(HttpServerSession *s)
 {
   hsm_release_assert(server_session == nullptr);
   hsm_release_assert(server_entry == nullptr);
@@ -7948,7 +7948,7 @@ HttpSM::is_private()
   if (server_session) {
     res = server_session->private_session;
   } else if (ua_txn) {
-    Http1ServerSession *ss = ua_txn->get_server_session();
+    HttpServerSession *ss = ua_txn->get_server_session();
     if (ss) {
       res = ss->private_session;
     } else if (will_be_private_ss) {

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -39,7 +39,7 @@
 #include "UrlRewrite.h"
 #include "HttpTunnel.h"
 #include "InkAPIInternal.h"
-#include "../ProxyTransaction.h"
+#include "../ProxyClientTransaction.h"
 #include "HdrUtils.h"
 #include <string_view>
 #include "tscore/History.h"
@@ -59,7 +59,7 @@ static size_t const HTTP_HEADER_BUFFER_SIZE_INDEX = CLIENT_CONNECTION_FIRST_READ
 //   the larger buffer size
 static size_t const HTTP_SERVER_RESP_HDR_BUFFER_INDEX = BUFFER_SIZE_INDEX_8K;
 
-class Http1ServerSession;
+class HttpServerSession;
 class AuthHttpAdapter;
 
 class HttpSM;
@@ -215,22 +215,22 @@ public:
 
   void init();
 
-  void attach_client_session(ProxyTransaction *client_vc_arg, IOBufferReader *buffer_reader);
+  void attach_client_session(ProxyClientTransaction *client_vc_arg, IOBufferReader *buffer_reader);
 
   // Called by httpSessionManager so that we can reset
   //  the session timeouts and initiate a read while
   //  holding the lock for the server session
-  void attach_server_session(Http1ServerSession *s);
+  void attach_server_session(HttpServerSession *s);
 
   // Used to read attributes of
   // the current active server session
-  Http1ServerSession *
+  HttpServerSession *
   get_server_session()
   {
     return server_session;
   }
 
-  ProxyTransaction *
+  ProxyClientTransaction *
   get_ua_txn()
   {
     return ua_txn;
@@ -350,7 +350,7 @@ protected:
   void remove_ua_entry();
 
 public:
-  ProxyTransaction *ua_txn         = nullptr;
+  ProxyClientTransaction *ua_txn   = nullptr;
   BackgroundFill_t background_fill = BACKGROUND_FILL_NONE;
   // AuthHttpAdapter authAdapter;
   void set_http_schedule(Continuation *);
@@ -362,8 +362,8 @@ protected:
   IOBufferReader *ua_buffer_reader     = nullptr;
   IOBufferReader *ua_raw_buffer_reader = nullptr;
 
-  HttpVCTableEntry *server_entry     = nullptr;
-  Http1ServerSession *server_session = nullptr;
+  HttpVCTableEntry *server_entry    = nullptr;
+  HttpServerSession *server_session = nullptr;
 
   /* Because we don't want to take a session from a shared pool if we know that it will be private,
    * but we cannot set it to private until we have an attached server session.

--- a/proxy/http/HttpServerSession.h
+++ b/proxy/http/HttpServerSession.h
@@ -23,7 +23,7 @@
 
 /****************************************************************************
 
-   Http1ServerSession.h
+   HttpServerSession.h
 
    Description:
 
@@ -53,16 +53,14 @@ enum {
   HTTP_SS_MAGIC_DEAD  = 0xDEADFEED,
 };
 
-/// Class to manage a Http v1 session to a server
-// TODO: inherit from ProxySession
-class Http1ServerSession : public VConnection
+class HttpServerSession : public VConnection
 {
-  using self_type  = Http1ServerSession;
+  using self_type  = HttpServerSession;
   using super_type = VConnection;
 
 public:
-  Http1ServerSession() : super_type(nullptr) {}
-  Http1ServerSession(self_type const &) = delete;
+  HttpServerSession() : super_type(nullptr) {}
+  HttpServerSession(self_type const &) = delete;
   self_type &operator=(self_type const &) = delete;
 
   void destroy();
@@ -151,8 +149,8 @@ public:
     static sockaddr const *key_of(self_type const *ssn);
     static bool equal(sockaddr const *lhs, sockaddr const *rhs);
     // Add a couple overloads for internal convenience.
-    static bool equal(sockaddr const *lhs, Http1ServerSession const *rhs);
-    static bool equal(Http1ServerSession const *lhs, sockaddr const *rhs);
+    static bool equal(sockaddr const *lhs, HttpServerSession const *rhs);
+    static bool equal(HttpServerSession const *lhs, sockaddr const *rhs);
   } _ip_link;
 
   /// Hash map descriptor class for FQDN map.
@@ -201,86 +199,86 @@ private:
   IOBufferReader *buf_reader = nullptr;
 };
 
-extern ClassAllocator<Http1ServerSession> http1ServerSessionAllocator;
+extern ClassAllocator<HttpServerSession> httpServerSessionAllocator;
 
 // --- Implementation ---
 
 inline void
-Http1ServerSession::attach_hostname(const char *hostname)
+HttpServerSession::attach_hostname(const char *hostname)
 {
   if (CRYPTO_HASH_ZERO == hostname_hash) {
     CryptoContext().hash_immediate(hostname_hash, (unsigned char *)hostname, strlen(hostname));
   }
 }
 
-inline Http1ServerSession *&
-Http1ServerSession::IPLinkage::next_ptr(self_type *ssn)
+inline HttpServerSession *&
+HttpServerSession::IPLinkage::next_ptr(self_type *ssn)
 {
   return ssn->_ip_link._next;
 }
 
-inline Http1ServerSession *&
-Http1ServerSession::IPLinkage::prev_ptr(self_type *ssn)
+inline HttpServerSession *&
+HttpServerSession::IPLinkage::prev_ptr(self_type *ssn)
 {
   return ssn->_ip_link._prev;
 }
 
 inline uint32_t
-Http1ServerSession::IPLinkage::hash_of(sockaddr const *key)
+HttpServerSession::IPLinkage::hash_of(sockaddr const *key)
 {
   return ats_ip_hash(key);
 }
 
 inline sockaddr const *
-Http1ServerSession::IPLinkage::key_of(self_type const *ssn)
+HttpServerSession::IPLinkage::key_of(self_type const *ssn)
 {
   return &ssn->get_server_ip().sa;
 }
 
 inline bool
-Http1ServerSession::IPLinkage::equal(sockaddr const *lhs, sockaddr const *rhs)
+HttpServerSession::IPLinkage::equal(sockaddr const *lhs, sockaddr const *rhs)
 {
   return ats_ip_addr_port_eq(lhs, rhs);
 }
 
 inline bool
-Http1ServerSession::IPLinkage::equal(sockaddr const *lhs, Http1ServerSession const *rhs)
+HttpServerSession::IPLinkage::equal(sockaddr const *lhs, HttpServerSession const *rhs)
 {
   return ats_ip_addr_port_eq(lhs, key_of(rhs));
 }
 
 inline bool
-Http1ServerSession::IPLinkage::equal(Http1ServerSession const *lhs, sockaddr const *rhs)
+HttpServerSession::IPLinkage::equal(HttpServerSession const *lhs, sockaddr const *rhs)
 {
   return ats_ip_addr_port_eq(key_of(lhs), rhs);
 }
 
-inline Http1ServerSession *&
-Http1ServerSession::FQDNLinkage::next_ptr(self_type *ssn)
+inline HttpServerSession *&
+HttpServerSession::FQDNLinkage::next_ptr(self_type *ssn)
 {
   return ssn->_fqdn_link._next;
 }
 
-inline Http1ServerSession *&
-Http1ServerSession::FQDNLinkage::prev_ptr(self_type *ssn)
+inline HttpServerSession *&
+HttpServerSession::FQDNLinkage::prev_ptr(self_type *ssn)
 {
   return ssn->_fqdn_link._prev;
 }
 
 inline uint64_t
-Http1ServerSession::FQDNLinkage::hash_of(CryptoHash const &key)
+HttpServerSession::FQDNLinkage::hash_of(CryptoHash const &key)
 {
   return key.fold();
 }
 
 inline CryptoHash const &
-Http1ServerSession::FQDNLinkage::key_of(self_type *ssn)
+HttpServerSession::FQDNLinkage::key_of(self_type *ssn)
 {
   return ssn->hostname_hash;
 }
 
 inline bool
-Http1ServerSession::FQDNLinkage::equal(CryptoHash const &lhs, CryptoHash const &rhs)
+HttpServerSession::FQDNLinkage::equal(CryptoHash const &lhs, CryptoHash const &rhs)
 {
   return lhs == rhs;
 }

--- a/proxy/http/HttpSessionManager.cc
+++ b/proxy/http/HttpSessionManager.cc
@@ -31,8 +31,8 @@
  ****************************************************************************/
 
 #include "HttpSessionManager.h"
-#include "../ProxySession.h"
-#include "Http1ServerSession.h"
+#include "../ProxyClientSession.h"
+#include "HttpServerSession.h"
 #include "HttpSM.h"
 #include "HttpDebugNames.h"
 
@@ -57,13 +57,13 @@ ServerSessionPool::purge()
 {
   // @c do_io_close can free the instance which clears the intrusive links and breaks the iterator.
   // Therefore @c do_io_close is called on a post-incremented iterator.
-  m_ip_pool.apply([](Http1ServerSession *ssn) -> void { ssn->do_io_close(); });
+  m_ip_pool.apply([](HttpServerSession *ssn) -> void { ssn->do_io_close(); });
   m_ip_pool.clear();
   m_fqdn_pool.clear();
 }
 
 bool
-ServerSessionPool::match(Http1ServerSession *ss, sockaddr const *addr, CryptoHash const &hostname_hash,
+ServerSessionPool::match(HttpServerSession *ss, sockaddr const *addr, CryptoHash const &hostname_hash,
                          TSServerSessionSharingMatchType match_style)
 {
   return TS_SERVER_SESSION_SHARING_MATCH_NONE !=
@@ -93,7 +93,7 @@ ServerSessionPool::validate_sni(HttpSM *sm, NetVConnection *netvc)
 
 HSMresult_t
 ServerSessionPool::acquireSession(sockaddr const *addr, CryptoHash const &hostname_hash,
-                                  TSServerSessionSharingMatchType match_style, HttpSM *sm, Http1ServerSession *&to_return)
+                                  TSServerSessionSharingMatchType match_style, HttpSM *sm, HttpServerSession *&to_return)
 {
   HSMresult_t zret = HSM_NOT_FOUND;
   to_return        = nullptr;
@@ -144,7 +144,7 @@ ServerSessionPool::acquireSession(sockaddr const *addr, CryptoHash const &hostna
 }
 
 void
-ServerSessionPool::releaseSession(Http1ServerSession *ss)
+ServerSessionPool::releaseSession(HttpServerSession *ss)
 {
   ss->state = HSS_KA_SHARED;
   // Now we need to issue a read on the connection to detect
@@ -176,7 +176,7 @@ int
 ServerSessionPool::eventHandler(int event, void *data)
 {
   NetVConnection *net_vc = nullptr;
-  Http1ServerSession *s  = nullptr;
+  HttpServerSession *s   = nullptr;
 
   switch (event) {
   case VC_EVENT_READ_READY:
@@ -275,9 +275,9 @@ HttpSessionManager::purge_keepalives()
 
 HSMresult_t
 HttpSessionManager::acquire_session(Continuation * /* cont ATS_UNUSED */, sockaddr const *ip, const char *hostname,
-                                    ProxyTransaction *ua_txn, HttpSM *sm)
+                                    ProxyClientTransaction *ua_txn, HttpSM *sm)
 {
-  Http1ServerSession *to_return = nullptr;
+  HttpServerSession *to_return = nullptr;
   TSServerSessionSharingMatchType match_style =
     static_cast<TSServerSessionSharingMatchType>(sm->t_state.txn_conf->server_session_sharing_match);
   CryptoHash hostname_hash;
@@ -371,7 +371,7 @@ HttpSessionManager::acquire_session(Continuation * /* cont ATS_UNUSED */, sockad
 }
 
 HSMresult_t
-HttpSessionManager::release_session(Http1ServerSession *to_release)
+HttpSessionManager::release_session(HttpServerSession *to_release)
 {
   EThread *ethread = this_ethread();
   ServerSessionPool *pool =

--- a/proxy/http/HttpSessionManager.h
+++ b/proxy/http/HttpSessionManager.h
@@ -33,10 +33,10 @@
 #pragma once
 
 #include "P_EventSystem.h"
-#include "Http1ServerSession.h"
+#include "HttpServerSession.h"
 #include "tscore/IntrusiveHashMap.h"
 
-class ProxyTransaction;
+class ProxyClientTransaction;
 class HttpSM;
 
 void initialize_thread_for_http_sessions(EThread *thread, int thread_index);
@@ -67,13 +67,13 @@ public:
   static bool validate_sni(HttpSM *sm, NetVConnection *netvc);
 
 protected:
-  using IPTable   = IntrusiveHashMap<Http1ServerSession::IPLinkage>;
-  using FQDNTable = IntrusiveHashMap<Http1ServerSession::FQDNLinkage>;
+  using IPTable   = IntrusiveHashMap<HttpServerSession::IPLinkage>;
+  using FQDNTable = IntrusiveHashMap<HttpServerSession::FQDNLinkage>;
 
 public:
   /** Check if a session matches address and host name.
    */
-  static bool match(Http1ServerSession *ss, sockaddr const *addr, CryptoHash const &host_hash,
+  static bool match(HttpServerSession *ss, sockaddr const *addr, CryptoHash const &host_hash,
                     TSServerSessionSharingMatchType match_style);
 
   /** Get a session from the pool.
@@ -84,10 +84,10 @@ public:
       @return A pointer to the session or @c NULL if not matching session was found.
   */
   HSMresult_t acquireSession(sockaddr const *addr, CryptoHash const &host_hash, TSServerSessionSharingMatchType match_style,
-                             HttpSM *sm, Http1ServerSession *&server_session);
+                             HttpSM *sm, HttpServerSession *&server_session);
   /** Release a session to to pool.
    */
-  void releaseSession(Http1ServerSession *ss);
+  void releaseSession(HttpServerSession *ss);
 
   /// Close all sessions and then clear the table.
   void purge();
@@ -103,8 +103,9 @@ class HttpSessionManager
 public:
   HttpSessionManager() : m_g_pool(nullptr) {}
   ~HttpSessionManager() {}
-  HSMresult_t acquire_session(Continuation *cont, sockaddr const *addr, const char *hostname, ProxyTransaction *ua_txn, HttpSM *sm);
-  HSMresult_t release_session(Http1ServerSession *to_release);
+  HSMresult_t acquire_session(Continuation *cont, sockaddr const *addr, const char *hostname, ProxyClientTransaction *ua_txn,
+                              HttpSM *sm);
+  HSMresult_t release_session(HttpServerSession *to_release);
   void purge_keepalives();
   void init();
   int main_handler(int event, void *data);

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -39,7 +39,7 @@
 #include "RemapPluginInfo.h"
 #include "UrlMapping.h"
 #include "records/I_RecHttp.h"
-#include "ProxySession.h"
+#include "ProxyClientSession.h"
 
 #define HTTP_RELEASE_ASSERT(X) ink_release_assert(X)
 

--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -932,7 +932,7 @@ HttpTunnel::producer_run(HttpTunnelProducer *p)
       // the amount to read since we know it.  We will forward the FIN
       // to the server on VC_EVENT_WRITE_COMPLETE.
       if (p->vc_type == HT_HTTP_CLIENT) {
-        ProxyTransaction *ua_vc = static_cast<ProxyTransaction *>(p->vc);
+        ProxyClientTransaction *ua_vc = static_cast<ProxyClientTransaction *>(p->vc);
         if (ua_vc->get_half_close_flag()) {
           c_write          = c->buffer_reader->read_avail();
           p->alive         = false;

--- a/proxy/http/Makefile.am
+++ b/proxy/http/Makefile.am
@@ -46,8 +46,8 @@ libhttp_a_SOURCES = \
 	HttpCacheSM.h \
 	Http1ClientSession.cc \
 	Http1ClientSession.h \
-	Http1Transaction.cc \
-	Http1Transaction.h \
+	Http1ClientTransaction.cc \
+	Http1ClientTransaction.h \
 	HttpConfig.cc \
 	HttpConfig.h \
 	HttpConnectionCount.cc \
@@ -60,8 +60,8 @@ libhttp_a_SOURCES = \
 	HttpProxyServerMain.h \
 	HttpSM.cc \
 	HttpSM.h \
-	Http1ServerSession.cc \
-	Http1ServerSession.h \
+	HttpServerSession.cc \
+	HttpServerSession.h \
 	HttpSessionManager.cc \
 	HttpSessionManager.h \
 	HttpTransact.cc \

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -179,7 +179,7 @@ Http2ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOB
   HTTP2_INCREMENT_THREAD_DYN_STAT(HTTP2_STAT_TOTAL_CLIENT_CONNECTION_COUNT, new_vc->mutex->thread_holding);
 
   // Unique client session identifier.
-  this->con_id    = ProxySession::next_connection_id();
+  this->con_id    = ProxyClientSession::next_connection_id();
   this->client_vc = new_vc;
   client_vc->set_inactivity_timeout(HRTIME_SECONDS(Http2::accept_no_activity_timeout));
   this->schedule_event = nullptr;

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -25,7 +25,7 @@
 
 #include "HTTP2.h"
 #include "Plugin.h"
-#include "ProxySession.h"
+#include "ProxyClientSession.h"
 #include "Http2ConnectionState.h"
 #include <string_view>
 #include "tscore/ink_inet.h"
@@ -158,15 +158,15 @@ private:
   IOBufferReader *ioreader;
 };
 
-class Http2ClientSession : public ProxySession
+class Http2ClientSession : public ProxyClientSession
 {
 public:
-  typedef ProxySession super; ///< Parent type.
+  typedef ProxyClientSession super; ///< Parent type.
   typedef int (Http2ClientSession::*SessionHandler)(int, void *);
 
   Http2ClientSession();
 
-  // Implement ProxySession interface.
+  // Implement ProxyClientSession interface.
   void start() override;
   void destroy() override;
   void free() override;
@@ -225,7 +225,7 @@ public:
   }
 
   void
-  release(ProxyTransaction *trans) override
+  release(ProxyClientTransaction *trans) override
   {
   }
 

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -24,7 +24,7 @@
 #pragma once
 
 #include "HTTP2.h"
-#include "../ProxyTransaction.h"
+#include "../ProxyClientTransaction.h"
 #include "Http2DebugNames.h"
 #include "../http/HttpTunnel.h" // To get ChunkedHandler
 #include "Http2DependencyTree.h"
@@ -35,10 +35,10 @@ class Http2ConnectionState;
 
 typedef Http2DependencyTree::Tree<Http2Stream *> DependencyTree;
 
-class Http2Stream : public ProxyTransaction
+class Http2Stream : public ProxyClientTransaction
 {
 public:
-  typedef ProxyTransaction super; ///< Parent type.
+  typedef ProxyClientTransaction super; ///< Parent type.
   Http2Stream(Http2StreamId sid = 0, ssize_t initial_rwnd = Http2::initial_window_size) : client_rwnd(initial_rwnd), _id(sid)
   {
     SET_HANDLER(&Http2Stream::main_event_handler);

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -37,9 +37,9 @@
 #include "URL.h"
 #include "MIME.h"
 #include "HTTP.h"
-#include "ProxySession.h"
+#include "ProxyClientSession.h"
 #include "Http2ClientSession.h"
-#include "Http1ServerSession.h"
+#include "HttpServerSession.h"
 #include "HttpSM.h"
 #include "HttpConfig.h"
 #include "P_Net.h"
@@ -4721,7 +4721,7 @@ TSHttpSsnHookAdd(TSHttpSsn ssnp, TSHttpHookID id, TSCont contp)
   sdk_assert(sdk_sanity_check_continuation(contp) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_hook_id(id) == TS_SUCCESS);
 
-  ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
+  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
   cs->ssn_hook_append(id, (INKContInternal *)contp);
 }
 
@@ -4730,28 +4730,28 @@ TSHttpSsnTransactionCount(TSHttpSsn ssnp)
 {
   sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
 
-  ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
+  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
   return cs->get_transact_count();
 }
 
 TSVConn
 TSHttpSsnClientVConnGet(TSHttpSsn ssnp)
 {
-  ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
+  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
   return reinterpret_cast<TSVConn>(cs->get_netvc());
 }
 
 TSVConn
 TSHttpSsnServerVConnGet(TSHttpSsn ssnp)
 {
-  Http1ServerSession *ss = reinterpret_cast<Http1ServerSession *>(ssnp);
+  HttpServerSession *ss = reinterpret_cast<HttpServerSession *>(ssnp);
   return reinterpret_cast<TSVConn>(ss->get_netvc());
 }
 
 class TSHttpSsnCallback : public Continuation
 {
 public:
-  TSHttpSsnCallback(ProxySession *cs, TSEvent event) : Continuation(cs->mutex), m_cs(cs), m_event(event)
+  TSHttpSsnCallback(ProxyClientSession *cs, TSEvent event) : Continuation(cs->mutex), m_cs(cs), m_event(event)
   {
     SET_HANDLER(&TSHttpSsnCallback::event_handler);
   }
@@ -4765,7 +4765,7 @@ public:
   }
 
 private:
-  ProxySession *m_cs;
+  ProxyClientSession *m_cs;
   TSEvent m_event;
 };
 
@@ -4774,8 +4774,8 @@ TSHttpSsnReenable(TSHttpSsn ssnp, TSEvent event)
 {
   sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
 
-  ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
-  EThread *eth     = this_ethread();
+  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
+  EThread *eth           = this_ethread();
 
   // If this function is being executed on a thread created by the API
   // which is DEDICATED, the continuation needs to be called back on a
@@ -5475,7 +5475,7 @@ TSHttpTxnTransformRespGet(TSHttpTxn txnp, TSMBuffer *bufp, TSMLoc *obj)
 sockaddr const *
 TSHttpSsnClientAddrGet(TSHttpSsn ssnp)
 {
-  ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
+  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
 
   if (cs == nullptr) {
     return nullptr;
@@ -5494,7 +5494,7 @@ TSHttpTxnClientAddrGet(TSHttpTxn txnp)
 sockaddr const *
 TSHttpSsnIncomingAddrGet(TSHttpSsn ssnp)
 {
-  ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
+  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
 
   if (cs == nullptr) {
     return nullptr;
@@ -5517,7 +5517,7 @@ TSHttpTxnOutgoingAddrGet(TSHttpTxn txnp)
 
   HttpSM *sm = reinterpret_cast<HttpSM *>(txnp);
 
-  Http1ServerSession *ssn = sm->get_server_session();
+  HttpServerSession *ssn = sm->get_server_session();
   if (ssn == nullptr) {
     return nullptr;
   }
@@ -5635,7 +5635,7 @@ TSHttpTxnServerPacketMarkSet(TSHttpTxn txnp, int mark)
 
   // change the mark on an active server session
   if (nullptr != sm->ua_txn) {
-    Http1ServerSession *ssn = sm->ua_txn->get_server_session();
+    HttpServerSession *ssn = sm->ua_txn->get_server_session();
     if (nullptr != ssn) {
       NetVConnection *vc = ssn->get_netvc();
       if (vc != nullptr) {
@@ -5677,7 +5677,7 @@ TSHttpTxnServerPacketTosSet(TSHttpTxn txnp, int tos)
 
   // change the tos on an active server session
   if (nullptr != sm->ua_txn) {
-    Http1ServerSession *ssn = sm->ua_txn->get_server_session();
+    HttpServerSession *ssn = sm->ua_txn->get_server_session();
     if (nullptr != ssn) {
       NetVConnection *vc = ssn->get_netvc();
       if (vc != nullptr) {
@@ -5719,7 +5719,7 @@ TSHttpTxnServerPacketDscpSet(TSHttpTxn txnp, int dscp)
 
   // change the tos on an active server session
   if (nullptr != sm->ua_txn) {
-    Http1ServerSession *ssn = sm->ua_txn->get_server_session();
+    HttpServerSession *ssn = sm->ua_txn->get_server_session();
     if (nullptr != ssn) {
       NetVConnection *vc = ssn->get_netvc();
       if (vc != nullptr) {
@@ -6073,7 +6073,7 @@ TSHttpSsnArgSet(TSHttpSsn ssnp, int arg_idx, void *arg)
   sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
   sdk_assert(arg_idx >= 0 && arg_idx < TS_HTTP_MAX_USER_ARG);
 
-  ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
+  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
 
   cs->set_user_arg(arg_idx, arg);
 }
@@ -6084,7 +6084,7 @@ TSHttpSsnArgGet(TSHttpSsn ssnp, int arg_idx)
   sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
   sdk_assert(arg_idx >= 0 && arg_idx < TS_HTTP_MAX_USER_ARG);
 
-  ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
+  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
   return cs->get_user_arg(arg_idx);
 }
 
@@ -6219,14 +6219,14 @@ void
 TSHttpSsnDebugSet(TSHttpSsn ssnp, int on)
 {
   sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
-  (reinterpret_cast<ProxySession *>(ssnp))->set_debug(0 != on);
+  (reinterpret_cast<ProxyClientSession *>(ssnp))->set_debug(0 != on);
 }
 
 int
 TSHttpSsnDebugGet(TSHttpSsn ssnp)
 {
   sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
-  return (reinterpret_cast<ProxySession *>(ssnp))->debug();
+  return (reinterpret_cast<ProxyClientSession *>(ssnp))->debug();
 }
 
 int
@@ -7387,8 +7387,8 @@ TSHttpSsnClientFdGet(TSHttpSsn ssnp, int *fdp)
 {
   sdk_assert(sdk_sanity_check_null_ptr((void *)fdp) == TS_SUCCESS);
 
-  VConnection *basecs = reinterpret_cast<VConnection *>(ssnp);
-  ProxySession *cs    = dynamic_cast<ProxySession *>(basecs);
+  VConnection *basecs    = reinterpret_cast<VConnection *>(ssnp);
+  ProxyClientSession *cs = dynamic_cast<ProxyClientSession *>(basecs);
 
   if (cs == nullptr) {
     return TS_ERROR;
@@ -7421,7 +7421,7 @@ TSHttpTxnServerFdGet(TSHttpTxn txnp, int *fdp)
   HttpSM *sm = reinterpret_cast<HttpSM *>(txnp);
   *fdp       = -1;
 
-  Http1ServerSession *ss = sm->get_server_session();
+  HttpServerSession *ss = sm->get_server_session();
   if (ss == nullptr) {
     return TS_ERROR;
   }
@@ -7789,7 +7789,7 @@ TSFetchRespHdrMLocGet(TSFetchSM fetch_sm)
 int
 TSHttpSsnIsInternal(TSHttpSsn ssnp)
 {
-  ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
+  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
 
   if (!cs) {
     return 0;
@@ -9277,7 +9277,7 @@ int64_t
 TSHttpSsnIdGet(TSHttpSsn ssnp)
 {
   sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
-  ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
+  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
   return cs->connection_id();
 }
 
@@ -9307,8 +9307,8 @@ TSHttpSsnClientProtocolStackGet(TSHttpSsn ssnp, int n, const char **result, int 
 {
   sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
   sdk_assert(n == 0 || result != nullptr);
-  ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
-  int count        = 0;
+  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
+  int count              = 0;
   if (cs && n > 0) {
     auto mem = static_cast<std::string_view *>(alloca(sizeof(std::string_view) * n));
     count    = cs->populate_protocol(mem, n);
@@ -9340,7 +9340,7 @@ const char *
 TSHttpSsnClientProtocolStackContains(TSHttpSsn ssnp, const char *tag)
 {
   sdk_assert(sdk_sanity_check_http_ssn(ssnp) == TS_SUCCESS);
-  ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
+  ProxyClientSession *cs = reinterpret_cast<ProxyClientSession *>(ssnp);
   return cs->protocol_contains(std::string_view{tag});
 }
 

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -76,7 +76,7 @@ extern "C" int plock(int);
 #include "ProxyConfig.h"
 #include "HttpProxyServerMain.h"
 #include "HttpBodyFactory.h"
-#include "ProxySession.h"
+#include "ProxyClientSession.h"
 #include "logging/Log.h"
 #include "CacheControl.h"
 #include "IPAllow.h"


### PR DESCRIPTION
This reverts commit dfd5d8f4533fadf1ca15834e0c2cdde06f96453e. (#4894)

 Conflicts:
	proxy/ProxyClientSession.cc
	proxy/http/HttpSM.h

---

I'd like to revert the renaming around Proxy Session / Transaction for now. The reasons are:
1) I am not sure enough this renaming is reasonable and will not need another renaming
2) Refactoring on master over the long term makes merging master to other branches difficult

I am +1 on doing the refactoring, but I want to see and discuss the design before we start making changes to not monkey around with our master code.