### PR TITLE
Cleanup debug logs around SSLWriteBuffer

### DIFF
--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -729,6 +729,8 @@ SSLNetVConnection::load_buffer_and_write(int64_t towrite, MIOBufferAccessor &buf
     return this->super::load_buffer_and_write(towrite, buf, total_written, needs);
   }
 
+  Debug("ssl", "towrite=%" PRId64, towrite);
+
   do {
     // What is remaining left in the next block?
     l                   = buf.reader()->block_read_avail();
@@ -773,8 +775,7 @@ SSLNetVConnection::load_buffer_and_write(int64_t towrite, MIOBufferAccessor &buf
 
     try_to_write       = l;
     num_really_written = 0;
-    Debug("ssl", "SSLNetVConnection::loadBufferAndCallWrite, before SSLWriteBuffer, l=%" PRId64 ", towrite=%" PRId64 ", b=%p", l,
-          towrite, current_block);
+    Debug("v_ssl", "b=%p l=%" PRId64, current_block, l);
     err = SSLWriteBuffer(ssl, current_block, l, num_really_written);
 
     // We wrote all that we thought we should
@@ -783,8 +784,8 @@ SSLNetVConnection::load_buffer_and_write(int64_t towrite, MIOBufferAccessor &buf
       buf.reader()->consume(num_really_written);
     }
 
-    Debug("ssl", "SSLNetVConnection::loadBufferAndCallWrite,Number of bytes written=%" PRId64 " , total=%" PRId64 "",
-          num_really_written, total_written);
+    Debug("ssl", "try_to_write=%" PRId64 " written=%" PRId64 " total_written=%" PRId64, try_to_write, num_really_written,
+          total_written);
     NET_INCREMENT_DYN_STAT(net_calls_to_write_stat);
   } while (num_really_written == try_to_write && total_written < towrite);
 


### PR DESCRIPTION
Debug logs in `SSLNetVConnection::load_buffer_and_write()` looks not well formatted.
There're two debug logs before and after `SSLWriteBuffer()` call, but I think we need only one debug log. Because the printed values before the `SSLWriteBuffer()` call are not changed by call it it.

Before
```
[Jul 25 11:30:37.203] [ET_NET 0] DEBUG: <SSLNetVConnection.cc:782 (load_buffer_and_write)> (ssl) SSLNetVConnection::loadBufferAndCallWrite, before SSLWriteBuffer, l=16384, towrite=65572, b=0xaa0e000
[Jul 25 11:30:37.203] [ET_NET 0] DEBUG: <SSLNetVConnection.cc:792 (load_buffer_and_write)> (ssl) SSLNetVConnection::loadBufferAndCallWrite,Number of bytes written=16384 , total=65572
```

After
```
[Jul 25 11:59:05.351] [ET_NET 1] DEBUG: <SSLNetVConnection.cc:785 (load_buffer_and_write)> (ssl) towrite=1049335 b=0x11742c000 try_to_write=16384 written=16384 total_written=918191
```

This PR doesn't change any logic.