### PR TITLE
gcc9 - fix CryptoHash.h

### DIFF
--- a/include/tscore/CryptoHash.h
+++ b/include/tscore/CryptoHash.h
@@ -45,6 +45,8 @@ union CryptoHash {
 
   /// Default constructor - init to zero.
   CryptoHash() { memset(this, 0, sizeof(*this)); }
+  /// Copy constructor.
+  CryptoHash(CryptoHash const &that) = default;
 
   /// Assignment - bitwise copy.
   CryptoHash &


### PR DESCRIPTION
This is simple - just need to explicitly declare the copy constructor.