### PR TITLE
clang analyzer: suppress nullptr derefence report in mime_hdr_sanity_check

### DIFF
--- a/proxy/hdrs/MIME.cc
+++ b/proxy/hdrs/MIME.cc
@@ -559,6 +559,8 @@ mime_hdr_sanity_check(MIMEHdrImpl *mh)
   uint32_t slot_index, index;
   uint64_t masksum;
 
+  ink_assert(mh != nullptr);
+
   masksum     = 0;
   slot_index  = 0;
   last_fblock = nullptr;


### PR DESCRIPTION
I didn't see this one on the spreadsheet, but locals runs with LLVM 8.0 generate an error here, which is suppressed by asserting `mh` is non-null.