### PR TITLE
Ignore Pipfile.lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,6 +178,7 @@ RELEASE
 
 # autest
 tests/env-test/
+tests/Pipfile.lock
 
 iocore/cache/test_*
 iocore/cache/test/var/trafficserver/cache.db


### PR DESCRIPTION
We started using pipenv for autest by #5560. It looks like Pipfile.lock should not in version control for our use case.

> Generally, keep both Pipfile and Pipfile.lock in version control.
> Do not keep Pipfile.lock in version control if multiple versions of Python are being targeted.

https://pipenv.readthedocs.io/en/latest/basics/#general-recommendations-version-control