### PR TITLE
Don't keep packets sent

### DIFF
--- a/iocore/net/P_QUICNetVConnection.h
+++ b/iocore/net/P_QUICNetVConnection.h
@@ -288,10 +288,10 @@ private:
 
   void _store_frame(ats_unique_buf &buf, size_t &offset, uint64_t &max_frame_size, QUICFrame &frame,
                     std::vector<QUICFrameInfo> &frames);
-  QUICPacketUPtr _packetize_frames(QUICEncryptionLevel level, uint64_t max_packet_size);
+  QUICPacketUPtr _packetize_frames(QUICEncryptionLevel level, uint64_t max_packet_size, std::vector<QUICFrameInfo> &frames);
   void _packetize_closing_frame();
   QUICPacketUPtr _build_packet(QUICEncryptionLevel level, ats_unique_buf buf, size_t len, bool retransmittable, bool probing,
-                               bool crypto, std::vector<QUICFrameInfo> &frames);
+                               bool crypto);
 
   QUICConnectionErrorUPtr _recv_and_ack(QUICPacket &packet, bool *has_non_probing_frame = nullptr);
 

--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -1199,19 +1199,19 @@ QUICNetVConnection::_state_common_send_packet()
       QUICPacketInfoUPtr packet_info = std::make_unique<QUICPacketInfo>();
       QUICPacketUPtr packet          = this->_packetize_frames(level, max_packet_size, packet_info->frames);
 
-      packet_info->packet_number    = packet->packet_number();
-      packet_info->time_sent        = Thread::get_hrtime();
-      packet_info->ack_eliciting    = packet->is_ack_eliciting();
-      packet_info->is_crypto_packet = packet->is_crypto_packet();
-      packet_info->in_flight        = true;
-      if (packet_info->ack_eliciting) {
-        packet_info->sent_bytes = packet->size();
-      } else {
-        packet_info->sent_bytes = 0;
-      }
-      packet_info->type = packet->type();
-
       if (packet) {
+        packet_info->packet_number    = packet->packet_number();
+        packet_info->time_sent        = Thread::get_hrtime();
+        packet_info->ack_eliciting    = packet->is_ack_eliciting();
+        packet_info->is_crypto_packet = packet->is_crypto_packet();
+        packet_info->in_flight        = true;
+        if (packet_info->ack_eliciting) {
+          packet_info->sent_bytes = packet->size();
+        } else {
+          packet_info->sent_bytes = 0;
+        }
+        packet_info->type = packet->type();
+
         if (this->netvc_context == NET_VCONNECTION_IN && !this->_verfied_state.is_verified()) {
           QUICConDebug("send to unverified window: %u", this->_verfied_state.windows());
           this->_verfied_state.consume(packet->size());

--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -1223,7 +1223,7 @@ QUICNetVConnection::_state_common_send_packet()
         }
 
         int index = QUICTypeUtil::pn_space_index(level);
-        this->_loss_detector[index]->on_packet_sent(std::move(packet));
+        this->_loss_detector[index]->on_packet_sent(*packet);
         packet_count++;
       }
     }

--- a/iocore/net/quic/Mock.h
+++ b/iocore/net/quic/Mock.h
@@ -343,7 +343,7 @@ public:
   MockQUICCongestionController(QUICConnectionInfoProvider *info) : QUICCongestionController(info) {}
   // Override
   virtual void
