### PR TITLE
Add virtual destructor to SSLMultiCertConfigLoader.

### DIFF
--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -67,6 +67,7 @@ class SSLMultiCertConfigLoader
 {
 public:
   SSLMultiCertConfigLoader(const SSLConfigParams *p) : _params(p) {}
+  virtual ~SSLMultiCertConfigLoader(){};
 
   bool load(SSLCertLookup *lookup);
 


### PR DESCRIPTION
This class now has virtual methods, so it must have a virtual destructor.