### PR TITLE
YAML config:  output erroneous keyword and line number

### DIFF
--- a/iocore/net/YamlSNIConfig.cc
+++ b/iocore/net/YamlSNIConfig.cc
@@ -117,10 +117,10 @@ template <> struct convert<YamlSNIConfig::Item> {
   static bool
   decode(const Node &node, YamlSNIConfig::Item &item)
   {
-    for (auto &&item : node) {
+    for (const auto &elem : node) {
       if (std::none_of(valid_sni_config_keys.begin(), valid_sni_config_keys.end(),
-                       [&item](const std::string &s) { return s == item.first.as<std::string>(); })) {
-        throw YAML::ParserException(item.Mark(), "unsupported key " + item.first.as<std::string>());
+                       [&elem](const std::string &s) { return s == elem.first.as<std::string>(); })) {
+        throw YAML::ParserException(elem.first.Mark(), "unsupported key " + elem.first.as<std::string>());
       }
     }
 

--- a/proxy/logging/YamlLogConfig.cc
+++ b/proxy/logging/YamlLogConfig.cc
@@ -120,7 +120,7 @@ YamlLogConfig::decodeLogObject(const YAML::Node &node)
   for (auto const &item : node) {
     if (std::none_of(valid_log_object_keys.begin(), valid_log_object_keys.end(),
                      [&item](const std::string &s) { return s == item.first.as<std::string>(); })) {
-      throw YAML::ParserException(item.Mark(), "log: unsupported key '" + item.first.as<std::string>() + "'");
+      throw YAML::ParserException(item.first.Mark(), "log: unsupported key '" + item.first.as<std::string>() + "'");
     }
   }
 

--- a/proxy/logging/YamlLogConfigDecoders.cc
+++ b/proxy/logging/YamlLogConfigDecoders.cc
@@ -36,10 +36,10 @@ namespace YAML
 bool
 convert<std::unique_ptr<LogFormat>>::decode(const Node &node, std::unique_ptr<LogFormat> &logFormat)
 {
-  for (auto &&item : node) {
+  for (const auto &item : node) {
     if (std::none_of(valid_log_format_keys.begin(), valid_log_format_keys.end(),
                      [&item](const std::string &s) { return s == item.first.as<std::string>(); })) {
-      throw YAML::ParserException(node.Mark(), "format: unsupported key '" + item.first.as<std::string>() + "'");
+      throw YAML::ParserException(item.first.Mark(), "format: unsupported key '" + item.first.as<std::string>() + "'");
     }
   }
 


### PR DESCRIPTION
 In YAML file it appears on in diags.log.