### PR TITLE
IPAllow: Fix syntax checking heuristic, tweak default file contents.

### DIFF
--- a/configs/ip_allow.yaml.default
+++ b/configs/ip_allow.yaml.default
@@ -15,8 +15,11 @@
 #            HEAD, OPTIONS, POST, PURGE, PUT, TRACE, PUSH. The special name "ALL" indicates all
 #            methods and it overrides any other methods.
 #
-# A rule must have either "src" or "dst" to indicate if the IP addresses apply to inbound connections
-# or outbound connections.
+# A rule must have
+#
+# * the "apply" key with either "src" or "dst" to indicate if the IP addresses apply to inbound
+#   connections or outbound connections.
+# * the "ip_addrs" key to specific the IP addresses to which the rule applies.
 #
 # The top level tag 'ip_allow' identifies the rule items. Its value must be a rule item or a
 # sequence of rule items.
@@ -24,27 +27,23 @@
 # Rules are applied in the order listed starting from the top.
 # That means you generally want to append your rules after the ones listed here.
 #
-# Allow anything on localhost, limit destructive methods elsewhere.
+
+# Allow anything on loopback addresses, limit destructive methods elsewhere.
 ip_allow:
-  - apply: in
-    ip_addrs: 127.0.0.1
-    action: allow
-    methods: ALL
-  - apply: in
-    ip_addrs: ::1
-    action: allow
-    methods: ALL
-  - apply: in
-    ip_addrs: 0/0
-    action: deny
-    methods:
-      - PURGE
-      - PUSH
-      - DELETE
-  - apply: in
-    ip_addrs: ::/0
-    action: deny
-    methods:
-      - PURGE
-      - PUSH
-      - DELETE
+
+- apply: in
+  ip_addrs:
+  - 127.0.0.0/8
+  - ::1
+  action: allow
+  methods: ALL
+
+- apply: in
+  ip_addrs:
+  - 0/0
+  - ::/0
+  action: deny
+  methods:
+  - PURGE
+  - PUSH
+  - DELETE

--- a/proxy/IPAllow.cc
+++ b/proxy/IPAllow.cc
@@ -259,8 +259,9 @@ IpAllow::BuildTable()
   std::error_code ec;
   std::string content{ts::file::load(config_file, ec)};
   if (ec.value() == 0) {
-    // If it's a .yaml or the root tag is present, treat as YAML.
-    if (TextView{config_file.view()}.take_suffix_at('.') == "yaml" || std::string::npos != content.find(YAML_TAG_ROOT)) {
+    // If it's a .yaml or the tokens "apply" *and* "ip_addrs" are present, treat as YAML.
+    if (TextView{config_file.view()}.take_suffix_at('.') == "yaml" ||
+        (std::string::npos != content.find(YAML_TAG_IP_ADDRS) && std::string::npos != content.find(YAML_TAG_APPLY))) {
       this->YAMLBuildTable(content);
     } else {
       this->ATSBuildTable(content);

--- a/tests/gold_tests/autest-site/min_cfg/ip_allow.yaml
+++ b/tests/gold_tests/autest-site/min_cfg/ip_allow.yaml
@@ -15,29 +15,33 @@
 
 # Allow anything on localhost, limit destructive methods elsewhere.
 ip_allow:
-  - apply: in
-    ip_addrs: 127.0.0.1
-    action: allow
-    methods: ALL
-  - apply: out
-    ip_addrs: [ 10.0.0.0/8, 192.168.1.0/24 ]
-    action: allow
-    methods: [GET, HEAD, POST ]
-  - apply: in
-    ip_addrs: ::1
-    action: allow
-    methods: ALL
-  - apply: in
-    ip_addrs: 0/0
-    action: deny
-    methods:
-      - PURGE
-      - PUSH
-      - DELETE
-  - apply: in
-    ip_addrs: ::/0
-    action: deny
-    methods:
-      - PURGE
-      - PUSH
-      - DELETE
+
+- apply: in
+  ip_addrs:
+  - 127.0.0.0/8
+  - ::1
+  action: allow
+  methods: ALL
+
+- apply: in
+  ip_addrs:
+  - 0/0
+  - ::/0
+  action: deny
+  methods:
+  - PURGE
+  - PUSH
+  - DELETE
+
+# Restrict outbound connections to non-routables to avoid hitting actual servers.
+# Although, this has no effect without enabling it in "remap.config" which is rarely if ever done
+# in the tests.
+- apply: out
+  ip_addrs:
+  - 10.0.0.0/8
+  - 192.168.0.0/16
+  action: allow
+  methods:
+  - GET
+  - HEAD
+  - POST


### PR DESCRIPTION
Currently if the old "ip_allow.config" file is still in the configuration directory, no connections will be allowed. This is because the file type heuristic detects it as YAML, not old style. In the original PR, the root tag was not "ip_allow" and therefore didn't occur in the old style, but since it was changed that
string is in the old style file and is therefore falsely detected as YAML. This is problematic for any developer testing locally because if the old file is not removed, no testing will work.

I changed the default file configuration to be more compact and take advantage of YAML instead of simply directly mirroring the old style configuration.