### PR TITLE
Fix Makefile.am to run clang-tidy

### DIFF
--- a/proxy/Makefile.am
+++ b/proxy/Makefile.am
@@ -62,7 +62,7 @@ libproxy_a_SOURCES = \
 	ProxyClientSession.cc \
 	ProxyClientSession.h \
 	ProxyClientTransaction.cc \
-	ProxyClientTransaction \
+	ProxyClientTransaction.h \
 	ReverseProxy.cc \
 	ReverseProxy.h \
 	StatPages.cc \
@@ -164,3 +164,6 @@ install-data-hook:
 		chown -R $(pkgsysuser):$(pkgsysgroup) $(DESTDIR)$(pkgsysconfdir) $(DESTDIR)$(pkgdatadir);\
 	fi
 	-echo "<TS_VERSION> $(PACKAGE_VERSION)" > $(DESTDIR)$(pkgsysconfdir)/trafficserver-release
+
+clang-tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -43,4 +43,3 @@ include traffic_logcat/Makefile.inc
 
 clang-tidy-local: $(DIST_SOURCES)
 	$(CXX_Clang_Tidy)
-	$(CC_Clang_Tidy)

--- a/src/tscore/Makefile.am
+++ b/src/tscore/Makefile.am
@@ -48,162 +48,74 @@ libtscore_la_LIBADD = \
 	-lc
 
 libtscore_la_SOURCES = \
-	Allocator.h \
 	AcidPtr.cc \
-	AcidPtr.h \
 	Arena.cc \
-	Arena.h \
 	ArgParser.cc \
-	ArgParser.h \
 	BaseLogFile.cc \
-	BaseLogFile.h \
-	BufferWriter.h \
-	BufferWriterForward.h \
 	BufferWriterFormat.cc \
 	ConsistentHash.cc \
-	ConsistentHash.h \
 	ContFlags.cc \
-	ContFlags.h \
 	CryptoHash.cc \
-	CryptoHash.h \
-	defalloc.h \
 	Diags.cc \
-	Diags.h \
 	EventNotify.cc \
-	EventNotify.h \
-	Extendible.h \
 	fastlz.c \
-	fastlz.h \
 	Hash.cc \
 	HashFNV.cc \
-	HashFNV.h \
-	Hash.h \
 	HashMD5.cc \
-	HashMD5.h \
 	HashSip.cc \
-	HashSip.h \
-	History.h \
 	HostLookup.cc \
-	HostLookup.h \
 	hugepages.cc \
-	hugepages.h \
-	I_Layout.h \
-	ink_aiocb.h \
-	ink_align.h \
-	ink_apidefs.h \
 	ink_args.cc \
-	ink_args.h \
 	ink_assert.cc \
-	ink_assert.h \
-	ink_atomic.h \
 	ink_base64.cc \
-	ink_base64.h \
 	ink_cap.cc \
-	ink_cap.h \
 	ink_code.cc \
-	ink_code.h \
 	ink_defs.cc \
-	ink_defs.h \
 	InkErrno.cc \
-	InkErrno.h \
 	ink_error.cc \
-	ink_error.h \
-	ink_exception.h \
 	ink_file.cc \
-	ink_file.h \
 	ink_hrtime.cc \
-	ink_hrtime.h \
 	ink_inet.cc \
-	ink_inet.h \
-	ink_inout.h \
-	ink_llqueue.h \
-	ink_lockfile.h \
-	INK_MD5.h \
 	ink_memory.cc \
-	ink_memory.h \
 	ink_mutex.cc \
-	ink_mutex.h \
-	ink_platform.h \
 	ink_queue.cc \
-	ink_queue.h \
 	ink_queue_utils.cc \
 	ink_rand.cc \
-	ink_rand.h \
 	ink_res_init.cc \
 	ink_res_mkquery.cc \
-	ink_resolver.h \
 	ink_resource.cc \
-	ink_resource.h \
 	ink_rwlock.cc \
-	ink_rwlock.h \
 	ink_sock.cc \
-	ink_sock.h \
 	ink_sprintf.cc \
-	ink_sprintf.h \
 	ink_stack_trace.cc \
-	ink_stack_trace.h \
 	ink_string.cc \
 	ink_string++.cc \
-	ink_string.h \
-	ink_string++.h \
 	ink_sys_control.cc \
