### PR TITLE
Fixed an ownership issue in autest

### DIFF
--- a/tests/gold_tests/autest-site/trafficserver.test.ext
+++ b/tests/gold_tests/autest-site/trafficserver.test.ext
@@ -76,6 +76,7 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True):
     # set root for this test
     p.Env['TS_ROOT'] = ts_dir
     p.Setup.MakeDir(ts_dir)
+
     # set bin location
 
     p.Env['PROXY_CONFIG_BIN_PATH'] = bin_dir
@@ -89,7 +90,9 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True):
     cfg_dir = os.path.join(AUTEST_SITE_PATH, "min_cfg")
 
     p.Setup.MakeDir(config_dir)
-    p.Setup.Chown(config_dir, "nobody", "root", ignore=True)
+    p.Setup.Chown(config_dir, "nobody", "nobody", ignore=True)
+    # covers ubuntu's unprivileged group
+    p.Setup.Chown(config_dir, "nobody", "nogroup", ignore=True)
 
     for f in os.listdir(cfg_dir):
         p.Setup.CopyAs(os.path.join(cfg_dir, f), config_dir)
@@ -123,7 +126,9 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True):
     # create subdirectories that need to exist (but are empty)
     # log directory has to be created with correct permissions
     p.Setup.MakeDir(log_dir)  # log directory has to be created
-    p.Setup.Chown(log_dir, "nobody", "root", ignore=True)
+    p.Setup.Chown(log_dir, "nobody", "nobody", ignore=True)
+    # covers ubuntu's unprivileged group
+    p.Setup.Chown(log_dir, "nobody", "nogroup", ignore=True)
 
     # set env so traffic server uses correct locations
     p.Env['PROXY_CONFIG_LOG_LOGFILE_DIR'] = log_dir
@@ -138,7 +143,10 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True):
     p.Variables.LOCALSTATEDIR = runtime_dir
 
     p.Setup.MakeDir(runtime_dir)
-    p.Setup.Chown(runtime_dir, "nobody", "root", ignore=True)
+    p.Setup.Chown(runtime_dir, "nobody", "nobody", ignore=True)
+    # covers ubuntu's unprivileged group
+    p.Setup.Chown(runtime_dir, "nobody", "nogroup", ignore=True)
+
     # will need this for traffic_manager is it runs
     p.Setup.MakeDir(os.path.join(config_dir, 'snapshots'))
     p.Env['PROXY_CONFIG_SNAPSHOT_DIR'] = os.path.join(config_dir, 'snapshots')
@@ -146,7 +154,9 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True):
     # create subdirectories that need to exist (but are empty)
     # ssl directory has to be created for keeping certs and keys
     p.Setup.MakeDir(ssl_dir)
-    p.Setup.Chown(ssl_dir, "nobody", "root", ignore=True)
+    p.Setup.Chown(ssl_dir, "nobody", "nobody", ignore=True)
+    # covers ubuntu's unprivileged server
+    p.Setup.Chown(ssl_dir, "nobody", "nogroup", ignore=True)
 
     # set env so traffic server uses correct locations
     p.Env['PROXY_CONFIG_SSL_DIR'] = ssl_dir
@@ -155,7 +165,10 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True):
     ########################################################
     # cache.db directory
     p.Setup.MakeDir(storage_dir)
-    p.Setup.Chown(storage_dir, "nobody", "root", ignore=True)
+    p.Setup.Chown(storage_dir, "nobody", "nobody", ignore=True)
+    # covers ubuntu's unprivileged group
+    p.Setup.Chown(storage_dir, "nobody", "nogroup", ignore=True)
+
     # set env so traffic server uses correct locations
     p.Env['PROXY_CONFIG_STORAGE_DIR'] = storage_dir
     p.Variables.STORAGEDIR = storage_dir

--- a/tests/gold_tests/autest-site/trafficserver.test.ext
+++ b/tests/gold_tests/autest-site/trafficserver.test.ext
@@ -76,7 +76,6 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True):
     # set root for this test
     p.Env['TS_ROOT'] = ts_dir
     p.Setup.MakeDir(ts_dir)
-
     # set bin location
 
     p.Env['PROXY_CONFIG_BIN_PATH'] = bin_dir
@@ -88,6 +87,9 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True):
 
     # copy all basic config files we need to get this to work
     cfg_dir = os.path.join(AUTEST_SITE_PATH, "min_cfg")
+
+    p.Setup.MakeDir(config_dir)
+    p.Setup.Chown(config_dir, "nobody", "root", ignore=True)
 
     for f in os.listdir(cfg_dir):
         p.Setup.CopyAs(os.path.join(cfg_dir, f), config_dir)
@@ -121,7 +123,7 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True):
     # create subdirectories that need to exist (but are empty)
     # log directory has to be created with correct permissions
     p.Setup.MakeDir(log_dir)  # log directory has to be created
-    p.Setup.Chown(log_dir, "nobody", "nobody", ignore=True)
+    p.Setup.Chown(log_dir, "nobody", "root", ignore=True)
 
     # set env so traffic server uses correct locations
     p.Env['PROXY_CONFIG_LOG_LOGFILE_DIR'] = log_dir
@@ -136,6 +138,7 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True):
     p.Variables.LOCALSTATEDIR = runtime_dir
 
     p.Setup.MakeDir(runtime_dir)
+    p.Setup.Chown(runtime_dir, "nobody", "root", ignore=True)
     # will need this for traffic_manager is it runs
     p.Setup.MakeDir(os.path.join(config_dir, 'snapshots'))
     p.Env['PROXY_CONFIG_SNAPSHOT_DIR'] = os.path.join(config_dir, 'snapshots')
@@ -143,7 +146,7 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True):
     # create subdirectories that need to exist (but are empty)
     # ssl directory has to be created for keeping certs and keys
     p.Setup.MakeDir(ssl_dir)
-    p.Setup.Chown(ssl_dir, "nobody", "nobody", ignore=True)
+    p.Setup.Chown(ssl_dir, "nobody", "root", ignore=True)
 
     # set env so traffic server uses correct locations
     p.Env['PROXY_CONFIG_SSL_DIR'] = ssl_dir
@@ -152,7 +155,7 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True):
     ########################################################
     # cache.db directory
     p.Setup.MakeDir(storage_dir)
-    p.Setup.Chown(storage_dir, "nobody", "nobody", ignore=True)
+    p.Setup.Chown(storage_dir, "nobody", "root", ignore=True)
     # set env so traffic server uses correct locations
     p.Env['PROXY_CONFIG_STORAGE_DIR'] = storage_dir
     p.Variables.STORAGEDIR = storage_dir


### PR DESCRIPTION
A problem I ran into when using AuTest in Docker is that since root access is by default, config_dir and runtime_dir had problems that prevented file from being modified. So the owner is changed to "nobody". Furthermore, the group don't have to be "nobody", and since some platforms use "nogroup", the group is now "root". 