### PR TITLE
cppcheck: fixes issues found for plugins/background_fetch

### DIFF
--- a/plugins/background_fetch/configs.cc
+++ b/plugins/background_fetch/configs.cc
@@ -127,9 +127,9 @@ BgFetchConfig::readConfig(const char *config_file)
       char *cfg_type  = strtok_r(buffer, " ", &savePtr);
       char *cfg_name  = nullptr;
       char *cfg_value = nullptr;
-      bool exclude    = false;
 
       if (cfg_type) {
+        bool exclude = false;
         if (!strcmp(cfg_type, "exclude")) {
           exclude = true;
         } else if (strcmp(cfg_type, "include")) {

--- a/plugins/background_fetch/headers.cc
+++ b/plugins/background_fetch/headers.cc
@@ -100,7 +100,6 @@ dump_headers(TSMBuffer bufp, TSMLoc hdr_loc)
   TSIOBuffer output_buffer;
   TSIOBufferReader reader;
   TSIOBufferBlock block;
-  const char *block_start;
   int64_t block_avail;
 
   output_buffer = TSIOBufferCreate();
@@ -112,7 +111,7 @@ dump_headers(TSMBuffer bufp, TSMLoc hdr_loc)
   /* We need to loop over all the buffer blocks, there can be more than 1 */
   block = TSIOBufferReaderStart(reader);
   do {
-    block_start = TSIOBufferBlockReadStart(block, reader, &block_avail);
+    const char *block_start = TSIOBufferBlockReadStart(block, reader, &block_avail);
     if (block_avail > 0) {
       TSDebug(PLUGIN_NAME, "Headers are:\n%.*s", static_cast<int>(block_avail), block_start);
     }


### PR DESCRIPTION
* [plugins/background_fetch/configs.cc:130]: (style) The scope of the variable 'exclude' can be reduced.
* [plugins/background_fetch/headers.cc:103]: (style) The scope of the variable 'block_start' can be reduced.
