### PR TITLE
Fix #5093: new/delete mismatch in test_IntrusivePtr.cc

### DIFF
--- a/src/tscore/unit_tests/test_IntrusivePtr.cc
+++ b/src/tscore/unit_tests/test_IntrusivePtr.cc
@@ -28,7 +28,7 @@
 
 struct Thing : public ts::IntrusivePtrCounter {
   Thing() { ++_count; }
-  ~Thing() { --_count; }
+  virtual ~Thing() { --_count; }
   std::string _name;
   static int _count; // instance count.
 };


### PR DESCRIPTION
Make the destructor virtual so there's no type slicing for ASAN to complain about. This is a fix for #5093.