### PR TITLE
Add protection against use after free due to Http2ConnectionState::destroy() being called more than once per session.

### DIFF
--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -147,6 +147,7 @@ public:
     in_destroy = true;
     if (shutdown_cont_event) {
       shutdown_cont_event->cancel();
+      shutdown_cont_event = nullptr;
     }
     cleanup_streams();
 

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -140,6 +140,11 @@ public:
   void
   destroy()
   {
+    if (in_destroy) {
+      schedule_zombie_event();
+      return;
+    }
+    in_destroy = true;
     if (shutdown_cont_event) {
       shutdown_cont_event->cancel();
     }
@@ -374,6 +379,7 @@ private:
   Http2StreamId continued_stream_id = 0;
   bool _scheduled                   = false;
   bool fini_received                = false;
+  bool in_destroy                   = false;
   int recursion                     = 0;
   Http2ShutdownState shutdown_state = HTTP2_SHUTDOWN_NONE;
   Http2ErrorCode shutdown_reason    = Http2ErrorCode::HTTP2_ERROR_MAX;


### PR DESCRIPTION
Replacing the fix with a more defensive fix to protect against double delete when Http2ConnectionState::destroy() is called more than once (similar to the technique used in Http2ClientSession::destroy() via a `in_destroy` state). (as it looks like preventing `ua_session->destroy()` from being called multiple times will result in leaking the io buffers). Also resetting the shutdown_cont_event