### PR TITLE
QUIC: Adds QUICPadder to padding quic packets

### DIFF
--- a/iocore/net/P_QUICNetVConnection.h
+++ b/iocore/net/P_QUICNetVConnection.h
@@ -54,6 +54,7 @@
 #include "quic/QUICHandshakeProtocol.h"
 #include "quic/QUICAckFrameCreator.h"
 #include "quic/QUICPinger.h"
+#include "quic/QUICPadder.h"
 #include "quic/QUICLossDetector.h"
 #include "quic/QUICStreamManager.h"
 #include "quic/QUICAltConnectionManager.h"
@@ -197,7 +198,7 @@ public:
   // QUICFrameGenerator
   bool will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num) override;
   QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                            uint32_t seq_num) override;
+                            size_t current_packet_size, uint32_t seq_num) override;
 
   int in_closed_queue = 0;
 
@@ -239,6 +240,7 @@ private:
   // TODO: use custom allocator and make them std::unique_ptr or std::shared_ptr
   // or make them just member variables.
   QUICPinger *_pinger                               = nullptr;
+  QUICPadder *_padder                               = nullptr;
   QUICHandshake *_handshake_handler                 = nullptr;
   QUICHandshakeProtocol *_hs_protocol               = nullptr;
   QUICLossDetector *_loss_detector                  = nullptr;
@@ -295,7 +297,6 @@ private:
                                   std::vector<QUICFrameInfo> &frames);
   QUICPacketUPtr _packetize_frames(QUICEncryptionLevel level, uint64_t max_packet_size, std::vector<QUICFrameInfo> &frames);
   void _packetize_closing_frame();
-  Ptr<IOBufferBlock> _generate_padding_frame(size_t frame_size);
   QUICPacketUPtr _build_packet(QUICEncryptionLevel level, Ptr<IOBufferBlock> parent_block, bool retransmittable, bool probing,
                                bool crypto);
 

--- a/iocore/net/quic/Makefile.am
+++ b/iocore/net/quic/Makefile.am
@@ -90,7 +90,8 @@ libquic_a_SOURCES = \
   QUICBidirectionalStream.cc \
   QUICCryptoStream.cc \
   QUICUnidirectionalStream.cc \
-  QUICStreamFactory.cc
+  QUICStreamFactory.cc \
+  QUICPadder.cc
 
 #
 # Check Programs

--- a/iocore/net/quic/Mock.h
+++ b/iocore/net/quic/Mock.h
@@ -395,7 +395,7 @@ class MockQUICLossDetector : public QUICLossDetector
 public:
   MockQUICLossDetector(QUICConnectionInfoProvider *info, QUICCongestionController *cc, QUICRTTMeasure *rtt_measure,
                        const QUICLDConfig &ld_config)
-    : QUICLossDetector(info, cc, rtt_measure, ld_config)
+    : QUICLossDetector(info, cc, rtt_measure, &this->_pinger, ld_config)
   {
   }
   void
@@ -407,6 +407,9 @@ public:
   on_packet_sent(QUICPacketUPtr packet)
   {
   }
+
+private:
+  QUICPinger _pinger;
 };
 
 class MockQUICApplication : public QUICApplication
@@ -644,14 +647,14 @@ class MockQUICFrameGenerator : public QUICFrameGenerator
 {
 public:
   bool
-  will_generate_frame(QUICEncryptionLevel level, ink_hrtime timestamp) override
+  will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num) override
   {
     return true;
   }
 
   QUICFrame *
   generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                 ink_hrtime timestamp) override
+                 size_t current_packet_size, uint32_t seq_num) override
   {
     QUICFrame *frame              = QUICFrameFactory::create_ping_frame(buf, 0, this);
     QUICFrameInformationUPtr info = QUICFrameInformationUPtr(quicFrameInformationAllocator.alloc());

--- a/iocore/net/quic/QUICAckFrameCreator.cc
+++ b/iocore/net/quic/QUICAckFrameCreator.cc
@@ -61,7 +61,7 @@ QUICAckFrameManager::update(QUICEncryptionLevel level, QUICPacketNumber packet_n
  */
 QUICFrame *
 QUICAckFrameManager::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t /* connection_credit */,
-                                    uint16_t maximum_frame_size, uint32_t seq_num)
+                                    uint16_t maximum_frame_size, size_t current_packet_size, uint32_t seq_num)
 {
   QUICAckFrame *ack_frame = nullptr;
 

--- a/iocore/net/quic/QUICAckFrameCreator.h
+++ b/iocore/net/quic/QUICAckFrameCreator.h
@@ -107,7 +107,7 @@ public:
    * Calls create directly.
    */
   QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                            uint32_t seq_num) override;
+                            size_t current_packet_size, uint32_t seq_num) override;
 
   QUICFrameId issue_frame_id();
   uint8_t ack_delay_exponent() const;

--- a/iocore/net/quic/QUICAltConnectionManager.cc
+++ b/iocore/net/quic/QUICAltConnectionManager.cc
@@ -280,7 +280,7 @@ QUICAltConnectionManager::will_generate_frame(QUICEncryptionLevel level, uint32_
  */
 QUICFrame *
 QUICAltConnectionManager::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t /* connection_credit */,
-                                         uint16_t maximum_frame_size, uint32_t seq_num)
+                                         uint16_t maximum_frame_size, size_t current_packet_size, uint32_t seq_num)
 {
   QUICFrame *frame = nullptr;
   if (!this->_is_level_matched(level)) {

--- a/iocore/net/quic/QUICAltConnectionManager.h
+++ b/iocore/net/quic/QUICAltConnectionManager.h
@@ -85,7 +85,7 @@ public:
   // QUICFrameGenerator
   bool will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num) override;
   QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                            uint32_t seq_num) override;
