### PR TITLE
Fix a self detection issue where parents are not marked down during ATS startup.

### DIFF
--- a/proxy/HostStatus.h
+++ b/proxy/HostStatus.h
@@ -50,11 +50,12 @@ struct HostStatRec_t {
 };
 
 struct Reasons {
-  static constexpr const char *ACTIVE = "active";
-  static constexpr const char *LOCAL  = "local";
-  static constexpr const char *MANUAL = "manual";
+  static constexpr const char *ACTIVE      = "active";
+  static constexpr const char *LOCAL       = "local";
+  static constexpr const char *MANUAL      = "manual";
+  static constexpr const char *SELF_DETECT = "self_detect";
 
-  static constexpr const char *reasons[3] = {ACTIVE, LOCAL, MANUAL};
+  static constexpr const char *reasons[4] = {ACTIVE, LOCAL, MANUAL, SELF_DETECT};
 
   static bool
   validReason(const char *reason)

--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -372,8 +372,7 @@ ParentRecord::PreProcessParents(const char *val, const int line_num, char *buf, 
           continue;
         } else {
           Debug("parent_select", "token: %s, matches this machine.  Marking down self from parent list at line %d", fqdn, line_num);
-          hs.createHostStat(fqdn);
-          hs.setHostStatus(fqdn, HostStatus_t::HOST_STATUS_DOWN, 0, Reasons::MANUAL);
+          hs.setHostStatus(fqdn, HostStatus_t::HOST_STATUS_DOWN, 0, Reasons::SELF_DETECT);
         }
       }
     } else {
@@ -385,8 +384,7 @@ ParentRecord::PreProcessParents(const char *val, const int line_num, char *buf, 
         } else {
           Debug("parent_select", "token: %s, matches this machine.  Marking down self from parent list at line %d", token,
                 line_num);
-          hs.createHostStat(token);
-          hs.setHostStatus(token, HostStatus_t::HOST_STATUS_DOWN, 0, Reasons::MANUAL);
+          hs.setHostStatus(token, HostStatus_t::HOST_STATUS_DOWN, 0, Reasons::SELF_DETECT);
         }
       }
     }
@@ -517,7 +515,9 @@ ParentRecord::ProcessParents(char *val, bool isPrimary)
         memcpy(this->parents[i].hash_string, tmp3 + 1, strlen(tmp3));
         this->parents[i].name = this->parents[i].hash_string;
       }
-      hs.createHostStat(this->parents[i].hostname);
+      if (hs.getHostStatus(this->parents[i].hostname) == HostStatus_t::HOST_STATUS_INIT) {
+        hs.setHostStatus(this->parents[i].hostname, HOST_STATUS_UP, 0, Reasons::MANUAL);
+      }
     } else {
       memcpy(this->secondary_parents[i].hostname, current, tmp - current);
       this->secondary_parents[i].hostname[tmp - current] = '\0';
@@ -533,7 +533,9 @@ ParentRecord::ProcessParents(char *val, bool isPrimary)
         memcpy(this->secondary_parents[i].hash_string, tmp3 + 1, strlen(tmp3));
         this->secondary_parents[i].name = this->secondary_parents[i].hash_string;
       }
-      hs.createHostStat(this->secondary_parents[i].hostname);
+      if (hs.getHostStatus(this->secondary_parents[i].hostname) == HostStatus_t::HOST_STATUS_INIT) {
+        hs.setHostStatus(this->secondary_parents[i].hostname, HOST_STATUS_UP, 0, Reasons::MANUAL);
+      }
     }
     tmp3 = nullptr;
   }

--- a/src/traffic_server/HostStatus.cc
+++ b/src/traffic_server/HostStatus.cc
@@ -120,6 +120,10 @@ HostStatus::setHostStatus(const char *name, HostStatus_t status, const unsigned 
 
   getStatName(reason_stat, name, reason);
 
+  if (getHostStatId(reason_stat.c_str()) == -1) {
+    createHostStat(name);
+  }
+
   int stat_id = getHostStatId(reason_stat.c_str());
 
   // update the stats
@@ -212,7 +216,6 @@ HostStatus::createHostStat(const char *name)
     }
   }
   ink_rwlock_unlock(&host_statids_rwlock);
-  setHostStatus(name, HostStatus_t::HOST_STATUS_UP, 0, nullptr);
 }
 
 int


### PR DESCRIPTION
When proxy.config.http.parent_proxy.self_detect is set to 2 the host in parent.config should be marked down
when that host is the same host ATS is running on ie, self detected.   The fix eliminates multiple calls to createHostStat() which was marking the self detected host back up.  Also, this PR adds a SELF_DETECT reason code used when self detection marks down the host in parent.config. 
