### PR TITLE
Remove duplicate calls to TSHttpTxnReenable in xdebug

### DIFF
--- a/plugins/xdebug/xdebug.cc
+++ b/plugins/xdebug/xdebug.cc
@@ -540,7 +540,6 @@ XScanRequestHeaders(TSCont /* contp */, TSEvent event, void *edata)
               }
             }
           }
-          TSHttpTxnReenable(txn, TS_EVENT_HTTP_CONTINUE);
           return TS_EVENT_NONE;
         };
         TSHttpTxnHookAdd(txn, TS_HTTP_SEND_REQUEST_HDR_HOOK, TSContCreate(send_req_dump, nullptr));
@@ -553,7 +552,6 @@ XScanRequestHeaders(TSCont /* contp */, TSEvent event, void *edata)
           if (TSHttpTxnServerRespGet(txn, &buffer, &hdr) == TS_SUCCESS) {
             log_headers(txn, buffer, hdr, "ServerResponse");
           }
-          TSHttpTxnReenable(txn, TS_EVENT_HTTP_CONTINUE);
           return TS_EVENT_NONE;
         };
         TSHttpTxnHookAdd(txn, TS_HTTP_READ_RESPONSE_HDR_HOOK, TSContCreate(read_resp_dump, nullptr));


### PR DESCRIPTION
With PostScript in set in XScanRequestHeaders, we shouldn't explicitly call TSHttpTxnReenable.  The PostScript construct ensures that it will be called after any exit.

