### PR TITLE
gcc9 - Fix Errata.h, NumericType.h.

### DIFF
--- a/lib/tsconfig/Errata.h
+++ b/lib/tsconfig/Errata.h
@@ -378,7 +378,7 @@ struct Errata::Message {
 
   /// Default constructor.
   /// The message has Id = 0, default code,  and empty text.
-  Message();
+  Message() = default;
 
   /// Construct from text.
   /// Id is zero and Code is default.
@@ -482,8 +482,8 @@ struct Errata::Message {
 
   template < typename ... Args> static std::string stringify(Args const& ... items);
 
-  Id m_id; ///< Message ID.
-  Code m_code; ///< Message code.
+  Id m_id = 0; ///< Message ID.
+  Code m_code = Default_Code; ///< Message code.
   std::string m_text; ///< Final text.
   Errata m_errata; ///< Nested errata.
 };
@@ -749,17 +749,14 @@ MakeRv(
 /* ----------------------------------------------------------------------- */
 /* ----------------------------------------------------------------------- */
 // Inline methods.
-inline Errata::Message::Message()
-  : m_id(0), m_code(Default_Code) {
-}
 inline Errata::Message::Message(std::string const& text)
-  : m_id(0), m_code(Default_Code), m_text(text) {
+  : m_text(text) {
 }
 inline Errata::Message::Message(Id id, std::string const& text)
-  : m_id(id), m_code(Default_Code), m_text(text) {
+  : m_text(text) {
 }
 inline Errata::Message::Message(Id id, Code code, std::string const& text)
-  : m_id(id), m_code(code), m_text(text) {
+  : m_text(text) {
 }
 template < typename ... Args>
 Errata::Message::Message(Id id, Code code, Args const& ... text)

--- a/lib/tsconfig/NumericType.h
+++ b/lib/tsconfig/NumericType.h
@@ -1,6 +1,3 @@
-# if !defined(TS_NUMERIC_TYPE_HEADER)
-# define TS_NUMERIC_TYPE_HEADER
-
 /** @file
 
     Create a distinct type from a builtin numeric type.
@@ -41,12 +38,14 @@
     limitations under the License.
  */
 
-# include <limits>
+#pragma once
 
-namespace ts {
+#include <limits>
 
+namespace ts
+{
 // Forward declare.
-template < typename T, typename X > class NumericType;
+template <typename T, typename X> class NumericType;
 
 /// @cond NOT_DOCUMENTED
 /** Support template for resolving operator ambiguity.
@@ -65,26 +64,25 @@ template < typename T, typename X > class NumericType;
     @internal Note that we don't have to provide an actual implementation
     for these operators. Funky, isn't it?
 */
-template <
-  typename T, ///< Base numeric type.
-  typename X ///< Distinguishing tag type.
-> class NumericTypeIntOperators {
+template <typename T, ///< Base numeric type.
+          typename X  ///< Distinguishing tag type.
+          >
+class NumericTypeIntOperators
+{
 public:
-    NumericType<T,X>& operator += ( int t );
-    NumericType<T,X>& operator -= ( int t );
+  NumericType<T, X> &operator+=(int t);
+  NumericType<T, X> &operator-=(int t);
 
-    // Must have const and non-const versions.
-    NumericType<T,X> operator +  ( int t );
-    NumericType<T,X> operator -  ( int t );
-    NumericType<T,X> operator +  ( int t ) const;
-    NumericType<T,X> operator -  ( int t ) const;
+  // Must have const and non-const versions.
+  NumericType<T, X> operator+(int t);
+  NumericType<T, X> operator-(int t);
+  NumericType<T, X> operator+(int t) const;
+  NumericType<T, X> operator-(int t) const;
 };
 
-template < typename T, typename X > NumericType<T,X>
-operator + ( int t, NumericTypeIntOperators<T,X> const& );
+template <typename T, typename X> NumericType<T, X> operator+(int t, NumericTypeIntOperators<T, X> const &);
 
-template < typename T, typename X > NumericType<T,X>
-operator - ( int t, NumericTypeIntOperators<T,X> const& );
+template <typename T, typename X> NumericType<T, X> operator-(int t, NumericTypeIntOperators<T, X> const &);
 
 /// @endcond
 
@@ -93,91 +91,189 @@ operator - ( int t, NumericTypeIntOperators<T,X> const& );
     @internal One issue is that this is not a POD and so doesn't work
     with @c printf. I will need to investigate what that would take.
  */
-template <
-  typename T, ///< Base numeric type.
-  typename X ///< Distinguishing tag type.
-> class NumericType : public NumericTypeIntOperators<T,X> {
+template <typename T, ///< Base numeric type.
+          typename X  ///< Distinguishing tag type.
+          >
+class NumericType : public NumericTypeIntOperators<T, X>
+{
 public:
-    typedef T raw_type; //!< Base builtin type.
-    typedef NumericType self; //!< Self reference type.
+  using raw_type  = T;           ///< Base type.
+  using self_type = NumericType; ///< Self reference type.
 
-    /// @cond NOT_DOCUMENTED
-    // Need to import these to avoid compiler problems.
-    using NumericTypeIntOperators<T,X>::operator +=;
-    using NumericTypeIntOperators<T,X>::operator -=;
-    using NumericTypeIntOperators<T,X>::operator +;
-    using NumericTypeIntOperators<T,X>::operator -;
-    /// @endcond
+  /// @cond NOT_DOCUMENTED
+  // Need to import these to avoid compiler problems.
+  using NumericTypeIntOperators<T, X>::operator+=;
+  using NumericTypeIntOperators<T, X>::operator-=;
+  using NumericTypeIntOperators<T, X>::operator+;
+  using NumericTypeIntOperators<T, X>::operator-;
+  /// @endcond
 
-    /// Default constructor, uninitialized.
-    NumericType();
-    //! Construct from implementation type.
-    NumericType(
-      raw_type const t ///< Initialized value.
-    );
-    //! Assignment from implementation type.
-    NumericType & operator = (raw_type const t);
-    //! Self assignment.
-    NumericType & operator = (self const& that);
+  /// Default constructor, uninitialized.
+  NumericType();
+  //! Construct from implementation type.
+  constexpr NumericType(raw_type const t ///< Initialized value.
+  );
+  /// Copy constructor.
+  constexpr NumericType(self_type const &that) = default;
 
-    /// User conversion to implementation type.
-    /// @internal If we have just a single const method conversion to a copy
-    /// of the @c raw_type then the stream operators don't work. Only a CR
-    /// conversion operator satisifies the argument matching.
-    operator raw_type const& () const { return _t; }
-    /// User conversion to implementation type.
-    operator raw_type& () { return _t; }
-    /// Explicit conversion to host type
-    raw_type raw() const { return _t; }
+  //! Assignment from implementation type.
+  NumericType &operator=(raw_type const t);
+  //! Self assignment.
+  NumericType &operator=(self_type const &that);
 
-    // User conversions to raw type provide the standard comparison operators.
-    self& operator += ( self const& that );
-    self& operator -= ( self const& that );
+  /// User conversion to implementation type.
+  /// @internal If we have just a single const method conversion to a copy
+  /// of the @c raw_type then the stream operators don't work. Only a CR
+  /// conversion operator satisifies the argument matching.
+  operator raw_type const &() const { return _t; }
+  /// User conversion to implementation type.
+  operator raw_type &() { return _t; }
+  /// Explicit conversion to host type
+  raw_type
+  raw() const
+  {
+    return _t;
+  }
 
-    self& operator += ( raw_type t );
-    self& operator -= ( raw_type t );
+  // User conversions to raw type provide the standard comparison operators.
+  self_type &operator+=(self_type const &that);
+  self_type &operator-=(self_type const &that);
 
-    self operator +  ( self const& that );
-    self operator -  ( self const& that );
+  self_type &operator+=(raw_type t);
+  self_type &operator-=(raw_type t);
 
-    self operator +  ( raw_type t );
-    self operator -  ( raw_type t );
+  self_type operator+(self_type const &that);
+  self_type operator-(self_type const &that);
 
-    self& operator ++();
-    self operator ++(int);
-    self& operator --();
-    self operator --(int);
+  self_type operator+(raw_type t);
+  self_type operator-(raw_type t);
+
+  self_type &operator++();
+  self_type operator++(int);
+  self_type &operator--();
+  self_type operator--(int);
 
 private:
-    raw_type   _t;
+  raw_type _t;
 };
 
 // Method definitions.
 // coverity[uninit_ctor]
-template < typename T, typename X > NumericType<T,X>::NumericType() { }
-template < typename T, typename X > NumericType<T,X>::NumericType(raw_type const t) : _t(t) { }
-template < typename T, typename X > NumericType<T,X>& NumericType<T,X>::operator = (raw_type const t) { _t = t; return *this; }
-template < typename T, typename X > NumericType<T,X>& NumericType<T,X>::operator = (self const& that) { _t = that._t; return *this; }
+template <typename T, typename X> NumericType<T, X>::NumericType() {}
+template <typename T, typename X> constexpr NumericType<T, X>::NumericType(raw_type const t) : _t(t) {}
+template <typename T, typename X>
+NumericType<T, X> &
+NumericType<T, X>::operator=(raw_type const t)
+{
+  _t = t;
+  return *this;
+}
+template <typename T, typename X>
+NumericType<T, X> &
+NumericType<T, X>::operator=(self_type const &that)
+{
+  _t = that._t;
+  return *this;
+}
 
-template < typename T, typename X > NumericType<T,X>& NumericType<T,X>::operator += ( self const& that ) { _t += that._t; return *this; }
-template < typename T, typename X > NumericType<T,X>& NumericType<T,X>::operator -= ( self const& that ) { _t -= that._t; return *this; }
-template < typename T, typename X > NumericType<T,X> NumericType<T,X>::operator +  ( self const& that ) { return self(_t + that._t); }
-template < typename T, typename X > NumericType<T,X> NumericType<T,X>::operator -  ( self const& that ) { return self(_t - that._t); }
+template <typename T, typename X>
+NumericType<T, X> &
+NumericType<T, X>::operator+=(self_type const &that)
+{
+  _t += that._t;
+  return *this;
+}
+template <typename T, typename X>
+NumericType<T, X> &
+NumericType<T, X>::operator-=(self_type const &that)
+{
+  _t -= that._t;
+  return *this;
+}
+template <typename T, typename X>
+NumericType<T, X>
+NumericType<T, X>::operator+(self_type const &that)
+{
+  return self_type(_t + that._t);
+}
+template <typename T, typename X>
+NumericType<T, X>
+NumericType<T, X>::operator-(self_type const &that)
+{
+  return self_type(_t - that._t);
+}
 
-template < typename T, typename X > NumericType<T,X>& NumericType<T,X>::operator += ( raw_type t ) { _t += t; return *this; }
-template < typename T, typename X > NumericType<T,X>& NumericType<T,X>::operator -= ( raw_type t ) { _t -= t; return *this; }
-template < typename T, typename X > NumericType<T,X> NumericType<T,X>::operator +  ( raw_type t ) { return self(_t + t); }
-template < typename T, typename X > NumericType<T,X> NumericType<T,X>::operator -  ( raw_type t ) { return self(_t - t); }
+template <typename T, typename X>
+NumericType<T, X> &
+NumericType<T, X>::operator+=(raw_type t)
+{
+  _t += t;
+  return *this;
+}
+template <typename T, typename X>
+NumericType<T, X> &
+NumericType<T, X>::operator-=(raw_type t)
+{
+  _t -= t;
+  return *this;
+}
+template <typename T, typename X>
+NumericType<T, X>
+NumericType<T, X>::operator+(raw_type t)
+{
+  return self_type(_t + t);
+}
+template <typename T, typename X>
+NumericType<T, X>
+NumericType<T, X>::operator-(raw_type t)
+{
+  return self_type(_t - t);
+}
 
-template < typename T, typename X > NumericType<T,X>& NumericType<T,X>::operator ++() { ++_t; return *this; }
-template < typename T, typename X > NumericType<T,X>& NumericType<T,X>::operator --() { --_t; return *this; }
-template < typename T, typename X > NumericType<T,X> NumericType<T,X>::operator ++(int) { self tmp(*this); ++_t; return tmp; }
-template < typename T, typename X > NumericType<T,X> NumericType<T,X>::operator --(int) { self tmp(*this); --_t; return tmp; }
+template <typename T, typename X>
+NumericType<T, X> &
+NumericType<T, X>::operator++()
+{
+  ++_t;
+  return *this;
+}
+template <typename T, typename X>
+NumericType<T, X> &
+NumericType<T, X>::operator--()
+{
+  --_t;
+  return *this;
+}
+template <typename T, typename X>
+NumericType<T, X>
+NumericType<T, X>::operator++(int)
+{
+  self_type tmp(*this);
+  ++_t;
+  return tmp;
+}
+template <typename T, typename X>
+NumericType<T, X>
+NumericType<T, X>::operator--(int)
+{
+  self_type tmp(*this);
+  --_t;
+  return tmp;
+}
 
-template < typename T, typename X > NumericType<T,X> operator +  ( T const& lhs, NumericType<T,X> const& rhs ) { return rhs + lhs; }
-template < typename T, typename X > NumericType<T,X> operator -  ( T const& lhs, NumericType<T,X> const& rhs ) { return NumericType<T,X>(lhs - rhs.raw()); }
+template <typename T, typename X>
+NumericType<T, X>
+operator+(T const &lhs, NumericType<T, X> const &rhs)
+{
+  return rhs + lhs;
+}
+template <typename T, typename X>
+NumericType<T, X>
+operator-(T const &lhs, NumericType<T, X> const &rhs)
+{
+  return NumericType<T, X>(lhs - rhs.raw());
+}
 
 /* ----------------------------------------------------------------------- */
-} /* end namespace ts */
+} // namespace ts
 /* ----------------------------------------------------------------------- */
-# endif // TS_NUMERIC_TYPE_HEADER


### PR DESCRIPTION
*  Fix gcc9 compile issues in Errata.h, NumericType.h
*  Clean up formatting in NumericType.h with clang-format.
*  Update NumericType.h to use `self_type` instead of `self.