### PR TITLE
URI signing renewed tokens should have configured identity as value of issuer

### DIFF
--- a/plugins/experimental/uri_signing/uri_signing.c
+++ b/plugins/experimental/uri_signing/uri_signing.c
@@ -240,7 +240,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
   }
 
   struct signer *signer = config_signer((struct config *)ih);
-  char *cookie          = renew(jwt, signer->issuer, signer->jwk, signer->alg, package);
+  char *cookie          = renew(jwt, config_get_id((struct config *)ih), signer->jwk, signer->alg, package);
   jwt_delete(jwt);
 
   if (cpi < max_cpi) {


### PR DESCRIPTION
The iss claim in renewed tokens should contain the identity of the cache that
reissued the token rather than the original issuer. This identity is configured in
the id field in the uri_signing config. This is the same value that is used to
validate the aud claim.