### PR TITLE
ProxyTxn Refactor move code to cc

### DIFF
--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -514,3 +514,86 @@ Http1ClientSession::decrement_current_active_client_connections_stat()
 {
   HTTP_DECREMENT_DYN_STAT(http_current_active_client_connections_stat);
 }
+
+void
+Http1ClientSession::start()
+{
+  // Troll for data to get a new transaction
+  this->release(&trans);
+}
+
+bool
+Http1ClientSession::allow_half_open() const
+{
+  // Only allow half open connections if the not over TLS
+  return (client_vc && dynamic_cast<SSLNetVConnection *>(client_vc) == nullptr);
+}
+
+void
+Http1ClientSession::set_half_close_flag(bool flag)
+{
+  half_close = flag;
+}
+
+bool
+Http1ClientSession::get_half_close_flag() const
+{
+  return half_close;
+}
+
+bool
+Http1ClientSession::is_chunked_encoding_supported() const
+{
+  return true;
+}
+
+NetVConnection *
+Http1ClientSession::get_netvc() const
+{
+  return client_vc;
+}
+
+int
+Http1ClientSession::get_transact_count() const
+{
+  return transact_count;
+}
+
+bool
+Http1ClientSession::is_outbound_transparent() const
+{
+  return f_outbound_transparent;
+}
+
+Http1ServerSession *
+Http1ClientSession::get_server_session() const
+{
+  return bound_ss;
+}
+
+void
+Http1ClientSession::set_active_timeout(ink_hrtime timeout_in)
+{
+  if (client_vc)
+    client_vc->set_active_timeout(timeout_in);
+}
+
+void
+Http1ClientSession::set_inactivity_timeout(ink_hrtime timeout_in)
+{
+  if (client_vc)
+    client_vc->set_inactivity_timeout(timeout_in);
+}
+
+void
+Http1ClientSession::cancel_inactivity_timeout()
+{
+  if (client_vc)
+    client_vc->cancel_inactivity_timeout();
+}
+
+const char *
+Http1ClientSession::get_protocol_string() const
+{
+  return "http";
+}

--- a/proxy/http/Http1ServerSession.cc
+++ b/proxy/http/Http1ServerSession.cc
@@ -203,3 +203,43 @@ Http1ServerSession::release()
     ink_assert(r == HSM_DONE);
   }
 }
+
+IOBufferReader *
+Http1ServerSession::get_reader()
+{
+  return buf_reader;
+};
+
+NetVConnection *
+Http1ServerSession::get_netvc() const
+{
+  return server_vc;
+};
+
+void
+Http1ServerSession::set_netvc(NetVConnection *new_vc)
+{
+  server_vc = new_vc;
+}
+
+// Keys for matching hostnames
+IpEndpoint const &
+Http1ServerSession::get_server_ip() const
+{
+  ink_release_assert(server_vc != nullptr);
+  return server_vc->get_remote_endpoint();
+}
+
+int
+Http1ServerSession::populate_protocol(std::string_view *result, int size) const
+{
+  auto vc = this->get_netvc();
+  return vc ? vc->populate_protocol(result, size) : 0;
+}
+
+const char *
+Http1ServerSession::protocol_contains(std::string_view tag_prefix) const
+{
+  auto vc = this->get_netvc();
+  return vc ? vc->protocol_contains(tag_prefix) : nullptr;
+}

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -50,122 +50,31 @@ enum class Http2StreamMilestone {
 class Http2Stream : public ProxyTransaction
 {
 public:
-  typedef ProxyTransaction super; ///< Parent type.
-  Http2Stream(Http2StreamId sid = 0, ssize_t initial_rwnd = Http2::initial_window_size) : _id(sid), _client_rwnd(initial_rwnd)
-  {
-    SET_HANDLER(&Http2Stream::main_event_handler);
-  }
+  using super = ProxyTransaction; ///< Parent type.
 
-  void
-  init(Http2StreamId sid, ssize_t initial_rwnd)
-  {
-    this->mark_milestone(Http2StreamMilestone::OPEN);
+  Http2Stream(Http2StreamId sid = 0, ssize_t initial_rwnd = Http2::initial_window_size);
 
-    this->_id          = sid;
-    this->_thread      = this_ethread();
-    this->_client_rwnd = initial_rwnd;
-
-    sm_reader = request_reader = request_buffer.alloc_reader();
-    // FIXME: Are you sure? every "stream" needs request_header?
-    _req_header.create(HTTP_TYPE_REQUEST);
-    response_header.create(HTTP_TYPE_RESPONSE);
-    http_parser_init(&http_parser);
-  }
+  void init(Http2StreamId sid, ssize_t initial_rwnd);
 
   int main_event_handler(int event, void *edata);
 
   void destroy() override;
-
-  bool
-  is_body_done() const
-  {
-    return body_done;
-  }
-
-  void
-  mark_body_done()
-  {
-    body_done = true;
-    if (response_is_chunked()) {
-      ink_assert(chunked_handler.state == ChunkedHandler::CHUNK_READ_DONE ||
-                 chunked_handler.state == ChunkedHandler::CHUNK_READ_ERROR);
-      this->write_vio.nbytes = response_header.length_get() + chunked_handler.dechunked_size;
-    }
-  }
-
-  void
-  update_sent_count(unsigned num_bytes)
-  {
-    bytes_sent += num_bytes;
-    this->write_vio.ndone += num_bytes;
-  }
-
-  Http2StreamId
-  get_id() const
-  {
-    return _id;
-  }
-
-  int
-  get_transaction_id() const override
-  {
-    return _id;
-  }
-
-  Http2StreamState
-  get_state() const
-  {
-    return _state;
-  }
-
-  bool change_state(uint8_t type, uint8_t flags);
-
-  void
-  update_initial_rwnd(Http2WindowSize new_size)
-  {
-    this->_client_rwnd = new_size;
-  }
-
-  bool
-  has_trailing_header() const
-  {
-    return trailing_header;
-  }
-
-  void
-  set_request_headers(HTTPHdr &h2_headers)
-  {
-    _req_header.copy(&h2_headers);
-  }
-
-  // Check entire DATA payload length if content-length: header is exist
-  void
-  increment_data_length(uint64_t length)
-  {
-    data_length += length;
-  }
-
-  bool
-  payload_length_is_valid() const
-  {
-    uint32_t content_length = _req_header.get_content_length();
-    return content_length == 0 || content_length == data_length;
-  }
-
-  Http2ErrorCode decode_header_blocks(HpackHandle &hpack_handle, uint32_t maximum_table_size);
-  void send_request(Http2ConnectionState &cstate);
-  VIO *do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf) override;
-  VIO *do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *abuffer, bool owner = false) override;
-  void do_io_close(int lerrno = -1) override;
-  void initiating_close();
-  void terminate_if_possible();
-  void do_io_shutdown(ShutdownHowTo_t) override {}
-  void update_read_request(int64_t read_len, bool send_update, bool check_eos = false);
-  void update_write_request(IOBufferReader *buf_reader, int64_t write_len, bool send_update);
-  void signal_write_event(bool call_update);
+  void release(IOBufferReader *r) override;
   void reenable(VIO *vio) override;
   void transaction_done() override;
 
