### PR TITLE
Change handling 400/500 responses with no body and no Content-length/Transfer Encoding

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -6850,6 +6850,7 @@ HttpTransact::handle_response_keep_alive_headers(State *s, HTTPVersion ver, HTTP
          (s->state_machine->plugin_tag && (!strncmp(s->state_machine->plugin_tag, "http/2", 6)))) &&
         // if we're not sending a body, don't set a chunked header regardless of server response
         !is_response_body_precluded(s->hdr_info.client_response.status_get(), s->method) &&
+        !is_response_body_not_required(s->hdr_info.client_response.status_get()) &&
         // we do not need chunked encoding for internal error messages
         // that are sent to the client if the server response is not valid.
         (((s->source == SOURCE_HTTP_ORIGIN_SERVER || s->source == SOURCE_TRANSFORM) && s->hdr_info.server_response.valid() &&

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -1105,6 +1105,12 @@ is_response_body_precluded(HTTPStatus status_code)
 }
 
 inline bool
+is_response_body_not_required(HTTPStatus status_code)
+{
+  return is_response_body_precluded(status_code) || (status_code >= 400);
+}
+
+inline bool
 is_response_body_precluded(HTTPStatus status_code, int method)
 {
   if ((method == HTTP_WKSIDX_HEAD) || (method == HTTP_WKSIDX_CONNECT) || is_response_body_precluded(status_code)) {


### PR DESCRIPTION
We ran into this while replaying a production captured transaction through a Traffic Server in the lab.

1. Client sends a GET request.  
2. ATS relays that request to origin
3. Origin returns  "HTTP/1.1 404" with no body, no Content-length header and no Transfer-Encoding header.  It does send "Connection: keep-alive" header.
4. ATS inserts "Transfer-Encoding: chunked" header before sending response onto client.
5. ATS waits to read data from origin.  Client waits to read data from ATS.  Origin does not close the connection.
6. Timeout happens and connections are closed 30 seconds later.

ATS seems to be inserting the Transfer-Encoding to correctly deal with  keep-alive logic to client.  Perhaps that makes the most sense for 200 responses?  My reading of the spec https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.4  seems to indicate that if the response has no content-length or transfer-encoding it may be reasonable to assume there is no body.  But of course reading a spec is like reading tea-leaves so hard telling what "should" happen.

I would appreciate any insights folks might have.  I am posting my hacky solution that stopped the replay case from stalling.

I will post the replay data in a bit once I cleanse out sensitive headers.