-  on_packets_lost(const std::map<QUICPacketNumber, PacketInfo *> &packets, uint32_t pto_count) override
+  on_packets_lost(const std::map<QUICPacketNumber, QUICPacketInfo *> &packets, uint32_t pto_count) override
   {
     for (auto &p : packets) {
       lost_packets.insert(p.first);

--- a/iocore/net/quic/QUICCongestionController.cc
+++ b/iocore/net/quic/QUICCongestionController.cc
@@ -66,7 +66,7 @@ QUICCongestionController::_in_recovery(ink_hrtime sent_time)
 }
 
 void
-QUICCongestionController::on_packet_acked(const PacketInfo &acked_packet)
+QUICCongestionController::on_packet_acked(const QUICPacketInfo &acked_packet)
 {
   // Remove from bytes_in_flight.
   SCOPED_MUTEX_LOCK(lock, this->_cc_mutex, this_ethread());
@@ -109,7 +109,7 @@ QUICCongestionController::_congestion_event(ink_hrtime sent_time, uint32_t pto_c
 // the original one is:
 //   ProcessECN(ack):
 void
-QUICCongestionController::process_ecn(const PacketInfo &acked_largest_packet, const QUICAckFrame::EcnSection *ecn_section,
+QUICCongestionController::process_ecn(const QUICPacketInfo &acked_largest_packet, const QUICAckFrame::EcnSection *ecn_section,
                                       uint32_t pto_count)
 {
   // If the ECN-CE counter reported by the peer has increased,
@@ -127,7 +127,7 @@ QUICCongestionController::process_ecn(const PacketInfo &acked_largest_packet, co
 // the original one is:
 //   OnPacketsLost(lost_packets):
 void
-QUICCongestionController::on_packets_lost(const std::map<QUICPacketNumber, PacketInfo *> &lost_packets, uint32_t pto_count)
+QUICCongestionController::on_packets_lost(const std::map<QUICPacketNumber, QUICPacketInfo *> &lost_packets, uint32_t pto_count)
 {
   if (lost_packets.empty()) {
     return;

--- a/iocore/net/quic/QUICFrame.cc
+++ b/iocore/net/quic/QUICFrame.cc
@@ -2702,13 +2702,13 @@ QUICFrameFactory::create_retire_connection_id_frame(uint8_t *buf, uint64_t seq_n
 }
 
 QUICFrameId
-QUICFrameInfo::id()
+QUICFrameInfo::id() const
 {
   return this->_id;
 }
 
 QUICFrameGenerator *
-QUICFrameInfo::generated_by()
+QUICFrameInfo::generated_by() const
 {
   return this->_generator;
 }

--- a/iocore/net/quic/QUICFrame.h
+++ b/iocore/net/quic/QUICFrame.h
@@ -853,8 +853,8 @@ class QUICFrameInfo
 {
 public:
   QUICFrameInfo(QUICFrameId id, QUICFrameGenerator *generator) : _id(id), _generator(generator) {}
-  QUICFrameId id();
-  QUICFrameGenerator *generated_by();
+  QUICFrameId id() const;
+  QUICFrameGenerator *generated_by() const;
 
 private:
   QUICFrameId _id = 0;

--- a/iocore/net/quic/QUICLossDetector.h
+++ b/iocore/net/quic/QUICLossDetector.h
@@ -49,7 +49,8 @@ struct PacketInfo {
   size_t sent_bytes;
 
   // addition
-  QUICPacketUPtr packet;
+  QUICPacketType type;
+  std::vector<QUICFrameInfo> frames;
   // end
 };
 
@@ -125,7 +126,7 @@ public:
 
   std::vector<QUICFrameType> interests() override;
   virtual QUICConnectionErrorUPtr handle_frame(QUICEncryptionLevel level, const QUICFrame &frame) override;
-  void on_packet_sent(QUICPacketUPtr packet, bool in_flight = true);
+  void on_packet_sent(QUICPacket &packet, bool in_flight = true);
   QUICPacketNumber largest_acked_packet_number();
   void update_ack_delay_exponent(uint8_t ack_delay_exponent);
   void reset();
@@ -177,14 +178,14 @@ private:
   ink_hrtime _loss_detection_alarm_at = 0;
 
   void _on_packet_sent(QUICPacketNumber packet_number, bool ack_eliciting, bool in_flight, bool is_crypto_packet, size_t sent_bytes,
-                       QUICPacketUPtr packet);
+                       QUICPacketType type, std::vector<QUICFrameInfo> &frames);
   void _on_ack_received(const QUICAckFrame &ack_frame);
   void _on_packet_acked(const PacketInfo &acked_packet);
   void _update_rtt(ink_hrtime latest_rtt, ink_hrtime ack_delay);
   void _detect_lost_packets();
   void _set_loss_detection_timer();
   void _on_loss_detection_timeout();
-  void _retransmit_lost_packet(QUICPacketUPtr &packet);
+  void _retransmit_lost_packet(PacketInfo &packet_info);
 
   std::set<QUICAckFrame::PacketNumberRange> _determine_newly_acked_packets(const QUICAckFrame &ack_frame);
 

--- a/iocore/net/quic/QUICPacket.cc
+++ b/iocore/net/quic/QUICPacket.cc
@@ -777,20 +777,6 @@ QUICPacketShortHeader::store(uint8_t *buf, size_t *len) const
 }
 
 //
-// QUICTrackablePacket
-//
-QUICTrackablePacket::QUICTrackablePacket(std::vector<QUICFrameInfo> &frames)
-{
-  this->_frames = std::move(frames);
-}
-
-std::vector<QUICFrameInfo> &
-QUICTrackablePacket::frames()
-{
-  return this->_frames;
-}
-
-//
 // QUICPacket
 //
 
@@ -803,26 +789,7 @@ QUICPacket::QUICPacket(QUICPacketHeaderUPtr header, ats_unique_buf payload, size
   this->_payload_size = payload_len;
 }
 
-QUICPacket::QUICPacket(QUICPacketHeaderUPtr header, ats_unique_buf payload, size_t payload_len, std::vector<QUICFrameInfo> &frames)
-  : QUICTrackablePacket(frames)
-{
-  this->_header       = std::move(header);
-  this->_payload      = std::move(payload);
-  this->_payload_size = payload_len;
-}
-
 QUICPacket::QUICPacket(QUICPacketHeaderUPtr header, ats_unique_buf payload, size_t payload_len, bool ack_eliciting, bool probing)
-{
-  this->_header            = std::move(header);
-  this->_payload           = std::move(payload);
-  this->_payload_size      = payload_len;
-  this->_is_ack_eliciting  = ack_eliciting;
-  this->_is_probing_packet = probing;
-}
-
-QUICPacket::QUICPacket(QUICPacketHeaderUPtr header, ats_unique_buf payload, size_t payload_len, bool ack_eliciting, bool probing,
-                       std::vector<QUICFrameInfo> &frames)
-  : QUICTrackablePacket(frames)
 {
   this->_header            = std::move(header);
   this->_payload           = std::move(payload);

--- a/iocore/net/quic/QUICPacket.h
+++ b/iocore/net/quic/QUICPacket.h
@@ -51,18 +51,6 @@ extern ClassAllocator<QUICPacketShortHeader> quicPacketShortHeaderAllocator;
 using QUICPacketHeaderDeleterFunc = void (*)(QUICPacketHeader *p);
 using QUICPacketHeaderUPtr        = std::unique_ptr<QUICPacketHeader, QUICPacketHeaderDeleterFunc>;
 
-class QUICTrackablePacket
-{
-public:
-  virtual ~QUICTrackablePacket() {}
-  std::vector<QUICFrameInfo> &frames();
-
-protected:
-  QUICTrackablePacket() {}
-  QUICTrackablePacket(std::vector<QUICFrameInfo> &frames);
-  std::vector<QUICFrameInfo> _frames;
-};
-
 class QUICPacketHeader
 {
 public:
@@ -321,7 +309,7 @@ public:
   }
 };
 
-class QUICPacket : public QUICTrackablePacket
+class QUICPacket
 {
 public:
   QUICPacket();

--- a/iocore/net/quic/QUICPacketFactory.h
+++ b/iocore/net/quic/QUICPacketFactory.h
@@ -56,17 +56,16 @@ public:
                         QUICPacketCreationResult &result);
   QUICPacketUPtr create_initial_packet(QUICConnectionId destination_cid, QUICConnectionId source_cid,
                                        QUICPacketNumber base_packet_number, ats_unique_buf payload, size_t len, bool ack_eliciting,
-                                       bool probing, bool crypto, std::vector<QUICFrameInfo> &frame,
-                                       ats_unique_buf token = ats_unique_buf(nullptr), size_t token_len = 0);
+                                       bool probing, bool crypto, ats_unique_buf token = ats_unique_buf(nullptr),
+                                       size_t token_len = 0);
   QUICPacketUPtr create_handshake_packet(QUICConnectionId destination_cid, QUICConnectionId source_cid,
                                          QUICPacketNumber base_packet_number, ats_unique_buf payload, size_t len,
-                                         bool ack_eliciting, bool probing, bool crypto, std::vector<QUICFrameInfo> &frames);
+                                         bool ack_eliciting, bool probing, bool crypto);
   QUICPacketUPtr create_zero_rtt_packet(QUICConnectionId destination_cid, QUICConnectionId source_cid,
                                         QUICPacketNumber base_packet_number, ats_unique_buf payload, size_t len, bool ack_eliciting,
-                                        bool probing, std::vector<QUICFrameInfo> &frames);
+                                        bool probing);
   QUICPacketUPtr create_protected_packet(QUICConnectionId connection_id, QUICPacketNumber base_packet_number,
-                                         ats_unique_buf payload, size_t len, bool ack_eliciting, bool probing,
-                                         std::vector<QUICFrameInfo> &frames);
+                                         ats_unique_buf payload, size_t len, bool ack_eliciting, bool probing);
   void set_version(QUICVersion negotiated_version);
 
   bool is_ready_to_create_protected_packet();
@@ -82,6 +81,5 @@ private:
   QUICPacketNumberGenerator _packet_number_generator[3];
 
   static QUICPacketUPtr _create_unprotected_packet(QUICPacketHeaderUPtr header);
-  QUICPacketUPtr _create_encrypted_packet(QUICPacketHeaderUPtr header, bool ack_eliciting, bool probing,
-                                          std::vector<QUICFrameInfo> &frames);
+  QUICPacketUPtr _create_encrypted_packet(QUICPacketHeaderUPtr header, bool ack_eliciting, bool probing);
 };

--- a/iocore/net/quic/test/test_QUICLossDetector.cc
+++ b/iocore/net/quic/test/test_QUICLossDetector.cc
@@ -43,7 +43,6 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
   size_t payload_len     = 512;
   QUICPacketUPtr packet  = QUICPacketFactory::create_null_packet();
   QUICAckFrame *frame    = nullptr;
-  std::vector<QUICFrameInfo> dummy_frames;
 
   SECTION("Handshake")
   {
@@ -68,7 +67,14 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
                               false, std::move(payload), sizeof(raw));
     QUICPacketUPtr packet = QUICPacketUPtr(new QUICPacket(std::move(header), std::move(payload), sizeof(raw), true, false),
                                            [](QUICPacket *p) { delete p; });
-    detector.on_packet_sent(*packet);
+    detector.on_packet_sent(QUICPacketInfoUPtr(new QUICPacketInfo{packet->packet_number(),
+                                                                  Thread::get_hrtime(),
+                                                                  packet->is_ack_eliciting(),
+                                                                  packet->is_crypto_packet(),
+                                                                  true,
+                                                                  packet->size(),
+                                                                  packet->type(),
+                                                                  {}}));
     ink_hrtime_sleep(HRTIME_MSECONDS(1000));
     CHECK(g.lost_frame_count >= 0);
 
@@ -87,34 +93,34 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
     // Send packet (1) to (7)
     payload                 = ats_unique_malloc(payload_len);
     QUICPacketUPtr packet1  = pf.create_protected_packet(connection_id, detector.largest_acked_packet_number(), std::move(payload),
-                                                        payload_len, true, false, dummy_frames);
+                                                        payload_len, true, false);
     payload                 = ats_unique_malloc(payload_len);
     QUICPacketUPtr packet2  = pf.create_protected_packet(connection_id, detector.largest_acked_packet_number(), std::move(payload),
-                                                        payload_len, true, false, dummy_frames);
+                                                        payload_len, true, false);
     payload                 = ats_unique_malloc(payload_len);
     QUICPacketUPtr packet3  = pf.create_protected_packet(connection_id, detector.largest_acked_packet_number(), std::move(payload),
-                                                        payload_len, true, false, dummy_frames);
+                                                        payload_len, true, false);
     payload                 = ats_unique_malloc(payload_len);
     QUICPacketUPtr packet4  = pf.create_protected_packet(connection_id, detector.largest_acked_packet_number(), std::move(payload),
-                                                        payload_len, true, false, dummy_frames);
+                                                        payload_len, true, false);
     payload                 = ats_unique_malloc(payload_len);
     QUICPacketUPtr packet5  = pf.create_protected_packet(connection_id, detector.largest_acked_packet_number(), std::move(payload),
-                                                        payload_len, true, false, dummy_frames);
+                                                        payload_len, true, false);
     payload                 = ats_unique_malloc(payload_len);
     QUICPacketUPtr packet6  = pf.create_protected_packet(connection_id, detector.largest_acked_packet_number(), std::move(payload),
-                                                        payload_len, true, false, dummy_frames);
+                                                        payload_len, true, false);
     payload                 = ats_unique_malloc(payload_len);
     QUICPacketUPtr packet7  = pf.create_protected_packet(connection_id, detector.largest_acked_packet_number(), std::move(payload),
-                                                        payload_len, true, false, dummy_frames);
+                                                        payload_len, true, false);
     payload                 = ats_unique_malloc(payload_len);
     QUICPacketUPtr packet8  = pf.create_protected_packet(connection_id, detector.largest_acked_packet_number(), std::move(payload),
-                                                        payload_len, true, false, dummy_frames);
+                                                        payload_len, true, false);
     payload                 = ats_unique_malloc(payload_len);
     QUICPacketUPtr packet9  = pf.create_protected_packet(connection_id, detector.largest_acked_packet_number(), std::move(payload),
-                                                        payload_len, true, false, dummy_frames);
+                                                        payload_len, true, false);
     payload                 = ats_unique_malloc(payload_len);
     QUICPacketUPtr packet10 = pf.create_protected_packet(connection_id, detector.largest_acked_packet_number(), std::move(payload),
-                                                         payload_len, true, false, dummy_frames);
+                                                         payload_len, true, false);
 
     QUICPacketNumber pn1  = packet1->packet_number();
     QUICPacketNumber pn2  = packet2->packet_number();
