### PR TITLE
Fixed syntax issue with clang

### DIFF
--- a/plugins/experimental/ssl_session_reuse/src/ats_ssl_plugin.cc
+++ b/plugins/experimental/ssl_session_reuse/src/ats_ssl_plugin.cc
@@ -36,7 +36,7 @@ int SSL_session_callback(TSCont contp, TSEvent event, void *edata);
 static int
 shutdown_handler(TSCont contp, TSEvent event, void *edata)
 {
-  if ((event == TS_EVENT_LIFECYCLE_SHUTDOWN)) {
+  if (event == TS_EVENT_LIFECYCLE_SHUTDOWN) {
     plugin_threads.terminate();
   }
   return 0;


### PR DESCRIPTION
This commit caused the problem: 841b9c699a779cc5528c6861aacf29f229f290db

It is breaking the build for clang on Fedora and Ubuntu:

```
../../plugins/experimental/ssl_session_reuse/src/ats_ssl_plugin.cc:39:14: error: equality comparison with extraneous parentheses [-Werror,-Wparentheses-equality]
  if ((event == TS_EVENT_LIFECYCLE_SHUTDOWN)) {
       ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```