### PR TITLE
Cleanup debug log in mime_hdr_describe

### DIFF
--- a/proxy/hdrs/MIME.cc
+++ b/proxy/hdrs/MIME.cc
@@ -2599,7 +2599,7 @@ mime_hdr_describe(HdrHeapObjImpl *raw, bool recurse)
   MIMEFieldBlockImpl *fblock;
   MIMEHdrImpl *obj = (MIMEHdrImpl *)raw;
 
-  Debug("http", "\n\t[PBITS: 0x%08X%08X, SLACC: 0x%04X%04X%04X%04X, HEADBLK: %p, TAILBLK: %p]",
+  Debug("http", "\t[PBITS: 0x%08X%08X, SLACC: 0x%04X%04X%04X%04X, HEADBLK: %p, TAILBLK: %p]",
         (uint32_t)((obj->m_presence_bits >> 32) & (TOK_64_CONST(0xFFFFFFFF))),
         (uint32_t)((obj->m_presence_bits >> 0) & (TOK_64_CONST(0xFFFFFFFF))), obj->m_slot_accelerators[0],
         obj->m_slot_accelerators[1], obj->m_slot_accelerators[2], obj->m_slot_accelerators[3], &(obj->m_first_fblock),


### PR DESCRIPTION
# Before
```
[Jun 17 10:42:36.483] [ET_NET 3] DEBUG: <MIME.cc:2606 (mime_hdr_describe)> (http)
        [PBITS: 0x0008000001000001, SLACC: 0xFFFFFFF1FFFFFFFFFFFFFFFFFFF0FFFF, HEADBLK: 0x148338f8, TAILBLK: 0x148338f8]
[Jun 17 10:42:36.483] [ET_NET 3] DEBUG: <MIME.cc:2611 (mime_hdr_describe)> (http)       [CBITS: 0x00000000, T_MAXAGE: 0, T_SMAXAGE: 0, T_MAXSTALE: 0, T_MINFRESH: 0, PNO$: 0]
```

# After
```
[Jun 17 10:42:36.483] [ET_NET 3] DEBUG: <MIME.cc:2606 (mime_hdr_describe)> (http)       [PBITS: 0x0008000001000001, SLACC: 0xFFFFFFF1FFFFFFFFFFFFFFFFFFF0FFFF, HEADBLK: 0x148338f8, TAILBLK: 0x148338f8]
[Jun 17 10:42:36.483] [ET_NET 3] DEBUG: <MIME.cc:2611 (mime_hdr_describe)> (http)       [CBITS: 0x00000000, T_MAXAGE: 0, T_SMAXAGE: 0, T_MAXSTALE: 0, T_MINFRESH: 0, PNO$: 0]
```