### PR TITLE
Slice Plugin: add options for disabling or pacing detailed block stitch error logging.

### DIFF
--- a/plugins/experimental/slice/Config.h
+++ b/plugins/experimental/slice/Config.h
@@ -20,21 +20,27 @@
 
 #include "slice.h"
 
-#include <string>
+#include <mutex>
 
 // Data Structures and Classes
 struct Config {
-  static int64_t const blockbytesmin     = 1024 * 256;       // 256KB
-  static int64_t const blockbytesmax     = 1024 * 1024 * 32; // 32MB
-  static int64_t const blockbytesdefault = 1024 * 1024;      // 1MB
-
-  static constexpr char const *const blockbytesstr = "blockbytes";
-  static constexpr char const *const bytesoverstr  = "bytesover";
+  static constexpr int64_t const blockbytesmin     = 1024 * 256;       // 256KB
+  static constexpr int64_t const blockbytesmax     = 1024 * 1024 * 32; // 32MB
+  static constexpr int64_t const blockbytesdefault = 1024 * 1024;      // 1MB
 
   int64_t m_blockbytes{blockbytesdefault};
+  int m_paceerrsecs{0}; // -1 disable logging, 0 no pacing, max 60s
 
-  // Last one wins
-  bool fromArgs(int const argc, char const *const argv[], char *const errbuf, int const errbuf_size);
+  // Convert optarg to bytes
+  static int64_t bytesFrom(char const *const valstr);
 
-  static int64_t bytesFrom(std::string const &valstr);
+  // Parse from args, ast one wins
+  bool fromArgs(int const argc, char const *const argv[]);
+
+  // Check if the error should can be logged, if sucessful may update m_nexttime
+  bool canLogError();
+
+private:
+  TSHRTime m_nextlogtime{0}; // next time to log in ns
+  std::mutex m_mutex;
 };

--- a/plugins/experimental/slice/Data.h
+++ b/plugins/experimental/slice/Data.h
@@ -20,10 +20,10 @@
 
 #include "ts/ts.h"
 
+#include "Config.h"
 #include "HttpHeader.h"
 #include "Range.h"
 #include "Stage.h"
-#include "slice.h"
 
 #include <netinet/in.h>
 
