### PR TITLE
Add optional normalization of scheme and host to lower case letters in effective URLs.

### DIFF
--- a/doc/developer-guide/api/functions/TSUrlStringGet.en.rst
+++ b/doc/developer-guide/api/functions/TSUrlStringGet.en.rst
@@ -31,6 +31,7 @@ Synopsis
 
 .. function:: char * TSUrlStringGet(TSMBuffer bufp, TSMLoc offset, int * length)
 .. function:: char * TSHttpTxnEffectiveUrlStringGet(TSHttpTxn txn, int * length)
+.. function:: char * TSHttpTxnEffectiveNormalizedUrlStringGet(TSHttpTxn txn, int * length)
 .. function:: int TSUrlLengthGet(TSMBuffer bufp, TSMLoc offset)
 .. function:: void TSUrlPrint(TSMBuffer bufp, TSMLoc offset, TSIOBuffer iobufp)
 
@@ -59,6 +60,9 @@ attempt is made to de-reference it.
 
 This function is useful to guarantee a URL that is as complete as possible given
 the specific request.
+
+:func:`TSHttpTxnEffectiveNormalizedUrlStringGet` is the same as :func:`TSHttpTxnEffectiveUrlStringGet`,
+except that the host and scheme in the URL will be normalized to all lowercase letters.
 
 :func:`TSUrlLengthGet` calculates the length of the URL located at
 :arg:`offset` within the marshal buffer bufp as if it were returned as a

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -384,7 +384,8 @@ tsapi int TSUrlLengthGet(TSMBuffer bufp, TSMLoc offset);
     The length parameter must present, providing storage for the URL
     string length value.
     Note: To get the effective URL from a request, use the alternative
-          TSHttpTxnEffectiveUrlStringGet API.
+          TSHttpTxnEffectiveUrlStringGet or
+          TSHttpTxnEffectiveNormalizedUrlStringGet APIs.
 
     @param bufp marshal buffer containing the URL you want to get.
     @param offset location of the URL within bufp.
@@ -1288,6 +1289,18 @@ tsapi TSReturnCode TSHttpTxnPristineUrlGet(TSHttpTxn txnp, TSMBuffer *bufp, TSML
     after use with @c TSfree.
 */
 tsapi char *TSHttpTxnEffectiveUrlStringGet(TSHttpTxn txnp, int *length /**< String length return, may be @c NULL. */
+);
+
+/** Get the effective URL for the transaction, with the scheme and host normalized to lower case letter.
+    The effective URL is the URL taking in to account both the explicit
+    URL in the request and the HOST field.
+
+    A possibly non-null terminated string is returned.
+
+    @note The returned string is allocated and must be freed by the caller
+    after use with @c TSfree.
+*/
+tsapi char *TSHttpTxnEffectiveNormalizedUrlStringGet(TSHttpTxn txnp, int *length /**< String length return, may be @c NULL. */
 );
 
 tsapi void TSHttpTxnRespCacheableSet(TSHttpTxn txnp, int flag);

--- a/proxy/hdrs/HTTP.cc
+++ b/proxy/hdrs/HTTP.cc
@@ -1747,7 +1747,7 @@ class UrlPrintHack
 };
 
 char *
-HTTPHdr::url_string_get(Arena *arena, int *length)
+HTTPHdr::url_string_get(Arena *arena, int *length, bool normalized)
 {
   char *zret = nullptr;
   UrlPrintHack hack(this);
@@ -1757,7 +1757,8 @@ HTTPHdr::url_string_get(Arena *arena, int *length)
     // even uglier but it's less so than duplicating this entire method to
     // change that one thing.
 
-    zret = (arena == USE_HDR_HEAP_MAGIC) ? m_url_cached.string_get_ref(length) : m_url_cached.string_get(arena, length);
+    zret = (arena == USE_HDR_HEAP_MAGIC) ? m_url_cached.string_get_ref(length, normalized) :
+                                           m_url_cached.string_get(arena, length, normalized);
   }
   return zret;
 }

--- a/proxy/hdrs/HTTP.h
+++ b/proxy/hdrs/HTTP.h
@@ -542,8 +542,9 @@ public:
       and invoking @c URL::string_get if the host is in a header
       field and not explicitly in the URL.
    */