+                            size_t current_packet_size, uint32_t seq_num) override;
 
 private:
   struct AltConnectionInfo {

--- a/iocore/net/quic/QUICBidirectionalStream.cc
+++ b/iocore/net/quic/QUICBidirectionalStream.cc
@@ -360,7 +360,7 @@ QUICBidirectionalStream::will_generate_frame(QUICEncryptionLevel level, uint32_t
 
 QUICFrame *
 QUICBidirectionalStream::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit,
-                                        uint16_t maximum_frame_size, uint32_t seq_num)
+                                        uint16_t maximum_frame_size, size_t current_packet_size, uint32_t seq_num)
 {
   SCOPED_MUTEX_LOCK(lock, this->_write_vio.mutex, this_ethread());
 
@@ -391,7 +391,7 @@ QUICBidirectionalStream::generate_frame(uint8_t *buf, QUICEncryptionLevel level,
   }
 
   // MAX_STREAM_DATA
-  frame = this->_local_flow_controller.generate_frame(buf, level, UINT16_MAX, maximum_frame_size, seq_num);
+  frame = this->_local_flow_controller.generate_frame(buf, level, UINT16_MAX, maximum_frame_size, current_packet_size, seq_num);
   if (frame) {
     return frame;
   }
@@ -427,7 +427,8 @@ QUICBidirectionalStream::generate_frame(uint8_t *buf, QUICEncryptionLevel level,
     uint64_t stream_credit = this->_remote_flow_controller.credit();
     if (stream_credit == 0) {
       // STREAM_DATA_BLOCKED
-      frame = this->_remote_flow_controller.generate_frame(buf, level, UINT16_MAX, maximum_frame_size, seq_num);
+      frame =
+        this->_remote_flow_controller.generate_frame(buf, level, UINT16_MAX, maximum_frame_size, current_packet_size, seq_num);
       return frame;
     }
 

--- a/iocore/net/quic/QUICBidirectionalStream.h
+++ b/iocore/net/quic/QUICBidirectionalStream.h
@@ -46,7 +46,7 @@ public:
   // QUICFrameGenerator
   bool will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num) override;
   QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                            uint32_t seq_num) override;
+                            size_t current_packet_size, uint32_t seq_num) override;
 
   virtual QUICConnectionErrorUPtr recv(const QUICStreamFrame &frame) override;
   virtual QUICConnectionErrorUPtr recv(const QUICMaxStreamDataFrame &frame) override;

--- a/iocore/net/quic/QUICCryptoStream.cc
+++ b/iocore/net/quic/QUICCryptoStream.cc
@@ -112,7 +112,7 @@ QUICCryptoStream::will_generate_frame(QUICEncryptionLevel level, uint32_t seq_nu
  */
 QUICFrame *
 QUICCryptoStream::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t /* connection_credit */,
-                                 uint16_t maximum_frame_size, uint32_t seq_num)
+                                 uint16_t maximum_frame_size, size_t current_packet_size, uint32_t seq_num)
 {
   QUICConnectionErrorUPtr error = nullptr;
 

--- a/iocore/net/quic/QUICCryptoStream.h
+++ b/iocore/net/quic/QUICCryptoStream.h
@@ -55,7 +55,7 @@ public:
   // QUICFrameGenerator
   bool will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num) override;
   QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                            uint32_t seq_num) override;
+                            size_t current_packet_size, uint32_t seq_num) override;
 
 private:
   void _on_frame_acked(QUICFrameInformationUPtr &info) override;

--- a/iocore/net/quic/QUICFlowController.cc
+++ b/iocore/net/quic/QUICFlowController.cc
@@ -110,7 +110,7 @@ QUICFlowController::will_generate_frame(QUICEncryptionLevel level, uint32_t seq_
  */
 QUICFrame *
 QUICFlowController::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t /* connection_credit */,
-                                   uint16_t maximum_frame_size, uint32_t seq_num)
+                                   uint16_t maximum_frame_size, size_t current_packet_size, uint32_t seq_num)
 {
   QUICFrame *frame = nullptr;
 

--- a/iocore/net/quic/QUICFlowController.h
+++ b/iocore/net/quic/QUICFlowController.h
@@ -62,7 +62,7 @@ public:
   // QUICFrameGenerator
   bool will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num) override;
   QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                            uint32_t seq_num) override;
+                            size_t current_packet_size, uint32_t seq_num) override;
 
 protected:
   QUICFlowController(uint64_t initial_limit) : _limit(initial_limit) {}

--- a/iocore/net/quic/QUICFrame.h
+++ b/iocore/net/quic/QUICFrame.h
@@ -61,6 +61,7 @@ public:
   virtual void parse(const uint8_t *buf, size_t len){};
   virtual QUICFrameGenerator *generated_by();
   bool valid() const;
+  bool ack_eliciting() const;
   LINK(QUICFrame, link);
 
 protected:
@@ -335,13 +336,18 @@ private:
 class QUICPaddingFrame : public QUICFrame
 {
 public:
-  QUICPaddingFrame() {}
+  QUICPaddingFrame(size_t size) : _size(size) {}
   QUICPaddingFrame(const uint8_t *buf, size_t len);
   virtual QUICFrameType type() const override;
   virtual size_t size() const override;
   virtual bool is_probing_frame() const override;
   virtual size_t store(uint8_t *buf, size_t *len, size_t limit) const override;
   virtual void parse(const uint8_t *buf, size_t len) override;
+
+private:
+  // padding frame is a resident of padding frames
+  // size indicate how many padding frames in this QUICPaddingFrame
+  size_t _size = 0;
 };
 
 //
@@ -848,6 +854,11 @@ public:
    */
   static QUICRetireConnectionIdFrame *create_retire_connection_id_frame(uint8_t *buf, uint64_t seq_num, QUICFrameId id = 0,
                                                                         QUICFrameGenerator *owner = nullptr);
+
+  /*
+   * Creates a PADDING frame
+   */
+  static QUICPaddingFrame *create_padding_frame(uint8_t *buf, size_t size, QUICFrameId id = 0, QUICFrameGenerator *owner = nullptr);
 
 private:
   // FIXME Actual number of frame types is several but some of the values are not sequential.

--- a/iocore/net/quic/QUICFrameGenerator.h
+++ b/iocore/net/quic/QUICFrameGenerator.h
@@ -37,7 +37,7 @@ public:
    * It returns a pointer for the frame if it succeeded, and returns nullptr if it failed.
    */
   virtual QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit,
-                                    uint16_t maximum_frame_size, uint32_t seq_num) = 0;
+                                    uint16_t maximum_frame_size, size_t current_packet_size, uint32_t seq_num) = 0;
 
   void on_frame_acked(QUICFrameId id);
   void on_frame_lost(QUICFrameId id);

--- a/iocore/net/quic/QUICHandshake.cc
+++ b/iocore/net/quic/QUICHandshake.cc
@@ -333,13 +333,13 @@ QUICHandshake::will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num)
 
 QUICFrame *
 QUICHandshake::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                              uint32_t seq_num)
