### PR TITLE
Fix directives for checking TS_USE_TLS_OCSP

### DIFF
--- a/iocore/net/OCSPStapling.cc
+++ b/iocore/net/OCSPStapling.cc
@@ -20,7 +20,7 @@
  */
 
 #include "P_OCSPStapling.h"
-#ifdef TS_USE_TLS_OCSP
+#if TS_USE_TLS_OCSP
 
 #include <openssl/ssl.h>
 #include <openssl/ocsp.h>

--- a/iocore/net/SSLNetProcessor.cc
+++ b/iocore/net/SSLNetProcessor.cc
@@ -37,7 +37,7 @@ SSLNetProcessor ssl_NetProcessor;
 NetProcessor &sslNetProcessor = ssl_NetProcessor;
 SNIActionPerformer sni_action_performer;
 
-#ifdef TS_USE_TLS_OCSP
+#if TS_USE_TLS_OCSP
 struct OCSPContinuation : public Continuation {
   int
   mainEvent(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
@@ -76,7 +76,7 @@ SSLNetProcessor::start(int, size_t stacksize)
   // Initialize SSL statistics. This depends on an initial set of certificates being loaded above.
   SSLInitializeStatistics();
 
-#ifdef TS_USE_TLS_OCSP
+#if TS_USE_TLS_OCSP
   if (SSLConfigParams::ssl_ocsp_enabled) {
     // Call the update initially to get things populated
     ocsp_update();

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1022,7 +1022,7 @@ SSLInitializeLibrary()
   }
 #endif
 
-#ifdef TS_USE_TLS_OCSP
+#if TS_USE_TLS_OCSP
   ssl_stapling_ex_init();
 #endif /* TS_USE_TLS_OCSP */
 
@@ -1604,7 +1604,7 @@ SSLInitServerContext(const SSLConfigParams *params, const ssl_user_config *sslMu
   SSL_CTX_set_alpn_select_cb(ctx, SSLNetVConnection::select_next_protocol, nullptr);
 #endif /* TS_USE_TLS_ALPN */
 
-#ifdef TS_USE_TLS_OCSP
+#if TS_USE_TLS_OCSP
   if (SSLConfigParams::ssl_ocsp_enabled) {
     Debug("ssl", "SSL OCSP Stapling is enabled");
     SSL_CTX_set_tlsext_status_cb(ctx, ssl_callback_ocsp_stapling);

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -8984,7 +8984,7 @@ TSSslServerContextCreate(TSSslX509 cert, const char *certname)
   SSLConfigParams *config = SSLConfig::acquire();
   if (config != nullptr) {
     ret = reinterpret_cast<TSSslContext>(SSLCreateServerContext(config));
-#ifdef TS_USE_TLS_OCSP
+#if TS_USE_TLS_OCSP
     if (ret && SSLConfigParams::ssl_ocsp_enabled && cert && certname) {
       if (SSL_CTX_set_tlsext_status_cb(reinterpret_cast<SSL_CTX *>(ret), ssl_callback_ocsp_stapling)) {
         if (!ssl_stapling_init_cert(reinterpret_cast<SSL_CTX *>(ret), reinterpret_cast<X509 *>(cert), certname)) {


### PR DESCRIPTION
`#ifdef` directives for `TS_USE_TLS_OCSP` doesn't make sense. Because `TS_USE_*` are defined as `0` or `1`, unlike `HAVE_OPENSSL_*` nor `OPENSSL_NO_*` (these are defined or undefined).

https://github.com/apache/trafficserver/blob/5b86099e66221d2786ba09b5a432f8d73619cf35/include/tscore/ink_config.h.in#L83