### PR TITLE
QUIC: Send ping packets if PTO fired

### DIFF
--- a/iocore/net/P_QUICNetVConnection.h
+++ b/iocore/net/P_QUICNetVConnection.h
@@ -195,9 +195,9 @@ public:
   QUICConnectionErrorUPtr handle_frame(QUICEncryptionLevel level, const QUICFrame &frame) override;
 
   // QUICFrameGenerator
-  bool will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp) override;
+  bool will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num) override;
   QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                            ink_hrtime timestamp) override;
+                            uint32_t seq_num) override;
 
   int in_closed_queue = 0;
 
@@ -364,6 +364,9 @@ private:
 
   // QUICFrameGenerator
   void _on_frame_lost(QUICFrameInformationUPtr &info) override;
+
+  // seq_num in packetize_frame
+  uint32_t _seq_num = 0;
 };
 
 typedef int (QUICNetVConnection::*QUICNetVConnHandler)(int, void *);

--- a/iocore/net/P_QUICNetVConnection.h
+++ b/iocore/net/P_QUICNetVConnection.h
@@ -228,7 +228,6 @@ private:
   QUICPacketFactory _packet_factory;
   QUICFrameFactory _frame_factory;
   QUICAckFrameManager _ack_frame_manager;
-  QUICPinger _pinger;
   QUICPacketHeaderProtector _ph_protector;
   QUICRTTMeasure _rtt_measure;
   QUICApplicationMap *_application_map = nullptr;
@@ -239,6 +238,7 @@ private:
 
   // TODO: use custom allocator and make them std::unique_ptr or std::shared_ptr
   // or make them just member variables.
+  QUICPinger *_pinger                               = nullptr;
   QUICHandshake *_handshake_handler                 = nullptr;
   QUICHandshakeProtocol *_hs_protocol               = nullptr;
   QUICLossDetector *_loss_detector                  = nullptr;

--- a/iocore/net/quic/QUICAckFrameCreator.cc
+++ b/iocore/net/quic/QUICAckFrameCreator.cc
@@ -61,7 +61,7 @@ QUICAckFrameManager::update(QUICEncryptionLevel level, QUICPacketNumber packet_n
  */
 QUICFrame *
 QUICAckFrameManager::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t /* connection_credit */,
-                                    uint16_t maximum_frame_size, ink_hrtime timestamp)
+                                    uint16_t maximum_frame_size, uint32_t seq_num)
 {
   QUICAckFrame *ack_frame = nullptr;
 
@@ -87,7 +87,7 @@ QUICAckFrameManager::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uin
 }
 
 bool
-QUICAckFrameManager::will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp)
+QUICAckFrameManager::will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num)
 {
   // No ACK frame on ZERO_RTT level
   if (!this->_is_level_matched(level) || level == QUICEncryptionLevel::ZERO_RTT) {

--- a/iocore/net/quic/QUICAckFrameCreator.h
+++ b/iocore/net/quic/QUICAckFrameCreator.h
@@ -101,13 +101,13 @@ public:
   /*
    * Returns true only if should send ack.
    */
-  bool will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp) override;
+  bool will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num) override;
 
   /*
    * Calls create directly.
    */
   QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                            ink_hrtime timestamp) override;
+                            uint32_t seq_num) override;
 
   QUICFrameId issue_frame_id();
   uint8_t ack_delay_exponent() const;

--- a/iocore/net/quic/QUICAltConnectionManager.cc
+++ b/iocore/net/quic/QUICAltConnectionManager.cc
@@ -266,7 +266,7 @@ QUICAltConnectionManager::invalidate_alt_connections()
 }
 
 bool
-QUICAltConnectionManager::will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp)
+QUICAltConnectionManager::will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num)
 {
   if (!this->_is_level_matched(level)) {
     return false;
@@ -280,7 +280,7 @@ QUICAltConnectionManager::will_generate_frame(QUICEncryptionLevel level, ink_hrt
  */
 QUICFrame *
 QUICAltConnectionManager::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t /* connection_credit */,
-                                         uint16_t maximum_frame_size, ink_hrtime timestamp)
+                                         uint16_t maximum_frame_size, uint32_t seq_num)
 {
   QUICFrame *frame = nullptr;
   if (!this->_is_level_matched(level)) {

--- a/iocore/net/quic/QUICAltConnectionManager.h
+++ b/iocore/net/quic/QUICAltConnectionManager.h
@@ -83,9 +83,9 @@ public:
   virtual QUICConnectionErrorUPtr handle_frame(QUICEncryptionLevel level, const QUICFrame &frame) override;
 
   // QUICFrameGenerator
-  bool will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp) override;
+  bool will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num) override;
   QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                            ink_hrtime timestamp) override;
