### PR TITLE
cachekey: allow multiple values for `--key-type`

### DIFF
--- a/doc/admin-guide/plugins/cachekey.en.rst
+++ b/doc/admin-guide/plugins/cachekey.en.rst
@@ -53,11 +53,11 @@ Key type
 
 The plugin manipulates the `cache key` by default. If `parent selection URL` manipulation is needed the following option can be used:
 
-* ``--key-type=[cache_key|parent_selection_url]`` (default: ``cache_key``)
+* ``--key-type=<list of target types>``  (default: ``cache_key``) - list of ``cache_key`` or ``parent_selection_url``, if multiple ``--key-type`` options are specified then all values are combined together.
 
-One instance of this plugin can used either for `cache key` or `parent selection URL` manupulation but never both.
-If `simultaneous cache key and parent selection URL manipulation`_ is needed two separate instances of the plugin
-have to be loaded for each key type.
+An instance of this plugin can be used for applying manipulations to `cache key`, `parent selection URL` or both depending on the need. See `simultaneous cache key and parent selection URL manipulation`_
+for examples of how to apply the **same** set of manupulations to both targets with a single plugin instance or applying **diferent** sets of manipulations to each target using separate plugin instances.
+
 
 Cache key structure and related plugin parameters
 =================================================
@@ -664,3 +664,20 @@ For this purpose two separate instances are loaded for that remap rule:
 
 In the example above the first instance of the plugin sets the prefix to the parent selection URI and
 the second instance of the plugin sets the prefix to the cache key.
+
+The **same** string manipulations can be applied to both cache key and parent selection url more concisely without chaining cachekey plugin instances by specifying multiple target types `--key-type`.
+
+Instead of::
+
+    @plugin=cachekey.so \
+        @pparam=--key-type=parent_selection_url \
+        @pparam=--remove-all-params=true
+    @plugin=cachekey.so \
+        @pparam=--key-type=cache_key \
+        @pparam=--remove-all-params=true
+
+one could write::
+
+    @plugin=cachekey.so \
+        @pparam=--key-type=parent_selection_url,cache_key \
+        @pparam=--remove-all-params=true

--- a/plugins/cachekey/configs.h
+++ b/plugins/cachekey/configs.h
@@ -41,6 +41,8 @@ enum CacheKeyKeyType {
 const char *getCacheKeyUriTypeName(CacheKeyUriType type);
 const char *getCacheKeyKeyTypeName(CacheKeyKeyType type);
 
+typedef std::set<CacheKeyKeyType> CacheKeyKeyTypeSet;
+
 /**
  * @brief Plug-in configuration elements (query / headers / cookies).
  *
@@ -203,7 +205,7 @@ public:
   /**
    * @brief get target URI type.
    */
-  CacheKeyKeyType getKeyType();
+  CacheKeyKeyTypeSet &getKeyType();
 
   /* Make the following members public to avoid unnecessary accessors */
   ConfigQuery _query;        /**< @brief query parameter related configuration */
@@ -231,5 +233,5 @@ private:
   bool _canonicalPrefix    = false; /**< @brief keep the URI scheme and authority element used as input to transforming into key */
   String _separator        = "/";   /**< @brief a separator used to separate the cache key elements extracted from the URI */
   CacheKeyUriType _uriType = REMAP; /**< @brief shows which URI the cache key will be based on */
-  CacheKeyKeyType _keyType = CACHE_KEY; /**< @brief target URI to be modified, cache key or paren selection */
+  CacheKeyKeyTypeSet _keyTypes;     /**< @brief target URI to be modified, cache key or paren selection */
 };

--- a/plugins/cachekey/plugin.cc
+++ b/plugins/cachekey/plugin.cc
@@ -38,34 +38,38 @@ Configs *globalConfig = nullptr;
 static void
 setCacheKey(TSHttpTxn txn, Configs *config, TSRemapRequestInfo *rri = nullptr)
 {
-  /* Initial cache key facility from the requested URL. */
-  CacheKey cachekey(txn, config->getSeparator(), config->getUriType(), config->getKeyType(), rri);
+  const CacheKeyKeyTypeSet &keyTypes = config->getKeyType();
 
-  /* Append custom prefix or the host:port */
-  if (!config->prefixToBeRemoved()) {
-    cachekey.appendPrefix(config->_prefix, config->_prefixCapture, config->_prefixCaptureUri, config->canonicalPrefix());
+  for (auto type : keyTypes) {
+    /* Initial cache key facility from the requested URL. */
+    CacheKey cachekey(txn, config->getSeparator(), config->getUriType(), type, rri);
+
+    /* Append custom prefix or the host:port */
+    if (!config->prefixToBeRemoved()) {
+      cachekey.appendPrefix(config->_prefix, config->_prefixCapture, config->_prefixCaptureUri, config->canonicalPrefix());
+    }
+    /* Classify User-Agent and append the class name to the cache key if matched. */
+    cachekey.appendUaClass(config->_classifier);
+
+    /* Capture from User-Agent header. */
+    cachekey.appendUaCaptures(config->_uaCapture);
+
+    /* Append headers to the cache key. */
+    cachekey.appendHeaders(config->_headers);
+
+    /* Append cookies to the cache key. */
+    cachekey.appendCookies(config->_cookies);
+
+    /* Append the path to the cache key. */
+    if (!config->pathToBeRemoved()) {
+      cachekey.appendPath(config->_pathCapture, config->_pathCaptureUri);
+    }
+    /* Append query parameters to the cache key. */
+    cachekey.appendQuery(config->_query);
+
+    /* Set the cache key */
+    cachekey.finalize();
   }
-  /* Classify User-Agent and append the class name to the cache key if matched. */
-  cachekey.appendUaClass(config->_classifier);
-
-  /* Capture from User-Agent header. */
-  cachekey.appendUaCaptures(config->_uaCapture);
-
-  /* Append headers to the cache key. */
-  cachekey.appendHeaders(config->_headers);
-
-  /* Append cookies to the cache key. */
-  cachekey.appendCookies(config->_cookies);
-
-  /* Append the path to the cache key. */
-  if (!config->pathToBeRemoved()) {
-    cachekey.appendPath(config->_pathCapture, config->_pathCaptureUri);
-  }
-  /* Append query parameters to the cache key. */
-  cachekey.appendQuery(config->_query);
-
-  /* Set the cache key */
-  cachekey.finalize();
 }
 
 static int


### PR DESCRIPTION
Allow multiple target types to be specified for `--key-type` so the
operator can apply the same modifications to both cache key and parent
selection url at the same time without chaining cachekey plugin
instances.

Instead of:
```
    @plugin=cachekey.so \
        @pparam=--key-type=parent_selection_url \
        @pparam=--remove-all-params=true
    @plugin=cachekey.so \
        @pparam=--key-type=cache_key \
        @pparam=--remove-all-params=true
```
to write:
```
    @plugin=cachekey.so \
        @pparam=--key-type=parent_selection_url,cache_key \
        @pparam=--remove-all-params=true
```