### PR TITLE
"Plugin (un)used" post reload notification

### DIFF
--- a/doc/developer-guide/api/functions/TSRemap.en.rst
+++ b/doc/developer-guide/api/functions/TSRemap.en.rst
@@ -72,8 +72,10 @@ invoked by current and all previous still used configurations. This is an option
 
 :func:`TSRemapPostConfigReload` is called to indicate the end of the the new remap configuration
 load. It is called on the newly and previously loaded plugins, invoked by the new, current and
-previous still used configurations. It also indicates if the configuration reload was successful
-by passing :macro:`TS_SUCCESS` or :macro:`TS_ERROR`. This is an optional entry point.
+previous still used configurations. It also indicates wheather the configuration reload was successful
+by passing :macro:`TSREMAP_CONFIG_RELOAD_FAILURE` in case of failure and to notify the plugins if they
+are going to be part of the new configuration by passing :macro:`TSREMAP_CONFIG_RELOAD_SUCCESS_PLUGIN_USED`
+or :macro:`TSREMAP_CONFIG_RELOAD_SUCCESS_PLUGIN_UNUSED`. This is an optional entry point.
 
 Generally speaking, calls to these functions are mutually exclusive. The exception
 is for functions which take an HTTP transaction as a parameter. Calls to these
@@ -110,6 +112,20 @@ Types
 
         The remapping attempt in general failed and the transaction should fail with an
         error return to the user agent.
+
+.. type:: TSRemapReloadStatus
+
+    .. macro:: TSREMAP_CONFIG_RELOAD_FAILURE
+
+        Notify the plugin that configuration parsing failed.
+
+    .. macro:: TSREMAP_CONFIG_RELOAD_SUCCESS_PLUGIN_USED
+
+        Configuration parsing succeeded and plugin was used by the new configuration.
+
+    .. macro:: TSREMAP_CONFIG_RELOAD_SUCCESS_PLUGIN_UNUSED
+
+        Configuration parsing succeeded but plugin was NOT used by the new configuration.
 
 Return Values
 =============

--- a/include/ts/remap.h
+++ b/include/ts/remap.h
@@ -75,6 +75,16 @@ typedef enum {
   TSREMAP_ERROR = -1 /* Some error, that should generate an error page */
 } TSRemapStatus;
 
+/* Status code passed to the plugin by TSRemapPostConfigReload() signaling
+ * (1) if the configuration reload was successful and
+ * (2) if (1) is successful show if the plugin was part of the new configuration */
+typedef enum {
+  TSREMAP_CONFIG_RELOAD_FAILURE             = 0, /* notify the plugin that configuration parsing failed */
+  TSREMAP_CONFIG_RELOAD_SUCCESS_PLUGIN_USED = 1, /* configuration parsing succeeded and plugin was used by the new configuration */
+  TSREMAP_CONFIG_RELOAD_SUCCESS_PLUGIN_UNUSED =
+    2 /* configuration parsing succeeded but plugin was NOT used by the new configuration */
+} TSRemapReloadStatus;
+
 /* ----------------------------------------------------------------------------------
    These are the entry points a plugin can implement. Note that TSRemapInit() and
    TSRemapDoRemap() are both required.
@@ -108,7 +118,7 @@ tsapi void TSRemapPreConfigReload(void);
                           TS_ERROR - (re)load failed.
    Return: none
 */
-tsapi void TSRemapPostConfigReload(TSReturnCode reloadStatus);
+tsapi void TSRemapPostConfigReload(TSRemapReloadStatus reloadStatus);
 
 /* Remap new request
    Mandatory interface function.

--- a/proxy/http/remap/PluginDso.h
+++ b/proxy/http/remap/PluginDso.h
@@ -34,6 +34,7 @@
 #include <ctime>
 
 #include "ts/apidefs.h"
+#include "ts/remap.h"
 #include "tscore/ts_file.h"
 namespace fs = ts::file;
 
@@ -75,10 +76,10 @@ public:
   using PluginList = ts::IntrusiveDList<PluginDso::Linkage>;
 
   /* Methods to be called when processing a list of plugins, to be overloaded by the remap or the global plugins correspondingly */
