### PR TITLE
Initialize EventIO

### DIFF
--- a/iocore/net/UnixNet.cc
+++ b/iocore/net/UnixNet.cc
@@ -234,7 +234,8 @@ initialize_thread_for_net(EThread *thread)
   thread->schedule_every(inactivityCop, HRTIME_SECONDS(cop_freq));
 
   thread->set_tail_handler(nh);
-  thread->ep       = (EventIO *)ats_malloc(sizeof(EventIO));
+  thread->ep = (EventIO *)ats_malloc(sizeof(EventIO));
+  new (thread->ep) EventIO();
   thread->ep->type = EVENTIO_ASYNC_SIGNAL;
 #if HAVE_EVENTFD
   thread->ep->start(pd, thread->evfd, nullptr, EVENTIO_READ);


### PR DESCRIPTION
Fix #5754

c815b17d3a855618620c9c9bcc491c0e68bcc4c1 introduced `syscall` member with default value in EventIO, but EventIO was not initialized.