### PR TITLE
Issue 3654 addr based loop detection

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -508,9 +508,8 @@ HttpSM::attach_client_session(ProxyTransaction *client_vc, IOBufferReader *buffe
 
   ats_ip_copy(&t_state.client_info.src_addr, netvc->get_remote_addr());
   ats_ip_copy(&t_state.client_info.dst_addr, netvc->get_local_addr());
-  t_state.client_info.dst_addr.port() = netvc->get_local_port();
-  t_state.client_info.is_transparent  = netvc->get_is_transparent();
-  t_state.client_info.port_attribute  = static_cast<HttpProxyPort::TransportType>(netvc->attributes);
+  t_state.client_info.is_transparent = netvc->get_is_transparent();
+  t_state.client_info.port_attribute = static_cast<HttpProxyPort::TransportType>(netvc->attributes);
 
   // Record api hook set state
   hooks_set = client_vc->has_hooks();

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -6533,7 +6533,7 @@ HttpTransact::will_this_request_self_loop(State *s)
   if (s->dns_info.lookup_success) {
     if (ats_ip_addr_eq(s->host_db_info.ip(), &Machine::instance()->ip.sa)) {
       in_port_t host_port  = s->hdr_info.client_request.url_get()->port_get();
-      in_port_t local_port = s->client_info.src_addr.host_order_port();
+      in_port_t local_port = s->client_info.dst_addr.host_order_port();
       if (host_port == local_port) {
         switch (s->dns_info.looking_up) {
         case ORIGIN_SERVER:

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -6531,24 +6531,25 @@ HttpTransact::will_this_request_self_loop(State *s)
   // check if we are about to self loop //
   ////////////////////////////////////////
   if (s->dns_info.lookup_success) {
-    if (ats_ip_addr_eq(s->host_db_info.ip(), &Machine::instance()->ip.sa)) {
-      in_port_t host_port  = s->hdr_info.client_request.url_get()->port_get();
-      in_port_t local_port = s->client_info.dst_addr.host_order_port();
-      if (host_port == local_port) {
-        switch (s->dns_info.looking_up) {
-        case ORIGIN_SERVER:
-          TxnDebug("http_transact", "host ip and port same as local ip and port - bailing");
-          break;
-        case PARENT_PROXY:
-          TxnDebug("http_transact", "parent proxy ip and port same as local ip and port - bailing");
-          break;
-        default:
-          TxnDebug("http_transact", "unknown's ip and port same as local ip and port - bailing");
-          break;
-        }
-        build_error_response(s, HTTP_STATUS_BAD_REQUEST, "Cycle Detected", "request#cycle_detected");
-        return true;
+    in_port_t dst_port   = s->hdr_info.client_request.url_get()->port_get(); // going to this port.
+    in_port_t local_port = s->client_info.dst_addr.host_order_port();        // already connected proxy port.
+    // It's a loop if connecting to the same port as it already connected to the proxy and
+    // it's a proxy address or the same address it already connected to.
+    if (dst_port == local_port && (ats_ip_addr_eq(s->host_db_info.ip(), &Machine::instance()->ip.sa) ||
+                                   ats_ip_addr_eq(s->host_db_info.ip(), s->client_info.dst_addr))) {
+      switch (s->dns_info.looking_up) {
+      case ORIGIN_SERVER:
+        TxnDebug("http_transact", "host ip and port same as local ip and port - bailing");
+        break;
+      case PARENT_PROXY:
+        TxnDebug("http_transact", "parent proxy ip and port same as local ip and port - bailing");
+        break;
+      default:
+        TxnDebug("http_transact", "unknown's ip and port same as local ip and port - bailing");
+        break;
       }
+      build_error_response(s, HTTP_STATUS_BAD_REQUEST, "Cycle Detected", "request#cycle_detected");
+      return true;
     }
 
     // Now check for a loop using the Via string.


### PR DESCRIPTION
This fixes two distinct problems.

* IP address based loop detection for single address systems. As far as I can tell, loop detection doesn't work on hosts with a single address, due to port byte ordering problems.

* Issue #3654 - the address based check only checks a single address. If the request is for a different address on the same machine, to which a proxy port is bound (common case) then the loop is not detected. This fix checks if the destination address / port is the same as the inbound local address / port, which means the connection is looping.
