### PR TITLE
Replace ProxyTransaction::get_parent()/set_parent() with get_proxy_ssn()/set_proxy_ssn()

### DIFF
--- a/proxy/ProxyTransaction.cc
+++ b/proxy/ProxyTransaction.cc
@@ -246,15 +246,15 @@ ProxyTransaction::set_outbound_transparent(bool flag)
 }
 
 ProxySession *
-ProxyTransaction::get_parent()
+ProxyTransaction::get_proxy_ssn()
 {
   return proxy_ssn;
 }
 
 void
-ProxyTransaction::set_parent(ProxySession *new_parent)
+ProxyTransaction::set_proxy_ssn(ProxySession *new_proxy_ssn)
 {
-  proxy_ssn      = new_parent;
+  proxy_ssn      = new_proxy_ssn;
   host_res_style = proxy_ssn->host_res_style;
 }
 

--- a/proxy/ProxyTransaction.h
+++ b/proxy/ProxyTransaction.h
@@ -70,7 +70,7 @@ public:
   virtual bool get_half_close_flag() const;
   virtual bool is_chunked_encoding_supported() const;
 
-  virtual void set_parent(ProxySession *new_parent);
+  virtual void set_proxy_ssn(ProxySession *set_proxy_ssn);
   virtual void set_h2c_upgrade_flag();
 
   virtual const char *get_protocol_string();
@@ -97,7 +97,7 @@ public:
 
   const IpAllow::ACL &get_acl() const;
 
-  ProxySession *get_parent();
+  ProxySession *get_proxy_ssn();
   Http1ServerSession *get_server_session() const;
   HttpSM *get_sm() const;
 

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -458,7 +458,7 @@ Http1ClientSession::new_transaction()
 
   read_state = HCS_ACTIVE_READER;
 
-  trans.set_parent(this);
+  trans.set_proxy_ssn(this);
   transact_count++;
 
   client_vc->add_to_active_queue();

--- a/proxy/http/Http1Transaction.cc
+++ b/proxy/http/Http1Transaction.cc
@@ -47,16 +47,16 @@ Http1Transaction::release(IOBufferReader *r)
 }
 
 void
-Http1Transaction::set_parent(ProxySession *new_parent)
+Http1Transaction::set_proxy_ssn(ProxySession *new_proxy_ssn)
 {
-  Http1ClientSession *http1_parent = dynamic_cast<Http1ClientSession *>(new_parent);
+  Http1ClientSession *http1_proxy_ssn = dynamic_cast<Http1ClientSession *>(new_proxy_ssn);
 
-  if (http1_parent) {
-    outbound_port        = http1_parent->outbound_port;
-    outbound_ip4         = http1_parent->outbound_ip4;
-    outbound_ip6         = http1_parent->outbound_ip6;
-    outbound_transparent = http1_parent->f_outbound_transparent;
-    super_type::set_parent(new_parent);
+  if (http1_proxy_ssn) {
+    outbound_port        = http1_proxy_ssn->outbound_port;
+    outbound_ip4         = http1_proxy_ssn->outbound_ip4;
+    outbound_ip6         = http1_proxy_ssn->outbound_ip6;
+    outbound_transparent = http1_proxy_ssn->f_outbound_transparent;
+    super_type::set_proxy_ssn(new_proxy_ssn);
   } else {
     proxy_ssn = nullptr;
   }

--- a/proxy/http/Http1Transaction.h
+++ b/proxy/http/Http1Transaction.h
@@ -83,7 +83,7 @@ public:
 
   bool allow_half_open() const override;
 
-  void set_parent(ProxySession *new_parent) override;
+  void set_proxy_ssn(ProxySession *new_proxy_ssn) override;
 
   bool
   is_outbound_transparent() const override

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -459,7 +459,7 @@ HttpSM::attach_client_session(ProxyTransaction *client_vc, IOBufferReader *buffe
   //
   _client_transaction_id = ua_txn->get_transaction_id();
   {
-    auto p = ua_txn->get_parent();
+    auto p = ua_txn->get_proxy_ssn();
 
     if (p) {
       _client_connection_id = p->connection_id();

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -7815,7 +7815,7 @@ HttpTransact::build_response(State *s, HTTPHdr *base_response, HTTPHdr *outgoing
 
   HttpTransactHeaders::add_server_header_to_response(s->txn_conf, outgoing_response);
 
-  if (s->state_machine->ua_txn && s->state_machine->ua_txn->get_parent()->is_draining()) {
+  if (s->state_machine->ua_txn && s->state_machine->ua_txn->get_proxy_ssn()->is_draining()) {
     HttpTransactHeaders::add_connection_close(outgoing_response);
   }
 

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1132,7 +1132,7 @@ Http2ConnectionState::create_stream(Http2StreamId new_id, Http2Error &error)
     zombie_event = nullptr;
   }
 
-  new_stream->set_parent(ua_session);
+  new_stream->set_proxy_ssn(ua_session);
   new_stream->mutex                     = new_ProxyMutex();
   new_stream->is_first_transaction_flag = get_stream_requests() == 0;
   increment_stream_requests();

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -4833,7 +4833,7 @@ TSHttpTxnSsnGet(TSHttpTxn txnp)
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
 
   HttpSM *sm = reinterpret_cast<HttpSM *>(txnp);
-  return reinterpret_cast<TSHttpSsn>(sm->ua_txn ? (TSHttpSsn)sm->ua_txn->get_parent() : nullptr);
+  return reinterpret_cast<TSHttpSsn>(sm->ua_txn ? (TSHttpSsn)sm->ua_txn->get_proxy_ssn() : nullptr);
 }
 
 // TODO: Is this still necessary ??
@@ -7814,7 +7814,7 @@ TSHttpTxnServerPush(TSHttpTxn txnp, const char *url, int url_len)
   HttpSM *sm          = reinterpret_cast<HttpSM *>(txnp);
   Http2Stream *stream = dynamic_cast<Http2Stream *>(sm->ua_txn);
   if (stream) {
-    Http2ClientSession *ua_session = static_cast<Http2ClientSession *>(stream->get_parent());
+    Http2ClientSession *ua_session = static_cast<Http2ClientSession *>(stream->get_proxy_ssn());
     SCOPED_MUTEX_LOCK(lock, ua_session->mutex, this_ethread());
     if (!ua_session->connection_state.is_state_closed() && !ua_session->is_url_pushed(url, url_len)) {
       HTTPHdr *hptr = &(sm->t_state.hdr_info.client_request);


### PR DESCRIPTION
Because `ProxyTransaction::parent` is renamed to `proxy_ssn` by 92338aed4d2ec8fc0ba9132e88ac12d97b08c7aa.