### PR TITLE
Fix AcidPtr test

### DIFF
--- a/src/tscore/unit_tests/test_AcidPtr.cc
+++ b/src/tscore/unit_tests/test_AcidPtr.cc
@@ -94,3 +94,20 @@ TEST_CASE("AcidPtr Isolation")
   }
   CHECK(*p.getPtr() == 42);
 }
+
+TEST_CASE("AcidPtr Abort")
+{
+  AcidPtr<int> p;
+  {
+    AcidCommitPtr<int> w(p);
+    *w = 40;
+  }
+  CHECK(*p.getPtr() == 40);
+  {
+    AcidCommitPtr<int> w = p;
+    *w += 1;
+    w.abort();
+    CHECK(w == nullptr);
+  }
+  CHECK(*p.getPtr() == 40);
+}


### PR DESCRIPTION
Adding a destructor call to appease ASAN build. 
Also adding an abort unit test. 