### PR TITLE
log filter enhancement

### DIFF
--- a/proxy/logging/LogFilter.h
+++ b/proxy/logging/LogFilter.h
@@ -383,6 +383,72 @@ LogFilterString::_checkCondition(OperatorFunction f, const char *field_value, si
 }
 
 /*---------------------------------------------------------------------------
+ * find pattern from the query param
+ * 1) if pattern is not in the query param, return nullptr
+ * 2) if got the pattern in one param's value, search again until it's in one param name, or nullptr if can't find it from param
+name
+---------------------------------------------------------------------------*/
+static const char *
+findPatternFromParamName(const char *lookup_query_param, const char *pattern)
+{
+  const char *pattern_in_query_param = strstr(lookup_query_param, pattern);
+  while (pattern_in_query_param) {
+    // wipe pattern in param name, need to search again if find pattern in param value
+    const char *param_value_str = strchr(pattern_in_query_param, '=');
+    if (!param_value_str) {
+      // no "=" after pattern_in_query_param, means pattern_in_query_param is not in the param name, and no more param after it
+      pattern_in_query_param = nullptr;
+      break;
+    }
+    const char *param_name_str = strchr(pattern_in_query_param, '&');
+    if (param_name_str && param_value_str > param_name_str) {
+      //"=" is after "&" followd by pattern_in_query_param, means pattern_in_query_param is not in the param name
+      pattern_in_query_param = strstr(param_name_str, pattern);
+      continue;
+    }
+    // ensure pattern_in_query_param is in the param name now
+    break;
+  }
+  return pattern_in_query_param;
+}
+
+/*---------------------------------------------------------------------------
+ * replace param value whose name contains pattern with same count 'X' of original value str length
+---------------------------------------------------------------------------*/
+static void
+updatePatternForFieldValue(char **field, const char *pattern_str, int field_pos, char *buf_dest)
+{
+  int buf_dest_len = strlen(buf_dest);
+  char buf_dest_to_field[buf_dest_len + 1];
+  char *temp_text = buf_dest_to_field;
+  memcpy(temp_text, buf_dest, (pattern_str - buf_dest));
+  temp_text += (pattern_str - buf_dest);
+  const char *value_str = strchr(pattern_str, '=');
+  if (value_str) {
+    value_str++;
+    memcpy(temp_text, pattern_str, (value_str - pattern_str));
+    temp_text += (value_str - pattern_str);
+    const char *next_param_str = strchr(value_str, '&');
+    if (next_param_str) {
+      for (int i = 0; i < (next_param_str - value_str); i++) {
+        temp_text[i] = 'X';
+      }
+      temp_text += (next_param_str - value_str);
+      memcpy(temp_text, next_param_str, ((buf_dest + buf_dest_len) - next_param_str));
+    } else {
+      for (int i = 0; i < ((buf_dest + buf_dest_len) - value_str); i++) {
+        temp_text[i] = 'X';
+      }
+    }
+  } else {
+    return;
+  }
+
+  buf_dest_to_field[buf_dest_len] = '\0';
+  strcpy(*field, buf_dest_to_field);
+}
+
+/*---------------------------------------------------------------------------
   wipeField : Given a dest buffer, wipe the first occurrence of the value of the
   field in the buffer.
 
@@ -394,44 +460,25 @@ wipeField(char **field, char *pattern, const char *uppercase_field)
   const char *lookup_dest = uppercase_field ? uppercase_field : *field;
 
   if (buf_dest) {
-    char *query_param              = strstr(buf_dest, "?");
-    const char *lookup_query_param = strstr(lookup_dest, "?");
+    char *query_param              = strchr(buf_dest, '?');
+    const char *lookup_query_param = strchr(lookup_dest, '?');
     if (!query_param || !lookup_query_param) {
       return;
     }
 
-    const char *p1 = strstr(lookup_query_param, pattern);
-    int field_pos  = p1 - lookup_query_param;
-    p1             = query_param + field_pos;
+    const char *pattern_in_param_name = findPatternFromParamName(lookup_query_param, pattern);
+    while (pattern_in_param_name) {
+      int field_pos         = pattern_in_param_name - lookup_query_param;
+      pattern_in_param_name = query_param + field_pos;
+      updatePatternForFieldValue(field, pattern_in_param_name, field_pos, buf_dest);
 
-    if (p1) {
-      char tmp_text[strlen(buf_dest) + 10];
-      char *temp_text = tmp_text;
-      memcpy(temp_text, buf_dest, (p1 - buf_dest));
-      temp_text += (p1 - buf_dest);
-      const char *p2 = strstr(p1, "=");
-      if (p2) {
-        p2++;
-        memcpy(temp_text, p1, (p2 - p1));
-        temp_text += (p2 - p1);
-        const char *p3 = strstr(p2, "&");
-        if (p3) {
-          for (int i = 0; i < (p3 - p2); i++) {
-            temp_text[i] = 'X';
-          }
-          temp_text += (p3 - p2);
-          memcpy(temp_text, p3, ((buf_dest + strlen(buf_dest)) - p3));
-        } else {
-          for (int i = 0; i < ((buf_dest + strlen(buf_dest)) - p2); i++) {
-            temp_text[i] = 'X';
-          }
-        }
+      // search new param again
+      const char *new_param = strchr(lookup_query_param + field_pos, '&');
+      if (new_param && (new_param + 1)) {
+        pattern_in_param_name = findPatternFromParamName(new_param + 1, pattern);
       } else {
-        return;
+        break;
       }
-
-      tmp_text[strlen(buf_dest)] = '\0';
-      strcpy(*field, tmp_text);
     }
   }
 }

--- a/tests/gold_tests/logging/gold/filter-test.gold
+++ b/tests/gold_tests/logging/gold/filter-test.gold
@@ -1,0 +1,5 @@
+http://test-1/test-1?name=value&email=XXXXXXXXXXXXX
+http://test-2/test-2?email=XXXXXXXXXXXXX&name=password
+http://test-3/test-3?trivial=password&name1=val1&email=XXXXXXXXXXXXX
+http://test-4/test-4?trivial=password&email=&name=handle&session_redirect=XXXXXXXXXXXX
+http://test-5/test-5?trivial=password&email=XXXXXXXXXXXXX&email=XXXXXXXXXXXXX&session_redirect=XXXXXXXXXXXX&email=XXXXXXXXXXXXX&name=value

--- a/tests/gold_tests/logging/log-filter.test.py
+++ b/tests/gold_tests/logging/log-filter.test.py
@@ -1,0 +1,124 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+
+Test.Summary = ''' 
+Test log filter.
+'''
+# Only on Linux (why??)
+Test.SkipUnless(
+    Condition.IsPlatform("linux")
+)
+
+# Define default ATS
+ts = Test.MakeATSProcess("ts")
+# Microserver
+server = Test.MakeOriginServer("server")
+
+request_header = {'timestamp': 100, "headers": "GET /test-1 HTTP/1.1\r\nHost: test-1\r\n\r\n", "body": ""} 
+response_header = {'timestamp': 100,
+                   "headers": "HTTP/1.1 200 OK\r\nTest: 1\r\nContent-Type: application/json\r\nConnection: close\r\nContent-Type: application/json\r\n\r\n", "body": "Test 1"}
+server.addResponse("sessionlog.json", request_header, response_header)
+server.addResponse("sessionlog.json",
+                   {'timestamp': 101, "headers": "GET /test-2 HTTP/1.1\r\nHost: test-2\r\n\r\n", "body": ""},
+                   {'timestamp': 101, "headers": "HTTP/1.1 200 OK\r\nTest: 2\r\nContent-Type: application/jason\r\nConnection: close\r\nContent-Type: application/json\r\n\r\n", "body": "Test 2"}
+                   )
+server.addResponse("sessionlog.json",
+                   {'timestamp': 102, "headers": "GET /test-3 HTTP/1.1\r\nHost: test-3\r\n\r\n", "body": ""},
+                   {'timestamp': 102, "headers": "HTTP/1.1 200 OK\r\nTest: 3\r\nConnection: close\r\nContent-Type: application/json\r\n\r\n", "body": "Test 3"}
+                   )
+server.addResponse("sessionlog.json",
+                   {'timestamp': 103, "headers": "GET /test-4 HTTP/1.1\r\nHost: test-4\r\n\r\n", "body": ""},
+                   {'timestamp': 103, "headers": "HTTP/1.1 200 OK\r\nTest: 4\r\nConnection: close\r\nContent-Type: application/json\r\n\r\n", "body": "Test 4"}
+                   )
+server.addResponse("sessionlog.json",
+                   {'timestamp': 104, "headers": "GET /test-5 HTTP/1.1\r\nHost: test-5\r\n\r\n", "body": ""},
+                   {'timestamp': 104, "headers": "HTTP/1.1 200 OK\r\nTest: 5\r\nConnection: close\r\nContent-Type: application/json\r\n\r\n", "body": "Test 5"}
+                   )
+
+ts.Disk.records_config.update({
+    'proxy.config.net.connections_throttle': 100,
+    'proxy.config.http.cache.http': 0
+})
+# setup some config file for this server
+ts.Disk.remap_config.AddLine(
+    'map / http://localhost:{}/'.format(server.Variables.Port)
+)
+
+ts.Disk.logging_yaml.AddLines(
+    ''' 
+logging:
+  filters:
+    - name: queryparamescaper_cquuc
+      action: WIPE_FIELD_VALUE
+      condition: cquuc CASE_INSENSITIVE_CONTAIN password,secret,access_token,session_redirect,cardNumber,code,query,search-query,prefix,keywords,email,handle
+  formats:
+    - name: custom
+      format: '%<cquuc>'
+  logs:
+    - filename: filter-test
+      format: custom
+      filters: 
+      - queryparamescaper_cquuc
+'''.split("\n")
+)
+
+# #########################################################################
+# at the end of the different test run a custom log file should exist
+# Because of this we expect the testruns to pass the real test is if the
+# customlog file exists and passes the format check
+Test.Disk.File(os.path.join(ts.Variables.LOGDIR, 'filter-test.log'),
+               exists=True, content='gold/filter-test.gold')
+
+# first test is a miss for default
+tr = Test.AddTestRun()
+# Wait for the micro server
+tr.Processes.Default.StartBefore(server)
+# Delay on readiness of our ssl ports
+tr.Processes.Default.StartBefore(Test.Processes.ts)
+
+tr.Processes.Default.Command = 'curl --verbose --header "Host: test-1" "http://localhost:{0}/test-1?name=value&email=123@gmail.com"' .format(
+    ts.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = 'curl --verbose --header "Host: test-2" "http://localhost:{0}/test-2?email=123@gmail.com&name=password"' .format(
+    ts.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = 'curl --verbose --header "Host: test-3" "http://localhost:{0}/test-3?trivial=password&name1=val1&email=123@gmail.com"' .format(
+    ts.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = 'curl --verbose --header "Host: test-4" "http://localhost:{0}/test-4?trivial=password&email=&name=handle&session_redirect=wiped_string"' .format(
+    ts.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = 'curl --verbose --header "Host: test-5" "http://localhost:{0}/test-5?trivial=password&email=123@gmail.com&email=456@gmail.com&session_redirect=wiped_string&email=789@gmail.com&name=value"' .format(
+    ts.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+
+tr = Test.AddTestRun()
+tr.DelayStart = 10
+tr.Processes.Default.Command = 'echo "Delay for log flush"'
+tr.Processes.Default.ReturnCode = 0
+


### PR DESCRIPTION
fix the bug if filter word included in param value

(cherry picked from commit d3ed0276545774d989d050fe57fdf7dd3877b49c)

fix the bug if filter word included in param value

(cherry picked from commit 601d090b07f64a90cbf11bf55d6c1fad83f34f2d)

fix typo issue

(cherry picked from commit 16ddd19307dc8a04a05bf5cbe8afedd00c538019)

move code to utility function to reduce the interface size

(cherry picked from commit 89bed7bcbc5b57652f9392b1905908d993483674)

code clean from review comments

(cherry picked from commit ca24696ab407f532cb090a0abd40c1a5edb99d40)

1) add autest for log filter; 2) support filter for duplicated param name in query parm of URL

(cherry picked from commit 87db2452595ccbc2498a5eecc31dc9d2a67be62c)