### PR TITLE
Clean up: Remove proxy.config.http.parent_proxy_routing_enable variable

### DIFF
--- a/configs/records.config.default.in
+++ b/configs/records.config.default.in
@@ -34,7 +34,6 @@ CONFIG proxy.config.http.insert_response_via_str INT 0
 #    https://docs.trafficserver.apache.org/records.config#parent-proxy-configuration
 #    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/parent.config.en.html
 ##############################################################################
-CONFIG proxy.config.http.parent_proxy_routing_enable INT 0
 CONFIG proxy.config.http.parent_proxy.retry_time INT 300
 CONFIG proxy.config.http.parent_proxy.connect_attempts_timeout INT 30
 CONFIG proxy.config.http.forward.proxy_auth_to_parent INT 0

--- a/doc/admin-guide/configuration/hierarchical-caching.en.rst
+++ b/doc/admin-guide/configuration/hierarchical-caching.en.rst
@@ -159,12 +159,6 @@ the configuration adjustments detailed below.
     configured to serve the child's origin server, no additional configuration is
     needed for the nodes acting as Traffic Server parent caches.
 
-#. Enable the parent caching option by adjusting
-   :ts:cv:`proxy.config.http.parent_proxy_routing_enable` in
-   :file:`records.config`. ::
-
-        CONFIG proxy.config.http.parent_proxy_routing_enable INT 1
-
 #. Identify the parent cache you want to use to service missed requests. To
    use parent failover, you must identify more than one parent cache so that
    when a parent cache is unavailable, requests are sent to another parent

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -1098,11 +1098,6 @@ mptcp
 Parent Proxy Configuration
 ==========================
 
-.. ts:cv:: CONFIG proxy.config.http.parent_proxy_routing_enable INT 0
-   :reloadable:
-
-   Enables (``1``) or disables (``0``) the parent caching option. Refer to :ref:`admin-hierarchical-caching`.
-
 .. ts:cv:: CONFIG proxy.config.http.parent_proxy.retry_time INT 300
    :reloadable:
    :overridable:

--- a/doc/locale/ja/LC_MESSAGES/admin-guide/configuration/hierachical-caching.en.po
+++ b/doc/locale/ja/LC_MESSAGES/admin-guide/configuration/hierachical-caching.en.po
@@ -124,12 +124,6 @@ msgid ""
 "proxy."
 msgstr ""
 
-#: ../../admin-guide/configuration/hierachical-caching.en.rst:143
-msgid ""
-"Enable the parent caching option by adjusting :ts:cv:`proxy.config.http."
-"parent_proxy_routing_enable` in :file:`records.config`. ::"
-msgstr ""
-
 #: ../../admin-guide/configuration/hierachical-caching.en.rst:57
 msgid ""
 "The figure below illustrates a simple cache hierarchy with a Traffic Server "

--- a/lib/perl/lib/Apache/TS/AdminClient.pm
+++ b/lib/perl/lib/Apache/TS/AdminClient.pm
@@ -485,7 +485,6 @@ The Apache Traffic Server Administration Manual will explain what these strings 
  proxy.config.http.parent_proxy.file
  proxy.config.http.parent_proxy.per_parent_connect_attempts
  proxy.config.http.parent_proxy.retry_time
- proxy.config.http.parent_proxy_routing_enable
  proxy.config.http.parent_proxy.total_connect_attempts
  proxy.config.http.post_connect_attempts_timeout
  proxy.config.http.post_copy_size

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -416,8 +416,6 @@ static const RecordElement RecordsConfig[] =
   //        ##############################
   //        # parent proxy configuration #
   //        ##############################
-  {RECT_CONFIG, "proxy.config.http.parent_proxy_routing_enable", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
-  ,
   {RECT_CONFIG, "proxy.config.http.parent_proxies", RECD_STRING, nullptr, RECU_DYNAMIC, RR_NULL, RECC_STR, ".*", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.http.parent_proxy.file", RECD_STRING, "parent.config", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}

--- a/src/traffic_server/InkAPITest.cc
+++ b/src/traffic_server/InkAPITest.cc
@@ -7093,16 +7093,6 @@ struct ParentTest {
     this->magic      = MAGIC_ALIVE;
     this->configured = false;
     this->browser    = synclient_txn_create();
-
-    /* If parent proxy routing is not enabled, enable it for the life of the test. */
-    RecGetRecordBool("proxy.config.http.parent_proxy_routing_enable", &this->parent_proxy_routing_enable);
-    if (!this->parent_proxy_routing_enable) {
-      rprintf(this->regtest, "enabling proxy.config.http.parent_proxy_routing_enable\n");
-      RecSetRecordInt("proxy.config.http.parent_proxy_routing_enable", 1, REC_SOURCE_EXPLICIT);
-
-      // Force the config change to sync.
-      RecExecConfigUpdateCbs(REC_UPDATE_REQUIRED);
-    }
   }
 
   ~ParentTest()
@@ -7135,7 +7125,6 @@ struct ParentTest {
   ClientTxn *browser;
   TSEventFunc handler;
 
-  RecBool parent_proxy_routing_enable;
   unsigned int magic;
 };
 
@@ -7259,8 +7248,6 @@ parent_proxy_handler(TSCont contp, TSEvent event, void *edata)
 
     } else {
       // Otherwise the test completed so clean up.
-      RecSetRecordInt("proxy.config.http.parent_proxy_routing_enable", ptest->parent_proxy_routing_enable, REC_SOURCE_EXPLICIT);
-
       TSContDataSet(contp, nullptr);
       delete ptest;
     }
@@ -7282,7 +7269,6 @@ parent_proxy_handler(TSCont contp, TSEvent event, void *edata)
     if (status != REGRESSION_TEST_INPROGRESS) {
       int *pstatus = ptest->pstatus;
 
-      RecSetRecordInt("proxy.config.http.parent_proxy_routing_enable", ptest->parent_proxy_routing_enable, REC_SOURCE_EXPLICIT);
       TSContDataSet(contp, nullptr);
       delete ptest;
 


### PR DESCRIPTION
The proxy.config.http.parent_proxy_routing_enable will only prevent sending the request to parent but doesn't prevent loading parent.config file. This behavior may lead to confusion. Having rules in parent.config file should be enough to enable parent proxy routing. 

