### PR TITLE
clang analyzer: Fix false positive "use after free" in IpMap.cc

### DIFF
--- a/src/tscore/IpMap.cc
+++ b/src/tscore/IpMap.cc
@@ -368,23 +368,23 @@ namespace detail
     // Work through the rest of the nodes of interest.
     // Invariant: n->_min >= min
 
-    // Careful here -- because max_plus1 might wrap we need to use it only
-    // if we can certain it didn't. This is done by ordering the range
-    // tests so that when max_plus1 is used when we know there exists a
-    // larger value than max.
+    // Careful here -- because max_plus1 might wrap we need to use it only if we can be certain it
+    // didn't. This is done by ordering the range tests so that when max_plus1 is used when we know
+    // there exists a larger value than max.
     Metric max_plus1 = max;
     N::inc(max_plus1);
+
     /* Notes:
-       - max (and thence max_plus1) never change during the loop.
-       - we must have either x != 0 or adjust min but not both.
+       - max (and thence also max_plus1) never change during the loop.
+       - we must have either x != 0 or adjust min but not both for each loop iteration.
     */
     while (n) {
       if (n->_data == payload) {
         if (x) {
-          if (n->_max <= max) {
-// next range is covered, so we can remove and continue.
+          if (n->_max <= max) { // next range is covered, so we can remove and continue.
 #if defined(__clang_analyzer__)
-            ink_assert(x != n);
+            x->_next = n->_next; // done in @c remove, but CA doesn't realize that.
+                                 // It's insufficient to assert(x->_next != n) after the remove.
 #endif
             this->remove(n);
             n = next(x);


### PR DESCRIPTION
This is an alternative to #5473.

I added an extra bit of code (which, unfortunately, would break the actual code if executed) to convince clang analyzer to shut up. I fiddled with this far more than I should and was unable to find any sort of assert
that would suppress the false positive. I _think_ the problem is the analyzer knows `x->_next == n` because of the previous code path, but doesn't realize `x->_next` gets updated when `n` is removed (via standard linked list removal). It's also annoying that the analyzer complains about the _assignment_ of a stale pointer as if it were a dereference. While dangerous, the assignment of `n = next(x)` is not actually a use after free. If I replace that with the content of the `next` function, however, the use after free moves to the next loop iteration, which would be correct if there was an actual use after free.

I prefer this because if the code is changed solely to make clang analyzer shut up, that should be obvious to a reader of the code, rather than puzzling over obtusely different implementation styles. It also means if we ever discuss this with the LLVM group, we can easily find the places in the code where the clang analyzer messes up.