### PR TITLE
Fix broken template path caused by ba42078 (PR 1468) (Cherry pick 396…

### DIFF
--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -753,7 +753,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.body_factory.enable_logging", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.body_factory.template_sets_dir", RECD_STRING, TS_BUILD_SYSCONFDIR "/body_factory", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[^[:space:]]+$", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.body_factory.template_sets_dir", RECD_STRING, "body_factory", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[^[:space:]]+$", RECA_NULL}
   ,
   //# 0 - never suppress generated responses
   //# 1 - always suppress generated responses

--- a/proxy/http/HttpBodyFactory.cc
+++ b/proxy/http/HttpBodyFactory.cc
@@ -171,7 +171,6 @@ HttpBodyFactory::fabricate_with_old_api(const char *type, HttpTransact::State *c
   // handle return of instantiated template and generate the content //
   // language and content type return values                         //
   /////////////////////////////////////////////////////////////////////
-
   if (buffer) { // got an instantiated template
     if (!plain_flag) {
       snprintf(content_language_out_buf, content_language_buf_size, "%s", lang_ptr);
@@ -268,7 +267,6 @@ HttpBodyFactory::reconfigure()
 //#endif
 {
   RecInt e;
-  RecString s = nullptr;
   bool all_found;
   int rec_err;
 
@@ -304,20 +302,14 @@ HttpBodyFactory::reconfigure()
   all_found                 = all_found && (rec_err == REC_ERR_OKAY);
   Debug("body_factory", "response_suppression_mode = %d (found = %" PRId64 ")", response_suppression_mode, e);
 
-  ats_scoped_str directory_of_template_sets;
+  ats_scoped_str directory_of_template_sets(RecConfigReadConfigPath("proxy.config.body_factory.template_sets_dir", "body_factory"));
 
-  rec_err   = RecGetRecordString_Xmalloc("proxy.config.body_factory.template_sets_dir", &s);
-  all_found = all_found && (rec_err == REC_ERR_OKAY);
-  if (rec_err == REC_ERR_OKAY) {
-    directory_of_template_sets = Layout::get()->relative(s);
-    if (access(directory_of_template_sets, R_OK) < 0) {
-      Warning("Unable to access() directory '%s': %d, %s", (const char *)directory_of_template_sets, errno, strerror(errno));
-      Warning(" Please set 'proxy.config.body_factory.template_sets_dir' ");
-    }
+  if (access(directory_of_template_sets, R_OK) < 0) {
+    Warning("Unable to access() directory '%s': %d, %s", (const char *)directory_of_template_sets, errno, strerror(errno));
+    Warning(" Please set 'proxy.config.body_factory.template_sets_dir' ");
   }
 
-  Debug("body_factory", "directory_of_template_sets = '%s' (found = %s)", (const char *)directory_of_template_sets, s);
-  ats_free(s);
+  Debug("body_factory", "directory_of_template_sets = '%s'", (const char *)directory_of_template_sets);
 
   if (!all_found) {
     Warning("config changed, but can't fetch all proxy.config.body_factory values");


### PR DESCRIPTION
This is a back port of PR1508 to ats7, undoing PR1468.  ats7 was branched after PR1468 but before PR1508.

I ran into this bug while testing the slice plugin.  When the upstream virtual loopback connection hits a fail condition it should return an appropriate fail header (502, etc) to the slice plugin.  Unfortunately the vconn/vio is set to a bad state allowing for a null pointer dereference.

The scenario:

under ats8, if the above condition is hit and the proxy.config.body_factory.template_sets_dir is configured CORRECTLY a proper header is passed back over the vconn/vio.  IF proxy.config.body_factory.template_sets_dir is configured incorrectly the core dump condition is hit.

Under ats7 if the above condition is hit and proxy.config.body_factory.template_sets_dir is configured CORRECTLY core dump condition is hit.  If proxy.config.body_factory.template_sets_dir is configure incorrectly there is no core dump.

Under ats master there is no core dump under either condition.