### PR TITLE
Add a required library to "Getting Started" docs

### DIFF
--- a/doc/getting-started/index.en.rst
+++ b/doc/getting-started/index.en.rst
@@ -159,6 +159,7 @@ libraries on the machine used to build |TS|:
 - flex (for TPROXY)
 - hwloc
 - lua
+- zlib
 - curses (for traffic_top)
 - curl (for traffic_top)
 


### PR DESCRIPTION
Noticed that zlib is required but missing from the docs when I was trying to compile ATS on a fresh OS