### PR TITLE
Don't read frames after sending GOAWAY with an error code

### DIFF
--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -543,6 +543,11 @@ Http2ClientSession::state_process_frame_read(int event, VIO *vio, bool inside_fr
   }
 
   while (this->sm_reader->read_avail() >= (int64_t)HTTP2_FRAME_HEADER_LEN) {
+    // Cancel reading if there was an error
+    if (connection_state.tx_error_code.code != static_cast<uint32_t>(Http2ErrorCode::HTTP2_ERROR_NO_ERROR)) {
+      Http2SsnDebug("reading a frame has been canceled (%u)", connection_state.tx_error_code.code);
+      break;
+    }
     // Return if there was an error
     Http2ErrorCode err;
     if (do_start_frame_read(err) < 0) {


### PR DESCRIPTION
ATS keeps processing H2 frames arrived even after sending GOAWAY frame with an error code, but it is unnecessary and it delays closing process. We should skip reading frames after sending GOAWAY, and initiate closing process without delay. Closing process will be initiated by FINI event which should be scheduled when we sent GOAWAY.

> An endpoint that encounters a connection error SHOULD first send a
   GOAWAY frame (Section 6.8) with the stream identifier of the last
   stream that it successfully received from its peer.  The GOAWAY frame
   includes an error code that indicates why the connection is
   terminating.  After sending the GOAWAY frame for an error condition,
   the endpoint MUST close the TCP connection.

>   It is possible that the GOAWAY will not be reliably received by the
   receiving endpoint ([RFC7230], Section 6.6 describes how an immediate
   connection close can result in data loss).  In the event of a
   connection error, GOAWAY only provides a best-effort attempt to
   communicate with the peer about why the connection is being
   terminated.

https://tools.ietf.org/html/rfc7540#section-5.4.1