### PR TITLE
Slight adjust to the thread affinity logic

### DIFF
--- a/iocore/eventsystem/P_UnixEventProcessor.h
+++ b/iocore/eventsystem/P_UnixEventProcessor.h
@@ -70,8 +70,14 @@ EventProcessor::schedule(Event *e, EventType etype, bool fast_signal)
   if (ethread != nullptr && ethread->is_event_type(etype)) {
     e->ethread = ethread;
   } else {
-    e->ethread = assign_thread(etype);
-    if (ethread == nullptr) {
+    ethread = this_ethread();
+    // Is the current thread eligible?
+    if (ethread != nullptr && ethread->is_event_type(etype)) {
+      e->ethread = ethread;
+    } else {
+      e->ethread = assign_thread(etype);
+    }
+    if (e->continuation->getThreadAffinity() == nullptr) {
       e->continuation->setThreadAffinity(e->ethread);
     }
   }

--- a/tests/gold_tests/cont_schedule/gold/schedule_on_pool.gold
+++ b/tests/gold_tests/cont_schedule/gold/schedule_on_pool.gold
@@ -3,7 +3,6 @@
 ``ET_NET``TSContScheduleOnPool handler 1``
 ``(TSContSchedule_test.check) pass [should not be the same thread]
 ``ET_TASK``TSContScheduleOnPool handler 2``
-``(TSContSchedule_test.check) pass [should not be the same thread]
 ``ET_TASK``TSContScheduleOnPool handler 2``
-``(TSContSchedule_test.check) pass [should not be the same thread]
+``(TSContSchedule_test.check) pass [should be the same thread]
 ``

--- a/tests/tools/plugins/cont_schedule.cc
+++ b/tests/tools/plugins/cont_schedule.cc
@@ -103,7 +103,7 @@ TSContScheduleOnPool_handler_1(TSCont contp, TSEvent event, void *edata)
     } else {
       TSDebug(DEBUG_TAG_CHK, "fail [on the same thread]");
     }
-    check_thread = TSThreadSelf();
+    check_thread = nullptr;
   }
   return 0;
 }
@@ -115,10 +115,10 @@ TSContScheduleOnPool_handler_2(TSCont contp, TSEvent event, void *edata)
   if (check_thread == nullptr) {
     check_thread = TSThreadSelf();
   } else {
-    if (check_thread != TSThreadSelf()) {
-      TSDebug(DEBUG_TAG_CHK, "pass [should not be the same thread]");
+    if (check_thread == TSThreadSelf()) {
+      TSDebug(DEBUG_TAG_CHK, "pass [should be the same thread]");
     } else {
-      TSDebug(DEBUG_TAG_CHK, "fail [on the same thread]");
+      TSDebug(DEBUG_TAG_CHK, "fail [not the same thread]");
     }
     check_thread = TSThreadSelf();
   }


### PR DESCRIPTION
Set thread affinity to current thread if the current thread type is the same as the target thread.