### PR TITLE
Ran clang-tidy before branching 9.0.0

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-Checks: -*,modernize-use-default-member-init,modernize-loop-convert,modernize-use-bool-literals,modernize-deprecated-headers,performance-unnecessary-value-param,performance-faster-string-find,modernize-raw-string-literal,modernize-redundant-void-arg,modernize-use-nullptr,modernize-use-override
+Checks: -*,google-readability-braces-around-statements,google-readability-casting,modernize-use-using,modernize-loop-convert,modernize-use-bool-literals,modernize-deprecated-headers,performance-unnecessary-value-param,performance-faster-string-find,modernize-raw-string-literal,modernize-redundant-void-arg,modernize-use-nullptr,modernize-use-override,performance-unnecessary-copy-initialization
 CheckOptions:
   - key: modernize-use-default-member-init.UseAssignment
     value: '1'

--- a/build/tidy.mk
+++ b/build/tidy.mk
@@ -20,8 +20,8 @@ Clang_Tidy_Options = -fix -fix-errors
 # just the C and C++ sources so we don't pick up lex and yacc files
 # for example.
 
-Clang_Tidy_CC_Files = $(filter %.c, $(sort $(1)))
-Clang_Tidy_CXX_Files = $(filter %.cc, $(sort $(1)))
+Clang_Tidy_CC_Files = $(filter %.c, $(sort $^))
+Clang_Tidy_CXX_Files = $(filter %.cc, $(sort $^))
 
 # clang-tidy rules. We expect these to be actions with something like
 # $(DIST_SOURCES) as the dependencies.rules. Note that $DIST_SOURCES
@@ -30,5 +30,5 @@ Clang_Tidy_CXX_Files = $(filter %.cc, $(sort $(1)))
 #
 # All this clearly requires GNU make.
 
-CXX_Clang_Tidy = $(foreach tidy_target, $(call Clang_Tidy_CXX_Files,$^), $(CLANG_TIDY) $(Clang_Tidy_Options) $(tidy_target) -- $(CXXCOMPILE) -x c++;)
-CC_Clang_Tidy = $(foreach tidy_target, $(call Clang_Tidy_CC_Files,$^), $(CLANG_TIDY) $(Clang_Tidy_Options) $(tidy_target) -- $(COMPILE) -x c;)
+CXX_Clang_Tidy = $(CLANG_TIDY) $(Clang_Tidy_Options) $(Clang_Tidy_CXX_Files) -- $(CXXCOMPILE) -x c++
+CC_Clang_Tidy = $(CLANG_TIDY) $(Clang_Tidy_Options) $(Clang_Tidy_CC_Files) -- $(COMPILE) -x c

--- a/example/cppapi/websocket/WSBuffer.cc
+++ b/example/cppapi/websocket/WSBuffer.cc
@@ -189,7 +189,7 @@ WSBuffer::ws_digest(std::string const &key)
   char digest_buf[WS_DIGEST_MAX];
   size_t digest_len = 0;
 
