### PR TITLE
Cleanup: Signal READ_READY event only if the buffer is readable

### DIFF
--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -165,15 +165,13 @@ Http2ClientSession::free()
 void
 Http2ClientSession::start()
 {
-  VIO *read_vio;
-
   SCOPED_MUTEX_LOCK(lock, this->mutex, this_ethread());
 
   SET_HANDLER(&Http2ClientSession::main_event_handler);
   HTTP2_SET_SESSION_HANDLER(&Http2ClientSession::state_read_connection_preface);
 
-  read_vio  = this->do_io_read(this, INT64_MAX, this->read_buffer);
-  write_vio = this->do_io_write(this, INT64_MAX, this->sm_writer);
+  VIO *read_vio = this->do_io_read(this, INT64_MAX, this->read_buffer);
+  write_vio     = this->do_io_write(this, INT64_MAX, this->sm_writer);
 
   // 3.5 HTTP/2 Connection Preface. Upon establishment of a TCP connection and
   // determination that HTTP/2 will be used by both peers, each endpoint MUST
@@ -183,7 +181,10 @@ Http2ClientSession::start()
 
   this->connection_state.init();
   send_connection_event(&this->connection_state, HTTP2_SESSION_EVENT_INIT, this);
-  this->handleEvent(VC_EVENT_READ_READY, read_vio);
+
+  if (this->sm_reader->is_read_avail_more_than(0)) {
+    this->handleEvent(VC_EVENT_READ_READY, read_vio);
+  }
 }
 
 void


### PR DESCRIPTION
READ_READY event is always signaled itself when Http2ClientSession is started.
But this could waste some CPU cycle if there no data to read.