### PR TITLE
Ensure queued HostDB requests get rescheduled back to the original thread

### DIFF
--- a/iocore/cache/CacheWrite.cc
+++ b/iocore/cache/CacheWrite.cc
@@ -358,7 +358,7 @@ Vol::aggWriteDone(int event, Event *e)
   CacheVC *c = nullptr;
   while ((c = sync.dequeue())) {
     if (UINT_WRAP_LTE(c->write_serial + 2, header->write_serial)) {
-      c->initial_thread->schedule_imm_signal(c, AIO_EVENT_DONE);
+      eventProcessor.schedule_imm_signal(c, ET_CALL, AIO_EVENT_DONE);
     } else {
       sync.push(c); // put it back on the front
       break;
@@ -1019,11 +1019,7 @@ Lagain:
       ink_assert(false);
       while ((c = agg.dequeue())) {
         agg_todo_size -= c->agg_len;
-        if (c->initial_thread != nullptr) {
-          c->initial_thread->schedule_imm_signal(c, AIO_EVENT_DONE);
-        } else {
-          eventProcessor.schedule_imm_signal(c, ET_CALL, AIO_EVENT_DONE);
-        }
+        eventProcessor.schedule_imm_signal(c, ET_CALL, AIO_EVENT_DONE);
       }
       return EVENT_CONT;
     }
@@ -1086,8 +1082,6 @@ Lwait:
   while ((c = tocall.dequeue())) {
     if (event == EVENT_CALL && c->mutex->thread_holding == mutex->thread_holding) {
       ret = EVENT_RETURN;
-    } else if (c->initial_thread != nullptr) {
-      c->initial_thread->schedule_imm_signal(c, AIO_EVENT_DONE);
     } else {
       eventProcessor.schedule_imm_signal(c, ET_CALL, AIO_EVENT_DONE);
     }

--- a/iocore/cache/P_CacheInternal.h
+++ b/iocore/cache/P_CacheInternal.h
@@ -440,7 +440,6 @@ struct CacheVC : public CacheVConnection {
   // NOTE: NOTE: NOTE: If vio is NOT the start, then CHANGE the
   // size_to_init initialization
   VIO vio;
-  EThread *initial_thread; // initial thread open_XX was called on
   CacheFragType frag_type;
   CacheHTTPInfo *info;
   CacheHTTPInfoVector *write_vector;
@@ -549,9 +548,9 @@ new_CacheVC(Continuation *cont)
   CacheVC *c          = THREAD_ALLOC(cacheVConnectionAllocator, t);
   c->vector.data.data = &c->vector.data.fast_data[0];
   c->_action          = cont;
-  c->initial_thread   = t->tt == DEDICATED ? nullptr : t;
   c->mutex            = cont->mutex;
   c->start_time       = Thread::get_hrtime();
+  c->setThreadAffinity(t);
   ink_assert(c->trigger == nullptr);
   Debug("cache_new", "new %p", c);
 #ifdef CACHE_STAT_PAGES


### PR DESCRIPTION
This change along with https://github.com/apache/trafficserver/pull/5089 fixed our corruptions on the netHandler active_queue and keep_alive_queue.  The HostDB continuations that were queued up waiting for the dns result were all getting reactivated on the same thread.  This was unlikely to be the thread associated with the netvc's for the transaction.  There were paths that created the CacheVC on on a different thread and then caused the netHandler queue manipulation to be called from the non-net handler thread.

Also removed the explicit initial_thread member variable for CacheVC and used the thread affinity instead.