### PR TITLE
Additional places to propagate the per-client-ip debug tags.

### DIFF
--- a/iocore/eventsystem/P_UnixEThread.h
+++ b/iocore/eventsystem/P_UnixEThread.h
@@ -95,6 +95,11 @@ EThread::schedule(Event *e, bool fast_signal)
     e->mutex = e->continuation->mutex = e->ethread->mutex;
   }
   ink_assert(e->mutex.get());
+
+  // Make sure client IP debugging works consistently
+  // The continuation that gets scheduled later is not always the
+  // client VC, it can be HttpCacheSM etc. so save the flags
+  e->continuation->control_flags.set_flags(get_cont_flags().get_flags());
   EventQueueExternal.enqueue(e, fast_signal);
   return e;
 }
@@ -153,6 +158,11 @@ EThread::schedule_local(Event *e)
     ink_assert(e->ethread == this);
   }
   e->globally_allocated = false;
+
+  // Make sure client IP debugging works consistently
+  // The continuation that gets scheduled later is not always the
+  // client VC, it can be HttpCacheSM etc. so save the flags
+  e->continuation->control_flags.set_flags(get_cont_flags().get_flags());
   EventQueueExternal.enqueue_local(e);
   return e;
 }

--- a/iocore/eventsystem/UnixEThread.cc
+++ b/iocore/eventsystem/UnixEThread.cc
@@ -129,6 +129,10 @@ EThread::process_event(Event *e, int calling_code)
     }
     Continuation *c_temp = e->continuation;
     // Make sure that the continuation is locked before calling the handler
+
+    // Restore the client IP debugging flags
+    set_cont_flags(e->continuation->control_flags);
+
     e->continuation->handleEvent(calling_code, e);
     ink_assert(!e->in_the_priority_queue);
     ink_assert(c_temp == e->continuation);


### PR DESCRIPTION
Fixes created by @pushkarpradhan to propagate the per-client-ip tag across more of the State Machine transitions.