### PR TITLE
Change HostStatus to use only one stat per host.  

### DIFF
--- a/iocore/cache/test/stub.cc
+++ b/iocore/cache/test/stub.cc
@@ -149,7 +149,7 @@ ts::svtoi(TextView src, TextView *out, int base)
 }
 
 void
-HostStatus::setHostStatus(const char *name, HostStatus_t status, const unsigned int down_time, const char *reason)
+HostStatus::setHostStatus(const char *name, HostStatus_t status, const unsigned int down_time, const unsigned int reason)
 {
 }
 
@@ -160,7 +160,7 @@ HostStatus::getHostStatus(const char *name)
 }
 
 void
-HostStatus::createHostStat(const char *name)
+HostStatus::createHostStat(const char *name, const char *data)
 {
 }
 

--- a/proxy/HostStatus.h
+++ b/proxy/HostStatus.h
@@ -32,10 +32,14 @@
 
 #include <ctime>
 #include <string>
+#include <sstream>
 #include "tscore/ink_rwlock.h"
 #include "records/P_RecProcess.h"
 
 #include <unordered_map>
+
+// host_status stats prefix.
+static const std::string stat_prefix = "proxy.process.host_status.";
 
 enum HostStatus_t {
   HOST_STATUS_INIT,
@@ -43,19 +47,23 @@ enum HostStatus_t {
   HOST_STATUS_UP,
 };
 
-struct HostStatRec_t {
-  HostStatus_t status;
-  time_t marked_down;     // the time that this host was marked down.
-  unsigned int down_time; // number of seconds that the host should be down, 0 is indefinately
-};
+static const constexpr char *HostStatusNames[3] = {"HOST_STATUS_INIT", "HOST_STATUS_DOWN", "HOST_STATUS_UP"};
+static const constexpr char *ReasonStatus[2]    = {"UP", "DOWN"};
 
-struct Reasons {
-  static constexpr const char *ACTIVE      = "active";
-  static constexpr const char *LOCAL       = "local";
-  static constexpr const char *MANUAL      = "manual";
-  static constexpr const char *SELF_DETECT = "self_detect";
+struct Reason {
+  static constexpr const unsigned int ACTIVE      = 0x1;
+  static constexpr const unsigned int LOCAL       = 0x2;
+  static constexpr const unsigned int MANUAL      = 0x4;
+  static constexpr const unsigned int SELF_DETECT = 0x8;
+  static constexpr const unsigned int ALL         = 0xf;
 
-  static constexpr const char *reasons[4] = {ACTIVE, LOCAL, MANUAL, SELF_DETECT};
+  static constexpr const char *ACTIVE_REASON      = "active";
+  static constexpr const char *LOCAL_REASON       = "local";
+  static constexpr const char *MANUAL_REASON      = "manual";
+  static constexpr const char *SELF_DETECT_REASON = "self_detect";
+  static constexpr const char *ALL_REASON         = "all";
+
+  static constexpr const char *reasons[3] = {ACTIVE_REASON, LOCAL_REASON, MANUAL_REASON};
 
   static bool
   validReason(const char *reason)
@@ -67,9 +75,102 @@ struct Reasons {
     }
     return false;
   }
+
+  static unsigned int
+  getReason(const char *reason_str)
+  {
+    if (strcmp(reason_str, ACTIVE_REASON) == 0) {
+      return ACTIVE;
+    } else if (strcmp(reason_str, LOCAL_REASON) == 0) {
+      return LOCAL;
+    } else if (strcmp(reason_str, MANUAL_REASON) == 0) {
+      return MANUAL;
+    } else if (strcmp(reason_str, SELF_DETECT_REASON) == 0) {
+      return SELF_DETECT;
+    } else if (strcmp(reason_str, ALL_REASON) == 0) {
+      return ALL;
+    }
+    // default is MANUAL
+    return MANUAL;
+  }
 };
 
-static const std::string stat_prefix = "proxy.process.host_status.";
+// host status POD
+struct HostStatRec {
+  HostStatus_t status;
+  unsigned int reasons;
+  // time the host was marked down for a given reason.
+  time_t active_marked_down;
+  time_t local_marked_down;
+  time_t manual_marked_down;
+  time_t self_detect_marked_down;
+  // number of seconds that the host should be marked down for a given reason.
+  unsigned int active_down_time;
+  unsigned int local_down_time;
+  unsigned int manual_down_time;
+
+  HostStatRec();
+  HostStatRec(std::string str);
+  HostStatRec(const HostStatRec &src)
+  {
+    status                  = src.status;
+    reasons                 = src.reasons;
+    active_marked_down      = src.active_marked_down;
+    active_down_time        = src.active_down_time;
+    local_marked_down       = src.local_marked_down;
+    local_down_time         = src.local_down_time;
+    manual_marked_down      = src.manual_marked_down;
+    manual_down_time        = src.manual_down_time;
+    self_detect_marked_down = src.self_detect_marked_down;
+  }
+  ~HostStatRec() {}
+
+  // serialize this HostStatusRec
+  std::stringstream &
+  operator<<(std::stringstream &os)
+  {
+    unsigned int r = getReasonState(Reason::ACTIVE);
+    os << HostStatusNames[status];
+    os << ",ACTIVE:" << ReasonStatus[r] << ":" << active_marked_down << ":" << active_down_time;
+    r = getReasonState(Reason::LOCAL);
+    os << ",LOCAL:" << ReasonStatus[r] << ":" << local_marked_down << ":" << local_down_time;
+    r = getReasonState(Reason::MANUAL);
+    os << ",MANUAL:" << ReasonStatus[r] << ":" << manual_marked_down << ":" << manual_down_time;
+    r = getReasonState(Reason::SELF_DETECT);
+    os << ",SELF_DETECT:" << ReasonStatus[r] << ":" << self_detect_marked_down;
+
+    return os;
+  }
+
+  // serialize a HostStatRec
+  friend std::stringstream &
+  operator<<(std::stringstream &os, HostStatRec &hs)
+  {
+    unsigned int r = hs.getReasonState(Reason::ACTIVE);
+    os << HostStatusNames[hs.status];
+    os << ",ACTIVE:" << ReasonStatus[r] << ":" << hs.active_marked_down << ":" << hs.active_down_time;
+    r = hs.getReasonState(Reason::LOCAL);
+    os << ",LOCAL:" << ReasonStatus[r] << ":" << hs.local_marked_down << ":" << hs.local_down_time;
+    r = hs.getReasonState(Reason::MANUAL);
+    os << ",MANUAL:" << ReasonStatus[r] << ":" << hs.manual_marked_down << ":" << hs.manual_down_time;
+    r = hs.getReasonState(Reason::SELF_DETECT);
+    os << ",SELF_DETECT:" << ReasonStatus[r] << ":" << hs.self_detect_marked_down;
+
+    return os;
+  }
+
+  inline unsigned int
+  getReasonState(unsigned int reason)
+  {
+    unsigned int r = 0;
+    if (reasons == 0) {
+      r = 0;
+    } else if (reasons & reason) {
+      r = 1;
+    }
+    return r;
+  }
+};
 
 /**
  * Singleton placeholder for next hop status.
@@ -83,23 +184,20 @@ struct HostStatus {
     static HostStatus instance;
     return instance;
   }
-  void setHostStatus(const char *name, const HostStatus_t status, const unsigned int down_time, const char *reason);
+  void setHostStatus(const char *name, const HostStatus_t status, const unsigned int down_time, const unsigned int reason);
   HostStatus_t getHostStatus(const char *name);
-  void createHostStat(const char *name);
+  void createHostStat(const char *name, const char *data = nullptr);
   void loadHostStatusFromStats();
-  int getHostStatId(const char *name);
+  void loadRecord(std::string &name, HostStatRec &h);
+  RecErrT getHostStat(std::string &stat_name, char *buf, unsigned int buf_len);
 
 private:
-  int next_stat_id = 1;
   HostStatus();
   HostStatus(const HostStatus &obj) = delete;
   HostStatus &operator=(HostStatus const &) = delete;
 
-  // next hop status, key is hostname or ip string, data is bool (available).
-  std::unordered_map<std::string, HostStatRec_t *> hosts_statuses;
-  // next hop stat ids, key is hostname or ip string, data is int stat id.
-  std::unordered_map<std::string, int> hosts_stats_ids;
+  // next hop status, key is hostname or ip string, data is HostStatRec
+  std::unordered_map<std::string, HostStatRec *> hosts_statuses;
 
   ink_rwlock host_status_rwlock;
-  ink_rwlock host_statids_rwlock;
 };

--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -372,7 +372,7 @@ ParentRecord::PreProcessParents(const char *val, const int line_num, char *buf, 
           continue;
         } else {
           Debug("parent_select", "token: %s, matches this machine.  Marking down self from parent list at line %d", fqdn, line_num);
-          hs.setHostStatus(fqdn, HostStatus_t::HOST_STATUS_DOWN, 0, Reasons::SELF_DETECT);
+          hs.setHostStatus(fqdn, HostStatus_t::HOST_STATUS_DOWN, 0, Reason::SELF_DETECT);
         }
       }
     } else {
@@ -384,7 +384,7 @@ ParentRecord::PreProcessParents(const char *val, const int line_num, char *buf, 
         } else {
           Debug("parent_select", "token: %s, matches this machine.  Marking down self from parent list at line %d", token,
                 line_num);
-          hs.setHostStatus(token, HostStatus_t::HOST_STATUS_DOWN, 0, Reasons::SELF_DETECT);
+          hs.setHostStatus(token, HostStatus_t::HOST_STATUS_DOWN, 0, Reason::SELF_DETECT);
         }
       }
     }
@@ -516,7 +516,7 @@ ParentRecord::ProcessParents(char *val, bool isPrimary)
         this->parents[i].name = this->parents[i].hash_string;
       }
       if (hs.getHostStatus(this->parents[i].hostname) == HostStatus_t::HOST_STATUS_INIT) {
-        hs.setHostStatus(this->parents[i].hostname, HOST_STATUS_UP, 0, Reasons::MANUAL);
+        hs.setHostStatus(this->parents[i].hostname, HOST_STATUS_UP, 0, Reason::MANUAL);
       }
     } else {
       memcpy(this->secondary_parents[i].hostname, current, tmp - current);
@@ -534,7 +534,7 @@ ParentRecord::ProcessParents(char *val, bool isPrimary)
         this->secondary_parents[i].name = this->secondary_parents[i].hash_string;
       }
       if (hs.getHostStatus(this->secondary_parents[i].hostname) == HostStatus_t::HOST_STATUS_INIT) {
-        hs.setHostStatus(this->secondary_parents[i].hostname, HOST_STATUS_UP, 0, Reasons::MANUAL);
+        hs.setHostStatus(this->secondary_parents[i].hostname, HOST_STATUS_UP, 0, Reason::MANUAL);
       }
     }
     tmp3 = nullptr;
@@ -1451,7 +1451,7 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
   // Test 184
   // mark fuzzy down with HostStatus API.
   HostStatus &_st = HostStatus::instance();
-  _st.setHostStatus("fuzzy", HOST_STATUS_DOWN, 0, Reasons::MANUAL);
+  _st.setHostStatus("fuzzy", HOST_STATUS_DOWN, 0, Reason::MANUAL);
 
   ST(184);
   REINIT;
@@ -1462,7 +1462,7 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
 
   // Test 185
   // mark fluffy down and expect furry to be chosen
-  _st.setHostStatus("fluffy", HOST_STATUS_DOWN, 0, Reasons::MANUAL);
+  _st.setHostStatus("fluffy", HOST_STATUS_DOWN, 0, Reason::MANUAL);
 
   ST(185);
   REINIT;
@@ -1473,9 +1473,9 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
 
   // Test 186
   // mark furry and frisky down, fuzzy up and expect fuzzy to be chosen
-  _st.setHostStatus("furry", HOST_STATUS_DOWN, 0, Reasons::MANUAL);
-  _st.setHostStatus("frisky", HOST_STATUS_DOWN, 0, Reasons::MANUAL);
-  _st.setHostStatus("fuzzy", HOST_STATUS_UP, 0, Reasons::MANUAL);
+  _st.setHostStatus("furry", HOST_STATUS_DOWN, 0, Reason::MANUAL);
+  _st.setHostStatus("frisky", HOST_STATUS_DOWN, 0, Reason::MANUAL);
+  _st.setHostStatus("fuzzy", HOST_STATUS_UP, 0, Reason::MANUAL);
 
   ST(186);
   REINIT;
@@ -1493,10 +1493,10 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
   REBUILD;
 
   // mark all up.
-  _st.setHostStatus("furry", HOST_STATUS_UP, 0, Reasons::MANUAL);
-  _st.setHostStatus("fluffy", HOST_STATUS_UP, 0, Reasons::MANUAL);
-  _st.setHostStatus("frisky", HOST_STATUS_UP, 0, Reasons::MANUAL);
-  _st.setHostStatus("fuzzy", HOST_STATUS_UP, 0, Reasons::MANUAL);
+  _st.setHostStatus("furry", HOST_STATUS_UP, 0, Reason::MANUAL);
+  _st.setHostStatus("fluffy", HOST_STATUS_UP, 0, Reason::MANUAL);
+  _st.setHostStatus("frisky", HOST_STATUS_UP, 0, Reason::MANUAL);
+  _st.setHostStatus("fuzzy", HOST_STATUS_UP, 0, Reason::MANUAL);
 
   REINIT;
   br(request, "i.am.rabbit.net");
@@ -1506,7 +1506,7 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
 
   // Test 188
   // mark fuzzy down and expect fluffy.
-  _st.setHostStatus("fuzzy", HOST_STATUS_DOWN, 0, Reasons::MANUAL);
+  _st.setHostStatus("fuzzy", HOST_STATUS_DOWN, 0, Reason::MANUAL);
 
   ST(188);
   REINIT;
@@ -1517,7 +1517,7 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
 
   // Test 189
   // mark fuzzy back up and expect fuzzy.
-  _st.setHostStatus("fuzzy", HOST_STATUS_UP, 0, Reasons::MANUAL);
+  _st.setHostStatus("fuzzy", HOST_STATUS_UP, 0, Reason::MANUAL);
 
   ST(189);
   REINIT;
@@ -1533,7 +1533,7 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
   // because the host status is set to down.
   params->markParentDown(result, fail_threshold, retry_time);
   // set host status down
-  _st.setHostStatus("fuzzy", HOST_STATUS_DOWN, 0, Reasons::MANUAL);
+  _st.setHostStatus("fuzzy", HOST_STATUS_DOWN, 0, Reason::MANUAL);
   // sleep long enough so that fuzzy is retryable
   sleep(params->policy.ParentRetryTime + 1);
   ST(190);
@@ -1544,7 +1544,7 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
 
   // now set the host staus on fuzzy to up and it should now
   // be retried.
-  _st.setHostStatus("fuzzy", HOST_STATUS_UP, 0, Reasons::MANUAL);
+  _st.setHostStatus("fuzzy", HOST_STATUS_UP, 0, Reason::MANUAL);
   ST(191);
   REINIT;
   br(request, "i.am.rabbit.net");
@@ -1557,10 +1557,10 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
   T("dest_domain=rabbit.net parent=fuzzy:80,fluffy:80,furry:80,frisky:80 round_robin=false go_direct=true\n");
   REBUILD;
   // mark all up.
-  _st.setHostStatus("fuzzy", HOST_STATUS_UP, 0, Reasons::MANUAL);
-  _st.setHostStatus("fluffy", HOST_STATUS_UP, 0, Reasons::MANUAL);
-  _st.setHostStatus("furry", HOST_STATUS_UP, 0, Reasons::MANUAL);
-  _st.setHostStatus("frisky", HOST_STATUS_UP, 0, Reasons::MANUAL);
+  _st.setHostStatus("fuzzy", HOST_STATUS_UP, 0, Reason::MANUAL);
+  _st.setHostStatus("fluffy", HOST_STATUS_UP, 0, Reason::MANUAL);
+  _st.setHostStatus("furry", HOST_STATUS_UP, 0, Reason::MANUAL);
+  _st.setHostStatus("frisky", HOST_STATUS_UP, 0, Reason::MANUAL);
   // fuzzy should be chosen.
   sleep(1);
   REINIT;
@@ -1575,7 +1575,7 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
   sleep(params->policy.ParentRetryTime + 1);
   // since the host status is down even though fuzzy is
   // retryable, fluffy should be chosen
-  _st.setHostStatus("fuzzy", HOST_STATUS_DOWN, 0, Reasons::MANUAL);
+  _st.setHostStatus("fuzzy", HOST_STATUS_DOWN, 0, Reason::MANUAL);
   REINIT;
   br(request, "i.am.rabbit.net");
   FP;
@@ -1585,7 +1585,7 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
   // set the host status for fuzzy  back up and since its
   // retryable fuzzy should be chosen
   ST(194);
-  _st.setHostStatus("fuzzy", HOST_STATUS_UP, 0, Reasons::MANUAL);
+  _st.setHostStatus("fuzzy", HOST_STATUS_UP, 0, Reason::MANUAL);
   REINIT;
   br(request, "i.am.rabbit.net");
   FP;
@@ -1706,7 +1706,7 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
   T("dest_domain=rabbit.net parent=fuzzy:80|1.0;fluffy:80|1.0 secondary_parent=furry:80|1.0;frisky:80|1.0 "
     "round_robin=consistent_hash go_direct=false secondary_mode=3\n");
   REBUILD;
-  _st.setHostStatus("fuzzy", HOST_STATUS_DOWN, 0, Reasons::MANUAL);
+  _st.setHostStatus("fuzzy", HOST_STATUS_DOWN, 0, Reason::MANUAL);
   REINIT;
   br(request, "i.am.rabbit.net");
   FP;
@@ -1777,15 +1777,15 @@ EXCLUSIVE_REGRESSION_TEST(PARENTSELECTION)(RegressionTest * /* t ATS_UNUSED */, 
     "round_robin=consistent_hash go_direct=false\n");
   REBUILD;
   REINIT;
