### PR TITLE
ProxySession cleanup: moving inline functions to .h

### DIFF
--- a/proxy/ProxySession.h
+++ b/proxy/ProxySession.h
@@ -181,3 +181,89 @@ private:
   // aborts.
   bool m_active = false;
 };
+
+///////////////////
+// INLINE
+
+static inline int64_t next_cs_id = 0;
+
+inline int64_t
+ProxySession::next_connection_id()
+{
+  return ink_atomic_increment(&next_cs_id, 1);
+}
+
+inline void *
+ProxySession::get_user_arg(unsigned ix) const
+{
+  ink_assert(ix < countof(user_args));
+  return this->user_args[ix];
+}
+
+inline void
+ProxySession::set_user_arg(unsigned ix, void *arg)
+{
+  ink_assert(ix < countof(user_args));
+  user_args[ix] = arg;
+}
+
+inline void
+ProxySession::set_debug(bool flag)
+{
+  debug_on = flag;
+}
+
+// Return whether debugging is enabled for this session.
+inline bool
+ProxySession::debug() const
+{
+  return this->debug_on;
+}
+
+inline bool
+ProxySession::is_active() const
+{
+  return m_active;
+}
+
+inline bool
+ProxySession::is_draining() const
+{
+  return TSSystemState::is_draining();
+}
+
+inline bool
+ProxySession::is_client_closed() const
+{
+  return get_netvc() == nullptr;
+}
+
+inline TSHttpHookID
+ProxySession::get_hookid() const
+{
+  return hook_state.id();
+}
+
+inline void
+ProxySession::hook_add(TSHttpHookID id, INKContInternal *cont)
+{
+  this->api_hooks.append(id, cont);
+}
+
+inline APIHook *
+ProxySession::hook_get(TSHttpHookID id) const
+{
+  return this->api_hooks.get(id);
+}
+
+inline HttpAPIHooks const *
+ProxySession::feature_hooks() const
+{
+  return &api_hooks;
+}
+
+inline bool
+ProxySession::has_hooks() const
+{
+  return this->api_hooks.has_hooks() || http_global_hooks->has_hooks();
+}

--- a/proxy/ProxyTransaction.cc
+++ b/proxy/ProxyTransaction.cc
@@ -124,58 +124,6 @@ ProxyTransaction::is_first_transaction() const
 {
   return _proxy_ssn->get_transact_count() == 1;
 }
-// Ask your session if this is allowed
-bool
-ProxyTransaction::is_transparent_passthrough_allowed()
-{
-  return upstream_outbound_options.f_transparent_passthrough;
-}
-
-bool
-ProxyTransaction::is_chunked_encoding_supported() const
-{
-  return _proxy_ssn ? _proxy_ssn->is_chunked_encoding_supported() : false;
-}
-
-void
-ProxyTransaction::set_half_close_flag(bool flag)
-{
-  if (_proxy_ssn) {
-    _proxy_ssn->set_half_close_flag(flag);
-  }
-}
-
-bool
-ProxyTransaction::get_half_close_flag() const
-{
-  return _proxy_ssn ? _proxy_ssn->get_half_close_flag() : false;
-}
-
-// What are the debug and hooks_enabled used for?  How are they set?
-// Just calling through to proxy session for now
-bool
-ProxyTransaction::debug() const
-{
-  return _proxy_ssn ? _proxy_ssn->debug() : false;
-}
-
-APIHook *
-ProxyTransaction::hook_get(TSHttpHookID id) const
-{
-  return _proxy_ssn ? _proxy_ssn->hook_get(id) : nullptr;
-}
-
-HttpAPIHooks const *
-ProxyTransaction::feature_hooks() const
-{
-  return _proxy_ssn ? _proxy_ssn->feature_hooks() : nullptr;
-}
-
-bool
-ProxyTransaction::has_hooks() const
-{
-  return _proxy_ssn->has_hooks();
-}
 
 void
 ProxyTransaction::set_session_active()
