### PR TITLE
ProxyTxn refactor: moved host_res_style to t_state.dns_info

### DIFF
--- a/include/tscore/ink_resolver.h
+++ b/include/tscore/ink_resolver.h
@@ -182,8 +182,8 @@ enum HostResStyle {
 extern const char *const HOST_RES_STYLE_STRING[];
 
 /// Calculate the effective resolution preferences.
-extern HostResStyle ats_host_res_from(int family,            ///< Connection family
-                                      HostResPreferenceOrder ///< Preference ordering.
+extern HostResStyle ats_host_res_from(int family,                    ///< Connection family
+                                      HostResPreferenceOrder const & ///< Preference ordering.
 );
 /// Calculate the host resolution style to force a family match to @a addr.
 extern HostResStyle ats_host_res_match(sockaddr const *addr);

--- a/proxy/ProxySession.h
+++ b/proxy/ProxySession.h
@@ -150,8 +150,6 @@ public:
 
   HttpSessionAccept::Options const *accept_options; ///< connection info // L7R TODO: set in constructor
 
-  HostResStyle host_res_style = HOST_RES_NONE; ///< DNS resolution preferences.
-
   ink_hrtime ssn_start_time    = 0;
   ink_hrtime ssn_last_txn_time = 0;
 

--- a/proxy/ProxyTransaction.cc
+++ b/proxy/ProxyTransaction.cc
@@ -193,18 +193,6 @@ ProxyTransaction::clear_session_active()
   }
 }
 
-/// DNS resolution preferences.
-HostResStyle
-ProxyTransaction::get_host_res_style() const
-{
-  return host_res_style;
-}
-void
-ProxyTransaction::set_host_res_style(HostResStyle style)
-{
-  host_res_style = style;
-}
-
 const IpAllow::ACL &
 ProxyTransaction::get_acl() const
 {
@@ -268,8 +256,7 @@ ProxyTransaction::get_proxy_ssn()
 void
 ProxyTransaction::set_proxy_ssn(ProxySession *new_proxy_ssn)
 {
-  proxy_ssn      = new_proxy_ssn;
-  host_res_style = proxy_ssn->host_res_style;
+  proxy_ssn = new_proxy_ssn;
 }
 
 void

--- a/proxy/ProxyTransaction.h
+++ b/proxy/ProxyTransaction.h
@@ -120,9 +120,7 @@ protected:
   HttpSM *current_reader    = nullptr;
   IOBufferReader *sm_reader = nullptr;
 
-  /// DNS resolution preferences.
-  HostResStyle host_res_style = HOST_RES_NONE;
-  bool restart_immediate      = false;
+  bool restart_immediate = false;
 
 private:
 };

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -494,6 +494,12 @@ HttpSM::attach_client_session(ProxyTransaction *client_vc, IOBufferReader *buffe
     debug_on = true;
   }
 
+  ink_assert(ua_txn->get_proxy_ssn());
+  ink_assert(ua_txn->get_proxy_ssn()->accept_options);
+  // default the upstream IP style host resolution from inbound
+  t_state.dns_info.host_res_style =
+    ats_host_res_from(netvc->get_local_addr()->sa_family, ua_txn->get_proxy_ssn()->accept_options->host_res_preference);
+
   start_sub_sm();
 
   // Allocate a user agent entry in the state machine's
@@ -2230,7 +2236,7 @@ HttpSM::state_hostdb_lookup(int event, void *data)
     opt.flags = (t_state.cache_info.directives.does_client_permit_dns_storing) ? HostDBProcessor::HOSTDB_DO_NOT_FORCE_DNS :
                                                                                  HostDBProcessor::HOSTDB_FORCE_DNS_RELOAD;
     opt.timeout        = (t_state.api_txn_dns_timeout_value != -1) ? t_state.api_txn_dns_timeout_value : 0;
-    opt.host_res_style = ua_txn->get_host_res_style();
+    opt.host_res_style = t_state.dns_info.host_res_style;
 
     Action *dns_lookup_action_handle =
       hostDBProcessor.getbyname_imm(this, (cb_process_result_pfn)&HttpSM::process_hostdb_info, host_name, 0, opt);
@@ -4011,7 +4017,7 @@ HttpSM::do_hostdb_lookup()
       opt.flags = (t_state.cache_info.directives.does_client_permit_dns_storing) ? HostDBProcessor::HOSTDB_DO_NOT_FORCE_DNS :
                                                                                    HostDBProcessor::HOSTDB_FORCE_DNS_RELOAD;
       opt.timeout        = (t_state.api_txn_dns_timeout_value != -1) ? t_state.api_txn_dns_timeout_value : 0;
-      opt.host_res_style = ua_txn->get_host_res_style();
+      opt.host_res_style = t_state.dns_info.host_res_style;
 
       Action *dns_lookup_action_handle =
         hostDBProcessor.getbyname_imm(this, (cb_process_result_pfn)&HttpSM::process_hostdb_info, host_name, 0, opt);
@@ -4046,7 +4052,7 @@ HttpSM::do_hostdb_lookup()
     opt.flags = (t_state.cache_info.directives.does_client_permit_dns_storing) ? HostDBProcessor::HOSTDB_DO_NOT_FORCE_DNS :
                                                                                  HostDBProcessor::HOSTDB_FORCE_DNS_RELOAD;
     opt.timeout        = (t_state.api_txn_dns_timeout_value != -1) ? t_state.api_txn_dns_timeout_value : 0;
-    opt.host_res_style = ua_txn->get_host_res_style();
+    opt.host_res_style = t_state.dns_info.host_res_style;
 
     Action *dns_lookup_action_handle = hostDBProcessor.getbyname_imm(this, (cb_process_result_pfn)&HttpSM::process_hostdb_info,
                                                                      t_state.dns_info.lookup_name, 0, opt);