+  void do_io_shutdown(ShutdownHowTo_t) override {}
+  VIO *do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf) override;
+  VIO *do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *abuffer, bool owner = false) override;
+  void do_io_close(int lerrno = -1) override;
+
+  Http2ErrorCode decode_header_blocks(HpackHandle &hpack_handle, uint32_t maximum_table_size);
+  void send_request(Http2ConnectionState &cstate);
+  void initiating_close();
+  void terminate_if_possible();
+  void update_read_request(int64_t read_len, bool send_update, bool check_eos = false);
+  void update_write_request(IOBufferReader *buf_reader, int64_t write_len, bool send_update);
+  void signal_write_event(bool call_update);
   void restart_sending();
   void push_promise(URL &url, const MIMEField *accept_encoding);
 
@@ -177,6 +86,44 @@ public:
   Http2ErrorCode increment_server_rwnd(size_t amount);
   Http2ErrorCode decrement_server_rwnd(size_t amount);
 
+  /////////////////
+  // Accessors
+  void set_active_timeout(ink_hrtime timeout_in) override;
+  void set_inactivity_timeout(ink_hrtime timeout_in) override;
+  void cancel_inactivity_timeout() override;
+
+  bool allow_half_open() const override;
+  bool is_first_transaction() const override;
+  void increment_client_transactions_stat() override;
+  void decrement_client_transactions_stat() override;
+  int get_transaction_id() const override;
+
+  void clear_inactive_timer();
+  void clear_active_timer();
+  void clear_timers();
+  void clear_io_events();
+
+  bool is_client_state_writeable() const;
+  bool is_closed() const;
+  bool response_is_chunked() const;
+  IOBufferReader *response_get_data_reader() const;
+
+  void mark_milestone(Http2StreamMilestone type);
+
+  void increment_data_length(uint64_t length);
+  bool payload_length_is_valid() const;
+  bool is_body_done() const;
+  void mark_body_done();
+  void update_sent_count(unsigned num_bytes);
+  Http2StreamId get_id() const;
+  Http2StreamState get_state() const;
+  bool change_state(uint8_t type, uint8_t flags);
+  void update_initial_rwnd(Http2WindowSize new_size);
+  bool has_trailing_header() const;
+  void set_request_headers(HTTPHdr &h2_headers);
+
+  //////////////////
+  // Variables
   uint8_t *header_blocks        = nullptr;
   uint32_t header_blocks_length = 0;  // total length of header blocks (not include
                                       // Padding or other fields)
@@ -195,53 +142,6 @@ public:
   IOBufferReader *request_reader           = nullptr;
   MIOBuffer request_buffer                 = CLIENT_CONNECTION_FIRST_READ_BUFFER_SIZE_INDEX;
   Http2DependencyTree::Node *priority_node = nullptr;
-
-  IOBufferReader *response_get_data_reader() const;
-  bool
-  response_is_chunked() const
-  {
-    return chunked;
-  }
-
-  void release(IOBufferReader *r) override;
-
-  bool
-  allow_half_open() const override
-  {
-    return false;
-  }
-
-  void set_active_timeout(ink_hrtime timeout_in) override;
-  void set_inactivity_timeout(ink_hrtime timeout_in) override;
-  void cancel_inactivity_timeout() override;
-  void clear_inactive_timer();
-  void clear_active_timer();
-  void clear_timers();
-  void clear_io_events();
-  bool
-  is_client_state_writeable() const
-  {
-    return _state == Http2StreamState::HTTP2_STREAM_STATE_OPEN ||
-           _state == Http2StreamState::HTTP2_STREAM_STATE_HALF_CLOSED_REMOTE ||
-           _state == Http2StreamState::HTTP2_STREAM_STATE_RESERVED_LOCAL;
-  }
-
-  bool
-  is_closed() const
-  {
-    return closed;
-  }
-
-  bool
-  is_first_transaction() const override
-  {
-    return is_first_transaction_flag;
-  }
-
-  void increment_client_transactions_stat() override;
-  void decrement_client_transactions_stat() override;
-
-  void mark_milestone(Http2StreamMilestone type);
 
 private:
   void response_initialize_data_handling(bool &is_done);


### PR DESCRIPTION
Organizing header files into something readable. 
Code moved from .h to .cc. No functional changes.