### PR TITLE
gcc9: Added default assignment operator

### DIFF
--- a/proxy/HostStatus.h
+++ b/proxy/HostStatus.h
@@ -125,6 +125,8 @@ struct HostStatRec {
   }
   ~HostStatRec() {}
 
+  HostStatRec &operator=(const HostStatRec &source) = default;
+
   // serialize this HostStatusRec
   std::stringstream &
   operator<<(std::stringstream &os)


### PR DESCRIPTION
The Fedora 30 build is breaking with:
```
../../src/traffic_server/HostStatus.cc:242:20: error: implicitly-declared 'constexpr HostStatRec& HostStatRec::operator=(const HostStatRec&)' is deprecated [-Werror=deprecated-copy]
  242 |       *host_stat = h;
      |                    ^
In file included from ../../src/traffic_server/HostStatus.cc:23:
/var/jenkins/workspace/fedora_30-master/compiler/gcc/label/fedora_30/type/release/11/build/BUILDS/../proxy/HostStatus.h:114:3: note: because 'HostStatRec' has user-provided 'HostStatRec::HostStatRec(const HostStatRec&)'
  114 |   HostStatRec(const HostStatRec &src)
      |   ^~~~~~~~~~~
```

Building here on Fedora 30: https://ci.trafficserver.apache.org/view/github/job/any-github/47/console