### PR TITLE
correct the size of DNS buffers

### DIFF
--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -597,7 +597,7 @@ static inline int
 _ink_res_mkquery(ink_res_state res, char *qname, int qtype, unsigned char *buffer, bool over_tcp = false)
 {
   int offset = over_tcp ? tcp_data_length_offset : 0;
-  int r      = ink_res_mkquery(res, QUERY, qname, C_IN, qtype, nullptr, 0, nullptr, buffer + offset, MAX_DNS_PACKET_LEN);
+  int r      = ink_res_mkquery(res, QUERY, qname, C_IN, qtype, nullptr, 0, nullptr, buffer + offset, MAX_DNS_REQUEST_LEN - offset);
   if (over_tcp) {
     NS_PUT16(r, buffer);
   }
@@ -629,7 +629,7 @@ DNSHandler::retry_named(int ndx, ink_hrtime t, bool reopen)
   }
   bool over_tcp = dns_conn_mode == DNS_CONN_MODE::TCP_ONLY;
   int con_fd    = over_tcp ? tcpcon[ndx].fd : udpcon[ndx].fd;
-  unsigned char buffer[MAX_DNS_PACKET_LEN];
+  unsigned char buffer[MAX_DNS_REQUEST_LEN];
   Debug("dns", "trying to resolve '%s' from DNS connection, ndx %d", try_server_names[try_servers], ndx);
   int r       = _ink_res_mkquery(m_res, try_server_names[try_servers], T_A, buffer, over_tcp);
   try_servers = (try_servers + 1) % countof(try_server_names);
@@ -650,7 +650,7 @@ DNSHandler::try_primary_named(bool reopen)
     open_cons(&ip.sa, true, 0);
   }
   if ((t - last_primary_retry) > DNS_PRIMARY_RETRY_PERIOD) {
-    unsigned char buffer[MAX_DNS_PACKET_LEN];
+    unsigned char buffer[MAX_DNS_REQUEST_LEN];
     bool over_tcp      = dns_conn_mode == DNS_CONN_MODE::TCP_ONLY;
     int con_fd         = over_tcp ? tcpcon[0].fd : udpcon[0].fd;
     last_primary_retry = t;
@@ -824,7 +824,7 @@ DNSHandler::recv_dns(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
             goto Lerror;
           }
           dnsc->tcp_data.total_length = ntohs(dnsc->tcp_data.total_length);
-          if (res != sizeof(dnsc->tcp_data.total_length) || dnsc->tcp_data.total_length > MAX_DNS_PACKET_LEN) {
+          if (res != sizeof(dnsc->tcp_data.total_length)) {
             goto Lerror;
           }
         }
@@ -852,7 +852,7 @@ DNSHandler::recv_dns(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
         hostent_cache = dnsBufAllocator.alloc();
       }
 
-      res = socketManager.recvfrom(dnsc->fd, hostent_cache->buf, MAX_DNS_PACKET_LEN, 0, &from_ip.sa, &from_length);
+      res = socketManager.recvfrom(dnsc->fd, hostent_cache->buf, MAX_DNS_RESPONSE_LEN, 0, &from_ip.sa, &from_length);
       Debug("dns", "DNSHandler::recv_dns res = [%d]", res);
       if (res == -EAGAIN) {
         break;
@@ -1092,7 +1092,7 @@ static bool
 write_dns_event(DNSHandler *h, DNSEntry *e, bool over_tcp)
 {
   ProxyMutex *mutex = h->mutex.get();
-  unsigned char buffer[MAX_DNS_PACKET_LEN];
+  unsigned char buffer[MAX_DNS_REQUEST_LEN];
   int offset     = over_tcp ? tcp_data_length_offset : 0;
   HEADER *header = reinterpret_cast<HEADER *>(buffer + offset);
   int r          = 0;

--- a/iocore/dns/I_DNSProcessor.h
+++ b/iocore/dns/I_DNSProcessor.h
@@ -28,11 +28,12 @@
 const int DOMAIN_SERVICE_PORT        = NAMESERVER_PORT;
 const int DEFAULT_DOMAIN_NAME_SERVER = 0;
 
-const int MAX_DNS_PACKET_LEN = 8192;
-const int DNS_RR_MAX_COUNT   = (MAX_DNS_PACKET_LEN - HFIXEDSZ + RRFIXEDSZ - 1) / RRFIXEDSZ;
-const int DNS_MAX_ALIASES    = DNS_RR_MAX_COUNT;
-const int DNS_MAX_ADDRS      = DNS_RR_MAX_COUNT;
-const int DNS_HOSTBUF_SIZE   = MAX_DNS_PACKET_LEN;
+const int MAX_DNS_REQUEST_LEN  = NS_PACKETSZ;
+const int MAX_DNS_RESPONSE_LEN = 65536;
+const int DNS_RR_MAX_COUNT     = (MAX_DNS_RESPONSE_LEN - HFIXEDSZ + RRFIXEDSZ - 1) / RRFIXEDSZ;
+const int DNS_MAX_ALIASES      = DNS_RR_MAX_COUNT;
+const int DNS_MAX_ADDRS        = DNS_RR_MAX_COUNT;
+const int DNS_HOSTBUF_SIZE     = MAX_DNS_RESPONSE_LEN;
 
 /**
   All buffering required to handle a DNS receipt. For asynchronous DNS,
@@ -41,10 +42,10 @@ const int DNS_HOSTBUF_SIZE   = MAX_DNS_PACKET_LEN;
 
 */
 struct HostEnt : RefCountObj {
-  struct hostent ent           = {.h_name = nullptr, .h_aliases = nullptr, .h_addrtype = 0, .h_length = 0, .h_addr_list = nullptr};
-  uint32_t ttl                 = 0;
-  int packet_size              = 0;
-  char buf[MAX_DNS_PACKET_LEN] = {0};
+  struct hostent ent = {.h_name = nullptr, .h_aliases = nullptr, .h_addrtype = 0, .h_length = 0, .h_addr_list = nullptr};
+  uint32_t ttl       = 0;
+  int packet_size    = 0;
+  char buf[MAX_DNS_RESPONSE_LEN]         = {0};
   u_char *host_aliases[DNS_MAX_ALIASES]  = {nullptr};
   u_char *h_addr_ptrs[DNS_MAX_ADDRS + 1] = {nullptr};
   u_char hostbuf[DNS_HOSTBUF_SIZE]       = {0};


### PR DESCRIPTION
With DNS over TCP, the max size of DNS response is the same as the max size of a TCP packet, 64K.
The buffer to build DNS queries can be much small than that. 1K is the number this PR chooses.

Tested locally, with this diff, the DNS module correctly handles DNS response large than previous limit 8K.