### PR TITLE
QUIC: Fixed build error under ubuntu 16.04

### DIFF
--- a/src/traffic_quic/traffic_quic.cc
+++ b/src/traffic_quic/traffic_quic.cc
@@ -230,6 +230,13 @@ StatPagesManager statPagesManager;
 #include "ProcessManager.h"
 inkcoreapi ProcessManager *pmgmt = nullptr;
 
+int
+BaseManager::registerMgmtCallback(int, const MgmtCallback &)
+{
+  ink_assert(false);
+  return 0;
+}
+
 void
 ProcessManager::signalManager(int, char const *, int)
 {


### PR DESCRIPTION
```
../lib/records/librecords_p.a(RecProcess.o): In function `RecMessageInit()':
/root/trafficserver_quic/lib/records/RecProcess.cc:234: undefined reference to `BaseManager::registerMgmtCallback(int, std::function<void (ts::MemSpan)> const&)'
../lib/records/librecords_p.a(RecProcess.o): In function `RecRegisterManagerCb(int, std::function<void (ts::MemSpan)> const&)':
/root/trafficserver_quic/lib/records/RecProcess.cc:305: undefined reference to `BaseManager::registerMgmtCallback(int, std::function<void (ts::MemSpan)> const&)'\
```

Not sure why we need this. But it seems be removed after 5da8f67a9b11b859b537daed30e9eed624dec054 and then I got this error.