+                            uint32_t seq_num) override;
 
 private:
   struct AltConnectionInfo {

--- a/iocore/net/quic/QUICBidirectionalStream.cc
+++ b/iocore/net/quic/QUICBidirectionalStream.cc
@@ -352,15 +352,15 @@ QUICBidirectionalStream::reenable(VIO *vio)
 }
 
 bool
-QUICBidirectionalStream::will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp)
+QUICBidirectionalStream::will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num)
 {
-  return this->_local_flow_controller.will_generate_frame(level, timestamp) || !this->is_retransmited_frame_queue_empty() ||
+  return this->_local_flow_controller.will_generate_frame(level, seq_num) || !this->is_retransmited_frame_queue_empty() ||
          this->_write_vio.get_reader()->is_read_avail_more_than(0);
 }
 
 QUICFrame *
 QUICBidirectionalStream::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit,
-                                        uint16_t maximum_frame_size, ink_hrtime timestamp)
+                                        uint16_t maximum_frame_size, uint32_t seq_num)
 {
   SCOPED_MUTEX_LOCK(lock, this->_write_vio.mutex, this_ethread());
 
@@ -391,7 +391,7 @@ QUICBidirectionalStream::generate_frame(uint8_t *buf, QUICEncryptionLevel level,
   }
 
   // MAX_STREAM_DATA
-  frame = this->_local_flow_controller.generate_frame(buf, level, UINT16_MAX, maximum_frame_size, timestamp);
+  frame = this->_local_flow_controller.generate_frame(buf, level, UINT16_MAX, maximum_frame_size, seq_num);
   if (frame) {
     return frame;
   }
@@ -427,7 +427,7 @@ QUICBidirectionalStream::generate_frame(uint8_t *buf, QUICEncryptionLevel level,
     uint64_t stream_credit = this->_remote_flow_controller.credit();
     if (stream_credit == 0) {
       // STREAM_DATA_BLOCKED
-      frame = this->_remote_flow_controller.generate_frame(buf, level, UINT16_MAX, maximum_frame_size, timestamp);
+      frame = this->_remote_flow_controller.generate_frame(buf, level, UINT16_MAX, maximum_frame_size, seq_num);
       return frame;
     }
 

--- a/iocore/net/quic/QUICBidirectionalStream.h
+++ b/iocore/net/quic/QUICBidirectionalStream.h
@@ -44,9 +44,9 @@ public:
   int state_stream_closed(int event, void *data);
 
   // QUICFrameGenerator
-  bool will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp) override;
+  bool will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num) override;
   QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                            ink_hrtime timestamp) override;
+                            uint32_t seq_num) override;
 
   virtual QUICConnectionErrorUPtr recv(const QUICStreamFrame &frame) override;
   virtual QUICConnectionErrorUPtr recv(const QUICMaxStreamDataFrame &frame) override;

--- a/iocore/net/quic/QUICCryptoStream.cc
+++ b/iocore/net/quic/QUICCryptoStream.cc
@@ -102,7 +102,7 @@ QUICCryptoStream::write(const uint8_t *buf, int64_t len)
 }
 
 bool
-QUICCryptoStream::will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp)
+QUICCryptoStream::will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num)
 {
   return this->_write_buffer_reader->is_read_avail_more_than(0) || !this->is_retransmited_frame_queue_empty();
 }
@@ -112,7 +112,7 @@ QUICCryptoStream::will_generate_frame(QUICEncryptionLevel level, ink_hrtime time
  */
 QUICFrame *
 QUICCryptoStream::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t /* connection_credit */,
-                                 uint16_t maximum_frame_size, ink_hrtime timestamp)
+                                 uint16_t maximum_frame_size, uint32_t seq_num)
 {
   QUICConnectionErrorUPtr error = nullptr;
 

--- a/iocore/net/quic/QUICCryptoStream.h
+++ b/iocore/net/quic/QUICCryptoStream.h
@@ -53,9 +53,9 @@ public:
   int64_t write(const uint8_t *buf, int64_t len);
 
   // QUICFrameGenerator
-  bool will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp) override;
+  bool will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num) override;
   QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                            ink_hrtime timestamp) override;
