### PR TITLE
fixed datatype in example plugin

### DIFF
--- a/example/plugins/c-api/bnull_transform/bnull_transform.c
+++ b/example/plugins/c-api/bnull_transform/bnull_transform.c
@@ -81,7 +81,7 @@ static int
 handle_buffering(TSCont contp, MyData *data)
 {
   TSVIO write_vio;
-  int towrite;
+  int64_t towrite;
 
   /* Get the write VIO for the write operation that was performed on
      ourself. This VIO contains the buffer that we are to read from
@@ -117,7 +117,7 @@ handle_buffering(TSCont contp, MyData *data)
     /* The amount of data left to read needs to be truncated by
        the amount of data actually in the read buffer. */
 
-    int avail = TSIOBufferReaderAvail(TSVIOReaderGet(write_vio));
+    int64_t avail = TSIOBufferReaderAvail(TSVIOReaderGet(write_vio));
     if (towrite > avail) {
       towrite = avail;
     }

--- a/example/plugins/c-api/server_transform/server_transform.c
+++ b/example/plugins/c-api/server_transform/server_transform.c
@@ -284,7 +284,7 @@ static int
 transform_buffer_event(TSCont contp, TransformData *data, TSEvent event ATS_UNUSED, void *edata ATS_UNUSED)
 {
   TSVIO write_vio;
-  int towrite;
+  int64_t towrite;
 
   if (!data->input_buf) {
     data->input_buf    = TSIOBufferCreate();
@@ -313,7 +313,7 @@ transform_buffer_event(TSCont contp, TransformData *data, TSEvent event ATS_UNUS
   if (towrite > 0) {
     /* The amount of data left to read needs to be truncated by
        the amount of data actually in the read buffer. */
-    int avail = TSIOBufferReaderAvail(TSVIOReaderGet(write_vio));
+    int64_t avail = TSIOBufferReaderAvail(TSVIOReaderGet(write_vio));
     if (towrite > avail) {
       towrite = avail;
     }


### PR DESCRIPTION
This change fixes some datatype in some example plugins. The old datatype can cause overflow and make subsequent logic diverges, causing plugin not able to read all data.