+                              size_t current_packet_size, uint32_t seq_num)
 {
   QUICFrame *frame = nullptr;
 
   if (this->_is_level_matched(level)) {
-    frame =
-      this->_crypto_streams[static_cast<int>(level)].generate_frame(buf, level, connection_credit, maximum_frame_size, seq_num);
+    frame = this->_crypto_streams[static_cast<int>(level)].generate_frame(buf, level, connection_credit, maximum_frame_size,
+                                                                          current_packet_size, seq_num);
   }
 
   return frame;

--- a/iocore/net/quic/QUICHandshake.h
+++ b/iocore/net/quic/QUICHandshake.h
@@ -53,7 +53,7 @@ public:
   // QUICFrameGenerator
   bool will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num) override;
   QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                            uint32_t seq_num) override;
+                            size_t current_packet_size, uint32_t seq_num) override;
 
   // for client side
   QUICConnectionErrorUPtr start(const QUICTPConfig &tp_config, QUICPacketFactory *packet_factory, bool vn_exercise_enabled);

--- a/iocore/net/quic/QUICPadder.cc
+++ b/iocore/net/quic/QUICPadder.cc
@@ -1,0 +1,121 @@
+/** @file
+
+  A brief file description
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "QUICIntUtil.h"
+#include "QUICPadder.h"
+
+static constexpr uint32_t MINIMUM_INITIAL_PACKET_SIZE = 1200;
+static constexpr uint32_t MIN_PKT_PAYLOAD_LEN         = 3; ///< Minimum payload length for sampling for header protection
+
+void
+QUICPadder::request(QUICEncryptionLevel level)
+{
+  SCOPED_MUTEX_LOCK(lock, this->_mutex, this_ethread());
+  if (!this->_is_level_matched(level)) {
+    return;
+  }
+  ++this->_need_to_fire[static_cast<int>(level)];
+}
+
+void
+QUICPadder::cancel(QUICEncryptionLevel level)
+{
+  SCOPED_MUTEX_LOCK(lock, this->_mutex, this_ethread());
+  if (!this->_is_level_matched(level)) {
+    return;
+  }
+
+  this->_need_to_fire[static_cast<int>(level)] = 0;
+}
+
+uint64_t
+QUICPadder::count(QUICEncryptionLevel level)
+{
+  SCOPED_MUTEX_LOCK(lock, this->_mutex, this_ethread());
+  return this->_need_to_fire[static_cast<int>(level)];
+}
+
+bool
+QUICPadder::will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num)
+{
+  SCOPED_MUTEX_LOCK(lock, this->_mutex, this_ethread());
+  if (seq_num == this->_latest_seq_num) {
+    return false;
+  }
+
+  this->_latest_seq_num = seq_num;
+  return true;
+}
+
+QUICFrame *
+QUICPadder::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
+                           size_t current_packet_size, uint32_t seq_num)
+{
+  SCOPED_MUTEX_LOCK(lock, this->_mutex, this_ethread());
+  QUICFrame *frame = nullptr;
+
+  // no extre padding packet
+  if (current_packet_size == 0 && this->_need_to_fire[static_cast<int>(level)] == 0) {
+    return frame;
+  }
+
+  uint64_t min_size = 0;
+  if (level == QUICEncryptionLevel::INITIAL && this->_context == NET_VCONNECTION_OUT) {
+    min_size = this->_minimum_quic_packet_size();
+    if (this->_av_token_len && min_size > (QUICVariableInt::size(this->_av_token_len) + this->_av_token_len)) {
+      min_size -= (QUICVariableInt::size(this->_av_token_len) + this->_av_token_len);
+    }
+  } else {
+    min_size = MIN_PKT_PAYLOAD_LEN;
+  }
+
+  if (min_size > current_packet_size) { // ignore if we don't need to pad.
+    frame = QUICFrameFactory::create_padding_frame(
+      buf, 0, std::min(min_size - current_packet_size, static_cast<uint64_t>(maximum_frame_size)));
+  }
+
+  this->_need_to_fire[static_cast<int>(level)] = 0;
+  this->_latest_seq_num                        = seq_num;
+  return frame;
+}
+
+uint32_t
+QUICPadder::_minimum_quic_packet_size()
+{
+  SCOPED_MUTEX_LOCK(lock, this->_mutex, this_ethread());
+  if (this->_context == NET_VCONNECTION_OUT) {
+    // FIXME Only the first packet need to be 1200 bytes at least
+    return MINIMUM_INITIAL_PACKET_SIZE;
+  } else {
+    // FIXME This size should be configurable and should have some randomness
+    // This is just for providing protection against packet analysis for protected packets
+    return 32 + (this->_rnd() & 0x3f); // 32 to 96
+  }
+}
+
+void
+QUICPadder::set_av_token_len(uint32_t len)
+{
+  SCOPED_MUTEX_LOCK(lock, this->_mutex, this_ethread());
+  this->_av_token_len = len;
+}

--- a/iocore/net/quic/QUICPadder.h
+++ b/iocore/net/quic/QUICPadder.h
@@ -23,42 +23,37 @@
 
 #pragma once
 
-#include <vector>
 #include "QUICTypes.h"
 #include "QUICFrameHandler.h"
 #include "QUICFrameGenerator.h"
 
-class QUICPathValidator : public QUICFrameHandler, public QUICFrameGenerator
+#include "I_Lock.h"
+
+class QUICPadder : public QUICFrameGenerator
 {
 public:
-  QUICPathValidator() {}
-  bool is_validating();
-  bool is_validated();
-  void validate();
+  QUICPadder(NetVConnectionContext_t context) : _mutex(new_ProxyMutex()), _context(context) {}
 
-  // QUICFrameHandler
-  std::vector<QUICFrameType> interests() override;
-  QUICConnectionErrorUPtr handle_frame(QUICEncryptionLevel level, const QUICFrame &frame) override;
+  void request(QUICEncryptionLevel level);
+  void cancel(QUICEncryptionLevel level);
+  uint64_t count(QUICEncryptionLevel level);
+  void set_av_token_len(uint32_t len);
 
-  // QUICFrameGeneratro
+  // QUICFrameGenerator
   bool will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num) override;
+  // a trick, Different from other generator padder will generate multi-pad-frames.
   QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
                             size_t current_packet_size, uint32_t seq_num) override;
 
 private:
-  enum class ValidationState : int {
-    NOT_VALIDATED,
-    VALIDATING,
-    VALIDATED,
-  };
-  ValidationState _state      = ValidationState::NOT_VALIDATED;
-  int _has_outgoing_challenge = 0;
-  bool _has_outgoing_response = false;
-  uint32_t _latest_seq_num    = 0;
-  uint8_t _incoming_challenge[QUICPathChallengeFrame::DATA_LEN];
-  uint8_t _outgoing_challenge[QUICPathChallengeFrame::DATA_LEN * 3];
+  uint32_t _minimum_quic_packet_size();
 
-  void _generate_challenge();
-  void _generate_response(const QUICPathChallengeFrame &frame);
-  QUICConnectionErrorUPtr _validate_response(const QUICPathResponseFrame &frame);
+  Ptr<ProxyMutex> _mutex;
+  std::random_device _rnd;
+
+  uint32_t _av_token_len   = 0;
+  uint32_t _latest_seq_num = 0;
+  // Initial, 0/1-RTT, and Handshake
+  uint64_t _need_to_fire[4]        = {0};
+  NetVConnectionContext_t _context = NET_VCONNECTION_OUT;
 };

--- a/iocore/net/quic/QUICPathValidator.cc
+++ b/iocore/net/quic/QUICPathValidator.cc
@@ -135,7 +135,7 @@ QUICPathValidator::will_generate_frame(QUICEncryptionLevel level, uint32_t seq_n
  */
 QUICFrame *
 QUICPathValidator::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t /* connection_credit */,
