### PR TITLE
Fix IntrusiveHashMap active bucket list corruption issue during expansion.

### DIFF
--- a/include/tscore/IntrusiveHashMap.h
+++ b/include/tscore/IntrusiveHashMap.h
@@ -343,6 +343,9 @@ IntrusiveHashMap<H>::Bucket::clear()
   _v       = nullptr;
   _count   = 0;
   _mixed_p = false;
+  // These can be left set during an expansion, when the bucket did have elements before but not
+  // after. Therefore make sure they are cleared.
+  _link._next = _link._prev = nullptr;
 }
 
 template <typename H>


### PR DESCRIPTION
If the table is expanded, the buckets are cleared and the items re-entered. However, if a bucket had items before the expansion but not afterwards, the link pointers aren't cleared. If a later find hits that bucket, then the bucket content iteration will break. This doesn't happen if the bucket had no items before or gets items during the expansion.