### PR TITLE
Log H2 priority information

### DIFF
--- a/doc/admin-guide/logging/formatting.en.rst
+++ b/doc/admin-guide/logging/formatting.en.rst
@@ -184,6 +184,8 @@ Connections and Transactions
 .. _sstc:
 .. _ccid:
 .. _ctid:
+.. _ctpw:
+.. _ctpd:
 
 The following log fields are used to list various details of connections and
 transactions between |TS| proxies and origin servers.
@@ -203,6 +205,10 @@ ctid  Client Request Client Transaction ID, a non-negative number for a transact
                      which is different for all currently-active transactions on the
                      same client connection.  For client HTTP/2 transactions, this
                      value is the stream ID for the transaction.
+ctpw  Client Request Client Transaction Priority Weight, the priority weight for the 
+                     underlying HTTP/2 protocol.
+ctpd  Client Request Client Transaction Priority Dependence, the transaction ID that 
+                     the current transaction depends on for HTTP/2 priority logic.
 ===== ============== ==================================================================
 
 .. _admin-logging-fields-content-type:

--- a/proxy/ProxyTransaction.cc
+++ b/proxy/ProxyTransaction.cc
@@ -199,3 +199,15 @@ void
 ProxyTransaction::set_h2c_upgrade_flag()
 {
 }
+
+int
+ProxyTransaction::get_transaction_priority_weight() const
+{
+  return 0;
+}
+
+int
+ProxyTransaction::get_transaction_priority_dependence() const
+{
+  return 0;
+}

--- a/proxy/ProxyTransaction.h
+++ b/proxy/ProxyTransaction.h
@@ -50,9 +50,11 @@ public:
   virtual void set_inactivity_timeout(ink_hrtime timeout_in) = 0;
   virtual void cancel_inactivity_timeout()                   = 0;
   virtual int get_transaction_id() const                     = 0;
-  virtual bool allow_half_open() const                       = 0;
-  virtual void increment_client_transactions_stat()          = 0;
-  virtual void decrement_client_transactions_stat()          = 0;
+  virtual int get_transaction_priority_weight() const;
+  virtual int get_transaction_priority_dependence() const;
+  virtual bool allow_half_open() const              = 0;
+  virtual void increment_client_transactions_stat() = 0;
+  virtual void decrement_client_transactions_stat() = 0;
 
   virtual NetVConnection *get_netvc() const;
   virtual bool is_first_transaction() const;

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -488,7 +488,9 @@ HttpSM::attach_client_session(ProxyTransaction *client_vc, IOBufferReader *buffe
   // It seems to be possible that the ua_txn pointer will go stale before log entries for this HTTP transaction are
   // generated.  Therefore, collect information that may be needed for logging from the ua_txn object at this point.
   //
-  _client_transaction_id = ua_txn->get_transaction_id();
+  _client_transaction_id                  = ua_txn->get_transaction_id();
+  _client_transaction_priority_weight     = ua_txn->get_transaction_priority_weight();
+  _client_transaction_priority_dependence = ua_txn->get_transaction_priority_dependence();
   {
     auto p = ua_txn->get_proxy_ssn();
 

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -613,6 +613,18 @@ public:
     return _client_transaction_id;
   }
 
+  int
+  client_transaction_priority_weight() const
+  {
+    return _client_transaction_priority_weight;
+  }
+
+  int
+  client_transaction_priority_dependence() const
+  {
+    return _client_transaction_priority_dependence;
+  }
+
   void set_server_netvc_inactivity_timeout(NetVConnection *netvc);
   void set_server_netvc_active_timeout(NetVConnection *netvc);
   void set_server_netvc_connect_timeout(NetVConnection *netvc);
@@ -621,6 +633,7 @@ public:
 private:
   PostDataBuffers _postbuf;
   int _client_connection_id = -1, _client_transaction_id = -1;
+  int _client_transaction_priority_weight = -1, _client_transaction_priority_dependence = -1;
 };
 
 // Function to get the cache_sm object - YTS Team, yamsat

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -1063,3 +1063,19 @@ Http2Stream::mark_body_done()
     this->write_vio.nbytes = response_header.length_get() + chunked_handler.dechunked_size;
   }
 }
