### PR TITLE
Use client setting for max_frame size

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1439,7 +1439,7 @@ Http2SendDataFrameResult
 Http2ConnectionState::send_a_data_frame(Http2Stream *stream, size_t &payload_length)
 {
   const ssize_t window_size         = std::min(this->client_rwnd(), stream->client_rwnd());
-  const size_t buf_len              = BUFFER_SIZE_FOR_INDEX(buffer_size_index[HTTP2_FRAME_TYPE_DATA]);
+  const size_t buf_len              = client_settings.get(HTTP2_SETTINGS_MAX_FRAME_SIZE);
   const size_t write_available_size = std::min(buf_len, static_cast<size_t>(window_size));
   payload_length                    = 0;
 


### PR DESCRIPTION
It appears that currently the major browsers do not set the max frame size in the settings, but it seems that we should take them up on larger frame sizes if they are willing to handle them.