### PR TITLE
Fixed nullptr check in cookie remap

### DIFF
--- a/plugins/experimental/cookie_remap/strip.cc
+++ b/plugins/experimental/cookie_remap/strip.cc
@@ -48,7 +48,7 @@ room(const char *p, const int len, const char *maxp)
 static void
 write_char_if_room(char **p, const char *maxp, const char c)
 {
-  if (p == nullptr || *p != nullptr) {
+  if (p == nullptr || *p == nullptr) {
     return;
   }
 
@@ -64,7 +64,7 @@ write_char_if_room(char **p, const char *maxp, const char c)
 static void
 write_spaces_if_room(char **p, const char *maxp, int &slen)
 {
-  if (p == nullptr || *p != nullptr) {
+  if (p == nullptr || *p == nullptr) {
     return;
   }
 


### PR DESCRIPTION
Bug was introduced with 37661eb4bd512a1ba7278979140d963dd864cd7c - my bad

It is breaking the builds:
```
../../plugins/experimental/cookie_remap/strip.cc:72:11: error: argument 1 null where non-null expected [-Werror=nonnull]
     memset(*p, ' ', slen);
     ~~~~~~^~~~~~~~~~~~~~~
In file included from ../../plugins/experimental/cookie_remap/strip.cc:20:0:
/usr/include/string.h:60:14: note: in a call to function 'void* memset(void*, int, size_t)' declared here
 extern void *memset (void *__s, int __c, size_t __n) __THROW __nonnull ((1));
              ^~~~~~
../../plugins/experimental/cookie_remap/strip.cc:72:11: error: argument 1 null where non-null expected [-Werror=nonnull]
     memset(*p, ' ', slen);
     ~~~~~~^~~~~~~~~~~~~~~
In file included from ../../plugins/experimental/cookie_remap/strip.cc:20:0:
/usr/include/string.h:60:14: note: in a call to function 'void* memset(void*, int, size_t)' declared here
 extern void *memset (void *__s, int __c, size_t __n) __THROW __nonnull ((1));
              ^~~~~~
```