@@ -35,7 +35,8 @@ struct Data {
   Data(Data const &) = delete;
   Data &operator=(Data const &) = delete;
 
-  int64_t const m_blockbytes_config; // configured slice block size
+  Config *const m_config;
+
   sockaddr_storage m_client_ip;
 
   // for pristine url coming in
@@ -76,8 +77,8 @@ struct Data {
 
   TSHttpParser m_http_parser{nullptr}; //!< cached for reuse
 
-  explicit Data(int64_t const blockbytes)
-    : m_blockbytes_config(blockbytes),
+  explicit Data(Config *const config)
+    : m_config(config),
       m_client_ip(),
       m_urlbuffer(nullptr),
       m_urlloc(nullptr),

--- a/plugins/experimental/slice/Makefile.inc
+++ b/plugins/experimental/slice/Makefile.inc
@@ -43,21 +43,21 @@ experimental_slice_slice_la_SOURCES = \
 
 check_PROGRAMS += experimental/slice/test_content_range
 
-experimental_slice_test_content_range_CPPFLAGS = $(AM_CPPFLAGS) -I$(abs_top_srcdir)/tests/include -DSLICE_UNIT_TEST
+experimental_slice_test_content_range_CPPFLAGS = $(AM_CPPFLAGS) -I$(abs_top_srcdir)/tests/include -DUNITTEST
 experimental_slice_test_content_range_SOURCES = \
   experimental/slice/unit-tests/test_content_range.cc \
   experimental/slice/ContentRange.cc
 
 check_PROGRAMS += experimental/slice/test_range
 
-experimental_slice_test_range_CPPFLAGS = $(AM_CPPFLAGS) -I$(abs_top_srcdir)/tests/include -DSLICE_UNIT_TEST
+experimental_slice_test_range_CPPFLAGS = $(AM_CPPFLAGS) -I$(abs_top_srcdir)/tests/include -DUNITTEST
 experimental_slice_test_range_SOURCES = \
   experimental/slice/unit-tests/test_range.cc \
   experimental/slice/Range.cc
 
 check_PROGRAMS += experimental/slice/test_config
 
-experimental_slice_test_config_CPPFLAGS = $(AM_CPPFLAGS) -I$(abs_top_srcdir)/tests/include -DSLICE_UNIT_TEST
+experimental_slice_test_config_CPPFLAGS = $(AM_CPPFLAGS) -I$(abs_top_srcdir)/tests/include -DUNITTEST
 experimental_slice_test_config_SOURCES = \
   experimental/slice/unit-tests/test_config.cc \
   experimental/slice/Config.cc

--- a/plugins/experimental/slice/client.cc
+++ b/plugins/experimental/slice/client.cc
@@ -34,8 +34,8 @@ shutdown(TSCont const contp, Data *const data)
 bool
 requestBlock(TSCont contp, Data *const data)
 {
-  int64_t const blockbeg = (data->m_blockbytes_config * data->m_blocknum);
-  Range blockbe(blockbeg, blockbeg + data->m_blockbytes_config);
+  int64_t const blockbeg = (data->m_config->m_blockbytes * data->m_blocknum);
+  Range blockbe(blockbeg, blockbeg + data->m_config->m_blockbytes);
 
   char rangestr[1024];
   int rangelen      = sizeof(rangestr);
@@ -131,7 +131,7 @@ handle_client_req(TSCont contp, TSEvent event, Data *const data)
         data->m_statustype = TS_HTTP_STATUS_REQUESTED_RANGE_NOT_SATISFIABLE;
 
         // First block will give Content-Length
-        rangebe = Range(0, data->m_blockbytes_config);
+        rangebe = Range(0, data->m_config->m_blockbytes);
       }
     } else {
       DEBUG_LOG("Full content request");
@@ -143,7 +143,7 @@ handle_client_req(TSCont contp, TSEvent event, Data *const data)
     }
 
     // set to the first block in range
-    data->m_blocknum  = rangebe.firstBlockFor(data->m_blockbytes_config);
+    data->m_blocknum  = rangebe.firstBlockFor(data->m_config->m_blockbytes);
     data->m_req_range = rangebe;
 
     // remove ATS keys to avoid 404 loop

--- a/plugins/experimental/slice/slice.cc
+++ b/plugins/experimental/slice/slice.cc
@@ -33,7 +33,7 @@ namespace
 Config globalConfig;
 
 bool
-read_request(TSHttpTxn txnp, Config const *const config)
+read_request(TSHttpTxn txnp, Config *const config)
 {
   DEBUG_LOG("slice read_request");
   TxnHdrMgr hdrmgr;
@@ -55,7 +55,8 @@ read_request(TSHttpTxn txnp, Config const *const config)
         return false;
       }
 
-      Data *const data = new Data(config->m_blockbytes);
+      TSAssert(nullptr != config);
+      Data *const data = new Data(config);
 
       // set up feedback connect
       if (AF_INET == ip->sa_family) {
@@ -150,11 +151,11 @@ TSRemapOSResponse(void *ih, TSHttpTxn rh, int os_response_type)
 
 SLICE_EXPORT
 TSReturnCode
-TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_size)
+TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf */, int /* errbuf_size */)
 {
   Config *const config = new Config;
   if (2 < argc) {
-    config->fromArgs(argc - 2, argv + 2, errbuf, errbuf_size);
+    config->fromArgs(argc - 2, argv + 2);
   }
   *ih = static_cast<void *>(config);
   return TS_SUCCESS;
@@ -195,7 +196,7 @@ TSPluginInit(int argc, char const *argv[])
   }
 
   if (1 < argc) {
-    globalConfig.fromArgs(argc - 1, argv + 1, nullptr, 0);
+    globalConfig.fromArgs(argc - 1, argv + 1);
   }
 
   TSCont const contp(TSContCreate(global_read_request_hook, nullptr));

--- a/plugins/experimental/slice/slice.h
+++ b/plugins/experimental/slice/slice.h
@@ -30,10 +30,9 @@
 #define PLUGIN_NAME "slice"
 #endif
 
-#define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
-
 #if !defined(UNITTEST)
 
