### PR TITLE
Replaced ProxyTxn::outbound vars with accept::options

### DIFF
--- a/proxy/ProxySession.cc
+++ b/proxy/ProxySession.cc
@@ -222,13 +222,6 @@ ProxySession::is_draining() const
   return TSSystemState::is_draining();
 }
 
-// Override if your session protocol allows this.
-bool
-ProxySession::is_transparent_passthrough_allowed() const
-{
-  return false;
-}
-
 bool
 ProxySession::is_chunked_encoding_supported() const
 {
@@ -245,24 +238,6 @@ bool
 ProxySession::get_half_close_flag() const
 {
   return false;
-}
-
-in_port_t
-ProxySession::get_outbound_port() const
-{
-  return outbound_port;
-}
-
-IpAddr
-ProxySession::get_outbound_ip4() const
-{
-  return outbound_ip4;
-}
-
-IpAddr
-ProxySession::get_outbound_ip6() const
-{
-  return outbound_ip6;
 }
 
 int64_t

--- a/proxy/ProxySession.h
+++ b/proxy/ProxySession.h
@@ -30,6 +30,7 @@
 #include "P_Net.h"
 #include "InkAPIInternal.h"
 #include "http/Http1ServerSession.h"
+#include "http/HttpSessionAccept.h"
 #include "IPAllow.h"
 
 // Emit a debug message conditional on whether this particular client session
@@ -99,7 +100,6 @@ public:
   virtual NetVConnection *get_netvc() const       = 0;
   virtual int get_transact_count() const          = 0;
   virtual const char *get_protocol_string() const = 0;
-  virtual bool is_transparent_passthrough_allowed() const;
 
   virtual void hook_add(TSHttpHookID id, INKContInternal *cont);
 
@@ -108,9 +108,6 @@ public:
   virtual void set_half_close_flag(bool flag);
   virtual bool get_half_close_flag() const;
 
-  virtual in_port_t get_outbound_port() const;
-  virtual IpAddr get_outbound_ip4() const;
-  virtual IpAddr get_outbound_ip6() const;
   virtual Http1ServerSession *get_server_session() const;
 
   // Replicate NetVConnection API
@@ -151,9 +148,7 @@ public:
 
   IpAllow::ACL acl; ///< IpAllow based method ACL.
 
-  IpAddr outbound_ip4;        ///< Local address for outbound connection.
-  IpAddr outbound_ip6;        ///< Local address for outbound connection.
-  in_port_t outbound_port{0}; ///< Local port for outbound connection.
+  HttpSessionAccept::Options const *accept_options; ///< connection info // L7R TODO: set in constructor
 
   HostResStyle host_res_style = HOST_RES_NONE; ///< DNS resolution preferences.
 

--- a/proxy/ProxyTransaction.cc
+++ b/proxy/ProxyTransaction.cc
@@ -128,7 +128,7 @@ ProxyTransaction::is_first_transaction() const
 bool
 ProxyTransaction::is_transparent_passthrough_allowed()
 {
-  return proxy_ssn ? proxy_ssn->is_transparent_passthrough_allowed() : false;
+  return upstream_outbound_options.f_transparent_passthrough;
 }
 
 bool
@@ -215,43 +215,48 @@ ProxyTransaction::get_acl() const
 in_port_t
 ProxyTransaction::get_outbound_port() const
 {
-  return outbound_port;
-}
-IpAddr
-ProxyTransaction::get_outbound_ip4() const
-{
-  return outbound_ip4;
-}
-IpAddr
-ProxyTransaction::get_outbound_ip6() const
-{
-  return outbound_ip6;
+  return upstream_outbound_options.outbound_port;
 }
 void
 ProxyTransaction::set_outbound_port(in_port_t port)
 {
-  outbound_port = port;
+  upstream_outbound_options.outbound_port = port;
 }
+
+IpAddr
+ProxyTransaction::get_outbound_ip4() const
+{
+  return upstream_outbound_options.outbound_ip4;
+}
+
+IpAddr
+ProxyTransaction::get_outbound_ip6() const
+{
+  return upstream_outbound_options.outbound_ip6;
+}
+
 void
 ProxyTransaction::set_outbound_ip(const IpAddr &new_addr)
 {
   if (new_addr.isIp4()) {
-    outbound_ip4 = new_addr;
+    upstream_outbound_options.outbound_ip4 = new_addr;
   } else if (new_addr.isIp6()) {
-    outbound_ip6 = new_addr;
+    upstream_outbound_options.outbound_ip6 = new_addr;
   } else {
-    outbound_ip4.invalidate();
-    outbound_ip6.invalidate();
+    upstream_outbound_options.outbound_ip4.invalidate();
+    upstream_outbound_options.outbound_ip6.invalidate();
   }
 }
 bool
 ProxyTransaction::is_outbound_transparent() const
 {
-  return false;
+  return upstream_outbound_options.f_outbound_transparent;
 }
+
 void
 ProxyTransaction::set_outbound_transparent(bool flag)
 {
+  upstream_outbound_options.f_outbound_transparent = flag;
 }
 
 ProxySession *

--- a/proxy/ProxyTransaction.h
+++ b/proxy/ProxyTransaction.h
@@ -111,6 +111,10 @@ public:
   void set_rx_error_code(ProxyError e);
   void set_tx_error_code(ProxyError e);
 
+  /// Variables
+  //
+  HttpSessionAccept::Options upstream_outbound_options; // overwritable copy of options
+
 protected:
   ProxySession *proxy_ssn   = nullptr;
   HttpSM *current_reader    = nullptr;
@@ -118,12 +122,7 @@ protected:
 
   /// DNS resolution preferences.
   HostResStyle host_res_style = HOST_RES_NONE;
-  /// Local outbound address control.
-  in_port_t outbound_port{0};
-  IpAddr outbound_ip4;
-  IpAddr outbound_ip6;
-
-  bool restart_immediate = false;
+  bool restart_immediate      = false;
 
 private:
 };

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -156,12 +156,6 @@ public:
     return "http";
   }
 