@@ -247,49 +195,7 @@ ProxyTransaction::set_outbound_transparent(bool flag)
   upstream_outbound_options.f_outbound_transparent = flag;
 }
 
-ProxySession *
-ProxyTransaction::get_proxy_ssn()
-{
-  return _proxy_ssn;
-}
-
-void
-ProxyTransaction::set_proxy_ssn(ProxySession *new_proxy_ssn)
-{
-  _proxy_ssn = new_proxy_ssn;
-}
-
 void
 ProxyTransaction::set_h2c_upgrade_flag()
 {
-}
-
-Http1ServerSession *
-ProxyTransaction::get_server_session() const
-{
-  return _proxy_ssn ? _proxy_ssn->get_server_session() : nullptr;
-}
-
-HttpSM *
-ProxyTransaction::get_sm() const
-{
-  return _sm;
-}
-
-const char *
-ProxyTransaction::get_protocol_string()
-{
-  return _proxy_ssn ? _proxy_ssn->get_protocol_string() : nullptr;
-}
-
-int
-ProxyTransaction::populate_protocol(std::string_view *result, int size) const
-{
-  return _proxy_ssn ? _proxy_ssn->populate_protocol(result, size) : 0;
-}
-
-const char *
-ProxyTransaction::protocol_contains(std::string_view tag_prefix) const
-{
-  return _proxy_ssn ? _proxy_ssn->protocol_contains(tag_prefix) : nullptr;
 }

--- a/proxy/ProxyTransaction.h
+++ b/proxy/ProxyTransaction.h
@@ -73,14 +73,11 @@ public:
   virtual void set_proxy_ssn(ProxySession *set_proxy_ssn);
   virtual void set_h2c_upgrade_flag();
 
-  virtual const char *get_protocol_string();
-
-  virtual int populate_protocol(std::string_view *result, int size) const;
-
-  virtual const char *protocol_contains(std::string_view tag_prefix) const;
-
   /// Non-Virtual Methods
   //
+  const char *get_protocol_string();
+  int populate_protocol(std::string_view *result, int size) const;
+  const char *protocol_contains(std::string_view tag_prefix) const;
 
   /// Non-Virtual Accessors
   //
@@ -119,3 +116,98 @@ protected:
 
 private:
 };
+
+////////////////////////////////////////////////////////////
+// INLINE
+
+inline bool
+ProxyTransaction::is_transparent_passthrough_allowed()
+{
+  return upstream_outbound_options.f_transparent_passthrough;
+}
+inline bool
+ProxyTransaction::is_chunked_encoding_supported() const
+{
+  return _proxy_ssn ? _proxy_ssn->is_chunked_encoding_supported() : false;
+}
+inline void
+ProxyTransaction::set_half_close_flag(bool flag)
+{
+  if (_proxy_ssn) {
+    _proxy_ssn->set_half_close_flag(flag);
+  }
+}
+
+inline bool
+ProxyTransaction::get_half_close_flag() const
+{
+  return _proxy_ssn ? _proxy_ssn->get_half_close_flag() : false;
+}
+
+// What are the debug and hooks_enabled used for?  How are they set?
+// Just calling through to proxy session for now
+inline bool
+ProxyTransaction::debug() const
+{
+  return _proxy_ssn ? _proxy_ssn->debug() : false;
+}
+
+inline APIHook *
+ProxyTransaction::hook_get(TSHttpHookID id) const
+{
+  return _proxy_ssn ? _proxy_ssn->hook_get(id) : nullptr;
+}
+
+inline HttpAPIHooks const *
+ProxyTransaction::feature_hooks() const
+{
+  return _proxy_ssn ? _proxy_ssn->feature_hooks() : nullptr;
+}
+
+inline bool
+ProxyTransaction::has_hooks() const
+{
+  return _proxy_ssn->has_hooks();
+}
+
+inline ProxySession *
+ProxyTransaction::get_proxy_ssn()
+{
+  return _proxy_ssn;
+}
+
+inline void
+ProxyTransaction::set_proxy_ssn(ProxySession *new_proxy_ssn)
+{
+  _proxy_ssn = new_proxy_ssn;
+}
+
+inline Http1ServerSession *
+ProxyTransaction::get_server_session() const
+{
+  return _proxy_ssn ? _proxy_ssn->get_server_session() : nullptr;
+}
+
+inline HttpSM *
+ProxyTransaction::get_sm() const
+{
+  return _sm;
+}
+
+inline const char *
+ProxyTransaction::get_protocol_string()
+{
+  return _proxy_ssn ? _proxy_ssn->get_protocol_string() : nullptr;
+}
+
+inline int
+ProxyTransaction::populate_protocol(std::string_view *result, int size) const
+{
+  return _proxy_ssn ? _proxy_ssn->populate_protocol(result, size) : 0;
+}
+
+inline const char *
+ProxyTransaction::protocol_contains(std::string_view tag_prefix) const
+{
+  return _proxy_ssn ? _proxy_ssn->protocol_contains(tag_prefix) : nullptr;
+}

