### PR TITLE
Run clang-format against the same files on both make clang-foramt and…

### DIFF
--- a/include/ts/apidefs.h.in
+++ b/include/ts/apidefs.h.in
@@ -283,7 +283,7 @@ typedef enum {
   // Putting the SSL hooks in the same enum space
   // So both sets of hooks can be set by the same Hook function
   TS_SSL_FIRST_HOOK,
-  TS_VCONN_START_HOOK = TS_SSL_FIRST_HOOK,
+  TS_VCONN_START_HOOK      = TS_SSL_FIRST_HOOK,
   TS_VCONN_PRE_ACCEPT_HOOK = TS_VCONN_START_HOOK, // Deprecated but compatible for now.
   TS_VCONN_CLOSE_HOOK,
   TS_SSL_SNI_HOOK,
@@ -292,7 +292,7 @@ typedef enum {
   TS_SSL_SERVER_VERIFY_HOOK,
   TS_SSL_VERIFY_CLIENT_HOOK,
   TS_SSL_SESSION_HOOK,
-  TS_SSL_LAST_HOOK = TS_SSL_SESSION_HOOK,
+  TS_SSL_LAST_HOOK                          = TS_SSL_SESSION_HOOK,
   TS_HTTP_REQUEST_BUFFER_READ_COMPLETE_HOOK = 24,
   TS_HTTP_LAST_HOOK
 } TSHttpHookID;

--- a/include/tscore/ink_config.h.in
+++ b/include/tscore/ink_config.h.in
@@ -127,6 +127,6 @@
 #define TS_BUILD_DEFAULT_LOOPBACK_IFACE "@default_loopback_iface@"
 /* clang-format on */
 
-static const int DEFAULT_STACKSIZE = @default_stack_size@;
+static const int DEFAULT_STACKSIZE = @default_stack_size @;
 
 #endif /* _ink_config_h */

--- a/tools/clang-format.sh
+++ b/tools/clang-format.sh
@@ -77,7 +77,7 @@ EOF
       echo "or alternatively, undefine the FORMAT environment variable"
       exit 1
   else
-      for file in $(find $DIR -iname \*.[ch] -o -iname \*.cc); do
+      for file in $(find $DIR -iname \*.[ch] -o -iname \*.cc -o -iname \*.h.in); do
     echo $file
     ${FORMAT} -i $file
       done

--- a/tools/git/pre-commit
+++ b/tools/git/pre-commit
@@ -47,7 +47,7 @@ patch_file=$(mktemp -t clang-format.XXXXXXXXXX)
 trap "rm -f $patch_file" 0 1 2 3 5 15
 
 # Loop over all files that are changed, and produce a diff file
-git diff-index --cached --diff-filter=ACMR --name-only HEAD | while read file; do
+git diff-index --cached --diff-filter=ACMR --name-only HEAD | grep -vE "lib/tsconfig|lib/yamlcpp" | while read file; do
     case "$file" in
 	*.cc | *.c | *.h | *.h.in)
 	    ${FORMAT} "$file" | diff -u "$file" - >> "$patch_file"


### PR DESCRIPTION
… git pre-hook

Include *.h.in on make clang-format
Exclude lib/tsconfig and lib/yamlcpp on git/pre-hook

(cherry picked from commit 1b300dfed5292efbaee257f369aa8bc8757b65b4)

 Conflicts:
	include/ts/apidefs.h.in