### PR TITLE
Introduce classes for each QUIC packet types

### DIFF
--- a/iocore/net/quic/QUICPacketFactory.h
+++ b/iocore/net/quic/QUICPacketFactory.h
@@ -44,11 +44,11 @@ class QUICPacketFactory
 {
 public:
   static QUICPacketUPtr create_null_packet();
-  static QUICPacketUPtr create_version_negotiation_packet(QUICConnectionId dcid, QUICConnectionId scid);
-  static QUICPacketUPtr create_stateless_reset_packet(QUICConnectionId connection_id,
-                                                      QUICStatelessResetToken stateless_reset_token);
-  static QUICPacketUPtr create_retry_packet(QUICConnectionId destination_cid, QUICConnectionId source_cid,
-                                            QUICConnectionId original_dcid, QUICRetryToken &token);
+  static QUICVersionNegotiationPacket *create_version_negotiation_packet(uint8_t *buf, QUICConnectionId dcid,
+                                                                         QUICConnectionId scid);
+  static QUICStatelessResetPacket *create_stateless_reset_packet(uint8_t *buf, QUICStatelessResetToken stateless_reset_token);
+  static QUICRetryPacket *create_retry_packet(uint8_t *buf, QUICConnectionId destination_cid, QUICConnectionId source_cid,
+                                              QUICConnectionId original_dcid, QUICRetryToken &token);
 
   QUICPacketFactory(const QUICPacketProtectionKeyInfo &pp_key_info) : _pp_key_info(pp_key_info), _pp_protector(pp_key_info) {}
 
@@ -81,7 +81,6 @@ private:
   // Initial, 0/1-RTT, and Handshake
   QUICPacketNumberGenerator _packet_number_generator[3];
 
-  static QUICPacketUPtr _create_unprotected_packet(QUICPacketHeaderUPtr header);
   QUICPacketUPtr _create_encrypted_packet(QUICPacketHeaderUPtr header, bool ack_eliciting, bool probing,
                                           std::vector<QUICFrameInfo> &frames);
 };


### PR DESCRIPTION
The idea is the same as QUICFrame classes. This will introduce classes for each QUIC packet types and changes factory's interface so that we can eliminate the class allocator.

This will make `QUICPacketSomething::store()` simple (currently there are many `if`s checking packet type in it), and I'm going to replace it with `to_io_buffer_block()`.

This depends on #5124.