### PR TITLE
Cleanup of autest prog checks, and indentation

### DIFF
--- a/plugins/experimental/ssl_session_reuse/tests/plug-load.test.py
+++ b/plugins/experimental/ssl_session_reuse/tests/plug-load.test.py
@@ -23,10 +23,6 @@ pluginName = 'ats_ssl_plugin'
 path=os.path.abspath(".")
 configFile='./packages/rhel.6.5.package/conf/trafficserver/ats_ssl_session_reuse.xml'
 
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl","Curl need to be installed on system for this test to work")
-    )
 Test.ContinueOnFail=True
 # Define default ATS
 ts=Test.MakeATSProcess("ts")

--- a/tests/gold_tests/basic/basic-manager.test.py
+++ b/tests/gold_tests/basic/basic-manager.test.py
@@ -20,8 +20,6 @@ Test.Summary = '''
 Test that Trafficserver starts with default configurations.
 '''
 
-Test.SkipUnless(Condition.HasProgram("curl", "Curl need to be installed on system for this test to work"))
-
 ts = Test.MakeATSProcess("ts", command="traffic_manager", select_ports=False)
 
 t = Test.AddTestRun("Test traffic server started properly")

--- a/tests/gold_tests/basic/basic.test.py
+++ b/tests/gold_tests/basic/basic.test.py
@@ -20,8 +20,6 @@ Test.Summary = '''
 Test that Trafficserver starts with default configurations.
 '''
 
-Test.SkipUnless(Condition.HasProgram("curl", "Curl need to be installed on system for this test to work"))
-
 p = Test.MakeATSProcess("ts", select_ports=False)
 t = Test.AddTestRun("Test traffic server started properly")
 t.StillRunningAfter = Test.Processes.ts

--- a/tests/gold_tests/basic/config.test.py
+++ b/tests/gold_tests/basic/config.test.py
@@ -18,9 +18,6 @@
 
 Test.Summary = "Test start up of Traffic server with configuration modification of starting port"
 
-Test.SkipUnless(Condition.HasProgram("curl",
-                                     "Curl needs to be installed on your system for this test to work"))
-
 ts1 = Test.MakeATSProcess("ts1", select_ports=False)
 ts1.Setup.ts.CopyConfig('config/records_8090.config', "records.config")
 t = Test.AddTestRun("Test traffic server started properly")

--- a/tests/gold_tests/basic/copy_config.test.py
+++ b/tests/gold_tests/basic/copy_config.test.py
@@ -18,9 +18,6 @@
 
 Test.Summary = "Test start up of Traffic server with configuration modification of starting port of different servers at the same time"
 
-Test.SkipUnless(Condition.HasProgram("curl",
-                                     "Curl needs to be installed on your system for this test to work"))
-
 # set up some ATS processes
 ts1 = Test.MakeATSProcess("ts1", select_ports=False)
 ts1.Setup.ts.CopyConfig('config/records_8090.config', 'records.config')

--- a/tests/gold_tests/basic/copy_config2.test.py
+++ b/tests/gold_tests/basic/copy_config2.test.py
@@ -18,9 +18,6 @@
 
 Test.Summary = "Test start up of Traffic server with generated ports of more than one servers at the same time"
 
-Test.SkipUnless(Condition.HasProgram("curl",
-                                     "Curl needs to be installed on your system for this test to work"))
-
 # set up some ATS processes
 ts1 = Test.MakeATSProcess("ts1")
 ts2 = Test.MakeATSProcess("ts2")

--- a/tests/gold_tests/body_factory/http204_response.test.py
+++ b/tests/gold_tests/body_factory/http204_response.test.py
@@ -23,8 +23,6 @@ Test.Summary = '''
 Tests that 204 responses conform to rfc2616, unless custom templates override.
 '''
 
