### PR TITLE
Report missing SSL elliptic curve consistently

### DIFF
--- a/plugins/lua/ts_lua_client_request.c
+++ b/plugins/lua/ts_lua_client_request.c
@@ -1045,7 +1045,8 @@ ts_lua_client_request_get_ssl_curve(lua_State *L)
   client_conn = TSHttpSsnClientVConnGet(ssnp);
 
   if (TSVConnIsSsl(client_conn)) {
-    ssl_curve = TSVConnSslCurveGet(client_conn);
+    const char *curve = TSVConnSslCurveGet(client_conn);
+    ssl_curve         = curve ? curve : "-";
   }
 
   lua_pushstring(L, ssl_curve);


### PR DESCRIPTION
Currently when a SSL elliptic curve is not being used as part of the TLS handshake, the logging field `cqssu` reports it using a hyphen "-" while lua `ts.client_request.get_ssl_curve` function uses the string "nil".
This PR refactors `ts.client_request.get_ssl_curve` to report the lack of a SSL EC in the same way as the logging field `cqssu`