### PR TITLE
Add slice option to disable errorlog, redo config parameters

### DIFF
--- a/doc/admin-guide/plugins/slice.en.rst
+++ b/doc/admin-guide/plugins/slice.en.rst
@@ -63,14 +63,18 @@ Plugin Options
 
 Slice block sizes can specified using the blockbytes parameter::
 
-    @plugin=slice.so @pparam=blockbytes:1000000 @cache_range_requests.so
+    @plugin=slice.so @pparam=--blockbytes=1000000 @cache_range_requests.so
+
+Or alternatively::
+
+    @plugin=slice.so @pparam=-b @pparam=1000000 @cache_range_requests.so
 
 In adition to bytes, 'k', 'm' and 'g' suffixes may be used for
 kilobytes, megabytes and gigabytes::
 
-    @plugin=slice.so @pparam=blockbytes:5m @cache_range_requests.so
-    @plugin=slice.so @pparam=blockbytes:512k @cache_range_requests.so
-    @plugin=slice.so @pparam=blockbytes:32m @cache_range_requests.so
+    @plugin=slice.so @pparam=--blockbytes=5m @cache_range_requests.so
+    @plugin=slice.so @pparam=--blockbytes=512k @cache_range_requests.so
+    @plugin=slice.so @pparam=--blockbytes=32m @cache_range_requests.so
 
 paramater ``blockbytes`` is checked to be between 32kb and 32mb
 inclusive.
@@ -78,12 +82,20 @@ inclusive.
 For testing and extreme purposes the parameter ``bytesover`` may
 be used instead which is unchecked::
 
-    @plugin=slice.so @pparam=bytesover:1G @cache_range_requests.so
-    @plugin=slice.so @pparam=bytesover:13 @cache_range_requests.so
+    @plugin=slice.so @pparam=--bytesover=1G @cache_range_requests.so
+    @plugin=slice.so @pparam=--bytesover=13 @cache_range_requests.so
 
 After modifying :file:`remap.config`, restart or reload traffic server
 (sudo traffic_ctl config reload) or (sudo traffic_ctl server restart)
 to activate the new configuration values.
+
+Slice block stitching errors are logged to diags.log.  In some special
+cases the volume of these logs may start to overwhelm the system.
+In this case adding the --disable-errorlog flag::
+
+    @plugin=slice.so @pparam=--disable-errorlog @cache_range_requests.so
+
+Will turn off logging these errors to diags.log
 
 Implementation Notes
 ====================

--- a/plugins/experimental/slice/Config.h
+++ b/plugins/experimental/slice/Config.h
@@ -20,21 +20,17 @@
 
 #include "slice.h"
 
-#include <string>
-
 // Data Structures and Classes
 struct Config {
-  static int64_t const blockbytesmin     = 1024 * 256;       // 256KB
-  static int64_t const blockbytesmax     = 1024 * 1024 * 32; // 32MB
-  static int64_t const blockbytesdefault = 1024 * 1024;      // 1MB
-
-  static constexpr char const *const blockbytesstr = "blockbytes";
-  static constexpr char const *const bytesoverstr  = "bytesover";
+  static constexpr int64_t const blockbytesmin     = 1024 * 256;       // 256KB
+  static constexpr int64_t const blockbytesmax     = 1024 * 1024 * 32; // 32MB
+  static constexpr int64_t const blockbytesdefault = 1024 * 1024;      // 1MB
 
   int64_t m_blockbytes{blockbytesdefault};
+  bool m_disable_errorlog{false};
 
   // Last one wins
-  bool fromArgs(int const argc, char const *const argv[], char *const errbuf, int const errbuf_size);
+  bool fromArgs(int const argc, char const *const argv[]);
 
-  static int64_t bytesFrom(std::string const &valstr);
+  static int64_t bytesFrom(char const *const valstr);
 };

--- a/plugins/experimental/slice/Data.h
+++ b/plugins/experimental/slice/Data.h
@@ -20,10 +20,10 @@
 
 #include "ts/ts.h"
 