-                                  uint16_t maximum_frame_size, uint32_t seq_num)
+                                  uint16_t maximum_frame_size, size_t current_packet_size, uint32_t seq_num)
 {
   QUICFrame *frame = nullptr;
 

--- a/iocore/net/quic/QUICPinger.cc
+++ b/iocore/net/quic/QUICPinger.cc
@@ -67,7 +67,7 @@ QUICPinger::will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num)
  */
 QUICFrame *
 QUICPinger::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t /* connection_credit */, uint16_t maximum_frame_size,
-                           uint32_t seq_num)
+                           size_t current_packet_size, uint32_t seq_num)
 {
   SCOPED_MUTEX_LOCK(lock, this->_mutex, this_ethread());
   QUICFrame *frame = nullptr;

--- a/iocore/net/quic/QUICPinger.h
+++ b/iocore/net/quic/QUICPinger.h
@@ -42,7 +42,7 @@ public:
   // QUICFrameGenerator
   bool will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num) override;
   QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                            uint32_t seq_num) override;
+                            size_t current_packet_size, uint32_t seq_num) override;
 
 private:
   Ptr<ProxyMutex> _mutex;

--- a/iocore/net/quic/QUICStreamManager.cc
+++ b/iocore/net/quic/QUICStreamManager.cc
@@ -429,7 +429,7 @@ QUICStreamManager::will_generate_frame(QUICEncryptionLevel level, uint32_t seq_n
 
 QUICFrame *
 QUICStreamManager::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                                  uint32_t seq_num)
+                                  size_t current_packet_size, uint32_t seq_num)
 {
   QUICFrame *frame = nullptr;
 
@@ -444,7 +444,7 @@ QUICStreamManager::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint6
 
   // FIXME We should pick a stream based on priority
   for (QUICStreamVConnection *s = this->stream_list.head; s; s = s->link.next) {
-    frame = s->generate_frame(buf, level, connection_credit, maximum_frame_size, seq_num);
+    frame = s->generate_frame(buf, level, connection_credit, maximum_frame_size, current_packet_size, seq_num);
     if (frame) {
       break;
     }

--- a/iocore/net/quic/QUICStreamManager.h
+++ b/iocore/net/quic/QUICStreamManager.h
@@ -65,7 +65,7 @@ public:
   // QUICFrameGenerator
   bool will_generate_frame(QUICEncryptionLevel level, uint32_t timestamp) override;
   QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                            uint32_t timestamp) override;
+                            size_t current_packet_size, uint32_t timestamp) override;
 
 protected:
   virtual bool _is_level_matched(QUICEncryptionLevel level) override;

--- a/iocore/net/quic/QUICUnidirectionalStream.cc
+++ b/iocore/net/quic/QUICUnidirectionalStream.cc
@@ -132,7 +132,7 @@ QUICSendStream::will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num)
 
 QUICFrame *
 QUICSendStream::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                               uint32_t seq_num)
+                               size_t current_packet_size, uint32_t seq_num)
 {
   SCOPED_MUTEX_LOCK(lock, this->_write_vio.mutex, this_ethread());
 
@@ -183,7 +183,8 @@ QUICSendStream::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t
     uint64_t stream_credit = this->_remote_flow_controller.credit();
     if (stream_credit == 0) {
       // STREAM_DATA_BLOCKED
-      frame = this->_remote_flow_controller.generate_frame(buf, level, UINT16_MAX, maximum_frame_size, seq_num);
+      frame =
+        this->_remote_flow_controller.generate_frame(buf, level, UINT16_MAX, maximum_frame_size, current_packet_size, seq_num);
       return frame;
     }
 
@@ -534,7 +535,7 @@ QUICReceiveStream::will_generate_frame(QUICEncryptionLevel level, uint32_t seq_n
 
 QUICFrame *
 QUICReceiveStream::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                                  uint32_t seq_num)
+                                  size_t current_packet_size, uint32_t seq_num)
 {
   QUICFrame *frame = nullptr;
   // STOP_SENDING
@@ -548,7 +549,7 @@ QUICReceiveStream::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint6
   }
 
   // MAX_STREAM_DATA
-  frame = this->_local_flow_controller.generate_frame(buf, level, UINT16_MAX, maximum_frame_size, seq_num);
+  frame = this->_local_flow_controller.generate_frame(buf, level, UINT16_MAX, maximum_frame_size, current_packet_size, seq_num);
   return frame;
 }
 

--- a/iocore/net/quic/QUICUnidirectionalStream.h
+++ b/iocore/net/quic/QUICUnidirectionalStream.h
@@ -39,7 +39,7 @@ public:
   // QUICFrameGenerator
   bool will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num) override;
   QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                            uint32_t seq_num) override;
+                            size_t current_packet_size, uint32_t seq_num) override;
 
   virtual QUICConnectionErrorUPtr recv(const QUICMaxStreamDataFrame &frame) override;
   virtual QUICConnectionErrorUPtr recv(const QUICStopSendingFrame &frame) override;
