### PR TITLE
Concurrent SRV requests failure

### DIFF
--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -1556,7 +1556,7 @@ HostDBContinuation::probeEvent(int /* event ATS_UNUSED */, Event *e)
     }
 
     if (action.continuation && r) {
-      reply_to_cont(action.continuation, r.get());
+      reply_to_cont(action.continuation, r.get(), is_srv());
     }
 
     // If it succeeds or it was a remote probe, we are done


### PR DESCRIPTION
An ongoing SRV request causes the next SRV request to fail as IP in the cached object isn't valid.