### PR TITLE
TSIOBufferReaderCopy: copy data from a reader to a fixed buffer.

### DIFF
--- a/doc/developer-guide/api/functions/TSSslClientCertUpdate.en.rst
+++ b/doc/developer-guide/api/functions/TSSslClientCertUpdate.en.rst
@@ -14,7 +14,7 @@
    implied.  See the License for the specific language governing
    permissions and limitations under the License.
 
-.. include:: ../../../common.defs
+.. include:: /common.defs
 
 .. default-domain:: c
 
@@ -35,5 +35,5 @@ Description
 
 :func:`TSSslClientCertUpdate` updates existing client certificates configured in :file:`sni.yaml` or
 `proxy.config.ssl.client.cert.filename`. :arg:`cert_path` should be exact match as provided in
-configurations. :func:`TSSslClientCertUpdate` returns `TS_SUCCESS` only if :arg:`cert_path` exists
+configurations. :func:`TSSslClientCertUpdate` returns :c:macro:`TS_SUCCESS` only if :arg:`cert_path` exists
 in configuration and reloaded to update the context.

--- a/include/ts/InkAPIPrivateIOCore.h
+++ b/include/ts/InkAPIPrivateIOCore.h
@@ -132,7 +132,6 @@ tsapi TSMutex TSMutexCreateInternal(void);
 tsapi int TSMutexCheck(TSMutex mutex);
 
 /* IOBuffer */
-tsapi void TSIOBufferReaderCopy(TSIOBufferReader readerp, const void *buf, int64_t length);
 tsapi int64_t TSIOBufferBlockDataSizeGet(TSIOBufferBlock blockp);
 tsapi void TSIOBufferBlockDestroy(TSIOBufferBlock blockp);
 typedef void *INKUDPPacket;

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -1992,6 +1992,7 @@ tsapi void TSIOBufferReaderFree(TSIOBufferReader readerp);
 tsapi TSIOBufferBlock TSIOBufferReaderStart(TSIOBufferReader readerp);
 tsapi void TSIOBufferReaderConsume(TSIOBufferReader readerp, int64_t nbytes);
 tsapi int64_t TSIOBufferReaderAvail(TSIOBufferReader readerp);
+tsapi int64_t TSIOBufferReaderCopy(TSIOBufferReader readerp, void *buf, int64_t length);
 
 tsapi struct sockaddr const *TSNetVConnLocalAddrGet(TSVConn vc);
 

--- a/iocore/eventsystem/IOBuffer.cc
+++ b/iocore/eventsystem/IOBuffer.cc
@@ -257,9 +257,9 @@ IOBufferReader::memchr(char c, int64_t len, int64_t offset)
 }
 
 char *
-IOBufferReader::memcpy(const void *ap, int64_t len, int64_t offset)
+IOBufferReader::memcpy(void *ap, int64_t len, int64_t offset)
 {
-  char *p          = (char *)ap;
+  char *p          = static_cast<char *>(ap);
   IOBufferBlock *b = block.get();
   offset += start_offset;
 

--- a/iocore/eventsystem/I_IOBuffer.h
+++ b/iocore/eventsystem/I_IOBuffer.h
@@ -859,7 +859,7 @@ public:
       parameter buf is set to this value also.
 
   */
-  inkcoreapi char *memcpy(const void *buf, int64_t len = INT64_MAX, int64_t offset = 0);
+  inkcoreapi char *memcpy(void *buf, int64_t len = INT64_MAX, int64_t offset = 0);
 
   /**
     Subscript operator. Returns a reference to the character at the

--- a/src/traffic_server/InkIOCoreAPI.cc
+++ b/src/traffic_server/InkIOCoreAPI.cc
@@ -633,12 +633,12 @@ TSIOBufferWrite(TSIOBuffer bufp, const void *buf, int64_t length)
   return b->write(buf, length);
 }
 
-// not in SDK3.0
-void
-TSIOBufferReaderCopy(TSIOBufferReader readerp, const void *buf, int64_t length)
+int64_t
+TSIOBufferReaderCopy(TSIOBufferReader readerp, void *buf, int64_t length)
 {
-  IOBufferReader *r = (IOBufferReader *)readerp;
-  r->memcpy(buf, length);
+  auto r{reinterpret_cast<IOBufferReader *>(readerp)};
+  char *limit = r->memcpy(buf, length, 0);
+  return limit - static_cast<char *>(buf);
 }
 
 void


### PR DESCRIPTION
I originally intended to implement `TSIOBufferReaderRead` to parallel `TSIOBufferWrite`, which copies data between a fixed sized buffer and an IOBuffer. Somehow the documentation I wrote for it got in to the official documentation, which confused people because the function looked useful but didn't actually exist.

I started this PR to remedy this discrepancy by implementing the function but near the end discovered it was already (mostly) implemented, but _hidden from the plugin API_ for some Turing forsaken reason. 

I also had to fix an API issue in `IOBufferReader::memcpy` which wanted the destination buffer to be `const void *`, which makes no sense. This wasn't noticed due to the C style cast which not only changed the type but cast away `const`. DO NOT USE C STYLE CASTS! Once I switched to a C++ cast the problem was obvious.

I also cleaned up the documentation, and tweaked the function to return the number of characters copied.