@@ -88,7 +88,7 @@ public:
   // QUICFrameGenerator
   bool will_generate_frame(QUICEncryptionLevel level, uint32_t seq_num) override;
   QUICFrame *generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t connection_credit, uint16_t maximum_frame_size,
-                            uint32_t seq_num) override;
+                            size_t current_packet_size, uint32_t seq_num) override;
 
   virtual QUICConnectionErrorUPtr recv(const QUICStreamFrame &frame) override;
   virtual QUICConnectionErrorUPtr recv(const QUICStreamDataBlockedFrame &frame) override;

--- a/iocore/net/quic/test/test_QUICAckFrameCreator.cc
+++ b/iocore/net/quic/test/test_QUICAckFrameCreator.cc
@@ -34,13 +34,13 @@ TEST_CASE("QUICAckFrameManager", "[quic]")
   uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
 
   // Initial state
-  QUICFrame *ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0);
+  QUICFrame *ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0, 0);
   QUICAckFrame *frame  = static_cast<QUICAckFrame *>(ack_frame);
   CHECK(frame == nullptr);
 
   // One packet
   ack_manager.update(level, 1, 1, false);
-  ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0);
+  ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0, 0);
   frame     = static_cast<QUICAckFrame *>(ack_frame);
   CHECK(frame != nullptr);
   CHECK(frame->ack_block_count() == 0);
@@ -55,7 +55,7 @@ TEST_CASE("QUICAckFrameManager", "[quic]")
   ack_manager.update(level, 5, 1, false);
   ack_manager.update(level, 3, 1, false);
   ack_manager.update(level, 4, 1, false);
-  ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0);
+  ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0, 0);
   frame     = static_cast<QUICAckFrame *>(ack_frame);
   CHECK(frame != nullptr);
   CHECK(frame->ack_block_count() == 0);
@@ -66,7 +66,7 @@ TEST_CASE("QUICAckFrameManager", "[quic]")
   ack_manager.update(level, 6, 1, false);
   ack_manager.update(level, 7, 1, false);
   ack_manager.update(level, 10, 1, false);
-  ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0);
+  ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0, 0);
   frame     = static_cast<QUICAckFrame *>(ack_frame);
   CHECK(frame != nullptr);
   CHECK(frame->ack_block_count() == 1);
@@ -78,13 +78,13 @@ TEST_CASE("QUICAckFrameManager", "[quic]")
   ack_manager.on_frame_acked(frame->id());
 
   CHECK(ack_manager.will_generate_frame(level, 0) == false);
-  ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0);
+  ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0, 0);
   CHECK(ack_frame == nullptr);
 
   ack_manager.update(level, 11, 1, false);
   ack_manager.update(level, 12, 1, false);
   ack_manager.update(level, 13, 1, false);
-  ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0);
+  ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0, 0);
   frame     = static_cast<QUICAckFrame *>(ack_frame);
   CHECK(frame != nullptr);
   CHECK(frame->ack_block_count() == 0);
@@ -99,10 +99,10 @@ TEST_CASE("QUICAckFrameManager", "[quic]")
   ack_manager.update(level, 15, 1, true);
   ack_manager.update(level, 16, 1, true);
   CHECK(ack_manager.will_generate_frame(level, 0) == false);
-  ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0);
+  ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0, 0);
 
   ack_manager.update(level, 17, 1, false);
-  ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0);
+  ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0, 0);
   frame     = static_cast<QUICAckFrame *>(ack_frame);
   CHECK(frame != nullptr);
   CHECK(frame->ack_block_count() == 0);
@@ -189,7 +189,7 @@ TEST_CASE("QUICAckFrameManager should send", "[quic]")
     QUICEncryptionLevel level = QUICEncryptionLevel::ONE_RTT;
 
     uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
-    QUICFrame *ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0);
+    QUICFrame *ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0, 0);
     QUICAckFrame *frame  = static_cast<QUICAckFrame *>(ack_frame);
     CHECK(frame == nullptr);
 
@@ -203,7 +203,7 @@ TEST_CASE("QUICAckFrameManager should send", "[quic]")
     sleep(1);
     Thread::get_hrtime_updated();
     CHECK(ack_manager.will_generate_frame(level, 0) == true);
-    ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0);
+    ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0, 0);
     frame     = static_cast<QUICAckFrame *>(ack_frame);
 
     CHECK(frame->ack_block_count() == 0);
@@ -220,7 +220,7 @@ TEST_CASE("QUICAckFrameManager_loss_recover", "[quic]")
 
   // Initial state
   uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
-  QUICFrame *ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0);
+  QUICFrame *ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0, 0);
   QUICAckFrame *frame  = static_cast<QUICAckFrame *>(ack_frame);
   CHECK(frame == nullptr);
 
@@ -230,7 +230,7 @@ TEST_CASE("QUICAckFrameManager_loss_recover", "[quic]")
   ack_manager.update(level, 8, 1, false);
   ack_manager.update(level, 9, 1, false);
 
-  ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0);
+  ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0, 0);
   frame     = static_cast<QUICAckFrame *>(ack_frame);
   CHECK(frame != nullptr);
   CHECK(frame->ack_block_count() == 2);
@@ -242,7 +242,7 @@ TEST_CASE("QUICAckFrameManager_loss_recover", "[quic]")
 
   ack_manager.update(level, 7, 1, false);
   ack_manager.update(level, 4, 1, false);
-  ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0);
+  ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0, 0);
   frame     = static_cast<QUICAckFrame *>(ack_frame);
   CHECK(frame != nullptr);
   CHECK(frame->ack_block_count() == 1);
@@ -298,7 +298,7 @@ TEST_CASE("QUICAckFrameManager lost_frame", "[quic]")
   uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
 
   // Initial state
-  QUICFrame *ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0);
+  QUICFrame *ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0, 0);
   QUICAckFrame *frame  = static_cast<QUICAckFrame *>(ack_frame);
   CHECK(frame == nullptr);
 
@@ -308,7 +308,7 @@ TEST_CASE("QUICAckFrameManager lost_frame", "[quic]")
   ack_manager.update(level, 8, 1, false);
   ack_manager.update(level, 9, 1, false);
 
-  ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0);
+  ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0, 0);
   frame     = static_cast<QUICAckFrame *>(ack_frame);
   CHECK(frame != nullptr);
   CHECK(frame->ack_block_count() == 2);
