### PR TITLE
Don't allow header values to overflow into negative values

### DIFF
--- a/proxy/hdrs/MIME.h
+++ b/proxy/hdrs/MIME.h
@@ -784,12 +784,12 @@ uint32_t mime_parse_uint(const char *buf, const char *end = nullptr);
 int64_t mime_parse_int64(const char *buf, const char *end = nullptr);
 int mime_parse_rfc822_date_fastcase(const char *buf, int length, struct tm *tp);
 time_t mime_parse_date(const char *buf, const char *end = nullptr);
-int mime_parse_day(const char *&buf, const char *end, int *day);
-int mime_parse_month(const char *&buf, const char *end, int *month);
-int mime_parse_mday(const char *&buf, const char *end, int *mday);
-int mime_parse_year(const char *&buf, const char *end, int *year);
-int mime_parse_time(const char *&buf, const char *end, int *hour, int *min, int *sec);
-int mime_parse_integer(const char *&buf, const char *end, int *integer);
+bool mime_parse_day(const char *&buf, const char *end, int *day);
+bool mime_parse_month(const char *&buf, const char *end, int *month);
+bool mime_parse_mday(const char *&buf, const char *end, int *mday);
+bool mime_parse_year(const char *&buf, const char *end, int *year);
+bool mime_parse_time(const char *&buf, const char *end, int *hour, int *min, int *sec);
+bool mime_parse_integer(const char *&buf, const char *end, int *integer);
 
 /***********************************************************************
  *                                                                     *

--- a/proxy/hdrs/test_mime.cc
+++ b/proxy/hdrs/test_mime.cc
@@ -52,6 +52,47 @@ REGRESSION_TEST(MIME)(RegressionTest *t, int /* atype ATS_UNUSED */, int *pstatu
   hdr.destroy();
 }
 
+REGRESSION_TEST(MIME_PARSERS)(RegressionTest *t, int /* atype ATS_UNUSED */, int *pstatus)
+{
+  const char *end;
+  int value;
+  TestBox box(t, pstatus);
+  box = REGRESSION_TEST_PASSED;
+
+  std::vector<std::pair<const char *, int>> tests = {{"0", 0},
+                                                     {"1234", 1234},
+                                                     {"-1234", -1234},
+                                                     {"2147483647", 2147483647},
+                                                     {"-2147483648", 2147483648},
+                                                     {"2147483648", INT_MAX},
+                                                     {"-2147483649", INT_MIN},
+                                                     {"2147483647", INT_MAX},
+                                                     {"-2147483648", INT_MIN},
+                                                     {"999999999999", INT_MAX},
+                                                     {"-999999999999", INT_MIN}};
+
+  for (const auto &it : tests) {
+    auto [buf, val] = it;
+
+    end = buf + strlen(buf);
+    box.check(mime_parse_int(buf, end) == val, "Failed mime_parse_int");
+    box.check(mime_parse_integer(buf, end, &value), "Failed mime_parse_integer call");
+    box.check(value == val, "Failed mime_parse_integer value");
+  }
+
+  // Also check the date parser, which relies heavily on the mime_parse_integer() function
+  const char *date1 = "Sun, 05 Dec 1999 08:49:37 GMT";
+  const char *date2 = "Sunday, 05-Dec-1999 08:49:37 GMT";
+
+  int d1 = mime_parse_date(date1, date1 + strlen(date1));
+  int d2 = mime_parse_date(date2, date2 + strlen(date2));
+
+  box.check(d1 == d2, "Failed mime_parse_date");
+
+  printf("Date1: %d\n", d1);
+  printf("Date2: %d\n", d2);
+}
+
 int
 main(int argc, const char **argv)
 {


### PR DESCRIPTION
For example, CC: max-age=2147483648  will turn into a negative values
and hence, can not be served out of cache. Since this parser deals with
proper negative value, it seems reasonable to clamp this to INT_MAX.

This fixes several issue from the cache-tests harness.