### PR TITLE
Make sure autest has all minimal config files

### DIFF
--- a/ci/rat-regex.txt
+++ b/ci/rat-regex.txt
@@ -22,6 +22,7 @@
 .*\.default$
 .*\.default\.in$
 .*\.config$
+.*\.yaml$
 .*\.gold$
 ^\.gitignore$
 ^\.gitmodules$

--- a/tests/gold_tests/autest-site/min_cfg/logging.yaml
+++ b/tests/gold_tests/autest-site/min_cfg/logging.yaml
@@ -1,0 +1,1 @@
+# this files just needs to exist

--- a/tests/gold_tests/autest-site/min_cfg/plugin.config
+++ b/tests/gold_tests/autest-site/min_cfg/plugin.config
@@ -1,0 +1,1 @@
+# this files just needs to exist

--- a/tests/gold_tests/autest-site/min_cfg/socks.config
+++ b/tests/gold_tests/autest-site/min_cfg/socks.config
@@ -1,0 +1,1 @@
+# this files just needs to exist

--- a/tests/gold_tests/autest-site/min_cfg/splitdns.config
+++ b/tests/gold_tests/autest-site/min_cfg/splitdns.config
@@ -1,0 +1,1 @@
+# this files just needs to exist

--- a/tests/gold_tests/autest-site/min_cfg/ssl_server_name.yaml
+++ b/tests/gold_tests/autest-site/min_cfg/ssl_server_name.yaml
@@ -1,0 +1,1 @@
+# this files just needs to exist


### PR DESCRIPTION
This is necessary for work I'm doing to allow is to not write
to the config directory at all. This eliminates all the Rollback
code, however, autest now actually depends on the Rollback object
to create non-existing config files for it. Once I get everything
done eliminating Rollbacks, the goal is to make the core handle
non-existing config files the same as an empty file, but baby steps,
and these failures in autest makes testing difficult.

These are the ones I've found so far, there might be others.