### PR TITLE
Avoid Http2Stream use after free

### DIFF
--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -245,7 +245,7 @@ public:
   // HTTP/2 frame sender
   void schedule_stream(Http2Stream *stream);
   void send_data_frames_depends_on_priority();
-  void send_data_frames(Http2Stream *stream);
+  bool send_data_frames(Http2Stream *stream);
   Http2SendDataFrameResult send_a_data_frame(Http2Stream *stream, size_t &payload_length);
   void send_headers_frame(Http2Stream *stream);
   void send_push_promise_frame(Http2Stream *stream, URL &url, const MIMEField *accept_encoding);


### PR DESCRIPTION
We have been seeing a few cores with the following trace.
```
[ 00 ] traffic_server      max_read_avail                                                     ( P_IOBuffer.h:1057 )
[ 01 ] traffic_server      high_water                                                         ( I_IOBuffer.h:1008 )
[ 02 ] traffic_server      check_add_block                                                    ( P_IOBuffer.h:974 )
[ 03 ] traffic_server      write_avail                                                        ( P_IOBuffer.h:1018 )
[ 04 ] traffic_server      Http2Stream::restart_sending()                                     ( Http2Stream.cc:521 )
[ 05 ] traffic_server      Http2ConnectionState::restart_streams()                            ( Http2ConnectionState.cc:1165 )
[ 06 ] traffic_server      rcv_window_update_frame(Http2ConnectionState&, Http2Frame const&)  ( Http2ConnectionState.cc:728 )
[ 07 ] traffic_server      Http2ConnectionState::main_event_handler(int, void*)               ( Http2ConnectionState.cc:948 )
[ 08 ] traffic_server      send_connection_event(Continuation*, int, void*)                   ( I_Continuation.h:182 )
[ 09 ] traffic_server      Http2ClientSession::do_complete_frame_read()                       ( Http2ClientSession.cc:514 )
[ 10 ] traffic_server      Http2ClientSession::state_process_frame_read(int, VIO*, bool)      ( Http2ClientSession.cc:551 )
[ 11 ] traffic_server      Http2ClientSession::state_start_frame_read(int, void*)             ( Http2ClientSession.cc:444 )
[ 12 ] traffic_server      Http2ClientSession::main_event_handler(int, void*)                 ( Http2ClientSession.cc:330 )
[ 13 ] traffic_server      handleEvent                                                        ( I_Continuation.h:182 )
[ 14 ] traffic_server      read_signal_and_update                                             ( UnixNetVConnection.cc:144 )
[ 15 ] traffic_server      UnixNetVConnection::readSignalAndUpdate(int)                       ( UnixNetVConnection.cc:1103 )
[ 16 ] traffic_server      SSLNetVConnection::net_read_io(NetHandler*, EThread*)              ( SSLNetVConnection.cc:618 )
[ 17 ] traffic_server      NetHandler::waitForActivity(long)                                  ( UnixNet.cc:497 )
[ 18 ] traffic_server      EThread::execute_regular()                                         ( UnixEThread.cc:278 )
[ 19 ] traffic_server      spawn_thread_internal                                              ( Thread.cc:85 )
[ 20 ] libpthread-2.17.so  start_thread                                                       
```

The stream object at the top of the stack has been clearly freed and the memory reused.   We are running with the ATS free list turned off.  At first I thought some thread in parallel was deleting the stream and removing it from the Http2ConnectionState stream_list.  But looking at the code more closely, Http2Stream::restart_sending calls Http2Stream::send_response_body which calls Http2ConnectionState::send_data_frames.  send_data_frames may delete the stream, so calling any methods on the stream object after calling send_data_frames is a very bad idea.

This PR adds an argument to Http2Connection::send_data_frames so the caller can avoid any use of the stream object if it has been freed.  We are in the process of testing this patch internally.

Our code is slightly different than what is on master at the moment, so the master could would not show the write_avail failure, instead it would show the problem through calling signal_write_event on the deleted stream object.
