### PR TITLE
Update documentation for connect_attempts_timeout.

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -1528,8 +1528,8 @@ Origin Server Connect Attempts
    :reloadable:
    :overridable:
 
-   The timeout value (in seconds) for time to first byte for an origin server
-   connection.
+   The timeout value (in seconds) for time to set up a connection to the origin. After the connection is established the value of
+   ``proxy.config.http.transaction_no_activity_timeout_out`` is used to established timeouts on the data over the connection.
 
    See :ref:`admin-performance-timeouts` for more discussion on |TS| timeouts.
 

--- a/doc/admin-guide/performance/index.en.rst
+++ b/doc/admin-guide/performance/index.en.rst
@@ -327,7 +327,9 @@ Origin Connection Timeouts
 Origin server connection timeouts are configured with :ts:cv:`proxy.config.http.connect_attempts_timeout`,
 which is applied both to the initial connection as well as any retries attempted,
 should an attempt timeout. The timeout applies from the moment |TS| begins the
-connection attempt until the origin returns the first byte.
+connection attempt until the origin fully establishes a connection (the connection is ready to write).
+After the connection is established the value of
+:ts:cv:`proxy.config.http.transaction_no_activity_timeout_out` is used to established timeouts on the data over the connection.
 
 In the case where you wish to have a different (generally longer) timeout for
 ``POST`` and ``PUT`` connections to an origin server, you may also adjust


### PR DESCRIPTION
In discussions on the ASF channel @jvgutierrez pointed out at the docs to not match reality for this setting at least for master and 9.x.   Not sure how much this fix got back ported.