### PR TITLE
Add slow logs for HTTP/2 Connection & Stream

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -2825,6 +2825,26 @@ Logging Configuration
    completion will cause its timing stats to be written to the :ts:cv:`debugging log file
    <proxy.config.output.logfile>`. This is identifying data about the transaction and all of the :c:type:`transaction milestones <TSMilestonesType>`.
 
+.. ts:cv:: CONFIG proxy.config.http2.connection.slow.log.threshold INT 0
+   :reloadable:
+   :units: milliseconds
+
+   If set to a non-zero value :arg:`N` then any HTTP/2 connection
+   that takes longer than :arg:`N` milliseconds from open to close will cause
+   its timing stats to be written to the :ts:cv:`debugging log file
+   <proxy.config.output.logfile>`. This is identifying data about the
+   transaction and all of the :c:type:`transaction milestones <TSMilestonesType>`.
+
+.. ts:cv:: CONFIG proxy.config.http2.stream.slow.log.threshold INT 0
+   :reloadable:
+   :units: milliseconds
+
+   If set to a non-zero value :arg:`N` then any HTTP/2 stream
+   that takes longer than :arg:`N` milliseconds from open to close will cause
+   its timing stats to be written to the :ts:cv:`debugging log file
+   <proxy.config.output.logfile>`. This is identifying data about the
+   transaction and all of the :c:type:`transaction milestones <TSMilestonesType>`.
+
 .. ts:cv:: CONFIG proxy.config.log.config.filename STRING logging.yaml
    :reloadable:
 

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -641,6 +641,10 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.http.slow.log.threshold", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.http2.connection.slow.log.threshold", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
+  ,
+  {RECT_CONFIG, "proxy.config.http2.stream.slow.log.threshold", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
+  ,
 
   //##############################################################################
   //#

--- a/proxy/Milestones.h
+++ b/proxy/Milestones.h
@@ -1,6 +1,6 @@
 /** @file
 
-  A brief file description
+  Milestones
 
   @section license License
 
@@ -23,22 +23,32 @@
 
 #pragma once
 
+#include "ts/apidefs.h"
+
 #include "tscore/ink_platform.h"
 #include "tscore/ink_hrtime.h"
-#include "ts/apidefs.h"
-#include "tscore/ink_hrtime.h"
 
-/////////////////////////////////////////////////////////////
-//
-// class TransactionMilestones
-//
-/////////////////////////////////////////////////////////////
-class TransactionMilestones
+#include "I_EventSystem.h"
+
+template <class T, size_t entries> class Milestones
 {
 public:
-  TransactionMilestones() { ink_zero(milestones); }
-  ink_hrtime &operator[](TSMilestonesType ms) { return milestones[ms]; }
-  ink_hrtime operator[](TSMilestonesType ms) const { return milestones[ms]; }
+  ink_hrtime &operator[](T ms) { return this->_milestones[static_cast<size_t>(ms)]; }
+  ink_hrtime operator[](T ms) const { return this->_milestones[static_cast<size_t>(ms)]; }
+
+  /**
+   * Mark given milestone with timestamp if it's not marked yet
+   * @param ms The milestone to mark
+   * @return N/A
+   */
+  void
+  mark(T ms)
+  {
+    if (this->_milestones[static_cast<size_t>(ms)] == 0) {
+      this->_milestones[static_cast<size_t>(ms)] = Thread::get_hrtime();
+    }
+  }
+
   /**
    * Takes two milestones and returns the difference.
    * @param start The start time
@@ -46,12 +56,12 @@ public:
    * @return The difference time in milliseconds
    */
   int64_t
-  difference_msec(TSMilestonesType ms_start, TSMilestonesType ms_end) const
+  difference_msec(T ms_start, T ms_end) const
   {
-    if (milestones[ms_end] == 0) {
+    if (this->_milestones[static_cast<size_t>(ms_end)] == 0) {
       return -1;
     }
-    return ink_hrtime_to_msec(milestones[ms_end] - milestones[ms_start]);
+    return ink_hrtime_to_msec(this->_milestones[static_cast<size_t>(ms_end)] - this->_milestones[static_cast<size_t>(ms_start)]);
   }
 
   /**
@@ -61,17 +71,26 @@ public:
    * @return A double that is the difference time in seconds
    */
   double
-  difference_sec(TSMilestonesType ms_start, TSMilestonesType ms_end) const
+  difference_sec(T ms_start, T ms_end) const
   {
-    return (double)difference_msec(ms_start, ms_end) / 1000.0;
+    return static_cast<double>(difference_msec(ms_start, ms_end) / 1000.0);
   }
 
+  /**
+   * Takes two milestones and returns the difference.
+   * @param start The start time
+   * @param end The end time
+   * @return The difference time in high-resolution time
+   */
   ink_hrtime
-  elapsed(TSMilestonesType ms_start, TSMilestonesType ms_end) const
+  elapsed(T ms_start, T ms_end) const
   {
-    return milestones[ms_end] - milestones[ms_start];
+    return this->_milestones[static_cast<size_t>(ms_end)] - this->_milestones[static_cast<size_t>(ms_start)];
   }
 
 private:
-  ink_hrtime milestones[TS_MILESTONE_LAST_ENTRY];
+  std::array<ink_hrtime, entries> _milestones = {0};
 };
+
+// For compatibility with HttpSM.h and HttpTransact.h
+using TransactionMilestones = Milestones<TSMilestonesType, TS_MILESTONE_LAST_ENTRY>;

--- a/proxy/http2/HTTP2.cc
+++ b/proxy/http2/HTTP2.cc
@@ -745,6 +745,8 @@ uint32_t Http2::zombie_timeout_in          = 0;
 float Http2::stream_error_rate_threshold   = 0.1;
 uint32_t Http2::max_settings_per_frame     = 7;
 uint32_t Http2::max_settings_per_minute    = 14;
+uint32_t Http2::con_slow_log_threshold     = 0;
+uint32_t Http2::stream_slow_log_threshold  = 0;
 
 void
 Http2::init()
@@ -765,6 +767,8 @@ Http2::init()
   REC_EstablishStaticConfigFloat(stream_error_rate_threshold, "proxy.config.http2.stream_error_rate_threshold");
   REC_EstablishStaticConfigInt32U(max_settings_per_frame, "proxy.config.http2.max_settings_per_frame");
   REC_EstablishStaticConfigInt32U(max_settings_per_minute, "proxy.config.http2.max_settings_per_minute");
+  REC_EstablishStaticConfigInt32U(con_slow_log_threshold, "proxy.config.http2.connection.slow.log.threshold");
+  REC_EstablishStaticConfigInt32U(stream_slow_log_threshold, "proxy.config.http2.stream.slow.log.threshold");
 
   // If any settings is broken, ATS should not start
   ink_release_assert(http2_settings_parameter_is_valid({HTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, max_concurrent_streams_in}));

--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -378,6 +378,8 @@ public:
   static float stream_error_rate_threshold;
   static uint32_t max_settings_per_frame;
   static uint32_t max_settings_per_minute;
+  static uint32_t con_slow_log_threshold;
+  static uint32_t stream_slow_log_threshold;
 
   static void init();
 };

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -30,6 +30,7 @@
 #include <string_view>
 #include "tscore/ink_inet.h"
 #include "tscore/History.h"
