### PR TITLE
Fix macOS build

### DIFF
--- a/doc/admin-guide/logging/examples.en.rst
+++ b/doc/admin-guide/logging/examples.en.rst
@@ -303,8 +303,8 @@ Configuring ASCII Pipe Buffer Size
 ==================================
 
 This example mirrors the one above but also sets a ```pipe_buffer_size``` of
-1024 * 1024 for the pipe. This can be set on a per-pipe basis but is not 
-available on FreeBSD dists of ATS. If this field is not set, the pipe buffer
+1024 * 1024 for the pipe. This can be set on a per-pipe basis but is only
+available on Linux (later than 2.6.35). If this field is not set, the pipe buffer
 will default to the OS default size.
 
 .. code:: yaml

--- a/proxy/logging/LogFile.cc
+++ b/proxy/logging/LogFile.cc
@@ -188,9 +188,7 @@ LogFile::open_file()
       return LOG_FILE_NO_PIPE_READERS;
     }
 
-#ifdef __FreeBSD__
-    // we don't do this for FreeBSD
-#else
+#ifdef F_GETPIPE_SZ
     // adjust pipe size if necessary
     if (m_pipe_buffer_size) {
       long pipe_size = (long)fcntl(m_fd, F_GETPIPE_SZ);
@@ -212,7 +210,7 @@ LogFile::open_file()
         Debug("log-file", "NEW pipe size for pipe %s = %ld", m_name, pipe_size);
       }
     }
-#endif
+#endif // F_GETPIPE_SZ
   } else {
     if (m_log) {
       int status = m_log->open_file(Log::config->logfile_perm);


### PR DESCRIPTION
`F_GETPIPE_SZ` is introduced by #5863, but it's not available on mac neither. 

```
  CXX      LogFilter.o
../../../proxy/logging/LogFile.cc:196:42: error: use of undeclared identifier 'F_GETPIPE_SZ'
      long pipe_size = (long)fcntl(m_fd, F_GETPIPE_SZ);
                                         ^
../../../proxy/logging/LogFile.cc:203:29: error: use of undeclared identifier 'F_SETPIPE_SZ'
      int ret = fcntl(m_fd, F_SETPIPE_SZ, m_pipe_buffer_size);
                            ^
../../../proxy/logging/LogFile.cc:208:37: error: use of undeclared identifier 'F_GETPIPE_SZ'
      pipe_size = (long)fcntl(m_fd, F_GETPIPE_SZ);
                                    ^
  CXX      LogFormat.o
3 errors generated.
make[2]: *** [LogFile.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [all-recursive] Error 1
make: *** [all-recursive] Error 1
```
https://ci.trafficserver.apache.org/view/10.x%20master/job/macOS-master/compiler=clang,label=macOS,type=release/2574/console

/cc @ericcarlschwartz