### PR TITLE
Add effective url options to slice plugin.

### DIFF
--- a/doc/admin-guide/plugins/slice.en.rst
+++ b/doc/admin-guide/plugins/slice.en.rst
@@ -69,17 +69,25 @@ The slice plugin supports the following options::
         Suffix k,m,g supported
         Limited to 32k and 32m inclusive.
 
-    --test-blockbytes=<bytes> (optional)
+    --blockbytes-test=<bytes> (optional)
         Suffix k,m,g supported
         -t <bytes> for short.
         Limited to any positive number.
         Ignored if --blockbytes provided.
 
+    --remap-host=<loopback hostname> (optional)
+        Uses effective url with given hostname for remapping.
+        Requires setting up an intermediate loopback remap rule.
+        -r for short
+
     --pace-errorlog=<seconds> (optional)
         Limit stitching error logs to every 'n' second(s)
+        -p for short
 
     --disable-errorlog (optional)
         Disable writing block stitch errors to the error log.
+        -d for short
+
 
 Examples::
 
@@ -95,10 +103,10 @@ Byte suffix examples::
     slice.so -b 512k
     slice.so --blockbytes=32m
 
-For testing and extreme purposes the parameter ``test-blockbytes`` may
+For testing and extreme purposes the parameter ``blockbytes-test`` may
 be used instead which is unchecked::
 
-    slice.so --test-blockbytes=1G
+    slice.so --blockbytes-test=1G
     slice.so -t 13
 
 Because the slice plugin is susceptible to errors during block stitching
@@ -128,9 +136,11 @@ Under normal logging these slice block errors tend to show up as::
     crc value ERR_READ_ERROR
 
 By default more detailed stitching errors are written to ``diags.log``.
-An example is as follows::
+Examples are as follows::
 
-[Apr 19 20:26:13.639] [ET_NET 17] ERROR: [slice] 1555705573.639 reason="Non 206 internal block response" uri="http://localhost:18080/%7Ep.tex/%7Es.50M/%7Eui.20000/" uas="curl/7.29.0" req_range="bytes=1000000-" norm_range="bytes 1000000-52428799/52428800" etag_exp="%221603934496%22" lm_exp="Fri, 19 Apr 2019 18:53:20 GMT" blk_range="21000000-21999999" status_got="400" cr_got="" etag_got="" lm_got="" cc="no-store" via=""
+ERROR: [slice.cc: 288] logSliceError(): 1555705573.639 reason="Non 206 internal block response" uri="http://ats_ep/someasset.mp4" uas="curl" req_range="bytes=1000000-" norm_range="bytes 1000000-52428799/52428800" etag_exp="%221603934496%22" lm_exp="Fri, 19 Apr 2019 18:53:20 GMT" blk_range="21000000-21999999" status_got="206" cr_got="" etag_got="%221603934496%22" lm_got="" cc="no-store" via=""
+
+ERROR: [server.cc: 288] logSliceError(): 1572370000.219 reason="Mismatch block Etag" uri="http://ats_ep/someasset.mp4" uas="curl" req_range="bytes=1092779033-1096299354" norm_range="bytes 1092779033-1096299354/2147483648" etag_exp="%223719843648%22" lm_exp="Tue, 29 Oct 2019 14:40:00 GMT" blk_range="1095000000-1095999999" status_got="206" cr_got="bytes 1095000000-1095999999/2147483648" etag_got="%223719853648%22" lm_got="Tue, 29 Oct 2019 17:26:40 GMT" cc="max-age=10000" via=""
 
 Whether or how often these detailed log entries are written are
 configurable plugin options.
@@ -204,14 +214,43 @@ by cache_range_requests.  The parent will trim those requests to
 account for the asset Content-Length so only the appropriate number
 of bytes are actually transferred and cached.
 
