### PR TITLE
Add options to sort to reduce os differences in all_headers test

### DIFF
--- a/tests/gold_tests/logging/all_headers.test.py
+++ b/tests/gold_tests/logging/all_headers.test.py
@@ -97,7 +97,7 @@ tr.Processes.Default.ReturnCode = 0
 #
 tr = Test.AddTestRun()
 tr.DelayStart = 10
-tr.Processes.Default.Command = 'python {0} {4} < {2} | . {1} > {3}'.format(
+tr.Processes.Default.Command = 'python {0} {4} < {2} | sh {1} > {3}'.format(
     os.path.join(Test.TestDirectory, 'all_headers_sanitizer.py'),
     os.path.join(Test.TestDirectory, 'all_headers_sanitizer.sh'),
     os.path.join(ts.Variables.LOGDIR, 'test_all_headers.log'),

--- a/tests/gold_tests/logging/all_headers_sanitizer.sh
+++ b/tests/gold_tests/logging/all_headers_sanitizer.sh
@@ -21,5 +21,5 @@ do
     # individual headers on separate lines, then sort the lines.
     #
     echo $LN | sed 's/}}/}}\
-/g' | sort
+/g' | sort --ignore-nonprinting  --dictionary-order
 done

--- a/tests/gold_tests/logging/gold/test_all_headers.gold
+++ b/tests/gold_tests/logging/gold/test_all_headers.gold
@@ -9,21 +9,21 @@
 
 ({__AGE__}}
 ({__ATS_SERVER__}}
-({__DATE__}}
 {{Cache-Control}:{max-age=85000}}
 {{Connection}:{keep-alive}}
 {{Content-Length}:{3}}
-
 ({__DATE__}}
+
 {{Cache-Control}:{max-age=85000}}
 {{Connection}:{close}}
 {{Content-Length}:{3}}
+({__DATE__}}
 
-({__VIA__}}
 {{Accept}:{*/*}}
 {{Client-ip}:{127.0.0.1}}
 {{Host}:{127.0.0.1__TS_PORT__}}
 {{User-Agent}:{007}}
+({__VIA__}}
 {{X-Forwarded-For}:{127.0.0.1}}
 {{x-header0}:{abcdefghijklmnopabcdefghijklmnopabcdefghijklmnopabcdefghijklmnopabcdefghijklmnopabcdefghijklmnopabcdefghijklmnopabcdefghijklmnop}}
 {{x-header1}:{abcdefghijklmnopabcdefghijklmnopabcdefghijklmnopabcdefghijklmnopabcdefghijklmnopabcdefghijklmnopabcdefghijklmnopabcdefghijklmnop}}
@@ -42,18 +42,18 @@ END_TXN
 
 ({__AGE__}}
 ({__ATS_SERVER__}}
-({__DATE__}}
 {{Cache-Control}:{max-age=85000}}
 {{Connection}:{keep-alive}}
 {{Content-Length}:{3}}
+({__DATE__}}
 
 
 
 ({__AGE__}}
 ({__ATS_SERVER__}}
-({__DATE__}}
 {{Cache-Control}:{max-age=85000}}
 {{Connection}:{keep-alive}}
 {{Content-Length}:{3}}
+({__DATE__}}
 END_TXN
 


### PR DESCRIPTION
@zwoop and I are having problems with all_headers test on Centos 7.  @ywkaras added logic to sort the header output to avoid failures from ATS sending back the headers in different orders.  However, it appears that the unix sort utilities has variances depending on the OS.  This test currently passes on the PR autest.  It also passes in our internal CI on Rhel7.  But when I run on Centos 7 the __DATE__ gets sorted differently.

This PR adds options to sort to explicitly direct how things should be sorted and updates the gold file.  Hopefully this makes everyone happy.