### PR TITLE
Ignore unsupported HTTP/2 settings parameters

### DIFF
--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -85,7 +85,7 @@ public:
     if (0 < id && id < HTTP2_SETTINGS_MAX) {
       return this->settings[indexof(id)] = value;
     } else {
-      ink_assert(!"Bad Settings Identifier");
+      // Do nothing - 6.5.3 Unsupported parameters MUST be ignored.
     }
 
     return 0;


### PR DESCRIPTION
There're `ink_assert()` on setting unknown HTTP/2 parameters. But [RFC 7540 - 6.5.3.  Settings Synchronization](https://tools.ietf.org/html/rfc7540#section-6.5.3) says

> Unsupported parameters MUST be ignored.

----

Fortunately, this is not `ink_release_assert()`. Probably, we don't need to backport to 7.x nor 8.x branch.