### PR TITLE
Preserve the raw log fields when wiping using case insensitive contains and update container log fields

### DIFF
--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -2796,3 +2796,52 @@ LogAccess::marshal_milestone_diff(TSMilestonesType ms1, TSMilestonesType ms2, ch
   }
   return INK_MIN_ALIGN;
 }
+
+void
+LogAccess::set_http_header_field(LogField::Container container, char *field, char *buf, int len)
+{
+  HTTPHdr *header;
+
+  switch (container) {
+  case LogField::CQH:
+  case LogField::ECQH:
+    header = m_client_request;
+    break;
+
+  case LogField::PSH:
+  case LogField::EPSH:
+    header = m_proxy_response;
+    break;
+
+  case LogField::PQH:
+  case LogField::EPQH:
+    header = m_proxy_request;
+    break;
+
+  case LogField::SSH:
+  case LogField::ESSH:
+    header = m_server_response;
+    break;
+
+  case LogField::CSSH:
+  case LogField::ECSSH:
+    header = m_cache_response;
+    break;
+
+  default:
+    header = nullptr;
+    break;
+  }
+
+  if (header && buf) {
+    MIMEField *fld = header->field_find(field, (int)::strlen(field));
+    if (fld) {
+      // Loop over dups, update each of them
+      //
+      while (fld) {
+        header->value_set((const char *)field, (int)::strlen(field), buf, len);
+        fld = fld->m_next_dup;
+      }
+    }
+  }
+}

--- a/proxy/logging/LogAccess.h
+++ b/proxy/logging/LogAccess.h
@@ -280,6 +280,7 @@ public:
   inkcoreapi int marshal_milestone_fmt_time(TSMilestonesType ms, char *buf);
   inkcoreapi int marshal_milestone_fmt_ms(TSMilestonesType ms, char *buf);
   inkcoreapi int marshal_milestone_diff(TSMilestonesType ms1, TSMilestonesType ms2, char *buf);
+  inkcoreapi void set_http_header_field(LogField::Container container, char *field, char *buf, int len);
   //
   // unmarshalling routines
   //

--- a/proxy/logging/LogField.h
+++ b/proxy/logging/LogField.h
@@ -174,6 +174,7 @@ public:
     return m_time_field;
   }
 
+  inkcoreapi void set_http_header_field(LogAccess *lad, LogField::Container container, char *field, char *buf, int len);
   void set_aggregate_op(Aggregate agg_op);
   void update_aggregate(int64_t val);
 
@@ -181,6 +182,7 @@ public:
   static Container valid_container_name(char *name);
   static Aggregate valid_aggregate_name(char *name);
   static bool fieldlist_contains_aggregates(const char *fieldlist);
+  static bool isContainerUpdateFieldSupported(Container container);
 
 private:
   char *m_name;

--- a/proxy/logging/LogFilter.cc
+++ b/proxy/logging/LogFilter.cc
@@ -360,7 +360,7 @@ LogFilterString::wipe_this_entry(LogAccess *lad)
     for (size_t i = 0; i < marsh_len; i++) {
       buf_upper[i] = ParseRules::ink_toupper(buf[i]);
     }
-    cond_satisfied = _checkConditionAndWipe(&_isSubstring, &buf_upper, marsh_len, m_value_uppercase, &buf, DATA_LENGTH_LARGER);
+    cond_satisfied = _checkConditionAndWipe(&_isSubstring, &buf, marsh_len, m_value_uppercase, buf_upper, DATA_LENGTH_LARGER);
     break;
   default:
     ink_assert(!"INVALID FILTER OPERATOR");


### PR DESCRIPTION
This PR addresses the below issues:
1) When using the wipe field log filter with case insensitive contains as the condition, the log fields are wiped out correctly but printed in upper case. For e.g, when trying to  wipe `password` field out of the URL
 `www.abc.com/somepath?Password=abc&q1=query`, the output to log files would be something like `WWW.ABC.COM/SOMEPATH?PASSWORD=xxx&Q1=QUERY`

2) Extend Log Filter to support updating Container Log fields (e.g `cqh` - HTTP Headers), which is needed for example to use a wipe filter against things like `Referer` header, which may contain sensitive tokens.