### PR TITLE
TextView: clean up on strcasecmp, strcmp, and memcmp.

### DIFF
--- a/include/tscpp/util/TextView.h
+++ b/include/tscpp/util/TextView.h
@@ -33,37 +33,61 @@
 #include <string>
 #include <string_view>
 
-/// Compare the strings in two views.
-/// Return based on the first different character. If one argument is a prefix of the other, the prefix
-/// is considered the "smaller" value. The values are compared ignoring case.
-/// @note This works for @c ts::TextView because it is a subclass of @c std::string_view.
-/// @return
-/// - -1 if @a lhs char is less than @a rhs char.
-/// -  1 if @a lhs char is greater than @a rhs char.
-/// -  0 if the views contain identical strings.
+/** Compare views with ordering, ignoring case.
+ *
+ * @param lhs input view
+ * @param rhs input view
+ * @return The ordered comparison value.
+ *
+ * - -1 if @a lhs is less than @a rhs
+ * -  1 if @a lhs is greater than @a rhs
+ * -  0 if the views have identical content.
+ *
+ * If one view is the prefix of the other, the shorter view is less (first in the ordering).
+ */
 int strcasecmp(const std::string_view &lhs, const std::string_view &rhs);
+
+/** Compare views with ordering.
+ *
+ * @param lhs input view
+ * @param rhs input view
+ * @return The ordered comparison value.
+ *
+ * - -1 if @a lhs is less than @a rhs
+ * -  1 if @a lhs is greater than @a rhs
+ * -  0 if the views have identical content.
+ *
+ * If one view is the prefix of the other, the shorter view is less (first in the ordering).
+ *
+ * @note For string views, there is no difference between @c strcmp and @c memcmp.
+ * @see strcmp
+ */
+int memcmp(const std::string_view &lhs, const std::string_view &rhs);
+
+/** Compare views with ordering.
+ *
+ * @param lhs input view
+ * @param rhs input view
+ * @return The ordered comparison value.
+ *
+ * - -1 if @a lhs is less than @a rhs
+ * -  1 if @a lhs is greater than @a rhs
+ * -  0 if the views have identical content.
+ *
+ * If one view is the prefix of the other, the shorter view is less (first in the ordering).
+ *
+ * @note For string views, there is no difference between @c strcmp and @c memcmp.
+ * @see memcmp
+ */
+inline int
+strcmp(const std::string_view &lhs, const std::string_view &rhs)
+{
+  return memcmp(lhs, rhs);
+}
 
 namespace ts
 {
 class TextView;
-/// Compare the memory in two views.
-/// Return based on the first different byte. If one argument is a prefix of the other, the prefix
-/// is considered the "smaller" value.
-/// @return
-/// - -1 if @a lhs byte is less than @a rhs byte.
-/// -  1 if @a lhs byte is greater than @a rhs byte.
-/// -  0 if the views contain identical memory.
-int memcmp(TextView const &lhs, TextView const &rhs);
-using ::memcmp; // Make this an overload, not an override.
-/// Compare the strings in two views.
-/// Return based on the first different character. If one argument is a prefix of the other, the prefix
-/// is considered the "smaller" value.
-/// @return
-/// - -1 if @a lhs char is less than @a rhs char.
-/// -  1 if @a lhs char is greater than @a rhs char.
-/// -  0 if the views contain identical strings.
-int strcmp(TextView const &lhs, TextView const &rhs);
-using ::strcmp; // Make this an overload, not an override.
 
 /** A read only view of contiguous piece of memory.
 
@@ -1132,12 +1156,6 @@ inline bool
 TextView::isNoCasePrefixOf(super_type const &that) const
 {
   return this->size() <= that.size() && 0 == strncasecmp(this->data(), that.data(), this->size());
-}
-
-inline int
-strcmp(TextView const &lhs, TextView const &rhs)
-{
-  return memcmp(lhs, rhs);
 }
 
 template <typename Stream>

--- a/src/tscpp/util/TextView.cc
+++ b/src/tscpp/util/TextView.cc
@@ -28,40 +28,44 @@
 #include <sstream>
 
 int
-ts::memcmp(TextView const &lhs, TextView const &rhs)
+memcmp(std::string_view const &lhs, std::string_view const &rhs)
 {
-  int zret;
-  size_t n;
+  int zret = 0;
+  size_t n = rhs.size();
 
   // Seems a bit ugly but size comparisons must be done anyway to get the memcmp args.
   if (lhs.size() < rhs.size()) {
-    zret = 1, n = lhs.size();
-  } else {
-    n    = rhs.size();
-    zret = rhs.size() < lhs.size() ? -1 : 0;
+    zret = 1;
+    n    = lhs.size();
+  } else if (lhs.size() > rhs.size()) {
+    zret = -1;
+  } else if (lhs.data() == rhs.data()) { // same memory, obviously equal.
+    return 0;
   }
 
   int r = ::memcmp(lhs.data(), rhs.data(), n);
-  if (0 != r) { // If we got a not-equal, override the size based result.
-    zret = r;
-  }
-
-  return zret;
+  return r ? r : zret;
 }
 
 int
 strcasecmp(const std::string_view &lhs, const std::string_view &rhs)
 {
-  size_t len = std::min(lhs.size(), rhs.size());
-  int zret   = strncasecmp(lhs.data(), rhs.data(), len);
-  if (0 == zret) {
-    if (lhs.size() < rhs.size()) {
-      zret = -1;
-    } else if (lhs.size() > rhs.size()) {
-      zret = 1;
-    }
+  int zret = 0;
+  size_t n = rhs.size();
+
+  // Seems a bit ugly but size comparisons must be done anyway to get the @c strncasecmp args.
+  if (lhs.size() < rhs.size()) {
+    zret = 1;
+    n    = lhs.size();
+  } else if (lhs.size() > rhs.size()) {
+    zret = -1;
+  } else if (lhs.data() == rhs.data()) { // the same memory, obviously equal.
+    return 0;
   }
-  return zret;
+
+  int r = ::strncasecmp(lhs.data(), rhs.data(), n);
+
+  return r ? r : zret;
 }
 
 const int8_t ts::svtoi_convert[256] = {

--- a/tests/tools/plugins/test_cppapi.cc
+++ b/tests/tools/plugins/test_cppapi.cc
@@ -58,7 +58,7 @@ f()
 
   oss << tv;
 
-  ALWAYS_ASSERT(ts::memcmp(ts::TextView(oss.str()), tv) == 0)
+  ALWAYS_ASSERT(memcmp(ts::TextView(oss.str()), tv) == 0)
 }
 
 TEST(f)


### PR DESCRIPTION
This unifies the handling of these functions for both `string_view` and `TextView` with less implementation. In addition, because it is based on `string_view` it handles character pointers as expected without extra casting. E.g. this works as expected
```
void func(std::string_view name) {
   if (0 == strcasecmp(name, "Persia")) {
    is_cool_p = true;
  }
}
```

This also micro-optimizes the compare logic, by overloading the size comparisons for result tuning, short circuit checking, and minimum size computation.

I have another PR to do some cleanup in `LogFilterInt` that needs this cleanup first.