### PR TITLE
Add soft limit for HTTP Request URI and Header field length.

### DIFF
--- a/configs/body_factory/default/Makefile.am
+++ b/configs/body_factory/default/Makefile.am
@@ -44,5 +44,6 @@ dist_bodyfactory_DATA = \
 	timeout\#activity \
 	timeout\#inactivity \
 	transcoding\#unsupported \
-	urlrouting\#no_mapping
+	urlrouting\#no_mapping \
+        request\#uri_len_too_long
 

--- a/configs/body_factory/default/request#uri_len_too_long
+++ b/configs/body_factory/default/request#uri_len_too_long
@@ -1,0 +1,15 @@
+<HTML>
+<HEAD>
+<TITLE>URI Too Long</TITLE>
+</HEAD>
+
+<BODY BGCOLOR="white" FGCOLOR="black">
+<H1>URI Too Long</H1>
+<HR>
+
+<FONT FACE="Helvetica,Arial"><B>
+Description: Could not process this request because
+the request uri was longer than proxy.config.http.request_line_max_size
+</B></FONT>
+<HR>
+</BODY>

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -1084,6 +1084,20 @@ mptcp
    This enables buffering the content for incoming ``POST`` requests. If enabled no outbound
    connection is made until the entire ``POST`` request has been buffered.
 
+.. ts:cv:: CONFIG proxy.config.http.request_line_max_size INT 65535
+
+   Controls the maximum size, in bytes, of an HTTP Request Line in requests. Requests
+   with a request line exceeding this size will be treated as invalid and
+   rejected by the proxy. Note that the HTTP request line typically includes HTTP method,
+   request target and HTTP version string except when the request is made using absolute
+   URI in which case the request line may also include the request scheme and domain name.
+
+.. ts:cv:: CONFIG proxy.config.http.header_field_max_size INT 131070
+
+   Controls the maximum size, in bytes, of an HTTP header field in requests. Headers
+   in a request with the sum of their name and value that exceed this size will cause the
+   entire request to be treated as invalid and rejected by the proxy.
+
 .. ts:cv:: CONFIG proxy.config.http.request_header_max_size INT 131072
 
    Controls the maximum size, in bytes, of an HTTP header in requests. Headers

--- a/doc/admin-guide/monitoring/error-messages.en.rst
+++ b/doc/admin-guide/monitoring/error-messages.en.rst
@@ -311,3 +311,10 @@ with corresponding HTTP response codes and customizable files.
    Cannot perform your request for the document ``URL`` because the
    protocol scheme is unknown.
    ``request#scheme_unsupported``
+
+``URI Too Long``
+   ``414``
+   Could not process this request because the request uri 
+   was too long ..
+   ``request#uri_len_too_long``
+

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -540,6 +540,10 @@ static const RecordElement RecordsConfig[] =
   {RECT_CONFIG, "proxy.config.http.global_user_agent_header", RECD_STRING, nullptr, RECU_DYNAMIC, RR_NULL, RECC_STR, ".*", RECA_NULL}
   ,
 
