### PR TITLE
MIME: Fix line_is_real false positive.

### DIFF
--- a/proxy/hdrs/MIME.cc
+++ b/proxy/hdrs/MIME.cc
@@ -2442,14 +2442,14 @@ MIMEScanner::get(TextView &input, TextView &output, bool &output_shares_input, b
   }
 
   // adjust out arguments.
+  output_shares_input = true;
   if (PARSE_RESULT_CONT != zret) {
     if (!m_line.empty()) {
       output = m_line;
       m_line.resize(0); // depending resize(0) not deallocating internal string memory.
       output_shares_input = false;
     } else {
-      output              = parsed_text;
-      output_shares_input = true;
+      output = parsed_text;
     }
   }
 
@@ -2569,8 +2569,8 @@ mime_parser_parse(MIMEParser *parser, HdrHeap *heap, MIMEHdrImpl *mh, const char
     //////////////////////////////////////////////////////////////////////
 
     if (must_copy_strings || (!line_is_real)) {
-      char *dup      = heap->duplicate_str(parsed.data(), parsed.size());
-      intptr_t delta = dup - parsed.data();
+      char *dup       = heap->duplicate_str(parsed.data(), parsed.size());
+      ptrdiff_t delta = dup - parsed.data();
       field_name.assign(field_name.data() + delta, field_name.size());
       field_value.assign(field_value.data() + delta, field_value.size());
     }


### PR DESCRIPTION
This fixes a false positive. The claim is `line_is_real` may not be initialized, but that's not the case. Currently it is set  iff the result from `MIMEScanner:get` is not `PARSE_CONT`. Therefore it is uninitialized iff the result is `PARSE_CONT`. However, immediately after `MIMEScanner::get` is called (around "MIME.cc:2506") the code checks the result and returns if it is not `PARSE_OK`. That is, if the result is `PARSE_CONT` then `mime_parser_parse` is exited and the line in question, "MIME.cc:2571", is not executed.

But, whatever - easier to just set the flag even if it's irrelevant.