### PR TITLE
Eliminate extra copies for data frames

### DIFF
--- a/plugins/cachekey/configs.h
+++ b/plugins/cachekey/configs.h
@@ -226,10 +226,10 @@ private:
    */
   bool loadClassifiers(const String &args, bool blacklist = true);
 
-  bool _prefixToBeRemoved  = false;     /**< @brief instructs the prefix (i.e. host:port) not to added to the cache key */
-  bool _pathToBeRemoved    = false;     /**< @brief instructs the path not to added to the cache key */
-  bool _canonicalPrefix    = false;     /**< @brief keep the URI scheme and authority element used as input to transforming into key */
-  String _separator        = "/";       /**< @brief a separator used to separate the cache key elements extracted from the URI */
-  CacheKeyUriType _uriType = REMAP;     /**< @brief shows which URI the cache key will be based on */
+  bool _prefixToBeRemoved  = false; /**< @brief instructs the prefix (i.e. host:port) not to added to the cache key */
+  bool _pathToBeRemoved    = false; /**< @brief instructs the path not to added to the cache key */
+  bool _canonicalPrefix    = false; /**< @brief keep the URI scheme and authority element used as input to transforming into key */
+  String _separator        = "/";   /**< @brief a separator used to separate the cache key elements extracted from the URI */
+  CacheKeyUriType _uriType = REMAP; /**< @brief shows which URI the cache key will be based on */
   CacheKeyKeyType _keyType = CACHE_KEY; /**< @brief target URI to be modified, cache key or paren selection */
 };


### PR DESCRIPTION
Trying to address performance concerns with H2.  This PR removes two copies that were present in Http2ConnectionState::send_a_data_frame method.  The first copy was to a stack allocated buffer called payload.  The second copy was from the stack allocated buffer to an IOBlock variable allocated with the Http2Frame object.

We removed the stack buffer, and instead of copying data from the SM provided reader to another IOBlock, we assign the SM provided reader to the Http2Frame.  When the Http2Frame::xmit method is called, the data from the SM provided reader is copied into the write buffer associated with the Http2ClientSession netvc.  This copy should just copy over the IOBlocks since the data is moving from MIOBuffer to MIOBuffer.

Using the proxy.config.res_track_memory and fetching a 10MB file, the number of allocates for the Http2Frame::alloc were reduced from 644 to 3.  For the non-data frames, we still use the original IOBlock scheme to sending the smaller frame payloads like Settings and Window updates.

We may still want to do the copy for the data buffers if we can include the Http2Frame in the buffer with the data.  That would eliminate the extra small TLS records on the wire due to writing out the headers separately from the data payload.  Will do some more experiments with that approach and put up another PR if that pans out.