### PR TITLE
Fixing a previous fix to fully allocate strings when heap mismatch detected

### DIFF
--- a/proxy/hdrs/HTTP.cc
+++ b/proxy/hdrs/HTTP.cc
@@ -708,7 +708,7 @@ http_hdr_url_set(HdrHeap *heap, HTTPHdrImpl *hh, URLImpl *url)
         int url_string_length   = url->strings_length();
         heap->m_read_write_heap = new_HdrStrHeap(url_string_length);
       }
-      hh->u.req.m_url_impl->move_strings(heap->m_read_write_heap.get());
+      hh->u.req.m_url_impl->rehome_strings(heap);
     } else {
       hh->u.req.m_url_impl = url;
     }

--- a/proxy/hdrs/HdrHeap.h
+++ b/proxy/hdrs/HdrHeap.h
@@ -235,6 +235,26 @@ public:
     }
   }
 
+  // Working function to copy strings into a new heap
+  // Unlike the HDR_MOVE_STR macro, this function will call
+  // allocate_str which will update the new_heap to create more space
+  // if there is not originally sufficient space
+  inline std::string_view
+  localize(const std::string_view &string)
+  {
+    auto length = string.length();
+    if (length > 0) {
+      char *new_str = this->allocate_str(length);
+      if (new_str) {
+        memcpy(new_str, string.data(), length);
+      } else {
+        length = 0;
+      }
+      return {new_str, length};
+    }
+    return {nullptr, 0};
+  }
+
   // Sanity Check Functions
   void sanity_check_strs();
   bool check_marshalled(uint32_t buf_length);

--- a/proxy/hdrs/URL.cc
+++ b/proxy/hdrs/URL.cc
@@ -349,6 +349,21 @@ URLImpl::unmarshal(intptr_t offset)
 }
 
 void
+URLImpl::rehome_strings(HdrHeap *new_heap)
+{
+  m_ptr_scheme         = new_heap->localize({m_ptr_scheme, m_len_scheme}).data();
+  m_ptr_user           = new_heap->localize({m_ptr_user, m_len_user}).data();
+  m_ptr_password       = new_heap->localize({m_ptr_password, m_len_password}).data();
+  m_ptr_host           = new_heap->localize({m_ptr_host, m_len_host}).data();
+  m_ptr_port           = new_heap->localize({m_ptr_port, m_len_port}).data();
+  m_ptr_path           = new_heap->localize({m_ptr_path, m_len_path}).data();
+  m_ptr_params         = new_heap->localize({m_ptr_params, m_len_params}).data();
+  m_ptr_query          = new_heap->localize({m_ptr_query, m_len_query}).data();
+  m_ptr_fragment       = new_heap->localize({m_ptr_fragment, m_len_fragment}).data();
+  m_ptr_printed_string = new_heap->localize({m_ptr_printed_string, m_len_printed_string}).data();
+}
+
+void
 URLImpl::move_strings(HdrStrHeap *new_heap)
 {
   HDR_MOVE_STR(m_ptr_scheme, m_len_scheme);

--- a/proxy/hdrs/URL.h
+++ b/proxy/hdrs/URL.h
@@ -80,6 +80,7 @@ struct URLImpl : public HdrHeapObjImpl {
   int marshal(MarshalXlate *str_xlate, int num_xlate);
   void unmarshal(intptr_t offset);
   void move_strings(HdrStrHeap *new_heap);
+  void rehome_strings(HdrHeap *new_heap);
   size_t strings_length();
 
   // Sanity Check Functions


### PR DESCRIPTION
Someone internal noticed, a problem in the PR I made to detect that the URL hadn't been cloned into the target buffer and moved the string into the target buffer.
https://github.com/apache/trafficserver/pull/3875

That PR used URL::move_strings, but that function would not create more space if there wasn't already sufficient space in the string heap.  This would cause mysterious crashes where m_query_len was non-zero, but m_ptr_query was null. 

This PR adds a URL::rehome_strings method that calls allocate_str against the target HdrHeap.  That function will update the HdrHeap to create more space if needed.