-  _st.setHostStatus("curly", HOST_STATUS_DOWN, 0, Reasons::MANUAL);
+  _st.setHostStatus("curly", HOST_STATUS_DOWN, 0, Reason::MANUAL);
   br(request, "i.am.stooges.net");
   FP;
   RE(verify(result, PARENT_SPECIFIED, "carol", 80), 211);
 
   // cleanup, allow changes to be persisted to records.snap
   // so that subsequent test runs do not fail unexpectedly.
-  _st.setHostStatus("curly", HOST_STATUS_UP, 0, Reasons::MANUAL);
-  _st.setHostStatus("fuzzy", HOST_STATUS_UP, 0, Reasons::MANUAL);
+  _st.setHostStatus("curly", HOST_STATUS_UP, 0, Reason::MANUAL);
+  _st.setHostStatus("fuzzy", HOST_STATUS_UP, 0, Reason::MANUAL);
   sleep(2);
 
   delete request;

--- a/src/traffic_server/HostStatus.cc
+++ b/src/traffic_server/HostStatus.cc
@@ -25,16 +25,10 @@
 
 static RecRawStatBlock *host_status_rsb = nullptr;
 
-static void
-getStatName(std::string &stat_name, const char *name, const char *reason)
+inline void
+getStatName(std::string &stat_name, const char *name)
 {
-  stat_name = stat_prefix + name + "_";
-
-  if (reason == nullptr) {
-    stat_name += Reasons::MANUAL;
-  } else {
-    stat_name += reason;
-  }
+  stat_name = stat_prefix + name;
 }
 
 static void
