### PR TITLE
Doc: open_read_retry_time is overridable

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -2307,6 +2307,7 @@ all the different user-agent versions of documents it encounters.
 
 .. ts:cv:: CONFIG proxy.config.http.cache.open_read_retry_time INT 10
    :reloadable:
+   :overridable:
 
     The number of milliseconds a cacheable request will wait before requesting the object from cache if an equivalent request is in flight.
 


### PR DESCRIPTION
proxy.config.http.cache.open_read_retry_time is overridable

```
$ git grep proxy.config.http.cache.open_read_retry_time | grep InkAPI.cc
src/traffic_server/InkAPI.cc:8630:   {"proxy.config.http.cache.open_read_retry_time", {TS_CONFIG_HTTP_CACHE_OPEN_READ_RETRY_TIME, TS_RECORDDATATYPE_INT}},
```
(i.e. its overridable).