### PR TITLE
make check race condition fix

### DIFF
--- a/proxy/http/remap/unit-tests/plugin_testing_common.cc
+++ b/proxy/http/remap/unit-tests/plugin_testing_common.cc
@@ -37,3 +37,16 @@ PrintToStdErr(const char *fmt, ...)
   vfprintf(stderr, fmt, args);
   va_end(args);
 }
+
+fs::path
+getTemporaryDir()
+{
+  std::error_code ec;
+  fs::path tmpDir = fs::canonical(fs::temp_directory_path(), ec);
+  tmpDir /= "sandbox_XXXXXX";
+
+  char dirNameTemplate[tmpDir.string().length() + 1];
+  sprintf(dirNameTemplate, "%s", tmpDir.c_str());
+
+  return fs::path(mkdtemp(dirNameTemplate));
+}

--- a/proxy/http/remap/unit-tests/plugin_testing_common.h
+++ b/proxy/http/remap/unit-tests/plugin_testing_common.h
@@ -40,6 +40,9 @@
 
 extern thread_local PluginThreadContext *pluginThreadContext;
 
+/* A temp sandbox to play with our toys used for all fun with this test-bench */
+fs::path getTemporaryDir();
+
 class PluginDebugObject
 {
 public:

--- a/proxy/http/remap/unit-tests/test_PluginDso.cc
+++ b/proxy/http/remap/unit-tests/test_PluginDso.cc
@@ -39,11 +39,8 @@ thread_local PluginThreadContext *pluginThreadContext;
 
 std::error_code ec;
 
-/* A temp sandbox to play with our toys used for all fun with this test-bench */
-static fs::path tmpDir = fs::canonical(fs::temp_directory_path(), ec);
-
 /* The following are dirs that are used commonly in the unit-tests */
-static fs::path sandboxDir     = tmpDir / fs::path("sandbox");
+static fs::path sandboxDir     = getTemporaryDir();
 static fs::path runtimeDir     = sandboxDir / fs::path("runtime");
 static fs::path searchDir      = sandboxDir / fs::path("search");
 static fs::path pluginBuildDir = fs::current_path() / fs::path("unit-tests/.libs");
@@ -91,6 +88,8 @@ public:
  */
 SCENARIO("loading plugins", "[plugin][core]")
 {
+  REQUIRE_FALSE(sandboxDir.empty());
+
   clean();
   std::string error;
 
@@ -322,6 +321,8 @@ SCENARIO("loading plugins", "[plugin][core]")
  */
 SCENARIO("looking for symbols inside a plugin DSO", "[plugin][core]")
 {
+  REQUIRE_FALSE(sandboxDir.empty());
+
   clean();
   std::string error;
 

--- a/proxy/http/remap/unit-tests/test_PluginFactory.cc
+++ b/proxy/http/remap/unit-tests/test_PluginFactory.cc
@@ -77,11 +77,8 @@ getDebugObject(const PluginDso &plugin)
   }
 }
 
-/* A temp sandbox to play with our toys used for all fun with this test-bench */
-static fs::path tmpDir = fs::canonical(fs::temp_directory_path(), ec);
-
 /* The following are paths that are used commonly in the unit-tests */
-static fs::path sandboxDir     = tmpDir / "sandbox";
+static fs::path sandboxDir     = getTemporaryDir();
 static fs::path runtimeRootDir = sandboxDir / "runtime";
 static fs::path runtimeDir     = runtimeRootDir / tempComponent;
 static fs::path searchDir      = sandboxDir / "search";
@@ -149,6 +146,8 @@ validateSuccessfulConfigPathTest(const RemapPluginInst *pluginInst, const std::s
 
 SCENARIO("loading plugins", "[plugin][core]")
 {
+  REQUIRE_FALSE(sandboxDir.empty());
+
   fs::path effectivePath;
   fs::path runtimePath;
   std::string error;
@@ -249,6 +248,8 @@ SCENARIO("loading plugins", "[plugin][core]")
 
 SCENARIO("multiple search dirs + multiple or no plugins installed", "[plugin][core]")
 {
+  REQUIRE_FALSE(sandboxDir.empty());
+
   GIVEN("multiple search dirs specified for the plugin search")
   {
     /* Create the directory structure and install plugins */
@@ -386,6 +387,8 @@ getPluginVersion(const PluginDso &plugin)
 
 SCENARIO("loading multiple version of the same plugin at the same time", "[plugin][core]")
 {
+  REQUIRE_FALSE(sandboxDir.empty());
+
   static fs::path uuid_t1 = fs::path("c71e2bab-90dc-4770-9535-c9304c3de381"); /* UUID at moment t1 */
   static fs::path uuid_t2 = fs::path("c71e2bab-90dc-4770-9535-e7304c3ee732"); /* UUID at moment t2 */
 
@@ -532,6 +535,8 @@ SCENARIO("loading multiple version of the same plugin at the same time", "[plugi
 
 SCENARIO("notifying plugins of config reload", "[plugin][core]")
 {
+  REQUIRE_FALSE(sandboxDir.empty());
+
   /* use 2 copies of the same plugin to test */
   fs::path configName1 = fs::path("plugin_testing_calls_1.so");
   fs::path configName2 = fs::path("plugin_testing_calls_2.so");

--- a/proxy/http/remap/unit-tests/test_RemapPlugin.cc
+++ b/proxy/http/remap/unit-tests/test_RemapPlugin.cc
@@ -40,16 +40,8 @@ thread_local PluginThreadContext *pluginThreadContext;
 static void *INSTANCE_HANDLER = (void *)789;
 std::error_code ec;
 
-/* Some plugin context pointers used for unit testing */
-// static const PluginThreadContext *PLUGIN_INIT_CONTEXT_CUR    = (PluginThreadContext *)1;
-// static const PluginThreadContext *PLUGIN_INIT_CONTEXT_NEW_V1 = (PluginThreadContext *)2;
-// static const PluginThreadContext *PLUGIN_INIT_CONTEXT_NEW_V2 = (PluginThreadContext *)3;
-
-/* A temp sandbox to play with our toys used for all fun with this test-bench */
-static fs::path tmpDir = fs::canonical(fs::temp_directory_path(), ec);
-
 /* The following are paths that are used commonly in the unit-tests */
-static fs::path sandboxDir     = tmpDir / "sandbox";
+static fs::path sandboxDir     = getTemporaryDir();
 static fs::path runtimeDir     = sandboxDir / "runtime";
 static fs::path searchDir      = sandboxDir / "search";
 static fs::path pluginBuildDir = fs::current_path() / "unit-tests/.libs";
@@ -128,6 +120,8 @@ cleanupSandBox(RemapPluginInfo *plugin)
 
 SCENARIO("loading remap plugins", "[plugin][core]")
 {
+  REQUIRE_FALSE(sandboxDir.empty());
+
   std::string error;
   PluginDebugObject *debugObject = nullptr;
 
@@ -244,6 +238,8 @@ checkCallTest(bool shouldHaveFailed, bool result, const std::string &error, std:
 
 SCENARIO("invoking plugin init", "[plugin][core]")
 {
+  REQUIRE_FALSE(sandboxDir.empty());
+
   std::string error;
   PluginDebugObject *debugObject = nullptr;
 
@@ -290,6 +286,8 @@ SCENARIO("invoking plugin init", "[plugin][core]")
 
 SCENARIO("invoking plugin instance init", "[plugin][core]")
 {
+  REQUIRE_FALSE(sandboxDir.empty());
+
   std::string error;
   PluginDebugObject *debugObject = nullptr;
   void *ih                       = nullptr; // Instance handler pointer.
@@ -361,6 +359,8 @@ SCENARIO("invoking plugin instance init", "[plugin][core]")
 
 SCENARIO("unloading the plugin", "[plugin][core]")
 {
+  REQUIRE_FALSE(sandboxDir.empty());
+
   std::string error;
   PluginDebugObject *debugObject = nullptr;
 
@@ -409,6 +409,8 @@ SCENARIO("unloading the plugin", "[plugin][core]")
 
 SCENARIO("config reload", "[plugin][core]")
 {
+  REQUIRE_FALSE(sandboxDir.empty());
+
   std::string error;
   PluginDebugObject *debugObject = nullptr;
 


### PR DESCRIPTION
Avoid race conditions when creating unique temporary
unit-test sandbox directory by using [mkdtemp](http://man7.org/linux/man-pages/man3/mkdtemp.3.html)().