### PR TITLE
Doc: fix proxy.config.hostdb.timeout default

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -2577,7 +2577,7 @@ HostDB
          value become a minimum TTL.
    ===== ======================================================================
 
-.. ts:cv:: CONFIG proxy.config.hostdb.timeout INT 1440
+.. ts:cv:: CONFIG proxy.config.hostdb.timeout INT 86400
    :units: seconds
    :reloadable:
 


### PR DESCRIPTION
I noticed that proxy.config.hostdb.timeout default parameter on the document is incorrect.  
I corrected it to the correct value referring to the following source code.

https://github.com/apache/trafficserver/blob/af308e54db7f18cdb92dd4700bdff37af97ea45e/mgmt/RecordsConfig.cc#L944