-  if (TSBase64Encode((char *)hash_buf, hash_len, digest_buf, WS_DIGEST_MAX, &digest_len) != TS_SUCCESS) {
+  if (TSBase64Encode(reinterpret_cast<char *>(hash_buf), hash_len, digest_buf, WS_DIGEST_MAX, &digest_len) != TS_SUCCESS) {
     return "base64encode-failed";
   }
 
@@ -244,9 +244,9 @@ WSBuffer::get_closing_code(std::string const &message, std::string *desc)
 {
   uint16_t code = 0;
   if (message.size() >= 2) {
-    code = (unsigned char)message[0];
+    code = static_cast<unsigned char>(message[0]);
     code <<= 8;
-    code += (unsigned char)message[1];
+    code += static_cast<unsigned char>(message[1]);
     if (desc) {
       *desc = message.substr(2);
     }

--- a/example/protocol/Protocol.c
+++ b/example/protocol/Protocol.c
@@ -49,8 +49,8 @@ accept_handler(TSCont contp, TSEvent event, void *edata)
   case TS_EVENT_NET_ACCEPT:
     /* Create a new mutex for the TxnSM, which is going
        to handle the incoming request. */
-    pmutex = (TSMutex)TSMutexCreate();
-    txn_sm = (TSCont)TxnSMCreate(pmutex, (TSVConn)edata, server_port);
+    pmutex = TSMutexCreate();
+    txn_sm = TxnSMCreate(pmutex, (TSVConn)edata, server_port);
 
     /* This is no reason for not grabbing the lock.
        So skip the routine which handle LockTry failure case. */

--- a/example/protocol/TxnSM.c
+++ b/example/protocol/TxnSM.c
@@ -175,7 +175,7 @@ state_start(TSCont contp, TSEvent event ATS_UNUSED, void *data ATS_UNUSED)
      INT64_MAX, so that we will always get TS_EVENT_VCONN_READ_READY
      event, but never TS_EVENT_VCONN_READ_COMPLETE event. */
   set_handler(txn_sm->q_current_handler, (TxnSMHandler)&state_interface_with_client);
-  txn_sm->q_client_read_vio = TSVConnRead(txn_sm->q_client_vc, (TSCont)contp, txn_sm->q_client_request_buffer, INT64_MAX);
+  txn_sm->q_client_read_vio = TSVConnRead(txn_sm->q_client_vc, contp, txn_sm->q_client_request_buffer, INT64_MAX);
 
   return TS_SUCCESS;
 }
@@ -239,7 +239,7 @@ state_read_request_from_client(TSCont contp, TSEvent event, TSVIO vio ATS_UNUSED
 
         /* Start to do cache lookup */
         TSDebug(PLUGIN_NAME, "Key material: file name is %s*****", txn_sm->q_file_name);
-        txn_sm->q_key = (TSCacheKey)CacheKeyCreate(txn_sm->q_file_name);
+        txn_sm->q_key = CacheKeyCreate(txn_sm->q_file_name);
 
         set_handler(txn_sm->q_current_handler, (TxnSMHandler)&state_handle_cache_lookup);
         txn_sm->q_pending_action = TSCacheRead(contp, txn_sm->q_key);
@@ -908,8 +908,7 @@ send_response_to_client(TSCont contp)
   TSDebug(PLUGIN_NAME, " . resp_len is %d", response_len);
 
   set_handler(txn_sm->q_current_handler, (TxnSMHandler)&state_interface_with_client);
-  txn_sm->q_client_write_vio =
-    TSVConnWrite(txn_sm->q_client_vc, (TSCont)contp, txn_sm->q_client_response_buffer_reader, response_len);
+  txn_sm->q_client_write_vio = TSVConnWrite(txn_sm->q_client_vc, contp, txn_sm->q_client_response_buffer_reader, response_len);
   return TS_SUCCESS;
 }
 

--- a/example/protocol_stack/protocol_stack.cc
+++ b/example/protocol_stack/protocol_stack.cc
@@ -31,7 +31,7 @@
 static int
 proto_stack_cb(TSCont contp ATS_UNUSED, TSEvent event, void *edata)
 {
-  TSHttpTxn txnp = (TSHttpTxn)edata;
+  TSHttpTxn txnp = static_cast<TSHttpTxn>(edata);
   const char *results[10];
   int count = 0;
   TSDebug(PLUGIN_NAME, "Protocols:");

--- a/example/query_remap/query_remap.c
+++ b/example/query_remap/query_remap.c
@@ -127,7 +127,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh ATS_UNUSED, TSRemapRequestInfo *rri)
     int hostidx = -1;
 
     /* make a copy of the query, as it is read only */
-    q = (char *)TSstrndup(req_query, req_query_len + 1);
+    q = TSstrndup(req_query, req_query_len + 1);
 
     /* parse query parameters */
     for (key = strtok_r(q, "&", &s); key != NULL;) {

--- a/example/secure_link/secure_link.c
+++ b/example/secure_link/secure_link.c
@@ -61,7 +61,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
 
   qh = TSUrlHttpQueryGet(rri->requestBufp, rri->requestUrl, &len);
   if (qh && len > 0) {
-    s = (char *)TSstrndup(qh, len);
+    s = TSstrndup(qh, len);
     if ((ptr = strtok_r(s, "&", &saveptr)) != NULL) {
       do {
         if ((val = strchr(ptr, '=')) != NULL) {

--- a/example/thread_pool/psi.c
+++ b/example/thread_pool/psi.c
@@ -422,7 +422,7 @@ _basename(const char *filename)
   char *cptr;
   const char *ptr = filename;
 
-  while ((cptr = strchr(ptr, (int)'/')) != NULL) {
+  while ((cptr = strchr(ptr, '/')) != NULL) {
     ptr = cptr + 1;
   }
   return ptr;

--- a/example/vconn_args/vconn_args.cc
+++ b/example/vconn_args/vconn_args.cc
@@ -38,7 +38,7 @@ vconn_arg_handler(TSCont contp, TSEvent event, void *edata)
     // Testing set argument
     int idx = 0;
     while (TSVConnArgIndexReserve(PLUGIN_NAME, "test", &idx) == TS_SUCCESS) {
-      char *buf = (char *)TSmalloc(64);
+      char *buf = static_cast<char *>(TSmalloc(64));
       snprintf(buf, 64, "Test Arg Idx %d", idx);
       TSVConnArgSet(ssl_vc, idx, (void *)buf);
       TSDebug(PLUGIN_NAME, "Successfully reserve and set arg #%d", idx);
@@ -65,7 +65,7 @@ vconn_arg_handler(TSCont contp, TSEvent event, void *edata)
     // Testing argget and delete
     int idx = 0;
     while (idx <= last_arg) {
-      char *buf = (char *)TSVConnArgGet(ssl_vc, idx);
+      char *buf = static_cast<char *>(TSVConnArgGet(ssl_vc, idx));
       if (buf) {
         TSDebug(PLUGIN_NAME, "Successfully retrieve vconn arg #%d: %s", idx, buf);
         TSfree(buf);

--- a/example/verify_cert/verify_cert.cc
+++ b/example/verify_cert/verify_cert.cc
@@ -52,7 +52,7 @@ debug_certificate(const char *msg, X509_NAME *name)
     long len;
     char *ptr;
     len = BIO_get_mem_data(bio, &ptr);
-    TSDebug(PLUGIN_NAME, "%s %.*s", msg, (int)len, ptr);
+    TSDebug(PLUGIN_NAME, "%s %.*s", msg, static_cast<int>(len), ptr);
   }
 
   BIO_free(bio);

--- a/include/tscpp/api/Headers.h
+++ b/include/tscpp/api/Headers.h
@@ -306,7 +306,7 @@ public:
    * @param an iterator which points to a single HeaderField value.
    * @return true if the header value was successfully erased.
    */
-  bool erase(iterator it);
+  bool erase(const iterator &it);
 
   /**
    * Append a value or a separated list of values to this HeaderField
@@ -473,7 +473,7 @@ public:
    * @param an iterator pointing to a header field.
    * @return true if the header field pointed to by the iterator was erased.
    */
-  bool erase(iterator it);
+  bool erase(const iterator &it);
 
   /**
    * Erase all headers whose name matches key (this is a case insensitive match).

--- a/iocore/cache/test/main.cc
+++ b/iocore/cache/test/main.cc
@@ -38,7 +38,7 @@ const char *GLOBAL_DATA = static_cast<char *>(ats_malloc(10 * 1024 * 1024 + 3));
 struct EventProcessorListener : Catch::TestEventListenerBase {
   using TestEventListenerBase::TestEventListenerBase; // inherit constructor
 
-  virtual void
+  void
   testRunStarting(Catch::TestRunInfo const &testRunInfo) override
   {
     BaseLogFile *base_log_file = new BaseLogFile("stderr");

--- a/iocore/cache/test/test_Alternate_L_to_S.cc
+++ b/iocore/cache/test/test_Alternate_L_to_S.cc
@@ -45,8 +45,8 @@ public:
     return 0;
   }
 
-  virtual void
-  handle_cache_event(int event, CacheTestBase *base)
+  void
+  handle_cache_event(int event, CacheTestBase *base) override
   {
     switch (event) {
     case CACHE_EVENT_OPEN_READ:
@@ -113,8 +113,8 @@ public:
     return 0;
   }
 
-  virtual void
-  handle_cache_event(int event, CacheTestBase *base)
+  void
+  handle_cache_event(int event, CacheTestBase *base) override
   {
     switch (event) {
     case CACHE_EVENT_OPEN_WRITE:

--- a/iocore/cache/test/test_Alternate_L_to_S_remove_L.cc
+++ b/iocore/cache/test/test_Alternate_L_to_S_remove_L.cc
@@ -56,8 +56,8 @@ public:
     return 0;
   }
 
-  virtual void
-  handle_cache_event(int event, CacheTestBase *base)
+  void
+  handle_cache_event(int event, CacheTestBase *base) override
   {
     switch (event) {
     case CACHE_EVENT_OPEN_READ:
@@ -109,8 +109,8 @@ public:
     return 0;
   }
 
-  virtual void
-  handle_cache_event(int event, CacheTestBase *base)
+  void
+  handle_cache_event(int event, CacheTestBase *base) override
   {
     switch (event) {
     case CACHE_EVENT_OPEN_READ_FAILED:
@@ -169,8 +169,8 @@ public:
     return 0;
   }
 
-  virtual void
-  handle_cache_event(int event, CacheTestBase *base)
+  void
+  handle_cache_event(int event, CacheTestBase *base) override
   {
     switch (event) {
     case CACHE_EVENT_OPEN_WRITE:

--- a/iocore/cache/test/test_Alternate_L_to_S_remove_S.cc
+++ b/iocore/cache/test/test_Alternate_L_to_S_remove_S.cc
@@ -49,8 +49,8 @@ public:
     return 0;
   }
 
-  virtual void
-  handle_cache_event(int event, CacheTestBase *base)
+  void
+  handle_cache_event(int event, CacheTestBase *base) override
   {
     switch (event) {
     case CACHE_EVENT_OPEN_READ:
@@ -110,8 +110,8 @@ public:
     return 0;
   }
 
-  virtual void
-  handle_cache_event(int event, CacheTestBase *base)
+  void
+  handle_cache_event(int event, CacheTestBase *base) override
   {
     switch (event) {
     case CACHE_EVENT_OPEN_READ_FAILED:
@@ -170,8 +170,8 @@ public:
     return 0;
   }
 
-  virtual void
-  handle_cache_event(int event, CacheTestBase *base)
+  void
+  handle_cache_event(int event, CacheTestBase *base) override
   {
     switch (event) {
     case CACHE_EVENT_OPEN_WRITE:

--- a/iocore/cache/test/test_Alternate_S_to_L.cc
+++ b/iocore/cache/test/test_Alternate_S_to_L.cc
@@ -45,8 +45,8 @@ public:
     return 0;
   }
 
-  virtual void
-  handle_cache_event(int event, CacheTestBase *base)
+  void
+  handle_cache_event(int event, CacheTestBase *base) override
   {
     switch (event) {
     case CACHE_EVENT_OPEN_READ:
@@ -113,8 +113,8 @@ public:
     return 0;
   }
 
-  virtual void
-  handle_cache_event(int event, CacheTestBase *base)
+  void
+  handle_cache_event(int event, CacheTestBase *base) override
   {
     switch (event) {
     case CACHE_EVENT_OPEN_WRITE:

--- a/iocore/cache/test/test_Alternate_S_to_L_remove_L.cc
+++ b/iocore/cache/test/test_Alternate_S_to_L_remove_L.cc
@@ -49,8 +49,8 @@ public:
     return 0;
   }
 
-  virtual void
-  handle_cache_event(int event, CacheTestBase *base)
+  void
+  handle_cache_event(int event, CacheTestBase *base) override
   {
     switch (event) {
     case CACHE_EVENT_OPEN_READ:
@@ -111,8 +111,8 @@ public:
     return 0;
   }
 
-  virtual void
-  handle_cache_event(int event, CacheTestBase *base)
+  void
+  handle_cache_event(int event, CacheTestBase *base) override
   {
     switch (event) {
     case CACHE_EVENT_OPEN_READ_FAILED:
@@ -171,8 +171,8 @@ public:
     return 0;
   }
 
-  virtual void
-  handle_cache_event(int event, CacheTestBase *base)
+  void
+  handle_cache_event(int event, CacheTestBase *base) override
   {
     switch (event) {
     case CACHE_EVENT_OPEN_WRITE:

--- a/iocore/cache/test/test_Alternate_S_to_L_remove_S.cc
+++ b/iocore/cache/test/test_Alternate_S_to_L_remove_S.cc
@@ -56,8 +56,8 @@ public:
     return 0;
   }
 
-  virtual void
-  handle_cache_event(int event, CacheTestBase *base)
+  void
+  handle_cache_event(int event, CacheTestBase *base) override
   {
     switch (event) {
     case CACHE_EVENT_OPEN_READ:
@@ -109,8 +109,8 @@ public:
     return 0;
   }
 
-  virtual void
-  handle_cache_event(int event, CacheTestBase *base)
+  void
+  handle_cache_event(int event, CacheTestBase *base) override
   {
     switch (event) {
     case CACHE_EVENT_OPEN_READ_FAILED:
@@ -169,8 +169,8 @@ public:
     return 0;
   }
 
-  virtual void
-  handle_cache_event(int event, CacheTestBase *base)
+  void
+  handle_cache_event(int event, CacheTestBase *base) override
   {
     switch (event) {
     case CACHE_EVENT_OPEN_WRITE:

--- a/iocore/cache/test/test_Update_L_to_S.cc
+++ b/iocore/cache/test/test_Update_L_to_S.cc
@@ -45,8 +45,8 @@ public:
     return 0;
   }
 
-  virtual void
-  handle_cache_event(int event, CacheTestBase *base)
+  void
+  handle_cache_event(int event, CacheTestBase *base) override
   {
     switch (event) {
     case CACHE_EVENT_OPEN_READ:
@@ -88,8 +88,8 @@ public:
     return 0;
   }
 
-  virtual void
-  handle_cache_event(int event, CacheTestBase *base)
+  void
+  handle_cache_event(int event, CacheTestBase *base) override
   {
     CacheWriteTest *wt = static_cast<CacheWriteTest *>(this->_wt);
     switch (event) {

--- a/iocore/cache/test/test_Update_S_to_L.cc
+++ b/iocore/cache/test/test_Update_S_to_L.cc
@@ -45,8 +45,8 @@ public:
     return 0;
   }
 
-  virtual void
-  handle_cache_event(int event, CacheTestBase *base)
+  void
+  handle_cache_event(int event, CacheTestBase *base) override
   {
     switch (event) {
     case CACHE_EVENT_OPEN_READ:
@@ -88,8 +88,8 @@ public:
     return 0;
   }
 
-  virtual void
-  handle_cache_event(int event, CacheTestBase *base)
+  void
+  handle_cache_event(int event, CacheTestBase *base) override
   {
     CacheWriteTest *wt = static_cast<CacheWriteTest *>(this->_wt);
     switch (event) {

--- a/iocore/cache/test/test_Update_header.cc
+++ b/iocore/cache/test/test_Update_header.cc
@@ -51,8 +51,8 @@ public:
     return 0;
   }
 
-  virtual void
-  handle_cache_event(int event, CacheTestBase *base)
+  void
+  handle_cache_event(int event, CacheTestBase *base) override
   {
     switch (event) {
     case CACHE_EVENT_OPEN_READ:
@@ -122,8 +122,8 @@ public:
     return 0;
   }
 
-  virtual void
-  handle_cache_event(int event, CacheTestBase *base)
+  void
+  handle_cache_event(int event, CacheTestBase *base) override
   {
     CacheWriteTest *wt = static_cast<CacheWriteTest *>(this->_wt);
     switch (event) {

--- a/iocore/eventsystem/IOBuffer.cc
+++ b/iocore/eventsystem/IOBuffer.cc
@@ -304,8 +304,9 @@ IOBufferChain::write(IOBufferBlock *blocks, int64_t length, int64_t offset)
         block_bytes -= offset; // bytes really available to use.
         offset = 0;
       }
-      if (block_bytes > n)
+      if (block_bytes > n) {
         bb->_end -= (block_bytes - n);
+      }
       // Attach the cloned block since its data will be kept.
       this->append(bb);
       n -= bytes;
@@ -324,8 +325,9 @@ IOBufferChain::write(IOBufferData *data, int64_t length, int64_t offset)
   int64_t zret     = 0;
   IOBufferBlock *b = new_IOBufferBlock();
 
-  if (length < 0)
+  if (length < 0) {
     length = 0;
+  }
 
   b->set(data, length, offset);
   this->append(b);

--- a/iocore/eventsystem/UnixEventProcessor.cc
+++ b/iocore/eventsystem/UnixEventProcessor.cc
@@ -37,7 +37,7 @@ class EventProcessor eventProcessor;
 
 class ThreadAffinityInitializer : public Continuation
 {
-  typedef ThreadAffinityInitializer self;
+  using self = ThreadAffinityInitializer;
 
 public:
   /// Default construct.

--- a/iocore/net/OCSPStapling.cc
+++ b/iocore/net/OCSPStapling.cc
@@ -494,8 +494,8 @@ ocsp_update()
       certinfo_map *map = stapling_get_cert_info(ctx);
       if (map) {
         // Walk over all certs associated with this CTX
-        for (certinfo_map::iterator iter = map->begin(); iter != map->end(); ++iter) {
-          cinf = iter->second;
+        for (auto &iter : *map) {
+          cinf = iter.second;
           ink_mutex_acquire(&cinf->stapling_mutex);
           current_time = time(nullptr);
           if ((cinf->resp_derlen == 0 || cinf->is_expire || cinf->expire_time < current_time) && !cinf->is_prefetched) {

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -153,8 +153,9 @@ NetAccept::init_accept_loop()
   int i, n;
   char thr_name[MAX_THREAD_NAME_LENGTH];
   size_t stacksize;
-  if (do_listen(BLOCKING))
+  if (do_listen(BLOCKING)) {
     return;
+  }
   REC_ReadConfigInteger(stacksize, "proxy.config.thread.default.stacksize");
   SET_CONTINUATION_HANDLER(this, &NetAccept::acceptLoopEvent);
 

--- a/iocore/net/YamlSNIConfig.cc
+++ b/iocore/net/YamlSNIConfig.cc
@@ -113,7 +113,7 @@ template <> struct convert<YamlSNIConfig::Item> {
   {
     for (auto &&item : node) {
       if (std::none_of(valid_sni_config_keys.begin(), valid_sni_config_keys.end(),
-                       [&item](std::string s) { return s == item.first.as<std::string>(); })) {
+                       [&item](const std::string &s) { return s == item.first.as<std::string>(); })) {
         throw YAML::ParserException(item.Mark(), "unsupported key " + item.first.as<std::string>());
       }
     }

--- a/mgmt/api/CoreAPI.cc
+++ b/mgmt/api/CoreAPI.cc
@@ -209,7 +209,7 @@ Lerror:
 #include <sys/ptrace.h>
 #include <cxxabi.h>
 
-typedef std::vector<pid_t> threadlist;
+using threadlist = std::vector<pid_t>;
 
 static threadlist
 threads_for_process(pid_t proc)

--- a/plugins/authproxy/authproxy.cc
+++ b/plugins/authproxy/authproxy.cc
@@ -627,7 +627,7 @@ AuthRequestIsTagged(TSHttpTxn txn)
 static int
 AuthProxyGlobalHook(TSCont /* cont ATS_UNUSED */, TSEvent event, void *edata)
 {
-  TSHttpTxn txn = (TSHttpTxn)edata;
+  TSHttpTxn txn = static_cast<TSHttpTxn>(edata);
 
   AuthLogDebug("handling event=%d edata=%p", (int)event, edata);
 
@@ -684,7 +684,7 @@ AuthParseOptions(int argc, const char **argv)
   for (;;) {
     int opt;
 
-    opt = getopt_long(argc, (char *const *)argv, "", longopt, nullptr);
+    opt = getopt_long(argc, const_cast<char *const *>(argv), "", longopt, nullptr);
     switch (opt) {
     case 'h':
       options->hostname = optarg;

--- a/plugins/authproxy/utils.cc
+++ b/plugins/authproxy/utils.cc
@@ -76,7 +76,7 @@ HttpDebugHeader(TSMBuffer mbuf, TSMLoc mhdr)
 
   blk   = TSIOBufferReaderStart(iobuf.reader);
   avail = TSIOBufferBlockReadAvail(blk, iobuf.reader);
-  ptr   = (const char *)TSIOBufferBlockReadStart(blk, iobuf.reader, &nbytes);
+  ptr   = TSIOBufferBlockReadStart(blk, iobuf.reader, &nbytes);
 
   AuthLogDebug("http request (%u of %u bytes):\n%*.*s", (unsigned)nbytes, (unsigned)avail, (int)nbytes, (int)nbytes, ptr);
 }
@@ -169,7 +169,7 @@ HttpGetOriginHost(TSMBuffer mbuf, TSMLoc mhdr, char *name, size_t namelen)
 
     if (host) {
       AuthLogDebug("using origin %.*s from host header", len, host);
-      len = std::min(len, (int)namelen - 1);
+      len = std::min(len, static_cast<int>(namelen) - 1);
       memcpy(name, host, len);
       name[len] = '\0';
       return true;
@@ -183,7 +183,7 @@ HttpGetOriginHost(TSMBuffer mbuf, TSMLoc mhdr, char *name, size_t namelen)
 
     if (host) {
       AuthLogDebug("using origin %.*s from request URL", len, host);
-      len = std::min(len, (int)namelen - 1);
+      len = std::min(len, static_cast<int>(namelen) - 1);
       memcpy(name, host, len);
       name[len] = '\0';
       return true;

--- a/plugins/background_fetch/background_fetch.cc
+++ b/plugins/background_fetch/background_fetch.cc
@@ -370,7 +370,7 @@ cont_bg_fetch(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
     // Debug info for this particular bg fetch (put all debug in here please)
     if (TSIsDebugTagSet(PLUGIN_NAME)) {
       char buf[INET6_ADDRSTRLEN];
-      const sockaddr *sockaddress = (const sockaddr *)&data->client_ip;
+      const sockaddr *sockaddress = reinterpret_cast<const sockaddr *>(&data->client_ip);
 
       switch (sockaddress->sa_family) {
       case AF_INET:
@@ -391,7 +391,7 @@ cont_bg_fetch(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
 
     // Setup the NetVC for background fetch
     TSAssert(nullptr == data->vc);
-    if ((data->vc = TSHttpConnectWithPluginId((sockaddr *)&data->client_ip, PLUGIN_NAME, 0)) != nullptr) {
+    if ((data->vc = TSHttpConnectWithPluginId(reinterpret_cast<sockaddr *>(&data->client_ip), PLUGIN_NAME, 0)) != nullptr) {
       TSHttpHdrPrint(data->mbuf, data->hdr_loc, data->req_io_buf);
       // We never send a body with the request. ToDo: Do we ever need to support that ?
       TSIOBufferWrite(data->req_io_buf, "\r\n", 2);

--- a/plugins/background_fetch/configs.cc
+++ b/plugins/background_fetch/configs.cc
@@ -40,7 +40,7 @@ BgFetchConfig::parseOptions(int argc, const char *argv[])
                                           {nullptr, no_argument, nullptr, '\0'}};
 
   while (true) {
-    int opt = getopt_long(argc, (char *const *)argv, "lc", longopt, nullptr);
+    int opt = getopt_long(argc, const_cast<char *const *>(argv), "lc", longopt, nullptr);
 
     if (opt == -1) {
       break;
@@ -190,7 +190,7 @@ BgFetchConfig::bgFetchAllowed(TSHttpTxn txnp) const
   // We could do this recursively, but following the linked list is probably more efficient.
   for (const BgFetchRule *r = _rules; nullptr != r; r = r->_next) {
     if (r->check_field_configured(txnp)) {
-      TSDebug(PLUGIN_NAME, "found field match %s, exclude %d", r->_field, (int)r->_exclude);
+      TSDebug(PLUGIN_NAME, "found field match %s, exclude %d", r->_field, static_cast<int>(r->_exclude));
       allow_bg_fetch = !r->_exclude;
       break;
     }

--- a/plugins/cache_promote/cache_promote.cc
+++ b/plugins/cache_promote/cache_promote.cc
@@ -60,7 +60,7 @@ public:
   {
     // This doesn't have to be perfect, since this is just chance sampling.
     // coverity[dont_call]
-    srand48((long)time(nullptr));
+    srand48(static_cast<long>(time(nullptr)));
   }
 
   void
@@ -182,7 +182,7 @@ struct LRUHashHasher {
   size_t
   operator()(const LRUHash *s) const
   {
-    return *((size_t *)s->_hash) ^ *((size_t *)(s->_hash + 9));
+    return *(reinterpret_cast<const size_t *>(s->_hash)) ^ *(reinterpret_cast<const size_t *>(s->_hash + 9));
   }
 };
 
@@ -233,7 +233,7 @@ public:
 
     // This doesn't have to be perfect, since this is just chance sampling.
     // coverity[dont_call]
-    srand48((long)time(nullptr) ^ (long)getpid() ^ (long)getppid());
+    srand48(static_cast<long>(time(nullptr)) ^ static_cast<long>(getpid()) ^ static_cast<long>(getppid()));
 
     return true;
   }
@@ -449,7 +449,7 @@ cont_handle_policy(TSCont contp, TSEvent event, void *edata)
 
   // Should not happen
   default:
-    TSDebug(PLUGIN_NAME, "Unhandled event %d", (int)event);
+    TSDebug(PLUGIN_NAME, "Unhandled event %d", static_cast<int>(event));
     break;
   }
 

--- a/plugins/cachekey/configs.cc
+++ b/plugins/cachekey/configs.cc
@@ -411,7 +411,7 @@ Configs::init(int argc, const char *argv[], bool perRemapConfig)
 
   for (;;) {
     int opt;
-    opt = getopt_long(argc, (char *const *)argv, "", longopt, nullptr);
+    opt = getopt_long(argc, const_cast<char *const *>(argv), "", longopt, nullptr);
 
     if (opt == -1) {
       break;

--- a/plugins/cachekey/plugin.cc
+++ b/plugins/cachekey/plugin.cc
@@ -161,7 +161,7 @@ TSRemapNewInstance(int argc, char *argv[], void **instance, char *errBuf, int er
 void
 TSRemapDeleteInstance(void *instance)
 {
-  Configs *config = (Configs *)instance;
+  Configs *config = static_cast<Configs *>(instance);
   delete config;
 }
 
@@ -177,7 +177,7 @@ TSRemapDeleteInstance(void *instance)
 TSRemapStatus
 TSRemapDoRemap(void *instance, TSHttpTxn txn, TSRemapRequestInfo *rri)
 {
-  Configs *config = (Configs *)instance;
+  Configs *config = static_cast<Configs *>(instance);
 
   if (nullptr != config) {
     setCacheKey(txn, config, rri);

--- a/plugins/compress/compress.cc
+++ b/plugins/compress/compress.cc
@@ -74,7 +74,7 @@ data_alloc(int compression_type, int compression_algorithms)
   Data *data;
   int err;
 
-  data                         = (Data *)TSmalloc(sizeof(Data));
+  data                         = static_cast<Data *>(TSmalloc(sizeof(Data)));
   data->downstream_vio         = nullptr;
   data->downstream_buffer      = nullptr;
   data->downstream_reader      = nullptr;
@@ -105,7 +105,7 @@ data_alloc(int compression_type, int compression_algorithms)
   }
 
   if (dictionary) {
-    err = deflateSetDictionary(&data->zstrm, (const Bytef *)dictionary, strlen(dictionary));
+    err = deflateSetDictionary(&data->zstrm, reinterpret_cast<const Bytef *>(dictionary), strlen(dictionary));
     if (err != Z_OK) {
       fatal("gzip-transform: ERROR: deflateSetDictionary (%d)!", err);
     }
@@ -309,7 +309,7 @@ gzip_transform_one(Data *data, const char *upstream_buffer, int64_t upstream_len
     downstream_blkp         = TSIOBufferStart(data->downstream_buffer);
     char *downstream_buffer = TSIOBufferBlockWriteStart(downstream_blkp, &downstream_length);
 
-    data->zstrm.next_out  = (unsigned char *)downstream_buffer;
+    data->zstrm.next_out  = reinterpret_cast<unsigned char *>(downstream_buffer);
     data->zstrm.avail_out = downstream_length;
 
     if (!data->hc->flush()) {
@@ -450,12 +450,12 @@ gzip_transform_finish(Data *data)
       downstream_blkp = TSIOBufferStart(data->downstream_buffer);
 
       char *downstream_buffer = TSIOBufferBlockWriteStart(downstream_blkp, &downstream_length);
-      data->zstrm.next_out    = (unsigned char *)downstream_buffer;
+      data->zstrm.next_out    = reinterpret_cast<unsigned char *>(downstream_buffer);
       data->zstrm.avail_out   = downstream_length;
 
       int err = deflate(&data->zstrm, Z_FINISH);
 
-      if (downstream_length > (int64_t)data->zstrm.avail_out) {
+      if (downstream_length > static_cast<int64_t>(data->zstrm.avail_out)) {
         TSIOBufferProduce(data->downstream_buffer, downstream_length - data->zstrm.avail_out);
         data->downstream_length += (downstream_length - data->zstrm.avail_out);
       }
@@ -470,7 +470,7 @@ gzip_transform_finish(Data *data)
       break;
     }
 
-    if (data->downstream_length != (int64_t)(data->zstrm.total_out)) {
+    if (data->downstream_length != static_cast<int64_t>(data->zstrm.total_out)) {
       error("gzip-transform: output lengths don't match (%d, %ld)", data->downstream_length, data->zstrm.total_out);
     }
 
@@ -530,7 +530,7 @@ compress_transform_do(TSCont contp)
   int64_t upstream_todo;
   int64_t downstream_bytes_written;
 
-  data = (Data *)TSContDataGet(contp);
+  data = static_cast<Data *>(TSContDataGet(contp));
   if (data->state == transform_state_initialized) {
     compress_transform_init(contp, data);
   }
@@ -587,7 +587,7 @@ static int
 compress_transform(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   if (TSVConnClosedGet(contp)) {
-    data_destroy((Data *)TSContDataGet(contp));
+    data_destroy(static_cast<Data *>(TSContDataGet(contp)));
     TSContDestroy(contp);
     return 0;
   } else {
@@ -811,10 +811,10 @@ find_host_configuration(TSHttpTxn /* txnp ATS_UNUSED */, TSMBuffer bufp, TSMLoc 
 static int
 transform_plugin(TSCont contp, TSEvent event, void *edata)
 {
-  TSHttpTxn txnp        = (TSHttpTxn)edata;
+  TSHttpTxn txnp        = static_cast<TSHttpTxn>(edata);
   int compress_type     = COMPRESSION_TYPE_DEFAULT;
   int algorithms        = ALGORITHM_DEFAULT;
-  HostConfiguration *hc = (HostConfiguration *)TSContDataGet(contp);
+  HostConfiguration *hc = static_cast<HostConfiguration *>(TSContDataGet(contp));
 
   switch (event) {
   case TS_EVENT_HTTP_READ_RESPONSE_HDR:
@@ -939,7 +939,7 @@ handle_request(TSHttpTxn txnp, Configuration *config)
 static int
 transform_global_plugin(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
 {
-  TSHttpTxn txnp = (TSHttpTxn)edata;
+  TSHttpTxn txnp = static_cast<TSHttpTxn>(edata);
 
   switch (event) {
   case TS_EVENT_HTTP_READ_REQUEST_HDR:
@@ -959,7 +959,7 @@ transform_global_plugin(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edat
 static void
 load_global_configuration(TSCont contp)
 {
-  const char *path         = (const char *)TSContDataGet(contp);
+  const char *path         = static_cast<const char *>(TSContDataGet(contp));
   Configuration *newconfig = Configuration::Parse(path);
   Configuration *oldconfig = __sync_lock_test_and_set(&cur_config, newconfig);
 
@@ -1083,7 +1083,7 @@ TSRemapDoRemap(void *instance, TSHttpTxn txnp, TSRemapRequestInfo *rri)
     info("No Rules configured, falling back to default");
   } else {
     info("Remap Rules configured for compress");
-    Configuration *config = (Configuration *)instance;
+    Configuration *config = static_cast<Configuration *>(instance);
     // Handle compress request and use the configs populated from remap instance
     handle_request(txnp, config);
   }

--- a/plugins/compress/configuration.cc
+++ b/plugins/compress/configuration.cc
@@ -46,7 +46,7 @@ ltrim_if(string &s, int (*fp)(int))
 void
 rtrim_if(string &s, int (*fp)(int))
 {
-  for (ssize_t i = (ssize_t)s.size() - 1; i >= 0; i--) {
+  for (ssize_t i = static_cast<ssize_t>(s.size()) - 1; i >= 0; i--) {
     if (fp(s[i])) {
       s.erase(i, 1);
     } else {

--- a/plugins/compress/misc.cc
+++ b/plugins/compress/misc.cc
@@ -32,7 +32,7 @@
 voidpf
 gzip_alloc(voidpf /* opaque ATS_UNUSED */, uInt items, uInt size)
 {
-  return (voidpf)TSmalloc(items * size);
+  return static_cast<voidpf>(TSmalloc(items * size));
 }
 
 void
@@ -63,12 +63,12 @@ normalize_accept_encoding(TSHttpTxn /* txnp ATS_UNUSED */, TSMBuffer reqp, TSMLo
         --value_count;
         val = TSMimeHdrFieldValueStringGet(reqp, hdr_loc, field, value_count, &val_len);
 
-        if (val_len == (int)strlen("br")) {
+        if (val_len == static_cast<int>(strlen("br"))) {
           br = !strncmp(val, "br", val_len);
         }
-        if (val_len == (int)strlen("gzip")) {
+        if (val_len == static_cast<int>(strlen("gzip"))) {
           gzip = !strncmp(val, "gzip", val_len);
-        } else if (val_len == (int)strlen("deflate")) {
+        } else if (val_len == static_cast<int>(strlen("deflate"))) {
           deflate = !strncmp(val, "deflate", val_len);
         }
       }
@@ -139,7 +139,7 @@ init_hidden_header_name()
     fatal("failed to get server name");
   } else {
     int hidden_header_name_len                 = strlen("x-accept-encoding-") + strlen(result);
-    hidden_header_name                         = (char *)TSmalloc(hidden_header_name_len + 1);
+    hidden_header_name                         = static_cast<char *>(TSmalloc(hidden_header_name_len + 1));
     hidden_header_name[hidden_header_name_len] = 0;
     sprintf(hidden_header_name, "x-accept-encoding-%s", result);
   }

--- a/plugins/escalate/escalate.cc
+++ b/plugins/escalate/escalate.cc
@@ -84,7 +84,7 @@ MakeEscalateUrl(TSMBuffer mbuf, TSMLoc url, const char *host, size_t host_len, i
 static int
 EscalateResponse(TSCont cont, TSEvent event, void *edata)
 {
-  TSHttpTxn txn       = (TSHttpTxn)edata;
+  TSHttpTxn txn       = static_cast<TSHttpTxn>(edata);
   EscalationState *es = static_cast<EscalationState *>(TSContDataGet(cont));
   EscalationState::StatusMapType::const_iterator entry;
   TSMBuffer mbuf;
@@ -111,12 +111,12 @@ EscalateResponse(TSCont cont, TSEvent event, void *edata)
   TSHandleMLocRelease(mbuf, TS_NULL_MLOC, hdrp); // Don't need this any more
 
   // See if we have an escalation retry config for this response code
-  entry = es->status_map.find((unsigned)status);
+  entry = es->status_map.find(static_cast<unsigned>(status));
   if (entry == es->status_map.end()) {
     goto no_action;
   }
 
-  TSDebug(PLUGIN_NAME, "Found an entry for HTTP status %u", (unsigned)status);
+  TSDebug(PLUGIN_NAME, "Found an entry for HTTP status %u", static_cast<unsigned>(status));
   if (EscalationState::RETRY_URL == entry->second.type) {
     url_str = TSstrdup(entry->second.target.c_str());
     url_len = entry->second.target.size();
@@ -195,7 +195,7 @@ TSRemapNewInstance(int argc, char *argv[], void **instance, char *errbuf, int er
         unsigned status = strtol(token, nullptr, 10);
 
         if (status < 100 || status > 599) {
-          snprintf(errbuf, errbuf_size, "invalid status code: %.*s", (int)std::distance(argv[i], sep), argv[i]);
+          snprintf(errbuf, errbuf_size, "invalid status code: %.*s", static_cast<int>(std::distance(argv[i], sep)), argv[i]);
           goto fail;
         }
 

--- a/plugins/esi/esi.cc
+++ b/plugins/esi/esi.cc
@@ -713,7 +713,8 @@ transformData(TSCont contp)
   if (process_input_complete) {
     TSDebug(cont_data->debug_tag, "[%s] Completed reading input", __FUNCTION__);
     if (cont_data->input_type == DATA_TYPE_PACKED_ESI) {
-      TSDebug(DEBUG_TAG, "[%s] Going to use packed node list of size %d", __FUNCTION__, (int)cont_data->packed_node_list.size());
+      TSDebug(DEBUG_TAG, "[%s] Going to use packed node list of size %d", __FUNCTION__,
+              static_cast<int>(cont_data->packed_node_list.size()));
       if (cont_data->esi_proc->usePackedNodeList(cont_data->packed_node_list) == EsiProcessor::UNPACK_FAILURE) {
         removeCacheKey(cont_data->txnp);
 
@@ -777,7 +778,7 @@ transformData(TSCont contp)
             out_data     = "";
           } else {
             TSDebug(cont_data->debug_tag, "[%s] Compressed document from size %d to %d bytes", __FUNCTION__, out_data_len,
-                    (int)cdata.size());
+                    static_cast<int>(cdata.size()));
             out_data_len = cdata.size();
             out_data     = cdata.data();
           }
@@ -824,7 +825,7 @@ transformData(TSCont contp)
 
     if (retval == EsiProcessor::SUCCESS) {
       TSDebug(cont_data->debug_tag, "[%s] ESI processor output document of size %d starting with [%.10s]", __FUNCTION__,
-              (int)out_data.size(), (out_data.size() ? out_data.data() : "(null)"));
+              static_cast<int>(out_data.size()), (out_data.size() ? out_data.data() : "(null)"));
     } else {
       TSError("[esi][%s] ESI processor failed to process document; will return empty document", __FUNCTION__);
       out_data.assign("");
@@ -841,8 +842,8 @@ transformData(TSCont contp)
         if (!cont_data->esi_gzip->stream_encode(out_data, cdata)) {
           TSError("[esi][%s] Error while gzipping content", __FUNCTION__);
         } else {
-          TSDebug(cont_data->debug_tag, "[%s] Compressed document from size %d to %d bytes", __FUNCTION__, (int)out_data.size(),
-                  (int)cdata.size());
+          TSDebug(cont_data->debug_tag, "[%s] Compressed document from size %d to %d bytes", __FUNCTION__,
+                  static_cast<int>(out_data.size()), static_cast<int>(cdata.size()));
         }
       }
 
@@ -1002,8 +1003,8 @@ transformHandler(TSCont contp, TSEvent event, void *edata)
     }
   }
 
-  TSDebug(cont_data->debug_tag, "[%s] transformHandler, event: %d, curr_state: %d", __FUNCTION__, (int)event,
-          (int)cont_data->curr_state);
+  TSDebug(cont_data->debug_tag, "[%s] transformHandler, event: %d, curr_state: %d", __FUNCTION__, static_cast<int>(event),
+          static_cast<int>(cont_data->curr_state));
 
   shutdown = (cont_data->xform_closed && (cont_data->curr_state == ContData::PROCESSING_COMPLETE));
   if (shutdown) {
@@ -1496,11 +1497,11 @@ pthread_key_t threadKey = 0;
 static int
 globalHookHandler(TSCont contp, TSEvent event, void *edata)
 {
-  TSHttpTxn txnp                 = (TSHttpTxn)edata;
+  TSHttpTxn txnp                 = static_cast<TSHttpTxn>(edata);
   bool intercept_header          = false;
   bool head_only                 = false;
   bool intercept_req             = isInterceptRequest(txnp);
-  struct OptionInfo *pOptionInfo = (struct OptionInfo *)TSContDataGet(contp);
+  struct OptionInfo *pOptionInfo = static_cast<struct OptionInfo *>(TSContDataGet(contp));
 
   switch (event) {
   case TS_EVENT_HTTP_READ_REQUEST_HDR:
@@ -1602,7 +1603,7 @@ esiPluginInit(int argc, const char *argv[], struct OptionInfo *pOptionInfo)
     };
 
     int longindex = 0;
-    while ((c = getopt_long(argc, (char *const *)argv, "npzbf:", longopts, &longindex)) != -1) {
+    while ((c = getopt_long(argc, const_cast<char *const *>(argv), "npzbf:", longopts, &longindex)) != -1) {
       switch (c) {
       case 'n':
         pOptionInfo->packed_node_support = true;
@@ -1665,9 +1666,9 @@ TSPluginInit(int argc, const char *argv[])
     return;
   }
 
-  struct OptionInfo *pOptionInfo = (struct OptionInfo *)TSmalloc(sizeof(struct OptionInfo));
+  struct OptionInfo *pOptionInfo = static_cast<struct OptionInfo *>(TSmalloc(sizeof(struct OptionInfo)));
   if (pOptionInfo == nullptr) {
-    TSError("[esi][%s] malloc %d bytes fail", __FUNCTION__, (int)sizeof(struct OptionInfo));
+    TSError("[esi][%s] malloc %d bytes fail", __FUNCTION__, static_cast<int>(sizeof(struct OptionInfo)));
     return;
   }
   if (esiPluginInit(argc, argv, pOptionInfo) != 0) {
@@ -1731,10 +1732,10 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_s
   }
   new_argv[index] = nullptr;
 
-  struct OptionInfo *pOptionInfo = (struct OptionInfo *)TSmalloc(sizeof(struct OptionInfo));
+  struct OptionInfo *pOptionInfo = static_cast<struct OptionInfo *>(TSmalloc(sizeof(struct OptionInfo)));
   if (pOptionInfo == nullptr) {
-    snprintf(errbuf, errbuf_size, "malloc %d bytes fail", (int)sizeof(struct OptionInfo));
-    TSError("[esi][%s] malloc %d bytes fail", __FUNCTION__, (int)sizeof(struct OptionInfo));
+    snprintf(errbuf, errbuf_size, "malloc %d bytes fail", static_cast<int>(sizeof(struct OptionInfo)));
+    TSError("[esi][%s] malloc %d bytes fail", __FUNCTION__, static_cast<int>(sizeof(struct OptionInfo)));
     return TS_ERROR;
   }
   if (esiPluginInit(index, new_argv, pOptionInfo) != 0) {

--- a/plugins/esi/fetcher/HttpDataFetcherImpl.cc
+++ b/plugins/esi/fetcher/HttpDataFetcherImpl.cc
@@ -77,10 +77,10 @@ HttpDataFetcherImpl::addFetchRequest(const string &url, FetchedDataProcessor *ca
   int length;
 
   length = sizeof("GET ") - 1 + url.length() + sizeof(" HTTP/1.0\r\n") - 1 + _headers_str.length() + sizeof("\r\n") - 1;
-  if (length < (int)sizeof(buff)) {
+  if (length < static_cast<int>(sizeof(buff))) {
     http_req = buff;
   } else {
-    http_req = (char *)malloc(length + 1);
+    http_req = static_cast<char *>(malloc(length + 1));
     if (http_req == nullptr) {
       TSError("[HttpDataFetcherImpl][%s] malloc %d bytes fail", __FUNCTION__, length + 1);
       return false;

--- a/plugins/esi/serverIntercept.cc
+++ b/plugins/esi/serverIntercept.cc
@@ -281,7 +281,7 @@ processRequest(SContData *cont_data)
 static int
 serverIntercept(TSCont contp, TSEvent event, void *edata)
 {
-  TSDebug(DEBUG_TAG, "[%s] Received event: %d", __FUNCTION__, (int)event);
+  TSDebug(DEBUG_TAG, "[%s] Received event: %d", __FUNCTION__, static_cast<int>(event));
 
   SContData *cont_data = static_cast<SContData *>(TSContDataGet(contp));
   bool read_complete   = false;

--- a/plugins/experimental/access_control/common.cc
+++ b/plugins/experimental/access_control/common.cc
@@ -42,7 +42,7 @@ string2int(const StringView &s)
 {
   time_t t = 0;
   try {
-    t = (time_t)std::stoi(String(s));
+    t = static_cast<time_t>(std::stoi(String(s)));
   } catch (...) {
     /* Failed to convert return impossible value */
     return 0;

--- a/plugins/experimental/access_control/config.cc
+++ b/plugins/experimental/access_control/config.cc
@@ -206,27 +206,27 @@ AccessControlConfig::init(int argc, char *argv[])
     switch (opt) {
     case 'a': /* invalid-syntax-status-code */
     {
-      _invalidSignature = (TSHttpStatus)string2int(optarg);
+      _invalidSignature = static_cast<TSHttpStatus>(string2int(optarg));
     } break;
     case 'b': /* invalid-signature-status-code */
     {
-      _invalidSignature = (TSHttpStatus)string2int(optarg);
+      _invalidSignature = static_cast<TSHttpStatus>(string2int(optarg));
     } break;
     case 'c': /* invalid-timing-status-code */
     {
-      _invalidTiming = (TSHttpStatus)string2int(optarg);
+      _invalidTiming = static_cast<TSHttpStatus>(string2int(optarg));
     } break;
     case 'd': /* invalid-scope-status-code */
     {
-      _invalidScope = (TSHttpStatus)string2int(optarg);
+      _invalidScope = static_cast<TSHttpStatus>(string2int(optarg));
     } break;
     case 'e': /* invalid-origin-response */
     {
-      _invalidOriginResponse = (TSHttpStatus)string2int(optarg);
+      _invalidOriginResponse = static_cast<TSHttpStatus>(string2int(optarg));
     } break;
     case 'f': /* internal-error-status-code */
     {
-      _internalError = (TSHttpStatus)string2int(optarg);
+      _internalError = static_cast<TSHttpStatus>(string2int(optarg));
     } break;
     case 'g': /* check-cookie */
     {

--- a/plugins/experimental/access_control/plugin.cc
+++ b/plugins/experimental/access_control/plugin.cc
@@ -139,7 +139,7 @@ TSRemapNewInstance(int argc, char *argv[], void **instance, char *errBuf, int er
 void
 TSRemapDeleteInstance(void *instance)
 {
-  AccessControlConfig *config = (AccessControlConfig *)instance;
+  AccessControlConfig *config = static_cast<AccessControlConfig *>(instance);
   delete config;
 }
 
@@ -399,7 +399,7 @@ contHandleAccessControl(const TSCont contp, TSEvent event, void *edata)
               /* Don't set any cookie, fail the request here returning appropriate status code and body.*/
               TSHttpTxnStatusSet(txnp, config->_invalidOriginResponse);
               static const char *body = "Unexpected Response From the Origin Server\n";
-              char *buf               = (char *)TSmalloc(strlen(body) + 1);
+              char *buf               = static_cast<char *>(TSmalloc(strlen(body) + 1));
               sprintf(buf, "%s", body);
               TSHttpTxnErrorBodySet(txnp, buf, strlen(buf), nullptr);
 
@@ -570,7 +570,7 @@ TSRemapStatus
 TSRemapDoRemap(void *instance, TSHttpTxn txnp, TSRemapRequestInfo *rri)
 {
   TSRemapStatus remapStatus   = TSREMAP_NO_REMAP;
-  AccessControlConfig *config = (AccessControlConfig *)instance;
+  AccessControlConfig *config = static_cast<AccessControlConfig *>(instance);
 
   if (nullptr != config) {
     /* Plugin is designed to be used only with TLS, check the scheme */

--- a/plugins/experimental/access_control/utils.cc
+++ b/plugins/experimental/access_control/utils.cc
@@ -78,7 +78,7 @@ hexEncode(const char *in, size_t inLen, char *out, size_t outLen)
   char *dst          = out;
   char *dstEnd       = out + outLen;
 
-  while (src < srcEnd && dst < dstEnd && 2 == sprintf(dst, "%02x", (unsigned char)*src)) {
+  while (src < srcEnd && dst < dstEnd && 2 == sprintf(dst, "%02x", static_cast<unsigned char>(*src))) {
     dst += 2;
     src++;
   }
@@ -94,12 +94,15 @@ hexEncode(const char *in, size_t inLen, char *out, size_t outLen)
 static unsigned char
 hex2uchar(char c)
 {
-  if (c >= '0' && c <= '9')
+  if (c >= '0' && c <= '9') {
     return c - '0';
-  if (c >= 'a' && c <= 'f')
+  }
+  if (c >= 'a' && c <= 'f') {
     return c - 'a' + 10;
-  if (c >= 'A' && c <= 'F')
+  }
+  if (c >= 'A' && c <= 'F') {
     return c - 'A' + 10;
+  }
   return 255;
 }
 
@@ -141,14 +144,14 @@ urlEncode(const char *in, size_t inLen, char *out, size_t outLen)
 {
   const char *src = in;
   char *dst       = out;
-  while ((size_t)(src - in) < inLen && (size_t)(dst - out) < outLen) {
+  while (static_cast<size_t>(src - in) < inLen && static_cast<size_t>(dst - out) < outLen) {
     if (isalnum(*src) || *src == '-' || *src == '_' || *src == '.' || *src == '~') {
       *dst++ = *src;
     } else if (*src == ' ') {
       *dst++ = '+';
     } else {
       *dst++ = '%';
-      sprintf(dst, "%02x", (unsigned char)*src);
+      sprintf(dst, "%02x", static_cast<unsigned char>(*src));
       dst += 2;
     }
     src++;
@@ -170,11 +173,11 @@ urlDecode(const char *in, size_t inLen, char *out, size_t outLen)
 {
   const char *src = in;
   char *dst       = out;
-  while ((size_t)(src - in) < inLen && (size_t)(dst - out) < outLen) {
+  while (static_cast<size_t>(src - in) < inLen && static_cast<size_t>(dst - out) < outLen) {
     if (*src == '%') {
       if (src[1] && src[2]) {
         int u  = hex2uchar(*(src + 1)) << 4 | hex2uchar(*(src + 2));
-        *dst++ = (char)u;
+        *dst++ = static_cast<char>(u);
         src += 2;
       }
     } else if (*src == '+') {
@@ -255,7 +258,7 @@ cryptoMessageDigestGet(const char *digestType, const char *data, size_t dataLen,
     AccessControlError("failed to create EVP message digest context: %s", cryptoErrStr(buffer, sizeof(buffer)));
   } else {
 #ifndef OPENSSL_IS_BORINGSSL
-    if (!(pkey = EVP_PKEY_new_mac_key(EVP_PKEY_HMAC, nullptr, (const unsigned char *)key, keyLen))) {
+    if (!(pkey = EVP_PKEY_new_mac_key(EVP_PKEY_HMAC, nullptr, reinterpret_cast<const unsigned char *>(key), keyLen))) {
 #else
     if (false) {
 #endif
@@ -278,7 +281,7 @@ cryptoMessageDigestGet(const char *digestType, const char *data, size_t dataLen,
           break;
         }
 
-        if (1 != EVP_DigestSignFinal(ctx, (unsigned char *)out, &len)) {
+        if (1 != EVP_DigestSignFinal(ctx, reinterpret_cast<unsigned char *>(out), &len)) {
           AccessControlError("failed to finalize the signing hash. %s", cryptoErrStr(buffer, sizeof(buffer)));
         }
 

--- a/plugins/experimental/balancer/balancer.cc
+++ b/plugins/experimental/balancer/balancer.cc
@@ -44,7 +44,7 @@ MakeBalancerInstance(const char *opt)
   } else if (len == lengthof("roundrobin") && strncmp(opt, "roundrobin", len) == 0) {
     return MakeRoundRobinBalancer(end ? end + 1 : nullptr);
   } else {
-    TSError("[balancer] Invalid balancing policy '%.*s'", (int)len, opt);
+    TSError("[balancer] Invalid balancing policy '%.*s'", static_cast<int>(len), opt);
     return nullptr;
   }
 }
@@ -163,13 +163,13 @@ TSRemapNewInstance(int argc, char *argv[], void **instance, char *errbuf, int er
 void
 TSRemapDeleteInstance(void *instance)
 {
-  delete (BalancerInstance *)instance;
+  delete static_cast<BalancerInstance *>(instance);
 }
 
 TSRemapStatus
 TSRemapDoRemap(void *instance, TSHttpTxn txn, TSRemapRequestInfo *rri)
 {
-  BalancerInstance *balancer   = (BalancerInstance *)instance;
+  BalancerInstance *balancer   = static_cast<BalancerInstance *>(instance);
   const BalancerTarget &target = balancer->balance(txn, rri);
 
   if (TSIsDebugTagSet("balancer")) {

--- a/plugins/experimental/buffer_upload/buffer_upload.cc
+++ b/plugins/experimental/buffer_upload/buffer_upload.cc
@@ -168,7 +168,7 @@ write_buffer_to_disk(TSIOBufferReader reader, pvc_state *my_state, TSCont contp)
   block = TSIOBufferReaderStart(reader);
   while (block != nullptr) {
     ptr  = TSIOBufferBlockReadStart(block, reader, &size);
-    pBuf = (char *)TSmalloc(sizeof(char) * size);
+    pBuf = static_cast<char *>(TSmalloc(sizeof(char) * size));
     if (pBuf == nullptr) {
       LOG_ERROR_AND_RETURN("TSAIOWrite");
     }
@@ -266,7 +266,7 @@ pvc_process_accept(TSCont contp, int event, void *edata, pvc_state *my_state)
   TSDebug(DEBUG_TAG, "plugin called: pvc_process_accept with event %d", event);
 
   if (event == TS_EVENT_NET_ACCEPT) {
-    my_state->p_vc = (TSVConn)edata;
+    my_state->p_vc = static_cast<TSVConn>(edata);
 
     my_state->req_buffer = TSIOBufferCreate();
     my_state->req_reader = TSIOBufferReaderAlloc(my_state->req_buffer);
@@ -609,7 +609,7 @@ convert_url_func(TSMBuffer req_bufp, TSMLoc req_loc)
 
   // for now we assume the <upload proxy service domain> in the format is the hostname
   // but this needs to be verified later
-  if ((NOT_VALID_PTR(str) || !strncmp(str, hostname, len)) && strlen(hostname) == (size_t)len) {
+  if ((NOT_VALID_PTR(str) || !strncmp(str, hostname, len)) && strlen(hostname) == static_cast<size_t>(len)) {
     const char *slash;
     const char *colon;
     // if (VALID_PTR(str))
@@ -628,7 +628,7 @@ convert_url_func(TSMBuffer req_bufp, TSMLoc req_loc)
     TSDebug(DEBUG_TAG, "convert_url_func working on path: %s", pathTmp);
     colon = strstr(str, ":");
     if (colon != nullptr && colon < slash) {
-      char *port_str = (char *)TSmalloc(sizeof(char) * (slash - colon));
+      char *port_str = static_cast<char *>(TSmalloc(sizeof(char) * (slash - colon)));
       strncpy(port_str, colon + 1, slash - colon - 1);
       port_str[slash - colon - 1] = '\0';
       TSUrlPortSet(req_bufp, url_loc, atoi(port_str));
@@ -662,7 +662,7 @@ convert_url_func(TSMBuffer req_bufp, TSMLoc req_loc)
 static int
 attach_pvc_plugin(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
 {
-  TSHttpTxn txnp = (TSHttpTxn)edata;
+  TSHttpTxn txnp = static_cast<TSHttpTxn>(edata);
   TSMutex mutex;
   TSCont new_cont;
   pvc_state *my_state;
@@ -837,7 +837,7 @@ attach_pvc_plugin(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
       break;
     }
 
-    my_state              = (pvc_state *)TSmalloc(sizeof(pvc_state));
+    my_state              = static_cast<pvc_state *>(TSmalloc(sizeof(pvc_state)));
     my_state->req_size    = content_length;
     my_state->p_vc        = nullptr;
     my_state->p_read_vio  = nullptr;
@@ -867,7 +867,7 @@ attach_pvc_plugin(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
     my_state->read_offset          = 0;
     my_state->is_reading_from_disk = 0;
 
-    my_state->chunk_buffer = (char *)TSmalloc(sizeof(char) * uconfig->chunk_size);
+    my_state->chunk_buffer = static_cast<char *>(TSmalloc(sizeof(char) * uconfig->chunk_size));
 
     my_state->disk_io_mutex = TSMutexCreate();
     if (NOT_VALID_PTR(my_state->disk_io_mutex)) {
@@ -901,7 +901,7 @@ attach_pvc_plugin(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
     if (uconfig->use_disk_buffer) {
       char path[500];
       // coverity[dont_call]
-      int index = (int)(random() % uconfig->subdir_num);
+      int index = static_cast<int>(random() % uconfig->subdir_num);
 
       sprintf(path, "%s/%02X/tmp-XXXXXX", uconfig->base_dir, index);
 
@@ -1008,7 +1008,7 @@ load_urls(char *filename)
   char *eol;
   int i;
 
-  url_buf                          = (char *)TSmalloc(sizeof(char) * (uconfig->max_url_length + 1));
+  url_buf                          = static_cast<char *>(TSmalloc(sizeof(char) * (uconfig->max_url_length + 1)));
   url_buf[uconfig->max_url_length] = '\0';
 
   for (i = 0; i < 2; i++) {
@@ -1022,7 +1022,7 @@ load_urls(char *filename)
       while (TSfgets(file, url_buf, uconfig->max_url_length) != nullptr) {
         uconfig->url_num++;
       }
-      uconfig->urls = (char **)TSmalloc(sizeof(char *) * uconfig->url_num);
+      uconfig->urls = static_cast<char **>(TSmalloc(sizeof(char *) * uconfig->url_num));
     } else { // second round
       int idx = 0;
       while (TSfgets(file, url_buf, uconfig->max_url_length) != nullptr && idx < uconfig->url_num) {
@@ -1061,7 +1061,7 @@ parse_config_line(char *line, const struct config_val_ul *cv)
           char *end = tok;
           int iv    = strtol(tok, &end, 10);
           if (end && *end == '\0') {
-            *((int *)cv->val) = iv;
+            *(static_cast<int *>(cv->val)) = iv;
             TSError("[%s] Parsed int config value %s : %d", PLUGIN_NAME, cv->str, iv);
             TSDebug(DEBUG_TAG, "Parsed int config value %s : %d", cv->str, iv);
           }
@@ -1071,7 +1071,7 @@ parse_config_line(char *line, const struct config_val_ul *cv)
           char *end        = tok;
           unsigned int uiv = strtoul(tok, &end, 10);
           if (end && *end == '\0') {
-            *((unsigned int *)cv->val) = uiv;
+            *(static_cast<unsigned int *>(cv->val)) = uiv;
             TSError("[%s] Parsed uint config value %s : %u", PLUGIN_NAME, cv->str, uiv);
             TSDebug(DEBUG_TAG, "Parsed uint config value %s : %u", cv->str, uiv);
           }
@@ -1081,7 +1081,7 @@ parse_config_line(char *line, const struct config_val_ul *cv)
           char *end = tok;
           long lv   = strtol(tok, &end, 10);
           if (end && *end == '\0') {
-            *((long *)cv->val) = lv;
+            *(static_cast<long *>(cv->val)) = lv;
             TSError("[%s] Parsed long config value %s : %ld", PLUGIN_NAME, cv->str, lv);
             TSDebug(DEBUG_TAG, "Parsed long config value %s : %ld", cv->str, lv);
           }
@@ -1091,7 +1091,7 @@ parse_config_line(char *line, const struct config_val_ul *cv)
           char *end         = tok;
           unsigned long ulv = strtoul(tok, &end, 10);
           if (end && *end == '\0') {
-            *((unsigned long *)cv->val) = ulv;
+            *(static_cast<unsigned long *>(cv->val)) = ulv;
             TSError("[%s] Parsed ulong config value %s : %lu", PLUGIN_NAME, cv->str, ulv);
             TSDebug(DEBUG_TAG, "Parsed ulong config value %s : %lu", cv->str, ulv);
           }
@@ -1100,8 +1100,8 @@ parse_config_line(char *line, const struct config_val_ul *cv)
         case TYPE_STRING: {
           size_t len = strlen(tok);
           if (len > 0) {
-            *((char **)cv->val) = (char *)TSmalloc(len + 1);
-            strcpy(*((char **)cv->val), tok);
+            *(static_cast<char **>(cv->val)) = static_cast<char *>(TSmalloc(len + 1));
+            strcpy(*(static_cast<char **>(cv->val)), tok);
             TSError("[%s] Parsed string config value %s : %s", PLUGIN_NAME, cv->str, tok);
             TSDebug(DEBUG_TAG, "Parsed string config value %s : %s", cv->str, tok);
           }
@@ -1111,12 +1111,12 @@ parse_config_line(char *line, const struct config_val_ul *cv)
           size_t len = strlen(tok);
           if (len > 0) {
             if (*tok == '1' || *tok == 't') {
-              *((bool *)cv->val) = true;
+              *(static_cast<bool *>(cv->val)) = true;
             } else {
-              *((bool *)cv->val) = false;
+              *(static_cast<bool *>(cv->val)) = false;
             }
-            TSError("[%s] Parsed bool config value %s : %d", PLUGIN_NAME, cv->str, *((bool *)cv->val));
-            TSDebug(DEBUG_TAG, "Parsed bool config value %s : %d", cv->str, *((bool *)cv->val));
+            TSError("[%s] Parsed bool config value %s : %d", PLUGIN_NAME, cv->str, *(static_cast<bool *>(cv->val)));
+            TSDebug(DEBUG_TAG, "Parsed bool config value %s : %d", cv->str, *(static_cast<bool *>(cv->val)));
           }
           break;
         }
@@ -1133,7 +1133,7 @@ bool
 read_upload_config(const char *file_name)
 {
   TSDebug(DEBUG_TAG, "read_upload_config: %s", file_name);
-  uconfig                  = (upload_config *)TSmalloc(sizeof(upload_config));
+  uconfig                  = static_cast<upload_config *>(TSmalloc(sizeof(upload_config)));
   uconfig->use_disk_buffer = true;
   uconfig->convert_url     = false;
   uconfig->chunk_size      = 16 * 1024;

--- a/plugins/experimental/certifier/certifier.cc
+++ b/plugins/experimental/certifier/certifier.cc
@@ -377,7 +377,7 @@ mkcrt(X509_REQ *req, int serial)
   }
   /// Set certificate time
   X509_gmtime_adj(X509_get_notBefore(cert.get()), 0);
-  X509_gmtime_adj(X509_get_notAfter(cert.get()), (long)3650 * 24 * 3600);
+  X509_gmtime_adj(X509_get_notAfter(cert.get()), static_cast<long>(3650) * 24 * 3600);
 
   /// Get a handle to csr subject name
   subj = X509_REQ_get_subject_name(req);
@@ -604,7 +604,7 @@ TSPluginInit(int argc, const char *argv[])
   int opt = 0;
 
   while (opt >= 0) {
-    opt = getopt_long(argc, (char *const *)argv, "c:k:r:m:s:", longopts, nullptr);
+    opt = getopt_long(argc, const_cast<char *const *>(argv), "c:k:r:m:s:", longopts, nullptr);
     switch (opt) {
     case 'c': {
       cert = optarg;

--- a/plugins/experimental/collapsed_forwarding/collapsed_forwarding.cc
+++ b/plugins/experimental/collapsed_forwarding/collapsed_forwarding.cc
@@ -312,9 +312,9 @@ process_args(int argc, const char **argv)
   // basic argv processing..
   for (int i = 1; i < argc; ++i) {
     if (strncmp(argv[i], "--delay=", 8) == 0) {
-      OPEN_WRITE_FAIL_REQ_DELAY_TIMEOUT = atoi((char *)(argv[i] + 8));
+      OPEN_WRITE_FAIL_REQ_DELAY_TIMEOUT = atoi(const_cast<char *>(argv[i] + 8));
     } else if (strncmp(argv[i], "--retries=", 10) == 0) {
-      OPEN_WRITE_FAIL_MAX_REQ_DELAY_RETRIES = atoi((char *)(argv[i] + 10));
+      OPEN_WRITE_FAIL_MAX_REQ_DELAY_RETRIES = atoi(const_cast<char *>(argv[i] + 10));
     }
   }
 }
@@ -327,7 +327,7 @@ TSPluginInit(int argc, const char *argv[])
 {
   TSPluginRegistrationInfo info;
 
-  info.plugin_name   = (char *)DEBUG_TAG;
+  info.plugin_name   = const_cast<char *>(DEBUG_TAG);
   info.vendor_name   = (char *)"Apache Software Foundation";
   info.support_email = (char *)"dev@trafficserver.apache.org";
 

--- a/plugins/experimental/cookie_remap/cookie_remap.cc
+++ b/plugins/experimental/cookie_remap/cookie_remap.cc
@@ -74,8 +74,9 @@ struct UrlComponents {
 
   ~UrlComponents()
   {
-    if (url != nullptr)
+    if (url != nullptr) {
       TSfree((void *)url);
+    }
   }
 
   void
@@ -160,8 +161,9 @@ dec_to_hex(type _num, char *hdigits)
   const char *hlookup = "0123456789ABCDEF"; // lookup table stores the hex digits into their
   // corresponding index.
 
-  if (_num < 0)
+  if (_num < 0) {
     _num *= -1; // and make _num positive to clear(zero) the sign bit
+  }
 
   char mask = 0x000f; // mask will clear(zero) out all the bits except lowest 4
   // which represent a single hex digit
@@ -206,11 +208,13 @@ public:
   ~subop()
   {
     TSDebug(MY_NAME, "subop destructor called");
-    if (regex)
+    if (regex) {
       pcre_free(regex);
+    }
 
-    if (regex_extra)
+    if (regex_extra) {
       pcre_free(regex_extra);
+    }
   }
 
   bool
@@ -274,10 +278,11 @@ public:
   void
   setTarget(const std::string &s)
   {
-    if (s == "uri")
+    if (s == "uri") {
       target = URI;
-    else
+    } else {
       target = COOKIE;
+    }
   }
 
   void
@@ -335,8 +340,9 @@ public:
       return false;
     }
 
-    if (pcre_fullinfo(regex, regex_extra, PCRE_INFO_CAPTURECOUNT, &regex_ccount) != 0)
+    if (pcre_fullinfo(regex, regex_extra, PCRE_INFO_CAPTURECOUNT, &regex_ccount) != 0) {
       return false;
+    }
 
     return true;
   }
@@ -403,7 +409,7 @@ private:
   unsigned int out_of   = 0;
 };
 
-typedef std::vector<const subop *> SubOpQueue;
+using SubOpQueue = std::vector<const subop *>;
 
 //----------------------------------------------------------------------------
 class op
@@ -446,10 +452,11 @@ public:
   void
   setStatus(const std::string &s)
   {
-    if (else_sendto.size() > 0)
+    if (else_sendto.size() > 0) {
       else_status = static_cast<TSHttpStatus>(atoi(s.c_str()));
-    else
+    } else {
       status = static_cast<TSHttpStatus>(atoi(s.c_str()));
+    }
   }
 
   void
@@ -468,8 +475,9 @@ public:
     for (auto subop : subops) {
       subop->printSubOp();
     }
-    if (else_sendto.size() > 0)
+    if (else_sendto.size() > 0) {
       TSDebug(MY_NAME, "else: %s", else_sendto.c_str());
+    }
   }
 
   bool
@@ -565,8 +573,9 @@ public:
         } // handled EXISTS / NOTEXISTS subops
 
         TSDebug(MY_NAME, "processing cookie data: \"%s\"", cookie_data.c_str());
-      } else
+      } else {
         target = URI;
+      }
 
       // INVARIANT: we now have the data from the cookie (if
       // any) inside
@@ -597,8 +606,9 @@ public:
 
         TSDebug(MY_NAME, "process req_url.path = %s", req_url.path.c_str());
         request_uri = req_url.path;
-        if (request_uri.length() && request_uri[0] != '/')
+        if (request_uri.length() && request_uri[0] != '/') {
           request_uri.insert(0, 1, '/');
+        }
         if (req_url.query_len > 0) {
           request_uri += '?';
           request_uri += std::string(req_url.query, req_url.query_len);
@@ -720,9 +730,10 @@ public:
     }
 
     if (retval == 1) {
-      if (dest.size() == 0) // Unless already set by one of
-                            // the operators (e.g. regex)
+      if (dest.size() == 0) { // Unless already set by one of
+                              // the operators (e.g. regex)
         dest = sendto;
+      }
       if (status > 0) {
         retstat = status;
       }
@@ -748,7 +759,7 @@ private:
 };
 
 typedef std::pair<std::string, std::string> StringPair;
-typedef std::vector<StringPair> OpMap;
+using OpMap = std::vector<StringPair>;
 
 //----------------------------------------------------------------------------
 static bool
@@ -821,7 +832,7 @@ error:
   return false;
 }
 
-typedef std::vector<const op *> OpsQueue;
+using OpsQueue = std::vector<const op *>;
 
 //----------------------------------------------------------------------------
 // init
@@ -891,7 +902,7 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_s
       }
     }
 
-    TSDebug(MY_NAME, "# of ops: %d", (int)ops->size());
+    TSDebug(MY_NAME, "# of ops: %d", static_cast<int>(ops->size()));
     *ih = static_cast<void *>(ops.release());
   } catch (const YAML::Exception &e) {
     TSError("YAML::Exception %s when parsing YAML config file %s for cookie_remap", e.what(), filename.c_str());
@@ -921,8 +932,9 @@ cr_substitutions(std::string &obj, TSRemapRequestInfo *rri)
   TSDebug(MY_NAME, "x req_url.url: %s %d", std::string(req_url.url, req_url.url_len).c_str(), req_url.url_len);
 
   while (pos < obj.length()) {
-    if (pos + 1 >= obj.length())
+    if (pos + 1 >= obj.length()) {
       break; // trailing ?
+    }
 
     switch (obj[pos + 1]) {
     case 'p':
@@ -951,7 +963,7 @@ cr_substitutions(std::string &obj, TSRemapRequestInfo *rri)
       }
       break;
     case 'c':
-      if (obj.substr(pos + 1, 3) == "cr_")
+      if (obj.substr(pos + 1, 3) == "cr_") {
         switch (obj[pos + 4]) {
         case 'r':
           if (obj.substr(pos + 4, 7) == "req_url") {
@@ -986,10 +998,12 @@ cr_substitutions(std::string &obj, TSRemapRequestInfo *rri)
           }
           break;
         }
+      }
       break;
     }
-    if (last_pos == pos)
+    if (last_pos == pos) {
       pos++; // don't search the same place again and again
+    }
     last_pos = pos;
     pos      = obj.find('$', pos);
   }
@@ -1003,7 +1017,7 @@ cr_substitutions(std::string &obj, TSRemapRequestInfo *rri)
 TSRemapStatus
 TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
 {
-  OpsQueue *ops       = (OpsQueue *)ih;
+  OpsQueue *ops       = static_cast<OpsQueue *>(ih);
   TSHttpStatus status = TS_HTTP_STATUS_NONE;
 
   UrlComponents req_url;
@@ -1053,8 +1067,9 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
       size_t tmp_pos = rewrite_to.find('?', pos); // we don't want to alter the query string
       do {
         pos = rewrite_to.find("//", pos);
-        if (pos < tmp_pos)
+        if (pos < tmp_pos) {
           rewrite_to.erase(pos, 1); // remove one '/'
+        }
       } while (pos <= rewrite_to.length() && pos < tmp_pos);
 
       // Add Query Parameters if not already present
@@ -1134,7 +1149,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
 void
 TSRemapDeleteInstance(void *ih)
 {
-  OpsQueue *ops = (OpsQueue *)ih;
+  OpsQueue *ops = static_cast<OpsQueue *>(ih);
 
   TSDebug(MY_NAME, "deleting loaded operations");
   for (auto &op : *ops) {

--- a/plugins/experimental/cookie_remap/cookiejar.cc
+++ b/plugins/experimental/cookie_remap/cookiejar.cc
@@ -75,8 +75,9 @@ CookieJar::parse(const string &arg, const char *sepstr, bool val_check, bool mai
   char *cp;
   char *key;
 
-  if ((arg_copy = strdup(arg.c_str())) == nullptr)
+  if ((arg_copy = strdup(arg.c_str())) == nullptr) {
     return -1;
+  }
 
   cp           = arg_copy;
   char empty[] = "";
@@ -106,8 +107,9 @@ CookieJar::parse(const string &arg, const char *sepstr, bool val_check, bool mai
         /* verify that the value is valid according to our configured
          * option and possibly strip out invalid characters. */
 
-        if (val_check && verify_value(addme, val_len) != 0)
+        if (val_check && verify_value(addme, val_len) != 0) {
           continue;
+        }
       } else {
         // Empty cookie case eg: "L="
         addme = empty;
@@ -121,13 +123,15 @@ CookieJar::parse(const string &arg, const char *sepstr, bool val_check, bool mai
      * cookie names only so we'll use the val_check variables
      * to know what we're processing */
 
-    if (val_check && verify_name(key) != 0)
+    if (val_check && verify_name(key) != 0) {
       continue;
+    }
 
-    if (mainElement)
+    if (mainElement) {
       addElement(key, addme);
-    else
+    } else {
       addSubElement(key, addme);
+    }
   }
 
   free(arg_copy);
@@ -162,8 +166,9 @@ CookieJar::verify_value(char *val, int val_len)
 
   if (val_len > static_cast<int>(sizeof(data_buf) - 1)) {
     buf_len = val_len + 1;
-    if ((data_ptr = static_cast<char *>(malloc(buf_len))) == nullptr)
+    if ((data_ptr = static_cast<char *>(malloc(buf_len))) == nullptr) {
       return -1;
+    }
 
     buf = data_ptr;
   } else {
@@ -172,8 +177,9 @@ CookieJar::verify_value(char *val, int val_len)
   }
 
   if (get_stripped(val, val_len, buf, &buf_len, 0) != STRIP_RESULT_OK) {
-    if (data_ptr)
+    if (data_ptr) {
       free(data_ptr);
+    }
     return -1;
   }
 
@@ -182,14 +188,16 @@ CookieJar::verify_value(char *val, int val_len)
    * with a bigger buffer than what we started with */
 
   if (buf_len > val_len + 1) {
-    if (data_ptr)
+    if (data_ptr) {
       free(data_ptr);
+    }
     return -1;
   }
 
   memcpy(val, buf, buf_len);
-  if (data_ptr)
+  if (data_ptr) {
     free(data_ptr);
+  }
 
   return 0;
 }
@@ -203,8 +211,9 @@ CookieJar::verify_name(char *name)
     /* if we get any invalid characters then return failure
      * in order to skip this cookie completely */
 
-    if (rfc_cookie_name_table[(int)*p] == 0)
+    if (rfc_cookie_name_table[static_cast<int>(*p)] == 0) {
       return -1;
+    }
   }
 
   return 0;
@@ -223,8 +232,9 @@ CookieJar::get_full(const string &cookie_name, string &val)
 bool
 CookieJar::get_part(const string &cookie_name, const string &part_name, string &val)
 {
-  if (m_jar.empty())
+  if (m_jar.empty()) {
     return false;
+  }
 
   if (m_jar.find(cookie_name) == m_jar.end()) {
     /* full cookie not found */
@@ -239,8 +249,9 @@ CookieJar::get_part(const string &cookie_name, const string &part_name, string &
      * we'll be passing 0/false for the val_check argument */
 
     m_currentVal = &fe;
-    if (parse(fe.m_val, "&", false, false) != 0)
+    if (parse(fe.m_val, "&", false, false) != 0) {
       return false;
+    }
 
     fe.parts_inited = true;
     m_currentVal    = nullptr;

--- a/plugins/experimental/cookie_remap/strip.cc
+++ b/plugins/experimental/cookie_remap/strip.cc
@@ -16,14 +16,14 @@
   limitations under the License.
 */
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include <sys/types.h>
-#include <stdlib.h>
-#include <limits.h>
-#include <ctype.h>
-#include <assert.h>
-#include <inttypes.h>
+#include <cstdlib>
+#include <climits>
+#include <cctype>
+#include <cassert>
+#include <cinttypes>
 
 #include "strip.h"
 
@@ -189,8 +189,9 @@ get_stripped(const char *in, ssize_t in_len, char *out, int *out_len, unsigned i
   char *w, *out_end;      /* where we write to, write limit */
 
   /* validate params */
-  if (in == NULL || in_len < 0 || out_len == NULL || *out_len < 0 || (out == NULL && *out_len > 0) || (flags & (~allowed_flags))) {
-    if (out != NULL && out_len != NULL && *out_len > 0) {
+  if (in == nullptr || in_len < 0 || out_len == nullptr || *out_len < 0 || (out == nullptr && *out_len > 0) ||
+      (flags & (~allowed_flags))) {
+    if (out != nullptr && out_len != nullptr && *out_len > 0) {
       *out     = '\0';
       *out_len = 1;
     }

--- a/plugins/experimental/custom_redirect/custom_redirect.cc
+++ b/plugins/experimental/custom_redirect/custom_redirect.cc
@@ -69,7 +69,7 @@ handle_response(TSHttpTxn txnp, TSCont /* contp ATS_UNUSED */)
             redirect_url_str = TSMimeHdrFieldValueStringGet(resp_bufp, resp_loc, redirect_url_loc, -1, &redirect_url_length);
             if (redirect_url_str) {
               if (redirect_url_length > 0) {
-                char *url = (char *)TSmalloc(redirect_url_length + 1);
+                char *url = static_cast<char *>(TSmalloc(redirect_url_length + 1));
 
                 TSstrlcpy(url, redirect_url_str, redirect_url_length + 1);
                 TSHttpTxnRedirectUrlSet(txnp, url, redirect_url_length);
@@ -92,7 +92,7 @@ plugin_main_handler(TSCont contp, TSEvent event, void *edata)
 {
   switch (event) {
   case TS_EVENT_HTTP_READ_RESPONSE_HDR: {
-    TSHttpTxn txnp = (TSHttpTxn)edata;
+    TSHttpTxn txnp = static_cast<TSHttpTxn>(edata);
     TSDebug("[custom_redirect1]", "MAIN_HANDLER::TS_HTTP_READ_RESPONSE_HDR_HOOK");
     handle_response(txnp, contp);
     break;

--- a/plugins/experimental/geoip_acl/geoip_acl.cc
+++ b/plugins/experimental/geoip_acl/geoip_acl.cc
@@ -106,8 +106,8 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
 
     if (!a->eval(rri, rh)) {
       TSDebug(PLUGIN_NAME, "denying request");
-      TSHttpTxnStatusSet((TSHttpTxn)rh, (TSHttpStatus)403);
-      a->send_html((TSHttpTxn)rh);
+      TSHttpTxnStatusSet(rh, static_cast<TSHttpStatus>(403));
+      a->send_html(rh);
     }
   }
 

--- a/plugins/experimental/header_normalize/header_normalize.cc
+++ b/plugins/experimental/header_normalize/header_normalize.cc
@@ -179,7 +179,7 @@ TSRemapDeleteInstance(void * /* ih */)
 static int
 read_request_hook(TSCont /* contp */, TSEvent /* event */, void *edata)
 {
-  TSHttpTxn rh = (TSHttpTxn)edata;
+  TSHttpTxn rh = static_cast<TSHttpTxn>(edata);
 
   TSMLoc hdr, next_hdr;
   TSMBuffer hdr_bufp;
@@ -215,7 +215,7 @@ read_request_hook(TSCont /* contp */, TSEvent /* event */, void *edata)
       // hdr returned by TSMimeHdrFieldNameGet is already
       // in camel case, just destroy the lowercase h2 header
       // and replace it with TSMimeHdrFieldNameGet
-      char *new_hdr_name = (char *)old_hdr_name;
+      char *new_hdr_name = const_cast<char *>(old_hdr_name);
       if (new_hdr_name) {
         TSMLoc new_hdr_loc;
         TSReturnCode rval = TSMimeHdrFieldCreateNamed(hdr_bufp, req_hdrs, new_hdr_name, old_hdr_len, &new_hdr_loc);

--- a/plugins/experimental/hipes/hipes.cc
+++ b/plugins/experimental/hipes/hipes.cc
@@ -104,7 +104,7 @@ unescapify(const char *src, char *dst, int len)
       subStr[0] = *(++cur);
       subStr[1] = *(++cur);
       len -= 2;
-      *dst = (char)strtol(subStr, (char **)nullptr, 16);
+      *dst = static_cast<char>(strtol(subStr, (char **)nullptr, 16));
     } else {
       *dst = *cur;
     }
@@ -256,7 +256,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
 {
   const char *slash;
   char *ptr;
-  HIPESService *h_conf = (HIPESService *)ih;
+  HIPESService *h_conf = static_cast<HIPESService *>(ih);
 
   char new_query[MAX_PATH_SIZE];
   int new_query_size;
@@ -317,7 +317,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
     TSDebug(PLUGIN_NAME, "Escaped service URL is %s(%d)", svc_url_esc, len);
 
     // Prepare the new query arguments, make sure it fits
-    if (((slash - param) + 2 + (int)h_conf->url_param.size() + len) > MAX_PATH_SIZE) {
+    if (((slash - param) + 2 + static_cast<int>(h_conf->url_param.size()) + len) > MAX_PATH_SIZE) {
       TSHttpTxnStatusSet(rh, TS_HTTP_STATUS_REQUEST_URI_TOO_LONG);
       return TSREMAP_NO_REMAP;
     }
@@ -352,7 +352,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
   int redirect_flag = h_conf->default_redirect_flag;
   char *pos         = new_query;
 
-  while (pos && (pos = (char *)memchr(pos, '_', new_query_size - (pos - new_query)))) {
+  while (pos && (pos = static_cast<char *>(memchr(pos, '_', new_query_size - (pos - new_query))))) {
     if (pos) {
       ++pos;
       if ((new_query_size - (pos - new_query)) < 10) { // redirect=n
@@ -510,7 +510,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
 
     // Set server ...
     TSUrlHostSet(rri->requestBufp, rri->requestUrl, h_conf->svc_server.c_str(), h_conf->svc_server.size());
-    TSDebug(PLUGIN_NAME, "New server is %.*s", (int)h_conf->svc_server.size(), h_conf->svc_server.c_str());
+    TSDebug(PLUGIN_NAME, "New server is %.*s", static_cast<int>(h_conf->svc_server.size()), h_conf->svc_server.c_str());
 
     // ... and port
     TSUrlPortSet(rri->requestBufp, rri->requestUrl, h_conf->svc_port);
@@ -518,7 +518,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
 
     // Update the path
     TSUrlPathSet(rri->requestBufp, rri->requestUrl, h_conf->path.c_str(), h_conf->path.size());
-    TSDebug(PLUGIN_NAME, "New path is %.*s", (int)h_conf->path.size(), h_conf->path.c_str());
+    TSDebug(PLUGIN_NAME, "New path is %.*s", static_cast<int>(h_conf->path.size()), h_conf->path.c_str());
 
     // Enable SSL?
     if (h_conf->ssl) {

--- a/plugins/experimental/ja3_fingerprint/ja3_fingerprint.cc
+++ b/plugins/experimental/ja3_fingerprint/ja3_fingerprint.cc
@@ -295,7 +295,7 @@ client_hello_ja3_handler(TSCont contp, TSEvent event, void *edata)
     MD5((unsigned char *)data->ja3_string.c_str(), data->ja3_string.length(), digest);
 
     for (int i = 0; i < 16; i++) {
-      sprintf(&(data->md5String[i * 2]), "%02x", (unsigned int)digest[i]);
+      sprintf(&(data->md5String[i * 2]), "%02x", static_cast<unsigned int>(digest[i]));
     }
     TSDebug(PLUGIN_NAME, "Fingerprint: %s", data->md5String);
     break;
@@ -384,7 +384,7 @@ read_config_option(int argc, const char *argv[], int &raw, int &log)
     {"ja3raw", no_argument, &raw, 1}, {"ja3log", no_argument, &log, 1}, {nullptr, 0, nullptr, 0}};
 
   int opt = 0;
-  while ((opt = getopt_long(argc, (char *const *)argv, "", longopts, nullptr)) >= 0) {
+  while ((opt = getopt_long(argc, const_cast<char *const *>(argv), "", longopts, nullptr)) >= 0) {
     switch (opt) {
     case '?':
       TSDebug(PLUGIN_NAME, "read_config_option(): Unrecognized command arguments.");

--- a/plugins/experimental/memcached_remap/memcached_remap.cc
+++ b/plugins/experimental/memcached_remap/memcached_remap.cc
@@ -49,7 +49,7 @@ do_memcached_remap(TSCont contp, TSHttpTxn txnp)
   uint32_t flags;
   memcached_return_t lrc;
 
-  if (TSHttpTxnClientReqGet((TSHttpTxn)txnp, &reqp, &hdr_loc) != TS_SUCCESS) {
+  if (TSHttpTxnClientReqGet(txnp, &reqp, &hdr_loc) != TS_SUCCESS) {
     TSDebug(PLUGIN_NAME, "could not get request data");
     return false;
   }
@@ -138,7 +138,7 @@ release_hdr:
 static int
 memcached_remap(TSCont contp, TSEvent event, void *edata)
 {
-  TSHttpTxn txnp   = (TSHttpTxn)edata;
+  TSHttpTxn txnp   = static_cast<TSHttpTxn>(edata);
   TSEvent reenable = TS_EVENT_HTTP_CONTINUE;
 
   if (event == TS_EVENT_HTTP_READ_REQUEST_HDR) {

--- a/plugins/experimental/metalink/metalink.cc
+++ b/plugins/experimental/metalink/metalink.cc
@@ -114,8 +114,8 @@ cache_open_write(TSCont contp, void *edata)
   char *value;
   int length;
 
-  WriteData *data = (WriteData *)TSContDataGet(contp);
-  data->connp     = (TSVConn)edata;
+  WriteData *data = static_cast<WriteData *>(TSContDataGet(contp));
+  data->connp     = static_cast<TSVConn>(edata);
 
   TSCacheKeyDestroy(data->key);
 
@@ -175,7 +175,7 @@ cache_open_write(TSCont contp, void *edata)
 static int
 cache_open_write_failed(TSCont contp, void * /* edata ATS_UNUSED */)
 {
-  WriteData *data = (WriteData *)TSContDataGet(contp);
+  WriteData *data = static_cast<WriteData *>(TSContDataGet(contp));
   TSContDestroy(contp);
 
   TSCacheKeyDestroy(data->key);
@@ -187,7 +187,7 @@ cache_open_write_failed(TSCont contp, void * /* edata ATS_UNUSED */)
 static int
 write_vconn_write_complete(TSCont contp, void * /* edata ATS_UNUSED */)
 {
-  WriteData *data = (WriteData *)TSContDataGet(contp);
+  WriteData *data = static_cast<WriteData *>(TSContDataGet(contp));
   TSContDestroy(contp);
 
   /* The object is not committed to the cache until the VConnection is
@@ -343,7 +343,7 @@ vconn_write_ready(TSCont contp, void * /* edata ATS_UNUSED */)
 
   char digest[32]; /* SHA-256 */
 
-  TransformData *transform_data = (TransformData *)TSContDataGet(contp);
+  TransformData *transform_data = static_cast<TransformData *>(TSContDataGet(contp));
 
   /* Check if we are "closed" before doing anything else to avoid
    * errors.  We *must* check for this case, if only to clean up
@@ -446,9 +446,9 @@ vconn_write_ready(TSCont contp, void * /* edata ATS_UNUSED */)
 
     /* Write the digest to the cache */
 
-    SHA256_Final((unsigned char *)digest, &transform_data->c);
+    SHA256_Final(reinterpret_cast<unsigned char *>(digest), &transform_data->c);
 
-    WriteData *write_data = (WriteData *)TSmalloc(sizeof(WriteData));
+    WriteData *write_data = static_cast<WriteData *>(TSmalloc(sizeof(WriteData)));
     write_data->txnp      = transform_data->txnp;
 
     /* Don't finish computing the digest more than once! */
@@ -502,8 +502,8 @@ transform_handler(TSCont contp, TSEvent event, void *edata)
 static int
 http_read_response_hdr(TSCont /* contp ATS_UNUSED */, void *edata)
 {
-  TransformData *data = (TransformData *)TSmalloc(sizeof(TransformData));
-  data->txnp          = (TSHttpTxn)edata;
+  TransformData *data = static_cast<TransformData *>(TSmalloc(sizeof(TransformData)));
+  data->txnp          = static_cast<TSHttpTxn>(edata);
 
   /* Can't initialize data here because we can't call TSVConnWrite()
    * before TS_HTTP_RESPONSE_TRANSFORM_HOOK */
@@ -527,8 +527,8 @@ http_read_response_hdr(TSCont /* contp ATS_UNUSED */, void *edata)
 static int
 cache_open_read(TSCont contp, void *edata)
 {
-  SendData *data = (SendData *)TSContDataGet(contp);
-  data->connp    = (TSVConn)edata;
+  SendData *data = static_cast<SendData *>(TSContDataGet(contp));
+  data->connp    = static_cast<TSVConn>(edata);
 
   data->cache_bufp = TSIOBufferCreate();
 
@@ -543,7 +543,7 @@ cache_open_read(TSCont contp, void *edata)
 static int
 cache_open_read_failed(TSCont contp, void * /* edata ATS_UNUSED */)
 {
-  SendData *data = (SendData *)TSContDataGet(contp);
+  SendData *data = static_cast<SendData *>(TSContDataGet(contp));
   TSContDestroy(contp);
 
   TSCacheKeyDestroy(data->key);
@@ -564,7 +564,7 @@ cache_open_read_failed(TSCont contp, void * /* edata ATS_UNUSED */)
 static int
 rewrite_handler(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
 {
-  SendData *data = (SendData *)TSContDataGet(contp);
+  SendData *data = static_cast<SendData *>(TSContDataGet(contp));
   TSContDestroy(contp);
 
   TSCacheKeyDestroy(data->key);
@@ -602,7 +602,7 @@ rewrite_handler(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
 static int
 vconn_read_ready(TSCont contp, void * /* edata ATS_UNUSED */)
 {
-  SendData *data = (SendData *)TSContDataGet(contp);
+  SendData *data = static_cast<SendData *>(TSContDataGet(contp));
   TSContDestroy(contp);
 
   TSVConnClose(data->connp);
@@ -698,7 +698,7 @@ location_handler(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
 
   char digest[33]; /* ATS_BASE64_DECODE_DSTLEN() */
 
-  SendData *data = (SendData *)TSContDataGet(contp);
+  SendData *data = static_cast<SendData *>(TSContDataGet(contp));
   TSContDestroy(contp);
 
   switch (event) {
@@ -711,7 +711,7 @@ location_handler(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
 
     /* No allocation, freed with data->resp_bufp? */
     value = TSMimeHdrFieldValueStringGet(data->resp_bufp, data->hdr_loc, data->digest_loc, data->idx, &length);
-    if (TSBase64Decode(value + 8, length - 8, (unsigned char *)digest, sizeof(digest), nullptr) != TS_SUCCESS ||
+    if (TSBase64Decode(value + 8, length - 8, reinterpret_cast<unsigned char *>(digest), sizeof(digest), nullptr) != TS_SUCCESS ||
         TSCacheKeyDigestSet(data->key, digest, 32 /* SHA-256 */) != TS_SUCCESS) {
       break;
     }
@@ -756,8 +756,8 @@ http_send_response_hdr(TSCont contp, void *edata)
   const char *value;
   int length;
 
-  SendData *data = (SendData *)TSmalloc(sizeof(SendData));
-  data->txnp     = (TSHttpTxn)edata;
+  SendData *data = static_cast<SendData *>(TSmalloc(sizeof(SendData)));
+  data->txnp     = static_cast<TSHttpTxn>(edata);
 
   if (TSHttpTxnClientRespGet(data->txnp, &data->resp_bufp, &data->hdr_loc) != TS_SUCCESS) {
     TSError("[metalink] Couldn't retrieve client response header");

--- a/plugins/experimental/money_trace/money_trace.cc
+++ b/plugins/experimental/money_trace/money_trace.cc
@@ -33,7 +33,7 @@ static struct txndata *
 allocTransactionData()
 {
   LOG_DEBUG("allocating transaction state data.");
-  struct txndata *txn_data           = (struct txndata *)TSmalloc(sizeof(struct txndata));
+  struct txndata *txn_data           = static_cast<struct txndata *>(TSmalloc(sizeof(struct txndata)));
   txn_data->client_request_mt_header = nullptr;
   txn_data->new_span_mt_header       = nullptr;
   return txn_data;
@@ -79,7 +79,7 @@ mt_cache_lookup_check(TSCont contp, TSHttpTxn txnp, struct txndata *txn_data)
     switch (cache_result) {
     case TS_CACHE_LOOKUP_MISS:
     case TS_CACHE_LOOKUP_SKIPPED:
-      new_mt_header = (char *)generator.moneyTraceHdr(txn_data->client_request_mt_header);
+      new_mt_header = const_cast<char *>(generator.moneyTraceHdr(txn_data->client_request_mt_header));
       if (new_mt_header != nullptr) {
         LOG_DEBUG("cache miss, built a new money trace header: %s.", new_mt_header);
         txn_data->new_span_mt_header = new_mt_header;
@@ -273,7 +273,7 @@ static int
 transaction_handler(TSCont contp, TSEvent event, void *edata)
 {
   TSHttpTxn txnp           = static_cast<TSHttpTxn>(edata);
-  struct txndata *txn_data = (struct txndata *)TSContDataGet(contp);
+  struct txndata *txn_data = static_cast<struct txndata *>(TSContDataGet(contp));
 
   switch (event) {
   case TS_EVENT_HTTP_CACHE_LOOKUP_COMPLETE:

--- a/plugins/experimental/mp4/mp4.cc
+++ b/plugins/experimental/mp4/mp4.cc
@@ -155,8 +155,8 @@ mp4_handler(TSCont contp, TSEvent event, void *edata)
   TSHttpTxn txnp;
   Mp4Context *mc;
 
-  txnp = (TSHttpTxn)edata;
-  mc   = (Mp4Context *)TSContDataGet(contp);
+  txnp = static_cast<TSHttpTxn>(edata);
+  mc   = static_cast<Mp4Context *>(TSContDataGet(contp));
 
   switch (event) {
   case TS_EVENT_HTTP_CACHE_LOOKUP_COMPLETE:
@@ -292,7 +292,7 @@ static int
 mp4_transform_entry(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   TSVIO input_vio;
-  Mp4Context *mc = (Mp4Context *)TSContDataGet(contp);
+  Mp4Context *mc = static_cast<Mp4Context *>(TSContDataGet(contp));
 
   if (TSVConnClosedGet(contp)) {
     TSContDestroy(contp);
@@ -493,7 +493,7 @@ ts_arg(const char *param, size_t param_len, const char *key, size_t key_len, siz
   last = p + param_len;
 
   for (; p < last; p++) {
-    p = (char *)memmem(p, last - p, key, key_len);
+    p = static_cast<char *>(memmem(p, last - p, key, key_len));
 
     if (p == nullptr) {
       return nullptr;
@@ -510,7 +510,7 @@ ts_arg(const char *param, size_t param_len, const char *key, size_t key_len, siz
 
       *val_len = p - val;
 
-      return (char *)val;
+      return const_cast<char *>(val);
     }
   }
 

--- a/plugins/experimental/mp4/mp4_meta.cc
+++ b/plugins/experimental/mp4/mp4_meta.cc
@@ -231,7 +231,7 @@ Mp4Meta::parse_root_atoms()
   memset(buf, 0, sizeof(buf));
 
   for (;;) {
-    if (meta_avail < (int64_t)sizeof(uint32_t)) {
+    if (meta_avail < static_cast<int64_t>(sizeof(uint32_t))) {
       return 0;
     }
 
@@ -244,9 +244,9 @@ Mp4Meta::parse_root_atoms()
 
     atom_header = buf;
 
-    if (atom_size < (int64_t)sizeof(mp4_atom_header)) {
+    if (atom_size < static_cast<int64_t>(sizeof(mp4_atom_header))) {
       if (atom_size == 1) {
-        if (meta_avail < (int64_t)sizeof(mp4_atom_header64)) {
+        if (meta_avail < static_cast<int64_t>(sizeof(mp4_atom_header64))) {
           return 0;
         }
 
@@ -259,7 +259,7 @@ Mp4Meta::parse_root_atoms()
 
     } else { // regular atom
 
-      if (meta_avail < (int64_t)sizeof(mp4_atom_header)) { // not enough for atom header
+      if (meta_avail < static_cast<int64_t>(sizeof(mp4_atom_header))) { // not enough for atom header
         return 0;
       }
 
@@ -333,7 +333,7 @@ Mp4Meta::mp4_read_atom(mp4_atom_handler *atom, int64_t size)
   }
 
   while (size > 0) {
-    if (meta_avail < (int64_t)sizeof(uint32_t)) { // data insufficient, not reasonable for internal atom box.
+    if (meta_avail < static_cast<int64_t>(sizeof(uint32_t))) { // data insufficient, not reasonable for internal atom box.
       return -1;
     }
 
@@ -346,9 +346,9 @@ Mp4Meta::mp4_read_atom(mp4_atom_handler *atom, int64_t size)
 
     atom_header = buf;
 
-    if (atom_size < (int64_t)sizeof(mp4_atom_header)) {
+    if (atom_size < static_cast<int64_t>(sizeof(mp4_atom_header))) {
       if (atom_size == 1) {
-        if (meta_avail < (int64_t)sizeof(mp4_atom_header64)) {
+        if (meta_avail < static_cast<int64_t>(sizeof(mp4_atom_header64))) {
           return -1;
         }
 
@@ -361,7 +361,7 @@ Mp4Meta::mp4_read_atom(mp4_atom_handler *atom, int64_t size)
 
     } else { // regular atom
 
-      if (meta_avail < (int64_t)sizeof(mp4_atom_header)) {
+      if (meta_avail < static_cast<int64_t>(sizeof(mp4_atom_header))) {
         return -1;
       }
 
@@ -470,13 +470,13 @@ Mp4Meta::mp4_read_mvhd_atom(int64_t atom_header_size, int64_t atom_data_size)
   mp4_mvhd_atom *mvhd;
   mp4_mvhd64_atom mvhd64;
 
-  if (sizeof(mp4_mvhd_atom) - 8 > (size_t)atom_data_size) {
+  if (sizeof(mp4_mvhd_atom) - 8 > static_cast<size_t>(atom_data_size)) {
     return -1;
   }
 
   memset(&mvhd64, 0, sizeof(mvhd64));
   IOBufferReaderCopy(meta_reader, &mvhd64, sizeof(mp4_mvhd64_atom));
-  mvhd = (mp4_mvhd_atom *)&mvhd64;
+  mvhd = reinterpret_cast<mp4_mvhd_atom *>(&mvhd64);
 
   if (mvhd->version[0] == 0) {
     timescale = mp4_get_32value(mvhd->timescale);
@@ -576,7 +576,7 @@ Mp4Meta::mp4_read_mdhd_atom(int64_t atom_header_size, int64_t atom_data_size)
 
   memset(&mdhd64, 0, sizeof(mdhd64));
   IOBufferReaderCopy(meta_reader, &mdhd64, sizeof(mp4_mdhd64_atom));
-  mdhd = (mp4_mdhd_atom *)&mdhd64;
+  mdhd = reinterpret_cast<mp4_mdhd_atom *>(&mdhd64);
 
   if (mdhd->version[0] == 0) {
     ts       = mp4_get_32value(mdhd->timescale);
@@ -746,7 +746,7 @@ Mp4Meta::mp4_read_stts_atom(int64_t atom_header_size, int64_t atom_data_size)
   mp4_stts_atom stts;
   Mp4Trak *trak;
 
-  if (sizeof(mp4_stts_atom) - 8 > (size_t)atom_data_size) {
+  if (sizeof(mp4_stts_atom) - 8 > static_cast<size_t>(atom_data_size)) {
     return -1;
   }
 
@@ -754,7 +754,7 @@ Mp4Meta::mp4_read_stts_atom(int64_t atom_header_size, int64_t atom_data_size)
   entries     = copied_size > 0 ? mp4_get_32value(stts.entries) : 0;
   esize       = entries * sizeof(mp4_stts_entry);
 
-  if (sizeof(mp4_stts_atom) - 8 + esize > (size_t)atom_data_size) {
+  if (sizeof(mp4_stts_atom) - 8 + esize > static_cast<size_t>(atom_data_size)) {
     return -1;
   }
 
@@ -782,7 +782,7 @@ Mp4Meta::mp4_read_stss_atom(int64_t atom_header_size, int64_t atom_data_size)
   mp4_stss_atom stss;
   Mp4Trak *trak;
 
-  if (sizeof(mp4_stss_atom) - 8 > (size_t)atom_data_size) {
+  if (sizeof(mp4_stss_atom) - 8 > static_cast<size_t>(atom_data_size)) {
     return -1;
   }
 
@@ -790,7 +790,7 @@ Mp4Meta::mp4_read_stss_atom(int64_t atom_header_size, int64_t atom_data_size)
   entries     = copied_size > 0 ? mp4_get_32value(stss.entries) : 0;
   esize       = entries * sizeof(int32_t);
 
-  if (sizeof(mp4_stss_atom) - 8 + esize > (size_t)atom_data_size) {
+  if (sizeof(mp4_stss_atom) - 8 + esize > static_cast<size_t>(atom_data_size)) {
     return -1;
   }
 
@@ -818,7 +818,7 @@ Mp4Meta::mp4_read_ctts_atom(int64_t atom_header_size, int64_t atom_data_size)
   mp4_ctts_atom ctts;
   Mp4Trak *trak;
 
-  if (sizeof(mp4_ctts_atom) - 8 > (size_t)atom_data_size) {
+  if (sizeof(mp4_ctts_atom) - 8 > static_cast<size_t>(atom_data_size)) {
     return -1;
   }
 
@@ -826,7 +826,7 @@ Mp4Meta::mp4_read_ctts_atom(int64_t atom_header_size, int64_t atom_data_size)
   entries     = copied_size > 0 ? mp4_get_32value(ctts.entries) : 0;
   esize       = entries * sizeof(mp4_ctts_entry);
 
-  if (sizeof(mp4_ctts_atom) - 8 + esize > (size_t)atom_data_size) {
+  if (sizeof(mp4_ctts_atom) - 8 + esize > static_cast<size_t>(atom_data_size)) {
     return -1;
   }
 
@@ -854,7 +854,7 @@ Mp4Meta::mp4_read_stsc_atom(int64_t atom_header_size, int64_t atom_data_size)
   mp4_stsc_atom stsc;
   Mp4Trak *trak;
 
-  if (sizeof(mp4_stsc_atom) - 8 > (size_t)atom_data_size) {
+  if (sizeof(mp4_stsc_atom) - 8 > static_cast<size_t>(atom_data_size)) {
     return -1;
   }
 
@@ -862,7 +862,7 @@ Mp4Meta::mp4_read_stsc_atom(int64_t atom_header_size, int64_t atom_data_size)
   entries     = copied_size > 0 ? mp4_get_32value(stsc.entries) : 0;
   esize       = entries * sizeof(mp4_stsc_entry);
 
-  if (sizeof(mp4_stsc_atom) - 8 + esize > (size_t)atom_data_size) {
+  if (sizeof(mp4_stsc_atom) - 8 + esize > static_cast<size_t>(atom_data_size)) {
     return -1;
   }
 
@@ -890,7 +890,7 @@ Mp4Meta::mp4_read_stsz_atom(int64_t atom_header_size, int64_t atom_data_size)
   mp4_stsz_atom stsz;
   Mp4Trak *trak;
 
-  if (sizeof(mp4_stsz_atom) - 8 > (size_t)atom_data_size) {
+  if (sizeof(mp4_stsz_atom) - 8 > static_cast<size_t>(atom_data_size)) {
     return -1;
   }
 
@@ -908,7 +908,7 @@ Mp4Meta::mp4_read_stsz_atom(int64_t atom_header_size, int64_t atom_data_size)
   TSIOBufferCopy(trak->atoms[MP4_STSZ_ATOM].buffer, meta_reader, sizeof(mp4_stsz_atom), 0);
 
   if (size == 0) {
-    if (sizeof(mp4_stsz_atom) - 8 + esize > (size_t)atom_data_size) {
+    if (sizeof(mp4_stsz_atom) - 8 + esize > static_cast<size_t>(atom_data_size)) {
       return -1;
     }
 
@@ -935,7 +935,7 @@ Mp4Meta::mp4_read_stco_atom(int64_t atom_header_size, int64_t atom_data_size)
   mp4_stco_atom stco;
   Mp4Trak *trak;
 
-  if (sizeof(mp4_stco_atom) - 8 > (size_t)atom_data_size) {
+  if (sizeof(mp4_stco_atom) - 8 > static_cast<size_t>(atom_data_size)) {
     return -1;
   }
 
@@ -943,7 +943,7 @@ Mp4Meta::mp4_read_stco_atom(int64_t atom_header_size, int64_t atom_data_size)
   entries     = copied_size > 0 ? mp4_get_32value(stco.entries) : 0;
   esize       = entries * sizeof(int32_t);
 
-  if (sizeof(mp4_stco_atom) - 8 + esize > (size_t)atom_data_size) {
+  if (sizeof(mp4_stco_atom) - 8 + esize > static_cast<size_t>(atom_data_size)) {
     return -1;
   }
 
@@ -971,7 +971,7 @@ Mp4Meta::mp4_read_co64_atom(int64_t atom_header_size, int64_t atom_data_size)
   mp4_co64_atom co64;
   Mp4Trak *trak;
 
-  if (sizeof(mp4_co64_atom) - 8 > (size_t)atom_data_size) {
+  if (sizeof(mp4_co64_atom) - 8 > static_cast<size_t>(atom_data_size)) {
     return -1;
   }
 
@@ -979,7 +979,7 @@ Mp4Meta::mp4_read_co64_atom(int64_t atom_header_size, int64_t atom_data_size)
   entries     = copied_size > 0 ? mp4_get_32value(co64.entries) : 0;
   esize       = entries * sizeof(int64_t);
 
-  if (sizeof(mp4_co64_atom) - 8 + esize > (size_t)atom_data_size) {
+  if (sizeof(mp4_co64_atom) - 8 + esize > static_cast<size_t>(atom_data_size)) {
     return -1;
   }
 
@@ -1027,25 +1027,25 @@ Mp4Meta::mp4_update_stts_atom(Mp4Trak *trak)
   entries    = trak->time_to_sample_entries;
   start_time = this->start * trak->timescale / 1000;
   if (this->rs > 0) {
-    start_time = (uint64_t)(this->rs * trak->timescale / 1000);
+    start_time = static_cast<uint64_t>(this->rs * trak->timescale / 1000);
   }
 
   start_sample = 0;
   readerp      = TSIOBufferReaderClone(trak->atoms[MP4_STTS_DATA].reader);
 
   for (i = 0; i < entries; i++) {
-    duration = (uint32_t)mp4_reader_get_32value(readerp, offsetof(mp4_stts_entry, duration));
-    count    = (uint32_t)mp4_reader_get_32value(readerp, offsetof(mp4_stts_entry, count));
+    duration = mp4_reader_get_32value(readerp, offsetof(mp4_stts_entry, duration));
+    count    = mp4_reader_get_32value(readerp, offsetof(mp4_stts_entry, count));
 
-    if (start_time < (uint64_t)count * duration) {
-      pass = (uint32_t)(start_time / duration);
+    if (start_time < static_cast<uint64_t>(count) * duration) {
+      pass = static_cast<uint32_t>(start_time / duration);
       start_sample += pass;
 
       goto found;
     }
 
     start_sample += count;
-    start_time -= (uint64_t)count * duration;
+    start_time -= static_cast<uint64_t>(count) * duration;
     TSIOBufferReaderConsume(readerp, sizeof(mp4_stts_entry));
   }
 
@@ -1065,25 +1065,25 @@ found:
   trak->start_sample = start_sample;
 
   for (i = 0; i < entries; i++) {
-    duration = (uint32_t)mp4_reader_get_32value(readerp, offsetof(mp4_stts_entry, duration));
-    count    = (uint32_t)mp4_reader_get_32value(readerp, offsetof(mp4_stts_entry, count));
+    duration = mp4_reader_get_32value(readerp, offsetof(mp4_stts_entry, duration));
+    count    = mp4_reader_get_32value(readerp, offsetof(mp4_stts_entry, count));
 
     if (start_sample < count) {
       count -= start_sample;
       mp4_reader_set_32value(readerp, offsetof(mp4_stts_entry, count), count);
 
-      sum += (uint64_t)start_sample * duration;
+      sum += static_cast<uint64_t>(start_sample) * duration;
       break;
     }
 
     start_sample -= count;
-    sum += (uint64_t)count * duration;
+    sum += static_cast<uint64_t>(count) * duration;
 
     TSIOBufferReaderConsume(readerp, sizeof(mp4_stts_entry));
   }
 
   if (this->rs == 0) {
-    this->rs = ((double)sum / trak->duration) * ((double)trak->duration / trak->timescale) * 1000;
+    this->rs = (static_cast<double>(sum) / trak->duration) * (static_cast<double>(trak->duration) / trak->timescale) * 1000;
   }
 
   left = entries - i;
@@ -1117,7 +1117,7 @@ Mp4Meta::mp4_update_stss_atom(Mp4Trak *trak)
   entries      = trak->sync_samples_entries;
 
   for (i = 0; i < entries; i++) {
-    sample = (uint32_t)mp4_reader_get_32value(readerp, 0);
+    sample = mp4_reader_get_32value(readerp, 0);
 
     if (sample >= start_sample) {
       goto found;
@@ -1135,7 +1135,7 @@ found:
 
   start_sample = trak->start_sample;
   for (j = 0; j < left; j++) {
-    sample = (uint32_t)mp4_reader_get_32value(readerp, 0);
+    sample = mp4_reader_get_32value(readerp, 0);
     sample -= start_sample;
     mp4_reader_set_32value(readerp, 0, sample);
     TSIOBufferReaderConsume(readerp, sizeof(uint32_t));
@@ -1172,7 +1172,7 @@ Mp4Meta::mp4_update_ctts_atom(Mp4Trak *trak)
   entries      = trak->composition_offset_entries;
 
   for (i = 0; i < entries; i++) {
-    count = (uint32_t)mp4_reader_get_32value(readerp, offsetof(mp4_ctts_entry, count));
+    count = mp4_reader_get_32value(readerp, offsetof(mp4_ctts_entry, count));
 
     if (start_sample <= count) {
       count -= (start_sample - 1);
@@ -1233,7 +1233,7 @@ Mp4Meta::mp4_update_stsc_atom(Mp4Trak *trak)
     return -1;
   }
 
-  start_sample = (uint32_t)trak->start_sample;
+  start_sample = trak->start_sample;
 
   readerp = TSIOBufferReaderClone(trak->atoms[MP4_STSC_DATA].reader);
 
@@ -1567,7 +1567,7 @@ Mp4Meta::mp4_find_key_sample(uint32_t start_sample, Mp4Trak *trak)
   readerp = TSIOBufferReaderClone(trak->atoms[MP4_STSS_DATA].reader);
 
   for (i = 0; i < entries; i++) {
-    sample = (uint32_t)mp4_reader_get_32value(readerp, 0);
+    sample = mp4_reader_get_32value(readerp, 0);
 
     if (sample > start_sample) {
       goto found;
@@ -1593,16 +1593,16 @@ Mp4Meta::mp4_update_mvhd_duration()
 
   need = TSIOBufferReaderAvail(mvhd_atom.reader);
 
-  if (need > (int64_t)sizeof(mp4_mvhd64_atom)) {
+  if (need > static_cast<int64_t>(sizeof(mp4_mvhd64_atom))) {
     need = sizeof(mp4_mvhd64_atom);
   }
 
   memset(&mvhd64, 0, sizeof(mvhd64));
   IOBufferReaderCopy(mvhd_atom.reader, &mvhd64, need);
-  mvhd = (mp4_mvhd_atom *)&mvhd64;
+  mvhd = reinterpret_cast<mp4_mvhd_atom *>(&mvhd64);
 
   if (this->rs > 0) {
-    cut = (uint64_t)(this->rs * this->timescale / 1000);
+    cut = static_cast<uint64_t>(this->rs * this->timescale / 1000);
 
   } else {
     cut = this->start * this->timescale / 1000;
@@ -1630,16 +1630,16 @@ Mp4Meta::mp4_update_tkhd_duration(Mp4Trak *trak)
 
   need = TSIOBufferReaderAvail(trak->atoms[MP4_TKHD_ATOM].reader);
 
-  if (need > (int64_t)sizeof(mp4_tkhd64_atom)) {
+  if (need > static_cast<int64_t>(sizeof(mp4_tkhd64_atom))) {
     need = sizeof(mp4_tkhd64_atom);
   }
 
   memset(&tkhd64_atom, 0, sizeof(tkhd64_atom));
   IOBufferReaderCopy(trak->atoms[MP4_TKHD_ATOM].reader, &tkhd64_atom, need);
-  tkhd_atom = (mp4_tkhd_atom *)&tkhd64_atom;
+  tkhd_atom = reinterpret_cast<mp4_tkhd_atom *>(&tkhd64_atom);
 
   if (this->rs > 0) {
-    cut = (uint64_t)(this->rs * this->timescale / 1000);
+    cut = static_cast<uint64_t>(this->rs * this->timescale / 1000);
 
   } else {
     cut = this->start * this->timescale / 1000;
@@ -1668,15 +1668,15 @@ Mp4Meta::mp4_update_mdhd_duration(Mp4Trak *trak)
 
   need = TSIOBufferReaderAvail(trak->atoms[MP4_MDHD_ATOM].reader);
 
-  if (need > (int64_t)sizeof(mp4_mdhd64_atom)) {
+  if (need > static_cast<int64_t>(sizeof(mp4_mdhd64_atom))) {
     need = sizeof(mp4_mdhd64_atom);
   }
 
   IOBufferReaderCopy(trak->atoms[MP4_MDHD_ATOM].reader, &mdhd64, need);
-  mdhd = (mp4_mdhd_atom *)&mdhd64;
+  mdhd = reinterpret_cast<mp4_mdhd_atom *>(&mdhd64);
 
   if (this->rs > 0) {
-    cut = (uint64_t)(this->rs * trak->timescale / 1000);
+    cut = static_cast<uint64_t>(this->rs * trak->timescale / 1000);
   } else {
     cut = this->start * trak->timescale / 1000;
   }
@@ -1712,10 +1712,10 @@ mp4_reader_set_32value(TSIOBufferReader readerp, int64_t offset, uint32_t n)
 
     } else {
       left = avail - offset;
-      ptr  = (u_char *)(const_cast<char *>(start) + offset);
+      ptr  = reinterpret_cast<u_char *>(const_cast<char *>(start) + offset);
 
       while (pos < 4 && left > 0) {
-        *ptr++ = (u_char)((n) >> ((3 - pos) * 8));
+        *ptr++ = static_cast<u_char>((n) >> ((3 - pos) * 8));
         pos++;
         left--;
       }
@@ -1751,10 +1751,10 @@ mp4_reader_set_64value(TSIOBufferReader readerp, int64_t offset, uint64_t n)
 
     } else {
       left = avail - offset;
-      ptr  = (u_char *)(const_cast<char *>(start) + offset);
+      ptr  = reinterpret_cast<u_char *>(const_cast<char *>(start) + offset);
 
       while (pos < 8 && left > 0) {
-        *ptr++ = (u_char)((n) >> ((7 - pos) * 8));
+        *ptr++ = static_cast<u_char>((n) >> ((7 - pos) * 8));
         pos++;
         left--;
       }
@@ -1800,7 +1800,7 @@ mp4_reader_get_32value(TSIOBufferReader readerp, int64_t offset)
       }
 
       if (pos >= 4) {
-        return *(uint32_t *)res;
+        return *reinterpret_cast<uint32_t *>(res);
       }
 
       offset = 0;
@@ -1842,7 +1842,7 @@ mp4_reader_get_64value(TSIOBufferReader readerp, int64_t offset)
       }
 
       if (pos >= 8) {
-        return *(uint64_t *)res;
+        return *reinterpret_cast<uint64_t *>(res);
       }
 
       offset = 0;
@@ -1869,7 +1869,7 @@ IOBufferReaderCopy(TSIOBufferReader readerp, void *buf, int64_t length)
     need  = length < avail ? length : avail;
 
     if (need > 0) {
-      memcpy((char *)buf + n, start, need);
+      memcpy(static_cast<char *>(buf) + n, start, need);
       length -= need;
       n += need;
     }

--- a/plugins/experimental/mysql_remap/mysql_remap.cc
+++ b/plugins/experimental/mysql_remap/mysql_remap.cc
@@ -48,7 +48,7 @@ do_mysql_remap(TSCont contp, TSHttpTxn txnp)
   MYSQL_ROW row;
   MYSQL_RES *res;
 
-  my_data *data = (my_data *)TSContDataGet(contp);
+  my_data *data = static_cast<my_data *>(TSContDataGet(contp));
   query         = data->query;
 
   if (TSHttpTxnClientReqGet(txnp, &reqp, &hdr_loc) != TS_SUCCESS) {
@@ -155,7 +155,7 @@ release_hdr:
 static int
 mysql_remap(TSCont contp, TSEvent event, void *edata)
 {
-  TSHttpTxn txnp   = (TSHttpTxn)edata;
+  TSHttpTxn txnp   = static_cast<TSHttpTxn>(edata);
   TSEvent reenable = TS_EVENT_HTTP_CONTINUE;
 
   switch (event) {
@@ -184,7 +184,7 @@ TSPluginInit(int argc, const char *argv[])
   const char *password;
   const char *db;
 
-  my_data *data = (my_data *)malloc(1 * sizeof(my_data));
+  my_data *data = static_cast<my_data *>(malloc(1 * sizeof(my_data)));
 
   TSPluginRegistrationInfo info;
   bool reconnect = true;
@@ -235,7 +235,7 @@ TSPluginInit(int argc, const char *argv[])
     return;
   }
 
-  data->query = (char *)TSmalloc(QSIZE * sizeof(char)); // TODO: malloc smarter sizes
+  data->query = static_cast<char *>(TSmalloc(QSIZE * sizeof(char))); // TODO: malloc smarter sizes
 
   TSDebug(PLUGIN_NAME, "h: %s; u: %s; p: %s; p:%d; d:%s", host, username, password, port, db);
   TSCont cont = TSContCreate(mysql_remap, TSMutexCreate());

--- a/plugins/experimental/prefetch/fetch.cc
+++ b/plugins/experimental/prefetch/fetch.cc
@@ -509,7 +509,7 @@ BgFetch::init(TSMBuffer reqBuffer, TSMLoc reqHdrLoc, TSHttpTxn txnp, const char 
   /* Now set or remove the prefetch API header */
   const String &header = _config.getApiHeader();
   if (_config.isFront()) {
-    if (setHeader(_mbuf, _headerLoc, header.c_str(), (int)header.length(), path, pathLen)) {
+    if (setHeader(_mbuf, _headerLoc, header.c_str(), static_cast<int>(header.length()), path, pathLen)) {
       PrefetchDebug("set header '%.*s: %.*s'", (int)header.length(), header.c_str(), (int)fetchPathLen, fetchPath);
     }
   } else {
@@ -629,7 +629,7 @@ BgFetch::logAndMetricUpdate(TSEvent event) const
 
   if (TSIsDebugTagSet(PLUGIN_NAME "_log")) {
     TSHRTime now   = TShrtime();
-    double elapsed = (double)(now - _startTime) / 1000000.0;
+    double elapsed = static_cast<double>(now - _startTime) / 1000000.0;
 
     PrefetchDebug("ns=%s bytes=%" PRId64 " time=%1.3lf status=%s url=%s key=%s", _config.getNameSpace().c_str(), _bytes, elapsed,
                   status, _url.c_str(), _cachekey.c_str());
@@ -659,7 +659,7 @@ BgFetch::handler(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
     // Debug info for this particular bg fetch (put all debug in here please)
     if (TSIsDebugTagSet(PLUGIN_NAME)) {
       char buf[INET6_ADDRSTRLEN];
-      const sockaddr *sockaddress = (const sockaddr *)&fetch->client_ip;
+      const sockaddr *sockaddress = reinterpret_cast<const sockaddr *>(&fetch->client_ip);
 
       switch (sockaddress->sa_family) {
       case AF_INET:
@@ -680,7 +680,7 @@ BgFetch::handler(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
 
     // Setup the NetVC for background fetch
     TSAssert(nullptr == fetch->vc);
-    if ((fetch->vc = TSHttpConnect((sockaddr *)&fetch->client_ip)) != nullptr) {
+    if ((fetch->vc = TSHttpConnect(reinterpret_cast<sockaddr *>(&fetch->client_ip))) != nullptr) {
       TSHttpHdrPrint(fetch->_mbuf, fetch->_headerLoc, fetch->req_io_buf);
       // We never send a body with the request. ToDo: Do we ever need to support that ?
       TSIOBufferWrite(fetch->req_io_buf, "\r\n", 2);

--- a/plugins/experimental/prefetch/pattern.cc
+++ b/plugins/experimental/prefetch/pattern.cc
@@ -213,8 +213,9 @@ Pattern::match(const String &subject)
 
   matchCount = pcre_exec(_re, _extra, subject.c_str(), subject.length(), 0, PCRE_NOTEMPTY, nullptr, 0);
   if (matchCount < 0) {
-    if (matchCount != PCRE_ERROR_NOMATCH)
+    if (matchCount != PCRE_ERROR_NOMATCH) {
       PrefetchError("matching error %d", matchCount);
+    }
     return false;
   }
 
@@ -240,8 +241,9 @@ Pattern::capture(const String &subject, StringVector &result)
 
   matchCount = pcre_exec(_re, nullptr, subject.c_str(), subject.length(), 0, PCRE_NOTEMPTY, ovector, OVECOUNT);
   if (matchCount < 0) {
-    if (matchCount != PCRE_ERROR_NOMATCH)
+    if (matchCount != PCRE_ERROR_NOMATCH) {
       PrefetchError("matching error %d", matchCount);
+    }
     return false;
   }
 
@@ -278,8 +280,9 @@ Pattern::replace(const String &subject, String &result)
 
   matchCount = pcre_exec(_re, nullptr, subject.c_str(), subject.length(), 0, PCRE_NOTEMPTY, ovector, OVECOUNT);
   if (matchCount < 0) {
-    if (matchCount != PCRE_ERROR_NOMATCH)
+    if (matchCount != PCRE_ERROR_NOMATCH) {
       PrefetchError("matching error %d", matchCount);
+    }
     return false;
   }
 

--- a/plugins/experimental/prefetch/plugin.cc
+++ b/plugins/experimental/prefetch/plugin.cc
@@ -565,7 +565,7 @@ contHandleFetch(const TSCont contp, TSEvent event, void *edata)
         TSHttpHdrReasonSet(bufp, hdrLoc, reason, reasonLen);
         PrefetchDebug("set response: %d %.*s '%s'", data->_status, reasonLen, reason, data->_body.c_str());
 
-        char *buf = (char *)TSmalloc(data->_body.length() + 1);
+        char *buf = static_cast<char *>(TSmalloc(data->_body.length() + 1));
         sprintf(buf, "%s", data->_body.c_str());
         TSHttpTxnErrorBodySet(txnp, buf, strlen(buf), nullptr);
 
@@ -658,7 +658,7 @@ TSRemapNewInstance(int argc, char *argv[], void **instance, char *errBuf, int er
 void
 TSRemapDeleteInstance(void *instance)
 {
-  PrefetchInstance *inst = (PrefetchInstance *)instance;
+  PrefetchInstance *inst = static_cast<PrefetchInstance *>(instance);
   delete inst;
 }
 
@@ -675,7 +675,7 @@ TSRemapDeleteInstance(void *instance)
 TSRemapStatus
 TSRemapDoRemap(void *instance, TSHttpTxn txnp, TSRemapRequestInfo *rri)
 {
-  PrefetchInstance *inst = (PrefetchInstance *)instance;
+  PrefetchInstance *inst = static_cast<PrefetchInstance *>(instance);
 
   if (nullptr != inst) {
     PrefetchConfig &config = inst->_config;

--- a/plugins/experimental/slice/Config.cc
+++ b/plugins/experimental/slice/Config.cc
@@ -37,13 +37,13 @@ Config::bytesFrom(char const *const valstr)
     if (dist < strlen(valstr) && 0 <= blockbytes) {
       switch (tolower(*endptr)) {
       case 'g':
-        blockbytes *= ((int64_t)1024 * (int64_t)1024 * (int64_t)1024);
+        blockbytes *= (static_cast<int64_t>(1024) * static_cast<int64_t>(1024) * static_cast<int64_t>(1024));
         break;
       case 'm':
-        blockbytes *= ((int64_t)1024 * (int64_t)1024);
+        blockbytes *= (static_cast<int64_t>(1024) * static_cast<int64_t>(1024));
         break;
       case 'k':
-        blockbytes *= (int64_t)1024;
+        blockbytes *= static_cast<int64_t>(1024);
         break;
       default:
         break;
@@ -100,7 +100,7 @@ Config::fromArgs(int const argc, char const *const argv[])
   };
 
   // getopt assumes args start at '1' so this hack is needed
-  char *const *argvp = ((char *const *)argv - 1);
+  char *const *argvp = (const_cast<char *const *>(argv) - 1);
 
   for (;;) {
     int const opt = getopt_long(argc + 1, argvp, "b:t:p:d", longopts, nullptr);

--- a/plugins/experimental/slice/Range.cc
+++ b/plugins/experimental/slice/Range.cc
@@ -146,7 +146,7 @@ int64_t
 Range::firstBlockFor(int64_t const blocksize) const
 {
   if (0 < blocksize && isValid()) {
-    return std::max((int64_t)0, m_beg / blocksize);
+    return std::max(static_cast<int64_t>(0), m_beg / blocksize);
   } else {
     return -1;
   }

--- a/plugins/experimental/slice/client.cc
+++ b/plugins/experimental/slice/client.cc
@@ -56,7 +56,7 @@ requestBlock(TSCont contp, Data *const data)
   }
 
   // create virtual connection back into ATS
-  TSVConn const upvc = TSHttpConnect((sockaddr *)&data->m_client_ip);
+  TSVConn const upvc = TSHttpConnect(reinterpret_cast<sockaddr *>(&data->m_client_ip));
 
   // set up connection with the HttpConnect server, maybe clear old one
   data->m_upstream.setupConnection(upvc);

--- a/plugins/experimental/slice/intercept.cc
+++ b/plugins/experimental/slice/intercept.cc
@@ -40,7 +40,7 @@ intercept_hook(TSCont contp, TSEvent event, void *edata)
   switch (event) {
   case TS_EVENT_NET_ACCEPT: {
     // set up reader from client
-    TSVConn const downvc = (TSVConn)edata;
+    TSVConn const downvc = static_cast<TSVConn>(edata);
     data->m_dnstream.setupConnection(downvc);
     data->m_dnstream.setupVioRead(contp);
   } break;

--- a/plugins/experimental/slice/server.cc
+++ b/plugins/experimental/slice/server.cc
@@ -100,7 +100,7 @@ handleFirstServerHeader(Data *const data, TSCont const contp)
   if (data->m_req_range.isEndBytes()) {
     data->m_req_range.m_end += data->m_contentlen;
     data->m_req_range.m_beg += data->m_contentlen;
-    data->m_req_range.m_beg = std::max((int64_t)0, data->m_req_range.m_beg);
+    data->m_req_range.m_beg = std::max(static_cast<int64_t>(0), data->m_req_range.m_beg);
   } else {
     // fix up request range end now that we have the content length
     data->m_req_range.m_end = std::min(data->m_contentlen, data->m_req_range.m_end);

--- a/plugins/experimental/ssl_session_reuse/src/session_process.cc
+++ b/plugins/experimental/ssl_session_reuse/src/session_process.cc
@@ -87,7 +87,7 @@ encrypt_session(const char *session_data, int32_t session_data_len, const unsign
   encrypted_buffer_size = ENCRYPT_LEN(len_all);
   encrypted_msg_len     = encrypted_buffer_size;
   encrypted_msg         = new unsigned char[encrypted_buffer_size];
-  if (1 != EVP_EncryptUpdate(context, (unsigned char *)encrypted_msg, &elen, (unsigned char *)pBuf, len_all)) {
+  if (1 != EVP_EncryptUpdate(context, encrypted_msg, &elen, reinterpret_cast<unsigned char *>(pBuf), len_all)) {
     TSDebug(PLUGIN, "Encryption of session data failed");
     ret = -1;
     goto Cleanup;
@@ -102,14 +102,16 @@ encrypt_session(const char *session_data, int32_t session_data_len, const unsign
 
   TSDebug(PLUGIN, "Encrypted buffer of size %d to buffer of size %d\n", session_data_len, encrypted_msg_len);
 
-  encrypted_data.assign((char *)encrypted_msg, encrypted_msg_len);
+  encrypted_data.assign(reinterpret_cast<char *>(encrypted_msg), encrypted_msg_len);
 
 Cleanup:
 
-  if (pBuf)
+  if (pBuf) {
     delete[] pBuf;
-  if (encrypted_msg)
+  }
+  if (encrypted_msg) {
     delete[] encrypted_msg;
+  }
   if (context) {
     EVP_CIPHER_CTX_free(context);
   }
@@ -152,10 +154,11 @@ decrypt_session(const std::string &encrypted_data, const unsigned char *key, int
   }
 
   decrypted_buffer_size = DECRYPT_LEN(encrypted_data.length());
-  decrypted_msg         = (unsigned char *)new char[decrypted_buffer_size + 1];
+  decrypted_msg         = reinterpret_cast<unsigned char *>(new char[decrypted_buffer_size + 1]);
   decrypted_msg_len     = decrypted_buffer_size + 1;
-  if (decrypted_msg == nullptr)
+  if (decrypted_msg == nullptr) {
     TSError("decrypted_msg allocate failure");
+  }
   if (1 != EVP_DecryptUpdate(context, decrypted_msg, &decrypted_msg_len, (unsigned char *)encrypted_data.c_str(),
                              encrypted_data.length())) {
     TSDebug(PLUGIN, "Decryption of encrypted session data failed");
@@ -163,13 +166,13 @@ decrypt_session(const std::string &encrypted_data, const unsigned char *key, int
   }
 
   // Retrieve ssl_session
-  ssl_sess_ptr = (unsigned char *)decrypted_msg;
+  ssl_sess_ptr = decrypted_msg;
 
   // Skip the expiration time.  Just a place holder to interact with the old version
   ssl_sess_ptr += sizeof(int64_t);
 
   // Length
-  ret = *(int32_t *)ssl_sess_ptr;
+  ret = *reinterpret_cast<int32_t *>(ssl_sess_ptr);
   ssl_sess_ptr += sizeof(int32_t);
   TSDebug(PLUGIN, "Decrypted buffer of size %d from buffer of size %d\n", ret, session_data_len);
   // If there is less data than the maxiumum buffer size, reduce accordingly
@@ -180,8 +183,9 @@ decrypt_session(const std::string &encrypted_data, const unsigned char *key, int
 
 Cleanup:
 
-  if (decrypted_msg)
+  if (decrypted_msg) {
     delete[] decrypted_msg;
+  }
 
   if (context) {
     EVP_CIPHER_CTX_free(context);
@@ -195,8 +199,8 @@ decode_id(const std::string &encoded_id, char *decoded_data, int &decoded_data_l
 {
   size_t decode_len = 0;
   memset(decoded_data, 0, decoded_data_len);
-  if (TSBase64Decode((const char *)encoded_id.c_str(), encoded_id.length(), (unsigned char *)decoded_data, decoded_data_len,
-                     &decode_len) != 0) {
+  if (TSBase64Decode(static_cast<const char *>(encoded_id.c_str()), encoded_id.length(),
+                     reinterpret_cast<unsigned char *>(decoded_data), decoded_data_len, &decode_len) != 0) {
     TSError("Base 64 decoding failed.");
     return -1;
   }
@@ -210,16 +214,18 @@ encode_id(const char *id, int idlen, std::string &encoded_data)
   char *encoded = new char[ENCODED_LEN(idlen)];
   memset(encoded, 0, ENCODED_LEN(idlen));
   size_t encoded_len = 0;
-  if (TSBase64Encode((const char *)id, idlen, encoded, ENCODED_LEN(idlen), &encoded_len) != 0) {
+  if (TSBase64Encode(id, idlen, encoded, ENCODED_LEN(idlen), &encoded_len) != 0) {
     TSError("Base 64 encoding failed.");
-    if (encoded)
+    if (encoded) {
       delete[] encoded;
+    }
     return -1;
   }
 
   encoded_data.assign(encoded);
-  if (encoded)
+  if (encoded) {
     delete[] encoded;
+  }
 
   return 0;
 }

--- a/plugins/experimental/ssl_session_reuse/src/simple_pool.cc
+++ b/plugins/experimental/ssl_session_reuse/src/simple_pool.cc
@@ -58,8 +58,9 @@ simple_pool::get()
 void
 simple_pool::put(connection *conn)
 {
-  if (conn == nullptr)
+  if (conn == nullptr) {
     return;
+  }
 
   if (!conn->is_valid()) {
     delete conn;

--- a/plugins/experimental/ssl_session_reuse/src/ssl_init.cc
+++ b/plugins/experimental/ssl_session_reuse/src/ssl_init.cc
@@ -61,7 +61,7 @@ init_ssl_params(const std::string &conf)
   if (ssl_param.key_update_interval > STEK_MAX_LIFETIME) {
     ssl_param.key_update_interval = STEK_MAX_LIFETIME;
     TSDebug(PLUGIN, "KeyUpdateInterval too high, resetting session ticket key rotation to %d seconds",
-            (int)ssl_param.key_update_interval);
+            ssl_param.key_update_interval);
   }
 
   TSDebug(PLUGIN, "init_ssl_params: I %s been configured to initially be stek_master",

--- a/plugins/experimental/sslheaders/expand.cc
+++ b/plugins/experimental/sslheaders/expand.cc
@@ -40,7 +40,7 @@ x509_expand_certificate(X509 *x509, BIO *bio)
 
   // The PEM format has newlines in it. mod_ssl replaces those with spaces.
   remain = BIO_get_mem_data(bio, &ptr);
-  for (char *nl; (nl = (char *)memchr(ptr, '\n', remain)); ptr = nl) {
+  for (char *nl; (nl = static_cast<char *>(memchr(ptr, '\n', remain))); ptr = nl) {
     *nl = ' ';
     remain -= nl - ptr;
   }
@@ -87,7 +87,7 @@ x509_expand_signature(X509 *x509, BIO *bio)
   // uppercase hex to match the serial number formatting.
 
   for (; ptr < end; ++ptr) {
-    BIO_printf(bio, "%02X", (unsigned char)(*ptr));
+    BIO_printf(bio, "%02X", static_cast<unsigned char>(*ptr));
   }
 }
 

--- a/plugins/experimental/sslheaders/sslheaders.cc
+++ b/plugins/experimental/sslheaders/sslheaders.cc
@@ -33,8 +33,8 @@ SslHdrExpandRequestHook(TSCont cont, TSEvent event, void *edata)
   TSMBuffer mbuf;
   TSMLoc mhdr;
 
-  txn                 = (TSHttpTxn)edata;
-  hdr                 = (const SslHdrInstance *)TSContDataGet(cont);
+  txn                 = static_cast<TSHttpTxn>(edata);
+  hdr                 = static_cast<const SslHdrInstance *>(TSContDataGet(cont));
   TSVConn vconn       = TSHttpSsnClientVConnGet(TSHttpTxnSsnGet(txn));
   TSSslConnection ssl = TSVConnSSLConnectionGet(vconn);
 
@@ -61,7 +61,7 @@ SslHdrExpandRequestHook(TSCont cont, TSEvent event, void *edata)
     goto done;
   }
 
-  SslHdrExpand((SSL *)ssl, hdr->expansions, mbuf, mhdr);
+  SslHdrExpand(reinterpret_cast<SSL *>(ssl), hdr->expansions, mbuf, mhdr);
   TSHandleMLocRelease(mbuf, TS_NULL_MLOC, mhdr);
 
 done:
@@ -220,7 +220,7 @@ SslHdrParseOptions(int argc, const char **argv)
   for (;;) {
     int opt;
 
-    opt = getopt_long(argc, (char *const *)argv, "", longopt, nullptr);
+    opt = getopt_long(argc, const_cast<char *const *>(argv), "", longopt, nullptr);
     switch (opt) {
     case 'a':
       if (strcmp(optarg, "client") == 0) {
@@ -268,7 +268,7 @@ TSPluginInit(int argc, const char *argv[])
     SslHdrError("plugin registration failed");
   }
 
-  hdr = SslHdrParseOptions(argc, (const char **)argv);
+  hdr = SslHdrParseOptions(argc, static_cast<const char **>(argv));
   if (hdr) {
     switch (hdr->attach) {
     case SSL_HEADERS_ATTACH_SERVER:
@@ -306,14 +306,14 @@ TSRemapNewInstance(int argc, char *argv[], void **instance, char * /* err */, in
 void
 TSRemapDeleteInstance(void *instance)
 {
-  SslHdrInstance *hdr = (SslHdrInstance *)instance;
+  SslHdrInstance *hdr = static_cast<SslHdrInstance *>(instance);
   delete hdr;
 }
 
 TSRemapStatus
 TSRemapDoRemap(void *instance, TSHttpTxn txn, TSRemapRequestInfo * /* rri */)
 {
-  SslHdrInstance *hdr = (SslHdrInstance *)instance;
+  SslHdrInstance *hdr = static_cast<SslHdrInstance *>(instance);
 
   switch (hdr->attach) {
   case SSL_HEADERS_ATTACH_SERVER:

--- a/plugins/experimental/sslheaders/test_sslheaders.cc
+++ b/plugins/experimental/sslheaders/test_sslheaders.cc
@@ -156,7 +156,7 @@ make_pem_header(const char *pem)
   hdr = ptr = strdup(pem);
   remain    = strlen(hdr);
 
-  for (char *nl; (nl = (char *)memchr(ptr, '\n', remain)); ptr = nl) {
+  for (char *nl; (nl = static_cast<char *>(memchr(ptr, '\n', remain))); ptr = nl) {
     *nl = ' ';
     remain -= nl - ptr;
   }

--- a/plugins/experimental/stream_editor/stream_editor.cc
+++ b/plugins/experimental/stream_editor/stream_editor.cc
@@ -672,7 +672,7 @@ streamedit_process(TSCont contp)
   // Loop over edits, and apply them to the stream
   // Retain buffered data at the end
   int64_t ntodo, nbytes;
-  contdata_t *contdata      = (contdata_t *)TSContDataGet(contp);
+  contdata_t *contdata      = static_cast<contdata_t *>(TSContDataGet(contp));
   TSVIO input_vio           = TSVConnWriteVIOGet(contp);
   TSIOBufferReader input_rd = TSVIOReaderGet(input_vio);
 
@@ -736,7 +736,7 @@ streamedit_filter(TSCont contp, TSEvent event, void *edata)
   TSVIO input_vio;
 
   if (TSVConnClosedGet(contp)) {
-    contdata_t *contdata = (contdata_t *)TSContDataGet(contp);
+    contdata_t *contdata = static_cast<contdata_t *>(TSContDataGet(contp));
     delete contdata;
     return TS_SUCCESS;
   }
@@ -759,8 +759,8 @@ streamedit_filter(TSCont contp, TSEvent event, void *edata)
 static int
 streamedit_setup(TSCont contp, TSEvent event, void *edata)
 {
-  TSHttpTxn txn        = (TSHttpTxn)edata;
-  ruleset_t *rules_in  = (ruleset_t *)TSContDataGet(contp);
+  TSHttpTxn txn        = static_cast<TSHttpTxn>(edata);
+  ruleset_t *rules_in  = static_cast<ruleset_t *>(TSContDataGet(contp));
   contdata_t *contdata = nullptr;
 
   assert((event == TS_EVENT_HTTP_READ_RESPONSE_HDR) || (event == TS_EVENT_HTTP_READ_REQUEST_HDR));

--- a/plugins/experimental/system_stats/system_stats.c
+++ b/plugins/experimental/system_stats/system_stats.c
@@ -68,8 +68,8 @@ statAdd(const char *name, TSRecordDataType record_type, TSMutex create_mutex)
 
   TSMutexLock(create_mutex);
 
-  if (TS_ERROR == TSStatFindName((const char *)name, &stat_id)) {
-    stat_id = TSStatCreate((const char *)name, record_type, TS_STAT_NON_PERSISTENT, TS_STAT_SYNC_SUM);
+  if (TS_ERROR == TSStatFindName(name, &stat_id)) {
+    stat_id = TSStatCreate(name, record_type, TS_STAT_NON_PERSISTENT, TS_STAT_SYNC_SUM);
     if (stat_id == TS_ERROR) {
       TSDebug(DEBUG_TAG, "Error creating stat_name: %s", name);
     } else {

--- a/plugins/experimental/tls_bridge/regex.cc
+++ b/plugins/experimental/tls_bridge/regex.cc
@@ -27,7 +27,7 @@
 #include <pthread.h>
 
 struct RegexThreadKey {
-  RegexThreadKey() { pthread_key_create(&this->key, (void (*)(void *)) & pcre_jit_stack_free); }
+  RegexThreadKey() { pthread_key_create(&this->key, reinterpret_cast<void (*)(void *)>(&pcre_jit_stack_free)); }
   pthread_key_t key;
 };
 
@@ -38,7 +38,7 @@ get_jit_stack(void *)
 {
   pcre_jit_stack *jit_stack;
 
-  if ((jit_stack = (pcre_jit_stack *)pthread_getspecific(k.key)) == nullptr) {
+  if ((jit_stack = static_cast<pcre_jit_stack *>(pthread_getspecific(k.key))) == nullptr) {
     jit_stack = pcre_jit_stack_alloc(8192, 1024 * 1024); // 1 page min and 1MB max
     pthread_setspecific(k.key, (void *)jit_stack);
   }

--- a/plugins/experimental/tls_bridge/tls_bridge.cc
+++ b/plugins/experimental/tls_bridge/tls_bridge.cc
@@ -153,8 +153,9 @@ BridgeConfig::load_config(int argc, const char *argv[])
           while (!src.empty()) {
             TextView line{src.take_prefix_at('\n').trim_if(&isspace)};
             ++line_no;
-            if (line.empty() || '#' == *line)
+            if (line.empty() || '#' == *line) {
               continue; // empty or comment, ignore.
+            }
 
             // Pick apart the line into the regular expression and destination service.
             TextView service{line};

--- a/plugins/experimental/traffic_dump/traffic_dump.cc
+++ b/plugins/experimental/traffic_dump/traffic_dump.cc
@@ -129,8 +129,9 @@ min_write(const char *buf, int64_t &prevIdx, int64_t &idx, std::ostream &jsonfil
 int
 esc_json_out(const char *buf, int64_t len, std::ostream &jsonfile)
 {
-  if (buf == nullptr)
+  if (buf == nullptr) {
     return 0;
+  }
   int64_t idx, prevIdx = 0;
   for (idx = 0; idx < len; idx++) {
     char c = *(buf + idx);
@@ -169,7 +170,7 @@ esc_json_out(const char *buf, int64_t len, std::ostream &jsonfile)
     default: {
       if ('\x00' <= c && c <= '\x1f') {
         min_write(buf, prevIdx, idx, jsonfile);
-        jsonfile << "\\u" << std::hex << std::setw(4) << std::setfill('0') << (int)c;
+        jsonfile << "\\u" << std::hex << std::setw(4) << std::setfill('0') << static_cast<int>(c);
       }
       break;
     }
@@ -561,7 +562,7 @@ TSPluginInit(int argc, const char *argv[])
                                            {nullptr, no_argument, nullptr, 0}};
   int opt                               = 0;
   while (opt >= 0) {
-    opt = getopt_long(argc, (char *const *)argv, "l:", longopts, nullptr);
+    opt = getopt_long(argc, const_cast<char *const *>(argv), "l:", longopts, nullptr);
     switch (opt) {
     case 'l': {
       log_path = ts::file::path{optarg};

--- a/plugins/experimental/uri_signing/config.c
+++ b/plugins/experimental/uri_signing/config.c
@@ -299,7 +299,7 @@ read_config(const char *path)
     size_t jwks_ct     = json_array_size(key_ary);
     cjose_jwk_t **jwks = (*jwkis++ = malloc((jwks_ct + 1) * sizeof *jwks));
     PluginDebug("Created table with size %d", cfg->issuers->size);
-    if (!hsearch_r(((ENTRY){(char *)*issuer, jwks}), ENTER, &(ENTRY *){0}, cfg->issuers)) {
+    if (!hsearch_r(((ENTRY){*issuer, jwks}), ENTER, &(ENTRY *){0}, cfg->issuers)) {
       PluginDebug("Failed to store keys for issuer %s", *issuer);
     } else {
       PluginDebug("Stored keys for %s at %16p", *issuer, jwks);

--- a/plugins/experimental/uri_signing/unit_tests/uri_signing_test.cc
+++ b/plugins/experimental/uri_signing/unit_tests/uri_signing_test.cc
@@ -58,7 +58,7 @@ normalize_uri_helper(const char *uri, const char *expected_normal)
   size_t uri_ct = strlen(uri);
   int buff_size = uri_ct + 2;
   int err;
-  char *uri_normal = (char *)malloc(buff_size);
+  char *uri_normal = static_cast<char *>(malloc(buff_size));
   memset(uri_normal, 0, buff_size);
 
   err = normalize_uri(uri, uri_ct, uri_normal, buff_size);
@@ -105,7 +105,7 @@ jws_parsing_helper(const char *uri, const char *paramName, const char *expected_
   size_t uri_ct   = strlen(uri);
   size_t strip_ct = 0;
 
-  char *uri_strip = (char *)malloc(uri_ct + 1);
+  char *uri_strip = static_cast<char *>(malloc(uri_ct + 1));
   memset(uri_strip, 0, uri_ct + 1);
 
   cjose_jws_t *jws = get_jws_from_uri(uri, uri_ct, paramName, uri_strip, uri_ct, &strip_ct);

--- a/plugins/experimental/url_sig/url_sig.c
+++ b/plugins/experimental/url_sig/url_sig.c
@@ -165,11 +165,11 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_s
       return TS_ERROR;
     }
     if (strncmp(line, "key", 3) == 0) {
-      if (strncmp((char *)(line + 3), "0", 1) == 0) {
+      if (strncmp((line + 3), "0", 1) == 0) {
         keynum = 0;
       } else {
         TSDebug(PLUGIN_NAME, ">>> %s <<<", line + 3);
-        keynum = atoi((char *)(line + 3));
+        keynum = atoi((line + 3));
         if (keynum == 0) {
           keynum = -1; // Not a Number
         }

--- a/plugins/generator/generator.cc
+++ b/plugins/generator/generator.cc
@@ -526,7 +526,7 @@ GeneratorInterceptionHook(TSCont contp, TSEvent event, void *edata)
     if (cdata.grq->nbytes) {
       int64_t nbytes;
 
-      if (cdata.grq->nbytes >= (ssize_t)sizeof(GeneratorData)) {
+      if (cdata.grq->nbytes >= static_cast<ssize_t>(sizeof(GeneratorData))) {
         nbytes = sizeof(GeneratorData);
       } else {
         nbytes = cdata.grq->nbytes % sizeof(GeneratorData);

--- a/plugins/header_rewrite/header_rewrite.cc
+++ b/plugins/header_rewrite/header_rewrite.cc
@@ -352,7 +352,7 @@ TSPluginInit(int argc, const char *argv[])
 
     for (int i = TS_HTTP_READ_REQUEST_HDR_HOOK; i < TS_HTTP_LAST_HOOK; ++i) {
       if (conf->rule(i)) {
-        TSDebug(PLUGIN_NAME, "Adding global ruleset to hook=%s", TSHttpHookNameLookup((TSHttpHookID)i));
+        TSDebug(PLUGIN_NAME, "Adding global ruleset to hook=%s", TSHttpHookNameLookup(static_cast<TSHttpHookID>(i)));
         TSHttpHookAdd(static_cast<TSHttpHookID>(i), contp);
       }
     }
@@ -418,7 +418,7 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
   if (TSIsDebugTagSet(PLUGIN_NAME)) {
     for (int i = TS_HTTP_READ_REQUEST_HDR_HOOK; i < TS_HTTP_LAST_HOOK; ++i) {
       if (conf->rule(i)) {
-        TSDebug(PLUGIN_NAME, "Adding remap ruleset to hook=%s", TSHttpHookNameLookup((TSHttpHookID)i));
+        TSDebug(PLUGIN_NAME, "Adding remap ruleset to hook=%s", TSHttpHookNameLookup(static_cast<TSHttpHookID>(i)));
       }
     }
   }
@@ -453,7 +453,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
   for (int i = TS_HTTP_READ_REQUEST_HDR_HOOK; i < TS_HTTP_LAST_HOOK; ++i) {
     if (conf->rule(i)) {
       TSHttpTxnHookAdd(rh, static_cast<TSHttpHookID>(i), conf->continuation());
-      TSDebug(PLUGIN_NAME, "Added remapped TXN hook=%s", TSHttpHookNameLookup((TSHttpHookID)i));
+      TSDebug(PLUGIN_NAME, "Added remapped TXN hook=%s", TSHttpHookNameLookup(static_cast<TSHttpHookID>(i)));
     }
   }
 

--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -77,7 +77,7 @@ OperatorSetStatus::initialize(Parser &p)
 
   _status.set_value(p.get_arg());
 
-  if (nullptr == (_reason = TSHttpHdrReasonLookup((TSHttpStatus)_status.get_int_value()))) {
+  if (nullptr == (_reason = TSHttpHdrReasonLookup(static_cast<TSHttpStatus>(_status.get_int_value())))) {
     TSError("[%s] unknown status %d", PLUGIN_NAME, _status.get_int_value());
     _reason_len = 0;
   } else {
@@ -106,14 +106,14 @@ OperatorSetStatus::exec(const Resources &res) const
   case TS_HTTP_READ_RESPONSE_HDR_HOOK:
   case TS_HTTP_SEND_RESPONSE_HDR_HOOK:
     if (res.bufp && res.hdr_loc) {
-      TSHttpHdrStatusSet(res.bufp, res.hdr_loc, (TSHttpStatus)_status.get_int_value());
+      TSHttpHdrStatusSet(res.bufp, res.hdr_loc, static_cast<TSHttpStatus>(_status.get_int_value()));
       if (_reason && _reason_len > 0) {
         TSHttpHdrReasonSet(res.bufp, res.hdr_loc, _reason, _reason_len);
       }
     }
     break;
   default:
-    TSHttpTxnStatusSet(res.txnp, (TSHttpStatus)_status.get_int_value());
+    TSHttpTxnStatusSet(res.txnp, static_cast<TSHttpStatus>(_status.get_int_value()));
     break;
   }
 
@@ -406,12 +406,12 @@ OperatorSetRedirect::exec(const Resources &res) const
       // Set new location.
       TSUrlParse(bufp, url_loc, &start, end);
       // Set the new status.
-      TSHttpTxnStatusSet(res.txnp, (TSHttpStatus)_status.get_int_value());
+      TSHttpTxnStatusSet(res.txnp, static_cast<TSHttpStatus>(_status.get_int_value()));
       const_cast<Resources &>(res).changed_url = true;
       res._rri->redirect                       = 1;
     } else {
       // Set the new status code and reason.
-      TSHttpStatus status = (TSHttpStatus)_status.get_int_value();
+      TSHttpStatus status = static_cast<TSHttpStatus>(_status.get_int_value());
       switch (get_hook()) {
       case TS_HTTP_PRE_REMAP_HOOK: {
         TSHttpTxnStatusSet(res.txnp, status);

--- a/plugins/lua/ts_lua_fetch.c
+++ b/plugins/lua/ts_lua_fetch.c
@@ -298,7 +298,7 @@ ts_lua_fetch_one_item(lua_State *L, const char *url, size_t url_len, ts_lua_fetc
   TSContDataSet(contp, fi);
 
   fi->contp = contp;
-  fi->fch   = TSFetchCreate(contp, method, url, "HTTP/1.1", (struct sockaddr *)&clientaddr, flags);
+  fi->fch   = TSFetchCreate(contp, method, url, "HTTP/1.1", &clientaddr, flags);
 
   /* header */
   cl = ht = ua = 0;

--- a/plugins/regex_remap/regex_remap.cc
+++ b/plugins/regex_remap/regex_remap.cc
@@ -923,7 +923,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
   UrlComponents req_url;
   req_url.populate(rri);
 
-  RemapInstance *ri = (RemapInstance *)ih;
+  RemapInstance *ri = static_cast<RemapInstance *>(ih);
   int ovector[OVECCOUNT];
   int lengths[OVECCOUNT / 2 + 1];
   int dest_len;
@@ -932,7 +932,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
   int match_len        = 0;
   char *match_buf;
 
-  match_buf = (char *)alloca(req_url.url_len + 32);
+  match_buf = static_cast<char *>(alloca(req_url.url_len + 32));
 
   if (ri->method) { // Prepend the URI path or URL with the HTTP method
     TSMBuffer mBuf;
@@ -1038,7 +1038,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
       if (new_len > 0) {
         char *dest;
 
-        dest     = (char *)alloca(new_len + 8);
+        dest     = static_cast<char *>(alloca(new_len + 8));
         dest_len = re->substitute(dest, match_buf, ovector, lengths, txnp, rri, &req_url, lowercase_substitutions);
 
         TSDebug(PLUGIN_NAME, "New URL is estimated to be %d bytes long, or less", new_len);

--- a/plugins/s3_auth/s3_auth.cc
+++ b/plugins/s3_auth/s3_auth.cc
@@ -844,24 +844,24 @@ S3Request::authorizeV2(S3Config *s3)
   ctx = HMAC_CTX_new();
 #endif
   HMAC_Init_ex(ctx, s3->secret(), s3->secret_len(), EVP_sha1(), nullptr);
-  HMAC_Update(ctx, (unsigned char *)method, method_len);
-  HMAC_Update(ctx, (unsigned char *)"\n", 1);
-  HMAC_Update(ctx, (unsigned char *)con_md5, con_md5_len);
-  HMAC_Update(ctx, (unsigned char *)"\n", 1);
-  HMAC_Update(ctx, (unsigned char *)con_type, con_type_len);
-  HMAC_Update(ctx, (unsigned char *)"\n", 1);
-  HMAC_Update(ctx, (unsigned char *)date, date_len);
-  HMAC_Update(ctx, (unsigned char *)"\n/", 2);
+  HMAC_Update(ctx, reinterpret_cast<const unsigned char *>(method), method_len);
+  HMAC_Update(ctx, reinterpret_cast<const unsigned char *>("\n"), 1);
+  HMAC_Update(ctx, reinterpret_cast<const unsigned char *>(con_md5), con_md5_len);
+  HMAC_Update(ctx, reinterpret_cast<const unsigned char *>("\n"), 1);
+  HMAC_Update(ctx, reinterpret_cast<const unsigned char *>(con_type), con_type_len);
+  HMAC_Update(ctx, reinterpret_cast<const unsigned char *>("\n"), 1);
+  HMAC_Update(ctx, reinterpret_cast<const unsigned char *>(date), date_len);
+  HMAC_Update(ctx, reinterpret_cast<const unsigned char *>("\n/"), 2);
 
   if (host && host_endp) {
-    HMAC_Update(ctx, (unsigned char *)host, host_endp - host);
-    HMAC_Update(ctx, (unsigned char *)"/", 1);
+    HMAC_Update(ctx, reinterpret_cast<const unsigned char *>(host), host_endp - host);
+    HMAC_Update(ctx, reinterpret_cast<const unsigned char *>("/"), 1);
   }
 
-  HMAC_Update(ctx, (unsigned char *)path, path_len);
+  HMAC_Update(ctx, reinterpret_cast<const unsigned char *>(path), path_len);
   if (param) {
-    HMAC_Update(ctx, (unsigned char *)";", 1); // TSUrlHttpParamsGet() does not include ';'
-    HMAC_Update(ctx, (unsigned char *)param, param_len);
+    HMAC_Update(ctx, reinterpret_cast<const unsigned char *>(";"), 1); // TSUrlHttpParamsGet() does not include ';'
+    HMAC_Update(ctx, reinterpret_cast<const unsigned char *>(param), param_len);
   }
 
   HMAC_Final(ctx, hmac, &hmac_len);
@@ -872,7 +872,7 @@ S3Request::authorizeV2(S3Config *s3)
 #endif
 
   // Do the Base64 encoding and set the Authorization header.
-  if (TS_SUCCESS == TSBase64Encode((const char *)hmac, hmac_len, hmac_b64, sizeof(hmac_b64) - 1, &hmac_b64_len)) {
+  if (TS_SUCCESS == TSBase64Encode(reinterpret_cast<const char *>(hmac), hmac_len, hmac_b64, sizeof(hmac_b64) - 1, &hmac_b64_len)) {
     char auth[256]; // This is way bigger than any string we can think of.
     int auth_len = snprintf(auth, sizeof(auth), "AWS %s:%.*s", s3->keyid(), static_cast<int>(hmac_b64_len), hmac_b64);
 

--- a/plugins/tcpinfo/tcpinfo.cc
+++ b/plugins/tcpinfo/tcpinfo.cc
@@ -174,31 +174,31 @@ tcp_info_hook(TSCont contp, TSEvent event, void *edata)
   TSHttpSsn ssnp = nullptr;
   TSHttpTxn txnp = nullptr;
   int random     = 0;
-  Config *config = (Config *)TSContDataGet(contp);
+  Config *config = static_cast<Config *>(TSContDataGet(contp));
 
   const char *event_name;
   switch (event) {
   case TS_EVENT_HTTP_SSN_START:
-    ssnp       = (TSHttpSsn)edata;
+    ssnp       = static_cast<TSHttpSsn>(edata);
     event_name = "ssn_start";
     break;
   case TS_EVENT_HTTP_TXN_START:
-    txnp       = (TSHttpTxn)edata;
+    txnp       = static_cast<TSHttpTxn>(edata);
     ssnp       = TSHttpTxnSsnGet(txnp);
     event_name = "txn_start";
     break;
   case TS_EVENT_HTTP_TXN_CLOSE:
-    txnp       = (TSHttpTxn)edata;
+    txnp       = static_cast<TSHttpTxn>(edata);
     ssnp       = TSHttpTxnSsnGet(txnp);
     event_name = "txn_close";
     break;
   case TS_EVENT_HTTP_SEND_RESPONSE_HDR:
-    txnp       = (TSHttpTxn)edata;
+    txnp       = static_cast<TSHttpTxn>(edata);
     ssnp       = TSHttpTxnSsnGet(txnp);
     event_name = "send_resp_hdr";
     break;
   case TS_EVENT_HTTP_SSN_CLOSE:
-    ssnp       = (TSHttpSsn)edata;
+    ssnp       = static_cast<TSHttpSsn>(edata);
     event_name = "ssn_close";
     break;
   default:
@@ -339,7 +339,7 @@ TSPluginInit(int argc, const char *argv[])
   for (;;) {
     unsigned long lval;
 
-    switch (getopt_long(argc, (char *const *)argv, "r:f:l:h:e:H:S:M:", longopts, nullptr)) {
+    switch (getopt_long(argc, const_cast<char *const *>(argv), "r:f:l:h:e:H:S:M:", longopts, nullptr)) {
     case 'r':
       if (parse_unsigned(optarg, lval)) {
         config->sample = atoi(optarg);

--- a/plugins/xdebug/xdebug.cc
+++ b/plugins/xdebug/xdebug.cc
@@ -170,7 +170,7 @@ InjectCacheHeader(TSHttpTxn txn, TSMBuffer buffer, TSMLoc hdr)
     // If the cache lookup hasn't happened yes, TSHttpTxnCacheLookupStatusGet will fail.
     TSReleaseAssert(TSMimeHdrFieldValueStringInsert(buffer, hdr, dst, 0 /* idx */, "none", 4) == TS_SUCCESS);
   } else {
-    const char *msg = (status < 0 || status >= (int)countof(names)) ? "unknown" : names[status];
+    const char *msg = (status < 0 || status >= static_cast<int>(countof(names))) ? "unknown" : names[status];
 
     TSReleaseAssert(TSMimeHdrFieldValueStringInsert(buffer, hdr, dst, 0 /* idx */, msg, -1) == TS_SUCCESS);
   }
@@ -240,8 +240,8 @@ InjectMilestonesHeader(TSHttpTxn txn, TSMBuffer buffer, TSMLoc hdr)
     // state machine the request doesn't traverse.
     TSHttpTxnMilestoneGet(txn, milestones[i].mstype, &time);
     if (time > 0) {
-      double elapsed = (double)(time - epoch) / 1000000000.0;
-      int len        = (int)snprintf(hdrval, sizeof(hdrval), "%s=%1.9lf", milestones[i].msname, elapsed);
+      double elapsed = static_cast<double>(time - epoch) / 1000000000.0;
+      int len        = snprintf(hdrval, sizeof(hdrval), "%s=%1.9lf", milestones[i].msname, elapsed);
 
       TSReleaseAssert(TSMimeHdrFieldValueStringInsert(buffer, hdr, dst, 0 /* idx */, hdrval, len) == TS_SUCCESS);
     }
@@ -328,7 +328,7 @@ InjectTxnUuidHeader(TSHttpTxn txn, TSMBuffer buffer, TSMLoc hdr)
 static int
 XInjectResponseHeaders(TSCont /* contp */, TSEvent event, void *edata)
 {
-  TSHttpTxn txn = (TSHttpTxn)edata;
+  TSHttpTxn txn = static_cast<TSHttpTxn>(edata);
   TSMBuffer buffer;
   TSMLoc hdr;
 
@@ -441,7 +441,7 @@ isFwdFieldValue(std::string_view value, intmax_t &fwdCnt)
 static int
 XScanRequestHeaders(TSCont /* contp */, TSEvent event, void *edata)
 {
-  TSHttpTxn txn      = (TSHttpTxn)edata;
+  TSHttpTxn txn      = static_cast<TSHttpTxn>(edata);
   uintptr_t xheaders = 0;
   intmax_t fwdCnt    = 0;
   TSMLoc field, next;
@@ -511,7 +511,7 @@ XScanRequestHeaders(TSCont /* contp */, TSEvent event, void *edata)
 
         // create a self-cleanup on close
         auto cleanupBodyBuilder = [](TSCont /* contp */, TSEvent event, void *edata) -> int {
-          TSHttpTxn txn     = (TSHttpTxn)edata;
+          TSHttpTxn txn     = static_cast<TSHttpTxn>(edata);
           BodyBuilder *data = static_cast<BodyBuilder *>(TSHttpTxnArgGet(txn, BodyBuilderArgIndex));
           delete data;
           return TS_EVENT_NONE;
@@ -615,7 +615,7 @@ TSPluginInit(int argc, const char *argv[])
 
   // Parse the arguments
   while (true) {
-    int opt = getopt_long(argc, (char *const *)argv, "", longopt, nullptr);
+    int opt = getopt_long(argc, const_cast<char *const *>(argv), "", longopt, nullptr);
 
     switch (opt) {
     case 'h':

--- a/proxy/PluginVC.cc
+++ b/proxy/PluginVC.cc
@@ -800,8 +800,9 @@ PluginVC::process_timeout(Event **e, int event_to_send)
 void
 PluginVC::clear_event(Event **e)
 {
-  if (e == nullptr || *e == nullptr)
+  if (e == nullptr || *e == nullptr) {
     return;
+  }
   if (*e == inactive_event) {
     inactive_event->cancel();
     inactive_timeout_at = 0;

--- a/proxy/http/Http1ServerSession.cc
+++ b/proxy/http/Http1ServerSession.cc
@@ -125,8 +125,9 @@ Http1ServerSession::do_io_close(int alerrno)
     this->server_trans_stat--;
   }
 
-  if (debug_p)
+  if (debug_p) {
     w.print("[{}] session close: nevtc {:x}", con_id, server_vc);
+  }
 
   HTTP_SUM_GLOBAL_DYN_STAT(http_current_server_connections_stat, -1); // Make sure to work on the global stat
   HTTP_SUM_DYN_STAT(http_transactions_per_server_con, transact_count);

--- a/proxy/http/remap/RemapProcessor.cc
+++ b/proxy/http/remap/RemapProcessor.cc
@@ -319,8 +319,9 @@ RemapProcessor::perform_remap(Continuation *cont, HttpTransact::State *s)
   } else {
     RemapPlugins plugins(s, request_url, request_header, hh_info);
 
-    while (!plugins.run_single_remap())
+    while (!plugins.run_single_remap()) {
       ; // EMPTY
+    }
 
     return ACTION_RESULT_DONE;
   }

--- a/proxy/logging/YamlLogConfig.cc
+++ b/proxy/logging/YamlLogConfig.cc
@@ -111,7 +111,7 @@ YamlLogConfig::decodeLogObject(const YAML::Node &node)
 {
   for (auto const &item : node) {
     if (std::none_of(valid_log_object_keys.begin(), valid_log_object_keys.end(),
-                     [&item](std::string s) { return s == item.first.as<std::string>(); })) {
+                     [&item](const std::string &s) { return s == item.first.as<std::string>(); })) {
       throw YAML::ParserException(item.Mark(), "log: unsupported key '" + item.first.as<std::string>() + "'");
     }
   }

--- a/proxy/logging/YamlLogConfigDecoders.cc
+++ b/proxy/logging/YamlLogConfigDecoders.cc
@@ -38,7 +38,7 @@ convert<std::unique_ptr<LogFormat>>::decode(const Node &node, std::unique_ptr<Lo
 {
   for (auto &&item : node) {
     if (std::none_of(valid_log_format_keys.begin(), valid_log_format_keys.end(),
-                     [&item](std::string s) { return s == item.first.as<std::string>(); })) {
+                     [&item](const std::string &s) { return s == item.first.as<std::string>(); })) {
       throw YAML::ParserException(node.Mark(), "format: unsupported key '" + item.first.as<std::string>() + "'");
     }
   }
@@ -79,7 +79,7 @@ convert<std::unique_ptr<LogFilter>>::decode(const Node &node, std::unique_ptr<Lo
 {
   for (auto &&item : node) {
     if (std::none_of(valid_log_filter_keys.begin(), valid_log_filter_keys.end(),
-                     [&item](std::string s) { return s == item.first.as<std::string>(); })) {
+                     [&item](const std::string &s) { return s == item.first.as<std::string>(); })) {
       throw YAML::ParserException(node.Mark(), "filter: unsupported key '" + item.first.as<std::string>() + "'");
     }
   }

--- a/src/traffic_cache_tool/CacheTool.cc
+++ b/src/traffic_cache_tool/CacheTool.cc
@@ -125,8 +125,8 @@ struct VolumeConfig {
   };
 
   std::vector<Data> _volumes;
-  typedef std::vector<Data>::iterator iterator;
-  typedef std::vector<Data>::const_iterator const_iterator;
+  using iterator       = std::vector<Data>::iterator;
+  using const_iterator = std::vector<Data>::const_iterator;
 
   iterator
   begin()
@@ -263,8 +263,7 @@ class VolumeAllocator
     }
   };
 
-  typedef std::vector<V> AV;
-  AV _av; ///< Working vector of volume data.
+  std::vector<V> _av; ///< Working vector of volume data.
 
   Cache _cache;       ///< Current state.
   VolumeConfig _vols; ///< Configuration state.

--- a/src/traffic_layout/engine.cc
+++ b/src/traffic_layout/engine.cc
@@ -205,8 +205,8 @@ LayoutEngine::create_runroot()
       return;
     }
   }
-  std::string original_root = Layout::get()->prefix;
-  std::string ts_runroot    = path;
+  std::string original_root     = Layout::get()->prefix;
+  const std::string &ts_runroot = path;
   // check for existing runroot to use rather than create new one
   if (!force_flag && exists(Layout::relative_to(ts_runroot, "runroot.yaml"))) {
     std::cout << "Using existing runroot...\n"

--- a/src/traffic_logcat/logcat.cc
+++ b/src/traffic_logcat/logcat.cc
@@ -308,8 +308,9 @@ main(int /* argc ATS_UNUSED */, const char *argv[])
         // If we don't plan on following the log file, we should let the kernel know
         // that we plan on reading the entire file so the kernel can do
         // some fancy optimizations.
-        if (!follow_flag)
+        if (!follow_flag) {
           posix_fadvise(in_fd, 0, 0, POSIX_FADV_WILLNEED);
+        }
 
         // We're always reading the file sequentially so this will always help
         posix_fadvise(in_fd, 0, 0, POSIX_FADV_SEQUENTIAL);

--- a/src/traffic_logstats/logstats.cc
+++ b/src/traffic_logstats/logstats.cc
@@ -336,7 +336,7 @@ struct hash_fnv32 {
   }
 };
 
-typedef std::list<UrlStats> LruStack;
+using LruStack = std::list<UrlStats>;
 typedef std::unordered_map<const char *, OriginStats *, hash_fnv32, eqstr> OriginStorage;
 typedef std::unordered_set<const char *, hash_fnv32, eqstr> OriginSet;
 typedef std::unordered_map<const char *, LruStack::iterator, hash_fnv32, eqstr> LruHash;

--- a/src/traffic_manager/AddConfigFilesHere.cc
+++ b/src/traffic_manager/AddConfigFilesHere.cc
@@ -46,8 +46,9 @@ registerFile(const char *configName, const char *defaultName)
 {
   bool found        = false;
   const char *fname = REC_readString(configName, &found);
-  if (!found)
+  if (!found) {
     fname = defaultName;
+  }
   configFiles->addFile(fname, configName, false);
 }
 

--- a/src/traffic_manager/traffic_manager.cc
+++ b/src/traffic_manager/traffic_manager.cc
@@ -1003,9 +1003,9 @@ restoreCapabilities()
       cap_set_flag(cap_set, CAP_EFFECTIVE, 1, cap_list + i, CAP_CLEAR);
     }
   }
-  for (int i = 0; i < CAP_COUNT; i++) {
+  for (int i : cap_list) {
     cap_flag_value_t val;
-    if (cap_get_flag(cap_set, cap_list[i], CAP_EFFECTIVE, &val) < 0) {
+    if (cap_get_flag(cap_set, i, CAP_EFFECTIVE, &val) < 0) {
     } else {
       Warning("CAP_EFFECTIVE offiset %d is %s", i, val == CAP_SET ? "set" : "unset");
     }

--- a/src/traffic_server/InkAPITest.cc
+++ b/src/traffic_server/InkAPITest.cc
@@ -86,7 +86,7 @@
 // STRUCTURES
 //////////////////////////////////////////////////////////////////////////////
 
-typedef int (*TxnHandler)(TSCont contp, TSEvent event, void *data);
+using TxnHandler = int (*)(TSCont, TSEvent, void *);
 
 /* Server transaction structure */
 typedef struct {

--- a/src/traffic_server/SocksProxy.cc
+++ b/src/traffic_server/SocksProxy.cc
@@ -43,7 +43,7 @@ static RecRawStatBlock *socksproxy_stat_block;
 #define SOCKSPROXY_INC_STAT(x) RecIncrRawStat(socksproxy_stat_block, mutex->thread_holding, x)
 
 struct SocksProxy;
-typedef int (SocksProxy::*SocksProxyHandler)(int event, void *data);
+using SocksProxyHandler = int (SocksProxy::*)(int, void *);
 
 struct SocksProxy : public Continuation {
   using EventHandler = int (SocksProxy::*)(int, void *);
@@ -340,8 +340,9 @@ SocksProxy::state_read_socks4_client_request(int event, void *data)
   unsigned char *p = (unsigned char *)reader->start();
   int i;
   // Skip UserID
-  for (i = 8; i < n && p[i] != 0; i++)
+  for (i = 8; i < n && p[i] != 0; i++) {
     ;
+  }
 
   if (p[i] == 0) {
     port                      = p[2] * 256 + p[3];

--- a/src/tscore/CryptoHash.cc
+++ b/src/tscore/CryptoHash.cc
@@ -114,8 +114,9 @@ ts::BufferWriter &
 bwformat(ts::BufferWriter &w, ts::BWFSpec const &spec, ats::CryptoHash const &hash)
 {
   ts::BWFSpec local_spec{spec};
-  if ('X' != local_spec._type)
+  if ('X' != local_spec._type) {
     local_spec._type = 'x';
+  }
   return bwformat(w, local_spec, std::string_view(reinterpret_cast<const char *>(hash.u8), CRYPTO_HASH_SIZE));
 }
 } // namespace ats

--- a/src/tscore/HostLookup.cc
+++ b/src/tscore/HostLookup.cc
@@ -277,8 +277,9 @@ CharIndex::~CharIndex()
 {
   // clean up the illegal key table.
   if (illegalKey) {
-    for (auto spot = illegalKey->begin(), limit = illegalKey->end(); spot != limit; delete &*(spot++))
+    for (auto spot = illegalKey->begin(), limit = illegalKey->end(); spot != limit; delete &*(spot++)) {
       ; // empty
+    }
   }
 }
 

--- a/src/tscore/ink_inet.cc
+++ b/src/tscore/ink_inet.cc
@@ -909,10 +909,12 @@ bwformat(BufferWriter &w, BWFSpec const &spec, sockaddr const *addr)
       w.print("*Not IP address [{}]*", addr->sa_family);
       break;
     }
-    if (bracket_p)
+    if (bracket_p) {
       w.write(']');
-    if (port_p)
+    }
+    if (port_p) {
       w.write(':');
+    }
   }
   if (port_p) {
     if (local_numeric_fill_p) {
@@ -926,8 +928,9 @@ bwformat(BufferWriter &w, BWFSpec const &spec, sockaddr const *addr)
   }
   if (family_p) {
     local_spec._min = 0;
-    if (addr_p || port_p)
+    if (addr_p || port_p) {
       w.write(' ');
+    }
     if (spec.has_numeric_type()) {
       bwformat(w, local_spec, static_cast<uintmax_t>(addr->sa_family));
     } else {

--- a/src/tscpp/api/Headers.cc
+++ b/src/tscpp/api/Headers.cc
@@ -293,7 +293,7 @@ HeaderField::clear()
 }
 
 bool
-HeaderField::erase(header_field_value_iterator it)
+HeaderField::erase(const header_field_value_iterator &it)
 {
   return (TSMimeHdrFieldValueDelete(it.state_->hdr_buf_, it.state_->hdr_loc_, it.state_->field_loc_, it.state_->index_) ==
           TS_SUCCESS);
@@ -561,7 +561,7 @@ Headers::clear()
 }
 
 bool
-Headers::erase(header_field_iterator it)
+Headers::erase(const header_field_iterator &it)
 {
   return (TSMimeHdrFieldDestroy(it.state_->mloc_container_->hdr_buf_, it.state_->mloc_container_->hdr_loc_,
                                 it.state_->mloc_container_->field_loc_) == TS_SUCCESS);


### PR DESCRIPTION
1. Changed the m4 macros so clang-tidy would run in the plugins directory
2. Added options:
google-readability-braces-around-statements
google-readability-casting
modernize-use-using
performance-unnecessary-copy-initialization
3. Removed option modernize-use-default-member-init because clang-tidy was core dumping on TextView

