### PR TITLE
Add Base64 encoding/decoding to encryption/decryption.

### DIFF
--- a/plugins/experimental/ssl_session_reuse/Makefile.inc
+++ b/plugins/experimental/ssl_session_reuse/Makefile.inc
@@ -18,17 +18,17 @@
 pkglib_LTLIBRARIES += experimental/ssl_session_reuse/ssl_session_reuse.la
 
 experimental_ssl_session_reuse_ssl_session_reuse_la_SOURCES = \
-         experimental/ssl_session_reuse/src/openssl_utils.cc \
-         experimental/ssl_session_reuse/src/session_process.cc  \
-         experimental/ssl_session_reuse/src/ssl_init.cc \
-         experimental/ssl_session_reuse/src/config.cc \
-         experimental/ssl_session_reuse/src/redis_endpoint.cc  \
-         experimental/ssl_session_reuse/src/simple_pool.cc \
-         experimental/ssl_session_reuse/src/ssl_key_utils.cc \
-         experimental/ssl_session_reuse/src/connection.cc  \
-         experimental/ssl_session_reuse/src/publish.cc \
-         experimental/ssl_session_reuse/src/subscriber.cc \
-  	 experimental/ssl_session_reuse/src/ats_ssl_plugin.cc
+    experimental/ssl_session_reuse/src/ats_ssl_plugin.cc \
+    experimental/ssl_session_reuse/src/common.cc \
+    experimental/ssl_session_reuse/src/config.cc \
+    experimental/ssl_session_reuse/src/connection.cc \
+    experimental/ssl_session_reuse/src/openssl_utils.cc \
+    experimental/ssl_session_reuse/src/publish.cc \
+    experimental/ssl_session_reuse/src/redis_endpoint.cc \
+    experimental/ssl_session_reuse/src/session_process.cc \
+    experimental/ssl_session_reuse/src/simple_pool.cc \
+    experimental/ssl_session_reuse/src/ssl_init.cc \
+    experimental/ssl_session_reuse/src/ssl_key_utils.cc \
+    experimental/ssl_session_reuse/src/subscriber.cc
 
-experimental_ssl_session_reuse_ssl_session_reuse_la_LIBADD = @LIB_HIREDIS@ 
-
+experimental_ssl_session_reuse_ssl_session_reuse_la_LIBADD = @LIB_HIREDIS@

--- a/plugins/experimental/ssl_session_reuse/example_config.config
+++ b/plugins/experimental/ssl_session_reuse/example_config.config
@@ -21,7 +21,7 @@ redis.RedisEndpoints=host1.com:6379,host2.com:6379
 # in milliseconds
 redis.RedisConnectTimeout=20000
 # in milliseconds
-resis.RedisRetryDelay=5000000
+redis.RedisRetryDelay=5000000
 ## end generic redis config parameters
 
 ## start pub config settings

--- a/plugins/experimental/ssl_session_reuse/src/ats_ssl_plugin.cc
+++ b/plugins/experimental/ssl_session_reuse/src/ats_ssl_plugin.cc
@@ -23,15 +23,14 @@
  */
 
 #include <cstdio>
+#include <openssl/ssl.h>
 #include <ts/ts.h>
 #include <ts/apidefs.h>
-#include <openssl/ssl.h>
 
+#include "common.h"
 #include "ssl_utils.h"
 
 PluginThreads plugin_threads;
-
-int SSL_session_callback(TSCont contp, TSEvent event, void *edata);
 
 static int
 shutdown_handler(TSCont contp, TSEvent event, void *edata)
@@ -49,7 +48,7 @@ TSPluginInit(int argc, const char *argv[])
 
   info.plugin_name   = (char *)("ats_session_reuse");
   info.vendor_name   = (char *)("ats");
-  info.support_email = (char *)("ats-devel@oath.com");
+  info.support_email = (char *)("ats-devel@verizonmedia.com");
 
   TSLifecycleHookAdd(TS_LIFECYCLE_SHUTDOWN_HOOK, TSContCreate(shutdown_handler, nullptr));
 