+#include "Config.h"
 #include "HttpHeader.h"
 #include "Range.h"
 #include "Stage.h"
-#include "slice.h"
 
 #include <netinet/in.h>
 
@@ -35,7 +35,8 @@ struct Data {
   Data(Data const &) = delete;
   Data &operator=(Data const &) = delete;
 
-  int64_t const m_blockbytes_config; // configured slice block size
+  Config const *const m_config;
+
   sockaddr_storage m_client_ip;
 
   // for pristine url coming in
@@ -76,8 +77,8 @@ struct Data {
 
   TSHttpParser m_http_parser{nullptr}; //!< cached for reuse
 
-  explicit Data(int64_t const blockbytes)
-    : m_blockbytes_config(blockbytes),
+  explicit Data(Config const *const config)
+    : m_config(config),
       m_client_ip(),
       m_urlbuffer(nullptr),
       m_urlloc(nullptr),

--- a/plugins/experimental/slice/HttpHeader.h
+++ b/plugins/experimental/slice/HttpHeader.h
@@ -71,6 +71,16 @@ struct HttpHeader {
     return getCharPtr(TSHttpHdrMethodGet, len);
   }
 
+  // request method version
+  int
+  version() const
+  {
+    return TSHttpHdrVersionGet(m_buffer, m_lochdr);
+  }
+
+  // Returns string representation of the url. Caller gets ownership!
+  char *urlString(int *const urllen) const;
+
   // host
   char const *
   hostname(int *const len) const
@@ -95,7 +105,7 @@ struct HttpHeader {
   bool valueForKey(char const *const keystr, int const keylen,
                    char *const valstr,  // <-- return string value
                    int *const vallen,   // <-- pass in capacity, returns len of string
-                   int const index = -1 // sets all values
+                   int const index = -1 // retrieves all values
                    ) const;
 
   /**

--- a/plugins/experimental/slice/README.md
+++ b/plugins/experimental/slice/README.md
@@ -18,18 +18,47 @@ To enable the plugin, specify the plugin library via @plugin at the end
 of a remap line as follows (2MB slice in this example):
 
 ```
-map http://ats-cache/ http://parent/ @plugin=slice.so @pparam=blockbytes:2097152 @plugin=cache_range_requests.so
+map http://ats-cache/ http://parent/ @plugin=slice.so @pparam=--blockbytes=2M @plugin=cache_range_requests.so
+```
+
+alternatively
+
+```
+map http://ats-cache/ http://parent/ @plugin=slice.so @pparam=-b @pparam=2M @plugin=cache_range_requests.so
 ```
 
 for global plugins.
 
 ```
-slice.so blockbytes:2097152
+slice.so --blockbytes=2097152
 cache_range_requests.so
 ```
 
-**Note**: cache_range_requests **MUST** follow slice.so Put these plugins at the end of the plugin list
-**Note**: blockbytes is defined in bytes. 1048576 (1MB) is the default.
+alternatively:
+
+```
+slice.so -b 2M
+cache_range_requests.so
+```
+
+Options for the slice plugin:
+```
+--blockbytes=<number bytes, can be followed by K, M or G>
+  also -b <num bytes> can be used
+
+--bytesover=<number bytes, can be followed by K, M or G>
+
+--disable-errorlog
+  This should only be used if there is an origin error that is
+	overly spamming diags.log.
+
+```
+
+**Note**: cache_range_requests **MUST** follow slice.so Put these plugins
+at the end of the plugin list
+
+**Note**: blockbytes is defined in bytes. Postfix for 'K', 'M' and 'G'
+may be used.  1048576 (1MB) is the default.
 
 For testing purposes an unchecked value of "bytesover" is also available.
 
@@ -47,6 +76,13 @@ Range: bytes=-<last N bytes>
 are supported as multi part range responses are non trivial to implement.
 This matches with the cache_range_requests.so plugin capability.
 
+By default the slice plugin will generate special error log messages
+that are written to diags.log
+
+The may look something like
+```
+[Apr 19 20:26:13.639] [ET_NET 17] ERROR: [slice] 1555705573.639 reason="Non 206 internal block response" uri="http://localhost:18080/%7Ep.tex/%7Es.50M/%7Eui.20000/" uas="curl/7.29.0" req_range="bytes=1000000-" norm_range="bytes 1000000-52428799/52428800" etag_exp="%221603934496%22" lm_exp="Fri, 19 Apr 2019 18:53:20 GMT" blk_range="21000000-21999999" status_got="400" cr_got="" etag_got="" lm_got="" cc="no-store" via=""
+```
 ---
 
 Important things to note:

--- a/plugins/experimental/slice/Range.cc
+++ b/plugins/experimental/slice/Range.cc
@@ -57,10 +57,10 @@ Range::fromStringClosed(char const *const rangestr)
   }
 
   // rip out any whitespace
-  static int const RLEN = 1024;
-  char rangebuf[RLEN];
-  char *pbuf = rangebuf;
-  while ('\0' != *pstr && (pbuf - rangebuf) < RLEN) {
+  char rangebuf[1024];
+  int const rangelen = sizeof(rangebuf);
+  char *pbuf         = rangebuf;
+  while ('\0' != *pstr && (pbuf - rangebuf) < rangelen) {
     if (!isblank(*pstr)) {
       *pbuf++ = *pstr;
     }

--- a/plugins/experimental/slice/client.cc
+++ b/plugins/experimental/slice/client.cc
@@ -34,8 +34,8 @@ shutdown(TSCont const contp, Data *const data)
 bool
 requestBlock(TSCont contp, Data *const data)
 {
-  int64_t const blockbeg = (data->m_blockbytes_config * data->m_blocknum);
-  Range blockbe(blockbeg, blockbeg + data->m_blockbytes_config);
+  int64_t const blockbeg = (data->m_config->m_blockbytes * data->m_blocknum);
+  Range blockbe(blockbeg, blockbeg + data->m_config->m_blockbytes);
 
   char rangestr[1024];
   int rangelen      = sizeof(rangestr);
@@ -131,7 +131,7 @@ handle_client_req(TSCont contp, TSEvent event, Data *const data)
         data->m_statustype = TS_HTTP_STATUS_REQUESTED_RANGE_NOT_SATISFIABLE;
 
         // First block will give Content-Length
-        rangebe = Range(0, data->m_blockbytes_config);
+        rangebe = Range(0, data->m_config->m_blockbytes);
       }
     } else {
       DEBUG_LOG("Full content request");
@@ -143,7 +143,7 @@ handle_client_req(TSCont contp, TSEvent event, Data *const data)
     }
 
     // set to the first block in range
-    data->m_blocknum  = rangebe.firstBlockFor(data->m_blockbytes_config);
+    data->m_blocknum  = rangebe.firstBlockFor(data->m_config->m_blockbytes);
     data->m_req_range = rangebe;
 
     // remove ATS keys to avoid 404 loop

--- a/plugins/experimental/slice/client.cc
+++ b/plugins/experimental/slice/client.cc
@@ -38,7 +38,7 @@ requestBlock(TSCont contp, Data *const data)
   Range blockbe(blockbeg, blockbeg + data->m_blockbytes_config);
 
   char rangestr[1024];
-  int rangelen      = 1023;
+  int rangelen      = sizeof(rangestr);
   bool const rpstat = blockbe.toStringClosed(rangestr, &rangelen);
   TSAssert(rpstat);
 
@@ -114,7 +114,7 @@ handle_client_req(TSCont contp, TSEvent event, Data *const data)
     Range rangebe;
 
     char rangestr[1024];
-    int rangelen        = 1024;
+    int rangelen        = sizeof(rangestr);
     bool const hasRange = header.valueForKey(TS_MIME_FIELD_RANGE, TS_MIME_LEN_RANGE, rangestr, &rangelen,
                                              0); // <-- first range only
     if (hasRange) {
@@ -135,7 +135,7 @@ handle_client_req(TSCont contp, TSEvent event, Data *const data)
       }
     } else {
       DEBUG_LOG("Full content request");
-      static char const *const valstr = "full content request";
+      static char const *const valstr = "-";
       static size_t const vallen      = strlen(valstr);
       header.setKeyVal(SLICER_MIME_FIELD_INFO, strlen(SLICER_MIME_FIELD_INFO), valstr, vallen);
       data->m_statustype = TS_HTTP_STATUS_OK;

--- a/plugins/experimental/slice/response.cc
+++ b/plugins/experimental/slice/response.cc
@@ -68,9 +68,8 @@ string502()
     bodystr.append("</body>\n");
     bodystr.append("</html>\n");
 
-    static int const CLEN = 1024;
-    char clenstr[CLEN];
-    int const clen = snprintf(clenstr, CLEN, "%lu", bodystr.size());
+    char clenstr[1024];
+    int const clen = snprintf(clenstr, sizeof(clenstr), "%lu", bodystr.size());
 
     msg.append("HTTP/1.1 502 Bad Gateway\r\n");
     msg.append("Content-Length: ");
@@ -96,9 +95,7 @@ form416HeaderAndBody(HttpHeader &header, int64_t const contentlen, std::string c
   header.setReason(reason, strlen(reason));
 
   char bufstr[256];
-  int buflen = snprintf
-    //    (bufstr, 255, "%" PRId64, bodystr.size());
-    (bufstr, 255, "%lu", bodystr.size());
+  int buflen = snprintf(bufstr, sizeof(bufstr), "%lu", bodystr.size());
   header.setKeyVal(TS_MIME_FIELD_CONTENT_LENGTH, TS_MIME_LEN_CONTENT_LENGTH, bufstr, buflen);
 
   static char const *const ctypestr = "text/html";

--- a/plugins/experimental/slice/slice.cc
+++ b/plugins/experimental/slice/slice.cc
@@ -55,7 +55,8 @@ read_request(TSHttpTxn txnp, Config const *const config)
         return false;
       }
 
-      Data *const data = new Data(config->m_blockbytes);
+      TSAssert(nullptr != config);
+      Data *const data = new Data(config);
 
       // set up feedback connect
       if (AF_INET == ip->sa_family) {
@@ -150,11 +151,11 @@ TSRemapOSResponse(void *ih, TSHttpTxn rh, int os_response_type)
 
 SLICE_EXPORT
 TSReturnCode
-TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_size)
+TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf */, int /* errbuf_size */)
 {
   Config *const config = new Config;
   if (2 < argc) {
-    config->fromArgs(argc - 2, argv + 2, errbuf, errbuf_size);
+    config->fromArgs(argc - 2, argv + 2);
   }
   *ih = static_cast<void *>(config);
   return TS_SUCCESS;
@@ -195,7 +196,7 @@ TSPluginInit(int argc, char const *argv[])
   }
 
   if (1 < argc) {
-    globalConfig.fromArgs(argc - 1, argv + 1, nullptr, 0);
+    globalConfig.fromArgs(argc - 1, argv + 1);
   }
 
   TSCont const contp(TSContCreate(global_read_request_hook, nullptr));

--- a/tests/gold_tests/pluginTest/slice/gold_error/crr.stderr.gold
+++ b/tests/gold_tests/pluginTest/slice/gold_error/crr.stderr.gold
@@ -1,0 +1,1 @@
+the quick``

--- a/tests/gold_tests/pluginTest/slice/gold_error/crr.stdout.gold
+++ b/tests/gold_tests/pluginTest/slice/gold_error/crr.stdout.gold
@@ -1,0 +1,9 @@
+``
+Cache-Control: ``
+Connection: ``
+Content-Length: 19
+Date: ``
+Etag: ``
+HTTP/1.1 200 OK
+Server: ``
+Via: ``

--- a/tests/gold_tests/pluginTest/slice/gold_error/etag.stderr.gold
+++ b/tests/gold_tests/pluginTest/slice/gold_error/etag.stderr.gold
@@ -1,0 +1,1 @@
+the quick``

--- a/tests/gold_tests/pluginTest/slice/gold_error/etag.stdout.gold
+++ b/tests/gold_tests/pluginTest/slice/gold_error/etag.stdout.gold
@@ -1,0 +1,9 @@
+``
+Cache-Control: ``
+Connection: ``
+Content-Length: 19
+Date: ``
+Etag: ``
+HTTP/1.1 200 OK
+Server: ``
+Via: ``

--- a/tests/gold_tests/pluginTest/slice/gold_error/lm.stderr.gold
+++ b/tests/gold_tests/pluginTest/slice/gold_error/lm.stderr.gold
@@ -1,0 +1,1 @@
+the quick``

--- a/tests/gold_tests/pluginTest/slice/gold_error/lm.stdout.gold
+++ b/tests/gold_tests/pluginTest/slice/gold_error/lm.stdout.gold
@@ -1,0 +1,9 @@
+``
+Cache-Control: ``
+Connection: ``
+Content-Length: 19
+Date: ``
+HTTP/1.1 200 OK
+Last-Modified: ``
+Server: ``
+Via: ``

--- a/tests/gold_tests/pluginTest/slice/gold_error/non206.stderr.gold
+++ b/tests/gold_tests/pluginTest/slice/gold_error/non206.stderr.gold
@@ -1,0 +1,1 @@
+the quick``

--- a/tests/gold_tests/pluginTest/slice/gold_error/non206.stdout.gold
+++ b/tests/gold_tests/pluginTest/slice/gold_error/non206.stdout.gold
@@ -1,0 +1,10 @@
+``
+Cache-Control: ``
+Connection: ``
+Content-Length: 19
+Date: ``
+Etag: ``
+HTTP/1.1 200 OK
+Last-Modified: ``
+Server: ``
+Via: ``

--- a/tests/gold_tests/pluginTest/slice/slice.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice.test.py
@@ -117,7 +117,7 @@ tr = Test.AddTestRun("Load Slice plugin")
 remap_config_path = ts.Disk.remap_config.Name
 tr.Disk.File(remap_config_path, typename="ats:config").AddLines([
   'map / http://127.0.0.1:{}'.format(server.Variables.Port) +
-    ' @plugin=slice.so @pparam=bytesover:{}'.format(block_bytes)
+    ' @plugin=slice.so @pparam=--bytesover={}'.format(block_bytes)
 ])
 
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/pluginTest/slice/slice_error.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice_error.test.py
@@ -1,0 +1,326 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import time
+Test.Summary = '''
+Slice plugin error.log test
+'''
+
+## Test description:
+# Preload the cache with the entire asset to be range requested.
+# Reload remap rule with slice plugin
+# Request content through the slice plugin
+
+Test.SkipUnless(
+    Condition.HasProgram("curl", "Curl needs to be installed on system for this test to work"),
+    Condition.PluginExists('slice.so'),
+)
+Test.ContinueOnFail = False
+
+# configure origin server
+server = Test.MakeOriginServer("server", lookup_key="{%Range}{PATH}")
+
+# Define ATS and configure
+ts = Test.MakeATSProcess("ts", command="traffic_manager")
+
+body = "the quick brown fox" # len 19
+
+# default root
+request_header_chk = {"headers":
+  "GET / HTTP/1.1\r\n" +
+  "Host: www.example.com\r\n" +
+  "Range: bytes=0-\r\n" +
+  "\r\n",
+  "timestamp": "1469733493.993",
+  "body": "",
+}
+
+response_header_chk = {"headers":
+  "HTTP/1.1 206 Partial Content\r\n" +
+  "Connection: close\r\n" +
+  "\r\n",
+  "timestamp": "1469733493.993",
+  "body": body,
+}
+
+server.addResponse("sessionlog.json", request_header_chk, response_header_chk)
+
+blockbytes = 9
+
+range0 = "{}-{}".format(0, blockbytes - 1)
+range1 = "{}-{}".format(blockbytes, (2 * blockbytes) - 1)
+
+body0 = body[0:blockbytes]
+body1 = body[blockbytes:2 * blockbytes]
+
+# Mismatch etag
+
+request_header_etag0 = {"headers":
+  "GET /etag HTTP/1.1\r\n" +
+  "Host: www.example.com\r\n" +
+  "Range: bytes={}\r\n".format(range0) +
+  "X-Slicer-Info: full content request\r\n" +
+  "\r\n",
+  "timestamp": "1469733493.993",
+  "body": "",
+}
+
+response_header_etag0 = {"headers":
+  "HTTP/1.1 206 Partial Content\r\n" +
+  "Connection: close\r\n" +
+  'Etag: "etag0"\r\n' +
+  "Content-Range: bytes {}/{}\r\n".format(range0, len(body)) +
+  "Cache-Control: max-age=500\r\n" +
+  "\r\n",
+  "timestamp": "1469733493.993",
+  "body": body0,
+}
+
+server.addResponse("sessionlog.json", request_header_etag0, response_header_etag0)
+
+request_header_etag1 = {"headers":
+  "GET /etag HTTP/1.1\r\n" +
+  "Host: www.example.com\r\n" +
+  "Range: bytes={}\r\n".format(range1) +
+  "X-Slicer-Info: full content request\r\n" +
+  "\r\n",
+  "timestamp": "1469733493.993",
+  "body": "",
+}
+
+response_header_etag1 = {"headers":
+  "HTTP/1.1 206 Partial Content\r\n" +
+  "Connection: close\r\n" +
+  'Etag: "etag1"\r\n' +
+  "Content-Range: bytes {}/{}\r\n".format(range1, len(body)) +
+  "Cache-Control: max-age=500\r\n" +
+  "\r\n",
+  "timestamp": "1469733493.993",
+  "body": body1,
+}
+
+server.addResponse("sessionlog.json", request_header_etag1, response_header_etag1)
+
+# mismatch Last-Modified
+
+request_header_lm0 = {"headers":
+  "GET /lastmodified HTTP/1.1\r\n" +
+  "Host: www.example.com\r\n" +
+  "Range: bytes={}\r\n".format(range0) +
+  "X-Slicer-Info: full content request\r\n" +
+  "\r\n",
+  "timestamp": "1469733493.993",
+  "body": "",
+}
+
+response_header_lm0 = {"headers":
+  "HTTP/1.1 206 Partial Content\r\n" +
+  "Connection: close\r\n" +
+  "Last-Modified: Tue, 08 May 2018 15:49:41 GMT\r\n" +
+  "Content-Range: bytes {}/{}\r\n".format(range0, len(body)) +
+  "Cache-Control: max-age=500\r\n" +
+  "\r\n",
+  "timestamp": "1469733493.993",
+  "body": body0,
+}
+
+server.addResponse("sessionlog.json", request_header_lm0, response_header_lm0)
+
+request_header_lm1 = {"headers":
+  "GET /lastmodified HTTP/1.1\r\n" +
+  "Host: www.example.com\r\n" +
+  "Range: bytes={}\r\n".format(range1) +
+  "X-Slicer-Info: full content request\r\n" +
+  "\r\n",
+  "timestamp": "1469733493.993",
+  "body": "",
+}
+
+response_header_lm1 = {"headers":
+  "HTTP/1.1 206 Partial Content\r\n" +
+  "Connection: close\r\n" +
+  "Last-Modified: Tue, 08 Apr 2019 18:00:00 GMT\r\n" +
+  "Content-Range: bytes {}/{}\r\n".format(range1, len(body)) +
+  "Cache-Control: max-age=500\r\n" +
+  "\r\n",
+  "timestamp": "1469733493.993",
+  "body": body1,
+}
+
+server.addResponse("sessionlog.json", request_header_lm1, response_header_lm1)
+
+# non 206 slice block
+
+request_header_n206_0 = {"headers":
+  "GET /non206 HTTP/1.1\r\n" +
+  "Host: www.example.com\r\n" +
+  "Range: bytes={}\r\n".format(range0) +
+  "X-Slicer-Info: full content request\r\n" +
+  "\r\n",
+  "timestamp": "1469733493.993",
+  "body": "",
+}
+
+response_header_n206_0 = {"headers":
+  "HTTP/1.1 206 Partial Content\r\n" +
+  "Connection: close\r\n" +
+  'Etag: "etag"\r\n' +
+  "Last-Modified: Tue, 08 May 2018 15:49:41 GMT\r\n" +
+  "Content-Range: bytes {}/{}\r\n".format(range0, len(body)) +
+  "Cache-Control: max-age=500\r\n" +
+  "\r\n",
+  "timestamp": "1469733493.993",
+  "body": body0,
+}
+
+server.addResponse("sessionlog.json", request_header_n206_0, response_header_n206_0)
+
+# mismatch content-range
+
+request_header_crr0 = {"headers":
+  "GET /crr HTTP/1.1\r\n" +
+  "Host: www.example.com\r\n" +
+  "Range: bytes={}\r\n".format(range0) +
+  "X-Slicer-Info: full content request\r\n" +
+  "\r\n",
+  "timestamp": "1469733493.993",
+  "body": "",
+}
+
+response_header_crr0 = {"headers":
+  "HTTP/1.1 206 Partial Content\r\n" +
+  "Connection: close\r\n" +
+  "Etag: crr\r\n" +
+  "Content-Range: bytes {}/{}\r\n".format(range0, len(body)) +
+  "Cache-Control: max-age=500\r\n" +
+  "\r\n",
+  "timestamp": "1469733493.993",
+  "body": body0,
+}
+
+server.addResponse("sessionlog.json", request_header_crr0, response_header_crr0)
+
+request_header_crr1 = {"headers":
+  "GET /crr HTTP/1.1\r\n" +
+  "Host: www.example.com\r\n" +
+  "Range: bytes={}\r\n".format(range1) +
+  "X-Slicer-Info: full content request\r\n" +
+  "\r\n",
+  "timestamp": "1469733493.993",
+  "body": "",
+}
+
+response_header_crr1 = {"headers":
+  "HTTP/1.1 206 Partial Content\r\n" +
+  "Connection: close\r\n" +
+  "Etag: crr\r\n" +
+  "Content-Range: bytes {}/{}\r\n".format(range1, len(body) - 1) +
+  "Cache-Control: max-age=500\r\n" +
+  "\r\n",
+  "timestamp": "1469733493.993",
+  "body": body1,
+}
+
+server.addResponse("sessionlog.json", request_header_crr1, response_header_crr1)
+
+ts.Setup.CopyAs('curlsort.sh', Test.RunDirectory)
+curl_and_args = 'sh curlsort.sh -H "Host: www.example.com"'
+
+# set up whole asset fetch into cache
+ts.Disk.remap_config.AddLine(
+  'map / http://127.0.0.1:{}'.format(server.Variables.Port) +
+    ' @plugin=slice.so @pparam=bytesover:{}'.format(blockbytes)
+)
+
+# minimal configuration
+ts.Disk.records_config.update({
+  'proxy.config.diags.debug.enabled': 1,
+  'proxy.config.diags.debug.tags': 'slice',
+  'proxy.config.http.cache.http': 0,
+  'proxy.config.http.wait_for_cache': 0,
+  'proxy.config.http.insert_age_in_response': 0,
+  'proxy.config.http.insert_request_via_str': 0,
+  'proxy.config.http.insert_response_via_str': 3,
+  'proxy.config.http.server_ports': '{}'.format(ts.Variables.port),
+})
+
+# Override builtin error check as these cases will fail
+# taken from the slice plug code
+ts.Disk.diags_log.Content = Testers.ContainsExpression('reason="Mismatch block Etag"', "Mismatch block etag")
+ts.Disk.diags_log.Content += Testers.ContainsExpression('reason="Mismatch block Last-Modified"', "Mismatch block Last-Modified")
+ts.Disk.diags_log.Content += Testers.ContainsExpression('reason="Non 206 internal block response"', "Non 206 internal block response")
+ts.Disk.diags_log.Content += Testers.ContainsExpression('reason="Mismatch/Bad block Content-Range"', "Mismatch/Bad block Content-Range")
+
+# 0 Test - Etag mismatch test
+tr = Test.AddTestRun("Etag test")
+tr.Processes.Default.StartBefore(server)
+tr.Processes.Default.StartBefore(Test.Processes.ts, ready=1)
+tr.Processes.Default.Command = curl_and_args + ' http://127.0.0.1:{}/etag'.format(ts.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = "gold_error/etag.stdout.gold"
+tr.Processes.Default.Streams.stderr = "gold_error/etag.stderr.gold"
+tr.StillRunningAfter = ts
+
+# 1 Check - diags.log message
+tr = Test.AddTestRun("Etag error check")
+tr.Processes.Default.Command = "grep 'Mismatch block Etag' {}".format(ts.Disk.diags_log.Name)
+tr.Processes.Default.ReturnCode = 0
+tr.StillRunningAfter = ts
+
+# 2 Test - Last Modified mismatch test
+tr = Test.AddTestRun("Last-Modified test")
+tr.Processes.Default.Command = curl_and_args + ' http://127.0.0.1:{}/lastmodified'.format(ts.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = "gold_error/lm.stdout.gold"
+tr.Processes.Default.Streams.stderr = "gold_error/lm.stderr.gold"
+tr.StillRunningAfter = ts
+
+# 3 Check - diags.log message
+tr = Test.AddTestRun("Last-Modified error check")
+tr.Processes.Default.Command = "grep 'Mismatch block Last-Modified' {}".format(ts.Disk.diags_log.Name)
+tr.Processes.Default.ReturnCode = 0
+tr.StillRunningAfter = ts
+
+# 4 Test - Non 206 mismatch test
+tr = Test.AddTestRun("Non 206 test")
+tr.Processes.Default.Command = curl_and_args + ' http://127.0.0.1:{}/non206'.format(ts.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = "gold_error/non206.stdout.gold"
+tr.Processes.Default.Streams.stderr = "gold_error/non206.stderr.gold"
+tr.StillRunningAfter = ts
+
+# 3 Check - diags.log message
+tr = Test.AddTestRun("Non 206 error check")
+tr.Processes.Default.Command = "grep 'Non 206 internal block response' {}".format(ts.Disk.diags_log.Name)
+tr.Processes.Default.ReturnCode = 0
+tr.StillRunningAfter = ts
+
+# 4 Test - Block content-range
+tr = Test.AddTestRun("Content-Range test")
+tr.Processes.Default.Command = curl_and_args + ' http://127.0.0.1:{}/crr'.format(ts.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = "gold_error/crr.stdout.gold"
+tr.Processes.Default.Streams.stderr = "gold_error/crr.stderr.gold"
+tr.StillRunningAfter = ts
+
+# 3 Check - diags.log message
+tr = Test.AddTestRun("Content-Range error check")
+tr.Processes.Default.Command = "grep 'Mismatch/Bad block Content-Range' {}".format(ts.Disk.diags_log.Name)
+tr.Processes.Default.ReturnCode = 0
+tr.StillRunningAfter = ts

--- a/tests/gold_tests/pluginTest/slice/slice_error.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice_error.test.py
@@ -245,7 +245,7 @@ curl_and_args = 'sh curlsort.sh -H "Host: www.example.com"'
 # set up whole asset fetch into cache
 ts.Disk.remap_config.AddLine(
   'map / http://127.0.0.1:{}'.format(server.Variables.Port) +
-    ' @plugin=slice.so @pparam=bytesover:{}'.format(blockbytes)
+    ' @plugin=slice.so @pparam=--bytesover={}'.format(blockbytes)
 )
 
 # minimal configuration


### PR DESCRIPTION
Added --disable-errorlog option in case slice block stitching errors start to overrun diags.log.
Also moved slice configuration over to using getopt_long.  Left in backwards compatibility to use bytesover:<bytes> in case someone has already deployed slice with this option.