### PR TITLE
HTTP/2: increment write_vio.ndone by consumed size

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -587,8 +587,8 @@ Http2Stream::update_write_request(IOBufferReader *buf_reader, int64_t write_len,
     // Still parsing the response_header
     int bytes_used = 0;
     int state      = this->response_header.parse_resp(&http_parser, this->response_reader, &bytes_used, false);
-    // HTTPHdr::parse_resp() consumed the response_reader in above
-    write_vio.ndone += this->response_header.length_get();
+    // HTTPHdr::parse_resp() consumed the response_reader in above (consumed size is `bytes_used`)
+    write_vio.ndone += bytes_used;
 
     switch (state) {
     case PARSE_RESULT_DONE: {


### PR DESCRIPTION
As @SolidWallOfCode pointed out on slack, when Http2Stream handle response header, ` write_vio.ndone` should be incremented by the size which `HTTPHdr::parse_resp()` used.

When the `state` is `PARSE_RESULT_DONE`, `this->response_header.length_get()` is same to `bytes_used`, but when the `state` is `PARSE_RESULT_CONT`, they are different. In that case, this could be problem.