### PR TITLE
Added end pointer to ink_atoi64 and used when parsing cache size

### DIFF
--- a/include/tscore/ParseRules.h
+++ b/include/tscore/ParseRules.h
@@ -825,7 +825,7 @@ ink_get_hex(char c)
   return (int)((c - 'a') + 10);
 }
 
-int64_t ink_atoi64(const char *);
+int64_t ink_atoi64(const char *, const char **end = nullptr);
 uint64_t ink_atoui64(const char *);
 int64_t ink_atoi64(const char *, int);
 

--- a/iocore/cache/Store.cc
+++ b/iocore/cache/Store.cc
@@ -369,7 +369,8 @@ Store::read_config()
     const char *e;
     while (nullptr != (e = tokens.getNext())) {
       if (ParseRules::is_digit(*e)) {
-        if ((size = ink_atoi64(e)) <= 0) {
+        const char *end;
+        if ((size = ink_atoi64(e, &end)) <= 0 || *end != '\0') {
           delete sd;
           Error("storage.config failed to load");
           return Result::failure("failed to parse size '%s'", e);

--- a/src/tscore/Makefile.am
+++ b/src/tscore/Makefile.am
@@ -169,6 +169,7 @@ test_tscore_SOURCES = \
 	unit_tests/test_List.cc \
 	unit_tests/test_MemArena.cc \
 	unit_tests/test_MT_hashtable.cc \
+  unit_tests/test_ParseRules.cc \
 	unit_tests/test_PriorityQueue.cc \
 	unit_tests/test_Ptr.cc \
 	unit_tests/test_Regex.cc \

--- a/src/tscore/ParseRules.cc
+++ b/src/tscore/ParseRules.cc
@@ -48,7 +48,7 @@ const char parseRulesCTypeToLower[256] = {
 //   2. They all honor the SI multipliers (i.e. K, M, G and T.
 //
 int64_t
-ink_atoi64(const char *str)
+ink_atoi64(const char *str, const char **end)
 {
   int64_t num  = 0;
   int negative = 0;
@@ -79,12 +79,16 @@ ink_atoi64(const char *str)
     if (*str) {
       if (*str == 'K') {
         num = num * (1LL << 10);
+        str++;
       } else if (*str == 'M') {
         num = num * (1LL << 20);
+        str++;
       } else if (*str == 'G') {
         num = num * (1LL << 30);
+        str++;
       } else if (*str == 'T') {
         num = num * (1LL << 40);
+        str++;
       }
     }
 #endif
@@ -92,6 +96,11 @@ ink_atoi64(const char *str)
       num = -num;
     }
   }
+
+  if (end != nullptr) {
+    *end = str;
+  }
+
   return num;
 }
 

--- a/src/tscore/unit_tests/test_ParseRules.cc
+++ b/src/tscore/unit_tests/test_ParseRules.cc
@@ -1,0 +1,93 @@
+/** @file
+
+    ParseRules unit test
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "../../../tests/include/catch.hpp"
+#include <tscore/ParseRules.h>
+#include <iostream>
+
+TEST_CASE("parse_rules", "[libts][parse_rules]")
+{
+  // test "100"
+  {
+    const char *end = nullptr;
+    int64_t value   = ink_atoi64("100", &end);
+    REQUIRE(value == 100);
+    REQUIRE(*end == '\0');
+  }
+
+  // testf "1M"
+  {
+    const char *end = nullptr;
+    int64_t value   = ink_atoi64("1M", &end);
+    REQUIRE(value == 1 << 20);
+    REQUIRE(*end == '\0');
+  }
+
+  // test -100
+  {
+    const char *end = nullptr;
+    int64_t value   = ink_atoi64("-100", &end);
+    REQUIRE(value == -100);
+    REQUIRE(*end == '\0');
+  }
+
+  // testf "-1M"
+  {
+    const char *end = nullptr;
+    int64_t value   = ink_atoi64("-1M", &end);
+    REQUIRE(value == (1 << 20) * -1);
+    REQUIRE(*end == '\0');
+  }
+
+  // test "9223372036854775807"
+  {
+    const char *end = nullptr;
+    int64_t value   = ink_atoi64("9223372036854775807", &end);
+    REQUIRE(value == 9223372036854775807ull);
+    REQUIRE(*end == '\0');
+  }
+
+  // test "-9223372036854775807"
+  {
+    const char *end = nullptr;
+    int64_t value   = ink_atoi64("-9223372036854775807", &end);
+    REQUIRE(value == -9223372036854775807ll);
+    REQUIRE(*end == '\0');
+  }
+
+  // testf "1.5T" - error case
+  {
+    const char *end = nullptr;
+    int64_t value   = ink_atoi64("1.5T", &end);
+    REQUIRE(value != 1649267441664);
+    REQUIRE(*end != '\0');
+  }
+
+  // testf "asdf" - error case
+  {
+    const char *end = nullptr;
+    int64_t value   = ink_atoi64("asdf", &end);
+    REQUIRE(value == 0);
+    REQUIRE(*end != '\0');
+  }
+}

--- a/tests/gold_tests/autest-site/min_cfg/storage.config
+++ b/tests/gold_tests/autest-site/min_cfg/storage.config
@@ -1,4 +1,4 @@
 # seems good enought for doing something for playing with.
 # not good for production
 # File must exist and must have this value in it
-storage 256MB
+storage 256M


### PR DESCRIPTION
Fixes #3177

Now ATS will report an error if it can't fully parse the size:
```
17:00:04 C02XF1ULJG5J:(storage_parse)~/dev/apache/trafficserver$ sudo src/traffic_server/traffic_server
Traffic Server 9.0.0 Jun 24 2019 16:22:10 C02XF1ULJG5J
traffic_server: using root directory '/usr/local'
Fatal: Failed to read cache storage configuration: failed to parse size '1.5T'
```