### PR TITLE
Make compress plugin normalization of Accept-Encoding header compatible with normalization in core TS.

### DIFF
--- a/tests/gold_tests/pluginTest/compress/compress.gold
+++ b/tests/gold_tests/pluginTest/compress/compress.gold
@@ -1,5 +1,5 @@
 > GET http://ae-0/obj0 HTTP/1.1
-> X-Ats-Compress-Test: ts/0/gzip, deflate, sdch, br
+> X-Ats-Compress-Test: 0/gzip, deflate, sdch, br
 > Accept-Encoding: gzip, deflate, sdch, br
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
@@ -8,7 +8,7 @@
 < Content-Length: 46
 
 > GET http://ae-0/obj0 HTTP/1.1
-> X-Ats-Compress-Test: ts/0/gzip
+> X-Ats-Compress-Test: 0/gzip
 > Accept-Encoding: gzip
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
@@ -17,7 +17,7 @@
 < Content-Length: 71
 
 > GET http://ae-0/obj0 HTTP/1.1
-> X-Ats-Compress-Test: ts/0/br
+> X-Ats-Compress-Test: 0/br
 > Accept-Encoding: br
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
@@ -26,14 +26,14 @@
 < Content-Length: 46
 
 > GET http://ae-0/obj0 HTTP/1.1
-> X-Ats-Compress-Test: ts/0/deflate
+> X-Ats-Compress-Test: 0/deflate
 > Accept-Encoding: deflate
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
 < Content-Length: 1049
 
 > GET http://ae-1/obj1 HTTP/1.1
-> X-Ats-Compress-Test: ts/1/gzip, deflate, sdch, br
+> X-Ats-Compress-Test: 1/gzip, deflate, sdch, br
 > Accept-Encoding: gzip, deflate, sdch, br
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
@@ -42,7 +42,7 @@
 < Content-Length: 71
 
 > GET http://ae-1/obj1 HTTP/1.1
-> X-Ats-Compress-Test: ts/1/gzip
+> X-Ats-Compress-Test: 1/gzip
 > Accept-Encoding: gzip
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
@@ -51,21 +51,21 @@
 < Content-Length: 71
 
 > GET http://ae-1/obj1 HTTP/1.1
-> X-Ats-Compress-Test: ts/1/br
+> X-Ats-Compress-Test: 1/br
 > Accept-Encoding: br
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
 < Content-Length: 1049
 
 > GET http://ae-1/obj1 HTTP/1.1
-> X-Ats-Compress-Test: ts/1/deflate
+> X-Ats-Compress-Test: 1/deflate
 > Accept-Encoding: deflate
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
 < Content-Length: 1049
 
 > GET http://ae-2/obj2 HTTP/1.1
-> X-Ats-Compress-Test: ts/2/gzip, deflate, sdch, br
+> X-Ats-Compress-Test: 2/gzip, deflate, sdch, br
 > Accept-Encoding: gzip, deflate, sdch, br
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
@@ -74,7 +74,7 @@
 < Content-Length: 46
 
 > GET http://ae-2/obj2 HTTP/1.1
-> X-Ats-Compress-Test: ts/2/gzip
+> X-Ats-Compress-Test: 2/gzip
 > Accept-Encoding: gzip
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
@@ -83,7 +83,7 @@
 < Content-Length: 71
 
 > GET http://ae-2/obj2 HTTP/1.1
-> X-Ats-Compress-Test: ts/2/br
+> X-Ats-Compress-Test: 2/br
 > Accept-Encoding: br
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
@@ -92,15 +92,15 @@
 < Content-Length: 46
 
 > GET http://ae-2/obj2 HTTP/1.1
-> X-Ats-Compress-Test: ts/2/deflate
+> X-Ats-Compress-Test: 2/deflate
 > Accept-Encoding: deflate
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
 < Content-Length: 1049
 
 > GET http://ae-0/obj0 HTTP/1.1
-> X-Ats-Compress-Test: ts2/0/gzip
-> Accept-Encoding: gzip
+> X-Ats-Compress-Test: 0/gzip;q=0.666
+> Accept-Encoding: gzip;q=0.666
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
 < Content-Encoding: gzip
@@ -108,8 +108,8 @@
 < Content-Length: 71
 
 > GET http://ae-0/obj0 HTTP/1.1