@@ -127,16 +133,87 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
     QUICPacketNumber pn9  = packet9->packet_number();
     QUICPacketNumber pn10 = packet10->packet_number();
 
-    detector.on_packet_sent(*packet1);
-    detector.on_packet_sent(*packet2);
-    detector.on_packet_sent(*packet3);
-    detector.on_packet_sent(*packet4);
-    detector.on_packet_sent(*packet5);
-    detector.on_packet_sent(*packet6);
-    detector.on_packet_sent(*packet7);
-    detector.on_packet_sent(*packet8);
-    detector.on_packet_sent(*packet9);
-    detector.on_packet_sent(*packet10);
+    QUICPacketInfoUPtr packet_info = nullptr;
+    detector.on_packet_sent(QUICPacketInfoUPtr(new QUICPacketInfo{packet1->packet_number(),
+                                                                  Thread::get_hrtime(),
+                                                                  packet1->is_ack_eliciting(),
+                                                                  packet1->is_crypto_packet(),
+                                                                  true,
+                                                                  packet1->size(),
+                                                                  packet1->type(),
+                                                                  {}}));
+    detector.on_packet_sent(QUICPacketInfoUPtr(new QUICPacketInfo{packet2->packet_number(),
+                                                                  Thread::get_hrtime(),
+                                                                  packet2->is_ack_eliciting(),
+                                                                  packet2->is_crypto_packet(),
+                                                                  true,
+                                                                  packet2->size(),
+                                                                  packet2->type(),
+                                                                  {}}));
+    detector.on_packet_sent(QUICPacketInfoUPtr(new QUICPacketInfo{packet3->packet_number(),
+                                                                  Thread::get_hrtime(),
+                                                                  packet3->is_ack_eliciting(),
+                                                                  packet3->is_crypto_packet(),
+                                                                  true,
+                                                                  packet3->size(),
+                                                                  packet3->type(),
+                                                                  {}}));
+    detector.on_packet_sent(QUICPacketInfoUPtr(new QUICPacketInfo{packet4->packet_number(),
+                                                                  Thread::get_hrtime(),
+                                                                  packet4->is_ack_eliciting(),
+                                                                  packet4->is_crypto_packet(),
+                                                                  true,
+                                                                  packet4->size(),
+                                                                  packet4->type(),
+                                                                  {}}));
+    detector.on_packet_sent(QUICPacketInfoUPtr(new QUICPacketInfo{packet5->packet_number(),
+                                                                  Thread::get_hrtime(),
+                                                                  packet5->is_ack_eliciting(),
+                                                                  packet5->is_crypto_packet(),
+                                                                  true,
+                                                                  packet5->size(),
+                                                                  packet5->type(),
+                                                                  {}}));
+    detector.on_packet_sent(QUICPacketInfoUPtr(new QUICPacketInfo{packet6->packet_number(),
+                                                                  Thread::get_hrtime(),
+                                                                  packet6->is_ack_eliciting(),
+                                                                  packet6->is_crypto_packet(),
+                                                                  true,
+                                                                  packet6->size(),
+                                                                  packet6->type(),
+                                                                  {}}));
+    detector.on_packet_sent(QUICPacketInfoUPtr(new QUICPacketInfo{packet7->packet_number(),
+                                                                  Thread::get_hrtime(),
+                                                                  packet6->is_ack_eliciting(),
+                                                                  packet7->is_crypto_packet(),
+                                                                  true,
+                                                                  packet7->size(),
+                                                                  packet7->type(),
+                                                                  {}}));
+    detector.on_packet_sent(QUICPacketInfoUPtr(new QUICPacketInfo{packet8->packet_number(),
+                                                                  Thread::get_hrtime(),
+                                                                  packet6->is_ack_eliciting(),
+                                                                  packet8->is_crypto_packet(),
+                                                                  true,
+                                                                  packet8->size(),
+                                                                  packet8->type(),
+                                                                  {}}));
+    detector.on_packet_sent(QUICPacketInfoUPtr(new QUICPacketInfo{packet9->packet_number(),
+                                                                  Thread::get_hrtime(),
+                                                                  packet6->is_ack_eliciting(),
+                                                                  packet9->is_crypto_packet(),
+                                                                  true,
+                                                                  packet9->size(),
+                                                                  packet9->type(),
+                                                                  {}}));
+    detector.on_packet_sent(QUICPacketInfoUPtr(new QUICPacketInfo{packet10->packet_number(),
+                                                                  Thread::get_hrtime(),
+                                                                  packet10->is_ack_eliciting(),
+                                                                  packet10->is_crypto_packet(),
+                                                                  true,
+                                                                  packet10->size(),
+                                                                  packet10->type(),
+                                                                  {}}));
 
     ink_hrtime_sleep(HRTIME_MSECONDS(2000));
     // Receive an ACK for (1) (4) (5) (7) (8) (9)