+#include "Milestones.h"
 
 // Name                       Edata                 Description
 // HTTP2_SESSION_EVENT_INIT   Http2ClientSession *  HTTP/2 session is born
@@ -47,6 +48,12 @@
 enum class Http2SessionCod : int {
   NOT_PROVIDED,
   HIGH_ERROR_RATE,
+};
+
+enum class Http2SsnMilestone {
+  OPEN = 0,
+  CLOSE,
+  LAST_ENTRY,
 };
 
 size_t const HTTP2_HEADER_BUFFER_SIZE_INDEX = CLIENT_CONNECTION_FIRST_READ_BUFFER_SIZE_INDEX;
@@ -334,6 +341,7 @@ private:
   IpEndpoint cached_local_addr;
 
   History<HISTORY_DEFAULT_SIZE> _history;
+  Milestones<Http2SsnMilestone, static_cast<size_t>(Http2SsnMilestone::LAST_ENTRY)> _milestones;
 
   // For Upgrade: h2c
   Http2UpgradeContext upgrade_context;

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -29,11 +29,23 @@
 #include "../http/HttpTunnel.h" // To get ChunkedHandler
 #include "Http2DependencyTree.h"
 #include "tscore/History.h"
+#include "Milestones.h"
 
 class Http2Stream;
 class Http2ConnectionState;
 
 typedef Http2DependencyTree::Tree<Http2Stream *> DependencyTree;
