### PR TITLE
Rearrange config reload notifications

### DIFF
--- a/build/plugins.mk
+++ b/build/plugins.mk
@@ -22,7 +22,7 @@ TS_PLUGIN_LD_FLAGS = \
   -module \
   -shared \
   -avoid-version \
-  -export-symbols-regex '^(TSRemapInit|TSRemapDone|TSRemapDoRemap|TSRemapNewInstance|TSRemapDeleteInstance|TSRemapOSResponse|TSPluginInit)$$'
+  -export-symbols-regex '^(TSRemapInit|TSRemapDone|TSRemapDoRemap|TSRemapNewInstance|TSRemapDeleteInstance|TSRemapOSResponse|TSPluginInit|TSRemapPreConfigReload|TSRemapPostConfigReload)$$'
 
 TS_PLUGIN_CPPFLAGS = \
   -I$(abs_top_builddir)/proxy/api \

--- a/doc/developer-guide/api/functions/TSRemap.en.rst
+++ b/doc/developer-guide/api/functions/TSRemap.en.rst
@@ -30,7 +30,8 @@ Synopsis
 `#include <ts/remap.h>`
 
 .. function:: TSReturnCode TSRemapInit(TSRemapInterface * api_info, char * errbuff, int errbuff_size)
-.. function:: void TSRemapConfigReload(void)
+.. function:: void TSRemapPreConfigReload(void)
+.. function:: void TSRemapPostConfigReload(TSReturnCode reloadStatus)
 .. function:: void TSRemapDone(void)
 .. function:: TSRemapStatus TSRemapDoRemap(void * ih, TSHttpTxn rh, TSRemapRequestInfo * rri)
 .. function:: TSReturnCode TSRemapNewInstance(int argc, char * argv[], void ** ih, char * errbuff, int errbuff_size)
@@ -65,9 +66,14 @@ any data or continuations associated with that instance.
 entry point. In this function, the remap plugin may examine and modify
 the HTTP transaction.
 
-:func:`TSRemapConfigReload` is called once for every remap plugin immediately after a new
-configuration is successfully loaded and immediately before the new remap configuration becomes
-active. This is an optional entry point, which takes no arguments and has no return value.
+:func:`TSRemapPreConfigReload` is called *before* the parsing of a new remap configuration starts
+to notify plugins of the coming configuration reload. It is called on all already loaded plugins,
+invoked by current and all previous still used configurations. This is an optional entry point.
+
+:func:`TSRemapPostConfigReload` is called to indicate the end of the the new remap configuration
+load. It is called on the newly and previously loaded plugins, invoked by the new, current and
+previous still used configurations. It also indicates if the configuration reload was successful
+by passing :macro:`TS_SUCCESS` or :macro:`TS_ERROR`. This is an optional entry point.
 
 Generally speaking, calls to these functions are mutually exclusive. The exception
 is for functions which take an HTTP transaction as a parameter. Calls to these

--- a/include/ts/remap.h
+++ b/include/ts/remap.h
@@ -88,13 +88,27 @@ typedef enum {
 */
 tsapi TSReturnCode TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size);
 
-/* This gets called every time remap.config is reloaded. This is complementary
-   to TSRemapInit() which gets called when the plugin is first loaded. You can
-   not fail, or cause reload to stop here, it's merely a notification.
+/* This gets called every time before remap.config is reloaded. This is complementary
+   to TSRemapInit() which gets called when the plugin is first loaded.
+   It is guaranteed to be called before TSRemapInit() and TSRemapNewInstance().
+   It cannot fail, or cause reload to stop here, it's merely a notification.
    Optional function.
+   Params: none
    Return: none
 */
