### PR TITLE
Combohandler: Set response as private if one of the origin responses is private

### DIFF
--- a/doc/admin-guide/plugins/combo_handler.en.rst
+++ b/doc/admin-guide/plugins/combo_handler.en.rst
@@ -90,8 +90,8 @@ Combohandler follows a few rules for the "Cache-Control" header:
 1) All requested documents must have "immutable" for the combo'd
    response to also have "immutable".
 
-2) [Feature gated for 8.0 release] If one or more requested documents has "private" set,
-   then the combo'd response will also have "private". If no requested documents have a
+2) If one or more requested documents has "private" set, then the combo'd
+   response will also have "private". If no requested documents have a
    publicity setting, then the default is "public".
 
 3) The "max-age" value will be set to the smallest of all the requested "max-age"

--- a/plugins/esi/README.combo
+++ b/plugins/esi/README.combo
@@ -66,8 +66,8 @@ Combohandler follows a few rules for the "Cache-Control" header:
 1) All requested documents must have "immutable" for the combo'd
    response to also have "immutable".
 
-2) [Feature gated for 8.0 release] If one or more requested documents has "private" set,
-   then the combo'd response will also have "private". If no requested documents have a
+2) If one or more requested documents has "private" set, then the combo'd
+   response will also have "private". If no requested documents have a
    publicity setting, then the default is "public".
 
 3) The "max-age" value will be set to the smallest of all the requested "max-age"

--- a/plugins/esi/combo_handler.cc
+++ b/plugins/esi/combo_handler.cc
@@ -45,7 +45,6 @@ using namespace std;
 using namespace EsiLib;
 
 #define DEBUG_TAG "combo_handler"
-#define FEAT_GATE_8_0
 
 // Because STL vs. C library leads to ugly casting, fix it once.
 inline int
@@ -282,18 +281,14 @@ CacheControlHeader::generate() const
   const char *publicity;
   const char *immutable;
 
-// TODO This feature gate should be removed for the 8.0 release. Previously, all combo_cache
-// documents were public. However, that's a bug. If any requested document is private the combo_cache
-// document should private as well.
-#ifndef FEAT_GATE_8_0
+  // Previously, all combo_cache documents were public. However, that's a bug. If any requested document is private the combo_cache
+  // document should private as well.
   if (_publicity == Publicity::PUBLIC || _publicity == Publicity::DEFAULT) {
     publicity = TS_HTTP_VALUE_PUBLIC;
   } else {
     publicity = TS_HTTP_VALUE_PRIVATE;
   }
-#else
-  publicity = TS_HTTP_VALUE_PUBLIC;
-#endif
+
   immutable = (_immutable ? ", " HTTP_IMMUTABLE : "");
   max_age   = (_max_age == numeric_limits<unsigned int>::max() ? 315360000 : _max_age); // default is 10 years
 


### PR DESCRIPTION
Fixes #1599

Original Commit: 9d33ca209bcd04d118ed1fea634423a6bafb8884