### PR TITLE
-H "xdebug: probe" injects trace of headers into response body

### DIFF
--- a/doc/admin-guide/plugins/xdebug.en.rst
+++ b/doc/admin-guide/plugins/xdebug.en.rst
@@ -57,11 +57,20 @@ Diags
     transaction specific diagnostics for the transaction. This also requires
     that :ts:cv:`proxy.config.diags.debug.enabled` is set to ``1``.
 
-log-headers
-    If the ``log-headers`` is requested while :ts:cv:`proxy.config.diags.debug.tags`
-    is set to ``xdebug.headers`` and :ts:cv:`proxy.config.diags.debug.enabled` is set to ``1``,
-    then all client and server, request and response headers are logged.
-    Also, the ``X-Debug: log-headers`` header is always added to the upstream request.
+Probe
+    All request and response headers are written to the response body. Because
+    the body is altered, it disables writing to cache.
+    In conjuction with the `fwd` tag, the response body will contain a
+    chronological log of all headers for all transactions used for this
+    response.
+
+    Layout:
+
+    - Request Headers from Client  -> Proxy A
+    - Request Headers from Proxy A -> Proxy B
+    - Original content body
+    - Response Headers from Proxy B -> Proxy A
+    - Response Headers from Proxy A -> Client
 
 X-Cache-Key
     The ``X-Cache-Key`` header contains the URL that identifies the HTTP object in the

--- a/plugins/xdebug/xdebug_headers.cc
+++ b/plugins/xdebug/xdebug_headers.cc
@@ -1,0 +1,159 @@
+/** @file
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include <cstdlib>
+#include <stdio.h>
+#include <cstdio>
+#include <strings.h>
+#include <string_view>
+#include <sstream>
+#include <cstring>
+#include <getopt.h>
+
+#define DEBUG_TAG_LOG_HEADERS "xdebug.headers"
+
+std::string_view
+escape_char_for_json(char const &c, bool &parsing_key)
+{
+  switch (c) {
+  case '\'':
+    return {"\\\'"};
+  case '"':
+    return {"\\\""};
+  case '\\':
+    return {"\\\\"};
+  case '\b':
+    return {"\\b"};
+  case '\f':
+    return {"\\f"};
+  case '\t':
+    return {"\\t"};
+
+  // Special header reformating
+  case '\r':
+    return {""};
+  case '\n':
+    parsing_key = true;
+    return {"',\r\n\t'"}; // replace new line with pair delemiter
+  case ':':
+    if (parsing_key) {
+      return {"' : "}; // replace colon after keywith quote + colon
+    }
+    return {":"};
+  case ' ':
+    if (parsing_key) {
+      parsing_key = false;
+      return {"'"}; // replace first space after the key to be a quote
+    }
+    return {" "};
+  default:
+    return {&c, 1};
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////
+// Dump a header on stderr, useful together with TSDebug().
+void
+print_headers(TSHttpTxn txn, TSMBuffer bufp, TSMLoc hdr_loc, std::stringstream &ss)
+{
+  TSIOBuffer output_buffer;
+  TSIOBufferReader reader;
+  TSIOBufferBlock block;
+  const char *block_start;
+  int64_t block_avail;
+  bool parsing_key    = true;
+  size_t print_rewind = ss.str().length();
+  output_buffer       = TSIOBufferCreate();
+  reader              = TSIOBufferReaderAlloc(output_buffer);
+
+  ss << "\t'";
+  /* This will print just MIMEFields and not the http request line */
+  TSMimeHdrPrint(bufp, hdr_loc, output_buffer);
+
+  /* We need to loop over all the buffer blocks, there can be more than 1 */
+  block = TSIOBufferReaderStart(reader);
+  do {
+    block_start = TSIOBufferBlockReadStart(block, reader, &block_avail);
+    for (const char *c = block_start; c < block_start + block_avail; ++c) {
+      bool was_parsing_key = parsing_key;
+      ss << escape_char_for_json(*c, parsing_key);
+      if (parsing_key && !was_parsing_key) {
+        print_rewind = ss.str().length() - 1;
+      }
+    }
+    TSIOBufferReaderConsume(reader, block_avail);
+    block = TSIOBufferReaderStart(reader);
+  } while (block && block_avail != 0);
+
+  ss.seekp(print_rewind);
+
+  /* Free up the TSIOBuffer that we used to print out the header */
+  TSIOBufferReaderFree(reader);
+  TSIOBufferDestroy(output_buffer);
+
+  TSDebug(DEBUG_TAG_LOG_HEADERS, "%s", ss.str().c_str());
+}
+
+void
+log_headers(TSHttpTxn txn, TSMBuffer bufp, TSMLoc hdr_loc, char const *type_msg)
+{
+  if (TSIsDebugTagSet(DEBUG_TAG_LOG_HEADERS)) {
+    std::stringstream output;
+    print_headers(txn, bufp, hdr_loc, output);
+    TSDebug(DEBUG_TAG_LOG_HEADERS, "\n=============\n %s headers are... \n %s", type_msg, output.str().c_str());
+  }
+}
+
+void
+print_request_headers(TSHttpTxn txn, std::stringstream &output)
+{
+  TSMBuffer buf_c, buf_s;
+  TSMLoc hdr_loc;
+  if (TSHttpTxnClientReqGet(txn, &buf_c, &hdr_loc) == TS_SUCCESS) {
+    output << "{'type':'request', 'side':'client', 'headers': {\n";
+    print_headers(txn, buf_c, hdr_loc, output);
+    output << "}}";
+    TSHandleMLocRelease(buf_c, TS_NULL_MLOC, hdr_loc);
+  }
+  if (TSHttpTxnServerReqGet(txn, &buf_s, &hdr_loc) == TS_SUCCESS) {
+    output << ",{'type':'request', 'side':'server', 'headers': {\n";
+    print_headers(txn, buf_s, hdr_loc, output);
+    output << "}}";
+    TSHandleMLocRelease(buf_s, TS_NULL_MLOC, hdr_loc);
+  }
+}
+
+void
+print_response_headers(TSHttpTxn txn, std::stringstream &output)
+{
+  TSMBuffer buf_c, buf_s;
+  TSMLoc hdr_loc;
+  if (TSHttpTxnServerRespGet(txn, &buf_s, &hdr_loc) == TS_SUCCESS) {
+    output << "{'type':'response', 'side':'server', 'headers': {\n";
+    print_headers(txn, buf_s, hdr_loc, output);
+    output << "}},";
+    TSHandleMLocRelease(buf_s, TS_NULL_MLOC, hdr_loc);
+  }
+  if (TSHttpTxnClientRespGet(txn, &buf_c, &hdr_loc) == TS_SUCCESS) {
+    output << "{'type':'response', 'side':'client', 'headers': {\n";
+    print_headers(txn, buf_c, hdr_loc, output);
+    output << "}}";
+    TSHandleMLocRelease(buf_c, TS_NULL_MLOC, hdr_loc);
+  }
+}

