### PR TITLE
Plugin intercept memleak

### DIFF
--- a/plugins/esi/combo_handler.cc
+++ b/plugins/esi/combo_handler.cc
@@ -450,7 +450,8 @@ handleReadRequestHeader(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edat
     TSMLoc url_loc;
     if (TSHttpHdrUrlGet(bufp, hdr_loc, &url_loc) == TS_SUCCESS) {
       if (isComboHandlerRequest(bufp, hdr_loc, url_loc)) {
-        TSCont contp = TSContCreate(handleServerEvent, TSMutexCreate());
+        TSMutex const mutex = TSContMutexGet(reinterpret_cast<TSCont>(txnp));
+        TSCont const contp  = TSContCreate(handleServerEvent, mutex);
         if (!contp) {
           LOG_ERROR("[%s] Could not create intercept request", __FUNCTION__);
           reenable_to_event = TS_EVENT_HTTP_ERROR;

--- a/plugins/esi/serverIntercept.cc
+++ b/plugins/esi/serverIntercept.cc
@@ -347,7 +347,8 @@ serverIntercept(TSCont contp, TSEvent event, void *edata)
 bool
 setupServerIntercept(TSHttpTxn txnp)
 {
-  TSCont contp = TSContCreate(serverIntercept, TSMutexCreate());
+  TSMutex const mutex = TSContMutexGet(reinterpret_cast<TSCont>(txnp));
+  TSCont const contp  = TSContCreate(serverIntercept, mutex);
   if (!contp) {
     TSError("[server_intercept][%s] Could not create intercept request", __FUNCTION__);
     return false;

--- a/plugins/experimental/acme/acme.c
+++ b/plugins/experimental/acme/acme.c
@@ -253,6 +253,7 @@ acme_hook(TSCont contp ATS_UNUSED, TSEvent event ATS_UNUSED, void *edata)
 {
   TSMBuffer reqp;
   TSMLoc hdr_loc = NULL, url_loc = NULL;
+  TSMutex mutex;
   TSCont icontp;
   AcmeState *my_state;
   TSHttpTxn txnp = (TSHttpTxn)edata;
@@ -272,7 +273,8 @@ acme_hook(TSCont contp ATS_UNUSED, TSEvent event ATS_UNUSED, void *edata)
     TSSkipRemappingSet(txnp, 1); /* not strictly necessary, but speed is everything these days */
 
     /* This request is for us -- register our intercept */
-    icontp = TSContCreate(acme_intercept, TSMutexCreate());
+    mutex  = TSContMutexGet((TSCont)txnp);
+    icontp = TSContCreate(acme_intercept, mutex);
 
     my_state = make_acme_state();
     open_acme_file(my_state, path + strlen(ACME_WK_PATH), path_len - strlen(ACME_WK_PATH));

--- a/plugins/experimental/buffer_upload/buffer_upload.cc
+++ b/plugins/experimental/buffer_upload/buffer_upload.cc
@@ -820,15 +820,7 @@ attach_pvc_plugin(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
 } else
     */
     //  content_length = value;
-
-    mutex = TSMutexCreate();
-    if (NOT_VALID_PTR(mutex)) {
-      TSHandleMLocRelease(req_bufp, req_loc, field_loc);
-      TSHandleMLocRelease(req_bufp, TS_NULL_MLOC, req_loc);
-      LOG_ERROR("TSMutexCreate");
-      break;
-    }
-
+    mutex    = TSContMutexGet(reinterpret_cast<TSCont>(txnp));
     new_cont = TSContCreate(pvc_plugin, mutex);
     if (NOT_VALID_PTR(new_cont)) {
       TSHandleMLocRelease(req_bufp, req_loc, field_loc);

--- a/plugins/experimental/slice/slice.cc
+++ b/plugins/experimental/slice/slice.cc
@@ -99,9 +99,9 @@ read_request(TSHttpTxn txnp, Config *const config)
       }
 
       // we'll intercept this GET and do it ourselves
-      TSCont const icontp(TSContCreate(intercept_hook, TSContMutexGet(reinterpret_cast<TSCont>(txnp))));
+      TSMutex const mutex = TSContMutexGet(reinterpret_cast<TSCont>(txnp));
+      TSCont const icontp(TSContCreate(intercept_hook, mutex));
       TSContDataSet(icontp, (void *)data);
-      //      TSHttpTxnHookAdd(txnp, TS_HTTP_TXN_CLOSE_HOOK, icontp);
       TSHttpTxnIntercept(icontp, txnp);
       return true;
     } else {

--- a/plugins/experimental/slice/slice.cc
+++ b/plugins/experimental/slice/slice.cc
@@ -99,7 +99,7 @@ read_request(TSHttpTxn txnp, Config *const config)
       }
 
       // we'll intercept this GET and do it ourselves
-      TSCont const icontp(TSContCreate(intercept_hook, TSMutexCreate()));
+      TSCont const icontp(TSContCreate(intercept_hook, TSContMutexGet(reinterpret_cast<TSCont>(txnp))));
       TSContDataSet(icontp, (void *)data);
       //      TSHttpTxnHookAdd(txnp, TS_HTTP_TXN_CLOSE_HOOK, icontp);
       TSHttpTxnIntercept(icontp, txnp);

--- a/plugins/generator/generator.cc
+++ b/plugins/generator/generator.cc
@@ -610,7 +610,9 @@ GeneratorTxnHook(TSCont contp, TSEvent event, void *edata)
     if (status != TS_CACHE_LOOKUP_HIT_FRESH) {
       // This transaction is going to be a cache miss, so intercept it.
       VDEBUG("intercepting origin server request for txn=%p", arg.txn);
-      TSHttpTxnServerIntercept(TSContCreate(GeneratorInterceptionHook, TSMutexCreate()), arg.txn);
+      TSMutex const mutex = TSContMutexGet(reinterpret_cast<TSCont>(arg.txn));
+      TSCont const contp  = TSContCreate(GeneratorInterceptionHook, mutex);
+      TSHttpTxnServerIntercept(contp, arg.txn);
     }
 
     break;

--- a/plugins/healthchecks/healthchecks.c
+++ b/plugins/healthchecks/healthchecks.c
@@ -503,6 +503,7 @@ health_check_origin(TSCont contp ATS_UNUSED, TSEvent event ATS_UNUSED, void *eda
 {
   TSMBuffer reqp;
   TSMLoc hdr_loc = NULL, url_loc = NULL;
+  TSMutex mutex;
   TSCont icontp;
   HCState *my_state;
   TSHttpTxn txnp   = (TSHttpTxn)edata;
@@ -532,7 +533,8 @@ health_check_origin(TSCont contp ATS_UNUSED, TSEvent event ATS_UNUSED, void *eda
     TSSkipRemappingSet(txnp, 1); /* not strictly necessary, but speed is everything these days */
 
     /* This is us -- register our intercept */
-    icontp   = TSContCreate(hc_intercept, TSMutexCreate());
+    mutex    = TSContMutexGet((TSCont)txnp);
+    icontp   = TSContCreate(hc_intercept, mutex);
     my_state = (HCState *)TSmalloc(sizeof(*my_state));
     memset(my_state, 0, sizeof(*my_state));
     my_state->info = info;

--- a/plugins/lua/ts_lua_http_intercept.c
+++ b/plugins/lua/ts_lua_http_intercept.c
@@ -64,6 +64,7 @@ static int
 ts_lua_http_intercept(lua_State *L)
 {
   TSCont contp;
+  TSMutex mutex;
   int type, n;
   ts_lua_http_ctx *http_ctx;
   ts_lua_http_intercept_ctx *ictx;
@@ -84,7 +85,8 @@ ts_lua_http_intercept(lua_State *L)
   }
 
   ictx  = ts_lua_create_http_intercept_ctx(L, http_ctx, n);
-  contp = TSContCreate(ts_lua_http_intercept_entry, TSMutexCreate());
+  mutex = TSContMutexGet((TSCont)http_ctx->txnp);
+  contp = TSContCreate(ts_lua_http_intercept_entry, mutex);
   TSContDataSet(contp, ictx);
 
   TSHttpTxnIntercept(contp, http_ctx->txnp);
@@ -97,6 +99,7 @@ static int
 ts_lua_http_server_intercept(lua_State *L)
 {
   TSCont contp;
+  TSMutex mutex;
   int type, n;
   ts_lua_http_ctx *http_ctx;
   ts_lua_http_intercept_ctx *ictx;
@@ -117,7 +120,8 @@ ts_lua_http_server_intercept(lua_State *L)
   }
 
   ictx  = ts_lua_create_http_intercept_ctx(L, http_ctx, n);
-  contp = TSContCreate(ts_lua_http_intercept_entry, TSMutexCreate());
+  mutex = TSContMutexGet((TSCont)http_ctx->txnp);
+  contp = TSContCreate(ts_lua_http_intercept_entry, mutex);
   TSContDataSet(contp, ictx);
 
   TSHttpTxnServerIntercept(contp, http_ctx->txnp);

--- a/plugins/stats_over_http/stats_over_http.c
+++ b/plugins/stats_over_http/stats_over_http.c
@@ -264,7 +264,7 @@ stats_origin(TSCont contp ATS_UNUSED, TSEvent event ATS_UNUSED, void *edata)
   /* This is us -- register our intercept */
   TSDebug(PLUGIN_NAME, "Intercepting request");
 
-  icontp   = TSContCreate(stats_dostuff, TSMutexCreate());
+  icontp   = TSContCreate(stats_dostuff, TSContMutexGet((TSCont)txnp));
   my_state = (stats_state *)TSmalloc(sizeof(*my_state));
   memset(my_state, 0, sizeof(*my_state));
   TSContDataSet(icontp, my_state);


### PR DESCRIPTION
This attempts to fix a general memory leak for plugins that use TSHttpTxnIntercept and TSHttpTxnServerIntercept.  The memory leak is caused when the intercepted continuation is created using TSMutexCreate() instead of being passed the intercepted transaction's mutex.