### PR TITLE
cppcheck: fixes issues in example/

### DIFF
--- a/example/blacklist_0/blacklist_0.c
+++ b/example/blacklist_0/blacklist_0.c
@@ -150,7 +150,6 @@ blacklist_plugin(TSCont contp, TSEvent event, void *edata)
 void
 TSPluginInit(int argc, const char *argv[])
 {
-  int i;
   TSPluginRegistrationInfo info;
 
   info.plugin_name   = PLUGIN_NAME;
@@ -165,7 +164,7 @@ TSPluginInit(int argc, const char *argv[])
   if (nsites > 0) {
     sites = (char **)TSmalloc(sizeof(char *) * nsites);
 
-    for (i = 0; i < nsites; i++) {
+    for (int i = 0; i < nsites; i++) {
       sites[i] = TSstrdup(argv[i + 1]);
     }
 

--- a/example/bnull_transform/bnull_transform.c
+++ b/example/bnull_transform/bnull_transform.c
@@ -82,7 +82,6 @@ handle_buffering(TSCont contp, MyData *data)
 {
   TSVIO write_vio;
   int towrite;
-  int avail;
 
   /* Get the write VIO for the write operation that was performed on
      ourself. This VIO contains the buffer that we are to read from
@@ -118,7 +117,7 @@ handle_buffering(TSCont contp, MyData *data)
     /* The amount of data left to read needs to be truncated by
        the amount of data actually in the read buffer. */
 
-    avail = TSIOBufferReaderAvail(TSVIOReaderGet(write_vio));
+    int avail = TSIOBufferReaderAvail(TSVIOReaderGet(write_vio));
     if (towrite > avail) {
       towrite = avail;
     }

--- a/example/cache_scan/cache_scan.cc
+++ b/example/cache_scan/cache_scan.cc
@@ -65,7 +65,6 @@ using cache_scan_state = struct cache_scan_state_t;
 static int
 handle_scan(TSCont contp, TSEvent event, void *edata)
 {
-  TSCacheHttpInfo cache_infop;
   cache_scan_state *cstate = (cache_scan_state *)TSContDataGet(contp);
 
   if (event == TS_EVENT_CACHE_REMOVE) {
@@ -120,19 +119,18 @@ handle_scan(TSCont contp, TSEvent event, void *edata)
     if (cstate->done) {
       return TS_CACHE_SCAN_RESULT_DONE;
     }
-    cache_infop = (TSCacheHttpInfo)edata;
+    TSCacheHttpInfo cache_infop = (TSCacheHttpInfo)edata;
 
     TSMBuffer req_bufp, resp_bufp;
     TSMLoc req_hdr_loc, resp_hdr_loc;
     TSMLoc url_loc;
 
-    char *url;
     int url_len;
     const char s1[] = "URL: ", s2[] = "\n";
     cstate->total_bytes += TSIOBufferWrite(cstate->resp_buffer, s1, sizeof(s1) - 1);
     TSCacheHttpInfoReqGet(cache_infop, &req_bufp, &req_hdr_loc);
     if (TS_SUCCESS == TSHttpHdrUrlGet(req_bufp, req_hdr_loc, &url_loc)) {
-      url = TSUrlStringGet(req_bufp, url_loc, &url_len);
+      char *url = TSUrlStringGet(req_bufp, url_loc, &url_len);
 
       cstate->total_bytes += TSIOBufferWrite(cstate->resp_buffer, url, url_len);
       cstate->total_bytes += TSIOBufferWrite(cstate->resp_buffer, s2, sizeof(s2) - 1);

--- a/example/cppapi/boom/boom.cc
+++ b/example/cppapi/boom/boom.cc
@@ -108,7 +108,7 @@ private:
   std::string current_code_string_;
 
 public:
-  IsRewritableCode(int current_code) : current_code_(current_code)
+  explicit IsRewritableCode(int current_code) : current_code_(current_code)
   {
     std::ostringstream oss;
     oss << current_code_;
@@ -218,12 +218,11 @@ BoomResponseRegistry::populate_error_responses(const std::string &base_directory
   // Filename (sans the .html suffix) becomes the entry to the
   // registry lookup table
   DIR *pDIR = nullptr;
-  struct dirent *entry;
 
   pDIR = opendir(base_error_directory_.c_str());
   if (pDIR != nullptr) {
     while (true) {
-      entry = readdir(pDIR);
+      struct dirent *entry = readdir(pDIR);
       if (entry == nullptr) {
         break;
       }
@@ -382,7 +381,7 @@ private:
   BoomResponseRegistry *response_registry_;
 
 public:
-  BoomGlobalPlugin(BoomResponseRegistry *response_registry) : response_registry_(response_registry)
+  explicit BoomGlobalPlugin(BoomResponseRegistry *response_registry) : response_registry_(response_registry)
   {
     TS_DEBUG(TAG, "Creating BoomGlobalHook %p", this);
     registerHook(HOOK_READ_RESPONSE_HEADERS);

--- a/example/cppapi/custom_error_remap_plugin/CustomErrorRemapPlugin.cc
+++ b/example/cppapi/custom_error_remap_plugin/CustomErrorRemapPlugin.cc
@@ -31,7 +31,8 @@ RemapPlugin *plugin;
 class MyRemapPlugin : public RemapPlugin
 {
 public:
-  MyRemapPlugin(void **instance_handle) : RemapPlugin(instance_handle) {}
+  explicit MyRemapPlugin(void **instance_handle) : RemapPlugin(instance_handle) {}
+
   Result
   doRemap(const Url &map_from_url, const Url &map_to_url, Transaction &transaction, bool &redirect) override
   {

--- a/example/cppapi/gzip_transformation/GzipTransformationPlugin.cc
+++ b/example/cppapi/gzip_transformation/GzipTransformationPlugin.cc
@@ -89,7 +89,7 @@ public:
 class SomeTransformationPlugin : public TransformationPlugin
 {
 public:
-  SomeTransformationPlugin(Transaction &transaction)
+  explicit SomeTransformationPlugin(Transaction &transaction)
     : TransformationPlugin(transaction, RESPONSE_TRANSFORMATION), transaction_(transaction)
   {
     registerHook(HOOK_SEND_RESPONSE_HEADERS);

--- a/example/cppapi/intercept/intercept.cc
+++ b/example/cppapi/intercept/intercept.cc
@@ -35,7 +35,7 @@ GlobalPlugin *plugin;
 class Intercept : public InterceptPlugin
 {
 public:
-  Intercept(Transaction &transaction) : InterceptPlugin(transaction, InterceptPlugin::SERVER_INTERCEPT) {}
+  explicit Intercept(Transaction &transaction) : InterceptPlugin(transaction, InterceptPlugin::SERVER_INTERCEPT) {}
   void consume(const string &data, InterceptPlugin::RequestDataType type) override;
   void handleInputComplete() override;
   ~Intercept() override { cout << "Shutting down" << endl; }

--- a/example/cppapi/multiple_transaction_hooks/MultipleTransactionHookPlugins.cc
+++ b/example/cppapi/multiple_transaction_hooks/MultipleTransactionHookPlugins.cc
@@ -31,7 +31,7 @@ GlobalPlugin *plugin;
 class MultipleTransactionHookPluginsOne : public atscppapi::TransactionPlugin
 {
 public:
-  MultipleTransactionHookPluginsOne(Transaction &transaction) : TransactionPlugin(transaction)
+  explicit MultipleTransactionHookPluginsOne(Transaction &transaction) : TransactionPlugin(transaction)
   {
     TransactionPlugin::registerHook(HOOK_SEND_RESPONSE_HEADERS);
     std::cout << "Constructed MultipleTransactionHookPluginsOne!" << std::endl;
@@ -49,7 +49,7 @@ public:
 class MultipleTransactionHookPluginsTwo : public atscppapi::TransactionPlugin
 {
 public:
-  MultipleTransactionHookPluginsTwo(Transaction &transaction) : TransactionPlugin(transaction)
+  explicit MultipleTransactionHookPluginsTwo(Transaction &transaction) : TransactionPlugin(transaction)
   {
     TransactionPlugin::registerHook(HOOK_SEND_REQUEST_HEADERS);
     TransactionPlugin::registerHook(HOOK_SEND_RESPONSE_HEADERS);

--- a/example/cppapi/post_buffer/PostBuffer.cc
+++ b/example/cppapi/post_buffer/PostBuffer.cc
@@ -36,7 +36,7 @@ GlobalPlugin *plugin;
 class PostBufferTransformationPlugin : public TransformationPlugin
 {
 public:
-  PostBufferTransformationPlugin(Transaction &transaction)
+  explicit PostBufferTransformationPlugin(Transaction &transaction)
     : TransformationPlugin(transaction, REQUEST_TRANSFORMATION), transaction_(transaction)
   {
     buffer_.reserve(1024); // not required, this is an optimization to start the buffer at a slightly higher value.

--- a/example/cppapi/remap_plugin/RemapPlugin.cc
+++ b/example/cppapi/remap_plugin/RemapPlugin.cc
@@ -36,7 +36,8 @@ RemapPlugin *plugin;
 class MyRemapPlugin : public RemapPlugin
 {
 public:
-  MyRemapPlugin(void **instance_handle) : RemapPlugin(instance_handle) {}
+  explicit MyRemapPlugin(void **instance_handle) : RemapPlugin(instance_handle) {}
+
   Result
   doRemap(const Url &map_from_url, const Url &map_to_url, Transaction &transaction, bool &redirect) override
   {

--- a/example/cppapi/transactionhook/TransactionHookPlugin.cc
+++ b/example/cppapi/transactionhook/TransactionHookPlugin.cc
@@ -31,12 +31,13 @@ GlobalPlugin *plugin;
 class TransactionHookPlugin : public atscppapi::TransactionPlugin
 {
 public:
-  TransactionHookPlugin(Transaction &transaction) : TransactionPlugin(transaction)
+  explicit TransactionHookPlugin(Transaction &transaction) : TransactionPlugin(transaction)
   {
     char_ptr_ = new char[100];
     TransactionPlugin::registerHook(HOOK_SEND_RESPONSE_HEADERS);
     std::cout << "Constructed!" << std::endl;
   }
+
   ~TransactionHookPlugin() override
   {
     delete[] char_ptr_; // cleanup

--- a/example/cppapi/websocket/WebSocket.h
+++ b/example/cppapi/websocket/WebSocket.h
@@ -40,7 +40,7 @@ using atscppapi::GlobalPlugin;
 class WebSocket : public InterceptPlugin
 {
 public:
-  WebSocket(Transaction &transaction);
+  explicit WebSocket(Transaction &transaction);
   ~WebSocket() override;
 
   void consume(const std::string &data, InterceptPlugin::RequestDataType type) override;

--- a/example/file_1/file_1.c
+++ b/example/file_1/file_1.c
@@ -41,7 +41,6 @@
 void
 TSPluginInit(int argc, const char *argv[])
 {
-  TSFile filep;
   char buf[4096];
   int i;
   TSPluginRegistrationInfo info;
@@ -55,7 +54,7 @@ TSPluginInit(int argc, const char *argv[])
   }
 
   for (i = 1; i < argc; i++) {
-    filep = TSfopen(argv[i], "r");
+    TSFile filep = TSfopen(argv[i], "r");
     if (!filep) {
       continue;
     }

--- a/example/null_transform/null_transform.c
+++ b/example/null_transform/null_transform.c
@@ -67,7 +67,6 @@ handle_transform(TSCont contp)
   TSVIO input_vio;
   MyData *data;
   int64_t towrite;
-  int64_t avail;
 
   TSDebug(PLUGIN_NAME, "Entering handle_transform()");
   /* Get the output (downstream) vconnection where we'll write data to. */
@@ -126,7 +125,7 @@ handle_transform(TSCont contp)
     /* The amount of data left to read needs to be truncated by
      * the amount of data actually in the read buffer.
      */
-    avail = TSIOBufferReaderAvail(TSVIOReaderGet(input_vio));
+    int64_t avail = TSIOBufferReaderAvail(TSVIOReaderGet(input_vio));
     TSDebug(PLUGIN_NAME, "\tavail is %" PRId64 "", avail);
     if (towrite > avail) {
       towrite = avail;

--- a/example/passthru/passthru.cc
+++ b/example/passthru/passthru.cc
@@ -182,7 +182,7 @@ static int
 PassthruSessionEvent(TSCont cont, TSEvent event, void *edata)
 {
   EventArgument arg(edata);
-  PassthruSession *sp = (PassthruSession *)TSContDataGet(cont);
+  PassthruSession *sp = static_cast<PassthruSession *>(TSContDataGet(cont));
 
   PassthruSessionDebug(sp, "session event on vconn=%p event=%d (%s)", TSVIOVConnGet(arg.vio), event, TSHttpEventNameLookup(event));
 

--- a/example/query_remap/query_remap.c
+++ b/example/query_remap/query_remap.c
@@ -91,7 +91,6 @@ void
 TSRemapDeleteInstance(void *ih)
 {
   /* Release instance memory allocated in TSRemapNewInstance */
-  int i;
   TSDebug(PLUGIN_NAME, "deleting instance %p", ih);
 
   if (ih) {
@@ -100,7 +99,7 @@ TSRemapDeleteInstance(void *ih)
       TSfree(qri->param_name);
     }
     if (qri->hosts) {
-      for (i = 0; i < qri->num_hosts; ++i) {
+      for (int i = 0; i < qri->num_hosts; ++i) {
         TSfree(qri->hosts[i]);
       }
       TSfree(qri->hosts);
@@ -112,7 +111,6 @@ TSRemapDeleteInstance(void *ih)
 TSRemapStatus
 TSRemapDoRemap(void *ih, TSHttpTxn rh ATS_UNUSED, TSRemapRequestInfo *rri)
 {
-  int hostidx           = -1;
   query_remap_info *qri = (query_remap_info *)ih;
 
   if (!qri || !rri) {
@@ -125,7 +123,8 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh ATS_UNUSED, TSRemapRequestInfo *rri)
 
   if (req_query && req_query_len > 0) {
     char *q, *key;
-    char *s = NULL;
+    char *s     = NULL;
+    int hostidx = -1;
 
     /* make a copy of the query, as it is read only */
     q = (char *)TSstrndup(req_query, req_query_len + 1);

--- a/example/redirect_1/redirect_1.c
+++ b/example/redirect_1/redirect_1.c
@@ -246,7 +246,6 @@ update_redirected_method_stats(TSMBuffer bufp, TSMLoc hdr_loc)
 {
   const char *txn_method;
   int length;
-  int64_t tempint;
 
   txn_method = TSHttpHdrMethodGet(bufp, hdr_loc, &length);
 
@@ -264,7 +263,7 @@ update_redirected_method_stats(TSMBuffer bufp, TSMLoc hdr_loc)
     } else if (0 == strncmp(txn_method, TS_HTTP_METHOD_OPTIONS, length)) {
       // This is a bad idea in a real plugin because it causes a race condition
       // with other transactions, but is here for illustrative purposes.
-      tempint = TSStatIntGet(redirect_count_options);
+      int64_t tempint = TSStatIntGet(redirect_count_options);
       ++tempint;
       TSStatIntSet(redirect_count_options, tempint);
     } else if (0 == strncmp(txn_method, TS_HTTP_METHOD_POST, length)) {
@@ -289,7 +288,6 @@ void
 TSPluginInit(int argc, const char *argv[])
 {
   const char prefix[] = "http://";
-  int uri_len;
   TSPluginRegistrationInfo info;
 
   info.plugin_name   = PLUGIN_NAME;
@@ -308,7 +306,7 @@ TSPluginInit(int argc, const char *argv[])
      */
 
     url_redirect = TSstrdup(argv[2]);
-    uri_len      = strlen(prefix) + strlen(url_redirect) + 1;
+    int uri_len  = strlen(prefix) + strlen(url_redirect) + 1;
     uri_redirect = TSmalloc(uri_len);
     TSstrlcpy(uri_redirect, prefix, uri_len);
     TSstrlcat(uri_redirect, url_redirect, uri_len);

--- a/example/remap_header_add/remap_header_add.cc
+++ b/example/remap_header_add/remap_header_add.cc
@@ -98,7 +98,7 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char *, int)
 
   // print all arguments for this particular remapping
 
-  rl       = (remap_line *)TSmalloc(sizeof(remap_line));
+  rl       = static_cast<remap_line *>(TSmalloc(sizeof(remap_line)));
   rl->argc = argc;
   rl->argv = argv;
   rl->nvc  = argc - 2; // the first two are the remap from and to

--- a/example/response_header_1/response_header_1.c
+++ b/example/response_header_1/response_header_1.c
@@ -68,7 +68,6 @@ modify_header(TSHttpTxn txnp)
   TSHttpStatus resp_status;
   TSMLoc new_field_loc;
   TSMLoc cached_field_loc;
-  time_t recvd_time;
 
   const char *chkptr;
   int chklength;
@@ -114,7 +113,8 @@ modify_header(TSHttpTxn txnp)
     TSDebug(PLUGIN_NAME, "Created new resp field with loc %p", new_field_loc);
     TSMimeHdrFieldAppend(resp_bufp, resp_loc, new_field_loc);
     TSMimeHdrFieldNameSet(resp_bufp, resp_loc, new_field_loc, mimehdr2_name, strlen(mimehdr2_name));
-    recvd_time = time(NULL);
+
+    time_t recvd_time = time(NULL);
     TSMimeHdrFieldValueDateInsert(resp_bufp, resp_loc, new_field_loc, recvd_time);
 
     TSHandleMLocRelease(resp_bufp, resp_loc, new_field_loc);

--- a/example/secure_link/secure_link.c
+++ b/example/secure_link/secure_link.c
@@ -151,7 +151,6 @@ TSReturnCode
 TSRemapNewInstance(int argc, char **argv, void **ih, char *errbuf, int errbuf_size)
 {
   int i;
-  char *ptr;
   secure_link_info *sli;
 
   // squash unused variable warnings ...
@@ -163,6 +162,7 @@ TSRemapNewInstance(int argc, char **argv, void **ih, char *errbuf, int errbuf_si
   sli->strict = 0;
 
   for (i = 2; i < argc; i++) {
+    char *ptr;
     if ((ptr = strchr(argv[i], ':')) != NULL) {
       *ptr++ = '\0';
       if (strcmp(argv[i], "secret") == 0) {

--- a/example/server_push/server_push.c
+++ b/example/server_push/server_push.c
@@ -47,16 +47,16 @@ bool
 should_push(TSHttpTxn txnp)
 {
   TSMBuffer mbuf;
-  TSMLoc hdr, url;
+  TSMLoc hdr, in_url;
   if (TSHttpTxnClientReqGet(txnp, &mbuf, &hdr) != TS_SUCCESS) {
     return false;
   }
-  if (TSHttpHdrUrlGet(mbuf, hdr, &url) != TS_SUCCESS) {
+  if (TSHttpHdrUrlGet(mbuf, hdr, &in_url) != TS_SUCCESS) {
     return false;
   }
   int len;
-  TSUrlHttpQueryGet(mbuf, url, &len);
-  TSHandleMLocRelease(mbuf, hdr, url);
+  TSUrlHttpQueryGet(mbuf, in_url, &len);
+  TSHandleMLocRelease(mbuf, hdr, in_url);
   TSHandleMLocRelease(mbuf, TS_NULL_MLOC, hdr);
   if (len > 0) {
     return true;

--- a/example/server_transform/server_transform.c
+++ b/example/server_transform/server_transform.c
@@ -285,7 +285,6 @@ transform_buffer_event(TSCont contp, TransformData *data, TSEvent event ATS_UNUS
 {
   TSVIO write_vio;
   int towrite;
-  int avail;
 
   if (!data->input_buf) {
     data->input_buf    = TSIOBufferCreate();
@@ -314,7 +313,7 @@ transform_buffer_event(TSCont contp, TransformData *data, TSEvent event ATS_UNUS
   if (towrite > 0) {
     /* The amount of data left to read needs to be truncated by
        the amount of data actually in the read buffer. */
-    avail = TSIOBufferReaderAvail(TSVIOReaderGet(write_vio));
+    int avail = TSIOBufferReaderAvail(TSVIOReaderGet(write_vio));
     if (towrite > avail) {
       towrite = avail;
     }
@@ -404,18 +403,16 @@ transform_read_status_event(TSCont contp, TransformData *data, TSEvent event, vo
     return transform_bypass(contp, data);
   case TS_EVENT_VCONN_READ_COMPLETE:
     if (TSIOBufferReaderAvail(data->output_reader) == sizeof(int)) {
-      TSIOBufferBlock blk;
-      char *buf;
       void *buf_ptr;
       int64_t avail;
       int64_t read_nbytes = sizeof(int);
-      int64_t read_ndone  = 0;
 
       buf_ptr = &data->content_length;
       while (read_nbytes > 0) {
-        blk        = TSIOBufferReaderStart(data->output_reader);
-        buf        = (char *)TSIOBufferBlockReadStart(blk, data->output_reader, &avail);
-        read_ndone = (avail >= read_nbytes) ? read_nbytes : avail;
+        TSIOBufferBlock blk = TSIOBufferReaderStart(data->output_reader);
+        char *buf           = (char *)TSIOBufferBlockReadStart(blk, data->output_reader, &avail);
+        int64_t read_ndone  = (avail >= read_nbytes) ? read_nbytes : avail;
+
         memcpy(buf_ptr, buf, read_ndone);
         if (read_ndone > 0) {
           TSIOBufferReaderConsume(data->output_reader, read_ndone);


### PR DESCRIPTION
 Assert statement calls a function which may have desired side effects: 'getDispatchController'.
 Assert statement calls a function which may have desired side effects: 'isAlive'.
 C-style pointer casting
 Class 'X' has a constructor with 1 argument that is not explicit.
 Local variable url shadows outer variable
 The scope of the variable 'X' can be reduced.
 Variable 'X' is assigned a value that is never used.