### PR TITLE
Don't read frames after sending GOAWAY with an error code

### DIFF
--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -37,6 +37,21 @@
 class ProxyClientTransaction;
 struct AclRecord;
 
+enum class ProxyErrorClass {
+  NONE,
+  SSN,
+  TXN,
+};
+
+struct ProxyError {
+  ProxyError() {}
+  ProxyError(ProxyErrorClass cl, uint32_t co) : cls(cl), code(co) {}
+  size_t str(char *buf, size_t buf_len);
+
+  ProxyErrorClass cls = ProxyErrorClass::NONE;
+  uint32_t code       = 0;
+};
+
 class ProxyClientSession : public VConnection
 {
 public:

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -499,6 +499,11 @@ Http2ClientSession::state_process_frame_read(int event, VIO *vio, bool inside_fr
   }
 
   while (this->sm_reader->read_avail() >= (int64_t)HTTP2_FRAME_HEADER_LEN) {
+    // Cancel reading if there was an error
+    if (connection_state.tx_error_code.code != static_cast<uint32_t>(Http2ErrorCode::HTTP2_ERROR_NO_ERROR)) {
+      DebugHttp2Ssn("reading a frame has been canceled (%u)", connection_state.tx_error_code.code);
+      break;
+    }
     // Return if there was an error
     Http2ErrorCode err;
     if (do_start_frame_read(err) < 0) {

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -636,6 +636,7 @@ rcv_goaway_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
   Http2StreamDebug(cstate.ua_session, stream_id, "GOAWAY: last stream id=%d, error code=%d", goaway.last_streamid,
                    static_cast<int>(goaway.error_code));
 
+  cstate.rx_error_code = {ProxyErrorClass::SSN, static_cast<uint32_t>(goaway.error_code)};
   cstate.handleEvent(HTTP2_SESSION_EVENT_FINI, nullptr);
   // eventProcessor.schedule_imm(&cs, ET_NET, VC_EVENT_ERROR);
 
@@ -1723,6 +1724,8 @@ Http2ConnectionState::send_goaway_frame(Http2StreamId id, Http2ErrorCode ec)
   frame.alloc(buffer_size_index[HTTP2_FRAME_TYPE_GOAWAY]);
   http2_write_goaway(goaway, frame.write());
   frame.finalize(HTTP2_GOAWAY_LEN);
+
+  this->tx_error_code = {ProxyErrorClass::SSN, static_cast<uint32_t>(ec)};
 
   // xmit event
   SCOPED_MUTEX_LOCK(lock, this->ua_session->mutex, this_ethread());

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -132,6 +132,8 @@ public:
     SET_HANDLER(&Http2ConnectionState::main_event_handler);
   }
 
+  ProxyError rx_error_code;
+  ProxyError tx_error_code;
   Http2ClientSession *ua_session;
   HpackHandle *local_hpack_handle;
   HpackHandle *remote_hpack_handle;


### PR DESCRIPTION
(cherry picked from commit 00237a141cdb6d9f2268080f03cb5f58ee32c7ec)

https://github.com/apache/trafficserver/pull/5289