-> X-Ats-Compress-Test: ts2/0/gzip
-> Accept-Encoding: gzip
+> X-Ats-Compress-Test: 0/gzip;q=0.666x
+> Accept-Encoding: gzip;q=0.666x
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
 < Content-Encoding: gzip
@@ -117,8 +117,51 @@
 < Content-Length: 71
 
 > GET http://ae-0/obj0 HTTP/1.1
-> X-Ats-Compress-Test: ts2/0/br
-> Accept-Encoding: br
+> X-Ats-Compress-Test: 0/gzip;q=#0.666
+> Accept-Encoding: gzip;q=#0.666
+< HTTP/1.1 200 OK
+< Content-Type: text/javascript
+< Content-Encoding: gzip
+< Vary: Accept-Encoding
+< Content-Length: 71
+
+> GET http://ae-0/obj0 HTTP/1.1
+> X-Ats-Compress-Test: 0/gzip; Q = 0.666
+> Accept-Encoding: gzip; Q = 0.666
+< HTTP/1.1 200 OK
+< Content-Type: text/javascript
+< Content-Encoding: gzip
+< Vary: Accept-Encoding
+< Content-Length: 71
+
+> GET http://ae-0/obj0 HTTP/1.1
+> X-Ats-Compress-Test: 0/gzip;q=0.0
+> Accept-Encoding: gzip;q=0.0
+< HTTP/1.1 200 OK
+< Content-Type: text/javascript
+< Content-Length: 1049
+
+> GET http://ae-0/obj0 HTTP/1.1
+> X-Ats-Compress-Test: 0/gzip;q=-0.1
+> Accept-Encoding: gzip;q=-0.1
+< HTTP/1.1 200 OK
+< Content-Type: text/javascript
+< Content-Encoding: gzip
+< Vary: Accept-Encoding
+< Content-Length: 71
+
+> GET http://ae-0/obj0 HTTP/1.1
+> X-Ats-Compress-Test: 0/aaa, gzip;q=0.666, bbb
+> Accept-Encoding: aaa, gzip;q=0.666, bbb
+< HTTP/1.1 200 OK
+< Content-Type: text/javascript
+< Content-Encoding: gzip
+< Vary: Accept-Encoding
+< Content-Length: 71
+
+> GET http://ae-0/obj0 HTTP/1.1
+> X-Ats-Compress-Test: 0/ br ; q=0.666, bbb
+> Accept-Encoding:  br ; q=0.666, bbb
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
 < Content-Encoding: br
@@ -126,171 +169,11 @@
 < Content-Length: 46
 
 > GET http://ae-0/obj0 HTTP/1.1
-> X-Ats-Compress-Test: ts2/0/deflate
-> Accept-Encoding: deflate
-< HTTP/1.1 200 OK
-< Content-Type: text/javascript
-< Content-Length: 1049
-
-> GET http://ae-1/obj1 HTTP/1.1
-> X-Ats-Compress-Test: ts2/1/gzip
-> Accept-Encoding: gzip
+> X-Ats-Compress-Test: 0/aaa, gzip;q=0.666 , 
+> Accept-Encoding: aaa, gzip;q=0.666 , 
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
 < Content-Length: 71
