### PR TITLE
Revert "Ran clang-tidy with google-readability-casting"

### DIFF
--- a/iocore/aio/AIO.cc
+++ b/iocore/aio/AIO.cc
@@ -104,7 +104,7 @@ aio_stats_cb(const char * /* name ATS_UNUSED */, RecDataT data_type, RecData *da
   diff = new_val - sum;
   RecSetGlobalRawStatSum(aio_rsb, id, new_val);
   RecSetGlobalRawStatCount(aio_rsb, id, now);
-  data->rec_float = static_cast<float>(diff) * 1000.00 / static_cast<float>(time_diff);
+  data->rec_float = (float)diff * 1000.00 / (float)time_diff;
   return 0;
 }
 
@@ -149,7 +149,7 @@ ink_aio_init(ts::ModuleVersion v)
 {
   ink_release_assert(v.check(AIO_MODULE_INTERNAL_VERSION));
 
-  aio_rsb = RecAllocateRawStatBlock(static_cast<int>(AIO_STAT_COUNT));
+  aio_rsb = RecAllocateRawStatBlock((int)AIO_STAT_COUNT);
   RecRegisterRawStat(aio_rsb, RECT_PROCESS, "proxy.process.cache.read_per_sec", RECD_FLOAT, RECP_PERSISTENT,
                      (int)AIO_STAT_READ_PER_SEC, aio_stats_cb);
   RecRegisterRawStat(aio_rsb, RECT_PROCESS, "proxy.process.cache.write_per_sec", RECD_FLOAT, RECP_PERSISTENT,
@@ -382,9 +382,9 @@ cache_op(AIOCallbackInternal *op)
     while (a->aio_nbytes - res > 0) {
       do {
         if (read) {
-          err = pread(a->aio_fildes, (static_cast<char *>(a->aio_buf)) + res, a->aio_nbytes - res, a->aio_offset + res);
+          err = pread(a->aio_fildes, ((char *)a->aio_buf) + res, a->aio_nbytes - res, a->aio_offset + res);
         } else {
-          err = pwrite(a->aio_fildes, (static_cast<char *>(a->aio_buf)) + res, a->aio_nbytes - res, a->aio_offset + res);
+          err = pwrite(a->aio_fildes, ((char *)a->aio_buf) + res, a->aio_nbytes - res, a->aio_offset + res);
         }
       } while ((err < 0) && (errno == EINTR || errno == ENOBUFS || errno == ENOMEM));
       if (err <= 0) {
@@ -432,8 +432,8 @@ ink_aio_thread_num_set(int thread_num)
 void *
 aio_thread_main(void *arg)
 {
-  AIOThreadInfo *thr_info = static_cast<AIOThreadInfo *>(arg);
-  AIO_Reqs *my_aio_req    = thr_info->req;
+  AIOThreadInfo *thr_info = (AIOThreadInfo *)arg;
+  AIO_Reqs *my_aio_req    = (AIO_Reqs *)thr_info->req;
   AIO_Reqs *current_req   = nullptr;
   AIOCallback *op         = nullptr;
   ink_mutex_acquire(&my_aio_req->aio_mutex);
@@ -464,7 +464,7 @@ aio_thread_main(void *arg)
       }
       ink_mutex_release(&current_req->aio_mutex);
       cache_op((AIOCallbackInternal *)op);
-      ink_atomic_increment(&current_req->requests_queued, -1);
+      ink_atomic_increment((int *)&current_req->requests_queued, -1);
 #ifdef AIO_STATS
       ink_atomic_increment((int *)&current_req->pending, -1);
 #endif

--- a/iocore/aio/test_AIO.cc
+++ b/iocore/aio/test_AIO.cc
@@ -121,11 +121,11 @@ struct AIO_Device : public Continuation {
     if (!touch_data) {
       return;
     }
-    unsigned int len    = static_cast<unsigned int>(orig_len);
-    unsigned int offset = static_cast<unsigned int>(orig_offset);
+    unsigned int len    = (unsigned int)orig_len;
+    unsigned int offset = (unsigned int)orig_offset;
     offset              = offset % 1024;
     char *b             = buf;
-    unsigned *x         = reinterpret_cast<unsigned *>(b);
+    unsigned *x         = (unsigned *)b;
     for (unsigned j = 0; j < (len / sizeof(int)); j++) {
       x[j]   = offset;
       offset = (offset + 1) % 1024;
@@ -137,10 +137,10 @@ struct AIO_Device : public Continuation {
     if (!touch_data) {
       return 0;
     }
-    unsigned int len    = static_cast<unsigned int>(orig_len);
-    unsigned int offset = static_cast<unsigned int>(orig_offset);
+    unsigned int len    = (unsigned int)orig_len;
+    unsigned int offset = (unsigned int)orig_offset;
     offset              = offset % 1024;
-    unsigned *x         = reinterpret_cast<unsigned *>(buf);
+    unsigned *x         = (unsigned *)buf;
     for (unsigned j = 0; j < (len / sizeof(int)); j++) {
       if (x[j] != offset) {
         return 1;
@@ -223,7 +223,7 @@ dump_summary()
 int
 AIO_Device::do_hotset(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
 {
-  off_t max_offset         = (static_cast<off_t>(disk_size)) * 1024 * 1024;
+  off_t max_offset         = ((off_t)disk_size) * 1024 * 1024;
   io->aiocb.aio_lio_opcode = LIO_WRITE;
   io->aiocb.aio_fildes     = fd;
   io->aiocb.aio_offset     = MIN_OFFSET + hotset_idx * max_size;
@@ -233,8 +233,8 @@ AIO_Device::do_hotset(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     fprintf(stderr, "Starting hotset document writing \n");
   }
   if (io->aiocb.aio_offset > max_offset) {
-    fprintf(stderr, "Finished hotset documents  [%d] offset [%6.0f] size [%6.0f]\n", hotset_idx, static_cast<float> MIN_OFFSET,
-            static_cast<float>(max_size));
+    fprintf(stderr, "Finished hotset documents  [%d] offset [%6.0f] size [%6.0f]\n", hotset_idx, (float)MIN_OFFSET,
+            (float)max_size);
     SET_HANDLER(&AIO_Device::do_fd);
     eventProcessor.schedule_imm(this);
     return (0);
@@ -264,10 +264,10 @@ AIO_Device::do_fd(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     return 0;
   }
 
-  off_t max_offset        = (static_cast<off_t>(disk_size)) * 1024 * 1024;   // MB-GB
-  off_t max_hotset_offset = (static_cast<off_t>(hotset_size)) * 1024 * 1024; // MB-GB
-  off_t seq_read_point    = (static_cast<off_t> MIN_OFFSET);
-  off_t seq_write_point   = (static_cast<off_t> MIN_OFFSET) + max_offset / 2 + write_after * 1024 * 1024;
+  off_t max_offset        = ((off_t)disk_size) * 1024 * 1024;   // MB-GB
+  off_t max_hotset_offset = ((off_t)hotset_size) * 1024 * 1024; // MB-GB
+  off_t seq_read_point    = ((off_t)MIN_OFFSET);
+  off_t seq_write_point   = ((off_t)MIN_OFFSET) + max_offset / 2 + write_after * 1024 * 1024;
   seq_write_point += (id % n_disk_path) * (max_offset / (threads_per_disk * 4));
   if (seq_write_point > max_offset) {
     seq_write_point = MIN_OFFSET;
@@ -298,7 +298,7 @@ AIO_Device::do_fd(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     io->aiocb.aio_offset     = seq_write_point;
     io->aiocb.aio_nbytes     = seq_write_size;
     io->aiocb.aio_lio_opcode = LIO_WRITE;
-    do_touch_data(seq_write_size, (static_cast<int>(seq_write_point)) % 1024);
+    do_touch_data(seq_write_size, ((int)seq_write_point) % 1024);
     ink_assert(ink_aio_write(io) >= 0);
     seq_write_point += seq_write_size;
     seq_write_point += write_skip;
@@ -315,9 +315,9 @@ AIO_Device::do_fd(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     f       = drand48();
     off_t o = 0;
     if (f < hotset_frequency) {
-      o = static_cast<off_t>(p) * max_hotset_offset;
+      o = (off_t)p * max_hotset_offset;
     } else {
-      o = static_cast<off_t>(p) * (max_offset - rand_read_size);
+      o = (off_t)p * (max_offset - rand_read_size);
     }
     if (o < MIN_OFFSET) {
       o = MIN_OFFSET;
@@ -464,7 +464,7 @@ main(int /* argc ATS_UNUSED */, char *argv[])
         perror(disk_path[i]);
         exit(1);
       }
-      dev[n_accessors]->buf = static_cast<char *>(valloc(max_size));
+      dev[n_accessors]->buf = (char *)valloc(max_size);
       eventProcessor.schedule_imm(dev[n_accessors]);
       n_accessors++;
     }

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -123,7 +123,7 @@ struct VolInitInfo {
   VolInitInfo()
   {
     recover_pos = 0;
-    vol_h_f     = static_cast<char *>(ats_memalign(ats_pagesize(), 4 * STORE_BLOCK_SIZE));
+    vol_h_f     = (char *)ats_memalign(ats_pagesize(), 4 * STORE_BLOCK_SIZE);
     memset(vol_h_f, 0, 4 * STORE_BLOCK_SIZE);
   }
 
@@ -231,7 +231,7 @@ cache_stats_bytes_used_cb(const char *name, RecDataT data_type, RecData *data, R
   char *p;
 
   // Well, there's no way to pass along the volume ID, so extracting it from the stat name.
-  p = strstr(const_cast<char *>(name), "volume_");
+  p = strstr((char *)name, "volume_");
   if (p != nullptr) {
     // I'm counting on the compiler to optimize out strlen("volume_").
     volume = strtol(p + strlen("volume_"), nullptr, 10);
@@ -244,10 +244,10 @@ cache_stats_bytes_used_cb(const char *name, RecDataT data_type, RecData *data, R
     used = cache_bytes_used(volume);
     RecSetGlobalRawStatSum(rsb, id, used);
     RecRawStatSyncSum(name, data_type, data, rsb, id);
-    RecGetGlobalRawStatSum(rsb, static_cast<int>(cache_bytes_total_stat), &total);
-    percent_full = static_cast<float>(used) / static_cast<float>(total) * 100;
+    RecGetGlobalRawStatSum(rsb, (int)cache_bytes_total_stat, &total);
+    percent_full = (float)used / (float)total * 100;
     // The percent_full float below gets rounded down
-    RecSetGlobalRawStatSum(rsb, static_cast<int>(cache_percent_full_stat), static_cast<int64_t>(percent_full));
+    RecSetGlobalRawStatSum(rsb, (int)cache_percent_full_stat, (int64_t)percent_full);
   }
 
   return 1;
@@ -408,10 +408,10 @@ CacheVC::get_data(int i, void *data)
 {
   switch (i) {
   case CACHE_DATA_HTTP_INFO:
-    *(static_cast<CacheHTTPInfo **>(data)) = &alternate;
+    *((CacheHTTPInfo **)data) = &alternate;
     return true;
   case CACHE_DATA_RAM_CACHE_HIT_FLAG:
-    *(static_cast<int *>(data)) = !f.not_from_ram_cache;
+    *((int *)data) = !f.not_from_ram_cache;
     return true;
   default:
     break;
@@ -422,7 +422,7 @@ CacheVC::get_data(int i, void *data)
 int64_t
 CacheVC::get_object_size()
 {
-  return (this)->doc_len;
+  return ((CacheVC *)this)->doc_len;
 }
 
 bool
@@ -435,7 +435,7 @@ CacheVC::set_data(int /* i ATS_UNUSED */, void * /* data */)
 void
 CacheVC::get_http_info(CacheHTTPInfo **ainfo)
 {
-  *ainfo = &(this)->alternate;
+  *ainfo = &((CacheVC *)this)->alternate;
 }
 
 // set_http_info must be called before do_io_write
@@ -600,7 +600,7 @@ CacheProcessor::start_internal(int flags)
   /* read the config file and create the data structures corresponding
      to the file */
   gndisks = theCacheStore.n_disks;
-  gdisks  = static_cast<CacheDisk **>(ats_malloc(gndisks * sizeof(CacheDisk *)));
+  gdisks  = (CacheDisk **)ats_malloc(gndisks * sizeof(CacheDisk *));
 
   gndisks = 0;
   ink_aio_set_callback(new AIO_Callback_handler());
@@ -798,14 +798,14 @@ CacheProcessor::diskInitialized()
   } else {
     CacheVol *cp = cp_list.head;
     for (; cp; cp = cp->link.next) {
-      cp->vol_rsb = RecAllocateRawStatBlock(static_cast<int>(cache_stat_count));
+      cp->vol_rsb = RecAllocateRawStatBlock((int)cache_stat_count);
       char vol_stat_str_prefix[256];
       snprintf(vol_stat_str_prefix, sizeof(vol_stat_str_prefix), "proxy.process.cache.volume_%d", cp->vol_number);
       register_cache_stats(cp->vol_rsb, vol_stat_str_prefix);
     }
   }
 
-  gvol = static_cast<Vol **>(ats_malloc(gnvol * sizeof(Vol *)));
+  gvol = (Vol **)ats_malloc(gnvol * sizeof(Vol *));
   memset(gvol, 0, gnvol * sizeof(Vol *));
   gnvol = 0;
   for (i = 0; i < gndisks; i++) {
@@ -814,10 +814,10 @@ CacheProcessor::diskInitialized()
       int j;
       Debug("cache_hosting", "Disk: %d:%s: Vol Blocks: %u: Free space: %" PRIu64, i, d->path, d->header->num_diskvol_blks,
             d->free_space);
-      for (j = 0; j < static_cast<int>(d->header->num_volumes); j++) {
+      for (j = 0; j < (int)d->header->num_volumes; j++) {
         Debug("cache_hosting", "\tVol: %d Size: %" PRIu64, d->disk_vols[j]->vol_number, d->disk_vols[j]->size);
       }
-      for (j = 0; j < static_cast<int>(d->header->num_diskvol_blks); j++) {
+      for (j = 0; j < (int)d->header->num_diskvol_blks; j++) {
         Debug("cache_hosting", "\tBlock No: %d Size: %" PRIu64 " Free: %u", d->header->vol_info[j].number,
               d->header->vol_info[j].len, d->header->vol_info[j].free);
       }
@@ -945,9 +945,7 @@ CacheProcessor::cacheInitialized()
         //   OOM or swapout, that is not a good situation for the server
         Debug("cache_init", "CacheProcessor::cacheInitialized - %" PRId64 " != AUTO_SIZE_RAM_CACHE", cache_config_ram_cache_size);
         int64_t http_ram_cache_size =
-          (theCache) ?
-            static_cast<int64_t>((static_cast<double>(theCache->cache_size) / total_size) * cache_config_ram_cache_size) :
-            0;
+          (theCache) ? (int64_t)(((double)theCache->cache_size / total_size) * cache_config_ram_cache_size) : 0;
         Debug("cache_init", "CacheProcessor::cacheInitialized - http_ram_cache_size = %" PRId64 " = %" PRId64 "Mb",
               http_ram_cache_size, http_ram_cache_size / (1024 * 1024));
         int64_t stream_ram_cache_size = cache_config_ram_cache_size - http_ram_cache_size;
@@ -963,10 +961,10 @@ CacheProcessor::cacheInitialized()
           double factor;
           if (gvol[i]->cache == theCache) {
             ink_assert(gvol[i]->cache != nullptr);
-            factor = static_cast<double>(static_cast<int64_t>(gvol[i]->len >> STORE_BLOCK_SHIFT)) / theCache->cache_size;
+            factor = (double)(int64_t)(gvol[i]->len >> STORE_BLOCK_SHIFT) / (int64_t)theCache->cache_size;
             Debug("cache_init", "CacheProcessor::cacheInitialized - factor = %f", factor);
-            gvol[i]->ram_cache->init(static_cast<int64_t>(http_ram_cache_size * factor), vol);
-            ram_cache_bytes += static_cast<int64_t>(http_ram_cache_size * factor);
+            gvol[i]->ram_cache->init((int64_t)(http_ram_cache_size * factor), vol);
+            ram_cache_bytes += (int64_t)(http_ram_cache_size * factor);
             CACHE_VOL_SUM_DYN_STAT(cache_ram_cache_bytes_total_stat, (int64_t)(http_ram_cache_size * factor));
           } else {
             ink_release_assert(!"Unexpected non-HTTP cache volume");
@@ -1112,7 +1110,7 @@ CacheProcessor::IsCacheReady(CacheFragType type)
   if (IsCacheEnabled() != CACHE_INITIALIZED) {
     return false;
   }
-  return static_cast<bool>(cache_ready & (1 << type));
+  return (bool)(cache_ready & (1 << type));
 }
 
 int
@@ -1120,14 +1118,14 @@ Vol::db_check(bool /* fix ATS_UNUSED */)
 {
   char tt[256];
   printf("    Data for [%s]\n", hash_text.get());
-  printf("        Length:          %" PRIu64 "\n", static_cast<uint64_t>(len));
-  printf("        Write Position:  %" PRIu64 "\n", static_cast<uint64_t>(header->write_pos - skip));
-  printf("        Phase:           %d\n", static_cast<int>(!!header->phase));
+  printf("        Length:          %" PRIu64 "\n", (uint64_t)len);
+  printf("        Write Position:  %" PRIu64 "\n", (uint64_t)(header->write_pos - skip));
+  printf("        Phase:           %d\n", (int)!!header->phase);
   ink_ctime_r(&header->create_time, tt);
   tt[strlen(tt) - 1] = 0;
   printf("        Create Time:     %s\n", tt);
-  printf("        Sync Serial:     %u\n", static_cast<unsigned int>(header->sync_serial));
-  printf("        Write Serial:    %u\n", static_cast<unsigned int>(header->write_serial));
+  printf("        Sync Serial:     %u\n", (unsigned int)header->sync_serial);
+  printf("        Write Serial:    %u\n", (unsigned int)header->write_serial);
   printf("\n");
 
   return 0;
@@ -1234,8 +1232,8 @@ Vol::init(char *s, off_t blocks, off_t dir_skip, bool clear)
 
   hash_text = static_cast<char *>(ats_malloc(hash_text_size));
   ink_strlcpy(hash_text, seed_str, hash_text_size);
-  snprintf(hash_text + hash_seed_size, (hash_text_size - hash_seed_size), " %" PRIu64 ":%" PRIu64 "",
-           static_cast<uint64_t>(dir_skip), static_cast<uint64_t>(blocks));
+  snprintf(hash_text + hash_seed_size, (hash_text_size - hash_seed_size), " %" PRIu64 ":%" PRIu64 "", (uint64_t)dir_skip,
+           (uint64_t)blocks);
   CryptoContext().hash_immediate(hash_id, hash_text, strlen(hash_text));
 
   dir_skip = ROUND_TO_STORE_BLOCK((dir_skip < START_POS ? START_POS : dir_skip));
@@ -1251,9 +1249,9 @@ Vol::init(char *s, off_t blocks, off_t dir_skip, bool clear)
   data_blocks         = (len - (start - skip)) / STORE_BLOCK_SIZE;
   hit_evacuate_window = (data_blocks * cache_config_hit_evacuate_percent) / 100;
 
-  evacuate_size = static_cast<int>(len / EVACUATION_BUCKET_SIZE) + 2;
-  int evac_len  = evacuate_size * sizeof(DLL<EvacuationBlock>);
-  evacuate      = static_cast<DLL<EvacuationBlock> *>(ats_malloc(evac_len));
+  evacuate_size = (int)(len / EVACUATION_BUCKET_SIZE) + 2;
+  int evac_len  = (int)evacuate_size * sizeof(DLL<EvacuationBlock>);
+  evacuate      = (DLL<EvacuationBlock> *)ats_malloc(evac_len);
   memset(static_cast<void *>(evacuate), 0, evac_len);
 
   Debug("cache_init", "Vol %s: allocating %zu directory bytes for a %lld byte volume (%lf%%)", hash_text.get(), dirlen(),
@@ -1261,15 +1259,15 @@ Vol::init(char *s, off_t blocks, off_t dir_skip, bool clear)
 
   raw_dir = nullptr;
   if (ats_hugepage_enabled()) {
-    raw_dir = static_cast<char *>(ats_alloc_hugepage(this->dirlen()));
+    raw_dir = (char *)ats_alloc_hugepage(this->dirlen());
   }
   if (raw_dir == nullptr) {
-    raw_dir = static_cast<char *>(ats_memalign(ats_pagesize(), this->dirlen()));
+    raw_dir = (char *)ats_memalign(ats_pagesize(), this->dirlen());
   }
 
-  dir    = reinterpret_cast<Dir *>(raw_dir + this->headerlen());
-  header = reinterpret_cast<VolHeaderFooter *>(raw_dir);
-  footer = reinterpret_cast<VolHeaderFooter *>(raw_dir + this->dirlen() - ROUND_TO_STORE_BLOCK(sizeof(VolHeaderFooter)));
+  dir    = (Dir *)(raw_dir + this->headerlen());
+  header = (VolHeaderFooter *)raw_dir;
+  footer = (VolHeaderFooter *)(raw_dir + this->dirlen() - ROUND_TO_STORE_BLOCK(sizeof(VolHeaderFooter)));
 
   if (clear) {
     Note("clearing cache directory '%s'", hash_text.get());
@@ -1314,8 +1312,8 @@ Vol::handle_dir_clear(int event, void *data)
   AIOCallback *op;
 
   if (event == AIO_EVENT_DONE) {
-    op = static_cast<AIOCallback *>(data);
-    if (static_cast<size_t>(op->aio_result) != op->aiocb.aio_nbytes) {
+    op = (AIOCallback *)data;
+    if ((size_t)op->aio_result != (size_t)op->aiocb.aio_nbytes) {
       Warning("unable to clear cache directory '%s'", hash_text.get());
       disk->incrErrors(op);
       fd = -1;
@@ -1341,10 +1339,10 @@ Vol::handle_dir_clear(int event, void *data)
 int
 Vol::handle_dir_read(int event, void *data)
 {
-  AIOCallback *op = static_cast<AIOCallback *>(data);
+  AIOCallback *op = (AIOCallback *)data;
 
   if (event == AIO_EVENT_DONE) {
-    if (static_cast<size_t>(op->aio_result) != op->aiocb.aio_nbytes) {
+    if ((size_t)op->aio_result != (size_t)op->aiocb.aio_nbytes) {
       Note("Directory read failed: clearing cache directory %s", this->hash_text.get());
       clear_dir();
       return EVENT_DONE;
@@ -1435,13 +1433,13 @@ Vol::handle_recover_from_data(int event, void * /* data ATS_UNUSED */)
       recover_wrapped = true;
       recover_pos     = start;
     }
-    io.aiocb.aio_buf    = static_cast<char *>(ats_memalign(ats_pagesize(), RECOVERY_SIZE));
+    io.aiocb.aio_buf    = (char *)ats_memalign(ats_pagesize(), RECOVERY_SIZE);
     io.aiocb.aio_nbytes = RECOVERY_SIZE;
-    if (static_cast<off_t>(recover_pos + io.aiocb.aio_nbytes) > static_cast<off_t>(skip + len)) {
+    if ((off_t)(recover_pos + io.aiocb.aio_nbytes) > (off_t)(skip + len)) {
       io.aiocb.aio_nbytes = (skip + len) - recover_pos;
     }
   } else if (event == AIO_EVENT_DONE) {
-    if (io.aiocb.aio_nbytes != static_cast<size_t>(io.aio_result)) {
+    if ((size_t)io.aiocb.aio_nbytes != (size_t)io.aio_result) {
       Warning("disk read error on recover '%s', clearing", hash_text.get());
       disk->incrErrors(&io);
       goto Lclear;
@@ -1455,9 +1453,9 @@ Vol::handle_recover_from_data(int event, void * /* data ATS_UNUSED */)
       uint32_t to_check = header->write_pos - header->last_write_pos;
       ink_assert(to_check && to_check < (uint32_t)io.aiocb.aio_nbytes);
       uint32_t done = 0;
-      s             = static_cast<char *>(io.aiocb.aio_buf);
+      s             = (char *)io.aiocb.aio_buf;
       while (done < to_check) {
-        Doc *doc = reinterpret_cast<Doc *>(s + done);
+        Doc *doc = (Doc *)(s + done);
         if (doc->magic != DOC_MAGIC || doc->write_serial > header->write_serial) {
           Warning("no valid directory found while recovering '%s', clearing", hash_text.get());
           goto Lclear;
@@ -1471,12 +1469,12 @@ Vol::handle_recover_from_data(int event, void * /* data ATS_UNUSED */)
 
       got_len = io.aiocb.aio_nbytes - done;
       recover_pos += io.aiocb.aio_nbytes;
-      s = static_cast<char *>(io.aiocb.aio_buf) + done;
+      s = (char *)io.aiocb.aio_buf + done;
       e = s + got_len;
     } else {
       got_len = io.aiocb.aio_nbytes;
       recover_pos += io.aiocb.aio_nbytes;
-      s = static_cast<char *>(io.aiocb.aio_buf);
+      s = (char *)io.aiocb.aio_buf;
       e = s + got_len;
     }
   }
@@ -1485,7 +1483,7 @@ Vol::handle_recover_from_data(int event, void * /* data ATS_UNUSED */)
     Doc *doc = nullptr;
 
     if (recover_wrapped && start == io.aiocb.aio_offset) {
-      doc = reinterpret_cast<Doc *>(s);
+      doc = (Doc *)s;
       if (doc->magic != DOC_MAGIC || doc->write_serial < last_write_serial) {
         recover_pos = skip + len - EVACUATION_SIZE;
         goto Ldone;
@@ -1496,7 +1494,7 @@ Vol::handle_recover_from_data(int event, void * /* data ATS_UNUSED */)
     // clang analyzer can't figure this out, so be explicit.
     ink_assert(s < e);
     while (s < e) {
-      doc = reinterpret_cast<Doc *>(s);
+      doc = (Doc *)s;
 
       if (doc->magic != DOC_MAGIC || doc->sync_serial != last_sync_serial) {
         if (doc->magic == DOC_MAGIC) {
@@ -1585,7 +1583,7 @@ Vol::handle_recover_from_data(int event, void * /* data ATS_UNUSED */)
         recover_pos     = start;
       }
       io.aiocb.aio_nbytes = RECOVERY_SIZE;
-      if (static_cast<off_t>(recover_pos + io.aiocb.aio_nbytes) > static_cast<off_t>(skip + len)) {
+      if ((off_t)(recover_pos + io.aiocb.aio_nbytes) > (off_t)(skip + len)) {
         io.aiocb.aio_nbytes = (skip + len) - recover_pos;
       }
     }
@@ -1671,7 +1669,7 @@ Ldone : {
 }
 
 Lclear:
-  free(static_cast<char *>(io.aiocb.aio_buf));
+  free((char *)io.aiocb.aio_buf);
   delete init_info;
   init_info = nullptr;
   clear_dir();
@@ -1682,7 +1680,7 @@ int
 Vol::handle_recover_write_dir(int /* event ATS_UNUSED */, void * /* data ATS_UNUSED */)
 {
   if (io.aiocb.aio_buf) {
-    free(static_cast<char *>(io.aiocb.aio_buf));
+    free((char *)io.aiocb.aio_buf);
   }
   delete init_info;
   init_info = nullptr;
@@ -1700,11 +1698,11 @@ Vol::handle_header_read(int event, void *data)
   VolHeaderFooter *hf[4];
   switch (event) {
   case AIO_EVENT_DONE:
-    op = static_cast<AIOCallback *>(data);
+    op = (AIOCallback *)data;
     for (auto &i : hf) {
       ink_assert(op != nullptr);
-      i = static_cast<VolHeaderFooter *>(op->aiocb.aio_buf);
-      if (static_cast<size_t>(op->aio_result) != op->aiocb.aio_nbytes) {
+      i = (VolHeaderFooter *)(op->aiocb.aio_buf);
+      if ((size_t)op->aio_result != (size_t)op->aiocb.aio_nbytes) {
         Note("Header read failed: clearing cache directory %s", this->hash_text.get());
         clear_dir();
         return EVENT_DONE;
@@ -1797,8 +1795,8 @@ void
 build_vol_hash_table(CacheHostRecord *cp)
 {
   int num_vols          = cp->num_vols;
-  unsigned int *mapping = static_cast<unsigned int *>(ats_malloc(sizeof(unsigned int) * num_vols));
-  Vol **p               = static_cast<Vol **>(ats_malloc(sizeof(Vol *) * num_vols));
+  unsigned int *mapping = (unsigned int *)ats_malloc(sizeof(unsigned int) * num_vols);
+  Vol **p               = (Vol **)ats_malloc(sizeof(Vol *) * num_vols);
 
   memset(mapping, 0, num_vols * sizeof(unsigned int));
   memset(p, 0, num_vols * sizeof(Vol *));
@@ -1830,12 +1828,12 @@ build_vol_hash_table(CacheHostRecord *cp)
     return;
   }
 
-  unsigned int *forvol   = static_cast<unsigned int *>(ats_malloc(sizeof(unsigned int) * num_vols));
-  unsigned int *gotvol   = static_cast<unsigned int *>(ats_malloc(sizeof(unsigned int) * num_vols));
-  unsigned int *rnd      = static_cast<unsigned int *>(ats_malloc(sizeof(unsigned int) * num_vols));
-  unsigned short *ttable = static_cast<unsigned short *>(ats_malloc(sizeof(unsigned short) * VOL_HASH_TABLE_SIZE));
+  unsigned int *forvol   = (unsigned int *)ats_malloc(sizeof(unsigned int) * num_vols);
+  unsigned int *gotvol   = (unsigned int *)ats_malloc(sizeof(unsigned int) * num_vols);
+  unsigned int *rnd      = (unsigned int *)ats_malloc(sizeof(unsigned int) * num_vols);
+  unsigned short *ttable = (unsigned short *)ats_malloc(sizeof(unsigned short) * VOL_HASH_TABLE_SIZE);
   unsigned short *old_table;
-  unsigned int *rtable_entries = static_cast<unsigned int *>(ats_malloc(sizeof(unsigned int) * num_vols));
+  unsigned int *rtable_entries = (unsigned int *)ats_malloc(sizeof(unsigned int) * num_vols);
   unsigned int rtable_size     = 0;
 
   // estimate allocation
@@ -1854,17 +1852,17 @@ build_vol_hash_table(CacheHostRecord *cp)
   // seed random number generator
   for (int i = 0; i < num_vols; i++) {
     uint64_t x = p[i]->hash_id.fold();
-    rnd[i]     = static_cast<unsigned int>(x);
+    rnd[i]     = (unsigned int)x;
   }
   // initialize table to "empty"
   for (int i = 0; i < VOL_HASH_TABLE_SIZE; i++) {
     ttable[i] = VOL_HASH_EMPTY;
   }
   // generate random numbers proportional to allocation
-  rtable_pair *rtable = static_cast<rtable_pair *>(ats_malloc(sizeof(rtable_pair) * rtable_size));
+  rtable_pair *rtable = (rtable_pair *)ats_malloc(sizeof(rtable_pair) * rtable_size);
   int rindex          = 0;
   for (int i = 0; i < num_vols; i++) {
-    for (int j = 0; j < static_cast<int>(rtable_entries[i]); j++) {
+    for (int j = 0; j < (int)rtable_entries[i]; j++) {
       rtable[rindex].rval = next_rand(&rnd[i]);
       rtable[rindex].idx  = i;
       rindex++;
@@ -1879,7 +1877,7 @@ build_vol_hash_table(CacheHostRecord *cp)
   int i = 0; // index moving through the random numbers
   for (int j = 0; j < VOL_HASH_TABLE_SIZE; j++) {
     pos = width / 2 + j * width; // position to select closest to
-    while (pos > rtable[i].rval && i < static_cast<int>(rtable_size) - 1) {
+    while (pos > rtable[i].rval && i < (int)rtable_size - 1) {
       i++;
     }
     ttable[j] = mapping[rtable[i].idx];
@@ -1994,7 +1992,7 @@ AIO_Callback_handler::handle_disk_failure(int /* event ATS_UNUSED */, void *data
     return EVENT_DONE;
   }
   int disk_no     = 0;
-  AIOCallback *cb = static_cast<AIOCallback *>(data);
+  AIOCallback *cb = (AIOCallback *)data;
 
   for (; disk_no < gndisks; disk_no++) {
     CacheDisk *d = gdisks[disk_no];
@@ -2071,7 +2069,7 @@ Cache::open(bool clear, bool /* fix ATS_UNUSED */)
   CacheVol *cp = cp_list.head;
   for (; cp; cp = cp->link.next) {
     if (cp->scheme == scheme) {
-      cp->vols   = static_cast<Vol **>(ats_malloc(cp->num_vols * sizeof(Vol *)));
+      cp->vols   = (Vol **)ats_malloc(cp->num_vols * sizeof(Vol *));
       int vol_no = 0;
       for (i = 0; i < gndisks; i++) {
         if (cp->disk_vols[i] && !DISK_BAD(cp->disk_vols[i]->disk)) {
@@ -2332,7 +2330,7 @@ CacheVC::handleReadDone(int event, Event *e)
       if (cache_config_enable_checksum && doc->checksum != DOC_NO_CHECKSUM) {
         // verify that the checksum matches
         uint32_t checksum = 0;
-        for (char *b = doc->hdr(); b < reinterpret_cast<char *>(doc) + doc->len; b++) {
+        for (char *b = doc->hdr(); b < (char *)doc + doc->len; b++) {
           checksum += *b;
         }
         ink_assert(checksum == doc->checksum);
@@ -2362,13 +2360,11 @@ CacheVC::handleReadDone(int event, Event *e)
         //                doc->total_len
         // After that, the decision is based of doc_len (doc_len != 0)
         // (cache_config_ram_cache_cutoff == 0) : no cutoffs
-        cutoff_check =
-          ((!doc_len && static_cast<int64_t>(doc->total_len) < cache_config_ram_cache_cutoff) ||
-           (doc_len && static_cast<int64_t>(doc_len) < cache_config_ram_cache_cutoff) || !cache_config_ram_cache_cutoff);
+        cutoff_check = ((!doc_len && (int64_t)doc->total_len < cache_config_ram_cache_cutoff) ||
+                        (doc_len && (int64_t)doc_len < cache_config_ram_cache_cutoff) || !cache_config_ram_cache_cutoff);
         if (cutoff_check && !f.doc_from_ram_cache) {
           uint64_t o = dir_offset(&dir);
-          vol->ram_cache->put(read_key, buf.get(), doc->len, http_copy_hdr, static_cast<uint32_t>(o >> 32),
-                              static_cast<uint32_t>(o));
+          vol->ram_cache->put(read_key, buf.get(), doc->len, http_copy_hdr, (uint32_t)(o >> 32), (uint32_t)o);
         }
         if (!doc_len) {
           // keep a pointer to it. In case the state machine decides to
@@ -2400,7 +2396,7 @@ CacheVC::handleRead(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   // check ram cache
   ink_assert(vol->mutex->thread_holding == this_ethread());
   int64_t o           = dir_offset(&dir);
-  int ram_hit_state   = vol->ram_cache->get(read_key, &buf, static_cast<uint32_t>(o >> 32), static_cast<uint32_t>(o));
+  int ram_hit_state   = vol->ram_cache->get(read_key, &buf, (uint32_t)(o >> 32), (uint32_t)o);
   f.compressed_in_ram = (ram_hit_state > RAM_HIT_COMPRESS_NONE) ? 1 : 0;
   if (ram_hit_state >= RAM_HIT_COMPRESS_NONE) {
     goto LramHit;
@@ -2426,7 +2422,7 @@ CacheVC::handleRead(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
 
   io.aiocb.aio_fildes = vol->fd;
   io.aiocb.aio_offset = vol->vol_offset(&dir);
-  if (static_cast<off_t>(io.aiocb.aio_offset + io.aiocb.aio_nbytes) > static_cast<off_t>(vol->skip + vol->len)) {
+  if ((off_t)(io.aiocb.aio_offset + io.aiocb.aio_nbytes) > (off_t)(vol->skip + vol->len)) {
     io.aiocb.aio_nbytes = vol->skip + vol->len - io.aiocb.aio_offset;
   }
   buf              = new_IOBufferData(iobuffer_size_to_index(io.aiocb.aio_nbytes, MAX_BUFFER_SIZE_INDEX), MEMALIGNED);
@@ -2441,7 +2437,7 @@ CacheVC::handleRead(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
 LramHit : {
   f.doc_from_ram_cache = true;
   io.aio_result        = io.aiocb.aio_nbytes;
-  Doc *doc             = reinterpret_cast<Doc *>(buf->data());
+  Doc *doc             = (Doc *)buf->data();
   if (cache_config_ram_cache_compress && doc->doc_type == CACHE_FRAG_TYPE_HTTP && doc->hlen) {
     SET_HANDLER(&CacheVC::handleReadDone);
     return EVENT_RETURN;
@@ -2521,12 +2517,12 @@ CacheVC::removeEvent(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
       goto Lcollision;
     }
     // check read completed correct FIXME: remove bad vols
-    if (static_cast<size_t>(io.aio_result) != io.aiocb.aio_nbytes) {
+    if ((size_t)io.aio_result != (size_t)io.aiocb.aio_nbytes) {
       goto Ldone;
     }
     {
       // verify that this is our document
-      Doc *doc = reinterpret_cast<Doc *>(buf->data());
+      Doc *doc = (Doc *)buf->data();
       /* should be first_key not key..right?? */
       if (doc->first_key == key) {
         ink_assert(doc->magic == DOC_MAGIC);
@@ -2637,7 +2633,7 @@ cplist_init()
         new_p->num_vols   = dp[j]->num_volblocks;
         new_p->size       = dp[j]->size;
         new_p->scheme     = dp[j]->dpb_queue.head->b->type;
-        new_p->disk_vols  = static_cast<DiskVol **>(ats_malloc(gndisks * sizeof(DiskVol *)));
+        new_p->disk_vols  = (DiskVol **)ats_malloc(gndisks * sizeof(DiskVol *));
         memset(new_p->disk_vols, 0, gndisks * sizeof(DiskVol *));
         new_p->disk_vols[i] = dp[j];
         cp_list.enqueue(new_p);
@@ -2717,7 +2713,7 @@ fillExclusiveDisks(CacheVol *cp)
     }
     /* The user had created several volumes before - clear the disk
        and create one volume for http */
-    for (int j = 0; j < static_cast<int>(gdisks[i]->header->num_volumes); j++) {
+    for (int j = 0; j < (int)gdisks[i]->header->num_volumes; j++) {
       if (volume_number != gdisks[i]->disk_vols[j]->vol_number) {
         Note("Clearing Disk: %s", gdisks[i]->path);
         gdisks[i]->delete_all_volumes();
@@ -2761,7 +2757,7 @@ cplist_reconfigure()
     CacheVol *cp   = new CacheVol();
     cp->vol_number = 0;
     cp->scheme     = CACHE_HTTP_TYPE;
-    cp->disk_vols  = static_cast<DiskVol **>(ats_malloc(gndisks * sizeof(DiskVol *)));
+    cp->disk_vols  = (DiskVol **)ats_malloc(gndisks * sizeof(DiskVol *));
     memset(cp->disk_vols, 0, gndisks * sizeof(DiskVol *));
     cp_list.enqueue(cp);
     cp_list_len++;
@@ -2819,7 +2815,7 @@ cplist_reconfigure()
           Warning("no volumes created");
           return -1;
         }
-        int64_t space_in_blks = static_cast<int64_t>(((config_vol->percent / percent_remaining)) * tot_space_in_blks);
+        int64_t space_in_blks = (int64_t)(((double)(config_vol->percent / percent_remaining)) * tot_space_in_blks);
 
         space_in_blks = space_in_blks >> (20 - STORE_BLOCK_SHIFT);
         /* round down to 128 megabyte multiple */
@@ -2854,7 +2850,7 @@ cplist_reconfigure()
 
       volume_number = config_vol->number;
 
-      size_in_blocks = (static_cast<off_t>(size) * 1024 * 1024) / STORE_BLOCK_SIZE;
+      size_in_blocks = ((off_t)size * 1024 * 1024) / STORE_BLOCK_SIZE;
 
       if (config_vol->cachep && config_vol->cachep->num_vols > 0) {
         gnvol += config_vol->cachep->num_vols;
@@ -2865,7 +2861,7 @@ cplist_reconfigure()
         // we did not find a corresponding entry in cache vol...creat one
 
         CacheVol *new_cp  = new CacheVol();
-        new_cp->disk_vols = static_cast<DiskVol **>(ats_malloc(gndisks * sizeof(DiskVol *)));
+        new_cp->disk_vols = (DiskVol **)ats_malloc(gndisks * sizeof(DiskVol *));
         memset(new_cp->disk_vols, 0, gndisks * sizeof(DiskVol *));
         if (create_volume(config_vol->number, size_in_blocks, config_vol->scheme, new_cp)) {
           ats_free(new_cp->disk_vols);
@@ -3174,7 +3170,7 @@ ink_cache_init(ts::ModuleVersion v)
 {
   ink_release_assert(v.check(CACHE_MODULE_VERSION));
 
-  cache_rsb = RecAllocateRawStatBlock(static_cast<int>(cache_stat_count));
+  cache_rsb = RecAllocateRawStatBlock((int)cache_stat_count);
 
   REC_EstablishStaticConfigInteger(cache_config_ram_cache_size, "proxy.config.cache.ram_cache.size");
   Debug("cache_init", "proxy.config.cache.ram_cache.size = %" PRId64 " = %" PRId64 "Mb", cache_config_ram_cache_size,

--- a/iocore/cache/CacheDir.cc
+++ b/iocore/cache/CacheDir.cc
@@ -400,7 +400,7 @@ dir_clear_range(off_t start, off_t end, Vol *vol)
 {
   for (off_t i = 0; i < vol->buckets * DIR_DEPTH * vol->segments; i++) {
     Dir *e = dir_index(vol, i);
-    if (!dir_token(e) && dir_offset(e) >= static_cast<int64_t>(start) && dir_offset(e) < static_cast<int64_t>(end)) {
+    if (!dir_token(e) && dir_offset(e) >= (int64_t)start && dir_offset(e) < (int64_t)end) {
       CACHE_DEC_DIR_USED(vol->mutex);
       dir_set_offset(e, 0); // delete
     }
@@ -513,7 +513,7 @@ dir_segment_accounted(int s, Vol *d, int offby, int *f, int *u, int *et, int *v,
     *av = agg_valid;
   }
   if (as) {
-    *as = used ? static_cast<int>(agg_size / used) : 0;
+    *as = used ? (int)(agg_size / used) : 0;
   }
   ink_assert(d->buckets * DIR_DEPTH - (free + used + empty) <= offby);
   return d->buckets * DIR_DEPTH - (free + used + empty) <= offby;
@@ -823,8 +823,7 @@ dir_lookaside_fixup(const CacheKey *key, Vol *d)
       DDebug("dir_lookaside", "fixup %X %X offset %" PRId64 " phase %d %d", key->slice32(0), key->slice32(1),
              dir_offset(&b->new_dir), dir_phase(&b->new_dir), res);
       int64_t o = dir_offset(&b->dir), n = dir_offset(&b->new_dir);
-      d->ram_cache->fixup(key, static_cast<uint32_t>(o >> 32), static_cast<uint32_t>(o), static_cast<uint32_t>(n >> 32),
-                          static_cast<uint32_t>(n));
+      d->ram_cache->fixup(key, (uint32_t)(o >> 32), (uint32_t)o, (uint32_t)(n >> 32), (uint32_t)n);
       d->lookaside[i].remove(b);
       free_EvacuationBlock(b, d->mutex->thread_holding);
       return res;
@@ -995,11 +994,11 @@ sync_cache_dir_on_shutdown()
       }
       buflen = dirlen;
       if (ats_hugepage_enabled()) {
-        buf      = static_cast<char *>(ats_alloc_hugepage(buflen));
+        buf      = (char *)ats_alloc_hugepage(buflen);
         buf_huge = true;
       }
       if (buf == nullptr) {
-        buf      = static_cast<char *>(ats_memalign(ats_pagesize(), buflen));
+        buf      = (char *)ats_memalign(ats_pagesize(), buflen);
         buf_huge = false;
       }
     }
@@ -1064,7 +1063,7 @@ Lrestart:
 
   if (event == AIO_EVENT_DONE) {
     // AIO Thread
-    if (io.aio_result != static_cast<int64_t>(io.aiocb.aio_nbytes)) {
+    if (io.aio_result != (int64_t)io.aiocb.aio_nbytes) {
       Warning("vol write error during directory sync '%s'", gvol[vol_idx]->hash_text.get());
       event = EVENT_NONE;
       goto Ldone;
@@ -1128,11 +1127,11 @@ Lrestart:
         }
         buflen = dirlen;
         if (ats_hugepage_enabled()) {
-          buf      = static_cast<char *>(ats_alloc_hugepage(buflen));
+          buf      = (char *)ats_alloc_hugepage(buflen);
           buf_huge = true;
         }
         if (buf == nullptr) {
-          buf      = static_cast<char *>(ats_memalign(ats_pagesize(), buflen));
+          buf      = (char *)ats_memalign(ats_pagesize(), buflen);
           buf_huge = false;
         }
       }
@@ -1149,15 +1148,15 @@ Lrestart:
       // write header
       aio_write(vol->fd, buf + writepos, headerlen, start + writepos);
       writepos += headerlen;
-    } else if (writepos < static_cast<off_t>(dirlen) - headerlen) {
+    } else if (writepos < (off_t)dirlen - headerlen) {
       // write part of body
       int l = SYNC_MAX_WRITE;
-      if (writepos + l > static_cast<off_t>(dirlen) - headerlen) {
+      if (writepos + l > (off_t)dirlen - headerlen) {
         l = dirlen - headerlen - writepos;
       }
       aio_write(vol->fd, buf + writepos, l, start + writepos);
       writepos += l;
-    } else if (writepos < static_cast<off_t>(dirlen)) {
+    } else if (writepos < (off_t)dirlen) {
       ink_assert(writepos == (off_t)dirlen - headerlen);
       // write footer
       aio_write(vol->fd, buf + writepos, headerlen, start + writepos);
@@ -1401,7 +1400,7 @@ void
 dir_corrupt_bucket(Dir *b, int s, Vol *d)
 {
   // coverity[dont_call]
-  int l    = (static_cast<int>(dir_bucket_length(b, s, d) * drand48()));
+  int l    = ((int)(dir_bucket_length(b, s, d) * drand48()));
   Dir *e   = b;
   Dir *seg = d->dir_segment(s);
   for (int i = 0; i < l; i++) {
@@ -1457,7 +1456,7 @@ EXCLUSIVE_REGRESSION_TEST(Cache_dir)(RegressionTest *t, int /* atype ATS_UNUSED 
     inserted++;
   }
   rprintf(t, "inserted: %d\n", inserted);
-  if (static_cast<unsigned int>(inserted - free) > 1) {
+  if ((unsigned int)(inserted - free) > 1) {
     ret = REGRESSION_TEST_FAILED;
   }
 
@@ -1471,7 +1470,7 @@ EXCLUSIVE_REGRESSION_TEST(Cache_dir)(RegressionTest *t, int /* atype ATS_UNUSED 
   dir_clean_segment(s, d);
   int newfree = dir_freelist_length(d, s);
   rprintf(t, "newfree: %d\n", newfree);
-  if (static_cast<unsigned int>(newfree - free) > 1) {
+  if ((unsigned int)(newfree - free) > 1) {
     ret = REGRESSION_TEST_FAILED;
   }
 
@@ -1487,7 +1486,7 @@ EXCLUSIVE_REGRESSION_TEST(Cache_dir)(RegressionTest *t, int /* atype ATS_UNUSED 
   // On windows us is sometimes 0. I don't know why.
   // printout the insert rate only if its not 0
   if (us) {
-    rprintf(t, "insert rate = %d / second\n", static_cast<int>((newfree * static_cast<uint64_t>(1000000)) / us));
+    rprintf(t, "insert rate = %d / second\n", (int)((newfree * (uint64_t)1000000) / us));
   }
   regress_rand_init(13);
   ttime = Thread::get_hrtime_updated();
@@ -1502,7 +1501,7 @@ EXCLUSIVE_REGRESSION_TEST(Cache_dir)(RegressionTest *t, int /* atype ATS_UNUSED 
   // On windows us is sometimes 0. I don't know why.
   // printout the probe rate only if its not 0
   if (us) {
-    rprintf(t, "probe rate = %d / second\n", static_cast<int>((newfree * static_cast<uint64_t>(1000000)) / us));
+    rprintf(t, "probe rate = %d / second\n", (int)((newfree * (uint64_t)1000000) / us));
   }
 
   for (int c = 0; c < d->direntries() * 0.75; c++) {

--- a/iocore/cache/CacheDisk.cc
+++ b/iocore/cache/CacheDisk.cc
@@ -29,8 +29,8 @@ CacheDisk::incrErrors(const AIOCallback *io)
   if (0 == this->num_errors) {
     /* This it the first read/write error on this span since ATS started.
      * Move the newly failing span from "online" to "failing" bucket. */
-    RecIncrGlobalRawStat(cache_rsb, static_cast<int>(cache_span_online_stat), -1);
-    RecIncrGlobalRawStat(cache_rsb, static_cast<int>(cache_span_failing_stat), 1);
+    RecIncrGlobalRawStat(cache_rsb, (int)(cache_span_online_stat), -1);
+    RecIncrGlobalRawStat(cache_rsb, (int)(cache_span_failing_stat), 1);
   }
   this->num_errors++;
 
@@ -40,11 +40,11 @@ CacheDisk::incrErrors(const AIOCallback *io)
   switch (io->aiocb.aio_lio_opcode) {
   case LIO_READ:
     opname = "READ";
-    RecIncrGlobalRawStat(cache_rsb, static_cast<int>(cache_span_errors_read_stat), 1);
+    RecIncrGlobalRawStat(cache_rsb, (int)(cache_span_errors_read_stat), 1);
     break;
   case LIO_WRITE:
     opname = "WRITE";
-    RecIncrGlobalRawStat(cache_rsb, static_cast<int>(cache_span_errors_write_stat), 1);
+    RecIncrGlobalRawStat(cache_rsb, (int)(cache_span_errors_write_stat), 1);
     break;
   default:
     break;
@@ -76,12 +76,12 @@ CacheDisk::open(char *s, off_t blocks, off_t askip, int ahw_sector_size, int fil
     start = skip + header_len;
   }
 
-  disk_vols         = static_cast<DiskVol **>(ats_calloc((l / MIN_VOL_SIZE + 1), sizeof(DiskVol *)));
+  disk_vols         = (DiskVol **)ats_calloc((l / MIN_VOL_SIZE + 1), sizeof(DiskVol *));
   header_len        = ROUND_TO_STORE_BLOCK(header_len);
   start             = skip + header_len;
   num_usable_blocks = (off_t(len * STORE_BLOCK_SIZE) - (start - askip)) >> STORE_BLOCK_SHIFT;
 
-  header = static_cast<DiskHeader *>(ats_memalign(ats_pagesize(), header_len));
+  header = (DiskHeader *)ats_memalign(ats_pagesize(), header_len);
   memset(header, 0, header_len);
 
   // traffic server was asked to clear the cache, i.e., auto clear cache flag is set
@@ -100,7 +100,7 @@ CacheDisk::open(char *s, off_t blocks, off_t askip, int ahw_sector_size, int fil
   //
   SET_HANDLER(&CacheDisk::openStart);
   io.aiocb.aio_offset = skip;
-  io.aiocb.aio_buf    = reinterpret_cast<char *>(header);
+  io.aiocb.aio_buf    = (char *)header;
   io.aiocb.aio_nbytes = header_len;
   io.thread           = AIO_CALLBACK_THREAD_ANY;
   ink_aio_read(&io);
@@ -111,7 +111,7 @@ CacheDisk::~CacheDisk()
 {
   if (path) {
     ats_free(path);
-    for (int i = 0; i < static_cast<int>(header->num_volumes); i++) {
+    for (int i = 0; i < (int)header->num_volumes; i++) {
       DiskVolBlockQueue *q = nullptr;
       while (disk_vols[i] && (q = (disk_vols[i]->dpb_queue.pop()))) {
         delete q;
@@ -147,7 +147,7 @@ CacheDisk::clearDone(int event, void * /* data ATS_UNUSED */)
 {
   ink_assert(event == AIO_EVENT_DONE);
 
-  if (io.aiocb.aio_nbytes != static_cast<size_t>(io.aio_result)) {
+  if ((size_t)io.aiocb.aio_nbytes != (size_t)io.aio_result) {
     Warning("Could not clear disk header for disk %s: declaring disk bad", path);
     incrErrors(&io);
     SET_DISK_BAD(this);
@@ -163,7 +163,7 @@ CacheDisk::openStart(int event, void * /* data ATS_UNUSED */)
 {
   ink_assert(event == AIO_EVENT_DONE);
 
-  if (io.aiocb.aio_nbytes != static_cast<size_t>(io.aio_result)) {
+  if ((size_t)io.aiocb.aio_nbytes != (size_t)io.aio_result) {
     Warning("could not read disk header for disk %s: declaring disk bad", path);
     incrErrors(&io);
     SET_DISK_BAD(this);
@@ -233,7 +233,7 @@ CacheDisk::syncDone(int event, void * /* data ATS_UNUSED */)
 {
   ink_assert(event == AIO_EVENT_DONE);
 
-  if (io.aiocb.aio_nbytes != static_cast<size_t>(io.aio_result)) {
+  if ((size_t)io.aiocb.aio_nbytes != (size_t)io.aio_result) {
     Warning("Error writing disk header for disk %s:disk bad", path);
     incrErrors(&io);
     SET_DISK_BAD(this);
@@ -265,7 +265,7 @@ CacheDisk::create_volume(int number, off_t size_in_blocks, int scheme)
   //  ink_assert(!(size_in_blocks % blocks_per_vol));
   DiskVolBlock *p = nullptr;
   for (; q; q = q->link.next) {
-    if (static_cast<off_t>(q->b->len) >= size_in_blocks) {
+    if ((off_t)q->b->len >= size_in_blocks) {
       p            = q->b;
       q->new_block = 1;
       break;
@@ -293,12 +293,12 @@ CacheDisk::create_volume(int number, off_t size_in_blocks, int scheme)
   free_blocks->size -= p->len;
 
   size_t new_size = p->len - size_in_blocks;
-  if (new_size >= static_cast<size_t>(blocks_per_vol)) {
+  if (new_size >= (size_t)blocks_per_vol) {
     /* create a new volume */
     DiskVolBlock *dpb = &header->vol_info[header->num_diskvol_blks];
     *dpb              = *p;
     dpb->len -= size_in_blocks;
-    dpb->offset += (size_in_blocks * STORE_BLOCK_SIZE);
+    dpb->offset += ((off_t)size_in_blocks * STORE_BLOCK_SIZE);
 
     DiskVolBlockQueue *new_q = new DiskVolBlockQueue();
     new_q->b                 = dpb;

--- a/iocore/cache/CacheHosting.cc
+++ b/iocore/cache/CacheHosting.cc
@@ -66,7 +66,7 @@ CacheHostMatcher::Print()
 void
 CacheHostMatcher::PrintFunc(void *opaque_data)
 {
-  CacheHostRecord *d = static_cast<CacheHostRecord *>(opaque_data);
+  CacheHostRecord *d = (CacheHostRecord *)opaque_data;
   d->Print();
 }
 
@@ -109,7 +109,7 @@ CacheHostMatcher::Match(const char *rdata, int rlen, CacheHostResult *result)
   if (rlen == 0) {
     return;
   }
-  char *data = static_cast<char *>(ats_malloc(rlen + 1));
+  char *data = (char *)ats_malloc(rlen + 1);
   memcpy(data, rdata, rlen);
   *(data + rlen) = '\0';
   HostLookupState s;
@@ -118,7 +118,7 @@ CacheHostMatcher::Match(const char *rdata, int rlen, CacheHostResult *result)
 
   while (r == true) {
     ink_assert(opaque_ptr != nullptr);
-    data_ptr = static_cast<CacheHostRecord *>(opaque_ptr);
+    data_ptr = (CacheHostRecord *)opaque_ptr;
     data_ptr->UpdateMatch(result, data);
 
     r = host_lookup->MatchNext(&s, &opaque_ptr);
@@ -229,7 +229,7 @@ int
 CacheHostTable::config_callback(const char * /* name ATS_UNUSED */, RecDataT /* data_type ATS_UNUSED */,
                                 RecData /* data ATS_UNUSED */, void *cookie)
 {
-  CacheHostTable **ppt = static_cast<CacheHostTable **>(cookie);
+  CacheHostTable **ppt = (CacheHostTable **)cookie;
   eventProcessor.schedule_imm(new CacheHostTableConfig(ppt));
   return 0;
 }
@@ -281,8 +281,8 @@ CacheHostTable::BuildTableFromString(const char *config_file_path, char *file_bu
     }
 
     if (*tmp != '#' && *tmp != '\0') {
-      current = static_cast<matcher_line *>(ats_malloc(sizeof(matcher_line)));
-      errPtr  = parseConfigLine(const_cast<char *>(tmp), current, &config_tags);
+      current = (matcher_line *)ats_malloc(sizeof(matcher_line));
+      errPtr  = parseConfigLine((char *)tmp, current, &config_tags);
 
       if (errPtr != nullptr) {
         RecSignalWarning(REC_SIGNAL_CONFIG_ERROR, "%s discarding %s entry at line %d : %s", matcher_name, config_file_path,
@@ -420,7 +420,7 @@ CacheHostRecord::Init(CacheType typ)
 
   num_vols = 0;
   type     = typ;
-  cp       = static_cast<CacheVol **>(ats_malloc(cp_list_len * sizeof(CacheVol *)));
+  cp       = (CacheVol **)ats_malloc(cp_list_len * sizeof(CacheVol *));
   memset(cp, 0, cp_list_len * sizeof(CacheVol *));
   num_cachevols    = 0;
   CacheVol *cachep = cp_list.head;
@@ -436,7 +436,7 @@ CacheHostRecord::Init(CacheType typ)
     RecSignalWarning(REC_SIGNAL_CONFIG_ERROR, "error: No volumes found for Cache Type %d", type);
     return -1;
   }
-  vols        = static_cast<Vol **>(ats_malloc(num_vols * sizeof(Vol *)));
+  vols        = (Vol **)ats_malloc(num_vols * sizeof(Vol *));
   int counter = 0;
   for (i = 0; i < num_cachevols; i++) {
     CacheVol *cachep1 = cp[i];
@@ -505,7 +505,7 @@ CacheHostRecord::Init(matcher_line *line_info, CacheType typ)
       }
       s = val;
       num_cachevols++;
-      cp = static_cast<CacheVol **>(ats_malloc(num_cachevols * sizeof(CacheVol *)));
+      cp = (CacheVol **)ats_malloc(num_cachevols * sizeof(CacheVol *));
       memset(cp, 0, num_cachevols * sizeof(CacheVol *));
       num_cachevols = 0;
       while (true) {
@@ -562,7 +562,7 @@ CacheHostRecord::Init(matcher_line *line_info, CacheType typ)
   if (!num_vols) {
     return -1;
   }
-  vols        = static_cast<Vol **>(ats_malloc(num_vols * sizeof(Vol *)));
+  vols        = (Vol **)ats_malloc(num_vols * sizeof(Vol *));
   int counter = 0;
   for (i = 0; i < num_cachevols; i++) {
     CacheVol *cachep = cp[i];
@@ -662,7 +662,7 @@ ConfigVolumes::BuildListFromString(char *config_file_path, char *file_buf)
         break;
       }
 
-      end = const_cast<char *>(tmp);
+      end = (char *)tmp;
       while (*end && !isspace(*end)) {
         end++;
       }
@@ -675,7 +675,7 @@ ConfigVolumes::BuildListFromString(char *config_file_path, char *file_buf)
       }
       char *eq_sign;
 
-      eq_sign = const_cast<char *>(strchr(tmp, '='));
+      eq_sign = (char *)strchr(tmp, '=');
       if (!eq_sign) {
         err = "Unexpected end of line";
         break;
@@ -1033,10 +1033,10 @@ execute_and_verify(RegressionTest *t)
     CacheDisk *d = gdisks[i];
     if (is_debug_tag_set("cache_hosting")) {
       Debug("cache_hosting", "Disk: %d: Vol Blocks: %u: Free space: %" PRIu64, i, d->header->num_diskvol_blks, d->free_space);
-      for (int j = 0; j < static_cast<int>(d->header->num_volumes); j++) {
+      for (int j = 0; j < (int)d->header->num_volumes; j++) {
         Debug("cache_hosting", "\tVol: %d Size: %" PRIu64, d->disk_vols[j]->vol_number, d->disk_vols[j]->size);
       }
-      for (int j = 0; j < static_cast<int>(d->header->num_diskvol_blks); j++) {
+      for (int j = 0; j < (int)d->header->num_diskvol_blks; j++) {
         Debug("cache_hosting", "\tBlock No: %d Size: %" PRIu64 " Free: %u", d->header->vol_info[j].number,
               d->header->vol_info[j].len, d->header->vol_info[j].free);
       }

--- a/iocore/cache/CacheHttp.cc
+++ b/iocore/cache/CacheHttp.cc
@@ -206,8 +206,8 @@ CacheHTTPInfoVector::unmarshal(const char *buf, int length, RefCountObj *block_p
   CacheHTTPInfo info;
   xcount = 0;
 
-  while (length - (buf - start) > static_cast<int>(sizeof(HTTPCacheAlt))) {
-    int tmp = HTTPInfo::unmarshal(const_cast<char *>(buf), length - (buf - start), block_ptr);
+  while (length - (buf - start) > (int)sizeof(HTTPCacheAlt)) {
+    int tmp = HTTPInfo::unmarshal((char *)buf, length - (buf - start), block_ptr);
     if (tmp < 0) {
       return -1;
     }
@@ -218,7 +218,7 @@ CacheHTTPInfoVector::unmarshal(const char *buf, int length, RefCountObj *block_p
     xcount++;
   }
 
-  return (const_cast<caddr_t>(buf) - const_cast<caddr_t>(start));
+  return ((caddr_t)buf - (caddr_t)start);
 }
 
 /*-------------------------------------------------------------------------
@@ -234,11 +234,11 @@ CacheHTTPInfoVector::get_handles(const char *buf, int length, RefCountObj *block
 
   vector_buf = block_ptr;
 
-  while (length - (buf - start) > static_cast<int>(sizeof(HTTPCacheAlt))) {
-    int tmp = info.get_handle(const_cast<char *>(buf), length - (buf - start));
+  while (length - (buf - start) > (int)sizeof(HTTPCacheAlt)) {
+    int tmp = info.get_handle((char *)buf, length - (buf - start));
     if (tmp < 0) {
       ink_assert(!"CacheHTTPInfoVector::unmarshal get_handle() failed");
-      return static_cast<uint32_t>(-1);
+      return (uint32_t)-1;
     }
     buf += tmp;
 
@@ -246,5 +246,5 @@ CacheHTTPInfoVector::get_handles(const char *buf, int length, RefCountObj *block
     xcount++;
   }
 
-  return (const_cast<caddr_t>(buf) - const_cast<caddr_t>(start));
+  return ((caddr_t)buf - (caddr_t)start);
 }

--- a/iocore/cache/CacheLink.cc
+++ b/iocore/cache/CacheLink.cc
@@ -137,14 +137,14 @@ CacheVC::derefRead(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   if (!buf) {
     goto Lcollision;
   }
-  if (static_cast<int>(io.aio_result) != static_cast<int>(io.aiocb.aio_nbytes)) {
+  if ((int)io.aio_result != (int)io.aiocb.aio_nbytes) {
     goto Ldone;
   }
   if (!dir_agg_valid(vol, &dir)) {
     last_collision = nullptr;
     goto Lcollision;
   }
-  doc = reinterpret_cast<Doc *>(buf->data());
+  doc = (Doc *)buf->data();
   if (!(doc->first_key == key)) {
     goto Lcollision;
   }

--- a/iocore/cache/CachePages.cc
+++ b/iocore/cache/CachePages.cc
@@ -84,7 +84,7 @@ struct ShowCache : public ShowCont {
     URL *u             = h->url_get();
 
     // process the query string
-    if (u->query_get(&query_len) && query_len < static_cast<int>(sizeof(query))) {
+    if (u->query_get(&query_len) && query_len < (int)sizeof(query)) {
       strncpy(query, u->query_get(&query_len), query_len);
       strncpy(unescapedQuery, u->query_get(&query_len), query_len);
 
@@ -97,7 +97,7 @@ struct ShowCache : public ShowCont {
 
       // remove 'C-m' s
       unsigned l, m;
-      for (l = 0, m = 0; l < static_cast<unsigned>(query_len); l++) {
+      for (l = 0, m = 0; l < (unsigned)query_len; l++) {
         if (query[l] != '\015') {
           query[m++] = query[l];
         }
@@ -110,7 +110,7 @@ struct ShowCache : public ShowCont {
       if (p) {
         while ((p = strstr(p, "\n"))) {
           nstrings++;
-          if (static_cast<size_t>(p - query) >= strlen(query) - 1) {
+          if ((size_t)(p - query) >= strlen(query) - 1) {
             break;
           } else {
             p++;
@@ -333,7 +333,7 @@ ShowCache::handleCacheEvent(int event, Event *e)
   }
   case CACHE_EVENT_OPEN_READ: {
     // get the vector
-    cache_vc                 = reinterpret_cast<CacheVC *>(e);
+    cache_vc                 = (CacheVC *)e;
     CacheHTTPInfoVector *vec = &(cache_vc->vector);
     int alt_count            = vec->count();
     if (alt_count) {
@@ -344,7 +344,7 @@ ShowCache::handleCacheEvent(int event, Event *e)
         return complete(event, e);
       }
 
-      Doc *d = reinterpret_cast<Doc *>(cache_vc->first_buf->data());
+      Doc *d = (Doc *)(cache_vc->first_buf->data());
       time_t t;
       char tmpstr[4096];
 
@@ -594,11 +594,11 @@ ShowCache::handleCacheScanCallback(int event, Event *e)
 {
   switch (event) {
   case CACHE_EVENT_SCAN: {
-    cache_vc = reinterpret_cast<CacheVC *>(e);
+    cache_vc = (CacheVC *)e;
     return EVENT_CONT;
   }
   case CACHE_EVENT_SCAN_OBJECT: {
-    HTTPInfo *alt = reinterpret_cast<HTTPInfo *>(e);
+    HTTPInfo *alt = (HTTPInfo *)e;
     char xx[501], m[501];
     int ib = 0, xd = 0, ml = 0;
 

--- a/iocore/cache/CachePagesInternal.cc
+++ b/iocore/cache/CachePagesInternal.cc
@@ -205,7 +205,7 @@ ShowCacheInternal::showVolEvacuations(int event, Event *e)
   for (int i = 0; i < last; i++) {
     for (b = p->evacuate[i].head; b; b = b->link.next) {
       char offset[60];
-      sprintf(offset, "%" PRIu64 "", static_cast<uint64_t>(p->vol_offset(&b->dir)));
+      sprintf(offset, "%" PRIu64 "", (uint64_t)p->vol_offset(&b->dir));
       CHECK_SHOW(show("<tr>"
                       "<td>%s</td>" // offset
                       "<td>%d</td>" // estimated size

--- a/iocore/cache/CacheTest.cc
+++ b/iocore/cache/CacheTest.cc
@@ -37,9 +37,9 @@ CacheTestSM::CacheTestSM(RegressionTest *t, const char *name) : RegressionSM(t),
 
 CacheTestSM::CacheTestSM(const CacheTestSM &ao) : RegressionSM(ao)
 {
-  int o = static_cast<int>((reinterpret_cast<char *>(&start_memcpy_on_clone)) - (reinterpret_cast<char *>(this)));
-  int s = static_cast<int>((reinterpret_cast<char *>(&end_memcpy_on_clone)) - (reinterpret_cast<char *>(&start_memcpy_on_clone)));
-  memcpy((reinterpret_cast<char *>(this)) + o, ((char *)&ao) + o, s);
+  int o = (int)(((char *)&start_memcpy_on_clone) - ((char *)this));
+  int s = (int)(((char *)&end_memcpy_on_clone) - ((char *)&start_memcpy_on_clone));
+  memcpy(((char *)this) + o, ((char *)&ao) + o, s);
   SET_HANDLER(&CacheTestSM::event_handler);
 }
 
@@ -96,7 +96,7 @@ CacheTestSM::event_handler(int event, void *data)
     initial_event = event;
     cancel_timeout();
     cache_action  = nullptr;
-    cache_vc      = static_cast<CacheVConnection *>(data);
+    cache_vc      = (CacheVConnection *)data;
     buffer        = new_empty_MIOBuffer();
     buffer_reader = buffer->alloc_reader();
     if (open_read_callout() < 0) {
@@ -113,7 +113,7 @@ CacheTestSM::event_handler(int event, void *data)
       goto Lclose_error_next;
     }
     buffer_reader->consume(buffer_reader->read_avail());
-    (static_cast<VIO *>(data))->reenable();
+    ((VIO *)data)->reenable();
     return EVENT_CONT;
 
   case VC_EVENT_READ_COMPLETE:
@@ -130,7 +130,7 @@ CacheTestSM::event_handler(int event, void *data)
     initial_event = event;
     cancel_timeout();
     cache_action  = nullptr;
-    cache_vc      = static_cast<CacheVConnection *>(data);
+    cache_vc      = (CacheVConnection *)data;
     buffer        = new_empty_MIOBuffer();
     buffer_reader = buffer->alloc_reader();
     if (open_write_callout() < 0) {
@@ -159,7 +159,7 @@ CacheTestSM::event_handler(int event, void *data)
 
   case CACHE_EVENT_SCAN:
     initial_event = event;
-    cache_vc      = static_cast<CacheVConnection *>(data);
+    cache_vc      = (CacheVConnection *)data;
     return EVENT_CONT;
 
   case CACHE_EVENT_SCAN_OBJECT:
@@ -221,7 +221,7 @@ CacheTestSM::fill_buffer()
   int64_t avail = buffer->write_avail();
   CacheKey k    = key;
   k.b[1] += content_salt;
-  int64_t sk = static_cast<int64_t>(sizeof(key));
+  int64_t sk = (int64_t)sizeof(key);
   while (avail > 0) {
     int64_t l = avail;
     if (l > sk) {
@@ -235,7 +235,7 @@ CacheTestSM::fill_buffer()
       l = sk - o;
     }
     k.b[0]  = pos / sk;
-    char *x = (reinterpret_cast<char *>(&k)) + o;
+    char *x = ((char *)&k) + o;
     buffer->write(x, l);
     buffer->fill(l);
     avail -= l;
@@ -249,7 +249,7 @@ CacheTestSM::check_buffer()
   CacheKey k    = key;
   k.b[1] += content_salt;
   char b[sizeof(key)];
-  int64_t sk  = static_cast<int64_t>(sizeof(key));
+  int64_t sk  = (int64_t)sizeof(key);
   int64_t pos = cvio->ndone - buffer_reader->read_avail();
   while (avail > 0) {
     int64_t l = avail;
@@ -261,7 +261,7 @@ CacheTestSM::check_buffer()
       l = sk - o;
     }
     k.b[0]  = pos / sk;
-    char *x = (reinterpret_cast<char *>(&k)) + o;
+    char *x = ((char *)&k) + o;
     buffer_reader->read(&b[0], l);
     if (::memcmp(b, x, l)) {
       return 0;
@@ -511,7 +511,7 @@ build_zipf()
   if (zipf_table) {
     return;
   }
-  zipf_table = static_cast<double *>(ats_malloc(ZIPF_SIZE * sizeof(double)));
+  zipf_table = (double *)ats_malloc(ZIPF_SIZE * sizeof(double));
   for (int i = 0; i < ZIPF_SIZE; i++) {
     zipf_table[i] = 1.0 / pow(i + 2, zipf_alpha);
   }
@@ -561,16 +561,16 @@ test_RamCache(RegressionTest *t, RamCache *cache, const char *name, int64_t cach
 
       d->alloc(BUFFER_SIZE_INDEX_16K);
       data.push_back(make_ptr(d));
-      hash.u64[0] = (static_cast<uint64_t>(i) << 32) + i;
-      hash.u64[1] = (static_cast<uint64_t>(i) << 32) + i;
+      hash.u64[0] = ((uint64_t)i << 32) + i;
+      hash.u64[1] = ((uint64_t)i << 32) + i;
       cache->put(&hash, data[i].get(), 1 << 15);
       // More hits for the first 10.
       for (int j = 0; j <= i && j < 10; j++) {
         Ptr<IOBufferData> data;
         CryptoHash hash;
 
-        hash.u64[0] = (static_cast<uint64_t>(j) << 32) + j;
-        hash.u64[1] = (static_cast<uint64_t>(j) << 32) + j;
+        hash.u64[0] = ((uint64_t)j << 32) + j;
+        hash.u64[1] = ((uint64_t)j << 32) + j;
         cache->get(&hash, &data);
       }
     }
@@ -580,8 +580,8 @@ test_RamCache(RegressionTest *t, RamCache *cache, const char *name, int64_t cach
     CryptoHash hash;
     Ptr<IOBufferData> data;
 
-    hash.u64[0] = (static_cast<uint64_t>(i) << 32) + i;
-    hash.u64[1] = (static_cast<uint64_t>(i) << 32) + i;
+    hash.u64[0] = ((uint64_t)i << 32) + i;
+    hash.u64[1] = ((uint64_t)i << 32) + i;
     if (!cache->get(&hash, &data)) {
       pass = false;
     }
@@ -590,7 +590,7 @@ test_RamCache(RegressionTest *t, RamCache *cache, const char *name, int64_t cach
   int sample_size = cache_size >> 6;
   build_zipf();
   srand48(13);
-  int *r = static_cast<int *>(ats_malloc(sample_size * sizeof(int)));
+  int *r = (int *)ats_malloc(sample_size * sizeof(int));
   for (int i = 0; i < sample_size; i++) {
     // coverity[dont_call]
     r[i] = get_zipf(drand48());
@@ -599,8 +599,8 @@ test_RamCache(RegressionTest *t, RamCache *cache, const char *name, int64_t cach
   int misses = 0;
   for (int i = 0; i < sample_size; i++) {
     CryptoHash hash;
-    hash.u64[0] = (static_cast<uint64_t>(r[i]) << 32) + r[i];
-    hash.u64[1] = (static_cast<uint64_t>(r[i]) << 32) + r[i];
+    hash.u64[0] = ((uint64_t)r[i] << 32) + r[i];
+    hash.u64[1] = ((uint64_t)r[i] << 32) + r[i];
     Ptr<IOBufferData> get_data;
     if (!cache->get(&hash, &get_data)) {
       IOBufferData *d = THREAD_ALLOC(ioDataAllocator, this_thread());
@@ -612,15 +612,15 @@ test_RamCache(RegressionTest *t, RamCache *cache, const char *name, int64_t cach
       }
     }
   }
-  double fixed_hit_rate = 1.0 - ((static_cast<double>(misses)) / (sample_size / 2));
+  double fixed_hit_rate = 1.0 - (((double)(misses)) / (sample_size / 2));
   rprintf(t, "RamCache %s Fixed Size Hit Rate %f\n", name, fixed_hit_rate);
 
   data.clear();
   misses = 0;
   for (int i = 0; i < sample_size; i++) {
     CryptoHash hash;
-    hash.u64[0] = (static_cast<uint64_t>(r[i]) << 32) + r[i];
-    hash.u64[1] = (static_cast<uint64_t>(r[i]) << 32) + r[i];
+    hash.u64[0] = ((uint64_t)r[i] << 32) + r[i];
+    hash.u64[1] = ((uint64_t)r[i] << 32) + r[i];
     Ptr<IOBufferData> get_data;
     if (!cache->get(&hash, &get_data)) {
       IOBufferData *d = THREAD_ALLOC(ioDataAllocator, this_thread());
@@ -632,7 +632,7 @@ test_RamCache(RegressionTest *t, RamCache *cache, const char *name, int64_t cach
       }
     }
   }
-  double variable_hit_rate = 1.0 - ((static_cast<double>(misses)) / (sample_size / 2));
+  double variable_hit_rate = 1.0 - (((double)(misses)) / (sample_size / 2));
   rprintf(t, "RamCache %s Variable Size Hit Rate %f\n", name, variable_hit_rate);
 
   rprintf(t, "RamCache %s Nominal Size %lld Size %lld\n", name, cache_size, cache->size());

--- a/iocore/cache/CacheVol.cc
+++ b/iocore/cache/CacheVol.cc
@@ -127,7 +127,7 @@ make_vol_map(Vol *d)
   off_t start_offset = d->vol_offset_to_offset(0);
   off_t vol_len      = d->vol_relative_length(start_offset);
   size_t map_len     = (vol_len + (SCAN_BUF_SIZE - 1)) / SCAN_BUF_SIZE;
-  char *vol_map      = static_cast<char *>(ats_malloc(map_len));
+  char *vol_map      = (char *)ats_malloc(map_len);
 
   memset(vol_map, 0, map_len);
 
@@ -187,7 +187,7 @@ CacheVC::scanObject(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     fragment            = 1;
     scan_vol_map        = make_vol_map(vol);
     io.aiocb.aio_offset = next_in_map(vol, scan_vol_map, vol->vol_offset_to_offset(0));
-    if (io.aiocb.aio_offset >= static_cast<off_t>(vol->skip + vol->len)) {
+    if (io.aiocb.aio_offset >= (off_t)(vol->skip + vol->len)) {
       goto Lnext_vol;
     }
     io.aiocb.aio_nbytes = SCAN_BUF_SIZE;
@@ -198,25 +198,24 @@ CacheVC::scanObject(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     goto Lread;
   }
 
-  if (static_cast<size_t>(io.aio_result) != io.aiocb.aio_nbytes) {
+  if ((size_t)io.aio_result != (size_t)io.aiocb.aio_nbytes) {
     result = (void *)-ECACHE_READ_FAIL;
     goto Ldone;
   }
 
-  doc = reinterpret_cast<Doc *>(buf->data() + offset);
+  doc = (Doc *)(buf->data() + offset);
   // If there is data in the buffer before the start that is from a partial object read previously
   // Fix things as if we read it this time.
   if (scan_fix_buffer_offset) {
     io.aio_result += scan_fix_buffer_offset;
     io.aiocb.aio_nbytes += scan_fix_buffer_offset;
     io.aiocb.aio_offset -= scan_fix_buffer_offset;
-    io.aiocb.aio_buf       = static_cast<char *>(io.aiocb.aio_buf) - scan_fix_buffer_offset;
+    io.aiocb.aio_buf       = (char *)io.aiocb.aio_buf - scan_fix_buffer_offset;
     scan_fix_buffer_offset = 0;
   }
-  while (static_cast<off_t>(reinterpret_cast<char *>(doc) - buf->data()) + next_object_len <
-         static_cast<off_t>(io.aiocb.aio_nbytes)) {
+  while ((off_t)((char *)doc - buf->data()) + next_object_len < (off_t)io.aiocb.aio_nbytes) {
     might_need_overlap_read = false;
-    doc                     = reinterpret_cast<Doc *>(reinterpret_cast<char *>(doc) + next_object_len);
+    doc                     = (Doc *)((char *)doc + next_object_len);
     next_object_len         = vol->round_to_approx_size(doc->len);
     int i;
     bool changed;
@@ -237,12 +236,12 @@ CacheVC::scanObject(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
         goto Lskip;
       }
       if (!dir_agg_valid(vol, &dir) || !dir_head(&dir) ||
-          (vol->vol_offset(&dir) != io.aiocb.aio_offset + (reinterpret_cast<char *>(doc) - buf->data()))) {
+          (vol->vol_offset(&dir) != io.aiocb.aio_offset + ((char *)doc - buf->data()))) {
         continue;
       }
       break;
     }
-    if (doc->data() - buf->data() > static_cast<int>(io.aiocb.aio_nbytes)) {
+    if (doc->data() - buf->data() > (int)io.aiocb.aio_nbytes) {
       might_need_overlap_read = true;
       goto Lskip;
     }
@@ -321,7 +320,7 @@ CacheVC::scanObject(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
         cacheProcessor.remove(this, &doc->first_key, CACHE_FRAG_TYPE_HTTP, hname, hlen);
         return EVENT_CONT;
       } else {
-        offset          = reinterpret_cast<char *>(doc) - buf->data();
+        offset          = (char *)doc - buf->data();
         write_len       = 0;
         frag_type       = CACHE_FRAG_TYPE_HTTP;
         f.use_first_key = 1;
@@ -340,19 +339,17 @@ CacheVC::scanObject(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   vector.clear();
   // If we had an object that went past the end of the buffer, and it is small enough to fix,
   // fix it.
-  if (might_need_overlap_read &&
-      (static_cast<off_t>(reinterpret_cast<char *>(doc) - buf->data()) + next_object_len >
-       static_cast<off_t>(io.aiocb.aio_nbytes)) &&
+  if (might_need_overlap_read && ((off_t)((char *)doc - buf->data()) + next_object_len > (off_t)io.aiocb.aio_nbytes) &&
       next_object_len > 0) {
-    off_t partial_object_len = io.aiocb.aio_nbytes - (reinterpret_cast<char *>(doc) - buf->data());
+    off_t partial_object_len = io.aiocb.aio_nbytes - ((char *)doc - buf->data());
     // Copy partial object to beginning of the buffer.
-    memmove(buf->data(), reinterpret_cast<char *>(doc), partial_object_len);
+    memmove(buf->data(), (char *)doc, partial_object_len);
     io.aiocb.aio_offset += io.aiocb.aio_nbytes;
     io.aiocb.aio_nbytes    = SCAN_BUF_SIZE - partial_object_len;
     io.aiocb.aio_buf       = buf->data() + partial_object_len;
     scan_fix_buffer_offset = partial_object_len;
   } else { // Normal case, where we ended on a object boundary.
-    io.aiocb.aio_offset += (reinterpret_cast<char *>(doc) - buf->data()) + next_object_len;
+    io.aiocb.aio_offset += ((char *)doc - buf->data()) + next_object_len;
     Debug("cache_scan_truss", "next %p:scanObject %" PRId64, this, (int64_t)io.aiocb.aio_offset);
     io.aiocb.aio_offset = next_in_map(vol, scan_vol_map, io.aiocb.aio_offset);
     Debug("cache_scan_truss", "next_in_map %p:scanObject %" PRId64, this, (int64_t)io.aiocb.aio_offset);
@@ -370,7 +367,7 @@ CacheVC::scanObject(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
 
 Lread:
   io.aiocb.aio_fildes = vol->fd;
-  if (static_cast<off_t>(io.aiocb.aio_offset + io.aiocb.aio_nbytes) > static_cast<off_t>(vol->skip + vol->len)) {
+  if ((off_t)(io.aiocb.aio_offset + io.aiocb.aio_nbytes) > (off_t)(vol->skip + vol->len)) {
     io.aiocb.aio_nbytes = vol->skip + vol->len - io.aiocb.aio_offset;
   }
   offset = 0;
@@ -442,8 +439,8 @@ CacheVC::scanOpenWrite(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     Debug("cache_scan", "got writer lock");
     Dir *l = nullptr;
     Dir d;
-    Doc *doc = reinterpret_cast<Doc *>(buf->data() + offset);
-    offset   = reinterpret_cast<char *>(doc) - buf->data() + vol->round_to_approx_size(doc->len);
+    Doc *doc = (Doc *)(buf->data() + offset);
+    offset   = (char *)doc - buf->data() + vol->round_to_approx_size(doc->len);
     // if the doc contains some data, then we need to create
     // a new directory entry for this fragment. Remember the
     // offset and the key in earliest_key

--- a/iocore/cache/CacheWrite.cc
+++ b/iocore/cache/CacheWrite.cc
@@ -112,8 +112,8 @@ CacheVC::updateVector(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     }
 
     if (od->move_resident_alt && first_buf.get() && !od->has_multiple_writers()) {
-      Doc *doc         = reinterpret_cast<Doc *>(first_buf->data());
-      int small_doc    = static_cast<int64_t>(doc->data_len()) < static_cast<int64_t>(cache_config_alt_rewrite_max_size);
+      Doc *doc         = (Doc *)first_buf->data();
+      int small_doc    = (int64_t)doc->data_len() < (int64_t)cache_config_alt_rewrite_max_size;
       int have_res_alt = doc->key == od->single_doc_key;
       // if the new alternate is not written with the vector
       // then move the old one with the vector
@@ -346,7 +346,7 @@ Vol::aggWriteDone(int event, Event *e)
     Dir del_dir;
     dir_clear(&del_dir);
     for (int done = 0; done < agg_buf_pos;) {
-      Doc *doc = reinterpret_cast<Doc *>(agg_buffer + done);
+      Doc *doc = (Doc *)(agg_buffer + done);
       dir_set_offset(&del_dir, header->write_pos + done);
       dir_delete(&doc->key, this, &del_dir);
       done += round_to_approx_size(doc->len);
@@ -395,7 +395,7 @@ CacheVC::evacuateReadHead(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */
   // The evacuator vc shares the lock with the volition mutex
   ink_assert(vol->mutex->thread_holding == this_ethread());
   cancel_trigger();
-  Doc *doc                     = reinterpret_cast<Doc *>(buf->data());
+  Doc *doc                     = (Doc *)buf->data();
   CacheHTTPInfo *alternate_tmp = nullptr;
   if (!io.ok()) {
     goto Ldone;
@@ -458,7 +458,7 @@ int
 CacheVC::evacuateDocDone(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
 {
   ink_assert(vol->mutex->thread_holding == this_ethread());
-  Doc *doc = reinterpret_cast<Doc *>(buf->data());
+  Doc *doc = (Doc *)buf->data();
   DDebug("cache_evac", "evacuateDocDone %X o %d p %d new_o %d new_p %d", (int)key.slice32(0), (int)dir_offset(&overwrite_dir),
          (int)dir_phase(&overwrite_dir), (int)dir_offset(&dir), (int)dir_phase(&dir));
   int i = dir_evac_bucket(&overwrite_dir);
@@ -519,8 +519,7 @@ CacheVC::evacuateDocDone(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
           }
           if (dir_overwrite(&doc->first_key, vol, &dir, &overwrite_dir)) {
             int64_t o = dir_offset(&overwrite_dir), n = dir_offset(&dir);
-            vol->ram_cache->fixup(&doc->first_key, static_cast<uint32_t>(o >> 32), static_cast<uint32_t>(o),
-                                  static_cast<uint32_t>(n >> 32), static_cast<uint32_t>(n));
+            vol->ram_cache->fixup(&doc->first_key, (uint32_t)(o >> 32), (uint32_t)o, (uint32_t)(n >> 32), (uint32_t)n);
           }
         } else {
           DDebug("cache_evac", "evacuating earliest: %X %d", (int)doc->key.slice32(0), (int)dir_offset(&overwrite_dir));
@@ -589,10 +588,10 @@ Vol::evacuateWrite(CacheVC *evacuator, int event, Event *e)
 {
   // push to front of aggregation write list, so it is written first
 
-  evacuator->agg_len = round_to_approx_size((reinterpret_cast<Doc *>(evacuator->buf->data()))->len);
+  evacuator->agg_len = round_to_approx_size(((Doc *)evacuator->buf->data())->len);
   agg_todo_size += evacuator->agg_len;
   /* insert the evacuator after all the other evacuators */
-  CacheVC *cur   = static_cast<CacheVC *>(agg.head);
+  CacheVC *cur   = (CacheVC *)agg.head;
   CacheVC *after = nullptr;
   for (; cur && cur->f.evacuator; cur = (CacheVC *)cur->link.next) {
     after = cur;
@@ -612,7 +611,7 @@ Vol::evacuateDocReadDone(int event, Event *e)
   ink_assert(is_io_in_progress());
   set_io_not_in_progress();
   ink_assert(mutex->thread_holding == this_ethread());
-  Doc *doc = reinterpret_cast<Doc *>(doc_evacuator->buf->data());
+  Doc *doc = (Doc *)doc_evacuator->buf->data();
   CacheKey next_key;
   EvacuationBlock *b = nullptr;
   if (doc->magic != DOC_MAGIC) {
@@ -634,7 +633,7 @@ Vol::evacuateDocReadDone(int event, Event *e)
   if (!b) {
     goto Ldone;
   }
-  if ((b->f.pinned && !b->readers) && doc->pinned < static_cast<uint32_t>(Thread::get_hrtime() / HRTIME_SECOND)) {
+  if ((b->f.pinned && !b->readers) && doc->pinned < (uint32_t)(Thread::get_hrtime() / HRTIME_SECOND)) {
     goto Ldone;
   }
 
@@ -719,7 +718,7 @@ Vol::evac_range(off_t low, off_t high, int evac_phase)
       io.aiocb.aio_fildes = fd;
       io.aiocb.aio_nbytes = dir_approx_size(&first->dir);
       io.aiocb.aio_offset = this->vol_offset(&first->dir);
-      if (static_cast<off_t>(io.aiocb.aio_offset + io.aiocb.aio_nbytes) > static_cast<off_t>(skip + len)) {
+      if ((off_t)(io.aiocb.aio_offset + io.aiocb.aio_nbytes) > (off_t)(skip + len)) {
         io.aiocb.aio_nbytes = skip + len - io.aiocb.aio_offset;
       }
       doc_evacuator                = new_DocEvacuator(io.aiocb.aio_nbytes, this);
@@ -744,7 +743,7 @@ agg_copy(char *p, CacheVC *vc)
   off_t o  = vol->header->write_pos + vol->agg_buf_pos;
 
   if (!vc->f.evacuator) {
-    Doc *doc                   = reinterpret_cast<Doc *>(p);
+    Doc *doc                   = (Doc *)p;
     IOBufferBlock *res_alt_blk = nullptr;
 
     uint32_t len = vc->write_len + vc->header_len + vc->frag_len + sizeof(Doc);
@@ -771,7 +770,7 @@ agg_copy(char *p, CacheVC *vc)
     doc->checksum                        = DOC_NO_CHECKSUM;
     if (vc->pin_in_cache) {
       dir_set_pinned(&vc->dir, 1);
-      doc->pinned = static_cast<uint32_t>(Thread::get_hrtime() / HRTIME_SECOND) + vc->pin_in_cache;
+      doc->pinned = (uint32_t)(Thread::get_hrtime() / HRTIME_SECOND) + vc->pin_in_cache;
     } else {
       dir_set_pinned(&vc->dir, 0);
       doc->pinned = 0;
@@ -797,7 +796,7 @@ agg_copy(char *p, CacheVC *vc)
 
     if (vc->f.rewrite_resident_alt) {
       ink_assert(vc->f.use_first_key);
-      Doc *res_doc   = reinterpret_cast<Doc *>(vc->first_buf->data());
+      Doc *res_doc   = (Doc *)vc->first_buf->data();
       res_alt_blk    = new_IOBufferBlock(vc->first_buf, res_doc->data_len(), sizeof(Doc) + res_doc->hlen);
       doc->key       = res_doc->key;
       doc->total_len = res_doc->data_len();
@@ -853,7 +852,7 @@ agg_copy(char *p, CacheVC *vc)
     }
     if (cache_config_enable_checksum) {
       doc->checksum = 0;
-      for (char *b = doc->hdr(); b < reinterpret_cast<char *>(doc) + doc->len; b++) {
+      for (char *b = doc->hdr(); b < (char *)doc + doc->len; b++) {
         doc->checksum += *b;
       }
     }
@@ -868,7 +867,7 @@ agg_copy(char *p, CacheVC *vc)
     return vc->agg_len;
   } else {
     // for evacuated documents, copy the data, and update directory
-    Doc *doc = reinterpret_cast<Doc *>(vc->buf->data());
+    Doc *doc = (Doc *)vc->buf->data();
     int l    = vc->vol->round_to_approx_size(doc->len);
     {
       ProxyMutex *mutex ATS_UNUSED = vc->vol->mutex.get();
@@ -986,7 +985,7 @@ Vol::aggWrite(int event, void * /* e ATS_UNUSED */)
 
 Lagain:
   // calculate length of aggregated write
-  for (c = static_cast<CacheVC *>(agg.head); c;) {
+  for (c = (CacheVC *)agg.head; c;) {
     int writelen = c->agg_len;
     // [amc] this is checked multiple places, on here was it strictly less.
     ink_assert(writelen <= AGG_SIZE);
@@ -1059,7 +1058,7 @@ Lagain:
     ink_assert(sync.head);
     int l       = round_to_approx_size(sizeof(Doc));
     agg_buf_pos = l;
-    Doc *d      = reinterpret_cast<Doc *>(agg_buffer);
+    Doc *d      = (Doc *)agg_buffer;
     memset(static_cast<void *>(d), 0, sizeof(Doc));
     d->magic        = DOC_MAGIC;
     d->len          = l;
@@ -1400,7 +1399,7 @@ Lagain:
       return EVENT_CONT;
     }
   }
-  int64_t ntodo       = static_cast<int64_t>(vio.ntodo() + length);
+  int64_t ntodo       = (int64_t)(vio.ntodo() + length);
   int64_t total_avail = vio.buffer.reader()->read_avail();
   int64_t avail       = total_avail;
   int64_t towrite     = avail + length;
@@ -1421,7 +1420,7 @@ Lagain:
     vio.ndone += avail;
     total_len += avail;
   }
-  length = static_cast<uint64_t>(towrite);
+  length = (uint64_t)towrite;
   if (length > target_fragment_size() && (length < target_fragment_size() + target_fragment_size() / 4)) {
     write_len = target_fragment_size();
   } else {
@@ -1469,7 +1468,7 @@ CacheVC::openWriteOverwrite(int event, Event *e)
     if (!io.ok()) {
       goto Ldone;
     }
-    doc = reinterpret_cast<Doc *>(buf->data());
+    doc = (Doc *)buf->data();
     if (!(doc->first_key == first_key)) {
       goto Lcollision;
     }
@@ -1521,7 +1520,7 @@ CacheVC::openWriteStartDone(int event, Event *e)
     }
 
     if (event == AIO_EVENT_DONE) { // vector read done
-      Doc *doc = reinterpret_cast<Doc *>(buf->data());
+      Doc *doc = (Doc *)buf->data();
       if (!io.ok()) {
         err = ECACHE_READ_FAIL;
         goto Lfailure;
@@ -1674,7 +1673,7 @@ Cache::open_write(Continuation *cont, const CacheKey *key, CacheFragType frag_ty
   c->f.overwrite      = (options & CACHE_WRITE_OPT_OVERWRITE) != 0;
   c->f.close_complete = (options & CACHE_WRITE_OPT_CLOSE_COMPLETE) != 0;
   c->f.sync           = (options & CACHE_WRITE_OPT_SYNC) == CACHE_WRITE_OPT_SYNC;
-  c->pin_in_cache     = static_cast<uint32_t>(apin_in_cache);
+  c->pin_in_cache     = (uint32_t)apin_in_cache;
 
   if ((res = c->vol->open_write_lock(c, false, 1)) > 0) {
     // document currently being written, abort
@@ -1774,7 +1773,7 @@ Cache::open_write(Continuation *cont, const CacheKey *key, CacheHTTPInfo *info, 
     c->base_stat = cache_write_active_stat;
   }
   CACHE_INCREMENT_DYN_STAT(c->base_stat + CACHE_STAT_ACTIVE);
-  c->pin_in_cache = static_cast<uint32_t>(apin_in_cache);
+  c->pin_in_cache = (uint32_t)apin_in_cache;
 
   {
     CACHE_TRY_LOCK(lock, c->vol->mutex, cont->mutex->thread_holding);

--- a/iocore/cache/RamCacheCLFUS.cc
+++ b/iocore/cache/RamCacheCLFUS.cc
@@ -169,7 +169,7 @@ RamCacheCLFUS::resize_hashtable()
   int anbuckets = bucket_sizes[ibuckets];
   DDebug("ram_cache", "resize hashtable %d", anbuckets);
   int64_t s                                        = anbuckets * sizeof(DList(RamCacheCLFUSEntry, hash_link));
-  DList(RamCacheCLFUSEntry, hash_link) *new_bucket = static_cast<DList(RamCacheCLFUSEntry, hash_link) *>(ats_malloc(s));
+  DList(RamCacheCLFUSEntry, hash_link) *new_bucket = (DList(RamCacheCLFUSEntry, hash_link) *)ats_malloc(s);
   memset(static_cast<void *>(new_bucket), 0, s);
   if (bucket) {
     for (int64_t i = 0; i < nbuckets; i++) {
@@ -185,7 +185,7 @@ RamCacheCLFUS::resize_hashtable()
   ats_free(seen);
   if (cache_config_ram_cache_use_seen_filter) {
     int size = bucket_sizes[ibuckets] * sizeof(uint16_t);
-    seen     = static_cast<uint16_t *>(ats_malloc(size));
+    seen     = (uint16_t *)ats_malloc(size);
     memset(seen, 0, size);
   }
 }
@@ -250,13 +250,13 @@ RamCacheCLFUS::get(CryptoHash *key, Ptr<IOBufferData> *ret_data, uint32_t auxkey
         e->hits++;
         uint32_t ram_hit_state = RAM_HIT_COMPRESS_NONE;
         if (e->flag_bits.compressed) {
-          b = static_cast<char *>(ats_malloc(e->len));
+          b = (char *)ats_malloc(e->len);
           switch (e->flag_bits.compressed) {
           default:
             goto Lfailed;
           case CACHE_COMPRESSION_FASTLZ: {
-            int l = static_cast<int>(e->len);
-            if ((l != fastlz_decompress(e->data->data(), e->compressed_len, b, l))) {
+            int l = (int)e->len;
+            if ((l != (int)fastlz_decompress(e->data->data(), e->compressed_len, b, l))) {
               goto Lfailed;
             }
             ram_hit_state = RAM_HIT_COMPRESS_FASTLZ;
@@ -265,8 +265,7 @@ RamCacheCLFUS::get(CryptoHash *key, Ptr<IOBufferData> *ret_data, uint32_t auxkey
 #ifdef HAVE_ZLIB_H
           case CACHE_COMPRESSION_LIBZ: {
             uLongf l = e->len;
-            if (Z_OK !=
-                uncompress(reinterpret_cast<Bytef *>(b), &l, reinterpret_cast<Bytef *>(e->data->data()), e->compressed_len)) {
+            if (Z_OK != uncompress((Bytef *)b, &l, (Bytef *)e->data->data(), e->compressed_len)) {
               goto Lfailed;
             }
             ram_hit_state = RAM_HIT_COMPRESS_LIBZ;
@@ -275,10 +274,10 @@ RamCacheCLFUS::get(CryptoHash *key, Ptr<IOBufferData> *ret_data, uint32_t auxkey
 #endif
 #ifdef HAVE_LZMA_H
           case CACHE_COMPRESSION_LIBLZMA: {
-            size_t l = static_cast<size_t>(e->len), ipos = 0, opos = 0;
+            size_t l = (size_t)e->len, ipos = 0, opos = 0;
             uint64_t memlimit = e->len * 2 + LZMA_BASE_MEMLIMIT;
-            if (LZMA_OK != lzma_stream_buffer_decode(&memlimit, 0, nullptr, reinterpret_cast<uint8_t *>(e->data->data()), &ipos,
-                                                     e->compressed_len, reinterpret_cast<uint8_t *>(b), &opos, l)) {
+            if (LZMA_OK != lzma_stream_buffer_decode(&memlimit, 0, nullptr, (uint8_t *)e->data->data(), &ipos, e->compressed_len,
+                                                     (uint8_t *)b, &opos, l)) {
               goto Lfailed;
             }
             ram_hit_state = RAM_HIT_COMPRESS_LIBLZMA;
@@ -289,7 +288,7 @@ RamCacheCLFUS::get(CryptoHash *key, Ptr<IOBufferData> *ret_data, uint32_t auxkey
           IOBufferData *data = new_xmalloc_IOBufferData(b, e->len);
           data->_mem_type    = DEFAULT_ALLOC;
           if (!e->flag_bits.copy) { // don't bother if we have to copy anyway
-            int64_t delta = (static_cast<int64_t>(e->compressed_len)) - static_cast<int64_t>(e->size);
+            int64_t delta = ((int64_t)e->compressed_len) - (int64_t)e->size;
             bytes += delta;
             CACHE_SUM_DYN_STAT_THREAD(cache_ram_cache_bytes_stat, delta);
             e->size = e->compressed_len;
@@ -436,11 +435,11 @@ RamCacheCLFUS::compress_entries(EThread *thread, int do_at_most)
       default:
         goto Lcontinue;
       case CACHE_COMPRESSION_FASTLZ:
-        l = static_cast<uint32_t>(static_cast<double>(e->len) * 1.05 + 66);
+        l = (uint32_t)((double)e->len * 1.05 + 66);
         break;
 #ifdef HAVE_ZLIB_H
       case CACHE_COMPRESSION_LIBZ:
-        l = static_cast<uint32_t>(compressBound(e->len));
+        l = (uint32_t)compressBound(e->len);
         break;
 #endif
 #ifdef HAVE_LZMA_H
@@ -454,7 +453,7 @@ RamCacheCLFUS::compress_entries(EThread *thread, int do_at_most)
       uint32_t elen           = e->len;
       CryptoHash key          = e->key;
       MUTEX_UNTAKE_LOCK(vol->mutex, thread);
-      b           = static_cast<char *>(ats_malloc(l));
+      b           = (char *)ats_malloc(l);
       bool failed = false;
       switch (ctype) {
       default:
@@ -470,22 +469,21 @@ RamCacheCLFUS::compress_entries(EThread *thread, int do_at_most)
 #ifdef HAVE_ZLIB_H
       case CACHE_COMPRESSION_LIBZ: {
         uLongf ll = l;
-        if ((Z_OK != compress(reinterpret_cast<Bytef *>(b), &ll, reinterpret_cast<Bytef *>(edata->data()), elen))) {
+        if ((Z_OK != compress((Bytef *)b, &ll, (Bytef *)edata->data(), elen))) {
           failed = true;
         }
-        l = static_cast<int>(ll);
+        l = (int)ll;
         break;
       }
 #endif
 #ifdef HAVE_LZMA_H
       case CACHE_COMPRESSION_LIBLZMA: {
         size_t pos = 0, ll = l;
-        if (LZMA_OK != lzma_easy_buffer_encode(LZMA_PRESET_DEFAULT, LZMA_CHECK_NONE, nullptr,
-                                               reinterpret_cast<uint8_t *>(edata->data()), elen, reinterpret_cast<uint8_t *>(b),
-                                               &pos, ll)) {
+        if (LZMA_OK != lzma_easy_buffer_encode(LZMA_PRESET_DEFAULT, LZMA_CHECK_NONE, nullptr, (uint8_t *)edata->data(), elen,
+                                               (uint8_t *)b, &pos, ll)) {
           failed = true;
         }
-        l = static_cast<int>(pos);
+        l = (int)pos;
         break;
       }
 #endif
@@ -518,20 +516,20 @@ RamCacheCLFUS::compress_entries(EThread *thread, int do_at_most)
       }
       if (l < e->len) {
         e->flag_bits.compressed = cache_config_ram_cache_compress;
-        bb                      = static_cast<char *>(ats_malloc(l));
+        bb                      = (char *)ats_malloc(l);
         memcpy(bb, b, l);
         ats_free(b);
         e->compressed_len = l;
-        int64_t delta     = (static_cast<int64_t>(l)) - static_cast<int64_t>(e->size);
+        int64_t delta     = ((int64_t)l) - (int64_t)e->size;
         bytes += delta;
         CACHE_SUM_DYN_STAT_THREAD(cache_ram_cache_bytes_stat, delta);
         e->size = l;
       } else {
         ats_free(b);
         e->flag_bits.compressed = 0;
-        bb                      = static_cast<char *>(ats_malloc(e->len));
+        bb                      = (char *)ats_malloc(e->len);
         memcpy(bb, e->data->data(), e->len);
-        int64_t delta = (static_cast<int64_t>(e->len)) - static_cast<int64_t>(e->size);
+        int64_t delta = ((int64_t)e->len) - (int64_t)e->size;
         bytes += delta;
         CACHE_SUM_DYN_STAT_THREAD(cache_ram_cache_bytes_stat, delta);
         e->size = e->len;
@@ -596,14 +594,14 @@ RamCacheCLFUS::put(CryptoHash *key, IOBufferData *data, uint32_t len, bool copy,
       move_compressed(e);
       lru[e->flag_bits.lru].remove(e);
       lru[e->flag_bits.lru].enqueue(e);
-      int64_t delta = (static_cast<int64_t>(size)) - static_cast<int64_t>(e->size);
+      int64_t delta = ((int64_t)size) - (int64_t)e->size;
       bytes += delta;
       CACHE_SUM_DYN_STAT_THREAD(cache_ram_cache_bytes_stat, delta);
       if (!copy) {
         e->size = size;
         e->data = data;
       } else {
-        char *b = static_cast<char *>(ats_malloc(len));
+        char *b = (char *)ats_malloc(len);
         memcpy(b, data->data(), len);
         e->data            = new_xmalloc_IOBufferData(b, len);
         e->data->_mem_type = DEFAULT_ALLOC;
@@ -713,7 +711,7 @@ Linsert:
   if (!copy) {
     e->data = data;
   } else {
-    char *b = static_cast<char *>(ats_malloc(len));
+    char *b = (char *)ats_malloc(len);
     memcpy(b, data->data(), len);
     e->data            = new_xmalloc_IOBufferData(b, len);
     e->data->_mem_type = DEFAULT_ALLOC;

--- a/iocore/cache/RamCacheLRU.cc
+++ b/iocore/cache/RamCacheLRU.cc
@@ -85,7 +85,7 @@ RamCacheLRU::resize_hashtable()
   int anbuckets = bucket_sizes[ibuckets];
   DDebug("ram_cache", "resize hashtable %d", anbuckets);
   int64_t s                                      = anbuckets * sizeof(DList(RamCacheLRUEntry, hash_link));
-  DList(RamCacheLRUEntry, hash_link) *new_bucket = static_cast<DList(RamCacheLRUEntry, hash_link) *>(ats_malloc(s));
+  DList(RamCacheLRUEntry, hash_link) *new_bucket = (DList(RamCacheLRUEntry, hash_link) *)ats_malloc(s);
   memset(static_cast<void *>(new_bucket), 0, s);
   if (bucket) {
     for (int64_t i = 0; i < nbuckets; i++) {
@@ -101,7 +101,7 @@ RamCacheLRU::resize_hashtable()
   ats_free(seen);
   int size = bucket_sizes[ibuckets] * sizeof(uint16_t);
   if (cache_config_ram_cache_use_seen_filter) {
-    seen = static_cast<uint16_t *>(ats_malloc(size));
+    seen = (uint16_t *)ats_malloc(size);
     memset(seen, 0, size);
   }
 }
@@ -170,7 +170,7 @@ RamCacheLRU::put(CryptoHash *key, IOBufferData *data, uint32_t len, bool, uint32
     uint16_t k  = key->slice32(3) >> 16;
     uint16_t kk = seen[i];
     seen[i]     = k;
-    if ((kk != k)) {
+    if ((kk != (uint16_t)k)) {
       DDebug("ram_cache", "put %X %d %d len %d UNSEEN", key->slice32(3), auxkey1, auxkey2, len);
       return 0;
     }

--- a/iocore/cache/Store.cc
+++ b/iocore/cache/Store.cc
@@ -120,7 +120,7 @@ Store::free(Store &s)
 void
 Store::sort()
 {
-  Span **vec = static_cast<Span **>(alloca(sizeof(Span *) * n_disks));
+  Span **vec = (Span **)alloca(sizeof(Span *) * n_disks);
   memset(vec, 0, sizeof(Span *) * n_disks);
   for (unsigned i = 0; i < n_disks; i++) {
     vec[i]  = disk[i];
@@ -225,7 +225,7 @@ Span::path(char *filename, int64_t *aoffset, char *buf, int buflen)
   ink_assert(!aoffset);
   Span *ds = this;
 
-  if ((strlen(ds->pathname) + strlen(filename) + 2) > static_cast<size_t>(buflen)) {
+  if ((strlen(ds->pathname) + strlen(filename) + 2) > (size_t)buflen) {
     return -1;
   }
   if (!ds->file_pathname) {
@@ -452,7 +452,7 @@ Store::write_config_data(int fd) const
   for (unsigned i = 0; i < n_disks; i++) {
     for (Span *sd = disk[i]; sd; sd = sd->link.next) {
       char buf[PATH_NAME_MAX + 64];
-      snprintf(buf, sizeof(buf), "%s %" PRId64 "\n", sd->pathname.get(), sd->blocks * static_cast<int64_t>(STORE_BLOCK_SIZE));
+      snprintf(buf, sizeof(buf), "%s %" PRId64 "\n", sd->pathname.get(), (int64_t)sd->blocks * (int64_t)STORE_BLOCK_SIZE);
       if (ink_file_fd_writestring(fd, buf) == -1) {
         return (-1);
       }
@@ -537,7 +537,7 @@ Span::init(const char *path, int64_t size)
     break;
 
   case S_IFDIR:
-    if (static_cast<int64_t>(vbuf.f_frsize * vbuf.f_bavail) < size) {
+    if ((int64_t)(vbuf.f_frsize * vbuf.f_bavail) < size) {
       Warning("not enough free space for cache %s '%s'", span_file_typename(sbuf.st_mode), path);
       // Just warn for now; let the cache open fail later.
     }
@@ -556,7 +556,7 @@ Span::init(const char *path, int64_t size)
   case S_IFREG:
     if (size > 0 && sbuf.st_size < size) {
       int64_t needed = size - sbuf.st_size;
-      if (static_cast<int64_t>(vbuf.f_frsize * vbuf.f_bavail) < needed) {
+      if ((int64_t)(vbuf.f_frsize * vbuf.f_bavail) < needed) {
         Warning("not enough free space for cache %s '%s'", span_file_typename(sbuf.st_mode), path);
         // Just warn for now; let the cache open fail later.
       }
@@ -587,7 +587,7 @@ Span::init(const char *path, int64_t size)
   }
 
   // A directory span means we will end up with a file, otherwise, we get what we asked for.
-  this->set_mmapable(ink_file_is_mmappable(S_ISDIR(sbuf.st_mode) ? static_cast<mode_t>(S_IFREG) : sbuf.st_mode));
+  this->set_mmapable(ink_file_is_mmappable(S_ISDIR(sbuf.st_mode) ? (mode_t)S_IFREG : sbuf.st_mode));
   this->pathname = ats_strdup(path);
 
   Debug("cache_init", "initialized span '%s'", this->pathname.get());
@@ -781,7 +781,7 @@ Span::write(int fd) const
     return (-1);
   }
 
-  snprintf(buf, sizeof(buf), "%d\n", static_cast<int>(is_mmapable()));
+  snprintf(buf, sizeof(buf), "%d\n", (int)is_mmapable());
   if (ink_file_fd_writestring(fd, buf) == -1) {
     return (-1);
   }
@@ -907,7 +907,7 @@ Store::read(int fd, char *aname)
     return (-1);
   }
 
-  disk = static_cast<Span **>(ats_malloc(sizeof(Span *) * n_disks));
+  disk = (Span **)ats_malloc(sizeof(Span *) * n_disks);
   if (!disk) {
     return -1;
   }
@@ -964,7 +964,7 @@ void
 Store::dup(Store &s)
 {
   s.n_disks = n_disks;
-  s.disk    = static_cast<Span **>(ats_malloc(sizeof(Span *) * n_disks));
+  s.disk    = (Span **)ats_malloc(sizeof(Span *) * n_disks);
   for (unsigned i = 0; i < n_disks; i++) {
     s.disk[i] = disk[i]->dup();
   }

--- a/iocore/cache/test/main.cc
+++ b/iocore/cache/test/main.cc
@@ -33,7 +33,7 @@ test_done()
   TSSystemState::shut_down_event_system();
 }
 
-const char *GLOBAL_DATA = static_cast<char *>(ats_malloc(10 * 1024 * 1024 + 3)); // 10M
+const char *GLOBAL_DATA = (char *)ats_malloc(10 * 1024 * 1024 + 3); // 10M
 
 struct EventProcessorListener : Catch::TestEventListenerBase {
   using TestEventListenerBase::TestEventListenerBase; // inherit constructor
@@ -166,7 +166,7 @@ CacheWriteTest::write_event(int event, void *e)
 {
   switch (event) {
   case CACHE_EVENT_OPEN_WRITE:
-    this->vc = static_cast<CacheVC *>(e);
+    this->vc = (CacheVC *)e;
     /* fall through */
   case CACHE_EVENT_OPEN_WRITE_FAILED:
     this->process_event(event);
@@ -219,7 +219,7 @@ CacheReadTest::read_event(int event, void *e)
 {
   switch (event) {
   case CACHE_EVENT_OPEN_READ:
-    this->vc = static_cast<CacheVC *>(e);
+    this->vc = (CacheVC *)e;
     /* fall through */
   case CACHE_EVENT_OPEN_READ_FAILED:
     this->process_event(event);

--- a/iocore/cache/test/stub.cc
+++ b/iocore/cache/test/stub.cc
@@ -240,7 +240,7 @@ INKVConnInternal::retry(unsigned int delay)
 {
 }
 
-INKContInternal::INKContInternal(TSEventFunc funcp, TSMutex mutexp) : DummyVConnection(reinterpret_cast<ProxyMutex *>(mutexp)) {}
+INKContInternal::INKContInternal(TSEventFunc funcp, TSMutex mutexp) : DummyVConnection((ProxyMutex *)mutexp) {}
 
 INKContInternal::INKContInternal() : DummyVConnection(nullptr) {}
 

--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -292,7 +292,7 @@ DNSProcessor::dns_init()
     int i;
     char *last;
     char *ns_list = ats_strdup(dns_ns_list);
-    char *ns      = strtok_r(ns_list, " ,;\t\r", &last);
+    char *ns      = (char *)strtok_r(ns_list, " ,;\t\r", &last);
 
     for (i = 0, nserv = 0; (i < MAX_NAMED) && ns; ++i) {
       Debug("dns", "Nameserver list - parsing \"%s\"", ns);
@@ -339,7 +339,7 @@ DNSProcessor::dns_init()
         ++nserv;
       }
 
-      ns = strtok_r(nullptr, " ,;\t\r", &last);
+      ns = (char *)strtok_r(nullptr, " ,;\t\r", &last);
     }
     ats_free(ns_list);
   }
@@ -383,8 +383,7 @@ DNSProcessor::dns_init()
 inline int
 ink_dn_expand(const u_char *msg, const u_char *eom, const u_char *comp_dn, u_char *exp_dn, int length)
 {
-  return ::dn_expand(const_cast<unsigned char *>(msg), const_cast<unsigned char *>(eom), const_cast<unsigned char *>(comp_dn),
-                     reinterpret_cast<char *>(exp_dn), length);
+  return ::dn_expand((unsigned char *)msg, (unsigned char *)eom, (unsigned char *)comp_dn, (char *)exp_dn, length);
 }
 
 DNSProcessor::DNSProcessor()
@@ -1053,7 +1052,7 @@ uint16_t
 DNSHandler::get_query_id()
 {
   uint16_t q1, q2;
-  q2 = q1 = static_cast<uint16_t>(generator.random() & 0xFFFF);
+  q2 = q1 = (uint16_t)(generator.random() & 0xFFFF);
   if (query_id_in_use(q2)) {
     uint16_t i = q2 >> 6;
     while (qid_in_flight[i] == UINT64_MAX) {
@@ -1094,7 +1093,7 @@ write_dns_event(DNSHandler *h, DNSEntry *e, bool over_tcp)
   ProxyMutex *mutex = h->mutex.get();
   unsigned char buffer[MAX_DNS_PACKET_LEN];
   int offset     = over_tcp ? tcp_data_length_offset : 0;
-  HEADER *header = reinterpret_cast<HEADER *>(buffer + offset);
+  HEADER *header = (HEADER *)(buffer + offset);
   int r          = 0;
 
   if ((r = _ink_res_mkquery(h->m_res, e->qname, e->qtype, buffer, over_tcp)) <= 0) {
@@ -1432,8 +1431,8 @@ static bool
 dns_process(DNSHandler *handler, HostEnt *buf, int len)
 {
   ProxyMutex *mutex = handler->mutex.get();
-  HEADER *h         = reinterpret_cast<HEADER *>(buf->buf);
-  DNSEntry *e       = get_dns(handler, static_cast<uint16_t>(ntohs(h->id)));
+  HEADER *h         = (HEADER *)(buf->buf);
+  DNSEntry *e       = get_dns(handler, (uint16_t)ntohs(h->id));
   bool retry        = false;
   bool tcp_retry    = false;
   bool server_ok    = true;
@@ -1500,8 +1499,8 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
     int ancount       = ntohs(h->ancount);
     unsigned char *bp = buf->hostbuf;
     int buflen        = sizeof(buf->hostbuf);
-    u_char *cp        = (reinterpret_cast<u_char *>(h)) + HFIXEDSZ;
-    u_char *eom       = reinterpret_cast<u_char *>(h) + len;
+    u_char *cp        = ((u_char *)h) + HFIXEDSZ;
+    u_char *eom       = (u_char *)h + len;
     int n;
     ink_assert(buf->srv_hosts.hosts.size() == 0 && buf->srv_hosts.srv_hosts_length == 0);
     buf->srv_hosts.hosts.clear();
@@ -1512,14 +1511,14 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
     //
     // Expand name
     //
-    if ((n = ink_dn_expand(reinterpret_cast<u_char *>(h), eom, cp, bp, buflen)) < 0) {
+    if ((n = ink_dn_expand((u_char *)h, eom, cp, bp, buflen)) < 0) {
       goto Lerror;
     }
 
     // Should we validate the query name?
     if (dns_validate_qname) {
       int qlen = e->qname_len;
-      int rlen = strlen(reinterpret_cast<char *>(bp));
+      int rlen = strlen((char *)bp);
 
       rname_len = rlen; // Save for later use
       if ((qlen > 0) && ('.' == e->qname[qlen - 1])) {
@@ -1531,7 +1530,7 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
       // TODO: At some point, we might want to care about the case here, and use an algorithm
       // to randomly pick upper case characters in the query, and validate the response with
       // case sensitivity.
-      if ((qlen != rlen) || (strncasecmp(e->qname, reinterpret_cast<const char *>(bp), qlen) != 0)) {
+      if ((qlen != rlen) || (strncasecmp(e->qname, (const char *)bp, qlen) != 0)) {
         // Bad mojo, forged?
         Warning("received DNS response with query name of '%s', but response query name is '%s'", e->qname, bp);
         goto Lerror;
@@ -1543,11 +1542,11 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
     cp += n + QFIXEDSZ;
     if (is_addr_query(e->qtype)) {
       if (-1 == rname_len) {
-        n = strlen(reinterpret_cast<char *>(bp)) + 1;
+        n = strlen((char *)bp) + 1;
       } else {
         n = rname_len + 1;
       }
-      buf->ent.h_name = reinterpret_cast<char *>(bp);
+      buf->ent.h_name = (char *)bp;
       bp += n;
       buflen -= n;
     }
@@ -1555,10 +1554,10 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
     // Configure HostEnt data structure
     //
     u_char **ap          = buf->host_aliases;
-    buf->ent.h_aliases   = reinterpret_cast<char **>(buf->host_aliases);
+    buf->ent.h_aliases   = (char **)buf->host_aliases;
     u_char **hap         = (u_char **)buf->h_addr_ptrs;
     *hap                 = nullptr;
-    buf->ent.h_addr_list = reinterpret_cast<char **>(buf->h_addr_ptrs);
+    buf->ent.h_addr_list = (char **)buf->h_addr_ptrs;
 
     //
     // INKqa10938: For customer (i.e. USPS) with closed environment, need to
@@ -1587,7 +1586,7 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
     /* added for SRV support [ebalsa]
        this skips the query section (qdcount)
      */
-    unsigned char *here = reinterpret_cast<unsigned char *>(buf->buf) + HFIXEDSZ;
+    unsigned char *here = (unsigned char *)buf->buf + HFIXEDSZ;
     if (e->qtype == T_SRV) {
       for (int ctr = ntohs(h->qdcount); ctr > 0; ctr--) {
         int strlen = dn_skipname(here, eom);
@@ -1600,7 +1599,7 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
     int answer = false, error = false;
 
     while (ancount-- > 0 && cp < eom && !error) {
-      n = ink_dn_expand(reinterpret_cast<u_char *>(h), eom, cp, bp, buflen);
+      n = ink_dn_expand((u_char *)h, eom, cp, bp, buflen);
       if (n < 0) {
         ++error;
         break;
@@ -1622,22 +1621,22 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
         if (ap >= &buf->host_aliases[DNS_MAX_ALIASES - 1]) {
           continue;
         }
-        n = ink_dn_expand(reinterpret_cast<u_char *>(h), eom, cp, tbuf, sizeof(tbuf));
+        n = ink_dn_expand((u_char *)h, eom, cp, tbuf, sizeof(tbuf));
         if (n < 0) {
           ++error;
           break;
         }
         cp += n;
-        *ap++ = bp;
-        n     = strlen(reinterpret_cast<char *>(bp)) + 1;
+        *ap++ = (unsigned char *)bp;
+        n     = strlen((char *)bp) + 1;
         bp += n;
         buflen -= n;
-        n = strlen(reinterpret_cast<char *>(tbuf)) + 1;
+        n = strlen((char *)tbuf) + 1;
         if (n > buflen) {
           ++error;
           break;
         }
-        ink_strlcpy(reinterpret_cast<char *>(bp), reinterpret_cast<char *>(tbuf), buflen);
+        ink_strlcpy((char *)bp, (char *)tbuf, buflen);
         bp += n;
         buflen -= n;
         if (is_debug_tag_set("dns")) {
@@ -1660,22 +1659,22 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
       // Decode names
       //
       if (type == T_PTR) {
-        n = ink_dn_expand(reinterpret_cast<u_char *>(h), eom, cp, bp, buflen);
+        n = ink_dn_expand((u_char *)h, eom, cp, bp, buflen);
         if (n < 0) {
           ++error;
           break;
         }
         cp += n;
         if (!answer) {
-          buf->ent.h_name = reinterpret_cast<char *>(bp);
+          buf->ent.h_name = (char *)bp;
           Debug("dns", "received PTR name = %s", bp);
-          n = strlen(reinterpret_cast<char *>(bp)) + 1;
+          n = strlen((char *)bp) + 1;
           bp += n;
           buflen -= n;
         } else if (ap < &buf->host_aliases[DNS_MAX_ALIASES - 1]) {
           *ap++ = bp;
           Debug("dns", "received PTR alias = %s", bp);
-          n = strlen(reinterpret_cast<char *>(bp)) + 1;
+          n = strlen((char *)bp) + 1;
           bp += n;
           buflen -= n;
         }
@@ -1694,7 +1693,7 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
         SRV srv;
 
         // expand the name
-        n = ink_dn_expand(reinterpret_cast<u_char *>(h), eom, srv_off + SRV_SERVER, reinterpret_cast<u_char *>(srv.host), MAXDNAME);
+        n = ink_dn_expand((u_char *)h, eom, srv_off + SRV_SERVER, (u_char *)srv.host, MAXDNAME);
         if (n < 0) {
           ++error;
           break;
@@ -1724,8 +1723,8 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
           int nn;
           buf->ent.h_length   = n;
           buf->ent.h_addrtype = T_A == type ? AF_INET : AF_INET6;
-          buf->ent.h_name     = reinterpret_cast<char *>(bp);
-          nn                  = strlen(reinterpret_cast<char *>(bp)) + 1;
+          buf->ent.h_name     = (char *)bp;
+          nn                  = strlen((char *)bp) + 1;
           Debug("dns", "received %s name = %s", QtypeName(type), bp);
           bp += nn;
           buflen -= nn;
@@ -1736,7 +1735,7 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
           cp += n;
         } else {
           ip_text_buffer ip_string;
-          bp = static_cast<unsigned char *>(align_pointer_forward(bp, sizeof(int)));
+          bp = (unsigned char *)align_pointer_forward(bp, sizeof(int));
           if (bp + n >= buf->hostbuf + DNS_HOSTBUF_SIZE) {
             ++error;
             break;
@@ -1761,8 +1760,8 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
       //
       if (!buf->ent.h_name) {
         Debug("dns", "inserting name = %s", e->qname);
-        ink_strlcpy(reinterpret_cast<char *>(bp), e->qname, sizeof(buf->hostbuf) - (bp - buf->hostbuf));
-        buf->ent.h_name = reinterpret_cast<char *>(bp);
+        ink_strlcpy((char *)bp, e->qname, sizeof(buf->hostbuf) - (bp - buf->hostbuf));
+        buf->ent.h_name = (char *)bp;
       }
       Debug("dns", "Returning %d DNS records for [%s]", answer, e->qname);
       dns_result(handler, e, buf, retry);
@@ -1793,7 +1792,7 @@ ink_dns_init(ts::ModuleVersion v)
   init_called = 1;
   // do one time stuff
   // create a stat block for HostDBStats
-  dns_rsb = RecAllocateRawStatBlock(static_cast<int>(DNS_Stat_Count));
+  dns_rsb = RecAllocateRawStatBlock((int)DNS_Stat_Count);
 
   //
   // Register statistics callbacks
@@ -1848,7 +1847,7 @@ struct DNSRegressionContinuation : public Continuation {
       if (he) {
         struct in_addr in;
         ++found;
-        in.s_addr = *reinterpret_cast<unsigned int *>(he->ent.h_addr_list[0]);
+        in.s_addr = *(unsigned int *)he->ent.h_addr_list[0];
         rprintf(test, "host %s [%s] = %s\n", hostnames[i - 1], he->ent.h_name, inet_ntoa(in));
       } else {
         rprintf(test, "host %s not found\n", hostnames[i - 1]);

--- a/iocore/dns/DNSConnection.cc
+++ b/iocore/dns/DNSConnection.cc
@@ -48,8 +48,7 @@ DNSConnection::Options const DNSConnection::DEFAULT_OPTIONS;
 // Functions
 //
 
-DNSConnection::DNSConnection()
-  : fd(NO_FD), generator(static_cast<uint32_t>(static_cast<uintptr_t>(time(nullptr)) ^ (uintptr_t)this))
+DNSConnection::DNSConnection() : fd(NO_FD), generator((uint32_t)((uintptr_t)time(nullptr) ^ (uintptr_t)this))
 {
   memset(&ip, 0, sizeof(ip));
 }

--- a/iocore/dns/SplitDNS.cc
+++ b/iocore/dns/SplitDNS.cc
@@ -226,14 +226,14 @@ SplitDNS::findServer(RequestData *rdata, SplitDNSResult *result)
      --------------------------- */
   if (m_bEnableFastPath) {
     SplitDNSRecord *data_ptr = nullptr;
-    char *pHost              = const_cast<char *>(rdata->get_host());
+    char *pHost              = (char *)rdata->get_host();
     if (nullptr == pHost) {
       Warning("SplitDNS: No host to match !");
       return;
     }
 
     int len        = strlen(pHost);
-    HostLeaf *pxHL = static_cast<HostLeaf *>(m_pxLeafArray);
+    HostLeaf *pxHL = (HostLeaf *)m_pxLeafArray;
     for (int i = 0; i < m_numEle; i++) {
       if (nullptr == pxHL) {
         break;
@@ -316,7 +316,7 @@ SplitDNSRecord::ProcessDNSHosts(char *val)
      ------------------------------------------------ */
   for (int i = 0; i < numTok; i++) {
     const char *current = pTok[i];
-    char *tmp           = const_cast<char *>(strchr(current, ':'));
+    char *tmp           = (char *)strchr(current, ':');
     // coverity[secure_coding]
     if (tmp != nullptr && sscanf(tmp + 1, "%d", &port) != 1) {
       return "Malformed DNS port";

--- a/iocore/eventsystem/IOBuffer.cc
+++ b/iocore/eventsystem/IOBuffer.cc
@@ -47,7 +47,7 @@ void
 init_buffer_allocators(int iobuffer_advice)
 {
   for (int i = 0; i < DEFAULT_BUFFER_SIZES; i++) {
-    int64_t s = DEFAULT_BUFFER_BASE_SIZE * ((static_cast<int64_t>(1)) << i);
+    int64_t s = DEFAULT_BUFFER_BASE_SIZE * (((int64_t)1) << i);
     int64_t a = DEFAULT_BUFFER_ALIGNMENT;
     int n     = i <= default_large_iobuffer_size ? DEFAULT_BUFFER_NUMBER : DEFAULT_HUGE_BUFFER_NUMBER;
     if (s < a) {
@@ -83,7 +83,7 @@ MIOBuffer::remove_append(IOBufferReader *r)
 int64_t
 MIOBuffer::write(const void *abuf, int64_t alen)
 {
-  const char *buf = static_cast<const char *>(abuf);
+  const char *buf = (const char *)abuf;
   int64_t len     = alen;
   while (len) {
     if (!_writer) {
@@ -186,7 +186,7 @@ MIOBuffer::puts(char *s, int64_t len)
       return -1;
     }
     if (!*pb || *pb == '\n') {
-      int64_t n = static_cast<int64_t>(pb - s);
+      int64_t n = (int64_t)(pb - s);
       memcpy(end(), s, n + 1); // Up to and including '\n'
       end()[n + 1] = 0;
       fill(n + 1);
@@ -201,7 +201,7 @@ MIOBuffer::puts(char *s, int64_t len)
 int64_t
 IOBufferReader::read(void *ab, int64_t len)
 {
-  char *b       = static_cast<char *>(ab);
+  char *b       = (char *)ab;
   int64_t n     = len;
   int64_t l     = block_read_avail();
   int64_t bytes = 0;
@@ -243,9 +243,9 @@ IOBufferReader::memchr(char c, int64_t len, int64_t offset)
       bytes = len;
     }
     char *s = b->start() + offset;
-    char *p = static_cast<char *>(::memchr(s, c, bytes));
+    char *p = (char *)::memchr(s, c, bytes);
     if (p) {
-      return static_cast<int64_t>(o - start_offset + p - s);
+      return (int64_t)(o - start_offset + p - s);
     }
     o += bytes;
     len -= bytes;

--- a/iocore/eventsystem/PQ-List.cc
+++ b/iocore/eventsystem/PQ-List.cc
@@ -33,7 +33,7 @@ void
 PriorityEventQueue::check_ready(ink_hrtime now, EThread *t)
 {
   int i, j, k = 0;
-  uint32_t check_buckets = static_cast<uint32_t>(now / PQ_BUCKET_TIME(0));
+  uint32_t check_buckets = (uint32_t)(now / PQ_BUCKET_TIME(0));
   uint32_t todo_buckets  = check_buckets ^ last_check_buckets;
   last_check_time        = now;
   last_check_buckets     = check_buckets;

--- a/iocore/eventsystem/ProxyAllocator.cc
+++ b/iocore/eventsystem/ProxyAllocator.cc
@@ -30,8 +30,8 @@ void *
 thread_alloc(Allocator &a, ProxyAllocator &l)
 {
   if (!cmd_disable_pfreelist && l.freelist) {
-    void *v    = l.freelist;
-    l.freelist = *static_cast<void **>(l.freelist);
+    void *v    = (void *)l.freelist;
+    l.freelist = *(void **)l.freelist;
     --(l.allocated);
     return v;
   }
@@ -41,12 +41,12 @@ thread_alloc(Allocator &a, ProxyAllocator &l)
 void
 thread_freeup(Allocator &a, ProxyAllocator &l)
 {
-  void *head   = l.freelist;
-  void *tail   = l.freelist;
+  void *head   = (void *)l.freelist;
+  void *tail   = (void *)l.freelist;
   size_t count = 0;
   while (l.freelist && l.allocated > thread_freelist_low_watermark) {
     tail       = l.freelist;
-    l.freelist = *static_cast<void **>(l.freelist);
+    l.freelist = *(void **)l.freelist;
     --(l.allocated);
     ++count;
   }

--- a/iocore/eventsystem/UnixEThread.cc
+++ b/iocore/eventsystem/UnixEThread.cc
@@ -56,7 +56,7 @@ EThread::EThread()
 
 EThread::EThread(ThreadType att, int anid) : id(anid), tt(att)
 {
-  ethreads_to_be_signalled = static_cast<EThread **>(ats_malloc(MAX_EVENT_THREADS * sizeof(EThread *)));
+  ethreads_to_be_signalled = (EThread **)ats_malloc(MAX_EVENT_THREADS * sizeof(EThread *));
   memset(ethreads_to_be_signalled, 0, MAX_EVENT_THREADS * sizeof(EThread *));
   memset(thread_private, 0, PER_THREAD_DATA);
 #if HAVE_EVENTFD

--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -78,7 +78,7 @@ HostDBInfo::srvname(HostDBRoundRobin *rr) const
   if (!is_srv || !data.srv.srv_offset) {
     return nullptr;
   }
-  return reinterpret_cast<char *>(rr) + data.srv.srv_offset;
+  return (char *)rr + data.srv.srv_offset;
 }
 
 static inline bool
@@ -968,7 +968,7 @@ remove_round_robin(HostDBInfo *r, const char *hostname, IpAddr const &ip)
         } else {
           if (is_debug_tag_set("hostdb")) {
             int bufsize      = rr->good * INET6_ADDRSTRLEN;
-            char *rr_ip_list = static_cast<char *>(alloca(bufsize));
+            char *rr_ip_list = (char *)alloca(bufsize);
             char *p          = rr_ip_list;
             for (int n = 0; n < rr->good; ++n) {
               ats_ip_ntop(rr->info(n).ip(), p, bufsize);
@@ -1237,7 +1237,7 @@ HostDBContinuation::dnsEvent(int event, HostEnt *e)
       } else {
         void *ptr; // tmp for current entry.
         for (int total_records = 0;
-             total_records < static_cast<int>(hostdb_round_robin_max_count) && nullptr != (ptr = e->ent.h_addr_list[total_records]);
+             total_records < (int)hostdb_round_robin_max_count && nullptr != (ptr = e->ent.h_addr_list[total_records]);
              ++total_records) {
           if (is_addr_valid(af, ptr)) {
             if (!first_record) {
@@ -1319,7 +1319,7 @@ HostDBContinuation::dnsEvent(int event, HostEnt *e)
       ;
       if (is_srv()) {
         int skip  = 0;
-        char *pos = reinterpret_cast<char *>(rr_data) + sizeof(HostDBRoundRobin) + valid_records * sizeof(HostDBInfo);
+        char *pos = (char *)rr_data + sizeof(HostDBRoundRobin) + valid_records * sizeof(HostDBInfo);
         SRV *q[valid_records];
         ink_assert(valid_records <= (int)hostdb_round_robin_max_count);
         // sort
@@ -1353,7 +1353,7 @@ HostDBContinuation::dnsEvent(int event, HostEnt *e)
           ink_assert((skip + t->host_len) <= e->srv_hosts.srv_hosts_length);
 
           memcpy(pos + skip, t->host, t->host_len);
-          item.data.srv.srv_offset = (pos - reinterpret_cast<char *>(rr_data)) + skip;
+          item.data.srv.srv_offset = (pos - (char *)rr_data) + skip;
 
           skip += t->host_len;
 
@@ -1715,7 +1715,7 @@ HostDBContinuation::backgroundEvent(int /* event ATS_UNUSED */, Event * /* e ATS
       hostdb_last_interval = hostdb_current_interval;
       if (*hostdb_hostfile_path) {
         if (0 == stat(hostdb_hostfile_path, &info)) {
-          if (info.st_mtime > static_cast<time_t>(hostdb_hostfile_update_timestamp)) {
+          if (info.st_mtime > (time_t)hostdb_hostfile_update_timestamp) {
             update_p = true; // same file but it's changed.
           }
         } else {
@@ -1762,7 +1762,7 @@ HostDBInfo::rr()
     return nullptr;
   }
 
-  return reinterpret_cast<HostDBRoundRobin *>(reinterpret_cast<char *>(this) + this->app.rr.offset);
+  return (HostDBRoundRobin *)((char *)this + this->app.rr.offset);
 }
 
 struct ShowHostDB;
@@ -2013,7 +2013,7 @@ register_ShowHostDB(Continuation *c, HTTPHdr *h)
     s->sarg           = ats_strndup(query, query_len);
     char *gn          = nullptr;
     if (s->sarg) {
-      gn = static_cast<char *>(memchr(s->sarg, '=', strlen(s->sarg)));
+      gn = (char *)memchr(s->sarg, '=', strlen(s->sarg));
     }
     if (gn) {
       ats_ip_pton(gn + 1, &s->ip); // hope that's null terminated.
@@ -2026,7 +2026,7 @@ register_ShowHostDB(Continuation *c, HTTPHdr *h)
     s->sarg           = ats_strndup(query, query_len);
     char *gn          = nullptr;
     if (s->sarg) {
-      gn = static_cast<char *>(memchr(s->sarg, '=', strlen(s->sarg)));
+      gn = (char *)memchr(s->sarg, '=', strlen(s->sarg));
     }
     if (gn) {
       s->name   = gn + 1;
@@ -2123,7 +2123,7 @@ ink_hostdb_init(ts::ModuleVersion v)
   init_called = 1;
   // do one time stuff
   // create a stat block for HostDBStats
-  hostdb_rsb = RecAllocateRawStatBlock(static_cast<int>(HostDB_Stat_Count));
+  hostdb_rsb = RecAllocateRawStatBlock((int)HostDB_Stat_Count);
 
   //
   // Register stats

--- a/iocore/hostdb/test_RefCountCache.cc
+++ b/iocore/hostdb/test_RefCountCache.cc
@@ -41,7 +41,7 @@ public:
   char *
   name()
   {
-    return reinterpret_cast<char *>(this) + this->name_offset;
+    return (char *)this + this->name_offset;
   }
 
   static ExampleStruct *
@@ -92,7 +92,7 @@ fillCache(RefCountCache<ExampleStruct> *cache, int start, int end)
 
   for (int i = start; i < end; i++) {
     ExampleStruct *tmp = ExampleStruct::alloc(allocSize);
-    cache->put(static_cast<uint64_t>(i), tmp);
+    cache->put((uint64_t)i, tmp);
 
     tmp->idx         = i;
     tmp->name_offset = sizeof(ExampleStruct);
@@ -155,17 +155,17 @@ testRefcounting()
   ExampleStruct *tmp = ExampleStruct::alloc();
   ret |= tmp->refcount() != 0;
   printf("ret=%d ref=%d\n", ret, tmp->refcount());
-  cache->put(static_cast<uint64_t>(1), tmp);
+  cache->put((uint64_t)1, tmp);
   ret |= tmp->refcount() != 1;
   printf("ret=%d ref=%d\n", ret, tmp->refcount());
   tmp->idx = 1;
 
   // Grab a pointer to item 1
-  Ptr<ExampleStruct> ccitem = cache->get(static_cast<uint64_t>(1));
+  Ptr<ExampleStruct> ccitem = cache->get((uint64_t)1);
   ret |= tmp->refcount() != 2;
   printf("ret=%d ref=%d\n", ret, tmp->refcount());
 
-  Ptr<ExampleStruct> tmpAfter = cache->get(static_cast<uint64_t>(1));
+  Ptr<ExampleStruct> tmpAfter = cache->get((uint64_t)1);
   ret |= tmp->refcount() != 3;
   printf("ret=%d ref=%d\n", ret, tmp->refcount());
 
@@ -252,17 +252,17 @@ test()
   // Verify that we can alloc() with no extra space
   printf("Alloc item idx 1\n");
   ExampleStruct *tmp = ExampleStruct::alloc();
-  cache->put(static_cast<uint64_t>(1), tmp);
+  cache->put((uint64_t)1, tmp);
   tmp->idx = 1;
 
-  Ptr<ExampleStruct> tmpAfter = cache->get(static_cast<uint64_t>(1));
+  Ptr<ExampleStruct> tmpAfter = cache->get((uint64_t)1);
   printf("Item after (ret=%d) %d %d\n", ret, 1, tmpAfter->idx);
   // Verify every item in the cache
   ret |= verifyCache(cache, 0, numTestEntries);
   printf("verified entire cache ret=%d\n", ret);
 
   // Grab a pointer to item 1
-  Ptr<ExampleStruct> ccitem = cache->get(static_cast<uint64_t>(1));
+  Ptr<ExampleStruct> ccitem = cache->get((uint64_t)1);
   ccitem->idx               = 1;
   // Delete a single item
   cache->erase(1);

--- a/iocore/net/Connection.cc
+++ b/iocore/net/Connection.cc
@@ -200,7 +200,7 @@ Server::setup_fd_for_listen(bool non_blocking, const NetProcessor::AcceptOptions
     l.l_onoff  = 0;
     l.l_linger = 0;
     if ((opt.sockopt_flags & NetVCOptions::SOCK_OPT_LINGER_ON) &&
-        (res = safe_setsockopt(fd, SOL_SOCKET, SO_LINGER, reinterpret_cast<char *>(&l), sizeof(l))) < 0) {
+        (res = safe_setsockopt(fd, SOL_SOCKET, SO_LINGER, (char *)&l, sizeof(l))) < 0) {
       goto Lerror;
     }
   }
@@ -248,8 +248,7 @@ Server::setup_fd_for_listen(bool non_blocking, const NetProcessor::AcceptOptions
 
 #if defined(TCP_MAXSEG)
   if (NetProcessor::accept_mss > 0) {
-    if ((res = safe_setsockopt(fd, IPPROTO_TCP, TCP_MAXSEG, reinterpret_cast<char *>(&NetProcessor::accept_mss), sizeof(int))) <
-        0) {
+    if ((res = safe_setsockopt(fd, IPPROTO_TCP, TCP_MAXSEG, (char *)&NetProcessor::accept_mss, sizeof(int))) < 0) {
       goto Lerror;
     }
   }

--- a/iocore/net/Net.cc
+++ b/iocore/net/Net.cc
@@ -147,7 +147,7 @@ ink_net_init(ts::ModuleVersion version)
   if (!init_called) {
     // do one time stuff
     // create a stat block for NetStats
-    net_rsb = RecAllocateRawStatBlock(static_cast<int>(Net_Stat_Count));
+    net_rsb = RecAllocateRawStatBlock((int)Net_Stat_Count);
     configure_net();
     register_net_stats();
   }

--- a/iocore/net/NetVCTest.cc
+++ b/iocore/net/NetVCTest.cc
@@ -160,7 +160,7 @@ NetVCTest::start_test()
 int
 NetVCTest::fill_buffer(MIOBuffer *buf, uint8_t *seed, int bytes)
 {
-  char *space = static_cast<char *>(ats_malloc(bytes));
+  char *space = (char *)ats_malloc(bytes);
   char *tmp   = space;
   int to_add  = bytes;
 
@@ -190,7 +190,7 @@ NetVCTest::consume_and_check_bytes(IOBufferReader *r, uint8_t *seed)
   while (r->read_avail() > 0) {
     int64_t b_avail = r->block_read_avail();
 
-    tmp        = reinterpret_cast<uint8_t *>(r->start());
+    tmp        = (uint8_t *)r->start();
     end        = tmp + b_avail;
     b_consumed = 0;
 
@@ -349,7 +349,7 @@ int
 NetVCTest::main_handler(int event, void *data)
 {
   if (event == NET_EVENT_ACCEPT) {
-    test_vc = static_cast<NetVConnection *>(data);
+    test_vc = (NetVConnection *)data;
     start_test();
     return 0;
   }

--- a/iocore/net/OCSPStapling.cc
+++ b/iocore/net/OCSPStapling.cc
@@ -58,7 +58,7 @@ using certinfo_map = std::map<X509 *, certinfo *>;
 void
 certinfo_map_free(void * /*parent*/, void *ptr, CRYPTO_EX_DATA * /*ad*/, int /*idx*/, long /*argl*/, void * /*argp*/)
 {
-  certinfo_map *map = static_cast<certinfo_map *>(ptr);
+  certinfo_map *map = (certinfo_map *)ptr;
 
   if (!map) {
     return;
@@ -548,7 +548,7 @@ ssl_callback_ocsp_stapling(SSL *ssl)
     Debug("ssl_ocsp", "ssl_callback_ocsp_stapling: failed to get certificate status for %s", cinf->certname);
     return SSL_TLSEXT_ERR_NOACK;
   } else {
-    unsigned char *p = static_cast<unsigned char *>(OPENSSL_malloc(cinf->resp_derlen));
+    unsigned char *p = (unsigned char *)OPENSSL_malloc(cinf->resp_derlen);
     unsigned int len = cinf->resp_derlen;
     memcpy(p, cinf->resp_der, cinf->resp_derlen);
     ink_mutex_release(&cinf->stapling_mutex);

--- a/iocore/net/SSLCertLookup.cc
+++ b/iocore/net/SSLCertLookup.cc
@@ -162,7 +162,7 @@ void
 ticket_block_free(void *ptr)
 {
   if (ptr) {
-    ssl_ticket_key_block *key_block_ptr = static_cast<ssl_ticket_key_block *>(ptr);
+    ssl_ticket_key_block *key_block_ptr = (ssl_ticket_key_block *)ptr;
     unsigned num_ticket_keys            = key_block_ptr->num_keys;
     memset(ptr, 0, sizeof(ssl_ticket_key_block) + num_ticket_keys * sizeof(ssl_ticket_key_t));
   }
@@ -175,7 +175,7 @@ ticket_block_alloc(unsigned count)
   ssl_ticket_key_block *ptr;
   size_t nbytes = sizeof(ssl_ticket_key_block) + count * sizeof(ssl_ticket_key_t);
 
-  ptr = static_cast<ssl_ticket_key_block *>(ats_malloc(nbytes));
+  ptr = (ssl_ticket_key_block *)ats_malloc(nbytes);
   memset(ptr, 0, nbytes);
   ptr->num_keys = count;
 

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -119,26 +119,26 @@ SSLConfigParams::reset()
 void
 SSLConfigParams::cleanup()
 {
-  serverCertChainFilename = static_cast<char *>(ats_free_null(serverCertChainFilename));
-  serverCACertFilename    = static_cast<char *>(ats_free_null(serverCACertFilename));
-  serverCACertPath        = static_cast<char *>(ats_free_null(serverCACertPath));
-  clientCertPath          = static_cast<char *>(ats_free_null(clientCertPath));
-  clientCertPathOnly      = static_cast<char *>(ats_free_null(clientCertPathOnly));
-  clientKeyPath           = static_cast<char *>(ats_free_null(clientKeyPath));
-  clientKeyPathOnly       = static_cast<char *>(ats_free_null(clientKeyPathOnly));
-  clientCACertFilename    = static_cast<char *>(ats_free_null(clientCACertFilename));
-  clientCACertPath        = static_cast<char *>(ats_free_null(clientCACertPath));
-  configFilePath          = static_cast<char *>(ats_free_null(configFilePath));
-  serverCertPathOnly      = static_cast<char *>(ats_free_null(serverCertPathOnly));
-  serverKeyPathOnly       = static_cast<char *>(ats_free_null(serverKeyPathOnly));
-  cipherSuite             = static_cast<char *>(ats_free_null(cipherSuite));
-  client_cipherSuite      = static_cast<char *>(ats_free_null(client_cipherSuite));
-  dhparamsFile            = static_cast<char *>(ats_free_null(dhparamsFile));
+  serverCertChainFilename = (char *)ats_free_null(serverCertChainFilename);
+  serverCACertFilename    = (char *)ats_free_null(serverCACertFilename);
+  serverCACertPath        = (char *)ats_free_null(serverCACertPath);
+  clientCertPath          = (char *)ats_free_null(clientCertPath);
+  clientCertPathOnly      = (char *)ats_free_null(clientCertPathOnly);
+  clientKeyPath           = (char *)ats_free_null(clientKeyPath);
+  clientKeyPathOnly       = (char *)ats_free_null(clientKeyPathOnly);
+  clientCACertFilename    = (char *)ats_free_null(clientCACertFilename);
+  clientCACertPath        = (char *)ats_free_null(clientCACertPath);
+  configFilePath          = (char *)ats_free_null(configFilePath);
+  serverCertPathOnly      = (char *)ats_free_null(serverCertPathOnly);
+  serverKeyPathOnly       = (char *)ats_free_null(serverKeyPathOnly);
+  cipherSuite             = (char *)ats_free_null(cipherSuite);
+  client_cipherSuite      = (char *)ats_free_null(client_cipherSuite);
+  dhparamsFile            = (char *)ats_free_null(dhparamsFile);
 
-  server_tls13_cipher_suites = static_cast<char *>(ats_free_null(server_tls13_cipher_suites));
-  client_tls13_cipher_suites = static_cast<char *>(ats_free_null(client_tls13_cipher_suites));
-  server_groups_list         = static_cast<char *>(ats_free_null(server_groups_list));
-  client_groups_list         = static_cast<char *>(ats_free_null(client_groups_list));
+  server_tls13_cipher_suites = (char *)ats_free_null(server_tls13_cipher_suites);
+  client_tls13_cipher_suites = (char *)ats_free_null(client_tls13_cipher_suites);
+  server_groups_list         = (char *)ats_free_null(server_groups_list);
+  client_groups_list         = (char *)ats_free_null(client_groups_list);
 
   cleanupCTXTable();
   reset();
@@ -312,8 +312,7 @@ SSLConfigParams::initialize()
   REC_ReadConfigInteger(ssl_session_cache_timeout, "proxy.config.ssl.session_cache.timeout");
   REC_ReadConfigInteger(ssl_session_cache_auto_clear, "proxy.config.ssl.session_cache.auto_clear");
 
-  SSLConfigParams::session_cache_max_bucket_size =
-    static_cast<size_t>(ceil(static_cast<double>(ssl_session_cache_size) / ssl_session_cache_num_buckets));
+  SSLConfigParams::session_cache_max_bucket_size = (size_t)ceil((double)ssl_session_cache_size / ssl_session_cache_num_buckets);
   SSLConfigParams::session_cache_skip_on_lock_contention = ssl_session_cache_skip_on_contention;
   SSLConfigParams::session_cache_number_buckets          = ssl_session_cache_num_buckets;
 
@@ -663,7 +662,7 @@ void
 SSLTicketParams::cleanup()
 {
   ticket_block_free(default_global_keyblock);
-  ticket_key_filename = static_cast<char *>(ats_free_null(ticket_key_filename));
+  ticket_key_filename = (char *)ats_free_null(ticket_key_filename);
 }
 
 SSL_CTX *

--- a/iocore/net/SSLDiags.cc
+++ b/iocore/net/SSLDiags.cc
@@ -160,7 +160,7 @@ SSLDiagnostic(const SourceLocation &loc, bool debug, SSLNetVConnection *vc, cons
     ats_ip_ntop(vc->get_remote_addr(), ip_buf, sizeof(ip_buf));
   }
 
-  es = reinterpret_cast<unsigned long>(pthread_self());
+  es = (unsigned long)pthread_self();
   while ((l = ERR_get_error_line_data(&file, &line, &data, &flags)) != 0) {
     if (debug) {
       if (unlikely(diags->on())) {
@@ -202,7 +202,7 @@ SSLErrorName(int ssl_error)
     "SSL_ERROR_NONE",    "SSL_ERROR_SSL",         "SSL_ERROR_WANT_READ",    "SSL_ERROR_WANT_WRITE", "SSL_ERROR_WANT_X509_LOOKUP",
     "SSL_ERROR_SYSCALL", "SSL_ERROR_ZERO_RETURN", "SSL_ERROR_WANT_CONNECT", "SSL_ERROR_WANT_ACCEPT"};
 
-  if (ssl_error < 0 || ssl_error >= static_cast<int>(countof(names))) {
+  if (ssl_error < 0 || ssl_error >= (int)countof(names)) {
     return "unknown SSL error";
   }
 

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -515,7 +515,7 @@ SSLNetVConnection::net_read_io(NetHandler *nh, EThread *lthread)
   // If the key renegotiation failed it's over, just signal the error and finish.
   if (sslClientRenegotiationAbort == true) {
     this->read.triggered = 0;
-    readSignalError(nh, static_cast<int>(r));
+    readSignalError(nh, (int)r);
     Debug("ssl", "[SSLNetVConnection::net_read_io] client renegotiation setting read signal error");
     return;
   }
@@ -584,7 +584,7 @@ SSLNetVConnection::net_read_io(NetHandler *nh, EThread *lthread)
     } else if (ret == SSL_HANDSHAKE_WANT_READ || ret == SSL_HANDSHAKE_WANT_ACCEPT) {
       ink_assert(this->handShakeReader != nullptr);
       if (SSLConfigParams::ssl_handshake_timeout_in > 0) {
-        double handshake_time = (static_cast<double>(Thread::get_hrtime() - sslHandshakeBeginTime) / 1000000000);
+        double handshake_time = ((double)(Thread::get_hrtime() - sslHandshakeBeginTime) / 1000000000);
         Debug("ssl", "ssl handshake for vc %p, took %.3f seconds, configured handshake_timer: %d", this, handshake_time,
               SSLConfigParams::ssl_handshake_timeout_in);
         if (handshake_time > SSLConfigParams::ssl_handshake_timeout_in) {
@@ -706,7 +706,7 @@ SSLNetVConnection::net_read_io(NetHandler *nh, EThread *lthread)
     break;
   case SSL_READ_ERROR:
     this->read.triggered = 0;
-    readSignalError(nh, static_cast<int>(r));
+    readSignalError(nh, (int)r);
     Debug("ssl", "read_from_net, read finished - read error");
     break;
   }
@@ -1510,7 +1510,7 @@ SSLNetVConnection::select_next_protocol(SSL *ssl, const unsigned char **out, uns
   if (netvc->npnSet && netvc->npnSet->advertiseProtocols(&npn, &npnsz)) {
     // SSL_select_next_proto chooses the first server-offered protocol that appears in the clients protocol set, ie. the
     // server selects the protocol. This is a n^2 search, so it's preferable to keep the protocol set short.
-    if (SSL_select_next_proto(const_cast<unsigned char **>(out), outlen, npn, npnsz, in, inlen) == OPENSSL_NPN_NEGOTIATED) {
+    if (SSL_select_next_proto((unsigned char **)out, outlen, npn, npnsz, in, inlen) == OPENSSL_NPN_NEGOTIATED) {
       Debug("ssl", "selected ALPN protocol %.*s", (int)(*outlen), *out);
       return SSL_TLSEXT_ERR_OK;
     }
@@ -1801,7 +1801,7 @@ SSLNetVConnection::populate(Connection &con, Continuation *c, void *arg)
     return retval;
   }
   // Add in the SSL data
-  this->ssl = static_cast<SSL *>(arg);
+  this->ssl = (SSL *)arg;
   // Maybe bring over the stats?
 
   sslHandshakeStatus = SSL_HANDSHAKE_DONE;

--- a/iocore/net/SSLNextProtocolSet.cc
+++ b/iocore/net/SSLNextProtocolSet.cc
@@ -37,7 +37,7 @@ unsigned char *
 append_protocol(const char *proto, unsigned char *buf)
 {
   size_t sz = strlen(proto);
-  *buf++    = static_cast<unsigned char>(sz);
+  *buf++    = (unsigned char)sz;
   memcpy(buf, proto, sz);
   return buf + sz;
 }
@@ -59,7 +59,7 @@ create_npn_advertisement(const SSLNextProtocolSet::NextProtocolEndpoint::list_ty
     *len += (strlen(ep->protocol) + 1);
   }
 
-  *npn = advertised = static_cast<unsigned char *>(ats_malloc(*len));
+  *npn = advertised = (unsigned char *)ats_malloc(*len);
   if (!(*npn)) {
     goto fail;
   }
@@ -113,7 +113,7 @@ SSLNextProtocolSet::registerEndpoint(const char *proto, Continuation *ep)
     return false;
   }
 
-  if (!findEndpoint(reinterpret_cast<const unsigned char *>(proto), len)) {
+  if (!findEndpoint((const unsigned char *)proto, len)) {
     this->endpoints.push(new NextProtocolEndpoint(proto, ep));
 
     if (npn) {

--- a/iocore/net/SSLSessionCache.cc
+++ b/iocore/net/SSLSessionCache.cc
@@ -118,7 +118,7 @@ SSLSessionBucket::insertSession(const SSLSessionID &id, SSL_SESSION *sess)
 {
   size_t len = i2d_SSL_SESSION(sess, nullptr); // make sure we're not going to need more than SSL_MAX_SESSION_SIZE bytes
   /* do not cache a session that's too big. */
-  if (len > static_cast<size_t>(SSL_MAX_SESSION_SIZE)) {
+  if (len > (size_t)SSL_MAX_SESSION_SIZE) {
     Debug("ssl.session_cache", "Unable to save SSL session because size of %zd exceeds the max of %d", len, SSL_MAX_SESSION_SIZE);
     return;
   }

--- a/iocore/net/SSLSessionTicket.cc
+++ b/iocore/net/SSLSessionTicket.cc
@@ -43,7 +43,7 @@
 void
 ssl_session_ticket_free(void * /*parent*/, void *ptr, CRYPTO_EX_DATA * /*ad*/, int /*idx*/, long /*argl*/, void * /*argp*/)
 {
-  ticket_block_free(static_cast<struct ssl_ticket_key_block *>(ptr));
+  ticket_block_free((struct ssl_ticket_key_block *)ptr);
 }
 
 /*

--- a/iocore/net/SSLStats.cc
+++ b/iocore/net/SSLStats.cc
@@ -72,7 +72,7 @@ SSLInitializeStatistics()
   STACK_OF(SSL_CIPHER) * ciphers;
 
   // Allocate SSL statistics block.
-  ssl_rsb = RecAllocateRawStatBlock(static_cast<int>(Ssl_Stat_Count));
+  ssl_rsb = RecAllocateRawStatBlock((int)Ssl_Stat_Count);
   ink_assert(ssl_rsb != nullptr);
 
   // SSL client errors.
@@ -227,7 +227,7 @@ SSLInitializeStatistics()
 
     // If not already registered ...
     if (cipherName && cipher_map.find(cipherName) == cipher_map.end()) {
-      cipher_map.emplace(cipherName, static_cast<intptr_t>(ssl_cipher_stats_start + index));
+      cipher_map.emplace(cipherName, (intptr_t)(ssl_cipher_stats_start + index));
       // Register as non-persistent since the order/index is dependent upon configuration.
       RecRegisterRawStat(ssl_rsb, RECT_PROCESS, statName.c_str(), RECD_INT, RECP_NON_PERSISTENT,
                          (int)ssl_cipher_stats_start + index, RecRawStatSyncSum);

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -173,7 +173,7 @@ SSL_CTX_add_extra_chain_cert_file(SSL_CTX *ctx, const char *chainfile)
 static bool
 ssl_session_timed_out(SSL_SESSION *session)
 {
-  return SSL_SESSION_get_timeout(session) < (time(nullptr) - SSL_SESSION_get_time(session));
+  return SSL_SESSION_get_timeout(session) < (long)(time(nullptr) - SSL_SESSION_get_time(session));
 }
 
 static void ssl_rm_cached_session(SSL_CTX *ctx, SSL_SESSION *sess);
@@ -298,7 +298,7 @@ set_context_cert(SSL *ssl)
   // don't find a name-based match at this point, we *do not* want to mess with the context because we've
   // already made a best effort to find the best match.
   if (likely(servername)) {
-    cc = lookup->find(const_cast<char *>(servername));
+    cc = lookup->find((char *)servername);
     if (cc && cc->ctx) {
       ctx = cc->ctx;
     }
@@ -886,7 +886,7 @@ SSLInitializeLibrary()
     Debug("ssl", "FIPS_mode: %d", mode);
 #endif
 
-    mutex_buf = static_cast<ink_mutex *>(OPENSSL_malloc(CRYPTO_num_locks() * sizeof(ink_mutex)));
+    mutex_buf = (ink_mutex *)OPENSSL_malloc(CRYPTO_num_locks() * sizeof(ink_mutex));
 
     for (int i = 0; i < CRYPTO_num_locks(); i++) {
       ink_mutex_init(&mutex_buf[i]);
@@ -1070,7 +1070,7 @@ SSLMultiCertConfigLoader::index_certificate(SSLCertLookup *lookup, SSLCertContex
 
 #if HAVE_OPENSSL_TS_H
   // Traverse the subjectAltNames (if any) and insert additional keys for the SSL context.
-  GENERAL_NAMES *names = static_cast<GENERAL_NAMES *>(X509_get_ext_d2i(cert, NID_subject_alt_name, nullptr, nullptr));
+  GENERAL_NAMES *names = (GENERAL_NAMES *)X509_get_ext_d2i(cert, NID_subject_alt_name, nullptr, nullptr);
   if (names) {
     unsigned count = sk_GENERAL_NAME_num(names);
     for (unsigned i = 0; i < count; ++i) {
@@ -1677,7 +1677,7 @@ SSLWriteBuffer(SSL *ssl, const void *buf, int64_t nbytes, int64_t &nwritten)
     return SSL_ERROR_NONE;
   }
   ERR_clear_error();
-  int ret = SSL_write(ssl, buf, static_cast<int>(nbytes));
+  int ret = SSL_write(ssl, buf, (int)nbytes);
   if (ret > 0) {
     nwritten = ret;
     BIO *bio = SSL_get_wbio(ssl);
@@ -1705,7 +1705,7 @@ SSLReadBuffer(SSL *ssl, void *buf, int64_t nbytes, int64_t &nread)
     return SSL_ERROR_NONE;
   }
   ERR_clear_error();
-  int ret = SSL_read(ssl, buf, static_cast<int>(nbytes));
+  int ret = SSL_read(ssl, buf, (int)nbytes);
   if (ret > 0) {
     nread = ret;
     return SSL_ERROR_NONE;

--- a/iocore/net/Socks.cc
+++ b/iocore/net/Socks.cc
@@ -164,7 +164,7 @@ SocksEntry::free()
     if (lerrno || !netVConnection) {
       Debug("Socks", "retryevent: Sent errno %d to HTTP", lerrno);
       NET_INCREMENT_DYN_STAT(socks_connections_unsuccessful_stat);
-      action_.continuation->handleEvent(NET_EVENT_OPEN_FAILED, (void *)static_cast<intptr_t>(-lerrno));
+      action_.continuation->handleEvent(NET_EVENT_OPEN_FAILED, (void *)(intptr_t)(-lerrno));
     } else {
       netVConnection->do_io_read(this, 0, nullptr);
       netVConnection->do_io_write(this, 0, nullptr);
@@ -189,7 +189,7 @@ int
 SocksEntry::startEvent(int event, void *data)
 {
   if (event == NET_EVENT_OPEN) {
-    netVConnection = static_cast<SocksNetVC *>(data);
+    netVConnection = (SocksNetVC *)data;
 
     if (version == SOCKS5_VERSION) {
       auth_handler = &socks5BasicAuthHandler;
@@ -248,7 +248,7 @@ SocksEntry::mainEvent(int event, void *data)
   case NET_EVENT_OPEN:
     buf->reset();
     unsigned short ts;
-    p = reinterpret_cast<unsigned char *>(buf->start());
+    p = (unsigned char *)buf->start();
     ink_assert(netVConnection);
 
     if (auth_handler) {
@@ -340,8 +340,8 @@ SocksEntry::mainEvent(int event, void *data)
     ret = EVENT_CONT;
 
     if (version == SOCKS5_VERSION && auth_handler == nullptr) {
-      VIO *vio = static_cast<VIO *>(data);
-      p        = reinterpret_cast<unsigned char *>(buf->start());
+      VIO *vio = (VIO *)data;
+      p        = (unsigned char *)buf->start();
 
       if (vio->ndone >= 5) {
         int reply_len;
@@ -379,7 +379,7 @@ SocksEntry::mainEvent(int event, void *data)
       timeout = nullptr;
     }
     // Debug("Socks", "Successfully read the reply from the SOCKS server");
-    p = reinterpret_cast<unsigned char *>(buf->start());
+    p = (unsigned char *)buf->start();
 
     if (auth_handler) {
       SocksAuthHandler temp = auth_handler;
@@ -574,7 +574,7 @@ loadSocksAuthInfo(int fd, socks_conf_struct *socks_stuff)
 
       socks_stuff->user_name_n_passwd_len = len1 + len2 + 2;
 
-      char *ptr = static_cast<char *>(ats_malloc(socks_stuff->user_name_n_passwd_len));
+      char *ptr = (char *)ats_malloc(socks_stuff->user_name_n_passwd_len);
       ptr[0]    = len1;
       memcpy(&ptr[1], user_name, len1);
       ptr[len1 + 1] = len2;
@@ -630,7 +630,7 @@ socks5BasicAuthHandler(int event, unsigned char *p, void (**h_ptr)(void))
           ret    = -1;
           *h_ptr = nullptr;
         } else {
-          *reinterpret_cast<SocksAuthHandler *>(h_ptr) = &socks5PasswdAuthHandler;
+          *(SocksAuthHandler *)h_ptr = &socks5PasswdAuthHandler;
         }
 
         break;

--- a/iocore/net/UnixConnection.cc
+++ b/iocore/net/UnixConnection.cc
@@ -61,8 +61,7 @@ Connection::setup_mc_send(sockaddr const *mc_addr, sockaddr const *my_addr, bool
 
   fd = res;
 
-  if ((res = safe_setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char *>(&enable_reuseaddr), sizeof(enable_reuseaddr)) <
-             0)) {
+  if ((res = safe_setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (char *)&enable_reuseaddr, sizeof(enable_reuseaddr)) < 0)) {
     goto Lerror;
   }
 
@@ -83,12 +82,12 @@ Connection::setup_mc_send(sockaddr const *mc_addr, sockaddr const *my_addr, bool
   }
 
   // Set MultiCast TTL to specified value
-  if ((res = safe_setsockopt(fd, IPPROTO_IP, IP_MULTICAST_TTL, reinterpret_cast<char *>(&mc_ttl), sizeof(mc_ttl)) < 0)) {
+  if ((res = safe_setsockopt(fd, IPPROTO_IP, IP_MULTICAST_TTL, (char *)&mc_ttl, sizeof(mc_ttl)) < 0)) {
     goto Lerror;
   }
 
   // Set MultiCast Interface to specified value
-  if ((res = safe_setsockopt(fd, IPPROTO_IP, IP_MULTICAST_IF, reinterpret_cast<char *>(&mc_if), sizeof(mc_if)) < 0)) {
+  if ((res = safe_setsockopt(fd, IPPROTO_IP, IP_MULTICAST_IF, (char *)&mc_if, sizeof(mc_if)) < 0)) {
     goto Lerror;
   }
 
@@ -96,7 +95,7 @@ Connection::setup_mc_send(sockaddr const *mc_addr, sockaddr const *my_addr, bool
   if (!mc_loopback) {
     char loop = 0;
 
-    if ((res = safe_setsockopt(fd, IPPROTO_IP, IP_MULTICAST_LOOP, &loop, sizeof(loop)) < 0)) {
+    if ((res = safe_setsockopt(fd, IPPROTO_IP, IP_MULTICAST_LOOP, (char *)&loop, sizeof(loop)) < 0)) {
       goto Lerror;
     }
   }
@@ -130,8 +129,7 @@ Connection::setup_mc_receive(sockaddr const *mc_addr, sockaddr const *my_addr, b
     goto Lerror;
   }
 
-  if ((res = safe_setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char *>(&enable_reuseaddr), sizeof(enable_reuseaddr)) <
-             0)) {
+  if ((res = safe_setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (char *)&enable_reuseaddr, sizeof(enable_reuseaddr)) < 0)) {
     goto Lerror;
   }
 
@@ -153,7 +151,7 @@ Connection::setup_mc_receive(sockaddr const *mc_addr, sockaddr const *my_addr, b
     mc_request.imr_multiaddr.s_addr = ats_ip4_addr_cast(mc_addr);
     mc_request.imr_interface.s_addr = ats_ip4_addr_cast(my_addr);
 
-    if ((res = safe_setsockopt(fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, reinterpret_cast<char *>(&mc_request), sizeof(mc_request)) < 0)) {
+    if ((res = safe_setsockopt(fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, (char *)&mc_request, sizeof(mc_request)) < 0)) {
       goto Lerror;
     }
   }
@@ -408,7 +406,7 @@ Connection::apply_options(NetVCOptions const &opt)
       struct linger l;
       l.l_onoff  = 1;
       l.l_linger = 0;
-      safe_setsockopt(fd, SOL_SOCKET, SO_LINGER, reinterpret_cast<char *>(&l), sizeof(l));
+      safe_setsockopt(fd, SOL_SOCKET, SO_LINGER, (char *)&l, sizeof(l));
       Debug("socket", "::open:: setsockopt() turn on SO_LINGER on socket");
     }
   }

--- a/iocore/net/UnixNet.cc
+++ b/iocore/net/UnixNet.cc
@@ -217,8 +217,8 @@ initialize_thread_for_net(EThread *thread)
 {
   NetHandler *nh = get_NetHandler(thread);
 
-  new (reinterpret_cast<ink_dummy_for_new *>(nh)) NetHandler();
-  new (reinterpret_cast<ink_dummy_for_new *>(get_PollCont(thread))) PollCont(thread->mutex, nh);
+  new ((ink_dummy_for_new *)nh) NetHandler();
+  new ((ink_dummy_for_new *)get_PollCont(thread)) PollCont(thread->mutex, nh);
   nh->mutex  = new_ProxyMutex();
   nh->thread = thread;
 
@@ -234,7 +234,7 @@ initialize_thread_for_net(EThread *thread)
   thread->schedule_every(inactivityCop, HRTIME_SECONDS(cop_freq));
 
   thread->set_tail_handler(nh);
-  thread->ep       = static_cast<EventIO *>(ats_malloc(sizeof(EventIO)));
+  thread->ep       = (EventIO *)ats_malloc(sizeof(EventIO));
   thread->ep->type = EVENTIO_ASYNC_SIGNAL;
 #if HAVE_EVENTFD
   thread->ep->start(pd, thread->evfd, nullptr, EVENTIO_READ);
@@ -480,7 +480,7 @@ NetHandler::waitForActivity(ink_hrtime timeout)
   PollDescriptor *pd     = get_PollDescriptor(this->thread);
   UnixNetVConnection *vc = nullptr;
   for (int x = 0; x < pd->result; x++) {
-    epd = static_cast<EventIO *> get_ev_data(pd, x);
+    epd = (EventIO *)get_ev_data(pd, x);
     if (epd->type == EVENTIO_READWRITE_VC) {
       vc = epd->data.vc;
       // Remove triggered NetVC from cop_list because it won't be timeout before next InactivityCop runs.

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -49,7 +49,7 @@ safe_delay(int msec)
 int
 net_accept(NetAccept *na, void *ep, bool blockable)
 {
-  Event *e               = static_cast<Event *>(ep);
+  Event *e               = (Event *)ep;
   int res                = 0;
   int count              = 0;
   int loop               = accept_till_done;
@@ -71,10 +71,10 @@ net_accept(NetAccept *na, void *ep, bool blockable)
       }
       if (na->server.fd != NO_FD && !na->action_->cancelled) {
         if (!blockable) {
-          na->action_->continuation->handleEvent(EVENT_ERROR, (void *)static_cast<intptr_t>(res));
+          na->action_->continuation->handleEvent(EVENT_ERROR, (void *)(intptr_t)res);
         } else {
           SCOPED_MUTEX_LOCK(lock, na->action_->mutex, e->ethread);
-          na->action_->continuation->handleEvent(EVENT_ERROR, (void *)static_cast<intptr_t>(res));
+          na->action_->continuation->handleEvent(EVENT_ERROR, (void *)(intptr_t)res);
         }
       }
       count = res;
@@ -286,7 +286,7 @@ NetAccept::do_blocking_accept(EThread *t)
       }
       if (!action_->cancelled) {
         SCOPED_MUTEX_LOCK(lock, action_->mutex ? action_->mutex : t->mutex, t);
-        action_->continuation->handleEvent(EVENT_ERROR, (void *)static_cast<intptr_t>(res));
+        action_->continuation->handleEvent(EVENT_ERROR, (void *)(intptr_t)res);
         Warning("accept thread received fatal error: errno = %d", errno);
       }
       return -1;
@@ -350,7 +350,7 @@ int
 NetAccept::acceptEvent(int event, void *ep)
 {
   (void)event;
-  Event *e = static_cast<Event *>(ep);
+  Event *e = (Event *)ep;
   // PollDescriptor *pd = get_PollDescriptor(e->ethread);
   Ptr<ProxyMutex> m;
 
@@ -392,7 +392,7 @@ NetAccept::acceptEvent(int event, void *ep)
 int
 NetAccept::acceptFastEvent(int event, void *ep)
 {
-  Event *e = static_cast<Event *>(ep);
+  Event *e = (Event *)ep;
   (void)event;
   (void)e;
   int bufsz, res = 0;
@@ -454,7 +454,7 @@ NetAccept::acceptFastEvent(int event, void *ep)
         goto Ldone;
       }
       if (!action_->cancelled) {
-        action_->continuation->handleEvent(EVENT_ERROR, (void *)static_cast<intptr_t>(res));
+        action_->continuation->handleEvent(EVENT_ERROR, (void *)(intptr_t)res);
       }
       goto Lerror;
     }

--- a/iocore/net/UnixNetPages.cc
+++ b/iocore/net/UnixNetPages.cc
@@ -223,7 +223,7 @@ register_ShowNet(Continuation *c, HTTPHdr *h)
     s->sarg           = ats_strndup(query, query_len);
     char *gn          = nullptr;
     if (s->sarg) {
-      gn = static_cast<char *>(memchr(s->sarg, '=', strlen(s->sarg)));
+      gn = (char *)memchr(s->sarg, '=', strlen(s->sarg));
     }
     if (gn) {
       ats_ip_pton(gn + 1, &s->addr);
@@ -235,7 +235,7 @@ register_ShowNet(Continuation *c, HTTPHdr *h)
     s->sarg           = ats_strndup(query, query_len);
     char *gn          = nullptr;
     if (s->sarg) {
-      gn = static_cast<char *>(memchr(s->sarg, '=', strlen(s->sarg)));
+      gn = (char *)memchr(s->sarg, '=', strlen(s->sarg));
     }
     if (gn) {
       ats_ip_port_cast(&s->addr.sa) = htons(atoi(gn + 1));

--- a/iocore/net/UnixNetProcessor.cc
+++ b/iocore/net/UnixNetProcessor.cc
@@ -63,7 +63,7 @@ net_next_connection_number()
 {
   unsigned int res = 0;
   do {
-    res = static_cast<unsigned int>(ink_atomic_increment(&net_connection_number, 1));
+    res = (unsigned int)ink_atomic_increment(&net_connection_number, 1);
   } while (!res);
   return res;
 }

--- a/iocore/net/test_I_UDPNet.cc
+++ b/iocore/net/test_I_UDPNet.cc
@@ -161,15 +161,15 @@ udp_client(char *buf)
   tv.tv_sec  = 20;
   tv.tv_usec = 0;
 
-  setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, reinterpret_cast<char *>(&tv), sizeof(tv));
-  setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<char *>(&tv), sizeof(tv));
+  setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, (char *)&tv, sizeof(tv));
+  setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv, sizeof(tv));
 
   sockaddr_in addr;
   addr.sin_family      = AF_INET;
   addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
   addr.sin_port        = htons(port);
 
-  ssize_t n = sendto(sock, payload, sizeof(payload), 0, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr));
+  ssize_t n = sendto(sock, payload, sizeof(payload), 0, (struct sockaddr *)&addr, sizeof(addr));
   if (n < 0) {
     std::cout << "Couldn't send udp packet" << std::endl;
     close(sock);

--- a/iocore/utils/OneWayMultiTunnel.cc
+++ b/iocore/utils/OneWayMultiTunnel.cc
@@ -150,7 +150,7 @@ OneWayMultiTunnel::init(Continuation *aCont, VIO *SourceVio, VIO **TargetVios, i
 int
 OneWayMultiTunnel::startEvent(int event, void *data)
 {
-  VIO *vio   = static_cast<VIO *>(data);
+  VIO *vio   = (VIO *)data;
   int ret    = VC_EVENT_DONE;
   int result = 0;
 
@@ -209,7 +209,7 @@ OneWayMultiTunnel::startEvent(int event, void *data)
 
   Lwrite_complete:
   case VC_EVENT_WRITE_COMPLETE:
-    close_target_vio(0, static_cast<VIO *>(data));
+    close_target_vio(0, (VIO *)data);
     if ((n_connections == 0) || (n_connections == 1 && source_read_previously_completed)) {
       goto Ldone;
     } else if (vioSource) {

--- a/iocore/utils/OneWayTunnel.cc
+++ b/iocore/utils/OneWayTunnel.cc
@@ -226,7 +226,7 @@ OneWayTunnel::transform(MIOBufferAccessor &in_buf, MIOBufferAccessor &out_buf)
 int
 OneWayTunnel::startEvent(int event, void *data)
 {
-  VIO *vio   = static_cast<VIO *>(data);
+  VIO *vio   = (VIO *)data;
   int ret    = VC_EVENT_DONE;
   int result = 0;
 
@@ -291,7 +291,7 @@ OneWayTunnel::startEvent(int event, void *data)
 
   case VC_EVENT_ERROR:
   Lerror:
-    lerrno = (static_cast<VIO *>(data))->vc_server->lerrno;
+    lerrno = ((VIO *)data)->vc_server->lerrno;
     // fallthrough
 
   case VC_EVENT_INACTIVITY_TIMEOUT:

--- a/lib/records/P_RecCore.cc
+++ b/lib/records/P_RecCore.cc
@@ -342,7 +342,7 @@ RecErrT
 RecRegisterConfigString(RecT rec_type, const char *name, const char *data_default_tmp, RecUpdateT update_type, RecCheckT check_type,
                         const char *check_regex, RecSourceT source, RecAccessT access_type)
 {
-  RecString data_default = const_cast<RecString>(data_default_tmp);
+  RecString data_default = (RecString)data_default_tmp;
   ink_assert((rec_type == RECT_CONFIG) || (rec_type == RECT_LOCAL));
   REC_REGISTER_CONFIG_XXX(rec_string, RECD_STRING);
 }

--- a/lib/records/RecConfigParse.cc
+++ b/lib/records/RecConfigParse.cc
@@ -66,7 +66,7 @@ RecFileImport_Xmalloc(const char *file, char **file_buf, int *file_size)
     *file_size = 0;
     if ((h_file = RecFileOpenR(file)) != REC_HANDLE_INVALID) {
       *file_size = RecFileGetSize(h_file);
-      *file_buf  = static_cast<char *>(ats_malloc(*file_size + 1));
+      *file_buf  = (char *)ats_malloc(*file_size + 1);
       if (RecFileRead(h_file, *file_buf, *file_size, &bytes_read) != REC_ERR_FAIL && bytes_read == *file_size) {
         (*file_buf)[*file_size] = '\0';
         err                     = REC_ERR_OKAY;
@@ -163,7 +163,7 @@ RecConfigFileParse(const char *path, RecConfigEntryCallback handler, bool inc_ve
   }
   // clear our g_rec_config_contents_xxx structures
   while (!queue_is_empty(g_rec_config_contents_llq)) {
-    cfe = static_cast<RecConfigFileEntry *>(dequeue(g_rec_config_contents_llq));
+    cfe = (RecConfigFileEntry *)dequeue(g_rec_config_contents_llq);
     ats_free(cfe->entry);
     ats_free(cfe);
   }
@@ -257,7 +257,7 @@ RecConfigFileParse(const char *path, RecConfigEntryCallback handler, bool inc_ve
     handler(rec_type, data_type, name_str, value_str, value_str == data_str ? REC_SOURCE_EXPLICIT : REC_SOURCE_ENV, inc_version);
 
     // update our g_rec_config_contents_xxx
-    cfe             = static_cast<RecConfigFileEntry *>(ats_malloc(sizeof(RecConfigFileEntry)));
+    cfe             = (RecConfigFileEntry *)ats_malloc(sizeof(RecConfigFileEntry));
     cfe->entry_type = RECE_RECORD;
     cfe->entry      = ats_strdup(name_str);
     enqueue(g_rec_config_contents_llq, (void *)cfe);
@@ -267,7 +267,7 @@ RecConfigFileParse(const char *path, RecConfigEntryCallback handler, bool inc_ve
   L_next_line:
     // store this line into g_rec_config_contents_llq so that we can
     // write it out later
-    cfe             = static_cast<RecConfigFileEntry *>(ats_malloc(sizeof(RecConfigFileEntry)));
+    cfe             = (RecConfigFileEntry *)ats_malloc(sizeof(RecConfigFileEntry));
     cfe->entry_type = RECE_COMMENT;
     cfe->entry      = ats_strdup(line);
     enqueue(g_rec_config_contents_llq, (void *)cfe);

--- a/lib/records/RecCore.cc
+++ b/lib/records/RecCore.cc
@@ -110,7 +110,7 @@ register_record(RecT rec_type, const char *name, RecDataT data_type, RecData dat
 static int
 link_int(const char * /* name */, RecDataT /* data_type */, RecData data, void *cookie)
 {
-  RecInt *rec_int = static_cast<RecInt *>(cookie);
+  RecInt *rec_int = (RecInt *)cookie;
   ink_atomic_swap(rec_int, data.rec_int);
   return REC_ERR_OKAY;
 }
@@ -118,28 +118,28 @@ link_int(const char * /* name */, RecDataT /* data_type */, RecData data, void *
 static int
 link_int32(const char * /* name */, RecDataT /* data_type */, RecData data, void *cookie)
 {
-  *(static_cast<int32_t *>(cookie)) = static_cast<int32_t>(data.rec_int);
+  *((int32_t *)cookie) = (int32_t)data.rec_int;
   return REC_ERR_OKAY;
 }
 
 static int
 link_uint32(const char * /* name */, RecDataT /* data_type */, RecData data, void *cookie)
 {
-  *(static_cast<uint32_t *>(cookie)) = static_cast<uint32_t>(data.rec_int);
+  *((uint32_t *)cookie) = (uint32_t)data.rec_int;
   return REC_ERR_OKAY;
 }
 
 static int
 link_float(const char * /* name */, RecDataT /* data_type */, RecData data, void *cookie)
 {
-  *(static_cast<RecFloat *>(cookie)) = data.rec_float;
+  *((RecFloat *)cookie) = data.rec_float;
   return REC_ERR_OKAY;
 }
 
 static int
 link_counter(const char * /* name */, RecDataT /* data_type */, RecData data, void *cookie)
 {
-  RecCounter *rec_counter = static_cast<RecCounter *>(cookie);
+  RecCounter *rec_counter = (RecCounter *)cookie;
   ink_atomic_swap(rec_counter, data.rec_counter);
   return REC_ERR_OKAY;
 }
@@ -149,7 +149,7 @@ link_counter(const char * /* name */, RecDataT /* data_type */, RecData data, vo
 static int
 link_byte(const char * /* name */, RecDataT /* data_type */, RecData data, void *cookie)
 {
-  RecByte *rec_byte = static_cast<RecByte *>(cookie);
+  RecByte *rec_byte = (RecByte *)cookie;
   RecByte byte      = static_cast<RecByte>(data.rec_int);
 
   ink_atomic_swap(rec_byte, byte);
@@ -170,8 +170,8 @@ link_string_alloc(const char * /* name */, RecDataT /* data_type */, RecData dat
   }
 
   // set new string for DEFAULT_xxx_str tp point to
-  RecString _temp2                    = *(static_cast<RecString *>(cookie));
-  *(static_cast<RecString *>(cookie)) = _new_value;
+  RecString _temp2       = *((RecString *)cookie);
+  *((RecString *)cookie) = _new_value;
   // free previous string DEFAULT_xxx_str points to
   ats_free(_temp2);
 
@@ -197,7 +197,7 @@ RecCoreInit(RecModeT mode_type, Diags *_diags)
   g_num_records = 0;
 
   // initialize record array for our internal stats (this can be reallocated later)
-  g_records = static_cast<RecRecord *>(ats_malloc(REC_MAX_RECORDS * sizeof(RecRecord)));
+  g_records = (RecRecord *)ats_malloc(REC_MAX_RECORDS * sizeof(RecRecord));
 
   // initialize record rwlock
   ink_rwlock_init(&g_records_rwlock);
@@ -215,7 +215,7 @@ RecCoreInit(RecModeT mode_type, Diags *_diags)
 
     g_rec_config_fpath = ats_stringdup(RecConfigReadConfigPath(nullptr, REC_CONFIG_FILE REC_SHADOW_EXT));
     if (RecFileExists(g_rec_config_fpath) == REC_ERR_FAIL) {
-      ats_free(const_cast<char *>(g_rec_config_fpath));
+      ats_free((char *)g_rec_config_fpath);
       g_rec_config_fpath = ats_stringdup(RecConfigReadConfigPath(nullptr, REC_CONFIG_FILE));
       if (RecFileExists(g_rec_config_fpath) == REC_ERR_FAIL) {
         RecLog(DL_Warning, "Could not find '%s', system will run with defaults\n", REC_CONFIG_FILE);
@@ -325,7 +325,7 @@ RecRegisterConfigUpdateCb(const char *name, RecConfigUpdateCb update_cb, void *c
          }
        */
 
-      RecConfigUpdateCbList *new_callback = static_cast<RecConfigUpdateCbList *>(ats_malloc(sizeof(RecConfigUpdateCbList)));
+      RecConfigUpdateCbList *new_callback = (RecConfigUpdateCbList *)ats_malloc(sizeof(RecConfigUpdateCbList));
       memset(new_callback, 0, sizeof(RecConfigUpdateCbList));
       new_callback->update_cb     = update_cb;
       new_callback->update_cookie = cookie;
@@ -735,7 +735,7 @@ RecGetRecordDefaultDataString_Xmalloc(char *name, char **buf, bool lock)
   if (auto it = g_records_ht.find(name); it != g_records_ht.end()) {
     RecRecord *r = it->second;
 
-    *buf = static_cast<char *>(ats_malloc(sizeof(char) * 1024));
+    *buf = (char *)ats_malloc(sizeof(char) * 1024);
     memset(*buf, 0, 1024);
     err = REC_ERR_OKAY;
 
@@ -1065,7 +1065,7 @@ char *
 REC_ConfigReadString(const char *name)
 {
   char *t = nullptr;
-  RecGetRecordString_Xmalloc(name, static_cast<RecString *>(&t));
+  RecGetRecordString_Xmalloc(name, (RecString *)&t);
   return t;
 }
 
@@ -1073,7 +1073,7 @@ RecFloat
 REC_ConfigReadFloat(const char *name)
 {
   RecFloat t = 0;
-  RecGetRecordFloat(name, &t);
+  RecGetRecordFloat(name, (RecFloat *)&t);
   return t;
 }
 
@@ -1081,7 +1081,7 @@ RecCounter
 REC_ConfigReadCounter(const char *name)
 {
   RecCounter t = 0;
-  RecGetRecordCounter(name, &t);
+  RecGetRecordCounter(name, (RecCounter *)&t);
   return t;
 }
 

--- a/lib/records/RecFile.cc
+++ b/lib/records/RecFile.cc
@@ -147,7 +147,7 @@ RecFileGetSize(RecHandle h_file)
 {
   struct stat fileStats;
   fstat(h_file, &fileStats);
-  return static_cast<int>(fileStats.st_size);
+  return (int)fileStats.st_size;
 }
 
 //-------------------------------------------------------------------------

--- a/lib/records/RecLocal.cc
+++ b/lib/records/RecLocal.cc
@@ -61,7 +61,7 @@ i_am_the_record_owner(RecT rec_type)
 static void *
 sync_thr(void *data)
 {
-  FileManager *configFiles = static_cast<FileManager *>(data);
+  FileManager *configFiles = (FileManager *)data;
 
   while (true) {
     RecBool check = true;
@@ -206,7 +206,7 @@ RecMessageSend(RecMessage *msg)
   if (g_mode_type == RECM_CLIENT || g_mode_type == RECM_SERVER) {
     msg->o_end = msg->o_write;
     msg_size   = sizeof(RecMessageHdr) + (msg->o_write - msg->o_start);
-    lmgmt->signalEvent(MGMT_EVENT_LIBRECORDS, reinterpret_cast<char *>(msg), msg_size);
+    lmgmt->signalEvent(MGMT_EVENT_LIBRECORDS, (char *)msg, msg_size);
   }
 
   return REC_ERR_OKAY;

--- a/lib/records/RecMessage.cc
+++ b/lib/records/RecMessage.cc
@@ -44,7 +44,7 @@ RecMessageAlloc(RecMessageT msg_type, int initial_size)
 {
   RecMessage *msg;
 
-  msg = static_cast<RecMessage *>(ats_malloc(sizeof(RecMessageHdr) + initial_size));
+  msg = (RecMessage *)ats_malloc(sizeof(RecMessageHdr) + initial_size);
   memset(msg, 0, sizeof(RecMessageHdr) + initial_size);
   msg->msg_type = msg_type;
   msg->o_start  = sizeof(RecMessageHdr);
@@ -110,22 +110,22 @@ RecMessageMarshal_Realloc(RecMessage *msg, const RecRecord *record)
   // get some space in our buffer
   while (msg->o_end - msg->o_write < msg_ele_size) {
     int realloc_size = (msg->o_end - msg->o_start) * 2;
-    msg              = static_cast<RecMessage *>(ats_realloc(msg, sizeof(RecMessageHdr) + realloc_size));
+    msg              = (RecMessage *)ats_realloc(msg, sizeof(RecMessageHdr) + realloc_size);
     msg->o_end       = msg->o_start + realloc_size;
   }
-  ele_hdr = reinterpret_cast<RecMessageEleHdr *>(reinterpret_cast<char *>(msg) + msg->o_write);
+  ele_hdr = (RecMessageEleHdr *)((char *)msg + msg->o_write);
   // The following memset() is pretty CPU intensive, replacing it with something
   // like the below would reduce CPU usage a fair amount. /leif.
   // *((char*)msg + msg->o_write) = 0;
-  memset(reinterpret_cast<char *>(msg) + msg->o_write, 0, msg->o_end - msg->o_write);
+  memset((char *)msg + msg->o_write, 0, msg->o_end - msg->o_write);
   msg->o_write += msg_ele_size;
 
   // store the record
   ele_hdr->magic  = REC_MESSAGE_ELE_MAGIC;
   ele_hdr->o_next = msg->o_write;
-  p               = reinterpret_cast<char *>(ele_hdr) + sizeof(RecMessageEleHdr);
+  p               = (char *)ele_hdr + sizeof(RecMessageEleHdr);
   memcpy(p, record, sizeof(RecRecord));
-  r = reinterpret_cast<RecRecord *>(p);
+  r = (RecRecord *)p;
   p += sizeof(RecRecord);
   if (rec_name_len != -1) {
     ink_assert((msg->o_end - ((uintptr_t)p - (uintptr_t)msg)) >= (uintptr_t)rec_name_len);
@@ -163,7 +163,7 @@ RecMessageMarshal_Realloc(RecMessage *msg, const RecRecord *record)
 int
 RecMessageUnmarshalFirst(RecMessage *msg, RecMessageItr *itr, RecRecord **record)
 {
-  itr->ele_hdr = reinterpret_cast<RecMessageEleHdr *>(reinterpret_cast<char *>(msg) + msg->o_start);
+  itr->ele_hdr = (RecMessageEleHdr *)((char *)msg + msg->o_start);
   itr->next    = 1;
 
   return RecMessageUnmarshalNext(msg, nullptr, record);
@@ -183,13 +183,13 @@ RecMessageUnmarshalNext(RecMessage *msg, RecMessageItr *itr, RecRecord **record)
     if (msg->entries == 0) {
       return REC_ERR_FAIL;
     } else {
-      eh = reinterpret_cast<RecMessageEleHdr *>(reinterpret_cast<char *>(msg) + msg->o_start);
+      eh = (RecMessageEleHdr *)((char *)msg + msg->o_start);
     }
   } else {
     if (itr->next >= msg->entries) {
       return REC_ERR_FAIL;
     }
-    itr->ele_hdr = reinterpret_cast<RecMessageEleHdr *>(reinterpret_cast<char *>(msg) + itr->ele_hdr->o_next);
+    itr->ele_hdr = (RecMessageEleHdr *)((char *)(msg) + itr->ele_hdr->o_next);
     itr->next += 1;
     eh = itr->ele_hdr;
   }
@@ -202,21 +202,21 @@ RecMessageUnmarshalNext(RecMessage *msg, RecMessageItr *itr, RecRecord **record)
     return REC_ERR_FAIL;
   }
 
-  r = reinterpret_cast<RecRecord *>(reinterpret_cast<char *>(eh) + sizeof(RecMessageEleHdr));
+  r = (RecRecord *)((char *)eh + sizeof(RecMessageEleHdr));
 
   if (r->name) {
-    r->name = reinterpret_cast<char *>(r) + (intptr_t)(r->name);
+    r->name = (char *)r + (intptr_t)(r->name);
   }
   if (r->data_type == RECD_STRING) {
     if (r->data.rec_string) {
-      r->data.rec_string = reinterpret_cast<char *>(r) + (intptr_t)(r->data.rec_string);
+      r->data.rec_string = (char *)r + (intptr_t)(r->data.rec_string);
     }
     if (r->data_default.rec_string) {
-      r->data_default.rec_string = reinterpret_cast<char *>(r) + (intptr_t)(r->data_default.rec_string);
+      r->data_default.rec_string = (char *)r + (intptr_t)(r->data_default.rec_string);
     }
   }
   if (REC_TYPE_IS_CONFIG(r->rec_type) && (r->config_meta.check_expr)) {
-    r->config_meta.check_expr = reinterpret_cast<char *>(r) + (intptr_t)(r->config_meta.check_expr);
+    r->config_meta.check_expr = (char *)r + (intptr_t)(r->config_meta.check_expr);
   }
 
   *record = r;
@@ -266,13 +266,12 @@ RecMessageReadFromDisk(const char *fpath)
   if ((h_file = RecFileOpenR(fpath)) == REC_HANDLE_INVALID) {
     goto Lerror;
   }
-  if (RecFileRead(h_file, reinterpret_cast<char *>(&msg_hdr), sizeof(RecMessageHdr), &bytes_read) == REC_ERR_FAIL) {
+  if (RecFileRead(h_file, (char *)(&msg_hdr), sizeof(RecMessageHdr), &bytes_read) == REC_ERR_FAIL) {
     goto Lerror;
   }
-  msg = static_cast<RecMessage *>(ats_malloc((msg_hdr.o_end - msg_hdr.o_start) + sizeof(RecMessageHdr)));
+  msg = (RecMessage *)ats_malloc((msg_hdr.o_end - msg_hdr.o_start) + sizeof(RecMessageHdr));
   memcpy(msg, &msg_hdr, sizeof(RecMessageHdr));
-  if (RecSnapFileRead(h_file, reinterpret_cast<char *>(msg) + msg_hdr.o_start, msg_hdr.o_end - msg_hdr.o_start, &bytes_read) ==
-      REC_ERR_FAIL) {
+  if (RecSnapFileRead(h_file, (char *)(msg) + msg_hdr.o_start, msg_hdr.o_end - msg_hdr.o_start, &bytes_read) == REC_ERR_FAIL) {
     goto Lerror;
   }
 
@@ -308,7 +307,7 @@ RecMessageWriteToDisk(RecMessage *msg, const char *fpath)
 
   msg_size = sizeof(RecMessageHdr) + (msg->o_write - msg->o_start);
   if ((h_file = RecFileOpenW(fpath)) != REC_HANDLE_INVALID) {
-    if (RecSnapFileWrite(h_file, reinterpret_cast<char *>(msg), msg_size, &bytes_written) == REC_ERR_FAIL) {
+    if (RecSnapFileWrite(h_file, (char *)msg, msg_size, &bytes_written) == REC_ERR_FAIL) {
       RecFileClose(h_file);
       return REC_ERR_FAIL;
     }

--- a/lib/records/RecProcess.cc
+++ b/lib/records/RecProcess.cc
@@ -315,7 +315,7 @@ RecMessageSend(RecMessage *msg)
   if (g_mode_type == RECM_CLIENT || g_mode_type == RECM_SERVER) {
     msg->o_end = msg->o_write;
     msg_size   = sizeof(RecMessageHdr) + (msg->o_write - msg->o_start);
-    pmgmt->signalManager(MGMT_SIGNAL_LIBRECORDS, reinterpret_cast<char *>(msg), msg_size);
+    pmgmt->signalManager(MGMT_SIGNAL_LIBRECORDS, (char *)msg, msg_size);
   }
 
   return REC_ERR_OKAY;

--- a/lib/records/RecRawStats.cc
+++ b/lib/records/RecRawStats.cc
@@ -130,22 +130,22 @@ raw_stat_clear(RecRawStatBlock *rsb, int id)
   // lock so the setting of the globals and last values are atomic
   {
     ink_scoped_mutex_lock lock(rsb->mutex);
-    ink_atomic_swap(&(rsb->global[id]->sum), static_cast<int64_t>(0));
-    ink_atomic_swap(&(rsb->global[id]->last_sum), static_cast<int64_t>(0));
-    ink_atomic_swap(&(rsb->global[id]->count), static_cast<int64_t>(0));
-    ink_atomic_swap(&(rsb->global[id]->last_count), static_cast<int64_t>(0));
+    ink_atomic_swap(&(rsb->global[id]->sum), (int64_t)0);
+    ink_atomic_swap(&(rsb->global[id]->last_sum), (int64_t)0);
+    ink_atomic_swap(&(rsb->global[id]->count), (int64_t)0);
+    ink_atomic_swap(&(rsb->global[id]->last_count), (int64_t)0);
   }
   // reset the local stats
   for (EThread *et : eventProcessor.active_ethreads()) {
     RecRawStat *tlp = thread_stat(et, rsb, id);
-    ink_atomic_swap(&(tlp->sum), static_cast<int64_t>(0));
-    ink_atomic_swap(&(tlp->count), static_cast<int64_t>(0));
+    ink_atomic_swap(&(tlp->sum), (int64_t)0);
+    ink_atomic_swap(&(tlp->count), (int64_t)0);
   }
 
   for (EThread *et : eventProcessor.active_dthreads()) {
     RecRawStat *tlp = thread_stat(et, rsb, id);
-    ink_atomic_swap(&(tlp->sum), static_cast<int64_t>(0));
-    ink_atomic_swap(&(tlp->count), static_cast<int64_t>(0));
+    ink_atomic_swap(&(tlp->sum), (int64_t)0);
+    ink_atomic_swap(&(tlp->count), (int64_t)0);
   }
 
   return REC_ERR_OKAY;
@@ -163,19 +163,19 @@ raw_stat_clear_sum(RecRawStatBlock *rsb, int id)
   // lock so the setting of the globals and last values are atomic
   {
     ink_scoped_mutex_lock lock(rsb->mutex);
-    ink_atomic_swap(&(rsb->global[id]->sum), static_cast<int64_t>(0));
-    ink_atomic_swap(&(rsb->global[id]->last_sum), static_cast<int64_t>(0));
+    ink_atomic_swap(&(rsb->global[id]->sum), (int64_t)0);
+    ink_atomic_swap(&(rsb->global[id]->last_sum), (int64_t)0);
   }
 
   // reset the local stats
   for (EThread *et : eventProcessor.active_ethreads()) {
     RecRawStat *tlp = thread_stat(et, rsb, id);
-    ink_atomic_swap(&(tlp->sum), static_cast<int64_t>(0));
+    ink_atomic_swap(&(tlp->sum), (int64_t)0);
   }
 
   for (EThread *et : eventProcessor.active_dthreads()) {
     RecRawStat *tlp = thread_stat(et, rsb, id);
-    ink_atomic_swap(&(tlp->sum), static_cast<int64_t>(0));
+    ink_atomic_swap(&(tlp->sum), (int64_t)0);
   }
 
   return REC_ERR_OKAY;
@@ -193,19 +193,19 @@ raw_stat_clear_count(RecRawStatBlock *rsb, int id)
   // lock so the setting of the globals and last values are atomic
   {
     ink_scoped_mutex_lock lock(rsb->mutex);
-    ink_atomic_swap(&(rsb->global[id]->count), static_cast<int64_t>(0));
-    ink_atomic_swap(&(rsb->global[id]->last_count), static_cast<int64_t>(0));
+    ink_atomic_swap(&(rsb->global[id]->count), (int64_t)0);
+    ink_atomic_swap(&(rsb->global[id]->last_count), (int64_t)0);
   }
 
   // reset the local stats
   for (EThread *et : eventProcessor.active_ethreads()) {
     RecRawStat *tlp = thread_stat(et, rsb, id);
-    ink_atomic_swap(&(tlp->count), static_cast<int64_t>(0));
+    ink_atomic_swap(&(tlp->count), (int64_t)0);
   }
 
   for (EThread *et : eventProcessor.active_dthreads()) {
     RecRawStat *tlp = thread_stat(et, rsb, id);
-    ink_atomic_swap(&(tlp->count), static_cast<int64_t>(0));
+    ink_atomic_swap(&(tlp->count), (int64_t)0);
   }
 
   return REC_ERR_OKAY;
@@ -226,10 +226,10 @@ RecAllocateRawStatBlock(int num_stats)
   }
 
   // create the raw-stat-block structure
-  rsb = static_cast<RecRawStatBlock *>(ats_malloc(sizeof(RecRawStatBlock)));
+  rsb = (RecRawStatBlock *)ats_malloc(sizeof(RecRawStatBlock));
   memset(rsb, 0, sizeof(RecRawStatBlock));
 
-  rsb->global = static_cast<RecRawStat **>(ats_malloc(num_stats * sizeof(RecRawStat *)));
+  rsb->global = (RecRawStat **)ats_malloc(num_stats * sizeof(RecRawStat *));
   memset(rsb->global, 0, num_stats * sizeof(RecRawStat *));
 
   rsb->num_stats        = 0;
@@ -330,7 +330,7 @@ RecRawStatSyncAvg(const char *name, RecDataT data_type, RecData *data, RecRawSta
   total.sum   = rsb->global[id]->sum;
   total.count = rsb->global[id]->count;
   if (total.count != 0) {
-    avg = static_cast<float>(static_cast<double>(total.sum) / static_cast<double>(total.count));
+    avg = (float)((double)total.sum / (double)total.count);
   }
   RecDataSetFromFloat(data_type, data, avg);
   return REC_ERR_OKAY;
@@ -350,8 +350,8 @@ RecRawStatSyncHrTimeAvg(const char *name, RecDataT data_type, RecData *data, Rec
   if (total.count == 0) {
     r = 0.0f;
   } else {
-    r = static_cast<float>(static_cast<double>(total.sum) / static_cast<double>(total.count));
-    r = r / static_cast<float>(HRTIME_SECOND);
+    r = (float)((double)total.sum / (double)total.count);
+    r = r / (float)(HRTIME_SECOND);
   }
 
   RecDataSetFromFloat(data_type, data, r);
@@ -372,7 +372,7 @@ RecRawStatSyncIntMsecsToFloatSeconds(const char *name, RecDataT data_type, RecDa
   if (total.count == 0) {
     r = 0.0f;
   } else {
-    r = static_cast<float>(static_cast<double>(total.sum) / 1000);
+    r = (float)((double)total.sum / 1000);
   }
 
   RecDataSetFromFloat(data_type, data, r);
@@ -393,8 +393,8 @@ RecRawStatSyncMHrTimeAvg(const char *name, RecDataT data_type, RecData *data, Re
   if (total.count == 0) {
     r = 0.0f;
   } else {
-    r = static_cast<float>(static_cast<double>(total.sum) / static_cast<double>(total.count));
-    r = r / static_cast<float>(HRTIME_MSECOND);
+    r = (float)((double)total.sum / (double)total.count);
+    r = r / (float)(HRTIME_MSECOND);
   }
 
   RecDataSetFromFloat(data_type, data, r);

--- a/lib/records/RecUtils.cc
+++ b/lib/records/RecUtils.cc
@@ -291,7 +291,7 @@ RecDataSetFromInt64(RecDataT data_type, RecData *data_dst, int64_t data_int64)
     data_src.rec_int = data_int64;
     break;
   case RECD_FLOAT:
-    data_src.rec_float = static_cast<float>(data_int64);
+    data_src.rec_float = (float)(data_int64);
     break;
   case RECD_STRING: {
     char buf[32 + 1];
@@ -320,10 +320,10 @@ RecDataSetFromFloat(RecDataT data_type, RecData *data_dst, float data_float)
 
   switch (data_type) {
   case RECD_INT:
-    data_src.rec_int = static_cast<RecInt>(data_float);
+    data_src.rec_int = (RecInt)data_float;
     break;
   case RECD_FLOAT:
-    data_src.rec_float = (data_float);
+    data_src.rec_float = (float)(data_float);
     break;
   case RECD_STRING: {
     char buf[32 + 1];
@@ -332,7 +332,7 @@ RecDataSetFromFloat(RecDataT data_type, RecData *data_dst, float data_float)
     break;
   }
   case RECD_COUNTER:
-    data_src.rec_counter = static_cast<RecCounter>(data_float);
+    data_src.rec_counter = (RecCounter)data_float;
     break;
   default:
     ink_assert(!"Unexpected RecD type");
@@ -362,7 +362,7 @@ RecDataSetFromString(RecDataT data_type, RecData *data_dst, const char *data_str
       data_src.rec_string = nullptr;
     } else {
       // It's OK to cast away the const here, because RecDataSet will copy the string.
-      data_src.rec_string = const_cast<char *>(data_string);
+      data_src.rec_string = (char *)data_string;
     }
     break;
   case RECD_COUNTER:

--- a/mgmt/Alarms.cc
+++ b/mgmt/Alarms.cc
@@ -188,7 +188,7 @@ Alarms::signalAlarm(alarm_t a, const char *desc, const char *ip)
   Debug("alarm", "[Alarms::signalAlarm] Sending Alarm: '%s'", desc);
 
   if (!desc) {
-    desc = const_cast<char *>(getAlarmText(a));
+    desc = (char *)getAlarmText(a);
   }
 
   /*
@@ -219,7 +219,7 @@ Alarms::signalAlarm(alarm_t a, const char *desc, const char *ip)
     }
   }
 
-  atmp              = static_cast<Alarm *>(ats_malloc(sizeof(Alarm)));
+  atmp              = (Alarm *)ats_malloc(sizeof(Alarm));
   atmp->type        = a;
   atmp->linger      = true;
   atmp->seen        = true;
@@ -252,7 +252,7 @@ Alarms::signalAlarm(alarm_t a, const char *desc, const char *ip)
   }
   const size_t sz = sizeof(char) * (strlen(desc) + strlen(my_ctime_str) + 4);
   ats_free(atmp->description);
-  atmp->description = static_cast<char *>(ats_malloc(sz));
+  atmp->description = (char *)ats_malloc(sz);
   snprintf(atmp->description, sz, "[%s] %s", my_ctime_str, desc);
 
   ink_mutex_release(&mutex);
@@ -356,7 +356,7 @@ Alarms::execAlarmBin(const char *desc)
   } else if (pid > 0) { /* Parent */
     int status;
     bool script_done = false;
-    time_t timeout   = static_cast<time_t>(REC_readInteger("proxy.config.alarm.script_runtime", nullptr));
+    time_t timeout   = (time_t)REC_readInteger("proxy.config.alarm.script_runtime", nullptr);
     if (!timeout) {
       timeout = 5; // default time = 5 secs
     }

--- a/mgmt/FileManager.cc
+++ b/mgmt/FileManager.cc
@@ -220,7 +220,7 @@ FileManager::rereadConfig()
   // INKqa11910
   // need to first check that enable_customizations is enabled
   bool found;
-  int enabled = static_cast<int>(REC_readInteger("proxy.config.body_factory.enable_customizations", &found));
+  int enabled = (int)REC_readInteger("proxy.config.body_factory.enable_customizations", &found);
   if (found && enabled) {
     fileChanged("proxy.config.body_factory.template_sets_dir", "proxy.config.body_factory.template_sets_dir", true);
   }

--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -383,7 +383,7 @@ LocalManager::pollMgmtProcessServer()
       if (process_server_sockfd != ts::NO_FD && FD_ISSET(process_server_sockfd, &fdlist)) { /* New connection */
         struct sockaddr_in clientAddr;
         socklen_t clientLen = sizeof(clientAddr);
-        int new_sockfd      = mgmt_accept(process_server_sockfd, reinterpret_cast<struct sockaddr *>(&clientAddr), &clientLen);
+        int new_sockfd      = mgmt_accept(process_server_sockfd, (struct sockaddr *)&clientAddr, &clientLen);
 
         mgmt_log("[LocalManager::pollMgmtProcessServer] New process connecting fd '%d'\n", new_sockfd);
 
@@ -405,10 +405,10 @@ LocalManager::pollMgmtProcessServer()
         keep_polling = true;
 
         // read the message
-        if ((res = mgmt_read_pipe(watched_process_fd, reinterpret_cast<char *>(&mh_hdr), sizeof(MgmtMessageHdr))) > 0) {
-          MgmtMessageHdr *mh_full = static_cast<MgmtMessageHdr *>(alloca(sizeof(MgmtMessageHdr) + mh_hdr.data_len));
+        if ((res = mgmt_read_pipe(watched_process_fd, (char *)&mh_hdr, sizeof(MgmtMessageHdr))) > 0) {
+          MgmtMessageHdr *mh_full = (MgmtMessageHdr *)alloca(sizeof(MgmtMessageHdr) + mh_hdr.data_len);
           memcpy(mh_full, &mh_hdr, sizeof(MgmtMessageHdr));
-          char *data_raw = reinterpret_cast<char *>(mh_full) + sizeof(MgmtMessageHdr);
+          char *data_raw = (char *)mh_full + sizeof(MgmtMessageHdr);
           if ((res = mgmt_read_pipe(watched_process_fd, data_raw, mh_hdr.data_len)) > 0) {
             handleMgmtMsgFromProcesses(mh_full);
           } else if (res < 0) {
@@ -482,10 +482,10 @@ LocalManager::pollMgmtProcessServer()
 void
 LocalManager::handleMgmtMsgFromProcesses(MgmtMessageHdr *mh)
 {
-  char *data_raw = reinterpret_cast<char *>(mh) + sizeof(MgmtMessageHdr);
+  char *data_raw = (char *)mh + sizeof(MgmtMessageHdr);
   switch (mh->msg_id) {
   case MGMT_SIGNAL_PID:
-    watched_process_pid = *(reinterpret_cast<pid_t *>(data_raw));
+    watched_process_pid = *((pid_t *)data_raw);
     lmgmt->alarm_keeper->signalAlarm(MGMT_ALARM_PROXY_PROCESS_BORN, nullptr);
     proxy_running++;
     proxy_launch_pid         = -1;
@@ -518,7 +518,7 @@ LocalManager::handleMgmtMsgFromProcesses(MgmtMessageHdr *mh)
     char var_value[256];
     MgmtType stype;
     // stype is an enum type, so cast to an int* to avoid warnings. /leif
-    int tokens = sscanf(data_raw, "%255s %d %255s", var_name, reinterpret_cast<int *>(&stype), var_value);
+    int tokens = sscanf(data_raw, "%255s %d %255s", var_name, (int *)&stype, var_value);
     if (tokens != 3) {
       stype = MGMT_INVALID;
     }
@@ -550,7 +550,7 @@ LocalManager::handleMgmtMsgFromProcesses(MgmtMessageHdr *mh)
     char *child                            = nullptr;
     MgmtMarshallInt options                = 0;
     if (mgmt_message_parse(data_raw, mh->data_len, fields, countof(fields), &parent, &child, &options) != -1) {
-      configFiles->configFileChild(parent, child, static_cast<unsigned int>(options));
+      configFiles->configFileChild(parent, child, (unsigned int)options);
     } else {
       mgmt_log("[LocalManager::handleMgmtMsgFromProcesses] "
                "MGMT_SIGNAL_CONFIG_FILE_CHILD mgmt_message_parse error\n");
@@ -577,10 +577,10 @@ LocalManager::sendMgmtMsgToProcesses(int msg_id, const char *data_raw, int data_
 {
   MgmtMessageHdr *mh;
 
-  mh           = static_cast<MgmtMessageHdr *>(alloca(sizeof(MgmtMessageHdr) + data_len));
+  mh           = (MgmtMessageHdr *)alloca(sizeof(MgmtMessageHdr) + data_len);
   mh->msg_id   = msg_id;
   mh->data_len = data_len;
-  memcpy(reinterpret_cast<char *>(mh) + sizeof(MgmtMessageHdr), data_raw, data_len);
+  memcpy((char *)mh + sizeof(MgmtMessageHdr), data_raw, data_len);
   sendMgmtMsgToProcesses(mh);
   return;
 }
@@ -611,7 +611,7 @@ LocalManager::sendMgmtMsgToProcesses(MgmtMessageHdr *mh)
     Rollback *rb;
     char *data_raw;
 
-    data_raw = reinterpret_cast<char *>(mh) + sizeof(MgmtMessageHdr);
+    data_raw = (char *)mh + sizeof(MgmtMessageHdr);
     fname    = REC_readString(data_raw, &found);
 
     RecT rec_type;
@@ -632,7 +632,7 @@ LocalManager::sendMgmtMsgToProcesses(MgmtMessageHdr *mh)
   }
 
   if (watched_process_fd != -1) {
-    if (mgmt_write_pipe(watched_process_fd, reinterpret_cast<char *>(mh), sizeof(MgmtMessageHdr) + mh->data_len) <= 0) {
+    if (mgmt_write_pipe(watched_process_fd, (char *)mh, sizeof(MgmtMessageHdr) + mh->data_len) <= 0) {
       // In case of Linux, sometimes when the TS dies, the connection between TS and TM
       // is not closed properly. the socket does not receive an EOF. So, the TM does
       // not detect that the connection and hence TS has gone down. Hence it still
@@ -1013,7 +1013,7 @@ LocalManager::bindProxyPort(HttpProxyPort &port)
       mgmt_log("[bindProxyPort] Unable to set socket options: %d : %s\n", port.m_port, strerror(errno));
     }
   }
-  if (setsockopt(port.m_fd, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char *>(&one), sizeof(int)) < 0) {
+  if (setsockopt(port.m_fd, SOL_SOCKET, SO_REUSEADDR, (char *)&one, sizeof(int)) < 0) {
     mgmt_fatal(0, "[bindProxyPort] Unable to set socket options: %d : %s\n", port.m_port, strerror(errno));
   }
 
@@ -1062,6 +1062,6 @@ void
 LocalManager::signalAlarm(int alarm_id, const char *desc, const char *ip)
 {
   if (alarm_keeper) {
-    alarm_keeper->signalAlarm(static_cast<alarm_t>(alarm_id), desc, ip);
+    alarm_keeper->signalAlarm((alarm_t)alarm_id, desc, ip);
   }
 }

--- a/mgmt/ProcessManager.cc
+++ b/mgmt/ProcessManager.cc
@@ -59,7 +59,7 @@ read_management_message(int sockfd, MgmtMessageHdr **msg)
   }
 
   size_t msg_size          = sizeof(MgmtMessageHdr) + hdr.data_len;
-  MgmtMessageHdr *full_msg = static_cast<MgmtMessageHdr *>(ats_malloc(msg_size));
+  MgmtMessageHdr *full_msg = (MgmtMessageHdr *)ats_malloc(msg_size);
 
   memcpy(full_msg, &hdr, sizeof(MgmtMessageHdr));
   char *data_raw = reinterpret_cast<char *>(full_msg) + sizeof(MgmtMessageHdr);
@@ -123,7 +123,7 @@ ProcessManager::stop()
   poll_thread = ink_thread_null();
 
   while (!queue_is_empty(mgmt_signal_queue)) {
-    char *sig = static_cast<char *>(::dequeue(mgmt_signal_queue));
+    char *sig = (char *)::dequeue(mgmt_signal_queue);
     ats_free(sig);
   }
 
@@ -226,7 +226,7 @@ ProcessManager::signalConfigFileChild(const char *parent, const char *child, uns
   void *buffer = ats_malloc(len);
 
   mgmt_message_marshall(buffer, len, fields, countof(fields), &parent, &child, &mgmtopt);
-  signalManager(MGMT_SIGNAL_CONFIG_FILE_CHILD, static_cast<const char *>(buffer), len);
+  signalManager(MGMT_SIGNAL_CONFIG_FILE_CHILD, (const char *)buffer, len);
 
   ats_free(buffer);
 }
@@ -242,10 +242,10 @@ ProcessManager::signalManager(int msg_id, const char *data_raw, int data_len)
 {
   MgmtMessageHdr *mh;
 
-  mh           = static_cast<MgmtMessageHdr *>(ats_malloc(sizeof(MgmtMessageHdr) + data_len));
+  mh           = (MgmtMessageHdr *)ats_malloc(sizeof(MgmtMessageHdr) + data_len);
   mh->msg_id   = msg_id;
   mh->data_len = data_len;
-  memcpy(reinterpret_cast<char *>(mh) + sizeof(MgmtMessageHdr), data_raw, data_len);
+  memcpy((char *)mh + sizeof(MgmtMessageHdr), data_raw, data_len);
   this->signalManager(mh);
 }
 
@@ -289,12 +289,12 @@ int
 ProcessManager::processSignalQueue()
 {
   while (!queue_is_empty(mgmt_signal_queue)) {
-    MgmtMessageHdr *mh = static_cast<MgmtMessageHdr *>(::dequeue(mgmt_signal_queue));
+    MgmtMessageHdr *mh = (MgmtMessageHdr *)::dequeue(mgmt_signal_queue);
 
     Debug("pmgmt", "signaling local manager with message ID %d", mh->msg_id);
 
     if (require_lm) {
-      int ret = mgmt_write_pipe(local_manager_sockfd, reinterpret_cast<char *>(mh), sizeof(MgmtMessageHdr) + mh->data_len);
+      int ret = mgmt_write_pipe(local_manager_sockfd, (char *)mh, sizeof(MgmtMessageHdr) + mh->data_len);
       ats_free(mh);
 
       if (ret < 0) {
@@ -324,7 +324,7 @@ ProcessManager::initLMConnection()
   }
 
   /* Setup Connection to LocalManager */
-  memset(reinterpret_cast<char *>(&serv_addr), 0, sizeof(serv_addr));
+  memset((char *)&serv_addr, 0, sizeof(serv_addr));
   serv_addr.sun_family = AF_UNIX;
 
   ink_strlcpy(serv_addr.sun_path, sockpath.c_str(), sizeof(serv_addr.sun_path));
@@ -342,7 +342,7 @@ ProcessManager::initLMConnection()
     Fatal("unable to set close-on-exec flag: %s", strerror(errno));
   }
 
-  if ((connect(local_manager_sockfd, reinterpret_cast<struct sockaddr *>(&serv_addr), servlen)) < 0) {
+  if ((connect(local_manager_sockfd, (struct sockaddr *)&serv_addr, servlen)) < 0) {
     Fatal("failed to connect management socket '%s': %s", sockpath.c_str(), strerror(errno));
   }
 
@@ -354,13 +354,13 @@ ProcessManager::initLMConnection()
 #endif
 
   data_len          = sizeof(pid_t);
-  mh_full           = static_cast<MgmtMessageHdr *>(alloca(sizeof(MgmtMessageHdr) + data_len));
+  mh_full           = (MgmtMessageHdr *)alloca(sizeof(MgmtMessageHdr) + data_len);
   mh_full->msg_id   = MGMT_SIGNAL_PID;
   mh_full->data_len = data_len;
 
-  memcpy(reinterpret_cast<char *>(mh_full) + sizeof(MgmtMessageHdr), &(pid), data_len);
+  memcpy((char *)mh_full + sizeof(MgmtMessageHdr), &(pid), data_len);
 
-  if (mgmt_write_pipe(local_manager_sockfd, reinterpret_cast<char *>(mh_full), sizeof(MgmtMessageHdr) + data_len) <= 0) {
+  if (mgmt_write_pipe(local_manager_sockfd, (char *)mh_full, sizeof(MgmtMessageHdr) + data_len) <= 0) {
     Fatal("error writing message: %s", strerror(errno));
   }
 }

--- a/mgmt/ProxyConfig.cc
+++ b/mgmt/ProxyConfig.cc
@@ -32,21 +32,21 @@ ConfigProcessor configProcessor;
 void *
 config_int_cb(void *data, void *value)
 {
-  *static_cast<int *>(data) = *static_cast<int64_t *>(value);
+  *(int *)data = *(int64_t *)value;
   return nullptr;
 }
 
 void *
 config_float_cb(void *data, void *value)
 {
-  *static_cast<float *>(data) = *static_cast<float *>(value);
+  *(float *)data = *(float *)value;
   return nullptr;
 }
 
 void *
 config_long_long_cb(void *data, void *value)
 {
-  *static_cast<int64_t *>(data) = *static_cast<int64_t *>(value);
+  *(int64_t *)data = *(int64_t *)value;
   return nullptr;
 }
 
@@ -66,7 +66,7 @@ config_long_long_cb(void *data, void *value)
 void *
 config_string_alloc_cb(void *data, void *value)
 {
-  char *_ss        = static_cast<char *>(value);
+  char *_ss        = (char *)value;
   char *_new_value = nullptr;
 
 #if defined(DEBUG_CONFIG_STRING_UPDATE)
@@ -75,12 +75,12 @@ config_string_alloc_cb(void *data, void *value)
 
   if (_ss) {
     int len    = strlen(_ss);
-    _new_value = static_cast<char *>(ats_malloc(len + 1));
+    _new_value = (char *)ats_malloc(len + 1);
     memcpy(_new_value, _ss, len + 1);
   }
 
-  char *_temp2                = *static_cast<char **>(data);
-  *static_cast<char **>(data) = _new_value;
+  char *_temp2   = *(char **)data;
+  *(char **)data = _new_value;
 
   // free old data
   if (_temp2 != nullptr) {

--- a/mgmt/RecordsConfigUtils.cc
+++ b/mgmt/RecordsConfigUtils.cc
@@ -120,12 +120,12 @@ initialize_record(const RecordElement *record, void *)
 
     switch (record->value_type) {
     case RECD_INT:
-      tempInt = static_cast<RecInt>(ink_atoi64(record->value));
+      tempInt = (RecInt)ink_atoi64(record->value);
       RecRegisterStatInt(type, record->name, tempInt, RECP_NON_PERSISTENT);
       break;
 
     case RECD_FLOAT:
-      tempFloat = static_cast<RecFloat>(atof(record->value));
+      tempFloat = (RecFloat)atof(record->value);
       RecRegisterStatFloat(type, record->name, tempFloat, RECP_NON_PERSISTENT);
       break;
 
@@ -134,7 +134,7 @@ initialize_record(const RecordElement *record, void *)
       break;
 
     case RECD_COUNTER:
-      tempCounter = static_cast<RecCounter>(ink_atoi64(record->value));
+      tempCounter = (RecCounter)ink_atoi64(record->value);
       RecRegisterStatCounter(type, record->name, tempCounter, RECP_NON_PERSISTENT);
       break;
 

--- a/mgmt/Rollback.cc
+++ b/mgmt/Rollback.cc
@@ -96,7 +96,7 @@ Rollback::Rollback(const char *fileName_, const char *configName_, bool root_acc
 
   if (varIntFromName("proxy.config.admin.number_config_bak", &numBak) == true) {
     if (numBak > 1) {
-      numberBackups = static_cast<int>(numBak);
+      numberBackups = (int)numBak;
     } else {
       numberBackups = 1;
     }
@@ -155,7 +155,7 @@ Rollback::Rollback(const char *fileName_, const char *configName_, bool root_acc
       if (needZeroLength == true) {
         int fd = openFile(ACTIVE_VERSION, O_RDWR | O_CREAT);
         if (fd >= 0) {
-          alarmMsg = static_cast<char *>(ats_malloc(2048));
+          alarmMsg = (char *)ats_malloc(2048);
           snprintf(alarmMsg, 2048, "Created zero length place holder for config file %s", fileName);
           mgmt_log("[RollBack::Rollback] %s\n", alarmMsg);
           lmgmt->alarm_keeper->signalAlarm(MGMT_ALARM_CONFIG_UPDATE_FAILED, alarmMsg);
@@ -203,7 +203,7 @@ Rollback::Rollback(const char *fileName_, const char *configName_, bool root_acc
   testFD = openFile(ACTIVE_VERSION, O_RDWR, &testErrno);
   if (testFD < 0) {
     // We failed to open read-write
-    alarmMsg = static_cast<char *>(ats_malloc(2048));
+    alarmMsg = (char *)ats_malloc(2048);
     testFD   = openFile(ACTIVE_VERSION, O_RDONLY, &testErrno);
 
     if (testFD < 0) {
@@ -241,7 +241,7 @@ Rollback::createPathStr(version_t version)
   char *buffer = nullptr;
   std::string sysconfdir(RecConfigReadConfigDir());
   bufSize = sysconfdir.size() + fileNameLen + MAX_VERSION_DIGITS + 1;
-  buffer  = static_cast<char *>(ats_malloc(bufSize));
+  buffer  = (char *)ats_malloc(bufSize);
   Layout::get()->relative_to(buffer, bufSize, sysconfdir, fileName);
   if (version != ACTIVE_VERSION) {
     size_t pos = strlen(buffer);
@@ -417,7 +417,7 @@ Rollback::internalUpdate(TextBuffer *buf, version_t newVersion, bool notifyChang
   // Write the buffer into the new configuration file
   writeBytes = write(diskFD, buf->bufPtr(), buf->spaceUsed());
   ret        = closeFile(diskFD, true);
-  if ((ret < 0) || (static_cast<size_t>(writeBytes) != buf->spaceUsed())) {
+  if ((ret < 0) || ((size_t)writeBytes != buf->spaceUsed())) {
     mgmt_log("[Rollback::internalUpdate] Unable to write new version of %s : %s\n", fileName, strerror(errno));
     returnCode = SYS_CALL_ERROR_ROLLBACK;
     goto UPDATE_CLEANUP;
@@ -486,7 +486,7 @@ UPDATE_CLEANUP:
   //   to manipulate the disk, the error might not get
   //   written to disk
   if (returnCode != OK_ROLLBACK) {
-    alarmMsg = static_cast<char *>(ats_malloc(1024));
+    alarmMsg = (char *)ats_malloc(1024);
     snprintf(alarmMsg, 1024, "[TrafficManager] Configuration File Update Failed: %s", strerror(errno));
     lmgmt->alarm_keeper->signalAlarm(MGMT_ALARM_CONFIG_UPDATE_FAILED, alarmMsg);
     ats_free(alarmMsg);
@@ -558,7 +558,7 @@ Rollback::getVersion_ml(version_t version, TextBuffer **buffer)
     }
   } while (readResult > 0);
 
-  if (static_cast<off_t>(newBuffer->spaceUsed()) != fileInfo.st_size) {
+  if ((off_t)newBuffer->spaceUsed() != fileInfo.st_size) {
     mgmt_log("[Rollback::getVersion] Incorrect amount of data retrieved from %s version %d.  Expected: %d   Got: %d\n", fileName,
              version, fileInfo.st_size, newBuffer->spaceUsed());
     returnCode = SYS_CALL_ERROR_ROLLBACK;
@@ -712,7 +712,7 @@ Rollback::extractVersionInfo(ExpandingArray *listNames, const char *testFileName
             struct stat fileInfo;
 
             if (statFile(version, &fileInfo) >= 0) {
-              versionInfo *verInfo = static_cast<versionInfo *>(ats_malloc(sizeof(versionInfo)));
+              versionInfo *verInfo = (versionInfo *)ats_malloc(sizeof(versionInfo));
               verInfo->version     = version;
               verInfo->modTime     = fileInfo.st_mtime;
               listNames->addEntry((void *)verInfo);
@@ -748,7 +748,7 @@ Rollback::findVersions_ml(Queue<versionInfo> &q)
 
   // Add the entries on to our passed in q
   for (int i = 0; i < num; i++) {
-    foundVer = static_cast<versionInfo *>(versions[i]);
+    foundVer = (versionInfo *)versions[i];
     //  We need to create our own copy so that
     //   constructor gets run
     versionInfo *addInfo = new versionInfo;
@@ -932,8 +932,8 @@ Rollback::checkForUserUpdate(RollBackCheckType how)
 int
 versionCmp(const void *i1, const void *i2)
 {
-  const versionInfo *v1 = static_cast<const versionInfo *>(i1);
-  const versionInfo *v2 = static_cast<const versionInfo *>(i2);
+  versionInfo *v1 = (versionInfo *)*(void **)i1;
+  versionInfo *v2 = (versionInfo *)*(void **)i2;
 
   if ((v1->version) < v2->version) {
     return -1;

--- a/mgmt/WebMgmtUtils.cc
+++ b/mgmt/WebMgmtUtils.cc
@@ -48,7 +48,7 @@ varSetFromStr(const char *varName, const char *value)
 
   memset(&data, 0, sizeof(RecData));
 
-  err = RecGetRecordDataType(const_cast<char *>(varName), &varDataType);
+  err = RecGetRecordDataType((char *)varName, &varDataType);
   if (err != REC_ERR_OKAY) {
     return found;
   }
@@ -62,14 +62,14 @@ varSetFromStr(const char *varName, const char *value)
   switch (varDataType) {
   case RECD_INT:
     if (sscanf(value, "%" PRId64 "", &data.rec_int) == 1) {
-      RecSetRecordInt(const_cast<char *>(varName), data.rec_int, REC_SOURCE_EXPLICIT);
+      RecSetRecordInt((char *)varName, data.rec_int, REC_SOURCE_EXPLICIT);
     } else {
       found = false;
     }
     break;
   case RECD_COUNTER:
     if (sscanf(value, "%" PRId64 "", &data.rec_counter) == 1) {
-      RecSetRecordCounter(const_cast<char *>(varName), data.rec_counter, REC_SOURCE_EXPLICIT);
+      RecSetRecordCounter((char *)varName, data.rec_counter, REC_SOURCE_EXPLICIT);
     } else {
       found = false;
     }
@@ -77,16 +77,16 @@ varSetFromStr(const char *varName, const char *value)
   case RECD_FLOAT:
     // coverity[secure_coding]
     if (sscanf(value, "%f", &data.rec_float) == 1) {
-      RecSetRecordFloat(const_cast<char *>(varName), data.rec_float, REC_SOURCE_EXPLICIT);
+      RecSetRecordFloat((char *)varName, data.rec_float, REC_SOURCE_EXPLICIT);
     } else {
       found = false;
     }
     break;
   case RECD_STRING:
     if (*value == '\0') {
-      RecSetRecordString(const_cast<char *>(varName), nullptr, REC_SOURCE_EXPLICIT);
+      RecSetRecordString((char *)varName, nullptr, REC_SOURCE_EXPLICIT);
     } else {
-      RecSetRecordString(const_cast<char *>(varName), const_cast<char *>(value), REC_SOURCE_EXPLICIT);
+      RecSetRecordString((char *)varName, (char *)value, REC_SOURCE_EXPLICIT);
     }
     break;
   case RECD_NULL:
@@ -114,27 +114,27 @@ varSetFloat(const char *varName, RecFloat value, bool convert)
   bool found           = true;
   int err              = REC_ERR_FAIL;
 
-  err = RecGetRecordDataType(const_cast<char *>(varName), &varDataType);
+  err = RecGetRecordDataType((char *)varName, &varDataType);
   if (err != REC_ERR_OKAY) {
     return found;
   }
 
   switch (varDataType) {
   case RECD_FLOAT:
-    RecSetRecordFloat(const_cast<char *>(varName), value, REC_SOURCE_EXPLICIT);
+    RecSetRecordFloat((char *)varName, (RecFloat)value, REC_SOURCE_EXPLICIT);
     break;
 
   case RECD_INT:
     if (convert) {
       value += 0.5; // rounding up
-      RecSetRecordInt(const_cast<char *>(varName), static_cast<RecInt>(value), REC_SOURCE_EXPLICIT);
+      RecSetRecordInt((char *)varName, (RecInt)value, REC_SOURCE_EXPLICIT);
       break;
     }
     // fallthrough
 
   case RECD_COUNTER:
     if (convert) {
-      RecSetRecordCounter(const_cast<char *>(varName), static_cast<RecCounter>(value), REC_SOURCE_EXPLICIT);
+      RecSetRecordCounter((char *)varName, (RecCounter)value, REC_SOURCE_EXPLICIT);
       break;
     }
     // fallthrough
@@ -165,26 +165,26 @@ varSetCounter(const char *varName, RecCounter value, bool convert)
   bool found           = true;
   int err              = REC_ERR_FAIL;
 
-  err = RecGetRecordDataType(const_cast<char *>(varName), &varDataType);
+  err = RecGetRecordDataType((char *)varName, &varDataType);
   if (err != REC_ERR_OKAY) {
     return found;
   }
 
   switch (varDataType) {
   case RECD_COUNTER:
-    RecSetRecordCounter(const_cast<char *>(varName), value, REC_SOURCE_EXPLICIT);
+    RecSetRecordCounter((char *)varName, (RecCounter)value, REC_SOURCE_EXPLICIT);
     break;
 
   case RECD_INT:
     if (convert) {
-      RecSetRecordInt(const_cast<char *>(varName), static_cast<RecInt>(value), REC_SOURCE_EXPLICIT);
+      RecSetRecordInt((char *)varName, (RecInt)value, REC_SOURCE_EXPLICIT);
       break;
     }
     // fallthrough
 
   case RECD_FLOAT:
     if (convert) {
-      RecSetRecordFloat(const_cast<char *>(varName), static_cast<RecFloat>(value), REC_SOURCE_EXPLICIT);
+      RecSetRecordFloat((char *)varName, (RecFloat)value, REC_SOURCE_EXPLICIT);
       break;
     }
     // fallthrough
@@ -215,26 +215,26 @@ varSetInt(const char *varName, RecInt value, bool convert)
   bool found           = true;
   int err              = REC_ERR_FAIL;
 
-  err = RecGetRecordDataType(const_cast<char *>(varName), &varDataType);
+  err = RecGetRecordDataType((char *)varName, &varDataType);
   if (err != REC_ERR_OKAY) {
     return found;
   }
 
   switch (varDataType) {
   case RECD_INT:
-    RecSetRecordInt(const_cast<char *>(varName), value, REC_SOURCE_EXPLICIT);
+    RecSetRecordInt((char *)varName, (RecInt)value, REC_SOURCE_EXPLICIT);
     break;
 
   case RECD_COUNTER:
     if (convert) {
-      RecSetRecordCounter(const_cast<char *>(varName), static_cast<RecCounter>(value), REC_SOURCE_EXPLICIT);
+      RecSetRecordCounter((char *)varName, (RecCounter)value, REC_SOURCE_EXPLICIT);
       break;
     }
     // fallthrough
 
   case RECD_FLOAT:
     if (convert) {
-      RecSetRecordFloat(const_cast<char *>(varName), static_cast<RecFloat>(value), REC_SOURCE_EXPLICIT);
+      RecSetRecordFloat((char *)varName, (RecFloat)value, REC_SOURCE_EXPLICIT);
       break;
     }
     // fallthrough
@@ -261,13 +261,13 @@ varSetData(RecDataT varType, const char *varName, RecData value)
 
   switch (varType) {
   case RECD_INT:
-    err = RecSetRecordInt(const_cast<char *>(varName), value.rec_int, REC_SOURCE_EXPLICIT);
+    err = RecSetRecordInt((char *)varName, value.rec_int, REC_SOURCE_EXPLICIT);
     break;
   case RECD_COUNTER:
-    err = RecSetRecordCounter(const_cast<char *>(varName), value.rec_counter, REC_SOURCE_EXPLICIT);
+    err = RecSetRecordCounter((char *)varName, value.rec_counter, REC_SOURCE_EXPLICIT);
     break;
   case RECD_FLOAT:
-    err = RecSetRecordFloat(const_cast<char *>(varName), value.rec_float, REC_SOURCE_EXPLICIT);
+    err = RecSetRecordFloat((char *)varName, value.rec_float, REC_SOURCE_EXPLICIT);
     break;
   default:
     Fatal("unsupport type:%d\n", varType);
@@ -306,7 +306,7 @@ varCounterFromName(const char *varName, RecCounter *value)
   bool found           = true;
   int err              = REC_ERR_FAIL;
 
-  err = RecGetRecordDataType(const_cast<char *>(varName), &varDataType);
+  err = RecGetRecordDataType((char *)varName, &varDataType);
 
   if (err == REC_ERR_FAIL) {
     return false;
@@ -315,19 +315,19 @@ varCounterFromName(const char *varName, RecCounter *value)
   switch (varDataType) {
   case RECD_INT: {
     RecInt tempInt = 0;
-    RecGetRecordInt(const_cast<char *>(varName), &tempInt);
-    *value = static_cast<RecCounter>(tempInt);
+    RecGetRecordInt((char *)varName, &tempInt);
+    *value = (RecCounter)tempInt;
     break;
   }
   case RECD_COUNTER: {
     *value = 0;
-    RecGetRecordCounter(const_cast<char *>(varName), value);
+    RecGetRecordCounter((char *)varName, value);
     break;
   }
   case RECD_FLOAT: {
     RecFloat tempFloat = 0.0;
-    RecGetRecordFloat(const_cast<char *>(varName), &tempFloat);
-    *value = static_cast<RecCounter>(tempFloat);
+    RecGetRecordFloat((char *)varName, &tempFloat);
+    *value = (RecCounter)tempFloat;
     break;
   }
   case RECD_STRING:
@@ -356,7 +356,7 @@ varFloatFromName(const char *varName, RecFloat *value)
 
   int err = REC_ERR_FAIL;
 
-  err = RecGetRecordDataType(const_cast<char *>(varName), &varDataType);
+  err = RecGetRecordDataType((char *)varName, &varDataType);
 
   if (err == REC_ERR_FAIL) {
     return false;
@@ -365,19 +365,19 @@ varFloatFromName(const char *varName, RecFloat *value)
   switch (varDataType) {
   case RECD_INT: {
     RecInt tempInt = 0;
-    RecGetRecordInt(const_cast<char *>(varName), &tempInt);
-    *value = static_cast<RecFloat>(tempInt);
+    RecGetRecordInt((char *)varName, &tempInt);
+    *value = (RecFloat)tempInt;
     break;
   }
   case RECD_COUNTER: {
     RecCounter tempCounter = 0;
-    RecGetRecordCounter(const_cast<char *>(varName), &tempCounter);
-    *value = static_cast<RecFloat>(tempCounter);
+    RecGetRecordCounter((char *)varName, &tempCounter);
+    *value = (RecFloat)tempCounter;
     break;
   }
   case RECD_FLOAT: {
     *value = 0.0;
-    RecGetRecordFloat(const_cast<char *>(varName), value);
+    RecGetRecordFloat((char *)varName, value);
     break;
   }
   case RECD_STRING:
@@ -405,7 +405,7 @@ varIntFromName(const char *varName, RecInt *value)
   bool found           = true;
   int err              = REC_ERR_FAIL;
 
-  err = RecGetRecordDataType(const_cast<char *>(varName), &varDataType);
+  err = RecGetRecordDataType((char *)varName, &varDataType);
 
   if (err != REC_ERR_OKAY) {
     return false;
@@ -414,19 +414,19 @@ varIntFromName(const char *varName, RecInt *value)
   switch (varDataType) {
   case RECD_INT: {
     *value = 0;
-    RecGetRecordInt(const_cast<char *>(varName), value);
+    RecGetRecordInt((char *)varName, value);
     break;
   }
   case RECD_COUNTER: {
     RecCounter tempCounter = 0;
-    RecGetRecordCounter(const_cast<char *>(varName), &tempCounter);
-    *value = static_cast<RecInt>(tempCounter);
+    RecGetRecordCounter((char *)varName, &tempCounter);
+    *value = (RecInt)tempCounter;
     break;
   }
   case RECD_FLOAT: {
     RecFloat tempFloat = 0.0;
-    RecGetRecordFloat(const_cast<char *>(varName), &tempFloat);
-    *value = static_cast<RecInt>(tempFloat);
+    RecGetRecordFloat((char *)varName, &tempFloat);
+    *value = (RecInt)tempFloat;
     break;
   }
   case RECD_STRING:
@@ -451,7 +451,7 @@ percentStrFromFloat(RecFloat val, char *bufVal)
 {
   int percent;
 
-  percent = static_cast<int>((val * 100.0) + 0.5);
+  percent = (int)((val * 100.0) + 0.5);
   snprintf(bufVal, 4, "%d%%", percent);
 }
 
@@ -522,7 +522,7 @@ bytesFromInt(RecInt bytes, char *bufVal)
   double unitBytes;
 
   if (bytes >= gb) {
-    unitBytes = bytes / static_cast<double>(gb);
+    unitBytes = bytes / (double)gb;
     snprintf(bufVal, 15, "%.1f GB", unitBytes);
   } else {
     // Reduce the precision of the bytes parameter
@@ -530,12 +530,12 @@ bytesFromInt(RecInt bytes, char *bufVal)
     //   has plenty of precision for a regular int
     //   and saves from 64 bit arithmetic which may
     //   be expensive on some processors
-    int bytesP = static_cast<int>(bytes);
+    int bytesP = (int)bytes;
     if (bytesP >= mb) {
-      unitBytes = bytes / static_cast<double>(mb);
+      unitBytes = bytes / (double)mb;
       snprintf(bufVal, 15, "%.1f MB", unitBytes);
     } else if (bytesP >= kb) {
-      unitBytes = bytes / static_cast<double>(kb);
+      unitBytes = bytes / (double)kb;
       snprintf(bufVal, 15, "%.1f KB", unitBytes);
     } else {
       snprintf(bufVal, 15, "%d", bytesP);
@@ -616,9 +616,9 @@ varStrFromName(const char *varNameConst, char *bufVal, int bufLen)
   case RECD_COUNTER:
     RecGetRecordCounter(varName, &data.rec_counter);
     if (formatOption == 'b') {
-      bytesFromInt(static_cast<MgmtInt>(data.rec_counter), bufVal);
+      bytesFromInt((MgmtInt)data.rec_counter, bufVal);
     } else if (formatOption == 'm') {
-      MbytesFromInt(static_cast<MgmtInt>(data.rec_counter), bufVal);
+      MbytesFromInt((MgmtInt)data.rec_counter, bufVal);
     } else if (formatOption == 'c') {
       commaStrFromInt(data.rec_counter, bufVal);
     } else {
@@ -637,7 +637,7 @@ varStrFromName(const char *varNameConst, char *bufVal, int bufLen)
     RecGetRecordString_Xmalloc(varName, &data.rec_string);
     if (data.rec_string == nullptr) {
       bufVal[0] = '\0';
-    } else if (strlen(data.rec_string) < static_cast<size_t>(bufLen - 1)) {
+    } else if (strlen(data.rec_string) < (size_t)(bufLen - 1)) {
       ink_strlcpy(bufVal, data.rec_string, bufLen);
     } else {
       ink_strlcpy(bufVal, data.rec_string, bufLen);
@@ -667,7 +667,7 @@ MgmtData::setFromName(const char *varName)
   bool found = true;
   int err;
 
-  err = RecGetRecordDataType(const_cast<char *>(varName), &this->type);
+  err = RecGetRecordDataType((char *)varName, &this->type);
 
   if (err == REC_ERR_FAIL) {
     return found;
@@ -675,16 +675,16 @@ MgmtData::setFromName(const char *varName)
 
   switch (this->type) {
   case RECD_INT:
-    RecGetRecordInt(const_cast<char *>(varName), &this->data.rec_int);
+    RecGetRecordInt((char *)varName, &this->data.rec_int);
     break;
   case RECD_COUNTER:
-    RecGetRecordCounter(const_cast<char *>(varName), &this->data.rec_counter);
+    RecGetRecordCounter((char *)varName, &this->data.rec_counter);
     break;
   case RECD_FLOAT:
-    RecGetRecordFloat(const_cast<char *>(varName), &this->data.rec_float);
+    RecGetRecordFloat((char *)varName, &this->data.rec_float);
     break;
   case RECD_STRING:
-    RecGetRecordString_Xmalloc(const_cast<char *>(varName), &this->data.rec_string);
+    RecGetRecordString_Xmalloc((char *)varName, &this->data.rec_string);
     break;
   case RECD_NULL:
   default:
@@ -779,7 +779,7 @@ varType(const char *varName)
   RecDataT data_type;
   int err;
 
-  err = RecGetRecordDataType(const_cast<char *>(varName), &data_type);
+  err = RecGetRecordDataType((char *)varName, &data_type);
 
   if (err == REC_ERR_FAIL) {
     return RECD_NULL;
@@ -834,7 +834,7 @@ substituteUnsafeChars(char *buffer)
       subStr[0] = *(++read);
       subStr[1] = *(++read);
       charVal   = strtol(subStr, (char **)nullptr, 16);
-      *write    = static_cast<char>(charVal);
+      *write    = (char)charVal;
       read++;
       write++;
       numSub++;
@@ -959,7 +959,7 @@ appendDefaultDomain(char *hostname, int bufLength)
 
   if (strchr(hostname, '.') == nullptr) {
     if (_res.defdname[0] != '\0') {
-      if (bufLength - 2 >= static_cast<int>(strlen(hostname) + strlen(_res.defdname))) {
+      if (bufLength - 2 >= (int)(strlen(hostname) + strlen(_res.defdname))) {
         ink_strlcat(hostname, ".", bufLength);
         ink_strlcat(hostname, _res.defdname, bufLength);
       } else {
@@ -983,10 +983,10 @@ recordValidityCheck(const char *varName, const char *value)
   RecCheckT check_t;
   char *pattern;
 
-  if (RecGetRecordCheckType(const_cast<char *>(varName), &check_t) != REC_ERR_OKAY) {
+  if (RecGetRecordCheckType((char *)varName, &check_t) != REC_ERR_OKAY) {
     return false;
   }
-  if (RecGetRecordCheckExpr(const_cast<char *>(varName), &pattern) != REC_ERR_OKAY) {
+  if (RecGetRecordCheckExpr((char *)varName, &pattern) != REC_ERR_OKAY) {
     return false;
   }
 
@@ -1040,7 +1040,7 @@ recordRegexCheck(const char *pattern, const char *value)
 bool
 recordRangeCheck(const char *pattern, const char *value)
 {
-  char *p = const_cast<char *>(pattern);
+  char *p = (char *)pattern;
   Tokenizer dashTok("-");
 
   if (recordRegexCheck("^[0-9]+$", value)) {
@@ -1074,8 +1074,7 @@ recordIPCheck(const char *pattern, const char *value)
 
   check = true;
   if (recordRegexCheck(range_pattern, pattern) && recordRegexCheck(ip_pattern, value)) {
-    if (dotTok1.Initialize(const_cast<char *>(pattern), COPY_TOKS) == 4 &&
-        dotTok2.Initialize(const_cast<char *>(value), COPY_TOKS) == 4) {
+    if (dotTok1.Initialize((char *)pattern, COPY_TOKS) == 4 && dotTok2.Initialize((char *)value, COPY_TOKS) == 4) {
       for (int i = 0; i < 4 && check; i++) {
         if (!recordRangeCheck(dotTok1[i], dotTok2[i])) {
           check = false;
@@ -1096,7 +1095,7 @@ recordRestartCheck(const char *varName)
 {
   RecUpdateT update_t;
 
-  if (RecGetRecordUpdateType(const_cast<char *>(varName), &update_t) != REC_ERR_OKAY) {
+  if (RecGetRecordUpdateType((char *)varName, &update_t) != REC_ERR_OKAY) {
     return false;
   }
 

--- a/mgmt/api/APITestCliRemote.cc
+++ b/mgmt/api/APITestCliRemote.cc
@@ -512,19 +512,19 @@ test_record_get_mlt()
   rec_list  = TSListCreate();
 
   const size_t v1_size = (sizeof(char) * (strlen("proxy.config.proxy_name") + 1));
-  v1                   = static_cast<char *>(TSmalloc(v1_size));
+  v1                   = (char *)TSmalloc(v1_size);
   ink_strlcpy(v1, "proxy.config.proxy_name", v1_size);
   const size_t v2_size = (sizeof(char) * (strlen("proxy.config.bin_path") + 1));
-  v2                   = static_cast<char *>(TSmalloc(v2_size));
+  v2                   = (char *)TSmalloc(v2_size);
   ink_strlcpy(v2, "proxy.config.bin_path", v2_size);
   const size_t v3_size = (sizeof(char) * (strlen("proxy.config.manager_binary") + 1));
-  v3                   = static_cast<char *>(TSmalloc(v3_size));
+  v3                   = (char *)TSmalloc(v3_size);
   ink_strlcpy(v3, "proxy.config.manager_binary", v3_size);
   const size_t v6_size = (sizeof(char) * (strlen("proxy.config.env_prep") + 1));
-  v6                   = static_cast<char *>(TSmalloc(v6_size));
+  v6                   = (char *)TSmalloc(v6_size);
   ink_strlcpy(v6, "proxy.config.env_prep", v6_size);
   const size_t v7_size = (sizeof(char) * (strlen("proxy.config.cop.core_signal") + 1));
-  v7                   = static_cast<char *>(TSmalloc(v7_size));
+  v7                   = (char *)TSmalloc(v7_size);
   ink_strlcpy(v7, "proxy.config.cop.core_signal", v7_size);
 
   // add the names to the get_list
@@ -544,7 +544,7 @@ test_record_get_mlt()
   }
 
   for (i = 0; i < num; i++) {
-    TSRecordEle *rec_ele = static_cast<TSRecordEle *>(TSListDequeue(rec_list));
+    TSRecordEle *rec_ele = (TSRecordEle *)TSListDequeue(rec_list);
     if (!rec_ele) {
       printf("ERROR\n");
       break;
@@ -612,7 +612,7 @@ test_record_set_mlt()
   // cleanup: need to iterate through list and delete each ele
   int count = TSListLen(list);
   for (int i = 0; i < count; i++) {
-    TSRecordEle *ele = static_cast<TSRecordEle *>(TSListDequeue(list));
+    TSRecordEle *ele = (TSRecordEle *)TSListDequeue(list);
     TSRecordEleDestroy(ele);
   }
   TSListDestroy(list);
@@ -731,7 +731,7 @@ print_active_events()
   } else { // successful get
     count = TSListLen(events);
     for (i = 0; i < count; i++) {
-      name = static_cast<char *>(TSListDequeue(events));
+      name = (char *)TSListDequeue(events);
       printf("\t%s\n", name);
       TSfree(name);
     }

--- a/mgmt/api/CoreAPI.cc
+++ b/mgmt/api/CoreAPI.cc
@@ -220,7 +220,7 @@ threads_for_process(pid_t proc)
   char path[64];
   threadlist threads;
 
-  if (snprintf(path, sizeof(path), "/proc/%ld/task", static_cast<long>(proc)) >= static_cast<int>(sizeof(path))) {
+  if (snprintf(path, sizeof(path), "/proc/%ld/task", (long)proc) >= (int)sizeof(path)) {
     goto done;
   }
 
@@ -304,10 +304,10 @@ backtrace_for_thread(pid_t threadid, TextBuffer &text)
     if (unw_get_proc_name(&cursor, buf, sizeof(buf), &offset) == 0) {
       int status;
       char *name = abi::__cxa_demangle(buf, nullptr, nullptr, &status);
-      text.format("%-4u 0x%016llx %s + %p\n", level, static_cast<unsigned long long>(ip), name ? name : buf, (void *)offset);
+      text.format("%-4u 0x%016llx %s + %p\n", level, (unsigned long long)ip, name ? name : buf, (void *)offset);
       free(name);
     } else {
-      text.format("%-4u 0x%016llx 0x0 + %p\n", level, static_cast<unsigned long long>(ip), (void *)offset);
+      text.format("%-4u 0x%016llx 0x0 + %p\n", level, (unsigned long long)ip, (void *)offset);
     }
 
     ++level;
@@ -346,14 +346,14 @@ ServerBacktrace(unsigned /* options */, char **trace)
     ats_scoped_fd fd;
     char threadname[128];
 
-    snprintf(threadname, sizeof(threadname), "/proc/%ld/comm", static_cast<long>(threadid));
+    snprintf(threadname, sizeof(threadname), "/proc/%ld/comm", (long)threadid);
     fd = open(threadname, O_RDONLY);
     if (fd >= 0) {
-      text.format("Thread %ld, ", static_cast<long>(threadid));
+      text.format("Thread %ld, ", (long)threadid);
       text.readFromFD(fd);
       text.chomp();
     } else {
-      text.format("Thread %ld", static_cast<long>(threadid));
+      text.format("Thread %ld", (long)threadid);
     }
 
     text.format(":\n");
@@ -518,7 +518,7 @@ MgmtRecordGet(const char *rec_name, TSRecordEle *rec_ele)
     if (!varCounterFromName(rec_name, &(counter_val))) {
       return TS_ERR_FAIL;
     }
-    rec_ele->valueT.counter_val = static_cast<TSCounter>(counter_val);
+    rec_ele->valueT.counter_val = (TSCounter)counter_val;
 
     Debug("RecOp", "[MgmtRecordGet] Get Counter Var %s = %" PRId64 "", rec_ele->rec_name, rec_ele->valueT.counter_val);
     break;
@@ -528,7 +528,7 @@ MgmtRecordGet(const char *rec_name, TSRecordEle *rec_ele)
     if (!varIntFromName(rec_name, &(int_val))) {
       return TS_ERR_FAIL;
     }
-    rec_ele->valueT.int_val = static_cast<TSInt>(int_val);
+    rec_ele->valueT.int_val = (TSInt)int_val;
 
     Debug("RecOp", "[MgmtRecordGet] Get Int Var %s = %" PRId64 "", rec_ele->rec_name, rec_ele->valueT.int_val);
     break;

--- a/mgmt/api/CoreAPIRemote.cc
+++ b/mgmt/api/CoreAPIRemote.cc
@@ -107,7 +107,7 @@ send_and_parse_list(OpType op, LLQ *list)
   }
 
   if (err != TS_ERR_OKAY) {
-    ret = static_cast<TSMgmtError>(err);
+    ret = (TSMgmtError)err;
     goto done;
   }
 
@@ -176,10 +176,10 @@ mgmt_record_set(const char *rec_name, const char *rec_val, TSActionNeedT *action
   }
 
   if (err != TS_ERR_OKAY) {
-    return static_cast<TSMgmtError>(err);
+    return (TSMgmtError)err;
   }
 
-  *action_need = static_cast<TSActionNeedT>(action);
+  *action_need = (TSActionNeedT)action;
   return TS_ERR_OKAY;
 }
 
@@ -321,7 +321,7 @@ ProxyStateGet()
     return TS_PROXY_UNDEFINED;
   }
 
-  return static_cast<TSProxyStateT>(state);
+  return (TSProxyStateT)state;
 }
 
 TSMgmtError
@@ -363,7 +363,7 @@ ServerBacktrace(unsigned options, char **trace)
   }
 
   if (err != TS_ERR_OKAY) {
-    ret = static_cast<TSMgmtError>(err);
+    ret = (TSMgmtError)err;
     goto fail;
   }
 
@@ -512,15 +512,15 @@ mgmt_record_convert_value(TSRecordT rec_type, const MgmtMarshallData &data, TSRe
     switch (rec_type) {
     case TS_REC_INT:
       ink_assert(data.len == sizeof(TSInt));
-      value.int_val = *static_cast<TSInt *>(data.ptr);
+      value.int_val = *(TSInt *)data.ptr;
       break;
     case TS_REC_COUNTER:
       ink_assert(data.len == sizeof(TSCounter));
-      value.counter_val = *static_cast<TSCounter *>(data.ptr);
+      value.counter_val = *(TSCounter *)data.ptr;
       break;
     case TS_REC_FLOAT:
       ink_assert(data.len == sizeof(TSFloat));
-      value.float_val = *static_cast<TSFloat *>(data.ptr);
+      value.float_val = *(TSFloat *)data.ptr;
       break;
     case TS_REC_STRING:
       ink_assert(data.len == strlen((char *)data.ptr) + 1);
@@ -559,12 +559,12 @@ mgmt_record_get_reply(OpType op, TSRecordEle *rec_ele)
   }
 
   if (err != TS_ERR_OKAY) {
-    ret = static_cast<TSMgmtError>(err);
+    ret = (TSMgmtError)err;
     goto done;
   }
 
-  rec_ele->rec_class = static_cast<TSInt>(rclass);
-  rec_ele->rec_type  = static_cast<TSRecordT>(type);
+  rec_ele->rec_class = (TSInt)rclass;
+  rec_ele->rec_type  = (TSRecordT)type;
   rec_ele->rec_name  = ats_strdup(name);
   mgmt_record_convert_value(rec_ele->rec_type, value, rec_ele->valueT);
 
@@ -612,14 +612,14 @@ mgmt_record_describe_reply(TSConfigRecordDescription *val)
   }
 
   if (err != TS_ERR_OKAY) {
-    ret = static_cast<TSMgmtError>(err);
+    ret = (TSMgmtError)err;
     goto done;
   }
 
   // Everything is cool, populate the description ...
   val->rec_name       = ats_strdup(name);
   val->rec_checkexpr  = ats_strdup(expr);
-  val->rec_type       = static_cast<TSRecordT>(rtype);
+  val->rec_type       = (TSRecordT)rtype;
   val->rec_class      = rclass;
   val->rec_version    = version;
   val->rec_rsb        = rsb;
@@ -700,14 +700,14 @@ MgmtConfigRecordDescribeMatching(const char *rec_name, unsigned options, TSList 
       break;
     }
 
-    enqueue(static_cast<LLQ *>(rec_vals), val);
+    enqueue((LLQ *)rec_vals, val);
   }
 
   return TS_ERR_OKAY;
 
 fail:
-  while (!queue_is_empty(static_cast<LLQ *>(rec_vals))) {
-    TSConfigRecordDescription *val = static_cast<TSConfigRecordDescription *>(dequeue(static_cast<LLQ *>(rec_vals)));
+  while (!queue_is_empty((LLQ *)rec_vals)) {
+    TSConfigRecordDescription *val = (TSConfigRecordDescription *)dequeue((LLQ *)rec_vals);
     TSConfigRecordDescriptionDestroy(val);
   }
 
@@ -765,14 +765,14 @@ MgmtRecordGetMatching(const char *regex, TSList rec_vals)
       break;
     }
 
-    enqueue(static_cast<LLQ *>(rec_vals), rec_ele);
+    enqueue((LLQ *)rec_vals, rec_ele);
   }
 
   return TS_ERR_OKAY;
 
 fail:
-  while (!queue_is_empty(static_cast<LLQ *>(rec_vals))) {
-    rec_ele = static_cast<TSRecordEle *>(dequeue(static_cast<LLQ *>(rec_vals)));
+  while (!queue_is_empty((LLQ *)rec_vals)) {
+    rec_ele = (TSRecordEle *)dequeue((LLQ *)rec_vals);
     TSRecordEleDestroy(rec_ele);
   }
 
@@ -949,7 +949,7 @@ EventIsActive(const char *event_name, bool *is_current)
   }
 
   *is_current = (bval != 0);
-  return static_cast<TSMgmtError>(err);
+  return (TSMgmtError)err;
 }
 
 /*-------------------------------------------------------------------------

--- a/mgmt/api/CoreAPIShared.cc
+++ b/mgmt/api/CoreAPIShared.cc
@@ -221,10 +221,10 @@ connectDirect(const char *host, int port, uint64_t /* timeout ATS_UNUSED */)
   if (!pHostent) {
     goto error;
   }
-  memcpy(reinterpret_cast<caddr_t>(&(name.sin_addr)), pHostent->h_addr, pHostent->h_length);
+  memcpy((caddr_t) & (name.sin_addr), pHostent->h_addr, pHostent->h_length);
 
   do {
-    err = connect(sock, reinterpret_cast<struct sockaddr *>(&name), sizeof(name));
+    err = connect(sock, (struct sockaddr *)&name, sizeof(name));
   } while ((err < 0) && ((errno == EINTR) || (errno == EAGAIN)));
 
   if ((err < 0) && (errno != EINPROGRESS)) {

--- a/mgmt/api/EventCallback.cc
+++ b/mgmt/api/EventCallback.cc
@@ -46,7 +46,7 @@
 EventCallbackT *
 create_event_callback(TSEventSignalFunc func, void *data)
 {
-  EventCallbackT *event_cb = static_cast<EventCallbackT *>(ats_malloc(sizeof(EventCallbackT)));
+  EventCallbackT *event_cb = (EventCallbackT *)ats_malloc(sizeof(EventCallbackT));
 
   event_cb->func = func;
   event_cb->data = data;
@@ -81,7 +81,7 @@ delete_event_callback(EventCallbackT *event_cb)
 CallbackTable *
 create_callback_table(const char *)
 {
-  CallbackTable *cb_table = static_cast<CallbackTable *>(ats_malloc(sizeof(CallbackTable)));
+  CallbackTable *cb_table = (CallbackTable *)ats_malloc(sizeof(CallbackTable));
 
   for (auto &i : cb_table->event_callback_l) {
     i = nullptr;
@@ -114,7 +114,7 @@ delete_callback_table(CallbackTable *cb_table)
     if (i) {
       // remove and delete each EventCallbackT for that event
       while (!queue_is_empty(i)) {
-        event_cb = static_cast<EventCallbackT *>(dequeue(i));
+        event_cb = (EventCallbackT *)dequeue(i);
         delete_event_callback(event_cb);
       }
 
@@ -268,7 +268,7 @@ cb_table_unregister(CallbackTable *cb_table, const char *event_name, TSEventSign
       // func == NULL means unregister all functions associated with alarm
       if (func == nullptr) {
         while (!queue_is_empty(i)) {
-          event_cb = static_cast<EventCallbackT *>(dequeue(i));
+          event_cb = (EventCallbackT *)dequeue(i);
           delete_event_callback(event_cb);
         }
         // clean up queue and set to NULL
@@ -280,7 +280,7 @@ cb_table_unregister(CallbackTable *cb_table, const char *event_name, TSEventSign
         queue_depth = queue_len(i);
         // remove this function
         for (int j = 0; j < queue_depth; j++) {
-          event_cb = static_cast<EventCallbackT *>(dequeue(i));
+          event_cb = (EventCallbackT *)dequeue(i);
           cb_fun   = event_cb->func;
 
           // the pointers are the same so don't enqueue the fn back on
@@ -310,7 +310,7 @@ cb_table_unregister(CallbackTable *cb_table, const char *event_name, TSEventSign
         // func == NULL means unregister all functions associated with alarm
         if (func == nullptr) {
           while (!queue_is_empty(cb_table->event_callback_l[id])) {
-            event_cb = static_cast<EventCallbackT *>(dequeue(cb_table->event_callback_l[id]));
+            event_cb = (EventCallbackT *)dequeue(cb_table->event_callback_l[id]);
             delete_event_callback(event_cb);
           }
 
@@ -320,7 +320,7 @@ cb_table_unregister(CallbackTable *cb_table, const char *event_name, TSEventSign
         } else {
           // remove this function
           for (int j = 0; j < queue_depth; j++) {
-            event_cb = static_cast<EventCallbackT *>(dequeue(cb_table->event_callback_l[id]));
+            event_cb = (EventCallbackT *)dequeue(cb_table->event_callback_l[id]);
             cb_fun   = event_cb->func;
 
             // the pointers are the same

--- a/mgmt/api/EventControlMain.cc
+++ b/mgmt/api/EventControlMain.cc
@@ -58,14 +58,14 @@ static TSMgmtError handle_event_message(EventClientT *client, void *req, size_t 
 EventClientT *
 new_event_client()
 {
-  EventClientT *ele = static_cast<EventClientT *>(ats_malloc(sizeof(EventClientT)));
+  EventClientT *ele = (EventClientT *)ats_malloc(sizeof(EventClientT));
 
   // now set the alarms registered section
   for (bool &i : ele->events_registered) {
     i = false;
   }
 
-  ele->adr = static_cast<struct sockaddr *>(ats_malloc(sizeof(struct sockaddr)));
+  ele->adr = (struct sockaddr *)ats_malloc(sizeof(struct sockaddr));
   return ele;
 }
 
@@ -178,7 +178,7 @@ delete_event_queue(LLQ *q)
   }
 
   while (!queue_is_empty(q)) {
-    TSMgmtEvent *ele = static_cast<TSMgmtEvent *>(dequeue(q));
+    TSMgmtEvent *ele = (TSMgmtEvent *)dequeue(q);
     ats_free(ele);
   }
 
@@ -237,7 +237,7 @@ event_callback_main(void *arg)
   int *socket_fd;
   int con_socket_fd; // main socket for listening to new connections
 
-  socket_fd     = static_cast<int *>(arg);
+  socket_fd     = (int *)arg;
   con_socket_fd = *socket_fd; // the socket for event callbacks
 
   Debug("event", "[event_callback_main] listen on socket = %d", con_socket_fd);
@@ -350,9 +350,9 @@ event_callback_main(void *arg)
     }
     // iterate through each event in mgmt_events
     while (!queue_is_empty(mgmt_events)) {
-      ink_mutex_acquire(&mgmt_events_lock);                     // acquire lock
-      event = static_cast<TSMgmtEvent *>(dequeue(mgmt_events)); // get what we want
-      ink_mutex_release(&mgmt_events_lock);                     // release lock
+      ink_mutex_acquire(&mgmt_events_lock);        // acquire lock
+      event = (TSMgmtEvent *)dequeue(mgmt_events); // get what we want
+      ink_mutex_release(&mgmt_events_lock);        // release lock
 
       if (!event) {
         continue;
@@ -544,6 +544,6 @@ handle_event_message(EventClientT *client, void *req, size_t reqlen)
   return handlers[static_cast<unsigned>(optype)](client, req, reqlen);
 
 fail:
-  mgmt_elog(0, "%s: missing handler for type %d event message\n", __func__, static_cast<int>(optype));
+  mgmt_elog(0, "%s: missing handler for type %d event message\n", __func__, (int)optype);
   return TS_ERR_PARAMS;
 }

--- a/mgmt/api/INKMgmtAPI.cc
+++ b/mgmt/api/INKMgmtAPI.cc
@@ -88,7 +88,7 @@ TSListDestroy(TSList l)
     return;
   }
 
-  delete_queue(static_cast<LLQ *>(l));
+  delete_queue((LLQ *)l);
   return;
 }
 
@@ -102,7 +102,7 @@ TSListEnqueue(TSList l, void *data)
     return TS_ERR_PARAMS;
   }
 
-  ret = enqueue(static_cast<LLQ *>(l), data); /* returns TRUE=1 or FALSE=0 */
+  ret = enqueue((LLQ *)l, data); /* returns TRUE=1 or FALSE=0 */
   if (ret == 0) {
     return TS_ERR_FAIL;
   } else {
@@ -114,11 +114,11 @@ tsapi void *
 TSListDequeue(TSList l)
 {
   ink_assert(l);
-  if (!l || queue_is_empty(static_cast<LLQ *>(l))) {
+  if (!l || queue_is_empty((LLQ *)l)) {
     return nullptr;
   }
 
-  return dequeue(static_cast<LLQ *>(l));
+  return dequeue((LLQ *)l);
 }
 
 tsapi bool
@@ -129,7 +129,7 @@ TSListIsEmpty(TSList l)
     return true; // list doesn't exist, so it's empty
   }
 
-  return queue_is_empty(static_cast<LLQ *>(l));
+  return queue_is_empty((LLQ *)l);
 }
 
 tsapi int
@@ -140,7 +140,7 @@ TSListLen(TSList l)
     return -1;
   }
 
-  return queue_len(static_cast<LLQ *>(l));
+  return queue_len((LLQ *)l);
 }
 
 tsapi bool
@@ -152,13 +152,13 @@ TSListIsValid(TSList l)
     return false;
   }
 
-  len = queue_len(static_cast<LLQ *>(l));
+  len = queue_len((LLQ *)l);
   for (i = 0; i < len; i++) {
-    void *ele = dequeue(static_cast<LLQ *>(l));
+    void *ele = (void *)dequeue((LLQ *)l);
     if (!ele) {
       return false;
     }
-    enqueue(static_cast<LLQ *>(l), ele);
+    enqueue((LLQ *)l, ele);
   }
   return true;
 }
@@ -179,12 +179,12 @@ TSStringListDestroy(TSStringList strl)
   }
 
   /* dequeue each element and free it */
-  while (!queue_is_empty(static_cast<LLQ *>(strl))) {
-    char *str = static_cast<char *>(dequeue(static_cast<LLQ *>(strl)));
+  while (!queue_is_empty((LLQ *)strl)) {
+    char *str = (char *)dequeue((LLQ *)strl);
     ats_free(str);
   }
 
-  delete_queue(static_cast<LLQ *>(strl));
+  delete_queue((LLQ *)strl);
 }
 
 tsapi TSMgmtError
@@ -197,7 +197,7 @@ TSStringListEnqueue(TSStringList strl, char *str)
     return TS_ERR_PARAMS;
   }
 
-  ret = enqueue(static_cast<LLQ *>(strl), str); /* returns TRUE=1 or FALSE=0 */
+  ret = enqueue((LLQ *)strl, str); /* returns TRUE=1 or FALSE=0 */
   if (ret == 0) {
     return TS_ERR_FAIL;
   } else {
@@ -209,11 +209,11 @@ tsapi char *
 TSStringListDequeue(TSStringList strl)
 {
   ink_assert(strl);
-  if (!strl || queue_is_empty(static_cast<LLQ *>(strl))) {
+  if (!strl || queue_is_empty((LLQ *)strl)) {
     return nullptr;
   }
 
-  return static_cast<char *>(dequeue(static_cast<LLQ *>(strl)));
+  return (char *)dequeue((LLQ *)strl);
 }
 
 tsapi bool
@@ -224,7 +224,7 @@ TSStringListIsEmpty(TSStringList strl)
     return true;
   }
 
-  return queue_is_empty(static_cast<LLQ *>(strl));
+  return queue_is_empty((LLQ *)strl);
 }
 
 tsapi int
@@ -235,7 +235,7 @@ TSStringListLen(TSStringList strl)
     return -1;
   }
 
-  return queue_len(static_cast<LLQ *>(strl));
+  return queue_len((LLQ *)strl);
 }
 
 // returns false if any element is NULL string
@@ -248,13 +248,13 @@ TSStringListIsValid(TSStringList strl)
     return false;
   }
 
-  len = queue_len(static_cast<LLQ *>(strl));
+  len = queue_len((LLQ *)strl);
   for (i = 0; i < len; i++) {
-    char *str = static_cast<char *>(dequeue(static_cast<LLQ *>(strl)));
+    char *str = (char *)dequeue((LLQ *)strl);
     if (!str) {
       return false;
     }
-    enqueue(static_cast<LLQ *>(strl), str);
+    enqueue((LLQ *)strl, str);
   }
   return true;
 }
@@ -275,12 +275,12 @@ TSIntListDestroy(TSIntList intl)
   }
 
   /* dequeue each element and free it */
-  while (!queue_is_empty(static_cast<LLQ *>(intl))) {
-    int *iPtr = static_cast<int *>(dequeue(static_cast<LLQ *>(intl)));
+  while (!queue_is_empty((LLQ *)intl)) {
+    int *iPtr = (int *)dequeue((LLQ *)intl);
     ats_free(iPtr);
   }
 
-  delete_queue(static_cast<LLQ *>(intl));
+  delete_queue((LLQ *)intl);
   return;
 }
 
@@ -294,7 +294,7 @@ TSIntListEnqueue(TSIntList intl, int *elem)
     return TS_ERR_PARAMS;
   }
 
-  ret = enqueue(static_cast<LLQ *>(intl), elem); /* returns TRUE=1 or FALSE=0 */
+  ret = enqueue((LLQ *)intl, elem); /* returns TRUE=1 or FALSE=0 */
   if (ret == 0) {
     return TS_ERR_FAIL;
   } else {
@@ -306,11 +306,11 @@ tsapi int *
 TSIntListDequeue(TSIntList intl)
 {
   ink_assert(intl);
-  if (!intl || queue_is_empty(static_cast<LLQ *>(intl))) {
+  if (!intl || queue_is_empty((LLQ *)intl)) {
     return nullptr;
   }
 
-  return static_cast<int *>(dequeue(static_cast<LLQ *>(intl)));
+  return (int *)dequeue((LLQ *)intl);
 }
 
 tsapi bool
@@ -321,7 +321,7 @@ TSIntListIsEmpty(TSIntList intl)
     return true;
   }
 
-  return queue_is_empty(static_cast<LLQ *>(intl));
+  return queue_is_empty((LLQ *)intl);
 }
 
 tsapi int
@@ -332,7 +332,7 @@ TSIntListLen(TSIntList intl)
     return -1;
   }
 
-  return queue_len(static_cast<LLQ *>(intl));
+  return queue_len((LLQ *)intl);
 }
 
 tsapi bool
@@ -342,15 +342,15 @@ TSIntListIsValid(TSIntList intl, int min, int max)
     return false;
   }
 
-  for (unsigned long i = 0; i < queue_len(static_cast<LLQ *>(intl)); i++) {
-    int *item = static_cast<int *>(dequeue(static_cast<LLQ *>(intl)));
+  for (unsigned long i = 0; i < queue_len((LLQ *)intl); i++) {
+    int *item = (int *)dequeue((LLQ *)intl);
     if (*item < min) {
       return false;
     }
     if (*item > max) {
       return false;
     }
-    enqueue(static_cast<LLQ *>(intl), item);
+    enqueue((LLQ *)intl, item);
   }
   return true;
 }
@@ -359,7 +359,7 @@ TSIntListIsValid(TSIntList intl, int min, int max)
 tsapi TSMgmtEvent *
 TSEventCreate(void)
 {
-  TSMgmtEvent *event = static_cast<TSMgmtEvent *>(ats_malloc(sizeof(TSMgmtEvent)));
+  TSMgmtEvent *event = (TSMgmtEvent *)ats_malloc(sizeof(TSMgmtEvent));
 
   event->id          = -1;
   event->name        = nullptr;
@@ -383,7 +383,7 @@ TSEventDestroy(TSMgmtEvent *event)
 tsapi TSRecordEle *
 TSRecordEleCreate(void)
 {
-  TSRecordEle *ele = static_cast<TSRecordEle *>(ats_malloc(sizeof(TSRecordEle)));
+  TSRecordEle *ele = (TSRecordEle *)ats_malloc(sizeof(TSRecordEle));
 
   ele->rec_name = nullptr;
   ele->rec_type = TS_REC_UNDEFINED;
@@ -535,9 +535,9 @@ TSRecordGetMlt(TSStringList rec_names, TSList rec_vals)
     return TS_ERR_PARAMS;
   }
 
-  num_recs = queue_len(static_cast<LLQ *>(rec_names));
+  num_recs = queue_len((LLQ *)rec_names);
   for (i = 0; i < num_recs; i++) {
-    char *rec_name = static_cast<char *>(dequeue(static_cast<LLQ *>(rec_names))); // remove name from list
+    char *rec_name = (char *)dequeue((LLQ *)rec_names); // remove name from list
     if (!rec_name) {
       return TS_ERR_PARAMS; // NULL is invalid record name
     }
@@ -545,20 +545,20 @@ TSRecordGetMlt(TSStringList rec_names, TSList rec_vals)
     TSRecordEle *ele = TSRecordEleCreate();
 
     ret = MgmtRecordGet(rec_name, ele);
-    enqueue(static_cast<LLQ *>(rec_names), rec_name); // return name to list
+    enqueue((LLQ *)rec_names, rec_name); // return name to list
 
     if (ret != TS_ERR_OKAY) { // RecordGet failed
       // need to free all the ele's allocated by MgmtRecordGet so far
       TSRecordEleDestroy(ele);
       for (j = 0; j < i; j++) {
-        ele = static_cast<TSRecordEle *>(dequeue(static_cast<LLQ *>(rec_vals)));
+        ele = (TSRecordEle *)dequeue((LLQ *)rec_vals);
         if (ele) {
           TSRecordEleDestroy(ele);
         }
       }
       return ret;
     }
-    enqueue(static_cast<LLQ *>(rec_vals), ele); // all is good; add ele to end of list
+    enqueue((LLQ *)rec_vals, ele); // all is good; add ele to end of list
   }
 
   return TS_ERR_OKAY;
@@ -631,10 +631,10 @@ TSRecordSetMlt(TSList rec_list, TSActionNeedT *action_need)
     return TS_ERR_PARAMS;
   }
 
-  num_recs = queue_len(static_cast<LLQ *>(rec_list));
+  num_recs = queue_len((LLQ *)rec_list);
 
   for (i = 0; i < num_recs; i++) {
-    TSRecordEle *ele = static_cast<TSRecordEle *>(dequeue(static_cast<LLQ *>(rec_list)));
+    TSRecordEle *ele = (TSRecordEle *)dequeue((LLQ *)rec_list);
     if (ele) {
       switch (ele->rec_type) {
       case TS_REC_INT:
@@ -664,7 +664,7 @@ TSRecordSetMlt(TSList rec_list, TSActionNeedT *action_need)
         top_action_req = *action_need;
       }
     }
-    enqueue(static_cast<LLQ *>(rec_list), ele);
+    enqueue((LLQ *)rec_list, ele);
   }
 
   // set the action_need to be the most sever action needed of all the "set" calls
@@ -987,12 +987,12 @@ TSReadFromUrlEx(const char *url, char **header, int *headerSize, char **body, in
 
   /* sending the HTTP request via the established socket */
   snprintf(request, BUFSIZE, "http://%s:%d/%s", httpHost, httpPort, httpPath);
-  if ((status = sendHTTPRequest(hFD, request, static_cast<uint64_t>(timeout))) != TS_ERR_OKAY) {
+  if ((status = sendHTTPRequest(hFD, request, (uint64_t)timeout)) != TS_ERR_OKAY) {
     goto END;
   }
 
   memset(buffer, 0, bufsize); /* empty the buffer */
-  if ((status = readHTTPResponse(hFD, buffer, bufsize, static_cast<uint64_t>(timeout))) != TS_ERR_OKAY) {
+  if ((status = readHTTPResponse(hFD, buffer, bufsize, (uint64_t)timeout)) != TS_ERR_OKAY) {
     goto END;
   }
 
@@ -1037,12 +1037,12 @@ TSLookupFromCacheUrl(TSString url, TSString *info)
     goto END;
   }
   snprintf(request, BUFSIZE, "http://{cache}/lookup_url?url=%s", url);
-  if ((err = sendHTTPRequest(fd, request, static_cast<uint64_t>(timeout))) != TS_ERR_OKAY) {
+  if ((err = sendHTTPRequest(fd, request, (uint64_t)timeout)) != TS_ERR_OKAY) {
     goto END;
   }
 
   memset(response, 0, URL_BUFSIZE);
-  if ((err = readHTTPResponse(fd, response, URL_BUFSIZE, static_cast<uint64_t>(timeout))) != TS_ERR_OKAY) {
+  if ((err = readHTTPResponse(fd, response, URL_BUFSIZE, (uint64_t)timeout)) != TS_ERR_OKAY) {
     goto END;
   }
 
@@ -1079,12 +1079,12 @@ TSLookupFromCacheUrlRegex(TSString url_regex, TSString *list)
     goto END;
   }
   snprintf(request, BUFSIZE, "http://{cache}/lookup_regex?url=%s", url_regex);
-  if ((err = sendHTTPRequest(fd, request, static_cast<uint64_t>(timeout))) != TS_ERR_OKAY) {
+  if ((err = sendHTTPRequest(fd, request, (uint64_t)timeout)) != TS_ERR_OKAY) {
     goto END;
   }
 
   memset(response, 0, URL_BUFSIZE);
-  if ((err = readHTTPResponse(fd, response, URL_BUFSIZE, static_cast<uint64_t>(timeout))) != TS_ERR_OKAY) {
+  if ((err = readHTTPResponse(fd, response, URL_BUFSIZE, (uint64_t)timeout)) != TS_ERR_OKAY) {
     goto END;
   }
 
@@ -1120,12 +1120,12 @@ TSDeleteFromCacheUrl(TSString url, TSString *info)
     goto END;
   }
   snprintf(request, BUFSIZE, "http://{cache}/delete_url?url=%s", url);
-  if ((err = sendHTTPRequest(fd, request, static_cast<uint64_t>(timeout))) != TS_ERR_OKAY) {
+  if ((err = sendHTTPRequest(fd, request, (uint64_t)timeout)) != TS_ERR_OKAY) {
     goto END;
   }
 
   memset(response, 0, URL_BUFSIZE);
-  if ((err = readHTTPResponse(fd, response, URL_BUFSIZE, static_cast<uint64_t>(timeout))) != TS_ERR_OKAY) {
+  if ((err = readHTTPResponse(fd, response, URL_BUFSIZE, (uint64_t)timeout)) != TS_ERR_OKAY) {
     goto END;
   }
 
@@ -1162,12 +1162,12 @@ TSDeleteFromCacheUrlRegex(TSString url_regex, TSString *list)
     goto END;
   }
   snprintf(request, BUFSIZE, "http://{cache}/delete_regex?url=%s", url_regex);
-  if ((err = sendHTTPRequest(fd, request, static_cast<uint64_t>(timeout))) != TS_ERR_OKAY) {
+  if ((err = sendHTTPRequest(fd, request, (uint64_t)timeout)) != TS_ERR_OKAY) {
     goto END;
   }
 
   memset(response, 0, URL_BUFSIZE);
-  if ((err = readHTTPResponse(fd, response, URL_BUFSIZE, static_cast<uint64_t>(timeout))) != TS_ERR_OKAY) {
+  if ((err = readHTTPResponse(fd, response, URL_BUFSIZE, (uint64_t)timeout)) != TS_ERR_OKAY) {
     goto END;
   }
 
@@ -1203,12 +1203,12 @@ TSInvalidateFromCacheUrlRegex(TSString url_regex, TSString *list)
     goto END;
   }
   snprintf(request, BUFSIZE, "http://{cache}/invalidate_regex?url=%s", url_regex);
-  if ((err = sendHTTPRequest(fd, request, static_cast<uint64_t>(timeout))) != TS_ERR_OKAY) {
+  if ((err = sendHTTPRequest(fd, request, (uint64_t)timeout)) != TS_ERR_OKAY) {
     goto END;
   }
 
   memset(response, 0, URL_BUFSIZE);
-  if ((err = readHTTPResponse(fd, response, URL_BUFSIZE, static_cast<uint64_t>(timeout))) != TS_ERR_OKAY) {
+  if ((err = readHTTPResponse(fd, response, URL_BUFSIZE, (uint64_t)timeout)) != TS_ERR_OKAY) {
     goto END;
   }
 
@@ -1243,7 +1243,7 @@ TSEventResolve(const char *event_name)
 tsapi TSMgmtError
 TSActiveEventGetMlt(TSList active_events)
 {
-  return ActiveEventGetMlt(static_cast<LLQ *>(active_events));
+  return ActiveEventGetMlt((LLQ *)active_events);
 }
 
 tsapi TSMgmtError
@@ -1267,7 +1267,7 @@ TSEventSignalCbUnregister(char *event_name, TSEventSignalFunc func)
 TSConfigRecordDescription *
 TSConfigRecordDescriptionCreate(void)
 {
-  TSConfigRecordDescription *val = static_cast<TSConfigRecordDescription *>(ats_malloc(sizeof(TSConfigRecordDescription)));
+  TSConfigRecordDescription *val = (TSConfigRecordDescription *)ats_malloc(sizeof(TSConfigRecordDescription));
 
   ink_zero(*val);
   val->rec_type = TS_REC_UNDEFINED;

--- a/mgmt/api/NetworkMessage.cc
+++ b/mgmt/api/NetworkMessage.cc
@@ -131,7 +131,7 @@ send_mgmt_request(const mgmt_message_sender &snd, OpType optype, ...)
   msglen = mgmt_message_length_v(cmd->fields, cmd->nfields, ap);
   va_end(ap);
 
-  msgbuf = static_cast<char *>(ats_malloc(msglen + 4));
+  msgbuf = (char *)ats_malloc(msglen + 4);
 
   // First marshall the total message length.
   mgmt_message_marshall((char *)msgbuf, msglen, lenfield, countof(lenfield), &msglen);
@@ -165,7 +165,7 @@ send_mgmt_request(int fd, OpType optype, ...)
 
   ink_assert(msglen >= 0);
 
-  req.ptr = static_cast<char *>(ats_malloc(msglen));
+  req.ptr = (char *)ats_malloc(msglen);
   req.len = msglen;
 
   // Marshall the message itself.
@@ -284,7 +284,7 @@ send_mgmt_response(int fd, OpType optype, ...)
 
   ink_assert(msglen >= 0);
 
-  reply.ptr = static_cast<char *>(ats_malloc(msglen));
+  reply.ptr = (char *)ats_malloc(msglen);
   reply.len = msglen;
 
   // Marshall the message itself.
@@ -368,5 +368,5 @@ extract_mgmt_request_optype(void *msg, size_t msglen)
     return OpType::UNDEFINED_OP;
   }
 
-  return static_cast<OpType>(optype);
+  return (OpType)optype;
 }

--- a/mgmt/api/NetworkUtilsRemote.cc
+++ b/mgmt/api/NetworkUtilsRemote.cc
@@ -137,7 +137,7 @@ ts_connect()
   sockaddr_len = sizeof(client_sock.sun_family) + strlen(client_sock.sun_path);
 #endif
   // connect call
-  if (connect(main_socket_fd, reinterpret_cast<struct sockaddr *>(&client_sock), sockaddr_len) < 0) {
+  if (connect(main_socket_fd, (struct sockaddr *)&client_sock, sockaddr_len) < 0) {
     close(main_socket_fd);
     main_socket_fd = -1;
     goto ERROR; // connection is down
@@ -160,7 +160,7 @@ ts_connect()
   sockaddr_len = sizeof(client_event_sock.sun_family) + strlen(client_event_sock.sun_path);
 #endif
   // connect call
-  if (connect(event_socket_fd, reinterpret_cast<struct sockaddr *>(&client_event_sock), sockaddr_len) < 0) {
+  if (connect(event_socket_fd, (struct sockaddr *)&client_event_sock, sockaddr_len) < 0) {
     close(event_socket_fd);
     close(main_socket_fd);
     event_socket_fd = -1;
@@ -336,7 +336,7 @@ socket_write_conn(int fd, const void *msg_buf, size_t bytes)
 
   // write until we fulfill the number
   while (byte_wrote < bytes) {
-    ssize_t ret = write(fd, static_cast<const char *>(msg_buf) + byte_wrote, bytes - byte_wrote);
+    ssize_t ret = write(fd, (const char *)msg_buf + byte_wrote, bytes - byte_wrote);
 
     if (ret == 0) {
       return TS_ERR_NET_EOF;
@@ -469,8 +469,8 @@ send_register_all_callbacks(int fd, CallbackTable *cb_table)
     // iterate through the LLQ and send request for each event
     for (int i = 0; i < num_events; i++) {
       OpType optype                 = OpType::EVENT_REG_CALLBACK;
-      MgmtMarshallInt event_id      = *static_cast<int *>(dequeue(events_with_cb));
-      MgmtMarshallString event_name = get_event_name(event_id);
+      MgmtMarshallInt event_id      = *(int *)dequeue(events_with_cb);
+      MgmtMarshallString event_name = (char *)get_event_name(event_id);
 
       if (event_name) {
         err = MGMTAPI_SEND_MESSAGE(fd, OpType::EVENT_REG_CALLBACK, &optype, &event_name);
@@ -524,7 +524,7 @@ send_unregister_all_callbacks(int fd, CallbackTable *cb_table)
     int num_events = queue_len(events_with_cb);
     // iterate through the LLQ and mark events that have a callback
     for (int i = 0; i < num_events; i++) {
-      int event_id           = *static_cast<int *>(dequeue(events_with_cb));
+      int event_id           = *(int *)dequeue(events_with_cb);
       reg_callback[event_id] = 1; // mark the event as having a callback
     }
     delete_queue(events_with_cb);
@@ -578,7 +578,7 @@ parse_generic_response(OpType optype, int fd)
     return err;
   }
 
-  return static_cast<TSMgmtError>(ival);
+  return (TSMgmtError)ival;
 }
 
 /**********************************************************************
@@ -605,7 +605,7 @@ event_poll_thread_main(void *arg)
 {
   int sock_fd;
 
-  sock_fd = *(static_cast<int *>(arg)); // should be same as event_socket_fd
+  sock_fd = *((int *)arg); // should be same as event_socket_fd
 
   // the sock_fd is going to be the one we listen for events on
   while (true) {
@@ -674,8 +674,8 @@ event_callback_thread(void *arg)
   EventCallbackT *event_cb;
   int index;
 
-  event_notice = static_cast<TSMgmtEvent *>(arg);
-  index        = event_notice->id;
+  event_notice = (TSMgmtEvent *)arg;
+  index        = (int)event_notice->id;
   LLQ *func_q; // list of callback functions need to call
 
   func_q = create_queue();
@@ -694,10 +694,10 @@ event_callback_thread(void *arg)
     int queue_depth = queue_len(remote_event_callbacks->event_callback_l[index]);
 
     for (int i = 0; i < queue_depth; i++) {
-      event_cb = static_cast<EventCallbackT *>(dequeue(remote_event_callbacks->event_callback_l[index]));
+      event_cb = (EventCallbackT *)dequeue(remote_event_callbacks->event_callback_l[index]);
       cb       = event_cb->func;
       enqueue(remote_event_callbacks->event_callback_l[index], event_cb);
-      enqueue(func_q, reinterpret_cast<void *>(cb)); // add callback function only to list
+      enqueue(func_q, (void *)cb); // add callback function only to list
     }
   }
   // release lock
@@ -705,7 +705,7 @@ event_callback_thread(void *arg)
 
   // execute the callback function
   while (!queue_is_empty(func_q)) {
-    cb = reinterpret_cast<TSEventSignalFunc>(dequeue(func_q));
+    cb = (TSEventSignalFunc)dequeue(func_q);
     (*cb)(event_notice->name, event_notice->description, event_notice->priority, nullptr);
   }
 

--- a/mgmt/api/TSControlMain.cc
+++ b/mgmt/api/TSControlMain.cc
@@ -61,9 +61,9 @@ static TSMgmtError handle_control_message(int fd, void *msg, size_t msglen);
 static ClientT *
 create_client()
 {
-  ClientT *ele = static_cast<ClientT *>(ats_malloc(sizeof(ClientT)));
+  ClientT *ele = (ClientT *)ats_malloc(sizeof(ClientT));
 
-  ele->adr = static_cast<struct sockaddr *>(ats_malloc(sizeof(struct sockaddr)));
+  ele->adr = (struct sockaddr *)ats_malloc(sizeof(struct sockaddr));
   return ele;
 }
 
@@ -123,7 +123,7 @@ ts_ctrl_main(void *arg)
   int *socket_fd;
   int con_socket_fd; // main socket for listening to new connections
 
-  socket_fd     = static_cast<int *>(arg);
+  socket_fd     = (int *)arg;
   con_socket_fd = *socket_fd;
 
   // now we can start listening, accepting connections and servicing requests
@@ -344,7 +344,7 @@ send_record_get_response(int fd, const RecRecord *rec)
 static void
 send_record_get(const RecRecord *rec, void *edata)
 {
-  int *fd = static_cast<int *>(edata);
+  int *fd = (int *)edata;
   *fd     = send_record_get_response(*fd, rec);
 }
 
@@ -375,7 +375,7 @@ handle_record_get(int fd, void *req, size_t reqlen)
 
   // If the lookup succeeded, the final error is in "fderr".
   if (ret == TS_ERR_OKAY) {
-    ret = static_cast<TSMgmtError>(fderr);
+    ret = (TSMgmtError)fderr;
   }
 
 done:
@@ -391,7 +391,7 @@ struct record_match_state {
 static void
 send_record_match(const RecRecord *rec, void *edata)
 {
-  record_match_state *match = static_cast<record_match_state *>(edata);
+  record_match_state *match = (record_match_state *)edata;
 
   if (match->err != TS_ERR_OKAY) {
     return;
@@ -518,7 +518,7 @@ handle_proxy_state_set(int fd, void *req, size_t reqlen)
     return send_mgmt_response(fd, OpType::PROXY_STATE_SET, &err);
   }
 
-  err = ProxyStateSet(static_cast<TSProxyStateT>(state), static_cast<TSCacheClearT>(clear));
+  err = ProxyStateSet((TSProxyStateT)state, (TSCacheClearT)clear);
   return send_mgmt_response(fd, OpType::PROXY_STATE_SET, &err);
 }
 
@@ -698,7 +698,7 @@ handle_event_get_mlt(int fd, void *req, size_t reqlen)
   // iterate through list and put into a delimited string list
   memset(buf, 0, MAX_BUF_SIZE);
   while (!queue_is_empty(event_list)) {
-    event_name = static_cast<char *>(dequeue(event_list));
+    event_name = (char *)dequeue(event_list);
     if (event_name) {
       snprintf(buf + buf_pos, (MAX_BUF_SIZE - buf_pos), "%s%c", event_name, REMOTE_DELIM);
       buf_pos += (strlen(event_name) + 1);
@@ -771,7 +771,7 @@ handle_stats_reset(int fd, void *req, size_t reqlen)
   }
 
   ats_free(name);
-  return send_mgmt_response(fd, optype, &err);
+  return send_mgmt_response(fd, (OpType)optype, &err);
 }
 
 /**************************************************************************
@@ -795,7 +795,7 @@ handle_host_status_up(int fd, void *req, size_t reqlen)
   }
 
   ats_free(name);
-  return send_mgmt_response(fd, optype, &err);
+  return send_mgmt_response(fd, (OpType)optype, &err);
 }
 
 /**************************************************************************
@@ -819,7 +819,7 @@ handle_host_status_down(int fd, void *req, size_t reqlen)
   }
 
   ats_free(name);
-  return send_mgmt_response(fd, optype, &err);
+  return send_mgmt_response(fd, (OpType)optype, &err);
 }
 /**************************************************************************
  * handle_api_ping
@@ -853,7 +853,7 @@ handle_server_backtrace(int fd, void *req, size_t reqlen)
   err = send_mgmt_response(fd, OpType::SERVER_BACKTRACE, &err, &trace);
   ats_free(trace);
 
-  return static_cast<TSMgmtError>(err);
+  return (TSMgmtError)err;
 }
 
 static void
@@ -876,7 +876,7 @@ send_record_describe(const RecRecord *rec, void *edata)
 
   TSMgmtError err = TS_ERR_OKAY;
 
-  record_match_state *match = static_cast<record_match_state *>(edata);
+  record_match_state *match = (record_match_state *)edata;
 
   if (match->err != TS_ERR_OKAY) {
     return;
@@ -1086,6 +1086,6 @@ handle_control_message(int fd, void *req, size_t reqlen)
   return TS_ERR_OKAY;
 
 fail:
-  mgmt_elog(0, "%s: missing handler for type %d control message\n", __func__, static_cast<int>(optype));
+  mgmt_elog(0, "%s: missing handler for type %d control message\n", __func__, (int)optype);
   return TS_ERR_PARAMS;
 }

--- a/mgmt/utils/ExpandingArray.cc
+++ b/mgmt/utils/ExpandingArray.cc
@@ -31,7 +31,7 @@ ExpandingArray::ExpandingArray(int initialSize, bool freeContents)
     initialSize = EA_MIN_SIZE;
   }
 
-  internalArray = static_cast<void **>(ats_malloc(initialSize * sizeof(void *)));
+  internalArray = (void **)ats_malloc(initialSize * sizeof(void *));
 
   freeContentsOnDestruct = freeContents;
   internalArraySize      = initialSize;
@@ -62,7 +62,7 @@ ExpandingArray::addEntry(void *entry)
 {
   if (numValidValues == internalArraySize) {
     // Time to increase the size of the array
-    internalArray = static_cast<void **>(ats_realloc(internalArray, 2 * sizeof(void *) * internalArraySize));
+    internalArray = (void **)ats_realloc(internalArray, 2 * sizeof(void *) * internalArraySize);
     internalArraySize *= 2;
   }
 

--- a/mgmt/utils/MgmtMarshall.cc
+++ b/mgmt/utils/MgmtMarshall.cc
@@ -40,7 +40,7 @@ static char *empty = const_cast<char *>("");
 static bool
 data_is_nul_terminated(const MgmtMarshallData *data)
 {
-  const char *str = static_cast<const char *>(data->ptr);
+  const char *str = (const char *)(data->ptr);
 
   ink_assert(str);
   if (str[data->len - 1] != '\0') {
@@ -81,7 +81,7 @@ socket_read_bytes(int fd, void *buf, size_t needed)
       return -1;
     }
 
-    buf = static_cast<uint8_t *>(buf) + ret;
+    buf = (uint8_t *)buf + ret;
     nread += ret;
   }
 
@@ -127,7 +127,7 @@ socket_write_buffer(int fd, const MgmtMarshallData *data)
 
   if (data->len) {
     nwrite = socket_write_bytes(fd, data->ptr, data->len);
-    if (nwrite != static_cast<ssize_t>(data->len)) {
+    if (nwrite != (ssize_t)data->len) {
       goto fail;
     }
   }
@@ -153,7 +153,7 @@ socket_read_buffer(int fd, MgmtMarshallData *data)
   if (data->len) {
     data->ptr = ats_malloc(data->len);
     nread     = socket_read_bytes(fd, data->ptr, data->len);
-    if (nread != static_cast<ssize_t>(data->len)) {
+    if (nread != (ssize_t)data->len) {
       goto fail;
     }
   }
@@ -349,7 +349,7 @@ mgmt_message_read_v(int fd, const MgmtMarshallType *fields, unsigned count, va_l
 
       ink_assert(data_is_nul_terminated(&data));
       ptr.m_string  = va_arg(ap, MgmtMarshallString *);
-      *ptr.m_string = static_cast<char *>(data.ptr);
+      *ptr.m_string = (char *)data.ptr;
       break;
     }
     case MGMT_MARSHALL_DATA:
@@ -425,7 +425,7 @@ mgmt_message_marshall_v(void *buf, size_t remain, const MgmtMarshallType *fields
       }
 
       memcpy(buf, &data.len, 4);
-      memcpy(static_cast<uint8_t *>(buf) + 4, data.ptr, data.len);
+      memcpy((uint8_t *)buf + 4, data.ptr, data.len);
       nwritten = 4 + data.len;
       break;
     }
@@ -435,7 +435,7 @@ mgmt_message_marshall_v(void *buf, size_t remain, const MgmtMarshallType *fields
         goto nospace;
       }
       memcpy(buf, &(ptr.m_data->len), 4);
-      memcpy(static_cast<uint8_t *>(buf) + 4, ptr.m_data->ptr, ptr.m_data->len);
+      memcpy((uint8_t *)buf + 4, ptr.m_data->ptr, ptr.m_data->len);
       nwritten = 4 + ptr.m_data->len;
       break;
     default:
@@ -444,7 +444,7 @@ mgmt_message_marshall_v(void *buf, size_t remain, const MgmtMarshallType *fields
     }
 
     nbytes += nwritten;
-    buf = static_cast<uint8_t *>(buf) + nwritten;
+    buf = (uint8_t *)buf + nwritten;
     remain -= nwritten;
   }
 
@@ -496,7 +496,7 @@ mgmt_message_parse_v(const void *buf, size_t len, const MgmtMarshallType *fields
       break;
     case MGMT_MARSHALL_STRING: {
       MgmtMarshallData data;
-      nread = buffer_read_buffer(static_cast<const uint8_t *>(buf), len, &data);
+      nread = buffer_read_buffer((const uint8_t *)buf, len, &data);
       if (nread == -1) {
         goto nospace;
       }
@@ -504,12 +504,12 @@ mgmt_message_parse_v(const void *buf, size_t len, const MgmtMarshallType *fields
       ink_assert(data_is_nul_terminated(&data));
 
       ptr.m_string  = va_arg(ap, MgmtMarshallString *);
-      *ptr.m_string = static_cast<char *>(data.ptr);
+      *ptr.m_string = (char *)data.ptr;
       break;
     }
     case MGMT_MARSHALL_DATA:
       ptr.m_data = va_arg(ap, MgmtMarshallData *);
-      nread      = buffer_read_buffer(static_cast<const uint8_t *>(buf), len, ptr.m_data);
+      nread      = buffer_read_buffer((const uint8_t *)buf, len, ptr.m_data);
       if (nread == -1) {
         goto nospace;
       }

--- a/mgmt/utils/MgmtSocket.cc
+++ b/mgmt/utils/MgmtSocket.cc
@@ -80,7 +80,7 @@ mgmt_accept(int s, struct sockaddr *addr, socklen_t *addrlen)
   int r, retries;
   ink_assert(*addrlen != 0);
   for (retries = 0; retries < MGMT_MAX_TRANSIENT_ERRORS; retries++) {
-    r = ::accept(s, addr, addrlen);
+    r = ::accept(s, addr, (socklen_t *)addrlen);
     if (r >= 0) {
       return r;
     }
@@ -215,7 +215,7 @@ mgmt_sendto(int fd, void *buf, int len, int flags, struct sockaddr *to, int tole
 {
   int r, retries;
   for (retries = 0; retries < MGMT_MAX_TRANSIENT_ERRORS; retries++) {
-    r = ::sendto(fd, static_cast<char *>(buf), len, flags, to, tolen);
+    r = ::sendto(fd, (char *)buf, len, flags, to, tolen);
     if (r >= 0) {
       return r;
     }
@@ -266,7 +266,7 @@ mgmt_write_timeout(int fd, int sec, int usec)
   timeout.tv_sec  = sec;
   timeout.tv_usec = usec;
 
-  if (fd < 0 || fd >= FD_SETSIZE) {
+  if (fd < 0 || fd >= (int)FD_SETSIZE) {
     errno = EBADF;
     return -1;
   }
@@ -305,7 +305,7 @@ mgmt_read_timeout(int fd, int sec, int usec)
   timeout.tv_sec  = sec;
   timeout.tv_usec = usec;
 
-  if (fd < 0 || fd >= FD_SETSIZE) {
+  if (fd < 0 || fd >= (int)FD_SETSIZE) {
     errno = EBADF;
     return -1;
   }

--- a/mgmt/utils/MgmtUtils.cc
+++ b/mgmt/utils/MgmtUtils.cc
@@ -351,7 +351,7 @@ mgmt_getAddrForIntr(char *intrName, sockaddr *addr, int *mtu)
   lastlen = 0;
   len     = 128 * sizeof(struct ifreq); // initial buffer size guess
   for (;;) {
-    ifbuf = static_cast<char *>(ats_malloc(len));
+    ifbuf = (char *)ats_malloc(len);
     memset(ifbuf, 0, len); // prevent UMRs
     ifc.ifc_len = len;
     ifc.ifc_buf = ifbuf;
@@ -371,11 +371,11 @@ mgmt_getAddrForIntr(char *intrName, sockaddr *addr, int *mtu)
 
   found = false;
   // Loop through the list of interfaces
-  ifend = reinterpret_cast<struct ifreq *>(ifc.ifc_buf + ifc.ifc_len);
+  ifend = (struct ifreq *)(ifc.ifc_buf + ifc.ifc_len);
   for (ifr = ifc.ifc_req; ifr < ifend;) {
     if (ifr->ifr_addr.sa_family == AF_INET && strcmp(ifr->ifr_name, intrName) == 0) {
       // Get the address of the interface
-      if (ioctl(fakeSocket, SIOCGIFADDR, reinterpret_cast<char *>(ifr)) < 0) {
+      if (ioctl(fakeSocket, SIOCGIFADDR, (char *)ifr) < 0) {
         mgmt_log("[getAddrForIntr] Unable obtain address for network interface %s\n", intrName);
       } else {
         // Only look at the address if it an internet address
@@ -396,7 +396,7 @@ mgmt_getAddrForIntr(char *intrName, sockaddr *addr, int *mtu)
 #if defined(freebsd) || defined(darwin)
     ifr = (struct ifreq *)((char *)&ifr->ifr_addr + ifr->ifr_addr.sa_len);
 #else
-    ifr = reinterpret_cast<struct ifreq *>((reinterpret_cast<char *>(ifr)) + sizeof(*ifr));
+    ifr = (struct ifreq *)(((char *)ifr) + sizeof(*ifr));
 #endif
   }
   ats_free(ifbuf);
@@ -418,7 +418,7 @@ mgmt_sortipaddrs(int num, struct in_addr **list)
 
   min   = (list[0])->s_addr;
   entry = list[0];
-  while (i < num && (tmp = list[i]) != nullptr) {
+  while (i < num && (tmp = (struct in_addr *)list[i]) != nullptr) {
     i++;
     if (min > tmp->s_addr) {
       min   = tmp->s_addr;

--- a/mgmt/utils/test_marshall.cc
+++ b/mgmt/utils/test_marshall.cc
@@ -46,7 +46,7 @@
     }                                                                                                                \
   } while (0)
 
-const MgmtMarshallType inval[] = {static_cast<MgmtMarshallType>(1568)};
+const MgmtMarshallType inval[] = {(MgmtMarshallType)1568};
 
 const MgmtMarshallType ifields[] = {MGMT_MARSHALL_INT, MGMT_MARSHALL_LONG};
 
@@ -88,7 +88,7 @@ message_connect_channel(RegressionTest *t, int listenfd, int clientfd, int serve
   fcntl(clientfd, F_SETFL, O_NONBLOCK);
   fcntl(listenfd, F_SETFL, O_NONBLOCK);
 
-  connect(clientfd, reinterpret_cast<const struct sockaddr *>(&in), sizeof(in));
+  connect(clientfd, (const struct sockaddr *)&in, sizeof(in));
 
   while (need_accept) {
     serverfd = accept(listenfd, nullptr, nullptr);

--- a/proxy/ControlMatcher.cc
+++ b/proxy/ControlMatcher.cc
@@ -407,7 +407,7 @@ RegexMatcher<Data, MatchResult>::AllocateSpace(int num_entries)
   // Should not have been allocated before
   ink_assert(array_len == -1);
 
-  re_array = static_cast<pcre **>(ats_malloc(sizeof(pcre *) * num_entries));
+  re_array = (pcre **)ats_malloc(sizeof(pcre *) * num_entries);
   memset(re_array, 0, sizeof(pcre *) * num_entries);
 
   data_array = new Data[num_entries];
@@ -808,8 +808,8 @@ ControlMatcher<Data, MatchResult>::BuildTableFromString(char *file_buf)
     if (*tmp != '#' && *tmp != '\0') {
       const char *errptr;
 
-      current = static_cast<matcher_line *>(ats_malloc(sizeof(matcher_line)));
-      errptr  = parseConfigLine(const_cast<char *>(tmp), current, config_tags);
+      current = (matcher_line *)ats_malloc(sizeof(matcher_line));
+      errptr  = parseConfigLine((char *)tmp, current, config_tags);
 
       if (errptr != nullptr) {
         if (config_tags != &socks_server_tags) {

--- a/proxy/ParentConsistentHash.cc
+++ b/proxy/ParentConsistentHash.cc
@@ -187,8 +187,8 @@ ParentConsistentHash::selectParent(bool first_call, ParentResult *result, Reques
   path_hash = getPathHash(request_info, (ATSHash64 *)&hash);
   fhash     = chash[last_lookup];
   do { // search until we've selected a different parent if !firstCall
-    prtmp = chash_lookup(fhash, path_hash, &result->chashIter[last_lookup], &wrap_around[last_lookup], &hash,
-                         &result->chash_init[last_lookup]);
+    prtmp = (pRecord *)chash_lookup(fhash, path_hash, &result->chashIter[last_lookup], &wrap_around[last_lookup], &hash,
+                                    &result->chash_init[last_lookup]);
     lookups++;
     if (prtmp) {
       pRec = (parents[last_lookup] + prtmp->idx);
@@ -275,8 +275,8 @@ ParentConsistentHash::selectParent(bool first_call, ParentResult *result, Reques
           }
         }
         fhash = chash[last_lookup];
-        prtmp = chash_lookup(fhash, path_hash, &result->chashIter[last_lookup], &wrap_around[last_lookup], &hash,
-                             &result->chash_init[last_lookup]);
+        prtmp = (pRecord *)chash_lookup(fhash, path_hash, &result->chashIter[last_lookup], &wrap_around[last_lookup], &hash,
+                                        &result->chash_init[last_lookup]);
         lookups++;
         if (prtmp) {
           pRec = (parents[last_lookup] + prtmp->idx);
@@ -386,7 +386,7 @@ ParentConsistentHash::markParentUp(ParentResult *result)
   ink_atomic_swap(&pRec->available, true);
   Debug("parent_select", "%s:%s(): marked %s:%d available.", __FILE__, __func__, pRec->hostname, pRec->port);
 
-  ink_atomic_swap(&pRec->failedAt, static_cast<time_t>(0));
+  ink_atomic_swap(&pRec->failedAt, (time_t)0);
   int old_count = ink_atomic_swap(&pRec->failCount, 0);
 
   if (old_count > 0) {

--- a/proxy/ParentRoundRobin.cc
+++ b/proxy/ParentRoundRobin.cc
@@ -99,7 +99,7 @@ ParentRoundRobin::selectParent(bool first_call, ParentResult *result, RequestDat
         }
         break;
       case P_STRICT_ROUND_ROBIN:
-        cur_index = ink_atomic_increment(reinterpret_cast<int32_t *>(&result->rec->rr_next), 1);
+        cur_index = ink_atomic_increment((int32_t *)&result->rec->rr_next, 1);
         cur_index = result->start_parent = cur_index % num_parents;
         break;
       case P_NO_ROUND_ROBIN:
@@ -117,7 +117,7 @@ ParentRoundRobin::selectParent(bool first_call, ParentResult *result, RequestDat
     latched_parent = cur_index = (result->last_parent + 1) % num_parents;
 
     // Check to see if we have wrapped around
-    if (static_cast<unsigned int>(cur_index) == result->start_parent) {
+    if ((unsigned int)cur_index == result->start_parent) {
       // We've wrapped around so bypass if we can
       if (result->rec->go_direct == true) {
         // Could not find a parent
@@ -181,7 +181,7 @@ ParentRoundRobin::selectParent(bool first_call, ParentResult *result, RequestDat
       return;
     }
     latched_parent = cur_index = (cur_index + 1) % num_parents;
-  } while (static_cast<unsigned int>(cur_index) != result->start_parent);
+  } while ((unsigned int)cur_index != result->start_parent);
 
   if (result->rec->go_direct == true && result->rec->parent_is_proxy == true) {
     result->result = PARENT_DIRECT;

--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -419,9 +419,9 @@ ParentRecord::ProcessParents(char *val, bool isPrimary)
   HostStatus &hs = HostStatus::instance();
   // Allocate the parents array
   if (isPrimary) {
-    this->parents = static_cast<pRecord *>(ats_malloc(sizeof(pRecord) * numTok));
+    this->parents = (pRecord *)ats_malloc(sizeof(pRecord) * numTok);
   } else {
-    this->secondary_parents = static_cast<pRecord *>(ats_malloc(sizeof(pRecord) * numTok));
+    this->secondary_parents = (pRecord *)ats_malloc(sizeof(pRecord) * numTok);
   }
 
   // Loop through the set of parents specified
@@ -430,7 +430,7 @@ ParentRecord::ProcessParents(char *val, bool isPrimary)
     current = pTok[i];
 
     // Find the parent port
-    tmp = const_cast<char *>(strchr(current, ':'));
+    tmp = (char *)strchr(current, ':');
 
     if (tmp == nullptr) {
       errPtr = "No parent port specified";
@@ -444,7 +444,7 @@ ParentRecord::ProcessParents(char *val, bool isPrimary)
     }
 
     // See if there is an optional parent weight
-    tmp2 = const_cast<char *>(strchr(current, '|'));
+    tmp2 = (char *)strchr(current, '|');
 
     if (tmp2) {
       if (sscanf(tmp2 + 1, "%f", &weight) != 1) {
@@ -453,7 +453,7 @@ ParentRecord::ProcessParents(char *val, bool isPrimary)
       }
     }
 
-    tmp3 = const_cast<char *>(strchr(current, '&'));
+    tmp3 = (char *)strchr(current, '&');
 
     // Make sure that is no garbage beyond the parent
     //  port or weight
@@ -571,7 +571,7 @@ ParentRecord::DefaultInit(char *val)
   errPtr                = ProcessParents(val, true);
 
   if (errPtr != nullptr) {
-    errBuf = static_cast<char *>(ats_malloc(1024));
+    errBuf = (char *)ats_malloc(1024);
     snprintf(errBuf, 1024, "%s %s for default parent proxy", modulePrefix, errPtr);
     SignalError(errBuf, alarmAlready);
     ats_free(errBuf);
@@ -1805,7 +1805,7 @@ br(HttpRequestData *h, const char *os_hostname, sockaddr const *dest_ip)
 {
   h->hdr = new HTTPHdr();
   h->hdr->create(HTTP_TYPE_REQUEST);
-  h->hostname_str = ats_strdup(os_hostname);
+  h->hostname_str = (char *)ats_strdup(os_hostname);
   h->xact_start   = time(nullptr);
   ink_zero(h->src_ip);
   ink_zero(h->dest_ip);

--- a/proxy/ParentSelectionStrategy.cc
+++ b/proxy/ParentSelectionStrategy.cc
@@ -119,7 +119,7 @@ ParentSelectionStrategy::markParentUp(ParentResult *result)
   pRec = parents + result->last_parent;
   ink_atomic_swap(&pRec->available, true);
 
-  ink_atomic_swap(&pRec->failedAt, static_cast<time_t>(0));
+  ink_atomic_swap(&pRec->failedAt, (time_t)0);
   int old_count = ink_atomic_swap(&pRec->failCount, 0);
 
   if (old_count > 0) {

--- a/proxy/Plugin.cc
+++ b/proxy/Plugin.cc
@@ -112,7 +112,7 @@ plugin_load(int argc, char *argv[], bool validateOnly)
     plugin_reg_current->plugin_path = ats_strdup(path);
     plugin_reg_current->dlh         = handle;
 
-    init = reinterpret_cast<init_func_t>(dlsym(plugin_reg_current->dlh, "TSPluginInit"));
+    init = (init_func_t)dlsym(plugin_reg_current->dlh, "TSPluginInit");
     if (!init) {
       delete plugin_reg_current;
       if (validateOnly) {
@@ -169,7 +169,7 @@ plugin_expand(char *arg)
     if (RecGetRecordString_Xmalloc(arg, &str_val) != REC_ERR_OKAY) {
       goto not_found;
     }
-    return static_cast<char *>(str_val);
+    return (char *)str_val;
     break;
   }
   case RECD_FLOAT: {
@@ -177,8 +177,8 @@ plugin_expand(char *arg)
     if (RecGetRecordFloat(arg, &float_val) != REC_ERR_OKAY) {
       goto not_found;
     }
-    str = static_cast<char *>(ats_malloc(128));
-    snprintf(str, 128, "%f", static_cast<float>(float_val));
+    str = (char *)ats_malloc(128);
+    snprintf(str, 128, "%f", (float)float_val);
     return str;
     break;
   }
@@ -187,8 +187,8 @@ plugin_expand(char *arg)
     if (RecGetRecordInt(arg, &int_val) != REC_ERR_OKAY) {
       goto not_found;
     }
-    str = static_cast<char *>(ats_malloc(128));
-    snprintf(str, 128, "%ld", static_cast<long int>(int_val));
+    str = (char *)ats_malloc(128);
+    snprintf(str, 128, "%ld", (long int)int_val);
     return str;
     break;
   }
@@ -197,8 +197,8 @@ plugin_expand(char *arg)
     if (RecGetRecordCounter(arg, &count_val) != REC_ERR_OKAY) {
       goto not_found;
     }
-    str = static_cast<char *>(ats_malloc(128));
-    snprintf(str, 128, "%ld", static_cast<long int>(count_val));
+    str = (char *)ats_malloc(128);
+    snprintf(str, 128, "%ld", (long int)count_val);
     return str;
     break;
   }

--- a/proxy/PluginVC.cc
+++ b/proxy/PluginVC.cc
@@ -124,7 +124,7 @@ PluginVC::main_handler(int event, void *data)
   ink_assert(!deletable);
   ink_assert(data != nullptr);
 
-  Event *call_event   = static_cast<Event *>(data);
+  Event *call_event   = (Event *)data;
   EThread *my_ethread = mutex->thread_holding;
   ink_release_assert(my_ethread != nullptr);
 
@@ -990,23 +990,23 @@ PluginVC::get_data(int id, void *data)
   switch (id) {
   case PLUGIN_VC_DATA_LOCAL:
     if (vc_type == PLUGIN_VC_ACTIVE) {
-      *static_cast<void **>(data) = core_obj->active_data;
+      *(void **)data = core_obj->active_data;
     } else {
-      *static_cast<void **>(data) = core_obj->passive_data;
+      *(void **)data = core_obj->passive_data;
     }
     return true;
   case PLUGIN_VC_DATA_REMOTE:
     if (vc_type == PLUGIN_VC_ACTIVE) {
-      *static_cast<void **>(data) = core_obj->passive_data;
+      *(void **)data = core_obj->passive_data;
     } else {
-      *static_cast<void **>(data) = core_obj->active_data;
+      *(void **)data = core_obj->active_data;
     }
     return true;
   case TS_API_DATA_CLOSED:
     *static_cast<int *>(data) = this->closed;
     return true;
   default:
-    *static_cast<void **>(data) = nullptr;
+    *(void **)data = nullptr;
     return false;
   }
 }

--- a/proxy/ProtocolProbeSessionAccept.cc
+++ b/proxy/ProtocolProbeSessionAccept.cc
@@ -170,7 +170,7 @@ ProtocolProbeSessionAccept::mainEvent(int event, void *data)
     ink_assert(data);
 
     VIO *vio;
-    NetVConnection *netvc          = static_cast<NetVConnection *>(data);
+    NetVConnection *netvc          = (NetVConnection *)data;
     ProtocolProbeTrampoline *probe = new ProtocolProbeTrampoline(this, netvc->mutex, nullptr, nullptr);
 
     // XXX we need to apply accept inactivity timeout here ...
@@ -187,7 +187,7 @@ ProtocolProbeSessionAccept::mainEvent(int event, void *data)
     return EVENT_CONT;
   }
 
-  ink_abort("Protocol probe received a fatal error: errno = %d", -(static_cast<int>((intptr_t)data)));
+  ink_abort("Protocol probe received a fatal error: errno = %d", -((int)(intptr_t)data));
   return EVENT_CONT;
 }
 

--- a/proxy/RegressionSM.cc
+++ b/proxy/RegressionSM.cc
@@ -100,7 +100,7 @@ RegressionSM::regression_sm_waiting(int /* event ATS_UNUSED */, void *data)
     return EVENT_DONE;
   }
   if (parallel || nwaiting > 1) {
-    (static_cast<Event *>(data))->schedule_in(REGRESSION_SM_RETRY);
+    ((Event *)data)->schedule_in(REGRESSION_SM_RETRY);
     return EVENT_CONT;
   }
   run();
@@ -193,9 +193,9 @@ RegressionSM::run()
         x = children[ichild];
       } else {
         if (ichild != n - 1) {
-          x = children[static_cast<intptr_t>(0)]->clone();
+          x = children[(intptr_t)0]->clone();
         } else {
-          x = children[static_cast<intptr_t>(0)];
+          x = children[(intptr_t)0];
         }
       }
       if (!ichild) {
@@ -221,7 +221,7 @@ Lretry:
 
 RegressionSM::RegressionSM(const RegressionSM &ao) : Continuation(ao)
 {
-  RegressionSM &o = *const_cast<RegressionSM *>(&ao);
+  RegressionSM &o = *(RegressionSM *)&ao;
 
   t        = o.t;
   status   = o.status;

--- a/proxy/ReverseProxy.cc
+++ b/proxy/ReverseProxy.cc
@@ -168,7 +168,7 @@ reloadUrlRewrite()
 int
 url_rewrite_CB(const char * /* name ATS_UNUSED */, RecDataT /* data_type ATS_UNUSED */, RecData data, void *cookie)
 {
-  int my_token = static_cast<int>((long)cookie);
+  int my_token = (int)(long)cookie;
 
   switch (my_token) {
   case REVERSE_CHANGED:

--- a/proxy/StatPages.cc
+++ b/proxy/StatPages.cc
@@ -59,7 +59,7 @@ StatPagesManager::register_http(const char *module, StatPagesFunc func)
   ink_mutex_acquire(&stat_pages_mutex);
   ink_release_assert(n_stat_pages < MAX_STAT_PAGES);
 
-  stat_pages[n_stat_pages].module = static_cast<char *>(ats_malloc(strlen(module) + 3));
+  stat_pages[n_stat_pages].module = (char *)ats_malloc(strlen(module) + 3);
   snprintf(stat_pages[n_stat_pages].module, strlen(module) + 3, "{%s}", module);
   stat_pages[n_stat_pages++].func = func;
   ink_mutex_release(&stat_pages_mutex);
@@ -176,9 +176,9 @@ BaseStatPagesHandler::resp_add(const char *fmt, ...)
 
   if (size != response_size) {
     if (!response) {
-      response = static_cast<char *>(ats_malloc(size));
+      response = (char *)ats_malloc(size);
     } else {
-      response = static_cast<char *>(ats_realloc(response, size));
+      response = (char *)ats_realloc(response, size);
     }
     response_size = size;
   }

--- a/proxy/Transform.cc
+++ b/proxy/Transform.cc
@@ -139,7 +139,7 @@ TransformTerminus::handle_event(int event, void * /* edata ATS_UNUSED */)
 
   m_deletable = ((m_closed != 0) && (m_tvc->m_closed != 0));
 
-  val = ink_atomic_increment(&m_event_count, -1);
+  val = ink_atomic_increment((int *)&m_event_count, -1);
 
   Debug("transform", "[TransformTerminus::handle_event] event_count %d", m_event_count);
 
@@ -275,7 +275,7 @@ TransformTerminus::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
   m_read_vio.ndone     = 0;
   m_read_vio.vc_server = this;
 
-  if (ink_atomic_increment(&m_event_count, 1) < 0) {
+  if (ink_atomic_increment((int *)&m_event_count, 1) < 0) {
     ink_assert(!"not reached");
   }
   Debug("transform", "[TransformTerminus::do_io_read] event_count %d", m_event_count);
@@ -300,7 +300,7 @@ TransformTerminus::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *
   m_write_vio.ndone     = 0;
   m_write_vio.vc_server = this;
 
-  if (ink_atomic_increment(&m_event_count, 1) < 0) {
+  if (ink_atomic_increment((int *)&m_event_count, 1) < 0) {
     ink_assert(!"not reached");
   }
   Debug("transform", "[TransformTerminus::do_io_write] event_count %d", m_event_count);
@@ -316,7 +316,7 @@ TransformTerminus::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *
 void
 TransformTerminus::do_io_close(int error)
 {
-  if (ink_atomic_increment(&m_event_count, 1) < 0) {
+  if (ink_atomic_increment((int *)&m_event_count, 1) < 0) {
     ink_assert(!"not reached");
   }
 
@@ -364,7 +364,7 @@ TransformTerminus::reenable(VIO *vio)
   ink_assert((vio == &m_read_vio) || (vio == &m_write_vio));
 
   if (m_event_count == 0) {
-    if (ink_atomic_increment(&m_event_count, 1) < 0) {
+    if (ink_atomic_increment((int *)&m_event_count, 1) < 0) {
       ink_assert(!"not reached");
     }
     Debug("transform", "[TransformTerminus::reenable] event_count %d", m_event_count);
@@ -1018,7 +1018,7 @@ RangeTransform::change_response_header()
 
   status_code = HTTP_STATUS_PARTIAL_CONTENT;
   m_transform_resp->status_set(status_code);
-  reason_phrase = const_cast<char *>(http_hdr_reason_lookup(status_code));
+  reason_phrase = (char *)(http_hdr_reason_lookup(status_code));
   m_transform_resp->reason_set(reason_phrase, strlen(reason_phrase));
 
   if (m_num_range_fields > 1) {

--- a/proxy/hdrs/HdrTSOnly.cc
+++ b/proxy/hdrs/HdrTSOnly.cc
@@ -75,7 +75,7 @@ HTTPHdr::parse_req(HTTPParser *parser, IOBufferReader *r, int *bytes_used, bool 
     m_heap->set_ronly_str_heap_end(heap_slot, tmp);
     m_heap->unlock_ronly_str_heap(heap_slot);
 
-    used = static_cast<int>(tmp - start);
+    used = (int)(tmp - start);
     r->consume(used);
     *bytes_used += used;
 
@@ -123,7 +123,7 @@ HTTPHdr::parse_resp(HTTPParser *parser, IOBufferReader *r, int *bytes_used, bool
     m_heap->set_ronly_str_heap_end(heap_slot, tmp);
     m_heap->unlock_ronly_str_heap(heap_slot);
 
-    used = static_cast<int>(tmp - start);
+    used = (int)(tmp - start);
     r->consume(used);
     *bytes_used += used;
 
@@ -150,7 +150,7 @@ HdrHeap::set_ronly_str_heap_end(int slot, const char *end)
   ink_assert(m_ronly_heap[slot].m_heap_start <= end);
   ink_assert(end <= m_ronly_heap[slot].m_heap_start + m_ronly_heap[slot].m_heap_len);
 
-  m_ronly_heap[slot].m_heap_len = static_cast<int>(end - m_ronly_heap[slot].m_heap_start);
+  m_ronly_heap[slot].m_heap_len = (int)(end - m_ronly_heap[slot].m_heap_start);
 }
 
 // void HdrHeap::attach_block(IOBufferBlock* b, const char* use_start)

--- a/proxy/hdrs/HdrTest.cc
+++ b/proxy/hdrs/HdrTest.cc
@@ -121,12 +121,11 @@ HdrTest::test_parse_date()
   bri_box("test_parse_date");
 
   for (i = 0; dates[i].fast; i++) {
-    fast_t = mime_parse_date(dates[i].fast, dates[i].fast + static_cast<int>(strlen(dates[i].fast)));
-    slow_t = mime_parse_date(dates[i].slow, dates[i].slow + static_cast<int>(strlen(dates[i].slow)));
+    fast_t = mime_parse_date(dates[i].fast, dates[i].fast + (int)strlen(dates[i].fast));
+    slow_t = mime_parse_date(dates[i].slow, dates[i].slow + (int)strlen(dates[i].slow));
     // compare with strptime here!
     if (fast_t != slow_t) {
-      printf("FAILED: date %lu (%s) != %lu (%s)\n", static_cast<unsigned long>(fast_t), dates[i].fast,
-             static_cast<unsigned long>(slow_t), dates[i].slow);
+      printf("FAILED: date %lu (%s) != %lu (%s)\n", (unsigned long)fast_t, dates[i].fast, (unsigned long)slow_t, dates[i].slow);
       ++failures;
     }
   }
@@ -159,11 +158,11 @@ HdrTest::test_format_date()
   int failures              = 0;
 
   // shift into GMT timezone for cftime conversions
-  putenv(const_cast<char *>(envstr));
+  putenv((char *)envstr);
   tzset();
 
   for (i = 0; dates[i]; i++) {
-    t = mime_parse_date(dates[i], dates[i] + static_cast<int>(strlen(dates[i])));
+    t = mime_parse_date(dates[i], dates[i] + (int)strlen(dates[i]));
 
     cftime_replacement(buffer, sizeof(buffer), "%a, %d %b %Y %T %Z", &t);
     if (memcmp(dates[i], buffer, 29) != 0) {
@@ -185,13 +184,13 @@ HdrTest::test_format_date()
   // (2) test a few times per day from 1/1/1970 to past 2010
 
   // coverity[dont_call]
-  for (t = 0; t < 40 * 366 * (24 * 60 * 60); t += static_cast<int>(drand48() * (24 * 60 * 60))) {
+  for (t = 0; t < 40 * 366 * (24 * 60 * 60); t += (int)(drand48() * (24 * 60 * 60))) {
     cftime_replacement(buffer, sizeof(buffer), "%a, %d %b %Y %T %Z", &t);
-    t2 = mime_parse_date(buffer, buffer + static_cast<int>(strlen(buffer)));
+    t2 = mime_parse_date(buffer, buffer + (int)strlen(buffer));
     if (t2 != t) {
       printf("FAILED: parsed time_t doesn't match original time_t\n");
-      printf("  input time_t:  %d (%s)\n", static_cast<int>(t), buffer);
-      printf("  parsed time_t: %d\n", static_cast<int>(t2));
+      printf("  input time_t:  %d (%s)\n", (int)t, buffer);
+      printf("  parsed time_t: %d\n", (int)t2);
       ++failures;
     }
     mime_format_date(buffer2, t);
@@ -201,11 +200,11 @@ HdrTest::test_format_date()
       printf("  formatted date: %s\n", buffer2);
       ++failures;
     }
-    t3 = mime_parse_date(buffer2, buffer2 + static_cast<int>(strlen(buffer2)));
+    t3 = mime_parse_date(buffer2, buffer2 + (int)strlen(buffer2));
     if (t != t3) {
       printf("FAILED: parsed time_t doesn't match original time_t\n");
-      printf("  input time_t:  %d (%s)\n", static_cast<int>(t), buffer2);
-      printf("  parsed time_t: %d\n", static_cast<int>(t3));
+      printf("  input time_t:  %d (%s)\n", (int)t, buffer2);
+      printf("  parsed time_t: %d\n", (int)t3);
       ++failures;
     }
 
@@ -280,7 +279,7 @@ HdrTest::test_url()
 
   failed = 0;
   for (unsigned i = 0; i < countof(strs); i++) {
-    old_length = static_cast<int>(strlen(strs[i]));
+    old_length = (int)strlen(strs[i]);
     start      = strs[i];
     end        = start + old_length;
 
@@ -463,7 +462,7 @@ HdrTest::test_mime()
   hdr.set_date(t1);
   t2 = hdr.get_date();
   if (t1 != t2) {
-    printf("FAILED: set_date(%" PRId64 ") ... get_date = %" PRId64 "\n\n", static_cast<int64_t>(t1), static_cast<int64_t>(t2));
+    printf("FAILED: set_date(%" PRId64 ") ... get_date = %" PRId64 "\n\n", (int64_t)t1, (int64_t)t2);
     return (failures_to_status("test_mime", 1));
   }
 
@@ -565,7 +564,7 @@ HdrTest::test_http_aux(const char *request, const char *response)
 
   /*** (2) print out the request ***/
 
-  printf("======== real request (length=%d)\n\n", static_cast<int>(strlen(request)));
+  printf("======== real request (length=%d)\n\n", (int)strlen(request));
   printf("%s\n", request);
 
   printf("\n[");
@@ -601,7 +600,7 @@ HdrTest::test_http_aux(const char *request, const char *response)
 
   /*** (4) print out the response ***/
 
-  printf("\n======== real response (length=%d)\n\n", static_cast<int>(strlen(response)));
+  printf("\n======== real response (length=%d)\n\n", (int)strlen(response));
   printf("%s\n", response);
 
   printf("\n[");
@@ -839,8 +838,8 @@ comp_http_hdr(HTTPHdr *h1, HTTPHdr *h2)
     return "length mismatch";
   }
 
-  h1_pbuf = static_cast<char *>(ats_malloc(h1_len + 1));
-  h2_pbuf = static_cast<char *>(ats_malloc(h2_len + 1));
+  h1_pbuf = (char *)ats_malloc(h1_len + 1);
+  h2_pbuf = (char *)ats_malloc(h2_len + 1);
 
   p_index = p_dumpoffset = 0;
   rval                   = h1->print(h1_pbuf, h1_len, &p_index, &p_dumpoffset);
@@ -981,8 +980,8 @@ done:
 
   if (comp_str) {
     printf("FAILED: (test #%d) copy & compare: %s\n", testnum, comp_str);
-    printf("REQ:\n[%.*s]\n", static_cast<int>(strlen(request)), request);
-    printf("RESP  :\n[%.*s]\n", static_cast<int>(strlen(response)), response);
+    printf("REQ:\n[%.*s]\n", (int)strlen(request), request);
+    printf("RESP  :\n[%.*s]\n", (int)strlen(response), response);
     return (0);
   } else {
     return (1);
@@ -1095,7 +1094,7 @@ HdrTest::test_http_hdr_print_and_copy_aux(int testnum, const char *request, cons
   int cpy_bufsize = sizeof(cpy_buf);
   int cpy_bufindex, cpy_dumpoffset, cpy_ret;
 
-  char *marshal_buf   = static_cast<char *>(ats_malloc(2048));
+  char *marshal_buf   = (char *)ats_malloc(2048);
   int marshal_bufsize = sizeof(cpy_buf);
 
   /*** (1) parse the request string into hdr ***/
@@ -1148,12 +1147,12 @@ HdrTest::test_http_hdr_print_and_copy_aux(int testnum, const char *request, cons
     return (0);
   }
 
-  if ((static_cast<size_t>(prt_bufindex) != strlen(request_tgt)) || (static_cast<size_t>(cpy_bufindex) != strlen(request_tgt))) {
+  if (((size_t)prt_bufindex != strlen(request_tgt)) || ((size_t)cpy_bufindex != strlen(request_tgt))) {
     printf("FAILED: (test #%d) print req output size mismatch --- tgt=%d, prt_bufsize=%d, cpy_bufsize=%d\n", testnum,
-           static_cast<int>(strlen(request_tgt)), prt_bufindex, cpy_bufindex);
+           (int)strlen(request_tgt), prt_bufindex, cpy_bufindex);
 
-    printf("ORIGINAL:\n[%.*s]\n", static_cast<int>(strlen(request)), request);
-    printf("TARGET  :\n[%.*s]\n", static_cast<int>(strlen(request_tgt)), request_tgt);
+    printf("ORIGINAL:\n[%.*s]\n", (int)strlen(request), request);
+    printf("TARGET  :\n[%.*s]\n", (int)strlen(request_tgt), request_tgt);
     printf("PRT_BUFF:\n[%.*s]\n", prt_bufindex, prt_buf);
     printf("CPY_BUFF:\n[%.*s]\n", cpy_bufindex, cpy_buf);
     return (0);
@@ -1162,8 +1161,8 @@ HdrTest::test_http_hdr_print_and_copy_aux(int testnum, const char *request, cons
   if ((strncasecmp(request_tgt, prt_buf, strlen(request_tgt)) != 0) ||
       (strncasecmp(request_tgt, cpy_buf, strlen(request_tgt)) != 0)) {
     printf("FAILED: (test #%d) print req output mismatch\n", testnum);
-    printf("ORIGINAL:\n[%.*s]\n", static_cast<int>(strlen(request)), request);
-    printf("TARGET  :\n[%.*s]\n", static_cast<int>(strlen(request_tgt)), request_tgt);
+    printf("ORIGINAL:\n[%.*s]\n", (int)strlen(request), request);
+    printf("TARGET  :\n[%.*s]\n", (int)strlen(request_tgt), request_tgt);
     printf("PRT_BUFF:\n[%.*s]\n", prt_bufindex, prt_buf);
     printf("CPY_BUFF:\n[%.*s]\n", cpy_bufindex, cpy_buf);
     return (0);
@@ -1211,11 +1210,11 @@ HdrTest::test_http_hdr_print_and_copy_aux(int testnum, const char *request, cons
     return (0);
   }
 
-  if ((static_cast<size_t>(prt_bufindex) != strlen(response_tgt)) || (static_cast<size_t>(cpy_bufindex) != strlen(response_tgt))) {
+  if (((size_t)prt_bufindex != strlen(response_tgt)) || ((size_t)cpy_bufindex != strlen(response_tgt))) {
     printf("FAILED: (test #%d) print rsp output size mismatch --- tgt=%d, prt_bufsize=%d, cpy_bufsize=%d\n", testnum,
-           static_cast<int>(strlen(response_tgt)), prt_bufindex, cpy_bufindex);
-    printf("ORIGINAL:\n[%.*s]\n", static_cast<int>(strlen(response)), response);
-    printf("TARGET  :\n[%.*s]\n", static_cast<int>(strlen(response_tgt)), response_tgt);
+           (int)strlen(response_tgt), prt_bufindex, cpy_bufindex);
+    printf("ORIGINAL:\n[%.*s]\n", (int)strlen(response), response);
+    printf("TARGET  :\n[%.*s]\n", (int)strlen(response_tgt), response_tgt);
     printf("PRT_BUFF:\n[%.*s]\n", prt_bufindex, prt_buf);
     printf("CPY_BUFF:\n[%.*s]\n", cpy_bufindex, cpy_buf);
     return (0);
@@ -1224,8 +1223,8 @@ HdrTest::test_http_hdr_print_and_copy_aux(int testnum, const char *request, cons
   if ((strncasecmp(response_tgt, prt_buf, strlen(response_tgt)) != 0) ||
       (strncasecmp(response_tgt, cpy_buf, strlen(response_tgt)) != 0)) {
     printf("FAILED: (test #%d) print rsp output mismatch\n", testnum);
-    printf("ORIGINAL:\n[%.*s]\n", static_cast<int>(strlen(response)), response);
-    printf("TARGET  :\n[%.*s]\n", static_cast<int>(strlen(response_tgt)), response_tgt);
+    printf("ORIGINAL:\n[%.*s]\n", (int)strlen(response), response);
+    printf("TARGET  :\n[%.*s]\n", (int)strlen(response_tgt), response_tgt);
     printf("PRT_BUFF:\n[%.*s]\n", prt_bufindex, prt_buf);
     printf("CPY_BUFF:\n[%.*s]\n", cpy_bufindex, cpy_buf);
     return (0);
@@ -1505,22 +1504,22 @@ HdrTest::test_http_mutation()
   for (i = 1; i <= 100; i++) {
     snprintf(field_name, sizeof(field_name), "Test%d", i);
     snprintf(field_value, sizeof(field_value), "%d %d %d %d %d", i, i, i, i, i);
-    resp_hdr.value_set(field_name, static_cast<int>(strlen(field_name)), field_value, static_cast<int>(strlen(field_value)));
+    resp_hdr.value_set(field_name, (int)strlen(field_name), field_value, (int)strlen(field_value));
   }
 
   /**** (3) delete all the even numbered fields *****/
   for (i = 2; i <= 100; i += 2) {
     snprintf(field_name, sizeof(field_name), "Test%d", i);
-    resp_hdr.field_delete(field_name, static_cast<int>(strlen(field_name)));
+    resp_hdr.field_delete(field_name, (int)strlen(field_name));
   }
 
   /***** (4) add in secondary fields for all multiples of 3 ***/
   for (i = 3; i <= 100; i += 3) {
     snprintf(field_name, sizeof(field_name), "Test%d", i);
-    MIMEField *f = resp_hdr.field_create(field_name, static_cast<int>(strlen(field_name)));
+    MIMEField *f = resp_hdr.field_create(field_name, (int)strlen(field_name));
     resp_hdr.field_attach(f);
     snprintf(field_value, sizeof(field_value), "d %d %d %d %d %d", i, i, i, i, i);
-    f->value_set(resp_hdr.m_heap, resp_hdr.m_mime, field_value, static_cast<int>(strlen(field_value)));
+    f->value_set(resp_hdr.m_heap, resp_hdr.m_mime, field_value, (int)strlen(field_value));
   }
 
   /***** (5) append all fields with multiples of 5 ***/
@@ -1528,14 +1527,13 @@ HdrTest::test_http_mutation()
     snprintf(field_name, sizeof(field_name), "Test%d", i);
     snprintf(field_value, sizeof(field_value), "a %d", i);
 
-    resp_hdr.value_append(field_name, static_cast<int>(strlen(field_name)), field_value, static_cast<int>(strlen(field_value)),
-                          true);
+    resp_hdr.value_append(field_name, (int)strlen(field_name), field_value, (int)strlen(field_value), true);
   }
 
   /**** (6) delete all multiples of nine *****/
   for (i = 9; i <= 100; i += 9) {
     snprintf(field_name, sizeof(field_name), "Test%d", i);
-    resp_hdr.field_delete(field_name, static_cast<int>(strlen(field_name)));
+    resp_hdr.field_delete(field_name, (int)strlen(field_name));
   }
 
   printf("\n======== mutated response ==========\n\n");
@@ -1555,7 +1553,7 @@ int
 HdrTest::test_arena_aux(Arena *arena, int len)
 {
   char *str      = arena->str_alloc(len);
-  int verify_len = static_cast<int>(arena->str_length(str));
+  int verify_len = (int)arena->str_length(str);
 
   if (len != verify_len) {
     printf("FAILED: requested %d, got %d bytes\n", len, verify_len);
@@ -1666,10 +1664,9 @@ HdrTest::test_accept_language_match()
 
   for (i = 0; test_cases[i].accept_language; i++) {
     StrList acpt_lang_list(false);
-    HttpCompat::parse_comma_list(&acpt_lang_list, test_cases[i].accept_language,
-                                 static_cast<int>(strlen(test_cases[i].accept_language)));
+    HttpCompat::parse_comma_list(&acpt_lang_list, test_cases[i].accept_language, (int)strlen(test_cases[i].accept_language));
 
-    Q = HttpCompat::match_accept_language(test_cases[i].content_language, static_cast<int>(strlen(test_cases[i].content_language)),
+    Q = HttpCompat::match_accept_language(test_cases[i].content_language, (int)strlen(test_cases[i].content_language),
                                           &acpt_lang_list, &L, &I);
 
     if ((Q != test_cases[i].Q) || (L != test_cases[i].L) || (I != test_cases[i].I)) {
@@ -1733,11 +1730,10 @@ HdrTest::test_accept_charset_match()
 
   for (i = 0; test_cases[i].accept_charset; i++) {
     StrList acpt_lang_list(false);
-    HttpCompat::parse_comma_list(&acpt_lang_list, test_cases[i].accept_charset,
-                                 static_cast<int>(strlen(test_cases[i].accept_charset)));
+    HttpCompat::parse_comma_list(&acpt_lang_list, test_cases[i].accept_charset, (int)strlen(test_cases[i].accept_charset));
 
-    Q = HttpCompat::match_accept_charset(test_cases[i].content_charset, static_cast<int>(strlen(test_cases[i].content_charset)),
-                                         &acpt_lang_list, &I);
+    Q = HttpCompat::match_accept_charset(test_cases[i].content_charset, (int)strlen(test_cases[i].content_charset), &acpt_lang_list,
+                                         &I);
 
     if ((Q != test_cases[i].Q) || (I != test_cases[i].I)) {
       printf("FAILED: (#%d) got { Q = %.3f; I = %d; }, expected { Q = %.3f; I = %d; }, from matching\n  '%s' against '%s'\n", i, Q,
@@ -1802,7 +1798,7 @@ HdrTest::test_comma_vals()
   for (i = 0; i < ntests; i++) {
     snprintf(field_name, sizeof(field_name), "Test%d", i);
 
-    MIMEField *f = hdr.field_create(field_name, static_cast<int>(strlen(field_name)));
+    MIMEField *f = hdr.field_create(field_name, (int)strlen(field_name));
     ink_release_assert(f->m_ptr_value == nullptr);
 
     hdr.field_attach(f);
@@ -1901,7 +1897,7 @@ HdrTest::test_set_comma_vals()
   for (i = 0; i < ntests; i++) {
     snprintf(field_name, sizeof(field_name), "Test%d", i);
 
-    MIMEField *f = hdr.field_create(field_name, static_cast<int>(strlen(field_name)));
+    MIMEField *f = hdr.field_create(field_name, (int)strlen(field_name));
     hdr.field_value_set(f, tests[i].old_raw, strlen(tests[i].old_raw));
     mime_field_value_set_comma_val(hdr.m_heap, hdr.m_mime, f, tests[i].idx, tests[i].slice, strlen(tests[i].slice));
     ink_release_assert(f->m_ptr_value != nullptr);
@@ -1909,8 +1905,8 @@ HdrTest::test_set_comma_vals()
     if ((f->m_len_value != strlen(tests[i].new_raw)) || (memcmp(f->m_ptr_value, tests[i].new_raw, f->m_len_value) != 0)) {
       ++failures;
       printf("FAILED:  test #%d (setting idx %d of '%s' to '%s') expected '%s' len %d, got '%.*s' len %d\n", i + 1, tests[i].idx,
-             tests[i].old_raw, tests[i].slice, tests[i].new_raw, static_cast<int>(strlen(tests[i].new_raw)), f->m_len_value,
-             f->m_ptr_value, f->m_len_value);
+             tests[i].old_raw, tests[i].slice, tests[i].new_raw, (int)strlen(tests[i].new_raw), f->m_len_value, f->m_ptr_value,
+             f->m_len_value);
     }
   }
 
@@ -2029,7 +2025,7 @@ HdrTest::test_parse_comma_list()
         if (cell != nullptr) {
           ++failures;
           printf("FAILED: test #%d (string '%s', idx %d) expected NULL piece, got [offset %d len %d]\n", i + 1, tests[i].value, j,
-                 offset, static_cast<int>(cell->len));
+                 offset, (int)cell->len);
         }
       } else // should have a piece
       {
@@ -2037,10 +2033,10 @@ HdrTest::test_parse_comma_list()
           ++failures;
           printf("FAILED: test #%d (string '%s', idx %d) expected [offset %d len %d], got NULL piece\n", i + 1, tests[i].value, j,
                  tests[i].pieces[j].offset, tests[i].pieces[j].len);
-        } else if ((offset != tests[i].pieces[j].offset) || (cell->len != static_cast<size_t>(tests[i].pieces[j].len))) {
+        } else if ((offset != tests[i].pieces[j].offset) || (cell->len != (size_t)tests[i].pieces[j].len)) {
           ++failures;
           printf("FAILED: test #%d (string '%s', idx %d) expected [offset %d len %d], got [offset %d len %d]\n", i + 1,
-                 tests[i].value, j, tests[i].pieces[j].offset, tests[i].pieces[j].len, offset, static_cast<int>(cell->len));
+                 tests[i].value, j, tests[i].pieces[j].offset, tests[i].pieces[j].len, offset, (int)cell->len);
         }
       }
     }
@@ -2057,7 +2053,7 @@ HdrTest::bri_box(const char *s)
 {
   int i, len;
 
-  len = static_cast<int>(strlen(s));
+  len = (int)strlen(s);
   printf("\n+-");
   for (i = 0; i < len; i++) {
     putchar('-');

--- a/proxy/hdrs/HdrToken.cc
+++ b/proxy/hdrs/HdrToken.cc
@@ -159,7 +159,7 @@ static HdrTokenTypeBinding _hdrtoken_strs_type_initializers[] = {
   {"s-maxage", HDRTOKEN_TYPE_CACHE_CONTROL},
   {"need-revalidate-once", HDRTOKEN_TYPE_CACHE_CONTROL},
 
-  {(char *)nullptr, static_cast<HdrTokenType>(0)},
+  {(char *)nullptr, (HdrTokenType)0},
 };
 
 static HdrTokenFieldInfo _hdrtoken_strs_field_initializers[] = {
@@ -373,23 +373,22 @@ hdrtoken_hash_init()
   memset(hdrtoken_hash_table, 0, sizeof(hdrtoken_hash_table));
   num_collisions = 0;
 
-  for (i = 0; i < static_cast<int> SIZEOF(_hdrtoken_commonly_tokenized_strs); i++) {
+  for (i = 0; i < (int)SIZEOF(_hdrtoken_commonly_tokenized_strs); i++) {
     // convert the common string to the well-known token
     unsigned const char *wks;
-    int wks_idx =
-      hdrtoken_tokenize_dfa(_hdrtoken_commonly_tokenized_strs[i], static_cast<int>(strlen(_hdrtoken_commonly_tokenized_strs[i])),
-                            reinterpret_cast<const char **>(&wks));
+    int wks_idx = hdrtoken_tokenize_dfa(_hdrtoken_commonly_tokenized_strs[i], (int)strlen(_hdrtoken_commonly_tokenized_strs[i]),
+                                        (const char **)&wks);
     ink_release_assert(wks_idx >= 0);
 
     uint32_t hash = hdrtoken_hash(wks, hdrtoken_str_lengths[wks_idx]);
     uint32_t slot = hash_to_slot(hash);
 
     if (hdrtoken_hash_table[slot].wks) {
-      printf("ERROR: hdrtoken_hash_table[%u] collision: '%s' replacing '%s'\n", slot, reinterpret_cast<const char *>(wks),
+      printf("ERROR: hdrtoken_hash_table[%u] collision: '%s' replacing '%s'\n", slot, (const char *)wks,
              hdrtoken_hash_table[slot].wks);
       ++num_collisions;
     }
-    hdrtoken_hash_table[slot].wks  = reinterpret_cast<const char *>(wks);
+    hdrtoken_hash_table[slot].wks  = (const char *)wks;
     hdrtoken_hash_table[slot].hash = hash;
   }
 
@@ -427,7 +426,7 @@ hdrtoken_init()
     inited = 1;
 
     hdrtoken_strs_dfa = new DFA;
-    hdrtoken_strs_dfa->compile(_hdrtoken_strs, SIZEOF(_hdrtoken_strs), (RE_CASE_INSENSITIVE));
+    hdrtoken_strs_dfa->compile(_hdrtoken_strs, SIZEOF(_hdrtoken_strs), (REFlags)(RE_CASE_INSENSITIVE));
 
     // all the tokenized hdrtoken strings are placed in a special heap,
     // and each string is prepended with a HdrTokenHeapPrefix ---
@@ -437,19 +436,19 @@ hdrtoken_init()
     // other info from the prefix.
 
     int heap_size = 0;
-    for (i = 0; i < static_cast<int> SIZEOF(_hdrtoken_strs); i++) {
-      hdrtoken_str_lengths[i]   = static_cast<int>(strlen(_hdrtoken_strs[i]));
+    for (i = 0; i < (int)SIZEOF(_hdrtoken_strs); i++) {
+      hdrtoken_str_lengths[i]   = (int)strlen(_hdrtoken_strs[i]);
       int sstr_len              = snap_up_to_multiple(hdrtoken_str_lengths[i] + 1, sizeof(HdrTokenHeapPrefix));
       int packed_prefix_str_len = sizeof(HdrTokenHeapPrefix) + sstr_len;
       heap_size += packed_prefix_str_len;
     }
 
-    _hdrtoken_strs_heap_f = static_cast<const char *>(ats_malloc(heap_size));
+    _hdrtoken_strs_heap_f = (const char *)ats_malloc(heap_size);
     _hdrtoken_strs_heap_l = _hdrtoken_strs_heap_f + heap_size - 1;
 
-    char *heap_ptr = const_cast<char *>(_hdrtoken_strs_heap_f);
+    char *heap_ptr = (char *)_hdrtoken_strs_heap_f;
 
-    for (i = 0; i < static_cast<int> SIZEOF(_hdrtoken_strs); i++) {
+    for (i = 0; i < (int)SIZEOF(_hdrtoken_strs); i++) {
       HdrTokenHeapPrefix prefix;
 
       memset(&prefix, 0, sizeof(HdrTokenHeapPrefix));
@@ -464,13 +463,12 @@ hdrtoken_init()
 
       int sstr_len = snap_up_to_multiple(hdrtoken_str_lengths[i] + 1, sizeof(HdrTokenHeapPrefix));
 
-      *reinterpret_cast<HdrTokenHeapPrefix *>(heap_ptr) = prefix; // set string prefix
-      heap_ptr += sizeof(HdrTokenHeapPrefix);                     // advance heap ptr past index
-      hdrtoken_strs[i] = heap_ptr;                                // record string pointer
+      *(HdrTokenHeapPrefix *)heap_ptr = prefix; // set string prefix
+      heap_ptr += sizeof(HdrTokenHeapPrefix);   // advance heap ptr past index
+      hdrtoken_strs[i] = heap_ptr;              // record string pointer
       // coverity[secure_coding]
-      ink_strlcpy(const_cast<char *>(hdrtoken_strs[i]), _hdrtoken_strs[i],
-                  heap_size - sizeof(HdrTokenHeapPrefix)); // copy string into heap
-      heap_ptr += sstr_len;                                // advance heap ptr past string
+      ink_strlcpy((char *)hdrtoken_strs[i], _hdrtoken_strs[i], heap_size - sizeof(HdrTokenHeapPrefix)); // copy string into heap
+      heap_ptr += sstr_len; // advance heap ptr past string
       heap_size -= sstr_len;
     }
 
@@ -479,8 +477,8 @@ hdrtoken_init()
       int wks_idx;
       HdrTokenHeapPrefix *prefix;
 
-      wks_idx = hdrtoken_tokenize_dfa(_hdrtoken_strs_type_initializers[i].name,
-                                      static_cast<int>(strlen(_hdrtoken_strs_type_initializers[i].name)));
+      wks_idx =
+        hdrtoken_tokenize_dfa(_hdrtoken_strs_type_initializers[i].name, (int)strlen(_hdrtoken_strs_type_initializers[i].name));
 
       ink_assert((wks_idx >= 0) && (wks_idx < (int)SIZEOF(hdrtoken_strs)));
       // coverity[negative_returns]
@@ -493,8 +491,8 @@ hdrtoken_init()
       int wks_idx;
       HdrTokenHeapPrefix *prefix;
 
-      wks_idx = hdrtoken_tokenize_dfa(_hdrtoken_strs_field_initializers[i].name,
-                                      static_cast<int>(strlen(_hdrtoken_strs_field_initializers[i].name)));
+      wks_idx =
+        hdrtoken_tokenize_dfa(_hdrtoken_strs_field_initializers[i].name, (int)strlen(_hdrtoken_strs_field_initializers[i].name));
 
       ink_assert((wks_idx >= 0) && (wks_idx < (int)SIZEOF(hdrtoken_strs)));
       prefix                  = hdrtoken_index_to_prefix(wks_idx);
@@ -503,7 +501,7 @@ hdrtoken_init()
       prefix->wks_info.mask   = _hdrtoken_strs_field_initializers[i].mask;
     }
 
-    for (i = 0; i < static_cast<int> SIZEOF(_hdrtoken_strs); i++) {
+    for (i = 0; i < (int)SIZEOF(_hdrtoken_strs); i++) {
       HdrTokenHeapPrefix *prefix  = hdrtoken_index_to_prefix(i);
       prefix->wks_info.name       = hdrtoken_strs[i];
       hdrtoken_str_token_types[i] = prefix->wks_token_type;  // parallel array for speed
@@ -560,7 +558,7 @@ hdrtoken_tokenize(const char *string, int string_len, const char **wks_string_ou
     return wks_idx;
   }
 
-  uint32_t hash = hdrtoken_hash(reinterpret_cast<const unsigned char *>(string), static_cast<unsigned int>(string_len));
+  uint32_t hash = hdrtoken_hash((const unsigned char *)string, (unsigned int)string_len);
   uint32_t slot = hash_to_slot(hash);
 
   bucket = &(hdrtoken_hash_table[slot]);
@@ -583,7 +581,7 @@ const char *
 hdrtoken_string_to_wks(const char *string)
 {
   const char *wks = nullptr;
-  hdrtoken_tokenize(string, static_cast<int>(strlen(string)), &wks);
+  hdrtoken_tokenize(string, (int)strlen(string), &wks);
   return wks;
 }
 

--- a/proxy/hdrs/HttpCompat.cc
+++ b/proxy/hdrs/HttpCompat.cc
@@ -46,7 +46,7 @@ HttpCompat::parse_tok_list(StrList *list, int trim_quotes, const char *string, c
   if (string == nullptr) {
     return;
   }
-  HttpCompat::parse_tok_list(list, trim_quotes, string, static_cast<int>(strlen(string)), sep);
+  HttpCompat::parse_tok_list(list, trim_quotes, string, (int)strlen(string), sep);
 }
 
 void
@@ -152,7 +152,7 @@ HttpCompat::parse_tok_list(StrList *list, int trim_quotes, const char *string, i
     // after the last char in the string.                              //
     /////////////////////////////////////////////////////////////////////
 
-    byte_length = static_cast<int>(e - s);
+    byte_length = (int)(e - s);
     ink_assert(byte_length >= 0);
 
     ///////////////////////////////////////////
@@ -573,7 +573,7 @@ HttpCompat::match_accept_language(const char *lang_str, int lang_len, StrList *a
     // now rip the Accept-Language tag into head and Q parts //
     ///////////////////////////////////////////////////////////
     StrList a_param_list(false);
-    HttpCompat::parse_semicolon_list(&a_param_list, a_value->str, static_cast<int>(a_value->len));
+    HttpCompat::parse_semicolon_list(&a_param_list, a_value->str, (int)a_value->len);
     if (!a_param_list.head) {
       continue;
     }
@@ -586,7 +586,7 @@ HttpCompat::match_accept_language(const char *lang_str, int lang_len, StrList *a
     // was specified, this document matches all accept headers.        //
     /////////////////////////////////////////////////////////////////////
     const char *atag_str = a_param_list.head->str;
-    int atag_len         = static_cast<int>(a_param_list.head->len);
+    int atag_len         = (int)a_param_list.head->len;
 
     float tq = HttpCompat::find_Q_param_in_strlist(&a_param_list);
 
@@ -688,7 +688,7 @@ HttpCompat::match_accept_charset(const char *charset_str, int charset_len, StrLi
     // now rip the Accept-Charset tag into head and Q parts //
     //////////////////////////////////////////////////////////
     StrList a_param_list(false);
-    HttpCompat::parse_semicolon_list(&a_param_list, a_value->str, static_cast<int>(a_value->len));
+    HttpCompat::parse_semicolon_list(&a_param_list, a_value->str, (int)a_value->len);
     if (!a_param_list.head) {
       continue;
     }
@@ -697,7 +697,7 @@ HttpCompat::match_accept_charset(const char *charset_str, int charset_len, StrLi
     // see if the Accept-Charset tag matches the current charset //
     ///////////////////////////////////////////////////////////////
     const char *atag_str = a_param_list.head->str;
-    int atag_len         = static_cast<int>(a_param_list.head->len);
+    int atag_len         = (int)a_param_list.head->len;
     float tq             = HttpCompat::find_Q_param_in_strlist(&a_param_list);
 
     if ((atag_len == 1) && (atag_str[0] == '*')) // wildcard

--- a/proxy/hdrs/MIME.cc
+++ b/proxy/hdrs/MIME.cc
@@ -979,12 +979,12 @@ mime_init_date_format_table()
   int m = 0, d = 0, y = 0;
 
   time(&now_secs);
-  now_days   = static_cast<int>(now_secs / (60 * 60 * 24));
+  now_days   = (int)(now_secs / (60 * 60 * 24));
   first_days = now_days - 366;
   last_days  = now_days + 366;
   num_days   = last_days - first_days + 1;
 
-  _days_to_mdy_fast_lookup_table           = static_cast<MDY *>(ats_malloc(num_days * sizeof(MDY)));
+  _days_to_mdy_fast_lookup_table           = (MDY *)ats_malloc(num_days * sizeof(MDY));
   _days_to_mdy_fast_lookup_table_first_day = first_days;
   _days_to_mdy_fast_lookup_table_last_day  = last_days;
 
@@ -1116,8 +1116,8 @@ mime_hdr_copy_onto(MIMEHdrImpl *s_mh, HdrHeap *s_heap, MIMEHdrImpl *d_mh, HdrHea
   ink_assert(((char *)&(s_mh->m_first_fblock.m_field_slots[MIME_FIELD_BLOCK_SLOTS]) - (char *)s_mh) == sizeof(struct MIMEHdrImpl));
 
   int top             = s_mh->m_first_fblock.m_freetop;
-  char *end           = reinterpret_cast<char *>(&(s_mh->m_first_fblock.m_field_slots[top]));
-  int bytes_below_top = end - reinterpret_cast<char *>(s_mh);
+  char *end           = (char *)&(s_mh->m_first_fblock.m_field_slots[top]);
+  int bytes_below_top = end - (char *)s_mh;
 
   // copies useful part of enclosed first block too
   memcpy(d_mh, s_mh, bytes_below_top);
@@ -1758,7 +1758,7 @@ MIMEField::value_get_index(const char *value, int length) const
 
   // if field doesn't support commas and there is just one instance, just compare the value
   if (!this->supports_commas() && !this->has_dups()) {
-    if (this->m_len_value == static_cast<uint32_t>(length) && strncasecmp(value, this->m_ptr_value, length) == 0) {
+    if (this->m_len_value == (uint32_t)length && strncasecmp(value, this->m_ptr_value, length) == 0) {
       retval = 0;
     }
   } else {
@@ -1835,7 +1835,7 @@ mime_field_value_get_comma_val(const MIMEField *field, int *length, int idx)
     mime_field_value_get_comma_list(field, &list);
     str = list.get_idx(idx);
     if (str != nullptr) {
-      *length = static_cast<int>(str->len);
+      *length = (int)(str->len);
       return str->str;
     } else {
       *length = 0;
@@ -2073,7 +2073,7 @@ mime_field_value_extend_comma_val(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField *fie
   if (extended_len <= sizeof(temp_buf)) {
     temp_ptr = temp_buf;
   } else {
-    temp_ptr = static_cast<char *>(ats_malloc(extended_len));
+    temp_ptr = (char *)ats_malloc(extended_len);
   }
 
   // (7) construct new extended token
@@ -2953,15 +2953,15 @@ mime_format_date(char *buffer, time_t value)
 
   buf = buffer;
 
-  sec = static_cast<int>(value % 60);
+  sec = (int)(value % 60);
   value /= 60;
-  min = static_cast<int>(value % 60);
+  min = (int)(value % 60);
   value /= 60;
-  hour = static_cast<int>(value % 24);
+  hour = (int)(value % 24);
   value /= 24;
 
   /* Jan 1, 1970 was a Thursday */
-  wday = static_cast<int>((4 + value) % 7);
+  wday = (int)((4 + value) % 7);
 
 /* value is days since Jan 1, 1970 */
 #if MIME_FORMAT_DATE_USE_LOOKUP_TABLE
@@ -3342,7 +3342,7 @@ mime_parse_date(const char *buf, const char *end)
   int mday;
 
   if (!buf) {
-    return static_cast<time_t>(0);
+    return (time_t)0;
   }
 
   while ((buf != end) && is_ws(*buf)) {
@@ -3351,24 +3351,24 @@ mime_parse_date(const char *buf, const char *end)
 
   if ((buf != end) && is_digit(*buf)) { // NNTP date
     if (!mime_parse_mday(buf, end, &tp.tm_mday)) {
-      return static_cast<time_t>(0);
+      return (time_t)0;
     }
     if (!mime_parse_month(buf, end, &tp.tm_mon)) {
-      return static_cast<time_t>(0);
+      return (time_t)0;
     }
     if (!mime_parse_year(buf, end, &tp.tm_year)) {
-      return static_cast<time_t>(0);
+      return (time_t)0;
     }
     if (!mime_parse_time(buf, end, &tp.tm_hour, &tp.tm_min, &tp.tm_sec)) {
-      return static_cast<time_t>(0);
+      return (time_t)0;
     }
   } else if (end && (end - buf >= 29) && (buf[3] == ',')) {
     if (!mime_parse_rfc822_date_fastcase(buf, end - buf, &tp)) {
-      return static_cast<time_t>(0);
+      return (time_t)0;
     }
   } else {
     if (!mime_parse_day(buf, end, &tp.tm_wday)) {
-      return static_cast<time_t>(0);
+      return (time_t)0;
     }
 
     while ((buf != end) && is_ws(*buf)) {
@@ -3378,31 +3378,31 @@ mime_parse_date(const char *buf, const char *end)
     if ((buf != end) && ((*buf == ',') || is_digit(*buf))) {
       // RFC 822 or RFC 850 time format
       if (!mime_parse_mday(buf, end, &tp.tm_mday)) {
-        return static_cast<time_t>(0);
+        return (time_t)0;
       }
       if (!mime_parse_month(buf, end, &tp.tm_mon)) {
-        return static_cast<time_t>(0);
+        return (time_t)0;
       }
       if (!mime_parse_year(buf, end, &tp.tm_year)) {
-        return static_cast<time_t>(0);
+        return (time_t)0;
       }
       if (!mime_parse_time(buf, end, &tp.tm_hour, &tp.tm_min, &tp.tm_sec)) {
-        return static_cast<time_t>(0);
+        return (time_t)0;
       }
       // ignore timezone specifier...should always be GMT anyways
     } else {
       // ANSI C's asctime format
       if (!mime_parse_month(buf, end, &tp.tm_mon)) {
-        return static_cast<time_t>(0);
+        return (time_t)0;
       }
       if (!mime_parse_mday(buf, end, &tp.tm_mday)) {
-        return static_cast<time_t>(0);
+        return (time_t)0;
       }
       if (!mime_parse_time(buf, end, &tp.tm_hour, &tp.tm_min, &tp.tm_sec)) {
-        return static_cast<time_t>(0);
+        return (time_t)0;
       }
       if (!mime_parse_year(buf, end, &tp.tm_year)) {
-        return static_cast<time_t>(0);
+        return (time_t)0;
       }
     }
   }
@@ -3413,10 +3413,10 @@ mime_parse_date(const char *buf, const char *end)
 
   // what should we do?
   if (year > 137) {
-    return static_cast<time_t>(INT_MAX);
+    return (time_t)INT_MAX;
   }
   if (year < 70) {
-    return static_cast<time_t>(0);
+    return (time_t)0;
   }
 
   mday += days[month];

--- a/proxy/hdrs/URL.cc
+++ b/proxy/hdrs/URL.cc
@@ -621,7 +621,7 @@ url_string_get_ref(HdrHeap *heap, URLImpl *url, int *length)
     if (length) {
       *length = url->m_len_printed_string;
     }
-    return const_cast<char *>(url->m_ptr_printed_string);
+    return (char *)url->m_ptr_printed_string;
   } else { // either not clean or never printed
     int len = url_length_get(url);
     char *buf;
@@ -652,7 +652,7 @@ url_string_get(URLImpl *url, Arena *arena, int *length, HdrHeap *heap)
   int index  = 0;
   int offset = 0;
 
-  buf = arena ? arena->str_alloc(len) : static_cast<char *>(ats_malloc(len + 1));
+  buf = arena ? arena->str_alloc(len) : (char *)ats_malloc(len + 1);
 
   url_print(url, buf, len, &index, &offset);
   buf[len] = '\0';
@@ -866,7 +866,7 @@ url_to_string(URLImpl *url, Arena *arena, int *length)
   if (arena) {
     str = arena->str_alloc(len);
   } else {
-    str = static_cast<char *>(ats_malloc(len + 1));
+    str = (char *)ats_malloc(len + 1);
   }
 
   idx = 0;
@@ -946,12 +946,12 @@ unescape_str(char *&buf, char *buf_e, const char *&str, const char *str_e, int &
 {
   int copy_len;
   char *first_pct;
-  int buf_len = static_cast<int>(buf_e - buf);
-  int str_len = static_cast<int>(str_e - str);
-  int min_len = (str_len < buf_len ? str_len : buf_len);
+  int buf_len = (int)(buf_e - buf);
+  int str_len = (int)(str_e - str);
+  int min_len = (int)(str_len < buf_len ? str_len : buf_len);
 
-  first_pct = ink_memcpy_until_char(buf, const_cast<char *>(str), min_len, '%');
-  copy_len  = static_cast<int>(first_pct - str);
+  first_pct = ink_memcpy_until_char(buf, (char *)str, min_len, '%');
+  copy_len  = (int)(first_pct - str);
   str += copy_len;
   buf += copy_len;
   if (copy_len == min_len) {
@@ -1077,7 +1077,7 @@ url_unescapify(Arena *arena, const char *str, int length)
   int s;
 
   if (length == -1) {
-    length = static_cast<int>(strlen(str));
+    length = (int)strlen(str);
   }
 
   buffer = arena->str_alloc(length);
@@ -1660,9 +1660,9 @@ url_CryptoHash_get_fast(const URLImpl *url, CryptoContext &ctx, CryptoHash *hash
   // no query
 
   ink_assert(sizeof(url->m_port) == 2);
-  uint16_t port = static_cast<uint16_t>(url_canonicalize_port(url->m_url_type, url->m_port));
-  *p++          = (reinterpret_cast<char *>(&port))[0];
-  *p++          = (reinterpret_cast<char *>(&port))[1];
+  uint16_t port = (uint16_t)url_canonicalize_port(url->m_url_type, url->m_port);
+  *p++          = ((char *)&port)[0];
+  *p++          = ((char *)&port)[1];
 
   ctx.update(buffer, p - buffer);
   if (generation != -1) {

--- a/proxy/http/Http1ServerSession.cc
+++ b/proxy/http/Http1ServerSession.cc
@@ -69,7 +69,7 @@ Http1ServerSession::new_connection(NetVConnection *new_vc)
   mutex = new_vc->mutex;
 
   // Unique client session identifier.
-  con_id = ink_atomic_increment((&next_ss_id), 1);
+  con_id = ink_atomic_increment((int64_t *)(&next_ss_id), 1);
 
   magic = HTTP_SS_MAGIC_ALIVE;
   HTTP_SUM_GLOBAL_DYN_STAT(http_current_server_connections_stat, 1); // Update the true global stat

--- a/proxy/http/HttpBodyFactory.cc
+++ b/proxy/http/HttpBodyFactory.cc
@@ -160,7 +160,7 @@ HttpBodyFactory::fabricate_with_old_api(const char *type, HttpTransact::State *c
                  set, type, *resulting_buffer_length, max_buffer_length);
     }
     *resulting_buffer_length = 0;
-    buffer                   = static_cast<char *>(ats_free_null(buffer));
+    buffer                   = (char *)ats_free_null(buffer);
   }
   /////////////////////////////////////////////////////////////////////
   // handle return of instantiated template and generate the content //
@@ -231,7 +231,7 @@ static int
 config_callback(const char * /* name ATS_UNUSED */, RecDataT /* data_type ATS_UNUSED */, RecData /* data ATS_UNUSED */,
                 void *cookie)
 {
-  HttpBodyFactory *body_factory = static_cast<HttpBodyFactory *>(cookie);
+  HttpBodyFactory *body_factory = (HttpBodyFactory *)cookie;
   body_factory->reconfigure();
   return 0;
 }
@@ -1110,7 +1110,7 @@ HttpBodyTemplate::load_from_file(char *dir, char *file)
   ////////////////////////////////////////
 
   new_byte_count                      = stat_buf.st_size;
-  new_template_buffer                 = static_cast<char *>(ats_malloc(new_byte_count + 1));
+  new_template_buffer                 = (char *)ats_malloc(new_byte_count + 1);
   bytes_read                          = read(fd, new_template_buffer, new_byte_count);
   new_template_buffer[new_byte_count] = '\0';
   close(fd);

--- a/proxy/http/HttpCacheSM.cc
+++ b/proxy/http/HttpCacheSM.cc
@@ -110,7 +110,7 @@ HttpCacheSM::state_cache_open_read(int event, void *data)
       close_read();
     }
     open_read_cb  = true;
-    cache_read_vc = static_cast<CacheVConnection *>(data);
+    cache_read_vc = (CacheVConnection *)data;
     master_sm->handleEvent(event, data);
     break;
 
@@ -165,7 +165,7 @@ HttpCacheSM::state_cache_open_write(int event, void *data)
   case CACHE_EVENT_OPEN_WRITE:
     HTTP_INCREMENT_DYN_STAT(http_current_cache_connections_stat);
     ink_assert(cache_write_vc == nullptr);
-    cache_write_vc = static_cast<CacheVConnection *>(data);
+    cache_write_vc = (CacheVConnection *)data;
     open_write_cb  = true;
     master_sm->handleEvent(event, data);
     break;
@@ -196,10 +196,10 @@ HttpCacheSM::state_cache_open_write(int event, void *data)
           "retrying cache open write...",
           master_sm->sm_id, open_write_tries);
 
-    open_write(&cache_key, lookup_url, read_request_hdr, master_sm->t_state.cache_info.object_read,
-               static_cast<time_t>(
-                 (master_sm->t_state.cache_control.pin_in_cache_for < 0) ? 0 : master_sm->t_state.cache_control.pin_in_cache_for),
-               retry_write, false);
+    open_write(
+      &cache_key, lookup_url, read_request_hdr, master_sm->t_state.cache_info.object_read,
+      (time_t)((master_sm->t_state.cache_control.pin_in_cache_for < 0) ? 0 : master_sm->t_state.cache_control.pin_in_cache_for),
+      retry_write, false);
     break;
 
   default:

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -131,7 +131,7 @@ HttpConfigCont::HttpConfigCont() : Continuation(new_ProxyMutex())
 int
 HttpConfigCont::handle_event(int /* event ATS_UNUSED */, void * /* edata ATS_UNUSED */)
 {
-  if (ink_atomic_increment(&http_config_changes, -1) == 1) {
+  if (ink_atomic_increment((int *)&http_config_changes, -1) == 1) {
     HttpConfig::reconfigure();
   }
   return 0;
@@ -141,7 +141,7 @@ static int
 http_config_cb(const char * /* name ATS_UNUSED */, RecDataT /* data_type ATS_UNUSED */, RecData /* data ATS_UNUSED */,
                void * /* cookie ATS_UNUSED */)
 {
-  ink_atomic_increment(&http_config_changes, 1);
+  ink_atomic_increment((int *)&http_config_changes, 1);
 
   INK_MEMORY_BARRIER;
 
@@ -962,7 +962,7 @@ void
 HttpConfig::startup()
 {
   extern void SSLConfigInit(IpMap * map);
-  http_rsb = RecAllocateRawStatBlock(static_cast<int>(http_stat_count));
+  http_rsb = RecAllocateRawStatBlock((int)http_stat_count);
   register_stat_callbacks();
 
   HttpConfigParams &c = m_master;
@@ -973,7 +973,7 @@ HttpConfig::startup()
   c.proxy_hostname_len = -1;
 
   if (c.proxy_hostname == nullptr) {
-    c.proxy_hostname    = static_cast<char *>(ats_malloc(sizeof(char)));
+    c.proxy_hostname    = (char *)ats_malloc(sizeof(char));
     c.proxy_hostname[0] = '\0';
   }
 

--- a/proxy/http/HttpPages.cc
+++ b/proxy/http/HttpPages.cc
@@ -45,12 +45,12 @@ HttpPagesHandler::HttpPagesHandler(Continuation *cont, HTTPHdr *header)
   int length;
 
   url     = header->url_get();
-  request = const_cast<char *>(url->path_get(&length));
+  request = (char *)url->path_get(&length);
   request = arena.str_store(request, length);
 
   if (strncmp(request, "sm_details", sizeof("sm_details")) == 0) {
     arena.str_free(request);
-    request = const_cast<char *>(url->query_get(&length));
+    request = (char *)url->query_get(&length);
     request = arena.str_store(request, length);
     SET_HANDLER(&HttpPagesHandler::handle_smdetails);
 
@@ -67,7 +67,7 @@ HttpPagesHandler::extract_id(const char *query)
   char *p;
   int64_t id;
 
-  p = const_cast<char *>(strstr(query, "id="));
+  p = (char *)strstr(query, "id=");
   if (!p) {
     return -1;
   }
@@ -220,11 +220,11 @@ HttpPagesHandler::dump_history(HttpSM *sm)
     resp_end_column();
 
     resp_begin_column();
-    resp_add("%u", static_cast<unsigned int>(sm->history[i].event));
+    resp_add("%u", (unsigned int)sm->history[i].event);
     resp_end_column();
 
     resp_begin_column();
-    resp_add("%d", static_cast<int>(sm->history[i].reentrancy));
+    resp_add("%d", (int)sm->history[i].reentrancy);
     resp_end_column();
 
     resp_end_row();

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -378,7 +378,7 @@ HttpSM::state_add_to_list(int event, void * /* data ATS_UNUSED */)
     STATE_ENTER(&HttpSM::state_add_to_list, event);
     ink_assert(event == EVENT_NONE || event == EVENT_INTERVAL);
 
-    int bucket = (static_cast<unsigned int>(sm_id) % HTTP_LIST_BUCKETS);
+    int bucket = ((unsigned int)sm_id % HTTP_LIST_BUCKETS);
 
     MUTEX_TRY_LOCK(lock, HttpSMList[bucket].mutex, mutex->thread_holding);
     // the client_vc`s timeout events can be triggered, so we should not
@@ -406,7 +406,7 @@ HttpSM::state_remove_from_list(int event, void * /* data ATS_UNUSED */)
     STATE_ENTER(&HttpSM::state_remove_from_list, event);
     ink_assert(event == EVENT_NONE || event == EVENT_INTERVAL);
 
-    int bucket = (static_cast<unsigned int>(sm_id) % HTTP_LIST_BUCKETS);
+    int bucket = ((unsigned int)sm_id % HTTP_LIST_BUCKETS);
 
     MUTEX_TRY_LOCK(lock, HttpSMList[bucket].mutex, mutex->thread_holding);
     if (!lock.is_locked()) {
@@ -814,7 +814,7 @@ HttpSM::wait_for_full_body()
 
   // content length is undefined, use default buffer size
   if (t_state.hdr_info.request_content_length == HTTP_UNDEFINED_CL) {
-    alloc_index = static_cast<int>(t_state.txn_conf->default_buffer_size_index);
+    alloc_index = (int)t_state.txn_conf->default_buffer_size_index;
     if (alloc_index < MIN_CONFIG_BUFFER_SIZE_INDEX || alloc_index > MAX_BUFFER_SIZE_INDEX) {
       alloc_index = DEFAULT_REQUEST_BUFFER_SIZE_INDEX;
     }
@@ -1102,7 +1102,7 @@ HttpSM::state_raw_http_server_open(int event, void *data)
 
     // Record the VC in our table
     server_entry     = vc_table.new_entry();
-    server_entry->vc = netvc = static_cast<NetVConnection *>(data);
+    server_entry->vc = netvc = (NetVConnection *)data;
     server_entry->vc_type    = HTTP_RAW_SERVER_VC;
     t_state.current.state    = HttpTransact::CONNECTION_ALIVE;
     ats_ip_copy(&t_state.server_info.src_addr, netvc->get_local_addr());
@@ -1142,7 +1142,7 @@ HttpSM::state_request_wait_for_transform_read(int event, void *data)
 
   switch (event) {
   case TRANSFORM_READ_READY:
-    size = *(static_cast<int64_t *>(data));
+    size = *((int64_t *)data);
     if (size != INT64_MAX && size >= 0) {
       // We got a content length so update our internal
       //   data as well as fix up the request header
@@ -1178,7 +1178,7 @@ int
 HttpSM::state_response_wait_for_transform_read(int event, void *data)
 {
   STATE_ENTER(&HttpSM::state_response_wait_for_transform_read, event);
-  int64_t size = *(static_cast<int64_t *>(data));
+  int64_t size = *((int64_t *)data);
 
   switch (event) {
   case TRANSFORM_READ_READY:
@@ -1842,7 +1842,7 @@ HttpSM::state_read_server_response_header(int event, void *data)
   ink_assert(t_state.current.state == HttpTransact::STATE_UNDEFINED);
 
   int bytes_used = 0;
-  VIO *vio       = static_cast<VIO *>(data);
+  VIO *vio       = (VIO *)data;
 
   switch (event) {
   case VC_EVENT_EOS:
@@ -2105,7 +2105,7 @@ HttpSM::process_srv_info(HostDBInfo *r)
     HostDBInfo *srv      = nullptr;
     if (rr) {
       srv = rr->select_best_srv(t_state.dns_info.srv_hostname, &mutex->thread_holding->generator, ink_local_time(),
-                                static_cast<int>(t_state.txn_conf->down_server_timeout));
+                                (int)t_state.txn_conf->down_server_timeout);
     }
     if (!srv) {
       t_state.dns_info.srv_lookup_success = false;
@@ -2175,7 +2175,7 @@ HttpSM::process_hostdb_info(HostDBInfo *r)
             }
           }
 
-          if (last_failure != 0 && static_cast<uint32_t>(now - t_state.txn_conf->down_server_timeout) < last_failure) {
+          if (last_failure != 0 && (uint32_t)(now - t_state.txn_conf->down_server_timeout) < last_failure) {
             HostDBApplicationInfo app;
             app.allotment.application1 = 0;
             app.allotment.application2 = 0;
@@ -2212,7 +2212,7 @@ HttpSM::process_hostdb_info(HostDBInfo *r)
 
   if (is_debug_tag_set("http_timeout")) {
     if (t_state.api_txn_dns_timeout_value != -1) {
-      int foo = static_cast<int>(milestones.difference_msec(TS_MILESTONE_DNS_LOOKUP_BEGIN, TS_MILESTONE_DNS_LOOKUP_END));
+      int foo = (int)(milestones.difference_msec(TS_MILESTONE_DNS_LOOKUP_BEGIN, TS_MILESTONE_DNS_LOOKUP_END));
       SMDebug("http_timeout", "DNS took: %d msec", foo);
     }
   }
@@ -2237,12 +2237,12 @@ HttpSM::state_hostdb_lookup(int event, void *data)
   switch (event) {
   case EVENT_HOST_DB_LOOKUP:
     pending_action = nullptr;
-    process_hostdb_info(static_cast<HostDBInfo *>(data));
+    process_hostdb_info((HostDBInfo *)data);
     call_transact_and_set_next_state(nullptr);
     break;
   case EVENT_SRV_LOOKUP: {
     pending_action = nullptr;
-    process_srv_info(static_cast<HostDBInfo *>(data));
+    process_srv_info((HostDBInfo *)data);
 
     char *host_name = t_state.dns_info.srv_lookup_success ? t_state.dns_info.srv_hostname : t_state.dns_info.lookup_name;
     HostDBProcessor::Options opt;
@@ -2285,7 +2285,7 @@ HttpSM::state_hostdb_reverse_lookup(int event, void *data)
   case EVENT_HOST_DB_LOOKUP:
     pending_action = nullptr;
     if (data) {
-      t_state.request_data.hostname_str = (static_cast<HostDBInfo *>(data))->hostname();
+      t_state.request_data.hostname_str = ((HostDBInfo *)data)->hostname();
     } else {
       SMDebug("http", "[%" PRId64 "] reverse DNS lookup failed for '%s'", sm_id, t_state.dns_info.lookup_name);
     }
@@ -2310,7 +2310,7 @@ HttpSM::state_mark_os_down(int event, void *data)
   HostDBInfo *mark_down = nullptr;
 
   if (event == EVENT_HOST_DB_LOOKUP && data) {
-    HostDBInfo *r = static_cast<HostDBInfo *>(data);
+    HostDBInfo *r = (HostDBInfo *)data;
 
     if (r->round_robin) {
       // Look for the entry we need mark down in the round robin
@@ -2349,7 +2349,7 @@ HttpSM::state_handle_stat_page(int event, void *data)
     pending_action = nullptr;
 
     if (data) {
-      StatPageData *spd = static_cast<StatPageData *>(data);
+      StatPageData *spd = (StatPageData *)data;
 
       t_state.internal_msg_buffer = spd->data;
       if (spd->type) {
@@ -2574,7 +2574,7 @@ HttpSM::main_handler(int event, void *data)
     //  do with a VIO to save a few cycles
 
     if (event < VC_EVENT_EVENTS_START + 100) {
-      vc_entry = vc_table.find_entry(static_cast<VIO *>(data));
+      vc_entry = vc_table.find_entry((VIO *)data);
     }
   }
 
@@ -3147,7 +3147,7 @@ HttpSM::is_bg_fill_necessary(HttpTunnelConsumer *c)
 
     if (ua_cl > 0) {
       int64_t ua_body_done = c->bytes_written - client_response_hdr_bytes;
-      float pDone          = static_cast<float>(ua_body_done) / ua_cl;
+      float pDone          = (float)ua_body_done / ua_cl;
 
       // If we got a good content length.  Check to make sure that we haven't already
       //  done more the content length since that would indicate the content-length
@@ -3924,7 +3924,7 @@ HttpSM::state_srv_lookup(int event, void *data)
   switch (event) {
   case EVENT_SRV_LOOKUP:
     pending_action = nullptr;
-    process_srv_info(static_cast<HostDBInfo *>(data));
+    process_srv_info((HostDBInfo *)data);
     break;
   case EVENT_SRV_IP_REMOVED:
     ink_assert(!"Unexpected SRV event from HostDB. What up, Eric?");
@@ -4254,7 +4254,7 @@ HttpSM::parse_range_and_compare(MIMEField *field, int64_t content_length)
   t_state.range_in_cache = true;
 
   for (; value; value = csv.get_next(&value_len)) {
-    if (!(tmp = static_cast<const char *>(memchr(value, '-', value_len)))) {
+    if (!(tmp = (const char *)memchr(value, '-', value_len))) {
       t_state.range_setup = HttpTransact::RANGE_NONE;
       goto Lfaild;
     }
@@ -4369,7 +4369,7 @@ HttpSM::parse_range_and_compare(MIMEField *field, int64_t content_length)
       HTTPInfo::FragOffset *frag_offset_tbl = t_state.cache_info.object_read->get_frag_table();
       int frag_offset_cnt                   = t_state.cache_info.object_read->get_frag_offset_count();
 
-      if (!frag_offset_tbl || !frag_offset_cnt || (frag_offset_tbl[frag_offset_cnt - 1] < static_cast<uint64_t>(end))) {
+      if (!frag_offset_tbl || !frag_offset_cnt || (frag_offset_tbl[frag_offset_cnt - 1] < (uint64_t)end)) {
         Debug("http_range", "request range in cache, end %" PRId64 ", frg_offset_cnt %d" PRId64, end, frag_offset_cnt);
         t_state.range_in_cache = false;
       }
@@ -4534,9 +4534,9 @@ HttpSM::do_cache_lookup_and_read()
   HttpCacheKey key;
   Cache::generate_key(&key, c_url, t_state.txn_conf->cache_generation_number);
 
-  Action *cache_action_handle = cache_sm.open_read(
-    &key, c_url, &t_state.hdr_info.client_request, t_state.txn_conf,
-    static_cast<time_t>((t_state.cache_control.pin_in_cache_for < 0) ? 0 : t_state.cache_control.pin_in_cache_for));
+  Action *cache_action_handle =
+    cache_sm.open_read(&key, c_url, &t_state.hdr_info.client_request, t_state.txn_conf,
+                       (time_t)((t_state.cache_control.pin_in_cache_for < 0) ? 0 : t_state.cache_control.pin_in_cache_for));
   //
   // pin_in_cache value is an open_write parameter.
   // It is passed in open_read to allow the cluster to
@@ -4650,10 +4650,9 @@ HttpSM::do_cache_prepare_action(HttpCacheSM *c_sm, CacheHTTPInfo *object_read_in
   HttpCacheKey key;
   Cache::generate_key(&key, s_url, t_state.txn_conf->cache_generation_number);
 
-  Action *cache_action_handle =
-    c_sm->open_write(&key, s_url, &t_state.hdr_info.client_request, object_read_info,
-                     static_cast<time_t>((t_state.cache_control.pin_in_cache_for < 0) ? 0 : t_state.cache_control.pin_in_cache_for),
-                     retry, allow_multiple);
+  Action *cache_action_handle = c_sm->open_write(
+    &key, s_url, &t_state.hdr_info.client_request, object_read_info,
+    (time_t)((t_state.cache_control.pin_in_cache_for < 0) ? 0 : t_state.cache_control.pin_in_cache_for), retry, allow_multiple);
 
   if (cache_action_handle != ACTION_RESULT_DONE) {
     ink_assert(!pending_action);
@@ -5129,7 +5128,7 @@ HttpSM::do_api_callout_internal()
     }
     break;
   default:
-    cur_hook_id = static_cast<TSHttpHookID>(-1);
+    cur_hook_id = (TSHttpHookID)-1;
     ink_assert(!"not reached");
   }
 
@@ -5436,7 +5435,7 @@ HttpSM::handle_http_server_open()
 void
 HttpSM::handle_server_setup_error(int event, void *data)
 {
-  VIO *vio = static_cast<VIO *>(data);
+  VIO *vio = (VIO *)data;
   ink_assert(vio != nullptr);
 
   STATE_ENTER(&HttpSM::handle_server_setup_error, event);
@@ -5645,7 +5644,7 @@ HttpSM::do_setup_post_tunnel(HttpVC_t to_vc_type)
     int64_t alloc_index;
     // content length is undefined, use default buffer size
     if (t_state.hdr_info.request_content_length == HTTP_UNDEFINED_CL) {
-      alloc_index = static_cast<int>(t_state.txn_conf->default_buffer_size_index);
+      alloc_index = (int)t_state.txn_conf->default_buffer_size_index;
       if (alloc_index < MIN_CONFIG_BUFFER_SIZE_INDEX || alloc_index > MAX_BUFFER_SIZE_INDEX) {
         alloc_index = DEFAULT_REQUEST_BUFFER_SIZE_INDEX;
       }
@@ -6081,7 +6080,7 @@ HttpSM::setup_cache_read_transfer()
   buf->append_block(HTTP_HEADER_BUFFER_SIZE_INDEX);
 #endif
 
-  buf->water_mark = static_cast<int>(t_state.txn_conf->default_buffer_water_mark);
+  buf->water_mark = (int)t_state.txn_conf->default_buffer_water_mark;
 
   IOBufferReader *buf_start = buf->alloc_reader();
 
@@ -6332,7 +6331,7 @@ HttpSM::find_http_resp_buffer_size(int64_t content_length)
   if (content_length == HTTP_UNDEFINED_CL) {
     // Try use our configured default size.  Otherwise pick
     //   the default size
-    alloc_index = static_cast<int>(t_state.txn_conf->default_buffer_size_index);
+    alloc_index = (int)t_state.txn_conf->default_buffer_size_index;
     if (alloc_index < MIN_CONFIG_BUFFER_SIZE_INDEX || alloc_index > DEFAULT_MAX_BUFFER_SIZE) {
       alloc_index = DEFAULT_RESPONSE_BUFFER_SIZE_INDEX;
     }
@@ -6441,7 +6440,7 @@ HttpSM::setup_transfer_from_transform()
 
   // TODO change this call to new_empty_MIOBuffer()
   MIOBuffer *buf            = new_MIOBuffer(alloc_index);
-  buf->water_mark           = static_cast<int>(t_state.txn_conf->default_buffer_water_mark);
+  buf->water_mark           = (int)t_state.txn_conf->default_buffer_water_mark;
   IOBufferReader *buf_start = buf->alloc_reader();
 
   HttpTunnelConsumer *c = tunnel.get_consumer(transform_info.vc);
@@ -6545,7 +6544,7 @@ HttpSM::setup_server_transfer()
   MIOBuffer *buf = new_empty_MIOBuffer(alloc_index);
   buf->append_block(HTTP_HEADER_BUFFER_SIZE_INDEX);
 #endif
-  buf->water_mark           = static_cast<int>(t_state.txn_conf->default_buffer_water_mark);
+  buf->water_mark           = (int)t_state.txn_conf->default_buffer_water_mark;
   IOBufferReader *buf_start = buf->alloc_reader();
 
   // we need to know if we are going to chunk the response or not
@@ -7112,7 +7111,7 @@ HttpSM::dump_state_hdr(HTTPHdr *h, const char *s)
   // Dump the client request if available
   if (h->valid()) {
     int l         = h->length_get();
-    char *hdr_buf = static_cast<char *>(ats_malloc(l + 1));
+    char *hdr_buf = (char *)ats_malloc(l + 1);
     int index     = 0;
     int offset    = 0;
 
@@ -7665,9 +7664,8 @@ HttpSM::do_redirect()
         HTTP_INCREMENT_DYN_STAT(http_total_x_redirect_stat);
       } else {
         // get the location header and setup the redirect
-        int redir_len = 0;
-        char *redir_url =
-          const_cast<char *>(t_state.hdr_info.client_response.value_get(MIME_FIELD_LOCATION, MIME_LEN_LOCATION, &redir_len));
+        int redir_len   = 0;
+        char *redir_url = (char *)t_state.hdr_info.client_response.value_get(MIME_FIELD_LOCATION, MIME_LEN_LOCATION, &redir_len);
         redirect_request(redir_url, redir_len);
       }
 
@@ -7700,7 +7698,7 @@ HttpSM::redirect_request(const char *arg_redirect_url, const int arg_redirect_le
     char *tmpOrigHost;
 
     origPort    = t_state.hdr_info.server_request.port_get();
-    tmpOrigHost = const_cast<char *>(t_state.hdr_info.server_request.value_get(MIME_FIELD_HOST, MIME_LEN_HOST, &origHost_len));
+    tmpOrigHost = (char *)t_state.hdr_info.server_request.value_get(MIME_FIELD_HOST, MIME_LEN_HOST, &origHost_len);
 
     if (tmpOrigHost) {
       memcpy(origHost, tmpOrigHost, origHost_len);
@@ -7709,7 +7707,7 @@ HttpSM::redirect_request(const char *arg_redirect_url, const int arg_redirect_le
       valid_origHost = false;
     }
 
-    char *tmpOrigMethod = const_cast<char *>(t_state.hdr_info.server_request.method_get(&origMethod_len));
+    char *tmpOrigMethod = (char *)t_state.hdr_info.server_request.method_get(&origMethod_len);
     if (tmpOrigMethod) {
       memcpy(origMethod, tmpOrigMethod, std::min(origMethod_len, static_cast<int>(sizeof(origMethod))));
     } else {

--- a/proxy/http/HttpSessionAccept.cc
+++ b/proxy/http/HttpSessionAccept.cc
@@ -98,6 +98,6 @@ HttpSessionAccept::mainEvent(int event, void *data)
     HTTP_SUM_DYN_STAT(http_ua_msecs_counts_errors_pre_accept_hangups_stat, 0);
   }
 
-  ink_abort("HTTP accept received fatal error: errno = %d", -(static_cast<int>((intptr_t)data)));
+  ink_abort("HTTP accept received fatal error: errno = %d", -((int)(intptr_t)data));
   return EVENT_CONT;
 }

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -373,7 +373,7 @@ do_cookies_prevent_caching(int cookies_conf, HTTPHdr *request, HTTPHdr *response
 #endif
 
   // Can cache all regardless of cookie header - just ignore all cookie headers
-  if (static_cast<CookiesConfig>(cookies_conf) == COOKIES_CACHE_ALL) {
+  if ((CookiesConfig)cookies_conf == COOKIES_CACHE_ALL) {
     return false;
   }
 
@@ -396,13 +396,13 @@ do_cookies_prevent_caching(int cookies_conf, HTTPHdr *request, HTTPHdr *response
 
   // Do not cache if cookies option is COOKIES_CACHE_NONE
   // and a Cookie is detected
-  if (static_cast<CookiesConfig>(cookies_conf) == COOKIES_CACHE_NONE) {
+  if ((CookiesConfig)cookies_conf == COOKIES_CACHE_NONE) {
     return true;
   }
   // All other options depend on the Content-Type
   content_type = response->value_get(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE, &str_len);
 
-  if (static_cast<CookiesConfig>(cookies_conf) == COOKIES_CACHE_IMAGES) {
+  if ((CookiesConfig)cookies_conf == COOKIES_CACHE_IMAGES) {
     if (content_type && str_len >= 5 && memcmp(content_type, "image", 5) == 0) {
       // Images can be cached
       return false;
@@ -418,7 +418,7 @@ do_cookies_prevent_caching(int cookies_conf, HTTPHdr *request, HTTPHdr *response
     // COOKIES_CACHE_ALL_BUT_TEXT_EXT.
     // Furthermore, if there is a Set-Cookie header, then
     // Cache-Control must be set.
-    if (static_cast<CookiesConfig>(cookies_conf) == COOKIES_CACHE_ALL_BUT_TEXT_EXT &&
+    if ((CookiesConfig)cookies_conf == COOKIES_CACHE_ALL_BUT_TEXT_EXT &&
         ((!response->presence(MIME_PRESENCE_SET_COOKIE)) || response->is_cache_control_set(HTTP_VALUE_PUBLIC))) {
       return false;
     }
@@ -1009,7 +1009,7 @@ HttpTransact::ModifyRequest(State *s)
   }
   // Copy out buf to a hostname just in case its heap header memory is freed during coalescing
   // due to later HdrHeap operations
-  char *hostname = static_cast<char *>(alloca(hostname_len + PORT_PADDING));
+  char *hostname = (char *)alloca(hostname_len + PORT_PADDING);
   memcpy(hostname, buf, hostname_len);
 
   // Make clang analyzer happy. hostname is non-null iff request.is_target_in_url().
@@ -4575,7 +4575,7 @@ HttpTransact::merge_and_update_headers_for_cache_update(State *s)
     // If the cached response has an Age: we should update it
     // We could use calculate_document_age but my guess is it's overkill
     // Just use 'now' - 304's Date: + Age: (response's Age: if there)
-    date_value = std::max(s->current.now - date_value, static_cast<ink_time_t>(0));
+    date_value = std::max(s->current.now - date_value, (ink_time_t)0);
     if (s->hdr_info.server_response.presence(MIME_PRESENCE_AGE)) {
       time_t new_age = s->hdr_info.server_response.get_age();
 
@@ -5370,10 +5370,10 @@ HttpTransact::handle_trace_and_options_requests(State *s, HTTPHdr *incoming_hdr)
 
       if (s->internal_msg_buffer_size <= max_iobuffer_size) {
         s->internal_msg_buffer_fast_allocator_size = buffer_size_to_index(s->internal_msg_buffer_size);
-        s->internal_msg_buffer = static_cast<char *>(ioBufAllocator[s->internal_msg_buffer_fast_allocator_size].alloc_void());
+        s->internal_msg_buffer = (char *)ioBufAllocator[s->internal_msg_buffer_fast_allocator_size].alloc_void();
       } else {
         s->internal_msg_buffer_fast_allocator_size = -1;
-        s->internal_msg_buffer                     = static_cast<char *>(ats_malloc(s->internal_msg_buffer_size));
+        s->internal_msg_buffer                     = (char *)ats_malloc(s->internal_msg_buffer_size);
       }
 
       // clear the stupid buffer
@@ -5727,7 +5727,7 @@ HttpTransact::is_cache_response_returnable(State *s)
   }
   // If cookies in response and no TTL set, we do not cache the doc
   if ((s->cache_control.ttl_in_cache <= 0) &&
-      do_cookies_prevent_caching(static_cast<int>(s->txn_conf->cache_responses_to_cookies), &s->hdr_info.client_request,
+      do_cookies_prevent_caching((int)s->txn_conf->cache_responses_to_cookies, &s->hdr_info.client_request,
                                  s->cache_info.object_read->response_get(), s->cache_info.object_read->request_get())) {
     SET_VIA_STRING(VIA_CACHE_RESULT, VIA_IN_CACHE_NOT_ACCEPTABLE);
     SET_VIA_STRING(VIA_DETAIL_CACHE_LOOKUP, VIA_DETAIL_MISS_COOKIE);
@@ -6018,7 +6018,7 @@ HttpTransact::is_response_cacheable(State *s, HTTPHdr *request, HTTPHdr *respons
   // Check whether the response is cachable based on its cookie
   // If there are cookies in response but a ttl is set, allow caching
   if ((s->cache_control.ttl_in_cache <= 0) &&
-      do_cookies_prevent_caching(static_cast<int>(s->txn_conf->cache_responses_to_cookies), request, response)) {
+      do_cookies_prevent_caching((int)s->txn_conf->cache_responses_to_cookies, request, response)) {
     TxnDebug("http_trans", "[is_response_cacheable] "
                            "response has uncachable cookies, response is not cachable");
     return false;
@@ -6591,7 +6591,7 @@ HttpTransact::handle_content_length_header(State *s, HTTPHdr *header, HTTPHdr *b
         //   Otherwise, set the state's machine view  //
         //   of c-l to undefined to turn off K-A      //
         ////////////////////////////////////////////////
-        else if (s->cache_info.object_read->object_size_get() == cl) {
+        else if ((int64_t)s->cache_info.object_read->object_size_get() == cl) {
           s->hdr_info.trust_response_cl = true;
         } else {
           TxnDebug("http_trans", "Content Length header and cache object size mismatch."
@@ -7042,13 +7042,13 @@ HttpTransact::calculate_document_freshness_limit(State *s, HTTPHdr *response, ti
 
   if (cc_mask & (MIME_COOKED_MASK_CC_S_MAXAGE | MIME_COOKED_MASK_CC_MAX_AGE)) {
     if (cc_mask & MIME_COOKED_MASK_CC_S_MAXAGE) {
-      freshness_limit = static_cast<int>(response->get_cooked_cc_s_maxage());
+      freshness_limit = (int)response->get_cooked_cc_s_maxage();
       TxnDebug("http_match", "calculate_document_freshness_limit --- s_max_age set, freshness_limit = %d", freshness_limit);
     } else if (cc_mask & MIME_COOKED_MASK_CC_MAX_AGE) {
-      freshness_limit = static_cast<int>(response->get_cooked_cc_max_age());
+      freshness_limit = (int)response->get_cooked_cc_max_age();
       TxnDebug("http_match", "calculate_document_freshness_limit --- max_age set, freshness_limit = %d", freshness_limit);
     }
-    freshness_limit = std::min(std::max(0, freshness_limit), static_cast<int>(s->txn_conf->cache_guaranteed_max_lifetime));
+    freshness_limit = std::min(std::max(0, freshness_limit), (int)s->txn_conf->cache_guaranteed_max_lifetime);
   } else {
     date_set = last_modified_set = false;
 
@@ -7080,12 +7080,12 @@ HttpTransact::calculate_document_freshness_limit(State *s, HTTPHdr *response, ti
         expires_value = date_value;
         TxnDebug("http_match", "calculate_document_freshness_limit --- no expires, using date %" PRId64, (int64_t)expires_value);
       }
-      freshness_limit = static_cast<int>(expires_value - date_value);
+      freshness_limit = (int)(expires_value - date_value);
 
       TxnDebug("http_match", "calculate_document_freshness_limit --- Expires: %" PRId64 ", Date: %" PRId64 ", freshness_limit = %d",
                (int64_t)expires_value, (int64_t)date_value, freshness_limit);
 
-      freshness_limit = std::min(std::max(0, freshness_limit), static_cast<int>(s->txn_conf->cache_guaranteed_max_lifetime));
+      freshness_limit = std::min(std::max(0, freshness_limit), (int)s->txn_conf->cache_guaranteed_max_lifetime);
     } else {
       last_modified_value = 0;
       if (response->presence(MIME_PRESENCE_LAST_MODIFIED)) {
@@ -7108,7 +7108,7 @@ HttpTransact::calculate_document_freshness_limit(State *s, HTTPHdr *response, ti
         MgmtFloat f = s->txn_conf->cache_heuristic_lm_factor;
         ink_assert((f >= 0.0) && (f <= 1.0));
         ink_time_t time_since_last_modify = date_value - last_modified_value;
-        int h_freshness                   = static_cast<int>(time_since_last_modify * f);
+        int h_freshness                   = (int)(time_since_last_modify * f);
         freshness_limit                   = std::max(h_freshness, 0);
         TxnDebug("http_match",
                  "calculate_document_freshness_limit --- heuristic: date=%" PRId64 ", lm=%" PRId64
@@ -7122,7 +7122,7 @@ HttpTransact::calculate_document_freshness_limit(State *s, HTTPHdr *response, ti
   }
 
   // The freshness limit must always fall within the min and max guaranteed bounds.
-  min_freshness_bounds = std::max(static_cast<MgmtInt>(0), s->txn_conf->cache_guaranteed_min_lifetime);
+  min_freshness_bounds = std::max((MgmtInt)0, s->txn_conf->cache_guaranteed_min_lifetime);
   max_freshness_bounds = s->txn_conf->cache_guaranteed_max_lifetime;
 
   // Heuristic freshness can be more strict.
@@ -7218,9 +7218,9 @@ HttpTransact::what_is_document_freshness(State *s, HTTPHdr *client_request, HTTP
   if (current_age < 0) {
     current_age = s->txn_conf->cache_guaranteed_max_lifetime;
   } else if (current_age < s->txn_conf->cache_guaranteed_max_lifetime) {
-    current_age = std::min(static_cast<time_t>(s->txn_conf->cache_guaranteed_max_lifetime), current_age);
+    current_age = std::min((time_t)s->txn_conf->cache_guaranteed_max_lifetime, current_age);
   } else {
-    current_age = std::max(static_cast<time_t>(s->txn_conf->cache_guaranteed_max_lifetime), current_age);
+    current_age = std::max((time_t)s->txn_conf->cache_guaranteed_max_lifetime, current_age);
   }
 
   TxnDebug("http_match", "[what_is_document_freshness] fresh_limit:  %d  current_age: %" PRId64, fresh_limit, (int64_t)current_age);
@@ -7614,7 +7614,7 @@ HttpTransact::build_request(State *s, HTTPHdr *base_request, HTTPHdr *outgoing_r
     // to the default port.
     int port = url->port_get();
     if (port != url_canonicalize_port(URL_TYPE_HTTP, 0)) {
-      char *buf = static_cast<char *>(alloca(host_len + 15));
+      char *buf = (char *)alloca(host_len + 15);
       memcpy(buf, host, host_len);
       host_len += snprintf(buf + host_len, 15, ":%d", port);
       outgoing_request->value_set(MIME_FIELD_HOST, MIME_LEN_HOST, buf, host_len);
@@ -7940,8 +7940,7 @@ HttpTransact::build_error_response(State *s, HTTPStatus status_code, const char 
     break;
   }
 
-  const char *reason_phrase =
-    (reason_phrase_or_null ? reason_phrase_or_null : const_cast<char *>(http_hdr_reason_lookup(status_code)));
+  const char *reason_phrase = (reason_phrase_or_null ? reason_phrase_or_null : (char *)(http_hdr_reason_lookup(status_code)));
   if (unlikely(!reason_phrase)) {
     reason_phrase = "Unknown HTTP Status";
   }
@@ -7993,7 +7992,7 @@ HttpTransact::build_error_response(State *s, HTTPStatus status_code, const char 
   s->free_internal_msg_buffer();
   if (len == 0) {
     // If the file is empty, we may have a malloc(1) buffer. Release it.
-    new_msg = static_cast<char *>(ats_free_null(new_msg));
+    new_msg = (char *)ats_free_null(new_msg);
   }
   s->internal_msg_buffer                     = new_msg;
   s->internal_msg_buffer_size                = len;
@@ -8024,7 +8023,7 @@ HttpTransact::build_redirect_response(State *s)
   char *to_free = nullptr;
 
   HTTPStatus status_code = HTTP_STATUS_MOVED_TEMPORARILY;
-  char *reason_phrase    = const_cast<char *>(http_hdr_reason_lookup(status_code));
+  char *reason_phrase    = (char *)(http_hdr_reason_lookup(status_code));
 
   build_response(s, &s->hdr_info.client_response, s->client_info.http_version, status_code, reason_phrase);
 
@@ -8171,9 +8170,8 @@ HttpTransact::histogram_request_document_size(State *s, int64_t doc_size)
 void
 HttpTransact::user_agent_connection_speed(State *s, ink_hrtime transfer_time, int64_t nbytes)
 {
-  float bytes_per_hrtime =
-    (transfer_time == 0) ? (nbytes) : (static_cast<float>(nbytes) / static_cast<float>(static_cast<int64_t>(transfer_time)));
-  int bytes_per_sec = static_cast<int>(bytes_per_hrtime * HRTIME_SECOND);
+  float bytes_per_hrtime = (transfer_time == 0) ? (nbytes) : ((float)nbytes / (float)(int64_t)transfer_time);
+  int bytes_per_sec      = (int)(bytes_per_hrtime * HRTIME_SECOND);
 
   if (bytes_per_sec <= 100) {
     HTTP_INCREMENT_DYN_STAT(http_user_agent_speed_bytes_per_sec_100_stat);
@@ -8499,9 +8497,8 @@ HttpTransact::client_result_stat(State *s, ink_hrtime total_time, ink_hrtime req
 void
 HttpTransact::origin_server_connection_speed(State *s, ink_hrtime transfer_time, int64_t nbytes)
 {
-  float bytes_per_hrtime =
-    (transfer_time == 0) ? (nbytes) : (static_cast<float>(nbytes) / static_cast<float>(static_cast<int64_t>(transfer_time)));
-  int bytes_per_sec = static_cast<int>(bytes_per_hrtime * HRTIME_SECOND);
+  float bytes_per_hrtime = (transfer_time == 0) ? (nbytes) : ((float)nbytes / (float)(int64_t)transfer_time);
+  int bytes_per_sec      = (int)(bytes_per_hrtime * HRTIME_SECOND);
 
   if (bytes_per_sec <= 100) {
     HTTP_INCREMENT_DYN_STAT(http_origin_server_speed_bytes_per_sec_100_stat);
@@ -8543,7 +8540,7 @@ HttpTransact::update_size_and_time_stats(State *s, ink_hrtime total_time, ink_hr
   switch (s->state_machine->background_fill) {
   case BACKGROUND_FILL_COMPLETED: {
     int64_t bg_size = origin_server_response_body_size - user_agent_response_body_size;
-    bg_size         = std::max(static_cast<int64_t>(0), bg_size);
+    bg_size         = std::max((int64_t)0, bg_size);
     HTTP_SUM_DYN_STAT(http_background_fill_bytes_completed_stat, bg_size);
     break;
   }
@@ -8760,7 +8757,7 @@ HttpTransact::change_response_header_because_of_range_request(State *s, HTTPHdr 
   TxnDebug("http_trans", "Partial content requested, re-calculating content-length");
 
   header->status_set(HTTP_STATUS_PARTIAL_CONTENT);
-  reason_phrase = const_cast<char *>(http_hdr_reason_lookup(HTTP_STATUS_PARTIAL_CONTENT));
+  reason_phrase = (char *)(http_hdr_reason_lookup(HTTP_STATUS_PARTIAL_CONTENT));
   header->reason_set(reason_phrase, strlen(reason_phrase));
 
   // set the right Content-Type for multiple entry Range

--- a/proxy/http/HttpTransactCache.cc
+++ b/proxy/http/HttpTransactCache.cc
@@ -53,7 +53,7 @@ find_etag(const char *raw_tag_field, int raw_tag_field_len, int *length)
   if ((etag_start < etag_end) && (*etag_start == '"')) {
     ++etag_start;
     --etag_length;
-    quote = static_cast<const char *>(memchr(etag_start, '"', etag_length));
+    quote = (const char *)memchr(etag_start, '"', etag_length);
     if (quote) {
       etag_length = quote - etag_start;
     }
@@ -94,7 +94,7 @@ do_strings_match_strongly(const char *raw_tag_field, int raw_tag_field_len, cons
 
     n = 0;
 
-    if ((static_cast<int>(tag->len - n) == etag_length) && (strncmp(etag_start, tag->str + n, etag_length) == 0)) {
+    if (((int)(tag->len - n) == etag_length) && (strncmp(etag_start, tag->str + n, etag_length) == 0)) {
       return true;
     }
   }
@@ -212,7 +212,7 @@ HttpTransactCache::SelectFromAlternates(CacheHTTPInfoVector *cache_vector, HTTPH
           current_age = CacheHighAgeWatermark;
         }
       } else {
-        current_age = static_cast<time_t>(0);
+        current_age = (time_t)0;
       }
 
       if (is_debug_tag_set("http_alts")) {
@@ -289,7 +289,7 @@ HttpTransactCache::calculate_quality_of_match(OverridableHttpConfigParams *http_
 {
   // For PURGE requests, any alternate is good really.
   if (client_request->method_get_wksidx() == HTTP_WKSIDX_PURGE) {
-    return static_cast<float>(1.0);
+    return (float)1.0;
   }
 
   // Now calculate a quality based on all sorts of logic
@@ -630,13 +630,13 @@ HttpTransactCache::calculate_quality_of_accept_charset_match(MIMEField *accept_f
     ca_raw = cached_accept_field->value_get(&ca_raw_len);
     if (a_raw && ca_raw && a_raw_len == ca_raw_len && !strncmp(a_raw, ca_raw, a_raw_len)) {
       Debug("http_alternate", "Exact match for ACCEPT CHARSET");
-      return static_cast<float>(1.001); // slightly higher weight to this guy
+      return (float)1.001; // slightly higher weight to this guy
     }
   }
   // return match if either ac or ct is missing
   // this check is different from accept-encoding
   if (accept_field == nullptr || content_field == nullptr) {
-    return static_cast<float>(1.0);
+    return (float)1.0;
   }
   // get the charset of this content-type //
   c_raw = content_field->value_get(&c_raw_len);
@@ -657,7 +657,7 @@ HttpTransactCache::calculate_quality_of_accept_charset_match(MIMEField *accept_f
     HttpCompat::parse_semicolon_list(&a_param_list, a_raw, a_raw_len);
 
     if (a_param_list.head) {
-      a_charset     = const_cast<char *>(a_param_list.head->str);
+      a_charset     = (char *)a_param_list.head->str;
       a_charset_len = a_param_list.head->len;
     } else {
       continue;
@@ -760,7 +760,7 @@ HttpTransactCache::match_content_encoding(MIMEField *accept_field, const char *e
     a_raw = a_value->str;
     HttpCompat::parse_semicolon_list(&a_param_list, a_raw);
     if (a_param_list.head) {
-      a_encoding = const_cast<char *>(a_param_list.head->str);
+      a_encoding = (char *)a_param_list.head->str;
     } else {
       continue;
     }
@@ -798,7 +798,7 @@ match_accept_content_encoding(const char *c_raw, MIMEField *accept_field, bool *
     // break Accept-Encoding piece into semi-colon separated parts //
     HttpCompat::parse_semicolon_list(&a_param_list, a_raw);
     if (a_param_list.head) {
-      a_encoding = const_cast<char *>(a_param_list.head->str);
+      a_encoding = (char *)a_param_list.head->str;
     } else {
       continue;
     }
@@ -842,13 +842,13 @@ HttpTransactCache::calculate_quality_of_accept_encoding_match(MIMEField *accept_
     ca_raw = cached_accept_field->value_get(&ca_raw_len);
     if (a_raw && ca_raw && a_raw_len == ca_raw_len && !strncmp(a_raw, ca_raw, a_raw_len)) {
       Debug("http_alternate", "Exact match for ACCEPT ENCODING");
-      return static_cast<float>(1.001); // slightly higher weight to this guy
+      return (float)1.001; // slightly higher weight to this guy
     }
   }
   // return match if both ae and ce are missing
   // this check is different from accept charset
   if (accept_field == nullptr && content_field == nullptr) {
-    return static_cast<float>(1.0);
+    return (float)1.0;
   }
   // if no Content-Encoding, treat as "identity" //
   if (!content_field) {
@@ -888,12 +888,12 @@ HttpTransactCache::calculate_quality_of_accept_encoding_match(MIMEField *accept_
   if (!accept_field) {
     if (is_identity_encoding) {
       if (!cached_accept_field) {
-        return (static_cast<float>(1.0));
+        return ((float)1.0);
       } else {
-        return (static_cast<float>(0.001));
+        return ((float)0.001);
       }
     } else {
-      return (static_cast<float>(-1.0));
+      return ((float)-1.0);
     }
   }
 
@@ -1022,7 +1022,7 @@ match_accept_content_language(const char *c_raw, MIMEField *accept_field, bool *
     // was specified, this document matches all accept headers.        //
     /////////////////////////////////////////////////////////////////////
     if (a_param_list.head) {
-      a_range         = const_cast<char *>(a_param_list.head->str);
+      a_range         = (char *)a_param_list.head->str;
       *a_range_length = a_param_list.head->len;
     } else {
       continue;
@@ -1073,7 +1073,7 @@ HttpTransactCache::calculate_quality_of_accept_language_match(MIMEField *accept_
     ca_raw = cached_accept_field->value_get(&ca_raw_len);
     if (a_raw && ca_raw && a_raw_len == ca_raw_len && !strncmp(a_raw, ca_raw, a_raw_len)) {
       Debug("http_alternate", "Exact match for ACCEPT LANGUAGE");
-      return static_cast<float>(1.001); // slightly higher weight to this guy
+      return (float)1.001; // slightly higher weight to this guy
     }
   }
 
@@ -1208,13 +1208,13 @@ HttpTransactCache::CalcVariability(OverridableHttpConfigParams *http_config_para
       // Special case: if 'proxy.config.http.global_user_agent_header' set                  //
       // we should ignore Vary: User-Agent.                                                 //
       ////////////////////////////////////////////////////////////////////////////////////////
-      if (http_config_params->global_user_agent_header && !strcasecmp(const_cast<char *>(field->str), "User-Agent")) {
+      if (http_config_params->global_user_agent_header && !strcasecmp((char *)field->str, "User-Agent")) {
         continue;
       }
 
       // Disable Vary mismatch checking for Accept-Encoding.  This is only safe to
       // set if you are promising to fix any Accept-Encoding/Content-Encoding mismatches.
-      if (http_config_params->ignore_accept_encoding_mismatch && !strcasecmp(const_cast<char *>(field->str), "Accept-Encoding")) {
+      if (http_config_params->ignore_accept_encoding_mismatch && !strcasecmp((char *)field->str, "Accept-Encoding")) {
         continue;
       }
 
@@ -1235,9 +1235,9 @@ HttpTransactCache::CalcVariability(OverridableHttpConfigParams *http_config_para
 
       ink_assert(strlen(field->str) == field->len);
 
-      char *field_name_str = const_cast<char *>(hdrtoken_string_to_wks(field->str, field->len));
+      char *field_name_str = (char *)hdrtoken_string_to_wks(field->str, field->len);
       if (field_name_str == nullptr) {
-        field_name_str = const_cast<char *>(field->str);
+        field_name_str = (char *)field->str;
       }
 
       MIMEField *cached_hdr_field  = obj_client_request->field_find(field_name_str, field->len);

--- a/proxy/http/HttpTransactHeaders.cc
+++ b/proxy/http/HttpTransactHeaders.cc
@@ -146,7 +146,7 @@ HttpTransactHeaders::insert_supported_methods_in_response(HTTPHdr *response, int
     alloced_buffer = nullptr;
     value_buffer   = inline_buffer;
   } else {
-    alloced_buffer = static_cast<char *>(ats_malloc(bytes));
+    alloced_buffer = (char *)ats_malloc(bytes);
     value_buffer   = alloced_buffer;
   }
 
@@ -423,7 +423,7 @@ HttpTransactHeaders::calculate_document_age(ink_time_t request_time, ink_time_t 
   ink_assert(now_value >= response_time);
 
   if (date_value > 0) {
-    apparent_age = std::max(static_cast<time_t>(0), (response_time - date_value));
+    apparent_age = std::max((time_t)0, (response_time - date_value));
   }
   if (age_value < 0) {
     current_age = -1; // Overflow from Age: header
@@ -661,7 +661,7 @@ HttpTransactHeaders::insert_warning_header(HttpConfigParams *http_config_param, 
     warn_text_len = 0; // Make sure it's really zero
   }
 
-  char *warning_text = static_cast<char *>(alloca(bufsize));
+  char *warning_text = (char *)alloca(bufsize);
 
   len =
     snprintf(warning_text, bufsize, "%3d %s %.*s", code, http_config_param->proxy_response_via_string, warn_text_len, warn_text);
@@ -949,7 +949,7 @@ HttpTransactHeaders::insert_basic_realm_in_proxy_authenticate(const char *realm,
 
   basic_realm = new_basic_realm;
   basic_realm += nstrcpy(basic_realm, "Basic realm=\"");
-  basic_realm += nstrcpy(basic_realm, const_cast<char *>(realm));
+  basic_realm += nstrcpy(basic_realm, (char *)realm);
   *basic_realm++ = '"';
   *basic_realm   = 0;
 

--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1452,7 +1452,7 @@ HttpTunnel::finish_all_internal(HttpTunnelProducer *p, bool chain)
         if (c->write_vio->nbytes < 0) {
           // TODO: Wtf, printf?
           fprintf(stderr, "[HttpTunnel::finish_all_internal] ERROR: Incorrect total_bytes - c->skip_bytes = %" PRId64 "\n",
-                  static_cast<int64_t>(total_bytes - c->skip_bytes));
+                  (int64_t)(total_bytes - c->skip_bytes));
         }
       }
 
@@ -1558,10 +1558,10 @@ HttpTunnel::main_handler(int event, void *data)
   ink_assert(sm->magic == HTTP_SM_MAGIC_ALIVE);
 
   // Find the appropriate entry
-  if ((p = get_producer(static_cast<VIO *>(data))) != nullptr) {
+  if ((p = get_producer((VIO *)data)) != nullptr) {
     sm_callback = producer_handler(event, p);
   } else {
-    if ((c = get_consumer(static_cast<VIO *>(data))) != nullptr) {
+    if ((c = get_consumer((VIO *)data)) != nullptr) {
       ink_assert(c->write_vio == (VIO *)data || c->vc == ((VIO *)data)->vc_server);
       sm_callback = consumer_handler(event, c);
     } else {

--- a/proxy/http/remap/AclFiltering.cc
+++ b/proxy/http/remap/AclFiltering.cc
@@ -33,7 +33,7 @@ acl_filter_rule::reset()
 {
   int i;
   for (i = (argc = 0); i < ACL_FILTER_MAX_ARGV; i++) {
-    argv[i] = static_cast<char *>(ats_free_null(argv[i]));
+    argv[i] = (char *)ats_free_null(argv[i]);
   }
   method_restriction_enabled = false;
   for (i = 0; i < HTTP_WKSIDX_METHODS_CNT; i++) {
@@ -82,7 +82,7 @@ acl_filter_rule::add_argv(int _argc, char *_argv[])
 void
 acl_filter_rule::name(const char *_name)
 {
-  filter_name = static_cast<char *>(ats_free_null(filter_name));
+  filter_name = (char *)ats_free_null(filter_name);
   if (_name) {
     filter_name = ats_strdup(_name);
   }
@@ -95,7 +95,7 @@ acl_filter_rule::print()
   printf("-----------------------------------------------------------------------------------------\n");
   printf("Filter \"%s\" status: allow_flag=%s, src_ip_valid=%s, in_ip_valid=%s, internal=%s, active_queue_flag=%d\n",
          filter_name ? filter_name : "<NONAME>", allow_flag ? "true" : "false", src_ip_valid ? "true" : "false",
-         in_ip_valid ? "true" : "false", internal ? "true" : "false", static_cast<int>(active_queue_flag));
+         in_ip_valid ? "true" : "false", internal ? "true" : "false", (int)active_queue_flag);
   printf("standard methods=");
   for (i = 0; i < HTTP_WKSIDX_METHODS_CNT; i++) {
     if (standard_method_lookup[i]) {

--- a/proxy/http/remap/RemapProcessor.cc
+++ b/proxy/http/remap/RemapProcessor.cc
@@ -165,8 +165,8 @@ RemapProcessor::finish_remap(HttpTransact::State *s, UrlRewrite *table)
 
     if (request_header->presence(MIME_PRESENCE_REFERER) &&
         (referer_hdr = request_header->value_get(MIME_FIELD_REFERER, MIME_LEN_REFERER, &referer_len)) != nullptr) {
-      if (referer_len >= static_cast<int>(sizeof(tmp_referer_buf))) {
-        referer_len = static_cast<int>(sizeof(tmp_referer_buf) - 1);
+      if (referer_len >= (int)sizeof(tmp_referer_buf)) {
+        referer_len = (int)(sizeof(tmp_referer_buf) - 1);
       }
       memcpy(tmp_referer_buf, referer_hdr, referer_len);
       tmp_referer_buf[referer_len] = 0;
@@ -201,8 +201,8 @@ RemapProcessor::finish_remap(HttpTransact::State *s, UrlRewrite *table)
             case 'f':
             case 't':
               remapped_host = (rc->type == 'f') ?
-                                map->fromURL.string_get_buf(tmp_buf, static_cast<int>(sizeof(tmp_buf)), &from_len) :
-                                ((s->url_map).getToURL())->string_get_buf(tmp_buf, static_cast<int>(sizeof(tmp_buf)), &from_len);
+                                map->fromURL.string_get_buf(tmp_buf, (int)sizeof(tmp_buf), &from_len) :
+                                ((s->url_map).getToURL())->string_get_buf(tmp_buf, (int)sizeof(tmp_buf), &from_len);
               if (remapped_host && from_len > 0) {
                 c = &tmp_buf[0];
               }
@@ -212,7 +212,7 @@ RemapProcessor::finish_remap(HttpTransact::State *s, UrlRewrite *table)
               break;
             };
 
-            if (c && tmp < static_cast<int>(sizeof(tmp_redirect_buf) - 1)) {
+            if (c && tmp < (int)(sizeof(tmp_redirect_buf) - 1)) {
               tmp += snprintf(&tmp_redirect_buf[tmp], sizeof(tmp_redirect_buf) - tmp, "%s", c);
             }
           }
@@ -241,7 +241,7 @@ RemapProcessor::finish_remap(HttpTransact::State *s, UrlRewrite *table)
   if (request_url && host_hdr != nullptr && s->txn_conf->maintain_pristine_host_hdr == 0) {
     if (is_debug_tag_set("url_rewrite")) {
       int old_host_hdr_len;
-      char *old_host_hdr = const_cast<char *>(request_header->value_get(MIME_FIELD_HOST, MIME_LEN_HOST, &old_host_hdr_len));
+      char *old_host_hdr = (char *)request_header->value_get(MIME_FIELD_HOST, MIME_LEN_HOST, &old_host_hdr_len);
       if (old_host_hdr) {
         Debug("url_rewrite", "Host: Header before rewrite %.*s", old_host_hdr_len, old_host_hdr);
       }

--- a/proxy/http/remap/UrlMapping.cc
+++ b/proxy/http/remap/UrlMapping.cc
@@ -83,8 +83,8 @@ url_mapping::~url_mapping()
   redirect_tag_str *rc;
   acl_filter_rule *afr;
 
-  tag                 = static_cast<char *>(ats_free_null(tag));
-  filter_redirect_url = static_cast<char *>(ats_free_null(filter_redirect_url));
+  tag                 = (char *)ats_free_null(tag);
+  filter_redirect_url = (char *)ats_free_null(filter_redirect_url);
 
   while ((r = referer_list) != nullptr) {
     referer_list = r->next;
@@ -119,8 +119,8 @@ url_mapping::Print()
 {
   char from_url_buf[131072], to_url_buf[131072];
 
-  fromURL.string_get_buf(from_url_buf, static_cast<int>(sizeof(from_url_buf)));
-  toURL.string_get_buf(to_url_buf, static_cast<int>(sizeof(to_url_buf)));
+  fromURL.string_get_buf(from_url_buf, (int)sizeof(from_url_buf));
+  toURL.string_get_buf(to_url_buf, (int)sizeof(to_url_buf));
   printf("\t %s %s=> %s %s <%s> [plugins %s enabled; running with %zu plugins]\n", from_url_buf, unique ? "(unique)" : "",
          to_url_buf, homePageRedirect ? "(R)" : "", tag ? tag : "", plugin_count() > 0 ? "are" : "not", plugin_count());
 }
@@ -140,7 +140,7 @@ redirect_tag_str::parse_format_redirect_url(char *url)
       char type = 0;
       for (type = 's'; *c; c++) {
         if (c[0] == '%') {
-          char tmp_type = static_cast<char>(tolower(static_cast<int>(c[1])));
+          char tmp_type = (char)tolower((int)c[1]);
           if (tmp_type == 'r' || tmp_type == 'f' || tmp_type == 't' || tmp_type == 'o') {
             if (url == c) {
               type = tmp_type;

--- a/proxy/http/remap/UrlRewrite.cc
+++ b/proxy/http/remap/UrlRewrite.cc
@@ -502,7 +502,7 @@ UrlRewrite::Remap_redirect(HTTPHdr *request_header, URL *redirect_url)
       host_hdr_len = 0;
     }
 
-    const char *tmp = static_cast<const char *>(memchr(host_hdr, ':', host_hdr_len));
+    const char *tmp = (const char *)memchr(host_hdr, ':', host_hdr_len);
 
     if (tmp == nullptr) {
       host_len = host_hdr_len;

--- a/proxy/http2/HTTP2.cc
+++ b/proxy/http2/HTTP2.cc
@@ -536,7 +536,7 @@ http2_generate_h2_header_from_1_1(HTTPHdr *headers, HTTPHdr *h2_headers)
     value = headers->host_get(&value_len);
     if (headers->is_port_in_header()) {
       int port            = headers->port_get();
-      char *host_and_port = static_cast<char *>(ats_malloc(value_len + 8));
+      char *host_and_port = (char *)ats_malloc(value_len + 8);
       value_len           = snprintf(host_and_port, value_len + 8, "%.*s:%d", value_len, value, port);
       field->value_set(h2_headers->m_heap, h2_headers->m_mime, host_and_port, value_len);
       ats_free(host_and_port);
@@ -554,7 +554,7 @@ http2_generate_h2_header_from_1_1(HTTPHdr *headers, HTTPHdr *h2_headers)
     // Add ':path' header field
     field      = h2_headers->field_create(HTTP2_VALUE_PATH, HTTP2_LEN_PATH);
     value      = headers->path_get(&value_len);
-    char *path = static_cast<char *>(ats_malloc(value_len + 1));
+    char *path = (char *)ats_malloc(value_len + 1);
     path[0]    = '/';
     memcpy(path + 1, value, value_len);
     field->value_set(h2_headers->m_heap, h2_headers->m_mime, path, value_len + 1);

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -55,7 +55,7 @@ copy_from_buffer_reader(void *dst, IOBufferReader *reader, unsigned nbytes)
   char *end;
 
   end = reader->memcpy(dst, nbytes, 0 /* offset */);
-  return end - static_cast<char *>(dst);
+  return end - (char *)dst;
 }
 
 static int
@@ -407,12 +407,12 @@ Http2ClientSession::main_event_handler(int event, void *edata)
 int
 Http2ClientSession::state_read_connection_preface(int event, void *edata)
 {
-  VIO *vio = static_cast<VIO *>(edata);
+  VIO *vio = (VIO *)edata;
 
   STATE_ENTER(&Http2ClientSession::state_read_connection_preface, event);
   ink_assert(event == VC_EVENT_READ_COMPLETE || event == VC_EVENT_READ_READY);
 
-  if (this->sm_reader->read_avail() >= static_cast<int64_t>(HTTP2_CONNECTION_PREFACE_LEN)) {
+  if (this->sm_reader->read_avail() >= (int64_t)HTTP2_CONNECTION_PREFACE_LEN) {
     char buf[HTTP2_CONNECTION_PREFACE_LEN];
     unsigned nbytes;
 
@@ -452,7 +452,7 @@ Http2ClientSession::state_read_connection_preface(int event, void *edata)
 int
 Http2ClientSession::state_start_frame_read(int event, void *edata)
 {
-  VIO *vio = static_cast<VIO *>(edata);
+  VIO *vio = (VIO *)edata;
 
   STATE_ENTER(&Http2ClientSession::state_start_frame_read, event);
   ink_assert(event == VC_EVENT_READ_COMPLETE || event == VC_EVENT_READ_READY);
@@ -507,7 +507,7 @@ Http2ClientSession::do_start_frame_read(Http2ErrorCode &ret_error)
 int
 Http2ClientSession::state_complete_frame_read(int event, void *edata)
 {
-  VIO *vio = static_cast<VIO *>(edata);
+  VIO *vio = (VIO *)edata;
   STATE_ENTER(&Http2ClientSession::state_complete_frame_read, event);
   ink_assert(event == VC_EVENT_READ_COMPLETE || event == VC_EVENT_READ_READY);
   if (this->sm_reader->read_avail() < this->current_hdr.length) {
@@ -542,7 +542,7 @@ Http2ClientSession::state_process_frame_read(int event, VIO *vio, bool inside_fr
     do_complete_frame_read();
   }
 
-  while (this->sm_reader->read_avail() >= static_cast<int64_t>(HTTP2_FRAME_HEADER_LEN)) {
+  while (this->sm_reader->read_avail() >= (int64_t)HTTP2_FRAME_HEADER_LEN) {
     // Cancel reading if there was an error
     if (connection_state.tx_error_code.code != static_cast<uint32_t>(Http2ErrorCode::HTTP2_ERROR_NO_ERROR)) {
       Http2SsnDebug("reading a frame has been canceled (%u)", connection_state.tx_error_code.code);

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1515,7 +1515,7 @@ Http2ConnectionState::send_headers_frame(Http2Stream *stream)
   http2_generate_h2_header_from_1_1(resp_header, &h2_hdr);
 
   buf_len = resp_header->length_get() * 2; // Make it double just in case
-  buf     = static_cast<uint8_t *>(ats_malloc(buf_len));
+  buf     = (uint8_t *)ats_malloc(buf_len);
   if (buf == nullptr) {
     h2_hdr.destroy();
     return;
@@ -1625,7 +1625,7 @@ Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url, con
 
   buf_len = h1_hdr.length_get() * 2; // Make it double just in case
   h1_hdr.destroy();
-  buf = static_cast<uint8_t *>(ats_malloc(buf_len));
+  buf = (uint8_t *)ats_malloc(buf_len);
   if (buf == nullptr) {
     h2_hdr.destroy();
     return;

--- a/proxy/http2/Http2SessionAccept.cc
+++ b/proxy/http2/Http2SessionAccept.cc
@@ -84,6 +84,6 @@ Http2SessionAccept::mainEvent(int event, void *data)
     HTTP_SUM_DYN_STAT(http_ua_msecs_counts_errors_pre_accept_hangups_stat, 0);
   }
 
-  ink_abort("HTTP/2 accept received fatal error: errno = %d", -(static_cast<int>((intptr_t)data)));
+  ink_abort("HTTP/2 accept received fatal error: errno = %d", -((int)(intptr_t)data));
   return EVENT_CONT;
 }

--- a/proxy/http2/RegressionHPACK.cc
+++ b/proxy/http2/RegressionHPACK.cc
@@ -44,34 +44,32 @@ const static int MAX_TABLE_SIZE                         = 4096;
 // [RFC 7541] C.1. Integer Representation Examples
 const static struct {
   uint32_t raw_integer;
-  const uint8_t *encoded_field;
+  uint8_t *encoded_field;
   int encoded_field_len;
   int prefix;
-} integer_test_case[] = {{10, reinterpret_cast<const uint8_t *>("\x0A"), 1, 5},
-                         {1337, reinterpret_cast<const uint8_t *>("\x1F\x9A\x0A"), 3, 5},
-                         {42, reinterpret_cast<const uint8_t *>(R"(*)"), 1, 8}};
+} integer_test_case[] = {{10, (uint8_t *)"\x0A", 1, 5}, {1337, (uint8_t *)"\x1F\x9A\x0A", 3, 5}, {42, (uint8_t *)R"(*)", 1, 8}};
 
 // Example: custom-key: custom-header
 const static struct {
   char *raw_string;
   uint32_t raw_string_len;
-  const uint8_t *encoded_field;
+  uint8_t *encoded_field;
   int encoded_field_len;
 } string_test_case[] = {{(char *)"", 0,
-                         reinterpret_cast<const uint8_t *>("\x0"
-                                                           ""),
+                         (uint8_t *)"\x0"
+                                    "",
                          1},
                         {(char *)"custom-key", 10,
-                         reinterpret_cast<const uint8_t *>("\xA"
-                                                           "custom-key"),
+                         (uint8_t *)"\xA"
+                                    "custom-key",
                          11},
                         {(char *)"", 0,
-                         reinterpret_cast<const uint8_t *>("\x80"
-                                                           ""),
+                         (uint8_t *)"\x80"
+                                    "",
                          1},
                         {(char *)"custom-key", 10,
-                         reinterpret_cast<const uint8_t *>("\x88"
-                                                           "\x25\xa8\x49\xe9\x5b\xa9\x7d\x7f"),
+                         (uint8_t *)"\x88"
+                                    "\x25\xa8\x49\xe9\x5b\xa9\x7d\x7f",
                          9}};
 
 // [RFC 7541] C.2.4. Indexed Header Field
@@ -79,9 +77,9 @@ const static struct {
   int index;
   char *raw_name;
   char *raw_value;
-  const uint8_t *encoded_field;
+  uint8_t *encoded_field;
   int encoded_field_len;
-} indexed_test_case[] = {{2, (char *)":method", (char *)"GET", reinterpret_cast<const uint8_t *>("\x82"), 1}};
+} indexed_test_case[] = {{2, (char *)":method", (char *)"GET", (uint8_t *)"\x82", 1}};
 
 // [RFC 7541] C.2. Header Field Representation Examples
 const static struct {
@@ -89,92 +87,92 @@ const static struct {
   char *raw_value;
   int index;
   HpackField type;
-  const uint8_t *encoded_field;
+  uint8_t *encoded_field;
   int encoded_field_len;
 } literal_test_case[] = {{(char *)"custom-key", (char *)"custom-header", 0, HpackField::INDEXED_LITERAL,
-                          reinterpret_cast<const uint8_t *>("\x40\x0a"
-                                                            "custom-key\x0d"
-                                                            "custom-header"),
+                          (uint8_t *)"\x40\x0a"
+                                     "custom-key\x0d"
+                                     "custom-header",
                           26},
                          {(char *)"custom-key", (char *)"custom-header", 0, HpackField::NOINDEX_LITERAL,
-                          reinterpret_cast<const uint8_t *>("\x00\x0a"
-                                                            "custom-key\x0d"
-                                                            "custom-header"),
+                          (uint8_t *)"\x00\x0a"
+                                     "custom-key\x0d"
+                                     "custom-header",
                           26},
                          {(char *)"custom-key", (char *)"custom-header", 0, HpackField::NEVERINDEX_LITERAL,
-                          reinterpret_cast<const uint8_t *>("\x10\x0a"
-                                                            "custom-key\x0d"
-                                                            "custom-header"),
+                          (uint8_t *)"\x10\x0a"
+                                     "custom-key\x0d"
+                                     "custom-header",
                           26},
                          {(char *)":path", (char *)"/sample/path", 4, HpackField::INDEXED_LITERAL,
-                          reinterpret_cast<const uint8_t *>("\x44\x0c"
-                                                            "/sample/path"),
+                          (uint8_t *)"\x44\x0c"
+                                     "/sample/path",
                           14},
                          {(char *)":path", (char *)"/sample/path", 4, HpackField::NOINDEX_LITERAL,
-                          reinterpret_cast<const uint8_t *>("\x04\x0c"
-                                                            "/sample/path"),
+                          (uint8_t *)"\x04\x0c"
+                                     "/sample/path",
                           14},
                          {(char *)":path", (char *)"/sample/path", 4, HpackField::NEVERINDEX_LITERAL,
-                          reinterpret_cast<const uint8_t *>("\x14\x0c"
-                                                            "/sample/path"),
+                          (uint8_t *)"\x14\x0c"
+                                     "/sample/path",
                           14},
                          {(char *)"password", (char *)"secret", 0, HpackField::INDEXED_LITERAL,
-                          reinterpret_cast<const uint8_t *>("\x40\x08"
-                                                            "password\x06"
-                                                            "secret"),
+                          (uint8_t *)"\x40\x08"
+                                     "password\x06"
+                                     "secret",
                           17},
                          {(char *)"password", (char *)"secret", 0, HpackField::NOINDEX_LITERAL,
-                          reinterpret_cast<const uint8_t *>("\x00\x08"
-                                                            "password\x06"
-                                                            "secret"),
+                          (uint8_t *)"\x00\x08"
+                                     "password\x06"
+                                     "secret",
                           17},
                          {(char *)"password", (char *)"secret", 0, HpackField::NEVERINDEX_LITERAL,
-                          reinterpret_cast<const uint8_t *>("\x10\x08"
-                                                            "password\x06"
-                                                            "secret"),
+                          (uint8_t *)"\x10\x08"
+                                     "password\x06"
+                                     "secret",
                           17},
                          // with Huffman Coding
                          {(char *)"custom-key", (char *)"custom-header", 0, HpackField::INDEXED_LITERAL,
-                          reinterpret_cast<const uint8_t *>("\x40"
-                                                            "\x88\x25\xa8\x49\xe9\x5b\xa9\x7d\x7f"
-                                                            "\x89\x25\xa8\x49\xe9\x5a\x72\x8e\x42\xd9"),
+                          (uint8_t *)"\x40"
+                                     "\x88\x25\xa8\x49\xe9\x5b\xa9\x7d\x7f"
+                                     "\x89\x25\xa8\x49\xe9\x5a\x72\x8e\x42\xd9",
                           20},
                          {(char *)"custom-key", (char *)"custom-header", 0, HpackField::NOINDEX_LITERAL,
-                          reinterpret_cast<const uint8_t *>("\x00"
-                                                            "\x88\x25\xa8\x49\xe9\x5b\xa9\x7d\x7f"
-                                                            "\x89\x25\xa8\x49\xe9\x5a\x72\x8e\x42\xd9"),
+                          (uint8_t *)"\x00"
+                                     "\x88\x25\xa8\x49\xe9\x5b\xa9\x7d\x7f"
+                                     "\x89\x25\xa8\x49\xe9\x5a\x72\x8e\x42\xd9",
                           20},
                          {(char *)"custom-key", (char *)"custom-header", 0, HpackField::NEVERINDEX_LITERAL,
-                          reinterpret_cast<const uint8_t *>("\x10"
-                                                            "\x88\x25\xa8\x49\xe9\x5b\xa9\x7d\x7f"
-                                                            "\x89\x25\xa8\x49\xe9\x5a\x72\x8e\x42\xd9"),
+                          (uint8_t *)"\x10"
+                                     "\x88\x25\xa8\x49\xe9\x5b\xa9\x7d\x7f"
+                                     "\x89\x25\xa8\x49\xe9\x5a\x72\x8e\x42\xd9",
                           20},
                          {(char *)":path", (char *)"/sample/path", 4, HpackField::INDEXED_LITERAL,
-                          reinterpret_cast<const uint8_t *>("\x44"
-                                                            "\x89\x61\x03\xa6\xba\x0a\xc5\x63\x4c\xff"),
+                          (uint8_t *)"\x44"
+                                     "\x89\x61\x03\xa6\xba\x0a\xc5\x63\x4c\xff",
                           11},
                          {(char *)":path", (char *)"/sample/path", 4, HpackField::NOINDEX_LITERAL,
-                          reinterpret_cast<const uint8_t *>("\x04"
-                                                            "\x89\x61\x03\xa6\xba\x0a\xc5\x63\x4c\xff"),
+                          (uint8_t *)"\x04"
+                                     "\x89\x61\x03\xa6\xba\x0a\xc5\x63\x4c\xff",
                           11},
                          {(char *)":path", (char *)"/sample/path", 4, HpackField::NEVERINDEX_LITERAL,
-                          reinterpret_cast<const uint8_t *>("\x14"
-                                                            "\x89\x61\x03\xa6\xba\x0a\xc5\x63\x4c\xff"),
+                          (uint8_t *)"\x14"
+                                     "\x89\x61\x03\xa6\xba\x0a\xc5\x63\x4c\xff",
                           11},
                          {(char *)"password", (char *)"secret", 0, HpackField::INDEXED_LITERAL,
-                          reinterpret_cast<const uint8_t *>("\x40"
-                                                            "\x86\xac\x68\x47\x83\xd9\x27"
-                                                            "\x84\x41\x49\x61\x53"),
+                          (uint8_t *)"\x40"
+                                     "\x86\xac\x68\x47\x83\xd9\x27"
+                                     "\x84\x41\x49\x61\x53",
                           13},
                          {(char *)"password", (char *)"secret", 0, HpackField::NOINDEX_LITERAL,
-                          reinterpret_cast<const uint8_t *>("\x00"
-                                                            "\x86\xac\x68\x47\x83\xd9\x27"
-                                                            "\x84\x41\x49\x61\x53"),
+                          (uint8_t *)"\x00"
+                                     "\x86\xac\x68\x47\x83\xd9\x27"
+                                     "\x84\x41\x49\x61\x53",
                           13},
                          {(char *)"password", (char *)"secret", 0, HpackField::NEVERINDEX_LITERAL,
-                          reinterpret_cast<const uint8_t *>("\x10"
-                                                            "\x86\xac\x68\x47\x83\xd9\x27"
-                                                            "\x84\x41\x49\x61\x53"),
+                          (uint8_t *)"\x10"
+                                     "\x86\xac\x68\x47\x83\xd9\x27"
+                                     "\x84\x41\x49\x61\x53",
                           13}};
 
 // [RFC 7541] C.3. Request Examples without Huffman Coding - C.3.1. First Request
@@ -197,33 +195,33 @@ const static struct {
                                                          {(char *)"", (char *)""} // End of this test case
                                                        }};
 const static struct {
-  const uint8_t *encoded_field;
+  uint8_t *encoded_field;
   int encoded_field_len;
-} encoded_field_request_test_case[] = {{reinterpret_cast<const uint8_t *>("\x40"
-                                                                          "\x7:method"
-                                                                          "\x3GET"
-                                                                          "\x40"
-                                                                          "\x7:scheme"
-                                                                          "\x4http"
-                                                                          "\x40"
-                                                                          "\x5:path"
-                                                                          "\x1/"
-                                                                          "\x40"
-                                                                          "\xa:authority"
-                                                                          "\xfwww.example.com"),
+} encoded_field_request_test_case[] = {{(uint8_t *)"\x40"
+                                                   "\x7:method"
+                                                   "\x3GET"
+                                                   "\x40"
+                                                   "\x7:scheme"
+                                                   "\x4http"
+                                                   "\x40"
+                                                   "\x5:path"
+                                                   "\x1/"
+                                                   "\x40"
+                                                   "\xa:authority"
+                                                   "\xfwww.example.com",
                                         64},
-                                       {reinterpret_cast<const uint8_t *>("\x40"
-                                                                          "\x85\xb9\x49\x53\x39\xe4"
-                                                                          "\x83\xc5\x83\x7f"
-                                                                          "\x40"
-                                                                          "\x85\xb8\x82\x4e\x5a\x4b"
-                                                                          "\x83\x9d\x29\xaf"
-                                                                          "\x40"
-                                                                          "\x84\xb9\x58\xd3\x3f"
-                                                                          "\x81\x63"
-                                                                          "\x40"
-                                                                          "\x88\xb8\x3b\x53\x39\xec\x32\x7d\x7f"
-                                                                          "\x8c\xf1\xe3\xc2\xe5\xf2\x3a\x6b\xa0\xab\x90\xf4\xff"),
+                                       {(uint8_t *)"\x40"
+                                                   "\x85\xb9\x49\x53\x39\xe4"
+                                                   "\x83\xc5\x83\x7f"
+                                                   "\x40"
+                                                   "\x85\xb8\x82\x4e\x5a\x4b"
+                                                   "\x83\x9d\x29\xaf"
+                                                   "\x40"
+                                                   "\x84\xb9\x58\xd3\x3f"
+                                                   "\x81\x63"
+                                                   "\x40"
+                                                   "\x88\xb8\x3b\x53\x39\xec\x32\x7d\x7f"
+                                                   "\x8c\xf1\xe3\xc2\xe5\xf2\x3a\x6b\xa0\xab\x90\xf4\xff",
                                         53}};
 
 // [RFC 7541] C.6. Response Examples with Huffman Coding
@@ -255,39 +253,38 @@ const static struct {
     {(char *)"", (char *)""} // End of this test case
   }};
 const static struct {
-  const uint8_t *encoded_field;
+  uint8_t *encoded_field;
   int encoded_field_len;
-} encoded_field_response_test_case[] = {
-  {reinterpret_cast<const uint8_t *>("\x48\x82"
-                                     "\x64\x02"
-                                     "\x58\x85"
-                                     "\xae\xc3\x77\x1a\x4b"
-                                     "\x61\x96"
-                                     "\xd0\x7a\xbe\x94\x10\x54\xd4\x44\xa8\x20\x05\x95\x04\x0b\x81\x66"
-                                     "\xe0\x82\xa6\x2d\x1b\xff"
-                                     "\x6e\x91"
-                                     "\x9d\x29\xad\x17\x18\x63\xc7\x8f\x0b\x97\xc8\xe9\xae\x82\xae\x43"
-                                     "\xd3"),
-   54},
-  {reinterpret_cast<const uint8_t *>("\x48\x83"
-                                     "\x64\x0e\xff"
-                                     "\xc1"
-                                     "\xc0"
-                                     "\xbf"),
-   8},
-  {reinterpret_cast<const uint8_t *>("\x88"
-                                     "\xc1"
-                                     "\x61\x96"
-                                     "\xd0\x7a\xbe\x94\x10\x54\xd4\x44\xa8\x20\x05\x95\x04\x0b\x81\x66"
-                                     "\xe0\x84\xa6\x2d\x1b\xff"
-                                     "\xc0"
-                                     "\x5a\x83"
-                                     "\x9b\xd9\xab"
-                                     "\x77\xad"
-                                     "\x94\xe7\x82\x1d\xd7\xf2\xe6\xc7\xb3\x35\xdf\xdf\xcd\x5b\x39\x60"
-                                     "\xd5\xaf\x27\x08\x7f\x36\x72\xc1\xab\x27\x0f\xb5\x29\x1f\x95\x87"
-                                     "\x31\x60\x65\xc0\x03\xed\x4e\xe5\xb1\x06\x3d\x50\x07"),
-   79}};
+} encoded_field_response_test_case[] = {{(uint8_t *)"\x48\x82"
+                                                    "\x64\x02"
+                                                    "\x58\x85"
+                                                    "\xae\xc3\x77\x1a\x4b"
+                                                    "\x61\x96"
+                                                    "\xd0\x7a\xbe\x94\x10\x54\xd4\x44\xa8\x20\x05\x95\x04\x0b\x81\x66"
+                                                    "\xe0\x82\xa6\x2d\x1b\xff"
+                                                    "\x6e\x91"
+                                                    "\x9d\x29\xad\x17\x18\x63\xc7\x8f\x0b\x97\xc8\xe9\xae\x82\xae\x43"
+                                                    "\xd3",
+                                         54},
+                                        {(uint8_t *)"\x48\x83"
+                                                    "\x64\x0e\xff"
+                                                    "\xc1"
+                                                    "\xc0"
+                                                    "\xbf",
+                                         8},
+                                        {(uint8_t *)"\x88"
+                                                    "\xc1"
+                                                    "\x61\x96"
+                                                    "\xd0\x7a\xbe\x94\x10\x54\xd4\x44\xa8\x20\x05\x95\x04\x0b\x81\x66"
+                                                    "\xe0\x84\xa6\x2d\x1b\xff"
+                                                    "\xc0"
+                                                    "\x5a\x83"
+                                                    "\x9b\xd9\xab"
+                                                    "\x77\xad"
+                                                    "\x94\xe7\x82\x1d\xd7\xf2\xe6\xc7\xb3\x35\xdf\xdf\xcd\x5b\x39\x60"
+                                                    "\xd5\xaf\x27\x08\x7f\x36\x72\xc1\xab\x27\x0f\xb5\x29\x1f\x95\x87"
+                                                    "\x31\x60\x65\xc0\x03\xed\x4e\xe5\xb1\x06\x3d\x50\x07",
+                                         79}};
 const static struct {
   uint32_t size;
   char *name;

--- a/proxy/http2/test_Huffmancode.cc
+++ b/proxy/http2/test_Huffmancode.cc
@@ -29,7 +29,7 @@
 
 using namespace std;
 
-const int32_t test_values[] = {
+uint32_t test_values[] = {
   0x1ff8,     13, 0x7fffd8,  23, 0xfffffe2,  28, 0xfffffe3, 28, 0xfffffe4, 28, 0xfffffe5,  28, 0xfffffe6,  28, 0xfffffe7, 28,
   0xfffffe8,  28, 0xffffea,  24, 0x3ffffffc, 30, 0xfffffe9, 28, 0xfffffea, 28, 0x3ffffffd, 30, 0xfffffeb,  28, 0xfffffec, 28,
   0xfffffed,  28, 0xfffffee, 28, 0xfffffef,  28, 0xffffff0, 28, 0xffffff1, 28, 0xffffff2,  28, 0x3ffffffe, 30, 0xffffff3, 28,
@@ -68,14 +68,14 @@ void
 random_test()
 {
   const int size  = 1024;
-  char *dst_start = static_cast<char *>(malloc(size * 2));
+  char *dst_start = (char *)malloc(size * 2);
   char string[size];
   for (char &i : string) {
     // coverity[dont_call]
     long num = lrand48();
-    i        = static_cast<char>(num);
+    i        = (char)num;
   }
-  const uint8_t *src = reinterpret_cast<const uint8_t *>(string);
+  const uint8_t *src = (const uint8_t *)string;
   uint32_t src_len   = sizeof(string);
 
   int bytes = huffman_decode(dst_start, src, src_len);
@@ -143,20 +143,19 @@ values_test()
 
 // NOTE: Test data from "C.6.1 First Response" in RFC 7541.
 const static struct {
-  const uint8_t *src;
+  uint8_t *src;
   int64_t src_len;
-  const uint8_t *expect;
+  uint8_t *expect;
   int64_t expect_len;
 } huffman_encode_test_data[] = {
-  {reinterpret_cast<const uint8_t *>(""), 0, reinterpret_cast<const uint8_t *>(""), 0},
-  {reinterpret_cast<const uint8_t *>("0"), 1, reinterpret_cast<const uint8_t *>("\x07"), 1},
-  {reinterpret_cast<const uint8_t *>("302"), 3, reinterpret_cast<const uint8_t *>("\x64\x02"), 2},
-  {reinterpret_cast<const uint8_t *>("private"), 7, reinterpret_cast<const uint8_t *>("\xae\xc3\x77\x1a\x4b"), 5},
-  {reinterpret_cast<const uint8_t *>("Mon, 21 Oct 2013 20:13:21 GMT"), 29,
-   reinterpret_cast<const uint8_t *>("\xd0\x7a\xbe\x94\x10\x54\xd4\x44\xa8\x20\x05\x95\x04\x0b\x81\x66\xe0\x82\xa6\x2d\x1b\xff"),
-   22},
-  {reinterpret_cast<const uint8_t *>("https://www.example.com"), 23,
-   reinterpret_cast<const uint8_t *>("\x9d\x29\xad\x17\x18\x63\xc7\x8f\x0b\x97\xc8\xe9\xae\x82\xae\x43\xd3"), 17}};
+  {(uint8_t *)"", 0, (uint8_t *)"", 0},
+  {(uint8_t *)"0", 1, (uint8_t *)"\x07", 1},
+  {(uint8_t *)"302", 3, (uint8_t *)"\x64\x02", 2},
+  {(uint8_t *)"private", 7, (uint8_t *)"\xae\xc3\x77\x1a\x4b", 5},
+  {(uint8_t *)"Mon, 21 Oct 2013 20:13:21 GMT", 29,
+   (uint8_t *)"\xd0\x7a\xbe\x94\x10\x54\xd4\x44\xa8\x20\x05\x95\x04\x0b\x81\x66\xe0\x82\xa6\x2d\x1b\xff", 22},
+  {(uint8_t *)"https://www.example.com", 23, (uint8_t *)"\x9d\x29\xad\x17\x18\x63\xc7\x8f\x0b\x97\xc8\xe9\xae\x82\xae\x43\xd3",
+   17}};
 
 void
 encode_test()

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -203,7 +203,7 @@ Log::periodic_tasks(long time_now)
     Debug("log-config", "Performing reconfiguration, init status = %d", init_status);
 
     if (logging_mode_changed) {
-      int val = static_cast<int>(REC_ConfigReadInteger("proxy.config.log.logging_enabled"));
+      int val = (int)REC_ConfigReadInteger("proxy.config.log.logging_enabled");
 
       if (val < LOG_MODE_NONE || val > LOG_MODE_FULL) {
         logging_mode = LOG_MODE_FULL;
@@ -211,7 +211,7 @@ Log::periodic_tasks(long time_now)
                 "value setting it to %d",
                 logging_mode);
       } else {
-        logging_mode = static_cast<LoggingMode>(val);
+        logging_mode = (LoggingMode)val;
       }
       logging_mode_changed = false;
     }
@@ -345,7 +345,7 @@ Log::init_fields()
   field_symbol_hash.emplace("hiih", field);
   // interface ip end
   field = new LogField("client_auth_user_name", "caun", LogField::STRING, &LogAccess::marshal_client_auth_user_name,
-                       reinterpret_cast<LogField::UnmarshalFunc>(&LogAccess::unmarshal_str));
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
   global_field_list.add(field, false);
   field_symbol_hash.emplace("caun", field);
 
@@ -390,50 +390,48 @@ Log::init_fields()
   field_symbol_hash.emplace("cqtt", field);
 
   field = new LogField("client_req_text", "cqtx", LogField::STRING, &LogAccess::marshal_client_req_text,
-                       reinterpret_cast<LogField::UnmarshalFunc>(&LogAccess::unmarshal_http_text));
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_http_text);
   global_field_list.add(field, false);
   field_symbol_hash.emplace("cqtx", field);
 
   field = new LogField("client_req_http_method", "cqhm", LogField::STRING, &LogAccess::marshal_client_req_http_method,
-                       reinterpret_cast<LogField::UnmarshalFunc>(&LogAccess::unmarshal_str));
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
   global_field_list.add(field, false);
   field_symbol_hash.emplace("cqhm", field);
 
   field = new LogField("client_req_url", "cqu", LogField::STRING, &LogAccess::marshal_client_req_url,
-                       reinterpret_cast<LogField::UnmarshalFunc>(&LogAccess::unmarshal_str), &LogAccess::set_client_req_url);
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str, &LogAccess::set_client_req_url);
   global_field_list.add(field, false);
   field_symbol_hash.emplace("cqu", field);
 
   field = new LogField("client_req_url_canonical", "cquc", LogField::STRING, &LogAccess::marshal_client_req_url_canon,
-                       reinterpret_cast<LogField::UnmarshalFunc>(&LogAccess::unmarshal_str), &LogAccess::set_client_req_url_canon);
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str, &LogAccess::set_client_req_url_canon);
   global_field_list.add(field, false);
   field_symbol_hash.emplace("cquc", field);
 
-  field = new LogField(
-    "client_req_unmapped_url_canonical", "cquuc", LogField::STRING, &LogAccess::marshal_client_req_unmapped_url_canon,
-    reinterpret_cast<LogField::UnmarshalFunc>(&LogAccess::unmarshal_str), &LogAccess::set_client_req_unmapped_url_canon);
+  field =
+    new LogField("client_req_unmapped_url_canonical", "cquuc", LogField::STRING, &LogAccess::marshal_client_req_unmapped_url_canon,
+                 (LogField::UnmarshalFunc)&LogAccess::unmarshal_str, &LogAccess::set_client_req_unmapped_url_canon);
   global_field_list.add(field, false);
   field_symbol_hash.emplace("cquuc", field);
 
   field = new LogField("client_req_unmapped_url_path", "cquup", LogField::STRING, &LogAccess::marshal_client_req_unmapped_url_path,
-                       reinterpret_cast<LogField::UnmarshalFunc>(&LogAccess::unmarshal_str),
-                       &LogAccess::set_client_req_unmapped_url_path);
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str, &LogAccess::set_client_req_unmapped_url_path);
   global_field_list.add(field, false);
   field_symbol_hash.emplace("cquup", field);
 
   field = new LogField("client_req_unmapped_url_host", "cquuh", LogField::STRING, &LogAccess::marshal_client_req_unmapped_url_host,
-                       reinterpret_cast<LogField::UnmarshalFunc>(&LogAccess::unmarshal_str),
-                       &LogAccess::set_client_req_unmapped_url_host);
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str, &LogAccess::set_client_req_unmapped_url_host);
   global_field_list.add(field, false);
   field_symbol_hash.emplace("cquuh", field);
 
   field = new LogField("client_req_url_scheme", "cqus", LogField::STRING, &LogAccess::marshal_client_req_url_scheme,
-                       reinterpret_cast<LogField::UnmarshalFunc>(&LogAccess::unmarshal_str));
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
   global_field_list.add(field, false);
   field_symbol_hash.emplace("cqus", field);
 
   field = new LogField("client_req_url_path", "cqup", LogField::STRING, &LogAccess::marshal_client_req_url_path,
-                       reinterpret_cast<LogField::UnmarshalFunc>(&LogAccess::unmarshal_str), &LogAccess::set_client_req_url_path);
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str, &LogAccess::set_client_req_url_path);
   global_field_list.add(field, false);
   field_symbol_hash.emplace("cqup", field);
 
@@ -443,7 +441,7 @@ Log::init_fields()
   field_symbol_hash.emplace("cqhv", field);
 
   field = new LogField("client_req_protocol_version", "cqpv", LogField::dINT, &LogAccess::marshal_client_req_protocol_version,
-                       reinterpret_cast<LogField::UnmarshalFunc>(&LogAccess::unmarshal_str));
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
   global_field_list.add(field, false);
   field_symbol_hash.emplace("cqpv", field);
 
@@ -458,12 +456,12 @@ Log::init_fields()
   field_symbol_hash.emplace("cqql", field);
 
   field = new LogField("cache_lookup_url_canonical", "cluc", LogField::STRING, &LogAccess::marshal_cache_lookup_url_canon,
-                       reinterpret_cast<LogField::UnmarshalFunc>(&LogAccess::unmarshal_str));
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
   global_field_list.add(field, false);
   field_symbol_hash.emplace("cluc", field);
 
   field = new LogField("process_uuid", "puuid", LogField::STRING, &LogAccess::marshal_process_uuid,
-                       reinterpret_cast<LogField::UnmarshalFunc>(&LogAccess::unmarshal_str));
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
   global_field_list.add(field, false);
   field_symbol_hash.emplace("puuid", field);
 
@@ -498,12 +496,12 @@ Log::init_fields()
   field_symbol_hash.emplace("cqmpt", field);
 
   field = new LogField("client_sec_protocol", "cqssv", LogField::STRING, &LogAccess::marshal_client_security_protocol,
-                       reinterpret_cast<LogField::UnmarshalFunc>(&LogAccess::unmarshal_str));
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
   global_field_list.add(field, false);
   field_symbol_hash.emplace("cqssv", field);
 
   field = new LogField("client_cipher_suite", "cqssc", LogField::STRING, &LogAccess::marshal_client_security_cipher_suite,
-                       reinterpret_cast<LogField::UnmarshalFunc>(&LogAccess::unmarshal_str));
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
   global_field_list.add(field, false);
   field_symbol_hash.emplace("cqssc", field);
 
@@ -521,17 +519,17 @@ Log::init_fields()
   field_symbol_hash.emplace("crid", field);
 
   field = new LogField("client_req_uuid", "cruuid", LogField::STRING, &LogAccess::marshal_client_req_uuid,
-                       reinterpret_cast<LogField::UnmarshalFunc>(&LogAccess::unmarshal_str));
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
   global_field_list.add(field, false);
   field_symbol_hash.emplace("cruuid", field);
 
   field = new LogField("client_rx_error_code", "crec", LogField::STRING, &LogAccess::marshal_client_rx_error_code,
-                       reinterpret_cast<LogField::UnmarshalFunc>(&LogAccess::unmarshal_str));
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
   global_field_list.add(field, false);
   field_symbol_hash.emplace("crec", field);
 
   field = new LogField("client_tx_error_code", "ctec", LogField::STRING, &LogAccess::marshal_client_tx_error_code,
-                       reinterpret_cast<LogField::UnmarshalFunc>(&LogAccess::unmarshal_str));
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
   global_field_list.add(field, false);
   field_symbol_hash.emplace("ctec", field);
 
@@ -542,12 +540,12 @@ Log::init_fields()
 
   // proxy -> client fields
   field = new LogField("proxy_resp_content_type", "psct", LogField::STRING, &LogAccess::marshal_proxy_resp_content_type,
-                       reinterpret_cast<LogField::UnmarshalFunc>(&LogAccess::unmarshal_str));
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
   global_field_list.add(field, false);
   field_symbol_hash.emplace("psct", field);
 
   field = new LogField("proxy_resp_reason_phrase", "prrp", LogField::STRING, &LogAccess::marshal_proxy_resp_reason_phrase,
-                       reinterpret_cast<LogField::UnmarshalFunc>(&LogAccess::unmarshal_str));
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
   global_field_list.add(field, false);
   field_symbol_hash.emplace("prrp", field);
 
@@ -702,7 +700,7 @@ Log::init_fields()
   field_symbol_hash.emplace("phr", field);
 
   field = new LogField("proxy_host_name", "phn", LogField::STRING, &LogAccess::marshal_proxy_host_name,
-                       reinterpret_cast<LogField::UnmarshalFunc>(&LogAccess::unmarshal_str));
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
   global_field_list.add(field, false);
   field_symbol_hash.emplace("phn", field);
 
@@ -732,7 +730,7 @@ Log::init_fields()
   field_symbol_hash.emplace("shi", field);
 
   field = new LogField("server_host_name", "shn", LogField::STRING, &LogAccess::marshal_server_host_name,
-                       reinterpret_cast<LogField::UnmarshalFunc>(&LogAccess::unmarshal_str));
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
   global_field_list.add(field, false);
   field_symbol_hash.emplace("shn", field);
 
@@ -909,7 +907,7 @@ Log::handle_periodic_tasks_int_change(const char * /* name ATS_UNUSED */, RecDat
     Error("new periodic tasks interval = %d is invalid, falling back to default = %d", (int)data.rec_int,
           PERIODIC_TASKS_INTERVAL_FALLBACK);
   } else {
-    periodic_tasks_interval = static_cast<uint32_t>(data.rec_int);
+    periodic_tasks_interval = (uint32_t)data.rec_int;
     Debug("log-periodic", "periodic task interval changed to %u", periodic_tasks_interval);
   }
   return REC_ERR_OKAY;
@@ -935,20 +933,20 @@ Log::init(int flags)
   if (config_flags & LOGCAT) {
     logging_mode = LOG_MODE_NONE;
   } else {
-    log_rsb = RecAllocateRawStatBlock(static_cast<int>(log_stat_count));
+    log_rsb = RecAllocateRawStatBlock((int)log_stat_count);
     LogConfig::register_stat_callbacks();
 
     config->read_configuration_variables();
     preproc_threads = config->preproc_threads;
 
-    int val = static_cast<int>(REC_ConfigReadInteger("proxy.config.log.logging_enabled"));
+    int val = (int)REC_ConfigReadInteger("proxy.config.log.logging_enabled");
     if (val < LOG_MODE_NONE || val > LOG_MODE_FULL) {
       logging_mode = LOG_MODE_FULL;
       Warning("proxy.config.log.logging_enabled has an invalid "
               "value, setting it to %d",
               logging_mode);
     } else {
-      logging_mode = static_cast<LoggingMode>(val);
+      logging_mode = (LoggingMode)val;
     }
     // periodic task interval are set on a per instance basis
     MgmtInt pti = REC_ConfigReadInteger("proxy.config.log.periodic_tasks_interval");
@@ -1201,8 +1199,8 @@ Log::trace_va(bool in, const sockaddr *peer_addr, uint16_t peer_port, const char
 
   struct timeval tp = ink_gettimeofday();
 
-  Log::error("[%9d.%03d] Trace {0x%" PRIx64 "} %s %s:%d: ", static_cast<int>(tp.tv_sec), static_cast<int>(tp.tv_usec / 1000),
-             reinterpret_cast<uint64_t>(ink_thread_self()), in ? "RECV" : "SEND", ip, peer_port);
+  Log::error("[%9d.%03d] Trace {0x%" PRIx64 "} %s %s:%d: ", (int)tp.tv_sec, (int)(tp.tv_usec / 1000), (uint64_t)ink_thread_self(),
+             in ? "RECV" : "SEND", ip, peer_port);
   Log::va_error(format_string, ap);
   Log::error("[End Trace]\n");
 }
@@ -1218,7 +1216,7 @@ Log::trace_va(bool in, const sockaddr *peer_addr, uint16_t peer_port, const char
 void *
 Log::preproc_thread_main(void *args)
 {
-  int idx = *static_cast<int *>(args);
+  int idx = *(int *)args;
 
   Debug("log-preproc", "log preproc thread is alive ...");
 
@@ -1290,11 +1288,11 @@ Log::flush_thread_main(void * /* args ATS_UNUSED */)
         logbuffer                      = static_cast<LogBuffer *>(fdata->m_data);
         LogBufferHeader *buffer_header = logbuffer->header();
 
-        buf         = reinterpret_cast<char *>(buffer_header);
+        buf         = (char *)buffer_header;
         total_bytes = buffer_header->byte_count;
 
       } else if (logfile->m_file_format == LOG_FILE_ASCII || logfile->m_file_format == LOG_FILE_PIPE) {
-        buf         = static_cast<char *>(fdata->m_data);
+        buf         = (char *)fdata->m_data;
         total_bytes = fdata->m_len;
 
       } else {

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -106,18 +106,18 @@ LogAccess::init()
     m_proxy_response = &(hdr->client_response);
     MIMEField *field = m_proxy_response->field_find(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE);
     if (field) {
-      m_proxy_resp_content_type_str = const_cast<char *>(field->value_get(&m_proxy_resp_content_type_len));
+      m_proxy_resp_content_type_str = (char *)field->value_get(&m_proxy_resp_content_type_len);
 
       LogUtils::remove_content_type_attributes(m_proxy_resp_content_type_str, &m_proxy_resp_content_type_len);
     } else {
       // If Content-Type field is missing, check for @Content-Type
       field = m_proxy_response->field_find(HIDDEN_CONTENT_TYPE, HIDDEN_CONTENT_TYPE_LEN);
       if (field) {
-        m_proxy_resp_content_type_str = const_cast<char *>(field->value_get(&m_proxy_resp_content_type_len));
+        m_proxy_resp_content_type_str = (char *)field->value_get(&m_proxy_resp_content_type_len);
         LogUtils::remove_content_type_attributes(m_proxy_resp_content_type_str, &m_proxy_resp_content_type_len);
       }
     }
-    m_proxy_resp_reason_phrase_str = const_cast<char *>(m_proxy_response->reason_get(&m_proxy_resp_reason_phrase_len));
+    m_proxy_resp_reason_phrase_str = (char *)m_proxy_response->reason_get(&m_proxy_resp_reason_phrase_len);
   }
   if (hdr->server_request.valid()) {
     m_proxy_request = &(hdr->server_request);
@@ -167,7 +167,7 @@ LogAccess::marshal_process_uuid(char *buf)
   int len = round_strlen(TS_UUID_STRING_LEN + 1);
 
   if (buf) {
-    const char *str = const_cast<char *>(Machine::instance()->uuid.getString());
+    const char *str = (char *)Machine::instance()->uuid.getString();
     marshal_str(buf, str, len);
   }
   return len;
@@ -180,7 +180,7 @@ int
 LogAccess::marshal_config_int_var(char *config_var, char *buf)
 {
   if (buf) {
-    int64_t val = static_cast<int64_t>(REC_ConfigReadInteger(config_var));
+    int64_t val = (int64_t)REC_ConfigReadInteger(config_var);
     marshal_int(buf, val);
   }
   return INK_MIN_ALIGN;
@@ -252,13 +252,13 @@ LogAccess::marshal_record(char *record, char *buf)
       //
       ink_assert(max_chars > 21);
 
-      int64_t val = static_cast<int64_t>(LOG_INTEGER == stype ? REC_readInteger(record, &found) : REC_readCounter(record, &found));
+      int64_t val = (int64_t)(LOG_INTEGER == stype ? REC_readInteger(record, &found) : REC_readCounter(record, &found));
 
       if (found) {
         out_buf = int64_to_str(ascii_buf, max_chars, val, &num_chars);
         ink_assert(out_buf);
       } else {
-        out_buf   = const_cast<char *>(record_not_found_msg);
+        out_buf   = (char *)record_not_found_msg;
         num_chars = record_not_found_chars;
       }
     } else if (LOG_FLOAT == stype) {
@@ -291,7 +291,7 @@ LogAccess::marshal_record(char *record, char *buf)
           out_buf = ascii_buf;
         }
       } else {
-        out_buf   = const_cast<char *>(record_not_found_msg);
+        out_buf   = (char *)record_not_found_msg;
         num_chars = record_not_found_chars;
       }
     } else if (LOG_STRING == stype) {
@@ -311,7 +311,7 @@ LogAccess::marshal_record(char *record, char *buf)
           num_chars = ::strlen(out_buf) + 1;
         }
       } else {
-        out_buf   = const_cast<char *>(record_not_found_msg);
+        out_buf   = (char *)record_not_found_msg;
         num_chars = record_not_found_chars;
       }
     } else {
@@ -442,7 +442,7 @@ LogAccess::unmarshal_with_map(int64_t code, char *dest, int len, const Ptr<LogFi
 {
   long int codeStrLen = 0;
 
-  switch (map->asString(code, dest, len, reinterpret_cast<size_t *>(&codeStrLen))) {
+  switch (map->asString(code, dest, len, (size_t *)&codeStrLen)) {
   case LogFieldAliasMap::INVALID_INT:
     if (msg) {
       const int bufSize = 64;
@@ -480,7 +480,7 @@ LogAccess::unmarshal_int(char **buf)
   int64_t val;
 
   // TODO: this used to do nthol, do we need to worry? TS-1156.
-  val = *(reinterpret_cast<int64_t *>(*buf));
+  val = *((int64_t *)(*buf));
   *buf += INK_MIN_ALIGN;
   return val;
 }
@@ -532,7 +532,7 @@ LogAccess::unmarshal_itoa(int64_t val, char *dest, int field_width, char leading
     *p-- = '-';
   }
 
-  return static_cast<int>(dest - p);
+  return (int)(dest - p);
 }
 
 /*-------------------------------------------------------------------------
@@ -552,7 +552,7 @@ LogAccess::unmarshal_itox(int64_t val, char *dest, int field_width, char leading
   char *p             = dest;
   static char table[] = "0123456789abcdef?";
 
-  for (int i = 0; i < static_cast<int>(sizeof(int64_t) * 2); i++) {
+  for (int i = 0; i < (int)(sizeof(int64_t) * 2); i++) {
     *p-- = table[val & 0xf];
     val >>= 4;
   }
@@ -560,7 +560,7 @@ LogAccess::unmarshal_itox(int64_t val, char *dest, int field_width, char leading
     *p-- = leading_char;
   }
 
-  return static_cast<int64_t>(dest - p);
+  return (int64_t)(dest - p);
 }
 
 /*-------------------------------------------------------------------------
@@ -640,7 +640,7 @@ LogAccess::unmarshal_str(char **buf, char *dest, int len, LogSlice *slice)
   ink_assert(dest != nullptr);
 
   char *val_buf = *buf;
-  int val_len   = static_cast<int>(::strlen(val_buf));
+  int val_len   = (int)::strlen(val_buf);
 
   *buf += LogAccess::strlen(val_buf); // this is how it was stored
 
@@ -675,7 +675,7 @@ LogAccess::unmarshal_ttmsf(char **buf, char *dest, int len)
   ink_assert(dest != nullptr);
 
   int64_t val = unmarshal_int(buf);
-  double secs = static_cast<double>(val) / 1000;
+  double secs = (double)val / 1000;
   int val_len = snprintf(dest, len, "%.3f", secs);
   return val_len;
 }
@@ -689,7 +689,7 @@ LogAccess::unmarshal_int_to_date_str(char **buf, char *dest, int len)
 
   int64_t value = unmarshal_int(buf);
   char *strval  = LogUtils::timestamp_to_date_str(value);
-  int strlen    = static_cast<int>(::strlen(strval));
+  int strlen    = (int)::strlen(strval);
 
   memcpy(dest, strval, strlen);
   return strlen;
@@ -704,7 +704,7 @@ LogAccess::unmarshal_int_to_time_str(char **buf, char *dest, int len)
 
   int64_t value = unmarshal_int(buf);
   char *strval  = LogUtils::timestamp_to_time_str(value);
-  int strlen    = static_cast<int>(::strlen(strval));
+  int strlen    = (int)::strlen(strval);
 
   memcpy(dest, strval, strlen);
   return strlen;
@@ -731,7 +731,7 @@ LogAccess::unmarshal_int_to_netscape_str(char **buf, char *dest, int len)
 
   int64_t value = unmarshal_int(buf);
   char *strval  = LogUtils::timestamp_to_netscape_str(value);
-  int strlen    = static_cast<int>(::strlen(strval));
+  int strlen    = (int)::strlen(strval);
 
   memcpy(dest, strval, strlen);
   return strlen;
@@ -774,7 +774,7 @@ LogAccess::unmarshal_http_version(char **buf, char *dest, int len)
   ink_assert(dest != nullptr);
 
   static const char *http = "HTTP/";
-  static int http_len     = static_cast<int>(::strlen(http));
+  static int http_len     = (int)::strlen(http);
 
   char val_buf[128];
   char *p = val_buf;
@@ -1036,7 +1036,7 @@ LogAccess::unmarshal_record(char **buf, char *dest, int len)
   ink_assert(dest != nullptr);
 
   char *val_buf = *buf;
-  int val_len   = static_cast<int>(::strlen(val_buf));
+  int val_len   = (int)::strlen(val_buf);
   *buf += MARSHAL_RECORD_LENGTH; // this is how it was stored
   if (val_len < len) {
     memcpy(dest, val_buf, val_len);
@@ -1108,7 +1108,7 @@ resolve_logfield_string(LogAccess *context, const char *format_str)
   Debug("log-resolve", "Marshaling data from LogAccess into buffer ...");
   context->init();
   unsigned bytes_needed = fields.marshal_len(context);
-  char *buf             = static_cast<char *>(ats_malloc(bytes_needed));
+  char *buf             = (char *)ats_malloc(bytes_needed);
   unsigned bytes_used   = fields.marshal(context, buf);
 
   ink_assert(bytes_needed == bytes_used);
@@ -1120,7 +1120,7 @@ resolve_logfield_string(LogAccess *context, const char *format_str)
   // we're not sure how much space it will take when it's unmarshalled.
   // So, we'll just guess.
   //
-  char *result = static_cast<char *>(ats_malloc(8192));
+  char *result = (char *)ats_malloc(8192);
   unsigned bytes_resolved =
     LogBuffer::resolve_custom_entry(&fields, printf_str, buf, result, 8191, LogUtils::timestamp(), 0, LOG_SEGMENT_VERSION);
   ink_assert(bytes_resolved < 8192);
@@ -1341,19 +1341,17 @@ LogAccess::validate_unmapped_url_path()
 
     if (m_client_req_unmapped_url_path_len >= 6) { // xxx:// - minimum schema size
       int len;
-      char *c =
-        static_cast<char *>(memchr((void *)m_client_req_unmapped_url_path_str, ':', m_client_req_unmapped_url_path_len - 1));
+      char *c = (char *)memchr((void *)m_client_req_unmapped_url_path_str, ':', m_client_req_unmapped_url_path_len - 1);
 
-      if (c && (len = static_cast<int>(c - m_client_req_unmapped_url_path_str)) <= 5) { // 5 - max schema size
+      if (c && (len = (int)(c - m_client_req_unmapped_url_path_str)) <= 5) { // 5 - max schema size
         if (len + 2 <= m_client_req_unmapped_url_canon_len && c[1] == '/' && c[2] == '/') {
           len += 3; // Skip "://"
           m_client_req_unmapped_url_host_str = &m_client_req_unmapped_url_canon_str[len];
           m_client_req_unmapped_url_host_len = m_client_req_unmapped_url_path_len - len;
           // Attempt to find first '/' in the path
-          if (m_client_req_unmapped_url_host_len > 0 &&
-              (c = static_cast<char *>(
-                 memchr((void *)m_client_req_unmapped_url_host_str, '/', m_client_req_unmapped_url_path_len))) != nullptr) {
-            m_client_req_unmapped_url_host_len = static_cast<int>(c - m_client_req_unmapped_url_host_str);
+          if (m_client_req_unmapped_url_host_len > 0 && (c = (char *)memchr((void *)m_client_req_unmapped_url_host_str, '/',
+                                                                            m_client_req_unmapped_url_path_len)) != nullptr) {
+            m_client_req_unmapped_url_host_len = (int)(c - m_client_req_unmapped_url_host_str);
             m_client_req_unmapped_url_path_str = &m_client_req_unmapped_url_host_str[m_client_req_unmapped_url_host_len];
             m_client_req_unmapped_url_path_len = m_client_req_unmapped_url_path_len - len - m_client_req_unmapped_url_host_len;
           }
@@ -1434,7 +1432,7 @@ LogAccess::marshal_client_req_http_method(char *buf)
   int plen  = INK_MIN_ALIGN;
 
   if (m_client_request) {
-    str = const_cast<char *>(m_client_request->method_get(&alen));
+    str = (char *)m_client_request->method_get(&alen);
 
     // calculate the the padded length only if the actual length
     // is not zero. We don't want the padded length to be zero
@@ -1934,7 +1932,7 @@ LogAccess::marshal_proxy_resp_status_code(char *buf)
     } else {
       status = HTTP_STATUS_NONE;
     }
-    marshal_int(buf, static_cast<int64_t>(status));
+    marshal_int(buf, (int64_t)status);
   }
   return INK_MIN_ALIGN;
 }
@@ -2003,7 +2001,7 @@ LogAccess::marshal_cache_result_code(char *buf)
 {
   if (buf) {
     SquidLogCode code = m_http_sm->t_state.squid_codes.log_code;
-    marshal_int(buf, static_cast<int64_t>(code));
+    marshal_int(buf, (int64_t)code);
   }
   return INK_MIN_ALIGN;
 }
@@ -2016,7 +2014,7 @@ LogAccess::marshal_cache_result_subcode(char *buf)
 {
   if (buf) {
     SquidSubcode code = m_http_sm->t_state.squid_codes.subcode;
-    marshal_int(buf, static_cast<int64_t>(code));
+    marshal_int(buf, (int64_t)code);
   }
   return INK_MIN_ALIGN;
 }
@@ -2029,7 +2027,7 @@ LogAccess::marshal_cache_hit_miss(char *buf)
 {
   if (buf) {
     SquidHitMissCode code = m_http_sm->t_state.squid_codes.hit_miss_code;
-    marshal_int(buf, static_cast<int64_t>(code));
+    marshal_int(buf, (int64_t)code);
   }
   return INK_MIN_ALIGN;
 }
@@ -2134,7 +2132,7 @@ LogAccess::marshal_proxy_hierarchy_route(char *buf)
 {
   if (buf) {
     SquidHierarchyCode code = m_http_sm->t_state.squid_codes.hier_code;
-    marshal_int(buf, static_cast<int64_t>(code));
+    marshal_int(buf, (int64_t)code);
   }
   return INK_MIN_ALIGN;
 }
@@ -2194,7 +2192,7 @@ LogAccess::marshal_server_resp_status_code(char *buf)
     } else {
       status = HTTP_STATUS_NONE;
     }
-    marshal_int(buf, static_cast<int64_t>(status));
+    marshal_int(buf, (int64_t)status);
   }
   return INK_MIN_ALIGN;
 }
@@ -2321,7 +2319,7 @@ LogAccess::marshal_cache_resp_status_code(char *buf)
     } else {
       status = HTTP_STATUS_NONE;
     }
-    marshal_int(buf, static_cast<int64_t>(status));
+    marshal_int(buf, (int64_t)status);
   }
   return INK_MIN_ALIGN;
 }
@@ -2486,8 +2484,8 @@ LogAccess::marshal_file_size(char *buf)
 
     if (hdr && (fld = hdr->field_find(MIME_FIELD_CONTENT_RANGE, MIME_LEN_CONTENT_RANGE))) {
       int len;
-      char *str = const_cast<char *>(fld->value_get(&len));
-      char *pos = static_cast<char *>(memchr(str, '/', len)); // Find the /
+      char *str = (char *)fld->value_get(&len);
+      char *pos = (char *)memchr(str, '/', len); // Find the /
 
       // If the size is not /* (which means unknown) use it as the file_size.
       if (pos && !memchr(pos + 1, '*', len - (pos + 1 - str))) {
@@ -2578,7 +2576,7 @@ LogAccess::marshal_http_header_field(LogField::Container container, char *field,
   }
 
   if (header) {
-    MIMEField *fld = header->field_find(field, static_cast<int>(::strlen(field)));
+    MIMEField *fld = header->field_find(field, (int)::strlen(field));
     if (fld) {
       valid_field = true;
 
@@ -2587,7 +2585,7 @@ LogAccess::marshal_http_header_field(LogField::Container container, char *field,
       //
       int running_len = 0;
       while (fld) {
-        str = const_cast<char *>(fld->value_get(&actual_len));
+        str = (char *)fld->value_get(&actual_len);
         if (buf) {
           memcpy(buf, str, actual_len);
           buf += actual_len;
@@ -2679,7 +2677,7 @@ LogAccess::marshal_http_header_field_escapify(LogField::Container container, cha
   }
 
   if (header) {
-    MIMEField *fld = header->field_find(field, static_cast<int>(::strlen(field)));
+    MIMEField *fld = header->field_find(field, (int)::strlen(field));
     if (fld) {
       valid_field = true;
 
@@ -2688,7 +2686,7 @@ LogAccess::marshal_http_header_field_escapify(LogField::Container container, cha
       //
       int running_len = 0;
       while (fld) {
-        str     = const_cast<char *>(fld->value_get(&actual_len));
+        str     = (char *)fld->value_get(&actual_len);
         new_str = LogUtils::escapify_url(&m_arena, str, actual_len, &new_len);
         if (buf) {
           memcpy(buf, new_str, new_len);

--- a/proxy/logging/LogBuffer.cc
+++ b/proxy/logging/LogBuffer.cc
@@ -67,7 +67,7 @@ LogBufferHeader::fmt_fieldlist()
 {
   char *addr = nullptr;
   if (fmt_fieldlist_offset) {
-    addr = reinterpret_cast<char *>(this) + fmt_fieldlist_offset;
+    addr = (char *)this + fmt_fieldlist_offset;
   }
   return addr;
 }
@@ -77,7 +77,7 @@ LogBufferHeader::fmt_printf()
 {
   char *addr = nullptr;
   if (fmt_printf_offset) {
-    addr = reinterpret_cast<char *>(this) + fmt_printf_offset;
+    addr = (char *)this + fmt_printf_offset;
   }
   return addr;
 }
@@ -87,7 +87,7 @@ LogBufferHeader::src_hostname()
 {
   char *addr = nullptr;
   if (src_hostname_offset) {
-    addr = reinterpret_cast<char *>(this) + src_hostname_offset;
+    addr = (char *)this + src_hostname_offset;
   }
   return addr;
 }
@@ -97,7 +97,7 @@ LogBufferHeader::log_filename()
 {
   char *addr = nullptr;
   if (log_filename_offset) {
-    addr = reinterpret_cast<char *>(this) + log_filename_offset;
+    addr = (char *)this + log_filename_offset;
   }
   return addr;
 }
@@ -113,12 +113,12 @@ LogBuffer::LogBuffer(LogObject *owner, size_t size, size_t buf_align, size_t wri
 
   if (alloc_size <= max_iobuffer_size) {
     m_buffer_fast_allocator_size = buffer_size_to_index(alloc_size);
-    m_unaligned_buffer           = static_cast<char *>(ioBufAllocator[m_buffer_fast_allocator_size].alloc_void());
+    m_unaligned_buffer           = (char *)ioBufAllocator[m_buffer_fast_allocator_size].alloc_void();
   } else {
     m_buffer_fast_allocator_size = -1;
-    m_unaligned_buffer           = static_cast<char *>(ats_malloc(alloc_size));
+    m_unaligned_buffer           = (char *)ats_malloc(alloc_size);
   }
-  m_buffer = static_cast<char *>(align_pointer_forward(m_unaligned_buffer, buf_align));
+  m_buffer = (char *)align_pointer_forward(m_unaligned_buffer, buf_align);
 
   // add the header
   hdr_size = _add_buffer_header();
@@ -127,7 +127,7 @@ LogBuffer::LogBuffer(LogObject *owner, size_t size, size_t buf_align, size_t wri
   m_state.s.offset = hdr_size;
 
   // update the buffer id (m_id gets the old value)
-  m_id = static_cast<uint32_t>(ink_atomic_increment(&M_ID, 1));
+  m_id = (uint32_t)ink_atomic_increment((int32_t *)&M_ID, 1);
 
   m_expiration_time = LogUtils::timestamp() + Log::config->max_secs_per_buffer;
 
@@ -137,7 +137,7 @@ LogBuffer::LogBuffer(LogObject *owner, size_t size, size_t buf_align, size_t wri
 
 LogBuffer::LogBuffer(LogObject *owner, LogBufferHeader *header)
   : m_unaligned_buffer(nullptr),
-    m_buffer(reinterpret_cast<char *>(header)),
+    m_buffer((char *)header),
     m_size(0),
     m_buf_align(LB_DEFAULT_ALIGN),
     m_write_align(INK_MIN_ALIGN),
@@ -154,7 +154,7 @@ LogBuffer::LogBuffer(LogObject *owner, LogBufferHeader *header)
 
   // update the buffer id (m_id gets the old value)
   //
-  m_id = static_cast<uint32_t>(ink_atomic_increment(&M_ID, 1));
+  m_id = (uint32_t)ink_atomic_increment((int32_t *)&M_ID, 1);
 
   Debug("log-logbuffer", "[%p] Created repurposed buffer %u for %s at address %p", this_ethread(), m_id,
         m_owner->get_base_filename(), m_buffer);
@@ -207,7 +207,7 @@ LogBuffer::checkout_write(size_t *write_offset, size_t write_size)
   size_t offset            = 0;
   size_t actual_write_size = INK_ALIGN(write_size + sizeof(LogEntryHeader), m_write_align);
 
-  uint64_t retries = static_cast<uint64_t>(-1);
+  uint64_t retries = (uint64_t)-1;
   do {
     // we want sequence points between these two statements
     old_s = m_state;
@@ -276,7 +276,7 @@ LogBuffer::checkout_write(size_t *write_offset, size_t write_size)
     // ink_release_assert(mutex->thread_holding == this_ethread());
     // SUM_DYN_STAT(log_stat_bytes_buffered_stat, actual_write_size);
 
-    LogEntryHeader *entry_header = reinterpret_cast<LogEntryHeader *>(&m_buffer[offset]);
+    LogEntryHeader *entry_header = (LogEntryHeader *)&m_buffer[offset];
     // entry_header->timestamp = LogUtils::timestamp();
     struct timeval tp = ink_gettimeofday();
 
@@ -353,7 +353,7 @@ LogBuffer::_add_buffer_header()
   // initialize the header
   //
   LogFormat *fmt                 = m_owner->m_format;
-  m_header                       = reinterpret_cast<LogBufferHeader *>(m_buffer);
+  m_header                       = (LogBufferHeader *)m_buffer;
   m_header->cookie               = LOG_SEGMENT_COOKIE;
   m_header->version              = LOG_SEGMENT_VERSION;
   m_header->format_type          = fmt->type();
@@ -458,7 +458,7 @@ LogBuffer::resolve_custom_entry(LogFieldList *fieldlist, char *printf_str, char 
     int n_alt_fields = alt_fieldlist->count();
     int i            = 0;
 
-    readfrom_map = static_cast<int *>(ats_malloc(n_alt_fields * sizeof(int)));
+    readfrom_map = (int *)ats_malloc(n_alt_fields * sizeof(int));
     for (f = alt_fieldlist->first(); f; f = alt_fieldlist->next(f)) {
       int readfrom_pos = 0;
       bool found_match = false;
@@ -558,7 +558,7 @@ LogBuffer::to_ascii(LogEntryHeader *entry, LogFormatType type, char *buf, int bu
   char *read_from; // keeps track of where we're reading from entry
   char *write_to;  // keeps track of where we're writing into buf
 
-  read_from = reinterpret_cast<char *>(entry) + sizeof(LogEntryHeader);
+  read_from = (char *)entry + sizeof(LogEntryHeader);
   write_to  = buf;
 
   if (type == LOG_FORMAT_TEXT) {
@@ -732,7 +732,7 @@ LogEntryHeader *
 LogBufferIterator::next()
 {
   LogEntryHeader *ret_val = nullptr;
-  LogEntryHeader *entry   = reinterpret_cast<LogEntryHeader *>(m_next);
+  LogEntryHeader *entry   = (LogEntryHeader *)m_next;
 
   if (entry) {
     if (m_iter_entry_count < m_buffer_entry_count) {

--- a/proxy/logging/LogConfig.cc
+++ b/proxy/logging/LogConfig.cc
@@ -72,7 +72,7 @@ LogConfig::setup_default_values()
   }
   hostname = ats_strdup(name);
 
-  log_buffer_size       = static_cast<int>(10 * LOG_KILOBYTE);
+  log_buffer_size       = (int)(10 * LOG_KILOBYTE);
   max_secs_per_buffer   = 5;
   max_space_mb_for_logs = 100;
   max_space_mb_headroom = 10;
@@ -109,22 +109,22 @@ LogConfig::read_configuration_variables()
   int val;
   char *ptr;
 
-  val = static_cast<int>(REC_ConfigReadInteger("proxy.config.log.log_buffer_size"));
+  val = (int)REC_ConfigReadInteger("proxy.config.log.log_buffer_size");
   if (val > 0) {
     log_buffer_size = val;
   }
 
-  val = static_cast<int>(REC_ConfigReadInteger("proxy.config.log.max_secs_per_buffer"));
+  val = (int)REC_ConfigReadInteger("proxy.config.log.max_secs_per_buffer");
   if (val > 0) {
     max_secs_per_buffer = val;
   }
 
-  val = static_cast<int>(REC_ConfigReadInteger("proxy.config.log.max_space_mb_for_logs"));
+  val = (int)REC_ConfigReadInteger("proxy.config.log.max_space_mb_for_logs");
   if (val > 0) {
     max_space_mb_for_logs = val;
   }
 
-  val = static_cast<int>(REC_ConfigReadInteger("proxy.config.log.max_space_mb_headroom"));
+  val = (int)REC_ConfigReadInteger("proxy.config.log.max_space_mb_headroom");
   if (val > 0) {
     max_space_mb_headroom = val;
   }
@@ -152,7 +152,7 @@ LogConfig::read_configuration_variables()
     ::exit(1);
   }
 
-  val = static_cast<int>(REC_ConfigReadInteger("proxy.config.log.preproc_threads"));
+  val = (int)REC_ConfigReadInteger("proxy.config.log.preproc_threads");
   if (val > 0 && val <= 128) {
     preproc_threads = val;
   }
@@ -162,31 +162,31 @@ LogConfig::read_configuration_variables()
   // we don't check for valid values of rolling_enabled, rolling_interval_sec,
   // rolling_offset_hr, or rolling_size_mb because the LogObject takes care of this
   //
-  rolling_interval_sec = static_cast<int>(REC_ConfigReadInteger("proxy.config.log.rolling_interval_sec"));
-  rolling_offset_hr    = static_cast<int>(REC_ConfigReadInteger("proxy.config.log.rolling_offset_hr"));
-  rolling_size_mb      = static_cast<int>(REC_ConfigReadInteger("proxy.config.log.rolling_size_mb"));
-  rolling_min_count    = static_cast<int>(REC_ConfigReadInteger("proxy.config.log.rolling_min_count"));
-  val                  = static_cast<int>(REC_ConfigReadInteger("proxy.config.log.rolling_enabled"));
+  rolling_interval_sec = (int)REC_ConfigReadInteger("proxy.config.log.rolling_interval_sec");
+  rolling_offset_hr    = (int)REC_ConfigReadInteger("proxy.config.log.rolling_offset_hr");
+  rolling_size_mb      = (int)REC_ConfigReadInteger("proxy.config.log.rolling_size_mb");
+  rolling_min_count    = (int)REC_ConfigReadInteger("proxy.config.log.rolling_min_count");
+  val                  = (int)REC_ConfigReadInteger("proxy.config.log.rolling_enabled");
   if (LogRollingEnabledIsValid(val)) {
-    rolling_enabled = static_cast<Log::RollingEnabledValues>(val);
+    rolling_enabled = (Log::RollingEnabledValues)val;
   } else {
     Warning("invalid value '%d' for '%s', disabling log rolling", val, "proxy.config.log.rolling_enabled");
     rolling_enabled = Log::NO_ROLLING;
   }
 
-  val                      = static_cast<int>(REC_ConfigReadInteger("proxy.config.log.auto_delete_rolled_files"));
+  val                      = (int)REC_ConfigReadInteger("proxy.config.log.auto_delete_rolled_files");
   auto_delete_rolled_files = (val > 0);
 
   // Read in min_count control values for auto deletion
   if (auto_delete_rolled_files) {
     // For diagnostic logs
-    val = static_cast<int>(REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_min_count"));
+    val = (int)REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_min_count");
     val = ((val == 0) ? INT_MAX : val);
     deleting_info.insert(new LogDeletingInfo(DIAGS_LOG_FILENAME, val));
 
     // For traffic.out
     ats_scoped_str name(REC_ConfigReadString("proxy.config.output.logfile"));
-    val = static_cast<int>(REC_ConfigReadInteger("proxy.config.output.logfile.rolling_min_count"));
+    val = (int)REC_ConfigReadInteger("proxy.config.output.logfile.rolling_min_count");
     val = ((val == 0) ? INT_MAX : val);
     if (name) {
       deleting_info.insert(new LogDeletingInfo(name.get(), val));
@@ -195,28 +195,28 @@ LogConfig::read_configuration_variables()
     }
   }
   // PERFORMANCE
-  val = static_cast<int>(REC_ConfigReadInteger("proxy.config.log.sampling_frequency"));
+  val = (int)REC_ConfigReadInteger("proxy.config.log.sampling_frequency");
   if (val > 0) {
     sampling_frequency = val;
   }
 
-  val = static_cast<int>(REC_ConfigReadInteger("proxy.config.log.file_stat_frequency"));
+  val = (int)REC_ConfigReadInteger("proxy.config.log.file_stat_frequency");
   if (val > 0) {
     file_stat_frequency = val;
   }
 
-  val = static_cast<int>(REC_ConfigReadInteger("proxy.config.log.space_used_frequency"));
+  val = (int)REC_ConfigReadInteger("proxy.config.log.space_used_frequency");
   if (val > 0) {
     space_used_frequency = val;
   }
 
   // ASCII BUFFER
-  val = static_cast<int>(REC_ConfigReadInteger("proxy.config.log.ascii_buffer_size"));
+  val = (int)REC_ConfigReadInteger("proxy.config.log.ascii_buffer_size");
   if (val > 0) {
     ascii_buffer_size = val;
   }
 
-  val = static_cast<int>(REC_ConfigReadInteger("proxy.config.log.max_line_size"));
+  val = (int)REC_ConfigReadInteger("proxy.config.log.max_line_size");
   if (val > 0) {
     max_line_size = val;
   }
@@ -231,7 +231,7 @@ LogConfig::read_configuration_variables()
   -------------------------------------------------------------------------*/
 
 // TODO: Is UINT_MAX here really correct?
-LogConfig::LogConfig() : m_partition_space_left(static_cast<int64_t>(UINT_MAX))
+LogConfig::LogConfig() : m_partition_space_left((int64_t)UINT_MAX)
 
 {
   // Setup the default values for all LogConfig public variables so that
@@ -278,8 +278,8 @@ LogConfig::init(LogConfig *prev_config)
 
     Debug("log", "creating predefined error log object");
 
-    errlog = new LogObject(fmt.get(), logfile_dir, "error.log", LOG_FILE_ASCII, nullptr, rolling_enabled, preproc_threads,
-                           rolling_interval_sec, rolling_offset_hr, rolling_size_mb);
+    errlog = new LogObject(fmt.get(), logfile_dir, "error.log", LOG_FILE_ASCII, nullptr, (Log::RollingEnabledValues)rolling_enabled,
+                           preproc_threads, rolling_interval_sec, rolling_offset_hr, rolling_size_mb);
 
     log_object_manager.manage_object(errlog);
     errlog->set_fmt_timestamps();
@@ -335,7 +335,7 @@ LogConfig::display(FILE *fd)
   fprintf(fd, "   space_used_frequency = %d\n", space_used_frequency);
 
   fprintf(fd, "\n");
-  fprintf(fd, "************ Log Objects (%u objects) ************\n", log_object_manager.get_num_objects());
+  fprintf(fd, "************ Log Objects (%u objects) ************\n", (unsigned int)log_object_manager.get_num_objects());
   log_object_manager.display(fd);
 
   fprintf(fd, "************ Filter List (%u filters) ************\n", filter_list.count());
@@ -513,11 +513,11 @@ LogConfig::space_to_write(int64_t bytes_to_write) const
   int64_t logical_space_used, physical_space_left;
   bool space;
 
-  config_space       = static_cast<int64_t>(get_max_space_mb()) * LOG_MEGABYTE;
-  partition_headroom = static_cast<int64_t>(PARTITION_HEADROOM_MB) * LOG_MEGABYTE;
+  config_space       = (int64_t)get_max_space_mb() * LOG_MEGABYTE;
+  partition_headroom = (int64_t)PARTITION_HEADROOM_MB * LOG_MEGABYTE;
 
   logical_space_used  = m_space_used + bytes_to_write;
-  physical_space_left = m_partition_space_left - bytes_to_write;
+  physical_space_left = m_partition_space_left - (int64_t)bytes_to_write;
 
   space = ((logical_space_used < config_space) && (physical_space_left > partition_headroom));
 
@@ -601,7 +601,7 @@ LogConfig::update_space_used()
 
     sret = ::stat(path, &sbuf);
     if (sret != -1 && S_ISREG(sbuf.st_mode)) {
-      total_space_used += static_cast<int64_t>(sbuf.st_size);
+      total_space_used += (int64_t)sbuf.st_size;
 
       if (auto_delete_rolled_files && LogFile::rolled_logfile(entry->d_name)) {
         //
@@ -617,7 +617,7 @@ LogConfig::update_space_used()
         }
 
         auto &candidates = iter->candidates;
-        candidates.push_back(LogDeleteCandidate(path, static_cast<int64_t>(sbuf.st_size), sbuf.st_mtime));
+        candidates.push_back(LogDeleteCandidate(path, (int64_t)sbuf.st_size, sbuf.st_mtime));
         candidate_count++;
       }
     }
@@ -633,7 +633,7 @@ LogConfig::update_space_used()
   struct statvfs fs;
 
   if (::statvfs(logfile_dir, &fs) >= 0) {
-    partition_space_left = static_cast<int64_t>(fs.f_bavail) * static_cast<int64_t>(fs.f_bsize);
+    partition_space_left = (int64_t)fs.f_bavail * (int64_t)fs.f_bsize;
   }
 
   //
@@ -658,8 +658,8 @@ LogConfig::update_space_used()
   // selected).
   //
 
-  int64_t max_space = static_cast<int64_t>(get_max_space_mb()) * LOG_MEGABYTE;
-  int64_t headroom  = static_cast<int64_t>(max_space_mb_headroom) * LOG_MEGABYTE;
+  int64_t max_space = (int64_t)get_max_space_mb() * LOG_MEGABYTE;
+  int64_t headroom  = (int64_t)max_space_mb_headroom * LOG_MEGABYTE;
 
   if (candidate_count > 0 && !space_to_write(headroom)) {
     Debug("logspace", "headroom reached, trying to clear space ...");

--- a/proxy/logging/LogField.cc
+++ b/proxy/logging/LogField.cc
@@ -347,7 +347,7 @@ LogField::LogField(const char *field, Container container, SetFunc _setfunc)
   case ESSH:
   case ECSSH:
   case SCFG:
-    m_unmarshal_func = reinterpret_cast<UnmarshalFunc>(&(LogAccess::unmarshal_str));
+    m_unmarshal_func = (UnmarshalFunc) & (LogAccess::unmarshal_str);
     break;
 
   case ICFG:
@@ -568,9 +568,9 @@ unsigned
 LogField::unmarshal(char **buf, char *dest, int len)
 {
   if (!m_alias_map) {
-    if (m_unmarshal_func == reinterpret_cast<UnmarshalFunc>(LogAccess::unmarshal_str) ||
-        m_unmarshal_func == reinterpret_cast<UnmarshalFunc>(LogAccess::unmarshal_http_text)) {
-      UnmarshalFuncWithSlice func = reinterpret_cast<UnmarshalFuncWithSlice>(m_unmarshal_func);
+    if (m_unmarshal_func == (UnmarshalFunc)LogAccess::unmarshal_str ||
+        m_unmarshal_func == (UnmarshalFunc)LogAccess::unmarshal_http_text) {
+      UnmarshalFuncWithSlice func = (UnmarshalFuncWithSlice)m_unmarshal_func;
       return (*func)(buf, dest, len, &m_slice);
     }
     return (*m_unmarshal_func)(buf, dest, len);
@@ -658,7 +658,7 @@ LogField::valid_container_name(char *name)
 {
   for (unsigned i = 1; i < countof(container_names); i++) {
     if (strcmp(name, container_names[i]) == 0) {
-      return static_cast<LogField::Container>(i);
+      return (LogField::Container)i;
     }
   }
 
@@ -670,7 +670,7 @@ LogField::valid_aggregate_name(char *name)
 {
   for (unsigned i = 1; i < countof(aggregate_names); i++) {
     if (strcmp(name, aggregate_names[i]) == 0) {
-      return static_cast<LogField::Aggregate>(i);
+      return (LogField::Aggregate)i;
     }
   }
 

--- a/proxy/logging/LogFile.cc
+++ b/proxy/logging/LogFile.cc
@@ -372,7 +372,7 @@ LogFile::write_ascii_logbuffer(LogBufferHeader *buffer_header, int fd, const cha
 
   switch (buffer_header->version) {
   case LOG_SEGMENT_VERSION:
-    format_type = static_cast<LogFormatType>(buffer_header->format_type);
+    format_type = (LogFormatType)buffer_header->format_type;
 
     fieldlist_str = buffer_header->fmt_fieldlist();
     printf_str    = buffer_header->fmt_printf();
@@ -439,7 +439,7 @@ LogFile::write_ascii_logbuffer3(LogBufferHeader *buffer_header, const char *alt_
 
   switch (buffer_header->version) {
   case LOG_SEGMENT_VERSION:
-    format_type   = static_cast<LogFormatType>(buffer_header->format_type);
+    format_type   = (LogFormatType)buffer_header->format_type;
     fieldlist_str = buffer_header->fmt_fieldlist();
     printf_str    = buffer_header->fmt_printf();
     break;
@@ -456,9 +456,9 @@ LogFile::write_ascii_logbuffer3(LogBufferHeader *buffer_header, const char *alt_
     fmt_buf_bytes   = 0;
 
     if (m_file_format == LOG_FILE_PIPE) {
-      ascii_buffer = static_cast<char *>(ats_malloc(m_max_line_size));
+      ascii_buffer = (char *)ats_malloc(m_max_line_size);
     } else {
-      ascii_buffer = static_cast<char *>(ats_malloc(m_ascii_buffer_size));
+      ascii_buffer = (char *)ats_malloc(m_ascii_buffer_size);
     }
 
     // fill the buffer with as many records as possible
@@ -549,7 +549,7 @@ LogFile::writeln(char *data, int len, int fd, const char *path)
 #else
     wvec[0].iov_base = (void *)data;
 #endif
-    wvec[0].iov_len = static_cast<size_t>(len);
+    wvec[0].iov_len = (size_t)len;
 
     if (data[len - 1] != '\n') {
 #if defined(solaris)
@@ -557,11 +557,11 @@ LogFile::writeln(char *data, int len, int fd, const char *path)
 #else
       wvec[1].iov_base = (void *)"\n";
 #endif
-      wvec[1].iov_len = static_cast<size_t>(1);
+      wvec[1].iov_len = (size_t)1;
       vcnt++;
     }
 
-    if ((bytes_this_write = static_cast<int>(::writev(fd, (const struct iovec *)wvec, vcnt))) < 0) {
+    if ((bytes_this_write = (int)::writev(fd, (const struct iovec *)wvec, vcnt)) < 0) {
       Warning("An error was encountered in writing to %s: %s.", ((path) ? path : "logfile"), strerror(errno));
     } else {
       total_bytes = bytes_this_write;

--- a/proxy/logging/LogFilter.cc
+++ b/proxy/logging/LogFilter.cc
@@ -141,7 +141,7 @@ LogFilter::parse(const char *name, Action action, const char *condition)
   LogFilter::Operator oper = LogFilter::N_OPERATORS;
   for (unsigned i = 0; i < LogFilter::N_OPERATORS; ++i) {
     if (strcasecmp(oper_str, LogFilter::OPERATOR_NAME[i]) == 0) {
-      oper = static_cast<LogFilter::Operator>(i);
+      oper = (LogFilter::Operator)i;
       break;
     }
   }
@@ -202,7 +202,7 @@ LogFilterString::_setValues(size_t n, char **value)
     for (size_t i = 0; i < n; ++i) {
       m_value[i]           = ats_strdup(value[i]);
       m_length[i]          = strlen(value[i]);
-      m_value_uppercase[i] = static_cast<char *>(ats_malloc(static_cast<unsigned int>(m_length[i]) + 1));
+      m_value_uppercase[i] = (char *)ats_malloc((unsigned int)m_length[i] + 1);
       size_t j;
       for (j = 0; j < m_length[i]; ++j) {
         m_value_uppercase[i][j] = ParseRules::ink_toupper(m_value[i][j]);
@@ -318,7 +318,7 @@ LogFilterString::wipe_this_entry(LogAccess *lad)
   size_t marsh_len = m_field->marshal_len(lad); // includes null termination
 
   if (marsh_len > BUFSIZE) {
-    big_buf = static_cast<char *>(ats_malloc(marsh_len));
+    big_buf = (char *)ats_malloc(marsh_len);
     ink_assert(big_buf != nullptr);
     buf = big_buf;
   }
@@ -392,7 +392,7 @@ LogFilterString::toss_this_entry(LogAccess *lad)
   size_t marsh_len    = m_field->marshal_len(lad); // includes null termination
 
   if (marsh_len > BUFSIZE) {
-    big_buf = static_cast<char *>(ats_malloc(static_cast<unsigned int>(marsh_len)));
+    big_buf = (char *)ats_malloc((unsigned int)marsh_len);
     ink_assert(big_buf != nullptr);
     buf = big_buf;
   }
@@ -420,7 +420,7 @@ LogFilterString::toss_this_entry(LogAccess *lad)
     break;
   case CASE_INSENSITIVE_CONTAIN: {
     if (big_buf) {
-      big_buf_upper = static_cast<char *>(ats_malloc(static_cast<unsigned int>(marsh_len)));
+      big_buf_upper = (char *)ats_malloc((unsigned int)marsh_len);
       buf_upper     = big_buf_upper;
     } else {
       buf = small_buf; // make clang happy
@@ -612,7 +612,7 @@ LogFilterInt::wipe_this_entry(LogAccess *lad)
   bool cond_satisfied = false;
   int64_t value;
 
-  m_field->marshal(lad, reinterpret_cast<char *>(&value));
+  m_field->marshal(lad, (char *)&value);
   // This used to do an ntohl() on value, but that breaks various filters.
   // Long term we should move IPs to their own log type.
 
@@ -650,7 +650,7 @@ LogFilterInt::toss_this_entry(LogAccess *lad)
   bool cond_satisfied = false;
   int64_t value;
 
-  m_field->marshal(lad, reinterpret_cast<char *>(&value));
+  m_field->marshal(lad, (char *)&value);
   // This used to do an ntohl() on value, but that breaks various filters.
   // Long term we should move IPs to their own log type.
 

--- a/proxy/logging/LogFormat.cc
+++ b/proxy/logging/LogFormat.cc
@@ -64,7 +64,7 @@ LogFormat::setup(const char *name, const char *format_str, unsigned interval_sec
   if (format_str) {
     const char *tag                = " %<phn>";
     const size_t m_format_str_size = strlen(format_str) + (m_tagging_on ? strlen(tag) : 0) + 1;
-    m_format_str                   = static_cast<char *>(ats_malloc(m_format_str_size));
+    m_format_str                   = (char *)ats_malloc(m_format_str_size);
     ink_strlcpy(m_format_str, format_str, m_format_str_size);
     if (m_tagging_on) {
       Note("Log tagging enabled, adding %%<phn> field at the end of "
@@ -114,7 +114,7 @@ LogFormat::id_from_name(const char *name)
      * This problem is only known to occur on Linux which
      * is a 32-bit OS.
      */
-    id = static_cast<int32_t>(hash.fold()) & 0x7fffffff;
+    id = (int32_t)hash.fold() & 0x7fffffff;
 #else
     id = (int32_t)hash.fold();
 #endif
@@ -139,7 +139,7 @@ LogFormat::init_variables(const char *name, const char *fieldlist_str, const cha
     m_valid = false;
   } else {
     if (m_aggregate) {
-      m_agg_marshal_space = static_cast<char *>(ats_malloc(m_field_count * INK_MIN_ALIGN));
+      m_agg_marshal_space = (char *)ats_malloc(m_field_count * INK_MIN_ALIGN);
     }
 
     if (m_name_str) {
@@ -572,9 +572,9 @@ LogFormat::parse_escape_string(const char *str, int len)
     return -1;
   }
 
-  a = static_cast<unsigned char>(str[start + 1]);
-  b = static_cast<unsigned char>(str[start + 2]);
-  c = static_cast<unsigned char>(str[start + 3]);
+  a = (unsigned char)str[start + 1];
+  b = (unsigned char)str[start + 2];
+  c = (unsigned char)str[start + 3];
 
   if (isdigit(a) && isdigit(b)) {
     sum = (a - '0') * 64 + (b - '0') * 8 + (c - '0');
@@ -643,9 +643,9 @@ LogFormat::parse_format_string(const char *format_str, char **printf_str, char *
   // each is guaranteed to be smaller (or the same size) as the format
   // string.
   //
-  unsigned len = static_cast<unsigned>(::strlen(format_str));
-  *printf_str  = static_cast<char *>(ats_malloc(len + 1));
-  *fields_str  = static_cast<char *>(ats_malloc(len + 1));
+  unsigned len = (unsigned)::strlen(format_str);
+  *printf_str  = (char *)ats_malloc(len + 1);
+  *fields_str  = (char *)ats_malloc(len + 1);
 
   unsigned printf_pos  = 0;
   unsigned fields_pos  = 0;
@@ -692,10 +692,10 @@ LogFormat::parse_format_string(const char *format_str, char **printf_str, char *
 
         if (escape_char == '\\') {
           start += 1;
-          (*printf_str)[printf_pos++] = static_cast<char>(escape_char);
+          (*printf_str)[printf_pos++] = (char)escape_char;
         } else if (escape_char >= 0) {
           start += 3;
-          (*printf_str)[printf_pos++] = static_cast<char>(escape_char);
+          (*printf_str)[printf_pos++] = (char)escape_char;
         } else {
           memcpy(&(*printf_str)[printf_pos], &format_str[start], stop - start + 1);
           printf_pos += stop - start + 1;
@@ -710,10 +710,10 @@ LogFormat::parse_format_string(const char *format_str, char **printf_str, char *
 
       if (escape_char == '\\') {
         start += 1;
-        (*printf_str)[printf_pos++] = static_cast<char>(escape_char);
+        (*printf_str)[printf_pos++] = (char)escape_char;
       } else if (escape_char >= 0) {
         start += 3;
-        (*printf_str)[printf_pos++] = static_cast<char>(escape_char);
+        (*printf_str)[printf_pos++] = (char)escape_char;
       } else {
         (*printf_str)[printf_pos++] = format_str[start];
       }

--- a/proxy/logging/LogObject.cc
+++ b/proxy/logging/LogObject.cc
@@ -179,7 +179,7 @@ LogObject::~LogObject()
   ats_free(m_alt_filename);
   delete m_format;
   delete[] m_buffer_manager;
-  delete static_cast<LogBuffer *>(FREELIST_POINTER(m_log_buffer));
+  delete (LogBuffer *)FREELIST_POINTER(m_log_buffer);
 }
 
 //-----------------------------------------------------------------------------
@@ -232,12 +232,12 @@ LogObject::generate_filenames(const char *log_dir, const char *basename, LogFile
     }
   }
 
-  int dir_len      = static_cast<int>(strlen(log_dir));
+  int dir_len      = (int)strlen(log_dir);
   int basename_len = len + ext_len + 1;          // include null terminator
   int total_len    = dir_len + 1 + basename_len; // include '/'
 
-  m_filename = static_cast<char *>(ats_malloc(total_len));
-  m_basename = static_cast<char *>(ats_malloc(basename_len));
+  m_filename = (char *)ats_malloc(total_len);
+  m_basename = (char *)ats_malloc(basename_len);
 
   memcpy(m_filename, log_dir, dir_len);
   m_filename[dir_len++] = '/';
@@ -298,7 +298,7 @@ LogObject::compute_signature(LogFormat *format, char *filename, unsigned int fla
 
   if (fl && ps && filename) {
     int buf_size = strlen(fl) + strlen(ps) + strlen(filename) + 2;
-    char *buffer = static_cast<char *>(ats_malloc(buf_size));
+    char *buffer = (char *)ats_malloc(buf_size);
 
     ink_string_concatenate_strings(buffer, fl, ps, filename,
                                    flags & LogObject::BINARY ? "B" : (flags & LogObject::WRITES_TO_PIPE ? "P" : "A"), NULL);
@@ -366,7 +366,7 @@ LogObject::_checkout_write(size_t *write_offset, size_t bytes_needed)
     // Increment the version of m_log_buffer, returning the previous version.
     head_p h = increment_pointer_version(&m_log_buffer);
 
-    buffer           = static_cast<LogBuffer *>(FREELIST_POINTER(h));
+    buffer           = (LogBuffer *)FREELIST_POINTER(h);
     result_code      = buffer->checkout_write(write_offset, bytes_needed);
     bool decremented = false;
 
@@ -549,7 +549,7 @@ LogObject::log(LogAccess *lad, std::string_view text_entry)
     int64_t val;
     for (f = fl->first(); f; f = fl->next(f)) {
       // convert to host order to do computations
-      val = (f->is_time_field()) ? time_now : *(reinterpret_cast<int64_t *>(data_ptr));
+      val = (f->is_time_field()) ? time_now : *((int64_t *)data_ptr);
       f->update_aggregate(val);
       data_ptr += INK_MIN_ALIGN;
     }
@@ -615,7 +615,7 @@ void
 LogObject::_setup_rolling(Log::RollingEnabledValues rolling_enabled, int rolling_interval_sec, int rolling_offset_hr,
                           int rolling_size_mb)
 {
-  if (!LogRollingEnabledIsValid(static_cast<int>(rolling_enabled))) {
+  if (!LogRollingEnabledIsValid((int)rolling_enabled)) {
     m_rolling_enabled      = Log::NO_ROLLING;
     m_rolling_interval_sec = 0;
     m_rolling_offset_hr    = 0;
@@ -757,7 +757,7 @@ LogObject::_roll_files(long last_roll_time, long time_now)
 void
 LogObject::check_buffer_expiration(long time_now)
 {
-  LogBuffer *b = static_cast<LogBuffer *>(FREELIST_POINTER(m_log_buffer));
+  LogBuffer *b = (LogBuffer *)FREELIST_POINTER(m_log_buffer);
   if (b && time_now > b->expiration_time()) {
     force_new_buffer();
   }
@@ -1330,8 +1330,7 @@ REGRESSION_TEST(LogObjectManager_Transfer)(RegressionTest *t, int /* atype ATS_U
 
     mgr2.transfer_objects(mgr1);
 
-    rprintf(t, "mgr1 has %d objects, mgr2 has %d objects\n", static_cast<int>(mgr1.get_num_objects()),
-            static_cast<int>(mgr2.get_num_objects()));
+    rprintf(t, "mgr1 has %d objects, mgr2 has %d objects\n", (int)mgr1.get_num_objects(), (int)mgr2.get_num_objects());
     box.check(mgr1.get_num_objects() == 0, "Testing that manager 1 has 0 objects");
     box.check(mgr2.get_num_objects() == 4, "Testing that manager 2 has 4 objects");
 

--- a/proxy/logging/LogUtils.cc
+++ b/proxy/logging/LogUtils.cc
@@ -374,7 +374,7 @@ escapify_url_common(Arena *arena, char *url, size_t len_in, int *len_out, char *
   if (dst) {
     new_url = dst;
   } else {
-    new_url = arena->str_alloc(out_len + 1);
+    new_url = (char *)arena->str_alloc(out_len + 1);
   }
 
   char *from = url;
@@ -445,7 +445,7 @@ LogUtils::remove_content_type_attributes(char *type_str, int *type_len)
   }
   // Look for a semicolon and cut out everything after that
   //
-  char *p = static_cast<char *>(memchr(type_str, ';', *type_len));
+  char *p = (char *)memchr(type_str, ';', *type_len);
   if (p) {
     *type_len = p - type_str;
   }
@@ -571,7 +571,7 @@ LogUtils::file_is_writeable(const char *full_filename, off_t *size_bytes, bool *
     if (e < 0) {
       ret_val = -1;
     } else {
-      if (limit_data.rlim_cur != static_cast<rlim_t> RLIM_INFINITY) {
+      if (limit_data.rlim_cur != (rlim_t)RLIM_INFINITY) {
         if (has_size_limit) {
           *has_size_limit = true;
         }

--- a/proxy/logging/YamlLogConfig.cc
+++ b/proxy/logging/YamlLogConfig.cc
@@ -182,7 +182,7 @@ YamlLogConfig::decodeLogObject(const YAML::Node &node)
   }
 
   auto logObject = new LogObject(fmt, Log::config->logfile_dir, filename.c_str(), file_type, header.c_str(),
-                                 static_cast<Log::RollingEnabledValues>(obj_rolling_enabled), Log::config->preproc_threads,
+                                 (Log::RollingEnabledValues)obj_rolling_enabled, Log::config->preproc_threads,
                                  obj_rolling_interval_sec, obj_rolling_offset_hr, obj_rolling_size_mb);
 
   // Generate LogDeletingInfo entry for later use

--- a/proxy/logging/YamlLogConfigDecoders.cc
+++ b/proxy/logging/YamlLogConfigDecoders.cc
@@ -100,7 +100,7 @@ convert<std::unique_ptr<LogFilter>>::decode(const Node &node, std::unique_ptr<Lo
   int i;
   for (i = 0; i < LogFilter::N_ACTIONS; i++) {
     if (strcasecmp(action_str, LogFilter::ACTION_NAME[i]) == 0) {
-      act = static_cast<LogFilter::Action>(i);
+      act = (LogFilter::Action)i;
       break;
     }
   }

--- a/proxy/shared/DiagsConfig.cc
+++ b/proxy/shared/DiagsConfig.cc
@@ -71,19 +71,19 @@ DiagsConfig::reconfigure_diags()
 
   // enabled if records.config set
 
-  e = static_cast<int>(REC_readInteger("proxy.config.diags.debug.enabled", &found));
+  e = (int)REC_readInteger("proxy.config.diags.debug.enabled", &found);
   if (e && found) {
     c.enabled[DiagsTagType_Debug] = e; // implement OR logic
   }
   all_found = all_found && found;
 
-  e = static_cast<int>(REC_readInteger("proxy.config.diags.action.enabled", &found));
+  e = (int)REC_readInteger("proxy.config.diags.action.enabled", &found);
   if (e && found) {
     c.enabled[DiagsTagType_Action] = true; // implement OR logic
   }
   all_found = all_found && found;
 
-  e                    = static_cast<int>(REC_readInteger("proxy.config.diags.show_location", &found));
+  e                    = (int)REC_readInteger("proxy.config.diags.show_location", &found);
   diags->show_location = ((e == 1 && found) ? SHOW_LOCATION_DEBUG : ((e == 2 && found) ? SHOW_LOCATION_ALL : SHOW_LOCATION_NONE));
   all_found            = all_found && found;
 
@@ -170,7 +170,7 @@ diags_config_callback(const char * /* name ATS_UNUSED */, RecDataT /* data_type 
 {
   DiagsConfig *diagsConfig;
 
-  diagsConfig = static_cast<DiagsConfig *>(opaque_token);
+  diagsConfig = (DiagsConfig *)opaque_token;
   ink_assert(diags->magic == DIAGS_MAGIC);
   diagsConfig->reconfigure_diags();
   return (0);
@@ -296,12 +296,12 @@ DiagsConfig::DiagsConfig(const char *prefix_string, const char *filename, const 
 
   // Grab rolling intervals from configuration
   // TODO error check these values
-  int output_log_roll_int    = static_cast<int>(REC_ConfigReadInteger("proxy.config.output.logfile.rolling_interval_sec"));
-  int output_log_roll_size   = static_cast<int>(REC_ConfigReadInteger("proxy.config.output.logfile.rolling_size_mb"));
-  int output_log_roll_enable = static_cast<int>(REC_ConfigReadInteger("proxy.config.output.logfile.rolling_enabled"));
-  int diags_log_roll_int     = static_cast<int>(REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_interval_sec"));
-  int diags_log_roll_size    = static_cast<int>(REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_size_mb"));
-  int diags_log_roll_enable  = static_cast<int>(REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_enabled"));
+  int output_log_roll_int    = (int)REC_ConfigReadInteger("proxy.config.output.logfile.rolling_interval_sec");
+  int output_log_roll_size   = (int)REC_ConfigReadInteger("proxy.config.output.logfile.rolling_size_mb");
+  int output_log_roll_enable = (int)REC_ConfigReadInteger("proxy.config.output.logfile.rolling_enabled");
+  int diags_log_roll_int     = (int)REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_interval_sec");
+  int diags_log_roll_size    = (int)REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_size_mb");
+  int diags_log_roll_enable  = (int)REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_enabled");
 
   // Grab some perms for the actual files on disk
   char *diags_perm       = REC_ConfigReadString("proxy.config.diags.logfile_perm");
@@ -315,9 +315,8 @@ DiagsConfig::DiagsConfig(const char *prefix_string, const char *filename, const 
   // Set up diags, FILE streams are opened in Diags constructor
   diags_log = new BaseLogFile(diags_logpath);
   diags     = new Diags(prefix_string, tags, actions, diags_log, diags_perm_parsed, output_perm_parsed);
-  diags->config_roll_diagslog(static_cast<RollingEnabledValues>(diags_log_roll_enable), diags_log_roll_int, diags_log_roll_size);
-  diags->config_roll_outputlog(static_cast<RollingEnabledValues>(output_log_roll_enable), output_log_roll_int,
-                               output_log_roll_size);
+  diags->config_roll_diagslog((RollingEnabledValues)diags_log_roll_enable, diags_log_roll_int, diags_log_roll_size);
+  diags->config_roll_outputlog((RollingEnabledValues)output_log_roll_enable, output_log_roll_int, output_log_roll_size);
 
   Status("opened %s", diags_logpath);
 

--- a/src/traffic_cache_tool/CacheDefs.cc
+++ b/src/traffic_cache_tool/CacheDefs.cc
@@ -106,7 +106,7 @@ URLparser::getPort(std::string &fullURL, int &port_ptr, int &port_len)
   }
   if (u_pos != -1) {
     fullURL.insert(u_pos, ":@");
-    TextView url(fullURL.data(), static_cast<int>(fullURL.size()));
+    TextView url(fullURL.data(), (int)fullURL.size());
 
     url += 9;
 
@@ -248,12 +248,12 @@ Stripe::InitializeMeta()
   }
   if (!freelist) // freelist is not allocated yet
   {
-    freelist = static_cast<uint16_t *>(malloc(_segments * sizeof(uint16_t))); // segments has already been calculated
+    freelist = (uint16_t *)malloc(_segments * sizeof(uint16_t)); // segments has already been calculated
   }
   if (!dir) // for new spans, this will likely be nullptr as we don't need to read the stripe meta from disk
   {
-    char *raw_dir = static_cast<char *>(ats_memalign(ats_pagesize(), this->vol_dirlen()));
-    dir           = reinterpret_cast<CacheDirEntry *>(raw_dir + this->vol_headerlen());
+    char *raw_dir = (char *)ats_memalign(ats_pagesize(), this->vol_dirlen());
+    dir           = (CacheDirEntry *)(raw_dir + this->vol_headerlen());
   }
   init_dir();
   return zret;
@@ -309,7 +309,7 @@ Stripe::updateHeaderFooter()
     return zret;
   }
 
-  char *meta_t = static_cast<char *>(ats_memalign(ats_pagesize(), dir_size));
+  char *meta_t = (char *)ats_memalign(ats_pagesize(), dir_size);
   // copy headers
   for (auto i : {A, B}) {
     // copy header
@@ -455,7 +455,7 @@ Stripe::dir_probe(CryptoHash *key, CacheDirEntry *result, CacheDirEntry **last_c
     do {
       if (dir_compare_tag(e, key)) {
         if (dir_valid(e)) {
-          stripe_buff2 = static_cast<char *>(ats_memalign(ats_pagesize(), dir_approx_size(e)));
+          stripe_buff2 = (char *)ats_memalign(ats_pagesize(), dir_approx_size(e));
           std::cout << "dir_probe hit: found seg: " << segment << " bucket: " << bucket << " offset: " << dir_offset(e)
                     << "size: " << dir_approx_size(e) << std::endl;
           break;
@@ -622,8 +622,8 @@ Stripe::loadDir()
 {
   Errata zret;
   int64_t dirlen = this->vol_dirlen();
-  char *raw_dir  = static_cast<char *>(ats_memalign(ats_pagesize(), dirlen));
-  dir            = reinterpret_cast<CacheDirEntry *>(raw_dir + this->vol_headerlen());
+  char *raw_dir  = (char *)ats_memalign(ats_pagesize(), dirlen);
+  dir            = (CacheDirEntry *)(raw_dir + this->vol_headerlen());
   // read directory
   ssize_t n = pread(this->_span->_fd, raw_dir, dirlen, this->_start);
   if (n < dirlen) {
@@ -990,7 +990,7 @@ Stripe::loadMeta()
   data.assign(stripe_buff2, n);
   meta = static_cast<StripeMeta *>(data.data());
   // copy freelist
-  freelist = static_cast<uint16_t *>(malloc(_segments * sizeof(uint16_t)));
+  freelist = (uint16_t *)malloc(_segments * sizeof(uint16_t));
   for (int i = 0; i < _segments; i++) {
     freelist[i] = meta->freelist[i];
   }

--- a/src/traffic_cache_tool/CacheScan.cc
+++ b/src/traffic_cache_tool/CacheScan.cc
@@ -39,7 +39,7 @@ CacheScan::Scan(bool search)
   int64_t guessed_size = 1048576; // 1M
   Errata zret;
   std::bitset<65536> dir_bitset;
-  char *stripe_buff2 = static_cast<char *>(ats_memalign(ats_pagesize(), guessed_size));
+  char *stripe_buff2 = (char *)ats_memalign(ats_pagesize(), guessed_size);
   for (int s = 0; s < this->stripe->_segments; s++) {
     dir_bitset.reset();
     for (int b = 0; b < this->stripe->_buckets; b++) {
@@ -54,7 +54,7 @@ CacheScan::Scan(bool search)
           int64_t size = dir_approx_size(e);
           if (size > guessed_size) {
             ats_free(stripe_buff2);
-            stripe_buff2 = static_cast<char *>(ats_memalign(ats_pagesize(), dir_approx_size(e)));
+            stripe_buff2 = (char *)ats_memalign(ats_pagesize(), dir_approx_size(e));
           }
           int fd         = this->stripe->_span->_fd;
           int64_t offset = this->stripe->stripe_offset(e);
@@ -182,8 +182,8 @@ CacheScan::unmarshal(HdrHeap *hh, int buf_length, int obj_type, HdrHeapObjImpl *
   ink_assert(hh->m_free_start == nullptr);
 
   // Convert Heap offsets to pointers
-  hh->m_data_start                 = (reinterpret_cast<char *>(hh)) + (intptr_t)hh->m_data_start;
-  hh->m_free_start                 = (reinterpret_cast<char *>(hh)) + hh->m_size;
+  hh->m_data_start                 = ((char *)hh) + (intptr_t)hh->m_data_start;
+  hh->m_free_start                 = ((char *)hh) + hh->m_size;
   hh->m_ronly_heap[0].m_heap_start = ((char *)hh) + (intptr_t)hh->m_ronly_heap[0].m_heap_start;
 
   // Crazy Invariant - If we are sitting in a ref counted block,
@@ -206,13 +206,13 @@ CacheScan::unmarshal(HdrHeap *hh, int buf_length, int obj_type, HdrHeapObjImpl *
   intptr_t offset = (intptr_t)hh;
 
   while (obj_data < hh->m_free_start) {
-    HdrHeapObjImpl *obj = reinterpret_cast<HdrHeapObjImpl *>(obj_data);
+    HdrHeapObjImpl *obj = (HdrHeapObjImpl *)obj_data;
     if (!obj_is_aligned(obj)) {
       std::cout << "Invalid alignment of object of type HdrHeapObjImpl" << std::endl;
       return zret;
     }
 
-    if (obj->m_type == static_cast<unsigned>(obj_type) && *found_obj == nullptr) {
+    if (obj->m_type == (unsigned)obj_type && *found_obj == nullptr) {
       *found_obj = obj;
     }
     // TODO : fix this switch
@@ -255,7 +255,7 @@ Errata
 CacheScan::unmarshal(char *buf, int len, RefCountObj *block_ref)
 {
   Errata zret;
-  HTTPCacheAlt *alt = reinterpret_cast<HTTPCacheAlt *>(buf);
+  HTTPCacheAlt *alt = (HTTPCacheAlt *)buf;
   int orig_len      = len;
 
   if (alt->m_magic == CACHE_ALT_MAGIC_ALIVE) {
@@ -305,11 +305,11 @@ CacheScan::unmarshal(char *buf, int len, RefCountObj *block_ref)
 
   // request hdrs
 
-  HdrHeap *heap   = reinterpret_cast<HdrHeap *>(alt->m_request_hdr.m_heap ? (buf + (intptr_t)alt->m_request_hdr.m_heap) : nullptr);
+  HdrHeap *heap   = (HdrHeap *)(alt->m_request_hdr.m_heap ? (buf + (intptr_t)alt->m_request_hdr.m_heap) : nullptr);
   HTTPHdrImpl *hh = nullptr;
   int tmp         = 0;
-  if (heap != nullptr && (reinterpret_cast<char *>(heap) - buf) < len) {
-    tmp = this->unmarshal(heap, len, HDR_HEAP_OBJ_HTTP_HEADER, reinterpret_cast<HdrHeapObjImpl **>(&hh), block_ref);
+  if (heap != nullptr && ((char *)heap - buf) < len) {
+    tmp = this->unmarshal(heap, len, HDR_HEAP_OBJ_HTTP_HEADER, (HdrHeapObjImpl **)&hh, block_ref);
     if (hh == nullptr || tmp < 0) {
       zret.push(0, 0, "HTTPInfo::request unmarshal failed");
       return zret;
@@ -323,9 +323,9 @@ CacheScan::unmarshal(char *buf, int len, RefCountObj *block_ref)
 
   // response hdrs
 
-  heap = reinterpret_cast<HdrHeap *>(alt->m_response_hdr.m_heap ? (buf + (intptr_t)alt->m_response_hdr.m_heap) : nullptr);
-  if (heap != nullptr && (reinterpret_cast<char *>(heap) - buf) < len) {
-    tmp = this->unmarshal(heap, len, HDR_HEAP_OBJ_HTTP_HEADER, reinterpret_cast<HdrHeapObjImpl **>(&hh), block_ref);
+  heap = (HdrHeap *)(alt->m_response_hdr.m_heap ? (buf + (intptr_t)alt->m_response_hdr.m_heap) : nullptr);
+  if (heap != nullptr && ((char *)heap - buf) < len) {
+    tmp = this->unmarshal(heap, len, HDR_HEAP_OBJ_HTTP_HEADER, (HdrHeapObjImpl **)&hh, block_ref);
     if (hh == nullptr || tmp < 0) {
       zret.push(0, 0, "HTTPInfo::response unmarshal failed");
       return zret;
@@ -349,12 +349,11 @@ CacheScan::check_url(ts::MemSpan<char> &mem, URLImpl *url)
   bool in_bound = false; // boolean to check if address in bound
   if (!url->m_ptr_scheme) {
     in_bound = true; // nullptr is valid
-  } else if (mem.contains(const_cast<char *>(url->m_ptr_scheme))) {
+  } else if (mem.contains((char *)url->m_ptr_scheme)) {
     in_bound = true;
   }
 
-  return in_bound && mem.contains(reinterpret_cast<char *>(url)) &&
-         !(url == nullptr || url->m_length <= 0 || url->m_type != HDR_HEAP_OBJ_URL);
+  return in_bound && mem.contains((char *)url) && !(url == nullptr || url->m_length <= 0 || url->m_type != HDR_HEAP_OBJ_URL);
 }
 
 Errata
@@ -363,11 +362,11 @@ CacheScan::get_alternates(const char *buf, int length, bool search)
   Errata zret;
   ink_assert(!(((intptr_t)buf) & 3)); // buf must be aligned
 
-  char *start            = const_cast<char *>(buf);
+  char *start            = (char *)buf;
   RefCountObj *block_ref = nullptr;
-  ts::MemSpan<char> doc_mem(const_cast<char *>(buf), length);
+  ts::MemSpan<char> doc_mem((char *)buf, length);
 
-  while (length - (buf - start) > static_cast<int>(sizeof(HTTPCacheAlt))) {
+  while (length - (buf - start) > (int)sizeof(HTTPCacheAlt)) {
     HTTPCacheAlt *a = (HTTPCacheAlt *)buf;
 
     if (a->m_magic == CACHE_ALT_MAGIC_MARSHALED) {
@@ -378,7 +377,7 @@ CacheScan::get_alternates(const char *buf, int length, bool search)
       } else if (!a->m_request_hdr.m_http) {
         std::cerr << "no http object found in the request header object" << std::endl;
         return zret;
-      } else if (!doc_mem.contains(reinterpret_cast<char *>(a->m_request_hdr.m_http))) {
+      } else if (!doc_mem.contains((char *)a->m_request_hdr.m_http)) {
         std::cerr << "out of bounds request header in the alternate" << std::endl;
         return zret;
       }

--- a/src/traffic_cache_tool/CacheTool.cc
+++ b/src/traffic_cache_tool/CacheTool.cc
@@ -941,11 +941,11 @@ Cache::build_stripe_hash_table()
 {
   int num_stripes = globalVec_stripe.size();
   CacheStoreBlocks total;
-  unsigned int *forvol         = static_cast<unsigned int *>(ats_malloc(sizeof(unsigned int) * num_stripes));
-  unsigned int *gotvol         = static_cast<unsigned int *>(ats_malloc(sizeof(unsigned int) * num_stripes));
-  unsigned int *rnd            = static_cast<unsigned int *>(ats_malloc(sizeof(unsigned int) * num_stripes));
-  unsigned short *ttable       = static_cast<unsigned short *>(ats_malloc(sizeof(unsigned short) * VOL_HASH_TABLE_SIZE));
-  unsigned int *rtable_entries = static_cast<unsigned int *>(ats_malloc(sizeof(unsigned int) * num_stripes));
+  unsigned int *forvol         = (unsigned int *)ats_malloc(sizeof(unsigned int) * num_stripes);
+  unsigned int *gotvol         = (unsigned int *)ats_malloc(sizeof(unsigned int) * num_stripes);
+  unsigned int *rnd            = (unsigned int *)ats_malloc(sizeof(unsigned int) * num_stripes);
+  unsigned short *ttable       = (unsigned short *)ats_malloc(sizeof(unsigned short) * VOL_HASH_TABLE_SIZE);
+  unsigned int *rtable_entries = (unsigned int *)ats_malloc(sizeof(unsigned int) * num_stripes);
   unsigned int rtable_size     = 0;
   int i                        = 0;
   uint64_t used                = 0;
@@ -981,10 +981,10 @@ Cache::build_stripe_hash_table()
   }
 
   // generate random numbers proportional to allocation
-  rtable_pair *rtable = static_cast<rtable_pair *>(ats_malloc(sizeof(rtable_pair) * rtable_size));
+  rtable_pair *rtable = (rtable_pair *)ats_malloc(sizeof(rtable_pair) * rtable_size);
   int rindex          = 0;
   for (int i = 0; i < num_stripes; i++) {
-    for (int j = 0; j < static_cast<int>(rtable_entries[i]); j++) {
+    for (int j = 0; j < (int)rtable_entries[i]; j++) {
       rtable[rindex].rval = next_rand(&rnd[i]);
       rtable[rindex].idx  = i;
       rindex++;
@@ -999,7 +999,7 @@ Cache::build_stripe_hash_table()
   i = 0; // index moving through the random numbers
   for (int j = 0; j < VOL_HASH_TABLE_SIZE; j++) {
     pos = width / 2 + j * width; // position to select closest to
-    while (pos > rtable[i].rval && i < static_cast<int>(rtable_size) - 1) {
+    while (pos > rtable[i].rval && i < (int)rtable_size - 1) {
       i++;
     }
     ttable[j] = rtable[i].idx;

--- a/src/traffic_crashlog/procinfo.cc
+++ b/src/traffic_crashlog/procinfo.cc
@@ -28,7 +28,7 @@ static int
 procfd_open(pid_t pid, const char *fname)
 {
   char path[128];
-  snprintf(path, sizeof(path), "/proc/%ld/%s", static_cast<long>(pid), fname);
+  snprintf(path, sizeof(path), "/proc/%ld/%s", (long)pid, fname);
   return open(path, O_RDONLY);
 }
 
@@ -37,9 +37,9 @@ procfd_readlink(pid_t pid, const char *fname)
 {
   char path[128];
   ssize_t nbytes;
-  ats_scoped_str resolved(static_cast<char *>(ats_malloc(MAXPATHLEN + 1)));
+  ats_scoped_str resolved((char *)ats_malloc(MAXPATHLEN + 1));
 
-  snprintf(path, sizeof(path), "/proc/%ld/%s", static_cast<long>(pid), fname);
+  snprintf(path, sizeof(path), "/proc/%ld/%s", (long)pid, fname);
   nbytes = readlink(path, resolved, MAXPATHLEN);
   if (nbytes == -1) {
     Note("readlink failed with %s", strerror(errno));
@@ -60,7 +60,7 @@ write_procfd_file(const char *filename, const char *label, FILE *fp, const crash
   if (fd != -1) {
     text.slurp(fd);
     text.chomp();
-    fprintf(fp, "%s:\n%.*s\n", label, static_cast<int>(text.spaceUsed()), text.bufPtr());
+    fprintf(fp, "%s:\n%.*s\n", label, (int)text.spaceUsed(), text.bufPtr());
   }
 
   return !text.empty();
@@ -123,9 +123,9 @@ crashlog_write_procname(FILE *fp, const crashlog_target &target)
   if (fd != -1) {
     text.slurp(fd);
     text.chomp();
-    fprintf(fp, LABELFMT "%s [%ld]\n", "Process:", text.bufPtr(), static_cast<long>(target.pid));
+    fprintf(fp, LABELFMT "%s [%ld]\n", "Process:", text.bufPtr(), (long)target.pid);
   } else {
-    fprintf(fp, LABELFMT "%ld\n", "Process:", static_cast<long>(target.pid));
+    fprintf(fp, LABELFMT "%ld\n", "Process:", (long)target.pid);
   }
 
   return true;
@@ -225,9 +225,9 @@ crashlog_write_siginfo(FILE *fp, const crashlog_target &target)
   fprintf(fp, "Signal Status:\n");
   fprintf(fp, LABELFMT "%d (%s)\n", "siginfo.si_signo:", target.siginfo.si_signo, strsignal(target.siginfo.si_signo));
 
-  snprintf(tmp, sizeof(tmp), "%ld", static_cast<long>(target.siginfo.si_pid));
+  snprintf(tmp, sizeof(tmp), "%ld", (long)target.siginfo.si_pid);
   fprintf(fp, LABELFMT LABELFMT, "siginfo.si_pid:", tmp);
-  fprintf(fp, LABELFMT "%ld", "siginfo.si_uid:", static_cast<long>(target.siginfo.si_uid));
+  fprintf(fp, LABELFMT "%ld", "siginfo.si_uid:", (long)target.siginfo.si_uid);
   fprintf(fp, "\n");
 
   snprintf(tmp, sizeof(tmp), "0x%x (%d)", target.siginfo.si_code, target.siginfo.si_code);
@@ -236,8 +236,7 @@ crashlog_write_siginfo(FILE *fp, const crashlog_target &target)
   fprintf(fp, "\n");
 
   if (target.siginfo.si_code == SI_USER) {
-    fprintf(fp, "Signal delivered by user %ld from process %ld\n", static_cast<long>(target.siginfo.si_uid),
-            static_cast<long>(target.siginfo.si_pid));
+    fprintf(fp, "Signal delivered by user %ld from process %ld\n", (long)target.siginfo.si_uid, (long)target.siginfo.si_pid);
     return true;
   }
 

--- a/src/traffic_crashlog/traffic_crashlog.cc
+++ b/src/traffic_crashlog/traffic_crashlog.cc
@@ -93,7 +93,7 @@ max_passwd_size()
 #if defined(_SC_GETPW_R_SIZE_MAX)
   long val = sysconf(_SC_GETPW_R_SIZE_MAX);
   if (val > 0) {
-    return static_cast<unsigned>(val);
+    return (unsigned)val;
   }
 #endif
 
@@ -203,7 +203,7 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   }
 
   ink_zero(target);
-  target.pid       = static_cast<pid_t>(target_pid);
+  target.pid       = (pid_t)target_pid;
   target.timestamp = timestamp();
 
   if (host_triplet && strncmp(host_triplet, "x86_64-unknown-linux", sizeof("x86_64-unknown-linux") - 1) == 0) {
@@ -211,13 +211,13 @@ main(int /* argc ATS_UNUSED */, const char **argv)
     target.flags |= CRASHLOG_HAVE_THREADINFO;
 
     nbytes = read(STDIN_FILENO, &target.siginfo, sizeof(target.siginfo));
-    if (nbytes < static_cast<ssize_t>(sizeof(target.siginfo))) {
+    if (nbytes < (ssize_t)sizeof(target.siginfo)) {
       Warning("received %zd of %zu expected signal info bytes", nbytes, sizeof(target.siginfo));
       target.flags &= ~CRASHLOG_HAVE_THREADINFO;
     }
 
     nbytes = read(STDIN_FILENO, &target.ucontext, sizeof(target.ucontext));
-    if (nbytes < static_cast<ssize_t>(sizeof(target.ucontext))) {
+    if (nbytes < (ssize_t)sizeof(target.ucontext)) {
       Warning("received %zd of %zu expected thread context bytes", nbytes, sizeof(target.ucontext));
       target.flags &= ~CRASHLOG_HAVE_THREADINFO;
     }

--- a/src/traffic_ctl/alarm.cc
+++ b/src/traffic_ctl/alarm.cc
@@ -35,7 +35,7 @@ struct AlarmListPolicy {
   static entry_type
   cast(void *ptr)
   {
-    return static_cast<entry_type>(ptr);
+    return (entry_type)ptr;
   }
 };
 

--- a/src/traffic_layout/file_system.cc
+++ b/src/traffic_layout/file_system.cc
@@ -82,7 +82,7 @@ create_directory(const std::string &dir)
   // create directory one layer by one layer
   while (true) {
     pos = s.find('/', pos1);
-    if (static_cast<size_t>(pos) == s.npos) {
+    if ((size_t)pos == s.npos) {
       break;
     }
     ret  = mkdir(s.substr(0, pos).c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);

--- a/src/traffic_logstats/logstats.cc
+++ b/src/traffic_logstats/logstats.cc
@@ -1197,7 +1197,7 @@ find_or_create_stats(const char *key)
   if (origin_set->empty() || (origin_set->find(key) != origin_set->end())) {
     o_iter = origins.find(key);
     if (origins.end() == o_iter) {
-      o_stats = static_cast<OriginStats *>(ats_malloc(sizeof(OriginStats)));
+      o_stats = (OriginStats *)ats_malloc(sizeof(OriginStats));
       memset(o_stats, 0, sizeof(OriginStats));
       init_elapsed(o_stats);
       o_server = ats_strdup(key);
@@ -1895,7 +1895,7 @@ inline void
 format_int(int64_t num)
 {
   if (num > 0) {
-    int64_t mult = static_cast<int64_t>(pow(static_cast<double>(10), static_cast<int>(log10(static_cast<double>(num)) / 3) * 3));
+    int64_t mult = (int64_t)pow((double)10, (int)(log10((double)num) / 3) * 3);
     int64_t div;
     std::stringstream ss;
 
@@ -1963,7 +1963,7 @@ format_line(const char *desc, const StatsCounter &stat, const StatsCounter &tota
 {
   static char metrics[] = "KKMGTP";
   static char buf[64];
-  int ix = (stat.bytes > 1024 ? static_cast<int>(log10(static_cast<double>(stat.bytes)) / LOG10_1024) : 1);
+  int ix = (stat.bytes > 1024 ? (int)(log10((double)stat.bytes) / LOG10_1024) : 1);
 
   if (json) {
     std::cout << "    " << '"' << desc << "\" : "
@@ -1986,13 +1986,13 @@ format_line(const char *desc, const StatsCounter &stat, const StatsCounter &tota
     std::cout << std::right << std::setw(15);
     format_int(stat.count);
 
-    snprintf(buf, sizeof(buf), "%10.2f%%", (static_cast<double>(stat.count) / total.count * 100));
+    snprintf(buf, sizeof(buf), "%10.2f%%", ((double)stat.count / total.count * 100));
     std::cout << std::right << buf;
 
-    snprintf(buf, sizeof(buf), "%10.2f%cB", stat.bytes / pow(static_cast<double>(1024), ix), metrics[ix]);
+    snprintf(buf, sizeof(buf), "%10.2f%cB", stat.bytes / pow((double)1024, ix), metrics[ix]);
     std::cout << std::right << buf;
 
-    snprintf(buf, sizeof(buf), "%10.2f%%", (static_cast<double>(stat.bytes) / total.bytes * 100));
+    snprintf(buf, sizeof(buf), "%10.2f%%", ((double)stat.bytes / total.bytes * 100));
     std::cout << std::right << buf << std::endl;
   }
 }
@@ -2554,8 +2554,8 @@ main(int /* argc ATS_UNUSED */, const char *argv[])
     // Use more portable & standard fcntl() over flock()
     lck.l_type   = F_WRLCK;
     lck.l_whence = 0; /* offset l_start from beginning of file*/
-    lck.l_start  = static_cast<off_t>(0);
-    lck.l_len    = static_cast<off_t>(0); /* till end of file*/
+    lck.l_start  = (off_t)0;
+    lck.l_len    = (off_t)0; /* till end of file*/
     cnt          = 10;
     while (((res = fcntl(state_fd, F_SETLK, &lck)) < 0) && --cnt) {
       switch (errno) {

--- a/src/traffic_manager/traffic_manager.cc
+++ b/src/traffic_manager/traffic_manager.cc
@@ -218,7 +218,7 @@ check_lockfile()
   } else {
     char *reason = strerror(-err);
     if (err == 0) {
-      fprintf(stderr, "FATAL: Lockfile '%s' says server already running as PID %ld\n", lockfile, static_cast<long>(holding_pid));
+      fprintf(stderr, "FATAL: Lockfile '%s' says server already running as PID %ld\n", lockfile, (long)holding_pid);
       mgmt_log("FATAL: Lockfile '%s' says server already running as PID %d\n", lockfile, holding_pid);
     } else {
       fprintf(stderr, "FATAL: Can't open server lockfile '%s' (%s)\n", lockfile, (reason ? reason : "Unknown Reason"));
@@ -238,7 +238,7 @@ check_lockfile()
     fprintf(stderr, "FATAL: Can't acquire manager lockfile '%s'", lockfile);
     mgmt_log("FATAL: Can't acquire manager lockfile '%s'", lockfile);
     if (err == 0) {
-      fprintf(stderr, " (Lock file held by process ID %ld)\n", static_cast<long>(holding_pid));
+      fprintf(stderr, " (Lock file held by process ID %ld)\n", (long)holding_pid);
       mgmt_log(" (Lock file held by process ID %d)\n", holding_pid);
     } else if (reason) {
       fprintf(stderr, " (%s)\n", reason);
@@ -394,9 +394,8 @@ set_process_limits(RecInt fds_throttle)
 
     lim.rlim_cur = lim.rlim_max = static_cast<rlim_t>(maxfiles * file_max_pct);
     if (setrlimit(RLIMIT_NOFILE, &lim) == 0 && getrlimit(RLIMIT_NOFILE, &lim) == 0) {
-      fds_limit = static_cast<int>(lim.rlim_cur);
-      syslog(LOG_NOTICE, "NOTE: RLIMIT_NOFILE(%d):cur(%d),max(%d)", RLIMIT_NOFILE, static_cast<int>(lim.rlim_cur),
-             static_cast<int>(lim.rlim_max));
+      fds_limit = (int)lim.rlim_cur;
+      syslog(LOG_NOTICE, "NOTE: RLIMIT_NOFILE(%d):cur(%d),max(%d)", RLIMIT_NOFILE, (int)lim.rlim_cur, (int)lim.rlim_max);
     }
   }
 
@@ -404,9 +403,8 @@ set_process_limits(RecInt fds_throttle)
     if (fds_throttle > (int)(lim.rlim_cur + FD_THROTTLE_HEADROOM)) {
       lim.rlim_cur = (lim.rlim_max = (rlim_t)fds_throttle);
       if (!setrlimit(RLIMIT_NOFILE, &lim) && !getrlimit(RLIMIT_NOFILE, &lim)) {
-        fds_limit = static_cast<int>(lim.rlim_cur);
-        syslog(LOG_NOTICE, "NOTE: RLIMIT_NOFILE(%d):cur(%d),max(%d)", RLIMIT_NOFILE, static_cast<int>(lim.rlim_cur),
-               static_cast<int>(lim.rlim_max));
+        fds_limit = (int)lim.rlim_cur;
+        syslog(LOG_NOTICE, "NOTE: RLIMIT_NOFILE(%d):cur(%d),max(%d)", RLIMIT_NOFILE, (int)lim.rlim_cur, (int)lim.rlim_max);
       }
     }
   }

--- a/src/traffic_server/CoreUtils.cc
+++ b/src/traffic_server/CoreUtils.cc
@@ -131,7 +131,7 @@ char *ptr_data;
 intptr_t
 CoreUtils::find_vaddr(intptr_t vaddr, intptr_t upper, intptr_t lower)
 {
-  intptr_t index = static_cast<intptr_t>(floor(static_cast<double>((upper + lower) / 2)));
+  intptr_t index = (intptr_t)floor((double)((upper + lower) / 2));
 
   // match in table, returns index to be inserted into
   if (arrayMem[index].vaddr == vaddr) {
@@ -338,11 +338,11 @@ CoreUtils::find_stuff(StuffTest_f f)
 void
 CoreUtils::test_HdrHeap(void *arg)
 {
-  HdrHeap *hheap_test = static_cast<HdrHeap *>(arg);
+  HdrHeap *hheap_test = (HdrHeap *)arg;
   uint32_t *magic_ptr = &(hheap_test->m_magic);
   uint32_t magic      = 0;
 
-  if (read_from_core((intptr_t)magic_ptr, sizeof(uint32_t), reinterpret_cast<char *>(&magic)) != 0) {
+  if (read_from_core((intptr_t)magic_ptr, sizeof(uint32_t), (char *)&magic) != 0) {
     if (magic == HDR_BUF_MAGIC_ALIVE || magic == HDR_BUF_MAGIC_DEAD || magic == HDR_BUF_MAGIC_CORRUPT ||
         magic == HDR_BUF_MAGIC_MARSHALED) {
       printf("Found Hdr Heap @ 0x%p\n", arg);
@@ -384,11 +384,11 @@ CoreUtils::test_HttpSM_from_tunnel(void *arg)
 void
 CoreUtils::test_HttpSM(void *arg)
 {
-  HttpSM *hsm_test        = static_cast<HttpSM *>(arg);
+  HttpSM *hsm_test        = (HttpSM *)arg;
   unsigned int *magic_ptr = &(hsm_test->magic);
   unsigned int magic      = 0;
 
-  if (read_from_core((intptr_t)magic_ptr, sizeof(int), reinterpret_cast<char *>(&magic)) != 0) {
+  if (read_from_core((intptr_t)magic_ptr, sizeof(int), (char *)&magic) != 0) {
     if (magic == HTTP_SM_MAGIC_ALIVE || magic == HTTP_SM_MAGIC_DEAD) {
       printf("test_HttpSM:******MATCH*****\n");
       process_HttpSM(hsm_test);
@@ -562,7 +562,7 @@ CoreUtils::load_http_hdr(HTTPHdr *core_hdr, HTTPHdr *live_hdr)
     }
 
     char *free_start = (char *)(((HdrStrHeap *)str_hdr)->m_free_start);
-    int nto_copy     = std::abs(copy_start - free_start);
+    int nto_copy     = std::abs((char *)copy_start - free_start);
     ats_free(str_hdr);
     char rw_heap[sizeof(char) * nto_copy];
     if (read_from_core((intptr_t)copy_start, nto_copy, rw_heap) == -1) {
@@ -686,7 +686,7 @@ CoreUtils::process_EThread(EThread *eth_test)
   char *buf = (char *)ats_malloc(sizeof(char) * sizeof(EThread));
 
   if (read_from_core((intptr_t)eth_test, sizeof(EThread), buf) != -1) {
-    EThread *loaded_eth = reinterpret_cast<EThread *>(buf);
+    EThread *loaded_eth = (EThread *)buf;
 
     printf("----------- EThread @ 0x%p ----------\n", eth_test);
 #if !defined(kfreebsd) && (defined(freebsd) || defined(darwin) || defined(openbsd))
@@ -715,7 +715,7 @@ CoreUtils::process_NetVC(UnixNetVConnection *nvc_test)
   char *buf = (char *)ats_malloc(sizeof(char) * sizeof(UnixNetVConnection));
 
   if (read_from_core((intptr_t)nvc_test, sizeof(UnixNetVConnection), buf) != -1) {
-    UnixNetVConnection *loaded_nvc = reinterpret_cast<UnixNetVConnection *>(buf);
+    UnixNetVConnection *loaded_nvc = (UnixNetVConnection *)buf;
     char addrbuf[INET6_ADDRSTRLEN];
 
     printf("----------- UnixNetVConnection @ 0x%p ----------\n", nvc_test);
@@ -836,7 +836,7 @@ process_core(char *fname)
 
               len = sizeof *thdr + ((thdr->n_namesz + 3) & ~3) + ((thdr->n_descsz + 3) & ~3);
               // making sure the offset is byte aligned
-              char *offset = reinterpret_cast<char *>(thdr + 1) + ((thdr->n_namesz + 3) & ~3);
+              char *offset = (char *)(thdr + 1) + ((thdr->n_namesz + 3) & ~3);
 
               if (len < 0 || len > size) {
                 ::exit(1);
@@ -851,12 +851,12 @@ process_core(char *fname)
 
               switch (thdr->n_type) {
               case NT_PRSTATUS:
-                ps = reinterpret_cast<prstatus_t *>(offset);
+                ps = (prstatus_t *)offset;
                 memcpy(&pstat, ps, sizeof(prstatus_t));
                 printf("\n*** printing registers****\n");
                 for (j = 0; j < ELF_NGREG; j++) {
                   rinfo[j] = pstat.pr_reg[j];
-                  printf("%#x ", static_cast<unsigned int>(rinfo[j]));
+                  printf("%#x ", (unsigned int)rinfo[j]);
                 }
                 printf("\n");
 
@@ -867,15 +867,15 @@ process_core(char *fname)
 
                 printf("Signal that caused this core dump is signal  = %d\n", pstat.pr_cursig);
 
-                printf("stack pointer = %#x\n", static_cast<unsigned int>(pstat.pr_reg[SP_REGNUM])); // UESP
+                printf("stack pointer = %#x\n", (unsigned int)pstat.pr_reg[SP_REGNUM]); // UESP
                 framep = pstat.pr_reg[FP_REGNUM];
                 pc     = pstat.pr_reg[PC_REGNUM];
-                printf("frame pointer = %#x\n", static_cast<unsigned int>(pstat.pr_reg[FP_REGNUM])); // EBP
-                printf("program counter if no save = %#x\n", static_cast<unsigned int>(pstat.pr_reg[PC_REGNUM]));
+                printf("frame pointer = %#x\n", (unsigned int)pstat.pr_reg[FP_REGNUM]); // EBP
+                printf("program counter if no save = %#x\n", (unsigned int)pstat.pr_reg[PC_REGNUM]);
                 break;
 
               case NT_PRPSINFO:
-                ist = reinterpret_cast<prpsinfo_t *>(offset);
+                ist = (prpsinfo_t *)offset;
                 memcpy(&infostat, ist, sizeof(prpsinfo_t));
 
                 if (is_debug_tag_set("note")) {
@@ -888,7 +888,7 @@ process_core(char *fname)
                 }
                 break;
               }
-              thdr = reinterpret_cast<Elf32_Nhdr *>(reinterpret_cast<char *>(thdr) + len);
+              thdr = (Elf32_Nhdr *)((char *)thdr + len);
               sum += len;
               size -= len;
             }

--- a/src/traffic_server/FetchSM.cc
+++ b/src/traffic_server/FetchSM.cc
@@ -673,7 +673,7 @@ FetchSM::ext_read_data(char *buf, size_t len)
     memcpy(&buf[already], start, need);
     already += need;
 
-    if (already >= static_cast<int64_t>(len)) {
+    if (already >= (int64_t)len) {
       break;
     }
 

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -6136,7 +6136,7 @@ TSHttpTxnCntl(TSHttpTxn txnp, TSHttpCntlType cntl, void *data)
       return TS_ERROR;
     }
 
-    intptr_t *rptr = static_cast<intptr_t *>(data);
+    intptr_t *rptr = (intptr_t *)data;
 
     if (sm->t_state.api_info.logging_enabled) {
       *rptr = (intptr_t)TS_HTTP_CNTL_ON;
@@ -6161,7 +6161,7 @@ TSHttpTxnCntl(TSHttpTxn txnp, TSHttpCntlType cntl, void *data)
       return TS_ERROR;
     }
 
-    intptr_t *rptr = static_cast<intptr_t *>(data);
+    intptr_t *rptr = (intptr_t *)data;
 
     if (sm->t_state.api_info.retry_intercept_failures) {
       *rptr = (intptr_t)TS_HTTP_CNTL_ON;
@@ -6369,7 +6369,7 @@ TSHttpCurrentClientConnectionsGet()
   int64_t S;
 
   HTTP_READ_DYN_SUM(http_current_client_connections_stat, S);
-  return static_cast<int>(S);
+  return (int)S;
 }
 
 int
@@ -6378,7 +6378,7 @@ TSHttpCurrentActiveClientConnectionsGet()
   int64_t S;
 
   HTTP_READ_DYN_SUM(http_current_active_client_connections_stat, S);
-  return static_cast<int>(S);
+  return (int)S;
 }
 
 int
@@ -6391,7 +6391,7 @@ TSHttpCurrentIdleClientConnectionsGet()
   HTTP_READ_DYN_SUM(http_current_active_client_connections_stat, active);
 
   if (total >= active) {
-    return static_cast<int>(total - active);
+    return (int)(total - active);
   }
 
   return 0;
@@ -6403,7 +6403,7 @@ TSHttpCurrentCacheConnectionsGet()
   int64_t S;
 
   HTTP_READ_DYN_SUM(http_current_cache_connections_stat, S);
-  return static_cast<int>(S);
+  return (int)S;
 }
 
 int
@@ -6412,7 +6412,7 @@ TSHttpCurrentServerConnectionsGet()
   int64_t S;
 
   HTTP_READ_GLOBAL_DYN_SUM(http_current_server_connections_stat, S);
-  return static_cast<int>(S);
+  return (int)S;
 }
 
 /* HTTP alternate selection */
@@ -7502,7 +7502,7 @@ TSMgmtConfigIntSet(const char *var_name, TSMgmtInt value)
   // construct a buffer
   int buffer_size = strlen(var_name) + 1 + 32 + 1 + 64 + 1;
 
-  buffer = static_cast<char *>(alloca(buffer_size));
+  buffer = (char *)alloca(buffer_size);
   snprintf(buffer, buffer_size, "%s %d %" PRId64 "", var_name, MGMT_INT, value);
 
   // tell manager to set the configuration; note that this is not
@@ -7636,7 +7636,7 @@ char *
 TSFetchRespGet(TSHttpTxn txnp, int *length)
 {
   sdk_assert(sdk_sanity_check_null_ptr((void *)length) == TS_SUCCESS);
-  FetchSM *fetch_sm = reinterpret_cast<FetchSM *>(txnp);
+  FetchSM *fetch_sm = (FetchSM *)txnp;
   return fetch_sm->resp_get(length);
 }
 
@@ -7700,7 +7700,7 @@ TSFetchCreate(TSCont contp, const char *method, const char *url, const char *ver
 
   fetch_sm->ext_init((Continuation *)contp, method, url, version, client_addr, flags);
 
-  return reinterpret_cast<TSFetchSM>(fetch_sm);
+  return (TSFetchSM)fetch_sm;
 }
 
 void
@@ -7708,7 +7708,7 @@ TSFetchHeaderAdd(TSFetchSM fetch_sm, const char *name, int name_len, const char 
 {
   sdk_assert(sdk_sanity_check_fetch_sm(fetch_sm) == TS_SUCCESS);
 
-  (reinterpret_cast<FetchSM *>(fetch_sm))->ext_add_header(name, name_len, value, value_len);
+  ((FetchSM *)fetch_sm)->ext_add_header(name, name_len, value, value_len);
 }
 
 void
@@ -7716,7 +7716,7 @@ TSFetchWriteData(TSFetchSM fetch_sm, const void *data, size_t len)
 {
   sdk_assert(sdk_sanity_check_fetch_sm(fetch_sm) == TS_SUCCESS);
 
-  (reinterpret_cast<FetchSM *>(fetch_sm))->ext_write_data(data, len);
+  ((FetchSM *)fetch_sm)->ext_write_data(data, len);
 }
 
 ssize_t
@@ -7724,7 +7724,7 @@ TSFetchReadData(TSFetchSM fetch_sm, void *buf, size_t len)
 {
   sdk_assert(sdk_sanity_check_fetch_sm(fetch_sm) == TS_SUCCESS);
 
-  return (reinterpret_cast<FetchSM *>(fetch_sm))->ext_read_data(static_cast<char *>(buf), len);
+  return ((FetchSM *)fetch_sm)->ext_read_data((char *)buf, len);
 }
 
 void
@@ -7732,7 +7732,7 @@ TSFetchLaunch(TSFetchSM fetch_sm)
 {
   sdk_assert(sdk_sanity_check_fetch_sm(fetch_sm) == TS_SUCCESS);
 
-  (reinterpret_cast<FetchSM *>(fetch_sm))->ext_launch();
+  ((FetchSM *)fetch_sm)->ext_launch();
 }
 
 void
@@ -7740,7 +7740,7 @@ TSFetchDestroy(TSFetchSM fetch_sm)
 {
   sdk_assert(sdk_sanity_check_fetch_sm(fetch_sm) == TS_SUCCESS);
 
-  (reinterpret_cast<FetchSM *>(fetch_sm))->ext_destroy();
+  ((FetchSM *)fetch_sm)->ext_destroy();
 }
 
 void
@@ -7748,7 +7748,7 @@ TSFetchUserDataSet(TSFetchSM fetch_sm, void *data)
 {
   sdk_assert(sdk_sanity_check_fetch_sm(fetch_sm) == TS_SUCCESS);
 
-  (reinterpret_cast<FetchSM *>(fetch_sm))->ext_set_user_data(data);
+  ((FetchSM *)fetch_sm)->ext_set_user_data(data);
 }
 
 void *
@@ -7756,7 +7756,7 @@ TSFetchUserDataGet(TSFetchSM fetch_sm)
 {
   sdk_assert(sdk_sanity_check_fetch_sm(fetch_sm) == TS_SUCCESS);
 
-  return (reinterpret_cast<FetchSM *>(fetch_sm))->ext_get_user_data();
+  return ((FetchSM *)fetch_sm)->ext_get_user_data();
 }
 
 TSMBuffer

--- a/src/traffic_server/InkIOCoreAPI.cc
+++ b/src/traffic_server/InkIOCoreAPI.cc
@@ -122,7 +122,7 @@ static void *
 ink_thread_trampoline(void *data)
 {
   void *retval;
-  INKThreadInternal *ithread = static_cast<INKThreadInternal *>(data);
+  INKThreadInternal *ithread = (INKThreadInternal *)data;
 
   ithread->set_specific();
   retval = ithread->func(ithread->data);
@@ -158,7 +158,7 @@ TSThreadCreate(TSThreadFunc func, void *data)
     return (TSThread) nullptr;
   }
 
-  return reinterpret_cast<TSThread>(thread);
+  return (TSThread)thread;
 }
 
 // Wait for a thread to complete. When a thread calls TSThreadCreate,
@@ -171,7 +171,7 @@ void
 TSThreadWait(TSThread thread)
 {
   sdk_assert(sdk_sanity_check_iocore_structure(thread) == TS_SUCCESS);
-  INKThreadInternal *ithread = reinterpret_cast<INKThreadInternal *>(thread);
+  INKThreadInternal *ithread = (INKThreadInternal *)thread;
 
   ink_mutex_acquire(&ithread->completion.lock);
 
@@ -205,7 +205,7 @@ TSThreadDestroy(TSThread thread)
 {
   sdk_assert(sdk_sanity_check_iocore_structure(thread) == TS_SUCCESS);
 
-  INKThreadInternal *ithread = reinterpret_cast<INKThreadInternal *>(thread);
+  INKThreadInternal *ithread = (INKThreadInternal *)thread;
 
   // The thread must be destroyed by the same thread that created
   // it because that thread is holding the thread mutex.

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -258,14 +258,14 @@ public:
       ResourceTracker::dump(stderr);
 
       if (!end) {
-        end = static_cast<char *>(sbrk(0));
+        end = (char *)sbrk(0);
       }
 
       if (!snap) {
-        snap = static_cast<char *>(sbrk(0));
+        snap = (char *)sbrk(0);
       }
 
-      char *now = static_cast<char *>(sbrk(0));
+      char *now = (char *)sbrk(0);
       Note("sbrk 0x%" PRIu64 " from first %" PRIu64 " from last %" PRIu64 "\n", (uint64_t)((ptrdiff_t)now),
            (uint64_t)((ptrdiff_t)(now - end)), (uint64_t)((ptrdiff_t)(now - snap)));
       snap = now;
@@ -563,7 +563,7 @@ check_lockfile()
     fprintf(stderr, "WARNING: Can't acquire lockfile '%s'", lockfile.c_str());
 
     if ((err == 0) && (holding_pid != -1)) {
-      fprintf(stderr, " (Lock file held by process ID %ld)\n", static_cast<long>(holding_pid));
+      fprintf(stderr, " (Lock file held by process ID %ld)\n", (long)holding_pid);
     } else if ((err == 0) && (holding_pid == -1)) {
       fprintf(stderr, " (Lock file exists, but can't read process ID)\n");
     } else if (reason) {
@@ -1137,9 +1137,8 @@ adjust_sys_settings()
 
     lim.rlim_cur = lim.rlim_max = static_cast<rlim_t>(maxfiles * file_max_pct);
     if (setrlimit(RLIMIT_NOFILE, &lim) == 0 && getrlimit(RLIMIT_NOFILE, &lim) == 0) {
-      fds_limit = static_cast<int>(lim.rlim_cur);
-      syslog(LOG_NOTICE, "NOTE: RLIMIT_NOFILE(%d):cur(%d),max(%d)", RLIMIT_NOFILE, static_cast<int>(lim.rlim_cur),
-             static_cast<int>(lim.rlim_max));
+      fds_limit = (int)lim.rlim_cur;
+      syslog(LOG_NOTICE, "NOTE: RLIMIT_NOFILE(%d):cur(%d),max(%d)", RLIMIT_NOFILE, (int)lim.rlim_cur, (int)lim.rlim_max);
     }
   }
 
@@ -1149,9 +1148,8 @@ adjust_sys_settings()
     if (fds_throttle > (int)(lim.rlim_cur - THROTTLE_FD_HEADROOM)) {
       lim.rlim_cur = (lim.rlim_max = (rlim_t)(fds_throttle + THROTTLE_FD_HEADROOM));
       if (setrlimit(RLIMIT_NOFILE, &lim) == 0 && getrlimit(RLIMIT_NOFILE, &lim) == 0) {
-        fds_limit = static_cast<int>(lim.rlim_cur);
-        syslog(LOG_NOTICE, "NOTE: RLIMIT_NOFILE(%d):cur(%d),max(%d)", RLIMIT_NOFILE, static_cast<int>(lim.rlim_cur),
-               static_cast<int>(lim.rlim_max));
+        fds_limit = (int)lim.rlim_cur;
+        syslog(LOG_NOTICE, "NOTE: RLIMIT_NOFILE(%d):cur(%d),max(%d)", RLIMIT_NOFILE, (int)lim.rlim_cur, (int)lim.rlim_max);
       }
     }
   }
@@ -1351,7 +1349,7 @@ struct RegressionCont : public Continuation {
       return EVENT_CONT;
     }
 
-    char *rt = const_cast<char *>(regression_test[0] == 0 ? "" : regression_test);
+    char *rt = (char *)(regression_test[0] == 0 ? "" : regression_test);
     if (!initialized && RegressionTest::run(rt, regression_level) == REGRESSION_TEST_INPROGRESS) {
       initialized = 1;
       return EVENT_CONT;
@@ -1419,7 +1417,7 @@ adjust_num_of_net_threads(int nthreads)
   } else { /* autoconfig is enabled */
     num_of_threads_tmp = nthreads;
     REC_ReadConfigFloat(autoconfig_scale, "proxy.config.exec_thread.autoconfig.scale");
-    num_of_threads_tmp = static_cast<int>(static_cast<float>(num_of_threads_tmp) * autoconfig_scale);
+    num_of_threads_tmp = (int)((float)num_of_threads_tmp * autoconfig_scale);
 
     if (unlikely(num_of_threads_tmp > MAX_EVENT_THREADS)) {
       num_of_threads_tmp = MAX_EVENT_THREADS;

--- a/src/traffic_top/traffic_top.cc
+++ b/src/traffic_top/traffic_top.cc
@@ -120,9 +120,9 @@ prettyPrint(const int x, const int y, const double number, const int type)
     } else {
       color = colorPair::green;
     }
-    snprintf(buffer, sizeof(buffer), "%6.1f%%%%", my_number);
+    snprintf(buffer, sizeof(buffer), "%6.1f%%%%", (double)my_number);
   } else {
-    snprintf(buffer, sizeof(buffer), "%6.1f%c", my_number, exp);
+    snprintf(buffer, sizeof(buffer), "%6.1f%c", (double)my_number, exp);
   }
   attron(COLOR_PAIR(color));
   attron(A_BOLD);
@@ -152,7 +152,7 @@ makeTable(const int x, const int y, const list<string> &items, Stats &stats)
 size_t
 write_data(void *ptr, size_t size, size_t nmemb, void * /* stream */)
 {
-  response.append(static_cast<char *>(ptr), size * nmemb);
+  response.append((char *)ptr, size * nmemb);
   return size * nmemb;
 }
 

--- a/src/traffic_via/traffic_via.cc
+++ b/src/traffic_via/traffic_via.cc
@@ -59,50 +59,48 @@ detailViaLookup(char flag)
   // Detailed via codes after ":"
   switch (flag) {
   case 't':
-    viaTable                                           = new VIA("Tunnel info");
-    viaTable->viaData[static_cast<unsigned char>(' ')] = "no tunneling";
-    viaTable->viaData[static_cast<unsigned char>('U')] = "tunneling because of url (url suggests dynamic content)";
-    viaTable->viaData[static_cast<unsigned char>('M')] = "tunneling due to a method (e.g. CONNECT)";
-    viaTable->viaData[static_cast<unsigned char>('O')] = "tunneling because cache is turned off";
-    viaTable->viaData[static_cast<unsigned char>('F')] = "tunneling due to a header field (such as presence of If-Range header)";
-    viaTable->viaData[static_cast<unsigned char>('N')] = "tunneling due to no forward";
-    viaTable->viaData[static_cast<unsigned char>('A')] = "tunnel authorization";
+    viaTable                              = new VIA("Tunnel info");
+    viaTable->viaData[(unsigned char)' '] = "no tunneling";
+    viaTable->viaData[(unsigned char)'U'] = "tunneling because of url (url suggests dynamic content)";
+    viaTable->viaData[(unsigned char)'M'] = "tunneling due to a method (e.g. CONNECT)";
+    viaTable->viaData[(unsigned char)'O'] = "tunneling because cache is turned off";
+    viaTable->viaData[(unsigned char)'F'] = "tunneling due to a header field (such as presence of If-Range header)";
+    viaTable->viaData[(unsigned char)'N'] = "tunneling due to no forward";
+    viaTable->viaData[(unsigned char)'A'] = "tunnel authorization";
     break;
   case 'c':
     // Cache type
-    viaTable                                           = new VIA("Cache Type");
-    viaTable->viaData[static_cast<unsigned char>('C')] = "cache";
-    viaTable->viaData[static_cast<unsigned char>('L')] = "cluster, (not used)";
-    viaTable->viaData[static_cast<unsigned char>('P')] = "parent";
-    viaTable->viaData[static_cast<unsigned char>('S')] = "server";
-    viaTable->viaData[static_cast<unsigned char>(' ')] = "unknown";
+    viaTable                              = new VIA("Cache Type");
+    viaTable->viaData[(unsigned char)'C'] = "cache";
+    viaTable->viaData[(unsigned char)'L'] = "cluster, (not used)";
+    viaTable->viaData[(unsigned char)'P'] = "parent";
+    viaTable->viaData[(unsigned char)'S'] = "server";
+    viaTable->viaData[(unsigned char)' '] = "unknown";
 
     // Cache Lookup Result
-    viaTable->next                                           = new VIA("Cache Lookup Result");
-    viaTable->next->viaData[static_cast<unsigned char>('C')] = "cache hit but config forces revalidate";
-    viaTable->next->viaData[static_cast<unsigned char>('I')] =
-      "conditional miss (client sent conditional, fresh in cache, returned 412)";
-    viaTable->next->viaData[static_cast<unsigned char>(' ')] = "cache miss or no cache lookup";
-    viaTable->next->viaData[static_cast<unsigned char>('U')] = "cache hit, but client forces revalidate (e.g. Pragma: no-cache)";
-    viaTable->next->viaData[static_cast<unsigned char>('D')] = "cache hit, but method forces revalidated (e.g. ftp, not anonymous)";
-    viaTable->next->viaData[static_cast<unsigned char>('M')] = "cache miss (url not in cache)";
-    viaTable->next->viaData[static_cast<unsigned char>('N')] =
-      "conditional hit (client sent conditional, doc fresh in cache, returned 304)";
-    viaTable->next->viaData[static_cast<unsigned char>('H')] = "cache hit";
-    viaTable->next->viaData[static_cast<unsigned char>('S')] = "cache hit, but expired";
-    viaTable->next->viaData[static_cast<unsigned char>('K')] = "cookie miss";
+    viaTable->next                              = new VIA("Cache Lookup Result");
+    viaTable->next->viaData[(unsigned char)'C'] = "cache hit but config forces revalidate";
+    viaTable->next->viaData[(unsigned char)'I'] = "conditional miss (client sent conditional, fresh in cache, returned 412)";
+    viaTable->next->viaData[(unsigned char)' '] = "cache miss or no cache lookup";
+    viaTable->next->viaData[(unsigned char)'U'] = "cache hit, but client forces revalidate (e.g. Pragma: no-cache)";
+    viaTable->next->viaData[(unsigned char)'D'] = "cache hit, but method forces revalidated (e.g. ftp, not anonymous)";
+    viaTable->next->viaData[(unsigned char)'M'] = "cache miss (url not in cache)";
+    viaTable->next->viaData[(unsigned char)'N'] = "conditional hit (client sent conditional, doc fresh in cache, returned 304)";
+    viaTable->next->viaData[(unsigned char)'H'] = "cache hit";
+    viaTable->next->viaData[(unsigned char)'S'] = "cache hit, but expired";
+    viaTable->next->viaData[(unsigned char)'K'] = "cookie miss";
     break;
   case 'p':
-    viaTable                                           = new VIA("Parent proxy connection status");
-    viaTable->viaData[static_cast<unsigned char>(' ')] = "no parent proxy or unknown";
-    viaTable->viaData[static_cast<unsigned char>('S')] = "connection opened successfully";
-    viaTable->viaData[static_cast<unsigned char>('F')] = "connection open failed";
+    viaTable                              = new VIA("Parent proxy connection status");
+    viaTable->viaData[(unsigned char)' '] = "no parent proxy or unknown";
+    viaTable->viaData[(unsigned char)'S'] = "connection opened successfully";
+    viaTable->viaData[(unsigned char)'F'] = "connection open failed";
     break;
   case 's':
-    viaTable                                           = new VIA("Origin server connection status");
-    viaTable->viaData[static_cast<unsigned char>(' ')] = "no server connection needed";
-    viaTable->viaData[static_cast<unsigned char>('S')] = "connection opened successfully";
-    viaTable->viaData[static_cast<unsigned char>('F')] = "connection open failed";
+    viaTable                              = new VIA("Origin server connection status");
+    viaTable->viaData[(unsigned char)' '] = "no server connection needed";
+    viaTable->viaData[(unsigned char)'S'] = "connection opened successfully";
+    viaTable->viaData[(unsigned char)'F'] = "connection open failed";
     break;
   default:
     viaTable = nullptr;
@@ -122,58 +120,58 @@ standardViaLookup(char flag)
   // Via codes before ":"
   switch (flag) {
   case 'u':
-    viaTable                                           = new VIA("Request headers received from client");
-    viaTable->viaData[static_cast<unsigned char>('C')] = "cookie";
-    viaTable->viaData[static_cast<unsigned char>('E')] = "error in request";
-    viaTable->viaData[static_cast<unsigned char>('S')] = "simple request (not conditional)";
-    viaTable->viaData[static_cast<unsigned char>('N')] = "no-cache";
-    viaTable->viaData[static_cast<unsigned char>('I')] = "IMS";
-    viaTable->viaData[static_cast<unsigned char>(' ')] = "unknown";
+    viaTable                              = new VIA("Request headers received from client");
+    viaTable->viaData[(unsigned char)'C'] = "cookie";
+    viaTable->viaData[(unsigned char)'E'] = "error in request";
+    viaTable->viaData[(unsigned char)'S'] = "simple request (not conditional)";
+    viaTable->viaData[(unsigned char)'N'] = "no-cache";
+    viaTable->viaData[(unsigned char)'I'] = "IMS";
+    viaTable->viaData[(unsigned char)' '] = "unknown";
     break;
   case 'c':
-    viaTable                                           = new VIA("Result of Traffic Server cache lookup for URL");
-    viaTable->viaData[static_cast<unsigned char>('A')] = "in cache, not acceptable (a cache \"MISS\")";
-    viaTable->viaData[static_cast<unsigned char>('H')] = "in cache, fresh (a cache \"HIT\")";
-    viaTable->viaData[static_cast<unsigned char>('S')] = "in cache, stale (a cache \"MISS\")";
-    viaTable->viaData[static_cast<unsigned char>('R')] = "in cache, fresh Ram hit (a cache \"HIT\")";
-    viaTable->viaData[static_cast<unsigned char>('M')] = "miss (a cache \"MISS\")";
-    viaTable->viaData[static_cast<unsigned char>(' ')] = "no cache lookup";
+    viaTable                              = new VIA("Result of Traffic Server cache lookup for URL");
+    viaTable->viaData[(unsigned char)'A'] = "in cache, not acceptable (a cache \"MISS\")";
+    viaTable->viaData[(unsigned char)'H'] = "in cache, fresh (a cache \"HIT\")";
+    viaTable->viaData[(unsigned char)'S'] = "in cache, stale (a cache \"MISS\")";
+    viaTable->viaData[(unsigned char)'R'] = "in cache, fresh Ram hit (a cache \"HIT\")";
+    viaTable->viaData[(unsigned char)'M'] = "miss (a cache \"MISS\")";
+    viaTable->viaData[(unsigned char)' '] = "no cache lookup";
     break;
   case 's':
-    viaTable                                           = new VIA("Response information received from origin server");
-    viaTable->viaData[static_cast<unsigned char>('E')] = "error in response";
-    viaTable->viaData[static_cast<unsigned char>('S')] = "connection opened successfully";
-    viaTable->viaData[static_cast<unsigned char>('N')] = "not-modified";
-    viaTable->viaData[static_cast<unsigned char>(' ')] = "no server connection needed";
+    viaTable                              = new VIA("Response information received from origin server");
+    viaTable->viaData[(unsigned char)'E'] = "error in response";
+    viaTable->viaData[(unsigned char)'S'] = "connection opened successfully";
+    viaTable->viaData[(unsigned char)'N'] = "not-modified";
+    viaTable->viaData[(unsigned char)' '] = "no server connection needed";
     break;
   case 'f':
-    viaTable                                           = new VIA("Result of document write-to-cache:");
-    viaTable->viaData[static_cast<unsigned char>('U')] = "updated old cache copy";
-    viaTable->viaData[static_cast<unsigned char>('D')] = "cached copy deleted";
-    viaTable->viaData[static_cast<unsigned char>('W')] = "written into cache (new copy)";
-    viaTable->viaData[static_cast<unsigned char>(' ')] = "no cache write performed";
+    viaTable                              = new VIA("Result of document write-to-cache:");
+    viaTable->viaData[(unsigned char)'U'] = "updated old cache copy";
+    viaTable->viaData[(unsigned char)'D'] = "cached copy deleted";
+    viaTable->viaData[(unsigned char)'W'] = "written into cache (new copy)";
+    viaTable->viaData[(unsigned char)' '] = "no cache write performed";
     break;
   case 'p':
-    viaTable                                           = new VIA("Proxy operation result");
-    viaTable->viaData[static_cast<unsigned char>('R')] = "origin server revalidated";
-    viaTable->viaData[static_cast<unsigned char>(' ')] = "unknown";
-    viaTable->viaData[static_cast<unsigned char>('S')] = "served or connection opened successfully";
-    viaTable->viaData[static_cast<unsigned char>('N')] = "not-modified";
+    viaTable                              = new VIA("Proxy operation result");
+    viaTable->viaData[(unsigned char)'R'] = "origin server revalidated";
+    viaTable->viaData[(unsigned char)' '] = "unknown";
+    viaTable->viaData[(unsigned char)'S'] = "served or connection opened successfully";
+    viaTable->viaData[(unsigned char)'N'] = "not-modified";
     break;
   case 'e':
-    viaTable                                           = new VIA("Error codes (if any)");
-    viaTable->viaData[static_cast<unsigned char>('A')] = "authorization failure";
-    viaTable->viaData[static_cast<unsigned char>('H')] = "header syntax unacceptable";
-    viaTable->viaData[static_cast<unsigned char>('C')] = "connection to server failed";
-    viaTable->viaData[static_cast<unsigned char>('T')] = "connection timed out";
-    viaTable->viaData[static_cast<unsigned char>('S')] = "server related error";
-    viaTable->viaData[static_cast<unsigned char>('D')] = "dns failure";
-    viaTable->viaData[static_cast<unsigned char>('N')] = "no error";
-    viaTable->viaData[static_cast<unsigned char>('F')] = "request forbidden";
-    viaTable->viaData[static_cast<unsigned char>('R')] = "cache read error";
-    viaTable->viaData[static_cast<unsigned char>('M')] = "moved temporarily";
-    viaTable->viaData[static_cast<unsigned char>('L')] = "looped detected";
-    viaTable->viaData[static_cast<unsigned char>(' ')] = "unknown";
+    viaTable                              = new VIA("Error codes (if any)");
+    viaTable->viaData[(unsigned char)'A'] = "authorization failure";
+    viaTable->viaData[(unsigned char)'H'] = "header syntax unacceptable";
+    viaTable->viaData[(unsigned char)'C'] = "connection to server failed";
+    viaTable->viaData[(unsigned char)'T'] = "connection timed out";
+    viaTable->viaData[(unsigned char)'S'] = "server related error";
+    viaTable->viaData[(unsigned char)'D'] = "dns failure";
+    viaTable->viaData[(unsigned char)'N'] = "no error";
+    viaTable->viaData[(unsigned char)'F'] = "request forbidden";
+    viaTable->viaData[(unsigned char)'R'] = "cache read error";
+    viaTable->viaData[(unsigned char)'M'] = "moved temporarily";
+    viaTable->viaData[(unsigned char)'L'] = "looped detected";
+    viaTable->viaData[(unsigned char)' '] = "unknown";
     break;
   default:
     viaTable = nullptr;
@@ -209,8 +207,7 @@ printViaHeader(const char *header)
       // This is a one of the sequence of (uppercase) VIA codes.
       if (viaEntry) {
         printf("%-55s:", viaEntry->title);
-        printf("%s\n", viaEntry->viaData[static_cast<unsigned char>(*c)] ? viaEntry->viaData[static_cast<unsigned char>(*c)] :
-                                                                           "Invalid sequence");
+        printf("%s\n", viaEntry->viaData[(unsigned char)*c] ? viaEntry->viaData[(unsigned char)*c] : "Invalid sequence");
         viaEntry = viaEntry->next;
       }
     }
@@ -288,8 +285,8 @@ filterViaHeader()
       *newLinePtr = '\0';
     }
     // Match for via header pattern
-    pcreExecCode = pcre_exec(compiledReg, extraReg, viaHeader, static_cast<int>(sizeof(viaHeader)), 0, 0, subStringVector,
-                             SUBSTRING_VECTOR_COUNT);
+    pcreExecCode =
+      pcre_exec(compiledReg, extraReg, viaHeader, (int)sizeof(viaHeader), 0, 0, subStringVector, SUBSTRING_VECTOR_COUNT);
 
     // Match failed, don't worry. Continue to next line.
     if (pcreExecCode < 0) {

--- a/src/tscore/Arena.cc
+++ b/src/tscore/Arena.cc
@@ -42,9 +42,9 @@ blk_alloc(int size)
   ArenaBlock *blk;
 
   if (size == DEFAULT_BLOCK_SIZE) {
-    blk = static_cast<ArenaBlock *>(defaultSizeArenaBlock.alloc_void());
+    blk = (ArenaBlock *)defaultSizeArenaBlock.alloc_void();
   } else {
-    blk = static_cast<ArenaBlock *>(ats_malloc(size + sizeof(ArenaBlock) - 8));
+    blk = (ArenaBlock *)ats_malloc(size + sizeof(ArenaBlock) - 8);
   }
 
   blk->next          = nullptr;
@@ -109,7 +109,7 @@ Arena::alloc(size_t size, size_t alignment)
     b = b->next;
   }
 
-  block_size = static_cast<unsigned int>(size * 1.5);
+  block_size = (unsigned int)(size * 1.5);
   if (block_size < DEFAULT_BLOCK_SIZE) {
     block_size = DEFAULT_BLOCK_SIZE;
   }
@@ -133,8 +133,8 @@ Arena::free(void *mem, size_t size)
 
     b = m_blocks;
     while (b->next) {
-      if (b->m_water_level == (static_cast<char *>(mem) + size)) {
-        b->m_water_level = static_cast<char *>(mem);
+      if (b->m_water_level == ((char *)mem + size)) {
+        b->m_water_level = (char *)mem;
         return;
       }
       b = b->next;

--- a/src/tscore/BaseLogFile.cc
+++ b/src/tscore/BaseLogFile.cc
@@ -167,8 +167,8 @@ BaseLogFile::roll(long interval_start, long interval_end)
 
   // Now that we have our timestamp values, convert them to the proper
   // timestamp formats and create the rolled file name.
-  timestamp_to_str(static_cast<long>(start), start_time_ext, sizeof(start_time_ext));
-  timestamp_to_str(static_cast<long>(end), end_time_ext, sizeof(start_time_ext));
+  timestamp_to_str((long)start, start_time_ext, sizeof(start_time_ext));
+  timestamp_to_str((long)end, end_time_ext, sizeof(start_time_ext));
   snprintf(roll_name, LOGFILE_ROLL_MAXPATHLEN, "%s%s%s.%s-%s%s", m_name.get(), (m_hostname.get() ? LOGFILE_SEPARATOR_STRING : ""),
            (m_hostname.get() ? m_hostname.get() : ""), start_time_ext, end_time_ext, LOGFILE_ROLLED_EXTENSION);
 
@@ -236,8 +236,8 @@ BaseLogFile::roll()
 bool
 BaseLogFile::rolled_logfile(char *path)
 {
-  const int target_len = static_cast<int>(strlen(LOGFILE_ROLLED_EXTENSION));
-  int len              = static_cast<int>(strlen(path));
+  const int target_len = (int)strlen(LOGFILE_ROLLED_EXTENSION);
+  int len              = (int)strlen(path);
   if (len > target_len) {
     char *str = &path[len - target_len];
     if (!strcmp(str, LOGFILE_ROLLED_EXTENSION)) {
@@ -302,9 +302,9 @@ BaseLogFile::open_file(int perm)
     // The log file does not exist, so we create a new MetaInfo object
     //  which will save itself to disk right away (in the constructor)
     if (m_has_signature) {
-      m_meta_info = new BaseMetaInfo(m_name.get(), static_cast<long>(time(nullptr)), m_signature);
+      m_meta_info = new BaseMetaInfo(m_name.get(), (long)time(nullptr), m_signature);
     } else {
-      m_meta_info = new BaseMetaInfo(m_name.get(), static_cast<long>(time(nullptr)));
+      m_meta_info = new BaseMetaInfo(m_name.get(), (long)time(nullptr));
     }
   }
 
@@ -450,7 +450,7 @@ BaseMetaInfo::_build_name(const char *filename)
 
   // 7 = 1 (dot at beginning) + 5 (".meta") + 1 (null terminating)
   //
-  _filename = static_cast<char *>(ats_malloc(l + 7));
+  _filename = (char *)ats_malloc(l + 7);
 
   if (i < 0) {
     ink_string_concatenate_strings(_filename, ".", filename, ".meta", nullptr);
@@ -481,7 +481,7 @@ BaseMetaInfo::_read_from_file()
         if (strcmp(t, "creation_time") == 0) {
           t = tok.getNext();
           if (t) {
-            _creation_time = static_cast<time_t>(ink_atoi64(t));
+            _creation_time = (time_t)ink_atoi64(t);
             _flags |= VALID_CREATION_TIME;
           }
         } else if (strcmp(t, "object_signature") == 0) {
@@ -521,7 +521,7 @@ BaseMetaInfo::_write_to_file()
   int n;
   if (_flags & VALID_CREATION_TIME) {
     log_log_trace("Writing creation time to %s\n", _filename);
-    n = snprintf(_buffer, BUF_SIZE, "creation_time = %lu\n", static_cast<unsigned long>(_creation_time));
+    n = snprintf(_buffer, BUF_SIZE, "creation_time = %lu\n", (unsigned long)_creation_time);
     // TODO modify this runtime check so that it is not an assertion
     ink_release_assert(n <= BUF_SIZE);
     if (write(fd, _buffer, n) == -1) {

--- a/src/tscore/CompileParseRules.cc
+++ b/src/tscore/CompileParseRules.cc
@@ -161,7 +161,7 @@ main()
   for (c = 0; c < 256; c++) {
     fprintf(fp, "/* %3d (%c) */\t", c, (isprint(c) ? c : '?'));
     fprintf(fp, "0x%08X%c\t\t", tparseRulesCType[c], (c != 255 ? ',' : ' '));
-    fprintf(fp, "/* [%s] */\n", uint_to_binary((tparseRulesCType[c])));
+    fprintf(fp, "/* [%s] */\n", uint_to_binary((unsigned int)(tparseRulesCType[c])));
   }
   fclose(fp);
   fp = fopen("ParseRulesCTypeToUpper", "w");

--- a/src/tscore/ConsistentHash.cc
+++ b/src/tscore/ConsistentHash.cc
@@ -55,7 +55,7 @@ ATSConsistentHash::insert(ATSConsistentHashNode *node, float weight, ATSHash64 *
   string_stream << *node;
   std_string = string_stream.str();
 
-  for (i = 0; i < static_cast<int>(roundf(replicas * weight)); i++) {
+  for (i = 0; i < (int)roundf(replicas * weight); i++) {
     snprintf(numstr, 256, "%d-", i);
     thash->update(numstr, strlen(numstr));
     thash->update(std_string.c_str(), strlen(std_string.c_str()));

--- a/src/tscore/Diags.cc
+++ b/src/tscore/Diags.cc
@@ -453,8 +453,8 @@ Diags::dump(FILE *fp) const
   fprintf(fp, "  action default tags: '%s'\n", (base_action_tags ? base_action_tags : "NULL"));
   fprintf(fp, "  outputs:\n");
   for (i = 0; i < DiagsLevel_Count; i++) {
-    fprintf(fp, "    %10s [stdout=%d, stderr=%d, syslog=%d, diagslog=%d]\n", level_name(static_cast<DiagsLevel>(i)),
-            config.outputs[i].to_stdout, config.outputs[i].to_stderr, config.outputs[i].to_syslog, config.outputs[i].to_diagslog);
+    fprintf(fp, "    %10s [stdout=%d, stderr=%d, syslog=%d, diagslog=%d]\n", level_name((DiagsLevel)i), config.outputs[i].to_stdout,
+            config.outputs[i].to_stderr, config.outputs[i].to_syslog, config.outputs[i].to_diagslog);
   }
 }
 

--- a/src/tscore/HashSip.cc
+++ b/src/tscore/HashSip.cc
@@ -98,10 +98,10 @@ ATSHash64Sip24::final()
   int i;
 
   if (!finalized) {
-    last7 = static_cast<uint64_t>(total_len & 0xff) << 56;
+    last7 = (uint64_t)(total_len & 0xff) << 56;
 
     for (i = block_buffer_len - 1; i >= 0; i--) {
-      last7 |= static_cast<uint64_t>(block_buffer[i]) << (i * 8);
+      last7 |= (uint64_t)block_buffer[i] << (i * 8);
     }
 
     v3 ^= last7;

--- a/src/tscore/IpMapConf.cc
+++ b/src/tscore/IpMapConf.cc
@@ -87,7 +87,7 @@ Load_IpMap_From_File(IpMap *map, int fd, const char *key_str)
     zret = Load_IpMap_From_File(map, f, key_str);
     fclose(f);
   } else {
-    zret = static_cast<char *>(ats_malloc(ERR_STRING_LEN));
+    zret = (char *)ats_malloc(ERR_STRING_LEN);
     snprintf(zret, ERR_STRING_LEN, "Unable to reopen file descriptor as stream %d:%s", errno, strerror(errno));
   }
   return zret;
@@ -139,7 +139,7 @@ Load_IpMap_From_File(IpMap *map, FILE *f, const char *key_str)
       }
 
       if (0 != read_addr(line, n, &i, &laddr.sa, err_buff)) {
-        char *error_str = static_cast<char *>(ats_malloc(ERR_STRING_LEN));
+        char *error_str = (char *)ats_malloc(ERR_STRING_LEN);
         snprintf(error_str, ERR_STRING_LEN, "Invalid input configuration (%s) at line %d offset %d - '%s'", err_buff, line_no, i,
                  line);
         return error_str;
@@ -158,11 +158,11 @@ Load_IpMap_From_File(IpMap *map, FILE *f, const char *key_str)
         // Now, read the end of the IP range
         ++i;
         if (!skip_space(line, n, i)) {
-          char *error_str = static_cast<char *>(ats_malloc(ERR_STRING_LEN));
+          char *error_str = (char *)ats_malloc(ERR_STRING_LEN);
           snprintf(error_str, ERR_STRING_LEN, "Invalid input (unterminated range) at line %d offset %d - '%s'", line_no, i, line);
           return error_str;
         } else if (0 != read_addr(line, n, &i, &raddr.sa, err_buff)) {
-          char *error_str = static_cast<char *>(ats_malloc(ERR_STRING_LEN));
+          char *error_str = (char *)ats_malloc(ERR_STRING_LEN);
           snprintf(error_str, ERR_STRING_LEN, "Invalid input (%s) at line %d offset %d - '%s'", err_buff, line_no, i, line);
           return error_str;
         }
@@ -171,13 +171,13 @@ Load_IpMap_From_File(IpMap *map, FILE *f, const char *key_str)
           break;
         }
         if (line[i] != ',') {
-          char *error_str = static_cast<char *>(ats_malloc(ERR_STRING_LEN));
+          char *error_str = (char *)ats_malloc(ERR_STRING_LEN);
           snprintf(error_str, ERR_STRING_LEN, "Invalid input (expecting comma) at line %d offset %d - '%s'", line_no, i, line);
           return error_str;
         }
         ++i;
       } else {
-        char *error_str = static_cast<char *>(ats_malloc(ERR_STRING_LEN));
+        char *error_str = (char *)ats_malloc(ERR_STRING_LEN);
         snprintf(error_str, ERR_STRING_LEN, "Invalid input (expecting dash or comma) at line %d offset %d", line_no, i);
         return error_str;
       }

--- a/src/tscore/JeAllocator.cc
+++ b/src/tscore/JeAllocator.cc
@@ -111,7 +111,7 @@ JemallocNodumpAllocator::allocate(InkFreeList *f)
 #else
     newp = ats_memalign(f->alignment, f->type_size);
     if (INK_ALIGN((uint64_t)newp, ats_pagesize()) == (uint64_t)newp) {
-      ats_madvise(static_cast<caddr_t>(newp), INK_ALIGN(f->type_size, f->alignment), f->advice);
+      ats_madvise((caddr_t)newp, INK_ALIGN(f->type_size, f->alignment), f->advice);
     }
 #endif
   } else {

--- a/src/tscore/MMH.cc
+++ b/src/tscore/MMH.cc
@@ -101,10 +101,10 @@ ink_code_incr_MMH_init(MMH_CTX *ctx)
 {
   ctx->buffer_size = 0;
   ctx->blocks      = 0;
-  ctx->state[0]    = (MMH_x[MMH_X_SIZE + 0] << 32) + MMH_x[MMH_X_SIZE + 1];
-  ctx->state[1]    = (MMH_x[MMH_X_SIZE + 2] << 32) + MMH_x[MMH_X_SIZE + 3];
-  ctx->state[2]    = (MMH_x[MMH_X_SIZE + 4] << 32) + MMH_x[MMH_X_SIZE + 5];
-  ctx->state[3]    = (MMH_x[MMH_X_SIZE + 6] << 32) + MMH_x[MMH_X_SIZE + 7];
+  ctx->state[0]    = ((uint64_t)MMH_x[MMH_X_SIZE + 0] << 32) + MMH_x[MMH_X_SIZE + 1];
+  ctx->state[1]    = ((uint64_t)MMH_x[MMH_X_SIZE + 2] << 32) + MMH_x[MMH_X_SIZE + 3];
+  ctx->state[2]    = ((uint64_t)MMH_x[MMH_X_SIZE + 4] << 32) + MMH_x[MMH_X_SIZE + 5];
+  ctx->state[3]    = ((uint64_t)MMH_x[MMH_X_SIZE + 6] << 32) + MMH_x[MMH_X_SIZE + 7];
   return 0;
 }
 
@@ -113,7 +113,7 @@ ink_code_MMH(unsigned char *input, int len, unsigned char *sixteen_byte_hash)
 {
   MMH_CTX ctx;
   ink_code_incr_MMH_init(&ctx);
-  ink_code_incr_MMH_update(&ctx, reinterpret_cast<const char *>(input), len);
+  ink_code_incr_MMH_update(&ctx, (const char *)input, len);
   ink_code_incr_MMH_final(sixteen_byte_hash, &ctx);
   return 0;
 }
@@ -121,7 +121,7 @@ ink_code_MMH(unsigned char *input, int len, unsigned char *sixteen_byte_hash)
 static inline void
 MMH_update(MMH_CTX *ctx, unsigned char *ab)
 {
-  uint32_t *b = reinterpret_cast<uint32_t *>(ab);
+  uint32_t *b = (uint32_t *)ab;
   ctx->state[0] += b[0] * MMH_x[(ctx->blocks + 0) % MMH_X_SIZE];
   ctx->state[1] += b[1] * MMH_x[(ctx->blocks + 1) % MMH_X_SIZE];
   ctx->state[2] += b[2] * MMH_x[(ctx->blocks + 2) % MMH_X_SIZE];
@@ -132,7 +132,7 @@ MMH_update(MMH_CTX *ctx, unsigned char *ab)
 static inline void
 MMH_updateb1(MMH_CTX *ctx, unsigned char *ab)
 {
-  uint32_t *b = reinterpret_cast<uint32_t *>(ab - 1);
+  uint32_t *b = (uint32_t *)(ab - 1);
   uint32_t b0 = b[0], b1 = b[1], b2 = b[2], b3 = b[3], b4 = b[4];
   b0 = (b0 << 8) + (b1 >> 24);
   b1 = (b1 << 8) + (b2 >> 24);
@@ -148,7 +148,7 @@ MMH_updateb1(MMH_CTX *ctx, unsigned char *ab)
 static inline void
 MMH_updateb2(MMH_CTX *ctx, unsigned char *ab)
 {
-  uint32_t *b = reinterpret_cast<uint32_t *>(ab - 2);
+  uint32_t *b = (uint32_t *)(ab - 2);
   uint32_t b0 = b[0], b1 = b[1], b2 = b[2], b3 = b[3], b4 = b[4];
   b0 = (b0 << 16) + (b1 >> 16);
   b1 = (b1 << 16) + (b2 >> 16);
@@ -164,7 +164,7 @@ MMH_updateb2(MMH_CTX *ctx, unsigned char *ab)
 static inline void
 MMH_updateb3(MMH_CTX *ctx, unsigned char *ab)
 {
-  uint32_t *b = reinterpret_cast<uint32_t *>(ab - 3);
+  uint32_t *b = (uint32_t *)(ab - 3);
   uint32_t b0 = b[0], b1 = b[1], b2 = b[2], b3 = b[3], b4 = b[4];
   b0 = (b0 << 24) + (b1 >> 8);
   b1 = (b1 << 24) + (b2 >> 8);
@@ -180,7 +180,7 @@ MMH_updateb3(MMH_CTX *ctx, unsigned char *ab)
 static inline void
 MMH_updatel1(MMH_CTX *ctx, unsigned char *ab)
 {
-  uint32_t *b = reinterpret_cast<uint32_t *>(ab - 1);
+  uint32_t *b = (uint32_t *)(ab - 1);
   uint32_t b0 = b[0], b1 = b[1], b2 = b[2], b3 = b[3], b4 = b[4];
   b0 = (b0 >> 8) + (b1 << 24);
   b1 = (b1 >> 8) + (b2 << 24);
@@ -196,7 +196,7 @@ MMH_updatel1(MMH_CTX *ctx, unsigned char *ab)
 static inline void
 MMH_updatel2(MMH_CTX *ctx, unsigned char *ab)
 {
-  uint32_t *b = reinterpret_cast<uint32_t *>(ab - 2);
+  uint32_t *b = (uint32_t *)(ab - 2);
   uint32_t b0 = b[0], b1 = b[1], b2 = b[2], b3 = b[3], b4 = b[4];
   b0 = (b0 >> 16) + (b1 << 16);
   b1 = (b1 >> 16) + (b2 << 16);
@@ -212,7 +212,7 @@ MMH_updatel2(MMH_CTX *ctx, unsigned char *ab)
 static inline void
 MMH_updatel3(MMH_CTX *ctx, unsigned char *ab)
 {
-  uint32_t *b = reinterpret_cast<uint32_t *>(ab - 3);
+  uint32_t *b = (uint32_t *)(ab - 3);
   uint32_t b0 = b[0], b1 = b[1], b2 = b[2], b3 = b[3], b4 = b[4];
   b0 = (b0 >> 24) + (b1 << 8);
   b1 = (b1 >> 24) + (b2 << 8);
@@ -246,7 +246,7 @@ ink_code_incr_MMH_update(MMH_CTX *ctx, const char *ainput, int input_length)
   }
   {
     // check alignment
-    int alignment = static_cast<int>((intptr_t)in & 0x3);
+    int alignment = (int)((intptr_t)in & 0x3);
     if (alignment) {
 #if defined(_BIG_ENDIAN)
 #define big_endian 1
@@ -254,7 +254,7 @@ ink_code_incr_MMH_update(MMH_CTX *ctx, const char *ainput, int input_length)
 #define big_endian 0
 #else
       unsigned int endian = 1;
-      int big_endian      = !*reinterpret_cast<char *>(&endian);
+      int big_endian      = !*(char *)&endian;
 #endif
       if (big_endian) {
         if (alignment == 1) {
@@ -301,11 +301,11 @@ ink_code_incr_MMH_update(MMH_CTX *ctx, const char *ainput, int input_length)
 Lstore:
   if (end - in) {
     int oldbs = ctx->buffer_size;
-    ctx->buffer_size += static_cast<int>(end - in);
+    ctx->buffer_size += (int)(end - in);
 #ifndef TEST
     ink_assert(ctx->buffer_size < 16);
 #endif
-    memcpy(ctx->buffer + oldbs, in, static_cast<int>(end - in));
+    memcpy(ctx->buffer + oldbs, in, (int)(end - in));
   }
   return 0;
 }
@@ -337,12 +337,12 @@ ink_code_incr_MMH_final(uint8_t *presult, MMH_CTX *ctx)
     MMH_update(ctx, ctx->buffer);
   }
   // append length (before padding)
-  unsigned int *pbuffer = reinterpret_cast<unsigned int *>(ctx->buffer);
+  unsigned int *pbuffer = (unsigned int *)ctx->buffer;
   pbuffer[1] = pbuffer[2] = pbuffer[3] = pbuffer[0] = len;
   MMH_update(ctx, ctx->buffer);
   // final phase
-  uint32_t *b = reinterpret_cast<uint32_t *>(presult);
-  uint64_t d  = ((static_cast<uint64_t>(1)) << 32) + 15;
+  uint32_t *b = (uint32_t *)presult;
+  uint64_t d  = (((uint64_t)1) << 32) + 15;
   uint32_t b0 = uint32_t(ctx->state[0] % d);
   uint32_t b1 = uint32_t(ctx->state[1] % d);
   uint32_t b2 = uint32_t(ctx->state[2] % d);

--- a/src/tscore/MatcherUtils.cc
+++ b/src/tscore/MatcherUtils.cc
@@ -84,7 +84,7 @@ readIntoBuffer(const char *file_path, const char *module_name, int *read_size_pt
   // Allocate a buffer large enough to hold the entire file
   //   File size should be small and this makes it easy to
   //   do two passes on the file
-  file_buf = static_cast<char *>(ats_malloc(file_size + 1));
+  file_buf = (char *)ats_malloc(file_size + 1);
   // Null terminate the buffer so that string operations will work
   file_buf[file_size] = '\0';
 
@@ -144,7 +144,7 @@ unescapifyStr(char *buffer)
     if (*read == '%' && *(read + 1) != '\0' && *(read + 2) != '\0') {
       subStr[0] = *(++read);
       subStr[1] = *(++read);
-      *write    = static_cast<char>(strtol(subStr, (char **)nullptr, 16));
+      *write    = (char)strtol(subStr, (char **)nullptr, 16);
       read++;
       write++;
     } else if (*read == '+') {

--- a/src/tscore/Regex.cc
+++ b/src/tscore/Regex.cc
@@ -30,7 +30,7 @@
 
 #ifdef PCRE_CONFIG_JIT
 struct RegexThreadKey {
-  RegexThreadKey() { ink_thread_key_create(&this->key, reinterpret_cast<void (*)(void *)>(&pcre_jit_stack_free)); }
+  RegexThreadKey() { ink_thread_key_create(&this->key, (void (*)(void *)) & pcre_jit_stack_free); }
   ink_thread_key key;
 };
 
@@ -41,7 +41,7 @@ get_jit_stack(void *data ATS_UNUSED)
 {
   pcre_jit_stack *jit_stack;
 
-  if ((jit_stack = static_cast<pcre_jit_stack *>(ink_thread_getspecific(k.key))) == nullptr) {
+  if ((jit_stack = (pcre_jit_stack *)ink_thread_getspecific(k.key)) == nullptr) {
     jit_stack = pcre_jit_stack_alloc(ats_pagesize(), 1024 * 1024); // 1 page min and 1MB max
     ink_thread_setspecific(k.key, (void *)jit_stack);
   }

--- a/src/tscore/Regression.cc
+++ b/src/tscore/Regression.cc
@@ -52,10 +52,10 @@ progname(const char *path)
 char *
 regression_status_string(int status)
 {
-  return const_cast<char *>(
-    status == REGRESSION_TEST_NOT_RUN ?
-      "NOT_RUN" :
-      (status == REGRESSION_TEST_PASSED ? "PASSED" : (status == REGRESSION_TEST_INPROGRESS ? "INPROGRESS" : "FAILED")));
+  return (
+    char *)(status == REGRESSION_TEST_NOT_RUN ?
+              "NOT_RUN" :
+              (status == REGRESSION_TEST_PASSED ? "PASSED" : (status == REGRESSION_TEST_INPROGRESS ? "INPROGRESS" : "FAILED")));
 }
 
 RegressionTest::RegressionTest(const char *_n, const SourceLocation &_l, TestFunction *_f, int _o)
@@ -83,7 +83,7 @@ start_test(RegressionTest *t, int regression_level)
   (*t->function)(t, regression_level, &t->status);
   int tresult = t->status;
   if (tresult != REGRESSION_TEST_INPROGRESS) {
-    fprintf(stderr, "    REGRESSION_RESULT %s:%*s %s\n", t->name, 40 - static_cast<int>(strlen(t->name)), " ",
+    fprintf(stderr, "    REGRESSION_RESULT %s:%*s %s\n", t->name, 40 - (int)strlen(t->name), " ",
             regression_status_string(tresult));
     t->printed = true;
   }
@@ -145,7 +145,7 @@ RegressionTest::run_some(int regression_level)
     if (current->status != REGRESSION_TEST_NOT_RUN) {
       if (!current->printed) {
         current->printed = true;
-        fprintf(stderr, "    REGRESSION_RESULT %s:%*s %s\n", current->name, 40 - static_cast<int>(strlen(current->name)), " ",
+        fprintf(stderr, "    REGRESSION_RESULT %s:%*s %s\n", current->name, 40 - (int)strlen(current->name), " ",
                 regression_status_string(current->status));
       }
       current = current->next;
@@ -184,7 +184,7 @@ check_test_list:
   while (t) {
     if ((t->status == REGRESSION_TEST_PASSED || t->status == REGRESSION_TEST_FAILED) && !t->printed) {
       t->printed = true;
-      fprintf(stderr, "    REGRESSION_RESULT %s:%*s %s\n", t->name, 40 - static_cast<int>(strlen(t->name)), " ",
+      fprintf(stderr, "    REGRESSION_RESULT %s:%*s %s\n", t->name, 40 - (int)strlen(t->name), " ",
               regression_status_string(t->status));
     }
 

--- a/src/tscore/TextBuffer.cc
+++ b/src/tscore/TextBuffer.cc
@@ -46,7 +46,7 @@ TextBuffer::TextBuffer(int size)
       size = 1024;
     }
 
-    bufferStart = static_cast<char *>(ats_malloc(size));
+    bufferStart = (char *)ats_malloc(size);
     nextAdd     = bufferStart;
     currentSize = size;
     spaceLeft   = size - 1; // Leave room for a terminator;
@@ -135,9 +135,9 @@ TextBuffer::enlargeBuffer(unsigned N)
 
     addedSize = newSize - currentSize;
 
-    newSpace = static_cast<char *>(ats_realloc(bufferStart, newSize));
+    newSpace = (char *)ats_realloc(bufferStart, newSize);
     if (newSpace != nullptr) {
-      nextAdd     = newSpace + static_cast<unsigned>(nextAdd - bufferStart);
+      nextAdd     = newSpace + (unsigned)(nextAdd - bufferStart);
       bufferStart = newSpace;
       spaceLeft += addedSize;
       currentSize = newSize;
@@ -245,7 +245,7 @@ TextBuffer::vformat(const char *fmt, va_list ap)
 
     va_end(args);
 
-    if (static_cast<unsigned>(num) < this->spaceLeft) {
+    if ((unsigned)num < this->spaceLeft) {
       // We had enough space to format including the NUL. Since the returned character
       // count does not include the NUL, we can just increment and the next format will
       // overwrite the previous NUL.

--- a/src/tscore/Tokenizer.cc
+++ b/src/tscore/Tokenizer.cc
@@ -42,7 +42,7 @@ Tokenizer::Tokenizer(const char *StrOfDelimiters)
   if (StrOfDelimiters == nullptr) {
     strOfDelimit = nullptr;
   } else {
-    length       = static_cast<int>(strlen(StrOfDelimiters) + 1);
+    length       = (int)(strlen(StrOfDelimiters) + 1);
     strOfDelimit = new char[length];
     memcpy(strOfDelimit, StrOfDelimiters, length);
   }
@@ -89,7 +89,7 @@ Tokenizer::~Tokenizer()
 unsigned
 Tokenizer::Initialize(const char *str)
 {
-  return Initialize(const_cast<char *>(str), COPY_TOKS);
+  return Initialize((char *)str, COPY_TOKS);
 }
 
 inline int
@@ -163,7 +163,7 @@ Tokenizer::Initialize(char *str, unsigned opt)
     //          to skip past repeated delimiters
     if (options & ALLOW_EMPTY_TOKS) {
       if (isDelimiter(*str)) {
-        addToken(tokStart, static_cast<int>(str - tokStart));
+        addToken(tokStart, (int)(str - tokStart));
         tok_count++;
         tokStart            = str + 1;
         priorCharWasDelimit = 1;
@@ -175,7 +175,7 @@ Tokenizer::Initialize(char *str, unsigned opt)
       if (isDelimiter(*str)) {
         if (priorCharWasDelimit == 0) {
           // This is a word end, so add it
-          addToken(tokStart, static_cast<int>(str - tokStart));
+          addToken(tokStart, (int)(str - tokStart));
           tok_count++;
         }
         priorCharWasDelimit = 1;
@@ -236,7 +236,7 @@ Tokenizer::Initialize(char *str, unsigned opt)
   //  only have gotten it if the string ended with a delimiter
   if (priorCharWasDelimit == 0) {
     // We did not get it
-    addToken(tokStart, static_cast<int>(str - tokStart));
+    addToken(tokStart, (int)(str - tokStart));
     tok_count++;
   }
 
@@ -252,7 +252,7 @@ Tokenizer::addToken(char *startAddr, int length)
     startAddr[length] = '\0';
     add_ptr           = startAddr;
   } else {
-    add_ptr = static_cast<char *>(ats_malloc(length + 1));
+    add_ptr = (char *)ats_malloc(length + 1);
     memcpy(add_ptr, startAddr, length);
     add_ptr[length] = '\0';
   }
@@ -267,7 +267,7 @@ Tokenizer::addToken(char *startAddr, int length)
   //   if there is not a next one
   if (add_index >= TOK_NODE_ELEMENTS) {
     if (add_node->next == nullptr) {
-      add_node->next = static_cast<tok_node *>(ats_malloc(sizeof(tok_node)));
+      add_node->next = (tok_node *)ats_malloc(sizeof(tok_node));
       memset(add_node->next, 0, sizeof(tok_node));
     }
     add_node  = add_node->next;

--- a/src/tscore/X509HostnameValidator.cc
+++ b/src/tscore/X509HostnameValidator.cc
@@ -179,7 +179,7 @@ equal_wildcard(const unsigned char *pattern, size_t pattern_len, const unsigned 
 {
   const unsigned char *wildcard = nullptr;
 
-  bool is_idna = (subject_len > 4 && strncasecmp(reinterpret_cast<const char *>(subject), "xn--", 4) == 0);
+  bool is_idna = (subject_len > 4 && strncasecmp((const char *)(subject), "xn--", 4) == 0);
   /*
    * Subject names starting with '.' can only match a wildcard pattern
    * via a subject sub-domain pattern suffix match (that we don't allow).
@@ -236,7 +236,7 @@ validate_hostname(X509 *x, const unsigned char *hostname, bool is_ip, char **pee
   }
 
   // Check SANs for a match.
-  gens = static_cast<GENERAL_NAMES *>(X509_get_ext_d2i(x, NID_subject_alt_name, nullptr, nullptr));
+  gens = (GENERAL_NAMES *)X509_get_ext_d2i(x, NID_subject_alt_name, nullptr, nullptr);
   if (gens) {
     // BoringSSL has sk_GENERAL_NAME_num() return size_t.
     for (i = 0; i < static_cast<int>(sk_GENERAL_NAME_num(gens)); i++) {

--- a/src/tscore/ink_args.cc
+++ b/src/tscore/ink_args.cc
@@ -85,9 +85,9 @@ process_arg(const AppVersionInfo *appinfo, const ArgumentDescription *argument_d
   if (argument_descriptions[i].type) {
     char type = argument_descriptions[i].type[0];
     if (type == 'F' || type == 'f') {
-      *static_cast<int *>(argument_descriptions[i].location) = type == 'F' ? 1 : 0;
+      *(int *)argument_descriptions[i].location = type == 'F' ? 1 : 0;
     } else if (type == 'T') {
-      *static_cast<int *>(argument_descriptions[i].location) = !*static_cast<int *>(argument_descriptions[i].location);
+      *(int *)argument_descriptions[i].location = !*(int *)argument_descriptions[i].location;
     } else {
       arg = *++(**argv) ? **argv : *++(*argv);
       if (!arg) {
@@ -95,20 +95,20 @@ process_arg(const AppVersionInfo *appinfo, const ArgumentDescription *argument_d
       }
       switch (type) {
       case 'I':
-        *static_cast<int *>(argument_descriptions[i].location) = atoi(arg);
+        *(int *)argument_descriptions[i].location = atoi(arg);
         break;
       case 'D':
-        *static_cast<double *>(argument_descriptions[i].location) = atof(arg);
+        *(double *)argument_descriptions[i].location = atof(arg);
         break;
       case 'L':
-        *static_cast<int64_t *>(argument_descriptions[i].location) = ink_atoi64(arg);
+        *(int64_t *)argument_descriptions[i].location = ink_atoi64(arg);
         break;
       case 'S':
         if (argument_descriptions[i].type[1] == '*') {
-          char **out = static_cast<char **>(argument_descriptions[i].location);
+          char **out = (char **)argument_descriptions[i].location;
           *out       = ats_strdup(arg);
         } else {
-          ink_strlcpy(static_cast<char *>(argument_descriptions[i].location), arg, atoi(argument_descriptions[i].type + 1));
+          ink_strlcpy((char *)argument_descriptions[i].location, arg, atoi(argument_descriptions[i].type + 1));
         }
         break;
       default:
@@ -137,19 +137,19 @@ show_argument_configuration(const ArgumentDescription *argument_descriptions, un
       case 'F':
       case 'f':
       case 'T':
-        printf(*static_cast<int *>(argument_descriptions[i].location) ? "TRUE" : "FALSE");
+        printf(*(int *)argument_descriptions[i].location ? "TRUE" : "FALSE");
         break;
       case 'I':
-        printf("%d", *static_cast<int *>(argument_descriptions[i].location));
+        printf("%d", *(int *)argument_descriptions[i].location);
         break;
       case 'D':
-        printf("%f", *static_cast<double *>(argument_descriptions[i].location));
+        printf("%f", *(double *)argument_descriptions[i].location);
         break;
       case 'L':
-        printf("%" PRId64 "", *static_cast<int64_t *>(argument_descriptions[i].location));
+        printf("%" PRId64 "", *(int64_t *)argument_descriptions[i].location);
         break;
       case 'S':
-        printf("%s", static_cast<char *>(argument_descriptions[i].location));
+        printf("%s", (char *)argument_descriptions[i].location);
         break;
       default:
         ink_fatal("bad argument description");
@@ -188,16 +188,16 @@ process_args_ex(const AppVersionInfo *appinfo, const ArgumentDescription *argume
       case 'f':
       case 'F':
       case 'I':
-        *static_cast<int *>(argument_descriptions[i].location) = atoi(env);
+        *(int *)argument_descriptions[i].location = atoi(env);
         break;
       case 'D':
-        *static_cast<double *>(argument_descriptions[i].location) = atof(env);
+        *(double *)argument_descriptions[i].location = atof(env);
         break;
       case 'L':
-        *static_cast<int64_t *>(argument_descriptions[i].location) = atoll(env);
+        *(int64_t *)argument_descriptions[i].location = atoll(env);
         break;
       case 'S':
-        ink_strlcpy(static_cast<char *>(argument_descriptions[i].location), env, atoi(argument_descriptions[i].type + 1));
+        ink_strlcpy((char *)argument_descriptions[i].location, env, atoi(argument_descriptions[i].type + 1));
         break;
       }
     }
@@ -302,14 +302,14 @@ usage(const ArgumentDescription *argument_descriptions, unsigned n_argument_desc
       fprintf(stderr, "          ");
       break;
     case 'L':
-      fprintf(stderr, " %-9" PRId64 "", *static_cast<int64_t *>(argument_descriptions[i].location));
+      fprintf(stderr, " %-9" PRId64 "", *(int64_t *)argument_descriptions[i].location);
       break;
     case 'S': {
       char *location;
       if (argument_descriptions[i].type[1] == '*') {
-        location = *static_cast<char **>(argument_descriptions[i].location);
+        location = *(char **)argument_descriptions[i].location;
       } else {
-        location = static_cast<char *>(argument_descriptions[i].location);
+        location = (char *)argument_descriptions[i].location;
       }
 
       if (location) {
@@ -324,16 +324,16 @@ usage(const ArgumentDescription *argument_descriptions, unsigned n_argument_desc
       break;
     }
     case 'D':
-      fprintf(stderr, " %-9.3f", *static_cast<double *>(argument_descriptions[i].location));
+      fprintf(stderr, " %-9.3f", *(double *)argument_descriptions[i].location);
       break;
     case 'I':
-      fprintf(stderr, " %-9d", *static_cast<int *>(argument_descriptions[i].location));
+      fprintf(stderr, " %-9d", *(int *)argument_descriptions[i].location);
       break;
     case 'T':
     case 'f':
     case 'F':
       if (argument_descriptions[i].location) {
-        fprintf(stderr, " %-9s", *static_cast<int *>(argument_descriptions[i].location) ? "true " : "false");
+        fprintf(stderr, " %-9s", *(int *)argument_descriptions[i].location ? "true " : "false");
       } else {
         fprintf(stderr, " %-9s", "false");
       }

--- a/src/tscore/ink_base64.cc
+++ b/src/tscore/ink_base64.cc
@@ -97,7 +97,7 @@ ats_base64_encode(const unsigned char *inBuffer, size_t inBufferSize, char *outB
 bool
 ats_base64_encode(const char *inBuffer, size_t inBufferSize, char *outBuffer, size_t outBufSize, size_t *length)
 {
-  return ats_base64_encode(reinterpret_cast<const unsigned char *>(inBuffer), inBufferSize, outBuffer, outBufSize, length);
+  return ats_base64_encode((const unsigned char *)inBuffer, inBufferSize, outBuffer, outBufSize, length);
 }
 
 /*-------------------------------------------------------------------------
@@ -136,14 +136,14 @@ ats_base64_decode(const char *inBuffer, size_t inBufferSize, unsigned char *outB
 
   // Ignore any trailing ='s or other undecodable characters.
   // TODO: Perhaps that ought to be an error instead?
-  while (printableToSixBit[static_cast<uint8_t>(inBuffer[inBytes])] <= MAX_PRINT_VAL) {
+  while (printableToSixBit[(uint8_t)inBuffer[inBytes]] <= MAX_PRINT_VAL) {
     ++inBytes;
   }
 
   for (size_t i = 0; i < inBytes; i += 4) {
-    buf[0] = static_cast<unsigned char>(DECODE(inBuffer[0]) << 2 | DECODE(inBuffer[1]) >> 4);
-    buf[1] = static_cast<unsigned char>(DECODE(inBuffer[1]) << 4 | DECODE(inBuffer[2]) >> 2);
-    buf[2] = static_cast<unsigned char>(DECODE(inBuffer[2]) << 6 | DECODE(inBuffer[3]));
+    buf[0] = (unsigned char)(DECODE(inBuffer[0]) << 2 | DECODE(inBuffer[1]) >> 4);
+    buf[1] = (unsigned char)(DECODE(inBuffer[1]) << 4 | DECODE(inBuffer[2]) >> 2);
+    buf[2] = (unsigned char)(DECODE(inBuffer[2]) << 6 | DECODE(inBuffer[3]));
 
     buf += 3;
     inBuffer += 4;

--- a/src/tscore/ink_cap.cc
+++ b/src/tscore/ink_cap.cc
@@ -108,7 +108,7 @@ max_passwd_size()
 #if defined(_SC_GETPW_R_SIZE_MAX)
   long val = sysconf(_SC_GETPW_R_SIZE_MAX);
   if (val > 0) {
-    return static_cast<unsigned>(val);
+    return (unsigned)val;
   }
 #endif
 
@@ -225,7 +225,7 @@ ImpersonateUser(const char *user, ImpersonationLevel level)
 
   if (*user == '#') {
     // Numeric user notation.
-    uid_t uid = static_cast<uid_t>(atoi(&user[1]));
+    uid_t uid = (uid_t)atoi(&user[1]);
     if (getpwuid_r(uid, &pbuf, buf, sizeof(buf), &pwd) != 0) {
       Fatal("missing password database entry for UID %ld: %s", (long)uid, strerror(errno));
     }

--- a/src/tscore/ink_code.cc
+++ b/src/tscore/ink_code.cc
@@ -72,7 +72,7 @@ ink_code_incr_md5_update(INK_DIGEST_CTX *context, const char *input, int input_l
 int
 ink_code_incr_md5_final(char *sixteen_byte_hash_pointer, INK_DIGEST_CTX *context)
 {
-  return MD5_Final(reinterpret_cast<unsigned char *>(sixteen_byte_hash_pointer), context);
+  return MD5_Final((unsigned char *)sixteen_byte_hash_pointer, context);
 }
 
 /**

--- a/src/tscore/ink_file.cc
+++ b/src/tscore/ink_file.cc
@@ -129,7 +129,7 @@ ink_file_fd_writestring(int fd, const char *buf)
 {
   int len, i = 0;
 
-  if (buf && (len = strlen(buf)) > 0 && (i = static_cast<int>(write(fd, buf, static_cast<size_t>(len))) != len)) {
+  if (buf && (len = strlen(buf)) > 0 && (i = (int)write(fd, buf, (size_t)len) != len)) {
     i = -1;
   }
 
@@ -199,7 +199,7 @@ ink_filepath_merge(char *path, int pathsz, const char *rootpath, const char *add
   maxlen  = rootlen + strlen(addpath) + 4; // 4 for slashes at start, after
                                            // root, and at end, plus trailing
                                            // null
-  if (maxlen > static_cast<size_t>(pathsz)) {
+  if (maxlen > (size_t)pathsz) {
     return E2BIG; // APR_ENAMETOOLONG;
   }
   if (addpath[0] == '/') {
@@ -360,9 +360,9 @@ ink_filepath_make(char *path, int pathsz, const char *rootpath, const char *addp
   }
   rootlen = strlen(rootpath);
   maxlen  = strlen(addpath) + 2;
-  if (maxlen > static_cast<size_t>(pathsz)) {
+  if (maxlen > (size_t)pathsz) {
     *path = '\0';
-    return static_cast<int>(maxlen);
+    return (int)maxlen;
   }
   ink_strlcpy(path, rootpath, pathsz);
   path += rootlen;
@@ -531,7 +531,7 @@ ink_fileperm_parse(const char *perms)
 {
   if (perms && strlen(perms) == 9) {
     int re  = 0;
-    char *c = const_cast<char *>(perms);
+    char *c = (char *)perms;
     if (*c == 'r') {
       re |= S_IRUSR;
     }

--- a/src/tscore/ink_hrtime.cc
+++ b/src/tscore/ink_hrtime.cc
@@ -66,11 +66,11 @@ int64_to_str(char *buf, unsigned int buf_size, int64_t val, unsigned int *total_
   }
 
   if (val < 10) {
-    *out_buf-- = '0' + static_cast<char>(val);
+    *out_buf-- = '0' + (char)val;
     ++num_chars;
   } else {
     do {
-      *out_buf-- = static_cast<char>(val % 10) + '0';
+      *out_buf-- = (char)(val % 10) + '0';
       val /= 10;
       ++num_chars;
     } while (val);
@@ -169,7 +169,7 @@ squid_timestamp_to_buf(char *buf, unsigned int buf_size, long timestamp_sec, lon
     memcpy(buf, ts_s, chars_to_write);
     res = chars_to_write;
   } else {
-    res = -(static_cast<int>(chars_to_write));
+    res = -((int)chars_to_write);
   }
 
   return res;

--- a/src/tscore/ink_inet.cc
+++ b/src/tscore/ink_inet.cc
@@ -389,7 +389,7 @@ ats_ip_port_hash(sockaddr const *addr)
     CryptoContext hash_context;
     hash_context.update(const_cast<uint8_t *>(ats_ip_addr8_cast(addr)), TS_IP6_SIZE);
     in_port_t port = ats_ip_port_cast(addr);
-    hash_context.update(reinterpret_cast<uint8_t *>(&port), sizeof(port));
+    hash_context.update((uint8_t *)(&port), sizeof(port));
     hash_context.finalize(hash);
     return hash.u64[0];
   } else {

--- a/src/tscore/ink_memory.cc
+++ b/src/tscore/ink_memory.cc
@@ -265,7 +265,7 @@ _xstrdup(const char *str, int length, const char * /* path ATS_UNUSED */)
       length = strlen(str);
     }
 
-    newstr = static_cast<char *>(ats_malloc(length + 1));
+    newstr = (char *)ats_malloc(length + 1);
     // If this is a zero length string just null terminate and return.
     if (unlikely(length == 0)) {
       *newstr = '\0';

--- a/src/tscore/ink_queue_utils.cc
+++ b/src/tscore/ink_queue_utils.cc
@@ -75,6 +75,6 @@ ink_queue_load_64(void *dst, void *src)
   (*(head_p *)dst).s.version = src_version;
   (*(head_p *)dst).s.pointer = src_pointer;
 #else
-  *static_cast<void **>(dst) = *static_cast<void **>(src);
+  *(void **)dst = *(void **)src;
 #endif
 }

--- a/src/tscore/ink_rand.cc
+++ b/src/tscore/ink_rand.cc
@@ -88,14 +88,14 @@ InkRand::random()
   if (mti >= NN) { /* generate NN words at one time */
     for (i = 0; i < NN - MM; i++) {
       x     = (mt[i] & UM) | (mt[i + 1] & LM);
-      mt[i] = mt[i + MM] ^ (x >> 1) ^ mag01[static_cast<int>(x & 1ULL)];
+      mt[i] = mt[i + MM] ^ (x >> 1) ^ mag01[(int)(x & 1ULL)];
     }
     for (; i < NN - 1; i++) {
       x     = (mt[i] & UM) | (mt[i + 1] & LM);
-      mt[i] = mt[i + (MM - NN)] ^ (x >> 1) ^ mag01[static_cast<int>(x & 1ULL)];
+      mt[i] = mt[i + (MM - NN)] ^ (x >> 1) ^ mag01[(int)(x & 1ULL)];
     }
     x          = (mt[NN - 1] & UM) | (mt[0] & LM);
-    mt[NN - 1] = mt[MM - 1] ^ (x >> 1) ^ mag01[static_cast<int>(x & 1ULL)];
+    mt[NN - 1] = mt[MM - 1] ^ (x >> 1) ^ mag01[(int)(x & 1ULL)];
 
     mti = 0;
   }

--- a/src/tscore/ink_res_mkquery.cc
+++ b/src/tscore/ink_res_mkquery.cc
@@ -109,7 +109,7 @@ int ink_res_mkquery(ink_res_state statp, int op,               /*!< opcode of qu
     return (-1);
   }
   memset(buf, 0, HFIXEDSZ);
-  hp         = reinterpret_cast<HEADER *>(buf);
+  hp         = (HEADER *)buf;
   hp->id     = htons(++statp->id);
   hp->opcode = op;
   hp->rd     = (statp->options & INK_RES_RECURSE) != 0U;
@@ -145,7 +145,7 @@ int ink_res_mkquery(ink_res_state statp, int op,               /*!< opcode of qu
     if ((ep - cp) < RRFIXEDSZ) {
       return (-1);
     }
-    n = dn_comp(reinterpret_cast<const char *>(data), cp, ep - cp - RRFIXEDSZ, dnptrs, lastdnptr);
+    n = dn_comp((const char *)data, cp, ep - cp - RRFIXEDSZ, dnptrs, lastdnptr);
     if (n < 0) {
       return (-1);
     }
@@ -369,7 +369,7 @@ ink_ns_name_ntop(const u_char *src, char *dst, size_t dstsiz)
           return (-1);
         }
         *dn++ = '\\';
-        *dn++ = static_cast<char>(c);
+        *dn++ = (char)c;
       } else if (!printable(c)) {
         if (dn + 3 >= eom) {
           errno = EMSGSIZE;
@@ -384,7 +384,7 @@ ink_ns_name_ntop(const u_char *src, char *dst, size_t dstsiz)
           errno = EMSGSIZE;
           return (-1);
         }
-        *dn++ = static_cast<char>(c);
+        *dn++ = (char)c;
       }
     }
   }
@@ -475,7 +475,7 @@ ns_name_ntop(const u_char *src, char *dst, size_t dstsiz)
           return (-1);
         }
         *dn++ = '\\';
-        *dn++ = static_cast<char>(c);
+        *dn++ = (char)c;
       } else if (!printable(c)) {
         if (dn + 3 >= eom) {
           errno = EMSGSIZE;
@@ -490,7 +490,7 @@ ns_name_ntop(const u_char *src, char *dst, size_t dstsiz)
           errno = EMSGSIZE;
           return (-1);
         }
-        *dn++ = static_cast<char>(c);
+        *dn++ = (char)c;
       }
     }
   }

--- a/src/tscore/ink_resource.cc
+++ b/src/tscore/ink_resource.cc
@@ -118,7 +118,7 @@ ResourceTracker::increment(const char *name, const int64_t size)
 void
 ResourceTracker::increment(const void *symbol, const int64_t size, const char *name)
 {
-  Resource &resource = lookup(static_cast<const char *>(symbol));
+  Resource &resource = lookup((const char *)symbol);
   if (resource.getSymbol() == nullptr && name != nullptr) {
     resource.setName(symbol, name);
     resource.setSymbol(symbol);

--- a/src/tscore/ink_sock.cc
+++ b/src/tscore/ink_sock.cc
@@ -72,7 +72,7 @@ safe_getsockopt(int s, int level, int optname, char *optval, int *optlevel)
 {
   int r;
   do {
-    r = getsockopt(s, level, optname, optval, reinterpret_cast<socklen_t *>(optlevel));
+    r = getsockopt(s, level, optname, optval, (socklen_t *)optlevel);
   } while (r < 0 && (errno == EAGAIN || errno == EINTR));
   return r;
 }
@@ -197,7 +197,7 @@ safe_getsockname(int s, struct sockaddr *name, int *namelen)
 {
   int r;
   do {
-    r = getsockname(s, name, reinterpret_cast<socklen_t *>(namelen));
+    r = getsockname(s, name, (socklen_t *)namelen);
   } while (r < 0 && (errno == EAGAIN || errno == EINTR));
   return r;
 }
@@ -207,7 +207,7 @@ safe_getpeername(int s, struct sockaddr *name, int *namelen)
 {
   int r;
   do {
-    r = getpeername(s, name, reinterpret_cast<socklen_t *>(namelen));
+    r = getpeername(s, name, (socklen_t *)namelen);
   } while (r < 0 && (errno == EAGAIN || errno == EINTR));
   return r;
 }
@@ -312,7 +312,7 @@ bind_unix_domain_socket(const char *path, mode_t mode)
     goto fail;
   }
 
-  if (bind(sockfd, reinterpret_cast<struct sockaddr *>(&sockaddr), socklen) < 0) {
+  if (bind(sockfd, (struct sockaddr *)&sockaddr, socklen) < 0) {
     goto fail;
   }
 

--- a/src/tscore/ink_sprintf.cc
+++ b/src/tscore/ink_sprintf.cc
@@ -154,5 +154,5 @@ ink_bvsprintf(char *buffer, const char *format, va_list ap)
   ++d;
 
   va_end(ap_local);
-  return static_cast<int>(d - buffer);
+  return (int)(d - buffer);
 }

--- a/src/tscore/ink_string++.cc
+++ b/src/tscore/ink_string++.cc
@@ -69,18 +69,18 @@ StrList::_new_cell(const char *s, int len_not_counting_nul)
   if (cells_allocated < STRLIST_BASE_CELLS) {
     cell = &(base_cells[cells_allocated]);
   } else {
-    p = static_cast<char *>(alloc(sizeof(Str) + 7));
+    p = (char *)alloc(sizeof(Str) + 7);
     if (p == nullptr) {
       return (nullptr); // FIX: scale heap
     }
     p    = (char *)((((uintptr_t)p) + 7) & ~7); // round up to multiple of 8
-    cell = reinterpret_cast<Str *>(p);
+    cell = (Str *)p;
   }
   ++cells_allocated;
 
   // are we supposed to copy the string?
   if (copy_when_adding_string) {
-    char *buf = static_cast<char *>(alloc(l + 1));
+    char *buf = (char *)alloc(l + 1);
     if (buf == nullptr) {
       return (nullptr); // FIX: need to grow heap!
     }
@@ -162,7 +162,7 @@ StrListOverflow::alloc(int size, StrListOverflow **new_heap_ptr)
     return next->alloc(size, new_heap_ptr);
   }
 
-  char *start = (reinterpret_cast<char *>(this)) + overflow_head_hdr_size;
+  char *start = ((char *)this) + overflow_head_hdr_size;
   char *rval  = start + heap_used;
   heap_used += size;
   ink_assert(heap_used <= heap_size);
@@ -180,7 +180,7 @@ StrListOverflow::create_heap(int user_size)
   //  aren't aligned, again mirroring the previous implementation
   int total_size = overflow_head_hdr_size + user_size;
 
-  StrListOverflow *o = static_cast<StrListOverflow *>(ats_malloc(total_size));
+  StrListOverflow *o = (StrListOverflow *)ats_malloc(total_size);
   o->init();
   o->heap_size = user_size;
 

--- a/src/tscore/ink_string.cc
+++ b/src/tscore/ink_string.cc
@@ -35,7 +35,7 @@ char *
 ink_memcpy_until_char(char *dst, char *src, unsigned int n, unsigned char c)
 {
   unsigned int i = 0;
-  for (; ((i < n) && ((static_cast<unsigned char>(src[i])) != c)); i++) {
+  for (; ((i < n) && (((unsigned char)src[i]) != c)); i++) {
     dst[i] = src[i];
   }
   return &src[i];

--- a/src/tscore/ink_time.cc
+++ b/src/tscore/ink_time.cc
@@ -88,7 +88,7 @@ ink_time_wall_seconds()
   struct timeval s_val;
 
   gettimeofday(&s_val, nullptr);
-  return (static_cast<double>(s_val.tv_sec) + 0.000001 * s_val.tv_usec);
+  return ((double)s_val.tv_sec + 0.000001 * s_val.tv_usec);
 } /* End ink_time_wall_seconds */
 
 struct dtconv {
@@ -150,7 +150,7 @@ convert_tm(const struct tm *tp)
 
   /* what should we do? */
   if ((year < 70) || (year > 137)) {
-    return static_cast<ink_time_t> UNDEFINED_TIME;
+    return (ink_time_t)UNDEFINED_TIME;
   }
 
   mday += days[month];

--- a/src/tscore/ink_uuid.cc
+++ b/src/tscore/ink_uuid.cc
@@ -41,8 +41,8 @@ ATSUuid::initialize(TSUuidVersion v)
     break;
   case TS_UUID_V4:
     RAND_bytes(_uuid.data, sizeof(_uuid.data));
-    _uuid.clockSeqAndReserved = static_cast<uint8_t>((_uuid.clockSeqAndReserved & 0x3F) | 0x80);
-    _uuid.timeHighAndVersion  = static_cast<uint16_t>((_uuid.timeHighAndVersion & 0x0FFF) | 0x4000);
+    _uuid.clockSeqAndReserved = (uint8_t)((_uuid.clockSeqAndReserved & 0x3F) | 0x80);
+    _uuid.timeHighAndVersion  = (uint16_t)((_uuid.timeHighAndVersion & 0x0FFF) | 0x4000);
 
     break;
   }

--- a/src/tscore/llqueue.cc
+++ b/src/tscore/llqueue.cc
@@ -73,7 +73,7 @@ freerec(LLQ *Q, LLQrec *rec)
 LLQ *
 create_queue()
 {
-  LLQ *new_val = static_cast<LLQ *>(ats_malloc(sizeof(LLQ)));
+  LLQ *new_val = (LLQ *)ats_malloc(sizeof(LLQ));
 
   ink_sem_init(&(new_val->sema), 0);
   ink_mutex_init(&(new_val->mux));
@@ -104,7 +104,7 @@ enqueue(LLQ *Q, void *data)
   LLQrec *new_val;
 
   ink_mutex_acquire(&(Q->mux));
-  new_val       = static_cast<LLQrec *>(ats_malloc(sizeof(LLQrec)));
+  new_val       = (LLQrec *)ats_malloc(sizeof(LLQrec));
   new_val->data = data;
   new_val->next = nullptr;
 

--- a/src/tscore/lockfile.cc
+++ b/src/tscore/lockfile.cc
@@ -91,7 +91,7 @@ Lockfile::Open(pid_t *holding_pid)
     *t = '\0';
 
     // coverity[secure_coding]
-    if (sscanf(buf, "%d\n", static_cast<int *>(&val)) != 1) {
+    if (sscanf(buf, "%d\n", (int *)&val) != 1) {
       *holding_pid = 0;
     } else {
       *holding_pid = val;
@@ -154,13 +154,13 @@ Lockfile::Get(pid_t *holding_pid)
     return (-errno);
   }
   // Write our process id to the Lockfile.
-  snprintf(buf, sizeof(buf), "%d\n", static_cast<int>(getpid()));
+  snprintf(buf, sizeof(buf), "%d\n", (int)getpid());
 
   do {
     err = write(fd, buf, strlen(buf));
   } while ((err < 0) && (errno == EINTR));
 
-  if (err != static_cast<int>(strlen(buf))) {
+  if (err != (int)strlen(buf)) {
     close(fd);
     return (-errno);
   }

--- a/src/tscore/signals.cc
+++ b/src/tscore/signals.cc
@@ -40,13 +40,13 @@ signal_check_handler(int signal, signal_handler_t handler)
   void *sigact;
 
   ink_release_assert(sigaction(signal, nullptr, &oact) == 0);
-  if (handler == reinterpret_cast<signal_handler_t>(SIG_DFL) || handler == reinterpret_cast<signal_handler_t>(SIG_IGN)) {
-    sigact = reinterpret_cast<void *>(oact.sa_handler);
+  if (handler == (signal_handler_t)SIG_DFL || handler == (signal_handler_t)SIG_IGN) {
+    sigact = (void *)oact.sa_handler;
   } else {
-    sigact = reinterpret_cast<void *>(oact.sa_sigaction);
+    sigact = (void *)oact.sa_sigaction;
   }
 
-  if (sigact != reinterpret_cast<void *>(handler)) {
+  if (sigact != (void *)handler) {
     Warning("handler for signal %d was %p, not %p as expected", signal, sigact, handler);
     return false;
   }
@@ -63,7 +63,7 @@ signal_check_handler(int signal, signal_handler_t handler)
 void
 check_signals(signal_handler_t handler)
 {
-  signal_check_handler(SIGPIPE, reinterpret_cast<signal_handler_t>(SIG_IGN));
+  signal_check_handler(SIGPIPE, (signal_handler_t)SIG_IGN);
   signal_check_handler(SIGQUIT, handler);
   signal_check_handler(SIGHUP, handler);
   signal_check_handler(SIGTERM, handler);
@@ -105,7 +105,7 @@ signal_reset_default(int signo)
 static void *
 check_signal_thread(void *ptr)
 {
-  signal_handler_t handler = reinterpret_cast<signal_handler_t>(ptr);
+  signal_handler_t handler = (signal_handler_t)ptr;
   for (;;) {
     check_signals(handler);
     sleep(2);
@@ -116,7 +116,7 @@ check_signal_thread(void *ptr)
 void
 signal_start_check_thread(signal_handler_t handler)
 {
-  ink_thread_create(nullptr, check_signal_thread, reinterpret_cast<void *>(handler), 0, 0, nullptr);
+  ink_thread_create(nullptr, check_signal_thread, (void *)handler, 0, 0, nullptr);
 }
 
 bool

--- a/src/tscore/test_atomic.cc
+++ b/src/tscore/test_atomic.cc
@@ -42,7 +42,7 @@ int al_done = 0;
 void *
 testalist(void *ame)
 {
-  int me = static_cast<int>((uintptr_t)ame);
+  int me = (int)(uintptr_t)ame;
   int j, k;
   for (k = 0; k < MAX_ALIST_ARRAY; k++) {
     ink_atomiclist_push(&al[k % MAX_ALIST_TEST], &al_test[me][k]);
@@ -53,7 +53,7 @@ testalist(void *ame)
       ink_atomiclist_push(&al[rand() % MAX_ALIST_TEST], x);
     }
   }
-  ink_atomic_increment(&al_done, 1);
+  ink_atomic_increment((int *)&al_done, 1);
   return nullptr;
 }
 #endif // !LONG_ATOMICLIST_TEST
@@ -147,7 +147,7 @@ main(int /* argc ATS_UNUSED */, const char * /* argv ATS_UNUSED */ [])
   const char *m2 = "hello";
   char *n2;
 
-  printf("sizeof(int32_t)==%d   sizeof(void *)==%d\n", static_cast<int>(sizeof(int32_t)), static_cast<int>(sizeof(void *)));
+  printf("sizeof(int32_t)==%d   sizeof(void *)==%d\n", (int)sizeof(int32_t), (int)sizeof(void *));
 
   printf("CAS: %d == 1  then  2\n", m);
   n = ink_atomic_cas(&m, 1, 2);
@@ -167,18 +167,18 @@ main(int /* argc ATS_UNUSED */, const char * /* argv ATS_UNUSED */ [])
 
   n = 100;
   printf("Atomic Inc of %d\n", n);
-  m = ink_atomic_increment(static_cast<int *>(&n), 1);
+  m = ink_atomic_increment((int *)&n, 1);
   printf("changed to: %d,  result=%d\n", n, m);
 
   printf("Atomic Fetch-and-Add 2 to pointer to '%s'\n", m2);
-  n2 = static_cast<char *>(ink_atomic_increment((void **)&m2, (void *)2));
+  n2 = (char *)ink_atomic_increment((void **)&m2, (void *)2);
   printf("changed to: %s,  result=%s\n", m2, n2);
 
   printf("Testing atomic lists\n");
   {
     int ali;
     srand(time(nullptr));
-    printf("sizeof(al_test) = %d\n", static_cast<int>(sizeof(al_test)));
+    printf("sizeof(al_test) = %d\n", (int)sizeof(al_test));
     memset(&al_test[0][0], 0, sizeof(al_test));
     for (ali = 0; ali < MAX_ALIST_TEST; ali++) {
       ink_atomiclist_init(&al[ali], "foo", 0);

--- a/src/tscore/test_freelist.cc
+++ b/src/tscore/test_freelist.cc
@@ -45,8 +45,8 @@ test(void *d)
     m3 = ink_freelist_new(flist);
 
     if ((m1 == m2) || (m1 == m3) || (m2 == m3)) {
-      printf("0x%08" PRIx64 "   0x%08" PRIx64 "   0x%08" PRIx64 "\n", static_cast<uint64_t>((uintptr_t)m1),
-             static_cast<uint64_t>((uintptr_t)m2), static_cast<uint64_t>((uintptr_t)m3));
+      printf("0x%08" PRIx64 "   0x%08" PRIx64 "   0x%08" PRIx64 "\n", (uint64_t)(uintptr_t)m1, (uint64_t)(uintptr_t)m2,
+             (uint64_t)(uintptr_t)m3);
       exit(1);
     }
 
@@ -74,7 +74,7 @@ main(int /* argc ATS_UNUSED */, char * /*argv ATS_UNUSED */ [])
 
   for (i = 0; i < NTHREADS; i++) {
     fprintf(stderr, "Create thread %d\n", i);
-    ink_thread_create(nullptr, test, (void *)(static_cast<intptr_t>(i)), 0, 0, nullptr);
+    ink_thread_create(nullptr, test, (void *)((intptr_t)i), 0, 0, nullptr);
   }
 
   test((void *)NTHREADS);

--- a/src/tscpp/api/Transaction.cc
+++ b/src/tscpp/api/Transaction.cc
@@ -182,7 +182,7 @@ void
 Transaction::setErrorBody(const std::string &page)
 {
   LOG_DEBUG("Transaction tshttptxn=%p setting error body page length: %lu", state_->txn_, page.length());
-  char *body = static_cast<char *>(TSmalloc(page.length()));
+  char *body = (char *)TSmalloc(page.length());
   memcpy(body, page.data(), page.length());
   TSHttpTxnErrorBodySet(state_->txn_, body, page.length(), nullptr); // Default to text/html
 }
@@ -191,7 +191,7 @@ void
 Transaction::setErrorBody(const std::string &page, const std::string &mimetype)
 {
   LOG_DEBUG("Transaction tshttptxn=%p setting error body page length: %lu", state_->txn_, page.length());
-  char *body = static_cast<char *>(TSmalloc(page.length()));
+  char *body = (char *)TSmalloc(page.length());
   memcpy(body, page.data(), page.length());
   TSHttpTxnErrorBodySet(state_->txn_, body, page.length(), TSstrdup(mimetype.c_str()));
 }


### PR DESCRIPTION
This reverts commit 58e7e8675c96a5a4eb958a442942892f6e2a0ef4.

I'm reverting this for now, because it's really messing up a big commit that I'm
working on. I'd much prefer that we only run tools such as clang-format (with new
configs) and clang-tidy (with new configs) just before we branch.