### PR TITLE
Update TSVConnSslConnectionGet name to match other TSVConnSsl* APIs

### DIFF
--- a/example/plugins/c-api/disable_http2/disable_http2.cc
+++ b/example/plugins/c-api/disable_http2/disable_http2.cc
@@ -42,7 +42,7 @@ int
 CB_SNI(TSCont contp, TSEvent, void *cb_data)
 {
   auto vc                  = static_cast<TSVConn>(cb_data);
-  TSSslConnection ssl_conn = TSVConnSSLConnectionGet(vc);
+  TSSslConnection ssl_conn = TSVConnSslConnectionGet(vc);
   auto *ssl                = reinterpret_cast<SSL *>(ssl_conn);
   char const *sni          = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
   if (sni) {

--- a/example/plugins/c-api/ssl_sni/ssl_sni.cc
+++ b/example/plugins/c-api/ssl_sni/ssl_sni.cc
@@ -49,7 +49,7 @@ int
 CB_servername(TSCont /* contp */, TSEvent /* event */, void *edata)
 {
   TSVConn ssl_vc         = reinterpret_cast<TSVConn>(edata);
-  TSSslConnection sslobj = TSVConnSSLConnectionGet(ssl_vc);
+  TSSslConnection sslobj = TSVConnSslConnectionGet(ssl_vc);
   SSL *ssl               = reinterpret_cast<SSL *>(sslobj);
   const char *servername = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
   if (servername != nullptr) {

--- a/example/plugins/c-api/ssl_sni_whitelist/ssl_sni_whitelist.cc
+++ b/example/plugins/c-api/ssl_sni_whitelist/ssl_sni_whitelist.cc
@@ -40,7 +40,7 @@ int
 CB_servername_whitelist(TSCont /* contp */, TSEvent /* event */, void *edata)
 {
   TSVConn ssl_vc         = reinterpret_cast<TSVConn>(edata);
-  TSSslConnection sslobj = TSVConnSSLConnectionGet(ssl_vc);
+  TSSslConnection sslobj = TSVConnSslConnectionGet(ssl_vc);
   SSL *ssl               = reinterpret_cast<SSL *>(sslobj);
   const char *servername = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
 

--- a/example/plugins/c-api/verify_cert/verify_cert.cc
+++ b/example/plugins/c-api/verify_cert/verify_cert.cc
@@ -62,7 +62,7 @@ int
 CB_clientcert(TSCont /* contp */, TSEvent /* event */, void *edata)
 {
   TSVConn ssl_vc         = reinterpret_cast<TSVConn>(edata);
-  TSSslConnection sslobj = TSVConnSSLConnectionGet(ssl_vc);
+  TSSslConnection sslobj = TSVConnSslConnectionGet(ssl_vc);
   SSL *ssl               = reinterpret_cast<SSL *>(sslobj);
   X509 *cert             = SSL_get_peer_certificate(ssl);
   TSDebug(PLUGIN_NAME, "plugin verify_cert verifying client certificate");

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -1233,7 +1233,7 @@ tsapi void TSVConnReenableEx(TSVConn sslvcp, TSEvent event);
 /*  Set the connection to go into blind tunnel mode */
 tsapi TSReturnCode TSVConnTunnel(TSVConn sslp);
 /*  Return the SSL object associated with the connection */
-tsapi TSSslConnection TSVConnSSLConnectionGet(TSVConn sslp);
+tsapi TSSslConnection TSVConnSslConnectionGet(TSVConn sslp);
 /* Return the intermediate X509StoreCTX object that references the certificate being validated */
 tsapi TSSslVerifyCTX TSVConnSslVerifyCTXGet(TSVConn sslp);
 /*  Fetch a SSL context from the global lookup table */

--- a/plugins/certifier/certifier.cc
+++ b/plugins/certifier/certifier.cc
@@ -534,7 +534,7 @@ shadow_cert_generator(TSCont contp, TSEvent event, void *edata)
     TSDebug(PLUGIN_NAME, "\tClearing the queue size %lu", localQ.size());
     TSVConn ssl_vc = reinterpret_cast<TSVConn>(localQ.front());
     localQ.pop();
-    TSSslConnection sslobj = TSVConnSSLConnectionGet(ssl_vc);
+    TSSslConnection sslobj = TSVConnSslConnectionGet(ssl_vc);
     SSL *ssl               = reinterpret_cast<SSL *>(sslobj);
     SSL_set_SSL_CTX(ssl, ref_ctx);
     TSVConnReenable(ssl_vc);
@@ -549,7 +549,7 @@ static int
 cert_retriever(TSCont contp, TSEvent event, void *edata)
 {
   TSVConn ssl_vc         = reinterpret_cast<TSVConn>(edata);
-  TSSslConnection sslobj = TSVConnSSLConnectionGet(ssl_vc);
+  TSSslConnection sslobj = TSVConnSslConnectionGet(ssl_vc);
   SSL *ssl               = reinterpret_cast<SSL *>(sslobj);
   const char *servername = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
   SSL_CTX *ref_ctx       = nullptr;

--- a/plugins/experimental/ja3_fingerprint/ja3_fingerprint.cc
+++ b/plugins/experimental/ja3_fingerprint/ja3_fingerprint.cc
@@ -302,7 +302,7 @@ client_hello_ja3_handler(TSCont contp, TSEvent event, void *edata)
 #error OpenSSL cannot be 1.1.0
 #endif
 
-    TSSslConnection sslobj = TSVConnSSLConnectionGet(ssl_vc);
+    TSSslConnection sslobj = TSVConnSslConnectionGet(ssl_vc);
 
     // OpenSSL handle
     SSL *ssl = reinterpret_cast<SSL *>(sslobj);

--- a/plugins/experimental/sslheaders/sslheaders.cc
+++ b/plugins/experimental/sslheaders/sslheaders.cc
@@ -36,7 +36,7 @@ SslHdrExpandRequestHook(TSCont cont, TSEvent event, void *edata)
   txn                 = static_cast<TSHttpTxn>(edata);
   hdr                 = static_cast<const SslHdrInstance *>(TSContDataGet(cont));
   TSVConn vconn       = TSHttpSsnClientVConnGet(TSHttpTxnSsnGet(txn));
-  TSSslConnection ssl = TSVConnSSLConnectionGet(vconn);
+  TSSslConnection ssl = TSVConnSslConnectionGet(vconn);
 
   switch (event) {
   case TS_EVENT_HTTP_READ_REQUEST_HDR:

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -9162,7 +9162,7 @@ TSVConnTunnel(TSVConn sslp)
 }
 
 TSSslConnection
-TSVConnSSLConnectionGet(TSVConn sslp)
+TSVConnSslConnectionGet(TSVConn sslp)
 {
   TSSslConnection ssl       = nullptr;
   NetVConnection *vc        = reinterpret_cast<NetVConnection *>(sslp);

--- a/src/tscpp/api/InterceptPlugin.cc
+++ b/src/tscpp/api/InterceptPlugin.cc
@@ -190,7 +190,7 @@ InterceptPlugin::getSslConnection()
     return nullptr;
   }
 
-  return TSVConnSSLConnectionGet(state_->net_vc_);
+  return TSVConnSslConnectionGet(state_->net_vc_);
 }
 
 bool

--- a/tests/tools/plugins/ssl_verify_test.cc
+++ b/tests/tools/plugins/ssl_verify_test.cc
@@ -47,7 +47,7 @@ CB_server_verify(TSCont cont, TSEvent event, void *edata)
 
   // Is this a good name or not?
   TSEvent reenable_event = TS_EVENT_CONTINUE;
-  TSSslConnection sslobj = TSVConnSSLConnectionGet(ssl_vc);
+  TSSslConnection sslobj = TSVConnSslConnectionGet(ssl_vc);
   SSL *ssl               = (SSL *)sslobj;
   const char *sni_name   = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
   if (sni_name) {


### PR DESCRIPTION
TSVConnSSLConnectionGet is the only one of the TSVConnSsl* API's that uses SSL instead of Ssl.

The documentation refers to TSVConnSslConnectionGet instead of TSVConnSSLConnectionGet which is how I stumbled on this while upgrading internal plugins for 9.

This PR makes the incompatible change to normalize the API names.  Instead we could keep both versions of the name or keep the names inconsistent and update the documentation.