### PR TITLE
Change url_mapping::toUrl to url_mapping::toURL

### DIFF
--- a/proxy/http/remap/RemapConfig.cc
+++ b/proxy/http/remap/RemapConfig.cc
@@ -854,7 +854,7 @@ remap_load_plugin(const char **argv, int argc, url_mapping *mp, char *errbuf, in
   parv[parc++] = ats_strdup(err);
   ats_free(err);
 
-  if ((err = mp->toUrl.string_get(nullptr)) == nullptr) {
+  if ((err = mp->toURL.string_get(nullptr)) == nullptr) {
     snprintf(errbuf, errbufsize, "Can't load toURL from URL class");
     return -7;
   }
@@ -960,7 +960,7 @@ process_regex_mapping_config(const char *from_host_lower, url_mapping *new_mappi
     goto lFail;
   }
 
-  to_host = new_mapping->toUrl.host_get(&to_host_len);
+  to_host = new_mapping->toURL.host_get(&to_host_len);
   for (int i = 0; i < (to_host_len - 1); ++i) {
     if (to_host[i] == '$') {
       if (substitution_count > UrlRewrite::MAX_REGEX_SUBS) {
@@ -981,7 +981,7 @@ process_regex_mapping_config(const char *from_host_lower, url_mapping *new_mappi
   // so the regex itself is stored in fromURL.host; string to match
   // will be in the request; string to use for substitutions will be
   // in this buffer
-  str                               = new_mapping->toUrl.host_get(&str_index); // reusing str and str_index
+  str                               = new_mapping->toURL.host_get(&str_index); // reusing str and str_index
   reg_map->to_url_host_template_len = str_index;
   reg_map->to_url_host_template     = static_cast<char *>(ats_malloc(str_index));
   memcpy(reg_map->to_url_host_template, str, str_index);
@@ -1185,8 +1185,8 @@ remap_parse_config_bti(const char *path, BUILD_TABLE_INFO *bti)
     map_to_start = map_to;
     tmp          = map_to;
 
-    new_mapping->toUrl.create(nullptr);
-    rparse                   = new_mapping->toUrl.parse_no_path_component_breakdown(tmp, length);
+    new_mapping->toURL.create(nullptr);
+    rparse                   = new_mapping->toURL.parse_no_path_component_breakdown(tmp, length);
     map_to_start[origLength] = '\0'; // Unwhack
 
     if (rparse != PARSE_RESULT_DONE) {
@@ -1202,7 +1202,7 @@ remap_parse_config_bti(const char *path, BUILD_TABLE_INFO *bti)
       fromScheme                        = new_mapping->fromURL.scheme_get(&fromSchemeLen);
       new_mapping->wildcard_from_scheme = true;
     }
-    toScheme = new_mapping->toUrl.scheme_get(&toSchemeLen);
+    toScheme = new_mapping->toURL.scheme_get(&toSchemeLen);
 
     // Include support for HTTPS scheme
     // includes support for FILE scheme
@@ -1281,7 +1281,7 @@ remap_parse_config_bti(const char *path, BUILD_TABLE_INFO *bti)
       }
     }
 
-    toHost = new_mapping->toUrl.host_get(&toHostLen);
+    toHost = new_mapping->toURL.host_get(&toHostLen);
     if (toHost == nullptr || toHostLen <= 0) {
       errStr = "The remap destinations require a hostname";
       goto MAP_ERROR;
@@ -1340,8 +1340,8 @@ remap_parse_config_bti(const char *path, BUILD_TABLE_INFO *bti)
             u_mapping->fromURL.create(nullptr);
             u_mapping->fromURL.copy(&new_mapping->fromURL);
             u_mapping->fromURL.host_set(ipb, strlen(ipb));
-            u_mapping->toUrl.create(nullptr);
-            u_mapping->toUrl.copy(&new_mapping->toUrl);
+            u_mapping->toURL.create(nullptr);
+            u_mapping->toURL.copy(&new_mapping->toURL);
 
             if (bti->paramv[3] != nullptr) {
               u_mapping->tag = ats_strdup(&(bti->paramv[3][0]));

--- a/proxy/http/remap/UrlMapping.cc
+++ b/proxy/http/remap/UrlMapping.cc
@@ -111,7 +111,7 @@ url_mapping::~url_mapping()
 
   // Destroy the URLs
   fromURL.destroy();
-  toUrl.destroy();
+  toURL.destroy();
 }
 
 void
@@ -120,7 +120,7 @@ url_mapping::Print()
   char from_url_buf[131072], to_url_buf[131072];
 
   fromURL.string_get_buf(from_url_buf, (int)sizeof(from_url_buf));
-  toUrl.string_get_buf(to_url_buf, (int)sizeof(to_url_buf));
+  toURL.string_get_buf(to_url_buf, (int)sizeof(to_url_buf));
   printf("\t %s %s=> %s %s <%s> [plugins %s enabled; running with %zu plugins]\n", from_url_buf, unique ? "(unique)" : "",
          to_url_buf, homePageRedirect ? "(R)" : "", tag ? tag : "", plugin_count() > 0 ? "are" : "not", plugin_count());
 }

--- a/proxy/http/remap/UrlMapping.h
+++ b/proxy/http/remap/UrlMapping.h
@@ -94,7 +94,7 @@ public:
 
   int from_path_len = 0;
   URL fromURL;
-  URL toUrl; // Default TO-URL (from remap.config)
+  URL toURL; // Default TO-URL (from remap.config)
   bool homePageRedirect              = false;
   bool unique                        = false; // INKqa11970 - unique mapping
   bool default_redirect_url          = false;
@@ -159,7 +159,7 @@ public:
   {
     deleteToURL();
     _mapping  = m;
-    _toURLPtr = m ? &(m->toUrl) : nullptr;
+    _toURLPtr = m ? &(m->toURL) : nullptr;
   }
 
   void

--- a/proxy/http/remap/UrlRewrite.cc
+++ b/proxy/http/remap/UrlRewrite.cc
@@ -144,8 +144,8 @@ UrlRewrite::SetupBackdoorMapping()
   mapping->fromURL.parse(from_url, sizeof(from_url) - 1);
   mapping->fromURL.scheme_set(URL_SCHEME_HTTP, URL_LEN_HTTP);
 
-  mapping->toUrl.create(nullptr);
-  mapping->toUrl.parse(to_url, sizeof(to_url) - 1);
+  mapping->toURL.create(nullptr);
+  mapping->toURL.parse(to_url, sizeof(to_url) - 1);
 
   return mapping;
 }
@@ -599,7 +599,7 @@ UrlRewrite::InsertMapping(mapping_type maptype, url_mapping *new_mapping, RegexM
     success = _addToStore(forward_mappings, new_mapping, reg_map, src_host, is_cur_mapping_regex, num_rules_forward);
     if (success) {
       // @todo: is this applicable to regex mapping too?
-      SetHomePageRedirectFlag(new_mapping, new_mapping->toUrl);
+      SetHomePageRedirectFlag(new_mapping, new_mapping->toURL);
     }
     break;
   case REVERSE_MAP:
@@ -641,7 +641,7 @@ UrlRewrite::InsertForwardMapping(mapping_type maptype, url_mapping *mapping, con
     case FORWARD_MAP:
     case FORWARD_MAP_REFERER:
     case FORWARD_MAP_WITH_RECV_PORT:
-      SetHomePageRedirectFlag(mapping, mapping->toUrl);
+      SetHomePageRedirectFlag(mapping, mapping->toURL);
       break;
     default:
       break;
@@ -914,7 +914,7 @@ UrlRewrite::_regexMappingLookup(RegexMappingList &regex_mappings, URL *request_u
       // Expand substitutions in the host field from the stored template
       buf_len           = _expandSubstitutions(matches_info, list_iter, request_host, buf, sizeof(buf));
       URL *expanded_url = mapping_container.createNewToURL();
-      expanded_url->copy(&((list_iter->url_map)->toUrl));
+      expanded_url->copy(&((list_iter->url_map)->toURL));
       expanded_url->host_set(buf, buf_len);
 
       Debug("url_rewrite_regex", "Expanded toURL to [%.*s]", expanded_url->length_get(), expanded_url->string_get_ref());


### PR DESCRIPTION
I have tripped over this one too many times, where it's 'url_mapping::fromURL` but `url_mapping::toUrl`. It was a face palm moment when I realized why I couldn't ever remember the case of the members.