### PR TITLE
gcc9: Fix compiler error with s3_auth plugin and strncat.

### DIFF
--- a/plugins/s3_auth/s3_auth.cc
+++ b/plugins/s3_auth/s3_auth.cc
@@ -652,10 +652,13 @@ S3Request::set_header(const char *header, int header_len, const char *val, int v
 static size_t
 str_concat(char *dst, size_t dst_len, const char *src, size_t src_len)
 {
-  size_t to_copy = (src_len < dst_len) ? src_len : dst_len;
+  // Need an extra byte of source for the terminating null.
+  size_t to_copy = std::min<size_t>(src_len + 1, dst_len);
 
-  if (to_copy > 0) {
-    (void)strncat(dst, src, to_copy);
+  if (to_copy > 1) {
+    --to_copy; // don't explicitly count the terminating nul.
+    memcpy(dst, src, to_copy);
+    dst[to_copy] = '\0';
   }
 
   return to_copy;


### PR DESCRIPTION
This doesn't compile for me with `gcc` 9 and `-O2`.
```
In function ‘size_t str_concat(char*, size_t, const char*, size_t)’,
    inlined from ‘TSHttpStatus S3Request::authorizeV2(S3Config*)’ at s3_auth/s3_auth.cc:817:25:
s3_auth/s3_auth.cc:658:18: error: ‘char* strncat(char*, const char*, size_t)’ output truncated copying between 0 and 1 bytes from a string of length 1 [-Werror=stringop-truncation]
  658 |     (void)strncat(dst, src, to_copy);
      |           ~~~~~~~^~~~~~~~~~~~~~~~~~~
In function ‘size_t str_concat(char*, size_t, const char*, size_t)’,
    inlined from ‘TSHttpStatus S3Request::authorizeV2(S3Config*)’ at s3_auth/s3_auth.cc:823:25:
s3_auth/s3_auth.cc:658:18: error: ‘char* strncat(char*, const char*, size_t)’ output truncated copying between 0 and 1 bytes from a string of length 1 [-Werror=stringop-truncation]
  658 |     (void)strncat(dst, src, to_copy);
      |           ~~~~~~~^~~~~~~~~~~~~~~~~~~
```