### PR TITLE
HTTP/2: ignore unknown settings

### DIFF
--- a/proxy/http2/HTTP2.cc
+++ b/proxy/http2/HTTP2.cc
@@ -155,7 +155,8 @@ http2_settings_parameter_is_valid(const Http2SettingsParameter &param)
   };
 
   if (param.id == 0 || param.id >= HTTP2_SETTINGS_MAX) {
-    return false;
+    // Do nothing - 6.5.2 Unsupported parameters MUST be ignored
+    return true;
   }
 
   if (param.value > settings_max[param.id]) {

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -85,7 +85,7 @@ public:
     if (0 < id && id < HTTP2_SETTINGS_MAX) {
       return this->settings[indexof(id)] = value;
     } else {
-      // Do nothing - 6.5.3 Unsupported parameters MUST be ignored.
+      // Do nothing - 6.5.2 Unsupported parameters MUST be ignored
     }
 
     return 0;


### PR DESCRIPTION
[RFC 7540 6.5.2.](https://tools.ietf.org/html/rfc7540#section-6.5.2) says below

> An endpoint that receives a SETTINGS frame with any unknown or
   unsupported identifier MUST ignore that setting.

Prior this change, h2spec http2/6.5.2 was failed.
```
$ h2spec http2/6.5.2 -h localhost -p 4443 -t -k
Hypertext Transfer Protocol Version 2 (HTTP/2)
    6.5. SETTINGS
      6.5.2. Defined SETTINGS Parameters
        × 5: Sends a SETTINGS frame with unknown identifier
          -> The endpoint MUST ignore that setting.
             Expected: PING Frame (length:8, flags:0x01, stream_id:0, opaque_data:)
               Actual: Connection closed
```