### PR TITLE
Remove hard-coded ssl_multicert.config log reference

### DIFF
--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -530,9 +530,9 @@ SSLCertificateConfig::reconfigure()
   }
 
   if (retStatus) {
-    Note("ssl_multicert.config finished loading");
+    Note("%s finished loading", params->configFilePath);
   } else {
-    Error("ssl_multicert.config failed to load");
+    Error("%s failed to load", params->configFilePath);
   }
 
   return retStatus;


### PR DESCRIPTION
SSLCertificateConfig::reconfigure() had a couple messages that used a
hard-coded config name for SSL multicert. This filename, however, is
configurable per records.config. This change makes use of the name at runtime
per SSLConfig params variable rather than the hard-coded value.