### PR TITLE
Reduce use of QUICConfig::scoped_config

### DIFF
--- a/iocore/net/P_QUICNetVConnection.h
+++ b/iocore/net/P_QUICNetVConnection.h
@@ -40,6 +40,7 @@
 #include "tscore/ink_apidefs.h"
 #include "tscore/List.h"
 
+#include "quic/QUICConfig.h"
 #include "quic/QUICConnection.h"
 #include "quic/QUICConnectionTable.h"
 #include "quic/QUICVersionNegotiator.h"
@@ -207,6 +208,8 @@ public:
 
 private:
   std::random_device _rnd;
+
+  QUICConfig::scoped_config _quic_config;
 
   QUICConnectionId _peer_quic_connection_id;     // dst cid in local
   QUICConnectionId _peer_old_quic_connection_id; // dst previous cid in local

--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -419,7 +419,6 @@ void
 QUICNetVConnection::start()
 {
   ink_release_assert(this->thread != nullptr);
-  QUICConfig::scoped_config params;
 
   this->_five_tuple.update(this->local_addr, this->remote_addr, SOCK_DGRAM);
   // Version 0x00000001 uses stream 0 for cryptographic handshake with TLS 1.3, but newer version may not
@@ -427,22 +426,23 @@ QUICNetVConnection::start()
     QUICCertConfig::scoped_config server_cert;
 
     this->_pp_key_info.set_context(QUICPacketProtectionKeyInfo::Context::SERVER);
-    this->_ack_frame_manager.set_ack_delay_exponent(params->ack_delay_exponent_in());
-    this->_reset_token       = QUICStatelessResetToken(this->_quic_connection_id, params->instance_id());
-    this->_hs_protocol       = this->_setup_handshake_protocol(server_cert->ssl_default);
-    this->_handshake_handler = new QUICHandshake(this, this->_hs_protocol, this->_reset_token, params->stateless_retry());
-    this->_ack_frame_manager.set_max_ack_delay(params->max_ack_delay_in());
-    this->_schedule_ack_manager_periodic(params->max_ack_delay_in());
+    this->_ack_frame_manager.set_ack_delay_exponent(this->_quic_config->ack_delay_exponent_in());
+    this->_reset_token = QUICStatelessResetToken(this->_quic_connection_id, this->_quic_config->instance_id());
+    this->_hs_protocol = this->_setup_handshake_protocol(server_cert->ssl_default);
+    this->_handshake_handler =
+      new QUICHandshake(this, this->_hs_protocol, this->_reset_token, this->_quic_config->stateless_retry());
+    this->_ack_frame_manager.set_max_ack_delay(this->_quic_config->max_ack_delay_in());
+    this->_schedule_ack_manager_periodic(this->_quic_config->max_ack_delay_in());
   } else {
-    QUICTPConfigQCP tp_config(params, NET_VCONNECTION_OUT);
+    QUICTPConfigQCP tp_config(this->_quic_config, NET_VCONNECTION_OUT);
     this->_pp_key_info.set_context(QUICPacketProtectionKeyInfo::Context::CLIENT);
-    this->_ack_frame_manager.set_ack_delay_exponent(params->ack_delay_exponent_out());
-    this->_hs_protocol       = this->_setup_handshake_protocol(params->client_ssl_ctx());
+    this->_ack_frame_manager.set_ack_delay_exponent(this->_quic_config->ack_delay_exponent_out());
+    this->_hs_protocol       = this->_setup_handshake_protocol(this->_quic_config->client_ssl_ctx());
     this->_handshake_handler = new QUICHandshake(this, this->_hs_protocol);
-    this->_handshake_handler->start(tp_config, &this->_packet_factory, params->vn_exercise_enabled());
+    this->_handshake_handler->start(tp_config, &this->_packet_factory, this->_quic_config->vn_exercise_enabled());
     this->_handshake_handler->do_handshake();
-    this->_ack_frame_manager.set_max_ack_delay(params->max_ack_delay_out());
-    this->_schedule_ack_manager_periodic(params->max_ack_delay_out());
+    this->_ack_frame_manager.set_max_ack_delay(this->_quic_config->max_ack_delay_out());
+    this->_schedule_ack_manager_periodic(this->_quic_config->max_ack_delay_out());
   }
 
   this->_application_map = new QUICApplicationMap();
