### PR TITLE
Use IOBufferBlock for sending frame payloads

### DIFF
--- a/iocore/net/P_QUICNetVConnection.h
+++ b/iocore/net/P_QUICNetVConnection.h
@@ -289,11 +289,11 @@ private:
   uint32_t _minimum_quic_packet_size();
   uint64_t _maximum_stream_frame_data_size();
 
-  void _store_frame(ats_unique_buf &buf, size_t &offset, uint64_t &max_frame_size, QUICFrame &frame,
-                    std::vector<QUICFrameInfo> &frames);
+  Ptr<IOBufferBlock> _store_frame(Ptr<IOBufferBlock> parent_block, size_t &size_added, uint64_t &max_frame_size, QUICFrame &frame,
+                                  std::vector<QUICFrameInfo> &frames);
   QUICPacketUPtr _packetize_frames(QUICEncryptionLevel level, uint64_t max_packet_size, std::vector<QUICFrameInfo> &frames);
   void _packetize_closing_frame();
-  QUICPacketUPtr _build_packet(QUICEncryptionLevel level, ats_unique_buf buf, size_t len, bool retransmittable, bool probing,
+  QUICPacketUPtr _build_packet(QUICEncryptionLevel level, Ptr<IOBufferBlock> parent_block, bool retransmittable, bool probing,
                                bool crypto);
 
   QUICConnectionErrorUPtr _recv_and_ack(QUICPacket &packet, bool *has_non_probing_frame = nullptr);

--- a/iocore/net/quic/QUICFrame.cc
+++ b/iocore/net/quic/QUICFrame.cc
@@ -105,6 +105,22 @@ QUICFrame::type(const uint8_t *buf)
   }
 }
 
