### PR TITLE
cache_promote plugin:  put a mutex-protected critical section into a Continuation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ src/tscore/test_geometry
 src/tscore/test_Regex
 src/tscore/test_X509HostnameValidator
 src/tscore/test_tscore
+src/tscpp/api/test_tscppapi
 src/tscpp/util/test_tscpputil
 lib/records/test_librecords
 lib/perl/lib/Apache/TS.pm

--- a/example/cppapi/delay_transformation_plugin/DelayTransformationPlugin.cc
+++ b/example/cppapi/delay_transformation_plugin/DelayTransformationPlugin.cc
@@ -75,7 +75,7 @@ public:
     pause();
 
     TS_DEBUG(TAG, "Resuming in 2ms...");
-    resumeCont().schedule(2, TS_THREAD_POOL_NET);
+    resumeCont().schedule(2);
   }
 
   void

--- a/plugins/cache_promote/cache_promote.cc
+++ b/plugins/cache_promote/cache_promote.cc
@@ -31,6 +31,9 @@
 #include "ts/ts.h"
 #include "ts/remap.h"
 #include "tscore/ink_config.h"
+#include "tscpp/api/Continuation.h"
+
+using atscppapi::ContinueInMemberFunc;
 
 #define MINIMUM_BUCKET_SIZE 10
 
@@ -101,13 +104,29 @@ public:
   }
 
   // These are pure virtual
-  virtual bool doPromote(TSHttpTxn txnp) = 0;
+
+  // Overrides must reenable transaction, and call cache_turned_off() or cache_left_on().
+  virtual void doPromote(TSHttpTxn txnp) = 0;
+
   virtual const char *policyName() const = 0;
   virtual void usage() const             = 0;
 
 private:
   float _sample = 0.0;
 };
