### PR TITLE
cppcheck: fixed uninitialized variable and scoping in healthchecks

### DIFF
--- a/plugins/healthchecks/healthchecks.c
+++ b/plugins/healthchecks/healthchecks.c
@@ -137,13 +137,12 @@ setup_watchers(int fd)
   HCFileInfo *conf     = g_config;
   HCDirEntry *head_dir = NULL, *last_dir = NULL, *dir;
   char fname[MAX_PATH_LEN];
-  char *dname;
 
   while (conf) {
     conf->wd = inotify_add_watch(fd, conf->fname, IN_DELETE_SELF | IN_CLOSE_WRITE | IN_ATTRIB);
     TSDebug(PLUGIN_NAME, "Setting up a watcher for %s", conf->fname);
     strncpy(fname, conf->fname, MAX_PATH_LEN);
-    dname = dirname(fname);
+    char *dname = dirname(fname);
     /* Make sure to only watch each directory once */
     if (!(dir = find_direntry(dname, head_dir))) {
       TSDebug(PLUGIN_NAME, "Setting up a watcher for directory %s", dname);
@@ -171,9 +170,7 @@ setup_watchers(int fd)
 static void *
 hc_thread(void *data ATS_UNUSED)
 {
-  int fd = inotify_init();
-  HCDirEntry *dirs;
-  int len;
+  int fd              = inotify_init();
   HCFileData *fl_head = NULL;
   char buffer[INOTIFY_BUFLEN];
   struct timeval last_free, now;
@@ -188,7 +185,7 @@ hc_thread(void *data ATS_UNUSED)
 
     gettimeofday(&now, NULL);
     /* Read the inotify events, blocking until we get something */
-    len = read(fd, buffer, INOTIFY_BUFLEN);
+    int len = read(fd, buffer, INOTIFY_BUFLEN);
 
     /* The fl_head is a linked list of previously released data entries. They
        are ordered "by time", so once we find one that is scheduled for deletion,
@@ -257,14 +254,6 @@ hc_thread(void *data ATS_UNUSED)
     }
   }
 
-  /* Cleanup, in case we later exit this thread ... */
-  while (dirs) {
-    HCDirEntry *d = dirs;
-
-    dirs = dirs->_next;
-    TSfree(d);
-  }
-
   return NULL; /* Yeah, that never happens */
 }
 
@@ -321,14 +310,14 @@ parse_configs(const char *fname)
 
   while (!feof(fd)) {
     char *str, *save;
-    int state = 0;
     char *ok = NULL, *miss = NULL, *mime = NULL;
 
     finfo = TSmalloc(sizeof(HCFileInfo));
     memset(finfo, 0, sizeof(HCFileInfo));
 
     if (fgets(buf, sizeof(buf) - 1, fd)) {
-      str = strtok_r(buf, SEPARATORS, &save);
+      str       = strtok_r(buf, SEPARATORS, &save);
+      int state = 0;
       while (NULL != str) {
         if (strlen(str) > 0) {
           switch (state) {


### PR DESCRIPTION
dirs would be used without being assigned a value