+Ptr<IOBufferBlock>
+QUICFrame::to_io_buffer_block(size_t limit) const
+{
+  // FIXME Each classes should override this and drop store().
+  // This just wraps store() for now.
+
+  Ptr<IOBufferBlock> block = make_ptr<IOBufferBlock>(new_IOBufferBlock());
+  block->alloc(iobuffer_size_to_index(limit));
+
+  size_t written_len = 0;
+  this->store(reinterpret_cast<uint8_t *>(block->start()), &written_len, limit);
+  block->fill(written_len);
+
+  return block;
+}
+
 int
 QUICFrame::debug_msg(char *msg, size_t msg_len) const
 {

--- a/iocore/net/quic/QUICFrame.h
+++ b/iocore/net/quic/QUICFrame.h
@@ -56,6 +56,7 @@ public:
   virtual bool is_probing_frame() const;
   virtual bool is_flow_controlled() const;
   virtual size_t store(uint8_t *buf, size_t *len, size_t limit) const = 0;
+  virtual Ptr<IOBufferBlock> to_io_buffer_block(size_t limit) const;
   virtual int debug_msg(char *msg, size_t msg_len) const;
   virtual void parse(const uint8_t *buf, size_t len){};
   virtual QUICFrameGenerator *generated_by();

--- a/iocore/net/quic/QUICPacketPayloadProtector.cc
+++ b/iocore/net/quic/QUICPacketPayloadProtector.cc
@@ -28,8 +28,8 @@
 static constexpr char tag[] = "quic_ppp";
 
 Ptr<IOBufferBlock>
-QUICPacketPayloadProtector::protect(Ptr<IOBufferBlock> unprotected_header, Ptr<IOBufferBlock> unprotected_payload, uint64_t pkt_num,
-                                    QUICKeyPhase phase) const
+QUICPacketPayloadProtector::protect(const Ptr<IOBufferBlock> unprotected_header, const Ptr<IOBufferBlock> unprotected_payload,
+                                    uint64_t pkt_num, QUICKeyPhase phase) const
 {
   Ptr<IOBufferBlock> protected_payload;
   protected_payload = nullptr;
@@ -62,8 +62,8 @@ QUICPacketPayloadProtector::protect(Ptr<IOBufferBlock> unprotected_header, Ptr<I
 }
 
 Ptr<IOBufferBlock>
-QUICPacketPayloadProtector::unprotect(Ptr<IOBufferBlock> unprotected_header, Ptr<IOBufferBlock> protected_payload, uint64_t pkt_num,
-                                      QUICKeyPhase phase) const
+QUICPacketPayloadProtector::unprotect(const Ptr<IOBufferBlock> unprotected_header, const Ptr<IOBufferBlock> protected_payload,
+                                      uint64_t pkt_num, QUICKeyPhase phase) const
 {
   Ptr<IOBufferBlock> unprotected_payload;
   unprotected_payload = nullptr;
@@ -87,7 +87,7 @@ QUICPacketPayloadProtector::unprotect(Ptr<IOBufferBlock> unprotected_header, Ptr
                         reinterpret_cast<uint8_t *>(unprotected_header->buf()), unprotected_header->size(), key, iv, iv_len, aead,
                         tag_len)) {
     Debug(tag, "Failed to decrypt a packet #%" PRIu64, pkt_num);
-    unprotected_header = nullptr;
+    unprotected_payload = nullptr;
   } else {
     unprotected_payload->fill(written_len);
   }

--- a/iocore/net/quic/QUICPacketPayloadProtector.h
+++ b/iocore/net/quic/QUICPacketPayloadProtector.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include "I_IOBuffer.h"
 #include "QUICTypes.h"
 #include "QUICKeyGenerator.h"
 
@@ -33,10 +34,10 @@ class QUICPacketPayloadProtector
 public:
   QUICPacketPayloadProtector(const QUICPacketProtectionKeyInfo &pp_key_info) : _pp_key_info(pp_key_info) {}
 
-  bool unprotect(uint8_t *plain, size_t &plain_len, size_t max_plain_len, const uint8_t *cipher, size_t cipher_len,
-                 uint64_t pkt_num, const uint8_t *ad, size_t ad_len, QUICKeyPhase phase) const;
-  bool protect(uint8_t *cipher, size_t &cipher_len, size_t max_cipher_len, const uint8_t *plain, size_t plain_len, uint64_t pkt_num,
-               const uint8_t *ad, size_t ad_len, QUICKeyPhase phase) const;
+  Ptr<IOBufferBlock> protect(Ptr<IOBufferBlock> unprotected_header, Ptr<IOBufferBlock> unprotected_payload, uint64_t pkt_num,
+                             QUICKeyPhase phase) const;
+  Ptr<IOBufferBlock> unprotect(Ptr<IOBufferBlock> unprotected_header, Ptr<IOBufferBlock> protected_payload, uint64_t pkt_num,
+                               QUICKeyPhase phase) const;
 
 private:
   const QUICPacketProtectionKeyInfo &_pp_key_info;
@@ -44,9 +45,9 @@ private:
   bool _unprotect(uint8_t *plain, size_t &plain_len, size_t max_plain_len, const uint8_t *cipher, size_t cipher_len,
                   uint64_t pkt_num, const uint8_t *ad, size_t ad_len, const uint8_t *key, const uint8_t *iv, size_t iv_len,
                   const QUIC_EVP_CIPHER *aead, size_t tag_len) const;
-  bool _protect(uint8_t *cipher, size_t &cipher_len, size_t max_cipher_len, const uint8_t *plain, size_t plain_len,
-                uint64_t pkt_num, const uint8_t *ad, size_t ad_len, const uint8_t *key, const uint8_t *iv, size_t iv_len,
-                const QUIC_EVP_CIPHER *aead, size_t tag_len) const;
+  bool _protect(uint8_t *cipher, size_t &cipher_len, size_t max_cipher_len, Ptr<IOBufferBlock> plain, uint64_t pkt_num,
+                const uint8_t *ad, size_t ad_len, const uint8_t *key, const uint8_t *iv, size_t iv_len, const QUIC_EVP_CIPHER *aead,
+                size_t tag_len) const;
 
   void _gen_nonce(uint8_t *nonce, size_t &nonce_len, uint64_t pkt_num, const uint8_t *iv, size_t iv_len) const;
 };

--- a/iocore/net/quic/QUICPacketPayloadProtector.h
+++ b/iocore/net/quic/QUICPacketPayloadProtector.h
@@ -34,10 +34,10 @@ class QUICPacketPayloadProtector
 public:
   QUICPacketPayloadProtector(const QUICPacketProtectionKeyInfo &pp_key_info) : _pp_key_info(pp_key_info) {}
 
-  Ptr<IOBufferBlock> protect(Ptr<IOBufferBlock> unprotected_header, Ptr<IOBufferBlock> unprotected_payload, uint64_t pkt_num,
-                             QUICKeyPhase phase) const;
-  Ptr<IOBufferBlock> unprotect(Ptr<IOBufferBlock> unprotected_header, Ptr<IOBufferBlock> protected_payload, uint64_t pkt_num,
-                               QUICKeyPhase phase) const;
+  Ptr<IOBufferBlock> protect(const Ptr<IOBufferBlock> unprotected_header, const Ptr<IOBufferBlock> unprotected_payload,
+                             uint64_t pkt_num, QUICKeyPhase phase) const;
+  Ptr<IOBufferBlock> unprotect(const Ptr<IOBufferBlock> unprotected_header, const Ptr<IOBufferBlock> protected_payload,
+                               uint64_t pkt_num, QUICKeyPhase phase) const;
 
 private:
   const QUICPacketProtectionKeyInfo &_pp_key_info;
@@ -45,7 +45,7 @@ private:
   bool _unprotect(uint8_t *plain, size_t &plain_len, size_t max_plain_len, const uint8_t *cipher, size_t cipher_len,
                   uint64_t pkt_num, const uint8_t *ad, size_t ad_len, const uint8_t *key, const uint8_t *iv, size_t iv_len,
                   const QUIC_EVP_CIPHER *aead, size_t tag_len) const;
-  bool _protect(uint8_t *cipher, size_t &cipher_len, size_t max_cipher_len, Ptr<IOBufferBlock> plain, uint64_t pkt_num,
+  bool _protect(uint8_t *cipher, size_t &cipher_len, size_t max_cipher_len, const Ptr<IOBufferBlock> plain, uint64_t pkt_num,
                 const uint8_t *ad, size_t ad_len, const uint8_t *key, const uint8_t *iv, size_t iv_len, const QUIC_EVP_CIPHER *aead,
                 size_t tag_len) const;
 

--- a/iocore/net/quic/QUICPacketPayloadProtector_openssl.cc
+++ b/iocore/net/quic/QUICPacketPayloadProtector_openssl.cc
@@ -28,9 +28,9 @@
 static constexpr char tag[] = "quic_ppp";
 
 bool
-QUICPacketPayloadProtector::_protect(uint8_t *cipher, size_t &cipher_len, size_t max_cipher_len, const uint8_t *plain,
-                                     size_t plain_len, uint64_t pkt_num, const uint8_t *ad, size_t ad_len, const uint8_t *key,
-                                     const uint8_t *iv, size_t iv_len, const EVP_CIPHER *aead, size_t tag_len) const
+QUICPacketPayloadProtector::_protect(uint8_t *cipher, size_t &cipher_len, size_t max_cipher_len, Ptr<IOBufferBlock> plain,
+                                     uint64_t pkt_num, const uint8_t *ad, size_t ad_len, const uint8_t *key, const uint8_t *iv,
+                                     size_t iv_len, const EVP_CIPHER *aead, size_t tag_len) const
 {
   EVP_CIPHER_CTX *aead_ctx;
   int len;
@@ -54,12 +54,17 @@ QUICPacketPayloadProtector::_protect(uint8_t *cipher, size_t &cipher_len, size_t
   if (!EVP_EncryptUpdate(aead_ctx, nullptr, &len, ad, ad_len)) {
     return false;
   }
-  if (!EVP_EncryptUpdate(aead_ctx, cipher, &len, plain, plain_len)) {
-    return false;
-  }
-  cipher_len = len;
 
-  if (!EVP_EncryptFinal_ex(aead_ctx, cipher + len, &len)) {
+  cipher_len = 0;
+  while (plain) {
+    if (!EVP_EncryptUpdate(aead_ctx, cipher + cipher_len, &len, reinterpret_cast<unsigned char *>(plain->buf()), plain->size())) {
+      return false;
+    }
+    cipher_len += len;
+    plain = plain->next;
+  }
+
+  if (!EVP_EncryptFinal_ex(aead_ctx, cipher + cipher_len, &len)) {
     return false;
   }
   cipher_len += len;


### PR DESCRIPTION
The idea is using IOBufferBlock instead of std::unique_ptr<uint8_t> to reduce a number of copies, which was discussed on QUIC ATS Hackathon in Jan 2018.

On this PR, to not make a huge change on it, I changed only QUICFrame and QUICPacketPayloadProtector as a preparation for the goal. I'm going to make changes for QUICPacket on #5125, and I may create one more PR for QUICHeaderProtector and QUICPacketHandler.

Because QUICPacket has not changed yet, there are few code that copies data from IOBufferBlock to ats_unique_buf. I had to add them to keep code runnable, but they will be removed on the following PRs.

<img width="1811" alt="image" src="https://user-images.githubusercontent.com/153144/54325914-db74d480-4647-11e9-9fdd-72ed55f5488b.png">