+                            uint32_t seq_num) override;
 
 private:
   void _on_frame_acked(QUICFrameInformationUPtr &info) override;

--- a/iocore/net/quic/QUICFlowController.cc
+++ b/iocore/net/quic/QUICFlowController.cc
@@ -96,7 +96,7 @@ QUICFlowController::set_limit(QUICOffset limit)
 
 // For RemoteFlowController, caller of this function should also check QUICStreamManager::will_generate_frame()
 bool
-QUICFlowController::will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp)
+QUICFlowController::will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num)
 {
   if (!this->_is_level_matched(level)) {
     return false;
@@ -110,7 +110,7 @@ QUICFlowController::will_generate_frame(QUICEncryptionLevel level, ink_hrtime ti
  */
 QUICFrame *
 QUICFlowController::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t /* connection_credit */,
-                                   uint16_t maximum_frame_size, ink_hrtime timestamp)
+                                   uint16_t maximum_frame_size, uint32_t seq_num)
 {
   QUICFrame *frame = nullptr;
 

--- a/iocore/net/quic/QUICFlowController.h
+++ b/iocore/net/quic/QUICFlowController.h
@@ -60,9 +60,9 @@ public:
   virtual void set_limit(QUICOffset limit);
 
   // QUICFrameGenerator
-  bool will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp) override;
+  bool will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num) override;
   QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                            ink_hrtime timestamp) override;
+                            uint32_t seq_num) override;
 
 protected:
   QUICFlowController(uint64_t initial_limit) : _limit(initial_limit) {}

--- a/iocore/net/quic/QUICFrameGenerator.h
+++ b/iocore/net/quic/QUICFrameGenerator.h
@@ -30,14 +30,14 @@ class QUICFrameGenerator
 {
 public:
   virtual ~QUICFrameGenerator(){};
-  virtual bool will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp) = 0;
+  virtual bool will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num) = 0;
 
   /*
    * This function constructs an instance of QUICFrame on buf.
    * It returns a pointer for the frame if it succeeded, and returns nullptr if it failed.
    */
   virtual QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit,
-                                    uint16_t maximum_frame_size, ink_hrtime timestamp) = 0;
+                                    uint16_t maximum_frame_size, uint32_t seq_num) = 0;
 
   void on_frame_acked(QUICFrameId id);
   void on_frame_lost(QUICFrameId id);

--- a/iocore/net/quic/QUICHandshake.cc
+++ b/iocore/net/quic/QUICHandshake.cc
@@ -322,24 +322,24 @@ QUICHandshake::handle_frame(QUICEncryptionLevel level, const QUICFrame &frame)
 }
 
 bool
-QUICHandshake::will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp)
+QUICHandshake::will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num)
 {
   if (!this->_is_level_matched(level)) {
     return false;
   }
 
-  return this->_crypto_streams[static_cast<int>(level)].will_generate_frame(level, timestamp);
+  return this->_crypto_streams[static_cast<int>(level)].will_generate_frame(level, seq_num);
 }
 
 QUICFrame *
 QUICHandshake::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                              ink_hrtime timestamp)
+                              uint32_t seq_num)
 {
   QUICFrame *frame = nullptr;
 
   if (this->_is_level_matched(level)) {
     frame =
-      this->_crypto_streams[static_cast<int>(level)].generate_frame(buf, level, connection_credit, maximum_frame_size, timestamp);
+      this->_crypto_streams[static_cast<int>(level)].generate_frame(buf, level, connection_credit, maximum_frame_size, seq_num);
   }
 
   return frame;

--- a/iocore/net/quic/QUICHandshake.h
+++ b/iocore/net/quic/QUICHandshake.h
@@ -51,9 +51,9 @@ public:
   virtual QUICConnectionErrorUPtr handle_frame(QUICEncryptionLevel level, const QUICFrame &frame) override;
 
   // QUICFrameGenerator
-  bool will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp) override;
+  bool will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num) override;
   QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                            ink_hrtime timestamp) override;
