### PR TITLE
Fix compile problems with PR-5211

### DIFF
--- a/include/ts/apidefs.h.in
+++ b/include/ts/apidefs.h.in
@@ -1287,5 +1287,12 @@ typedef enum {
 typedef struct tsapi_uuid *TSUuid;
 
 #ifdef __cplusplus
+namespace ts
+{
+  static const int NO_FD = -1; ///< No or invalid file descriptor.
+}
+#endif
+
+#ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/include/tscore/ink_defs.h
+++ b/include/tscore/ink_defs.h
@@ -130,12 +130,3 @@ int ink_login_name_max();
 // Get the hardware topology
 hwloc_topology_t ink_get_topology();
 #endif
-
-/** Constants.
- */
-#ifdef __cplusplus
-namespace ts
-{
-static const int NO_FD = -1; ///< No or invalid file descriptor.
-}
-#endif

--- a/iocore/eventsystem/I_EventSystem.h
+++ b/iocore/eventsystem/I_EventSystem.h
@@ -26,6 +26,7 @@
 #define _I_EventSystem_h
 
 #include "tscore/ink_platform.h"
+#include "ts/apidefs.h"
 
 #include "I_IOBuffer.h"
 #include "I_Action.h"

--- a/mgmt/api/NetworkUtilsRemote.h
+++ b/mgmt/api/NetworkUtilsRemote.h
@@ -35,6 +35,7 @@
 #pragma once
 
 #include "mgmtapi.h"
+#include "ts/apidefs.h"
 #include "NetworkMessage.h"
 #include "EventCallback.h"
 

--- a/plugins/experimental/ssl_session_reuse/src/config.cc
+++ b/plugins/experimental/ssl_session_reuse/src/config.cc
@@ -23,6 +23,7 @@
  */
 
 #include <ts/ts.h>
+#include <ts/apidefs.h>
 #include <cstring>
 #include <fcntl.h>
 #include <sys/types.h>
@@ -62,7 +63,7 @@ Config::loadConfig(const std::string &filename)
     size_t n = info.st_size;
     std::string config_data;
     config_data.resize(n);
-    if (read(fd, const_cast<char *>(config_data.data()), n) != n) {
+    if (read(fd, const_cast<char *>(config_data.data()), n) != static_cast<int>(n)) {
       close(fd);
       return success;
     }


### PR DESCRIPTION
Since we aren't building with hiredis, this compile problem was not caught in the original PR.

Moving definition of NO_FD to apidefs.h so it can be included by the plugin.