### PR TITLE
Record HttpSM Id on new transaction

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -148,6 +148,9 @@ Http2Stream::decode_header_blocks(HpackHandle &hpack_handle, uint32_t maximum_ta
 void
 Http2Stream::send_request(Http2ConnectionState &cstate)
 {
+  ink_release_assert(this->current_reader != nullptr);
+  this->_http_sm_id = this->current_reader->sm_id;
+
   // Convert header to HTTP/1.1 format
   http2_convert_header_from_2_to_1_1(&_req_header);
 
@@ -174,7 +177,6 @@ Http2Stream::send_request(Http2ConnectionState &cstate)
 
   // Is there a read_vio request waiting?
   this->update_read_request(INT64_MAX, true);
-  this->_http_sm_id = this->current_reader->sm_id;
 }
 
 bool


### PR DESCRIPTION
After 0d2ad23921061c4117104b64d15bc17cae79c9fe (#5747) merged, I intermittently faced below crash.

```
(lldb) bt
* thread #2, name = '[ET_NET 1]', stop reason = EXC_BAD_ACCESS (code=1, address=0x48)
  * frame #0: 0x000000010018efbc traffic_server`Http2Stream::send_request(this=0x000000010916fee0, cstate=0x00000001087fc040) at Http2Stream.cc:175:45
    frame #1: 0x0000000100185926 traffic_server`rcv_headers_frame(cstate=0x00000001087fc040, frame=0x0000000106c810f8) at Http2ConnectionState.cc:366:15
    frame #2: 0x000000010017bdde traffic_server`Http2ConnectionState::main_event_handler(this=0x00000001087fc040, event=2253, edata=0x0000000106c810f8) at Http2ConnectionState.cc:970:15
    frame #3: 0x0000000100010901 traffic_server`Continuation::handleEvent(this=0x00000001087fc040, event=2253, data=0x0000000106c810f8) at I_Continuation.h:190:12
    frame #4: 0x0000000100176a0c traffic_server`send_connection_event(cont=0x00000001087fc040, event=2253, edata=0x0000000106c810f8) at Http2ClientSession.cc:65:16
    frame #5: 0x0000000100178b4d traffic_server`Http2ClientSession::do_complete_frame_read(this=0x00000001087fbd20) at Http2ClientSession.cc:540:3
    frame #6: 0x0000000100178030 traffic_server`Http2ClientSession::state_process_frame_read(this=0x00000001087fbd20, event=100, vio=0x0000000107ab9d78, inside_frame=false) at Http2ClientSession.cc:584:5
    frame #7: 0x0000000100177c2a traffic_server`Http2ClientSession::state_start_frame_read(this=0x00000001087fbd20, event=100, edata=0x0000000107ab9d78) at Http2ClientSession.cc:470:10
    frame #8: 0x0000000100175a9a traffic_server`Http2ClientSession::main_event_handler(this=0x00000001087fbd20, event=100, edata=0x0000000107ab9d78) at Http2ClientSession.cc:344:22
    frame #9: 0x0000000100010901 traffic_server`Continuation::handleEvent(this=0x00000001087fbd20, event=100, data=0x0000000107ab9d78) at I_Continuation.h:190:12
    frame #10: 0x0000000100176836 traffic_server`Http2ClientSession::state_read_connection_preface(this=0x00000001087fbd20, event=100, edata=0x0000000107ab9d78) at Http2ClientSession.cc:450:20
    frame #11: 0x0000000100175a9a traffic_server`Http2ClientSession::main_event_handler(this=0x00000001087fbd20, event=100, edata=0x0000000107ab9d78) at Http2ClientSession.cc:344:22
    frame #12: 0x0000000100010901 traffic_server`Continuation::handleEvent(this=0x00000001087fbd20, event=100, data=0x0000000107ab9d78) at I_Continuation.h:190:12
    frame #13: 0x0000000100377ab8 traffic_server`read_signal_and_update(event=100, vc=0x0000000107ab9ba0) at UnixNetVConnection.cc:83:24
    frame #14: 0x0000000100377a4b traffic_server`UnixNetVConnection::readSignalAndUpdate(this=0x0000000107ab9ba0, event=100) at UnixNetVConnection.cc:1006:11
    frame #15: 0x0000000100331978 traffic_server`SSLNetVConnection::net_read_io(this=0x0000000107ab9ba0, nh=0x0000000105675d50, lthread=0x0000000105672000) at SSLNetVConnection.cc:644:11
    frame #16: 0x0000000100367e22 traffic_server`NetHandler::process_ready_list(this=0x0000000105675d50) at UnixNet.cc:396:11
    frame #17: 0x0000000100368871 traffic_server`NetHandler::waitForActivity(this=0x0000000105675d50, timeout=60000000) at UnixNet.cc:529:3
    frame #18: 0x00000001003a837b traffic_server`EThread::execute_regular(this=0x0000000105672000) at UnixEThread.cc:277:14
    frame #19: 0x00000001003a87e8 traffic_server`EThread::execute(this=0x0000000105672000) at UnixEThread.cc:338:11
    frame #20: 0x00000001003a6b42 traffic_server`spawn_thread_internal(a=0x0000000101524160) at Thread.cc:92:12
    frame #21: 0x00007fff7172c2eb libsystem_pthread.dylib`_pthread_body + 126
    frame #22: 0x00007fff7172f249 libsystem_pthread.dylib`_pthread_start + 66
    frame #23: 0x00007fff7172b40d libsystem_pthread.dylib`thread_start + 13
```

I thought accessing `Http2Stream::current_reader` in `Http2Stream::send_request()` is safe. But there is a path of `Http2Stream::update_read_request()` starts shutdown and make it `nullptr`.