### PR TITLE
Doc: fix some default parameter on records.config

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3317,7 +3317,7 @@ SSL Termination
    The filename of the certificate authority that client certificates
    will be verified against.
 
-.. ts:cv:: CONFIG proxy.config.ssl.server.ticket_key.filename STRING ssl_ticket.key
+.. ts:cv:: CONFIG proxy.config.ssl.server.ticket_key.filename STRING NULL
 
    The filename of the default and global ticket key for SSL sessions. The location is relative to the
    :ts:cv:`proxy.config.ssl.server.cert.path` directory. One way to generate this would be to run

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3660,7 +3660,7 @@ HTTP/2 Configuration
    The maximum size of the header compression table used to decode header
    blocks.
 
-.. ts:cv:: CONFIG proxy.config.http2.max_header_list_size INT 4294967295
+.. ts:cv:: CONFIG proxy.config.http2.max_header_list_size INT 131072
    :reloadable:
 
    This advisory setting informs a peer of the maximum size of header list


### PR DESCRIPTION
I noticed that some default parameter on the document is incorrect.  
I corrected it to the correct value referring to the following source code.  

* proxy.config.ssl.server.ticket_key.filename
https://github.com/apache/trafficserver/blob/1e9e4ed3be52dc8ef2433baba6816df4eb032055/mgmt/RecordsConfig.cc#L1131

* proxy.config.http2.max_header_list_size
https://github.com/apache/trafficserver/blob/1e9e4ed3be52dc8ef2433baba6816df4eb032055/mgmt/RecordsConfig.cc#L1322

