### PR TITLE
Exclude library headers from clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,1 +1,2 @@
 Checks: -*,modernize-loop-convert,modernize-use-bool-literals,modernize-deprecated-headers,performance-unnecessary-value-param,performance-faster-string-find,modernize-raw-string-literal,modernize-redundant-void-arg,modernize-use-nullptr,modernize-use-override
+HeaderFilterRegex: (?!(\/openssl\/|\/pcre\/|\/lib\/yaml\/)).*

--- a/build/tidy.mk
+++ b/build/tidy.mk
@@ -14,7 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-Clang_Tidy_Options = -fix -fix-errors -header-filter=.*
+Clang_Tidy_Options = -fix -fix-errors
 
 # Sort the filenames to remove duplicates, then filter to retain
 # just the C and C++ sources so we don't pick up lex and yacc files


### PR DESCRIPTION
Fix #5178.