+  {RECT_CONFIG, "proxy.config.http.request_line_max_size", RECD_INT, "65535", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
+  {RECT_CONFIG, "proxy.config.http.header_field_max_size", RECD_INT, "131070", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
   //        ############
   //        # security #
   //        ############

--- a/proxy/hdrs/HdrTSOnly.cc
+++ b/proxy/hdrs/HdrTSOnly.cc
@@ -45,7 +45,8 @@
   -------------------------------------------------------------------------*/
 
 ParseResult
-HTTPHdr::parse_req(HTTPParser *parser, IOBufferReader *r, int *bytes_used, bool eof, bool strict_uri_parsing)
+HTTPHdr::parse_req(HTTPParser *parser, IOBufferReader *r, int *bytes_used, bool eof, bool strict_uri_parsing,
+                   size_t max_request_line_size, size_t max_hdr_field_size)
 {
   const char *start;
   const char *tmp;
@@ -71,7 +72,8 @@ HTTPHdr::parse_req(HTTPParser *parser, IOBufferReader *r, int *bytes_used, bool 
     int heap_slot = m_heap->attach_block(r->get_current_block(), start);
 
     m_heap->lock_ronly_str_heap(heap_slot);
-    state = http_parser_parse_req(parser, m_heap, m_http, &tmp, end, false, eof, strict_uri_parsing);
+    state = http_parser_parse_req(parser, m_heap, m_http, &tmp, end, false, eof, strict_uri_parsing, max_request_line_size,
+                                  max_hdr_field_size);
     m_heap->set_ronly_str_heap_end(heap_slot, tmp);
     m_heap->unlock_ronly_str_heap(heap_slot);
 

--- a/proxy/hdrs/HdrTest.h
+++ b/proxy/hdrs/HdrTest.h
@@ -70,6 +70,7 @@ private:
   int test_http_hdr_ctl_char(int testnum, const char *req, const char *req_tgt);
   int test_http_hdr_copy_over_aux(int testnum, const char *request, const char *response);
   int test_http_aux(const char *request, const char *response);
+  int test_http_req_parse_error(const char *request, const char *response);
   int test_arena_aux(Arena *arena, int len);
   void bri_box(const char *s);
   int failures_to_status(const char *testname, int nfail);

--- a/proxy/hdrs/MIME.cc
+++ b/proxy/hdrs/MIME.cc
@@ -2493,7 +2493,7 @@ mime_parser_clear(MIMEParser *parser)
 
 ParseResult
 mime_parser_parse(MIMEParser *parser, HdrHeap *heap, MIMEHdrImpl *mh, const char **real_s, const char *real_e,
-                  bool must_copy_strings, bool eof)
+                  bool must_copy_strings, bool eof, size_t max_hdr_field_size)
 {
   ParseResult err;
   bool line_is_real;
@@ -2561,8 +2561,8 @@ mime_parser_parse(MIMEParser *parser, HdrHeap *heap, MIMEHdrImpl *mh, const char
     field_value.ltrim_if(&ParseRules::is_ws);
     field_value.rtrim_if(&ParseRules::is_wslfcr);
 
-    // Make sure the name or value is not longer than 64K
-    if (field_name.size() >= UINT16_MAX || field_value.size() >= UINT16_MAX) {
+    // Make sure the name + value is not longer than configured max_hdr_field_size
+    if (field_name.size() + field_value.size() > max_hdr_field_size) {
       return PARSE_RESULT_ERROR;
     }
 

--- a/proxy/hdrs/MIME.h
+++ b/proxy/hdrs/MIME.h
@@ -757,7 +757,7 @@ void mime_field_value_append(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField *field, c
 void mime_parser_init(MIMEParser *parser);
 void mime_parser_clear(MIMEParser *parser);
 ParseResult mime_parser_parse(MIMEParser *parser, HdrHeap *heap, MIMEHdrImpl *mh, const char **real_s, const char *real_e,
-                              bool must_copy_strings, bool eof);
+                              bool must_copy_strings, bool eof, size_t max_hdr_field_size = 131070);
 
 void mime_hdr_describe(HdrHeapObjImpl *raw, bool recurse);
 void mime_field_block_describe(HdrHeapObjImpl *raw, bool recurse);
@@ -1013,7 +1013,8 @@ public:
 
   int print(char *buf, int bufsize, int *bufindex, int *chars_to_skip);
 
-  int parse(MIMEParser *parser, const char **start, const char *end, bool must_copy_strs, bool eof);
+  int parse(MIMEParser *parser, const char **start, const char *end, bool must_copy_strs, bool eof,
+            size_t max_hdr_field_size = UINT16_MAX);
 
   int value_get_index(const char *name, int name_length, const char *value, int value_length) const;
   const char *value_get(const char *name, int name_length, int *value_length) const;
@@ -1288,7 +1289,7 @@ MIMEHdr::print(char *buf, int bufsize, int *bufindex, int *chars_to_skip)
   -------------------------------------------------------------------------*/
 
 inline int
-MIMEHdr::parse(MIMEParser *parser, const char **start, const char *end, bool must_copy_strs, bool eof)
+MIMEHdr::parse(MIMEParser *parser, const char **start, const char *end, bool must_copy_strs, bool eof, size_t max_hdr_field_size)
 {
   if (!m_heap)
     m_heap = new_HdrHeap();
@@ -1296,7 +1297,7 @@ MIMEHdr::parse(MIMEParser *parser, const char **start, const char *end, bool mus
   if (!m_mime)
     m_mime = mime_hdr_create(m_heap);
 
-  return mime_parser_parse(parser, m_heap, m_mime, start, end, must_copy_strs, eof);
+  return mime_parser_parse(parser, m_heap, m_mime, start, end, must_copy_strs, eof, max_hdr_field_size);
 }
 
 /*-------------------------------------------------------------------------

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -987,6 +987,9 @@ HttpConfig::startup()
   HttpEstablishStaticConfigLongLong(c.origin_min_keep_alive_connections, "proxy.config.http.per_server.min_keep_alive");
   HttpEstablishStaticConfigByte(c.oride.attach_server_session_to_client, "proxy.config.http.attach_server_session_to_client");
 
+  HttpEstablishStaticConfigLongLong(c.http_request_line_max_size, "proxy.config.http.request_line_max_size");
+  HttpEstablishStaticConfigLongLong(c.http_hdr_field_max_size, "proxy.config.http.header_field_max_size");
+
   HttpEstablishStaticConfigByte(c.disable_ssl_parenting, "proxy.local.http.parent_proxy.disable_connect_tunneling");
   HttpEstablishStaticConfigByte(c.oride.forward_connect_method, "proxy.config.http.forward_connect_method");
 
@@ -1272,6 +1275,9 @@ HttpConfig::reconfigure()
   }
   params->origin_min_keep_alive_connections     = m_master.origin_min_keep_alive_connections;
   params->oride.attach_server_session_to_client = m_master.oride.attach_server_session_to_client;
+
+  params->http_request_line_max_size = m_master.http_request_line_max_size;
+  params->http_hdr_field_max_size    = m_master.http_hdr_field_max_size;
 
   if (params->oride.outbound_conntrack.max > 0 &&
       params->oride.outbound_conntrack.max < params->origin_min_keep_alive_connections) {

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -785,6 +785,9 @@ public:
 
   MgmtInt body_factory_response_max_size = 8192;
 
+  MgmtInt http_request_line_max_size = 65535;
+  MgmtInt http_hdr_field_max_size    = 131070;
+
   // noncopyable
   /////////////////////////////////////
   // operator = and copy constructor //

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -520,7 +520,22 @@ HttpTransact::BadRequest(State *s)
   TxnDebug("http_trans", "[BadRequest]"
                          "parser marked request bad");
   bootstrap_state_variables_from_request(s, &s->hdr_info.client_request);
-  build_error_response(s, HTTP_STATUS_BAD_REQUEST, "Invalid HTTP Request", "request#syntax_error");
+
+  const char *body_factory_template = "request#syntax_error";
+  HTTPStatus status                 = HTTP_STATUS_BAD_REQUEST;
+  const char *reason                = "Invalid HTTP Request";
+
+  switch (s->http_return_code) {
+  case HTTP_STATUS_REQUEST_URI_TOO_LONG:
+    body_factory_template = "request#uri_len_too_long";
+    status                = s->http_return_code;
+    reason                = "URI Too Long";
+    break;
+  default:
+    break;
+  }
+
+  build_error_response(s, status, reason, body_factory_template);
   TRANSACT_RETURN(SM_ACTION_SEND_ERROR_CACHE_NOOP, nullptr);
 }
 


### PR DESCRIPTION
Add a default body_factory template when rejecting a request that's too long