### PR TITLE
Don't create packets on encryption levels already done

### DIFF
--- a/iocore/net/P_QUICNetVConnection.h
+++ b/iocore/net/P_QUICNetVConnection.h
@@ -284,6 +284,8 @@ private:
   void _unschedule_ack_manager_periodic();
   Event *_ack_manager_periodic = nullptr;
 
+  QUICEncryptionLevel _minimum_encryption_level = QUICEncryptionLevel::INITIAL;
+
   QUICPacketNumber _largest_acked_packet_number(QUICEncryptionLevel level) const;
   uint32_t _maximum_quic_packet_size() const;
   uint32_t _minimum_quic_packet_size();


### PR DESCRIPTION
After dropping keys for an encryption level, we should not create packets that use the dropped key.

Currently ATS tries to create INITIAL packets after dropping keys for the encryption level, and it seems like to cause an abort below.

```
[Mar 15 16:30:37.113] [ET_NET 6] DEBUG: <QUICPacketFactory.cc:309 (_create_encrypted_packet> (v_quic_packet       ) [83411b05-e5a129af] Encrypting INITIAL packet #2 using CLEARTEXT
=================================================================
==447==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7f5a4c080a28 at pc 0x000000eb431b bp 0x7f5a4c080870 sp 0x7f5a4c080860
READ of size 1 at 0x7f5a4c080a28 thread T8 ([ET_NET 6])
    #0 0xeb431a in QUICPacketPayloadProtector::_gen_nonce(unsigned char*, unsigned long&, unsigned long, unsigned char const*, unsigned long) const /usr/local/src/trafficserver/iocore/net/quic/QUICPacketPayloadProtector.cc:98
    #1 0xeb461b in QUICPacketPayloadProtector::_protect(unsigned char*, unsigned long&, unsigned long, unsigned char const*, unsigned long, unsigned long, unsigned char const*, unsigned long, unsigned char const*, unsigned char const*, unsigned long, evp_cipher_st const*, unsigned long) const /usr/local/src/trafficserver/iocore/net/quic/QUICPacketPayloadProtector_openssl.cc:40
    #2 0xeb3a12 in QUICPacketPayloadProtector::protect(unsigned char*, unsigned long&, unsigned long, unsigned char const*, unsigned long, unsigned long, unsigned char const*, unsigned long, QUICKeyPhase) const /usr/local/src/trafficserver/iocore/net/quic/QUICPacketPayloadProtector.cc:45
    #3 0xe5b17a in QUICPacketFactory::_create_encrypted_packet(std::unique_ptr<QUICPacketHeader, void (*)(QUICPacketHeader*)>, bool, bool) /usr/local/src/trafficserver/iocore/net/quic/QUICPacketFactory.cc:312
    #4 0xe58705 in QUICPacketFactory::create_initial_packet(QUICConnectionId, QUICConnectionId, unsigned long, std::unique_ptr<unsigned char [], ats_unique_buf_deleter>, unsigned long, bool, bool, bool, std::unique_ptr<unsigned char [], ats_unique_buf_deleter>, unsigned long) /usr/local/src/trafficserver/iocore/net/quic/QUICPacketFactory.cc:208
```