+#define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 #define DEBUG_LOG(fmt, ...)                                                      \
   TSDebug(PLUGIN_NAME, "[%s:%04d] %s(): " fmt, __FILENAME__, __LINE__, __func__, \
           ##__VA_ARGS__) /*                                                      \
@@ -48,6 +47,7 @@
   TSDebug(PLUGIN_NAME, "[%s:%04d] %s(): " fmt, __FILENAME__, __LINE__, __func__, ##__VA_ARGS__)
 
 #else
+
 #define DEBUG_LOG(fmt, ...)
 #define ERROR_LOG(fmt, ...)
 

--- a/plugins/experimental/slice/unit-tests/test_config.cc
+++ b/plugins/experimental/slice/unit-tests/test_config.cc
@@ -25,6 +25,8 @@
 #include "../Config.h"
 #include "catch.hpp" /* catch unit-test framework */
 
+#include <array>
+
 TEST_CASE("config default", "[AWS][slice][utility]")
 {
   Config const config;
@@ -34,9 +36,13 @@ TEST_CASE("config default", "[AWS][slice][utility]")
 
 TEST_CASE("config bytesfrom valid parsing", "[AWS][slice][utility]")
 {
-  std::vector<std::string> const teststrings = {"1000", "1m", "5g", "2k", "3kb", "1z"};
+  static std::array<std::string, 6> const teststrings = {
+    "1000", "1m", "5g", "2k", "3kb", "1z",
+  };
 
-  std::vector<int64_t> const expvals = {1000, 1024 * 1024, int64_t(1024) * 1024 * 1024 * 5, 1024 * 2, 1024 * 3, 1};
+  constexpr std::array<int64_t, 6> const expvals = {
+    1000, 1024 * 1024, int64_t(1024) * 1024 * 1024 * 5, 1024 * 2, 1024 * 3, 1,
+  };
 
   for (size_t index = 0; index < teststrings.size(); ++index) {
     std::string const &teststr = teststrings[index];
@@ -52,12 +58,12 @@ TEST_CASE("config bytesfrom valid parsing", "[AWS][slice][utility]")
 
 TEST_CASE("config bytesfrom invalid parsing", "[AWS][slice][utility]")
 {
-  std::vector<std::string> const badstrings = {
-    "abc", // alpha
-    "g00", // giga
-    "M00", // mega
-    "k00", // kilo
-    "-500" // negative
+  static std::array<std::string, 5> const badstrings = {
+    "abc",  // alpha
+    "g00",  // giga
+    "M00",  // mega
+    "k00",  // kilo
+    "-500", // negative
   };
 
   for (std::string const &badstr : badstrings) {

--- a/tests/gold_tests/pluginTest/slice/slice.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice.test.py
@@ -117,7 +117,7 @@ tr = Test.AddTestRun("Load Slice plugin")
 remap_config_path = ts.Disk.remap_config.Name
 tr.Disk.File(remap_config_path, typename="ats:config").AddLines([
   'map / http://127.0.0.1:{}'.format(server.Variables.Port) +
-    ' @plugin=slice.so @pparam=bytesover:{}'.format(block_bytes)
+    ' @plugin=slice.so @pparam=--test-blockbytes={}'.format(block_bytes)
 ])
 
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/pluginTest/slice/slice_error.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice_error.test.py
@@ -245,12 +245,12 @@ curl_and_args = 'sh curlsort.sh -H "Host: www.example.com"'
 # set up whole asset fetch into cache
 ts.Disk.remap_config.AddLine(
   'map / http://127.0.0.1:{}'.format(server.Variables.Port) +
-    ' @plugin=slice.so @pparam=bytesover:{}'.format(blockbytes)
+    ' @plugin=slice.so @pparam=--test-blockbytes={}'.format(blockbytes)
 )
 
 # minimal configuration
 ts.Disk.records_config.update({
-  'proxy.config.diags.debug.enabled': 1,
+  'proxy.config.diags.debug.enabled': 0,
   'proxy.config.diags.debug.tags': 'slice',
   'proxy.config.http.cache.http': 0,
   'proxy.config.http.wait_for_cache': 0,


### PR DESCRIPTION
Switching configuration over to using getopt_long.  Still retains compatibility with blockbytes:[bytes] option.

Added the errorlog features in order to possibly avoid swamping diags.log with block stitching errors in case origins decide to (unwisely) modify assets in place.

Options:

> --blockbytes=[bytes] (or -b [bytes]) (or blockbytes:[bytes] for backwards compat)
> --test-blockbytes=[bytes] (or -t [bytes])
> --pace-errorlog=[seconds] (or -p [seconds])
> --disable-errorlog (or -d)