### PR TITLE
Turns off TLS v1.0 and TLS v1.1 by default

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3081,11 +3081,11 @@ SSL Termination
 
    This configuration works with OpenSSL v1.0.2 and above.
 
-.. ts:cv:: CONFIG proxy.config.ssl.TLSv1 INT 1
+.. ts:cv:: CONFIG proxy.config.ssl.TLSv1 INT 0
 
-   Enables (``1``) or disables (``0``) TLSv1.
+   Enables (``1``) or disables (``0``) TLSv1.0.
 
-.. ts:cv:: CONFIG proxy.config.ssl.TLSv1_1 INT 1
+.. ts:cv:: CONFIG proxy.config.ssl.TLSv1_1 INT 0
 
    Enables (``1``) or disables (``0``) TLS v1.1.  If not specified, enabled by default.  [Requires OpenSSL v1.0.1 and higher]
 
@@ -3411,11 +3411,11 @@ Client-Related Configuration
 
    Enables (``1``) or disables (``0``) SSLv3 in the ATS client context. Disabled by default
 
-.. ts:cv:: CONFIG proxy.config.ssl.client.TLSv1 INT 1
+.. ts:cv:: CONFIG proxy.config.ssl.client.TLSv1 INT 0
 
-   Enables (``1``) or disables (``0``) TLSv1 in the ATS client context. If not specified, enabled by default
+   Enables (``1``) or disables (``0``) TLSv1.0 in the ATS client context. If not specified, enabled by default
 
-.. ts:cv:: CONFIG proxy.config.ssl.client.TLSv1_1 INT 1
+.. ts:cv:: CONFIG proxy.config.ssl.client.TLSv1_1 INT 0
 
    Enables (``1``) or disables (``0``) TLSv1_1 in the ATS client context. If not specified, enabled by default
 

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -198,61 +198,59 @@ SSLConfigParams::initialize()
 
   dhparamsFile = ats_stringdup(RecConfigReadConfigPath("proxy.config.ssl.server.dhparams_file"));
 
-  int options;
-  int client_ssl_options = 0;
-  REC_ReadConfigInteger(options, "proxy.config.ssl.TLSv1");
-  if (!options) {
+  int option = 0;
+
+#if TS_USE_SSLV3_CLIENT
+  REC_ReadConfigInteger(option, "proxy.config.ssl.client.SSLv3");
+  if (option)
+    ssl_client_ctx_options &= ~SSL_OP_NO_SSLv3;
+#endif
+
+  REC_ReadConfigInteger(option, "proxy.config.ssl.TLSv1");
+  if (!option) {
     ssl_ctx_options |= SSL_OP_NO_TLSv1;
   }
 
-#if TS_USE_SSLV3_CLIENT
-  REC_ReadConfigInteger(client_ssl_options, "proxy.config.ssl.client.SSLv3");
-  if (client_ssl_options)
-    ssl_client_ctx_options &= ~SSL_OP_NO_SSLv3;
-#endif
-  REC_ReadConfigInteger(client_ssl_options, "proxy.config.ssl.client.TLSv1");
-  if (!client_ssl_options) {
+  REC_ReadConfigInteger(option, "proxy.config.ssl.client.TLSv1");
+  if (!option) {
     ssl_client_ctx_options |= SSL_OP_NO_TLSv1;
   }
 
-// These are not available in all versions of OpenSSL (e.g. CentOS6). Also see http://s.apache.org/TS-2355.
-#ifdef SSL_OP_NO_TLSv1_1
-  REC_ReadConfigInteger(options, "proxy.config.ssl.TLSv1_1");
-  if (!options) {
+  REC_ReadConfigInteger(option, "proxy.config.ssl.TLSv1_1");
+  if (!option) {
     ssl_ctx_options |= SSL_OP_NO_TLSv1_1;
   }
 
-  REC_ReadConfigInteger(client_ssl_options, "proxy.config.ssl.client.TLSv1_1");
-  if (!client_ssl_options) {
+  REC_ReadConfigInteger(option, "proxy.config.ssl.client.TLSv1_1");
+  if (!option) {
     ssl_client_ctx_options |= SSL_OP_NO_TLSv1_1;
   }
-#endif
-#ifdef SSL_OP_NO_TLSv1_2
-  REC_ReadConfigInteger(options, "proxy.config.ssl.TLSv1_2");
-  if (!options) {
+
+  REC_ReadConfigInteger(option, "proxy.config.ssl.TLSv1_2");
+  if (!option) {
     ssl_ctx_options |= SSL_OP_NO_TLSv1_2;
   }
 
-  REC_ReadConfigInteger(client_ssl_options, "proxy.config.ssl.client.TLSv1_2");
-  if (!client_ssl_options) {
+  REC_ReadConfigInteger(option, "proxy.config.ssl.client.TLSv1_2");
+  if (!option) {
     ssl_client_ctx_options |= SSL_OP_NO_TLSv1_2;
   }
-#endif
+
 #ifdef SSL_OP_NO_TLSv1_3
-  REC_ReadConfigInteger(options, "proxy.config.ssl.TLSv1_3");
-  if (!options) {
+  REC_ReadConfigInteger(option, "proxy.config.ssl.TLSv1_3");
+  if (!option) {
     ssl_ctx_options |= SSL_OP_NO_TLSv1_3;
   }
 
-  REC_ReadConfigInteger(client_ssl_options, "proxy.config.ssl.client.TLSv1_3");
-  if (!client_ssl_options) {
+  REC_ReadConfigInteger(option, "proxy.config.ssl.client.TLSv1_3");
+  if (!option) {
     ssl_client_ctx_options |= SSL_OP_NO_TLSv1_3;
   }
 #endif
 
 #ifdef SSL_OP_CIPHER_SERVER_PREFERENCE
-  REC_ReadConfigInteger(options, "proxy.config.ssl.server.honor_cipher_order");
-  if (options) {
+  REC_ReadConfigInteger(option, "proxy.config.ssl.server.honor_cipher_order");
+  if (option) {
     ssl_ctx_options |= SSL_OP_CIPHER_SERVER_PREFERENCE;
   }
 #endif

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1059,9 +1059,9 @@ static const RecordElement RecordsConfig[] =
   //##############################################################################
   {RECT_CONFIG, "proxy.config.ssl.server.session_ticket.enable", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.ssl.TLSv1", RECD_INT, "1", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.ssl.TLSv1", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.ssl.TLSv1_1", RECD_INT, "1", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.ssl.TLSv1_1", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
   ,
   // Disable this when using some versions of OpenSSL that causes crashes. See TS-2355.
   {RECT_CONFIG, "proxy.config.ssl.TLSv1_2", RECD_INT, "1", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
@@ -1074,9 +1074,9 @@ static const RecordElement RecordsConfig[] =
   {RECT_CONFIG, "proxy.config.ssl.client.SSLv3", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
   ,
 #endif
-  {RECT_CONFIG, "proxy.config.ssl.client.TLSv1", RECD_INT, "1", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.ssl.client.TLSv1", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.ssl.client.TLSv1_1", RECD_INT, "1", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.ssl.client.TLSv1_1", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.ssl.client.TLSv1_2", RECD_INT, "1", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
   ,


### PR DESCRIPTION
I also reorganized the order slightly in the config loading portion.