### PR TITLE
HostDB: cancel timeout on free

### DIFF
--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -124,6 +124,9 @@ hostdb_cont_free(HostDBContinuation *cont)
   if (cont->pending_action) {
     cont->pending_action->cancel();
   }
+  if (cont->timeout) {
+    cont->timeout->cancel();
+  }
   cont->mutex        = nullptr;
   cont->action.mutex = nullptr;
   hostDBContAllocator.free(cont);


### PR DESCRIPTION
adding a line to cancel the hostdb cont timeout, when the hostdb cont is freed.