### PR TITLE
cppcheck: Remove an unused private function

### DIFF
--- a/iocore/net/P_UDPNet.h
+++ b/iocore/net/P_UDPNet.h
@@ -269,12 +269,6 @@ public:
     }
     return HRTIME_FOREVER;
   }
-
-private:
-  void
-  kill_cancelled_events()
-  {
-  }
 };
 
 class UDPQueue


### PR DESCRIPTION
> [iocore/net/P_UDPNet.h:275]: (style) Unused private function: 'PacketQueue::kill_cancelled_events'