-Test.SkipUnless(Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"))
-
 ts = Test.MakeATSProcess("ts")
 server = Test.MakeOriginServer("server")
 

--- a/tests/gold_tests/body_factory/http204_response_plugin.test.py
+++ b/tests/gold_tests/body_factory/http204_response_plugin.test.py
@@ -23,8 +23,6 @@ Test.Summary = '''
 Tests that plugins may break HTTP by sending 204 respose bodies
 '''
 
-Test.SkipUnless(Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"))
-
 ts = Test.MakeATSProcess("ts")
 server = Test.MakeOriginServer("server")
 

--- a/tests/gold_tests/body_factory/http304_response.test.py
+++ b/tests/gold_tests/body_factory/http304_response.test.py
@@ -23,9 +23,6 @@ Test.Summary = '''
 Tests 304 responses
 '''
 
-Test.SkipUnless(Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"))
-Test.SkipUnless(Condition.HasProgram("sed", "grep needs to be installed on system for this test to work"))
-
 ts = Test.MakeATSProcess("ts")
 server = Test.MakeOriginServer("server")
 

--- a/tests/gold_tests/body_factory/http_head_no_origin.test.py
+++ b/tests/gold_tests/body_factory/http_head_no_origin.test.py
@@ -23,8 +23,6 @@ Test.Summary = '''
 Tests that HEAD requests return proper responses when origin fails
 '''
 
-Test.SkipUnless(Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"))
-
 ts = Test.MakeATSProcess("ts")
 server = Test.MakeOriginServer("server")
 

--- a/tests/gold_tests/body_factory/http_with_origin.test.py
+++ b/tests/gold_tests/body_factory/http_with_origin.test.py
@@ -23,9 +23,6 @@ Test.Summary = '''
 Tests that HEAD requests return proper responses
 '''
 
-Test.SkipUnless(Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"))
-Test.SkipUnless(Condition.HasProgram("sed", "grep needs to be installed on system for this test to work"))
-
 ts = Test.MakeATSProcess("ts")
 
 HOST = 'www.example.test'

--- a/tests/gold_tests/cache/cache-control.test.py
+++ b/tests/gold_tests/cache/cache-control.test.py
@@ -21,12 +21,7 @@ import os
 Test.Summary = '''
 Test cached responses and requests with bodies
 '''
-
-# Needs Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "curl needs to be installed on system for this test to work"),
-    Condition.HasProgram("nc", "nc needs to be installed on system for this test to work")
-)
+ 
 Test.ContinueOnFail = True
 
 # Define default ATS
@@ -103,5 +98,3 @@ tr.Processes.Default.Command = "printf 'GET /no_cache_control HTTP/1.1\r\n''Cach
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/cache_no_cache.gold"
 tr.StillRunningAfter = ts
-
-

--- a/tests/gold_tests/cache/cache-generation-clear.test.py
+++ b/tests/gold_tests/cache/cache-generation-clear.test.py
@@ -21,8 +21,6 @@ import uuid
 Test.Summary = '''
 Test that incrementing the cache generation acts like a cache clear
 '''
-# need Curl
-Test.SkipUnless(Condition.HasProgram("curl", "Curl need to be installed on system for this test to work"))
 Test.ContinueOnFail = True
 # Define default ATS
 ts = Test.MakeATSProcess("ts", command="traffic_manager")

--- a/tests/gold_tests/cache/cache-generation-disjoint.test.py
+++ b/tests/gold_tests/cache/cache-generation-disjoint.test.py
@@ -22,7 +22,6 @@ Test.Summary = '''
 Test that the same URL path in different cache generations creates disjoint objects
 '''
 # need Curl
-Test.SkipUnless(Condition.HasProgram("curl", "Curl need to be installed on system for this test to work"))
 Test.ContinueOnFail = True
 # Define default ATS
 ts = Test.MakeATSProcess("ts")

--- a/tests/gold_tests/cache/disjoint-wait-for-cache.test.py
+++ b/tests/gold_tests/cache/disjoint-wait-for-cache.test.py
@@ -23,7 +23,6 @@ Same as cache-generaertaion-disjoint, but uses proxy.config.http.wait_for_cache 
 the server from accepting connection till the cache is loaded
 '''
 # need Curl
-Test.SkipUnless(Condition.HasProgram("curl", "Curl need to be installed on system for this test to work"))
 Test.SkipIf(Condition.true("This test fails at the moment as is turned off"))
 Test.ContinueOnFail = True
 # Define default ATS

--- a/tests/gold_tests/chunked_encoding/chunked_encoding.test.py
+++ b/tests/gold_tests/chunked_encoding/chunked_encoding.test.py
@@ -20,9 +20,8 @@ import os
 Test.Summary = '''
 Test a basic remap of a http connection
 '''
-# need Curl
+# need Curl with HTTP/2
 Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work"),
     Condition.HasCurlFeature('http2')
 )
 Test.ContinueOnFail = True

--- a/tests/gold_tests/cont_schedule/schedule.test.py
+++ b/tests/gold_tests/cont_schedule/schedule.test.py
@@ -20,8 +20,6 @@
 import os
 
 Test.Summary = 'Test TSContSchedule API'
-Test.SkipUnless(Condition.HasProgram('curl', 'Curl need to be installed on system for this test to work'))
-
 Test.ContinueOnFail = True
 
 # Define default ATS

--- a/tests/gold_tests/cont_schedule/schedule_on_pool.test.py
+++ b/tests/gold_tests/cont_schedule/schedule_on_pool.test.py
@@ -20,8 +20,6 @@
 import os
 
 Test.Summary = 'Test TSContScheduleOnPool API'
-Test.SkipUnless(Condition.HasProgram('curl', 'Curl need to be installed on system for this test to work'))
-
 Test.ContinueOnFail = True
 
 # Define default ATS

--- a/tests/gold_tests/cont_schedule/schedule_on_thread.test.py
+++ b/tests/gold_tests/cont_schedule/schedule_on_thread.test.py
@@ -20,8 +20,6 @@
 import os
 
 Test.Summary = 'Test TSContScheduleOnThread API'
-Test.SkipUnless(Condition.HasProgram('curl', 'Curl need to be installed on system for this test to work'))
-
 Test.ContinueOnFail = True
 
 # Define default ATS

--- a/tests/gold_tests/cont_schedule/thread_affinity.test.py
+++ b/tests/gold_tests/cont_schedule/thread_affinity.test.py
@@ -20,8 +20,6 @@
 import os
 
 Test.Summary = 'Test TSContThreadAffinity APIs'
-Test.SkipUnless(Condition.HasProgram('curl', 'Curl need to be installed on system for this test to work'))
-
 Test.ContinueOnFail = True
 
 # Define default ATS

--- a/tests/gold_tests/continuations/double.test.py
+++ b/tests/gold_tests/continuations/double.test.py
@@ -22,9 +22,6 @@ Test.Summary = '''
 Test transactions and sessions for http1, making sure the two continuations catch the same number of hooks.
 '''
 
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl needs to be installed on system for this test to work"),
-)
 Test.ContinueOnFail = True
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=False, command="traffic_manager")

--- a/tests/gold_tests/continuations/double_h2.test.py
+++ b/tests/gold_tests/continuations/double_h2.test.py
@@ -22,7 +22,6 @@ Test.Summary = '''
 Test transactions and sessions for http2, making sure the two continuations catch the same number of hooks.
 '''
 Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl needs to be installed on system for this test to work"),
     Condition.HasCurlFeature('http2')
 )
 Test.ContinueOnFail = True

--- a/tests/gold_tests/continuations/openclose.test.py
+++ b/tests/gold_tests/continuations/openclose.test.py
@@ -22,10 +22,6 @@ Test.Summary = '''
 Test transactions and sessions, making sure they open and close in the proper order.
 '''
 
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl needs to be installed on system for this test to work")
-)
-
 # Define default ATS
 ts = Test.MakeATSProcess("ts", command="traffic_manager")
 

--- a/tests/gold_tests/h2/h2disable.test.py
+++ b/tests/gold_tests/h2/h2disable.test.py
@@ -23,7 +23,6 @@ Test disabling H2 on a per domain basis
 
 # need Curl
 Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work"),
     Condition.HasCurlFeature('http2')
 )
 
@@ -98,5 +97,3 @@ tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 tr2.Processes.Default.Streams.All += Testers.ExcludesExpression("Using HTTP2", "Curl should not negotiate HTTP2")
 tr2.TimeOut = 5
-
-

--- a/tests/gold_tests/h2/http2.test.py
+++ b/tests/gold_tests/h2/http2.test.py
@@ -22,7 +22,6 @@ Test a basic remap of a http connection
 '''
 # need Curl
 Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work"),
     Condition.HasCurlFeature('http2')
 )
 Test.ContinueOnFail = True

--- a/tests/gold_tests/h2/http2_priority.test.py
+++ b/tests/gold_tests/h2/http2_priority.test.py
@@ -26,7 +26,6 @@ Test a basic remap of a http connection with Stream Priority Feature
 '''
 # need Curl
 Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work"),
     Condition.HasCurlFeature('http2'),
     Condition.HasProgram("shasum", "shasum need to be installed on system for this test to work"),
 )

--- a/tests/gold_tests/h2/httpbin.test.py
+++ b/tests/gold_tests/h2/httpbin.test.py
@@ -26,7 +26,6 @@ Test HTTP/2 with httpbin origin server
 '''
 # Require HTTP/2 enabled Curl
 Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work"),
     Condition.HasCurlFeature('http2'),
     Condition.HasProgram("shasum", "shasum need to be installed on system for this test to work"),
 )

--- a/tests/gold_tests/headers/cache_and_req_body.test.py
+++ b/tests/gold_tests/headers/cache_and_req_body.test.py
@@ -22,11 +22,6 @@ Test.Summary = '''
 Test cached responses and requests with bodies
 '''
 
-# Needs Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "curl needs to be installed on system for this test to work"),
-    Condition.HasProgram("nc", "nc needs to be installed on system for this test to work")
-)
 Test.ContinueOnFail = True
 
 # Define default ATS

--- a/tests/gold_tests/headers/cachedIMSRange.test.py
+++ b/tests/gold_tests/headers/cachedIMSRange.test.py
@@ -24,11 +24,6 @@ Test revalidating cached objects
 '''
 
 testName = "RevalidateCacheObject"
-
-# Needs Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "curl needs to be installed on system for this test to work"),
-)
 Test.ContinueOnFail = True
 
 # Set up Origin server

--- a/tests/gold_tests/headers/domain-blacklist-30x.test.py
+++ b/tests/gold_tests/headers/domain-blacklist-30x.test.py
@@ -23,8 +23,6 @@ Test.Summary = '''
 Tests 30x responses are returned for matching domains
 '''
 
-Test.SkipUnless(Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"))
-
 ts = Test.MakeATSProcess("ts")
 server = Test.MakeOriginServer("server")
 

--- a/tests/gold_tests/headers/hsts.test.py
+++ b/tests/gold_tests/headers/hsts.test.py
@@ -22,10 +22,6 @@ Test.Summary = '''
 heck hsts header is set correctly
 '''
 
-# Needs Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
 Test.ContinueOnFail = True
 
 # Define default ATS

--- a/tests/gold_tests/headers/normalize_ae.test.py
+++ b/tests/gold_tests/headers/normalize_ae.test.py
@@ -25,7 +25,6 @@ Test normalizations of the Accept-Encoding header field.
 '''
 
 Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work"),
     Condition.HasATSFeature('TS_HAS_BROTLI')
 )
 

--- a/tests/gold_tests/headers/syntax.test.py
+++ b/tests/gold_tests/headers/syntax.test.py
@@ -22,10 +22,6 @@ Test.Summary = '''
 Test whitespace between field name and colon in the header
 '''
 
-# Needs Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
 Test.ContinueOnFail = True
 
 # Define default ATS

--- a/tests/gold_tests/logging/all_headers.test.py
+++ b/tests/gold_tests/logging/all_headers.test.py
@@ -22,12 +22,6 @@ import subprocess
 Test.Summary = '''
 Test new "all headers" log fields
 '''
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram(
-        "curl", "Curl need to be installed on system for this test to work"),
-    # Condition.IsPlatform("linux"), Don't see the need for this.
-)
 
 # Define ATS.
 #

--- a/tests/gold_tests/logging/ccid_ctid.test.py
+++ b/tests/gold_tests/logging/ccid_ctid.test.py
@@ -24,9 +24,6 @@ Test new ccid and ctid log fields
 '''
 # need Curl
 Test.SkipUnless(
-    Condition.HasProgram(
-        "curl", "Curl need to be installed on system for this test to work"),
-    # Condition.IsPlatform("linux"), Don't see the need for this.
     Condition.HasCurlFeature('http2')
 )
 

--- a/tests/gold_tests/logging/custom-log.test.py
+++ b/tests/gold_tests/logging/custom-log.test.py
@@ -23,8 +23,6 @@ Test custom log file format
 '''
 # need Curl
 Test.SkipUnless(
-    Condition.HasProgram(
-        "curl", "Curl need to be installed on system for this test to work"),
     Condition.IsPlatform("linux")
 )
 

--- a/tests/gold_tests/logging/log-field.test.py
+++ b/tests/gold_tests/logging/log-field.test.py
@@ -21,10 +21,8 @@ import os
 Test.Summary = '''
 Test log fields.
 '''
-# need Curl
+# Only on Linux (why??)
 Test.SkipUnless(
-    Condition.HasProgram(
-        "curl", "Curl need to be installed on system for this test to work"),
     Condition.IsPlatform("linux")
 )
 

--- a/tests/gold_tests/null_transform/null_transform.test.py
+++ b/tests/gold_tests/null_transform/null_transform.test.py
@@ -23,10 +23,6 @@ Test.Summary = '''
 Test a basic null transform plugin
 '''
 
-# Need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "curl needs to be installed on system for this test to work")
-)
 Test.ContinueOnFail = True
 
 # Define default ATS

--- a/tests/gold_tests/pluginTest/cookie_remap/bucketcookie.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/bucketcookie.test.py
@@ -21,10 +21,6 @@ Test.Summary = '''
 
 '''
 Test.SkipUnless(Condition.PluginExists('cookie_remap.so'))
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
 Test.ContinueOnFail = True
 Test.testName = "cookie_remap: cookie in bucket or not"
 
