### PR TITLE
Ran clang-tidy

### DIFF
--- a/include/ts/apidefs.h.in
+++ b/include/ts/apidefs.h.in
@@ -43,7 +43,7 @@
  */
 
 #include <stdbool.h>
-#include <stdint.h>
+#include <stdint.h> // NOLINT(modernize-deprecated-headers)
 #include <sys/types.h>
 #include <sys/socket.h>
 

--- a/include/tscore/EventNotify.h
+++ b/include/tscore/EventNotify.h
@@ -36,12 +36,12 @@ class EventNotify
 {
 public:
   EventNotify();
-  void signal(void);
-  int wait(void);
+  void signal();
+  int wait();
   int timedwait(int timeout); // milliseconds
-  void lock(void);
-  bool trylock(void);
-  void unlock(void);
+  void lock();
+  bool trylock();
+  void unlock();
   ~EventNotify();
 
 private:

--- a/include/tscore/Extendible.h
+++ b/include/tscore/Extendible.h
@@ -30,7 +30,7 @@
  */
 
 #pragma once
-#include "stdint.h"
+#include <cstdint>
 #include <typeinfo>
 #include <typeindex>
 #include <cstddef>
@@ -60,7 +60,7 @@ enum AccessEnum { ATOMIC, BIT, STATIC, ACIDPTR, DIRECT, C_API, NUM_ACCESS_TYPES 
 inline bool &
 areStaticsFrozen()
 {
-  static bool frozen = 0;
+  static bool frozen = false;
   return frozen;
 }
 

--- a/include/tscore/Hash.h
+++ b/include/tscore/Hash.h
@@ -27,8 +27,8 @@
 
 struct ATSHashBase {
   virtual void update(const void *, size_t) = 0;
-  virtual void final(void)                  = 0;
-  virtual void clear(void)                  = 0;
+  virtual void final()                      = 0;
+  virtual void clear()                      = 0;
   virtual ~ATSHashBase();
 };
 
@@ -49,17 +49,17 @@ struct ATSHash : ATSHashBase {
     }
   };
 
-  virtual const void *get(void) const = 0;
-  virtual size_t size(void) const     = 0;
+  virtual const void *get() const = 0;
+  virtual size_t size() const     = 0;
   virtual bool operator==(const ATSHash &) const;
 };
 
 struct ATSHash32 : ATSHashBase {
-  virtual uint32_t get(void) const = 0;
+  virtual uint32_t get() const = 0;
   virtual bool operator==(const ATSHash32 &) const;
 };
 
 struct ATSHash64 : ATSHashBase {
-  virtual uint64_t get(void) const = 0;
+  virtual uint64_t get() const = 0;
   virtual bool operator==(const ATSHash64 &) const;
 };