-  char *url_string_get(Arena *arena = nullptr, ///< Arena to use, or @c malloc if NULL.
-                       int *length  = nullptr  ///< Store string length here.
+  char *url_string_get(Arena *arena    = nullptr, ///< Arena to use, or @c malloc if NULL.
+                       int *length     = nullptr, ///< Store string length here.
+                       bool normalized = false    ///< Scheme and host normalized to lower case letters.
   );
   /** Get a string with the effective URL in it.
       This is automatically allocated if needed in the request heap.

--- a/proxy/hdrs/MIME.cc
+++ b/proxy/hdrs/MIME.cc
@@ -28,6 +28,7 @@
 #include <cassert>
 #include <cstdio>
 #include <cstring>
+#include <cctype>
 #include "MIME.h"
 #include "HdrHeap.h"
 #include "HdrToken.h"
@@ -2705,11 +2706,12 @@ mime_hdr_print(HdrHeap * /* heap ATS_UNUSED */, MIMEHdrImpl *mh, char *buf_start
   return 1;
 }
 
-int
-mime_mem_print(const char *src_d, int src_l, char *buf_start, int buf_length, int *buf_index_inout, int *buf_chars_to_skip_inout)
+namespace
 {
-  int copy_l;
-
+template <int (*Char_transform)(int char_in)>
+int
+mime_mem_print_(const char *src_d, int src_l, char *buf_start, int buf_length, int *buf_index_inout, int *buf_chars_to_skip_inout)
+{
   if (buf_start == nullptr) { // this case should only be used by test_header
     ink_release_assert(buf_index_inout == nullptr);
     ink_release_assert(buf_chars_to_skip_inout == nullptr);
@@ -2719,7 +2721,6 @@ mime_mem_print(const char *src_d, int src_l, char *buf_start, int buf_length, in
     return 1;
   }
 
-  ink_assert(buf_start != nullptr);
   ink_assert(src_d != nullptr);
 
   if (*buf_chars_to_skip_inout > 0) {
@@ -2733,12 +2734,35 @@ mime_mem_print(const char *src_d, int src_l, char *buf_start, int buf_length, in
     }
   }
 
-  copy_l = std::min(buf_length - *buf_index_inout, src_l);
+  int copy_l = std::min(buf_length - *buf_index_inout, src_l);
   if (copy_l > 0) {
-    memcpy(buf_start + *buf_index_inout, src_d, copy_l);
+    buf_start += *buf_index_inout;
+    for (int i = 0; i < copy_l; ++i) {
+      buf_start[i] = Char_transform(src_d[i]);
+    }
     *buf_index_inout += copy_l;
   }
   return (src_l == copy_l);
+}
+
+int
+to_same_char(int ch)
+{
+  return ch;
+}
+
+} // end anonymous namespace
+
+int
+mime_mem_print(const char *src_d, int src_l, char *buf_start, int buf_length, int *buf_index_inout, int *buf_chars_to_skip_inout)
+{
+  return mime_mem_print_<to_same_char>(src_d, src_l, buf_start, buf_length, buf_index_inout, buf_chars_to_skip_inout);
+}
+
+int
+mime_mem_print_lc(const char *src_d, int src_l, char *buf_start, int buf_length, int *buf_index_inout, int *buf_chars_to_skip_inout)
+{
+  return mime_mem_print_<std::tolower>(src_d, src_l, buf_start, buf_length, buf_index_inout, buf_chars_to_skip_inout);
 }
 
 int

--- a/proxy/hdrs/MIME.h
+++ b/proxy/hdrs/MIME.h
@@ -766,6 +766,8 @@ int mime_hdr_print(HdrHeap *heap, MIMEHdrImpl *mh, char *buf_start, int buf_leng
                    int *buf_chars_to_skip_inout);
 int mime_mem_print(const char *src_d, int src_l, char *buf_start, int buf_length, int *buf_index_inout,
                    int *buf_chars_to_skip_inout);
+int mime_mem_print_lc(const char *src_d, int src_l, char *buf_start, int buf_length, int *buf_index_inout,
+                      int *buf_chars_to_skip_inout);
 int mime_field_print(MIMEField *field, char *buf_start, int buf_length, int *buf_index_inout, int *buf_chars_to_skip_inout);
 
 const char *mime_str_u16_set(HdrHeap *heap, const char *s_str, int s_len, const char **d_str, uint16_t *d_len, bool must_copy);

--- a/proxy/hdrs/URL.h
+++ b/proxy/hdrs/URL.h
@@ -164,13 +164,13 @@ URLImpl *url_copy(URLImpl *s_url, HdrHeap *s_heap, HdrHeap *d_heap, bool inherit
 void url_copy_onto(URLImpl *s_url, HdrHeap *s_heap, URLImpl *d_url, HdrHeap *d_heap, bool inherit_strs = true);
 void url_copy_onto_as_server_url(URLImpl *s_url, HdrHeap *s_heap, URLImpl *d_url, HdrHeap *d_heap, bool inherit_strs = true);
 
-int url_print(URLImpl *u, char *buf, int bufsize, int *bufindex, int *dumpoffset);
+int url_print(URLImpl *u, char *buf, int bufsize, int *bufindex, int *dumpoffset, bool normalized = false);
 void url_describe(HdrHeapObjImpl *raw, bool recurse);
 
 int url_length_get(URLImpl *url);
-char *url_string_get(URLImpl *url, Arena *arena, int *length, HdrHeap *heap);
+char *url_string_get(URLImpl *url, Arena *arena, int *length, HdrHeap *heap, bool normalized = false);
 void url_clear_string_ref(URLImpl *url);
-char *url_string_get_ref(HdrHeap *heap, URLImpl *url, int *length);
+char *url_string_get_ref(HdrHeap *heap, URLImpl *url, int *length, bool normalized = false);
 void url_called_set(URLImpl *url);
 char *url_string_get_buf(URLImpl *url, char *dstbuf, int dstbuf_size, int *length);
 
@@ -242,8 +242,8 @@ public:
 
   int length_get();
   void clear_string_ref();
-  char *string_get(Arena *arena, int *length = nullptr);
-  char *string_get_ref(int *length = nullptr);
+  char *string_get(Arena *arena, int *length = nullptr, bool normalized = false);
+  char *string_get_ref(int *length = nullptr, bool normalized = false);
   char *string_get_buf(char *dstbuf, int dsbuf_size, int *length = nullptr);
   void hash_get(CryptoHash *hash, cache_generation_t generation = -1) const;
   void host_hash_get(CryptoHash *hash);
@@ -392,17 +392,17 @@ URL::length_get()
   -------------------------------------------------------------------------*/
 
 inline char *
-URL::string_get(Arena *arena_or_null_for_malloc, int *length)
+URL::string_get(Arena *arena_or_null_for_malloc, int *length, bool normalized)
 {
   ink_assert(valid());
-  return url_string_get(m_url_impl, arena_or_null_for_malloc, length, m_heap);
+  return url_string_get(m_url_impl, arena_or_null_for_malloc, length, m_heap, normalized);
 }
 
 inline char *
-URL::string_get_ref(int *length)
+URL::string_get_ref(int *length, bool normalized)
 {
   ink_assert(valid());
-  return url_string_get_ref(m_heap, m_url_impl, length);
+  return url_string_get_ref(m_heap, m_url_impl, length, normalized);
 }
 
 inline void

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -4908,6 +4908,19 @@ TSHttpTxnEffectiveUrlStringGet(TSHttpTxn txnp, int *length)
   return sm->t_state.hdr_info.client_request.url_string_get(nullptr, length);
 }
 
+// Shortcut to just get the URL, with scheme and host normalized to lowwer
+// case letters.  The caller is responsible to free memory that is allocated
+// for the string that is returned.
+char *
+TSHttpTxnEffectiveNormalizedUrlStringGet(TSHttpTxn txnp, int *length)
+{
+  sdk_assert(TS_SUCCESS == sdk_sanity_check_txn(txnp));
+  sdk_assert(sdk_sanity_check_null_ptr((void *)length) == TS_SUCCESS);
+
+  HttpSM *sm = reinterpret_cast<HttpSM *>(txnp);
+  return sm->t_state.hdr_info.client_request.url_string_get(nullptr, length, true);
+}
+
 TSReturnCode
 TSHttpTxnClientRespGet(TSHttpTxn txnp, TSMBuffer *bufp, TSMLoc *obj)
 {

--- a/tests/gold_tests/pluginTest/tsapi/log.gold
+++ b/tests/gold_tests/pluginTest/tsapi/log.gold
@@ -1,10 +1,14 @@
 Global: event=TS_EVENT_HTTP_TXN_START
 Global: event=TS_EVENT_HTTP_READ_REQUEST_HDR
-TSHttpTxnEffectiveUrlStringGet():  http://myhost.test:SERVER_PORT/
+TSHttpTxnEffectiveUrlStringGet():  http://mYhOsT.teSt:SERVER_PORT/
+TSHttpTxnEffectiveNormalizedUrlStringGet():  http://myhost.test:SERVER_PORT/
 Transaction: event=TS_EVENT_HTTP_READ_REQUEST_HDR
-TSHttpTxnEffectiveUrlStringGet():  http://myhost.test:SERVER_PORT/
+TSHttpTxnEffectiveUrlStringGet():  http://mYhOsT.teSt:SERVER_PORT/
+TSHttpTxnEffectiveNormalizedUrlStringGet():  http://myhost.test:SERVER_PORT/
 Global: event=TS_EVENT_HTTP_TXN_START
 Global: event=TS_EVENT_HTTP_READ_REQUEST_HDR
 TSHttpTxnEffectiveUrlStringGet():  https://myhost.test:SERVER_PORT/
+TSHttpTxnEffectiveNormalizedUrlStringGet():  https://myhost.test:SERVER_PORT/
 Transaction: event=TS_EVENT_HTTP_READ_REQUEST_HDR
 TSHttpTxnEffectiveUrlStringGet():  https://myhost.test:SERVER_PORT/
+TSHttpTxnEffectiveNormalizedUrlStringGet():  https://myhost.test:SERVER_PORT/

--- a/tests/gold_tests/pluginTest/tsapi/tsapi.test.py
+++ b/tests/gold_tests/pluginTest/tsapi/tsapi.test.py
@@ -72,14 +72,14 @@ tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Po
 tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.port))
 #
 tr.Processes.Default.Command = (
-    'curl --verbose --ipv4 --header "Host: myhost.test:{0}" http://localhost:{1}/'.format(server.Variables.Port, ts.Variables.port)
+    'curl --verbose --ipv4 --header "Host: mYhOsT.teSt:{0}" hTtP://loCalhOst:{1}/'.format(server.Variables.Port, ts.Variables.port)
 )
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
     'curl --verbose --ipv4 --http2 --insecure --header ' +
