### PR TITLE
Reduce unnecesary IOBufferBlock allocation

### DIFF
--- a/iocore/eventsystem/IOBuffer.cc
+++ b/iocore/eventsystem/IOBuffer.cc
@@ -60,6 +60,9 @@ init_buffer_allocators(int iobuffer_advice)
   }
 }
 
+//
+// MIOBuffer
+//
 int64_t
 MIOBuffer::remove_append(IOBufferReader *r)
 {
@@ -173,6 +176,9 @@ MIOBuffer::puts(char *s, int64_t len)
   return 0;
 }
 
+//
+// IOBufferReader
+//
 int64_t
 IOBufferReader::read(void *ab, int64_t len)
 {
@@ -262,6 +268,9 @@ IOBufferReader::memcpy(void *ap, int64_t len, int64_t offset)
   return p;
 }
 
+//
+// IOBufferChain
+//
 int64_t
 IOBufferChain::write(IOBufferBlock *blocks, int64_t length, int64_t offset)
 {
@@ -349,7 +358,9 @@ IOBufferChain::consume(int64_t size)
   return zret;
 }
 
-//-- MIOBufferWriter
+//
+// MIOBufferWriter
+//
 MIOBufferWriter &
 MIOBufferWriter::write(const void *data_, size_t length)
 {

--- a/iocore/eventsystem/I_IOBuffer.h
+++ b/iocore/eventsystem/I_IOBuffer.h
@@ -933,9 +933,8 @@ public:
   void append_block(int64_t asize_index);
 
   /**
-    Adds new block to the end of block list using the block size for
-    the buffer specified when the buffer was allocated.
-
+    Adds a new block to the end of the block list. Note that this does nothing when the next block of the current writer exists.
+    The block size is the same as specified size when the buffer was allocated.
   */
   void add_block();
 

--- a/iocore/eventsystem/P_IOBuffer.h
+++ b/iocore/eventsystem/P_IOBuffer.h
@@ -961,7 +961,9 @@ MIOBuffer::append_block(int64_t asize_index)
 TS_INLINE void
 MIOBuffer::add_block()
 {
-  append_block(size_index);
+  if (this->_writer == nullptr || this->_writer->next == nullptr) {
+    append_block(size_index);
+  }
 }
 
 TS_INLINE void


### PR DESCRIPTION
`MIOBuffer::write_avail()` adds IOBlocks if needed. As @shinrich pointed at #5894 , some of them are unnecessary. It looks like the root cause is `MIOBuffer::add_block` always overwrite the writer->next if the "next" is writable.

This appends new IOBufferBlock in the tail of the block list for the general fix.

Unit tests will be added. 