### PR TITLE
Log H2 errors with the codes

### DIFF
--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -239,7 +239,7 @@ struct Http2FrameHeader {
 // [RFC 7540] 5.4. Error Handling
 struct Http2Error {
   Http2Error(const Http2ErrorClass error_class = Http2ErrorClass::HTTP2_ERROR_CLASS_NONE,
-             const Http2ErrorCode error_code = Http2ErrorCode::HTTP2_ERROR_NO_ERROR, const char *err_msg = nullptr)
+             const Http2ErrorCode error_code = Http2ErrorCode::HTTP2_ERROR_NO_ERROR, const char *err_msg = "")
   {
     cls  = error_class;
     code = error_code;

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -970,8 +970,8 @@ Http2ConnectionState::main_event_handler(int event, void *edata)
       const char *client_ip = ats_ip_ntop(ua_session->get_client_addr(), ipb, sizeof(ipb));
       if (error.cls == Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION) {
         if (error.msg) {
-          Error("HTTP/2 connection error client_ip=%s session_id=%" PRId64 " stream_id=%u %s", client_ip,
-                ua_session->connection_id(), stream_id, error.msg);
+          Error("HTTP/2 connection error code=0x%02x client_ip=%s session_id=%" PRId64 " stream_id=%u %s",
+                static_cast<int>(error.code), client_ip, ua_session->connection_id(), stream_id, error.msg);
         }
         this->send_goaway_frame(this->latest_streamid_in, error.code);
         this->ua_session->set_half_close_local_flag(true);
@@ -983,8 +983,8 @@ Http2ConnectionState::main_event_handler(int event, void *edata)
         // The Http2ClientSession will shutdown because connection_state.is_state_closed() will be true
       } else if (error.cls == Http2ErrorClass::HTTP2_ERROR_CLASS_STREAM) {
         if (error.msg) {
-          Error("HTTP/2 stream error client_ip=%s session_id=%" PRId64 " stream_id=%u %s", client_ip, ua_session->connection_id(),
-                stream_id, error.msg);
+          Error("HTTP/2 stream error code=0x%02x client_ip=%s session_id=%" PRId64 " stream_id=%u %s", static_cast<int>(error.code),
+                client_ip, ua_session->connection_id(), stream_id, error.msg);
         }
         this->send_rst_stream_frame(stream_id, error.code);
       }


### PR DESCRIPTION
H2 errors are logged only if they have error messages, and even with the messages, actual error codes are not logged.

We should log all errors with the codes at these places so that we can see what happened. If you don't want to log some particular errors for some reasons, you can skip these logging by passing `nullptr` as an error message (the default message is an empty string).

If everything is working well, amount of logs should not increase.

I'd like to backport this change to older versions because I think this is essential information for troubleshooting.