### PR TITLE
Don't send PING frame on INITIAL and HANDSHAKE packets

### DIFF
--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -704,7 +704,7 @@ QUICNetVConnection::handle_received_packet(UDPPacket *packet)
 void
 QUICNetVConnection::ping()
 {
-  this->_pinger->request(QUICEncryptionLevel::ONE_RTT);
+  this->_pinger->request();
 }
 
 void

--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -1579,6 +1579,17 @@ QUICNetVConnection::_packetize_frames(QUICEncryptionLevel level, uint64_t max_pa
       frame =
         g->generate_frame(frame_instance_buffer, level, this->_remote_flow_controller->credit(), max_frame_size, len, seq_num);
       if (frame) {
+        // Some frame types must not be sent on Initial and Handshake packets
+        switch (auto t = frame->type(); level) {
+        case QUICEncryptionLevel::INITIAL:
+        case QUICEncryptionLevel::HANDSHAKE:
+          ink_assert(t == QUICFrameType::CRYPTO || t == QUICFrameType::ACK || t == QUICFrameType::PADDING ||
+                     t == QUICFrameType::CONNECTION_CLOSE);
+          break;
+        default:
+          break;
+        }
+
         ++frame_count;
         probing |= frame->is_probing_frame();
         if (frame->is_flow_controlled()) {

--- a/iocore/net/quic/QUICLossDetector.cc
+++ b/iocore/net/quic/QUICLossDetector.cc
@@ -485,7 +485,7 @@ QUICLossDetector::_send_packet(QUICEncryptionLevel level, bool padded)
   if (padded) {
     this->_padder->request(level);
   } else {
-    this->_pinger->request(level);
+    this->_pinger->request();
   }
   this->_cc->add_extra_packets_count();
 }
@@ -495,25 +495,23 @@ QUICLossDetector::_send_one_or_two_packet()
 {
   this->_send_packet(QUICEncryptionLevel::ONE_RTT);
   this->_send_packet(QUICEncryptionLevel::ONE_RTT);
-  ink_assert(this->_pinger->count(QUICEncryptionLevel::ONE_RTT) >= 2);
+  ink_assert(this->_pinger->count() >= 2);
   QUICLDDebug("[%s] send ping frame %" PRIu64, QUICDebugNames::encryption_level(QUICEncryptionLevel::ONE_RTT),
-              this->_pinger->count(QUICEncryptionLevel::ONE_RTT));
+              this->_pinger->count());
 }
 
 void
 QUICLossDetector::_send_one_handshake_packets()
 {
   this->_send_packet(QUICEncryptionLevel::HANDSHAKE);
-  QUICLDDebug("[%s] send handshake packet: %" PRIu64, QUICDebugNames::encryption_level(QUICEncryptionLevel::HANDSHAKE),
-              this->_pinger->count(QUICEncryptionLevel::HANDSHAKE));
+  QUICLDDebug("[%s] send handshake packet", QUICDebugNames::encryption_level(QUICEncryptionLevel::HANDSHAKE));
 }
 
 void
 QUICLossDetector::_send_one_padded_packets()
 {
   this->_send_packet(QUICEncryptionLevel::INITIAL, true);
-  QUICLDDebug("[%s] send PADDING frame %" PRIu64, QUICDebugNames::encryption_level(QUICEncryptionLevel::INITIAL),
-              this->_pinger->count(QUICEncryptionLevel::INITIAL));
+  QUICLDDebug("[%s] send PADDING frame", QUICDebugNames::encryption_level(QUICEncryptionLevel::INITIAL));
 }
 
 // ===== Functions below are helper functions =====

--- a/iocore/net/quic/QUICPinger.cc
+++ b/iocore/net/quic/QUICPinger.cc
@@ -24,18 +24,18 @@
 #include "QUICPinger.h"
 
 void
-QUICPinger::request(QUICEncryptionLevel level)
+QUICPinger::request()
 {
   SCOPED_MUTEX_LOCK(lock, this->_mutex, this_ethread());
-  ++this->_need_to_fire[static_cast<int>(level)];
+  ++this->_need_to_fire;
 }
 
 void
-QUICPinger::cancel(QUICEncryptionLevel level)
+QUICPinger::cancel()
 {
   SCOPED_MUTEX_LOCK(lock, this->_mutex, this_ethread());
-  if (this->_need_to_fire[static_cast<int>(level)] > 0) {
-    --this->_need_to_fire[static_cast<int>(level)];
+  if (this->_need_to_fire > 0) {
+    --this->_need_to_fire;
   }
 }
 
@@ -43,24 +43,28 @@ bool
 QUICPinger::_will_generate_frame(QUICEncryptionLevel level, size_t current_packet_size, bool ack_eliciting)
 {
   SCOPED_MUTEX_LOCK(lock, this->_mutex, this_ethread());
-  // PING Frame is meaningless for ack_eliciting packet. Cancel it.
-  if (ack_eliciting) {
-    this->_ack_eliciting_packet_out = true;
-    this->cancel(level);
+
+  if (level != QUICEncryptionLevel::ONE_RTT) {
     return false;
   }
 
-  if (this->_ack_eliciting_packet_out == false && !ack_eliciting && current_packet_size > 0 &&
-      this->_need_to_fire[static_cast<int>(level)] == 0) {
+  // PING Frame is meaningless for ack_eliciting packet. Cancel it.
+  if (ack_eliciting) {
+    this->_ack_eliciting_packet_out = true;
+    this->cancel();
+    return false;
+  }
+
+  if (this->_ack_eliciting_packet_out == false && !ack_eliciting && current_packet_size > 0 && this->_need_to_fire == 0) {
     // force to send an PING Frame
-    this->request(level);
+    this->request();
   }
 
   // only update `_ack_eliciting_packet_out` when we has something to send.
   if (current_packet_size) {
     this->_ack_eliciting_packet_out = ack_eliciting;
   }
-  return this->_need_to_fire[static_cast<int>(level)] > 0;
+  return this->_need_to_fire > 0;
 }
 
 /**
@@ -73,10 +77,10 @@ QUICPinger::_generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t /*
   SCOPED_MUTEX_LOCK(lock, this->_mutex, this_ethread());
   QUICFrame *frame = nullptr;
 
-  if (this->_need_to_fire[static_cast<int>(level)] > 0 && maximum_frame_size > 0) {
+  if (level != QUICEncryptionLevel::ONE_RTT && this->_need_to_fire > 0 && maximum_frame_size > 0) {
     // don't care ping frame lost or acked
     frame = QUICFrameFactory::create_ping_frame(buf, 0, nullptr);
-    --this->_need_to_fire[static_cast<int>(level)];
+    --this->_need_to_fire;
     this->_ack_eliciting_packet_out = true;
   }
 
@@ -84,8 +88,8 @@ QUICPinger::_generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64_t /*
 }
 
 uint64_t
-QUICPinger::count(QUICEncryptionLevel level)
+QUICPinger::count()
 {
   SCOPED_MUTEX_LOCK(lock, this->_mutex, this_ethread());
-  return this->_need_to_fire[static_cast<int>(level)];
+  return this->_need_to_fire;
 }

--- a/iocore/net/quic/QUICPinger.h
+++ b/iocore/net/quic/QUICPinger.h
@@ -35,9 +35,9 @@ class QUICPinger : public QUICFrameOnceGenerator
 public:
   QUICPinger() : _mutex(new_ProxyMutex()) {}
 
-  void request(QUICEncryptionLevel level);
-  void cancel(QUICEncryptionLevel level);
-  uint64_t count(QUICEncryptionLevel level);
+  void request();
+  void cancel();
+  uint64_t count();
 
 private:
   // QUICFrameGenerator
@@ -48,6 +48,5 @@ private:
   bool _ack_eliciting_packet_out = false;
 
   Ptr<ProxyMutex> _mutex;
-  // Initial, 0/1-RTT, and Handshake
-  uint64_t _need_to_fire[4] = {0};
+  uint64_t _need_to_fire = 0;
 };


### PR DESCRIPTION
It seems like we can send PING frames only on Short packets (ONE_RTT encryption level).

This fixes #5743.