@@ -450,8 +450,8 @@ QUICNetVConnection::start()
   this->_frame_dispatcher = new QUICFrameDispatcher(this);
 
   // Create frame handlers
-  QUICCCConfigQCP cc_config(params);
-  QUICLDConfigQCP ld_config(params);
+  QUICCCConfigQCP cc_config(this->_quic_config);
+  QUICLDConfigQCP ld_config(this->_quic_config);
   this->_congestion_controller = new QUICCongestionController(this, cc_config);
   for (auto s : QUIC_PN_SPACES) {
     int index            = static_cast<int>(s);
@@ -747,12 +747,10 @@ QUICNetVConnection::state_pre_handshake(int event, Event *data)
   }
 
   // FIXME: Should be accept_no_activity_timeout?
-  QUICConfig::scoped_config params;
-
   if (this->get_context() == NET_VCONNECTION_IN) {
-    this->set_inactivity_timeout(HRTIME_SECONDS(params->no_activity_timeout_in()));
+    this->set_inactivity_timeout(HRTIME_SECONDS(this->_quic_config->no_activity_timeout_in()));
   } else {
-    this->set_inactivity_timeout(HRTIME_SECONDS(params->no_activity_timeout_out()));
+    this->set_inactivity_timeout(HRTIME_SECONDS(this->_quic_config->no_activity_timeout_out()));
   }
 
   this->add_to_active_queue();
