### PR TITLE
Add HTTP/3 support to traffic_quic cmd

### DIFF
--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -179,6 +179,10 @@ struct NetVCOptions {
 
   EventType etype;
 
+  /** ALPN protocol-lists. The format is OpenSSL protocol-lists format (vector of 8-bit length-prefixed, byte strings)
+      https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_alpn_protos.html
+   */
+  std::string_view alpn_protos;
   /** Server name to use for SNI data on an outbound connection.
    */
   ats_scoped_str sni_servername;
@@ -224,6 +228,7 @@ struct NetVCOptions {
 
   NetVCOptions() { reset(); }
   ~NetVCOptions() {}
+
   /** Set the SNI server name.
       A local copy is made of @a name.
   */
@@ -240,6 +245,7 @@ struct NetVCOptions {
     }
     return *this;
   }
+
   self &
   set_ssl_servername(const char *name)
   {

--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -2236,7 +2236,8 @@ QUICNetVConnection::_setup_handshake_protocol(SSL_CTX *ctx)
 {
   // Initialize handshake protocol specific stuff
   // For QUICv1 TLS is the only option
-  QUICTLS *tls = new QUICTLS(this->_pp_key_info, ctx, this->direction(), this->_quic_config->session_file());
+  QUICTLS *tls =
+    new QUICTLS(this->_pp_key_info, ctx, this->direction(), this->options, this->_quic_config->session_file());
   SSL_set_ex_data(tls->ssl_handle(), QUIC::ssl_quic_qc_index, static_cast<QUICConnection *>(this));
   return tls;
 }

--- a/iocore/net/quic/QUICTLS.h
+++ b/iocore/net/quic/QUICTLS.h
@@ -40,7 +40,7 @@ class QUICTLS : public QUICHandshakeProtocol
 {
 public:
   QUICTLS(QUICPacketProtectionKeyInfo &pp_key_info, SSL_CTX *ssl_ctx, NetVConnectionContext_t nvc_ctx,
-          const char *session_file = nullptr);
+          const NetVCOptions &netvc_options, const char *session_file = nullptr);
   ~QUICTLS();
 
   // TODO: integrate with _early_data_processed

--- a/iocore/net/quic/QUICTLS_openssl.cc
+++ b/iocore/net/quic/QUICTLS_openssl.cc
@@ -329,13 +329,16 @@ QUICTLS::update_key_materials_on_key_cb(int name, const uint8_t *secret, size_t 
 }
 
 QUICTLS::QUICTLS(QUICPacketProtectionKeyInfo &pp_key_info, SSL_CTX *ssl_ctx, NetVConnectionContext_t nvc_ctx,
-                 const char *session_file)
+                 const NetVCOptions &netvc_options, const char *session_file)
   : QUICHandshakeProtocol(pp_key_info), _session_file(session_file), _ssl(SSL_new(ssl_ctx)), _netvc_context(nvc_ctx)
 {
   ink_assert(this->_netvc_context != NET_VCONNECTION_UNSET);
 
   if (this->_netvc_context == NET_VCONNECTION_OUT) {
     SSL_set_connect_state(this->_ssl);
+
+    SSL_set_alpn_protos(this->_ssl, reinterpret_cast<const unsigned char *>(netvc_options.alpn_protos.data()), netvc_options.alpn_protos.size());
+    SSL_set_tlsext_host_name(this->_ssl, netvc_options.sni_servername.get());
   } else {
     SSL_set_accept_state(this->_ssl);
   }

--- a/proxy/http2/HTTP2.cc
+++ b/proxy/http2/HTTP2.cc
@@ -477,6 +477,11 @@ http2_convert_header_from_2_to_1_1(HTTPHdr *headers)
     headers->field_delete(HTTP2_VALUE_AUTHORITY, HTTP2_LEN_AUTHORITY);
     headers->field_delete(HTTP2_VALUE_PATH, HTTP2_LEN_PATH);
   } else {
+    // Set HTTP Version 1.1
+    int32_t version = HTTP_VERSION(1, 1);
+    http_hdr_version_set(headers->m_http, version);
+
+    // Set status from :status
     int status_len;
     const char *status;
 
@@ -521,6 +526,9 @@ http2_generate_h2_header_from_1_1(HTTPHdr *headers, HTTPHdr *h2_headers)
     int value_len;
 
     // Add ':authority' header field
+    // TODO: remove host/Host header
+    // [RFC 7540] 8.1.2.3. Clients that generate HTTP/2 requests directly SHOULD use the ":authority" pseudo-header field instead of
+    // the Host header field.
     field = h2_headers->field_create(HTTP2_VALUE_AUTHORITY, HTTP2_LEN_AUTHORITY);
     value = headers->host_get(&value_len);
     if (headers->is_port_in_header()) {

--- a/proxy/http3/Http3App.h
+++ b/proxy/http3/Http3App.h
@@ -44,23 +44,29 @@ class Http3App : public QUICApplication
 {
 public:
   Http3App(QUICNetVConnection *client_vc, IpAllow::ACL session_acl);
-  ~Http3App();
+  virtual ~Http3App();
 
-  void start();
-  int main_event_handler(int event, Event *data);
+  virtual void start();
+  virtual int main_event_handler(int event, Event *data);
 
   // TODO: Return StreamIO. It looks bother that coller have to look up StreamIO by stream id.
   // Why not create_bidi_stream ?
   QUICConnectionErrorUPtr create_uni_stream(QUICStreamId &new_stream_id, Http3StreamType type);
 
+protected:
+  // TODO: create Http3Session
+  Http3ClientSession *_ssn = nullptr;
+
 private:
   void _handle_uni_stream_on_read_ready(int event, QUICStreamIO *stream_io);
-  void _handle_bidi_stream_on_read_ready(int event, QUICStreamIO *stream_io);
   void _handle_uni_stream_on_write_ready(int event, QUICStreamIO *stream_io);
+  void _handle_uni_stream_on_eos(int event, QUICStreamIO *stream_io);
+  void _handle_bidi_stream_on_read_ready(int event, QUICStreamIO *stream_io);
   void _handle_bidi_stream_on_write_ready(int event, QUICStreamIO *stream_io);
+  void _handle_bidi_stream_on_eos(int event, QUICStreamIO *stream_io);
+
   void _set_qpack_stream(Http3StreamType type, QUICStreamIO *stream_io);
 
-  Http3ClientSession *_client_session   = nullptr;
   Http3FrameHandler *_settings_handler  = nullptr;
   Http3FrameGenerator *_settings_framer = nullptr;
 

--- a/proxy/http3/Http3ClientTransaction.h
+++ b/proxy/http3/Http3ClientTransaction.h
@@ -66,6 +66,7 @@ public:
   // HQClientTransaction
   virtual int state_stream_open(int, void *)             = 0;
   virtual int state_stream_closed(int event, void *data) = 0;
+  NetVConnectionContext_t direction() const;
 
 protected:
   virtual int64_t _process_read_vio()  = 0;
@@ -85,7 +86,7 @@ protected:
   Event *_read_event  = nullptr;
   Event *_write_event = nullptr;
 
-  HTTPHdr _request_header;
+  HTTPHdr _header; ///< HTTP header buffer for decoding
 };
 
 class Http3ClientTransaction : public HQClientTransaction

--- a/proxy/http3/Http3HeaderVIOAdaptor.cc
+++ b/proxy/http3/Http3HeaderVIOAdaptor.cc
@@ -49,11 +49,12 @@ Http3HeaderVIOAdaptor::handle_frame(std::shared_ptr<const Http3Frame> frame)
   if (res == 0) {
     // When decoding is not blocked, continuation should be called directly?
   } else if (res == 1) {
-    // Decoding is blocked. Callback will be fired.
+    // Decoding is blocked.
+    Debug("http3", "Decoding is blocked. DecodeRequest is scheduled");
   } else if (res < 0) {
-    // error
+    Debug("http3", "Error on decoding header (%d)", res);
   } else {
-    // should not be here
+    ink_abort("should not be here");
   }
 
   return Http3ErrorUPtr(new Http3NoError());

--- a/src/traffic_quic/Makefile.inc
+++ b/src/traffic_quic/Makefile.inc
@@ -19,39 +19,45 @@ bin_PROGRAMS += traffic_quic/traffic_quic
 
 traffic_quic_traffic_quic_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
-  $(iocore_include_dirs) \
-  -I$(abs_top_srcdir)/lib \
-  -I$(abs_top_srcdir)/lib/records \
-  -I$(abs_top_srcdir)/mgmt \
-  -I$(abs_top_srcdir)/mgmt/utils \
-  -I$(abs_top_srcdir)/proxy \
-  -I$(abs_top_srcdir)/proxy/hdrs \
-  -I$(abs_top_srcdir)/proxy/http \
-  -I$(abs_top_srcdir)/proxy/logging \
-  -I$(abs_top_srcdir)/proxy/shared \
-  $(TS_INCLUDES) \
-  @OPENSSL_INCLUDES@
+	$(iocore_include_dirs) \
+	-I$(abs_top_srcdir)/lib \
+	-I$(abs_top_srcdir)/lib/records \
+	-I$(abs_top_srcdir)/mgmt \
+	-I$(abs_top_srcdir)/mgmt/utils \
+	-I$(abs_top_srcdir)/proxy \
+	-I$(abs_top_srcdir)/proxy/hdrs \
+	-I$(abs_top_srcdir)/proxy/http \
+	-I$(abs_top_srcdir)/proxy/http/remap \
+	-I$(abs_top_srcdir)/proxy/http3 \
+	-I$(abs_top_srcdir)/proxy/logging \
+	-I$(abs_top_srcdir)/proxy/shared \
+	$(TS_INCLUDES) \
+	@OPENSSL_INCLUDES@
 
 traffic_quic_traffic_quic_LDFLAGS = \
-  $(AM_LDFLAGS) \
-  @OPENSSL_LDFLAGS@
+	$(AM_LDFLAGS) \
+	@OPENSSL_LDFLAGS@
 
 traffic_quic_traffic_quic_SOURCES = \
-  traffic_quic/quic_client.cc \
-  traffic_quic/traffic_quic.cc
+	traffic_quic/quic_client.cc \
+	traffic_quic/traffic_quic.cc
 
 traffic_quic_traffic_quic_LDADD = \
-  $(top_builddir)/iocore/net/libinknet.a \
-  $(top_builddir)/iocore/aio/libinkaio.a \
-  $(top_builddir)/iocore/net/quic/libquic.a \
-  $(top_builddir)/iocore/eventsystem/libinkevent.a \
-  $(top_builddir)/mgmt/libmgmt_p.la \
-  $(top_builddir)/lib/records/librecords_p.a \
-  $(top_builddir)/src/tscore/libtscore.la \
-  $(top_builddir)/src/tscpp/util/libtscpputil.la \
-  $(top_builddir)/lib/tsconfig/libtsconfig.la \
-  $(top_builddir)/proxy/ParentSelectionStrategy.o \
-  @HWLOC_LIBS@ \
-  @YAMLCPP_LIBS@ \
-  @OPENSSL_LIBS@ \
-  @LIBPCRE@
+	$(top_builddir)/iocore/net/libinknet.a \
+	$(top_builddir)/iocore/aio/libinkaio.a \
+	$(top_builddir)/iocore/net/quic/libquic.a \
+	$(top_builddir)/iocore/eventsystem/libinkevent.a \
+	$(top_builddir)/mgmt/libmgmt_p.la \
+	$(top_builddir)/lib/records/librecords_p.a \
+	$(top_builddir)/src/tscore/libtscore.la \
+	$(top_builddir)/src/tscpp/util/libtscpputil.la \
+	$(top_builddir)/lib/tsconfig/libtsconfig.la \
+	$(top_builddir)/proxy/ParentSelectionStrategy.o \
+	$(top_builddir)/proxy/libproxy.a \
+	$(top_builddir)/proxy/hdrs/libhdrs.a \
+	$(top_builddir)/proxy/http2/libhttp2.a \
+	$(top_builddir)/proxy/http3/libhttp3.a \
+	@HWLOC_LIBS@ \
+	@YAMLCPP_LIBS@ \
+	@OPENSSL_LIBS@ \
+	@LIBPCRE@

--- a/src/traffic_quic/traffic_quic.cc
+++ b/src/traffic_quic/traffic_quic.cc
@@ -27,6 +27,11 @@
 #include "tscore/I_Version.h"
 
 #include "RecordsConfig.h"
+#include "URL.h"
+#include "MIME.h"
+#include "HTTP.h"
+#include "HuffmanCodec.h"
+#include "Http3Config.h"
 
 #include "diags.h"
 #include "quic_client.h"
@@ -94,6 +99,14 @@ main(int argc, const char **argv)
   eventProcessor.start(THREADS);
   udpNet.start(1, stacksize);
   quic_NetProcessor.start(-1, stacksize);
+
+  // Same to init_http_header(); in traffic_server.cc
+  url_init();
+  mime_init();
+  http_init();
+  hpack_huffman_init();
+
+  Http3Config::startup();
 
   QUICClient client(&config);
   eventProcessor.schedule_in(&client, 1, ET_NET);
@@ -168,6 +181,7 @@ Log::trace_out(sockaddr const *, unsigned short, char const *, ...)
 }
 
 #include "InkAPIInternal.h"
+
 int
 APIHook::invoke(int, void *)
 {
@@ -187,6 +201,24 @@ APIHooks::get() const
 {
   ink_assert(false);
   return nullptr;
+}
+
+void
+APIHooks::clear()
+{
+  ink_abort("do not call stub");
+}
+
+void
+APIHooks::append(INKContInternal *)
+{
+  ink_abort("do not call stub");
+}
+
+void
+APIHooks::prepend(INKContInternal *)
+{
+  ink_abort("do not call stub");
 }
 
 void
@@ -227,19 +259,76 @@ HttpRequestData::get_client_ip()
 SslAPIHooks *ssl_hooks = nullptr;
 StatPagesManager statPagesManager;
 
-#include "ProcessManager.h"
-inkcoreapi ProcessManager *pmgmt = nullptr;
-
-int
-BaseManager::registerMgmtCallback(int, const MgmtCallback &)
+#include "HttpDebugNames.h"
+const char *
+HttpDebugNames::get_api_hook_name(TSHttpHookID t)
 {
-  ink_assert(false);
-  return 0;
+  return "dummy";
+}
+
+#include "HttpSM.h"
+HttpSM::HttpSM() : Continuation(nullptr), vc_table(this) {}
+
+void
+HttpSM::cleanup()
+{
+  ink_abort("do not call stub");
 }
 
 void
-ProcessManager::signalManager(int, char const *, int)
+HttpSM::destroy()
 {
-  ink_assert(false);
-  return;
+  ink_abort("do not call stub");
+}
+
+void
+HttpSM::set_next_state()
+{
+  ink_abort("do not call stub");
+}
+
+void
+HttpSM::handle_api_return()
+{
+  ink_abort("do not call stub");
+}
+
+int
+HttpSM::kill_this_async_hook(int /* event ATS_UNUSED */, void * /* data ATS_UNUSED */)
+{
+  return EVENT_DONE;
+}
+
+void
+HttpSM::attach_client_session(ProxyClientTransaction *, IOBufferReader *)
+{
+  ink_abort("do not call stub");
+}
+
+void
+HttpSM::init()
+{
+  ink_abort("do not call stub");
+}
+
+ClassAllocator<HttpSM> httpSMAllocator("httpSMAllocator");
+HttpAPIHooks *http_global_hooks;
+
+HttpVCTable::HttpVCTable(HttpSM *) {}
+
+PostDataBuffers::~PostDataBuffers() {}
+
+#include "HttpTunnel.h"
+HttpTunnel::HttpTunnel() : Continuation(nullptr) {}
+HttpTunnelConsumer::HttpTunnelConsumer() {}
+HttpTunnelProducer::HttpTunnelProducer() {}
+ChunkedHandler::ChunkedHandler() {}
+
+#include "HttpCacheSM.h"
+HttpCacheSM::HttpCacheSM() {}
+
+HttpCacheAction::HttpCacheAction() : sm(nullptr) {}
+void
+HttpCacheAction::cancel(Continuation *c)
+{
 }


### PR DESCRIPTION
Interoped with many other QUIC server impls.

Know issues
- When `-o` options is used, HTTP header and body could be mixed. Because of QPACK decoder always use callback and `traffic_quic` doesn't buffering body.
- `Http3ClientSession` and `Http3ClientTransaction` are used as session & transaction from client to server on client side. These should be renamed when HTTP/2 origin server connection is implemented.