### PR TITLE
gcc9: sprintf and strncat fixes in plugins

### DIFF
--- a/example/thread_pool/psi.c
+++ b/example/thread_pool/psi.c
@@ -465,7 +465,7 @@ psi_include(TSCont contp, void *edata ATS_UNUSED)
   /* For security reason, we do not allow to include files that are
      not in the directory <plugin_path>/include.
      Also include file cannot contain any path. */
-  sprintf(inc_file, "%s/%s", psi_directory, _basename(data->psi_filename));
+  snprintf(inc_file, sizeof(inc_file), "%s/%s", psi_directory, _basename(data->psi_filename));
 
   /* Read the include file and copy content into iobuffer */
   if ((filep = TSfopen(inc_file, "r")) != NULL) {
@@ -963,7 +963,7 @@ TSPluginInit(int argc ATS_UNUSED, const char *argv[] ATS_UNUSED)
   }
 
   /* Initialize the psi directory = <plugin_path>/include */
-  sprintf(psi_directory, "%s/%s", TSPluginDirGet(), PSI_PATH);
+  snprintf(psi_directory, sizeof(psi_directory), "%s/%s", TSPluginDirGet(), PSI_PATH);
 
   /* create an TSTextLogObject to log any psi include */
   retval = TSTextLogObjectCreate("psi", TS_LOG_MODE_ADD_TIMESTAMP, &log);

--- a/plugins/s3_auth/s3_auth.cc
+++ b/plugins/s3_auth/s3_auth.cc
@@ -652,10 +652,10 @@ S3Request::set_header(const char *header, int header_len, const char *val, int v
 static size_t
 str_concat(char *dst, size_t dst_len, const char *src, size_t src_len)
 {
-  size_t to_copy = (src_len < dst_len) ? src_len : dst_len;
+  size_t to_copy = std::min(dst_len, src_len);
 
   if (to_copy > 0) {
-    (void)strncat(dst, src, to_copy);
+    strncat(dst, src, to_copy);
   }
 
   return to_copy;


### PR DESCRIPTION
Failing builds on Fedora 30.  Used Docker and Fedora 30 on my Mac to make sure it Is building correctly.