-  bool
-  is_transparent_passthrough_allowed() const override
-  {
-    return f_transparent_passthrough;
-  }
-
   void increment_current_active_client_connections_stat() override;
   void decrement_current_active_client_connections_stat() override;
 
@@ -206,8 +200,6 @@ public:
 
   /// Set outbound connection to transparent.
   bool f_outbound_transparent = false;
-  /// Transparently pass-through non-HTTP traffic.
-  bool f_transparent_passthrough = false;
 
   Http1Transaction trans;
 };

--- a/proxy/http/Http1Transaction.cc
+++ b/proxy/http/Http1Transaction.cc
@@ -47,22 +47,6 @@ Http1Transaction::release(IOBufferReader *r)
 }
 
 void
-Http1Transaction::set_proxy_ssn(ProxySession *new_proxy_ssn)
-{
-  Http1ClientSession *http1_proxy_ssn = dynamic_cast<Http1ClientSession *>(new_proxy_ssn);
-
-  if (http1_proxy_ssn) {
-    outbound_port        = http1_proxy_ssn->outbound_port;
-    outbound_ip4         = http1_proxy_ssn->outbound_ip4;
-    outbound_ip6         = http1_proxy_ssn->outbound_ip6;
-    outbound_transparent = http1_proxy_ssn->f_outbound_transparent;
-    super_type::set_proxy_ssn(new_proxy_ssn);
-  } else {
-    proxy_ssn = nullptr;
-  }
-}
-
-void
 Http1Transaction::transaction_done()
 {
   if (proxy_ssn) {

--- a/proxy/http/Http1Transaction.h
+++ b/proxy/http/Http1Transaction.h
@@ -83,19 +83,6 @@ public:
 
   bool allow_half_open() const override;
 
-  void set_proxy_ssn(ProxySession *new_proxy_ssn) override;
-
-  bool
-  is_outbound_transparent() const override
-  {
-    return outbound_transparent;
-  }
-  void
-  set_outbound_transparent(bool flag) override
-  {
-    outbound_transparent = flag;
-  }
-
   // Pass on the timeouts to the netvc
   void
   set_active_timeout(ink_hrtime timeout_in) override

--- a/proxy/http/HttpSessionAccept.cc
+++ b/proxy/http/HttpSessionAccept.cc
@@ -51,16 +51,13 @@ HttpSessionAccept::accept(NetVConnection *netvc, MIOBuffer *iobuf, IOBufferReade
 
   Http1ClientSession *new_session = THREAD_ALLOC_INIT(http1ClientSessionAllocator, this_ethread());
 
-  // copy over session related data.
-  new_session->f_outbound_transparent    = f_outbound_transparent;
-  new_session->f_transparent_passthrough = f_transparent_passthrough;
-  new_session->outbound_ip4              = outbound_ip4;
-  new_session->outbound_ip6              = outbound_ip6;
-  new_session->outbound_port             = outbound_port;
-  new_session->host_res_style            = ats_host_res_from(client_ip->sa_family, host_res_preference);
-  new_session->acl                       = std::move(acl);
+  new_session->accept_options = static_cast<Options *>(this);
+  new_session->host_res_style = ats_host_res_from(client_ip->sa_family, host_res_preference);
+  new_session->acl            = std::move(acl);
 
   new_session->new_connection(netvc, iobuf, reader);
+
+  new_session->trans.upstream_outbound_options = *new_session->accept_options;
 
   return true;
 }

--- a/proxy/http2/Http2SessionAccept.cc
+++ b/proxy/http2/Http2SessionAccept.cc
@@ -56,9 +56,7 @@ Http2SessionAccept::accept(NetVConnection *netvc, MIOBuffer *iobuf, IOBufferRead
   Http2ClientSession *new_session = THREAD_ALLOC_INIT(http2ClientSessionAllocator, this_ethread());
   new_session->acl                = std::move(session_acl);
   new_session->host_res_style     = ats_host_res_from(client_ip->sa_family, options.host_res_preference);
-  new_session->outbound_ip4       = options.outbound_ip4;
-  new_session->outbound_ip6       = options.outbound_ip6;
-  new_session->outbound_port      = options.outbound_port;
+  new_session->accept_options     = &options;
   new_session->new_connection(netvc, iobuf, reader);
 
   return true;

--- a/proxy/http3/Http09App.cc
+++ b/proxy/http3/Http09App.cc
@@ -43,9 +43,7 @@ Http09App::Http09App(QUICNetVConnection *client_vc, IpAllow::ACL &&session_acl, 
   // TODO: avoid const cast
   this->_ssn->host_res_style =
     ats_host_res_from(client_vc->get_remote_addr()->sa_family, const_cast<HostResPreference *>(options.host_res_preference));
-  this->_ssn->outbound_ip4  = options.outbound_ip4;
-  this->_ssn->outbound_ip6  = options.outbound_ip6;
-  this->_ssn->outbound_port = options.outbound_port;
+  this->_ssn->accept_options = &options;
   this->_ssn->new_connection(client_vc, nullptr, nullptr);
 
   this->_qc->stream_manager()->set_default_application(this);

--- a/proxy/http3/Http3App.cc
+++ b/proxy/http3/Http3App.cc
@@ -45,9 +45,7 @@ Http3App::Http3App(QUICNetVConnection *client_vc, IpAllow::ACL &&session_acl, co
   // TODO: avoid const cast
   this->_ssn->host_res_style =
     ats_host_res_from(client_vc->get_remote_addr()->sa_family, const_cast<HostResPreference *>(options.host_res_preference));
-  this->_ssn->outbound_ip4  = options.outbound_ip4;
-  this->_ssn->outbound_ip6  = options.outbound_ip6;
-  this->_ssn->outbound_port = options.outbound_port;
+  this->_ssn->accept_options = &options;
 
   this->_ssn->new_connection(client_vc, nullptr, nullptr);
 

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -5725,7 +5725,7 @@ TSHttpTxnOutgoingAddrSet(TSHttpTxn txnp, const struct sockaddr *addr)
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
   HttpSM *sm = (HttpSM *)txnp;
 
-  sm->ua_txn->set_outbound_port(ats_ip_port_host_order(addr));
+  sm->ua_txn->upstream_outbound_options.outbound_port = ats_ip_port_host_order(addr);
   sm->ua_txn->set_outbound_ip(IpAddr(addr));
   return TS_SUCCESS;
 }


### PR DESCRIPTION
Each session gets a reference to accept::options.
Each stream/transaction gets a copy of accept:options so it can be overwritten for upstream.
This reduces redundant variables and api. 