### PR TITLE
Do not run clang-format for @default_stack_size@

### DIFF
--- a/include/tscore/ink_config.h.in
+++ b/include/tscore/ink_config.h.in
@@ -121,6 +121,6 @@
 #define TS_BUILD_CANONICAL_HOST "@host@"
 
 #define TS_BUILD_DEFAULT_LOOPBACK_IFACE "@default_loopback_iface@"
-/* clang-format on */
 
 static const int DEFAULT_STACKSIZE = @default_stack_size@;
+/* clang-format on */


### PR DESCRIPTION
Everytime when I touch this file, clang-foramt add a space and make compile error.

```
-static const int DEFAULT_STACKSIZE = @default_stack_size@;
+static const int DEFAULT_STACKSIZE = @default_stack_size @;
```