### PR TITLE
ssl_session_resuse:  operator for redis endpoint compare functor must be const

### DIFF
--- a/plugins/experimental/ssl_session_reuse/src/redis_endpoint.h
+++ b/plugins/experimental/ssl_session_reuse/src/redis_endpoint.h
@@ -38,7 +38,7 @@ typedef struct redis_endpoint {
 
 typedef struct redis_endpoint_compare {
   bool
-  operator()(const RedisEndpoint &lhs, const RedisEndpoint &rhs)
+  operator()(const RedisEndpoint &lhs, const RedisEndpoint &rhs) const
   {
     return lhs.m_hostname < rhs.m_hostname || (lhs.m_hostname == rhs.m_hostname && lhs.m_port < rhs.m_port);
   }


### PR DESCRIPTION
for STL compatibility.