### PR TITLE
cppcheck: Fix issues in P_UDPx.h

### DIFF
--- a/iocore/net/P_UDPNet.h
+++ b/iocore/net/P_UDPNet.h
@@ -61,15 +61,11 @@ extern UDPNetProcessorInternal udpNetInternal;
 class PacketQueue
 {
 public:
-  PacketQueue()
-  {
-    lastPullLongTermQ = 0;
-    init();
-  }
+  PacketQueue() { init(); }
 
   virtual ~PacketQueue() {}
-  int nPackets = 0;
-  ink_hrtime lastPullLongTermQ;
+  int nPackets                 = 0;
+  ink_hrtime lastPullLongTermQ = 0;
   Queue<UDPPacketInternal> longTermQ;
   Queue<UDPPacketInternal> bucket[N_SLOTS];
   ink_hrtime delivery_time[N_SLOTS];

--- a/iocore/net/P_UDPPacket.h
+++ b/iocore/net/P_UDPPacket.h
@@ -189,7 +189,6 @@ new_UDPPacket(struct sockaddr const *to, ink_hrtime when, IOBufferBlock *buf, in
 {
   (void)len;
   UDPPacketInternal *p = udpPacketAllocator.alloc();
-  IOBufferBlock *body;
 
   p->in_the_priority_queue = 0;
   p->in_heap               = 0;
@@ -197,7 +196,7 @@ new_UDPPacket(struct sockaddr const *to, ink_hrtime when, IOBufferBlock *buf, in
   ats_ip_copy(&p->to, to);
 
   while (buf) {
-    body = buf->clone();
+    IOBufferBlock *body = buf->clone();
     p->append_block(body);
     buf = buf->next.get();
   }


### PR DESCRIPTION
> [iocore/net/P_UDPPacket.h:192]: (style) The scope of the variable 'body' can be reduced.
[iocore/net/P_UDPNet.h:66]: (performance) Variable 'lastPullLongTermQ' is assigned in constructor body. Consider performing initialization in initialization list.
