### PR TITLE
Weak mutex locking macros

### DIFF
--- a/iocore/eventsystem/I_Lock.h
+++ b/iocore/eventsystem/I_Lock.h
@@ -48,13 +48,20 @@
   @param _t The current EThread executing your code.
 
 */
+
+// A weak version of the SCOPED_MUTEX_LOCK macro, allows the mutex to be a nullptr.
 #ifdef DEBUG
-#define SCOPED_MUTEX_LOCK(_l, _m, _t) MutexLock _l(MakeSourceLocation(), nullptr, _m, _t)
-#else
-#define SCOPED_MUTEX_LOCK(_l, _m, _t) MutexLock _l(_m, _t)
+#define WEAK_SCOPED_MUTEX_LOCK(_l, _m, _t) WeakMutexLock _l(MakeSourceLocation(), (char *)nullptr, _m, _t);
+#else // DEBUG
+#define WEAK_SCOPED_MUTEX_LOCK(_l, _m, _t) WeakMutexLock _l(_m, _t);
 #endif // DEBUG
 
 #ifdef DEBUG
+#define SCOPED_MUTEX_LOCK(_l, _m, _t) MutexLock _l(MakeSourceLocation(), (char *)nullptr, _m, _t)
+#else // DEBUG
+#define SCOPED_MUTEX_LOCK(_l, _m, _t) MutexLock _l(_m, _t)
+#endif // DEBUG
+
 /**
   Attempts to acquire the lock to the ProxyMutex.
 
@@ -68,8 +75,15 @@
   @param _t The current EThread executing your code.
 
 */
-#define MUTEX_TRY_LOCK(_l, _m, _t) MutexTryLock _l(MakeSourceLocation(), (char *)nullptr, _m, _t)
 
+#ifdef DEBUG
+#define WEAK_MUTEX_TRY_LOCK(_l, _m, _t) WeakMutexTryLock _l(MakeSourceLocation(), (char *)nullptr, _m, _t);
+#else // DEBUG
+#define WEAK_MUTEX_TRY_LOCK(_l, _m, _t) WeakMutexTryLock _l(_m, _t);
+#endif // DEBUG
+
+#ifdef DEBUG
+#define MUTEX_TRY_LOCK(_l, _m, _t) MutexTryLock _l(MakeSourceLocation(), (char *)nullptr, _m, _t)
 #else // DEBUG
 #define MUTEX_TRY_LOCK(_l, _m, _t) MutexTryLock _l(_m, _t)
 #endif // DEBUG
@@ -337,6 +351,41 @@ Mutex_unlock(Ptr<ProxyMutex> &m, EThread *t)
   }
 }
 
+class WeakMutexLock
+{
+private:
+  Ptr<ProxyMutex> m;
+  bool locked_p;
+
+public:
+  WeakMutexLock(
+#ifdef DEBUG
+    const SourceLocation &location, const char *ahandler,
+#endif // DEBUG
+    Ptr<ProxyMutex> &am, EThread *t)
+    : m(am), locked_p(true)
+  {
+    if (m.get()) {
+      Mutex_lock(
+#ifdef DEBUG
+        location, ahandler,
+#endif // DEBUG
+        m, t);
+    }
+  }
+
+  void
+  release()
+  {
+    if (locked_p && m.get()) {
+      Mutex_unlock(m, m->thread_holding);
+    }
+    locked_p = false;
+  }
+
+  ~WeakMutexLock() { this->release(); }
+};
+
 /** Scoped lock class for ProxyMutex
  */
 class MutexLock
@@ -353,25 +402,91 @@ public:
     Ptr<ProxyMutex> &am, EThread *t)
     : m(am), locked_p(true)
   {
-    if (am) {
-      Mutex_lock(
+    Mutex_lock(
 #ifdef DEBUG
-        location, ahandler,
+      location, ahandler,
 #endif // DEBUG
-        m, t);
-    }
+      m, t);
   }
 
   void
   release()
   {
-    if (locked_p && m) {
+    if (locked_p) {
       Mutex_unlock(m, m->thread_holding);
     }
     locked_p = false;
   }
 
   ~MutexLock() { this->release(); }
+};
+
+/** Scoped try lock class for ProxyMutex
+ */
+class WeakMutexTryLock
+{
+private:
+  Ptr<ProxyMutex> m;
+  bool lock_acquired;
+
+public:
+  WeakMutexTryLock(
+#ifdef DEBUG
+    const SourceLocation &location, const char *ahandler,
+#endif // DEBUG
+    Ptr<ProxyMutex> &am, EThread *t)
+    : m(am)
+  {
+    if (m.get()) {
+      lock_acquired = Mutex_trylock(
+#ifdef DEBUG
+        location, ahandler,
+#endif // DEBUG
+        m, t);
+    } else {
+      lock_acquired = true;
+    }
+  }
+
+  ~WeakMutexTryLock()
+  {
+    if (lock_acquired && m.get()) {
+      Mutex_unlock(m, m->thread_holding);
+    }
+    lock_acquired = false;
+  }
+
+  /** Spin till lock is acquired
+   */
+  void
+  acquire(EThread *t)
+  {
+    lock_acquired = true;
+    if (m.get()) {
+      MUTEX_TAKE_LOCK(m, t);
+    }
+  }
+
+  void
+  release()
+  {
+    if (lock_acquired && m.get()) {
+      Mutex_unlock(m, m->thread_holding);
+    }
+    lock_acquired = false;
+  }
+
+  bool
+  is_locked() const
+  {
+    return lock_acquired;
+  }
+
+  const ProxyMutex *
+  get_mutex() const
+  {
+    return m.get();
+  }
 };
 
 /** Scoped try lock class for ProxyMutex
@@ -390,20 +505,16 @@ public:
     Ptr<ProxyMutex> &am, EThread *t)
     : m(am)
   {
-    if (am) {
-      lock_acquired = Mutex_trylock(
+    lock_acquired = Mutex_trylock(
 #ifdef DEBUG
-        location, ahandler,
+      location, ahandler,
 #endif // DEBUG
-        m, t);
-    } else {
-      lock_acquired = true;
-    }
+      m, t);
   }
 
   ~MutexTryLock()
   {
-    if (lock_acquired && m.get()) {
+    if (lock_acquired) {
       Mutex_unlock(m, m->thread_holding);
     }
   }
@@ -413,16 +524,14 @@ public:
   void
   acquire(EThread *t)
   {
+    MUTEX_TAKE_LOCK(m, t);
     lock_acquired = true;
-    if (m.get()) {
-      MUTEX_TAKE_LOCK(m, t);
-    }
   }
 
   void
   release()
   {
-    if (lock_acquired && m.get()) {
+    if (lock_acquired) {
       Mutex_unlock(m, m->thread_holding);
     }
     lock_acquired = false;

--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -994,7 +994,7 @@ HostDBContinuation::removeEvent(int /* event ATS_UNUSED */, Event *e)
   if (cont) {
     proxy_mutex = cont->mutex;
   }
