### PR TITLE
Fix lost fragments when update object

### DIFF
--- a/iocore/cache/CacheWrite.cc
+++ b/iocore/cache/CacheWrite.cc
@@ -105,7 +105,9 @@ CacheVC::updateVector(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
          called iff the update is a header only update so the fragment
          data should remain valid.
       */
-      if (alternate_index >= 0) {
+      // If we are not in header only updating case. Don't copy fragments.
+      if (alternate_index >= 0 &&
+          ((total_len == 0 && alternate.get_frag_offset_count() == 0) && !(f.allow_empty_doc && this->vio.nbytes == 0))) {
         alternate.copy_frag_offsets_from(write_vector->get(alternate_index));
       }
       alternate_index = write_vector->insert(&alternate, alternate_index);

--- a/iocore/cache/test/test_Update_L_to_S.cc
+++ b/iocore/cache/test/test_Update_L_to_S.cc
@@ -51,6 +51,7 @@ public:
     switch (event) {
     case CACHE_EVENT_OPEN_READ:
       base->do_io_read();
+      REQUIRE(base->vc->alternate.get_frag_offset_count() < 5);
       break;
     case VC_EVENT_READ_READY:
       base->reenable();

--- a/iocore/cache/test/test_Update_S_to_L.cc
+++ b/iocore/cache/test/test_Update_S_to_L.cc
@@ -51,6 +51,7 @@ public:
     switch (event) {
     case CACHE_EVENT_OPEN_READ:
       base->do_io_read();
+      REQUIRE(base->vc->alternate.get_frag_offset_count() > 8);
       break;
     case VC_EVENT_READ_READY:
       base->reenable();


### PR DESCRIPTION
fix #5342 

Avoid copying from old info. If we have written the fragment table. 