### PR TITLE
QUIC: Bring back retransmittion test case

### DIFF
--- a/iocore/net/quic/QUICFrameRetransmitter.cc
+++ b/iocore/net/quic/QUICFrameRetransmitter.cc
@@ -175,3 +175,9 @@ QUICFrameRetransmitter::_create_crypto_frame(uint8_t *buf, QUICFrameInformationU
   ink_assert(frame != nullptr);
   return frame;
 }
+
+bool
+QUICFrameRetransmitter::is_retransmited_frame_queue_empty() const
+{
+  return this->_lost_frame_info_queue.empty();
+}

--- a/iocore/net/quic/QUICFrameRetransmitter.h
+++ b/iocore/net/quic/QUICFrameRetransmitter.h
@@ -74,6 +74,7 @@ public:
   virtual QUICFrame *create_retransmitted_frame(uint8_t *buf, QUICEncryptionLevel level, uint16_t maximum_frame_size,
                                                 QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr);
   virtual void save_frame_info(QUICFrameInformationUPtr info);
+  bool is_retransmited_frame_queue_empty() const;
 
 private:
   QUICFrame *_create_stream_frame(uint8_t *buf, QUICFrameInformationUPtr &info, uint16_t maximum_frame_size,

--- a/iocore/net/quic/QUICStream.cc
+++ b/iocore/net/quic/QUICStream.cc
@@ -585,7 +585,8 @@ QUICBidirectionalStream::reenable(VIO *vio)
 bool
 QUICBidirectionalStream::will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp)
 {
-  return this->_local_flow_controller.will_generate_frame(level, timestamp) || (this->_write_vio.get_reader()->read_avail() > 0);
+  return this->_local_flow_controller.will_generate_frame(level, timestamp) || !this->is_retransmited_frame_queue_empty() ||
+         (this->_write_vio.get_reader()->read_avail() > 0);
 }
 
 QUICFrame *
@@ -914,7 +915,7 @@ QUICCryptoStream::write(const uint8_t *buf, int64_t len)
 bool
 QUICCryptoStream::will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp)
 {
-  return this->_write_buffer_reader->is_read_avail_more_than(0);
+  return this->_write_buffer_reader->is_read_avail_more_than(0) || !this->is_retransmited_frame_queue_empty();
 }
 
 /**


### PR DESCRIPTION
Bring back retransmittion test case.

And `will _generate_frame` should return true when the frame is lost.