### PR TITLE
uri_signing build helpers

### DIFF
--- a/build/cjose.m4
+++ b/build/cjose.m4
@@ -1,0 +1,47 @@
+dnl -------------------------------------------------------- -*- autoconf -*-
+dnl Licensed to the Apache Software Foundation (ASF) under one or more
+dnl contributor license agreements.  See the NOTICE file distributed with
+dnl this work for additional information regarding copyright ownership.
+dnl The ASF licenses this file to You under the Apache License, Version 2.0
+dnl (the "License"); you may not use this file except in compliance with
+dnl the License.  You may obtain a copy of the License at
+dnl
+dnl     http://www.apache.org/licenses/LICENSE-2.0
+dnl
+dnl Unless required by applicable law or agreed to in writing, software
+dnl distributed under the License is distributed on an "AS IS" BASIS,
+dnl WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+dnl See the License for the specific language governing permissions and
+dnl limitations under the License.
+
+dnl
+dnl cjose.m4: Trafficserver's cjose autoconf macros
+dnl
+
+dnl
+dnl TS_CHECK_CJOSE: look for cjose libraries and headers
+dnl
+
+AC_DEFUN([TS_CHECK_CJOSE], [
+AC_MSG_CHECKING([for --with-cjose])
+  AC_ARG_WITH(
+      [cjose],
+      [AS_HELP_STRING([--with-cjose=DIR], [use a specific cjose library])],
+      [ LDFLAGS="$LDFLAGS -L$with_cjose/lib";
+        CFLAGS="$CFLAGS -I$with_cjose/include/";
+        CPPFLAGS="$CPPFLAGS -I$with_cjose/include/";
+        AC_MSG_RESULT([$with_cjose])
+      ],
+      [ AC_MSG_RESULT([no])]
+  )
+
+  AC_CHECK_HEADERS([cjose/cjose.h], [
+    AC_MSG_CHECKING([whether cjose is dynamic])
+    TS_LINK_WITH_FLAGS_IFELSE([-fPIC -lcjose -ljansson -lcrypto],[AC_LANG_PROGRAM(
+                              [#include <cjose/cjose.h>],
+                              [(void) cjose_jws_import("", 0, NULL);])],
+                              [AC_MSG_RESULT([yes]); LIBCJOSE=-lcjose],
+                              [AC_MSG_RESULT([no]);  LIBCJOSE=-l:libcjose.a])
+    ],
+    [LIBCJOSE=])
+])

--- a/build/hiredis.m4
+++ b/build/hiredis.m4
@@ -33,7 +33,7 @@ AC_ARG_WITH(hiredis, [AC_HELP_STRING([--with-hiredis=DIR],[use a specific hiredi
     if test "$withval" != "no"; then
       case "$withval" in
       *":"*)
-        hidredis_include="`echo $withval |sed -e 's/:.*$//'`"
+        hiredis_include="`echo $withval |sed -e 's/:.*$//'`"
         hiredis_ldflags="`echo $withval |sed -e 's/^.*://'`"
         AC_MSG_CHECKING(checking for hiredis includes in $hiredis_include libs in $hiredis_ldflags )
         ;;

--- a/build/jansson.m4
+++ b/build/jansson.m4
@@ -1,0 +1,47 @@
+dnl -------------------------------------------------------- -*- autoconf -*-
+dnl Licensed to the Apache Software Foundation (ASF) under one or more
+dnl contributor license agreements.  See the NOTICE file distributed with
+dnl this work for additional information regarding copyright ownership.
+dnl The ASF licenses this file to You under the Apache License, Version 2.0
+dnl (the "License"); you may not use this file except in compliance with
+dnl the License.  You may obtain a copy of the License at
+dnl
+dnl     http://www.apache.org/licenses/LICENSE-2.0
+dnl
+dnl Unless required by applicable law or agreed to in writing, software
+dnl distributed under the License is distributed on an "AS IS" BASIS,
+dnl WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+dnl See the License for the specific language governing permissions and
+dnl limitations under the License.
+
+dnl
+dnl jansson.m4: Trafficserver's jansson autoconf macros
+dnl
+
+dnl
+dnl TS_CHECK_JANSSON: look for jansson libraries and headers
+dnl
+
+AC_DEFUN([TS_CHECK_JANSSON], [
+  AC_MSG_CHECKING([for --with-jansson])
+  AC_ARG_WITH(
+      [jansson],
+      [AS_HELP_STRING([--with-jansson], [use a specific jansson library])],
+      [ LDFLAGS="$LDFLAGS -L$with_jansson/lib";
+        CFLAGS="$CFLAGS -I$with_jansson/include/";
+        CPPFLAGS="$CPPFLAGS -I$with_jansson/include/";
+        AC_MSG_RESULT([$with_jansson])
+      ],
+      [ AC_MSG_RESULT([no])]
+  )
+
+  AC_CHECK_HEADERS([jansson.h], [
+    AC_MSG_CHECKING([whether jansson is dynamic])
+    TS_LINK_WITH_FLAGS_IFELSE([-fPIC -ljansson],[AC_LANG_PROGRAM(
+                              [#include <jansson.h>],
+                              [(void) json_object();])],
+                              [AC_MSG_RESULT([yes]); LIBJANSSON=-ljansson],
+                              [AC_MSG_RESULT([no]);  LIBJANSSON=-l:libjansson.a])
+    ],
+    [LIBJANSSON=])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -1318,26 +1318,14 @@ TS_CHECK_LUAJIT
 # Enable experimental/uri_singing plugin
 # This is here, instead of above, because it needs to know if PCRE is available.
 #
-AC_CHECK_HEADERS([jansson.h], [
-  AC_MSG_CHECKING([whether jansson is dynamic])
-  TS_LINK_WITH_FLAGS_IFELSE([-fPIC -ljansson],[AC_LANG_PROGRAM(
-                            [#include <jansson.h>],
-                            [(void) json_object();])],
-                            [AC_MSG_RESULT([yes]); LIBJANSSON=-ljansson],
-                            [AC_MSG_RESULT([no]);  LIBJANSSON=-l:libjansson.a])
-  ],
-  [LIBJANSSON=])
 
-AC_CHECK_HEADERS([cjose/cjose.h], [
-  AC_MSG_CHECKING([whether cjose is dynamic])
-  TS_LINK_WITH_FLAGS_IFELSE([-fPIC -lcjose],[AC_LANG_PROGRAM(
-                            [#include <cjose/cjose.h>],
-                            [(void) cjose_jws_import("", 0, NULL);])],
-                            [AC_MSG_RESULT([yes]); LIBCJOSE=-lcjose],
-                            [AC_MSG_RESULT([no]);  LIBCJOSE=-l:libcjose.a])
-  ],
-  [LIBCJOSE=])
+#### Check for optional jansson library (uri_signing)
+TS_CHECK_JANSSON
+
 AC_CHECK_LIB([crypto],[HMAC],[has_libcrypto=1],[has_libcrypto=0])
+
+#### Check for optional cjose library (uri_signing)
+TS_CHECK_CJOSE
 
 AM_CONDITIONAL([BUILD_URI_SIGNING_PLUGIN], [test ! -z "${LIBCJOSE}" -a ! -z "${LIBJANSSON}" -a "x${enable_pcre}" = "xyes" -a "x${has_libcrypto}" = "x1"])
 AC_SUBST([LIBCJOSE])

--- a/plugins/experimental/uri_signing/README.md
+++ b/plugins/experimental/uri_signing/README.md
@@ -185,3 +185,42 @@ plugin.
 If you would like to statically link them, you will need to ensure that they are
 compiled with the `-fPIC` flag in their CFLAGs. If the archives have PIC, the
 build scripts will automatically statically link them.
+
+Here are some sample commands for building jansson, cjose and trafficserver
+locally using static linking.  This assumes all source is under ${HOME}/git.
+
+### Sample
+
+If using local jansson:
+
+    cd ${HOME}/git
+    git clone https://github.com/akheron/jansson.git
+    cd jansson
+    autoreconf -i
+    ./configure --disable-shared CC="gcc -fpic"
+    make -j`nproc`
+
+    # Needed for ATS configure
+    ln -s src/.libs lib
+    ln -s src include
+
+If using local cjose:
+
+    cd ${HOME}/git
+    git clone https://github.com/cisco/cjose.git
+    cd cjose
+    autoreconf -i
+    ./configure --with-jansson=${HOME}/git/jansson --disable-shared CC="gcc -fpic"
+    make -j`nproc`
+
+    # Needed for ATS configure
+    ln -s src/.libs lib
+
+ATS:
+
+    cd ${HOME}/git/
+    git clone https://github.com/apache/trafficserver.git
+    cd trafficserver
+		autoreconf -i
+    ./configure --enable-experimental-plugins --with-jansson=${HOME}/git/jansson --with-cjose=${HOME}/git/cjose
+    make -j`nproc`


### PR DESCRIPTION
add --with-jansson and --with-cjose options, document sample command for building and configuring both locally

README.md has sample instructions on how to build and link everything locally
using -fpic for cjose (and jansson if applicable) to allow static plugin linking.