### PR TITLE
Fixed std::array initialization for older compilers

### DIFF
--- a/proxy/Milestones.h
+++ b/proxy/Milestones.h
@@ -89,7 +89,7 @@ public:
   }
 
 private:
-  std::array<ink_hrtime, entries> _milestones = {0};
+  std::array<ink_hrtime, entries> _milestones = {{0}};
 };
 
 // For compatibility with HttpSM.h and HttpTransact.h


### PR DESCRIPTION
Will hopefully fix the ubuntu clang 5 master build.