### PR TITLE
Update ImageTransform.cc

### DIFF
--- a/plugins/experimental/webp_transform/ImageTransform.cc
+++ b/plugins/experimental/webp_transform/ImageTransform.cc
@@ -49,7 +49,7 @@ public:
   handleReadResponseHeaders(Transaction &transaction) override
   {
     transaction.getServerResponse().getHeaders()["Content-Type"] = "image/webp";
-    transaction.getServerResponse().getHeaders()["Vary"]         = "Content-Type"; // to have a separate cache entry.
+    transaction.getServerResponse().getHeaders()["Vary"]         = "Accept"; // to have a separate cache entry.
 
     TS_DEBUG(TAG, "url %s", transaction.getServerRequest().getUrl().getUrlString().c_str());
     transaction.resume();


### PR DESCRIPTION
Using Content-Type as a Vary header serves always the first cached response - serve only webp or only jpg/png for each image no matter what the browser supports.
Serving webp or not must Vary on the browser's Accept header and not on the Content-Type as the browser knows whether it support webp or not.