### PR TITLE
Check for OpenSSSL v1.1.1, for now, for this test

### DIFF
--- a/tests/gold_tests/tls/tls_hooks_client_verify.test.py
+++ b/tests/gold_tests/tls/tls_hooks_client_verify.test.py
@@ -24,6 +24,8 @@ Test.Summary = '''
 Test different combinations of TLS handshake hooks to ensure they are applied consistently.
 '''
 
+Test.SkipUnless(Condition.HasOpenSSLVersion("1.1.1"))
+
 ts = Test.MakeATSProcess("ts", select_ports=False)
 server = Test.MakeOriginServer("server", ssl=True)
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}


### PR DESCRIPTION
This doesn't compile with older OpenSSL, particularly on
CentOS7 which has v1.0.2, our oldest supported version. A
better fix should be put in place, but the issue is that
tsxs does not get the defines from ink_config.h[.in].