### PR TITLE
Fix typo in lua plugin documentation

### DIFF
--- a/doc/admin-guide/plugins/lua.en.rst
+++ b/doc/admin-guide/plugins/lua.en.rst
@@ -3429,7 +3429,7 @@ Here is an example:
 ::
 
     function do_remap()
-        ts.http.timeout_set(TS_LUA_TIMEOUT_DNS, 30)    -- 30 seconds
+        ts.http.timeout_set(TS_LUA_TIMEOUT_DNS, 30)    -- 30 ms
         return 0
     end
 


### PR DESCRIPTION
@mlibbey Pls help to review a tiny mistake in the lua plugin documentation. Thanks.