--- a/proxy/http/Http1ServerSession.cc
+++ b/proxy/http/Http1ServerSession.cc
@@ -204,12 +204,6 @@ Http1ServerSession::release()
   }
 }
 
-IOBufferReader *
-Http1ServerSession::get_reader()
-{
-  return buf_reader;
-};
-
 NetVConnection *
 Http1ServerSession::get_netvc() const
 {

--- a/proxy/http/Http1ServerSession.h
+++ b/proxy/http/Http1ServerSession.h
@@ -163,7 +163,8 @@ private:
 
 extern ClassAllocator<Http1ServerSession> httpServerSessionAllocator;
 
-// --- Implementation ---
+////////////////////////////////////////////
+// INLINE
 
 inline void
 Http1ServerSession::attach_hostname(const char *hostname)
@@ -172,6 +173,15 @@ Http1ServerSession::attach_hostname(const char *hostname)
     CryptoContext().hash_immediate(hostname_hash, (unsigned char *)hostname, strlen(hostname));
   }
 }
+
+inline IOBufferReader *
+Http1ServerSession::get_reader()
+{
+  return buf_reader;
+};
+
+//
+// LINKAGE
 
 inline Http1ServerSession *&
 Http1ServerSession::IPLinkage::next_ptr(self_type *ssn)

--- a/proxy/http/Http1Transaction.cc
+++ b/proxy/http/Http1Transaction.cc
@@ -114,12 +114,6 @@ Http1Transaction::do_io_shutdown(ShutdownHowTo_t howto)
 }
 
 void
-Http1Transaction::set_reader(IOBufferReader *reader)
-{
-  _reader = reader;
-}
-
-void
 Http1Transaction::set_active_timeout(ink_hrtime timeout_in)
 {
   if (_proxy_ssn)

--- a/proxy/http/Http1Transaction.h
+++ b/proxy/http/Http1Transaction.h
@@ -64,3 +64,12 @@ public:
 protected:
   bool outbound_transparent{false};
 };
+
+//////////////////////////////////
+// INLINE
+
+inline void
+Http1Transaction::set_reader(IOBufferReader *reader)
+{
+  _reader = reader;
+}

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -650,12 +650,6 @@ Http2ClientSession::_should_do_something_else()
   return (this->_n_frame_read & 0x7F) == 0;
 }
 
-bool
-Http2ClientSession::ready_to_free() const
-{
-  return kill_me;
-}
-
 NetVConnection *
 Http2ClientSession::get_netvc() const
 {
@@ -679,12 +673,6 @@ Http2ClientSession::write_reenable()
   write_vio->reenable();
 }
 
