### PR TITLE
Add append_block into MIOBuffer

### DIFF
--- a/iocore/eventsystem/I_IOBuffer.h
+++ b/iocore/eventsystem/I_IOBuffer.h
@@ -945,6 +945,14 @@ public:
   void append_block(IOBufferBlock *b);
 
   /**
+    Adds a block to the end of the block list. The block added to list
+    must be writable by this buffer and must not be writable by any
+    other buffer. For QUIC mostly
+
+  */
+  void append_block2(IOBufferBlock *b);
+
+  /**
     Adds a new block to the end of the block list. The size is determined
     by asize_index. See the remarks section for a mapping of indexes to
     buffer block sizes.


### PR DESCRIPTION
There is a something in old `append_block` which cause the lost of the blocks. 
For example:
 - The MIOBuffer should be empty (MIOBuffer::_writer is nullptr)
 - The first block of the chan should be writeable. 

So if we try to append a->b->c to an empty MIOBuffer. Then it should be _writer->a->b->c but if you try to append another chain d->e->f. The chain in MIOBuffer will change to _writer->a->e->f. It is totally different from my thought.

Add `append_block2` to make a last change as _writer->a->b->c->d->e->f. then _writer move forwards to f(_writer->f).

The reason I don't touch the `append_block` is https://github.com/apache/trafficserver/blob/dee68b4dffb50a2de776723437323aa872a98363/iocore/eventsystem/P_IOBuffer.h#L933-L957 . The comment in line 936

I'am not sure why it will break http. And how to reproduce that ?