@@ -1135,15 +1133,15 @@ QUICNetVConnection::_state_handshake_process_initial_packet(QUICPacketUPtr packe
 
   // Start handshake
   if (this->netvc_context == NET_VCONNECTION_IN) {
-    QUICConfig::scoped_config params;
     if (!this->_alt_con_manager) {
-      this->_alt_con_manager = new QUICAltConnectionManager(this, *this->_ctable, this->_peer_quic_connection_id,
-                                                            params->instance_id(), params->num_alt_connection_ids(),
-                                                            params->preferred_address_ipv4(), params->preferred_address_ipv6());
+      this->_alt_con_manager =
+        new QUICAltConnectionManager(this, *this->_ctable, this->_peer_quic_connection_id, this->_quic_config->instance_id(),
+                                     this->_quic_config->num_alt_connection_ids(), this->_quic_config->preferred_address_ipv4(),
+                                     this->_quic_config->preferred_address_ipv6());
       this->_frame_generators.push_back(this->_alt_con_manager);
       this->_frame_dispatcher->add_handler(this->_alt_con_manager);
     }
-    QUICTPConfigQCP tp_config(params, NET_VCONNECTION_IN);
+    QUICTPConfigQCP tp_config(this->_quic_config, NET_VCONNECTION_IN);
     error =
       this->_handshake_handler->start(tp_config, packet.get(), &this->_packet_factory, this->_alt_con_manager->preferred_address());
 
@@ -1250,8 +1248,7 @@ QUICNetVConnection::_state_connection_established_process_protected_packet(QUICP
   }
 
   // For Connection Migration excercise
-  QUICConfig::scoped_config params;
-  if (this->netvc_context == NET_VCONNECTION_OUT && params->cm_exercise_enabled()) {
+  if (this->netvc_context == NET_VCONNECTION_OUT && this->_quic_config->cm_exercise_enabled()) {
     this->_state_connection_established_initiate_connection_migration();
   }
 
@@ -1999,10 +1996,9 @@ QUICNetVConnection::_switch_to_established_state()
       std::shared_ptr<const QUICTransportParameters> remote_tp = this->_handshake_handler->remote_transport_parameters();
       const uint8_t *pref_addr_buf;
       uint16_t len;
-      QUICConfig::scoped_config params;
       pref_addr_buf          = remote_tp->getAsBytes(QUICTransportParameterId::PREFERRED_ADDRESS, len);
       this->_alt_con_manager = new QUICAltConnectionManager(this, *this->_ctable, this->_peer_quic_connection_id,
-                                                            params->instance_id(), 1, {pref_addr_buf, len});
+                                                            this->_quic_config->instance_id(), 1, {pref_addr_buf, len});
       this->_frame_generators.push_back(this->_alt_con_manager);
       this->_frame_dispatcher->add_handler(this->_alt_con_manager);
     }
@@ -2178,8 +2174,7 @@ QUICNetVConnection::_setup_handshake_protocol(SSL_CTX *ctx)
 {
   // Initialize handshake protocol specific stuff
   // For QUICv1 TLS is the only option
-  QUICConfig::scoped_config params;
-  QUICTLS *tls = new QUICTLS(this->_pp_key_info, ctx, this->direction(), params->session_file());
+  QUICTLS *tls = new QUICTLS(this->_pp_key_info, ctx, this->direction(), this->_quic_config->session_file());
   SSL_set_ex_data(tls->ssl_handle(), QUIC::ssl_quic_qc_index, static_cast<QUICConnection *>(this));
   return tls;
 }

--- a/iocore/net/QUICPacketHandler.cc
+++ b/iocore/net/QUICPacketHandler.cc
@@ -295,7 +295,6 @@ QUICPacketHandlerIn::_recv_packet(int event, UDPPacket *udp_packet)
   // Servers MUST drop incoming packets under all other circumstances. They SHOULD send a Stateless Reset (Section 6.10.4) if a
   // connection ID is present in the header.
   if ((!vc && !QUICInvariants::is_long_header(buf)) || (vc && vc->in_closed_queue)) {
-    QUICConfig::scoped_config params;
     QUICStatelessResetToken token(dcid, params->instance_id());
     auto packet = QUICPacketFactory::create_stateless_reset_packet(dcid, token);
     this->_send_packet(*packet, udp_packet->getConnection(), udp_packet->from, 1200, nullptr, 0);

--- a/iocore/net/quic/Mock.h
+++ b/iocore/net/quic/Mock.h
@@ -340,7 +340,10 @@ class MockQUICConnectionInfoProvider : public QUICConnectionInfoProvider
 class MockQUICCongestionController : public QUICCongestionController
 {
 public:
-  MockQUICCongestionController(QUICConnectionInfoProvider *info) : QUICCongestionController(info) {}
+  MockQUICCongestionController(QUICConnectionInfoProvider *info, const QUICCCConfig &cc_config)
+    : QUICCongestionController(info, cc_config)
+  {
+  }
   // Override
   virtual void
   on_packets_lost(const std::map<QUICPacketNumber, PacketInfo *> &packets, uint32_t pto_count) override
@@ -385,8 +388,9 @@ private:
 class MockQUICLossDetector : public QUICLossDetector
 {
 public:
-  MockQUICLossDetector(QUICConnectionInfoProvider *info, QUICCongestionController *cc, QUICRTTMeasure *rtt_measure, int index)
-    : QUICLossDetector(info, cc, rtt_measure, index)
+  MockQUICLossDetector(QUICConnectionInfoProvider *info, QUICCongestionController *cc, QUICRTTMeasure *rtt_measure, int index,
+                       const QUICLDConfig &ld_config)
+    : QUICLossDetector(info, cc, rtt_measure, index, ld_config)
   {
   }
   void
@@ -639,5 +643,65 @@ private:
   _on_frame_lost(QUICFrameInformationUPtr &info) override
   {
     lost_frame_count++;
+  }
+};
+
+class MockQUICLDConfig : public QUICLDConfig
+{
+  uint32_t
+  packet_threshold() const
+  {
+    return 3;
+  }
+
+  float
+  time_threshold() const
+  {
+    return 1.25;
+  }
+
+  ink_hrtime
+  granularity() const
+  {
+    return HRTIME_MSECONDS(1);
+  }
+
+  ink_hrtime
+  initial_rtt() const
+  {
+    return HRTIME_MSECONDS(100);
+  }
+};
+
+class MockQUICCCConfig : public QUICCCConfig
+{
+  uint32_t
+  max_datagram_size() const
+  {
+    return 1200;
+  }
+
+  uint32_t
+  initial_window() const
+  {
+    return 10;
+  }
+
+  uint32_t
+  minimum_window() const
+  {
+    return 2;
+  }
+
+  float
+  loss_reduction_factor() const
+  {
+    return 0.5;
+  }
+
+  uint32_t
+  persistent_congestion_threshold() const
+  {
+    return 2;
   }
 };

--- a/iocore/net/quic/QUICCongestionController.cc
+++ b/iocore/net/quic/QUICCongestionController.cc
@@ -24,8 +24,6 @@
 #include <tscore/Diags.h>
 #include <QUICLossDetector.h>
 
-#include "QUICConfig.h"
-
 #define QUICCCDebug(fmt, ...)                                                \
   Debug("quic_cc",                                                           \
         "[%s] "                                                              \
@@ -38,16 +36,15 @@
         "window: %" PRIu32 " bytes: %" PRIu32 " ssthresh: %" PRIu32 " " fmt, \
         this->_info->cids().data(), this->_congestion_window, this->_bytes_in_flight, this->_ssthresh, ##__VA_ARGS__)
 
-QUICCongestionController::QUICCongestionController(QUICConnectionInfoProvider *info) : _info(info)
+QUICCongestionController::QUICCongestionController(QUICConnectionInfoProvider *info, const QUICCCConfig &cc_config) : _info(info)
 {
   this->_cc_mutex = new_ProxyMutex();
 
-  QUICConfig::scoped_config params;
-  this->_k_max_datagram_size               = params->cc_max_datagram_size();
-  this->_k_initial_window                  = params->cc_initial_window();
-  this->_k_minimum_window                  = params->cc_minimum_window();
-  this->_k_loss_reduction_factor           = params->cc_loss_reduction_factor();
-  this->_k_persistent_congestion_threshold = params->cc_persistent_congestion_threshold();
+  this->_k_max_datagram_size               = cc_config.max_datagram_size();
+  this->_k_initial_window                  = cc_config.initial_window();
+  this->_k_minimum_window                  = cc_config.minimum_window();
+  this->_k_loss_reduction_factor           = cc_config.loss_reduction_factor();
+  this->_k_persistent_congestion_threshold = cc_config.persistent_congestion_threshold();
 
   this->reset();
 }

--- a/iocore/net/quic/QUICGlobals.cc
+++ b/iocore/net/quic/QUICGlobals.cc
@@ -69,9 +69,11 @@ int
 QUIC::ssl_client_new_session(SSL *ssl, SSL_SESSION *session)
 {
   QUICConfig::scoped_config params;
-  auto file = BIO_new_file(params->session_file(), "w");
+  const char *session_file = params->session_file();
+  auto file                = BIO_new_file(session_file, "w");
+
   if (file == nullptr) {
-    QUICGlobalDebug("Could not write TLS session in %s", params->session_file());
+    QUICGlobalDebug("Could not write TLS session in %s", session_file);
     return 0;
   }
 

--- a/iocore/net/quic/QUICGlobals.cc
+++ b/iocore/net/quic/QUICGlobals.cc
@@ -31,6 +31,9 @@
 #include "QUICConfig.h"
 #include "QUICConnection.h"
 
+#include "QUICTLS.h"
+#include <openssl/ssl.h>
+
 #define QUICGlobalDebug(fmt, ...) Debug("quic_global", fmt, ##__VA_ARGS__)
 #define QUICGlobalQCDebug(qc, fmt, ...) Debug("quic_global", "[%s] " fmt, qc->cids().data(), ##__VA_ARGS__)
 
@@ -68,8 +71,8 @@ QUIC::ssl_select_next_protocol(SSL *ssl, const unsigned char **out, unsigned cha
 int
 QUIC::ssl_client_new_session(SSL *ssl, SSL_SESSION *session)
 {
-  QUICConfig::scoped_config params;
-  const char *session_file = params->session_file();
+  QUICTLS *qtls            = static_cast<QUICTLS *>(SSL_get_ex_data(ssl, QUIC::ssl_quic_tls_index));
+  const char *session_file = qtls->session_file();
   auto file                = BIO_new_file(session_file, "w");
 
   if (file == nullptr) {

--- a/iocore/net/quic/QUICHandshake.h
+++ b/iocore/net/quic/QUICHandshake.h
@@ -56,12 +56,12 @@ public:
                             ink_hrtime timestamp) override;
 
   // for client side
-  QUICConnectionErrorUPtr start(QUICPacketFactory *packet_factory, bool vn_exercise_enabled);
+  QUICConnectionErrorUPtr start(const QUICTPConfig &tp_config, QUICPacketFactory *packet_factory, bool vn_exercise_enabled);
   QUICConnectionErrorUPtr negotiate_version(const QUICPacket *packet, QUICPacketFactory *packet_factory);
   void reset();
 
   // for server side
-  QUICConnectionErrorUPtr start(const QUICPacket *initial_packet, QUICPacketFactory *packet_factory,
+  QUICConnectionErrorUPtr start(const QUICTPConfig &tp_config, const QUICPacket *initial_packet, QUICPacketFactory *packet_factory,
                                 const QUICPreferredAddress *pref_addr);
 
   QUICConnectionErrorUPtr do_handshake();
@@ -101,8 +101,9 @@ private:
       QUICEncryptionLevel::ONE_RTT,
     };
   }
-  void _load_local_server_transport_parameters(QUICVersion negotiated_version, const QUICPreferredAddress *pref_addr);
-  void _load_local_client_transport_parameters(QUICVersion initial_version);
+  void _load_local_server_transport_parameters(const QUICTPConfig &tp_config, QUICVersion negotiated_version,
+                                               const QUICPreferredAddress *pref_addr);
+  void _load_local_client_transport_parameters(const QUICTPConfig &tp_config, QUICVersion initial_version);
   bool _check_remote_transport_parameters(std::shared_ptr<const QUICTransportParametersInClientHello> tp);
   bool _check_remote_transport_parameters(std::shared_ptr<const QUICTransportParametersInEncryptedExtensions> tp);
   std::shared_ptr<const QUICTransportParameters> _local_transport_parameters  = nullptr;

--- a/iocore/net/quic/QUICLossDetector.cc
+++ b/iocore/net/quic/QUICLossDetector.cc
@@ -38,17 +38,16 @@
         ##__VA_ARGS__)
 
 QUICLossDetector::QUICLossDetector(QUICConnectionInfoProvider *info, QUICCongestionController *cc, QUICRTTMeasure *rtt_measure,
-                                   int index)
+                                   int index, const QUICLDConfig &ld_config)
   : _info(info), _cc(cc), _rtt_measure(rtt_measure), _pn_space_index(index)
 {
   this->mutex                 = new_ProxyMutex();
   this->_loss_detection_mutex = new_ProxyMutex();
 
-  QUICConfig::scoped_config params;
-  this->_k_packet_threshold = params->ld_packet_threshold();
-  this->_k_time_threshold   = params->ld_time_threshold();
-  this->_k_granularity      = params->ld_granularity();
-  this->_k_initial_rtt      = params->ld_initial_rtt();
+  this->_k_packet_threshold = ld_config.packet_threshold();
+  this->_k_time_threshold   = ld_config.time_threshold();
+  this->_k_granularity      = ld_config.granularity();
+  this->_k_initial_rtt      = ld_config.initial_rtt();
 
   this->reset();
 

--- a/iocore/net/quic/QUICLossDetector.h
+++ b/iocore/net/quic/QUICLossDetector.h
@@ -74,7 +74,7 @@ private:
 class QUICCongestionController
 {
 public:
-  QUICCongestionController(QUICConnectionInfoProvider *info);
+  QUICCongestionController(QUICConnectionInfoProvider *info, const QUICCCConfig &cc_config);
   virtual ~QUICCongestionController() {}
   void on_packet_sent(size_t bytes_sent);
   void on_packet_acked(const PacketInfo &acked_packet);
@@ -118,7 +118,8 @@ private:
 class QUICLossDetector : public Continuation, public QUICFrameHandler
 {
 public:
-  QUICLossDetector(QUICConnectionInfoProvider *info, QUICCongestionController *cc, QUICRTTMeasure *rtt_measure, int index);
+  QUICLossDetector(QUICConnectionInfoProvider *info, QUICCongestionController *cc, QUICRTTMeasure *rtt_measure, int index,
+                   const QUICLDConfig &ld_config);
   ~QUICLossDetector();
 
   int event_handler(int event, Event *edata);

--- a/iocore/net/quic/QUICTLS.cc
+++ b/iocore/net/quic/QUICTLS.cc
@@ -62,6 +62,12 @@ QUICTLS::set_remote_transport_parameters(std::shared_ptr<const QUICTransportPara
   this->_remote_transport_parameters = tp;
 }
 
+const char *
+QUICTLS::session_file() const
+{
+  return this->_session_file;
+}
+
 QUICTLS::~QUICTLS()
 {
   SSL_free(this->_ssl);

--- a/iocore/net/quic/QUICTLS.h
+++ b/iocore/net/quic/QUICTLS.h
@@ -57,11 +57,12 @@ public:
   void set_local_transport_parameters(std::shared_ptr<const QUICTransportParameters> tp) override;
   void set_remote_transport_parameters(std::shared_ptr<const QUICTransportParameters> tp) override;
 
+  const char *session_file() const;
+
   // FIXME Should not exist
   SSL *ssl_handle();
 
   // QUICHandshakeProtocol
-
   int handshake(QUICHandshakeMsgs *out, const QUICHandshakeMsgs *in) override;
   void reset() override;
   bool is_handshake_finished() const override;
@@ -77,6 +78,8 @@ private:
   QUICKeyGenerator _keygen_for_client = QUICKeyGenerator(QUICKeyGenerator::Context::CLIENT);
   QUICKeyGenerator _keygen_for_server = QUICKeyGenerator(QUICKeyGenerator::Context::SERVER);
   const EVP_MD *_get_handshake_digest() const;
+
+  const char *_session_file;
 
   int _read_early_data();
   int _write_early_data();

--- a/iocore/net/quic/QUICTLS.h
+++ b/iocore/net/quic/QUICTLS.h
@@ -39,7 +39,8 @@
 class QUICTLS : public QUICHandshakeProtocol
 {
 public:
-  QUICTLS(QUICPacketProtectionKeyInfo &pp_key_info, SSL_CTX *ssl_ctx, NetVConnectionContext_t nvc_ctx);
+  QUICTLS(QUICPacketProtectionKeyInfo &pp_key_info, SSL_CTX *ssl_ctx, NetVConnectionContext_t nvc_ctx,
+          const char *session_file = nullptr);
   ~QUICTLS();
 
   // TODO: integrate with _early_data_processed

--- a/iocore/net/quic/QUICTLS_openssl.cc
+++ b/iocore/net/quic/QUICTLS_openssl.cc
@@ -330,7 +330,7 @@ QUICTLS::update_key_materials_on_key_cb(int name, const uint8_t *secret, size_t 
 
 QUICTLS::QUICTLS(QUICPacketProtectionKeyInfo &pp_key_info, SSL_CTX *ssl_ctx, NetVConnectionContext_t nvc_ctx,
                  const char *session_file)
-  : QUICHandshakeProtocol(pp_key_info), _ssl(SSL_new(ssl_ctx)), _netvc_context(nvc_ctx)
+  : QUICHandshakeProtocol(pp_key_info), _session_file(session_file), _ssl(SSL_new(ssl_ctx)), _netvc_context(nvc_ctx)
 {
   ink_assert(this->_netvc_context != NET_VCONNECTION_UNSET);
 

--- a/iocore/net/quic/QUICTypes.h
+++ b/iocore/net/quic/QUICTypes.h
@@ -448,6 +448,41 @@ private:
   uint64_t _hash_code = 0;
 };
 
+class QUICTPConfig
+{
+public:
+  virtual uint32_t no_activity_timeout() const                 = 0;
+  virtual const IpEndpoint *preferred_address_ipv4() const     = 0;
+  virtual const IpEndpoint *preferred_address_ipv6() const     = 0;
+  virtual uint32_t initial_max_data() const                    = 0;
+  virtual uint32_t initial_max_stream_data_bidi_local() const  = 0;
+  virtual uint32_t initial_max_stream_data_bidi_remote() const = 0;
+  virtual uint32_t initial_max_stream_data_uni() const         = 0;
+  virtual uint64_t initial_max_streams_bidi() const            = 0;
+  virtual uint64_t initial_max_streams_uni() const             = 0;
+  virtual uint8_t ack_delay_exponent() const                   = 0;
+  virtual uint8_t max_ack_delay() const                        = 0;
+};
+
+class QUICLDConfig
+{
+public:
+  virtual uint32_t packet_threshold() const = 0;
+  virtual float time_threshold() const      = 0;
+  virtual ink_hrtime granularity() const    = 0;
+  virtual ink_hrtime initial_rtt() const    = 0;
+};
+
+class QUICCCConfig
+{
+public:
+  virtual uint32_t max_datagram_size() const               = 0;
+  virtual uint32_t initial_window() const                  = 0;
+  virtual uint32_t minimum_window() const                  = 0;
+  virtual float loss_reduction_factor() const              = 0;
+  virtual uint32_t persistent_congestion_threshold() const = 0;
+};
+
 // TODO: move version independent functions to QUICInvariants
 class QUICTypeUtil
 {

--- a/iocore/net/quic/test/test_QUICFrameDispatcher.cc
+++ b/iocore/net/quic/test/test_QUICFrameDispatcher.cc
@@ -36,12 +36,14 @@ TEST_CASE("QUICFrameHandler", "[quic]")
 
   QUICStreamFrame streamFrame(block, 0x03, 0);
 
+  MockQUICLDConfig ld_config;
+  MockQUICCCConfig cc_config;
   MockQUICConnection connection;
   MockQUICStreamManager streamManager;
   MockQUICConnectionInfoProvider info;
-  MockQUICCongestionController cc(&info);
+  MockQUICCongestionController cc(&info, cc_config);
   QUICRTTMeasure rtt_measure;
-  MockQUICLossDetector lossDetector(&info, &cc, &rtt_measure, 0);
+  MockQUICLossDetector lossDetector(&info, &cc, &rtt_measure, 0, ld_config);
 
   QUICFrameDispatcher quicFrameDispatcher(&info);
   quicFrameDispatcher.add_handler(&connection);

--- a/iocore/net/quic/test/test_QUICLossDetector.cc
+++ b/iocore/net/quic/test/test_QUICLossDetector.cc
@@ -36,9 +36,11 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
 
   QUICAckFrameManager afm;
   QUICConnectionId connection_id = {reinterpret_cast<const uint8_t *>("\x01"), 1};
+  MockQUICCCConfig cc_config;
+  MockQUICLDConfig ld_config;
   MockQUICConnectionInfoProvider info;
-  MockQUICCongestionController cc(&info);
-  QUICLossDetector detector(&info, &cc, &rtt_measure, 0);
+  MockQUICCongestionController cc(&info, cc_config);
+  QUICLossDetector detector(&info, &cc, &rtt_measure, 0, ld_config);
   ats_unique_buf payload = ats_unique_malloc(512);
   size_t payload_len     = 512;
   QUICPacketUPtr packet  = QUICPacketFactory::create_null_packet();
@@ -173,9 +175,11 @@ TEST_CASE("QUICLossDetector_HugeGap", "[quic]")
 {
   uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   MockQUICConnectionInfoProvider info;
-  MockQUICCongestionController cc(&info);
+  MockQUICCCConfig cc_config;
+  MockQUICLDConfig ld_config;
+  MockQUICCongestionController cc(&info, cc_config);
   QUICRTTMeasure rtt_measure;
-  QUICLossDetector detector(&info, &cc, &rtt_measure, 0);
+  QUICLossDetector detector(&info, &cc, &rtt_measure, 0, ld_config);
 
   auto t1           = Thread::get_hrtime();
   QUICAckFrame *ack = QUICFrameFactory::create_ack_frame(frame_buf, 100000000, 100, 10000000);


### PR DESCRIPTION
`QUICConfig::scoped_config` was used here and there, and somehow it brought a dependency for libinknet after the refactoring around `QUICMultiCertConfigLoader`.

This PR reduces direct use of `QUICConfig::scoped_config` by introducing `QUICTPConfig`, `QUICLDConfig` and `QUICCCConfig`. Only `QUICPacketHandler`, `QUICNetVConnection` and `QUIC` (global) use `QUICConfig` directly. In other words, no classes under `QUICNetVConnection` use it.

The original motivation was removing dependency for libinknet, but unfortunately it still remains because of functions for OpenSSL callbacks. However, I think this change goes in the right direction.

