### PR TITLE
Fixed compilation under ubuntu 18.04

### DIFF
--- a/src/traffic_quic/Makefile.inc
+++ b/src/traffic_quic/Makefile.inc
@@ -47,17 +47,18 @@ traffic_quic_traffic_quic_LDADD = \
 	$(top_builddir)/iocore/aio/libinkaio.a \
 	$(top_builddir)/iocore/net/quic/libquic.a \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
-	$(top_builddir)/mgmt/libmgmt_p.la \
 	$(top_builddir)/lib/records/librecords_p.a \
+	$(top_builddir)/mgmt/libmgmt_p.la \
 	$(top_builddir)/src/tscore/libtscore.la \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	$(top_builddir)/lib/tsconfig/libtsconfig.la \
 	$(top_builddir)/proxy/ParentSelectionStrategy.o \
+	$(top_builddir)/proxy/http3/libhttp3.a \
+	$(top_builddir)/proxy/http2/libhttp2.a \
 	$(top_builddir)/proxy/libproxy.a \
 	$(top_builddir)/proxy/hdrs/libhdrs.a \
-	$(top_builddir)/proxy/http2/libhttp2.a \
-	$(top_builddir)/proxy/http3/libhttp3.a \
 	@HWLOC_LIBS@ \
 	@YAMLCPP_LIBS@ \
 	@OPENSSL_LIBS@ \
 	@LIBPCRE@
+