+
+enum class Http2StreamMilestone {
+  OPEN = 0,
+  START_DECODE_HEADERS,
+  START_TXN,
+  START_ENCODE_HEADERS,
+  START_TX_HEADERS_FRAMES,
+  START_TX_DATA_FRAMES,
+  CLOSE,
+  LAST_ENTRY,
+};
 
 class Http2Stream : public ProxyTransaction
 {
@@ -47,10 +59,12 @@ public:
   void
   init(Http2StreamId sid, ssize_t initial_rwnd)
   {
-    _id               = sid;
-    _start_time       = Thread::get_hrtime();
-    _thread           = this_ethread();
+    this->mark_milestone(Http2StreamMilestone::OPEN);
+
+    this->_id         = sid;
+    this->_thread     = this_ethread();
     this->client_rwnd = initial_rwnd;
+
     sm_reader = request_reader = request_buffer.alloc_reader();
     // FIXME: Are you sure? every "stream" needs request_header?
     _req_header.create(HTTP_TYPE_REQUEST);
@@ -223,6 +237,8 @@ public:
   void increment_client_transactions_stat() override;
   void decrement_client_transactions_stat() override;
 
+  void mark_milestone(Http2StreamMilestone type);
+
 private:
   void response_initialize_data_handling(bool &is_done);
   void response_process_data(bool &is_done);
@@ -238,16 +254,17 @@ private:
   bool _switch_thread_if_not_on_right_thread(int event, void *edata);
 
   HTTPParser http_parser;
-  ink_hrtime _start_time = 0;
-  EThread *_thread       = nullptr;
+  EThread *_thread = nullptr;
   Http2StreamId _id;
   Http2StreamState _state = Http2StreamState::HTTP2_STREAM_STATE_IDLE;
+  int64_t _http_sm_id     = -1;
 
   HTTPHdr _req_header;
   VIO read_vio;
   VIO write_vio;
 
   History<HISTORY_DEFAULT_SIZE> _history;
+  Milestones<Http2StreamMilestone, static_cast<size_t>(Http2StreamMilestone::LAST_ENTRY)> _milestones;
 
   bool trailing_header = false;
   bool body_done       = false;


### PR DESCRIPTION
Similar to HTTP Slow Log, record and print HTTP/2 milestones to figure out bottleneck.

Prefix of logs are
- session : `[CONNECTION ID]`
- stream : `[CONNECTION ID] [STREAM ID] [HTTP SM ID]`

The first field (`open`) is absolute timestamp to compare with other logs. Other fields are relative time from the `open` field.

Example of milestones 
```
[Jul 25 15:45:59.002] [ET_NET 0] NOTE: [0] [1] [0] H2 Stream Milestones: open: 1564037158335 dec_hdrs: 0.000 txn: 0.000 enc_hdrs: 0.228 tx_hdrs: 0.228 tx_data: 0.232 close: 0.666
[Jul 25 15:45:59.177] [ET_NET 0] NOTE: [0] [3] [1] H2 Stream Milestones: open: 1564037159014 dec_hdrs: 0.000 txn: 0.000 enc_hdrs: 0.063 tx_hdrs: 0.063 tx_data: 0.063 close: 0.161
[Jul 25 15:45:59.314] [ET_NET 0] NOTE: [0] [5] [2] H2 Stream Milestones: open: 1564037159190 dec_hdrs: 0.000 txn: 0.000 enc_hdrs: 0.061 tx_hdrs: 0.061 tx_data: 0.061 close: 0.123
[Jul 25 15:45:59.324] [ET_NET 0] NOTE: [0] H2 SSN Milestones: open: 1564037158333 close: 0.990
```

We might want to add more milestones. Let's do it on separate PR.