### PR TITLE
Update MT_Hashtable interface to use smart pointer

### DIFF
--- a/include/tscore/MT_hashtable.h
+++ b/include/tscore/MT_hashtable.h
@@ -354,10 +354,10 @@ public:
     }
   }
 
-  ProxyMutex *
+  Ptr<ProxyMutex>
   lock_for_key(key_t key)
   {
-    return locks[part_num(key)].get();
+    return locks[part_num(key)];
   }
 
   int


### PR DESCRIPTION
Mutex_lock uses smartpointers after #4926, but MT_hashtable was not updated.

This is required by QUIC code.