-const Http2UpgradeContext &
-Http2ClientSession::get_upgrade_context() const
-{
-  return upgrade_context;
-}
-
 int
 Http2ClientSession::get_transact_count() const
 {
@@ -694,24 +682,6 @@ Http2ClientSession::get_transact_count() const
 void
 Http2ClientSession::release(ProxyTransaction *trans)
 {
-}
-
-void
-Http2ClientSession::set_dying_event(int event)
-{
-  dying_event = event;
-}
-
-int
-Http2ClientSession::get_dying_event() const
-{
-  return dying_event;
-}
-
-bool
-Http2ClientSession::is_recursing() const
-{
-  return recursion > 0;
 }
 
 const char *
@@ -746,28 +716,10 @@ Http2ClientSession::protocol_contains(std::string_view prefix) const
   return retval;
 }
 
-bool
-Http2ClientSession::get_half_close_local_flag() const
-{
-  return half_close_local;
-}
-
-bool
-Http2ClientSession::is_url_pushed(const char *url, int url_len)
-{
-  return h2_pushed_urls.find(url) != h2_pushed_urls.end();
-}
-
 void
 Http2ClientSession::add_url_to_pushed_table(const char *url, int url_len)
 {
   if (h2_pushed_urls.size() < Http2::push_diary_size) {
     h2_pushed_urls.emplace(url);
   }
-}
-
-int64_t
-Http2ClientSession::write_buffer_size()
-{
-  return write_buffer->max_read_avail();
 }

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -267,3 +267,54 @@ private:
 };
 
 extern ClassAllocator<Http2ClientSession> http2ClientSessionAllocator;
+
+///////////////////////////////////////////////
+// INLINE
+
+inline const Http2UpgradeContext &
+Http2ClientSession::get_upgrade_context() const
+{
+  return upgrade_context;
+}
+
+inline bool
+Http2ClientSession::ready_to_free() const
+{
+  return kill_me;
+}
+
+inline void
+Http2ClientSession::set_dying_event(int event)
+{
+  dying_event = event;
+}
+
+inline int
+Http2ClientSession::get_dying_event() const
+{
+  return dying_event;
+}
+
+inline bool
+Http2ClientSession::is_recursing() const
+{
+  return recursion > 0;
+}
+
+inline bool
+Http2ClientSession::get_half_close_local_flag() const
+{
+  return half_close_local;
+}
+
+inline bool
+Http2ClientSession::is_url_pushed(const char *url, int url_len)
+{
+  return h2_pushed_urls.find(url) != h2_pushed_urls.end();
+}
+
+inline int64_t
+Http2ClientSession::write_buffer_size()
+{
+  return write_buffer->max_read_avail();
+}

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -1017,12 +1017,6 @@ Http2Stream::decrement_server_rwnd(size_t amount)
   }
 }
 
-void
-Http2Stream::mark_milestone(Http2StreamMilestone type)
-{
-  this->_milestones.mark(type);
-}
-
 bool
 Http2Stream::_switch_thread_if_not_on_right_thread(int event, void *edata)
 {
@@ -1037,12 +1031,6 @@ Http2Stream::_switch_thread_if_not_on_right_thread(int event, void *edata)
   return true;
 }
 
-bool
-Http2Stream::is_body_done() const
-{
-  return body_done;
-}
-
 void
 Http2Stream::mark_body_done()
 {
@@ -1052,91 +1040,4 @@ Http2Stream::mark_body_done()
                chunked_handler.state == ChunkedHandler::CHUNK_READ_ERROR);
     this->write_vio.nbytes = response_header.length_get() + chunked_handler.dechunked_size;
   }
