### PR TITLE
traffic_layout/engine: add missing stat import

### DIFF
--- a/src/traffic_layout/engine.h
+++ b/src/traffic_layout/engine.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <sys/stat.h>
 #include "tscore/ArgParser.h"
 #include <unordered_map>
 


### PR DESCRIPTION
We were using `mode_t` without it being available on some architectures. 

Found while attempting to compile latest master on alpine:
```
  CXX      traffic_layout/traffic_layout-traffic_layout.o
In file included from traffic_layout/traffic_layout.cc:26:
traffic_layout/engine.h:34:3: error: 'mode_t' does not name a type; did you mean 'off_t'?
   mode_t r_mode;
   ^~~~~~
   off_t
traffic_layout/engine.h:35:3: error: 'mode_t' does not name a type; did you mean 'off_t'?
   mode_t w_mode;
   ^~~~~~
   off_t
traffic_layout/engine.h:36:3: error: 'mode_t' does not name a type; did you mean 'off_t'?
   mode_t e_mode;
   ^~~~~~
   off_t
make[2]: *** [Makefile:2304: traffic_layout/traffic_layout-traffic_layout.o] Error 1
```

..with that, trafficserver now compiles on alpine \o/