### PR TITLE
Fix ContFlags for gcc 9.

### DIFF
--- a/include/tscore/ContFlags.h
+++ b/include/tscore/ContFlags.h
@@ -42,6 +42,7 @@ public:
   enum flags { DEBUG_OVERRIDE = 0, DISABLE_PLUGINS = 1, LAST_FLAG };
 
   ContFlags() {}
+  ContFlags(ContFlags const &that) = default;
   ContFlags(uint32_t in_flags) : raw_flags(in_flags) {}
   void
   set_flags(uint32_t new_flags)


### PR DESCRIPTION
This fixes the gcc9 related compiler errors in "ContFlag.h".