### PR TITLE
QUIC: Hidden more pp_key_info detail in QUICContext

### DIFF
--- a/iocore/net/quic/QUICContext.cc
+++ b/iocore/net/quic/QUICContext.cc
@@ -100,7 +100,8 @@ private:
   const QUICConfigParams *_params;
 };
 
-QUICContextImpl::QUICContextImpl(QUICRTTProvider *rtt, QUICConnectionInfoProvider *info, QUICPacketProtectionKeyInfo *key_info)
+QUICContextImpl::QUICContextImpl(QUICRTTProvider *rtt, QUICConnectionInfoProvider *info,
+                                 QUICPacketProtectionKeyInfoProvider *key_info)
   : _key_info(key_info),
     _connection_info(info),
     _rtt_provider(rtt),
@@ -121,7 +122,7 @@ QUICContextImpl::config() const
   return _config;
 }
 
-QUICPacketProtectionKeyInfo *
+QUICPacketProtectionKeyInfoProvider *
 QUICContextImpl::key_info() const
 {
   return _key_info;

--- a/iocore/net/quic/QUICContext.h
+++ b/iocore/net/quic/QUICContext.h
@@ -28,7 +28,7 @@
 
 class QUICRTTProvider;
 class QUICCongestionController;
-class QUICPacketProtectionKeyInfo;
+class QUICPacketProtectionKeyInfoProvider;
 
 class QUICNetVConnection;
 
@@ -43,9 +43,9 @@ class QUICLDContext
 {
 public:
   virtual ~QUICLDContext() {}
-  virtual QUICConnectionInfoProvider *connection_info() const = 0;
-  virtual QUICLDConfig &ld_config() const                     = 0;
-  virtual QUICPacketProtectionKeyInfo *key_info() const       = 0;
+  virtual QUICConnectionInfoProvider *connection_info() const   = 0;
+  virtual QUICLDConfig &ld_config() const                       = 0;
+  virtual QUICPacketProtectionKeyInfoProvider *key_info() const = 0;
 };
 
 class QUICCCContext
@@ -60,23 +60,23 @@ public:
 class QUICContextImpl : public QUICContext, public QUICCCContext, public QUICLDContext
 {
 public:
-  QUICContextImpl(QUICRTTProvider *rtt, QUICConnectionInfoProvider *info, QUICPacketProtectionKeyInfo *key_info);
+  QUICContextImpl(QUICRTTProvider *rtt, QUICConnectionInfoProvider *info, QUICPacketProtectionKeyInfoProvider *key_info);
 
   virtual QUICConnectionInfoProvider *connection_info() const override;
   virtual QUICConfig::scoped_config config() const override;
   virtual QUICRTTProvider *rtt_provider() const override;
 
   // TODO should be more abstract
-  virtual QUICPacketProtectionKeyInfo *key_info() const override;
+  virtual QUICPacketProtectionKeyInfoProvider *key_info() const override;
 
   virtual QUICLDConfig &ld_config() const override;
   virtual QUICCCConfig &cc_config() const override;
 
 private:
   QUICConfig::scoped_config _config;
-  QUICPacketProtectionKeyInfo *_key_info       = nullptr;
-  QUICConnectionInfoProvider *_connection_info = nullptr;
-  QUICRTTProvider *_rtt_provider               = nullptr;
+  QUICPacketProtectionKeyInfoProvider *_key_info = nullptr;
+  QUICConnectionInfoProvider *_connection_info   = nullptr;
+  QUICRTTProvider *_rtt_provider                 = nullptr;
 
   std::unique_ptr<QUICLDConfig> _ld_config = nullptr;
   std::unique_ptr<QUICCCConfig> _cc_config = nullptr;

--- a/iocore/net/quic/QUICPacketProtectionKeyInfo.h
+++ b/iocore/net/quic/QUICPacketProtectionKeyInfo.h
@@ -29,8 +29,31 @@
 class QUICPacketProtectionKeyInfoProvider
 {
 public:
+  virtual ~QUICPacketProtectionKeyInfoProvider() {}
+  // Payload Protection (common)
+  virtual const EVP_CIPHER *get_cipher(QUICKeyPhase phase) const = 0;
+  virtual size_t get_tag_len(QUICKeyPhase phase) const           = 0;
+
+  // Payload Protection (encryption)
   virtual bool is_encryption_key_available(QUICKeyPhase phase) const = 0;
+  virtual const uint8_t *encryption_key(QUICKeyPhase phase) const    = 0;
+  virtual size_t encryption_key_len(QUICKeyPhase phase) const        = 0;
+  virtual const uint8_t *encryption_iv(QUICKeyPhase phase) const     = 0;
+  virtual const size_t *encryption_iv_len(QUICKeyPhase phase) const  = 0;
+
+  // Payload Protection (decryption)
   virtual bool is_decryption_key_available(QUICKeyPhase phase) const = 0;
+  virtual const uint8_t *decryption_key(QUICKeyPhase phase) const    = 0;
+  virtual size_t decryption_key_len(QUICKeyPhase phase) const        = 0;
+  virtual const uint8_t *decryption_iv(QUICKeyPhase phase) const     = 0;
+  virtual const size_t *decryption_iv_len(QUICKeyPhase phase) const  = 0;
+
+  // Header Protection
+  virtual const EVP_CIPHER *get_cipher_for_hp(QUICKeyPhase phase) const  = 0;
+  virtual const uint8_t *encryption_key_for_hp(QUICKeyPhase phase) const = 0;
+  virtual size_t encryption_key_for_hp_len(QUICKeyPhase phase) const     = 0;
+  virtual const uint8_t *decryption_key_for_hp(QUICKeyPhase phase) const = 0;
+  virtual size_t decryption_key_for_hp_len(QUICKeyPhase phase) const     = 0;
 };
 
 class QUICPacketProtectionKeyInfo : public QUICPacketProtectionKeyInfoProvider
@@ -47,58 +70,58 @@ public:
 
   // Payload Protection (common)
 
-  virtual const EVP_CIPHER *get_cipher(QUICKeyPhase phase) const;
-  virtual size_t get_tag_len(QUICKeyPhase phase) const;
+  virtual const EVP_CIPHER *get_cipher(QUICKeyPhase phase) const override;
+  virtual size_t get_tag_len(QUICKeyPhase phase) const override;
   virtual void set_cipher_initial(const EVP_CIPHER *cipher);
   virtual void set_cipher(const EVP_CIPHER *cipher, size_t tag_len);
 
   // Payload Protection (encryption)
 
-  virtual bool is_encryption_key_available(QUICKeyPhase phase) const;
+  virtual bool is_encryption_key_available(QUICKeyPhase phase) const override;
   virtual void set_encryption_key_available(QUICKeyPhase phase);
 
-  virtual const uint8_t *encryption_key(QUICKeyPhase phase) const;
+  virtual const uint8_t *encryption_key(QUICKeyPhase phase) const override;
   virtual uint8_t *encryption_key(QUICKeyPhase phase);
 
-  virtual size_t encryption_key_len(QUICKeyPhase phase) const;
+  virtual size_t encryption_key_len(QUICKeyPhase phase) const override;
 
-  virtual const uint8_t *encryption_iv(QUICKeyPhase phase) const;
+  virtual const uint8_t *encryption_iv(QUICKeyPhase phase) const override;
   virtual uint8_t *encryption_iv(QUICKeyPhase phase);
 
-  virtual const size_t *encryption_iv_len(QUICKeyPhase phase) const;
+  virtual const size_t *encryption_iv_len(QUICKeyPhase phase) const override;
   virtual size_t *encryption_iv_len(QUICKeyPhase phase);
 
   // Payload Protection (decryption)
 
-  virtual bool is_decryption_key_available(QUICKeyPhase phase) const;
+  virtual bool is_decryption_key_available(QUICKeyPhase phase) const override;
   virtual void set_decryption_key_available(QUICKeyPhase phase);
 
-  virtual const uint8_t *decryption_key(QUICKeyPhase phase) const;
+  virtual const uint8_t *decryption_key(QUICKeyPhase phase) const override;
   virtual uint8_t *decryption_key(QUICKeyPhase phase);
 
-  virtual size_t decryption_key_len(QUICKeyPhase phase) const;
+  virtual size_t decryption_key_len(QUICKeyPhase phase) const override;
 
-  virtual const uint8_t *decryption_iv(QUICKeyPhase phase) const;
+  virtual const uint8_t *decryption_iv(QUICKeyPhase phase) const override;
   virtual uint8_t *decryption_iv(QUICKeyPhase phase);
 
-  virtual const size_t *decryption_iv_len(QUICKeyPhase phase) const;
+  virtual const size_t *decryption_iv_len(QUICKeyPhase phase) const override;
   virtual size_t *decryption_iv_len(QUICKeyPhase phase);
 
   // Header Protection
 
-  virtual const EVP_CIPHER *get_cipher_for_hp(QUICKeyPhase phase) const;
+  virtual const EVP_CIPHER *get_cipher_for_hp(QUICKeyPhase phase) const override;
   virtual void set_cipher_for_hp_initial(const EVP_CIPHER *cipher);
   virtual void set_cipher_for_hp(const EVP_CIPHER *cipher);
 
-  virtual const uint8_t *encryption_key_for_hp(QUICKeyPhase phase) const;
+  virtual const uint8_t *encryption_key_for_hp(QUICKeyPhase phase) const override;
   virtual uint8_t *encryption_key_for_hp(QUICKeyPhase phase);
 
-  virtual size_t encryption_key_for_hp_len(QUICKeyPhase phase) const;
+  virtual size_t encryption_key_for_hp_len(QUICKeyPhase phase) const override;
 
-  virtual const uint8_t *decryption_key_for_hp(QUICKeyPhase phase) const;
+  virtual const uint8_t *decryption_key_for_hp(QUICKeyPhase phase) const override;
   virtual uint8_t *decryption_key_for_hp(QUICKeyPhase phase);
 
-  virtual size_t decryption_key_for_hp_len(QUICKeyPhase phase) const;
+  virtual size_t decryption_key_for_hp_len(QUICKeyPhase phase) const override;
 
 private:
   Context _ctx = Context::SERVER;

--- a/iocore/net/quic/QUICPacketProtectionKeyInfo.h
+++ b/iocore/net/quic/QUICPacketProtectionKeyInfo.h
@@ -26,7 +26,14 @@
 #include "QUICTypes.h"
 #include "QUICKeyGenerator.h"
 
-class QUICPacketProtectionKeyInfo
+class QUICPacketProtectionKeyInfoProvider
+{
+public:
+  virtual bool is_encryption_key_available(QUICKeyPhase phase) const = 0;
+  virtual bool is_decryption_key_available(QUICKeyPhase phase) const = 0;
+};
+
+class QUICPacketProtectionKeyInfo : public QUICPacketProtectionKeyInfoProvider
 {
 public:
   enum class Context { SERVER, CLIENT };


### PR DESCRIPTION
It is not necessary to explore all pp_key_info to context. So hidden it into context.