### PR TITLE
cppcheck: fixes issues in ink_uuid.h

### DIFF
--- a/include/tscore/ink_uuid.h
+++ b/include/tscore/ink_uuid.h
@@ -34,7 +34,7 @@ class ATSUuid
 public:
   // Constructors
   ATSUuid() {}
-  ATSUuid &operator=(const ATSUuid other);
+  ATSUuid &operator=(const ATSUuid &other);
 
   // Initialize the UUID from a string
   bool parseString(const char *str);

--- a/src/tscore/ink_uuid.cc
+++ b/src/tscore/ink_uuid.cc
@@ -52,7 +52,7 @@ ATSUuid::initialize(TSUuidVersion v)
 
 // Copy assignment
 ATSUuid &
-ATSUuid::operator=(const ATSUuid other)
+ATSUuid::operator=(const ATSUuid &other)
 {
   memcpy(_uuid.data, other._uuid.data, sizeof(_uuid.data));
   memcpy(_string, other._string, sizeof(_string));


### PR DESCRIPTION
Function parameter 'other' should be passed by const reference.