-}
-
-void
-Http2Stream::update_sent_count(unsigned num_bytes)
-{
-  bytes_sent += num_bytes;
-  this->write_vio.ndone += num_bytes;
-}
-
-Http2StreamId
-Http2Stream::get_id() const
-{
-  return _id;
-}
-
-int
-Http2Stream::get_transaction_id() const
-{
-  return _id;
-}
-
-Http2StreamState
-Http2Stream::get_state() const
-{
-  return _state;
-}
-
-void
-Http2Stream::update_initial_rwnd(Http2WindowSize new_size)
-{
-  this->_client_rwnd = new_size;
-}
-
-bool
-Http2Stream::has_trailing_header() const
-{
-  return trailing_header;
-}
-
-void
-Http2Stream::set_request_headers(HTTPHdr &h2_headers)
-{
-  _req_header.copy(&h2_headers);
-}
-
-// Check entire DATA payload length if content-length: header is exist
-void
-Http2Stream::increment_data_length(uint64_t length)
-{
-  data_length += length;
-}
-
-bool
-Http2Stream::payload_length_is_valid() const
-{
-  uint32_t content_length = _req_header.get_content_length();
-  return content_length == 0 || content_length == data_length;
-}
-
-bool
-Http2Stream::response_is_chunked() const
-{
-  return chunked;
-}
-
-bool
-Http2Stream::allow_half_open() const
-{
-  return false;
-}
-
-bool
-Http2Stream::is_client_state_writeable() const
-{
-  return _state == Http2StreamState::HTTP2_STREAM_STATE_OPEN || _state == Http2StreamState::HTTP2_STREAM_STATE_HALF_CLOSED_REMOTE ||
-         _state == Http2StreamState::HTTP2_STREAM_STATE_RESERVED_LOCAL;
-}
-bool
-Http2Stream::is_closed() const
-{
-  return closed;
-}
-
-bool
-Http2Stream::is_first_transaction() const
-{
-  return is_first_transaction_flag;
 }

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -223,3 +223,106 @@ private:
 };
 
 extern ClassAllocator<Http2Stream> http2StreamAllocator;
+
+////////////////////////////////////////////////////
+// INLINE
+
+inline void
+Http2Stream::mark_milestone(Http2StreamMilestone type)
+{
+  this->_milestones.mark(type);
+}
+
+inline bool
+Http2Stream::is_body_done() const
+{
+  return body_done;
+}
+
+inline void
+Http2Stream::update_sent_count(unsigned num_bytes)
+{
+  bytes_sent += num_bytes;
+  this->write_vio.ndone += num_bytes;
+}
+
+inline Http2StreamId
+Http2Stream::get_id() const
+{
+  return _id;
+}
+
+inline int
+Http2Stream::get_transaction_id() const
+{
+  return _id;
+}
+
+inline Http2StreamState
+Http2Stream::get_state() const
+{
+  return _state;
+}
+
+inline void
+Http2Stream::update_initial_rwnd(Http2WindowSize new_size)
+{
+  this->_client_rwnd = new_size;
+}
+
+inline bool
+Http2Stream::has_trailing_header() const
+{
+  return trailing_header;
+}
+
+inline void
+Http2Stream::set_request_headers(HTTPHdr &h2_headers)
+{
+  _req_header.copy(&h2_headers);
+}
+
+inline // Check entire DATA payload length if content-length: header is exist
+  void
+  Http2Stream::increment_data_length(uint64_t length)
+{
+  data_length += length;
+}
+
+inline bool
+Http2Stream::payload_length_is_valid() const
+{
+  uint32_t content_length = _req_header.get_content_length();
+  return content_length == 0 || content_length == data_length;
+}
+
+inline bool
+Http2Stream::response_is_chunked() const
+{
+  return chunked;
+}
+
+inline bool
+Http2Stream::allow_half_open() const
+{
+  return false;
+}
+
+inline bool
+Http2Stream::is_client_state_writeable() const
+{
+  return _state == Http2StreamState::HTTP2_STREAM_STATE_OPEN || _state == Http2StreamState::HTTP2_STREAM_STATE_HALF_CLOSED_REMOTE ||
+         _state == Http2StreamState::HTTP2_STREAM_STATE_RESERVED_LOCAL;
+}
+
+inline bool
+Http2Stream::is_closed() const
+{
+  return closed;
+}
+
+inline bool
+Http2Stream::is_first_transaction() const
+{
+  return is_first_transaction_flag;
+}


### PR DESCRIPTION
@shinrich request we move non-virtual, one-liner functions to the .h with "inline" keyword.