--- a/iocore/net/quic/test/test_QUICLossDetector.cc
+++ b/iocore/net/quic/test/test_QUICLossDetector.cc
@@ -68,7 +68,7 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
                               false, std::move(payload), sizeof(raw));
     QUICPacketUPtr packet = QUICPacketUPtr(new QUICPacket(std::move(header), std::move(payload), sizeof(raw), true, false),
                                            [](QUICPacket *p) { delete p; });
-    detector.on_packet_sent(std::move(packet));
+    detector.on_packet_sent(*packet);
     ink_hrtime_sleep(HRTIME_MSECONDS(1000));
     CHECK(g.lost_frame_count >= 0);
 
@@ -127,16 +127,16 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
     QUICPacketNumber pn9  = packet9->packet_number();
     QUICPacketNumber pn10 = packet10->packet_number();
 
-    detector.on_packet_sent(std::move(packet1));
-    detector.on_packet_sent(std::move(packet2));
-    detector.on_packet_sent(std::move(packet3));
-    detector.on_packet_sent(std::move(packet4));
-    detector.on_packet_sent(std::move(packet5));
-    detector.on_packet_sent(std::move(packet6));
-    detector.on_packet_sent(std::move(packet7));
-    detector.on_packet_sent(std::move(packet8));
-    detector.on_packet_sent(std::move(packet9));
-    detector.on_packet_sent(std::move(packet10));
+    detector.on_packet_sent(*packet1);
+    detector.on_packet_sent(*packet2);
+    detector.on_packet_sent(*packet3);
+    detector.on_packet_sent(*packet4);
+    detector.on_packet_sent(*packet5);
+    detector.on_packet_sent(*packet6);
+    detector.on_packet_sent(*packet7);
+    detector.on_packet_sent(*packet8);
+    detector.on_packet_sent(*packet9);
+    detector.on_packet_sent(*packet10);
 
     ink_hrtime_sleep(HRTIME_MSECONDS(2000));
     // Receive an ACK for (1) (4) (5) (7) (8) (9)

