### PR TITLE
cache_promote plugin: put a mutex-protected critical section into a Continuation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ src/tscore/test_geometry
 src/tscore/test_Regex
 src/tscore/test_X509HostnameValidator
 src/tscore/test_tscore
+src/tscpp/api/test_tscppapi
 src/tscpp/util/test_tscpputil
 lib/records/test_librecords
 lib/perl/lib/Apache/TS.pm

--- a/example/plugins/cpp-api/delay_transformation_plugin/DelayTransformationPlugin.cc
+++ b/example/plugins/cpp-api/delay_transformation_plugin/DelayTransformationPlugin.cc
@@ -75,7 +75,7 @@ public:
     pause();
 
     TS_DEBUG(TAG, "Resuming in 2ms...");
-    resumeCont().schedule(2, TS_THREAD_POOL_NET);
+    resumeCont().schedule(2);
   }
 
   void

--- a/src/tscpp/api/Makefile.am
+++ b/src/tscpp/api/Makefile.am
@@ -51,3 +51,17 @@ libtscppapi_la_SOURCES = \
 
 clang-tidy-local: $(DIST_SOURCES)
 	$(CXX_Clang_Tidy)
+
+check_PROGRAMS = test_tscppapi
+
+TESTS = $(check_PROGRAMS)
+
+test_tscppapi_CPPFLAGS = $(AM_CPPFLAGS)\
+	-I$(abs_top_srcdir)/tests/include -Wall -Wextra -Werror $(AM_CXXFLAGS)
+
+# test_tscppapi_LDADD =
+
+test_tscppapi_SOURCES = \
+	Continuation.cc \
+	unit_tests/unit_test_main.cc \
+	unit_tests/test_Continuation.cc

--- a/src/tscpp/api/TransformationPlugin.cc
+++ b/src/tscpp/api/TransformationPlugin.cc
@@ -43,7 +43,7 @@ namespace detail
   public:
     ResumeAfterPauseCont() : Continuation() {}
 
-    ResumeAfterPauseCont(Continuation::Mutex m) : Continuation(m) {}
+    ResumeAfterPauseCont(TSMutex m) : Continuation(m) {}
 
   protected:
     int _run(TSEvent event, void *edata) override;

--- a/src/tscpp/api/unit_tests/test_Continuation.cc
+++ b/src/tscpp/api/unit_tests/test_Continuation.cc
@@ -1,0 +1,115 @@
+/** @file
+
+    Unit tests for Continuation.h.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#include "catch.hpp"
+#include "tscpp/api/Continuation.h"
+
+using atscppapi::Continuation;
+
+using atscppapi::ContinueInMemberFunc;
+
+namespace
+{
+class X
+{
+private:
+  int foo(TSEvent, void *edata);
+
+public:
+  using CallFoo = ContinueInMemberFunc<X, &X::foo>;
+};
+
+X x;
+
+int
+X::foo(TSEvent, void *edata)
+{
+  REQUIRE(this == &x);
+
+  return 666;
+}
+
+} // end anonymous namespace
+
+TEST_CASE("Continuation", "[Cont]")
+{
+  static X::CallFoo cf(x, nullptr);
+
+  REQUIRE(cf.call(TS_EVENT_IMMEDIATE) == 666);
+
+  REQUIRE(X::CallFoo::once(x, nullptr)->call(TS_EVENT_IMMEDIATE) == 666);
+}
+
+// Mocks
+
+namespace
+{
+TSEventFunc contFuncp = nullptr;
+
+void *contDatap = nullptr;
+
+int dummy;
+TSCont const DummyTSCont = reinterpret_cast<TSCont>(&dummy);
+} // namespace
+
+TSCont
+TSContCreate(TSEventFunc funcp, TSMutex mutexp)
+{
+  REQUIRE(mutexp == nullptr);
+  contFuncp = funcp;
+  return DummyTSCont;
+}
+
+void *
+TSContDataGet(TSCont contp)
+{
+  REQUIRE(contp == DummyTSCont);
+  return contDatap;
+}
+
+void
+TSContDataSet(TSCont contp, void *data)
+{
+  REQUIRE(contp == DummyTSCont);
+  contDatap = data;
+}
+
+void TSContDestroy(TSCont) {}
+
+int
+TSContCall(TSCont contp, TSEvent event, void *edata)
+{
+  REQUIRE(contp == DummyTSCont);
+  return contFuncp(contp, event, edata);
+}
+
+#include <cstdlib>
+#include <iostream>
+
+void
+_TSReleaseAssert(const char *text, const char *file, int line)
+{
+  std::cout << "_TSReleaseAssert: " << text << " File:" << file << " Line:" << line << '\n';
+
+  std::exit(1);
+}

--- a/src/tscpp/api/unit_tests/unit_test_main.cc
+++ b/src/tscpp/api/unit_tests/unit_test_main.cc
@@ -1,0 +1,25 @@
+/** @file
+
+  This file used for catch based tests. It is the main() stub.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"


### PR DESCRIPTION
This is a draft PR that takes the place of https://github.com/apache/trafficserver/pull/5406 .