@@ -318,7 +318,7 @@ TEST_CASE("QUICAckFrameManager lost_frame", "[quic]")
 
   ack_manager.on_frame_lost(frame->id());
   CHECK(ack_manager.will_generate_frame(level, 0) == true);
-  ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0);
+  ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0, 0);
   frame     = static_cast<QUICAckFrame *>(ack_frame);
   CHECK(frame != nullptr);
   CHECK(frame->ack_block_count() == 2);
@@ -332,7 +332,7 @@ TEST_CASE("QUICAckFrameManager lost_frame", "[quic]")
   ack_manager.update(level, 7, 1, false);
   ack_manager.update(level, 4, 1, false);
 
-  ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0);
+  ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0, 0);
   frame     = static_cast<QUICAckFrame *>(ack_frame);
   CHECK(frame != nullptr);
   CHECK(frame->ack_block_count() == 1);
@@ -352,7 +352,7 @@ TEST_CASE("QUICAckFrameManager ack only packet", "[quic]")
     uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
 
     // Initial state
-    QUICFrame *ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0);
+    QUICFrame *ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0, 0);
     QUICAckFrame *frame  = static_cast<QUICAckFrame *>(ack_frame);
     CHECK(frame == nullptr);
 
@@ -364,7 +364,7 @@ TEST_CASE("QUICAckFrameManager ack only packet", "[quic]")
 
     CHECK(ack_manager.will_generate_frame(level, 0) == true);
 
-    ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0);
+    ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0, 0);
     frame     = static_cast<QUICAckFrame *>(ack_frame);
     CHECK(frame != nullptr);
     CHECK(frame->ack_block_count() == 0);
@@ -384,7 +384,7 @@ TEST_CASE("QUICAckFrameManager ack only packet", "[quic]")
     uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
 
     // Initial state
-    QUICFrame *ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0);
+    QUICFrame *ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0, 0);
     QUICAckFrame *frame  = static_cast<QUICAckFrame *>(ack_frame);
     CHECK(frame == nullptr);
 
@@ -396,7 +396,7 @@ TEST_CASE("QUICAckFrameManager ack only packet", "[quic]")
 
     CHECK(ack_manager.will_generate_frame(level, 0) == true);
 
-    ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0);
+    ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0, 0);
     frame     = static_cast<QUICAckFrame *>(ack_frame);
     CHECK(frame != nullptr);
     CHECK(frame->ack_block_count() == 0);

--- a/iocore/net/quic/test/test_QUICFrame.cc
+++ b/iocore/net/quic/test/test_QUICFrame.cc
@@ -772,11 +772,11 @@ TEST_CASE("Load Padding Frame", "[quic]")
 {
   uint8_t frame_buf[QUICFrame::MAX_INSTANCE_SIZE];
   uint8_t buf1[] = {
-    0x00, // Type
+    0x00, 0x00, 0x00 // Type
   };
   const QUICFrame *frame1 = QUICFrameFactory::create(frame_buf, buf1, sizeof(buf1));
   CHECK(frame1->type() == QUICFrameType::PADDING);
-  CHECK(frame1->size() == 1);
+  CHECK(frame1->size() == 3);
   const QUICPaddingFrame *paddingFrame1 = static_cast<const QUICPaddingFrame *>(frame1);
   CHECK(paddingFrame1 != nullptr);
 }
@@ -787,11 +787,11 @@ TEST_CASE("Store Padding Frame", "[quic]")
   size_t len;
 
   uint8_t expected[] = {
-    0x00, // Type
+    0x00, 0x00, 0x00, // Type
   };
-  QUICPaddingFrame padding_frame;
+  QUICPaddingFrame padding_frame(3);
   padding_frame.store(buf, &len, 65535);
-  CHECK(len == 1);
+  CHECK(len == 3);
   CHECK(memcmp(buf, expected, len) == 0);
 }
 

--- a/iocore/net/quic/test/test_QUICStream.cc
+++ b/iocore/net/quic/test/test_QUICStream.cc
@@ -230,28 +230,28 @@ TEST_CASE("QUICBidiStream", "[quic]")
     write_buffer->write(data, 1024);
     stream->handleEvent(VC_EVENT_WRITE_READY, nullptr);
     CHECK(stream->will_generate_frame(level, 0) == true);
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     CHECK(frame->type() == QUICFrameType::STREAM);
     CHECK(stream->will_generate_frame(level, 0) == false);
 
     write_buffer->write(data, 1024);
     stream->handleEvent(VC_EVENT_WRITE_READY, nullptr);
     CHECK(stream->will_generate_frame(level, 0) == true);
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     CHECK(frame->type() == QUICFrameType::STREAM);
     CHECK(stream->will_generate_frame(level, 0) == false);
 
     write_buffer->write(data, 1024);
     stream->handleEvent(VC_EVENT_WRITE_READY, nullptr);
     CHECK(stream->will_generate_frame(level, 0) == true);
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     CHECK(frame->type() == QUICFrameType::STREAM);
     CHECK(stream->will_generate_frame(level, 0) == false);
 
     write_buffer->write(data, 1024);
     stream->handleEvent(VC_EVENT_WRITE_READY, nullptr);
     CHECK(stream->will_generate_frame(level, 0) == true);
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     CHECK(frame->type() == QUICFrameType::STREAM);
     CHECK(stream->will_generate_frame(level, 0) == false);
 
@@ -259,7 +259,7 @@ TEST_CASE("QUICBidiStream", "[quic]")
     write_buffer->write(data, 1024);
     stream->handleEvent(VC_EVENT_WRITE_READY, nullptr);
     CHECK(stream->will_generate_frame(level, 0) == true);
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     CHECK(frame);
     CHECK(frame->type() == QUICFrameType::STREAM_DATA_BLOCKED);
     CHECK(stream->will_generate_frame(level, 0) == true);
@@ -270,7 +270,7 @@ TEST_CASE("QUICBidiStream", "[quic]")
     // This should send a frame
     stream->handleEvent(VC_EVENT_WRITE_READY, nullptr);
     CHECK(stream->will_generate_frame(level, 0) == true);
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     CHECK(frame->type() == QUICFrameType::STREAM);
     CHECK(stream->will_generate_frame(level, 0) == false);
 