--- a/plugins/xdebug/xdebug_transforms.cc
+++ b/plugins/xdebug/xdebug_transforms.cc
@@ -1,0 +1,158 @@
+/** @file
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <functional>
+#include <atomic>
+
+#include "ts/ts.h"
+
+static const std::string_view MultipartBoundary{"\r\n--- ATS xDebug Probe Injection Boundary ---\r\n\r\n"};
+
+struct BodyBuilder {
+  TSVIO output_vio               = nullptr;
+  TSIOBuffer output_buffer       = nullptr;
+  TSIOBufferReader output_reader = nullptr;
+  bool wrote_prebody             = false;
+  bool wrote_body                = false;
+  bool hdr_ready                 = false;
+  std::atomic_flag wrote_postbody;
+
+  int64_t nbytes = 0;
+  TSHttpTxn txn  = nullptr;
+};
+
+static char Hostname[1024];
+
+static std::string
+getPreBody(TSHttpTxn txn)
+{
+  std::stringstream output;
+  output << "{'xDebugProbeAt' : '" << Hostname << "'\n   'captured':[";
+  print_request_headers(txn, output);
+  output << "\n   ]\n}";
+  output << MultipartBoundary;
+  return output.str();
+}
+
+static std::string
+getPostBody(TSHttpTxn txn)
+{
+  std::stringstream output;
+  output << MultipartBoundary;
+  output << "{'xDebugProbeAt' : '" << Hostname << "'\n   'captured':[";
+  print_response_headers(txn, output);
+  output << "\n   ]\n}";
+  return output.str();
+}
+
+static void
+writePostBody(BodyBuilder *data)
+{
+  if (data->wrote_body && data->hdr_ready && !data->wrote_postbody.test_and_set()) {
+    TSDebug("xdebug_transform", "body_transform(): Writing postbody headers...");
+    std::string postbody = getPostBody(data->txn);
+    TSIOBufferWrite(data->output_buffer, postbody.data(), postbody.length());
+    data->nbytes += postbody.length();
+    TSVIONBytesSet(data->output_vio, data->nbytes);
+    TSVIOReenable(data->output_vio);
+  }
+}
+
+static int
+body_transform(TSCont contp, TSEvent event, void *edata)
+{
+  BodyBuilder *data = static_cast<BodyBuilder *>(TSContDataGet(contp));
+  if (!data) {
+    TSContDestroy(contp);
+    return TS_ERROR;
+  }
+  if (TSVConnClosedGet(contp)) {
+    // write connection destoried. cleanup.
+    delete data;
+    TSContDestroy(contp);
+    return 0;
+  }
+
+  TSVIO src_vio = TSVConnWriteVIOGet(contp);
+
+  switch (event) {
+  case TS_EVENT_ERROR: {
+    // Notify input vio of this error event
+    TSContCall(TSVIOContGet(src_vio), TS_EVENT_ERROR, src_vio);
+    return 0;
+  }
+  case TS_EVENT_VCONN_WRITE_COMPLETE: {
+    TSVConnShutdown(TSTransformOutputVConnGet(contp), 0, 1);
+    return 0;
+  }
+  case TS_EVENT_VCONN_WRITE_READY:
+    TSDebug("xdebug_transform", "body_transform(): Event is TS_EVENT_VCONN_WRITE_READY");
+  // fallthru
+  default:
+    if (!data->output_buffer) {
+      data->output_buffer = TSIOBufferCreate();
+      data->output_reader = TSIOBufferReaderAlloc(data->output_buffer);
+      data->output_vio    = TSVConnWrite(TSTransformOutputVConnGet(contp), contp, data->output_reader, INT64_MAX);
+    }
+
+    if (data->wrote_prebody == false) {
+      TSDebug("xdebug_transform", "body_transform(): Writing prebody headers...");
+      std::string prebody = getPreBody(data->txn);
+      TSIOBufferWrite(data->output_buffer, prebody.data(), prebody.length()); // write prebody
+      data->wrote_prebody = true;
+      data->nbytes += prebody.length();
+    }
+
+    TSIOBuffer src_buf = TSVIOBufferGet(src_vio);
+
+    if (!src_buf) {
+      // upstream continuation shuts down write operation.
+      data->wrote_body = true;
+      writePostBody(data);
+      return 0;
+    }
+
+    int64_t towrite = TSVIONTodoGet(src_vio);
+    TSDebug("xdebug_transform", "body_transform(): %li bytes of body is expected", towrite);
+    int64_t avail = TSIOBufferReaderAvail(TSVIOReaderGet(src_vio));
+    towrite       = towrite > avail ? avail : towrite;
+    if (towrite > 0) {
+      TSIOBufferCopy(TSVIOBufferGet(data->output_vio), TSVIOReaderGet(src_vio), towrite, 0);
+      TSIOBufferReaderConsume(TSVIOReaderGet(src_vio), towrite);
+      TSVIONDoneSet(src_vio, TSVIONDoneGet(src_vio) + towrite);
+      TSDebug("xdebug_transform", "body_transform(): writing %li bytes of body", towrite);
+    }
+
+    if (TSVIONTodoGet(src_vio) > 0) {
+      TSVIOReenable(data->output_vio);
+      TSContCall(TSVIOContGet(src_vio), TS_EVENT_VCONN_WRITE_READY, src_vio);
+    } else {
+      // End of src vio
+      // Write post body content and update output VIO
+      data->wrote_body = true;
+      data->nbytes += TSVIONDoneGet(src_vio);
+      writePostBody(data);
+      TSContCall(TSVIOContGet(src_vio), TS_EVENT_VCONN_WRITE_COMPLETE, src_vio);
+    }
+  }
+  return 0;
+}


### PR DESCRIPTION
Update xdebug probe to output to json format.

[previous description]
With the intent to debug CDN, peered or multi-tiered proxy behavior, this header will trigger the code to write the request and response headers to the response body at each proxy the request is processed.
This has been proven to be significantly easier to use than log-headers.

As with all xdebug features some security layer should be applied to control who is allowed to see this type of response data.
