### PR TITLE
Cppcheck fix for iocore/dns

### DIFF
--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -673,7 +673,7 @@ DNSHandler::try_primary_named(bool reopen)
 void
 DNSHandler::switch_named(int ndx)
 {
-  for (DNSEntry *e = entries.head; e; e = (DNSEntry *)e->link.next) {
+  for (DNSEntry *e = entries.head; e; e = static_cast<DNSEntry *>(e->link.next)) {
     e->written_flag = false;
     if (e->retries < dns_retries) {
       ++(e->retries); // give them another chance
@@ -759,7 +759,7 @@ DNSHandler::rr_failure(int ndx)
     Warning("connection to all DNS servers lost, retrying");
     // actual retries will be done in retry_named called from mainEvent
     // mark any outstanding requests as not sent for later retry
-    for (DNSEntry *e = entries.head; e; e = (DNSEntry *)e->link.next) {
+    for (DNSEntry *e = entries.head; e; e = static_cast<DNSEntry *>(e->link.next)) {
       e->written_flag = false;
       if (e->retries < dns_retries) {
         ++(e->retries); // give them another chance
@@ -769,7 +769,7 @@ DNSHandler::rr_failure(int ndx)
     }
   } else {
     // move outstanding requests that were sent to this nameserver to another
-    for (DNSEntry *e = entries.head; e; e = (DNSEntry *)e->link.next) {
+    for (DNSEntry *e = entries.head; e; e = static_cast<DNSEntry *>(e->link.next)) {
       if (e->which_ns == ndx) {
         e->written_flag = false;
         if (e->retries < dns_retries) {
@@ -795,7 +795,7 @@ DNSHandler::recv_dns(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   DNSConnection *dnsc = nullptr;
   ip_text_buffer ipbuff1, ipbuff2;
   Ptr<HostEnt> buf;
-  while ((dnsc = (DNSConnection *)triggered.dequeue())) {
+  while ((dnsc = static_cast<DNSConnection *>(triggered.dequeue()))) {
     while (true) {
       int res;
       IpEndpoint from_ip;
@@ -967,7 +967,7 @@ DNSHandler::mainEvent(int event, Event *e)
 inline static DNSEntry *
 get_dns(DNSHandler *h, uint16_t id)
 {
-  for (DNSEntry *e = h->entries.head; e; e = (DNSEntry *)e->link.next) {
+  for (DNSEntry *e = h->entries.head; e; e = static_cast<DNSEntry *>(e->link.next)) {
     if (e->once_written_flag) {
       for (int j : e->id) {
         if (j == id) {
@@ -986,7 +986,7 @@ get_dns(DNSHandler *h, uint16_t id)
 inline static DNSEntry *
 get_entry(DNSHandler *h, char *qname, int qtype)
 {
-  for (DNSEntry *e = h->entries.head; e; e = (DNSEntry *)e->link.next) {
+  for (DNSEntry *e = h->entries.head; e; e = static_cast<DNSEntry *>(e->link.next)) {
     if (e->qtype == qtype) {
       if (is_addr_query(qtype)) {
         if (!strcmp(qname, e->qname)) {
@@ -1027,7 +1027,7 @@ write_dns(DNSHandler *h, bool tcp_retry)
   if (h->in_flight < dns_max_dns_in_flight) {
     DNSEntry *e = h->entries.head;
     while (e) {
-      DNSEntry *n = (DNSEntry *)e->link.next;
+      DNSEntry *n = static_cast<DNSEntry *>(e->link.next);
       if (!e->written_flag) {
         if (dns_ns_rr) {
           int ns_start = h->name_server;

--- a/iocore/dns/P_DNSProcessor.h
+++ b/iocore/dns/P_DNSProcessor.h
@@ -66,7 +66,7 @@ extern unsigned int dns_sequence_number;
 #define DNS_SEQUENCE_NUMBER_RESTART_OFFSET 4000
 #define DNS_PRIMARY_RETRY_PERIOD HRTIME_SECONDS(5)
 #define DNS_PRIMARY_REOPEN_PERIOD HRTIME_SECONDS(60)
-#define BAD_DNS_RESULT ((HostEnt *)(uintptr_t)-1)
+#define BAD_DNS_RESULT (reinterpret_cast<HostEnt *>((uintptr_t)-1))
 #define DEFAULT_NUM_TRY_SERVER 8
 
 // these are from nameser.h

--- a/iocore/dns/SplitDNS.cc
+++ b/iocore/dns/SplitDNS.cc
@@ -94,7 +94,7 @@ SplitDNS::~SplitDNS()
 SplitDNS *
 SplitDNSConfig::acquire()
 {
-  return (SplitDNS *)configProcessor.get(SplitDNSConfig::m_id);
+  return static_cast<SplitDNS *>(configProcessor.get(SplitDNSConfig::m_id));
 }
 
 /* --------------------------------------------------------------
@@ -255,7 +255,7 @@ SplitDNS::findServer(RequestData *rdata, SplitDNSResult *result)
       int res = memcmp(pH, pMatch, pxHL[i].match.size());
 
       if ((0 != res && '!' == cNot) || (0 == res && '!' != cNot)) {
-        data_ptr = (SplitDNSRecord *)pxHL[i].opaque_data;
+        data_ptr = static_cast<SplitDNSRecord *>(pxHL[i].opaque_data);
         data_ptr->UpdateMatch(result, rdata);
         break;
       }
@@ -298,9 +298,7 @@ SplitDNSRecord::ProcessDNSHosts(char *val)
 {
   Tokenizer pTok(",; \t\r");
   int numTok;
-  const char *current;
-  int port = 0;
-  char *tmp;
+  int port  = 0;
   int totsz = 0, sz = 0;
 
   numTok = pTok.Initialize(val, SHARE_TOKS);
@@ -317,8 +315,8 @@ SplitDNSRecord::ProcessDNSHosts(char *val)
      set of servers specified
      ------------------------------------------------ */
   for (int i = 0; i < numTok; i++) {
-    current = pTok[i];
-    tmp     = (char *)strchr(current, ':');
+    const char *current = pTok[i];
+    char *tmp           = (char *)strchr(current, ':');
     // coverity[secure_coding]
     if (tmp != nullptr && sscanf(tmp + 1, "%d", &port) != 1) {
       return "Malformed DNS port";
@@ -402,9 +400,8 @@ SplitDNSRecord::ProcessDomainSrchList(char *val)
 {
   Tokenizer pTok(",; \t\r");
   int numTok;
-  int cnt = 0, sz = 0;
+  int sz    = 0;
   char *pSp = nullptr;
-  const char *current;
 
   numTok = pTok.Initialize(val, SHARE_TOKS);
 
@@ -415,8 +412,8 @@ SplitDNSRecord::ProcessDomainSrchList(char *val)
   pSp = &m_servers.x_domain_srch_list[0];
 
   for (int i = 0; i < numTok; i++) {
-    current = pTok[i];
-    cnt     = sz += strlen(current);
+    const char *current = pTok[i];
+    int cnt             = sz += strlen(current);
 
     if (MAXDNAME - 1 < sz) {
       break;
@@ -440,14 +437,11 @@ Result
 SplitDNSRecord::Init(matcher_line *line_info)
 {
   const char *errPtr = nullptr;
-  const char *tmp;
-  char *label;
-  char *val;
 
   this->line_num = line_info->line_num;
   for (int i = 0; i < MATCHER_MAX_TOKENS; i++) {
-    label = line_info->line[0][i];
-    val   = line_info->line[1][i];
+    char *label = line_info->line[0][i];
+    char *val   = line_info->line[1][i];
 
     if (label == nullptr) {
       continue;
@@ -509,7 +503,7 @@ SplitDNSRecord::Init(matcher_line *line_info)
      Process any modifiers to the directive, if they exist
      ----------------------------------------------------- */
   if (line_info->num_el > 0) {
-    tmp = ProcessModifiers(line_info);
+    const char *tmp = ProcessModifiers(line_info);
     if (tmp != nullptr) {
       return Result::failure("%s %s at line %d in splitdns.config", modulePrefix, tmp, line_num);
     }

--- a/iocore/dns/test_I_DNS.cc
+++ b/iocore/dns/test_I_DNS.cc
@@ -26,6 +26,7 @@
 
 #include "diags.i"
 
+int
 main()
 {
   init_diags("net_test", nullptr);

--- a/iocore/dns/test_P_DNS.cc
+++ b/iocore/dns/test_P_DNS.cc
@@ -75,4 +75,7 @@ struct NetTesterSM : public Continuation {
   }
 };
 
-main() {}
+int
+main()
+{
+}


### PR DESCRIPTION
Before
```
Checking iocore/dns/DNS.cc ...
[iocore/dns/DNS.cc:676]: (style) C-style pointer casting
[iocore/dns/DNS.cc:762]: (style) C-style pointer casting
[iocore/dns/DNS.cc:772]: (style) C-style pointer casting
[iocore/dns/DNS.cc:798]: (style) C-style pointer casting
[iocore/dns/DNS.cc:970]: (style) C-style pointer casting
[iocore/dns/DNS.cc:989]: (style) C-style pointer casting
[iocore/dns/DNS.cc:1030]: (style) C-style pointer casting
[iocore/dns/DNS.cc:1300]: (style) C-style pointer casting
Checking iocore/dns/DNS.cc: SPLIT_DNS...
Checking iocore/dns/DNS.cc: TS_HAS_TESTS...
102/791 files checked 12% done
Checking iocore/dns/DNSConnection.cc ...
Checking iocore/dns/DNSConnection.cc: RECV_BUF_SIZE...
[iocore/dns/DNSConnection.cc:189]: (information) Skipping configuration 'RECV_BUF_SIZE' since the value of 'RECV_BUF_SIZE' is unknown. Use -D if you want to check it. You can use -U to skip it explicitly.
103/791 files checked 13% done
Checking iocore/dns/Inline.cc ...
104/791 files checked 13% done
Checking iocore/dns/SplitDNS.cc ...
Checking iocore/dns/SplitDNS.cc: SPLIT_DNS...
[iocore/dns/SplitDNS.cc:97]: (style) C-style pointer casting
[iocore/dns/SplitDNS.cc:258]: (style) C-style pointer casting
[iocore/dns/SplitDNS.cc:301]: (style) The scope of the variable 'current' can be reduced.
[iocore/dns/SplitDNS.cc:405]: (style) The scope of the variable 'cnt' can be reduced.
[iocore/dns/SplitDNS.cc:407]: (style) The scope of the variable 'current' can be reduced.
[iocore/dns/SplitDNS.cc:443]: (style) The scope of the variable 'tmp' can be reduced.
[iocore/dns/SplitDNS.cc:444]: (style) The scope of the variable 'label' can be reduced.
[iocore/dns/SplitDNS.cc:445]: (style) The scope of the variable 'val' can be reduced.
[iocore/dns/SplitDNS.cc:82]: (warning) Member variable 'SplitDNS::m_DNSSrvrTable' is not initialized in the constructor.
105/791 files checked 13% done
Checking iocore/dns/test_I_DNS.cc ...
[iocore/dns/test_I_DNS.cc:29]: (error) syntax error
106/791 files checked 13% done
Checking iocore/dns/test_P_DNS.cc ...
[iocore/dns/test_P_DNS.cc:78]: (error) syntax error
107/791 files checked 13% done
```


After
```
Checking iocore/dns/DNS.cc ...
Checking iocore/dns/DNS.cc: SPLIT_DNS...
Checking iocore/dns/DNS.cc: TS_HAS_TESTS...
1/6 files checked 16% done
Checking iocore/dns/DNSConnection.cc ...
Checking iocore/dns/DNSConnection.cc: RECV_BUF_SIZE...
[iocore/dns/DNSConnection.cc:189]: (information) Skipping configuration 'RECV_BUF_SIZE' since the value of 'RECV_BUF_SIZE' is unknown. Use -D if you want to check it. You can use -U to skip it explicitly.
2/6 files checked 33% done
Checking iocore/dns/Inline.cc ...
3/6 files checked 50% done
Checking iocore/dns/SplitDNS.cc ...
Checking iocore/dns/SplitDNS.cc: SPLIT_DNS...
[iocore/dns/SplitDNS.cc:82]: (warning) Member variable 'SplitDNS::m_DNSSrvrTable' is not initialized in the constructor.
4/6 files checked 66% done
Checking iocore/dns/test_I_DNS.cc ...
5/6 files checked 83% done
Checking iocore/dns/test_P_DNS.cc ...
6/6 files checked 100% done
```