### PR TITLE
Remove unnecessary write_avail causing extra block allocations for h2

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -603,9 +603,8 @@ Http2Stream::update_write_request(IOBufferReader *buf_reader, int64_t write_len,
     }
   }
 
-  Http2StreamDebug("write_vio.nbytes=%" PRId64 ", write_vio.ndone=%" PRId64 ", write_vio.write_avail=%" PRId64
-                   ", reader.read_avail=%" PRId64,
-                   write_vio.nbytes, write_vio.ndone, write_vio.get_writer()->write_avail(), bytes_avail);
+  Http2StreamDebug("write_vio.nbytes=%" PRId64 ", write_vio.ndone=%" PRId64 ", reader.read_avail=%" PRId64, write_vio.nbytes,
+                   write_vio.ndone, bytes_avail);
 
   if (bytes_avail <= 0 && !is_done) {
     return;
@@ -679,10 +678,6 @@ void
 Http2Stream::signal_write_event(bool call_update)
 {
   if (this->write_vio.cont == nullptr || this->write_vio.op == VIO::NONE) {
-    return;
-  }
-
-  if (this->write_vio.get_writer()->write_avail() == 0) {
     return;
   }
 


### PR DESCRIPTION
Using @bryancall's proxy.config.res_track_memory feature to figure out buffer allocations, it showed that the buffer set up by HttpSM::setup_server_transfer had over 2000 allocations for a H2 transfer of 10MB but only 600 allocations for the same transfer over H1.

This code change, reduced the number of allocations to around 1000 for H2.  Still higher than H1, but much better.

The write_avail will never return 0 and always allocate a new block if the current writer block is full.  So the if return should never trigger.  In the H2 logic, we are copying IOBlocks from the origin side MIOBuffer, so the empty block will never be used.  Could explain why we started seeing unusually long buffer block chains.