### PR TITLE
Remove extra args to bwprint in SSLConfigParams::getCTX()

### DIFF
--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -673,7 +673,7 @@ SSLConfigParams::getCTX(const char *client_cert, const char *key_file, const cha
   CTX_MAP *ctx_map    = nullptr;
   std::string top_level_key, ctx_key;
   ts::bwprint(top_level_key, "{}:{}", ca_bundle_file, ca_bundle_path);
-  ts::bwprint(ctx_key, "{}:{}", client_cert, key_file, ca_bundle_file, ca_bundle_path);
+  ts::bwprint(ctx_key, "{}:{}", client_cert, key_file);
 
   ink_mutex_acquire(&ctxMapLock);
   // Do first level searching and create new CTX_MAP as second level if not exists.


### PR DESCRIPTION
Clean up extra arguments used in ts::bwprint introduced in #5051 