### PR TITLE
Make code compilable with BoringSSL

### DIFF
--- a/iocore/net/SSLSessionTicket.h
+++ b/iocore/net/SSLSessionTicket.h
@@ -25,6 +25,7 @@
 
 #include <openssl/safestack.h>
 #include <openssl/tls1.h>
+#include <openssl/ssl.h>
 
 // Check if the ticket_key callback #define is available, and if so, enable session tickets.
 #ifdef SSL_CTX_set_tlsext_ticket_key_cb

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -928,12 +928,17 @@ SSLMultiCertConfigLoader::default_server_ssl_ctx()
 static bool
 SSLPrivateKeyHandler(SSL_CTX *ctx, const SSLConfigParams *params, const std::string &completeServerCertPath, const char *keyPath)
 {
+#ifndef OPENSSL_IS_BORINGSSL
   ENGINE *e = ENGINE_get_default_RSA();
   if (e != nullptr) {
     const char *argkey = (keyPath == nullptr || keyPath[0] == '\0') ? completeServerCertPath.c_str() : keyPath;
     if (!SSL_CTX_use_PrivateKey(ctx, ENGINE_load_private_key(e, argkey, nullptr, nullptr))) {
       SSLError("failed to load server private key from engine");
     }
+#else
+  ENGINE *e = nullptr;
+  if (false) {
+#endif
   } else if (!keyPath) {
     // assume private key is contained in cert obtained from multicert file.
     if (!SSL_CTX_use_PrivateKey_file(ctx, completeServerCertPath.c_str(), SSL_FILETYPE_PEM)) {

--- a/plugins/experimental/access_control/utils.cc
+++ b/plugins/experimental/access_control/utils.cc
@@ -27,6 +27,7 @@
 #include <openssl/bio.h>    /* BIO I/O abstraction */
 #include <openssl/buffer.h> /* buf_mem_st */
 #include <openssl/err.h>    /* ERR_get_error() and ERR_error_string_n() */
+#include <openssl/crypto.h>
 
 #include "common.h"
 #include "utils.h"
@@ -253,7 +254,11 @@ cryptoMessageDigestGet(const char *digestType, const char *data, size_t dataLen,
   if (!(ctx = EVP_MD_CTX_create())) {
     AccessControlError("failed to create EVP message digest context: %s", cryptoErrStr(buffer, sizeof(buffer)));
   } else {
+#ifndef OPENSSL_IS_BORINGSSL
     if (!(pkey = EVP_PKEY_new_mac_key(EVP_PKEY_HMAC, nullptr, (const unsigned char *)key, keyLen))) {
+#else
+    if (false) {
+#endif
       AccessControlError("failed to create EVP private key. %s", cryptoErrStr(buffer, sizeof(buffer)));
       EVP_MD_CTX_destroy(ctx);
     } else {


### PR DESCRIPTION
This makes ATS compilable with BoringSSL, however, I have no idea what features I disabled. As far as I can see, it fails appropriately.

This closes #5397