### PR TITLE
Enable logging of the Elliptic Curve used to communicate with the client

### DIFF
--- a/doc/admin-guide/logging/formatting.en.rst
+++ b/doc/admin-guide/logging/formatting.en.rst
@@ -577,6 +577,7 @@ SSL / Encryption
 .. _cqssr:
 .. _cqssv:
 .. _cqssc:
+.. _cqssu:
 .. _pqssl:
 
 Fields which expose the use, or lack thereof, of specific SSL and encryption
@@ -592,6 +593,8 @@ cqssr Client Request SSL session ticket reused status; indicates if the current
                      handshake.
 cqssv Client Request SSL version used to communicate with the client.
 cqssc Client Request SSL Cipher used by |TS| to communicate with the client.
+cqssu Client Request SSL Elliptic Curve used by |TS| to communicate with the
+                     client when using an ECDHE cipher.
 pqssl Proxy Request  Indicates whether the connection from |TS| to the origin
                      was over SSL or not.
 ===== ============== ==========================================================

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -37,6 +37,7 @@
 
 #include <openssl/ssl.h>
 #include <openssl/err.h>
+#include <openssl/objects.h>
 
 #include "P_EventSystem.h"
 #include "P_UnixNetVConnection.h"
@@ -307,6 +308,21 @@ public:
   getSSLCipherSuite() const
   {
     return ssl ? SSL_get_cipher_name(ssl) : nullptr;
+  }
+
+  const char *
+  getSSLCurve() const
+  {
+    if (!ssl) {
+      return nullptr;
+    }
+
+    int curve_nid = SSL_get_shared_curve(ssl, 0);
+
+    if (curve_nid == NID_undef) {
+      return nullptr;
+    }
+    return OBJ_nid2sn(curve_nid);
   }
 
   bool

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -481,6 +481,8 @@ HttpSM::attach_client_session(ProxyTransaction *client_vc, IOBufferReader *buffe
     client_sec_protocol      = protocol ? protocol : "-";
     const char *cipher       = ssl_vc->getSSLCipherSuite();
     client_cipher_suite      = cipher ? cipher : "-";
+    const char *curve        = ssl_vc->getSSLCurve();
+    client_curve             = curve ? curve : "-";
     if (!client_tcp_reused) {
       // Copy along the TLS handshake timings
       milestones[TS_MILESTONE_TLS_HANDSHAKE_START] = ssl_vc->sslHandshakeBeginTime;

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -546,6 +546,7 @@ public:
   const char *client_protocol     = "-";
   const char *client_sec_protocol = "-";
   const char *client_cipher_suite = "-";
+  const char *client_curve        = "-";
   int server_transact_count       = 0;
 
   TransactionMilestones milestones;

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -505,6 +505,11 @@ Log::init_fields()
   global_field_list.add(field, false);
   field_symbol_hash.emplace("cqssc", field);
 
+  field = new LogField("client_curve", "cqssu", LogField::STRING, &LogAccess::marshal_client_security_curve,
+                       (LogField::UnmarshalFunc)&LogAccess::unmarshal_str);
+  global_field_list.add(field, false);
+  field_symbol_hash.emplace("cqssu", field);
+
   Ptr<LogFieldAliasTable> finish_status_map = make_ptr(new LogFieldAliasTable);
   finish_status_map->init(N_LOG_FINISH_CODE_TYPES, LOG_FINISH_FIN, "FIN", LOG_FINISH_INTR, "INTR", LOG_FINISH_TIMEOUT, "TIMEOUT");
 

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -1856,6 +1856,19 @@ LogAccess::marshal_client_security_cipher_suite(char *buf)
   return round_len;
 }
 
+int
+LogAccess::marshal_client_security_curve(char *buf)
+{
+  const char *curve = m_http_sm->client_curve;
+  int round_len     = LogAccess::strlen(curve);
+
+  if (buf) {
+    marshal_str(buf, curve, round_len);
+  }
+
+  return round_len;
+}
+
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 

--- a/proxy/logging/LogAccess.h
+++ b/proxy/logging/LogAccess.h
@@ -153,6 +153,7 @@ public:
   inkcoreapi int marshal_client_req_mptcp_state(char *);        // INT
   inkcoreapi int marshal_client_security_protocol(char *);      // STR
   inkcoreapi int marshal_client_security_cipher_suite(char *);  // STR
+  inkcoreapi int marshal_client_security_curve(char *);         // STR
   inkcoreapi int marshal_client_finish_status_code(char *);     // INT
   inkcoreapi int marshal_client_req_id(char *);                 // INT
   inkcoreapi int marshal_client_req_uuid(char *);               // STR


### PR DESCRIPTION
This PR adds the ability of logging the SSL Elliptic Curve used by Trafficserver to communicate with the client when using an ECDHE cipher.