### PR TITLE
JA3 fingerprint: Corrected usage of OpenSSL API for ec and ecpf list retrieval. 

### DIFF
--- a/plugins/experimental/ja3_fingerprint/ja3_fingerprint.cc
+++ b/plugins/experimental/ja3_fingerprint/ja3_fingerprint.cc
@@ -227,14 +227,21 @@ custom_get_ja3(SSL *s)
   // Get cipher suites
   len = SSL_client_hello_get0_ciphers(s, &p);
   custom_get_ja3_prefixed(2, p, len, ja3);
+  ja3 += ',';
 
   // Get extenstions
   int *o;
   std::string eclist, ecpflist;
   if (SSL_client_hello_get0_ext(s, 0x0a, &p, &len) == 1) {
+    // Skip first 2 bytes since we already have length
+    p += 2;
+    len -= 2;
     custom_get_ja3_prefixed(2, p, len, eclist);
   }
   if (SSL_client_hello_get0_ext(s, 0x0b, &p, &len) == 1) {
+    // Skip first byte since we already have length
+    ++p;
+    --len;
     custom_get_ja3_prefixed(1, p, len, ecpflist);
   }
   if (SSL_client_hello_get1_extensions_present(s, &o, &len) == 1) {
@@ -249,6 +256,7 @@ custom_get_ja3(SSL *s)
         ja3 += std::to_string(type);
       }
     }
+    OPENSSL_free(o);
   }
   ja3 += "," + eclist + "," + ecpflist;
   return ja3;


### PR DESCRIPTION
`SSL_client_hello_get0_ext()` gives a pointer to the length bytes instead of the actual content. The plugin mistook that extra padding as part of signatures before. The new changes shift that pointers past length bytes and points to actual content.

An example would be 
![Screen Shot 2019-04-10 at 1 18 39 PM](https://user-images.githubusercontent.com/11047937/55903956-57553480-5b94-11e9-8d8d-49c918d9a698.png)
The old signature: JA3: 771,52393-52392-52394-49200-49196-49192-49188-49172-49162-159-107-57-65413-196-136-129-157-61-53-192-132-49199-49195-49191-49187-49171-49161-158-103-51-190-69-156-60-47-186-65-49170-49160-22-10-255,11-10-13-16,**6-29-23-24,1-0**
The correct signature: JA3: 771,52393-52392-52394-49200-49196-49192-49188-49172-49162-159-107-57-65413-196-136-129-157-61-53-192-132-49199-49195-49191-49187-49171-49161-158-103-51-190-69-156-60-47-186-65-49170-49160-22-10-255,11-10-13-16,**29-23-24,0**

Added OPENSSL_free to free allocated memory in SSL_client_hello_get1_extensions_present API.