### PR TITLE
Adds a missing dependency, bump autest version

### DIFF
--- a/tests/bootstrap.py
+++ b/tests/bootstrap.py
@@ -26,12 +26,13 @@ import platform
 import sys
 
 pip_packages = [
-    "autest==1.7.2",
+    "autest==1.7.3",
     "hyper",
     "requests",
     "dnslib",
     "httpbin",
-    "traffic-replay" # this should install TRLib, MicroServer, MicroDNS, Traffic-Replay
+    "gunicorn",
+    "traffic-replay"  # this should install TRLib, MicroServer, MicroDNS, Traffic-Replay
 ]
 
 
@@ -50,7 +51,7 @@ distro_packages = {
         "install python3",
         "install python3-virtualenv",
         "install virtualenv",
-	"install python3-dev"
+        "install python3-dev"
     ],
     "CentOS": [
         "install epel-release",


### PR DESCRIPTION
I had to manually pip3 install gunicorn on  my CentOS7 box, it seems it did not pull it in with the httpbin dependencies. I think this is a candidate for 8.0.4 as well.