### PR TITLE
Unify plugins hook dispatch

### DIFF
--- a/iocore/cache/test/stub.cc
+++ b/iocore/cache/test/stub.cc
@@ -39,7 +39,7 @@ APIHooks::append(INKContInternal *cont)
 }
 
 int
-APIHook::invoke(int, void *)
+APIHook::invoke(int, void *) const
 {
   ink_assert(false);
   return 0;
@@ -53,19 +53,27 @@ APIHook::next() const
 }
 
 APIHook *
-APIHooks::get() const
+APIHooks::head() const
 {
   return nullptr;
 }
 
 void
-APIHooks::prepend(INKContInternal *cont)
+APIHooks::clear()
 {
 }
 
+HttpHookState::HttpHookState() {}
+
 void
-APIHooks::clear()
+HttpHookState::init(TSHttpHookID id, HttpAPIHooks const *global, HttpAPIHooks const *ssn, HttpAPIHooks const *txn)
 {
+}
+
+APIHook const *
+HttpHookState::getNext()
+{
+  return nullptr;
 }
 
 void

--- a/iocore/net/libinknet_stub.cc
+++ b/iocore/net/libinknet_stub.cc
@@ -86,7 +86,7 @@ Log::trace_out(sockaddr const *, unsigned short, char const *, ...)
 
 #include "InkAPIInternal.h"
 int
-APIHook::invoke(int, void *)
+APIHook::invoke(int, void *) const
 {
   ink_assert(false);
   return 0;
@@ -100,7 +100,14 @@ APIHook::next() const
 }
 
 APIHook *
-APIHooks::get() const
+APIHook::prev() const
+{
+  ink_assert(false);
+  return nullptr;
+}
+
+APIHook *
+APIHooks::head() const
 {
   ink_assert(false);
   return nullptr;

--- a/proxy/ProxySession.h
+++ b/proxy/ProxySession.h
@@ -101,9 +101,7 @@ public:
   virtual const char *get_protocol_string() const = 0;
   virtual bool is_transparent_passthrough_allowed() const;
 
-  virtual void ssn_hook_append(TSHttpHookID id, INKContInternal *cont);
-
-  virtual void ssn_hook_prepend(TSHttpHookID id, INKContInternal *cont);
+  virtual void hook_add(TSHttpHookID id, INKContInternal *cont);
 
   virtual bool is_chunked_encoding_supported() const;
 
@@ -146,8 +144,8 @@ public:
   TSHttpHookID get_hookid() const;
   bool has_hooks() const;
 
-  APIHook *ssn_hook_get(TSHttpHookID id) const;
-
+  APIHook *hook_get(TSHttpHookID id) const;
+  HttpAPIHooks const *feature_hooks() const;
   ////////////////////
   // Members
 
@@ -163,6 +161,9 @@ public:
   ink_hrtime ssn_last_txn_time = 0;
 
 protected:
+  // Hook dispatching state
+  HttpHookState hook_state;
+
   // XXX Consider using a bitwise flags variable for the following flags, so
   // that we can make the best use of internal alignment padding.
 
@@ -177,9 +178,7 @@ private:
   void handle_api_return(int event);
   int state_api_callout(int event, void *edata);
 
-  APIHookScope api_scope  = API_HOOK_SCOPE_NONE;
-  TSHttpHookID api_hookid = TS_HTTP_READ_REQUEST_HDR_HOOK;
-  APIHook *api_current    = nullptr;
+  APIHook const *cur_hook = nullptr;
   HttpAPIHooks api_hooks;
   void *user_args[TS_HTTP_MAX_USER_ARG];
 

--- a/proxy/ProxyTransaction.cc
+++ b/proxy/ProxyTransaction.cc
@@ -157,9 +157,15 @@ ProxyTransaction::debug() const
 }
 
 APIHook *
-ProxyTransaction::ssn_hook_get(TSHttpHookID id) const
+ProxyTransaction::hook_get(TSHttpHookID id) const
 {
-  return proxy_ssn ? proxy_ssn->ssn_hook_get(id) : nullptr;
+  return proxy_ssn ? proxy_ssn->hook_get(id) : nullptr;
+}
+
+HttpAPIHooks const *
+ProxyTransaction::feature_hooks() const
+{
+  return proxy_ssn ? proxy_ssn->feature_hooks() : nullptr;
 }
 
 bool

--- a/proxy/ProxyTransaction.h
+++ b/proxy/ProxyTransaction.h
@@ -89,7 +89,8 @@ public:
 
   bool debug() const;
 
-  APIHook *ssn_hook_get(TSHttpHookID id) const;
+  APIHook *hook_get(TSHttpHookID id) const;
+  HttpAPIHooks const *feature_hooks() const;
   bool has_hooks() const;
 
   HostResStyle get_host_res_style() const;

