### PR TITLE
Fixed const issue with magick plugin

### DIFF
--- a/plugins/experimental/magick/magick.cc
+++ b/plugins/experimental/magick/magick.cc
@@ -184,7 +184,7 @@ struct EVPKey {
   EVPKey() : key(EVP_PKEY_new()) { assert(nullptr != key); }
 
   bool
-  assign(const char *const k) const
+  assign(char *k) const
   {
     assert(nullptr != k);
     const int rc = EVP_PKEY_assign_RSA(key, k);
@@ -196,7 +196,7 @@ struct EVPKey {
   bool
   assign(T &t)
   {
-    return assign(reinterpret_cast<const char *>(t));
+    return assign(reinterpret_cast<char *>(t));
   }
 };
 


### PR DESCRIPTION
When doing to QUIC builds for Github-autest I saw this issue:

The second argument should be a non const:
```
#  define EVP_PKEY_assign_RSA(pkey,rsa) EVP_PKEY_assign((pkey),EVP_PKEY_RSA,\
                                        (char *)(rsa))
```

Error from CI:
```
In file included from experimental/magick/magick.cc:39:0:
experimental/magick/magick.cc: In member function 'bool magick::EVPKey::assign(const char*) const':
experimental/magick/magick.cc:190:45: error: invalid conversion from 'const void*' to 'void*' [-fpermissive]
     const int rc = EVP_PKEY_assign_RSA(key, k);
/opt/openssl-quic/include/openssl/evp.h:418:42: note: in definition of macro 'EVP_PKEY_assign_RSA'
                                         (rsa))
                                          ^~~
/opt/openssl-quic/include/openssl/evp.h:1072:5: note:   initializing argument 3 of 'int EVP_PKEY_assign(EVP_PKEY*, int, void*)'
 int EVP_PKEY_assign(EVP_PKEY *pkey, int type, void *key);
     ^~~~~~~~~~~~~~~
```