### PR TITLE
fallback to curves list if available

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3209,7 +3209,7 @@ SSL Termination
 
    X25519:P-256:X448:P-521:P-384
 
-   This configuration works with OpenSSL v1.1.1 and above.
+   This configuration works with OpenSSL v1.0.2 and above.
 
 .. ts:cv:: CONFIG proxy.config.ssl.client.groups_list STRING <See notes under proxy.config.ssl.server.groups_list.>
 
@@ -3219,7 +3219,7 @@ SSL Termination
    group NIDs or names, for example "P-521:P-384:P-256". For
    instructions, see "Groups" section of `TLS1.3 - OpenSSLWiki <https://wiki.openssl.org/index.php/TLS1.3#Groups>`_.
 
-   This configuration works with OpenSSL v1.1.1 and above.
+   This configuration works with OpenSSL v1.0.2 and above.
 
 .. ts:cv:: CONFIG proxy.config.ssl.TLSv1 INT 1
 

--- a/iocore/net/SSLClientUtils.cc
+++ b/iocore/net/SSLClientUtils.cc
@@ -169,9 +169,13 @@ SSLInitClientContext(const SSLConfigParams *params)
   }
 #endif
 
-#ifdef SSL_CTX_set1_groups_list
+#if defined(SSL_CTX_set1_groups_list) || defined(SSL_CTX_set1_curves_list)
   if (params->client_groups_list != nullptr) {
+#ifdef SSL_CTX_set1_groups_list
     if (!SSL_CTX_set1_groups_list(client_ctx, params->client_groups_list)) {
+#else
+    if (!SSL_CTX_set1_curves_list(client_ctx, params->client_groups_list)) {
+#endif
       SSLError("invalid groups list for client in records.config");
       goto fail;
     }

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1333,9 +1333,13 @@ SSLMultiCertConfigLoader::init_server_ssl_ctx(std::vector<X509 *> &cert_list, co
   }
 #endif
 
-#ifdef SSL_CTX_set1_groups_list
+#if defined(SSL_CTX_set1_groups_list) || defined(SSL_CTX_set1_curves_list)
   if (params->server_groups_list != nullptr) {
+#ifdef SSL_CTX_set1_groups_list
     if (!SSL_CTX_set1_groups_list(ctx, params->server_groups_list)) {
+#else
+    if (!SSL_CTX_set1_curves_list(ctx, params->server_groups_list)) {
+#endif
       SSLError("invalid groups list for server in records.config");
       goto fail;
     }


### PR DESCRIPTION
This PR allows to drop the OpenSSL version requirement for `proxy.config.ssl.server.groups_list`and `proxy.config.ssl.client.groups_list` from 1.1.1 to 1.0.2 by leveraging the fact that `SSL_CTX_set1_curves_list` has been renamed to `SSL_CTX_set1_groups_list` and according to the OpenSSL documentation:
> The curve functions are synonyms for the equivalently named group functions and are identical in every respect. They exist because, prior to TLS1.3, there was only the concept of supported curves. In TLS1.3 this was renamed to supported groups, and extended to include Diffie Hellman groups. The group functions should be used in preference.

Also as is mentioned in the OpenSSL documentation quoted above, `SSL_CTX_se1_groups_list` is the preferred function.
This is pretty useful for environments running openssl 1.1.0 like Debian stretch where openssl 1.1.1 is not available.