### PR TITLE
tscore/ink_hrtime: add missing cstdint import

### DIFF
--- a/include/tscore/ink_hrtime.h
+++ b/include/tscore/ink_hrtime.h
@@ -33,6 +33,7 @@
 #include "tscore/ink_config.h"
 #include "tscore/ink_assert.h"
 #include <ctime>
+#include <cstdint>
 #include <sys/time.h>
 #include <cstdlib>
 typedef int64_t ink_hrtime;


### PR DESCRIPTION
On alpine linux 3.9/edge the compilation was failing because of a missing import.

Fixes: https://github.com/apache/trafficserver/issues/5103