### PR TITLE
Run clang-tidy one by one

### DIFF
--- a/build/tidy.mk
+++ b/build/tidy.mk
@@ -23,12 +23,12 @@ Clang_Tidy_Options = -fix -fix-errors -header-filter=.*
 Clang_Tidy_CC_Files = $(filter %.c, $(sort $(1)))
 Clang_Tidy_CXX_Files = $(filter %.cc, $(sort $(1)))
 
-#clang-tidy rules. We expect these to be actions with something like
-#$(DIST_SOURCES) as the dependencies.rules. Note that $DIST_SOURCES
-#is not an automake API, it is an implementation detail, but it ought
-#to be stable enough.
+# clang-tidy rules. We expect these to be actions with something like
+# $(DIST_SOURCES) as the dependencies.rules. Note that $DIST_SOURCES
+# is not an automake API, it is an implementation detail, but it ought
+# to be stable enough.
 #
-#All this clearly requires GNU make.
+# All this clearly requires GNU make.
 
-CXX_Clang_Tidy = $(CLANG_TIDY) $(Clang_Tidy_Options) $(call Clang_Tidy_CXX_Files,$^) -- $(CXXCOMPILE) -x c++
-CC_Clang_Tidy = $(CLANG_TIDY) $(Clang_Tidy_Options) $(call Clang_Tidy_CC_Files,$^) -- $(COMPILE) -x c
+CXX_Clang_Tidy = $(foreach tidy_target, $(call Clang_Tidy_CXX_Files,$^), $(CLANG_TIDY) $(Clang_Tidy_Options) $(tidy_target) -- $(CXXCOMPILE) -x c++;)
+CC_Clang_Tidy = $(foreach tidy_target, $(call Clang_Tidy_CC_Files,$^), $(CLANG_TIDY) $(Clang_Tidy_Options) $(tidy_target) -- $(COMPILE) -x c;)


### PR DESCRIPTION
I saw clang-tidy makes wired changes like below. (to run `make clang-tidy`, #5167 is required)
```
diff --git a/include/tscpp/api/Async.h b/include/tscpp/api/Async.h
index b392f494e..210ef5f6b 100644
--- a/include/tscpp/api/Async.h
+++ b/include/tscpp/api/Async.h
@@ -105,7 +116,7 @@ private:
   void
   doRun(std::shared_ptr<AsyncDispatchControllerBase> dispatch_controller)
   {
-    dispatch_controller_ = dispatch_controller;
+    dispatch_controller_ = std::move(std::move(std::move(std::move(std::move(std::move(std::move(std::move(std::move(std::move(std::move(dispatch_controller)))))))))));
     run();
   }
```

Probably, clang-tidy made same change many times. Because the header (Async.h in above) is included by multiple files and clang-tidy ran with these files in same time.

FWIW, I'm using below version.
```
$ clang-tidy -version
LLVM (http://llvm.org/):
  LLVM version 7.0.1
  Optimized build.
  Default target: x86_64-apple-darwin18.2.0
  Host CPU: skylake
``` 