### PR TITLE
Add MIMEHdr Garbage Collection to HPACK Dynamic Table

### DIFF
--- a/proxy/hdrs/HdrHeap.cc
+++ b/proxy/hdrs/HdrHeap.cc
@@ -1124,6 +1124,24 @@ HdrHeap::dump_heap(int len)
   fprintf(stderr, "\n-------------- End header heap dump -----------\n");
 }
 
+uint64_t
+HdrHeap::total_used_size() const
+{
+  uint64_t size    = 0;
+  const HdrHeap *h = this;
+
+  while (h) {
+    size += (h->m_free_start - h->m_data_start);
+    h = h->m_next;
+  }
+
+  return size;
+}
+
+//
+// HdrStrHeap
+//
+
 void
 HdrStrHeap::free()
 {

--- a/proxy/hdrs/HdrHeap.h
+++ b/proxy/hdrs/HdrHeap.h
@@ -287,6 +287,8 @@ public:
   size_t required_space_for_evacuation();
   bool attach_str_heap(char const *h_start, int h_len, RefCountObj *h_ref_obj, int *index);
 
+  uint64_t total_used_size() const;
+
   /** Struct to prevent garbage collection on heaps.
       This bumps the reference count to the heap containing the pointer
       while the instance of this class exists. When it goes out of scope

--- a/proxy/http2/HPACK.h
+++ b/proxy/http2/HPACK.h
@@ -112,13 +112,7 @@ public:
     _mhdr->create();
   }
 
-  ~HpackDynamicTable()
-  {
-    _headers.clear();
-    _mhdr->fields_clear();
-    _mhdr->destroy();
-    delete _mhdr;
-  }
+  ~HpackDynamicTable();
 
   // noncopyable
   HpackDynamicTable(HpackDynamicTable &) = delete;
@@ -135,11 +129,13 @@ public:
 
 private:
   bool _evict_overflowed_entries();
+  void _mime_hdr_gc();
 
-  uint32_t _current_size;
-  uint32_t _maximum_size;
+  uint32_t _current_size = 0;
+  uint32_t _maximum_size = 0;
 
-  MIMEHdr *_mhdr;
+  MIMEHdr *_mhdr     = nullptr;
+  MIMEHdr *_mhdr_old = nullptr;
   std::vector<MIMEField *> _headers;
 };
 


### PR DESCRIPTION
Prior this change, the size of HdrHeap which is owned by MIMEHdr of HpackDynamicTable had no limit.
Because when MIMEFiled is deleted the allocated memory of the HdrHeap was not freed.
To mitigate this issue, when HdrHeap size exceeds the threshold, HpackDynamicTable start using new MIMEHdr and HdrHeap.
The old MIMEHdr and HdrHeap will be freed, when all MIMEFiled is deleted by HPACK Dynamic Table Entry Eviction.