--- a/proxy/Transform.cc
+++ b/proxy/Transform.cc
@@ -545,7 +545,7 @@ TransformControl::handle_event(int event, void * /* edata ATS_UNUSED */)
     if (http_global_hooks && http_global_hooks->get(TS_HTTP_RESPONSE_TRANSFORM_HOOK)) {
       m_tvc = transformProcessor.open(this, http_global_hooks->get(TS_HTTP_RESPONSE_TRANSFORM_HOOK));
     } else {
-      m_tvc = transformProcessor.open(this, m_hooks.get());
+      m_tvc = transformProcessor.open(this, m_hooks.head());
     }
     ink_assert(m_tvc != nullptr);
 

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -1400,67 +1400,46 @@ plugins required to work with sni_routing.
     }
   // FALLTHROUGH
   case HTTP_API_CONTINUE:
-    if ((cur_hook_id >= 0) && (cur_hook_id < TS_HTTP_LAST_HOOK)) {
-      if (!cur_hook) {
-        if (cur_hooks == 0) {
-          cur_hook = http_global_hooks->get(cur_hook_id);
-          cur_hooks++;
-        }
+    if (nullptr == cur_hook) {
+      cur_hook = hook_state.getNext();
+    }
+    if (cur_hook) {
+      if (callout_state == HTTP_API_NO_CALLOUT) {
+        callout_state = HTTP_API_IN_CALLOUT;
       }
-      // even if ua_txn is NULL, cur_hooks must
-      // be incremented otherwise cur_hooks is not set to 2 and
-      // transaction hooks (stored in api_hooks object) are not called.
-      if (!cur_hook) {
-        if (cur_hooks == 1) {
-          if (ua_txn) {
-            cur_hook = ua_txn->ssn_hook_get(cur_hook_id);
-          }
-          cur_hooks++;
-        }
-      }
-      if (!cur_hook) {
-        if (cur_hooks == 2) {
-          cur_hook = api_hooks.get(cur_hook_id);
-          cur_hooks++;
-        }
-      }
-      if (cur_hook) {
-        if (callout_state == HTTP_API_NO_CALLOUT) {
-          callout_state = HTTP_API_IN_CALLOUT;
-        }
 
-        MUTEX_TRY_LOCK(lock, cur_hook->m_cont->mutex, mutex->thread_holding);
-        // Have a mutex but didn't get the lock, reschedule
-        if (!lock.is_locked()) {
-          api_timer = -Thread::get_hrtime_updated();
-          HTTP_SM_SET_DEFAULT_HANDLER(&HttpSM::state_api_callout);
-          ink_assert(pending_action == nullptr);
-          pending_action = mutex->thread_holding->schedule_in(this, HRTIME_MSECONDS(10));
-          // Should @a callout_state be reset back to HTTP_API_NO_CALLOUT here? Because the default
-          // handler has been changed the value isn't important to the rest of the state machine
-          // but not resetting means there is no way to reliably detect re-entrance to this state with an
-          // outstanding callout.
-          return 0;
-        }
-        SMDebug("http", "[%" PRId64 "] calling plugin on hook %s at hook %p", sm_id, HttpDebugNames::get_api_hook_name(cur_hook_id),
-                cur_hook);
+      MUTEX_TRY_LOCK(lock, cur_hook->m_cont->mutex, mutex->thread_holding);
 
-        APIHook *hook = cur_hook;
-        cur_hook      = cur_hook->next();
-
-        if (!api_timer) {
-          api_timer = Thread::get_hrtime_updated();
-        }
-        hook->invoke(TS_EVENT_HTTP_READ_REQUEST_HDR + cur_hook_id, this);
-        if (api_timer > 0) { // true if the hook did not call TxnReenable()
-          milestone_update_api_time(milestones, api_timer);
-          api_timer = -Thread::get_hrtime_updated(); // set in order to track non-active callout duration
-          // which means that if we get back from the invoke with api_timer < 0 we're already
-          // tracking a non-complete callout from a chain so just let it ride. It will get cleaned
-          // up in state_api_callback when the plugin re-enables this transaction.
-        }
+      // Have a mutex but didn't get the lock, reschedule
+      if (!lock.is_locked()) {
+        api_timer = -Thread::get_hrtime_updated();
+        HTTP_SM_SET_DEFAULT_HANDLER(&HttpSM::state_api_callout);
+        ink_assert(pending_action == nullptr);
+        pending_action = mutex->thread_holding->schedule_in(this, HRTIME_MSECONDS(10));
         return 0;
       }
+
+      SMDebug("http", "[%" PRId64 "] calling plugin on hook %s at hook %p", sm_id, HttpDebugNames::get_api_hook_name(cur_hook_id),
+              cur_hook);
+
+      APIHook const *hook = cur_hook;
+      // Need to delay the next hook update until after this hook is called to handle dynamic
+      // callback manipulation. cur_hook isn't needed to track state (in hook_state).
+      cur_hook = nullptr;
+
+      if (!api_timer) {
+        api_timer = Thread::get_hrtime();
+      }
+
+      hook->invoke(TS_EVENT_HTTP_READ_REQUEST_HDR + cur_hook_id, this);
+      if (api_timer > 0) { // true if the hook did not call TxnReenable()
+        milestone_update_api_time(milestones, api_timer);
+        api_timer = -Thread::get_hrtime(); // set in order to track non-active callout duration
+        // which means that if we get back from the invoke with api_timer < 0 we're already
+        // tracking a non-complete callout from a chain so just let it ride. It will get cleaned
+        // up in state_api_callback when the plugin re-enables this transaction.
+      }
+      return 0;
     }
     // Map the callout state into api_next
     switch (callout_state) {
@@ -5137,6 +5116,7 @@ HttpSM::do_api_callout_internal()
     ink_assert(!"not reached");
   }
 
+  hook_state.init(cur_hook_id, http_global_hooks, ua_txn ? ua_txn->feature_hooks() : nullptr, &api_hooks);
   cur_hook  = nullptr;
   cur_hooks = 0;
   state_api_callout(0, nullptr);
@@ -5148,7 +5128,7 @@ HttpSM::do_post_transform_open()
   ink_assert(post_transform_info.vc == nullptr);
 
   if (is_action_tag_set("http_post_nullt")) {
-    txn_hook_prepend(TS_HTTP_REQUEST_TRANSFORM_HOOK, transformProcessor.null_transform(mutex.get()));
+    txn_hook_add(TS_HTTP_REQUEST_TRANSFORM_HOOK, transformProcessor.null_transform(mutex.get()));
   }
 
   post_transform_info.vc = transformProcessor.open(this, api_hooks.get(TS_HTTP_REQUEST_TRANSFORM_HOOK));
@@ -5169,7 +5149,7 @@ HttpSM::do_transform_open()
   APIHook *hooks;
 
   if (is_action_tag_set("http_nullt")) {
-    txn_hook_prepend(TS_HTTP_RESPONSE_TRANSFORM_HOOK, transformProcessor.null_transform(mutex.get()));
+    txn_hook_add(TS_HTTP_RESPONSE_TRANSFORM_HOOK, transformProcessor.null_transform(mutex.get()));
   }
 
   hooks = api_hooks.get(TS_HTTP_RESPONSE_TRANSFORM_HOOK);

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -291,8 +291,7 @@ public:
   void dump_state_hdr(HTTPHdr *h, const char *s);
 
   // Functions for manipulating api hooks
-  void txn_hook_append(TSHttpHookID id, INKContInternal *cont);
-  void txn_hook_prepend(TSHttpHookID id, INKContInternal *cont);
+  void txn_hook_add(TSHttpHookID id, INKContInternal *cont);
   APIHook *txn_hook_get(TSHttpHookID id);
 
   bool is_private();
@@ -563,7 +562,8 @@ public:
 
 protected:
   TSHttpHookID cur_hook_id = TS_HTTP_LAST_HOOK;
-  APIHook *cur_hook        = nullptr;
+  APIHook const *cur_hook  = nullptr;
+  HttpHookState hook_state;
 
   //
   // Continuation time keeper
@@ -678,16 +678,9 @@ HttpSM::find_server_buffer_size()
 }
 
 inline void
-HttpSM::txn_hook_append(TSHttpHookID id, INKContInternal *cont)
+HttpSM::txn_hook_add(TSHttpHookID id, INKContInternal *cont)
 {
   api_hooks.append(id, cont);
-  hooks_set = true;
-}
-
-inline void
-HttpSM::txn_hook_prepend(TSHttpHookID id, INKContInternal *cont)
-{
-  api_hooks.prepend(id, cont);
   hooks_set = true;
 }
 

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -1303,12 +1303,23 @@ INKVConnInternal::set_data(int id, void *data)
 
 ////////////////////////////////////////////////////////////////////
 //
-// APIHook, APIHooks, HttpAPIHooks
+// APIHook, APIHooks, HttpAPIHooks, HttpHookState
 //
 ////////////////////////////////////////////////////////////////////
+APIHook *
+APIHook::next() const
+{
+  return m_link.next;
+}
+
+APIHook *
+APIHook::prev() const
+{
+  return m_link.prev;
+}
 
 int
-APIHook::invoke(int event, void *edata)
+APIHook::invoke(int event, void *edata) const
 {
   if ((event == EVENT_IMMEDIATE) || (event == EVENT_INTERVAL) || event == TS_EVENT_HTTP_TXN_CLOSE) {
     if (ink_atomic_increment((int *)&m_cont->m_event_count, 1) < 0) {
@@ -1324,20 +1335,9 @@ APIHook::invoke(int event, void *edata)
 }
 
 APIHook *
-APIHook::next() const
+APIHooks::head() const
 {
-  return m_link.next;
-}
-
-void
-APIHooks::prepend(INKContInternal *cont)
-{
-  APIHook *api_hook;
-
-  api_hook         = apiHookAllocator.alloc();
-  api_hook->m_cont = cont;
-
-  m_hooks.push(api_hook);
+  return m_hooks.head;
 }
 
 void
@@ -1351,12 +1351,6 @@ APIHooks::append(INKContInternal *cont)
   m_hooks.enqueue(api_hook);
 }
 
-APIHook *
-APIHooks::get() const
-{
-  return m_hooks.head;
-}
-
 void
 APIHooks::clear()
 {
@@ -1364,6 +1358,94 @@ APIHooks::clear()
   while (nullptr != (hook = m_hooks.pop())) {
     apiHookAllocator.free(hook);
   }
+}
+
+HttpHookState::HttpHookState() : _id(TS_HTTP_LAST_HOOK) {}
+
+void
+HttpHookState::init(TSHttpHookID id, HttpAPIHooks const *global, HttpAPIHooks const *ssn, HttpAPIHooks const *txn)
+{
+  _id = id;
+
+  if (global) {
+    _global.init(global, id);
+  } else {
+    _global.clear();
+  }
+
+  if (ssn) {
+    _ssn.init(ssn, id);
+  } else {
+    _ssn.clear();
+  }
+
+  if (txn) {
+    _txn.init(txn, id);
+  } else {
+    _txn.clear();
+  }
+}
+
+APIHook const *
+HttpHookState::getNext()
+{
+  APIHook const *zret = nullptr;
+  do {
+    APIHook const *hg   = _global.candidate();
+    APIHook const *hssn = _ssn.candidate();
+    APIHook const *htxn = _txn.candidate();
+    zret                = nullptr;
+
+    Debug("plugin", "computing next callback for hook %d", _id);
+
+    if (hg) {
+      zret = hg;
+      ++_global;
+    } else if (hssn) {
+      zret = hssn;
+      ++_ssn;
+    } else if (htxn) {
+      zret = htxn;
+      ++_txn;
+    }
+  } while (zret != nullptr && !this->is_enabled());
+
+  return zret;
+}
+
+bool
+HttpHookState::is_enabled()
+{
+  return true;
+}
+
+void
+HttpHookState::Scope::init(HttpAPIHooks const *feature_hooks, TSHttpHookID id)
+{
+  APIHooks const *hooks = (*feature_hooks)[id];
+
+  _p = nullptr;
+  _c = hooks->head();
+}
+
+APIHook const *
+HttpHookState::Scope::candidate()
+{
+  /// Simply returns _c hook for now. Later will do priority checking here
+  return _c;
+}
+
+void
+HttpHookState::Scope::operator++()
+{
+  _p = _c;
+  _c = _c->next();
+}
+
+void
+HttpHookState::Scope::clear()
+{
+  _p = _c = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -4743,7 +4825,7 @@ TSHttpSsnHookAdd(TSHttpSsn ssnp, TSHttpHookID id, TSCont contp)
   sdk_assert(sdk_sanity_check_hook_id(id) == TS_SUCCESS);
 
   ProxySession *cs = reinterpret_cast<ProxySession *>(ssnp);
-  cs->ssn_hook_append(id, (INKContInternal *)contp);
+  cs->hook_add(id, (INKContInternal *)contp);
 }
 
 int
@@ -4831,7 +4913,7 @@ TSHttpTxnHookAdd(TSHttpTxn txnp, TSHttpHookID id, TSCont contp)
     }
     hook = hook->m_link.next;
   }
-  sm->txn_hook_append(id, (INKContInternal *)contp);
+  sm->txn_hook_add(id, (INKContInternal *)contp);
 }
 
 // Private api function for gzip plugin.


### PR DESCRIPTION
* Added`HttpHookState` class that manages all http hooks. This will be useful for later plugin coordination work.
* Changed `ProxySession` and `HttpSM` to use `HttpHookState` for hooks dispatch
* Minor changes to `APIHook`, `APIHooks`, and `FeatureAPIHooks`

This is phase one of the [Plugin Coordination project](https://solidwallofcode.github.io/plugin-coordination.en.html). The early phases will provide mostly debugging support.