### PR TITLE
cppcheck:  fix comparison issues found in plugins

### DIFF
--- a/plugins/experimental/acme/acme.c
+++ b/plugins/experimental/acme/acme.c
@@ -208,7 +208,7 @@ acme_process_write(TSCont contp, TSEvent event, AcmeState *my_state)
 
     TSVIONBytesSet(my_state->write_vio, my_state->output_bytes);
     TSVIOReenable(my_state->write_vio);
-  } else if (TS_EVENT_VCONN_WRITE_COMPLETE) {
+  } else if (event == TS_EVENT_VCONN_WRITE_COMPLETE) {
     cleanup(contp, my_state);
   } else if (event == TS_EVENT_ERROR) {
     TSError("[%s] acme_process_write: Received TS_EVENT_ERROR", PLUGIN_NAME);

--- a/plugins/healthchecks/healthchecks.c
+++ b/plugins/healthchecks/healthchecks.c
@@ -458,7 +458,7 @@ hc_process_write(TSCont contp, TSEvent event, HCState *my_state)
     }
     TSVIONBytesSet(my_state->write_vio, my_state->output_bytes);
     TSVIOReenable(my_state->write_vio);
-  } else if (TS_EVENT_VCONN_WRITE_COMPLETE) {
+  } else if (event == TS_EVENT_VCONN_WRITE_COMPLETE) {
     cleanup(contp, my_state);
   } else if (event == TS_EVENT_ERROR) {
     TSError("[healthchecks] hc_process_write: Received TS_EVENT_ERROR");

--- a/plugins/stats_over_http/stats_over_http.c
+++ b/plugins/stats_over_http/stats_over_http.c
@@ -205,7 +205,7 @@ stats_process_write(TSCont contp, TSEvent event, stats_state *my_state)
       TSVIONBytesSet(my_state->write_vio, my_state->output_bytes);
     }
     TSVIOReenable(my_state->write_vio);
-  } else if (TS_EVENT_VCONN_WRITE_COMPLETE) {
+  } else if (event == TS_EVENT_VCONN_WRITE_COMPLETE) {
     stats_cleanup(contp, my_state);
   } else if (event == TS_EVENT_ERROR) {
     TSError("[%s] stats_process_write: Received TS_EVENT_ERROR", PLUGIN_NAME);


### PR DESCRIPTION
(style) Condition 'TS_EVENT_VCONN_WRITE_COMPLETE' is always true