--- a/proxy/http/HttpSessionAccept.cc
+++ b/proxy/http/HttpSessionAccept.cc
@@ -52,7 +52,6 @@ HttpSessionAccept::accept(NetVConnection *netvc, MIOBuffer *iobuf, IOBufferReade
   Http1ClientSession *new_session = THREAD_ALLOC_INIT(http1ClientSessionAllocator, this_ethread());
 
   new_session->accept_options = static_cast<Options *>(this);
-  new_session->host_res_style = ats_host_res_from(client_ip->sa_family, host_res_preference);
   new_session->acl            = std::move(acl);
 
   new_session->new_connection(netvc, iobuf, reader);

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -3515,7 +3515,7 @@ HttpTransact::handle_response_from_server(State *s)
         // Force host resolution to have the same family as the client.
         // Because this is a transparent connection, we can't switch address
         // families - that is locked in by the client source address.
-        s->state_machine->ua_txn->set_host_res_style(ats_host_res_match(&s->current.server->dst_addr.sa));
+        s->dns_info.host_res_style = ats_host_res_match(&s->current.server->dst_addr.sa);
         return CallOSDNSLookup(s);
       } else if ((s->dns_info.srv_lookup_success || s->host_db_info.is_rr_elt()) &&
                  (s->txn_conf->connect_attempts_rr_retries > 0) &&

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -629,7 +629,8 @@ public:
       OS_ADDR_USE_CLIENT   ///< Use client target addr, no fallback.
     };
 
-    OS_Addr os_addr_style = OS_Addr::OS_ADDR_TRY_DEFAULT;
+    OS_Addr os_addr_style       = OS_Addr::OS_ADDR_TRY_DEFAULT;
+    HostResStyle host_res_style = HOST_RES_IPV4;
 
     bool lookup_success         = false;
     char *lookup_name           = nullptr;
@@ -638,6 +639,7 @@ public:
     bool srv_lookup_success     = false;
     short srv_port              = 0;
     HostDBApplicationInfo srv_app;
+
     /*** Set to true by default.  If use_client_target_address is set
      * to 1, this value will be set to false if the client address is
      * not in the DNS pool */

--- a/proxy/http2/Http2SessionAccept.cc
+++ b/proxy/http2/Http2SessionAccept.cc
@@ -55,7 +55,6 @@ Http2SessionAccept::accept(NetVConnection *netvc, MIOBuffer *iobuf, IOBufferRead
 
   Http2ClientSession *new_session = THREAD_ALLOC_INIT(http2ClientSessionAllocator, this_ethread());
   new_session->acl                = std::move(session_acl);
-  new_session->host_res_style     = ats_host_res_from(client_ip->sa_family, options.host_res_preference);
   new_session->accept_options     = &options;
   new_session->new_connection(netvc, iobuf, reader);
 

--- a/proxy/http3/Http09App.cc
+++ b/proxy/http3/Http09App.cc
@@ -38,11 +38,8 @@ static constexpr char debug_tag_v[] = "v_quic_simple_app";
 Http09App::Http09App(QUICNetVConnection *client_vc, IpAllow::ACL &&session_acl, const HttpSessionAccept::Options &options)
   : QUICApplication(client_vc)
 {
-  this->_ssn      = new Http09Session(client_vc);
-  this->_ssn->acl = std::move(session_acl);
-  // TODO: avoid const cast
-  this->_ssn->host_res_style =
-    ats_host_res_from(client_vc->get_remote_addr()->sa_family, const_cast<HostResPreference *>(options.host_res_preference));
+  this->_ssn                 = new Http09Session(client_vc);
+  this->_ssn->acl            = std::move(session_acl);
   this->_ssn->accept_options = &options;
   this->_ssn->new_connection(client_vc, nullptr, nullptr);
 

--- a/proxy/http3/Http3App.cc
+++ b/proxy/http3/Http3App.cc
@@ -40,13 +40,9 @@ static constexpr char debug_tag_v[] = "v_http3";
 Http3App::Http3App(QUICNetVConnection *client_vc, IpAllow::ACL &&session_acl, const HttpSessionAccept::Options &options)
   : QUICApplication(client_vc)
 {
-  this->_ssn      = new Http3Session(client_vc);
-  this->_ssn->acl = std::move(session_acl);
-  // TODO: avoid const cast
-  this->_ssn->host_res_style =
-    ats_host_res_from(client_vc->get_remote_addr()->sa_family, const_cast<HostResPreference *>(options.host_res_preference));
+  this->_ssn                 = new Http3Session(client_vc);
+  this->_ssn->acl            = std::move(session_acl);
   this->_ssn->accept_options = &options;
-
   this->_ssn->new_connection(client_vc, nullptr, nullptr);
 
   this->_qc->stream_manager()->set_default_application(this);

--- a/src/tscore/ink_res_mkquery.cc
+++ b/src/tscore/ink_res_mkquery.cc
@@ -510,7 +510,7 @@ ns_name_ntop(const u_char *src, char *dst, size_t dstsiz)
 }
 
 HostResStyle
-ats_host_res_from(int family, HostResPreferenceOrder order)
+ats_host_res_from(int family, HostResPreferenceOrder const &order)
 {
   bool v4 = false, v6 = false;
   HostResPreference client = AF_INET6 == family ? HOST_RES_PREFER_IPV6 : HOST_RES_PREFER_IPV4;


### PR DESCRIPTION
Organizing data before refactoring. Moved ProxyTxn::host_res_style to t_state.dns_info, because that makes sense to me.