### PR DESCRIPTION
```
../lib/records/librecords_p.a(RecProcess.o): In function `RecMessageInit()':
/home/scw00/trafficserver/lib/records/RecProcess.cc:234: undefined reference to `pmgmt'
/home/scw00/trafficserver/lib/records/RecProcess.cc:234: undefined reference to `BaseManager::registerMgmtCallback(int, std::function<void (ts::MemSpan)> const&)'
../lib/records/librecords_p.a(RecProcess.o): In function `RecSignalManager(int, char const*, unsigned long)':
/home/scw00/trafficserver/lib/records/RecProcess.cc:299: undefined reference to `pmgmt'
/home/scw00/trafficserver/lib/records/RecProcess.cc:299: undefined reference to `ProcessManager::signalManager(int, char const*, int)'
../lib/records/librecords_p.a(RecProcess.o): In function `RecRegisterManagerCb(int, std::function<void (ts::MemSpan)> const&)':
/home/scw00/trafficserver/lib/records/RecProcess.cc:305: undefined reference to `pmgmt'
/home/scw00/trafficserver/lib/records/RecProcess.cc:305: undefined reference to `BaseManager::registerMgmtCallback(int, std::function<void (ts::MemSpan)> const&)'
../lib/records/librecords_p.a(RecProcess.o): In function `RecMessageSend(RecMessageHdr*)':
/home/scw00/trafficserver/lib/records/RecProcess.cc:325: undefined reference to `pmgmt'
/home/scw00/trafficserver/lib/records/RecProcess.cc:325: undefined reference to `ProcessManager::signalManager(int, char const*, int)'
../proxy/libproxy.a(IPAllow.o): In function `(anonymous namespace)::SignalError(ts::BufferWriter&, bool&)':
/home/scw00/trafficserver/proxy/IPAllow.cc:41: undefined reference to `pmgmt'
/home/scw00/trafficserver/proxy/IPAllow.cc:41: undefined reference to `ProcessManager::signalManager(int, char const*)'
../proxy/http3/libhttp3.a(Http3ClientSession.o): In function `ProxyClientSession::~ProxyClientSession()':
/home/scw00/trafficserver/proxy/ProxyClientSession.h:75: undefined reference to `vtable for ProxyClientSession'
../proxy/http3/libhttp3.a(Http3ClientSession.o): In function `HQClientSession::HQClientSession(NetVConnection*)':
/home/scw00/trafficserver/proxy/http3/Http3ClientSession.h:35: undefined reference to `ProxyClientSession::ProxyClientSession()'
../proxy/http3/libhttp3.a(Http3ClientSession.o):(.rodata._ZTV19Http09ClientSession[_ZTV19Http09ClientSession]+0x70): undefined reference to `ProxyClientSession::free()'
../proxy/http3/libhttp3.a(Http3ClientSession.o):(.rodata._ZTV18Http3ClientSession[_ZTV18Http3ClientSession]+0x70): undefined reference to `ProxyClientSession::free()'
../proxy/http3/libhttp3.a(Http3ClientSession.o):(.rodata._ZTV15HQClientSession[_ZTV15HQClientSession]+0x70): undefined reference to `ProxyClientSession::free()'
../proxy/http3/libhttp3.a(Http3ClientSession.o):(.rodata._ZTI15HQClientSession[_ZTI15HQClientSession]+0x10): undefined reference to `typeinfo for ProxyClientSession'
../proxy/http3/libhttp3.a(Http3ClientTransaction.o): In function `HQClientTransaction::HQClientTransaction(HQClientSession*, QUICStreamIO*)':
/home/scw00/trafficserver/proxy/http3/Http3ClientTransaction.cc:59: undefined reference to `ProxyClientTransaction::ProxyClientTransaction()'
../proxy/http3/libhttp3.a(Http3ClientTransaction.o): In function `HQClientTransaction::release(IOBufferReader*)':
/home/scw00/trafficserver/proxy/http3/Http3ClientTransaction.cc:110: undefined reference to `ProxyClientTransaction::release(IOBufferReader*)'
../proxy/http3/libhttp3.a(Http3ClientTransaction.o): In function `Http3ClientTransaction::_convert_header_from_3_to_1_1(HTTPHdr*)':
/home/scw00/trafficserver/proxy/http3/Http3ClientTransaction.cc:544: undefined reference to `http2_convert_header_from_2_to_1_1(HTTPHdr*)'
../proxy/http3/libhttp3.a(Http3ClientTransaction.o): In function `ProxyClientTransaction::set_session_active()':
/home/scw00/trafficserver/proxy/ProxyClientTransaction.h:118: undefined reference to `ProxyClientSession::set_session_active()'
../proxy/http3/libhttp3.a(Http3ClientTransaction.o): In function `ProxyClientTransaction::clear_session_active()':
/home/scw00/trafficserver/proxy/ProxyClientTransaction.h:126: undefined reference to `ProxyClientSession::clear_session_active()'
../proxy/http3/libhttp3.a(Http3ClientTransaction.o): In function `ProxyClientTransaction::~ProxyClientTransaction()':
/home/scw00/trafficserver/proxy/ProxyClientTransaction.h:31: undefined reference to `vtable for ProxyClientTransaction'
../proxy/http3/libhttp3.a(Http3ClientTransaction.o):(.rodata._ZTV23Http09ClientTransaction[_ZTV23Http09ClientTransaction]+0x68): undefined reference to `ProxyClientTransaction::new_transaction()'
../proxy/http3/libhttp3.a(Http3ClientTransaction.o):(.rodata._ZTV23Http09ClientTransaction[_ZTV23Http09ClientTransaction]+0x90): undefined reference to `ProxyClientTransaction::attach_server_session(HttpServerSession*, bool)'
../proxy/http3/libhttp3.a(Http3ClientTransaction.o):(.rodata._ZTV22Http3ClientTransaction[_ZTV22Http3ClientTransaction]+0x68): undefined reference to `ProxyClientTransaction::new_transaction()'
../proxy/http3/libhttp3.a(Http3ClientTransaction.o):(.rodata._ZTV22Http3ClientTransaction[_ZTV22Http3ClientTransaction]+0x90): undefined reference to `ProxyClientTransaction::attach_server_session(HttpServerSession*, bool)'
../proxy/http3/libhttp3.a(Http3ClientTransaction.o):(.rodata._ZTV19HQClientTransaction[_ZTV19HQClientTransaction]+0x68): undefined reference to `ProxyClientTransaction::new_transaction()'
../proxy/http3/libhttp3.a(Http3ClientTransaction.o):(.rodata._ZTV19HQClientTransaction[_ZTV19HQClientTransaction]+0x90): undefined reference to `ProxyClientTransaction::attach_server_session(HttpServerSession*, bool)'
../proxy/http3/libhttp3.a(Http3ClientTransaction.o):(.rodata._ZTI19HQClientTransaction[_ZTI19HQClientTransaction]+0x10): undefined reference to `typeinfo for ProxyClientTransaction'
../proxy/http3/libhttp3.a(Http3HeaderFramer.o): In function `Http3HeaderFramer::_convert_header_from_1_1_to_3(HTTPHdr*, HTTPHdr*)':
/home/scw00/trafficserver/proxy/http3/Http3HeaderFramer.cc:76: undefined reference to `http2_generate_h2_header_from_1_1(HTTPHdr*, HTTPHdr*)'
../proxy/http3/libhttp3.a(Http3HeaderFramer.o): In function `Http3HeaderFramer::_generate_header_block()':
/home/scw00/trafficserver/proxy/http3/Http3HeaderFramer.cc:88: undefined reference to `HTTPHdr::parse_req(HTTPParser*, IOBufferReader*, int*, bool, bool)'
/home/scw00/trafficserver/proxy/http3/Http3HeaderFramer.cc:91: undefined reference to `HTTPHdr::parse_resp(HTTPParser*, IOBufferReader*, int*, bool)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::decode(unsigned long, unsigned char const*, unsigned long, HTTPHdr&, Continuation*, EThread*)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:235: undefined reference to `xpack_decode_integer(unsigned long&, unsigned char const*, unsigned char const*, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_encode_prefix(unsigned short, unsigned short, IOBufferBlock*)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:293: undefined reference to `xpack_encode_integer(unsigned char*, unsigned char const*, unsigned long, unsigned char)'
/home/scw00/trafficserver/proxy/http3/QPACK.cc:308: undefined reference to `xpack_encode_integer(unsigned char*, unsigned char const*, unsigned long, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_encode_indexed_header_field(unsigned short, unsigned short, bool, IOBufferBlock*)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:485: undefined reference to `xpack_encode_integer(unsigned char*, unsigned char const*, unsigned long, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_encode_indexed_header_field_with_postbase_index(unsigned short, unsigned short, bool, IOBufferBlock*)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:510: undefined reference to `xpack_encode_integer(unsigned char*, unsigned char const*, unsigned long, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_encode_literal_header_field_with_name_ref(unsigned short, bool, unsigned short, char const*, int, bool, IOBufferBlock*)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:547: undefined reference to `xpack_encode_integer(unsigned char*, unsigned char const*, unsigned long, unsigned char)'
/home/scw00/trafficserver/proxy/http3/QPACK.cc:554: undefined reference to `xpack_encode_string(unsigned char*, unsigned char const*, char const*, unsigned long, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_encode_literal_header_field_without_name_ref(char const*, int, char const*, int, bool, IOBufferBlock*)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:583: undefined reference to `xpack_encode_string(unsigned char*, unsigned char const*, char const*, unsigned long, unsigned char)'
/home/scw00/trafficserver/proxy/http3/QPACK.cc:590: undefined reference to `xpack_encode_string(unsigned char*, unsigned char const*, char const*, unsigned long, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_encode_literal_header_field_with_postbase_name_ref(unsigned short, unsigned short, char const*, int, bool, IOBufferBlock*)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:619: undefined reference to `xpack_encode_integer(unsigned char*, unsigned char const*, unsigned long, unsigned char)'
/home/scw00/trafficserver/proxy/http3/QPACK.cc:626: undefined reference to `xpack_encode_string(unsigned char*, unsigned char const*, char const*, unsigned long, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_decode_indexed_header_field(short, unsigned char const*, unsigned long, HTTPHdr&, unsigned int&)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:644: undefined reference to `xpack_decode_integer(unsigned long&, unsigned char const*, unsigned char const*, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_decode_literal_header_field_with_name_ref(short, unsigned char const*, unsigned long, HTTPHdr&, unsigned int&)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:691: undefined reference to `xpack_decode_integer(unsigned long&, unsigned char const*, unsigned char const*, unsigned char)'
/home/scw00/trafficserver/proxy/http3/QPACK.cc:718: undefined reference to `xpack_decode_string(Arena&, char**, unsigned long&, unsigned char const*, unsigned char const*, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_decode_literal_header_field_without_name_ref(unsigned char const*, unsigned long, HTTPHdr&, unsigned int&)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:749: undefined reference to `xpack_decode_string(Arena&, char**, unsigned long&, unsigned char const*, unsigned char const*, unsigned char)'
/home/scw00/trafficserver/proxy/http3/QPACK.cc:756: undefined reference to `xpack_decode_string(Arena&, char**, unsigned long&, unsigned char const*, unsigned char const*, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_decode_indexed_header_field_with_postbase_index(short, unsigned char const*, unsigned long, HTTPHdr&, unsigned int&)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:778: undefined reference to `xpack_decode_integer(unsigned long&, unsigned char const*, unsigned char const*, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_decode_literal_header_field_with_postbase_name_ref(short, unsigned char const*, unsigned long, HTTPHdr&, unsigned int&)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:821: undefined reference to `xpack_decode_integer(unsigned long&, unsigned char const*, unsigned char const*, unsigned char)'
/home/scw00/trafficserver/proxy/http3/QPACK.cc:844: undefined reference to `xpack_decode_string(Arena&, char**, unsigned long&, unsigned char const*, unsigned char const*, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_decode_header(unsigned char const*, unsigned long, HTTPHdr&)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:868: undefined reference to `xpack_decode_integer(unsigned long&, unsigned char const*, unsigned char const*, unsigned char)'
/home/scw00/trafficserver/proxy/http3/QPACK.cc:876: undefined reference to `xpack_decode_integer(unsigned long&, unsigned char const*, unsigned char const*, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_write_insert_with_name_ref(unsigned short, bool, char const*, unsigned short)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:1425: undefined reference to `xpack_encode_integer(unsigned char*, unsigned char const*, unsigned long, unsigned char)'
/home/scw00/trafficserver/proxy/http3/QPACK.cc:1432: undefined reference to `xpack_encode_string(unsigned char*, unsigned char const*, char const*, unsigned long, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_write_insert_without_name_ref(char const*, int, char const*, unsigned short)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:1460: undefined reference to `xpack_encode_string(unsigned char*, unsigned char const*, char const*, unsigned long, unsigned char)'
/home/scw00/trafficserver/proxy/http3/QPACK.cc:1467: undefined reference to `xpack_encode_string(unsigned char*, unsigned char const*, char const*, unsigned long, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_write_duplicate(unsigned short)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:1492: undefined reference to `xpack_encode_integer(unsigned char*, unsigned char const*, unsigned long, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_write_dynamic_table_size_update(unsigned short)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:1520: undefined reference to `xpack_encode_integer(unsigned char*, unsigned char const*, unsigned long, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_write_table_state_syncrhonize(unsigned short)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:1545: undefined reference to `xpack_encode_integer(unsigned char*, unsigned char const*, unsigned long, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_write_header_acknowledgement(unsigned long)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:1573: undefined reference to `xpack_encode_integer(unsigned char*, unsigned char const*, unsigned long, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_write_stream_cancellation(unsigned long)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:1601: undefined reference to `xpack_encode_integer(unsigned char*, unsigned char const*, unsigned long, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_read_insert_with_name_ref(QUICStreamIO&, bool&, unsigned short&, Arena&, char**, unsigned short&)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:1629: undefined reference to `xpack_decode_integer(unsigned long&, unsigned char const*, unsigned char const*, unsigned char)'
/home/scw00/trafficserver/proxy/http3/QPACK.cc:1636: undefined reference to `xpack_decode_string(Arena&, char**, unsigned long&, unsigned char const*, unsigned char const*, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_read_insert_without_name_ref(QUICStreamIO&, Arena&, char**, unsigned short&, char**, unsigned short&)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:1659: undefined reference to `xpack_decode_string(Arena&, char**, unsigned long&, unsigned char const*, unsigned char const*, unsigned char)'
/home/scw00/trafficserver/proxy/http3/QPACK.cc:1666: undefined reference to `xpack_decode_string(Arena&, char**, unsigned long&, unsigned char const*, unsigned char const*, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_read_duplicate(QUICStreamIO&, unsigned short&)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:1688: undefined reference to `xpack_decode_integer(unsigned long&, unsigned char const*, unsigned char const*, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_read_dynamic_table_size_update(QUICStreamIO&, unsigned short&)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:1710: undefined reference to `xpack_decode_integer(unsigned long&, unsigned char const*, unsigned char const*, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_read_table_state_synchronize(QUICStreamIO&, unsigned short&)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:1732: undefined reference to `xpack_decode_integer(unsigned long&, unsigned char const*, unsigned char const*, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_read_header_acknowledgement(QUICStreamIO&, unsigned long&)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:1754: undefined reference to `xpack_decode_integer(unsigned long&, unsigned char const*, unsigned char const*, unsigned char)'
../proxy/http3/libhttp3.a(QPACK.o): In function `QPACK::_read_stream_cancellation(QUICStreamIO&, unsigned long&)':
/home/scw00/trafficserver/proxy/http3/QPACK.cc:1775: undefined reference to `xpack_decode_integer(unsigned long&, unsigned char const*, unsigned char const*, unsigned char)'
collect2: error: ld returned 1 exit status
```

```
Using built-in specs.
COLLECT_GCC=g++
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/8/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none
OFFLOAD_TARGET_DEFAULT=1
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Ubuntu 8.2.0-1ubuntu2~18.04' --with-bugurl=file:///usr/share/doc/gcc-8/README.Bugs --enable-languages=c,ada,c++,go,brig,d,fortran,objc,obj-c++ --prefix=/usr --with-gcc-major-version-only --program-suffix=-8 --program-prefix=x86_64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-libmpx --enable-plugin --enable-default-pie --with-system-zlib --with-target-system-zlib --enable-objc-gc=auto --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-offload-targets=nvptx-none --without-cuda-driver --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
Thread model: posix
```