+
+void
+cache_turned_off(TSHttpTxn txnp)
+{
+  TSDebug(PLUGIN_NAME, "turning off the cache (not promoted)");
+  TSHttpTxnServerRespNoStoreSet(txnp, 1);
+}
+
+void
+cache_left_on()
+{
+  TSDebug(PLUGIN_NAME, "leaving cache on (promoted)");
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 // This is the simplest of all policies, just give each request a (small)
@@ -116,10 +135,15 @@ private:
 class ChancePolicy : public PromotionPolicy
 {
 public:
-  bool doPromote(TSHttpTxn /* txnp ATS_UNUSED */) override
+  void
+  doPromote(TSHttpTxn txnp) override
   {
     TSDebug(PLUGIN_NAME, "ChancePolicy::doPromote(%f)", getSample());
-    return true;
+
+    cache_left_on();
+
+    // Reenable and continue with the state machine.
+    TSHttpTxnReenable(txnp, TS_EVENT_HTTP_CONTINUE);
   }
 
   void
@@ -195,7 +219,7 @@ static LRUEntry NULL_LRU_ENTRY; // Used to create an "empty" new LRUEntry
 class LRUPolicy : public PromotionPolicy
 {
 public:
-  LRUPolicy() : PromotionPolicy(), _lock(TSMutexCreate()) {}
+  LRUPolicy() : PromotionPolicy() {}
   ~LRUPolicy() override
   {
     TSDebug(PLUGIN_NAME, "deleting LRUPolicy object");
@@ -238,85 +262,10 @@ public:
     return true;
   }
 
-  bool
+  void
   doPromote(TSHttpTxn txnp) override
   {
-    LRUHash hash;
-    LRUMap::iterator map_it;
-    char *url   = nullptr;
-    int url_len = 0;
-    bool ret    = false;
-    TSMBuffer request;
-    TSMLoc req_hdr;
-
-    if (TS_SUCCESS == TSHttpTxnClientReqGet(txnp, &request, &req_hdr)) {
-      TSMLoc c_url = TS_NULL_MLOC;
-
-      // Get the cache key URL (for now), since this has better lookup behavior when using
-      // e.g. the cachekey plugin.
-      if (TS_SUCCESS == TSUrlCreate(request, &c_url)) {
-        if (TS_SUCCESS == TSHttpTxnCacheLookupUrlGet(txnp, request, c_url)) {
-          url = TSUrlStringGet(request, c_url, &url_len);
-          TSHandleMLocRelease(request, TS_NULL_MLOC, c_url);
-        }
-      }
-      TSHandleMLocRelease(request, TS_NULL_MLOC, req_hdr);
-    }
-
-    // Generally shouldn't happen ...
-    if (!url) {
-      return false;
-    }
-
-    TSDebug(PLUGIN_NAME, "LRUPolicy::doPromote(%.*s%s)", url_len > 100 ? 100 : url_len, url, url_len > 100 ? "..." : "");
-    hash.init(url, url_len);
-    TSfree(url);
-
-    // We have to hold the lock across all list and hash access / updates
-    TSMutexLock(_lock);
-
-    map_it = _map.find(&hash);
-    if (_map.end() != map_it) {
-      // We have an entry in the LRU
-      TSAssert(_list_size > 0); // mismatch in the LRUs hash and list, shouldn't happen
-      if (++(map_it->second->second) >= _hits) {
-        // Promoted! Cleanup the LRU, and signal success. Save the promoted entry on the freelist.
-        TSDebug(PLUGIN_NAME, "saving the LRUEntry to the freelist");
-        _freelist.splice(_freelist.begin(), _list, map_it->second);
-        ++_freelist_size;
-        --_list_size;
-        _map.erase(map_it->first);
-        ret = true;
-      } else {
-        // It's still not promoted, make sure it's moved to the front of the list
-        TSDebug(PLUGIN_NAME, "still not promoted, got %d hits so far", map_it->second->second);
-        _list.splice(_list.begin(), _list, map_it->second);
-      }
-    } else {
-      // New LRU entry for the URL, try to repurpose the list entry as much as possible
-      if (_list_size >= _buckets) {
-        TSDebug(PLUGIN_NAME, "repurposing last LRUHash entry");
-        _list.splice(_list.begin(), _list, --_list.end());
-        _map.erase(&(_list.begin()->first));
-      } else if (_freelist_size > 0) {
-        TSDebug(PLUGIN_NAME, "reusing LRUEntry from freelist");
-        _list.splice(_list.begin(), _freelist, _freelist.begin());
-        --_freelist_size;
-        ++_list_size;
-      } else {
-        TSDebug(PLUGIN_NAME, "creating new LRUEntry");
-        _list.push_front(NULL_LRU_ENTRY);
-        ++_list_size;
-      }
-      // Update the "new" LRUEntry and add it to the hash
-      _list.begin()->first          = hash;
-      _list.begin()->second         = 1;
-      _map[&(_list.begin()->first)] = _list.begin();
-    }
-
-    TSMutexUnlock(_lock);
-
-    return ret;
+    (*new Do_promote_steps(txnp, this))();
   }
 
   void
@@ -337,10 +286,128 @@ private:
   unsigned _hits    = 10;
   // For the LRU. Note that we keep track of the List sizes, because some versions fo STL have broken
   // implementations of size(), making them obsessively slow on calling ::size().
-  TSMutex _lock;
+  TSMutex _lock{TSMutexCreate()};
   LRUMap _map;
   LRUList _list, _freelist;
   size_t _list_size = 0, _freelist_size = 0;
+
+  class Do_promote_steps
+  {
+  public:
+    Do_promote_steps(TSHttpTxn txnp, LRUPolicy *policy) : _txnp(txnp), _policy(policy) {}
+
+    void
+    operator()()
+    {
+      char *url   = nullptr;
+      int url_len = 0;
+      TSMBuffer request;
+      TSMLoc req_hdr;
+
+      if (TS_SUCCESS == TSHttpTxnClientReqGet(_txnp, &request, &req_hdr)) {
+        TSMLoc c_url = TS_NULL_MLOC;
+
+        // Get the cache key URL (for now), since this has better lookup behavior when using
+        // e.g. the cachekey plugin.
+        if (TS_SUCCESS == TSUrlCreate(request, &c_url)) {
+          if (TS_SUCCESS == TSHttpTxnCacheLookupUrlGet(_txnp, request, c_url)) {
+            url = TSUrlStringGet(request, c_url, &url_len);
+            TSHandleMLocRelease(request, TS_NULL_MLOC, c_url);
+          }
+        }
+        TSHandleMLocRelease(request, TS_NULL_MLOC, req_hdr);
+      }
+
+      // Generally shouldn't happen ...
+      if (!url) {
+        cache_turned_off(_txnp);
+
+        // Reenable and continue with the state machine.
+        TSHttpTxnReenable(_txnp, TS_EVENT_HTTP_CONTINUE);
+
+        delete this;
+
+        return;
+      }
+
+      TSDebug(PLUGIN_NAME, "LRUPolicy::doPromote(%.*s%s)", url_len > 100 ? 100 : url_len, url, url_len > 100 ? "..." : "");
+      _hash.init(url, url_len);
+      TSfree(url);
+
+      ContinueInMemberFunc<Do_promote_steps, &Do_promote_steps::critical_section>::once(*this, _policy->_lock)->schedule();
+    }
+
+  private:
+    TSHttpTxn _txnp;
+    LRUPolicy *_policy;
+
+    bool _success = false;
+    LRUHash _hash;
+
+    int
+    critical_section(TSEvent, void *)
+    {
+      LRUMap::iterator map_it = _policy->_map.find(&_hash);
+      if (_policy->_map.end() != map_it) {
+        // We have an entry in the LRU
+        TSAssert(_policy->_list_size > 0); // mismatch in the LRUs hash and list, shouldn't happen
+        if (++(map_it->second->second) >= _policy->_hits) {
+          // Promoted! Cleanup the LRU, and signal success. Save the promoted entry on the freelist.
+          TSDebug(PLUGIN_NAME, "saving the LRUEntry to the freelist");
+          _policy->_freelist.splice(_policy->_freelist.begin(), _policy->_list, map_it->second);
+          ++_policy->_freelist_size;
+          --_policy->_list_size;
+          _policy->_map.erase(map_it->first);
+          _success = true;
+        } else {
+          // It's still not promoted, make sure it's moved to the front of the list
+          TSDebug(PLUGIN_NAME, "still not promoted, got %d hits so far", map_it->second->second);
+          _policy->_list.splice(_policy->_list.begin(), _policy->_list, map_it->second);
+        }
+      } else {
+        // New LRU entry for the URL, try to repurpose the list entry as much as possible
+        if (_policy->_list_size >= _policy->_buckets) {
+          TSDebug(PLUGIN_NAME, "repurposing last LRUHash entry");
+          _policy->_list.splice(_policy->_list.begin(), _policy->_list, --_policy->_list.end());
+          _policy->_map.erase(&(_policy->_list.begin()->first));
+        } else if (_policy->_freelist_size > 0) {
+          TSDebug(PLUGIN_NAME, "reusing LRUEntry from freelist");
+          _policy->_list.splice(_policy->_list.begin(), _policy->_freelist, _policy->_freelist.begin());
+          --_policy->_freelist_size;
+          ++_policy->_list_size;
+        } else {
+          TSDebug(PLUGIN_NAME, "creating new LRUEntry");
+          _policy->_list.push_front(NULL_LRU_ENTRY);
+          ++_policy->_list_size;
+        }
+        // Update the "new" LRUEntry and add it to the hash
+        _policy->_list.begin()->first                   = _hash;
+        _policy->_list.begin()->second                  = 1;
+        _policy->_map[&(_policy->_list.begin()->first)] = _policy->_list.begin();
+      }
+
+      ContinueInMemberFunc<Do_promote_steps, &Do_promote_steps::after_critical_section>::once(*this, nullptr)->schedule();
+
+      return 0;
+    }
+
+    int
+    after_critical_section(TSEvent, void *)
+    {
+      if (_success) {
+        cache_left_on();
+      } else {
+        cache_turned_off(_txnp);
+      }
+
+      // Reenable and continue with the state machine.
+      TSHttpTxnReenable(_txnp, TS_EVENT_HTTP_CONTINUE);
+
+      delete this;
+
+      return 0;
+    }
+  };
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -418,6 +485,7 @@ cont_handle_policy(TSCont contp, TSEvent event, void *edata)
 {
   TSHttpTxn txnp          = static_cast<TSHttpTxn>(edata);
   PromotionConfig *config = static_cast<PromotionConfig *>(TSContDataGet(contp));
+  bool reenable_belayed   = false;
 
   switch (event) {
   // Main HOOK
@@ -426,14 +494,15 @@ cont_handle_policy(TSCont contp, TSEvent event, void *edata)
       int obj_status;
 
       if (TS_ERROR != TSHttpTxnCacheLookupStatusGet(txnp, &obj_status)) {
+        TSDebug(PLUGIN_NAME, "cache-status is %d", obj_status);
         switch (obj_status) {
         case TS_CACHE_LOOKUP_MISS:
         case TS_CACHE_LOOKUP_SKIPPED:
-          if (config->getPolicy()->doSample() && config->getPolicy()->doPromote(txnp)) {
-            TSDebug(PLUGIN_NAME, "cache-status is %d, and leaving cache on (promoted)", obj_status);
+          if (config->getPolicy()->doSample()) {
+            config->getPolicy()->doPromote(txnp);
+            reenable_belayed = true;
           } else {
-            TSDebug(PLUGIN_NAME, "cache-status is %d, and turning off the cache (not promoted)", obj_status);
-            TSHttpTxnServerRespNoStoreSet(txnp, 1);
+            cache_turned_off(txnp);
           }
           break;
         default:
@@ -453,8 +522,10 @@ cont_handle_policy(TSCont contp, TSEvent event, void *edata)
     break;
   }
 
-  // Reenable and continue with the state machine.
-  TSHttpTxnReenable(txnp, TS_EVENT_HTTP_CONTINUE);
+  if (!reenable_belayed) {
+    TSHttpTxnReenable(txnp, TS_EVENT_HTTP_CONTINUE);
+  }
+
   return 0;
 }
 

--- a/src/tscpp/api/Makefile.am
+++ b/src/tscpp/api/Makefile.am
@@ -51,3 +51,17 @@ libtscppapi_la_SOURCES = \
 
 clang-tidy-local: $(DIST_SOURCES)
 	$(CXX_Clang_Tidy)
+
+check_PROGRAMS = test_tscppapi
+
+TESTS = $(check_PROGRAMS)
+
+test_tscppapi_CPPFLAGS = $(AM_CPPFLAGS)\
+	-I$(abs_top_srcdir)/tests/include -Wall -Wextra -Werror $(AM_CXXFLAGS)
+
+# test_tscppapi_LDADD =
+
+test_tscppapi_SOURCES = \
+	Continuation.cc \
+	unit_tests/unit_test_main.cc \
+	unit_tests/test_Continuation.cc

--- a/src/tscpp/api/TransformationPlugin.cc
+++ b/src/tscpp/api/TransformationPlugin.cc
@@ -43,7 +43,7 @@ namespace detail
   public:
     ResumeAfterPauseCont() : Continuation() {}
 
-    ResumeAfterPauseCont(Continuation::Mutex m) : Continuation(m) {}
+    ResumeAfterPauseCont(TSMutex m) : Continuation(m) {}
 
   protected:
     int _run(TSEvent event, void *edata) override;

--- a/src/tscpp/api/unit_tests/test_Continuation.cc
+++ b/src/tscpp/api/unit_tests/test_Continuation.cc
@@ -1,0 +1,115 @@
+/** @file
+
+    Unit tests for Continuation.h.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#include "catch.hpp"
+#include "tscpp/api/Continuation.h"
+
+using atscppapi::Continuation;
+
+using atscppapi::ContinueInMemberFunc;
+
+namespace
+{
+class X
+{
+private:
+  int foo(TSEvent, void *edata);
+
+public:
+  using CallFoo = ContinueInMemberFunc<X, &X::foo>;
+};
+
+X x;
+
+int
+X::foo(TSEvent, void *edata)
+{
+  REQUIRE(this == &x);
+
+  return 666;
+}
+
+} // end anonymous namespace
+
+TEST_CASE("Continuation", "[Cont]")
+{
+  static X::CallFoo cf(x, nullptr);
+
+  REQUIRE(cf.call(TS_EVENT_IMMEDIATE) == 666);
+
+  REQUIRE(X::CallFoo::once(x, nullptr)->call(TS_EVENT_IMMEDIATE) == 666);
+}
+
+// Mocks
+
+namespace
+{
+TSEventFunc contFuncp = nullptr;
+
+void *contDatap = nullptr;
+
+int dummy;
+TSCont const DummyTSCont = reinterpret_cast<TSCont>(&dummy);
+} // namespace
+
+TSCont
+TSContCreate(TSEventFunc funcp, TSMutex mutexp)
+{
+  REQUIRE(mutexp == nullptr);
+  contFuncp = funcp;
+  return DummyTSCont;
+}
+
+void *
+TSContDataGet(TSCont contp)
+{
+  REQUIRE(contp == DummyTSCont);
+  return contDatap;
+}
+
+void
+TSContDataSet(TSCont contp, void *data)
+{
+  REQUIRE(contp == DummyTSCont);
+  contDatap = data;
+}
+
+void TSContDestroy(TSCont) {}
+
+int
+TSContCall(TSCont contp, TSEvent event, void *edata)
+{
+  REQUIRE(contp == DummyTSCont);
+  return contFuncp(contp, event, edata);
+}
+
+#include <cstdlib>
+#include <iostream>
+
+void
+_TSReleaseAssert(const char *text, const char *file, int line)
+{
+  std::cout << "_TSReleaseAssert: " << text << " File:" << file << " Line:" << line << '\n';
+
+  std::exit(1);
+}

--- a/src/tscpp/api/unit_tests/unit_test_main.cc
+++ b/src/tscpp/api/unit_tests/unit_test_main.cc
@@ -1,0 +1,25 @@
+/** @file
+
+  This file used for catch based tests. It is the main() stub.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"


### PR DESCRIPTION
This should hopefully reduce event thread blocking.

This PR is dependent on https://github.com/apache/trafficserver/pull/4848 .

The drawback is that this new version involves three dynamic memory allocations each time the critical section is entered.  So it depends on jemalloc whether there is a net benefit.  Whether jemalloc is good at avoiding the need to take a mutex for allocation, and at keeping the critical section short when taking a mutex is necessary.

If you fetch the branch for this PR and do a diff with 'meld', it shows more clearly what has really been changed.