### PR TITLE
Cleanup LogFilterInt to use C++17 features.

### DIFF
--- a/proxy/http/Makefile.am
+++ b/proxy/http/Makefile.am
@@ -97,8 +97,6 @@ test_proxy_http_SOURCES = \
 	HttpBodyFactory.h
 
 test_proxy_http_LDADD = \
-	$(top_builddir)/src/tscpp/util/libtscpputil.la \
-	$(top_builddir)/src/tscore/libtscore.la \
 	$(top_builddir)/proxy/hdrs/libhdrs.a \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/lib/records/librecords_p.a \
@@ -106,6 +104,8 @@ test_proxy_http_LDADD = \
 	$(top_builddir)/proxy/shared/libUglyLogStubs.a \
 	$(top_builddir)/mgmt/libmgmt_p.la \
 	$(top_builddir)/iocore/utils/libinkutils.a \
+	$(top_builddir)/src/tscore/libtscore.la \
+	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	@HWLOC_LIBS@ \
 	@LIBCAP@
 

--- a/proxy/logging/LogFieldAliasMap.h
+++ b/proxy/logging/LogFieldAliasMap.h
@@ -35,6 +35,7 @@
 #include "tscore/Ptr.h"
 #include "LogUtils.h"
 #include "tscore/ink_string.h"
+#include "tscpp/util/TextView.h"
 
 /*****************************************************************************
 
@@ -86,7 +87,12 @@ public:
     BUFFER_TOO_SMALL,
   };
 
-  virtual int asInt(char *key, IntType *val, bool case_sensitive = false) const                 = 0;
+  virtual int asInt(std::string_view key, IntType *val, bool case_sensitive = false) const = 0;
+  int
+  asInt(char *key, IntType *val, bool case_sensitive = false)
+  {
+    return this->asInt(std::string_view{key}, val, case_sensitive);
+  }
   virtual int asString(IntType key, char *buf, size_t bufLen, size_t *numChars = nullptr) const = 0;
 };
 
@@ -130,7 +136,7 @@ public:
   void init(size_t numPairs, ...);
 
   int
-  asInt(char *key, IntType *val, bool case_sensitive) const override
+  asInt(std::string_view key, IntType *val, bool case_sensitive) const override
   {
     int retVal = INVALID_STRING;
 
@@ -146,7 +152,7 @@ public:
         found = false;
       }
       if (found) {
-        *val   = (unsigned int)(i + m_min);
+        *val   = static_cast<unsigned int>(i + m_min);
         retVal = ALL_OK;
         break;
       }

--- a/proxy/logging/LogFilter.h
+++ b/proxy/logging/LogFilter.h
@@ -185,28 +185,30 @@ private:
 class LogFilterInt : public LogFilter
 {
 public:
-  LogFilterInt(const char *name, LogField *field, Action a, Operator o, int64_t value);
-  LogFilterInt(const char *name, LogField *field, Action a, Operator o, size_t num_values, int64_t *value);
   LogFilterInt(const char *name, LogField *field, Action a, Operator o, char *values);
   LogFilterInt(const LogFilterInt &rhs);
-  ~LogFilterInt() override;
   bool operator==(LogFilterInt &rhs);
 
   bool toss_this_entry(LogAccess *lad) override;
   bool wipe_this_entry(LogAccess *lad) override;
   void display(FILE *fd = stdout) override;
 
-  // noncopyable
+  // unassignable
   LogFilterInt &operator=(LogFilterInt &rhs) = delete;
 
 private:
-  int64_t *m_value = nullptr; // the array of values
+  std::vector<int64_t> m_value; ///< Array of values.
 
-  void _setValues(size_t n, int64_t *value);
-  int _convertStringToInt(char *val, int64_t *ival, LogFieldAliasMap *map);
-
-  // -- member functions that are not allowed --
-  LogFilterInt();
+  /** Convert the text @a val into a integral value.
+   *
+   * @param val Input string.
+   * @param map Aliases.
+   * @return A tuple of the integer value and a success flag.
+   *
+   * If the success flag is @c false the input @a val was malformed and the return integer
+   * value is garbage.
+   */
+  std::tuple<int64_t, bool> _convertStringToInt(ts::TextView val, LogFieldAliasMap *map);
 };
 
 /*-------------------------------------------------------------------------


### PR DESCRIPTION
Junk code I ran in to while working on clang analyzer I thought should be cleaned up. Standard sorts of things -

*  Use `std::vector` instead of hand rolled memory allocation.
*  Use algorithms instead of hand rolled loops.
*  Use C++ style casts.
*  Use string views instead of raw pointers.