### PR TITLE
Do not run clang-tidy on lib/yamlcpp/

### DIFF
--- a/lib/yamlcpp/Makefile.am
+++ b/lib/yamlcpp/Makefile.am
@@ -17,8 +17,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-include $(top_srcdir)/build/tidy.mk
-
 AM_CPPFLAGS += \
 	-I$(abs_top_srcdir)/lib/yamlcpp/include
 
@@ -52,6 +50,3 @@ src/simplekey.cpp \
 src/singledocparser.cpp \
 src/stream.cpp \
 src/tag.cpp
-
-clang-tidy-local: $(DIST_SOURCES)
-	$(CXX_Clang_Tidy)


### PR DESCRIPTION
`lib/yamlcpp/` is imported library. We should not run clang-tidy to this.