### PR TITLE
Convert ssl_preaccept plugin to use command-line arguments

### DIFF
--- a/example/ssl_preaccept/ssl_preaccept.config
+++ b/example/ssl_preaccept/ssl_preaccept.config
@@ -1,7 +1,0 @@
-
-// SSL traffic initiating from these addresses should
-// be placed into a blind tunnel.  ATS should not inspect
-// the tunnel
-client-blind-tunnel = "192.168.56.145"
-
-//client-blind-tunnel = "192.168.56.0/24"


### PR DESCRIPTION
Drops use of TSConfig. Not converted to YAML since this is a single
parameter example plugin.