+Effective URL remap
+===================
+
+By default the plugin restores the Pristine Url which reuses the same
+remap rule for each slice block.  This is wasteful in that it reruns
+the previous remap rules, and those remap rules must be smart enough to
+check for the existence of any headers they may have created the first
+time they have were visited.
+
+To get around this the '--remap-host=<host>' or '-r <host>' option may
+be used.  This requires an intermediate loopback remap to be defined which
+handles each slice block request.
+
+This works well with any remap rules that use the url_sig or uri_signing
+plugins.  As the client remap rule is not caching any plugins that
+manipulate the cache key would need to go into the loopback to parent
+remap rule.
+
+NOTE: Requests NOT handled by the slice plugin (ie: HEAD requests) are
+handled as with a typical remap rule.  GET requests intercepted by the
+slice plugin are virtually reissued into ATS and are proxied through
+another remap rule which must contain the ``cache_range_requests`` plugin
+
+Examples::
+
+    map http://ats/ http://parent/ @plugin=slice.so @pparam=--remap-host=loopback
+    map http://loopback/ http://parent/ @plugin=cache_range_requests.so
+
+Alternatively::
+
+    map http://ats/ http://parent/ @plugin=slice.so @pparam=-r @pparam=loopback
+    map http://loopback/ http://parent/ @plugin=cache_range_requests.so
+
 Current Limitations
 ===================
 
-By restoring the pristine Url the plugin as it works today reuses the
-same remap rule for each slice block.  This is wasteful in that it reruns
-the previous remap rules, and those remap rules must be smart enough to
-check for the existence of any headers they may have created the
-first time they have were visited.
-
 Since the Slice plugin is written as an intercept handler it loses the
-ability to use normal state machine hooks and transaction states.
+ability to use normal state machine hooks and transaction states. This
+functionality is handled by using the ``cache_range_requests`` plugin
+to interact with ATS.