+                            uint32_t seq_num) override;
 
   // for client side
   QUICConnectionErrorUPtr start(const QUICTPConfig &tp_config, QUICPacketFactory *packet_factory, bool vn_exercise_enabled);

--- a/iocore/net/quic/QUICLossDetector.h
+++ b/iocore/net/quic/QUICLossDetector.h
@@ -37,6 +37,7 @@
 #include "QUICFrameHandler.h"
 #include "QUICConnection.h"
 
+class QUICPinger;
 class QUICLossDetector;
 class QUICRTTMeasure;
 
@@ -88,6 +89,8 @@ public:
   uint32_t congestion_window() const;
   uint32_t current_ssthresh() const;
 
+  void add_extra_packets_count();
+
 private:
   Ptr<ProxyMutex> _cc_mutex;
 
@@ -96,6 +99,8 @@ private:
                                  QUICPacketInfo *largest_lost_packet);
   bool _in_window_lost(const std::map<QUICPacketNumber, QUICPacketInfo *> &lost_packets, QUICPacketInfo *largest_lost_packet,
                        ink_hrtime period) const;
+
+  uint32_t _extra_packets_count = 0;
 
   // [draft-17 recovery] 7.9.1. Constants of interest
   // Values will be loaded from records.config via QUICConfig at constructor
@@ -121,7 +126,7 @@ private:
 class QUICLossDetector : public Continuation, public QUICFrameHandler
 {
 public:
-  QUICLossDetector(QUICConnectionInfoProvider *info, QUICCongestionController *cc, QUICRTTMeasure *rtt_measure,
+  QUICLossDetector(QUICConnectionInfoProvider *info, QUICCongestionController *cc, QUICRTTMeasure *rtt_measure, QUICPinger *pinger,
                    const QUICLDConfig &ld_config);
   ~QUICLossDetector();
 
@@ -187,6 +192,7 @@ private:
   QUICConnectionInfoProvider *_info = nullptr;
   QUICRTTMeasure *_rtt_measure      = nullptr;
   QUICCongestionController *_cc     = nullptr;
+  QUICPinger *_pinger               = nullptr;
 };
 
 class QUICRTTMeasure : public QUICRTTProvider

--- a/iocore/net/quic/QUICPathValidator.cc
+++ b/iocore/net/quic/QUICPathValidator.cc
@@ -117,13 +117,13 @@ QUICPathValidator::handle_frame(QUICEncryptionLevel level, const QUICFrame &fram
 // QUICFrameGenerator
 //
 bool
-QUICPathValidator::will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp)
+QUICPathValidator::will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num)
 {
   if (!this->_is_level_matched(level)) {
     return false;
   }
 
-  if (this->_last_sent_at == timestamp) {
+  if (this->_latest_seq_num == seq_num) {
     return false;
   }
 
@@ -135,7 +135,7 @@ QUICPathValidator::will_generate_frame(QUICEncryptionLevel level, ink_hrtime tim
  */
 QUICFrame *
 QUICPathValidator::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t /* connection_credit */,
-                                  uint16_t maximum_frame_size, ink_hrtime timestamp)
+                                  uint16_t maximum_frame_size, uint32_t seq_num)
 {
   QUICFrame *frame = nullptr;
 
@@ -163,7 +163,7 @@ QUICPathValidator::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint6
     }
   }
 
-  this->_last_sent_at = timestamp;
+  this->_latest_seq_num = seq_num;
 
   return frame;
 }

--- a/iocore/net/quic/QUICPathValidator.h
+++ b/iocore/net/quic/QUICPathValidator.h
@@ -41,9 +41,9 @@ public:
   QUICConnectionErrorUPtr handle_frame(QUICEncryptionLevel level, const QUICFrame &frame) override;
 
   // QUICFrameGeneratro
-  bool will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp) override;
+  bool will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num) override;
   QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                            ink_hrtime timestamp) override;
