### PR TITLE
Off by 1 error in memcpy of redirect url

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -7733,7 +7733,9 @@ HttpSM::redirect_request(const char *arg_redirect_url, const int arg_redirect_le
       // Prepend a slash and parse again.
       char redirect_url_leading_slash[arg_redirect_len + 1];
       redirect_url_leading_slash[0] = '/';
-      memcpy(redirect_url_leading_slash + 1, arg_redirect_url, arg_redirect_len + 1);
+      if (arg_redirect_len > 0) {
+        memcpy(redirect_url_leading_slash + 1, arg_redirect_url, arg_redirect_len);
+      }
       url_nuke_proxy_stuff(redirectUrl.m_url_impl);
       redirectUrl.parse(redirect_url_leading_slash, arg_redirect_len + 1);
     }


### PR DESCRIPTION
This was pointed out by ASAN as a dynamic-stack-buffer-overflow.  Specifically the stack buffer appeared to be 1 long.  So if the original argument length is 0, we should not memcpy.  And the memcpy should only copy over the original argument length, not the argument length + 1.

This triggered almost immediately on a machine in a cluster that is following redirects.  These machines have been less stable that than the other machines that do not follow redirects.  Perhaps this is the reason. 