### PR TITLE
compress plugin: document undocumented options

### DIFF
--- a/doc/admin-guide/plugins/compress.en.rst
+++ b/doc/admin-guide/plugins/compress.en.rst
@@ -108,6 +108,23 @@ Provides a wildcard to match against content types, determining which are to be
 considered compressible. This defaults to ``text/*``. Takes one Content-Type
 per line.
 
+compressible-status-code
+------------------------
+
+A comma separated list of response status codes for which to enable
+compression. Defaults to 200, 206, 304.
+
+minimum-content-length
+----------------------
+
+Minimum Content-Length value sent by the origin server to consider the response
+compressible. Due to the overhead and latency of compression and decompression,
+it only makes sense to compress files above a certain size threshold.
+Compressing files below 150 bytes can actually make them larger. This setting
+only applies if the response explicitly sends Content-Length. Regardless of
+this setting, responses with ``Content-Length: 0`` are considered not
+compressible.
+
 allow
 --------
 
@@ -167,6 +184,8 @@ might create a configuration with the following options::
    remove-accept-encoding false
    compressible-content-type text/*
    compressible-content-type application/json
+   compressible-status-code 200, 206
+   minimum-content-length 860
    flush false
 
    # Now set a configuration for www.example.com


### PR DESCRIPTION
Document the configuration options compressible-status-code and
minimum-content-length.