### PR TITLE
Fix the hiredis autoconf for the default case

### DIFF
--- a/build/hiredis.m4
+++ b/build/hiredis.m4
@@ -24,34 +24,33 @@ dnl
 
 AC_DEFUN([TS_CHECK_HIREDIS], [
 hiredis_base_dir='/usr'
-has_hiredis=0
+has_hiredis=1
 AC_ARG_WITH(hiredis, [AC_HELP_STRING([--with-hiredis=DIR],[use a specific hiredis library])],
 [
-  has_hiredis=1
   if test "x$withval" != "xyes" && test "x$withval" != "x"; then
     hiredis_base_dir="$withval"
-    if test "$withval" != "no"; then
-      case "$withval" in
-      *":"*)
-        hiredis_include="`echo $withval |sed -e 's/:.*$//'`"
-        hiredis_ldflags="`echo $withval |sed -e 's/^.*://'`"
-        AC_MSG_CHECKING(checking for hiredis includes in $hiredis_include libs in $hiredis_ldflags )
-        ;;
-      *)
-        hiredis_include="$withval/include"
-        hiredis_ldflags="$withval/lib"
-        AC_MSG_CHECKING(checking for hiredis includes in $withval)
-        ;;
-      esac
-    fi
   fi
+],[])
 
-  if test -d $hiredis_include && test -d $hiredis_ldflags && test -f $hiredis_include/hiredis/hiredis.h; then
-    AC_MSG_RESULT([ok])
-  else
-    has_hiredis=0
-    AC_MSG_RESULT([not found])
-  fi
+case "$hiredis_base_dir" in
+*":"*)
+  hidredis_include="`echo $hiredis_base_dir |sed -e 's/:.*$//'`"
+  hiredis_ldflags="`echo $hiredis_base_dir |sed -e 's/^.*://'`"
+  AC_MSG_CHECKING(checking for hiredis includes in $hiredis_include libs in $hiredis_ldflags )
+  ;;
+*)
+  hiredis_include="$hiredis_base_dir/include"
+  hiredis_ldflags="$hiredis_base_dir/lib"
+  AC_MSG_CHECKING(checking for hiredis includes in $hiredis_base_dir)
+  ;;
+esac
+
+if test -d $hiredis_include && test -d $hiredis_ldflags && test -f $hiredis_include/hiredis/hiredis.h; then
+  AC_MSG_RESULT([ok])
+else
+  has_hiredis=0
+  AC_MSG_RESULT([not found])
+fi
 
 if test "$has_hiredis" != "0"; then
   saved_ldflags=$LDFLAGS
@@ -77,17 +76,6 @@ if test "$has_hiredis" != "0"; then
     LDFLAGS=$saved_ldflags
   fi
 fi
-],
-[
-has_hiredis=1
-AC_CHECK_HEADER([hiredis/hiredis.h], [], [has_hiredis=0])
-AC_CHECK_LIB([hiredis], redisConnect, [], [has_hiredis=0])
-
-if test "x$has_hiredis" == "x1"; then
-    AC_SUBST([LIB_HIREDIS], [-lhiredis])
-fi
-])
-
 ])
 
 


### PR DESCRIPTION
This won't build until PR #5215 is merged since the master version of ssl_session_reuse is currently not building.  Actually, I guess it will build just fine since the PR environment doesn't include libhiredis and so will not build the ssl_session_reuse plugin in any case.

The original M4 macro would work fine if the --with-redis option was provided.  But the default case would erroneously also add -lhiredis to the global LIBS macro causing traffic_server to require libhiredis even if the ssl_session_reuse plugin was not used.

While I was in there I made changes suggested by @SolidWallOfCode to reduce duplication in the macro.