### PR TITLE
Fixed pthread mutex init issue with cache test

### DIFF
--- a/iocore/cache/test/main.cc
+++ b/iocore/cache/test/main.cc
@@ -54,6 +54,7 @@ struct EventProcessorListener : Catch::TestEventListenerBase {
     ink_net_init(ts::ModuleVersion(1, 0, ts::ModuleVersion::PRIVATE));
     ink_assert(GLOBAL_DATA != nullptr);
 
+    statPagesManager.init(); // mutex needs to be initialized before calling netProcessor.init
     netProcessor.init();
     eventProcessor.start(THREADS);
 


### PR DESCRIPTION
This issue is showing up on the Mac.  Here is the backtrace in lldb:
```
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
  * frame #0: 0x00007fff70eee2c6 libsystem_kernel.dylib`__pthread_kill + 10
    frame #1: 0x00007fff70fa3bf1 libsystem_pthread.dylib`pthread_kill + 284
    frame #2: 0x00007fff70e586a6 libsystem_c.dylib`abort + 127
    frame #3: 0x000000010a365994 libtscore.9.dylib`ink_abort(message_format=<unavailable>) at ink_error.cc:99:3 [opt]
    frame #4: 0x0000000109e90806 test_Cache`StatPagesManager::register_http(char const*, Action* (*)(Continuation*, HTTPHdr*)) [inlined] ink_mutex_acquire(m=<unavailable>) at ink_mutex.h:50:5 [opt]
    frame #5: 0x0000000109e907e5 test_Cache`StatPagesManager::register_http(this=<unavailable>, module="net", func=(test_Cache`register_ShowNet(Continuation*, HTTPHdr*) at UnixNetPages.cc:210))(Continuation*, HTTPHdr*)) at StatPages.cc:61 [opt]
    frame #6: 0x0000000109ed94f9 test_Cache`UnixNetProcessor::init(this=0x000000010a015c98) at UnixNetProcessor.cc:344:22 [opt]
    frame #7: 0x0000000109d7cd22 test_Cache`EventProcessorListener::testRunStarting(this=<unavailable>, testRunInfo=<unavailable>) at main.cc:61:18 [opt]
    frame #8: 0x0000000109d4cb8c test_Cache`Catch::MultipleReporters::testRunStarting(this=<unavailable>, testRunInfo=<unavailable>) at catch.hpp:12451:23 [opt]
    frame #9: 0x0000000109d2d541 test_Cache`Catch::RunContext::RunContext(this=0x00007ffee5eebde0, _config=std::__1::shared_ptr<const Catch::IConfig>::element_type @ 0x00007fc78340d258 strong=6 weak=1, reporter=<unavailable>) at catch.hpp:8562:21 [opt]
    frame #10: 0x0000000109d34e3d test_Cache`Catch::Session::runInternal() [inlined] Catch::RunContext::RunContext(this=0x0000000109fda1b8, _config=std::__1::shared_ptr<const Catch::IConfig>::element_type @ 0x0000000109fd9c90 strong=1 weak=1, reporter=0x0000000000000000) at catch.hpp:8558:5 [opt]
    frame #11: 0x0000000109d34e38 test_Cache`Catch::Session::runInternal() [inlined] Catch::(anonymous namespace)::runTests(config=nullptr) at catch.hpp:9124 [opt]
    frame #12: 0x0000000109d34885 test_Cache`Catch::Session::runInternal(this=<unavailable>) at catch.hpp:9333 [opt]
    frame #13: 0x0000000109d340f1 test_Cache`Catch::Session::run(this=0x00007ffee5eec038) at catch.hpp:9290:24 [opt]
    frame #14: 0x0000000109d4fa91 test_Cache`main [inlined] Catch::Session::run(this=0x0000000109fda2c0, argc=1, argv=0x00007ffee5eec1b8) at catch.hpp:9258:26 [opt]
    frame #15: 0x0000000109d4fa67 test_Cache`main(argc=1, argv=0x00007ffee5eec1b8) at catch.hpp:12750 [opt]
    frame #16: 0x00007fff70db33d5 libdyld.dylib`start + 1
    frame #17: 0x00007fff70db33d5 libdyld.dylib`start + 1
```