### PR TITLE
Add nullptr check on ConfigProcessor::release()

### DIFF
--- a/mgmt/ProxyConfig.cc
+++ b/mgmt/ProxyConfig.cc
@@ -188,7 +188,7 @@ ConfigProcessor::release(unsigned int id, ConfigInfo *info)
 
   idx = id - 1;
 
-  if (info->refcount_dec() == 0) {
+  if (info && info->refcount_dec() == 0) {
     // When we release, we should already have replaced this object in the index.
     Debug("config", "Release config %d 0x%" PRId64, id, (int64_t)info);
     ink_release_assert(info != this->infos[idx]);


### PR DESCRIPTION
We saw crash with SSLTicketParams on 8.0.x. It looks like `ConfigProcessor::release(unsigned int id, ConfigInfo *info)` could be called with `info=nullptr`.
```
[ 0  ] libc-2.12.so       __libc_waitpid                                               ( :undefined           ) 
[ 1  ] traffic_server     crash_logger_invoke                                          ( Crash.cc:165         ) 
[ 2  ] libc-2.12.so       0x2b7797255570                                               ( :undefined           ) 
[ 3  ] traffic_server     ink_atomic_increment<int, int>                               ( ink_atomic.h:78      ) 
[ 4  ] traffic_server     refcount_dec                                                 ( Ptr.h:73             ) 
[ 5  ] traffic_server     ConfigProcessor::release(unsigned int, RefCountObj*)         ( ProxyConfig.cc:199   ) 
[ 6  ] traffic_server     release                                                      ( P_SSLConfig.h:199    ) 
[ 7  ] traffic_server     ~scoped_config                                               ( ProxyConfig.h:81     ) 
[ 8  ] traffic_server     SSLTicketParams::LoadTicket()                                ( SSLConfig.cc:626     ) 
[ 9  ] traffic_server     reconfigure                                                  ( SSLConfig.cc:660     ) 
[ 10 ] traffic_server     ConfigUpdateContinuation<SSLTicketKeyConfig>::update(int,... ( ProxyConfig.h:104    ) 
[ 11 ] traffic_server     handleEvent                                                  ( I_Continuation.h:160 ) 
[ 12 ] traffic_server     EThread::process_event(Event*, int)                          ( UnixEThread.cc:131   ) 
[ 13 ] traffic_server     EThread::process_queue(Queue<Event, Event::Link_link>*, i... ( UnixEThread.cc:170   ) 
[ 14 ] traffic_server     EThread::execute_regular()                                   ( UnixEThread.cc:230   ) 
[ 15 ] traffic_server     spawn_thread_internal                                        ( Thread.cc:85         ) 
[ 16 ] libpthread-2.12.so start_thread                                                 ( :undefined           )
```

----
Fix #4735