### PR TITLE
UrlRewrite: separate constructor and configuration loading for testability

### DIFF
--- a/proxy/ReverseProxy.cc
+++ b/proxy/ReverseProxy.cc
@@ -64,7 +64,7 @@ init_reverse_proxy()
   rewrite_table  = new UrlRewrite();
 
   Note("remap.config loading ...");
-  if (!rewrite_table->is_valid()) {
+  if (!rewrite_table->load()) {
     Fatal("remap.config failed to load");
   }
   Note("remap.config finished loading");
@@ -121,7 +121,7 @@ struct UR_UpdateContinuation : public Continuation {
 bool
 urlRewriteVerify()
 {
-  return UrlRewrite().is_valid();
+  return UrlRewrite().load();
 }
 
 /**
@@ -138,7 +138,7 @@ reloadUrlRewrite()
   Note("remap.config loading ...");
   Debug("url_rewrite", "remap.config updated, reloading...");
   newTable = new UrlRewrite();
-  if (newTable->is_valid()) {
+  if (newTable->load()) {
     static const char *msg = "remap.config finished loading";
 
     // Hold at least one lease, until we reload the configuration

--- a/proxy/http/remap/UrlRewrite.cc
+++ b/proxy/http/remap/UrlRewrite.cc
@@ -1,6 +1,6 @@
 /** @file
 
-  A brief file description
+  URL rewriting.
 
   @section license License
 
@@ -49,20 +49,8 @@ SetHomePageRedirectFlag(url_mapping *new_mapping, URL &new_to_url)
   new_mapping->homePageRedirect = (from_path && !to_path) ? true : false;
 }
 
-//
-// CTOR / DTOR for the UrlRewrite class.
-//
-UrlRewrite::UrlRewrite()
-  : nohost_rules(0),
-    reverse_proxy(0),
-    ts_name(nullptr),
-    http_default_redirect_url(nullptr),
-    num_rules_forward(0),
-    num_rules_reverse(0),
-    num_rules_redirect_permanent(0),
-    num_rules_redirect_temporary(0),
-    num_rules_forward_with_recv_port(0),
-    _valid(false)
+bool
+UrlRewrite::load()
 {
   ats_scoped_str config_file_path;
 
@@ -70,7 +58,7 @@ UrlRewrite::UrlRewrite()
   if (!config_file_path) {
     pmgmt->signalManager(MGMT_SIGNAL_CONFIG_ERROR, "Unable to find proxy.config.url_remap.filename");
     Warning("%s Unable to locate remap.config. No remappings in effect", modulePrefix);
-    return;
+    return false;
   }
 
   this->ts_name = nullptr;
@@ -99,6 +87,7 @@ UrlRewrite::UrlRewrite()
   } else {
     Warning("something failed during BuildTable() -- check your remap plugins!");
   }
+  return _valid;
 }
 
 UrlRewrite::~UrlRewrite()
@@ -662,8 +651,6 @@ UrlRewrite::InsertForwardMapping(mapping_type maptype, url_mapping *mapping, con
 int
 UrlRewrite::BuildTable(const char *path)
 {
-  BUILD_TABLE_INFO bti;
-
   ink_assert(forward_mappings.empty());
   ink_assert(reverse_mappings.empty());
   ink_assert(permanent_redirects.empty());

--- a/proxy/http/remap/UrlRewrite.h
+++ b/proxy/http/remap/UrlRewrite.h
@@ -1,6 +1,6 @@
 /** @file
 
-  A brief file description
+  URL rewriting.
 
   @section license License
 
@@ -57,10 +57,24 @@ class UrlRewrite : public RefCountObj
 {
 public:
   using URLTable = std::unordered_map<std::string, UrlMappingPathIndex *>;
-  UrlRewrite();
+  UrlRewrite()   = default;
   ~UrlRewrite() override;
 
+  /** Load the configuration.
+   *
+   * This access data in librecords to obtain the information needed for loading the configuration.
+   *
+   * @return @c true if the instance state is valid, @c false if not.
+   */
+  bool load();
+
+  /** Build the internal url write tables.
+   *
+   * @param path Path to configuration file.
+   * @return 0 on success, non-zero error code on failure.
+   */
   int BuildTable(const char *path);
+
   mapping_type Remap_redirect(HTTPHdr *request_header, URL *redirect_url);
   bool ReverseMap(HTTPHdr *response_header);
   void SetReverseFlag(int flag);
@@ -182,20 +196,20 @@ public:
                           mapping_container);
   }
 
-  int nohost_rules;
-  int reverse_proxy;
+  int nohost_rules  = 0;
+  int reverse_proxy = 0;
 
-  char *ts_name; // Used to send redirects when no host info
+  char *ts_name = nullptr; // Used to send redirects when no host info
 
-  char *http_default_redirect_url; // Used if redirect in "referer" filtering was not defined properly
-  int num_rules_forward;
-  int num_rules_reverse;
-  int num_rules_redirect_permanent;
-  int num_rules_redirect_temporary;
-  int num_rules_forward_with_recv_port;
+  char *http_default_redirect_url      = nullptr; // Used if redirect in "referer" filtering was not defined properly
+  int num_rules_forward                = 0;
+  int num_rules_reverse                = 0;
+  int num_rules_redirect_permanent     = 0;
+  int num_rules_redirect_temporary     = 0;
+  int num_rules_forward_with_recv_port = 0;
 
 private:
-  bool _valid;
+  bool _valid = false;
 
   bool _mappingLookup(MappingsStore &mappings, URL *request_url, int request_port, const char *request_host, int request_host_len,
                       UrlMappingContainer &mapping_container);


### PR DESCRIPTION
`UrlRewrite` is the top level url rewriting (remappping) object. This

*  Updates the member initialization to be inline instead of in the constructor.
*  Movess the global configuration loading from the constructor to a `load` method.
*  Updates call sites to call `load` and check its return value.

The point of this is twofold. The major one is testability. Currently it's effectively impossible to test url rewriting in a unit test framework, due to the dependency on librecords in the constructor, which is not only a linking / setup nightmare, but makes it impossible to load test configurations. Splitting it means
the test framework can easily adjust the values normally retrieved from librecords to be what is needed for unit tests. The other minor effect is the "remap.config load" messages now happen _before_ the configuration is loaded, instead of after.