### PR TITLE
Fix race condition when invoking TASK_THREADS_READY lifecycle hook

### DIFF
--- a/iocore/eventsystem/UnixEventProcessor.cc
+++ b/iocore/eventsystem/UnixEventProcessor.cc
@@ -395,8 +395,7 @@ EventProcessor::initThreadState(EThread *t)
   // Run all thread type initialization continuations that match the event types for this thread.
   for (int i = 0; i < MAX_EVENT_TYPES; ++i) {
     if (t->is_event_type(i)) { // that event type done here, roll thread start events of that type.
-      ++thread_group[i]._started;
-      if (thread_group[i]._started == thread_group[i]._count && thread_group[i]._afterStartCallback != nullptr) {
+      if (++thread_group[i]._started == thread_group[i]._count && thread_group[i]._afterStartCallback != nullptr) {
         thread_group[i]._afterStartCallback();
       }
       // To avoid race conditions on the event in the spawn queue, create a local one to actually send.


### PR DESCRIPTION
If thread A and thread B tries to increment `thread_group[i]._started` at the same time, because `thread_group[i]._started` is atomic, the final value will be correctly incremented by 2. But when `thread_group[i]._started == thread_group[i]._count` is being checked, both thread A and thread B might see the increment by 2 at the same time, which may causes the call back to be triggered twice. This PR fixes the problem by using the return value of the atomic increment such that every thread will only see the intended value.