@@ -43,22 +37,27 @@ mgmt_host_status_up_callback(ts::MemSpan span)
   MgmtInt op;
   MgmtMarshallString name;
   MgmtMarshallInt down_time;
-  MgmtMarshallString reason;
-  std::string reason_stat;
+  MgmtMarshallString reason_str;
+  std::string stat_name;
+  char buf[1024]                         = {0};
   char *data                             = static_cast<char *>(span.data());
   auto len                               = span.size();
   static const MgmtMarshallType fields[] = {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING, MGMT_MARSHALL_STRING, MGMT_MARSHALL_INT};
   Debug("host_statuses", "%s:%s:%d - data: %s, len: %ld\n", __FILE__, __func__, __LINE__, data, len);
 
-  if (mgmt_message_parse(data, len, fields, countof(fields), &op, &name, &reason, &down_time) == -1) {
+  if (mgmt_message_parse(data, len, fields, countof(fields), &op, &name, &reason_str, &down_time) == -1) {
     Error("Plugin message - RPC parsing error - message discarded.");
   }
-  Debug("host_statuses", "op: %ld, name: %s, down_time: %d, reason: %s", static_cast<long>(op), name, static_cast<int>(down_time),
-        reason);
+  Debug("host_statuses", "op: %ld, name: %s, down_time: %d, reason_str: %s", static_cast<long>(op), name,
+        static_cast<int>(down_time), reason_str);
+
+  unsigned int reason = Reason::getReason(reason_str);
+
+  getStatName(stat_name, name);
   if (data != nullptr) {
     Debug("host_statuses", "marking up server %s", data);
     HostStatus &hs = HostStatus::instance();
-    if (hs.getHostStatId(reason_stat.c_str()) == -1) {
+    if (hs.getHostStat(stat_name, buf, 1024) == REC_ERR_FAIL) {
       hs.createHostStat(name);
     }
     hs.setHostStatus(name, HostStatus_t::HOST_STATUS_UP, down_time, reason);
@@ -71,26 +70,116 @@ mgmt_host_status_down_callback(ts::MemSpan span)
   MgmtInt op;
   MgmtMarshallString name;
   MgmtMarshallInt down_time;
-  MgmtMarshallString reason;
-  std::string reason_stat;
+  MgmtMarshallString reason_str;
+  std::string stat_name;
   char *data                             = static_cast<char *>(span.data());
+  char buf[1024]                         = {0};
   auto len                               = span.size();
   static const MgmtMarshallType fields[] = {MGMT_MARSHALL_INT, MGMT_MARSHALL_STRING, MGMT_MARSHALL_STRING, MGMT_MARSHALL_INT};
   Debug("host_statuses", "%s:%s:%d - data: %s, len: %ld\n", __FILE__, __func__, __LINE__, data, len);
 
-  if (mgmt_message_parse(data, len, fields, countof(fields), &op, &name, &reason, &down_time) == -1) {
+  if (mgmt_message_parse(data, len, fields, countof(fields), &op, &name, &reason_str, &down_time) == -1) {
     Error("Plugin message - RPC parsing error - message discarded.");
   }
-  Debug("host_statuses", "op: %ld, name: %s, down_time: %d, reason: %s", static_cast<long>(op), name, static_cast<int>(down_time),
-        reason);
+  Debug("host_statuses", "op: %ld, name: %s, down_time: %d, reason_str: %s", static_cast<long>(op), name,
+        static_cast<int>(down_time), reason_str);
+
+  unsigned int reason = Reason::getReason(reason_str);
 
   if (data != nullptr) {
     Debug("host_statuses", "marking down server %s", name);
     HostStatus &hs = HostStatus::instance();
-    if (hs.getHostStatId(reason_stat.c_str()) == -1) {
+    if (hs.getHostStat(stat_name, buf, 1024) == REC_ERR_FAIL) {
       hs.createHostStat(name);
     }
     hs.setHostStatus(name, HostStatus_t::HOST_STATUS_DOWN, down_time, reason);
+  }
+}
+
+HostStatRec::HostStatRec()
+  : status(HOST_STATUS_UP),
+    reasons(0),
+    active_marked_down(0),
+    local_marked_down(0),
+    manual_marked_down(0),
+    self_detect_marked_down(0),
+    active_down_time(0),
+    local_down_time(0),
+    manual_down_time(0){};
+
+HostStatRec::HostStatRec(std::string str)
+{
+  std::vector<std::string> v1;
+  std::stringstream ss1(str);
+
+  reasons = 0;
+
+  // parse the csv strings from the stat record value string.
+  while (ss1.good()) {
+    char b1[64];
+    ss1.getline(b1, 64, ',');
+    v1.push_back(b1);
+  }
+
+  // v1 contains 5 strings.
+  ink_assert(v1.size() == 5);
+
+  // set the status and reasons fields.
+  for (unsigned int i = 0; i < v1.size(); i++) {
+    if (i == 0) { // set the status field
+      if (v1.at(i).compare("HOST_STATUS_UP") == 0) {
+        status = HOST_STATUS_UP;
+      } else if (v1.at(i).compare("HOST_STATUS_DOWN") == 0) {
+        status = HOST_STATUS_DOWN;
+      }
+    } else { // parse and set remaining reason fields.
+      std::vector<std::string> v2;
+      v2.clear();
+      std::stringstream ss2(v1.at(i));
+      while (ss2.good()) {
+        char b2[64];
+        ss2.getline(b2, 64, ':');
+        v2.push_back(b2);
+      }
+      // v2 contains 4 strings.
+      ink_assert(v2.size() == 3 || v2.size() == 4);
+
+      if (v2.at(0).compare("ACTIVE") == 0) {
+        if (v2.at(1).compare("DOWN") == 0) {
+          reasons |= Reason::ACTIVE;
+        } else if (reasons & Reason::ACTIVE) {
+          reasons ^= Reason::ACTIVE;
+        }
+        active_marked_down = atoi(v2.at(2).c_str());
+        active_down_time   = atoi(v2.at(3).c_str());
+      }
+      if (v2.at(0).compare("LOCAL") == 0) {
+        if (v2.at(1).compare("DOWN") == 0) {
+          reasons |= Reason::LOCAL;
+        } else if (reasons & Reason::LOCAL) {
+          reasons ^= Reason::LOCAL;
+        }
+        local_marked_down = atoi(v2.at(2).c_str());
+        local_down_time   = atoi(v2.at(3).c_str());
+      }
+      if (v2.at(0).compare("MANUAL") == 0) {
+        if (v2.at(1).compare("DOWN") == 0) {
+          reasons |= Reason::MANUAL;
+        } else if (reasons & Reason::MANUAL) {
+          reasons ^= Reason::MANUAL;
+        }
+        manual_marked_down = atoi(v2.at(2).c_str());
+        manual_down_time   = atoi(v2.at(3).c_str());
+      }
+      if (v2.at(0).compare("SELF_DETECT") == 0) {
+        if (v2.at(1).compare("DOWN") == 0) {
+          reasons |= Reason::SELF_DETECT;
+        } else if (reasons & Reason::SELF_DETECT) {
+          reasons ^= Reason::SELF_DETECT;
+        }
+        self_detect_marked_down = atoi(v2.at(2).c_str());
+      }
+    }
   }
 }
 
@@ -99,33 +188,24 @@ handle_record_read(const RecRecord *rec, void *edata)
 {
   HostStatus &hs = HostStatus::instance();
   std::string hostname;
-  std::string reason;
 
   if (rec) {
+    Debug("host_statuses", "name: %s", rec->name);
+
     // parse the hostname from the stat name
     char *s = const_cast<char *>(rec->name);
     // 1st move the pointer past the stat prefix.
-    s += strlen(stat_prefix.c_str());
+    s += stat_prefix.length();
     hostname = s;
-    // parse the reason from the stat name.
-    reason = hostname.substr(hostname.find('_'));
-    reason.erase(0, 1);
-    // erase the reason tag
-    hostname.erase(hostname.find('_'));
-
-    // if the data loaded from stats indicates that the host was down,
-    // then update the state so that the host remains down until
-    // specifically marked up using traffic_ctl.
-    if (rec->data.rec_int == 0 && Reasons::validReason(reason.c_str())) {
-      hs.setHostStatus(hostname.c_str(), HOST_STATUS_DOWN, 0, reason.c_str());
-    }
+    hs.createHostStat(hostname.c_str(), rec->data.rec_string);
+    HostStatRec h(rec->data.rec_string);
+    hs.loadRecord(hostname, h);
   }
 }
 
 HostStatus::HostStatus()
 {
   ink_rwlock_init(&host_status_rwlock);
-  ink_rwlock_init(&host_statids_rwlock);
   pmgmt->registerMgmtCallback(MGMT_EVENT_HOST_STATUS_UP, &mgmt_host_status_up_callback);
   pmgmt->registerMgmtCallback(MGMT_EVENT_HOST_STATUS_DOWN, &mgmt_host_status_down_callback);
   host_status_rsb = RecAllocateRawStatBlock((int)TS_MAX_API_STATS);
@@ -136,64 +216,142 @@ HostStatus::~HostStatus()
   for (auto &&it : hosts_statuses) {
     ats_free(it.second);
   }
-  // release host_stats_ids hash and the read and writer locks.
+  // release the read and writer locks.
   ink_rwlock_destroy(&host_status_rwlock);
-  ink_rwlock_destroy(&host_statids_rwlock);
 }
 
 void
 HostStatus::loadHostStatusFromStats()
 {
-  if (RecLookupMatchingRecords(RECT_ALL, stat_prefix.c_str(), handle_record_read, nullptr) != REC_ERR_OKAY) {
+  if (RecLookupMatchingRecords(RECT_PROCESS, stat_prefix.c_str(), handle_record_read, nullptr) != REC_ERR_OKAY) {
     Error("[HostStatus] - While loading HostStatus stats, there was an Error reading HostStatus stats.");
   }
 }
 
 void
-HostStatus::setHostStatus(const char *name, HostStatus_t status, const unsigned int down_time, const char *reason)
+HostStatus::loadRecord(std::string &name, HostStatRec &h)
 {
-  std::string reason_stat;
+  HostStatRec *host_stat = nullptr;
+  Debug("host_statuses", "loading host status record for %s", name.c_str());
+  ink_rwlock_wrlock(&host_status_rwlock);
+  {
+    if (auto it = hosts_statuses.find(name.c_str()); it != hosts_statuses.end()) {
+      host_stat = it->second;
+    } else {
+      host_stat  = static_cast<HostStatRec *>(ats_malloc(sizeof(HostStatRec)));
+      *host_stat = h;
+      hosts_statuses.emplace(name, host_stat);
+    }
+  }
+  ink_rwlock_unlock(&host_status_rwlock);
 
-  getStatName(reason_stat, name, reason);
+  *host_stat = h;
+}
 
-  if (getHostStatId(reason_stat.c_str()) == -1) {
+void
+HostStatus::setHostStatus(const char *name, HostStatus_t status, const unsigned int down_time, const unsigned int reason)
+{
+  std::string stat_name;
+  char buf[1024] = {0};
+
+  getStatName(stat_name, name);
+
+  if (getHostStat(stat_name, buf, 1024) == REC_ERR_FAIL) {
     createHostStat(name);
   }
 
-  int stat_id = getHostStatId(reason_stat.c_str());
-
-  // update the stats
-  if (stat_id != -1) {
-    if (status == HostStatus_t::HOST_STATUS_UP) {
-      Debug("host_statuses", "set status up for :  name: %s, status: %d, reason_stat: %s", name, status, reason_stat.c_str());
-      RecSetRawStatCount(host_status_rsb, stat_id, 1);
-      RecSetRawStatSum(host_status_rsb, stat_id, 1);
-    } else {
-      Debug("host_statuses", "set status down for :  name: %s, status: %d, reason_stat: %s", name, status, reason_stat.c_str());
-      RecSetRawStatCount(host_status_rsb, stat_id, 0);
-      RecSetRawStatSum(host_status_rsb, stat_id, 0);
-    }
-  }
-  Debug("host_statuses", "name: %s, status: %d", name, status);
+  RecErrT result = getHostStat(stat_name, buf, 1024);
 
   // update / insert status.
   // using the hash table pointer to store the HostStatus_t value.
-  HostStatRec_t *host_stat = nullptr;
+  HostStatRec *host_stat = nullptr;
   ink_rwlock_wrlock(&host_status_rwlock);
-  if (auto it = hosts_statuses.find(name); it != hosts_statuses.end()) {
-    host_stat = it->second;
-  } else {
-    host_stat = static_cast<HostStatRec_t *>(ats_malloc(sizeof(HostStatRec_t)));
-    hosts_statuses.emplace(name, host_stat);
-  }
-  host_stat->status    = status;
-  host_stat->down_time = down_time;
-  if (status == HostStatus_t::HOST_STATUS_DOWN) {
-    host_stat->marked_down = time(0);
-  } else {
-    host_stat->marked_down = 0;
+  {
+    if (auto it = hosts_statuses.find(name); it != hosts_statuses.end()) {
+      host_stat = it->second;
+    } else {
+      host_stat = static_cast<HostStatRec *>(ats_malloc(sizeof(HostStatRec)));
+      bzero(host_stat, sizeof(HostStatRec));
+      hosts_statuses.emplace(name, host_stat);
+    }
+    if (reason & Reason::ACTIVE) {
+      Debug("host_statuses", "for host %s set status: %s, Reason:ACTIVE", name, HostStatusNames[status]);
+      if (status == HostStatus_t::HOST_STATUS_DOWN) {
+        host_stat->active_marked_down = time(0);
+        host_stat->active_down_time   = down_time;
+        host_stat->reasons |= Reason::ACTIVE;
+      } else {
+        host_stat->active_marked_down = 0;
+        host_stat->active_down_time   = 0;
+        if (host_stat->reasons & Reason::ACTIVE) {
+          host_stat->reasons ^= Reason::ACTIVE;
+        }
+      }
+    }
+    if (reason & Reason::LOCAL) {
+      Debug("host_statuses", "for host %s set status: %s, Reason:LOCAL", name, HostStatusNames[status]);
+      if (status == HostStatus_t::HOST_STATUS_DOWN) {
+        host_stat->local_marked_down = time(0);
+        host_stat->local_down_time   = down_time;
+        host_stat->reasons |= Reason::LOCAL;
+      } else {
+        host_stat->local_marked_down = 0;
+        host_stat->local_down_time   = 0;
+        if (host_stat->reasons & Reason::LOCAL) {
+          host_stat->reasons ^= Reason::LOCAL;
+        }
+      }
+    }
+    if (reason & Reason::MANUAL) {
+      Debug("host_statuses", "for host %s set status: %s, Reason:MANUAL", name, HostStatusNames[status]);
+      if (status == HostStatus_t::HOST_STATUS_DOWN) {
+        host_stat->manual_marked_down = time(0);
+        host_stat->manual_down_time   = down_time;
+        host_stat->reasons |= Reason::MANUAL;
+      } else {
+        host_stat->manual_marked_down = 0;
+        host_stat->manual_down_time   = 0;
+        if (host_stat->reasons & Reason::MANUAL) {
+          host_stat->reasons ^= Reason::MANUAL;
+        }
+      }
+    }
+    if (reason & Reason::SELF_DETECT) {
+      Debug("host_statuses", "for host %s set status: %s, Reason:SELF_DETECT", name, HostStatusNames[status]);
+      if (status == HostStatus_t::HOST_STATUS_DOWN) {
+        host_stat->self_detect_marked_down = time(0);
+        host_stat->reasons |= Reason::SELF_DETECT;
+      } else {
+        host_stat->self_detect_marked_down = 0;
+        if (host_stat->reasons & Reason::SELF_DETECT) {
+          host_stat->reasons ^= Reason::SELF_DETECT;
+        }
+      }
+    }
+    if (status == HostStatus_t::HOST_STATUS_UP) {
+      if (host_stat->reasons == 0) {
+        host_stat->status = HostStatus_t::HOST_STATUS_UP;
+      }
+      Debug("host_statuses", "reasons: %d, status: %s", host_stat->reasons, HostStatusNames[host_stat->status]);
+    } else {
+      host_stat->status = status;
+      Debug("host_statuses", "reasons: %d, status: %s", host_stat->reasons, HostStatusNames[host_stat->status]);
+    }
   }
   ink_rwlock_unlock(&host_status_rwlock);
+
+  // update the stats
+  if (result == REC_ERR_OKAY) {
+    std::stringstream status_rec;
+    status_rec << *host_stat;
+    RecSetRecordString(stat_name.c_str(), const_cast<char *>(status_rec.str().c_str()), REC_SOURCE_EXPLICIT, true, false);
+    if (status == HostStatus_t::HOST_STATUS_UP) {
+      Debug("host_statuses", "set status up for name: %s, status: %d, stat_name: %s", name, status, stat_name.c_str());
+    } else {
+      Debug("host_statuses", "set status down for name: %s, status: %d, stat_name: %s", name, status, stat_name.c_str());
+    }
+  }
+  Debug("host_statuses", "name: %s, status: %d", name, status);
 
   // log it.
   if (status == HostStatus_t::HOST_STATUS_DOWN) {
@@ -206,65 +364,85 @@ HostStatus::setHostStatus(const char *name, HostStatus_t status, const unsigned 
 HostStatus_t
 HostStatus::getHostStatus(const char *name)
 {
-  HostStatRec_t *_status = 0;
-  time_t now             = time(0);
+  HostStatRec *_status = 0;
+  time_t now           = time(0);
+  bool lookup          = false;
 
   // the hash table value pointer has the HostStatus_t value.
   ink_rwlock_rdlock(&host_status_rwlock);
-  auto it     = hosts_statuses.find(name);
-  bool lookup = it != hosts_statuses.end();
-  if (lookup) {
-    _status = it->second;
+  {
+    auto it = hosts_statuses.find(name);
+    lookup  = it != hosts_statuses.end();
+    if (lookup) {
+      _status = it->second;
+    }
   }
   ink_rwlock_unlock(&host_status_rwlock);
 
   // if the host was marked down and it's down_time has elapsed, mark it up.
-  if (lookup && _status->status == HostStatus_t::HOST_STATUS_DOWN && _status->down_time > 0) {
-    if ((_status->down_time + _status->marked_down) < now) {
-      Debug("host_statuses", "name: %s, now: %ld, down_time: %d, marked_down: %ld", name, now, _status->down_time,
-            _status->marked_down);
-      setHostStatus(name, HostStatus_t::HOST_STATUS_UP, 0, nullptr);
+  if (lookup && _status->status == HostStatus_t::HOST_STATUS_DOWN) {
+    unsigned int reasons = _status->reasons;
+    if ((_status->reasons & Reason::ACTIVE) && _status->active_down_time > 0) {
+      if ((_status->active_down_time + _status->active_marked_down) < now) {
+        Debug("host_statuses", "name: %s, now: %ld, down_time: %d, marked_down: %ld, reason: %s", name, now,
+              _status->active_down_time, _status->active_marked_down, Reason::ACTIVE_REASON);
+        setHostStatus(name, HostStatus_t::HOST_STATUS_UP, 0, Reason::ACTIVE);
+        reasons ^= Reason::ACTIVE;
+      }
+    }
+    if ((_status->reasons & Reason::LOCAL) && _status->local_down_time > 0) {
+      if ((_status->local_down_time + _status->local_marked_down) < now) {
+        Debug("host_statuses", "name: %s, now: %ld, down_time: %d, marked_down: %ld, reason: %s", name, now,
+              _status->local_down_time, _status->local_marked_down, Reason::LOCAL_REASON);
+        setHostStatus(name, HostStatus_t::HOST_STATUS_UP, 0, Reason::LOCAL);
+        reasons ^= Reason::LOCAL;
+      }
+    }
+    if ((_status->reasons & Reason::MANUAL) && _status->manual_down_time > 0) {
+      if ((_status->manual_down_time + _status->manual_marked_down) < now) {
+        Debug("host_statuses", "name: %s, now: %ld, down_time: %d, marked_down: %ld, reason: %s", name, now,
+              _status->manual_down_time, _status->manual_marked_down, Reason::MANUAL_REASON);
+        setHostStatus(name, HostStatus_t::HOST_STATUS_UP, 0, Reason::MANUAL);
+        reasons ^= Reason::MANUAL;
+      }
+    }
+    if (reasons == 0) {
       return HostStatus_t::HOST_STATUS_UP;
+    } else {
+      return HostStatus_t::HOST_STATUS_DOWN;
     }
   }
-  return lookup ? static_cast<HostStatus_t>(_status->status) : HostStatus_t::HOST_STATUS_INIT;
+  // didn't find this host in host status db, create the record
+  if (!lookup) {
+    createHostStat(name);
+  }
+
+  return lookup ? static_cast<HostStatus_t>(_status->status) : HostStatus_t::HOST_STATUS_UP;
 }
 
 void
-HostStatus::createHostStat(const char *name)
+HostStatus::createHostStat(const char *name, const char *data)
 {
-  ink_rwlock_wrlock(&host_statids_rwlock);
-  {
-    for (const char *i : Reasons::reasons) {
-      std::string reason_stat;
-      getStatName(reason_stat, name, i);
-      if (hosts_stats_ids.find(reason_stat) == hosts_stats_ids.end()) {
-        RecRegisterRawStat(host_status_rsb, RECT_PROCESS, (reason_stat).c_str(), RECD_INT, RECP_PERSISTENT, (int)next_stat_id,
-                           RecRawStatSyncSum);
-        RecSetRawStatCount(host_status_rsb, next_stat_id, 1);
-        RecSetRawStatSum(host_status_rsb, next_stat_id, 1);
+  char buf[1024] = {0};
+  HostStatRec r;
 
-        hosts_stats_ids.emplace(reason_stat, next_stat_id);
-
-        Debug("host_statuses", "stat name: %s, id: %d", reason_stat.c_str(), next_stat_id);
-        next_stat_id++;
-      }
-    }
+  std::string stat_name;
+  std::stringstream status_rec;
+  if (data != nullptr) {
+    HostStatRec h(data);
+    r = h;
   }
-  ink_rwlock_unlock(&host_statids_rwlock);
+  status_rec << r;
+  getStatName(stat_name, name);
+
+  if (getHostStat(stat_name, buf, 1024) == REC_ERR_FAIL) {
+    RecRegisterStatString(RECT_PROCESS, stat_name.c_str(), const_cast<char *>(status_rec.str().c_str()), RECP_PERSISTENT);
+    Debug("host_statuses", "stat name: %s, data: %s", stat_name.c_str(), status_rec.str().c_str());
+  }
 }
 
-int
-HostStatus::getHostStatId(const char *stat_name)
+RecErrT
+HostStatus::getHostStat(std::string &stat_name, char *buf, unsigned int buf_len)
 {
-  int _id = -1;
-
-  ink_rwlock_rdlock(&host_statids_rwlock);
-  if (auto it = hosts_stats_ids.find(stat_name); it != hosts_stats_ids.end()) {
-    _id = it->second;
-  }
-  ink_rwlock_unlock(&host_statids_rwlock);
-  Debug("host_statuses", "name: %s, id: %d", stat_name, static_cast<int>(_id));
-
-  return _id;
+  return RecGetRecordString(stat_name.c_str(), buf, buf_len, true);
 }


### PR DESCRIPTION
This PR refactors the HostStatus module so that only one stat is created per host.  The single stat is now a string value rather than an int value.  The string value is a serialized copy of the HostStatRec struct containing all the reason codes, down times, and marked down times.  When ATS is restarted, the stat data is read from records.snap, deserialized and loaded so that each host status state is recreated from the persistent record.

Because of the stat type change from int to string, it may be required that you remove the records.snap file on a build with this commit.