--- a/iocore/net/quic/test/test_QUICPacketFactory.cc
+++ b/iocore/net/quic/test/test_QUICPacketFactory.cc
@@ -87,7 +87,6 @@ TEST_CASE("QUICPacketFactory_Create_Handshake", "[quic]")
   MockQUICPacketProtectionKeyInfo pp_key_info;
   QUICPacketFactory factory(pp_key_info);
   factory.set_version(0x11223344);
-  std::vector<QUICFrameInfo> dummy_frames;
 
   uint8_t raw[]          = {0xaa, 0xbb, 0xcc, 0xdd};
   ats_unique_buf payload = ats_unique_malloc(sizeof(raw));
@@ -96,7 +95,7 @@ TEST_CASE("QUICPacketFactory_Create_Handshake", "[quic]")
   QUICPacketUPtr packet =
     factory.create_handshake_packet(QUICConnectionId(reinterpret_cast<const uint8_t *>("\x01\x02\x03\x04"), 4),
                                     QUICConnectionId(reinterpret_cast<const uint8_t *>("\x11\x12\x13\x14"), 4), 0,
-                                    std::move(payload), sizeof(raw), true, false, true, dummy_frames);
+                                    std::move(payload), sizeof(raw), true, false, true);
   CHECK(packet->type() == QUICPacketType::HANDSHAKE);
   CHECK((packet->destination_cid() == QUICConnectionId(reinterpret_cast<const uint8_t *>("\x01\x02\x03\x04"), 4)));
   CHECK(memcmp(packet->payload(), raw, sizeof(raw)) != 0);