-  virtual void indicatePreReload()                           = 0;
-  virtual void indicatePostReload(TSReturnCode reloadStatus) = 0;
-  virtual bool init(std::string &error)                      = 0;
-  virtual void done()                                        = 0;
+  virtual void indicatePreReload()                                  = 0;
+  virtual void indicatePostReload(TSRemapReloadStatus reloadStatus) = 0;
+  virtual bool init(std::string &error)                             = 0;
+  virtual void done()                                               = 0;
 
   void acquire();
   void release();

--- a/proxy/http/remap/PluginFactory.h
+++ b/proxy/http/remap/PluginFactory.h
@@ -102,7 +102,7 @@ public:
 
   void deactivate();
   void indicatePreReload();
-  void indicatePostReload(TSReturnCode reloadStatus);
+  void indicatePostReload(bool reloadSuccessful);
 
 protected:
   PluginDso *findByEffectivePath(const fs::path &path);

--- a/proxy/http/remap/RemapConfig.cc
+++ b/proxy/http/remap/RemapConfig.cc
@@ -1329,7 +1329,7 @@ remap_parse_config(const char *path, UrlRewrite *rewrite)
 
   /* Now after we parsed the configuration and (re)loaded plugins and plugin instances
    * accordingly notify all plugins that we are done */
-  rewrite->pluginFactory.indicatePostReload(status ? TS_SUCCESS : TS_ERROR);
+  rewrite->pluginFactory.indicatePostReload(status);
 
   return status;
 }

--- a/proxy/http/remap/RemapPluginInfo.cc
+++ b/proxy/http/remap/RemapPluginInfo.cc
@@ -258,7 +258,7 @@ RemapPluginInfo::indicatePreReload()
 }
 
 void
-RemapPluginInfo::indicatePostReload(TSReturnCode reloadStatus)
+RemapPluginInfo::indicatePostReload(TSRemapReloadStatus reloadStatus)
 {
   setPluginContext();
 

--- a/proxy/http/remap/RemapPluginInfo.h
+++ b/proxy/http/remap/RemapPluginInfo.h
@@ -57,7 +57,7 @@ public:
   /// Reload function, called to inform the plugin that configuration is going to be reloaded.
   using PreReload_F = void();
   /// Reload function, called to inform the plugin that configuration is done reloading.
-  using PostReload_F = void(TSReturnCode);
+  using PostReload_F = void(TSRemapReloadStatus);
   /// Called when remapping for a transaction has finished.
   using Done_F = void();
   /// Create an rule instance.
@@ -99,7 +99,7 @@ public:
 
   /* Used by traffic server core to indicate configuration reload */
   virtual void indicatePreReload();
-  virtual void indicatePostReload(TSReturnCode reloadStatus);
+  virtual void indicatePostReload(TSRemapReloadStatus reloadStatus);
 
 protected:
   /* Utility to be used only with unit testing */

--- a/proxy/http/remap/unit-tests/plugin_testing_calls.cc
+++ b/proxy/http/remap/unit-tests/plugin_testing_calls.cc
@@ -109,10 +109,10 @@ TSRemapPreConfigReload(void)
 }
 
 void
-TSRemapPostConfigReload(TSReturnCode reloadStatus)
+TSRemapPostConfigReload(TSRemapReloadStatus reloadStatus)
 {
   debugObject.postReloadConfigCalled++;
-  debugObject.postReloadConfigSuccess = (TS_SUCCESS == reloadStatus);
+  debugObject.postReloadConfigStatus = reloadStatus;
 }
 
 /* The folowing functions are meant for unit testing */

