### PR TITLE
TS API - Adds the TSHttpTxnNextHopNameGet() function.

### DIFF
--- a/doc/admin-guide/plugins/lua.en.rst
+++ b/doc/admin-guide/plugins/lua.en.rst
@@ -1603,6 +1603,27 @@ Here is an example:
 
 `TOP <#lua-plugin>`_
 
+ts.server_request.server_addr.get_nexthop_name
+----------------------------------------------
+**syntax:** *ts.server_request.server_addr.get_nexthop_name()*
+
+**context:** function @ TS_LUA_HOOK_SEND_REQUEST_HDR hook point or later
+
+**description**: This function can be used to get the host name of the next hop to the origin server.
+
+The ts.server_request.server_addr.get_nexthop_name function returns the name as a string.
+
+Here is an example:
+
+::
+
+    function do_global_send_request()
+        name = ts.server_request.server_addr.get_nexthop_name()
+        print(name)             -- test
+    end
+
+`TOP <#ts-lua-plugin>`_
+
 ts.server_request.server_addr.get_ip
 ------------------------------------
 **syntax:** *ts.server_request.server_addr.get_ip()*

--- a/doc/developer-guide/api/functions/TSHttpTxnNextHopNameGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnNextHopNameGet.en.rst
@@ -1,0 +1,40 @@
+.. Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed
+   with this work for additional information regarding copyright
+   ownership.  The ASF licenses this file to you under the Apache
+   License, Version 2.0 (the "License"); you may not use this file
+   except in compliance with the License.  You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied.  See the License for the specific language governing
+   permissions and limitations under the License.
+
+.. include:: ../../../common.defs
+
+.. default-domain:: c
+
+TSHttpTxnNextHopNameGet
+***********************
+
+Synopsis
+========
+
+`#include <ts/ts.h>`
+
+.. function:: const char *TSHttpTxnNextHopNameGet(TSHttpTxn txnp)
+
+Description
+===========
+
+Get the next hop name for transaction :arg:`txnp`.
+
+.. note::
+
+   The pointer is valid only for the current callback. Clients that
+   need to keep the value across callbacks must maintain their own
+   storage.

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -1384,6 +1384,16 @@ tsapi TSReturnCode TSHttpTxnServerAddrSet(TSHttpTxn txnp, struct sockaddr const 
 */
 tsapi struct sockaddr const *TSHttpTxnNextHopAddrGet(TSHttpTxn txnp);
 
+/** Get the next hop name.
+ *
+    @note The pointer is valid only for the current callback. Clients
+    that need to keep the value across callbacks must maintain their
+    own storage.
+
+    @return The name of the next hop for transaction @a txnp.
+*/
+tsapi const char *TSHttpTxnNextHopNameGet(TSHttpTxn txnp);
+
 tsapi TSReturnCode TSHttpTxnClientFdGet(TSHttpTxn txnp, int *fdp);
 tsapi TSReturnCode TSHttpTxnOutgoingAddrSet(TSHttpTxn txnp, struct sockaddr const *addr);
 tsapi TSReturnCode TSHttpTxnOutgoingTransparencySet(TSHttpTxn txnp, int flag);

--- a/plugins/lua/ts_lua_server_request.c
+++ b/plugins/lua/ts_lua_server_request.c
@@ -75,6 +75,7 @@ static int ts_lua_server_request_server_addr_set_addr(lua_State *L);
 static int ts_lua_server_request_server_addr_get_outgoing_port(lua_State *L);
 static int ts_lua_server_request_server_addr_set_outgoing_addr(lua_State *L);
 static int ts_lua_server_request_server_addr_get_nexthop_addr(lua_State *L);
+static int ts_lua_server_request_server_addr_get_nexthop_name(lua_State *L);
 
 void
 ts_lua_inject_server_request_api(lua_State *L)
@@ -127,6 +128,9 @@ ts_lua_inject_server_request_server_addr_api(lua_State *L)
 
   lua_pushcfunction(L, ts_lua_server_request_server_addr_get_nexthop_addr);
   lua_setfield(L, -2, "get_nexthop_addr");
+
+  lua_pushcfunction(L, ts_lua_server_request_server_addr_get_nexthop_name);
+  lua_setfield(L, -2, "get_nexthop_name");
 
   lua_setfield(L, -2, "server_addr");
 
@@ -808,6 +812,25 @@ ts_lua_server_request_server_addr_get_nexthop_addr(lua_State *L)
   }
 
   return 3;
+}
+
+static int
+ts_lua_server_request_server_addr_get_nexthop_name(lua_State *L)
+{
+  ts_lua_http_ctx *http_ctx;
+  const char *name;
+
+  GET_HTTP_CONTEXT(http_ctx, L);
+
+  name = TSHttpTxnNextHopNameGet(http_ctx->txnp);
+
+  if (name == NULL) {
+    lua_pushnil(L);
+  } else {
+    lua_pushstring(L, name);
+  }
+
+  return 1;
 }
 
 static int

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -5592,6 +5592,23 @@ TSHttpTxnNextHopAddrGet(TSHttpTxn txnp)
   return &sm->t_state.current.server->dst_addr.sa;
 }
 
+const char *
+TSHttpTxnNextHopNameGet(TSHttpTxn txnp)
+{
+  sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
+
+  HttpSM *sm = reinterpret_cast<HttpSM *>(txnp);
+
+  /**
+   * Return zero if the server structure is not yet constructed.
+   */
+  if (sm->t_state.current.server == nullptr) {
+    return nullptr;
+  }
+
+  return sm->t_state.current.server->name;
+}
+
 TSReturnCode
 TSHttpTxnOutgoingTransparencySet(TSHttpTxn txnp, int flag)
 {


### PR DESCRIPTION
The new API function TSHttpTxnNextHopNameGet() is added to the API.
It is also added to the Lua plugin API as
ts.server_request.server_addr.get_nexthop_name(). This new call
operates in the same context as TSHttpTxnNextHopAddrGet() except
that it returns the host name string set by parent selection
for the next hop host rather than the socket (which provides IP
address, port, and address family).

The use case for this is when you must modify the send request
header based on the selected parent *and* mapping based on a
numeric IP is not feasible due to dynamic address changes
or a large number of addresses matching a parent host.