### PR TITLE
Remove a set water_mark in H2 to avoid unnecessary block allocates

### DIFF
--- a/iocore/cache/CacheRead.cc
+++ b/iocore/cache/CacheRead.cc
@@ -726,7 +726,7 @@ CacheVC::openReadMain(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   if (ntodo <= 0) {
     return EVENT_CONT;
   }
-  if (vio.buffer.writer()->max_read_avail() > vio.buffer.writer()->water_mark && vio.ndone) { // initiate read of first block
+  if (vio.buffer.writer()->max_read_avail() > vio.buffer.writer()->get_water_mark() && vio.ndone) { // initiate read of first block
     return EVENT_CONT;
   }
   if ((bytes <= 0) && vio.ntodo() >= 0) {

--- a/iocore/eventsystem/I_IOBuffer.h
+++ b/iocore/eventsystem/I_IOBuffer.h
@@ -1144,6 +1144,22 @@ public:
   void set_size_index(int64_t size);
 
   /**
+    Accessor methods for the water_mark member, so we can
+    enforce constrains on the water_mark compared to the size of the block
+  */
+  int64_t
+  get_water_mark()
+  {
+    return this->water_mark;
+  }
+  void
+  clear_water_mark()
+  {
+    this->water_mark = 0;
+  }
+  void set_water_mark(int64_t new_water_mark);
+
+  /**
     Allocates a new IOBuffer reader and sets it's its 'accessor' field
     to point to 'anAccessor'.
 
@@ -1268,6 +1284,7 @@ public:
 
   int64_t size_index;
 
+private:
   /**
     Determines when to stop writing or reading. The watermark is the
     level to which the producer (filler) is required to fill the buffer
@@ -1278,6 +1295,7 @@ public:
   */
   int64_t water_mark;
 
+public:
   Ptr<IOBufferBlock> _writer;
   IOBufferReader readers[MAX_MIOBUFFER_READERS];
 

--- a/iocore/utils/OneWayMultiTunnel.cc
+++ b/iocore/utils/OneWayMultiTunnel.cc
@@ -83,7 +83,7 @@ OneWayMultiTunnel::init(VConnection *vcSource, VConnection **vcTargets, int n_vc
   }
   topOutBuffer.writer_for(buf2);
 
-  buf1->water_mark = water_mark;
+  buf1->set_water_mark(water_mark);
 
   vioSource = vcSource->do_io_read(this, nbytes, buf1);
 

--- a/iocore/utils/OneWayTunnel.cc
+++ b/iocore/utils/OneWayTunnel.cc
@@ -142,7 +142,7 @@ OneWayTunnel::init(VConnection *vcSource, VConnection *vcTarget, Continuation *a
     buf2 = new_MIOBuffer(size_index);
   }
 
-  buf1->water_mark = water_mark;
+  buf1->set_water_mark(water_mark);
 
   SCOPED_MUTEX_LOCK(lock, mutex, this_ethread());
   vioSource = vcSource->do_io_read(this, nbytes, buf1);

--- a/plugins/experimental/memcache/tsmemcache.cc
+++ b/plugins/experimental/memcache/tsmemcache.cc
@@ -140,14 +140,14 @@ MCAccept::main_event(int event, void *data)
 void
 MC::new_connection(NetVConnection *netvc, EThread *thread)
 {
-  nvc              = netvc;
-  mutex            = new_ProxyMutex();
-  rbuf             = new_MIOBuffer(MAX_IOBUFFER_SIZE);
-  rbuf->water_mark = TSMEMCACHE_TMP_CMD_BUFFER_SIZE;
-  reader           = rbuf->alloc_reader();
-  wbuf             = new_empty_MIOBuffer();
-  cbuf             = 0;
-  writer           = wbuf->alloc_reader();
+  nvc   = netvc;
+  mutex = new_ProxyMutex();
+  rbuf  = new_MIOBuffer(MAX_IOBUFFER_SIZE);
+  rbuf->set_water_mark(TSMEMCACHE_TMP_CMD_BUFFER_SIZE);
+  reader = rbuf->alloc_reader();
+  wbuf   = new_empty_MIOBuffer();
+  cbuf   = 0;
+  writer = wbuf->alloc_reader();
   SCOPED_MUTEX_LOCK(lock, mutex, thread);
   rvio         = nvc->do_io_read(this, INT64_MAX, rbuf);
   wvio         = nvc->do_io_write(this, 0, writer);

--- a/proxy/PluginVC.cc
+++ b/proxy/PluginVC.cc
@@ -631,7 +631,7 @@ PluginVC::process_read_side(bool other_side_call)
   //
   MIOBuffer *output_buffer = read_state.vio.get_writer();
 
-  int64_t water_mark = output_buffer->water_mark;
+  int64_t water_mark = output_buffer->get_water_mark();
   water_mark         = std::max(water_mark, static_cast<int64_t>(PVC_DEFAULT_MAX_BYTES));
   int64_t buf_space  = water_mark - output_buffer->max_read_avail();
   if (buf_space <= 0) {

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -6052,7 +6052,7 @@ HttpSM::setup_cache_read_transfer()
   buf->append_block(HTTP_HEADER_BUFFER_SIZE_INDEX);
 #endif
 
-  buf->water_mark = static_cast<int>(t_state.txn_conf->default_buffer_water_mark);
+  buf->set_water_mark(static_cast<int>(t_state.txn_conf->default_buffer_water_mark));
 
   IOBufferReader *buf_start = buf->alloc_reader();
 
@@ -6395,8 +6395,8 @@ HttpSM::setup_transfer_from_transform()
   int64_t alloc_index = find_server_buffer_size();
 
   // TODO change this call to new_empty_MIOBuffer()
-  MIOBuffer *buf            = new_MIOBuffer(alloc_index);
-  buf->water_mark           = static_cast<int>(t_state.txn_conf->default_buffer_water_mark);
+  MIOBuffer *buf = new_MIOBuffer(alloc_index);
+  buf->set_water_mark(static_cast<int>(t_state.txn_conf->default_buffer_water_mark));
   IOBufferReader *buf_start = buf->alloc_reader();
 
   HttpTunnelConsumer *c = tunnel.get_consumer(transform_info.vc);
@@ -6500,7 +6500,7 @@ HttpSM::setup_server_transfer()
   MIOBuffer *buf = new_empty_MIOBuffer(alloc_index);
   buf->append_block(HTTP_HEADER_BUFFER_SIZE_INDEX);
 #endif
-  buf->water_mark           = static_cast<int>(t_state.txn_conf->default_buffer_water_mark);
+  buf->set_water_mark(static_cast<int>(t_state.txn_conf->default_buffer_water_mark));
   IOBufferReader *buf_start = buf->alloc_reader();
 
   // we need to know if we are going to chunk the response or not

--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -71,10 +71,10 @@ ChunkedHandler::init_by_action(IOBufferReader *buffer_in, Action action)
 
   switch (action) {
   case ACTION_DOCHUNK:
-    dechunked_reader                   = buffer_in->mbuf->clone_reader(buffer_in);
-    dechunked_reader->mbuf->water_mark = min_block_transfer_bytes;
-    chunked_buffer                     = new_MIOBuffer(CHUNK_IOBUFFER_SIZE_INDEX);
-    chunked_size                       = 0;
+    dechunked_reader = buffer_in->mbuf->clone_reader(buffer_in);
+    dechunked_reader->mbuf->set_water_mark(min_block_transfer_bytes);
+    chunked_buffer = new_MIOBuffer(CHUNK_IOBUFFER_SIZE_INDEX);
+    chunked_size   = 0;
     break;
   case ACTION_DECHUNK:
     chunked_reader   = buffer_in->mbuf->clone_reader(buffer_in);

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -203,9 +203,8 @@ Http2ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOB
 
   this->client_vc->set_tcp_congestion_control(CLIENT_SIDE);
 
-  this->read_buffer             = iobuf ? iobuf : new_MIOBuffer(HTTP2_HEADER_BUFFER_SIZE_INDEX);
-  this->read_buffer->water_mark = connection_state.server_settings.get(HTTP2_SETTINGS_MAX_FRAME_SIZE);
-  this->sm_reader               = reader ? reader : this->read_buffer->alloc_reader();
+  this->read_buffer = iobuf ? iobuf : new_MIOBuffer(HTTP2_HEADER_BUFFER_SIZE_INDEX);
+  this->sm_reader   = reader ? reader : this->read_buffer->alloc_reader();
 
   this->write_buffer = new_MIOBuffer(HTTP2_HEADER_BUFFER_SIZE_INDEX);
   this->sm_writer    = this->write_buffer->alloc_reader();

--- a/src/traffic_server/FetchSM.h
+++ b/src/traffic_server/FetchSM.h
@@ -73,7 +73,7 @@ public:
     //
     // So we should set the water_mark of resp_buffer with a large value,
     // INT64_MAX would be reasonable.
-    resp_buffer->water_mark = INT64_MAX;
+    resp_buffer->set_water_mark(INT64_MAX);
   }
 
   int fetch_handler(int event, void *data);

--- a/src/traffic_server/InkIOCoreAPI.cc
+++ b/src/traffic_server/InkIOCoreAPI.cc
@@ -758,7 +758,7 @@ TSIOBufferWaterMarkGet(TSIOBuffer bufp)
   sdk_assert(sdk_sanity_check_iocore_structure(bufp) == TS_SUCCESS);
 
   MIOBuffer *b = (MIOBuffer *)bufp;
-  return b->water_mark;
+  return b->get_water_mark();
 }
 
 void
@@ -767,8 +767,8 @@ TSIOBufferWaterMarkSet(TSIOBuffer bufp, int64_t water_mark)
   sdk_assert(sdk_sanity_check_iocore_structure(bufp) == TS_SUCCESS);
   sdk_assert(water_mark >= 0);
 
-  MIOBuffer *b  = (MIOBuffer *)bufp;
-  b->water_mark = water_mark;
+  MIOBuffer *b = (MIOBuffer *)bufp;
+  b->set_water_mark(water_mark);
 }
 
 TSIOBufferReader


### PR DESCRIPTION
More results from looking at H2 download of a 10MB file using the proxy.config.res_track_memory setting.

The real change is in Http2ClientSession::new_connection which removes an update to the read buffer water_mark.  This was causing the call to write_avail to add a new block even through the current write block was empty because the check_add method check against water marks was passing.  Added an assert to add_block to catch the case of adding blocks after an empty write block. I removed the call to set the water_mark to the max_buffer size (16K) which was bigger than the block size (4K).  Moving this call got rid of 10 allocations on that buffer for the 10MB download.  Not one of the bigger wins, but seems like a good tidy up.

I'm not at all clear on the water mark logic.  From the description at the top of I_IOBuffer.h, the water_mark indicates that the logic shouldn't bother reading unless at least "water_mark" bytes are available.  Not clear how it should be used for deciding to add more blocks for writing.

The bulk of the changes are making the water_mark member private and adding accessor methods so I could add constraints on the setting.  But my asserts triggered too off.  I think leaving the wrappers is a good thing.  Someone should probably spend some cycles reviewing the purpose of the buffer water_mark, but I don't think we are using them as it was originally intended.