@@ -281,13 +281,13 @@ TEST_CASE("QUICBidiStream", "[quic]")
     write_buffer->write(data, 1024);
     stream->handleEvent(VC_EVENT_WRITE_READY, nullptr);
     CHECK(stream->will_generate_frame(level, 0) == true);
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     CHECK(frame->type() == QUICFrameType::STREAM);
     CHECK(stream->will_generate_frame(level, 0) == true);
 
     stream->handleEvent(VC_EVENT_WRITE_READY, nullptr);
     CHECK(stream->will_generate_frame(level, 0) == true);
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     CHECK(frame->type() == QUICFrameType::STREAM_DATA_BLOCKED);
 
     // Update window
@@ -295,7 +295,7 @@ TEST_CASE("QUICBidiStream", "[quic]")
 
     stream->handleEvent(VC_EVENT_WRITE_READY, nullptr);
     CHECK(stream->will_generate_frame(level, 0) == true);
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     CHECK(frame->type() == QUICFrameType::STREAM);
     CHECK(stream->will_generate_frame(level, 0) == false);
   }
@@ -329,10 +329,10 @@ TEST_CASE("QUICBidiStream", "[quic]")
     write_buffer->write(data1, sizeof(data1));
     stream->handleEvent(VC_EVENT_WRITE_READY, nullptr);
     // Generate STREAM frame
-    frame  = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame  = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     frame1 = static_cast<QUICStreamFrame *>(frame);
     CHECK(frame->type() == QUICFrameType::STREAM);
-    CHECK(stream->generate_frame(frame_buf, level, 4096, 4096, 0) == nullptr);
+    CHECK(stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0) == nullptr);
     CHECK(stream->will_generate_frame(level, 0) == false);
     stream->on_frame_lost(frame->id());
     CHECK(stream->will_generate_frame(level, 0) == true);
@@ -343,7 +343,7 @@ TEST_CASE("QUICBidiStream", "[quic]")
     // Lost the frame
     stream->on_frame_lost(frame->id());
     // Regenerate a frame
-    frame = stream->generate_frame(frame_buf2, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf2, level, 4096, 4096, 0, 0);
     // Lost data should be resent first
     frame2 = static_cast<QUICStreamFrame *>(frame);
     CHECK(frame->type() == QUICFrameType::STREAM);
@@ -370,15 +370,15 @@ TEST_CASE("QUICBidiStream", "[quic]")
     QUICFrame *frame          = nullptr;
 
     stream->reset(QUICStreamErrorUPtr(new QUICStreamError(stream.get(), QUIC_APP_ERROR_CODE_STOPPING)));
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     REQUIRE(frame);
     CHECK(frame->type() == QUICFrameType::RESET_STREAM);
     // Don't send it again untill it is considers as lost
-    CHECK(stream->generate_frame(frame_buf, level, 4096, 4096, 0) == nullptr);
+    CHECK(stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0) == nullptr);
     // Loss the frame
     stream->on_frame_lost(frame->id());
     // After the loss the frame should be regenerated
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     REQUIRE(frame);
     CHECK(frame->type() == QUICFrameType::RESET_STREAM);
   }
@@ -401,15 +401,15 @@ TEST_CASE("QUICBidiStream", "[quic]")
     QUICFrame *frame          = nullptr;
 
     stream->stop_sending(QUICStreamErrorUPtr(new QUICStreamError(stream.get(), QUIC_APP_ERROR_CODE_STOPPING)));
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     REQUIRE(frame);
     CHECK(frame->type() == QUICFrameType::STOP_SENDING);
     // Don't send it again untill it is considers as lost
-    CHECK(stream->generate_frame(frame_buf, level, 4096, 4096, 0) == nullptr);
+    CHECK(stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0) == nullptr);
     // Loss the frame
     stream->on_frame_lost(frame->id());
     // After the loss the frame should be regenerated
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     REQUIRE(frame);
     CHECK(frame->type() == QUICFrameType::STOP_SENDING);
   }
@@ -599,15 +599,15 @@ TEST_CASE("QUIC receive only stream", "[quic]")
     QUICFrame *frame          = nullptr;
 
     stream->stop_sending(QUICStreamErrorUPtr(new QUICStreamError(stream.get(), QUIC_APP_ERROR_CODE_STOPPING)));
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     REQUIRE(frame);
     CHECK(frame->type() == QUICFrameType::STOP_SENDING);
     // Don't send it again untill it is considers as lost
-    CHECK(stream->generate_frame(frame_buf, level, 4096, 4096, 0) == nullptr);
+    CHECK(stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0) == nullptr);
     // Loss the frame
     stream->on_frame_lost(frame->id());
     // After the loss the frame should be regenerated
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     REQUIRE(frame);
     CHECK(frame->type() == QUICFrameType::STOP_SENDING);
   }
@@ -688,28 +688,28 @@ TEST_CASE("QUIC send only stream", "[quic]")
     write_buffer->write(data, 1024);
     stream->handleEvent(VC_EVENT_WRITE_READY, nullptr);
     CHECK(stream->will_generate_frame(level, 0) == true);
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     CHECK(frame->type() == QUICFrameType::STREAM);
     CHECK(stream->will_generate_frame(level, 0) == false);
 
     write_buffer->write(data, 1024);
     stream->handleEvent(VC_EVENT_WRITE_READY, nullptr);
     CHECK(stream->will_generate_frame(level, 0) == true);
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     CHECK(frame->type() == QUICFrameType::STREAM);
     CHECK(stream->will_generate_frame(level, 0) == false);
 
     write_buffer->write(data, 1024);
     stream->handleEvent(VC_EVENT_WRITE_READY, nullptr);
     CHECK(stream->will_generate_frame(level, 0) == true);
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     CHECK(frame->type() == QUICFrameType::STREAM);
     CHECK(stream->will_generate_frame(level, 0) == false);
 
     write_buffer->write(data, 1024);
     stream->handleEvent(VC_EVENT_WRITE_READY, nullptr);
     CHECK(stream->will_generate_frame(level, 0) == true);
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     CHECK(frame->type() == QUICFrameType::STREAM);
     CHECK(stream->will_generate_frame(level, 0) == false);
 
@@ -717,7 +717,7 @@ TEST_CASE("QUIC send only stream", "[quic]")
     write_buffer->write(data, 1024);
     stream->handleEvent(VC_EVENT_WRITE_READY, nullptr);
     CHECK(stream->will_generate_frame(level, 0) == true);
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     CHECK(frame);
     CHECK(frame->type() == QUICFrameType::STREAM_DATA_BLOCKED);
     CHECK(stream->will_generate_frame(level, 0) == true);
