### PR TITLE
clang-analyzer: Fixed err value being uninitialized

### DIFF
--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -534,7 +534,7 @@ SSLNetVConnection::net_read_io(NetHandler *nh, EThread *lthread)
 
   // Continue on if we are still in the handshake
   if (!getSSLHandShakeComplete()) {
-    int err;
+    int err = 0;
 
     if (get_context() == NET_VCONNECTION_OUT) {
       ret = sslStartHandShake(SSL_EVENT_CLIENT, err);


### PR DESCRIPTION
I believe this is the correct value to initialize it to.