### PR TITLE
gcc9: fixed issue with always printing a null char*

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -7811,7 +7811,7 @@ HttpSM::redirect_request(const char *arg_redirect_url, const int arg_redirect_le
 
       if (redirectScheme == nullptr) {
         clientUrl.scheme_set(scheme_str, scheme_len);
-        SMDebug("http_redirect", "[HttpSM::redirect_request] URL without scheme %.*s", redirectSchemeLen, redirectScheme);
+        SMDebug("http_redirect", "[HttpSM::redirect_request] URL without scheme");
       }
 
       if (noPortInHost) {


### PR DESCRIPTION
This is breaking the gcc9 build.
This issue was created with this commit: 9e8800c5f648e4902c522087e88d9ea806a1de4f