### PR TITLE
Check nullptr before call netvc->do_io_close in SSLNextProtocolAccept::mainEvent

### DIFF
--- a/iocore/net/SSLNextProtocolAccept.cc
+++ b/iocore/net/SSLNextProtocolAccept.cc
@@ -139,7 +139,9 @@ SSLNextProtocolAccept::mainEvent(int event, void *edata)
     netvc->do_io_read(new SSLNextProtocolTrampoline(this, netvc->mutex), 0, this->buffer);
     return EVENT_CONT;
   default:
-    netvc->do_io_close();
+    if (netvc) {
+      netvc->do_io_close();
+    }
     return EVENT_DONE;
   }
 }


### PR DESCRIPTION
```
SSLNetVConnection *netvc = ssl_netvc_cast(event, edata);
```

netvc could be nullptr. So we need to check nullptr to avoid crash.