@@ -728,7 +728,7 @@ TEST_CASE("QUIC send only stream", "[quic]")
     // This should send a frame
     stream->handleEvent(VC_EVENT_WRITE_READY, nullptr);
     CHECK(stream->will_generate_frame(level, 0) == true);
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     CHECK(frame->type() == QUICFrameType::STREAM);
     CHECK(stream->will_generate_frame(level, 0) == false);
 
@@ -739,13 +739,13 @@ TEST_CASE("QUIC send only stream", "[quic]")
     write_buffer->write(data, 1024);
     stream->handleEvent(VC_EVENT_WRITE_READY, nullptr);
     CHECK(stream->will_generate_frame(level, 0) == true);
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     CHECK(frame->type() == QUICFrameType::STREAM);
     CHECK(stream->will_generate_frame(level, 0) == true);
 
     stream->handleEvent(VC_EVENT_WRITE_READY, nullptr);
     CHECK(stream->will_generate_frame(level, 0) == true);
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     CHECK(frame->type() == QUICFrameType::STREAM_DATA_BLOCKED);
 
     // Update window
@@ -753,7 +753,7 @@ TEST_CASE("QUIC send only stream", "[quic]")
 
     stream->handleEvent(VC_EVENT_WRITE_READY, nullptr);
     CHECK(stream->will_generate_frame(level, 0) == true);
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     CHECK(frame->type() == QUICFrameType::STREAM);
     CHECK(stream->will_generate_frame(level, 0) == false);
   }
@@ -786,10 +786,10 @@ TEST_CASE("QUIC send only stream", "[quic]")
     write_buffer->write(data1, sizeof(data1));
     stream->handleEvent(VC_EVENT_WRITE_READY, nullptr);
     // Generate STREAM frame
-    frame  = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame  = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     frame1 = static_cast<QUICStreamFrame *>(frame);
     CHECK(frame->type() == QUICFrameType::STREAM);
-    CHECK(stream->generate_frame(frame_buf, level, 4096, 4096, 0) == nullptr);
+    CHECK(stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0) == nullptr);
     CHECK(stream->will_generate_frame(level, 0) == false);
     stream->on_frame_lost(frame->id());
     CHECK(stream->will_generate_frame(level, 0) == true);
@@ -800,7 +800,7 @@ TEST_CASE("QUIC send only stream", "[quic]")
     // Lost the frame
     stream->on_frame_lost(frame->id());
     // Regenerate a frame
-    frame = stream->generate_frame(frame_buf2, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf2, level, 4096, 4096, 0, 0);
     // Lost data should be resent first
     frame2 = static_cast<QUICStreamFrame *>(frame);
     CHECK(frame->type() == QUICFrameType::STREAM);
@@ -826,15 +826,15 @@ TEST_CASE("QUIC send only stream", "[quic]")
     QUICFrame *frame          = nullptr;
 
     stream->reset(QUICStreamErrorUPtr(new QUICStreamError(stream.get(), QUIC_APP_ERROR_CODE_STOPPING)));
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     REQUIRE(frame);
     CHECK(frame->type() == QUICFrameType::RESET_STREAM);
     // Don't send it again untill it is considers as lost
-    CHECK(stream->generate_frame(frame_buf, level, 4096, 4096, 0) == nullptr);
+    CHECK(stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0) == nullptr);
     // Loss the frame
     stream->on_frame_lost(frame->id());
     // After the loss the frame should be regenerated
-    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0);
+    frame = stream->generate_frame(frame_buf, level, 4096, 4096, 0, 0);
     REQUIRE(frame);
     CHECK(frame->type() == QUICFrameType::RESET_STREAM);
   }

--- a/iocore/net/quic/test/test_QUICStreamManager.cc
+++ b/iocore/net/quic/test/test_QUICStreamManager.cc
@@ -247,12 +247,12 @@ TEST_CASE("QUICStreamManager_total_offset_sent", "[quic]")
   // total_offset should be a integer in unit of octets
   uint8_t frame_buf[4096];
   mock_app.send(reinterpret_cast<uint8_t *>(block_1024->buf()), 1024, 0);
-  sm.generate_frame(frame_buf, QUICEncryptionLevel::ONE_RTT, 16384, 16384, 0);
+  sm.generate_frame(frame_buf, QUICEncryptionLevel::ONE_RTT, 16384, 16384, 0, 0);
   CHECK(sm.total_offset_sent() == 1024);
 
   // total_offset should be a integer in unit of octets
   mock_app.send(reinterpret_cast<uint8_t *>(block_1024->buf()), 1024, 4);
-  sm.generate_frame(frame_buf, QUICEncryptionLevel::ONE_RTT, 16384, 16384, 0);
+  sm.generate_frame(frame_buf, QUICEncryptionLevel::ONE_RTT, 16384, 16384, 0, 0);
   CHECK(sm.total_offset_sent() == 2048);
 
   // Wait for event processing


### PR DESCRIPTION
This is a part of the recovery-20. In recovery-20 we need to send a initial packet to elicit peers Initialize packets if we are on server side.

```
A.9. On Timeout
When the loss detection timer expires, the timer’s mode determines the action to be performed.

Pseudocode for OnLossDetectionTimeout follows:

OnLossDetectionTimeout():
  loss_time, pn_space = GetEarliestLossTime()
  if (loss_time != 0):
    // Time threshold loss Detection
    DetectLostPackets(pn_space)
  // Retransmit crypto data if no packets were lost
  // and there is crypto data to retransmit.
  else if (has unacknowledged crypto data):
    // Crypto retransmission timeout.
    RetransmitUnackedCryptoData()
    crypto_count++
  else if (endpoint is client without 1-RTT keys):
    // Client sends an anti-deadlock packet: Initial is padded
    // to earn more anti-amplification credit,
    // a Handshake packet proves address ownership.
    if (has Handshake keys):
       SendOneHandshakePacket()
     else:
       SendOnePaddedInitialPacket()
    crypto_count++
  else:
    // PTO. Send new data if available, else retransmit old data.
    // If neither is available, send a single PING frame.
    SendOneOrTwoPackets()
    pto_count++

  SetLossDetectionTimer()
```

The changes of this pr is mainly around the QUICPaddingFrame.
 - Adds QUICPadder to control padding frame
 - QUICPadderFrame is a resident of the several padding frames.
 - Adds current size of the packet to `generate_frame` to check whether we need to send padding frame or not.

`Warning: The padder should be the tail of the frame genearators`