### PR TITLE
ProxySsn renaming member vars

### DIFF
--- a/doc/developer-guide/client-session-architecture.en.rst
+++ b/doc/developer-guide/client-session-architecture.en.rst
@@ -80,7 +80,7 @@ When the Http1Transaction object is instantiated via :code:`ProxyTransaction::ne
 new HttpSM object, initializes it, and calls :code:`HttpSM::attach_client_session()` to associate the
 Http1Transaction object with the new HttpSM.
 
-The ProxyTransaction object refers to the HttpSM via the current_reader member variable.  The HttpSM object
+The ProxyTransaction object refers to the HttpSM via the _sm member variable.  The HttpSM object
 refers to ProxyTransaction via the ua_session member variable (session in the member name is
 historical because the HttpSM used to refer directly to the ClientSession object).
 

--- a/proxy/ProxyTransaction.h
+++ b/proxy/ProxyTransaction.h
@@ -113,9 +113,9 @@ public:
   HttpSessionAccept::Options upstream_outbound_options; // overwritable copy of options
 
 protected:
-  ProxySession *proxy_ssn   = nullptr;
-  HttpSM *current_reader    = nullptr;
-  IOBufferReader *sm_reader = nullptr;
+  ProxySession *_proxy_ssn = nullptr;
+  HttpSM *_sm              = nullptr;
+  IOBufferReader *_reader  = nullptr;
 
 private:
 };

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -186,8 +186,8 @@ Http1ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOB
   client_vc->set_tcp_congestion_control(CLIENT_SIDE);
 
   read_buffer = iobuf ? iobuf : new_MIOBuffer(HTTP_HEADER_BUFFER_SIZE_INDEX);
-  sm_reader   = reader ? reader : read_buffer->alloc_reader();
-  trans.set_reader(sm_reader);
+  _reader     = reader ? reader : read_buffer->alloc_reader();
+  trans.set_reader(_reader);
 
   // INKqa11186: Use a local pointer to the mutex as
   // when we return from do_api_callout, the ClientSession may
@@ -272,7 +272,7 @@ Http1ClientSession::do_io_close(int alerrno)
     // [bug 2610799] Drain any data read.
     // If the buffer is full and the client writes again, we will not receive a
     // READ_READY event.
-    sm_reader->consume(sm_reader->read_avail());
+    _reader->consume(_reader->read_avail());
   } else {
     read_state = HCS_CLOSED;
     HttpSsnDebug("[%" PRId64 "] session closed", con_id);
@@ -312,7 +312,7 @@ Http1ClientSession::state_wait_for_close(int event, void *data)
     break;
   case VC_EVENT_READ_READY:
     // Drain any data read
-    sm_reader->consume(sm_reader->read_avail());
+    _reader->consume(_reader->read_avail());
     break;
 
   default:
@@ -421,7 +421,7 @@ Http1ClientSession::release(ProxyTransaction *trans)
   //  buffer.  If there is, spin up a new state
   //  machine to process it.  Otherwise, issue an
   //  IO to wait for new data
-  bool more_to_read = this->sm_reader->is_read_avail_more_than(0);
+  bool more_to_read = this->_reader->is_read_avail_more_than(0);
   if (more_to_read) {
     trans->destroy();
     HttpSsnDebug("[%" PRId64 "] data already in buffer, starting new transaction", con_id);

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -112,8 +112,8 @@ private:
   bool half_close           = false;
   bool conn_decrease        = false;
 
-  MIOBuffer *read_buffer    = nullptr;
-  IOBufferReader *sm_reader = nullptr;
+  MIOBuffer *read_buffer  = nullptr;
+  IOBufferReader *_reader = nullptr;
 
   C_Read_State read_state = HCS_INIT;
 

--- a/proxy/http/HttpUpdateTester.cc
+++ b/proxy/http/HttpUpdateTester.cc
@@ -87,9 +87,9 @@ UpTest::make_requests()
     test_req.parse_req(&http_parser, &req, req + strlen(req), false);
     http_parser_clear(&http_parser);
 
-    HttpUpdateSM *current_reader = HttpUpdateSM::allocate();
-    current_reader->init();
-    Action *a = current_reader->start_scheduled_update(this, test_req);
+    HttpUpdateSM *_sm = HttpUpdateSM::allocate();
+    _sm->init();
+    Action *a = _sm->start_scheduled_update(this, test_req);
     (void)a;
 
     active_req++;

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -239,7 +239,7 @@ private:
   SessionHandler session_handler = nullptr;
   NetVConnection *client_vc      = nullptr;
   MIOBuffer *read_buffer         = nullptr;
-  IOBufferReader *sm_reader      = nullptr;
+  IOBufferReader *_reader        = nullptr;
   MIOBuffer *write_buffer        = nullptr;
   IOBufferReader *sm_writer      = nullptr;
   Http2FrameHeader current_hdr   = {0, 0, 0, 0};


### PR DESCRIPTION
Renaming protected variables of ProxySession to be more accurate and use naming conventions.
- proxy_ssn => _proxy_ssn
- current_reader => _sm
- sm_reader => _reader