### PR TITLE
Fix the number of net_connections_currently_open_stat error increase

### DIFF
--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -6645,7 +6645,6 @@ TSVConnFdCreate(int fd)
     return nullptr;
   }
 
-  NET_SUM_GLOBAL_DYN_STAT(net_connections_currently_open_stat, 1);
   return reinterpret_cast<TSVConn>(vc);
 }
 


### PR DESCRIPTION
when connectUp success, connectUp function will increase net_connections_currently_open_stat, so it is no need in function TSVconnFdCreate.