### PR TITLE
Fix SessionProtocolNameRegistry lookup

### DIFF
--- a/lib/records/RecHttp.cc
+++ b/lib/records/RecHttp.cc
@@ -751,8 +751,9 @@ SessionProtocolNameRegistry::toIndexConst(TextView name)
 int
 SessionProtocolNameRegistry::indexFor(TextView name) const
 {
-  auto spot = std::find(m_names.begin(), m_names.begin() + m_n, name);
-  if (spot != m_names.end()) {
+  const ts::TextView *end = m_names.begin() + m_n;
+  auto spot               = std::find(m_names.begin(), end, name);
+  if (spot != end) {
     return static_cast<int>(spot - m_names.begin());
   }
   return INVALID;


### PR DESCRIPTION
Prior this change, SessionProtocolNameRegistry::indexFor() always returns 0.
Because `spot` never reach to `m_names.end()`.
This is introduced by 5ad8eec303b5f9c38da0de3775e0aadb7186fc38.