### PR TITLE
Fix use-after-free problem related to logging headers

### DIFF
--- a/proxy/hdrs/MIME.h
+++ b/proxy/hdrs/MIME.h
@@ -1036,7 +1036,7 @@ public:
   void value_append(const char *name, int name_length, const char *value, int value_length, bool prepend_comma = false,
                     const char separator = ',');
 
-  void field_value_set(MIMEField *field, const char *value, int value_length);
+  void field_value_set(MIMEField *field, const char *value, int value_length, bool reuse_heaps = false);
   void field_value_set_int(MIMEField *field, int32_t value);
   void field_value_set_uint(MIMEField *field, uint32_t value);
   void field_value_set_int64(MIMEField *field, int64_t value);
@@ -1092,6 +1092,12 @@ public:
   // No gratuitous copies & refcounts!
   MIMEHdr(const MIMEHdr &m) = delete;
   MIMEHdr &operator=(const MIMEHdr &m) = delete;
+
+private:
+  // Interface to replace (overwrite) field value without
+  // changing the heap as long as the new value is not longer
+  // than the current value
+  bool field_value_replace(MIMEField *field, const char *value, int value_length);
 };
 
 /*-------------------------------------------------------------------------
@@ -1397,10 +1403,23 @@ MIMEHdr::value_get_comma_list(const char *name, int name_length, StrList *list) 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-inline void
-MIMEHdr::field_value_set(MIMEField *field, const char *value, int value_length)
+inline bool
+MIMEHdr::field_value_replace(MIMEField *field, const char *value, int value_length)
 {
-  field->value_set(m_heap, m_mime, value, value_length);
+  if (field->m_len_value >= value_length) {
+    memcpy((char *)field->m_ptr_value, value, value_length);
+    field->m_len_value = value_length;
+    return true;
+  }
+  return false;
+}
+
+inline void
+MIMEHdr::field_value_set(MIMEField *field, const char *value, int value_length, bool reuse_heaps)
+{
+  if (!reuse_heaps || !field_value_replace(field, value, value_length)) {
+    field->value_set(m_heap, m_mime, value, value_length);
+  }
 }
 
 inline void

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -2841,7 +2841,10 @@ LogAccess::set_http_header_field(LogField::Container container, char *field, cha
       // Loop over dups, update each of them
       //
       while (fld) {
-        header->value_set((const char *)field, static_cast<int>(::strlen(field)), buf, len);
+        // make sure to reuse header heaps as otherwise
+        // coalesce logic in header heap may free up
+        // memory pointed to by cquuc or other log fields
+        header->field_value_set(fld, buf, len, true);
         fld = fld->m_next_dup;
       }
     }


### PR DESCRIPTION
mime_header_value_set() has a coalesce logic to coalesce dead allocations
in the header heap and in the process can free up previously allocated
strings that Logging references (cquuc etc).  When logging tries to
access those fields subsequently it results in a use-after-free
(caught using ASAN build). In the wipe field logging use case, there
isn't a need to recreate new header heaps, just need to replace the
fields with wiped values. So, added a new utility function to simply overwrite
the fields. The fix has been retested with ASAN and looks good on prod host.