### PR TITLE
Track scheduled events to (read|write)_vio.cont from Http2Stream

### DIFF
--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -218,8 +218,10 @@ private:
   ink_hrtime inactive_timeout_at = 0;
   Event *inactive_event          = nullptr;
 
-  Event *read_event  = nullptr;
-  Event *write_event = nullptr;
+  Event *read_event       = nullptr;
+  Event *write_event      = nullptr;
+  Event *_read_vio_event  = nullptr;
+  Event *_write_vio_event = nullptr;
 };
 
 extern ClassAllocator<Http2Stream> http2StreamAllocator;


### PR DESCRIPTION
Possible fix for #4921. 

There is a path of Http2Stream schedules `VC_EVENT_WRITE_COMPLETE(103)` event to HttpTunnel (`write_vio.cont`). The event should be tracked and canceled when HttpSM and Http2Stream are closed.