### PR TITLE
Move minimum OpenSSL version to 1.0.2

### DIFF
--- a/build/crypto.m4
+++ b/build/crypto.m4
@@ -39,38 +39,28 @@ AC_DEFUN([TS_CHECK_CRYPTO], [
 
   dnl add checks for other varieties of ssl here
 ])
+
 dnl
-
-AC_DEFUN([TS_CHECK_CRYPTO_EC_KEYS], [
-  _eckeys_saved_LIBS=$LIBS
-
-  TS_ADDTO(LIBS, [$OPENSSL_LIBS])
-  AC_CHECK_HEADERS(openssl/ec.h)
-  AC_CHECK_FUNCS(EC_KEY_new_by_curve_name, [enable_tls_eckey=yes], [enable_tls_eckey=no])
-  LIBS=$_eckeys_saved_LIBS
-
-  AC_MSG_CHECKING(whether EC keys are supported)
-  AC_MSG_RESULT([$enable_tls_eckey])
-  TS_ARG_ENABLE_VAR([use], [tls-eckey])
-  AC_SUBST(use_tls_eckey)
+dnl Check OpenSSL Version
+dnl
+AC_DEFUN([TS_CHECK_CRYPTO_VERSION], [
+  AC_MSG_CHECKING([OpenSSL version])
+  AC_TRY_RUN([
+#include <openssl/opensslv.h>
+int main() {
+  if (OPENSSL_VERSION_NUMBER < 0x1000200fL) {
+    return 1;
+  }
+  return 0;
+}
+],
+  [AC_MSG_RESULT([ok])],
+  [AC_MSG_FAILURE([requires an OpenSSL version 1.0.2 or greater])])
 ])
 
-AC_DEFUN([TS_CHECK_CRYPTO_NEXTPROTONEG], [
-  enable_tls_npn=yes
-  _npn_saved_LIBS=$LIBS
-
-  TS_ADDTO(LIBS, [$OPENSSL_LIBS])
-  AC_CHECK_FUNCS(SSL_CTX_set_next_protos_advertised_cb SSL_CTX_set_next_proto_select_cb SSL_select_next_proto SSL_get0_next_proto_negotiated,
-    [], [enable_tls_npn=no]
-  )
-  LIBS=$_npn_saved_LIBS
-
-  AC_MSG_CHECKING(whether to enable Next Protocol Negotiation TLS extension support)
-  AC_MSG_RESULT([$enable_tls_npn])
-  TS_ARG_ENABLE_VAR([use], [tls-npn])
-  AC_SUBST(use_tls_npn)
-])
-
+dnl
+dnl Since OpenSSL 1.1.0
+dnl
 AC_DEFUN([TS_CHECK_CRYPTO_ASYNC], [
   enable_tls_async=yes
   _async_saved_LIBS=$LIBS
@@ -87,63 +77,9 @@ AC_DEFUN([TS_CHECK_CRYPTO_ASYNC], [
   AC_SUBST(use_tls_async)
 ])
 
-AC_DEFUN([TS_CHECK_CRYPTO_ALPN], [
-  enable_tls_alpn=yes
-  _alpn_saved_LIBS=$LIBS
-
-  TS_ADDTO(LIBS, [$OPENSSL_LIBS])
-  AC_CHECK_FUNCS(SSL_CTX_set_alpn_protos SSL_CTX_set_alpn_select_cb SSL_get0_alpn_selected SSL_select_next_proto,
-    [], [enable_tls_alpn=no]
-  )
-  LIBS=$_alpn_saved_LIBS
-
-  AC_MSG_CHECKING(whether to enable Application Layer Protocol Negotiation TLS extension support)
-  AC_MSG_RESULT([$enable_tls_alpn])
-  TS_ARG_ENABLE_VAR([use], [tls-alpn])
-  AC_SUBST(use_tls_alpn)
-])
-
-AC_DEFUN([TS_CHECK_CRYPTO_CERT_CB], [
-  _cert_saved_LIBS=$LIBS
-  enable_cert_cb=yes
-
-  TS_ADDTO(LIBS, [$OPENSSL_LIBS])
-  AC_CHECK_HEADERS(openssl/ssl.h openssl/ts.h)
-  AC_CHECK_HEADERS(openssl/tls1.h, [], [],
-[ #if HAVE_OPENSSL_SSL_H
-#include <openssl/ssl.h>
-#include <openssl/tls1.h>
-#endif ])
-
-  AC_MSG_CHECKING([for SSL_CTX_set_cert_cb])
-  AC_LINK_IFELSE(
-  [
-    AC_LANG_PROGRAM([[
-#if HAVE_OPENSSL_SSL_H
-#include <openssl/ssl.h>
-#endif
-#if HAVE_OPENSSL_TLS1_H
-#include <openssl/tls1.h>
-#endif
-      ]],
-      [[SSL_CTX_set_cert_cb(NULL, NULL, NULL);]])
-  ],
-  [
-    AC_MSG_RESULT([yes])
-  ],
-  [
-    AC_MSG_RESULT([no])
-    enable_cert_cb=no
-  ])
-
-  LIBS=$_cert_saved_LIBS
-
-  AC_MSG_CHECKING(whether to enable TLS certificate callback support)
-  AC_MSG_RESULT([$enable_cert_cb])
-  TS_ARG_ENABLE_VAR([use], [cert-cb])
-  AC_SUBST(use_cert_cb)
-])
-
+dnl
+dnl Since OpenSSL 1.1.1
+dnl
 AC_DEFUN([TS_CHECK_CRYPTO_HELLO_CB], [
   _hello_saved_LIBS=$LIBS
   enable_hello_cb=yes
@@ -185,6 +121,9 @@ AC_DEFUN([TS_CHECK_CRYPTO_HELLO_CB], [
   AC_SUBST(use_hello_cb)
 ])
 
+dnl
+dnl Since OpenSSL 1.1.0
+dnl
 AC_DEFUN([TS_CHECK_CRYPTO_SET_RBIO], [
   _rbio_saved_LIBS=$LIBS
   enable_set_rbio=yes
@@ -219,6 +158,9 @@ AC_DEFUN([TS_CHECK_CRYPTO_SET_RBIO], [
   AC_SUBST(use_set_rbio)
 ])
 
+dnl
+dnl Since OpenSSL 1.1.0
+dnl
 AC_DEFUN([TS_CHECK_CRYPTO_DH_GET_2048_256], [
   _dh_saved_LIBS=$LIBS
   enable_dh_get_2048_256=yes
@@ -253,6 +195,9 @@ AC_DEFUN([TS_CHECK_CRYPTO_DH_GET_2048_256], [
   AC_SUBST(use_dh_get_2048_256)
 ])
 
+dnl
+dnl Since OpenSSL 1.1.0
+dnl
 AC_DEFUN([TS_CHECK_CRYPTO_OCSP], [
   _ocsp_saved_LIBS=$LIBS
 
@@ -268,6 +213,9 @@ AC_DEFUN([TS_CHECK_CRYPTO_OCSP], [
   AC_SUBST(use_tls_ocsp)
 ])
 
+dnl
+dnl Since OpenSSL 1.1.1
+dnl
 AC_DEFUN([TS_CHECK_CRYPTO_SET_CIPHERSUITES], [
   _set_ciphersuites_saved_LIBS=$LIBS
 

--- a/configure.ac
+++ b/configure.ac
@@ -1173,32 +1173,18 @@ TS_ADDTO([LDFLAGS], [$ATOMIC_LIBS])
 
 #
 # Check for SSL presence and usability
+#
 TS_CHECK_CRYPTO
 
-#
-# Check for NextProtocolNegotiation TLS extension support.
-TS_CHECK_CRYPTO_NEXTPROTONEG
+# Check for OpenSSL Version
+TS_CHECK_CRYPTO_VERSION
 
-#
-# Check for ALPN TLS extension support.
-TS_CHECK_CRYPTO_ALPN
-
-#
 # Check for openssl ASYNC jobs
 TS_CHECK_CRYPTO_ASYNC
-
-#
-# Check for EC key support.
-TS_CHECK_CRYPTO_EC_KEYS
-
-#
-# Check for the presense of the certificate callback in the ssl library
-TS_CHECK_CRYPTO_CERT_CB
 
 # Check for the client hello callback
 TS_CHECK_CRYPTO_HELLO_CB
 
-#
 # Check for SSL_set0_rbio call
 TS_CHECK_CRYPTO_SET_RBIO
 

--- a/include/tscore/ink_config.h.in
+++ b/include/tscore/ink_config.h.in
@@ -68,14 +68,10 @@
 #define TS_HAS_SO_MARK @has_so_mark@
 #define TS_HAS_IP_TOS @has_ip_tos@
 #define TS_USE_HWLOC @use_hwloc@
-#define TS_USE_TLS_NPN @use_tls_npn@
-#define TS_USE_TLS_ALPN @use_tls_alpn@
 #define TS_USE_TLS_ASYNC @use_tls_async@
-#define TS_USE_CERT_CB @use_cert_cb@
 #define TS_USE_HELLO_CB @use_hello_cb@
 #define TS_USE_SET_RBIO @use_set_rbio@
 #define TS_USE_GET_DH_2048_256 @use_dh_get_2048_256@
-#define TS_USE_TLS_ECKEY @use_tls_eckey@
 #define TS_USE_TLS_SET_CIPHERSUITES @use_tls_set_ciphersuites@
 #define TS_USE_LINUX_NATIVE_AIO @use_linux_native_aio@
 #define TS_USE_REMOTE_UNWINDING @use_remote_unwinding@

--- a/iocore/net/SSLClientUtils.cc
+++ b/iocore/net/SSLClientUtils.cc
@@ -32,12 +32,6 @@
 #include <openssl/err.h>
 #include <openssl/pem.h>
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10000000L) // openssl returns a const SSL_METHOD
-using ink_ssl_method_t = const SSL_METHOD *;
-#else
-typedef SSL_METHOD *ink_ssl_method_t;
-#endif
-
 int
 verify_callback(int signature_ok, X509_STORE_CTX *ctx)
 {
@@ -143,8 +137,8 @@ verify_callback(int signature_ok, X509_STORE_CTX *ctx)
 SSL_CTX *
 SSLInitClientContext(const SSLConfigParams *params)
 {
-  ink_ssl_method_t meth = nullptr;
-  SSL_CTX *client_ctx   = nullptr;
+  const SSL_METHOD *meth = nullptr;
+  SSL_CTX *client_ctx    = nullptr;
 
   // Note that we do not call RAND_seed() explicitly here, we depend on OpenSSL
   // to do the seeding of the PRNG for us. This is the case for all platforms that

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -256,10 +256,9 @@ SSLConfigParams::initialize()
 #endif
 
 #ifdef SSL_OP_NO_COMPRESSION
-  /* OpenSSL >= 1.0 only */
   ssl_ctx_options |= SSL_OP_NO_COMPRESSION;
   ssl_client_ctx_options |= SSL_OP_NO_COMPRESSION;
-#elif OPENSSL_VERSION_NUMBER >= 0x00908000L
+#else
   sk_SSL_COMP_zero(SSL_COMP_get_compression_methods());
 #endif
 

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -1274,16 +1274,10 @@ SSLNetVConnection::sslServerHandShakeEvent(int &err)
       // is preferred since it is the server's preference.  The server
       // preference would not be meaningful if we let the client
       // preference have priority.
-
-#if TS_USE_TLS_ALPN
       SSL_get0_alpn_selected(ssl, &proto, &len);
-#endif /* TS_USE_TLS_ALPN */
-
-#if TS_USE_TLS_NPN
       if (len == 0) {
         SSL_get0_next_proto_negotiated(ssl, &proto, &len);
       }
-#endif /* TS_USE_TLS_NPN */
 
       if (len) {
         // If there's no NPN set, we should not have done this negotiation.
@@ -1517,13 +1511,10 @@ SSLNetVConnection::select_next_protocol(SSL *ssl, const unsigned char **out, uns
   if (netvc->npnSet && netvc->npnSet->advertiseProtocols(&npn, &npnsz)) {
     // SSL_select_next_proto chooses the first server-offered protocol that appears in the clients protocol set, ie. the
     // server selects the protocol. This is a n^2 search, so it's preferable to keep the protocol set short.
-
-#if HAVE_SSL_SELECT_NEXT_PROTO
     if (SSL_select_next_proto((unsigned char **)out, outlen, npn, npnsz, in, inlen) == OPENSSL_NPN_NEGOTIATED) {
       Debug("ssl", "selected ALPN protocol %.*s", (int)(*outlen), *out);
       return SSL_TLSEXT_ERR_OK;
     }
-#endif /* HAVE_SSL_SELECT_NEXT_PROTO */
   }
 
   *out    = nullptr;

--- a/src/traffic_layout/info.cc
+++ b/src/traffic_layout/info.cc
@@ -89,11 +89,7 @@ produce_features(bool json)
   print_feature("TS_HAS_SO_MARK", TS_HAS_SO_MARK, json);
   print_feature("TS_HAS_IP_TOS", TS_HAS_IP_TOS, json);
   print_feature("TS_USE_HWLOC", TS_USE_HWLOC, json);
-  print_feature("TS_USE_TLS_NPN", TS_USE_TLS_NPN, json);
-  print_feature("TS_USE_TLS_ALPN", TS_USE_TLS_ALPN, json);
-  print_feature("TS_USE_CERT_CB", TS_USE_CERT_CB, json);
   print_feature("TS_USE_SET_RBIO", TS_USE_SET_RBIO, json);
-  print_feature("TS_USE_TLS_ECKEY", TS_USE_TLS_ECKEY, json);
   print_feature("TS_USE_LINUX_NATIVE_AIO", TS_USE_LINUX_NATIVE_AIO, json);
   print_feature("TS_HAS_SO_PEERCRED", TS_HAS_SO_PEERCRED, json);
   print_feature("TS_USE_REMOTE_UNWINDING", TS_USE_REMOTE_UNWINDING, json);

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -6971,7 +6971,6 @@ extern bool ssl_register_protocol(const char *, Continuation *);
 extern bool ssl_unregister_protocol(const char *, Continuation *);
 
 TSReturnCode
-#if TS_USE_TLS_NPN
 TSNetAcceptNamedProtocol(TSCont contp, const char *protocol)
 {
   sdk_assert(protocol != nullptr);
@@ -6985,12 +6984,6 @@ TSNetAcceptNamedProtocol(TSCont contp, const char *protocol)
 
   return TS_SUCCESS;
 }
-#else  /* TS_USE_TLS_NPN */
-TSNetAcceptNamedProtocol(TSCont, const char *)
-{
-  return TS_ERROR;
-}
-#endif /* TS_USE_TLS_NPN */
 
 /* DNS Lookups */
 TSAction

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,8 +6,8 @@ This directory contains different tests for Apache Trafficserver. It is recommen
 ## Layout
 The current layout is:
 
-**gold_tests/** - contains all the TSQA v4 based tests that run on the Reusable Gold Testing System (AuTest)  
-**tools/** - contains programs used to help with testing.  
+**gold_tests/** - contains all the TSQA v4 based tests that run on the Reusable Gold Testing System (AuTest)
+**tools/** - contains programs used to help with testing.
 **include/** - contains headers used for unit testing.
 
 ## Scripts
@@ -290,11 +290,7 @@ ts.Disk.remap_config.AddLine(
  * TS_HAS_SO_MARK
  * TS_HAS_IP_TOS
  * TS_USE_HWLOC
- * TS_USE_TLS_NPN
- * TS_USE_TLS_ALPN
- * TS_USE_CERT_CB
  * TS_USE_SET_RBIO
- * TS_USE_TLS_ECKEY
  * TS_USE_LINUX_NATIVE_AIO
  * TS_HAS_SO_PEERCRED
  * TS_USE_REMOTE_UNWINDING
@@ -307,7 +303,7 @@ ts.Disk.remap_config.AddLine(
 ```python
 #create the origin server process
 Test.SkipUnless(
-    Condition.HasATSFeature('TS_USE_TLS_ALPN'),
+    Condition.HasATSFeature('TS_USE_LINUX_NATIVE_AIO'),
 )
 ```
 

--- a/tests/gold_tests/headers/forwarded.test.py
+++ b/tests/gold_tests/headers/forwarded.test.py
@@ -25,7 +25,6 @@ Test FORWARDED header.
 '''
 
 Test.SkipUnless(
-    Condition.HasATSFeature('TS_USE_TLS_ALPN'),
     Condition.HasCurlFeature('http2'),
     Condition.HasCurlFeature('IPv6'),
 )

--- a/tests/gold_tests/headers/via.test.py
+++ b/tests/gold_tests/headers/via.test.py
@@ -26,7 +26,6 @@ Check VIA header for protocol stack data.
 '''
 
 Test.SkipUnless(
-    Condition.HasATSFeature('TS_USE_TLS_ALPN'),
     Condition.HasCurlFeature('http2'),
     Condition.HasCurlFeature('IPv6')
 )

--- a/tests/gold_tests/logging/ccid_ctid.test.py
+++ b/tests/gold_tests/logging/ccid_ctid.test.py
@@ -27,7 +27,6 @@ Test.SkipUnless(
     Condition.HasProgram(
         "curl", "Curl need to be installed on system for this test to work"),
     # Condition.IsPlatform("linux"), Don't see the need for this.
-    Condition.HasATSFeature('TS_USE_TLS_ALPN'),
     Condition.HasCurlFeature('http2')
 )
 

--- a/tests/gold_tests/pluginTest/sslheaders/sslheaders.test.py
+++ b/tests/gold_tests/pluginTest/sslheaders/sslheaders.test.py
@@ -22,7 +22,6 @@ Test sslheaders plugin.
 '''
 
 Test.SkipUnless(
-    Condition.HasATSFeature('TS_USE_TLS_ALPN'),
     Condition.HasCurlFeature('http2'),
 )
 

--- a/tests/gold_tests/pluginTest/test_hooks/test_hooks.test.py
+++ b/tests/gold_tests/pluginTest/test_hooks/test_hooks.test.py
@@ -19,7 +19,6 @@ Test TS API Hooks.
 '''
 
 Test.SkipUnless(
-    Condition.HasATSFeature('TS_USE_TLS_ALPN'),
     Condition.HasCurlFeature('http2'),
 )
 Test.ContinueOnFail = True

--- a/tests/gold_tests/pluginTest/tsapi/tsapi.test.py
+++ b/tests/gold_tests/pluginTest/tsapi/tsapi.test.py
@@ -19,7 +19,6 @@ Test TS API.
 '''
 
 Test.SkipUnless(
-    Condition.HasATSFeature('TS_USE_TLS_ALPN'),
     Condition.HasCurlFeature('http2'),
 )
 Test.ContinueOnFail = True

--- a/tests/gold_tests/pluginTest/url_sig/url_sig.test.py
+++ b/tests/gold_tests/pluginTest/url_sig/url_sig.test.py
@@ -22,9 +22,6 @@ Test.Summary = '''
 Test url_sig plugin
 '''
 
-Test.SkipUnless(
-    Condition.HasATSFeature('TS_USE_TLS_ALPN'),
-)
 Test.ContinueOnFail = True
 Test.SkipIf(Condition.true("Test is temporarily turned off, to be fixed according to an incompatible plugin API change (PR #4964)"))
 


### PR DESCRIPTION
Discussed on dev ML, we're going to change minimum OpenSSL version to 1.0.2.
Thus we can assume OpenSSL 1.0.2 API and header files. It looks like we can remove below

Checking header file (AC_CHECK_HEADERS)
- `HAVE_OPENSSL_EC_H`
- `HAVE_OPENSSL_EVP_H` ( actually, this was not checked )

Checking functions (AC_CHECK_FUNCSS)
- `HAVE_EC_KEY_NEW_BY_CURVE_NAME`
- `HAVE_SSL_SELECT_NEXT_PROTO`

Checking TS features (TS_CHECK_)
- `TS_USE_TLS_NPN`
- `TS_USE_TLS_ALPN`
- `TS_USE_CERT_CB`
- `TS_USE_TLS_ECKEY`

We still need some TS_CHECK_* stuff for APIs introduced by OpenSSL 1.1.0 and above.

Docs of APIs of each versions are below
- https://www.openssl.org/docs/man1.0.2/man3/
- https://www.openssl.org/docs/man1.1.0/man3/
- https://www.openssl.org/docs/man1.1.1/man3/

----

This is incompatible change. Do NOT backport to 8.x.x branch. 
Part of #5040.