### PR TITLE
Don't assign if this and other are the same object

### DIFF
--- a/src/tscore/ink_uuid.cc
+++ b/src/tscore/ink_uuid.cc
@@ -54,9 +54,11 @@ ATSUuid::initialize(TSUuidVersion v)
 ATSUuid &
 ATSUuid::operator=(const ATSUuid &other)
 {
-  memcpy(_uuid.data, other._uuid.data, sizeof(_uuid.data));
-  memcpy(_string, other._string, sizeof(_string));
-  _version = other._version;
+  if (this != &other) { // Self assignment guard
+    memcpy(_uuid.data, other._uuid.data, sizeof(_uuid.data));
+    memcpy(_string, other._string, sizeof(_string));
+    _version = other._version;
+  }
 
   return *this;
 }


### PR DESCRIPTION
This fixes a clang-analyzer error, where we could otherwise memcpy() on overlapping buffers.