--- a/include/tscore/HashFNV.h
+++ b/include/tscore/HashFNV.h
@@ -31,7 +31,7 @@
 #include <cstdint>
 
 struct ATSHash32FNV1a : ATSHash32 {
-  ATSHash32FNV1a(void);
+  ATSHash32FNV1a();
 
   template <typename Transform> void update(const void *data, size_t len, Transform xfrm);
   void
@@ -40,9 +40,9 @@ struct ATSHash32FNV1a : ATSHash32 {
     update(data, len, ATSHash::nullxfrm());
   }
 
-  void final(void) override;
-  uint32_t get(void) const override;
-  void clear(void) override;
+  void final() override;
+  uint32_t get() const override;
+  void clear() override;
 
 private:
   uint32_t hval;
@@ -62,7 +62,7 @@ ATSHash32FNV1a::update(const void *data, size_t len, Transform xfrm)
 }
 
 struct ATSHash64FNV1a : ATSHash64 {
-  ATSHash64FNV1a(void);
+  ATSHash64FNV1a();
 
   template <typename Transform> void update(const void *data, size_t len, Transform xfrm);
   void
@@ -71,9 +71,9 @@ struct ATSHash64FNV1a : ATSHash64 {
     update(data, len, ATSHash::nullxfrm());
   }
 
-  void final(void) override;
-  uint64_t get(void) const override;
-  void clear(void) override;
+  void final() override;
+  uint64_t get() const override;
+  void clear() override;
 
 private:
   uint64_t hval;

--- a/include/tscore/HashMD5.h
+++ b/include/tscore/HashMD5.h
@@ -25,12 +25,12 @@
 #include <openssl/evp.h>
 
 struct ATSHashMD5 : ATSHash {
-  ATSHashMD5(void);
+  ATSHashMD5();
   void update(const void *data, size_t len) override;
-  void final(void) override;
-  const void *get(void) const override;
-  size_t size(void) const override;
-  void clear(void) override;
+  void final() override;
+  const void *get() const override;
+  size_t size() const override;
+  void clear() override;
   ~ATSHashMD5() override;
 
 private:

--- a/include/tscore/HashSip.h
+++ b/include/tscore/HashSip.h
@@ -32,13 +32,13 @@
  */
 
 struct ATSHash64Sip24 : ATSHash64 {
-  ATSHash64Sip24(void);
+  ATSHash64Sip24();
   ATSHash64Sip24(const unsigned char key[16]);
   ATSHash64Sip24(std::uint64_t key0, std::uint64_t key1);
   void update(const void *data, std::size_t len) override;
-  void final(void) override;
-  std::uint64_t get(void) const override;
-  void clear(void) override;
+  void final() override;
+  std::uint64_t get() const override;
+  void clear() override;
 
 private:
   unsigned char block_buffer[8] = {0};

--- a/include/tscore/List.h
+++ b/include/tscore/List.h
@@ -507,7 +507,7 @@ template <class C, class L = typename C::Link_link> struct SortableQueue : publi
 
 template <class C, class L = typename C::Link_link> struct CountQueue : public Queue<C, L> {
   int size;
-  inline CountQueue(void) : size(0) {}
+  inline CountQueue() : size(0) {}
   inline void push(C *e);
   inline C *pop();
   inline void enqueue(C *e);

--- a/include/tscore/MT_hashtable.h
+++ b/include/tscore/MT_hashtable.h
@@ -77,7 +77,7 @@ public:
 template <class key_t, class data_t> class IMTHashTable
 {
 public:
-  IMTHashTable(int size, bool (*gc_func)(data_t) = NULL, void (*pre_gc_func)(void) = nullptr)
+  IMTHashTable(int size, bool (*gc_func)(data_t) = NULL, void (*pre_gc_func)() = nullptr)
   {
     m_gc_func     = gc_func;
     m_pre_gc_func = pre_gc_func;
@@ -136,7 +136,7 @@ public:
   data_t remove_entry(HashTableIteratorState<key_t, data_t> *s);
 
   void
-  GC(void)
+  GC()
   {
     if (m_gc_func == NULL) {
       return;
@@ -195,7 +195,7 @@ private:
   int cur_size;
   int bucket_num;
   bool (*m_gc_func)(data_t);
-  void (*m_pre_gc_func)(void);
+  void (*m_pre_gc_func)();
 
 private:
   IMTHashTable();
@@ -336,7 +336,7 @@ IMTHashTable<key_t, data_t>::remove_entry(HashTableIteratorState<key_t, data_t> 
 template <class key_t, class data_t> class MTHashTable
 {
 public:
-  MTHashTable(int size, bool (*gc_func)(data_t) = NULL, void (*pre_gc_func)(void) = nullptr)
+  MTHashTable(int size, bool (*gc_func)(data_t) = NULL, void (*pre_gc_func)() = nullptr)
   {
     for (int i = 0; i < MT_HASHTABLE_PARTITIONS; i++) {
       locks[i]      = new_ProxyMutex();

--- a/include/tscore/hugepages.h
+++ b/include/tscore/hugepages.h
@@ -22,8 +22,8 @@
 
 #include <cstring>
 
-size_t ats_hugepage_size(void);
-bool ats_hugepage_enabled(void);
+size_t ats_hugepage_size();
+bool ats_hugepage_enabled();
 void ats_hugepage_init(int);
 void *ats_alloc_hugepage(size_t);
 bool ats_free_hugepage(void *, size_t);

--- a/include/tscore/ink_defs.h
+++ b/include/tscore/ink_defs.h
@@ -24,17 +24,17 @@
 #pragma once
 
 #include "tscore/ink_config.h"
-#include <stddef.h>
+#include <stddef.h> // NOLINT(modernize-deprecated-headers)
 #include <sys/mman.h>
 
 #ifdef HAVE_STDINT_H
-#include <stdint.h>
+#include <stdint.h> // NOLINT(modernize-deprecated-headers)
 #else
 // TODO: Add "standard" int types?
 #endif
 
 #ifdef HAVE_INTTYPES_H
-#include <inttypes.h>
+#include <inttypes.h> // NOLINT(modernize-deprecated-headers)
 #else
 // TODO: add PRI*64 stuff?
 #endif

--- a/include/tscore/ink_error.h
+++ b/include/tscore/ink_error.h
@@ -31,8 +31,8 @@
 
 #pragma once
 
-#include <stdarg.h>
-#include <stdio.h>
+#include <cstdarg>
+#include <cstdio>
 #include "tscore/ink_platform.h"
 #include "tscore/ink_apidefs.h"
 

--- a/include/tscore/ink_llqueue.h
+++ b/include/tscore/ink_llqueue.h
@@ -43,7 +43,7 @@ typedef struct llq_s {
   ink_semaphore sema;
 } LLQ;
 
-LLQ *create_queue(void);
+LLQ *create_queue();
 int enqueue(LLQ *q, void *data);
 void *dequeue(LLQ *q);
 bool queue_is_empty(LLQ *q);

--- a/include/tscore/ink_lockfile.h
+++ b/include/tscore/ink_lockfile.h
@@ -33,10 +33,10 @@
 class Lockfile
 {
 public:
-  Lockfile(void) : fd(0) { fname[0] = '\0'; }
+  Lockfile() : fd(0) { fname[0] = '\0'; }
   // coverity[uninit_member]
   Lockfile(const char *filename) : fd(0) { ink_strlcpy(fname, filename, sizeof(fname)); }
-  ~Lockfile(void) {}
+  ~Lockfile() {}
   void
   SetLockfileName(const char *filename)
   {
@@ -44,7 +44,7 @@ public:
   }
 
   const char *
-  GetLockfileName(void)
+  GetLockfileName()
   {
     return fname;
   }
@@ -69,7 +69,7 @@ public:
   // Close()
   //
   // Closes the file handle on the opened Lockfile.
-  void Close(void);
+  void Close();
 
   // Kill()
   // KillGroup()

--- a/include/tscore/ink_memory.h
+++ b/include/tscore/ink_memory.h
@@ -109,7 +109,7 @@ void *ats_track_malloc(size_t size, uint64_t *stat);
 void *ats_track_realloc(void *ptr, size_t size, uint64_t *alloc_stat, uint64_t *free_stat);
 void ats_track_free(void *ptr, uint64_t *stat);
 
-static inline size_t __attribute__((const)) ats_pagesize(void)
+static inline size_t __attribute__((const)) ats_pagesize()
 {
   static size_t page_size;
 

--- a/include/tscore/ink_platform.h
+++ b/include/tscore/ink_platform.h
@@ -33,14 +33,14 @@
 #endif
 
 #include <fcntl.h>
-#include <limits.h>
-#include <assert.h>
-#include <time.h>
+#include <limits.h> // NOLINT(modernize-deprecated-headers)
+#include <assert.h> // NOLINT(modernize-deprecated-headers)
+#include <time.h>   // NOLINT(modernize-deprecated-headers)
 #include <sys/time.h>
 #include <sys/uio.h>
 #include <sys/file.h>
 #include <sys/resource.h>
-#include <errno.h>
+#include <errno.h> // NOLINT(modernize-deprecated-headers)
 #include <syslog.h>
 #include <pwd.h>
 #include <poll.h>
@@ -61,11 +61,11 @@ struct ifafilt;
 #include <net/if.h>
 
 #ifdef HAVE_STDLIB_H
-#include <stdlib.h>
+#include <stdlib.h> // NOLINT(modernize-deprecated-headers)
 #endif
-#include <ctype.h>
+#include <ctype.h> // NOLINT(modernize-deprecated-headers)
 #ifdef HAVE_STRING_H
-#include <string.h>
+#include <string.h> // NOLINT(modernize-deprecated-headers)
 #endif
 #ifdef HAVE_STRINGS_H
 #include <strings.h>
@@ -107,7 +107,7 @@ struct ifafilt;
 #include <arpa/nameser_compat.h>
 #endif
 
-#include <signal.h>
+#include <signal.h> // NOLINT(modernize-deprecated-headers)
 #ifdef HAVE_SIGINFO_H
 #include <siginfo.h>
 #endif
@@ -170,7 +170,7 @@ typedef unsigned int in_addr_t;
 #endif
 
 #ifdef HAVE_FLOAT_H
-#include <float.h>
+#include <float.h> // NOLINT(modernize-deprecated-headers)
 #endif
 
 #ifdef HAVE_SYS_SYSMACROS_H

--- a/include/tscore/ink_thread.h
+++ b/include/tscore/ink_thread.h
@@ -192,6 +192,9 @@ ink_thread_self()
 static inline ink_thread
 ink_thread_null()
 {
+  // The implementation of ink_thread (the alias of pthread_t) is different on platforms
+  // - e.g. `struct pthread *` on Unix and `unsigned long int` on Linux
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   return (ink_thread)0;
 }
 

--- a/include/tscpp/api/Async.h
+++ b/include/tscpp/api/Async.h
@@ -26,6 +26,7 @@
 #include <memory>
 #include <mutex>
 #include <unordered_map>
+#include <utility>
 
 #include "tscpp/api/noncopyable.h"
 
@@ -105,7 +106,7 @@ private:
   void
   doRun(std::shared_ptr<AsyncDispatchControllerBase> dispatch_controller)
   {
-    dispatch_controller_ = dispatch_controller;
+    dispatch_controller_ = std::move(dispatch_controller);
     run();
   }
   friend class Async;
@@ -157,7 +158,7 @@ public:
    * @param mutex Mutex of the receiver that is locked during the dispatch
    */
   AsyncDispatchController(AsyncEventReceiverType *event_receiver, AsyncProviderType *provider, std::shared_ptr<Mutex> mutex)
-    : event_receiver_(event_receiver), dispatch_mutex_(mutex), provider_(provider)
+    : event_receiver_(event_receiver), dispatch_mutex_(std::move(mutex)), provider_(provider)
   {
   }
 

--- a/include/tscpp/api/Headers.h
+++ b/include/tscpp/api/Headers.h
@@ -235,7 +235,7 @@ class HeaderField
 {
 private:
   header_field_iterator iter_;
-  HeaderField(header_field_iterator iter) : iter_(iter) {}
+  HeaderField(const header_field_iterator &iter) : iter_(iter) {}
 
 public:
   typedef unsigned int size_type;

--- a/include/wccp/Wccp.h
+++ b/include/wccp/Wccp.h
@@ -292,7 +292,7 @@ public:
   /// Default constructor.
   Cache();
   /// Destructor
-  ~Cache();
+  ~Cache() override;
 
   /// Define services from a configuration file.
   ts::Errata loadServicesFromFile(char const *path ///< Path to file.
@@ -308,7 +308,7 @@ public:
       - @c ServiceGroup::CONFLICT if the service doesn't match the existing service.
    */
   Service defineServiceGroup(ServiceGroup const &svc, ///< Service group description.
-                             ServiceGroup::Result *result = 0);
+                             ServiceGroup::Result *result = nullptr);
 
   /** Add a seed router to the service group.
 
@@ -335,7 +335,7 @@ protected:
   /// Get the current implementation instance cast to correct type.
   ImplType const *impl() const;
   /// Create a new implementation instance.
-  super::ImplType *make();
+  super::ImplType *make() override;
 };
 
 /** Hold a reference to a service group in this end point.
@@ -387,7 +387,7 @@ public:
   /// Default constructor
   Router();
   /// Destructor.
-  ~Router();
+  ~Router() override;
 
   /// Transmit pending messages.
   int sendPendingMessages();
@@ -398,7 +398,7 @@ protected:
   /// Get the current implementation instance cast to correct type.
   ImplType *impl();
   /// Create a new implementation instance.
-  super::ImplType *make();
+  super::ImplType *make() override;
 };
 
 // ------------------------------------------------------
@@ -499,7 +499,7 @@ ServiceGroup::clearPorts()
   return *this;
 }
 
-inline Cache::Service::Service() : m_group(0) {}
+inline Cache::Service::Service() : m_group(nullptr) {}
 
 inline Cache::Service::Service(Cache const &cache, detail::cache::GroupData &group) : m_cache(cache), m_group(&group) {}
 

--- a/iocore/aio/I_AIO.h
+++ b/iocore/aio/I_AIO.h
@@ -149,4 +149,4 @@ int ink_aio_write(AIOCallback *op, int fromAPI = 0);
 int ink_aio_readv(AIOCallback *op,
                   int fromAPI = 0); // fromAPI is a boolean to indicate if this is from a API call such as upload proxy feature
 int ink_aio_writev(AIOCallback *op, int fromAPI = 0);
-AIOCallback *new_AIOCallback(void);
+AIOCallback *new_AIOCallback();

--- a/iocore/cache/P_CacheHosting.h
+++ b/iocore/cache/P_CacheHosting.h
@@ -194,7 +194,7 @@ struct ConfigVolumes {
   void BuildListFromString(char *config_file_path, char *file_buf);
 
   void
-  clear_all(void)
+  clear_all()
   {
     // remove all the volumes from the queue
     for (int i = 0; i < num_volumes; i++) {

--- a/iocore/cache/P_CacheInternal.h
+++ b/iocore/cache/P_CacheInternal.h
@@ -955,8 +955,8 @@ CacheRemoveCont::event_handler(int event, void *data)
   return EVENT_DONE;
 }
 
-int64_t cache_bytes_used(void);
-int64_t cache_bytes_total(void);
+int64_t cache_bytes_used();
+int64_t cache_bytes_total();
 
 #ifdef DEBUG
 #define CACHE_DEBUG_INCREMENT_DYN_STAT(_x) CACHE_INCREMENT_DYN_STAT(_x)

--- a/iocore/dns/P_SplitDNSProcessor.h
+++ b/iocore/dns/P_SplitDNSProcessor.h
@@ -130,12 +130,12 @@ class DNSRequestData : public RequestData
 public:
   DNSRequestData();
 
-  char *get_string();
+  char *get_string() override;
 
-  const char *get_host();
+  const char *get_host() override;
 
-  sockaddr const *get_ip();        // unused required virtual method.
-  sockaddr const *get_client_ip(); // unused required virtual method.
+  sockaddr const *get_ip() override;        // unused required virtual method.
+  sockaddr const *get_client_ip() override; // unused required virtual method.
 
   const char *m_pHost;
 };

--- a/iocore/eventsystem/I_Thread.h
+++ b/iocore/eventsystem/I_Thread.h
@@ -99,6 +99,7 @@ public:
     processors and you should not modify it directly.
 
   */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   ink_thread tid = 0;
 
   /**

--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -533,7 +533,7 @@ db_mark_for(IpAddr const &ip)
 }
 
 Ptr<HostDBInfo>
-probe(Ptr<ProxyMutex> mutex, HostDBHash const &hash, bool ignore_timeout)
+probe(const Ptr<ProxyMutex> &mutex, HostDBHash const &hash, bool ignore_timeout)
 {
   // If hostdb is disabled, don't return anything
   if (!hostdb_enable) {

--- a/iocore/hostdb/P_RefCountCache.h
+++ b/iocore/hostdb/P_RefCountCache.h
@@ -396,7 +396,7 @@ template <class C> class RefCountCache
 public:
   // Constructor
   RefCountCache(unsigned int num_partitions, int size = -1, int items = -1, ts::VersionNumber object_version = ts::VersionNumber(),
-                std::string metrics_prefix = "");
+                const std::string &metrics_prefix = "");
   // Destructor
   ~RefCountCache();
 
@@ -427,7 +427,7 @@ private:
 
 template <class C>
 RefCountCache<C>::RefCountCache(unsigned int num_partitions, int size, int items, ts::VersionNumber object_version,
-                                std::string metrics_prefix)
+                                const std::string &metrics_prefix)
   : header(RefCountCacheHeader(object_version)), rsb(nullptr)
 {
   this->max_size       = size;
@@ -568,7 +568,7 @@ RefCountCache<C>::clear()
 // Errors are -1
 template <typename CacheEntryType>
 int
-LoadRefCountCacheFromPath(RefCountCache<CacheEntryType> &cache, std::string dirname, std::string filepath,
+LoadRefCountCacheFromPath(RefCountCache<CacheEntryType> &cache, const std::string &dirname, const std::string &filepath,
                           CacheEntryType *(*load_func)(char *, unsigned int))
 {
   // If we have no load method, then we can't load anything so lets just stop right here

--- a/iocore/hostdb/P_RefCountCacheSerializer.h
+++ b/iocore/hostdb/P_RefCountCacheSerializer.h
@@ -25,6 +25,7 @@
 
 #include "P_RefCountCache.h"
 
+#include <utility>
 #include <vector>
 
 // This continuation is responsible for persisting RefCountCache to disk
@@ -57,7 +58,7 @@ public:
   int write_to_disk(const void *, size_t);
 
   RefCountCacheSerializer(Continuation *acont, RefCountCache<C> *cc, int frequency, std::string dirname, std::string filename);
-  ~RefCountCacheSerializer();
+  ~RefCountCacheSerializer() override;
 
 private:
   std::vector<RefCountCacheHashEntry *> partition_items;
@@ -85,8 +86,8 @@ RefCountCacheSerializer<C>::RefCountCacheSerializer(Continuation *acont, RefCoun
     cache(cc),
     cont(acont),
     fd(-1),
-    dirname(dirname),
-    filename(filename),
+    dirname(std::move(dirname)),
+    filename(std::move(filename)),
     time_per_partition(HRTIME_SECONDS(frequency) / cc->partition_count()),
     start(Thread::get_hrtime()),
     total_items(0),

--- a/iocore/net/I_SessionAccept.h
+++ b/iocore/net/I_SessionAccept.h
@@ -56,7 +56,7 @@ class SessionAccept : public Continuation
 {
 public:
   SessionAccept(ProxyMutex *amutex) : Continuation(amutex) { SET_HANDLER(&SessionAccept::mainEvent); }
-  ~SessionAccept() {}
+  ~SessionAccept() override {}
   /**
     Accept a new connection on this session.
 

--- a/iocore/net/I_UDPConnection.h
+++ b/iocore/net/I_UDPConnection.h
@@ -83,7 +83,7 @@ public:
   void AddRef();
   int GetRefCount();
 
-  int getPortNum(void);
+  int getPortNum();
 
   int GetSendGenerationNumber(); // const
   void SetLastSentPktTSSeqNum(int64_t sentSeqNum);

--- a/iocore/net/P_SNIActionPerformer.h
+++ b/iocore/net/P_SNIActionPerformer.h
@@ -81,7 +81,7 @@ class TunnelDestination : public ActionItem
 {
 public:
   TunnelDestination(const std::string_view &dest, bool decrypt) : destination(dest), tunnel_decrypt(decrypt) {}
-  ~TunnelDestination() {}
+  ~TunnelDestination() override {}
 
   int
   SNIAction(Continuation *cont) const override

--- a/iocore/net/P_SSLConfig.h
+++ b/iocore/net/P_SSLConfig.h
@@ -130,7 +130,7 @@ struct SSLConfigParams : public ConfigInfo {
   mutable std::unordered_map<std::string, CTX_MAP *> top_level_ctx_map;
   mutable ink_mutex ctxMapLock;
 
-  SSL_CTX *getClientSSL_CTX(void) const;
+  SSL_CTX *getClientSSL_CTX() const;
   SSL_CTX *getCTX(const char *client_cert, const char *key_file, const char *ca_bundle_file, const char *ca_bundle_path) const;
   void cleanupCTXTable();
 

--- a/iocore/net/P_SSLNetProcessor.h
+++ b/iocore/net/P_SSLNetProcessor.h
@@ -55,7 +55,7 @@ struct SSLNetProcessor : public UnixNetProcessor {
 public:
   int start(int, size_t stacksize) override;
 
-  void cleanup(void);
+  void cleanup();
 
   SSLNetProcessor();
   ~SSLNetProcessor() override;

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -298,13 +298,13 @@ public:
   }
 
   const char *
-  getSSLProtocol(void) const
+  getSSLProtocol() const
   {
     return ssl ? SSL_get_version(ssl) : nullptr;
   }
 
   const char *
-  getSSLCipherSuite(void) const
+  getSSLCipherSuite() const
   {
     return ssl ? SSL_get_cipher_name(ssl) : nullptr;
   }

--- a/iocore/net/P_SSLSNI.h
+++ b/iocore/net/P_SSLSNI.h
@@ -59,12 +59,12 @@ public:
   setGlobName(std::string name)
   {
     std::string::size_type pos = 0;
-    while ((pos = name.find(".", pos)) != std::string::npos) {
+    while ((pos = name.find('.', pos)) != std::string::npos) {
       name.replace(pos, 1, "\\.");
       pos += 2;
     }
     pos = 0;
-    while ((pos = name.find("*", pos)) != std::string::npos) {
+    while ((pos = name.find('*', pos)) != std::string::npos) {
       name.replace(pos, 1, ".{0,}");
     }
     Debug("ssl_sni", "Regexed fqdn=%s", name.c_str());

--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -171,7 +171,7 @@ namespace detail
 struct ats_wildcard_matcher {
   ats_wildcard_matcher()
   {
-    if (!regex.compile("^\\*\\.[^\\*.]+")) {
+    if (!regex.compile(R"(^\*\.[^\*.]+)")) {
       Fatal("failed to compile TLS wildcard matching regex");
     }
   }

--- a/iocore/net/P_UDPConnection.h
+++ b/iocore/net/P_UDPConnection.h
@@ -140,13 +140,13 @@ UDPConnection::GetSendGenerationNumber()
 }
 
 TS_INLINE int
-UDPConnection::getPortNum(void)
+UDPConnection::getPortNum()
 {
   return ats_ip_port_host_order(&static_cast<UDPConnectionInternal *>(this)->binding);
 }
 
 TS_INLINE int64_t
-UDPConnection::cancel(void)
+UDPConnection::cancel()
 {
   UDPConnectionInternal *p = (UDPConnectionInternal *)this;
 

--- a/iocore/net/P_UDPNet.h
+++ b/iocore/net/P_UDPNet.h
@@ -76,7 +76,7 @@ public:
   int now_slot;
 
   void
-  init(void)
+  init()
   {
     now_slot       = 0;
     ink_hrtime now = ink_get_hrtime_internal();

--- a/iocore/net/P_UDPPacket.h
+++ b/iocore/net/P_UDPPacket.h
@@ -151,14 +151,14 @@ UDPPacket::setConnection(UDPConnection *c)
 }
 
 TS_INLINE IOBufferBlock *
-UDPPacket::getIOBlockChain(void)
+UDPPacket::getIOBlockChain()
 {
   ink_assert(dynamic_cast<UDPPacketInternal *>(this) != nullptr);
   return ((UDPPacketInternal *)this)->chain.get();
 }
 
 TS_INLINE UDPConnection *
-UDPPacket::getConnection(void)
+UDPPacket::getConnection()
 {
   return ((UDPPacketInternal *)this)->conn;
 }

--- a/iocore/net/P_UnixPollDescriptor.h
+++ b/iocore/net/P_UnixPollDescriptor.h
@@ -112,7 +112,7 @@ struct PollDescriptor {
     }
     return &pfd[nfds++];
 #else
-    return 0;
+    return nullptr;
 #endif
   }
 

--- a/iocore/net/ProxyProtocol.h
+++ b/iocore/net/ProxyProtocol.h
@@ -40,7 +40,7 @@ extern bool proxy_protov1_parse(NetVConnection *, ts::TextView hdr);
 extern bool ssl_has_proxy_v1(NetVConnection *, char *, int64_t *);
 extern bool http_has_proxy_v1(IOBufferReader *, NetVConnection *);
 
-const char *const PROXY_V1_CONNECTION_PREFACE = "\x50\x52\x4F\x58\x59";
+const char *const PROXY_V1_CONNECTION_PREFACE = R"(PROXY)";
 const char *const PROXY_V2_CONNECTION_PREFACE = "\x0D\x0A\x0D\x0A\x00\x0D\x0A\x51\x55\x49\x54\x0A\x02";
 
 const size_t PROXY_V1_CONNECTION_PREFACE_LEN = strlen(PROXY_V1_CONNECTION_PREFACE); // 5

--- a/iocore/net/SSLSNIConfig.cc
+++ b/iocore/net/SSLSNIConfig.cc
@@ -109,11 +109,11 @@ SNIConfigParams::SNIConfigParams() {}
 const actionVector *
 SNIConfigParams::get(const std::string &servername) const
 {
-  for (auto retval = sni_action_list.begin(); retval != sni_action_list.end(); ++retval) {
-    if (retval->match == nullptr && servername.length() == 0) {
-      return &retval->actions;
-    } else if (pcre_exec(retval->match, nullptr, servername.c_str(), servername.length(), 0, 0, nullptr, 0) >= 0) {
-      return &retval->actions;
+  for (const auto &retval : sni_action_list) {
+    if (retval.match == nullptr && servername.length() == 0) {
+      return &retval.actions;
+    } else if (pcre_exec(retval.match, nullptr, servername.c_str(), servername.length(), 0, 0, nullptr, 0) >= 0) {
+      return &retval.actions;
     }
   }
   return nullptr;

--- a/iocore/net/SSLSessionCache.h
+++ b/iocore/net/SSLSessionCache.h
@@ -116,7 +116,7 @@ public:
   Ptr<IOBufferData> asn1_data; /* this is the ASN1 representation of the SSL_CTX */
   size_t len_asn1_data;
 
-  SSLSession(const SSLSessionID &id, Ptr<IOBufferData> ssl_asn1_data, size_t len_asn1)
+  SSLSession(const SSLSessionID &id, const Ptr<IOBufferData> &ssl_asn1_data, size_t len_asn1)
     : session_id(id), asn1_data(ssl_asn1_data), len_asn1_data(len_asn1)
   {
   }

--- a/iocore/utils/Machine.cc
+++ b/iocore/utils/Machine.cc
@@ -231,8 +231,8 @@ Machine::Machine(char const *the_hostname, sockaddr const *addr)
 Machine::~Machine()
 {
   ats_free(hostname);
-  for (auto spot = machine_id_ipaddrs.begin(); spot != machine_id_ipaddrs.end(); spot++) {
-    delete spot->second;
+  for (auto &machine_id_ipaddr : machine_id_ipaddrs) {
+    delete machine_id_ipaddr.second;
   }
 }
 

--- a/lib/records/I_RecCore.h
+++ b/lib/records/I_RecCore.h
@@ -46,7 +46,7 @@ int RecSetDiags(Diags *diags);
 typedef void (*RecConfigEntryCallback)(RecT rec_type, RecDataT data_type, const char *name, const char *value, RecSourceT source,
                                        bool inc_version);
 
-void RecConfigFileInit(void);
+void RecConfigFileInit();
 int RecConfigFileParse(const char *path, RecConfigEntryCallback handler, bool inc_version);
 
 // Return a copy of the system's configuration directory.

--- a/lib/records/I_RecProcess.h
+++ b/lib/records/I_RecProcess.h
@@ -31,7 +31,7 @@
 //-------------------------------------------------------------------------
 int RecProcessInit(RecModeT mode_type, Diags *diags = nullptr);
 int RecProcessInitMessage(RecModeT mode_type);
-int RecProcessStart(void);
+int RecProcessStart();
 
 //-------------------------------------------------------------------------
 // Setters for manipulating internal sleep intervals

--- a/lib/tsconfig/Errata.h
+++ b/lib/tsconfig/Errata.h
@@ -827,7 +827,7 @@ inline size_t Errata::size() const {
 }
 
 inline bool Errata::isOK() const {
-  return 0 == m_data
+  return nullptr == m_data
     || 0 == m_data->size()
     || Message::Success_Test(this->top())
     ;

--- a/lib/tsconfig/TsValue.h
+++ b/lib/tsconfig/TsValue.h
@@ -29,6 +29,7 @@
 #include <tsconfig/NumericType.h>
 #include <tsconfig/IntrusivePtr.h>
 #include <tsconfig/Errata.h>
+#include <utility>
 #include <vector>
 
 namespace ts { namespace config {
@@ -651,7 +652,7 @@ namespace detail {
 
 inline Value::~Value() { }
 inline Value::Value() : _vidx(detail::NULL_VALUE_INDEX) {}
-inline Value::Value(Configuration cfg, detail::ValueIndex vidx) : _config(cfg), _vidx(vidx) { }
+inline Value::Value(Configuration cfg, detail::ValueIndex vidx) : _config(std::move(cfg)), _vidx(vidx) { }
 inline bool Value::hasValue() const { return _config && _vidx != detail::NULL_VALUE_INDEX; }
 inline Value::operator detail::PseudoBool::Type () const { return this->hasValue() ? detail::PseudoBool::TRUE : detail::PseudoBool::FALSE; }
 inline bool Value::operator ! () const { return ! this->hasValue(); }

--- a/mgmt/utils/MgmtSocket.h
+++ b/mgmt/utils/MgmtSocket.h
@@ -94,7 +94,7 @@ int mgmt_write_timeout(int fd, int sec, int usec);
 int mgmt_read_timeout(int fd, int sec, int usec);
 
 // Do we support passing Unix domain credentials on this platform?
-bool mgmt_has_peereid(void);
+bool mgmt_has_peereid();
 
 // Get the Unix domain peer credentials.
 int mgmt_get_peereid(int fd, uid_t *euid, gid_t *egid);

--- a/plugins/background_fetch/rules.cc
+++ b/plugins/background_fetch/rules.cc
@@ -24,7 +24,7 @@
 
 #include <cstdlib>
 #include <string_view>
-#include <string.h>
+#include <cstring>
 
 #include "configs.h"
 #include "rules.h"

--- a/plugins/cachekey/cachekey.cc
+++ b/plugins/cachekey/cachekey.cc
@@ -23,6 +23,7 @@
 
 #include <cstring> /* strlen() */
 #include <sstream> /* istringstream */
+#include <utility>
 #include "cachekey.h"
 
 static void
@@ -195,7 +196,7 @@ getUri(TSMBuffer buf, TSMLoc url)
  * @param rri remap request info
  */
 CacheKey::CacheKey(TSHttpTxn txn, String separator, CacheKeyUriType uriType, TSRemapRequestInfo *rri)
-  : _txn(txn), _separator(separator), _uriType(uriType)
+  : _txn(txn), _separator(std::move(separator)), _uriType(uriType)
 {
   _key.reserve(512);
 

--- a/plugins/cachekey/configs.cc
+++ b/plugins/cachekey/configs.cc
@@ -183,8 +183,8 @@ ConfigElements::noIncludeExcludeRules() const
 
 ConfigElements::~ConfigElements()
 {
-  for (auto it = _captures.begin(); it != _captures.end(); it++) {
-    delete it->second;
+  for (auto &_capture : _captures) {
+    delete _capture.second;
   }
 }
 

--- a/plugins/cachekey/pattern.h
+++ b/plugins/cachekey/pattern.h
@@ -77,7 +77,7 @@ private:
 class MultiPattern
 {
 public:
-  MultiPattern(const String name = "") : _name(name) {}
+  MultiPattern(const String &name = "") : _name(name) {}
   virtual ~MultiPattern();
 
   bool empty() const;

--- a/plugins/esi/lib/HandlerManager.h
+++ b/plugins/esi/lib/HandlerManager.h
@@ -45,7 +45,7 @@ public:
   SpecialIncludeHandler *getHandler(Variables &esi_vars, Expression &esi_expr, HttpDataFetcher &http_fetcher,
                                     const std::string &id) const;
 
-  ~HandlerManager();
+  ~HandlerManager() override;
 
 private:
   typedef std::map<std::string, SpecialIncludeHandlerCreator> FunctionHandleMap;

--- a/plugins/experimental/access_control/access_control.h
+++ b/plugins/experimental/access_control/access_control.h
@@ -216,7 +216,7 @@ class KvpAccessToken : public AccessToken
 {
 public:
   KvpAccessToken(const KvpAccessTokenConfig &tokenConfig, const StringMap &secretsMap, bool enableDebug = false);
-  AccessTokenStatus parse(const StringView token);
+  AccessTokenStatus parse(const StringView token) override;
 
 protected:
   const KvpAccessTokenConfig &_tokenConfig; /** @brief description of keys' names and delimiters */

--- a/plugins/experimental/access_control/config.cc
+++ b/plugins/experimental/access_control/config.cc
@@ -169,23 +169,23 @@ load(T &container, const String &filename)
 bool
 AccessControlConfig::init(int argc, char *argv[])
 {
-  static const struct option longopt[] = {{const_cast<char *>("invalid-syntax-status-code"), optional_argument, 0, 'a'},
-                                          {const_cast<char *>("invalid-signature-status-code"), optional_argument, 0, 'b'},
-                                          {const_cast<char *>("invalid-timing-status-code"), optional_argument, 0, 'c'},
-                                          {const_cast<char *>("invalid-scope-status-code"), optional_argument, 0, 'd'},
-                                          {const_cast<char *>("invalid-origin-response"), optional_argument, 0, 'e'},
-                                          {const_cast<char *>("internal-error-status-code"), optional_argument, 0, 'f'},
-                                          {const_cast<char *>("check-cookie"), optional_argument, 0, 'g'},
-                                          {const_cast<char *>("symmetric-keys-map"), optional_argument, 0, 'h'},
-                                          {const_cast<char *>("reject-invalid-token-requests"), optional_argument, 0, 'i'},
-                                          {const_cast<char *>("extract-subject-to-header"), optional_argument, 0, 'j'},
-                                          {const_cast<char *>("extract-tokenid-to-header"), optional_argument, 0, 'k'},
-                                          {const_cast<char *>("extract-status-to-header"), optional_argument, 0, 'l'},
-                                          {const_cast<char *>("token-response-header"), optional_argument, 0, 'm'},
-                                          {const_cast<char *>("use-redirects"), optional_argument, 0, 'n'},
+  static const struct option longopt[] = {{const_cast<char *>("invalid-syntax-status-code"), optional_argument, nullptr, 'a'},
+                                          {const_cast<char *>("invalid-signature-status-code"), optional_argument, nullptr, 'b'},
+                                          {const_cast<char *>("invalid-timing-status-code"), optional_argument, nullptr, 'c'},
+                                          {const_cast<char *>("invalid-scope-status-code"), optional_argument, nullptr, 'd'},
+                                          {const_cast<char *>("invalid-origin-response"), optional_argument, nullptr, 'e'},
+                                          {const_cast<char *>("internal-error-status-code"), optional_argument, nullptr, 'f'},
+                                          {const_cast<char *>("check-cookie"), optional_argument, nullptr, 'g'},
+                                          {const_cast<char *>("symmetric-keys-map"), optional_argument, nullptr, 'h'},
+                                          {const_cast<char *>("reject-invalid-token-requests"), optional_argument, nullptr, 'i'},
+                                          {const_cast<char *>("extract-subject-to-header"), optional_argument, nullptr, 'j'},
+                                          {const_cast<char *>("extract-tokenid-to-header"), optional_argument, nullptr, 'k'},
+                                          {const_cast<char *>("extract-status-to-header"), optional_argument, nullptr, 'l'},
+                                          {const_cast<char *>("token-response-header"), optional_argument, nullptr, 'm'},
+                                          {const_cast<char *>("use-redirects"), optional_argument, nullptr, 'n'},
                                           {const_cast<char *>("include-uri-paths-file"), optional_argument, nullptr, 'o'},
                                           {const_cast<char *>("exclude-uri-paths-file"), optional_argument, nullptr, 'p'},
-                                          {0, 0, 0, 0}};
+                                          {nullptr, 0, nullptr, 0}};
 
   bool status = true;
   optind      = 0;

--- a/plugins/experimental/access_control/headers.cc
+++ b/plugins/experimental/access_control/headers.cc
@@ -21,8 +21,8 @@
  * @brief HTTP headers manipulation.
  */
 
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 
 #include "headers.h"
 #include "common.h"

--- a/plugins/experimental/access_control/pattern.h
+++ b/plugins/experimental/access_control/pattern.h
@@ -76,7 +76,7 @@ private:
 class MultiPattern
 {
 public:
-  MultiPattern(const String name = "") : _name(name) {}
+  MultiPattern(const String &name = "") : _name(name) {}
   virtual ~MultiPattern();
 
   bool empty() const;
@@ -106,14 +106,14 @@ public:
    * @param subject subject string
    * @return return false if any of the patterns matches, true otherwise.
    */
-  virtual bool
-  match(const String &subject) const
+  bool
+  match(const String &subject) const override
   {
     return !MultiPattern::match(subject);
   }
 
-  virtual bool
-  match(const String &subject, String &pattern) const
+  bool
+  match(const String &subject, String &pattern) const override
   {
     return !MultiPattern::match(subject, pattern);
   }

--- a/plugins/experimental/access_control/plugin.cc
+++ b/plugins/experimental/access_control/plugin.cc
@@ -359,7 +359,7 @@ contHandleAccessControl(const TSCont contp, TSEvent event, void *edata)
 
             AccessToken *token = config->_tokenFactory->getAccessToken();
             if (nullptr != token &&
-                VALID == (data->_originState = token->validate(StringView(tokenHdrValue, tokenHdrValueLen), time(0)))) {
+                VALID == (data->_originState = token->validate(StringView(tokenHdrValue, tokenHdrValueLen), time(nullptr)))) {
               /*
                * From RFC 6265 "HTTP State Management Mechanism":
                * To maximize compatibility with user agents, servers that wish to
@@ -520,7 +520,7 @@ enforceAccessControl(TSHttpTxn txnp, TSRemapRequestInfo *rri, AccessControlConfi
     if (0 < decryptedCookieSize) {
       AccessToken *token = config->_tokenFactory->getAccessToken();
       if (nullptr != token) {
-        data->_vaState = token->validate(StringView(decodedCookie, decryptedCookieSize), time(0));
+        data->_vaState = token->validate(StringView(decodedCookie, decryptedCookieSize), time(nullptr));
         if (VALID != data->_vaState) {
           remapStatus =
             handleInvalidToken(txnp, data, reject, accessTokenStateToHttpStatus(data->_vaState, config), data->_vaState);

--- a/plugins/experimental/access_control/utils.cc
+++ b/plugins/experimental/access_control/utils.cc
@@ -22,8 +22,8 @@
  * @see utils.h
  */
 
-#include <errno.h>          /* errno */
-#include <limits.h>         /* LONG_MIN, LONG_MAX */
+#include <cerrno>           /* errno */
+#include <climits>          /* LONG_MIN, LONG_MAX */
 #include <openssl/bio.h>    /* BIO I/O abstraction */
 #include <openssl/buffer.h> /* buf_mem_st */
 #include <openssl/err.h>    /* ERR_get_error() and ERR_error_string_n() */
@@ -279,7 +279,7 @@ cryptoMessageDigestGet(const char *digestType, const char *data, size_t dataLen,
 
         /* success */
         result = len;
-      } while (0);
+      } while (false);
 
       EVP_PKEY_free(pkey);
       EVP_MD_CTX_destroy(ctx);

--- a/plugins/experimental/access_control/utils.h
+++ b/plugins/experimental/access_control/utils.h
@@ -26,7 +26,7 @@
 
 #include <string_view>   /* std:string_view */
 #include <openssl/evp.h> /* EVP_* constants, structures and functions. */
-#include <string.h>      /* strlen, strncmp, strncpy, memset, size_t */
+#include <cstring>       /* strlen, strncmp, strncpy, memset, size_t */
 
 #define MAX_MSGDIGEST_BUFFER_SIZE EVP_MAX_MD_SIZE
 

--- a/plugins/experimental/cookie_remap/cookie_remap.cc
+++ b/plugins/experimental/cookie_remap/cookie_remap.cc
@@ -32,7 +32,7 @@
 #include <list>
 #include <map>
 #include <set>
-#include <string.h>
+#include <cstring>
 #include <string>
 #include <unistd.h>
 #include <vector>
@@ -300,7 +300,7 @@ public:
   void
   setBucket(const std::string &s)
   {
-    int start_pos = s.find("/");
+    int start_pos = s.find('/');
 
     op_type  = BUCKET;
     bucket   = s;
@@ -335,7 +335,7 @@ public:
       return false;
     }
     regex_extra = pcre_study(regex, 0, &error_study);
-    if ((regex_extra == nullptr) && (error_study != 0)) {
+    if ((regex_extra == nullptr) && (error_study != nullptr)) {
       return false;
     }
 
@@ -418,8 +418,8 @@ public:
   ~op()
   {
     TSDebug(MY_NAME, "op destructor called");
-    for (SubOpQueue::iterator it = subops.begin(); it != subops.end(); ++it) {
-      delete *it;
+    for (auto &subop : subops) {
+      delete subop;
     }
   }
 
@@ -469,8 +469,8 @@ public:
     TSDebug(MY_NAME, "sending to: %s", sendto.c_str());
     TSDebug(MY_NAME, "if these operations match: ");
 
-    for (SubOpQueue::const_iterator it = subops.begin(); it != subops.end(); ++it) {
-      (*it)->printSubOp();
+    for (auto subop : subops) {
+      subop->printSubOp();
     }
     if (else_sendto.size() > 0)
       TSDebug(MY_NAME, "else: %s", else_sendto.c_str());
@@ -494,16 +494,16 @@ public:
 
     TSDebug(MY_NAME, "starting to process a new operation");
 
-    for (SubOpQueue::const_iterator it = subops.begin(); it != subops.end(); ++it) {
+    for (auto subop : subops) {
       // subop* s = *it;
-      int subop_type     = (*it)->getOpType();
-      target_type target = (*it)->getTargetType();
+      int subop_type     = subop->getOpType();
+      target_type target = subop->getTargetType();
 
-      c = (*it)->getCookieName();
+      c = subop->getCookieName();
       if (c.length()) {
         TSDebug(MY_NAME, "processing cookie: %s", c.c_str());
 
-        size_t period_pos = c.find_first_of(".");
+        size_t period_pos = c.find_first_of('.');
 
         if (period_pos == std::string::npos) { // not a sublevel
                                                // cookie name
@@ -616,7 +616,7 @@ public:
 
       // OPERATION::string matching
       if (subop_type == STRING) {
-        if (string_to_match == (*it)->getStringMatch()) {
+        if (string_to_match == subop->getStringMatch()) {
           TSDebug(MY_NAME, "string match succeeded");
           continue;
         } else {
@@ -629,7 +629,7 @@ public:
       // OPERATION::regex matching
       if (subop_type == REGEXP) {
         int ovector[OVECCOUNT];
-        int ret = (*it)->regexMatch(string_to_match.c_str(), string_to_match.length(), ovector);
+        int ret = subop->regexMatch(string_to_match.c_str(), string_to_match.length(), ovector);
 
         if (ret >= 0) {
           std::string::size_type pos  = sendto.find('$');
@@ -649,7 +649,7 @@ public:
                   "successful regex "
                   "match of: %s with %s "
                   "rewriting string: %s",
-                  string_to_match.c_str(), (*it)->getRegexString().c_str(), sendto.c_str());
+                  string_to_match.c_str(), subop->getRegexString().c_str(), sendto.c_str());
 
           // replace the $(1-9) in the sendto url
           // as necessary
@@ -659,7 +659,7 @@ public:
             if (isdigit(sendto[pos + 1])) {
               int ix = sendto[pos + 1] - '0';
 
-              if (ix <= (*it)->getRegexCcount()) { // Just skip an illegal regex group
+              if (ix <= subop->getRegexCcount()) { // Just skip an illegal regex group
                 dest += sendto.substr(ppos, pos - ppos);
                 dest += string_to_match.substr(ovector[ix * 2], ovector[ix * 2 + 1] - ovector[ix * 2]);
                 ppos = pos + 2;
@@ -682,7 +682,7 @@ public:
                   "could not match "
                   "regular expression "
                   "%s to %s",
-                  (*it)->getRegexString().c_str(), string_to_match.c_str());
+                  subop->getRegexString().c_str(), string_to_match.c_str());
           retval &= 0;
           break;
         }
@@ -690,8 +690,8 @@ public:
 
       // OPERATION::bucket ranges
       if (subop_type == BUCKET) {
-        unsigned int taking = (*it)->bucketGetTaking();
-        unsigned int out_of = (*it)->bucketOutOf();
+        unsigned int taking = subop->bucketGetTaking();
+        unsigned int out_of = subop->bucketOutOf();
 
         uint32_t hash;
 
@@ -1047,9 +1047,9 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
   CookieJar jar;
   jar.create(temp_cookie);
 
-  for (OpsQueue::iterator it = ops->begin(); it != ops->end(); ++it) {
+  for (auto &op : *ops) {
     TSDebug(MY_NAME, ">>> processing new operation");
-    if ((*it)->process(jar, rewrite_to, status, rri)) {
+    if (op->process(jar, rewrite_to, status, rri)) {
       cr_substitutions(rewrite_to, rri);
 
       size_t pos = 7;                             // 7 because we want to ignore the // in
@@ -1062,7 +1062,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
       } while (pos <= rewrite_to.length() && pos < tmp_pos);
 
       // Add Query Parameters if not already present
-      if (!client_req_query_params.empty() && rewrite_to.find("?") == std::string::npos) {
+      if (!client_req_query_params.empty() && rewrite_to.find('?') == std::string::npos) {
         rewrite_to.append(client_req_query_params);
       }
 
@@ -1141,8 +1141,8 @@ TSRemapDeleteInstance(void *ih)
   OpsQueue *ops = (OpsQueue *)ih;
 
   TSDebug(MY_NAME, "deleting loaded operations");
-  for (OpsQueue::iterator it = ops->begin(); it != ops->end(); ++it) {
-    delete *it;
+  for (auto &op : *ops) {
+    delete op;
   }
 
   delete ops;

--- a/plugins/experimental/cookie_remap/cookiejar.cc
+++ b/plugins/experimental/cookie_remap/cookiejar.cc
@@ -18,7 +18,7 @@
 
 #include "cookiejar.h"
 #include "strip.h"
-#include <string.h>
+#include <cstring>
 
 /* allowed cookie-name definition from RFC
  * cookie-name       = token

--- a/plugins/experimental/cookie_remap/cookiejar.h
+++ b/plugins/experimental/cookie_remap/cookiejar.h
@@ -52,7 +52,7 @@ private:
   public:
     unordered_map<string, string> m_subelements;
     string m_val;
-    bool parts_inited = 0;
+    bool parts_inited = false;
   };
   CookieVal *m_currentVal = nullptr;
 

--- a/plugins/experimental/cookie_remap/hash.h
+++ b/plugins/experimental/cookie_remap/hash.h
@@ -19,9 +19,9 @@
 #ifndef _CKREMAP_HASH_H_
 #define _CKREMAP_HASH_H_
 
-#include <stddef.h>
+#include <stddef.h> // NOLINT(modernize-deprecated-headers)
 #include <sys/types.h>
-#include <inttypes.h>
+#include <inttypes.h> // NOLINT(modernize-deprecated-headers)
 
 #ifdef __cplusplus
 extern "C" {

--- a/plugins/experimental/cookie_remap/test_cookiejar.cc
+++ b/plugins/experimental/cookie_remap/test_cookiejar.cc
@@ -19,7 +19,7 @@
 #define CATCH_CONFIG_MAIN // This tells Catch to provide a main() - only do this in one cpp file
 #include <iostream>
 #include <string>
-#include <assert.h>
+#include <cassert>
 #include "catch.hpp"
 #include "cookiejar.h"
 

--- a/plugins/experimental/inliner/cache-handler.h
+++ b/plugins/experimental/inliner/cache-handler.h
@@ -101,7 +101,7 @@ namespace inliner
     }
 
     void
-    done(void)
+    done()
     {
       if (GIF::verifySignature(content_)) {
         contentType_ = "image/gif";
@@ -165,13 +165,13 @@ namespace inliner
     }
 
     void
-    timeout(void) const
+    timeout() const
     {
       TSDebug(PLUGIN_TAG, "Fetch timeout");
     }
 
     void
-    error(void) const
+    error() const
     {
       TSDebug(PLUGIN_TAG, "Fetch error");
     }
@@ -225,7 +225,7 @@ namespace inliner
     }
 
     template <class T1, class T2>
-    CacheHandler(const std::string &s, const std::string &o, const std::string c, const std::string &i, T1 &&si, T2 &&si2)
+    CacheHandler(const std::string &s, const std::string &o, const std::string &c, const std::string &i, T1 &&si, T2 &&si2)
       : src_(s), original_(o), classes_(c), id_(i), sink_(std::forward<T1>(si)), sink2_(std::forward<T2>(si2)), reader_(nullptr)
     {
       assert(sink_ != nullptr);
@@ -248,7 +248,7 @@ namespace inliner
     CacheHandler &operator=(const CacheHandler &) = delete;
 
     void
-    done(void)
+    done()
     {
       assert(reader_ != nullptr);
       assert(sink2_ != nullptr);
@@ -291,7 +291,7 @@ namespace inliner
     }
 
     void
-    miss(void)
+    miss()
     {
       assert(sink_ != nullptr);
       *sink_ << original_;

--- a/plugins/experimental/inliner/cache.h
+++ b/plugins/experimental/inliner/cache.h
@@ -40,7 +40,7 @@ namespace cache
       TSCacheKeyDestroy(key_);
     }
 
-    Key(void) : key_(TSCacheKeyCreate()) { assert(key_ != nullptr); }
+    Key() : key_(TSCacheKeyCreate()) { assert(key_ != nullptr); }
     Key(const Key &) = delete;
     Key &operator=(const Key &) = delete;
 
@@ -51,7 +51,7 @@ namespace cache
     }
 
     TSCacheKey
-    key(void) const
+    key() const
     {
       return key_;
     }

--- a/plugins/experimental/inliner/chunk-decoder.h
+++ b/plugins/experimental/inliner/chunk-decoder.h
@@ -70,14 +70,14 @@ class ChunkDecoder
   int64_t size_;
 
 public:
-  ChunkDecoder(void) : state_(State::kSize), size_(0) {}
+  ChunkDecoder() : state_(State::kSize), size_(0) {}
   void parseSizeCharacter(const char);
   int parseSize(const char *, const int64_t);
   int decode(const TSIOBufferReader &);
-  bool isSizeState(void) const;
+  bool isSizeState() const;
 
   inline bool
-  isEnd(void) const
+  isEnd() const
   {
     return state_ == State::kEnd;
   }

--- a/plugins/experimental/inliner/fetcher.h
+++ b/plugins/experimental/inliner/fetcher.h
@@ -68,7 +68,7 @@ struct HttpParser {
   TSMBuffer buffer_;
   TSMLoc location_;
 
-  void destroyParser(void);
+  void destroyParser();
 
   ~HttpParser()
   {
@@ -77,7 +77,7 @@ struct HttpParser {
     destroyParser();
   }
 
-  HttpParser(void) : parsed_(false), parser_(TSHttpParserCreate()), buffer_(TSMBufferCreate()), location_(TSHttpHdrCreate(buffer_))
+  HttpParser() : parsed_(false), parser_(TSHttpParserCreate()), buffer_(TSMBufferCreate()), location_(TSHttpHdrCreate(buffer_))
   {
     TSHttpHdrTypeSet(buffer_, location_, TS_HTTP_TYPE_RESPONSE);
   }
@@ -85,7 +85,7 @@ struct HttpParser {
   bool parse(io::IO &);
 
   int
-  statusCode(void) const
+  statusCode() const
   {
     return static_cast<int>(TSHttpHdrStatusGet(buffer_, location_));
   }

--- a/plugins/experimental/inliner/html-parser.h
+++ b/plugins/experimental/inliner/html-parser.h
@@ -35,7 +35,7 @@ namespace inliner
   typedef std::vector<Pair> AttributeVector;
 
   struct Attributes : AttributeVector {
-    operator std::string(void) const;
+    operator std::string() const;
   };
 
   struct Tag {
@@ -104,9 +104,9 @@ namespace inliner
     Attribute::ATTRIBUTES state_;
     Attributes attributes;
 
-    AttributeParser(void) : state_(Attribute::kPreName) {}
+    AttributeParser() : state_(Attribute::kPreName) {}
     void
-    reset(void)
+    reset()
     {
       state_ = Attribute::kPreName;
       attributes.clear();
@@ -133,7 +133,7 @@ namespace inliner
     Tag::TAGS tag_;
     AttributeParser attributeParser_;
 
-    HtmlParser(void) : state_(State::kUndefined), tag_(Tag::kUndefined) {}
+    HtmlParser() : state_(State::kUndefined), tag_(Tag::kUndefined) {}
     virtual ~HtmlParser() {}
     bool parseTag(const char);
     size_t parse(const char *, size_t, size_t o = 0);

--- a/plugins/experimental/inliner/inliner-handler.h
+++ b/plugins/experimental/inliner/inliner-handler.h
@@ -57,14 +57,14 @@ namespace inliner
     Handler(const Handler &) = delete;
     Handler &operator=(const Handler &) = delete;
 
-    void parse(void);
+    void parse();
 
     size_t bypass(const size_t, const size_t) override;
     void handleImage(const Attributes &) override;
 
-    std::string generateId(void);
+    std::string generateId();
 
-    void abort(void);
+    void abort();
   };
 
 } // namespace inliner

--- a/plugins/experimental/inliner/png.h
+++ b/plugins/experimental/inliner/png.h
@@ -63,13 +63,13 @@ namespace inliner
 
     public:
       uint32_t
-      length(void) const
+      length() const
       {
         return (length_[0] << 24) | (length_[1] << 16) | (length_[2] << 8) | length_[3];
       }
 
       std::string
-      type(void) const
+      type() const
       {
         return std::string(type_, 4);
       }

--- a/plugins/experimental/inliner/ts.h
+++ b/plugins/experimental/inliner/ts.h
@@ -58,7 +58,7 @@ namespace io
       TSIOBufferDestroy(buffer);
     }
 
-    IO(void) : buffer(TSIOBufferCreate()), reader(TSIOBufferReaderAlloc(buffer)), vio(nullptr) {}
+    IO() : buffer(TSIOBufferCreate()), reader(TSIOBufferReaderAlloc(buffer)), vio(nullptr) {}
     IO(const TSIOBuffer &b) : buffer(b), reader(TSIOBufferReaderAlloc(buffer)), vio(nullptr) { assert(buffer != nullptr); }
     static IO *read(TSVConn, TSCont, const int64_t);
 
@@ -78,9 +78,9 @@ namespace io
 
     uint64_t copy(const std::string &) const;
 
-    int64_t consume(void) const;
+    int64_t consume() const;
 
-    int64_t done(void) const;
+    int64_t done() const;
   };
 
   struct ReaderSize {
@@ -131,7 +131,7 @@ namespace io
     }
 
     // noncopyable
-    Lock(void) : mutex_(nullptr) {}
+    Lock() : mutex_(nullptr) {}
     Lock(const Lock &) = delete;
 
     Lock(Lock &&l) : mutex_(l.mutex_) { const_cast<TSMutex &>(l.mutex_) = nullptr; }
@@ -166,8 +166,8 @@ namespace io
     WriteOperation &operator<<(const std::string &);
 
     void process(const size_t b = 0);
-    void close(void);
-    void abort(void);
+    void close();
+    void abort();
 
   private:
     WriteOperation(const TSVConn, const TSMutex, const size_t);
@@ -215,10 +215,10 @@ namespace io
       return IOSinkPointer(new IOSink(WriteOperation::Create(std::forward<A>(a)...)));
     }
 
-    void process(void);
-    SinkPointer branch(void);
-    Lock lock(void);
-    void abort(void);
+    void process();
+    SinkPointer branch();
+    Lock lock();
+    void abort();
 
   private:
     IOSink(WriteOperationWeakPointer &&p) : operation_(std::move(p)) {}
@@ -249,7 +249,7 @@ namespace io
       TSIOBufferDestroy(buffer_);
     }
 
-    BufferNode(void) : buffer_(TSIOBufferCreate()), reader_(TSIOBufferReaderAlloc(buffer_))
+    BufferNode() : buffer_(TSIOBufferCreate()), reader_(TSIOBufferReaderAlloc(buffer_))
     {
       assert(buffer_ != nullptr);
       assert(reader_ != nullptr);
@@ -289,7 +289,7 @@ namespace io
     Sink(const Sink &) = delete;
     Sink &operator=(const Sink &) = delete;
 
-    SinkPointer branch(void);
+    SinkPointer branch();
 
     Sink &operator<<(std::string &&);
 

--- a/plugins/experimental/ja3_fingerprint/ja3_fingerprint.cc
+++ b/plugins/experimental/ja3_fingerprint/ja3_fingerprint.cc
@@ -16,12 +16,12 @@
   limitations under the License.
  */
 
-#include <inttypes.h>
+#include <cinttypes>
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
 #include <cerrno>
-#include <stdlib.h>
+#include <cstdlib>
 #include <getopt.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -365,7 +365,8 @@ req_hdr_ja3_handler(TSCont contp, TSEvent event, void *edata)
 static bool
 read_config_option(int argc, const char *argv[], int &raw, int &log)
 {
-  static const struct option longopts[] = {{"ja3raw", no_argument, &raw, 1}, {"ja3log", no_argument, &log, 1}, {0, 0, 0, 0}};
+  static const struct option longopts[] = {
+    {"ja3raw", no_argument, &raw, 1}, {"ja3log", no_argument, &log, 1}, {nullptr, 0, nullptr, 0}};
 
   int opt = 0;
   while ((opt = getopt_long(argc, (char *const *)argv, "", longopts, nullptr)) >= 0) {

--- a/plugins/experimental/magick/magick.cc
+++ b/plugins/experimental/magick/magick.cc
@@ -169,7 +169,7 @@ struct EVPContext {
     EVP_MD_CTX_destroy(context);
   }
 
-  EVPContext(void) : context(EVP_MD_CTX_create()) { assert(nullptr != context); }
+  EVPContext() : context(EVP_MD_CTX_create()) { assert(nullptr != context); }
 };
 
 struct EVPKey {
@@ -181,7 +181,7 @@ struct EVPKey {
     EVP_PKEY_free(key);
   }
 
-  EVPKey(void) : key(EVP_PKEY_new()) { assert(nullptr != key); }
+  EVPKey() : key(EVP_PKEY_new()) { assert(nullptr != key); }
 
   bool
   assign(const char *const k) const
@@ -250,7 +250,7 @@ struct Exception {
     info = DestroyExceptionInfo(info);
   }
 
-  Exception(void) : info(AcquireExceptionInfo()) { assert(nullptr != info); }
+  Exception() : info(AcquireExceptionInfo()) { assert(nullptr != info); }
 };
 
 struct Image {
@@ -262,7 +262,7 @@ struct Image {
     info = DestroyImageInfo(info);
   }
 
-  Image(void) : info(AcquireImageInfo()) { assert(nullptr != info); }
+  Image() : info(AcquireImageInfo()) { assert(nullptr != info); }
 };
 
 struct Wand {
@@ -278,17 +278,17 @@ struct Wand {
     }
   }
 
-  Wand(void) : wand(NewMagickWand()), blob(nullptr) { assert(nullptr != wand); }
+  Wand() : wand(NewMagickWand()), blob(nullptr) { assert(nullptr != wand); }
 
   void
-  clear(void) const
+  clear() const
   {
     assert(nullptr != wand);
     ClearMagickWand(wand);
   }
 
   std::string_view
-  get(void)
+  get()
   {
     assert(nullptr != wand);
     std::size_t length = 0;
@@ -336,7 +336,7 @@ struct Wand {
 struct Core {
   ~Core() { MagickCoreTerminus(); }
 
-  Core(void) { MagickCoreGenesis("/tmp", MagickFalse); }
+  Core() { MagickCoreGenesis("/tmp", MagickFalse); }
 };
 
 } // namespace magick
@@ -362,7 +362,7 @@ struct QueryMap {
   }
 
   void
-  parse(void)
+  parse()
   {
     std::string_view key;
     std::size_t i = 0, j = 0;
@@ -473,7 +473,7 @@ struct ImageTransform : TransformationPlugin {
   }
 
   void
-  handleInputComplete(void) override
+  handleInputComplete() override
   {
     TSDebug(PLUGIN_TAG, "handleInputComplete");
 
@@ -515,7 +515,7 @@ struct GlobalHookPlugin : GlobalPlugin {
   magick::EVPKey *key_;
   ThreadPool threadPool_;
 
-  ~GlobalHookPlugin()
+  ~GlobalHookPlugin() override
   {
     if (nullptr != key_) {
       delete key_;

--- a/plugins/experimental/memcache/tsmemcache.cc
+++ b/plugins/experimental/memcache/tsmemcache.cc
@@ -962,7 +962,7 @@ MC::ascii_incr_decr_event(int event, void *data)
     }
     header.cas = ink_atomic_increment(&next_cas, 1);
     {
-      char *data = 0;
+      char *data = nullptr;
       int len    = 0;
       // must be huge, why convert to a counter ??
       if (cwvc->get_single_data((void **)&data, &len) < 0) {

--- a/plugins/experimental/multiplexer/chunk-decoder.h
+++ b/plugins/experimental/multiplexer/chunk-decoder.h
@@ -55,10 +55,10 @@ public:
   void parseSizeCharacter(const char);
   int parseSize(const char *, const int64_t);
   int decode(const TSIOBufferReader &);
-  bool isSizeState(void) const;
+  bool isSizeState() const;
 
   inline bool
-  isEnd(void) const
+  isEnd() const
   {
     return state_ == State::kEnd;
   }

--- a/plugins/experimental/multiplexer/fetcher.h
+++ b/plugins/experimental/multiplexer/fetcher.h
@@ -47,7 +47,7 @@ struct HttpParser {
   TSMBuffer buffer_;
   TSMLoc location_;
 
-  void destroyParser(void);
+  void destroyParser();
 
   ~HttpParser()
   {
@@ -56,7 +56,7 @@ struct HttpParser {
     destroyParser();
   }
 
-  HttpParser(void) : parsed_(false), parser_(TSHttpParserCreate()), buffer_(TSMBufferCreate()), location_(TSHttpHdrCreate(buffer_))
+  HttpParser() : parsed_(false), parser_(TSHttpParserCreate()), buffer_(TSMBufferCreate()), location_(TSHttpHdrCreate(buffer_))
   {
     TSHttpHdrTypeSet(buffer_, location_, TS_HTTP_TYPE_RESPONSE);
   }
@@ -64,7 +64,7 @@ struct HttpParser {
   bool parse(io::IO &);
 
   int
-  statusCode(void) const
+  statusCode() const
   {
     return static_cast<int>(TSHttpHdrStatusGet(buffer_, location_));
   }

--- a/plugins/experimental/multiplexer/ts.h
+++ b/plugins/experimental/multiplexer/ts.h
@@ -52,7 +52,7 @@ namespace io
       TSIOBufferDestroy(buffer);
     }
 
-    IO(void) : buffer(TSIOBufferCreate()), reader(TSIOBufferReaderAlloc(buffer)), vio(nullptr) {}
+    IO() : buffer(TSIOBufferCreate()), reader(TSIOBufferReaderAlloc(buffer)), vio(nullptr) {}
     IO(const TSIOBuffer &b) : buffer(b), reader(TSIOBufferReaderAlloc(buffer)), vio(nullptr) { assert(buffer != nullptr); }
     static IO *read(TSVConn, TSCont, const int64_t);
 

--- a/plugins/experimental/mysql_remap/lib/iniparser.h
+++ b/plugins/experimental/mysql_remap/lib/iniparser.h
@@ -42,9 +42,9 @@
                                                                 Includes
  ---------------------------------------------------------------------------*/
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 /*
  * The following #include is necessary on many Unixes but not Linux.

--- a/plugins/experimental/mysql_remap/mysql_remap.cc
+++ b/plugins/experimental/mysql_remap/mysql_remap.cc
@@ -187,7 +187,7 @@ TSPluginInit(int argc, const char *argv[])
   my_data *data = (my_data *)malloc(1 * sizeof(my_data));
 
   TSPluginRegistrationInfo info;
-  bool reconnect = 1;
+  bool reconnect = true;
 
   info.plugin_name   = const_cast<char *>(PLUGIN_NAME);
   info.vendor_name   = const_cast<char *>("Apache Software Foundation");

--- a/plugins/experimental/prefetch/common.cc
+++ b/plugins/experimental/prefetch/common.cc
@@ -22,8 +22,8 @@
  * @see common.h
  */
 
-#include <string.h>
-#include <stdlib.h>
+#include <cstring>
+#include <cstdlib>
 
 #include "common.h"
 

--- a/plugins/experimental/prefetch/configs.cc
+++ b/plugins/experimental/prefetch/configs.cc
@@ -54,19 +54,19 @@ isTrue(const char *arg)
 bool
 PrefetchConfig::init(int argc, char *argv[])
 {
-  static const struct option longopt[] = {{const_cast<char *>("front"), optional_argument, 0, 'f'},
-                                          {const_cast<char *>("api-header"), optional_argument, 0, 'h'},
-                                          {const_cast<char *>("next-header"), optional_argument, 0, 'n'},
-                                          {const_cast<char *>("fetch-policy"), optional_argument, 0, 'p'},
-                                          {const_cast<char *>("fetch-count"), optional_argument, 0, 'c'},
-                                          {const_cast<char *>("fetch-path-pattern"), optional_argument, 0, 'e'},
-                                          {const_cast<char *>("fetch-max"), optional_argument, 0, 'x'},
-                                          {const_cast<char *>("replace-host"), optional_argument, 0, 'r'},
-                                          {const_cast<char *>("name-space"), optional_argument, 0, 's'},
-                                          {const_cast<char *>("metrics-prefix"), optional_argument, 0, 'm'},
-                                          {const_cast<char *>("exact-match"), optional_argument, 0, 'y'},
-                                          {const_cast<char *>("log-name"), optional_argument, 0, 'l'},
-                                          {0, 0, 0, 0}};
+  static const struct option longopt[] = {{const_cast<char *>("front"), optional_argument, nullptr, 'f'},
+                                          {const_cast<char *>("api-header"), optional_argument, nullptr, 'h'},
+                                          {const_cast<char *>("next-header"), optional_argument, nullptr, 'n'},
+                                          {const_cast<char *>("fetch-policy"), optional_argument, nullptr, 'p'},
+                                          {const_cast<char *>("fetch-count"), optional_argument, nullptr, 'c'},
+                                          {const_cast<char *>("fetch-path-pattern"), optional_argument, nullptr, 'e'},
+                                          {const_cast<char *>("fetch-max"), optional_argument, nullptr, 'x'},
+                                          {const_cast<char *>("replace-host"), optional_argument, nullptr, 'r'},
+                                          {const_cast<char *>("name-space"), optional_argument, nullptr, 's'},
+                                          {const_cast<char *>("metrics-prefix"), optional_argument, nullptr, 'm'},
+                                          {const_cast<char *>("exact-match"), optional_argument, nullptr, 'y'},
+                                          {const_cast<char *>("log-name"), optional_argument, nullptr, 'l'},
+                                          {nullptr, 0, nullptr, 0}};
 
   bool status = true;
   optind      = 0;

--- a/plugins/experimental/prefetch/fetch.cc
+++ b/plugins/experimental/prefetch/fetch.cc
@@ -25,9 +25,9 @@
 #include <sys/types.h>
 #include <netinet/in.h>
 #include <netinet/ip.h>
-#include <string.h>
+#include <cstring>
 #include <sys/socket.h>
-#include <inttypes.h>
+#include <cinttypes>
 
 #include "ts/ts.h" /* ATS API */
 #include "fetch.h"

--- a/plugins/experimental/prefetch/fetch_policy.cc
+++ b/plugins/experimental/prefetch/fetch_policy.cc
@@ -23,7 +23,7 @@
 
 #include "fetch_policy.h"
 
-#include <string.h>
+#include <cstring>
 
 #include "common.h"
 #include "fetch_policy_lru.h"

--- a/plugins/experimental/prefetch/fetch_policy.h
+++ b/plugins/experimental/prefetch/fetch_policy.h
@@ -25,7 +25,7 @@
 
 #include <list>
 #include <openssl/sha.h>
-#include <string.h>
+#include <cstring>
 #include <string>
 #include <unordered_map>
 

--- a/plugins/experimental/prefetch/fetch_policy_lru.h
+++ b/plugins/experimental/prefetch/fetch_policy_lru.h
@@ -87,15 +87,15 @@ class FetchPolicyLru : public FetchPolicy
 public:
   /* Default size values are also considered minimum. TODO: find out if this works OK. */
   FetchPolicyLru() : _maxSize(10), _size(0){};
-  virtual ~FetchPolicyLru(){};
+  ~FetchPolicyLru() override{};
 
   /* Fetch policy interface methods */
-  bool init(const char *parameters);
-  bool acquire(const std::string &url);
-  bool release(const std::string &url);
-  const char *name();
-  size_t getMaxSize();
-  size_t getSize();
+  bool init(const char *parameters) override;
+  bool acquire(const std::string &url) override;
+  bool release(const std::string &url) override;
+  const char *name() override;
+  size_t getMaxSize() override;
+  size_t getSize() override;
 
 protected:
   LruMap _map;

--- a/plugins/experimental/prefetch/fetch_policy_simple.h
+++ b/plugins/experimental/prefetch/fetch_policy_simple.h
@@ -33,13 +33,13 @@ class FetchPolicySimple : public FetchPolicy
 {
 public:
   FetchPolicySimple() {}
-  virtual ~FetchPolicySimple(){};
-  bool init(const char *parameters);
-  bool acquire(const std::string &url);
-  bool release(const std::string &url);
-  const char *name();
-  size_t getSize();
-  size_t getMaxSize();
+  ~FetchPolicySimple() override{};
+  bool init(const char *parameters) override;
+  bool acquire(const std::string &url) override;
+  bool release(const std::string &url) override;
+  const char *name() override;
+  size_t getSize() override;
+  size_t getMaxSize() override;
 
 private:
   std::unordered_map<std::string, bool> _urls;

--- a/plugins/experimental/prefetch/headers.cc
+++ b/plugins/experimental/prefetch/headers.cc
@@ -21,8 +21,8 @@
  * @brief HTTP headers manipulation.
  */
 
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 
 #include "configs.h"
 #include "headers.h"

--- a/plugins/experimental/prefetch/pattern.cc
+++ b/plugins/experimental/prefetch/pattern.cc
@@ -84,7 +84,7 @@ Pattern::init(const String &config)
     size_t next    = 1;
     do {
       current = next + 1;
-      next    = config.find_first_of("/", current);
+      next    = config.find_first_of('/', current);
     } while (next != String::npos && '\\' == config[next - 1]);
 
     if (next != String::npos) {
@@ -98,7 +98,7 @@ Pattern::init(const String &config)
     start = next + 1;
     do {
       current = next + 1;
-      next    = config.find_first_of("/", current);
+      next    = config.find_first_of('/', current);
     } while (next != String::npos && '\\' == config[next - 1]);
 
     if (next != String::npos) {
@@ -393,8 +393,8 @@ Pattern::compile()
  */
 MultiPattern::~MultiPattern()
 {
-  for (std::vector<Pattern *>::iterator p = this->_list.begin(); p != this->_list.end(); ++p) {
-    delete (*p);
+  for (auto &p : this->_list) {
+    delete p;
   }
 }
 
@@ -428,8 +428,8 @@ MultiPattern::add(Pattern *pattern)
 bool
 MultiPattern::match(const String &subject) const
 {
-  for (std::vector<Pattern *>::const_iterator p = this->_list.begin(); p != this->_list.end(); ++p) {
-    if (nullptr != (*p) && (*p)->match(subject)) {
+  for (auto p : this->_list) {
+    if (nullptr != p && p->match(subject)) {
       return true;
     }
   }
@@ -445,8 +445,8 @@ MultiPattern::match(const String &subject) const
 bool
 MultiPattern::replace(const String &subject, String &result) const
 {
-  for (std::vector<Pattern *>::const_iterator p = this->_list.begin(); p != this->_list.end(); ++p) {
-    if (nullptr != (*p) && (*p)->replace(subject, result)) {
+  for (auto p : this->_list) {
+    if (nullptr != p && p->replace(subject, result)) {
       return true;
     }
   }

--- a/plugins/experimental/prefetch/pattern.h
+++ b/plugins/experimental/prefetch/pattern.h
@@ -73,7 +73,7 @@ private:
 class MultiPattern
 {
 public:
-  MultiPattern(const String name = "") : _name(name) {}
+  MultiPattern(const String &name = "") : _name(name) {}
   virtual ~MultiPattern();
 
   bool empty() const;

--- a/plugins/experimental/prefetch/plugin.cc
+++ b/plugins/experimental/prefetch/plugin.cc
@@ -195,7 +195,7 @@ evaluate(const String &v)
   /* Find out if width is specified (hence leading zeros are required if the width is bigger then the result width) */
   String stmt;
   size_t len = 0;
-  size_t pos = v.find_first_of(":");
+  size_t pos = v.find_first_of(':');
   if (String::npos != pos) {
     stmt.assign(v.substr(0, pos));
     len = getValue(v.substr(pos + 1));
@@ -237,8 +237,8 @@ expand(String &s)
 {
   size_t cur = 0;
   while (String::npos != cur) {
-    size_t start = s.find_first_of("{", cur);
-    size_t stop  = s.find_first_of("}", start);
+    size_t start = s.find_first_of('{', cur);
+    size_t stop  = s.find_first_of('}', start);
 
     if (String::npos != start && String::npos != stop) {
       s.replace(start, stop - start + 1, evaluate(s.substr(start + 1, stop - start - 1)));

--- a/plugins/experimental/slice/Config.cc
+++ b/plugins/experimental/slice/Config.cc
@@ -76,7 +76,7 @@ Config::fromArgs(int const argc, char const *const argv[], char *const errbuf, i
   for (int index = 0; index < argc; ++index) {
     std::string const argstr = argv[index];
 
-    std::size_t const spos = argstr.find_first_of(":");
+    std::size_t const spos = argstr.find_first_of(':');
     if (spos != std::string::npos) {
       std::string key = argstr.substr(0, spos);
       std::string val = argstr.substr(spos + 1);

--- a/plugins/experimental/slice/Data.cc
+++ b/plugins/experimental/slice/Data.cc
@@ -36,7 +36,7 @@ monitor()
 {
   std::lock_guard<std::mutex> guard(mutex);
   //	while (0 < inplay)
-  while (1) {
+  while (true) {
     mutex.unlock();
     std::this_thread::sleep_for(std::chrono::seconds(10));
     std::cerr << "Inplay: " << inplay << std::endl;

--- a/plugins/experimental/ssl_session_reuse/src/ats_ssl_plugin.cc
+++ b/plugins/experimental/ssl_session_reuse/src/ats_ssl_plugin.cc
@@ -22,7 +22,7 @@
 
  */
 
-#include <stdio.h>
+#include <cstdio>
 #include <ts/ts.h>
 #include <ts/apidefs.h>
 #include <openssl/ssl.h>

--- a/plugins/experimental/ssl_session_reuse/src/config.cc
+++ b/plugins/experimental/ssl_session_reuse/src/config.cc
@@ -23,7 +23,7 @@
  */
 
 #include <ts/ts.h>
-#include <string.h>
+#include <cstring>
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -105,7 +105,7 @@ Config::setLastConfigChange()
 bool
 Config::configHasChanged()
 {
-  time_t checkTime = time(0) / cCheckDivisor;
+  time_t checkTime = time(nullptr) / cCheckDivisor;
 
   if (0 == m_lastmtime || m_lastCheck != checkTime) {
     m_lastCheck = checkTime;

--- a/plugins/experimental/ssl_session_reuse/src/openssl_utils.cc
+++ b/plugins/experimental/ssl_session_reuse/src/openssl_utils.cc
@@ -26,10 +26,10 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <string.h>
+#include <cstring>
 #include <pthread.h>
-#include <errno.h>
-#include <math.h>
+#include <cerrno>
+#include <cmath>
 #include <openssl/rand.h>
 #include <pthread.h>
 #include <netinet/in.h>

--- a/plugins/experimental/ssl_session_reuse/src/publish.cc
+++ b/plugins/experimental/ssl_session_reuse/src/publish.cc
@@ -26,7 +26,7 @@
 #include <unistd.h>
 #include <iostream>
 #include <exception>
-#include <string.h>
+#include <cstring>
 #include <memory>
 #include <ts/ts.h>
 #include "common.h"

--- a/plugins/experimental/ssl_session_reuse/src/session_process.cc
+++ b/plugins/experimental/ssl_session_reuse/src/session_process.cc
@@ -22,9 +22,9 @@
 
  */
 
-#include <math.h>
-#include <string.h>
-#include <errno.h>
+#include <cmath>
+#include <cstring>
+#include <cerrno>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
@@ -191,7 +191,7 @@ Cleanup:
 }
 
 int
-decode_id(std::string encoded_id, char *decoded_data, int &decoded_data_len)
+decode_id(const std::string &encoded_id, char *decoded_data, int &decoded_data_len)
 {
   size_t decode_len = 0;
   memset(decoded_data, 0, decoded_data_len);

--- a/plugins/experimental/ssl_session_reuse/src/session_process.h
+++ b/plugins/experimental/ssl_session_reuse/src/session_process.h
@@ -24,7 +24,7 @@
 #pragma once
 
 #include <string>
-#include <math.h>
+#include <cmath>
 
 #define SSL_SESSION_MAX_DER 1024 * 10
 
@@ -42,6 +42,6 @@ int decrypt_session(const std::string &encrypted_data, const unsigned char *key,
                     int32_t &session_len);
 
 int encode_id(const char *id, int idlen, std::string &decoded_data);
-int decode_id(std::string encoded_id, char *decoded_data, int &decoded_data_len);
+int decode_id(const std::string &encoded_id, char *decoded_data, int &decoded_data_len);
 
 int add_session(char *session_id, int session_id_len, const std::string &encrypted_session);

--- a/plugins/experimental/ssl_session_reuse/src/ssl_init.cc
+++ b/plugins/experimental/ssl_session_reuse/src/ssl_init.cc
@@ -23,7 +23,7 @@
  */
 
 #include <string>
-#include <string.h>
+#include <cstring>
 #include "ssl_utils.h"
 #include "Config.h"
 #include "common.h"

--- a/plugins/experimental/ssl_session_reuse/src/ssl_key_utils.cc
+++ b/plugins/experimental/ssl_session_reuse/src/ssl_key_utils.cc
@@ -23,14 +23,14 @@
  */
 
 #include <unistd.h>
-#include <string.h>
+#include <cstring>
 #include <mutex>
 #include <sys/time.h>
 #include <ts/ts.h>
 #include <openssl/rand.h>
 
 #include "ssl_utils.h"
-#include "assert.h"
+#include <cassert>
 #include "redis_auth.h"
 #include "stek.h"
 #include "common.h"
@@ -303,7 +303,7 @@ STEK_Update_Setter_Thread(void *arg)
   stek_master_setter_running = 1;
   TSDebug(PLUGIN, "Will now act as the STEK rotator for pod");
 
-  while (1) {
+  while (true) {
     // Create new STEK, set it for me, and then send it to the POD.
     if ((!STEK_CreateNew(&newKey, 0, 1 /* entropy ensured */)) || (!STEK_Send_To_Network(&newKey))) {
       // Error occurred. We will retry after a short interval.
@@ -381,7 +381,7 @@ STEK_Update_Checker_Thread(void *arg)
 
   lastChangeTime = lastWarningTime = time(&currentTime); // init to current to supress a startup warning.
 
-  while (1) {
+  while (true) {
     if (!stek_initialized && ssl_param.pub) {
       // Launch a request for the master to resend you the ticket key
       std::string redis_channel = ssl_param.cluster_name + "." + STEK_ID_RESEND;

--- a/plugins/experimental/ssl_session_reuse/src/subscriber.cc
+++ b/plugins/experimental/ssl_session_reuse/src/subscriber.cc
@@ -26,7 +26,7 @@
 #include <ts/ts.h>
 #include <openssl/ssl.h>
 #include <hiredis/hiredis.h>
-#include <string.h>
+#include <cstring>
 #include "common.h"
 
 #include "subscriber.h"

--- a/plugins/experimental/sslheaders/util.cc
+++ b/plugins/experimental/sslheaders/util.cc
@@ -78,9 +78,9 @@ SslHdrParseExpansion(const char *spec, SslHdrExpansion &exp)
 
   // Push sep to point to the field selector.
   selector = sep + 1;
-  for (unsigned i = 0; i < fields.size(); ++i) {
-    if (strcmp(selector, fields[i].name) == 0) {
-      exp.field = fields[i].field;
+  for (auto field : fields) {
+    if (strcmp(selector, field.name) == 0) {
+      exp.field = field.field;
       return true;
     }
   }

--- a/plugins/experimental/traffic_dump/traffic_dump.cc
+++ b/plugins/experimental/traffic_dump/traffic_dump.cc
@@ -18,7 +18,7 @@
   limitations under the License.
  */
 
-#include <inttypes.h>
+#include <cinttypes>
 
 #include <cstdio>
 #include <cstdlib>
@@ -28,7 +28,7 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
+#include <cerrno>
 #include <arpa/inet.h>
 #include <netinet/in.h>
 

--- a/plugins/header_rewrite/condition.h
+++ b/plugins/header_rewrite/condition.h
@@ -49,7 +49,7 @@ class Condition : public Statement
 public:
   Condition() { TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for Condition"); }
 
-  virtual ~Condition()
+  ~Condition() override
   {
     TSDebug(PLUGIN_NAME_DBG, "Calling DTOR for Condition");
     delete _matcher;

--- a/plugins/header_rewrite/header_rewrite.cc
+++ b/plugins/header_rewrite/header_rewrite.cc
@@ -42,13 +42,13 @@ initGeoIP()
 {
   GeoIPDBTypes dbs[] = {GEOIP_COUNTRY_EDITION, GEOIP_COUNTRY_EDITION_V6, GEOIP_ASNUM_EDITION, GEOIP_ASNUM_EDITION_V6};
 
-  for (unsigned i = 0; i < sizeof(dbs) / sizeof(dbs[0]); ++i) {
-    if (!gGeoIP[dbs[i]] && GeoIP_db_avail(dbs[i])) {
+  for (auto &db : dbs) {
+    if (!gGeoIP[db] && GeoIP_db_avail(db)) {
       // GEOIP_STANDARD seems to break threaded apps...
-      gGeoIP[dbs[i]] = GeoIP_open_type(dbs[i], GEOIP_MMAP_CACHE);
+      gGeoIP[db] = GeoIP_open_type(db, GEOIP_MMAP_CACHE);
 
-      char *db_info = GeoIP_database_info(gGeoIP[dbs[i]]);
-      TSDebug(PLUGIN_NAME, "initialized GeoIP-DB[%d] %s", dbs[i], db_info);
+      char *db_info = GeoIP_database_info(gGeoIP[db]);
+      TSDebug(PLUGIN_NAME, "initialized GeoIP-DB[%d] %s", db, db_info);
       free(db_info);
     }
   }

--- a/plugins/header_rewrite/matcher.h
+++ b/plugins/header_rewrite/matcher.h
@@ -67,7 +67,7 @@ public:
   };
 
   void
-  setRegex(const std::string /* data ATS_UNUSED */)
+  setRegex(const std::string & /* data ATS_UNUSED */)
   {
     if (!helper.setRegexMatch(_data)) {
       std::stringstream ss;

--- a/plugins/header_rewrite/value.cc
+++ b/plugins/header_rewrite/value.cc
@@ -33,8 +33,8 @@
 Value::~Value()
 {
   TSDebug(PLUGIN_NAME_DBG, "Calling DTOR for Value");
-  for (auto it = _cond_vals.begin(); it != _cond_vals.end(); it++) {
-    delete *it;
+  for (auto &_cond_val : _cond_vals) {
+    delete _cond_val;
   }
 }
 
@@ -47,8 +47,7 @@ Value::set_value(const std::string &val)
     SimpleTokenizer tokenizer(_value);
     auto tokens = tokenizer.get_tokens();
 
-    for (auto it = tokens.begin(); it != tokens.end(); it++) {
-      std::string token    = *it;
+    for (auto token : tokens) {
       Condition *tcond_val = nullptr;
 
       if (token.substr(0, 2) == "%{") {

--- a/plugins/header_rewrite/value.h
+++ b/plugins/header_rewrite/value.h
@@ -41,7 +41,7 @@ class Value : Statement
 public:
   Value() { TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for Value"); }
 
-  virtual ~Value();
+  ~Value() override;
 
   // noncopyable
   Value(const Value &) = delete;
@@ -53,8 +53,8 @@ public:
   append_value(std::string &s, const Resources &res) const
   {
     if (!_cond_vals.empty()) {
-      for (auto it = _cond_vals.begin(); it != _cond_vals.end(); it++) {
-        (*it)->append_value(s, res);
+      for (auto _cond_val : _cond_vals) {
+        _cond_val->append_value(s, res);
       }
     } else {
       s += _value;

--- a/proxy/HostStatus.h
+++ b/proxy/HostStatus.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include <time.h>
+#include <ctime>
 #include <string>
 #include "tscore/ink_rwlock.h"
 #include "records/P_RecProcess.h"

--- a/proxy/RegressionSM.cc
+++ b/proxy/RegressionSM.cc
@@ -229,8 +229,8 @@ RegressionSM::RegressionSM(const RegressionSM &ao) : Continuation(ao)
   parent   = &o;
   nwaiting = o.nwaiting;
 
-  for (unsigned i = 0; i < o.children.size(); i++) {
-    children.push_back(o.children[i]->clone());
+  for (auto &i : o.children) {
+    children.push_back(i->clone());
   }
 
   n              = o.n;

--- a/proxy/StatPages.h
+++ b/proxy/StatPages.h
@@ -97,17 +97,17 @@ public:
   ~BaseStatPagesHandler() override { resp_clear(); };
 
 protected:
-  inkcoreapi void resp_clear(void);
+  inkcoreapi void resp_clear();
   inkcoreapi void resp_add(const char *fmt, ...);
-  inkcoreapi void resp_add_sep(void);
+  inkcoreapi void resp_add_sep();
   inkcoreapi void resp_begin(const char *title);
-  inkcoreapi void resp_end(void);
-  void resp_begin_numbered(void);
-  void resp_end_numbered(void);
-  inkcoreapi void resp_begin_unnumbered(void);
-  inkcoreapi void resp_end_unnumbered(void);
-  inkcoreapi void resp_begin_item(void);
-  void resp_end_item(void);
+  inkcoreapi void resp_end();
+  void resp_begin_numbered();
+  void resp_end_numbered();
+  inkcoreapi void resp_begin_unnumbered();
+  inkcoreapi void resp_end_unnumbered();
+  inkcoreapi void resp_begin_item();
+  void resp_end_item();
   inkcoreapi void resp_begin_table(int border, int columns, int percent);
   inkcoreapi void resp_end_table();
   inkcoreapi void resp_begin_row();

--- a/proxy/TransformInternal.h
+++ b/proxy/TransformInternal.h
@@ -55,21 +55,21 @@ class TransformVConnection : public TransformVCChain
 {
 public:
   TransformVConnection(Continuation *cont, APIHook *hooks);
-  ~TransformVConnection();
+  ~TransformVConnection() override;
 
   int handle_event(int event, void *edata);
 
-  VIO *do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf);
-  VIO *do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool owner = false);
-  void do_io_close(int lerrno = -1);
-  void do_io_shutdown(ShutdownHowTo_t howto);
+  VIO *do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf) override;
+  VIO *do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool owner = false) override;
+  void do_io_close(int lerrno = -1) override;
+  void do_io_shutdown(ShutdownHowTo_t howto) override;
 
-  void reenable(VIO *vio);
+  void reenable(VIO *vio) override;
 
   /** Compute the backlog.
       @return The actual backlog, or a value at least @a limit.
   */
-  virtual uint64_t backlog(uint64_t limit = UINT64_MAX);
+  uint64_t backlog(uint64_t limit = UINT64_MAX) override;
 
 public:
   VConnection *m_transform;
@@ -96,7 +96,7 @@ class NullTransform : public INKVConnInternal
 {
 public:
   NullTransform(ProxyMutex *mutex);
-  ~NullTransform();
+  ~NullTransform() override;
 
   int handle_event(int event, void *edata);
 
@@ -111,7 +111,7 @@ class RangeTransform : public INKVConnInternal
 public:
   RangeTransform(ProxyMutex *mutex, RangeRecord *ranges, int num_fields, HTTPHdr *transform_resp, const char *content_type,
                  int content_type_len, int64_t content_length);
-  ~RangeTransform();
+  ~RangeTransform() override;
 
   int handle_event(int event, void *edata);
 

--- a/proxy/hdrs/HdrHeap.cc
+++ b/proxy/hdrs/HdrHeap.cc
@@ -707,25 +707,25 @@ HdrHeap::marshal(char *buf, int len)
     str_heaps++;
   }
 
-  for (unsigned i = 0; i < HDR_BUF_RONLY_HEAPS; ++i) {
-    if (m_ronly_heap[i].m_heap_start != nullptr) {
-      if (m_ronly_heap[i].m_heap_len > len) {
+  for (auto &i : m_ronly_heap) {
+    if (i.m_heap_start != nullptr) {
+      if (i.m_heap_len > len) {
         goto Failed;
       }
 
-      memcpy(b, m_ronly_heap[i].m_heap_start, m_ronly_heap[i].m_heap_len);
+      memcpy(b, i.m_heap_start, i.m_heap_len);
 
       // Add translation table entry for string heaps
       //   FIX ME - possible offset overflow issues?
-      str_xlation[str_heaps].start  = m_ronly_heap[i].m_heap_start;
-      str_xlation[str_heaps].end    = m_ronly_heap[i].m_heap_start + m_ronly_heap[i].m_heap_len;
+      str_xlation[str_heaps].start  = i.m_heap_start;
+      str_xlation[str_heaps].end    = i.m_heap_start + i.m_heap_len;
       str_xlation[str_heaps].offset = str_xlation[str_heaps].start - (b - buf);
       ink_assert(str_xlation[str_heaps].start <= str_xlation[str_heaps].end);
 
       str_heaps++;
-      b += m_ronly_heap[i].m_heap_len;
-      len -= m_ronly_heap[i].m_heap_len;
-      str_size += m_ronly_heap[i].m_heap_len;
+      b += i.m_heap_len;
+      len -= i.m_heap_len;
+      str_size += i.m_heap_len;
     }
   }
 
@@ -1024,10 +1024,10 @@ HdrHeap::inherit_string_heaps(const HdrHeap *inherit_from)
     free_slots--;
     inherit_str_size = inherit_from->m_read_write_heap->m_heap_size;
   }
-  for (unsigned index = 0; index < HDR_BUF_RONLY_HEAPS; ++index) {
-    if (inherit_from->m_ronly_heap[index].m_heap_start != nullptr) {
+  for (const auto &index : inherit_from->m_ronly_heap) {
+    if (index.m_heap_start != nullptr) {
       free_slots--;
-      inherit_str_size += inherit_from->m_ronly_heap[index].m_heap_len;
+      inherit_str_size += index.m_heap_len;
     } else {
       // Heaps are allocated from the front of the array, so if
       //  we hit a NULL, we know we can stop

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -921,7 +921,7 @@ set_negative_caching_list(const char *name, RecDataT dtype, RecData data, HttpCo
       } else if (n <= 0 || n >= HTTP_STATUS_NUMBER) {
         Error("Invalid status code '%.*s' for negative caching: out of range", static_cast<int>(token.size()), token.data());
       } else {
-        set[n] = 1;
+        set[n] = true;
       }
     }
   }

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -1112,4 +1112,4 @@ is_response_body_precluded(HTTPStatus status_code, int method)
   }
 }
 
-inkcoreapi extern ink_time_t ink_local_time(void);
+inkcoreapi extern ink_time_t ink_local_time();

--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -529,11 +529,11 @@ HttpTunnel::reset()
 {
   ink_assert(active == false);
 #ifdef DEBUG
-  for (int i = 0; i < MAX_PRODUCERS; ++i) {
-    ink_assert(producers[i].alive == false);
+  for (auto &producer : producers) {
+    ink_assert(producer.alive == false);
   }
-  for (int j = 0; j < MAX_CONSUMERS; ++j) {
-    ink_assert(consumers[j].alive == false);
+  for (auto &consumer : consumers) {
+    ink_assert(consumer.alive == false);
   }
 #endif
 

--- a/proxy/http/HttpUpdateSM.h
+++ b/proxy/http/HttpUpdateSM.h
@@ -50,7 +50,7 @@ public:
   HttpUpdateSM();
 
   static HttpUpdateSM *allocate();
-  void destroy();
+  void destroy() override;
 
   Action *start_scheduled_update(Continuation *cont, HTTPHdr *req);
 
@@ -61,9 +61,9 @@ public:
   int cb_event;
 
 protected:
-  void handle_api_return();
-  void set_next_state();
-  int kill_this_async_hook(int event, void *data);
+  void handle_api_return() override;
+  void set_next_state() override;
+  int kill_this_async_hook(int event, void *data) override;
 };
 
 inline HttpUpdateSM *

--- a/proxy/http/remap/AclFiltering.h
+++ b/proxy/http/remap/AclFiltering.h
@@ -64,7 +64,7 @@ struct src_ip_info_t {
 class acl_filter_rule
 {
 private:
-  void reset(void);
+  void reset();
 
 public:
   acl_filter_rule *next;
@@ -98,7 +98,7 @@ public:
   ~acl_filter_rule();
   void name(const char *_name = nullptr);
   int add_argv(int _argc, char *_argv[]);
-  void print(void);
+  void print();
 
   static acl_filter_rule *find_byname(acl_filter_rule *list, const char *name);
   static void delete_byname(acl_filter_rule **list, const char *name);

--- a/proxy/http/remap/UrlRewrite.cc
+++ b/proxy/http/remap/UrlRewrite.cc
@@ -144,8 +144,8 @@ void
 UrlRewrite::_destroyTable(std::unique_ptr<URLTable> &h_table)
 {
   if (h_table) {
-    for (auto it = h_table->begin(); it != h_table->end(); ++it) {
-      delete it->second;
+    for (auto &it : *h_table) {
+      delete it.second;
     }
   }
 }
@@ -183,8 +183,8 @@ void
 UrlRewrite::PrintStore(MappingsStore &store)
 {
   if (store.hash_lookup) {
-    for (auto it = store.hash_lookup->begin(); it != store.hash_lookup->end(); ++it) {
-      it->second->Print();
+    for (auto &it : *store.hash_lookup) {
+      it.second->Print();
     }
   }
 

--- a/proxy/http2/Http2DependencyTree.h
+++ b/proxy/http2/Http2DependencyTree.h
@@ -177,7 +177,7 @@ template <typename T>
 void
 Tree<T>::_dump(Node *node, std::ostream &output) const
 {
-  output << "{ \"id\":\"" << node->id << "/" << node->weight << "/" << node->point << "/" << ((node->t != nullptr) ? "1" : "0")
+  output << R"({ "id":")" << node->id << "/" << node->weight << "/" << node->point << "/" << ((node->t != nullptr) ? "1" : "0")
          << "/" << ((node->active) ? "a" : "d") << "\",";
   // Dump the children
   output << " \"c\":[";

--- a/proxy/http2/RegressionHPACK.cc
+++ b/proxy/http2/RegressionHPACK.cc
@@ -47,7 +47,7 @@ const static struct {
   uint8_t *encoded_field;
   int encoded_field_len;
   int prefix;
-} integer_test_case[] = {{10, (uint8_t *)"\x0A", 1, 5}, {1337, (uint8_t *)"\x1F\x9A\x0A", 3, 5}, {42, (uint8_t *)"\x2A", 1, 8}};
+} integer_test_case[] = {{10, (uint8_t *)"\x0A", 1, 5}, {1337, (uint8_t *)"\x1F\x9A\x0A", 3, 5}, {42, (uint8_t *)R"(*)", 1, 8}};
 
 // Example: custom-key: custom-header
 const static struct {

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -438,7 +438,7 @@ LogAccess::marshal_ip(char *dest, sockaddr const *ip)
 }
 
 inline int
-LogAccess::unmarshal_with_map(int64_t code, char *dest, int len, Ptr<LogFieldAliasMap> map, const char *msg)
+LogAccess::unmarshal_with_map(int64_t code, char *dest, int len, const Ptr<LogFieldAliasMap> &map, const char *msg)
 {
   long int codeStrLen = 0;
 
@@ -951,7 +951,7 @@ LogAccess::unmarshal_ip_to_hex(char **buf, char *dest, int len)
   -------------------------------------------------------------------------*/
 
 int
-LogAccess::unmarshal_hierarchy(char **buf, char *dest, int len, Ptr<LogFieldAliasMap> map)
+LogAccess::unmarshal_hierarchy(char **buf, char *dest, int len, const Ptr<LogFieldAliasMap> &map)
 {
   ink_assert(buf != nullptr);
   ink_assert(*buf != nullptr);
@@ -969,7 +969,7 @@ LogAccess::unmarshal_hierarchy(char **buf, char *dest, int len, Ptr<LogFieldAlia
   -------------------------------------------------------------------------*/
 
 int
-LogAccess::unmarshal_finish_status(char **buf, char *dest, int len, Ptr<LogFieldAliasMap> map)
+LogAccess::unmarshal_finish_status(char **buf, char *dest, int len, const Ptr<LogFieldAliasMap> &map)
 {
   ink_assert(buf != nullptr);
   ink_assert(*buf != nullptr);
@@ -987,7 +987,7 @@ LogAccess::unmarshal_finish_status(char **buf, char *dest, int len, Ptr<LogField
   -------------------------------------------------------------------------*/
 
 int
-LogAccess::unmarshal_cache_code(char **buf, char *dest, int len, Ptr<LogFieldAliasMap> map)
+LogAccess::unmarshal_cache_code(char **buf, char *dest, int len, const Ptr<LogFieldAliasMap> &map)
 {
   ink_assert(buf != nullptr);
   ink_assert(*buf != nullptr);
@@ -1005,7 +1005,7 @@ LogAccess::unmarshal_cache_code(char **buf, char *dest, int len, Ptr<LogFieldAli
   -------------------------------------------------------------------------*/
 
 int
-LogAccess::unmarshal_cache_hit_miss(char **buf, char *dest, int len, Ptr<LogFieldAliasMap> map)
+LogAccess::unmarshal_cache_hit_miss(char **buf, char *dest, int len, const Ptr<LogFieldAliasMap> &map)
 {
   ink_assert(buf != nullptr);
   ink_assert(*buf != nullptr);
@@ -1015,7 +1015,7 @@ LogAccess::unmarshal_cache_hit_miss(char **buf, char *dest, int len, Ptr<LogFiel
 }
 
 int
-LogAccess::unmarshal_cache_write_code(char **buf, char *dest, int len, Ptr<LogFieldAliasMap> map)
+LogAccess::unmarshal_cache_write_code(char **buf, char *dest, int len, const Ptr<LogFieldAliasMap> &map)
 {
   ink_assert(buf != nullptr);
   ink_assert(*buf != nullptr);

--- a/proxy/logging/LogAccess.h
+++ b/proxy/logging/LogAccess.h
@@ -300,14 +300,14 @@ public:
   static int unmarshal_ip(char **buf, IpEndpoint *dest);
   static int unmarshal_ip_to_str(char **buf, char *dest, int len);
   static int unmarshal_ip_to_hex(char **buf, char *dest, int len);
-  static int unmarshal_hierarchy(char **buf, char *dest, int len, Ptr<LogFieldAliasMap> map);
-  static int unmarshal_finish_status(char **buf, char *dest, int len, Ptr<LogFieldAliasMap> map);
-  static int unmarshal_cache_code(char **buf, char *dest, int len, Ptr<LogFieldAliasMap> map);
-  static int unmarshal_cache_hit_miss(char **buf, char *dest, int len, Ptr<LogFieldAliasMap> map);
-  static int unmarshal_cache_write_code(char **buf, char *dest, int len, Ptr<LogFieldAliasMap> map);
+  static int unmarshal_hierarchy(char **buf, char *dest, int len, const Ptr<LogFieldAliasMap> &map);
+  static int unmarshal_finish_status(char **buf, char *dest, int len, const Ptr<LogFieldAliasMap> &map);
+  static int unmarshal_cache_code(char **buf, char *dest, int len, const Ptr<LogFieldAliasMap> &map);
+  static int unmarshal_cache_hit_miss(char **buf, char *dest, int len, const Ptr<LogFieldAliasMap> &map);
+  static int unmarshal_cache_write_code(char **buf, char *dest, int len, const Ptr<LogFieldAliasMap> &map);
   static int unmarshal_client_protocol_stack(char **buf, char *dest, int len, Ptr<LogFieldAliasMap> map);
 
-  static int unmarshal_with_map(int64_t code, char *dest, int len, Ptr<LogFieldAliasMap> map, const char *msg = nullptr);
+  static int unmarshal_with_map(int64_t code, char *dest, int len, const Ptr<LogFieldAliasMap> &map, const char *msg = nullptr);
 
   static int unmarshal_record(char **buf, char *dest, int len);
 
@@ -359,10 +359,10 @@ private:
   char *m_cache_lookup_url_canon_str;
   int m_cache_lookup_url_canon_len;
 
-  void validate_unmapped_url(void);
-  void validate_unmapped_url_path(void);
+  void validate_unmapped_url();
+  void validate_unmapped_url_path();
 
-  void validate_lookup_url(void);
+  void validate_lookup_url();
 };
 
 inline int

--- a/proxy/logging/LogBuffer.h
+++ b/proxy/logging/LogBuffer.h
@@ -261,9 +261,9 @@ public:
   ~LogBufferList();
 
   void add(LogBuffer *lb);
-  LogBuffer *get(void);
+  LogBuffer *get();
   int
-  get_size(void)
+  get_size()
   {
     return m_size;
   }

--- a/proxy/logging/LogField.h
+++ b/proxy/logging/LogField.h
@@ -79,7 +79,7 @@ public:
   typedef int (LogAccess::*MarshalFunc)(char *buf);
   typedef int (*UnmarshalFunc)(char **buf, char *dest, int len);
   typedef int (*UnmarshalFuncWithSlice)(char **buf, char *dest, int len, LogSlice *slice);
-  typedef int (*UnmarshalFuncWithMap)(char **buf, char *dest, int len, Ptr<LogFieldAliasMap> map);
+  typedef int (*UnmarshalFuncWithMap)(char **buf, char *dest, int len, const Ptr<LogFieldAliasMap> &map);
   typedef void (LogAccess::*SetFunc)(char *buf, int len);
 
   enum Type {
@@ -177,7 +177,7 @@ public:
   void set_aggregate_op(Aggregate agg_op);
   void update_aggregate(int64_t val);
 
-  static void init_milestone_container(void);
+  static void init_milestone_container();
   static Container valid_container_name(char *name);
   static Aggregate valid_aggregate_name(char *name);
   static bool fieldlist_contains_aggregates(const char *fieldlist);

--- a/src/traffic_cache_tool/CacheDefs.h
+++ b/src/traffic_cache_tool/CacheDefs.h
@@ -398,7 +398,7 @@ dir_from_offset(int64_t i, CacheDirEntry *seg)
 {
 #if DIR_DEPTH < 5
   if (!i)
-    return 0;
+    return nullptr;
   return dir_in_seg(seg, i);
 #else
   i = i + ((i - 1) / (DIR_DEPTH - 1));

--- a/src/traffic_cache_tool/CacheTool.cc
+++ b/src/traffic_cache_tool/CacheTool.cc
@@ -1219,7 +1219,7 @@ dir_check()
 }
 
 void
-walk_bucket_chain(std::string devicePath)
+walk_bucket_chain(const std::string &devicePath)
 {
   Cache cache;
   if ((err = cache.loadSpan(SpanFile))) {
@@ -1237,7 +1237,7 @@ walk_bucket_chain(std::string devicePath)
 }
 
 void
-Clear_Span(std::string devicePath)
+Clear_Span(const std::string &devicePath)
 {
   Cache cache;
   if ((err = cache.loadSpan(SpanFile))) {
@@ -1253,7 +1253,7 @@ Clear_Span(std::string devicePath)
 }
 
 void
-Check_Freelist(std::string devicePath)
+Check_Freelist(const std::string &devicePath)
 {
   Cache cache;
   if ((err = cache.loadSpan(SpanFile))) {

--- a/src/traffic_layout/file_system.cc
+++ b/src/traffic_layout/file_system.cc
@@ -73,15 +73,15 @@ create_directory(const std::string &dir)
 
   int ret = 0, pos = 0, pos1 = 0;
   if ((s[0] == '.') || (s[0] == '/')) {
-    pos1 = s.find("/") + 1;
+    pos1 = s.find('/') + 1;
   }
-  pos = s.find("/", pos1);
+  pos = s.find('/', pos1);
 
   ret  = mkdir(s.substr(0, pos).c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
   pos1 = pos + 1;
   // create directory one layer by one layer
   while (true) {
-    pos = s.find("/", pos1);
+    pos = s.find('/', pos1);
     if ((size_t)pos == s.npos) {
       break;
     }
@@ -192,7 +192,7 @@ filter_ts_files(const std::string &dir, const std::string &dst_path)
   // ----- filter traffic server related files -----
   if (dir == LAYOUT_BINDIR || dir == LAYOUT_SBINDIR) {
     // check if executable is in the list of traffic server executables. If not, end the copying.
-    if (executables.find(dst_path.substr(dst_path.find_last_of("/") + 1)) == executables.end()) {
+    if (executables.find(dst_path.substr(dst_path.find_last_of('/') + 1)) == executables.end()) {
       return false;
     }
   }

--- a/src/traffic_logcat/logcat.cc
+++ b/src/traffic_logcat/logcat.cc
@@ -198,7 +198,7 @@ process_file(int in_fd, int out_fd)
     // see if there is an alternate format request from the command
     // line
     //
-    const char *alt_format = NULL;
+    const char *alt_format = nullptr;
     // convert the buffer to ascii entries and place onto stdout
     //
     if (header->fmt_fieldlist()) {
@@ -218,7 +218,7 @@ open_output_file(char *output_file)
     if (access(output_file, F_OK)) {
       if (errno != ENOENT) {
         fprintf(stderr, "Error accessing output file %s: ", output_file);
-        perror(0);
+        perror(nullptr);
         file_desc = -1;
       }
     } else {
@@ -235,7 +235,7 @@ open_output_file(char *output_file)
 
     if (file_desc < 0) {
       fprintf(stderr, "Error while opening output file %s: ", output_file);
-      perror(0);
+      perror(nullptr);
     }
   }
 
@@ -303,7 +303,7 @@ main(int /* argc ATS_UNUSED */, const char *argv[])
       int in_fd = open(file_arguments[i], O_RDONLY);
       if (in_fd < 0) {
         fprintf(stderr, "Error opening input file %s: ", file_arguments[i]);
-        perror(0);
+        perror(nullptr);
         error = DATA_PROCESSING_ERROR;
       } else {
 #if HAVE_POSIX_FADVISE

--- a/src/traffic_logstats/logstats.cc
+++ b/src/traffic_logstats/logstats.cc
@@ -753,7 +753,7 @@ struct ExitStatus {
   }
 
   void
-  append(const std::string s)
+  append(const std::string &s)
   {
     ink_strlcat(notice, s.c_str(), sizeof(notice));
   }

--- a/src/traffic_server/CoreUtils.cc
+++ b/src/traffic_server/CoreUtils.cc
@@ -100,9 +100,9 @@ int program_counter = 0;
 
 #if defined(darwin) || defined(freebsd) || defined(solaris) || defined(openbsd) // FIXME: solaris x86
 // TODO: Cleanup multiple includes
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdint.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
 #include "tscore/ink_platform.h"
 #include "CoreUtils.h"
 #endif /* darwin || freebsd || solaris */

--- a/src/traffic_server/CoreUtils.h
+++ b/src/traffic_server/CoreUtils.h
@@ -55,11 +55,11 @@ struct core_stack_state {
 #endif // linux check
 
 #if defined(darwin) || defined(freebsd) || defined(solaris) || defined(openbsd) // FIXME: solaris x86
-#include <stdio.h>
+#include <cstdio>
 #include <unistd.h>
-#include <stdlib.h>
-#include <string.h>
-#include <assert.h>
+#include <cstdlib>
+#include <cstring>
+#include <cassert>
 
 #define NO_OF_ARGS                                              \
   10 /* The argument depth up to which we would be looking into \

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -1777,28 +1777,28 @@ TShrtime()
 ////////////////////////////////////////////////////////////////////
 
 const char *
-TSInstallDirGet(void)
+TSInstallDirGet()
 {
   static std::string prefix = Layout::get()->prefix;
   return prefix.c_str();
 }
 
 const char *
-TSConfigDirGet(void)
+TSConfigDirGet()
 {
   static std::string sysconfdir = RecConfigReadConfigDir();
   return sysconfdir.c_str();
 }
 
 const char *
-TSRuntimeDirGet(void)
+TSRuntimeDirGet()
 {
   static std::string runtimedir = RecConfigReadRuntimeDir();
   return runtimedir.c_str();
 }
 
 const char *
-TSTrafficServerVersionGet(void)
+TSTrafficServerVersionGet()
 {
   return traffic_server_version;
 }
@@ -1820,7 +1820,7 @@ TSTrafficServerVersionGetPatch()
 }
 
 const char *
-TSPluginDirGet(void)
+TSPluginDirGet()
 {
   static std::string path = RecConfigReadPluginDir();
   return path.c_str();
@@ -1962,7 +1962,7 @@ TSHandleMLocRelease(TSMBuffer bufp, TSMLoc parent, TSMLoc mloc)
 // TSMBuffer: pointers to HdrHeapSDKHandle objects
 
 TSMBuffer
-TSMBufferCreate(void)
+TSMBufferCreate()
 {
   TSMBuffer bufp;
   HdrHeapSDKHandle *new_heap = new HdrHeapSDKHandle;
@@ -2456,7 +2456,7 @@ TSIpStringToAddr(const char *str, size_t str_len, sockaddr *addr)
 /**************/
 
 TSMimeParser
-TSMimeParserCreate(void)
+TSMimeParserCreate()
 {
   TSMimeParser parser = reinterpret_cast<TSMimeParser>(ats_malloc(sizeof(MIMEParser)));
 
@@ -3547,7 +3547,7 @@ TSMimeHdrFieldValueDelete(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx)
 /* HttpParser */
 /**************/
 TSHttpParser
-TSHttpParserCreate(void)
+TSHttpParserCreate()
 {
   TSHttpParser parser = reinterpret_cast<TSHttpParser>(ats_malloc(sizeof(HTTPParser)));
   http_parser_init((HTTPParser *)parser);
@@ -4039,7 +4039,7 @@ sdk_sanity_check_cachekey(TSCacheKey key)
 }
 
 TSCacheKey
-TSCacheKeyCreate(void)
+TSCacheKeyCreate()
 {
   TSCacheKey key = (TSCacheKey) new CacheInfo();
 
@@ -4249,7 +4249,7 @@ TSCacheHttpInfoDestroy(TSCacheHttpInfo infop)
 }
 
 TSCacheHttpInfo
-TSCacheHttpInfoCreate(void)
+TSCacheHttpInfoCreate()
 {
   CacheHTTPInfo *info = new CacheHTTPInfo;
   info->create();
@@ -6367,7 +6367,7 @@ TSHttpTxnLookingUpTypeGet(TSHttpTxn txnp)
 }
 
 int
-TSHttpCurrentClientConnectionsGet(void)
+TSHttpCurrentClientConnectionsGet()
 {
   int64_t S;
 
@@ -6376,7 +6376,7 @@ TSHttpCurrentClientConnectionsGet(void)
 }
 
 int
-TSHttpCurrentActiveClientConnectionsGet(void)
+TSHttpCurrentActiveClientConnectionsGet()
 {
   int64_t S;
 
@@ -6385,7 +6385,7 @@ TSHttpCurrentActiveClientConnectionsGet(void)
 }
 
 int
-TSHttpCurrentIdleClientConnectionsGet(void)
+TSHttpCurrentIdleClientConnectionsGet()
 {
   int64_t total  = 0;
   int64_t active = 0;
@@ -6401,7 +6401,7 @@ TSHttpCurrentIdleClientConnectionsGet(void)
 }
 
 int
-TSHttpCurrentCacheConnectionsGet(void)
+TSHttpCurrentCacheConnectionsGet()
 {
   int64_t S;
 
@@ -6410,7 +6410,7 @@ TSHttpCurrentCacheConnectionsGet(void)
 }
 
 int
-TSHttpCurrentServerConnectionsGet(void)
+TSHttpCurrentServerConnectionsGet()
 {
   int64_t S;
 
@@ -7458,7 +7458,7 @@ TSMatcherExtractIPRange(char *match_str, sockaddr *addr1, sockaddr *addr2)
 }
 
 TSMatcherLine
-TSMatcherLineCreate(void)
+TSMatcherLineCreate()
 {
   return reinterpret_cast<TSMatcherLine>(ats_malloc(sizeof(matcher_line)));
 }
@@ -9156,7 +9156,7 @@ TSSslSessionRemove(const TSSslSessionID *session_id)
 
 // APIs for managing and using UUIDs.
 TSUuid
-TSUuidCreate(void)
+TSUuidCreate()
 {
   ATSUuid *uuid = new ATSUuid();
   return (TSUuid)uuid;
@@ -9196,7 +9196,7 @@ TSUuidInitialize(TSUuid uuid, TSUuidVersion v)
 }
 
 TSUuid
-TSProcessUuidGet(void)
+TSProcessUuidGet()
 {
   Machine *machine = Machine::instance();
   return (TSUuid)(&machine->uuid);

--- a/src/traffic_server/InkAPITest.cc
+++ b/src/traffic_server/InkAPITest.cc
@@ -160,7 +160,7 @@ static char *generate_response(const char *request);
 static int get_request_id(TSHttpTxn txnp);
 
 /* client side */
-static ClientTxn *synclient_txn_create(void);
+static ClientTxn *synclient_txn_create();
 static int synclient_txn_delete(ClientTxn *txn);
 static void synclient_txn_close(ClientTxn *txn);
 static int synclient_txn_send_request(ClientTxn *txn, char *request);
@@ -503,7 +503,7 @@ get_response_id(TSHttpTxn txnp)
 //////////////////////////////////////////////////////////////////////////////
 
 static ClientTxn *
-synclient_txn_create(void)
+synclient_txn_create()
 {
   const HttpProxyPort *proxy_port;
 

--- a/src/traffic_top/stats.h
+++ b/src/traffic_top/stats.h
@@ -73,7 +73,7 @@ public:
 
       // set the host
       size_t start = _url.find(":");
-      size_t end   = _url.find("/", start + 3);
+      size_t end   = _url.find('/', start + 3);
       _host        = _url.substr(start + 3, end - start - 3);
       end          = _host.find(":");
       if (end != string::npos) {

--- a/src/traffic_wccp/wccp_client.cc
+++ b/src/traffic_wccp/wccp_client.cc
@@ -20,9 +20,9 @@
     limitations under the License.
  */
 
-#include <stdio.h>
+#include <cstdio>
 #include <unistd.h>
-#include <stdarg.h>
+#include <cstdarg>
 #include <memory.h>
 #include <strings.h>
 #include <iostream>

--- a/src/tscore/ArgParser.cc
+++ b/src/tscore/ArgParser.cc
@@ -28,6 +28,7 @@
 #include <iostream>
 #include <set>
 #include <sstream>
+#include <utility>
 #include <sysexits.h>
 
 std::string global_usage;
@@ -199,7 +200,7 @@ ArgParser::require_commands()
 void
 ArgParser::set_error(std::string e)
 {
-  _error_msg = e;
+  _error_msg = std::move(e);
 }
 
 std::string

--- a/src/tscore/ink_hrtime.cc
+++ b/src/tscore/ink_hrtime.cc
@@ -37,7 +37,7 @@
 #include <sys/param.h>
 #include <sys/sysctl.h>
 #endif
-#include <string.h>
+#include <cstring>
 #include <sys/time.h>
 
 char *

--- a/src/tscore/runroot.cc
+++ b/src/tscore/runroot.cc
@@ -96,7 +96,7 @@ get_parent_yaml_path(const std::string &path)
     if (!yaml_file.empty()) {
       return yaml_file;
     }
-    whole_path = whole_path.substr(0, whole_path.find_last_of("/"));
+    whole_path = whole_path.substr(0, whole_path.find_last_of('/'));
   }
   return {};
 }
@@ -135,7 +135,7 @@ runroot_extra_handling(const char *executable, bool json)
   char RealBinPath[PATH_MAX] = {0};
   if ((executable != nullptr) && realpath(executable, RealBinPath) != nullptr) {
     std::string bindir = RealBinPath;
-    bindir             = bindir.substr(0, bindir.find_last_of("/")); // getting the bin dir not executable path
+    bindir             = bindir.substr(0, bindir.find_last_of('/')); // getting the bin dir not executable path
     path               = get_parent_yaml_path(bindir);
     if (!path.empty()) {
       runroot_file = path;
@@ -242,7 +242,7 @@ runroot_map(const std::string &file)
   RunrootMapType map;
   try {
     YAML::Node yamlfile = YAML::LoadFile(file);
-    std::string prefix  = file.substr(0, file.find_last_of("/"));
+    std::string prefix  = file.substr(0, file.find_last_of('/'));
 
     for (const auto &it : yamlfile) {
       // key value pairs of dirs

--- a/src/tscore/unit_tests/test_IntrusiveHashMap.cc
+++ b/src/tscore/unit_tests/test_IntrusiveHashMap.cc
@@ -112,9 +112,9 @@ TEST_CASE("IntrusiveHashMap", "[libts][IntrusiveHashMap]")
   REQUIRE(map.bucket_count() > nb);
   for (auto &thing : map) {
     REQUIRE(0 == marks[thing._n]);
-    marks[thing._n] = 1;
+    marks[thing._n] = true;
   }
-  marks[0] = 1;
+  marks[0] = true;
   REQUIRE(marks.all());
   map.insert(new Thing("dup"sv, 79));
   map.insert(new Thing("dup"sv, 80));

--- a/src/tscore/unit_tests/test_PriorityQueue.cc
+++ b/src/tscore/unit_tests/test_PriorityQueue.cc
@@ -21,7 +21,7 @@
     limitations under the License.
 */
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "tscore/PriorityQueue.h"
 #include "catch.hpp"

--- a/src/tscpp/api/TransformationPlugin.cc
+++ b/src/tscpp/api/TransformationPlugin.cc
@@ -92,7 +92,7 @@ struct TransformationPluginState : noncopyable, public detail::ResumeAfterPauseC
     output_buffer_reader_ = TSIOBufferReaderAlloc(output_buffer_);
   };
 
-  ~TransformationPluginState()
+  ~TransformationPluginState() override
   {
     if (output_buffer_reader_) {
       TSIOBufferReaderFree(output_buffer_reader_);


### PR DESCRIPTION
Ran clang-tidy with current settings. 

- modernize-loop-convert
- modernize-use-bool-literals
- modernize-deprecated-headers
- modernize-raw-string-literal
- modernize-redundant-void-arg
- modernize-use-nullptr
- modernize-use-override
- performance-unnecessary-value-param
- performance-faster-string-find

Below changes made by hand.

1. Add `NOLINT(modernize-deprecated-headers)` to below files which are included by both of C and C++ file.
  - include/ts/apidefs.h.in
  - include/tscore/ink_defs.h
  - include/tscore/ink_platform.h
  - plugins/experimental/cookie_remap/hash.h

2. Change proxy/logging/LogField.h to follow changes made by `performance-unnecessary-value-param` to proxy/logging/LogAccess.h

3. Exclude whole `lib/yamlcpp` -> #5183
4. Add `NOLINTNEXTLINE(modernize-use-nullptr)` for `ink_thread`
  - include/tscore/ink_thread.h
  - iocore/eventsystem/I_Thread.h