### PR TITLE
Fix crash in MIMEScanner::append with std::string.

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -755,6 +755,7 @@ Http2Stream::destroy()
   chunked_handler.clear();
   clear_timers();
   clear_io_events();
+  http_parser_clear(&http_parser);
 
   super::destroy();
   THREAD_FREE(this, http2StreamAllocator, this_ethread());

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -41,8 +41,6 @@ public:
   typedef ProxyTransaction super; ///< Parent type.
   Http2Stream(Http2StreamId sid = 0, ssize_t initial_rwnd = Http2::initial_window_size) : client_rwnd(initial_rwnd), _id(sid)
   {
-    http_parser_init(&http_parser);
-
     SET_HANDLER(&Http2Stream::main_event_handler);
   }
 
@@ -57,6 +55,7 @@ public:
     // FIXME: Are you sure? every "stream" needs request_header?
     _req_header.create(HTTP_TYPE_REQUEST);
     response_header.create(HTTP_TYPE_RESPONSE);
+    http_parser_init(&http_parser);
   }
 
   int main_event_handler(int event, void *edata);


### PR DESCRIPTION
I think this is a fix for #5587. The problem was `Http2Stream` wasn't calling the HTTP parser initialization and destruction correctly. `http_parser_init` needs to be called every initialization after a proxy allocate, not just in the constructor. Converserly, `http_parser_clear` needs to be called in the `destroy` method. Otherwise the parser (which contains the MIME scanner) is left in a bad state.