### PR TITLE
cppcheck: Fix various issues of Http2DependencyTree

### DIFF
--- a/proxy/http2/Http2DependencyTree.h
+++ b/proxy/http2/Http2DependencyTree.h
@@ -41,7 +41,7 @@ namespace Http2DependencyTree
 class Node
 {
 public:
-  Node(void *t = nullptr) : t(t)
+  explicit Node(void *t = nullptr) : t(t)
   {
     entry = new PriorityQueueEntry<Node *>(this);
     queue = new PriorityQueue<Node *>();
@@ -71,6 +71,9 @@ public:
     }
   }
 
+  Node(const Node &) = delete;
+  Node &operator=(const Node &) = delete;
+
   LINK(Node, link);
 
   bool
@@ -78,6 +81,7 @@ public:
   {
     return point < n.point;
   }
+
   bool
   operator>(const Node &n) const
   {
@@ -111,7 +115,7 @@ public:
 template <typename T> class Tree
 {
 public:
-  Tree(uint32_t max_concurrent_streams) : _max_depth(MIN(max_concurrent_streams, HTTP2_DEPENDENCY_TREE_MAX_DEPTH))
+  explicit Tree(uint32_t max_concurrent_streams) : _max_depth(MIN(max_concurrent_streams, HTTP2_DEPENDENCY_TREE_MAX_DEPTH))
   {
     _ancestors.resize(_max_ancestors);
   }
@@ -119,7 +123,7 @@ public:
   Node *find(uint32_t id, bool *is_max_leaf = nullptr);
   Node *find_shadow(uint32_t id, bool *is_max_leaf = nullptr);
   Node *add(uint32_t parent_id, uint32_t id, uint32_t weight, bool exclusive, T t, bool shadow = false);
-  Node *reprioritize(uint32_t new_parent_id, uint32_t id, bool exclusive);
+  Node *reprioritize(uint32_t id, uint32_t new_parent_id, bool exclusive);
   Node *reprioritize(Node *node, uint32_t id, bool exclusive);
   Node *top();
   void remove(Node *node);
@@ -143,7 +147,7 @@ private:
   void _dump(Node *node, std::ostream &output) const;
   Node *_find(Node *node, uint32_t id, uint32_t depth = 1, bool *is_max_leaf = nullptr);
   Node *_top(Node *node);
-  void _change_parent(Node *new_parent, Node *node, bool exclusive);
+  void _change_parent(Node *node, Node *new_parent, bool exclusive);
   bool in_parent_chain(Node *maybe_parent, Node *target);
 
   Node *_root = new Node(this);


### PR DESCRIPTION
Fix argument order on declarations

> [Http2DependencyTree.h:122] -> [Http2DependencyTree.h:393]: (warning) Function 'reprioritize' argument order different: declaration 'new_parent_id, id, exclusive' definition 'id, new_parent_id, exclusive'
> [Http2DependencyTree.h:146] -> [Http2DependencyTree.h:454]: (warning) Function '_change_parent' argument order different: declaration 'new_parent, node, exclusive' definition 'node, new_parent, exclusive'

Add explicit specifier
> [Http2DependencyTree.h:44]: (style) Class 'Node' has a constructor with 1 argument that is not explicit.
> [Http2DependencyTree.h:114]: (style) Class 'Tree < Http2Stream * >' has a constructor with 1 argument that is not explicit.

Delete operator= and copy constructor
> [Http2DependencyTree.h:52]: (style) Class 'Node' does not have a operator= which is recommended since it has dynamic memory/resource allocation(s).
> [Http2DependencyTree.h:52]: (style) Class 'Node' does not have a copy constructor which is recommended since it has dynamic memory/resource allocation(s).