### PR TITLE
Change the ready checks for ats to use the actual ats port

### DIFF
--- a/tests/gold_tests/headers/syntax.test.py
+++ b/tests/gold_tests/headers/syntax.test.py
@@ -40,8 +40,8 @@ ts.Disk.remap_config.AddLine(
 
 # Test 1 - 200 Response
 tr = Test.AddTestRun()
-tr.Processes.Default.StartBefore(server)
-tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(server.Variables.Port))
+tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Port))
+tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.port))
 tr.Processes.Default.Command = 'curl -s -D - -v --ipv4 --http1.1 -H " foo: bar" -H "Host: www.example.com" http://localhost:{0}/'.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "syntax.200.gold"


### PR DESCRIPTION
Currently the autest for syntax checks if the miniserver port is ready when marking ATS as ready. This should be the ATS port.  Also adding a readiness check for the miniserver on it's port.