### PR TITLE
This fixes state machine looping when using upstream connection throttling with parent selection

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -4663,8 +4663,13 @@ HttpSM::do_cache_prepare_action(HttpCacheSM *c_sm, CacheHTTPInfo *object_read_in
 void
 HttpSM::send_origin_throttled_response()
 {
-  t_state.current.attempts = t_state.txn_conf->connect_attempts_max_retries;
-  t_state.current.state    = HttpTransact::OUTBOUND_CONGESTION;
+  // if the request is to a parent proxy, do not reset
+  // t_state.current.attempts so that another parent or
+  // NextHop may be tried.
+  if (t_state.current.request_to != HttpTransact::PARENT_PROXY) {
+    t_state.current.attempts = t_state.txn_conf->connect_attempts_max_retries;
+  }
+  t_state.current.state = HttpTransact::OUTBOUND_CONGESTION;
   call_transact_and_set_next_state(HttpTransact::HandleResponse);
 }
 


### PR DESCRIPTION
Fixes #5642 when using upstream connection throttling with parent selection.

Parent Selection may be used to provide redundancy and load balancing to origin servers.  If upstream connection throttling is used on these origins, a state machine loop can occur that leads to a crash as the parent selection handlers did not handle this congestion connection throttling.  This patch adds congestion connection throttling to the HttpSM parent handler,handle_response_from_parent().