-tsapi void TSRemapConfigReload(void);
+tsapi void TSRemapPreConfigReload(void);
+
+/* This gets called every time afterremap.config is reloaded. This is complementary
+   to TSRemapInit() which gets called when the plugin is first loaded.
+   It is guaranteed to be called after TSRemapInit() and TSRemapNewInstance().
+   It cannot fail, or cause reload to stop here, it's merely a notification that
+   the (re)load is done and provide a status of its success or failure..
+   Optional function.
+   Params: reloadStatus - TS_SUCCESS - (re)load was successful,
+                          TS_ERROR - (re)load failed.
+   Return: none
+*/
+tsapi void TSRemapPostConfigReload(TSReturnCode reloadStatus);
 
 /* Remap new request
    Mandatory interface function.

--- a/proxy/ReverseProxy.cc
+++ b/proxy/ReverseProxy.cc
@@ -151,7 +151,7 @@ reloadUrlRewrite()
     ink_assert(oldTable != nullptr);
 
     // Release the old one
-    oldTable->pluginFactory.indicateReload();
+    oldTable->pluginFactory.deactivate();
     oldTable->release();
 
     Debug("url_rewrite", "%s", msg);

--- a/proxy/http/remap/Makefile.am
+++ b/proxy/http/remap/Makefile.am
@@ -103,7 +103,7 @@ DSO_LDFLAGS = \
 	-module \
 	-shared \
 	-avoid-version \
-	-export-symbols-regex '^(TSRemapInit|TSRemapDone|TSRemapDoRemap|TSRemapNewInstance|TSRemapDeleteInstance|TSRemapOSResponse|TSRemapConfigReload|TSPluginInit|pluginDsoVersionTest|getPluginDebugObjectTest)$$'
+	-export-symbols-regex '^(TSRemapInit|TSRemapDone|TSRemapDoRemap|TSRemapNewInstance|TSRemapDeleteInstance|TSRemapOSResponse|TSRemapPreConfigReload|TSRemapPostConfigReload|TSPluginInit|pluginDsoVersionTest|getPluginDebugObjectTest)$$'
 
 # Build plugins for unit testing the plugin (re)load.
 pkglib_LTLIBRARIES = \

--- a/proxy/http/remap/PluginDso.h
+++ b/proxy/http/remap/PluginDso.h
@@ -33,6 +33,7 @@
 #include <vector>
 #include <ctime>
 
+#include "ts/apidefs.h"
 #include "tscore/ts_file.h"
 namespace fs = ts::file;
 
@@ -73,10 +74,11 @@ public:
   using Linkage    = ts::IntrusiveLinkage<self_type>;
   using PluginList = ts::IntrusiveDList<PluginDso::Linkage>;
 
-  /* Methods to be called when processing a list of plugins, to overloaded by the remap or the global plugins correspondingly */
-  virtual void indicateReload()         = 0;
-  virtual bool init(std::string &error) = 0;
-  virtual void done()                   = 0;
+  /* Methods to be called when processing a list of plugins, to be overloaded by the remap or the global plugins correspondingly */
+  virtual void indicatePreReload()                           = 0;
+  virtual void indicatePostReload(TSReturnCode reloadStatus) = 0;
+  virtual bool init(std::string &error)                      = 0;
+  virtual void done()                                        = 0;
 
   void acquire();
   void release();

--- a/proxy/http/remap/PluginFactory.h
+++ b/proxy/http/remap/PluginFactory.h
@@ -47,7 +47,7 @@ public:
   ~RemapPluginInst();
 
   /* Used by the PluginFactory */
-  bool init(int argc, char **argv, std::string &error);
+  static RemapPluginInst *init(RemapPluginInfo *plugin, int argc, char **argv, std::string &error);
   void done();
 
   /* Used by the traffic server core while processing requests */
@@ -100,7 +100,9 @@ public:
   virtual const char *getUuid();
   void clean(std::string &error);
 
-  void indicateReload();
+  void deactivate();
+  void indicatePreReload();
+  void indicatePostReload(TSReturnCode reloadStatus);
 
 protected:
   PluginDso *findByEffectivePath(const fs::path &path);

--- a/proxy/http/remap/RemapConfig.cc
+++ b/proxy/http/remap/RemapConfig.cc
@@ -1320,9 +1320,16 @@ remap_parse_config(const char *path, UrlRewrite *rewrite)
 {
   BUILD_TABLE_INFO bti;
 
-  // If this happens to be a config reload, the list of loaded remap plugins is non-empty, and we
-  // can signal all these plugins that a reload has begun.
-  rewrite->pluginFactory.indicateReload();
+  /* If this happens to be a config reload, the list of loaded remap plugins is non-empty, and we
+   * can signal all these plugins that a reload has begun. */
+  rewrite->pluginFactory.indicatePreReload();
+
   bti.rewrite = rewrite;
-  return remap_parse_config_bti(path, &bti);
+  bool status = remap_parse_config_bti(path, &bti);
+
+  /* Now after we parsed the configuration and (re)loaded plugins and plugin instances
+   * accordingly notify all plugins that we are done */
+  rewrite->pluginFactory.indicatePostReload(status ? TS_SUCCESS : TS_ERROR);
+
+  return status;
 }

