### PR TITLE
tscore/eventnotify: change fcntl include path

### DIFF
--- a/src/tscore/EventNotify.cc
+++ b/src/tscore/EventNotify.cc
@@ -33,7 +33,7 @@
 
 #ifdef HAVE_EVENTFD
 #include <sys/eventfd.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <sys/epoll.h>
 #endif
 


### PR DESCRIPTION
The default include path for `fnctl.h` changed some time in the 90's.