--- a/proxy/http/remap/unit-tests/plugin_testing_common.h
+++ b/proxy/http/remap/unit-tests/plugin_testing_common.h
@@ -51,19 +51,19 @@ public:
   void
   clear()
   {
-    contextInit             = nullptr;
-    contextInitInstance     = nullptr;
-    doRemapCalled           = 0;
-    initCalled              = 0;
-    doneCalled              = 0;
-    initInstanceCalled      = 0;
-    deleteInstanceCalled    = 0;
-    preReloadConfigCalled   = 0;
-    postReloadConfigCalled  = 0;
-    postReloadConfigSuccess = 0;
-    ih                      = nullptr;
-    argc                    = 0;
-    argv                    = nullptr;
+    contextInit            = nullptr;
+    contextInitInstance    = nullptr;
+    doRemapCalled          = 0;
+    initCalled             = 0;
+    doneCalled             = 0;
+    initInstanceCalled     = 0;
+    deleteInstanceCalled   = 0;
+    preReloadConfigCalled  = 0;
+    postReloadConfigCalled = 0;
+    postReloadConfigStatus = TSREMAP_CONFIG_RELOAD_FAILURE;
+    ih                     = nullptr;
+    argc                   = 0;
+    argv                   = nullptr;
   }
 
   /* Input fields used to set the test behavior of the plugin call-backs */
@@ -71,19 +71,19 @@ public:
   void *input_ih;    /* the value to be returned by the plugin instance init function */
 
   /* Output fields showing what happend during the test */
-  const PluginThreadContext *contextInit         = nullptr; /* plugin initialization context */
-  const PluginThreadContext *contextInitInstance = nullptr; /* plugin instance initialization context */
-  int doRemapCalled                              = 0;       /* mark if remap was called */
-  int initCalled                                 = 0;       /* mark if plugin init was called */
-  int doneCalled                                 = 0;       /* mark if done was called */
-  int initInstanceCalled                         = 0;       /* mark if instance init was called */
-  int deleteInstanceCalled                       = 0;       /* mark if delete instance was called */
-  int preReloadConfigCalled                      = 0;       /* mark if pre-reload config was called */
-  int postReloadConfigCalled                     = 0;       /* mark if post-reload config was called */
-  bool postReloadConfigSuccess                   = 0;       /* mark if plugin reload status is passed correctly */
-  void *ih                                       = nullptr; /* instance handler */
-  int argc                                       = 0;       /* number of plugin instance parameters received by the plugin */
-  char **argv                                    = nullptr; /* plugin instance parameters received by the plugin */
+  const PluginThreadContext *contextInit         = nullptr;                   /* plugin initialization context */
+  const PluginThreadContext *contextInitInstance = nullptr;                   /* plugin instance initialization context */
+  int doRemapCalled                              = 0;                         /* mark if remap was called */
+  int initCalled                                 = 0;                         /* mark if plugin init was called */
+  int doneCalled                                 = 0;                         /* mark if done was called */
+  int initInstanceCalled                         = 0;                         /* mark if instance init was called */
+  int deleteInstanceCalled                       = 0;                         /* mark if delete instance was called */
+  int preReloadConfigCalled                      = 0;                         /* mark if pre-reload config was called */
+  int postReloadConfigCalled                     = 0;                         /* mark if post-reload config was called */
+  TSRemapReloadStatus postReloadConfigStatus = TSREMAP_CONFIG_RELOAD_FAILURE; /* mark if plugin reload status is passed correctly */
+  void *ih                                   = nullptr;                       /* instance handler */
+  int argc                                   = 0;       /* number of plugin instance parameters received by the plugin */
+  char **argv                                = nullptr; /* plugin instance parameters received by the plugin */
 };
 
 #ifdef __cplusplus

--- a/proxy/http/remap/unit-tests/test_PluginDso.cc
+++ b/proxy/http/remap/unit-tests/test_PluginDso.cc
@@ -73,7 +73,7 @@ public:
   {
   }
   virtual void
-  indicatePostReload(TSReturnCode reloadStatus)
+  indicatePostReload(TSRemapReloadStatus reloadStatus)
   {
   }
   virtual bool