@@ -73,12 +69,12 @@ ts.Disk.remap_config.AddLine(
 # Cookie value in bucket
 tr = Test.AddTestRun("cookie value in bucket")
 tr.Processes.Default.Command = '''
-curl 
---proxy 127.0.0.1:{0} 
-"http://www.example.com/magic" 
--H"Cookie: fpbeta=333"
--H "Proxy-Connection: keep-alive" 
---verbose
+curl \
+--proxy 127.0.0.1:{0} \
+"http://www.example.com/magic" \
+-H"Cookie: fpbeta=333" \
+-H "Proxy-Connection: keep-alive" \
+--verbose \
 '''.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 # time delay as proxy.config.http.wait_for_cache could be broken
@@ -91,12 +87,12 @@ server.Streams.All = "gold/matchcookie.gold"
 # cookie value not in bucket
 tr = Test.AddTestRun("cooke value not in bucket")
 tr.Processes.Default.Command = '''
-curl 
---proxy 127.0.0.1:{0} 
-"http://www.example.com/magic" 
--H"Cookie: fpbeta=etc" 
--H "Proxy-Connection: keep-alive" 
---verbose
+curl \
+--proxy 127.0.0.1:{0} \
+"http://www.example.com/magic" \
+-H"Cookie: fpbeta=etc" \
+-H "Proxy-Connection: keep-alive" \
+--verbose \
 '''.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(server2, ready=When.PortOpen(server2.Variables.Port))

--- a/tests/gold_tests/pluginTest/cookie_remap/collapseslashes.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/collapseslashes.test.py
@@ -21,10 +21,6 @@ Test.Summary = '''
 
 '''
 Test.SkipUnless(Condition.PluginExists('cookie_remap.so'))
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
 Test.ContinueOnFail = True
 Test.testName = "cookie_remap: plugin collapses consecutive slashes"
 Test.SkipIf(Condition.true("Test is temporarily turned off, to be fixed according to an incompatible plugin API change (PR #4964)"))
@@ -64,11 +60,11 @@ ts.Disk.remap_config.AddLine(
 
 tr = Test.AddTestRun("collapse consecutive forward slashes")
 tr.Processes.Default.Command = '''
-curl 
---proxy 127.0.0.1:{0} 
-"http://www.example.com/magic" 
--H "Proxy-Connection: keep-alive" 
---verbose
+curl \
+--proxy 127.0.0.1:{0} \
+"http://www.example.com/magic" \
+-H "Proxy-Connection: keep-alive" \
+--verbose \
 '''.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 # time delay as proxy.config.http.wait_for_cache could be broken
@@ -77,4 +73,3 @@ tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 
 server.Streams.All = "gold/collapseslashes.gold"
-

--- a/tests/gold_tests/pluginTest/cookie_remap/connector.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/connector.test.py
@@ -21,10 +21,6 @@ Test.Summary = '''
 
 '''
 Test.SkipUnless(Condition.PluginExists('cookie_remap.so'))
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
 Test.ContinueOnFail = True
 Test.testName = "cookie_remap: test connector"
 Test.SkipIf(Condition.true("Test is temporarily turned off, to be fixed according to an incompatible plugin API change (PR #4964)"))
@@ -74,12 +70,12 @@ ts.Disk.remap_config.AddLine(
 # Positive test case that remaps because all connected operations pass
 tr = Test.AddTestRun("cookie value matches")
 tr.Processes.Default.Command = '''
-curl 
---proxy 127.0.0.1:{0} 
-"http://www.example.com/magic" 
--H"Cookie: fpbeta=abcd icecream=donteat" 
--H "Proxy-Connection: keep-alive" 
---verbose
+curl \
+--proxy 127.0.0.1:{0} \
+"http://www.example.com/magic" \
+-H"Cookie: fpbeta=abcd icecream=donteat" \
+-H "Proxy-Connection: keep-alive" \
+--verbose \
 '''.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 # time delay as proxy.config.http.wait_for_cache could be broken
@@ -92,12 +88,12 @@ server.Streams.All = "gold/matchcookie.gold"
 # Negative test case that doesn't remap because not all subops pass
 tr = Test.AddTestRun("cookie value doesn't match")
 tr.Processes.Default.Command = '''
-curl 
---proxy 127.0.0.1:{0} 
-"http://www.example.com/magic" 
--H"Cookie: fpbeta=somethingelse" 
--H "Proxy-Connection: keep-alive" 
---verbose
+curl \
+--proxy 127.0.0.1:{0} \
+"http://www.example.com/magic" \
+-H"Cookie: fpbeta=somethingelse" \
+-H "Proxy-Connection: keep-alive" \
+--verbose \
 '''.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(server2, ready=When.PortOpen(server2.Variables.Port))

--- a/tests/gold_tests/pluginTest/cookie_remap/existscookie.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/existscookie.test.py
@@ -21,10 +21,6 @@ Test.Summary = '''
 
 '''
 Test.SkipUnless(Condition.PluginExists('cookie_remap.so'))
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
 Test.ContinueOnFail = True
 Test.testName = "cookie_remap: cookie exists"
 
@@ -73,12 +69,12 @@ ts.Disk.remap_config.AddLine(
 # Positive test case that remaps because cookie exists
 tr = Test.AddTestRun("cookie fpbeta exists")
 tr.Processes.Default.Command = '''
-curl 
---proxy 127.0.0.1:{0} 
-"http://www.example.com/magic" 
--H"Cookie: fpbeta=fdkfkdfkdfkdkdfkdfk" 
--H "Proxy-Connection: keep-alive" 
---verbose
+curl \
+--proxy 127.0.0.1:{0} \
+"http://www.example.com/magic" \
+-H"Cookie: fpbeta=fdkfkdfkdfkdkdfkdfk" \
+-H "Proxy-Connection: keep-alive" \
+--verbose \
 '''.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 # time delay as proxy.config.http.wait_for_cache could be broken
@@ -91,12 +87,12 @@ server.Streams.All = "gold/existscookie.gold"
 # Negative test case that doesn't remap because cookie doesn't exist
 tr = Test.AddTestRun("cooke fpbeta doesnt exist")
 tr.Processes.Default.Command = '''
-curl 
---proxy 127.0.0.1:{0} 
-"http://www.example.com/magic" 
--H"Cookie: breadcrumb=etc" 
--H "Proxy-Connection: keep-alive" 
---verbose
+curl \
+--proxy 127.0.0.1:{0} \
+"http://www.example.com/magic" \
+-H"Cookie: breadcrumb=etc" \
+-H "Proxy-Connection: keep-alive" \
+--verbose \
 '''.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(server2, ready=When.PortOpen(server2.Variables.Port))

--- a/tests/gold_tests/pluginTest/cookie_remap/matchcookie.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/matchcookie.test.py
@@ -21,10 +21,6 @@ Test.Summary = '''
 
 '''
 Test.SkipUnless(Condition.PluginExists('cookie_remap.so'))
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
 Test.ContinueOnFail = True
 Test.testName = "cookie_remap: match cookie"
 

--- a/tests/gold_tests/pluginTest/cookie_remap/matchuri.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/matchuri.test.py
@@ -21,10 +21,6 @@ Test.Summary = '''
 
 '''
 Test.SkipUnless(Condition.PluginExists('cookie_remap.so'))
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
 Test.ContinueOnFail = True
 Test.testName = "cookie_remap: match cookie"
 
@@ -73,11 +69,11 @@ ts.Disk.remap_config.AddLine(
 # Positive test case, URI matches rule
 tr = Test.AddTestRun("URI value matches")
 tr.Processes.Default.Command = '''
-curl 
---proxy 127.0.0.1:{0} 
-"http://www.example.com/magic/thisispartofthepath" 
--H "Proxy-Connection: keep-alive" 
---verbose
+curl \
+--proxy 127.0.0.1:{0} \
+"http://www.example.com/magic/thisispartofthepath" \
+-H "Proxy-Connection: keep-alive" \
+--verbose \
 '''.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 # time delay as proxy.config.http.wait_for_cache could be broken
@@ -90,12 +86,12 @@ server.Streams.All = "gold/matchcookie.gold"
 # Negative test case that doesn't remap because URI doesn't match
 tr = Test.AddTestRun("URI value doesn't match")
 tr.Processes.Default.Command = '''
-curl 
---proxy 127.0.0.1:{0} 
-"http://www.example.com/magic" 
--H"Cookie: fpbeta=etc" 
--H "Proxy-Connection: keep-alive" 
---verbose
+curl \
+--proxy 127.0.0.1:{0} \
+"http://www.example.com/magic" \
+-H"Cookie: fpbeta=etc" \
+-H "Proxy-Connection: keep-alive" \
+--verbose \
 '''.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(server2, ready=When.PortOpen(server2.Variables.Port))

--- a/tests/gold_tests/pluginTest/cookie_remap/matrixparams.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/matrixparams.test.py
@@ -21,10 +21,6 @@ Test.Summary = '''
 
 '''
 Test.SkipUnless(Condition.PluginExists('cookie_remap.so'))
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
 Test.ContinueOnFail = True
 Test.testName = "cookie_remap: Tests when matrix parameters are present"
 Test.SkipIf(Condition.true("Test is temporarily turned off, to be fixed according to an incompatible plugin API change (PR #4964)"))
@@ -172,4 +168,3 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 
 server.Streams.All = "gold/matrix.gold"
-

--- a/tests/gold_tests/pluginTest/cookie_remap/notexistscookie.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/notexistscookie.test.py
@@ -21,10 +21,6 @@ Test.Summary = '''
 
 '''
 Test.SkipUnless(Condition.PluginExists('cookie_remap.so'))
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
 Test.ContinueOnFail = True
 Test.testName = "cookie_remap: cookie not exists"
 
@@ -73,11 +69,11 @@ ts.Disk.remap_config.AddLine(
 # Positive test case that remaps because cookie doesn't exist
 tr = Test.AddTestRun("cookie fpbeta doesn't exist")
 tr.Processes.Default.Command = '''
-curl 
---proxy 127.0.0.1:{0} 
-"http://www.example.com/magic" 
--H "Proxy-Connection: keep-alive" 
---verbose
+curl \
+--proxy 127.0.0.1:{0} \
+"http://www.example.com/magic" \
+-H "Proxy-Connection: keep-alive" \
+--verbose \
 '''.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 # time delay as proxy.config.http.wait_for_cache could be broken
@@ -90,12 +86,12 @@ server.Streams.All = "gold/doesntexistcookie.gold"
 # Negative test case that doesn't remap because cookie exists
 tr = Test.AddTestRun("cooke fpbeta exists")
 tr.Processes.Default.Command = '''
-curl 
---proxy 127.0.0.1:{0} 
-"http://www.example.com/magic" 
--H"Cookie: fpbeta=etc" 
--H "Proxy-Connection: keep-alive" 
---verbose
+curl \
+--proxy 127.0.0.1:{0} \
+"http://www.example.com/magic" \
+-H"Cookie: fpbeta=etc" \
+-H "Proxy-Connection: keep-alive" \
+--verbose \
 '''.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(server2, ready=When.PortOpen(server2.Variables.Port))

--- a/tests/gold_tests/pluginTest/cookie_remap/regexcookie.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/regexcookie.test.py
@@ -21,10 +21,6 @@ Test.Summary = '''
 
 '''
 Test.SkipUnless(Condition.PluginExists('cookie_remap.so'))
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
 Test.ContinueOnFail = True
 Test.testName = "cookie_remap: cookie regex match and substition"
 
@@ -73,12 +69,12 @@ ts.Disk.remap_config.AddLine(
 # Positive test case that remaps because cookie regex matches
 tr = Test.AddTestRun("cookie regex matches")
 tr.Processes.Default.Command = '''
-curl 
---proxy 127.0.0.1:{0} 
-"http://www.example.com/magic" 
--H"Cookie: fpbeta=ilove-oreos-chipsahoy-icecream"
--H "Proxy-Connection: keep-alive" 
---verbose
+curl \
+--proxy 127.0.0.1:{0} \
+"http://www.example.com/magic" \
+-H"Cookie: fpbeta=ilove-oreos-chipsahoy-icecream" \
+-H "Proxy-Connection: keep-alive" \
+--verbose \
 '''.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 # time delay as proxy.config.http.wait_for_cache could be broken
@@ -91,12 +87,12 @@ server.Streams.All = "gold/regexmatches.gold"
 # Negative test case that doesn't remap because cookie regex doesn't match
 tr = Test.AddTestRun("cookie regex doesn't match")
 tr.Processes.Default.Command = '''
-curl 
---proxy 127.0.0.1:{0} 
-"http://www.example.com/magic" 
--H"Cookie: fpbeta=etc" 
--H "Proxy-Connection: keep-alive" 
---verbose
+curl \
+--proxy 127.0.0.1:{0} \
+"http://www.example.com/magic" \
+-H"Cookie: fpbeta=etc" \
+-H "Proxy-Connection: keep-alive" \
+--verbose \
 '''.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(server2, ready=When.PortOpen(server2.Variables.Port))

--- a/tests/gold_tests/pluginTest/cookie_remap/setstatus.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/setstatus.test.py
@@ -21,10 +21,6 @@ Test.Summary = '''
 
 '''
 Test.SkipUnless(Condition.PluginExists('cookie_remap.so'))
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
 Test.ContinueOnFail = True
 Test.testName = "cookie_remap: set HTTP status of the response"
 
@@ -51,12 +47,12 @@ ts.Disk.remap_config.AddLine(
 # Plugin sets the HTTP status because first rule matches
 tr = Test.AddTestRun("Sets the status to 205")
 tr.Processes.Default.Command = '''
-curl 
---proxy 127.0.0.1:{0} 
-"http://www.example.com/magic" 
--H"Cookie: fpbeta=magic" 
--H "Proxy-Connection: keep-alive" 
---verbose
+curl \
+--proxy 127.0.0.1:{0} \
+"http://www.example.com/magic" \
+-H"Cookie: fpbeta=magic" \
+-H "Proxy-Connection: keep-alive" \
+--verbose \
 '''.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(Test.Processes.ts)
@@ -67,12 +63,12 @@ tr.Streams.All = "gold/matchstatus.gold"
 # Plugin sets the HTTP status because the else rule matches (i.e. no match)
 tr = Test.AddTestRun("Sets the else status to 400")
 tr.Processes.Default.Command = '''
-curl 
---proxy 127.0.0.1:{0} 
-"http://www.example.com/magic" 
--H "Proxy-Connection: keep-alive" 
--H "Proxy-Connection: keep-alive" 
---verbose
+curl \
+--proxy 127.0.0.1:{0} \
+"http://www.example.com/magic" \
+-H "Proxy-Connection: keep-alive" \
+-H "Proxy-Connection: keep-alive" \
+--verbose \
 '''.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/pluginTest/cookie_remap/subcookie.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/subcookie.test.py
@@ -21,10 +21,6 @@ Test.Summary = '''
 
 '''
 Test.SkipUnless(Condition.PluginExists('cookie_remap.so'))
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
 Test.ContinueOnFail = True
 Test.testName = "cookie_remap: test connector"
 Test.SkipIf(Condition.true("Test is temporarily turned off, to be fixed according to an incompatible plugin API change (PR #4964)"))
@@ -77,11 +73,11 @@ tr = Test.AddTestRun("cookie value matches")
 # be interpreted by the autest framework or the shell (tried escaping with \)
 tr.Processes.Default.Command = 'curl --proxy 127.0.0.1:{0} "http://www.example.com/magic" -H"Cookie: fpbeta=a=1&b=2&c=3" -H "Proxy-Connection: keep-alive" --verbose '.format(ts.Variables.port)
 #tr.Processes.Default.Command = '''
-#curl 
-#--proxy 127.0.0.1:{0} 
-#"http://www.example.com/magic" 
-#-H\"Cookie: fpbeta=a=1&b=2&c=3\" 
-#-H "Proxy-Connection: keep-alive" 
+#curl
+#--proxy 127.0.0.1:{0}
+#"http://www.example.com/magic"
+#-H\"Cookie: fpbeta=a=1&b=2&c=3\"
+#-H "Proxy-Connection: keep-alive"
 #--verbose
 #'''.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/pluginTest/cookie_remap/substitute.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/substitute.test.py
@@ -21,10 +21,6 @@ Test.Summary = '''
 
 '''
 Test.SkipUnless(Condition.PluginExists('cookie_remap.so'))
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
 Test.ContinueOnFail = True
 Test.testName = "cookie_remap: Substitute variables"
 Test.SkipIf(Condition.true("Test is temporarily turned off, to be fixed according to an incompatible plugin API change (PR #4964)"))
@@ -70,12 +66,12 @@ ts.Disk.remap_config.AddLine(
 
 tr = Test.AddTestRun("Substitute $path in the dest query")
 tr.Processes.Default.Command = '''
-curl 
---proxy 127.0.0.1:{0} 
-"http://www.example.com/magic" 
--H"Cookie: fpbeta=abcd" 
--H "Proxy-Connection: keep-alive" 
---verbose
+curl \
+--proxy 127.0.0.1:{0} \
+"http://www.example.com/magic" \
+-H"Cookie: fpbeta=abcd" \
+-H "Proxy-Connection: keep-alive" \
+--verbose \
 '''.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 # time delay as proxy.config.http.wait_for_cache could be broken
@@ -86,12 +82,12 @@ tr.StillRunningAfter = server
 
 tr = Test.AddTestRun("Substitute $unmatched_path in the dest query")
 tr.Processes.Default.Command = '''
-curl 
---proxy 127.0.0.1:{0} 
-"http://www.example.com/magic/theunmatchedpath" 
--H"Cookie: oxalpha=3333" 
--H "Proxy-Connection: keep-alive" 
---verbose
+curl \
+--proxy 127.0.0.1:{0} \
+"http://www.example.com/magic/theunmatchedpath" \
+-H"Cookie: oxalpha=3333" \
+-H "Proxy-Connection: keep-alive" \
+--verbose \
 '''.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = ts
@@ -99,12 +95,12 @@ tr.StillRunningAfter = server
 
 tr = Test.AddTestRun("Substitute $cr_req_url using $cr_urlencode")
 tr.Processes.Default.Command = '''
-curl 
---proxy 127.0.0.1:{0} 
-"http://www.example.com/magic" 
--H"Cookie: acgamma=dfndfdfd" 
--H "Proxy-Connection: keep-alive" 
---verbose
+curl \
+--proxy 127.0.0.1:{0} \
+"http://www.example.com/magic" \
+-H"Cookie: acgamma=dfndfdfd" \
+-H "Proxy-Connection: keep-alive" \
+--verbose \
 '''.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = ts
@@ -112,15 +108,14 @@ tr.StillRunningAfter = server
 
 tr = Test.AddTestRun("Substitute $path as is in outgoing path")
 tr.Processes.Default.Command = '''
-curl 
---proxy 127.0.0.1:{0} 
-"http://www.example.com/magic/foobar" 
--H "Proxy-Connection: keep-alive" 
---verbose
+curl \
+--proxy 127.0.0.1:{0} \
+"http://www.example.com/magic/foobar" \
+-H "Proxy-Connection: keep-alive" \
+--verbose \
 '''.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 
 server.Streams.All = "gold/substitute.gold"
-

--- a/tests/gold_tests/pluginTest/header_rewrite/header_rewrite.test.py
+++ b/tests/gold_tests/pluginTest/header_rewrite/header_rewrite.test.py
@@ -20,10 +20,7 @@ import os
 Test.Summary = '''
 Test a basic remap of a http connection
 '''
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
+
 Test.ContinueOnFail = True
 # Define default ATS
 ts = Test.MakeATSProcess("ts")

--- a/tests/gold_tests/pluginTest/multiplexer/multiplexer.test.py
+++ b/tests/gold_tests/pluginTest/multiplexer/multiplexer.test.py
@@ -22,7 +22,6 @@ Test experimental/multiplexer.
 '''
 # need Curl
 Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work"),
     Condition.PluginExists('multiplexer.so')
 )
 Test.ContinueOnFail = False

--- a/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate.test.py
+++ b/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate.test.py
@@ -33,7 +33,6 @@ Test a basic regex_revalidate
 # A rule's expiry can't be changed after the fact!
 
 Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work"),
     Condition.PluginExists('regex_revalidate.so'),
     Condition.PluginExists('xdebug.so')
 )
@@ -138,7 +137,7 @@ path1_rule = 'path1 {}\n'.format(int(time.time()) + 600)
 
 # Define first revistion for when trafficserver starts
 ts.Disk.File(regex_revalidate_conf_path, typename="ats:config").AddLines([
-    "# Empty\n"    
+    "# Empty\n"
 ])
 
 ts.Disk.remap_config.AddLine(

--- a/tests/gold_tests/pluginTest/slice/slice.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice.test.py
@@ -28,7 +28,6 @@ Basic slice plugin test
 # Request content through the slice plugin
 
 Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl needs to be installed on system for this test to work"),
     Condition.PluginExists('slice.so'),
 )
 Test.ContinueOnFail = False
@@ -185,4 +184,3 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/slice_mid.stdout.gold"
 tr.Processes.Default.Streams.stderr = "gold/slice_mid.stderr.gold"
 tr.StillRunningAfter = ts
-

--- a/tests/gold_tests/pluginTest/slice/slice_error.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice_error.test.py
@@ -28,7 +28,6 @@ Slice plugin error.log test
 # Request content through the slice plugin
 
 Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl needs to be installed on system for this test to work"),
     Condition.PluginExists('slice.so'),
 )
 Test.ContinueOnFail = False

--- a/tests/gold_tests/redirect/redirect_post.test.py
+++ b/tests/gold_tests/redirect/redirect_post.test.py
@@ -25,7 +25,6 @@ Test basic post redirection
 MAX_REDIRECT = 99
 
 Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work"),
     Condition.HasProgram("truncate", "truncate need to be installed on system for this test to work")
 )
 

--- a/tests/gold_tests/remap/remap_http.test.py
+++ b/tests/gold_tests/remap/remap_http.test.py
@@ -20,10 +20,7 @@ import os
 Test.Summary = '''
 Test a basic remap of a http connection
 '''
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
+
 Test.ContinueOnFail = True
 # Define default ATS
 ts = Test.MakeATSProcess("ts")

--- a/tests/gold_tests/remap/remap_https.test.py
+++ b/tests/gold_tests/remap/remap_https.test.py
@@ -20,10 +20,7 @@ import os
 Test.Summary = '''
 Test a basic remap of a http connection
 '''
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
+
 Test.ContinueOnFail = True
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=False)

--- a/tests/gold_tests/thread_config/thread_100_0.test.py
+++ b/tests/gold_tests/thread_config/thread_100_0.test.py
@@ -20,8 +20,6 @@ import sys
 
 
 Test.Summary = 'Test that Trafficserver starts with different thread configurations.'
-Test.SkipUnless(Condition.HasProgram('curl', 'Curl need to be installed on system for this test to work'))
-
 Test.ContinueOnFail = True
 
 ts = Test.MakeATSProcess('ts')

--- a/tests/gold_tests/thread_config/thread_100_1.test.py
+++ b/tests/gold_tests/thread_config/thread_100_1.test.py
@@ -20,9 +20,6 @@ import sys
 
 
 Test.Summary = 'Test that Trafficserver starts with different thread configurations.'
-Test.SkipUnless(Condition.HasProgram('curl', 'Curl need to be installed on system for this test to work'))
-
-
 Test.ContinueOnFail = True
 
 ts = Test.MakeATSProcess('ts')

--- a/tests/gold_tests/thread_config/thread_100_10.test.py
+++ b/tests/gold_tests/thread_config/thread_100_10.test.py
@@ -20,8 +20,6 @@ import sys
 
 
 Test.Summary = 'Test that Trafficserver starts with different thread configurations.'
-Test.SkipUnless(Condition.HasProgram('curl', 'Curl need to be installed on system for this test to work'))
-
 Test.ContinueOnFail = True
 
 ts = Test.MakeATSProcess('ts')

--- a/tests/gold_tests/thread_config/thread_1_0.test.py
+++ b/tests/gold_tests/thread_config/thread_1_0.test.py
@@ -20,8 +20,6 @@ import sys
 
 
 Test.Summary = 'Test that Trafficserver starts with different thread configurations.'
-Test.SkipUnless(Condition.HasProgram('curl', 'Curl need to be installed on system for this test to work'))
-
 Test.ContinueOnFail = True
 
 ts = Test.MakeATSProcess('ts')

--- a/tests/gold_tests/thread_config/thread_1_1.test.py
+++ b/tests/gold_tests/thread_config/thread_1_1.test.py
@@ -20,8 +20,6 @@ import sys
 
 
 Test.Summary = 'Test that Trafficserver starts with different thread configurations.'
-Test.SkipUnless(Condition.HasProgram('curl', 'Curl need to be installed on system for this test to work'))
-
 Test.ContinueOnFail = True
 
 ts = Test.MakeATSProcess('ts')

--- a/tests/gold_tests/thread_config/thread_1_10.test.py
+++ b/tests/gold_tests/thread_config/thread_1_10.test.py
@@ -20,8 +20,6 @@ import sys
 
 
 Test.Summary = 'Test that Trafficserver starts with different thread configurations.'
-Test.SkipUnless(Condition.HasProgram('curl', 'Curl need to be installed on system for this test to work'))
-
 Test.ContinueOnFail = True
 
 ts = Test.MakeATSProcess('ts')

--- a/tests/gold_tests/thread_config/thread_2_0.test.py
+++ b/tests/gold_tests/thread_config/thread_2_0.test.py
@@ -20,8 +20,6 @@ import sys
 
 
 Test.Summary = 'Test that Trafficserver starts with different thread configurations.'
-Test.SkipUnless(Condition.HasProgram('curl', 'Curl need to be installed on system for this test to work'))
-
 Test.ContinueOnFail = True
 
 ts = Test.MakeATSProcess('ts')

--- a/tests/gold_tests/thread_config/thread_2_1.test.py
+++ b/tests/gold_tests/thread_config/thread_2_1.test.py
@@ -20,8 +20,6 @@ import sys
 
 
 Test.Summary = 'Test that Trafficserver starts with different thread configurations.'
-Test.SkipUnless(Condition.HasProgram('curl', 'Curl need to be installed on system for this test to work'))
-
 Test.ContinueOnFail = True
 
 ts = Test.MakeATSProcess('ts')

--- a/tests/gold_tests/thread_config/thread_2_10.test.py
+++ b/tests/gold_tests/thread_config/thread_2_10.test.py
@@ -20,8 +20,6 @@ import sys
 
 
 Test.Summary = 'Test that Trafficserver starts with different thread configurations.'
-Test.SkipUnless(Condition.HasProgram('curl', 'Curl need to be installed on system for this test to work'))
-
 Test.ContinueOnFail = True
 
 ts = Test.MakeATSProcess('ts')

--- a/tests/gold_tests/thread_config/thread_32_0.test.py
+++ b/tests/gold_tests/thread_config/thread_32_0.test.py
@@ -20,8 +20,6 @@ import sys
 
 
 Test.Summary = 'Test that Trafficserver starts with different thread configurations.'
-Test.SkipUnless(Condition.HasProgram('curl', 'Curl need to be installed on system for this test to work'))
-
 Test.ContinueOnFail = True
 
 ts = Test.MakeATSProcess('ts')

--- a/tests/gold_tests/thread_config/thread_32_1.test.py
+++ b/tests/gold_tests/thread_config/thread_32_1.test.py
@@ -20,8 +20,6 @@ import sys
 
 
 Test.Summary = 'Test that Trafficserver starts with different thread configurations.'
-Test.SkipUnless(Condition.HasProgram('curl', 'Curl need to be installed on system for this test to work'))
-
 Test.ContinueOnFail = True
 
 ts = Test.MakeATSProcess('ts')

--- a/tests/gold_tests/thread_config/thread_32_10.test.py
+++ b/tests/gold_tests/thread_config/thread_32_10.test.py
@@ -20,8 +20,6 @@ import sys
 
 
 Test.Summary = 'Test that Trafficserver starts with different thread configurations.'
-Test.SkipUnless(Condition.HasProgram('curl', 'Curl need to be installed on system for this test to work'))
-
 Test.ContinueOnFail = True
 
 ts = Test.MakeATSProcess('ts')

--- a/tests/gold_tests/timeout/timeout.test.py
+++ b/tests/gold_tests/timeout/timeout.test.py
@@ -18,10 +18,6 @@
 
 Test.Summary = 'Testing ATS TCP handshake timeout'
 
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
-
 ts = Test.MakeATSProcess("ts")
 server = Test.MakeOriginServer("server", delay=15)
 dns = Test.MakeDNServer("dns", ip='127.0.0.1', default=['127.0.0.1'])

--- a/tests/gold_tests/tls/tls.test.py
+++ b/tests/gold_tests/tls/tls.test.py
@@ -21,11 +21,6 @@ Test.Summary = '''
 Test tls
 '''
 
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
-
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server = Test.MakeOriginServer("server")

--- a/tests/gold_tests/tls/tls_check_cert_selection.test.py
+++ b/tests/gold_tests/tls/tls_check_cert_selection.test.py
@@ -21,11 +21,6 @@ Test.Summary = '''
 Test ATS offering different certificates based on SNI
 '''
 
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
-
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server = Test.MakeOriginServer("server", ssl=True)
@@ -122,4 +117,3 @@ tr2.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connec
 tr2.Processes.Default.Streams.All += Testers.ContainsExpression("CN=foo.com", "Cert should contain foo.com")
 tr2.Processes.Default.Streams.All += Testers.ExcludesExpression("CN=bar.com", "Cert should not contain bar.com")
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("404", "Should make an exchange")
-

--- a/tests/gold_tests/tls/tls_client_cert.test.py
+++ b/tests/gold_tests/tls/tls_client_cert.test.py
@@ -25,8 +25,6 @@ Test.Summary = '''
 Test different combinations of TLS handshake hooks to ensure they are applied consistently.
 '''
 
-Test.SkipUnless(Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"))
-
 ts = Test.MakeATSProcess("ts", command="traffic_manager", select_ports=False)
 cafile = "{0}/signer.pem".format(Test.RunDirectory)
 cafile2 = "{0}/signer2.pem".format(Test.RunDirectory)
@@ -296,4 +294,3 @@ tr4fail.StillRunningAfter = server2
 tr4fail.Processes.Default.Command = 'curl  -H host:example.com http://127.0.0.1:{0}/case2'.format(ts.Variables.port)
 tr4fail.Processes.Default.ReturnCode = 0
 tr4fail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
-

--- a/tests/gold_tests/tls/tls_client_cert2.test.py
+++ b/tests/gold_tests/tls/tls_client_cert2.test.py
@@ -24,8 +24,6 @@ Test.Summary = '''
 Test client certs to origin selected via wildcard names in ssl_server_name
 '''
 
-Test.SkipUnless(Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"))
-
 ts = Test.MakeATSProcess("ts", command="traffic_server", select_ports=False)
 cafile = "{0}/signer.pem".format(Test.RunDirectory)
 cafile2 = "{0}/signer2.pem".format(Test.RunDirectory)
@@ -176,4 +174,3 @@ trfail.StillRunningAfter = server2
 trfail.Processes.Default.Command = 'curl -H host:random.foo.com  http://127.0.0.1:{0}/case1'.format(ts.Variables.port)
 trfail.Processes.Default.ReturnCode = 0
 trfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
-

--- a/tests/gold_tests/tls/tls_client_cert_override.test.py
+++ b/tests/gold_tests/tls/tls_client_cert_override.test.py
@@ -24,8 +24,6 @@ Test.Summary = '''
 Test conf_remp to specify different client certificates to offer to the origin
 '''
 
-Test.SkipUnless(Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"))
-
 ts = Test.MakeATSProcess("ts", command="traffic_manager", select_ports=False)
 cafile = "{0}/signer.pem".format(Test.RunDirectory)
 cafile2 = "{0}/signer2.pem".format(Test.RunDirectory)
@@ -132,5 +130,3 @@ trbarfail.StillRunningAfter = server2
 trbarfail.Processes.Default.Command = 'curl -H host:bar.com  http://127.0.0.1:{0}/badcase2'.format(ts.Variables.port)
 trbarfail.Processes.Default.ReturnCode = 0
 trbarfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
-
-

--- a/tests/gold_tests/tls/tls_client_verify.test.py
+++ b/tests/gold_tests/tls/tls_client_verify.test.py
@@ -24,8 +24,6 @@ Test.Summary = '''
 Test various options for requiring certificate from client for mutual authentication TLS
 '''
 
-Test.SkipUnless(Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"))
-
 ts = Test.MakeATSProcess("ts", select_ports=False)
 cafile = "{0}/signer.pem".format(Test.RunDirectory)
 cafile2 = "{0}/signer2.pem".format(Test.RunDirectory)
@@ -174,5 +172,3 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./server.pem --key ./server.key --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 35
-
-

--- a/tests/gold_tests/tls/tls_client_verify2.test.py
+++ b/tests/gold_tests/tls/tls_client_verify2.test.py
@@ -24,8 +24,6 @@ Test.Summary = '''
 Test various options for requiring certificate from client for mutual authentication TLS
 '''
 
-Test.SkipUnless(Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"))
-
 ts = Test.MakeATSProcess("ts", select_ports=False)
 cafile = "{0}/signer.pem".format(Test.RunDirectory)
 cafile2 = "{0}/signer2.pem".format(Test.RunDirectory)
@@ -164,4 +162,3 @@ tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./server.pem --key ./server.key --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("alert unknown ca", "TLS handshake should succeed")
-

--- a/tests/gold_tests/tls/tls_client_versions.test.py
+++ b/tests/gold_tests/tls/tls_client_versions.test.py
@@ -26,7 +26,6 @@ Test TLS protocol offering  based on SNI
 
 # need Curl
 Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work"),
     Condition.HasOpenSSLVersion("1.1.1")
 )
 
@@ -98,4 +97,3 @@ tr = Test.AddTestRun("bar.com TLSv1_2")
 tr.Processes.Default.Command = "curl -v --tls-max 1.2 --tlsv1.2 --resolve 'bar.com:{0}:127.0.0.1' -k  https://bar.com:{0}".format(ts.Variables.ssl_port)
 tr.ReturnCode = 0
 tr.StillRunningAfter = ts
-

--- a/tests/gold_tests/tls/tls_forward_nonhttp.test.py
+++ b/tests/gold_tests/tls/tls_forward_nonhttp.test.py
@@ -21,11 +21,6 @@ Test.Summary = '''
 Forwarding a non-HTTP protocol out of TLS
 '''
 
-# need nc
-Test.SkipUnless(
-    Condition.HasProgram("nc", "nc need to be installed on system for this test to work")
-)
-
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=False)
 
@@ -71,4 +66,3 @@ tr.StillRunningAfter = ts
 testout_path = os.path.join(Test.RunDirectory, "test.out")
 tr.Disk.File(testout_path, id = "testout")
 tr.Processes.Default.Streams.All += Testers.IncludesExpression("This is a reply", "s_client should get response")
-

--- a/tests/gold_tests/tls/tls_hooks_client_verify.test.py
+++ b/tests/gold_tests/tls/tls_hooks_client_verify.test.py
@@ -24,8 +24,6 @@ Test.Summary = '''
 Test different combinations of TLS handshake hooks to ensure they are applied consistently.
 '''
 
-Test.SkipUnless(Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"))
-
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server = Test.MakeOriginServer("server", ssl=True)
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
@@ -109,4 +107,3 @@ ts.Streams.All += Testers.ContainsExpression("Client verify callback 0 [\da-fx]+
 ts.Streams.All += Testers.ContainsExpression("Client verify callback 1 [\da-fx]+? - event is good good HS", "verify callback happens 2 times")
 ts.Streams.All += Testers.ContainsExpression("Client verify callback 0 [\da-fx]+? - event is good error HS", "verify callback happens 2 times")
 ts.Streams.All += Testers.ContainsExpression("Client verify callback 1 [\da-fx]+? - event is good error HS", "verify callback happens 2 times")
-

--- a/tests/gold_tests/tls/tls_hooks_verify.test.py
+++ b/tests/gold_tests/tls/tls_hooks_verify.test.py
@@ -24,8 +24,6 @@ Test.Summary = '''
 Test different combinations of TLS handshake hooks to ensure they are applied consistently.
 '''
 
-Test.SkipUnless(Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"))
-
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server = Test.MakeOriginServer("server", ssl=True)
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
@@ -107,4 +105,3 @@ ts.Streams.All += Testers.ContainsExpression("Server verify callback 0 [\da-fx]+
 ts.Streams.All += Testers.ContainsExpression("Server verify callback 1 [\da-fx]+? - event is good SNI=random.com error HS", "verify callback happens 2 times")
 ts.Streams.All += Testers.ContainsExpression("Server verify callback 0 [\da-fx]+? - event is good SNI=bar.com error HS", "verify callback happens 2 times")
 ts.Streams.All += Testers.ContainsExpression("Server verify callback 1 [\da-fx]+? - event is good SNI=bar.com error HS", "verify callback happens 2 times")
-

--- a/tests/gold_tests/tls/tls_keepalive.test.py
+++ b/tests/gold_tests/tls/tls_keepalive.test.py
@@ -25,7 +25,6 @@ Verify that the client-side keep alive is honored for TLS and different versions
 '''
 
 Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work"),
     Condition.HasCurlFeature('http2')
 )
 
@@ -105,4 +104,3 @@ tr.Processes.Default.Command = 'ls'
 tr.Processes.Default.ReturnCode = 0
 
 ts.Disk.squid_log.Content = "gold/accesslog.gold"
-

--- a/tests/gold_tests/tls/tls_ticket.test.py
+++ b/tests/gold_tests/tls/tls_ticket.test.py
@@ -22,11 +22,6 @@ Test.Summary = '''
 Test tls tickets
 '''
 
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
-
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=False)
 ts2 = Test.MakeATSProcess("ts2", select_ports=False)

--- a/tests/gold_tests/tls/tls_tunnel.test.py
+++ b/tests/gold_tests/tls/tls_tunnel.test.py
@@ -22,11 +22,6 @@ Test.Summary = '''
 Test tunneling based on SNI
 '''
 
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
-
 # Define default ATS
 ts = Test.MakeATSProcess("ts", command="traffic_manager", select_ports=False)
 server_foo = Test.MakeOriginServer("server_foo", ssl=True)
@@ -188,4 +183,3 @@ tr.Processes.Default.Streams.All += Testers.ExcludesExpression("Could Not Connec
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("Not Found on Accelerato", "Terminates on on Traffic Server")
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("ATS", "Terminate on Traffic Server")
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("bar ok", "Should get a response from bar")
-

--- a/tests/gold_tests/tls/tls_tunnel_forward.test.py
+++ b/tests/gold_tests/tls/tls_tunnel_forward.test.py
@@ -21,11 +21,6 @@ Test.Summary = '''
 Test tunneling and forwarding based on SNI
 '''
 
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
-
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server_foo = Test.MakeOriginServer("server_foo", ssl=True)
@@ -122,4 +117,3 @@ tr3.Processes.Default.Streams.All += Testers.ExcludesExpression("Not Found on Ac
 tr3.Processes.Default.Streams.All += Testers.ContainsExpression("CN=foo.com", "Should TLS terminate on Traffic Server")
 tr3.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/1.1 200 OK", "Should get a successful response")
 tr3.Processes.Default.Streams.All += Testers.ContainsExpression("ok random", "Body is expected")
-

--- a/tests/gold_tests/tls/tls_tunnel_plugin_rename.test.py
+++ b/tests/gold_tests/tls/tls_tunnel_plugin_rename.test.py
@@ -21,11 +21,6 @@ Test.Summary = '''
 Test tunneling based on SNI renaming
 '''
 
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
-
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server_bar = Test.MakeOriginServer("server_bar", ssl=True)
@@ -74,7 +69,7 @@ ts.Disk.records_config.update({
     'proxy.config.url_remap.pristine_host_hdr': 1
 })
 
-# bar.com should terminate.  
+# bar.com should terminate.
 # empty should tunnel to server_random (should not happen)
 # newname should tunnel to server_bar
 ts.Disk.ssl_server_name_yaml.AddLines([
@@ -97,4 +92,3 @@ tr.Processes.Default.Streams.All += Testers.ExcludesExpression("Could Not Connec
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("Not Found on Accelerato", "Should not try to remap on Traffic Server")
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/1.1 200 OK", "Should get a successful response")
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("ok bar", "Body is expected")
-

--- a/tests/gold_tests/tls/tls_verify.test.py
+++ b/tests/gold_tests/tls/tls_verify.test.py
@@ -21,11 +21,6 @@ Test.Summary = '''
 Test tls server certificate verification options
 '''
 
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
-
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server_foo = Test.MakeOriginServer("server_foo", ssl=True, options = {"--key": "{0}/signed-foo.key".format(Test.RunDirectory), "--cert": "{0}/signed-foo.pem".format(Test.RunDirectory)})
@@ -144,7 +139,7 @@ tr4.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Con
 tr4.ReturnCode = 0
 tr4.StillRunningAfter = server
 tr4.StillRunningAfter = ts
- 
+
 tr5 = Test.AddTestRun("Exercise-wildcard-cert-underscore-name-check")
 tr5.Processes.Default.Command = "curl -v -k -H \"host: foo_bar.wild.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port)
 tr5.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")

--- a/tests/gold_tests/tls/tls_verify2.test.py
+++ b/tests/gold_tests/tls/tls_verify2.test.py
@@ -21,11 +21,6 @@ Test.Summary = '''
 Test tls server certificate verification options
 '''
 
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
-
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server_foo = Test.MakeOriginServer("server_foo", ssl=True, options = {"--key": "{0}/signed-foo.key".format(Test.RunDirectory), "--cert": "{0}/signed-foo.pem".format(Test.RunDirectory)})

--- a/tests/gold_tests/tls/tls_verify3.test.py
+++ b/tests/gold_tests/tls/tls_verify3.test.py
@@ -21,11 +21,6 @@ Test.Summary = '''
 Test tls server certificate verification options
 '''
 
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
-
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server_foo = Test.MakeOriginServer("server_foo", ssl=True, options = {"--key": "{0}/signed-foo.key".format(Test.RunDirectory), "--cert": "{0}/signed-foo.pem".format(Test.RunDirectory)})

--- a/tests/gold_tests/tls/tls_verify_base.test.py
+++ b/tests/gold_tests/tls/tls_verify_base.test.py
@@ -21,11 +21,6 @@ Test.Summary = '''
 Test tls server certificate verification options
 '''
 
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
-
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server_foo = Test.MakeOriginServer("server_foo", ssl=True, options = {"--key": "{0}/signed-foo.key".format(Test.RunDirectory), "--cert": "{0}/signed-foo.pem".format(Test.RunDirectory)})

--- a/tests/gold_tests/tls/tls_verify_ca_override.test.py
+++ b/tests/gold_tests/tls/tls_verify_ca_override.test.py
@@ -21,11 +21,6 @@ Test.Summary = '''
 Test tls server  certificate verification options. Exercise conf_remap for ca bundle
 '''
 
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
-
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server1 = Test.MakeOriginServer("server1", ssl=True, options = {"--key": "{0}/signed-foo.key".format(Test.RunDirectory), "--cert": "{0}/signed-foo.pem".format(Test.RunDirectory)})
@@ -87,7 +82,7 @@ ts.Disk.records_config.update({
     'proxy.config.url_remap.pristine_host_hdr': 1
 })
 
-# Should succeed 
+# Should succeed
 tr = Test.AddTestRun("Use corrcect ca bundle for server 1")
 tr.Processes.Default.Command = 'curl -k -H \"host: foo.com\"  http://127.0.0.1:{0}/case1'.format(ts.Variables.port)
 tr.ReturnCode = 0
@@ -115,7 +110,7 @@ tr2.Processes.Default.Command = "curl -k -H \"host: random.com\"  http://127.0.0
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server2
 tr2.StillRunningAfter = ts
-# Should succeed, but will be message in log about signature 
+# Should succeed, but will be message in log about signature
 tr2.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr3 = Test.AddTestRun("User incorrect ca bundle for server 2")
@@ -125,5 +120,3 @@ tr3.StillRunningAfter = server2
 tr3.StillRunningAfter = ts
 # Should succeed.  No error messages
 tr3.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Curl attempt should have succeeded")
-
-

--- a/tests/gold_tests/tls/tls_verify_not_pristine.test.py
+++ b/tests/gold_tests/tls/tls_verify_not_pristine.test.py
@@ -21,11 +21,6 @@ Test.Summary = '''
 Test tls server certificate verification without a pristine host header
 '''
 
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
-
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server_foo = Test.MakeOriginServer("server_foo", ssl=True, options = {"--key": "{0}/signed-foo.key".format(Test.RunDirectory), "--cert": "{0}/signed-foo.pem".format(Test.RunDirectory)})

--- a/tests/gold_tests/tls/tls_verify_override.test.py
+++ b/tests/gold_tests/tls/tls_verify_override.test.py
@@ -21,11 +21,6 @@ Test.Summary = '''
 Test tls server certificate verification options. Exercise conf_remap
 '''
 
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
-
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server_foo = Test.MakeOriginServer("server_foo", ssl=True, options = {"--key": "{0}/signed-foo.key".format(Test.RunDirectory), "--cert": "{0}/signed-foo.pem".format(Test.RunDirectory)})
@@ -143,7 +138,7 @@ tr2.Processes.Default.Command = "curl -k -H \"host: random.com\"  http://127.0.0
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.StillRunningAfter = ts
-# Should succeed, but will be message in log about signature 
+# Should succeed, but will be message in log about signature
 tr2.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr3 = Test.AddTestRun("default-foo-to-bar")
@@ -227,7 +222,5 @@ ts.Disk.diags_log.Content += Testers.ContainsExpression("WARNING: SNI \(bar.com\
 ts.Disk.diags_log.Content += Testers.ContainsExpression("WARNING: SNI \(random.com\) not in certificate. Action=Continue server=random.com\(127.0.0.1\)", "Warning on missing name for randome.com")
 # name check failure for bar.com
 ts.Disk.diags_log.Content += Testers.ContainsExpression("WARNING: SNI \(bar.com\) not in certificate. Action=Terminate server=bar.com\(127.0.0.1\)", "Failure on missing name for bar.com")
-# See if the explicitly set default sni_policy of remap works.  
+# See if the explicitly set default sni_policy of remap works.
 ts.Disk.diags_log.Content += Testers.ExcludesExpression("WARNING: SNI \(foo.com\) not in certificate. Action=Continue", "Warning on missing name for foo.com")
-
-

--- a/tests/gold_tests/tls/tls_verify_override_base.test.py
+++ b/tests/gold_tests/tls/tls_verify_override_base.test.py
@@ -21,11 +21,6 @@ Test.Summary = '''
 Test tls server certificate verification options. Exercise conf_remap
 '''
 
-# need Curl
-Test.SkipUnless(
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work")
-)
-
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server_foo = Test.MakeOriginServer("server_foo", ssl=True, options = {"--key": "{0}/signed-foo.key".format(Test.RunDirectory), "--cert": "{0}/signed-foo.pem".format(Test.RunDirectory)})
@@ -138,7 +133,7 @@ tr2.Processes.Default.Command = "curl -k -H \"host: random.com\"  http://127.0.0
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.StillRunningAfter = ts
-# Should succeed, but will be message in log about signature 
+# Should succeed, but will be message in log about signature
 tr2.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr3 = Test.AddTestRun("override-foo")
@@ -215,5 +210,3 @@ ts.Disk.diags_log.Content += Testers.ContainsExpression("WARNING: SNI \(bar.com\
 ts.Disk.diags_log.Content += Testers.ContainsExpression("WARNING: SNI \(random.com\) not in certificate. Action=Continue server=127.0.0.1\(127.0.0.1\)", "Warning on missing name for randome.com")
 # name check failure for bar.com
 ts.Disk.diags_log.Content += Testers.ContainsExpression("WARNING: SNI \(bar.com\) not in certificate. Action=Terminate server=bar.com\(127.0.0.1\)", "Failure on missing name for bar.com")
-
-

--- a/tests/gold_tests/tls_hooks/tls_hooks.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks.test.py
@@ -24,8 +24,6 @@ Test.Summary = '''
 Test different combinations of TLS handshake hooks to ensure they are applied consistently.
 '''
 
-Test.SkipUnless(Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"))
-
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server = Test.MakeOriginServer("server")
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}

--- a/tests/gold_tests/tls_hooks/tls_hooks10.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks10.test.py
@@ -24,11 +24,6 @@ Test.Summary = '''
 Test different combinations of TLS handshake hooks to ensure they are applied consistently.
 '''
 
-Test.SkipUnless(
-    Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"),
-    Condition.HasOpenSSLVersion("1.0.2")
-    )
-
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server = Test.MakeOriginServer("server")
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}

--- a/tests/gold_tests/tls_hooks/tls_hooks11.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks11.test.py
@@ -24,8 +24,6 @@ Test.Summary = '''
 Test different combinations of TLS handshake hooks to ensure they are applied consistently.
 '''
 
-Test.SkipUnless(Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"))
-
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server = Test.MakeOriginServer("server")
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}

--- a/tests/gold_tests/tls_hooks/tls_hooks12.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks12.test.py
@@ -24,8 +24,6 @@ Test.Summary = '''
 Test different combinations of TLS handshake hooks to ensure they are applied consistently.
 '''
 
-Test.SkipUnless(Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"))
-
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server = Test.MakeOriginServer("server")
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}

--- a/tests/gold_tests/tls_hooks/tls_hooks13.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks13.test.py
@@ -24,8 +24,6 @@ Test.Summary = '''
 Test different combinations of TLS handshake hooks to ensure they are applied consistently.
 '''
 
-Test.SkipUnless(Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"))
-
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server = Test.MakeOriginServer("server", ssl=True)
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}

--- a/tests/gold_tests/tls_hooks/tls_hooks14.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks14.test.py
@@ -24,8 +24,6 @@ Test.Summary = '''
 Test different combinations of TLS handshake hooks to ensure they are applied consistently.
 '''
 
-Test.SkipUnless(Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"))
-
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server = Test.MakeOriginServer("server", ssl=True)
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
@@ -57,7 +55,7 @@ ts.Disk.remap_config.AddLine(
 )
 
 Test.PreparePlugin(os.path.join(Test.Variables.AtsTestToolsDir, 'plugins', 'ssl_hook_test.cc'), ts, '-out_start_delay=2')
- 
+
 tr = Test.AddTestRun("Test outbound delay start")
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.ssl_port))

--- a/tests/gold_tests/tls_hooks/tls_hooks15.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks15.test.py
@@ -24,8 +24,6 @@ Test.Summary = '''
 Test different combinations of TLS handshake hooks to ensure they are applied consistently.
 '''
 
-Test.SkipUnless(Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"))
-
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server = Test.MakeOriginServer("server", ssl=True)
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}

--- a/tests/gold_tests/tls_hooks/tls_hooks16.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks16.test.py
@@ -25,7 +25,6 @@ Test different combinations of TLS handshake hooks to ensure they are applied co
 '''
 
 Test.SkipUnless(
-    Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"),
     Condition.HasOpenSSLVersion("1.1.1"))
 
 ts = Test.MakeATSProcess("ts", select_ports=False)

--- a/tests/gold_tests/tls_hooks/tls_hooks17.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks17.test.py
@@ -25,7 +25,6 @@ Test different combinations of TLS handshake hooks to ensure they are applied co
 '''
 
 Test.SkipUnless(
-    Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"),
     Condition.HasOpenSSLVersion("1.1.1"))
 
 ts = Test.MakeATSProcess("ts", select_ports=False)

--- a/tests/gold_tests/tls_hooks/tls_hooks18.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks18.test.py
@@ -25,7 +25,6 @@ Test different combinations of TLS handshake hooks to ensure they are applied co
 '''
 
 Test.SkipUnless(
-    Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"),
     Condition.HasOpenSSLVersion("1.1.1")
     )
 

--- a/tests/gold_tests/tls_hooks/tls_hooks2.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks2.test.py
@@ -24,8 +24,6 @@ Test.Summary = '''
 Test different combinations of TLS handshake hooks to ensure they are applied consistently.
 '''
 
-Test.SkipUnless(Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"))
-
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server = Test.MakeOriginServer("server")
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}

--- a/tests/gold_tests/tls_hooks/tls_hooks3.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks3.test.py
@@ -24,11 +24,6 @@ Test.Summary = '''
 Test different combinations of TLS handshake hooks to ensure they are applied consistently.
 '''
 
-Test.SkipUnless(
-    Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"),
-    Condition.HasOpenSSLVersion("1.0.2")
-    )
-
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server = Test.MakeOriginServer("server")
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}

--- a/tests/gold_tests/tls_hooks/tls_hooks4.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks4.test.py
@@ -24,11 +24,6 @@ Test.Summary = '''
 Test different combinations of TLS handshake hooks to ensure they are applied consistently.
 '''
 
-Test.SkipUnless(
-    Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"),
-    Condition.HasOpenSSLVersion("1.0.2")
-    )
-
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server = Test.MakeOriginServer("server")
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}

--- a/tests/gold_tests/tls_hooks/tls_hooks6.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks6.test.py
@@ -24,8 +24,6 @@ Test.Summary = '''
 Test different combinations of TLS handshake hooks to ensure they are applied consistently.
 '''
 
-Test.SkipUnless(Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"))
-
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server = Test.MakeOriginServer("server")
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}

--- a/tests/gold_tests/tls_hooks/tls_hooks7.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks7.test.py
@@ -24,8 +24,6 @@ Test.Summary = '''
 Test different combinations of TLS handshake hooks to ensure they are applied consistently.
 '''
 
-Test.SkipUnless(Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"))
-
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server = Test.MakeOriginServer("server")
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}

--- a/tests/gold_tests/tls_hooks/tls_hooks8.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks8.test.py
@@ -24,11 +24,6 @@ Test.Summary = '''
 Test different combinations of TLS handshake hooks to ensure they are applied consistently.
 '''
 
-Test.SkipUnless(
-    Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"),
-    Condition.HasOpenSSLVersion("1.0.2")
-    )
-
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server = Test.MakeOriginServer("server")
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}

--- a/tests/gold_tests/tls_hooks/tls_hooks9.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks9.test.py
@@ -24,8 +24,6 @@ Test.Summary = '''
 Test different combinations of TLS handshake hooks to ensure they are applied consistently.
 '''
 
-Test.SkipUnless(Condition.HasProgram("grep", "grep needs to be installed on system for this test to work"))
-
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server = Test.MakeOriginServer("server")
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}


### PR DESCRIPTION
The checks for grep, sed, curl and nc are superflous. Most systems will have them,
and if not, we should just fail hard, and it's obvious what the user has to do.

In addition, I added the \ on the multiline Command lines, because some editors
are at risk of eliminating the trailing slashes. And, most of the time we used \
to avoid the \n in the command, so I chose to standardize on that.

Finally, it eliminates checks for OpenSSL v1.0.2, since that's required now.