### PR TITLE
Refactor Http1Session to derive from ProxySsn

### DIFF
--- a/proxy/ProxySession.h
+++ b/proxy/ProxySession.h
@@ -29,7 +29,6 @@
 #include <string_view>
 #include "P_Net.h"
 #include "InkAPIInternal.h"
-#include "http/Http1ServerSession.h"
 #include "http/HttpSessionAccept.h"
 #include "IPAllow.h"
 
@@ -39,6 +38,12 @@
 #define SsnDebug(ssn, tag, ...) SpecificDebug((ssn)->debug(), tag, __VA_ARGS__)
 
 class ProxyTransaction;
+class Http1ServerSession; // TODO: refactor
+
+enum {
+  HTTP_MAGIC_ALIVE = 0x0123FEED,
+  HTTP_MAGIC_DEAD  = 0xDEADFEED,
+};
 
 enum class ProxyErrorClass {
   NONE,
@@ -86,7 +91,7 @@ public:
   // Virtual Methods
   virtual void new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader) = 0;
   virtual void start()                                                                          = 0;
-  virtual void attach_server_session(Http1ServerSession *ssession, bool transaction_done = true);
+  virtual void attach_server_session(Http1ServerSession *ssession, bool transaction_done = true); // TODO: refactor
 
   virtual void release(ProxyTransaction *trans) = 0;
 
@@ -108,7 +113,7 @@ public:
   virtual void set_half_close_flag(bool flag);
   virtual bool get_half_close_flag() const;
 
-  virtual Http1ServerSession *get_server_session() const;
+  virtual Http1ServerSession *get_server_session() const; // TODO: refactor
 
   // Replicate NetVConnection API
   virtual sockaddr const *get_client_addr();

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -107,7 +107,7 @@ private:
   };
 
   NetVConnection *client_vc = nullptr;
-  int magic                 = HTTP_SS_MAGIC_DEAD;
+  int magic                 = HTTP_MAGIC_DEAD;
   int transact_count        = 0;
   bool half_close           = false;
   bool conn_decrease        = false;

--- a/proxy/http/Http1ServerSession.cc
+++ b/proxy/http/Http1ServerSession.cc
@@ -45,7 +45,7 @@ Http1ServerSession::destroy()
   ink_release_assert(server_vc == nullptr);
   ink_assert(read_buffer);
   ink_assert(server_trans_stat == 0);
-  magic = HTTP_SS_MAGIC_DEAD;
+  magic = HTTP_MAGIC_DEAD;
   if (read_buffer) {
     free_MIOBuffer(read_buffer);
     read_buffer = nullptr;
@@ -71,7 +71,7 @@ Http1ServerSession::new_connection(NetVConnection *new_vc)
   // Unique client session identifier.
   con_id = ink_atomic_increment((&next_ss_id), 1);
 
-  magic = HTTP_SS_MAGIC_ALIVE;
+  magic = HTTP_MAGIC_ALIVE;
   HTTP_SUM_GLOBAL_DYN_STAT(http_current_server_connections_stat, 1); // Update the true global stat
   HTTP_INCREMENT_DYN_STAT(http_total_server_connections_stat);
 
@@ -243,3 +243,9 @@ Http1ServerSession::protocol_contains(std::string_view tag_prefix) const
   auto vc = this->get_netvc();
   return vc ? vc->protocol_contains(tag_prefix) : nullptr;
 }
+
+const char *
+Http1ServerSession::get_protocol_string() const
+{
+  return "http";
+};

--- a/proxy/http/Http1ServerSession.h
+++ b/proxy/http/Http1ServerSession.h
@@ -36,6 +36,7 @@
 
 #include "HttpConnectionCount.h"
 #include "HttpProxyAPIEnums.h"
+#include "ProxySession.h"
 
 class HttpSM;
 class MIOBuffer;
@@ -48,18 +49,13 @@ enum HSS_State {
   HSS_KA_SHARED,
 };
 