-
-> GET http://ae-1/obj1 HTTP/1.1
-> X-Ats-Compress-Test: ts2/1/gzip
-> Accept-Encoding: gzip
-< HTTP/1.1 200 OK
-< Content-Type: text/javascript
-< Content-Encoding: gzip
-< Vary: Accept-Encoding
-< Content-Length: 71
-
-> GET http://ae-1/obj1 HTTP/1.1
-> X-Ats-Compress-Test: ts2/1/br
-> Accept-Encoding: br
-< HTTP/1.1 200 OK
-< Content-Type: text/javascript
-< Content-Length: 1049
-
-> GET http://ae-1/obj1 HTTP/1.1
-> X-Ats-Compress-Test: ts2/1/deflate
-> Accept-Encoding: deflate
-< HTTP/1.1 200 OK
-< Content-Type: text/javascript
-< Content-Length: 1049
-
-> GET http://ae-2/obj2 HTTP/1.1
-> X-Ats-Compress-Test: ts2/2/gzip
-> Accept-Encoding: gzip
-< HTTP/1.1 200 OK
-< Content-Type: text/javascript
-< Content-Encoding: gzip
-< Vary: Accept-Encoding
-< Content-Length: 71
-
-> GET http://ae-2/obj2 HTTP/1.1
-> X-Ats-Compress-Test: ts2/2/gzip
-> Accept-Encoding: gzip
-< HTTP/1.1 200 OK
-< Content-Type: text/javascript
-< Content-Encoding: gzip
-< Vary: Accept-Encoding
-< Content-Length: 71
-
-> GET http://ae-2/obj2 HTTP/1.1
-> X-Ats-Compress-Test: ts2/2/br
-> Accept-Encoding: br
-< HTTP/1.1 200 OK
-< Content-Type: text/javascript
-< Content-Encoding: br
-< Vary: Accept-Encoding
-< Content-Length: 46
-
-> GET http://ae-2/obj2 HTTP/1.1
-> X-Ats-Compress-Test: ts2/2/deflate
-> Accept-Encoding: deflate
-< HTTP/1.1 200 OK
-< Content-Type: text/javascript
-< Content-Length: 1049
-
-> GET http://ae-0/obj0 HTTP/1.1
-> X-Ats-Compress-Test: ts3/0/deflate
-> Accept-Encoding: deflate
-< HTTP/1.1 200 OK
-< Content-Type: text/javascript
-< Content-Length: 1049
-
-> GET http://ae-0/obj0 HTTP/1.1
-> X-Ats-Compress-Test: ts3/0/gzip
-> Accept-Encoding: gzip
-< HTTP/1.1 200 OK
-< Content-Type: text/javascript
-< Content-Encoding: gzip
-< Vary: Accept-Encoding
-< Content-Length: 71
-
-> GET http://ae-0/obj0 HTTP/1.1
-> X-Ats-Compress-Test: ts3/0/br
-> Accept-Encoding: br
-< HTTP/1.1 200 OK
-< Content-Type: text/javascript
-< Content-Encoding: br
-< Vary: Accept-Encoding
-< Content-Length: 46
-
-> GET http://ae-0/obj0 HTTP/1.1
-> X-Ats-Compress-Test: ts3/0/deflate
-> Accept-Encoding: deflate
-< HTTP/1.1 200 OK
-< Content-Type: text/javascript
-< Content-Length: 1049
-
-> GET http://ae-1/obj1 HTTP/1.1
-> X-Ats-Compress-Test: ts3/1/deflate
-> Accept-Encoding: deflate
-< HTTP/1.1 200 OK
-< Content-Type: text/javascript
-< Content-Length: 1049
-
-> GET http://ae-1/obj1 HTTP/1.1
-> X-Ats-Compress-Test: ts3/1/gzip
-> Accept-Encoding: gzip
-< HTTP/1.1 200 OK
-< Content-Type: text/javascript
-< Content-Encoding: gzip
-< Vary: Accept-Encoding
-< Content-Length: 71
-
-> GET http://ae-1/obj1 HTTP/1.1
-> X-Ats-Compress-Test: ts3/1/br
-> Accept-Encoding: br
-< HTTP/1.1 200 OK
-< Content-Type: text/javascript
-< Content-Encoding: br
-< Vary: Accept-Encoding
-< Content-Length: 46
-
-> GET http://ae-1/obj1 HTTP/1.1
-> X-Ats-Compress-Test: ts3/1/deflate
-> Accept-Encoding: deflate
-< HTTP/1.1 200 OK
-< Content-Type: text/javascript
-< Content-Length: 1049
-
-> GET http://ae-2/obj2 HTTP/1.1
-> X-Ats-Compress-Test: ts3/2/deflate
-> Accept-Encoding: deflate
-< HTTP/1.1 200 OK
-< Content-Type: text/javascript
-< Content-Length: 1049
-
-> GET http://ae-2/obj2 HTTP/1.1
-> X-Ats-Compress-Test: ts3/2/gzip
-> Accept-Encoding: gzip
-< HTTP/1.1 200 OK
-< Content-Type: text/javascript
-< Content-Encoding: gzip
-< Vary: Accept-Encoding
-< Content-Length: 71
-
-> GET http://ae-2/obj2 HTTP/1.1
-> X-Ats-Compress-Test: ts3/2/br
-> Accept-Encoding: br
-< HTTP/1.1 200 OK
-< Content-Type: text/javascript
-< Content-Encoding: br
-< Vary: Accept-Encoding
-< Content-Length: 46
-
-> GET http://ae-2/obj2 HTTP/1.1
-> X-Ats-Compress-Test: ts3/2/deflate
-> Accept-Encoding: deflate
-< HTTP/1.1 200 OK
-< Content-Type: text/javascript
-< Content-Length: 1049
 

