### PR TITLE
cppcheck: fixes issue found in proxy/IPAllow.cc

### DIFF
--- a/proxy/IPAllow.cc
+++ b/proxy/IPAllow.cc
@@ -133,10 +133,7 @@ IpAllow::match(sockaddr const *ip, match_key_t key)
 //   End API functions
 //
 
-IpAllow::IpAllow(const char *config_var)
-{
-  config_file_path = RecConfigReadConfigPath(config_var);
-}
+IpAllow::IpAllow(const char *config_var) : config_file_path(RecConfigReadConfigPath(config_var)) {}
 
 void
 IpAllow::PrintMap(IpMap *map)


### PR DESCRIPTION
Variable 'config_file_path' is assigned in constructor body. Consider performing initialization in initialization list.