--- a/plugins/experimental/slice/Config.h
+++ b/plugins/experimental/slice/Config.h
@@ -29,7 +29,8 @@ struct Config {
   static constexpr int64_t const blockbytesdefault = 1024 * 1024;      // 1MB
 
   int64_t m_blockbytes{blockbytesdefault};
-  int m_paceerrsecs{0}; // -1 disable logging, 0 no pacing, max 60s
+  std::string m_remaphost; // remap host to use for loopback slice GET
+  int m_paceerrsecs{0};    // -1 disable logging, 0 no pacing, max 60s
 
   // Convert optarg to bytes
   static int64_t bytesFrom(char const *const valstr);

--- a/plugins/experimental/slice/Data.h
+++ b/plugins/experimental/slice/Data.h
@@ -39,8 +39,8 @@ struct Data {
 
   sockaddr_storage m_client_ip;
 
-  // for pristine url coming in
-  TSMBuffer m_urlbuffer{nullptr};
+  // for pristine/effective url coming in
+  TSMBuffer m_urlbuf{nullptr};
   TSMLoc m_urlloc{nullptr};
 
   char m_hostname[8192];
@@ -80,7 +80,7 @@ struct Data {
   explicit Data(Config *const config)
     : m_config(config),
       m_client_ip(),
-      m_urlbuffer(nullptr),
+      m_urlbuf(nullptr),
       m_urlloc(nullptr),
       m_hostlen(0),
       m_etaglen(0),
@@ -113,11 +113,11 @@ struct Data {
   ~Data()
   {
     // decrData();
-    if (nullptr != m_urlbuffer) {
+    if (nullptr != m_urlbuf) {
       if (nullptr != m_urlloc) {
-        TSHandleMLocRelease(m_urlbuffer, TS_NULL_MLOC, m_urlloc);
+        TSHandleMLocRelease(m_urlbuf, TS_NULL_MLOC, m_urlloc);
       }
-      TSMBufferDestroy(m_urlbuffer);
+      TSMBufferDestroy(m_urlbuf);
     }
     if (nullptr != m_http_parser) {
       TSHttpParserDestroy(m_http_parser);

--- a/plugins/experimental/slice/README.md
+++ b/plugins/experimental/slice/README.md
@@ -15,66 +15,86 @@ The plugin uses TSHttpConnect to delegate each block request to
 cache_range_requests.so which handles all cache and parent interaction.
 
 To enable the plugin, specify the plugin library via @plugin at the end
-of a remap line as follows (2MB slice in this example):
+of a remap line as follows (default 1MB slice in this example):
 
 ```
-map http://ats-cache/ http://parent/ @plugin=slice.so @pparam=--blockbytes=2M @plugin=cache_range_requests.so
+map http://ats-cache/ http://parent/ @plugin=slice.so @plugin=cache_range_requests.so
+map https://ats-cache/ http://parent/ @plugin=slice.so @plugin=cache_range_requests.so
 ```
 
-alternatively
+alternatively (2MB slice block)
 
 ```
 map http://ats-cache/ http://parent/ @plugin=slice.so @pparam=-b @pparam=2M @plugin=cache_range_requests.so
-```
-
-for global plugins.
-
-```
-slice.so --blockbytes=2097152
-cache_range_requests.so
-```
-
-alternatively:
-
-```
-slice.so -b 2M
-cache_range_requests.so
+map https://ats-cache/ http://parent/ @plugin=slice.so @pparam=--blockbytes=2M @plugin=cache_range_requests.so
 ```
 
 Options for the slice plugin (typically last one wins):
 ```
 --blockbytes=<number bytes> (optional)
   Slice block size.
-	Default is 1m or 1048576 bytes.
+  Default is 1m or 1048576 bytes.
   also -b <num bytes>
-	Suffix k,m,g supported.
-	Limited to 32k and 32m inclusive.
-	For backwards compatibility blockbytes:<num bytes> is also supported.
+  Suffix k,m,g supported.
+  Limited to 32k and 32m inclusive.
+  For backwards compatibility blockbytes:<num bytes> is also supported.
 
---test-blockbytes=<number bytes> (optional)
+--blockbytes-test=<number bytes> (optional)
   Slice block size for testing.
   also -t <num bytes>
-	Suffix k,m,g supported.
-	Limited to any positive number.
-	Ignored if --blockbytes is provided.
+  Suffix k,m,g supported.
+  Limited to any positive number.
+  Ignored if --blockbytes is provided.
+
+--remap-host=<loopback hostname> (optional)
+  Uses effective url with given host and port 0 for remapping.
+  Requires setting up an intermediate loopback remap rule.
+  -r for short
 
 --pace-errorlog=<second(s)> (optional)
   Limit stitching error logs to every 'n' second(s)
   Default is to log all errors (no pacing).
-  also -p <seconds>
+  also -e <seconds>
 
 --disable-errorlog (optional)
   Disable writing stitching errors to the error log.
   also -d
 ```
 
-**Note**: cache_range_requests **MUST** follow slice.so Put these plugins
-at the end of the plugin list
+By default the plugin uses the pristine url to loopback call back
+into the same rule as each range slice is issued.  The effective url
+with loopback remap host may be used by adding the '-r <hostname>' or
+'--remap-host=<hostname>' plugin option.
+
+Using the `--remap-host` option splits the plugin chain into 2 remap rules.
+One remap rule for all the incoming requests and the other for just the block
+range requests.  This allows for easier trouble shooting via logs and
+also allows for more effecient plugin rules.  The default pristine method
+runs the remap plugins twice, one for the incoming request and one for
+eace slice.  Splitting the rules allows for plugins like URI signing to
+be done on the client request only.
+
+NOTE: Requests NOT handled by the slice plugin (ie: HEAD requests) are
+handled as with a typical remap rule.  GET requests intercepted by the
+slice plugin are virtually reissued into ATS and are forward proxied
+through the cache_range_requests plugin.
+
+```
+map http://ats/ http://parent/ @plugin=slice.so @pparam=--blockbytes=512k @pparam=--remap-host=loopback
+map https://ats/ https://parent/ @plugin=slice.so @pparam=--blockbytes=512k @pparam=--remap-host=loopback
+
+# Virtual forward proxy for slice range blocks
+map http://loopback/ http://parent/ @plugin=cache_range_requests.so
+map https://loopback/ http://parent/ @plugin=cache_range_requests.so
+```
+
+**Note**: For default pristine behavior cache_range_requests **MUST**
+follow slice.so Put these plugins at the end of the plugin list
 
 **Note**: blockbytes is defined in bytes. Postfix for 'K', 'M' and 'G'
 may be used.  1048576 (1MB) is the default.
 
-For testing purposes an unchecked value of "bytesover" is also available.
+For testing purposes an unchecked value of "blockbytes-test" is also available.
 
 Debug output can be enable by setting the debug tag: **slice**.  If debug
 is enabled all block stitch errors will log to diags.log
@@ -90,9 +110,9 @@ provided to help with debugging.  Below is a sample error log entry::
 Current error types logged:
 ```
     Mismatch block Etag
-		Mismatch block Last-Modified
-		Non 206 internal block response
-		Mismatch/Bad block Content-Range
+    Mismatch block Last-Modified
+    Non 206 internal block response
+    Mismatch/Bad block Content-Range
 ```
 
 

--- a/plugins/experimental/slice/client.cc
+++ b/plugins/experimental/slice/client.cc
@@ -106,7 +106,7 @@ handle_client_req(TSCont contp, TSEvent event, Data *const data)
     HttpHeader header(data->m_req_hdrmgr.m_buffer, data->m_req_hdrmgr.m_lochdr);
 
     // set the request url back to pristine in case of plugin stacking
-    header.setUrl(data->m_urlbuffer, data->m_urlloc);
+    header.setUrl(data->m_urlbuf, data->m_urlloc);
 
     header.setKeyVal(TS_MIME_FIELD_HOST, TS_MIME_LEN_HOST, data->m_hostname, data->m_hostlen);
 

--- a/tests/gold_tests/pluginTest/slice/slice.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice.test.py
@@ -115,7 +115,7 @@ tr = Test.AddTestRun("Load Slice plugin")
 remap_config_path = ts.Disk.remap_config.Name
 tr.Disk.File(remap_config_path, typename="ats:config").AddLines([
   'map / http://127.0.0.1:{}'.format(server.Variables.Port) +
-    ' @plugin=slice.so @pparam=--test-blockbytes={}'.format(block_bytes)
+    ' @plugin=slice.so @pparam=--blockbytes-test={}'.format(block_bytes)
 ])
 
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/pluginTest/slice/slice_error.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice_error.test.py
@@ -244,7 +244,7 @@ curl_and_args = 'sh curlsort.sh -H "Host: www.example.com"'
 # set up whole asset fetch into cache
 ts.Disk.remap_config.AddLine(
   'map / http://127.0.0.1:{}'.format(server.Variables.Port) +
-    ' @plugin=slice.so @pparam=--test-blockbytes={}'.format(blockbytes)
+    ' @plugin=slice.so @pparam=--blockbytes-test={}'.format(blockbytes)
 )
 
 # minimal configuration


### PR DESCRIPTION
Initial slice plugin used pristine url to virtually call back into the same rule.  This allows using a single remap line, but it has a disadvantage of rerunning all plugin rules for each slice transaction in addition to the incoming request transaction.  Also it makes log analysis more difficult, the only difference being that the callback comes in on port '0'.  http and https get a bit confusing as well with using the pristine url as the loopback is connected with the https url if the incoming rule is https.

This changes the default remap behaviour of the slice plugin to use a virtual remap parent point, allowing separate remap lines.

the way to set up the slice plugin with effective url: (option --remap-host=<loop name> or -r <loop name>)

```
# Base remap rule (non GET requests pass through)
map http://ats/ http://parent/ @plugin=uri_signing.so @pparam=foo_uri.config @plugin=slice.so @pparam=--remap-host=loopback

# Virtual forward proxy slice block leg (cached)
map http://loopback/ http://parent/ @plugin=header_rewrite.so @pparam=reject_non_php0.config @plugin=cache_range_requests.so
```

Previous configuration is still default behavior (uri_signs for incoming AND each sliced up block):

```
map http://ats/ http://parent/ @plugin=uri_signing.so @pparam=foo_uri.config @plugin=slice.so @plugin=cache_range_requests.so
```