--- a/tests/gold_tests/pluginTest/compress/compress.test.py
+++ b/tests/gold_tests/pluginTest/compress/compress.test.py
@@ -32,7 +32,6 @@ Test.SkipUnless(
     Condition.HasATSFeature('TS_HAS_BROTLI')
 )
 
-
 server = Test.MakeOriginServer("server", options={'--load': '{}/compress_observer.py'.format(Test.TestDirectory)})
 
 def repeat(str, count):
@@ -64,71 +63,103 @@ for i in range(3):
     }
     server.addResponse("sessionfile.log", request_header, response_header)
 
-def curl(ts, name, idx, encodingList):
+def curl(ts, idx, encodingList):
     return (
         "curl --verbose --proxy http://127.0.0.1:{}".format(ts.Variables.port) +
-        " --header 'X-Ats-Compress-Test: {}/{}/{}'".format(name, idx, encodingList) +
+        " --header 'X-Ats-Compress-Test: {}/{}'".format(idx, encodingList) +
         " --header 'Accept-Encoding: {0}' 'http://ae-{1}/obj{1}'".format(encodingList, idx) +
         " >> {0}/compress_long.log 2>&1 ; printf '\n\n' >> {0}/compress_long.log".format(Test.RunDirectory)
     )
 
-def oneTs(name, AeHdr1='gzip, deflate, sdch, br'):
-    global waitForServer
-
-    waitForTs = True
-
-    ts = Test.MakeATSProcess(name)
-
-    ts.Disk.records_config.update({
-        'proxy.config.diags.debug.enabled': 0,
-        'proxy.config.diags.debug.tags': 'http|compress|cache',
-        'proxy.config.http.normalize_ae': 0,
-    })
-
-    ts.Disk.remap_config.AddLine(
-        'map http://ae-0/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
-        ' @plugin=compress.so @pparam={}/compress.config'.format(Test.TestDirectory)
-    )
-    ts.Disk.remap_config.AddLine(
-        'map http://ae-1/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
-        ' @plugin=conf_remap.so @pparam=proxy.config.http.normalize_ae=1' +
-        ' @plugin=compress.so @pparam={}/compress.config'.format(Test.TestDirectory)
-    )
-    ts.Disk.remap_config.AddLine(
-        'map http://ae-2/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
-        ' @plugin=conf_remap.so @pparam=proxy.config.http.normalize_ae=2' +
-        ' @plugin=compress.so @pparam={}/compress2.config'.format(Test.TestDirectory)
-    )
-
-    for i in range(3):
-
-        tr = Test.AddTestRun()
-        if (waitForTs):
-            tr.Processes.Default.StartBefore(ts, ready=When.PortOpen(ts.Variables.port))
-        waitForTs = False
-        if (waitForServer):
-            tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Port))
-        waitForServer = False
-        tr.Processes.Default.ReturnCode = 0
-        tr.Processes.Default.Command = curl(ts, name, i, AeHdr1)
-
-        tr = Test.AddTestRun()
-        tr.Processes.Default.ReturnCode = 0
-        tr.Processes.Default.Command = curl(ts, name, i, "gzip")
-
-        tr = Test.AddTestRun()
-        tr.Processes.Default.ReturnCode = 0
-        tr.Processes.Default.Command = curl(ts, name, i, "br")
-
-        tr = Test.AddTestRun()
-        tr.Processes.Default.ReturnCode = 0
-        tr.Processes.Default.Command = curl(ts, name, i, "deflate")
-
 waitForServer = True
 
