### PR TITLE
QUIC: revert makefile changes

### DIFF
--- a/iocore/net/quic/Makefile.am
+++ b/iocore/net/quic/Makefile.am
@@ -130,6 +130,7 @@ test_CPPFLAGS = \
 
 test_LDADD = \
   libquic.a \
+  $(top_builddir)/iocore/net/libinknet.a \
   $(top_builddir)/iocore/eventsystem/libinkevent.a \
   $(top_builddir)/mgmt/libmgmt_p.la \
   $(top_builddir)/lib/records/librecords_p.a \
@@ -140,9 +141,11 @@ test_LDADD = \
   @HWLOC_LIBS@ @OPENSSL_LIBS@ @LIBPCRE@ @YAMLCPP_LIBS@
 
 test_event_main_SOURCES = \
+  ../libinknet_stub.cc \
   ./test/event_processor_main.cc
 
 test_main_SOURCES = \
+  ../libinknet_stub.cc \
   ./test/main.cc
 
 test_QUICAckFrameCreator_CPPFLAGS = $(test_CPPFLAGS)


### PR DESCRIPTION
```
make[1]: *** [Makefile:1519: test_QUICPacketHeaderProtector] Error 1
../../../lib/records/librecords_p.a(RecProcess.o): In function `RecMessageInit()':
/home/scw00/trafficserver/lib/records/RecProcess.cc:227: undefined reference to `pmgmt'
/home/scw00/trafficserver/lib/records/RecProcess.cc:227: undefined reference to `BaseManager::registerMgmtCallback(int, std::function<void (ts::MemSpan<void>)> const&)'
../../../lib/records/librecords_p.a(RecProcess.o): In function `RecSignalManager(int, char const*, unsigned long)':
/home/scw00/trafficserver/lib/records/RecProcess.cc:291: undefined reference to `pmgmt'
/home/scw00/trafficserver/lib/records/RecProcess.cc:292: undefined reference to `pmgmt'
/home/scw00/trafficserver/lib/records/RecProcess.cc:292: undefined reference to `ProcessManager::signalManager(int, char const*, int)'
../../../lib/records/librecords_p.a(RecProcess.o): In function `RecRegisterManagerCb(int, std::function<void (ts::MemSpan<void>)> const&)':
/home/scw00/trafficserver/lib/records/RecProcess.cc:298: undefined reference to `pmgmt'
/home/scw00/trafficserver/lib/records/RecProcess.cc:298: undefined reference to `BaseManager::registerMgmtCallback(int, std::function<void (ts::MemSpan<void>)> const&)'
../../../lib/records/librecords_p.a(RecProcess.o): In function `RecMessageSend(RecMessageHdr*)':
/home/scw00/trafficserver/lib/records/RecProcess.cc:318: undefined reference to `pmgmt'
/home/scw00/trafficserver/lib/records/RecProcess.cc:318: undefined reference to `ProcessManager::signalManager(int, char const*, int)'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:1511: test_QUICPacketFactory] Error 1
../../../lib/records/librecords_p.a(RecProcess.o): In function `RecMessageInit()':
/home/scw00/trafficserver/lib/records/RecProcess.cc:227: undefined reference to `pmgmt'
/home/scw00/trafficserver/lib/records/RecProcess.cc:227: undefined reference to `BaseManager::registerMgmtCallback(int, std::function<void (ts::MemSpan<void>)> const&)'
../../../lib/records/librecords_p.a(RecProcess.o): In function `RecSignalManager(int, char const*, unsigned long)':
/home/scw00/trafficserver/lib/records/RecProcess.cc:291: undefined reference to `pmgmt'
/home/scw00/trafficserver/lib/records/RecProcess.cc:292: undefined reference to `pmgmt'
/home/scw00/trafficserver/lib/records/RecProcess.cc:292: undefined reference to `ProcessManager::signalManager(int, char const*, int)'
../../../lib/records/librecords_p.a(RecProcess.o): In function `RecRegisterManagerCb(int, std::function<void (ts::MemSpan<void>)> const&)':
/home/scw00/trafficserver/lib/records/RecProcess.cc:298: undefined reference to `pmgmt'
/home/scw00/trafficserver/lib/records/RecProcess.cc:298: undefined reference to `BaseManager::registerMgmtCallback(int, std::function<void (ts::MemSpan<void>)> const&)'
../../../lib/records/librecords_p.a(RecProcess.o): In function `RecMessageSend(RecMessageHdr*)':
/home/scw00/trafficserver/lib/records/RecProcess.cc:318: undefined reference to `pmgmt'
/home/scw00/trafficserver/lib/records/RecProcess.cc:318: undefined reference to `ProcessManager::signalManager(int, char const*, int)'
collect2: error: ld returned 1 exit status

```

Build failed under centos 7 