-    '"Host: myhost.test:{0}" https://localhost:{1}/'.format(server.Variables.Port, ts.Variables.ssl_port)
+    '"Host: myhost.test:{0}" HttPs://LocalHost:{1}/'.format(server.Variables.Port, ts.Variables.ssl_port)
 )
 tr.Processes.Default.ReturnCode = 0
 

--- a/tests/tools/plugins/test_tsapi.cc
+++ b/tests/tools/plugins/test_tsapi.cc
@@ -63,6 +63,20 @@ testsForReadReqHdrHook(TSHttpTxn txn)
 
     TSfree(urlStr);
   }
+
+  logFile << "TSHttpTxnEffectiveNormalizedUrlStringGet():  ";
+  urlStr = TSHttpTxnEffectiveNormalizedUrlStringGet(txn, &urlLength);
+  if (!urlStr) {
+    logFile << "URL null" << std::endl;
+  } else if (0 == urlLength) {
+    logFile << "URL length zero" << std::endl;
+  } else if (0 > urlLength) {
+    logFile << "URL length negative" << std::endl;
+  } else {
+    logFile << std::string_view(urlStr, urlLength) << std::endl;
+
+    TSfree(urlStr);
+  }
 }
 
 int


### PR DESCRIPTION
This allows for plugins to match on URIs with a simple string compare in many cases.