### PR TITLE
Add keylog support on QUIC client

### DIFF
--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -2236,8 +2236,10 @@ QUICNetVConnection::_setup_handshake_protocol(SSL_CTX *ctx)
 {
   // Initialize handshake protocol specific stuff
   // For QUICv1 TLS is the only option
-  QUICTLS *tls = new QUICTLS(this->_pp_key_info, ctx, this->direction(), this->options, this->_quic_config->session_file());
+  QUICTLS *tls = new QUICTLS(this->_pp_key_info, ctx, this->direction(), this->options, this->_quic_config->client_session_file(),
+                             this->_quic_config->client_keylog_file());
   SSL_set_ex_data(tls->ssl_handle(), QUIC::ssl_quic_qc_index, static_cast<QUICConnection *>(this));
+
   return tls;
 }
 

--- a/iocore/net/quic/QUICConfig.h
+++ b/iocore/net/quic/QUICConfig.h
@@ -45,7 +45,8 @@ public:
 
   const char *server_supported_groups() const;
   const char *client_supported_groups() const;
-  const char *session_file() const;
+  const char *client_session_file() const;
+  const char *client_keylog_file() const;
 
   SSL_CTX *client_ssl_ctx() const;
 
@@ -100,7 +101,8 @@ private:
 
   char *_server_supported_groups = nullptr;
   char *_client_supported_groups = nullptr;
-  char *_session_file            = nullptr;
+  char *_client_session_file     = nullptr;
+  char *_client_keylog_file      = nullptr;
 
   SSL_CTX *_client_ssl_ctx = nullptr;
 

--- a/iocore/net/quic/QUICGlobals.cc
+++ b/iocore/net/quic/QUICGlobals.cc
@@ -24,6 +24,7 @@
 #include "QUICGlobals.h"
 
 #include <cstring>
+#include <fstream>
 
 #include "P_SSLNextProtocolSet.h"
 
@@ -83,6 +84,23 @@ QUIC::ssl_client_new_session(SSL *ssl, SSL_SESSION *session)
   PEM_write_bio_SSL_SESSION(file, session);
   BIO_free(file);
   return 0;
+}
+
+void
+QUIC::ssl_client_keylog_cb(const SSL *ssl, const char *line)
+{
+  QUICTLS *qtls           = static_cast<QUICTLS *>(SSL_get_ex_data(ssl, QUIC::ssl_quic_tls_index));
+  const char *keylog_file = qtls->keylog_file();
+  std::ofstream file(keylog_file, std::ios_base::app);
+
+  if (!file.is_open()) {
+    QUICGlobalDebug("could not open keylog file: %s", keylog_file);
+    return;
+  }
+
+  file.write(line, strlen(line));
+  file.put('\n');
+  file.flush();
 }
 
 int

--- a/iocore/net/quic/QUICGlobals.h
+++ b/iocore/net/quic/QUICGlobals.h
@@ -34,6 +34,7 @@ public:
   static int ssl_select_next_protocol(SSL *ssl, const unsigned char **out, unsigned char *outlen, const unsigned char *in,
                                       unsigned inlen, void *);
   static int ssl_client_new_session(SSL *ssl, SSL_SESSION *session);
+  static void ssl_client_keylog_cb(const SSL *ssl, const char *line);
   static int ssl_cert_cb(SSL *ssl, void *arg);
   static int ssl_sni_cb(SSL *ssl, int *ad, void *arg);
 

--- a/iocore/net/quic/QUICTLS.cc
+++ b/iocore/net/quic/QUICTLS.cc
@@ -68,6 +68,12 @@ QUICTLS::session_file() const
   return this->_session_file;
 }
 
+const char *
+QUICTLS::keylog_file() const
+{
+  return this->_keylog_file;
+}
+
 QUICTLS::~QUICTLS()
 {
   SSL_free(this->_ssl);

--- a/iocore/net/quic/QUICTLS.h
+++ b/iocore/net/quic/QUICTLS.h
@@ -40,7 +40,7 @@ class QUICTLS : public QUICHandshakeProtocol
 {
 public:
   QUICTLS(QUICPacketProtectionKeyInfo &pp_key_info, SSL_CTX *ssl_ctx, NetVConnectionContext_t nvc_ctx,
-          const NetVCOptions &netvc_options, const char *session_file = nullptr);
+          const NetVCOptions &netvc_options, const char *session_file = nullptr, const char *keylog_file = nullptr);
   ~QUICTLS();
 
   // TODO: integrate with _early_data_processed
@@ -58,6 +58,7 @@ public:
   void set_remote_transport_parameters(std::shared_ptr<const QUICTransportParameters> tp) override;
 
   const char *session_file() const;
+  const char *keylog_file() const;
 
   // FIXME Should not exist
   SSL *ssl_handle();
@@ -79,8 +80,6 @@ private:
   QUICKeyGenerator _keygen_for_server = QUICKeyGenerator(QUICKeyGenerator::Context::SERVER);
   const EVP_MD *_get_handshake_digest() const;
 
-  const char *_session_file;
-
   int _read_early_data();
   int _write_early_data();
   int _handshake(QUICHandshakeMsgs *out, const QUICHandshakeMsgs *in);
@@ -94,6 +93,8 @@ private:
   void _print_km(const char *header, const uint8_t *key_for_hp, size_t key_for_hp_len, const uint8_t *key, size_t key_len,
                  const uint8_t *iv, size_t iv_len, const uint8_t *secret = nullptr, size_t secret_len = 0);
 
+  const char *_session_file              = nullptr;
+  const char *_keylog_file               = nullptr;
   SSL *_ssl                              = nullptr;
   NetVConnectionContext_t _netvc_context = NET_VCONNECTION_UNSET;
   bool _early_data_processed             = false;

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1372,6 +1372,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.quic.client.session_file", RECD_STRING, nullptr , RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.quic.client.keylog_file", RECD_STRING, nullptr , RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
   // Transport Parameters
   {RECT_CONFIG, "proxy.config.quic.no_activity_timeout_in", RECD_INT, "30", RECU_DYNAMIC, RR_NULL, RECC_STR, "^-?[0-9]+$", RECA_NULL}
   ,


### PR DESCRIPTION
This is quite handy for debugging. Wireshark can decrypt captured QUIC packets with dumped key.
The format is NSS Key Log Format.

https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_keylog_callback.html
https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format

But I'm not sure we should add this under iocore/net/quic/. I wanted put these code in under src/traffic_quic/, but it requires a handle to tweak SSL_CTX from there. Any ideas?