### PR TITLE
Fix QUIC build

### DIFF
--- a/src/traffic_quic/traffic_quic.cc
+++ b/src/traffic_quic/traffic_quic.cc
@@ -182,22 +182,8 @@ Log::trace_out(sockaddr const *, unsigned short, char const *, ...)
 
 #include "InkAPIInternal.h"
 
-int
-APIHook::invoke(int, void *)
-{
-  ink_assert(false);
-  return 0;
-}
-
 APIHook *
 APIHook::next() const
-{
-  ink_assert(false);
-  return nullptr;
-}
-
-APIHook *
-APIHooks::get() const
 {
   ink_assert(false);
   return nullptr;
@@ -215,10 +201,30 @@ APIHooks::append(INKContInternal *)
   ink_abort("do not call stub");
 }
 
-void
-APIHooks::prepend(INKContInternal *)
+int
+APIHook::invoke(int, void *) const
 {
-  ink_abort("do not call stub");
+  ink_assert(false);
+  return 0;
+}
+
+APIHook *
+APIHooks::head() const
+{
+  return nullptr;
+}
+
+HttpHookState::HttpHookState() {}
+
+void
+HttpHookState::init(TSHttpHookID id, HttpAPIHooks const *global, HttpAPIHooks const *ssn, HttpAPIHooks const *txn)
+{
+}
+
+APIHook const *
+HttpHookState::getNext()
+{
+  return nullptr;
 }
 
 void


### PR DESCRIPTION
PR #5077 broke QUIC build

```
traffic_quic/traffic_quic.cc:186:10: error: out-of-line definition of 'invoke' does not match any declaration in 'APIHook'
APIHook::invoke(int, void *)
         ^~~~~~
/Users/mkitajo/src/github.com/trafficserver/proxy/InkAPIInternal.h:118:7: note: member declaration does not match because it is const qualified
  int invoke(int event, void *edata) const;
      ^                              ~~~~~
traffic_quic/traffic_quic.cc:200:11: error: out-of-line definition of 'get' does not match any declaration in 'APIHooks'
APIHooks::get() const
          ^~~
traffic_quic/traffic_quic.cc:219:11: error: out-of-line definition of 'prepend' does not match any declaration in 'APIHooks'
APIHooks::prepend(INKContInternal *)
          ^~~~~~~
3 errors generated.
```