### PR TITLE
Add wait_for_cache to make all_headers test more resilient

### DIFF
--- a/tests/gold_tests/logging/all_headers.test.py
+++ b/tests/gold_tests/logging/all_headers.test.py
@@ -43,6 +43,7 @@ response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\nCache-con
 server.addResponse("sessionlog.json", request_header, response_header)
 
 ts.Disk.records_config.update({
+    'proxy.config.http.wait_for_cache': 1,
     'proxy.config.diags.debug.enabled': 0,
     'proxy.config.diags.debug.tags': 'http|dns',
 })


### PR DESCRIPTION
@SolidWallOfCode mentioned that adding proxy.config.http.wait_for_cache might help the test failure case described in issue #5437.

On my local runs I don't have problems with the second case not serving from cache.  However, about 50% of the time, the first log entry fails to match because the Cache-Control and Connection headers have swapped places.  We should perform a position independent header comparison to fix that.