### PR TITLE
Fix code to avoid HostDBContinuation use after free

### DIFF
--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -1178,8 +1178,9 @@ HostDBContinuation::dnsEvent(int event, HostEnt *e)
   if (event == EVENT_INTERVAL) {
     if (!action.continuation) {
       // give up on insert, it has been too long
+      // remove_trigger_pending_dns will notify and clean up all requests
+      // including this one.
       remove_trigger_pending_dns();
-      hostdb_cont_free(this);
       return EVENT_DONE;
     }
     MUTEX_TRY_LOCK(lock, action.mutex, thread);
@@ -1434,18 +1435,18 @@ HostDBContinuation::dnsEvent(int event, HostEnt *e)
         }
       }
       if (need_to_reschedule) {
-        remove_trigger_pending_dns();
         SET_HANDLER((HostDBContHandler)&HostDBContinuation::probeEvent);
-        thread->schedule_in(this, HOST_DB_RETRY_PERIOD);
+        // remove_trigger_pending_dns should kick off the current hostDB too
+        // No need to explicitly reschedule
+        remove_trigger_pending_dns();
         return EVENT_CONT;
       }
     }
     // wake up everyone else who is waiting
     remove_trigger_pending_dns();
 
-    // all done
+    // all done, or at least scheduled to be all done
     //
-    hostdb_cont_free(this);
     return EVENT_DONE;
   }
 }


### PR DESCRIPTION
This stack as been showing up in our environment intermittently for a while.
```
#0  0x00000000006ae0c6 in HostDBContinuation::do_dns() () at HostDB.cc:1835
#1  0x00000000006b09e0 in HostDBContinuation::probeEvent(int, Event*) () at HostDB.cc:1757
#2  0x00000000006b0c08 in HostDBContinuation::dnsPendingEvent(int, Event*) () at HostDB.cc:1183
#3  0x00000000007c3f3c in handleEvent (data=0x2b36790007e0, event=1, this=0x2b3b17d8c800) at I_Continuation.h:182
#4  EThread::process_event(Event*, int) () at UnixEThread.cc:136
#5  0x00000000007c50ac in EThread::execute_regular (this=0x2b3669d95440) at UnixEThread.cc:250
#6  0x00000000007c3932 in spawn_thread_internal (a=0x2b366801efc0) at Thread.cc:85
#7  0x00002b3666627dd5 in start_thread () from /lib64/libpthread.so.0
#8  0x00002b366735cead in clone () from /lib64/libc.so.6
```

In this case, the HostDBContinuation->mutex is NULL this causing the crash in do_dns.  The handler is set to probeEvent().  I see no place were the hostDBContinuation is created but init() is not called (which sets the mutex).  However when the HostDBContinuation is freed, the mutex is nulled.

Ultimately, I think the use-after-free issue is caused by the combination of these two lines.
```
remove_trigger_pending_dns();
hostdb_cont_free(this);
```

remove_trigger_pending_dns, walks the pending list and sends a schedule_imm so it can process the result on the invoking thread.  However, based on my search of the code, particularly set_check_pending_dns,  the current object (this) is on the list.  So we just scheduled an event to process that object and then delete the object before the immediate event can be processed (most likely).

The code change removes the extra host_db_cont_free and schedule. 