### PR TITLE
cppcheck: fixes issues found for plugins/authproxy

### DIFF
--- a/plugins/authproxy/utils.h
+++ b/plugins/authproxy/utils.h
@@ -43,9 +43,8 @@ struct HttpIoBuffer {
   TSIOBufferReader reader;
 
   explicit HttpIoBuffer(TSIOBufferSizeIndex size = TS_IOBUFFER_SIZE_INDEX_32K)
+    : buffer(TSIOBufferSizedCreate(size)), reader(TSIOBufferReaderAlloc(buffer))
   {
-    this->buffer = TSIOBufferSizedCreate(size);
-    this->reader = TSIOBufferReaderAlloc(this->buffer);
   }
 
   ~HttpIoBuffer()


### PR DESCRIPTION
* (style) C-style pointer casting
* (style) The scope of the variable X can be reduced.
* (performance) Variable X is assigned in constructor body. Consider performing initialization in initialization list.