-	ink_sys_control.h \
 	ink_syslog.cc \
-	ink_syslog.h \
 	ink_thread.cc \
-	ink_thread.h \
 	ink_time.cc \
-	ink_time.h \
 	ink_uuid.cc \
-	ink_uuid.h \
 	IpMap.cc \
 	IpMapConf.cc \
-	IpMapConf.h \
-	IpMap.h \
-	I_Version.h \
-	JeAllocator.h \
 	JeAllocator.cc \
 	Layout.cc \
-	List.h \
 	llqueue.cc \
 	lockfile.cc \
 	MatcherUtils.cc \
-	MatcherUtils.h \
-	MemSpan.h \
 	MemArena.cc \
-	MemArena.h \
 	MMH.cc \
-	MMH.h \
-	MT_hashtable.h \
 	ParseRules.cc \
-	ParseRules.h \
-	PriorityQueue.h \
-	Ptr.h \
 	RbTree.cc \
-	RbTree.h \
 	Regex.cc \
-	Regex.h \
 	Regression.cc \
-	Regression.h \
-	Result.h \
 	runroot.cc \
-	runroot.h \
 	signals.cc \
-	signals.h \
-	SimpleTokenizer.h \
 	SourceLocation.cc \
-	SourceLocation.h \
-	TestBox.h \
 	TextBuffer.cc \
-	TextBuffer.h \
 	Tokenizer.cc \
-	Tokenizer.h \
-	Trie.h \
-	TsBuffer.h \
-	ts_file. h ts_file.cc \
+	ts_file.cc \
 	Version.cc \
-	X509HostnameValidator.cc \
-	X509HostnameValidator.h
+	X509HostnameValidator.cc
 
 BufferWriterFormat.o : AM_CPPFLAGS += -Wno-char-subscripts
 

--- a/src/tscpp/api/Makefile.am
+++ b/src/tscpp/api/Makefile.am
@@ -15,6 +15,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+include $(top_srcdir)/build/tidy.mk
+
 lib_LTLIBRARIES = libtscppapi.la
 
 libtscppapi_la_CPPFLAGS = $(AM_CPPFLAGS) -I $(abs_top_srcdir)/include
@@ -47,3 +49,5 @@ libtscppapi_la_SOURCES = \
 	utils.cc \
 	utils_internal.cc
 
+clang-tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)

--- a/src/tscpp/util/Makefile.am
+++ b/src/tscpp/util/Makefile.am
@@ -16,6 +16,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+include $(top_srcdir)/build/tidy.mk
+
 check_PROGRAMS = test_tscpputil
 
 TESTS = $(check_PROGRAMS)
@@ -27,9 +29,7 @@ AM_CPPFLAGS += -I$(abs_top_srcdir)/include
 libtscpputil_la_LDFLAGS = -no-undefined -version-info @TS_LIBTOOL_VERSION@
 
 libtscpputil_la_SOURCES = \
-	IntrusiveDList.h \
-	PostScript.h \
-	TextView.h TextView.cc
+	TextView.cc
 
 test_tscpputil_CPPFLAGS = $(AM_CPPFLAGS)\
 	-I$(abs_top_srcdir)/tests/include
@@ -48,4 +48,3 @@ clean-local:
 
 clang-tidy-local: $(DIST_SOURCES)
 	$(CXX_Clang_Tidy)
-

--- a/src/wccp/Makefile.am
+++ b/src/wccp/Makefile.am
@@ -41,3 +41,5 @@ libwccp_a_SOURCES = \
 	WccpStatic.cc \
 	WccpUtil.h
 
+clang-tidy-local: $(DIST_SOURCES)
+	$(CXX_Clang_Tidy)


### PR DESCRIPTION
Restructuring library headers broke clang-tidy make target.

```
Making clang-tidy in src/tscpp/util
make[1]: *** No rule to make target `IntrusiveDList.h', needed by `clang-tidy-local'.  Stop.
make: *** [clang-tidy-recursive] Error 1
```

1. Remove header files from `libtscore_la_SOURCES` and `libtscpputil_la_SOURCES`. Because it should be included by appropriate cc files.
2. Remove `$(CC_Clang_Tidy)` from `src/Makefile.am`. Because there're no C files under `src/`.
3. Fix lack of `including tidy.mk` or `clang-tidy-local` target.