### PR TITLE
Use IPPROTO_TCP instead of SOL_TCP for macOS compatibility

### DIFF
--- a/tests/gold_tests/tls/ssl-post.c
+++ b/tests/gold_tests/tls/ssl-post.c
@@ -85,7 +85,7 @@ spawn_same_session_send(void *arg)
   fcntl(sfd, F_SETFL, O_NONBLOCK);
   // Make sure we are nagling
   int one = 0;
-  setsockopt(sfd, SOL_TCP, TCP_NODELAY, &one, sizeof(one));
+  setsockopt(sfd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
 
   SSL_CTX *client_ctx = SSL_CTX_new(SSLv23_client_method());
   SSL *ssl            = SSL_new(client_ctx);


### PR DESCRIPTION
IPPROTO_TCP should be more portable