### PR TITLE
Fix a type mismatch in client_context_dump plugin

### DIFF
--- a/example/client_context_dump/client_context_dump.cc
+++ b/example/client_context_dump/client_context_dump.cc
@@ -115,7 +115,7 @@ dump_context(const char *ca_path, const char *ck_path)
         }
 
         // Serial number
-        long sn = 0;
+        int64_t sn = 0;
 #if OPENSSL_VERSION_NUMBER >= 0x010100000
         ASN1_INTEGER_get_int64(&sn, serial);
 #else


### PR DESCRIPTION
`ASN1_INTEGER_get_int64` receives `int64_t *` but not `long *`.

```
client_context_dump/client_context_dump.cc:120:9: error: no matching function for call to 'ASN1_INTEGER_get_int64'
        ASN1_INTEGER_get_int64(&sn, serial);
        ^~~~~~~~~~~~~~~~~~~~~~
/Users/mkitajo/opt/openssl-quic/include/openssl/asn1.h:644:5: note: candidate function not viable: no known conversion from 'long *' to 'int64_t *' (aka 'long long *') for 1st argument
int ASN1_INTEGER_get_int64(int64_t *pr, const ASN1_INTEGER *a);
    ^
1 error generated.
```