### PR TITLE
Clear api set bit to avoid crash in following redirect.

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -7782,6 +7782,9 @@ HttpSM::redirect_request(const char *arg_redirect_url, const int arg_redirect_le
   t_state.server_info.clear();
   t_state.parent_info.clear();
 
+  // Must reset whether the InkAPI has set the destination address
+  t_state.api_server_addr_set = false;
+
   if (t_state.txn_conf->cache_http) {
     t_state.cache_info.object_read = nullptr;
   }


### PR DESCRIPTION
Found while testing 9.0 in our environment.  After processing traffic, the traffic_server process crashes with the following at the top of the stack.

```
{code}
#0  0x00002aab8bd99207 in raise () from /lib64/libc.so.6
#1  0x00002aab8bd9a8f8 in abort () from /lib64/libc.so.6
#2  0x00002aab8930362b in ink_abort (message_format=message_format@entry=0x2aab8936ce47 "%s:%d: failed assertion `%s`") at ink_error.cc:99
#3  0x00002aab89300de5 in _ink_assert (expression=expression@entry=0x760a90 "s->http_config_param->redirect_actions_map->contains(s->host_db_info.ip(), reinterpret_cast<void **>(&x))", 
    file=file@entry=0x765ac0 "HttpTransact.cc", line=line@entry=1685) at ink_assert.cc:37
#4  0x0000000000574b41 in HttpTransact::OSDNSLookup (s=0x2aad461e1878) at /home/shinrich/build/_build/build_debug_posix-x86_64/trafficserver9/iocore/hostdb/I_HostDBProcessor.h:198
#5  0x0000000000538216 in HttpSM::call_transact_and_set_next_state (this=this@entry=0x2aad461e1800, f=f@entry=0x0) at HttpSM.cc:7108
#6  0x000000000054df4f in HttpSM::set_next_state (this=0x2aad461e1800) at HttpSM.cc:7192
#7  0x000000000053811f in HttpSM::call_transact_and_set_next_state (this=this@entry=0x2aad461e1800, f=f@entry=0x0) at HttpSM.cc:7116
#8  0x000000000054796a in HttpSM::handle_api_return (this=0x2aad461e1800) at HttpSM.cc:1570
#9  0x0000000000543206 in HttpSM::state_api_callout(int, void*) () at HttpSM.cc:1502
#10 0x0000000000546527 in HttpSM::state_api_callback (this=this@entry=0x2aad461e1800, event=event@entry=60000, data=data@entry=0x0) at HttpSM.cc:1311
#11 0x00000000004ec2f1 in TSHttpTxnReenable () at traffic_server/InkAPI.cc:6101
#12 0x00002aabaa7e990e in main_handler (cont=<optimized out>, event=<optimized out>, edata=0x2aad461e1800) at regex_revalidate/regex_revalidate.c:453
#13 0x00000000004d8ef3 in INKContInternal::handle_event (this=0x2aab8ca9dca0, event=60015, edata=0x2aad461e1800) at traffic_server/InkAPI.cc:1101
#14 0x00000000004e9a96 in handleEvent (data=0x2aad461e1800, event=60015, this=0x2aab8ca9dca0)
    at /home/shinrich/build/_build/build_debug_posix-x86_64/trafficserver9/iocore/eventsystem/I_Continuation.h:190
#15 APIHook::invoke(int, void*) const () at traffic_server/InkAPI.cc:1338
#16 0x0000000000542dcc in HttpSM::state_api_callout(int, void*) () at HttpSM.cc:1435
#17 0x0000000000546527 in HttpSM::state_api_callback (this=this@entry=0x2aad461e1800, event=event@entry=60000, data=data@entry=0x0) at HttpSM.cc:1311
#18 0x00000000004ec2f1 in TSHttpTxnReenable () at traffic_server/InkAPI.cc:6101
#19 0x00002aaba378abcd in carpLookup(tsapi_cont*, TSEvent, void*) () at _vcs/carp-9/carp/carp.cc:767
#20 0x00000000004d8ef3 in INKContInternal::handle_event (this=0x2aab8f10c100, event=60015, edata=0x2aad461e1800) at traffic_server/InkAPI.cc:1101
#21 0x00000000004e9a96 in handleEvent (data=0x2aad461e1800, event=60015, this=0x2aab8f10c100)
    at /home/shinrich/build/_build/build_debug_posix-x86_64/trafficserver9/iocore/eventsystem/I_Continuation.h:190
#22 APIHook::invoke(int, void*) const () at traffic_server/InkAPI.cc:1338
#23 0x0000000000542dcc in HttpSM::state_api_callout(int, void*) () at HttpSM.cc:1435
#24 0x0000000000543828 in HttpSM::do_api_callout_internal (this=this@entry=0x2aad461e1800) at HttpSM.cc:5096
#25 0x00000000005462a8 in do_api_callout (this=0x2aad461e1800) at HttpSM.cc:361
#26 setup_cache_lookup_complete_api (this=0x2aad461e1800) at HttpSM.cc:2464
#27 HttpSM::state_cache_open_read (this=0x2aad461e1800, event=<optimized out>, data=0xffffffffffffb050) at HttpSM.cc:2526
#28 0x00000000005455b3 in HttpSM::main_handler (this=0x2aad461e1800, event=1103, data=0xffffffffffffb050) at HttpSM.cc:2568
#29 0x000000000059250a in handleEvent (data=0xffffffffffffb050, event=1103, this=0x2aad461e1800)
    at /home/shinrich/build/_build/build_debug_posix-x86_64/trafficserver9/iocore/eventsystem/I_Continuation.h:190
#30 HttpCacheSM::state_cache_open_read (this=<optimized out>, event=<optimized out>, data=0xffffffffffffb050) at HttpCacheSM.cc:133
#31 0x0000000000664537 in Cache::open_read(Continuation*, ats::CryptoHash const*, HTTPHdr*, OverridableHttpConfigParams*, CacheFragType, char const*, int) () at CacheRead.cc:151
#32 0x0000000000642008 in CacheProcessor::open_read (this=<optimized out>, cont=cont@entry=0x2aad461e3560, key=<optimized out>, request=<optimized out>, params=<optimized out>, 
    pin_in_cache=<optimized out>, type=CACHE_FRAG_TYPE_HTTP) at Cache.cc:3264
#33 0x00000000005922e7 in HttpCacheSM::do_cache_open_read (this=this@entry=0x2aad461e3560, key=...) at HttpCacheSM.cc:238
#34 0x0000000000592897 in HttpCacheSM::open_read (this=this@entry=0x2aad461e3560, key=key@entry=0x2aab91c188a0, url=url@entry=0x2aad461e1f40, hdr=hdr@entry=0x2aad461e1f28, params=<optimized out>, 
    pin_in_cache=<optimized out>) at HttpCacheSM.cc:271
#35 0x0000000000535636 in HttpSM::do_cache_lookup_and_read (this=this@entry=0x2aad461e1800) at HttpSM.cc:4489
#36 0x000000000054de31 in HttpSM::set_next_state (this=0x2aad461e1800) at HttpSM.cc:7286
#37 0x000000000053811f in HttpSM::call_transact_and_set_next_state (this=this@entry=0x2aad461e1800, f=<optimized out>) at HttpSM.cc:7116
#38 0x0000000000547b4f in HttpSM::handle_api_return (this=0x2aad461e1800) at HttpSM.cc:1669
#39 0x000000000054e481 in HttpSM::set_next_state (this=0x2aad461e1800) at HttpSM.cc:7350
#40 0x000000000053811f in HttpSM::call_transact_and_set_next_state (this=this@entry=0x2aad461e1800, f=f@entry=0x0) at HttpSM.cc:7116
#41 0x000000000054796a in HttpSM::handle_api_return (this=0x2aad461e1800) at HttpSM.cc:1570
#42 0x0000000000543206 in HttpSM::state_api_callout(int, void*) () at HttpSM.cc:1502
#43 0x0000000000546527 in HttpSM::state_api_callback (this=this@entry=0x2aad461e1800, event=event@entry=60000, data=data@entry=0x0) at HttpSM.cc:1311
#44 0x00000000004ec2f1 in TSHttpTxnReenable () at traffic_server/InkAPI.cc:6101
#45 0x00002aaba3788149 in onReadResponse (contp=<optimized out>, event=<optimized out>, edata=0x2aad461e1800) at _vcs/carp-9/carp/carp.cc:1008
#46 onReadResponse (contp=<optimized out>, event=<optimized out>, edata=0x2aad461e1800) at _vcs/carp-9/carp/carp.cc:993
#47 0x00000000004d8ef3 in INKContInternal::handle_event (this=0x2aab9b923140, event=60006, edata=0x2aad461e1800) at traffic_server/InkAPI.cc:1101
#48 0x00000000004e9a96 in handleEvent (data=0x2aad461e1800, event=60006, this=0x2aab9b923140)
    at /home/shinrich/build/_build/build_debug_posix-x86_64/trafficserver9/iocore/eventsystem/I_Continuation.h:190
#49 APIHook::invoke(int, void*) const () at traffic_server/InkAPI.cc:1338
#50 0x0000000000542dcc in HttpSM::state_api_callout(int, void*) () at HttpSM.cc:1435
#51 0x0000000000546527 in HttpSM::state_api_callback (this=this@entry=0x2aad461e1800, event=event@entry=60000, data=data@entry=0x0) at HttpSM.cc:1311
#52 0x00000000004ec2f1 in TSHttpTxnReenable () at traffic_server/InkAPI.cc:6101
#53 0x00002aabaa1b6b46 in cont_rewrite_headers (contp=<optimized out>, event=<optimized out>, edata=0x2aad461e1800) at header_rewrite/header_rewrite.cc:310
#54 0x00000000004d8ef3 in INKContInternal::handle_event (this=0x2aab8ca9d980, event=60006, edata=0x2aad461e1800) at traffic_server/InkAPI.cc:1101
#55 0x00000000004e9a96 in handleEvent (data=0x2aad461e1800, event=60006, this=0x2aab8ca9d980)
    at /home/shinrich/build/_build/build_debug_posix-x86_64/trafficserver9/iocore/eventsystem/I_Continuation.h:190
#56 APIHook::invoke(int, void*) const () at traffic_server/InkAPI.cc:1338
#57 0x0000000000542dcc in HttpSM::state_api_callout(int, void*) () at HttpSM.cc:1435
#58 0x0000000000546527 in HttpSM::state_api_callback (this=this@entry=0x2aad461e1800, event=event@entry=60000, data=data@entry=0x0) at HttpSM.cc:1311
#59 0x00000000004ec2f1 in TSHttpTxnReenable () at traffic_server/InkAPI.cc:6101
#60 0x00002aaba3bb1037 in handle_response (txnp=0x2aad461e1800) at experimental/custom_redirect/custom_redirect.cc:87
#61 plugin_main_handler (contp=<optimized out>, event=TS_EVENT_HTTP_READ_RESPONSE_HDR, edata=0x2aad461e1800) at experimental/custom_redirect/custom_redirect.cc:97
#62 plugin_main_handler (contp=<optimized out>, event=<optimized out>, edata=0x2aad461e1800) at experimental/custom_redirect/custom_redirect.cc:91
#63 0x00000000004d8ef3 in INKContInternal::handle_event (this=0x2aab8f10c240, event=60006, edata=0x2aad461e1800) at traffic_server/InkAPI.cc:1101
#64 0x00000000004e9a96 in handleEvent (data=0x2aad461e1800, event=60006, this=0x2aab8f10c240)
    at /home/shinrich/build/_build/build_debug_posix-x86_64/trafficserver9/iocore/eventsystem/I_Continuation.h:190
#65 APIHook::invoke(int, void*) const () at traffic_server/InkAPI.cc:1338
#66 0x0000000000542dcc in HttpSM::state_api_callout(int, void*) () at HttpSM.cc:1435
#67 0x0000000000546527 in HttpSM::state_api_callback (this=this@entry=0x2aad461e1800, event=event@entry=60000, data=data@entry=0x0) at HttpSM.cc:1311
#68 0x00000000004ec2f1 in TSHttpTxnReenable () at traffic_server/InkAPI.cc:6101
#69 0x00002aaba2075ed5 in http_hook (contp=<optimized out>, event=<optimized out>, edata=0x2aad461e1800) at _vcs/yahoo_connection-9/yahoo_connection/INKPluginInit.cc:439
#70 0x00000000004d8ef3 in INKContInternal::handle_event (this=0x2aab8f10a800, event=60006, edata=0x2aad461e1800) at traffic_server/InkAPI.cc:1101
#71 0x00000000004e9a96 in handleEvent (data=0x2aad461e1800, event=60006, this=0x2aab8f10a800)
    at /home/shinrich/build/_build/build_debug_posix-x86_64/trafficserver9/iocore/eventsystem/I_Continuation.h:190
#72 APIHook::invoke(int, void*) const () at traffic_server/InkAPI.cc:1338
#73 0x0000000000542dcc in HttpSM::state_api_callout(int, void*) () at HttpSM.cc:1435
#74 0x0000000000543b70 in HttpSM::state_read_server_response_header (this=0x2aad461e1800, event=100, data=0x2aadb2a3c5d0) at HttpSM.cc:1960
#75 0x00000000005455b3 in HttpSM::main_handler (this=0x2aad461e1800, event=100, data=0x2aadb2a3c5d0) at HttpSM.cc:2568
#76 0x00000000006f96e5 in handleEvent (data=0x2aadb2a3c5d0, event=100, this=0x2aad461e1800)
    at /home/shinrich/build/_build/build_debug_posix-x86_64/trafficserver9/iocore/eventsystem/I_Continuation.h:190
#77 read_signal_and_update (event=100, vc=0x2aadb2a3c400) at UnixNetVConnection.cc:83
#78 0x00000000006febbf in read_from_net(NetHandler*, UnixNetVConnection*, EThread*) () at UnixNetVConnection.cc:309
#79 0x00000000006ef53d in NetHandler::process_ready_list (this=this@entry=0x2aab8f25fad0) at UnixNet.cc:400
#80 0x00000000006ef8ff in NetHandler::waitForActivity(long) () at UnixNet.cc:533
#81 0x000000000073c1b3 in EThread::execute_regular (this=this@entry=0x2aab8f25bd80) at UnixEThread.cc:274
#82 0x000000000073c3ca in EThread::execute (this=0x2aab8f25bd80) at UnixEThread.cc:338
#83 0x000000000073a819 in spawn_thread_internal (a=0x2aab8cae17c0) at Thread.cc:92
#84 0x00002aab8b12bdd5 in start_thread () from /lib64/libpthread.so.0
#85 0x00002aab8be60ead in clone () from /lib64/libc.so.6
```

It turns out the request was following a redirect, so this was the second time through the DNS lookup logic.  Plus one of our plugins called TSHttpTxnServerAddSet on the first time through.  But the api set bit is not cleared, so the second time through no address is set and not DNS lookup is performed causing bad things to happen.

I had caught this in our 7.1.x branch but forgot to get this pushed to open source.   Locally applied and it has been merrily running in production without issue.  For much longer than yesterday.