### PR TITLE
JA3 plugin: Fix ja3 hooks for openssl 1.0.2

### DIFF
--- a/plugins/experimental/ja3_fingerprint/ja3_fingerprint.cc
+++ b/plugins/experimental/ja3_fingerprint/ja3_fingerprint.cc
@@ -270,7 +270,14 @@ client_hello_ja3_handler(TSCont contp, TSEvent event, void *edata)
 {
   TSVConn ssl_vc = reinterpret_cast<TSVConn>(edata);
   switch (event) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+  case TS_EVENT_SSL_SERVERNAME: {
+#elif OPENSSL_VERSION_NUMBER >= 0x10101000L
   case TS_EVENT_SSL_CLIENT_HELLO: {
+#else
+#error OpenSSL cannot be 1.1.0
+#endif
+
     TSSslConnection sslobj = TSVConnSSLConnectionGet(ssl_vc);
 
     // OpenSSL handle
@@ -421,7 +428,13 @@ TSPluginInit(int argc, const char *argv[])
     // SNI handler
     TSCont ja3_cont = TSContCreate(client_hello_ja3_handler, nullptr);
     TSVConnArgIndexReserve(PLUGIN_NAME, "used to pass ja3", &ja3_idx);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    TSHttpHookAdd(TS_SSL_SERVERNAME_HOOK, ja3_cont);
+#elif OPENSSL_VERSION_NUMBER >= 0x10101000L
     TSHttpHookAdd(TS_SSL_CLIENT_HELLO_HOOK, ja3_cont);
+#else
+#error OpenSSL cannot be 1.1.0
+#endif
     TSHttpHookAdd(TS_VCONN_CLOSE_HOOK, ja3_cont);
     TSHttpHookAdd(TS_HTTP_SEND_REQUEST_HDR_HOOK, TSContCreate(req_hdr_ja3_handler, nullptr));
   }
@@ -444,7 +457,13 @@ TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
   // Set up SNI handler for all TLS connections
   TSCont ja3_cont = TSContCreate(client_hello_ja3_handler, nullptr);
   TSVConnArgIndexReserve(PLUGIN_NAME, "Used to pass ja3", &ja3_idx);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+  TSHttpHookAdd(TS_SSL_SERVERNAME_HOOK, ja3_cont);
+#elif OPENSSL_VERSION_NUMBER >= 0x10101000L
   TSHttpHookAdd(TS_SSL_CLIENT_HELLO_HOOK, ja3_cont);
+#else
+#error OpenSSL cannot be 1.1.0
+#endif
   TSHttpHookAdd(TS_VCONN_CLOSE_HOOK, ja3_cont);
 
   return TS_SUCCESS;


### PR DESCRIPTION
Client Hello callback only exists for 1.1.1. For 1.0.2, we should stick to SNI hook.

(cherry picked from commit 92c1ac501789ea25d12158241a8f5c4974b7063c)