--- a/iocore/net/quic/test/test_QUICVersionNegotiator.cc
+++ b/iocore/net/quic/test/test_QUICVersionNegotiator.cc
@@ -34,7 +34,6 @@ TEST_CASE("QUICVersionNegotiator - Server Side", "[quic]")
   QUICVersionNegotiator vn;
   ats_unique_buf dummy_payload = ats_unique_malloc(128);
   size_t dummy_payload_len     = 128;
-  std::vector<QUICFrameInfo> dummy_frames;
 
   SECTION("Normal case")
   {
@@ -44,7 +43,7 @@ TEST_CASE("QUICVersionNegotiator - Server Side", "[quic]")
     // Negotiate version
     packet_factory.set_version(QUIC_SUPPORTED_VERSIONS[0]);
     QUICPacketUPtr initial_packet =
-      packet_factory.create_initial_packet({}, {}, 0, std::move(dummy_payload), dummy_payload_len, true, false, true, dummy_frames);
+      packet_factory.create_initial_packet({}, {}, 0, std::move(dummy_payload), dummy_payload_len, true, false, true);
     vn.negotiate(initial_packet.get());
     CHECK(vn.status() == QUICVersionNegotiationStatus::NEGOTIATED);
 
@@ -63,7 +62,7 @@ TEST_CASE("QUICVersionNegotiator - Server Side", "[quic]")
     // Negotiate version
     packet_factory.set_version(QUIC_SUPPORTED_VERSIONS[0]);
     QUICPacketUPtr initial_packet =
-      packet_factory.create_initial_packet({}, {}, 0, std::move(dummy_payload), dummy_payload_len, true, false, true, dummy_frames);
+      packet_factory.create_initial_packet({}, {}, 0, std::move(dummy_payload), dummy_payload_len, true, false, true);
     vn.negotiate(initial_packet.get());
     CHECK(vn.status() == QUICVersionNegotiationStatus::NEGOTIATED);
 
@@ -82,7 +81,7 @@ TEST_CASE("QUICVersionNegotiator - Server Side", "[quic]")
     // Negotiate version
     packet_factory.set_version(QUIC_EXERCISE_VERSION);
     QUICPacketUPtr initial_packet =
-      packet_factory.create_initial_packet({}, {}, 0, std::move(dummy_payload), dummy_payload_len, true, false, true, dummy_frames);
+      packet_factory.create_initial_packet({}, {}, 0, std::move(dummy_payload), dummy_payload_len, true, false, true);
     vn.negotiate(initial_packet.get());
     CHECK(vn.status() == QUICVersionNegotiationStatus::NOT_NEGOTIATED);
 
@@ -101,7 +100,6 @@ TEST_CASE("QUICVersionNegotiator - Client Side", "[quic]")
   QUICVersionNegotiator vn;
   ats_unique_buf dummy_payload = ats_unique_malloc(128);
   size_t dummy_payload_len     = 128;
-  std::vector<QUICFrameInfo> dummy_frames;
 
   SECTION("Normal case")
   {
@@ -127,7 +125,7 @@ TEST_CASE("QUICVersionNegotiator - Client Side", "[quic]")
     // Negotiate version
     packet_factory.set_version(QUIC_EXERCISE_VERSION);
     QUICPacketUPtr initial_packet =
-      packet_factory.create_initial_packet({}, {}, 0, std::move(dummy_payload), dummy_payload_len, true, false, true, dummy_frames);
+      packet_factory.create_initial_packet({}, {}, 0, std::move(dummy_payload), dummy_payload_len, true, false, true);
 
     // Server send VN packet based on Initial packet
     QUICPacketUPtr vn_packet =


### PR DESCRIPTION
Since we removed `QUICPacketRetransmitter` which requires packet payloads, we don't need to keep actual packets (`QUICPacketUPtr`) in `QUICLossDetector`.