### PR TITLE
fix If-Match and If-Unmodified-Since priority problem

### DIFF
--- a/proxy/http/HttpTransactCache.cc
+++ b/proxy/http/HttpTransactCache.cc
@@ -1269,7 +1269,6 @@ HttpTransactCache::match_response_to_request_conditionals(HTTPHdr *request, HTTP
       // sub-ranges, we can do a weak validation.                           //
       ////////////////////////////////////////////////////////////////////////
       if (do_strings_match_weakly(raw_etags, raw_etags_len, comma_sep_tag_list, comma_sep_tag_list_len)) {
-        // the response already failed If-modified-since (if one exists)
         return HTTP_STATUS_NOT_MODIFIED;
       } else {
         return response->status_get();
@@ -1313,24 +1312,6 @@ HttpTransactCache::match_response_to_request_conditionals(HTTPHdr *request, HTTP
     return response_code;
   }
 
-  // return PRECONDITIONAL_FAILED if either If-unmodified-since
-  // or If-match fails
-  // BUT, return the original response code only if both pass
-
-  // If-Unmodified-Since //
-  if (request->presence(MIME_PRESENCE_IF_UNMODIFIED_SINCE)) {
-    // lm_value is zero if Last-modified not exists
-    ink_time_t lm_value = response->get_last_modified();
-
-    // Condition fails if Last-modified not exists
-    if ((request->get_if_unmodified_since() < lm_value) || (lm_value == 0)) {
-      return HTTP_STATUS_PRECONDITION_FAILED;
-    } else {
-      // we cannot return yet, need to check If-match
-      response_code = response->status_get();
-    }
-  }
-
   // If-Match: must match strongly //
   if (request->presence(MIME_PRESENCE_IF_MATCH)) {
     int raw_etags_len, comma_sep_tag_list_len;
@@ -1352,13 +1333,25 @@ HttpTransactCache::match_response_to_request_conditionals(HTTPHdr *request, HTTP
     }
 
     if (do_strings_match_strongly(raw_etags, raw_etags_len, comma_sep_tag_list, comma_sep_tag_list_len)) {
-      // at the point, the response passed both If-unmodified-since
-      // and If-match, so we can return the original response code
       return response->status_get();
     } else {
       return HTTP_STATUS_PRECONDITION_FAILED;
     }
   }
+
+  // If-Unmodified-Since //
+  if (request->presence(MIME_PRESENCE_IF_UNMODIFIED_SINCE)) {
+    // lm_value is zero if Last-modified not exists
+    ink_time_t lm_value = response->get_last_modified();
+
+    // Condition fails if Last-modified not exists
+    if ((request->get_if_unmodified_since() < lm_value) || (lm_value == 0)) {
+      return HTTP_STATUS_PRECONDITION_FAILED;
+    } else {
+      response_code = response->status_get();
+    }
+  }
+
   // There is no If-match, and If-unmodified-since passed,
   // so return the original response code
   if (response_code != HTTP_STATUS_NONE) {


### PR DESCRIPTION
A recipient MUST ignore If-Unmodified-Since if the request contains
   an If-Match header field，about rfc https://tools.ietf.org/html/rfc7232#section-3.3.