### PR TITLE
cppcheck: fixes issues found in example/thread_pool

### DIFF
--- a/example/thread_pool/test/SDKTest/psi_server.c
+++ b/example/thread_pool/test/SDKTest/psi_server.c
@@ -134,9 +134,6 @@ TSResponsePut(void **resp_id /* return */, void *resp_buffer /* return */, int *
 {
   int i            = 0;
   RequestInfo *rid = *((RequestInfo **)resp_id);
-  int psi          = 0;
-  int len;
-  char psi_tag[PSI_TAG_MAX_SIZE];
 
   /* copy the header into the response buffer */
   if (!rid->done_sent_header) {
@@ -163,7 +160,8 @@ TSResponsePut(void **resp_id /* return */, void *resp_buffer /* return */, int *
     else {
       if (rid->psi) {
         /* generate our psi tag: <!--include=fileN.txt--> */
-        len = sprintf(psi_tag, PSI_TAG_FORMAT, rand() % 100);
+        char psi_tag[PSI_TAG_MAX_SIZE];
+        int len = sprintf(psi_tag, PSI_TAG_FORMAT, rand() % 100);
 
         /* hopefully enough space for our include command */
         if (rid->bytes_not_sent >= len) {

--- a/example/thread_pool/thread.c
+++ b/example/thread_pool/thread.c
@@ -48,13 +48,10 @@ init_queue(Queue *q)
 void
 add_to_queue(Queue *q, void *data)
 {
-  Cell *new_cell;
-  int n;
-
   if (data != NULL) {
     TSMutexLock(q->mutex);
     /* Init the new cell */
-    new_cell           = TSmalloc(sizeof(Cell));
+    Cell *new_cell     = TSmalloc(sizeof(Cell));
     new_cell->magic    = MAGIC_ALIVE;
     new_cell->ptr_data = data;
     new_cell->ptr_next = q->tail;
@@ -71,7 +68,7 @@ add_to_queue(Queue *q, void *data)
       q->tail->ptr_prev = new_cell;
       q->tail           = new_cell;
     }
-    n = q->nb_elem++;
+    int n = q->nb_elem++;
     TSMutexUnlock(q->mutex);
 
     if (n > MAX_JOBS_ALARM) {
@@ -157,12 +154,10 @@ thread_init()
 void *
 thread_loop(void *arg ATS_UNUSED)
 {
-  Job *job_todo;
-
   /* Infinite loop */
   for (;;) {
     /* returns a job or NULL if no jobs to do */
-    job_todo = remove_from_queue(&job_queue);
+    Job *job_todo = remove_from_queue(&job_queue);
 
     if (job_todo != NULL) {
       TSAssert(job_todo->magic == MAGIC_ALIVE);


### PR DESCRIPTION
(style) The scope of the variable 'X' can be reduced.
(style) Variable 'psi' is assigned a value that is never used.