### PR TITLE
Make TSVConnInacitivityTimeoutCancel work as expected.

### DIFF
--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -386,8 +386,8 @@ inline void
 UnixNetVConnection::cancel_inactivity_timeout()
 {
   Debug("socket", "Cancel inactive timeout for NetVC=%p", this);
-  inactivity_timeout_in = 0;
-  set_inactivity_timeout(0);
+  inactivity_timeout_in      = 0;
+  next_inactivity_timeout_at = 0;
 }
 
 inline void


### PR DESCRIPTION
Without this change, the set_inactivity_timeout(0) will in fact set the inactivity timeout to proxy.config.net.default_inactivity_timeout rather than just eliminating the timeout.  Most of the time it is not desirable to clear the inactivity timeout, but if we have a PluginAPI that promises to do that, we should actually implement it correctly or remove the API.

I ran across an internal plugin where canceling the inactivity timeout on a secondary pipe that was made a TSVConn made sense.  Not actually cancelling the timeout caused an additional week of confusion before we just set the inactivity timeout "really high".

Discussed this issue in #5691 