### PR TITLE
Fix for() loop, correctly calculate the value of seg_in_use within Vol::dir_check()

### DIFF
--- a/iocore/cache/CacheDir.cc
+++ b/iocore/cache/CacheDir.cc
@@ -1267,10 +1267,6 @@ int Vol::dir_check(bool /* fix ATS_UNUSED */) // TODO: we should eliminate this 
             ++frag_demographics[dir_size(e)][dir_big(e)];
           }
         }
-        e = next_dir(e, seg);
-        if (!e) {
-          break;
-        }
       }
 
       // Check for duplicates (identical tags in the same bucket).


### PR DESCRIPTION
The bug was introduced by commit d0d0afb9 .