### PR TITLE
Don't read frames after sending GOAWAY with an error code

### DIFF
--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -510,6 +510,11 @@ Http2ClientSession::state_process_frame_read(int event, VIO *vio, bool inside_fr
   }
 
   while (this->sm_reader->read_avail() >= (int64_t)HTTP2_FRAME_HEADER_LEN) {
+    // Cancel reading if there was an error
+    if (connection_state.tx_error_code.code != static_cast<uint32_t>(Http2ErrorCode::HTTP2_ERROR_NO_ERROR)) {
+      Http2SsnDebug("reading a frame has been canceled (%u)", connection_state.tx_error_code.code);
+      break;
+    }
     // Return if there was an error
     Http2ErrorCode err;
     if (do_start_frame_read(err) < 0) {


### PR DESCRIPTION
(cherry picked from commit 00237a141cdb6d9f2268080f03cb5f58ee32c7ec)

https://github.com/apache/trafficserver/pull/5289