### PR TITLE
Doc: Remove origin KA note from removed setting

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -845,12 +845,6 @@ mptcp
          origin server has previously returned HTTP/1.1.
    ===== ======================================================================
 
-.. note::
-
-   If HTTP/1.1 is used, then |TS| can use keep-alive connections to origin servers.
-
-   If HTTP/1.0 is used, then |TS| can use keep-alive connections to origin servers.
-
 .. ts:cv:: CONFIG proxy.config.http.chunking.size INT 4096
    :overridable:
 


### PR DESCRIPTION
This note was originally from the setting
```proxy.config.http.send_http11_requests```
but was incorrectly moved to the chunking setting. Then the http11 setting
was killed off. So, this note should have been killed off too.

<img width="721" alt="TE_Admin_v1_5_deprecated pdf (page 410 of 504)-1" src="https://user-images.githubusercontent.com/387053/58195058-eff2d000-7c7b-11e9-82d8-57c5c9cc66c9.png">