--- a/proxy/http/remap/unit-tests/plugin_testing_calls.cc
+++ b/proxy/http/remap/unit-tests/plugin_testing_calls.cc
@@ -103,9 +103,16 @@ TSRemapOSResponse(void *ih, TSHttpTxn rh, int os_response_type)
 }
 
 void
-TSRemapConfigReload(void)
+TSRemapPreConfigReload(void)
 {
-  debugObject.reloadConfigCalled++;
+  debugObject.preReloadConfigCalled++;
+}
+
+void
+TSRemapPostConfigReload(TSReturnCode reloadStatus)
+{
+  debugObject.postReloadConfigCalled++;
+  debugObject.postReloadConfigSuccess = (TS_SUCCESS == reloadStatus);
 }
 
 /* The folowing functions are meant for unit testing */

--- a/proxy/http/remap/unit-tests/plugin_testing_common.h
+++ b/proxy/http/remap/unit-tests/plugin_testing_common.h
@@ -51,17 +51,19 @@ public:
   void
   clear()
   {
-    contextInit          = nullptr;
-    contextInitInstance  = nullptr;
-    doRemapCalled        = 0;
-    initCalled           = 0;
-    doneCalled           = 0;
-    initInstanceCalled   = 0;
-    deleteInstanceCalled = 0;
-    reloadConfigCalled   = 0;
-    ih                   = nullptr;
-    argc                 = 0;
-    argv                 = nullptr;
+    contextInit             = nullptr;
+    contextInitInstance     = nullptr;
+    doRemapCalled           = 0;
+    initCalled              = 0;
+    doneCalled              = 0;
+    initInstanceCalled      = 0;
+    deleteInstanceCalled    = 0;
+    preReloadConfigCalled   = 0;
+    postReloadConfigCalled  = 0;
+    postReloadConfigSuccess = 0;
+    ih                      = nullptr;
+    argc                    = 0;
+    argv                    = nullptr;
   }
 
   /* Input fields used to set the test behavior of the plugin call-backs */
@@ -76,7 +78,9 @@ public:
   int doneCalled                                 = 0;       /* mark if done was called */
   int initInstanceCalled                         = 0;       /* mark if instance init was called */
   int deleteInstanceCalled                       = 0;       /* mark if delete instance was called */
-  int reloadConfigCalled                         = 0;       /* mark if reload config was called */
+  int preReloadConfigCalled                      = 0;       /* mark if pre-reload config was called */
+  int postReloadConfigCalled                     = 0;       /* mark if post-reload config was called */
+  bool postReloadConfigSuccess                   = 0;       /* mark if plugin reload status is passed correctly */
   void *ih                                       = nullptr; /* instance handler */
   int argc                                       = 0;       /* number of plugin instance parameters received by the plugin */
   char **argv                                    = nullptr; /* plugin instance parameters received by the plugin */

--- a/proxy/http/remap/unit-tests/test_PluginDso.cc
+++ b/proxy/http/remap/unit-tests/test_PluginDso.cc
@@ -69,7 +69,11 @@ public:
   }
 
   virtual void
-  indicateReload()
+  indicatePreReload()
+  {
+  }
+  virtual void
+  indicatePostReload(TSReturnCode reloadStatus)
   {
   }
   virtual bool

--- a/proxy/http/remap/unit-tests/test_RemapPlugin.cc
+++ b/proxy/http/remap/unit-tests/test_RemapPlugin.cc
@@ -426,9 +426,14 @@ SCENARIO("config reload", "[plugin][core]")
     {
       debugObject->clear();
 
-      plugin->indicateReload();
+      plugin->indicatePreReload();
+      plugin->indicatePostReload(TS_SUCCESS);
 
-      THEN("expect it to run") { CHECK(1 == debugObject->reloadConfigCalled); }
+      THEN("expect it to run")
+      {
+        CHECK(1 == debugObject->preReloadConfigCalled);
+        CHECK(1 == debugObject->postReloadConfigCalled);
+      }
       cleanupSandBox(plugin);
     }
   }


### PR DESCRIPTION
Renamed `TSRemapConfigReload` to `TSRemapPreConfigReload` to notify
all already loaded plugins that a configuration (re)load is about to
start.

Added new `TSRemapPostConfigReload(TSReturnCode)` to notify the plugins
that the configuration (re)load is done and provide status of its
success or failure.