### PR TITLE
Fix HostDBReverseTest sa_family initialization.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1262,7 +1262,7 @@ TS_CHECK_ZLIB
 TS_CHECK_LZMA
 
 AC_CHECK_FUNCS([clock_gettime kqueue epoll_ctl posix_fadvise posix_madvise posix_fallocate inotify_init])
-AC_CHECK_FUNCS([lrand48_r srand48_r port_create strlcpy strlcat sysconf sysctlbyname getpagesize])
+AC_CHECK_FUNCS([port_create strlcpy strlcat sysconf sysctlbyname getpagesize])
 AC_CHECK_FUNCS([getreuid getresuid getresgid setreuid setresuid getpeereid getpeerucred])
 AC_CHECK_FUNCS([strsignal psignal psiginfo accept4])
 

--- a/iocore/hostdb/P_RefCountCache.h
+++ b/iocore/hostdb/P_RefCountCache.h
@@ -290,9 +290,9 @@ RefCountCachePartition<C>::clear()
   // Hence, this monstrosity.
   auto it = this->item_map.begin();
   while (it != this->item_map.end()) {
-    auto cur = it;
+    auto cur = it++;
 
-    it = this->item_map.erase(it);
+    this->item_map.erase(cur);
     this->dealloc_entry(cur);
   }
 }


### PR DESCRIPTION
This required other fixes, because the failure to initialize `sa_family` meant the test didn't work at all.

*  Use `std::random` instead of `lrand48` and `srand48`.
*  Remove the `LRAND48` and `SRAND48` `#ifdef`s.
*  Remove `LRAND48` from "configure.ac" because it is  no longer used. Note that `SRAND48`, although checked, had no support in "configure.ac" and therefore didn't work at all.
*  Change the test bounds to be something reasonable, as every test item generates a DNS request, and doing 100,000 DNS requests per regression test seemed excessive. Further, each one generated a line of output, and 100,000 lines of test output for just HostDB also seemed excessive.