### PR TITLE
cppcheck fixes for iocore/hostdb

### DIFF
--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -240,7 +240,7 @@ bool
 HostDBCache::is_pending_dns_for_hash(const CryptoHash &hash)
 {
   Queue<HostDBContinuation> &q = pending_dns_for_hash(hash);
-  for (HostDBContinuation *c = q.head; c; c = (HostDBContinuation *)c->link.next) {
+  for (HostDBContinuation *c = q.head; c; c = static_cast<HostDBContinuation *>(c->link.next)) {
     if (hash == c->hash.hash) {
       return true;
     }
@@ -1320,7 +1320,7 @@ HostDBContinuation::dnsEvent(int event, HostEnt *e)
     if (is_rr) {
       r->app.rr.offset = offset;
       // This will only be set if is_rr
-      HostDBRoundRobin *rr_data = (HostDBRoundRobin *)(r->rr());
+      HostDBRoundRobin *rr_data = static_cast<HostDBRoundRobin *>(r->rr());
       ;
       if (is_srv()) {
         int skip  = 0;
@@ -1583,7 +1583,7 @@ HostDBContinuation::set_check_pending_dns()
   Queue<HostDBContinuation> &q = hostDB.pending_dns_for_hash(hash.hash);
   this->setThreadAffinity(this_ethread());
   HostDBContinuation *c = q.head;
-  for (; c; c = (HostDBContinuation *)c->link.next) {
+  for (; c; c = static_cast<HostDBContinuation *>(c->link.next)) {
     if (hash.hash == c->hash.hash) {
       Debug("hostdb", "enqueuing additional request");
       q.enqueue(this);
@@ -1602,7 +1602,7 @@ HostDBContinuation::remove_trigger_pending_dns()
   HostDBContinuation *c = q.head;
   Queue<HostDBContinuation> qq;
   while (c) {
-    HostDBContinuation *n = (HostDBContinuation *)c->link.next;
+    HostDBContinuation *n = static_cast<HostDBContinuation *>(c->link.next);
     if (hash.hash == c->hash.hash) {
       Debug("hostdb", "dequeuing additional request");
       q.remove(c);
@@ -1958,7 +1958,7 @@ struct ShowHostDB : public ShowCont {
   int
   showLookupDone(int event, Event *e)
   {
-    HostDBInfo *r = (HostDBInfo *)e;
+    HostDBInfo *r = reinterpret_cast<HostDBInfo *>(e);
 
     CHECK_SHOW(begin("HostDB Lookup"));
     if (name) {

--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -286,7 +286,7 @@ HostDBBackgroundTask::wait_event(int, void *)
 struct HostDBSync : public HostDBBackgroundTask {
   std::string storage_path;
   std::string full_path;
-  HostDBSync(int frequency, std::string storage_path, std::string full_path)
+  HostDBSync(int frequency, const std::string &storage_path, const std::string &full_path)
     : HostDBBackgroundTask(frequency), storage_path(std::move(storage_path)), full_path(std::move(full_path)){};
   int
   sync_event(int, void *) override

--- a/iocore/hostdb/P_HostDBProcessor.h
+++ b/iocore/hostdb/P_HostDBProcessor.h
@@ -306,10 +306,9 @@ HostDBRoundRobin::select_best_http(sockaddr const *client_ip, ink_time_t now, in
     Debug("hostdb", "Using default round robin");
     unsigned int best_hash_any = 0;
     unsigned int best_hash_up  = 0;
-    sockaddr const *ip;
     for (int i = 0; i < good; i++) {
-      ip             = info(i).ip();
-      unsigned int h = HOSTDB_CLIENT_IP_HASH(client_ip, ip);
+      sockaddr const *ip = info(i).ip();
+      unsigned int h     = HOSTDB_CLIENT_IP_HASH(client_ip, ip);
       if (best_hash_any <= h) {
         best_any      = i;
         best_hash_any = h;

--- a/iocore/hostdb/test_I_HostDB.cc
+++ b/iocore/hostdb/test_I_HostDB.cc
@@ -30,6 +30,7 @@ class HostDBTest : Continuation
 {
 };
 
+int
 main()
 {
   init_diags("net_test", nullptr);

--- a/iocore/hostdb/test_P_HostDB.cc
+++ b/iocore/hostdb/test_P_HostDB.cc
@@ -52,6 +52,7 @@ struct NetTesterSM : public Continuation {
       str = new char[r + 10];
       reader->read(str, r);
       printf("%s", str);
+      delete[] str;
       fflush(stdout);
       break;
     case VC_EVENT_READ_COMPLETE:
@@ -61,6 +62,7 @@ struct NetTesterSM : public Continuation {
       str = new char[r + 10];
       reader->read(str, r);
       printf("%s", str);
+      delete[] str;
       fflush(stdout);
     case VC_EVENT_ERROR:
       vc->do_io_close();
@@ -74,4 +76,7 @@ struct NetTesterSM : public Continuation {
   }
 };
 
-main() {}
+int
+main()
+{
+}

--- a/iocore/hostdb/test_RefCountCache.cc
+++ b/iocore/hostdb/test_RefCountCache.cc
@@ -63,7 +63,7 @@ public:
   {
     this->idx = -1;
     items_freed.insert(this);
-    printf("freeing: %p items_freed.size(): %zd\n", this, items_freed.size());
+    printf("freeing: %p items_freed.size(): %zu\n", this, items_freed.size());
   }
 
   static ExampleStruct *


### PR DESCRIPTION
```if(auto a = b; b)``` is counted as a syntax error for cppcheck.