--- a/proxy/http/remap/unit-tests/test_PluginFactory.cc
+++ b/proxy/http/remap/unit-tests/test_PluginFactory.cc
@@ -556,7 +556,7 @@ SCENARIO("notifying plugins of config reload", "[plugin][core]")
   {
     WHEN("(1) signal pre-new-config-load, (2) signal post-new-config-load, (3) old-config deactivate")
     {
-      /* Simulate configuration without plugins - an unused factory */
+      /* Simulate configuration with 1 factory and 1 plugin */
       setupConfigPathTest(configName1, buildPath, uuid_t1, effectivePath1, runtimePath1, 1556825556);
       PluginFactoryUnitTest *factory1 = getFactory(uuid_t1);
       RemapPluginInst *plugin1        = factory1->getRemapPlugin(configName1, 0, nullptr, error);
@@ -581,19 +581,19 @@ SCENARIO("notifying plugins of config reload", "[plugin][core]")
 
         /* Assume (re)load was done OK and test */
         debugObject->clear();
-        factory1->indicatePostReload(TS_SUCCESS);
+        factory1->indicatePostReload(/* reload succeeded */ true);
         CHECK(0 == debugObject->deleteInstanceCalled);
         CHECK(0 == debugObject->doneCalled);
         CHECK(1 == debugObject->postReloadConfigCalled);
-        CHECK(true == debugObject->postReloadConfigSuccess);
+        CHECK(TSREMAP_CONFIG_RELOAD_SUCCESS_PLUGIN_USED == debugObject->postReloadConfigStatus);
 
         /* Assume (re)load failed and test */
         debugObject->clear();
-        factory1->indicatePostReload(TS_ERROR);
+        factory1->indicatePostReload(/* reload succeeded */ false);
         CHECK(0 == debugObject->deleteInstanceCalled);
         CHECK(0 == debugObject->doneCalled);
         CHECK(1 == debugObject->postReloadConfigCalled);
-        CHECK(false == debugObject->postReloadConfigSuccess);
+        CHECK(TSREMAP_CONFIG_RELOAD_FAILURE == debugObject->postReloadConfigStatus);
 
         /* ... swap the new and the old config ... */
 
@@ -613,7 +613,7 @@ SCENARIO("notifying plugins of config reload", "[plugin][core]")
   {
     WHEN("(1) signal pre-new-config-load, (2) signal post-new-config-load, (3) old-config deactivate")
     {
-      /* Simulate configuration without plugins - an unused factory */
+      /* Simulate configuration with 1 factories and 2 plugin */
       setupConfigPathTest(configName1, buildPath, uuid_t1, effectivePath1, runtimePath1, 1556825556);
       setupConfigPathTest(configName2, buildPath, uuid_t1, effectivePath2, runtimePath2, 1556825556, /* append */ true);
       PluginFactoryUnitTest *factory1 = getFactory(uuid_t1);
@@ -646,28 +646,28 @@ SCENARIO("notifying plugins of config reload", "[plugin][core]")
         /* Assume (re)load was done OK */
         debugObject1->clear();
         debugObject2->clear();
-        factory1->indicatePostReload(TS_SUCCESS);
+        factory1->indicatePostReload(/* reload succeeded */ true);
         CHECK(0 == debugObject1->deleteInstanceCalled);
         CHECK(0 == debugObject1->doneCalled);
         CHECK(1 == debugObject1->postReloadConfigCalled);
-        CHECK(true == debugObject1->postReloadConfigSuccess);
+        CHECK(TSREMAP_CONFIG_RELOAD_SUCCESS_PLUGIN_USED == debugObject1->postReloadConfigStatus);
         CHECK(0 == debugObject2->deleteInstanceCalled);
         CHECK(0 == debugObject2->doneCalled);
         CHECK(1 == debugObject2->postReloadConfigCalled);
-        CHECK(true == debugObject2->postReloadConfigSuccess);
+        CHECK(TSREMAP_CONFIG_RELOAD_SUCCESS_PLUGIN_USED == debugObject2->postReloadConfigStatus);
 
         /* Assume (re)load failed */
         debugObject1->clear();
         debugObject2->clear();
-        factory1->indicatePostReload(TS_ERROR);
+        factory1->indicatePostReload(/* reload succeeded */ false);
         CHECK(0 == debugObject1->deleteInstanceCalled);
         CHECK(0 == debugObject1->doneCalled);
         CHECK(1 == debugObject1->postReloadConfigCalled);
-        CHECK(false == debugObject1->postReloadConfigSuccess);
+        CHECK(TSREMAP_CONFIG_RELOAD_FAILURE == debugObject1->postReloadConfigStatus);
         CHECK(0 == debugObject2->deleteInstanceCalled);
         CHECK(0 == debugObject2->doneCalled);
         CHECK(1 == debugObject2->postReloadConfigCalled);
-        CHECK(false == debugObject2->postReloadConfigSuccess);
+        CHECK(TSREMAP_CONFIG_RELOAD_FAILURE == debugObject2->postReloadConfigStatus);
 
         /* ... swap the new and the old config ... */
 
@@ -691,7 +691,7 @@ SCENARIO("notifying plugins of config reload", "[plugin][core]")
   {
     WHEN("indicating de-activation of the factories")
     {
-      /* Simulate configuration without plugins - an unused factory */
+      /* Simulate configuration with 2 factories and 1 plugin */
       setupConfigPathTest(configName1, buildPath, uuid_t1, effectivePath1, runtimePath1, 1556825556);
       PluginFactoryUnitTest *factory1 = getFactory(uuid_t1);
       PluginFactoryUnitTest *factory2 = getFactory(uuid_t2);
@@ -719,6 +719,65 @@ SCENARIO("notifying plugins of config reload", "[plugin][core]")
         CHECK(0 == debugObject1->preReloadConfigCalled);
 
         delete factory1;
+      }
+
+      clean();
+    }
+  }
+
+  GIVEN("configuration with 2 plugin loaded by 2 factories")
+  {
+    WHEN("2 plugins are loaded by the 1st factory and only one of them loaded by the 2nd factory")
+    {
+      /* Simulate configuration with 2 factories and 2 different plugins */
+      setupConfigPathTest(configName1, buildPath, uuid_t1, effectivePath1, runtimePath1, 1556825556, /* append */ false);
+      setupConfigPathTest(configName2, buildPath, uuid_t1, effectivePath2, runtimePath2, 1556825556, /* append */ true);
+      PluginFactoryUnitTest *factory1 = getFactory(uuid_t1);
+      PluginFactoryUnitTest *factory2 = getFactory(uuid_t2);
+
+      /* 2 plugins loaded by the 1st factory */
+      RemapPluginInst *pluginInst1 = factory1->getRemapPlugin(configName1, 0, nullptr, error);
+      RemapPluginInst *pluginInst2 = factory1->getRemapPlugin(configName2, 0, nullptr, error);
+
+      /* only 1 plugin loaded by the 2st factory */
+      RemapPluginInst *pluginInst3 = factory2->getRemapPlugin(configName1, 0, nullptr, error);
+
+      /* pluginInst1 and pluginInst3 should be using the same plugin DSO named configName1
+       * pluginInst2 should be using plugin DSO named configName 2*/
+      CHECK_FALSE(nullptr == pluginInst1);
+      CHECK_FALSE(nullptr == pluginInst2);
+      CHECK_FALSE(nullptr == pluginInst3);
+      CHECK(&pluginInst1->_plugin == &pluginInst3->_plugin);
+
+      /* Get test objects for the 2 plugins used by the 3 instances from the 2 factories */
+      PluginDebugObject *debugObject1 = getDebugObject(pluginInst1->_plugin);
+      PluginDebugObject *debugObject2 = getDebugObject(pluginInst2->_plugin);
+
+      THEN(
+        "expect the plugin that is not loaded by the second factory to receive 'plugin unused' notification from the 2nd factory")
+      {
+        /* Factory 1: reload was OK and both plugins were part of the configuration that used/instantiated that factory */
+        debugObject1->clear();
+        debugObject2->clear();
+
+        factory1->indicatePostReload(/* reload succeeded */ true);
+        CHECK(1 == debugObject1->postReloadConfigCalled);
+        CHECK(TSREMAP_CONFIG_RELOAD_SUCCESS_PLUGIN_USED == debugObject1->postReloadConfigStatus);
+        CHECK(1 == debugObject2->postReloadConfigCalled);
+        CHECK(TSREMAP_CONFIG_RELOAD_SUCCESS_PLUGIN_USED == debugObject2->postReloadConfigStatus);
+
+        /* Factory 2: (re)load was OK and only 1 plugin was part of the configuration that used/instantiated that factory */
+        debugObject1->clear();
+        debugObject2->clear();
+
+        factory2->indicatePostReload(/* reload succeeded */ true);
+        CHECK(1 == debugObject1->postReloadConfigCalled);
+        CHECK(TSREMAP_CONFIG_RELOAD_SUCCESS_PLUGIN_USED == debugObject1->postReloadConfigStatus);
+        CHECK(1 == debugObject2->postReloadConfigCalled);
+        CHECK(TSREMAP_CONFIG_RELOAD_SUCCESS_PLUGIN_UNUSED == debugObject2->postReloadConfigStatus);
+
+        delete factory1;
+        delete factory2;
       }
 
       clean();

--- a/proxy/http/remap/unit-tests/test_RemapPlugin.cc
+++ b/proxy/http/remap/unit-tests/test_RemapPlugin.cc
@@ -422,17 +422,50 @@ SCENARIO("config reload", "[plugin][core]")
     bool result = loadPlugin(plugin, error, debugObject);
     CHECK(true == result);
 
-    WHEN("'config reload' is called")
+    WHEN("'config reload' failed")
     {
       debugObject->clear();
 
       plugin->indicatePreReload();
-      plugin->indicatePostReload(TS_SUCCESS);
+      plugin->indicatePostReload(TSREMAP_CONFIG_RELOAD_FAILURE);
 
       THEN("expect it to run")
       {
         CHECK(1 == debugObject->preReloadConfigCalled);
         CHECK(1 == debugObject->postReloadConfigCalled);
+        CHECK(TSREMAP_CONFIG_RELOAD_FAILURE == debugObject->postReloadConfigStatus);
+      }
+      cleanupSandBox(plugin);
+    }
+
+    WHEN("'config reload' is successful and the plugin is part of the new configuration")
+    {
+      debugObject->clear();
+
+      plugin->indicatePreReload();
+      plugin->indicatePostReload(TSREMAP_CONFIG_RELOAD_SUCCESS_PLUGIN_USED);
+
+      THEN("expect it to run")
+      {
+        CHECK(1 == debugObject->preReloadConfigCalled);
+        CHECK(1 == debugObject->postReloadConfigCalled);
+        CHECK(TSREMAP_CONFIG_RELOAD_SUCCESS_PLUGIN_USED == debugObject->postReloadConfigStatus);
+      }
+      cleanupSandBox(plugin);
+    }
+
+    WHEN("'config reload' is successful and the plugin is part of the new configuration")
+    {
+      debugObject->clear();
+
+      plugin->indicatePreReload();
+      plugin->indicatePostReload(TSREMAP_CONFIG_RELOAD_SUCCESS_PLUGIN_UNUSED);
+
+      THEN("expect it to run")
+      {
+        CHECK(1 == debugObject->preReloadConfigCalled);
+        CHECK(1 == debugObject->postReloadConfigCalled);
+        CHECK(TSREMAP_CONFIG_RELOAD_SUCCESS_PLUGIN_UNUSED == debugObject->postReloadConfigStatus);
       }
       cleanupSandBox(plugin);
     }


### PR DESCRIPTION
Most of the plugins is assumed to use per-plugin-instance data-structures
when reloading their configs and only a few of them that wish to optimize
performance or deal with the complexities of using per-plugin DSO "global"
data-structures would use plugin configuration reload notifications like
`TSRemapPreConfigReload` and `TSRemapPostConfigReload`.

Instead of trying to foresee the needs or the expectations of each use-case,
a more "open-ended" and straight-forward design was chosen for the configuration
reload notifications. The notifications are broadcasted to all loaded plugins
at the moments before and after the reload attempt, regardless of whether
a plugin is part of the new configuration or not.

During the `TSRemapPostConfigReload` we already decided to notify the
plugin if the plugin reload was successful or not so the plugins can
recover adequately in case of configuration reload failure.

This change adds a signal to show if the particaular plugin was part of
the new configuration. This will be beneficial for use-cases that expect
plugin reload notification not to be called in case they are not part of
the new configuration so they can ignore the notification.

This change also attempts to clarify related documentation and code
comments as well.