+
+int
+Http2Stream::get_transaction_priority_weight() const
+{
+  return priority_node ? priority_node->weight : 0;
+}
+
+int
+Http2Stream::get_transaction_priority_dependence() const
+{
+  if (!priority_node) {
+    return -1;
+  } else {
+    return priority_node->parent ? priority_node->parent->id : 0;
+  }
+}

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -97,6 +97,8 @@ public:
   void increment_client_transactions_stat() override;
   void decrement_client_transactions_stat() override;
   int get_transaction_id() const override;
+  int get_transaction_priority_weight() const override;
+  int get_transaction_priority_dependence() const override;
 
   void clear_inactive_timer();
   void clear_active_timer();

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -887,6 +887,16 @@ Log::init_fields()
   global_field_list.add(field, false);
   field_symbol_hash.emplace("ctid", field);
 
+  field = new LogField("client_transaction_priority_weight", "ctpw", LogField::sINT,
+                       &LogAccess::marshal_client_http_transaction_priority_weight, &LogAccess::unmarshal_int_to_str);
+  global_field_list.add(field, false);
+  field_symbol_hash.emplace("ctpw", field);
+
+  field = new LogField("client_transaction_priority_dependence", "ctpd", LogField::sINT,
+                       &LogAccess::marshal_client_http_transaction_priority_dependence, &LogAccess::unmarshal_int_to_str);
+  global_field_list.add(field, false);
+  field_symbol_hash.emplace("ctpd", field);
+
   init_status |= FIELDS_INITIALIZED;
 }
 

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -2556,6 +2556,38 @@ LogAccess::marshal_client_http_transaction_id(char *buf)
   -------------------------------------------------------------------------*/
 
 int
+LogAccess::marshal_client_http_transaction_priority_weight(char *buf)
+{
+  if (buf) {
+    int64_t id = 0;
+    if (m_http_sm) {
+      id = m_http_sm->client_transaction_priority_weight();
+    }
+    marshal_int(buf, id);
+  }
+  return INK_MIN_ALIGN;
+}
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+int
+LogAccess::marshal_client_http_transaction_priority_dependence(char *buf)
+{
+  if (buf) {
+    int64_t id = 0;
+    if (m_http_sm) {
+      id = m_http_sm->client_transaction_priority_dependence();
+    }
+    marshal_int(buf, id);
+  }
+  return INK_MIN_ALIGN;
+}
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+int
 LogAccess::marshal_http_header_field(LogField::Container container, char *field, char *buf)
 {
   char *str        = nullptr;

--- a/proxy/logging/LogAccess.h
+++ b/proxy/logging/LogAccess.h
@@ -239,15 +239,17 @@ public:
 
   // other fields
   //
-  inkcoreapi int marshal_transfer_time_ms(char *);           // INT
-  inkcoreapi int marshal_transfer_time_s(char *);            // INT
-  inkcoreapi int marshal_file_size(char *);                  // INT
-  inkcoreapi int marshal_plugin_identity_id(char *);         // INT
-  inkcoreapi int marshal_plugin_identity_tag(char *);        // STR
-  inkcoreapi int marshal_process_uuid(char *);               // STR
-  inkcoreapi int marshal_client_http_connection_id(char *);  // INT
-  inkcoreapi int marshal_client_http_transaction_id(char *); // INT
-  inkcoreapi int marshal_cache_lookup_url_canon(char *);     // STR
+  inkcoreapi int marshal_transfer_time_ms(char *);                            // INT
+  inkcoreapi int marshal_transfer_time_s(char *);                             // INT
+  inkcoreapi int marshal_file_size(char *);                                   // INT
+  inkcoreapi int marshal_plugin_identity_id(char *);                          // INT
+  inkcoreapi int marshal_plugin_identity_tag(char *);                         // STR
+  inkcoreapi int marshal_process_uuid(char *);                                // STR
+  inkcoreapi int marshal_client_http_connection_id(char *);                   // INT
+  inkcoreapi int marshal_client_http_transaction_id(char *);                  // INT
+  inkcoreapi int marshal_client_http_transaction_priority_weight(char *);     // INT
+  inkcoreapi int marshal_client_http_transaction_priority_dependence(char *); // INT
+  inkcoreapi int marshal_cache_lookup_url_canon(char *);                      // STR
 
   // named fields from within a http header
   //


### PR DESCRIPTION
Adding format strings to log priority weight and dependence for a transaction so we can understand changes in performance characteristics when enabling HTTP/2 priority.