### PR TITLE
Use more pthread APIs

### DIFF
--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -1105,6 +1105,10 @@ tsapi const char *TSHttpHdrReasonLookup(TSHttpStatus status);
    Threads */
 tsapi TSThread TSThreadCreate(TSThreadFunc func, void *data);
 tsapi TSThread TSThreadInit(void);
+tsapi void TSThreadSetCancelState(TSThread thread, int state);
+tsapi void TSThreadSetCancelType(TSThread thread, int type);
+tsapi void TSThreadCancel(TSThread thread);
+tsapi void *TSThreadJoin(TSThread thread);
 tsapi void TSThreadDestroy(TSThread thread);
 tsapi void TSThreadWait(TSThread thread);
 tsapi TSThread TSThreadSelf(void);

--- a/include/tscore/ink_thread.h
+++ b/include/tscore/ink_thread.h
@@ -163,16 +163,28 @@ ink_thread_create(ink_thread *tid, void *(*f)(void *), void *a, int detached, si
   pthread_attr_destroy(&attr);
 }
 
+static inline int
+ink_thread_setcancelstate(ink_thread who, int state)
+{
+  int r;
+  ink_assert(!pthread_setcancelstate(state, &r));
+  return r;
+}
+
+static inline int
+ink_thread_setcanceltype(ink_thread who, int type)
+{
+  int r;
+  ink_assert(!pthread_setcanceltype(type, &r));
+  return r;
+}
+
 static inline void
 ink_thread_cancel(ink_thread who)
 {
-#if defined(freebsd)
-  (void)who;
-  ink_assert(!"not supported");
-#else
-  int ret = pthread_cancel(who);
-  ink_assert(ret == 0);
-#endif
+  // Removing the check for FreeBSD according to this
+  // https://www.freebsd.org/cgi/man.cgi?query=pthread_cancel
+  ink_assert(!pthread_cancel(who));
 }
 
 static inline void *

--- a/src/traffic_server/InkIOCoreAPI.cc
+++ b/src/traffic_server/InkIOCoreAPI.cc
@@ -157,6 +157,7 @@ TSThreadCreate(TSThreadFunc func, void *data)
   if (!tid) {
     return (TSThread) nullptr;
   }
+  thread->tid = tid;
 
   return (TSThread)thread;
 }
@@ -198,6 +199,51 @@ TSThreadInit()
   thread->set_specific();
 
   return reinterpret_cast<TSThread>(thread);
+}
+
+void
+TSThreadSetCancelState(TSThread thread, int state)
+{
+  sdk_assert(sdk_sanity_check_iocore_structure(thread) == TS_SUCCESS);
+  INKThreadInternal *ithread = reinterpret_cast<INKThreadInternal *>(thread);
+
+  if (ithread->tid != 0) {
+    ink_thread_setcancelstate(ithread->tid, state);
+  }
+}
+
+void
+TSThreadSetCancelType(TSThread thread, int type)
+{
+  sdk_assert(sdk_sanity_check_iocore_structure(thread) == TS_SUCCESS);
+  INKThreadInternal *ithread = reinterpret_cast<INKThreadInternal *>(thread);
+
+  if (ithread->tid != 0) {
+    ink_thread_setcanceltype(ithread->tid, type);
+  }
+}
+
+void
+TSThreadCancel(TSThread thread)
+{
+  sdk_assert(sdk_sanity_check_iocore_structure(thread) == TS_SUCCESS);
+  INKThreadInternal *ithread = reinterpret_cast<INKThreadInternal *>(thread);
+
+  if (ithread->tid != 0) {
+    ink_thread_cancel(ithread->tid);
+  }
+}
+
+void *
+TSThreadJoin(TSThread thread)
+{
+  sdk_assert(sdk_sanity_check_iocore_structure(thread) == TS_SUCCESS);
+  INKThreadInternal *ithread = reinterpret_cast<INKThreadInternal *>(thread);
+
+  if (ithread->tid != 0) {
+    return ink_thread_join(ithread->tid);
+  }
+  return nullptr;
 }
 
 void


### PR DESCRIPTION
Adding support for `pthread_setcancelstate` and `pthread_setcanceltype` calls, and exposing them to plugins. Also exposing `pthread_cancel` and `pthread_join`.