### PR TITLE
QUIC: Fixed warning in Mock.h

### DIFF
--- a/iocore/net/quic/Mock.h
+++ b/iocore/net/quic/Mock.h
@@ -488,7 +488,7 @@ public:
     return EVP_GCM_TLS_TAG_LEN;
   }
 
-  size_t *encryption_iv_len(QUICKeyPhase) const override
+  const size_t *encryption_iv_len(QUICKeyPhase) const override
   {
     static size_t dummy = 12;
     return &dummy;


### PR DESCRIPTION
```
In file included from ./test/test_QUICStream.cc:27:
/root/trafficserver_quic/iocore/net/quic/Mock.h:491:11: warning: invalid covariant return type for ‘virtual size_t* MockQUICPacketProtectionKeyInfo::encryption_iv_len(QUICKeyPhase) const’
   size_t *encryption_iv_len(QUICKeyPhase) const override
           ^~~~~~~~~~~~~~~~~
In file included from /root/trafficserver_quic/iocore/net/P_QUICNetVConnection.h:63,
                 from /root/trafficserver_quic/iocore/net/P_Net.h:114,
                 from /root/trafficserver_quic/iocore/net/quic/Mock.h:26,
                 from ./test/test_QUICStream.cc:27:
/root/trafficserver_quic/iocore/net/quic/QUICPacketProtectionKeyInfo.h:59:25: note: overridden function is ‘virtual const size_t* QUICPacketProtectionKeyInfo::encryption_iv_len(QUICKeyPhase) const’
   virtual const size_t *encryption_iv_len(QUICKeyPhase phase) const;
```