### PR TITLE
Cleanup: Remove unused AllocType and unused functions

### DIFF
--- a/iocore/eventsystem/I_IOBuffer.h
+++ b/iocore/eventsystem/I_IOBuffer.h
@@ -62,11 +62,8 @@ extern int64_t default_large_iobuffer_size; // matched to size of OS buffers
 
 enum AllocType {
   NO_ALLOC,
-  FAST_ALLOCATED,
-  XMALLOCED,
   MEMALIGNED,
   DEFAULT_ALLOC,
-  CONSTANT,
 };
 
 #define DEFAULT_BUFFER_NUMBER 128
@@ -144,23 +141,11 @@ void init_buffer_allocators(int iobuffer_advice);
       <td></td>
     </tr>
     <tr>
-      <td>FAST_ALLOCATED</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>XMALLOCED</td>
-      <td></td>
-    </tr>
-    <tr>
       <td>MEMALIGNED</td>
       <td></td>
     </tr>
     <tr>
       <td>DEFAULT_ALLOC</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>CONSTANT</td>
       <td></td>
     </tr>
   </table>
@@ -465,8 +450,6 @@ public:
   void realloc_set_internal(void *b, int64_t buf_size, int64_t asize_index);
   void realloc(void *b, int64_t buf_size);
   void realloc(int64_t i);
-  void realloc_xmalloc(void *b, int64_t buf_size);
-  void realloc_xmalloc(int64_t buf_size);
 
   /**
     Frees the IOBufferBlock object and its underlying memory.
@@ -957,6 +940,10 @@ public:
   void add_block();
 
   /**
+    Deprecated
+
+    TODO: remove this function. Because ats_xmalloc() doesn't exist anymore.
+
     Adds by reference len bytes of data pointed to by b to the end
     of the buffer.  b MUST be a pointer to the beginning of  block
     allocated from the ats_xmalloc() routine. The data will be deallocated
@@ -1186,9 +1173,7 @@ public:
   void dealloc_all_readers();
 
   void set(void *b, int64_t len);
-  void set_xmalloced(void *b, int64_t len);
   void alloc(int64_t i = default_large_iobuffer_size);
-  void alloc_xmalloc(int64_t buf_size);
   void append_block_internal(IOBufferBlock *b);
   int64_t write(IOBufferBlock const *b, int64_t len, int64_t offset);
   int64_t puts(char *buf, int64_t len);
@@ -1254,16 +1239,6 @@ public:
   realloc(void *b, int64_t buf_size)
   {
     _writer->realloc(b, buf_size);
-  }
-  void
-  realloc_xmalloc(void *b, int64_t buf_size)
-  {
-    _writer->realloc_xmalloc(b, buf_size);
-  }
-  void
-  realloc_xmalloc(int64_t buf_size)
-  {
-    _writer->realloc_xmalloc(buf_size);
   }
 
   int64_t size_index;
@@ -1454,12 +1429,6 @@ extern IOBufferData *new_xmalloc_IOBufferData_internal(
 #endif
   void *b, int64_t size);
 
-extern IOBufferData *new_constant_IOBufferData_internal(
-#ifdef TRACK_BUFFER_USER
-  const char *locaction,
-#endif
-  void *b, int64_t size);
-
 #ifdef TRACK_BUFFER_USER
 class IOBufferData_tracker
 {
@@ -1475,14 +1444,13 @@ public:
 };
 #endif
 
+// TODO: remove new_xmalloc_IOBufferData. Because ats_xmalloc() doesn't exist anymore.
 #ifdef TRACK_BUFFER_USER
 #define new_IOBufferData IOBufferData_tracker(RES_PATH("memory/IOBuffer/"))
 #define new_xmalloc_IOBufferData(b, size) new_xmalloc_IOBufferData_internal(RES_PATH("memory/IOBuffer/"), (b), (size))
-#define new_constant_IOBufferData(b, size) new_constant_IOBufferData_internal(RES_PATH("memory/IOBuffer/"), (b), (size))
 #else
 #define new_IOBufferData new_IOBufferData_internal
 #define new_xmalloc_IOBufferData new_xmalloc_IOBufferData_internal
-#define new_constant_IOBufferData new_constant_IOBufferData_internal
 #endif
 
 extern int64_t iobuffer_size_to_index(int64_t size, int64_t max = max_iobuffer_size);

--- a/iocore/eventsystem/P_IOBuffer.h
+++ b/iocore/eventsystem/P_IOBuffer.h
@@ -217,20 +217,6 @@ new_IOBufferData_internal(
 }
 
 TS_INLINE IOBufferData *
-new_constant_IOBufferData_internal(
-#ifdef TRACK_BUFFER_USER
-  const char *loc,
-#endif
-  void *b, int64_t size)
-{
-  return new_IOBufferData_internal(
-#ifdef TRACK_BUFFER_USER
-    loc,
-#endif
-    b, size, BUFFER_SIZE_INDEX_FOR_CONSTANT_SIZE(size));
-}
-
-TS_INLINE IOBufferData *
 new_xmalloc_IOBufferData_internal(
 #ifdef TRACK_BUFFER_USER
   const char *location,
@@ -516,18 +502,6 @@ TS_INLINE void
 IOBufferBlock::realloc(void *b, int64_t buf_size)
 {
   realloc_set_internal(b, buf_size, BUFFER_SIZE_NOT_ALLOCATED);
-}
-
-TS_INLINE void
-IOBufferBlock::realloc_xmalloc(void *b, int64_t buf_size)
-{
-  realloc_set_internal(b, buf_size, -buf_size);
-}
-
-TS_INLINE void
-IOBufferBlock::realloc_xmalloc(int64_t buf_size)
-{
-  realloc_set_internal(ats_malloc(buf_size), buf_size, -buf_size);
 }
 
 TS_INLINE void
@@ -1105,18 +1079,6 @@ MIOBuffer::set(void *b, int64_t len)
 }
 
 TS_INLINE void
-MIOBuffer::set_xmalloced(void *b, int64_t len)
-{
-#ifdef TRACK_BUFFER_USER
-  _writer = new_IOBufferBlock_internal(_location);
-#else
-  _writer          = new_IOBufferBlock_internal();
-#endif
-  _writer->set_internal(b, len, BUFFER_SIZE_INDEX_FOR_XMALLOC_SIZE(len));
-  init_readers();
-}
-
-TS_INLINE void
 MIOBuffer::append_xmalloced(void *b, int64_t len)
 {
 #ifdef TRACK_BUFFER_USER
@@ -1151,13 +1113,6 @@ MIOBuffer::alloc(int64_t i)
   _writer->alloc(i);
   size_index = i;
   init_readers();
-}
-
-TS_INLINE void
-MIOBuffer::alloc_xmalloc(int64_t buf_size)
-{
-  char *b = (char *)ats_malloc(buf_size);
-  set_xmalloced(b, buf_size);
 }
 
 TS_INLINE void


### PR DESCRIPTION
No logic change.

`MIOBuffer::append_xmalloced()` and `new_xmalloc_IOBufferData()` are left as deprecated. Because these are used from some places. These should be removed in the future.