+                            uint32_t seq_num) override;
 
 private:
   enum class ValidationState : int {
@@ -54,7 +54,7 @@ private:
   ValidationState _state      = ValidationState::NOT_VALIDATED;
   int _has_outgoing_challenge = 0;
   bool _has_outgoing_response = false;
-  ink_hrtime _last_sent_at    = 0;
+  uint32_t _latest_seq_num    = 0;
   uint8_t _incoming_challenge[QUICPathChallengeFrame::DATA_LEN];
   uint8_t _outgoing_challenge[QUICPathChallengeFrame::DATA_LEN * 3];
 

--- a/iocore/net/quic/QUICPinger.h
+++ b/iocore/net/quic/QUICPinger.h
@@ -28,13 +28,16 @@
 #include "QUICFrameHandler.h"
 #include "QUICFrameGenerator.h"
 
+#include "I_Lock.h"
+
 class QUICPinger : public QUICFrameGenerator
 {
 public:
-  QUICPinger() {}
+  QUICPinger() : _mutex(new_ProxyMutex()) {}
 
   void request(QUICEncryptionLevel level);
   void cancel(QUICEncryptionLevel level);
+  uint64_t count(QUICEncryptionLevel level);
 
   // QUICFrameGenerator
   bool will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp) override;
@@ -42,6 +45,7 @@ public:
                             ink_hrtime timestamp) override;
 
 private:
+  Ptr<ProxyMutex> _mutex;
   // Initial, 0/1-RTT, and Handshake
   uint64_t _need_to_fire[4] = {0};
 };

--- a/iocore/net/quic/QUICPinger.h
+++ b/iocore/net/quic/QUICPinger.h
@@ -40,12 +40,13 @@ public:
   uint64_t count(QUICEncryptionLevel level);
 
   // QUICFrameGenerator
-  bool will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp) override;
+  bool will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num) override;
   QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                            ink_hrtime timestamp) override;
+                            uint32_t seq_num) override;
 
 private:
   Ptr<ProxyMutex> _mutex;
   // Initial, 0/1-RTT, and Handshake
   uint64_t _need_to_fire[4] = {0};
+  uint32_t _latest_seq_num  = 0;
 };

--- a/iocore/net/quic/QUICStreamManager.cc
+++ b/iocore/net/quic/QUICStreamManager.cc
@@ -407,7 +407,7 @@ QUICStreamManager::set_default_application(QUICApplication *app)
 }
 
 bool
-QUICStreamManager::will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp)
+QUICStreamManager::will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num)
 {
   if (!this->_is_level_matched(level)) {
     return false;
@@ -419,7 +419,7 @@ QUICStreamManager::will_generate_frame(QUICEncryptionLevel level, ink_hrtime tim
   }
 
   for (QUICStreamVConnection *s = this->stream_list.head; s; s = s->link.next) {
-    if (s->will_generate_frame(level, timestamp)) {
+    if (s->will_generate_frame(level, seq_num)) {
       return true;
     }
   }
@@ -429,7 +429,7 @@ QUICStreamManager::will_generate_frame(QUICEncryptionLevel level, ink_hrtime tim
 
 QUICFrame *
 QUICStreamManager::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                                  ink_hrtime timestamp)
+                                  uint32_t seq_num)
 {
   QUICFrame *frame = nullptr;
 
@@ -444,7 +444,7 @@ QUICStreamManager::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint6
 
   // FIXME We should pick a stream based on priority
   for (QUICStreamVConnection *s = this->stream_list.head; s; s = s->link.next) {
-    frame = s->generate_frame(buf, level, connection_credit, maximum_frame_size, timestamp);
+    frame = s->generate_frame(buf, level, connection_credit, maximum_frame_size, seq_num);
     if (frame) {
       break;
     }

--- a/iocore/net/quic/QUICStreamManager.h
+++ b/iocore/net/quic/QUICStreamManager.h
@@ -63,9 +63,9 @@ public:
   virtual QUICConnectionErrorUPtr handle_frame(QUICEncryptionLevel level, const QUICFrame &frame) override;
 
   // QUICFrameGenerator
-  bool will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp) override;
+  bool will_generate_frame(QUICEncryptionLevel level, uint32_t timestamp) override;
   QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                            ink_hrtime timestamp) override;
+                            uint32_t timestamp) override;
 
 protected:
   virtual bool _is_level_matched(QUICEncryptionLevel level) override;

--- a/iocore/net/quic/QUICTypes.h
+++ b/iocore/net/quic/QUICTypes.h
@@ -75,9 +75,10 @@ constexpr QUICEncryptionLevel QUIC_ENCRYPTION_LEVELS[] = {
 
 // introduce by draft-19 kPacketNumberSpace
 enum class QUICPacketNumberSpace {
-  Initial,
-  Handshake,
-  ApplicationData,
+  None            = -1,
+  Initial         = 0,
+  Handshake       = 1,
+  ApplicationData = 2,
 };
 
 // Devide to QUICPacketType and QUICPacketLongHeaderType ?

--- a/iocore/net/quic/QUICUnidirectionalStream.cc
+++ b/iocore/net/quic/QUICUnidirectionalStream.cc
@@ -125,14 +125,14 @@ QUICSendStream::state_stream_closed(int event, void *data)
 }
 
 bool
-QUICSendStream::will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp)
+QUICSendStream::will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num)
 {
   return !this->is_retransmited_frame_queue_empty() || this->_write_vio.get_reader()->is_read_avail_more_than(0);
 }
 
 QUICFrame *
 QUICSendStream::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                               ink_hrtime timestamp)
