### PR TITLE
Cleanup: unifdef WRITE_AND_TRANSFER

### DIFF
--- a/iocore/eventsystem/IOBuffer.cc
+++ b/iocore/eventsystem/IOBuffer.cc
@@ -108,31 +108,6 @@ MIOBuffer::write(const void *abuf, int64_t alen)
   return alen;
 }
 
-#ifdef WRITE_AND_TRANSFER
-/*
- * Same functionality as write but for the one small difference.
- * The space available in the last block is taken from the original
- * and this space becomes available to the copy.
- *
- */
-int64_t
-MIOBuffer::write_and_transfer_left_over_space(IOBufferReader *r, int64_t alen, int64_t offset)
-{
-  int64_t rval = write(r, alen, offset);
-  // reset the end markers of the original so that it cannot
-  // make use of the space in the current block
-  if (r->mbuf->_writer)
-    r->mbuf->_writer->_buf_end = r->mbuf->_writer->_end;
-  // reset the end marker of the clone so that it can make
-  // use of the space in the current block
-  if (_writer) {
-    _writer->_buf_end = _writer->data->data() + _writer->block_size();
-  }
-  return rval;
-}
-
-#endif
-
 int64_t
 MIOBuffer::write(IOBufferReader *r, int64_t len, int64_t offset)
 {

--- a/iocore/eventsystem/I_IOBuffer.h
+++ b/iocore/eventsystem/I_IOBuffer.h
@@ -52,9 +52,6 @@ class MIOBuffer;
 class IOBufferReader;
 class VIO;
 
-// Removing this optimization since this is breaking WMT over HTTP
-//#define WRITE_AND_TRANSFER
-
 inkcoreapi extern int64_t max_iobuffer_size;
 extern int64_t default_small_iobuffer_size;
 extern int64_t default_large_iobuffer_size; // matched to size of OS buffers
@@ -986,16 +983,6 @@ public:
 
   */
   inkcoreapi int64_t write(const void *rbuf, int64_t nbytes);
-
-#ifdef WRITE_AND_TRANSFER
-  /**
-    Same functionality as write but for the one small difference. The
-    space available in the last block is taken from the original and
-    this space becomes available to the copy.
-
-  */
-  inkcoreapi int64_t write_and_transfer_left_over_space(IOBufferReader *r, int64_t len = INT64_MAX, int64_t offset = 0);
-#endif
 
   /**
     Add by data from IOBufferReader r to the this buffer by reference. If

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -6294,14 +6294,8 @@ HttpSM::find_http_resp_buffer_size(int64_t content_length)
       alloc_index = DEFAULT_RESPONSE_BUFFER_SIZE_INDEX;
     }
   } else {
-    int64_t buf_size;
-
-#ifdef WRITE_AND_TRANSFER
-    buf_size = HTTP_HEADER_BUFFER_SIZE + content_length - index_to_buffer_size(HTTP_SERVER_RESP_HDR_BUFFER_INDEX);
-#else
-    buf_size = index_to_buffer_size(HTTP_HEADER_BUFFER_SIZE_INDEX) + content_length;
-#endif
-    alloc_index = buffer_size_to_index(buf_size);
+    int64_t buf_size = index_to_buffer_size(HTTP_HEADER_BUFFER_SIZE_INDEX) + content_length;
+    alloc_index      = buffer_size_to_index(buf_size);
   }
 
   return alloc_index;
@@ -6336,18 +6330,8 @@ HttpSM::server_transfer_init(MIOBuffer *buf, int hdr_size)
     nbytes  = t_state.hdr_info.response_content_length + hdr_size;
   }
 
-  // Next order of business if copy the remaining data from the
-  //  header buffer into new buffer.
-
-  int64_t server_response_pre_read_bytes =
-#ifdef WRITE_AND_TRANSFER
-    /* relinquish the space in server_buffer and let
-       the tunnel use the trailing space
-     */
-    buf->write_and_transfer_left_over_space(server_buffer_reader, to_copy);
-#else
-    buf->write(server_buffer_reader, to_copy);
-#endif
+  // Next order of business if copy the remaining data from the header buffer into new buffer.
+  int64_t server_response_pre_read_bytes = buf->write(server_buffer_reader, to_copy);
   server_buffer_reader->consume(server_response_pre_read_bytes);
 
   //  If we know the length & copied the entire body


### PR DESCRIPTION
`WRITE_AND_TRANSFER` has never been used since initial commit.