### PR TITLE
Doc: add prefetch to plugin index page

### DIFF
--- a/doc/admin-guide/plugins/index.en.rst
+++ b/doc/admin-guide/plugins/index.en.rst
@@ -220,6 +220,9 @@ directory of the |TS| source tree. Experimental plugins can be compiled by passi
 :doc:`MySQL Remap <mysql_remap.en>`
    Allows dynamic remaps from a MySQL database.
 
+:doc:`Prefetch <prefetch.en>`
+   Pre-fetch objects based on the requested URL path pattern.
+
 :doc:`Remap Purge <remap_purge.en>`
    This remap plugin allows the administrator to easily setup remotely
    controlled ``PURGE`` for the content of an entire remap rule.


### PR DESCRIPTION
The Prefetch plugin is mentioned in the Table of Content section, but not the body.