### PR TITLE
Fix client transaction stats

### DIFF
--- a/proxy/ProxyTransaction.cc
+++ b/proxy/ProxyTransaction.cc
@@ -49,6 +49,7 @@ ProxyTransaction::new_transaction()
     current_reader->plugin_id  = pi->getPluginId();
   }
 
+  this->increment_client_transactions_stat();
   current_reader->attach_client_session(this, sm_reader);
 }
 
@@ -57,6 +58,8 @@ ProxyTransaction::release(IOBufferReader *r)
 {
   HttpTxnDebug("[%" PRId64 "] session released by sm [%" PRId64 "]", proxy_ssn ? proxy_ssn->connection_id() : 0,
                current_reader ? current_reader->sm_id : 0);
+
+  this->decrement_client_transactions_stat();
 
   // Pass along the release to the session
   if (proxy_ssn) {


### PR DESCRIPTION
Fix #5619. 

https://github.com/apache/trafficserver/commit/92338aed4d2ec8fc0ba9132e88ac12d97b08c7aa removed `increment_client_transactions_stat()`/`increment_client_transactions_stat()` function calls.

- https://github.com/apache/trafficserver/commit/92338aed4d2ec8fc0ba9132e88ac12d97b08c7aa#diff-9c809c3761b279ca1d9aea6b3f952b2fL52
- https://github.com/apache/trafficserver/commit/92338aed4d2ec8fc0ba9132e88ac12d97b08c7aa#diff-9c809c3761b279ca1d9aea6b3f952b2fL62

This revert the changes.