-oneTs("ts")
-oneTs("ts2", "gzip")
-oneTs("ts3", "deflate")
+waitForTs = True
+
+ts = Test.MakeATSProcess("ts")
+
+ts.Disk.records_config.update({
+    'proxy.config.http.cache.http': 0,
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'compress',
+    'proxy.config.http.normalize_ae': 0,
+})
+
+ts.Disk.remap_config.AddLine(
+    'map http://ae-0/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
+    ' @plugin=compress.so @pparam={}/compress.config'.format(Test.TestDirectory)
+)
+ts.Disk.remap_config.AddLine(
+    'map http://ae-1/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
+    ' @plugin=conf_remap.so @pparam=proxy.config.http.normalize_ae=1' +
+    ' @plugin=compress.so @pparam={}/compress.config'.format(Test.TestDirectory)
+)
+ts.Disk.remap_config.AddLine(
+    'map http://ae-2/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
+    ' @plugin=conf_remap.so @pparam=proxy.config.http.normalize_ae=2' +
+    ' @plugin=compress.so @pparam={}/compress2.config'.format(Test.TestDirectory)
+)
+
+for i in range(3):
+
+    tr = Test.AddTestRun()
+    if (waitForTs):
+        tr.Processes.Default.StartBefore(ts, ready=When.PortOpen(ts.Variables.port))
+    waitForTs = False
+    if (waitForServer):
+        tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Port))
+    waitForServer = False
+    tr.Processes.Default.ReturnCode = 0
+    tr.Processes.Default.Command = curl(ts, i, 'gzip, deflate, sdch, br')
+
+    tr = Test.AddTestRun()
+    tr.Processes.Default.ReturnCode = 0
+    tr.Processes.Default.Command = curl(ts, i, "gzip")
+
+    tr = Test.AddTestRun()
+    tr.Processes.Default.ReturnCode = 0
+    tr.Processes.Default.Command = curl(ts, i, "br")
+
+    tr = Test.AddTestRun()
+    tr.Processes.Default.ReturnCode = 0
+    tr.Processes.Default.Command = curl(ts, i, "deflate")
+
+# Test Aceept-Encoding normalization.
+
+tr = Test.AddTestRun()
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Command = curl(ts, 0, "gzip;q=0.666")
+
+tr = Test.AddTestRun()
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Command = curl(ts, 0, "gzip;q=0.666x")
+
+tr = Test.AddTestRun()
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Command = curl(ts, 0, "gzip;q=#0.666")
+
+tr = Test.AddTestRun()
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Command = curl(ts, 0, "gzip; Q = 0.666")
+
+tr = Test.AddTestRun()
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Command = curl(ts, 0, "gzip;q=0.0")
+
+tr = Test.AddTestRun()
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Command = curl(ts, 0, "gzip;q=-0.1")
+
+tr = Test.AddTestRun()
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Command = curl(ts, 0, "aaa, gzip;q=0.666, bbb")
+
+tr = Test.AddTestRun()
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Command = curl(ts, 0, " br ; q=0.666, bbb")
+
+tr = Test.AddTestRun()
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Command = curl(ts, 0, "aaa, gzip;q=0.666 , ")
 
 tr = Test.AddTestRun()
 tr.Processes.Default.ReturnCode = 0
@@ -138,9 +169,7 @@ tr.Processes.Default.Command = (
 f = tr.Disk.File("compress_short.log")
 f.Content = "compress.gold"
 
-# Have to comment this out, because caching does not seem to be consistent, which is disturbing.
-#
-# tr = Test.AddTestRun()
-# tr.Processes.Default.Command = "echo"
-# f = tr.Disk.File("compress_userver.log")
-# f.Content = "compress_userver.gold"
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = "echo"
+f = tr.Disk.File("compress_userver.log")
+f.Content = "compress_userver.gold"

--- a/tests/gold_tests/pluginTest/compress/compress_userver.gold
+++ b/tests/gold_tests/pluginTest/compress/compress_userver.gold
@@ -1,0 +1,21 @@
+0/gzip, deflate, sdch, br
+0/gzip
+0/br
+0/deflate
+1/gzip, deflate, sdch, br
+1/gzip
+1/br
+1/deflate
+2/gzip, deflate, sdch, br
+2/gzip
+2/br
+2/deflate
+0/gzip;q=0.666
+0/gzip;q=0.666x
+0/gzip;q=#0.666
+0/gzip; Q = 0.666
+0/gzip;q=0.0
+0/gzip;q=-0.1
+0/aaa, gzip;q=0.666, bbb
+0/ br ; q=0.666, bbb
+0/aaa, gzip;q=0.666 , 


### PR DESCRIPTION
Specifically, remove parameters on values, but if there is a valid q parameter which is equal to 0.0, remove the associated value from the value list.