@@ -63,10 +62,11 @@ TSPluginInit(int argc, const char *argv[])
   }
 #endif
   if (argc < 2) {
-    TSError("Must specify config file");
+    TSError("Must specify config file.");
   } else if (!init_ssl_params(argv[1])) {
     init_subscriber();
     TSCont cont = TSContCreate(SSL_session_callback, nullptr);
+    TSDebug(PLUGIN, "TSPluginInit adding TS_SSL_SESSION_HOOK.");
     TSHttpHookAdd(TS_SSL_SESSION_HOOK, cont);
   } else {
     TSError("init_ssl_params failed.");

--- a/plugins/experimental/ssl_session_reuse/src/common.cc
+++ b/plugins/experimental/ssl_session_reuse/src/common.cc
@@ -1,0 +1,182 @@
+/** @file
+
+  common.cc - Some common functions everyone needs
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+ */
+
+#include <cstdio>
+#include <cstring>
+#include <openssl/ssl.h>
+#include <ts/ts.h>
+#include <ts/apidefs.h>
+
+#include "common.h"
+
+const unsigned char salt[] = {115, 97, 108, 117, 0, 85, 137, 229};
+
+std::string
+hex_str(std::string str)
+{
+  std::string hex_str = "";
+  for (char &c : str) {
+    std::stringstream stream;
+    stream << std::hex << std::setfill('0') << std::setw(2) << (0xFF & static_cast<unsigned int>(c));
+    hex_str += stream.str();
+  }
+  return hex_str;
+}
+
+int
+encrypt_encode64(const unsigned char *key, int key_length, const unsigned char *in_data, int in_data_len, char *out_data,
+                 size_t out_data_size, size_t *out_data_len)
+{
+  if (!key || !in_data || !out_data || !out_data_len) {
+    return -1;
+  }
+
+  int cipher_block_size    = 0;
+  unsigned char *encrypted = nullptr;
+  int encrypted_len        = 0;
+  int encrypted_len_extra  = 0;
+  int ret                  = -1;
+
+  // Initialize context
+  EVP_CIPHER_CTX *context = EVP_CIPHER_CTX_new();
+  unsigned char iv[EVP_MAX_IV_LENGTH];
+  unsigned char gen_key[EVP_MAX_KEY_LENGTH];
+
+  // generate key and iv
+  if (EVP_BytesToKey(EVP_aes_256_cbc(), EVP_md5(), salt, key, key_length, 1, gen_key, iv) <= 0) {
+    TSDebug(PLUGIN, "Error generating key.");
+  }
+
+  // Set context AES128 with the generated key and iv
+  if (1 != EVP_EncryptInit_ex(context, EVP_aes_256_cbc(), nullptr, gen_key, iv)) {
+    TSDebug(PLUGIN, "EVP_EncryptInit_ex failed.");
+    goto Cleanup;
+  }
+
+  // https://www.openssl.org/docs/manmaster/man3/EVP_EncryptUpdate.html
+  // EVP_EncryptUpdate() needs (inl + cipher_block_size - 1) bytes.
+  // EVP_EncryptFinal_ex needs (inl + cipher_block_size) bytes.
+  cipher_block_size = EVP_CIPHER_CTX_block_size(context);
+  encrypted         = new unsigned char[in_data_len + cipher_block_size * 2];
+  if (1 != EVP_EncryptUpdate(context, encrypted, &encrypted_len, in_data, in_data_len)) {
+    TSDebug(PLUGIN, "EVP_EncryptUpdate failed.");
+    goto Cleanup;
+  }
+
+  if (1 != EVP_EncryptFinal_ex(context, encrypted + encrypted_len, &encrypted_len_extra)) {
+    TSDebug(PLUGIN, "EVP_EncryptFinal_ex failed.");
+    goto Cleanup;
+  }
+
+  // We must encode it to base64 here, since the encryption doesn't guarantee that there are no
+  // null bytes in the output. Which will cause a problem when sending it through redis since
+  // the redis command needs to be formatted to a C string.
+  if (TSBase64Encode(reinterpret_cast<char *>(encrypted), encrypted_len + encrypted_len_extra, out_data, out_data_size,
+                     out_data_len) != 0) {
+    TSDebug(PLUGIN, "Base 64 encoding failed.");
+    goto Cleanup;
+  }
+
+  TSDebug(PLUGIN, "Encrypted buffer of size %d to buffer of size %lu.", in_data_len, *out_data_len);
+  ret = 0;
+
+Cleanup:
+
+  if (encrypted) {
+    delete[] encrypted;
+  }
+
+  if (context) {
+    EVP_CIPHER_CTX_free(context);
+  }
+
+  return ret;
+}
+
+int
+decrypt_decode64(const unsigned char *key, int key_length, const char *in_data, int in_data_len, unsigned char *out_data,
+                 size_t out_data_size, size_t *out_data_len)
+{
+  if (!key || !in_data || !out_data || !out_data_len) {
+    return -1;
+  }
+
+  size_t decoded_size     = DECODED_LEN(in_data_len);
+  size_t decoded_len      = 0;
+  unsigned char *decoded  = new unsigned char[decoded_size];
+  int decrypted_len       = 0;
+  int decrypted_len_extra = 0;
+  int ret                 = -1;
+
+  // Initialize context
+  EVP_CIPHER_CTX *context = EVP_CIPHER_CTX_new();
+  unsigned char iv[EVP_MAX_IV_LENGTH];
+  unsigned char gen_key[EVP_MAX_KEY_LENGTH];
+
+  // Decode base64
+  std::memset(decoded, 0, decoded_size);
+  if (TSBase64Decode(in_data, in_data_len, decoded, decoded_size, &decoded_len) != 0) {
+    TSDebug(PLUGIN, "Base 64 decoding failed.");
+    goto Cleanup;
+  }
+
+  // generate key and iv
+  if (EVP_BytesToKey(EVP_aes_256_cbc(), EVP_md5(), salt, key, key_length, 1, gen_key, iv) <= 0) {
+    TSDebug(PLUGIN, "Error generating key.");
+  }
+  // set context with the generated key and iv
+  if (1 != EVP_DecryptInit_ex(context, EVP_aes_256_cbc(), nullptr, gen_key, iv)) {
+    TSDebug(PLUGIN, "EVP_DecryptInit_ex failed.");
+    goto Cleanup;
+  }
+
+  // https://www.openssl.org/docs/manmaster/man3/EVP_DecryptUpdate.html
+  // EVP_DecryptUpdate() and EVP_DecryptFinal_ex() have the exact same requirements as their encrypt counterparts.
+  if (1 != EVP_DecryptUpdate(context, out_data, &decrypted_len, decoded, decoded_len)) {
+    TSDebug(PLUGIN, "EVP_DecryptUpdate failed.");
+    goto Cleanup;
+  }
+
+  if (1 != EVP_DecryptFinal_ex(context, out_data + decrypted_len, &decrypted_len_extra)) {
+    TSDebug(PLUGIN, "EVP_DecryptFinal_ex failed.");
+    goto Cleanup;
+  }
+
+  *out_data_len = decrypted_len + decrypted_len_extra;
+
+  TSDebug(PLUGIN, "Decrypted buffer of size %d to buffer of size %lu.", in_data_len, *out_data_len);
+  ret = 0;
+
+Cleanup:
+
+  if (decoded) {
+    delete[] decoded;
+  }
+
+  if (context) {
+    EVP_CIPHER_CTX_free(context);
+  }
+
+  return ret;
+}

--- a/plugins/experimental/ssl_session_reuse/src/config.cc
+++ b/plugins/experimental/ssl_session_reuse/src/config.cc
@@ -22,17 +22,17 @@
 
  */
 
-#include <ts/ts.h>
-#include <ts/apidefs.h>
 #include <cstring>
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#include "tscpp/util/TextView.h"
+#include <ts/ts.h>
+#include <ts/apidefs.h>
 
 #include "Config.h"
 #include "common.h"
+#include "tscpp/util/TextView.h"
 
 Config::Config()
 {

--- a/plugins/experimental/ssl_session_reuse/src/message.h
+++ b/plugins/experimental/ssl_session_reuse/src/message.h
@@ -25,6 +25,7 @@
 
 #include <string>
 #include <set>
+
 #include "redis_endpoint.h"
 
 typedef struct message {

--- a/plugins/experimental/ssl_session_reuse/src/publish.cc
+++ b/plugins/experimental/ssl_session_reuse/src/publish.cc
@@ -22,13 +22,14 @@
 
  */
 
-#include <sys/time.h>
-#include <unistd.h>
 #include <iostream>
 #include <exception>
 #include <cstring>
 #include <memory>
+#include <unistd.h>
+#include <sys/time.h>
 #include <ts/ts.h>
+
 #include "common.h"
 #include "publisher.h"
 #include "Config.h"
@@ -49,14 +50,12 @@ RedisPublisher::start_worker_thread(void *arg)
 
 RedisPublisher::RedisPublisher(const std::string &conf)
   : m_redisEndpointsStr(cDefaultRedisEndpoint),
-
     m_numWorkers(cPubNumWorkerThreads),
     m_redisConnectTimeout(cDefaultRedisConnectTimeout),
     m_redisConnectTries(cDefaultRedisConnectTries),
     m_redisPublishTries(cDefaultRedisPublishTries),
     m_redisRetryDelay(cDefaultRedisRetryDelay),
     m_maxQueuedMessages(cDefaultMaxQueuedMessages)
-
 {
   if (Config::getSingleton().loadConfig(conf)) {
     Config::getSingleton().getValue("pubconfig", "PubNumWorkers", m_numWorkers);
@@ -73,7 +72,7 @@ RedisPublisher::RedisPublisher(const std::string &conf)
   char redis_auth_key[MAX_REDIS_KEYSIZE];
   if (!(get_redis_auth_key(redis_auth_key, MAX_REDIS_KEYSIZE))) {
     err = true;
-    TSError("RedisPublisher::RedisPublisher.Cannot get redis AUTH password.");
+    TSError("RedisPublisher::RedisPublisher: Cannot get redis AUTH password.");
     redis_passwd.clear();
   } else {
     redis_passwd = redis_auth_key;
@@ -82,25 +81,24 @@ RedisPublisher::RedisPublisher(const std::string &conf)
 
   addto_endpoint_vector(m_redisEndpoints, m_redisEndpointsStr);
 
-  TSDebug(PLUGIN, "RedisPublisher::RedisPublisher.NumWorkers= %d RedisConnectTimeout=%d", m_numWorkers, m_redisConnectTimeout);
+  TSDebug(PLUGIN, "RedisPublisher::RedisPublisher: NumWorkers: %d RedisConnectTimeout: %d", m_numWorkers, m_redisConnectTimeout);
   TSDebug(PLUGIN,
-          "RedisPublisher::RedisPublisher.RedisPublishTries= %d RedisConnectTries=%d RedisRetryDelay=%d MaxQueuedMessages=%d",
+          "RedisPublisher::RedisPublisher: RedisPublishTries: %d RedisConnectTries: %d RedisRetryDelay: %d MaxQueuedMessages: %d",
           m_redisPublishTries, m_redisConnectTries, m_redisRetryDelay, m_maxQueuedMessages);
 
-  TSDebug(PLUGIN, "RedisPublisher::RedisPublisher.Redis Publish endpoints are as follows:");
+  TSDebug(PLUGIN, "RedisPublisher::RedisPublisher: Redis Publish endpoints are as follows:");
   for (std::vector<RedisEndpoint>::iterator it = m_redisEndpoints.begin(); it != m_redisEndpoints.end(); ++it) {
-    // LOGDEBUG(PUB, *it);
     simple_pool *pool = simple_pool::create(it->m_hostname, it->m_port, m_poolRedisConnectTimeout);
     pools.push_back(pool);
   }
 
-  TSDebug(PLUGIN, "RedisPublisher::RedisPublisher.PoolRedisConnectTimeout= %d", m_poolRedisConnectTimeout);
+  TSDebug(PLUGIN, "RedisPublisher::RedisPublisher: PoolRedisConnectTimeout: %d", m_poolRedisConnectTimeout);
 
   ::sem_init(&m_workerSem, 0, 0);
 
   if (m_redisEndpoints.size() > m_numWorkers) {
     err = true;
-    TSError("RedisPublisher::RedisPublisher.Number of threads in the thread pool less than the number of redis endpoints");
+    TSError("RedisPublisher::RedisPublisher: Number of threads in the thread pool less than the number of redis endpoints.");
   }
 
   if (!err) {
@@ -120,7 +118,7 @@ RedisPublisher::is_good()
 RedisPublisher::setup_connection(const RedisEndpoint &re)
 {
   ::pthread_t my_id = ::pthread_self();
-  TSDebug(PLUGIN, "RedisPublisher::setup_connection.called by threadId: %d", static_cast<int>(my_id));
+  TSDebug(PLUGIN, "RedisPublisher::setup_connection: Called by threadId: %lx", my_id);
 
   RedisContextPtr my_context;
   struct ::timeval timeout;
@@ -130,33 +128,32 @@ RedisPublisher::setup_connection(const RedisEndpoint &re)
   for (int i = 0; i < static_cast<int>(m_redisConnectTries); ++i) {
     my_context.reset(::redisConnectWithTimeout(re.m_hostname.c_str(), re.m_port, timeout));
     if (!my_context) {
-      TSError("RedisPublisher::setup_connection.connect to host: %s and port: %d fail count: %d threadId: %d",
-              re.m_hostname.c_str(), re.m_port, i + 1, static_cast<int>(my_id));
+      TSError("RedisPublisher::setup_connection: Connect to host: %s port: %d fail count: %d threadId: %lx", re.m_hostname.c_str(),
+              re.m_port, i + 1, my_id);
     } else if (my_context->err) {
-      TSError("RedisPublisher::setup_connection.connect to host: %s port: %d fail count: %d and threadId: %d",
-              re.m_hostname.c_str(), re.m_port, i + 1, static_cast<int>(my_id));
+      TSError("RedisPublisher::setup_connection: Connect to host: %s port: %d fail count: %d threadId: %lx", re.m_hostname.c_str(),
+              re.m_port, i + 1, my_id);
       my_context.reset(nullptr);
     } else {
-      TSDebug(PLUGIN, "RedisPublisher::setup_connection.threadId: %d  successfully connected to the redis instance",
-              static_cast<int>(my_id));
+      TSDebug(PLUGIN, "RedisPublisher::setup_connection: threadId: %lx Successfully connected to the redis instance.", my_id);
 
       redisReply *reply = static_cast<redisReply *>(redisCommand(my_context.get(), "AUTH %s", redis_passwd.c_str()));
 
       if (reply == nullptr) {
-        TSError("RedisPublisher::setup_connection. Cannot AUTH redis server, no reply.");
+        TSError("RedisPublisher::setup_connection: Cannot AUTH redis server, no reply.");
         my_context.reset(nullptr);
       } else if (reply->type == REDIS_REPLY_ERROR) {
-        TSError("RedisPublisher::setup_connection. Cannot AUTH redis server, error reply.");
+        TSError("RedisPublisher::setup_connection: Cannot AUTH redis server, error reply.");
         freeReplyObject(reply);
         my_context.reset(nullptr);
       } else {
-        TSDebug(PLUGIN, "RedisPublisher::setup_connection. Successfully AUTH redis server.");
+        TSDebug(PLUGIN, "RedisPublisher::setup_connection: Successfully AUTH redis server.");
         freeReplyObject(reply);
       }
       break;
     }
 
-    TSError("RedisPublisher::setup_connection.connect failed.will wait for: %d microseconds and try again.", m_redisRetryDelay);
+    TSError("RedisPublisher::setup_connection: Connect failed, will wait for: %d microseconds and try again.", m_redisRetryDelay);
     ::usleep(m_redisRetryDelay);
   }
 
@@ -167,7 +164,7 @@ RedisPublisher::setup_connection(const RedisEndpoint &re)
 RedisPublisher::send_publish(RedisContextPtr &ctx, const RedisEndpoint &re, const Message &msg)
 {
   ::pthread_t my_id = ::pthread_self();
-  TSDebug(PLUGIN, "RedisPublisher::send_publish.called by threadId: %d", static_cast<int>(my_id));
+  TSDebug(PLUGIN, "RedisPublisher::send_publish: Called by threadId: %lx", my_id);
 
   ::redisReply *current_reply(nullptr);
 
@@ -176,21 +173,20 @@ RedisPublisher::send_publish(RedisContextPtr &ctx, const RedisEndpoint &re, cons
       ctx.reset(setup_connection(re));
 
       if (!ctx) {
-        TSError("RedisPublisher::send_publish.Unable to setup a connection to the redis server: %s:%d .ThreadId: %d Try: %d",
-                re.m_hostname.c_str(), re.m_port, static_cast<int>(my_id), (i + 1));
+        TSError("RedisPublisher::send_publish: Unable to setup a connection to the redis server: %s:%d threadId: %lx try: %d",
+                re.m_hostname.c_str(), re.m_port, my_id, (i + 1));
         continue;
       }
     }
 
     current_reply = static_cast<redisReply *>(::redisCommand(ctx.get(), "PUBLISH %s %s", msg.channel.c_str(), msg.data.c_str()));
     if (!current_reply) {
-      TSError("RedisPublisher::send_publish.Unable to get a reply from the server for publish.ThreadId: %d Try: %d",
-              static_cast<int>(my_id), (i + 1));
+      TSError("RedisPublisher::send_publish: Unable to get a reply from the server for publish. threadId: %lx try: %d", my_id,
+              (i + 1));
       ctx.reset(nullptr); // Clean up previous attempt
 
     } else if (REDIS_REPLY_ERROR == current_reply->type) {
-      TSError("RedisPublisher::send_publish.Server responded with error for publish.ThreadId: %d Try: %d", static_cast<int>(my_id),
-              i + 1);
+      TSError("RedisPublisher::send_publish: Server responded with error for publish. threadId: %lx try: %d", my_id, i + 1);
       clear_reply(current_reply);
       current_reply = nullptr;
       ctx.reset(nullptr); // Clean up previous attempt
@@ -243,7 +239,8 @@ RedisPublisher::runWorker()
       continue;
     }
 
-    Message &current_message(m_messageQueue.front());
+    // Can't do reference here, since we pop it off the queue, the reference will be invalid.
+    Message current_message(m_messageQueue.front());
     if (!current_message.cleanup) {
       m_messageQueue.pop_front();
     }
@@ -252,7 +249,7 @@ RedisPublisher::runWorker()
     ::sem_wait(&m_workerSem);
 
     if (current_message.cleanup) {
-      TSDebug(PLUGIN, "RedisPublisher::runWorker.Thread id: %d received the cleanup message. exiting!", static_cast<int>(my_id));
+      TSDebug(PLUGIN, "RedisPublisher::runWorker: threadId: %lx received the cleanup message. Exiting!", my_id);
       break;
     }
     current_reply = send_publish(my_context, my_endpoint, current_message);
@@ -284,8 +281,8 @@ RedisPublisher::runWorker()
 int
 RedisPublisher::publish(const std::string &channel, const std::string &data)
 {
-  TSDebug(PLUGIN, "RedisPublisher::publish.Publish request for channel: %s and message: \"%s\" received", channel.c_str(),
-          data.c_str());
+  TSDebug(PLUGIN, "RedisPublisher::publish: Publish request for channel: %s and message: \"%s\" received.", channel.c_str(),
+          hex_str(data).c_str());
 
   m_messageQueueMutex.lock();
 
@@ -302,7 +299,7 @@ RedisPublisher::publish(const std::string &channel, const std::string &data)
 int
 RedisPublisher::signal_cleanup()
 {
-  TSDebug(PLUGIN, "RedisPublisher::signal_cleanup.called");
+  TSDebug(PLUGIN, "RedisPublisher::signal_cleanup: Called.");
   Message cleanup_message("", "", true);
 
   m_messageQueueMutex.lock();
@@ -316,7 +313,7 @@ RedisPublisher::signal_cleanup()
 
 RedisPublisher::~RedisPublisher()
 {
-  TSDebug(PLUGIN, "RedisPublisher::~RedisPublisher.called");
+  TSDebug(PLUGIN, "RedisPublisher::~RedisPublisher: Called.");
   RedisPublisher::signal_cleanup();
 
   ::sem_destroy(&m_workerSem);
@@ -325,18 +322,18 @@ RedisPublisher::~RedisPublisher()
 std::string
 RedisPublisher::get_session(const std::string &channel)
 {
-  TSDebug(PLUGIN, "RedisPublisher::get_session. Called by threadId: %d", static_cast<int>(pthread_self()));
+  TSDebug(PLUGIN, "RedisPublisher::get_session: Called by threadId: %lx", ::pthread_self());
   std::string ret;
   uint32_t index    = get_hash_index(channel);
   redisReply *reply = nullptr;
-  TSDebug(PLUGIN, "RedisPublisher::get_session. Start to try to get session.");
+  TSDebug(PLUGIN, "RedisPublisher::get_session: Start to try to get session.");
   for (uint32_t i = 0; i < m_redisEndpoints.size(); i++) {
     connection *conn = pools[index]->get();
 
     if (conn) {
       reply = static_cast<redisReply *>(redisCommand(conn->c_ptr(), "GET %s", channel.c_str()));
       if (reply && reply->type == REDIS_REPLY_STRING) {
-        TSDebug(PLUGIN, "RedisPublisher::get_session. Success to GET a value from redis server index: %d", index);
+        TSDebug(PLUGIN, "RedisPublisher::get_session: Success to GET a value from redis server index: %d", index);
         pools[index]->put(conn);
         ret = reply->str;
         clear_reply(reply);
@@ -345,19 +342,19 @@ RedisPublisher::get_session(const std::string &channel)
       pools[index]->put(conn);
       clear_reply(reply);
     }
-    TSError("RedisPublisher::get_session. Fail to GET a value from this redis server index: %d", index);
+    TSError("RedisPublisher::get_session: Fail to GET a value from this redis server index: %d", index);
     index = get_next_index(index);
-    TSDebug(PLUGIN, "RedisPublisher::get_session. Will try the next redis server: %d", index);
+    TSDebug(PLUGIN, "RedisPublisher::get_session: Will try the next redis server: %d", index);
   }
 
-  TSError("RedisPublisher::get_session. Fail to GET a value from all redis servers!");
+  TSError("RedisPublisher::get_session: Fail to GET a value from all redis servers!");
   return ret;
 }
 
 redisReply *
 RedisPublisher::set_session(const Message &msg)
 {
-  TSDebug(PLUGIN, "RedisPublisher::set_session. Called by threadId: %d", static_cast<int>(pthread_self()));
+  TSDebug(PLUGIN, "RedisPublisher::set_session: Called by threadId: %lx", ::pthread_self());
   uint32_t index    = get_hash_index(msg.channel);
   redisReply *reply = nullptr;
   for (uint32_t i = 0; i < m_redisEndpoints.size(); i++) {
@@ -366,7 +363,7 @@ RedisPublisher::set_session(const Message &msg)
     if (conn) {
       reply = static_cast<redisReply *>(redisCommand(conn->c_ptr(), "SET %s %s", msg.channel.c_str(), msg.data.c_str()));
       if (reply && reply->type == REDIS_REPLY_STATUS && strcasecmp(reply->str, "OK") == 0) {
-        TSDebug(PLUGIN, "RedisPublisher::set_session. Success to SET a value to redis server: %s:%d",
+        TSDebug(PLUGIN, "RedisPublisher::set_session: Success to SET a value to redis server: %s:%d",
                 m_redisEndpoints[index].m_hostname.c_str(), m_redisEndpoints[index].m_port);
         pools[index]->put(conn);
         return reply;
@@ -374,14 +371,14 @@ RedisPublisher::set_session(const Message &msg)
       pools[index]->put(conn);
       clear_reply(reply);
     }
-    TSError("RedisPublisher::set_session. Fail to SET a value to this redis server %s:%d",
+    TSError("RedisPublisher::set_session: Fail to SET a value to this redis server %s:%d",
             m_redisEndpoints[index].m_hostname.c_str(), m_redisEndpoints[index].m_port);
 
     index = get_next_index(index);
-    TSDebug(PLUGIN, "RedisPublisher::set_session. Will try the next redis server: %s:%d",
+    TSDebug(PLUGIN, "RedisPublisher::set_session: Will try the next redis server: %s:%d",
             m_redisEndpoints[index].m_hostname.c_str(), m_redisEndpoints[index].m_port);
   }
 
-  TSError("RedisPublisher::set_session. Fail to SET a value to all redis servers!");
+  TSError("RedisPublisher::set_session: Fail to SET a value to all redis servers!");
   return nullptr;
 }

--- a/plugins/experimental/ssl_session_reuse/src/publisher.h
+++ b/plugins/experimental/ssl_session_reuse/src/publisher.h
@@ -30,6 +30,7 @@
 #include <memory>
 #include <semaphore.h>
 #include <hiredis/hiredis.h>
+
 #include "message.h"
 #include "globals.h"
 #include "redis_endpoint.h"

--- a/plugins/experimental/ssl_session_reuse/src/redis_endpoint.h
+++ b/plugins/experimental/ssl_session_reuse/src/redis_endpoint.h
@@ -25,6 +25,7 @@
 
 #include <string>
 #include <vector>
+
 #include "globals.h"
 
 typedef struct redis_endpoint {

--- a/plugins/experimental/ssl_session_reuse/src/session_process.h
+++ b/plugins/experimental/ssl_session_reuse/src/session_process.h
@@ -26,14 +26,7 @@
 #include <string>
 #include <cmath>
 
-#define SSL_SESSION_MAX_DER 1024 * 10
-
-// Base 64 encoding takes 4*(floor(n/3)) bytes
-#define ENCODED_LEN(len) ((int)ceil(1.34 * len + 5)) + 1
-#define DECODED_LEN(len) ((int)ceil(0.75 * len)) + 1
-// 3DES encryption will take at most 8 extra bytes.  Plus we base 64 encode the result
-#define ENCRYPT_LEN(len) (int)ceil(1.34 * (len + 8) + 5) + 1
-#define DECRYPT_LEN(len) (int)ceil(1.34 * (len + 8) + 5) + 1
+#define SSL_SESSION_MAX_DER (1024 * 10)
 
 int encrypt_session(const char *session_data, int32_t session_data_len, const unsigned char *key, int key_length,
                     std::string &encrypted_data);

--- a/plugins/experimental/ssl_session_reuse/src/simple_pool.h
+++ b/plugins/experimental/ssl_session_reuse/src/simple_pool.h
@@ -23,9 +23,10 @@
  */
 #pragma once
 
-#include "connection.h"
 #include <set>
 #include <mutex>
+
+#include "connection.h"
 
 /**
  * @brief Manages a pool of connections to a single Redis server

--- a/plugins/experimental/ssl_session_reuse/src/ssl_utils.h
+++ b/plugins/experimental/ssl_session_reuse/src/ssl_utils.h
@@ -23,15 +23,15 @@
  */
 #pragma once
 
-#include <openssl/ssl.h>
 #include <string>
+#include <iostream>
+#include <iomanip>
+#include <atomic>
+#include <openssl/ssl.h>
 #include <ts/ts.h>
-#include <mutex>
-#include <deque>
 
 #include "publisher.h"
 #include "subscriber.h"
-
 #include "stek.h"
 
 struct ssl_session_param {
@@ -45,35 +45,6 @@ struct ssl_session_param {
 
   ssl_session_param();
   ~ssl_session_param();
-};
-
-class PluginThreads
-{
-public:
-  void
-  store(const pthread_t &th)
-  {
-    std::lock_guard<std::mutex> lock(threads_mutex);
-    threads_queue.push_back(th);
-  }
-
-  void
-  terminate()
-  {
-    std::lock_guard<std::mutex> lock(threads_mutex);
-    for (pthread_t th : threads_queue) {
-      ::pthread_cancel(th);
-    }
-    while (!threads_queue.empty()) {
-      pthread_t th = threads_queue.front();
-      ::pthread_join(th, nullptr);
-      threads_queue.pop_front();
-    }
-  }
-
-private:
-  std::deque<pthread_t> threads_queue;
-  std::mutex threads_mutex;
 };
 
 int STEK_init_keys();
@@ -97,5 +68,3 @@ int init_subscriber();
 int SSL_session_callback(TSCont contp, TSEvent event, void *edata);
 
 extern ssl_session_param ssl_param; // almost everything one needs is stored in here
-
-extern PluginThreads plugin_threads;

--- a/plugins/experimental/ssl_session_reuse/src/subscriber.h
+++ b/plugins/experimental/ssl_session_reuse/src/subscriber.h
@@ -25,6 +25,7 @@
 
 #include <vector>
 #include <string>
+
 #include "message.h"
 #include "globals.h"
 #include "redis_endpoint.h"


### PR DESCRIPTION
When calling `EVP_Encrypt` related functions and their decryption counterparts, it is not guaranteed to have no null bytes in the middle of the whole output, so we need to encode it with Base64 to avoid redis sending partial data.

Also made some general cleanup to the code, mostly to the debug outputs. Code changes are mostly made in the following files:
```
common.cc
common.h
publish.cc:243
session_process.cc
ssl_key_utils.cc
```