### PR TITLE
Removes priorities for AIOs, thanks oknet

### DIFF
--- a/include/tscore/ink_aiocb.h
+++ b/include/tscore/ink_aiocb.h
@@ -46,14 +46,9 @@ struct ink_aiocb {
   void *aio_buf; /* buffer location */
 #endif
   size_t aio_nbytes; /* length of transfer */
+  off_t aio_offset;  /* file offset */
 
-  // TODO change to off_t
-  off_t aio_offset; /* file offset */
-
-  int aio_reqprio; /* request priority offset */
-  //    struct sigevent aio_sigevent;   /* signal number and offset */
   int aio_lio_opcode; /* listio operation */
-  //    aio_result_t    aio_resultp;    /* results */
-  int aio_state;   /* state flag for List I/O */
-  int aio__pad[1]; /* extension padding */
+  int aio_state;      /* state flag for List I/O */
+  int aio__pad[1];    /* extension padding */
 };

--- a/iocore/aio/I_AIO.h
+++ b/iocore/aio/I_AIO.h
@@ -72,7 +72,6 @@ struct ink_aiocb {
   size_t aio_nbytes = 0;       /* length of transfer */
   off_t aio_offset  = 0;       /* file offset */
 
-  int aio_reqprio    = 0; /* request priority offset */
   int aio_lio_opcode = 0; /* listio operation */
   int aio_state      = 0; /* state flag for List I/O */
   int aio__pad[1];        /* extension padding */
@@ -85,9 +84,6 @@ bool ink_aio_thread_num_set(int thread_num);
 // AIOCallback::thread special values
 #define AIO_CALLBACK_THREAD_ANY ((EThread *)0) // any regular event thread
 #define AIO_CALLBACK_THREAD_AIO ((EThread *)-1)
-
-#define AIO_LOWEST_PRIORITY 0
-#define AIO_DEFAULT_PRIORITY AIO_LOWEST_PRIORITY
 
 struct AIOCallback : public Continuation {
   // set before calling aio_read/aio_write

--- a/iocore/aio/P_AIO.h
+++ b/iocore/aio/P_AIO.h
@@ -85,24 +85,19 @@ struct AIOCallbackInternal : public AIOCallback {
 
   int io_complete(int event, void *data);
 
-  AIOCallbackInternal()
-  {
-    aiocb.aio_reqprio = AIO_DEFAULT_PRIORITY;
-    SET_HANDLER(&AIOCallbackInternal::io_complete);
-  }
+  AIOCallbackInternal() { SET_HANDLER(&AIOCallbackInternal::io_complete); }
 };
 
 struct AIO_Reqs {
-  Que(AIOCallback, link) aio_todo;      /* queue for holding non-http requests */
-  Que(AIOCallback, link) http_aio_todo; /* queue for http requests */
-                                        /* Atomic list to temporarily hold the request if the
-                                           lock for a particular queue cannot be acquired */
+  Que(AIOCallback, link) aio_todo; /* queue for AIO operations */
+                                   /* Atomic list to temporarily hold the request if the
+                                      lock for a particular queue cannot be acquired */
   ASLL(AIOCallbackInternal, alink) aio_temp_list;
   ink_mutex aio_mutex;
   ink_cond aio_cond;
   int index           = 0; /* position of this struct in the aio_reqs array */
   int pending         = 0; /* number of outstanding requests on the disk */
-  int queued          = 0; /* total number of aio_todo and http_todo requests */
+  int queued          = 0; /* total number of aio_todo requests */
   int filedes         = 0; /* the file descriptor for the requests */
   int requests_queued = 0;
 };

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -482,24 +482,10 @@ CacheVC::set_pin_in_cache(time_t time_pin)
   return true;
 }
 
-bool
-CacheVC::set_disk_io_priority(int priority)
-{
-  ink_assert(priority >= AIO_LOWEST_PRIORITY);
-  io.aiocb.aio_reqprio = priority;
-  return true;
-}
-
 time_t
 CacheVC::get_pin_in_cache()
 {
   return pin_in_cache;
-}
-
-int
-CacheVC::get_disk_io_priority()
-{
-  return io.aiocb.aio_reqprio;
 }
 
 int

--- a/iocore/cache/CacheDisk.cc
+++ b/iocore/cache/CacheDisk.cc
@@ -61,10 +61,9 @@ CacheDisk::open(char *s, off_t blocks, off_t askip, int ahw_sector_size, int fil
   skip           = askip;
   start          = skip;
   /* we can't use fractions of store blocks. */
-  len                  = blocks;
-  io.aiocb.aio_fildes  = fd;
-  io.aiocb.aio_reqprio = 0;
-  io.action            = this;
+  len                 = blocks;
+  io.aiocb.aio_fildes = fd;
+  io.action           = this;
   // determine header size and hence start point by successive approximation
   uint64_t l;
   for (int i = 0; i < 3; i++) {

--- a/iocore/cache/I_Cache.h
+++ b/iocore/cache/I_Cache.h
@@ -189,12 +189,10 @@ struct CacheVConnection : public VConnection {
   virtual void set_http_info(CacheHTTPInfo *info)  = 0;
   virtual void get_http_info(CacheHTTPInfo **info) = 0;
 
-  virtual bool is_ram_cache_hit() const           = 0;
-  virtual bool set_disk_io_priority(int priority) = 0;
-  virtual int get_disk_io_priority()              = 0;
-  virtual bool set_pin_in_cache(time_t t)         = 0;
-  virtual time_t get_pin_in_cache()               = 0;
-  virtual int64_t get_object_size()               = 0;
+  virtual bool is_ram_cache_hit() const   = 0;
+  virtual bool set_pin_in_cache(time_t t) = 0;
+  virtual time_t get_pin_in_cache()       = 0;
+  virtual int64_t get_object_size()       = 0;
   virtual bool
   is_compressed_in_ram() const
   {

--- a/iocore/cache/P_CacheInternal.h
+++ b/iocore/cache/P_CacheInternal.h
@@ -388,8 +388,6 @@ struct CacheVC : public CacheVConnection {
   bool is_pread_capable() override;
   bool set_pin_in_cache(time_t time_pin) override;
   time_t get_pin_in_cache() override;
-  bool set_disk_io_priority(int priority) override;
-  int get_disk_io_priority() override;
 
 // offsets from the base stat
 #define CACHE_STAT_ACTIVE 0
@@ -585,9 +583,8 @@ free_CacheVC(CacheVC *cont)
   cont->io.action.continuation = nullptr;
   cont->io.action.mutex        = nullptr;
   cont->io.mutex.clear();
-  cont->io.aio_result        = 0;
-  cont->io.aiocb.aio_nbytes  = 0;
-  cont->io.aiocb.aio_reqprio = AIO_DEFAULT_PRIORITY;
+  cont->io.aio_result       = 0;
+  cont->io.aiocb.aio_nbytes = 0;
   cont->request.reset();
   cont->vector.clear();
   cont->vio.buffer.clear();


### PR DESCRIPTION
It also renames the http_aio_todo queue to just aio_todo. This
was all dead code, that could not be triggered.