### PR TITLE
Removes the abort() from header_rewrite, and try to deal with errors

### DIFF
--- a/plugins/header_rewrite/matcher.h
+++ b/plugins/header_rewrite/matcher.h
@@ -23,6 +23,7 @@
 
 #include <string>
 #include <sstream>
+#include <stdexcept>
 
 #include "ts/ts.h"
 
@@ -73,9 +74,11 @@ public:
       std::stringstream ss;
       ss << _data;
       TSError("[%s] Invalid regex: failed to precompile: %s", PLUGIN_NAME, ss.str().c_str());
-      abort();
+      TSDebug(PLUGIN_NAME, "Invalid regex: failed to precompile: %s", ss.str().c_str());
+      throw std::runtime_error("Malformed regex");
+    } else {
+      TSDebug(PLUGIN_NAME, "Regex precompiled successfully");
     }
-    TSDebug(PLUGIN_NAME, "Regex precompiled successfully");
   }
 
   void


### PR DESCRIPTION
    Bryan suggested using exceptions here, rather than just producing errors
    in the log files. As ugly as it is, it does seem to work ... But I blame
    him for all future issues! Long term, I think it'd be better to eliminate
    the exceptions here, and fix all the various layers of returning and
    perculating errors all the way back up through the stack.

Closes #2424