We have started seeing unhandled C++ exceptions like the stack below.  Not sure what to make of it, but @SolidWallOfCode noticed that there are paths that call TSHttpTxnReenable explicitly in addition to the PostScript call, so that seems like a bad idea and should be fixed.
```
#0  0x00002ac26ccc81d7 in raise () from /lib64/libc.so.6
#1  0x00002ac26ccc98c8 in abort () from /lib64/libc.so.6
#2  0x00002ac26c4d49b5 in __gnu_cxx::__verbose_terminate_handler() () from /lib64/libstdc++.so.6
#3  0x00002ac26c4d2926 in ?? () from /lib64/libstdc++.so.6
#4  0x00002ac26c4d2953 in std::terminate() () from /lib64/libstdc++.so.6
#5  0x00002ac26c4d2561 in __gxx_personality_v0 () from /lib64/libstdc++.so.6
#6  0x00002ac26ca8c913 in ?? () from /lib64/libgcc_s.so.1
#7  0x00002ac26ca8ce47 in _Unwind_Resume () from /lib64/libgcc_s.so.1
#8  0x00000000004ae1eb in TSHttpTxnReenable (txnp=<optimized out>, event=TS_EVENT_HTTP_CONTINUE)
    at /sd/workspace/src/git.ouroath.com/Edge/build/_build/build_release_posix-x86_64_gcc_8/trafficserver7/iocore/eventsystem/P_VConnection.h:119
#9  0x00002ac29b56c6e9 in operator() (this=0x2ac2787fce68) at /opt/rh/devtoolset-8/root/usr/include/c++/8/bits/std_function.h:260
#10 ~PostScript (this=0x2ac2787fce60, __in_chrg=<optimized out>) at ../lib/ts/PostScript.h:46
#11 XScanRequestHeaders (event=<optimized out>, edata=0x2ac277b43100) at xdebug/xdebug.cc:449
#12 0x00000000004ed4db in INKContInternal::handle_event (this=0x2ac270607500, event=60002, edata=0x2ac277b43100) at InkAPI.cc:1062
#13 0x00000000004edfde in APIHook::invoke(int, void*) const () at InkAPI.cc:1301
#14 0x00000000005c46bc in HttpSM::state_api_callout(int, void*) () at HttpSM.cc:1512
#15 0x00000000005cf97f in HttpSM::state_api_callback (this=this@entry=0x2ac277b43100, event=event@entry=60000, data=data@entry=0x0) at HttpSM.cc:1390
#16 0x00000000004ff4f2 in TSHttpTxnReenable () at InkAPI.cc:6019
#17 0x00002ac2937a2842 in health_check_origin (contp=0x2ac270607880, event=TS_EVENT_HTTP_READ_REQUEST_HDR, edata=0x2ac277b43100)
    at healthchecks/healthchecks.c:555
#18 0x00000000004ed4db in INKContInternal::handle_event (this=0x2ac270607880, event=60002, edata=0x2ac277b43100) at InkAPI.cc:1062
#19 0x00000000004edfde in APIHook::invoke(int, void*) const () at InkAPI.cc:1301
#20 0x00000000005c46bc in HttpSM::state_api_callout(int, void*) () at HttpSM.cc:1512
#21 0x00000000005cf97f in HttpSM::state_api_callback (this=this@entry=0x2ac277b43100, event=event@entry=60000, data=data@entry=0x0) at HttpSM.cc:1390
#22 0x00000000004ff4f2 in TSHttpTxnReenable () at InkAPI.cc:6019
#23 0x00002ac28cda2be7 in GUCE_continuation(tsapi_cont*, TSEvent, void*) () from /opt/oath/trafficserver/7.1/libexec/trafficserver/guce_cookie.so
#24 0x00000000004ed4db in INKContInternal::handle_event (this=0x2ac270607a00, event=60002, edata=0x2ac277b43100) at InkAPI.cc:1062
#25 0x00000000004edfde in APIHook::invoke(int, void*) const () at InkAPI.cc:1301
#26 0x00000000005c46bc in HttpSM::state_api_callout(int, void*) () at HttpSM.cc:1512
#27 0x00000000005cf97f in HttpSM::state_api_callback (this=this@entry=0x2ac277b43100, event=event@entry=60000, data=data@entry=0x0) at HttpSM.cc:1390
#28 0x00000000004ff4f2 in TSHttpTxnReenable () at InkAPI.cc:6019
#29 0x00002ac28c76a53d in onReadRequest(tsapi_cont*, TSEvent, void*) () at _vcs/carp-7/carp/carp.cc:375
#30 0x00000000004ed4db in INKContInternal::handle_event (this=0x2ac270607b80, event=60002, edata=0x2ac277b43100) at InkAPI.cc:1062
#31 0x00000000004edfde in APIHook::invoke(int, void*) const () at InkAPI.cc:1301
#32 0x00000000005c46bc in HttpSM::state_api_callout(int, void*) () at HttpSM.cc:1512
#33 0x00000000005cf97f in HttpSM::state_api_callback (this=this@entry=0x2ac277b43100, event=event@entry=60000, data=data@entry=0x0) at HttpSM.cc:1390
#34 0x00000000004ff4f2 in TSHttpTxnReenable () at InkAPI.cc:6019
#35 0x00002ac28960bd1d in http_hook (contp=<optimized out>, event=<optimized out>, edata=0x2ac277b43100)
    at _vcs/yahoo_connection-7/yahoo_connection/INKPluginInit.cc:405
#36 0x00000000004ed4db in INKContInternal::handle_event (this=0x2ac270607e00, event=60002, edata=0x2ac277b43100) at InkAPI.cc:1062
#37 0x00000000004edfde in APIHook::invoke(int, void*) const () at InkAPI.cc:1301
#38 0x00000000005c46bc in HttpSM::state_api_callout(int, void*) () at HttpSM.cc:1512
#39 0x00000000005d073b in HttpSM::set_next_state (this=0x2ac277b43100) at HttpSM.cc:7402
#40 0x00000000005bac7f in HttpSM::call_transact_and_set_next_state (this=this@entry=0x2ac277b43100, f=<optimized out>) at HttpSM.cc:7369
#41 0x00000000005c3af4 in HttpSM::state_read_client_request_header (this=0x2ac277b43100, event=<optimized out>, data=<optimized out>) at HttpSM.cc:897
#42 0x00000000005cfb1a in HttpSM::main_handler (this=0x2ac277b43100, event=100, data=0x2ad11f53cf00) at HttpSM.cc:2749
#43 0x000000000061c40e in Http2Stream::update_read_request(long, bool, bool) () at Http2Stream.cc:507
#44 0x000000000061c899 in Http2Stream::send_request (this=this@entry=0x2ad11f53cc80, cstate=...) at Http2Stream.cc:173
#45 0x0000000000633369 in rcv_headers_frame(Http2ConnectionState&, Http2Frame const&) () at Http2ConnectionState.cc:356
#46 0x00000000006357c9 in Http2ConnectionState::main_event_handler(int, void*) () at Http2ClientSession.h:91
#47 0x0000000000629e8f in handleEvent (data=0x2ac2787fe000, event=2253, this=0x2ac66745cfe8)
    at /sd/workspace/src/git.ouroath.com/Edge/build/_build/build_release_posix-x86_64_gcc_8/trafficserver7/iocore/eventsystem/I_Continuation.h:157
#48 send_connection_event(Continuation*, int, void*) () at Http2ClientSession.cc:58
#49 0x000000000062acec in Http2ClientSession::do_complete_frame_read() () at Http2ClientSession.cc:514
#50 0x000000000062b691 in Http2ClientSession::state_process_frame_read(int, VIO*, bool) () at Http2ClientSession.cc:551
#51 0x000000000062b911 in Http2ClientSession::state_start_frame_read (this=0x2ac66745ccd0, event=100, edata=0x2ac680873290)
    at Http2ClientSession.cc:444
#52 0x000000000062a5bb in Http2ClientSession::main_event_handler (this=0x2ac66745ccd0, event=100, edata=0x2ac680873290) at Http2ClientSession.cc:330
#53 0x000000000078038a in handleEvent (data=0x2ac680873290, event=100, this=0x2ac66745ccd0)
    at /sd/workspace/src/git.ouroath.com/Edge/build/_build/build_release_posix-x86_64_gcc_8/trafficserver7/iocore/eventsystem/I_Continuation.h:157
#54 read_signal_and_update (vc=vc@entry=0x2ac680873120, event=event@entry=100) at UnixNetVConnection.cc:144
#55 UnixNetVConnection::readSignalAndUpdate (this=this@entry=0x2ac680873120, event=event@entry=100) at UnixNetVConnection.cc:1103
#56 0x00000000007601c2 in SSLNetVConnection::net_read_io(NetHandler*, EThread*) () at SSLNetVConnection.cc:611
#57 0x0000000000774359 in NetHandler::waitForActivity(long) () at UnixNet.cc:497
#58 0x00000000007b9e43 in EThread::execute_regular (this=0x2ac271d95600) at UnixEThread.cc:274
#59 0x00000000007b8522 in spawn_thread_internal (a=0x2ac26dd955c0) at Thread.cc:85
#60 0x00002ac26c05bdc5 in start_thread () from /lib64/libpthread.so.0
#61 0x00002ac26cd8a76d in clone () from /lib64/libc.so.6
```