### PR TITLE
url_sig debug fix for when url is missing the signature query string

### DIFF
--- a/plugins/experimental/url_sig/README
+++ b/plugins/experimental/url_sig/README
@@ -133,7 +133,7 @@ Example
 
 	Add the remap rule like
 
-		map http://test-remap.domain.com http://google.com @plugin=url_sig.so @pparam=sign_test.config
+		map http://test-remap.domain.com http://google.com @plugin=url_sig.so @pparam=sign_test.config @pparam=pristineurl
 
 	Restart traffic server or traffic_ctl config reload  - verify there are no errors in diags.log
 


### PR DESCRIPTION
There is currently a logging bug where an unsigned url generates a message in diags.log:
```
ERROR: [url_sig] Invalid err_log request
```
when it should generate an indicator like the following:
```
ERROR: [url_sig] [URL=http://test-remap.domain.com]: Has no signing query string or signing path parameters.
```

To test:

I used the README example to generate a test signed url:
```
./sign.pl --url http://test-remap.domain.com/ --useparts 1 --algorithm 1 --duration 6000 --keyindex <index> --key <key>
```
and issued a request as:
```
curl -s -o /dev/null -v --max-redirs 0 'http://localhost:8080/' -H 'Host: test-remap.domain.com'
```

Run with both the broken url_sig.so to recreate the message and the fixed plugin to ensure messages as seem above.