+                               uint32_t seq_num)
 {
   SCOPED_MUTEX_LOCK(lock, this->_write_vio.mutex, this_ethread());
 
@@ -183,7 +183,7 @@ QUICSendStream::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t
     uint64_t stream_credit = this->_remote_flow_controller.credit();
     if (stream_credit == 0) {
       // STREAM_DATA_BLOCKED
-      frame = this->_remote_flow_controller.generate_frame(buf, level, UINT16_MAX, maximum_frame_size, timestamp);
+      frame = this->_remote_flow_controller.generate_frame(buf, level, UINT16_MAX, maximum_frame_size, seq_num);
       return frame;
     }
 
@@ -526,15 +526,15 @@ QUICReceiveStream::is_cancelled() const
 }
 
 bool
-QUICReceiveStream::will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp)
+QUICReceiveStream::will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num)
 {
-  return this->_local_flow_controller.will_generate_frame(level, timestamp) ||
+  return this->_local_flow_controller.will_generate_frame(level, seq_num) ||
          (this->_stop_sending_reason != nullptr && this->_is_stop_sending_sent == false);
 }
 
 QUICFrame *
 QUICReceiveStream::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                                  ink_hrtime timestamp)
+                                  uint32_t seq_num)
 {
   QUICFrame *frame = nullptr;
   // STOP_SENDING
@@ -548,7 +548,7 @@ QUICReceiveStream::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint6
   }
 
   // MAX_STREAM_DATA
-  frame = this->_local_flow_controller.generate_frame(buf, level, UINT16_MAX, maximum_frame_size, timestamp);
+  frame = this->_local_flow_controller.generate_frame(buf, level, UINT16_MAX, maximum_frame_size, seq_num);
   return frame;
 }
 

--- a/iocore/net/quic/QUICUnidirectionalStream.h
+++ b/iocore/net/quic/QUICUnidirectionalStream.h
@@ -37,9 +37,9 @@ public:
   int state_stream_closed(int event, void *data);
 
   // QUICFrameGenerator
-  bool will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp) override;
+  bool will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num) override;
   QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                            ink_hrtime timestamp) override;
+                            uint32_t seq_num) override;
 
   virtual QUICConnectionErrorUPtr recv(const QUICMaxStreamDataFrame &frame) override;
   virtual QUICConnectionErrorUPtr recv(const QUICStopSendingFrame &frame) override;
@@ -86,9 +86,9 @@ public:
   int state_stream_closed(int event, void *data);
 
   // QUICFrameGenerator
-  bool will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp) override;
+  bool will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num) override;
   QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                            ink_hrtime timestamp) override;
+                            uint32_t seq_num) override;
 
   virtual QUICConnectionErrorUPtr recv(const QUICStreamFrame &frame) override;
   virtual QUICConnectionErrorUPtr recv(const QUICStreamDataBlockedFrame &frame) override;


### PR DESCRIPTION
This is one of the performance issue.

```
7.6.  Probe Timeout

   Probe packets MUST NOT be blocked by the congestion controller.  A
   sender MUST however count these packets as being additionally in
   flight, since these packets add network load without establishing
   packet loss.  Note that sending probe packets might cause the
   sender's bytes in flight to exceed the congestion window until an
   acknowledgement is received that establishes loss or delivery of
   packets.
```

And will cause the client timeout when loss something( test with 100mb file) without this change.