### PR TITLE
Fix stale heap triggering assert in TSHttpTxnCachedRespGet

### DIFF
--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -5037,9 +5037,10 @@ TSHttpTxnCachedRespGet(TSHttpTxn txnp, TSMBuffer *bufp, TSMLoc *obj)
   HdrHeapSDKHandle **handle = &(sm->t_state.cache_resp_hdr_heap_handle);
 
   if (*handle == nullptr) {
-    *handle           = (HdrHeapSDKHandle *)sm->t_state.arena.alloc(sizeof(HdrHeapSDKHandle));
-    (*handle)->m_heap = cached_hdr->m_heap;
+    *handle = (HdrHeapSDKHandle *)sm->t_state.arena.alloc(sizeof(HdrHeapSDKHandle));
   }
+  // Always reset the m_heap to make sure the heap is not stale
+  (*handle)->m_heap = cached_hdr->m_heap;
 
   *(reinterpret_cast<HdrHeapSDKHandle **>(bufp)) = *handle;
   *obj                                           = reinterpret_cast<TSMLoc>(cached_hdr->m_http);


### PR DESCRIPTION
A member from our video team reported that the were getting the crash below every few minutes.  

"We see huge number of transaction aborted for content that is no longer exist (live event that ended). We are using the “open write fail action 3” to forward a single request that for another unknown reason takes a lot of time, at that time I suspect that the connection are piling up and crash the ATS."

Looking at the history in the HttpSM on the stack, we see that the SM had successfully done a cache read and then failed the cache write twice.  Then it is going in for another cache read as this crash happened.  

Looking into the code in TSHttpTxnCachedRespGet, we see that it is asserting on the fact that the bufp retrieved from the t_state.cache_resp_hdr_heap_handle is good.
```
sdk_assert(sdk_sanity_check_mbuffer(*bufp) == TS_SUCCESS);
```
And digging through the bufp, it does indeed look bad.

The speculation is that the cached handle was created on the first set of cache reads using the heap from the cached hdr object from that read.  But after the failed write and the second read, the original cached hdr has already been deleted and the associated heap is invalid.

This patch only allocates the HdrHeapSDKHandle once, but always assigns the m_heap of the handle from the current cached_hdr.  The video team run a Traffic Server built with this patch and it seems to have addressed the crash.

```
Thread 29464, [ET_NET 64]:
0    0x00000000004ce632 crash_logger_invoke(int, siginfo*, void*) + 0x72
1    0x00002b12478577e0 __restore_rt + (nil)
2    0x00002b1248645495 gsignal + 0x35
3    0x00002b1248646c75 abort + 0x175
4    0x00002b124635c7bb ink_abort(char const*, ...) + 0x9b
5    0x00002b124635a275 _ink_assert + 0x15
6    0x00000000004edf80 TSHttpTxnCachedRespGet + 0xc0
7    0x00002aab73bb205e atscppapi::Transaction::getCachedResponseStatus() + 0x2e
8    0x00002aab78d6800f atlas::ats::transform::utils::IsCacheTransformable(atscppapi::Transaction const&) + 0xa0
9    0x00002aab78d67ae6 atlas::ats::transform::utils::IsTransformable(atscppapi::Transaction const&, atlas::ats::utils::transformType) + 0x46
10   0x00002aab78d605ee atlas::ats::transform::TransformGlobalPlugin::SetTransform(atscppapi::Transaction&, atscppapi::Plugin::HookType) + 0xce
11   0x00002aab78d60488 atlas::ats::transform::TransformGlobalPlugin::handleReadCacheLookupComplete(atscppapi::Transaction&) + 0x56
12   0x00002aab73baf92d atscppapi::ScopedContinuationLock::~ScopedContinuationLock() + 0x5d
13   0x00000000004e6b8b INKContInternal::handle_event(int, void*) + 0x6b
14   0x00000000007b71a3 Continuation::dispatchEvent(int, void*) + 0x123
15   0x00000000005c2e90 HttpSM::state_api_callout(int, void*) + 0x2d0
16   0x00000000005cb36b HttpSM::set_next_state() + 0x5fb
17   0x00000000005b364d HttpSM::call_transact_and_set_next_state(void (*)(HttpTransact::State*)) + 0x3d
18   0x00000000005ca8ea HttpSM::handle_api_return() + 0x8a
19   0x00000000005c319e HttpSM::state_api_callout(int, void*) + 0x5de
20   0x00000000005ca266 HttpSM::state_api_callback(int, void*) + 0x126
21   0x00000000004fba05 TSHttpTxnReenable + 0x145
22   0x00002aab73bb0e35 atscppapi::utils::internal::initTransactionManagement() + 0xa5
23   0x00000000004e6b8b INKContInternal::handle_event(int, void*) + 0x6b
24   0x00000000007b71a3 Continuation::dispatchEvent(int, void*) + 0x123
25   0x00000000005c2e90 HttpSM::state_api_callout(int, void*) + 0x2d0
26   0x00000000005cb36b HttpSM::set_next_state() + 0x5fb
27   0x00000000005b364d HttpSM::call_transact_and_set_next_state(void (*)(HttpTransact::State*)) + 0x3d
28   0x00000000005c5481 HttpSM::state_cache_open_read(int, void*) + 0x161
29   0x00000000005ca420 HttpSM::main_handler(int, void*) + 0xa0
30   0x0000000000597ee2 HttpCacheSM::state_cache_open_read(int, void*) + 0x232
31   0x00000000006b7aca CacheVC::callcont(int) + 0x4a
32   0x000000000072053d CacheVC::openReadStartHead(int, Event*) + 0x63d
33   0x000000000072061b CacheVC::openReadStartHead(int, Event*) + 0x71b
34   0x0000000000721226 CacheVC::openReadFromWriter(int, Event*) + 0x516
35   0x00000000007b810d EThread::process_event(Event*, int) + 0x7d
36   0x00000000007b9113 EThread::execute_regular() + 0x413
37   0x00000000007b7ab2 spawn_thread_internal(void*) + 0x62
38   0x00002b124784faa1 start_thread + 0xd1
39   0x00002b12486fbbdd clone + 0x6d
40   0x0000000000000000 0x0 + 0x6d
```

This cache handle logic has been present since at least 2009.  @SolidWallOfCode speculates that this problem is triggered by the addition of write_action failures.