### PR TITLE
A general autoconf cleanup

### DIFF
--- a/build/ax_check_openssl.m4
+++ b/build/ax_check_openssl.m4
@@ -79,6 +79,7 @@ AC_DEFUN([AX_CHECK_OPENSSL], [
         for ssldir in $ssldirs; do
             AC_MSG_CHECKING([for openssl/ssl.h in $ssldir])
             if test -f "$ssldir/include/openssl/ssl.h"; then
+                AC_MSG_RESULT([yes])
                 OPENSSL_INCLUDES="-I$ssldir/include"
                 if test -d "$ssldir/lib64"; then
                   OPENSSL_LDFLAGS="-L$ssldir/lib64"
@@ -93,7 +94,6 @@ AC_DEFUN([AX_CHECK_OPENSSL], [
                 fi
                 OPENSSL_LIBS="-lssl -lcrypto"
                 found=true
-                AC_MSG_RESULT([yes])
                 break
             else
                 AC_MSG_RESULT([no])

--- a/build/hiredis.m4
+++ b/build/hiredis.m4
@@ -36,20 +36,20 @@ case "$hiredis_base_dir" in
 *":"*)
   hidredis_include="`echo $hiredis_base_dir |sed -e 's/:.*$//'`"
   hiredis_ldflags="`echo $hiredis_base_dir |sed -e 's/^.*://'`"
-  AC_MSG_CHECKING(checking for hiredis includes in $hiredis_include libs in $hiredis_ldflags )
+  AC_MSG_CHECKING(for hiredis includes in $hiredis_include libs in $hiredis_ldflags )
   ;;
 *)
   hiredis_include="$hiredis_base_dir/include"
   hiredis_ldflags="$hiredis_base_dir/lib"
-  AC_MSG_CHECKING(checking for hiredis includes in $hiredis_base_dir)
+  AC_MSG_CHECKING(for hiredis includes in $hiredis_base_dir)
   ;;
 esac
 
 if test -d $hiredis_include && test -d $hiredis_ldflags && test -f $hiredis_include/hiredis/hiredis.h; then
-  AC_MSG_RESULT([ok])
+  AC_MSG_RESULT([yes])
 else
   has_hiredis=0
-  AC_MSG_RESULT([not found])
+  AC_MSG_RESULT([no])
 fi
 
 if test "$has_hiredis" != "0"; then
@@ -77,5 +77,3 @@ if test "$has_hiredis" != "0"; then
   fi
 fi
 ])
-
-

--- a/build/jemalloc.m4
+++ b/build/jemalloc.m4
@@ -31,17 +31,17 @@ AC_ARG_WITH([jemalloc], [AC_HELP_STRING([--with-jemalloc=DIR], [use a specific j
     case "$withval" in
       yes)
         jemalloc_base_dir="/usr"
-        AC_MSG_CHECKING(checking for jemalloc includes standard directories)
-	;;
+        AC_MSG_NOTICE(checking for jemalloc includes and libs in standard directories)
+        ;;
       *":"*)
         jemalloc_include="`echo $withval |sed -e 's/:.*$//'`"
         jemalloc_ldflags="`echo $withval |sed -e 's/^.*://'`"
-        AC_MSG_CHECKING(checking for jemalloc includes in $jemalloc_include libs in $jemalloc_ldflags)
+        AC_MSG_NOTICE(checking for jemalloc includes in $jemalloc_include and libs in $jemalloc_ldflags)
         ;;
       *)
         jemalloc_include="$withval/include"
         jemalloc_ldflags="$withval/lib"
-        AC_MSG_CHECKING(checking for jemalloc includes in $withval)
+        AC_MSG_NOTICE(checking for jemalloc includes in $jemalloc_include and libs in $jemalloc_ldflags)
         ;;
     esac
   fi
@@ -70,6 +70,7 @@ if test "$enable_jemalloc" != "no"; then
   if test "$jemalloc_have_headers" != "0"; then
     jemalloch=1
   else
+    AC_MSG_WARN([jemalloc not found])
     CPPFLAGS=$saved_cppflags
     LDFLAGS=$saved_ldflags
   fi

--- a/configure.ac
+++ b/configure.ac
@@ -649,7 +649,7 @@ TS_ADDTO(AM_CFLAGS, [-std=gnu99])
 ac_save_CXX="$CXX"
 CXX="$CXX -std=c++17"
 AC_LANG_PUSH(C++)
-AC_MSG_CHECKING([checking whether $CXX supports -std=c++17])
+AC_MSG_CHECKING([whether $CXX supports -std=c++17])
 AC_COMPILE_IFELSE([
     AC_LANG_PROGRAM([
 #if __cplusplus < 201703L
@@ -813,7 +813,7 @@ AX_PROG_PERL_MODULES([ExtUtils::MakeMaker], AM_CONDITIONAL([BUILD_PERL_LIB], [tr
 )
 
 # Check for GNU-style -On optimization flags
-AC_MSG_CHECKING([checking whether to auto-set compiler optimization flags])
+AC_MSG_CHECKING([whether to auto-set compiler optimization flags])
 has_optimizer_flags=`echo "$CFLAGS $CXXFLAGS" | ${AWK} '$0 !~ /-O.?/{print "no"}'`
 AS_IF([test "x${has_optimizer_flags}" = "xno"],
         [


### PR DESCRIPTION
The `./configure` output was a bit off with the jemalloc related checks, while fixing that found a few other similar ones.