-enum {
-  HTTP_SS_MAGIC_ALIVE = 0x0123FEED,
-  HTTP_SS_MAGIC_DEAD  = 0xDEADFEED,
-};
-
-class Http1ServerSession : public VConnection
+class Http1ServerSession : public ProxySession
 {
   using self_type  = Http1ServerSession;
-  using super_type = VConnection;
+  using super_type = ProxySession;
 
 public:
-  Http1ServerSession() : super_type(nullptr) {}
+  Http1ServerSession() : super_type() {}
   Http1ServerSession(self_type const &) = delete;
   self_type &operator=(self_type const &) = delete;
 
@@ -67,8 +63,9 @@ public:
   // Methods
   void new_connection(NetVConnection *new_vc);
   void release();
-  void destroy();
+  void destroy() override;
 
+  ////////////////////
   // VConnection Methods
   VIO *do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = nullptr) override;
   VIO *do_io_write(Continuation *c = nullptr, int64_t nbytes = INT64_MAX, IOBufferReader *buf = nullptr,
@@ -77,15 +74,64 @@ public:
   void do_io_shutdown(ShutdownHowTo_t howto) override;
 
   void reenable(VIO *vio) override;
+  void
+  new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader) override
+  {
+    // TODO: refactor this
+    ink_assert(0);
+  }
+  void
+  start() override
+  {
+    // TODO: refactor this
+    ink_assert(0);
+  }
+  void
+  attach_server_session(Http1ServerSession *ssession, bool transaction_done = true) override
+  {
+    // TODO: refactor this
+    ink_assert(0);
+  }
+  void
+  release(ProxyTransaction *trans) override
+  {
+    // TODO: refactor this
+    ink_assert(0);
+  }
 
+  void
+  increment_current_active_client_connections_stat() override
+  {
+    // TODO: refactor this
+    ink_assert(0);
+  }
+  void
+  decrement_current_active_client_connections_stat() override
+  {
+    // TODO: refactor this
+    ink_assert(0);
+  }
+
+  ////////////////////
+  // Virtual Accessors
+  int
+  get_transact_count() const override
+  {
+    // TODO: refactor this
+    return transact_count;
+  }
+  const char *get_protocol_string() const override;
+
+  ////////////////////
+  // Accessors
+  NetVConnection *get_netvc() const override;
+  const char *protocol_contains(std::string_view tag_prefix) const override;
+  int populate_protocol(std::string_view *result, int size) const override;
   void enable_outbound_connection_tracking(OutboundConnTrack::Group *group);
   IOBufferReader *get_reader();
   void attach_hostname(const char *hostname);
-  NetVConnection *get_netvc() const;
   void set_netvc(NetVConnection *new_vc);
   IpEndpoint const &get_server_ip() const;
-  int populate_protocol(std::string_view *result, int size) const;
-  const char *protocol_contains(std::string_view tag_prefix) const;
 
   ////////////////////
   // Variables
@@ -156,7 +202,7 @@ public:
 
 private:
   NetVConnection *server_vc = nullptr;
-  int magic                 = HTTP_SS_MAGIC_DEAD;
+  int magic                 = HTTP_MAGIC_DEAD;
 
   IOBufferReader *buf_reader = nullptr;
 };

--- a/proxy/http/HttpTransactHeaders.cc
+++ b/proxy/http/HttpTransactHeaders.cc
@@ -35,6 +35,7 @@
 #include "HdrUtils.h"
 #include "HttpCompat.h"
 #include "HttpSM.h"
+#include "Http1ServerSession.h"
 
 #include "I_Machine.h"
 
@@ -883,7 +884,7 @@ HttpTransactHeaders::insert_via_header_in_response(HttpTransact::State *s, HTTPH
   // Should suffice - if we're adding a response VIA, the connection is HTTP and only 1.0 and 1.1 are supported outbound.
   proto_buf[n_proto++] = HTTP_MINOR(header->version_get().m_version) == 0 ? IP_PROTO_TAG_HTTP_1_0 : IP_PROTO_TAG_HTTP_1_1;
 
-  auto ss = s->state_machine->get_server_session();
+  Http1ServerSession *ss = s->state_machine->get_server_session();
   if (ss) {
     n_proto += ss->populate_protocol(proto_buf.data() + n_proto, proto_buf.size() - n_proto);
   }


### PR DESCRIPTION
Follow up from #5898 
Created this feature branch to continue work of H1 outbound refactoring.
This will maintain the same functionality and API and be merged into a 9.1+ release.

A step towards H2-to-Origin.
This contains minimal change to compile, and a few TODO comments. This will be followed by many PRs to refactor and cleanup methods and variables.