-  MUTEX_TRY_LOCK(lock, proxy_mutex, e->ethread);
+  WEAK_MUTEX_TRY_LOCK(lock, proxy_mutex, e->ethread);
   if (!lock.is_locked()) {
     e->schedule_in(HOST_DB_RETRY_PERIOD);
     return EVENT_CONT;

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -1747,6 +1747,7 @@ SSLNetVConnection::callHooks(TSEvent eventId)
   }
 
   if (curHook != nullptr) {
+    WEAK_SCOPED_MUTEX_LOCK(lock, curHook->m_cont->mutex, this_ethread());
     curHook->invoke(eventId, this);
     reenabled =
       (this->sslHandshakeHookState != HANDSHAKE_HOOKS_CERT_INVOKE && this->sslHandshakeHookState != HANDSHAKE_HOOKS_PRE_INVOKE &&

--- a/proxy/ProxySession.cc
+++ b/proxy/ProxySession.cc
@@ -108,7 +108,7 @@ ProxySession::state_api_callout(int event, void *data)
     if (nullptr != cur_hook) {
       APIHook const *hook = cur_hook;
 
-      MUTEX_TRY_LOCK(lock, hook->m_cont->mutex, mutex->thread_holding);
+      WEAK_MUTEX_TRY_LOCK(lock, hook->m_cont->mutex, mutex->thread_holding);
 
       // Have a mutex but didn't get the lock, reschedule
       if (!lock.is_locked()) {

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -1463,7 +1463,7 @@ plugins required to work with sni_routing.
         callout_state = HTTP_API_IN_CALLOUT;
       }
 
-      MUTEX_TRY_LOCK(lock, cur_hook->m_cont->mutex, mutex->thread_holding);
+      WEAK_MUTEX_TRY_LOCK(lock, cur_hook->m_cont->mutex, mutex->thread_holding);
 
       // Have a mutex but didn't get the lock, reschedule
       if (!lock.is_locked()) {

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -1330,7 +1330,7 @@ APIHook::invoke(int event, void *edata) const
       ink_assert(!"not reached");
     }
   }
-  MUTEX_TRY_LOCK(lock, m_cont->mutex, this_ethread());
+  WEAK_MUTEX_TRY_LOCK(lock, m_cont->mutex, this_ethread());
   if (!lock.is_locked()) {
     // If we cannot get the lock, the caller needs to restructure to handle rescheduling
     ink_release_assert(0);
@@ -4785,7 +4785,7 @@ int
 TSContCall(TSCont contp, TSEvent event, void *edata)
 {
   Continuation *c = (Continuation *)contp;
-  MUTEX_TRY_LOCK(lock, c->mutex, this_ethread());
+  WEAK_MUTEX_TRY_LOCK(lock, c->mutex, this_ethread());
   if (!lock.is_locked()) {
     // If we cannot get the lock, the caller needs to restructure to handle rescheduling
     ink_release_assert(0);

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -230,7 +230,7 @@ struct AutoStopCont : public Continuation {
 
     APIHook *hook = lifecycle_hooks->get(TS_LIFECYCLE_SHUTDOWN_HOOK);
     while (hook) {
-      SCOPED_MUTEX_LOCK(lock, hook->m_cont->mutex, this_ethread());
+      WEAK_SCOPED_MUTEX_LOCK(lock, hook->m_cont->mutex, this_ethread());
       hook->invoke(TS_EVENT_LIFECYCLE_SHUTDOWN, nullptr);
       hook = hook->next();
     }
@@ -2113,7 +2113,7 @@ task_threads_started_callback()
 {
   APIHook *hook = lifecycle_hooks->get(TS_LIFECYCLE_TASK_THREADS_READY_HOOK);
   while (hook) {
-    SCOPED_MUTEX_LOCK(lock, hook->m_cont->mutex, this_ethread());
+    WEAK_SCOPED_MUTEX_LOCK(lock, hook->m_cont->mutex, this_ethread());
     hook->invoke(TS_EVENT_LIFECYCLE_TASK_THREADS_READY, nullptr);
     hook = hook->next();
   }


### PR DESCRIPTION
This deals with the problem brought up in the discussions under PRs #5855 and #5857. And also makes the change such that #4926 still works as intended.