### PR TITLE
Remove quotes from records.config documentation examples

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -2712,7 +2712,7 @@ HostDB
 
     Set the interval (in seconds) in which to re-query DNS regardless of TTL status.
 
-.. ts:cv:: CONFIG proxy.config.hostdb.filename STRING "host.db"
+.. ts:cv:: CONFIG proxy.config.hostdb.filename STRING host.db
 
    The filename to persist hostdb to on disk.
 

--- a/doc/admin-guide/monitoring/alarms.en.rst
+++ b/doc/admin-guide/monitoring/alarms.en.rst
@@ -35,7 +35,7 @@ occurs, follow the steps below:
 #. Set :ts:cv:`proxy.config.alarm_email` in :file:`records.config` to the email
    address you want to receive alarm notifications. ::
 
-        CONFIG proxy.config.alarm_email STRING "alerts@example.com"
+        CONFIG proxy.config.alarm_email STRING alerts@example.com
 
 #. Run the command :option:`traffic_ctl config reload` to apply the configuration changes.
 

--- a/doc/admin-guide/security/index.en.rst
+++ b/doc/admin-guide/security/index.en.rst
@@ -146,7 +146,7 @@ Client/Traffic Server connections, you must do the following:
    The list of acceptable CA signers is configured with
    :ts:cv:`proxy.config.ssl.CA.cert.path` in :file:`records.config`. ::
 
-        CONFIG proxy.config.ssl.CA.cert.path STRING "/opt/CA/certs/private-ca.pem"
+        CONFIG proxy.config.ssl.CA.cert.path STRING /opt/CA/certs/private-ca.pem
 
 #. Run the command :option:`traffic_ctl server restart` to restart Traffic Server.
 
@@ -208,16 +208,16 @@ and origin server connections, you must do the following:
    :file:`records.config` in the setting :ts:cv:`proxy.config.ssl.client.cert.path`
    and :ts:cv:`proxy.config.ssl.client.cert.filename`. ::
 
-        CONFIG proxy.config.ssl.client.cert.path STRING "/opt/ts/etc/ssl/certs/"
-        CONFIG proxy.config.ssl.client.cert.filename STRING "client.pem"
+        CONFIG proxy.config.ssl.client.cert.path STRING /opt/ts/etc/ssl/certs/
+        CONFIG proxy.config.ssl.client.cert.filename STRING client.pem
 
    You must also provide the paths to the private key for this certificate,
    unless the key is contained within the same file as the certificate, using
    :ts:cv:`proxy.config.ssl.client.private_key.path` and
    :ts:cv:`proxy.config.ssl.client.private_key.filename`. ::
 
-        CONFIG proxy.config.ssl.client.private_key.path STRING "/opt/ts/etc/ssl/keys/"
-        CONFIG proxy.config.ssl.client.private_key.filename STRING "client.pem"
+        CONFIG proxy.config.ssl.client.private_key.path STRING /opt/ts/etc/ssl/keys/
+        CONFIG proxy.config.ssl.client.private_key.filename STRING client.pem
 
 #. Enable or disable, per your security policy, server SSL certificate
    verification using :ts:cv:`proxy.config.ssl.client.verify.server.policy` in
@@ -230,8 +230,8 @@ and origin server connections, you must do the following:
    :ts:cv:`proxy.config.ssl.client.CA.cert.path` and
    :ts:cv:`proxy.config.ssl.client.CA.cert.filename`. ::
 
-        CONFIG proxy.config.ssl.client.CA.cert.path STRING "/opt/ts/etc/ssl/certs/"
-        CONFIG proxy.config.ssl.client.CA.cert.filename STRING "CAs.pem"
+        CONFIG proxy.config.ssl.client.CA.cert.path STRING /opt/ts/etc/ssl/certs/
+        CONFIG proxy.config.ssl.client.CA.cert.filename STRING CAs.pem
 
 #. Run the command :option:`traffic_ctl server restart` to restart Traffic Server.
 


### PR DESCRIPTION
Quotes are not needed for these values

This is a follow up to 405ce9f5791746a5b91e90db3d7649aa8ba2b2e5