### PR TITLE
Remove OS dependency in test_BufferWriterFormat.cc

### DIFF
--- a/src/tscore/unit_tests/test_BufferWriterFormat.cc
+++ b/src/tscore/unit_tests/test_BufferWriterFormat.cc
@@ -522,7 +522,7 @@ TEST_CASE("bwstring std formats", "[libts][bwprint]")
   w.print("{}", ts::bwf::Errno(13));
   REQUIRE(w.view() == "EACCES: Permission denied [13]"sv);
   w.reset().print("{}", ts::bwf::Errno(134));
-  REQUIRE(w.view().substr(0, 22) == "Unknown: Unknown error"sv);
+  REQUIRE(w.view().substr(0, 9) == "Unknown: "sv);
 
   time_t t = 1528484137;
   // default is GMT


### PR DESCRIPTION
This is a fix for #5108. The test was trying to verify the errno value was out of range, but that apparently varies quite a bit across operating systems. This tweaks it to check only for the part generated by BW formatting, not the operating system.