### PR TITLE
Check for nullptr when locking

### DIFF
--- a/iocore/eventsystem/I_Lock.h
+++ b/iocore/eventsystem/I_Lock.h
@@ -353,17 +353,19 @@ public:
     Ptr<ProxyMutex> &am, EThread *t)
     : m(am), locked_p(true)
   {
-    Mutex_lock(
+    if (am) {
+      Mutex_lock(
 #ifdef DEBUG
-      location, ahandler,
+        location, ahandler,
 #endif // DEBUG
-      m, t);
+        m, t);
+    }
   }
 
   void
   release()
   {
-    if (locked_p) {
+    if (locked_p && m) {
       Mutex_unlock(m, m->thread_holding);
     }
     locked_p = false;


### PR DESCRIPTION
We need to check if the mutex pointer is actually pointing to something before using it, such that calling `SCOPED_MUTEX_LOCK` doesn't crash.