### PR TITLE
Make code buildable with BoringSSL

### DIFF
--- a/example/plugins/c-api/client_context_dump/client_context_dump.cc
+++ b/example/plugins/c-api/client_context_dump/client_context_dump.cc
@@ -116,7 +116,7 @@ dump_context(const char *ca_path, const char *ck_path)
 
         // Serial number
         int64_t sn = 0;
-#if OPENSSL_VERSION_NUMBER >= 0x010100000
+#if !defined(OPENSSL_IS_BORINGSSL) && (OPENSSL_VERSION_NUMBER >= 0x010100000)
         ASN1_INTEGER_get_int64(&sn, serial);
 #else
         sn = ASN1_INTEGER_get(serial);

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -309,12 +309,20 @@ public:
       return nullptr;
     }
 
+#ifndef OPENSSL_IS_BORINGSSL
     int curve_nid = SSL_get_shared_curve(ssl, 0);
 
     if (curve_nid == NID_undef) {
       return nullptr;
     }
     return OBJ_nid2sn(curve_nid);
+#else
+    if (uint16_t curve_id = SSL_get_curve_id(ssl); curve_id != 0) {
+      return SSL_get_curve_name(curve_id);
+    } else {
+      return nullptr;
+    }
+#endif
   }
 
   bool

--- a/plugins/experimental/cert_reporting_tool/cert_reporting_tool.cc
+++ b/plugins/experimental/cert_reporting_tool/cert_reporting_tool.cc
@@ -115,7 +115,7 @@ dump_context(const char *ca_path, const char *ck_path)
 
         // Serial number
         int64_t sn = 0;
-#if OPENSSL_VERSION_NUMBER >= 0x010100000
+#if !defined(OPENSSL_IS_BORINGSSL) && (OPENSSL_VERSION_NUMBER >= 0x010100000)
         ASN1_INTEGER_get_int64(&sn, serial);
 #else
         sn = ASN1_INTEGER_get(serial);


### PR DESCRIPTION
Checked with the latest BoringSSL (f7b830d8df9f5578c748aa0283d44c59ea7eeb25).

This fixes #5775. The logging tag which was added by #5724 to log a curve name works at minimum, but not sure about the plugins.