### PR TITLE
gcc9: set default value for printing debug message

### DIFF
--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -837,7 +837,7 @@ ConditionNow::eval(const Resources &res)
 const char *
 ConditionGeo::get_geo_string(const sockaddr *addr) const
 {
-  const char *ret = nullptr;
+  const char *ret = "(unknown)";
   int v           = 4;
 
   if (addr) {


### PR DESCRIPTION
Failing on the Fedora 30 gcc9 build:
```
../../plugins/header_rewrite/conditions.cc: In member function 'const char* ConditionGeo::get_geo_string(const sockaddr*) const':
../../plugins/header_rewrite/conditions.cc:866:14: error: '%s' directive argument is null [-Werror=format-overflow=]
  866 |       TSDebug(PLUGIN_NAME, "eval(): Client IPv%d seems to come from Country: %s", v, ret);
      |       ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../plugins/header_rewrite/conditions.cc:866:14: error: '%s' directive argument is null [-Werror=format-overflow=]
../../plugins/header_rewrite/conditions.cc:890:14: error: '%s' directive argument is null [-Werror=format-overflow=]
  890 |       TSDebug(PLUGIN_NAME, "eval(): Client IPv%d seems to come from ASN Name: %s", v, ret);
      |       ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../plugins/header_rewrite/conditions.cc:890:14: error: '%s' directive argument is null [-Werror=format-overflow=]
```